### PR TITLE
[cxxmodules] Add bits/stl_{map,tree}.h to the modulemap.

### DIFF
--- a/build/unix/std.modulemap
+++ b/build/unix/std.modulemap
@@ -418,4 +418,13 @@ module "std" [system] {
     export *
     header "bits/locale_facets.h"
   }
+  module "bits/stl_map.h" {
+    export *
+    export bits_stl_tree_h
+    header "bits/stl_map.h"
+  }
+  explicit module "bits_stl_tree_h" {
+    export *
+    header "bits/stl_tree.h"
+  }
 }


### PR DESCRIPTION
This should reduce the textual duplicates in all C++ modules.