### PR TITLE
[Exp PyROOT] Run cleanup to nonify Python proxies at teardown

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/__init__.py
@@ -73,3 +73,18 @@ if _is_ipython:
     if hasattr(ip,"kernel"):
         import JupyROOT
         import JsMVA
+
+# Register cleanup
+import atexit
+def cleanup():
+    if 'libROOTPython' in sys.modules:
+        # Run part of the gROOT shutdown sequence.
+        # Running it here ensures that it is done before any ROOT libraries
+        # are off-loaded, with unspecified order of static object destruction.
+        # This also makes sure that Python proxies involved in RecursiveRemove
+        # are properly nonified at teardown time
+        gROOT = sys.modules['libROOTPython'].gROOT
+        gROOT.EndOfProcessCleanups()
+
+atexit.register(cleanup)
+

--- a/bindings/pyroot_experimental/PyROOT/src/TMemoryRegulator.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/TMemoryRegulator.cxx
@@ -35,6 +35,8 @@ std::pair<bool, bool> PyROOT::TMemoryRegulator::RegisterHook(Cppyy::TCppObject_t
    if (Cppyy::IsSubtype(klass, tobjectTypeID)) {
       ObjectMap_t::iterator ppo = fObjectMap.find(cppobj);
       if (ppo == fObjectMap.end()) {
+         // Set cleanup bit so RecursiveRemove is tried on registered object
+         ((TObject*)cppobj)->SetBit(TObject::kMustCleanup);
          fObjectMap.insert({cppobj, klass});
       }
    }


### PR DESCRIPTION
This is related to:
https://sft.its.cern.ch/jira/browse/ROOT-10295
https://bitbucket.org/wlav/cppyy/issues/160

and should fix `projectroot.runtutorials.tutorial_pyroot_pyroot002_TTreeAsMatrix_py`.

It was observed that, under some circumstances (reproduced in
Python3.6.5 using a TFile and a TTree created inside a function,
destroying the objects at teardown time), the Python proxy of
a TFile-owned object is not nonified when running RecursiveRemove
on it. The reason is that, when trying to get the proxy from its
weak reference, the result is Py_None even if the object has not
been destroyed yet. As a result, the proxy is not nonified and
later tries to double delete its internal C++ object, resulting
in a crash because the C++ TFile also deleted it before.

Running EndOfProcessCleanups via a Python exit handler forces the
execution of RecursiveRemove and the right nonification of Python
proxies. This has been ported from old PyROOT (was in ROOT.py).