### PR TITLE
Fixes in vmc for multi-engine mode (B. Volkel, I. Hrivnacova):

### DIFF
--- a/montecarlo/vmc/inc/TMCManager.h
+++ b/montecarlo/vmc/inc/TMCManager.h
@@ -105,6 +105,12 @@ public:
    /// Transfer track from current engine to target engine mc
    void TransferTrack(TVirtualMC *mc);
 
+   /// Try to restore geometry for a given track
+   Bool_t RestoreGeometryState(Int_t trackId, Bool_t checkTrackIdRange = kTRUE);
+
+   /// Try to restore geometry for the track currently set
+   Bool_t RestoreGeometryState();
+
    //
    // Steering and control
    //

--- a/montecarlo/vmc/inc/TMCManagerStack.h
+++ b/montecarlo/vmc/inc/TMCManagerStack.h
@@ -111,15 +111,6 @@ public:
    /// Get current particle's geometry status
    const TGeoBranchArray *GetCurrentGeoState() const;
 
-   //
-   // Action methods
-   //
-
-   /// To free the cached geo state which was associated to a track
-   void NotifyOnRestoredGeometry(Int_t trackId);
-   /// To free the cached geo state which was associated to the current track
-   void NotifyOnRestoredGeometry();
-
 private:
    friend class TMCManager;
    /// Check whether track trackId exists

--- a/montecarlo/vmc/inc/TMCParticleStatus.h
+++ b/montecarlo/vmc/inc/TMCParticleStatus.h
@@ -48,7 +48,7 @@ struct TMCParticleStatus {
    /// Print all info at once
    void Print() const
    {
-      ::Info("Print", "Status of track");
+      Info("Print", "Status of track");
       std::cout << "\t"
                 << "ID: " << fId << "\n"
                 << "\t"
@@ -90,6 +90,8 @@ struct TMCParticleStatus {
    Int_t fId = -1;
    /// Unique ID assigned by the user
    Int_t fParentId = -1;
+   /// Flags to (re)set for TGeoNavigator's fIsOutside state
+   Bool_t fIsOutside;
 
 private:
    /// Copying kept private

--- a/montecarlo/vmc/inc/TVirtualMC.h
+++ b/montecarlo/vmc/inc/TVirtualMC.h
@@ -867,28 +867,12 @@ public:
    /// Return the VMC's ID
    Int_t GetId() const { return fId; }
 
-   /// Check whether external geometry construction should be used
-   Bool_t UseExternalGeometryConstruction() const { return fUseExternalGeometryConstruction; }
-
-   /// Check whether external particle generation should be used
-   Bool_t UseExternalParticleGeneration() const { return fUseExternalParticleGeneration; }
-
 private:
    /// Set the VMC id
    void SetId(UInt_t id);
 
    /// Set container holding additional information for transported TParticles
    void SetManagerStack(TMCManagerStack *stack);
-
-   /// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
-   /// and hence rely on geometry construction being trigeered from outside.
-   void SetExternalGeometryConstruction(Bool_t value = kTRUE);
-
-   /// Disables internal dispatch to TVirtualMCApplication::GeneratePrimaries()
-   /// and tells the engine to not make any implicit assumptions on whether it's
-   /// a primary or a secondary. The track could have even been transported by
-   /// another engine to the current point.
-   void SetExternalParticleGeneration(Bool_t value = kTRUE);
 
    /// An interruptible event can be paused and resumed at any time. It must not
    /// call TVirtualMCApplication::BeginEvent() and ::FinishEvent()
@@ -916,23 +900,17 @@ private:
 #endif
 
 private:
-   Int_t fId;                               //!< Unique identification of this VMC
-                                            // (don't use TObject::SetUniqueId since this
-                                            // is used to uniquely identify TObjects in
-                                            // in general)
-                                            // An ID is given by the running TVirtualMCApp
-                                            // and not by the user.
-   TVirtualMCStack *fStack;                 //!< Particles stack
-   TMCManagerStack *fManagerStack;          //!< Stack handled by the TMCManager
-   TVirtualMCDecayer *fDecayer;             //!< External decayer
-   TRandom *fRandom;                        //!< Random number generator
-   TVirtualMagField *fMagField;             //!< Magnetic field
-   Bool_t fUseExternalGeometryConstruction; //!< Don't attempt to
-                                            // call
-                                            // TVirtualMCApplication
-                                            // hooks related to geometry
-   // construction
-   Bool_t fUseExternalParticleGeneration;
+   Int_t fId;                      //!< Unique identification of this VMC
+                                   // (don't use TObject::SetUniqueId since this
+                                   // is used to uniquely identify TObjects in
+                                   // in general)
+                                   // An ID is given by the running TVirtualMCApp
+                                   // and not by the user.
+   TVirtualMCStack *fStack;        //!< Particles stack
+   TMCManagerStack *fManagerStack; //!< Stack handled by the TMCManager
+   TVirtualMCDecayer *fDecayer;    //!< External decayer
+   TRandom *fRandom;               //!< Random number generator
+   TVirtualMagField *fMagField;    //!< Magnetic field
 
    ClassDef(TVirtualMC, 1) // Interface to Monte Carlo
 };

--- a/montecarlo/vmc/src/TMCManager.cxx
+++ b/montecarlo/vmc/src/TMCManager.cxx
@@ -97,10 +97,6 @@ void TMCManager::Register(TVirtualMC *mc)
    fStacks.emplace_back(new TMCManagerStack());
    mc->SetStack(fStacks.back().get());
    mc->SetManagerStack(fStacks.back().get());
-   // Don't attempt to call TVirtualMCApplication hooks related to geometry
-   // construction
-   mc->SetExternalGeometryConstruction();
-   mc->SetExternalParticleGeneration();
    // Must update engine pointers here since during construction of the concrete TVirtualMC
    // implementation the static TVirtualMC::GetMC() or defined gMC might be used.
    UpdateEnginePointers(mc);
@@ -313,6 +309,9 @@ void TMCManager::TransferTrack(TVirtualMC *mc)
    fParticlesStatus[trackId]->fTrackLength = fCurrentEngine->TrackLength();
    fParticlesStatus[trackId]->fWeight = fCurrentEngine->TrackWeight();
 
+   // Store TGeoNavidator's fIsOutside state
+   fParticlesStatus[trackId]->fIsOutside = gGeoManager->IsOutside();
+
    TGeoBranchArray *geoState = fBranchArrayContainer.GetNewGeoState(fParticlesStatus[trackId]->fGeoStateIndex);
    geoState->InitFromNavigator(gGeoManager->GetCurrentNavigator());
 
@@ -323,6 +322,38 @@ void TMCManager::TransferTrack(TVirtualMC *mc)
       fStacks[mc->GetId()]->PushSecondaryTrackId(trackId);
    }
    fCurrentEngine->InterruptTrack();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Try to restore geometry for a given track
+///
+
+Bool_t TMCManager::RestoreGeometryState(Int_t trackId, Bool_t checkTrackIdRange)
+{
+  if (checkTrackIdRange && (trackId < 0 || trackId >= static_cast<Int_t>(fParticles.size()) || !fParticles[trackId])) {
+     return kFALSE;
+  }
+  UInt_t& geoStateId = fParticlesStatus[trackId]->fGeoStateIndex;
+  if(geoStateId == 0) {
+    return kFALSE;
+  }
+  const TGeoBranchArray* branchArray = fBranchArrayContainer.GetGeoState(geoStateId);
+  branchArray->UpdateNavigator(gGeoManager->GetCurrentNavigator());
+  fBranchArrayContainer.FreeGeoState(geoStateId);
+  gGeoManager->SetOutside(fParticlesStatus[trackId]->fIsOutside);
+  geoStateId = 0;
+  return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Try to restore geometry for the track currently set
+///
+
+Bool_t TMCManager::RestoreGeometryState()
+{
+  return RestoreGeometryState(fStacks[fCurrentEngine->GetId()]->GetCurrentTrackNumber(), kFALSE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/montecarlo/vmc/src/TMCManagerStack.cxx
+++ b/montecarlo/vmc/src/TMCManagerStack.cxx
@@ -230,31 +230,6 @@ const TGeoBranchArray *TMCManagerStack::GetCurrentGeoState() const
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// To free the cached geo state which was associated to the current track
-///
-
-void TMCManagerStack::NotifyOnRestoredGeometry()
-{
-   fBranchArrayContainer->FreeGeoState(fParticlesStatus->operator[](fCurrentTrackId)->fGeoStateIndex);
-   fParticlesStatus->operator[](fCurrentTrackId)->fGeoStateIndex = 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// To free the cached geo state which was associated to a track
-///
-
-void TMCManagerStack::NotifyOnRestoredGeometry(Int_t trackId)
-{
-   if (!HasTrackId(trackId)) {
-      Fatal("NotifyOnRestoredGeometry", "Invalid track ID %i", trackId);
-   }
-   fBranchArrayContainer->FreeGeoState(fParticlesStatus->operator[](trackId)->fGeoStateIndex);
-   fParticlesStatus->operator[](trackId)->fGeoStateIndex = 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
 /// Check whether track trackId exists
 ///
 

--- a/montecarlo/vmc/src/TMCVerbose.cxx
+++ b/montecarlo/vmc/src/TMCVerbose.cxx
@@ -249,6 +249,7 @@ void TMCVerbose::Stepping()
 
       // Step number
       //
+      // std::cout << "#" << std::setw(4) << gMC->StepNumber() << "  ";
       std::cout << "#" << std::setw(4) << fStepNumber++ << "  ";
 
       // Position
@@ -310,7 +311,7 @@ void TMCVerbose::PostTrack()
 
 void TMCVerbose::FinishPrimary()
 {
-   if (fLevel==2)
+   if (fLevel==1)
       std::cout << "--- Finish primary " << std::endl;
 }
 

--- a/montecarlo/vmc/src/TVirtualMC.cxx
+++ b/montecarlo/vmc/src/TVirtualMC.cxx
@@ -37,8 +37,7 @@ TMCThreadLocal TVirtualMC *TVirtualMC::fgMC = nullptr;
 
 TVirtualMC::TVirtualMC(const char *name, const char *title, Bool_t /*isRootGeometrySupported*/)
    : TNamed(name, title), fApplication(nullptr), fId(0), fStack(nullptr), fManagerStack(nullptr), fDecayer(nullptr),
-     fRandom(nullptr), fMagField(nullptr), fUseExternalGeometryConstruction(kFALSE),
-     fUseExternalParticleGeneration(kFALSE)
+     fRandom(nullptr), fMagField(nullptr)
 {
    fApplication = TVirtualMCApplication::Instance();
 
@@ -58,8 +57,7 @@ TVirtualMC::TVirtualMC(const char *name, const char *title, Bool_t /*isRootGeome
 
 TVirtualMC::TVirtualMC()
    : TNamed(), fApplication(nullptr), fId(0), fStack(nullptr), fManagerStack(nullptr), fDecayer(nullptr),
-     fRandom(nullptr), fMagField(nullptr), fUseExternalGeometryConstruction(kFALSE),
-     fUseExternalParticleGeneration(kFALSE)
+     fRandom(nullptr), fMagField(nullptr)
 {
 }
 
@@ -213,28 +211,6 @@ void TVirtualMC::SetId(UInt_t id)
 void TVirtualMC::SetManagerStack(TMCManagerStack *stack)
 {
    fManagerStack = stack;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
-/// and hence rely on geometry construction being trigeered from outside.
-///
-
-void TVirtualMC::SetExternalGeometryConstruction(Bool_t value)
-{
-   fUseExternalGeometryConstruction = value;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
-/// and hence rely on geometry construction being trigeered from outside.
-///
-
-void TVirtualMC::SetExternalParticleGeneration(Bool_t value)
-{
-   fUseExternalParticleGeneration = value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Only rely on presence of TMCManager in multi run (PR#6 in vmc-project/vmc)
- Withdraw unwanted TMCVerbose modifications to avoid changes in the tests outputs
- Recover TGeoManager::fIsOutside for transfer tracks (PR#3 in vmc-project/vmc)