### PR TITLE
Avoid stdlib.h in GUI includes ROOT-10336

### DIFF
--- a/gui/gui/inc/TGFSContainer.h
+++ b/gui/gui/inc/TGFSContainer.h
@@ -24,7 +24,6 @@
 #include "TGListView.h"
 #include "TGDNDManager.h"
 #include "TBufferFile.h"
-#include <stdlib.h>
 
 //----- file sort mode
 enum EFSSortMode {

--- a/gui/gui/src/TGFSContainer.cxx
+++ b/gui/gui/src/TGFSContainer.cxx
@@ -36,11 +36,12 @@
 #include "TList.h"
 #include "TSystem.h"
 #include "TGDNDManager.h"
-#include "TBufferFile.h"
 #include "Riostream.h"
 #include "TRemoteObject.h"
 #include "TImage.h"
+
 #include <time.h>
+#include <stdlib.h>
 
 ClassImp(TGFileItem);
 ClassImp(TGFileContainer);


### PR DESCRIPTION
Causes warning from cling when generating dictionary.