### PR TITLE
Math io conversions v6 18

### DIFF
--- a/math/genvector/inc/Math/LinkDef_GenVector.h
+++ b/math/genvector/inc/Math/LinkDef_GenVector.h
@@ -16,118 +16,622 @@
 #pragma link C++ namespace ROOT::Math;
 
 
-#pragma link C++ class ROOT::Math::Cartesian2D<double>+;
-#pragma link C++ class ROOT::Math::Polar2D<double>+;
+#pragma link C++ class    ROOT::Math::Cartesian2D<double>+;
+#pragma read sourceClass="ROOT::Math::Cartesian2D<Double32_t>" \
+             targetClass="ROOT::Math::Cartesian2D<double>";
+#pragma read sourceClass="ROOT::Math::Cartesian2D<float>"      \
+             targetClass="ROOT::Math::Cartesian2D<double>";
+#pragma read sourceClass="ROOT::Math::Cartesian2D<Float16_t>"  \
+             targetClass="ROOT::Math::Cartesian2D<double>";
+
+#pragma link C++ class    ROOT::Math::Polar2D<double>+;
+#pragma read sourceClass="ROOT::Math::Polar2D<Double32_t>" \
+             targetClass="ROOT::Math::Polar2D<double>";
+#pragma read sourceClass="ROOT::Math::Polar2D<float>"      \
+             targetClass="ROOT::Math::Polar2D<double>";
+#pragma read sourceClass="ROOT::Math::Polar2D<Float16_t>"  \
+             targetClass="ROOT::Math::Polar2D<double>";
 
 
-#pragma link C++ class ROOT::Math::Cartesian3D<double>+;
-#pragma link C++ class ROOT::Math::Polar3D<double>+;
-#pragma link C++ class ROOT::Math::Cylindrical3D<double>+;
-#pragma link C++ class ROOT::Math::CylindricalEta3D<double>+;
+
+#pragma link C++ class    ROOT::Math::Cartesian3D<double>+;
+#pragma read sourceClass="ROOT::Math::Cartesian3D<Double32_t>" \
+             targetClass="ROOT::Math::Cartesian3D<double>";
+#pragma read sourceClass="ROOT::Math::Cartesian3D<float>"      \
+             targetClass="ROOT::Math::Cartesian3D<double>";
+#pragma read sourceClass="ROOT::Math::Cartesian3D<Float16_t>"  \
+             targetClass="ROOT::Math::Cartesian3D<double>";
+
+#pragma link C++ class    ROOT::Math::Polar3D<double>+;
+#pragma read sourceClass="ROOT::Math::Polar3D<Double32_t>" \
+             targetClass="ROOT::Math::Polar3D<double>";
+#pragma read sourceClass="ROOT::Math::Polar3D<float>"      \
+             targetClass="ROOT::Math::Polar3D<double>";
+#pragma read sourceClass="ROOT::Math::Polar3D<Float16_t>"  \
+             targetClass="ROOT::Math::Polar3D<double>";
+
+#pragma link C++ class    ROOT::Math::Cylindrical3D<double>+;
+#pragma read sourceClass="ROOT::Math::Cylindrical3D<Double32_t>" \
+             targetClass="ROOT::Math::Cylindrical3D<double>";
+#pragma read sourceClass="ROOT::Math::Cylindrical3D<float>"      \
+             targetClass="ROOT::Math::Cylindrical3D<double>";
+#pragma read sourceClass="ROOT::Math::Cylindrical3D<Float16_t>"  \
+             targetClass="ROOT::Math::Cylindrical3D<double>";
+
+#pragma link C++ class    ROOT::Math::CylindricalEta3D<double>+;
+#pragma read sourceClass="ROOT::Math::CylindricalEta3D<Double32_t>" \
+             targetClass="ROOT::Math::CylindricalEta3D<double>";
+#pragma read sourceClass="ROOT::Math::CylindricalEta3D<float>"      \
+             targetClass="ROOT::Math::CylindricalEta3D<double>";
+#pragma read sourceClass="ROOT::Math::CylindricalEta3D<Float16_t>"  \
+             targetClass="ROOT::Math::CylindricalEta3D<double>";
+
 
 #pragma link C++ class ROOT::Math::DefaultCoordinateSystemTag+;
 #pragma link C++ class ROOT::Math::LocalCoordinateSystemTag+;
 #pragma link C++ class ROOT::Math::GlobalCoordinateSystemTag+;
 
-#pragma link C++ class ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<double> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<double> >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<double> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<float> >"      \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<double> >";
 
-#pragma link C++ class ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<double> >+;
-#pragma link C++ class ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<double> >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<double> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<float> >"      \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<double> >";
 
 
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double> >+;
+#pragma link C++ class    ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<double> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<float> >"      \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<double> >";
 
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double> >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double> >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> >+;
+#pragma link C++ class    ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<double> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<float> >"      \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<double> >";
+
+
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float> >"      \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float> >"      \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float> >"      \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float> >"      \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double> >";
+
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float> >"      \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float> >"      \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double> >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float> >"      \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double> >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float> >"      \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> >";
+
 
 #ifdef __CLING__
 // Work around CINT and autoloader deficiency with template default parameter
 // Those requests are solely for rlibmap, they do no need to be seen by rootcint.
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"      \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
 
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"      \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"      \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"      \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"      \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"      \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"      \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"      \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >";
+
 #endif
 
-#pragma link C++ class ROOT::Math::PxPyPzE4D<double>+;
-#pragma link C++ class ROOT::Math::PtEtaPhiE4D<double>+;
-#pragma link C++ class ROOT::Math::PxPyPzM4D<double>+;
-#pragma link C++ class ROOT::Math::PtEtaPhiM4D<double>+;
-//#pragma link C++ class ROOT::Math::EEtaPhiMSystem<double>+;
-//#pragma link C++ class ROOT::Math::PtEtaPhiMSystem<double>+;
+#pragma link C++ class    ROOT::Math::PxPyPzE4D<double>+;
+#pragma read sourceClass="ROOT::Math::PxPyPzE4D<Double32_t>" \
+             targetClass="ROOT::Math::PxPyPzE4D<double>";
+#pragma read sourceClass="ROOT::Math::PxPyPzE4D<float>"      \
+             targetClass="ROOT::Math::PxPyPzE4D<double>";
+#pragma read sourceClass="ROOT::Math::PxPyPzE4D<Float16_t>"  \
+             targetClass="ROOT::Math::PxPyPzE4D<double>";
 
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >+;
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double> >+;
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >+;
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> >+;
+#pragma link C++ class    ROOT::Math::PtEtaPhiE4D<double>+;
+#pragma read sourceClass="ROOT::Math::PtEtaPhiE4D<Double32_t>" \
+             targetClass="ROOT::Math::PtEtaPhiE4D<double>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiE4D<float>"      \
+             targetClass="ROOT::Math::PtEtaPhiE4D<double>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiE4D<Float16_t>"  \
+             targetClass="ROOT::Math::PtEtaPhiE4D<double>";
+
+#pragma link C++ class    ROOT::Math::PxPyPzM4D<double>+;
+#pragma read sourceClass="ROOT::Math::PxPyPzM4D<Double32_t>" \
+             targetClass="ROOT::Math::PxPyPzM4D<double>";
+#pragma read sourceClass="ROOT::Math::PxPyPzM4D<float>"      \
+             targetClass="ROOT::Math::PxPyPzM4D<double>";
+#pragma read sourceClass="ROOT::Math::PxPyPzM4D<Float16_t>"  \
+             targetClass="ROOT::Math::PxPyPzM4D<double>";
+
+#pragma link C++ class    ROOT::Math::PtEtaPhiM4D<double>+;
+#pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<Double32_t>" \
+             targetClass="ROOT::Math::PtEtaPhiM4D<double>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<float>"      \
+             targetClass="ROOT::Math::PtEtaPhiM4D<double>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<Float16_t>"  \
+             targetClass="ROOT::Math::PtEtaPhiM4D<double>";
+
+//#pragma link C++ class    ROOT::Math::EEtaPhiMSystem<double>+;
+#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<Double32_t>" \
+             targetClass="ROOT::Math::EEtaPhiMSystem<double>";
+#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<float>"      \
+             targetClass="ROOT::Math::EEtaPhiMSystem<double>";
+#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<Float16_t>"  \
+             targetClass="ROOT::Math::EEtaPhiMSystem<double>";
+
+//#pragma link C++ class    ROOT::Math::PtEtaPhiMSystem<double>+;
+#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<Double32_t>" \
+             targetClass="ROOT::Math::PtEtaPhiMSystem<double>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<float>"      \
+             targetClass="ROOT::Math::PtEtaPhiMSystem<double>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<Float16_t>"  \
+             targetClass="ROOT::Math::PtEtaPhiMSystem<double>";
+
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Double32_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >"      \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Float16_t> >"  \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >";
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Double32_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float> >"      \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Float16_t> >"  \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double> >";
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Double32_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<float> >"      \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Float16_t> >"  \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >";
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Double32_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >"      \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Float16_t> >"  \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> >";
+
 
 //// Floating types 
 
-#pragma link C++ class ROOT::Math::Cartesian2D<float>+;
-#pragma link C++ class ROOT::Math::Polar2D<float>+;
+#pragma link C++ class    ROOT::Math::Cartesian2D<float>+;
+#pragma read sourceClass="ROOT::Math::Cartesian2D<double>"     \
+             targetClass="ROOT::Math::Cartesian2D<float>";
+#pragma read sourceClass="ROOT::Math::Cartesian2D<Double32_t>" \
+             targetClass="ROOT::Math::Cartesian2D<float>";
+#pragma read sourceClass="ROOT::Math::Cartesian2D<Float16_t>"  \
+             targetClass="ROOT::Math::Cartesian2D<float>";
 
-#pragma link C++ class ROOT::Math::Cartesian3D<float>+;
-#pragma link C++ class ROOT::Math::Polar3D<float>+;
-#pragma link C++ class ROOT::Math::Cylindrical3D<float>+;
-#pragma link C++ class ROOT::Math::CylindricalEta3D<float>+;
+#pragma link C++ class    ROOT::Math::Polar2D<float>+;
+#pragma read sourceClass="ROOT::Math::Polar2D<double>"     \
+             targetClass="ROOT::Math::Polar2D<float>";
+#pragma read sourceClass="ROOT::Math::Polar2D<Double32_t>" \
+             targetClass="ROOT::Math::Polar2D<float>";
+#pragma read sourceClass="ROOT::Math::Polar2D<Float16_t>"  \
+             targetClass="ROOT::Math::Polar2D<float>";
+
+
+#pragma link C++ class    ROOT::Math::Cartesian3D<float>+;
+#pragma read sourceClass="ROOT::Math::Cartesian3D<double>"     \
+             targetClass="ROOT::Math::Cartesian3D<float>";
+#pragma read sourceClass="ROOT::Math::Cartesian3D<Double32_t>" \
+             targetClass="ROOT::Math::Cartesian3D<float>";
+#pragma read sourceClass="ROOT::Math::Cartesian3D<Float16_t>"  \
+             targetClass="ROOT::Math::Cartesian3D<float>";
+
+#pragma link C++ class    ROOT::Math::Polar3D<float>+;
+#pragma read sourceClass="ROOT::Math::Polar3D<double>"     \
+             targetClass="ROOT::Math::Polar3D<float>";
+#pragma read sourceClass="ROOT::Math::Polar3D<Double32_t>" \
+             targetClass="ROOT::Math::Polar3D<float>";
+#pragma read sourceClass="ROOT::Math::Polar3D<Float16_t>"  \
+             targetClass="ROOT::Math::Polar3D<float>";
+
+#pragma link C++ class    ROOT::Math::Cylindrical3D<float>+;
+#pragma read sourceClass="ROOT::Math::Cylindrical3D<double>"     \
+             targetClass="ROOT::Math::Cylindrical3D<float>";
+#pragma read sourceClass="ROOT::Math::Cylindrical3D<Double32_t>" \
+             targetClass="ROOT::Math::Cylindrical3D<float>";
+#pragma read sourceClass="ROOT::Math::Cylindrical3D<Float16_t>"  \
+             targetClass="ROOT::Math::Cylindrical3D<float>";
+
+#pragma link C++ class    ROOT::Math::CylindricalEta3D<float>+;
+#pragma read sourceClass="ROOT::Math::CylindricalEta3D<double>"     \
+             targetClass="ROOT::Math::CylindricalEta3D<float>";
+#pragma read sourceClass="ROOT::Math::CylindricalEta3D<Double32_t>" \
+             targetClass="ROOT::Math::CylindricalEta3D<float>";
+#pragma read sourceClass="ROOT::Math::CylindricalEta3D<Float16_t>"  \
+             targetClass="ROOT::Math::CylindricalEta3D<float>";
+
 
 #pragma link C++ class ROOT::Math::DefaultCoordinateSystemTag+;
 #pragma link C++ class ROOT::Math::LocalCoordinateSystemTag+;
 #pragma link C++ class ROOT::Math::GlobalCoordinateSystemTag+;
 
-#pragma link C++ class ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<float> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<float> >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<float> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<double> >"     \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<float> >";
 
-#pragma link C++ class ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<float> >+;
-#pragma link C++ class ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<float> >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<float> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<double> >"     \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<float> >";
 
 
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float> >+;
+#pragma link C++ class    ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<float> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<double> >"     \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Cartesian2D<float> >";
 
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float> >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float> >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float> >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float> >+;
+#pragma link C++ class    ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<float> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<double> >"     \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector2D<ROOT::Math::Polar2D<float> >";
+
+
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double> >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double> >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double> >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Float16_t> >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float> >";
+
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float> >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double> >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float> >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double> >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float> >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Float16_t> >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float> >";
+
 
 #ifdef __CLING__
 // Work around CINT and autoloader deficiency with template default parameter
 // Those requests are solely for rlibmap, they do no need to be seen by rootcint.
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
 
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >"  \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >";
+
 #endif
 
-#pragma link C++ class ROOT::Math::PxPyPzE4D<float>+;
-#pragma link C++ class ROOT::Math::PtEtaPhiE4D<float>+;
-#pragma link C++ class ROOT::Math::PxPyPzM4D<float>+;
-#pragma link C++ class ROOT::Math::PtEtaPhiM4D<float>+;
-//#pragma link C++ class ROOT::Math::EEtaPhiMSystem<float>+;
-//#pragma link C++ class ROOT::Math::PtEtaPhiMSystem<float>+;
+#pragma link C++ class    ROOT::Math::PxPyPzE4D<float>+;
+#pragma read sourceClass="ROOT::Math::PxPyPzE4D<double>"     \
+             targetClass="ROOT::Math::PxPyPzE4D<float>";
+#pragma read sourceClass="ROOT::Math::PxPyPzE4D<Double32_t>" \
+             targetClass="ROOT::Math::PxPyPzE4D<float>";
+#pragma read sourceClass="ROOT::Math::PxPyPzE4D<Float16_t>"  \
+             targetClass="ROOT::Math::PxPyPzE4D<float>";
 
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >+;
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float> >+;
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<float> >+;
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >+;
+#pragma link C++ class    ROOT::Math::PtEtaPhiE4D<float>+;
+#pragma read sourceClass="ROOT::Math::PtEtaPhiE4D<double>"     \
+             targetClass="ROOT::Math::PtEtaPhiE4D<float>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiE4D<Double32_t>" \
+             targetClass="ROOT::Math::PtEtaPhiE4D<float>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiE4D<Float16_t>"  \
+             targetClass="ROOT::Math::PtEtaPhiE4D<float>";
+
+#pragma link C++ class    ROOT::Math::PxPyPzM4D<float>+;
+#pragma read sourceClass="ROOT::Math::PxPyPzM4D<double>"     \
+             targetClass="ROOT::Math::PxPyPzM4D<float>";
+#pragma read sourceClass="ROOT::Math::PxPyPzM4D<Double32_t>" \
+             targetClass="ROOT::Math::PxPyPzM4D<float>";
+#pragma read sourceClass="ROOT::Math::PxPyPzM4D<Float16_t>"  \
+             targetClass="ROOT::Math::PxPyPzM4D<float>";
+
+#pragma link C++ class    ROOT::Math::PtEtaPhiM4D<float>+;
+#pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<double>"     \
+             targetClass="ROOT::Math::PtEtaPhiM4D<float>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<Double32_t>" \
+             targetClass="ROOT::Math::PtEtaPhiM4D<float>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<Float16_t>"  \
+             targetClass="ROOT::Math::PtEtaPhiM4D<float>";
+
+//#pragma link C++ class    ROOT::Math::EEtaPhiMSystem<float>+;
+#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<double>"     \
+             targetClass="ROOT::Math::EEtaPhiMSystem<float>";
+#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<Double32_t>" \
+             targetClass="ROOT::Math::EEtaPhiMSystem<float>";
+#pragma read sourceClass="ROOT::Math::EEtaPhiMSystem<Float16_t>"  \
+             targetClass="ROOT::Math::EEtaPhiMSystem<float>";
+
+//#pragma link C++ class    ROOT::Math::PtEtaPhiMSystem<float>+;
+#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<double>"     \
+             targetClass="ROOT::Math::PtEtaPhiMSystem<float>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<Double32_t>" \
+             targetClass="ROOT::Math::PtEtaPhiMSystem<float>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiMSystem<Float16_t>"  \
+             targetClass="ROOT::Math::PtEtaPhiMSystem<float>";
+
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >"     \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Double32_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Float16_t> >"  \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >";
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double> >"     \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Double32_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Float16_t> >"  \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float> >";
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<float> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >"     \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<float> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Double32_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<float> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Float16_t> >"  \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<float> >";
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> >"     \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Double32_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Float16_t> >"  \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >";
+
 
 
 

--- a/math/genvector/inc/Math/LinkDef_GenVector32.h
+++ b/math/genvector/inc/Math/LinkDef_GenVector32.h
@@ -11,61 +11,313 @@
 #pragma link off all functions;
 
 
-#pragma link C++ class ROOT::Math::Cartesian2D<Double32_t>+;
-#pragma link C++ class ROOT::Math::Polar2D<Double32_t>+;
+#pragma link C++ class    ROOT::Math::Cartesian2D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::Cartesian2D<double>"    \
+             targetClass="ROOT::Math::Cartesian2D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Cartesian2D<float>"     \
+             targetClass="ROOT::Math::Cartesian2D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Cartesian2D<Float16_t>" \
+             targetClass="ROOT::Math::Cartesian2D<Double32_t>";
 
-#pragma link C++ class ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Double32_t> >+;
+#pragma link C++ class    ROOT::Math::Polar2D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::Polar2D<double>"    \
+             targetClass="ROOT::Math::Polar2D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Polar2D<float>"     \
+             targetClass="ROOT::Math::Polar2D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Polar2D<Float16_t>" \
+             targetClass="ROOT::Math::Polar2D<Double32_t>";
 
 
-#pragma link C++ class ROOT::Math::Cartesian3D<Double32_t>+;
-#pragma link C++ class ROOT::Math::CylindricalEta3D<Double32_t>+;
-#pragma link C++ class ROOT::Math::Polar3D<Double32_t>+;
-#pragma link C++ class ROOT::Math::Cylindrical3D<Double32_t>+;
+#pragma link C++ class    ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<double> >"    \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<float> >"     \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Float16_t> >" \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Cartesian2D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<double> >"    \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<float> >"     \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Float16_t> >" \
+             targetClass="ROOT::Math::DisplacementVector2D<ROOT::Math::Polar2D<Double32_t> >";
 
 
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Double32_t> >+;
 
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Double32_t> >+;
+#pragma link C++ class    ROOT::Math::Cartesian3D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::Cartesian3D<double>"    \
+             targetClass="ROOT::Math::Cartesian3D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Cartesian3D<float>"     \
+             targetClass="ROOT::Math::Cartesian3D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Cartesian3D<Float16_t>" \
+             targetClass="ROOT::Math::Cartesian3D<Double32_t>";
+
+#pragma link C++ class    ROOT::Math::CylindricalEta3D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::CylindricalEta3D<double>"    \
+             targetClass="ROOT::Math::CylindricalEta3D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::CylindricalEta3D<float>"     \
+             targetClass="ROOT::Math::CylindricalEta3D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::CylindricalEta3D<Float16_t>" \
+             targetClass="ROOT::Math::CylindricalEta3D<Double32_t>";
+
+#pragma link C++ class    ROOT::Math::Polar3D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::Polar3D<double>"    \
+             targetClass="ROOT::Math::Polar3D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Polar3D<float>"     \
+             targetClass="ROOT::Math::Polar3D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Polar3D<Float16_t>" \
+             targetClass="ROOT::Math::Polar3D<Double32_t>";
+
+#pragma link C++ class    ROOT::Math::Cylindrical3D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::Cylindrical3D<double>"    \
+             targetClass="ROOT::Math::Cylindrical3D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Cylindrical3D<float>"     \
+             targetClass="ROOT::Math::Cylindrical3D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::Cylindrical3D<Float16_t>" \
+             targetClass="ROOT::Math::Cylindrical3D<Double32_t>";
+
+
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float> >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Float16_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double> >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float> >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Float16_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<double> >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<float> >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Float16_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Polar3D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<double> >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<float> >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Float16_t> >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cylindrical3D<Double32_t> >";
+
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double> >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float> >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Float16_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float> >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Float16_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<double> >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<float> >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Float16_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Polar3D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<double> >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<float> >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Float16_t> >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cylindrical3D<Double32_t> >";
+
 
 // using a tag (only cartesian and cylindrical eta)
 
 #ifdef __CLING__
 // Work around CINT and autoloader deficiency with template default parameter
 // Those requests as solely for rlibmap, they do no need to be seen by rootcint
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
 
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::DefaultCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::DefaultCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::DefaultCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag >";
+
 #endif
 
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::LocalCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::GlobalCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::LocalCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>, ROOT::Math::LocalCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::LocalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>, ROOT::Math::LocalCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::LocalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Float16_t>, ROOT::Math::LocalCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::LocalCoordinateSystemTag >";
 
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >+;
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::LocalCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::LocalCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::LocalCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::GlobalCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>, ROOT::Math::GlobalCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::GlobalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>, ROOT::Math::GlobalCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::GlobalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Float16_t>, ROOT::Math::GlobalCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>, ROOT::Math::GlobalCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::GlobalCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::GlobalCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::GlobalCoordinateSystemTag >" \
+             targetClass="ROOT::Math::DisplacementVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >";
 
 
-#pragma link C++ class ROOT::Math::PxPyPzE4D<Double32_t>+;
-#pragma link C++ class ROOT::Math::PtEtaPhiE4D<Double32_t>+;
-#pragma link C++ class ROOT::Math::PxPyPzM4D<Double32_t>+;
-#pragma link C++ class ROOT::Math::PtEtaPhiM4D<Double32_t>+;
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::LocalCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::LocalCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Float16_t>,ROOT::Math::LocalCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >";
 
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Double32_t> >+;
-#pragma link C++ class ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Double32_t> >+;
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::LocalCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::LocalCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::LocalCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::LocalCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::GlobalCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::GlobalCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Float16_t>,ROOT::Math::GlobalCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >";
+
+#pragma link C++ class    ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >+;
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double>,ROOT::Math::GlobalCoordinateSystemTag >"    \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<float>,ROOT::Math::GlobalCoordinateSystemTag >"     \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >";
+#pragma read sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Float16_t>,ROOT::Math::GlobalCoordinateSystemTag >" \
+             targetClass="ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag >";
+
+
+
+#pragma link C++ class    ROOT::Math::PxPyPzE4D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::PxPyPzE4D<double>"    \
+             targetClass="ROOT::Math::PxPyPzE4D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::PxPyPzE4D<float>"     \
+             targetClass="ROOT::Math::PxPyPzE4D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::PxPyPzE4D<Float16_t>" \
+             targetClass="ROOT::Math::PxPyPzE4D<Double32_t>";
+
+#pragma link C++ class    ROOT::Math::PtEtaPhiE4D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::PtEtaPhiE4D<double>"    \
+             targetClass="ROOT::Math::PtEtaPhiE4D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiE4D<float>"     \
+             targetClass="ROOT::Math::PtEtaPhiE4D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiE4D<Float16_t>" \
+             targetClass="ROOT::Math::PtEtaPhiE4D<Double32_t>";
+
+#pragma link C++ class    ROOT::Math::PxPyPzM4D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::PxPyPzM4D<double>"    \
+             targetClass="ROOT::Math::PxPyPzM4D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::PxPyPzM4D<float>"     \
+             targetClass="ROOT::Math::PxPyPzM4D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::PxPyPzM4D<Float16_t>" \
+             targetClass="ROOT::Math::PxPyPzM4D<Double32_t>";
+
+#pragma link C++ class    ROOT::Math::PtEtaPhiM4D<Double32_t>+;
+#pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<double>"    \
+             targetClass="ROOT::Math::PtEtaPhiM4D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<float>"     \
+             targetClass="ROOT::Math::PtEtaPhiM4D<Double32_t>";
+#pragma read sourceClass="ROOT::Math::PtEtaPhiM4D<Float16_t>" \
+             targetClass="ROOT::Math::PtEtaPhiM4D<Double32_t>";
+
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> >"    \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> >"     \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Float16_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double> >"    \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float> >"     \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Float16_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> >"    \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >"     \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Float16_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Double32_t> >";
+
+#pragma link C++ class    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Double32_t> >+;
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >"    \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<float> >"     \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Double32_t> >";
+#pragma read sourceClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Float16_t> >" \
+             targetClass="ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<Double32_t> >";
+
 
 
 

--- a/math/smatrix/inc/LinkDef.h
+++ b/math/smatrix/inc/LinkDef.h
@@ -22,43 +22,253 @@
 
 //generate up to 7x7
 
-#pragma link C++ class ROOT::Math::SVector<double,2>+;
-#pragma link C++ class ROOT::Math::SVector<double,3>+;
-#pragma link C++ class ROOT::Math::SVector<double,4>+;
-#pragma link C++ class ROOT::Math::SVector<double,5>+;
-#pragma link C++ class ROOT::Math::SVector<double,6>+;
-#pragma link C++ class ROOT::Math::SVector<double,7>+;
-// #pragma link C++ class ROOT::Math::SVector<double,8>+;
-// #pragma link C++ class ROOT::Math::SVector<double,9>+;
-// #pragma link C++ class ROOT::Math::SVector<double,10>+;
+#pragma link C++ class    ROOT::Math::SVector<double,2>+;
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,2>" \
+             targetClass="ROOT::Math::SVector<double,2>";
+#pragma read sourceClass="ROOT::Math::SVector<float,2>"      \
+             targetClass="ROOT::Math::SVector<double,2>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,2>"  \
+             targetClass="ROOT::Math::SVector<double,2>";
+
+#pragma link C++ class    ROOT::Math::SVector<double,3>+;
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,3>" \
+             targetClass="ROOT::Math::SVector<double,3>";
+#pragma read sourceClass="ROOT::Math::SVector<float,3>"      \
+             targetClass="ROOT::Math::SVector<double,3>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,3>"  \
+             targetClass="ROOT::Math::SVector<double,3>";
+
+#pragma link C++ class    ROOT::Math::SVector<double,4>+;
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,4>" \
+             targetClass="ROOT::Math::SVector<double,4>";
+#pragma read sourceClass="ROOT::Math::SVector<float,4>"      \
+             targetClass="ROOT::Math::SVector<double,4>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,4>"  \
+             targetClass="ROOT::Math::SVector<double,4>";
+
+#pragma link C++ class    ROOT::Math::SVector<double,5>+;
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,5>" \
+             targetClass="ROOT::Math::SVector<double,5>";
+#pragma read sourceClass="ROOT::Math::SVector<float,5>"      \
+             targetClass="ROOT::Math::SVector<double,5>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,5>"  \
+             targetClass="ROOT::Math::SVector<double,5>";
+
+#pragma link C++ class    ROOT::Math::SVector<double,6>+;
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,6>" \
+             targetClass="ROOT::Math::SVector<double,6>";
+#pragma read sourceClass="ROOT::Math::SVector<float,6>"      \
+             targetClass="ROOT::Math::SVector<double,6>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,6>"  \
+             targetClass="ROOT::Math::SVector<double,6>";
+
+#pragma link C++ class    ROOT::Math::SVector<double,7>+;
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,7>" \
+             targetClass="ROOT::Math::SVector<double,7>";
+#pragma read sourceClass="ROOT::Math::SVector<float,7>"      \
+             targetClass="ROOT::Math::SVector<double,7>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,7>"  \
+             targetClass="ROOT::Math::SVector<double,7>";
+
+// #pragma link C++ class    ROOT::Math::SVector<double,8>+;
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,8>" \
+             targetClass="ROOT::Math::SVector<double,8>";
+#pragma read sourceClass="ROOT::Math::SVector<float,8>"      \
+             targetClass="ROOT::Math::SVector<double,8>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,8>"  \
+             targetClass="ROOT::Math::SVector<double,8>";
+
+// #pragma link C++ class    ROOT::Math::SVector<double,9>+;
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,9>" \
+             targetClass="ROOT::Math::SVector<double,9>";
+#pragma read sourceClass="ROOT::Math::SVector<float,9>"      \
+             targetClass="ROOT::Math::SVector<double,9>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,9>"  \
+             targetClass="ROOT::Math::SVector<double,9>";
+
+// #pragma link C++ class    ROOT::Math::SVector<double,10>+;
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,10>" \
+             targetClass="ROOT::Math::SVector<double,10>";
+#pragma read sourceClass="ROOT::Math::SVector<float,10>"      \
+             targetClass="ROOT::Math::SVector<double,10>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,10>"  \
+             targetClass="ROOT::Math::SVector<double,10>";
 
 
-#pragma link C++ class ROOT::Math::MatRepStd<double,2,2>+;
-#pragma link C++ class ROOT::Math::MatRepStd<double,3,3>+;
-#pragma link C++ class ROOT::Math::MatRepStd<double,4,4>+;
-#pragma link C++ class ROOT::Math::MatRepStd<double,5,5>+;
-#pragma link C++ class ROOT::Math::MatRepStd<double,6,6>+;
-#pragma link C++ class ROOT::Math::MatRepStd<double,7,7>+;
-// #pragma link C++ class ROOT::Math::MatRepStd<double,8,8>+;
-// #pragma link C++ class ROOT::Math::MatRepStd<double,9,9>+;
-// #pragma link C++ class ROOT::Math::MatRepStd<double,10,10>+;
+
+#pragma link C++ class    ROOT::Math::MatRepStd<double,2,2>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,2,2>" \
+             targetClass="ROOT::Math::MatRepStd<double,2,2>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,2,2>"      \
+             targetClass="ROOT::Math::MatRepStd<double,2,2>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,2,2>"  \
+             targetClass="ROOT::Math::MatRepStd<double,2,2>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<double,3,3>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,3,3>" \
+             targetClass="ROOT::Math::MatRepStd<double,3,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,3,3>"      \
+             targetClass="ROOT::Math::MatRepStd<double,3,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,3,3>"  \
+             targetClass="ROOT::Math::MatRepStd<double,3,3>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<double,4,4>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,4,4>" \
+             targetClass="ROOT::Math::MatRepStd<double,4,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,4,4>"      \
+             targetClass="ROOT::Math::MatRepStd<double,4,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,4,4>"  \
+             targetClass="ROOT::Math::MatRepStd<double,4,4>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<double,5,5>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,5,5>" \
+             targetClass="ROOT::Math::MatRepStd<double,5,5>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,5,5>"      \
+             targetClass="ROOT::Math::MatRepStd<double,5,5>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,5,5>"  \
+             targetClass="ROOT::Math::MatRepStd<double,5,5>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<double,6,6>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,6,6>" \
+             targetClass="ROOT::Math::MatRepStd<double,6,6>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,6,6>"      \
+             targetClass="ROOT::Math::MatRepStd<double,6,6>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,6,6>"  \
+             targetClass="ROOT::Math::MatRepStd<double,6,6>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<double,7,7>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,7,7>" \
+             targetClass="ROOT::Math::MatRepStd<double,7,7>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,7,7>"      \
+             targetClass="ROOT::Math::MatRepStd<double,7,7>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,7,7>"  \
+             targetClass="ROOT::Math::MatRepStd<double,7,7>";
+
+// #pragma link C++ class    ROOT::Math::MatRepStd<double,8,8>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,8,8>" \
+             targetClass="ROOT::Math::MatRepStd<double,8,8>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,8,8>"      \
+             targetClass="ROOT::Math::MatRepStd<double,8,8>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,8,8>"  \
+             targetClass="ROOT::Math::MatRepStd<double,8,8>";
+
+// #pragma link C++ class    ROOT::Math::MatRepStd<double,9,9>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,9,9>" \
+             targetClass="ROOT::Math::MatRepStd<double,9,9>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,9,9>"      \
+             targetClass="ROOT::Math::MatRepStd<double,9,9>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,9,9>"  \
+             targetClass="ROOT::Math::MatRepStd<double,9,9>";
+
+// #pragma link C++ class    ROOT::Math::MatRepStd<double,10,10>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,10,10>" \
+             targetClass="ROOT::Math::MatRepStd<double,10,10>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,10,10>"      \
+             targetClass="ROOT::Math::MatRepStd<double,10,10>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,10,10>"  \
+             targetClass="ROOT::Math::MatRepStd<double,10,10>";
 
 
 
 
-#pragma link C++ class ROOT::Math::MatRepStd<double,4,3>+;
-#pragma link C++ class ROOT::Math::MatRepStd<double,3,4>+;
-#pragma link C++ class ROOT::Math::MatRepStd<double,9,7>+;
 
-#pragma link C++ class ROOT::Math::SMatrix<double,2,2>+;
-#pragma link C++ class ROOT::Math::SMatrix<double,3,3>+;
-#pragma link C++ class ROOT::Math::SMatrix<double,4,4>+;
-#pragma link C++ class ROOT::Math::SMatrix<double,5,5>+;
-#pragma link C++ class ROOT::Math::SMatrix<double,6,6>+;
-#pragma link C++ class ROOT::Math::SMatrix<double,7,7>+;
-// #pragma link C++ class ROOT::Math::SMatrix<double,8,8>+;
-// #pragma link C++ class ROOT::Math::SMatrix<double,9,9>+;
-// #pragma link C++ class ROOT::Math::SMatrix<double,10,10>+;
+#pragma link C++ class    ROOT::Math::MatRepStd<double,4,3>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,4,3>" \
+             targetClass="ROOT::Math::MatRepStd<double,4,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,4,3>"      \
+             targetClass="ROOT::Math::MatRepStd<double,4,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,4,3>"  \
+             targetClass="ROOT::Math::MatRepStd<double,4,3>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<double,3,4>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,3,4>" \
+             targetClass="ROOT::Math::MatRepStd<double,3,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,3,4>"      \
+             targetClass="ROOT::Math::MatRepStd<double,3,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,3,4>"  \
+             targetClass="ROOT::Math::MatRepStd<double,3,4>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<double,9,7>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,9,7>" \
+             targetClass="ROOT::Math::MatRepStd<double,9,7>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,9,7>"      \
+             targetClass="ROOT::Math::MatRepStd<double,9,7>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,9,7>"  \
+             targetClass="ROOT::Math::MatRepStd<double,9,7>";
+
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,2,2>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,2,2>" \
+             targetClass="ROOT::Math::SMatrix<double,2,2>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,2,2>"      \
+             targetClass="ROOT::Math::SMatrix<double,2,2>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,2,2>"  \
+             targetClass="ROOT::Math::SMatrix<double,2,2>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,3,3>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,3,3>" \
+             targetClass="ROOT::Math::SMatrix<double,3,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,3,3>"      \
+             targetClass="ROOT::Math::SMatrix<double,3,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,3,3>"  \
+             targetClass="ROOT::Math::SMatrix<double,3,3>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,4,4>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,4,4>" \
+             targetClass="ROOT::Math::SMatrix<double,4,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,4,4>"      \
+             targetClass="ROOT::Math::SMatrix<double,4,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,4,4>"  \
+             targetClass="ROOT::Math::SMatrix<double,4,4>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,5,5>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,5,5>" \
+             targetClass="ROOT::Math::SMatrix<double,5,5>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,5,5>"      \
+             targetClass="ROOT::Math::SMatrix<double,5,5>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,5,5>"  \
+             targetClass="ROOT::Math::SMatrix<double,5,5>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,6,6>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,6,6>" \
+             targetClass="ROOT::Math::SMatrix<double,6,6>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,6,6>"      \
+             targetClass="ROOT::Math::SMatrix<double,6,6>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,6,6>"  \
+             targetClass="ROOT::Math::SMatrix<double,6,6>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,7,7>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,7,7>" \
+             targetClass="ROOT::Math::SMatrix<double,7,7>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,7,7>"      \
+             targetClass="ROOT::Math::SMatrix<double,7,7>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,7,7>"  \
+             targetClass="ROOT::Math::SMatrix<double,7,7>";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<double,8,8>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,8,8>" \
+             targetClass="ROOT::Math::SMatrix<double,8,8>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,8,8>"      \
+             targetClass="ROOT::Math::SMatrix<double,8,8>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,8,8>"  \
+             targetClass="ROOT::Math::SMatrix<double,8,8>";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<double,9,9>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,9,9>" \
+             targetClass="ROOT::Math::SMatrix<double,9,9>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,9,9>"      \
+             targetClass="ROOT::Math::SMatrix<double,9,9>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,9,9>"  \
+             targetClass="ROOT::Math::SMatrix<double,9,9>";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<double,10,10>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,10,10>" \
+             targetClass="ROOT::Math::SMatrix<double,10,10>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,10,10>"      \
+             targetClass="ROOT::Math::SMatrix<double,10,10>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,10,10>"  \
+             targetClass="ROOT::Math::SMatrix<double,10,10>";
+
 
 #pragma link C++ class ROOT::Math::SMatrix<double,2,2>::SMatrixRow;
 #pragma link C++ class ROOT::Math::SMatrix<double,3,3>::SMatrixRow;
@@ -75,9 +285,30 @@
 #pragma link C++ class ROOT::Math::SMatrix<double,7,7>::SMatrixRow_const;
 
 
-#pragma link C++ class ROOT::Math::SMatrix<double,4,3>+;
-#pragma link C++ class ROOT::Math::SMatrix<double,3,4>+;
-#pragma link C++ class ROOT::Math::SMatrix<double,9,7>+;
+#pragma link C++ class    ROOT::Math::SMatrix<double,4,3>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,4,3>" \
+             targetClass="ROOT::Math::SMatrix<double,4,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,4,3>"      \
+             targetClass="ROOT::Math::SMatrix<double,4,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,4,3>"  \
+             targetClass="ROOT::Math::SMatrix<double,4,3>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,3,4>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,3,4>" \
+             targetClass="ROOT::Math::SMatrix<double,3,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,3,4>"      \
+             targetClass="ROOT::Math::SMatrix<double,3,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,3,4>"  \
+             targetClass="ROOT::Math::SMatrix<double,3,4>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,9,7>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,9,7>" \
+             targetClass="ROOT::Math::SMatrix<double,9,7>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,9,7>"      \
+             targetClass="ROOT::Math::SMatrix<double,9,7>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,9,7>"  \
+             targetClass="ROOT::Math::SMatrix<double,9,7>";
+
 
 #pragma link C++ class ROOT::Math::SMatrix<double,4,3>::SMatrixRow;
 #pragma link C++ class ROOT::Math::SMatrix<double,3,4>::SMatrixRow;
@@ -88,15 +319,78 @@
 #pragma link C++ class ROOT::Math::SMatrix<double,9,7>::SMatrixRow_const;
 
 
-#pragma link C++ class ROOT::Math::MatRepSym<double,2>+;
-#pragma link C++ class ROOT::Math::MatRepSym<double,3>+;
-#pragma link C++ class ROOT::Math::MatRepSym<double,4>+;
-#pragma link C++ class ROOT::Math::MatRepSym<double,5>+;
-#pragma link C++ class ROOT::Math::MatRepSym<double,6>+;
-#pragma link C++ class ROOT::Math::MatRepSym<double,7>+;
-// #pragma link C++ class ROOT::Math::MatRepSym<double,8>+;
-// #pragma link C++ class ROOT::Math::MatRepSym<double,9>+;
-// #pragma link C++ class ROOT::Math::MatRepSym<double,10>+;
+#pragma link C++ class    ROOT::Math::MatRepSym<double,2>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,2>" \
+             targetClass="ROOT::Math::MatRepSym<double,2>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,2>"      \
+             targetClass="ROOT::Math::MatRepSym<double,2>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,2>"  \
+             targetClass="ROOT::Math::MatRepSym<double,2>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<double,3>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,3>" \
+             targetClass="ROOT::Math::MatRepSym<double,3>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,3>"      \
+             targetClass="ROOT::Math::MatRepSym<double,3>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,3>"  \
+             targetClass="ROOT::Math::MatRepSym<double,3>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<double,4>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,4>" \
+             targetClass="ROOT::Math::MatRepSym<double,4>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,4>"      \
+             targetClass="ROOT::Math::MatRepSym<double,4>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,4>"  \
+             targetClass="ROOT::Math::MatRepSym<double,4>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<double,5>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,5>" \
+             targetClass="ROOT::Math::MatRepSym<double,5>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,5>"      \
+             targetClass="ROOT::Math::MatRepSym<double,5>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,5>"  \
+             targetClass="ROOT::Math::MatRepSym<double,5>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<double,6>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,6>" \
+             targetClass="ROOT::Math::MatRepSym<double,6>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,6>"      \
+             targetClass="ROOT::Math::MatRepSym<double,6>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,6>"  \
+             targetClass="ROOT::Math::MatRepSym<double,6>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<double,7>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,7>" \
+             targetClass="ROOT::Math::MatRepSym<double,7>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,7>"      \
+             targetClass="ROOT::Math::MatRepSym<double,7>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,7>"  \
+             targetClass="ROOT::Math::MatRepSym<double,7>";
+
+// #pragma link C++ class    ROOT::Math::MatRepSym<double,8>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,8>" \
+             targetClass="ROOT::Math::MatRepSym<double,8>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,8>"      \
+             targetClass="ROOT::Math::MatRepSym<double,8>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,8>"  \
+             targetClass="ROOT::Math::MatRepSym<double,8>";
+
+// #pragma link C++ class    ROOT::Math::MatRepSym<double,9>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,9>" \
+             targetClass="ROOT::Math::MatRepSym<double,9>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,9>"      \
+             targetClass="ROOT::Math::MatRepSym<double,9>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,9>"  \
+             targetClass="ROOT::Math::MatRepSym<double,9>";
+
+// #pragma link C++ class    ROOT::Math::MatRepSym<double,10>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,10>" \
+             targetClass="ROOT::Math::MatRepSym<double,10>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,10>"      \
+             targetClass="ROOT::Math::MatRepSym<double,10>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,10>"  \
+             targetClass="ROOT::Math::MatRepSym<double,10>";
+
 
 #pragma link C++ struct ROOT::Math::RowOffsets<2>;
 #pragma link C++ struct ROOT::Math::RowOffsets<3>;
@@ -109,12 +403,54 @@
 // #pragma link C++ struct ROOT::Math::RowOffsets<10>;
 
 
-#pragma link C++ class ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<double,2> >+;
-#pragma link C++ class ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> >+;
-#pragma link C++ class ROOT::Math::SMatrix<double,4,4,ROOT::Math::MatRepSym<double,4> >+;
-#pragma link C++ class ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<double,5> >+;
-#pragma link C++ class ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<double,6> >+;
-#pragma link C++ class ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<double,7> >+;
+#pragma link C++ class    ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<double,2> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<Double32_t,2> >" \
+             targetClass="ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<double,2> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<float,2> >"      \
+             targetClass="ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<double,2> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<Float16_t,2> >"  \
+             targetClass="ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<double,2> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<Double32_t,3> >" \
+             targetClass="ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<float,3> >"      \
+             targetClass="ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<Float16_t,3> >"  \
+             targetClass="ROOT::Math::SMatrix<double,3,3,ROOT::Math::MatRepSym<double,3> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,4,4,ROOT::Math::MatRepSym<double,4> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,4,4,ROOT::Math::MatRepSym<Double32_t,4> >" \
+             targetClass="ROOT::Math::SMatrix<double,4,4,ROOT::Math::MatRepSym<double,4> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,4,4,ROOT::Math::MatRepSym<float,4> >"      \
+             targetClass="ROOT::Math::SMatrix<double,4,4,ROOT::Math::MatRepSym<double,4> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,4,4,ROOT::Math::MatRepSym<Float16_t,4> >"  \
+             targetClass="ROOT::Math::SMatrix<double,4,4,ROOT::Math::MatRepSym<double,4> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<double,5> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<Double32_t,5> >" \
+             targetClass="ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<double,5> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<float,5> >"      \
+             targetClass="ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<double,5> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<Float16_t,5> >"  \
+             targetClass="ROOT::Math::SMatrix<double,5,5,ROOT::Math::MatRepSym<double,5> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<double,6> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<Double32_t,6> >" \
+             targetClass="ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<double,6> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<float,6> >"      \
+             targetClass="ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<double,6> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<Float16_t,6> >"  \
+             targetClass="ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<double,6> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<double,7> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<Double32_t,7> >" \
+             targetClass="ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<double,7> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<float,7> >"      \
+             targetClass="ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<double,7> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<Float16_t,7> >"  \
+             targetClass="ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<double,7> >";
+
 
 
 #pragma link C++ class ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<double,2> >::SMatrixRow;
@@ -132,9 +468,30 @@
 #pragma link C++ class ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<double,7> >::SMatrixRow_const;
 
 
-// #pragma link C++ class ROOT::Math::SMatrix<double,8,8,ROOT::Math::MatRepSym<double,8> >+;
-// #pragma link C++ class ROOT::Math::SMatrix<double,9,9,ROOT::Math::MatRepSym<double,9> >+;
-// #pragma link C++ class ROOT::Math::SMatrix<double,10,10,ROOT::Math::MatRepSym<double,10> >+;
+// #pragma link C++ class    ROOT::Math::SMatrix<double,8,8,ROOT::Math::MatRepSym<double,8> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,8,8,ROOT::Math::MatRepSym<Double32_t,8> >" \
+             targetClass="ROOT::Math::SMatrix<double,8,8,ROOT::Math::MatRepSym<double,8> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,8,8,ROOT::Math::MatRepSym<float,8> >"      \
+             targetClass="ROOT::Math::SMatrix<double,8,8,ROOT::Math::MatRepSym<double,8> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,8,8,ROOT::Math::MatRepSym<Float16_t,8> >"  \
+             targetClass="ROOT::Math::SMatrix<double,8,8,ROOT::Math::MatRepSym<double,8> >";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<double,9,9,ROOT::Math::MatRepSym<double,9> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,9,9,ROOT::Math::MatRepSym<Double32_t,9> >" \
+             targetClass="ROOT::Math::SMatrix<double,9,9,ROOT::Math::MatRepSym<double,9> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,9,9,ROOT::Math::MatRepSym<float,9> >"      \
+             targetClass="ROOT::Math::SMatrix<double,9,9,ROOT::Math::MatRepSym<double,9> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,9,9,ROOT::Math::MatRepSym<Float16_t,9> >"  \
+             targetClass="ROOT::Math::SMatrix<double,9,9,ROOT::Math::MatRepSym<double,9> >";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<double,10,10,ROOT::Math::MatRepSym<double,10> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,10,10,ROOT::Math::MatRepSym<Double32_t,10> >" \
+             targetClass="ROOT::Math::SMatrix<double,10,10,ROOT::Math::MatRepSym<double,10> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,10,10,ROOT::Math::MatRepSym<float,10> >"      \
+             targetClass="ROOT::Math::SMatrix<double,10,10,ROOT::Math::MatRepSym<double,10> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<double,10,10,ROOT::Math::MatRepSym<Float16_t,10> >"  \
+             targetClass="ROOT::Math::SMatrix<double,10,10,ROOT::Math::MatRepSym<double,10> >";
+
 
 // typedef's for  double matrices
 #pragma link C++ typedef ROOT::Math::SMatrix2D;
@@ -155,44 +512,275 @@
 
 //now for float
 
-#pragma link C++ class ROOT::Math::SVector<float,2>+;
-#pragma link C++ class ROOT::Math::SVector<float,3>+;
-#pragma link C++ class ROOT::Math::SVector<float,4>+;
-#pragma link C++ class ROOT::Math::SVector<float,5>+;
-#pragma link C++ class ROOT::Math::SVector<float,6>+;
-#pragma link C++ class ROOT::Math::SVector<float,7>+;
-// #pragma link C++ class ROOT::Math::SVector<float,8>+;
-// #pragma link C++ class ROOT::Math::SVector<float,9>+;
-// #pragma link C++ class ROOT::Math::SVector<float,10>+;
+#pragma link C++ class    ROOT::Math::SVector<float,2>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,2>"     \
+             targetClass="ROOT::Math::SVector<float,2>";
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,2>" \
+             targetClass="ROOT::Math::SVector<float,2>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,2>"  \
+             targetClass="ROOT::Math::SVector<float,2>";
+
+#pragma link C++ class    ROOT::Math::SVector<float,3>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,3>"     \
+             targetClass="ROOT::Math::SVector<float,3>";
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,3>" \
+             targetClass="ROOT::Math::SVector<float,3>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,3>"  \
+             targetClass="ROOT::Math::SVector<float,3>";
+
+#pragma link C++ class    ROOT::Math::SVector<float,4>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,4>"     \
+             targetClass="ROOT::Math::SVector<float,4>";
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,4>" \
+             targetClass="ROOT::Math::SVector<float,4>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,4>"  \
+             targetClass="ROOT::Math::SVector<float,4>";
+
+#pragma link C++ class    ROOT::Math::SVector<float,5>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,5>"     \
+             targetClass="ROOT::Math::SVector<float,5>";
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,5>" \
+             targetClass="ROOT::Math::SVector<float,5>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,5>"  \
+             targetClass="ROOT::Math::SVector<float,5>";
+
+#pragma link C++ class    ROOT::Math::SVector<float,6>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,6>"     \
+             targetClass="ROOT::Math::SVector<float,6>";
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,6>" \
+             targetClass="ROOT::Math::SVector<float,6>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,6>"  \
+             targetClass="ROOT::Math::SVector<float,6>";
+
+#pragma link C++ class    ROOT::Math::SVector<float,7>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,7>"     \
+             targetClass="ROOT::Math::SVector<float,7>";
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,7>" \
+             targetClass="ROOT::Math::SVector<float,7>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,7>"  \
+             targetClass="ROOT::Math::SVector<float,7>";
+
+// #pragma link C++ class    ROOT::Math::SVector<float,8>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,8>"     \
+             targetClass="ROOT::Math::SVector<float,8>";
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,8>" \
+             targetClass="ROOT::Math::SVector<float,8>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,8>"  \
+             targetClass="ROOT::Math::SVector<float,8>";
+
+// #pragma link C++ class    ROOT::Math::SVector<float,9>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,9>"     \
+             targetClass="ROOT::Math::SVector<float,9>";
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,9>" \
+             targetClass="ROOT::Math::SVector<float,9>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,9>"  \
+             targetClass="ROOT::Math::SVector<float,9>";
+
+// #pragma link C++ class    ROOT::Math::SVector<float,10>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,10>"     \
+             targetClass="ROOT::Math::SVector<float,10>";
+#pragma read sourceClass="ROOT::Math::SVector<Double32_t,10>" \
+             targetClass="ROOT::Math::SVector<float,10>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,10>"  \
+             targetClass="ROOT::Math::SVector<float,10>";
 
 
-#pragma link C++ class ROOT::Math::MatRepStd<float,2,2>+;
-#pragma link C++ class ROOT::Math::MatRepStd<float,3,3>+;
-#pragma link C++ class ROOT::Math::MatRepStd<float,4,4>+;
-#pragma link C++ class ROOT::Math::MatRepStd<float,5,5>+;
-#pragma link C++ class ROOT::Math::MatRepStd<float,6,6>+;
-#pragma link C++ class ROOT::Math::MatRepStd<float,7,7>+;
-// #pragma link C++ class ROOT::Math::MatRepStd<float,8,8>+;
-// #pragma link C++ class ROOT::Math::MatRepStd<float,9,9>+;
-// #pragma link C++ class ROOT::Math::MatRepStd<float,10,10>+;
 
-#pragma link C++ class ROOT::Math::MatRepStd<float,4,3>+;
-#pragma link C++ class ROOT::Math::MatRepStd<float,3,4>+;
-#pragma link C++ class ROOT::Math::MatRepStd<float,9,7>+;
+#pragma link C++ class    ROOT::Math::MatRepStd<float,2,2>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,2,2>"     \
+             targetClass="ROOT::Math::MatRepStd<float,2,2>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,2,2>" \
+             targetClass="ROOT::Math::MatRepStd<float,2,2>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,2,2>"  \
+             targetClass="ROOT::Math::MatRepStd<float,2,2>";
 
-#pragma link C++ class ROOT::Math::SMatrix<float,2,2>+;
-#pragma link C++ class ROOT::Math::SMatrix<float,3,3>+;
-#pragma link C++ class ROOT::Math::SMatrix<float,4,4>+;
-#pragma link C++ class ROOT::Math::SMatrix<float,5,5>+;
-#pragma link C++ class ROOT::Math::SMatrix<float,6,6>+;
-#pragma link C++ class ROOT::Math::SMatrix<float,7,7>+;
-// #pragma link C++ class ROOT::Math::SMatrix<float,8,8>+;
-// #pragma link C++ class ROOT::Math::SMatrix<float,9,9>+;
-// #pragma link C++ class ROOT::Math::SMatrix<float,10,10>+;
+#pragma link C++ class    ROOT::Math::MatRepStd<float,3,3>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,3,3>"     \
+             targetClass="ROOT::Math::MatRepStd<float,3,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,3,3>" \
+             targetClass="ROOT::Math::MatRepStd<float,3,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,3,3>"  \
+             targetClass="ROOT::Math::MatRepStd<float,3,3>";
 
-#pragma link C++ class ROOT::Math::SMatrix<float,4,3>+;
-#pragma link C++ class ROOT::Math::SMatrix<float,3,4>+;
-#pragma link C++ class ROOT::Math::SMatrix<float,9,7>+;
+#pragma link C++ class    ROOT::Math::MatRepStd<float,4,4>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,4,4>"     \
+             targetClass="ROOT::Math::MatRepStd<float,4,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,4,4>" \
+             targetClass="ROOT::Math::MatRepStd<float,4,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,4,4>"  \
+             targetClass="ROOT::Math::MatRepStd<float,4,4>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<float,5,5>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,5,5>"     \
+             targetClass="ROOT::Math::MatRepStd<float,5,5>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,5,5>" \
+             targetClass="ROOT::Math::MatRepStd<float,5,5>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,5,5>"  \
+             targetClass="ROOT::Math::MatRepStd<float,5,5>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<float,6,6>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,6,6>"     \
+             targetClass="ROOT::Math::MatRepStd<float,6,6>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,6,6>" \
+             targetClass="ROOT::Math::MatRepStd<float,6,6>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,6,6>"  \
+             targetClass="ROOT::Math::MatRepStd<float,6,6>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<float,7,7>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,7,7>"     \
+             targetClass="ROOT::Math::MatRepStd<float,7,7>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,7,7>" \
+             targetClass="ROOT::Math::MatRepStd<float,7,7>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,7,7>"  \
+             targetClass="ROOT::Math::MatRepStd<float,7,7>";
+
+// #pragma link C++ class    ROOT::Math::MatRepStd<float,8,8>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,8,8>"     \
+             targetClass="ROOT::Math::MatRepStd<float,8,8>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,8,8>" \
+             targetClass="ROOT::Math::MatRepStd<float,8,8>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,8,8>"  \
+             targetClass="ROOT::Math::MatRepStd<float,8,8>";
+
+// #pragma link C++ class    ROOT::Math::MatRepStd<float,9,9>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,9,9>"     \
+             targetClass="ROOT::Math::MatRepStd<float,9,9>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,9,9>" \
+             targetClass="ROOT::Math::MatRepStd<float,9,9>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,9,9>"  \
+             targetClass="ROOT::Math::MatRepStd<float,9,9>";
+
+// #pragma link C++ class    ROOT::Math::MatRepStd<float,10,10>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,10,10>"     \
+             targetClass="ROOT::Math::MatRepStd<float,10,10>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,10,10>" \
+             targetClass="ROOT::Math::MatRepStd<float,10,10>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,10,10>"  \
+             targetClass="ROOT::Math::MatRepStd<float,10,10>";
+
+
+#pragma link C++ class    ROOT::Math::MatRepStd<float,4,3>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,4,3>"     \
+             targetClass="ROOT::Math::MatRepStd<float,4,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,4,3>" \
+             targetClass="ROOT::Math::MatRepStd<float,4,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,4,3>"  \
+             targetClass="ROOT::Math::MatRepStd<float,4,3>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<float,3,4>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,3,4>"     \
+             targetClass="ROOT::Math::MatRepStd<float,3,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,3,4>" \
+             targetClass="ROOT::Math::MatRepStd<float,3,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,3,4>"  \
+             targetClass="ROOT::Math::MatRepStd<float,3,4>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<float,9,7>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,9,7>"     \
+             targetClass="ROOT::Math::MatRepStd<float,9,7>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Double32_t,9,7>" \
+             targetClass="ROOT::Math::MatRepStd<float,9,7>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,9,7>"  \
+             targetClass="ROOT::Math::MatRepStd<float,9,7>";
+
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,2,2>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,2,2>"     \
+             targetClass="ROOT::Math::SMatrix<float,2,2>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,2,2>" \
+             targetClass="ROOT::Math::SMatrix<float,2,2>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,2,2>"  \
+             targetClass="ROOT::Math::SMatrix<float,2,2>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,3,3>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,3,3>"     \
+             targetClass="ROOT::Math::SMatrix<float,3,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,3,3>" \
+             targetClass="ROOT::Math::SMatrix<float,3,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,3,3>"  \
+             targetClass="ROOT::Math::SMatrix<float,3,3>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,4,4>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,4,4>"     \
+             targetClass="ROOT::Math::SMatrix<float,4,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,4,4>" \
+             targetClass="ROOT::Math::SMatrix<float,4,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,4,4>"  \
+             targetClass="ROOT::Math::SMatrix<float,4,4>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,5,5>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,5,5>"     \
+             targetClass="ROOT::Math::SMatrix<float,5,5>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,5,5>" \
+             targetClass="ROOT::Math::SMatrix<float,5,5>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,5,5>"  \
+             targetClass="ROOT::Math::SMatrix<float,5,5>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,6,6>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,6,6>"     \
+             targetClass="ROOT::Math::SMatrix<float,6,6>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,6,6>" \
+             targetClass="ROOT::Math::SMatrix<float,6,6>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,6,6>"  \
+             targetClass="ROOT::Math::SMatrix<float,6,6>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,7,7>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,7,7>"     \
+             targetClass="ROOT::Math::SMatrix<float,7,7>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,7,7>" \
+             targetClass="ROOT::Math::SMatrix<float,7,7>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,7,7>"  \
+             targetClass="ROOT::Math::SMatrix<float,7,7>";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<float,8,8>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,8,8>"     \
+             targetClass="ROOT::Math::SMatrix<float,8,8>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,8,8>" \
+             targetClass="ROOT::Math::SMatrix<float,8,8>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,8,8>"  \
+             targetClass="ROOT::Math::SMatrix<float,8,8>";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<float,9,9>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,9,9>"     \
+             targetClass="ROOT::Math::SMatrix<float,9,9>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,9,9>" \
+             targetClass="ROOT::Math::SMatrix<float,9,9>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,9,9>"  \
+             targetClass="ROOT::Math::SMatrix<float,9,9>";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<float,10,10>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,10,10>"     \
+             targetClass="ROOT::Math::SMatrix<float,10,10>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,10,10>" \
+             targetClass="ROOT::Math::SMatrix<float,10,10>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,10,10>"  \
+             targetClass="ROOT::Math::SMatrix<float,10,10>";
+
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,4,3>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,4,3>"     \
+             targetClass="ROOT::Math::SMatrix<float,4,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,4,3>" \
+             targetClass="ROOT::Math::SMatrix<float,4,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,4,3>"  \
+             targetClass="ROOT::Math::SMatrix<float,4,3>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,3,4>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,3,4>"     \
+             targetClass="ROOT::Math::SMatrix<float,3,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,3,4>" \
+             targetClass="ROOT::Math::SMatrix<float,3,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,3,4>"  \
+             targetClass="ROOT::Math::SMatrix<float,3,4>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,9,7>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,9,7>"     \
+             targetClass="ROOT::Math::SMatrix<float,9,7>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,9,7>" \
+             targetClass="ROOT::Math::SMatrix<float,9,7>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,9,7>"  \
+             targetClass="ROOT::Math::SMatrix<float,9,7>";
+
 
 #pragma link C++ class ROOT::Math::SMatrix<float,2,2>::SMatrixRow;
 #pragma link C++ class ROOT::Math::SMatrix<float,3,3>::SMatrixRow;
@@ -217,15 +805,78 @@
 #pragma link C++ class ROOT::Math::SMatrix<float,9,7>::SMatrixRow_const;
 
 
-#pragma link C++ class ROOT::Math::MatRepSym<float,2>+;
-#pragma link C++ class ROOT::Math::MatRepSym<float,3>+;
-#pragma link C++ class ROOT::Math::MatRepSym<float,4>+;
-#pragma link C++ class ROOT::Math::MatRepSym<float,5>+;
-#pragma link C++ class ROOT::Math::MatRepSym<float,6>+;
-#pragma link C++ class ROOT::Math::MatRepSym<float,7>+;
-// #pragma link C++ class ROOT::Math::MatRepSym<float,8>+;
-// #pragma link C++ class ROOT::Math::MatRepSym<float,9>+;
-// #pragma link C++ class ROOT::Math::MatRepSym<float,10>+;
+#pragma link C++ class    ROOT::Math::MatRepSym<float,2>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,2>"     \
+             targetClass="ROOT::Math::MatRepSym<float,2>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,2>" \
+             targetClass="ROOT::Math::MatRepSym<float,2>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,2>"  \
+             targetClass="ROOT::Math::MatRepSym<float,2>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<float,3>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,3>"     \
+             targetClass="ROOT::Math::MatRepSym<float,3>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,3>" \
+             targetClass="ROOT::Math::MatRepSym<float,3>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,3>"  \
+             targetClass="ROOT::Math::MatRepSym<float,3>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<float,4>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,4>"     \
+             targetClass="ROOT::Math::MatRepSym<float,4>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,4>" \
+             targetClass="ROOT::Math::MatRepSym<float,4>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,4>"  \
+             targetClass="ROOT::Math::MatRepSym<float,4>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<float,5>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,5>"     \
+             targetClass="ROOT::Math::MatRepSym<float,5>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,5>" \
+             targetClass="ROOT::Math::MatRepSym<float,5>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,5>"  \
+             targetClass="ROOT::Math::MatRepSym<float,5>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<float,6>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,6>"     \
+             targetClass="ROOT::Math::MatRepSym<float,6>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,6>" \
+             targetClass="ROOT::Math::MatRepSym<float,6>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,6>"  \
+             targetClass="ROOT::Math::MatRepSym<float,6>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<float,7>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,7>"     \
+             targetClass="ROOT::Math::MatRepSym<float,7>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,7>" \
+             targetClass="ROOT::Math::MatRepSym<float,7>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,7>"  \
+             targetClass="ROOT::Math::MatRepSym<float,7>";
+
+// #pragma link C++ class    ROOT::Math::MatRepSym<float,8>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,8>"     \
+             targetClass="ROOT::Math::MatRepSym<float,8>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,8>" \
+             targetClass="ROOT::Math::MatRepSym<float,8>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,8>"  \
+             targetClass="ROOT::Math::MatRepSym<float,8>";
+
+// #pragma link C++ class    ROOT::Math::MatRepSym<float,9>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,9>"     \
+             targetClass="ROOT::Math::MatRepSym<float,9>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,9>" \
+             targetClass="ROOT::Math::MatRepSym<float,9>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,9>"  \
+             targetClass="ROOT::Math::MatRepSym<float,9>";
+
+// #pragma link C++ class    ROOT::Math::MatRepSym<float,10>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,10>"     \
+             targetClass="ROOT::Math::MatRepSym<float,10>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Double32_t,10>" \
+             targetClass="ROOT::Math::MatRepSym<float,10>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,10>"  \
+             targetClass="ROOT::Math::MatRepSym<float,10>";
+
 
 #pragma link C++ struct ROOT::Math::RowOffsets<2>;
 #pragma link C++ struct ROOT::Math::RowOffsets<3>;
@@ -238,15 +889,78 @@
 // #pragma link C++ struct ROOT::Math::RowOffsets<10>;
 
 
-#pragma link C++ class ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<float,2> >+;
-#pragma link C++ class ROOT::Math::SMatrix<float,3,3,ROOT::Math::MatRepSym<float,3> >+;
-#pragma link C++ class ROOT::Math::SMatrix<float,4,4,ROOT::Math::MatRepSym<float,4> >+;
-#pragma link C++ class ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<float,5> >+;
-#pragma link C++ class ROOT::Math::SMatrix<float,6,6,ROOT::Math::MatRepSym<float,6> >+;
-#pragma link C++ class ROOT::Math::SMatrix<float,7,7,ROOT::Math::MatRepSym<float,7> >+;
-// #pragma link C++ class ROOT::Math::SMatrix<float,8,8,ROOT::Math::MatRepSym<float,8> >+;
-// #pragma link C++ class ROOT::Math::SMatrix<float,9,9,ROOT::Math::MatRepSym<float,9> >+;
-// #pragma link C++ class ROOT::Math::SMatrix<float,10,10,ROOT::Math::MatRepSym<float,10> >+;
+#pragma link C++ class    ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<float,2> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<double,2> >"     \
+             targetClass="ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<float,2> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<Double32_t,2> >" \
+             targetClass="ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<float,2> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<Float16_t,2> >"  \
+             targetClass="ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<float,2> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,3,3,ROOT::Math::MatRepSym<float,3> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<float,3,3,ROOT::Math::MatRepSym<double,3> >"     \
+             targetClass="ROOT::Math::SMatrix<float,3,3,ROOT::Math::MatRepSym<float,3> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,3,3,ROOT::Math::MatRepSym<Double32_t,3> >" \
+             targetClass="ROOT::Math::SMatrix<float,3,3,ROOT::Math::MatRepSym<float,3> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,3,3,ROOT::Math::MatRepSym<Float16_t,3> >"  \
+             targetClass="ROOT::Math::SMatrix<float,3,3,ROOT::Math::MatRepSym<float,3> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,4,4,ROOT::Math::MatRepSym<float,4> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<float,4,4,ROOT::Math::MatRepSym<double,4> >"     \
+             targetClass="ROOT::Math::SMatrix<float,4,4,ROOT::Math::MatRepSym<float,4> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,4,4,ROOT::Math::MatRepSym<Double32_t,4> >" \
+             targetClass="ROOT::Math::SMatrix<float,4,4,ROOT::Math::MatRepSym<float,4> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,4,4,ROOT::Math::MatRepSym<Float16_t,4> >"  \
+             targetClass="ROOT::Math::SMatrix<float,4,4,ROOT::Math::MatRepSym<float,4> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<float,5> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<double,5> >"     \
+             targetClass="ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<float,5> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<Double32_t,5> >" \
+             targetClass="ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<float,5> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<Float16_t,5> >"  \
+             targetClass="ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<float,5> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,6,6,ROOT::Math::MatRepSym<float,6> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<float,6,6,ROOT::Math::MatRepSym<double,6> >"     \
+             targetClass="ROOT::Math::SMatrix<float,6,6,ROOT::Math::MatRepSym<float,6> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,6,6,ROOT::Math::MatRepSym<Double32_t,6> >" \
+             targetClass="ROOT::Math::SMatrix<float,6,6,ROOT::Math::MatRepSym<float,6> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,6,6,ROOT::Math::MatRepSym<Float16_t,6> >"  \
+             targetClass="ROOT::Math::SMatrix<float,6,6,ROOT::Math::MatRepSym<float,6> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<float,7,7,ROOT::Math::MatRepSym<float,7> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<float,7,7,ROOT::Math::MatRepSym<double,7> >"     \
+             targetClass="ROOT::Math::SMatrix<float,7,7,ROOT::Math::MatRepSym<float,7> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,7,7,ROOT::Math::MatRepSym<Double32_t,7> >" \
+             targetClass="ROOT::Math::SMatrix<float,7,7,ROOT::Math::MatRepSym<float,7> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,7,7,ROOT::Math::MatRepSym<Float16_t,7> >"  \
+             targetClass="ROOT::Math::SMatrix<float,7,7,ROOT::Math::MatRepSym<float,7> >";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<float,8,8,ROOT::Math::MatRepSym<float,8> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<float,8,8,ROOT::Math::MatRepSym<double,8> >"     \
+             targetClass="ROOT::Math::SMatrix<float,8,8,ROOT::Math::MatRepSym<float,8> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,8,8,ROOT::Math::MatRepSym<Double32_t,8> >" \
+             targetClass="ROOT::Math::SMatrix<float,8,8,ROOT::Math::MatRepSym<float,8> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,8,8,ROOT::Math::MatRepSym<Float16_t,8> >"  \
+             targetClass="ROOT::Math::SMatrix<float,8,8,ROOT::Math::MatRepSym<float,8> >";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<float,9,9,ROOT::Math::MatRepSym<float,9> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<float,9,9,ROOT::Math::MatRepSym<double,9> >"     \
+             targetClass="ROOT::Math::SMatrix<float,9,9,ROOT::Math::MatRepSym<float,9> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,9,9,ROOT::Math::MatRepSym<Double32_t,9> >" \
+             targetClass="ROOT::Math::SMatrix<float,9,9,ROOT::Math::MatRepSym<float,9> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,9,9,ROOT::Math::MatRepSym<Float16_t,9> >"  \
+             targetClass="ROOT::Math::SMatrix<float,9,9,ROOT::Math::MatRepSym<float,9> >";
+
+// #pragma link C++ class    ROOT::Math::SMatrix<float,10,10,ROOT::Math::MatRepSym<float,10> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<float,10,10,ROOT::Math::MatRepSym<double,10> >"     \
+             targetClass="ROOT::Math::SMatrix<float,10,10,ROOT::Math::MatRepSym<float,10> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,10,10,ROOT::Math::MatRepSym<Double32_t,10> >" \
+             targetClass="ROOT::Math::SMatrix<float,10,10,ROOT::Math::MatRepSym<float,10> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,10,10,ROOT::Math::MatRepSym<Float16_t,10> >"  \
+             targetClass="ROOT::Math::SMatrix<float,10,10,ROOT::Math::MatRepSym<float,10> >";
+
 
 
 #pragma link C++ class ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<float,2> >::SMatrixRow;

--- a/math/smatrix/inc/LinkDefD32.h
+++ b/math/smatrix/inc/LinkDefD32.h
@@ -20,32 +20,172 @@
 //#pragma link C++ class ROOT::Math::SMatrixIdentity+;
 
 //generate from 3x3 up to 6x6
-#pragma link C++ class ROOT::Math::SMatrix<Double32_t,3,3>+;
-#pragma link C++ class ROOT::Math::SMatrix<Double32_t,4,4>+;
-#pragma link C++ class ROOT::Math::SMatrix<Double32_t,5,5>+;
-#pragma link C++ class ROOT::Math::SMatrix<Double32_t,6,6>+;
+#pragma link C++ class    ROOT::Math::SMatrix<Double32_t,3,3>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,3,3>"    \
+             targetClass="ROOT::Math::SMatrix<Double32_t,3,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,3,3>"     \
+             targetClass="ROOT::Math::SMatrix<Double32_t,3,3>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,3,3>" \
+             targetClass="ROOT::Math::SMatrix<Double32_t,3,3>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<Double32_t,4,4>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,4,4>"    \
+             targetClass="ROOT::Math::SMatrix<Double32_t,4,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,4,4>"     \
+             targetClass="ROOT::Math::SMatrix<Double32_t,4,4>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,4,4>" \
+             targetClass="ROOT::Math::SMatrix<Double32_t,4,4>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<Double32_t,5,5>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,5,5>"    \
+             targetClass="ROOT::Math::SMatrix<Double32_t,5,5>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,5,5>"     \
+             targetClass="ROOT::Math::SMatrix<Double32_t,5,5>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,5,5>" \
+             targetClass="ROOT::Math::SMatrix<Double32_t,5,5>";
+
+#pragma link C++ class    ROOT::Math::SMatrix<Double32_t,6,6>+;
+#pragma read sourceClass="ROOT::Math::SMatrix<double,6,6>"    \
+             targetClass="ROOT::Math::SMatrix<Double32_t,6,6>";
+#pragma read sourceClass="ROOT::Math::SMatrix<float,6,6>"     \
+             targetClass="ROOT::Math::SMatrix<Double32_t,6,6>";
+#pragma read sourceClass="ROOT::Math::SMatrix<Float16_t,6,6>" \
+             targetClass="ROOT::Math::SMatrix<Double32_t,6,6>";
 
 
-#pragma link C++ class ROOT::Math::MatRepStd<Double32_t,3,3>+;
-#pragma link C++ class ROOT::Math::MatRepStd<Double32_t,4,4>+;
-#pragma link C++ class ROOT::Math::MatRepStd<Double32_t,5,5>+;
-#pragma link C++ class ROOT::Math::MatRepStd<Double32_t,6,6>+;
+
+#pragma link C++ class    ROOT::Math::MatRepStd<Double32_t,3,3>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,3,3>"    \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,3,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,3,3>"     \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,3,3>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,3,3>" \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,3,3>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<Double32_t,4,4>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,4,4>"    \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,4,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,4,4>"     \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,4,4>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,4,4>" \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,4,4>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<Double32_t,5,5>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,5,5>"    \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,5,5>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,5,5>"     \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,5,5>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,5,5>" \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,5,5>";
+
+#pragma link C++ class    ROOT::Math::MatRepStd<Double32_t,6,6>+;
+#pragma read sourceClass="ROOT::Math::MatRepStd<double,6,6>"    \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,6,6>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<float,6,6>"     \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,6,6>";
+#pragma read sourceClass="ROOT::Math::MatRepStd<Float16_t,6,6>" \
+             targetClass="ROOT::Math::MatRepStd<Double32_t,6,6>";
 
 
-#pragma link C++ class ROOT::Math::SVector<Double32_t,3>+;
-#pragma link C++ class ROOT::Math::SVector<Double32_t,4>+;
-#pragma link C++ class ROOT::Math::SVector<Double32_t,5>+;
-#pragma link C++ class ROOT::Math::SVector<Double32_t,6>+;
 
-#pragma link C++ class ROOT::Math::MatRepSym<Double32_t,3>+;
-#pragma link C++ class ROOT::Math::MatRepSym<Double32_t,4>+;
-#pragma link C++ class ROOT::Math::MatRepSym<Double32_t,5>+;
-#pragma link C++ class ROOT::Math::MatRepSym<Double32_t,6>+;
+#pragma link C++ class    ROOT::Math::SVector<Double32_t,3>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,3>"    \
+             targetClass="ROOT::Math::SVector<Double32_t,3>";
+#pragma read sourceClass="ROOT::Math::SVector<float,3>"     \
+             targetClass="ROOT::Math::SVector<Double32_t,3>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,3>" \
+             targetClass="ROOT::Math::SVector<Double32_t,3>";
 
-#pragma link C++ class ROOT::Math::SMatrix<Double32_t,3,3,ROOT::Math::MatRepSym<Double32_t,3> >+;
-#pragma link C++ class ROOT::Math::SMatrix<Double32_t,4,4,ROOT::Math::MatRepSym<Double32_t,4> >+;
-#pragma link C++ class ROOT::Math::SMatrix<Double32_t,5,5,ROOT::Math::MatRepSym<Double32_t,5> >+;
-#pragma link C++ class ROOT::Math::SMatrix<Double32_t,6,6,ROOT::Math::MatRepSym<Double32_t,6> >+;
+#pragma link C++ class    ROOT::Math::SVector<Double32_t,4>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,4>"    \
+             targetClass="ROOT::Math::SVector<Double32_t,4>";
+#pragma read sourceClass="ROOT::Math::SVector<float,4>"     \
+             targetClass="ROOT::Math::SVector<Double32_t,4>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,4>" \
+             targetClass="ROOT::Math::SVector<Double32_t,4>";
+
+#pragma link C++ class    ROOT::Math::SVector<Double32_t,5>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,5>"    \
+             targetClass="ROOT::Math::SVector<Double32_t,5>";
+#pragma read sourceClass="ROOT::Math::SVector<float,5>"     \
+             targetClass="ROOT::Math::SVector<Double32_t,5>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,5>" \
+             targetClass="ROOT::Math::SVector<Double32_t,5>";
+
+#pragma link C++ class    ROOT::Math::SVector<Double32_t,6>+;
+#pragma read sourceClass="ROOT::Math::SVector<double,6>"    \
+             targetClass="ROOT::Math::SVector<Double32_t,6>";
+#pragma read sourceClass="ROOT::Math::SVector<float,6>"     \
+             targetClass="ROOT::Math::SVector<Double32_t,6>";
+#pragma read sourceClass="ROOT::Math::SVector<Float16_t,6>" \
+             targetClass="ROOT::Math::SVector<Double32_t,6>";
+
+
+#pragma link C++ class    ROOT::Math::MatRepSym<Double32_t,3>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,3>"    \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,3>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,3>"     \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,3>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,3>" \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,3>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<Double32_t,4>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,4>"    \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,4>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,4>"     \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,4>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,4>" \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,4>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<Double32_t,5>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,5>"    \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,5>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,5>"     \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,5>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,5>" \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,5>";
+
+#pragma link C++ class    ROOT::Math::MatRepSym<Double32_t,6>+;
+#pragma read sourceClass="ROOT::Math::MatRepSym<double,6>"    \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,6>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<float,6>"     \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,6>";
+#pragma read sourceClass="ROOT::Math::MatRepSym<Float16_t,6>" \
+             targetClass="ROOT::Math::MatRepSym<Double32_t,6>";
+
+
+#pragma link C++ class    ROOT::Math::SMatrix<Double32_t,3,3,ROOT::Math::MatRepSym<Double32_t,3> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,3,3,ROOT::Math::MatRepSym<double,3> >"    \
+             targetClass="ROOT::Math::SMatrix<Double32_t,3,3,ROOT::Math::MatRepSym<Double32_t,3> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,3,3,ROOT::Math::MatRepSym<float,3> >"     \
+             targetClass="ROOT::Math::SMatrix<Double32_t,3,3,ROOT::Math::MatRepSym<Double32_t,3> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,3,3,ROOT::Math::MatRepSym<Float16_t,3> >" \
+             targetClass="ROOT::Math::SMatrix<Double32_t,3,3,ROOT::Math::MatRepSym<Double32_t,3> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<Double32_t,4,4,ROOT::Math::MatRepSym<Double32_t,4> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,4,4,ROOT::Math::MatRepSym<double,4> >"    \
+             targetClass="ROOT::Math::SMatrix<Double32_t,4,4,ROOT::Math::MatRepSym<Double32_t,4> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,4,4,ROOT::Math::MatRepSym<float,4> >"     \
+             targetClass="ROOT::Math::SMatrix<Double32_t,4,4,ROOT::Math::MatRepSym<Double32_t,4> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,4,4,ROOT::Math::MatRepSym<Float16_t,4> >" \
+             targetClass="ROOT::Math::SMatrix<Double32_t,4,4,ROOT::Math::MatRepSym<Double32_t,4> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<Double32_t,5,5,ROOT::Math::MatRepSym<Double32_t,5> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,5,5,ROOT::Math::MatRepSym<double,5> >"    \
+             targetClass="ROOT::Math::SMatrix<Double32_t,5,5,ROOT::Math::MatRepSym<Double32_t,5> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,5,5,ROOT::Math::MatRepSym<float,5> >"     \
+             targetClass="ROOT::Math::SMatrix<Double32_t,5,5,ROOT::Math::MatRepSym<Double32_t,5> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,5,5,ROOT::Math::MatRepSym<Float16_t,5> >" \
+             targetClass="ROOT::Math::SMatrix<Double32_t,5,5,ROOT::Math::MatRepSym<Double32_t,5> >";
+
+#pragma link C++ class    ROOT::Math::SMatrix<Double32_t,6,6,ROOT::Math::MatRepSym<Double32_t,6> >+;
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,6,6,ROOT::Math::MatRepSym<double,6> >"    \
+             targetClass="ROOT::Math::SMatrix<Double32_t,6,6,ROOT::Math::MatRepSym<Double32_t,6> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,6,6,ROOT::Math::MatRepSym<float,6> >"     \
+             targetClass="ROOT::Math::SMatrix<Double32_t,6,6,ROOT::Math::MatRepSym<Double32_t,6> >";
+#pragma read sourceClass="ROOT::Math::SMatrix<Double32_t,6,6,ROOT::Math::MatRepSym<Float16_t,6> >" \
+             targetClass="ROOT::Math::SMatrix<Double32_t,6,6,ROOT::Math::MatRepSym<Double32_t,6> >";
+
 
 
 #endif


### PR DESCRIPTION
This adds the ability to read math_template< floating_point > into math_template< other_floating_point> where floating_point is one of float, double, Double32_t or Float16_t [note that we are not yet generating dictionary for Float16_t and the user that does it for themselves would need to add the renaming rules with the Float16_t as target as well (if they need them)]