### PR TITLE
[cxxmodules] Quote the imported module.

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -840,7 +840,9 @@ namespace cling {
     if (getSema().isModuleVisible(M))
       return true;
 
-    if (declare("#pragma clang module import " + M->Name) == kSuccess)
+    // FIXME: What about importing submodules such as std.blah. This disables
+    // this functionality.
+    if (declare("#pragma clang module import \"" + M->Name + "\"") == kSuccess)
       return true;
 
     if (complain) {


### PR DESCRIPTION
In some cases we have dict.C which the modules system considers as two
components: one top-level module and one submodule.