### PR TITLE
Allow user to actually customize the 1st block's size in TMemFile. (v618)

### DIFF
--- a/README/ReleaseNotes/v618/index.md
+++ b/README/ReleaseNotes/v618/index.md
@@ -690,4 +690,6 @@ df.AsNumpy()
 
 These changes will be part of the future 6.18/02.
 
-None so far!
+## I/O Libraries
+
+* TMemFile: Apply customization of minimal block size also to the first block.

--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -80,7 +80,8 @@ private:
 public:
    TMemFile(const char *name, Option_t *option = "", const char *ftitle = "",
             Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose, Long64_t defBlockSize = 0LL);
-   TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose, Long64_t defBlockSize = 0LL);
+   TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option = "", const char *ftitle = "",
+            Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose, Long64_t defBlockSize = 0LL);
    TMemFile(const char *name, ExternalDataPtr_t data);
    TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer);
    TMemFile(const TMemFile &orig);

--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -80,7 +80,7 @@ private:
 public:
    TMemFile(const char *name, Option_t *option = "", const char *ftitle = "",
             Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose, Long64_t defBlockSize = 0LL);
-   TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
+   TMemFile(const char *name, char *buffer, Long64_t size, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose, Long64_t defBlockSize = 0LL);
    TMemFile(const char *name, ExternalDataPtr_t data);
    TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer);
    TMemFile(const TMemFile &orig);

--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -171,13 +171,13 @@ TMemFile::TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer) :
 TMemFile::TMemFile(const char *path, Option_t *option, const char *ftitle, Int_t compress, Long64_t defBlockSize)
    : TMemFile(path, nullptr, -1, option, ftitle, compress, defBlockSize)
 {
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Usual Constructor.  See the TFile constructor for details. Copy data from buffer.
 
-TMemFile::TMemFile(const char *path, char *buffer, Long64_t size, Option_t *option, const char *ftitle, Int_t compress, Long64_t defBlockSize)
+TMemFile::TMemFile(const char *path, char *buffer, Long64_t size, Option_t *option, const char *ftitle, Int_t compress,
+                   Long64_t defBlockSize)
    : TFile(path, "WEB", ftitle, compress), fBlockList(size), fSize(size), fSysOffset(0), fBlockSeek(&(fBlockList)),
      fBlockOffset(0)
 {

--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -169,18 +169,20 @@ TMemFile::TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer) :
 /// See the TFile constructor for details.
 
 TMemFile::TMemFile(const char *path, Option_t *option, const char *ftitle, Int_t compress, Long64_t defBlockSize)
-   : TMemFile(path, nullptr, -1, option, ftitle, compress)
+   : TMemFile(path, nullptr, -1, option, ftitle, compress, defBlockSize)
 {
-   fDefaultBlockSize = defBlockSize == 0LL ? fgDefaultBlockSize : defBlockSize;
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Usual Constructor.  See the TFile constructor for details. Copy data from buffer.
 
-TMemFile::TMemFile(const char *path, char *buffer, Long64_t size, Option_t *option, const char *ftitle, Int_t compress)
+TMemFile::TMemFile(const char *path, char *buffer, Long64_t size, Option_t *option, const char *ftitle, Int_t compress, Long64_t defBlockSize)
    : TFile(path, "WEB", ftitle, compress), fBlockList(size), fSize(size), fSysOffset(0), fBlockSeek(&(fBlockList)),
      fBlockOffset(0)
 {
+   fDefaultBlockSize = defBlockSize == 0LL ? fgDefaultBlockSize : defBlockSize;
+
    EMode optmode = ParseOption(option);
 
    if (NeedsToWrite(optmode)) {

--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -189,7 +189,7 @@ TMemFile::TMemFile(const char *path, char *buffer, Long64_t size, Option_t *opti
       Int_t mode = O_RDWR | O_CREAT;
       if (optmode == EMode::kRecreate) mode |= O_TRUNC;
 
-      fD = SysOpen(path, O_RDWR | O_CREAT, 0644);
+      fD = TMemFile::SysOpen(path, O_RDWR | O_CREAT, 0644);
       if (fD == -1) {
          SysError("TMemFile", "file %s can not be opened", path);
          goto zombie;
@@ -197,7 +197,7 @@ TMemFile::TMemFile(const char *path, char *buffer, Long64_t size, Option_t *opti
       fWritable = kTRUE;
 
    } else {
-      fD = SysOpen(path, O_RDONLY, 0644);
+      fD = TMemFile::SysOpen(path, O_RDONLY, 0644);
       if (fD == -1) {
          SysError("TMemFile", "file %s can not be opened for reading", path);
          goto zombie;


### PR DESCRIPTION
Previously the user input was recorded only after the first block was created.

See https://root-forum.cern.ch/t/tmemfile-default-size/35731