### PR TITLE
[cxxmodules] Mark the overridden transient file.

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -2081,8 +2081,10 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
 
   // For an overridden file, create a virtual file with the stored
   // size/timestamp.
-  if ((Overridden || Transient) && (DisableValidation || File == nullptr))
+  if ((Overridden || Transient) && (DisableValidation || File == nullptr)) {
     File = FileMgr.getVirtualFile(Filename, StoredSize, StoredTime);
+    Overridden = true;
+  }
 
   if (File == nullptr) {
     if (Complain) {


### PR DESCRIPTION
This patch is a complementary chenge to root-project/root@d2c0929e0d It will turn off the isOutOfDate checks for transient files with different size on disk. This is quite dangerous but we are supposed to control the build environment which prepares the distributable binaries.

This should fix the cmssw issue:

StdDictionaries/src/DataFormatsStdDictionaries/a/DataFormatsStdDictionaries_all_def.xml
input_line_8:1:22: error: file '/usr/include/linux/falloc.h' from the precompiled header has been overridden
                     ^
rootcling: /build/cmsbld/jenkins/workspace/build-any-ib/w/BUILD/slc7_amd64_gcc820/lcg/root/6.17.01/root-6.17.01/interpreter/llvm/src/tools/clang/include/clang/Serialization/Module.h:72: clang::serialization::InputFile::InputFile(const clang::FileEntry*, bool, bool): Assertion `!(isOverridden && isOutOfDate) && "an overridden cannot be out-of-date"' failed.

The error tells us that `falloc.h` has different file size on the build machine and
on the distribution machine. We should probably rely on an environment variable
to turn off this diagnostic selectively and more the reponsibility if something goes
wrong to the distribution team. They should have better knowledge what is safe to
be ignored anyway.

cc: @davidlange6, @oshadura, @smuzaffar 