### PR TITLE
[webgui] support Safari on Mac

### DIFF
--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 #include <ROOT/RWebDisplayArgs.hxx>
+#include <ROOT/RConfig.hxx>
 
 #include "TROOT.h"
 
@@ -66,6 +67,7 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(int width, int height, int 
 ///  firefox - use Mozilla Firefox browser, supports headless mode from v57
 ///   native - (or empty string) either chrome or firefox, only these browsers support batch (headless) mode
 ///  browser - default system web-browser, no batch mode
+///   safari - Safari browser on Mac
 ///      cef - Chromium Embeded Framework, local display, local communication
 ///      qt5 - Qt5 WebEngine, local display, local communication
 ///    local - either cef or qt5
@@ -177,5 +179,13 @@ void ROOT::Experimental::RWebDisplayArgs::SetCustomExec(const std::string &exec)
 
 std::string ROOT::Experimental::RWebDisplayArgs::GetCustomExec() const
 {
-   return GetBrowserKind() == kCustom ? fExec : "";
+   if (GetBrowserKind() != kCustom)
+      return "";
+
+#ifdef R__MACOSX
+   if ((fExec == "safari") || (fExec == "Safari"))
+      return "open -a Safari";
+#endif
+
+   return fExec;
 }


### PR DESCRIPTION
When running on macOS, one could specify now:

root.exe --web=safari draw.cxx