### PR TITLE
[ntuple] Simplifications for concrete page storage classes

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -88,7 +88,7 @@ public:
       std::string_view fieldName,
       std::unique_ptr<RNTupleModel> collectionModel);
 
-   RFieldRoot* GetRootField() { return fRootField.get(); }
+   RFieldRoot *GetRootField() const { return fRootField.get(); }
    REntry* GetDefaultEntry() { return fDefaultEntry.get(); }
    std::unique_ptr<REntry> CreateEntry();
    RNTupleVersion GetVersion() const { return RNTupleVersion(); }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -147,6 +147,11 @@ mapped into memory. The page source also gives access to the ntuple's meta-data.
 */
 // clang-format on
 class RPageSource : public RPageStorage {
+protected:
+   RNTupleDescriptor fDescriptor;
+
+   virtual RNTupleDescriptor DoAttach() = 0;
+
 public:
    explicit RPageSource(std::string_view ntupleName);
    virtual ~RPageSource();
@@ -154,14 +159,14 @@ public:
    virtual std::unique_ptr<RPageSource> Clone() const = 0;
 
    EPageStorageType GetType() final { return EPageStorageType::kSource; }
+   const RNTupleDescriptor &GetDescriptor() const { return fDescriptor; }
+   ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
 
    /// Open the physical storage container for the tree
-   virtual void Attach() = 0;
-
-   virtual NTupleSize_t GetNEntries() = 0;
-   virtual NTupleSize_t GetNElements(ColumnHandle_t columnHandle) = 0;
-   virtual ColumnId_t GetColumnId(ColumnHandle_t columnHandle) = 0;
-   virtual const RNTupleDescriptor& GetDescriptor() const = 0;
+   void Attach() { fDescriptor = DoAttach(); }
+   NTupleSize_t GetNEntries();
+   NTupleSize_t GetNElements(ColumnHandle_t columnHandle);
+   ColumnId_t GetColumnId(ColumnHandle_t columnHandle);
 
    /// Allocates and fills a page that contains the index-th element
    virtual RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -76,29 +76,19 @@ private:
    TDirectory *fDirectory;
    RSettings fSettings;
 
-   /// Field, column, cluster ids and page indexes per cluster are issued sequentially starting with 0
-   DescriptorId_t fLastFieldId = 0;
-   DescriptorId_t fLastColumnId = 0;
-   DescriptorId_t fLastClusterId = 0;
+   /// Instead of a physical file offset, pages in root are identified by an index which becomes part of the key
    DescriptorId_t fLastPageIdx = 0;
-   NTupleSize_t fPrevClusterNEntries = 0;
-   RNTupleDescriptorBuilder fDescriptorBuilder;
 
-   /// Keeps track of the number of elements in the currently open cluster. Indexed by column id.
-   std::vector<RClusterDescriptor::RColumnRange> fOpenColumnRanges;
-   /// Keeps track of the written pages in the currently open cluster. Indexed by column id.
-   std::vector<RClusterDescriptor::RPageRange> fOpenPageRanges;
+protected:
+   void DoCreate(const RNTupleModel &model) final;
+   RClusterDescriptor::RLocator DoCommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
+   void DoCommitCluster(NTupleSize_t nEntries) final;
+   void DoCommitDataset() final;
 
 public:
    RPageSinkRoot(std::string_view ntupleName, RSettings settings);
    RPageSinkRoot(std::string_view ntupleName, std::string_view path);
    virtual ~RPageSinkRoot();
-
-   ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
-   void Create(RNTupleModel &model) final;
-   void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
-   void CommitCluster(NTupleSize_t nEntries) final;
-   void CommitDataset() final;
 
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) final;
    void ReleasePage(RPage &page) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -131,23 +131,17 @@ private:
    TDirectory *fDirectory;
    RSettings fSettings;
 
-   RNTupleDescriptor fDescriptor;
+   RPage PopulatePageFromCluster(ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor,
+                                 ClusterSize_t::ValueType clusterIndex);
 
-   RPage DoPopulatePage(ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor,
-                        ClusterSize_t::ValueType clusterIndex);
+protected:
+   RNTupleDescriptor DoAttach() final;
 
 public:
    RPageSourceRoot(std::string_view ntupleName, RSettings settings);
    RPageSourceRoot(std::string_view ntupleName, std::string_view path);
    std::unique_ptr<RPageSource> Clone() const final;
    virtual ~RPageSourceRoot();
-
-   ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
-   void Attach() final;
-   NTupleSize_t GetNEntries() final;
-   NTupleSize_t GetNElements(ColumnHandle_t columnHandle) final;
-   ColumnId_t GetColumnId(ColumnHandle_t columnHandle) final;
-   const RNTupleDescriptor& GetDescriptor() const final { return fDescriptor; }
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
    RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -43,7 +43,7 @@ ROOT::Experimental::Detail::RNTuple::~RNTuple()
 void ROOT::Experimental::RNTupleReader::ConnectModel() {
    std::unordered_map<const Detail::RFieldBase *, DescriptorId_t> fieldPtr2Id;
    fieldPtr2Id[fModel->GetRootField()] = fSource->GetDescriptor().FindFieldId("", kInvalidDescriptorId);
-   for (auto& field : *fModel->GetRootField()) {
+   for (auto &field : *fModel->GetRootField()) {
       auto parentId = fieldPtr2Id[field.GetParent()];
       auto fieldId = fSource->GetDescriptor().FindFieldId(field.GetName(), parentId);
       R__ASSERT(fieldId != kInvalidDescriptorId);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -44,6 +44,31 @@ ROOT::Experimental::Detail::RPageSource::~RPageSource()
 {
 }
 
+ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
+ROOT::Experimental::Detail::RPageSource::AddColumn(DescriptorId_t fieldId, const RColumn &column)
+{
+   R__ASSERT(fieldId != kInvalidDescriptorId);
+   auto columnId = fDescriptor.FindColumnId(fieldId, column.GetIndex());
+   R__ASSERT(columnId != kInvalidDescriptorId);
+   return ColumnHandle_t(columnId, &column);
+}
+
+ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNEntries()
+{
+   return fDescriptor.GetNEntries();
+}
+
+ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNElements(ColumnHandle_t columnHandle)
+{
+   return fDescriptor.GetNElements(columnHandle.fId);
+}
+
+ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSource::GetColumnId(ColumnHandle_t columnHandle)
+{
+   // TODO(jblomer) distinguish trees
+   return columnHandle.fId;
+}
+
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR moves the ntuple static meta-data handling code out of the page storage classes for ROOT files into the base classes.  It's preparing the code for a raw file page storage implementation.