### PR TITLE
[cxxmodules] Invert the assert condition.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6364,7 +6364,7 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string &mangled_nam
 // linker stores this symbol as __ZN8TRandom34RndmEv (adding an extra _).
    std::string maybe_prefixed_mangled_name = mangled_name;
 #ifdef R__MACOSX
-   assert(llvm::StringRef(mangled_name).startswith("__"));
+   assert(!llvm::StringRef(mangled_name).startswith("__") && "Already added!");
    maybe_prefixed_mangled_name = "_" + maybe_prefixed_mangled_name;
 #endif
 


### PR DESCRIPTION
Fixes the builds with -Druntime_cxxmodules=On on OSX.