### PR TITLE
[cxxmodules] Preload libMathCore as usual.

### DIFF
--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -159,7 +159,7 @@ TRint::TRint(const char *appClassName, Int_t *argc, char **argv, void *options,
    // Explicitly load libMathCore it cannot be auto-loaded it when using one
    // of its freestanding functions. Once functions can trigger autoloading we
    // can get rid of this.
-   if (!gInterpreter->HasPCMForLibrary("libMathCore") && !gClassTable->GetDict("TRandom"))
+   if (!gClassTable->GetDict("TRandom"))
       gSystem->Load("libMathCore");
 
    if (!gInterpreter->HasPCMForLibrary("std")) {


### PR DESCRIPTION
This appease the bots' sporadic failures about missing gRandom while we are investigating.