### PR TITLE
[tcling] Skip weak undefined symbols produced by gcc. 

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6176,8 +6176,12 @@ static bool FindSymbol(const std::string &library_filename,
          continue;
       }
 
-      if (SymNameErr.get() == mangled_name)
+      if (SymNameErr.get() == mangled_name) {
+       if (gDebug > 1)
+         Info("TCling__FindSymbol", "Symbol %s found in %s\n",
+              mangled_name.c_str(), library_filename.c_str());
          return true;
+      }
    }
 
    if (!BinObjFile->isELF())

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -7038,14 +7038,24 @@ static std::string GetSharedLibImmediateDepsSlow(std::string lib,
          if (SymName.empty())
             continue;
 
-         // Skip the symbols which are part of the C/C++ runtime and have a
-         // fixed library version. See binutils ld VERSION. Those reside in
-         // 'system' libraries, which we avoid in ResolveSymbol.
-         if (BinObjFile->isELF() && (SymName.contains("@@GLIBCXX") ||
-                                     SymName.contains("@@CXXABI") ||
-                                     SymName.contains("@@GLIBC") ||
-                                     SymName.contains("@@GCC")))
+         if (BinObjFile->isELF()) {
+          // Skip the symbols which are part of the C/C++ runtime and have a
+          // fixed library version. See binutils ld VERSION. Those reside in
+          // 'system' libraries, which we avoid in ResolveSymbol.
+          if (SymName.contains("@@GLIBCXX") || SymName.contains("@@CXXABI") ||
+              SymName.contains("@@GLIBC") || SymName.contains("@@GCC"))
             continue;
+
+          // Those are 'weak undefined' symbols produced by gcc. We can
+          // ignore them.
+          // FIXME: It is unclear whether we can ignore all weak undefined
+          // symbols:
+          // http://lists.llvm.org/pipermail/llvm-dev/2017-October/118177.html
+          if (SymName == "_Jv_RegisterClasses" ||
+              SymName == "_ITM_deregisterTMCloneTable" ||
+              SymName == "_ITM_registerTMCloneTable")
+            continue;
+      }
 
          // If we can find the address of the symbol, we have loaded it. Skip.
          if (skipLoadedLibs && llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(SymName))

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -214,10 +214,10 @@ TEST_F(TClingTests, GetSharedLibDeps)
    llvm::StringRef SeenDepsRef = SeenDeps;
 
    // Depending on the configuration we expect:
-   // TreePlayer Gpad Graf Graf3d Hist [Imt] MathCore MultiProc Net [New] Tree [tbb]..
+   // TreePlayer Gpad Graf Graf3d Hist [Imt] [MathCore] MultiProc Net [New] Tree [tbb]..
    // FIXME: We should add a generic gtest regex matcher and use a regex here.
    ASSERT_TRUE(SeenDepsRef.startswith("TreePlayer Gpad Graf Graf3d Hist"));
-   ASSERT_TRUE(SeenDepsRef.contains("MathCore MultiProc Net"));
+   ASSERT_TRUE(SeenDepsRef.contains("MultiProc Net"));
    ASSERT_TRUE(SeenDepsRef.contains("Tree"));
 
    EXPECT_ROOT_ERROR(ASSERT_TRUE(nullptr == GetLibDeps("")),


### PR DESCRIPTION
We get these symbols even for a simple hello world message. While it is not clear if we can skip all weak undefined symbols, we can certainly skip those which get resolved to libgcj.so and libitm.so.

Oddly enough gcc emits a weak undefined symbol to _Jv_RegisterClasses (resolved in libgcj.so) which is some gcc/java library. _ITM_deregisterTMCloneTable and _ITM_registerTMCloneTable are emitted because (resolved in libitm.so) of pointer arithmetics for transactional memory support.

The current understanding is that we can safely omit these when harvesting library dependencies.

This should fix the rootbench builds.