### PR TITLE
[TMVA][TMVA-Gui] - Generic object to log and present Keras and DNN training history

### DIFF
--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -181,6 +181,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     TMVA/TNeuronInputSqSum.h
     TMVA/TNeuronInputSum.h
     TMVA/Tools.h
+    TMVA/TrainingHistory.h
     TMVA/TransformationHandler.h
     TMVA/TSpline1.h
     TMVA/TSpline2.h
@@ -341,6 +342,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     src/TNeuronInputSqSum.cxx
     src/TNeuronInputSum.cxx
     src/Tools.cxx
+    src/TrainingHistory.cxx
     src/TransformationHandler.cxx
     src/TSpline1.cxx
     src/TSpline2.cxx

--- a/tmva/tmva/inc/TMVA/MethodBase.h
+++ b/tmva/tmva/inc/TMVA/MethodBase.h
@@ -55,6 +55,7 @@
 #include "TMVA/Event.h"
 #include "TMVA/TransformationHandler.h"
 #include <TMVA/Results.h>
+#include "TMVA/TrainingHistory.h"
 
 #include <TFile.h>
 
@@ -88,6 +89,7 @@ namespace TMVA {
    namespace Experimental {
    class Classification;
    }
+   class TrainingHistory;
 
    class IPythonInteractive {
    public:
@@ -222,6 +224,12 @@ namespace TMVA {
 
       // multiclass classification response
       virtual const std::vector<Float_t>& GetMulticlassValues() {
+         std::vector<Float_t>* ptr = new std::vector<Float_t>(0);
+         return (*ptr);
+      }
+
+      // Training history
+      virtual const std::vector<Float_t>& GetTrainingHistory(const char* name) {
          std::vector<Float_t>* ptr = new std::vector<Float_t>(0);
          return (*ptr);
       }
@@ -414,6 +422,7 @@ namespace TMVA {
       const Event*     GetTestingEvent ( Long64_t ievt ) const;
       const std::vector<TMVA::Event*>& GetEventCollection( Types::ETreeType type );
 
+      TrainingHistory  fTrainHistory;
       // ---------- public auxiliary methods ---------------------------------------
 
       // this method is used to decide whether an event is signal- or background-like

--- a/tmva/tmva/inc/TMVA/TrainingHistory.h
+++ b/tmva/tmva/inc/TMVA/TrainingHistory.h
@@ -1,0 +1,50 @@
+/**********************************************************************************
+ * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
+ * Package: TMVA                                                                  *
+ * Class  : MsgLogger                                                             *
+ * Web    : http://tmva.sourceforge.net                                           *
+ *                                                                                *
+ * Description:                                                                   *
+ *      Implementation (see header for description)                               *
+ *                                                                                *
+ * Author:                                                                        *
+ *      Joseph McKenna        <Joseph.McKenna@cern.ch> - Aarhus, Denmark          *
+ *                                                                                *
+* Copyright (c) 2019:                                                             *
+ *      Aarhus, Denmark                                                           *
+ *                                                                                *
+ * Redistribution and use in source and binary forms, with or without             *
+ * modification, are permitted according to the terms listed in LICENSE           *
+ * (http://tmva.sourceforge.net/LICENSE)                                          *
+ **********************************************************************************/
+
+
+#ifndef ROOT_TMVA_TrainingHistory
+#define ROOT_TMVA_TrainingHistory
+
+#include <vector>
+#include "TString.h"
+#include <map>
+#include "TH1D.h"
+#include <iostream>
+namespace TMVA {
+
+
+   class TrainingHistory {
+
+   public:
+      typedef std::vector<std::pair<Int_t,Double_t>> IterationRecord;
+      TrainingHistory();
+      virtual ~TrainingHistory();
+
+      void AddValue(TString Property, Int_t stage, Double_t value);
+      void SaveHistory(TString Name);
+   private:
+      std::map<TString,int> fHistoryMap;
+      std::vector<IterationRecord*> fHistoryData;
+   
+   };
+
+} // namespace TMVA
+
+#endif

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -1169,6 +1169,13 @@ void TMVA::Factory::TrainAllMethods()
      }
       }
 
+      for (UInt_t i=0; i<methods->size(); i++) {
+         MethodBase* m = dynamic_cast<MethodBase*>((*methods)[i]);
+         if(m==0) continue;
+         m->BaseDir()->cd();
+         m->fTrainHistory.SaveHistory(m->GetMethodName());
+      }
+
       // delete all methods and recreate them from weight file - this ensures that the application
       // of the methods (in TMVAClassificationApplication) is consistent with the results obtained
       // in the testing
@@ -1365,6 +1372,8 @@ void TMVA::Factory::EvaluateAllMethods( void )
       std::vector<std::vector<Float_t> > multiclass_trainEff;
       std::vector<std::vector<Float_t> > multiclass_testPur;
       std::vector<std::vector<Float_t> > multiclass_trainPur;
+      
+      std::vector<std::vector<Float_t> > train_history;
 
       // Multiclass confusion matrices.
       std::vector<TMatrixD> multiclass_trainConfusionEffB01;

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1399,6 +1399,9 @@ void MethodDL::TrainDeepNet()
             Double_t regTerm = (includeRegularization) ? deepNet.RegularizationTerm() : 0.0; 
             valError /= (Double_t)(nValidationSamples / settings.batchSize);
             valError += regTerm; 
+
+            //Log the loss value
+            fTrainHistory.AddValue("valError",optimizer->GetGlobalStep(),valError);
             
             t2 = std::chrono::system_clock::now();
 
@@ -1440,6 +1443,9 @@ void MethodDL::TrainDeepNet()
             // normalize loss to number of batches and add regularization term 
             trainingError /= (Double_t)(nTrainingSamples / settings.batchSize);
             trainingError += regTerm; 
+
+            //Log the loss value
+            fTrainHistory.AddValue("trainingError",optimizer->GetGlobalStep(),trainingError);
 
             // stop measuring
             tend = std::chrono::system_clock::now();

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -1024,6 +1024,9 @@ void TMVA::MethodDNN::TrainGpu()
             }
             testError /= (Double_t) (nTestSamples / settings.batchSize);
 
+            //Log the loss value
+            fTrainHistory.AddValue("testError",stepCount,testError);
+
             end   = std::chrono::system_clock::now();
 
             // Compute training error.
@@ -1034,6 +1037,8 @@ void TMVA::MethodDNN::TrainGpu()
                trainingError += net.Loss(inputMatrix, outputMatrix);
             }
             trainingError /= (Double_t) (nTrainingSamples / settings.batchSize);
+            //Log the loss value
+            fTrainHistory.AddValue("trainingError",stepCount,trainingError);
 
             // Compute numerical throughput.
             std::chrono::duration<double> elapsed_seconds = end - start;
@@ -1208,6 +1213,9 @@ void TMVA::MethodDNN::TrainCpu()
             }
             testError /= (Double_t) (nTestSamples / settings.batchSize);
 
+            //Log the loss value
+            fTrainHistory.AddValue("testError",stepCount,testError);
+
             end   = std::chrono::system_clock::now();
 
             // Compute training error.
@@ -1219,6 +1227,9 @@ void TMVA::MethodDNN::TrainCpu()
                trainingError += net.Loss(inputMatrix, outputMatrix, weightMatrix);
             }
             trainingError /= (Double_t) (nTrainingSamples / settings.batchSize);
+
+            //Log the loss value
+            fTrainHistory.AddValue("trainingError",stepCount,trainingError);
 
             if (fInteractive){
                fInteractive->AddPoint(stepCount, trainingError, testError);

--- a/tmva/tmva/src/TrainingHistory.cxx
+++ b/tmva/tmva/src/TrainingHistory.cxx
@@ -1,0 +1,81 @@
+/**********************************************************************************
+ * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
+ * Package: TMVA                                                                  *
+ * Class  : TrainingHistory                                                       *
+ * Web    : http://tmva.sourceforge.net                                           *
+ *                                                                                *
+ * Description:                                                                   *
+ *      Implementation (see header for description)                               *
+ *                                                                                *
+ * Author:                                                                        *
+ *      Joseph McKenna        <Joseph.McKenna@cern.ch> - Aarhus, Denmark          *
+ *                                                                                *
+ * Copyright (c) 2019:                                                            *
+ *      Aarhus, Denmark                                                           *
+ *                                                                                *
+ * Redistribution and use in source and binary forms, with or without             *
+ * modification, are permitted according to the terms listed in LICENSE           *
+ * (http://tmva.sourceforge.net/LICENSE)                                          *
+ **********************************************************************************/
+
+/*! \class TMVA::TrainingHistory
+\ingroup TMVA
+
+Tracking data from training. Eg, From deep learning record loss for each Epoch
+
+*/
+
+
+#include "TMVA/TrainingHistory.h"
+
+////////////////////////////////////////////////////////////////////////////////
+/// constructor
+
+TMVA::TrainingHistory::TrainingHistory()
+{
+}
+
+TMVA::TrainingHistory::~TrainingHistory()
+{
+   for (auto p : fHistoryData) {
+     delete p;
+   } 
+}
+
+void TMVA::TrainingHistory::AddValue(TString Property,Int_t stage, Double_t value)
+{
+   if (!fHistoryMap.count(Property))
+   {
+      fHistoryMap[Property]=fHistoryData.size();
+      IterationRecord* data=new IterationRecord();
+      fHistoryData.push_back(data);
+   }
+   int iHistory=fHistoryMap.at(Property);
+   //std::cout<<"HISTORY!"<<"Adding value ("<<Property<<"):"<<stage<<"\t"<<value<<std::endl;
+   fHistoryData.at(iHistory)->push_back({stage,value});
+}
+
+void TMVA::TrainingHistory::SaveHistory(TString Name)
+{
+   //if (fHistoryData.empty()) return;
+   //for(std::map<TString,Int_t>::iterator element = fHistoryMap.begin(); element != fHistoryMap.end(); ++element) {
+   //for (auto element :fHistoryMap) {
+   for ( const auto &element : fHistoryMap ) {
+      TString property = element.first;
+      Int_t iHistory = element.second;
+      Int_t nBins=fHistoryData.at(iHistory)->size();
+      Double_t xMin=fHistoryData.at(iHistory)->front().first;
+      Double_t xMax=fHistoryData.at(iHistory)->back().first;
+      TH1D* h=new TH1D("TrainingHistory_"+Name+"_"+property,"TrainingHistory_"+Name+"_"+property,nBins,xMin,xMax);
+      for (int i=0; i<nBins; i++) {
+         std::cout<<fHistoryData.at(iHistory)->at(i).first<<"\t"<<fHistoryData.at(iHistory)->at(i).second<<std::endl;
+         h->AddBinContent(i+1,fHistoryData.at(iHistory)->at(i).second);
+      }
+      h->Print();
+      if (h!=0) {
+         h->Write();
+         delete h;
+      }
+
+   }
+}

--- a/tmva/tmva/src/TrainingHistory.cxx
+++ b/tmva/tmva/src/TrainingHistory.cxx
@@ -58,17 +58,15 @@ void TMVA::TrainingHistory::AddValue(TString Property,Int_t stage, Double_t valu
 void TMVA::TrainingHistory::SaveHistory(TString Name)
 {
    //if (fHistoryData.empty()) return;
-   //for(std::map<TString,Int_t>::iterator element = fHistoryMap.begin(); element != fHistoryMap.end(); ++element) {
-   //for (auto element :fHistoryMap) {
    for ( const auto &element : fHistoryMap ) {
       TString property = element.first;
       Int_t iHistory = element.second;
       Int_t nBins=fHistoryData.at(iHistory)->size();
       Double_t xMin=fHistoryData.at(iHistory)->front().first;
       Double_t xMax=fHistoryData.at(iHistory)->back().first;
-      TH1D* h=new TH1D("TrainingHistory_"+Name+"_"+property,"TrainingHistory_"+Name+"_"+property,nBins,xMin,xMax);
+      Double_t BinSize=(xMax-xMin)/(Double_t)(nBins-1);
+      TH1D* h=new TH1D("TrainingHistory_"+Name+"_"+property,"TrainingHistory_"+Name+"_"+property,nBins,xMin-0.5*BinSize,xMax+0.5*BinSize);
       for (int i=0; i<nBins; i++) {
-         std::cout<<fHistoryData.at(iHistory)->at(i).first<<"\t"<<fHistoryData.at(iHistory)->at(i).second<<std::endl;
          h->AddBinContent(i+1,fHistoryData.at(iHistory)->at(i).second);
       }
       h->Print();

--- a/tmva/tmvagui/CMakeLists.txt
+++ b/tmva/tmvagui/CMakeLists.txt
@@ -44,6 +44,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVAGui
     TMVA/rulevisCorr.h
     TMVA/rulevisHists.h
     TMVA/tmvaglob.h
+    TMVA/training_history.h
     TMVA/variables.h
     TMVA/variablesMultiClass.h
   SOURCES
@@ -76,6 +77,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVAGui
     src/rulevisCorr.cxx
     src/rulevisHists.cxx
     src/tmvaglob.cxx
+    src/training_history.cxx
     src/variables.cxx
     src/variablesMultiClass.cxx
     src/BDT.cxx

--- a/tmva/tmvagui/inc/TMVA/training_history.h
+++ b/tmva/tmvagui/inc/TMVA/training_history.h
@@ -1,0 +1,13 @@
+#ifndef training_history__HH
+#define training_history__HH
+#include "tmvaglob.h"
+#include "TH2F.h"
+#include "TFile.h"
+#include "TIterator.h"
+#include "TKey.h"
+namespace TMVA{
+
+   void plot_training_history(TString dataset, TFile* file, TDirectory* BinDir=0);
+   void training_history(TString dataset, TString fin = "TMVA.root", Bool_t useTMVAStyle = kTRUE );
+}
+#endif

--- a/tmva/tmvagui/src/TMVAGui.cxx
+++ b/tmva/tmvagui/src/TMVAGui.cxx
@@ -242,6 +242,13 @@ void TMVA::TMVAGui( const char* fName  , TString dataset)
                  "Plots the PDFs of the classifier output distributions for signal and background - if requested (macro probas.cxx)",
                  buttonType, defaultRequiredClassifier );
 
+   title = Form( "(%i) Training History", ++ic );
+   ActionButton( cbar,  
+                 title,
+                 Form( "TMVA::training_history(\"%s\",\"%s\",%d)",dataset.Data(), fName ),
+                 "Plot training history of classifiers with multiple passed (eg Neural Networks) ",
+                 buttonType, defaultRequiredClassifier );
+
    title = Form( "(%i) Likelihood Reference Distributiuons", ++ic);
    ActionButton( cbar,  
                  title,

--- a/tmva/tmvagui/src/training_history.cxx
+++ b/tmva/tmvagui/src/training_history.cxx
@@ -74,8 +74,6 @@ void TMVA::plot_training_history(TString dataset, TFile* /*file*/, TDirectory* B
                if (h->GetBinLowEdge(0) < x1 ) x1 = h->GetBinLowEdge(0);
                if (h->GetBinLowEdge(h->GetNbinsX()+1 ) > x2 ) x2 = h->GetBinLowEdge(h->GetNbinsX()+1 );
                
-               std::cout<<"X:"<<x1<<"\t"<<x2<<std::endl;
-               std::cout<<"Y:"<<y1<<"\t"<<y2<<std::endl;
             }
          }
       }

--- a/tmva/tmvagui/src/training_history.cxx
+++ b/tmva/tmvagui/src/training_history.cxx
@@ -1,0 +1,199 @@
+#include "TMVA/training_history.h"
+
+#include "TH2F.h"
+#include "TFile.h"
+#include "TIterator.h"
+#include "TKey.h"
+
+void TMVA::plot_training_history(TString dataset, TFile* /*file*/, TDirectory* BinDir)
+{
+
+   Bool_t __PLOT_LOGO__  = kTRUE;
+   Bool_t __SAVE_IMAGE__ = kTRUE;
+
+   // the coordinates
+   Float_t x1 = 999;
+   Float_t x2 = -999;
+   Float_t y1 = 999.;
+   Float_t y2 = -999;
+
+   // create canvas
+   TCanvas* c = new TCanvas( "c", "the canvas", 200, 0, 650, 500 );
+
+   // global style settings
+   c->SetGrid();
+   c->SetTicks();
+
+   // legend
+   Float_t x0L = 0.107,     y0H = 0.899;
+   Float_t dxL = 0.457-x0L, dyH = 0.22;
+
+   TLegend *legend = new TLegend( x0L, y0H-dyH, x0L+dxL, y0H );
+   //legend->SetTextSize( 0.05 );
+   legend->SetHeader( "MVA Method:" );
+   legend->SetMargin( 0.4 );
+
+   TString xtit = "Training Step";
+   TString ytit = "";
+
+   TString ftit = "Training History";
+
+   TString hNameRef = "";//training_history";
+
+   TList xhists;
+   TList xmethods;
+   UInt_t xnm = TMVAGlob::GetListOfMethods( xmethods ,BinDir);
+   if (xnm==0){
+      cout << "ups .. no methods found in to plot training history for ... give up"  << endl;
+      return;
+   }
+   TIter xnext(&xmethods);
+   // loop over all methods
+   TKey *xkey;
+   while ((xkey = (TKey*)xnext())) {
+      TDirectory * mDir = (TDirectory*)xkey->ReadObj();
+      TList titles;
+      UInt_t ninst = TMVAGlob::GetListOfTitles(mDir,titles);
+      if (ninst==0) cout << "hmm... sorry, but this printout was supposed to be only to keep the compiler quite.. never supposed to happen :(" << endl;
+      TIter nextTitle(&titles);
+      TKey *titkey;
+      TDirectory *titDir;
+      while ((titkey = TMVAGlob::NextKey(nextTitle,"TDirectory"))) {
+         titDir = (TDirectory *)titkey->ReadObj();
+         TString methodTitle;
+         TMVAGlob::GetMethodTitle(methodTitle,titDir);
+         TIter nextKey( titDir->GetListOfKeys() );
+         TKey *hkey2;
+         while ((hkey2 = TMVAGlob::NextKey(nextKey,"TH1"))) {
+            TH1 *h = (TH1*)hkey2->ReadObj();
+            TString hname = h->GetName();
+            if (hname.Contains( hNameRef ) && hname.BeginsWith( "TrainingHistory_" )) {
+
+               if (h->GetMaximum() > y2) y2 = h->GetMaximum()*1.1;
+               if (h->GetMinimum() < y1) y1 = h->GetMinimum();
+               if (h->GetBinLowEdge(0) < x1 ) x1 = h->GetBinLowEdge(0);
+               if (h->GetBinLowEdge(h->GetNbinsX()+1 ) > x2 ) x2 = h->GetBinLowEdge(h->GetNbinsX()+1 );
+               
+               std::cout<<"X:"<<x1<<"\t"<<x2<<std::endl;
+               std::cout<<"Y:"<<y1<<"\t"<<y2<<std::endl;
+            }
+         }
+      }
+   }
+
+
+   // draw empty frame
+   if(gROOT->FindObject("frame")!=0) gROOT->FindObject("frame")->Delete();
+   TH2F* frame = new TH2F( "frame", ftit, 500, x1, x2, 500, y1, y2 );
+   frame->GetXaxis()->SetTitle( xtit );
+   frame->GetYaxis()->SetTitle( ytit );
+   TMVAGlob::SetFrameStyle( frame, 1.0 );
+
+   frame->Draw();
+
+   Int_t color = 1;
+   Int_t nmva  = 0;
+   TKey *key;
+
+   TList hists;
+   TList methods;
+   UInt_t nm = TMVAGlob::GetListOfMethods( methods,BinDir );
+   if (nm==0){
+      cout << "ups .. no methods found in to plot ROC curve for ... give up"  << endl;
+      return;
+   }
+   //   TIter next(file->GetListOfKeys());
+   TIter next(&methods);
+
+   // loop over all methods
+   while ((key = (TKey*)next())) {
+      TDirectory * mDir = (TDirectory*)key->ReadObj();
+      TList titles;
+      UInt_t ninst = TMVAGlob::GetListOfTitles(mDir,titles);
+      if (ninst==0) cout << "hmm...  sorry, but this printout was supposed to be only to keep the compiler quite.. never supposed to happen :(" << endl;
+      TIter nextTitle(&titles);
+      TKey *titkey;
+      TDirectory *titDir;
+      while ((titkey = TMVAGlob::NextKey(nextTitle,"TDirectory"))) {
+         titDir = (TDirectory *)titkey->ReadObj();
+         TString methodTitle;
+         TMVAGlob::GetMethodTitle(methodTitle,titDir);
+         TIter nextKey( titDir->GetListOfKeys() );
+         TKey *hkey2;
+         while ((hkey2 = TMVAGlob::NextKey(nextKey,"TH1"))) {
+            TH1 *h = (TH1*)hkey2->ReadObj();
+            TString hname = h->GetName();
+            if (hname.Contains( hNameRef ) && hname.BeginsWith( "TrainingHistory_" )) {
+               h->SetLineWidth(3);
+               h->SetLineColor(color);
+               color++; if (color == 5 || color == 10 || color == 11) color++;
+               h->Draw("csame");
+               hists.Add(h);
+               nmva++;
+            }
+         }
+      }
+   }
+
+   while (hists.GetSize()) {
+      TListIter hIt(&hists);
+      TH1* hist(0);
+      Double_t largestInt=-1;
+      TH1* histWithLargestInt(0);
+      while ((hist = (TH1*)hIt())!=0) {
+         Double_t integral = hist->Integral(1,hist->FindBin(0.9999));
+         if (integral>largestInt) {
+            largestInt = integral;
+            histWithLargestInt = hist;
+         }
+      }
+      if (histWithLargestInt == 0) {
+         cout << "ERROR - unknown hist \"histWithLargestInt\" --> serious problem in ROOT file" << endl;
+         break;
+      }
+      legend->AddEntry(histWithLargestInt,TString(histWithLargestInt->GetTitle()).ReplaceAll("MVA_",""),"l");
+      hists.Remove(histWithLargestInt);
+   }
+
+   // rescale legend box size
+   // current box size has been tuned for 3 MVAs + 1 title
+   dyH *= (Float_t(TMath::Min(10,nmva) - 3.0)/4.0);
+   legend->SetY2( y0H + dyH);
+   
+   // redraw axes
+   frame->Draw("sameaxis");
+   legend->Draw("same");
+
+   // ============================================================
+
+   if (__PLOT_LOGO__) TMVAGlob::plot_logo();
+
+   // ============================================================
+
+   c->Update();
+
+   TString fname = dataset+"/plots/" + hNameRef;
+   if (TString(BinDir->GetName()).Contains("multicut")){
+      TString fprepend(BinDir->GetName());
+      fprepend.ReplaceAll("multicutMVA_","");
+      fname = dataset+"plots/" + fprepend + "_" + hNameRef;
+   }
+   if (__SAVE_IMAGE__) TMVAGlob::imgconv( c, fname );
+
+   return;
+}
+
+void TMVA::training_history(TString dataset, TString fin , Bool_t useTMVAStyle )
+{
+
+   // set style and remove existing canvas'
+   TMVAGlob::Initialize( useTMVAStyle );
+
+   // checks if file with name "fin" is already open, and if not opens one
+   TFile* file = TMVAGlob::OpenFile( fin );
+
+   plot_training_history(dataset, file, file->GetDirectory(dataset.Data()));
+
+   return;
+}
+


### PR DESCRIPTION
Feature: Save training progress to root file, present it in TMVAGui

Add training history object for TMVA, here I incorporate usage to log DNN epoch performance with DNN_CPU and PyKeras. The tool is intended to be general enough that it can be used by any ML algorithm. For example, XGBoost could also record its progress per iteration with this object.

A request for this functionality can be found on the root forums
https://root-forum.cern.ch/t/how-to-get-training-history-using-tmva-keras-interface/28799

My solution does not require tensorboard and records are stored within the root file

Test:
```
. bin/thisroot.sh
cd tutorials/tmva/
make
./TMVAClassification
root -l
TMVA::TMVAGui("TMVA.root")
//Click on Training History... See the DNN_CPU_valError and trainingError plotted, not that data points are only added for every epoch printed in MethodDNN.cxx 
.q

cd keras
python ClassificationKeras.py
root -l
TMVA::TMVAGui("TMVA.root")
//Click on Training History... See Keras training history for PyKeras_val_acc, PyKeras_acc, PyKeras_loss and PyKeras_val_loss
```

Feedback welcomed