### PR TITLE
[RDF] Fixes / new features for CSV data source

### DIFF
--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -52,7 +52,7 @@ private:
    // work given that the pointer to the boolean in that case cannot be taken
    std::vector<std::deque<bool>> fBoolEvtValues; // one per column per slot
 
-   static TRegexp intRegex, doubleRegex1, doubleRegex2, trueRegex, falseRegex;
+   static TRegexp intRegex, doubleRegex1, doubleRegex2, doubleRegex3, trueRegex, falseRegex;
 
    void FillHeaders(const std::string &);
    void FillRecord(const std::string &, Record_t &);

--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -95,6 +95,7 @@ std::string RCsvDS::AsString()
 TRegexp RCsvDS::intRegex("^[-+]?[0-9]+$");
 TRegexp RCsvDS::doubleRegex1("^[-+]?[0-9]+\\.[0-9]*$");
 TRegexp RCsvDS::doubleRegex2("^[-+]?[0-9]*\\.[0-9]+$");
+TRegexp RCsvDS::doubleRegex3("^[-+]?[0-9]*\\.[0-9]+[eE][-+]?[0-9]+$");
 TRegexp RCsvDS::trueRegex("^true$");
 TRegexp RCsvDS::falseRegex("^false$");
 
@@ -199,7 +200,9 @@ void RCsvDS::InferType(const std::string &col, unsigned int idxCol)
 
    if (intRegex.Index(col, &dummy) != -1) {
       type = 'l'; // Long64_t
-   } else if (doubleRegex1.Index(col, &dummy) != -1 || doubleRegex2.Index(col, &dummy) != -1) {
+   } else if (doubleRegex1.Index(col, &dummy) != -1 ||
+              doubleRegex2.Index(col, &dummy) != -1 ||
+              doubleRegex3.Index(col, &dummy) != -1) {
       type = 'd'; // double
    } else if (trueRegex.Index(col, &dummy) != -1 || falseRegex.Index(col, &dummy) != -1) {
       type = 'b'; // bool

--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -95,7 +95,7 @@ std::string RCsvDS::AsString()
 TRegexp RCsvDS::intRegex("^[-+]?[0-9]+$");
 TRegexp RCsvDS::doubleRegex1("^[-+]?[0-9]+\\.[0-9]*$");
 TRegexp RCsvDS::doubleRegex2("^[-+]?[0-9]*\\.[0-9]+$");
-TRegexp RCsvDS::doubleRegex3("^[-+]?[0-9]*\\.[0-9]+[eE][-+]?[0-9]+$");
+TRegexp RCsvDS::doubleRegex3("^[-+]?[0-9]*\\.[0-9]+[eEdDqQ][-+]?[0-9]+$");
 TRegexp RCsvDS::trueRegex("^true$");
 TRegexp RCsvDS::falseRegex("^false$");
 

--- a/tree/dataframe/test/RCsvDS_test_headers.csv
+++ b/tree/dataframe/test/RCsvDS_test_headers.csv
@@ -1,7 +1,8 @@
-Name,Age,Height,Married
-Harry,60,185.2,true
-"Bob,Bob",50,180.0,true
-"""Joe""",40,200.5,false
-"Tom",30,170.,false
- John  ,1,.7,false
- "Mary Ann" ,-1,.7,true
+Name,Age,Height,Married,Salary
+Harry,60,185.2,true,2.5e+5
+"Bob,Bob",50,180.0,true,1.5E+5
+
+"""Joe""",40,200.5,false,9.1E+4
+"Tom",30,170.,false,1.1e+5
+ John  ,1,.7,false,1.3e+5
+ "Mary Ann" ,-1,.7,true,2.1E+5

--- a/tree/dataframe/test/RCsvDS_test_noheaders.csv
+++ b/tree/dataframe/test/RCsvDS_test_noheaders.csv
@@ -1,3 +1,4 @@
+
 Harry,60,185.2,true
 "Bob,Bob",55,180.0,true
 """Joe""",20,200.5,false

--- a/tree/dataframe/test/datasource_csv.cxx
+++ b/tree/dataframe/test/datasource_csv.cxx
@@ -25,11 +25,13 @@ TEST(RCsvDS, ColTypeNames)
 
    EXPECT_STREQ("Height", colNames[2].c_str());
    EXPECT_STREQ("Married", colNames[3].c_str());
+   EXPECT_STREQ("Salary", colNames[4].c_str());
 
    EXPECT_STREQ("std::string", tds.GetTypeName("Name").c_str());
    EXPECT_STREQ("Long64_t", tds.GetTypeName("Age").c_str());
    EXPECT_STREQ("double", tds.GetTypeName("Height").c_str());
    EXPECT_STREQ("bool", tds.GetTypeName("Married").c_str());
+   EXPECT_STREQ("double", tds.GetTypeName("Salary").c_str());
 }
 
 TEST(RCsvDS, ColNamesNoHeaders)


### PR DESCRIPTION
This PR adds:
- Support for 1.0e+10 syntax for type inference of double columns
- Skipping empty lines

as a result of the issue opened here:
https://sft.its.cern.ch/jira/browse/ROOT-10313