### PR TITLE
[cxxmodules] FindLibraryName should resolve possible symlinks.

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -88,7 +88,13 @@ namespace cling {
 #include "Varargs.h"
 
 namespace ROOT {
-   namespace TMetaUtils {
+namespace TMetaUtils {
+
+/// Resolve a symlink to its canonical path. If the symlink was relative it
+/// turns it into an absolute path with respect to the original symlink location.
+///
+///\returns the resolved absolute path.
+std::string ResolveSymlink(const std::string &path);
 
 // Forward Declarations --------------------------------------------------------
 class AnnotatedRecordDecl;

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -60,10 +60,50 @@
 
 #ifdef _WIN32
 #define strncasecmp _strnicmp
-#endif
+#include <io.h>
+#else
+#include <unistd.h>
+#endif // _WIN32
 
 namespace ROOT {
 namespace TMetaUtils {
+
+/// Resolve a symlink to its canonical path. If the symlink was relative it
+/// turns it into an absolute path with respect to the original symlink location.
+///
+///\returns the resolved absolute path.
+std::string ResolveSymlink(const std::string &path)
+{
+   // No symlinks on Windows.
+   if (!llvm::sys::fs::is_symlink_file(path))
+      return path;
+
+#ifndef R__WIN32
+
+   char Buffer[kMAXPATHLEN];
+   ssize_t CharCount = ::readlink(path.c_str(), Buffer, sizeof(Buffer));
+   // readlink does not append a NUL character to Buffer.
+   if (CharCount > 0) {
+      llvm::StringRef resolved_path(Buffer, CharCount);
+      if (llvm::sys::path::is_absolute(resolved_path))
+         return resolved_path.str();
+
+      // If the symlink did not resolve to an absolute path we should convert
+      // it, because if we are embedded in a framework we will resolve the link
+      // with respect to the current dir (which is most often the one of the
+      // file descriptor. However, in a relative path in a symlink we want to
+      // resolve it with respect to the symlink parent directory.
+      llvm::StringRef current_dir = llvm::sys::path::parent_path(path);
+      llvm::SmallString<256> relative_path(resolved_path);
+      llvm::sys::fs::make_absolute(/*wrt*/current_dir, relative_path);
+      return relative_path.str().str();
+   }
+
+   Error("ResolveSymlink", "Could not resolve symlink '%s'\n.", path.c_str());
+   return {};
+#endif // not R__WIN32
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/core/metacling/src/TClingRdictModuleFileExtension.cxx
+++ b/core/metacling/src/TClingRdictModuleFileExtension.cxx
@@ -123,7 +123,10 @@ TClingRdictModuleFileExtension::Reader::Reader(clang::ModuleFileExtension *Ext, 
       }
       case FIRST_EXTENSION_RECORD_ID + 1: {
          // FIXME: Remove the string copy in fPendingRdicts.
-         llvm::SmallString<255> FullRdictName = llvm::sys::path::parent_path(Mod.FileName);
+         std::string ResolvedFileName
+            = ROOT::TMetaUtils::ResolveSymlink(Mod.FileName);
+         llvm::StringRef ModDir = llvm::sys::path::parent_path(ResolvedFileName);
+         llvm::SmallString<255> FullRdictName = ModDir;
          llvm::sys::path::append(FullRdictName, CurrentRdictName);
          TCling__RegisterRdictForLoadPCM(FullRdictName.str(), &Blob);
          break;


### PR DESCRIPTION
In cmssw we see that depending on the invoking code the trigger function is
resolved sometimes with the symlink-ed path and sometimes without.

This can be observed in the cmssw biglib setup where all plugin libraries
are assembled into a single library to yield performance improvement of (10%).

This is seen in cms-sw/cmsdist#5172 where libHistPainter_rdict.pcm is not
found in the fPendingRdicts because it was registered with the 'other'
path.

cc: @davidlange6, @smuzaffar.