### PR TITLE
[qt5web] add missing QWebEngineDownloadItem include

### DIFF
--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -19,6 +19,7 @@
 #include <QThread>
 #include <QWebEngineSettings>
 #include <QWebEngineProfile>
+#include <QWebEngineDownloadItem>
 #include <QtGlobal>
 
 #if QT_VERSION >= 0x050C00


### PR DESCRIPTION
Was missing when compile with Qt5.6, which is oldest supported version.
Was fine for Qt5.13, therefore was not recognized