### PR TITLE
[textinput] Fixes issue ROOT-10285

### DIFF
--- a/core/textinput/src/textinput/Editor.h
+++ b/core/textinput/src/textinput/Editor.h
@@ -110,6 +110,8 @@ namespace textinput {
       EMoveID GetMoveID() const { return fMove;}
       char GetChar() const { return fChar;}
 
+      bool isCtrlD() const { return fKind == kCKControl
+                                    && (fChar == 'd'-0x60); }
     private:
       ECommandKind fKind; // discriminator for union
       union {

--- a/core/textinput/src/textinput/KeyBinding.cpp
+++ b/core/textinput/src/textinput/KeyBinding.cpp
@@ -48,9 +48,8 @@ namespace textinput {
     switch (In) {
       case 'a' - 0x60: return C(Editor::kMoveFront);
       case 'b' - 0x60: return C(Editor::kMoveLeft);
-      case 'c' - 0x60:
-        return C(In, Editor::kCKControl);
-      case 'd' - 0x60: return C(Editor::kCmdDel);
+      case 'c' - 0x60: return C(In, Editor::kCKControl);
+      case 'd' - 0x60: return C(In, Editor::kCKControl);
       case 'e' - 0x60: return C(Editor::kMoveEnd);
       case 'f' - 0x60: return C(Editor::kMoveRight);
       case 'g' - 0x60: return C(Editor::kMoveRight);

--- a/core/textinput/src/textinput/TextInput.cpp
+++ b/core/textinput/src/textinput/TextInput.cpp
@@ -148,6 +148,10 @@ namespace textinput {
     fLastKey = in.GetRaw(); // rough approximation
     Editor::Command Cmd = fContext->GetKeyBinding()->ToCommand(in);
 
+    // Translate Ctrl-D to delete if input line is not empty, as GNU readline does.
+    if (!fContext->GetLine().empty() && Cmd.isCtrlD())
+      Cmd = Editor::Command(Editor::kCmdDel);
+
     if (Cmd.GetKind() == Editor::kCKControl
         && (Cmd.GetChar() == 3 || Cmd.GetChar() == 26)) {
       // If there are modifications in the queue, process them now.
@@ -158,11 +162,8 @@ namespace textinput {
       std::for_each(fContext->GetDisplays().begin(),
                     fContext->GetDisplays().end(),
                     [](Display *D) { return D->NotifyWindowChange(); });
-    } else if (Cmd.GetKind() == Editor::kCKCommand
-      && Cmd.GetCommandID() == Editor::kCmdDel &&
-      !fContext->GetLine().length()) {
-      fContext->SetLine(".q");
-      Redraw();
+    } else if (Cmd.isCtrlD()) {
+      fContext->SetLine(".q"), Redraw();
       fLastReadResult = kRREOF;
       return;
     } else {


### PR DESCRIPTION
The issue was introduced in commit 0e90d01afe13c12fafd1002a5bf9fd6f8bc2fbb0.  The function `KeyBinding::ToCommandCtrl()` was (early) translating Ctrl-D (EOF) to kCmdDel.  Therefore, it couldn't be handled differently in `TextInput::ProcessNewInput()`.

Leave it as a kCKControl and defer translation to a delete command.