### PR TITLE
Reland "[cxxmodules] Preload libMathCore as usual."

### DIFF
--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -159,7 +159,7 @@ TRint::TRint(const char *appClassName, Int_t *argc, char **argv, void *options,
    // Explicitly load libMathCore it cannot be auto-loaded it when using one
    // of its freestanding functions. Once functions can trigger autoloading we
    // can get rid of this.
-   if (!gInterpreter->HasPCMForLibrary("libMathCore") && !gClassTable->GetDict("TRandom"))
+   if (!gClassTable->GetDict("TRandom"))
       gSystem->Load("libMathCore");
 
    if (!gInterpreter->HasPCMForLibrary("std")) {


### PR DESCRIPTION
This reverts commit e00fe57c831140383fbfe19ce486127fa7c0ac93.

We cannot only limit the preloading of libMathCore to PyROOT.
roottest-root-meta-drawing also seems to have issues with gRandom.