### PR TITLE
Unfold plotting

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -308,6 +308,11 @@ if(CMAKE_CXX_STANDARD GREATER 14)
   set(runtime_cxxmodules_defvalue OFF)
 endif()
 
+#---Modules do not play well with preinstalled ROOT in the system------------------------------
+find_file(PREINSTALLED_MODULEMAP module.modulemap)
+if(PREINSTALLED_MODULEMAP)
+  set(runtime_cxxmodules_defvalue OFF)
+endif()
 
 # Disable RDataFrame on 32-bit UNIX platforms due to ROOT-9236
 if(UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 4)

--- a/core/base/inc/Gtypes.h
+++ b/core/base/inc/Gtypes.h
@@ -11,16 +11,6 @@
 #ifndef ROOT_Gtypes
 #define ROOT_Gtypes
 
-#warning "This header is deprecated. Please include Rtypes.h"
-
-#ifdef __cplusplus
-#include "Rtypes.h"
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,20,00)
-# error "Remove this deprecated file".
-#endif
-#endif //__cplusplus
-
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // Gtypes                                                               //
@@ -30,5 +20,7 @@
 // Obsolete include: typedefs moved to Rtypes.h                         //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
+
+#include "Rtypes.h"
 
 #endif

--- a/core/base/inc/Htypes.h
+++ b/core/base/inc/Htypes.h
@@ -11,15 +11,6 @@
 #ifndef ROOT_Htypes
 #define ROOT_Htypes
 
-#warning "This header is deprecated. Please include Rtypes.h"
-
-#ifdef __cplusplus
-#include "Rtypes.h"
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,20,00)
-# error "Remove this deprecated file".
-#endif
-#endif //__cplusplus
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // Htypes                                                               //
@@ -30,6 +21,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "Rtypes.h"
 
 #endif
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrBase.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrBase.hxx
@@ -143,6 +143,7 @@ protected:
       return *this;
    }
 
+   void SetValue(const std::string &name, bool value);
    void SetValue(const std::string &name, double value);
    void SetValue(const std::string &name, int value);
    void SetValue(const std::string &name, const std::string &value);

--- a/graf2d/gpadv7/v7/inc/ROOT/RColor.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RColor.hxx
@@ -62,7 +62,10 @@ public:
    }
 
    /** Construct color with provided RGB_t value */
-   RColor(const RGB_t &rgb) : RColor() { SetRGB(rgb[0], rgb[1], rgb[2]); }
+   RColor(const RGB_t &rgb) : RColor() { SetRGB(rgb); }
+
+   /** Set r/g/b/ components of color as hex code, default for the color */
+   RColor &SetRGB(const RGB_t &rgb) { return SetRGB(rgb[0], rgb[1], rgb[2]); }
 
    /** Set r/g/b/ components of color as hex code, default for the color */
    RColor &SetRGB(int r, int g, int b) { return SetHex(toHex(r) + toHex(g) + toHex(b)); }

--- a/graf2d/gpadv7/v7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RDrawable.hxx
@@ -24,6 +24,7 @@ class RMenuItems;
 class RPadBase;
 class RAttrBase;
 class RDisplayItem;
+class RLegend;
 
 
 namespace Internal {
@@ -100,6 +101,7 @@ class RDrawable {
 friend class RPadBase; // to access Display method
 friend class RAttrBase;
 friend class RStyle;
+friend class RLegend; // to access CollectShared method
 
 private:
    RAttrMap fAttr;               ///< attributes values

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadBase.hxx
@@ -166,10 +166,7 @@ public:
    }
 
    /// Wipe the pad by clearing the list of primitives.
-   void Wipe()
-   {
-      fPrimitives.clear();
-   }
+   void Wipe() { fPrimitives.clear(); }
 
    void CreateFrameIfNeeded();
 
@@ -207,6 +204,9 @@ public:
    {
       return fFrame->UserToNormal(pos);
    }
+
+   void AssignAutoColors();
+
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/v7/src/RAttrBase.cxx
+++ b/graf2d/gpadv7/v7/src/RAttrBase.cxx
@@ -98,6 +98,12 @@ void ROOT::Experimental::RAttrBase::ClearValue(const std::string &name)
        const_cast<RAttrMap*>(access.attr)->Clear(access.fullname);
 }
 
+void ROOT::Experimental::RAttrBase::SetValue(const std::string &name, bool value)
+{
+   if (auto access = EnsureAttr(name))
+      access.attr->AddBool(access.fullname, value);
+}
+
 void ROOT::Experimental::RAttrBase::SetValue(const std::string &name, int value)
 {
    if (auto access = EnsureAttr(name))

--- a/graf2d/gpadv7/v7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/v7/src/RPadBase.cxx
@@ -91,7 +91,7 @@ void ROOT::Experimental::RPadBase::AssignAutoColors()
       for (auto &attr: drawable->fAttr) {
          // only boolean attribute can return true
          if (!attr.second->GetBool()) continue;
-         auto pos = attr.first.find("_color_auto");
+         auto pos = attr.first.rfind("_color_auto");
          if ((pos > 0) && (pos == attr.first.length() - 11)) {
             // FIXME: dummy code to assign autocolors, later should use RPalette
             switch (cnt++ % 3) {

--- a/graf2d/gpadv7/v7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/v7/src/RPadBase.cxx
@@ -80,6 +80,32 @@ std::shared_ptr<ROOT::Experimental::RDrawable> ROOT::Experimental::RPadBase::Fin
 }
 
 ///////////////////////////////////////////////////////////////////////////
+/// Method collect existing colors and assign new values if required
+
+void ROOT::Experimental::RPadBase::AssignAutoColors()
+{
+   int cnt = 0;
+   RColor col;
+
+   for (auto &drawable : fPrimitives) {
+      for (auto &attr: drawable->fAttr) {
+         // only boolean attribute can return true
+         if (!attr.second->GetBool()) continue;
+         auto pos = attr.first.find("_color_auto");
+         if ((pos > 0) && (pos == attr.first.length() - 11)) {
+            // FIXME: dummy code to assign autocolors, later should use RPalette
+            switch (cnt++ % 3) {
+              case 0: col.SetRGB(RColor::kRed); break;
+              case 1: col.SetRGB(RColor::kGreen); break;
+              case 2: col.SetRGB(RColor::kBlue); break;
+            }
+            drawable->fAttr.AddString(attr.first.substr(0,pos) + "_color_rgb", col.GetHex());
+         }
+      }
+   }
+}
+
+///////////////////////////////////////////////////////////////////////////
 /// Create display items for all primitives in the pad
 /// Each display item gets its special id, which used later for client-server communication
 

--- a/graf2d/gpadv7/v7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/v7/src/RPadBase.cxx
@@ -95,9 +95,9 @@ void ROOT::Experimental::RPadBase::AssignAutoColors()
          if ((pos > 0) && (pos == attr.first.length() - 11)) {
             // FIXME: dummy code to assign autocolors, later should use RPalette
             switch (cnt++ % 3) {
-              case 0: col.SetRGB(RColor::kRed); break;
-              case 1: col.SetRGB(RColor::kGreen); break;
-              case 2: col.SetRGB(RColor::kBlue); break;
+              case 0: col = RColor::kRed; break;
+              case 1: col = RColor::kGreen; break;
+              case 2: col = RColor::kBlue; break;
             }
             drawable->fAttr.AddString(attr.first.substr(0,pos) + "_color_rgb", col.GetHex());
          }

--- a/graf2d/primitives/CMakeLists.txt
+++ b/graf2d/primitives/CMakeLists.txt
@@ -12,11 +12,13 @@
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGraphicsPrimitives
   HEADERS
     ROOT/RBox.hxx
+    ROOT/RLegend.hxx
     ROOT/RLine.hxx
     ROOT/RMarker.hxx
     ROOT/RText.hxx
   SOURCES
     v7/src/RBox.cxx
+    v7/src/RLegend.cxx
     v7/src/RLine.cxx
     v7/src/RMarker.cxx
     v7/src/RText.cxx

--- a/graf2d/primitives/inc/LinkDef.h
+++ b/graf2d/primitives/inc/LinkDef.h
@@ -15,6 +15,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class ROOT::Experimental::RText+;
+#pragma link C++ class ROOT::Experimental::RLegend+;
 #pragma link C++ class ROOT::Experimental::RLine+;
 #pragma link C++ class ROOT::Experimental::RBox+;
 #pragma link C++ class ROOT::Experimental::RMarker+;

--- a/graf2d/primitives/inc/LinkDef.h
+++ b/graf2d/primitives/inc/LinkDef.h
@@ -15,6 +15,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class ROOT::Experimental::RText+;
+#pragma link C++ class ROOT::Experimental::Internal::RLegendEntry+;
 #pragma link C++ class ROOT::Experimental::RLegend+;
 #pragma link C++ class ROOT::Experimental::RLine+;
 #pragma link C++ class ROOT::Experimental::RBox+;

--- a/graf2d/primitives/v7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RBox.hxx
@@ -30,14 +30,22 @@ namespace Experimental {
 class RBox : public RDrawable {
 
    /// Box's coordinates
-   RPadPos fP1, fP2;                    ///< line begin,end
-   RAttrBox fBoxAttr{this, "box_"};     ///<! line attributes
+   RPadPos fP1, fP2;                    ///< box corners coordinates
+   RAttrBox fBoxAttr{this, "box_"};     ///<! box attributes
+
+protected:
+
+   // constructor for derived classes
+   RBox(const std::string &subtype) : RDrawable(subtype) {}
 
 public:
-
    RBox() : RDrawable("box") {}
 
-   RBox(const RPadPos& p1, const RPadPos& p2) : RBox() { fP1 = p1; fP2 = p2; }
+   RBox(const RPadPos &p1, const RPadPos &p2) : RBox()
+   {
+      fP1 = p1;
+      fP2 = p2;
+   }
 
    RBox &SetP1(const RPadPos& p1) { fP1 = p1; return *this; }
    RBox &SetP2(const RPadPos& p2) { fP2 = p2; return *this; }

--- a/graf2d/primitives/v7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RLegend.hxx
@@ -1,0 +1,40 @@
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RLegend
+#define ROOT7_RLegend
+
+#include <ROOT/RBox.hxx>
+
+#include <initializer_list>
+#include <memory>
+
+namespace ROOT {
+namespace Experimental {
+
+/** \class RLegend
+\ingroup GrafROOT7
+\brief A legend for several drawables
+\author Sergey Linev <S.Linev@gsi.de>
+\date 2019-10-09
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RLegend : public RBox {
+
+public:
+
+   RLegend() : RBox("legend") {}
+
+   RLegend(const RPadPos& p1, const RPadPos& p2) : RLegend() { SetP1(p1); SetP2(p2); }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf2d/primitives/v7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RLegend.hxx
@@ -11,11 +11,62 @@
 
 #include <ROOT/RBox.hxx>
 
+#include <ROOT/RAttrText.hxx>
+
 #include <initializer_list>
 #include <memory>
 
 namespace ROOT {
 namespace Experimental {
+
+class RLegend;
+
+namespace Internal {
+
+/** \class RLegendEntry
+\ingroup GrafROOT7
+\brief An entry in RLegend, references RDrawable and its attributes
+\author Sergey Linev <S.Linev@gsi.de>
+\date 2019-10-09
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+
+class RLegendEntry {
+
+   friend class ROOT::Experimental::RLegend;
+
+   std::string fLabel;    ///< label shown for the entry
+
+   std::string fLine, fFill, fMarker;  ///< prefixes for line, fill, marker attributes
+
+   RIOShared<RDrawable> fDrawable;  ///< reference to RDrawable
+
+public:
+
+   RLegendEntry() = default;
+
+   RLegendEntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl = "")
+   {
+      fDrawable = drawable;
+      fLabel = lbl;
+   }
+
+   RLegendEntry &SetLabel(const std::string &lbl) { fLabel = lbl; return *this; }
+   const std::string &GetLabel() const { return fLabel; }
+
+   RLegendEntry &SetLine(const std::string &lbl) { fLine = lbl; return *this; }
+   const std::string &GetLine() const { return fLine; }
+
+   RLegendEntry &SetFill(const std::string &lbl) { fFill = lbl; return *this; }
+   const std::string &GetFill() const { return fFill; }
+
+   RLegendEntry &SetMarker(const std::string &lbl) { fMarker = lbl; return *this; }
+   const std::string &GetMarker() const { return fMarker; }
+
+};
+
+}
 
 /** \class RLegend
 \ingroup GrafROOT7
@@ -27,11 +78,48 @@ namespace Experimental {
 
 class RLegend : public RBox {
 
+   std::string fTitle;                  ///< legend title
+
+   std::vector<Internal::RLegendEntry> fEntries; ///< list of entries which should be displayed
+
+   RAttrText  fTitleAttr{this, "title_"};    ///<! title attributes
+
+protected:
+
+   void CollectShared(Internal::RIOSharedVector_t &vect) override
+   {
+      for (auto &entry : fEntries) {
+         vect.emplace_back(&entry.fDrawable);
+         if (entry.fDrawable)
+            entry.fDrawable->CollectShared(vect);
+      }
+   }
+
 public:
 
    RLegend() : RBox("legend") {}
 
-   RLegend(const RPadPos& p1, const RPadPos& p2) : RLegend() { SetP1(p1); SetP2(p2); }
+   RLegend(const RPadPos &p1, const RPadPos &p2, const std::string &title = "") : RLegend()
+   {
+      SetP1(p1);
+      SetP2(p2);
+      SetTitle(title);
+   }
+
+   void SetTitle(const std::string &title) { fTitle = title; }
+   const std::string &GetTitle() const { return fTitle; }
+
+   RAttrText &AttrTitle() { return fTitleAttr; }
+   const RAttrText &AttrTitle() const { return fTitleAttr; }
+
+
+   Internal::RLegendEntry &AddEntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl = "")
+   {
+      fEntries.emplace_back(drawable, lbl);
+      return fEntries.back();
+   }
+
+
 };
 
 } // namespace Experimental

--- a/graf2d/primitives/v7/src/RLegend.cxx
+++ b/graf2d/primitives/v7/src/RLegend.cxx
@@ -1,0 +1,11 @@
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RLegend.hxx"
+
+using namespace ROOT::Experimental;

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -452,7 +452,9 @@ std::string ROOT::Experimental::RBrowser::ProcessDblClick(const std::string &ite
 
       canv->ForceUpdate(); // force update async - do not wait for confirmation
 
-      return "";
+      std::string res = "SLCTCANV:";
+      res.append(canv->GetName());
+      return res;
    }
 
    auto rcanv = GetActiveRCanvas();
@@ -475,7 +477,9 @@ std::string ROOT::Experimental::RBrowser::ProcessDblClick(const std::string &ite
 
       rcanv->Update(true);
 
-      return "";
+      std::string res = "SLCTCANV:";
+      res.append(rcanv->GetTitle());
+      return res;
    }
 
 

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -452,9 +452,7 @@ std::string ROOT::Experimental::RBrowser::ProcessDblClick(const std::string &ite
 
       canv->ForceUpdate(); // force update async - do not wait for confirmation
 
-      std::string res = "SLCTCANV:";
-      res.append(canv->GetName());
-      return res;
+      return "SLCTCANV:"s + canv->GetName();
    }
 
    auto rcanv = GetActiveRCanvas();
@@ -477,9 +475,7 @@ std::string ROOT::Experimental::RBrowser::ProcessDblClick(const std::string &ite
 
       rcanv->Update(true);
 
-      std::string res = "SLCTCANV:";
-      res.append(rcanv->GetTitle());
-      return res;
+      return "SLCTCANV:"s + rcanv->GetTitle();
    }
 
 

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -345,8 +345,8 @@ ROOT::Experimental::RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserC
    fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "fork: --headless --disable-gpu $url");
    fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --app=$url");
 #else
-   fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "fork:--headless $url");
-   fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --user-data-dir=$profile --app=\'$url\' &");
+   fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "fork:--headless --incognito $url");
+   fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --incognito --app=\'$url\' &");
 #endif
 }
 
@@ -410,8 +410,8 @@ ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::FirefoxCreator() : Browse
    fBatchExec = gEnv->GetValue("WebGui.FirefoxBatch", "fork: -headless -no-remote $profile $url");
    fExec = gEnv->GetValue("WebGui.FirefoxInteractive", "$prog -no-remote $profile $url");
 #else
-   fBatchExec = gEnv->GetValue("WebGui.FirefoxBatch", "fork:-headless -no-remote $profile $url");
-   fExec = gEnv->GetValue("WebGui.FirefoxInteractive", "$prog -no-remote $profile \'$url\' &");
+   fBatchExec = gEnv->GetValue("WebGui.FirefoxBatch", "fork:--headless --private-window --no-remote $profile $url");
+   fExec = gEnv->GetValue("WebGui.FirefoxInteractive", "$prog --private-window \'$url\' &");
 #endif
 }
 

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -343,10 +343,10 @@ ROOT::Experimental::RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserC
 
 #ifdef _MSC_VER
    fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "fork: --headless --disable-gpu $url");
-   fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --app=$url");
+   fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --app=$url");
 #else
    fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "fork:--headless $url");
-   fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --user-data-dir=$profile --app=\'$url\' &");
+   fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --user-data-dir=$profile --app=\'$url\' &");
 #endif
 }
 

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -378,6 +378,7 @@ std::string ROOT::Experimental::RWebDisplayHandle::ChromeCreator::MakeProfile(st
    if (chrome_profile && *chrome_profile) {
       profile_arg = chrome_profile;
    } else {
+      gRandom->SetSeed(0);
       rmdir = profile_arg = std::string(gSystem->TempDirectory()) + "/root_chrome_profile_"s + std::to_string(gRandom->Integer(0x100000));
    }
 
@@ -434,18 +435,16 @@ std::string ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::MakeProfile(s
       profile_arg = "-profile "s + ff_profilepath;
    } else if ((ff_randomprofile > 0) || (batch_mode && (ff_randomprofile >= 0))) {
 
+      gRandom->SetSeed(0);
       std::string rnd_profile = "root_ff_profile_"s + std::to_string(gRandom->Integer(0x100000));
       std::string profile_dir = std::string(gSystem->TempDirectory()) + "/"s + rnd_profile;
 
       profile_arg = "-profile "s + profile_dir;
 
-      if (!fProg.empty()) {
-         gSystem->Exec(Form("%s %s -no-remote -CreateProfile \"%s %s\"", fProg.c_str(), (batch_mode ? "-headless" : ""),
-                            rnd_profile.c_str(), profile_dir.c_str()));
-
+      if (gSystem->mkdir(profile_dir.c_str()) == 0) {
          rmdir = profile_dir;
       } else {
-         R__ERROR_HERE("WebDisplay") << "Cannot create Firefox profile without assigned executable, check WebGui.Firefox variable";
+         R__ERROR_HERE("WebDisplay") << "Cannot create Firefox profile directory " << profile_dir;
       }
    }
 

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -4316,6 +4316,7 @@
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RLine", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawLine", opt: "", direct: true, csstype: "line" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RBox", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawBox", opt: "", direct: true, csstype: "box" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RMarker", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawMarker", opt: "", direct: true, csstype: "marker" });
+   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RLegend", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawLegend", opt: "", direct: true, csstype: "legend" });
 
    JSROOT.v7.TAxisPainter = TAxisPainter;
    JSROOT.v7.TFramePainter = TFramePainter;

--- a/js/scripts/JSRootPainter.v7more.js
+++ b/js/scripts/JSRootPainter.v7more.js
@@ -51,6 +51,7 @@
       this.FinishTextDrawing();
    }
 
+   // =================================================================================
 
    function drawLine() {
 
@@ -76,6 +77,7 @@
            .style("stroke-dasharray", JSROOT.Painter.root_line_styles[line_style]);
    }
 
+   // =================================================================================
 
    function drawBox() {
 
@@ -93,7 +95,7 @@
 
     this.CreateG();
 
-    if (fill_style == 0 ) fill_color = "none";
+    if (fill_style == 0) fill_color = "none";
 
     this.draw_g
         .append("svg:rect")
@@ -109,6 +111,7 @@
         .style("stroke-dasharray", JSROOT.Painter.root_line_styles[line_style]);
    }
 
+   // =================================================================================
 
    function drawMarker() {
        var marker       = this.GetObject(),
@@ -128,12 +131,101 @@
                      .call(att.func);
    }
 
+   // =================================================================================
+
+   function drawLegend(arg) {
+
+      var legend       = this.GetObject(),
+          pp           = this.pad_painter(),
+          p1           = pp.GetCoordinate(legend.fP1),
+          p2           = pp.GetCoordinate(legend.fP2),
+          line_width   = this.v7EvalAttr( "box_border_width", 1),
+          line_style   = this.v7EvalAttr( "box_border_style", 1),
+          line_color   = this.v7EvalColor( "box_border_color", "black"),
+          fill_color   = this.v7EvalColor( "box_fill_color", "white"),
+          fill_style   = this.v7EvalAttr( "box_fill_style", 1),
+          text_size    = this.v7EvalAttr( "title_size", 20),
+          text_angle   = -1 * this.v7EvalAttr( "title_angle", 0),
+          text_align   = this.v7EvalAttr( "title_align", 22),
+          text_color   = this.v7EvalColor( "title_color", "black"),
+          text_font    = this.v7EvalAttr( "title_font", 41);
+
+      //if (arg=="drag_resize") {
+      //   p1.x = parseInt(this.draw_g.attr("x"));
+      //   p2.y = parseInt(this.draw_g.attr("y"));
+      //   p2.x = p1.x + parseInt(this.draw_g.attr("width"));
+      //   p1.y = p2.y + parseInt(this.draw_g.attr("height"));
+      //}
+
+      this.CreateG();
+
+      if (fill_style == 0) fill_color = "none";
+
+      // position and size required only for drag functions
+      // this.draw_g.attr("transfrom", "translate(" + p1.x + "," + p2.y + ")")
+      //           .attr("x", p1.x)
+      //           .attr("y", p2.y)
+      //           .attr("width", p2.x-p1.x)
+      //           .attr("height", p1.y-p2.y);
+
+      this.draw_g
+         .append("svg:rect")
+         .attr("x", p1.x)
+         .attr("width", p2.x-p1.x)
+         .attr("y", p2.y)
+         .attr("height", p1.y-p2.y)
+         .style("stroke", line_color)
+         .attr("stroke-width", line_width)
+         .attr("fill", fill_color)
+         .style("stroke-dasharray", JSROOT.Painter.root_line_styles[line_style]);
+
+      var nlines = legend.fEntries.length;
+
+      if (legend.fTitle) nlines++;
+
+      var arg = { align: text_align,  rotate: text_angle, color: text_color, latex: 1 };
+
+      this.StartTextDrawing(text_font, text_size);
+
+      var cnt = 0;
+      if (legend.fTitle) {
+         this.DrawText(JSROOT.extend({ x: p1.x + (p2.x-p1.x)/2, y: p2.y - 0.5*(p2.y-p1.y)/(nlines+1), text: legend.fTitle }, arg));
+         cnt++;
+      }
+
+      for (var i=0; i<legend.fEntries.length; ++i) {
+         var entry = legend.fEntries[i],
+             ypos = p2.y - (cnt+0.5)*(p2.y-p1.y)/(nlines+1);
+         this.DrawText(JSROOT.extend({ x: p1.x + (p2.x-p1.x)/4, y: ypos, text: entry.fLabel }, arg));
+
+         var objp = this.FindPainterFor(entry.fDrawable.fIO);
+
+         if (objp && objp.lineatt)
+            this.draw_g
+              .append("svg:line")
+              .attr("x1", p1.x + (p2.x-p1.x)*0.5)
+              .attr("y1", ypos)
+              .attr("x2", p1.x + (p2.x-p1.x)*0.8)
+              .attr("y2", ypos)
+              .call(objp.lineatt.func);
+
+         cnt++;
+      }
+
+      this.FinishTextDrawing();
+
+   //   this.AddDrag({ minwidth: 10, minheight: 20, canselect: false,
+   //      redraw: this.Redraw.bind(this, "drag_resize"),
+   //      ctxmenu: false /*JSROOT.touches && JSROOT.gStyle.ContextMenu && this.UseContextMenu */ });
+  }
+
    // ================================================================================
 
    JSROOT.v7.drawText   = drawText;
    JSROOT.v7.drawLine   = drawLine;
    JSROOT.v7.drawBox    = drawBox;
    JSROOT.v7.drawMarker = drawMarker;
+   JSROOT.v7.drawLegend = drawLegend;
 
    return JSROOT;
 

--- a/montecarlo/vmc/inc/TMCManager.h
+++ b/montecarlo/vmc/inc/TMCManager.h
@@ -105,6 +105,12 @@ public:
    /// Transfer track from current engine to target engine mc
    void TransferTrack(TVirtualMC *mc);
 
+   /// Try to restore geometry for a given track
+   Bool_t RestoreGeometryState(Int_t trackId, Bool_t checkTrackIdRange = kTRUE);
+
+   /// Try to restore geometry for the track currently set
+   Bool_t RestoreGeometryState();
+
    //
    // Steering and control
    //

--- a/montecarlo/vmc/inc/TMCManagerStack.h
+++ b/montecarlo/vmc/inc/TMCManagerStack.h
@@ -111,15 +111,6 @@ public:
    /// Get current particle's geometry status
    const TGeoBranchArray *GetCurrentGeoState() const;
 
-   //
-   // Action methods
-   //
-
-   /// To free the cached geo state which was associated to a track
-   void NotifyOnRestoredGeometry(Int_t trackId);
-   /// To free the cached geo state which was associated to the current track
-   void NotifyOnRestoredGeometry();
-
 private:
    friend class TMCManager;
    /// Check whether track trackId exists

--- a/montecarlo/vmc/inc/TMCParticleStatus.h
+++ b/montecarlo/vmc/inc/TMCParticleStatus.h
@@ -48,7 +48,7 @@ struct TMCParticleStatus {
    /// Print all info at once
    void Print() const
    {
-      ::Info("Print", "Status of track");
+      Info("Print", "Status of track");
       std::cout << "\t"
                 << "ID: " << fId << "\n"
                 << "\t"
@@ -90,6 +90,8 @@ struct TMCParticleStatus {
    Int_t fId = -1;
    /// Unique ID assigned by the user
    Int_t fParentId = -1;
+   /// Flags to (re)set for TGeoNavigator's fIsOutside state
+   Bool_t fIsOutside;
 
 private:
    /// Copying kept private

--- a/montecarlo/vmc/inc/TVirtualMC.h
+++ b/montecarlo/vmc/inc/TVirtualMC.h
@@ -867,28 +867,12 @@ public:
    /// Return the VMC's ID
    Int_t GetId() const { return fId; }
 
-   /// Check whether external geometry construction should be used
-   Bool_t UseExternalGeometryConstruction() const { return fUseExternalGeometryConstruction; }
-
-   /// Check whether external particle generation should be used
-   Bool_t UseExternalParticleGeneration() const { return fUseExternalParticleGeneration; }
-
 private:
    /// Set the VMC id
    void SetId(UInt_t id);
 
    /// Set container holding additional information for transported TParticles
    void SetManagerStack(TMCManagerStack *stack);
-
-   /// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
-   /// and hence rely on geometry construction being trigeered from outside.
-   void SetExternalGeometryConstruction(Bool_t value = kTRUE);
-
-   /// Disables internal dispatch to TVirtualMCApplication::GeneratePrimaries()
-   /// and tells the engine to not make any implicit assumptions on whether it's
-   /// a primary or a secondary. The track could have even been transported by
-   /// another engine to the current point.
-   void SetExternalParticleGeneration(Bool_t value = kTRUE);
 
    /// An interruptible event can be paused and resumed at any time. It must not
    /// call TVirtualMCApplication::BeginEvent() and ::FinishEvent()
@@ -916,23 +900,17 @@ private:
 #endif
 
 private:
-   Int_t fId;                               //!< Unique identification of this VMC
-                                            // (don't use TObject::SetUniqueId since this
-                                            // is used to uniquely identify TObjects in
-                                            // in general)
-                                            // An ID is given by the running TVirtualMCApp
-                                            // and not by the user.
-   TVirtualMCStack *fStack;                 //!< Particles stack
-   TMCManagerStack *fManagerStack;          //!< Stack handled by the TMCManager
-   TVirtualMCDecayer *fDecayer;             //!< External decayer
-   TRandom *fRandom;                        //!< Random number generator
-   TVirtualMagField *fMagField;             //!< Magnetic field
-   Bool_t fUseExternalGeometryConstruction; //!< Don't attempt to
-                                            // call
-                                            // TVirtualMCApplication
-                                            // hooks related to geometry
-   // construction
-   Bool_t fUseExternalParticleGeneration;
+   Int_t fId;                      //!< Unique identification of this VMC
+                                   // (don't use TObject::SetUniqueId since this
+                                   // is used to uniquely identify TObjects in
+                                   // in general)
+                                   // An ID is given by the running TVirtualMCApp
+                                   // and not by the user.
+   TVirtualMCStack *fStack;        //!< Particles stack
+   TMCManagerStack *fManagerStack; //!< Stack handled by the TMCManager
+   TVirtualMCDecayer *fDecayer;    //!< External decayer
+   TRandom *fRandom;               //!< Random number generator
+   TVirtualMagField *fMagField;    //!< Magnetic field
 
    ClassDef(TVirtualMC, 1) // Interface to Monte Carlo
 };

--- a/montecarlo/vmc/src/TMCManager.cxx
+++ b/montecarlo/vmc/src/TMCManager.cxx
@@ -97,10 +97,6 @@ void TMCManager::Register(TVirtualMC *mc)
    fStacks.emplace_back(new TMCManagerStack());
    mc->SetStack(fStacks.back().get());
    mc->SetManagerStack(fStacks.back().get());
-   // Don't attempt to call TVirtualMCApplication hooks related to geometry
-   // construction
-   mc->SetExternalGeometryConstruction();
-   mc->SetExternalParticleGeneration();
    // Must update engine pointers here since during construction of the concrete TVirtualMC
    // implementation the static TVirtualMC::GetMC() or defined gMC might be used.
    UpdateEnginePointers(mc);
@@ -313,6 +309,9 @@ void TMCManager::TransferTrack(TVirtualMC *mc)
    fParticlesStatus[trackId]->fTrackLength = fCurrentEngine->TrackLength();
    fParticlesStatus[trackId]->fWeight = fCurrentEngine->TrackWeight();
 
+   // Store TGeoNavidator's fIsOutside state
+   fParticlesStatus[trackId]->fIsOutside = gGeoManager->IsOutside();
+
    TGeoBranchArray *geoState = fBranchArrayContainer.GetNewGeoState(fParticlesStatus[trackId]->fGeoStateIndex);
    geoState->InitFromNavigator(gGeoManager->GetCurrentNavigator());
 
@@ -323,6 +322,38 @@ void TMCManager::TransferTrack(TVirtualMC *mc)
       fStacks[mc->GetId()]->PushSecondaryTrackId(trackId);
    }
    fCurrentEngine->InterruptTrack();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Try to restore geometry for a given track
+///
+
+Bool_t TMCManager::RestoreGeometryState(Int_t trackId, Bool_t checkTrackIdRange)
+{
+  if (checkTrackIdRange && (trackId < 0 || trackId >= static_cast<Int_t>(fParticles.size()) || !fParticles[trackId])) {
+     return kFALSE;
+  }
+  UInt_t& geoStateId = fParticlesStatus[trackId]->fGeoStateIndex;
+  if(geoStateId == 0) {
+    return kFALSE;
+  }
+  const TGeoBranchArray* branchArray = fBranchArrayContainer.GetGeoState(geoStateId);
+  branchArray->UpdateNavigator(gGeoManager->GetCurrentNavigator());
+  fBranchArrayContainer.FreeGeoState(geoStateId);
+  gGeoManager->SetOutside(fParticlesStatus[trackId]->fIsOutside);
+  geoStateId = 0;
+  return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Try to restore geometry for the track currently set
+///
+
+Bool_t TMCManager::RestoreGeometryState()
+{
+  return RestoreGeometryState(fStacks[fCurrentEngine->GetId()]->GetCurrentTrackNumber(), kFALSE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/montecarlo/vmc/src/TMCManagerStack.cxx
+++ b/montecarlo/vmc/src/TMCManagerStack.cxx
@@ -230,31 +230,6 @@ const TGeoBranchArray *TMCManagerStack::GetCurrentGeoState() const
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// To free the cached geo state which was associated to the current track
-///
-
-void TMCManagerStack::NotifyOnRestoredGeometry()
-{
-   fBranchArrayContainer->FreeGeoState(fParticlesStatus->operator[](fCurrentTrackId)->fGeoStateIndex);
-   fParticlesStatus->operator[](fCurrentTrackId)->fGeoStateIndex = 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// To free the cached geo state which was associated to a track
-///
-
-void TMCManagerStack::NotifyOnRestoredGeometry(Int_t trackId)
-{
-   if (!HasTrackId(trackId)) {
-      Fatal("NotifyOnRestoredGeometry", "Invalid track ID %i", trackId);
-   }
-   fBranchArrayContainer->FreeGeoState(fParticlesStatus->operator[](trackId)->fGeoStateIndex);
-   fParticlesStatus->operator[](trackId)->fGeoStateIndex = 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
 /// Check whether track trackId exists
 ///
 

--- a/montecarlo/vmc/src/TMCVerbose.cxx
+++ b/montecarlo/vmc/src/TMCVerbose.cxx
@@ -249,6 +249,7 @@ void TMCVerbose::Stepping()
 
       // Step number
       //
+      // std::cout << "#" << std::setw(4) << gMC->StepNumber() << "  ";
       std::cout << "#" << std::setw(4) << fStepNumber++ << "  ";
 
       // Position
@@ -310,7 +311,7 @@ void TMCVerbose::PostTrack()
 
 void TMCVerbose::FinishPrimary()
 {
-   if (fLevel==2)
+   if (fLevel==1)
       std::cout << "--- Finish primary " << std::endl;
 }
 

--- a/montecarlo/vmc/src/TVirtualMC.cxx
+++ b/montecarlo/vmc/src/TVirtualMC.cxx
@@ -37,8 +37,7 @@ TMCThreadLocal TVirtualMC *TVirtualMC::fgMC = nullptr;
 
 TVirtualMC::TVirtualMC(const char *name, const char *title, Bool_t /*isRootGeometrySupported*/)
    : TNamed(name, title), fApplication(nullptr), fId(0), fStack(nullptr), fManagerStack(nullptr), fDecayer(nullptr),
-     fRandom(nullptr), fMagField(nullptr), fUseExternalGeometryConstruction(kFALSE),
-     fUseExternalParticleGeneration(kFALSE)
+     fRandom(nullptr), fMagField(nullptr)
 {
    fApplication = TVirtualMCApplication::Instance();
 
@@ -58,8 +57,7 @@ TVirtualMC::TVirtualMC(const char *name, const char *title, Bool_t /*isRootGeome
 
 TVirtualMC::TVirtualMC()
    : TNamed(), fApplication(nullptr), fId(0), fStack(nullptr), fManagerStack(nullptr), fDecayer(nullptr),
-     fRandom(nullptr), fMagField(nullptr), fUseExternalGeometryConstruction(kFALSE),
-     fUseExternalParticleGeneration(kFALSE)
+     fRandom(nullptr), fMagField(nullptr)
 {
 }
 
@@ -213,28 +211,6 @@ void TVirtualMC::SetId(UInt_t id)
 void TVirtualMC::SetManagerStack(TMCManagerStack *stack)
 {
    fManagerStack = stack;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
-/// and hence rely on geometry construction being trigeered from outside.
-///
-
-void TVirtualMC::SetExternalGeometryConstruction(Bool_t value)
-{
-   fUseExternalGeometryConstruction = value;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///
-/// Disables internal dispatch to TVirtualMCApplication::ConstructGeometry()
-/// and hence rely on geometry construction being trigeered from outside.
-///
-
-void TVirtualMC::SetExternalParticleGeneration(Bool_t value)
-{
-   fUseExternalParticleGeneration = value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -753,12 +753,9 @@ Double_t ParamHistFunc::analyticalIntegralWN(Int_t /*code*/, const RooArgSet* /*
 /// as the recursive division strategy of RooCurve cannot deal efficiently
 /// with the vertical lines that occur in a non-interpolated histogram
 
-std::list<Double_t>* ParamHistFunc::plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, 
-						Double_t /*xhi*/) const
+std::list<Double_t>* ParamHistFunc::plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, 
+						Double_t xhi) const
 {
-  return 0;
-
-  /*
   // copied and edited from RooHistFunc
   RooAbsLValue* lvarg = &obs;
 
@@ -766,7 +763,7 @@ std::list<Double_t>* ParamHistFunc::plotSamplingHint(RooAbsRealLValue& /*obs*/, 
   const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
   Double_t* boundaries = binning->array() ;
 
-  list<Double_t>* hint = new list<Double_t> ;
+  std::list<Double_t>* hint = new std::list<Double_t> ;
 
   // Widen range slighty
   xlo = xlo - 0.01*(xhi-xlo) ;
@@ -782,9 +779,7 @@ std::list<Double_t>* ParamHistFunc::plotSamplingHint(RooAbsRealLValue& /*obs*/, 
       hint->push_back(boundaries[i]+delta) ;
     }
   }
-
   return hint ;
-  */
 }
 
 
@@ -793,12 +788,9 @@ std::list<Double_t>* ParamHistFunc::plotSamplingHint(RooAbsRealLValue& /*obs*/, 
 /// as the recursive division strategy of RooCurve cannot deal efficiently
 /// with the vertical lines that occur in a non-interpolated histogram
 
-std::list<Double_t>* ParamHistFunc::binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, 
-						  Double_t /*xhi*/) const 
+std::list<Double_t>* ParamHistFunc::binBoundaries(RooAbsRealLValue& obs, Double_t xlo, 
+						  Double_t xhi) const 
 {
-  return 0;
-
-  /*
   // copied and edited from RooHistFunc
   RooAbsLValue* lvarg = &obs;
 
@@ -806,7 +798,7 @@ std::list<Double_t>* ParamHistFunc::binBoundaries(RooAbsRealLValue& /*obs*/, Dou
   const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
   Double_t* boundaries = binning->array() ;
 
-  list<Double_t>* hint = new list<Double_t> ;
+  std::list<Double_t>* hint = new std::list<Double_t> ;
 
   // Construct array with pairs of points positioned epsilon to the left and
   // right of the bin boundaries
@@ -817,5 +809,4 @@ std::list<Double_t>* ParamHistFunc::binBoundaries(RooAbsRealLValue& /*obs*/, Dou
   }
 
   return hint ;
-  */
 }

--- a/roofit/roofit/inc/RooDstD0BG.h
+++ b/roofit/roofit/inc/RooDstD0BG.h
@@ -45,6 +45,8 @@ protected:
   RooRealProxy C,A,B ;
 
   Double_t evaluate() const;
+  RooSpan<double> evaluateBatch(std::size_t begin, std::size_t batchSize) const;
+
 
 private:
 

--- a/roofit/roofit/inc/RooLognormal.h
+++ b/roofit/roofit/inc/RooLognormal.h
@@ -38,7 +38,8 @@ protected:
   RooRealProxy k ;
 
   Double_t evaluate() const ;
-
+  RooSpan<double> evaluateBatch(std::size_t begin, std::size_t batchSize) const;
+  
 private:
 
   ClassDef(RooLognormal,1) // log-normal PDF

--- a/roofit/roofit/inc/RooNovosibirsk.h
+++ b/roofit/roofit/inc/RooNovosibirsk.h
@@ -44,13 +44,16 @@ public:
   inline virtual ~RooNovosibirsk() { }
 
 protected:
+  Double_t evaluate() const;
+  RooSpan<double> evaluateBatch(std::size_t begin, std::size_t batchSize) const;
+
+
+private:
   RooRealProxy x;
   RooRealProxy width;
   RooRealProxy peak;
   RooRealProxy tail;
-  Double_t evaluate() const;
 
-private:
   ClassDef(RooNovosibirsk,1) // Novosibirsk PDF
 };
 

--- a/roofit/roofit/inc/RooUniform.h
+++ b/roofit/roofit/inc/RooUniform.h
@@ -40,6 +40,9 @@ protected:
   RooListProxy x ;
 
   Double_t evaluate() const ;
+  inline RooSpan<double> evaluateBatch(std::size_t, std::size_t ) const {
+    return {};
+  }
 
 private:
 

--- a/roofit/roofit/inc/RooVoigtian.h
+++ b/roofit/roofit/inc/RooVoigtian.h
@@ -47,12 +47,13 @@ protected:
   RooRealProxy sigma ;
 
   Double_t evaluate() const ;
+  RooSpan<double> evaluateBatch(std::size_t begin, std::size_t batchSize) const;
+
 
 private:
 
-  Double_t _invRootPi;
   Bool_t _doFast;
-  ClassDef(RooVoigtian,1) // Voigtian PDF (Gauss (x) BreitWigner)
+  ClassDef(RooVoigtian,2) // Voigtian PDF (Gauss (x) BreitWigner)
 };
 
 #endif

--- a/roofit/roofit/src/RooBernstein.cxx
+++ b/roofit/roofit/src/RooBernstein.cxx
@@ -129,7 +129,7 @@ Double_t RooBernstein::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace BernsteinEvaluate {
+namespace {
 //Author: Emmanouil Michalainas, CERN 16 AUGUST 2019  
 
 void compute(  size_t batchSize, double xmax, double xmin,
@@ -192,17 +192,15 @@ void compute(  size_t batchSize, double xmax, double xmin,
 
 RooSpan<double> RooBernstein::evaluateBatch(std::size_t begin, std::size_t batchSize) const {
   auto xData = _x.getValBatch(begin, batchSize);
+  if (xData.empty()) {
+        return {};
+  }
+  
   batchSize = xData.size();
   auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
-
-  if (xData.empty()) {
-        throw std::logic_error("Requested a batch computation, but no batch data available.");
-  }
-  else {
-    const double xmax = _x.max();
-    const double xmin = _x.min();
-    BernsteinEvaluate::compute(batchSize, xmax, xmin, output.data(), xData.data(), _coefList);
-  }
+  const double xmax = _x.max();
+  const double xmin = _x.min();
+  compute(batchSize, xmax, xmin, output.data(), xData.data(), _coefList);
   return output;
 }
 

--- a/roofit/roofit/src/RooChebychev.cxx
+++ b/roofit/roofit/src/RooChebychev.cxx
@@ -183,7 +183,7 @@ Double_t RooChebychev::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace ChebychevEvaluate {
+namespace {
 //Author: Emmanouil Michalainas, CERN 12 AUGUST 2019  
 
 void compute(  size_t batchSize, double xmax, double xmin,
@@ -223,17 +223,15 @@ void compute(  size_t batchSize, double xmax, double xmin,
 
 RooSpan<double> RooChebychev::evaluateBatch(std::size_t begin, std::size_t batchSize) const {
   auto xData = _x.getValBatch(begin, batchSize);
+  if (xData.empty()) {
+    return {};
+  }
+  
   batchSize = xData.size();
   auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
-
-  if (xData.empty()) {
-        throw std::logic_error("Requested a batch computation, but no batch data available.");
-  }
-  else {
-    const Double_t xmax = _x.max(_refRangeName?_refRangeName->GetName() : nullptr);
-    const Double_t xmin = _x.min(_refRangeName?_refRangeName->GetName() : nullptr);
-    ChebychevEvaluate::compute(batchSize, xmax, xmin, output.data(), xData.data(), _coefList);
-  }
+  const Double_t xmax = _x.max(_refRangeName?_refRangeName->GetName() : nullptr);
+  const Double_t xmin = _x.min(_refRangeName?_refRangeName->GetName() : nullptr);
+  compute(batchSize, xmax, xmin, output.data(), xData.data(), _coefList);
   return output;
 }
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooGamma.cxx
+++ b/roofit/roofit/src/RooGamma.cxx
@@ -95,7 +95,7 @@ Double_t RooGamma::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace GammaBatchEvaluate {
+namespace {
 //Author: Emmanouil Michalainas, CERN 22 August 2019
 
 template<class Tx, class Tgamma, class Tbeta, class Tmu>
@@ -148,16 +148,15 @@ void compute(	size_t batchSize,
 
 RooSpan<double> RooGamma::evaluateBatch(std::size_t begin, std::size_t batchSize) const {
   using namespace BatchHelpers;
-  using namespace GammaBatchEvaluate;
 
   EvaluateInfo info = getInfo( {&x, &gamma, &beta, &mu}, begin, batchSize );
-  auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
-
-  auto xData = x.getValBatch(begin, info.size);
   if (info.nBatches == 0) {
-    throw std::logic_error("Requested a batch computation, but no batch data available.");
+    return {};
   }
-  else if (info.nBatches==1 && !xData.empty()) {
+  auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
+  auto xData = x.getValBatch(begin, info.size);
+
+  if (info.nBatches==1 && !xData.empty()) {
     compute(info.size, output.data(), xData.data(),
     BracketAdapter<double> (gamma),
     BracketAdapter<double> (beta),

--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -75,11 +75,10 @@ Double_t RooPoisson::evaluate() const
 namespace {
 
 template<class Tx, class TMean>
-void compute(RooSpan<double> output, Tx x, TMean mean,
+void compute(const size_t n, double* __restrict output, Tx x, TMean mean,
     const bool protectNegative, const bool noRounding) {
-  const int n = output.size();
 
-  for (int i = 0; i < n; ++i) { //CHECK_VECTORISE
+  for (size_t i = 0; i < n; ++i) { //CHECK_VECTORISE
     const double x_i = noRounding ? x[i] : floor(x[i]);
     // The std::lgamma yields different values than in the scalar implementation.
     // Need to check which one is more accurate.
@@ -88,7 +87,7 @@ void compute(RooSpan<double> output, Tx x, TMean mean,
   }
 
 
-  for (int i = 0; i < n; ++i) { //CHECK_VECTORISE
+  for (size_t i = 0; i < n; ++i) { //CHECK_VECTORISE
     const double x_i = noRounding ? x[i] : floor(x[i]);
     const double logMean = _rf_fast_log(mean[i]);
     const double logPoisson = x_i * logMean - mean[i] - output[i];
@@ -111,27 +110,27 @@ void compute(RooSpan<double> output, Tx x, TMean mean,
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute Poisson values in batches.
 RooSpan<double> RooPoisson::evaluateBatch(std::size_t begin, std::size_t batchSize) const {
-  auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
+  using namespace BatchHelpers;
   auto xData = x.getValBatch(begin, batchSize);
   auto meanData = mean.getValBatch(begin, batchSize);
-
   const bool batchX = !xData.empty();
   const bool batchMean = !meanData.empty();
 
-  if (batchX && batchMean) {
-    compute(output, xData, meanData, _protectNegative, _noRounding);
-  } else if (batchX && !batchMean) {
-    compute(output, xData, BatchHelpers::BracketAdapter<double>(mean), _protectNegative, _noRounding);
+  if (!batchX && !batchMean) {
+    return {};
   }
-  else if (!batchX && batchMean) {
-    compute(output, BatchHelpers::BracketAdapter<double>(x), meanData, _protectNegative, _noRounding);
-  } else if (!batchX && !batchMean) {
-    compute(output, BatchHelpers::BracketAdapter<double>(x), BatchHelpers::BracketAdapter<double>(mean), _protectNegative, _noRounding);
-  } else {
-    //Should not happen
-    assert(false);
-  }
+  batchSize = findSize({ xData, meanData });
+  auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
 
+  if (batchX && !batchMean ) {
+    compute(batchSize, output.data(), xData, BracketAdapter<double>(mean), _protectNegative, _noRounding);
+  }
+  else if (!batchX && batchMean ) {
+    compute(batchSize, output.data(), BracketAdapter<double>(x), meanData, _protectNegative, _noRounding);
+  }
+  else if (batchX && batchMean ) {
+    compute(batchSize, output.data(), xData, meanData, _protectNegative, _noRounding);
+  }
   return output;
 }
 

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -104,7 +104,7 @@ public:
 
   virtual RooSpan<const double> getValBatch(std::size_t begin, std::size_t maxSize, const RooArgSet* normSet = nullptr) const;
 
-  Double_t getPropagatedError(const RooFitResult &fr, const RooArgSet &nset = RooArgSet());
+  Double_t getPropagatedError(const RooFitResult &fr, const RooArgSet &nset = RooArgSet()) const;
 
   Bool_t operator==(Double_t value) const ;
   virtual Bool_t operator==(const RooAbsArg& other) ;
@@ -470,7 +470,7 @@ protected:
    PlotOpt() : drawOptions("L"), scaleFactor(1.0), stype(Relative), projData(0), binProjData(kFALSE), projSet(0), precision(1e-3), 
                shiftToZero(kFALSE),projDataSet(0),normRangeName(0),rangeLo(0),rangeHi(0),postRangeFracScale(kFALSE),wmode(RooCurve::Extended),
                projectionRangeName(0),curveInvisible(kFALSE), curveName(0),addToCurveName(0),addToWgtSelf(1.),addToWgtOther(1.),
-               numCPU(1),interleave(RooFit::Interleave),curveNameSuffix(""), numee(10), eeval(0), doeeval(kFALSE), progress(kFALSE) {} ;
+               numCPU(1),interleave(RooFit::Interleave),curveNameSuffix(""), numee(10), eeval(0), doeeval(kFALSE), progress(kFALSE), errorFR(0) {} ;
    Option_t* drawOptions ;
    Double_t scaleFactor ;	 
    ScaleType stype ;
@@ -498,6 +498,7 @@ protected:
    Double_t eeval ;
    Bool_t   doeeval ;
    Bool_t progress ;
+   const RooFitResult* errorFR ;
   } ;
 
   // Plot implementation functions

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -53,7 +53,7 @@ public:
   RooDataHist& operator=(const RooDataHist&) = delete;
 
   RooDataHist(const RooDataHist& other, const char* newname = 0) ;
-  virtual TObject* Clone(const char* newname) const {
+  virtual TObject* Clone(const char* newname="") const {
     return new RooDataHist(*this, newname && newname[0] != '\0' ? newname : GetName());
   }
   virtual ~RooDataHist() ;

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -91,7 +91,7 @@ RooCmdArg FillColor(Color_t color) ;
 RooCmdArg FillStyle(Style_t style) ;
 RooCmdArg ProjectionRange(const char* rangeName) ;
 RooCmdArg Name(const char* name) ;
-RooCmdArg Invisible() ;
+RooCmdArg Invisible(bool inv=true) ;
 RooCmdArg AddTo(const char* name, double wgtSel=1.0, double wgtOther=1.0) ;
 RooCmdArg EvalErrorValue(Double_t value) ;
 RooCmdArg MoveToBack()  ;

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -19,6 +19,7 @@
 
 #include "RooMsgService.h"
 #include "RooAbsArg.h"
+#include "RooAbsReal.h"
 
 #include <sstream>
 
@@ -148,6 +149,22 @@ class FormatPdfTree {
 void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_list<const RooAbsReal*> pars,
     double min = -std::numeric_limits<double>::max(), double max = std::numeric_limits<double>::max());
 
+
+/// Helper class to access a batch-related part of RooAbsReal's interface, which should not leak to the outside world.
+class BatchInterfaceAccessor {
+  public:
+    static void clearBatchMemory(RooAbsReal& theReal) {
+      theReal.clearBatchMemory();
+    }
+
+    static void checkBatchComputation(const RooAbsReal& theReal, std::size_t evtNo,
+        const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) {
+      theReal.checkBatchComputation(evtNo, normSet, relAccuracy);
+    }
+};
+
+
 }
+
 
 #endif /* ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_ */

--- a/roofit/roofitcore/inc/RooHist.h
+++ b/roofit/roofitcore/inc/RooHist.h
@@ -19,6 +19,7 @@
 #include "TGraphAsymmErrors.h"
 #include "RooPlotable.h"
 #include "RooAbsData.h"
+#include "RooAbsRealLValue.h"
 
 class TH1;
 class RooCurve ;
@@ -33,6 +34,7 @@ public:
 	  Double_t xErrorFrac=1.0, Bool_t efficiency=kFALSE, Double_t scaleFactor=1.0);
   RooHist(const RooHist& hist1, const RooHist& hist2, Double_t wgt1=1.0, Double_t wgt2=1.0, 
 	  RooAbsData::ErrorType etype=RooAbsData::Poisson, Double_t xErrorFrac=1.0) ;
+  RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac=1.0, Double_t scaleFactor=1.0, const RooArgSet *normVars = 0, const RooFitResult* fr = 0);
   virtual ~RooHist();
 
   // add a datapoint for a bin with n entries, using a Poisson error

--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -50,6 +50,9 @@ public:
 	  Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax);
   virtual ~RooPlot();
 
+  static RooPlot* frame(const RooAbsRealLValue &var, Double_t xmin, Double_t xmax, Int_t nBins);
+  static RooPlot* frameWithLabels(const RooAbsRealLValue &var);
+
   RooPlot* emptyClone(const char* name) ;
 
   // implement the TH1 interface

--- a/roofit/roofitcore/inc/RooVDTHeaders.h
+++ b/roofit/roofitcore/inc/RooVDTHeaders.h
@@ -25,6 +25,7 @@
 #if defined(R__HAS_VDT)
 #include "vdt/exp.h"
 #include "vdt/log.h"
+#include "vdt/sqrt.h"
 
 inline double _rf_fast_exp(double x) {
   return vdt::fast_exp(x);
@@ -32,6 +33,10 @@ inline double _rf_fast_exp(double x) {
 
 inline double _rf_fast_log(double x) {
   return vdt::fast_log(x);
+}
+
+inline double _rf_fast_isqrt(double x) {
+  return vdt::fast_isqrt(x);
 }
 
 #else
@@ -43,6 +48,10 @@ inline double _rf_fast_exp(double x) {
 
 inline double _rf_fast_log(double x) {
   return std::exp(x);
+}
+
+inline double _rf_fast_isqrt(double x) {
+  return 1/std::sqrt(x);
 }
 
 #endif

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2349,16 +2349,13 @@ Bool_t RooAbsPdf::isDirectGenSafe(const RooAbsArg& arg) const
   if (!findServer(arg.GetName())) return kFALSE ;
 
   // There must be no other dependency routes
-  TIterator* sIter = serverIterator() ;
-  const RooAbsArg *server = 0;
-  while((server=(const RooAbsArg*)sIter->Next())) {
+  for (const auto server : _serverList) {
     if(server == &arg) continue;
     if(server->dependsOn(arg)) {
-      delete sIter ;
       return kFALSE ;
     }
   }
-  delete sIter ;
+
   return kTRUE ;
 }
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4861,7 +4861,7 @@ RooSpan<double> RooAbsReal::evaluateBatch(std::size_t begin, std::size_t maxSize
 
 
 
-#ifdef ROOFIT_CHECK_CACHED_VALUES
+
 #include "TSystem.h"
 #include "RooHelpers.h"
 
@@ -4869,7 +4869,7 @@ using RooHelpers::CachingError;
 using RooHelpers::FormatPdfTree;
 
 
-Double_t RooAbsReal::getVal(const RooArgSet* normalisationSet) const {
+Double_t RooAbsReal::_DEBUG_getVal(const RooArgSet* normalisationSet) const {
 
   const bool tmpFast = _fast;
   const double tmp = _value;
@@ -4965,4 +4965,4 @@ void RooAbsReal::checkBatchComputation(std::size_t evtNo, const RooArgSet* normS
     }
   }
 }
-#endif
+

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2314,7 +2314,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
     TString opt(o.drawOptions);
     if(opt.Contains("P")){
       RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors) ;
-      RooHist *graph= new RooHist(*projection,*plotVar,1.,1.,frame->getNormVars(),o.errorFR);
+      RooHist *graph= new RooHist(*projection,*plotVar,1.,o.scaleFactor,frame->getNormVars(),o.errorFR);
       RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
 
       // Override name of curve by user name, if specified

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2290,6 +2290,8 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
       RooAbsReal* intFrac = projection->createIntegral(*plotVar,*plotVar,o.normRangeName) ;
       _globalSelectComp = true; //It's unclear why this is done a second time. Maybe unnecessary.
       if(o.stype != RooAbsReal::Raw){
+        // this scaling should only be !=1  when plotting partial ranges
+        // still, raw means raw
         o.scaleFactor /= intFrac->getVal() ;
       }
       delete intFrac ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1645,9 +1645,9 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 ///                                    function value is plotted.
 ///
 /// <tr><td> `Normalization(Double_t scale, ScaleType code)`   <td> Adjust normalization by given scale factor. Interpretation of number depends on code:
-///                     Relative: relative adjustment factor for a normalized function,
-///                     NumEvent: scale to match given number of events.
-///                     Raw: relative adjustment factor for an un-normalized function.
+///                    - Relative: relative adjustment factor for a normalized function,
+///                    - NumEvent: scale to match given number of events.
+///                    - Raw: relative adjustment factor for an un-normalized function.
 ///
 /// <tr><td> `Name(const chat* name)`          <td> Give curve specified name in frame. Useful if curve is to be referenced later
 ///
@@ -1663,7 +1663,8 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 /// <tr><td> `Components(const RooArgSet& compSet)` <td> As above, but pass a RooArgSet of the components themselves.
 ///
 /// <tr><th><th> Plotting control
-/// <tr><td> `DrawOption(const char* opt)`     <td> Select ROOT draw option for resulting TGraph object. Currently supported options are "F" (fill), "L" (line), and "P" (points). <i>Caution: Choosing option "P" will cause RooFit to plot (and treat) this pdf as if it were data! This is intended for plotting "corrected data"-type pdfs such as "data-minus-background" or unfolded datasets.</i> 
+/// <tr><td> `DrawOption(const char* opt)`     <td> Select ROOT draw option for resulting TGraph object. Currently supported options are "F" (fill), "L" (line), and "P" (points). 
+///           \note Option "P" will cause RooFit to plot (and treat) this pdf as if it were data! This is intended for plotting "corrected data"-type pdfs such as "data-minus-background" or unfolded datasets.
 ///
 /// <tr><td> `LineStyle(Int_t style)`          <td> Select line style by ROOT line style code, default is solid
 ///

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2299,7 +2299,9 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
     
     TString opt(o.drawOptions);
     if(opt.Contains("P")){
+      RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors) ;
       RooHist *graph= new RooHist(*projection,*plotVar,1.,1.,frame->getNormVars(),o.errorFR);
+      RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
 
       // Override name of curve by user name, if specified
       if (o.curveName) {

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -45,6 +45,7 @@
 #include "RooBinning.h"
 #include "RooPlot.h"
 #include "RooCurve.h"
+#include "RooHist.h"
 #include "RooRealVar.h"
 #include "RooArgProxy.h"
 #include "RooFormulaVar.h"
@@ -1802,18 +1803,21 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   }
 
   PlotOpt o ;
+  TString drawOpt(pc.getString("drawOption"));
 
   RooFitResult* errFR = (RooFitResult*) pc.getObject("errorFR") ;
   Double_t errZ = pc.getDouble("errorZ") ;
   RooArgSet* errPars = pc.getSet("errorPars") ;
   Bool_t linMethod = pc.getInt("linearMethod") ;
-  if (errFR) {
+  if (!drawOpt.Contains("P") && errFR) {
     return plotOnWithErrorBand(frame,*errFR,errZ,errPars,argList,linMethod) ;
+  } else {
+    o.errorFR = errFR;
   }
 
   // Extract values from named arguments
   o.numee       = pc.getInt("numee") ;
-  o.drawOptions = pc.getString("drawOption") ;
+  o.drawOptions = drawOpt.Data();
   o.curveNameSuffix = pc.getString("curveNameSuffix") ;
   o.scaleFactor = pc.getDouble("scaleFactor") ;
   o.projData = (const RooAbsData*) pc.getObject("projData") ;
@@ -2283,13 +2287,6 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
     // create a new curve of our function using the clone to do the evaluations
     // Curve constructor for regular projections
 
-    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors) ;
-    RooCurve *curve = new RooCurve(*projection,*plotVar,o.rangeLo,o.rangeHi,frame->GetNbinsX(),
-				   o.scaleFactor,0,o.precision,o.precision,o.shiftToZero,o.wmode,o.numee,o.doeeval,o.eeval,o.progress);
-    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
-
-
-
     // Set default name of curve
     TString curveName(projection->GetName()) ;
     if (sliceSet.getSize()>0) {
@@ -2299,25 +2296,42 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
       // Append any suffixes imported from RooAbsPdf::plotOn
       curveName.Append(o.curveNameSuffix) ;
     }
-    curve->SetName(curveName.Data()) ;
+    
+    TString opt(o.drawOptions);
+    if(opt.Contains("P")){
+      RooHist *graph= new RooHist(*projection,*plotVar,1.,1.,frame->getNormVars(),o.errorFR);
 
+      // Override name of curve by user name, if specified
+      if (o.curveName) {
+        graph->SetName(o.curveName) ;
+      }
 
-    // Add self to other curve if requested
-    if (o.addToCurveName) {
-      RooCurve* otherCurve = static_cast<RooCurve*>(frame->findObject(o.addToCurveName,RooCurve::Class())) ;
-      RooCurve* sumCurve = new RooCurve(projection->GetName(),projection->GetTitle(),*curve,*otherCurve,o.addToWgtSelf,o.addToWgtOther) ;
-      sumCurve->SetName(Form("%s_PLUS_%s",curve->GetName(),otherCurve->GetName())) ;
-      delete curve ;
-      curve = sumCurve ;
+      // add this new curve to the specified plot frame
+      frame->addPlotable(graph, o.drawOptions, o.curveInvisible);
+    } else {
+      RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors) ;
+      RooCurve *curve = new RooCurve(*projection,*plotVar,o.rangeLo,o.rangeHi,frame->GetNbinsX(),
+                                     o.scaleFactor,0,o.precision,o.precision,o.shiftToZero,o.wmode,o.numee,o.doeeval,o.eeval,o.progress);
+      RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
+      curve->SetName(curveName.Data()) ;
+
+      // Add self to other curve if requested
+      if (o.addToCurveName) {
+        RooCurve* otherCurve = static_cast<RooCurve*>(frame->findObject(o.addToCurveName,RooCurve::Class())) ;
+        RooCurve* sumCurve = new RooCurve(projection->GetName(),projection->GetTitle(),*curve,*otherCurve,o.addToWgtSelf,o.addToWgtOther) ;
+        sumCurve->SetName(Form("%s_PLUS_%s",curve->GetName(),otherCurve->GetName())) ;
+        delete curve ;
+        curve = sumCurve ;
+      }
+
+      // Override name of curve by user name, if specified
+      if (o.curveName) {
+        curve->SetName(o.curveName) ;
+      }
+
+      // add this new curve to the specified plot frame
+      frame->addPlotable(curve, o.drawOptions, o.curveInvisible);
     }
-
-    // Override name of curve by user name, if specified
-    if (o.curveName) {
-      curve->SetName(o.curveName) ;
-    }
-
-    // add this new curve to the specified plot frame
-    frame->addPlotable(curve, o.drawOptions, o.curveInvisible);
   }
 
   if (projDataNeededVars) delete projDataNeededVars ;
@@ -2658,7 +2672,7 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
 /// \f$ \mathrm{Corr}(a,a') \f$ = the correlation matrix from the fit result
 ///
 
-Double_t RooAbsReal::getPropagatedError(const RooFitResult &fr, const RooArgSet &nset_in)
+Double_t RooAbsReal::getPropagatedError(const RooFitResult &fr, const RooArgSet &nset_in) const
 {
 
    // Strip out parameters with zero error
@@ -2808,6 +2822,10 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
   RooLinkedList tmp(plotArgList) ;
   plotOn(frame,tmp) ;
   RooCurve* cenCurve = frame->getCurve() ;
+  if(!cenCurve){
+    coutE(Plotting) << ClassName() << "::" << GetName() << ":plotOnWithErrorBand: no curve for central value available" << endl;
+    return frame;
+  }
   frame->remove(0,kFALSE) ;
 
   RooCurve* band(0) ;
@@ -2984,7 +3002,6 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
   // Insert error band in plot frame
   frame->addPlotable(band,pc.getString("drawOption"),pc.getInt("curveInvisible")) ;
 
-
   // Optionally adjust line/fill attributes
   Int_t lineColor = pc.getInt("lineColor") ;
   Int_t lineStyle = pc.getInt("lineStyle") ;
@@ -2999,9 +3016,9 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
   if (lineWidth!=-999) frame->getAttLine()->SetLineWidth(lineWidth) ;
   if (fillColor!=-999) frame->getAttFill()->SetFillColor(fillColor) ;
   if (fillStyle!=-999) frame->getAttFill()->SetFillStyle(fillStyle) ;
-  if (markerColor!=-999) ret->getAttMarker()->SetMarkerColor(markerColor) ;
-  if (markerStyle!=-999) ret->getAttMarker()->SetMarkerStyle(markerStyle) ;
-  if (markerSize!=-999) ret->getAttMarker()->SetMarkerSize(markerSize) ;
+  if (markerColor!=-999) frame->getAttMarker()->SetMarkerColor(markerColor) ;
+  if (markerStyle!=-999) frame->getAttMarker()->SetMarkerStyle(markerStyle) ;
+  if (markerSize!=-999) frame->getAttMarker()->SetMarkerSize(markerSize) ;
 
   // Adjust name if requested
   if (pc.getString("curveName",0,kTRUE)) {

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1773,6 +1773,9 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   pc.defineInt("VLines","VLines",0,2) ; // 2==ExtendedWings
   pc.defineString("rangeName","RangeWithName",0,"") ;
   pc.defineString("normRangeName","NormRange",0,"") ;
+  pc.defineInt("markerColor","MarkerColor",0,-999) ;
+  pc.defineInt("markerStyle","MarkerStyle",0,-999) ;
+  pc.defineDouble("markerSize","MarkerSize",0,-999) ;
   pc.defineInt("lineColor","LineColor",0,-999) ;
   pc.defineInt("lineStyle","LineStyle",0,-999) ;
   pc.defineInt("lineWidth","LineWidth",0,-999) ;
@@ -1940,6 +1943,9 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   Int_t lineColor = pc.getInt("lineColor") ;
   Int_t lineStyle = pc.getInt("lineStyle") ;
   Int_t lineWidth = pc.getInt("lineWidth") ;
+  Int_t markerColor = pc.getInt("markerColor") ;
+  Int_t markerStyle = pc.getInt("markerStyle") ;
+  Size_t markerSize  = pc.getDouble("markerSize") ;
   Int_t fillColor = pc.getInt("fillColor") ;
   Int_t fillStyle = pc.getInt("fillStyle") ;
   if (lineColor!=-999) ret->getAttLine()->SetLineColor(lineColor) ;
@@ -1947,6 +1953,9 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   if (lineWidth!=-999) ret->getAttLine()->SetLineWidth(lineWidth) ;
   if (fillColor!=-999) ret->getAttFill()->SetFillColor(fillColor) ;
   if (fillStyle!=-999) ret->getAttFill()->SetFillStyle(fillStyle) ;
+  if (markerColor!=-999) ret->getAttMarker()->SetMarkerColor(markerColor) ;
+  if (markerStyle!=-999) ret->getAttMarker()->SetMarkerStyle(markerStyle) ;
+  if (markerSize!=-999) ret->getAttMarker()->SetMarkerSize(markerSize) ;
 
   // Move last inserted object to back to drawing stack if requested
   if (pc.getInt("moveToBack") && frame->numItems()>1) {
@@ -2956,6 +2965,9 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
   pc.defineInt("lineColor","LineColor",0,-999) ;
   pc.defineInt("lineStyle","LineStyle",0,-999) ;
   pc.defineInt("lineWidth","LineWidth",0,-999) ;
+  pc.defineInt("markerColor","MarkerColor",0,-999) ;
+  pc.defineInt("markerStyle","MarkerStyle",0,-999) ;
+  pc.defineDouble("markerSize","MarkerSize",0,-999) ;
   pc.defineInt("fillColor","FillColor",0,-999) ;
   pc.defineInt("fillStyle","FillStyle",0,-999) ;
   pc.defineString("curveName","Name",0,"") ;
@@ -2977,6 +2989,9 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
   Int_t lineColor = pc.getInt("lineColor") ;
   Int_t lineStyle = pc.getInt("lineStyle") ;
   Int_t lineWidth = pc.getInt("lineWidth") ;
+  Int_t markerColor = pc.getInt("markerColor") ;
+  Int_t markerStyle = pc.getInt("markerStyle") ;
+  Size_t markerSize  = pc.getDouble("markerSize") ;
   Int_t fillColor = pc.getInt("fillColor") ;
   Int_t fillStyle = pc.getInt("fillStyle") ;
   if (lineColor!=-999) frame->getAttLine()->SetLineColor(lineColor) ;
@@ -2984,6 +2999,9 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
   if (lineWidth!=-999) frame->getAttLine()->SetLineWidth(lineWidth) ;
   if (fillColor!=-999) frame->getAttFill()->SetFillColor(fillColor) ;
   if (fillStyle!=-999) frame->getAttFill()->SetFillStyle(fillStyle) ;
+  if (markerColor!=-999) ret->getAttMarker()->SetMarkerColor(markerColor) ;
+  if (markerStyle!=-999) ret->getAttMarker()->SetMarkerStyle(markerStyle) ;
+  if (markerSize!=-999) ret->getAttMarker()->SetMarkerSize(markerSize) ;
 
   // Adjust name if requested
   if (pc.getString("curveName",0,kTRUE)) {

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1644,8 +1644,10 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 /// <tr><td> `EvalErrorValue(Double_t value)`  <td> Set curve points at which (pdf) evaluation error occur to specified value. By default the
 ///                                    function value is plotted.
 ///
-/// <tr><td> `Normalization(Double_t scale, ScaleType code)`   <td> Adjust normalization by given scale factor. Interpretation of number depends on code: Relative:
-///                     relative adjustment factor, NumEvent: scale to match given number of events.
+/// <tr><td> `Normalization(Double_t scale, ScaleType code)`   <td> Adjust normalization by given scale factor. Interpretation of number depends on code:
+///                     Relative: relative adjustment factor for a normalized function,
+///                     NumEvent: scale to match given number of events.
+///                     Raw: relative adjustment factor for an un-normalized function.
 ///
 /// <tr><td> `Name(const chat* name)`          <td> Give curve specified name in frame. Useful if curve is to be referenced later
 ///
@@ -1668,6 +1670,12 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 /// <tr><td> `LineColor(Int_t color)`          <td> Select line color by ROOT color code, default is blue
 ///
 /// <tr><td> `LineWidth(Int_t width)`          <td> Select line with in pixels, default is 3
+///
+/// <tr><td> `MarkerStyle(Int_t style)`   <td> Select the ROOT marker style, default is 21
+///
+/// <tr><td> `MarkerColor(Int_t color)`   <td> Select the ROOT marker color, default is black
+///
+/// <tr><td> `MarkerSize(Double_t size)`   <td> Select the ROOT marker size
 ///
 /// <tr><td> `FillStyle(Int_t style)`          <td> Select fill style, default is not filled. If a filled style is selected, also use VLines()
 ///                                    to add vertical downward lines at end of curve to ensure proper closure

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1663,7 +1663,7 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 /// <tr><td> `Components(const RooArgSet& compSet)` <td> As above, but pass a RooArgSet of the components themselves.
 ///
 /// <tr><th><th> Plotting control
-/// <tr><td> `DrawOption(const char* opt)`     <td> Select ROOT draw option for resulting TGraph object
+/// <tr><td> `DrawOption(const char* opt)`     <td> Select ROOT draw option for resulting TGraph object. Currently supported options are "F" (fill), "L" (line), and "P" (points). <i>Caution: Choosing option "P" will cause RooFit to plot (and treat) this pdf as if it were data! This is intended for plotting "corrected data"-type pdfs such as "data-minus-background" or unfolded datasets.</i> 
 ///
 /// <tr><td> `LineStyle(Int_t style)`          <td> Select line style by ROOT line style code, default is solid
 ///

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1751,6 +1751,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   pc.defineString("curveNameSuffix","CurveNameSuffix",0,"") ;
   pc.defineString("sliceCatState","SliceCat",0,"",kTRUE) ;
   pc.defineDouble("scaleFactor","Normalization",0,1.0) ;
+  pc.defineInt("scaleType","Normalization",0,Relative) ; 
   pc.defineObject("sliceSet","SliceVars",0) ;
   pc.defineObject("sliceCatList","SliceCat",0,0,kTRUE) ;
   pc.defineObject("projSet","Project",0) ;
@@ -1820,6 +1821,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   o.drawOptions = drawOpt.Data();
   o.curveNameSuffix = pc.getString("curveNameSuffix") ;
   o.scaleFactor = pc.getDouble("scaleFactor") ;
+  o.stype = (ScaleType) pc.getInt("scaleType")  ;
   o.projData = (const RooAbsData*) pc.getObject("projData") ;
   o.binProjData = pc.getInt("binProjData") ;
   o.projDataSet = (const RooArgSet*) pc.getObject("projDataSet") ;
@@ -2279,7 +2281,9 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
       GlobalSelectComponentRAII selectCompRAII(true);
       RooAbsReal* intFrac = projection->createIntegral(*plotVar,*plotVar,o.normRangeName) ;
       _globalSelectComp = true; //It's unclear why this is done a second time. Maybe unnecessary.
-      o.scaleFactor /= intFrac->getVal() ;
+      if(o.stype != RooAbsReal::Raw){
+        o.scaleFactor /= intFrac->getVal() ;
+      }
       delete intFrac ;
 
     }

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -50,6 +50,7 @@ To retrieve a RooCurve from a RooPlot, use RooPlot::getCurve().
 #include "Riostream.h"
 #include "TClass.h"
 #include "TMath.h"
+#include "TAxis.h"
 #include "TMatrixD.h"
 #include "TVectorD.h"
 #include <iomanip>
@@ -148,6 +149,7 @@ RooCurve::RooCurve(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xlo, Doubl
     GetPoint(i,x2,y2) ;
     updateYAxisLimits(y2);
   }
+  this->Sort();
 }
 
 
@@ -178,6 +180,7 @@ RooCurve::RooCurve(const char *name, const char *title, const RooAbsFunc &func,
     GetPoint(i,x,y) ;
     updateYAxisLimits(y);
   }
+  this->Sort();
 }
 
 
@@ -227,7 +230,7 @@ RooCurve::RooCurve(const char* name, const char* title, const RooCurve& c1, cons
     }
     last = *iter ;
   }
-
+  this->Sort();
 }
 
 
@@ -749,7 +752,14 @@ RooCurve* RooCurve::makeErrorBand(const vector<RooCurve*>& variations, Double_t 
   }
   for (int i=GetN()-1 ; i>=0 ; i--) {
     band->addPoint(GetX()[i],bandHi[i]) ;
-  }	   
+  }	 
+
+  if(this->GetXaxis() && this->GetXaxis()->IsAlphanumeric()){
+    band->GetXaxis()->Set(this->GetXaxis()->GetNbins(),this->GetXaxis()->GetXmin(),this->GetXaxis()->GetXmax());
+    for(int i=0; i<this->GetXaxis()->GetNbins(); ++i){
+      band->GetXaxis()->SetBinLabel(i+1,this->GetXaxis()->GetBinLabel(i+1));
+    }
+  }
   
   return band ;
 }
@@ -764,6 +774,7 @@ RooCurve* RooCurve::makeErrorBand(const vector<RooCurve*>& variations, Double_t 
 
 RooCurve* RooCurve::makeErrorBand(const vector<RooCurve*>& plusVar, const vector<RooCurve*>& minusVar, const TMatrixD& C, Double_t Z) const
 {
+  
   RooCurve* band = new RooCurve ;
   band->SetName(Form("%s_errorband",GetName())) ;
   band->SetLineWidth(1) ;
@@ -783,6 +794,13 @@ RooCurve* RooCurve::makeErrorBand(const vector<RooCurve*>& plusVar, const vector
     band->addPoint(GetX()[i],bandHi[i]) ;
   }	   
   
+  if(this->GetXaxis() && this->GetXaxis()->IsAlphanumeric()){
+    band->GetXaxis()->Set(this->GetXaxis()->GetNbins(),this->GetXaxis()->GetXmin(),this->GetXaxis()->GetXmax());
+    for(int i=0; i<this->GetXaxis()->GetNbins(); ++i){
+      band->GetXaxis()->SetBinLabel(i+1,this->GetXaxis()->GetBinLabel(i+1));
+    }
+  }
+
   return band ;
 }
 

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -120,6 +120,7 @@ RooCurve::RooCurve(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xlo, Doubl
   // calculate the points to add to our curve
   Double_t prevYMax = getYAxisMax() ;
   if(xbins > 0){
+    // regular mode - use the sampling hint to decide where to evaluate the pdf
     list<Double_t>* hint = f.plotSamplingHint(x,xlo,xhi) ;
     addPoints(*funcPtr,xlo,xhi,xbins+1,prec,resolution,wmode,nEvalError,doEEVal,eeVal,hint);
     if (_showProgress) {
@@ -129,6 +130,8 @@ RooCurve::RooCurve(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xlo, Doubl
       delete hint ;
     }
   } else {
+    // if number of bins is set to <= 0, skip any interpolation and just evaluate the pdf at the bin centers
+    // this is useful when plotting a pdf like a histogram
     int nBinsX = x.numBins();
     for(int i=0; i<nBinsX; ++i){
       double xval = x.getBinning().binCenter(i);
@@ -753,7 +756,7 @@ RooCurve* RooCurve::makeErrorBand(const vector<RooCurve*>& variations, Double_t 
   for (int i=GetN()-1 ; i>=0 ; i--) {
     band->addPoint(GetX()[i],bandHi[i]) ;
   }	 
-
+  // if the axis of the old graph is alphanumeric, copy the labels to the new one as well
   if(this->GetXaxis() && this->GetXaxis()->IsAlphanumeric()){
     band->GetXaxis()->Set(this->GetXaxis()->GetNbins(),this->GetXaxis()->GetXmin(),this->GetXaxis()->GetXmax());
     for(int i=0; i<this->GetXaxis()->GetNbins(); ++i){
@@ -794,6 +797,7 @@ RooCurve* RooCurve::makeErrorBand(const vector<RooCurve*>& plusVar, const vector
     band->addPoint(GetX()[i],bandHi[i]) ;
   }	   
   
+  // if the axis of the old graph is alphanumeric, copy the labels to the new one as well
   if(this->GetXaxis() && this->GetXaxis()->IsAlphanumeric()){
     band->GetXaxis()->Set(this->GetXaxis()->GetNbins(),this->GetXaxis()->GetXmin(),this->GetXaxis()->GetXmax());
     for(int i=0; i<this->GetXaxis()->GetNbins(); ++i){

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -118,13 +118,21 @@ RooCurve::RooCurve(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xlo, Doubl
 
   // calculate the points to add to our curve
   Double_t prevYMax = getYAxisMax() ;
-  list<Double_t>* hint = f.plotSamplingHint(x,xlo,xhi) ;
-  addPoints(*funcPtr,xlo,xhi,xbins+1,prec,resolution,wmode,nEvalError,doEEVal,eeVal,hint);
-  if (_showProgress) {
-    ccoutP(Plotting) << endl ;
-  }
-  if (hint) {
-    delete hint ;
+  if(xbins > 0){
+    list<Double_t>* hint = f.plotSamplingHint(x,xlo,xhi) ;
+    addPoints(*funcPtr,xlo,xhi,xbins+1,prec,resolution,wmode,nEvalError,doEEVal,eeVal,hint);
+    if (_showProgress) {
+      ccoutP(Plotting) << endl ;
+    }
+    if (hint) {
+      delete hint ;
+    }
+  } else {
+    xbins = x.numBins();
+    for(int i=0; i<xbins; ++i){
+      double xval = x.getBinning().binCenter(i);
+      addPoint(xval,(*funcPtr)(&xval)) ;      
+    }
   }
   initialize();
 
@@ -328,7 +336,6 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
   step=0 ;
   for(list<Double_t>::iterator iter = xval->begin() ; iter!=xval->end() ; ++iter,++step) {
     Double_t xx = *iter ;
-    
     if (step==minPoints-1) xx-=1e-15 ;
 
     yval[step]= func(&xx);

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -128,8 +128,8 @@ RooCurve::RooCurve(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xlo, Doubl
       delete hint ;
     }
   } else {
-    xbins = x.numBins();
-    for(int i=0; i<xbins; ++i){
+    int nBinsX = x.numBins();
+    for(int i=0; i<nBinsX; ++i){
       double xval = x.getBinning().binCenter(i);
       addPoint(xval,(*funcPtr)(&xval)) ;      
     }

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -59,7 +59,7 @@ namespace RooFit {
   RooCmdArg FillStyle(Style_t style)               { return RooCmdArg("FillStyle",style,0,0,0,0,0,0,0) ; }
   RooCmdArg ProjectionRange(const char* rangeName) { return RooCmdArg("ProjectionRange",0,0,0,0,rangeName,0,0,0) ; }
   RooCmdArg Name(const char* name)                 { return RooCmdArg("Name",0,0,0,0,name,0,0,0) ; }
-  RooCmdArg Invisible()                            { return RooCmdArg("Invisible",1,0,0,0,0,0,0,0) ; }
+  RooCmdArg Invisible(bool inv)                    { return RooCmdArg("Invisible",inv,0,0,0,0,0,0,0) ; }
   RooCmdArg AddTo(const char* name, double wgtSel, double wgtOther) { return RooCmdArg("AddTo",0,0,wgtSel,wgtOther,name,0,0,0) ; }
   RooCmdArg EvalErrorValue(Double_t val)           { return RooCmdArg("EvalErrorValue",1,0,val,0,0,0,0,0) ; }
   RooCmdArg MoveToBack()                           { return RooCmdArg("MoveToBack",1,0,0,0,0,0,0,0) ; }

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -76,18 +76,18 @@ void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_lis
     auto par = dynamic_cast<const RooAbsRealLValue*>(parameter);
     if (par && (par->getMin() <= min || par->getMax() >= max) ) {
       std::stringstream rangeMsg;
-      rangeMsg << "]";
+      rangeMsg << "(";
       if (min > -std::numeric_limits<double>::max())
         rangeMsg << min << ", ";
       else
         rangeMsg << "-inf, ";
 
       if (max < std::numeric_limits<double>::max())
-        rangeMsg << max << "[";
+        rangeMsg << max << ")";
       else
-        rangeMsg << "inf[";
+        rangeMsg << "inf)";
 
-      oocoutE(callingClass, InputArguments) << "The parameter '" << par->GetName() << "' with range [" << par->getMin("") << ", "
+      oocoutW(callingClass, InputArguments) << "The parameter '" << par->GetName() << "' with range [" << par->getMin("") << ", "
           << par->getMax() << "] of the " << callingClass->IsA()->GetName() << " '" << callingClass->GetName()
           << "' exceeds the safe range of " << rangeMsg.str() << ". Advise to limit its range." << std::endl;
     }

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -267,7 +267,7 @@ RooHist::RooHist(const RooHist& hist1, const RooHist& hist2, Double_t wgt1, Doub
 /// This signature is intended for unfolding/deconvolution scenarios,
 /// where a pdf is constructed as "data minus background" and is thus
 /// intended to be displayed as "data" (or at least data-like).
-/// Usage of this signature is triggered by the draw style "P" in RooAbsReal::plotOn.
+/// Usage of this signature is triggered by the draw style "P" in RooAbsReal::plotOn().
 /// 
 /// More details.
 /// \param[in] f The function to be plotted.

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -261,6 +261,15 @@ RooHist::RooHist(const RooHist& hist1, const RooHist& hist2, Double_t wgt1, Doub
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Create histogram from a pdf or function. Errors are computed based on the fit result provided.
+/// 
+/// More details.
+/// \param[in] f The function to be plotted.
+/// \param[in] x The variable on the x-axis
+/// \param[in] xErrorFrac Size of the errror in x as a fraction of the bin width
+/// \param[in] scaleFactor arbitrary scaling of the y-values
+/// \param[in] normVars variables over which to normalize
 RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, Double_t scaleFactor, const RooArgSet *normVars, const RooFitResult* fr) :
   TGraphAsymmErrors(), _nSigma(1), _rawEntries(-1)
 {

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -317,11 +317,11 @@ RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, 
   }
   int count = 0;
   for(auto it:widthcount){
-    if(it.first > count){
-      count = it.first; _nominalBinWidth=it.second;
+    if(it.second > count){
+      count = it.second; _nominalBinWidth=it.first;
     }
   }
-
+  
   // cleanup
   delete funcPtr;
   if(rawPtr) delete rawPtr;

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -299,7 +299,7 @@ RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, 
   }
   setYAxisLabel(title.Data());
 
-  RooAbsFunc *funcPtr = 0;
+  RooAbsFunc *funcPtr = nullptr;
   RooAbsFunc *rawPtr  = 0;
   funcPtr= f.bindVars(x,normVars,kTRUE);
 

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -263,6 +263,11 @@ RooHist::RooHist(const RooHist& hist1, const RooHist& hist2, Double_t wgt1, Doub
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create histogram from a pdf or function. Errors are computed based on the fit result provided.
+///
+/// This signature is intended for unfolding/deconvolution scenarios,
+/// where a pdf is constructed as "data minus background" and is thus
+/// intended to be displayed as "data" (or at least data-like).
+/// Usage of this signature is triggered by the draw style "P" in RooAbsReal::plotOn.
 /// 
 /// More details.
 /// \param[in] f The function to be plotted.

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -310,7 +310,7 @@ RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, 
   }
   
   // apply a scale factor if necessary
-  assert(0 != funcPtr);
+  assert(funcPtr);
 
   // calculate the points to add to our curve
   int xbins = x.numBins();

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -372,7 +372,7 @@ RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, 
   }
   setYAxisLabel(title.Data());
 
-  RooAbsFunc *funcPtr = 0;
+  RooAbsFunc *funcPtr = nullptr;
   RooAbsFunc *rawPtr  = nullptr;
   funcPtr= f.bindVars(x,normVars,kTRUE);
 

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -299,15 +299,12 @@ RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, 
   assert(0 != funcPtr);
 
   // calculate the points to add to our curve
-  std::map<double,int> widthcount;
   int xbins = x.numBins();
   RooArgSet nset;
   if(normVars) nset.add(*normVars);
   for(int i=0; i<xbins; ++i){
     double xval = x.getBinning().binCenter(i);
     double xwidth = x.getBinning().binWidth(i);
-    if(widthcount.find(xwidth) == widthcount.end()) widthcount[xwidth] = 1;
-    else widthcount[xwidth]+=1;
     Axis_t xval_ax = xval;
     double yval = (*funcPtr)(&xval);
     double yerr = sqrt(yval);
@@ -315,12 +312,7 @@ RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, 
     addBinWithError(xval_ax,yval,yerr,yerr,xwidth,xErrorFrac,false,scaleFactor) ;
     _entries += yval;
   }
-  int count = 0;
-  for(auto it:widthcount){
-    if(it.second > count){
-      count = it.second; _nominalBinWidth=it.first;
-    }
-  }
+  _nominalBinWidth = 1.;
   
   // cleanup
   delete funcPtr;

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -335,6 +335,79 @@ RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, 
 
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Create histogram from a pdf or function. Errors are computed based on the fit result provided.
+///
+/// This signature is intended for unfolding/deconvolution scenarios,
+/// where a pdf is constructed as "data minus background" and is thus
+/// intended to be displayed as "data" (or at least data-like).
+/// Usage of this signature is triggered by the draw style "P" in RooAbsReal::plotOn.
+/// 
+/// More details.
+/// \param[in] f The function to be plotted.
+/// \param[in] x The variable on the x-axis
+/// \param[in] xErrorFrac Size of the errror in x as a fraction of the bin width
+/// \param[in] scaleFactor arbitrary scaling of the y-values
+/// \param[in] normVars variables over which to normalize
+RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, Double_t scaleFactor, const RooArgSet *normVars, const RooFitResult* fr) :
+  TGraphAsymmErrors(), _nSigma(1), _rawEntries(-1)
+{
+  // grab the function's name and title
+  TString name(f.GetName());
+  SetName(name.Data());
+  TString title(f.GetTitle());
+  SetTitle(title.Data());
+  // append " ( [<funit> ][/ <xunit> ])" to our y-axis label if necessary
+  if(0 != strlen(f.getUnit()) || 0 != strlen(x.getUnit())) {
+    title.Append(" ( ");
+    if(0 != strlen(f.getUnit())) {
+      title.Append(f.getUnit());
+      title.Append(" ");
+    }
+    if(0 != strlen(x.getUnit())) {
+      title.Append("/ ");
+      title.Append(x.getUnit());
+      title.Append(" ");
+    }
+    title.Append(")");
+  }
+  setYAxisLabel(title.Data());
+
+  RooAbsFunc *funcPtr = 0;
+  RooAbsFunc *rawPtr  = nullptr;
+  funcPtr= f.bindVars(x,normVars,kTRUE);
+
+  // apply a scale factor if necessary
+  if(scaleFactor != 1) {
+    rawPtr= funcPtr;
+    funcPtr= new RooScaledFunc(*rawPtr,scaleFactor);
+  }
+  
+  // apply a scale factor if necessary
+  assert(0 != funcPtr);
+
+  // calculate the points to add to our curve
+  int xbins = x.numBins();
+  RooArgSet nset;
+  if(normVars) nset.add(*normVars);
+  for(int i=0; i<xbins; ++i){
+    double xval = x.getBinning().binCenter(i);
+    double xwidth = x.getBinning().binWidth(i);
+    Axis_t xval_ax = xval;
+    double yval = (*funcPtr)(&xval);
+    double yerr = sqrt(yval);
+    if(fr) yerr = f.getPropagatedError(*fr,nset);
+    addBinWithError(xval_ax,yval,yerr,yerr,xwidth,xErrorFrac,false,scaleFactor) ;
+    _entries += yval;
+  }
+  _nominalBinWidth = 1.;
+  
+  // cleanup
+  delete funcPtr;
+  if(rawPtr) delete rawPtr;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Perform common initialization for all constructors.
 
 void RooHist::initialize()

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -383,7 +383,7 @@ RooHist::RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac, 
   }
   
   // apply a scale factor if necessary
-  assert(0 != funcPtr);
+  assert(funcPtr);
 
   // calculate the points to add to our curve
   int xbins = x.numBins();

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -85,7 +85,8 @@ fitting the PDF to data and accumulating the fit statistics.
 <tr><td> ConditionalObservables(const RooArgSet& set)  <td> The set of observables that the PDF should _not_ be normalized over
 <tr><td> Binned(Bool_t flag)               <td> Bin the dataset before fitting it. Speeds up fitting of large data samples
 <tr><td> FitOptions(const char*)           <td> Classic fit options, provided for backward compatibility
-<tr><td> FitOptions(....)                  <td> Options to be used for fitting. All named arguments inside FitOptions() are passed to RooAbsPdf::fitTo()
+<tr><td> FitOptions(....)                  <td> Options to be used for fitting. All named arguments inside FitOptions() are passed to RooAbsPdf::fitTo().
+                                                `Save()` is especially interesting to be able to retrieve fit results of each run using fitResult().
 <tr><td> Verbose(Bool_t flag)              <td> Activate informational messages in event generation phase
 <tr><td> Extended(Bool_t flag)             <td> Determine number of events for each sample anew from a Poisson distribution
 <tr><td> Constrain(const RooArgSet& pars)  <td> Apply internal constraints on given parameters in fit and sample constrained parameter values from constraint p.d.f for each toy.
@@ -996,8 +997,10 @@ const RooArgSet* RooMCStudy::fitParams(Int_t sampleNum) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return the RooFitResult object of the fit to given sample 
-
+/// Return the RooFitResult of the fit with the given run number.
+///
+/// \note Fit results are not saved by default. This requires passing `FitOptions(Save(), ...)`
+/// to the constructor.
 const RooFitResult* RooMCStudy::fitResult(Int_t sampleNum) const
 {
   // Check if sampleNum is in range

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -43,6 +43,7 @@ In extended mode, a
 #include "RooRealSumPdf.h"
 #include "RooRealVar.h"
 #include "RooProdPdf.h"
+#include "RooHelpers.h"
 
 #include "Math/Util.h"
 
@@ -239,13 +240,6 @@ void RooNLLVar::applyWeightSquared(Bool_t flag)
       ((RooNLLVar*)_gofArray[i])->applyWeightSquared(flag);
   }
 }
-
-class BatchInterfaceAccessor {
-  public:
-    static void clearBatchMemory(RooAbsReal* theReal) {
-      theReal->clearBatchMemory();
-    }
-};
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -463,7 +457,7 @@ std::tuple<double, double, double> RooNLLVar::computeBatched(std::size_t stepSiz
     assert(_dataClone->valid());
     pdfClone->getValV(_normSet);
     try {
-      pdfClone->checkBatchComputation(evtNo, _normSet);
+      RooHelpers::BatchInterfaceAccessor::checkBatchComputation(*pdfClone, evtNo, _normSet);
     } catch (std::exception& e) {
       std::cerr << "ERROR when checking batch computation for event " << evtNo << ":\n"
           << e.what() << std::endl;

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -489,22 +489,17 @@ void RooPlot::addTH1(TH1 *hist, Option_t *drawOptions, Bool_t invisible)
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-/// Add the specified plotable object to our plot. Increase our y-axis
-/// limits to fit this object if necessary. The default lower-limit
-/// is zero unless we are plotting an object that takes on negative values.
-/// This call transfers ownership of the plotable object to this class.
-/// The plotable object will be deleted when this plot object is deleted.
-
 namespace {
+  // this helper function is intended to translate a graph from a regular axis to a labelled axis
+  // this version uses TGraph, which is a parent of RooCurve
   void translateGraph(TH1* hist, RooAbsRealLValue* xvar, TGraph* graph){
-    if(graph->GetXaxis()->IsAlphanumeric()){
-      return;
-    }
+    // if the graph already has a labelled axis, don't do anything
+    if(graph->GetXaxis()->IsAlphanumeric()) return;
     double xmin = hist->GetXaxis()->GetXmin();
     double xmax = hist->GetXaxis()->GetXmax();
     if(graph->TestBit(TGraph::kIsSortedX)){
       // sorted graphs are "line graphs"
+      // evaluate the graph at the lower and upper edge as well as the center of each bin
       std::vector<double> x;
       std::vector<double> y;
       x.push_back(xmin);
@@ -527,6 +522,7 @@ namespace {
       std::map<int,double> maxValues;
       int n = graph->GetN();
       double x, y;
+      // for each bin, find the min and max points to form an envelope
       for(int i=0; i<n; ++i){
         graph->GetPoint(i,x,y);
         int bin = xvar->getBinning().binNumber(x)+1;
@@ -546,6 +542,7 @@ namespace {
       graph->Set(hist->GetNbinsX()+2);
       int np=0;
       graph->SetPoint(np,xmin,xminY);
+      // assign the calculated envelope boundaries to the bin centers of the bins
       for(auto it = maxValues.begin(); it != maxValues.end(); ++it){
         graph->SetPoint(++np,hist->GetXaxis()->GetBinCenter(it->first),it->second);
       }
@@ -555,17 +552,22 @@ namespace {
       }
       graph->SetPoint(++np,xmin,xminY);
     }
+    // make sure that the graph also has the labels set, such that subsequent calls to translate this graph will not do anything
     graph->GetXaxis()->Set(hist->GetNbinsX(),xmin,xmax);
     for(int i=0; i<hist->GetNbinsX(); ++i){
       graph->GetXaxis()->SetBinLabel(i+1,hist->GetXaxis()->GetBinLabel(i+1));
     }
   }
+  // this version uses TGraphErrors, which is a parent of RooHist
   void translateGraph(TH1* hist, RooAbsRealLValue* xvar, TGraphAsymmErrors* graph){
+    // if the graph already has a labelled axis, don't do anything
     if(graph->GetXaxis()->IsAlphanumeric()) return; 
     int n = graph->GetN();
     double xmin = hist->GetXaxis()->GetXmin();
     double xmax = hist->GetXaxis()->GetXmax();
     double x, y;
+    // as this graph is histogram-like, we expect there to be one point per bin
+    // we just move these points to the respective bin centers
     for(int i=0; i<n; ++i){
       if(graph->GetPoint(i,x,y)!=i) break;
       int bin = xvar->getBinning().binNumber(x);
@@ -574,12 +576,19 @@ namespace {
       graph->SetPointEXlow(i,0.5*hist->GetXaxis()->GetBinWidth(bin+1));
     }
     graph->GetXaxis()->Set(hist->GetNbinsX(),xmin,xmax);
+    // make sure that the graph also has the labels set, such that subsequent calls to translate this graph will not do anything    
     for(int i=0; i<hist->GetNbinsX(); ++i){
       graph->GetXaxis()->SetBinLabel(i+1,hist->GetXaxis()->GetBinLabel(i+1));
     }
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Add the specified plotable object to our plot. Increase our y-axis
+/// limits to fit this object if necessary. The default lower-limit
+/// is zero unless we are plotting an object that takes on negative values.
+/// This call transfers ownership of the plotable object to this class.
+/// The plotable object will be deleted when this plot object is deleted.
 void RooPlot::addPlotable(RooPlotable *plotable, Option_t *drawOptions, Bool_t invisible, Bool_t refreshNorm)
 {
   // update our y-axis label and limits
@@ -594,6 +603,7 @@ void RooPlot::addPlotable(RooPlotable *plotable, Option_t *drawOptions, Bool_t i
     coutE(InputArguments) << fName << "::add: cross-cast to TObject failed (nothing added)" << endl;
   }
   else {
+    // if the frame axis is alphanumeric, the coordinates of the graph need to be translated to this binning
     if(this->_hist->GetXaxis()->IsAlphanumeric()){
       if(obj->InheritsFrom(RooCurve::Class())){
         ::translateGraph(this->_hist,_plotVarClone,static_cast<RooCurve*>(obj));

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -267,11 +267,26 @@ RooPlot::RooPlot(const RooAbsRealLValue &var, Double_t xmin, Double_t xmax, Int_
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-//
-
+/// Create a new frame for a given variable in x. This is just a
+/// wrapper for the RooPlot constructor with the same interface.
+/// 
+/// More details.
+/// \param[in] var The variable on the x-axis
+/// \param[in] xmin Left edge of the x-axis
+/// \param[in] xmax Right edge of the x-axis
+/// \param[in] nBins number of bins on the x-axis
 RooPlot* RooPlot::frame(const RooAbsRealLValue &var, Double_t xmin, Double_t xmax, Int_t nBins){
   return new RooPlot(var,xmin,xmax,nBins);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Create a new frame for a given variable in x, adding bin labels.
+/// The binning will be extracted from the variable given. The bin
+/// labels will be set as "%g-%g" for the left and right edges of each
+/// bin of the given variable.
+///
+/// More details.
+/// \param[in] var The variable on the x-axis
 RooPlot* RooPlot::frameWithLabels(const RooAbsRealLValue &var){
   RooPlot* pl = new RooPlot();
   int nbins = var.getBinning().numBins();

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -484,18 +484,23 @@ void RooPlot::addTH1(TH1 *hist, Option_t *drawOptions, Bool_t invisible)
 namespace {
   void translateGraph(TH1* hist, RooAbsRealLValue* xvar, TGraph* graph){
     int n = graph->GetN();
+    std::map<int,double> values;
     double x, y;
     for(int i=0; i<n; ++i){
       if(graph->GetPoint(i,x,y)!=i) break;
       int bin = xvar->getBinning().binNumber(x);
-      graph->SetPoint(i,hist->GetXaxis()->GetBinCenter(bin+1),y);
+      values[bin+1] = y;
     }
     double xmin = hist->GetXaxis()->GetXmin();
-    double xminVal = graph->Eval(xmin);
     double xmax = hist->GetXaxis()->GetXmax();
-    double xmaxVal = graph->Eval(xmax);
-    graph->SetPoint(n,xmax,xmaxVal);
-    graph->SetPoint(n+1,xmin,xminVal);
+    double xminY = graph->Eval(xmin);
+    double xmaxY = graph->Eval(xmax);
+    graph->Set(values.size()+2);
+    graph->SetPoint(0,xmin,xminY);
+    for(auto it:values){
+      graph->SetPoint(it.first,hist->GetXaxis()->GetBinCenter(it.first),it.second);
+    }
+    graph->SetPoint(hist->GetNbinsX()+1,xmax,xmaxY);
     graph->Sort();
   }
   void translateGraph(TH1* hist, RooAbsRealLValue* xvar, TGraphAsymmErrors* graph){

--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -164,8 +164,8 @@ protected:
 
 private:
    // Not implemented yet
-   TTreeFormula(const TTreeFormula&);
-   TTreeFormula& operator=(const TTreeFormula&);
+   TTreeFormula(const TTreeFormula&) = delete;
+   TTreeFormula& operator=(const TTreeFormula&) = delete;
 
    template<typename T> T GetConstant(Int_t k);
 

--- a/tree/treeplayer/inc/TTreeFormulaManager.h
+++ b/tree/treeplayer/inc/TTreeFormulaManager.h
@@ -21,9 +21,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-
 #include "TObjArray.h"
-
 #include "TTreeFormula.h"
 
 class TArrayI;
@@ -50,8 +48,8 @@ private:
 
 private:
    // Not implemented yet
-   TTreeFormulaManager(const TTreeFormulaManager&);
-   TTreeFormulaManager& operator=(const TTreeFormulaManager&);
+   TTreeFormulaManager(const TTreeFormulaManager&) = delete;
+   TTreeFormulaManager& operator=(const TTreeFormulaManager&) = delete;
 
 protected:
 

--- a/tree/treeplayer/inc/TTreeIndex.h
+++ b/tree/treeplayer/inc/TTreeIndex.h
@@ -23,7 +23,8 @@
 
 
 #include "TVirtualIndex.h"
-#include "TTreeFormula.h"
+
+class TTreeFormula;
 
 class TTreeIndex : public TVirtualIndex {
 
@@ -40,8 +41,8 @@ protected:
    TTreeFormula  *fMinorFormulaParent;  //! Pointer to minor TreeFormula in Parent tree (if any)
 
 private:
-   TTreeIndex(const TTreeIndex&);            // Not implemented.
-   TTreeIndex &operator=(const TTreeIndex&); // Not implemented.
+   TTreeIndex(const TTreeIndex&) = delete;            // Not implemented.
+   TTreeIndex &operator=(const TTreeIndex&) = delete; // Not implemented.
 
 public:
    TTreeIndex();

--- a/tree/treeplayer/inc/TTreePerfStats.h
+++ b/tree/treeplayer/inc/TTreePerfStats.h
@@ -34,6 +34,7 @@ class TPaveText;
 class TGraphErrors;
 class TGaxis;
 class TText;
+
 class TTreePerfStats : public TVirtualPerfStats {
 
 public:

--- a/tree/treeplayer/inc/TTreePlayer.h
+++ b/tree/treeplayer/inc/TTreePlayer.h
@@ -27,18 +27,18 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TTree.h"
-#include "TSelectorDraw.h"
 #include "TVirtualTreePlayer.h"
 
+#include "TSelectorDraw.h"
+#include "TTree.h"
 
 class TVirtualIndex;
 
 class TTreePlayer : public TVirtualTreePlayer {
 
 private:
-   TTreePlayer(const TTreePlayer &);
-   TTreePlayer& operator=(const TTreePlayer &);
+   TTreePlayer(const TTreePlayer &) = delete;
+   TTreePlayer& operator=(const TTreePlayer &) = delete;
 
 protected:
    TTree         *fTree;            //!  Pointer to current Tree

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -22,7 +22,6 @@
 //                                                                        //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "THashTable.h"
 #include "TTree.h"
 #include "TTreeReaderUtils.h"
 #include "TNotifyLink.h"

--- a/tree/treeplayer/src/TTreeFormulaManager.cxx
+++ b/tree/treeplayer/src/TTreeFormulaManager.cxx
@@ -27,8 +27,7 @@ ClassImp(TTreeFormulaManager);
    ////////////////////////////////////////////////////////////////////////////////
    /// Tree FormulaManger default constructor.
 
-   TTreeFormulaManager::TTreeFormulaManager()
-   : TObject()
+TTreeFormulaManager::TTreeFormulaManager() : TObject()
 {
    fMultiplicity = 0;
    fMultiVarDim = kFALSE;

--- a/tree/treeplayer/src/TTreeIndex.cxx
+++ b/tree/treeplayer/src/TTreeIndex.cxx
@@ -14,6 +14,8 @@ A Tree Index with majorname and minorname.
 */
 
 #include "TTreeIndex.h"
+
+#include "TTreeFormula.h"
 #include "TTree.h"
 #include "TMath.h"
 

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -15,12 +15,13 @@ Implement some of the functionality of the class TTree requiring access to
 extra libraries (Histogram, display, etc).
 */
 
+#include "TTreePlayer.h"
+
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 #include "Riostream.h"
-#include "TTreePlayer.h"
 #include "TROOT.h"
 #include "TSystem.h"
 #include "TFile.h"
@@ -38,6 +39,7 @@ extra libraries (Histogram, display, etc).
 #include "TLeafI.h"
 #include "TLeafS.h"
 #include "TMath.h"
+#include "TH1.h"
 #include "TH2.h"
 #include "TH3.h"
 #include "TPolyMarker.h"
@@ -59,7 +61,6 @@ extra libraries (Histogram, display, etc).
 #include "TChain.h"
 #include "TChainElement.h"
 #include "TF1.h"
-#include "TH1.h"
 #include "TVirtualFitter.h"
 #include "TEnv.h"
 #include "THLimitsFinder.h"

--- a/tree/treeviewer/inc/TGTreeTable.h
+++ b/tree/treeviewer/inc/TGTreeTable.h
@@ -13,7 +13,6 @@
 
 #include "TGTable.h"
 
-class TTreeTableInterface;
 class TTree;
 
 class TGTreeTable : public TGTable {

--- a/tree/treeviewer/inc/TMemStatShow.h
+++ b/tree/treeviewer/inc/TMemStatShow.h
@@ -12,8 +12,6 @@
 #ifndef ROOT_TMemStatShow
 #define ROOT_TMemStatShow
 
-
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // TMemStatShow                                                         //

--- a/tree/treeviewer/inc/TParallelCoord.h
+++ b/tree/treeviewer/inc/TParallelCoord.h
@@ -64,7 +64,7 @@ public:
    TParallelCoord();
    TParallelCoord(Long64_t nentries);
    TParallelCoord(TTree* tree, Long64_t nentries);
-   ~TParallelCoord();
+   virtual ~TParallelCoord();
 
    void           AddVariable(Double_t* val, const char* title="");
    void           AddVariable(const char* varexp);

--- a/tree/treeviewer/inc/TParallelCoordEditor.h
+++ b/tree/treeviewer/inc/TParallelCoordEditor.h
@@ -80,7 +80,7 @@ public:
                         Int_t width = 140, Int_t height = 30,
                         UInt_t options = kChildFrame,
                         Pixel_t back = GetDefaultFrameBackground());
-   ~TParallelCoordEditor();
+   virtual ~TParallelCoordEditor();
 
    virtual void            DoActivateSelection(Bool_t);
    virtual void            DoAddSelection();

--- a/tree/treeviewer/inc/TParallelCoordRange.h
+++ b/tree/treeviewer/inc/TParallelCoordRange.h
@@ -13,7 +13,6 @@
 #define ROOT_TParallelCoordRange
 
 #include "TNamed.h"
-
 #include "TAttLine.h"
 
 class TParallelCoordVar;
@@ -43,8 +42,8 @@ private:
 
 public:
    TParallelCoordRange();
-   ~TParallelCoordRange();
    TParallelCoordRange(TParallelCoordVar *var, Double_t min=0, Double_t max=0, TParallelCoordSelect* sel=NULL);
+   virtual ~TParallelCoordRange();
 
    virtual void BringOnTop() ;// *MENU*
    virtual void Delete(const Option_t* options=""); // *MENU*

--- a/tree/treeviewer/inc/TParallelCoordVar.h
+++ b/tree/treeviewer/inc/TParallelCoordVar.h
@@ -12,8 +12,8 @@
 #ifndef ROOT_TParallelCoordVar
 #define ROOT_TParallelCoordVar
 
-#include "TAttLine.h"
 #include "TNamed.h"
+#include "TAttLine.h"
 #include "TAttFill.h"
 
 class TParallelCoord;
@@ -54,7 +54,7 @@ private:
 public:
    TParallelCoordVar();
    TParallelCoordVar(Double_t *val, const char* title,Int_t id, TParallelCoord* gram);
-   ~TParallelCoordVar();
+   virtual ~TParallelCoordVar();
 
    void           AddRange(TParallelCoordRange* range);
    void           AddRange() {AddRange(NULL);} // *MENU*

--- a/tree/treeviewer/inc/TSpider.h
+++ b/tree/treeviewer/inc/TSpider.h
@@ -22,12 +22,8 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "TObject.h"
-
 #include "TAttFill.h"
-
 #include "TAttLine.h"
-
-#include "TAttText.h"
 
 class TTree;
 class TGraphPolargram;

--- a/tree/treeviewer/inc/TTVSession.h
+++ b/tree/treeviewer/inc/TTVSession.h
@@ -19,7 +19,8 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "TGFrame.h"
+#include "TObject.h"
+#include "TString.h"
 
 class TTreeViewer;
 class TClonesArray;

--- a/tree/treeviewer/inc/TTreeViewer.h
+++ b/tree/treeviewer/inc/TTreeViewer.h
@@ -22,12 +22,10 @@
 
 #include "TTree.h"
 
-class TTreeViewer;
 class TTVLVContainer;
 class TTVLVEntry;
 class TTVSession;
 class TGSelectBox;
-class TTree;
 class TBranch;
 class TContextMenu;
 class TList;

--- a/tree/treeviewer/src/TTreeViewer.cxx
+++ b/tree/treeviewer/src/TTreeViewer.cxx
@@ -201,7 +201,6 @@ or :
 #include "TGFrame.h"
 #include "TCanvas.h"
 #include "TH1.h"
-#include "TTree.h"
 #include "TFriendElement.h"
 #include "TObjArray.h"
 #include "TObjString.h"

--- a/tutorials/v7/draw.cxx
+++ b/tutorials/v7/draw.cxx
@@ -20,6 +20,8 @@
 #include "ROOT/RColor.hxx"
 #include "ROOT/RHistDrawable.hxx"
 
+R__LOAD_LIBRARY(libROOTHistDraw)
+
 void draw()
 {
    using namespace ROOT::Experimental;

--- a/tutorials/v7/draw.cxx
+++ b/tutorials/v7/draw.cxx
@@ -20,6 +20,8 @@
 #include "ROOT/RColor.hxx"
 #include "ROOT/RHistDrawable.hxx"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
 
 void draw()

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -1,0 +1,56 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// This macro generates a small V7 TH1D, fills it and draw it in a V7 canvas.
+/// The canvas is display in the web browser and the corresponding png picture
+/// is generated.
+///
+/// \macro_code
+///
+/// \date 2015-03-22
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \author Axel Naumann <axel@cern.ch>
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RHistDrawable.hxx"
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RLegend.hxx"
+#include "TRandom.h"
+
+using namespace ROOT::Experimental;
+
+void draw_legend()
+{
+   // Create the histogram.
+   RAxisConfig xaxis(25, 0., 10.);
+   auto pHist = std::make_shared<RH1D>(xaxis);
+   auto pHist2 = std::make_shared<RH1D>(xaxis);
+
+   for (int n=0;n<1000;n++) {
+      pHist->Fill(gRandom->Gaus(3,0.8));
+      pHist2->Fill(gRandom->Gaus(7,1.2));
+   }
+
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create("Canvas Title");
+   auto draw1 = canvas->Draw(pHist);
+   draw1->AttrLine().SetColor(RColor::kRed).SetWidth(2);
+
+   auto draw2 = canvas->Draw(pHist2);
+   draw2->AttrLine().SetColor(RColor::kBlue).SetWidth(4);
+   
+   auto legend = canvas->Draw<RLegend>(RPadPos(0.5_normal, 0.6_normal), RPadPos(0.9_normal,0.9_normal), "Legend title");
+   legend->AttrBox().Fill().SetStyle(5).SetColor(RColor::kWhite);
+   legend->AttrBox().Border().SetWidth(2).SetColor(RColor::kRed);
+   legend->AddEntry(draw1, "histo1").SetLine("line_");
+   legend->AddEntry(draw2, "histo2").SetLine("line_");
+
+   canvas->Show();
+}

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -23,6 +23,8 @@
 #include "ROOT/RLegend.hxx"
 #include "TRandom.h"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
 
 using namespace ROOT::Experimental;

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -23,6 +23,8 @@
 #include "ROOT/RLegend.hxx"
 #include "TRandom.h"
 
+R__LOAD_LIBRARY(libROOTHistDraw)
+
 using namespace ROOT::Experimental;
 
 void draw_legend()

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -1,15 +1,14 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// This macro generates a small V7 TH1D, fills it and draw it in a V7 canvas.
-/// The canvas is display in the web browser and the corresponding png picture
-/// is generated.
+/// This macro generates two TH1D objects and build RLegend
+/// In addition use of auto colors are shown
 ///
 /// \macro_code
 ///
-/// \date 2015-03-22
+/// \date 2019-10-09
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-/// \author Axel Naumann <axel@cern.ch>
+/// \author Sergey Linev <s.linev@gsi.de>
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
@@ -28,7 +27,7 @@ using namespace ROOT::Experimental;
 
 void draw_legend()
 {
-   // Create the histogram.
+   // Create the histograms.
    RAxisConfig xaxis(25, 0., 10.);
    auto pHist = std::make_shared<RH1D>(xaxis);
    auto pHist2 = std::make_shared<RH1D>(xaxis);
@@ -40,11 +39,16 @@ void draw_legend()
 
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
-   auto draw1 = canvas->Draw(pHist);
-   draw1->AttrLine().SetColor(RColor::kRed).SetWidth(2);
 
+   // draw histogram
+   auto draw1 = canvas->Draw(pHist);
+   draw1->AttrLine().SetWidth(2).Color().SetAuto();
+
+   // draw histogram
    auto draw2 = canvas->Draw(pHist2);
-   draw2->AttrLine().SetColor(RColor::kBlue).SetWidth(4);
+   draw2->AttrLine().SetWidth(4).Color().SetAuto();
+
+   canvas->AssignAutoColors();
    
    auto legend = canvas->Draw<RLegend>(RPadPos(0.5_normal, 0.6_normal), RPadPos(0.9_normal,0.9_normal), "Legend title");
    legend->AttrBox().Fill().SetStyle(5).SetColor(RColor::kWhite);

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -25,6 +25,8 @@
 #include "ROOT/RHistDrawable.hxx"
 #include "ROOT/RCanvas.hxx"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
 
 #include "TRandom3.h"

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -25,7 +25,7 @@
 #include "ROOT/RHistDrawable.hxx"
 #include "ROOT/RCanvas.hxx"
 
-R__LOAD_LIBRARY(libROOTWebDisplay);
+R__LOAD_LIBRARY(libROOTHistDraw)
 
 #include "TRandom3.h"
 #include "TEnv.h"

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -23,8 +23,9 @@
 #include "ROOT/RCanvas.hxx"
 #include "TRandom.h"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
-
 
 using namespace ROOT::Experimental;
 

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -23,6 +23,9 @@
 #include "ROOT/RCanvas.hxx"
 #include "TRandom.h"
 
+R__LOAD_LIBRARY(libROOTHistDraw)
+
+
 using namespace ROOT::Experimental;
 
 void draw_rh1()

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -23,8 +23,9 @@
 #include "ROOT/RPad.hxx"
 #include "TRandom.h"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
-
 
 void draw_subpads()
 {

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -23,6 +23,9 @@
 #include "ROOT/RPad.hxx"
 #include "TRandom.h"
 
+R__LOAD_LIBRARY(libROOTHistDraw)
+
+
 void draw_subpads()
 {
   using namespace ROOT::Experimental;

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -467,6 +467,7 @@ sap.ui.define(['sap/ui/core/Component',
            for(let i=0; i<oTabContainerItems.length; i++) {
              if (oTabContainerItems[i].getAdditionalText() === msg) {
                oTabContainer.setSelectedItem(oTabContainerItems[i]);
+               break;
              }
            }
            break;

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -607,6 +607,11 @@ sap.ui.define(['sap/ui/core/Component',
          oTabContainerItem.setAdditionalText(name); // name can be used to set active canvas or close canvas
 
          oTabContainer.addItem(oTabContainerItem);
+
+         // Change the selected tabs, only if it is new one, not the basic one
+         if(name !== "rcanv1") {
+           oTabContainer.setSelectedItem(oTabContainerItem);
+         }
          
          var conn = new JSROOT.WebWindowHandle(this.websocket.kind);
          

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -461,6 +461,15 @@ sap.ui.define(['sap/ui/core/Component',
             var arr = JSON.parse(msg);
             this.createCanvas(arr[0], arr[1], arr[2]);
             break;
+         case "SLCTCANV": // Selected the back selected canvas
+           let oTabContainer = this.byId("myTabContainer");
+           let oTabContainerItems = oTabContainer.getItems();
+           for(let i=0; i<oTabContainerItems.length; i++) {
+             if (oTabContainerItems[i].getAdditionalText() === msg) {
+               oTabContainer.setSelectedItem(oTabContainerItems[i]);
+             }
+           }
+           break;
          case "FROOT": // Root file
            var selecedTabID = this.getSelectedtabFromtabContainer("myTabContainer"); // The ID of the selected tab in the TabContainer
 


### PR DESCRIPTION
Closed the previous pull request and creating a new one after rebasing. All changes are pertaining to plotting changes within RooFit.

@cburgard's comments from the previous MR 
The RooFit "plotOn" plotting engine is very useful to visualize RooFit objects.
However, there is currently a strict separation between "Data-like" objects (which can only really be drawn with points) and "Function-like" objects (which can only really be drawn as lines and areas).
However, in techniques like unfolding, "data" is often times corrected data, and hence might actually be a function-type object in RooFit.
With this PR, functionality is added to RooAbsReal::plotOn that allows to plot functions "data-like", with data points including error bars when using the draw option "P", which was previously unusable.