### PR TITLE
Provide preliminary autocolor functionality for RDrawable

### DIFF
--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrBase.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrBase.hxx
@@ -143,6 +143,7 @@ protected:
       return *this;
    }
 
+   void SetValue(const std::string &name, bool value);
    void SetValue(const std::string &name, double value);
    void SetValue(const std::string &name, int value);
    void SetValue(const std::string &name, const std::string &value);

--- a/graf2d/gpadv7/v7/inc/ROOT/RColor.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RColor.hxx
@@ -62,7 +62,10 @@ public:
    }
 
    /** Construct color with provided RGB_t value */
-   RColor(const RGB_t &rgb) : RColor() { SetRGB(rgb[0], rgb[1], rgb[2]); }
+   RColor(const RGB_t &rgb) : RColor() { SetRGB(rgb); }
+
+   /** Set r/g/b/ components of color as hex code, default for the color */
+   RColor &SetRGB(const RGB_t &rgb) { return SetRGB(rgb[0], rgb[1], rgb[2]); }
 
    /** Set r/g/b/ components of color as hex code, default for the color */
    RColor &SetRGB(int r, int g, int b) { return SetHex(toHex(r) + toHex(g) + toHex(b)); }

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadBase.hxx
@@ -166,10 +166,7 @@ public:
    }
 
    /// Wipe the pad by clearing the list of primitives.
-   void Wipe()
-   {
-      fPrimitives.clear();
-   }
+   void Wipe() { fPrimitives.clear(); }
 
    void CreateFrameIfNeeded();
 
@@ -207,6 +204,9 @@ public:
    {
       return fFrame->UserToNormal(pos);
    }
+
+   void AssignAutoColors();
+
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/v7/src/RAttrBase.cxx
+++ b/graf2d/gpadv7/v7/src/RAttrBase.cxx
@@ -98,6 +98,12 @@ void ROOT::Experimental::RAttrBase::ClearValue(const std::string &name)
        const_cast<RAttrMap*>(access.attr)->Clear(access.fullname);
 }
 
+void ROOT::Experimental::RAttrBase::SetValue(const std::string &name, bool value)
+{
+   if (auto access = EnsureAttr(name))
+      access.attr->AddBool(access.fullname, value);
+}
+
 void ROOT::Experimental::RAttrBase::SetValue(const std::string &name, int value)
 {
    if (auto access = EnsureAttr(name))

--- a/graf2d/gpadv7/v7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/v7/src/RPadBase.cxx
@@ -91,7 +91,7 @@ void ROOT::Experimental::RPadBase::AssignAutoColors()
       for (auto &attr: drawable->fAttr) {
          // only boolean attribute can return true
          if (!attr.second->GetBool()) continue;
-         auto pos = attr.first.find("_color_auto");
+         auto pos = attr.first.rfind("_color_auto");
          if ((pos > 0) && (pos == attr.first.length() - 11)) {
             // FIXME: dummy code to assign autocolors, later should use RPalette
             switch (cnt++ % 3) {

--- a/graf2d/gpadv7/v7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/v7/src/RPadBase.cxx
@@ -80,6 +80,32 @@ std::shared_ptr<ROOT::Experimental::RDrawable> ROOT::Experimental::RPadBase::Fin
 }
 
 ///////////////////////////////////////////////////////////////////////////
+/// Method collect existing colors and assign new values if required
+
+void ROOT::Experimental::RPadBase::AssignAutoColors()
+{
+   int cnt = 0;
+   RColor col;
+
+   for (auto &drawable : fPrimitives) {
+      for (auto &attr: drawable->fAttr) {
+         // only boolean attribute can return true
+         if (!attr.second->GetBool()) continue;
+         auto pos = attr.first.find("_color_auto");
+         if ((pos > 0) && (pos == attr.first.length() - 11)) {
+            // FIXME: dummy code to assign autocolors, later should use RPalette
+            switch (cnt++ % 3) {
+              case 0: col.SetRGB(RColor::kRed); break;
+              case 1: col.SetRGB(RColor::kGreen); break;
+              case 2: col.SetRGB(RColor::kBlue); break;
+            }
+            drawable->fAttr.AddString(attr.first.substr(0,pos) + "_color_rgb", col.GetHex());
+         }
+      }
+   }
+}
+
+///////////////////////////////////////////////////////////////////////////
 /// Create display items for all primitives in the pad
 /// Each display item gets its special id, which used later for client-server communication
 

--- a/graf2d/gpadv7/v7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/v7/src/RPadBase.cxx
@@ -95,9 +95,9 @@ void ROOT::Experimental::RPadBase::AssignAutoColors()
          if ((pos > 0) && (pos == attr.first.length() - 11)) {
             // FIXME: dummy code to assign autocolors, later should use RPalette
             switch (cnt++ % 3) {
-              case 0: col.SetRGB(RColor::kRed); break;
-              case 1: col.SetRGB(RColor::kGreen); break;
-              case 2: col.SetRGB(RColor::kBlue); break;
+              case 0: col = RColor::kRed; break;
+              case 1: col = RColor::kGreen; break;
+              case 2: col = RColor::kBlue; break;
             }
             drawable->fAttr.AddString(attr.first.substr(0,pos) + "_color_rgb", col.GetHex());
          }

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -1,15 +1,14 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// This macro generates a small V7 TH1D, fills it and draw it in a V7 canvas.
-/// The canvas is display in the web browser and the corresponding png picture
-/// is generated.
+/// This macro generates two TH1D objects and build RLegend
+/// In addition use of auto colors are shown
 ///
 /// \macro_code
 ///
-/// \date 2015-03-22
+/// \date 2019-10-09
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-/// \author Axel Naumann <axel@cern.ch>
+/// \author Sergey Linev <s.linev@gsi.de>
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
@@ -28,7 +27,7 @@ using namespace ROOT::Experimental;
 
 void draw_legend()
 {
-   // Create the histogram.
+   // Create the histograms.
    RAxisConfig xaxis(25, 0., 10.);
    auto pHist = std::make_shared<RH1D>(xaxis);
    auto pHist2 = std::make_shared<RH1D>(xaxis);
@@ -40,11 +39,16 @@ void draw_legend()
 
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
-   auto draw1 = canvas->Draw(pHist);
-   draw1->AttrLine().SetColor(RColor::kRed).SetWidth(2);
 
+   // draw histogram
+   auto draw1 = canvas->Draw(pHist);
+   draw1->AttrLine().SetWidth(2).Color().SetAuto();
+
+   // draw histogram
    auto draw2 = canvas->Draw(pHist2);
-   draw2->AttrLine().SetColor(RColor::kBlue).SetWidth(4);
+   draw2->AttrLine().SetWidth(4).Color().SetAuto();
+
+   canvas->AssignAutoColors();
    
    auto legend = canvas->Draw<RLegend>(RPadPos(0.5_normal, 0.6_normal), RPadPos(0.9_normal,0.9_normal), "Legend title");
    legend->AttrBox().Fill().SetStyle(5).SetColor(RColor::kWhite);


### PR DESCRIPTION
Introduce *Auto* property for RColor
Before drawing RCanvas, one could call `canvas->AssignAutoColors();` to performs color assignment
Later method can be invoked automatically
