### PR TITLE
Fix makepchinput on Windows

### DIFF
--- a/build/unix/makepchinput.py
+++ b/build/unix/makepchinput.py
@@ -13,6 +13,7 @@ import sys
 import os
 import glob
 import shutil
+import posixpath
 
 #-------------------------------------------------------------------------------
 def removeFiles(filesList):
@@ -373,7 +374,7 @@ def getLocalLinkDefs(rootSrcDir, outdir , dirName):
 
    for linkDefName in linkDefNames:
       fullLinkDefName = os.path.join(outdir,linkDefName)
-      linkDefPartContent += '#include "%s"\n' %fullLinkDefName
+      linkDefPartContent += '#include "%s"\n' %posixpath.join(*fullLinkDefName.split(os.sep))
    os.chdir(curDir)
    return linkDefPartContent
 
@@ -394,7 +395,7 @@ def getCppFlags(rootSrcDir,allIncPaths):
    for name in resolveSoftLinks((rootSrcDir,os.getcwd())):
       filteredIncPaths = filter (lambda incPath: not name in incPath,filteredIncPaths)
    for incPath in filteredIncPaths:
-      allHeadersPartContent += "-I%s\n" %incPath
+      allHeadersPartContent += "-I%s\n" %posixpath.join(*incPath.split(os.sep))
    return allHeadersPartContent
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Convert back slashes into forward slashes. This fixes the following errors on Windows:
input_line_12(12,4): error G954FC62D: \U used with no following hex digits [C:\Users\bellenot\build\release\onepcm.vcxproj]
  "C:\Users\bellenot\libs\GSL\2.5\include",
     ^~
input_line_12(13,4): error G954FC62D: \U used with no following hex digits [C:\Users\bellenot\build\release\onepcm.vcxproj]
  "C:\Users\bellenot\libs\libxml2\2.7.8\include",
     ^~
CUSTOMBUILD : error : .\bin\rootcling: compilation failure (./allDictd5c5124b81_dictContent.h) [C:\Users\bellenot\build\release\onepcm.vcxproj]