### PR TITLE
Simplify query for include directories

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -104,12 +104,10 @@ namespace {
                                        llvm::SmallVectorImpl<char>& Buf,
                                        AdditionalArgList& Args,
                                        bool Verbose) {
-    std::string CppInclQuery("LC_ALL=C ");
-    CppInclQuery.append(Compiler);
-    CppInclQuery.append(" -xc++ -E -v /dev/null 2>&1 >/dev/null "
-                        "| awk '/^#include </,/^End of search"
-                        "/{if (!/^#include </ && !/^End of search/){ print }}' "
-                        "| GREP_OPTIONS= grep -E \"(c|g)\\+\\+\"");
+    std::string CppInclQuery(Compiler);
+
+    CppInclQuery.append(" -xc++ -E -v /dev/null 2>&1 |"
+                        " sed -n -e '/^.include/,${' -e '/^ \\/.*++/p' -e '}'");
 
     if (Verbose)
       cling::log() << "Looking for C++ headers with:\n  " << CppInclQuery << "\n";

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -252,8 +252,7 @@ if (UNIX)
 
     execute_process(
       COMMAND echo ${CLING_CXX_HEADERS}
-      COMMAND awk "/^#include </,/^End of search/{if (!/^#include </ && !/^End of search/){ print }}"
-      COMMAND grep -E "(c|g)\\+\\+"
+      COMMAND sed -n -e /^.include/,\$\{ -e /^\\\ \\\/.*++/p -e \}
       OUTPUT_VARIABLE CLING_CXX_HEADERS)
 
     stripNewLine("${CLING_CXX_HEADERS}" CLING_CXX_HEADERS)


### PR DESCRIPTION
- Use only sed instead of awk and grep
- Use regex independent of locale settings

Below is the generated output for our supported compilers:
```
$ clang++ -xc++ -E -v /dev/null 2>&1 | sed -n /^.include/,\${/++/p}
 /usr/include/c++/v1
$ g++ -xc++ -E -v /dev/null 2>&1 | sed -n /^.include/,\${/++/p}
 /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8
 /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/x86_64-pc-linux-gnu
 /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/backward
$ icc -xc++ -E -v /dev/null 2>&1 | sed -n /^.include/,\${/++/p}
 /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8
 /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/x86_64-pc-linux-gnu
 /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/backward
```