### PR TITLE
Fix the scaling of the global histogram statistics in  TH1::Scale

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -6228,6 +6228,14 @@ void TH1::Scale(Double_t c1, Option_t *option)
       if (fBuffer) BufferEmpty(1);
       for(Int_t i = 0; i < fNcells; ++i) UpdateBinContent(i, c1 * RetrieveBinContent(i));
       if (fSumw2.fN) for(Int_t i = 0; i < fNcells; ++i) fSumw2.fArray[i] *= (c1 * c1); // update errors
+      // update global histograms statistics
+      Double_t s[kNstat] = {0};
+      GetStats(s);
+      for (Int_t i=0 ; i < kNstat; i++) {
+         if (i == 1)   s[i] = c1*c1*s[i];
+         else          s[i] = c1*s[i];
+      }
+      PutStats(s);
       SetMinimum(); SetMaximum(); // minimum and maximum value will be recalculated the next time
    }
 


### PR DESCRIPTION
This fixes the problem reported in https://root-forum.cern.ch/t/adding-weighted-histograms-now-requires-a-call-to-resetstats-bug-or-feature/35926

When calling TH1::Scale the histogram statistics (global sumw and sumw2) are  not scaled. The bug was introduced in Jan 2013 (v5.99.02) with a faster Scale implementation not using TH1::Add. 

