### PR TITLE
[ntuple] Add support for std::variant

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -216,6 +216,13 @@ public:
       *collectionStart = RClusterIndex(clusterIndex.GetClusterId(), idxStart);
    }
 
+   /// Get the currently active cluster id
+   void GetSwitchInfo(NTupleSize_t globalIndex, RClusterIndex *varIndex, std::uint32_t *tag) {
+      auto varSwitch = Map<RColumnSwitch, EColumnType::kSwitch>(globalIndex);
+      *varIndex = RClusterIndex(fCurrentPage.GetClusterInfo().GetId(), varSwitch->GetIndex());
+      *tag = varSwitch->GetTag();
+   }
+
    void Flush();
    void MapPage(const NTupleSize_t index);
    void MapPage(const RClusterIndex &clusterIndex);

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -191,6 +191,17 @@ public:
 };
 
 template <>
+class RColumnElement<RColumnSwitch, EColumnType::kSwitch> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = true;
+   static constexpr std::size_t kSize = sizeof(ROOT::Experimental::RColumnSwitch);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(RColumnSwitch *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
 class RColumnElement<char, EColumnType::kByte> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -36,6 +36,9 @@ enum class EColumnType {
    kUnknown = 0,
    // type for root columns of (nested) collections; 32bit integers that count relative to the current cluster
    kIndex,
+   // 64 bit column that uses the lower 32bits as kIndex and the higher 32bits as a dispatch tag; used, e.g.,
+   // in order to serialize std::variant
+   kSwitch,
    kByte,
    kBit,
    kReal64,
@@ -45,7 +48,6 @@ enum class EColumnType {
    kInt64,
    kInt32,
    kInt16,
-   //...
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -21,6 +21,7 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RNTupleUtil.hxx>
+#include <ROOT/RSpan.hxx>
 #include <ROOT/RStringView.hxx>
 #include <ROOT/RVec.hxx>
 #include <ROOT/TypeTraits.hxx>
@@ -36,6 +37,9 @@
 #include <string>
 #include <type_traits>
 #include <typeinfo>
+#if __cplusplus >= 201703L
+#include <variant>
+#endif
 #include <vector>
 #include <utility>
 
@@ -194,6 +198,8 @@ public:
    virtual RFieldValue CaptureValue(void *where) = 0;
    /// The number of bytes taken by a value of the appropriate type
    virtual size_t GetValueSize() const = 0;
+   /// For many types, the alignment requirement is equal to the size; otherwise override.
+   virtual size_t GetAlignment() const { return GetValueSize(); }
 
    /// Write the given value into columns. The value object has to be of the same type as the field.
    void Append(const RFieldValue& value) {
@@ -254,7 +260,7 @@ public:
    }
    void SetOrder(int o) { fOrder = o; }
 };
-   
+
 // clang-format off
 /**
 \class ROOT::Experimental::RFieldFuse
@@ -271,7 +277,7 @@ public:
 };
 
 } // namespace Detail
-   
+
 
 
 /// The container field for an ntuple model, which itself has no physical representation
@@ -312,6 +318,7 @@ public:
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
    Detail::RFieldValue CaptureValue(void *where) final;
    size_t GetValueSize() const override;
+   size_t GetAlignment() const final { return 1; /* TODO(jblomer) */ }
 };
 
 /// The generic field for a (nested) std::vector<Type> except for std::vector<bool>
@@ -336,7 +343,8 @@ public:
    Detail::RFieldValue GenerateValue(void* where) override;
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
    Detail::RFieldValue CaptureValue(void *where) override;
-   size_t GetValueSize() const override;
+   size_t GetValueSize() const override { return sizeof(std::vector<char>); }
+   size_t GetAlignment() const final { return std::alignment_of<std::vector<char>>(); }
    void CommitCluster() final;
 };
 
@@ -365,7 +373,46 @@ public:
    void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
    Detail::RFieldValue CaptureValue(void *where) final;
    size_t GetValueSize() const final { return fItemSize * fArrayLength; }
+   size_t GetAlignment() const final { return fSubFields[0]->GetAlignment(); }
 };
+
+#if __cplusplus >= 201703L
+/// The generic field for std::variant types
+class RFieldVariant : public Detail::RFieldBase {
+private:
+   size_t fMaxItemSize = 0;
+   size_t fMaxAlignment = 1;
+   /// In the std::variant memory layout, at which byte number is the index stored
+   size_t fTagOffset = 0;
+   std::vector<ClusterSize_t::ValueType> fNWritten;
+
+   static std::string GetTypeList(Detail::RFieldBase *itemFields, std::size_t nFields);
+   /// Extracts the index from an std::variant and transforms it into the 1-based index used for the switch column
+   std::uint32_t GetTag(void *variantPtr) const;
+   void SetTag(void *variantPtr, std::uint32_t tag) const;
+
+protected:
+   void DoAppend(const Detail::RFieldValue& value) final;
+   void DoReadGlobal(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
+
+public:
+   // TODO(jblomer): use std::span in signature
+   RFieldVariant(std::string_view fieldName, Detail::RFieldBase *itemFields, std::size_t nFields);
+   RFieldVariant(RFieldVariant &&other) = default;
+   RFieldVariant& operator =(RFieldVariant &&other) = default;
+   ~RFieldVariant() = default;
+   RFieldBase *Clone(std::string_view newName) final;
+
+   void DoGenerateColumns() final;
+   using Detail::RFieldBase::GenerateValue;
+   Detail::RFieldValue GenerateValue(void *where) override;
+   void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
+   Detail::RFieldValue CaptureValue(void *where) final;
+   size_t GetValueSize() const final;
+   size_t GetAlignment() const final { return 1; /* TODO(jblomer) */}
+   void CommitCluster() final;
+};
+#endif
 
 
 /// Classes with dictionaries that can be inspected by TClass
@@ -726,6 +773,7 @@ public:
       return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::string); }
+   size_t GetAlignment() const final { return std::alignment_of<std::string>(); }
    void CommitCluster() final;
 };
 
@@ -755,6 +803,31 @@ public:
    }
 };
 
+
+#if __cplusplus >= 201703L
+template <typename ItemT>
+class RField<std::variant<ItemT>> : public RFieldVariant {
+   using ContainerT = typename std::variant<ItemT>;
+public:
+   static std::string MyTypeName() { return "std::variant<" + RField<ItemT>::MyTypeName() + ">"; }
+   explicit RField(std::string_view name)
+      : RFieldVariant(name, new RField<ItemT>("1"), 1)
+   {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(this, static_cast<ContainerT*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final {
+      return GenerateValue(where, ContainerT());
+   }
+};
+#endif
 
 template <typename ItemT>
 class RField<std::vector<ItemT>> : public RFieldVector {
@@ -817,6 +890,7 @@ public:
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
 
    size_t GetValueSize() const final { return sizeof(std::vector<bool>); }
+   size_t GetAlignment() const final { return std::alignment_of<std::vector<bool>>(); }
    void CommitCluster() final { fNWritten = 0; }
 };
 
@@ -910,6 +984,7 @@ public:
       return Detail::RFieldValue(true /* captureFlag */, this, static_cast<ContainerT*>(where));
    }
    size_t GetValueSize() const final { return sizeof(ContainerT); }
+   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 /**
@@ -990,6 +1065,7 @@ public:
       return Detail::RFieldValue(true /* captureFlag */, this, static_cast<ContainerT*>(where));
    }
    size_t GetValueSize() const final { return sizeof(ContainerT); }
+   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -386,7 +386,7 @@ private:
    size_t fTagOffset = 0;
    std::vector<ClusterSize_t::ValueType> fNWritten;
 
-   static std::string GetTypeList(Detail::RFieldBase *itemFields, std::size_t nFields);
+   static std::string GetTypeList(const std::vector<Detail::RFieldBase *> &itemFields);
    /// Extracts the index from an std::variant and transforms it into the 1-based index used for the switch column
    std::uint32_t GetTag(void *variantPtr) const;
    void SetTag(void *variantPtr, std::uint32_t tag) const;
@@ -397,7 +397,7 @@ protected:
 
 public:
    // TODO(jblomer): use std::span in signature
-   RFieldVariant(std::string_view fieldName, Detail::RFieldBase *itemFields, std::size_t nFields);
+   RFieldVariant(std::string_view fieldName, const std::vector<Detail::RFieldBase *> &itemFields);
    RFieldVariant(RFieldVariant &&other) = default;
    RFieldVariant& operator =(RFieldVariant &&other) = default;
    ~RFieldVariant() = default;
@@ -805,14 +805,34 @@ public:
 
 
 #if __cplusplus >= 201703L
-template <typename ItemT>
-class RField<std::variant<ItemT>> : public RFieldVariant {
-   using ContainerT = typename std::variant<ItemT>;
+template <typename... ItemTs>
+class RField<std::variant<ItemTs...>> : public RFieldVariant {
+   using ContainerT = typename std::variant<ItemTs...>;
+private:
+   template <typename HeadT, typename... TailTs>
+   static std::string BuildItemTypes()
+   {
+      std::string result = RField<HeadT>::MyTypeName();
+      if constexpr(sizeof...(TailTs) > 0)
+         result += "," + BuildItemTypes<TailTs...>();
+      return result;
+   }
+
+   template <typename HeadT, typename... TailTs>
+   static std::vector<Detail::RFieldBase *> BuildItemFields(unsigned int index = 0)
+   {
+      std::vector<Detail::RFieldBase *> result;
+      result.emplace_back(new RField<HeadT>("variant" + std::to_string(index)));
+      if constexpr(sizeof...(TailTs) > 0) {
+         auto tailFields = BuildItemFields<TailTs...>(index + 1);
+         result.insert(result.end(), tailFields.begin(), tailFields.end());
+      }
+      return result;
+   }
+
 public:
-   static std::string MyTypeName() { return "std::variant<" + RField<ItemT>::MyTypeName() + ">"; }
-   explicit RField(std::string_view name)
-      : RFieldVariant(name, new RField<ItemT>("1"), 1)
-   {}
+   static std::string MyTypeName() { return "std::variant<" + BuildItemTypes<ItemTs...>() + ">"; }
+   explicit RField(std::string_view name) : RFieldVariant(name, BuildItemFields<ItemTs...>()) {}
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -301,6 +301,8 @@ public:
 class RFieldClass : public Detail::RFieldBase {
 private:
    TClass* fClass;
+   std::size_t fMaxAlignment = 1;
+
 protected:
    void DoAppend(const Detail::RFieldValue& value) final;
    void DoReadGlobal(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
@@ -318,7 +320,7 @@ public:
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
    Detail::RFieldValue CaptureValue(void *where) final;
    size_t GetValueSize() const override;
-   size_t GetAlignment() const final { return 1; /* TODO(jblomer) */ }
+   size_t GetAlignment() const final { return fMaxAlignment; }
 };
 
 /// The generic field for a (nested) std::vector<Type> except for std::vector<bool>
@@ -409,7 +411,7 @@ public:
    void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
    Detail::RFieldValue CaptureValue(void *where) final;
    size_t GetValueSize() const final;
-   size_t GetAlignment() const final { return 1; /* TODO(jblomer) */}
+   size_t GetAlignment() const final { return fMaxAlignment; }
    void CommitCluster() final;
 };
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -34,10 +34,9 @@ enum ENTupleStructure {
   kLeaf,
   kCollection,
   kRecord,
+  kVariant,
   // unimplemented so far
   kReference,
-  kOptional,
-  kVariant,
 };
 
 /// Integer type long enough to hold the maximum number of entries in a column
@@ -58,6 +57,19 @@ struct RClusterSize {
 };
 using ClusterSize_t = RClusterSize;
 constexpr ClusterSize_t kInvalidClusterIndex(std::uint32_t(-1));
+
+/// Holds the index and the tag of a kSwitch column
+class RColumnSwitch {
+private:
+   ClusterSize_t fIndex;
+   std::uint32_t fTag = 0;
+
+public:
+   RColumnSwitch() = default;
+   RColumnSwitch(ClusterSize_t index, std::uint32_t tag) : fIndex(index), fTag(tag) { }
+   ClusterSize_t GetIndex() const { return fIndex; }
+   std::uint32_t GetTag() const { return fTag; }
+};
 
 /// Uniquely identifies a physical column within the scope of the current process, used to tag pages
 using ColumnId_t = std::int64_t;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <cctype> // for isspace
 #include <cstdlib> // for malloc, free
+#include <cstring> // for memset
 #include <exception>
 #include <iostream>
 #include <type_traits>
@@ -744,6 +745,7 @@ void ROOT::Experimental::RFieldVariant::DoGenerateColumns()
 
 ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RFieldVariant::GenerateValue(void *where)
 {
+   memset(where, 0, GetValueSize());
    fSubFields[0]->GenerateValue(where);
    SetTag(where, 1);
    return Detail::RFieldValue(this, reinterpret_cast<unsigned char *>(where));

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -418,6 +418,7 @@ ROOT::Experimental::RFieldClass::RFieldClass(std::string_view fieldName, std::st
       //printf("Now looking at %s %s\n", dataMember->GetName(), dataMember->GetFullTypeName());
       auto subField = Detail::RFieldBase::Create(
          GetName() + "." + dataMember->GetName(), dataMember->GetFullTypeName());
+      fMaxAlignment = std::max(fMaxAlignment, subField->GetAlignment());
       Attach(std::unique_ptr<Detail::RFieldBase>(subField));
    }
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -211,10 +211,10 @@ void ROOT::Experimental::Detail::RFieldBase::RIterator::Advance()
 //------------------------------------------------------------------------------
 
 
-ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RFieldRoot::Clone(std::string_view /*newName*/)
+ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RFieldRoot::Clone(std::string_view /*newName*/)
 {
    Detail::RFieldBase* result = new RFieldRoot();
-   for (auto& f : fSubFields) {
+   for (auto &f : fSubFields) {
       auto clone = f->Clone(f->GetName());
       result->Attach(std::unique_ptr<RFieldBase>(clone));
    }
@@ -686,7 +686,7 @@ ROOT::Experimental::RFieldVariant::RFieldVariant(
    fTagOffset = (fMaxItemSize < fMaxAlignment) ? fMaxAlignment : fMaxItemSize;
 }
 
-ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RFieldVariant::Clone(std::string_view newName)
+ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RFieldVariant::Clone(std::string_view newName)
 {
    auto nFields = fSubFields.size();
    std::vector<Detail::RFieldBase *> itemFields;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -74,6 +74,7 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
    if (normalizedType == "ULong64_t") normalizedType = "std::uint64_t";
    if (normalizedType == "string") normalizedType = "std::string";
    if (normalizedType.substr(0, 7) == "vector<") normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 6) == "array<") normalizedType = "std::" + normalizedType;
 
    if (normalizedType == "ROOT::Experimental::ClusterSize_t") return new RField<ClusterSize_t>(fieldName);
    if (normalizedType == "bool") return new RField<bool>(fieldName);
@@ -98,7 +99,7 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
    }
    if (normalizedType.substr(0, 11) == "std::array<") {
       std::string arrayDef = normalizedType.substr(11, normalizedType.length() - 12);
-      auto posSeparator = arrayDef.find(',');
+      auto posSeparator = arrayDef.find_last_of(',');
       std::string itemTypeName = arrayDef.substr(0, posSeparator);
       auto arrayLength = std::stoi(arrayDef.substr(posSeparator + 1));
       auto itemField = Create(itemTypeName, itemTypeName);

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -75,6 +75,7 @@ TEST(RNTuple, ReconstructModel)
    auto fieldNnlo = model->MakeField<std::vector<std::vector<float>>>("nnlo");
    auto fieldKlass = model->MakeField<CustomStruct>("klass");
    auto fieldArray = model->MakeField<std::array<double, 2>>("array");
+   auto fieldVariant = model->MakeField<std::variant<double, std::variant<std::string, double>>>("variant");
    {
       RPageSinkRoot sinkRoot("myTree", fileGuard.GetPath());
       sinkRoot.Create(*model.get());
@@ -93,6 +94,9 @@ TEST(RNTuple, ReconstructModel)
    vecPtr->push_back(std::vector<float>{1.0});
    auto array = modelReconstructed->GetDefaultEntry()->Get<std::array<double, 2>>("array");
    EXPECT_TRUE(array != nullptr);
+   auto variant = modelReconstructed->GetDefaultEntry()->Get<
+      std::variant<double, std::variant<std::string, double>>>("variant");
+   EXPECT_TRUE(variant != nullptr);
 }
 
 TEST(RNTuple, StorageRoot)

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -289,7 +289,7 @@ TEST(RNTuple, Clusters)
    wrFourVec->at(1) = 1.0;
    wrFourVec->at(2) = 2.0;
    wrFourVec->at(3) = 3.0;
-   auto wrVariant = modelWrite->MakeField<std::variant<float>>("variant");
+   auto wrVariant = modelWrite->MakeField<std::variant<double, int>>("variant");
    *wrVariant = 2.0;
 
    auto modelRead = std::unique_ptr<RNTupleModel>(modelWrite->Clone());
@@ -302,7 +302,7 @@ TEST(RNTuple, Clusters)
       wrNnlo->clear();
       *wrTag = "";
       wrFourVec->at(2) = 42.0;
-      *wrVariant = 4.0;
+      *wrVariant = 4;
       ntuple.Fill();
       *wrPt = 12.0;
       wrNnlo->push_back(std::vector<float>{42.0});
@@ -316,7 +316,7 @@ TEST(RNTuple, Clusters)
    auto rdTag = modelRead->Get<std::string>("tag");
    auto rdNnlo = modelRead->Get<std::vector<std::vector<float>>>("nnlo");
    auto rdFourVec = modelRead->Get<std::array<float, 4>>("fourVec");
-   auto rdVariant = modelRead->Get<std::variant<float>>("variant");
+   auto rdVariant = modelRead->Get<std::variant<double, int>>("variant");
 
    RNTupleReader ntuple(std::move(modelRead), std::make_unique<RPageSourceRoot>("f", fileGuard.GetPath()));
    EXPECT_EQ(3U, ntuple.GetNEntries());
@@ -344,7 +344,7 @@ TEST(RNTuple, Clusters)
    EXPECT_STREQ("", rdTag->c_str());
    EXPECT_TRUE(rdNnlo->empty());
    EXPECT_EQ(42.0, (*rdFourVec)[2]);
-   EXPECT_EQ(4.0, std::get<0>(*rdVariant));
+   EXPECT_EQ(4, std::get<1>(*rdVariant));
 
    ntuple.LoadEntry(2);
    EXPECT_EQ(12.0, *rdPt);

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -377,11 +377,11 @@ TEST(RNTuple, Variant)
    EXPECT_EQ(3U, ntuple.GetNEntries());
 
    ntuple.LoadEntry(0);
-   EXPECT_EQ(2.0, std::get<0>(*rdVariant));
+   EXPECT_EQ(2.0, *std::get_if<double>(rdVariant));
    ntuple.LoadEntry(1);
-   EXPECT_EQ(4, std::get<1>(*rdVariant));
+   EXPECT_EQ(4, *std::get_if<int>(rdVariant));
    ntuple.LoadEntry(2);
-   EXPECT_EQ(8.0, std::get<0>(*rdVariant));
+   EXPECT_EQ(8.0, *std::get_if<double>(rdVariant));
 }
 #endif
 


### PR DESCRIPTION
While this might not be a critical type to support per se, it verifies that we can store references (offset columns) to multiple pointee fields (the different types/fields of the variant).