### PR TITLE
[rootcling] Deprecate flags with no effects.

### DIFF
--- a/README/ReleaseNotes/v620/index.md
+++ b/README/ReleaseNotes/v620/index.md
@@ -49,6 +49,10 @@ The following people have contributed to this new version:
  Stefan Wunsch, CERN/SFT
 
 ## Deprecation and Removal
+ * rootcling flags `-cint`, `-reflex` and `-gccxml` have no effect and will be
+   removed. Please remove them from the rootcling invocations.
+ * genreflex flag `--deep` has no effect and will be removed. Please remove it
+   from the genreflex invocation.
 
 ### Deprecated packages
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3796,13 +3796,13 @@ int RootClingMain(int argc,
    }
    if (ic < argc) {
       if (!strcmp(argv[ic], "-cint")) {
-         // Flag is ignored, should warn of deprecation.
+         ROOT::TMetaUtils::Warning(0, "-cint has no effect. Please remove the deprecated flag!\n");
          ic++;
       } else if (!strcmp(argv[ic], "-reflex")) {
-         // Flag is ignored, should warn of deprecation.
+         ROOT::TMetaUtils::Warning(0, "-reflex has no effect. Please remove the deprecated flag!\n");
          ic++;
       } else if (!strcmp(argv[ic], "-gccxml")) {
-         // Flag is ignored, should warn of deprecation.
+         ROOT::TMetaUtils::Warning(0, "-gccxml has no effect. Please remove the deprecated flag!\n");
          ic++;
       }
    }
@@ -5847,6 +5847,8 @@ int GenReflexMain(int argc, char **argv)
 
    ROOT::TMetaUtils::GetErrorIgnoreLevel() = ROOT::TMetaUtils::kNote;
 
+   if (options[DEEP])
+      ROOT::TMetaUtils::Warning(0, "--deep has no effect. Please remove the deprecated flag!\n");
    // The verbosity: debug wins over quiet
    //std::string verbosityOption("-v4"); // To be uncommented for the testing phase. It should be -v
    std::string verbosityOption("-v2");


### PR DESCRIPTION
They should not be present in the rootcling/genreflex invocation.