### PR TITLE
Fix the resetting of axis ranges in TH3::ProjectionX,Y,Z (ROOT-10332)

### DIFF
--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -128,10 +128,10 @@ public:
 
 protected:
 
-   virtual TH1D        *DoProject1D(const char* name, const char * title, int imin1, int imax1, int imin2, int imax2, 
+   virtual TH1D        *DoProject1D(const char* name, const char * title, int imin1, int imax1, int imin2, int imax2,
                                     const TAxis* projAxis, const TAxis * axis1, const TAxis * axis2, Option_t * option) const;
-   virtual TH1D        *DoProject1D(const char* name, const char * title, const TAxis* projAxis,  
-                         bool computeErrors, bool originalRange, bool useUF, bool useOF) const;
+   virtual TH1D *DoProject1D(const char *name, const char *title, const TAxis *projAxis, const TAxis *axis1,
+                             const TAxis *axis2, bool computeErrors, bool originalRange, bool useUF, bool useOF) const;
    virtual TH2D        *DoProject2D(const char* name, const char * title, const TAxis* projX, const TAxis* projY,
                         bool computeErrors, bool originalRange,
                          bool useUF, bool useOF) const;
@@ -141,7 +141,7 @@ protected:
    // these functions are need to be used inside TProfile3D::DoProjectProfile2D
    static TH1D         *DoProject1D(const TH3 & h, const char* name, const char * title, const TAxis* projX,
                                     bool computeErrors, bool originalRange, bool useUF, bool useOF)  {
-      return h.DoProject1D(name, title, projX, computeErrors, originalRange, useUF, useOF);
+      return h.DoProject1D(name, title, projX, nullptr, nullptr, computeErrors, originalRange, useUF, useOF);
    }
    static TH2D         *DoProject2D(const TH3 & h, const char* name, const char * title, const TAxis* projX, const TAxis* projY,
                                     bool computeErrors, bool originalRange, bool useUF, bool useOF)  {
@@ -335,4 +335,3 @@ protected:
 };
 
 #endif
-


### PR DESCRIPTION
This PR fixes the managing of axis range when calling TH3::ProjectionX/Y/Z. 
Now we create copy of the axes, so there is no need to rest range and its bit. This was missing and was showing the wrong behaviour observed in 
https://root-forum.cern.ch/t/strange-behavior-for-th3d-projection-projectiony-delete-the-overflow-content-on-x-axis/34244

 This  also fixes the const of  function and there is no need to use an internal const_cast. 