### PR TITLE
Fix the GSL random number generator wrapper for external engines (e.g. random engine from ROOT)

### DIFF
--- a/math/mathmore/src/GSLRndmEngines.cxx
+++ b/math/mathmore/src/GSLRndmEngines.cxx
@@ -433,11 +433,15 @@ namespace Math {
    GSLRngMixMax::GSLRngMixMax() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_mixmax) );
-      Initialize();      
+      Initialize(); // this creates the gsl_rng structure
+      //  no real need to call CreateEngine since the underlined MIXMAX engine is created
+      // by calling GSLMixMaxWrapper::Seed(gsl_default_seed) that is called 
+      // when gsl_rng is allocated (in Initialize) 
+      GSLMixMaxWrapper::CreateEngine(Engine()->Rng());
    }
    GSLRngMixMax::~GSLRngMixMax() {
       // we need to explicitly delete the ROOT wrapper class
-      GSLMixMaxWrapper::Free(Engine()->Rng()->state);
+      GSLMixMaxWrapper::FreeEngine(Engine()->Rng());
    }
 
 } // namespace Math

--- a/math/mathmore/src/GSLRngROOTWrapper.h
+++ b/math/mathmore/src/GSLRngROOTWrapper.h
@@ -22,66 +22,78 @@ namespace ROOT {
 
    namespace Math {
 
-      template<class Engine>
-      struct GSLRngROOTWrapper {
+   /**
+    * class for wrapping ROOT Engines in gsl_rng types which can be used as extra
+    * GSL random number generators
+    * For this we need to implment functions which will be called by gsl_rng.
+    * The functions (Seed, Rndm, IntRndm) are passed in the gsl_rng_type and used to build a gsl_rng object.
+    * When gsl_rng is alloacated, only the memory state is allocated using calloc(1,size), which gives a memory 
+    * block of the given bytes and it initializes to zero. Therefore no constructor of GSLRngROOTWrapper can be called 
+    * and also we cannot call non-static member funciton of the class. 
+    * The underlined ROOT engine is then built and deleted using the functions CreateEngine() and FreeEngine(), 
+    * called by the specific GSLRandomEngine class that instantiates for the  the generator (e.g. GSLRngMixMax)
+    *
+    **/
+   template <class Engine>
+   struct GSLRngROOTWrapper {
 
-         Engine * fEngine;
-         bool fFirst;
+      Engine *fEngine = nullptr;
 
-         
-         GSLRngROOTWrapper() {
-            fEngine = nullptr;
-            fFirst = false; 
-         }
+      // non need to have specific ctor/dtor since we cannot call them
 
-         ~GSLRngROOTWrapper() {
-            if (fEngine) delete fEngine; 
-         }
+      // function called by the specific GSLRndmEngine to create the ROOT engine
+      static void CreateEngine(gsl_rng *r)
+      {
+         // the engine pointer is retrieved from r
+         GSLRngROOTWrapper *wrng = ((GSLRngROOTWrapper *)r->state);
+         //printf("calling create engine - engine pointer : %p\n", wrng->fEngine);
+         if (!wrng->fEngine)
+            wrng->fEngine = new Engine();
+         // do nothing in case it is already created (e.g. when calling with default_seed)
+      }
 
-         static double Rndm(void * p) {
-            return ((GSLRngROOTWrapper *) p)->fEngine->operator()(); 
+      static double Rndm(void *p) { return ((GSLRngROOTWrapper *)p)->fEngine->operator()(); }
+      static unsigned long IntRndm(void *p) { return ((GSLRngROOTWrapper *)p)->fEngine->IntRndm(); }
+
+      static void Seed(void *p, unsigned long seed)
+      {
+         auto wrng = ((GSLRngROOTWrapper *)p);
+         // (GSL calls at the beginning with the defaul seed (typically zero))
+         //printf("calling the seed function with %d on %p and engine %p\n", seed, p, wrng->fEngine);
+         if (seed == gsl_rng_default_seed) {
+            seed = 111; // avoid using 0 that for ROOT means a specific seed
+            if (!wrng->fEngine) wrng->fEngine = new Engine();
          }
-         static unsigned long IntRndm(void * p) {
-            return ((GSLRngROOTWrapper *) p)->fEngine->IntRndm(); 
-         }
-         static void Seed(void * p, unsigned long seed) {
-            //if (fFirst) {
-            // this will be a memory leak because I have no way to delete
-            // the engine class 
-            auto wr = ((GSLRngROOTWrapper *) p);
-            if (wr->fFirst) {
-               //printf("calling the seed function with %d on %p . Build Engine class \n",seed,p);               
-               wr->fEngine = new Engine();
-               wr->fFirst = false;
-            }
-            // the seed cannot be zero (GSL calls at the beginning with seed 0)
-            if (seed == 0) return; 
-            ((GSLRngROOTWrapper *) p)->fEngine->SetSeed(seed); 
-         }
-         static void Free(void *p) {
-            auto wr = ((GSLRngROOTWrapper *) p);
-            if (wr->fEngine) delete wr->fEngine;
-            wr->fFirst = true;
-            //printf("deleting gsl mixmax\n");
-         }
-         
-         static unsigned long Max() { return Engine::MaxInt(); }
-         static unsigned long Min() { return Engine::MinInt(); }
-         static size_t Size() { return sizeof( GSLRngROOTWrapper<Engine>); }
-         static std::string Name() { return std::string("GSL_")+Engine::Name(); }
-      };
-   }
-}
+         assert(wrng->fEngine != nullptr);
+         wrng->fEngine->SetSeed(seed);
+      }
+      static void FreeEngine(gsl_rng *r)
+      {
+         auto wrng = ((GSLRngROOTWrapper *)r->state);
+         if (wrng->fEngine)
+            delete wrng->fEngine;
+         wrng->fEngine = nullptr;
+      }
+
+      static unsigned long Max() { return Engine::MaxInt(); }
+      static unsigned long Min() { return Engine::MinInt(); }
+      static size_t Size() { return sizeof(GSLRngROOTWrapper<Engine>); }
+      static std::string Name() { return std::string("GSL_") + Engine::Name(); }
+   };
+
+   }  // end namespace Math
+} // end namespace ROOT
 
 #include "Math/MixMaxEngine.h"
 
 // now define and implement the specific types    
 
-typedef ROOT::Math::GSLRngROOTWrapper<ROOT::Math::MixMaxEngine<240,0>> GSLMixMaxWrapper;
+typedef ROOT::Math::GSLRngROOTWrapper<ROOT::Math::MixMaxEngine<17,0>> GSLMixMaxWrapper;
 
+static const std::string gsl_mixmax_name =  GSLMixMaxWrapper::Name();
 static const gsl_rng_type mixmax_type =
 {
-   GSLMixMaxWrapper::Name().c_str(), 
+   gsl_mixmax_name.c_str(), 
    GSLMixMaxWrapper::Max(), 
    GSLMixMaxWrapper::Min(),
    GSLMixMaxWrapper::Size(),

--- a/math/mathmore/test/testRandom.cxx
+++ b/math/mathmore/test/testRandom.cxx
@@ -4,6 +4,7 @@
 #include "TRandom1.h"
 #include "TRandom2.h"
 #include "TRandom3.h"
+#include "TRandomGen.h"
 #include <iostream>
 #include <cmath>
 #include <cstdlib>
@@ -117,6 +118,12 @@ void printName( const TRandom2 & r) {
 void printName( const TRandom3 & r) {
   std::cout << "\nRandom :\t " << r.ClassName() << std::endl;
 }
+// specialization for TRandomGen
+template<class Engine>
+void printName(const TRandomGen<Engine> &r) {
+   std::cout << "\nRandom :\t " << r.ClassName() << std::endl;
+}
+
 
 template <class R>
 void generate( R & r, bool array=true) {
@@ -181,8 +188,12 @@ int main() {
   Random<GSLRngRand>       r7;
   Random<GSLRngRanMar>     r8;
   Random<GSLRngMinStd>     r9;
-  RandomStd                r10;
+  Random<GSLRngMixMax>     r10;
 
+  // std engine
+  RandomStd                sr0; 
+
+  // ROOT engine
   TRandom                  tr0;
   TRandom1                 tr1;
   TRandom1                 tr1a(0,0);
@@ -192,7 +203,9 @@ int main() {
   TRandom1                 tr1e(0,4);
   TRandom2                 tr2;
   TRandom3                 tr3;
-
+  TRandomMixMax            tr4;
+  TRandomMixMax17          tr5;
+  TRandomMixMax256         tr6;
 
   generate(tr0);
   generate(tr1);
@@ -203,8 +216,11 @@ int main() {
   generate(tr1e);
   generate(tr2);
   generate(tr3);
+  generate(tr4);
+  generate(tr5);
+  generate(tr6);
 
-  generate(r10);
+  generate(sr0);
 
   generate(r1);
   generate(r2);
@@ -219,7 +235,7 @@ int main() {
   generate(r7);
   generate(r8);
   generate(r9);
-
+  generate(r10);
 
 #ifdef HAVE_CLHEP
   RanluxEngine             e1(1,3);


### PR DESCRIPTION
Fix the GSLRngROOTWrapper class. Include also in  testRandom the new engine based on MixMax (uses now Mixmax 17) and fix a compiler warning found in Ubuntu 18