### PR TITLE
[hist_drawable] load ROOTHistDraw library in test macros ROOT-10336

### DIFF
--- a/tutorials/v7/draw.cxx
+++ b/tutorials/v7/draw.cxx
@@ -20,6 +20,8 @@
 #include "ROOT/RColor.hxx"
 #include "ROOT/RHistDrawable.hxx"
 
+R__LOAD_LIBRARY(libROOTHistDraw)
+
 void draw()
 {
    using namespace ROOT::Experimental;

--- a/tutorials/v7/draw.cxx
+++ b/tutorials/v7/draw.cxx
@@ -20,6 +20,8 @@
 #include "ROOT/RColor.hxx"
 #include "ROOT/RHistDrawable.hxx"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
 
 void draw()

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -23,6 +23,8 @@
 #include "ROOT/RLegend.hxx"
 #include "TRandom.h"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
 
 using namespace ROOT::Experimental;

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -23,6 +23,8 @@
 #include "ROOT/RLegend.hxx"
 #include "TRandom.h"
 
+R__LOAD_LIBRARY(libROOTHistDraw)
+
 using namespace ROOT::Experimental;
 
 void draw_legend()

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -25,6 +25,8 @@
 #include "ROOT/RHistDrawable.hxx"
 #include "ROOT/RCanvas.hxx"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
 
 #include "TRandom3.h"

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -25,7 +25,7 @@
 #include "ROOT/RHistDrawable.hxx"
 #include "ROOT/RCanvas.hxx"
 
-R__LOAD_LIBRARY(libROOTWebDisplay);
+R__LOAD_LIBRARY(libROOTHistDraw)
 
 #include "TRandom3.h"
 #include "TEnv.h"

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -23,8 +23,9 @@
 #include "ROOT/RCanvas.hxx"
 #include "TRandom.h"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
-
 
 using namespace ROOT::Experimental;
 

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -23,6 +23,9 @@
 #include "ROOT/RCanvas.hxx"
 #include "TRandom.h"
 
+R__LOAD_LIBRARY(libROOTHistDraw)
+
+
 using namespace ROOT::Experimental;
 
 void draw_rh1()

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -23,8 +23,9 @@
 #include "ROOT/RPad.hxx"
 #include "TRandom.h"
 
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
-
 
 void draw_subpads()
 {

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -23,6 +23,9 @@
 #include "ROOT/RPad.hxx"
 #include "TRandom.h"
 
+R__LOAD_LIBRARY(libROOTHistDraw)
+
+
 void draw_subpads()
 {
   using namespace ROOT::Experimental;


### PR DESCRIPTION
As it is now, cling is not capable to load library for outlined
functions. As long as modules not enabled by default - add
R__LOAD_LIBRARY macro to all test scripts