### PR TITLE
[json/xml]  mask out TObject::kNotDeleted & TObject::kIsOnHeap bits from text I/O

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -98,6 +98,7 @@ class Container {
 #include <locale.h>
 #include <cmath>
 #include <memory>
+#include <cstdlib>
 
 #include <ROOT/RMakeUnique.hxx>
 
@@ -1954,7 +1955,7 @@ void TBufferJSON::JsonReadTObjectMembers(TObject *tobj, void *node)
 
    tobj->SetUniqueID(uid);
    // there is no method to set all bits directly - do it one by one
-   for (unsigned n = 0; n < 32; n++)
+   for (unsigned n = 0; n < 24; n++)
       tobj->SetBit(BIT(n), (bits & BIT(n)) != 0);
 
    if (gDebug > 2)
@@ -2370,7 +2371,9 @@ void TBufferJSON::PerformPostProcessing(TJSONStackObj *stack, const TClass *obj_
          AppendOutput(stack->fValues[0].c_str());
          AppendOutput(stack->NextMemberSeparator(), "\"fBits\"");
          AppendOutput(fSemicolon.Data());
-         AppendOutput((stack->fValues.size() > 1) ? stack->fValues[1].c_str() : fValue.Data());
+         auto tbits = std::atol((stack->fValues.size() > 1) ? stack->fValues[1].c_str() : fValue.Data());
+         tbits = tbits & TObject::kBitMask;
+         AppendOutput(std::to_string(tbits).c_str());
          if (cnt == 3) {
             AppendOutput(stack->NextMemberSeparator(), "\"fPID\"");
             AppendOutput(fSemicolon.Data());

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -1314,7 +1314,7 @@ void TBufferXML::PerformPostProcessing()
       str = fXML->GetAttr(bitsnode, xmlio::v);
       UInt_t bits;
       sscanf(str.Data(), "%u", &bits);
-      bits = bits & TObject::kBitMask;
+      bits = bits & ~TObject::kNotDeleted & ~TObject::kIsOnHeap;
 
       char sbuf[20];
       snprintf(sbuf, sizeof(sbuf), "%x", bits);
@@ -1390,8 +1390,9 @@ void TBufferXML::PerformPreProcessing(const TStreamerElement *elem, XMLNodePoint
       node = fXML->NewChild(elemnode, nullptr, xmlio::UInt);
       fXML->NewAttr(node, nullptr, xmlio::v, idstr);
 
-      UInt_t bits;
+      UInt_t bits = 0;
       sscanf(bitsstr.Data(), "%x", &bits);
+      bits = bits | TObject::kNotDeleted | TObject::kIsOnHeap;
       char sbuf[20];
       snprintf(sbuf, sizeof(sbuf), "%u", bits);
 

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -1314,6 +1314,7 @@ void TBufferXML::PerformPostProcessing()
       str = fXML->GetAttr(bitsnode, xmlio::v);
       UInt_t bits;
       sscanf(str.Data(), "%u", &bits);
+      bits = bits & TObject::kBitMask;
 
       char sbuf[20];
       snprintf(sbuf, sizeof(sbuf), "%x", bits);


### PR DESCRIPTION
Sometime ROOT wrongly assign kIsOnHeap bit to object, making json-based tests failing.
While these bits must be on after object reading, there is no sense preserve them.
Making JSON code more compact. Instead of:

"fBits": 50331649,

one will get:

"fBits": 1,

Should solve sporadic problems with roottest.
roottest has to be modified after that PR