### PR TITLE
Properly reset the current entry and cluster info in TTreeCache::Rese…

### DIFF
--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -1516,10 +1516,10 @@ Long64_t TChain::LoadTree(Long64_t entry)
    // Reuse cache from previous file (if any).
    if (tpf) {
       if (fFile) {
-         tpf->ResetCache();
-         fFile->SetCacheRead(tpf, fTree);
          // FIXME: fTree may be zero here.
          tpf->UpdateBranches(fTree);
+         tpf->ResetCache();
+         fFile->SetCacheRead(tpf, fTree);
       } else {
          // FIXME: One of the file in the chain is missing
          // we have no place to hold the pointer to the

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -2018,6 +2018,19 @@ Int_t TTreeCache::ReadBuffer(char *buf, Long64_t pos, Int_t len)
 
 void TTreeCache::ResetCache()
 {
+   for (Int_t i = 0; i < fNbranches; ++i) {
+      TBranch *b = (TBranch*)fBranches->UncheckedAt(i);
+      if (b->GetDirectory()==0 || b->TestBit(TBranch::kDoNotProcess))
+         continue;
+      if (b->GetDirectory()->GetFile() != fFile)
+         continue;
+      b->fCacheInfo.Reset();
+   }
+   fEntryCurrent = -1;
+   fEntryNext = -1;
+   fCurrentClusterStart = -1;
+   fNextClusterStart = -1;
+
    TFileCacheRead::Prefetch(0,0);
 
    if (fEnablePrefetching) {

--- a/tree/treeplayer/src/TMPWorkerTree.cxx
+++ b/tree/treeplayer/src/TMPWorkerTree.cxx
@@ -77,7 +77,7 @@ TMPWorkerTree::~TMPWorkerTree()
 /// Auxilliary method for common initializations
 void TMPWorkerTree::Setup()
 {
-   Int_t uc = gEnv->GetValue("MultiProc.UseTreeCache", 0);
+   Int_t uc = gEnv->GetValue("MultiProc.UseTreeCache", 1);
    if (uc != 1) fUseTreeCache = kFALSE;
    fCacheSize = gEnv->GetValue("MultiProc.CacheSize", -1);
 }

--- a/tree/treeplayer/src/TMPWorkerTree.cxx
+++ b/tree/treeplayer/src/TMPWorkerTree.cxx
@@ -164,8 +164,6 @@ void TMPWorkerTree::SetupTreeCache(TTree *tree)
          }
          if (fTreeCache) {
             fTreeCacheIsLearning = fTreeCache->IsLearning();
-            if (fTreeCacheIsLearning)
-               Info("SetupTreeCache","the tree cache is in learning phase");
          }
       } else {
          Warning("SetupTreeCache", "default tree does not have a file attached: corruption? Tree cache untouched");

--- a/tree/treeplayer/src/TMPWorkerTree.cxx
+++ b/tree/treeplayer/src/TMPWorkerTree.cxx
@@ -158,9 +158,9 @@ void TMPWorkerTree::SetupTreeCache(TTree *tree)
             fTreeCache = (TTreeCache *)curfile->GetCacheRead(tree);
             if (fCacheSize < 0) fCacheSize = tree->GetCacheSize();
          } else {
+            fTreeCache->UpdateBranches(tree);
             fTreeCache->ResetCache();
             curfile->SetCacheRead(fTreeCache, tree);
-            fTreeCache->UpdateBranches(tree);
          }
          if (fTreeCache) {
             fTreeCacheIsLearning = fTreeCache->IsLearning();


### PR DESCRIPTION
…tCache.

Without this change, trying to read within the 'previously current' cluster after a call to ResetCache resulted in constant
(failed) calls to FillBuffer