### PR TITLE
[rootcling] Add a meaning to the -reflex flag.

### DIFF
--- a/README/ReleaseNotes/v620/index.md
+++ b/README/ReleaseNotes/v620/index.md
@@ -60,7 +60,7 @@ instead of the splash screen. The splash screen can still be seen with `root -a`
 or in `TBrowser` by opening `Browser Help → About ROOT`.
 
 ## Deprecation and Removal
- * rootcling flags `-cint`, `-reflex`, `-gccxml`, `-p` and `-c` have no effect
+ * rootcling flags `-cint`, `-gccxml`, `-p` and `-c` have no effect
    and will be removed. Please remove them from the rootcling invocations.
  * rootcling legacy cint flags `+P`, `+V` and `+STUB` have no effect and will be
    removed. Please remove them from the rootcling invocations.

--- a/core/dictgen/src/rootcling-argparse.py
+++ b/core/dictgen/src/rootcling-argparse.py
@@ -2,8 +2,7 @@ import argparse
 import sys
 
 EPILOG = """
-The options -p, -c, -l, -cint, -reflex and -gccxml are deprecated and
-currently ignored.
+The options -p, -c, -l, -cint and -gccxml are deprecated and currently ignored.
 
 
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3970,11 +3970,12 @@ int RootClingMain(int argc,
    if (gOptVerboseLevel == v4)
       genreflex::verbose = true;
 
+   if (gOptReflex)
+      isGenreflex = true;
+
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,21,00)
    if (gOptCint)
       fprintf(stderr, "warning: Please remove the deprecated flag -cint.\n");
-   if (gOptReflex)
-      fprintf(stderr, "warning: Please remove the deprecated flag -reflex.\n");
    if (gOptGccXml)
       fprintf(stderr, "warning: Please remove the deprecated flag -gccxml.\n");
    if (gOptC)
@@ -5404,7 +5405,6 @@ bool IsGoodLibraryName(const std::string &name)
 /// --pool, --dataonly
 /// --interpreteronly
 /// --gccxml{path,opt,post}
-/// --reflex
 ///
 ///
 /// Exceptions


### PR DESCRIPTION
-reflex was deprecated because the flag was parsed but nothing was done after. Rootcling works in two modes. The first mode is when it is called directly. The second mode is when it was called from genreflex. Genreflex is essentially calling rootcling with the appropriate flag translation and it sets the isGenReflex variable to true.

The argument translation mechanism of genreflex has a nice feature which can print the underlying rootcling invocation. This is helpful if we want to move away from reflex to rootcling. This might be reasonable to get access to the finer grained arguments and options rootcling provides. However, we should still call rootcling and set the isGenReflex to true as the variable alters the content of the dictionaries.

In cmssw C++ modules IB we use rootcling instead of genreflex to have better control on the module generation provided by the rootcling option set.

This patch implements a flag which can turn the rootcling invocation completely to genreflex.

Using rootcling -reflex should fix the DataFormats/Provenance dictionary generation for cmssw.

cc: @oshadura, @smuzaffar, @davidlange6 