### PR TITLE
[cxxmodules][pch] Disable validation of transent files.

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -2081,7 +2081,7 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
 
   // For an overridden file, create a virtual file with the stored
   // size/timestamp.
-  if ((Overridden || Transient) && File == nullptr)
+  if ((Overridden || Transient) && (DisableValidation || File == nullptr))
     File = FileMgr.getVirtualFile(Filename, StoredSize, StoredTime);
 
   if (File == nullptr) {


### PR DESCRIPTION
In clang a transient file is a header file which is stored in the pch/pcm file. If this file does not exist, clang creates a virtual file of the unzipped stored file. However, if the file exists it compares the size of the file on disk and the size of the transent file. If the two sizes are different it does not complain (as validation is off) but it triggers an assert in when constructing and outdated clang::InputFile. The implementation disallows a overridden or transient file to be out of date.

This patch extends the DisableValidation abilities to span not only for timestamps but we avoid checking the file sizes if the file is on the disk. And, instead we just create a virtual file of the file that we already have.

This patch should fix a relocation issue for cmssw and some of the reported LCG issues.

cc: @oshadura, @davidlange6, @smuzaffar, @emanca, @zygoloid 