### PR TITLE
Generate offset map performance improvement

### DIFF
--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -54,14 +54,21 @@ private:
 
 protected:
 
-   Int_t       fNdata;           ///<! Number of elements in fAddress data buffer.
-   Int_t       fLen;             ///<  Number of fixed length elements in the leaf's data.
-   Int_t       fLenType;         ///<  Number of bytes for this data type
-   Int_t       fOffset;          ///<  Offset in ClonesArray object (if one)
-   Bool_t      fIsRange;         ///<  (=kTRUE if leaf has a range, kFALSE otherwise).  This is equivalent to being a 'leafcount'.  For a TLeafElement the range information is actually store in the TBranchElement.
-   Bool_t      fIsUnsigned;      ///<  (=kTRUE if unsigned, kFALSE otherwise)
-   TLeaf      *fLeafCount;       ///<  Pointer to Leaf count if variable length (we do not own the counter)
-   TBranch    *fBranch;          ///<! Pointer to supporting branch (we do not own the branch)
+   using Counts_t = std::vector<Int_t>;
+   struct LeafCountValues {
+      Counts_t fValues;
+      Long64_t fStartEntry{-1}; ///<! entry number of corresponding to element 0 of the vector.
+   };
+
+   Int_t            fNdata;           ///<! Number of elements in fAddress data buffer.
+   Int_t            fLen;             ///<  Number of fixed length elements in the leaf's data.
+   Int_t            fLenType;         ///<  Number of bytes for this data type
+   Int_t            fOffset;          ///<  Offset in ClonesArray object (if one)
+   Bool_t           fIsRange;         ///<  (=kTRUE if leaf has a range, kFALSE otherwise).  This is equivalent to being a 'leafcount'.  For a TLeafElement the range information is actually store in the TBranchElement.
+   Bool_t           fIsUnsigned;      ///<  (=kTRUE if unsigned, kFALSE otherwise)
+   TLeaf           *fLeafCount;       ///<  Pointer to Leaf count if variable length (we do not own the counter)
+   TBranch         *fBranch;          ///<! Pointer to supporting branch (we do not own the branch)
+   LeafCountValues *fLeafCountValues; ///<! Cache of collection/array sizes
 
    TLeaf(const TLeaf&);
    TLeaf& operator=(const TLeaf&);
@@ -73,6 +80,7 @@ protected:
   Int_t *GenerateOffsetArrayBase(Int_t base, Int_t events) const; // For leaves containing fixed-size objects (no
                                                                   // polymorphism!), this will generate an appropriate
                                                                   // offset array.
+
 
 public:
    enum EStatusBits {
@@ -102,6 +110,9 @@ public:
    ///  return a pointer to the TLeaf that stores such size. Return a nullptr otherwise.
    virtual TLeaf   *GetLeafCount() const { return fLeafCount; }
    virtual TLeaf   *GetLeafCounter(Int_t &countval) const;
+
+   virtual const Counts_t *GetLeafCountValues(Long64_t start, Long64_t len);
+
    virtual Int_t    GetLen() const;
    /// Return the fixed length of this leaf.
    /// If the leaf stores a fixed-length array, this is the size of the array.

--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -58,7 +58,7 @@ protected:
    Int_t       fLen;             ///<  Number of fixed length elements in the leaf's data.
    Int_t       fLenType;         ///<  Number of bytes for this data type
    Int_t       fOffset;          ///<  Offset in ClonesArray object (if one)
-   Bool_t      fIsRange;         ///<  (=kTRUE if leaf has a range, kFALSE otherwise)
+   Bool_t      fIsRange;         ///<  (=kTRUE if leaf has a range, kFALSE otherwise).  This is equivalent to being a 'leafcount'.  For a TLeafElement the range information is actually store in the TBranchElement.
    Bool_t      fIsUnsigned;      ///<  (=kTRUE if unsigned, kFALSE otherwise)
    TLeaf      *fLeafCount;       ///<  Pointer to Leaf count if variable length (we do not own the counter)
    TBranch    *fBranch;          ///<! Pointer to supporting branch (we do not own the branch)

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -544,6 +544,7 @@ void TBranchElement::Init(TTree *tree, TBranch *parent,const char* bname, TStrea
             SetTitle(branchname);
             leaf->SetName(branchname);
             leaf->SetTitle(branchname);
+            leaf->SetRange(kTRUE);
             Unroll(name, clOfClones, clOfClones, pointer, basketsize, splitlevel+splitSTLP, 31);
             BuildTitle(name);
             SetReadLeavesPtr();
@@ -595,6 +596,7 @@ void TBranchElement::Init(TTree *tree, TBranch *parent,const char* bname, TStrea
                SetTitle(branchname);
                leaf->SetName(branchname);
                leaf->SetTitle(branchname);
+               leaf->SetRange(kTRUE);
                // Create sub branches for each data member of an STL container.
                Unroll(name, valueClass, valueClass, pointer, basketsize, splitlevel+splitSTLP, 41);
                BuildTitle(name);

--- a/tree/tree/src/TLeaf.cxx
+++ b/tree/tree/src/TLeaf.cxx
@@ -39,6 +39,7 @@ TLeaf::TLeaf()
    , fIsUnsigned(kFALSE)
    , fLeafCount(0)
    , fBranch(0)
+   , fLeafCountValues(0)
 {
 }
 
@@ -57,6 +58,7 @@ TLeaf::TLeaf(TBranch *parent, const char* name, const char *)
    , fIsUnsigned(kFALSE)
    , fLeafCount(0)
    , fBranch(parent)
+   , fLeafCountValues(0)
 {
    fLeafCount = GetLeafCounter(fLen);
 
@@ -81,7 +83,8 @@ TLeaf::TLeaf(const TLeaf& lf) :
   fIsRange(lf.fIsRange),
   fIsUnsigned(lf.fIsUnsigned),
   fLeafCount(lf.fLeafCount),
-  fBranch(lf.fBranch)
+  fBranch(lf.fBranch),
+  fLeafCountValues(nullptr)
 {
 }
 
@@ -100,6 +103,10 @@ TLeaf& TLeaf::operator=(const TLeaf& lf)
       fIsUnsigned=lf.fIsUnsigned;
       fLeafCount=lf.fLeafCount;
       fBranch=lf.fBranch;
+      if (fLeafCountValues) {
+         fLeafCountValues->fStartEntry = -1;
+         fLeafCountValues->fValues.resize(0);
+      }
    }
    return *this;
 }
@@ -118,6 +125,7 @@ TLeaf::~TLeaf()
       }
    }
    fLeafCount = 0;
+   delete fLeafCountValues;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -164,17 +172,22 @@ Int_t *TLeaf::GenerateOffsetArrayBase(Int_t base, Int_t events) const
       return nullptr;
    }
 
-   Int_t header = GetOffsetHeaderSize();
    Long64_t orig_entry = std::max(fBranch->GetReadEntry(), 0LL); // -1 indicates to start at the beginning
-   Long64_t orig_leaf_entry = fLeafCount->GetBranch()->GetReadEntry();
+   const std::vector<Int_t> *countValues = fLeafCount->GetLeafCountValues(orig_entry, events);
+
+   if (!countValues || ((Int_t)countValues->size()) < events) {
+      Error("GenerateOffsetArrayBase", "The leaf %s could not retrieve enough entries from its branch count (%s), ask for %d and got %ld",
+            GetName(), fLeafCount->GetName(), events, countValues ? countValues->size() : -1);
+      return nullptr;
+   }
+
+   Int_t header = GetOffsetHeaderSize();
    Int_t len = 0;
    for (Int_t idx = 0, offset = base; idx < events; idx++) {
       retval[idx] = offset;
-      fLeafCount->GetBranch()->GetEntry(orig_entry + idx);
-      len = static_cast<Int_t>(fLeafCount->GetValue());
+      len = (*countValues)[idx];
       offset += fLenType * len + header;
    }
-   fLeafCount->GetBranch()->GetEntry(orig_leaf_entry);
 
    return retval;
 }
@@ -303,6 +316,48 @@ TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
    delete[] countname;
    countname = 0;
    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// If this branch is a branch count, return the set of collection size for
+/// the entry range requested
+/// start: first entry to read and return information about
+/// len: number of entries to read.
+const TLeaf::Counts_t *TLeaf::GetLeafCountValues(Long64_t start, Long64_t len)
+{
+   if (len <= 0 || !IsRange())
+     return nullptr;
+
+   if (fLeafCountValues) {
+      if (fLeafCountValues->fStartEntry == start && len < (Long64_t)fLeafCountValues->fValues.size())
+      {
+         return &fLeafCountValues->fValues;
+      }
+      if (start >= fLeafCountValues->fStartEntry &&
+          (start+len) <= (Long64_t)(fLeafCountValues->fStartEntry + fLeafCountValues->fValues.size()))
+      {
+         auto &values(fLeafCountValues->fValues);
+         values.erase(values.begin(), values.begin() + start-fLeafCountValues->fStartEntry);
+         return &values;
+      }
+   } else {
+      fLeafCountValues = new LeafCountValues();
+   }
+
+
+   fLeafCountValues->fValues.clear();
+   fLeafCountValues->fValues.reserve(len);
+   fLeafCountValues->fStartEntry = start;
+
+   auto branch = GetBranch();
+   Long64_t orig_leaf_entry = branch->GetReadEntry();
+   for (Long64_t idx = 0; idx < len; ++idx) {
+       branch->GetEntry(start + idx);
+       auto size = static_cast<Int_t>(GetValue());
+       fLeafCountValues->fValues.push_back( size );
+   }
+   branch->GetEntry(orig_leaf_entry);
+   return &(fLeafCountValues->fValues);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Avoid redundant read (both unzipping and unstreaming in case basket are not perfectly aligned and same size)