### PR TITLE
[cxxmodules] Use common-rooted valid source location.

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -840,18 +840,10 @@ namespace cling {
     if (getSema().isModuleVisible(M))
       return true;
 
-    Preprocessor& PP = getCI()->getPreprocessor();
-
-    IdentifierInfo *II = PP.getIdentifierInfo(M->Name);
-    SourceLocation ValidLoc = M->DefinitionLoc;
     Interpreter::PushTransactionRAII RAII(this);
-    bool success = !getCI()->getSema().ActOnModuleImport(ValidLoc, ValidLoc,
-                                      std::make_pair(II, ValidLoc)).isInvalid();
-    if (success) {
-      // Also make the module visible in the preprocessor to export its macros.
-      PP.makeModuleVisible(M, ValidLoc);
-      return success;
-    }
+    if (declare("#pragma clang module import " + M->Name) == kSuccess)
+      return true;
+
     if (complain) {
       if (M->IsSystem)
         llvm::errs() << "Failed to load module " << M->Name << "\n";


### PR DESCRIPTION
Over the years we have a pathological issue with cling when it calls directly
compiler API. Most of the API assume they are called from code residing in a
text file. This code has valid source locations which can be used for
comparisons and things like point of instantiation for template instantiations.

This means that whenever a clang API requires a valid source location, cling
should have an interface which gives a pseudo-valid, commonly-rooted unique
source location.

We are bitten by this fact when preloading modules as if we have diagnostics
they cannot be ordered due to the fact that the compared decls from two
different modules do not have a common includer.

This patch avoids using an API and relies on a textual form which does not have
this problem at the cost of synthesizing an extra string.

This should fix the roottest python stl-stl test failure in the incremental builds.