### PR TITLE
[tcling] Turn off LazyFunctionCreatorAutoload when autoload is off.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6357,6 +6357,9 @@ static void* LazyFunctionCreatorAutoloadForModule(const std::string &mangled_nam
 /// Autoload a library based on a missing symbol.
 
 void* TCling::LazyFunctionCreatorAutoload(const std::string& mangled_name) {
+   if (!IsClassAutoloadingEnabled())
+      return nullptr;
+
    if (fCxxModulesEnabled)
       return LazyFunctionCreatorAutoloadForModule(mangled_name, fInterpreter);
 


### PR DESCRIPTION
We should not run our symbol-based autoloading when the autoloading in ROOT
is disabled.