### PR TITLE
[cxxmodules] Order includes by generality.

### DIFF
--- a/tree/treeplayer/inc/TRefProxy.h
+++ b/tree/treeplayer/inc/TRefProxy.h
@@ -12,12 +12,12 @@
 #ifndef ROOT_TRefProxy
 #define ROOT_TRefProxy
 
-#include <map>
-#include <string>
-
 #include "TVirtualRefProxy.h"
 
 #include "TClassRef.h"
+
+#include <map>
+#include <string>
 
 // Forward declarations
 class TFormLeafInfoReference;


### PR DESCRIPTION
This is attempt to fix an infinite loop of rootcling when building G__TreePlayer described in ROOT-10336. We do not have a dedicated issue or reproducer for the particular issue and thus we can only guess for the moment.