### PR TITLE
document PxPyPzEVector

### DIFF
--- a/math/genvector/doc/LorentzVector.html
+++ b/math/genvector/doc/LorentzVector.html
@@ -14,6 +14,7 @@ The following typedef's, defined in the header file <em>Math/Vector4Dfwd.h</em>,
 <li>ROOT::Math::PtEtaPhiEVector vector based on pt (rho),eta,phi and E (t) coordinates  in double precision
 <li>ROOT::Math::PtEtaPhiMVector vector based on pt (rho),eta,phi and M (t) coordinates  in double precision
 <li>ROOT::Math::PxPyPzMVector vector based on px,py,pz and M (mass) coordinates  in double precision
+<li>ROOT::Math::PxPyPzEVector vector based on px,py,pz and E (energy) coordinates  in double precision
 </ul>
 The metric used for all the LorentzVector's is (-,-,-,+)
 

--- a/math/genvector/doc/LorentzVector.md
+++ b/math/genvector/doc/LorentzVector.md
@@ -9,6 +9,7 @@ To avoid exposing templated parameter to the users, typedefs are defined for all
 *   ROOT::Math::PtEtaPhiEVector vector based on pt (rho),eta,phi and E (t) coordinates in double precision
 *   ROOT::Math::PtEtaPhiMVector vector based on pt (rho),eta,phi and M (t) coordinates in double precision
 *   ROOT::Math::PxPyPzMVector vector based on px,py,pz and M (mass) coordinates in double precision
+*   ROOT::Math::PxPyPzEVector vector based on px,py,pz and E (energy) coordinates in double precision
 
 The metric used for all the LorentzVector's is (-,-,-,+)
 

--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -46,6 +46,7 @@ namespace ROOT {
         - ROOT::Math::PtEtaPhiMVector based on pt (rho),eta,phi and M (t) coordinates in double precision
         - ROOT::Math::PtEtaPhiEVector based on pt (rho),eta,phi and E (t) coordinates in double precision
         - ROOT::Math::PxPyPzMVector based on px,py,pz and M (mass) coordinates in double precision
+        - ROOT::Math::PxPyPzEVector based on px,py,pz and E (energy) coordinates in double precision
         - ROOT::Math::XYZTVector based on x,y,z,t coordinates (cartesian) in double precision
         - ROOT::Math::XYZTVectorF based on x,y,z,t coordinates (cartesian) in float precision
 

--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -47,8 +47,8 @@ namespace ROOT {
         - ROOT::Math::PtEtaPhiEVector based on pt (rho),eta,phi and E (t) coordinates in double precision
         - ROOT::Math::PxPyPzMVector based on px,py,pz and M (mass) coordinates in double precision
         - ROOT::Math::PxPyPzEVector based on px,py,pz and E (energy) coordinates in double precision
-        - ROOT::Math::XYZTVector based on x,y,z,t coordinates (cartesian) in double precision
-        - ROOT::Math::XYZTVectorF based on x,y,z,t coordinates (cartesian) in float precision
+        - ROOT::Math::XYZTVector based on x,y,z,t coordinates (cartesian) in double precision (same as PxPyPzEVector)
+        - ROOT::Math::XYZTVectorF based on x,y,z,t coordinates (cartesian) in float precision (same as PxPyPzEVector but float)
 
 More details about the GenVector package can be found [here](Vector.html).
 

--- a/math/physics/src/TLorentzVector.cxx
+++ b/math/physics/src/TLorentzVector.cxx
@@ -17,8 +17,8 @@ are superior from the runtime performance offered, i.e.:
   - ROOT::Math::PtEtaPhiEVector based on pt (rho),eta,phi and E (t) coordinates in double precision
   - ROOT::Math::PxPyPzMVector based on px,py,pz and M (mass) coordinates in double precision
   - ROOT::Math::PxPyPzEVector based on px,py,pz and E (energy) coordinates in double precision
-  - ROOT::Math::XYZTVector based on x,y,z,t coordinates (cartesian) in double precision
-  - ROOT::Math::XYZTVectorF based on x,y,z,t coordinates (cartesian) in float precision
+  - ROOT::Math::XYZTVector based on x,y,z,t coordinates (cartesian) in double precision (same as PxPyPzEVector)
+  - ROOT::Math::XYZTVectorF based on x,y,z,t coordinates (cartesian) in float precision (same as PxPyPzEVector but float)
 
 More details about the GenVector package can be found [here](Vector.html).
 

--- a/math/physics/src/TLorentzVector.cxx
+++ b/math/physics/src/TLorentzVector.cxx
@@ -16,6 +16,7 @@ are superior from the runtime performance offered, i.e.:
   - ROOT::Math::PtEtaPhiMVector based on pt (rho),eta,phi and M (t) coordinates in double precision
   - ROOT::Math::PtEtaPhiEVector based on pt (rho),eta,phi and E (t) coordinates in double precision
   - ROOT::Math::PxPyPzMVector based on px,py,pz and M (mass) coordinates in double precision
+  - ROOT::Math::PxPyPzEVector based on px,py,pz and E (energy) coordinates in double precision
   - ROOT::Math::XYZTVector based on x,y,z,t coordinates (cartesian) in double precision
   - ROOT::Math::XYZTVectorF based on x,y,z,t coordinates (cartesian) in float precision
 


### PR DESCRIPTION
Add `ROOT::Math::PxPyPzEVector` to LorentzVector summary since it is such a commonly-used variation.