### PR TITLE
[TCling] Updates required by Cling's Definitionshadower

### DIFF
--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -47,6 +47,7 @@ class TObject;
 extern "C" {
    void TCling__UpdateListsOnCommitted(const cling::Transaction&, Interpreter*);
    void TCling__UpdateListsOnUnloaded(const cling::Transaction&);
+   void TCling__InvalidateGlobal(const clang::Decl*);
    void TCling__TransactionRollback(const cling::Transaction&);
    void TCling__GetNormalizedContext(const ROOT::TMetaUtils::TNormalizedCtxt*&);
    TObject* TCling__GetObjectAddress(const char *Name, void *&LookupCtx);
@@ -814,6 +815,10 @@ void TClingCallbacks::TransactionRollback(const Transaction &T) {
       return;
 
    TCling__TransactionRollback(T);
+}
+
+void TClingCallbacks::DefinitionShadowed(const clang::NamedDecl *D) {
+   TCling__InvalidateGlobal(D);
 }
 
 void TClingCallbacks::DeclDeserialized(const clang::Decl* D) {

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -93,6 +93,10 @@ public:
    //
    virtual void TransactionRollback(const cling::Transaction &T);
 
+   ///\brief A previous definition has been shadowed; invalidate TCling' stored
+   /// data about the old (global) decl.
+   virtual void DefinitionShadowed(const clang::NamedDecl *D);
+
    // Used to inform client about a new decl read by the ASTReader.
    //
    virtual void DeclDeserialized(const clang::Decl* D);

--- a/interpreter/cling/test/CodeUnloading/DeclShadowing.C
+++ b/interpreter/cling/test/CodeUnloading/DeclShadowing.C
@@ -12,11 +12,14 @@
 #include "cling/Interpreter/Interpreter.h"
 cling::runtime::gCling->allowRedefinition();
 
-// DefinitionShadower should leave Using{Directive,}Decl untouched.
+// ==== Test UsingDirectiveDecl/UsingDecl
+// These should not be nested into a `__cling_N5xxx' namespace (but placed at
+// the TU scope) so that the declaration they name is globally available.
 using namespace std;
-using ::strtol;
-strtol("0x33", NULL, 0)
-//CHECK: (long) 51
+namespace NS { string baz("Cling"); }
+using NS::baz;
+baz
+//CHECK: (std::string &) "Cling"
 
 // ==== Redeclare `i' with a different type
 int i = 1


### PR DESCRIPTION
Provides an implentation for the `DefinitionShadowed()` interpreter callback, that invalidates TCling cached information about a former declaration (that has been shadowed).

This PR also includes a minor fix for test 'cling/test/CodeUnloading/DeclShadowing.C'.