### PR TITLE
[ntuple] Add support for std::array (fixed-size arrays)

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -61,8 +61,6 @@ private:
    RPage fCurrentPage;
    /// The column id is used to find matching pages with content when reading
    ColumnId_t fColumnIdSource;
-   /// Optional link to a parent offset column that points into this column
-   RColumn* fOffsetColumn;
    /// Used to pack and unpack pages on writing/reading
    std::unique_ptr<RColumnElementBase> fElement;
 
@@ -183,7 +181,7 @@ public:
       if (!fCurrentPage.Contains(clusterIndex)) {
          MapPage(clusterIndex);
       }
-      return fCurrentPage.GetClusterInfo().GetSelfOffset() + clusterIndex.GetIndex();
+      return fCurrentPage.GetClusterInfo().GetIndexOffset() + clusterIndex.GetIndex();
    }
 
    RClusterIndex GetClusterIndex(NTupleSize_t globalIndex) {
@@ -191,7 +189,7 @@ public:
          MapPage(globalIndex);
       }
       return RClusterIndex(fCurrentPage.GetClusterInfo().GetId(),
-                           globalIndex - fCurrentPage.GetClusterInfo().GetSelfOffset());
+                           globalIndex - fCurrentPage.GetClusterInfo().GetIndexOffset());
    }
 
    /// For offset columns only, look at the two adjacent values that define a collection's coordinates
@@ -199,7 +197,7 @@ public:
    {
       auto idxStart = (globalIndex == 0) ? 0 : *Map<ClusterSize_t, EColumnType::kIndex>(globalIndex - 1);
       auto idxEnd = *Map<ClusterSize_t, EColumnType::kIndex>(globalIndex);
-      auto selfOffset = fCurrentPage.GetClusterInfo().GetSelfOffset();
+      auto selfOffset = fCurrentPage.GetClusterInfo().GetIndexOffset();
       if (globalIndex == selfOffset) {
          // Passed cluster boundary
          idxStart = 0;
@@ -229,8 +227,6 @@ public:
    RPageSource* GetPageSource() const { return fPageSource; }
    RPageStorage::ColumnHandle_t GetHandleSource() const { return fHandleSource; }
    RPageStorage::ColumnHandle_t GetHandleSink() const { return fHandleSink; }
-   void SetOffsetColumn(RColumn* offsetColumn) { fOffsetColumn = offsetColumn; }
-   RColumn* GetOffsetColumn() const { return fOffsetColumn; }
    RNTupleVersion GetVersion() const { return RNTupleVersion(); }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -405,8 +405,11 @@ public:
 
    void DoGenerateColumns() final;
 
-   ClusterSize_t *Map(NTupleSize_t index) {
-      return fPrincipalColumn->Map<ClusterSize_t, EColumnType::kIndex>(index);
+   ClusterSize_t *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<ClusterSize_t, EColumnType::kIndex>(globalIndex);
+   }
+   ClusterSize_t *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<ClusterSize_t, EColumnType::kIndex>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -425,8 +428,11 @@ public:
    size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
 
    /// Special help for offset fields
-   void GetCollectionInfo(NTupleSize_t index, NTupleSize_t* idxStart, ClusterSize_t* size) {
-      fPrincipalColumn->GetCollectionInfo(index, idxStart, size);
+   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) {
+      fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
+   }
+   void GetCollectionInfo(const RClusterIndex &clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) {
+      fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
    }
 };
 
@@ -444,8 +450,11 @@ public:
 
    void DoGenerateColumns() final;
 
-   bool *Map(NTupleSize_t index) {
-      return fPrincipalColumn->Map<bool, EColumnType::kBit>(index);
+   bool *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<bool, EColumnType::kBit>(globalIndex);
+   }
+   bool *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<bool, EColumnType::kBit>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -477,8 +486,11 @@ public:
 
    void DoGenerateColumns() final;
 
-   float *Map(NTupleSize_t index) {
-      return fPrincipalColumn->Map<float, EColumnType::kReal32>(index);
+   float *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kReal32>(globalIndex);
+   }
+   float *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kReal32>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -511,8 +523,11 @@ public:
 
    void DoGenerateColumns() final;
 
-   double *Map(NTupleSize_t index) {
-      return fPrincipalColumn->Map<double, EColumnType::kReal64>(index);
+   double *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<double, EColumnType::kReal64>(globalIndex);
+   }
+   double *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<double, EColumnType::kReal64>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -544,8 +559,11 @@ public:
 
    void DoGenerateColumns() final;
 
-   std::int32_t *Map(NTupleSize_t index) {
-      return fPrincipalColumn->Map<std::int32_t, EColumnType::kInt32>(index);
+   std::int32_t *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<std::int32_t, EColumnType::kInt32>(globalIndex);
+   }
+   std::int32_t *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<std::int32_t, EColumnType::kInt32>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -577,8 +595,11 @@ public:
 
    void DoGenerateColumns() final;
 
-   std::uint32_t *Map(NTupleSize_t index) {
-      return fPrincipalColumn->Map<std::uint32_t, EColumnType::kInt32>(index);
+   std::uint32_t *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<std::uint32_t, EColumnType::kInt32>(globalIndex);
+   }
+   std::uint32_t *Map(const RClusterIndex clusterIndex) {
+      return fPrincipalColumn->Map<std::uint32_t, EColumnType::kInt32>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -610,8 +631,11 @@ public:
 
    void DoGenerateColumns() final;
 
-   std::uint64_t *Map(NTupleSize_t index) {
-      return fPrincipalColumn->Map<std::uint64_t, EColumnType::kInt64>(index);
+   std::uint64_t *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<std::uint64_t, EColumnType::kInt64>(globalIndex);
+   }
+   std::uint64_t *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<std::uint64_t, EColumnType::kInt64>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -765,12 +789,12 @@ protected:
    void DoReadGlobal(NTupleSize_t globalIndex, Detail::RFieldValue *value) final {
       auto typedValue = value->Get<ContainerT>();
       ClusterSize_t nItems;
-      NTupleSize_t idxStart;
-      fPrincipalColumn->GetCollectionInfo(globalIndex, &idxStart, &nItems);
+      RClusterIndex collectionStart;
+      fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
       typedValue->resize(nItems);
       for (unsigned i = 0; i < nItems; ++i) {
          auto itemValue = fSubFields[0]->GenerateValue(&typedValue->data()[i]);
-         fSubFields[0]->Read(idxStart + i, &itemValue);
+         fSubFields[0]->Read(collectionStart + i, &itemValue);
       }
    }
 
@@ -855,13 +879,13 @@ protected:
    void DoReadGlobal(NTupleSize_t globalIndex, Detail::RFieldValue *value) final {
       auto typedValue = value->Get<ContainerT>();
       ClusterSize_t nItems;
-      NTupleSize_t idxStart;
-      fPrincipalColumn->GetCollectionInfo(globalIndex, &idxStart, &nItems);
+      RClusterIndex collectionStart;
+      fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
       typedValue->resize(nItems);
       for (unsigned i = 0; i < nItems; ++i) {
          bool bval = (*typedValue)[i];
          auto itemValue = fSubFields[0]->GenerateValue(&bval);
-         fSubFields[0]->Read(idxStart + i, &itemValue);
+         fSubFields[0]->Read(collectionStart + i, &itemValue);
          (*typedValue)[i] = bval;
       }
    }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -131,7 +131,6 @@ protected:
    /// column type exists.
    virtual void DoAppend(const RFieldValue& value);
    virtual void DoRead(NTupleSize_t index, RFieldValue* value);
-   virtual void DoReadV(NTupleSize_t index, NTupleSize_t count, void* dst);
 
 public:
    /// Iterates over the sub fields in depth-first search order
@@ -171,7 +170,7 @@ public:
    virtual ~RFieldBase();
 
    ///// Copies the field and its sub fields using a possibly new name and a new, unconnected set of columns
-   virtual RFieldBase* Clone(std::string_view newName) = 0;
+   virtual RFieldBase *Clone(std::string_view newName) = 0;
 
    /// Factory method to resurrect a field from the stored on-disk type information
    static RFieldBase *Create(const std::string &fieldName, const std::string &typeName);
@@ -200,7 +199,7 @@ public:
    }
 
    /// Populate a single value with data from the tree, which needs to be of the fitting type.
-   /// Reading copies data into the memory wrapped by the tree value.
+   /// Reading copies data into the memory wrapped by the ntuple value.
    void Read(NTupleSize_t index, RFieldValue* value) {
       if (!fIsSimple) {
          DoRead(index, value);
@@ -208,20 +207,6 @@ public:
       }
       fPrincipalColumn->Read(index, &value->fMappedElement);
    }
-
-   /// Type unsafe bulk read interface; dst must point to a vector of objects of the field type.
-   /// TODO(jblomer): can this be type safe?
-   void ReadV(NTupleSize_t index, NTupleSize_t count, void *dst)
-   {
-      if (!fIsSimple) {
-         DoReadV(index, count, dst);
-         return;
-      }
-      //fPrincipalColumn->ReadV(index, count, dst);
-   }
-
-   /// The number of elements in the principal column. For top level fields, the number of entries.
-   NTupleSize_t GetNItems();
 
    /// Ensure that all received items are written from page buffers to the storage.
    void Flush() const;

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -144,7 +144,7 @@ public:
       }
    }
 
-   RNTupleViewRange GetViewRange() { return RNTupleViewRange(0, fNEntries); }
+   RNTupleGlobalRange GetViewRange() { return RNTupleGlobalRange(0, fNEntries); }
 
    /// Provides access to an individual field that can contain either a scalar value or a collection, e.g.
    /// GetView<double>("particles.pt") or GetView<std::vector<double>>("particle").  It can as well be the index

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -60,7 +60,8 @@ private:
    ENTupleStructure fStructure;
    /// Establishes sub field relationships, such as classes and collections
    DescriptorId_t fParentId = kInvalidDescriptorId;
-   /// For pointers and optional/variant fields, the pointee field(s)
+   /// The pointers in the other direction from parent to children. They are serialized, too, to keep the
+   /// order of sub fields.
    std::vector<DescriptorId_t> fLinkIds;
 
 public:
@@ -103,10 +104,6 @@ private:
    DescriptorId_t fFieldId = kInvalidDescriptorId;
    /// A field can be serialized into several columns, which are numbered from zero to $n$
    std::uint32_t fIndex;
-   /// Pointer to the parent column with offsets
-   DescriptorId_t fOffsetId = kInvalidDescriptorId;
-   /// For index and offset columns of collections, pointers and variants, the pointee field(s)
-   std::vector<DescriptorId_t> fLinkIds;
 
 public:
    /// In order to handle changes to the serialization routine in future ntuple versions
@@ -120,8 +117,6 @@ public:
    RColumnModel GetModel() const { return fModel; }
    std::uint32_t GetIndex() const { return fIndex; }
    DescriptorId_t GetFieldId() const { return fFieldId; }
-   DescriptorId_t GetOffsetId() const { return fOffsetId; }
-   std::vector<DescriptorId_t> GetLinkIds() const { return fLinkIds; }
 };
 
 
@@ -350,13 +345,10 @@ public:
    void AddField(DescriptorId_t fieldId, const RNTupleVersion &fieldVersion, const RNTupleVersion &typeVersion,
                  std::string_view fieldName, std::string_view typeName, std::uint64_t nRepetitions,
                  ENTupleStructure structure);
-   void SetFieldParent(DescriptorId_t fieldId, DescriptorId_t parentId);
    void AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId);
 
    void AddColumn(DescriptorId_t columnId, DescriptorId_t fieldId,
                   const RNTupleVersion &version, const RColumnModel &model, std::uint32_t index);
-   void SetColumnOffset(DescriptorId_t columnId, DescriptorId_t offsetId);
-   void AddColumnLink(DescriptorId_t columnId, DescriptorId_t linkId);
 
    void SetFromHeader(void* headerBuffer);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -45,14 +45,16 @@ using NTupleSize_t = std::uint64_t;
 constexpr NTupleSize_t kInvalidNTupleIndex = std::uint64_t(-1);
 /// Wrap the 32bit integer in a struct in order to avoid template specialization clash with std::uint32_t
 struct RClusterSize {
-   RClusterSize() : fValue(0) {}
-   explicit constexpr RClusterSize(std::uint32_t value) : fValue(value) {}
-   RClusterSize& operator =(const std::uint32_t value) { fValue = value; return *this; }
-   RClusterSize& operator +=(const std::uint32_t value) { fValue += value; return *this; }
-   RClusterSize operator++(int) { auto result = *this; fValue++; return result; }
-   operator std::uint32_t() const { return fValue; }
+   using ValueType = std::uint32_t;
 
-   std::uint32_t fValue;
+   RClusterSize() : fValue(0) {}
+   explicit constexpr RClusterSize(ValueType value) : fValue(value) {}
+   RClusterSize& operator =(const ValueType value) { fValue = value; return *this; }
+   RClusterSize& operator +=(const ValueType value) { fValue += value; return *this; }
+   RClusterSize operator++(int) { auto result = *this; fValue++; return result; }
+   operator ValueType() const { return fValue; }
+
+   ValueType fValue;
 };
 using ClusterSize_t = RClusterSize;
 constexpr ClusterSize_t kInvalidClusterIndex(std::uint32_t(-1));

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -73,9 +73,21 @@ private:
    DescriptorId_t fClusterId = kInvalidDescriptorId;
    ClusterSize_t::ValueType fIndex = kInvalidClusterIndex;
 public:
-   RClusterIndex() = delete;
+   RClusterIndex() = default;
+   RClusterIndex(const RClusterIndex &other) = default;
+   RClusterIndex &operator =(const RClusterIndex &other) = default;
    constexpr RClusterIndex(DescriptorId_t clusterId, ClusterSize_t::ValueType index)
       : fClusterId(clusterId), fIndex(index) {}
+
+   RClusterIndex  operator+(ClusterSize_t::ValueType off) const { return RClusterIndex(fClusterId, fIndex + off); }
+   RClusterIndex  operator-(ClusterSize_t::ValueType off) const { return RClusterIndex(fClusterId, fIndex - off); }
+   RClusterIndex  operator++(int) /* postfix */        { auto r = *this; fIndex++; return r; }
+   RClusterIndex& operator++()    /* prefix */         { fIndex++; return *this; }
+   bool operator==(const RClusterIndex &other) const {
+      return fClusterId == other.fClusterId && fIndex == other.fIndex;
+   }
+   bool operator!=(const RClusterIndex &other) const { return !(*this == other); }
+
    DescriptorId_t GetClusterId() const { return fClusterId; }
    ClusterSize_t::ValueType GetIndex() const { return fIndex; }
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -67,6 +67,19 @@ constexpr ColumnId_t kInvalidColumnId = -1;
 using DescriptorId_t = std::uint64_t;
 constexpr DescriptorId_t kInvalidDescriptorId = std::uint64_t(-1);
 
+/// Addresses a column element or field item relative to a particular cluster, instead of a global NTupleSize_t index
+class RClusterIndex {
+private:
+   DescriptorId_t fClusterId = kInvalidDescriptorId;
+   ClusterSize_t::ValueType fIndex = kInvalidClusterIndex;
+public:
+   RClusterIndex() = delete;
+   constexpr RClusterIndex(DescriptorId_t clusterId, ClusterSize_t::ValueType index)
+      : fClusterId(clusterId), fIndex(index) {}
+   DescriptorId_t GetClusterId() const { return fClusterId; }
+   ClusterSize_t::ValueType GetIndex() const { return fIndex; }
+};
+
 /// Every NTuple is identified by a UUID.  TODO(jblomer): should this be a TUUID?
 using RNTupleUuid = std::string;
 

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -88,9 +88,18 @@ public:
    NTupleSize_t GetRangeFirst() const { return fRangeFirst; }
    NTupleSize_t GetRangeLast() const { return fRangeFirst + NTupleSize_t(fNElements) - 1; }
    const RClusterInfo& GetClusterInfo() const { return fClusterInfo; }
-   bool Contains(NTupleSize_t index) const {
-      return (index >= fRangeFirst) && (index < fRangeFirst + NTupleSize_t(fNElements));
+
+   bool Contains(NTupleSize_t globalIndex) const {
+      return (globalIndex >= fRangeFirst) && (globalIndex < fRangeFirst + NTupleSize_t(fNElements));
    }
+
+   bool Contains(DescriptorId_t clusterId, ClusterSize_t::ValueType clusterIndex) const {
+      if (fClusterInfo.GetId() != clusterId)
+         return false;
+      auto localRangeFirst = ClusterSize_t(fRangeFirst - fClusterInfo.GetSelfOffset());
+      return (clusterIndex >= localRangeFirst) && (clusterIndex < localRangeFirst + fNElements);
+    }
+
    void* GetBuffer() const { return fBuffer; }
    /// Return a pointer after the last element that has space for nElements new elements. If there is not enough capacity,
    /// return nullptr

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -46,18 +46,14 @@ public:
    class RClusterInfo {
    private:
       /// The cluster number
-      DescriptorId_t fId;
+      DescriptorId_t fId = 0;
       /// The first element index of the column in this cluster
-      NTupleSize_t fSelfOffset;
-      /// For offset columns, also store the cluster offset of the column being referenced
-      NTupleSize_t fPointeeOffset;
+      NTupleSize_t fIndexOffset = 0;
    public:
-      RClusterInfo() : fId(0), fSelfOffset(0), fPointeeOffset(0) {}
-      RClusterInfo(NTupleSize_t id, NTupleSize_t selfOffset, NTupleSize_t pointeeOffset)
-         : fId(id), fSelfOffset(selfOffset), fPointeeOffset(pointeeOffset) {}
+      RClusterInfo() = default;
+      RClusterInfo(NTupleSize_t id, NTupleSize_t indexOffset) : fId(id), fIndexOffset(indexOffset) {}
       NTupleSize_t GetId() const { return fId; }
-      NTupleSize_t GetSelfOffset() const { return fSelfOffset; }
-      NTupleSize_t GetPointeeOffset() const { return fPointeeOffset; }
+      NTupleSize_t GetIndexOffset() const { return fIndexOffset; }
    };
 
 private:
@@ -87,7 +83,7 @@ public:
    ClusterSize_t::ValueType GetNElements() const { return fNElements; }
    NTupleSize_t GetGlobalRangeFirst() const { return fRangeFirst; }
    NTupleSize_t GetGlobalRangeLast() const { return fRangeFirst + NTupleSize_t(fNElements) - 1; }
-   ClusterSize_t::ValueType GetClusterRangeFirst() const { return fRangeFirst - fClusterInfo.GetSelfOffset(); }
+   ClusterSize_t::ValueType GetClusterRangeFirst() const { return fRangeFirst - fClusterInfo.GetIndexOffset(); }
    ClusterSize_t::ValueType GetClusterRangeLast() const {
       return GetClusterRangeFirst() + NTupleSize_t(fNElements) - 1;
    }
@@ -100,7 +96,7 @@ public:
    bool Contains(const RClusterIndex &clusterIndex) const {
       if (fClusterInfo.GetId() != clusterIndex.GetClusterId())
          return false;
-      auto clusterRangeFirst = ClusterSize_t(fRangeFirst - fClusterInfo.GetSelfOffset());
+      auto clusterRangeFirst = ClusterSize_t(fRangeFirst - fClusterInfo.GetIndexOffset());
       return (clusterIndex.GetIndex() >= clusterRangeFirst) &&
              (clusterIndex.GetIndex() < clusterRangeFirst + fNElements);
     }

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -85,19 +85,24 @@ public:
    ClusterSize_t::ValueType GetSize() const { return fElementSize * fNElements; }
    ClusterSize_t::ValueType GetElementSize() const { return fElementSize; }
    ClusterSize_t::ValueType GetNElements() const { return fNElements; }
-   NTupleSize_t GetRangeFirst() const { return fRangeFirst; }
-   NTupleSize_t GetRangeLast() const { return fRangeFirst + NTupleSize_t(fNElements) - 1; }
+   NTupleSize_t GetGlobalRangeFirst() const { return fRangeFirst; }
+   NTupleSize_t GetGlobalRangeLast() const { return fRangeFirst + NTupleSize_t(fNElements) - 1; }
+   ClusterSize_t::ValueType GetClusterRangeFirst() const { return fRangeFirst - fClusterInfo.GetSelfOffset(); }
+   ClusterSize_t::ValueType GetClusterRangeLast() const {
+      return GetClusterRangeFirst() + NTupleSize_t(fNElements) - 1;
+   }
    const RClusterInfo& GetClusterInfo() const { return fClusterInfo; }
 
    bool Contains(NTupleSize_t globalIndex) const {
       return (globalIndex >= fRangeFirst) && (globalIndex < fRangeFirst + NTupleSize_t(fNElements));
    }
 
-   bool Contains(DescriptorId_t clusterId, ClusterSize_t::ValueType clusterIndex) const {
-      if (fClusterInfo.GetId() != clusterId)
+   bool Contains(const RClusterIndex &clusterIndex) const {
+      if (fClusterInfo.GetId() != clusterIndex.GetClusterId())
          return false;
-      auto localRangeFirst = ClusterSize_t(fRangeFirst - fClusterInfo.GetSelfOffset());
-      return (clusterIndex >= localRangeFirst) && (clusterIndex < localRangeFirst + fNElements);
+      auto clusterRangeFirst = ClusterSize_t(fRangeFirst - fClusterInfo.GetSelfOffset());
+      return (clusterIndex.GetIndex() >= clusterRangeFirst) &&
+             (clusterIndex.GetIndex() < clusterRangeFirst + fNElements);
     }
 
    void* GetBuffer() const { return fBuffer; }

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -66,7 +66,7 @@ public:
    /// Tries to find the page corresponding to column and index in the cache. If the page is found, its reference
    /// counter is increased
    RPage GetPage(ColumnId_t columnId, NTupleSize_t globalIndex);
-   RPage GetPage(ColumnId_t columnId, DescriptorId_t clusterId, ClusterSize_t::ValueType clusterIndex);
+   RPage GetPage(ColumnId_t columnId, const RClusterIndex &clusterIndex);
    /// Give back a page to the pool and decrease the reference counter. There must not be any pointers anymore into
    /// this page. If the reference counter drops to zero, the page pool might decide to call the deleter given in
    /// during registration.

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -65,7 +65,8 @@ public:
    void RegisterPage(const RPage &page, const RPageDeleter &deleter);
    /// Tries to find the page corresponding to column and index in the cache. If the page is found, its reference
    /// counter is increased
-   RPage GetPage(ColumnId_t columnId, NTupleSize_t index);
+   RPage GetPage(ColumnId_t columnId, NTupleSize_t globalIndex);
+   RPage GetPage(ColumnId_t columnId, DescriptorId_t clusterId, ClusterSize_t::ValueType clusterIndex);
    /// Give back a page to the pool and decrease the reference counter. There must not be any pointers anymore into
    /// this page. If the reference counter drops to zero, the page pool might decide to call the deleter given in
    /// during registration.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -141,7 +141,10 @@ public:
    virtual const RNTupleDescriptor& GetDescriptor() const = 0;
 
    /// Allocates and fills a page that contains the index-th element
-   virtual RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t index) = 0;
+   virtual RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) = 0;
+   /// Another version of PopulatePage that allows to specify cluster-relative indexes
+   virtual RPage PopulatePage(ColumnHandle_t columnHandle, DescriptorId_t clusterId,
+                              ClusterSize_t::ValueType clusterIndex) = 0;
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -143,8 +143,7 @@ public:
    /// Allocates and fills a page that contains the index-th element
    virtual RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) = 0;
    /// Another version of PopulatePage that allows to specify cluster-relative indexes
-   virtual RPage PopulatePage(ColumnHandle_t columnHandle, DescriptorId_t clusterId,
-                              ClusterSize_t::ValueType clusterIndex) = 0;
+   virtual RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) = 0;
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -159,8 +159,7 @@ public:
    const RNTupleDescriptor& GetDescriptor() const final { return fDescriptor; }
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
-   RPage PopulatePage(ColumnHandle_t columnHandle, DescriptorId_t clusterId,
-                      ClusterSize_t::ValueType clusterIndex) final;
+   RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
    void ReleasePage(RPage &page) final;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -143,6 +143,9 @@ private:
 
    RNTupleDescriptor fDescriptor;
 
+   RPage DoPopulatePage(ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor,
+                        ClusterSize_t::ValueType clusterIndex);
+
 public:
    RPageSourceRoot(std::string_view ntupleName, RSettings settings);
    RPageSourceRoot(std::string_view ntupleName, std::string_view path);
@@ -155,7 +158,9 @@ public:
    ColumnId_t GetColumnId(ColumnHandle_t columnHandle) final;
    const RNTupleDescriptor& GetDescriptor() const final { return fDescriptor; }
 
-   RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t index) final;
+   RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
+   RPage PopulatePage(ColumnHandle_t columnHandle, DescriptorId_t clusterId,
+                      ClusterSize_t::ValueType clusterIndex) final;
    void ReleasePage(RPage &page) final;
 };
 

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -69,3 +69,9 @@ void ROOT::Experimental::Detail::RColumn::MapPage(const NTupleSize_t index)
    fPageSource->ReleasePage(fCurrentPage);
    fCurrentPage = fPageSource->PopulatePage(fHandleSource, index);
 }
+
+void ROOT::Experimental::Detail::RColumn::MapPage(const RClusterIndex &clusterIndex)
+{
+   fPageSource->ReleasePage(fCurrentPage);
+   fCurrentPage = fPageSource->PopulatePage(fHandleSource, clusterIndex);
+}

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -24,8 +24,7 @@
 ROOT::Experimental::Detail::RColumn::RColumn(const RColumnModel& model, std::uint32_t index)
    : fModel(model), fIndex(index), fPageSink(nullptr), fPageSource(nullptr), fHeadPage(), fNElements(0),
      fCurrentPage(),
-     fColumnIdSource(kInvalidColumnId),
-     fOffsetColumn(nullptr)
+     fColumnIdSource(kInvalidColumnId)
 {
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -335,12 +335,12 @@ void ROOT::Experimental::RField<std::string>::DoReadGlobal(
    ROOT::Experimental::NTupleSize_t globalIndex, ROOT::Experimental::Detail::RFieldValue *value)
 {
    auto typedValue = value->Get<std::string>();
-   NTupleSize_t idxStart;
+   RClusterIndex collectionStart;
    ClusterSize_t nChars;
-   fPrincipalColumn->GetCollectionInfo(globalIndex, &idxStart, &nChars);
+   fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nChars);
    typedValue->resize(nChars);
    Detail::RColumnElement<char, EColumnType::kByte> elemChars(const_cast<char*>(typedValue->data()));
-   fColumns[1]->ReadV(idxStart, nChars, &elemChars);
+   fColumns[1]->ReadV(collectionStart, nChars, &elemChars);
 }
 
 void ROOT::Experimental::RField<std::string>::CommitCluster()
@@ -468,13 +468,13 @@ void ROOT::Experimental::RFieldVector::DoReadGlobal(NTupleSize_t globalIndex, De
    auto typedValue = value->Get<std::vector<char>>();
 
    ClusterSize_t nItems;
-   NTupleSize_t idxStart;
-   fPrincipalColumn->GetCollectionInfo(globalIndex, &idxStart, &nItems);
+   RClusterIndex collectionStart;
+   fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
 
    typedValue->resize(nItems * fItemSize);
    for (unsigned i = 0; i < nItems; ++i) {
       auto itemValue = fSubFields[0]->GenerateValue(typedValue->data() + (i * fItemSize));
-      fSubFields[0]->Read(idxStart + i, &itemValue);
+      fSubFields[0]->Read(collectionStart + i, &itemValue);
    }
 }
 
@@ -550,14 +550,14 @@ void ROOT::Experimental::RField<std::vector<bool>>::DoReadGlobal(NTupleSize_t gl
    auto typedValue = value->Get<std::vector<bool>>();
 
    ClusterSize_t nItems;
-   NTupleSize_t idxStart;
-   fPrincipalColumn->GetCollectionInfo(globalIndex, &idxStart, &nItems);
+   RClusterIndex collectionStart;
+   fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
 
    typedValue->resize(nItems);
    for (unsigned i = 0; i < nItems; ++i) {
       bool bval;
       auto itemValue = fSubFields[0]->GenerateValue(&bval);
-      fSubFields[0]->Read(idxStart + i, &itemValue);
+      fSubFields[0]->Read(collectionStart + i, &itemValue);
       (*typedValue)[i] = bval;
    }
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -38,11 +38,8 @@ void ROOT::Experimental::Detail::RFieldFuse::Connect(DescriptorId_t fieldId, RPa
 {
    if (field.fColumns.empty())
       field.DoGenerateColumns();
-   for (auto& column : field.fColumns) {
-      if ((field.fParent != nullptr) && (column->GetOffsetColumn() == nullptr))
-         column->SetOffsetColumn(field.fParent->fPrincipalColumn);
+   for (auto& column : field.fColumns)
       column->Connect(fieldId, &pageStorage);
-   }
 }
 
 
@@ -318,7 +315,6 @@ void ROOT::Experimental::RField<std::string>::DoGenerateColumns()
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<char, EColumnType::kByte>(modelChars, 1)));
    fPrincipalColumn = fColumns[0].get();
-   fColumns[1]->SetOffsetColumn(fPrincipalColumn);
 }
 
 void ROOT::Experimental::RField<std::string>::DoAppend(const ROOT::Experimental::Detail::RFieldValue& value)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -119,14 +119,6 @@ void ROOT::Experimental::Detail::RFieldBase::DoRead(
    R__ASSERT(false);
 }
 
-void ROOT::Experimental::Detail::RFieldBase::DoReadV(
-   ROOT::Experimental::NTupleSize_t /*index*/,
-   ROOT::Experimental::NTupleSize_t /*count*/,
-   void* /*dst*/)
-{
-   R__ASSERT(false);
-}
-
 ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::Detail::RFieldBase::GenerateValue()
 {
    void *where = malloc(GetValueSize());

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -50,13 +50,27 @@ void ROOT::Experimental::Detail::RPagePool::ReturnPage(const RPage& page)
 }
 
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
-   ColumnId_t columnId, NTupleSize_t index)
+   ColumnId_t columnId, NTupleSize_t globalIndex)
 {
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
       if (fReferences[i] == 0) continue;
       if (fPages[i].GetColumnId() != columnId) continue;
-      if (!fPages[i].Contains(index)) continue;
+      if (!fPages[i].Contains(globalIndex)) continue;
+      fReferences[i]++;
+      return fPages[i];
+   }
+   return RPage();
+}
+
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
+   ColumnId_t columnId, DescriptorId_t clusterId, ClusterSize_t::ValueType clusterIndex)
+{
+   unsigned int N = fPages.size();
+   for (unsigned int i = 0; i < N; ++i) {
+      if (fReferences[i] == 0) continue;
+      if (fPages[i].GetColumnId() != columnId) continue;
+      if (!fPages[i].Contains(clusterId, clusterIndex)) continue;
       fReferences[i]++;
       return fPages[i];
    }

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -64,13 +64,13 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage
 }
 
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
-   ColumnId_t columnId, DescriptorId_t clusterId, ClusterSize_t::ValueType clusterIndex)
+   ColumnId_t columnId, const RClusterIndex &clusterIndex)
 {
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
       if (fReferences[i] == 0) continue;
       if (fPages[i].GetColumnId() != columnId) continue;
-      if (!fPages[i].Contains(clusterId, clusterIndex)) continue;
+      if (!fPages[i].Contains(clusterIndex)) continue;
       fReferences[i]++;
       return fPages[i];
    }

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -90,7 +90,7 @@ void ROOT::Experimental::Detail::RPageSinkRoot::Create(RNTupleModel &model)
    std::unordered_map<const RFieldBase *, DescriptorId_t> fieldPtr2Id; // necessary to find parent field ids
    for (auto& f : *model.GetRootField()) {
       fDescriptorBuilder.AddField(fLastFieldId, f.GetFieldVersion(), f.GetTypeVersion(), f.GetName(), f.GetType(),
-                                  0 /* TODO(jblomer) */, f.GetStructure());
+                                  f.GetNRepetitions(), f.GetStructure());
       if (f.GetParent() != model.GetRootField()) {
          fDescriptorBuilder.AddFieldLink(fieldPtr2Id[f.GetParent()], fLastFieldId);
       }

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -372,16 +372,18 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceRoot::P
 
 
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceRoot::PopulatePage(
-   ColumnHandle_t columnHandle, DescriptorId_t clusterId, ClusterSize_t::ValueType clusterIndex)
+   ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex)
 {
+   auto clusterId = clusterIndex.GetClusterId();
+   auto index = clusterIndex.GetIndex();
    auto columnId = columnHandle.fId;
-   auto cachedPage = fPagePool->GetPage(columnId, clusterId, clusterIndex);
+   auto cachedPage = fPagePool->GetPage(columnId, clusterIndex);
    if (!cachedPage.IsNull())
       return cachedPage;
 
    R__ASSERT(clusterId != kInvalidDescriptorId);
    auto clusterDescriptor = fDescriptor.GetClusterDescriptor(clusterId);
-   return DoPopulatePage(columnHandle, clusterDescriptor, clusterIndex);
+   return DoPopulatePage(columnHandle, clusterDescriptor, index);
 }
 
 void ROOT::Experimental::Detail::RPageSourceRoot::ReleasePage(RPage &page)

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -16,6 +16,7 @@
 
 #include "CustomStruct.hxx"
 
+#include <array>
 #include <exception>
 #include <memory>
 #include <string>
@@ -73,6 +74,7 @@ TEST(RNTuple, ReconstructModel)
    auto fieldPt = model->MakeField<float>("pt", 42.0);
    auto fieldNnlo = model->MakeField<std::vector<std::vector<float>>>("nnlo");
    auto fieldKlass = model->MakeField<CustomStruct>("klass");
+   auto fieldArray = model->MakeField<std::array<double, 2>>("array");
    {
       RPageSinkRoot sinkRoot("myTree", "test.root");
       sinkRoot.Create(*model.get());
@@ -89,6 +91,8 @@ TEST(RNTuple, ReconstructModel)
    EXPECT_TRUE(vecPtr != nullptr);
    // Don't crash
    vecPtr->push_back(std::vector<float>{1.0});
+   auto array = modelReconstructed->GetDefaultEntry()->Get<std::array<double, 2>>("array");
+   EXPECT_TRUE(array != nullptr);
 }
 
 TEST(RNTuple, StorageRoot)
@@ -278,9 +282,14 @@ TEST(RNTuple, Clusters)
    auto wrPt = modelWrite->MakeField<float>("pt", 42.0);
    auto wrTag = modelWrite->MakeField<std::string>("tag", "xyz");
    auto wrNnlo = modelWrite->MakeField<std::vector<std::vector<float>>>("nnlo");
+   auto wrFourVec = modelWrite->MakeField<std::array<float, 4>>("fourVec");
    wrNnlo->push_back(std::vector<float>());
    wrNnlo->push_back(std::vector<float>{1.0});
    wrNnlo->push_back(std::vector<float>{1.0, 2.0, 4.0, 8.0});
+   wrFourVec->at(0) = 0.0;
+   wrFourVec->at(1) = 1.0;
+   wrFourVec->at(2) = 2.0;
+   wrFourVec->at(3) = 3.0;
 
    auto modelRead = std::unique_ptr<RNTupleModel>(modelWrite->Clone());
 
@@ -291,16 +300,19 @@ TEST(RNTuple, Clusters)
       *wrPt = 24.0;
       wrNnlo->clear();
       *wrTag = "";
+      wrFourVec->at(2) = 42.0;
       ntuple.Fill();
       *wrPt = 12.0;
       wrNnlo->push_back(std::vector<float>{42.0});
       *wrTag = "12345";
+      wrFourVec->at(1) = 24.0;
       ntuple.Fill();
    }
 
    auto rdPt = modelRead->Get<float>("pt");
    auto rdTag = modelRead->Get<std::string>("tag");
    auto rdNnlo = modelRead->Get<std::vector<std::vector<float>>>("nnlo");
+   auto rdFourVec = modelRead->Get<std::array<float, 4>>("fourVec");
 
    RNTupleReader ntuple(std::move(modelRead), std::make_unique<RPageSourceRoot>("f", "test.root"));
    EXPECT_EQ(3U, ntuple.GetNEntries());
@@ -317,11 +329,16 @@ TEST(RNTuple, Clusters)
    EXPECT_EQ(2.0, (*rdNnlo)[2][1]);
    EXPECT_EQ(4.0, (*rdNnlo)[2][2]);
    EXPECT_EQ(8.0, (*rdNnlo)[2][3]);
+   EXPECT_EQ(0.0, (*rdFourVec)[0]);
+   EXPECT_EQ(1.0, (*rdFourVec)[1]);
+   EXPECT_EQ(2.0, (*rdFourVec)[2]);
+   EXPECT_EQ(3.0, (*rdFourVec)[3]);
 
    ntuple.LoadEntry(1);
    EXPECT_EQ(24.0, *rdPt);
    EXPECT_STREQ("", rdTag->c_str());
    EXPECT_TRUE(rdNnlo->empty());
+   EXPECT_EQ(42.0, (*rdFourVec)[2]);
 
    ntuple.LoadEntry(2);
    EXPECT_EQ(12.0, *rdPt);
@@ -329,6 +346,7 @@ TEST(RNTuple, Clusters)
    EXPECT_EQ(1U, rdNnlo->size());
    EXPECT_EQ(1U, (*rdNnlo)[0].size());
    EXPECT_EQ(42.0, (*rdNnlo)[0][0]);
+   EXPECT_EQ(24.0, (*rdFourVec)[1]);
 }
 
 

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -573,7 +573,7 @@ TEST(RNTuple, Descriptor)
                         0, ENTupleStructure::kCollection);
    descBuilder.AddField(2, RNTupleVersion(), RNTupleVersion(), "list", "std::int32_t", 0, ENTupleStructure::kLeaf);
    descBuilder.AddField(42, RNTupleVersion(), RNTupleVersion(), "x", "std::string", 0, ENTupleStructure::kLeaf);
-   descBuilder.SetFieldParent(2, 1);
+   descBuilder.AddFieldLink(1, 2);
    descBuilder.AddColumn(3, 42, RNTupleVersion(), RColumnModel(EColumnType::kIndex, true), 0);
    descBuilder.AddColumn(4, 42, RNTupleVersion(), RColumnModel(EColumnType::kByte, true), 1);
 

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -28,7 +28,7 @@ TEST(Pages, Pool)
    EXPECT_TRUE(page.IsNull());
    pool.ReturnPage(page); // should not crash
 
-   RPage::RClusterInfo clusterInfo(2, 40, 0);
+   RPage::RClusterInfo clusterInfo(2, 40);
    page = RPage(1, &page, 10, 1);
    EXPECT_NE(nullptr, page.TryGrow(10));
    page.SetWindow(50, clusterInfo);

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -28,7 +28,7 @@ TEST(Pages, Pool)
    EXPECT_TRUE(page.IsNull());
    pool.ReturnPage(page); // should not crash
 
-   RPage::RClusterInfo clusterInfo;
+   RPage::RClusterInfo clusterInfo(2, 40, 0);
    page = RPage(1, &page, 10, 1);
    EXPECT_NE(nullptr, page.TryGrow(10));
    page.SetWindow(50, clusterInfo);
@@ -44,9 +44,18 @@ TEST(Pages, Pool)
    EXPECT_TRUE(page.IsNull());
    page = pool.GetPage(1, 55);
    EXPECT_FALSE(page.IsNull());
-   EXPECT_EQ(50U, page.GetRangeFirst());
-   EXPECT_EQ(59U, page.GetRangeLast());
+   EXPECT_EQ(50U, page.GetGlobalRangeFirst());
+   EXPECT_EQ(59U, page.GetGlobalRangeLast());
+   EXPECT_EQ(10U, page.GetClusterRangeFirst());
+   EXPECT_EQ(19U, page.GetClusterRangeLast());
 
+   page = pool.GetPage(1, ROOT::Experimental::RClusterIndex(0, 15));
+   EXPECT_TRUE(page.IsNull());
+   page = pool.GetPage(1, ROOT::Experimental::RClusterIndex(2, 15));
+   EXPECT_FALSE(page.IsNull());
+
+   pool.ReturnPage(page);
+   EXPECT_EQ(0U, nCallDeleter);
    pool.ReturnPage(page);
    EXPECT_EQ(0U, nCallDeleter);
    pool.ReturnPage(page);


### PR DESCRIPTION
Fixed-size arrays are stored without an explicit offset column. Instead, the array length is stored as part of the field description.

This PR also brings infrastructure work towards `std::variant` support. Variant fields will eventually store references to multiple sub fields (unlike vectors, which only reference a single sub field). To make that work, the methods related to reading data now understand a cluster-relative addressing mode.  This way, we don't need to store the pointee offset of linked fields anywhere but we can directly read referenced fields in the same cluster.