### PR TITLE
[cling] MetaSema code cleanup; add support in `.x` for a list of functions that will be called, in order (fallback)

### DIFF
--- a/interpreter/cling/include/cling/MetaProcessor/MetaSema.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaSema.h
@@ -11,7 +11,6 @@
 #define CLING_META_SEMA_H
 
 #include "cling/MetaProcessor/MetaProcessor.h"
-
 #include "cling/Interpreter/Transaction.h"
 
 #include "clang/Basic/FileManager.h" // for DenseMap<FileEntry*>
@@ -36,24 +35,20 @@ namespace cling {
     Interpreter& m_Interpreter;
     MetaProcessor& m_MetaProcessor;
     bool m_IsQuitRequested;
-    typedef llvm::DenseMap<const clang::FileEntry*, const Transaction*> Watermarks;
-    typedef llvm::DenseMap<const Transaction*, const clang::FileEntry*> ReverseWatermarks;
-    Watermarks m_Watermarks;
-    ReverseWatermarks m_ReverseWatermarks;
 
+    llvm::DenseMap<const clang::FileEntry*, const Transaction*> m_FEToTransaction;
+    llvm::DenseMap<const Transaction*, const clang::FileEntry*> m_TransactionToFE;
   public:
     enum SwitchMode {
       kOff = 0,
       kOn = 1,
       kToggle = 2
     };
-
     enum ActionResult {
       AR_Failure = 0,
       AR_Success = 1
     };
 
-  public:
     MetaSema(Interpreter& interp, MetaProcessor& meta);
 
     const Interpreter& getInterpreter() const { return m_Interpreter; }


### PR DESCRIPTION
Originally, the changes in this branch avoided the unload/load cycle for the `.x` command, if the timestamp of a file has not changed.  Due to potential problems with static variable initialization, this behavior is not finally part of this PR.

Other than that, this branch includes several improvements:
- General `MetaSema.cpp` code cleanup.
- `.x` now has a list of (fallback) function names that we will try to call, in order.  This makes it possible to add alternate entry points for a macro that are independent from the filename, and therefore immune to file renaming.