### PR TITLE
[dictpch] From Wim: disable shell for subprocess.call:

### DIFF
--- a/etc/dictpch/makepch.py
+++ b/etc/dictpch/makepch.py
@@ -115,7 +115,7 @@ def makepch():
    if not existing_ldlib: existing_ldlib = ""
    my_env["LD_LIBRARY_PATH"] = os.path.join(rootdir, "lib") + ":" + existing_ldlib
 
-   ret = subprocess.call(command, env=my_env, shell=True)
+   ret = subprocess.call(command.split(), env=my_env)
    if ret == 0:
       shutil.move("allDict_rdict.pch",pchFileName)
       os.unlink("allDict.cxx")


### PR DESCRIPTION
Wim says: adding 'shell=True' makes the command run on
/bin/sh and allows you to use shell features (such as expansion and
replacement of variables). But nothing in the command seems to need that
feature, and anyway it's a risky thing to rely on, or what am I missing?

Spawning an intermediate shell makes a mess of the environment when running
under conda on Mac in the non-build environment. Running the normal way as
per the patched line above, and all seems good.