### PR TITLE
[cxxmodules] Mark string_view as textual to avoid bugs in clang-5.0

### DIFF
--- a/build/unix/std.modulemap
+++ b/build/unix/std.modulemap
@@ -309,7 +309,7 @@ module "std" [system] {
   module "string_view" {
     requires !header_existence
     export *
-    header "string_view"
+    textual header "string_view"
   }
 //  module "string.h" {
 //    export *


### PR DESCRIPTION
This should fix the compilation failures when we build ROOT with modules
in c++17 mode. This should be solved in clang upstream.