### PR TITLE
Doxygen formatting for V7 graphics

### DIFF
--- a/graf2d/gpadv7/doc/index.md
+++ b/graf2d/gpadv7/doc/index.md
@@ -1,0 +1,21 @@
+\defgroup ROOT7Graphics ROOT7 Graphics
+\ingroup Graphics
+\brief Classes for ROOT7 graphics.
+
+\warning This is part of the ROOT7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+
+\defgroup GpadROOT7 ROOT7 Pad related classes
+\ingroup ROOT7Graphics
+\brief The ROOT7 Pad related classes.
+
+\defgroup BaseROOT7 ROOT7 Base graphics classes
+\ingroup ROOT7Graphics
+\brief The ROOT7 Base graphics classes.
+
+\defgroup CanvasPainterROOT7 ROOT7 Canvas painting classes
+\ingroup ROOT7Graphics
+\brief The ROOT7 Canvas painting classes.
+
+\defgroup GrafROOT7 ROOT7 Graphics primitives
+\ingroup ROOT7Graphics
+\brief The ROOT7 Graphics primitives.

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrBase.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrBase.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RAttrBase.hxx
-/// \ingroup Gpad ROOT7
-/// \author Sergey Linev <s.linev@gsi.de>
-/// \date 2019-09-17
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -23,7 +16,14 @@
 namespace ROOT {
 namespace Experimental {
 
-/** Base class for all attributes, used with RDrawable */
+/** \class RAttrBase
+\ingroup GpadROOT7
+\author Sergey Linev <s.linev@gsi.de>
+\date 2019-09-17
+\brief Base class for all attributes, used with RDrawable
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
 class RAttrBase {
 
    friend class RAttrMap;

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrBox.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrBox.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RAttrBox.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2018-10-17
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -23,9 +16,14 @@
 namespace ROOT {
 namespace Experimental {
 
-/** class ROOT::Experimental::RAttrBox
- Drawing attributes for a box: rectangular lines with size and position.
- */
+/** \class RAttrBox
+\ingroup GpadROOT7
+\author Axel Naumann <axel@cern.ch>
+\date 2018-10-17
+\brief Drawing attributes for a box: rectangular lines with size and position.
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
 class RAttrBox : public RAttrBase {
 
    RAttrLine fBorder{this, "border_"};       ///<!

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrFill.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RAttrLine.hxx
-/// \ingroup Gpad ROOT7
-/// \author Sergey Linev
-/// \date 2019-09-13
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -22,9 +15,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** class ROOT::Experimental::RAttrLine
- Drawing line attributes for different objects.
- */
+/** \class RAttrFill
+\ingroup GpadROOT7
+\author Sergey Linev
+\date 2019-09-13
+\brief Drawing fill attributes for different objects.
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RAttrFill : public RAttrBase {
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrLine.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RAttrLine.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2018-10-12
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -22,9 +15,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** class ROOT::Experimental::RAttrLine
- Drawing line attributes for different objects.
- */
+/** \class RAttrLine
+\ingroup GpadROOT7
+\author Axel Naumann <axel@cern.ch>
+\date 2018-10-12
+\brief Drawing line attributes for different objects.
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RAttrLine : public RAttrBase {
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrMap.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrMap.hxx
@@ -1,11 +1,3 @@
-/// \file ROOT/RAttrMap.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \author Sergey Linev <s.linev@gsi.de>
-/// \date 2017-09-26
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -29,6 +21,13 @@ namespace ROOT {
 namespace Experimental {
 
 class RAttrBase;
+
+/** \class RAttrMap
+\ingroup GpadROOT7
+\authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
+\date 2017-09-26
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RAttrMap {
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrMarker.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RAttrMarker.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2018-10-12
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -22,9 +15,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RAttrMarker
- A marker attributes.
- */
+/** \class RAttrMarker
+\ingroup GpadROOT7
+\author Axel Naumann <axel@cern.ch>
+\date 2018-10-12
+\brief A marker attributes.
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RAttrMarker : public RAttrBase {
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrText.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RAttrText.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2018-10-12
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -24,9 +17,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RText
- A text.
- */
+/** \class RAttrText
+\ingroup GpadROOT7
+\brief A text.attributes.
+\author Axel Naumann <axel@cern.ch>
+\date 2018-10-12
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 
 class RAttrText : public RAttrBase {

--- a/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RCanvas.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2015-07-08
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -26,9 +19,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RCanvas
-  A window's topmost `RPad`.
-  */
+/** \class RCanvas
+\ingroup GpadROOT7
+\brief A window's topmost `RPad`.
+\author Axel Naumann <axel@cern.ch>
+\date 2015-07-08
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RCanvas: public RPadBase {
 friend class RPadBase;  /// use for ID generation

--- a/graf2d/gpadv7/v7/inc/ROOT/RColor.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RColor.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RColor.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-09-26
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -26,6 +19,14 @@ namespace Experimental {
 
 // TODO: see also imagemagick's C++ interface for RColor operations!
 // https://www.imagemagick.org/api/magick++-classes.php
+
+/** \class RColor
+\ingroup GpadROOT7
+\brief The color class
+\author Axel Naumann <axel@cern.ch>
+\date 2017-09-26
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RColor : public RAttrBase {
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RDisplayItem.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RDisplayItem.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RDisplayItem.h
-/// \ingroup Base ROOT7
-/// \author Sergey Linev
-/// \date 2017-05-31
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -31,8 +24,12 @@ class RCanvas;
 class RFrame;
 
 /** \class RDisplayItem
-  Base class for painting data for JS.
-  */
+\ingroup BaseROOT7
+\brief Base class for painting data for JS.
+\author Sergey Linev
+\date 2017-05-31
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RDisplayItem {
 protected:

--- a/graf2d/gpadv7/v7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RDrawable.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RDrawable.hxx
-/// \ingroup Base ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2015-08-07
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -34,6 +27,13 @@ class RDisplayItem;
 
 
 namespace Internal {
+
+/** \class RIOSharedBase
+\ingroup BaseROOT7
+\\author Axel Naumann <axel@cern.ch>
+\date 2015-08-07
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RIOSharedBase {
 public:
@@ -87,8 +87,12 @@ public:
 }
 
 /** \class RDrawable
-  Base class for drawable entities: objects that can be painted on a `RPad`.
- */
+\ingroup BaseROOT7
+\brief Base class for drawable entities: objects that can be painted on a `RPad`.
+\author Axel Naumann <axel@cern.ch>
+\date 2015-08-07
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RDrawable {
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RFrame.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RFrame.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-09-26
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -27,9 +20,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RFrame
-  Holds a user coordinate system with a palette.
-  */
+/** \class RFrame
+\ingroup GpadROOT7
+\brief Holds a user coordinate system with a palette.
+\author Axel Naumann <axel@cern.ch>
+\date 2017-09-26
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RFrame : public RDrawable  {
 public:

--- a/graf2d/gpadv7/v7/inc/ROOT/RMenuItem.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RMenuItem.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RMenuItem.hxx
-/// \ingroup Base ROOT7
-/// \author Sergey Linev
-/// \date 2017-06-29
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -27,8 +20,12 @@ namespace Experimental {
 namespace Detail {
 
 /** \class RMenuItem
-  Class contains info for producing menu item on the JS side.
-  */
+\ingroup BaseROOT7
+\brief Class contains info for producing menu item on the JS side.
+\author Sergey Linev
+\date 2017-06-29
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RMenuItem {
 protected:

--- a/graf2d/gpadv7/v7/inc/ROOT/RObjectDrawable.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RObjectDrawable.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RObjectDrawable.hxx
-/// \ingroup Base ROOT7
-/// \author Sergey Linev
-/// \date 2017-05-31
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -25,8 +18,14 @@ namespace Experimental {
 
 class RPadBase;
 
-/// \class ROOT::Experimental::Internal::RObjectDrawable
-/// Provides v7 drawing facilities for TObject types (TGraph etc).
+/** \class RObjectDrawable
+\ingroup BaseROOT7
+\brief Provides v7 drawing facilities for TObject types (TGraph etc).
+\author Sergey Linev
+\date 2017-05-31
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
 class RObjectDrawable final : public RDrawable {
 
    Internal::RIOShared<TObject> fObj; ///< The object to be painted

--- a/graf2d/gpadv7/v7/inc/ROOT/RPad.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPad.hxx
@@ -1,11 +1,3 @@
-/// \file ROOT/RPad.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \author Sergey Linev <s.linev@gsi.de>
-/// \date 2017-07-06
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -23,9 +15,13 @@ namespace ROOT {
 namespace Experimental {
 
 
-/** \class ROOT::Experimental::RPad
-  Graphic container for `RDrawable`-s.
-  */
+/** \class RPad
+\ingroup GpadROOT7
+\brief Graphic container for `RDrawable`-s.
+\authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
+\date 2017-07-06
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RPad: public RPadBase {
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadBase.hxx
@@ -1,11 +1,3 @@
-/// \file ROOT/RPadBase.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \author Sergey Linev <s.linev@gsi.de>
-/// \date 2019-10-02
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -35,8 +27,12 @@ class RCanvas;
 class RPadBaseDisplayItem;
 
 /** \class ROOT::Experimental::RPadBase
-  Base class for graphic containers for `RDrawable`-s.
-  */
+\ingroup GpadROOT7
+\brief Base class for graphic containers for `RDrawable`-s.
+\authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
+\date 2019-10-02
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RPadBase : public RDrawable {
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadDisplayItem.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadDisplayItem.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RPadDisplayItem.hxx
-/// \ingroup Base ROOT7
-/// \author Sergey Linev
-/// \date 2017-05-31
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -23,8 +16,15 @@
 namespace ROOT {
 namespace Experimental {
 
-/// Display item for the RPadBase
-/// Includes primitives and frames
+
+/** class RPadBaseDisplayItem
+\ingroup BaseROOT7
+\brief Display item for the RPadBase
+Includes primitives and frames
+\author Sergey Linev
+\date 2017-05-31
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RPadBaseDisplayItem : public RDisplayItem {
 public:

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadExtent.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadExtent.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RPadExtent.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-07-07
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -24,9 +17,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RPadExtent
-  An extent / size (horizontal and vertical) in a `RPad`.
-  */
+/** \class RPadExtent
+\ingroup GpadROOT7
+\brief An extent / size (horizontal and vertical) in a `RPad`.
+\author Axel Naumann <axel@cern.ch>
+\date 2017-07-07
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 class RPadExtent  {
 
    RPadLength fHoriz;   ///<  horizontal part
@@ -78,9 +75,10 @@ public:
       return *this;
    };
 
-   /** \class ScaleFactor
-      A scale factor (separate factors for horizontal and vertical) for scaling a `RPadLength`.
-      */
+   /** \struct ScaleFactor
+       \ingroup GpadROOT7
+       \brief A scale factor (separate factors for horizontal and vertical) for scaling a `RPadLength`.
+   */
    struct ScaleFactor {
       double fHoriz; ///< Horizontal scale factor
       double fVert;  ///< Vertical scale factor

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadLength.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadLength.hxx
@@ -1,9 +1,9 @@
-/// \file ROOT/RPadLength.hxx
-/// \ingroup Gpad ROOT7
+/// \defgroup ROOT7PadCoordSystems ROOT7 RPad coordinate systems
+/// \ingroup ROOT7Graphics
+/// \brief The ROOT7 RPad coordinate systems.
+///
 /// \author Axel Naumann <axel@cern.ch>
 /// \date 2017-07-06
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
@@ -21,6 +21,11 @@
 
 namespace ROOT {
 namespace Experimental {
+
+   /** \class RPadLength
+       \ingroup ROOT7PadCoordSystems
+       \brief A length in RPad.
+    */
 
 class RPadLength  {
 
@@ -67,29 +72,36 @@ public:
       // no ==, !=
    };
 
-   /// \defgroup PadCoordSystems RPad coordinate systems
-   /// These define typesafe coordinates used by RPad to identify which coordinate system a coordinate is referring to.
+   /// \defgroup TypesafeCoordinates Typesafe Coordinates
+   /// \ingroup ROOT7PadCoordSystems
+   /// These define typesafe coordinates used by RPad to identify which coordinate system a coordinate is referring to
    /// The origin (0,0) is in the `RPad`'s bottom left corner for all of them.
    /// \{
 
-   /** \class Normal
-     A normalized coordinate: 0 in the left, bottom corner, 1 in the top, right corner of the `RPad`. Resizing the pad
-     will resize the objects with it.
+   /** \struct Normal
+       \brief A normalized coordinate.
+
+     0 in the left, bottom corner, 1 in the top, right corner of the `RPad`.
+     Resizing the pad will resize the objects with it.
     */
    struct Normal: CoordSysBase<Normal> {
       using CoordSysBase<Normal>::CoordSysBase;
    };
 
-   /** \class Pixel
-     A pixel coordinate: 0 in the left, bottom corner, 1 in the top, right corner of the `RPad`. Resizing the pad will
-     keep the pixel-position of the objects positioned in `Pixel` coordinates.
+   /** \struct Pixel
+       \brief A pixel coordinate.
+
+     0 in the left, bottom corner, 1 in the top, right corner of the `RPad`.
+     Resizing the pad will keep the pixel-position of the objects positioned in `Pixel` coordinates.
     */
    struct Pixel: CoordSysBase<Pixel> {
       using CoordSysBase<Pixel>::CoordSysBase;
    };
 
-   /** \class User
-     A user coordinate, as defined by the EUserCoordSystem parameter of the `RPad`.
+   /** \struct User
+       \brief A user coordinate.
+
+       as defined by the EUserCoordSystem parameter of the `RPad`.
     */
    struct User: CoordSysBase<User> {
       using CoordSysBase<User>::CoordSysBase;

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadPos.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadPos.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RPadPos.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-07-07
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -25,8 +18,13 @@ namespace ROOT {
 namespace Experimental {
 
 /** \class ROOT::Experimental::RPadPos
-  A position (horizontal and vertical) in a `RPad`.
-  */
+\ingroup GpadROOT7
+\brief A position (horizontal and vertical) in a `RPad`.
+\author Axel Naumann <axel@cern.ch>
+\date 2017-07-07
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
 class RPadPos {
 
    RPadLength fHoriz;   ///<  horizontal part
@@ -94,8 +92,9 @@ public:
    };
 
    /** \class ScaleFactor
-      A scale factor (separate factors for horizontal and vertical) for scaling a `RPadLength`.
-      */
+       \ingroup GpadROOT7
+       \brief A scale factor (separate factors for horizontal and vertical) for scaling a `RPadLength`.
+   */
    struct ScaleFactor {
       double fHoriz; ///< Horizontal scale factor
       double fVert;  ///< Vertical scale factor

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadUserAxis.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadUserAxis.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RPadUserAxis.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-07-15
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -24,9 +17,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::Internal::RPadUserAxisBase
-  Base class for user coordinates (e.g. for histograms) used by `RPad` and `RCanvas`.
-  */
+/** \class RPadUserAxisBase
+\ingroup GpadROOT7
+\brief Base class for user coordinates (e.g. for histograms) used by `RPad` and `RCanvas`.
+\author Axel Naumann <axel@cern.ch>
+\date 2017-07-15
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RPadUserAxisBase {
 public:

--- a/graf2d/gpadv7/v7/inc/ROOT/RPalette.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPalette.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RPalette.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-09-26
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -25,8 +18,9 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RPalette
-  A set of colors. `RColor`s can be conveniently generated from this.
+/** \class RPalette
+\ingroup GpadROOT7
+\brief A set of colors. `RColor`s can be conveniently generated from this.
 
   A palette associates a color with an ordinal number: for a normalized palette,
   this number ranges from 0..1. For user-valued palettes, the palette yields a color for
@@ -34,12 +28,16 @@ namespace Experimental {
 
   A palette can be a smooth gradients by interpolation of support points, or a set of
   discrete colors.
-  */
+
+\author Axel Naumann <axel@cern.ch>
+\date 2017-09-26
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+
+*/
+
 class RPalette {
 public:
-   /** \class ROOT::Experimental::RPalette::OrdinalAndColor
-    An ordinal value and its associated color.
-    */
+   /// An ordinal value and its associated color.
    struct OrdinalAndColor {
       double fOrdinal; ///< The value associated with the color.
       RColor fColor;   ///< The color associated with the value.

--- a/graf2d/gpadv7/v7/inc/ROOT/RStyle.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RStyle.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RStyle.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-10-10
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -29,9 +22,13 @@ namespace Experimental {
 
 class RDrawable;
 
-/** \class ROOT::Experimental::RStyle
-  A set of defaults for graphics attributes, e.g. for histogram fill color, line width, frame offsets etc.
-  */
+/** \class RStyle
+\ingroup GpadROOT7
+\brief A set of defaults for graphics attributes, e.g. for histogram fill color, line width, frame offsets etc.
+\author Axel Naumann <axel@cern.ch>
+\date 2017-10-10
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RStyle {
 public:

--- a/graf2d/gpadv7/v7/inc/ROOT/RVirtualCanvasPainter.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RVirtualCanvasPainter.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RVirtualCanvasPainter.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-05-31
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -31,8 +24,12 @@ class RWebWindow;
 namespace Internal {
 
 /** \class ROOT::Experimental::Internal::RVirtualCanvasPainter
-  Abstract interface for painting a canvas.
-  */
+\ingroup GpadROOT7
+\brief Abstract interface for painting a canvas.
+\author Axel Naumann <axel@cern.ch>
+\date 2017-05-31
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RVirtualCanvasPainter {
 protected:

--- a/graf2d/gpadv7/v7/src/RAttrBase.cxx
+++ b/graf2d/gpadv7/v7/src/RAttrBase.cxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RAttrBase.cxx
-/// \ingroup Gpad ROOT7
-/// \author Sergey Linev <s.linev@gsi.de>
-/// \date 2019-09-17
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RAttrMap.cxx
+++ b/graf2d/gpadv7/v7/src/RAttrMap.cxx
@@ -1,11 +1,3 @@
-/// \file RAttrMap.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \author Sergey Linev <s.linev@gsi.de>
-/// \date 2017-09-26
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/v7/src/RCanvas.cxx
@@ -1,10 +1,3 @@
-/// \file RCanvas.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2015-07-10
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -78,15 +71,15 @@ std::shared_ptr<ROOT::Experimental::RCanvas> ROOT::Experimental::RCanvas::Create
 
 //////////////////////////////////////////////////////////////////////////
 /// Create new display for the canvas
-/// Parameter \par where specifies which program could be used for display creation
+/// The parameter `where` specifies which program could be used for display creation
 /// Possible values:
 ///
-///      cef - Chromium Embeded Framework, local display, local communication
-///      qt5 - Qt5 WebEngine (when running via rootqt5), local display, local communication
-///  browser - default system web-browser, communication via random http port from range 8800 - 9800
-///  <prog> - any program name which will be started instead of default browser, like firefox or /usr/bin/opera
-///           one could also specify $url in program name, which will be replaced with canvas URL
-///  native - either any available local display or default browser
+///  - `cef` Chromium Embeded Framework, local display, local communication
+///  - `qt5` Qt5 WebEngine (when running via rootqt5), local display, local communication
+///  - `browser` default system web-browser, communication via random http port from range 8800 - 9800
+///  - `<prog>` any program name which will be started instead of default browser, like firefox or /usr/bin/opera
+///     one could also specify $url in program name, which will be replaced with canvas URL
+///  - `native` either any available local display or default browser
 ///
 ///  Canvas can be displayed in several different places
 

--- a/graf2d/gpadv7/v7/src/RColor.cxx
+++ b/graf2d/gpadv7/v7/src/RColor.cxx
@@ -1,10 +1,3 @@
-/// \file RColor.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-09-27
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RDisplayItem.cxx
+++ b/graf2d/gpadv7/v7/src/RDisplayItem.cxx
@@ -1,10 +1,3 @@
-/// \file RDisplayItem.cxx
-/// \ingroup Base ROOT7
-/// \author Sergey Linev
-/// \date 2017-05-31
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RDrawable.cxx
+++ b/graf2d/gpadv7/v7/src/RDrawable.cxx
@@ -1,10 +1,3 @@
-/// \file RDrawable.cxx
-/// \ingroup Base ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2015-07-08
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RFrame.cxx
+++ b/graf2d/gpadv7/v7/src/RFrame.cxx
@@ -1,10 +1,3 @@
-/// \file RFrame.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-09-26
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RMenuItem.cxx
+++ b/graf2d/gpadv7/v7/src/RMenuItem.cxx
@@ -1,10 +1,3 @@
-/// \file RMenuItem.cxx
-/// \ingroup Base ROOT7
-/// \author Sergey Linev
-/// \date 2017-07-18
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RObjectDrawable.cxx
+++ b/graf2d/gpadv7/v7/src/RObjectDrawable.cxx
@@ -1,10 +1,3 @@
-/// \file RObjectDrawable.cxx
-/// \ingroup CanvasPainter ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-05-31
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RPad.cxx
+++ b/graf2d/gpadv7/v7/src/RPad.cxx
@@ -1,10 +1,3 @@
-/// \file RPad.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-07-07
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/v7/src/RPadBase.cxx
@@ -1,10 +1,3 @@
-/// \file RPad.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-07-07
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RPadExtent.cxx
+++ b/graf2d/gpadv7/v7/src/RPadExtent.cxx
@@ -1,10 +1,3 @@
-/// \file RPadExtent.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2018-02-08
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RPadLength.cxx
+++ b/graf2d/gpadv7/v7/src/RPadLength.cxx
@@ -1,10 +1,3 @@
-/// \file RPadLength.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2018-07-22
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RPadPos.cxx
+++ b/graf2d/gpadv7/v7/src/RPadPos.cxx
@@ -1,10 +1,3 @@
-/// \file RPadPos.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2018-02-08
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RPadUserAxis.cxx
+++ b/graf2d/gpadv7/v7/src/RPadUserAxis.cxx
@@ -1,9 +1,10 @@
-/// \file RPadUserAxis.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-08-14
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
 
 #include <ROOT/RPadUserAxis.hxx>
 

--- a/graf2d/gpadv7/v7/src/RPalette.cxx
+++ b/graf2d/gpadv7/v7/src/RPalette.cxx
@@ -1,10 +1,3 @@
-/// \file RPalette.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-09-27
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RStyle.cxx
+++ b/graf2d/gpadv7/v7/src/RStyle.cxx
@@ -1,11 +1,3 @@
-/// \file RStyle.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \author Sergey Linev <s.linev@gsi.de>
-/// \date 2017-10-11
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RStyleReader.cxx
+++ b/graf2d/gpadv7/v7/src/RStyleReader.cxx
@@ -1,10 +1,3 @@
-/// \file RDrawingOptsReader.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-09-26
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/gpadv7/v7/src/RStyleReader.hxx
+++ b/graf2d/gpadv7/v7/src/RStyleReader.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RStyleReader.hxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-09-29
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -26,10 +19,14 @@
 namespace ROOT {
 namespace Experimental {
 namespace Internal {
-/** \class ROOT::Experimental::RStyleReader
- Reads the attribute config values from `.rootstylerc`. If the style entry is not found there, tries `~/.rootstylerc`
- and finally `$ROOTSYS/etc/system.rootstylerc`.
-  */
+/** \class RStyleReader
+\ingroup GpadROOT7
+\brief Reads the attribute config values from `.rootstylerc`.
+If the style entry is not found there, tries `~/.rootstylerc` and finally `$ROOTSYS/etc/system.rootstylerc`.
+\author Axel Naumann <axel@cern.ch>
+\date 2017-09-29
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 /*
 class RStyleReader {

--- a/graf2d/gpadv7/v7/src/RVirtualCanvasPainter.cxx
+++ b/graf2d/gpadv7/v7/src/RVirtualCanvasPainter.cxx
@@ -1,10 +1,3 @@
-/// \file RVirtualCanvasPainter.cxx
-/// \ingroup Gpad ROOT7
-/// \author Axel Naumann <axel@cern.ch>
-/// \date 2017-05-31
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/primitives/v7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RBox.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RBox.hxx
-/// \ingroup Graf ROOT7
-/// \author Olivier Couet <Olivier.Couet@cern.ch>
-/// \date 2017-10-16
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -26,9 +19,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RBox
- A simple box.
- */
+/** \class RBox
+\ingroup GrafROOT7
+\brief A simple box.
+\author Olivier Couet <Olivier.Couet@cern.ch>
+\date 2017-10-16
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RBox : public RDrawable {
 

--- a/graf2d/primitives/v7/inc/ROOT/RLine.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RLine.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RLine.hxx
-/// \ingroup Graf ROOT7
-/// \author Olivier Couet <Olivier.Couet@cern.ch>
-/// \date 2017-10-16
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -24,6 +17,14 @@
 
 namespace ROOT {
 namespace Experimental {
+
+/** \class RLine
+\ingroup GrafROOT7
+\brief A simple line.
+\author Olivier Couet <Olivier.Couet@cern.ch>
+\date 2017-10-16
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RLine : public RDrawable {
 

--- a/graf2d/primitives/v7/inc/ROOT/RMarker.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RMarker.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RMarker.hxx
-/// \ingroup Graf ROOT7
-/// \author Olivier Couet <Olivier.Couet@cern.ch>
-/// \date 2017-10-16
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -26,9 +19,13 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RMarker
- A simple marker.
- */
+/** \class RMarker
+\ingroup GrafROOT7
+\brief A simple marker.
+\author Olivier Couet <Olivier.Couet@cern.ch>
+\date 2017-10-16
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RMarker : public RDrawable {
 

--- a/graf2d/primitives/v7/inc/ROOT/RText.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RText.hxx
@@ -1,10 +1,3 @@
-/// \file ROOT/RText.hxx
-/// \ingroup Graf ROOT7
-/// \author Olivier Couet <Olivier.Couet@cern.ch>
-/// \date 2017-10-16
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -27,8 +20,12 @@ namespace ROOT {
 namespace Experimental {
 
 /** \class ROOT::Experimental::RText
- A text.
- */
+\ingroup GrafROOT7
+\brief A text.
+\author Olivier Couet <Olivier.Couet@cern.ch>
+\date 2017-10-16
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RText : public RDrawable {
 

--- a/graf2d/primitives/v7/src/RBox.cxx
+++ b/graf2d/primitives/v7/src/RBox.cxx
@@ -1,10 +1,3 @@
-/// \file RLine.cxx
-/// \ingroup Graf ROOT7
-/// \author Olivier Couet <Olivier.Couet@cern.ch>
-/// \date 2018-03-08
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/primitives/v7/src/RLine.cxx
+++ b/graf2d/primitives/v7/src/RLine.cxx
@@ -1,10 +1,3 @@
-/// \file RLine.cxx
-/// \ingroup Graf ROOT7
-/// \author Olivier Couet <Olivier.Couet@cern.ch>
-/// \date 2018-03-08
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/primitives/v7/src/RMarker.cxx
+++ b/graf2d/primitives/v7/src/RMarker.cxx
@@ -1,10 +1,3 @@
-/// \file RMarker.cxx
-/// \ingroup Graf ROOT7
-/// \author Olivier Couet <Olivier.Couet@cern.ch>
-/// \date 2018-03-08
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/graf2d/primitives/v7/src/RText.cxx
+++ b/graf2d/primitives/v7/src/RText.cxx
@@ -1,10 +1,3 @@
-/// \file RText.cxx
-/// \ingroup Graf ROOT7
-/// \author Olivier Couet <Olivier.Couet@cern.ch>
-/// \date 2017-07-07
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
-
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *


### PR DESCRIPTION
Revisit the doxygen formatting for ROOT 7 graphics.
Make new groups to better reflect the structure in "Functional part"of the Reference guide.