### PR TITLE
Fixes serious problems when replacing emulated classes in case on entangled classes

### DIFF
--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -21,6 +21,7 @@
 #include "TClass.h"
 #include "TClassEdit.h"
 #include "TClassStreamer.h"
+#include "TClassTable.h"
 #include "TBaseClass.h"
 #include "TDataMember.h"
 #include "TDataType.h"
@@ -46,6 +47,12 @@ static TString &IncludeNameBuffer() {
    return includeName;
 }
 
+static TString ExtractClassName(const TString &type_name)
+{
+   TString className = type_name.Strip(TString::kTrailing, '*');
+   if (className.Index("const ")==0) className.Remove(0,6);
+   return className;
+}
 ////////////////////////////////////////////////////////////////////////////////
 /// Helper function to initialize the 'index/counter' value of
 /// the Pointer streamerElements.  If directive is a StreamerInfo and it correspond to the
@@ -280,10 +287,10 @@ Bool_t TStreamerElement::CannotSplit() const
 TClass *TStreamerElement::GetClassPointer() const
 {
    if (fClassObject!=(TClass*)(-1)) return fClassObject;
-   TString className = fTypeName.Strip(TString::kTrailing, '*');
-   if (className.Index("const ")==0) className.Remove(0,6);
+
+   TString className(ExtractClassName(fTypeName));
    bool quiet = (fType == TVirtualStreamerInfo::kArtificial);
-   ((TStreamerElement*)this)->fClassObject = TClass::GetClass(className,kTRUE,quiet);
+   ((TStreamerElement*)this)->fClassObject = TClass::GetClass(className, kTRUE, quiet);
    return fClassObject;
 }
 
@@ -571,15 +578,25 @@ void TStreamerElement::Update(const TClass *oldClass, TClass *newClass)
       if (fClassObject && fClassObject->IsTObject()) {
          fTObjectOffset = fClassObject->GetBaseClassOffset(TObject::Class());
       }
-   } else if (fClassObject==0) {
+   } else if (fClassObject == nullptr) {
       // Well since some emulated class is replaced by a real class, we can
       // assume a new library has been loaded.  If this is the case, we should
       // check whether the class now exist (this would be the case for example
       // for reading STL containers).
-      fClassObject = (TClass*)-1;
-      GetClassPointer(); //force fClassObject
-      if (fClassObject && fClassObject->IsTObject()) {
-         fTObjectOffset = fClassObject->GetBaseClassOffset(TObject::Class());
+
+      TString classname(ExtractClassName(fTypeName));
+
+      if (classname == newClass->GetName()) {
+         fClassObject = newClass;
+         if (fClassObject && fClassObject->IsTObject()) {
+            fTObjectOffset = fClassObject->GetBaseClassOffset(TObject::Class());
+         }
+      } else if (TClassTable::GetDict(classname)) {
+         fClassObject = (TClass*)-1;
+         GetClassPointer(); //force fClassObject
+         if (fClassObject && fClassObject->IsTObject()) {
+            fTObjectOffset = fClassObject->GetBaseClassOffset(TObject::Class());
+         }
       }
    }
 }
@@ -819,21 +836,20 @@ void TStreamerBase::Streamer(TBuffer &R__b)
 
 void TStreamerBase::Update(const TClass *oldClass, TClass *newClass)
 {
-   if (fClassObject == oldClass) fClassObject = newClass;
-   else if (fClassObject == 0) {
-      fClassObject = (TClass*)-1;
-      GetClassPointer(); //force fClassObject
+   TStreamerElement::Update(oldClass, newClass);
+
+   if (fBaseClass == oldClass) {
+      fBaseClass = newClass;
+      InitStreaming();
+   } else if (fBaseClass == nullptr) {
+      if (fName == newClass->GetName()) {
+         fBaseClass = newClass;
+         InitStreaming();
+      } else if (TClassTable::GetDict(fName)) {
+         fBaseClass = TClass::GetClass(fName);
+         InitStreaming();
+      }
    }
-   if (fBaseClass   == oldClass) fBaseClass   = newClass;
-   else if (fBaseClass == 0 ) {
-      fBaseClass = (TClass*)-1;
-      GetClassPointer(); //force fClassObject
-   }
-   if (fClassObject != (TClass*)-1 &&
-       fClassObject && fClassObject->IsTObject()) {
-      fTObjectOffset = fClassObject->GetBaseClassOffset(TObject::Class());
-   }
-   InitStreaming();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -39,6 +39,7 @@ element type.
 #include "TStreamerElement.h"
 #include "TClass.h"
 #include "TClassEdit.h"
+#include "TClassTable.h"
 #include "TDataMember.h"
 #include "TMethodCall.h"
 #include "TDataType.h"
@@ -1770,12 +1771,14 @@ void TStreamerInfo::BuildOld()
          if (element->IsA() == TStreamerBase::Class()) {
             TStreamerBase* base = (TStreamerBase*) element;
 #if defined(PROPER_IMPLEMEMANTION_OF_BASE_CLASS_RENAMING)
-            TClass* baseclass =  fClass->GetBaseClass( base->GetName() );
+            TClassRef baseclass =  fClass->GetBaseClass( base->GetName() );
 #else
             // Currently the base class renaming does not work, so we use the old
             // version of the code which essentially disable the next if(!baseclass ..
             // statement.
-            TClass* baseclass =  base->GetClassPointer();
+            // During the TStreamerElement's Init an emulated TClass might be replaced
+            // by one from the dictionary, we use a TClassRef to be informed of the change.
+            TClassRef baseclass =  base->GetClassPointer();
 #endif
 
             //------------------------------------------------------------------
@@ -5489,9 +5492,9 @@ void TStreamerInfo::Update(const TClass *oldcl, TClass *newcl)
 void TStreamerInfo::TCompInfo::Update(const TClass *oldcl, TClass *newcl)
 {
    if (fType != -1) {
-      if (fClass == oldcl)
+      if (fClass == oldcl || strcmp(fClassName, newcl->GetName()) == 0)
          fClass = newcl;
-      else if (fClass == 0)
+      else if (fClass == 0 && TClassTable::GetDict(fClassName))
          fClass = TClass::GetClass(fClassName);
    }
 }


### PR DESCRIPTION
This should be the last crop of fixes needed by ROOT-10216.

In brief, the changes are to replace lookup by simpler search to avoid nested
initialization of TClasses (leading to the outer nested initialization
to end using deleted memory).

Some explanation of the reasons for and details of the actual changes.

With

```
namespace User {
class TrackerVtxBase
class BeamFlux : public User::TrackerVtxBase
class NTrackerVtx : public User::BeamFlux
}
```

We had a crash during BuildOld for User::BeamFlux

```
User::TBaseObject triggers replacement routines.
   reaches NTrackerVtx
   calls (unnecessary) TStreamerBase::InitStreaming() and BuildOld for BeamFlux
   in BuildOld look at base User::TrackerVtxBase (and record pointer value in baseclass)
   calls Init on the TStreamerElement base
     this triggers the creation of the TClass for User::TrackerVtxBase
   but BuildOld kept a stale pointer to the old TClass (was baseclass variable).
```

Solution: replace raw pointer by a TClassRef.

TCompInfo::Update did a TClass::GetClass for all type that were not classes :(
Usually it is just a waste of time.
In this case, one such type is User::TContext::Time (an enum) use as part
of User::TContext ..

Consequently, before the dictionary TClass for User::TContext was constructed,
another class requested the update of the emulated StreamerInfo for the (still)
emulated User::TContext, this in turn provoked the (unnecessary) call to
TClass::GetClass on ‘User::TContext::Time’ which provoked the creation of
the TClass for User::TContext … one of the steps is to absorb the existing
StreamerInfo (including the one being updated) and clear them (i.e. delete
the TCompInfo array) … upon return the result of the TClass::GetClass (a nullptr)
is stored in deleted memory.

Solution: Don’t call TClass::GetClass on non-type.

```
User::TDatum is loaded
   provokes update of a StreamerInfo with a TTrueParticle
     *spurrious* InitStreaming provoke need for TTrueParticle TClass
        start consuming the TTrueParticle TProtoClass
          needs the TTrueVertex TClass
             provokes update of a StreamerInfo with a TBaseObject
                *spurrious* InitStreaming provoke need for TBaseObject TClass
                   needs the TTrueParticle TClass
                     Consumes the TTrueParticle TProtoClass
          return fine with a good TTrueVertex TClass
        continue using the already “cleared” TTrueParticle TProtoClass
```

Solution: significant update of TStreamerElement::Update and TStreamerBase::Update
to call TStreamerBase::InitStreamer if and only if there was a change in the base
class pointer, and to call TClass::GetClass only if there is a chance of finding
a new TClass ….