### PR TITLE
[v7] Fix usage of std::span.

### DIFF
--- a/hist/hist/v7/inc/ROOT/RHist.hxx
+++ b/hist/hist/v7/inc/ROOT/RHist.hxx
@@ -141,13 +141,13 @@ public:
    /// For each coordinate in `xN`, add `weightN[i]` to the bin at coordinate
    /// `xN[i]`. The sizes of `xN` and `weightN` must be the same. This is more
    /// efficient than many separate calls to `Fill()`.
-   void FillN(const std::span<CoordArray_t> xN, const std::span<Weight_t> weightN) noexcept
+   void FillN(const std::span<const CoordArray_t> xN, const std::span<const Weight_t> weightN) noexcept
    {
       fImpl->FillN(xN, weightN);
    }
 
    /// Convenience overload: `FillN()` with weight 1.
-   void FillN(const std::span<CoordArray_t> xN) noexcept { fImpl->FillN(xN); }
+   void FillN(const std::span<const CoordArray_t> xN) noexcept { fImpl->FillN(xN); }
 
    /// Get the number of entries this histogram was filled with.
    int64_t GetEntries() const noexcept { return fImpl->GetStat().GetEntries(); }

--- a/hist/hist/v7/inc/ROOT/RHistBufferedFill.hxx
+++ b/hist/hist/v7/inc/ROOT/RHistBufferedFill.hxx
@@ -40,13 +40,13 @@ public:
    DERIVED &toDerived() { return *static_cast<DERIVED *>(this); }
    const DERIVED &toDerived() const { return *static_cast<const DERIVED *>(this); }
 
-   std::span<CoordArray_t> GetCoords() const
+   std::span<const CoordArray_t> GetCoords() const
    {
-      return std::span<CoordArray_t>(fXBuf.begin(), fXBuf.begin() + fCursor);
+      return std::span<const CoordArray_t>(fXBuf.begin(), fXBuf.begin() + fCursor);
    }
-   std::span<Weight_t> GetWeights() const
+   std::span<const Weight_t> GetWeights() const
    {
-      return std::span<Weight_t>(fWBuf.begin(), fWBuf.begin() + fCursor);
+      return std::span<const Weight_t>(fWBuf.begin(), fWBuf.begin() + fCursor);
    }
 
    void Fill(const CoordArray_t &x, Weight_t weight = 1.)
@@ -90,12 +90,12 @@ private:
 public:
    RHistBufferedFill(Hist_t &hist): fHist{hist} {}
 
-   void FillN(const std::span<CoordArray_t> xN, const std::span<Weight_t> weightN)
+   void FillN(const std::span<const CoordArray_t> xN, const std::span<const Weight_t> weightN)
    {
       fHist.FillN(xN, weightN);
    }
 
-   void FillN(const std::span<CoordArray_t> xN) { fHist.FillN(xN); }
+   void FillN(const std::span<const CoordArray_t> xN) { fHist.FillN(xN); }
 
    void Flush() { fHist.FillN(this->GetCoords(), this->GetWeights()); }
 

--- a/hist/hist/v7/inc/ROOT/RHistConcurrentFill.hxx
+++ b/hist/hist/v7/inc/ROOT/RHistConcurrentFill.hxx
@@ -47,13 +47,13 @@ public:
    using Internal::RHistBufferedFillBase<RHistConcurrentFiller<HIST, SIZE>, HIST, SIZE>::Fill;
 
    /// Thread-specific HIST::FillN().
-   void FillN(const std::span<CoordArray_t> xN, const std::span<Weight_t> weightN)
+   void FillN(const std::span<const CoordArray_t> xN, const std::span<const Weight_t> weightN)
    {
       fManager.FillN(xN, weightN);
    }
 
    /// Thread-specific HIST::FillN().
-   void FillN(const std::span<CoordArray_t> xN) { fManager.FillN(xN); }
+   void FillN(const std::span<const CoordArray_t> xN) { fManager.FillN(xN); }
 
    /// The buffer is full, flush it out.
    void Flush() { fManager.FillN(this->GetCoords(), this->GetWeights()); }
@@ -94,14 +94,14 @@ public:
    RHistConcurrentFiller<HIST, SIZE> MakeFiller() { return RHistConcurrentFiller<HIST, SIZE>{*this}; }
 
    /// Thread-specific HIST::FillN().
-   void FillN(const std::span<CoordArray_t> xN, const std::span<Weight_t> weightN)
+   void FillN(const std::span<const CoordArray_t> xN, const std::span<const Weight_t> weightN)
    {
       std::lock_guard<std::mutex> lockGuard(fFillMutex);
       fHist.FillN(xN, weightN);
    }
 
    /// Thread-specific HIST::FillN().
-   void FillN(const std::span<CoordArray_t> xN)
+   void FillN(const std::span<const CoordArray_t> xN)
    {
       std::lock_guard<std::mutex> lockGuard(fFillMutex);
       fHist.FillN(xN);

--- a/hist/hist/v7/inc/ROOT/RHistImpl.hxx
+++ b/hist/hist/v7/inc/ROOT/RHistImpl.hxx
@@ -168,10 +168,10 @@ public:
    /// Interface function to fill a vector or array of coordinates with
    /// corresponding weights.
    /// \note the size of `xN` and `weightN` must be the same!
-   virtual void FillN(const std::span<CoordArray_t> xN, const std::span<Weight_t> weightN) = 0;
+   virtual void FillN(const std::span<const CoordArray_t> xN, const std::span<const Weight_t> weightN) = 0;
 
    /// Interface function to fill a vector or array of coordinates.
-   virtual void FillN(const std::span<CoordArray_t> xN) = 0;
+   virtual void FillN(const std::span<const CoordArray_t> xN) = 0;
 
    /// Retrieve the pointer to the overridden Fill(x, w) function.
    virtual FillFunc_t GetFillFunc() const = 0;
@@ -474,7 +474,7 @@ public:
    /// For each element `i`, the weight `weightN[i]` will be added to the bin
    /// at the coordinate `xN[i]`
    /// \note `xN` and `weightN` must have the same size!
-   void FillN(const std::span<CoordArray_t> xN, const std::span<Weight_t> weightN) final
+   void FillN(const std::span<const CoordArray_t> xN, const std::span<const Weight_t> weightN) final
    {
 #ifndef NDEBUG
       if (xN.size() != weightN.size()) {
@@ -491,7 +491,7 @@ public:
    /// Fill an array of `weightN` to the bins specified by coordinates `xN`.
    /// For each element `i`, the weight `weightN[i]` will be added to the bin
    /// at the coordinate `xN[i]`
-   void FillN(const std::span<CoordArray_t> xN) final
+   void FillN(const std::span<const CoordArray_t> xN) final
    {
       for (auto &&x: xN) {
          Fill(x);

--- a/hist/hist/v7/speed/histspeedtest.cxx
+++ b/hist/hist/v7/speed/histspeedtest.cxx
@@ -101,8 +101,8 @@ struct BinEdges {
 
    using AConf_t = Experimental::RAxisConfig;
 
-   AConf_t GetConfigX() const { return AConf_t(std::span<double>(fXBins).to_vector()); }
-   AConf_t GetConfigY() const { return AConf_t(std::span<double>(fYBins).to_vector()); }
+   AConf_t GetConfigX() const { return AConf_t(std::span<const double>(fXBins).to_vector()); }
+   AConf_t GetConfigY() const { return AConf_t(std::span<const double>(fYBins).to_vector()); }
 };
 
 template <typename T>

--- a/math/mathcore/v7/inc/ROOT/RFit.hxx
+++ b/math/mathcore/v7/inc/ROOT/RFit.hxx
@@ -32,12 +32,12 @@ class RFitResult {
 template <int DIMENSION>
 class RFunction {
 public:
-   RFunction(std::function<double(const std::array<double, DIMENSION> &, const std::span<double> par)> func) {}
+   RFunction(std::function<double(const std::array<double, DIMENSION> &, const std::span<const double> par)> func) {}
 };
 
 template <int DIMENSIONS, class PRECISION, template <int D_, class P_> class... STAT>
 RFitResult FitTo(const RHist<DIMENSIONS, PRECISION, STAT...> &hist, const RFunction<DIMENSIONS> &func,
-                 std::span<double> paramInit)
+                 std::span<const double> paramInit)
 {
    return RFitResult();
 }

--- a/tutorials/v7/simple.cxx
+++ b/tutorials/v7/simple.cxx
@@ -39,7 +39,7 @@ void simple()
    hist.Fill({0.01, 1.02});
 
    // Fit the histogram.
-   RFunction<2> func([](const std::array<double, 2> &x, const std::span<double> par) {
+   RFunction<2> func([](const std::array<double, 2> &x, const std::span<const double> par) {
       return par[0] * x[0] * x[0] + (par[1] - x[1]) * x[1];
    });
 


### PR DESCRIPTION
After allowing for spans with non-const types, const correctness of
v7 code had to be improved, because it assumed that span<T> is the same
type as span<const T>.