### PR TITLE
PR33746: Store the 'inline'ness of a static data member with the upda…

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3987,6 +3987,8 @@ void ASTDeclReader::UpdateDecl(Decl *D,
       VarDecl *VD = cast<VarDecl>(D);
       VD->getMemberSpecializationInfo()->setPointOfInstantiation(
           ReadSourceLocation());
+      VD->NonParmVarDeclBits.IsInline = Record.readInt();
+      VD->NonParmVarDeclBits.IsInlineSpecified = Record.readInt();
       uint64_t Val = Record.readInt();
       if (Val && !VD->getInit()) {
         VD->setInit(Record.readExpr());

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriter.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriter.cpp
@@ -5062,6 +5062,8 @@ void ASTWriter::WriteDeclUpdatesBlocks(RecordDataImpl &OffsetsRecord) {
       case UPD_CXX_INSTANTIATED_STATIC_DATA_MEMBER: {
         const VarDecl *VD = cast<VarDecl>(D);
         Record.AddSourceLocation(Update.getLoc());
+        Record.push_back(VD->isInline());
+        Record.push_back(VD->isInlineSpecified());
         if (VD->getInit()) {
           Record.push_back(!VD->isInitKnownICE() ? 1
                                                  : (VD->isInitICE() ? 3 : 2));


### PR DESCRIPTION
…te record for instantiating its definition.

We model the 'inline'ness as being instantiated with the static data member in
order to track whether the declaration has become a definition yet.

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@317147 91177308-0d34-0410-b5e6-96231b3b80d8

This patch fixes a problem in cxxmodules and c++17 of the kind:
```
1/2 Test #263: tutorial-dataframe-df004_cutFlowReport ......***Failed  Error regular expression found in output. Regex=[: error:] 30.90 sec

Processing /home/vvassilev/workspace/sources/root/tutorials/dataframe/df004_cutFlowReport.C...
In module 'std' imported from input_line_1:1:
/usr/include/c++/7/string_view:88:41: error: static data member 'npos' already has an initializer
      static constexpr size_type npos = size_type(-1);
                                        ^
/usr/include/c++/7/string_view:319:43: note: in instantiation of static data member 'std::basic_string_view<char, std::char_traits<char> >::npos' requested here
      rfind(_CharT __c, size_type __pos = npos) const noexcept;
                                          ^
/home/vvassilev/workspace/builds/root_runtime_modules_builtin_clang_debug/include/ROOT/RDF/RInterface.hxx:468:14: note: in instantiation of function template specialization 'ROOT::RDF::RInterface<ROOT::Detail::RDF::RNodeBase, void>::SnapshotImpl<double, int>' requested here
      return SnapshotImpl<ColumnTypes...>(treename, filename, columnList, options);
             ^
input_line_102:2:206: note: in instantiation of function template specialization 'ROOT::RDF::RInterface<ROOT::Detail::RDF::RNodeBase, void>::Snapshot<double, int>' requested here
 *reinterpret_cast<ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager>>*>(0x7fffffff9598) = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNodeBase>*>(0x7fffffff95d0)->Snapshot<__rdf1::b13_type, __rdf1::b24_type>("myTree", "df004_cutFlowReport.root", *reinterpret_cast<std::vector<std::string>*>(0x7fffffff9940),*reinterpret_cast<ROOT::RDF::RSnapshotOptions*>(0x7fffffff9a40));
                                                                                                                                                                                                             ^
/usr/include/c++/7/string_view:88:41: note: previous initialization is here
      static constexpr size_type npos = size_type(-1);
                                        ^
terminate called after throwing an instance of 'std::runtime_error'
  what():  
An error occurred while jitting in Snapshot. The lines above might indicate the cause of the crash

CMake Error at /home/vvassilev/workspace/builds/root_runtime_modules_builtin_clang_debug/RootTestDriver.cmake:238 (message):
  error code: Child aborted

```