### PR TITLE
Embed web-based canvas in Rbrowser

### DIFF
--- a/gui/browserv7/CMakeLists.txt
+++ b/gui/browserv7/CMakeLists.txt
@@ -16,4 +16,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowserv7
     src/RBrowser.cxx
   DEPENDENCIES
     ROOTWebDisplay
+    Gpad
+    WebGui6
+    
 )

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -83,6 +83,7 @@ protected:
    std::string GetClassIcon(std::string &classname);
    std::string GetFileIcon(TString &name);
    std::string ProcessBrowserRequest(const std::string &msg);
+   std::string ProcessDblClick(const std::string &path);
 
    bool IsBuild() const { return fDesc.size() > 0; }
 

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -73,7 +73,7 @@ protected:
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
-   void AddCanvas();
+   TCanvas *AddCanvas();
    void CloseCanvas(const std::string &name);
 
    void AddFolder(const char *name);

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -21,6 +21,7 @@
 #include <ROOT/RBrowserItem.hxx>
 
 #include <vector>
+#include <memory>
 #include <stdint.h>
 
 class TString;
@@ -69,7 +70,7 @@ protected:
    std::string fDescPath;                ///<! last scanned directory
    std::vector<RRootFileItem> fDesc;     ///<! plain list of current directory
    std::vector<RRootFileItem *> fSorted; ///<! current sorted list (no ownership)
-   std::vector<std::string> fCanvases;   ///<! canvases created by browser, should be closed at the end
+   std::vector<std::unique_ptr<TCanvas>> fCanvases;  ///<! canvases created by browser, should be closed at the end
    std::string fActiveCanvas;            ///<! name of active for RBrowser canvas, not a gPad!
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 class TString;
+class TCanvas;
 
 namespace ROOT {
 namespace Experimental {
@@ -68,8 +69,12 @@ protected:
    std::string fDescPath;                ///<! last scanned directory
    std::vector<RRootFileItem> fDesc;     ///<! plain list of current directory
    std::vector<RRootFileItem *> fSorted; ///<! current sorted list (no ownership)
+   std::vector<std::string> fCanvases;   ///<! canvases created by browser, should be closed at the end
 
-   std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to show geometry
+   std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
+
+   void AddCanvas();
+   void CloseCanvas(const std::string &name);
 
    void AddFolder(const char *name);
    void AddFile(const char *name);

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -77,6 +77,7 @@ protected:
 
    TCanvas *AddCanvas();
    TCanvas *GetActiveCanvas() const;
+   std::string GetCanvasUrl(TCanvas *canv);
    void CloseCanvas(const std::string &name);
 
    void AddFolder(const char *name);
@@ -90,6 +91,7 @@ protected:
 
    bool IsBuild() const { return fDesc.size() > 0; }
 
+   void SendInitMsg(unsigned connid);
    void WebWindowCallback(unsigned connid, const std::string &arg);
 
 public:

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -70,10 +70,12 @@ protected:
    std::vector<RRootFileItem> fDesc;     ///<! plain list of current directory
    std::vector<RRootFileItem *> fSorted; ///<! current sorted list (no ownership)
    std::vector<std::string> fCanvases;   ///<! canvases created by browser, should be closed at the end
+   std::string fActiveCanvas;            ///<! name of active for RBrowser canvas, not a gPad!
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
    TCanvas *AddCanvas();
+   TCanvas *GetActiveCanvas() const;
    void CloseCanvas(const std::string &name);
 
    void AddFolder(const char *name);

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -23,6 +23,8 @@
 #include "TString.h"
 #include "TSystem.h"
 #include "TROOT.h"
+#include "TWebCanvas.h"
+#include "TCanvas.h"
 #include "TBufferJSON.h"
 
 #include <sstream>
@@ -61,6 +63,8 @@ ROOT::Experimental::RBrowser::RBrowser()
 
 ROOT::Experimental::RBrowser::~RBrowser()
 {
+   while (fCanvases.size() > 0)
+      CloseCanvas(fCanvases[fCanvases.size()-1]);
 }
 
 
@@ -437,6 +441,34 @@ void ROOT::Experimental::RBrowser::Hide()
 
    fWebWindow->CloseConnections();
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+/// Create new web canvas, invoked when new canvas created on client side
+
+void ROOT::Experimental::RBrowser::AddCanvas()
+{
+   TString canv_name;
+   int cnt = 1;
+   do {
+      canv_name.Format("webcanv%d", cnt++);
+   } while (gROOT->GetListOfCanvases()->FindObject(canv_name.Data()));
+
+   fCanvases.emplace_back(canv_name);
+
+}
+
+void ROOT::Experimental::RBrowser::CloseCanvas(const std::string &name)
+{
+   auto iter = std::find_if(fCanvases.begin(), fCanvases.end(), [name](std::string &item) { return item == name; });
+
+   if (iter != fCanvases.end())
+      fCanvases.erase(iter);
+
+   auto canv = gROOT->GetListOfCanvases()->FindObject(name.c_str());
+   if (canv) delete canv;
+}
+
+
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 /// receive data from client

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -295,7 +295,7 @@ public:
 
    void RecordData(const std::string &fname = "protocol.json", const std::string &fprefix = "");
 
-   std::string RelativeAddr(std::shared_ptr<RWebWindow> &win) const;
+   std::string RelativeAddr(const std::shared_ptr<RWebWindow> &win) const;
 
    void SetCallBacks(WebWindowConnectCallback_t conn, WebWindowDataCallback_t data, WebWindowConnectCallback_t disconn = nullptr);
 

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -818,7 +818,7 @@ void ROOT::Experimental::RWebWindow::Sync()
 /// Address can be required if one needs to access data from one window into another window
 /// Used for instance when inserting panel into canvas
 
-std::string ROOT::Experimental::RWebWindow::RelativeAddr(std::shared_ptr<RWebWindow> &win) const
+std::string ROOT::Experimental::RWebWindow::RelativeAddr(const std::shared_ptr<RWebWindow> &win) const
 {
    if (fMgr != win->fMgr) {
       R__ERROR_HERE("WebDisplay") << "Same web window manager should be used";

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -113,6 +113,8 @@ public:
 
    void ShowWebWindow(const ROOT::Experimental::RWebDisplayArgs &user_args = "");
 
+   const std::shared_ptr<ROOT::Experimental::RWebWindow> &GetWebWindow() const { return fWindow; }
+
    virtual Bool_t IsReadOnly() const { return kTRUE; }
 
    Int_t InitWindow() override;

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -134,8 +134,10 @@ public:
 
    void ActivateInEditor(TPad *pad, TObject *obj);
 
+   void ForceUpdate() override;
+
+
    /*
-      virtual void   ForceUpdate() { }
       virtual void   Iconify() { }
       virtual void   SetStatusText(const char *text = 0, Int_t partidx = 0);
       virtual void   SetWindowPosition(Int_t x, Int_t y);

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -842,6 +842,16 @@ Bool_t TWebCanvas::PerformUpdate()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
+/// Increment canvas version and force sending data to client - do not wit for reply
+
+void TWebCanvas::ForceUpdate()
+{
+   fCanvVersion++;
+
+   CheckDataToSend();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
 /// Wait when specified version of canvas was painted and confirmed by browser
 
 Bool_t TWebCanvas::WaitWhenCanvasPainted(Long64_t ver)

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -273,10 +273,10 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
 
    TList *primitives = pad->GetListOfPrimitives();
 
-   fPrimitivesLists.Add(primitives); // add list of primitives
+   if (primitives) fPrimitivesLists.Add(primitives); // add list of primitives
 
    TWebPS masterps;
-   bool usemaster = primitives->GetSize() > fPrimitivesMerge;
+   bool usemaster = primitives ? (primitives->GetSize() > fPrimitivesMerge) : false;
 
    TIter iter(primitives);
    TObject *obj = nullptr;
@@ -609,7 +609,8 @@ void TWebCanvas::ShowWebWindow(const ROOT::Experimental::RWebDisplayArgs &args)
    if ((w > 10) && (w < 50000) && (h > 10) && (h < 30000))
       fWindow->SetGeometry(w + 6, h + 22);
 
-   fWindow->Show(args);
+   if (args.GetBrowserName() != "embed")
+      fWindow->Show(args);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -4620,12 +4620,12 @@
       this._websocket.Connect();
    }
 
-   TCanvasPainter.prototype.UseWebsocket = function(handle) {
+   TCanvasPainter.prototype.UseWebsocket = function(handle, href) {
       this.CloseWebsocket();
 
       this._websocket = handle;
       this._websocket.SetReceiver(this);
-      this._websocket.Connect();
+      this._websocket.Connect(href);
    }
 
    TCanvasPainter.prototype.OnWebsocketOpened = function(handle) {

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -4112,13 +4112,13 @@
       this._websocket.Connect();
    }
 
-   TCanvasPainter.prototype.UseWebsocket = function(handle) {
+   TCanvasPainter.prototype.UseWebsocket = function(handle, href) {
       this.CloseWebsocket();
 
       this._websocket = handle;
       console.log('Use websocket', this._websocket.key);
       this._websocket.SetReceiver(this);
-      this._websocket.Connect();
+      this._websocket.Connect(href);
    }
 
    TCanvasPainter.prototype.WindowBeforeUnloadHanlder = function() {

--- a/ui5/browser/browser.html
+++ b/ui5/browser/browser.html
@@ -45,9 +45,9 @@
         if (JSROOT.GetUrlOption('libs')!==null) JSROOT.use_full_libs = true;
 
         JSROOT.ConnectWebWindow({
-           prereq: "openui5",
+           prereq: "openui5;v6",  // load v6 because of canvas painter
 //           openui5src: "jsroot",    // use JSROOT provided package, default
-//           openui5src: "https://openui5.hana.ondemand.com/1.64.1/",
+//           openui5src: "https://openui5.hana.ondemand.com/1.70.0/",
            openui5libs: "sap.m, sap.ui.layout, sap.ui.unified, sap.ui.table, sap.ui.codeeditor", // customize openui5 libs later
            prereq_logdiv: "BrowserDiv",
            callback: InitUI

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -318,33 +318,33 @@ sap.ui.define(['sap/ui/core/Component',
             this.connectCanvas(msg);
             break;
          case "FROOT:": // Root file
-           let selecedTabID = this.getSelectedtabFromtabContainer("myTabContainer"); // The ID of the selected tab in the TabContainer
+           var selecedTabID = this.getSelectedtabFromtabContainer("myTabContainer"); // The ID of the selected tab in the TabContainer
 
-           let jsonAnswer = JSON.parse(msg); // message received from the server to JSON
+           var jsonAnswer = JSON.parse(msg); // message received from the server to JSON
 
-           let rootFileArray = jsonAnswer.path.split("/"); // spliting the path on /
-           let rootFileRelativePath = ""; // Declaration of the var to open the good file
+           var rootFileArray = jsonAnswer.path.split("/"); // splitting the path on /
+           var  rootFileRelativePath = ""; // Declaration of the var to open the good file
 
-           let i = 0; // Iterator
+           var  i = 0; // Iterator
            while (rootFileArray[i].slice(-5) !== ".root") { // Iterating over the splited path until it find the .root file
              rootFileRelativePath += "/" + rootFileArray[i];
              i++;
            }
            rootFileRelativePath += "/" + rootFileArray[i]; // Adding the last bit (the wanted graphic) to the relative path
 
-           let oCanvas = this.getView().byId("aRootCanvas" + selecedTabID); // Get the drawing place object
+           var  oCanvas = this.getView().byId("aRootCanvas" + selecedTabID); // Get the drawing place object
 
            if (oCanvas === undefined || oCanvas === null) { // If the selected tabs it not a Root canvas then display and error message
              MessageToast.show("Please, select a Root Canvas tab", {duration: 1500});
              return;
            }
 
-           let oTabElement = oCanvas.getParent(); // Get the tab from the drawing place
-           let rootFileDisplayName = rootFileArray[i] + "/" + rootFileArray[i + 1]; // Creating a simple nameOfTheFile.root/graphic;1 to display on the tab
+           var  oTabElement = oCanvas.getParent(); // Get the tab from the drawing place
+           var  rootFileDisplayName = rootFileArray[i] + "/" + rootFileArray[i + 1]; // Creating a simple nameOfTheFile.root/graphic;1 to display on the tab
 
            document.getElementById("TopBrowserId--aRootCanvas" + selecedTabID).innerHTML = ""; // Clearing the canvas
            oTabElement.setAdditionalText(rootFileDisplayName); // Setting the tab file name
-           let finalJsonRoot = JSROOT.JSONR_unref(jsonAnswer.data); // Creating the graphic from the json
+           var  finalJsonRoot = JSROOT.JSONR_unref(jsonAnswer.data); // Creating the graphic from the json
            JSROOT.draw("TopBrowserId--aRootCanvas" + selecedTabID, finalJsonRoot, "colz"); // Drawing the graphic into the selected tab canvas
 
            break;
@@ -371,7 +371,7 @@ sap.ui.define(['sap/ui/core/Component',
 
       /** Get the ID of the currently selected tab of given tab container */
       getSelectedtabFromtabContainer: function(divid) {
-         let tabContainer = this.getView().byId('myTabContainer').getSelectedItem()
+         var  tabContainer = this.getView().byId('myTabContainer').getSelectedItem();
          return tabContainer.slice(6, tabContainer.length);
       },
 
@@ -453,9 +453,9 @@ sap.ui.define(['sap/ui/core/Component',
 
          this.last_created_item = oTabContainerItem; // FIXME, how to find item by ID!!!
          
-         /* let ID = oTabContainerItem.sId.slice(6, oTabContainerItem.sId.length);
+         /* var  ID = oTabContainerItem.sId.slice(6, oTabContainerItem.sId.length);
 
-         let html = new sap.ui.core.HTML("TopBrowserId--aRootCanvas" + ID, {
+         var  html = new sap.ui.core.HTML("TopBrowserId--aRootCanvas" + ID, {
             content: "<div style=\"height:100%\">{/rootCanvas}</div>"
          });
          oTabContainerItem.addContent(html);
@@ -477,7 +477,7 @@ sap.ui.define(['sap/ui/core/Component',
          delete this.last_created_item;
          if (!tabItem || tabItem.getId() != arr[0]) return;
          
-         tabItem.canvasName = arr[2]; // name can be used to set active canvas or close canvas
+         tabItem.setAdditionalText(arr[2]); // name can be used to set active canvas or close canvas
          
          var conn = new JSROOT.WebWindowHandle(this.websocket.kind);
          
@@ -489,10 +489,6 @@ sap.ui.define(['sap/ui/core/Component',
          } else {
             addr += relative_path;
          }
-         
-         console.log("connecting with", addr)
-         // establish connection
-         // conn.Connect(addr);
          
          var painter = new JSROOT.TCanvasPainter(null);
          painter.online_canvas = true;
@@ -509,6 +505,18 @@ sap.ui.define(['sap/ui/core/Component',
             tabItem.addContent(oView);
             // JSROOT.CallBack(call_back, true);
          });
+         
+      },
+      
+      tabSelectItem: function(oEvent) {
+         var oTabContainer = this.byId("myTabContainer");
+         var oItemSelected = oEvent.getParameter('item');
+         
+         if (oItemSelected.getName() != "ROOT Canvas") return;
+
+         console.log("Canvas selected:", oItemSelected.getAdditionalText());
+         
+         this.websocket.Send("SELECT_CANVAS:" + oItemSelected.getAdditionalText());
          
       },
 
@@ -528,7 +536,11 @@ sap.ui.define(['sap/ui/core/Component',
          MessageBox.confirm('Do you really want to close the "' + oItemToClose.getName() + '" tab?', {
             onClose: function (oAction) {
                if (oAction === MessageBox.Action.OK) {
+                  if (oItemToClose.getName() == "ROOT Canvas") 
+                     this.websocket.Send("CLOSE_CANVAS:" + oItemToClose.getAdditionalText());
+                  
                   oTabContainer.removeItem(oItemToClose);
+                  
                   MessageToast.show('Closed the "' + oItemToClose.getName() + '" tab', {duration: 1500});
                }
             }

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -258,13 +258,13 @@ sap.ui.define(['sap/ui/core/Component',
             fullpath = prop.fullpath.substr(1, prop.fullpath.length-2);
             var dirname = fullpath.substr(0, fullpath.lastIndexOf('/'));
             if (dirname.endsWith(".root"))
-               return this.sendBrowserRequest("DBLCLK", { path: fullpath });
+               return this.websocket.Send("DBLCLK:" + fullpath);
          }
          var oEditor = this.getView().byId("aCodeEditor");
          var oModel = oEditor.getModel();
          var filename = fullpath.substr(fullpath.lastIndexOf('/') + 1);
          if (this.setFileNameType(filename))
-            return this.sendBrowserRequest("DBLCLK", { path: fullpath });
+            return this.websocket.Send("DBLCLK:" + fullpath);
        },
 
       OnWebsocketOpened: function(handle) {

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -61,11 +61,11 @@
                   </l:Splitter>
                   </content>
                 </TabContainerItem>
-                <TabContainerItem name="ROOT Canvas" icon="sap-icon://column-chart-dual-axis" additionalText="" >
+                <!-- TabContainerItem name="ROOT Canvas" icon="sap-icon://column-chart-dual-axis" additionalText="" >
                   <content>
                     <core:HTML id="aRootCanvas1" content="&lt;div style=&quot;height:100%&quot;&gt;{/rootCanvas}&lt;/div&gt;" />
                   </content>
-                </TabContainerItem>
+                </TabContainerItem -->
               </items>
             </TabContainer>
           <!--/l:Splitter-->

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -42,6 +42,7 @@
             <TabContainer id="myTabContainer"
               showAddNewButton="true"
               addNewButtonPress="addNewButtonPressHandler"
+              itemSelect="tabSelectItem"
               itemClose="tabCloseHandler">
               <items>
                 <TabContainerItem name="Code Editor" icon="sap-icon://write-new-document" additionalText="untitled" >

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -3,7 +3,7 @@ sap.ui.define([
    'sap/ui/core/mvc/Controller',
    'sap/ui/core/Component',
    'sap/ui/model/json/JSONModel',
-   "sap/ui/core/mvc/XMLView",
+   'sap/ui/core/mvc/XMLView',
    'sap/ui/core/Fragment',
    'sap/m/MessageToast',
    'sap/m/Dialog',
@@ -31,8 +31,11 @@ sap.ui.define([
          var model = new JSONModel({ GedIcon: "", StatusIcon: "", ToolbarIcon: "", TooltipIcon: "sap-icon://accept",
                                      StatusLbl1:"", StatusLbl2:"", StatusLbl3:"", StatusLbl4:"" });
          this.getView().setModel(model);
+         
+         var vd = this.getView().getViewData();
+         var cp = vd ? vd.canvas_painter : null;
 
-         var cp = Component.getOwnerComponentFor(this.getView()).getComponentData().canvas_painter;
+         if (!cp) cp = Component.getOwnerComponentFor(this.getView()).getComponentData().canvas_painter;
 
          if (cp) {
 

--- a/ui5/canv/controller/CanvasPanel.controller.js
+++ b/ui5/canv/controller/CanvasPanel.controller.js
@@ -20,7 +20,7 @@ sap.ui.define([
       onAfterRendering: function() {
          if (this.canvas_painter && this.canvas_painter._window_handle) {
             this.canvas_painter.SetDivId(this.getView().getDomRef(), -1);
-            this.canvas_painter.UseWebsocket(this.canvas_painter._window_handle);
+            this.canvas_painter.UseWebsocket(this.canvas_painter._window_handle, this.canvas_painter._window_handle_href);
             delete this.canvas_painter._window_handle;
          }
       },


### PR DESCRIPTION
Instead of plain JSROOT graphics TWebCanvas will be used now to display objects in RBrowser

Main complication - appropriate embedding of RWebWindow inside another one.
Exactly same approach will be used for ROOT7 web canvas, Geometry viewer and all other future widgets which should be supported in RBrowser 