### PR TITLE
[PyROOT exp] Port TTree.AsMatrix feature

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_ttree.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_ttree.py
@@ -10,6 +10,7 @@
 
 from libROOTPython import AddBranchAttrSyntax, SetBranchAddressPyz, BranchPyz
 
+import cppyy
 from ROOT import pythonization
 
 # TTree iterator
@@ -47,6 +48,126 @@ def _Branch(self, *args):
 
     return res
 
+# TTree.AsMatrix functionality
+def _TTreeAsMatrix(self, columns=None, exclude=None, dtype="double", return_labels=False):
+    """Read-out the TTree as a numpy array.
+
+    Note that the reading is performed in multiple threads if the implicit
+    multi-threading of ROOT is enabled.
+
+    Parameters:
+        columns: If None return all branches as columns, otherwise specify names in iterable.
+        exclude: Exclude branches from selection.
+        dtype: Set return data-type of numpy array.
+        return_labels: Return additionally to the numpy array the names of the columns.
+
+    Returns:
+        array(, labels): Numpy array(, labels of columns)
+    """
+
+    # Import numpy lazily
+    try:
+        import numpy as np
+    except:
+        raise ImportError("Failed to import numpy during call of TTree.AsMatrix.")
+
+    # Check that tree has entries
+    if self.GetEntries() == 0:
+        raise Exception("Tree {} has no entries.".format(self.GetName()))
+
+    # Get all columns of the tree if no columns are specified
+    if columns is None:
+        columns = [branch.GetName() for branch in self.GetListOfBranches()]
+
+    # Exclude columns
+    if exclude == None:
+        exclude = []
+    columns = [col for col in columns if not col in exclude]
+
+    if not columns:
+        raise Exception("Arguments resulted in no selected branches.")
+
+    # Check validity of branches
+    supported_branch_dtypes = ["Float_t", "Double_t", "Char_t", "UChar_t", "Short_t", "UShort_t",
+            "Int_t", "UInt_t", "Long64_t", "ULong64_t"]
+    col_dtypes = []
+    invalid_cols_notfound = []
+    invalid_cols_dtype = {}
+    invalid_cols_multipleleaves = {}
+    invalid_cols_leafname = {}
+    for col in columns:
+        # Check that column exists
+        branch = self.GetBranch(col)
+        if branch == None:
+            invalid_cols_notfound.append(col)
+            continue
+
+        # Check that the branch has only one leaf with the name of the branch
+        leaves = [leaf.GetName() for leaf in branch.GetListOfLeaves()]
+        if len(leaves) != 1:
+            invalid_cols_multipleleaves[col] = len(leaves)
+            continue
+        if leaves[0] != col:
+            invalid_cols_leafname[col] = len(leaves[0])
+            continue
+
+        # Check that the leaf of the branch has an arithmetic data-type
+        col_dtype = self.GetBranch(col).GetLeaf(col).GetTypeName()
+        col_dtypes.append(col_dtype)
+        if not col_dtype in supported_branch_dtypes:
+            invalid_cols_dtype[col] = col_dtype
+
+    exception_template = "Reading of branch {} is not supported ({})."
+    if invalid_cols_notfound:
+        raise Exception(exception_template.format(invalid_cols_notfound, "branch not existent"))
+    if invalid_cols_multipleleaves:
+        raise Exception(exception_template.format([k for k in invalid_cols_multipleleaves], "branch has multiple leaves"))
+    if invalid_cols_leafname:
+        raise Exception(exception_template.format(
+            [k for k in invalid_cols_leafname], "name of leaf is different from name of branch {}".format(
+                [invalid_cols_leafname[k] for k in invalid_cols_leafname])))
+    if invalid_cols_dtype:
+        raise Exception(exception_template.format(
+            [k for k in invalid_cols_dtype], "branch has unsupported data-type {}".format(
+                [invalid_cols_dtype[k] for k in invalid_cols_dtype])))
+
+    # Check that given data-type is supported
+    supported_output_dtypes = ["int", "unsigned int", "long", "unsigned long", "float", "double"]
+    if not dtype in supported_output_dtypes:
+        raise Exception("Data-type {} is not supported, select from {}.".format(
+            dtype, supported_output_dtypes))
+
+    # Convert columns iterable to std.vector("string")
+    columns_vector = cppyy.gbl.std.vector["string"](len(columns))
+    for i, col in enumerate(columns):
+        columns_vector[i] = col
+
+    # Allocate memory for the read-out
+    flat_matrix = cppyy.gbl.std.vector[dtype](self.GetEntries()*len(columns))
+
+    # Read the tree as flat std.vector(dtype)
+    tree_ptr = cppyy.gbl.ROOT.Internal.RDF.GetAddress(self)
+    columns_vector_ptr = cppyy.gbl.ROOT.Internal.RDF.GetAddress(columns_vector)
+    flat_matrix_ptr = cppyy.gbl.ROOT.Internal.RDF.GetVectorAddress[dtype](flat_matrix)
+    jit_code = "ROOT::Internal::RDF::TTreeAsFlatMatrixHelper<{dtype}, {col_dtypes}>(*reinterpret_cast<TTree*>({tree_ptr}), *reinterpret_cast<std::vector<{dtype}>* >({flat_matrix_ptr}), *reinterpret_cast<std::vector<string>* >({columns_vector_ptr}));".format(
+            col_dtypes = ", ".join(col_dtypes),
+            dtype = dtype,
+            tree_ptr = tree_ptr,
+            flat_matrix_ptr = flat_matrix_ptr,
+            columns_vector_ptr = columns_vector_ptr)
+    cppyy.gbl.gInterpreter.Calc(jit_code)
+
+    # Convert the std.vector(dtype) to a numpy array by memory-adoption and
+    # reshape the flat array to the correct shape of the matrix
+    flat_matrix_np = np.asarray(flat_matrix)
+    reshaped_matrix_np = np.reshape(flat_matrix_np,
+            (int(len(flat_matrix)/len(columns)), len(columns)))
+
+    if return_labels:
+        return (reshaped_matrix_np, columns)
+    else:
+        return reshaped_matrix_np
+
 @pythonization()
 def pythonize_ttree(klass, name):
     # Parameters:
@@ -79,5 +200,8 @@ def pythonize_ttree(klass, name):
         # Branch
         klass._OriginalBranch = klass.Branch
         klass.Branch = _Branch
+
+        # AsMatrix
+        klass.AsMatrix = _TTreeAsMatrix
 
     return True

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -32,6 +32,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_setbranchaddress ttree_setbranchaddress.py
                     COPY_TO_BUILDDIR TreeHelper.h)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py
                     COPY_TO_BUILDDIR TreeHelper.h)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_asmatrix ttree_asmatrix.py)
 
 # TH1 and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_th1_operators th1_operators.py)

--- a/bindings/pyroot_experimental/PyROOT/test/ttree_asmatrix.py
+++ b/bindings/pyroot_experimental/PyROOT/test/ttree_asmatrix.py
@@ -1,0 +1,246 @@
+import unittest
+import ROOT
+import numpy as np
+from sys import maxsize
+
+
+class TTreeAsMatrix(unittest.TestCase):
+    is_64bit = True if maxsize > 2**32 else False
+
+    # Helpers
+    def make_tree(self, *dtypes):
+        tree = ROOT.TTree("test", "description")
+        col_names = ["col{}".format(i) for i in range(len(dtypes))]
+
+        col_vars = []
+        for dtype in dtypes:
+            if "F" in dtype:
+                var = np.empty(1, dtype=np.float32)
+            elif "D" in dtype:
+                var = np.empty(1, dtype=np.float64)
+            elif "I" in dtype:
+                var = np.empty(1, dtype=np.int32)
+            elif "i" in dtype:
+                var = np.empty(1, dtype=np.uint32)
+            elif "L" in dtype:
+                if self.is_64bit:
+                    var = np.empty(1, dtype=np.int64)
+                else:
+                    var = np.empty(1, dtype=np.int32)
+            elif "l" in dtype:
+                if self.is_64bit:
+                    var = np.empty(1, dtype=np.uint64)
+                else:
+                    var = np.empty(1, dtype=np.uint32)
+            elif "S" in dtype:
+                var = np.empty(1, dtype=np.int16)
+            elif "s" in dtype:
+                var = np.empty(1, dtype=np.uint16)
+            elif "B" in dtype:
+                var = np.empty(1, dtype=np.int8)
+            elif "b" in dtype:
+                var = np.empty(1, dtype=np.uint8)
+            elif "O" in dtype:
+                var = np.empty(1, dtype=np.uint8)
+            else:
+                raise Exception(
+                    "Type {} not known to create branch.".format(dtype))
+            col_vars.append(var)
+
+        for dtype, name, var in zip(dtypes, col_names, col_vars):
+            tree.Branch(name, var, name + "/" + dtype)
+
+        reference = []
+        for i in range(4):
+            row = []
+            for i_var, var in enumerate(col_vars):
+                var[0] = (i + i_var + 0.5) * np.power(-1, i)
+                row.append(var[0])
+            reference.append(row)
+            tree.Fill()
+
+        return tree, reference, dtypes, col_names, col_vars
+
+    def make_example(self, *dtypes):
+        tree, reference, dtypes, col_names, col_vars = self.make_tree(*dtypes)
+        matrix_ttree = tree.AsMatrix()
+        matrix_ref = np.asarray(reference)
+        return matrix_ttree, matrix_ref
+
+    # Tests
+    def test_instance(self):
+        """
+        Test instantiation
+        """
+        tree, _, _, col_names, _ = self.make_tree("F", "F")
+        tree.AsMatrix(col_names)
+
+    def test_return_labels(self):
+        """
+        Test returned labels
+        """
+        tree, _, _, col_names, _ = self.make_tree("F", "F")
+        matrix, labels = tree.AsMatrix(col_names, return_labels=True)
+        self.assertEqual(labels, col_names)
+
+    def test_exclude_columns(self):
+        """
+        Test excluding columns
+        """
+        tree, reference, _, _, _ = self.make_tree("F", "F")
+        matrix_ttree = tree.AsMatrix(exclude=["col0"])
+        matrix_ref = np.asarray([x[1] for x in reference])
+        for value_ttree, value_ref in zip(matrix_ttree, matrix_ref):
+            self.assertEqual(value_ttree, value_ref)
+
+    def test_not_supported_dtype(self):
+        """
+        Test error-handling of unsupported data-types
+        """
+        tree, _, _, col_names, _ = self.make_tree("F", "F")
+        try:
+            tree.AsMatrix(col_names, dtype="foo")
+            self.assertFail()
+        except Exception as exception:
+            self.assertIn("Data-type foo is not supported, select from",
+                          exception.args[0])
+
+    def test_not_existent_column(self):
+        """
+        Test if a column does not exist
+        """
+        tree, _, _, col_names, _ = self.make_tree("F", "F")
+        try:
+            tree.AsMatrix(["foo"])
+            self.assertFail()
+        except Exception as exception:
+            self.assertIn("branch not existent", exception.args[0])
+
+    def test_no_branches_selected(self):
+        """
+        Test if no branch is selected by the requested columns
+        """
+        tree, _, _, col_names, _ = self.make_tree("F", "F")
+        try:
+            tree.AsMatrix(columns=["col0"], exclude=["col0"])
+            self.assertFail()
+        except Exception as exception:
+            self.assertIn("Arguments resulted in no selected branches.",
+                          exception.args[0])
+
+    def test_shape(self):
+        """
+        Test shape of returned matrix
+        """
+        matrix_ttree, matrix_ref = self.make_example("F", "F")
+        for i in range(2):
+            self.assertEqual(matrix_ttree.shape[i], matrix_ref.shape[i])
+
+    def test_take_all_columns(self):
+        """
+        Test taking all columns
+        """
+        tree, reference, _, _, _ = self.make_tree("F", "F")
+        matrix_ttree = tree.AsMatrix()
+        matrix_ref = np.asarray(reference)
+        for i in range(matrix_ref.shape[0]):
+            for j in range(matrix_ref.shape[1]):
+                self.assertEqual(matrix_ttree[i, j], matrix_ref[i, j])
+
+    def test_values(self):
+        """
+        Test correctness of returned values
+        """
+        matrix_ttree, matrix_ref = self.make_example("F", "F")
+        for i in range(matrix_ref.shape[0]):
+            for j in range(matrix_ref.shape[1]):
+                self.assertEqual(matrix_ttree[i, j], matrix_ref[i, j])
+
+    def test_zero_entries(self):
+        """
+        Test behaviour for a tree with zero entries
+        """
+        tree = ROOT.TTree("test", "description")
+        var = np.empty(1, np.float32)
+        tree.Branch("col", var, "col/F")
+        try:
+            tree.AsMatrix(["col"])
+            self.assertFail()
+        except Exception as exception:
+            self.assertEqual("Tree test has no entries.", exception.args[0])
+
+    def test_multiple_leaves(self):
+        """
+        Test a column with multiple leaves
+        """
+        tree = ROOT.TTree("test", "description")
+        var = np.ones(2, np.float32)
+        tree.Branch("col", var, "sub1/F:sub2/F")
+        tree.Fill()
+        try:
+            tree.AsMatrix(["col"])
+            self.assertFail()
+        except Exception as exception:
+            self.assertIn("branch has multiple leaves", exception.args[0])
+
+    def test_dtype_conversion(self):
+        """
+        Test conversion of data-types of the columns to uniform output data-type
+        """
+        numpy_dtype = {
+            "unsigned int": np.dtype(np.uint32),
+            "int": np.dtype(np.int32),
+            "unsigned long": np.dtype(np.uint64),
+            "long": np.dtype(np.int64),
+            "float": np.dtype(np.float32),
+            "double": np.dtype(np.float64)
+        }
+        if not self.is_64bit:
+            numpy_dtype["long"] = np.dtype(np.int32)
+            numpy_dtype["unsigned long"] = np.dtype(np.uint32)
+        tree, reference, _, _, _ = self.make_tree("F", "F")
+        matrix_ref = np.asarray(reference, dtype=np.float64)
+        for dtype in numpy_dtype:
+            matrix_ttree = tree.AsMatrix(dtype=dtype)
+            self.assertEqual(matrix_ttree.dtype.name, numpy_dtype[dtype].name)
+
+    def test_branch_dtypes(self):
+        """
+        Test branches of different data-types
+        """
+        root_dtypes = ["B", "b", "S", "s", "I", "i", "L", "l", "F", "D"]
+        tree, _, _, col_names, _ = self.make_tree(*root_dtypes)
+        tree.AsMatrix()
+
+        try:
+            tree, _, _, col_names, _ = self.make_tree("O")
+            tree.AsMatrix()
+        except Exception as exception:
+            self.assertIn("branch has unsupported data-type ['Bool_t']",
+                          exception.args[0])
+
+    def test_tchain(self):
+        """
+        Test whether the pythonization works as well for a TChain
+        """
+        tree1 = ROOT.TTree("test1", "description")
+        tree2 = ROOT.TTree("test2", "description")
+        var = np.ones(1, np.float32)
+        tfile = ROOT.TFile("test_ttree_asmatrix.root", "RECREATE")
+        tree1.Branch("col", var, "col/F")
+        tree1.Fill()
+        tree2.Branch("col", var, "col/F")
+        tree2.Fill()
+        tree1.Write()
+        tree2.Write()
+        tfile.Close()
+
+        chain = ROOT.TChain("chain")
+        chain.Add("test_ttree_asmatrix.root/test1")
+        chain.Add("test_ttree_asmatrix.root/test2")
+        m = chain.AsMatrix(["col"])
+        self.assertTrue((m == np.ones((2, 1), dtype=m.dtype)).all())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Edit:** After rebasing to current master, everything is fine (fixed the memory regulation).

The port is rather straight forward, however, the tutorial `pyroot002_TTreeAsMatrix.py` fails during shutdown with following backtrace:

```
#6  0x0000000004c6c270 in ?? ()
#7  0x00007f958582abc0 in TClass::Destructor (this=0x4ae4ee0, obj=0x4c64ee0, dtorOnly=<optimized out>) at /home/stefan/root-dev/core/meta/src/TClass.cxx:5211
#8  0x00007f9579d01e7f in CPyCppyy::op_dealloc_nofree (pyobj=pyobj
entry=0x7f956c67acf8) at /home/stefan/root-dev/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPInstance.cxx:45
#9  0x00007f9579d01f69 in CPyCppyy::op_dealloc (pyobj=0x7f956c67acf8) at /home/stefan/root-dev/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPInstance.cxx:149
#10 0x00000000004f7592 in ?? ()
#11 0x00000000004fc33a in _PyModule_Clear ()
#12 0x00000000004fb9d3 in PyImport_Cleanup ()
#13 0x00000000004f8e14 in Py_Finalize ()
#14 0x00000000004938ec in Py_Main ()
#15 0x00007f9586fd9830 in __libc_start_main (main=0x4934c0 <main>, argc=2, argv=0x7fffc2505518, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffc2505508) at ../csu/libc-start.c:291
#16 0x00000000004933e9 in _start ()
```

I've ported as well the tests, these are fine.