### PR TITLE
[cxxmodules] Try harder to get the IO comment for modules.

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -4092,7 +4092,14 @@ llvm::StringRef ROOT::TMetaUtils::GetComment(const clang::Decl &decl, clang::Sou
 
    // If the location is a macro get the expansion location.
    sourceLocation = sourceManager.getExpansionRange(sourceLocation).second;
-   if (sourceManager.isLoadedSourceLocation(sourceLocation)) {
+   // FIXME: We should optimize this routine instead making it do the wrong thing
+   // returning an empty comment if the decl came from the AST.
+   // In order to do that we need to: check if the decl has an attribute and
+   // return the attribute content (including walking the redecl chain) and if
+   // this is not the case we should try finding it in the header file.
+   // This will allow us to move the implementation of TCling*Info::Title() in
+   // TClingDeclInfo.
+   if (!decl.hasOwningModule() && sourceManager.isLoadedSourceLocation(sourceLocation)) {
       // Do not touch disk for nodes coming from the PCH.
       return "";
    }


### PR DESCRIPTION
In some cases such as ROOT::Experimental::Internal::TUniWeakPtr the information about if a data member is transient is kept in the template pattern (residing in Core.pcm). The template instantiation is elsewhere (in the particular case) the ROOTHistDraw.pcm. In this scenario the LinkDef request for the particular instantiation is done after Core.pcm is built leaving no chance for rootcling to transform the comment into an annotation attibute attached to the template pattern.

This does not happen very often but it may occur regularly when we start writing more templated code. We should store the IO comments for the template patterns independently on if a particular template instantiation was required.

This is a modules-specific issue because the PCH includes the bulk of header files altogether and this helps the current system to place this information at the required place.

This should fix the failures in tutorial-hist-h1draw and cmssw CXXModules IB:
Fatal Root Error: @SUB=TProtoClass::FindDataMember
data member with index 0 is not found in class edm::value_ptr<vector<unsigned long> >.