### PR TITLE
[PyROOT] 6.18 Backport: Set correct type for enum values in namespaces

### DIFF
--- a/bindings/pyroot/src/PropertyProxy.cxx
+++ b/bindings/pyroot/src/PropertyProxy.cxx
@@ -216,11 +216,14 @@ void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t id
 
 void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, const std::string& name, void* address )
 {
+   Cppyy::TCppIndex_t idata = Cppyy::GetDatamemberIndex(scope, name);
+   std::string cppType = Cppyy::ResolveEnum(Cppyy::GetDatamemberType(scope, idata));
+
    fEnclosingScope = scope;
    fName           = name;
    fOffset         = (ptrdiff_t)address;
    fProperty       = (kIsStaticData | kIsConstData | kIsEnumData /* true, but may chance */ );
-   fConverter      = CreateConverter( "UInt_t", -1 );
+   fConverter      = CreateConverter( cppType, -1 );
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As reported by ROOT-8935, when an enum is in a namespace and the
values of the enum are accessed via the namespace, the underlying
type of the enum is not taken into account.

With this fix, we check the underlying type of the enum in
PropertyProxy::Set before creating the converter.