### PR TITLE
RBrowser revert to splitter

### DIFF
--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -16,20 +16,20 @@
 
           <l:layoutData><l:SplitterLayoutData size="310px" resizable="true"/></l:layoutData>
 
-            <Toolbar>
-              <layoutData><l:SplitterLayoutData size="32px" resizable="false"/></layoutData>
-              <Button icon="sap-icon://synchronize" type="Transparent"
-                      tooltip="Refresh" press="onRealoadPress"/>
-              <Button icon="sap-icon://log" type="Transparent"
-                      tooltip="Quit ROOT session" press="onQuitRootPress"/>
-              <Button icon="sap-icon://settings" type="Transparent" tooltip="Settings" press="onSettingPress"/>
-              <ToolbarSpacer/>
-              <SearchField liveChange="onSearch"/>
-            </Toolbar>
+          <Toolbar>
+            <layoutData><l:SplitterLayoutData size="32px" resizable="false"/></layoutData>
+            <Button icon="sap-icon://synchronize" type="Transparent"
+                    tooltip="Refresh" press="onRealoadPress"/>
+            <Button icon="sap-icon://log" type="Transparent"
+                    tooltip="Quit ROOT session" press="onQuitRootPress"/>
+            <Button icon="sap-icon://settings" type="Transparent" tooltip="Settings" press="onSettingPress"/>
+            <ToolbarSpacer/>
+            <SearchField liveChange="onSearch"/>
+          </Toolbar>
 
-            <Breadcrumbs id="breadcrumbs" separatorStyle="GreaterThan">
-              <layoutData><l:SplitterLayoutData size="32px" resizable="false"/></layoutData>
-            </Breadcrumbs>
+          <Breadcrumbs id="breadcrumbs" separatorStyle="GreaterThan">
+            <layoutData><l:SplitterLayoutData size="32px" resizable="false"/></layoutData>
+          </Breadcrumbs>
 
           <t:TreeTable
                   id="treeTable"

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -8,9 +8,44 @@
           xmlns:u="sap.ui.unified"
           xmlns:e="sap.ui.codeeditor">
 
-  <SplitApp id="SplitAppBrowser" initialDetail="detail" initialMaster="master" orientationChange="onOrientationChange">
-    <detailPages>
-      <Page title="Javascript ROOT Browser">
+  <Page title="" showNavButton="false" showFooter="false" showSubHeader="false" showHeader="false">
+    <content>
+      <l:Splitter id="mainSplitter" wdith="100%">
+
+        <l:Splitter orientation="Vertical">
+
+          <l:layoutData><l:SplitterLayoutData size="310px" resizable="true"/></l:layoutData>
+
+            <Toolbar>
+              <layoutData><l:SplitterLayoutData size="32px" resizable="false"/></layoutData>
+              <Button icon="sap-icon://synchronize" type="Transparent"
+                      tooltip="Refresh" press="onRealoadPress"/>
+              <Button icon="sap-icon://log" type="Transparent"
+                      tooltip="Quit ROOT session" press="onQuitRootPress"/>
+              <Button icon="sap-icon://settings" type="Transparent" tooltip="Settings" press="onSettingPress"/>
+              <ToolbarSpacer/>
+              <SearchField liveChange="onSearch"/>
+            </Toolbar>
+
+            <Breadcrumbs id="breadcrumbs" separatorStyle="GreaterThan">
+              <layoutData><l:SplitterLayoutData size="32px" resizable="false"/></layoutData>
+            </Breadcrumbs>
+
+          <t:TreeTable
+                  id="treeTable"
+                  columnHeaderVisible="true"
+                  editable="false"
+                  enableSelectAll="false"
+                  selectionBehavior="RowOnly"
+                  selectionMode="Single"
+                  visibleRowCountMode="Auto"
+
+                  showColumnVisibilityMenu="true"
+                  rows="{/nodes}">
+          </t:TreeTable>
+
+        </l:Splitter>
+
         <TabContainer id="myTabContainer"
                       showAddNewButton="true"
                       addNewButtonPress="addNewButtonPressHandler"
@@ -36,46 +71,16 @@
                 </l:Splitter>
               </content>
             </TabContainerItem>
-            <!--TabContainerItem name="ROOT Canvas" icon="sap-icon://column-chart-dual-axis" additionalText="" >
-              <content>
-                <core:HTML id="aRootCanvas1" content="&lt;div style=&quot;height:100%&quot;&gt;{/rootCanvas}&lt;/div&gt;" />
-              </content>
-            </TabContainerItem-->
           </items>
         </TabContainer>
-      </Page>
-    </detailPages>
-    <masterPages id="myMaster">
-      <Page title="" showNavButton="false" showFooter="false" showSubHeader="false" showHeader="false">
-        <Toolbar>
-          <layoutData><l:SplitterLayoutData size="35px" resizable="false"/></layoutData>
-          <Button icon="sap-icon://synchronize" type="Transparent"
-                  tooltip="Refresh" press="onRealoadPress"/>
-          <Button icon="sap-icon://log" type="Transparent"
-                  tooltip="Quit ROOT session" press="onQuitRootPress"/>
-          <Button icon="sap-icon://settings" type="Transparent" tooltip="Settings" press="onSettingPress"/>
-          <ToolbarSpacer/>
-          <SearchField liveChange="onSearch"/>
-        </Toolbar>
-        <Toolbar>
-          <Breadcrumbs id="breadcrumbs" separatorStyle="GreaterThan">
-          </Breadcrumbs>
-        </Toolbar>
-        <t:TreeTable
-                id="treeTable"
-                columnHeaderVisible="true"
-                editable="false"
-                enableSelectAll="false"
-                selectionBehavior="RowOnly"
-                selectionMode="Single"
-                visibleRowCountMode="Auto"
-                showColumnVisibilityMenu="true"
-                rows="{/nodes}">
-        </t:TreeTable>
-      </Page>
-    </masterPages>
-  </SplitApp>
+
+      </l:Splitter>
+    </content>
+  </Page>
+
 </mvc:View>
+
+
 
 
 


### PR DESCRIPTION
This commit revert the SplitApp into Splitter, it remove the bug of the TreeTable scrollbar appearing for no reason, and the bug of the breadcrumbs not creating the dropdown menu when not enough space is available.
I believe that this revert is useful if after CHEP users want to to try it, it will be more stable and more enjoyable.