### PR TITLE
In MakeProject avoid dereferencing deleted object.

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -2880,6 +2880,8 @@ void TFile::MakeProject(const char *dirname, const char * /*classes*/,
       ngener += info->GenerateHeaderFile(clean_dirname.Data(),&subClasses,&extrainfos);
       subClasses.Clear("nodelete");
    }
+   extrainfos.Clear("nodelete"); // We are done with this list.
+
    TString path;
    path.Form("%s/%sProjectHeaders.h",clean_dirname.Data(),subdirname.Data());
    FILE *allfp = fopen(path,"a");
@@ -3247,8 +3249,6 @@ void TFile::MakeProject(const char *dirname, const char * /*classes*/,
       }
    }
 
-   extrainfos.Clear("nodelete");
-   // filelist->Clear("nodetele");
    delete list;
    filelist->Delete();
    delete filelist;


### PR DESCRIPTION
Make sure to Clear the list 'extrainfos' before any of its content is deleted.

See https://root-forum.cern.ch/t/tfile-makeproject-severely-broken-in-root-6-08-06-6-18-00/34924