### PR TITLE
[rootcling] Do not fail on unrecognized options.

### DIFF
--- a/README/ReleaseNotes/v620/index.md
+++ b/README/ReleaseNotes/v620/index.md
@@ -66,6 +66,9 @@ or in `TBrowser` by opening `Browser Help → About ROOT`.
    removed. Please remove them from the rootcling invocations.
  * genreflex flag `--deep` has no effect and will be removed. Please remove it
    from the genreflex invocation.
+ * rootcling warns if it sees and unrecognized flag (usually coming from the
+   CXXFLAGS of the build system). Please remove them from the invocation because
+   the warning will become a hard error in the next releases.
 
 ### Deprecated packages
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3863,6 +3863,10 @@ static llvm::cl::list<std::string>
 gOptDictionaryHeaderFiles(llvm::cl::Positional, llvm::cl::OneOrMore,
                          llvm::cl::desc("<list of dictionary header files> <LinkDef file>"),
                          llvm::cl::cat(gRootclingOptions));
+static llvm::cl::list<std::string>
+gOptSink(llvm::cl::ZeroOrMore, llvm::cl::Sink,
+         llvm::cl::desc("Consumes all unrecognized options."),
+         llvm::cl::cat(gRootclingOptions));
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3948,6 +3952,9 @@ int RootClingMain(int argc,
          gOptDictionaryHeaderFiles.erase(I);
       }
    }
+
+   for (const std::string& Opt : gOptSink)
+      fprintf(stderr, "Please remove the deprecated flag %s\n", Opt.c_str());
 #else
 # error "Remove this deprecated code"
 #endif


### PR DESCRIPTION
root-project/root@72fe06a does not permit passing random options to rootcling
as improvement in encapsulation. Rootcling used to permit random flags usually
coming CXXFLAGS and it captured only -I, -D and -U. The old implementation
used to pass all flags directly to cling thus clang. This lead to allowing
the dictionaries to be compiled with incompatible to the rest of the build
flags.

Some users passed their entire CXXFLAGS from the build systems and the current
rootcling implementation started to reject it breaking backward compatibility.

This patch implements a sink for all unrecognized flags and issues a deprecation
message. Should address the rest of the concerns of ROOT-10303.