### PR TITLE
[TMVA experimental] Use http protocol to fetch model file

### DIFF
--- a/tutorials/tmva/tmva103_Application.C
+++ b/tutorials/tmva/tmva103_Application.C
@@ -16,7 +16,7 @@ using namespace TMVA::Experimental;
 void tmva103_Application()
 {
    // Load BDT model remotely from a webserver
-   RBDT<> bdt("myBDT", "https://root.cern/files/tmva101.root");
+   RBDT<> bdt("myBDT", "http://root.cern/files/tmva101.root");
 
    // Apply model on a single input
    auto y1 = bdt.Compute({1.0, 2.0, 3.0, 4.0});


### PR DESCRIPTION
This fixes tonights nightlies with the error `Error in <DavixOpen>: can not open file "https://root.cern/files/tmva101.root" with davix: Failure (Neon): Server certificate verification failed: issuer is not trusted after 3 attempts (6)`.