### PR TITLE
[RDF] Do not let Snapshot'ed TTrees spawn nested TBB tasks (v6.18)

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1299,6 +1299,8 @@ public:
       // TODO we could instead create the output tree and its branches, change addresses of input variables in each task
       fOutputTrees[slot] =
          std::make_unique<TTree>(fTreeName.c_str(), fTreeName.c_str(), fOptions.fSplitLevel, /*dir=*/treeDirectory);
+      // TODO can be removed when RDF supports interleaved TBB task execution properly, see ROOT-10269
+      fOutputTrees[slot]->SetImplicitMT(false);
       if (fOptions.fAutoFlush)
          fOutputTrees[slot]->SetAutoFlush(fOptions.fAutoFlush);
       if (r) {


### PR DESCRIPTION
This mitigates ROOT-10269 by avoiding nested task execution due
to a parallel Snapshot.