### PR TITLE
[Exp PyROOT] Prevent double copy of input test file

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/PyROOT/test/CMakeLists.txt
@@ -24,14 +24,11 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tdirectoryfile_attrsyntax_get tdirectoryfile_attr
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tfile_attrsyntax_get_writeobject_open tfile_attrsyntax_get_writeobject_open.py)
 
 # TTree and subclasses pythonizations
-ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch_attr ttree_branch_attr.py
-                    COPY_TO_BUILDDIR TreeHelper.h)
-ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_iterable ttree_iterable.py
-                    COPY_TO_BUILDDIR TreeHelper.h)
-ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_setbranchaddress ttree_setbranchaddress.py
-                    COPY_TO_BUILDDIR TreeHelper.h)
-ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py
-                    COPY_TO_BUILDDIR TreeHelper.h)
+file(COPY TreeHelper.h DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch_attr ttree_branch_attr.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_iterable ttree_iterable.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_setbranchaddress ttree_setbranchaddress.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_asmatrix ttree_asmatrix.py)
 
 # TH1 and subclasses pythonizations


### PR DESCRIPTION
Fix intermittent nightly test failures such as:

https://epsft-jenkins.cern.ch/job/root-exp-pyroot/264/LABEL=ROOT-ubuntu18.04,SPEC=python3/testReport/junit/projectroot.bindings.pyroot_experimental.PyROOT/test/pyunittests_pyroot_pyz_ttree_setbranchaddress/
