### PR TITLE
[rdrawable] rename setter/getter methods for attributes

### DIFF
--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrBox.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrBox.hxx
@@ -26,16 +26,18 @@ namespace Experimental {
 
 class RAttrBox : public RAttrBase {
 
-   RAttrLine fBorder{this, "border_"};       ///<!
-   RAttrFill fFill{this, "fill_"};           ///<!
+   RAttrLine fAttrBorder{this, "border_"};   ///<!
+   RAttrFill fAttrFill{this, "fill_"};           ///<!
 
-   R__ATTR_CLASS(RAttrBox, "box_", AddDefaults(fBorder).AddDefaults(fFill));
+   R__ATTR_CLASS(RAttrBox, "box_", AddDefaults(fAttrBorder).AddDefaults(fAttrFill));
 
-   const RAttrLine &Border() const { return fBorder; }
-   RAttrLine &Border() { return fBorder; }
+   const RAttrLine &GetAttrBorder() const { return fAttrBorder; }
+   RAttrBox &SetAttrBorder(const RAttrLine &border) { fAttrBorder = border; return *this; }
+   RAttrLine &AttrBorder() { return fAttrBorder; }
 
-   const RAttrFill &Fill() const { return fFill; }
-   RAttrFill &Fill() { return fFill; }
+   const RAttrFill &GetAttrFill() const { return fAttrFill; }
+   RAttrBox &SetAttrFill(const RAttrFill &fill) { fAttrFill = fill; return *this; }
+   RAttrFill &AttrFill() { return fAttrFill; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrFill.hxx
@@ -35,7 +35,7 @@ class RAttrFill : public RAttrBase {
 
    ///The fill color
    RAttrFill &SetColor(const RColor &color) { fColor = color; return *this; }
-   const RColor &Color() const { return fColor; }
+   const RColor &GetColor() const { return fColor; }
    RColor &Color() { return fColor; }
 
 };

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrLine.hxx
@@ -44,7 +44,7 @@ class RAttrLine : public RAttrBase {
 
    ///The color of the line.
    RAttrLine &SetColor(const RColor &color) { fColor = color; return *this; }
-   const RColor &Color() const { return fColor; }
+   const RColor &GetColor() const { return fColor; }
    RColor &Color() { return fColor; }
 
 };

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrMarker.hxx
@@ -30,7 +30,7 @@ class RAttrMarker : public RAttrBase {
    R__ATTR_CLASS(RAttrMarker, "marker_", AddDouble("size", 1.).AddInt("style", 1).AddDefaults(fColor));
 
    RAttrMarker &SetColor(const RColor &color) { fColor = color; return *this; }
-   const RColor &Color() const { return fColor; }
+   const RColor &GetColor() const { return fColor; }
    RColor &Color() { return fColor; }
 
    /// The size of the marker.

--- a/graf2d/gpadv7/v7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RAttrText.hxx
@@ -50,7 +50,7 @@ class RAttrText : public RAttrBase {
 
    ///The color of the text.
    RAttrText &SetColor(const RColor &color) { fColor = color; return *this; }
-   const RColor &Color() const { return fColor; }
+   const RColor &GetColor() const { return fColor; }
    RColor &Color() { return fColor; }
 
 };

--- a/graf2d/gpadv7/v7/inc/ROOT/RColor.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RColor.hxx
@@ -189,8 +189,9 @@ public:
 
    friend bool operator==(const RColor &lhs, const RColor &rhs)
    {
+      // auto flag is not taken into account when comparing colors
       return (lhs.GetHex() == rhs.GetHex()) && (lhs.GetName() == rhs.GetName()) &&
-             (lhs.GetAlphaHex() == rhs.GetAlphaHex()) && (lhs.IsAuto() == rhs.IsAuto());
+             (lhs.GetAlphaHex() == rhs.GetAlphaHex()); //  && (lhs.IsAuto() == rhs.IsAuto());
    }
 };
 

--- a/graf2d/gpadv7/v7/inc/ROOT/RPad.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPad.hxx
@@ -14,7 +14,6 @@
 namespace ROOT {
 namespace Experimental {
 
-
 /** \class RPad
 \ingroup GpadROOT7
 \brief Graphic container for `RDrawable`-s.

--- a/graf2d/gpadv7/v7/inc/ROOT/RPad.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPad.hxx
@@ -31,7 +31,7 @@ class RPad: public RPadBase {
    RPadPos fPos;                           ///< pad position
    RPadExtent fSize;                       ///< pad size
 
-   RAttrLine fLineAttr{this, "border_"};   ///<! border attributes
+   RAttrLine fAttrLine{this, "border_"};   ///<! border attributes
 
 protected:
 
@@ -72,8 +72,9 @@ public:
    /// Set position
    void SetPos(const RPadPos &p) { fPos = p; }
 
-   RAttrLine &AttrLine() { return fLineAttr; }
-   const RAttrLine &AttrLine() const { return fLineAttr; }
+   const RAttrLine &GetAttrLine() const { return fAttrLine; }
+   RPad &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
+   RAttrLine &AttrLine() { return fAttrLine; }
 
    /// Convert a `Pixel` position to Canvas-normalized positions.
    std::array<RPadLength::Normal, 2> PixelsToNormal(const std::array<RPadLength::Pixel, 2> &pos) const override

--- a/graf2d/gpadv7/v7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/v7/inc/ROOT/RPadBase.hxx
@@ -9,15 +9,15 @@
 #ifndef ROOT7_RPadBase
 #define ROOT7_RPadBase
 
-#include <memory>
-#include <vector>
-
 #include "ROOT/RDrawable.hxx"
 #include "ROOT/RFrame.hxx"
 #include "ROOT/RPadExtent.hxx"
 #include "ROOT/RPadPos.hxx"
 #include "ROOT/RPadUserAxis.hxx"
 #include "ROOT/TypeTraits.hxx"
+
+#include <memory>
+#include <vector>
 
 namespace ROOT {
 namespace Experimental {

--- a/graf2d/gpadv7/v7/test/attribute.cxx
+++ b/graf2d/gpadv7/v7/test/attribute.cxx
@@ -12,11 +12,13 @@ class CustomAttrs : public RAttrBase {
 
    R__ATTR_CLASS(CustomAttrs, "custom_", AddDefaults(fAttrBox).AddDefaults(fAttrText));
 
+   const RAttrBox &GetAttrBox() const { return fAttrBox; }
+   CustomAttrs &SetAttrBox(const RAttrBox &box) { fAttrBox = box; return *this; }
    RAttrBox &AttrBox() { return fAttrBox; }
-   const RAttrBox &AttrBox() const { return fAttrBox; }
 
+   const RAttrText &GetAttrText() const { return fAttrText; }
+   CustomAttrs &SetAttrText(const RAttrText &txt) { fAttrText = txt; return *this; }
    RAttrText &AttrText() { return fAttrText; }
-   const RAttrText &AttrText() const { return fAttrText; }
 
    double GetDirect(const std::string &name) const { return GetValue<double>(name); }
 };
@@ -25,7 +27,7 @@ class CustomAttrs : public RAttrBase {
 TEST(OptsTest, AttribStrings) {
    CustomAttrs attrs;
 
-   attrs.AttrBox().Border().SetWidth(42.);
+   attrs.AttrBox().AttrBorder().SetWidth(42.);
    attrs.AttrText().SetSize(1.7);
 
    {
@@ -43,18 +45,18 @@ TEST(OptsTest, AttribVals) {
    CustomAttrs attrs;
 
    attrs.AttrText().SetColor(RColor::kBlue);
-   auto &border = attrs.AttrBox().Border();
+   auto &border = attrs.AttrBox().AttrBorder();
    border.SetWidth(42.);
 
    {
       // Value was set on this attr, not coming from style:
-      EXPECT_FLOAT_EQ(attrs.AttrBox().Border().GetWidth(), 42.f);
+      EXPECT_FLOAT_EQ(attrs.GetAttrBox().GetAttrBorder().GetWidth(), 42.f);
       EXPECT_FLOAT_EQ(border.GetWidth(), 42.f);
    }
 
    {
       // Value was set on this attr, not coming from style:
-      EXPECT_EQ(attrs.AttrText().Color(), RColor::kBlue);
+      EXPECT_EQ(attrs.GetAttrText().GetColor(), RColor::kBlue);
    }
 
 }
@@ -69,8 +71,8 @@ TEST(OptsTest, NullAttribCompare) {
 TEST(OptsTest, AttribEqual) {
    CustomAttrs attrs;
 
-   auto &al1 = attrs.AttrBox().Border();
-   auto &al2 = attrs.AttrBox().Border();
+   auto &al1 = attrs.AttrBox().AttrBorder();
+   auto &al2 = attrs.AttrBox().AttrBorder();
    EXPECT_EQ(al1, al2);
    EXPECT_EQ(al2, al1);
 
@@ -85,9 +87,9 @@ TEST(OptsTest, AttribDiffer) {
    CustomAttrs attrs2;
    CustomAttrs attrs3;
 
-   auto &al1 = attrs1.AttrBox().Border();
-   auto &al2 = attrs2.AttrBox().Border();
-   auto &al3 = attrs3.AttrBox().Border();
+   auto &al1 = attrs1.AttrBox().AttrBorder();
+   auto &al2 = attrs2.AttrBox().AttrBorder();
+   auto &al3 = attrs3.AttrBox().AttrBorder();
 
    al1.SetWidth(7.);
    EXPECT_NE(al1, al2);
@@ -110,13 +112,13 @@ TEST(OptsTest, AttribAssign) {
    CustomAttrs attrs2;
 
    // deep copy - independent from origin
-   auto attrBox1 = attrs1.AttrBox();
-   auto attrBox2 = attrs2.AttrBox();
+   auto attrBox1 = attrs1.GetAttrBox();
+   auto attrBox2 = attrs2.GetAttrBox();
 
    EXPECT_EQ(attrBox2, attrBox1);
    EXPECT_EQ(attrBox1, attrBox2);
 
-   attrBox1.Border().SetWidth(42.);
+   attrBox1.AttrBorder().SetWidth(42.);
    EXPECT_NE(attrBox2, attrBox1);
 
    attrBox2 = attrBox1;
@@ -124,20 +126,20 @@ TEST(OptsTest, AttribAssign) {
    EXPECT_EQ(attrBox1, attrBox2);
 
    // But original attributes now differ
-   EXPECT_NE(attrs1.AttrBox(), attrBox1);
-   EXPECT_NE(attrs2.AttrBox(), attrBox2);
+   EXPECT_NE(attrs1.GetAttrBox(), attrBox1);
+   EXPECT_NE(attrs2.GetAttrBox(), attrBox2);
 
-   EXPECT_FLOAT_EQ(attrBox1.Border().GetWidth(), 42.);
-   EXPECT_FLOAT_EQ(attrBox2.Border().GetWidth(), 42.);
+   EXPECT_FLOAT_EQ(attrBox1.GetAttrBorder().GetWidth(), 42.);
+   EXPECT_FLOAT_EQ(attrBox2.GetAttrBorder().GetWidth(), 42.);
    // default width return 1
-   EXPECT_FLOAT_EQ(attrs1.AttrBox().Border().GetWidth(), 1.);
-   EXPECT_FLOAT_EQ(attrs2.AttrBox().Border().GetWidth(), 1.);
+   EXPECT_FLOAT_EQ(attrs1.GetAttrBox().GetAttrBorder().GetWidth(), 1.);
+   EXPECT_FLOAT_EQ(attrs2.GetAttrBox().GetAttrBorder().GetWidth(), 1.);
 
    // Are the two attributes disconnected?
-   attrBox2.Border().SetWidth(3.);
-   EXPECT_EQ(attrs1.AttrBox().Border(), attrs2.AttrBox().Border());
-   EXPECT_FLOAT_EQ(attrBox1.Border().GetWidth(), 42.);
-   EXPECT_FLOAT_EQ(attrBox2.Border().GetWidth(), 3.);
-   EXPECT_FLOAT_EQ(attrs1.AttrBox().Border().GetWidth(), 1.);
-   EXPECT_FLOAT_EQ(attrs2.AttrBox().Border().GetWidth(), 1.);
+   attrBox2.AttrBorder().SetWidth(3.);
+   EXPECT_EQ(attrs1.GetAttrBox().GetAttrBorder(), attrs2.GetAttrBox().GetAttrBorder());
+   EXPECT_FLOAT_EQ(attrBox1.GetAttrBorder().GetWidth(), 42.);
+   EXPECT_FLOAT_EQ(attrBox2.GetAttrBorder().GetWidth(), 3.);
+   EXPECT_FLOAT_EQ(attrs1.GetAttrBox().GetAttrBorder().GetWidth(), 1.);
+   EXPECT_FLOAT_EQ(attrs2.GetAttrBox().GetAttrBorder().GetWidth(), 1.);
 }

--- a/graf2d/gpadv7/v7/test/rcolor.cxx
+++ b/graf2d/gpadv7/v7/test/rcolor.cxx
@@ -16,7 +16,7 @@
 using namespace ROOT::Experimental;
 
 // Test usage of empty color
-TEST(RColorTest, Empty) {
+TEST(RColor, Empty) {
    RColor col;
    EXPECT_EQ(col.GetHex(), "");
    EXPECT_DOUBLE_EQ(col.GetAlpha(), 1.);
@@ -24,7 +24,7 @@ TEST(RColorTest, Empty) {
 }
 
 // Test usage of empty color
-TEST(RColorTest, AsHex) {
+TEST(RColor, AsHex) {
    RColor col;
    col.SetRGB(0,0,0);
    EXPECT_EQ(col.GetHex(), "000000");
@@ -37,7 +37,7 @@ TEST(RColorTest, AsHex) {
 }
 
 // Test usage of empty color
-TEST(RColorTest, Components) {
+TEST(RColor, Components) {
    RColor col;
    col.SetHex("012345");
    EXPECT_EQ(col.GetRed(), 0x01);
@@ -45,7 +45,7 @@ TEST(RColorTest, Components) {
    EXPECT_EQ(col.GetBlue(), 0x45);
 }
 
-TEST(RColorTest, Alpha) {
+TEST(RColor, Alpha) {
 
    static constexpr double delta = 0.01; // approx precision of alpha storage
 
@@ -67,7 +67,7 @@ TEST(RColorTest, Alpha) {
 }
 
 
-TEST(RColorTest, Predef) {
+TEST(RColor, Predef) {
    {
       RColor col{RColor::kRed};
       EXPECT_EQ(col.GetHex(), "FF0000");

--- a/graf2d/gpadv7/v7/test/rstyle.cxx
+++ b/graf2d/gpadv7/v7/test/rstyle.cxx
@@ -22,14 +22,17 @@ class CustomDrawable : public RDrawable {
 public:
    CustomDrawable() : RDrawable("custom") {}
 
+   const RAttrLine &GetAttrLine() const { return fAttrLine; }
+   CustomDrawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
    RAttrLine &AttrLine() { return fAttrLine; }
-   const RAttrLine &AttrLine() const { return fAttrLine; }
 
+   const RAttrBox &GetAttrBox() const { return fAttrBox; }
+   CustomDrawable &SetAttrBox(RAttrBox &box) { fAttrBox = box; return *this; }
    RAttrBox &AttrBox() { return fAttrBox; }
-   const RAttrBox &AttrBox() const { return fAttrBox; }
 
+   const RAttrText &GetAttrText() const { return fAttrText; }
+   CustomDrawable &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
    RAttrText &AttrText() { return fAttrText; }
-   const RAttrText &AttrText() const { return fAttrText; }
 };
 
 
@@ -49,11 +52,11 @@ TEST(RStyleTest, CreateStyle)
 
    drawable.UseStyle(style);
 
-   EXPECT_DOUBLE_EQ(drawable.AttrLine().GetWidth(), 2.);
+   EXPECT_DOUBLE_EQ(drawable.GetAttrLine().GetWidth(), 2.);
 
    EXPECT_EQ(drawable.AttrBox().GetAttrFill().GetStyle(), 5);
 
-   EXPECT_DOUBLE_EQ(drawable.AttrText().GetSize(), 3.);
+   EXPECT_DOUBLE_EQ(drawable.GetAttrText().GetSize(), 3.);
 }
 
 TEST(RStyleTest, LostStyle)
@@ -68,10 +71,10 @@ TEST(RStyleTest, LostStyle)
       // here weak_ptr will be set, therefore after style is deleted drawable will loose it
       drawable.UseStyle(style);
 
-      EXPECT_DOUBLE_EQ(drawable.AttrLine().GetWidth(), 2.);
+      EXPECT_DOUBLE_EQ(drawable.GetAttrLine().GetWidth(), 2.);
    }
 
    // here style no longer exists
-   EXPECT_DOUBLE_EQ(drawable.AttrLine().GetWidth(), 1.);
+   EXPECT_DOUBLE_EQ(drawable.GetAttrLine().GetWidth(), 1.);
 }
 

--- a/graf2d/gpadv7/v7/test/rstyle.cxx
+++ b/graf2d/gpadv7/v7/test/rstyle.cxx
@@ -51,7 +51,7 @@ TEST(RStyleTest, CreateStyle)
 
    EXPECT_DOUBLE_EQ(drawable.AttrLine().GetWidth(), 2.);
 
-   EXPECT_EQ(drawable.AttrBox().Fill().GetStyle(), 5);
+   EXPECT_EQ(drawable.AttrBox().GetAttrFill().GetStyle(), 5);
 
    EXPECT_DOUBLE_EQ(drawable.AttrText().GetSize(), 3.);
 }

--- a/graf2d/primitives/v7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RBox.hxx
@@ -31,7 +31,7 @@ class RBox : public RDrawable {
 
    /// Box's coordinates
    RPadPos fP1, fP2;                    ///< box corners coordinates
-   RAttrBox fBoxAttr{this, "box_"};     ///<! box attributes
+   RAttrBox fAttrBox{this, "box_"};     ///<! box attributes
 
 protected:
 
@@ -53,8 +53,9 @@ public:
    const RPadPos& GetP1() const { return fP1; }
    const RPadPos& GetP2() const { return fP2; }
 
-   RAttrBox &AttrBox() { return fBoxAttr; }
-   const RAttrBox &AttrBox() const { return fBoxAttr; }
+   const RAttrBox &GetAttrBox() const { return fAttrBox; }
+   RBox &SetAttrBox(RAttrBox &box) { fAttrBox = box; return *this; }
+   RAttrBox &AttrBox() { return fAttrBox; }
 };
 
 } // namespace Experimental

--- a/graf2d/primitives/v7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RLegend.hxx
@@ -82,7 +82,7 @@ class RLegend : public RBox {
 
    std::vector<Internal::RLegendEntry> fEntries; ///< list of entries which should be displayed
 
-   RAttrText  fTitleAttr{this, "title_"};    ///<! title attributes
+   RAttrText  fAttrTitle{this, "title_"};    ///<! title attributes
 
 protected:
 
@@ -106,11 +106,12 @@ public:
       SetTitle(title);
    }
 
-   void SetTitle(const std::string &title) { fTitle = title; }
+   RLegend &SetTitle(const std::string &title) { fTitle = title; return *this; }
    const std::string &GetTitle() const { return fTitle; }
 
-   RAttrText &AttrTitle() { return fTitleAttr; }
-   const RAttrText &AttrTitle() const { return fTitleAttr; }
+   const RAttrText &GetAttrTitle() const { return fAttrTitle; }
+   RLegend &SetAttrTitle(const RAttrText &attr) { fAttrTitle = attr; return *this; }
+   RAttrText &AttrTitle() { return fAttrTitle; }
 
 
    Internal::RLegendEntry &AddEntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl = "")

--- a/graf2d/primitives/v7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RLegend.hxx
@@ -113,12 +113,13 @@ public:
    RLegend &SetAttrTitle(const RAttrText &attr) { fAttrTitle = attr; return *this; }
    RAttrText &AttrTitle() { return fAttrTitle; }
 
-
    Internal::RLegendEntry &AddEntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl = "")
    {
       fEntries.emplace_back(drawable, lbl);
       return fEntries.back();
    }
+
+   auto NumEntries() const { return fEntries.size(); }
 
 
 };

--- a/graf2d/primitives/v7/inc/ROOT/RLine.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RLine.hxx
@@ -30,7 +30,7 @@ class RLine : public RDrawable {
 
    RPadPos fP1;                            ///< line begin
    RPadPos fP2;                            ///< line end
-   RAttrLine  fLineAttr{this, "line_"};    ///<! line attributes
+   RAttrLine  fAttrLine{this, "line_"};    ///<! line attributes
 
 public:
 
@@ -44,8 +44,9 @@ public:
    const RPadPos& GetP1() const { return fP1; }
    const RPadPos& GetP2() const { return fP2; }
 
-   RAttrLine &AttrLine() { return fLineAttr; }
-   const RAttrLine &AttrLine() const { return fLineAttr; }
+   const RAttrLine &GetAttrLine() const { return fAttrLine; }
+   RLine &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
+   RAttrLine &AttrLine() { return fAttrLine; }
 };
 
 } // namespace Experimental

--- a/graf2d/primitives/v7/inc/ROOT/RMarker.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RMarker.hxx
@@ -29,7 +29,7 @@ namespace Experimental {
 
 class RMarker : public RDrawable {
 
-   RPadPos fP;                                 ///< position
+   RPadPos fP;                                ///< position
    RAttrMarker fMarkerAttr{this, "marker_"};  ///<! marker attributes
 
 public:
@@ -41,8 +41,9 @@ public:
    RMarker &SetP(const RPadPos& p) { fP = p; return *this; }
    const RPadPos& GetP() const { return fP; }
 
+   const RAttrMarker &GetAttrMarker() const { return fMarkerAttr; }
+   RMarker &SetAttrMarker(const RAttrMarker &attr) { fMarkerAttr = attr; return *this; }
    RAttrMarker &AttrMarker() { return fMarkerAttr; }
-   const RAttrMarker &AttrMarker() const { return fMarkerAttr; }
 
 };
 

--- a/graf2d/primitives/v7/inc/ROOT/RText.hxx
+++ b/graf2d/primitives/v7/inc/ROOT/RText.hxx
@@ -31,7 +31,7 @@ class RText : public RDrawable {
 
    std::string fText;                      ///< text to display
    RPadPos fPos;                           ///< position
-   RAttrText  fTextAttr{this, "text_"};    ///<! text attributes
+   RAttrText  fAttrText{this, "text_"};    ///<! text attributes
 
 public:
 
@@ -47,8 +47,9 @@ public:
    RText &SetPos(const RPadPos& p) { fPos = p; return *this; }
    const RPadPos &GetPos() const { return fPos; }
 
-   RAttrText &AttrText() { return fTextAttr; }
-   const RAttrText &AttrText() const { return fTextAttr; }
+   const RAttrText &GetAttrText() const { return fAttrText; }
+   RText &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
+   RAttrText &AttrText() { return fAttrText; }
 };
 
 

--- a/graf2d/primitives/v7/test/primitives.cxx
+++ b/graf2d/primitives/v7/test/primitives.cxx
@@ -4,6 +4,7 @@
 #include "ROOT/RLine.hxx"
 #include "ROOT/RMarker.hxx"
 #include "ROOT/RText.hxx"
+#include "ROOT/RLegend.hxx"
 #include "ROOT/RCanvas.hxx"
 
 using namespace ROOT::Experimental;
@@ -75,5 +76,53 @@ TEST(Primitives, RText)
    EXPECT_DOUBLE_EQ(text->GetAttrText().GetAngle(), 90.);
    EXPECT_EQ(text->GetAttrText().GetAlign(), 13);
    EXPECT_EQ(text->GetAttrText().GetFont(), 42);
+}
+
+
+// Test same color functionality
+TEST(Primitives, SameColor)
+{
+   RCanvas canv;
+   auto line1 = canv.Draw<RLine>(RPadPos(0.1_normal, 0.1_normal), RPadPos(0.9_normal,0.9_normal));
+   auto line2 = canv.Draw<RLine>(RPadPos(0.1_normal, 0.9_normal), RPadPos(0.9_normal,0.1_normal));
+   auto line3 = canv.Draw<RLine>(RPadPos(0.9_normal, 0.1_normal), RPadPos(0.1_normal,0.9_normal));
+
+   line1->AttrLine().Color().SetAuto();
+   line2->AttrLine().Color().SetAuto();
+   line3->AttrLine().Color().SetAuto();
+
+   canv.AssignAutoColors();
+
+   EXPECT_EQ(canv.NumPrimitives(), 3u);
+
+   EXPECT_EQ(line1->GetAttrLine().GetColor(), RColor::kRed);
+   EXPECT_EQ(line2->GetAttrLine().GetColor(), RColor::kGreen);
+   EXPECT_EQ(line3->GetAttrLine().GetColor(), RColor::kBlue);
+}
+
+// Test RLegend API
+TEST(Primitives, RLegend)
+{
+   RCanvas canv;
+   auto line1 = canv.Draw<RLine>(RPadPos(0.1_normal, 0.1_normal), RPadPos(0.9_normal,0.9_normal));
+   auto line2 = canv.Draw<RLine>(RPadPos(0.1_normal, 0.9_normal), RPadPos(0.9_normal,0.1_normal));
+   auto line3 = canv.Draw<RLine>(RPadPos(0.9_normal, 0.1_normal), RPadPos(0.1_normal,0.9_normal));
+
+   line1->AttrLine().SetColor(RColor::kRed);
+   line2->AttrLine().SetColor(RColor::kGreen);
+   line3->AttrLine().SetColor(RColor::kBlue);
+
+   auto legend = canv.Draw<RLegend>(RPadPos(0.5_normal, 0.6_normal), RPadPos(0.9_normal,0.9_normal), "Legend title");
+   legend->AttrBox().AttrFill().SetStyle(5).SetColor(RColor::kWhite);
+   legend->AttrBox().AttrBorder().SetWidth(2).SetColor(RColor::kRed);
+   legend->AddEntry(line1, "RLine 1").SetLine("line_");
+   legend->AddEntry(line2, "RLine 2").SetLine("line_");
+   legend->AddEntry(line3, "RLine 3").SetLine("line_");
+
+   EXPECT_EQ(canv.NumPrimitives(), 4u);
+
+   EXPECT_EQ(legend->NumEntries(), 3u);
+   EXPECT_EQ(legend->GetTitle(), "Legend title");
+   EXPECT_EQ(legend->GetAttrBox().GetAttrFill().GetColor(), RColor::kWhite);
 }
 

--- a/graf2d/primitives/v7/test/primitives.cxx
+++ b/graf2d/primitives/v7/test/primitives.cxx
@@ -14,18 +14,18 @@ TEST(Primitives, RBox)
    RCanvas canv;
    auto box = canv.Draw<RBox>(RPadPos(0.1_normal, 0.3_normal), RPadPos(0.3_normal,0.6_normal));
 
-   box->AttrBox().Border().SetColor(RColor::kRed).SetWidth(5.).SetStyle(7);
-   box->AttrBox().Fill().SetColor(RColor::kBlue).SetStyle(6);
+   box->AttrBox().AttrBorder().SetColor(RColor::kRed).SetWidth(5.).SetStyle(7);
+   box->AttrBox().AttrFill().SetColor(RColor::kBlue).SetStyle(6);
 
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
-   EXPECT_EQ(box->AttrBox().Border().Color(), RColor::kRed);
-   EXPECT_DOUBLE_EQ(box->AttrBox().Border().GetWidth(), 5.);
-   EXPECT_EQ(box->AttrBox().Border().GetStyle(), 7);
+   EXPECT_EQ(box->AttrBox().GetAttrBorder().GetColor(), RColor::kRed);
+   EXPECT_DOUBLE_EQ(box->AttrBox().GetAttrBorder().GetWidth(), 5.);
+   EXPECT_EQ(box->AttrBox().GetAttrBorder().GetStyle(), 7);
 
-   EXPECT_EQ(box->AttrBox().Fill().Color(), RColor::kBlue);
-   EXPECT_EQ(box->AttrBox().Fill().GetStyle(), 6);
+   EXPECT_EQ(box->AttrBox().GetAttrFill().GetColor(), RColor::kBlue);
+   EXPECT_EQ(box->AttrBox().GetAttrFill().GetStyle(), 6);
 }
 
 // Test RLine API
@@ -38,7 +38,7 @@ TEST(Primitives, RLine)
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
-   EXPECT_EQ(line->AttrLine().Color(), RColor::kRed);
+   EXPECT_EQ(line->AttrLine().GetColor(), RColor::kRed);
    EXPECT_DOUBLE_EQ(line->AttrLine().GetWidth(), 5.);
    EXPECT_EQ(line->AttrLine().GetStyle(), 7);
 }
@@ -53,7 +53,7 @@ TEST(Primitives, RMarker)
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
-   EXPECT_EQ(marker->AttrMarker().Color(), RColor::kGreen);
+   EXPECT_EQ(marker->AttrMarker().GetColor(), RColor::kGreen);
    EXPECT_DOUBLE_EQ(marker->AttrMarker().GetSize(), 2.5);
    EXPECT_EQ(marker->AttrMarker().GetStyle(), 7);
 }
@@ -70,7 +70,7 @@ TEST(Primitives, RText)
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(text->GetText(), "Hello World");
-   EXPECT_EQ(text->AttrText().Color(), RColor::kBlack);
+   EXPECT_EQ(text->AttrText().GetColor(), RColor::kBlack);
    EXPECT_DOUBLE_EQ(text->AttrText().GetSize(), 12.5);
    EXPECT_DOUBLE_EQ(text->AttrText().GetAngle(), 90.);
    EXPECT_EQ(text->AttrText().GetAlign(), 13);

--- a/graf2d/primitives/v7/test/primitives.cxx
+++ b/graf2d/primitives/v7/test/primitives.cxx
@@ -20,12 +20,12 @@ TEST(Primitives, RBox)
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
-   EXPECT_EQ(box->AttrBox().GetAttrBorder().GetColor(), RColor::kRed);
-   EXPECT_DOUBLE_EQ(box->AttrBox().GetAttrBorder().GetWidth(), 5.);
-   EXPECT_EQ(box->AttrBox().GetAttrBorder().GetStyle(), 7);
+   EXPECT_EQ(box->GetAttrBox().GetAttrBorder().GetColor(), RColor::kRed);
+   EXPECT_DOUBLE_EQ(box->GetAttrBox().GetAttrBorder().GetWidth(), 5.);
+   EXPECT_EQ(box->GetAttrBox().GetAttrBorder().GetStyle(), 7);
 
-   EXPECT_EQ(box->AttrBox().GetAttrFill().GetColor(), RColor::kBlue);
-   EXPECT_EQ(box->AttrBox().GetAttrFill().GetStyle(), 6);
+   EXPECT_EQ(box->GetAttrBox().GetAttrFill().GetColor(), RColor::kBlue);
+   EXPECT_EQ(box->GetAttrBox().GetAttrFill().GetStyle(), 6);
 }
 
 // Test RLine API
@@ -38,9 +38,9 @@ TEST(Primitives, RLine)
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
-   EXPECT_EQ(line->AttrLine().GetColor(), RColor::kRed);
-   EXPECT_DOUBLE_EQ(line->AttrLine().GetWidth(), 5.);
-   EXPECT_EQ(line->AttrLine().GetStyle(), 7);
+   EXPECT_EQ(line->GetAttrLine().GetColor(), RColor::kRed);
+   EXPECT_DOUBLE_EQ(line->GetAttrLine().GetWidth(), 5.);
+   EXPECT_EQ(line->GetAttrLine().GetStyle(), 7);
 }
 
 // Test RMarker API
@@ -53,9 +53,9 @@ TEST(Primitives, RMarker)
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
-   EXPECT_EQ(marker->AttrMarker().GetColor(), RColor::kGreen);
-   EXPECT_DOUBLE_EQ(marker->AttrMarker().GetSize(), 2.5);
-   EXPECT_EQ(marker->AttrMarker().GetStyle(), 7);
+   EXPECT_EQ(marker->GetAttrMarker().GetColor(), RColor::kGreen);
+   EXPECT_DOUBLE_EQ(marker->GetAttrMarker().GetSize(), 2.5);
+   EXPECT_EQ(marker->GetAttrMarker().GetStyle(), 7);
 }
 
 // Test RText API
@@ -70,10 +70,10 @@ TEST(Primitives, RText)
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(text->GetText(), "Hello World");
-   EXPECT_EQ(text->AttrText().GetColor(), RColor::kBlack);
-   EXPECT_DOUBLE_EQ(text->AttrText().GetSize(), 12.5);
-   EXPECT_DOUBLE_EQ(text->AttrText().GetAngle(), 90.);
-   EXPECT_EQ(text->AttrText().GetAlign(), 13);
-   EXPECT_EQ(text->AttrText().GetFont(), 42);
+   EXPECT_EQ(text->GetAttrText().GetColor(), RColor::kBlack);
+   EXPECT_DOUBLE_EQ(text->GetAttrText().GetSize(), 12.5);
+   EXPECT_DOUBLE_EQ(text->GetAttrText().GetAngle(), 90.);
+   EXPECT_EQ(text->GetAttrText().GetAlign(), 13);
+   EXPECT_EQ(text->GetAttrText().GetFont(), 42);
 }
 

--- a/hist/histdraw/v7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdraw/v7/inc/ROOT/RHistDrawable.hxx
@@ -43,7 +43,7 @@ public:
 private:
    Internal::RIOShared<HistImpl_t> fHistImpl;  ///< I/O capable reference on histogram
 
-   RAttrLine  fLineAttr{this, "line_"};        ///<! line attributes
+   RAttrLine  fAttrLine{this, "line_"};        ///<! line attributes
 
 protected:
 
@@ -58,8 +58,9 @@ public:
       fHistImpl = std::shared_ptr<HistImpl_t>(hist, hist->GetImpl());
    }
 
-   RAttrLine &AttrLine() { return fLineAttr; }
-   const RAttrLine &AttrLine() const { return fLineAttr; }
+   const RAttrLine &GetAttrLine() const { return fAttrLine; }
+   RHistDrawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
+   RAttrLine &AttrLine() { return fAttrLine; }
 
    std::shared_ptr<HistImpl_t> GetHist() const { return fHistImpl.get_shared(); }
 

--- a/hist/histdraw/v7/test/draw.cxx
+++ b/hist/histdraw/v7/test/draw.cxx
@@ -49,6 +49,6 @@ TEST(DrawOptTest, OneD)
    RCanvas canv;
    auto drawable = canv.Draw(h);
    drawable->AttrLine().SetColor(RColor::kRed);
-   RColor shouldBeRed = drawable->AttrLine().Color();
+   RColor shouldBeRed = drawable->AttrLine().GetColor();
    EXPECT_EQ(shouldBeRed, RColor::kRed);
 }

--- a/tutorials/v7/box.cxx
+++ b/tutorials/v7/box.cxx
@@ -29,33 +29,28 @@ void box()
    RColor Color1(255, 0, 0, 0.5); // 50% opaque
    RColor Color2(0, 0, 255, 0.3); // 30% opaque
 
-   Box1->AttrBox().Border().SetColor(Color1).SetWidth(5);
-   Box1->AttrBox().Fill().SetColor(RColor::kRed);
-   //OptsBox1->Fill().SetColor(Color2);
+   Box1->AttrBox().AttrBorder().SetColor(Color1).SetWidth(5);
+   Box1->AttrBox().AttrFill().SetColor(RColor::kRed);
 
    auto Box2 = canvas->Draw<RBox>(RPadPos(0.4_normal, 0.2_normal), RPadPos(0.6_normal,0.7_normal));
-   Box2->AttrBox().Border().SetColor(Color2).SetStyle(2).SetWidth(3);
-   Box2->AttrBox().Fill().SetColor(RColor::kGreen);
-   //OptsBox2->Fill().SetStyle(0);
+   Box2->AttrBox().AttrBorder().SetColor(Color2).SetStyle(2).SetWidth(3);
+   Box2->AttrBox().AttrFill().SetColor(RColor::kGreen);
 
    auto Box3 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.4_normal), RPadPos(0.9_normal,0.6_normal));
-   //OptsBox3->SetFillStyle(0);
-   //OptsBox3->SetRoundWidth(50);
-   //OptsBox3->SetRoundHeight(50);
-   Box3->AttrBox().Border().SetWidth(3);
-   Box3->AttrBox().Fill().SetColor(RColor::kBlue);
+   Box3->AttrBox().AttrBorder().SetWidth(3);
+   Box3->AttrBox().AttrFill().SetColor(RColor::kBlue);
 
    auto Box4 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.7_normal), RPadPos(0.9_normal,0.9_normal));
    //OptsBox4->SetFillStyle(0);
    //OptsBox4->SetRoundWidth(50);
    //OptsBox4->SetRoundHeight(25);
-   Box4->AttrBox().Border().SetWidth(3);
+   Box4->AttrBox().AttrBorder().SetWidth(3);
 
    auto Box5 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.1_normal), RPadPos(0.9_normal,0.3_normal));
    //OptsBox5->SetFillStyle(0);
    //OptsBox5->SetRoundWidth(25);
    //OptsBox5->SetRoundHeight(50);
-   Box5->AttrBox().Border().SetWidth(3);
+   Box5->AttrBox().AttrBorder().SetWidth(3);
 
    canvas->Show();
 }

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -51,8 +51,8 @@ void draw_legend()
    canvas->AssignAutoColors();
    
    auto legend = canvas->Draw<RLegend>(RPadPos(0.5_normal, 0.6_normal), RPadPos(0.9_normal,0.9_normal), "Legend title");
-   legend->AttrBox().Fill().SetStyle(5).SetColor(RColor::kWhite);
-   legend->AttrBox().Border().SetWidth(2).SetColor(RColor::kRed);
+   legend->AttrBox().AttrFill().SetStyle(5).SetColor(RColor::kWhite);
+   legend->AttrBox().AttrBorder().SetWidth(2).SetColor(RColor::kRed);
    legend->AddEntry(draw1, "histo1").SetLine("line_");
    legend->AddEntry(draw2, "histo2").SetLine("line_");
 


### PR DESCRIPTION
Now for each attribute three methods should be used:
1. const Getter
2. non-const Setter
3. Access by reference

```
const RAttrText &GetAttrText() const { return fAttrText; }
CustomAttrs &SetAttrText(const RAttrText &txt) { fAttrText = txt; return *this; }
RAttrText &AttrText() { return fAttrText; }
```

Such set of methods allow to clearly separate const and non-const
access. And when setter is used, chain of methods can be called.

Add several new tests.