### PR TITLE
Backport 6.16: Better enum support in TCling and PyROOT

### DIFF
--- a/bindings/pyroot/src/Converters.cxx
+++ b/bindings/pyroot/src/Converters.cxx
@@ -1495,11 +1495,13 @@ PyROOT::TConverter* PyROOT::CreateConverter( const std::string& fullType, Long_t
           result = new TValueCppObjectConverter( klass, kTRUE );
       }
    } else if ( Cppyy::IsEnum( realType ) ) {
-   // special case (Cling): represent enums as unsigned integers
-      if ( cpd == "&" )
-         h = isConst ? gConvFactories.find( "const long&" ) : gConvFactories.find( "long&" );
-      else
-         h = gConvFactories.find( "UInt_t" );
+      // Get underlying type of enum
+      std::string et(TClassEdit::ResolveTypedef(Cppyy::ResolveEnum(realType).c_str()));
+      if (cpd == "&") {
+         auto reft = et + "&";
+         h = isConst ? gConvFactories.find("const " + reft) : gConvFactories.find(reft);
+      } else
+         h = gConvFactories.find(et);
    } else if ( realType.find( "(*)" ) != std::string::npos ||
              ( realType.find( "::*)" ) != std::string::npos ) ) {
    // this is a function function pointer
@@ -1629,7 +1631,6 @@ namespace {
       NFp_t( "const int&",                &CreateConstIntRefConverter        ),
       NFp_t( "unsigned int",              &CreateUIntConverter               ),
       NFp_t( "const unsigned int&",       &CreateConstUIntRefConverter       ),
-      NFp_t( "UInt_t", /* enum */         &CreateIntConverter /* yes: Int */ ),
       NFp_t( "long",                      &CreateLongConverter               ),
       NFp_t( "long&",                     &CreateLongRefConverter            ),
       NFp_t( "const long&",               &CreateConstLongRefConverter       ),

--- a/bindings/pyroot/src/Cppyy.cxx
+++ b/bindings/pyroot/src/Cppyy.cxx
@@ -175,6 +175,18 @@ std::string Cppyy::ResolveName( const std::string& cppitem_name )
    return TClassEdit::ResolveTypedef( tclean.c_str(), true );
 }
 
+std::string Cppyy::ResolveEnum(const std::string& enum_type)
+{
+   auto en = TEnum::GetEnum(enum_type.c_str());
+   if (en) {
+      auto ut = en->GetUnderlyingType();
+      if (ut != EDataType::kNumDataTypes)
+         return TDataType::GetTypeName(ut);
+   }
+   // Can't get type of enum, use int as default
+   return "int";
+}
+
 Cppyy::TCppScope_t Cppyy::GetScope( const std::string& sname )
 {
    std::string scope_name;

--- a/bindings/pyroot/src/Cppyy.cxx
+++ b/bindings/pyroot/src/Cppyy.cxx
@@ -12,7 +12,6 @@
 #include "TCollection.h"
 #include "TDataMember.h"
 #include "TDataType.h"
-#include "TEnum.h"
 #include "TEnumConstant.h"
 #include "TError.h"
 #include "TFunction.h"
@@ -175,9 +174,8 @@ std::string Cppyy::ResolveName( const std::string& cppitem_name )
    return TClassEdit::ResolveTypedef( tclean.c_str(), true );
 }
 
-std::string Cppyy::ResolveEnum(const std::string& enum_type)
+std::string Cppyy::ResolveEnum(const TEnum* en)
 {
-   auto en = TEnum::GetEnum(enum_type.c_str());
    if (en) {
       auto ut = en->GetUnderlyingType();
       if (ut != EDataType::kNumDataTypes)
@@ -185,6 +183,11 @@ std::string Cppyy::ResolveEnum(const std::string& enum_type)
    }
    // Can't get type of enum, use int as default
    return "int";
+}
+
+std::string Cppyy::ResolveEnum(const std::string& enum_type)
+{
+   return ResolveEnum(TEnum::GetEnum(enum_type.c_str()));
 }
 
 Cppyy::TCppScope_t Cppyy::GetScope( const std::string& sname )

--- a/bindings/pyroot/src/Cppyy.cxx
+++ b/bindings/pyroot/src/Cppyy.cxx
@@ -12,6 +12,8 @@
 #include "TCollection.h"
 #include "TDataMember.h"
 #include "TDataType.h"
+#include "TEnum.h"
+#include "TEnumConstant.h"
 #include "TError.h"
 #include "TFunction.h"
 #include "TGlobal.h"
@@ -1045,4 +1047,33 @@ Int_t Cppyy::GetDimensionSize( TCppScope_t scope, TCppIndex_t idata, int dimensi
       return m->GetMaxIndex( dimension );
    }
    return (Int_t)-1;
+}
+
+// enum properties -----------------------------------------------------------
+Cppyy::TCppEnum_t Cppyy::GetEnum(TCppScope_t scope, const std::string& enum_name)
+{
+    if (scope == GLOBAL_HANDLE)
+        return (TCppEnum_t)gROOT->GetListOfEnums(kTRUE)->FindObject(enum_name.c_str());
+
+    TClassRef& cr = type_from_handle(scope);
+    if (cr.GetClass())
+        return (TCppEnum_t)cr->GetListOfEnums(kTRUE)->FindObject(enum_name.c_str());
+
+    return (TCppEnum_t)0;
+}
+
+Cppyy::TCppIndex_t Cppyy::GetNumEnumData(TCppEnum_t etype)
+{
+    return (TCppIndex_t)((TEnum*)etype)->GetConstants()->GetSize();
+}
+
+std::string Cppyy::GetEnumDataName(TCppEnum_t etype, TCppIndex_t idata)
+{
+    return ((TEnumConstant*)((TEnum*)etype)->GetConstants()->At(idata))->GetName();
+}
+
+long long Cppyy::GetEnumDataValue(TCppEnum_t etype, TCppIndex_t idata)
+{
+     TEnumConstant* ecst = (TEnumConstant*)((TEnum*)etype)->GetConstants()->At(idata);
+     return (long long)ecst->GetValue();
 }

--- a/bindings/pyroot/src/Cppyy.h
+++ b/bindings/pyroot/src/Cppyy.h
@@ -1,6 +1,9 @@
 #ifndef PYROOT_CPPYY_H
 #define PYROOT_CPPYY_H
 
+// ROOT
+#include "TEnum.h"
+
 // Standard
 #include <string>
 #include <vector>
@@ -22,6 +25,7 @@ namespace Cppyy {
    TCppIndex_t GetNumScopes( TCppScope_t parent );
    std::string GetScopeName( TCppScope_t parent, TCppIndex_t iscope );
    std::string ResolveName( const std::string& cppitem_name );
+   std::string ResolveEnum(const TEnum* en);
    std::string ResolveEnum(const std::string& enum_type);
    TCppScope_t GetScope( const std::string& scope_name );
    std::string GetName( const std::string& scope_name );

--- a/bindings/pyroot/src/Cppyy.h
+++ b/bindings/pyroot/src/Cppyy.h
@@ -22,6 +22,7 @@ namespace Cppyy {
    TCppIndex_t GetNumScopes( TCppScope_t parent );
    std::string GetScopeName( TCppScope_t parent, TCppIndex_t iscope );
    std::string ResolveName( const std::string& cppitem_name );
+   std::string ResolveEnum(const std::string& enum_type);
    TCppScope_t GetScope( const std::string& scope_name );
    std::string GetName( const std::string& scope_name );
    TCppType_t  GetTemplate( const std::string& template_name );

--- a/bindings/pyroot/src/Cppyy.h
+++ b/bindings/pyroot/src/Cppyy.h
@@ -13,6 +13,7 @@ namespace Cppyy {
    typedef TCppScope_t TCppType_t;
    typedef void*       TCppObject_t;
    typedef ptrdiff_t   TCppMethod_t;
+   typedef void*       TCppEnum_t;
 
    typedef Long_t      TCppIndex_t;
    typedef void* (*TCppMethPtrGetter_t)( TCppObject_t );
@@ -124,6 +125,12 @@ namespace Cppyy {
    Bool_t IsConstData( TCppScope_t scope, TCppIndex_t idata );
    Bool_t IsEnumData( TCppScope_t scope, TCppIndex_t idata );
    Int_t  GetDimensionSize( TCppScope_t scope, TCppIndex_t idata, int dimension );
+
+// enum properties -----------------------------------------------------------
+   TCppEnum_t  GetEnum(TCppScope_t scope, const std::string& enum_name);
+   TCppIndex_t GetNumEnumData(TCppEnum_t);
+   std::string GetEnumDataName(TCppEnum_t, TCppIndex_t idata);
+   long long   GetEnumDataValue(TCppEnum_t, TCppIndex_t idata);
 
 } // namespace Cppyy
 

--- a/bindings/pyroot/src/Executors.cxx
+++ b/bindings/pyroot/src/Executors.cxx
@@ -722,8 +722,9 @@ PyROOT::TExecutor* PyROOT::CreateExecutor( const std::string& fullType,
             result = new TCppObjectExecutor( klass );
       }
    } else if ( Cppyy::IsEnum( realType ) ) {
-   // enums don't resolve to unsigned ints, but that's what they are ...
-      h = gExecFactories.find( "UInt_t" + cpd );
+      // Get underlying type of enum
+      std::string et(TClassEdit::ResolveTypedef(Cppyy::ResolveEnum(realType).c_str()));
+      h = gExecFactories.find( et + cpd );
    } else {
    // handle (with warning) unknown types
       std::stringstream s;

--- a/bindings/pyroot/src/PropertyProxy.cxx
+++ b/bindings/pyroot/src/PropertyProxy.cxx
@@ -216,11 +216,14 @@ void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t id
 
 void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, const std::string& name, void* address )
 {
+   Cppyy::TCppIndex_t idata = Cppyy::GetDatamemberIndex(scope, name);
+   std::string cppType = Cppyy::ResolveEnum(Cppyy::GetDatamemberType(scope, idata));
+
    fEnclosingScope = scope;
    fName           = name;
    fOffset         = (ptrdiff_t)address;
    fProperty       = (kIsStaticData | kIsConstData | kIsEnumData /* true, but may chance */ );
-   fConverter      = CreateConverter( "UInt_t", -1 );
+   fConverter      = CreateConverter( cppType, -1 );
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/bindings/pyroot/src/PropertyProxy.cxx
+++ b/bindings/pyroot/src/PropertyProxy.cxx
@@ -201,7 +201,8 @@ void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t id
 
    std::string fullType = Cppyy::GetDatamemberType( scope, idata );
    if ( Cppyy::IsEnumData( scope, idata ) ) {
-      fullType = "UInt_t";
+      // Get underlying type of enum
+      fullType = Cppyy::ResolveEnum(fullType);
       fProperty |= kIsEnumData;
    }
 

--- a/bindings/pyroot/src/PropertyProxy.cxx
+++ b/bindings/pyroot/src/PropertyProxy.cxx
@@ -214,10 +214,9 @@ void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t id
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, const std::string& name, void* address )
+void PyROOT::PropertyProxy::Set( Cppyy::TCppScope_t scope, const std::string& name, void* address, TEnum* en )
 {
-   Cppyy::TCppIndex_t idata = Cppyy::GetDatamemberIndex(scope, name);
-   std::string cppType = Cppyy::ResolveEnum(Cppyy::GetDatamemberType(scope, idata));
+   std::string cppType = Cppyy::ResolveEnum(en);
 
    fEnclosingScope = scope;
    fName           = name;

--- a/bindings/pyroot/src/PropertyProxy.h
+++ b/bindings/pyroot/src/PropertyProxy.h
@@ -25,7 +25,7 @@ namespace PyROOT {
    class PropertyProxy {
    public:
       void Set( Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t idata );
-      void Set( Cppyy::TCppScope_t scope, const std::string& name, void* address );
+      void Set( Cppyy::TCppScope_t scope, const std::string& name, void* address, TEnum* en );
 
       std::string GetName() { return fName; }
       void* GetAddress( ObjectProxy* pyobj /* owner */ );
@@ -70,12 +70,12 @@ namespace PyROOT {
    }
 
    inline PropertyProxy* PropertyProxy_NewConstant(
-      Cppyy::TCppScope_t scope, const std::string& name, void* address )
+      Cppyy::TCppScope_t scope, const std::string& name, void* address, TEnum* en )
    {
    // Create an initialize a new property descriptor, given the C++ datum.
       PropertyProxy* pyprop =
          (PropertyProxy*)PropertyProxy_Type.tp_new( &PropertyProxy_Type, 0, 0 );
-      pyprop->Set( scope, name, address );
+      pyprop->Set( scope, name, address, en );
       return pyprop;
    }
 

--- a/bindings/pyroot/src/PyRootType.cxx
+++ b/bindings/pyroot/src/PyRootType.cxx
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-
 namespace PyROOT {
 
 namespace {
@@ -92,6 +91,7 @@ namespace {
 
       // filter for python specials and lookup qualified class or function
          std::string name = PyROOT_PyUnicode_AsString( pyname );
+
          if ( name.size() <= 2 || name.substr( 0, 2 ) != "__" ) {
             attr = CreateScopeProxy( name, pyclass );
 
@@ -105,7 +105,6 @@ namespace {
                Cppyy::TCppScope_t scope = Cppyy::GetScope( cppname );
                TClass* klass = TClass::GetClass( cppname );
                if ( Cppyy::IsNamespace( scope ) ) {
-
                // tickle lazy lookup of functions
                   if ( ! attr ) {
                      TObject *methObj = nullptr;
@@ -148,11 +147,40 @@ namespace {
                }
 
             // enums types requested as type (rather than the constants)
-               if ( ! attr && klass && klass->GetListOfEnums()->FindObject( name.c_str() ) ) {
-               // special case; enum types; for now, pretend int
-               // TODO: although fine for C++98, this isn't correct in C++11
-                  Py_INCREF( &PyInt_Type );
-                  attr = (PyObject*)&PyInt_Type;
+               if (!attr) {
+                  if (Cppyy::IsEnum(Cppyy::GetScopedFinalName(scope)+"::"+name)) {
+                     // enum types (incl. named and class enums)
+                     Cppyy::TCppEnum_t enumtype = Cppyy::GetEnum(scope, name);
+                     if (enumtype) {
+                        // collect the enum values
+                        Cppyy::TCppIndex_t ndata = Cppyy::GetNumEnumData(enumtype);
+                        PyObject* dct = PyDict_New();
+                        for (Cppyy::TCppIndex_t idata = 0; idata < ndata; ++idata) {
+                           PyObject* val = PyLong_FromLongLong(Cppyy::GetEnumDataValue(enumtype, idata));
+                           PyDict_SetItemString(dct, Cppyy::GetEnumDataName(enumtype, idata).c_str(), val);
+                           Py_DECREF(val);
+                        }
+
+                        // add the __cppname__ for templates
+                        PyObject* cppnamepy = PyROOT_PyUnicode_FromString((Cppyy::GetScopedFinalName(scope)+"::"+name).c_str());
+                        PyDict_SetItem(dct, PyStrings::gCppName, cppnamepy);
+                        Py_DECREF(cppnamepy);
+
+                        // create new type with labeled values in place
+                        PyObject* pybases = PyTuple_New(1);
+                        Py_INCREF(&PyInt_Type);
+                        PyTuple_SET_ITEM(pybases, 0, (PyObject*)&PyInt_Type);
+                        PyObject* args = Py_BuildValue((char*)"sOO", name.c_str(), pybases, dct);
+                        attr = Py_TYPE(&PyInt_Type)->tp_new(Py_TYPE(&PyInt_Type), args, nullptr);
+                        Py_DECREF(args);
+                        Py_DECREF(pybases);
+                        Py_DECREF(dct);
+                     } else {
+                        // presumably not a class enum; simply pretend int
+                        Py_INCREF(&PyInt_Type);
+                        attr = (PyObject*)&PyInt_Type;
+                     }
+                  }
                }
 
                if ( attr ) {

--- a/bindings/pyroot/src/RootModule.cxx
+++ b/bindings/pyroot/src/RootModule.cxx
@@ -207,10 +207,40 @@ namespace {
          if ( object != 0 )
             return BindCppObject( object, object->IsA()->GetName() );
 
-      // 5th attempt: global enum (pretend int, TODO: is fine for C++98, not in C++11)
-         if ( Cppyy::IsEnum( name ) ) {
-            Py_INCREF( &PyInt_Type );
-            return (PyObject*)&PyInt_Type;
+      // 5th attempt: global enum
+         if (Cppyy::IsEnum(name)) {
+            // enum types (incl. named and class enums)
+            Cppyy::TCppEnum_t enumtype = Cppyy::GetEnum(Cppyy::gGlobalScope, name);
+            if (enumtype) {
+               // collect the enum values
+               Cppyy::TCppIndex_t ndata = Cppyy::GetNumEnumData(enumtype);
+               PyObject* dct = PyDict_New();
+               for (Cppyy::TCppIndex_t idata = 0; idata < ndata; ++idata) {
+                  PyObject* val = PyLong_FromLongLong(Cppyy::GetEnumDataValue(enumtype, idata));
+                  PyDict_SetItemString(dct, Cppyy::GetEnumDataName(enumtype, idata).c_str(), val);
+                  Py_DECREF(val);
+               }
+
+               // add the __cppname__ for templates
+               PyObject* cppnamepy = PyROOT_PyUnicode_FromString(cname);
+               PyDict_SetItem(dct, PyStrings::gCppName, cppnamepy);
+               Py_DECREF(cppnamepy);
+
+               // create new type with labeled values in place
+               PyObject* pybases = PyTuple_New(1);
+               Py_INCREF(&PyInt_Type);
+               PyTuple_SET_ITEM(pybases, 0, (PyObject*)&PyInt_Type);
+               PyObject* argsnt = Py_BuildValue((char*)"sOO", name.c_str(), pybases, dct);
+               attr = Py_TYPE(&PyInt_Type)->tp_new(Py_TYPE(&PyInt_Type), argsnt, nullptr);
+               Py_DECREF(argsnt);
+               Py_DECREF(pybases);
+               Py_DECREF(dct);
+            } else {
+               // presumably not a class enum; simply pretend int
+               Py_INCREF(&PyInt_Type);
+               attr = (PyObject*)&PyInt_Type;
+            }
+            return attr;
          }
 
       // 6th attempt: check macro's (debatable, but this worked in CINT)

--- a/bindings/pyroot/src/RootWrapper.cxx
+++ b/bindings/pyroot/src/RootWrapper.cxx
@@ -119,11 +119,11 @@ namespace {
       Py_DECREF( property );
    }
 
-   void AddPropertyToClass( PyObject* pyclass,
-         Cppyy::TCppScope_t scope, const std::string& name, void* address )
+   void AddConstantPropertyToClass( PyObject* pyclass,
+         Cppyy::TCppScope_t scope, const std::string& name, void* address, TEnum* en )
    {
       PyROOT::PropertyProxy* property =
-         PyROOT::PropertyProxy_NewConstant( scope, name, address );
+         PyROOT::PropertyProxy_NewConstant( scope, name, address, en );
       AddPropertyToClass1( pyclass, property, kTRUE );
       Py_DECREF( property );
    }
@@ -349,7 +349,7 @@ static int BuildScopeProxyDict( Cppyy::TCppScope_t scope, PyObject* pyclass ) {
       if (isScoped) continue; // scoped enum: do not add constants as properties of the enum's scope
       for ( Int_t i = 0; i < seq->GetSize(); i++ ) {
          TEnumConstant* ec = (TEnumConstant*)seq->At( i );
-         AddPropertyToClass( pyclass, scope, ec->GetName(), ec->GetAddress() );
+         AddConstantPropertyToClass( pyclass, scope, ec->GetName(), ec->GetAddress(), e );
       }
    }
 

--- a/bindings/pyroot/src/RootWrapper.cxx
+++ b/bindings/pyroot/src/RootWrapper.cxx
@@ -345,6 +345,8 @@ static int BuildScopeProxyDict( Cppyy::TCppScope_t scope, PyObject* pyclass ) {
    TEnum* e = 0;
    while ( (e = (TEnum*)ienum.Next()) ) {
       const TSeqCollection* seq = e->GetConstants();
+      auto isScoped = e->Property() & kIsScopedEnum;
+      if (isScoped) continue; // scoped enum: do not add constants as properties of the enum's scope
       for ( Int_t i = 0; i < seq->GetSize(); i++ ) {
          TEnumConstant* ec = (TEnumConstant*)seq->At( i );
          AddPropertyToClass( pyclass, scope, ec->GetName(), ec->GetAddress() );

--- a/core/meta/inc/TDictionary.h
+++ b/core/meta/inc/TDictionary.h
@@ -86,6 +86,7 @@ enum EProperty {
    kIsConstant      = 0x00100000,
    kIsVirtualBase   = 0x00200000,
    kIsConstPointer  = 0x00400000,
+   kIsScopedEnum    = 0x00800000,
    kIsExplicit      = 0x04000000,
    kIsNamespace     = 0x08000000,
    kIsConstMethod   = 0x10000000,

--- a/core/meta/inc/TEnum.h
+++ b/core/meta/inc/TEnum.h
@@ -20,21 +20,27 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TNamed.h"
-#include "THashList.h"
-#include "TString.h"
+#include "TDataType.h"
 #include "TDictionary.h"
+#include "THashList.h"
+#include "TNamed.h"
+#include "TString.h"
 
+class ClassInfo_t;
 class TClass;
 class TEnumConstant;
 
 class TEnum : public TDictionary {
 
 private:
-   THashList fConstantList;     //list of constants the enum type
-   void     *fInfo;             //!interpreter implementation provided declaration
-   TClass   *fClass;            //!owning class
-   std::string fQualName;       // fully qualified type name
+   THashList    fConstantList;  //list of constants the enum type
+   ClassInfo_t *fInfo;          //!interpreter information, owned by TEnum
+   TClass      *fClass;         //!owning class
+   std::string  fQualName;      // fully qualified type name
+
+   enum EBits {
+     kBitIsScopedEnum = BIT(14) ///< The enum is an enum class.
+   };
 
 public:
 
@@ -45,7 +51,7 @@ public:
                       };
 
    TEnum(): fInfo(0), fClass(0) {}
-   TEnum(const char *name, void *info, TClass *cls);
+   TEnum(const char *name, DeclId_t declid, TClass *cls);
    virtual ~TEnum();
 
    void                  AddConstant(TEnumConstant *constant);
@@ -58,9 +64,8 @@ public:
    const TEnumConstant  *GetConstant(const char *name) const {
       return (TEnumConstant *) fConstantList.FindObject(name);
    }
-   DeclId_t              GetDeclId() const {
-      return (DeclId_t)fInfo;
-   }
+   DeclId_t              GetDeclId() const;
+   EDataType             GetUnderlyingType() const;
    Bool_t                IsValid();
    Long_t                Property() const;
    void                  SetClass(TClass *cl) {

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -22,6 +22,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "TDataType.h"
 #include "TDictionary.h"
 #include "TInterpreterValue.h"
 #include "TVirtualRWMutex.h"
@@ -383,6 +384,7 @@ public:
    virtual ClassInfo_t  *ClassInfo_Factory(Bool_t /*all*/ = kTRUE) const = 0;
    virtual ClassInfo_t  *ClassInfo_Factory(ClassInfo_t * /* cl */) const = 0;
    virtual ClassInfo_t  *ClassInfo_Factory(const char * /* name */) const = 0;
+   virtual ClassInfo_t  *ClassInfo_Factory(DeclId_t declid) const = 0;
    virtual Long_t   ClassInfo_GetBaseOffset(ClassInfo_t* /* fromDerived */,
                                             ClassInfo_t* /* toBase */, void* /* address */ = 0, bool /*isderived*/ = true) const {return 0;}
    virtual int    ClassInfo_GetMethodNArg(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Bool_t /* objectIsConst */ = false, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
@@ -392,6 +394,8 @@ public:
    virtual void   ClassInfo_Init(ClassInfo_t * /* info */, int /* tagnum */) const {;}
    virtual Bool_t ClassInfo_IsBase(ClassInfo_t * /* info */, const char * /* name */) const {return 0;}
    virtual Bool_t ClassInfo_IsEnum(const char * /* name */) const {return 0;}
+   virtual Bool_t ClassInfo_IsScopedEnum(ClassInfo_t * /* info */) const {return 0;}
+   virtual EDataType ClassInfo_GetUnderlyingType(ClassInfo_t * /* info */) const {return kNumDataTypes;}
    virtual Bool_t ClassInfo_IsLoaded(ClassInfo_t * /* info */) const {return 0;}
    virtual Bool_t ClassInfo_IsValid(ClassInfo_t * /* info */) const {return 0;}
    virtual Bool_t ClassInfo_IsValidMethod(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Long_t * /* offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}

--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -30,13 +30,13 @@ ClassImp(TEnum);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor for TEnum class.
-/// It take the name of the TEnum type, specification if it is global
-/// and interpreter info.
+/// It takes the name of the TEnum type, interpreter info and surrounding class
+/// the enum it is not globalat namespace scope.
 /// Constant List is owner if enum not on global scope (thus constants not
 /// in TROOT::GetListOfGlobals).
 
-TEnum::TEnum(const char *name, void *info, TClass *cls)
-   : fInfo(info), fClass(cls)
+TEnum::TEnum(const char *name, DeclId_t declid, TClass *cls)
+   : fInfo(nullptr), fClass(cls)
 {
    SetName(name);
    if (cls) {
@@ -53,6 +53,8 @@ TEnum::TEnum(const char *name, void *info, TClass *cls)
    else { // it is in the global scope
       fQualName = GetName();
    }
+
+   Update(declid);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -60,6 +62,7 @@ TEnum::TEnum(const char *name, void *info, TClass *cls)
 
 TEnum::~TEnum()
 {
+   gInterpreter->ClassInfo_Delete(fInfo);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -80,9 +83,8 @@ Bool_t TEnum::IsValid()
    // Register the transaction when checking the validity of the object.
    if (!fInfo && UpdateInterpreterStateMarker()) {
       DeclId_t newId = gInterpreter->GetEnum(fClass, fName);
-      if (newId) {
+      if (newId)
          Update(newId);
-      }
       return newId != 0;
    }
    return fInfo != 0;
@@ -93,14 +95,47 @@ Bool_t TEnum::IsValid()
 
 Long_t TEnum::Property() const
 {
-   return kIsEnum;
+   return kIsEnum | (TestBit(kBitIsScopedEnum) ? kIsScopedEnum : 0);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get the unterlying integer type of the enum:
+///     enum E { kOne }; //  ==> int
+///     enum F: long; //  ==> long
+/// Returns kNumDataTypes if the enum is unknown / invalid.
+
+EDataType TEnum::GetUnderlyingType() const
+{
+   if (fInfo)
+      return gInterpreter->ClassInfo_GetUnderlyingType(fInfo);
+   return kNumDataTypes;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TDictionary::DeclId_t TEnum::GetDeclId() const
+{
+   if (fInfo)
+      return gInterpreter->GetDeclId(fInfo);
+
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void TEnum::Update(DeclId_t id)
 {
-   fInfo = (void *)id;
+   if (fInfo)
+      gInterpreter->ClassInfo_Delete(fInfo);
+   if (!id) {
+      fInfo = nullptr;
+      return;
+   }
+
+   fInfo = gInterpreter->ClassInfo_Factory(id);
+
+   if (fInfo)
+      SetBit(kBitIsScopedEnum, gInterpreter->ClassInfo_IsScopedEnum(fInfo));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/test/CMakeLists.txt
+++ b/core/meta/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 ROOT_ADD_GTEST(testStatusBitsChecker testStatusBitsChecker.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testHashRecursiveRemove testHashRecursiveRemove.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testTClass testTClass.cxx LIBRARIES Core)
+ROOT_ADD_GTEST(testTEnum testTEnum.cxx LIBRARIES Core)
 configure_file(stlDictCheck.h . COPYONLY)
 configure_file(stlDictCheckAux.h . COPYONLY)

--- a/core/meta/test/testTEnum.cxx
+++ b/core/meta/test/testTEnum.cxx
@@ -1,0 +1,76 @@
+#include "TEnum.h"
+#include "TInterpreter.h"
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+TEST(TEnum, UnderlyingType)
+{
+   gInterpreter->Declare(R"CODE(
+enum E0 { kE0One };
+enum E1 { kE1One = LONG_MAX };
+enum E2 { kE2One = ULONG_MAX };
+enum E3: char { kE3One };
+
+enum Eb: bool { kEbOne };
+enum Euc: unsigned char { kEucOne };
+enum Esc: signed char { kEscOne };
+enum Eus: unsigned short { kEusOne };
+enum Ess: signed short { kEssOne };
+enum Eui: unsigned int { kEuiOne };
+enum Esi: signed int { kEsiOne };
+enum Eul: unsigned long { kEulOne };
+enum Esl: signed long { kEslOne };
+enum Eull: unsigned long long { kEullOne };
+enum Esll: signed long long { kEsllOne };
+
+enum Ecl: short;
+
+enum class ECb: bool { kOne };
+enum class ECuc: unsigned char { kOne };
+enum class ECsc: signed char { kOne };
+enum class ECus: unsigned short { kOne };
+enum class ECss: signed short { kOne };
+enum class ECui: unsigned int { kOne };
+enum class ECsi: signed int { kOne };
+enum class ECul: unsigned long { kOne };
+enum class ECsl: signed long { kOne };
+enum class ECull: unsigned long long { kOne };
+enum class ECsll: signed long long { kOne };
+
+enum class ECcl: short;
+)CODE"
+			);
+
+   EXPECT_EQ(TEnum::GetEnum("E0")->GetUnderlyingType(), kUInt_t);
+   EXPECT_EQ(TEnum::GetEnum("E1")->GetUnderlyingType(), kULong_t);
+   EXPECT_EQ(TEnum::GetEnum("E2")->GetUnderlyingType(), kULong_t);
+   EXPECT_EQ(TEnum::GetEnum("E3")->GetUnderlyingType(), kChar_t);
+
+   EXPECT_EQ(TEnum::GetEnum("Eb")->GetUnderlyingType(), kBool_t);
+   EXPECT_EQ(TEnum::GetEnum("Euc")->GetUnderlyingType(), kUChar_t);
+   EXPECT_EQ(TEnum::GetEnum("Esc")->GetUnderlyingType(), kChar_t);
+   EXPECT_EQ(TEnum::GetEnum("Eus")->GetUnderlyingType(), kUShort_t);
+   EXPECT_EQ(TEnum::GetEnum("Ess")->GetUnderlyingType(), kShort_t);
+   EXPECT_EQ(TEnum::GetEnum("Eui")->GetUnderlyingType(), kUInt_t);
+   EXPECT_EQ(TEnum::GetEnum("Esi")->GetUnderlyingType(), kInt_t);
+   EXPECT_EQ(TEnum::GetEnum("Eul")->GetUnderlyingType(), kULong_t);
+   EXPECT_EQ(TEnum::GetEnum("Esl")->GetUnderlyingType(), kLong_t);
+   EXPECT_EQ(TEnum::GetEnum("Eull")->GetUnderlyingType(), kULong64_t);
+   EXPECT_EQ(TEnum::GetEnum("Esll")->GetUnderlyingType(), kLong64_t);
+   EXPECT_EQ(TEnum::GetEnum("Ecl")->GetUnderlyingType(), kShort_t);
+}
+
+
+TEST(TEnum, Scoped)
+{
+   gInterpreter->Declare(R"CODE(
+enum class EC { kOne };
+enum class EC1: long { kOne };
+enum ED { kEDOne };
+)CODE"
+			);
+   EXPECT_EQ(TEnum::GetEnum("EC")->Property() & kIsScopedEnum, kIsScopedEnum);
+   EXPECT_EQ(TEnum::GetEnum("EC1")->Property() & kIsScopedEnum, kIsScopedEnum);
+   EXPECT_EQ(TEnum::GetEnum("ED")->Property() & kIsScopedEnum, 0);
+}

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -7511,6 +7511,13 @@ ClassInfo_t* TCling::ClassInfo_Factory(const char* name) const
    return (ClassInfo_t*) new TClingClassInfo(fInterpreter, name);
 }
 
+ClassInfo_t* TCling::ClassInfo_Factory(DeclId_t declid) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return (ClassInfo_t*) new TClingClassInfo(fInterpreter, (const clang::Decl*)declid);
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 int TCling::ClassInfo_GetMethodNArg(ClassInfo_t* cinfo, const char* method, const char* proto, Bool_t objectIsConst /* = false */, EFunctionMatchMode mode /* = kConversionMatch */) const
@@ -7567,6 +7574,24 @@ bool TCling::ClassInfo_IsEnum(const char* name) const
 {
    return TClingClassInfo::IsEnum(fInterpreter, name);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+Bool_t TCling::ClassInfo_IsScopedEnum(ClassInfo_t *info) const
+{
+   TClingClassInfo* TClinginfo = (TClingClassInfo*) info;
+   return TClinginfo->IsScopedEnum();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+EDataType TCling::ClassInfo_GetUnderlyingType(ClassInfo_t* info) const
+{
+   TClingClassInfo* TClinginfo = (TClingClassInfo*) info;
+   return TClinginfo->GetUnderlyingType();
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -388,6 +388,7 @@ public: // Public Interface
    virtual ClassInfo_t*  ClassInfo_Factory(Bool_t all = kTRUE) const;
    virtual ClassInfo_t*  ClassInfo_Factory(ClassInfo_t* cl) const;
    virtual ClassInfo_t*  ClassInfo_Factory(const char* name) const;
+   virtual ClassInfo_t*  ClassInfo_Factory(DeclId_t declid) const;
    virtual Long_t   ClassInfo_GetBaseOffset(ClassInfo_t* fromDerived, ClassInfo_t* toBase, void * address, bool isDerivedObject) const;
    virtual int    ClassInfo_GetMethodNArg(ClassInfo_t* info, const char* method, const char* proto, Bool_t objectIsConst = false, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
    virtual bool   ClassInfo_HasDefaultConstructor(ClassInfo_t* info) const;
@@ -396,6 +397,8 @@ public: // Public Interface
    virtual void   ClassInfo_Init(ClassInfo_t* info, int tagnum) const;
    virtual bool   ClassInfo_IsBase(ClassInfo_t* info, const char* name) const;
    virtual bool   ClassInfo_IsEnum(const char* name) const;
+   virtual bool   ClassInfo_IsScopedEnum(ClassInfo_t* info) const;
+   virtual EDataType ClassInfo_GetUnderlyingType(ClassInfo_t* info) const;
    virtual bool   ClassInfo_IsLoaded(ClassInfo_t* info) const;
    virtual bool   ClassInfo_IsValid(ClassInfo_t* info) const;
    virtual bool   ClassInfo_IsValidMethod(ClassInfo_t* info, const char* method, const char* proto, Long_t* offset, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const;

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -772,6 +772,61 @@ bool TClingClassInfo::IsEnum(cling::Interpreter *interp, const char *name)
    return false;
 }
 
+bool TClingClassInfo::IsScopedEnum() const
+{
+   if (auto *ED = llvm::dyn_cast<clang::EnumDecl>(GetDecl()))
+      return ED->isScoped();
+   return false;
+}
+
+EDataType TClingClassInfo::GetUnderlyingType() const
+{
+   if (!IsValid())
+      return kNumDataTypes;
+   if (GetDecl() == 0)
+      return kNumDataTypes;
+
+   if (auto ED = llvm::dyn_cast<EnumDecl>(GetDecl())) {
+      R__LOCKGUARD(gInterpreterMutex);
+      auto Ty = ED->getIntegerType().getTypePtrOrNull();
+      if (auto BTy = llvm::dyn_cast<BuiltinType>(Ty)) {
+         switch (BTy->getKind()) {
+         case BuiltinType::Bool:
+            return kBool_t;
+
+         case BuiltinType::Char_U:
+         case BuiltinType::UChar:
+            return kUChar_t;
+
+         case BuiltinType::Char_S:
+         case BuiltinType::SChar:
+            return kChar_t;
+
+         case BuiltinType::UShort:
+            return kUShort_t;
+         case BuiltinType::Short:
+            return kShort_t;
+         case BuiltinType::UInt:
+            return kUInt_t;
+         case BuiltinType::Int:
+            return kInt_t;
+         case BuiltinType::ULong:
+            return kULong_t;
+         case BuiltinType::Long:
+            return kLong_t;
+         case BuiltinType::ULongLong:
+            return kULong64_t;
+         case BuiltinType::LongLong:
+            return kLong64_t;
+         default:
+            return kNumDataTypes;
+         };
+      }
+   }
+   return kNumDataTypes;
+}
+
+
 bool TClingClassInfo::IsLoaded() const
 {
    // IsLoaded in CINT was meaning is known to the interpreter

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -26,6 +26,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "TClingMethodInfo.h"
+#include "TDataType.h"
 #include "TDictionary.h"
 
 #include <vector>
@@ -123,6 +124,8 @@ public:
    void                 Init(const clang::Type &);
    bool                 IsBase(const char *name) const;
    static bool          IsEnum(cling::Interpreter *interp, const char *name);
+   bool                 IsScopedEnum() const;
+   EDataType            GetUnderlyingType() const;
    bool                 IsLoaded() const;
    bool                 IsValid() const;
    bool                 IsValidMethod(const char *method, const char *proto, Bool_t objectIsConst, long *offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;


### PR DESCRIPTION
This PR ports to 6.16 some fixes to get the underlying type of enums in PyROOT.

This backport was requested in the ticket:
https://sft.its.cern.ch/jira/browse/ROOT-8935

Please @Axel-Naumann feel free to merge if the builds confirm everything is ok.