### PR TITLE
Find scope parser raii

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1404,10 +1404,12 @@ void TClass::Init(const char *name, Version_t cversion,
          }
       }
 
-      fClassInfo = gInterpreter->ClassInfo_Factory(givenInfo);
-      fCanLoadClassInfo = false; // avoids calls to LoadClassInfo() if info is already loaded
-      if (fState <= kEmulated)
-         fState = kInterpreted;
+      if (!invalid) {
+         fClassInfo = gInterpreter->ClassInfo_Factory(givenInfo);
+         fCanLoadClassInfo = false; // avoids calls to LoadClassInfo() if info is already loaded
+         if (fState <= kEmulated)
+            fState = kInterpreted;
+      }
    }
 
    // We need to check if the class it is not fwd declared for the cases where we

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6057,7 +6057,7 @@ void TClass::SetUnloaded()
             GetName(),(int)fState);
    }
 
-   InsertTClassInRegistryRAII insertRAII(fState,fName,fNoInfoOrEmuOrFwdDeclNameRegistry);
+   InsertTClassInRegistryRAII insertRAII(fState, fName, fNoInfoOrEmuOrFwdDeclNameRegistry);
 
    // Make sure SetClassInfo, re-calculated the state.
    fState = kForwardDeclared;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1406,6 +1406,8 @@ void TClass::Init(const char *name, Version_t cversion,
 
       fClassInfo = gInterpreter->ClassInfo_Factory(givenInfo);
       fCanLoadClassInfo = false; // avoids calls to LoadClassInfo() if info is already loaded
+      if (fState <= kEmulated)
+         fState = kInterpreted;
    }
 
    // We need to check if the class it is not fwd declared for the cases where we
@@ -6052,6 +6054,8 @@ void TClass::SetUnloaded()
       Fatal("SetUnloaded","The TClass for %s is being unloaded when in state %d\n",
             GetName(),(int)fState);
    }
+
+   InsertTClassInRegistryRAII insertRAII(fState,fName,fNoInfoOrEmuOrFwdDeclNameRegistry);
 
    // Make sure SetClassInfo, re-calculated the state.
    fState = kForwardDeclared;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6511,9 +6511,8 @@ void TCling::RefreshClassInfo(TClass *cl, const clang::TagDecl *tdDef, bool alia
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Internal function. Inform a TClass about its new TagDecl or NamespaceDecl.
-void TCling::UpdateClassInfoWithDecl(const void* vTD)
+void TCling::UpdateClassInfoWithDecl(const NamedDecl* ND)
 {
-   const NamedDecl* ND = static_cast<const NamedDecl*>(vTD);
    const TagDecl* td = dyn_cast<TagDecl>(ND);
    std::string name;
    TagDecl* tdDef = 0;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6500,7 +6500,7 @@ void TCling::UpdateClassInfoWithDecl(const void* vTD)
       clang::QualType type( td->getTypeForDecl(), 0 );
       ROOT::TMetaUtils::GetNormalizedName(name, type, *fInterpreter, *fNormalizedCtxt);
    } else {
-      name = ND->getNameAsString();
+      name = ND->getQualifiedNameAsString();
    }
 
    // Supposedly we are being called while something is being

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6487,8 +6487,13 @@ void TCling::UpdateClassInfoWithDecl(const void* vTD)
       }
 
       auto declName=ND->getNameAsString();
+      // Check if we have registered the unqualified name into the list
+      // of TClass that are in kNoInfo, kEmulated or kFwdDeclaredState.
+      // Since this is used as heureutistic to avoid spurrious calls to GetNormalizedName
+      // the unqualified name is sufficient (and the fully qualified name might be
+      // 'wrong' if there is difference in spelling in the template paramters (for example)
       if (!TClass::HasNoInfoOrEmuOrFwdDeclaredDecl(declName.c_str())){
-//          printf ("Impossible to find a TClassEntry in kNoInfo or kEmulated the decl of which would be called %s. Skip w/o building the normalized name.\n",declName );
+         // fprintf (stderr,"WARNING: Impossible to find a TClassEntry in kNoInfo or kEmulated the decl of which would be called %s. Skip w/o building the normalized name.\n",declName.c_str() );
          return;
       }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6523,7 +6523,8 @@ void TCling::UpdateClassInfoWithDecl(const NamedDecl* ND)
       td = tdDef;
       ND = td;
 
-      if (llvm::isa<clang::FunctionDecl>(td->getDeclContext())) {
+      if (!td->isCompleteDefinition() || llvm::isa<clang::FunctionDecl>(td->getDeclContext())) {
+         // Ignore incomplete definition.
          // Ignore declaration within a function.
          return;
       }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6465,11 +6465,11 @@ Bool_t TCling::IsAutoLoadNamespaceCandidate(const clang::NamespaceDecl* nsDecl)
    return fNSFromRootmaps.count(nsDecl) != 0;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Internal function. Actually do the update of the ClassInfo when seeing
 //  new TagDecl or NamespaceDecl.
-void TCling::RefreshClassInfo(TClass *cl, const clang::TagDecl *tdDef, bool alias) {
+void TCling::RefreshClassInfo(TClass *cl, const clang::TagDecl *tdDef, bool alias)
+{
 
    TClingClassInfo *cci = ((TClingClassInfo *)cl->fClassInfo);
    if (cci) {
@@ -6493,7 +6493,7 @@ void TCling::RefreshClassInfo(TClass *cl, const clang::TagDecl *tdDef, bool alia
       if (!alias)
          cl->fClassInfo = (ClassInfo_t *)new TClingClassInfo(fInterpreter, tdDef);
       else
-          cl->fClassInfo = (ClassInfo_t *)new TClingClassInfo(fInterpreter, cl->GetName());
+         cl->fClassInfo = (ClassInfo_t *)new TClingClassInfo(fInterpreter, cl->GetName());
       if (((TClingClassInfo *)cl->fClassInfo)->IsValid()) {
          // We now need to update the state and bits.
          if (cl->fState != TClass::kHasTClassInit) {
@@ -6540,13 +6540,11 @@ void TCling::UpdateClassInfoWithDecl(const void* vTD)
          return;
       }
 
-      clang::QualType type( td->getTypeForDecl(), 0 );
+      clang::QualType type(td->getTypeForDecl(), 0);
       ROOT::TMetaUtils::GetNormalizedName(name, type, *fInterpreter, *fNormalizedCtxt);
    } else {
       name = ND->getQualifiedNameAsString();
    }
-
-
 
    // Supposedly we are being called while something is being
    // loaded ... let's now tell the autoloader to do the work

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6468,18 +6468,18 @@ Bool_t TCling::IsAutoLoadNamespaceCandidate(const clang::NamespaceDecl* nsDecl)
 ////////////////////////////////////////////////////////////////////////////////
 /// Internal function. Actually do the update of the ClassInfo when seeing
 //  new TagDecl or NamespaceDecl.
-void TCling::RefreshClassInfo(TClass *cl, const clang::TagDecl *tdDef, bool alias)
+void TCling::RefreshClassInfo(TClass *cl, const clang::NamedDecl *def, bool alias)
 {
 
    TClingClassInfo *cci = ((TClingClassInfo *)cl->fClassInfo);
    if (cci) {
       // If we only had a forward declaration then update the
       // TClingClassInfo with the definition if we have it now.
-      const TagDecl *tdOld = llvm::dyn_cast_or_null<TagDecl>(cci->GetDecl());
-      if (!tdOld || (tdDef && tdDef != tdOld)) {
+      const NamedDecl *oldDef = llvm::dyn_cast_or_null<NamedDecl>(cci->GetDecl());
+      if (!oldDef || (def && def != oldDef)) {
          cl->ResetCaches();
          TClass::RemoveClassDeclId(cci->GetDeclId());
-         if (tdDef) {
+         if (def) {
             // It's a tag decl, not a namespace decl.
             cci->Init(*cci->GetType());
             TClass::AddClassToDeclIdMap(cci->GetDeclId(), cl);
@@ -6490,8 +6490,8 @@ void TCling::RefreshClassInfo(TClass *cl, const clang::TagDecl *tdDef, bool alia
       // yes, this is almost a waste of time, but we do need to lookup
       // the 'type' corresponding to the TClass anyway in order to
       // preserve the opaque typedefs (Double32_t)
-      if (!alias)
-         cl->fClassInfo = (ClassInfo_t *)new TClingClassInfo(fInterpreter, tdDef);
+      if (!alias && def != nullptr)
+         cl->fClassInfo = (ClassInfo_t *)new TClingClassInfo(fInterpreter, def);
       else
          cl->fClassInfo = (ClassInfo_t *)new TClingClassInfo(fInterpreter, cl->GetName());
       if (((TClingClassInfo *)cl->fClassInfo)->IsValid()) {
@@ -6513,11 +6513,14 @@ void TCling::RefreshClassInfo(TClass *cl, const clang::TagDecl *tdDef, bool alia
 /// Internal function. Inform a TClass about its new TagDecl or NamespaceDecl.
 void TCling::UpdateClassInfoWithDecl(const NamedDecl* ND)
 {
-   const TagDecl* td = dyn_cast<TagDecl>(ND);
+   const TagDecl *td = dyn_cast<TagDecl>(ND);
+   const NamespaceDecl *ns = dyn_cast<NamespaceDecl>(ND);
+   const NamedDecl *canon = nullptr;
+
    std::string name;
    TagDecl* tdDef = 0;
    if (td) {
-      tdDef = td->getDefinition();
+      canon = tdDef = td->getDefinition();
       // Let's pass the decl to the TClass only if it has a definition.
       if (!tdDef) return;
 
@@ -6540,6 +6543,9 @@ void TCling::UpdateClassInfoWithDecl(const NamedDecl* ND)
 
       clang::QualType type(tdDef->getTypeForDecl(), 0);
       ROOT::TMetaUtils::GetNormalizedName(name, type, *fInterpreter, *fNormalizedCtxt);
+   } else if (ns) {
+      canon = ns->getCanonicalDecl();
+      name = ND->getQualifiedNameAsString();
    } else {
       name = ND->getQualifiedNameAsString();
    }
@@ -6552,7 +6558,7 @@ void TCling::UpdateClassInfoWithDecl(const NamedDecl* ND)
    // for example vector<double> and vector<Double32_t>
    TClass* cl = (TClass*)gROOT->GetListOfClasses()->FindObject(name.c_str());
    if (cl && GetModTClasses().find(cl) == GetModTClasses().end()) {
-      RefreshClassInfo(cl, tdDef, false);
+      RefreshClassInfo(cl, canon, false);
    }
    // And here we should find the other 'aliases' (eg. vector<Double32_t>)
    // and update them too:

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6485,7 +6485,6 @@ void TCling::UpdateClassInfoWithDecl(const void* vTD)
          // Ignore declaration within a function.
          return;
       }
-      clang::QualType type( td->getTypeForDecl(), 0 );
 
       auto declName=ND->getNameAsString();
       if (!TClass::HasNoInfoOrEmuOrFwdDeclaredDecl(declName.c_str())){
@@ -6493,6 +6492,7 @@ void TCling::UpdateClassInfoWithDecl(const void* vTD)
          return;
       }
 
+      clang::QualType type( td->getTypeForDecl(), 0 );
       ROOT::TMetaUtils::GetNormalizedName(name, type, *fInterpreter, *fNormalizedCtxt);
    } else {
       name = ND->getNameAsString();

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6520,16 +6520,14 @@ void TCling::UpdateClassInfoWithDecl(const NamedDecl* ND)
       tdDef = td->getDefinition();
       // Let's pass the decl to the TClass only if it has a definition.
       if (!tdDef) return;
-      td = tdDef;
-      ND = td;
 
-      if (!td->isCompleteDefinition() || llvm::isa<clang::FunctionDecl>(td->getDeclContext())) {
+      if (!tdDef->isCompleteDefinition() || llvm::isa<clang::FunctionDecl>(tdDef->getDeclContext())) {
          // Ignore incomplete definition.
          // Ignore declaration within a function.
          return;
       }
 
-      auto declName=ND->getNameAsString();
+      auto declName = tdDef->getNameAsString();
       // Check if we have registered the unqualified name into the list
       // of TClass that are in kNoInfo, kEmulated or kFwdDeclaredState.
       // Since this is used as heureutistic to avoid spurrious calls to GetNormalizedName
@@ -6540,7 +6538,7 @@ void TCling::UpdateClassInfoWithDecl(const NamedDecl* ND)
          return;
       }
 
-      clang::QualType type(td->getTypeForDecl(), 0);
+      clang::QualType type(tdDef->getTypeForDecl(), 0);
       ROOT::TMetaUtils::GetNormalizedName(name, type, *fInterpreter, *fNormalizedCtxt);
    } else {
       name = ND->getQualifiedNameAsString();

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6465,9 +6465,52 @@ Bool_t TCling::IsAutoLoadNamespaceCandidate(const clang::NamespaceDecl* nsDecl)
    return fNSFromRootmaps.count(nsDecl) != 0;
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Internal function. Actually do the update of the ClassInfo when seeing
+//  new TagDecl or NamespaceDecl.
+void TCling::RefreshClassInfo(TClass *cl, const clang::TagDecl *tdDef, bool alias) {
+
+   TClingClassInfo *cci = ((TClingClassInfo *)cl->fClassInfo);
+   if (cci) {
+      // If we only had a forward declaration then update the
+      // TClingClassInfo with the definition if we have it now.
+      const TagDecl *tdOld = llvm::dyn_cast_or_null<TagDecl>(cci->GetDecl());
+      if (!tdOld || (tdDef && tdDef != tdOld)) {
+         cl->ResetCaches();
+         TClass::RemoveClassDeclId(cci->GetDeclId());
+         if (tdDef) {
+            // It's a tag decl, not a namespace decl.
+            cci->Init(*cci->GetType());
+            TClass::AddClassToDeclIdMap(cci->GetDeclId(), cl);
+         }
+      }
+   } else if (!cl->TestBit(TClass::kLoading) && !cl->fHasRootPcmInfo) {
+      cl->ResetCaches();
+      // yes, this is almost a waste of time, but we do need to lookup
+      // the 'type' corresponding to the TClass anyway in order to
+      // preserve the opaque typedefs (Double32_t)
+      if (!alias)
+         cl->fClassInfo = (ClassInfo_t *)new TClingClassInfo(fInterpreter, tdDef);
+      else
+          cl->fClassInfo = (ClassInfo_t *)new TClingClassInfo(fInterpreter, cl->GetName());
+      if (((TClingClassInfo *)cl->fClassInfo)->IsValid()) {
+         // We now need to update the state and bits.
+         if (cl->fState != TClass::kHasTClassInit) {
+            // if (!cl->fClassInfo->IsValid()) cl->fState = TClass::kForwardDeclared; else
+            cl->fState = TClass::kInterpreted;
+            cl->ResetBit(TClass::kIsEmulation);
+         }
+         TClass::AddClassToDeclIdMap(((TClingClassInfo *)(cl->fClassInfo))->GetDeclId(), cl);
+      } else {
+         delete ((TClingClassInfo *)cl->fClassInfo);
+         cl->fClassInfo = nullptr;
+      }
+   }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Internal function. Inform a TClass about its new TagDecl or NamespaceDecl.
-
 void TCling::UpdateClassInfoWithDecl(const void* vTD)
 {
    const NamedDecl* ND = static_cast<const NamedDecl*>(vTD);
@@ -6503,6 +6546,8 @@ void TCling::UpdateClassInfoWithDecl(const void* vTD)
       name = ND->getQualifiedNameAsString();
    }
 
+
+
    // Supposedly we are being called while something is being
    // loaded ... let's now tell the autoloader to do the work
    // yet another time.
@@ -6511,35 +6556,12 @@ void TCling::UpdateClassInfoWithDecl(const void* vTD)
    // for example vector<double> and vector<Double32_t>
    TClass* cl = (TClass*)gROOT->GetListOfClasses()->FindObject(name.c_str());
    if (cl && GetModTClasses().find(cl) == GetModTClasses().end()) {
-      TClingClassInfo* cci = ((TClingClassInfo*)cl->fClassInfo);
-      if (cci) {
-         // If we only had a forward declaration then update the
-         // TClingClassInfo with the definition if we have it now.
-         const TagDecl* tdOld = llvm::dyn_cast_or_null<TagDecl>(cci->GetDecl());
-         if (!tdOld || (tdDef && tdDef != tdOld)) {
-            cl->ResetCaches();
-            TClass::RemoveClassDeclId(cci->GetDeclId());
-            if (td) {
-               // It's a tag decl, not a namespace decl.
-               cci->Init(*cci->GetType());
-               TClass::AddClassToDeclIdMap(cci->GetDeclId(), cl);
-            }
-         }
-      } else if (!cl->TestBit(TClass::kLoading) && !cl->fHasRootPcmInfo) {
-         cl->ResetCaches();
-         // yes, this is almost a waste of time, but we do need to lookup
-         // the 'type' corresponding to the TClass anyway in order to
-         // preserve the opaque typedefs (Double32_t)
-         cl->fClassInfo = (ClassInfo_t *)new TClingClassInfo(fInterpreter, cl->GetName());
-         // We now need to update the state and bits.
-         if (cl->fState != TClass::kHasTClassInit) {
-            // if (!cl->fClassInfo->IsValid()) cl->fState = TClass::kForwardDeclared; else
-            cl->fState = TClass::kInterpreted;
-            cl->ResetBit(TClass::kIsEmulation);
-         }
-         TClass::AddClassToDeclIdMap(((TClingClassInfo*)(cl->fClassInfo))->GetDeclId(), cl);
-      }
+      RefreshClassInfo(cl, tdDef, false);
    }
+   // And here we should find the other 'aliases' (eg. vector<Double32_t>)
+   // and update them too:
+   // foreach(aliascl in gROOT->GetListOfClasses()->FindAliasesOf(name.c_str()))
+   //    RefreshClassInfo(cl, tdDef, true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -315,7 +315,7 @@ public: // Public Interface
 
    static void  UpdateClassInfo(char* name, Long_t tagnum);
    static void  UpdateClassInfoWork(const char* name);
-          void  RefreshClassInfo(TClass *cl, const clang::TagDecl *td, bool alias);
+          void  RefreshClassInfo(TClass *cl, const clang::NamedDecl *def, bool alias);
           void  UpdateClassInfoWithDecl(const clang::NamedDecl* ND);
    static void  UpdateAllCanvases();
 

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -47,6 +47,7 @@ namespace clang {
    class DeclContext;
    class EnumDecl;
    class FunctionDecl;
+   class NamedDecl;
    class NamespaceDecl;
    class TagDecl;
    class Type;
@@ -315,7 +316,7 @@ public: // Public Interface
    static void  UpdateClassInfo(char* name, Long_t tagnum);
    static void  UpdateClassInfoWork(const char* name);
           void  RefreshClassInfo(TClass *cl, const clang::TagDecl *td, bool alias);
-          void  UpdateClassInfoWithDecl(const void* vTD);
+          void  UpdateClassInfoWithDecl(const clang::NamedDecl* ND);
    static void  UpdateAllCanvases();
 
    // Misc

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -48,6 +48,7 @@ namespace clang {
    class EnumDecl;
    class FunctionDecl;
    class NamespaceDecl;
+   class TagDecl;
    class Type;
    class QualType;
 }
@@ -313,6 +314,7 @@ public: // Public Interface
 
    static void  UpdateClassInfo(char* name, Long_t tagnum);
    static void  UpdateClassInfoWork(const char* name);
+          void  RefreshClassInfo(TClass *cl, const clang::TagDecl *td, bool alias);
           void  UpdateClassInfoWithDecl(const void* vTD);
    static void  UpdateAllCanvases();
 

--- a/interpreter/cling/include/cling/Utils/ParserStateRAII.h
+++ b/interpreter/cling/include/cling/Utils/ParserStateRAII.h
@@ -47,9 +47,7 @@ namespace cling {
     ParserStateRAII(clang::Parser& p, bool skipToEOF);
     ~ParserStateRAII();
 
-    void SetSkipToEOF(bool newvalue) {
-      SkipToEOF = newvalue;
-    }
+    void SetSkipToEOF(bool newvalue) { SkipToEOF = newvalue; }
 };
 
 } // end namespace cling

--- a/interpreter/cling/include/cling/Utils/ParserStateRAII.h
+++ b/interpreter/cling/include/cling/Utils/ParserStateRAII.h
@@ -47,6 +47,9 @@ namespace cling {
     ParserStateRAII(clang::Parser& p, bool skipToEOF);
     ~ParserStateRAII();
 
+    void SetSkipToEOF(bool newvalue) {
+      SkipToEOF = newvalue;
+    }
 };
 
 } // end namespace cling

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -39,10 +39,10 @@ namespace cling {
     LookupHelper& m_LH;
     llvm::SaveAndRestore<bool> SaveIsRecursivelyRunning;
     // Save and restore the state of the Parser and lexer.
-    // Note: ROOT::Internal::ParsingStateRAII also save and restore the state of Sema,
-    // including pending instantiation for example.  It is not clear whether we need
-    // to do so here too or whether we need to also see the "on-going" semantic information ...
-    // For now, we leave Sema untouched.
+    // Note: ROOT::Internal::ParsingStateRAII also save and restore the state of
+    // Sema, including pending instantiation for example.  It is not clear
+    // whether we need to do so here too or whether we need to also see the
+    // "on-going" semantic information ... For now, we leave Sema untouched.
     clang::Preprocessor::CleanupAndRestoreCacheRAII fCleanupRAII;
     clang::Parser::ParserCurTokRestoreRAII fSavedCurToken;
     ParserStateRAII ResetParserState;
@@ -52,11 +52,11 @@ namespace cling {
     StartParsingRAII(LookupHelper& LH, llvm::StringRef code,
                      llvm::StringRef bufferName,
                      LookupHelper::DiagSetting diagOnOff)
-        : m_LH(LH), SaveIsRecursivelyRunning(LH.IsRecursivelyRunning)
-          , fCleanupRAII(LH.m_Parser.get()->getPreprocessor())
-          , fSavedCurToken(*LH.m_Parser.get())
-          , ResetParserState(*LH.m_Parser.get(), !LH.IsRecursivelyRunning /*skipToEOF*/)
-    {
+        : m_LH(LH), SaveIsRecursivelyRunning(LH.IsRecursivelyRunning),
+          fCleanupRAII(LH.m_Parser.get()->getPreprocessor()),
+          fSavedCurToken(*LH.m_Parser.get()),
+          ResetParserState(*LH.m_Parser.get(),
+                           !LH.IsRecursivelyRunning /*skipToEOF*/) {
       LH.IsRecursivelyRunning = true;
       prepareForParsing(code, bufferName, diagOnOff);
     }
@@ -1422,8 +1422,8 @@ namespace cling {
 
     UnqualifiedId FuncId;
     ParserStateRAII ResetParserState(P, false /*skipToEOF*/);
-    if (!ParseWithShortcuts(foundDC, Context, funcName, Interp,
-                            FuncId, diagOnOff, ResetParserState)) {
+    if (!ParseWithShortcuts(foundDC, Context, funcName, Interp, FuncId,
+                            diagOnOff, ResetParserState)) {
       // Failed parse, cleanup.
       // Destroy the scope we created first, and
       // restore the original.


### PR DESCRIPTION
Improve the push/pop/RAII used in findScope for the Parser and lexer.
Also fixes several deficiencies 'revealed' by the 'failing' RAII

This fixes [https://sft.its.cern.ch/jira/browse/ROOT-10224]