### PR TITLE
[v7 tutorials] fix error in draw_mt.cxx

### DIFF
--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -25,15 +25,15 @@
 #include "ROOT/RHistDrawable.hxx"
 #include "ROOT/RCanvas.hxx"
 
-// macro must be here while cling is not capable to load
-// library automatically for outlined function see ROOT-10336
-R__LOAD_LIBRARY(libROOTHistDraw)
-
 #include "TRandom3.h"
 #include "TEnv.h"
 #include "TROOT.h"
 
 #include <thread>
+
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
+R__LOAD_LIBRARY(libROOTHistDraw)
 
 using namespace ROOT::Experimental;
 
@@ -95,6 +95,9 @@ void draw_mt()
    gEnv->SetValue("WebGui.SenderThrds", "yes");
 
    ROOT::EnableThreadSafety();
+
+   // create instance in main thread, used to assign thread id as well
+   RWebWindowsManager::Instance();
 
    std::thread thrd1(draw_canvas, "First", RColor::kRed);
    std::thread thrd2(draw_canvas, "Second", RColor::kBlue);


### PR DESCRIPTION
Multithreaded drawing requires exact knowledge that main thread id is.
Now it assigned when RWebWindowManager is created - first thread with RWebWindow.
Therefore do it in advance from the main thread.
Later one could provide more intelegent solution