### PR TITLE
[json] let store object as its base class

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1330,6 +1330,11 @@ void TBufferJSON::JsonWriteObject(const void *obj, const TClass *cl, Bool_t chec
    // provide possibility to store object as base class, can be useful when base class is STL container
    if (!special_kind && cl && cl->HasDefaultConstructor() && (const_cast<TClass *>(cl)->GetNdata() == 0)) {
       TMethod *m = const_cast<TClass *>(cl)->GetMethod(cl->GetName(), "");
+      if (!m) {
+         const char *str = strstr(cl->GetName(), "::"), *next = nullptr;
+         while (str && (next = strstr(str+2, "::"))) str = next;
+         if (str) m = const_cast<TClass *>(cl)->GetMethod(str+2, "");
+      }
       if (m && strstr(m->GetTitle(),"JSON_asbase")) {
          auto bases = const_cast<TClass *>(cl)->GetListOfBases();
          TClass *basecl = bases && (bases->GetSize() == 1) ? const_cast<TClass *>(cl)->GetBaseClass(bases->First()->GetName()) : nullptr;
@@ -1797,6 +1802,11 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
 
    if (!special_kind && objClass && objClass->HasDefaultConstructor() && (const_cast<TClass *>(objClass)->GetNdata() == 0)) {
       TMethod *m = const_cast<TClass *>(objClass)->GetMethod(objClass->GetName(), "");
+      if (!m) {
+         const char *str = strstr(objClass->GetName(), "::"), *next = nullptr;
+         while (str && (next = strstr(str+2, "::"))) str = next;
+         if (str) m = const_cast<TClass *>(objClass)->GetMethod(str+2, "");
+      }
       if (m && strstr(m->GetTitle(),"JSON_asbase")) {
          auto bases = const_cast<TClass *>(objClass)->GetListOfBases();
          TClass *basecl = bases && (bases->GetSize() == 1) ? const_cast<TClass *>(objClass)->GetBaseClass(bases->First()->GetName()) : nullptr;
@@ -1807,7 +1817,6 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
             special_kind = JsonSpecialClass(objClass);
          }
       }
-
    }
 
    // Extract pointer

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1326,6 +1326,14 @@ void TBufferJSON::JsonWriteObject(const void *obj, const TClass *cl, Bool_t chec
 
    Int_t special_kind = JsonSpecialClass(cl), map_convert{0};
 
+   if (!special_kind && cl && cl->GetStreamerInfo() && (cl->GetStreamerInfo()->GetElements()->GetLast()==0) && cl->GetStreamerInfo()->GetElement(0)->IsBase()) {
+      TClass *basecl = cl->GetStreamerInfo()->GetElement(0)->GetClassPointer();
+      if (TClassEdit::IsStdClass(basecl->GetName())) {
+         special_kind = basecl->GetCollectionType();
+         cl = basecl;
+      }
+   }
+
    TString fObjectOutput, *fPrevOutput{nullptr};
 
    TJSONStackObj *stack = Stack();

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1328,13 +1328,13 @@ void TBufferJSON::JsonWriteObject(const void *obj, const TClass *cl, Bool_t chec
    Int_t special_kind = JsonSpecialClass(cl), map_convert{0};
 
    // provide possibility to store object as base class, can be useful when base class is STL container
-   if (!special_kind && cl && cl->HasDefaultConstructor() && cl->GetStreamerInfo() && (cl->GetStreamerInfo()->GetElements()->GetLast()==0) && cl->GetStreamerInfo()->GetElement(0)->IsBase()) {
+   if (!special_kind && cl && cl->HasDefaultConstructor()) {
       TMethod *m = const_cast<TClass *>(cl)->GetMethod(cl->GetName(), "");
-      TClass *basecl = cl->GetStreamerInfo()->GetElement(0)->GetClassPointer();
-      if (basecl && m && strstr(m->GetTitle(),"JSON_asbase")) {
-         cl = basecl;
-         special_kind = JsonSpecialClass(cl);
-      }
+      if (m && strstr(m->GetTitle(),"JSON_asbase"))
+         if (cl->GetStreamerInfo() && (cl->GetStreamerInfo()->GetElements()->GetLast()==0) && cl->GetStreamerInfo()->GetElement(0)->IsBase()) {
+            cl = cl->GetStreamerInfo()->GetElement(0)->GetClassPointer();;
+            special_kind = JsonSpecialClass(cl);
+         }
    }
 
    TString fObjectOutput, *fPrevOutput{nullptr};
@@ -1792,15 +1792,16 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
 
    TClass *realClass = nullptr;
 
-   if (!special_kind && objClass && objClass->HasDefaultConstructor() && objClass->GetStreamerInfo() && (objClass->GetStreamerInfo()->GetElements()->GetLast()==0) && objClass->GetStreamerInfo()->GetElement(0)->IsBase()) {
+   if (!special_kind && objClass && objClass->HasDefaultConstructor()) {
       TMethod *m = const_cast<TClass *>(objClass)->GetMethod(objClass->GetName(), "");
-      TClass *basecl = objClass->GetStreamerInfo()->GetElement(0)->GetClassPointer();
-      if (basecl && m && strstr(m->GetTitle(),"JSON_asbase")) {
-         realClass = const_cast<TClass*>(objClass);
-         if (!obj) obj = realClass->New();
-         objClass = basecl;
-         special_kind = JsonSpecialClass(objClass);
-      }
+      if (m && strstr(m->GetTitle(),"JSON_asbase"))
+         if (objClass->GetStreamerInfo() && (objClass->GetStreamerInfo()->GetElements()->GetLast()==0) && objClass->GetStreamerInfo()->GetElement(0)->IsBase()) {
+            realClass = const_cast<TClass*>(objClass);
+            if (!obj) obj = realClass->New();
+            objClass = objClass->GetStreamerInfo()->GetElement(0)->GetClassPointer();
+            special_kind = JsonSpecialClass(objClass);
+         }
+
    }
 
    // Extract pointer


### PR DESCRIPTION
If comments for default class constructor includes JSON_asbase specifier
and object does not have extra persistent data members, only base class
data will be stored for it. 

Can be used for sub-class of STL class, where object representation differs very much.
Normally class `class UserVector1 : public std::vector<std::string>` stored as:
```
{
  "_typename" : "UserVector1",
  "fVector" : ["abc", "zdf"]
}
```
Now one can add comments to default constructor:
```
class UserVector1 : public std::vector<std::string> {
public:
   UserVector1() = default;  ///< JSON_asbase
};
```
In this case object will be converted into: `["abc", "zdf"]`
