### PR TITLE
Do not use =default for TObject-derived classes constructors ROOT-10300

### DIFF
--- a/core/base/inc/TUrl.h
+++ b/core/base/inc/TUrl.h
@@ -56,7 +56,7 @@ private:
    enum EStatusBits { kUrlWithDefaultPort = BIT(14), kUrlHasDefaultPort = BIT(15) };
 
 public:
-   TUrl() {} // // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
+   TUrl() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TUrl(const char *url, Bool_t defaultIsFile = kFALSE);
    TUrl(const TUrl &url);
    TUrl &operator=(const TUrl &rhs);

--- a/core/base/inc/TUrl.h
+++ b/core/base/inc/TUrl.h
@@ -56,7 +56,7 @@ private:
    enum EStatusBits { kUrlWithDefaultPort = BIT(14), kUrlHasDefaultPort = BIT(15) };
 
 public:
-   TUrl() = default;
+   TUrl() {} // // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TUrl(const char *url, Bool_t defaultIsFile = kFALSE);
    TUrl(const TUrl &url);
    TUrl &operator=(const TUrl &rhs);

--- a/graf2d/gpad/inc/TView.h
+++ b/graf2d/gpad/inc/TView.h
@@ -26,7 +26,7 @@ class TView : public TObject, public TAttLine {
 
 public:
 
-   TView() = default;
+   TView() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    virtual ~TView() = default;
 
    virtual void          DefinePerspectiveView() = 0;

--- a/graf2d/graf/inc/TLine.h
+++ b/graf2d/graf/inc/TLine.h
@@ -36,7 +36,7 @@ public:
       kHorizontal = BIT(16)  ///< Line is horizontal
    };
 
-   TLine() = default;
+   TLine() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TLine(Double_t x1, Double_t y1, Double_t x2, Double_t  y2);
    TLine(const TLine &line);
    virtual ~TLine() = default;

--- a/graf2d/graf/inc/TLine.h
+++ b/graf2d/graf/inc/TLine.h
@@ -36,7 +36,7 @@ public:
       kHorizontal = BIT(16)  ///< Line is horizontal
    };
 
-   TLine() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
+   TLine() {}
    TLine(Double_t x1, Double_t y1, Double_t x2, Double_t  y2);
    TLine(const TLine &line);
    virtual ~TLine() = default;

--- a/graf2d/graf/inc/TText.h
+++ b/graf2d/graf/inc/TText.h
@@ -33,7 +33,7 @@ public:
       kTextNDC = BIT(14)  ///< The text position is in the NDC space
    };
 
-   TText() = default;
+   TText() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TText(Double_t x, Double_t y, const char *text);
    TText(Double_t x, Double_t y, const wchar_t *text);
    TText(const TText &text);

--- a/graf2d/graf/inc/TWbox.h
+++ b/graf2d/graf/inc/TWbox.h
@@ -24,7 +24,7 @@ protected:
    Short_t      fBorderMode{0};    ///< Bordermode (-1=down, 0 = no border, 1=up)
 
 public:
-   TWbox() = default;
+   TWbox() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TWbox(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
          Color_t color=18, Short_t bordersize=5 ,Short_t bordermode=1);
    TWbox(const TWbox &wbox);

--- a/gui/webgui6/inc/TWebPadPainter.h
+++ b/gui/webgui6/inc/TWebPadPainter.h
@@ -41,7 +41,7 @@ protected:
 
 public:
 
-   TWebPadPainter() = default;
+   TWebPadPainter() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
 
    void SetPainting(TWebPainting *p) { fPainting = p; }
 

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -98,7 +98,7 @@ protected:
    Long64_t fVersion{0};           ///< actual canvas version
    std::string fScripts;           ///< custom scripts to load
 public:
-   TCanvasWebSnapshot() = default;
+   TCanvasWebSnapshot() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TCanvasWebSnapshot(bool readonly, Long64_t v) : TPadWebSnapshot(readonly), fVersion(v) {}
 
    Long64_t GetVersion() const { return fVersion; }

--- a/io/io/inc/TBufferFile.h
+++ b/io/io/inc/TBufferFile.h
@@ -52,7 +52,7 @@ protected:
    InfoList_t      fInfoStack;     ///< Stack of pointers to the TStreamerInfos
 
    // Default ctor
-   TBufferFile() = default;
+   TBufferFile() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
 
    // TBuffer objects cannot be copied or assigned
    TBufferFile(const TBufferFile &) = delete;       ///<  not implemented

--- a/io/io/inc/TBufferIO.h
+++ b/io/io/inc/TBufferIO.h
@@ -41,7 +41,7 @@ protected:
 
    static Int_t fgMapSize; ///< Default map size for all TBuffer objects
 
-   TBufferIO() = default;
+   TBufferIO() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
 
    TBufferIO(TBuffer::EMode mode);
    TBufferIO(TBuffer::EMode mode, Int_t bufsiz);

--- a/io/sql/inc/TKeySQL.h
+++ b/io/sql/inc/TKeySQL.h
@@ -23,7 +23,7 @@ private:
    TKeySQL &operator=(const TKeySQL &) = delete; // TKeySQL objects are not copiable.
 
 protected:
-   TKeySQL() = default;
+   TKeySQL() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
 
    using TKey::Read;
 

--- a/io/sql/inc/TSQLClassInfo.h
+++ b/io/sql/inc/TSQLClassInfo.h
@@ -21,7 +21,7 @@ class TObjArray;
 class TSQLClassColumnInfo final : public TObject {
 
 public:
-   TSQLClassColumnInfo() = default;
+   TSQLClassColumnInfo() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TSQLClassColumnInfo(const char *name, const char *sqlname, const char *sqltype);
 
    const char *GetName() const final { return fName.Data(); }
@@ -40,7 +40,7 @@ protected:
 
 class TSQLClassInfo final : public TObject {
 public:
-   TSQLClassInfo() = default;
+   TSQLClassInfo() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TSQLClassInfo(Long64_t classid, const char *classname, Int_t version);
    virtual ~TSQLClassInfo();
 

--- a/io/sql/inc/TSQLStructure.h
+++ b/io/sql/inc/TSQLStructure.h
@@ -110,7 +110,7 @@ protected:
    TObjArray fChilds;               //!
 
 public:
-   TSQLStructure() = default;
+   TSQLStructure() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    virtual ~TSQLStructure();
 
    TSQLStructure *GetParent() const { return fParent; }

--- a/io/xml/inc/TKeyXML.h
+++ b/io/xml/inc/TKeyXML.h
@@ -24,7 +24,7 @@ private:
    TKeyXML &operator=(const TKeyXML &) = delete; // TKeyXML objects are not copiable.
 
 protected:
-   TKeyXML() = default;
+   TKeyXML() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
 
 public:
    TKeyXML(TDirectory *mother, Long64_t keyid, const TObject *obj, const char *name = nullptr,

--- a/io/xml/inc/TXMLFile.h
+++ b/io/xml/inc/TXMLFile.h
@@ -49,7 +49,7 @@ private:
    void operator=(const TXMLFile &) = delete;      // TXMLFile cannot be copied, not implemented
 
 public:
-   TXMLFile() = default;
+   TXMLFile() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TXMLFile(const char *filename, Option_t *option = "read", const char *title = "title", Int_t compression = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
    virtual ~TXMLFile();
 

--- a/io/xml/inc/TXMLSetup.h
+++ b/io/xml/inc/TXMLSetup.h
@@ -88,6 +88,8 @@ public:
    TXMLSetup(const TXMLSetup &src);
    virtual ~TXMLSetup() = default;
 
+   TXMLSetup &operator=(const TXMLSetup &rhs);
+
    TString GetSetupAsString();
 
    void PrintSetup();

--- a/io/xml/src/TXMLSetup.cxx
+++ b/io/xml/src/TXMLSetup.cxx
@@ -130,6 +130,17 @@ TXMLSetup::TXMLSetup(const TXMLSetup &src)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// assign operator
+
+TXMLSetup &TXMLSetup::operator=(const TXMLSetup &rhs)
+{
+   fXmlLayout = rhs.fXmlLayout;
+   fStoreStreamerInfos = rhs.fStoreStreamerInfos;
+   fUseDtd = rhs.fUseDtd;
+   fUseNamespaces = rhs.fUseNamespaces;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// return setup values as string
 
 TString TXMLSetup::GetSetupAsString()

--- a/io/xml/src/TXMLSetup.cxx
+++ b/io/xml/src/TXMLSetup.cxx
@@ -138,6 +138,7 @@ TXMLSetup &TXMLSetup::operator=(const TXMLSetup &rhs)
    fStoreStreamerInfos = rhs.fStoreStreamerInfos;
    fUseDtd = rhs.fUseDtd;
    fUseNamespaces = rhs.fUseNamespaces;
+   return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -74,7 +74,7 @@ private:
    std::shared_ptr<THttpWSEngine> TakeWSEngine();
 
 public:
-   explicit THttpCallArg() = default;
+   explicit THttpCallArg() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    virtual ~THttpCallArg();
 
    // these methods used to set http request arguments

--- a/roofit/roofit/inc/RooJohnson.h
+++ b/roofit/roofit/inc/RooJohnson.h
@@ -25,7 +25,7 @@ class RooRealVar;
 
 class RooJohnson final : public RooAbsPdf {
 public:
-  RooJohnson() = default;
+  RooJohnson() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
 
   RooJohnson(const char *name, const char *title,
             RooAbsReal& mass, RooAbsReal& mu, RooAbsReal& sigma,

--- a/roofit/roofitcore/inc/RooNumIntFactory.h
+++ b/roofit/roofitcore/inc/RooNumIntFactory.h
@@ -41,12 +41,12 @@ public:
 
 
 private:
-	 
+
   friend class RooNumIntConfig ;
 
   std::map<std::string,std::pair<std::unique_ptr<RooAbsIntegrator>,std::string> > _map;
 
-  RooNumIntFactory() = default;
+  RooNumIntFactory() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
   RooNumIntFactory(const RooNumIntFactory& other) = delete;
 
   void init();


### PR DESCRIPTION
see https://sft.its.cern.ch/jira/browse/ROOT-10300

If sub-class of TObject uses `=default` specifier for default constructor, all members (including from TObject) are initialized. By this special logic for TObject::kIsOnHeap bit is corrupted.

The only solution for now - avoid such `= default` specifier. 