### PR TITLE
[core] Do not deprecate the obsolete headers Htypes.h, Gtypes.h:

### DIFF
--- a/core/base/inc/Gtypes.h
+++ b/core/base/inc/Gtypes.h
@@ -11,16 +11,6 @@
 #ifndef ROOT_Gtypes
 #define ROOT_Gtypes
 
-#warning "This header is deprecated. Please include Rtypes.h"
-
-#ifdef __cplusplus
-#include "Rtypes.h"
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,20,00)
-# error "Remove this deprecated file".
-#endif
-#endif //__cplusplus
-
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // Gtypes                                                               //
@@ -30,5 +20,7 @@
 // Obsolete include: typedefs moved to Rtypes.h                         //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
+
+#include "Rtypes.h"
 
 #endif

--- a/core/base/inc/Htypes.h
+++ b/core/base/inc/Htypes.h
@@ -11,15 +11,6 @@
 #ifndef ROOT_Htypes
 #define ROOT_Htypes
 
-#warning "This header is deprecated. Please include Rtypes.h"
-
-#ifdef __cplusplus
-#include "Rtypes.h"
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,20,00)
-# error "Remove this deprecated file".
-#endif
-#endif //__cplusplus
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // Htypes                                                               //
@@ -30,6 +21,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "Rtypes.h"
 
 #endif
 


### PR DESCRIPTION
The cost for the devs is minimal, and there is no point in making users pay.
As Vassil suggested, keep the #include of the "new header" containing the
declarations originally present in this header.