### PR TITLE
[cxxmodules] Do not load modules from entire LD_LIBRARY_PATH.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1287,7 +1287,7 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       // gnuinstall.
       Paths.push_back(TROOT::GetLibDir().Data());
       GetEnvVarPath("CLING_PREBUILT_MODULE_PATH", Paths);
-      GetEnvVarPath("LD_LIBRARY_PATH", Paths);
+      //GetEnvVarPath("LD_LIBRARY_PATH", Paths);
       std::string EnvVarPath;
       for (const std::string& P : Paths)
          EnvVarPath += P + EnvPathDelimiter;


### PR DESCRIPTION
C++ modules have two concepts -- a modulemap and a module file. The modulemap gives the mapping between a set of header files present in the module file.

Clang has two ways to discover these artifacts -- modulemaps must be either explicitly specified or they have to be on the include paths (-I). Module files must be in the module cache path or the prebuilt module path. ROOT enforces the module files to be next to the library files. In some cases it the LD_LIBRARY_PATH is considered to extend the set of discoverables ROOT libraries.

Over the years we have considered the LD_LIBRARY_PATH as the prebuilt module file locations. Relying on it leads to a number of issues. First, the osx system integrity protection filters its contents. Second, the LCG distribution mechanism can set the LD_LIBRARY_PATH to point to a complementary location of ROOT. In this case we will start loading irrelevant module files.

This patch disables the LD_LIBRARY_PATH module discovery and relies on ROOT to provide its set of locations where modules should be present. Nowadays the current state of the implementation allows us to enforce this finer granularity.