### PR TITLE
[cxxmodules] Rely on ROOT to tell us the primary module location.

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -305,10 +305,8 @@ endif()
 
 # Current limitations for modules:
 #---Modules do not play well with c++17 yet
-#---Modules do not play well with preinstalled ROOT in the system (PREINSTALLED_MODULEMAP)
 #---Modules are disabled on aarch64 platform (due ODR violations)
-find_file(PREINSTALLED_MODULEMAP module.modulemap)
-if(CMAKE_CXX_STANDARD GREATER 14 OR CMAKE_SYSTEM_PROCESSOR MATCHES aarch64 OR PREINSTALLED_MODULEMAP)
+if(CMAKE_CXX_STANDARD GREATER 14 OR CMAKE_SYSTEM_PROCESSOR MATCHES aarch64)
   set(runtime_cxxmodules_defvalue OFF)
 endif()
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1282,6 +1282,10 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       };
 
       std::vector<std::string> Paths;
+      // ROOT usually knows better where its libraries are. This way we can
+      // discover modules without having to should thisroot.sh and should fix
+      // gnuinstall.
+      Paths.push_back(TROOT::GetLibDir().Data());
       GetEnvVarPath("CLING_PREBUILT_MODULE_PATH", Paths);
       GetEnvVarPath("LD_LIBRARY_PATH", Paths);
       std::string EnvVarPath;


### PR DESCRIPTION
This enables ROOT to run without requiring to source thisroot.sh and also run from installed public locations (via gnuinstall).

Patch by Oksana Shadura and me!