### PR TITLE
[io] first step to introduce "reproducible" file content

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -174,6 +174,7 @@ private:
 public:
    /// TFile status bits. BIT(13) is taken up by TObject
    enum EStatusBits {
+      kReproducible  = BIT(9),
       kRecovered     = BIT(10),
       kHasReferences = BIT(11),
       kDevNull       = BIT(12),

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -751,7 +751,7 @@ void TDirectoryFile::FillBuffer(char *&buffer)
       version += 1000;
    }
    tobuf(buffer, version);
-   if (fFile && fFile->TestBit(TFile::kReproducible)) {
+   if (TestBit(TFile::kReproducible) || (fFile && fFile->TestBit(TFile::kReproducible))) {
       fDatimeC = (UInt_t) 1;
       fDatimeM = (UInt_t) 1;
       fUUID.SetUUID("00000000-0000-0000-0000-000000000000");

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -338,6 +338,11 @@ void TDirectoryFile::Build(TFile* motherFile, TDirectory* motherDir)
    fMother     = motherDir;
    fFile       = motherFile ? motherFile : TFile::CurrentFile();
    SetBit(kCanDelete);
+
+   if (fFile && fFile->TestBit(TFile::kReproducible)) {
+      fDatimeC = (UInt_t) 1;
+      fDatimeM = (UInt_t) 1;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -740,12 +745,17 @@ void TDirectoryFile::FillBuffer(char *&buffer)
        fSeekKeys > TFile::kStartBigFile )
    {
       // One of the address is larger than 2GB we need to use longer onfile
-      // integer, thus we increase the verison number.
+      // integer, thus we increase the version number.
       // Note that fSeekDir and fSeekKey are not necessarily correlated, if
       // some object are 'removed' from the file and the holes are reused.
       version += 1000;
    }
    tobuf(buffer, version);
+   if (fFile && fFile->TestBit(TFile::kReproducible)) {
+      fDatimeC = (UInt_t) 1;
+      fDatimeM = (UInt_t) 1;
+      fUUID.SetUUID("00000000-0000-0000-0000-000000000000");
+   }
    fDatimeC.FillBuffer(buffer);
    fDatimeM.FillBuffer(buffer);
    tobuf(buffer, fNbytesKeys);

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -2542,6 +2542,8 @@ void TFile::WriteHeader()
       tobuf(buffer, fSeekInfo);
       tobuf(buffer, fNbytesInfo);
    }
+   if (TestBit(kReproducible))
+      fUUID.SetUUID("00000000-0000-0000-0000-000000000000");
    fUUID.FillBuffer(buffer);
    Int_t nbytes  = buffer - psave;
    Seek(0);

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -350,6 +350,9 @@ TFile::TFile(const char *fname1, Option_t *option, const char *ftitle, Int_t com
    if (strstr(fUrl.GetOptions(), "filetype=pcm"))
       fIsPcmFile = kTRUE;
 
+   if (fUrl.HasOption("reproducible"))
+      SetBit(kReproducible);
+
    // Init initialization control flag
    fInitDone   = kFALSE;
    fMustFlush  = kTRUE;

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -413,6 +413,9 @@ void TKey::Build(TDirectory* motherDir, const char* classname, Long64_t filepos)
    if (filepos > TFile::kStartBigFile) fVersion += 1000;
 
    if (fTitle.Length() > kTitleMax) fTitle.Resize(kTitleMax);
+
+   if (GetFile() && GetFile()->TestBit(TFile::kReproducible))
+      fDatime = (UInt_t) 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -595,6 +598,8 @@ void TKey::FillBuffer(char *&buffer)
    tobuf(buffer, version);
 
    tobuf(buffer, fObjlen);
+   if (GetFile() && GetFile()->TestBit(TFile::kReproducible))
+      fDatime = (UInt_t) 1;
    fDatime.FillBuffer(buffer);
    tobuf(buffer, fKeylen);
    tobuf(buffer, fCycle);

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -477,7 +477,10 @@ void TKey::Create(Int_t nbytes, TFile* externFile)
             nsize,GetName(),GetTitle());
       return;
    }
-   fDatime.Set();
+   if (f->TestBit(TFile::kReproducible))
+      fDatime = (UInt_t) 1; // cannot use 0, when reading from file 0 time will be reassigned
+   else
+      fDatime.Set();
    fSeekKey  = bestfree->GetFirst();
 //*-*----------------- Case Add at the end of the file
    if (fSeekKey >= f->GetEND()) {


### PR DESCRIPTION
Idea to have method create ROOT files with reproducible binary content.
For that several fields in TDirectory and TFile have to be reassigned to default values.
To activate feature one should use "?reproducible" in file name like:
```
new TFile("name.root?reproducible","recreate")
```
This is alternative version to #4083 
