### PR TITLE
[cmake] Add LLVMRES to ClingUtils to propagate to all cling-related t…

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -169,6 +169,12 @@ else()
         COMMENT "Copying LLVM resource and header files")
 endif()
 add_custom_target(LLVMRES DEPENDS ${stamp_file} CLING)
-
+# CLING is a shorthand for CLING_LIBRARIES and some other clang-specific
+# dependencies which ensure the correct order of building. Then the cling header
+# files (such as RuntimeUniverse.h) are moved to a semi-private place in ROOT
+# #ROOTSYS/etc. This is the place where ROOT will use them from and we should
+# add an explcit dependency to something cling-related which ROOT knows.
+# ClingUtils seems a good candidate because it is very foundational.
+add_dependencies(ClingUtils LLVMRES)
 ROOT_ADD_TEST_SUBDIRECTORY(test)
 

--- a/core/rootcling_stage1/CMakeLists.txt
+++ b/core/rootcling_stage1/CMakeLists.txt
@@ -38,4 +38,4 @@ ROOT_EXECUTABLE(rootcling_stage1 src/rootcling_stage1.cxx
                               LIBRARIES ${CLING_LIBRARIES} ${LINK_LIBS} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT}
                               NOINSTALL)
 set_target_properties(rootcling_stage1 PROPERTIES RUNTIME_OUTPUT_DIRECTORY src)
-add_dependencies(rootcling_stage1 CLING LLVMRES)
+add_dependencies(rootcling_stage1 ClingUtils)


### PR DESCRIPTION
…argets.

ROOT builds cling and then moves a set of headers under the semi-private $ROOTSYS/etc/cling. This poses an issue -- the set of proper cling dependencies seem not enough to propagate that information to rootcling for example.

Instead of adding LLVMRES to rootcling (as it is the case for rootcling_stage1) add the dependency to something more fundamental such as ClingUtils. This will propagate it transitively to all parties without having to specify the sort-of internal LLVMRES target.

This patch should fix the incremental builds where the error is:
error: file '/.../RuntimePrintValue.h' from the precompiled header has been overridden

cc: @Axel-Naumann 