### PR TITLE
Prevent leak in TBasket when reading uncompressed TTree.

### DIFF
--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -491,8 +491,12 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
    // the basket was not compressed.
    TBuffer* readBufferRef;
    if (R__unlikely(fBranch->GetCompressionLevel()==0)) {
+      // Initialize the buffer to hold the uncompressed data.
+      fBufferRef = R__InitializeReadBasketBuffer(fBufferRef, len, file);
       readBufferRef = fBufferRef;
    } else {
+      // Initialize the buffer to hold the compressed data.
+      fCompressedBufferRef = R__InitializeReadBasketBuffer(fCompressedBufferRef, len, file);
       readBufferRef = fCompressedBufferRef;
    }
 
@@ -500,8 +504,6 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
    // and we will re-add the new size later on.
    fBranch->GetTree()->IncrementTotalBuffers(-fBufferSize);
 
-   // Initialize the buffer to hold the compressed data.
-   readBufferRef = R__InitializeReadBasketBuffer(readBufferRef, len, file);
    if (!readBufferRef) {
       Error("ReadBasketBuffers", "Unable to allocate buffer.");
       return 1;


### PR DESCRIPTION
This was first report at https://cdcvs.fnal.gov/redmine/issues/23348.