### PR TITLE
[base] Work around precision issue, thanks clang-HEAD:

### DIFF
--- a/core/base/inc/ROOT/StringConv.hxx
+++ b/core/base/inc/ROOT/StringConv.hxx
@@ -99,9 +99,9 @@ EFromHumanReadableSize FromHumanReadableSize(std::string_view str, T &value)
       int unit = 1000;
 
       auto result = [coeff,&exp,&unit,&value]() {
-         double v = exp ? coeff * std::pow(unit, exp / 3) : coeff;
+         T v = static_cast<T>(exp ? coeff * std::pow(unit, exp / 3) : coeff);
          if (v < std::numeric_limits<T>::max()) {
-            value = (T)v;
+            value = v;
             return EFromHumanReadableSize::kSuccess;
          } else {
             return EFromHumanReadableSize::kOverflow;


### PR DESCRIPTION
/ROOT/StringConv.hxx:103:18: warning: implicit conversion from 'long long' to 'double' changes value from 9223372036854775807 to 9223372036854775808