### PR TITLE
[PyROOT][ROOT-10294] Reuse TEnum to get its underlying type

### DIFF
--- a/bindings/pyroot/src/Cppyy.cxx
+++ b/bindings/pyroot/src/Cppyy.cxx
@@ -12,7 +12,6 @@
 #include "TCollection.h"
 #include "TDataMember.h"
 #include "TDataType.h"
-#include "TEnum.h"
 #include "TEnumConstant.h"
 #include "TError.h"
 #include "TFunction.h"
@@ -175,9 +174,8 @@ std::string Cppyy::ResolveName( const std::string& cppitem_name )
    return TClassEdit::ResolveTypedef( tclean.c_str(), true );
 }
 
-std::string Cppyy::ResolveEnum(const std::string& enum_type)
+std::string Cppyy::ResolveEnum(const TEnum* en)
 {
-   auto en = TEnum::GetEnum(enum_type.c_str());
    if (en) {
       auto ut = en->GetUnderlyingType();
       if (ut != EDataType::kNumDataTypes)
@@ -185,6 +183,11 @@ std::string Cppyy::ResolveEnum(const std::string& enum_type)
    }
    // Can't get type of enum, use int as default
    return "int";
+}
+
+std::string Cppyy::ResolveEnum(const std::string& enum_type)
+{
+   return ResolveEnum(TEnum::GetEnum(enum_type.c_str()));
 }
 
 Cppyy::TCppScope_t Cppyy::GetScope( const std::string& sname )

--- a/bindings/pyroot/src/Cppyy.h
+++ b/bindings/pyroot/src/Cppyy.h
@@ -1,6 +1,9 @@
 #ifndef PYROOT_CPPYY_H
 #define PYROOT_CPPYY_H
 
+// ROOT
+#include "TEnum.h"
+
 // Standard
 #include <string>
 #include <vector>
@@ -22,6 +25,7 @@ namespace Cppyy {
    TCppIndex_t GetNumScopes( TCppScope_t parent );
    std::string GetScopeName( TCppScope_t parent, TCppIndex_t iscope );
    std::string ResolveName( const std::string& cppitem_name );
+   std::string ResolveEnum(const TEnum* en);
    std::string ResolveEnum(const std::string& enum_type);
    TCppScope_t GetScope( const std::string& scope_name );
    std::string GetName( const std::string& scope_name );

--- a/bindings/pyroot/src/PropertyProxy.cxx
+++ b/bindings/pyroot/src/PropertyProxy.cxx
@@ -214,10 +214,9 @@ void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t id
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, const std::string& name, void* address )
+void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, const std::string& name, void* address, TEnum* en )
 {
-   Cppyy::TCppIndex_t idata = Cppyy::GetDatamemberIndex(scope, name);
-   std::string cppType = Cppyy::ResolveEnum(Cppyy::GetDatamemberType(scope, idata));
+   std::string cppType = Cppyy::ResolveEnum(en);
 
    fEnclosingScope = scope;
    fName           = name;

--- a/bindings/pyroot/src/PropertyProxy.h
+++ b/bindings/pyroot/src/PropertyProxy.h
@@ -25,7 +25,7 @@ namespace PyROOT {
    class PropertyProxy {
    public:
       void Set( Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t idata );
-      void Set( Cppyy::TCppScope_t scope, const std::string& name, void* address );
+      void Set( Cppyy::TCppScope_t scope, const std::string& name, void* address, TEnum* en );
 
       std::string GetName() { return fName; }
       void* GetAddress( ObjectProxy* pyobj /* owner */ );
@@ -70,12 +70,12 @@ namespace PyROOT {
    }
 
    inline PropertyProxy* PropertyProxy_NewConstant(
-      Cppyy::TCppScope_t scope, const std::string& name, void* address )
+      Cppyy::TCppScope_t scope, const std::string& name, void* address, TEnum* en )
    {
    // Create an initialize a new property descriptor, given the C++ datum.
       PropertyProxy* pyprop =
          (PropertyProxy*)PropertyProxy_Type.tp_new( &PropertyProxy_Type, 0, 0 );
-      pyprop->Set( scope, name, address );
+      pyprop->Set( scope, name, address, en );
       return pyprop;
    }
 

--- a/bindings/pyroot/src/RootWrapper.cxx
+++ b/bindings/pyroot/src/RootWrapper.cxx
@@ -121,11 +121,11 @@ namespace {
       Py_DECREF( property );
    }
 
-   void AddPropertyToClass( PyObject* pyclass,
-         Cppyy::TCppScope_t scope, const std::string& name, void* address )
+   void AddConstantPropertyToClass( PyObject* pyclass,
+         Cppyy::TCppScope_t scope, const std::string& name, void* address, TEnum* en )
    {
       PyROOT::PropertyProxy* property =
-         PyROOT::PropertyProxy_NewConstant( scope, name, address );
+         PyROOT::PropertyProxy_NewConstant( scope, name, address, en );
       AddPropertyToClass1( pyclass, property, kTRUE );
       Py_DECREF( property );
    }
@@ -366,7 +366,7 @@ static int BuildScopeProxyDict( Cppyy::TCppScope_t scope, PyObject* pyclass ) {
       if (isScoped) continue; // scoped enum: do not add constants as properties of the enum's scope
       for ( Int_t i = 0; i < seq->GetSize(); i++ ) {
          TEnumConstant* ec = (TEnumConstant*)seq->At( i );
-         AddPropertyToClass( pyclass, scope, ec->GetName(), ec->GetAddress() );
+         AddConstantPropertyToClass( pyclass, scope, ec->GetName(), ec->GetAddress(), e );
       }
    }
 


### PR DESCRIPTION
As pointed out in ROOT-10294, when using the CMSSW environment,
the lookup of an enum constant in the list of attributes of
the namespace does not succeed.

This commit passes on the TEnum obtained when creating the
namespace proxy to the addition of the enum constants as
properties of the namespace, so that the underlying type of
the enum can be taken from the TEnum, and therefore we
avoid the lookup in the list of attributes of the namespace.