### PR TITLE
Disable splash screen by default

### DIFF
--- a/README/ReleaseNotes/v620/index.md
+++ b/README/ReleaseNotes/v620/index.md
@@ -48,6 +48,17 @@ The following people have contributed to this new version:
  Zhe Zhang, Nebraska,\
  Stefan Wunsch, CERN/SFT
 
+## ROOT
+
+### Splash screen
+
+The venerable splash screen is now disabled by default to make ROOT's startup
+faster. Many users already use `root -l` to start ROOT, but this also hides the
+useful text banner with version information along with the splash screen. With
+this new default, starting up ROOT as just `root` will show only the text banner
+instead of the splash screen. The splash screen can still be seen with `root -a`
+or in `TBrowser` by opening `Browser Help → About ROOT`.
+
 ## Deprecation and Removal
  * rootcling flags `-cint`, `-reflex` and `-gccxml` have no effect and will be
    removed. Please remove them from the rootcling invocations.

--- a/rootx/src/rootx.cxx
+++ b/rootx/src/rootx.cxx
@@ -58,7 +58,7 @@ extern void PopdownLogo();
 extern void CloseDisplay();
 
 
-static bool gNoLogo = false;
+static bool gNoLogo = true;
       //const  int  kMAXPATHLEN = 8192; defined in Rtypes.h
 
 


### PR DESCRIPTION
Following our discussions, this is the proposed change to disable the splash screen by default. Most users use `root -l` to get rid of the splash screen in any case. As mentioned in the discussions, it is still possible to see the splash screen with `root -a` or from a `TBrowser`, by going to *Browser Help* → *About ROOT*.

If you want to check out this change, I have installed ROOT 6.18 with this change into CVMFS.
You can run it on Linux with (no setup required):
```
$ /cvmfs/sft.cern.ch/lcg/contrib/gentoo/linux/x86_64/usr/lib/root/6.18/bin/root
```