### PR TITLE
[PyROOT] Set correct type for enum values in namespaces

### DIFF
--- a/bindings/pyroot/src/PropertyProxy.cxx
+++ b/bindings/pyroot/src/PropertyProxy.cxx
@@ -216,11 +216,14 @@ void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t id
 
 void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, const std::string& name, void* address )
 {
+   Cppyy::TCppIndex_t idata = Cppyy::GetDatamemberIndex(scope, name);
+   std::string cppType = Cppyy::ResolveEnum(Cppyy::GetDatamemberType(scope, idata));
+
    fEnclosingScope = scope;
    fName           = name;
    fOffset         = (ptrdiff_t)address;
    fProperty       = (kIsStaticData | kIsConstData | kIsEnumData /* true, but may chance */ );
-   fConverter      = CreateConverter( "UInt_t", -1 );
+   fConverter      = CreateConverter( cppType, -1 );
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/bindings/pyroot/src/RootWrapper.cxx
+++ b/bindings/pyroot/src/RootWrapper.cxx
@@ -362,6 +362,8 @@ static int BuildScopeProxyDict( Cppyy::TCppScope_t scope, PyObject* pyclass ) {
    TEnum* e = 0;
    while ( (e = (TEnum*)ienum.Next()) ) {
       const TSeqCollection* seq = e->GetConstants();
+      auto isScoped = e->Property() & kIsScopedEnum;
+      if (isScoped) continue; // scoped enum: do not add constants as properties of the enum's scope
       for ( Int_t i = 0; i < seq->GetSize(); i++ ) {
          TEnumConstant* ec = (TEnumConstant*)seq->At( i );
          AddPropertyToClass( pyclass, scope, ec->GetName(), ec->GetAddress() );


### PR DESCRIPTION
This PR completes the fix provided for ROOT-8935 with another fix for ROOT-10279, by preventing
the injection of the constants of a scoped enum into the scope of the enum. The bug surfaced as a result of modifying `PropertyProxy::Set` to fix ROOT-9835.

There is still a pending issue identified while testing the fixes above: when a scoped enum belongs to the global namespace, once we do a lookup of that scoped enum its constants are added to the global space too and can be accessed as `ROOT.constant_name`, which is wrong. A subsequent PR will fix this issue.