### PR TITLE
[io] use override/final specifier for TBuffer classes

### DIFF
--- a/io/io/inc/TBufferFile.h
+++ b/io/io/inc/TBufferFile.h
@@ -59,209 +59,209 @@ protected:
    void operator=(const TBufferFile &);    ///<  not implemented
 
    Int_t  CheckByteCount(UInt_t startpos, UInt_t bcnt, const TClass *clss, const char* classname);
-   virtual void  CheckCount(UInt_t offset);
+   void  CheckCount(UInt_t offset) override;
    UInt_t CheckObject(UInt_t offset, const TClass *cl, Bool_t readClass = kFALSE);
 
-   virtual  void  WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
+   void  WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse) override;
 
 public:
    enum { kStreamedMemberWise = BIT(14) }; //added to version number to know if a collection has been stored member-wise
 
    TBufferFile(TBuffer::EMode mode);
    TBufferFile(TBuffer::EMode mode, Int_t bufsiz);
-   TBufferFile(TBuffer::EMode mode, Int_t bufsiz, void *buf, Bool_t adopt = kTRUE, ReAllocCharFun_t reallocfunc = 0);
+   TBufferFile(TBuffer::EMode mode, Int_t bufsiz, void *buf, Bool_t adopt = kTRUE, ReAllocCharFun_t reallocfunc = nullptr);
    virtual ~TBufferFile();
 
-   virtual Int_t      CheckByteCount(UInt_t startpos, UInt_t bcnt, const TClass *clss);
-   virtual Int_t      CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname);
-   virtual void       SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE);
+   Int_t      CheckByteCount(UInt_t startpos, UInt_t bcnt, const TClass *clss) override;
+   Int_t      CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname) override;
+   void       SetByteCount(UInt_t cntpos, Bool_t packInVersion = kFALSE) override;
 
-   virtual void       SkipVersion(const TClass *cl = 0);
-   virtual Version_t  ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0);
-   virtual Version_t  ReadVersionNoCheckSum(UInt_t *start = 0, UInt_t *bcnt = 0);
-   virtual Version_t  ReadVersionForMemberWise(const TClass *cl = 0);
-   virtual UInt_t     WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);
-   virtual UInt_t     WriteVersionMemberWise(const TClass *cl, Bool_t useBcnt = kFALSE);
+   void       SkipVersion(const TClass *cl = nullptr) override;
+   Version_t  ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr) override;
+   Version_t  ReadVersionNoCheckSum(UInt_t *start = nullptr, UInt_t *bcnt = nullptr) override;
+   Version_t  ReadVersionForMemberWise(const TClass *cl = nullptr) override;
+   UInt_t     WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE) override;
+   UInt_t     WriteVersionMemberWise(const TClass *cl, Bool_t useBcnt = kFALSE) override;
 
-   virtual void      *ReadObjectAny(const TClass* cast);
-   virtual void       SkipObjectAny();
+   void      *ReadObjectAny(const TClass* cast) override;
+   void       SkipObjectAny() override;
 
-   virtual void       IncrementLevel(TVirtualStreamerInfo* info);
-   virtual void       SetStreamerElementNumber(TStreamerElement*,Int_t) {}
-   virtual void       DecrementLevel(TVirtualStreamerInfo*);
-   TVirtualStreamerInfo  *GetInfo() {return (TVirtualStreamerInfo*)fInfo;}
-   virtual void       ClassBegin(const TClass*, Version_t = -1) {}
-   virtual void       ClassEnd(const TClass*) {}
-   virtual void       ClassMember(const char*, const char* = 0, Int_t = -1, Int_t = -1) {}
+   void       IncrementLevel(TVirtualStreamerInfo* info) override;
+   void       SetStreamerElementNumber(TStreamerElement*,Int_t) override {}
+   void       DecrementLevel(TVirtualStreamerInfo*) override;
+   TVirtualStreamerInfo  *GetInfo() override { return (TVirtualStreamerInfo*)fInfo; }
+   void       ClassBegin(const TClass*, Version_t = -1) override {}
+   void       ClassEnd(const TClass*) override {}
+   void       ClassMember(const char*, const char* = 0, Int_t = -1, Int_t = -1) override {}
 
-   virtual Int_t      ReadBuf(void *buf, Int_t max);
-   virtual void       WriteBuf(const void *buf, Int_t max);
+   Int_t      ReadBuf(void *buf, Int_t max) override;
+   void       WriteBuf(const void *buf, Int_t max) override;
 
-   virtual char      *ReadString(char *s, Int_t max);
-   virtual void       WriteString(const char *s);
+   char      *ReadString(char *s, Int_t max) override;
+   void       WriteString(const char *s) override;
 
-   virtual TClass    *ReadClass(const TClass *cl = 0, UInt_t *objTag = 0);
-   virtual void       WriteClass(const TClass *cl);
+   TClass    *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr) override;
+   void       WriteClass(const TClass *cl) override;
 
-   virtual TObject   *ReadObject(const TClass *cl);
+   TObject   *ReadObject(const TClass *cl) override;
 
    using TBufferIO::CheckObject;
 
    // basic types and arrays of basic types
-   virtual   void     ReadFloat16 (Float_t *f, TStreamerElement *ele=0);
-   virtual   void     WriteFloat16(Float_t *f, TStreamerElement *ele=0);
-   virtual   void     ReadDouble32 (Double_t *d, TStreamerElement *ele=0);
-   virtual   void     WriteDouble32(Double_t *d, TStreamerElement *ele=0);
-   virtual   void     ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue);
-   virtual   void     ReadWithNbits(Float_t *ptr, Int_t nbits);
-   virtual   void     ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue);
-   virtual   void     ReadWithNbits(Double_t *ptr, Int_t nbits);
+   void     ReadFloat16 (Float_t *f, TStreamerElement *ele = nullptr) override;
+   void     WriteFloat16(Float_t *f, TStreamerElement *ele = nullptr) override;
+   void     ReadDouble32 (Double_t *d, TStreamerElement *ele = nullptr) override;
+   void     WriteDouble32(Double_t *d, TStreamerElement *ele = nullptr) override;
+   void     ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue) override;
+   void     ReadWithNbits(Float_t *ptr, Int_t nbits) override;
+   void     ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue) override;
+   void     ReadWithNbits(Double_t *ptr, Int_t nbits) override;
 
-   virtual   Int_t    ReadArray(Bool_t    *&b);
-   virtual   Int_t    ReadArray(Char_t    *&c);
-   virtual   Int_t    ReadArray(UChar_t   *&c);
-   virtual   Int_t    ReadArray(Short_t   *&h);
-   virtual   Int_t    ReadArray(UShort_t  *&h);
-   virtual   Int_t    ReadArray(Int_t     *&i);
-   virtual   Int_t    ReadArray(UInt_t    *&i);
-   virtual   Int_t    ReadArray(Long_t    *&l);
-   virtual   Int_t    ReadArray(ULong_t   *&l);
-   virtual   Int_t    ReadArray(Long64_t  *&l);
-   virtual   Int_t    ReadArray(ULong64_t *&l);
-   virtual   Int_t    ReadArray(Float_t   *&f);
-   virtual   Int_t    ReadArray(Double_t  *&d);
-   virtual   Int_t    ReadArrayFloat16(Float_t  *&f, TStreamerElement *ele=0);
-   virtual   Int_t    ReadArrayDouble32(Double_t  *&d, TStreamerElement *ele=0);
+   Int_t    ReadArray(Bool_t    *&b) override;
+   Int_t    ReadArray(Char_t    *&c) override;
+   Int_t    ReadArray(UChar_t   *&c) override;
+   Int_t    ReadArray(Short_t   *&h) override;
+   Int_t    ReadArray(UShort_t  *&h) override;
+   Int_t    ReadArray(Int_t     *&i) override;
+   Int_t    ReadArray(UInt_t    *&i) override;
+   Int_t    ReadArray(Long_t    *&l) override;
+   Int_t    ReadArray(ULong_t   *&l) override;
+   Int_t    ReadArray(Long64_t  *&l) override;
+   Int_t    ReadArray(ULong64_t *&l) override;
+   Int_t    ReadArray(Float_t   *&f) override;
+   Int_t    ReadArray(Double_t  *&d) override;
+   Int_t    ReadArrayFloat16(Float_t  *&f, TStreamerElement *ele = nullptr) override;
+   Int_t    ReadArrayDouble32(Double_t  *&d, TStreamerElement *ele = nullptr) override;
 
-   virtual   Int_t    ReadStaticArray(Bool_t    *b);
-   virtual   Int_t    ReadStaticArray(Char_t    *c);
-   virtual   Int_t    ReadStaticArray(UChar_t   *c);
-   virtual   Int_t    ReadStaticArray(Short_t   *h);
-   virtual   Int_t    ReadStaticArray(UShort_t  *h);
-   virtual   Int_t    ReadStaticArray(Int_t     *i);
-   virtual   Int_t    ReadStaticArray(UInt_t    *i);
-   virtual   Int_t    ReadStaticArray(Long_t    *l);
-   virtual   Int_t    ReadStaticArray(ULong_t   *l);
-   virtual   Int_t    ReadStaticArray(Long64_t  *l);
-   virtual   Int_t    ReadStaticArray(ULong64_t *l);
-   virtual   Int_t    ReadStaticArray(Float_t   *f);
-   virtual   Int_t    ReadStaticArray(Double_t  *d);
-   virtual   Int_t    ReadStaticArrayFloat16(Float_t  *f, TStreamerElement *ele=0);
-   virtual   Int_t    ReadStaticArrayDouble32(Double_t  *d, TStreamerElement *ele=0);
+   Int_t    ReadStaticArray(Bool_t    *b) override;
+   Int_t    ReadStaticArray(Char_t    *c) override;
+   Int_t    ReadStaticArray(UChar_t   *c) override;
+   Int_t    ReadStaticArray(Short_t   *h) override;
+   Int_t    ReadStaticArray(UShort_t  *h) override;
+   Int_t    ReadStaticArray(Int_t     *i) override;
+   Int_t    ReadStaticArray(UInt_t    *i) override;
+   Int_t    ReadStaticArray(Long_t    *l) override;
+   Int_t    ReadStaticArray(ULong_t   *l) override;
+   Int_t    ReadStaticArray(Long64_t  *l) override;
+   Int_t    ReadStaticArray(ULong64_t *l) override;
+   Int_t    ReadStaticArray(Float_t   *f) override;
+   Int_t    ReadStaticArray(Double_t  *d) override;
+   Int_t    ReadStaticArrayFloat16(Float_t  *f, TStreamerElement *ele = nullptr) override;
+   Int_t    ReadStaticArrayDouble32(Double_t  *d, TStreamerElement *ele = nullptr) override;
 
-   virtual   void     ReadFastArray(Bool_t    *b, Int_t n);
-   virtual   void     ReadFastArray(Char_t    *c, Int_t n);
-   virtual   void     ReadFastArrayString(Char_t    *c, Int_t n);
-   virtual   void     ReadFastArray(UChar_t   *c, Int_t n);
-   virtual   void     ReadFastArray(Short_t   *h, Int_t n);
-   virtual   void     ReadFastArray(UShort_t  *h, Int_t n);
-   virtual   void     ReadFastArray(Int_t     *i, Int_t n);
-   virtual   void     ReadFastArray(UInt_t    *i, Int_t n);
-   virtual   void     ReadFastArray(Long_t    *l, Int_t n);
-   virtual   void     ReadFastArray(ULong_t   *l, Int_t n);
-   virtual   void     ReadFastArray(Long64_t  *l, Int_t n);
-   virtual   void     ReadFastArray(ULong64_t *l, Int_t n);
-   virtual   void     ReadFastArray(Float_t   *f, Int_t n);
-   virtual   void     ReadFastArray(Double_t  *d, Int_t n);
-   virtual   void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual   void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual   void     ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue) ;
-   virtual   void     ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
-   virtual   void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
-   virtual   void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits) ;
-   virtual   void     ReadFastArray(void  *start , const TClass *cl, Int_t n=1, TMemberStreamer *s=0, const TClass* onFileClass=0 );
-   virtual   void     ReadFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0, const TClass* onFileClass=0);
+   void     ReadFastArray(Bool_t    *b, Int_t n) override;
+   void     ReadFastArray(Char_t    *c, Int_t n) override;
+   void     ReadFastArrayString(Char_t    *c, Int_t n) override;
+   void     ReadFastArray(UChar_t   *c, Int_t n) override;
+   void     ReadFastArray(Short_t   *h, Int_t n) override;
+   void     ReadFastArray(UShort_t  *h, Int_t n) override;
+   void     ReadFastArray(Int_t     *i, Int_t n) override;
+   void     ReadFastArray(UInt_t    *i, Int_t n) override;
+   void     ReadFastArray(Long_t    *l, Int_t n) override;
+   void     ReadFastArray(ULong_t   *l, Int_t n) override;
+   void     ReadFastArray(Long64_t  *l, Int_t n) override;
+   void     ReadFastArray(ULong64_t *l, Int_t n) override;
+   void     ReadFastArray(Float_t   *f, Int_t n) override;
+   void     ReadFastArray(Double_t  *d, Int_t n) override;
+   void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele = nullptr) override;
+   void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele = nullptr) override;
+   void     ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue)  override;
+   void     ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits) override;
+   void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue) override;
+   void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits)  override;
+   void     ReadFastArray(void  *start , const TClass *cl, Int_t n=1, TMemberStreamer *s = nullptr, const TClass* onFileClass = nullptr) override;
+   void     ReadFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s = nullptr, const TClass* onFileClass = nullptr) override;
 
-   virtual   void     WriteArray(const Bool_t    *b, Int_t n);
-   virtual   void     WriteArray(const Char_t    *c, Int_t n);
-   virtual   void     WriteArray(const UChar_t   *c, Int_t n);
-   virtual   void     WriteArray(const Short_t   *h, Int_t n);
-   virtual   void     WriteArray(const UShort_t  *h, Int_t n);
-   virtual   void     WriteArray(const Int_t     *i, Int_t n);
-   virtual   void     WriteArray(const UInt_t    *i, Int_t n);
-   virtual   void     WriteArray(const Long_t    *l, Int_t n);
-   virtual   void     WriteArray(const ULong_t   *l, Int_t n);
-   virtual   void     WriteArray(const Long64_t  *l, Int_t n);
-   virtual   void     WriteArray(const ULong64_t *l, Int_t n);
-   virtual   void     WriteArray(const Float_t   *f, Int_t n);
-   virtual   void     WriteArray(const Double_t  *d, Int_t n);
-   virtual   void     WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual   void     WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0);
+   void     WriteArray(const Bool_t    *b, Int_t n) override;
+   void     WriteArray(const Char_t    *c, Int_t n) override;
+   void     WriteArray(const UChar_t   *c, Int_t n) override;
+   void     WriteArray(const Short_t   *h, Int_t n) override;
+   void     WriteArray(const UShort_t  *h, Int_t n) override;
+   void     WriteArray(const Int_t     *i, Int_t n) override;
+   void     WriteArray(const UInt_t    *i, Int_t n) override;
+   void     WriteArray(const Long_t    *l, Int_t n) override;
+   void     WriteArray(const ULong_t   *l, Int_t n) override;
+   void     WriteArray(const Long64_t  *l, Int_t n) override;
+   void     WriteArray(const ULong64_t *l, Int_t n) override;
+   void     WriteArray(const Float_t   *f, Int_t n) override;
+   void     WriteArray(const Double_t  *d, Int_t n) override;
+   void     WriteArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele = nullptr) override;
+   void     WriteArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele = nullptr) override;
 
-   virtual   void     WriteFastArray(const Bool_t    *b, Int_t n);
-   virtual   void     WriteFastArray(const Char_t    *c, Int_t n);
-   virtual   void     WriteFastArrayString(const Char_t    *c, Int_t n);
-   virtual   void     WriteFastArray(const UChar_t   *c, Int_t n);
-   virtual   void     WriteFastArray(const Short_t   *h, Int_t n);
-   virtual   void     WriteFastArray(const UShort_t  *h, Int_t n);
-   virtual   void     WriteFastArray(const Int_t     *i, Int_t n);
-   virtual   void     WriteFastArray(const UInt_t    *i, Int_t n);
-   virtual   void     WriteFastArray(const Long_t    *l, Int_t n);
-   virtual   void     WriteFastArray(const ULong_t   *l, Int_t n);
-   virtual   void     WriteFastArray(const Long64_t  *l, Int_t n);
-   virtual   void     WriteFastArray(const ULong64_t *l, Int_t n);
-   virtual   void     WriteFastArray(const Float_t   *f, Int_t n);
-   virtual   void     WriteFastArray(const Double_t  *d, Int_t n);
-   virtual   void     WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual   void     WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=0);
-   virtual   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0);
+   void     WriteFastArray(const Bool_t    *b, Int_t n) override;
+   void     WriteFastArray(const Char_t    *c, Int_t n) override;
+   void     WriteFastArrayString(const Char_t    *c, Int_t n) override;
+   void     WriteFastArray(const UChar_t   *c, Int_t n) override;
+   void     WriteFastArray(const Short_t   *h, Int_t n) override;
+   void     WriteFastArray(const UShort_t  *h, Int_t n) override;
+   void     WriteFastArray(const Int_t     *i, Int_t n) override;
+   void     WriteFastArray(const UInt_t    *i, Int_t n) override;
+   void     WriteFastArray(const Long_t    *l, Int_t n) override;
+   void     WriteFastArray(const ULong_t   *l, Int_t n) override;
+   void     WriteFastArray(const Long64_t  *l, Int_t n) override;
+   void     WriteFastArray(const ULong64_t *l, Int_t n) override;
+   void     WriteFastArray(const Float_t   *f, Int_t n) override;
+   void     WriteFastArray(const Double_t  *d, Int_t n) override;
+   void     WriteFastArrayFloat16(const Float_t  *f, Int_t n, TStreamerElement *ele = nullptr) override;
+   void     WriteFastArrayDouble32(const Double_t  *d, Int_t n, TStreamerElement *ele = nullptr) override;
+   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s = nullptr) override;
+   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s = nullptr) override;
 
-   virtual   void     StreamObject(void *obj, const std::type_info &typeinfo, const TClass* onFileClass = 0 );
-   virtual   void     StreamObject(void *obj, const char *className, const TClass* onFileClass = 0 );
-   virtual   void     StreamObject(void *obj, const TClass *cl, const TClass* onFileClass = 0 );
-   virtual   void     StreamObject(TObject *obj);
+   void     StreamObject(void *obj, const std::type_info &typeinfo, const TClass* onFileClass = nullptr) override;
+   void     StreamObject(void *obj, const char *className, const TClass* onFileClass = nullptr) override;
+   void     StreamObject(void *obj, const TClass *cl, const TClass* onFileClass = nullptr) override;
+   void     StreamObject(TObject *obj) override;
 
-   virtual   void     ReadBool(Bool_t       &b);
-   virtual   void     ReadChar(Char_t       &c);
-   virtual   void     ReadUChar(UChar_t     &c);
-   virtual   void     ReadShort(Short_t     &s);
-   virtual   void     ReadUShort(UShort_t   &s);
-   virtual   void     ReadInt(Int_t         &i);
-   virtual   void     ReadUInt(UInt_t       &i);
-   virtual   void     ReadLong(Long_t       &l);
-   virtual   void     ReadULong(ULong_t     &l);
-   virtual   void     ReadLong64(Long64_t   &l);
-   virtual   void     ReadULong64(ULong64_t &l);
-   virtual   void     ReadFloat(Float_t     &f);
-   virtual   void     ReadDouble(Double_t   &d);
-   virtual   void     ReadCharP(Char_t      *c);
-   virtual   void     ReadTString(TString   &s);
-   virtual   void     ReadStdString(std::string *s);
-   using              TBuffer::ReadStdString;
-   virtual   void     ReadCharStar(char* &s);
+   void     ReadBool(Bool_t       &b) override;
+   void     ReadChar(Char_t       &c) override;
+   void     ReadUChar(UChar_t     &c) override;
+   void     ReadShort(Short_t     &s) override;
+   void     ReadUShort(UShort_t   &s) override;
+   void     ReadInt(Int_t         &i) override;
+   void     ReadUInt(UInt_t       &i) override;
+   void     ReadLong(Long_t       &l) override;
+   void     ReadULong(ULong_t     &l) override;
+   void     ReadLong64(Long64_t   &l) override;
+   void     ReadULong64(ULong64_t &l) override;
+   void     ReadFloat(Float_t     &f) override;
+   void     ReadDouble(Double_t   &d) override;
+   void     ReadCharP(Char_t      *c) override;
+   void     ReadTString(TString   &s) override;
+   void     ReadStdString(std::string *s) override;
+   using    TBuffer::ReadStdString;
+   void     ReadCharStar(char* &s) override;
 
-   virtual   void     WriteBool(Bool_t       b);
-   virtual   void     WriteChar(Char_t       c);
-   virtual   void     WriteUChar(UChar_t     c);
-   virtual   void     WriteShort(Short_t     s);
-   virtual   void     WriteUShort(UShort_t   s);
-   virtual   void     WriteInt(Int_t         i);
-   virtual   void     WriteUInt(UInt_t       i);
-   virtual   void     WriteLong(Long_t       l);
-   virtual   void     WriteULong(ULong_t     l);
-   virtual   void     WriteLong64(Long64_t   l);
-   virtual   void     WriteULong64(ULong64_t l);
-   virtual   void     WriteFloat(Float_t     f);
-   virtual   void     WriteDouble(Double_t   d);
-   virtual   void     WriteCharP(const Char_t *c);
-   virtual   void     WriteTString(const TString &s);
-   using              TBuffer::WriteStdString;
-   virtual   void     WriteStdString(const std::string *s);
-   virtual   void     WriteCharStar(char *s);
+   void     WriteBool(Bool_t       b) override;
+   void     WriteChar(Char_t       c) override;
+   void     WriteUChar(UChar_t     c) override;
+   void     WriteShort(Short_t     s) override;
+   void     WriteUShort(UShort_t   s) override;
+   void     WriteInt(Int_t         i) override;
+   void     WriteUInt(UInt_t       i) override;
+   void     WriteLong(Long_t       l) override;
+   void     WriteULong(ULong_t     l) override;
+   void     WriteLong64(Long64_t   l) override;
+   void     WriteULong64(ULong64_t l) override;
+   void     WriteFloat(Float_t     f) override;
+   void     WriteDouble(Double_t   d) override;
+   void     WriteCharP(const Char_t *c) override;
+   void     WriteTString(const TString &s) override;
+   using    TBuffer::WriteStdString;
+   void     WriteStdString(const std::string *s) override;
+   void     WriteCharStar(char *s) override;
 
    // Utilities for TClass
-   virtual   Int_t  ReadClassEmulated(const TClass *cl, void *object, const TClass *onfile_class);
-   virtual   Int_t  ReadClassBuffer(const TClass *cl, void *pointer, const TClass *onfile_class);
-   virtual   Int_t  ReadClassBuffer(const TClass *cl, void *pointer, Int_t version, UInt_t start, UInt_t count, const TClass *onfile_class);
-   virtual   Int_t  WriteClassBuffer(const TClass *cl, void *pointer);
+   Int_t  ReadClassEmulated(const TClass *cl, void *object, const TClass *onfile_class) override;
+   Int_t  ReadClassBuffer(const TClass *cl, void *pointer, const TClass *onfile_class) override;
+   Int_t  ReadClassBuffer(const TClass *cl, void *pointer, Int_t version, UInt_t start, UInt_t count, const TClass *onfile_class) override;
+   Int_t  WriteClassBuffer(const TClass *cl, void *pointer) override;
 
-   // Utilites to streamer using sequences.
-   Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *object);
-   Int_t ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
-   Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
+   // Utilities to streamer using sequences.
+   Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *object) override;
+   Int_t ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection) override;
+   Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection) override;
 
-   ClassDef(TBufferFile,0)  //concrete implementation of TBuffer for writing/reading to/from a ROOT file or socket.
+   ClassDefOverride(TBufferFile,0)  //concrete implementation of TBuffer for writing/reading to/from a ROOT file or socket.
 };
 
 

--- a/io/io/inc/TBufferIO.h
+++ b/io/io/inc/TBufferIO.h
@@ -73,43 +73,43 @@ public:
 
    virtual ~TBufferIO();
 
-   virtual Int_t GetVersionOwner() const;
+   Int_t GetVersionOwner() const override;
 
    // See comment in TBuffer::SetPidOffset
-   virtual UShort_t GetPidOffset() const { return fPidOffset; }
-   virtual void SetPidOffset(UShort_t offset);
-   virtual Int_t GetBufferDisplacement() const { return fDisplacement; }
-   virtual void SetBufferDisplacement() { fDisplacement = 0; }
-   virtual void SetBufferDisplacement(Int_t skipped) { fDisplacement = (Int_t)(Length() - skipped); }
+   UShort_t GetPidOffset() const override { return fPidOffset; }
+   void SetPidOffset(UShort_t offset) override;
+   Int_t GetBufferDisplacement() const override { return fDisplacement; }
+   void SetBufferDisplacement() override { fDisplacement = 0; }
+   void SetBufferDisplacement(Int_t skipped) override { fDisplacement = (Int_t)(Length() - skipped); }
 
    // Utilities for objects map
-   virtual void SetReadParam(Int_t mapsize);
-   virtual void SetWriteParam(Int_t mapsize);
-   virtual void InitMap();
-   virtual void ResetMap();
-   virtual void Reset();
-   virtual Int_t GetMapCount() const { return fMapCount; }
-   virtual void MapObject(const TObject *obj, UInt_t offset = 1);
-   virtual void MapObject(const void *obj, const TClass *cl, UInt_t offset = 1);
-   virtual Bool_t CheckObject(const TObject *obj);
-   virtual Bool_t CheckObject(const void *obj, const TClass *ptrClass);
-   virtual void GetMappedObject(UInt_t tag, void *&ptr, TClass *&ClassPtr) const;
+   void SetReadParam(Int_t mapsize) override;
+   void SetWriteParam(Int_t mapsize) override;
+   void InitMap() override;
+   void ResetMap() override;
+   void Reset() override;
+   Int_t GetMapCount() const override { return fMapCount; }
+   void MapObject(const TObject *obj, UInt_t offset = 1) override;
+   void MapObject(const void *obj, const TClass *cl, UInt_t offset = 1) override;
+   Bool_t CheckObject(const TObject *obj) override;
+   Bool_t CheckObject(const void *obj, const TClass *ptrClass) override;
+   void GetMappedObject(UInt_t tag, void *&ptr, TClass *&ClassPtr) const override;
 
    // Utilities for TStreamerInfo
-   virtual void ForceWriteInfo(TVirtualStreamerInfo *info, Bool_t force);
-   virtual void ForceWriteInfoClones(TClonesArray *a);
-   virtual Int_t ReadClones(TClonesArray *a, Int_t nobjects, Version_t objvers);
-   virtual Int_t WriteClones(TClonesArray *a, Int_t nobjects);
-   virtual void TagStreamerInfo(TVirtualStreamerInfo *info);
+   void ForceWriteInfo(TVirtualStreamerInfo *info, Bool_t force) override;
+   void ForceWriteInfoClones(TClonesArray *a) override;
+   Int_t ReadClones(TClonesArray *a, Int_t nobjects, Version_t objvers) override;
+   Int_t WriteClones(TClonesArray *a, Int_t nobjects) override;
+   void TagStreamerInfo(TVirtualStreamerInfo *info) override;
 
    // Special basic ROOT objects and collections
-   virtual TProcessID *GetLastProcessID(TRefTable *reftable) const;
-   virtual UInt_t GetTRefExecId();
-   virtual TProcessID *ReadProcessID(UShort_t pidf);
-   virtual UShort_t WriteProcessID(TProcessID *pid);
+   TProcessID *GetLastProcessID(TRefTable *reftable) const override;
+   UInt_t GetTRefExecId() override;
+   TProcessID *ReadProcessID(UShort_t pidf) override;
+   UShort_t WriteProcessID(TProcessID *pid) override;
 
-   virtual Int_t WriteObjectAny(const void *obj, const TClass *ptrClass, Bool_t cacheReuse = kTRUE);
-   virtual void WriteObject(const TObject *obj, Bool_t cacheReuse = kTRUE);
+   Int_t WriteObjectAny(const void *obj, const TClass *ptrClass, Bool_t cacheReuse = kTRUE) override;
+   void WriteObject(const TObject *obj, Bool_t cacheReuse = kTRUE) override;
    using TBuffer::WriteObject;
 
    static void SetGlobalReadParam(Int_t mapsize);
@@ -117,7 +117,7 @@ public:
    static Int_t GetGlobalReadParam();
    static Int_t GetGlobalWriteParam();
 
-   ClassDef(TBufferIO, 0) // base class, share methods for TBufferFile and TBufferText
+   ClassDefOverride(TBufferIO, 0) // base class, share methods for TBufferFile and TBufferText
 };
 
 #endif

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -329,7 +329,7 @@ protected:
    TString fTypeVersionTag;            ///<! JSON member used to store class version, default empty
    std::vector<const TClass *> fSkipClasses; ///<! list of classes, which class info is not stored
 
-   ClassDefOverride(TBufferJSON, 1) // a specialized TBuffer to only write objects into JSON format
+   ClassDefOverride(TBufferJSON, 0) // a specialized TBuffer to only write objects into JSON format
 };
 
 #endif

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -27,7 +27,7 @@ class TMemberStreamer;
 class TDataMember;
 class TJSONStackObj;
 
-class TBufferJSON : public TBufferText {
+class TBufferJSON final : public TBufferText {
 
 public:
 
@@ -95,156 +95,156 @@ public:
 
    // suppress class writing/reading
 
-   virtual TClass *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr);
-   virtual void WriteClass(const TClass *cl);
+   TClass *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr) final;
+   void WriteClass(const TClass *cl) final;
 
    // redefined virtual functions of TBuffer
 
-   virtual Version_t ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr);
-   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);
+   Version_t ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr) final;
+   UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE) final;
 
-   virtual void *ReadObjectAny(const TClass *clCast);
-   virtual void SkipObjectAny();
+   void *ReadObjectAny(const TClass *clCast) final;
+   void SkipObjectAny() final;
 
    // these methods used in streamer info to indicate currently streamed element,
-   virtual void IncrementLevel(TVirtualStreamerInfo *);
-   virtual void SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type);
-   virtual void DecrementLevel(TVirtualStreamerInfo *);
+   void IncrementLevel(TVirtualStreamerInfo *) final;
+   void SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type) final;
+   void DecrementLevel(TVirtualStreamerInfo *) final;
 
-   virtual void ClassBegin(const TClass *, Version_t = -1);
-   virtual void ClassEnd(const TClass *);
-   virtual void ClassMember(const char *name, const char *typeName = nullptr, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
+   void ClassBegin(const TClass *, Version_t = -1) final;
+   void ClassEnd(const TClass *) final;
+   void ClassMember(const char *name, const char *typeName = nullptr, Int_t arrsize1 = -1, Int_t arrsize2 = -1) final;
 
-   virtual Int_t ReadArray(Bool_t *&b);
-   virtual Int_t ReadArray(Char_t *&c);
-   virtual Int_t ReadArray(UChar_t *&c);
-   virtual Int_t ReadArray(Short_t *&h);
-   virtual Int_t ReadArray(UShort_t *&h);
-   virtual Int_t ReadArray(Int_t *&i);
-   virtual Int_t ReadArray(UInt_t *&i);
-   virtual Int_t ReadArray(Long_t *&l);
-   virtual Int_t ReadArray(ULong_t *&l);
-   virtual Int_t ReadArray(Long64_t *&l);
-   virtual Int_t ReadArray(ULong64_t *&l);
-   virtual Int_t ReadArray(Float_t *&f);
-   virtual Int_t ReadArray(Double_t *&d);
+   Int_t ReadArray(Bool_t *&b) final;
+   Int_t ReadArray(Char_t *&c) final;
+   Int_t ReadArray(UChar_t *&c) final;
+   Int_t ReadArray(Short_t *&h) final;
+   Int_t ReadArray(UShort_t *&h) final;
+   Int_t ReadArray(Int_t *&i) final;
+   Int_t ReadArray(UInt_t *&i) final;
+   Int_t ReadArray(Long_t *&l) final;
+   Int_t ReadArray(ULong_t *&l) final;
+   Int_t ReadArray(Long64_t *&l) final;
+   Int_t ReadArray(ULong64_t *&l) final;
+   Int_t ReadArray(Float_t *&f) final;
+   Int_t ReadArray(Double_t *&d) final;
 
-   virtual Int_t ReadStaticArray(Bool_t *b);
-   virtual Int_t ReadStaticArray(Char_t *c);
-   virtual Int_t ReadStaticArray(UChar_t *c);
-   virtual Int_t ReadStaticArray(Short_t *h);
-   virtual Int_t ReadStaticArray(UShort_t *h);
-   virtual Int_t ReadStaticArray(Int_t *i);
-   virtual Int_t ReadStaticArray(UInt_t *i);
-   virtual Int_t ReadStaticArray(Long_t *l);
-   virtual Int_t ReadStaticArray(ULong_t *l);
-   virtual Int_t ReadStaticArray(Long64_t *l);
-   virtual Int_t ReadStaticArray(ULong64_t *l);
-   virtual Int_t ReadStaticArray(Float_t *f);
-   virtual Int_t ReadStaticArray(Double_t *d);
+   Int_t ReadStaticArray(Bool_t *b) final;
+   Int_t ReadStaticArray(Char_t *c) final;
+   Int_t ReadStaticArray(UChar_t *c) final;
+   Int_t ReadStaticArray(Short_t *h) final;
+   Int_t ReadStaticArray(UShort_t *h) final;
+   Int_t ReadStaticArray(Int_t *i) final;
+   Int_t ReadStaticArray(UInt_t *i) final;
+   Int_t ReadStaticArray(Long_t *l) final;
+   Int_t ReadStaticArray(ULong_t *l) final;
+   Int_t ReadStaticArray(Long64_t *l) final;
+   Int_t ReadStaticArray(ULong64_t *l) final;
+   Int_t ReadStaticArray(Float_t *f) final;
+   Int_t ReadStaticArray(Double_t *d) final;
 
-   virtual void ReadFastArray(Bool_t *b, Int_t n);
-   virtual void ReadFastArray(Char_t *c, Int_t n);
-   virtual void ReadFastArrayString(Char_t *c, Int_t n);
-   virtual void ReadFastArray(UChar_t *c, Int_t n);
-   virtual void ReadFastArray(Short_t *h, Int_t n);
-   virtual void ReadFastArray(UShort_t *h, Int_t n);
-   virtual void ReadFastArray(Int_t *i, Int_t n);
-   virtual void ReadFastArray(UInt_t *i, Int_t n);
-   virtual void ReadFastArray(Long_t *l, Int_t n);
-   virtual void ReadFastArray(ULong_t *l, Int_t n);
-   virtual void ReadFastArray(Long64_t *l, Int_t n);
-   virtual void ReadFastArray(ULong64_t *l, Int_t n);
-   virtual void ReadFastArray(Float_t *f, Int_t n);
-   virtual void ReadFastArray(Double_t *d, Int_t n);
-   virtual void ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr,
-                              const TClass *onFileClass = nullptr);
-   virtual void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
-                              TMemberStreamer *s = nullptr, const TClass *onFileClass = nullptr);
+   void ReadFastArray(Bool_t *b, Int_t n) final;
+   void ReadFastArray(Char_t *c, Int_t n) final;
+   void ReadFastArrayString(Char_t *c, Int_t n) final;
+   void ReadFastArray(UChar_t *c, Int_t n) final;
+   void ReadFastArray(Short_t *h, Int_t n) final;
+   void ReadFastArray(UShort_t *h, Int_t n) final;
+   void ReadFastArray(Int_t *i, Int_t n) final;
+   void ReadFastArray(UInt_t *i, Int_t n) final;
+   void ReadFastArray(Long_t *l, Int_t n) final;
+   void ReadFastArray(ULong_t *l, Int_t n) final;
+   void ReadFastArray(Long64_t *l, Int_t n) final;
+   void ReadFastArray(ULong64_t *l, Int_t n) final;
+   void ReadFastArray(Float_t *f, Int_t n) final;
+   void ReadFastArray(Double_t *d, Int_t n) final;
+   void ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr,
+                      const TClass *onFileClass = nullptr) final;
+   void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                      TMemberStreamer *s = nullptr, const TClass *onFileClass = nullptr) final;
 
-   virtual void WriteArray(const Bool_t *b, Int_t n);
-   virtual void WriteArray(const Char_t *c, Int_t n);
-   virtual void WriteArray(const UChar_t *c, Int_t n);
-   virtual void WriteArray(const Short_t *h, Int_t n);
-   virtual void WriteArray(const UShort_t *h, Int_t n);
-   virtual void WriteArray(const Int_t *i, Int_t n);
-   virtual void WriteArray(const UInt_t *i, Int_t n);
-   virtual void WriteArray(const Long_t *l, Int_t n);
-   virtual void WriteArray(const ULong_t *l, Int_t n);
-   virtual void WriteArray(const Long64_t *l, Int_t n);
-   virtual void WriteArray(const ULong64_t *l, Int_t n);
-   virtual void WriteArray(const Float_t *f, Int_t n);
-   virtual void WriteArray(const Double_t *d, Int_t n);
+   void WriteArray(const Bool_t *b, Int_t n) final;
+   void WriteArray(const Char_t *c, Int_t n) final;
+   void WriteArray(const UChar_t *c, Int_t n) final;
+   void WriteArray(const Short_t *h, Int_t n) final;
+   void WriteArray(const UShort_t *h, Int_t n) final;
+   void WriteArray(const Int_t *i, Int_t n) final;
+   void WriteArray(const UInt_t *i, Int_t n) final;
+   void WriteArray(const Long_t *l, Int_t n) final;
+   void WriteArray(const ULong_t *l, Int_t n) final;
+   void WriteArray(const Long64_t *l, Int_t n) final;
+   void WriteArray(const ULong64_t *l, Int_t n) final;
+   void WriteArray(const Float_t *f, Int_t n) final;
+   void WriteArray(const Double_t *d, Int_t n) final;
 
-   virtual void WriteFastArray(const Bool_t *b, Int_t n);
-   virtual void WriteFastArray(const Char_t *c, Int_t n);
-   virtual void WriteFastArrayString(const Char_t *c, Int_t n);
-   virtual void WriteFastArray(const UChar_t *c, Int_t n);
-   virtual void WriteFastArray(const Short_t *h, Int_t n);
-   virtual void WriteFastArray(const UShort_t *h, Int_t n);
-   virtual void WriteFastArray(const Int_t *i, Int_t n);
-   virtual void WriteFastArray(const UInt_t *i, Int_t n);
-   virtual void WriteFastArray(const Long_t *l, Int_t n);
-   virtual void WriteFastArray(const ULong_t *l, Int_t n);
-   virtual void WriteFastArray(const Long64_t *l, Int_t n);
-   virtual void WriteFastArray(const ULong64_t *l, Int_t n);
-   virtual void WriteFastArray(const Float_t *f, Int_t n);
-   virtual void WriteFastArray(const Double_t *d, Int_t n);
-   virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr);
-   virtual Int_t WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
-                                TMemberStreamer *s = nullptr);
+   void WriteFastArray(const Bool_t *b, Int_t n) final;
+   void WriteFastArray(const Char_t *c, Int_t n) final;
+   void WriteFastArrayString(const Char_t *c, Int_t n) final;
+   void WriteFastArray(const UChar_t *c, Int_t n) final;
+   void WriteFastArray(const Short_t *h, Int_t n) final;
+   void WriteFastArray(const UShort_t *h, Int_t n) final;
+   void WriteFastArray(const Int_t *i, Int_t n) final;
+   void WriteFastArray(const UInt_t *i, Int_t n) final;
+   void WriteFastArray(const Long_t *l, Int_t n) final;
+   void WriteFastArray(const ULong_t *l, Int_t n) final;
+   void WriteFastArray(const Long64_t *l, Int_t n) final;
+   void WriteFastArray(const ULong64_t *l, Int_t n) final;
+   void WriteFastArray(const Float_t *f, Int_t n) final;
+   void WriteFastArray(const Double_t *d, Int_t n) final;
+   void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr) final;
+   Int_t WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                        TMemberStreamer *s = nullptr) final;
 
-   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = nullptr);
+   void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = nullptr) final;
    using TBufferText::StreamObject;
 
-   virtual void ReadBool(Bool_t &b);
-   virtual void ReadChar(Char_t &c);
-   virtual void ReadUChar(UChar_t &c);
-   virtual void ReadShort(Short_t &s);
-   virtual void ReadUShort(UShort_t &s);
-   virtual void ReadInt(Int_t &i);
-   virtual void ReadUInt(UInt_t &i);
-   virtual void ReadLong(Long_t &l);
-   virtual void ReadULong(ULong_t &l);
-   virtual void ReadLong64(Long64_t &l);
-   virtual void ReadULong64(ULong64_t &l);
-   virtual void ReadFloat(Float_t &f);
-   virtual void ReadDouble(Double_t &d);
-   virtual void ReadCharP(Char_t *c);
-   virtual void ReadTString(TString &s);
-   virtual void ReadStdString(std::string *s);
+   void ReadBool(Bool_t &b) final;
+   void ReadChar(Char_t &c) final;
+   void ReadUChar(UChar_t &c) final;
+   void ReadShort(Short_t &s) final;
+   void ReadUShort(UShort_t &s) final;
+   void ReadInt(Int_t &i) final;
+   void ReadUInt(UInt_t &i) final;
+   void ReadLong(Long_t &l) final;
+   void ReadULong(ULong_t &l) final;
+   void ReadLong64(Long64_t &l) final;
+   void ReadULong64(ULong64_t &l) final;
+   void ReadFloat(Float_t &f) final;
+   void ReadDouble(Double_t &d) final;
+   void ReadCharP(Char_t *c) final;
+   void ReadTString(TString &s) final;
+   void ReadStdString(std::string *s) final;
    using TBuffer::ReadStdString;
-   virtual void ReadCharStar(char *&s);
+   void ReadCharStar(char *&s) final;
 
-   virtual void WriteBool(Bool_t b);
-   virtual void WriteChar(Char_t c);
-   virtual void WriteUChar(UChar_t c);
-   virtual void WriteShort(Short_t s);
-   virtual void WriteUShort(UShort_t s);
-   virtual void WriteInt(Int_t i);
-   virtual void WriteUInt(UInt_t i);
-   virtual void WriteLong(Long_t l);
-   virtual void WriteULong(ULong_t l);
-   virtual void WriteLong64(Long64_t l);
-   virtual void WriteULong64(ULong64_t l);
-   virtual void WriteFloat(Float_t f);
-   virtual void WriteDouble(Double_t d);
-   virtual void WriteCharP(const Char_t *c);
-   virtual void WriteTString(const TString &s);
-   virtual void WriteStdString(const std::string *s);
+   void WriteBool(Bool_t b) final;
+   void WriteChar(Char_t c) final;
+   void WriteUChar(UChar_t c) final;
+   void WriteShort(Short_t s) final;
+   void WriteUShort(UShort_t s) final;
+   void WriteInt(Int_t i) final;
+   void WriteUInt(UInt_t i) final;
+   void WriteLong(Long_t l) final;
+   void WriteULong(ULong_t l) final;
+   void WriteLong64(Long64_t l) final;
+   void WriteULong64(ULong64_t l) final;
+   void WriteFloat(Float_t f) final;
+   void WriteDouble(Double_t d) final;
+   void WriteCharP(const Char_t *c) final;
+   void WriteTString(const TString &s) final;
+   void WriteStdString(const std::string *s) final;
    using TBuffer::WriteStdString;
-   virtual void WriteCharStar(char *s);
+   void WriteCharStar(char *s) final;
 
-   virtual TVirtualStreamerInfo *GetInfo();
+   TVirtualStreamerInfo *GetInfo() final;
 
    // end of redefined virtual functions
 
-   virtual void ReadBaseClass(void *start, TStreamerBase *elem);
+   void ReadBaseClass(void *start, TStreamerBase *elem) final;
 
 protected:
    // redefined protected virtual functions
 
-   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
+   void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse) final;
 
    // end redefined protected virtual functions
 
@@ -329,7 +329,7 @@ protected:
    TString fTypeVersionTag;            ///<! JSON member used to store class version, default empty
    std::vector<const TClass *> fSkipClasses; ///<! list of classes, which class info is not stored
 
-   ClassDef(TBufferJSON, 1) // a specialized TBuffer to only write objects into JSON format
+   ClassDefOverride(TBufferJSON, 1) // a specialized TBuffer to only write objects into JSON format
 };
 
 #endif

--- a/io/io/inc/TBufferText.h
+++ b/io/io/inc/TBufferText.h
@@ -29,92 +29,92 @@ public:
 
    // virtual TBuffer methods, which are generic for all text-based streamers
 
-   virtual void StreamObject(void *obj, const std::type_info &typeinfo, const TClass *onFileClass = nullptr);
-   virtual void StreamObject(void *obj, const char *className, const TClass *onFileClass = nullptr);
-   virtual void StreamObject(TObject *obj);
+   void StreamObject(void *obj, const std::type_info &typeinfo, const TClass *onFileClass = nullptr) override;
+   void StreamObject(void *obj, const char *className, const TClass *onFileClass = nullptr) override;
+   void StreamObject(TObject *obj) override;
    using TBuffer::StreamObject;
 
-   virtual Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *object);
-   virtual Int_t ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection,
-                                     void *end_collection);
-   virtual Int_t
-   ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection);
+   Int_t ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *object) final;
+   Int_t ApplySequenceVecPtr(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection,
+                                     void *end_collection) final;
+   Int_t
+   ApplySequence(const TStreamerInfoActions::TActionSequence &sequence, void *start_collection, void *end_collection) final;
 
-   virtual void ReadFloat16(Float_t *f, TStreamerElement *ele = nullptr);
-   virtual void WriteFloat16(Float_t *f, TStreamerElement *ele = nullptr);
-   virtual void ReadDouble32(Double_t *d, TStreamerElement *ele = nullptr);
-   virtual void WriteDouble32(Double_t *d, TStreamerElement *ele = nullptr);
-   virtual void ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue);
-   virtual void ReadWithNbits(Float_t *ptr, Int_t nbits);
-   virtual void ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue);
-   virtual void ReadWithNbits(Double_t *ptr, Int_t nbits);
+   void ReadFloat16(Float_t *f, TStreamerElement *ele = nullptr) final;
+   void WriteFloat16(Float_t *f, TStreamerElement *ele = nullptr) final;
+   void ReadDouble32(Double_t *d, TStreamerElement *ele = nullptr) final;
+   void WriteDouble32(Double_t *d, TStreamerElement *ele = nullptr) final;
+   void ReadWithFactor(Float_t *ptr, Double_t factor, Double_t minvalue) final;
+   void ReadWithNbits(Float_t *ptr, Int_t nbits) final;
+   void ReadWithFactor(Double_t *ptr, Double_t factor, Double_t minvalue) final;
+   void ReadWithNbits(Double_t *ptr, Int_t nbits) final;
 
-   virtual Int_t ReadArrayFloat16(Float_t *&f, TStreamerElement *ele = nullptr);
-   virtual Int_t ReadArrayDouble32(Double_t *&d, TStreamerElement *ele = nullptr);
+   Int_t ReadArrayFloat16(Float_t *&f, TStreamerElement *ele = nullptr) override;
+   Int_t ReadArrayDouble32(Double_t *&d, TStreamerElement *ele = nullptr) override;
 
-   virtual Int_t ReadStaticArrayFloat16(Float_t *f, TStreamerElement *ele = nullptr);
-   virtual Int_t ReadStaticArrayDouble32(Double_t *d, TStreamerElement *ele = nullptr);
+   Int_t ReadStaticArrayFloat16(Float_t *f, TStreamerElement *ele = nullptr) final;
+   Int_t ReadStaticArrayDouble32(Double_t *d, TStreamerElement *ele = nullptr) final;
 
-   virtual void ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement *ele = nullptr);
-   virtual void ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
-   virtual void ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
-   virtual void ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
-   virtual void ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
-   virtual void ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits);
+   void ReadFastArrayFloat16(Float_t *f, Int_t n, TStreamerElement *ele = nullptr) final;
+   void ReadFastArrayDouble32(Double_t *d, Int_t n, TStreamerElement *ele = nullptr) final;
+   void ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue) final;
+   void ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits) final;
+   void ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue) final;
+   void ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits) final;
 
-   virtual void WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement *ele = nullptr);
-   virtual void WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
+   void WriteArrayFloat16(const Float_t *f, Int_t n, TStreamerElement *ele = nullptr) final;
+   void WriteArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = nullptr) final;
 
-   virtual void WriteFastArrayFloat16(const Float_t *d, Int_t n, TStreamerElement *ele = nullptr);
-   virtual void WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = nullptr);
+   void WriteFastArrayFloat16(const Float_t *d, Int_t n, TStreamerElement *ele = nullptr) final;
+   void WriteFastArrayDouble32(const Double_t *d, Int_t n, TStreamerElement *ele = nullptr) final;
 
    // Utilities for TClass
-   virtual Int_t ReadClassBuffer(const TClass * /*cl*/, void * /*pointer*/, const TClass * /*onfile_class*/ = nullptr);
-   virtual Int_t ReadClassBuffer(const TClass * /*cl*/, void * /*pointer*/, Int_t /*version*/, UInt_t /*start*/,
-                                 UInt_t /*count*/, const TClass * /*onfile_class*/ = nullptr);
-   virtual Int_t WriteClassBuffer(const TClass *cl, void *pointer);
+   Int_t ReadClassBuffer(const TClass * /*cl*/, void * /*pointer*/, const TClass * /*onfile_class*/ = nullptr) override;
+   Int_t ReadClassBuffer(const TClass * /*cl*/, void * /*pointer*/, Int_t /*version*/, UInt_t /*start*/,
+                                 UInt_t /*count*/, const TClass * /*onfile_class*/ = nullptr) override;
+   Int_t WriteClassBuffer(const TClass *cl, void *pointer) override;
 
    // virtual abstract TBuffer methods, which are not used in text streaming
 
-   virtual Int_t CheckByteCount(UInt_t /* startpos */, UInt_t /* bcnt */, const TClass * /* clss */) { return 0; }
-   virtual Int_t CheckByteCount(UInt_t /* startpos */, UInt_t /* bcnt */, const char * /* classname */) { return 0; }
-   virtual void SetByteCount(UInt_t /* cntpos */, Bool_t /* packInVersion */ = kFALSE) {}
-   virtual void SkipVersion(const TClass *cl = nullptr);
-   virtual Version_t ReadVersionNoCheckSum(UInt_t *, UInt_t *) { return 0; }
+   Int_t CheckByteCount(UInt_t /* startpos */, UInt_t /* bcnt */, const TClass * /* clss */) final { return 0; }
+   Int_t CheckByteCount(UInt_t /* startpos */, UInt_t /* bcnt */, const char * /* classname */) final { return 0; }
+   void SetByteCount(UInt_t /* cntpos */, Bool_t /* packInVersion */ = kFALSE) final {}
+   void SkipVersion(const TClass *cl = nullptr) final;
+   Version_t ReadVersionNoCheckSum(UInt_t *, UInt_t *) final { return 0; }
 
-   virtual Int_t ReadBuf(void * /*buf*/, Int_t /*max*/)
+   Int_t ReadBuf(void * /*buf*/, Int_t /*max*/) final
    {
       Error("ReadBuf", "useless in text streamers");
       return 0;
    }
-   virtual void WriteBuf(const void * /*buf*/, Int_t /*max*/) { Error("WriteBuf", "useless in text streamers"); }
+   void WriteBuf(const void * /*buf*/, Int_t /*max*/) final { Error("WriteBuf", "useless in text streamers"); }
 
-   virtual char *ReadString(char * /*s*/, Int_t /*max*/)
+   char *ReadString(char * /*s*/, Int_t /*max*/) final
    {
       Error("ReadString", "useless");
       return nullptr;
    }
-   virtual void WriteString(const char * /*s*/) { Error("WriteString", "useless"); }
+   void WriteString(const char * /*s*/) final { Error("WriteString", "useless"); }
 
-   virtual Version_t ReadVersionForMemberWise(const TClass * /*cl*/ = nullptr)
+   Version_t ReadVersionForMemberWise(const TClass * /*cl*/ = nullptr) final
    {
       Error("ReadVersionForMemberWise", "not defined in text-based streamers");
       return 0;
    }
-   virtual UInt_t WriteVersionMemberWise(const TClass * /*cl*/, Bool_t /*useBcnt*/ = kFALSE)
+   UInt_t WriteVersionMemberWise(const TClass * /*cl*/, Bool_t /*useBcnt*/ = kFALSE) final
    {
       Error("WriteVersionMemberWise", "not defined in text-based streamers");
       return 0;
    }
 
-   virtual TObject *ReadObject(const TClass * /*cl*/)
+   TObject *ReadObject(const TClass * /*cl*/) final
    {
       Error("ReadObject", "not yet implemented for text-based streamers");
       return nullptr;
    }
 
    // Utilities for TClass
-   virtual Int_t ReadClassEmulated(const TClass * /*cl*/, void * /*object*/, const TClass * /*onfile_class*/ = nullptr)
+   Int_t ReadClassEmulated(const TClass * /*cl*/, void * /*object*/, const TClass * /*onfile_class*/ = nullptr) final
    {
       Error("ReadClassEmulated", "not defined in text-based streamers");
       return 0;
@@ -137,7 +137,7 @@ protected:
    static const char *fgFloatFmt;  ///<!  printf argument for floats, either "%f" or "%e" or "%10f" and so on
    static const char *fgDoubleFmt; ///<!  printf argument for doubles, either "%f" or "%e" or "%10f" and so on
 
-   ClassDef(TBufferText, 0); // a TBuffer subclass for all text-based streamers
+   ClassDefOverride(TBufferText, 0); // a TBuffer subclass for all text-based streamers
 };
 
 #endif

--- a/io/sql/inc/TBufferSQL2.h
+++ b/io/sql/inc/TBufferSQL2.h
@@ -5,9 +5,7 @@
 #define ROOT_TBufferSQL2
 
 #include "TBufferText.h"
-
 #include "TString.h"
-
 #include "TObjArray.h"
 
 class TMap;
@@ -16,8 +14,8 @@ class TVirtualStreamerInfo;
 class TStreamerElement;
 class TObjArray;
 class TMemberStreamer;
-class TSQLStackObj;
 
+class TSQLStackObj;
 class TSQLServer;
 class TSQLResult;
 class TSQLRow;
@@ -26,7 +24,7 @@ class TSQLStructure;
 class TSQLObjectData;
 class TSQLClassInfo;
 
-class TBufferSQL2 : public TBufferText {
+class TBufferSQL2 final : public TBufferText {
 
    friend class TSQLStructure;
 
@@ -55,7 +53,7 @@ protected:
 
    // redefined protected virtual functions
 
-   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
+   void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse) final;
 
    // end redefined protected virtual functions
 
@@ -101,12 +99,12 @@ protected:
    const char *SqlReadValue(const char *tname);
    const char *SqlReadCharStarValue();
 
-   Int_t SqlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse, TMemberStreamer *streamer = 0,
+   Int_t SqlWriteObject(const void *obj, const TClass *objClass, Bool_t cacheReuse, TMemberStreamer *streamer = nullptr,
                         Int_t streamer_index = 0);
-   void *SqlReadObject(void *obj, TClass **cl = 0, TMemberStreamer *streamer = 0, Int_t streamer_index = 0,
-                       const TClass *onFileClass = 0);
-   void *SqlReadObjectDirect(void *obj, TClass **cl, Long64_t objid, TMemberStreamer *streamer = 0,
-                             Int_t streamer_index = 0, const TClass *onFileClass = 0);
+   void *SqlReadObject(void *obj, TClass **cl = nullptr, TMemberStreamer *streamer = nullptr, Int_t streamer_index = 0,
+                       const TClass *onFileClass = nullptr);
+   void *SqlReadObjectDirect(void *obj, TClass **cl, Long64_t objid, TMemberStreamer *streamer = nullptr,
+                             Int_t streamer_index = 0, const TClass *onFileClass = nullptr);
 
    void StreamObjectExtra(void *obj, TMemberStreamer *streamer, const TClass *cl, Int_t n = 0,
                           const TClass *onFileClass = nullptr);
@@ -141,150 +139,150 @@ public:
 
    // suppress class writing/reading
 
-   virtual TClass *ReadClass(const TClass *cl = 0, UInt_t *objTag = 0);
-   virtual void WriteClass(const TClass *cl);
+   TClass *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr) final;
+   void WriteClass(const TClass *cl) final;
 
    // redefined virtual functions of TBuffer
 
-   virtual Version_t ReadVersion(UInt_t *start = 0, UInt_t *bcnt = 0, const TClass *cl = 0);
-   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);
+   Version_t ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr) final;
+   UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE) final;
 
-   virtual void *ReadObjectAny(const TClass *clCast);
-   virtual void SkipObjectAny();
+   void *ReadObjectAny(const TClass *clCast) final;
+   void SkipObjectAny() final;
 
-   virtual void IncrementLevel(TVirtualStreamerInfo *);
-   virtual void SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type);
-   virtual void DecrementLevel(TVirtualStreamerInfo *);
+   void IncrementLevel(TVirtualStreamerInfo *) final;
+   void SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type) final;
+   void DecrementLevel(TVirtualStreamerInfo *) final;
 
-   virtual void ClassBegin(const TClass *, Version_t = -1);
-   virtual void ClassEnd(const TClass *);
-   virtual void ClassMember(const char *name, const char *typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
+   void ClassBegin(const TClass *, Version_t = -1) final;
+   void ClassEnd(const TClass *) final;
+   void ClassMember(const char *name, const char *typeName = 0, Int_t arrsize1 = -1, Int_t arrsize2 = -1) final;
 
-   virtual Int_t ReadArray(Bool_t *&b);
-   virtual Int_t ReadArray(Char_t *&c);
-   virtual Int_t ReadArray(UChar_t *&c);
-   virtual Int_t ReadArray(Short_t *&h);
-   virtual Int_t ReadArray(UShort_t *&h);
-   virtual Int_t ReadArray(Int_t *&i);
-   virtual Int_t ReadArray(UInt_t *&i);
-   virtual Int_t ReadArray(Long_t *&l);
-   virtual Int_t ReadArray(ULong_t *&l);
-   virtual Int_t ReadArray(Long64_t *&l);
-   virtual Int_t ReadArray(ULong64_t *&l);
-   virtual Int_t ReadArray(Float_t *&f);
-   virtual Int_t ReadArray(Double_t *&d);
+   Int_t ReadArray(Bool_t *&b) final;
+   Int_t ReadArray(Char_t *&c) final;
+   Int_t ReadArray(UChar_t *&c) final;
+   Int_t ReadArray(Short_t *&h) final;
+   Int_t ReadArray(UShort_t *&h) final;
+   Int_t ReadArray(Int_t *&i) final;
+   Int_t ReadArray(UInt_t *&i) final;
+   Int_t ReadArray(Long_t *&l) final;
+   Int_t ReadArray(ULong_t *&l) final;
+   Int_t ReadArray(Long64_t *&l) final;
+   Int_t ReadArray(ULong64_t *&l) final;
+   Int_t ReadArray(Float_t *&f) final;
+   Int_t ReadArray(Double_t *&d) final;
 
-   virtual Int_t ReadStaticArray(Bool_t *b);
-   virtual Int_t ReadStaticArray(Char_t *c);
-   virtual Int_t ReadStaticArray(UChar_t *c);
-   virtual Int_t ReadStaticArray(Short_t *h);
-   virtual Int_t ReadStaticArray(UShort_t *h);
-   virtual Int_t ReadStaticArray(Int_t *i);
-   virtual Int_t ReadStaticArray(UInt_t *i);
-   virtual Int_t ReadStaticArray(Long_t *l);
-   virtual Int_t ReadStaticArray(ULong_t *l);
-   virtual Int_t ReadStaticArray(Long64_t *l);
-   virtual Int_t ReadStaticArray(ULong64_t *l);
-   virtual Int_t ReadStaticArray(Float_t *f);
-   virtual Int_t ReadStaticArray(Double_t *d);
+   Int_t ReadStaticArray(Bool_t *b) final;
+   Int_t ReadStaticArray(Char_t *c) final;
+   Int_t ReadStaticArray(UChar_t *c) final;
+   Int_t ReadStaticArray(Short_t *h) final;
+   Int_t ReadStaticArray(UShort_t *h) final;
+   Int_t ReadStaticArray(Int_t *i) final;
+   Int_t ReadStaticArray(UInt_t *i) final;
+   Int_t ReadStaticArray(Long_t *l) final;
+   Int_t ReadStaticArray(ULong_t *l) final;
+   Int_t ReadStaticArray(Long64_t *l) final;
+   Int_t ReadStaticArray(ULong64_t *l) final;
+   Int_t ReadStaticArray(Float_t *f) final;
+   Int_t ReadStaticArray(Double_t *d) final;
 
-   virtual void ReadFastArray(Bool_t *b, Int_t n);
-   virtual void ReadFastArray(Char_t *c, Int_t n);
-   virtual void ReadFastArray(UChar_t *c, Int_t n);
-   virtual void ReadFastArray(Short_t *h, Int_t n);
-   virtual void ReadFastArray(UShort_t *h, Int_t n);
-   virtual void ReadFastArray(Int_t *i, Int_t n);
-   virtual void ReadFastArray(UInt_t *i, Int_t n);
-   virtual void ReadFastArray(Long_t *l, Int_t n);
-   virtual void ReadFastArray(ULong_t *l, Int_t n);
-   virtual void ReadFastArray(Long64_t *l, Int_t n);
-   virtual void ReadFastArray(ULong64_t *l, Int_t n);
-   virtual void ReadFastArray(Float_t *f, Int_t n);
-   virtual void ReadFastArray(Double_t *d, Int_t n);
-   virtual void ReadFastArrayString(Char_t *c, Int_t n);
-   virtual void
-   ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0, const TClass *onFileClass = 0);
-   virtual void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
-                              TMemberStreamer *s = 0, const TClass *onFileClass = 0);
+   void ReadFastArray(Bool_t *b, Int_t n) final;
+   void ReadFastArray(Char_t *c, Int_t n) final;
+   void ReadFastArray(UChar_t *c, Int_t n) final;
+   void ReadFastArray(Short_t *h, Int_t n) final;
+   void ReadFastArray(UShort_t *h, Int_t n) final;
+   void ReadFastArray(Int_t *i, Int_t n) final;
+   void ReadFastArray(UInt_t *i, Int_t n) final;
+   void ReadFastArray(Long_t *l, Int_t n) final;
+   void ReadFastArray(ULong_t *l, Int_t n) final;
+   void ReadFastArray(Long64_t *l, Int_t n) final;
+   void ReadFastArray(ULong64_t *l, Int_t n) final;
+   void ReadFastArray(Float_t *f, Int_t n) final;
+   void ReadFastArray(Double_t *d, Int_t n) final;
+   void ReadFastArrayString(Char_t *c, Int_t n) final;
+   void ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr,
+                      const TClass *onFileClass = nullptr) final;
+   void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                      TMemberStreamer *s = nullptr, const TClass *onFileClass = nullptr) final;
 
-   virtual void WriteArray(const Bool_t *b, Int_t n);
-   virtual void WriteArray(const Char_t *c, Int_t n);
-   virtual void WriteArray(const UChar_t *c, Int_t n);
-   virtual void WriteArray(const Short_t *h, Int_t n);
-   virtual void WriteArray(const UShort_t *h, Int_t n);
-   virtual void WriteArray(const Int_t *i, Int_t n);
-   virtual void WriteArray(const UInt_t *i, Int_t n);
-   virtual void WriteArray(const Long_t *l, Int_t n);
-   virtual void WriteArray(const ULong_t *l, Int_t n);
-   virtual void WriteArray(const Long64_t *l, Int_t n);
-   virtual void WriteArray(const ULong64_t *l, Int_t n);
-   virtual void WriteArray(const Float_t *f, Int_t n);
-   virtual void WriteArray(const Double_t *d, Int_t n);
+   void WriteArray(const Bool_t *b, Int_t n) final;
+   void WriteArray(const Char_t *c, Int_t n) final;
+   void WriteArray(const UChar_t *c, Int_t n) final;
+   void WriteArray(const Short_t *h, Int_t n) final;
+   void WriteArray(const UShort_t *h, Int_t n) final;
+   void WriteArray(const Int_t *i, Int_t n) final;
+   void WriteArray(const UInt_t *i, Int_t n) final;
+   void WriteArray(const Long_t *l, Int_t n) final;
+   void WriteArray(const ULong_t *l, Int_t n) final;
+   void WriteArray(const Long64_t *l, Int_t n) final;
+   void WriteArray(const ULong64_t *l, Int_t n) final;
+   void WriteArray(const Float_t *f, Int_t n) final;
+   void WriteArray(const Double_t *d, Int_t n) final;
 
-   virtual void WriteFastArray(const Bool_t *b, Int_t n);
-   virtual void WriteFastArray(const Char_t *c, Int_t n);
-   virtual void WriteFastArray(const UChar_t *c, Int_t n);
-   virtual void WriteFastArray(const Short_t *h, Int_t n);
-   virtual void WriteFastArray(const UShort_t *h, Int_t n);
-   virtual void WriteFastArray(const Int_t *i, Int_t n);
-   virtual void WriteFastArray(const UInt_t *i, Int_t n);
-   virtual void WriteFastArray(const Long_t *l, Int_t n);
-   virtual void WriteFastArray(const ULong_t *l, Int_t n);
-   virtual void WriteFastArray(const Long64_t *l, Int_t n);
-   virtual void WriteFastArray(const ULong64_t *l, Int_t n);
-   virtual void WriteFastArray(const Float_t *f, Int_t n);
-   virtual void WriteFastArray(const Double_t *d, Int_t n);
-   virtual void WriteFastArrayString(const Char_t *c, Int_t n);
-   virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = 0);
-   virtual Int_t
-   WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE, TMemberStreamer *s = 0);
+   void WriteFastArray(const Bool_t *b, Int_t n) final;
+   void WriteFastArray(const Char_t *c, Int_t n) final;
+   void WriteFastArray(const UChar_t *c, Int_t n) final;
+   void WriteFastArray(const Short_t *h, Int_t n) final;
+   void WriteFastArray(const UShort_t *h, Int_t n) final;
+   void WriteFastArray(const Int_t *i, Int_t n) final;
+   void WriteFastArray(const UInt_t *i, Int_t n) final;
+   void WriteFastArray(const Long_t *l, Int_t n) final;
+   void WriteFastArray(const ULong_t *l, Int_t n) final;
+   void WriteFastArray(const Long64_t *l, Int_t n) final;
+   void WriteFastArray(const ULong64_t *l, Int_t n) final;
+   void WriteFastArray(const Float_t *f, Int_t n) final;
+   void WriteFastArray(const Double_t *d, Int_t n) final;
+   void WriteFastArrayString(const Char_t *c, Int_t n) final;
+   void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr) final;
+   Int_t WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                        TMemberStreamer *s = nullptr) final;
 
-   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = nullptr);
+   void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = nullptr) final;
    using TBufferText::StreamObject;
 
-   virtual void ReadBool(Bool_t &b);
-   virtual void ReadChar(Char_t &c);
-   virtual void ReadUChar(UChar_t &c);
-   virtual void ReadShort(Short_t &s);
-   virtual void ReadUShort(UShort_t &s);
-   virtual void ReadInt(Int_t &i);
-   virtual void ReadUInt(UInt_t &i);
-   virtual void ReadLong(Long_t &l);
-   virtual void ReadULong(ULong_t &l);
-   virtual void ReadLong64(Long64_t &l);
-   virtual void ReadULong64(ULong64_t &l);
-   virtual void ReadFloat(Float_t &f);
-   virtual void ReadDouble(Double_t &d);
-   virtual void ReadCharP(Char_t *c);
-   virtual void ReadTString(TString &s);
-   virtual void ReadStdString(std::string *s);
+   void ReadBool(Bool_t &b) final;
+   void ReadChar(Char_t &c) final;
+   void ReadUChar(UChar_t &c) final;
+   void ReadShort(Short_t &s) final;
+   void ReadUShort(UShort_t &s) final;
+   void ReadInt(Int_t &i) final;
+   void ReadUInt(UInt_t &i) final;
+   void ReadLong(Long_t &l) final;
+   void ReadULong(ULong_t &l) final;
+   void ReadLong64(Long64_t &l) final;
+   void ReadULong64(ULong64_t &l) final;
+   void ReadFloat(Float_t &f) final;
+   void ReadDouble(Double_t &d) final;
+   void ReadCharP(Char_t *c) final;
+   void ReadTString(TString &s) final;
+   void ReadStdString(std::string *s) final;
    using TBuffer::ReadStdString;
-   virtual void ReadCharStar(char *&s);
+   void ReadCharStar(char *&s) final;
 
-   virtual void WriteBool(Bool_t b);
-   virtual void WriteChar(Char_t c);
-   virtual void WriteUChar(UChar_t c);
-   virtual void WriteShort(Short_t s);
-   virtual void WriteUShort(UShort_t s);
-   virtual void WriteInt(Int_t i);
-   virtual void WriteUInt(UInt_t i);
-   virtual void WriteLong(Long_t l);
-   virtual void WriteULong(ULong_t l);
-   virtual void WriteLong64(Long64_t l);
-   virtual void WriteULong64(ULong64_t l);
-   virtual void WriteFloat(Float_t f);
-   virtual void WriteDouble(Double_t d);
-   virtual void WriteCharP(const Char_t *c);
-   virtual void WriteTString(const TString &s);
-   virtual void WriteStdString(const std::string *s);
+   void WriteBool(Bool_t b) final;
+   void WriteChar(Char_t c) final;
+   void WriteUChar(UChar_t c) final;
+   void WriteShort(Short_t s) final;
+   void WriteUShort(UShort_t s) final;
+   void WriteInt(Int_t i) final;
+   void WriteUInt(UInt_t i) final;
+   void WriteLong(Long_t l) final;
+   void WriteULong(ULong_t l) final;
+   void WriteLong64(Long64_t l) final;
+   void WriteULong64(ULong64_t l) final;
+   void WriteFloat(Float_t f) final;
+   void WriteDouble(Double_t d) final;
+   void WriteCharP(const Char_t *c) final;
+   void WriteTString(const TString &s) final;
+   void WriteStdString(const std::string *s) final;
    using TBuffer::WriteStdString;
-   virtual void WriteCharStar(char *s);
+   void WriteCharStar(char *s) final;
 
-   virtual TVirtualStreamerInfo *GetInfo();
+   TVirtualStreamerInfo *GetInfo() final;
 
    // end of redefined virtual functions
 
-   ClassDef(TBufferSQL2, 0); // a specialized TBuffer to convert data to SQL statements or read data from SQL tables
+   ClassDefOverride(TBufferSQL2, 0); // a specialized TBuffer to convert data to SQL statements or read data from SQL tables
 };
 
 #endif

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -30,7 +30,7 @@ class TMemberStreamer;
 class TXMLFile;
 class TXMLStackObj;
 
-class TBufferXML : public TBufferText, public TXMLSetup {
+class TBufferXML final : public TBufferText, public TXMLSetup {
 
    friend class TKeyXML;
 
@@ -67,153 +67,153 @@ public:
 
    // suppress class writing/reading
 
-   virtual TClass *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr);
-   virtual void WriteClass(const TClass *cl);
+   TClass *ReadClass(const TClass *cl = nullptr, UInt_t *objTag = nullptr) final;
+   void WriteClass(const TClass *cl) final;
 
    // redefined virtual functions of TBuffer
 
-   virtual Version_t ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr);
-   virtual UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE);
+   Version_t ReadVersion(UInt_t *start = nullptr, UInt_t *bcnt = nullptr, const TClass *cl = nullptr) final;
+   UInt_t WriteVersion(const TClass *cl, Bool_t useBcnt = kFALSE) final;
 
-   virtual void *ReadObjectAny(const TClass *clCast);
-   virtual void SkipObjectAny();
+   void *ReadObjectAny(const TClass *clCast) final;
+   void SkipObjectAny() final;
 
-   virtual void IncrementLevel(TVirtualStreamerInfo *);
-   virtual void SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type);
-   virtual void DecrementLevel(TVirtualStreamerInfo *);
+   void IncrementLevel(TVirtualStreamerInfo *) final;
+   void SetStreamerElementNumber(TStreamerElement *elem, Int_t comp_type) final;
+   void DecrementLevel(TVirtualStreamerInfo *) final;
 
-   virtual void ClassBegin(const TClass *, Version_t = -1);
-   virtual void ClassEnd(const TClass *);
-   virtual void ClassMember(const char *name, const char *typeName = nullptr, Int_t arrsize1 = -1, Int_t arrsize2 = -1);
+   void ClassBegin(const TClass *, Version_t = -1) final;
+   void ClassEnd(const TClass *) final;
+   void ClassMember(const char *name, const char *typeName = nullptr, Int_t arrsize1 = -1, Int_t arrsize2 = -1) final;
 
-   virtual Int_t ReadArray(Bool_t *&b);
-   virtual Int_t ReadArray(Char_t *&c);
-   virtual Int_t ReadArray(UChar_t *&c);
-   virtual Int_t ReadArray(Short_t *&h);
-   virtual Int_t ReadArray(UShort_t *&h);
-   virtual Int_t ReadArray(Int_t *&i);
-   virtual Int_t ReadArray(UInt_t *&i);
-   virtual Int_t ReadArray(Long_t *&l);
-   virtual Int_t ReadArray(ULong_t *&l);
-   virtual Int_t ReadArray(Long64_t *&l);
-   virtual Int_t ReadArray(ULong64_t *&l);
-   virtual Int_t ReadArray(Float_t *&f);
-   virtual Int_t ReadArray(Double_t *&d);
+   Int_t ReadArray(Bool_t *&b) final;
+   Int_t ReadArray(Char_t *&c) final;
+   Int_t ReadArray(UChar_t *&c) final;
+   Int_t ReadArray(Short_t *&h) final;
+   Int_t ReadArray(UShort_t *&h) final;
+   Int_t ReadArray(Int_t *&i) final;
+   Int_t ReadArray(UInt_t *&i) final;
+   Int_t ReadArray(Long_t *&l) final;
+   Int_t ReadArray(ULong_t *&l) final;
+   Int_t ReadArray(Long64_t *&l) final;
+   Int_t ReadArray(ULong64_t *&l) final;
+   Int_t ReadArray(Float_t *&f) final;
+   Int_t ReadArray(Double_t *&d) final;
 
-   virtual Int_t ReadStaticArray(Bool_t *b);
-   virtual Int_t ReadStaticArray(Char_t *c);
-   virtual Int_t ReadStaticArray(UChar_t *c);
-   virtual Int_t ReadStaticArray(Short_t *h);
-   virtual Int_t ReadStaticArray(UShort_t *h);
-   virtual Int_t ReadStaticArray(Int_t *i);
-   virtual Int_t ReadStaticArray(UInt_t *i);
-   virtual Int_t ReadStaticArray(Long_t *l);
-   virtual Int_t ReadStaticArray(ULong_t *l);
-   virtual Int_t ReadStaticArray(Long64_t *l);
-   virtual Int_t ReadStaticArray(ULong64_t *l);
-   virtual Int_t ReadStaticArray(Float_t *f);
-   virtual Int_t ReadStaticArray(Double_t *d);
+   Int_t ReadStaticArray(Bool_t *b) final;
+   Int_t ReadStaticArray(Char_t *c) final;
+   Int_t ReadStaticArray(UChar_t *c) final;
+   Int_t ReadStaticArray(Short_t *h) final;
+   Int_t ReadStaticArray(UShort_t *h) final;
+   Int_t ReadStaticArray(Int_t *i) final;
+   Int_t ReadStaticArray(UInt_t *i) final;
+   Int_t ReadStaticArray(Long_t *l) final;
+   Int_t ReadStaticArray(ULong_t *l) final;
+   Int_t ReadStaticArray(Long64_t *l) final;
+   Int_t ReadStaticArray(ULong64_t *l) final;
+   Int_t ReadStaticArray(Float_t *f) final;
+   Int_t ReadStaticArray(Double_t *d) final;
 
-   virtual void ReadFastArray(Bool_t *b, Int_t n);
-   virtual void ReadFastArray(Char_t *c, Int_t n);
-   virtual void ReadFastArray(UChar_t *c, Int_t n);
-   virtual void ReadFastArray(Short_t *h, Int_t n);
-   virtual void ReadFastArray(UShort_t *h, Int_t n);
-   virtual void ReadFastArray(Int_t *i, Int_t n);
-   virtual void ReadFastArray(UInt_t *i, Int_t n);
-   virtual void ReadFastArray(Long_t *l, Int_t n);
-   virtual void ReadFastArray(ULong_t *l, Int_t n);
-   virtual void ReadFastArray(Long64_t *l, Int_t n);
-   virtual void ReadFastArray(ULong64_t *l, Int_t n);
-   virtual void ReadFastArray(Float_t *f, Int_t n);
-   virtual void ReadFastArray(Double_t *d, Int_t n);
-   virtual void ReadFastArrayString(Char_t *c, Int_t n);
-   virtual void ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr,
-                              const TClass *onFileClass = nullptr);
-   virtual void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
-                              TMemberStreamer *s = nullptr, const TClass *onFileClass = nullptr);
+   void ReadFastArray(Bool_t *b, Int_t n) final;
+   void ReadFastArray(Char_t *c, Int_t n) final;
+   void ReadFastArray(UChar_t *c, Int_t n) final;
+   void ReadFastArray(Short_t *h, Int_t n) final;
+   void ReadFastArray(UShort_t *h, Int_t n) final;
+   void ReadFastArray(Int_t *i, Int_t n) final;
+   void ReadFastArray(UInt_t *i, Int_t n) final;
+   void ReadFastArray(Long_t *l, Int_t n) final;
+   void ReadFastArray(ULong_t *l, Int_t n) final;
+   void ReadFastArray(Long64_t *l, Int_t n) final;
+   void ReadFastArray(ULong64_t *l, Int_t n) final;
+   void ReadFastArray(Float_t *f, Int_t n) final;
+   void ReadFastArray(Double_t *d, Int_t n) final;
+   void ReadFastArrayString(Char_t *c, Int_t n) final;
+   void ReadFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr,
+                      const TClass *onFileClass = nullptr) final;
+   void ReadFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                      TMemberStreamer *s = nullptr, const TClass *onFileClass = nullptr) final;
 
-   virtual void WriteArray(const Bool_t *b, Int_t n);
-   virtual void WriteArray(const Char_t *c, Int_t n);
-   virtual void WriteArray(const UChar_t *c, Int_t n);
-   virtual void WriteArray(const Short_t *h, Int_t n);
-   virtual void WriteArray(const UShort_t *h, Int_t n);
-   virtual void WriteArray(const Int_t *i, Int_t n);
-   virtual void WriteArray(const UInt_t *i, Int_t n);
-   virtual void WriteArray(const Long_t *l, Int_t n);
-   virtual void WriteArray(const ULong_t *l, Int_t n);
-   virtual void WriteArray(const Long64_t *l, Int_t n);
-   virtual void WriteArray(const ULong64_t *l, Int_t n);
-   virtual void WriteArray(const Float_t *f, Int_t n);
-   virtual void WriteArray(const Double_t *d, Int_t n);
+   void WriteArray(const Bool_t *b, Int_t n) final;
+   void WriteArray(const Char_t *c, Int_t n) final;
+   void WriteArray(const UChar_t *c, Int_t n) final;
+   void WriteArray(const Short_t *h, Int_t n) final;
+   void WriteArray(const UShort_t *h, Int_t n) final;
+   void WriteArray(const Int_t *i, Int_t n) final;
+   void WriteArray(const UInt_t *i, Int_t n) final;
+   void WriteArray(const Long_t *l, Int_t n) final;
+   void WriteArray(const ULong_t *l, Int_t n) final;
+   void WriteArray(const Long64_t *l, Int_t n) final;
+   void WriteArray(const ULong64_t *l, Int_t n) final;
+   void WriteArray(const Float_t *f, Int_t n) final;
+   void WriteArray(const Double_t *d, Int_t n) final;
 
-   virtual void WriteFastArray(const Bool_t *b, Int_t n);
-   virtual void WriteFastArray(const Char_t *c, Int_t n);
-   virtual void WriteFastArray(const UChar_t *c, Int_t n);
-   virtual void WriteFastArray(const Short_t *h, Int_t n);
-   virtual void WriteFastArray(const UShort_t *h, Int_t n);
-   virtual void WriteFastArray(const Int_t *i, Int_t n);
-   virtual void WriteFastArray(const UInt_t *i, Int_t n);
-   virtual void WriteFastArray(const Long_t *l, Int_t n);
-   virtual void WriteFastArray(const ULong_t *l, Int_t n);
-   virtual void WriteFastArray(const Long64_t *l, Int_t n);
-   virtual void WriteFastArray(const ULong64_t *l, Int_t n);
-   virtual void WriteFastArray(const Float_t *f, Int_t n);
-   virtual void WriteFastArray(const Double_t *d, Int_t n);
-   virtual void WriteFastArrayString(const Char_t *c, Int_t n);
-   virtual void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr);
-   virtual Int_t WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
-                                TMemberStreamer *s = nullptr);
+   void WriteFastArray(const Bool_t *b, Int_t n) final;
+   void WriteFastArray(const Char_t *c, Int_t n) final;
+   void WriteFastArray(const UChar_t *c, Int_t n) final;
+   void WriteFastArray(const Short_t *h, Int_t n) final;
+   void WriteFastArray(const UShort_t *h, Int_t n) final;
+   void WriteFastArray(const Int_t *i, Int_t n) final;
+   void WriteFastArray(const UInt_t *i, Int_t n) final;
+   void WriteFastArray(const Long_t *l, Int_t n) final;
+   void WriteFastArray(const ULong_t *l, Int_t n) final;
+   void WriteFastArray(const Long64_t *l, Int_t n) final;
+   void WriteFastArray(const ULong64_t *l, Int_t n) final;
+   void WriteFastArray(const Float_t *f, Int_t n) final;
+   void WriteFastArray(const Double_t *d, Int_t n) final;
+   void WriteFastArrayString(const Char_t *c, Int_t n) final;
+   void WriteFastArray(void *start, const TClass *cl, Int_t n = 1, TMemberStreamer *s = nullptr) final;
+   Int_t WriteFastArray(void **startp, const TClass *cl, Int_t n = 1, Bool_t isPreAlloc = kFALSE,
+                        TMemberStreamer *s = nullptr) final;
 
-   virtual void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = nullptr);
+   void StreamObject(void *obj, const TClass *cl, const TClass *onFileClass = nullptr) final;
    using TBufferText::StreamObject;
 
-   virtual void ReadBool(Bool_t &b);
-   virtual void ReadChar(Char_t &c);
-   virtual void ReadUChar(UChar_t &c);
-   virtual void ReadShort(Short_t &s);
-   virtual void ReadUShort(UShort_t &s);
-   virtual void ReadInt(Int_t &i);
-   virtual void ReadUInt(UInt_t &i);
-   virtual void ReadLong(Long_t &l);
-   virtual void ReadULong(ULong_t &l);
-   virtual void ReadLong64(Long64_t &l);
-   virtual void ReadULong64(ULong64_t &l);
-   virtual void ReadFloat(Float_t &f);
-   virtual void ReadDouble(Double_t &d);
-   virtual void ReadCharP(Char_t *c);
-   virtual void ReadTString(TString &s);
-   virtual void ReadStdString(std::string *s);
+   void ReadBool(Bool_t &b) final;
+   void ReadChar(Char_t &c) final;
+   void ReadUChar(UChar_t &c) final;
+   void ReadShort(Short_t &s) final;
+   void ReadUShort(UShort_t &s) final;
+   void ReadInt(Int_t &i) final;
+   void ReadUInt(UInt_t &i) final;
+   void ReadLong(Long_t &l) final;
+   void ReadULong(ULong_t &l) final;
+   void ReadLong64(Long64_t &l) final;
+   void ReadULong64(ULong64_t &l) final;
+   void ReadFloat(Float_t &f) final;
+   void ReadDouble(Double_t &d) final;
+   void ReadCharP(Char_t *c) final;
+   void ReadTString(TString &s) final;
+   void ReadStdString(std::string *s) final;
    using TBuffer::ReadStdString;
-   virtual void ReadCharStar(char *&s);
+   void ReadCharStar(char *&s) final;
 
-   virtual void WriteBool(Bool_t b);
-   virtual void WriteChar(Char_t c);
-   virtual void WriteUChar(UChar_t c);
-   virtual void WriteShort(Short_t s);
-   virtual void WriteUShort(UShort_t s);
-   virtual void WriteInt(Int_t i);
-   virtual void WriteUInt(UInt_t i);
-   virtual void WriteLong(Long_t l);
-   virtual void WriteULong(ULong_t l);
-   virtual void WriteLong64(Long64_t l);
-   virtual void WriteULong64(ULong64_t l);
-   virtual void WriteFloat(Float_t f);
-   virtual void WriteDouble(Double_t d);
-   virtual void WriteCharP(const Char_t *c);
-   virtual void WriteTString(const TString &s);
-   virtual void WriteStdString(const std::string *s);
+   void WriteBool(Bool_t b) final;
+   void WriteChar(Char_t c) final;
+   void WriteUChar(UChar_t c) final;
+   void WriteShort(Short_t s) final;
+   void WriteUShort(UShort_t s) final;
+   void WriteInt(Int_t i) final;
+   void WriteUInt(UInt_t i) final;
+   void WriteLong(Long_t l) final;
+   void WriteULong(ULong_t l) final;
+   void WriteLong64(Long64_t l) final;
+   void WriteULong64(ULong64_t l) final;
+   void WriteFloat(Float_t f) final;
+   void WriteDouble(Double_t d) final;
+   void WriteCharP(const Char_t *c) final;
+   void WriteTString(const TString &s) final;
+   void WriteStdString(const std::string *s) final;
    using TBuffer::WriteStdString;
-   virtual void WriteCharStar(char *s);
+   void WriteCharStar(char *s) final;
 
-   virtual TVirtualStreamerInfo *GetInfo();
+   TVirtualStreamerInfo *GetInfo() final;
 
 protected:
    TBufferXML();
 
    // redefined protected virtual functions
 
-   virtual void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse);
+   void WriteObjectClass(const void *actualObjStart, const TClass *actualClass, Bool_t cacheReuse) final;
 
    // end redefined protected virtual functions
 

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -15,11 +15,8 @@
 #include "Compression.h"
 #include "TBufferText.h"
 #include "TXMLSetup.h"
-#include "TXMLEngine.h"
 #include "TString.h"
-#include "TObjArray.h"
-#include "TArrayC.h"
-#include "TClonesArray.h"
+#include "TXMLEngine.h"
 
 #include <string>
 #include <deque>

--- a/net/net/inc/TMessage.h
+++ b/net/net/inc/TMessage.h
@@ -39,15 +39,15 @@ friend class TPSocket;
 friend class TXSocket;
 
 private:
-   TList   *fInfos;       //List of TStreamerInfo used in WriteObject
-   TBits    fBitsPIDs;    //Array of bits to mark the TProcessIDs uids written to the message
-   UInt_t   fWhat;        //Message type
-   TClass  *fClass;       //If message is kMESS_OBJECT pointer to object's class
-   Int_t    fCompress;    //Compression level and algorithm
-   char    *fBufComp;     //Compressed buffer
-   char    *fBufCompCur;  //Current position in compressed buffer
-   char    *fCompPos;     //Position of fBufCur when message was compressed
-   Bool_t   fEvolution;   //True if support for schema evolution required
+   TList *fInfos{nullptr};     // List of TStreamerInfo used in WriteObject
+   TBits fBitsPIDs;            // Array of bits to mark the TProcessIDs uids written to the message
+   UInt_t fWhat{0};            // Message type
+   TClass *fClass{nullptr};    // If message is kMESS_OBJECT pointer to object's class
+   Int_t fCompress{0};         // Compression level and algorithm
+   char *fBufComp{nullptr};    // Compressed buffer
+   char *fBufCompCur{nullptr}; // Current position in compressed buffer
+   char *fCompPos{nullptr};    // Position of fBufCur when message was compressed
+   Bool_t fEvolution{kFALSE};  // True if support for schema evolution required
 
    static Bool_t fgEvolution;  //True if global support for schema evolution required
 
@@ -66,11 +66,11 @@ public:
    TMessage(UInt_t what = kMESS_ANY, Int_t bufsiz = TBuffer::kInitialSize);
    virtual ~TMessage();
 
-   void     ForceWriteInfo(TVirtualStreamerInfo *info, Bool_t force);
+   void     ForceWriteInfo(TVirtualStreamerInfo *info, Bool_t force) override;
    void     Forward();
    TClass  *GetClass() const { return fClass;}
-   void     TagStreamerInfo(TVirtualStreamerInfo* info);
-   void     Reset();
+   void     TagStreamerInfo(TVirtualStreamerInfo* info) override;
+   void     Reset() override;
    void     Reset(UInt_t what) { SetWhat(what); Reset(); }
    UInt_t   What() const { return fWhat; }
    void     SetWhat(UInt_t what);
@@ -88,12 +88,12 @@ public:
    Int_t    Uncompress();
    char    *CompBuffer() const { return fBufComp; }
    Int_t    CompLength() const { return (Int_t)(fBufCompCur - fBufComp); }
-   UShort_t WriteProcessID(TProcessID *pid);
+   UShort_t WriteProcessID(TProcessID *pid) override;
 
    static void   EnableSchemaEvolutionForAll(Bool_t enable = kTRUE);
    static Bool_t UsesSchemaEvolutionForAll();
 
-   ClassDef(TMessage,0)  // Message buffer class
+   ClassDefOverride(TMessage,0)  // Message buffer class
 };
 
 //______________________________________________________________________________

--- a/net/net/inc/TMessage.h
+++ b/net/net/inc/TMessage.h
@@ -39,15 +39,15 @@ friend class TPSocket;
 friend class TXSocket;
 
 private:
-   TList *fInfos{nullptr};     // List of TStreamerInfo used in WriteObject
-   TBits fBitsPIDs;            // Array of bits to mark the TProcessIDs uids written to the message
-   UInt_t fWhat{0};            // Message type
-   TClass *fClass{nullptr};    // If message is kMESS_OBJECT pointer to object's class
-   Int_t fCompress{0};         // Compression level and algorithm
-   char *fBufComp{nullptr};    // Compressed buffer
-   char *fBufCompCur{nullptr}; // Current position in compressed buffer
-   char *fCompPos{nullptr};    // Position of fBufCur when message was compressed
-   Bool_t fEvolution{kFALSE};  // True if support for schema evolution required
+   TList   *fInfos{nullptr};      // List of TStreamerInfo used in WriteObject
+   TBits    fBitsPIDs;            // Array of bits to mark the TProcessIDs uids written to the message
+   UInt_t   fWhat{0};             // Message type
+   TClass  *fClass{nullptr};      // If message is kMESS_OBJECT pointer to object's class
+   Int_t    fCompress{0};         // Compression level and algorithm
+   char    *fBufComp{nullptr};    // Compressed buffer
+   char    *fBufCompCur{nullptr}; // Current position in compressed buffer
+   char    *fCompPos{nullptr};    // Position of fBufCur when message was compressed
+   Bool_t   fEvolution{kFALSE};   // True if support for schema evolution required
 
    static Bool_t fgEvolution;  //True if global support for schema evolution required
 

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -22,8 +22,8 @@
 #include "TMessage.h"
 #include "Compression.h"
 #include "TVirtualStreamerInfo.h"
+#include "TList.h"
 #include "Bytes.h"
-#include "TFile.h"
 #include "TProcessID.h"
 #include "RZip.h"
 
@@ -34,11 +34,11 @@ ClassImp(TMessage);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a TMessage object for storing objects. The "what" integer
-/// describes the type of message. Predifined ROOT system message types
+/// describes the type of message. Predefined ROOT system message types
 /// can be found in MessageTypes.h. Make sure your own message types are
 /// unique from the ROOT defined message types (i.e. 0 - 10000 are
 /// reserved by ROOT). In case you OR "what" with kMESS_ACK, the message
-/// will wait for an acknowledgement from the remote side. This makes
+/// will wait for an acknowledgment from the remote side. This makes
 /// the sending process synchronous. In case you OR "what" with kMESS_ZIP,
 /// the message will be compressed in TSocket using the zip algorithm
 /// (only if message is > 256 bytes).
@@ -101,7 +101,7 @@ TMessage::TMessage(void *buf, Int_t bufsize) : TBufferFile(TBuffer::kRead, bufsi
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Clean up compression buffer.
+/// Destructor
 
 TMessage::~TMessage()
 {
@@ -164,6 +164,7 @@ void TMessage::Forward()
 /// relevant TClass in case the TClass does not know yet about a particular
 /// class version. This feature is implemented to support clients and servers
 /// with either different ROOT versions or different user classes versions.
+
 void TMessage::TagStreamerInfo(TVirtualStreamerInfo *info)
 {
    if (fgEvolution || fEvolution) {
@@ -212,9 +213,9 @@ void TMessage::SetLength() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Using this method one can change the message type a-posteriory.
+/// Using this method one can change the message type a-posteriori
 /// In case you OR "what" with kMESS_ACK, the message will wait for
-/// an acknowledgement from the remote side. This makes the sending
+/// an acknowledgment from the remote side. This makes the sending
 /// process synchronous.
 
 void TMessage::SetWhat(UInt_t what)
@@ -233,6 +234,7 @@ void TMessage::SetWhat(UInt_t what)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Set compression algorithm
 
 void TMessage::SetCompressionAlgorithm(Int_t algorithm)
 {
@@ -254,6 +256,7 @@ void TMessage::SetCompressionAlgorithm(Int_t algorithm)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Set compression level
 
 void TMessage::SetCompressionLevel(Int_t level)
 {
@@ -277,6 +280,7 @@ void TMessage::SetCompressionLevel(Int_t level)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Set compression settings
 
 void TMessage::SetCompressionSettings(Int_t settings)
 {

--- a/net/net/src/TMessage.cxx
+++ b/net/net/src/TMessage.cxx
@@ -54,11 +54,11 @@ TMessage::TMessage(UInt_t what, Int_t bufsiz) :
    fWhat  = what;
    *this << what;
 
-   fClass      = 0;
-   fBufComp    = 0;
-   fBufCompCur = 0;
-   fCompPos    = 0;
-   fInfos      = 0;
+   fClass      = nullptr;
+   fBufComp    = nullptr;
+   fBufCompCur = nullptr;
+   fCompPos    = nullptr;
+   fInfos      = nullptr;
    fEvolution  = kFALSE;
 
    SetBit(kCannotHandleMemberWiseStreaming);
@@ -76,17 +76,17 @@ TMessage::TMessage(void *buf, Int_t bufsize) : TBufferFile(TBuffer::kRead, bufsi
 
    *this >> fWhat;
 
-   fBufComp    = 0;
-   fBufCompCur = 0;
-   fCompPos    = 0;
-   fInfos      = 0;
+   fBufComp    = nullptr;
+   fBufCompCur = nullptr;
+   fCompPos    = nullptr;
+   fInfos      = nullptr;
    fEvolution  = kFALSE;
 
    if (fWhat & kMESS_ZIP) {
       // if buffer has kMESS_ZIP set, move it to fBufComp and uncompress
       fBufComp    = fBuffer;
       fBufCompCur = fBuffer + bufsize;
-      fBuffer     = 0;
+      fBuffer     = nullptr;
       Uncompress();
    }
 
@@ -96,7 +96,7 @@ TMessage::TMessage(void *buf, Int_t bufsize) : TBufferFile(TBuffer::kRead, bufsi
       SetBufferOffset(sizeof(UInt_t) + sizeof(fWhat));
       ResetMap();
    } else {
-      fClass = 0;
+      fClass = nullptr;
    }
 }
 
@@ -182,9 +182,9 @@ void TMessage::Reset()
 
    if (fBufComp) {
       delete [] fBufComp;
-      fBufComp    = 0;
-      fBufCompCur = 0;
-      fCompPos    = 0;
+      fBufComp    = nullptr;
+      fBufCompCur = nullptr;
+      fCompPos    = nullptr;
    }
 
    if (fgEvolution || fEvolution) {
@@ -246,9 +246,9 @@ void TMessage::SetCompressionAlgorithm(Int_t algorithm)
    }
    if (newCompress != fCompress && fBufComp) {
       delete [] fBufComp;
-      fBufComp    = 0;
-      fBufCompCur = 0;
-      fCompPos    = 0;
+      fBufComp    = nullptr;
+      fBufCompCur = nullptr;
+      fCompPos    = nullptr;
    }
    fCompress = newCompress;
 }
@@ -269,9 +269,9 @@ void TMessage::SetCompressionLevel(Int_t level)
    }
    if (newCompress != fCompress && fBufComp) {
       delete [] fBufComp;
-      fBufComp    = 0;
-      fBufCompCur = 0;
-      fCompPos    = 0;
+      fBufComp    = nullptr;
+      fBufCompCur = nullptr;
+      fCompPos    = nullptr;
    }
    fCompress = newCompress;
 }
@@ -282,9 +282,9 @@ void TMessage::SetCompressionSettings(Int_t settings)
 {
    if (settings != fCompress && fBufComp) {
       delete [] fBufComp;
-      fBufComp    = 0;
-      fBufCompCur = 0;
-      fCompPos    = 0;
+      fBufComp    = nullptr;
+      fBufCompCur = nullptr;
+      fCompPos    = nullptr;
    }
    fCompress = settings;
 }
@@ -304,9 +304,9 @@ Int_t TMessage::Compress()
       // no compression specified
       if (fBufComp) {
          delete [] fBufComp;
-         fBufComp    = 0;
-         fBufCompCur = 0;
-         fCompPos    = 0;
+         fBufComp    = nullptr;
+         fBufCompCur = nullptr;
+         fCompPos    = nullptr;
       }
       return 0;
    }
@@ -319,9 +319,9 @@ Int_t TMessage::Compress()
    // remove any existing compressed buffer before compressing modified message
    if (fBufComp) {
       delete [] fBufComp;
-      fBufComp    = 0;
-      fBufCompCur = 0;
-      fCompPos    = 0;
+      fBufComp    = nullptr;
+      fBufCompCur = nullptr;
+      fCompPos    = nullptr;
    }
 
    if (Length() <= (Int_t)(256 + 2*sizeof(UInt_t))) {
@@ -350,9 +350,9 @@ Int_t TMessage::Compress()
       if (nout == 0 || nout >= messlen) {
          //this happens when the buffer cannot be compressed
          delete [] fBufComp;
-         fBufComp    = 0;
-         fBufCompCur = 0;
-         fCompPos    = 0;
+         fBufComp    = nullptr;
+         fBufCompCur = nullptr;
+         fCompPos    = nullptr;
          return -1;
       }
       bufcur  += nout;

--- a/tree/tree/inc/TBufferSQL.h
+++ b/tree/tree/inc/TBufferSQL.h
@@ -21,20 +21,17 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "TBufferFile.h"
-#include "TString.h"
 
-
-class TSQLResult;
 class TSQLRow;
 
-class TBufferSQL : public TBufferFile {
+class TBufferSQL final : public TBufferFile {
 
 private:
    std::vector<Int_t>::const_iterator fIter;
 
-   std::vector<Int_t>  *fColumnVec;   //!
-   TString             *fInsertQuery; //!
-   TSQLRow            **fRowPtr;      //!
+   std::vector<Int_t>  *fColumnVec{nullptr};   //!
+   TString             *fInsertQuery{nullptr}; //!
+   TSQLRow            **fRowPtr{nullptr};      //!
 
    // TBuffer objects cannot be copied or assigned
    TBufferSQL(const TBufferSQL &);        // not implemented
@@ -49,85 +46,85 @@ public:
 
    void ResetOffset();
 
-   virtual   void     ReadBool(Bool_t       &b);
-   virtual   void     ReadChar(Char_t       &c);
-   virtual   void     ReadUChar(UChar_t     &c);
-   virtual   void     ReadShort(Short_t     &s);
-   virtual   void     ReadUShort(UShort_t   &s);
-   virtual   void     ReadInt(Int_t         &i);
-   virtual   void     ReadUInt(UInt_t       &i);
-   virtual   void     ReadLong(Long_t       &l);
-   virtual   void     ReadULong(ULong_t     &l);
-   virtual   void     ReadLong64(Long64_t   &l);
-   virtual   void     ReadULong64(ULong64_t &l);
-   virtual   void     ReadFloat(Float_t     &f);
-   virtual   void     ReadDouble(Double_t   &d);
-   virtual   void     ReadCharP(Char_t      *c);
-   virtual   void     ReadTString(TString   &s);
-   virtual   void     ReadStdString(std::string *s);
-   using              TBuffer::ReadStdString;
-   virtual   void     ReadCharStar(char* &s);
+   void     ReadBool(Bool_t       &b) final;
+   void     ReadChar(Char_t       &c) final;
+   void     ReadUChar(UChar_t     &c) final;
+   void     ReadShort(Short_t     &s) final;
+   void     ReadUShort(UShort_t   &s) final;
+   void     ReadInt(Int_t         &i) final;
+   void     ReadUInt(UInt_t       &i) final;
+   void     ReadLong(Long_t       &l) final;
+   void     ReadULong(ULong_t     &l) final;
+   void     ReadLong64(Long64_t   &l) final;
+   void     ReadULong64(ULong64_t &l) final;
+   void     ReadFloat(Float_t     &f) final;
+   void     ReadDouble(Double_t   &d) final;
+   void     ReadCharP(Char_t      *c) final;
+   void     ReadTString(TString   &s) final;
+   void     ReadStdString(std::string *s) final;
+   using    TBuffer::ReadStdString;
+   void     ReadCharStar(char* &s) final;
 
-   virtual   void     WriteBool(Bool_t       b);
-   virtual   void     WriteChar(Char_t       c);
-   virtual   void     WriteUChar(UChar_t     c);
-   virtual   void     WriteShort(Short_t     s);
-   virtual   void     WriteUShort(UShort_t   s);
-   virtual   void     WriteInt(Int_t         i);
-   virtual   void     WriteUInt(UInt_t       i);
-   virtual   void     WriteLong(Long_t       l);
-   virtual   void     WriteULong(ULong_t     l);
-   virtual   void     WriteLong64(Long64_t   l);
-   virtual   void     WriteULong64(ULong64_t l);
-   virtual   void     WriteFloat(Float_t     f);
-   virtual   void     WriteDouble(Double_t   d);
-   virtual   void     WriteCharP(const Char_t *c);
-   virtual   void     WriteTString(const TString  &s);
-   virtual   void     WriteStdString(const std::string *s);
-   using              TBuffer::WriteStdString;
-   virtual   void     WriteCharStar(char *s);
+   void     WriteBool(Bool_t       b) final;
+   void     WriteChar(Char_t       c) final;
+   void     WriteUChar(UChar_t     c) final;
+   void     WriteShort(Short_t     s) final;
+   void     WriteUShort(UShort_t   s) final;
+   void     WriteInt(Int_t         i) final;
+   void     WriteUInt(UInt_t       i) final;
+   void     WriteLong(Long_t       l) final;
+   void     WriteULong(ULong_t     l) final;
+   void     WriteLong64(Long64_t   l) final;
+   void     WriteULong64(ULong64_t l) final;
+   void     WriteFloat(Float_t     f) final;
+   void     WriteDouble(Double_t   d) final;
+   void     WriteCharP(const Char_t *c) final;
+   void     WriteTString(const TString  &s) final;
+   void     WriteStdString(const std::string *s) final;
+   using    TBuffer::WriteStdString;
+   void     WriteCharStar(char *s) final;
 
-   virtual   void     WriteFastArray(const Bool_t    *b, Int_t n);
-   virtual   void     WriteFastArray(const Char_t    *c, Int_t n);
-   virtual   void     WriteFastArrayString(const Char_t   *c, Int_t n);
-   virtual   void     WriteFastArray(const UChar_t   *c, Int_t n);
-   virtual   void     WriteFastArray(const Short_t   *h, Int_t n);
-   virtual   void     WriteFastArray(const UShort_t  *h, Int_t n);
-   virtual   void     WriteFastArray(const Int_t     *i, Int_t n);
-   virtual   void     WriteFastArray(const UInt_t    *i, Int_t n);
-   virtual   void     WriteFastArray(const Long_t    *l, Int_t n);
-   virtual   void     WriteFastArray(const ULong_t   *l, Int_t n);
-   virtual   void     WriteFastArray(const Long64_t  *l, Int_t n);
-   virtual   void     WriteFastArray(const ULong64_t *l, Int_t n);
-   virtual   void     WriteFastArray(const Float_t   *f, Int_t n);
-   virtual   void     WriteFastArray(const Double_t  *d, Int_t n);
-   virtual   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=0);
-   virtual   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0);
+   void     WriteFastArray(const Bool_t    *b, Int_t n) final;
+   void     WriteFastArray(const Char_t    *c, Int_t n) final;
+   void     WriteFastArrayString(const Char_t   *c, Int_t n) final;
+   void     WriteFastArray(const UChar_t   *c, Int_t n) final;
+   void     WriteFastArray(const Short_t   *h, Int_t n) final;
+   void     WriteFastArray(const UShort_t  *h, Int_t n) final;
+   void     WriteFastArray(const Int_t     *i, Int_t n) final;
+   void     WriteFastArray(const UInt_t    *i, Int_t n) final;
+   void     WriteFastArray(const Long_t    *l, Int_t n) final;
+   void     WriteFastArray(const ULong_t   *l, Int_t n) final;
+   void     WriteFastArray(const Long64_t  *l, Int_t n) final;
+   void     WriteFastArray(const ULong64_t *l, Int_t n) final;
+   void     WriteFastArray(const Float_t   *f, Int_t n) final;
+   void     WriteFastArray(const Double_t  *d, Int_t n) final;
+   void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=nullptr) final;
+   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr) final;
 
-   virtual   void     ReadFastArray(Bool_t    *, Int_t );
-   virtual   void     ReadFastArray(Char_t    *, Int_t );
-   virtual   void     ReadFastArrayString(Char_t   *, Int_t );
-   virtual   void     ReadFastArray(UChar_t   *, Int_t );
-   virtual   void     ReadFastArray(Short_t   *, Int_t );
-   virtual   void     ReadFastArray(UShort_t  *, Int_t );
-   virtual   void     ReadFastArray(Int_t     *, Int_t );
-   virtual   void     ReadFastArray(UInt_t    *, Int_t );
-   virtual   void     ReadFastArray(Long_t    *, Int_t );
-   virtual   void     ReadFastArray(ULong_t   *, Int_t );
-   virtual   void     ReadFastArray(Long64_t  *, Int_t );
-   virtual   void     ReadFastArray(ULong64_t *, Int_t );
-   virtual   void     ReadFastArray(Float_t   *, Int_t );
-   virtual   void     ReadFastArray(Double_t  *, Int_t );
-   virtual   void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=0);
-   virtual   void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=0);
-   virtual   void     ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue) ;
-   virtual   void     ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits);
-   virtual   void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue);
-   virtual   void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits) ;
-   virtual   void     ReadFastArray(void  *, const TClass *, Int_t n=1, TMemberStreamer *s=0, const TClass *onFileClass=0);
-   virtual   void     ReadFastArray(void **, const TClass *, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0, const TClass *onFileClass=0);
+   void     ReadFastArray(Bool_t    *, Int_t ) final;
+   void     ReadFastArray(Char_t    *, Int_t ) final;
+   void     ReadFastArrayString(Char_t   *, Int_t ) final;
+   void     ReadFastArray(UChar_t   *, Int_t ) final;
+   void     ReadFastArray(Short_t   *, Int_t ) final;
+   void     ReadFastArray(UShort_t  *, Int_t ) final;
+   void     ReadFastArray(Int_t     *, Int_t ) final;
+   void     ReadFastArray(UInt_t    *, Int_t ) final;
+   void     ReadFastArray(Long_t    *, Int_t ) final;
+   void     ReadFastArray(ULong_t   *, Int_t ) final;
+   void     ReadFastArray(Long64_t  *, Int_t ) final;
+   void     ReadFastArray(ULong64_t *, Int_t ) final;
+   void     ReadFastArray(Float_t   *, Int_t ) final;
+   void     ReadFastArray(Double_t  *, Int_t ) final;
+   void     ReadFastArrayFloat16(Float_t  *f, Int_t n, TStreamerElement *ele=nullptr) final;
+   void     ReadFastArrayDouble32(Double_t  *d, Int_t n, TStreamerElement *ele=nullptr) final;
+   void     ReadFastArrayWithFactor(Float_t *ptr, Int_t n, Double_t factor, Double_t minvalue)  final;
+   void     ReadFastArrayWithNbits(Float_t *ptr, Int_t n, Int_t nbits) final;
+   void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue) final;
+   void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits)  final;
+   void     ReadFastArray(void  *, const TClass *, Int_t n=1, TMemberStreamer *s=nullptr, const TClass *onFileClass=nullptr) final;
+   void     ReadFastArray(void **, const TClass *, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr, const TClass *onFileClass=nullptr) final;
 
-   ClassDef(TBufferSQL, 0); // Implementation of TBuffer to load and write to a SQL database
+   ClassDefOverride(TBufferSQL, 0); // Implementation of TBuffer to load and write to a SQL database
 
 };
 


### PR DESCRIPTION
While TBuffer has many virtual methods, provide `override` and `final` specifiers for all derived classes. This will help to maintain code in the future - any bogus changes in TBuffer class interface will be reported already during compilation.