### PR TITLE
use RCanvas by default in RBrowser

### DIFF
--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -104,7 +104,7 @@ protected:
    void WebWindowCallback(unsigned connid, const std::string &arg);
 
 public:
-   RBrowser(bool use_rcanvas = false);
+   RBrowser(bool use_rcanvas = true);
    virtual ~RBrowser();
 
    bool GetUseRCanvas() const { return fUseRCanvas; }

--- a/js/changes.md
+++ b/js/changes.md
@@ -15,6 +15,7 @@
 12. Provide wrong_http_response workaround (#189)
 13. Improve "comp" and "compx" option to show TGeoCompositeShape components
 14. Update objects from list of histogram functions (#190)
+15. Add support of TGeo in TCanvas
 
 
 ## Changes in 5.7.1

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,14 +95,14 @@
 
    "use strict";
 
-   JSROOT.version = "dev 4/10/2019";
+   JSROOT.version = "dev 9/10/2019";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
    JSROOT.source_fullpath = ""; // full name of source script
    JSROOT.bower_dir = null;     // when specified, use standard libs from bower location
    JSROOT.nocache = false;      // when specified, used as extra URL parameter to load JSROOT scripts
-   JSROOT.wrong_http_response_handling = false; // wehn configured, try to handle wrong content-length response from server
+   JSROOT.wrong_http_response_handling = false; // when configured, try to handle wrong content-length response from server
    JSROOT.sources = ['core'];   // indicates which major sources were loaded
 
    JSROOT.id_counter = 1;       // avoid id value 0, starts from 1
@@ -168,7 +168,7 @@
          FrameNDC: { fX1NDC: 0.07, fY1NDC: 0.12, fX2NDC: 0.95, fY2NDC: 0.88 },
          Palette: 57,
          Latex: 2,    // 0 - never, 1 - only latex symbols, 2 - normal TLatex processing (default), 3 - use MathJax for complex case, 4 - use MathJax always
-         // MathJax : 0,  // depricated, will be supported till JSROOT 6.0, use Latex variable  0 - never, 1 - only for complex cases, 2 - always
+         // MathJax : 0,  // deprecated, will be supported till JSROOT 6.0, use Latex variable  0 - never, 1 - only for complex cases, 2 - always
          ProgressBox: true,  // show progress box
          Embed3DinSVG: 2,  // 0 - no embed, only 3D plot, 1 - overlay over SVG (IE/WebKit), 2 - embed into SVG (only Firefox)
          ImageSVG: !JSROOT.nodejs, // when producing SVG images, use <image> elements to insert 3D drawings from three.js,

--- a/js/scripts/JSRootPainter.js
+++ b/js/scripts/JSRootPainter.js
@@ -2437,8 +2437,7 @@
          if (rect_origin.width > lmt) {
             height_factor = height_factor || 0.66;
             main_origin.style('height', Math.round(rect_origin.width * height_factor)+'px');
-         } else
-         if (can_resize !== 'height') {
+         } else if (can_resize !== 'height') {
             main_origin.style('width', '200px').style('height', '100px');
          }
       }

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -1240,7 +1240,8 @@
       this.axes_drawn = false;
    }
 
-   TFramePainter.prototype.CleanDrawings = function() {
+   /** Removes all drawn elements of the frame @private */
+   TFramePainter.prototype.CleanFrameDrawings = function() {
       // cleanup all 3D drawings if any
       if (typeof this.Create3DScene === 'function')
          this.Create3DScene(-1);
@@ -1268,7 +1269,7 @@
 
    TFramePainter.prototype.Cleanup = function() {
 
-      this.CleanDrawings();
+      this.CleanFrameDrawings();
 
       if (this.draw_g) {
          this.draw_g.selectAll("*").remove();
@@ -1430,9 +1431,8 @@
          setTimeout(this.ProcessTooltipEvent.bind(this, hintsg.property('last_point')), 10);
    }
 
+   /** Returns frame rectangle plus extra info for hint display */
    TFramePainter.prototype.GetFrameRect = function() {
-      // returns frame rectangle plus extra info for hint display
-
       return {
          x: this.frame_x(),
          y: this.frame_y(),
@@ -1444,9 +1444,9 @@
       }
    }
 
+   /** Function called when frame is clicked and object selection can be performed
+     * such event can be used to select objects */
    TFramePainter.prototype.ProcessFrameClick = function(pnt, dblckick) {
-      // function called when frame is clicked and object selection can be performed
-      // such event can be used to select
 
       var pp = this.pad_painter();
       if (!pp) return;
@@ -2549,6 +2549,7 @@
 
    function TPadPainter(pad, iscan) {
       JSROOT.TObjectPainter.call(this, pad);
+      this.csstype = "pad";
       this.pad = pad;
       this.iscan = iscan; // indicate if working with canvas
       this.this_pad_name = "";
@@ -3381,7 +3382,7 @@
          this.painters = [];
          if (fp) {
             this.painters.push(fp);
-            fp.CleanDrawings();
+            fp.CleanFrameDrawings();
          }
          this.RemoveButtons();
          this.AddOnlineButtons();

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -26,6 +26,7 @@
 
    function THistPainter(histo) {
       JSROOT.TObjectPainter.call(this, histo);
+      this.csstype = "hist";
       this.draw_content = true;
       this.nbinsx = 0;
       this.nbinsy = 0;


### PR DESCRIPTION
Now RCanvas can correctly update/redraw ROOT6 objects - which is main test-case for RBrowser now