### PR TITLE
[RF] Fix ROOT-10331.

### DIFF
--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -56,10 +56,6 @@ class TH3F;
 #include <iostream>
 #include <sstream>
 
-#ifndef NDEBUG
-#define ROOFIT_CHECK_CACHED_VALUES
-#endif
-
 class RooAbsReal : public RooAbsArg {
 public:
   // Constructors, assignment etc

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -42,6 +42,9 @@ class RooFitResult ;
 class RooAbsMoment ;
 class RooDerivative ;
 class RooVectorDataStore ;
+namespace RooHelpers {
+class BatchInterfaceAccessor;
+}
 
 class TH1;
 class TH1F;
@@ -84,18 +87,19 @@ public:
   /// the variables to normalise over.
   /// These are integrated over their current ranges to compute the normalisation constant,
   /// and the unnormalised result is divided by this value.
-#ifdef ROOFIT_CHECK_CACHED_VALUES
-  Double_t getVal(const RooArgSet* normalisationSet = nullptr) const;
-#else
   inline Double_t getVal(const RooArgSet* normalisationSet = nullptr) const {
+#ifdef ROOFIT_CHECK_CACHED_VALUES
+    return _DEBUG_getVal(normalisationSet);
+#else
+
 #ifndef _WIN32
     return (_fast && !_inhibitDirty) ? _value : getValV(normalisationSet) ;
 #else
     return (_fast && !inhibitDirty()) ? _value : getValV(normalisationSet) ;
 #endif
-  }
 
 #endif
+  }
 
   /// Like getVal(const RooArgSet*), but always requires an argument for normalisation.
   inline  Double_t getVal(const RooArgSet& normalisationSet) const { return _fast ? _value : getValV(&normalisationSet) ; }
@@ -397,17 +401,14 @@ protected:
 
   // Function evaluation and error tracing
   Double_t traceEval(const RooArgSet* set) const ;
-//  virtual Bool_t traceEvalHook(Double_t /*value*/) const {
-//    // Hook function to add functionality to evaluation tracing in derived classes
-//    return kFALSE ;
-//  }
+
   /// Evaluate this PDF / function / constant. Needs to be overridden by all derived classes.
   virtual Double_t evaluate() const = 0;
   virtual RooSpan<double> evaluateBatch(std::size_t begin, std::size_t maxSize) const;
 
   //---------- Interface to access batch data ---------------------------
   //
-  friend class BatchInterfaceAccessor;
+  friend class RooHelpers::BatchInterfaceAccessor;
   void clearBatchMemory() {
     _batchData.clear();
     for (auto arg : _serverList) {
@@ -418,13 +419,15 @@ protected:
     }
   }
 
-#ifdef ROOFIT_CHECK_CACHED_VALUES
- public:
+ private:
   void checkBatchComputation(std::size_t evtNo, const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) const;
+
   const BatchHelpers::BatchData& batchData() const {
     return _batchData;
   }
-#endif
+
+  /// Debug version of getVal(), which is slow and does error checking.
+  Double_t _DEBUG_getVal(const RooArgSet* normalisationSet) const;
 
   //--------------------------------------------------------------------
 

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -19,6 +19,7 @@
 
 #include "RooMsgService.h"
 #include "RooAbsArg.h"
+#include "RooAbsReal.h"
 
 #include <sstream>
 
@@ -148,6 +149,22 @@ class FormatPdfTree {
 void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_list<const RooAbsReal*> pars,
     double min = -std::numeric_limits<double>::max(), double max = std::numeric_limits<double>::max());
 
+
+/// Helper class to access a batch-related part of RooAbsReal's interface, which should not leak to the outside world.
+class BatchInterfaceAccessor {
+  public:
+    static void clearBatchMemory(RooAbsReal& theReal) {
+      theReal.clearBatchMemory();
+    }
+
+    static void checkBatchComputation(const RooAbsReal& theReal, std::size_t evtNo,
+        const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) {
+      theReal.checkBatchComputation(evtNo, normSet, relAccuracy);
+    }
+};
+
+
 }
+
 
 #endif /* ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_ */

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4861,7 +4861,7 @@ RooSpan<double> RooAbsReal::evaluateBatch(std::size_t begin, std::size_t maxSize
 
 
 
-#ifdef ROOFIT_CHECK_CACHED_VALUES
+
 #include "TSystem.h"
 #include "RooHelpers.h"
 
@@ -4869,7 +4869,7 @@ using RooHelpers::CachingError;
 using RooHelpers::FormatPdfTree;
 
 
-Double_t RooAbsReal::getVal(const RooArgSet* normalisationSet) const {
+Double_t RooAbsReal::_DEBUG_getVal(const RooArgSet* normalisationSet) const {
 
   const bool tmpFast = _fast;
   const double tmp = _value;
@@ -4965,4 +4965,4 @@ void RooAbsReal::checkBatchComputation(std::size_t evtNo, const RooArgSet* normS
     }
   }
 }
-#endif
+

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -43,6 +43,7 @@ In extended mode, a
 #include "RooRealSumPdf.h"
 #include "RooRealVar.h"
 #include "RooProdPdf.h"
+#include "RooHelpers.h"
 
 #include "Math/Util.h"
 
@@ -239,13 +240,6 @@ void RooNLLVar::applyWeightSquared(Bool_t flag)
       ((RooNLLVar*)_gofArray[i])->applyWeightSquared(flag);
   }
 }
-
-class BatchInterfaceAccessor {
-  public:
-    static void clearBatchMemory(RooAbsReal* theReal) {
-      theReal->clearBatchMemory();
-    }
-};
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -463,7 +457,7 @@ std::tuple<double, double, double> RooNLLVar::computeBatched(std::size_t stepSiz
     assert(_dataClone->valid());
     pdfClone->getValV(_normSet);
     try {
-      pdfClone->checkBatchComputation(evtNo, _normSet);
+      RooHelpers::BatchInterfaceAccessor::checkBatchComputation(*pdfClone, evtNo, _normSet);
     } catch (std::exception& e) {
       std::cerr << "ERROR when checking batch computation for event " << evtNo << ":\n"
           << e.what() << std::endl;


### PR DESCRIPTION
When compiled in debug mode, RooFit was outlining a normally inlined
function, which created a linker error in a specific setup.