### PR TITLE
[Cling] print the value of the pointer when value printing smart pointers.

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
+++ b/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
@@ -286,21 +286,30 @@ namespace cling {
   template <class T>
   inline std::string printValue(std::unique_ptr<T> *val)
   {
-     return "std::unique_ptr -> " + printValue(val->get());
+     auto ptr = val->get();
+     // printValue dereference its argument. use cast to 'const void**' to get
+     // the same printout as a regular pointer.
+     return "std::unique_ptr -> " + printValue((const void**)&ptr);
   }
 
   // shared_ptr<T>:
   template <class T>
   inline std::string printValue(std::shared_ptr<T> *val)
   {
-     return "std::shared_ptr -> " + printValue(val->get());
+     auto ptr = val->get();
+     // printValue dereference its argument. use cast to 'const void**' to get
+     // the same printout as a regular pointer.
+     return "std::shared_ptr -> " + printValue((const void**)&ptr);
   }
 
   // weak_ptr<T>:
   template <class T>
   inline std::string printValue(std::weak_ptr<T> *val)
   {
-     return "std::weak_ptr -> " + printValue(val->lock().get());
+     auto ptr = val->lock().get();
+     // printValue dereference its argument. use cast to 'const void**' to get
+     // the same printout as a regular pointer.
+     return "std::weak_ptr -> " + printValue((const void**)&ptr);
   }
 
 }

--- a/interpreter/cling/test/Prompt/ValuePrinter/Ptrs.C
+++ b/interpreter/cling/test/Prompt/ValuePrinter/Ptrs.C
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling | FileCheck %s
+
+#include <utility>
+#include <memory>
+
+int *i_ptr = nullptr
+//CHECK: (int *) nullptr
+
+std::unique_ptr<int> i_uptr
+//CHECK: (std::unique_ptr<int> &) std::unique_ptr -> nullptr 
+
+std::shared_ptr<int> i_sptr
+//CHECK: (std::shared_ptr<int> &) std::shared_ptr -> nullptr
+
+std::weak_ptr<int> i_wptr
+//CHECK: (std::weak_ptr<int> &) std::weak_ptr -> nullptr
+
+i_uptr = std::make_unique<int>(3)
+//CHECK: (std::unique_ptr &) std::unique_ptr -> 0x{{[0-9a-f]+}} 
+
+i_uptr
+//CHECK: (std::unique_ptr<int> &) std::unique_ptr -> 0x{{[0-9a-f]+}} 
+
+i_sptr = std::make_shared<int>(6)
+//CHECK: (std::shared_ptr &) std::shared_ptr -> 0x{{[0-9a-f]+}} 
+
+i_sptr
+//CHECK: (std::shared_ptr<int> &) std::shared_ptr -> 0x{{[0-9a-f]+}} 
+
+i_wptr = i_sptr;
+i_wptr
+//CHECK: (std::weak_ptr<int> &) std::weak_ptr -> 0x{{[0-9a-f]+}}
+
+
+


### PR DESCRIPTION


This fixes ROOT-10333.

Since the printValue set of functions always takes a pointer and dereferences it without any checks,
the previous implementation was attempting to valuePrint the pointee (rather than the pointer value)
but this lead to a segmentation fault whenever the smart pointer was set to nullptr.

Now, the valuePrinting for the smart pointers behaves the same as for regular pointer.