### PR TITLE
Disable modules on aarch64 due to ODR violation

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -303,14 +303,12 @@ elseif(APPLE)
   set(x11_defvalue OFF)
 endif()
 
-#---Modules do not play well with c++17 yet----------------------------------------------------
-if(CMAKE_CXX_STANDARD GREATER 14)
-  set(runtime_cxxmodules_defvalue OFF)
-endif()
-
-#---Modules do not play well with preinstalled ROOT in the system------------------------------
+# Current limitations for modules:
+#---Modules do not play well with c++17 yet
+#---Modules do not play well with preinstalled ROOT in the system (PREINSTALLED_MODULEMAP)
+#---Modules are disabled on aarch64 platform (due ODR violations)
 find_file(PREINSTALLED_MODULEMAP module.modulemap)
-if(PREINSTALLED_MODULEMAP)
+if(CMAKE_CXX_STANDARD GREATER 14 OR CMAKE_SYSTEM_PROCESSOR MATCHES aarch64 OR PREINSTALLED_MODULEMAP)
   set(runtime_cxxmodules_defvalue OFF)
 endif()
 


### PR DESCRIPTION
error: std::map<std::basic_string<char>, double, std::less<std::basic_string<char> >, std::allocator<std::pair<const std::basic_string<char>, double> > >' has different definitions in different modules; first difference is defined here found end of class\n/usr/lib/gcc/aarch64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/bits/stl_map.h:941:9: note: but in 'std.bits/stl_map.h' found friend declaration\n        operator==(const map<_K1, _T1, _C1, _A1>&,\n        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\nroot.exe: ../../../../../../../../root/interpreter/cling/lib/Interpreter/Transaction.cpp:138: void cling::Transaction::append(cling::Transaction::DelayCallInfo): Assertion getState() == kCollecting && Cannot append declarations in current state.