### PR TITLE
[RF] Remove TFormula v5 from RooFit.

### DIFF
--- a/roofit/roofit/test/testRooJohnson.cxx
+++ b/roofit/roofit/test/testRooJohnson.cxx
@@ -40,7 +40,7 @@ const char* fixedFormula = "delta/(sigma*TMath::Sqrt(TMath::TwoPi()))"
 
 // This test needs to stay disabled until ROOT-10144 in TFormula v5 is fixed
 // or until RooFit is updated to use TFormula v6 (ROOT-10164)
-TEST(RooJohnson, DISABLED_ReferenceImplementation)
+TEST(RooJohnson, ReferenceImplementation)
 {
   MAKE_JOHNSON_AND_VARS
   // Note: Ownership bug. Deleting this might crash on Mac.

--- a/roofit/roofitcore/inc/RooFormula.h
+++ b/roofit/roofitcore/inc/RooFormula.h
@@ -16,42 +16,46 @@
 #ifndef ROO_FORMULA
 #define ROO_FORMULA
 
-#include "Rtypes.h"
-#include "v5/TFormula.h"
-#include "RooAbsReal.h"
-#include "RooArgSet.h"
 #include "RooPrintable.h"
-#include "RooLinkedList.h"
-#include <vector>
+#include "RooArgList.h"
+#include "RooArgSet.h"
+#include "TFormula.h"
 
-class RooFormula : public ROOT::v5::TFormula, public RooPrintable {
+#include <memory>
+#include <vector>
+#include <string>
+
+class RooFormula : public TNamed, public RooPrintable {
 public:
   // Constructors etc.
   RooFormula() ;
   RooFormula(const char* name, const char* formula, const RooArgList& varList);
-  RooFormula(const RooFormula& other, const char* name=0) ;
-  virtual TObject* Clone(const char* newName=0) const { return new RooFormula(*this,newName) ; }
-  virtual ~RooFormula();
+  RooFormula(const RooFormula& other, const char* name=0);
+  virtual TObject* Clone(const char* newName = nullptr) const {return new RooFormula(*this, newName);}
 	
-  // Dependent management
-  RooArgSet& actualDependents() const ;
+  ////////////////////////////////////////////////////////////////////////////////
+  /// Return list of arguments which are used in the formula.
+  RooArgSet actualDependents() const {return usedVariables();}
   Bool_t changeDependents(const RooAbsCollection& newDeps, Bool_t mustReplaceAll, Bool_t nameChange) ;
 
-  inline RooAbsArg* getParameter(const char* name) const { 
-    // Return pointer to parameter with given name
-    return (RooAbsArg*) _useList.FindObject(name) ; 
-  }
-  inline RooAbsArg* getParameter(Int_t index) const { 
-    // Return pointer to parameter at given index
-    return (RooAbsArg*) _origList.At(index) ; 
+  /// Return pointer to the parameter with given name.
+  /// \return Parameter if in use, nullptr if not in use.
+  RooAbsArg* getParameter(const char* name) const {
+    return usedVariables().find(name);
   }
 
-  // Function value accessor
-  inline Bool_t ok() { return _isOK ; }
-  Double_t eval(const RooArgSet* nset=0) ;
+  /// Return pointer to parameter at given index. This returns
+  /// irrespective of whether the parameter is in use.
+  RooAbsArg* getParameter(Int_t index) const {
+    return _origList.at(index);
+  }
 
-  // Debugging
-  void dump() ;
+  Bool_t ok() { return _tFormula != nullptr; }
+  /// Evalute all parameters/observables, and then evaluate formula.
+  Double_t eval(const RooArgSet* nset=0) const;
+
+  /// DEBUG: Dump state information
+  void dump() const;
   Bool_t reCompile(const char* newFormula) ;
 
 
@@ -62,31 +66,23 @@ public:
   virtual void printArgs(std::ostream& os) const ;
   void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  virtual void Print(Option_t *options= 0) const {
     // Printing interface (human readable)
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
-protected:
-  
-  RooFormula& operator=(const RooFormula& other) ;
-  void initCopy(const RooFormula& other) ;
+private:
+  RooFormula& operator=(const RooFormula& other);
+  std::string processFormula(std::string origFormula) const;
+  RooArgList  usedVariables() const;
+  std::string reconstructFormula(std::string internalRepr) const;
+  std::vector<bool> findCategoryServers(const RooAbsCollection& collection) const;
 
-  // Interface to ROOT::v5::TFormula engine
-  Int_t DefinedVariable(TString &name, int& action) ; // ROOT 4
-  Int_t DefinedVariable(TString &name) ; // ROOT 3
-  Double_t DefinedValue(Int_t code) ;
+  RooArgList _origList; //! Original list of dependents
+  std::vector<bool> _isCategory; //! Whether an element of the _origList is a category.
+  std::unique_ptr<TFormula> _tFormula; //! The formula used to compute values
 
-  RooArgSet* _nset ;
-  mutable Bool_t    _isOK ;     // Is internal state OK?
-  RooLinkedList     _origList ; //! Original list of dependents
-  std::vector<Bool_t> _useIsCat;//! Is given slot in _useList a category?
-  RooLinkedList _useList ;      //! List of actual dependents 
-  mutable RooArgSet _actual;    //! Set of actual dependents
-  RooLinkedList _labelList ;    //  List of label names for category objects  
-  mutable Bool_t    _compiled ; //  Flag set if formula is compiled
-
-  ClassDef(RooFormula,1)     // ROOT::v5::TFormula derived class interfacing with RooAbsArg objects
+  ClassDef(RooFormula,0)
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -22,17 +22,18 @@
 #include "RooListProxy.h"
 #include "RooTrace.h"
 
+#include <memory>
+
 class RooArgSet ;
 
 class RooFormulaVar : public RooAbsReal {
 public:
   // Constructors, assignment etc
-  inline RooFormulaVar() : _formula(0), _nset(0) {  }
+  RooFormulaVar() { }
   RooFormulaVar(const char *name, const char *title, const char* formula, const RooArgList& dependents);
   RooFormulaVar(const char *name, const char *title, const RooArgList& dependents);
   RooFormulaVar(const RooFormulaVar& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooFormulaVar(*this,newname); }
-  virtual ~RooFormulaVar();
 
   inline Bool_t ok() const { return formula().ok() ; }
 
@@ -63,17 +64,19 @@ public:
 
   // Function evaluation
   virtual Double_t evaluate() const ;
-  RooFormula& formula() const ;
 
   protected:
   // Post-processing of server redirection
   virtual Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
 
-  virtual Bool_t isValidReal(Double_t value, Bool_t printError) const ;
+  virtual Bool_t isValidReal(Double_t /*value*/, Bool_t /*printError*/) const {return true;}
+
+  private:
+  RooFormula& formula() const;
 
   RooListProxy _actualVars ;     // Actual parameters used by formula engine
-  mutable RooFormula* _formula ; //! Formula engine 
-  mutable RooArgSet* _nset ;     //! Normalization set to be passed along to contents
+  std::unique_ptr<RooFormula> _formula{nullptr}; //! Formula engine
+  mutable RooArgSet* _nset{nullptr}; //! Normalization set to be passed along to contents
   TString _formExpr ;            // Formula expression string
 
   ClassDef(RooFormulaVar,1) // Real-valued function of other RooAbsArgs calculated by a TFormula expression

--- a/roofit/roofitcore/inc/RooGenericPdf.h
+++ b/roofit/roofitcore/inc/RooGenericPdf.h
@@ -25,12 +25,10 @@ class RooArgList ;
 class RooGenericPdf : public RooAbsPdf {
 public:
   // Constructors, assignment etc
-  inline RooGenericPdf() : _formula(0) { }
   RooGenericPdf(const char *name, const char *title, const char* formula, const RooArgList& dependents);
   RooGenericPdf(const char *name, const char *title, const RooArgList& dependents);
   RooGenericPdf(const RooGenericPdf& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooGenericPdf(*this,newname); }
-  virtual ~RooGenericPdf();
 
   // I/O streaming interface (machine readable)
   virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
@@ -58,7 +56,7 @@ protected:
 
   virtual Bool_t isValidReal(Double_t value, Bool_t printError) const ;
 
-  mutable RooFormula* _formula ; //! Formula engine 
+  std::unique_ptr<RooFormula> _formula ; //! Formula engine
   TString _formExpr ;            // Formula expression string
 
   ClassDef(RooGenericPdf,1) // Generic PDF defined by string expression and list of variables

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -880,9 +880,9 @@ Double_t RooAbsData::moment(RooRealVar &var, Double_t order, Double_t offset, co
   }
 
   // Setup RooFormulaVar for cutSpec if it is present
-  RooFormula* select = 0 ;
+  std::unique_ptr<RooFormula> select;
   if (cutSpec) {
-    select = new RooFormula("select",cutSpec,*get()) ;
+    select.reset(new RooFormula("select",cutSpec,*get()));
   }
 
 

--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -19,29 +19,51 @@
 \class RooFormula
 \ingroup Roofitcore
 
-RooFormula an implementation of ROOT::v5::TFormula that interfaces it to RooAbsArg
-value objects. It allows to use the value of a given list of RooAbsArg objects in the formula
-expression. Reference is done either by the RooAbsArgs name
-or by list ordinal postion ('@0,@1,...'). State information
-of RooAbsCategories can be accessed used the '::' operator,
-e.g. 'tagCat::Kaon' will resolve to the numerical value of
-the 'Kaon' state of the RooAbsCategory object named tagCat.
+RooFormula internally uses ROOT's TFormula to compute user-defined expressions
+of RooAbsArgs.
+
+The string expression can be any valid TFormula expression referring to the
+listed servers either by name or by their ordinal list position. These three are
+forms equivalent:
+```
+  RooFormula("formula", "x*y",       RooArgList(x,y))  or
+  RooFormula("formula", "@0*@1",     RooArgList(x,y))
+  RooFormula("formula", "x[0]*x[1]", RooArgList(x,y))
+```
+Note that `x[i]` is an expression reserved for TFormula. If a variable with
+the name `x` is given, the RooFormula interprets `x[i]` as a list position,
+but `x` without brackets as a variable name.
+
+### Category expressions
+State information of RooAbsCategories can be accessed using the '::' operator,
+*e.g.*, `tagCat::Kaon` will resolve to the numerical value of
+the `Kaon` state of the RooAbsCategory object named `tagCat`.
+
+A formula to switch between lepton categories could look like this:
+```
+  RooFormula("formulaWithCat",
+    "x * (leptonMulti == leptonMulti::one) + y * (leptonMulti == leptonMulti::two)",
+    RooArgList(x, y, leptonMulti));
+```
+
+### Debugging a formula that won't compile
+When the formula is preprocessed, RooFit prints some information in the message stream.
+These can be retrieved by activating the RooFit::MsgLevel `RooFit::DEBUG`
+and the RooFit::MsgTopic `RooFit::InputArguments`.
+Check the tutorial rf506_msgservice.C for details.
 **/
 
-#include "RooFit.h"
-
-#include "Riostream.h"
-#include "Riostream.h"
-#include <stdlib.h>
-#include "TROOT.h"
-#include "TClass.h"
-#include "TObjString.h"
 #include "RooFormula.h"
+
+#include "RooFit.h"
 #include "RooAbsReal.h"
 #include "RooAbsCategory.h"
 #include "RooArgList.h"
 #include "RooMsgService.h"
-#include "RooTrace.h"
+#include "ROOT/RMakeUnique.hxx"
+
+#include <sstream>
+#include <regex>
 
 using namespace std;
 
@@ -52,32 +74,48 @@ ClassImp(RooFormula);
 /// Default constructor
 /// coverity[UNINIT_CTOR]
 
-RooFormula::RooFormula() : ROOT::v5::TFormula(), _nset(0)
+RooFormula::RooFormula() : TNamed()
 {
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor with expression string and list of RooAbsArg variables
-
-RooFormula::RooFormula(const char* name, const char* formula, const RooArgList& list) : 
-  ROOT::v5::TFormula(), _isOK(kTRUE), _compiled(kFALSE)
+/// Construct a new formula.
+/// \param[in] name Name of the formula.
+/// \param[in] formula Formula to be evaluated. Parameters/observables are identified by name
+/// or ordinal position in `varList`.
+/// \param[in] varList List of variables to be passed to the formula.
+RooFormula::RooFormula(const char* name, const char* formula, const RooArgList& varList) :
+  TNamed(name, formula), _tFormula{nullptr}
 {
-  SetName(name) ;
-  SetTitle(formula) ;
+  _origList.add(varList);
+  _isCategory = findCategoryServers(_origList);
 
-  TIterator* iter = list.createIterator() ;
-  RooAbsArg* arg ;
-  while ((arg=(RooAbsArg*)iter->Next())) {
-    _origList.Add(arg) ;
+  std::string processedFormula = processFormula(formula);
+
+  cxcoutD(InputArguments) << "RooFormula '" << GetName() << "' will be compiled as "
+      << "\n\t" << processedFormula
+      << "\n  and used as"
+      << "\n\t" << reconstructFormula(processedFormula)
+      << "\n  with the parameters " << _origList << endl;
+
+
+  if (!processedFormula.empty())
+    _tFormula = std::make_unique<TFormula>(name, processedFormula.c_str());
+
+  if (!_tFormula || !_tFormula->IsValid()) {
+    coutF(InputArguments) << "RooFormula '" << GetName() << "' did not compile."
+        << "\nInput:\n\t" << formula
+        << "\nProcessed:\n\t" << processedFormula << endl;
+    _tFormula.reset(nullptr);
   }
-  delete iter ;
 
-  _compiled = kTRUE ;
-  if (Compile()) {
-    coutE(InputArguments) << "RooFormula::RooFormula(" << GetName() << "): compile error" << endl ;
-    _isOK = kFALSE ;
-    return ;
+  RooArgList useList = usedVariables();
+  if (_origList.size() != useList.size()) {
+    coutI(InputArguments) << "The formula " << GetName() << " claims to use the variables " << _origList
+        << " but only " << useList << " seem to be in use."
+        << "\n  inputs:         " << formula
+        << "\n  interpretation: " << reconstructFormula(processedFormula) << std::endl;
   }
 }
 
@@ -85,327 +123,251 @@ RooFormula::RooFormula(const char* name, const char* formula, const RooArgList& 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
-
 RooFormula::RooFormula(const RooFormula& other, const char* name) : 
-  ROOT::v5::TFormula(), RooPrintable(other), _isOK(other._isOK), _compiled(kFALSE) 
+  TNamed(name ? name : other.GetName(), other.GetTitle()), RooPrintable(other)
 {
-  SetName(name?name:other.GetName()) ;
-  SetTitle(other.GetTitle()) ;
-
-  TIterator* iter = other._origList.MakeIterator() ;
-  RooAbsArg* arg ;
-  while ((arg=(RooAbsArg*)iter->Next())) {
-    _origList.Add(arg) ;
-  }
-  delete iter ;
+  _origList.add(other._origList);
+  _isCategory = findCategoryServers(_origList);
   
-  Compile() ;
-  _compiled=kTRUE ;
+  TFormula* newTF = nullptr;
+  if (other._tFormula) {
+    newTF = new TFormula(*other._tFormula);
+    newTF->SetName(GetName());
+  }
+
+  _tFormula.reset(newTF);
+}
+
+#if !defined(__GNUC__) || defined(__clang__) || (__GNUC__ > 4) || ( __GNUC__ == 4 && __GNUC_MINOR__ > 8)
+#define ROOFORMULA_HAVE_STD_REGEX
+////////////////////////////////////////////////////////////////////////////////
+/// Process given formula by replacing all ordinal and name references by
+/// `x[i]`, where `i` matches the position of the argument in `_origList`.
+/// Further, references to category states such as `leptonMulti:one` are replaced
+/// by the category index.
+std::string RooFormula::processFormula(std::string formula) const {
+
+  cxcoutD(InputArguments) << "Preprocessing formula step 1: find category tags (catName::catState) in "
+      << formula << endl;
+
+  // Step 1: Find all category tags and the corresponding index numbers
+  std::regex categoryReg("(\\w+)::(\\w+)");
+  std::map<std::string, int> categoryStates;
+  for (sregex_iterator matchIt = sregex_iterator(formula.begin(), formula.end(), categoryReg);
+       matchIt != sregex_iterator(); ++matchIt) {
+    assert(matchIt->size() == 3);
+    const std::string fullMatch = (*matchIt)[0];
+    const std::string catName = (*matchIt)[1];
+    const std::string catState = (*matchIt)[2];
+
+    const auto catVariable = dynamic_cast<const RooAbsCategory*>(_origList.find(catName.c_str()));
+    if (!catVariable) {
+      cxcoutD(InputArguments) << "Formula " << GetName() << " uses '::' to reference a category state as '" << fullMatch
+          << "' but a category '" << catName << "' cannot be found in the input variables." << endl;
+      continue;
+    }
+
+    const RooCatType* catType = catVariable->lookupType(catState.c_str(), false);
+    if (!catType) {
+      coutE(InputArguments) << "Formula " << GetName() << " uses '::' to reference a category state as '" << fullMatch
+          << "' but the category '" << catName << "' does not seem to have the state '" << catState << "'." << endl;
+      throw std::invalid_argument(formula);
+    }
+    const int catNum = catType->getVal();
+
+    categoryStates[fullMatch] = catNum;
+    cxcoutD(InputArguments) << "\n\t" << fullMatch << "\tname=" << catName << "\tstate=" << catState << "=" << catNum;
+  }
+  cxcoutD(InputArguments) << "-- End of category tags --"<< endl;
+
+  // Step 2: Replace all category tags
+  for (const auto& catState : categoryStates) {
+    std::stringstream replacement;
+    replacement << catState.second;
+    formula = std::regex_replace(formula, std::regex(catState.first), replacement.str());
+  }
+
+  cxcoutD(InputArguments) << "Preprocessing formula step 2: replace category tags\n\t" << formula << endl;
+
+  // Step 3: Convert `@i`-style references to `x[i]`
+  std::regex ordinalRegex("@([0-9]+)");
+  formula = std::regex_replace(formula, ordinalRegex, "x[$1]");
+
+  cxcoutD(InputArguments) << "Preprocessing formula step 3: replace '@'-references\n\t" << formula << endl;
+
+  // Step 4: Replace all named references with "x[i]"-style
+  for (unsigned int i = 0; i < _origList.size(); ++i) {
+    const auto& var = _origList[i];
+    std::string regex = "\\b";
+    regex += var.GetName();
+    regex += "\\b(?!\\[)"; //Negative lookahead. If the variable is called `x`, this might otherwise replace `x[0]`.
+    std::regex findParameterRegex(regex);
+
+    std::stringstream replacement;
+    replacement << "x[" << i << "]";
+    formula = std::regex_replace(formula, findParameterRegex, replacement.str());
+
+    cxcoutD(InputArguments) << "Preprocessing formula step 4: replace named references: "
+        << var.GetName() << " --> " << replacement.str()
+        << "\n\t" << formula << endl;
+  }
+
+  cxcoutD(InputArguments) << "Final formula:\n\t" << formula << endl;
+
+  return formula;
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Analyse internal formula to find out which variables are actually in use.
+RooArgList RooFormula::usedVariables() const {
+  RooArgList useList;
+  if (_tFormula == nullptr)
+    return useList;
+
+  const std::string formula(_tFormula->GetTitle());
+
+  std::set<unsigned int> matchedOrdinals;
+  std::regex newOrdinalRegex("\\bx\\[([0-9]+)\\]");
+  for (sregex_iterator matchIt = sregex_iterator(formula.begin(), formula.end(), newOrdinalRegex);
+      matchIt != sregex_iterator(); ++matchIt) {
+    assert(matchIt->size() == 2);
+    std::stringstream matchString((*matchIt)[1]);
+    unsigned int i;
+    matchString >> i;
+
+    matchedOrdinals.insert(i);
+  }
+
+  for (unsigned int i : matchedOrdinals) {
+    useList.add(_origList[i]);
+  }
+
+  return useList;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Recompile formula with new expression
+/// From the internal representation, construct a formula by replacing all index place holders
+/// with the names of the variables that are being used to evaluate it.
+std::string RooFormula::reconstructFormula(std::string internalRepr) const {
+  for (unsigned int i = 0; i < _origList.size(); ++i) {
+    const auto& var = _origList[i];
+    std::stringstream regexStr;
+    regexStr << "x\\[" << i << "\\]|@" << i;
+    std::regex regex(regexStr.str());
 
-Bool_t RooFormula::reCompile(const char* newFormula) 
+    std::string replacement = std::string("[") + var.GetName() + "]";
+    internalRepr = std::regex_replace(internalRepr, regex, replacement);
+  }
+
+  return internalRepr;
+}
+#endif //GCC < 4.9 Check
+
+////////////////////////////////////////////////////////////////////////////////
+/// Find all input arguments which are categories, and save this information in
+/// with the names of the variables that are being used to evaluate it.
+std::vector<bool> RooFormula::findCategoryServers(const RooAbsCollection& collection) const {
+  std::vector<bool> output;
+
+  for (unsigned int i = 0; i < collection.size(); ++i) {
+    output.push_back(dynamic_cast<const RooAbsCategory*>(collection[i]));
+  }
+
+  return output;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Recompile formula with new expression. In case of error, the old formula is
+/// retained.
+Bool_t RooFormula::reCompile(const char* newFormula)
 {
-  fNval=0 ;
-  _useList.Clear() ;  
+  std::string processed = processFormula(newFormula);
+  auto newTF = std::make_unique<TFormula>(GetName(), processed.c_str());
 
-  TString oldFormula=GetTitle() ;
-  if (Compile(newFormula)) {
-    coutE(InputArguments) << "RooFormula::reCompile: new equation doesn't compile, formula unchanged" << endl ;
-    reCompile(oldFormula) ;    
-    return kTRUE ;
+  if (!newTF->IsValid()) {
+    coutE(InputArguments) << __func__ << ": new equation doesn't compile, formula unchanged" << endl;
+    return true;
   }
 
-  SetTitle(newFormula) ;
-  return kFALSE ;
+  _tFormula = std::move(newTF);
+  SetTitle(newFormula);
+  return false;
 }
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooFormula::~RooFormula() 
+void RooFormula::dump() const
 {
-  _labelList.Delete() ;
+  printMultiline(std::cout, 0);
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Return list of RooAbsArg dependents that is actually used by formula expression
-
-RooArgSet& RooFormula::actualDependents() const
-{
-  if (!_compiled) {
-    _isOK = !((RooFormula*)this)->Compile() ;
-    _compiled = kTRUE ;
-  }
-
-  // Return list of dependents used in formula expression
-
-  _actual.removeAll();
-  
-  int i ;
-  for (i=0 ; i<_useList.GetSize() ; i++) {
-    _actual.add((RooAbsArg&)*_useList.At(i),kTRUE) ;
-  }
-
-  return _actual ;
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// DEBUG: Dump state information
-
-void RooFormula::dump() 
-{
-  int i ;
-  cout << "RooFormula::dump()" << endl ;
-  cout << "useList:" << endl ;
-  for (i=0 ; i<_useList.GetSize() ; i++) {
-    cout << "[" << i << "] = " << (void*) _useList.At(i) << " " << _useList.At(i)->GetName() << endl ;
-  }
-  cout << "labelList:" << endl ;
-  for (i=0 ; i<_labelList.GetSize() ; i++) {
-    cout << "[" << i << "] = " << (void*) _labelList.At(i) << " " << _labelList.At(i)->GetName() <<  endl ;
-  }
-  cout << "origList:" << endl ;
-  for (i=0 ; i<_origList.GetSize() ; i++) {
-    cout << "[" << i << "] = " << (void*) _origList.At(i)  << " " << _origList.At(i)->GetName() <<  endl ;
-  }
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Change used variables to those with the same name in given list
-/// If mustReplaceAll is true and error is generated if one of the
-/// elements of newDeps is not found as a server
-
-Bool_t RooFormula::changeDependents(const RooAbsCollection& newDeps, Bool_t mustReplaceAll, Bool_t nameChange) 
+/// Change used variables to those with the same name in given list.
+/// \param[in] newDeps New dependents to replace the old ones.
+/// \param[in] mustReplaceAll Will yield an error if one dependent does not have a replacement.
+/// \param[in] nameChange Passed down to RooAbsArg::findNewServer(const RooAbsCollection&, Bool_t) const.
+Bool_t RooFormula::changeDependents(const RooAbsCollection& newDeps, Bool_t mustReplaceAll, Bool_t nameChange)
 {
   //Change current servers to new servers with the same name given in list
-  Bool_t errorStat(kFALSE) ;
-  int i ;
+  bool errorStat = false;
 
-  for (i=0 ; i<_useList.GetSize() ; i++) {
-    RooAbsReal* replace = (RooAbsReal*) ((RooAbsArg*)_useList.At(i))->findNewServer(newDeps,nameChange) ;
-    if (replace) {
-      _useList.Replace(_useList.At(i),replace) ;
-    } else if (mustReplaceAll) {
-      coutE(LinkStateMgmt) << "RooFormula::changeDependents(1): cannot find replacement for " 
-			   << _useList.At(i)->GetName() << endl ;
-      errorStat = kTRUE ;
-    }
-  }  
-
-  TIterator* iter = _origList.MakeIterator() ;
-  RooAbsArg* arg ;
-  while ((arg=(RooAbsArg*)iter->Next())) {
+  for (const auto arg : _origList) {
     RooAbsReal* replace = (RooAbsReal*) arg->findNewServer(newDeps,nameChange) ;
     if (replace) {
-      _origList.Replace(arg,replace) ;
+      _origList.replace(*arg, *replace);
+
       if (arg->getStringAttribute("origName")) {
-	replace->setStringAttribute("origName",arg->getStringAttribute("origName")) ;
+        replace->setStringAttribute("origName",arg->getStringAttribute("origName")) ;
       } else {
-	replace->setStringAttribute("origName",arg->GetName()) ;
+        replace->setStringAttribute("origName",arg->GetName()) ;
       }
+
     } else if (mustReplaceAll) {
-      errorStat = kTRUE ;
+      coutE(LinkStateMgmt) << __func__ << ": cannot find replacement for " << arg->GetName() << endl;
+      errorStat = true;
     }
   }
-  delete iter ;
 
-  return errorStat ;
+  _isCategory = findCategoryServers(_origList);
+
+  return errorStat;
 }
 
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Evaluate ROOT::v5::TFormula using given normalization set to be used as
-/// observables definition passed to RooAbsReal::getVal()
-
-Double_t RooFormula::eval(const RooArgSet* nset)
-{ 
-  if (!_compiled) {
-    _isOK = !Compile() ;
-    _compiled = kTRUE ;
-  }
-
-  // WVE sanity check should go here
-  if (!_isOK) {
-    coutE(Eval) << "RooFormula::eval(" << GetName() << "): Formula doesn't compile: " << GetTitle() << endl ;
-    return 0. ;
-  }
-
-  // Pass current dataset pointer to DefinedValue
-  _nset = (RooArgSet*) nset ;
-
-  return EvalPar(0,0) ; 
-}
-
-
-Double_t
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface to ROOT::v5::TFormula, return value defined by object with id 'code'
-/// Object ids are mapped from object names by method DefinedVariable()
-
-RooFormula::DefinedValue(Int_t code) 
+/// Evaluate the internal TFormula.
+///
+/// First, all variables serving this instance are evaluated given the normalisation set,
+/// and then the formula is evaluated.
+/// \param[in] nset Normalisation set passed to evaluation of arguments serving values.
+/// \return The result of the evaluation.
+Double_t RooFormula::eval(const RooArgSet* nset) const
 {
-  // Return current value for variable indicated by internal reference code
-  if (code>=_useList.GetSize()) return 0 ;
+  if (!_tFormula) {
+    coutF(Eval) << __func__ << " (" << GetName() << "): Formula didn't compile: " << GetTitle() << endl;
+    std::string what = "Formula ";
+    what += GetTitle();
+    what += " didn't compile.";
+    throw std::invalid_argument(what);
+  }
 
-  RooAbsArg* arg=(RooAbsArg*)_useList.At(code) ;
-  if (_useIsCat[code]) {
-
-    // Process as category
-    const RooAbsCategory *absCat = (const RooAbsCategory*)(arg);
-    TString& label=((TObjString*)_labelList.At(code))->String() ;
-    if (label.IsNull()) {
-      return absCat->getIndex() ;
+  std::vector<double> pars;
+  pars.reserve(_origList.size());
+  for (unsigned int i = 0; i < _origList.size(); ++i) {
+    if (_isCategory[i]) {
+      const auto& cat = static_cast<RooAbsCategory&>(_origList[i]);
+      pars.push_back(cat.getIndex());
     } else {
-      return absCat->lookupType(label)->getVal() ; // DK: why not call getVal(_nset) here also?
+      const auto& real = static_cast<RooAbsReal&>(_origList[i]);
+      pars.push_back(real.getVal(nset));
     }
-
-  } else {
-
-    // Process as real 
-    const RooAbsReal *absReal= (const RooAbsReal*)(arg);  
-    return absReal->getVal(_nset) ;
-    
   }
 
-  return 0 ;
+  return _tFormula->EvalPar(pars.data());
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface to ROOT::v5::TFormula. If name passed by ROOT::v5::TFormula is recognized
-/// as one of our RooAbsArg servers, return a unique id integer
-/// that represent this variable.
-
-Int_t RooFormula::DefinedVariable(TString &name, int& action)
-{
-  Int_t ret = DefinedVariable(name) ;
-  if (ret>=0) {
-
-#if ROOT_VERSION_CODE >= ROOT_VERSION(4,0,1)
-     action = kDefinedVariable;
-#else
-     action = 0 ; // prevents compiler warning
-#endif
-
-  }
-  return ret ;
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface to ROOT::v5::TFormula. If name passed by ROOT::v5::TFormula is recognized
-/// as one of our RooAbsArg servers, return a unique id integer
-/// that represent this variable.
-
-Int_t RooFormula::DefinedVariable(TString &name) 
-{
-  char argName[1024];
-  strlcpy(argName,name.Data(),1024) ;
-
-  // Find :: operator and split string if found
-  char *labelName = strstr(argName,"::") ;
-  if (labelName) {
-    *labelName = 0 ;
-    labelName+= 2 ;
-  }
-
-  // Defined internal reference code for given named variable 
-  RooAbsArg *arg = 0;
-  if (argName[0] == '@') {
-    // Access by ordinal number
-    Int_t index = atoi(argName+1) ;
-    if (index>=0 && index<_origList.GetSize()) {
-      arg = (RooAbsArg*) _origList.At(index) ;
-    } else {
-      coutE(Eval) << "RooFormula::DefinedVariable(" << GetName() 
-		  << ") ERROR: ordinal variable reference " << name 
-		  << " out of range (0 - " << _origList.GetSize()-1 << ")" << endl ;
-    }
-  } else {
-    // Access by name
-    arg= (RooAbsArg*) _origList.FindObject(argName) ;
-    if (!arg) {
-      for (RooLinkedListIter it = _origList.iterator(); RooAbsArg* v = dynamic_cast<RooAbsArg*>(it.Next());) {
-	if (!TString(argName).CompareTo(v->getStringAttribute("origName"))) {
-	  arg= v ;
-	}
-      }
-    }
-  }
-
-  // Check that arg exists
-  if (!arg) return -1 ;
-
-  // Check that optional label corresponds to actual category state
-  if (labelName) {
-    RooAbsCategory* cat = dynamic_cast<RooAbsCategory*>(arg) ;
-    if (!cat) {
-      coutE(Eval) << "RooFormula::DefinedVariable(" << GetName() << ") ERROR: " 
-		  << arg->GetName() << "' is not a RooAbsCategory" << endl ;
-      return -1 ;
-    }
-
-    if (!cat->lookupType(labelName)) {
-      coutE(Eval) << "RooFormula::DefinedVariable(" << GetName() << ") ERROR '" 
-		  << labelName << "' is not a state of " << arg->GetName() << endl ;
-      return -1 ;
-    }
-
-  }
-
-
-  // Check if already registered
-  Int_t i ;
-  for(i=0 ; i<_useList.GetSize() ; i++) {
-    RooAbsArg* var = (RooAbsArg*) _useList.At(i) ;
-    //Bool_t varMatch = !TString(var->GetName()).CompareTo(arg->GetName()) ;
-    Bool_t varMatch = !TString(var->GetName()).CompareTo(arg->GetName()) && !TString(var->getStringAttribute("origName")).CompareTo(arg->GetName());
-
-    if (varMatch) {
-      TString& lbl= ((TObjString*) _labelList.At(i))->String() ;
-      Bool_t lblMatch(kFALSE) ;
-      if (!labelName && lbl.IsNull()) {
-	lblMatch=kTRUE ;
-      } else if (labelName && !lbl.CompareTo(labelName)) {
-	lblMatch=kTRUE ;
-      }
-
-      if (lblMatch) {
-	// Label and variable name match, recycle entry
-	return i ;
-      }
-    }
-  }
-
-  // Register new entry ;
-  _useList.Add(arg) ;
-  _useIsCat.push_back(dynamic_cast<RooAbsCategory*>(arg)) ;
-  if (!labelName) {
-    _labelList.Add(new TObjString("")) ;
-  } else {
-    _labelList.Add(new TObjString(labelName)) ;
-  }
-
-   return (_useList.GetSize()-1) ;
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -414,9 +376,11 @@ Int_t RooFormula::DefinedVariable(TString &name)
 void RooFormula::printMultiline(ostream& os, Int_t /*contents*/, Bool_t /*verbose*/, TString indent) const 
 {
   os << indent << "--- RooFormula ---" << endl;
-  os << indent << "  Formula: \"" << GetTitle() << "\"" << endl;
+  os << indent << " Formula:        '" << GetTitle() << "'" << endl;
+  os << indent << " Interpretation: '" << reconstructFormula(GetTitle()) << "'" << endl;
   indent.Append("  ");
-  os << indent << actualDependents() << endl ;
+  os << indent << "Servers: " << _origList << "\n";
+  os << indent << "In use : " << actualDependents() << endl;
 }
 
 
@@ -461,5 +425,166 @@ void RooFormula::printClassName(ostream& os) const
 
 void RooFormula::printArgs(ostream& os) const 
 {
-  os << "[ actualVars=" << _actual << " ]" ;
+  os << "[ actualVars=";
+  for (const auto arg : usedVariables()) {
+     os << " " << arg->GetName();
+  }
+  os << " ]";
 }
+
+
+
+
+
+#ifndef ROOFORMULA_HAVE_STD_REGEX
+/*
+ * g++ 4.8 doesn't support the std::regex. It has headers, but no implementations of the standard, leading to linker
+ * errors. As long as centos 7 needs to be supported, this forces us to have a legacy implementation.
+ */
+
+#include "TPRegexp.h"
+
+////////////////////////////////////////////////////////////////////////////////
+/// Process given formula by replacing all ordinal and name references by
+/// `x[i]`, where `i` matches the position of the argument in `_origList`.
+/// Further, references to category states such as `leptonMulti:one` are replaced
+/// by the category index.
+std::string RooFormula::processFormula(std::string formula) const {
+  TString formulaTString = formula.c_str();
+
+  cxcoutD(InputArguments) << "Preprocessing formula step 1: find category tags (catName::catState) in "
+      << formulaTString.Data() << endl;
+
+  // Step 1: Find all category tags and the corresponding index numbers
+  TPRegexp categoryReg("(\\w+)::(\\w+)");
+  std::map<std::string, int> categoryStates;
+  int offset = 0;
+  do {
+    std::unique_ptr<TObjArray> matches(categoryReg.MatchS(formulaTString, "", offset, 3));
+    if (matches->GetEntries() == 0)
+      break;
+
+    std::string fullMatch = static_cast<TObjString*>(matches->At(0))->GetString().Data();
+    std::string catName = static_cast<TObjString*>(matches->At(1))->GetString().Data();
+    std::string catState = static_cast<TObjString*>(matches->At(2))->GetString().Data();
+    offset = formulaTString.Index(categoryReg, offset) + fullMatch.size();
+
+    const auto catVariable = dynamic_cast<const RooAbsCategory*>(_origList.find(catName.c_str()));
+    if (!catVariable) {
+      cxcoutD(InputArguments) << "Formula " << GetName() << " uses '::' to reference a category state as '" << fullMatch
+          << "' but a category '" << catName << "' cannot be found in the input variables." << endl;
+      continue;
+    }
+
+    const RooCatType* catType = catVariable->lookupType(catState.c_str(), false);
+    if (!catType) {
+      coutE(InputArguments) << "Formula " << GetName() << " uses '::' to reference a category state as '" << fullMatch
+          << "' but the category '" << catName << "' does not seem to have the state '" << catState << "'." << endl;
+      throw std::invalid_argument(formula);
+    }
+    const int catNum = catType->getVal();
+
+    categoryStates[fullMatch] = catNum;
+    cxcoutD(InputArguments) << "\n\t" << fullMatch << "\tname=" << catName << "\tstate=" << catState << "=" << catNum;
+  } while (offset != -1);
+  cxcoutD(InputArguments) << "-- End of category tags --"<< endl;
+
+  // Step 2: Replace all category tags
+  for (const auto& catState : categoryStates) {
+    std::stringstream replacement;
+    replacement << catState.second;
+    formulaTString.ReplaceAll(catState.first.c_str(), replacement.str().c_str());
+  }
+
+  cxcoutD(InputArguments) << "Preprocessing formula step 2: replace category tags\n\t" << formulaTString.Data() << endl;
+
+  // Step 3: Convert `@i`-style references to `x[i]`
+  TPRegexp ordinalRegex("@([0-9]+)");
+  int nsub = 0;
+  do {
+    nsub = ordinalRegex.Substitute(formulaTString, "x[$1]");
+  } while (nsub > 0);
+
+  cxcoutD(InputArguments) << "Preprocessing formula step 3: replace '@'-references\n\t" << formulaTString.Data() << endl;
+
+  // Step 4: Replace all named references with "x[i]"-style
+  for (unsigned int i = 0; i < _origList.size(); ++i) {
+    const auto& var = _origList[i];
+    TString regex = "\\b";
+    regex += var.GetName();
+    regex += "\\b([^[]|$)"; //Negative lookahead. If the variable is called `x`, this might otherwise replace `x[0]`.
+    TPRegexp findParameterRegex(regex);
+
+    std::stringstream replacement;
+    replacement << "x[" << i << "]$1";
+    int nsub2 = 0;
+    do {
+      nsub2 = findParameterRegex.Substitute(formulaTString, replacement.str().c_str());
+    } while (nsub2 > 0);
+
+    cxcoutD(InputArguments) << "Preprocessing formula step 4: replace named references: "
+        << var.GetName() << " --> " << replacement.str()
+        << "\n\t" << formulaTString.Data() << endl;
+  }
+
+  cxcoutD(InputArguments) << "Final formula:\n\t" << formulaTString << endl;
+
+  return formulaTString.Data();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Analyse internal formula to find out which variables are actually in use.
+RooArgList RooFormula::usedVariables() const {
+  RooArgList useList;
+  if (_tFormula == nullptr)
+    return useList;
+
+  const TString formulaTString = _tFormula->GetTitle();
+
+  std::set<unsigned int> matchedOrdinals;
+  TPRegexp newOrdinalRegex("\\bx\\[([0-9]+)\\]");
+  int offset = 0;
+  do {
+    std::unique_ptr<TObjArray> matches(newOrdinalRegex.MatchS(formulaTString, "", offset, 2));
+    if (matches->GetEntries() == 0)
+      break;
+
+    std::string fullMatch = static_cast<TObjString*>(matches->At(0))->GetString().Data();
+    std::string ordinal   = static_cast<TObjString*>(matches->At(1))->GetString().Data();
+    offset = formulaTString.Index(newOrdinalRegex, offset) + fullMatch.size();
+
+    std::stringstream matchString(ordinal.c_str());
+    unsigned int i;
+    matchString >> i;
+
+    matchedOrdinals.insert(i);
+  } while (offset != -1);
+
+  for (unsigned int i : matchedOrdinals) {
+    useList.add(_origList[i]);
+  }
+
+  return useList;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// From the internal representation, construct a formula by replacing all index place holders
+/// with the names of the variables that are being used to evaluate it.
+std::string RooFormula::reconstructFormula(std::string internalRepr) const {
+  TString internalReprT = internalRepr.c_str();
+
+  for (unsigned int i = 0; i < _origList.size(); ++i) {
+    const auto& var = _origList[i];
+    std::stringstream regexStr;
+    regexStr << "x\\[" << i << "\\]|@" << i;
+    TPRegexp regex(regexStr.str().c_str());
+
+    std::string replacement = std::string("[") + var.GetName() + "]";
+    regex.Substitute(internalReprT, replacement.c_str());
+  }
+
+  return internalReprT.Data();
+}
+#endif //GCC < 4.9 Check


### PR DESCRIPTION
- Replace the old TFormula-v5-derived RooFormula by a small class that
creates a TFormula v6 [ROOT-10164,ROOT-10144].
- Update documentation for GenericPdf and FormulaVar accordingly.
- Fix small memory leak in RooAbsData.
- The This allows re-enabling the RooJohnson unit test that's based on
RooFormula [ROOT-10173].

It was further tested that [ROOT-8291] doesn't occur with the new
formula when it is serialised.