### PR TITLE
Jupyter: provide extra args to rootnb executable

### DIFF
--- a/README/ReleaseNotes/v620/index.md
+++ b/README/ReleaseNotes/v620/index.md
@@ -170,6 +170,8 @@ typedefs (in particular `Double32_t`)
 - When starting Jupyter server with `root --notebook arg1 arg2 ...`, extra arguments can be provided.
   All these arguments delivered as is to jupyter executable and can be used for configuration.
   Like server binding to specific host `root --notebook --ip=hostname`
+- Remove `c.NotebookApp.ip = '*'` from default jupyter config. One has to provide ip address for server
+  binding using `root --notebook --ip=<hostaddr>` arguments
 
 
 ## JavaScript ROOT

--- a/README/ReleaseNotes/v620/index.md
+++ b/README/ReleaseNotes/v620/index.md
@@ -166,6 +166,11 @@ typedefs (in particular `Double32_t`)
 
 ## Language Bindings
 
+### Jupyter Notebook Integration
+- When starting Jupyter server with `root --notebook arg1 arg2 ...`, extra arguments can be provided.
+  All these arguments delivered as is to jupyter executable and can be used for configuration.
+  Like server binding to specific host `root --notebook --ip=hostname`
+
 
 ## JavaScript ROOT
 - Provide monitoring capabilities for TGeoManager object. Now geomtry with some tracks can be displayed and

--- a/main/src/nbmain.cxx
+++ b/main/src/nbmain.cxx
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
    string homedir(getenv("HOME"));
 #endif
    int inst = CheckNbInstallation(homedir);
-   if (inst == -1) {
+   if ((inst == -1) || (argc > 1)) {
       // The etc directory contains the ROOT notebook files to install
       string source(rootetc + pathsep + NB_CONF_DIR);
       string dest(homedir + pathsep + ROOTNB_DIR);

--- a/main/src/nbmain.cxx
+++ b/main/src/nbmain.cxx
@@ -140,7 +140,6 @@ static bool CreateJupyterConfig(string dest, string rootbin, string rootlib)
       out << "os.environ['PATH']            = '%s:%s/bin' % (rootbin,rootbin) + ':' + os.getenv('PATH', '')" << endl;
       out << "os.environ['LD_LIBRARY_PATH'] = '%s' % rootlib + ':' + os.getenv('LD_LIBRARY_PATH', '')" << endl;
 #endif
-      out << "c.NotebookApp.ip = '*'" << endl;
       out.close();
       return true;
    }

--- a/rootx/src/rootx.cxx
+++ b/rootx/src/rootx.cxx
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
    // In batch mode don't show splash screen, idem for no logo mode,
    // in about mode show always splash screen
    bool batch = false, about = false;
-   bool notebook = false;
+   int notebook = 0; // index of --notebook args, all other args will be re-directed to nbmain
    int i;
    for (i = 1; i < argc; i++) {
       if (!strcmp(argv[i], "-?") || !strncmp(argv[i], "-h", 2) ||
@@ -314,10 +314,10 @@ int main(int argc, char **argv)
       if (!strcmp(argv[i], "-a"))         about    = true;
       if (!strcmp(argv[i], "-config"))    gNoLogo  = true;
       if (!strcmp(argv[i], "--version"))  gNoLogo  = true;
-      if (!strcmp(argv[i], "--notebook")) notebook = true;
+      if (!strcmp(argv[i], "--notebook")) { notebook = i; break; }
    }
 
-   if (notebook) {
+   if (notebook > 0) {
       // Build command
 #ifdef ROOTBINDIR
       if (getenv("ROOTIGNOREPREFIX"))
@@ -328,8 +328,16 @@ int main(int argc, char **argv)
          snprintf(arg0, sizeof(arg0), "%s/%s", ROOTBINDIR, ROOTNBBINARY);
 #endif
 
+      int numnbargs = 1 + (argc - notebook);
+
+      argvv = new char* [numnbargs+1];
+      argvv[0] = arg0;
+      for (i = 1; i < numnbargs; i++)
+         argvv[i] = argv[notebook + i];
+      argvv[numnbargs] = nullptr;
+
       // Execute ROOT notebook binary
-      execl(arg0, arg0, NULL);
+      execv(arg0, argvv);
 
       // Exec failed
       fprintf(stderr, "%s: can't start ROOT notebook -- this option is only available when building with CMake, please check that %s exists\n",


### PR DESCRIPTION
Use these args to re-assign IP address where server should be bind.
Now one can use:
```
root --notebook --localhost
root --notebook --ip=myhostname
```
Potentially, all optional args can be forwarded to jupyter-notebook