### PR TITLE
[Exp PyROOT] Fixes for collections, memory management of arguments, plotOn

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/CMakeLists.txt
@@ -26,6 +26,7 @@ set(py_sources
   ROOT/pythonization/_drawables.py
   ROOT/pythonization/_generic.py
   ROOT/pythonization/_rooabscollection.py
+  ROOT/pythonization/_roodatahist.py
   ROOT/pythonization/_rvec.py
   ROOT/pythonization/_stl_vector.py
   ROOT/pythonization/_tarray.py

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
@@ -22,6 +22,9 @@ environ['CLING_STANDARD_PCH'] = 'none'
 # Prevent cppyy's check for extra header directory
 environ['CPPYY_API_PATH'] = 'none'
 
+# Prevent cppyy from filtering ROOT libraries
+environ['CPPYY_NO_ROOT_FILTER'] = '1'
+
 import cppyy
 import ROOT.pythonization as pyz
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -97,6 +97,11 @@ class ROOTFacade(types.ModuleType):
         if not self.gROOT.IsBatch():
             self.app.init_graphics()
 
+        # Set memory policy to kUseHeuristics.
+        # This restores the default in PyROOT which was changed
+        # by new Cppyy
+        self.SetMemoryPolicy(self.kMemoryHeuristics)
+
         # Redirect lookups to cppyy's global namespace
         self.__dict__['ROOT_ns'] = gbl_namespace.ROOT
         self.__class__.__getattr__ = self._fallback_getattr

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_roodatahist.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_roodatahist.py
@@ -1,0 +1,26 @@
+# Author: Enric Tejedor CERN  08/2019
+
+################################################################################
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+from libROOTPython import AddUsingToClass
+
+
+@pythonization()
+def pythonize_roodatahist(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'RooDataHist':
+        # Add 'using' overloads for plotOn from RooAbsData
+        AddUsingToClass(klass, 'plotOn')
+
+    return True

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tcollection.py
@@ -75,8 +75,10 @@ def _imul_pyz(self, n):
     # - n: factor to multiply the collection by
     # Returns:
     # - self *= n
+    c = self.__class__()
+    c.AddAll(self)
     for _ in range(n - 1):
-        _extend_pyz(self, self)
+        _extend_pyz(self, c)
     return self
 
 # Python iteration

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
@@ -70,6 +70,15 @@ def _getitem_pyz(self, idx):
 
     return res
 
+def _remove_at(self, idx):
+    # Parameters:
+    # - self: collection to remove the item from
+    # - idx: index of the item, always positive
+    lnk = self.FirstLink()
+    for i in range(idx):
+        lnk = lnk.Next()
+    return self.Remove(lnk)
+
 def _setitem_pyz(self, idx, val):
     # Parameters:
     # - self: collection where to set item/s
@@ -110,7 +119,7 @@ def _setitem_pyz(self, idx, val):
     # Number
     else:
         idx = _check_index(self, idx)
-        self.RemoveAt(idx)
+        _remove_at(self, idx)
         self.AddAt(val, idx)
 
 def _delitem_pyz(self, idx):
@@ -129,11 +138,11 @@ def _delitem_pyz(self, idx):
             rg = reversed(rg)
 
         for i in rg:
-            self.RemoveAt(i)
+            _remove_at(self, i)
     # Number
     else:
         idx = _check_index(self, idx)
-        self.RemoveAt(idx)
+        _remove_at(self, idx)
 
 # Python-list-like methods
 
@@ -187,7 +196,7 @@ def _pop_pyz(self, *args):
     if idx < 0 or idx >= lcol:
         raise IndexError('pop index out of range')
 
-    return self.RemoveAt(idx)
+    return _remove_at(self, idx)
 
 def _reverse_pyz(self):
     # Parameters:

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_tseqcollection.py
@@ -97,6 +97,16 @@ def _setitem_pyz(self, idx, val):
             except StopIteration:
                 # No more indices in range, just append
                 self.append(elem)
+
+        # If range is longer than the number of elements in val,
+        # we need to remove the remaining elements of the range
+        try:
+            for i in it:
+                del self[i]
+        except StopIteration:
+            # No more indices in range, we are done
+            pass
+
     # Number
     else:
         idx = _check_index(self, idx)

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTModule.cxx
@@ -55,6 +55,8 @@ static PyMethodDef gPyROOTMethods[] = {
     (char *)"Cast the void* returned by TClass::DynamicCast to the right type"},
    {(char *)"AddTObjectEqNePyz", (PyCFunction)PyROOT::AddTObjectEqNePyz, METH_VARARGS,
     (char *)"Add equality and inequality comparison operators to TObject"},
+   {(char *)"AddUsingToClass", (PyCFunction)PyROOT::AddUsingToClass, METH_VARARGS,
+    (char *)"Add 'using' overloads for a given method to a class"},
    {(char *)"SetBranchAddressPyz", (PyCFunction)PyROOT::SetBranchAddressPyz, METH_VARARGS,
     (char *)"Fully enable the use of TTree::SetBranchAddress from Python"},
    {(char *)"BranchPyz", (PyCFunction)PyROOT::BranchPyz, METH_VARARGS,

--- a/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
+++ b/bindings/pyroot_experimental/PyROOT/src/PyROOTPythonize.h
@@ -35,6 +35,8 @@ PyObject *AddTObjectEqNePyz(PyObject *self, PyObject *args);
 
 PyObject *AddSetItemTCAPyz(PyObject *self, PyObject *args);
 
+PyObject *AddUsingToClass(PyObject *self, PyObject *args);
+
 PyObject *AsRVec(PyObject *self, PyObject *obj);
 PyObject *AsRTensor(PyObject *self, PyObject *obj);
 

--- a/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzPythonHelpers.cxx
@@ -19,7 +19,8 @@ PyROOT extension module.
 
 #include "CPyCppyy.h"
 #include "CPPInstance.h"
-#include "Utility.h"
+#include "CPPOverload.h"
+#include "PyStrings.h"
 
 #include "PyROOTPythonize.h"
 
@@ -105,3 +106,78 @@ PyObject *PyROOT::GetEndianess(PyObject * /* self */, PyObject * /* args */)
 #endif
 }
 
+using namespace CPyCppyy;
+
+// Helper to add base class methods to the derived class one
+static bool AddUsingToClass(PyObject *pyclass, const char *method)
+{
+   CPPOverload *derivedMethod = (CPPOverload *)PyObject_GetAttrString(pyclass, const_cast<char *>(method));
+   if (!CPPOverload_Check(derivedMethod)) {
+      Py_XDECREF(derivedMethod);
+      return false;
+   }
+
+   PyObject *mro = PyObject_GetAttr(pyclass, PyStrings::gMRO);
+   if (!mro || !PyTuple_Check(mro)) {
+      Py_XDECREF(mro);
+      Py_DECREF(derivedMethod);
+      return false;
+   }
+
+   CPPOverload *baseMethod = nullptr;
+   for (int i = 1; i < PyTuple_GET_SIZE(mro); ++i) {
+      baseMethod = (CPPOverload *)PyObject_GetAttrString(PyTuple_GET_ITEM(mro, i), const_cast<char *>(method));
+
+      if (!baseMethod) {
+         PyErr_Clear();
+         continue;
+      }
+
+      if (CPPOverload_Check(baseMethod))
+         break;
+
+      Py_DECREF(baseMethod);
+      baseMethod = nullptr;
+   }
+
+   Py_DECREF(mro);
+
+   if (!CPPOverload_Check(baseMethod)) {
+      Py_XDECREF(baseMethod);
+      Py_DECREF(derivedMethod);
+      return false;
+   }
+
+   for (PyCallable *pc : baseMethod->fMethodInfo->fMethods) {
+      derivedMethod->AdoptMethod(pc->Clone());
+   }
+
+   Py_DECREF(baseMethod);
+   Py_DECREF(derivedMethod);
+
+   return true;
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Add base class overloads of a given method to a derived class
+/// \param[in] self Always null, since this is a module function.
+/// \param[in] args[0] Derived class.
+/// \param[in] args[1] Name of the method whose base class overloads to
+///                    inject in the derived class.
+///
+/// This function adds base class overloads to a derived class for a given
+/// method. This covers the 'using' case, which is not supported by default
+/// by the bindings.
+PyObject *PyROOT::AddUsingToClass(PyObject * /* self */, PyObject *args)
+{
+   // Get derived class to pythonize
+   PyObject *pyclass = PyTuple_GetItem(args, 0);
+
+   // Get method name where to add overloads
+   PyObject *pyname = PyTuple_GetItem(args, 1);
+   auto cppname = CPyCppyy_PyText_AsString(pyname);
+
+   AddUsingToClass(pyclass, cppname);
+
+   Py_RETURN_NONE;
+}

--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -100,7 +100,7 @@ if(roofit)
   ROOT_ADD_PYUNITTEST(pyroot_pyz_rooabscollection_len rooabscollection_len.py)
 
   # RooDataHist pythonisations
-  ROOT_ADD_PYUNITTEST(pyroot_pyz_roodatahist_ploton roodatahist_ploton.py ${PYTESTS_WILLFAIL})
+  ROOT_ADD_PYUNITTEST(pyroot_pyz_roodatahist_ploton roodatahist_ploton.py)
 endif()
 
 # std::string_view backport in CPyCppyy

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_itemaccess.py
@@ -162,31 +162,43 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         self.assertEqual(sc3[1], l2[0])
         self.assertEqual(sc3[2], l3[2])
 
-        # Assign with step
+        # Assign second and third items to just one item.
+        # This tests that the third item is removed
         sc4 = self.create_tseqcollection()
-        o = sc4[1]
-        len4 = 2
-        l4 = [ ROOT.TObject() for _ in range(len4) ]
+        l4 = [ ROOT.TObject() ]
+        l5 = [ elem for elem in sc4 ]
 
-        sc4[::2] = l4
+        sc4[1:3] = l4
 
-        self.assertEqual(sc4.GetEntries(), self.num_elems)
-        self.assertEqual(sc4[0], l4[0])
-        self.assertEqual(sc4[1], o)
-        self.assertEqual(sc4[2], l4[1])
+        self.assertEqual(sc4.GetEntries(), self.num_elems - 1)
+        self.assertEqual(sc4[0], l5[0])
+        self.assertEqual(sc4[1], l4[0])
+
+        # Assign with step
+        sc5 = self.create_tseqcollection()
+        o = sc5[1]
+        len6 = 2
+        l6 = [ ROOT.TObject() for _ in range(len6) ]
+
+        sc5[::2] = l6
+
+        self.assertEqual(sc5.GetEntries(), self.num_elems)
+        self.assertEqual(sc5[0], l6[0])
+        self.assertEqual(sc5[1], o)
+        self.assertEqual(sc5[2], l6[1])
 
         # Assign with step (start from end)
-        sc4[::-2] = l4
+        sc5[::-2] = l6
 
-        self.assertEqual(sc4.GetEntries(), self.num_elems)
-        self.assertEqual(sc4[0], l4[1])
-        self.assertEqual(sc4[1], o)
-        self.assertEqual(sc4[2], l4[0])
+        self.assertEqual(sc5.GetEntries(), self.num_elems)
+        self.assertEqual(sc5[0], l6[1])
+        self.assertEqual(sc5[1], o)
+        self.assertEqual(sc5[2], l6[0])
 
         # Step cannot be zero
-        sc5 = self.create_tseqcollection()
+        sc6 = self.create_tseqcollection()
         with self.assertRaises(ValueError):
-            sc5[::0] = [ ROOT.TObject() ]
+            sc6[::0] = [ ROOT.TObject() ]
 
     def test_delitem(self):
         sc = self.create_tseqcollection()

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_listmethods.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_listmethods.py
@@ -16,10 +16,7 @@ class TSeqCollectionListMethods(unittest.TestCase):
     def create_tseqcollection(self):
         sc = ROOT.TList()
         for i in reversed(range(self.num_elems)):
-            o = ROOT.TObjString(str(i))
-            # Prevent immediate deletion of C++ TObjStrings
-            SetOwnership(o, False)
-            sc.Add(o)
+            sc.Add(ROOT.TObjString(str(i)))
 
         return sc
 

--- a/bindings/pyroot_experimental/PyROOT/test/tseqcollection_listmethods.py
+++ b/bindings/pyroot_experimental/PyROOT/test/tseqcollection_listmethods.py
@@ -86,6 +86,11 @@ class TSeqCollectionListMethods(unittest.TestCase):
         with self.assertRaises(TypeError):
             sc2.pop(1.0)
 
+        # Pop a repeated element
+        sc2.append(ROOT.TObjString('2'))
+        elem = sc2.pop()
+        self.assertEqual(sc2.At(0), elem)
+
     def test_reverse(self):
         sc = self.create_tseqcollection()
         l = [ elem for elem in sc ]

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -479,10 +479,6 @@ if(ROOT_python_FOUND)
   #---Tutorials expected to fail in PyROOT experimental
   set(pyexp_fail tutorial-pyroot-benchmarks-py
                  tutorial-pyroot-pyroot002_TTreeAsMatrix-py
-                 tutorial-roofit-rf106_plotdecoration-py
-                 tutorial-roofit-rf315_projectpdf-py
-                 tutorial-roofit-rf402_datahandling-py
-                 tutorial-roofit-rf610_visualerror-py
                  tutorial-vecops-vo004_SortAndSelect-py
                  tutorial-vecops-vo005_Combinations-py)
 

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -477,8 +477,7 @@ if(ROOT_python_FOUND)
   set(roofit-rf104_classfactory-depends tutorial-roofit-rf104_classfactory) #Race condition
 
   #---Tutorials expected to fail in PyROOT experimental
-  set(pyexp_fail tutorial-pyroot-benchmarks-py
-                 tutorial-pyroot-pyroot002_TTreeAsMatrix-py
+  set(pyexp_fail tutorial-pyroot-pyroot002_TTreeAsMatrix-py
                  tutorial-vecops-vo004_SortAndSelect-py
                  tutorial-vecops-vo005_Combinations-py)
 


### PR DESCRIPTION
This PR and their roottest sibling PR contain fixes for the following tests:

Roottest python basic tests:
- roottest-python-basic-basic
- roottest-python-basic-overload

Roofit tutorials fixed by the addition of a pythonisation to get the using declarations of `RooAbsData` into `RooDataHist`. This pythonisation will not be needed anymore when a general solution is provided by the bindings, mainly by merging this Cppyy patch into ROOT:  https://bitbucket.org/wlav/cppyy-backend/src/master/cling/patches/using_decls.diff
- tutorial-roofit-rf106_plotdecoration-py
- tutorial-roofit-rf610_visualerror-py
- pyunittests-pyroot-pyz-roodatahist-ploton
- tutorial-roofit-rf315_projectpdf-py
- tutorial-roofit-rf402_datahandling-py

Related to https://bitbucket.org/wlav/cppyy/issues/66/cppoverload-addmethod-cppoverload-clears
 - tutorial-roofit-rf307_fullpereventerrors-py
 - tutorial-roofit-rf706_histpdf-py

Some fixes for the following test, although it still can't be re-enabled due to https://bitbucket.org/wlav/cppyy/issues/145/enum-values-not-defined-as-constants
- roottest-python-basic-datatype

Some fixes for the following test, but still can't be re-enabled (more issues to investigate):
- roottest-python-regression-regression

