### PR TITLE
[PyROOT] Implement converters for Python Unicode & bytes to STL and C strings

### DIFF
--- a/bindings/pyroot/src/Converters.cxx
+++ b/bindings/pyroot/src/Converters.cxx
@@ -567,6 +567,10 @@ Bool_t PyROOT::TCStringConverter::SetArg(
    if (PyROOT_PyUnicode_Check(pyobject)) {
       auto strAndSize = getStringAndSize(pyobject);
       fBuffer = std::string(std::get<0>(strAndSize), std::get<1>(strAndSize));
+   } else if (PyBytes_Check(pyobject)) {
+      auto s = PyBytes_AsString(pyobject);                                    \
+      auto size = PyBytes_GET_SIZE(pyobject);
+      fBuffer = std::string(s, size);
    } else {
       return kFALSE;
    }

--- a/bindings/pyroot/src/Converters.cxx
+++ b/bindings/pyroot/src/Converters.cxx
@@ -875,6 +875,15 @@ Bool_t PyROOT::T##name##Converter::SetArg(                                    \
       return kTRUE;                                                           \
    }                                                                          \
                                                                               \
+   if (PyBytes_Check(pyobject)) {                                             \
+      auto s = PyBytes_AsString(pyobject);                                    \
+      auto size = PyBytes_GET_SIZE(pyobject);                                 \
+      fBuffer = type(s, size);                                                \
+      para.fValue.fVoidp = &fBuffer;                                          \
+      para.fTypeCode = 'V';                                                   \
+      return kTRUE;                                                           \
+   }                                                                          \
+                                                                              \
    if ( ! ( PyInt_Check( pyobject ) || PyLong_Check( pyobject ) ) ) {         \
       Bool_t result = TCppObjectConverter::SetArg( pyobject, para, ctxt );    \
       para.fTypeCode = 'V';                                                   \


### PR DESCRIPTION
This is related to:
https://sft.its.cern.ch/jira/browse/ROOT-10282
https://sft.its.cern.ch/jira/browse/ROOT-10222

and is a continuation of:
https://github.com/root-project/root/pull/4345

that completes the implementation of converters for Python Unicode and Bytes objects to STL and C strings.