### PR TITLE
[CMake] Protect move_headers dependency when not configuring ROOT.

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1228,7 +1228,9 @@ function(ROOT_EXECUTABLE executable)
   if (ARG_ADDITIONAL_COMPILE_FLAGS)
     set_target_properties(${executable} PROPERTIES COMPILE_FLAGS ${ARG_ADDITIONAL_COMPILE_FLAGS})
   endif()
-  add_dependencies(${executable} move_headers)
+  if(CMAKE_PROJECT_NAME STREQUAL ROOT)
+    add_dependencies(${executable} move_headers)
+  endif()
   if(ARG_BUILTINS)
     foreach(arg1 ${ARG_BUILTINS})
       if(${arg1}_TARGET)
@@ -1545,7 +1547,7 @@ function(ROOT_ADD_GTEST test_suite)
     gtest${mangled_name}
     COMMAND ${test_suite}
     WORKING_DIR ${CMAKE_CURRENT_BINARY_DIR}
-    COPY_TO_BUILDDIR ${ARG_COPY_TO_BUiILDDIR}
+    COPY_TO_BUILDDIR ${ARG_COPY_TO_BUILDDIR}
     ${willfail}
   )
 endfunction()

--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -7,7 +7,6 @@
 
 ROOT_GENERATE_DICTIONARY(ElementStructDict ElementStruct.h LINKDEF ElementStructLinkDef.h OPTIONS -inlineInputHeader)
 ROOT_ADD_GTEST(testTOffsetGeneration TOffsetGeneration.cxx ElementStruct.cxx ElementStructDict.cxx
-  COPY_TO_BUILDDIR ElementStruct.h
   LIBRARIES RIO Tree MathCore
 )
 target_include_directories(testTOffsetGeneration PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
When calling ROOT_EXECUTABLE from outside of ROOT (e.g. roottest), the
dependency on move_headers, which only works in the project ROOT,
must be ignored.