### PR TITLE
Backport 6.18: Add more property bits for TFunctionTemplate

### DIFF
--- a/core/meta/inc/TFunctionTemplate.h
+++ b/core/meta/inc/TFunctionTemplate.h
@@ -41,6 +41,7 @@ public:
 
    virtual Bool_t      IsValid();
    Long_t              Property() const;
+   Long_t              ExtraProperty() const;
 
    virtual bool        Update(FuncTempInfo_t *info);
 

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -466,6 +466,7 @@ public:
    virtual UInt_t FuncTempInfo_TemplateNargs(FuncTempInfo_t * /* ft_info */) const = 0;
    virtual UInt_t FuncTempInfo_TemplateMinReqArgs(FuncTempInfo_t * /* ft_info */) const = 0;
    virtual Long_t FuncTempInfo_Property(FuncTempInfo_t * /* ft_info */) const = 0;
+   virtual Long_t FuncTempInfo_ExtraProperty(FuncTempInfo_t * /* ft_info */) const = 0;
    virtual void FuncTempInfo_Name(FuncTempInfo_t * /* ft_info */, TString &name) const = 0;
    virtual void FuncTempInfo_Title(FuncTempInfo_t * /* ft_info */, TString &title) const = 0;
 

--- a/core/meta/src/TFunctionTemplate.cxx
+++ b/core/meta/src/TFunctionTemplate.cxx
@@ -126,6 +126,14 @@ Long_t TFunctionTemplate::Property() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Get the properties not already defined in Property.See TDictionary's EFunctionProperty.
+
+Long_t TFunctionTemplate::ExtraProperty() const
+{
+   return fInfo ? gCling->FuncTempInfo_ExtraProperty(fInfo) : 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 TDictionary::DeclId_t TFunctionTemplate::GetDeclId() const
 {

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8236,6 +8236,34 @@ Long_t TCling::FuncTempInfo_Property(FuncTempInfo_t *ft_info) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return the property not already defined in Property
+/// See TDictionary's EFunctionProperty
+
+Long_t TCling::FuncTempInfo_ExtraProperty(FuncTempInfo_t* ft_info) const
+{
+   if (!ft_info) return 0;
+
+   long property = 0L;
+   property |= kIsCompiled;
+
+   const clang::FunctionTemplateDecl *ft = (clang::FunctionTemplateDecl*)ft_info;
+   const clang::FunctionDecl *fd = ft->getTemplatedDecl();
+
+   if (fd->isOverloadedOperator()) {
+      property |= kIsOperator;
+   }
+   else if (llvm::isa<clang::CXXConversionDecl>(fd)) {
+      property |= kIsConversion;
+   } else if (llvm::isa<clang::CXXConstructorDecl>(fd)) {
+      property |= kIsConstructor;
+   } else if (llvm::isa<clang::CXXDestructorDecl>(fd)) {
+      property |= kIsDestructor;
+   }
+
+   return property;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return the name of this function template.
 
 void TCling::FuncTempInfo_Name(FuncTempInfo_t *ft_info, TString &output) const

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -463,6 +463,7 @@ public: // Public Interface
    virtual UInt_t FuncTempInfo_TemplateNargs(FuncTempInfo_t * /* ft_info */) const;
    virtual UInt_t FuncTempInfo_TemplateMinReqArgs(FuncTempInfo_t * /* ft_info */) const;
    virtual Long_t FuncTempInfo_Property(FuncTempInfo_t * /* ft_info */) const;
+   virtual Long_t FuncTempInfo_ExtraProperty(FuncTempInfo_t * /* ft_info */) const;
    virtual void FuncTempInfo_Name(FuncTempInfo_t * /* ft_info */, TString& name) const;
    virtual void FuncTempInfo_Title(FuncTempInfo_t * /* ft_info */, TString& name) const;
 


### PR DESCRIPTION
Backport of the TCling changes in https://github.com/root-project/root/pull/4051/

This incorporate the changes of the patch:
https://bitbucket.org/wlav/cppyy-backend/src/master/cling/patches/templ_ctor.diff