### PR TITLE
[Cling] Improve help message for .x, allow macros with main.

### DIFF
--- a/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
@@ -151,8 +151,8 @@ namespace cling {
 
       if (expression.empty()) {
         using namespace clang;
-        const char msg[] = "Failed to call `%0%1` to execute the macro."
-            " Add this function or rename the macro. Falling back to `.L`.";
+        const char msg[] = "Failed to call `%0%1` to execute the macro.\n"
+            "Add this function or rename the macro. Falling back to `.L`.";
 
         DiagnosticsEngine& Diags = m_Interpreter.getDiagnostics();
         unsigned diagID = Diags.getCustomDiagID(DiagnosticsEngine::Level::Warning, msg);

--- a/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
@@ -137,7 +137,7 @@ namespace cling {
         if (T->containsNamedDecl(FuncName)) {
           expression = FuncName + args.str();
           // Give the user some context in case we have a problem invoking
-          expression += " /* invoking function corresponding to '.x' */";
+          expression += " /* '.x' tries to invoke a function with the same name as the macro */";
 
           // Above transaction might have set a different OptLevel; use that.
           int prevOptLevel = m_Interpreter.getDefaultOptLevel();
@@ -151,13 +151,14 @@ namespace cling {
 
       if (expression.empty()) {
         using namespace clang;
+        const char msg[] = "Failed to call `%0%1` to execute the macro."
+            " Add this function or rename the macro. Falling back to `.L`.";
+
         DiagnosticsEngine& Diags = m_Interpreter.getDiagnostics();
-        unsigned diagID
-          = Diags.getCustomDiagID (DiagnosticsEngine::Level::Warning,
-                                   "cannot find function '%0()'; falling back to .L");
+        unsigned diagID = Diags.getCustomDiagID(DiagnosticsEngine::Level::Warning, msg);
         //FIXME: Figure out how to pass in proper source locations, which we can
         // use with -verify.
-        Diags.Report(SourceLocation(), diagID) << FuncName;
+        Diags.Report(SourceLocation(), diagID) << FuncName << args.str();
         return AR_Success;
       }
     }

--- a/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
@@ -151,7 +151,7 @@ namespace cling {
 
       if (expression.empty()) {
         using namespace clang;
-        const char msg[] = "Failed to call `%0%1` to execute the macro.\n"
+        static const char msg[] = "Failed to call `%0%1` to execute the macro.\n"
             "Add this function or rename the macro. Falling back to `.L`.";
 
         DiagnosticsEngine& Diags = m_Interpreter.getDiagnostics();


### PR DESCRIPTION
- When trying to execute a macro with .x and the corresponding function is
not found, a more informative warning is issued.
- Further, the interpreter can now fall back to main() if defined.

In local tests, I didn't manage to trigger a clash with the "real" main. I tried to define both
- `int main()` and
- `int main(int argc, char** argv)`,
but it just compiles and does the right thing (either it calls with the correct parameters or it complains that the parameters don't match).
