### PR TITLE
[core] Speed-up startup by skipping GetHostByName.

### DIFF
--- a/core/base/src/TUUID.cxx
+++ b/core/base/src/TUUID.cxx
@@ -129,6 +129,8 @@ system clock catches up.
 #if defined(R__LINUX) && !defined(R__WINGCC)
 #include <sys/sysinfo.h>
 #endif
+#include <ifaddrs.h>
+#include <netinet/in.h>
 #endif
 #include <chrono>
 
@@ -417,9 +419,34 @@ void TUUID::GetNodeIdentifier()
    if (gSystem) {
 #ifndef R__WIN32
       if (!adr) {
-         TInetAddress addr = gSystem->GetHostByName(gSystem->HostName());
-         if (addr.IsValid())
-            adr = addr.GetAddress();
+         UInt_t addr = 0;
+
+         struct ifaddrs *ifAddrStruct = nullptr;
+         struct ifaddrs *ifa = nullptr;
+
+         if (getifaddrs(&ifAddrStruct) != 0) {
+            adr = 1;
+         } else {
+            for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next) {
+               if (!ifa->ifa_addr) {
+                  continue;
+               }
+               if (ifa->ifa_addr->sa_family != AF_INET) { // check only IP4
+                  continue;
+               }
+               if (strncmp(ifa->ifa_name,"lo",2) == 0) { // skip loop back.
+                  continue;
+               }
+               addr = ntohl(((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr);
+               break;
+            }
+         }
+
+         if (ifAddrStruct != nullptr)
+            freeifaddrs(ifAddrStruct);
+
+         if (addr)
+            adr = addr;
          else
             adr = 1;  // illegal address
       }


### PR DESCRIPTION
Avoid connecting the DNS and avoid using getaddrinfo and instead scan the list of network interface.

In many cases those 2 operations were taking a significant amount of time during startup (in few cases
more than 5s).

In some cases (e.g. MacOS and possibly other WiFi use) the hostname is actually not registered and
consequently the search failed anyway ....

One drawback of the scan is that there is no cheap way to tell which of the IP4 addresses listed is
the 'public' address since only information are IP, port and name ... and the name is more or so
arbitrary (different on BSD and linux, depends on VPN or bridge, etc) ... so for now we just (try
to) skip the loopback interface.

A better technique (which would lead again to a 'spurrious' startup delay) is to open a socket to
a known server (eg google's DNS 8.8.8.8) and then interogate the socket to find out the IP seen
by the server.
For example with (https://stackoverflow.com/questions/212528/get-the-ip-address-of-the-machine)
```
void GetPrimaryIp(char* buffer, size_t buflen)
{
    assert(buflen >= 16);

    int sock = socket(AF_INET, SOCK_DGRAM, 0);
    assert(sock != -1);

    const char* kGoogleDnsIp = 8.8.8.8;
    uint16_t kDnsPort = 53;
    struct sockaddr_in serv;
    memset(&serv, 0, sizeof(serv));
    serv.sin_family = AF_INET;
    serv.sin_addr.s_addr = inet_addr(kGoogleDnsIp);
    serv.sin_port = htons(kDnsPort);

    int err = connect(sock, (const sockaddr*) &serv, sizeof(serv));
    assert(err != -1);

    sockaddr_in name;
    socklen_t namelen = sizeof(name);
    err = getsockname(sock, (sockaddr*) &name, &namelen);
    assert(err != -1);

    const char* p = inet_ntop(AF_INET, &name.sin_addr, buffer, buflen);
    assert(p);

    close(sock);
}
```