### PR TITLE
[rootcling] Add and deprecate the -std flag.

### DIFF
--- a/README/ReleaseNotes/v620/index.md
+++ b/README/ReleaseNotes/v620/index.md
@@ -60,8 +60,8 @@ instead of the splash screen. The splash screen can still be seen with `root -a`
 or in `TBrowser` by opening `Browser Help → About ROOT`.
 
 ## Deprecation and Removal
- * rootcling flags `-cint`, `-reflex`, `-gccxml`, `-p` and `-c` have no effect
-   and will be removed. Please remove them from the rootcling invocations.
+ * rootcling flags `-std`, `-cint`, `-reflex`, `-gccxml`, `-p` and `-c` have no
+   effect and will be removed. Please remove them from the rootcling invocations.
  * rootcling legacy cint flags `+P`, `+V` and `+STUB` have no effect and will be
    removed. Please remove them from the rootcling invocations.
  * genreflex flag `--deep` has no effect and will be removed. Please remove it

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3732,6 +3732,10 @@ gOptVerboseLevel(llvm::cl::desc("Choose verbosity level:"),
                 llvm::cl::init(v),
                 llvm::cl::cat(gRootclingOptions));
 
+static llvm::cl::opt<string>
+gOptStd("std", llvm::cl::desc("Deprecated, legacy flag which is ignored."),
+        llvm::cl::init("-"), llvm::cl::Hidden,
+        llvm::cl::cat(gRootclingOptions));
 static llvm::cl::opt<bool>
 gOptCint("cint", llvm::cl::desc("Deprecated, legacy flag which is ignored."),
         llvm::cl::Hidden,
@@ -3929,6 +3933,8 @@ int RootClingMain(int argc,
       genreflex::verbose = true;
 
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,21,00)
+   if (gOptStd != "-")
+      fprintf(stderr, "Please remove the deprecated flag -std.\n");
    if (gOptCint)
       fprintf(stderr, "Please remove the deprecated flag -cint.\n");
    if (gOptReflex)


### PR DESCRIPTION
This should address the DD4HEP issue described in ROOT-10303.