### PR TITLE
Revert "core/clingutils: improve configuration using external clang"

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -67,26 +67,31 @@ foreach(dict ${stldicts})
                                 DEPENDENCIES Core)
 endforeach()
 
-if(builtin_clang)
+set(CLANG_RESOURCE_DIR_STEM)
+if (builtin_clang)
   set(CLANG_RESOURCE_DIR_STEM ${CMAKE_BINARY_DIR}/interpreter/llvm/src/${CMAKE_CFG_INTDIR}/lib/clang)
   set(CLANG_RESOURCE_DIR_VERSION ${LLVM_VERSION})
-else()
-  execute_process(
-    COMMAND ${LLVM_TOOLS_BINARY_DIR}/clang -print-resource-dir
-    RESULT_VARIABLE _CLANG_ERROR OUTPUT_VARIABLE CLANG_RESOURCE_DIR)
+else ()
+  set(CLANG_RESOURCE_DIR_STEM ${LLVM_LIBRARY_DIR}/clang)
+  # A user can define a clang version to use, otherwise find it (but will error if more than one version is present)
+  if (NOT DEFINED CLANG_RESOURCE_DIR_VERSION)
+    if (NOT EXISTS ${CLANG_RESOURCE_DIR_STEM})
+      message(FATAL_ERROR "${CLANG_RESOURCE_DIR_STEM} does not exist. Please install clang.")
+    endif()
+    # There is no reasonable way to get the version of clang under which is its resource directory.
+    # For example, lib/clang/5.0.0/include. Deduce it.
+    file(GLOB CHILDREN RELATIVE ${CLANG_RESOURCE_DIR_STEM} ${CLANG_RESOURCE_DIR_STEM}/*)
+    list(LENGTH CHILDREN CHILDREN_LENGTH)
+    if (${CHILDREN_LENGTH} GREATER 1)
+      message(FATAL_ERROR "Found more than one version of clang. CLANG_RESOURCE_DIR_VERSION contains: '${CHILDREN}'." )
+    endif()
 
-  if(_CLANG_ERROR)
-    message(FATAL_ERROR "Cannot determine clang resource directory path")
+    list(GET CHILDREN 0 CLANG_RESOURCE_DIR_VERSION)
   endif()
-
-  string(STRIP ${CLANG_RESOURCE_DIR} CLANG_RESOURCE_DIR)
-  get_filename_component(CLANG_RESOURCE_DIR ${CLANG_RESOURCE_DIR} REALPATH)
-  get_filename_component(CLANG_RESOURCE_DIR_STEM ${CLANG_RESOURCE_DIR} DIRECTORY)
-  get_filename_component(CLANG_RESOURCE_DIR_VERSION ${CLANG_RESOURCE_DIR} NAME)
 endif()
 
-set(CLANG_RESOURCE_DIR ${CLANG_RESOURCE_DIR_STEM}/${CLANG_RESOURCE_DIR_VERSION}/include)
 
+set(CLANG_RESOURCE_DIR ${CLANG_RESOURCE_DIR_STEM}/${CLANG_RESOURCE_DIR_VERSION}/include)
 
 #---Deal with clang resource here----------------------------------------------
 install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/cling/lib/clang/${CLANG_RESOURCE_DIR_VERSION}/include/


### PR DESCRIPTION
This reverts commit 1e8c04dd4beff8fc3d34cfd21e45358e85ae0f79.
In this commit, main idea was to use clang binary to retrieve information
about resource-clang-dir. Sadly ROOT patched LLVM/Clang is built
without clang binary and ROOT CMake crash then with next error:

-- /home/oksana/CERN_sources/llvm-clang-root/inst/bin
CMake Error at core/clingutils/CMakeLists.txt:80 (message):
  Cannot determine clang resource directory path