### PR TITLE
No longer strip/ignore std in ResolveTypedef.  Adapt reference file.

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -180,7 +180,7 @@ public:
    virtual void GetPartiallyDesugaredName(std::string &nameLong);
    virtual bool IsAlreadyPartiallyDesugaredName(const std::string &nondef, const std::string &nameLong);
    virtual bool IsDeclaredScope(const std::string &base, bool &isInlined);
-   virtual bool GetPartiallyDesugaredNameWithScopeHandling(const std::string &tname, std::string &result);
+   virtual bool GetPartiallyDesugaredNameWithScopeHandling(const std::string &tname, std::string &result, bool dropstd = true);
    virtual void ShuttingDownSignal();
 };
 

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -554,7 +554,8 @@ bool TClingLookupHelper::IsDeclaredScope(const std::string &base, bool &isInline
 /// [const] typename[*&][const]
 
 bool TClingLookupHelper::GetPartiallyDesugaredNameWithScopeHandling(const std::string &tname,
-                                                                    std::string &result)
+                                                                    std::string &result,
+                                                                    bool dropstd /* = true */)
 {
    if (tname.empty()) return false;
 
@@ -599,13 +600,13 @@ bool TClingLookupHelper::GetPartiallyDesugaredNameWithScopeHandling(const std::s
          if (strncmp(result.c_str(), "const ", 6) == 0) {
             offset = 6;
          }
-         if (strncmp(result.c_str()+offset, "std::", 5) == 0) {
+         if (dropstd && strncmp(result.c_str()+offset, "std::", 5) == 0) {
             result.erase(offset,5);
          }
          for(unsigned int i = 1; i<result.length(); ++i) {
             if (result[i]=='s') {
                if (result[i-1]=='<' || result[i-1]==',' || result[i-1]==' ') {
-                  if (result.compare(i,5,"std::",5) == 0) {
+                  if (dropstd && result.compare(i,5,"std::",5) == 0) {
                      result.erase(i,5);
                   }
                }

--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -129,7 +129,8 @@ namespace TClassEdit {
                                                    const std::string & /*nameLong*/) = 0;
       virtual bool IsDeclaredScope(const std::string & /*base*/, bool & /*isInlined*/) = 0;
       virtual bool GetPartiallyDesugaredNameWithScopeHandling(const std::string & /*tname*/,
-                                                              std::string & /*result*/) = 0;
+                                                              std::string & /*result*/,
+                                                              bool /* dropstd */ = true) = 0;
       virtual void ShuttingDownSignal() = 0;
    };
 

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1531,7 +1531,7 @@ static void ResolveTypedefImpl(const char *tname,
                      result += "::";
                   }
                } else if (modified) {
-                  result += std::string(tname+prevScope,cursor+1-prevScope);
+                  result += std::string(tname+prevScope,cursor+2-prevScope);
                }
             } else if (!gInterpreterHelper->IsDeclaredScope(scope,isInlined)) {
                // the nesting namespace is not declared
@@ -1549,7 +1549,7 @@ static void ResolveTypedefImpl(const char *tname,
                   result += string(tname,start_of_type,prevScope - start_of_type);
                }
             } else if (modified) {
-               result += std::string(tname+prevScope,cursor+1-prevScope);
+               result += std::string(tname+prevScope,cursor+2-prevScope);
             }
             // Consume the 1st semi colon, the 2nd will be consume by the for loop.
             ++cursor;

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1416,7 +1416,7 @@ static void ResolveTypedefProcessType(const char *tname,
                     : string(tname, start_of_type, end_of_type == 0 ? cursor - start_of_type : end_of_type - start_of_type));  // we need to try to avoid this copy
    string typeresult;
    if (gInterpreterHelper->ExistingTypeCheck(type, typeresult)
-       || gInterpreterHelper->GetPartiallyDesugaredNameWithScopeHandling(type, typeresult)) {
+       || gInterpreterHelper->GetPartiallyDesugaredNameWithScopeHandling(type, typeresult, false)) {
       // it is a known type
       if (!typeresult.empty()) {
          // and it is a typedef, we need to replace it in the output.
@@ -1486,11 +1486,6 @@ static void ResolveTypedefImpl(const char *tname,
 
    }
 
-   // When either of those two is true, we should probably go to modified
-   // mode. (Otherwise we rely on somebody else to strip the std::)
-   if (len > 5 && strncmp(tname+cursor,"std::",5) == 0) {
-      cursor += 5;
-   }
    if (len > 2 && strncmp(tname+cursor,"::",2) == 0) {
       cursor += 2;
       len -= 2;


### PR DESCRIPTION
This is needed to solve ROOT-10337.

```
root [0] struct Complex {};
root [1] auto v = std::vector<Complex>{};
root [2] TClassEdit::ResolveTypedef("std::vector<Complex>::value_type")
(std::string) "std::Complex"
```