### PR TITLE
ROOT-10254: FoldFileOutput breaks output log

### DIFF
--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -410,6 +410,7 @@ void TMVA::CrossValidation::ParseOptions()
    fOutputFactoryOptions += Form("AnalysisType=%s:", fAnalysisTypeStr.Data());
 
    if (not fDrawProgressBar) {
+      fCvFactoryOptions += "!DrawProgressBar:";
       fOutputFactoryOptions += "!DrawProgressBar:";
    }
 
@@ -419,27 +420,25 @@ void TMVA::CrossValidation::ParseOptions()
    }
 
    if (fCorrelations) {
-      // fCvFactoryOptions += "Correlations:";
+      fCvFactoryOptions += "Correlations:";
       fOutputFactoryOptions += "Correlations:";
    } else {
-      // fCvFactoryOptions += "!Correlations:";
+      fCvFactoryOptions += "!Correlations:";
       fOutputFactoryOptions += "!Correlations:";
    }
 
    if (fROC) {
-      // fCvFactoryOptions += "ROC:";
+      fCvFactoryOptions += "ROC:";
       fOutputFactoryOptions += "ROC:";
    } else {
-      // fCvFactoryOptions += "!ROC:";
+      fCvFactoryOptions += "!ROC:";
       fOutputFactoryOptions += "!ROC:";
    }
 
    if (fSilent) {
-      // fCvFactoryOptions += Form("Silent:");
+      fCvFactoryOptions += Form("Silent:");
       fOutputFactoryOptions += Form("Silent:");
    }
-
-   fCvFactoryOptions += "!Correlations:!ROC:!Color:!DrawProgressBar";
 
    // CE specific options
    if (fFoldFileOutput and fOutputFile == nullptr) {

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -439,7 +439,7 @@ void TMVA::CrossValidation::ParseOptions()
       fOutputFactoryOptions += Form("Silent:");
    }
 
-   fCvFactoryOptions += "!Correlations:!ROC:!Color:!DrawProgressBar:Silent";
+   fCvFactoryOptions += "!Correlations:!ROC:!Color:!DrawProgressBar";
 
    // CE specific options
    if (fFoldFileOutput and fOutputFile == nullptr) {

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -516,8 +516,8 @@ TMVA::CrossValidationFoldResult TMVA::CrossValidation::ProcessFold(UInt_t iFold,
 
    if (fFoldFileOutput and fOutputFile != nullptr) {
       TString path = std::string("") + gSystem->DirName(fOutputFile->GetName()) + "/" + foldTitle + ".root";
-      std::cout << "PATH: " << path << std::endl;
       foldOutputFile = TFile::Open(path, "RECREATE");
+      Log() << kINFO << "Creating fold output at:" << path << Endl;
       fFoldFactory = std::make_unique<TMVA::Factory>(fJobName, foldOutputFile, fCvFactoryOptions);
    }
 
@@ -603,7 +603,12 @@ void TMVA::CrossValidation::Evaluate()
       }
 
       TMVA::MsgLogger::EnableOutput();
-      Log() << kINFO << "Evaluate method: " << methodTitle << Endl;
+      Log() << kINFO << Endl;
+      Log() << kINFO << Endl;
+      Log() << kINFO << "========================================" << Endl;
+      Log() << kINFO << "Processing folds for method " << methodTitle << Endl;
+      Log() << kINFO << "========================================" << Endl;
+      Log() << kINFO << Endl;
 
       // Process K folds
       auto nWorkers = fNumWorkerProcs;
@@ -650,6 +655,13 @@ void TMVA::CrossValidation::Evaluate()
 
       method->fEventToFoldMapping = fSplit->fEventToFoldMapping;
    }
+
+   Log() << kINFO << Endl;
+   Log() << kINFO << Endl;
+   Log() << kINFO << "========================================" << Endl;
+   Log() << kINFO << "Folds processed for all methods, evaluating." << Endl;
+   Log() << kINFO << "========================================" << Endl;
+   Log() << kINFO << Endl;
 
    // Recombination of data (making sure there is data in training and testing trees).
    fDataLoader->RecombineKFoldDataSet(*fSplit);


### PR DESCRIPTION
Problem: When creating the separate factory for per-fold output, the silent flag was given. This suppresses all TMVA logging output (touches global state).

Solution: The silent flag is not passed to the per-fold factory automatically anymore.