### PR TITLE
[ntuple] Add support for printing physical layout details

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -42,6 +42,7 @@ SOURCES
   v7/src/REntry.cxx
   v7/src/RNTuple.cxx
   v7/src/RNTupleDescriptor.cxx
+  v7/src/RNTupleDescriptorFmt.cxx
   v7/src/RNTupleModel.cxx
   v7/src/RPage.cxx
   v7/src/RPageAllocator.cxx

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -68,6 +68,8 @@ public:
    RColumnElementBase& operator =(RColumnElementBase&& other) = default;
    virtual ~RColumnElementBase() = default;
 
+   static RColumnElementBase Generate(EColumnType type);
+
    /// Write one or multiple column elements into destination
    void WriteTo(void *destination, std::size_t count) const {
       std::memcpy(destination, fRawContent, fSize * count);

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -79,6 +79,7 @@ public:
  */
 enum class ENTupleInfo {
    kSummary,  // The ntuple name, description, number of entries
+   kStorageDetails, // size on storage, page sizes, compression factor, etc.
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -181,7 +181,7 @@ triggered by Flush() or by destructing the ntuple.  On I/O errors, an exception 
 // clang-format on
 class RNTupleWriter : public Detail::RNTuple {
 private:
-   static constexpr NTupleSize_t kDefaultClusterSizeEntries = 8192;
+   static constexpr NTupleSize_t kDefaultClusterSizeEntries = 64000;
    std::unique_ptr<Detail::RPageSink> fSink;
    NTupleSize_t fClusterSizeEntries;
    NTupleSize_t fLastCommitted;
@@ -205,7 +205,8 @@ public:
          value.GetField()->Append(value);
       }
       fNEntries++;
-      if ((fNEntries % fClusterSizeEntries) == 0) CommitCluster();
+      if ((fNEntries % fClusterSizeEntries) == 0)
+         CommitCluster();
    }
    /// Ensure that the data from the so far seen Fill calls has been written to storage
    void CommitCluster();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <memory>
+#include <ostream>
 #include <vector>
 #include <string>
 #include <unordered_map>
@@ -327,6 +328,7 @@ public:
 
    /// Re-create the C++ model from the stored meta-data
    std::unique_ptr<RNTupleModel> GenerateModel() const;
+   void PrintInfo(std::ostream &output) const;
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -216,12 +216,12 @@ public:
 
 
 template <>
-class RNTupleView<int> {
+class RNTupleView<std::int32_t> {
    friend class RNTupleReader;
    friend class RNTupleViewCollection;
 
 protected:
-   RField<int> fField;
+   RField<std::int32_t> fField;
    RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
       : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName())
    {
@@ -235,8 +235,32 @@ public:
    RNTupleView& operator=(RNTupleView&& other) = default;
    ~RNTupleView() = default;
 
-   int operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
-   int operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
+   std::int32_t operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
+   std::int32_t operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
+};
+
+template <>
+class RNTupleView<ClusterSize_t> {
+   friend class RNTupleReader;
+   friend class RNTupleViewCollection;
+
+protected:
+   RField<ClusterSize_t> fField;
+   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
+      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName())
+   {
+      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
+   }
+
+public:
+   RNTupleView(const RNTupleView& other) = delete;
+   RNTupleView(RNTupleView&& other) = default;
+   RNTupleView& operator=(const RNTupleView& other) = delete;
+   RNTupleView& operator=(RNTupleView&& other) = default;
+   ~RNTupleView() = default;
+
+   ClusterSize_t operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
+   ClusterSize_t operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
 };
 
 

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -15,9 +15,37 @@
 
 #include <ROOT/RColumnElement.hxx>
 
+#include <TError.h>
+
 #include <algorithm>
 #include <bitset>
 #include <cstdint>
+
+ROOT::Experimental::Detail::RColumnElementBase
+ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType type) {
+   switch (type) {
+   case EColumnType::kReal32:
+      return RColumnElement<float, EColumnType::kReal32>(nullptr);
+   case EColumnType::kReal64:
+      return RColumnElement<double, EColumnType::kReal64>(nullptr);
+   case EColumnType::kByte:
+      return RColumnElement<std::uint8_t, EColumnType::kByte>(nullptr);
+   case EColumnType::kInt32:
+      return RColumnElement<std::int32_t, EColumnType::kInt32>(nullptr);
+   case EColumnType::kInt64:
+      return RColumnElement<std::int64_t, EColumnType::kInt64>(nullptr);
+   case EColumnType::kBit:
+      return RColumnElement<bool, EColumnType::kBit>(nullptr);
+   case EColumnType::kIndex:
+      return RColumnElement<ClusterSize_t, EColumnType::kIndex>(nullptr);
+   case EColumnType::kSwitch:
+      return RColumnElement<RColumnSwitch, EColumnType::kSwitch>(nullptr);
+   default:
+      R__ASSERT(false);
+   }
+   // never here
+   return RColumnElementBase();
+}
 
 void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Pack(
   void *dst, void *src, std::size_t count) const

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -135,7 +135,10 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       for (int i = 0; i < width; ++i)
          output << frameSymbol;
       output << std::endl;
-      return;
+      break;
+   case ENTupleInfo::kStorageDetails:
+      fSource->GetDescriptor().PrintInfo(output);
+      break;
    default:
       // Unhandled case, internal error
       assert(false);

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -179,13 +179,15 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
    std::sort(columns.begin(), columns.end());
    for (const auto &col : columns) {
       auto avgPageSize = (col.fNPages == 0) ? 0 : (col.fBytesOnStorage / col.fNPages);
+      auto avgElementsPerPage = (col.fNPages == 0) ? 0 : (col.fNElements / col.fNPages);
       output << "  " << col.fFieldName << " [#" << col.fLocalOrder << "]" << "  --  "
              << GetColumnTypeName(col.fType) << std::endl;
-      output << "    # Elements:      " << col.fNElements << std::endl;
-      output << "    # Pages:         " << col.fNPages << std::endl;
-      output << "    Avg page size:   " << avgPageSize << " B" << std::endl;
-      output << "    Size on storage: " << col.fBytesOnStorage << " B" << std::endl;
-      output << "    Compression:     " << std::fixed << std::setprecision(2)
+      output << "    # Elements:          " << col.fNElements << std::endl;
+      output << "    # Pages:             " << col.fNPages << std::endl;
+      output << "    Avg elements / page: " << avgElementsPerPage << std::endl;
+      output << "    Avg page size:       " << avgPageSize << " B" << std::endl;
+      output << "    Size on storage:     " << col.fBytesOnStorage << " B" << std::endl;
+      output << "    Compression:         " << std::fixed << std::setprecision(2)
              << float(col.fElementSize * col.fNElements) / float(col.fBytesOnStorage) << std::endl;
       output << "............................................................" << std::endl;
    }

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -1,0 +1,191 @@
+/// \file RNTupleDescriptorFmt.cxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2019-08-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RColumnElement.hxx>
+#include <ROOT/RColumnModel.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+
+#include <algorithm>
+#include <iomanip>
+#include <ostream>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+struct ClusterInfo {
+   std::uint64_t fFirstEntry = 0;
+   std::uint32_t fNEntries = 0;
+   std::uint32_t fBytesOnStorage = 0;
+   std::uint32_t fBytesInMemory = 0;
+
+   bool operator ==(const ClusterInfo &other) const {
+      return fFirstEntry == other.fFirstEntry;
+   }
+
+   bool operator <(const ClusterInfo &other) const {
+      return fFirstEntry < other.fFirstEntry;
+   }
+};
+
+struct ColumnInfo {
+   ROOT::Experimental::DescriptorId_t fFieldId = 0;
+   std::uint64_t fLocalOrder = 0;
+   std::uint64_t fNElements = 0;
+   std::uint64_t fNPages = 0;
+   std::uint64_t fBytesOnStorage = 0;
+   std::uint32_t fElementSize = 0;
+   ROOT::Experimental::EColumnType fType;
+   std::string fFieldName;
+
+   bool operator <(const ColumnInfo &other) const {
+      if (fFieldName == other.fFieldName)
+         return fLocalOrder < other.fLocalOrder;
+      return fFieldName < other.fFieldName;
+   }
+};
+
+static std::string GetFieldName(ROOT::Experimental::DescriptorId_t fieldId,
+   const ROOT::Experimental::RNTupleDescriptor &ntupleDesc)
+{
+   auto fieldDesc = ntupleDesc.GetFieldDescriptor(fieldId);
+   if (fieldDesc.GetParentId() == ROOT::Experimental::kInvalidDescriptorId)
+      return fieldDesc.GetFieldName();
+   return GetFieldName(fieldDesc.GetParentId(), ntupleDesc) + "." + fieldDesc.GetFieldName();
+}
+
+static std::string GetColumnTypeName(ROOT::Experimental::EColumnType type)
+{
+   switch (type) {
+   case ROOT::Experimental::EColumnType::kBit:
+      return "Bit";
+   case ROOT::Experimental::EColumnType::kByte:
+      return "Byte";
+   case ROOT::Experimental::EColumnType::kInt32:
+      return "Int32";
+   case ROOT::Experimental::EColumnType::kInt64:
+      return "Int64";
+   case ROOT::Experimental::EColumnType::kReal32:
+      return "Real32";
+   case ROOT::Experimental::EColumnType::kReal64:
+      return "Real64";
+   case ROOT::Experimental::EColumnType::kIndex:
+      return "Index";
+   case ROOT::Experimental::EColumnType::kSwitch:
+      return "Switch";
+   default:
+      return "UNKNOWN";
+   }
+}
+
+} // anonymous namespace
+
+void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) const
+{
+   std::vector<ColumnInfo> columns;
+   std::vector<ClusterInfo> clusters;
+   std::unordered_map<DescriptorId_t, unsigned int> cluster2Idx;
+   for (const auto &cluster : fClusterDescriptors) {
+      ClusterInfo info;
+      info.fFirstEntry = cluster.second.GetFirstEntryIndex();
+      info.fNEntries = cluster.second.GetNEntries();
+      cluster2Idx[cluster.first] = clusters.size();
+      clusters.emplace_back(info);
+   }
+
+   std::uint64_t bytesOnStorage = 0;
+   std::uint64_t bytesInMemory = 0;
+   int compression = -1;
+   for (const auto &column : fColumnDescriptors) {
+      auto element = Detail::RColumnElementBase::Generate(column.second.GetModel().GetType());
+      auto elementSize = element.GetSize();
+
+      ColumnInfo info;
+      info.fFieldId = column.second.GetFieldId();
+      info.fLocalOrder = column.second.GetIndex();
+      info.fElementSize = elementSize;
+      info.fType = column.second.GetModel().GetType();
+
+      for (const auto &cluster : fClusterDescriptors) {
+         auto columnRange = cluster.second.GetColumnRange(column.first);
+         info.fNElements += columnRange.fNElements;
+         if (compression == -1) {
+            compression = columnRange.fCompressionSettings;
+         }
+         const auto &pageRange = cluster.second.GetPageRange(column.first);
+         auto idx = cluster2Idx[cluster.first];
+         for (const auto page : pageRange.fPageInfos) {
+            bytesOnStorage += page.fLocator.fBytesOnStorage;
+            bytesInMemory += page.fNElements * elementSize;
+            clusters[idx].fBytesOnStorage += page.fLocator.fBytesOnStorage;
+            clusters[idx].fBytesInMemory += page.fNElements * elementSize;
+            info.fBytesOnStorage += page.fLocator.fBytesOnStorage;
+            ++info.fNPages;
+         }
+      }
+      columns.emplace_back(info);
+   }
+   auto headerSize = SerializeHeader(nullptr);
+   auto footerSize = SerializeFooter(nullptr);
+   output << "============================================================" << std::endl;
+   output << "NTUPLE:      " << GetName() << std::endl;
+   output << "Compression: " << compression << std::endl;
+   output << "------------------------------------------------------------" << std::endl;
+   output << "  # Entries:        " << GetNEntries() << std::endl;
+   output << "  # Fields:         " << GetNFields() << std::endl;
+   output << "  # Columns:        " << GetNColumns() << std::endl;
+   output << "  # Clusters:       " << GetNClusters() << std::endl;
+   output << "  Size on storage:  " << bytesOnStorage << " B" << std::endl;
+   output << "  Compression rate: " << std::fixed << std::setprecision(2)
+                                    << float(bytesInMemory) / float(bytesOnStorage) << std::endl;
+   output << "  Header size:      " << headerSize << " B" << std::endl;
+   output << "  Footer size:      " << footerSize << " B" << std::endl;
+   output << "  Meta-data / data: " << std::fixed << std::setprecision(3)
+                                    << float(headerSize + footerSize) / float(bytesOnStorage) << std::endl;
+   output << "------------------------------------------------------------" << std::endl;
+   output << "CLUSTER DETAILS" << std::endl;
+   output << "------------------------------------------------------------" << std::endl;
+
+   std::sort(clusters.begin(), clusters.end());
+   for (unsigned int i = 0; i < clusters.size(); ++i) {
+      output << "  # " << std::setw(5) << i
+             << "   Entry range:     [" << clusters[i].fFirstEntry << ".."
+             << clusters[i].fFirstEntry + clusters[i].fNEntries << ")  --  " << clusters[i].fNEntries << std::endl;
+      output << "         "
+             << "   Size on storage: " << clusters[i].fBytesOnStorage << " B" << std::endl;
+      output << "         "
+             << "   Compression:     " << std::fixed << std::setprecision(2)
+             << float(clusters[i].fBytesInMemory) / float(float(clusters[i].fBytesOnStorage)) << std::endl;
+   }
+
+   output << "------------------------------------------------------------" << std::endl;
+   output << "COLUMN DETAILS" << std::endl;
+   output << "------------------------------------------------------------" << std::endl;
+   for (auto &col : columns)
+      col.fFieldName = GetFieldName(col.fFieldId, *this).substr(1);
+   std::sort(columns.begin(), columns.end());
+   for (const auto &col : columns) {
+      output << "  " << col.fFieldName << " [#" << col.fLocalOrder << "]" << "  --  "
+             << GetColumnTypeName(col.fType) << std::endl;
+      output << "    # Elements:      " << col.fNElements << std::endl;
+      output << "    # Pages:         " << col.fNPages << std::endl;
+      output << "    Avg page size:   " << col.fBytesOnStorage / col.fNPages << " B" << std::endl;
+      output << "    Size on storage: " << col.fBytesOnStorage << " B" << std::endl;
+      output << "    Compression:     " << std::fixed << std::setprecision(2)
+             << float(col.fElementSize * col.fNElements) / float(col.fBytesOnStorage) << std::endl;
+      output << "............................................................" << std::endl;
+   }
+}

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -178,11 +178,12 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
       col.fFieldName = GetFieldName(col.fFieldId, *this).substr(1);
    std::sort(columns.begin(), columns.end());
    for (const auto &col : columns) {
+      auto avgPageSize = (col.fNPages == 0) ? 0 : (col.fBytesOnStorage / col.fNPages);
       output << "  " << col.fFieldName << " [#" << col.fLocalOrder << "]" << "  --  "
              << GetColumnTypeName(col.fType) << std::endl;
       output << "    # Elements:      " << col.fNElements << std::endl;
       output << "    # Pages:         " << col.fNPages << std::endl;
-      output << "    Avg page size:   " << col.fBytesOnStorage / col.fNPages << " B" << std::endl;
+      output << "    Avg page size:   " << avgPageSize << " B" << std::endl;
       output << "    Size on storage: " << col.fBytesOnStorage << " B" << std::endl;
       output << "    Compression:     " << std::fixed << std::setprecision(2)
              << float(col.fElementSize * col.fNElements) / float(col.fBytesOnStorage) << std::endl;


### PR DESCRIPTION
Details on cluster sizes, pages distribution, column sizes, and compression ratios can be printed with `RNTupleReader::PrintInfo(ENTupleInfo::kStorageDetails)`.