### PR TITLE
[ntuple] feature to chain ntuple-files

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -32,6 +32,7 @@ HEADERS
   ROOT/RPageAllocator.hxx
   ROOT/RPagePool.hxx
   ROOT/RPageStorage.hxx
+  ROOT/RPageStorageChain.hxx
   ROOT/RPageStorageRaw.hxx
   ROOT/RPageStorageRoot.hxx
 SOURCES
@@ -48,6 +49,7 @@ SOURCES
   v7/src/RPageAllocator.cxx
   v7/src/RPagePool.cxx
   v7/src/RPageStorage.cxx
+  v7/src/RPageStorageChain.cxx
   v7/src/RPageStorageRaw.cxx
   v7/src/RPageStorageRoot.cxx
 LINKDEF

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -150,7 +150,7 @@ public:
       if (clusterIndex.GetIndex() + count <= fCurrentPage.GetClusterRangeLast() + 1) {
          elemArray->ReadFrom(src, count);
       } else {
-         ClusterSize_t::ValueType nBatch = fCurrentPage.GetClusterRangeLast() - idxInPage;
+         ClusterSize_t::ValueType nBatch = fCurrentPage.GetNElements() - idxInPage;
          elemArray->ReadFrom(src, nBatch);
          RColumnElementBase elemTail(*elemArray, nBatch);
          ReadV(RClusterIndex(clusterIndex.GetClusterId(), clusterIndex.GetIndex() + nBatch), count - nBatch, &elemTail);

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -75,11 +75,16 @@ public:
 
 
 /**
- * Listing of the different options that can be returned by RNTupleReader::GetInfo()
+ * Listing of the different options that can be returned by RNTupleReader::PrintInfo()
  */
 enum class ENTupleInfo {
    kSummary,  // The ntuple name, description, number of entries
    kStorageDetails, // size on storage, page sizes, compression factor, etc.
+};
+
+enum class EFileOpeningOptions {
+   kChain,     // Multiple files with same fields are chained
+   kFriend     // The field structure of multiple files with the same cluster structure are combined
 };
 
 
@@ -124,14 +129,24 @@ public:
    static std::unique_ptr<RNTupleReader> Open(std::unique_ptr<RNTupleModel> model,
                                              std::string_view ntupleName,
                                              std::string_view storage);
-   static std::unique_ptr<RNTupleReader> Open(std::string_view ntupleName, std::string_view storage);
+   static std::unique_ptr<RNTupleReader> Open(std::string_view ntupleName,
+                                              std::string_view storage);
 
-   static std::unique_ptr<RNTupleReader> Open(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName, std::vector<std::string> storage);
-   static std::unique_ptr<RNTupleReader> Open(std::string_view ntupleName, std::vector<std::string> storage);
+   static std::unique_ptr<RNTupleReader> Open(std::unique_ptr<RNTupleModel> model,
+                                              std::string_view ntupleName,
+                                              std::vector<std::string> storage,
+                                              EFileOpeningOptions op = EFileOpeningOptions::kChain);
+   static std::unique_ptr<RNTupleReader> Open(std::string_view ntupleName,
+                                              std::vector<std::string> storage,
+                                              EFileOpeningOptions op = EFileOpeningOptions::kChain);
 
    /// Chains 2 RNTupleReader with the same field and columns into a single one.
-   static std::unique_ptr<RNTupleReader> ChainReader(std::string_view ntupleName, std::unique_ptr<RNTupleReader>& reader1, std::unique_ptr<RNTupleReader>& reader2);
-   static std::unique_ptr<RNTupleReader> ChainReader(std::string_view ntupleName, std::unique_ptr<RNTupleReader>&& reader1, std::unique_ptr<RNTupleReader>&& reader2);
+   static std::unique_ptr<RNTupleReader> ChainReader(std::string_view ntupleName,
+                                                     std::unique_ptr<RNTupleReader>& reader1,
+                                                     std::unique_ptr<RNTupleReader>& reader2);
+   static std::unique_ptr<RNTupleReader> ChainReader(std::string_view ntupleName,
+                                                     std::unique_ptr<RNTupleReader>&& reader1,
+                                                     std::unique_ptr<RNTupleReader>&& reader2);
 
    /// The user imposes an ntuple model, which must be compatible with the model found in the data on storage
    RNTupleReader(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Detail::RPageSource> source);

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -126,6 +126,13 @@ public:
                                              std::string_view storage);
    static std::unique_ptr<RNTupleReader> Open(std::string_view ntupleName, std::string_view storage);
 
+   static std::unique_ptr<RNTupleReader> Open(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName, std::vector<std::string> storage);
+   static std::unique_ptr<RNTupleReader> Open(std::string_view ntupleName, std::vector<std::string> storage);
+
+   /// Chains 2 RNTupleReader with the same field and columns into a single one.
+   static std::unique_ptr<RNTupleReader> ChainReader(std::string_view ntupleName, std::unique_ptr<RNTupleReader>& reader1, std::unique_ptr<RNTupleReader>& reader2);
+   static std::unique_ptr<RNTupleReader> ChainReader(std::string_view ntupleName, std::unique_ptr<RNTupleReader>&& reader1, std::unique_ptr<RNTupleReader>&& reader2);
+
    /// The user imposes an ntuple model, which must be compatible with the model found in the data on storage
    RNTupleReader(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Detail::RPageSource> source);
    /// The model is generated from the ntuple metadata on storage
@@ -134,6 +141,7 @@ public:
    ~RNTupleReader();
 
    NTupleSize_t GetNEntries() const { return fNEntries; }
+   const RNTupleDescriptor &GetDescriptor() const { return fSource->GetDescriptor(); }
 
    /// Prints a detailed summary of the ntuple, including a list of fields.
    void PrintInfo(const ENTupleInfo what = ENTupleInfo::kSummary, std::ostream &output = std::cout);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -400,6 +400,7 @@ public:
    void AddClusterPageRange(DescriptorId_t clusterId, RClusterDescriptor::RPageRange &&pageRange);
 
    void AddClustersFromFooter(void* footerBuffer);
+   void AddClustersFromAdditionalFile(const RNTupleDescriptor& desc);
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -33,7 +33,7 @@ namespace Detail {
 \brief A page is a slice of a column that is mapped into memory
 
 The page provides an opaque memory buffer for uncompressed, unpacked data. It does not interpret
-the contents but it does now about the size (and thus the number) of the elements inside as well as the element
+the contents but it does know about the size (and thus the number) of the elements inside as well as the element
 number range within the backing column/cluster. The memory buffer is not managed by the page. It is normally registered
 with the page pool and allocated/freed by the page storage.
 */

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -165,10 +165,6 @@ public:
    /// Guess the concrete derived page source from the file name (location)
    static std::unique_ptr<RPageSource> Create(std::string_view ntupleName, std::string_view location,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
-   static std::unique_ptr<RPageSource> Create(std::string_view ntupleName, std::vector<std::string> locationVec, const RNTupleReadOptions &options = RNTupleReadOptions());
-   static std::unique_ptr<RPageSource> CreateFrom2Reader(std::string_view ntupleName, RPageSource* s1, RPageSource* s2, const RNTupleReadOptions &options = RNTupleReadOptions());
-   static std::unique_ptr<RPageSource> CreateFrom2Reader(std::string_view ntupleName, std::unique_ptr<RPageSource>&& s1, std::unique_ptr<RPageSource>&& s2, const RNTupleReadOptions &options = RNTupleReadOptions());
-   /// Open the same storage multiple time, e.g. for reading in multiple threads
    virtual std::unique_ptr<RPageSource> Clone() const = 0;
 
    EPageStorageType GetType() final { return EPageStorageType::kSource; }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -165,6 +165,9 @@ public:
    /// Guess the concrete derived page source from the file name (location)
    static std::unique_ptr<RPageSource> Create(std::string_view ntupleName, std::string_view location,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
+   static std::unique_ptr<RPageSource> Create(std::string_view ntupleName, std::vector<std::string> locationVec, const RNTupleReadOptions &options = RNTupleReadOptions());
+   static std::unique_ptr<RPageSource> CreateFrom2Reader(std::string_view ntupleName, RPageSource* s1, RPageSource* s2, const RNTupleReadOptions &options = RNTupleReadOptions());
+   static std::unique_ptr<RPageSource> CreateFrom2Reader(std::string_view ntupleName, std::unique_ptr<RPageSource>&& s1, std::unique_ptr<RPageSource>&& s2, const RNTupleReadOptions &options = RNTupleReadOptions());
    /// Open the same storage multiple time, e.g. for reading in multiple threads
    virtual std::unique_ptr<RPageSource> Clone() const = 0;
 
@@ -182,6 +185,7 @@ public:
    virtual RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) = 0;
    /// Another version of PopulatePage that allows to specify cluster-relative indexes
    virtual RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) = 0;
+   virtual void GetHeaderAndFooter(RNTupleDescriptorBuilder &descBuilder) = 0;
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageChain.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageChain.hxx
@@ -48,8 +48,16 @@ private:
    /// column. fNElementsPerColumnPerSource.at(i).at(j) holds the entry of the i-th source and (j-1)-th column (start
    /// counting i and j from 1 instead of 0). For all j, fNElementsPerColumnPerSource.at(0).at(j) = 0.
    std::vector<std::vector<std::size_t>> fNElementsPerColumnPerSource;
-   /// Maps the buffer of a RPage (void*) to its RPageSource (std::size_t = (index of fSources))
-   std::unordered_map<void *, std::size_t> fPageMapper;
+   /// Keeps track to which RPageSource a populated page belongs to and how often the same page was populated but not
+   /// released yet.
+   struct PageInfo {
+      /// Tells that the RPage belongs to the RPageSource fSources.at(fSourceId).
+      std::size_t fSourceId;
+      /// Tells how often the same page was populated.
+      std::size_t fNSamePagePopulated;
+   };
+   /// Maps the buffer of a RPage (void*) to its RPageSource.
+   std::unordered_map<void *, PageInfo> fPageMapper;
    /// Is set to true when the meta-data of the fields and columns don't match.
    /// Getting pages from a unsafe RPageStorageChain can lead to undefined behaviour.
    bool fUnsafe = false;
@@ -67,10 +75,6 @@ public:
    RPageSourceChain(std::string_view ntupleName, std::vector<RPageSource *> sources, const RNTupleReadOptions &options);
    RPageSourceChain(std::string_view ntupleName, std::vector<std::unique_ptr<RPageSource>> &&sources,
                     const RNTupleReadOptions &options);
-   RPageSourceChain(const RPageSourceChain &other) = delete;
-   RPageSourceChain &operator=(const RPageSourceChain &other) = delete;
-   RPageSourceChain(RPageSourceChain &&other) = default;
-   RPageSourceChain &operator=(RPageSourceChain &&other) = default;
    ~RPageSourceChain() = default;
 
    std::unique_ptr<RPageSource> Clone() const;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageChain.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageChain.hxx
@@ -71,10 +71,10 @@ protected:
 
 public:
    RPageSourceChain(std::string_view ntupleName, std::vector<std::string> locationVec,
-                    const RNTupleReadOptions &options);
-   RPageSourceChain(std::string_view ntupleName, std::vector<RPageSource *> sources, const RNTupleReadOptions &options);
+                    const RNTupleReadOptions &options = RNTupleReadOptions());
+   RPageSourceChain(std::string_view ntupleName, std::vector<RPageSource *> sources, const RNTupleReadOptions &options = RNTupleReadOptions());
    RPageSourceChain(std::string_view ntupleName, std::vector<std::unique_ptr<RPageSource>> &&sources,
-                    const RNTupleReadOptions &options);
+                    const RNTupleReadOptions &options = RNTupleReadOptions());
    ~RPageSourceChain() = default;
 
    std::unique_ptr<RPageSource> Clone() const;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageChain.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageChain.hxx
@@ -1,0 +1,90 @@
+/// \file ROOT/RPageStorageChain.hxx
+/// \ingroup NTuple ROOT7
+/// \author Simon Leisibach <simon.satoshi.rene.leisibach@cern.ch>
+/// \date 2019-09-09
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RPageStorageChain
+#define ROOT7_RPageStorageChain
+
+#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RPageStorage.hxx>
+
+#include <memory>
+
+namespace ROOT {
+namespace Experimental {
+namespace Detail {
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RPageSourceChain
+\ingroup NTuple
+\brief A pagesource generated from multiple files with the same fields and columns. It acts like a PageSource for a file where multiple files were merged into one.
+ 
+ An instance of RPageSourceChain is created in RPageStorage::Create() when a std::vector of filenames is passed as an argument instead of a filename-string. It first creates a RPageSource (including its descriptor) for each filename passed and initalizes its members. Later it merges the information from all the descriptors to create a single descriptor containing all information. It's main job is to assign PopulatePage() and ReleasePage() to the correct RPageSource.
+*/
+// clang-format on
+class RPageSourceChain : public RPageSource {
+private:
+   /// Holds a RPageSource pointer for each file.
+   std::vector<std::unique_ptr<RPageSource>> fSources;
+   /// Holds the cumulative number of entries per file. It's size is number of files + 1.
+   /// fNEntryPerSource[i] holds the number of entries of the i-th file, fNEntryPerSource[0] = 0
+   std::vector<std::size_t> fNEntryPerSource;
+   /// Holds the cumulative number of clusters per file. It's size is number of files + 1.
+   /// fNClusterPerSource[i] holds the number of clusters of the i-th file, fNClusterPerSource[0] = 0
+   std::vector<std::size_t> fNClusterPerSource;
+   /// The number of elements can vary between different columns of the same RPageSource, e.g. for a int and std::string
+   /// column. fNElementsPerColumnPerSource.at(i).at(j) holds the entry of the i-th source and (j-1)-th column (start
+   /// counting i and j from 1 instead of 0) fNElementsPerColumnPerSource.at(0).at(j) = 0.
+   std::vector<std::vector<std::size_t>> fNElementsPerColumnPerSource;
+   /// Maps the buffer of a RPage (void*) to its RPageSource (std::size_t = index of fSources)
+   std::unordered_map<void *, std::size_t> fPageMapper;
+   /// Is set to true when the meta-data of the fields and columns don't match.
+   /// Getting pages from a unsafe RPageStorageChain can lead to undefined behaviour.
+   bool fUnsafe = false;
+
+protected:
+   RNTupleDescriptor DoAttach();
+   /// Checks if the field and column meta-data of all files are the same. If the meta-data doesn't match it allows
+   /// further work but warns the user of undefined behaviour.
+   void CompareFileMetaData();
+   void InitializeVariables();
+
+public:
+   RPageSourceChain(std::string_view ntupleName, std::vector<std::string> locationVec,
+                    const RNTupleReadOptions &options);
+   RPageSourceChain(std::string_view ntupleName, std::vector<RPageSource *> sources, const RNTupleReadOptions &options);
+   RPageSourceChain(std::string_view ntupleName, std::vector<std::unique_ptr<RPageSource>> &&sources,
+                    const RNTupleReadOptions &options);
+   RPageSourceChain(const RPageSourceChain &other) = delete;
+   RPageSourceChain &operator=(const RPageSourceChain &other) = delete;
+   RPageSourceChain(RPageSourceChain &&other) = default;
+   RPageSourceChain &operator=(RPageSourceChain &&other) = default;
+   ~RPageSourceChain() = default;
+
+   std::unique_ptr<RPageSource> Clone() const;
+
+   RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex);
+   RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex);
+   void ReleasePage(RPage &page);
+
+   void GetHeaderAndFooter(RNTupleDescriptorBuilder &descBuilder);
+   bool IsSafe() const { return fUnsafe; }
+};
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageChain.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageChain.hxx
@@ -31,7 +31,7 @@ namespace Detail {
 \ingroup NTuple
 \brief A pagesource generated from multiple files with the same fields and columns. It acts like a PageSource for a file where multiple files were merged into one.
  
- An instance of RPageSourceChain is created in RPageStorage::Create() when a std::vector of filenames is passed as an argument instead of a filename-string. It first creates a RPageSource (including its descriptor) for each filename passed and initalizes its members. Later it merges the information from all the descriptors to create a single descriptor containing all information. It's main job is to assign PopulatePage() and ReleasePage() to the correct RPageSource.
+ An instance of RPageSourceChain is created in RPageStorage::Create() when a std::vector of filenames is passed as an argument instead of a filename-string. It first creates a RPageSource (including its descriptor) for each filename passed and initalizes its members. Later it merges the information from all the descriptors to create a single descriptor containing all information. After that its main job is to assign PopulatePage() and ReleasePage() to the correct RPageSource.
 */
 // clang-format on
 class RPageSourceChain : public RPageSource {
@@ -42,13 +42,13 @@ private:
    /// fNEntryPerSource[i] holds the number of entries of the i-th file, fNEntryPerSource[0] = 0
    std::vector<std::size_t> fNEntryPerSource;
    /// Holds the cumulative number of clusters per file. It's size is number of files + 1.
-   /// fNClusterPerSource[i] holds the number of clusters of the i-th file, fNClusterPerSource[0] = 0
+   /// fNClusterPerSource[i] holds the number of clusters of the i-th file, fNClusterPerSource[0] is always = 0
    std::vector<std::size_t> fNClusterPerSource;
    /// The number of elements can vary between different columns of the same RPageSource, e.g. for a int and std::string
    /// column. fNElementsPerColumnPerSource.at(i).at(j) holds the entry of the i-th source and (j-1)-th column (start
-   /// counting i and j from 1 instead of 0) fNElementsPerColumnPerSource.at(0).at(j) = 0.
+   /// counting i and j from 1 instead of 0). For all j, fNElementsPerColumnPerSource.at(0).at(j) = 0.
    std::vector<std::vector<std::size_t>> fNElementsPerColumnPerSource;
-   /// Maps the buffer of a RPage (void*) to its RPageSource (std::size_t = index of fSources)
+   /// Maps the buffer of a RPage (void*) to its RPageSource (std::size_t = (index of fSources))
    std::unordered_map<void *, std::size_t> fPageMapper;
    /// Is set to true when the meta-data of the fields and columns don't match.
    /// Getting pages from a unsafe RPageStorageChain can lead to undefined behaviour.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRaw.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRaw.hxx
@@ -117,6 +117,7 @@ public:
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
    RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
    void ReleasePage(RPage &page) final;
+   void GetHeaderAndFooter(RNTupleDescriptorBuilder &descBuilder) final;
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRoot.hxx
@@ -132,6 +132,7 @@ public:
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
    RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
    void ReleasePage(RPage &page) final;
+   void GetHeaderAndFooter(RNTupleDescriptorBuilder &descBuilder) final;
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -97,6 +97,35 @@ std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleRe
    return std::make_unique<RNTupleReader>(Detail::RPageSource::Create(ntupleName, storage));
 }
 
+std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::Open(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName, std::vector<std::string> storageVec)
+{
+   if (storageVec.size() == 0) {
+      std::cout << "No Files were specified, the RNTuple is empty!" << std::endl;
+      return nullptr;
+   }
+   return std::make_unique<RNTupleReader>(std::move(model), Detail::RPageSource::Create(ntupleName, storageVec));
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::Open(std::string_view ntupleName, std::vector<std::string> storageVec)
+{
+   if (storageVec.size() == 0) {
+      std::cout << "No Files were specified, the RNTuple is empty!" << std::endl;
+      return nullptr;
+   }
+   return std::make_unique<RNTupleReader>(Detail::RPageSource::Create(ntupleName, storageVec));
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::ChainReader(std::string_view ntupleName, std::unique_ptr<RNTupleReader>& reader1, std::unique_ptr<RNTupleReader>& reader2)
+{
+   return std::make_unique<RNTupleReader>(Detail::RPageSource::CreateFrom2Reader(ntupleName, reader1->fSource.get(), reader2->fSource.get()));
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::ChainReader(std::string_view ntupleName, std::unique_ptr<RNTupleReader>&& reader1, std::unique_ptr<RNTupleReader>&& reader2)
+{
+   // TODO (lesimon) close RNTupleView of reader1 and reader2 if present. Not doing so leads to a segmentation fault when the destructor of RNTupleView of reader1 or reader2 is called.
+   return std::make_unique<RNTupleReader>(Detail::RPageSource::CreateFrom2Reader(ntupleName, std::move(reader1->fSource), std::move(reader2->fSource)));
+}
+
 void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output)
 {
    // TODO(lesimon): In a later version, these variables may be defined by the user or the ideal width may be read out from the terminal.

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -69,27 +69,6 @@ std::unique_ptr<ROOT::Experimental::Detail::RPageSource> ROOT::Experimental::Det
    return std::make_unique<RPageSourceRaw>(ntupleName, location, options);
 }
 
-std::unique_ptr<ROOT::Experimental::Detail::RPageSource> ROOT::Experimental::Detail::RPageSource::Create(std::string_view ntupleName, std::vector<std::string> locationVec, const RNTupleReadOptions &options)
-{
-   return std::make_unique<RPageSourceChain>(ntupleName, locationVec, options);
-}
-
-std::unique_ptr<ROOT::Experimental::Detail::RPageSource> ROOT::Experimental::Detail::RPageSource::CreateFrom2Reader(std::string_view ntupleName, RPageSource* s1, RPageSource* s2, const RNTupleReadOptions &options)
-{
-   std::vector<RPageSource*> sourceVec;
-   sourceVec.emplace_back(s1);
-   sourceVec.emplace_back(s2);
-   return std::make_unique<RPageSourceChain>(ntupleName, sourceVec, options);
-}
-
-std::unique_ptr<ROOT::Experimental::Detail::RPageSource> ROOT::Experimental::Detail::RPageSource::CreateFrom2Reader(std::string_view ntupleName, std::unique_ptr<RPageSource>&& s1, std::unique_ptr<RPageSource>&& s2, const RNTupleReadOptions &options)
-{
-   std::vector<std::unique_ptr<RPageSource>> sourceVec;
-   sourceVec.emplace_back(std::move(s1));
-   sourceVec.emplace_back(std::move(s2));
-   return std::make_unique<RPageSourceChain>(ntupleName, std::move(sourceVec), options);
-}
-
 ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
 ROOT::Experimental::Detail::RPageSource::AddColumn(DescriptorId_t fieldId, const RColumn &column)
 {

--- a/tree/ntuple/v7/src/RPageStorageChain.cxx
+++ b/tree/ntuple/v7/src/RPageStorageChain.cxx
@@ -1,0 +1,225 @@
+/// \file ROOT/RPageStorageChain.cxx
+/// \ingroup NTuple ROOT7
+/// \author Simon Leisibach <simon.satoshi.rene.leisibach@cern.ch>
+/// \date 2019-09-09
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RLogger.hxx>
+#include <ROOT/RPage.hxx>
+#include <ROOT/RPageStorage.hxx>
+#include <ROOT/RPageStorageChain.hxx>
+#include <ROOT/RPageStorageRaw.hxx>
+#include <ROOT/RPageStorageRoot.hxx>
+
+#include <TError.h>
+
+#include <iostream>
+#include <memory>
+
+ROOT::Experimental::Detail::RPageSourceChain::RPageSourceChain(std::string_view ntupleName,
+                                                               std::vector<std::string> locationVec,
+                                                               const RNTupleReadOptions &options)
+   : RPageSource{ntupleName, options}
+{
+   // No need to check if locationVec is empty. It's already tested in RNTupleReader::Open
+
+   for (const auto &location : locationVec) {
+      fSources.emplace_back(Create(ntupleName, location, options));
+      fSources.back()->Attach();
+   }
+
+   CompareFileMetaData();
+   InitializeVariables();
+}
+
+ROOT::Experimental::Detail::RPageSourceChain::RPageSourceChain(std::string_view ntupleName,
+                                                               std::vector<RPageSource *> sources,
+                                                               const RNTupleReadOptions &options)
+   : RPageSource{ntupleName, options}
+{
+   for (const auto &s : sources) {
+      fSources.emplace_back(s->Clone());
+      fSources.back()->Attach();
+   }
+
+   CompareFileMetaData();
+   InitializeVariables();
+}
+
+ROOT::Experimental::Detail::RPageSourceChain::RPageSourceChain(std::string_view ntupleName,
+                                                               std::vector<std::unique_ptr<RPageSource>> &&sources,
+                                                               const RNTupleReadOptions &options)
+   : RPageSource{ntupleName, options}, fSources{std::move(sources)}
+{
+   CompareFileMetaData();
+   InitializeVariables();
+}
+
+void ROOT::Experimental::Detail::RPageSourceChain::CompareFileMetaData()
+{
+   for (std::size_t i = 1; i < fSources.size(); ++i) {
+      // checks only number of fields and columns
+      if ((fSources.at(0)->GetDescriptor().GetNFields() != fSources.at(i)->GetDescriptor().GetNFields()) ||
+          (fSources.at(0)->GetDescriptor().GetNColumns() != fSources.at(i)->GetDescriptor().GetNColumns())) {
+         R__WARNING_HERE("NTuple") << "The meta-data (number of fields and columns) of the files do not match. Using "
+                                      "this reader may result in undefined behaviour!\n";
+         fUnsafe = true;
+         break;
+      }
+      // compares all fieldDescriptors
+      for (std::size_t j = 0; j < fSources.at(0)->GetDescriptor().GetNFields(); ++j) {
+         if (!(fSources.at(0)->GetDescriptor().GetFieldDescriptor(j) ==
+               fSources.at(i)->GetDescriptor().GetFieldDescriptor(j))) {
+            R__WARNING_HERE("NTuple") << "The meta-data of the fields of the files do not match. Using this reader may "
+                                         "result in undefined behaviour!\n";
+            fUnsafe = true;
+            break;
+         }
+      }
+      if (fUnsafe)
+         break;
+      // compares all columnDescriptors
+      for (std::size_t j = 0; j < fSources.at(0)->GetDescriptor().GetNColumns(); ++j) {
+         if (!(fSources.at(0)->GetDescriptor().GetColumnDescriptor(j) ==
+               fSources.at(i)->GetDescriptor().GetColumnDescriptor(j))) {
+            R__WARNING_HERE("NTuple") << "The meta-data of the columns of the files do not match. Using this reader "
+                                         "may result in undefined behaviour!\n";
+            fUnsafe = true;
+            break;
+         }
+      }
+      if (fUnsafe)
+         break;
+   }
+}
+
+void ROOT::Experimental::Detail::RPageSourceChain::InitializeVariables()
+{
+   // initialize fNEntryPerSource and fNClusterPerSource
+   fNEntryPerSource.resize(fSources.size() + 1);
+   fNClusterPerSource.resize(fSources.size() + 1);
+   fNEntryPerSource.at(0) = 0;
+   fNClusterPerSource.at(0) = 0;
+   for (std::size_t i = 0; i < fSources.size(); ++i) {
+      fNEntryPerSource.at(i + 1) = fNEntryPerSource.at(i) + fSources.at(i)->GetNEntries();
+      fNClusterPerSource.at(i + 1) = fNClusterPerSource.at(i) + fSources.at(i)->GetDescriptor().GetNClusters();
+   }
+
+   // initialize fNElementsPerColumnPerSource
+   auto nColumns{fSources.at(0)->GetDescriptor().GetNColumns()};
+   fNElementsPerColumnPerSource.resize(fSources.size() + 1);
+   for (auto &fN : fNElementsPerColumnPerSource) {
+      fN.resize(nColumns);
+   }
+   for (std::size_t i = 0; i < nColumns; ++i) {
+      fNElementsPerColumnPerSource.at(0).at(i) = 0;
+   }
+   for (std::size_t i = 0; i < fSources.size(); ++i) {
+      for (std::size_t j = 0; j < nColumns; ++j) {
+         auto lastClusterId = fSources.at(i)->GetDescriptor().GetNClusters() - 1;
+         auto columnDescript = fSources.at(i)->GetDescriptor().GetClusterDescriptor(lastClusterId).GetColumnRange(j);
+         fNElementsPerColumnPerSource.at(i + 1).at(j) =
+            columnDescript.fFirstElementIndex + columnDescript.fNElements + fNElementsPerColumnPerSource.at(i).at(j);
+      }
+   }
+}
+
+ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceChain::DoAttach()
+{
+   RNTupleDescriptorBuilder descBuilder;
+   fSources.at(0)->GetHeaderAndFooter(descBuilder);
+   for (std::size_t i = 1; i < fSources.size(); ++i) {
+      descBuilder.AddClustersFromAdditionalFile(fSources.at(i)->GetDescriptor());
+   }
+   return descBuilder.MoveDescriptor();
+}
+
+std::unique_ptr<ROOT::Experimental::Detail::RPageSource> ROOT::Experimental::Detail::RPageSourceChain::Clone() const
+{
+   std::vector<RPageSource *> sourceVec;
+   for (const auto &s : fSources) {
+      sourceVec.emplace_back(s.get());
+   }
+   return std::make_unique<RPageSourceChain>(fNTupleName, sourceVec, fOptions);
+}
+
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPageSourceChain::PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex)
+{
+   std::size_t sourceIndex{0};
+   for (; sourceIndex < fSources.size(); ++sourceIndex) {
+      if (globalIndex < fNEntryPerSource.at(sourceIndex + 1))
+         break;
+   }
+   R__ASSERT(sourceIndex != fSources.size() && "globalIndex is bigger than total number of entries.");
+
+   RPage page{fSources.at(sourceIndex)->PopulatePage(columnHandle, globalIndex - fNEntryPerSource.at(sourceIndex))};
+   fPageMapper.emplace(page.GetBuffer(), sourceIndex);
+
+   auto clusterId = fDescriptor.FindClusterId(columnHandle.fId, globalIndex);
+   auto selfOffset = fDescriptor.GetClusterDescriptor(clusterId).GetColumnRange(columnHandle.fId).fFirstElementIndex;
+   auto clusterInfo = RPage::RClusterInfo(clusterId, selfOffset);
+
+   page.SetWindow(page.GetGlobalRangeFirst() + fNElementsPerColumnPerSource.at(sourceIndex).at(columnHandle.fId),
+                  clusterInfo);
+   return page;
+}
+
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPageSourceChain::PopulatePage(ColumnHandle_t columnHandle,
+                                                           const RClusterIndex &clusterIndex)
+{
+   auto clusterId = clusterIndex.GetClusterId();
+   std::size_t sourceIndex{0};
+   for (; sourceIndex < fSources.size(); ++sourceIndex) {
+      if (clusterId < fNClusterPerSource.at(sourceIndex + 1))
+         break;
+   }
+   R__ASSERT(sourceIndex != fSources.size() && "clusterIndex is bigger than total number of entries.");
+
+   RClusterIndex newClusterIndex(clusterIndex.GetClusterId() - fNClusterPerSource.at(sourceIndex),
+                                 clusterIndex.GetIndex());
+   RPage page{fSources.at(sourceIndex)->PopulatePage(columnHandle, newClusterIndex)};
+   fPageMapper.emplace(page.GetBuffer(), sourceIndex);
+
+   auto selfOffset = fDescriptor.GetClusterDescriptor(clusterId).GetColumnRange(columnHandle.fId).fFirstElementIndex;
+   auto clusterInfo = RPage::RClusterInfo(clusterId, selfOffset);
+
+   page.SetWindow(page.GetGlobalRangeFirst() + fNElementsPerColumnPerSource.at(sourceIndex).at(columnHandle.fId),
+                  clusterInfo);
+   return page;
+}
+
+void ROOT::Experimental::Detail::RPageSourceChain::ReleasePage(RPage &page)
+{
+   if (page.IsNull())
+      return;
+   for (const auto &m : fPageMapper) {
+      if (m.first == page.GetBuffer()) {
+         fSources.at(m.second)->ReleasePage(page);
+         // Sometimes malloc allocates the same memory location as a previous malloc.
+         // To avoid a collision of keys for such cases, the entry is deleted from std::unordered_map when released.
+         fPageMapper.erase(m.first);
+         return;
+      }
+   }
+   R__ASSERT(false && "Page could not be assigned to source and released.");
+}
+
+void ROOT::Experimental::Detail::RPageSourceChain::GetHeaderAndFooter(RNTupleDescriptorBuilder &descBuilder)
+{
+   fSources.at(0)->GetHeaderAndFooter(descBuilder);
+   for (std::size_t i = 1; i < fSources.size(); ++i) {
+      descBuilder.AddClustersFromAdditionalFile(fSources.at(i)->GetDescriptor());
+   }
+}

--- a/tree/ntuple/v7/src/RPageStorageRaw.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRaw.cxx
@@ -215,7 +215,7 @@ void ROOT::Experimental::Detail::RPageSourceRaw::GetHeaderAndFooter(RNTupleDescr
    R__ASSERT(fileSize >= RNTupleDescriptor::kNBytesPostscript);
    auto offset = fileSize - RNTupleDescriptor::kNBytesPostscript;
    Read(postscript, RNTupleDescriptor::kNBytesPostscript, offset);
-   
+
    std::uint32_t szHeader;
    std::uint32_t szFooter;
    RNTupleDescriptor::LocateMetadata(postscript, szHeader, szFooter);

--- a/tree/ntuple/v7/src/RPageStorageRaw.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRaw.cxx
@@ -206,6 +206,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceRaw
    return descBuilder.MoveDescriptor();
 }
 
+
 void ROOT::Experimental::Detail::RPageSourceRaw::GetHeaderAndFooter(RNTupleDescriptorBuilder &descBuilder)
 {
    unsigned char postscript[RNTupleDescriptor::kNBytesPostscript];
@@ -219,17 +220,18 @@ void ROOT::Experimental::Detail::RPageSourceRaw::GetHeaderAndFooter(RNTupleDescr
    std::uint32_t szFooter;
    RNTupleDescriptor::LocateMetadata(postscript, szHeader, szFooter);
    R__ASSERT(fileSize >= szHeader + szFooter);
-   
+
    unsigned char *header = new unsigned char[szHeader];
    unsigned char *footer = new unsigned char[szFooter];
    Read(header, szHeader, 0);
    Read(footer, szFooter, fileSize - szFooter);
-   
+
    descBuilder.SetFromHeader(header);
    descBuilder.AddClustersFromFooter(footer);
    delete[] header;
    delete[] footer;
 }
+
 
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceRaw::PopulatePageFromCluster(
    ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor, ClusterSize_t::ValueType clusterIndex)

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -186,6 +186,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceRoo
    return descBuilder.MoveDescriptor();
 }
 
+
 void ROOT::Experimental::Detail::RPageSourceRoot::GetHeaderAndFooter(RNTupleDescriptorBuilder &descBuilder)
 {
    auto keyRawNTupleHeader = fDirectory->GetKey(kKeyNTupleHeader);
@@ -193,7 +194,7 @@ void ROOT::Experimental::Detail::RPageSourceRoot::GetHeaderAndFooter(RNTupleDesc
    descBuilder.SetFromHeader(ntupleRawHeader->fContent);
    free(ntupleRawHeader->fContent);
    delete ntupleRawHeader;
-   
+
    auto keyRawNTupleFooter = fDirectory->GetKey(kKeyNTupleFooter);
    auto ntupleRawFooter = keyRawNTupleFooter->ReadObject<ROOT::Experimental::Internal::RNTupleBlob>();
    descBuilder.AddClustersFromFooter(ntupleRawFooter->fContent);

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -182,20 +182,23 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceRoo
 {
    fDirectory = fFile->GetDirectory(fNTupleName.c_str());
    RNTupleDescriptorBuilder descBuilder;
+   GetHeaderAndFooter(descBuilder);
+   return descBuilder.MoveDescriptor();
+}
 
+void ROOT::Experimental::Detail::RPageSourceRoot::GetHeaderAndFooter(RNTupleDescriptorBuilder &descBuilder)
+{
    auto keyRawNTupleHeader = fDirectory->GetKey(kKeyNTupleHeader);
    auto ntupleRawHeader = keyRawNTupleHeader->ReadObject<ROOT::Experimental::Internal::RNTupleBlob>();
    descBuilder.SetFromHeader(ntupleRawHeader->fContent);
    free(ntupleRawHeader->fContent);
    delete ntupleRawHeader;
-
+   
    auto keyRawNTupleFooter = fDirectory->GetKey(kKeyNTupleFooter);
    auto ntupleRawFooter = keyRawNTupleFooter->ReadObject<ROOT::Experimental::Internal::RNTupleBlob>();
    descBuilder.AddClustersFromFooter(ntupleRawFooter->fContent);
    free(ntupleRawFooter->fContent);
    delete ntupleRawFooter;
-
-   return descBuilder.MoveDescriptor();
 }
 
 

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -17,6 +17,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(CustomStruct
                               LINKDEF CustomStructLinkDef.h
                               DEPENDENCIES RIO)
 ROOT_ADD_GTEST(ntuple ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+ROOT_ADD_GTEST(ntuple_combine ntuple_combine.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_packing ntuple_packing.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_pages ntuple_pages.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_print ntuple_print.cxx LIBRARIES ROOTNTuple)

--- a/tree/ntuple/v7/test/ntuple_combine.cxx
+++ b/tree/ntuple/v7/test/ntuple_combine.cxx
@@ -234,58 +234,58 @@ TEST(RNTupleChain, threeFiles)
    auto mergedStringView = ntuple->GetView<std::string>("st");
 
    // There are errors which only occur when the views are mixed up.
-   EXPECT_FLOAT_EQ(floatView(0), 5.0f);
-   EXPECT_FLOAT_EQ(floatView(14), 9.0f);
-   EXPECT_FLOAT_EQ(floatView(15), 10.0f);
-   EXPECT_FLOAT_EQ(floatView(1), 6.0f);
-   EXPECT_FLOAT_EQ(mergedfloatView(7), 6.0f);
-   EXPECT_FLOAT_EQ(floatView(2), 7.0f);
-   EXPECT_FLOAT_EQ(mergedfloatView(13), 8.0f);
-   EXPECT_FLOAT_EQ(floatView(5), 10.0f);
-   EXPECT_FLOAT_EQ(floatView(6), 11.0f);
-   EXPECT_FLOAT_EQ(floatView(10), 9.0f);
-   EXPECT_FLOAT_EQ(floatView(11), 10.0f);
-   EXPECT_FLOAT_EQ(floatView(7), 6.0f);
-   EXPECT_FLOAT_EQ(floatView(8), 7.0f);
-   EXPECT_FLOAT_EQ(floatView(9), 8.0f);
-   EXPECT_FLOAT_EQ(mergedfloatView(4), 9.0f);
-   EXPECT_FLOAT_EQ(floatView(12009), 12004.0f);
-   EXPECT_FLOAT_EQ(floatView(3), 8.0f);
-   EXPECT_FLOAT_EQ(floatView(4), 9.0f);
-   EXPECT_FLOAT_EQ(floatView(13), 8.0f);
-   EXPECT_FLOAT_EQ(mergedfloatView(0), 5.0f);
-   EXPECT_FLOAT_EQ(floatView(16), 11.0f);
-   EXPECT_FLOAT_EQ(floatView(17), 12.0f);
-   EXPECT_FLOAT_EQ(floatView(50000), 49995.0f);
+   EXPECT_FLOAT_EQ(5.0f, floatView(0));
+   EXPECT_FLOAT_EQ(9.0f, floatView(14));
+   EXPECT_FLOAT_EQ(10.0f, floatView(15));
+   EXPECT_FLOAT_EQ(6.0f, floatView(1));
+   EXPECT_FLOAT_EQ(6.0f, mergedfloatView(7));
+   EXPECT_FLOAT_EQ(7.0f, floatView(2));
+   EXPECT_FLOAT_EQ(8.0f, mergedfloatView(13));
+   EXPECT_FLOAT_EQ(10.0f, floatView(5));
+   EXPECT_FLOAT_EQ(11.0f, floatView(6));
+   EXPECT_FLOAT_EQ(9.0f, floatView(10));
+   EXPECT_FLOAT_EQ(10.0f, floatView(11));
+   EXPECT_FLOAT_EQ(6.0f, floatView(7));
+   EXPECT_FLOAT_EQ(7.0f, floatView(8));
+   EXPECT_FLOAT_EQ(8.0f, floatView(9));
+   EXPECT_FLOAT_EQ(9.0f, mergedfloatView(4));
+   EXPECT_FLOAT_EQ(12004.0f, floatView(12009));
+   EXPECT_FLOAT_EQ(8.0f, floatView(3));
+   EXPECT_FLOAT_EQ(9.0f, floatView(4));
+   EXPECT_FLOAT_EQ(8.0f, floatView(13));
+   EXPECT_FLOAT_EQ(5.0f, mergedfloatView(0));
+   EXPECT_FLOAT_EQ(11.0f, floatView(16));
+   EXPECT_FLOAT_EQ(12.0f, floatView(17));
+   EXPECT_FLOAT_EQ(49995.0f, floatView(50000));
 
-   EXPECT_EQ(stringView(14), "14");
-   EXPECT_EQ(stringView(0), "foofoofoo");
-   EXPECT_EQ(stringView(1), "foofoofoo");
-   EXPECT_EQ(stringView(1034), "1034");
-   EXPECT_EQ(stringView(2), "foofoofoo");
-   EXPECT_EQ(mergedStringView(6), "foofoofoo");
-   EXPECT_EQ(stringView(3), "foofoofoo");
-   EXPECT_EQ(stringView(8), "foo");
-   EXPECT_EQ(stringView(5), "foofoofoo");
-   EXPECT_EQ(mergedStringView(17), "17");
-   EXPECT_EQ(stringView(6), "foofoofoo");
-   EXPECT_EQ(mergedStringView(8), "foo");
-   EXPECT_EQ(stringView(7), "foo");
-   EXPECT_EQ(stringView(13), "13");
-   EXPECT_EQ(mergedStringView(0), "foofoofoo");
-   EXPECT_EQ(stringView(9), "foo");
-   EXPECT_EQ(stringView(10), "foo");
-   EXPECT_EQ(mergedStringView(7), "foo");
-   EXPECT_EQ(stringView(11), "foo");
-   EXPECT_EQ(mergedStringView(4), "foofoofoo");
-   EXPECT_EQ(stringView(12), "12");
-   EXPECT_EQ(mergedStringView(14), "14");
-   EXPECT_EQ(stringView(4), "foofoofoo");
-   EXPECT_EQ(stringView(17003), "17003");
-   EXPECT_EQ(stringView(15), "15");
-   EXPECT_EQ(stringView(34567), "34567");
-   EXPECT_EQ(stringView(1680), "1680");
-   EXPECT_EQ(stringView(60010), "60010");
+   EXPECT_EQ("14", stringView(14));
+   EXPECT_EQ("foofoofoo", stringView(0));
+   EXPECT_EQ("foofoofoo", stringView(1));
+   EXPECT_EQ("1034", stringView(1034));
+   EXPECT_EQ("foofoofoo", stringView(2));
+   EXPECT_EQ("foofoofoo", mergedStringView(6));
+   EXPECT_EQ("foofoofoo", stringView(3));
+   EXPECT_EQ("foo", stringView(8));
+   EXPECT_EQ("foofoofoo", stringView(5));
+   EXPECT_EQ("17", mergedStringView(17));
+   EXPECT_EQ("foofoofoo", stringView(6));
+   EXPECT_EQ("foo", mergedStringView(8));
+   EXPECT_EQ("foo", stringView(7));
+   EXPECT_EQ("13", stringView(13));
+   EXPECT_EQ("foofoofoo", mergedStringView(0));
+   EXPECT_EQ("foo", stringView(9));
+   EXPECT_EQ("foo", stringView(10));
+   EXPECT_EQ("foo", mergedStringView(7));
+   EXPECT_EQ("foo", stringView(11));
+   EXPECT_EQ("foofoofoo", mergedStringView(4));
+   EXPECT_EQ("12", stringView(12));
+   EXPECT_EQ("14", mergedStringView(14));
+   EXPECT_EQ("foofoofoo", stringView(4));
+   EXPECT_EQ("17003", stringView(17003));
+   EXPECT_EQ("15", stringView(15));
+   EXPECT_EQ("34567", stringView(34567));
+   EXPECT_EQ("1680", stringView(1680));
+   EXPECT_EQ("60010", stringView(60010));
    // TODO (lesimon): Check if RNTupleReader::Show() leads to desired output.
 }
 
@@ -320,51 +320,51 @@ TEST(RNTupleChain, ChainOfChain)
    auto doubleView3 = ntupleChainOfChain->GetView<double>("db");
    auto stringView3 = ntupleChainOfChain->GetView<std::string>("st");
 
-   EXPECT_DOUBLE_EQ(doubleView(0), 5.0f);
-   EXPECT_DOUBLE_EQ(doubleView(1), 6.0f);
-   EXPECT_DOUBLE_EQ(doubleView(2), 7.0f);
-   EXPECT_EQ(stringView(0), "foo0");
-   EXPECT_EQ(stringView(1), "foo1");
-   EXPECT_EQ(stringView(2), "foo2");
+   EXPECT_DOUBLE_EQ(5.0f, doubleView(0));
+   EXPECT_DOUBLE_EQ(6.0f, doubleView(1));
+   EXPECT_DOUBLE_EQ(7.0f, doubleView(2));
+   EXPECT_EQ("foo0", stringView(0));
+   EXPECT_EQ("foo1", stringView(1));
+   EXPECT_EQ("foo2", stringView(2));
 
-   EXPECT_DOUBLE_EQ(doubleView2(0), 5.0f);
-   EXPECT_DOUBLE_EQ(doubleView2(1), 6.0f);
-   EXPECT_DOUBLE_EQ(doubleView2(2), 7.0f);
-   EXPECT_DOUBLE_EQ(doubleView2(3), 5.0f);
-   EXPECT_DOUBLE_EQ(doubleView2(4), 6.0f);
-   EXPECT_DOUBLE_EQ(doubleView2(5), 7.0f);
+   EXPECT_DOUBLE_EQ(5.0f, doubleView2(0));
+   EXPECT_DOUBLE_EQ(6.0f, doubleView2(1));
+   EXPECT_DOUBLE_EQ(7.0f, doubleView2(2));
+   EXPECT_DOUBLE_EQ(5.0f, doubleView2(3));
+   EXPECT_DOUBLE_EQ(6.0f, doubleView2(4));
+   EXPECT_DOUBLE_EQ(7.0f, doubleView2(5));
 
-   EXPECT_EQ(stringView2(0), "foo0");
-   EXPECT_EQ(stringView2(1), "foo1");
-   EXPECT_EQ(stringView2(2), "foo2");
-   EXPECT_EQ(stringView2(3), "foo0");
-   EXPECT_EQ(stringView2(4), "foo1");
-   EXPECT_EQ(stringView2(5), "foo2");
+   EXPECT_EQ("foo0", stringView2(0));
+   EXPECT_EQ("foo1", stringView2(1));
+   EXPECT_EQ("foo2", stringView2(2));
+   EXPECT_EQ("foo0", stringView2(3));
+   EXPECT_EQ("foo1", stringView2(4));
+   EXPECT_EQ("foo2", stringView2(5));
 
-   EXPECT_DOUBLE_EQ(doubleView3(0), 5.0);
-   EXPECT_DOUBLE_EQ(doubleView3(1), 6.0);
-   EXPECT_DOUBLE_EQ(doubleView3(2), 7.0);
-   EXPECT_DOUBLE_EQ(doubleView3(3), 5.0);
-   EXPECT_DOUBLE_EQ(doubleView3(4), 6.0);
-   EXPECT_DOUBLE_EQ(doubleView3(5), 7.0);
-   EXPECT_DOUBLE_EQ(doubleView3(6), 5.0);
-   EXPECT_DOUBLE_EQ(doubleView3(7), 6.0);
-   EXPECT_DOUBLE_EQ(doubleView3(8), 7.0);
-   EXPECT_DOUBLE_EQ(doubleView3(9), 5.0);
-   EXPECT_DOUBLE_EQ(doubleView3(10), 6.0);
-   EXPECT_DOUBLE_EQ(doubleView3(11), 7.0);
-   EXPECT_EQ(stringView3(0), "foo0");
-   EXPECT_EQ(stringView3(1), "foo1");
-   EXPECT_EQ(stringView3(2), "foo2");
-   EXPECT_EQ(stringView3(3), "foo0");
-   EXPECT_EQ(stringView3(4), "foo1");
-   EXPECT_EQ(stringView3(5), "foo2");
-   EXPECT_EQ(stringView3(6), "foo0");
-   EXPECT_EQ(stringView3(7), "foo1");
-   EXPECT_EQ(stringView3(8), "foo2");
-   EXPECT_EQ(stringView3(9), "foo0");
-   EXPECT_EQ(stringView3(10), "foo1");
-   EXPECT_EQ(stringView3(11), "foo2");
+   EXPECT_DOUBLE_EQ(5.0, doubleView3(0));
+   EXPECT_DOUBLE_EQ(6.0, doubleView3(1));
+   EXPECT_DOUBLE_EQ(7.0, doubleView3(2));
+   EXPECT_DOUBLE_EQ(5.0, doubleView3(3));
+   EXPECT_DOUBLE_EQ(6.0, doubleView3(4));
+   EXPECT_DOUBLE_EQ(7.0, doubleView3(5));
+   EXPECT_DOUBLE_EQ(5.0, doubleView3(6));
+   EXPECT_DOUBLE_EQ(6.0, doubleView3(7));
+   EXPECT_DOUBLE_EQ(7.0, doubleView3(8));
+   EXPECT_DOUBLE_EQ(5.0, doubleView3(9));
+   EXPECT_DOUBLE_EQ(6.0, doubleView3(10));
+   EXPECT_DOUBLE_EQ(7.0, doubleView3(11));
+   EXPECT_EQ("foo0", stringView3(0));
+   EXPECT_EQ("foo1", stringView3(1));
+   EXPECT_EQ("foo2", stringView3(2));
+   EXPECT_EQ("foo0", stringView3(3));
+   EXPECT_EQ("foo1", stringView3(4));
+   EXPECT_EQ("foo2", stringView3(5));
+   EXPECT_EQ("foo0", stringView3(6));
+   EXPECT_EQ("foo1", stringView3(7));
+   EXPECT_EQ("foo2", stringView3(8));
+   EXPECT_EQ("foo0", stringView3(9));
+   EXPECT_EQ("foo1", stringView3(10));
+   EXPECT_EQ("foo2", stringView3(11));
 }
 
 TEST(RNTupleChain, ChainOfChainWithStdMove)
@@ -395,41 +395,69 @@ TEST(RNTupleChain, ChainOfChainWithStdMove)
    auto doubleView = ntupleChainOfChain->GetView<double>("db");
    auto stringView = ntupleChainOfChain->GetView<std::string>("st");
 
-   EXPECT_DOUBLE_EQ(doubleView(0), 5.0);
-   EXPECT_DOUBLE_EQ(doubleView(1), 6.0);
-   EXPECT_DOUBLE_EQ(doubleView(2), 7.0);
-   EXPECT_DOUBLE_EQ(doubleView(10000), 10005.0);
-   EXPECT_DOUBLE_EQ(doubleView(10001), 10006.0);
-   EXPECT_DOUBLE_EQ(doubleView(21000), 5.0);
-   EXPECT_DOUBLE_EQ(doubleView(21001), 6.0);
-   EXPECT_DOUBLE_EQ(doubleView(21002), 7.0);
-   EXPECT_DOUBLE_EQ(doubleView(31000), 10005.0);
-   EXPECT_DOUBLE_EQ(doubleView(63001), 6.0);
-   EXPECT_DOUBLE_EQ(doubleView(31001), 10006.0);
-   EXPECT_DOUBLE_EQ(doubleView(42000), 5.0);
-   EXPECT_DOUBLE_EQ(doubleView(42001), 6.0);
-   EXPECT_DOUBLE_EQ(doubleView(42002), 7.0);
-   EXPECT_DOUBLE_EQ(doubleView(52000), 10005.0);
-   EXPECT_DOUBLE_EQ(doubleView(52001), 10006.0);
-   EXPECT_DOUBLE_EQ(doubleView(63000), 5.0);
-   EXPECT_DOUBLE_EQ(doubleView(63002), 7.0);
-   EXPECT_EQ(stringView(0), "foo0");
-   EXPECT_EQ(stringView(1), "foo1");
-   EXPECT_EQ(stringView(2), "foo2");
-   EXPECT_EQ(stringView(10000), "foo10000");
-   EXPECT_EQ(stringView(10001), "foo10001");
-   EXPECT_EQ(stringView(21000), "foo0");
-   EXPECT_EQ(stringView(21001), "foo1");
-   EXPECT_EQ(stringView(21002), "foo2");
-   EXPECT_EQ(stringView(63000), "foo0");
-   EXPECT_EQ(stringView(63001), "foo1");
-   EXPECT_EQ(stringView(31000), "foo10000");
-   EXPECT_EQ(stringView(31001), "foo10001");
-   EXPECT_EQ(stringView(42000), "foo0");
-   EXPECT_EQ(stringView(42001), "foo1");
-   EXPECT_EQ(stringView(42002), "foo2");
-   EXPECT_EQ(stringView(52000), "foo10000");
-   EXPECT_EQ(stringView(52001), "foo10001");
-   EXPECT_EQ(stringView(63002), "foo2");
+   EXPECT_DOUBLE_EQ(5.0, doubleView(0));
+   EXPECT_DOUBLE_EQ(6.0, doubleView(1));
+   EXPECT_DOUBLE_EQ(7.0, doubleView(2));
+   EXPECT_DOUBLE_EQ(10005.0, doubleView(10000));
+   EXPECT_DOUBLE_EQ(10006.0, doubleView(10001));
+   EXPECT_DOUBLE_EQ(5.0, doubleView(21000));
+   EXPECT_DOUBLE_EQ(6.0, doubleView(21001));
+   EXPECT_DOUBLE_EQ(7.0, doubleView(21002));
+   EXPECT_DOUBLE_EQ(10005.0, doubleView(31000));
+   EXPECT_DOUBLE_EQ(6.0, doubleView(63001));
+   EXPECT_DOUBLE_EQ(10006.0, doubleView(31001));
+   EXPECT_DOUBLE_EQ(5.0, doubleView(42000));
+   EXPECT_DOUBLE_EQ(6.0, doubleView(42001));
+   EXPECT_DOUBLE_EQ(7.0, doubleView(42002));
+   EXPECT_DOUBLE_EQ(10005.0, doubleView(52000));
+   EXPECT_DOUBLE_EQ(10006.0, doubleView(52001));
+   EXPECT_DOUBLE_EQ(5.0, doubleView(63000));
+   EXPECT_DOUBLE_EQ(7.0, doubleView(63002));
+   EXPECT_EQ("foo0", stringView(0));
+   EXPECT_EQ("foo1", stringView(1));
+   EXPECT_EQ("foo2", stringView(2));
+   EXPECT_EQ("foo10000", stringView(10000));
+   EXPECT_EQ("foo10001", stringView(10001));
+   EXPECT_EQ("foo0", stringView(21000));
+   EXPECT_EQ("foo1", stringView(21001));
+   EXPECT_EQ("foo2", stringView(21002));
+   EXPECT_EQ("foo0", stringView(63000));
+   EXPECT_EQ("foo1", stringView(63001));
+   EXPECT_EQ("foo10000", stringView(31000));
+   EXPECT_EQ("foo10001", stringView(31001));
+   EXPECT_EQ("foo0", stringView(42000));
+   EXPECT_EQ("foo1", stringView(42001));
+   EXPECT_EQ("foo2", stringView(42002));
+   EXPECT_EQ("foo10000", stringView(52000));
+   EXPECT_EQ("foo10001", stringView(52001));
+   EXPECT_EQ("foo2", stringView(63002));
 }
 
+// When a cached page is returned in RPageSourceRoot::PopulatePage(), 2 pages with the same buffer will exist.
+// This test should check if RNTupleChain can deal with such a situation.
+TEST(RNTupleChain, CachedPage)
+{
+   const std::string ntupleName = "CachedPageNTuple";
+   FileRaii fileGuard("test_ntuple_chain_cachedPage.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto boField = model->MakeField<bool>("bo");
+      auto u64Field = model->MakeField<std::uint64_t>("u64");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+
+      for (unsigned int i = 0; i < 10; ++i) {
+         *boField = i%2;
+         *u64Field = i;
+         *stField = std::to_string(i) + "-th entry";
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open(ntupleName, { fileGuard.GetPath(), fileGuard.GetPath() });
+   auto ntupleView1 = ntuple->GetView<bool>("bo");
+   auto ntupleView2 = ntuple->GetView<bool>("bo");
+
+   EXPECT_EQ(true, ntupleView1(11));
+   EXPECT_EQ(false, ntupleView2(12));
+}

--- a/tree/ntuple/v7/test/ntuple_combine.cxx
+++ b/tree/ntuple/v7/test/ntuple_combine.cxx
@@ -3,11 +3,7 @@
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleModel.hxx>
 
-#include <TBranch.h>
 #include <TFile.h>
-#include <TLeaf.h>
-#include <TSystem.h>
-#include <TTree.h>
 
 #include "gtest/gtest.h"
 

--- a/tree/ntuple/v7/test/ntuple_combine.cxx
+++ b/tree/ntuple/v7/test/ntuple_combine.cxx
@@ -7,7 +7,6 @@
 
 #include "gtest/gtest.h"
 
-#include <cassert>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -405,6 +404,7 @@ TEST(RNTupleChain, ChainOfChainWithStdMove)
    EXPECT_DOUBLE_EQ(doubleView(21001), 6.0);
    EXPECT_DOUBLE_EQ(doubleView(21002), 7.0);
    EXPECT_DOUBLE_EQ(doubleView(31000), 10005.0);
+   EXPECT_DOUBLE_EQ(doubleView(63001), 6.0);
    EXPECT_DOUBLE_EQ(doubleView(31001), 10006.0);
    EXPECT_DOUBLE_EQ(doubleView(42000), 5.0);
    EXPECT_DOUBLE_EQ(doubleView(42001), 6.0);
@@ -412,7 +412,6 @@ TEST(RNTupleChain, ChainOfChainWithStdMove)
    EXPECT_DOUBLE_EQ(doubleView(52000), 10005.0);
    EXPECT_DOUBLE_EQ(doubleView(52001), 10006.0);
    EXPECT_DOUBLE_EQ(doubleView(63000), 5.0);
-   EXPECT_DOUBLE_EQ(doubleView(63001), 6.0);
    EXPECT_DOUBLE_EQ(doubleView(63002), 7.0);
    EXPECT_EQ(stringView(0), "foo0");
    EXPECT_EQ(stringView(1), "foo1");
@@ -422,6 +421,8 @@ TEST(RNTupleChain, ChainOfChainWithStdMove)
    EXPECT_EQ(stringView(21000), "foo0");
    EXPECT_EQ(stringView(21001), "foo1");
    EXPECT_EQ(stringView(21002), "foo2");
+   EXPECT_EQ(stringView(63000), "foo0");
+   EXPECT_EQ(stringView(63001), "foo1");
    EXPECT_EQ(stringView(31000), "foo10000");
    EXPECT_EQ(stringView(31001), "foo10001");
    EXPECT_EQ(stringView(42000), "foo0");
@@ -429,8 +430,6 @@ TEST(RNTupleChain, ChainOfChainWithStdMove)
    EXPECT_EQ(stringView(42002), "foo2");
    EXPECT_EQ(stringView(52000), "foo10000");
    EXPECT_EQ(stringView(52001), "foo10001");
-   EXPECT_EQ(stringView(63000), "foo0");
-   EXPECT_EQ(stringView(63001), "foo1");
    EXPECT_EQ(stringView(63002), "foo2");
 }
 

--- a/tree/ntuple/v7/test/ntuple_combine.cxx
+++ b/tree/ntuple/v7/test/ntuple_combine.cxx
@@ -1,0 +1,440 @@
+#include <ROOT/RField.hxx>
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RNTupleModel.hxx>
+
+#include <TBranch.h>
+#include <TFile.h>
+#include <TLeaf.h>
+#include <TSystem.h>
+#include <TTree.h>
+
+#include "gtest/gtest.h"
+
+#include <cassert>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
+using RNTupleReader = ROOT::Experimental::RNTupleReader;
+using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
+using RNTupleModel = ROOT::Experimental::RNTupleModel;
+using RNTupleDescriptor = ROOT::Experimental::RNTupleDescriptor;
+
+namespace {
+   /**
+    * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
+    * goes out of scope.
+    */
+   class FileRaii {
+   private:
+      std::string fPath;
+      TFile *file;
+   public:
+      FileRaii(const std::string &path) :
+         fPath(path),
+         file(TFile::Open(fPath.c_str(), "RECREATE"))
+         { }
+      FileRaii(const FileRaii&) = delete;
+      FileRaii& operator=(const FileRaii&) = delete;
+      TFile* GetFile() const { return file; }
+      std::string GetPath() const { return fPath; }
+      ~FileRaii() {
+         file->Close();
+         std::remove(fPath.c_str());
+      }
+   };
+} // anonymous namespace
+
+// -------------------------- helper functions ---------------------------------
+
+bool CompareFields (const RNTupleDescriptor &desc1, const RNTupleDescriptor &desc2) {
+   if (desc1.GetNFields() != desc2.GetNFields())
+      return false;
+   for (std::size_t i = 0; i < desc1.GetNFields(); ++i) {
+      if (desc1.GetFieldDescriptor(i) == desc2.GetFieldDescriptor(i))
+         return true;
+   }
+   return false;
+}
+
+bool CompareColumns (const RNTupleDescriptor &desc1, const RNTupleDescriptor &desc2) {
+   if(desc1.GetNColumns() != desc2.GetNColumns())
+      return false;
+   for (std::size_t i = 0; i < desc1.GetNColumns(); ++i) {
+      if (desc1.GetColumnDescriptor(i) == desc2.GetColumnDescriptor(i))
+         return true;
+   }
+   return false;
+}
+
+bool CompareClusters (const RNTupleDescriptor &desc1, const RNTupleDescriptor &desc2) {
+   if(desc1.GetNClusters() != desc2.GetNClusters())
+      return false;
+   for (std::size_t i = 0; i < desc1.GetNClusters(); ++i) {
+      if (desc1.GetClusterDescriptor(i) == desc2.GetClusterDescriptor(i))
+         return true;
+   }
+   return false;
+}
+
+bool DescriptorsAreSame(const RNTupleDescriptor &desc1, const RNTupleDescriptor &desc2) {
+   return ( CompareFields(desc1, desc2) && CompareColumns(desc1, desc2) && CompareClusters(desc1, desc2) );
+}
+
+// ------------------------------------------- Tests ------------------------------------------
+
+TEST(RNTupleChain, noFiles)
+{
+   const std::string_view ntupleName = "noFilesNTuple";
+   auto ntuple = RNTupleReader::Open(ntupleName,  std::vector<std::string>{ });
+   EXPECT_EQ(ntuple, nullptr);
+}
+
+TEST(RNTupleChain, oneFile)
+{
+   const std::string_view ntupleName = "oneFileNTuple";
+   FileRaii fileGuard("test_ntuple_chain_oneFile.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto dbField = model->MakeField<double>("db");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      
+      for (int i = 0; i < 3; ++i) {
+         *dbField = 5.0+i;
+         *stField = "foo";
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
+   auto ntupleVec = RNTupleReader::Open(ntupleName, std::vector<std::string>{ fileGuard.GetPath() });
+   EXPECT_TRUE(DescriptorsAreSame(ntuple->GetDescriptor(), ntupleVec->GetDescriptor()));
+}
+
+TEST(RNTupleChain, twiceSameFile)
+{
+   const std::string ntupleName = "twiceSameFileNTuple";
+   FileRaii fileGuard("test_ntuple_chain_twiceSameFile.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto itField = model->MakeField<int>("it");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+
+      for (int i = 0; i < 3; ++i) {
+         *itField = 5+i;
+         *stField = "boo";
+         ntuple->Fill();
+      }
+   }
+
+   const std::string ntupleName2 = "twiceSameFileNTupleMerged";
+   FileRaii fileGuardmerged("test_ntuple_chain_twiceSameFile_merged.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto itField = model->MakeField<int>("it");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName2, fileGuardmerged.GetPath());
+   
+      for (int i = 0; i < 6; ++i) {
+         *itField = 5+i;
+         *stField = "boo";
+         ntuple->Fill();
+         if (i == 2) ntuple->CommitCluster();
+      }
+   }
+
+   auto ntuple1 = RNTupleReader::Open(ntupleName, { fileGuard.GetPath(), fileGuard.GetPath() } );
+   auto ntuple2 = RNTupleReader::Open(ntupleName2, fileGuardmerged.GetPath() );
+   EXPECT_TRUE(DescriptorsAreSame(ntuple1->GetDescriptor(), ntuple2->GetDescriptor()));
+}
+
+TEST(RNTupleChain, threeFiles)
+{
+   const std::string_view ntupleName = "threeFilesNTuple";
+   FileRaii fileGuard1("test_ntuple_chain_threeFiles_first_file.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto ftField = model->MakeField<float>("ft");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard1.GetPath());
+      
+      for (int i = 0; i < 7; ++i) {
+         *ftField = 5.0f+(float)i;
+         *stField = "foofoofoo";
+         ntuple->Fill();
+         if ( i == 3) ntuple->CommitCluster();
+      }
+   }
+
+   // Note that a raw file is created here instead of a .root file.
+   FileRaii fileGuard2("test_ntuple_chain_threeFiles_second_file.ntuple");
+   {
+      auto model = RNTupleModel::Create();
+      auto ftField = model->MakeField<float>("ft");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard2.GetPath());
+      
+      for (int i = 0; i < 5; ++i) {
+         *ftField = 6.0f+(float)i;
+         *stField = "foo";
+         ntuple->Fill();
+      }
+   }
+
+   FileRaii fileGuard3("test_ntuple_chain_threeFiles_third_file.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto ftField = model->MakeField<float>("ft");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard3.GetPath());
+      
+      for (int i = 0; i < 60000; ++i) {
+         *ftField = 7.0f+(float)i;
+         *stField = std::to_string(i+12);
+         ntuple->Fill();
+      }
+   }
+
+   FileRaii fileGuardmerged("test_ntuple_chain_threeFiles_mergedfile.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto ftField = model->MakeField<float>("ft");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuardmerged.GetPath());
+
+      for (int i = 0; i < 7; ++i) {
+         *ftField = 5.0f+(float)i;
+         *stField = "foofoofoo";
+         ntuple->Fill();
+         if ( i == 3) ntuple->CommitCluster();
+      }
+      ntuple->CommitCluster();
+      for (int i = 0; i < 5; ++i) {
+         *ftField = 6.0f+(float)i;
+         *stField = "foo";
+         ntuple->Fill();
+      }
+      ntuple->CommitCluster();
+      for (int i = 0; i < 60000; ++i) {
+         *ftField = 7.0f+(float)i;
+         *stField = std::to_string(i+12);
+         ntuple->Fill();
+      }
+   }
+
+   auto ntupleVec = RNTupleReader::Open(ntupleName, { fileGuard1.GetPath(), fileGuard2.GetPath(), fileGuard3.GetPath() });
+   auto ntuple = RNTupleReader::Open(ntupleName, fileGuardmerged.GetPath());
+
+   EXPECT_TRUE(DescriptorsAreSame(ntuple->GetDescriptor(), ntupleVec->GetDescriptor()));
+
+   auto floatView = ntupleVec->GetView<float>("ft");
+   auto stringView = ntupleVec->GetView<std::string>("st");
+
+   auto mergedfloatView = ntuple->GetView<float>("ft");
+   auto mergedStringView = ntuple->GetView<std::string>("st");
+
+   // There are errors which only occur when the views are mixed up.
+   EXPECT_FLOAT_EQ(floatView(0), 5.0f);
+   EXPECT_FLOAT_EQ(floatView(14), 9.0f);
+   EXPECT_FLOAT_EQ(floatView(15), 10.0f);
+   EXPECT_FLOAT_EQ(floatView(1), 6.0f);
+   EXPECT_FLOAT_EQ(mergedfloatView(7), 6.0f);
+   EXPECT_FLOAT_EQ(floatView(2), 7.0f);
+   EXPECT_FLOAT_EQ(mergedfloatView(13), 8.0f);
+   EXPECT_FLOAT_EQ(floatView(5), 10.0f);
+   EXPECT_FLOAT_EQ(floatView(6), 11.0f);
+   EXPECT_FLOAT_EQ(floatView(10), 9.0f);
+   EXPECT_FLOAT_EQ(floatView(11), 10.0f);
+   EXPECT_FLOAT_EQ(floatView(7), 6.0f);
+   EXPECT_FLOAT_EQ(floatView(8), 7.0f);
+   EXPECT_FLOAT_EQ(floatView(9), 8.0f);
+   EXPECT_FLOAT_EQ(mergedfloatView(4), 9.0f);
+   EXPECT_FLOAT_EQ(floatView(12009), 12004.0f);
+   EXPECT_FLOAT_EQ(floatView(3), 8.0f);
+   EXPECT_FLOAT_EQ(floatView(4), 9.0f);
+   EXPECT_FLOAT_EQ(floatView(13), 8.0f);
+   EXPECT_FLOAT_EQ(mergedfloatView(0), 5.0f);
+   EXPECT_FLOAT_EQ(floatView(16), 11.0f);
+   EXPECT_FLOAT_EQ(floatView(17), 12.0f);
+   EXPECT_FLOAT_EQ(floatView(50000), 49995.0f);
+
+   EXPECT_EQ(stringView(14), "14");
+   EXPECT_EQ(stringView(0), "foofoofoo");
+   EXPECT_EQ(stringView(1), "foofoofoo");
+   EXPECT_EQ(stringView(1034), "1034");
+   EXPECT_EQ(stringView(2), "foofoofoo");
+   EXPECT_EQ(mergedStringView(6), "foofoofoo");
+   EXPECT_EQ(stringView(3), "foofoofoo");
+   EXPECT_EQ(stringView(8), "foo");
+   EXPECT_EQ(stringView(5), "foofoofoo");
+   EXPECT_EQ(mergedStringView(17), "17");
+   EXPECT_EQ(stringView(6), "foofoofoo");
+   EXPECT_EQ(mergedStringView(8), "foo");
+   EXPECT_EQ(stringView(7), "foo");
+   EXPECT_EQ(stringView(13), "13");
+   EXPECT_EQ(mergedStringView(0), "foofoofoo");
+   EXPECT_EQ(stringView(9), "foo");
+   EXPECT_EQ(stringView(10), "foo");
+   EXPECT_EQ(mergedStringView(7), "foo");
+   EXPECT_EQ(stringView(11), "foo");
+   EXPECT_EQ(mergedStringView(4), "foofoofoo");
+   EXPECT_EQ(stringView(12), "12");
+   EXPECT_EQ(mergedStringView(14), "14");
+   EXPECT_EQ(stringView(4), "foofoofoo");
+   EXPECT_EQ(stringView(17003), "17003");
+   EXPECT_EQ(stringView(15), "15");
+   EXPECT_EQ(stringView(34567), "34567");
+   EXPECT_EQ(stringView(1680), "1680");
+   EXPECT_EQ(stringView(60010), "60010");
+   // TODO (lesimon): Check if RNTupleReader::Show() leads to desired output.
+}
+
+
+TEST(RNTupleChain, ChainOfChain)
+{
+   const std::string_view ntupleName = "ChainOfChainNTuple";
+   FileRaii fileGuard("test_ntuple_chain_ChainOfChain.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto dbField = model->MakeField<double>("db");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+
+      for (int i = 0; i < 3; ++i) {
+         *dbField = 5.0+i;
+         *stField = "foo" + std::to_string(i);
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
+   auto ntupleChain = RNTupleReader::ChainReader(ntupleName, ntuple, ntuple);
+   auto ntupleChainOfChain = RNTupleReader::ChainReader(ntupleName, ntupleChain, ntupleChain);
+
+   auto doubleView = ntuple->GetView<double>("db");
+   auto stringView = ntuple->GetView<std::string>("st");
+
+   auto doubleView2 = ntupleChain->GetView<double>("db");
+   auto stringView2 = ntupleChain->GetView<std::string>("st");
+
+   auto doubleView3 = ntupleChainOfChain->GetView<double>("db");
+   auto stringView3 = ntupleChainOfChain->GetView<std::string>("st");
+
+   EXPECT_DOUBLE_EQ(doubleView(0), 5.0f);
+   EXPECT_DOUBLE_EQ(doubleView(1), 6.0f);
+   EXPECT_DOUBLE_EQ(doubleView(2), 7.0f);
+   EXPECT_EQ(stringView(0), "foo0");
+   EXPECT_EQ(stringView(1), "foo1");
+   EXPECT_EQ(stringView(2), "foo2");
+
+   EXPECT_DOUBLE_EQ(doubleView2(0), 5.0f);
+   EXPECT_DOUBLE_EQ(doubleView2(1), 6.0f);
+   EXPECT_DOUBLE_EQ(doubleView2(2), 7.0f);
+   EXPECT_DOUBLE_EQ(doubleView2(3), 5.0f);
+   EXPECT_DOUBLE_EQ(doubleView2(4), 6.0f);
+   EXPECT_DOUBLE_EQ(doubleView2(5), 7.0f);
+
+   EXPECT_EQ(stringView2(0), "foo0");
+   EXPECT_EQ(stringView2(1), "foo1");
+   EXPECT_EQ(stringView2(2), "foo2");
+   EXPECT_EQ(stringView2(3), "foo0");
+   EXPECT_EQ(stringView2(4), "foo1");
+   EXPECT_EQ(stringView2(5), "foo2");
+
+   EXPECT_DOUBLE_EQ(doubleView3(0), 5.0);
+   EXPECT_DOUBLE_EQ(doubleView3(1), 6.0);
+   EXPECT_DOUBLE_EQ(doubleView3(2), 7.0);
+   EXPECT_DOUBLE_EQ(doubleView3(3), 5.0);
+   EXPECT_DOUBLE_EQ(doubleView3(4), 6.0);
+   EXPECT_DOUBLE_EQ(doubleView3(5), 7.0);
+   EXPECT_DOUBLE_EQ(doubleView3(6), 5.0);
+   EXPECT_DOUBLE_EQ(doubleView3(7), 6.0);
+   EXPECT_DOUBLE_EQ(doubleView3(8), 7.0);
+   EXPECT_DOUBLE_EQ(doubleView3(9), 5.0);
+   EXPECT_DOUBLE_EQ(doubleView3(10), 6.0);
+   EXPECT_DOUBLE_EQ(doubleView3(11), 7.0);
+   EXPECT_EQ(stringView3(0), "foo0");
+   EXPECT_EQ(stringView3(1), "foo1");
+   EXPECT_EQ(stringView3(2), "foo2");
+   EXPECT_EQ(stringView3(3), "foo0");
+   EXPECT_EQ(stringView3(4), "foo1");
+   EXPECT_EQ(stringView3(5), "foo2");
+   EXPECT_EQ(stringView3(6), "foo0");
+   EXPECT_EQ(stringView3(7), "foo1");
+   EXPECT_EQ(stringView3(8), "foo2");
+   EXPECT_EQ(stringView3(9), "foo0");
+   EXPECT_EQ(stringView3(10), "foo1");
+   EXPECT_EQ(stringView3(11), "foo2");
+}
+
+TEST(RNTupleChain, ChainOfChainWithStdMove)
+{
+   const std::string_view ntupleName = "ChainOfChainNTuple";
+   FileRaii fileGuard("test_ntuple_chain_ChainOfChain.ntuple");
+   {
+      auto model = RNTupleModel::Create();
+      auto dbField = model->MakeField<double>("db");
+      auto stField = model->MakeField<std::string>("st");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      
+      for (int i = 0; i < 21000; ++i) {
+         *dbField = 5.0+i;
+         *stField = "foo" + std::to_string(i);
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
+   auto ntuple2 = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
+   auto ntuple3 = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
+   auto ntuple4 = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
+   auto ntupleChain = RNTupleReader::ChainReader(ntupleName, std::move(ntuple), std::move(ntuple2));
+   auto ntupleChain2 = RNTupleReader::ChainReader(ntupleName, std::move(ntuple3), std::move(ntuple4));
+   auto ntupleChainOfChain = RNTupleReader::ChainReader(ntupleName, std::move(ntupleChain), std::move(ntupleChain2));
+
+   auto doubleView = ntupleChainOfChain->GetView<double>("db");
+   auto stringView = ntupleChainOfChain->GetView<std::string>("st");
+
+   EXPECT_DOUBLE_EQ(doubleView(0), 5.0);
+   EXPECT_DOUBLE_EQ(doubleView(1), 6.0);
+   EXPECT_DOUBLE_EQ(doubleView(2), 7.0);
+   EXPECT_DOUBLE_EQ(doubleView(10000), 10005.0);
+   EXPECT_DOUBLE_EQ(doubleView(10001), 10006.0);
+   EXPECT_DOUBLE_EQ(doubleView(21000), 5.0);
+   EXPECT_DOUBLE_EQ(doubleView(21001), 6.0);
+   EXPECT_DOUBLE_EQ(doubleView(21002), 7.0);
+   EXPECT_DOUBLE_EQ(doubleView(31000), 10005.0);
+   EXPECT_DOUBLE_EQ(doubleView(31001), 10006.0);
+   EXPECT_DOUBLE_EQ(doubleView(42000), 5.0);
+   EXPECT_DOUBLE_EQ(doubleView(42001), 6.0);
+   EXPECT_DOUBLE_EQ(doubleView(42002), 7.0);
+   EXPECT_DOUBLE_EQ(doubleView(52000), 10005.0);
+   EXPECT_DOUBLE_EQ(doubleView(52001), 10006.0);
+   EXPECT_DOUBLE_EQ(doubleView(63000), 5.0);
+   EXPECT_DOUBLE_EQ(doubleView(63001), 6.0);
+   EXPECT_DOUBLE_EQ(doubleView(63002), 7.0);
+   EXPECT_EQ(stringView(0), "foo0");
+   EXPECT_EQ(stringView(1), "foo1");
+   EXPECT_EQ(stringView(2), "foo2");
+   EXPECT_EQ(stringView(10000), "foo10000");
+   EXPECT_EQ(stringView(10001), "foo10001");
+   EXPECT_EQ(stringView(21000), "foo0");
+   EXPECT_EQ(stringView(21001), "foo1");
+   EXPECT_EQ(stringView(21002), "foo2");
+   EXPECT_EQ(stringView(31000), "foo10000");
+   EXPECT_EQ(stringView(31001), "foo10001");
+   EXPECT_EQ(stringView(42000), "foo0");
+   EXPECT_EQ(stringView(42001), "foo1");
+   EXPECT_EQ(stringView(42002), "foo2");
+   EXPECT_EQ(stringView(52000), "foo10000");
+   EXPECT_EQ(stringView(52001), "foo10001");
+   EXPECT_EQ(stringView(63000), "foo0");
+   EXPECT_EQ(stringView(63001), "foo1");
+   EXPECT_EQ(stringView(63002), "foo2");
+}
+

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -31,7 +31,6 @@
 #include <TTree.h>
 
 #include <cassert>
-#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -109,44 +108,11 @@ void ntpl003_lhcbOpenData()
    TH1F h("h", "B Flight Distance", 200, 0, 140);
    h.SetFillColor(48);
 
-   auto t1 = std::chrono::high_resolution_clock::now();
    for (auto i : ntuple->GetViewRange()) {
       // Note that we do not load an entry in this loop, i.e. we avoid the memory copy of loading the data into
       // the memory location given by the entry
       h.Fill(viewFlightDistance(i));
    }
-   auto t2 = std::chrono::high_resolution_clock::now();
+
    h.DrawCopy();
-   
-   
-   
-   // Create a vector containing the same filename 20 times.
-   std::vector<std::string> vec(20);
-   for (auto &v : vec) {
-      v = kNTupleFileName;
-   }
-   
-   // Creates a ntuple where the same data is concatenated 20 times.
-   auto ntuple2 = RNTupleReader::Open("DecayTree", vec);
-
-   auto viewFlightDistance2 = ntuple2->GetView<double>("B_FlightDistance");
-   auto c2 = new TCanvas("c2", "B Flight Distance Chain", 200, 10, 700, 500);
-   TH1F h2("h", "B Flight Distance Chain", 200, 0, 140);
-   h2.SetFillColor(48);
-
-
-   auto t3 = std::chrono::high_resolution_clock::now();
-   // The ViewRange is 20 times longer than for the previous RNTupleReader
-   for (auto i : ntuple2->GetViewRange()) {
-      h2.Fill(viewFlightDistance2(i));
-   }
-   auto t4 = std::chrono::high_resolution_clock::now();
-   
-   // Draws the same graph with 20 times more entries
-   h2.DrawCopy();
-   
-   auto durationSingleFile = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
-   auto durationChainOfFiles = std::chrono::duration_cast<std::chrono::microseconds>(t4 - t3).count();
-   
-   std::cout << "It takes " << durationChainOfFiles / durationSingleFile << " times longer when the same file is concatenated 20 times in a chain.\n";
 }


### PR DESCRIPTION
This PR implements a feature to concatenate ntuple-files. This can be done in 2 ways:

1. Create one RNTupleReader from multiple files. (`auto ntupleReader = RNTupleReader::Open(std::string_view ntupleName, std::vector<std::string> fileNames);`)
2. Combine 2 RNTupleReader into one. This can be done with move-semantics (`auto reader = RNTupleReader::ChainReader(ntupleName, std::move(reader1), std::move(reader2));`) or without (`auto reader = RNTupleReader::ChainReader(ntupleName, reader1, reader2);`).

It works for both raw-files and .root-files. Combining raw-files and .root-files is also possible (although not advised).