### PR TITLE
Fix setting a prefix for TMVA weight file (ROOT-8887)

### DIFF
--- a/tmva/tmva/inc/TMVA/Config.h
+++ b/tmva/tmva/inc/TMVA/Config.h
@@ -1,4 +1,4 @@
-// @(#)root/tmva $Id$   
+// @(#)root/tmva $Id$
 // Author: Andreas Hoecker, Joerg Stelzer, Fredrik Tegenfeldt, Helge Voss
 
 /**********************************************************************************
@@ -79,7 +79,7 @@ namespace TMVA {
 //      ROOT::TSequentialExecutor &GetSeqExecutor() { return *fSeqfPool; }
 #endif
       /// Get executor class for multi-thread usage
-      /// In case when  MT is not enabled will return a serial executor 
+      /// In case when  MT is not enabled will return a serial executor
       Executor & GetThreadExecutor() { return fExecutor; }
 
       /// Enable MT in TMVA (by default is on when ROOT::EnableImplicitMT() is set
@@ -90,7 +90,7 @@ namespace TMVA {
 
       ///Check if IMT is enabled
       Bool_t IsMTEnabled() const { return  fExecutor.GetPoolSize() > 1; }
-      
+
    public:
 
       class VariablePlotting;
@@ -119,13 +119,14 @@ namespace TMVA {
       class IONames {
 
       public:
-
+         // this is name of weight file directory
+         TString fWeightFileDirPrefix;
          TString fWeightFileDir;
          TString fWeightFileExtension;
          TString fOptionsReferenceFileDir;
       } fIONames; // Customisable weight file properties
-         
-      
+
+
    private:
 
       // private constructor
@@ -137,7 +138,7 @@ namespace TMVA {
       static std::atomic<Config*> fgConfigPtr;
 #else
       static Config* fgConfigPtr;
-#endif                  
+#endif
    private:
 
 #if __cplusplus > 199711L
@@ -155,7 +156,7 @@ namespace TMVA {
 #endif
       mutable MsgLogger* fLogger;   // message logger
       MsgLogger& Log() const { return *fLogger; }
-         
+
       ClassDef(Config,0); // Singleton class for global configuration settings
    };
 

--- a/tmva/tmva/src/Config.cxx
+++ b/tmva/tmva/src/Config.cxx
@@ -74,6 +74,7 @@ TMVA::Config::Config() :
    fVariablePlotting.fUsePaperStyle = 0;
 
    // IO names
+   fIONames.fWeightFileDirPrefix = "";
    fIONames.fWeightFileDir           = "weights";
    fIONames.fWeightFileExtension     = "weights";
    fIONames.fOptionsReferenceFileDir = "optionInfo";
@@ -119,4 +120,3 @@ TMVA::Config& TMVA::Config::Instance()
    return fgConfigPtr ? *fgConfigPtr :*(fgConfigPtr = new Config());
 #endif
 }
-

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -399,7 +399,8 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
    conf->DeclareOptionRef( boostNum = 0, "Boost_num",
                            "Number of times the classifier will be boosted" );
    conf->ParseOptions();
-   delete conf; // this is name of weight file directory (weigh)
+   delete conf;
+   // this is name of weight file directory
    TString fileDir;
    if(fModelPersistence)
    {
@@ -422,11 +423,11 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
      Log() << kDEBUG <<"Boost Number is " << boostNum << " > 0: train boosted classifier" << Endl;
      im = ClassifierFactory::Instance().Create("Boost", fJobName, methodTitle, loader->GetDataSetInfo(), theOption);
      MethodBoost *methBoost = dynamic_cast<MethodBoost *>(im); // DSMTEST divided into two lines
-     if (!methBoost)                                           // DSMTEST
+     if (!methBoost) {                                    // DSMTEST
         Log() << kFATAL << "Method with type kBoost cannot be casted to MethodCategory. /Factory" << Endl; // DSMTEST
-
-     if (fModelPersistence)
-        methBoost->SetWeightFileDir(fileDir);
+        return nullptr;
+     }
+     if (fModelPersistence)  methBoost->SetWeightFileDir(fileDir);
      methBoost->SetModelPersistence(fModelPersistence);
      methBoost->SetBoostedMethodName(theMethodName);                            // DSMTEST divided into two lines
      methBoost->fDataSetManager = loader->GetDataSetInfo().GetDataSetManager(); // DSMTEST
@@ -440,9 +441,10 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
    // set fDataSetManager if MethodCategory (to enable Category to create datasetinfo objects) // DSMTEST
    if (method->GetMethodType() == Types::kCategory) { // DSMTEST
       MethodCategory *methCat = (dynamic_cast<MethodCategory*>(im)); // DSMTEST
-      if (!methCat) // DSMTEST
+      if (!methCat) {// DSMTEST
          Log() << kFATAL << "Method with type kCategory cannot be casted to MethodCategory. /Factory" << Endl; // DSMTEST
-
+         return nullptr;
+      }
       if(fModelPersistence) methCat->SetWeightFileDir(fileDir);
       methCat->SetModelPersistence(fModelPersistence);
       methCat->fDataSetManager = loader->GetDataSetInfo().GetDataSetManager(); // DSMTEST

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -399,12 +399,17 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
    conf->DeclareOptionRef( boostNum = 0, "Boost_num",
                            "Number of times the classifier will be boosted" );
    conf->ParseOptions();
-   delete conf;
-   TString fFileDir;
+   delete conf; // this is name of weight file directory (weigh)
+   TString fileDir;
    if(fModelPersistence)
    {
-       fFileDir=loader->GetName();
-       fFileDir+="/"+gConfig().GetIONames().fWeightFileDir;
+      // find prefix in fWeightFileDir;
+      TString prefix = gConfig().GetIONames().fWeightFileDirPrefix;
+      fileDir = prefix;
+      if (!prefix.IsNull())
+         if (fileDir[fileDir.Length()-1] != '/') fileDir += "/";
+      fileDir += loader->GetName();
+      fileDir += "/" + gConfig().GetIONames().fWeightFileDir;
    }
    // initialize methods
    IMethod* im;
@@ -421,7 +426,7 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
         Log() << kFATAL << "Method with type kBoost cannot be casted to MethodCategory. /Factory" << Endl; // DSMTEST
 
      if (fModelPersistence)
-        methBoost->SetWeightFileDir(fFileDir);
+        methBoost->SetWeightFileDir(fileDir);
      methBoost->SetModelPersistence(fModelPersistence);
      methBoost->SetBoostedMethodName(theMethodName);                            // DSMTEST divided into two lines
      methBoost->fDataSetManager = loader->GetDataSetInfo().GetDataSetManager(); // DSMTEST
@@ -438,7 +443,7 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
       if (!methCat) // DSMTEST
          Log() << kFATAL << "Method with type kCategory cannot be casted to MethodCategory. /Factory" << Endl; // DSMTEST
 
-      if(fModelPersistence) methCat->SetWeightFileDir(fFileDir);
+      if(fModelPersistence) methCat->SetWeightFileDir(fileDir);
       methCat->SetModelPersistence(fModelPersistence);
       methCat->fDataSetManager = loader->GetDataSetInfo().GetDataSetManager(); // DSMTEST
       methCat->SetFile(fgTargetFile);
@@ -462,7 +467,7 @@ TMVA::MethodBase* TMVA::Factory::BookMethod( TMVA::DataLoader *loader, TString t
       return 0;
    }
 
-   if(fModelPersistence) method->SetWeightFileDir(fFileDir);
+   if(fModelPersistence) method->SetWeightFileDir(fileDir);
    method->SetModelPersistence(fModelPersistence);
    method->SetAnalysisType( fAnalysisType );
    method->SetupMethod();
@@ -517,13 +522,19 @@ TMVA::MethodBase* TMVA::Factory::BookMethodWeightfile(DataLoader *loader, TMVA::
       Log() << kERROR << "Cannot handle category methods for now." << Endl;
    }
 
-   TString fFileDir;
+   TString fileDir;
    if(fModelPersistence) {
-      fFileDir=loader->GetName();
-      fFileDir+="/"+gConfig().GetIONames().fWeightFileDir;
+      // find prefix in fWeightFileDir;
+      TString prefix = gConfig().GetIONames().fWeightFileDirPrefix;
+      fileDir = prefix;
+      if (!prefix.IsNull())
+         if (fileDir[fileDir.Length() - 1] != '/')
+            fileDir += "/";
+      fileDir=loader->GetName();
+      fileDir+="/"+gConfig().GetIONames().fWeightFileDir;
    }
 
-   if(fModelPersistence) method->SetWeightFileDir(fFileDir);
+   if(fModelPersistence) method->SetWeightFileDir(fileDir);
    method->SetModelPersistence(fModelPersistence);
    method->SetAnalysisType( fAnalysisType );
    method->SetupMethod();
@@ -1211,9 +1222,9 @@ void TMVA::Factory::TrainAllMethods()
         }
         // ToDo, Do we need to fill the DataSetManager of MethodBoost here too?
 
-        TString fFileDir = m->DataInfo().GetName();
-        fFileDir += "/" + gConfig().GetIONames().fWeightFileDir;
-        m->SetWeightFileDir(fFileDir);
+        TString wfileDir = m->DataInfo().GetName();
+        wfileDir += "/" + gConfig().GetIONames().fWeightFileDir;
+        m->SetWeightFileDir(wfileDir);
         m->SetModelPersistence(fModelPersistence);
         m->SetSilentFile(IsSilentFile());
         m->SetAnalysisType(fAnalysisType);

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -764,8 +764,8 @@ void TMVA::MethodBase::AddRegressionOutput(Types::ETreeType type)
    regRes->Resize( nEvents );
 
    // Drawing the progress bar every event was causing a huge slowdown in the evaluation time
-   // So we set some parameters to draw the progress bar a total of totalProgressDraws, i.e. only draw every 1 in 100 
-   
+   // So we set some parameters to draw the progress bar a total of totalProgressDraws, i.e. only draw every 1 in 100
+
    Int_t totalProgressDraws = 100; // total number of times to update the progress bar
    Int_t drawProgressEvery = 1;    // draw every nth event such that we have a total of totalProgressDraws
    if(nEvents >= totalProgressDraws) drawProgressEvery = nEvents/totalProgressDraws;
@@ -1985,7 +1985,7 @@ TDirectory* TMVA::MethodBase::BaseDir() const
          sdir = methodDir->mkdir(defaultDir);
          sdir->cd();
          // write weight file name into target file
-         if (fModelPersistence) { 
+         if (fModelPersistence) {
             TObjString wfilePath( gSystem->WorkingDirectory() );
             TObjString wfileName( GetWeightFileName() );
             wfilePath.Write( "TrainingPath" );
@@ -2042,7 +2042,7 @@ TDirectory *TMVA::MethodBase::MethodBaseDir() const
 void TMVA::MethodBase::SetWeightFileDir( TString fileDir )
 {
    fFileDir = fileDir;
-   gSystem->MakeDirectory( fFileDir );
+   gSystem->mkdir( fFileDir, kTRUE );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3208,7 +3208,7 @@ void TMVA::MethodBase::MakeClass( const TString& theClassFileName ) const
           GetMethodType() != Types::kHMatrix) {
          fout << "         Transform( iV, -1 );" << std::endl;
       }
-      
+
       if(GetAnalysisType() == Types::kMulticlass) {
          fout << "         retval = GetMulticlassValues__( iV );" << std::endl;
       } else {


### PR DESCRIPTION
   Add a new gConfig.IONames fielf, fWrightFileDIrPrefix. 
This allows to have add a prefix for the directory to store the weights. 
By default the weights are stored in the directory starting with the dataset name, 
e.g. dataset/name0
    
If a non-nul prefix is set in 
``TMVA::gConfig().GetIONames().fWeightFileDirPrefix``   the weights will be stored in weightfile_prefix/dataset_name/weight_file_name

    This fixes ROOT-8887