### PR TITLE
Fix TMath::AreEqualAbs for the eps=0 case

### DIFF
--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -411,7 +411,9 @@ struct Limits {
    // Comparing floating points
    inline Bool_t AreEqualAbs(Double_t af, Double_t bf, Double_t epsilon) {
       //return kTRUE if absolute difference between af and bf is less than epsilon
-      return TMath::Abs(af-bf) < epsilon;
+      return TMath::Abs(af-bf) < epsilon ||
+             TMath::Abs(af - bf) < Limits<Double_t>::Min(); // handle 0 < 0 case
+
    }
    inline Bool_t AreEqualRel(Double_t af, Double_t bf, Double_t relPrec) {
       //return kTRUE if relative difference between af and bf is less than relPrec


### PR DESCRIPTION
This PR should fix the consistency checks used in TH1::Add (e.g.  TH1::CheckAxisLimits) when the histogram bin widths are zero. 

See for example https://root-forum.cern.ch/t/exception-on-th1/35026