### PR TITLE
Provide support of RCanvas in RBrowser

### DIFF
--- a/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RCanvas.hxx
@@ -85,6 +85,9 @@ public:
    /// Display the canvas.
    void Show(const std::string &where = "");
 
+   /// Returns window name used to display canvas
+   std::string GetWindowAddr() const;
+
    /// Hide all canvas displays
    void Hide();
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RVirtualCanvasPainter.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RVirtualCanvasPainter.hxx
@@ -61,6 +61,8 @@ public:
 
    virtual int NumDisplays() const = 0;
 
+   virtual std::string GetWindowAddr() const = 0;
+
    /// run canvas functionality in caller thread, not needed when main thread is used
    virtual void Run(double tm = 0.) = 0;
 

--- a/graf2d/gpadv7/v7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/v7/src/RCanvas.cxx
@@ -107,6 +107,18 @@ void ROOT::Experimental::RCanvas::Show(const std::string &where)
 }
 
 //////////////////////////////////////////////////////////////////////////
+/// Returns window name for canvas
+
+std::string ROOT::Experimental::RCanvas::GetWindowAddr() const
+{
+   if (fPainter)
+      return fPainter->GetWindowAddr();
+
+   return "";
+}
+
+
+//////////////////////////////////////////////////////////////////////////
 /// Hide all canvas displays
 
 void ROOT::Experimental::RCanvas::Hide()

--- a/gui/browserv7/CMakeLists.txt
+++ b/gui/browserv7/CMakeLists.txt
@@ -19,5 +19,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowserv7
     RIO
     Gpad
     WebGui6
-    
+    ROOTGpadv7
 )

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -66,13 +66,13 @@ class RBrowser {
 protected:
 
    std::string fTitle;  ///<! title
-   unsigned fConnId{0}; ///<! connection id
+   unsigned fConnId{0}; ///<! default connection id
 
    std::string fDescPath;                ///<! last scanned directory
    std::vector<RRootFileItem> fDesc;     ///<! plain list of current directory
    std::vector<RRootFileItem *> fSorted; ///<! current sorted list (no ownership)
 
-   bool fUseRCanvas{false};               ///<!
+   bool fUseRCanvas{false};             ///<!  which canvas should be used
    std::vector<std::unique_ptr<TCanvas>> fCanvases;  ///<! canvases created by browser, should be closed at the end
    std::string fActiveCanvas;            ///<! name of active for RBrowser canvas, not a gPad!
    std::vector<std::shared_ptr<ROOT::Experimental::RCanvas>> fRCanvases; ///<!  ROOT7 canvases
@@ -104,7 +104,7 @@ protected:
    void WebWindowCallback(unsigned connid, const std::string &arg);
 
 public:
-   RBrowser();
+   RBrowser(bool use_rcanvas = false);
    virtual ~RBrowser();
 
    bool GetUseRCanvas() const { return fUseRCanvas; }

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -17,7 +17,7 @@
 #define ROOT7_RBrowser
 
 #include <ROOT/RWebWindow.hxx>
-
+#include <ROOT/RCanvas.hxx>
 #include <ROOT/RBrowserItem.hxx>
 
 #include <vector>
@@ -71,8 +71,11 @@ protected:
    std::string fDescPath;                ///<! last scanned directory
    std::vector<RRootFileItem> fDesc;     ///<! plain list of current directory
    std::vector<RRootFileItem *> fSorted; ///<! current sorted list (no ownership)
+
+   bool fUseRCanvas{false};               ///<!
    std::vector<std::unique_ptr<TCanvas>> fCanvases;  ///<! canvases created by browser, should be closed at the end
    std::string fActiveCanvas;            ///<! name of active for RBrowser canvas, not a gPad!
+   std::vector<std::shared_ptr<ROOT::Experimental::RCanvas>> fRCanvases; ///<!  ROOT7 canvases
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
@@ -81,6 +84,10 @@ protected:
    TFile *OpenFile(const std::string &fname);
    std::string GetCanvasUrl(TCanvas *canv);
    void CloseCanvas(const std::string &name);
+
+   std::shared_ptr<RCanvas> AddRCanvas();
+   std::shared_ptr<RCanvas> GetActiveRCanvas() const;
+   std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &canv);
 
    void AddFolder(const char *name);
    void AddFile(const char *name);
@@ -99,6 +106,9 @@ protected:
 public:
    RBrowser();
    virtual ~RBrowser();
+
+   bool GetUseRCanvas() const { return fUseRCanvas; }
+   void SetUseRCanvas(bool on = true) { fUseRCanvas = on; }
 
    /// show Browser in specified place
    void Show(const RWebDisplayArgs &args = "", bool always_start_new_browser = false);

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -49,8 +49,10 @@ web-based ROOT Browser prototype.
 //////////////////////////////////////////////////////////////////////////////////////////////
 /// constructor
 
-ROOT::Experimental::RBrowser::RBrowser()
+ROOT::Experimental::RBrowser::RBrowser(bool use_rcanvas)
 {
+   SetUseRCanvas(use_rcanvas);
+
    fWebWindow = RWebWindow::Create();
    fWebWindow->SetDefaultPage("file:rootui5sys/browser/browser.html");
 
@@ -60,9 +62,15 @@ ROOT::Experimental::RBrowser::RBrowser()
    fWebWindow->SetGeometry(1200, 700); // configure predefined window geometry
    fWebWindow->SetConnLimit(1); // the only connection is allowed
    fWebWindow->SetMaxQueueLength(30); // number of allowed entries in the window queue
+
    Show();
 
-   AddCanvas();  // add first canvas by default
+   // add first canvas by default
+
+   if (GetUseRCanvas())
+      AddRCanvas();
+   else
+      AddCanvas();
 
    // AddRCanvas();
 }
@@ -449,7 +457,11 @@ std::string ROOT::Experimental::RBrowser::ProcessDblClick(const std::string &ite
 
    auto rcanv = GetActiveRCanvas();
    if (rcanv) {
-      rcanv->Wipe();
+      if (rcanv->NumPrimitives() > 0) {
+         rcanv->Wipe();
+         rcanv->Modified();
+         rcanv->Update(true);
+      }
 
       // FIXME: how to proced with ownership here
       TObject* clone = object->Clone();
@@ -459,6 +471,7 @@ std::string ROOT::Experimental::RBrowser::ProcessDblClick(const std::string &ite
       std::shared_ptr<TObject> ptr;
       ptr.reset(clone);
       rcanv->Draw<RObjectDrawable>(ptr, "");
+      rcanv->Modified();
 
       rcanv->Update(true);
 

--- a/gui/canvaspainter/v7/src/TCanvasPainter.cxx
+++ b/gui/canvaspainter/v7/src/TCanvasPainter.cxx
@@ -157,6 +157,8 @@ public:
 
    virtual int NumDisplays() const override;
 
+   virtual std::string GetWindowAddr() const override;
+
    virtual void Run(double tm = 0.) override;
 
    virtual bool AddPanel(std::shared_ptr<RWebWindow>) override;
@@ -577,6 +579,15 @@ int ROOT::Experimental::TCanvasPainter::NumDisplays() const
    return fWindow->NumConnections();
 }
 
+//////////////////////////////////////////////////////////////////////////
+/// Returns web window name
+
+std::string ROOT::Experimental::TCanvasPainter::GetWindowAddr() const
+{
+   if (!fWindow) return "";
+
+   return fWindow->GetAddr();
+}
 
 //////////////////////////////////////////////////////////////////////////
 /// Add window as panel inside canvas window
@@ -596,7 +607,7 @@ bool ROOT::Experimental::TCanvasPainter::AddPanel(std::shared_ptr<RWebWindow> wi
       return false;
    }
 
-   std::string addr = fWindow->RelativeAddr(win);
+   std::string addr = fWindow->GetRelativeAddr(win);
 
    if (addr.length() == 0) {
       R__ERROR_HERE("CanvasPainter") << "Cannot attach panel to canvas";

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -34,6 +34,7 @@ public:
       kQt5,      ///< QWebEngine libraries - Chrome code packed in qt5
       kLocal,    ///< either CEF or Qt5 - both runs on local display without real http server
       kStandard, ///< standard system web browser, not recognized by ROOT, without batch mode
+      kEmbedded,  ///< window will be embedded into other, no extra browser need to be started
       kCustom    ///< custom web browser, execution string should be provided
    };
 

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -295,6 +295,8 @@ public:
 
    void RecordData(const std::string &fname = "protocol.json", const std::string &fprefix = "");
 
+   std::string GetWindowAddr() const;
+
    std::string RelativeAddr(const std::shared_ptr<RWebWindow> &win) const;
 
    void SetCallBacks(WebWindowConnectCallback_t conn, WebWindowDataCallback_t data, WebWindowConnectCallback_t disconn = nullptr);

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -295,9 +295,9 @@ public:
 
    void RecordData(const std::string &fname = "protocol.json", const std::string &fprefix = "");
 
-   std::string GetWindowAddr() const;
+   std::string GetAddr() const;
 
-   std::string RelativeAddr(const std::shared_ptr<RWebWindow> &win) const;
+   std::string GetRelativeAddr(const std::shared_ptr<RWebWindow> &win) const;
 
    void SetCallBacks(WebWindowConnectCallback_t conn, WebWindowDataCallback_t data, WebWindowConnectCallback_t disconn = nullptr);
 

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -96,6 +96,8 @@ ROOT::Experimental::RWebDisplayArgs &ROOT::Experimental::RWebDisplayArgs::SetBro
       SetBrowserKind(kCEF);
    else if ((kind == "qt") || (kind == "qt5"))
       SetBrowserKind(kQt5);
+   else if ((kind == "embed") || (kind == "embedded"))
+      SetBrowserKind(kEmbedded);
    else
       SetCustomExec(kind);
 
@@ -115,6 +117,7 @@ std::string ROOT::Experimental::RWebDisplayArgs::GetBrowserName() const
       case kQt5: return "qt5";
       case kLocal: return "local";
       case kStandard: return "default";
+      case kEmbedded: return "embed";
       case kCustom:
           auto pos = fExec.find(" ");
           return (pos == std::string::npos) ? fExec : fExec.substr(0,pos);

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -816,7 +816,7 @@ void ROOT::Experimental::RWebWindow::Sync()
 ///////////////////////////////////////////////////////////////////////////////////
 /// Returns window address which is used in URL
 
-std::string ROOT::Experimental::RWebWindow::GetWindowAddr() const
+std::string ROOT::Experimental::RWebWindow::GetAddr() const
 {
     return fWSHandler->GetName();
 }
@@ -826,7 +826,7 @@ std::string ROOT::Experimental::RWebWindow::GetWindowAddr() const
 /// Address can be required if one needs to access data from one window into another window
 /// Used for instance when inserting panel into canvas
 
-std::string ROOT::Experimental::RWebWindow::RelativeAddr(const std::shared_ptr<RWebWindow> &win) const
+std::string ROOT::Experimental::RWebWindow::GetRelativeAddr(const std::shared_ptr<RWebWindow> &win) const
 {
    if (fMgr != win->fMgr) {
       R__ERROR_HERE("WebDisplay") << "Same web window manager should be used";
@@ -834,7 +834,7 @@ std::string ROOT::Experimental::RWebWindow::RelativeAddr(const std::shared_ptr<R
    }
 
    std::string res("../");
-   res.append(win->GetWindowAddr());
+   res.append(win->GetAddr());
    res.append("/");
    return res;
 }

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -814,6 +814,14 @@ void ROOT::Experimental::RWebWindow::Sync()
 }
 
 ///////////////////////////////////////////////////////////////////////////////////
+/// Returns window address which is used in URL
+
+std::string ROOT::Experimental::RWebWindow::GetWindowAddr() const
+{
+    return fWSHandler->GetName();
+}
+
+///////////////////////////////////////////////////////////////////////////////////
 /// Returns relative URL address for the specified window
 /// Address can be required if one needs to access data from one window into another window
 /// Used for instance when inserting panel into canvas
@@ -826,7 +834,7 @@ std::string ROOT::Experimental::RWebWindow::RelativeAddr(const std::shared_ptr<R
    }
 
    std::string res("../");
-   res.append(win->fWSHandler->GetName());
+   res.append(win->GetWindowAddr());
    res.append("/");
    return res;
 }

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -374,10 +374,14 @@ std::string ROOT::Experimental::RWebWindowsManager::GetUrl(const ROOT::Experimen
 ///
 ///   HTTP-server related parameters documented in RWebWindowsManager::CreateServer() method
 
-unsigned ROOT::Experimental::RWebWindowsManager::ShowWindow(ROOT::Experimental::RWebWindow &win, bool batch_mode, const RWebDisplayArgs &user_args)
+unsigned ROOT::Experimental::RWebWindowsManager::ShowWindow(RWebWindow &win, bool batch_mode, const RWebDisplayArgs &user_args)
 {
    // silently ignore regular Show() calls in batch mode
    if (!batch_mode && gROOT->IsWebDisplayBatch())
+      return 0;
+
+   // for embedded window no any browser need to be started
+   if (user_args.GetBrowserKind() == RWebDisplayArgs::kEmbedded)
       return 0;
 
    // we book manager mutex for a longer operation,

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -609,8 +609,7 @@ void TWebCanvas::ShowWebWindow(const ROOT::Experimental::RWebDisplayArgs &args)
    if ((w > 10) && (w < 50000) && (h > 10) && (h < 30000))
       fWindow->SetGeometry(w + 6, h + 22);
 
-   if (args.GetBrowserName() != "embed")
-      fWindow->Show(args);
+   fWindow->Show(args);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/ui5/browser/browser.html
+++ b/ui5/browser/browser.html
@@ -45,7 +45,7 @@
         if (JSROOT.GetUrlOption('libs')!==null) JSROOT.use_full_libs = true;
 
         JSROOT.ConnectWebWindow({
-           prereq: "openui5;v6",  // load v6 because of canvas painter
+           prereq: "openui5;v6;v7",  // load v6,v7 because of canvas painter
 //           openui5src: "jsroot",    // use JSROOT provided package, default
 //           openui5src: "https://openui5.hana.ondemand.com/1.70.0/",
            openui5libs: "sap.m, sap.ui.layout, sap.ui.unified, sap.ui.table, sap.ui.codeeditor", // customize openui5 libs later

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -313,7 +313,7 @@ sap.ui.define(['sap/ui/core/Component',
             break;
          case "CANVS:":  // canvas created by server, need to establish connection
             var arr = JSON.parse(msg);
-            this.createCanvas(arr[0], arr[1]);
+            this.createCanvas(arr[0], arr[1], arr[2]);
             break;
          case "FROOT:": // Root file
            var selecedTabID = this.getSelectedtabFromtabContainer("myTabContainer"); // The ID of the selected tab in the TabContainer
@@ -444,11 +444,11 @@ sap.ui.define(['sap/ui/core/Component',
          if (!arr) return;
          
          for (var k=0; k<arr.length; ++k) {
-            this.createCanvas(arr[k][0], arr[k][1]);
+            this.createCanvas(arr[k][0], arr[k][1], arr[k][2]);
          }
       },
       
-      createCanvas: function(url, name) {
+      createCanvas: function(kind, url, name) {
          console.log("Create canvas ", url, name);
          if (!url || !name) return;
          
@@ -473,7 +473,14 @@ sap.ui.define(['sap/ui/core/Component',
             addr += relative_path;
          }
          
-         var painter = new JSROOT.TCanvasPainter(null);
+         var painter = null;
+         
+         if (kind == "root7") {
+            painter = new JSROOT.v7.TCanvasPainter(null);
+         } else {
+            painter = new JSROOT.TCanvasPainter(null);
+         }
+         
          painter.online_canvas = true;
          painter.use_openui = true; 
          painter.batch_mode = false;


### PR DESCRIPTION
Now both TCanvas or RCanvas can be used in RBrowser.
In both cases very similar code is used for embedding - some extension of interface was required.
On client side code is mostly identical.
For the moment TCanvas is default while RCanvas has some problem on client side with update