### PR TITLE
[PyROOT][ROOT-10304] Segfault when calling cppyy.gbl.RDataFrame

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2707,8 +2707,10 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
    }
 
    else if ( name.find("ROOT::RDataFrame") == 0 || name.find("ROOT::RDF::RInterface<") == 0 ) {
-      PyObject_SetAttrString(pyclass, "AsNumpy",
-                             PyObject_GetAttrString( gRootModule, "_RDataFrameAsNumpy" ));
+      if (PyObject_HasAttrString( gRootModule, "_RDataFrameAsNumpy" )) {
+         PyObject_SetAttrString(pyclass, "AsNumpy",
+                                PyObject_GetAttrString( gRootModule, "_RDataFrameAsNumpy" ));
+      }
    }
 
    else if ( name == "TStyle" ) {


### PR DESCRIPTION
The pythonization RDataFrame.AsNumpy looks for the attribute
RDataFrameAsNumpy_ in the ROOT module and raises an attribute error if not found.
This error can not be triggered if ROOT is imported but is raised if
RDataFrame is accessed through cppyy.gbl. This PR implements a
protection for this skipping the pythonization if the pythonizer
function is not found in the ROOT module.