### PR TITLE
WIP: Do not print an extra blank line at startup

### DIFF
--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -387,8 +387,6 @@ void TRint::Run(Bool_t retrn)
             }
             TObjString *file = (TObjString *)fileObj;
             char cmd[kMAXPATHLEN+50];
-            if (!fNcmd)
-               printf("\n");
             Bool_t rootfile = kFALSE;
 
             if (file->TestBit(kExpression)) {


### PR DESCRIPTION
This improves the ability to use root in one liner scripts:

Before this change:
```
$ root -l -b -q -e 'cout << gROOT->GetVersion() << "\n";'

6.19/01
$
```
After this change:
```
$ root -l -b -q -e 'cout << gROOT->GetVersion() << "\n";'
6.19/01
$
```