### PR TITLE
[TMVA experimental] Add branchless jitted forests as inference backend

### DIFF
--- a/tmva/tmva/inc/TMVA/RBDT.hxx
+++ b/tmva/tmva/inc/TMVA/RBDT.hxx
@@ -31,7 +31,7 @@ namespace TMVA {
 namespace Experimental {
 
 /// Fast boosted decision tree inference
-template <typename Backend = BranchlessForest<float>>
+template <typename Backend = BranchlessJittedForest<float>>
 class RBDT {
 public:
    using Value_t = typename Backend::Value_t;
@@ -114,6 +114,7 @@ public:
 };
 
 extern template class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessForest<float>>;
+extern template class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessJittedForest<float>>;
 
 } // namespace Experimental
 } // namespace TMVA

--- a/tmva/tmva/inc/TMVA/TreeInference/Forest.hxx
+++ b/tmva/tmva/inc/TMVA/TreeInference/Forest.hxx
@@ -29,6 +29,8 @@
 
 #include "TFile.h"
 #include "TDirectory.h"
+#include "TInterpreter.h"
+#include "TUUID.h"
 
 #include "BranchlessTree.hxx"
 #include "Objectives.hxx"
@@ -175,6 +177,176 @@ BranchlessForest<T>::Load(const std::string &key, const std::string &filename, c
    delete inputs;
    delete thresholds;
    file->Close();
+}
+
+/// Forest using branchless jitted trees
+///
+/// \tparam T Value type for the computation (usually floating point type)
+template <typename T>
+struct BranchlessJittedForest : public ForestBase<T, std::function<void (const T *, const int, bool, T*)>> {
+    std::string Load(const std::string &key, const std::string &filename, const int output = 0, const bool sortTrees = true);
+   void Inference(const T *inputs, const int rows, bool layout, T *predictions);
+};
+
+/// Load parameters from a ROOT file to the branchless trees
+///
+/// \param[in] key Name of folder in the ROOT file containing the model parameters
+/// \param[in] filename Filename of the ROOT file
+/// \param[in] output Load trees corresponding to the given output node of the forest
+/// \param[in] sortTrees Flag to indicate sorting the input trees by the cut value of the first node of each tree
+template <typename T>
+inline std::string
+BranchlessJittedForest<T>::Load(const std::string &key, const std::string &filename, const int output, const bool sortTrees)
+{
+   // Open input file and get folder from key
+   auto file = TFile::Open(filename.c_str(), "READ");
+
+   // Load parameters from file
+   auto maxDepth = Internal::GetObjectSafe<std::vector<int>>(file, filename, key + "/max_depth");
+   auto numTrees = Internal::GetObjectSafe<std::vector<int>>(file, filename, key + "/num_trees");
+   auto numInputs = Internal::GetObjectSafe<std::vector<int>>(file, filename, key + "/num_inputs");
+   auto numOutputs = Internal::GetObjectSafe<std::vector<int>>(file, filename, key + "/num_outputs");
+   auto objective = Internal::GetObjectSafe<std::string>(file, filename, key + "/objective");
+   auto inputs = Internal::GetObjectSafe<std::vector<int>>(file, filename, key + "/inputs");
+   auto outputs = Internal::GetObjectSafe<std::vector<int>>(file, filename, key + "/outputs");
+   auto thresholds = Internal::GetObjectSafe<std::vector<T>>(file, filename, key + "/thresholds");
+
+   this->fNumInputs = numInputs->at(0);
+   this->fObjectiveFunc = Objectives::GetFunction<T>(*objective);
+   const auto lenInputs = std::pow(2, maxDepth->at(0)) - 1;
+   const auto lenThresholds = std::pow(2, maxDepth->at(0) + 1) - 1;
+
+   // Find number of trees corresponding to given output node
+   if (output > numOutputs->at(0))
+      throw std::runtime_error("Given output node of the forest is larger or equal to number of output nodes.");
+   int c = 0;
+   for (int i = 0; i < numTrees->at(0); i++)
+      if (outputs->at(i) == output)
+         c++;
+   if (c == 0)
+      std::runtime_error("No trees found for given output node of the forest.");
+
+   // Get typename of template argument as string
+   // TODO
+   std::string typeName = "float";
+
+   // Load parameters in trees
+   std::vector<T> firstThreshold(c);
+   std::vector<int> firstInput(c, -1);
+   std::vector<std::string> codes(c);
+   c = 0;
+   for (int i = 0; i < numTrees->at(0); i++) {
+      // Select only trees for the given output node of the forest
+      if (outputs->at(i) != output)
+         continue;
+
+      // Set tree depth
+      BranchlessTree<T> tree;
+      tree.fTreeDepth = maxDepth->at(0);
+
+      // Set feature indices
+      tree.fInputs.resize(lenInputs);
+      for (int j = 0; j < lenInputs; j++)
+         tree.fInputs[j] = inputs->at(i * lenInputs + j);
+
+      // Set threshold values
+      tree.fThresholds.resize(lenThresholds);
+      for (int j = 0; j < lenThresholds; j++)
+         tree.fThresholds[j] = thresholds->at(i * lenThresholds + j);
+
+      // Fill sparse trees fully
+      tree.FillSparse();
+
+      // Save first threshold and input index for ordering the trees later
+      firstThreshold[c] = tree.fThresholds[0];
+      if (lenInputs != 0)
+          firstInput[c] = tree.fInputs[0];
+
+      // Save code for jitting
+      std::stringstream ss;
+      ss << "tree" << c;
+      codes[c] = tree.GetInferenceCode(ss.str(), typeName);
+
+      c++;
+   }
+
+   // Sort trees by first cut variable and threshold value
+   std::vector<int> treeIndices(codes.size());
+   for(int i = 0; i < c; i++) treeIndices[i] = i;
+   if (sortTrees) {
+      auto compareIndices = [&firstInput, &firstThreshold](int i, int j)
+              {
+                 if (firstInput[i] == firstInput[j])
+                    return firstThreshold[i] < firstThreshold[j];
+                 else
+                    return firstInput[i] < firstInput[j];
+              };
+      std::sort(treeIndices.begin(), treeIndices.end(), compareIndices);
+   }
+
+   // Get unique ID for a private namespace
+   TUUID uuid;
+   std::string nameSpace = uuid.AsString();
+   for (auto& v : nameSpace) {
+      if (v == '-') v = '_';
+   }
+   nameSpace = "ns_" + nameSpace;
+
+   // JIT the forest
+   // TODO: Error-handling
+   std::stringstream jitForest;
+   jitForest << "#pragma cling optimize(3)\n"
+             << "namespace " << nameSpace << " {\n";
+   for (int i = 0; i < static_cast<int>(codes.size()); i++) {
+      jitForest << codes[treeIndices[i]] << "\n\n";
+   }
+   jitForest << "void Inference(const "
+             << typeName << "* inputs, const int rows, bool layout, "
+             << typeName << "* predictions)"
+             << "\n{\n"
+             << "   const auto strideTree = layout ? 1 : rows;\n"
+             << "   const auto strideBatch = layout ? " << this->fNumInputs << " : 1;\n"
+             << "   for (int i = 0; i < rows; i++) {\n"
+             << "      predictions[i] = 0.0;\n";
+   for (int i = 0; i < static_cast<int>(codes.size()); i++) {
+      std::stringstream ss;
+      ss << "tree" << i;
+      const std::string funcName = ss.str();
+      jitForest << "      predictions[i] += " << funcName << "(inputs + i * strideBatch, strideTree);\n";
+   }
+   jitForest << "   }\n"
+             << "}\n"
+             << "} // end namespace " << nameSpace;
+   const std::string jitForestStr = jitForest.str(); // DEBUG
+   gInterpreter->Declare(jitForestStr.c_str());
+
+   // Get function pointer and attach pointer to the forest
+   // TODO: Error-handling
+   std::stringstream treesFunc;
+   treesFunc << "#pragma cling optimize(3)\n" << nameSpace << "::Inference";
+   const std::string treesFuncStr = treesFunc.str();
+   auto ptr = gInterpreter->Calc(treesFuncStr.c_str());
+   this->fTrees = reinterpret_cast<void (*)(const T *, int, bool, float*)>(ptr);
+
+   // Clean-up
+   delete maxDepth;
+   delete numTrees;
+   delete numInputs;
+   delete objective;
+   delete inputs;
+   delete thresholds;
+   file->Close();
+
+   return jitForestStr;
+}
+
+// TODO: Put doxygen header
+template <typename T>
+void BranchlessJittedForest<T>::Inference(const T *inputs, const int rows, bool layout, T *predictions)
+{
+   this->fTrees(inputs, rows, layout, predictions);
+   for (int i = 0; i < rows; i++)
+      predictions[i] = this->fObjectiveFunc(predictions[i]);
 }
 
 } // namespace Experimental

--- a/tmva/tmva/src/RBDT.cxx
+++ b/tmva/tmva/src/RBDT.cxx
@@ -1,3 +1,4 @@
 #include "TMVA/RBDT.hxx"
 
 template class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessForest<float>>;
+template class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessJittedForest<float>>;

--- a/tmva/tmva/test/branchlessForest.cxx
+++ b/tmva/tmva/test/branchlessForest.cxx
@@ -82,16 +82,69 @@ TEST(BranchlessTree, InferenceSparseTreeDepth2)
    EXPECT_FLOAT_EQ(tree.Inference(input3, 1), 6.0);
 }
 
-TEST(BranchlessForest, InferenceSingleTree)
+TEST(BranchlessJittedTree, InferenceFullTreeDepth0)
+{
+   BranchlessTree<float> tree;
+   tree.fTreeDepth = 0;
+   tree.fThresholds = {-1.0};
+   tree.fInputs = {};
+   const auto code = tree.GetInferenceCode("foo", "float");
+   float r = JittedTreeInference<float>("BranchlessJittedTree001", "foo", code, nullptr, 1);
+   EXPECT_FLOAT_EQ(tree.Inference(nullptr, 1), r);
+}
+
+TEST(BranchlessJittedTree, InferenceFullTreeDepth1)
+{
+   BranchlessTree<float> tree;
+   tree.fTreeDepth = 1;
+   tree.fThresholds = {0.0, 1.0, -1.0};
+   tree.fInputs = {0};
+   float input[1] = {999.0};
+   const auto code = tree.GetInferenceCode("foo", "float");
+   float r = JittedTreeInference<float>("BranchlessJittedTree002", "foo", code, input, 1);
+   EXPECT_FLOAT_EQ(tree.Inference(input, 1), r);
+}
+
+TEST(BranchlessJittedTree, InferenceFullTreeDepth2)
+{
+   BranchlessTree<float> tree;
+   tree.fTreeDepth = 2;
+   tree.fThresholds = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+   tree.fInputs = {0, 1, 2};
+
+   float input0[3] = {-1.0, 0.0, -999.0};
+   const auto code0 = tree.GetInferenceCode("foo0", "float");
+   float r0 = JittedTreeInference<float>("BranchlessJittedTree003", "foo0", code0, input0, 1);
+   EXPECT_FLOAT_EQ(tree.Inference(input0, 1), r0);
+
+   float input1[3] = {-1.0, 2.0, -999.0};
+   const auto code1 = tree.GetInferenceCode("foo1", "float");
+   float r1 = JittedTreeInference<float>("BranchlessJittedTree003", "foo1", code1, input1, 1);
+   EXPECT_FLOAT_EQ(tree.Inference(input1, 1), r1);
+
+   float input2[3] = {1.0, -999.0, 1.0};
+   const auto code2 = tree.GetInferenceCode("foo2", "float");
+   float r2 = JittedTreeInference<float>("BranchlessJittedTree003", "foo2", code2, input2, 1);
+   EXPECT_FLOAT_EQ(tree.Inference(input2, 1), r2);
+
+   float input3[3] = {1.0, -999.0, 3.0};
+   const auto code3 = tree.GetInferenceCode("foo3", "float");
+   float r3 = JittedTreeInference<float>("BranchlessJittedTree003", "foo3", code3, input3, 1);
+   EXPECT_FLOAT_EQ(tree.Inference(input3, 1), r3);
+}
+
+template <typename ForestType>
+void TestInferenceSingleTree(const std::string& tag)
 {
    const auto maxDepth = 1;
    const auto numInputs = 1;
    const auto numTrees = 1;
-   WriteModel("myModel", "TestBranchlessForest0.root", "identity", {0}, {0}, {0.0, 1.0, -1.0}, {maxDepth}, {numTrees},
-              {numInputs}, {1});
+   WriteModel("myModel", "Test" + tag + "Forest0.root", "identity",
+           {0}, {0}, {0.0, 1.0, -1.0}, {maxDepth}, {numTrees},
+           {numInputs}, {1});
 
-   BranchlessForest<float> forest;
-   forest.Load("myModel", "TestBranchlessForest0.root", 0);
+   ForestType forest;
+   forest.Load("myModel", "Test" + tag + "Forest0.root", 0);
 
    const auto rows = 2;
    float inputs[numInputs * rows] = {-999.0, 999.0};
@@ -101,15 +154,27 @@ TEST(BranchlessForest, InferenceSingleTree)
    EXPECT_FLOAT_EQ(predictions[1], -1.0);
 }
 
-TEST(BranchlessForest, InferenceSingleTreeObjectiveLogistic)
+TEST(BranchlessJittedForest, InferenceSingleTree)
+{
+   TestInferenceSingleTree<BranchlessJittedForest<float>>("BranchlessJittedForest");
+}
+
+TEST(BranchlessForest, InferenceSingleTree)
+{
+   TestInferenceSingleTree<BranchlessForest<float>>("BranchlessForest");
+}
+
+template <typename ForestType>
+void TestInferenceSingleTreeObjectiveLogistic(const std::string& tag)
 {
    const auto maxDepth = 1;
    const auto numInputs = 1;
    const auto numTrees = 1;
-   WriteModel("myModel", "TestBranchlessForest1.root", "logistic", {0}, {0}, {0.0, 1.0, -1.0}, {maxDepth}, {numTrees},
-              {numInputs}, {1});
+   WriteModel("myModel", "Test" + tag + "1.root", "logistic",
+           {0}, {0}, {0.0, 1.0, -1.0}, {maxDepth}, {numTrees},
+           {numInputs}, {1});
 
-   BranchlessForest<float> forest;
+   ForestType forest;
    forest.Load("myModel", "TestBranchlessForest1.root", 0);
 
    const auto rows = 2;
@@ -120,17 +185,28 @@ TEST(BranchlessForest, InferenceSingleTreeObjectiveLogistic)
    EXPECT_FLOAT_EQ(predictions[1], Objectives::Logistic<float>(-1.0));
 }
 
-TEST(BranchlessForest, InferenceTwoTrees)
+TEST(BranchlessJittedForest, InferenceSingleTreeObjectiveLogistic)
+{
+   TestInferenceSingleTreeObjectiveLogistic<BranchlessJittedForest<float>>("BranchlessJittedForest");
+}
+
+TEST(BranchlessForest, InferenceSingleTreeObjectiveLogistic)
+{
+   TestInferenceSingleTreeObjectiveLogistic<BranchlessForest<float>>("BranchlessForest");
+}
+
+template <typename ForestType>
+void TestInferenceTwoTrees(const std::string& tag)
 {
    const auto maxDepth = 1;
    const auto numInputs = 2;
    const auto numTrees = 2;
    const auto outputNode = 1;
-   WriteModel("myModel", "TestBranchlessForest2.root", "identity", {0, 1}, {outputNode, outputNode},
+   WriteModel("myModel", "Test" + tag + "2.root", "identity", {0, 1}, {outputNode, outputNode},
               {0.0, 1.0, -1.0, 0.0, 2.0, -2.0}, {maxDepth}, {numTrees}, {numInputs}, {1});
 
-   BranchlessForest<float> forest;
-   forest.Load("myModel", "TestBranchlessForest2.root", outputNode);
+   ForestType forest;
+   forest.Load("myModel", "Test" + tag + "2.root", outputNode);
 
    const auto rows = 2;
    float inputs[numInputs * rows] = {-999.0, 999.0, 999.0, -999.0};
@@ -140,13 +216,24 @@ TEST(BranchlessForest, InferenceTwoTrees)
    EXPECT_FLOAT_EQ(predictions[1], -1.0 + 2.0);
 }
 
+TEST(BranchlessJittedForest, InferenceTwoTrees)
+{
+   TestInferenceTwoTrees<BranchlessJittedForest<float>>("BranchlessJittedForest");
+}
+
+TEST(BranchlessForest, InferenceTwoTrees)
+{
+   TestInferenceTwoTrees<BranchlessForest<float>>("BranchlessForest");
+}
+
 TEST(BranchlessForest, SortTrees)
 {
    const auto maxDepth = 1;
    const auto numInputs = 2;
    const auto numTrees = 3;
    WriteModel("myModel", "TestBranchlessForest3.root", "identity", {1, 0, 0}, {0, 0, 0},
-              {0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 1.0, 1.0, 1.0}, {maxDepth}, {numTrees}, {numInputs}, {1});
+              {0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 1.0, 1.0, 1.0},
+              {maxDepth}, {numTrees}, {numInputs}, {1});
 
    BranchlessForest<float> forest;
    forest.Load("myModel", "TestBranchlessForest3.root", 0, false);
@@ -165,4 +252,29 @@ TEST(BranchlessForest, SortTrees)
    EXPECT_EQ(forest2.fTrees[0].fThresholds[0], 1.0);
    EXPECT_EQ(forest2.fTrees[1].fThresholds[0], 2.0);
    EXPECT_EQ(forest2.fTrees[2].fThresholds[0], 0.0);
+}
+
+TEST(BranchlessJittedForest, SortTrees)
+{
+   const auto maxDepth = 1;
+   const auto numInputs = 2;
+   const auto numTrees = 3;
+   WriteModel("myModel", "TestBranchlessJittedForest3.root", "identity", {1, 0, 0}, {0, 0, 0},
+              {0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 1.0, 1.0, 1.0},
+              {maxDepth}, {numTrees}, {numInputs}, {1});
+
+   BranchlessJittedForest<float> forest;
+   forest.Load("myModel", "TestBranchlessJittedForest3.root", 0, false);
+   const auto rows = 2;
+   float inputs[numInputs * rows] = {-999.0, 999.0, 999.0, -999.0};
+   float predictions1[rows];
+   forest.Inference(inputs, rows, true, predictions1);
+
+   BranchlessJittedForest<float> forest2;
+   forest2.Load("myModel", "TestBranchlessJittedForest3.root", 0, true);
+   float predictions2[rows];
+   forest2.Inference(inputs, rows, true, predictions2);
+
+   for (int i = 0; i < rows; i++)
+      EXPECT_FLOAT_EQ(predictions1[i], predictions2[i]);
 }

--- a/tmva/tmva/test/branchlessForest.cxx
+++ b/tmva/tmva/test/branchlessForest.cxx
@@ -170,12 +170,12 @@ void TestInferenceSingleTreeObjectiveLogistic(const std::string& tag)
    const auto maxDepth = 1;
    const auto numInputs = 1;
    const auto numTrees = 1;
-   WriteModel("myModel", "Test" + tag + "1.root", "logistic",
+   WriteModel("myModel", "Test" + tag + "Logistic1.root", "logistic",
            {0}, {0}, {0.0, 1.0, -1.0}, {maxDepth}, {numTrees},
            {numInputs}, {1});
 
    ForestType forest;
-   forest.Load("myModel", "TestBranchlessForest1.root", 0);
+   forest.Load("myModel", "Test" + tag + "Logistic1.root", 0);
 
    const auto rows = 2;
    float inputs[numInputs * rows] = {-999.0, 999.0};

--- a/tmva/tmva/test/rbdt_xgboost.py
+++ b/tmva/tmva/test/rbdt_xgboost.py
@@ -76,6 +76,12 @@ class RBDT(unittest.TestCase):
         """
         _test_XGBBinary("TMVA::Experimental::BranchlessForest<float>", "branchlessForest")
 
+    def test_XGBBinary_branchlessjitted(self):
+        """
+        Test BranchlessJittedForest backend for model trained with binary XGBClassifier
+        """
+        _test_XGBBinary("TMVA::Experimental::BranchlessJittedForest<float>", "branchlessJittedForest")
+
     def test_XGBMulticlass_default(self):
         """
         Test default backend for model trained with multiclass XGBClassifier
@@ -88,6 +94,12 @@ class RBDT(unittest.TestCase):
         """
         _test_XGBMulticlass("TMVA::Experimental::BranchlessForest<float>", "branchlessForest")
 
+    def test_XGBMulticlass_branchlessjitted(self):
+        """
+        Test BranchlessJittedForest backend for model trained with multiclass XGBClassifier
+        """
+        _test_XGBMulticlass("TMVA::Experimental::BranchlessJittedForest<float>", "branchlessJittedForest")
+
     def test_XGBRegression_default(self):
         """
         Test default backend for model trained with XGBRegressor
@@ -99,6 +111,12 @@ class RBDT(unittest.TestCase):
         Test BranchlessForest backend for model trained with XGBRegressor
         """
         _test_XGBRegression("TMVA::Experimental::BranchlessForest<float>", "branchlessForest")
+
+    def test_XGBRegression_branchlessjitted(self):
+        """
+        Test BranchlessJittedForest backend for model trained with XGBRegressor
+        """
+        _test_XGBRegression("TMVA::Experimental::BranchlessJittedForest<float>", "branchlessJittedForest")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add tree inference backend using jitted evaluation of the forest. Preliminary benchmarks look promising and show a clear improvement due to the jitting (100 trees, depth 3, 100k events):

```
XGB: 2.30692 microsec/event
BranchlessForest: 0.962279 microsec/event
BranchlessJittedForest: 0.67292 microsec/event
```

WIP: Still needs some error-handling and doxygen markup.