### PR TITLE
[cxxmodules] Don't rely on the LD_LIBRARY_PATH for prebuilt modules.

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1058,8 +1058,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     // modules because we would miss the annotations that rootcling creates.
     if (COpts.CxxModules) {
       auto& HS = CI->getHeaderSearchOpts();
-      addPrebuiltModulePaths(HS, getPathsFromEnv(getenv("LD_LIBRARY_PATH")));
-      addPrebuiltModulePaths(HS, getPathsFromEnv(getenv("DYLD_LIBRARY_PATH")));
+      addPrebuiltModulePaths(HS, getPathsFromEnv(getenv("CLING_PREBUILT_MODULE_PATH")));
     }
 
     // Set up compiler language and target


### PR DESCRIPTION
The system integrity protection (SIP) on osx blocks 'dangerous' env variables when spawning a new process. The MetaProcessor command `.!` which calls the shell does not propagate (DY)LD_LIBRARY_PATH variables which prevents cling from finding the modules.

This patch introduces a new env variable CLING_PREBUILT_MODULE_PATH which contains the prebuilt modules' location where cling should look for modules.

Patch by Alexander Penev (@alexander-penev)!
