### PR TITLE
[cxxmodules] Allow submodules to contain headers which may be missing.

### DIFF
--- a/build/unix/std.modulemap
+++ b/build/unix/std.modulemap
@@ -82,6 +82,7 @@ module "std" [system] {
     header "csignal"
   }
   module "cstdalign" {
+    requires !cplusplus17, !header_existence
     export *
     header "cstdalign"
   }

--- a/build/unix/std.modulemap
+++ b/build/unix/std.modulemap
@@ -358,8 +358,14 @@ module "std" [system] {
     header "vector"
   }
   module "codecvt" {
+    requires !header_existence
     export *
     header "codecvt"
+  }
+  module "cuchar" {
+    requires !header_existence
+    export *
+    header "cuchar"
   }
   //module "experimental/algorithm" {
   //  export *


### PR DESCRIPTION
This allows us to use a single modulemap file across multiple libstdc++ versions and gives us a way forward to deal with deprecated files.

This patch will be submitted for a review upstream. It fixes our gcc 4.8 builds where codecvt and cuchar header files do not exist.