### PR TITLE
Fix rootcling error on Windows

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4041,7 +4041,7 @@ int RootClingMain(int argc,
       clingArgs.push_back(std::string("-U") + PPUndefine);
 
    for (const std::string &IncludePath : gOptIncludePaths)
-      clingArgs.push_back(std::string("-I") + IncludePath);
+      clingArgs.push_back(std::string("-I") + llvm::sys::path::convert_to_slash(IncludePath));
 
    for (const std::string &WDiag : gOptWDiags) {
       const std::string FullWDiag = std::string("-W") + WDiag;


### PR DESCRIPTION
Convert the backslashes into forward slashes in the include path for rootcling on Windows. This fixes the following errors:
input_line_12(12,4): error G954FC62D: \U used with no following hex digits [C:\Users\bellenot\build\release\onepcm.vcxproj]
"C:\Users\bellenot\libs\GSL\2.5\include",
^~
input_line_12(13,4): error G954FC62D: \U used with no following hex digits [C:\Users\bellenot\build\release\onepcm.vcxproj]
"C:\Users\bellenot\libs\libxml2\2.7.8\include",
^~
CUSTOMBUILD : error : .\bin\rootcling: compilation failure (./allDictd5c5124b81_dictContent.h) [C:\Users\bellenot\build\release\onepcm.vcxproj]

And (when using ACLiC):
Info in <TWinNTSystem::ACLiC>: creating shared library C:/Users/bellenot/build/debug/core/dictgen/test/myextramacro_C.dll
input_line_12:7:4: error: \U used with no following hex digits
"C:\Users\bellenot\build\debug\include",
   ^~
Error in <ACLiC>: Dictionary generation failed!