### PR TITLE
[cxxmodules] Add a missing bits header to the modulemap.

### DIFF
--- a/build/unix/std.modulemap
+++ b/build/unix/std.modulemap
@@ -386,6 +386,10 @@ module "std" [system] {
     export *
     header "bits/exception_defines.h"
   }
+  module "bits/basic_ios.h" {
+    export *
+    header "bits/basic_ios.h"
+  }
   module "bits/ios_base.h" {
     export *
     header "bits/ios_base.h"


### PR DESCRIPTION
Should fix ROOT-10316 and ROOT-10317