### PR TITLE
Add missing dependency for Hist library

### DIFF
--- a/hist/hist/CMakeLists.txt
+++ b/hist/hist/CMakeLists.txt
@@ -22,6 +22,7 @@ if(root7)
   )
 
   set(HIST_V7_SOURCES v7/src/RAxis.cxx)
+  set(HIST_V7_DEPS ROOTGpadv7)
 endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(Hist
@@ -177,6 +178,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Hist
     MathCore
     Matrix
     RIO
+    ${HIST_V7_DEPS}
 )
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
[ 73%] Generating G__Hist.cxx, ../../lib/Hist.pcm
In file included from input_line_21:82:
/home/oksana/CERN_sources/root-rtcxxmodules/builds/include/ROOT/RHist.hxx:21:10: remark: building module 'ROOTGpadv7' as '/home/oksana/CERN_sources/root-rtcxxmodules/builds/lib/ROOTGpadv7.pcm'
[-Rmodule-build]