### PR TITLE
Change some LangOptions for MSVC

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -430,6 +430,8 @@ namespace {
       Opts.MicrosoftExt = 1;
 #ifdef _MSC_VER
       Opts.MSCompatibilityVersion = (_MSC_VER * 100000);
+      Opts.MSVCCompat = 1;
+      Opts.ThreadsafeStatics = 0;
 #endif
       // Should fix http://llvm.org/bugs/show_bug.cgi?id=10528
       Opts.DelayedTemplateParsing = 1;

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -431,7 +431,7 @@ namespace {
 #ifdef _MSC_VER
       Opts.MSCompatibilityVersion = (_MSC_VER * 100000);
       Opts.MSVCCompat = 1;
-      Opts.ThreadsafeStatics = 0;
+      Opts.ThreadsafeStatics = 0; // FIXME: this is removing the thread guard around static init!
 #endif
       // Should fix http://llvm.org/bugs/show_bug.cgi?id=10528
       Opts.DelayedTemplateParsing = 1;


### PR DESCRIPTION
Add 'MSVCCompat' flag and set 'ThreadsafeStatics = 0' (this fixes crash when running line.cxx and text.cxx root7 tests in interpreted mode)