### PR TITLE
[PyROOT][ROOT-10268] Enable pickling of arrays returned by AsNumpy

### DIFF
--- a/bindings/pyroot/_rdf_utils.py
+++ b/bindings/pyroot/_rdf_utils.py
@@ -22,12 +22,11 @@ class ndarray(numpy.ndarray):
     def __new__(cls, numpy_array, result_ptr):
         """
         Dunder method invoked at the creation of an instance of this class. It
-        creates a `numpy.array` with an `RResultPtr` as an additional
+        creates a numpy array with an `RResultPtr` as an additional
         attribute.
         """
         obj = numpy.asarray(numpy_array).view(cls)
         obj.result_ptr = result_ptr
-        obj.__class__.__name__ = "numpy.array"
         return obj
 
     def __array_finalize__(self, obj):

--- a/bindings/pyroot/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot/test/rdataframe_asnumpy.py
@@ -1,6 +1,7 @@
 import unittest
 import ROOT
 import numpy as np
+import pickle
 
 
 class RDataFrameAsNumpy(unittest.TestCase):
@@ -204,6 +205,18 @@ class RDataFrameAsNumpy(unittest.TestCase):
         df = ROOT.RDataFrame(10).Define("x", "1.0").Filter("x<0")
         npy = df.AsNumpy(["x"])
         self.assertEqual(npy["x"].size, 0)
+
+    def test_pickle(self):
+        """
+        Testing pickling of returned numpy array
+        """
+        df = ROOT.RDataFrame(10).Define("x", "1.0")
+        npy = df.AsNumpy(["x"])
+        arr = npy["x"]
+
+        pickle.dump(arr, open("rdataframe_asnumpy.pickle", "wb"))
+        arr2 = pickle.load(open("rdataframe_asnumpy.pickle", "rb"))
+        self.assertTrue(all(arr == arr2))
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rdf_utils.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rdf_utils.py
@@ -22,12 +22,12 @@ class ndarray(numpy.ndarray):
     def __new__(cls, numpy_array, result_ptr):
         """
         Dunder method invoked at the creation of an instance of this class. It
-        creates a `numpy.array` with an `RResultPtr` as an additional
+        creates a numpy array with an `RResultPtr` as an additional
         attribute.
         """
         obj = numpy.asarray(numpy_array).view(cls)
         obj.result_ptr = result_ptr
-        obj.__class__.__name__ = "numpy.array"
+        data = numpy_array
         return obj
 
     def __array_finalize__(self, obj):

--- a/bindings/pyroot_experimental/PyROOT/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot_experimental/PyROOT/test/rdataframe_asnumpy.py
@@ -1,6 +1,7 @@
 import unittest
 import ROOT
 import numpy as np
+import pickle
 
 
 def make_tree(*dtypes):
@@ -255,6 +256,18 @@ class RDataFrameAsNumpy(unittest.TestCase):
         df = ROOT.ROOT.RDataFrame(10).Define("x", "1.0").Filter("x<0")
         npy = df.AsNumpy(["x"])
         self.assertEqual(npy["x"].size, 0)
+
+    def test_pickle(self):
+        """
+        Testing pickling of returned numpy array
+        """
+        df = ROOT.ROOT.RDataFrame(10).Define("x", "1.0")
+        npy = df.AsNumpy(["x"])
+        arr = npy["x"]
+
+        pickle.dump(arr, open("rdataframe_asnumpy.pickle", "wb"))
+        arr2 = pickle.load(open("rdataframe_asnumpy.pickle", "rb"))
+        self.assertTrue(all(arr == arr2))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We renamed the class of the numpy wrapper object to numpy.array so that
the wrapping is hidden from the user. However, this breaks pickling of
the object since the class name does not match the name of the true
class. Removing the renaming solves the issue. Now, the returned array
is not called numpy.array but ndarray.

This PR fixes current and experimental PyROOT.

@etejedor @maxgalli I think this is a feasible solution since the name of the class is anyway only visible in the `__repr__` representation and numpy.array is as good as ndarray since both indicate to the user that the object behaves like a numpy array.

Jira ticket can be found here: https://sft.its.cern.ch/jira/browse/ROOT-10268