### PR TITLE
Mark pointer TStreamerElement as 'CannotSplit'

### DIFF
--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -263,6 +263,9 @@ Bool_t TStreamerElement::CannotSplit() const
    TClass *cl = GetClassPointer();
    if (!cl) return kFALSE;  //basic type
 
+   static TClassRef clonesArray("TClonesArray");
+   if (IsaPointer() && cl != clonesArray && !cl->GetCollectionProxy()) return kTRUE;
+
    switch(fType) {
       case TVirtualStreamerInfo::kAny    +TVirtualStreamerInfo::kOffsetL:
       case TVirtualStreamerInfo::kObject +TVirtualStreamerInfo::kOffsetL:


### PR DESCRIPTION
This prevents TBranchElement's GatherArtificialElements from
infinitely recursing (pointlessly) through a setup like:
```
   class Vertex;
   class Event {
     Vertex *fVertex;
   };
   class Vertex {
     Event *fEvent;
   };
```
In addition:

When a branch is created from a TFolder (or if the top level branch name contains a non trailing dot, case which is 'inadvertently confused with the TFolder case), the top level branch name is prefixed (+ a trailing dot) to the sub-branch name *but* the name of base class is not suffixed to the name of their corresponding branches.  GatherArtificialElements was not handling this case correctly and thus tried 'too hard' to find (non-missing) branches for the base classes.