### PR TITLE
[TMVA experimental] Veto BDT inference tests on 32bit

### DIFF
--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -29,11 +29,10 @@ if(dataframe)
     ROOT_ADD_GTEST(rstandardscaler rstandardscaler.cxx LIBRARIES ROOTVecOps TMVA ROOTDataFrame)
     # RReader
     ROOT_ADD_GTEST(rreader rreader.cxx LIBRARIES ROOTVecOps TMVA ROOTDataFrame)
+    # Tree inference system and user interface
+    ROOT_ADD_GTEST(branchlessForest branchlessForest.cxx LIBRARIES TMVA)
+    ROOT_ADD_GTEST(rbdt rbdt.cxx LIBRARIES ROOTVecOps TMVA)
 endif()
-
-# Tree inference system and user interface
-ROOT_ADD_GTEST(branchlessForest branchlessForest.cxx LIBRARIES TMVA)
-ROOT_ADD_GTEST(rbdt rbdt.cxx LIBRARIES ROOTVecOps TMVA)
 
 if(dataframe AND pyroot_experimental)
   find_python_module(xgboost QUIET)


### PR DESCRIPTION
This fixes todays 32bit build: http://cdash.cern.ch/viewBuildError.php?buildid=733343