### PR TITLE
[cxxmodules] Do not trigger redundant deserializations.

### DIFF
--- a/bindings/r/inc/RExports.h
+++ b/bindings/r/inc/RExports.h
@@ -154,7 +154,7 @@ namespace ROOT {
          Rcpp::function(name_, fun, docstring);
       }
 
-      extern Rcpp::internal::NamedPlaceHolder Label;
+      extern const Rcpp::internal::NamedPlaceHolder &Label;
    }
 }
 

--- a/bindings/r/src/RExports.cxx
+++ b/bindings/r/src/RExports.cxx
@@ -11,7 +11,11 @@
 #include<TRDataFrame.h>
 #include<Rcpp/Vector.h>
 
-Rcpp::internal::NamedPlaceHolder ROOT::R::Label;
+namespace ROOT {
+   namespace R {
+     const Rcpp::internal::NamedPlaceHolder &Label(Rcpp::_);
+   }
+}
 
 namespace Rcpp {
 //TVectorT


### PR DESCRIPTION
ROOT::R::Label is a synonym of Rcpp::_. We should just bind to it, instead of
introducing a new variable causing redundant deserialization from the C++ module.