### PR TITLE
[ntuple] Allow storage of floating-point values with user-defined bitsize

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -75,6 +75,15 @@ public:
       return column;
    }
 
+   /// Used when storing data, where number of bits is defined by the user.
+   template <typename CppT, EColumnType ColumnT>
+   static RColumn *CreateCustom(const RColumnModel& model, std::uint32_t index, std::size_t nBits, std::int64_t min, std::int64_t max) {
+      R__ASSERT(model.GetType() == ColumnT);
+      auto column = new RColumn(model, index);
+      column->fElement = std::unique_ptr<RColumnElementBase>(new RColumnElement<CppT, ColumnT>(nullptr, nBits, min, max));
+      return column;
+   }
+
    RColumn(const RColumn&) = delete;
    RColumn &operator =(const RColumn&) = delete;
    ~RColumn();

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -21,6 +21,7 @@
 
 #include <TError.h>
 
+#include <cmath>
 #include <cstring> // for memcpy
 #include <cstdint>
 #include <type_traits>
@@ -232,6 +233,84 @@ public:
    static constexpr std::size_t kSize = sizeof(bool);
    static constexpr std::size_t kBitsOnStorage = 1;
    explicit RColumnElement(bool *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final;
+   void Unpack(void *dst, void *src, std::size_t count) const final;
+};
+
+template <>
+class RColumnElement<float, EColumnType::kReal24> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(float);
+   static constexpr std::size_t kBitsOnStorage = 24;
+   explicit RColumnElement(float *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final;
+   void Unpack(void *dst, void *src, std::size_t count) const final;
+};
+
+template <>
+class RColumnElement<float, EColumnType::kReal16> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(float);
+   static constexpr std::size_t kBitsOnStorage = 16;
+   explicit RColumnElement(float *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final;
+   void Unpack(void *dst, void *src, std::size_t count) const final;
+};
+
+template <>
+class RColumnElement<float, EColumnType::kReal8> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(float);
+   static constexpr std::size_t kBitsOnStorage = 8;
+   explicit RColumnElement(float *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final;
+   void Unpack(void *dst, void *src, std::size_t count) const final;
+};
+
+template <>
+class RColumnElement<double, EColumnType::kCustomDouble> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(double);
+   const std::size_t kBitsOnStorage;
+   const std::int64_t fMin;
+   const std::int64_t fMax;
+   const double fStep;
+   explicit RColumnElement(double *value) : RColumnElementBase(value, kSize), kBitsOnStorage{0}, fMin{0}, fMax{0}, fStep{0} {}
+   explicit RColumnElement(double *value, std::size_t p_nBits, std::int64_t p_min, std::int64_t p_max) : RColumnElementBase(value, kSize), kBitsOnStorage{p_nBits}, fMin{p_min}, fMax{p_max}, fStep{(p_max-p_min)/(std::pow(2, p_nBits)-4)} {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final;
+   void Unpack(void *dst, void *src, std::size_t count) const final;
+};
+
+template <>
+class RColumnElement<float, EColumnType::kCustomFloat> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(float);
+   const std::size_t kBitsOnStorage;
+   const std::int64_t fMin;
+   const std::int64_t fMax;
+   const double fStep;
+   explicit RColumnElement(float *value) : RColumnElementBase(value, kSize), kBitsOnStorage{0}, fMin{0}, fMax{0}, fStep{0} {}
+   explicit RColumnElement(float *value, std::size_t p_nBits, std::int64_t p_min, std::int64_t p_max) : RColumnElementBase(value, kSize), kBitsOnStorage{p_nBits}, fMin{p_min}, fMax{p_max}, fStep{(p_max-p_min)/(std::pow(2, p_nBits)-4)} {}
    bool IsMappable() const final { return kIsMappable; }
    std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -43,11 +43,14 @@ enum class EColumnType {
    kBit,
    kReal64,
    kReal32,
+   kReal24,
    kReal16,
    kReal8,
    kInt64,
    kInt32,
    kInt16,
+   kCustomDouble,
+   kCustomFloat,
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -69,6 +69,15 @@ public:
       fValuePtrs.emplace_back(ptr);
       return ptr;
    }
+   
+   /// The same as AddValue, but creates an RField with an additional RFieldEncoder parameter.
+   template<typename T, typename... ArgsT>
+   std::shared_ptr<T> AddValueEncoder(RField<T, RCustomSizedFloat>* field, ArgsT&&... args) {
+      auto ptr = std::make_shared<T>(std::forward<ArgsT>(args)...);
+      fValues.emplace_back(Detail::RFieldValue(field->CaptureValue(ptr.get())));
+      fValuePtrs.emplace_back(ptr);
+      return ptr;
+   }
 
    Detail::RFieldValue GetValue(std::string_view fieldName) {
       for (auto& v : fValues) {

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -70,7 +70,8 @@ public:
       return ptr;
    }
    
-   /// The same as AddValue, but creates an RField with an additional RFieldEncoder parameter.
+   /// The same as AddValue, but creates an RField with an additional RFieldEncoder parameter for custom-
+   /// sized floating-point types.
    template<typename T, typename... ArgsT>
    std::shared_ptr<T> AddValueEncoder(RField<T, RCustomSizedFloat>* field, ArgsT&&... args) {
       auto ptr = std::make_shared<T>(std::forward<ArgsT>(args)...);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -147,6 +147,7 @@ protected:
    virtual void DoReadInCluster(const RClusterIndex &clusterIndex, RFieldValue *value) {
       DoReadGlobal(fPrincipalColumn->GetGlobalIndex(clusterIndex), value);
    }
+   void SetType(const std::string &newType) { fType = newType; }
 
 public:
    /// Iterates over the sub fields in depth-first search order
@@ -596,6 +597,162 @@ public:
    size_t GetValueSize() const final { return sizeof(float); }
 };
 
+template <>
+class RField<float24_t> : public Detail::RFieldBase {
+public:
+   static std::string TypeName() { return "float24_t"; }
+   explicit RField(std::string_view name)
+     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+
+   void DoGenerateColumns() final;
+
+   float *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kReal24>(globalIndex);
+   }
+   float *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kReal24>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<float, EColumnType::kReal24>(static_cast<float*>(where)),
+         this, static_cast<float*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<float, EColumnType::kReal24>(static_cast<float*>(where)), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(float); }
+};
+
+template <>
+class RField<float16_t> : public Detail::RFieldBase {
+public:
+   static std::string TypeName() { return "float16_t"; }
+   explicit RField(std::string_view name)
+     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+
+   void DoGenerateColumns() final;
+
+   float *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kReal16>(globalIndex);
+   }
+   float *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kReal16>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<float, EColumnType::kReal16>(static_cast<float*>(where)),
+         this, static_cast<float*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<float, EColumnType::kReal16>(static_cast<float*>(where)), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(float); }
+};
+
+template <>
+class RField<float8_t> : public Detail::RFieldBase {
+public:
+   static std::string TypeName() { return "float8_t"; }
+   explicit RField(std::string_view name)
+     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+
+   void DoGenerateColumns() final;
+
+   float *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kReal8>(globalIndex);
+   }
+   float *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kReal8>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<float, EColumnType::kReal8>(static_cast<float*>(where)),
+         this, static_cast<float*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<float, EColumnType::kReal8>(static_cast<float*>(where)), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(float); }
+};
+
+/// Dummy class to produce different template specialization for custom-bit float and double.
+class RCustomSizedFloat{ }; // Members can be added later if required.
+
+/// Special version of RField<float> where the number of bits of a double-value in storage is defined by the user.
+template<>
+class RField<float, RCustomSizedFloat> : public Detail::RFieldBase {
+private:
+   std::size_t fNBits;
+   std::int64_t fMin; // integers were used to express the minimum and maximum instead of floating point numbers, because these fields are constructed by MakeField<double, nbits, min, max>(...), where it is not possible to write a floating point value as a template parameter.
+   std::int64_t fMax;
+public:
+   std::string TypeName() { return "float(nBits(" + std::to_string(fNBits) + ")/min(" + std::to_string(fMin) + ")/max(" + std::to_string(fMax) + ")"; }
+   explicit RField(std::string_view name, std::size_t nBits, std::int64_t min, std::int64_t max)
+   : Detail::RFieldBase(name, "" /* fType */, ENTupleStructure::kLeaf, true /* isSimple */), fNBits{nBits}, fMin{min}, fMax{max} { SetType(TypeName()); } // TypeName relies on fNBits, etc. so it has to be set after initalizing fNBits, etc.
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+   RFieldBase* Clone(std::string_view newName) final { return new RField(newName, fNBits, fMin, fMax); }
+
+   void DoGenerateColumns() final{
+      RColumnModel model(EColumnType::kCustomFloat, false /* isSorted*/);
+      fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
+         Detail::RColumn::CreateCustom<float, EColumnType::kCustomFloat>(model, 0, fNBits, fMin, fMax)));
+      fPrincipalColumn = fColumns[0].get();
+   }
+
+   float *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kCustomFloat>(globalIndex);
+   }
+   float *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<float, EColumnType::kCustomFloat>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<float, EColumnType::kCustomFloat>(static_cast<float*>(where), fNBits, fMin, fMax),
+         this, static_cast<float*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<float, EColumnType::kCustomFloat>(static_cast<float*>(where), fNBits, fMin, fMax), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(float); }
+};
 
 template <>
 class RField<double> : public Detail::RFieldBase {
@@ -629,6 +786,52 @@ public:
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
          Detail::RColumnElement<double, EColumnType::kReal64>(static_cast<double*>(where)), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(double); }
+};
+
+/// Special version of RField<double> where the number of bits of a double-value in storage is defined by the user.
+template<>
+class RField<double, RCustomSizedFloat> : public Detail::RFieldBase {
+private:
+   std::size_t fNBits;
+   std::int64_t fMin; // integers were used to express the minimum and maximum instead of floating point numbers, because these fields are constructed by MakeField<double, nbits, min, max>(...), where it is not possible to write a floating point value as a template parameter.
+   std::int64_t fMax;
+public:
+   std::string TypeName() { return "double(nBits(" + std::to_string(fNBits) + ")/min(" + std::to_string(fMin) + ")/max(" + std::to_string(fMax) + ")"; }
+   explicit RField(std::string_view name, std::size_t nBits, std::int64_t min, std::int64_t max)
+   : Detail::RFieldBase(name, "" /* TypeName() */, ENTupleStructure::kLeaf, true /* isSimple */), fNBits{nBits}, fMin{min}, fMax{max} { SetType(TypeName()); } // TypeName depends on fNBits, fMin and fMax, so these members should be initialized first.
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+   RFieldBase* Clone(std::string_view newName) final { return new RField(newName, fNBits, fMin, fMax); }
+
+   void DoGenerateColumns() final{
+      RColumnModel model(EColumnType::kCustomDouble, false /* isSorted*/);
+      fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
+         Detail::RColumn::CreateCustom<double, EColumnType::kCustomDouble>(model, 0, fNBits, fMin, fMax)));
+      fPrincipalColumn = fColumns[0].get();
+   }
+
+   double *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<double, EColumnType::kCustomDouble>(globalIndex);
+   }
+   double *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<double, EColumnType::kCustomDouble>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<double, EColumnType::kCustomDouble>(static_cast<double*>(where), fNBits, fMin, fMax),
+         this, static_cast<double*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<double, EColumnType::kCustomDouble>(static_cast<double*>(where), fNBits, fMin, fMax), this, where);
    }
    size_t GetValueSize() const final { return sizeof(double); }
 };
@@ -847,6 +1050,32 @@ public:
    }
 };
 
+/// Used when storing floating-point data with custom bit size in a std::array
+template <typename ItemT, std::size_t N>
+class RField<std::array<ItemT, N>, RCustomSizedFloat> : public RFieldArray {
+   using ContainerT = typename std::array<ItemT, N>;
+private:
+   std::size_t fNBits;
+   std::int64_t fMin;
+   std::int64_t fMax;
+public:
+   explicit RField(std::string_view name, std::size_t nBits, std::int64_t min, std::int64_t max)
+   : RFieldArray(name, std::make_unique<RField<ItemT, RCustomSizedFloat>>(RField<ItemT>::TypeName() + "(nBits(" + std::to_string(nBits) + ")/min(" + std::to_string(min) + ")/max(" + std::to_string(max) + ")", nBits, min, max), N), fNBits{nBits}, fMin{min}, fMax{max}
+   {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(this, static_cast<ContainerT*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final {
+      return GenerateValue(where, ContainerT());
+   }
+};
 
 #if __cplusplus >= 201703L
 template <typename... ItemTs>
@@ -958,6 +1187,36 @@ public:
    void CommitCluster() final { fNWritten = 0; }
 };
 
+/// Used when storing floating-point data with custom bit size in a std::vector
+template <typename ItemT>
+class RField<std::vector<ItemT>, RCustomSizedFloat> : public RFieldVector {
+   using ContainerT = typename std::vector<ItemT>;
+private:
+   std::size_t fNBits;
+   std::int64_t fMin;
+   std::int64_t fMax;
+public:
+   explicit RField(std::string_view name, std::size_t nBits, std::int64_t min, std::int64_t max)
+      : RFieldVector(name, std::make_unique<RField<ItemT, RCustomSizedFloat>>(RField<ItemT>::TypeName() + "(nBits(" + std::to_string(nBits) + ")/min(" + std::to_string(min) + ")/max(" + std::to_string(max) + ")", nBits, min, max)), fNBits{nBits}, fMin{min}, fMax{max}
+   {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(this, static_cast<ContainerT*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final {
+      return GenerateValue(where, ContainerT());
+   }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(ContainerT); }
+};
 
 /**
  * The RVec type has different layouts depending on the item type, therefore we cannot go with a generic

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -705,7 +705,7 @@ public:
    size_t GetValueSize() const final { return sizeof(float); }
 };
 
-/// Dummy class to produce different template specialization for custom-bit float and double.
+/// Dummy class to produce a different template specialization for custom-bit float and double.
 class RCustomSizedFloat{ }; // Members can be added later if required.
 
 /// Special version of RField<float> where the number of bits of a double-value in storage is defined by the user.
@@ -713,12 +713,18 @@ template<>
 class RField<float, RCustomSizedFloat> : public Detail::RFieldBase {
 private:
    std::size_t fNBits;
-   std::int64_t fMin; // integers were used to express the minimum and maximum instead of floating point numbers, because these fields are constructed by MakeField<double, nbits, min, max>(...), where it is not possible to write a floating point value as a template parameter.
+   // integers were used to express the minimum and maximum instead of floating point numbers, because these fields
+   // are constructed by MakeField<double, nbits, min, max>(...), where it is not possible to write a floating point
+   // value as a template parameter.
+   std::int64_t fMin;
    std::int64_t fMax;
 public:
-   std::string TypeName() { return "float(nBits(" + std::to_string(fNBits) + ")/min(" + std::to_string(fMin) + ")/max(" + std::to_string(fMax) + ")"; }
+   std::string TypeName() { return "float(nBits(" + std::to_string(fNBits) + ")/min(" + std::to_string(fMin) +
+      ")/max(" + std::to_string(fMax) + ")"; }
+   // TypeName relies on fNBits, fMin and fMax, so it has to be set after initializing those members.
    explicit RField(std::string_view name, std::size_t nBits, std::int64_t min, std::int64_t max)
-   : Detail::RFieldBase(name, "" /* fType */, ENTupleStructure::kLeaf, true /* isSimple */), fNBits{nBits}, fMin{min}, fMax{max} { SetType(TypeName()); } // TypeName relies on fNBits, etc. so it has to be set after initalizing fNBits, etc.
+   : Detail::RFieldBase(name, "" /* fType */, ENTupleStructure::kLeaf, true /* isSimple */), fNBits{nBits},
+      fMin{min}, fMax{max} { SetType(TypeName()); }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
@@ -749,7 +755,8 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<float, EColumnType::kCustomFloat>(static_cast<float*>(where), fNBits, fMin, fMax), this, where);
+         Detail::RColumnElement<float, EColumnType::kCustomFloat>(static_cast<float*>(where), fNBits, fMin, fMax),
+                                 this, where);
    }
    size_t GetValueSize() const final { return sizeof(float); }
 };
@@ -795,12 +802,18 @@ template<>
 class RField<double, RCustomSizedFloat> : public Detail::RFieldBase {
 private:
    std::size_t fNBits;
-   std::int64_t fMin; // integers were used to express the minimum and maximum instead of floating point numbers, because these fields are constructed by MakeField<double, nbits, min, max>(...), where it is not possible to write a floating point value as a template parameter.
+   // integers were used to express the minimum and maximum instead of floating point numbers, because these fields
+   // are constructed by MakeField<double, nbits, min, max>(...), where it is not possible to write a floating point
+   // value as a template parameter.
+   std::int64_t fMin;
    std::int64_t fMax;
 public:
-   std::string TypeName() { return "double(nBits(" + std::to_string(fNBits) + ")/min(" + std::to_string(fMin) + ")/max(" + std::to_string(fMax) + ")"; }
+   std::string TypeName() { return "double(nBits(" + std::to_string(fNBits) + ")/min(" + std::to_string(fMin) +
+      ")/max(" + std::to_string(fMax) + ")"; }
+   // TypeName relies on fNBits, fMin and fMax, so it has to be set after initializing those members.
    explicit RField(std::string_view name, std::size_t nBits, std::int64_t min, std::int64_t max)
-   : Detail::RFieldBase(name, "" /* TypeName() */, ENTupleStructure::kLeaf, true /* isSimple */), fNBits{nBits}, fMin{min}, fMax{max} { SetType(TypeName()); } // TypeName depends on fNBits, fMin and fMax, so these members should be initialized first.
+   : Detail::RFieldBase(name, "" /* TypeName() */, ENTupleStructure::kLeaf, true /* isSimple */), fNBits{nBits}, fMin{min},
+   fMax{max} { SetType(TypeName()); }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
@@ -1060,7 +1073,11 @@ private:
    std::int64_t fMax;
 public:
    explicit RField(std::string_view name, std::size_t nBits, std::int64_t min, std::int64_t max)
-   : RFieldArray(name, std::make_unique<RField<ItemT, RCustomSizedFloat>>(RField<ItemT>::TypeName() + "(nBits(" + std::to_string(nBits) + ")/min(" + std::to_string(min) + ")/max(" + std::to_string(max) + ")", nBits, min, max), N), fNBits{nBits}, fMin{min}, fMax{max}
+   : RFieldArray(name, std::make_unique<RField<ItemT, RCustomSizedFloat>>(RField<ItemT>::TypeName() + "(nBits(" +
+                                                                          std::to_string(nBits) + ")/min(" +
+                                                                          std::to_string(min) + ")/max(" +
+                                                                          std::to_string(max) + ")", nBits, min, max), N)
+   , fNBits{nBits}, fMin{min}, fMax{max}
    {}
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1197,7 +1214,12 @@ private:
    std::int64_t fMax;
 public:
    explicit RField(std::string_view name, std::size_t nBits, std::int64_t min, std::int64_t max)
-      : RFieldVector(name, std::make_unique<RField<ItemT, RCustomSizedFloat>>(RField<ItemT>::TypeName() + "(nBits(" + std::to_string(nBits) + ")/min(" + std::to_string(min) + ")/max(" + std::to_string(max) + ")", nBits, min, max)), fNBits{nBits}, fMin{min}, fMax{max}
+      : RFieldVector(name, std::make_unique<RField<ItemT, RCustomSizedFloat>>(RField<ItemT>::TypeName() +
+                                                                              "(nBits(" + std::to_string(nBits) +
+                                                                              ")/min(" + std::to_string(min) +
+                                                                              ")/max(" + std::to_string(max) +
+                                                                              ")", nBits, min, max)),
+   fNBits{nBits}, fMin{min}, fMax{max}
    {}
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -33,6 +33,7 @@ namespace ROOT {
 namespace Experimental {
 
 class REntry;
+class RFieldEncoder;
 class RNTupleModel;
 
 namespace Detail {
@@ -161,6 +162,11 @@ public:
    RNTupleView<T> GetView(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);
       return RNTupleView<T>(fieldId, fSource.get());
+   }
+   template<typename T, std::size_t nBits, std::int64_t min, std::int64_t max>
+   RNTupleView<T, RCustomSizedFloat> GetView(std::string_view fieldName) {
+      auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);
+      return RNTupleView<T, RCustomSizedFloat>(fieldId, fSource.get(), nBits, min, max);
    }
    RNTupleViewCollection GetViewCollection(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -163,6 +163,7 @@ public:
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);
       return RNTupleView<T>(fieldId, fSource.get());
    }
+   // Returns a view for reading fields where the number of Bits in storage is user defined.
    template<typename T, std::size_t nBits, std::int64_t min, std::int64_t max>
    RNTupleView<T, RCustomSizedFloat> GetView(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -138,6 +138,30 @@ public:
    NTupleFlags_t GetFlags() const { return fFlags; }
 };
 
+struct RFloat8 {
+   using FloatingPointType = float;
+   FloatingPointType fValue;
+   operator FloatingPointType() const { return fValue; } // casting to float
+   RFloat8(float x = 0.0f) { fValue = x; } // casting from float
+};
+using float8_t = RFloat8;
+
+struct RFloat16 {
+   using FloatingPointType = float;
+   FloatingPointType fValue;
+   operator FloatingPointType() const { return fValue; } // casting to float
+   RFloat16(float x = 0.0f) { fValue = x; } // casting from float
+};
+using float16_t = RFloat16;
+
+struct RFloat24 {
+   using FloatingPointType = float;
+   FloatingPointType fValue;
+   operator FloatingPointType() const { return fValue; } // casting to float
+   RFloat24(float x = 0.0f) { fValue = x; } // casting from float
+};
+using float24_t = RFloat24;
+
 } // namespace Experimental
 } // namespace ROOT
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -138,6 +138,7 @@ public:
    NTupleFlags_t GetFlags() const { return fFlags; }
 };
 
+/// Used as a template parameter in RField for 8bit-float.
 struct RFloat8 {
    using FloatingPointType = float;
    FloatingPointType fValue;
@@ -146,6 +147,7 @@ struct RFloat8 {
 };
 using float8_t = RFloat8;
 
+/// Used as a template parameter in RField for 16-bit float.
 struct RFloat16 {
    using FloatingPointType = float;
    FloatingPointType fValue;
@@ -154,6 +156,7 @@ struct RFloat16 {
 };
 using float16_t = RFloat16;
 
+/// Used as a template parameter in RField for 24-bit float.
 struct RFloat24 {
    using FloatingPointType = float;
    FloatingPointType fValue;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -189,6 +189,7 @@ public:
    float operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
 };
 
+/// Used when reading from RField<float, RCustomSizedFloat>
 template<>
 class RNTupleView<float, RCustomSizedFloat> {
    friend class RNTupleReader;
@@ -196,7 +197,8 @@ class RNTupleView<float, RCustomSizedFloat> {
 
 protected:
    RField<float, RCustomSizedFloat> fField;
-   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource, std::size_t nBits, std::int64_t min, std::int64_t max)
+   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource, std::size_t nBits, std::int64_t min,
+               std::int64_t max)
       : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName(), nBits, min, max)
    {
       Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
@@ -237,6 +239,7 @@ public:
    double operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
 };
 
+/// Used when reading from RField<double, RCustomSizedFloat>
 template<>
 class RNTupleView<double, RCustomSizedFloat> {
    friend class RNTupleReader;
@@ -244,7 +247,8 @@ class RNTupleView<double, RCustomSizedFloat> {
 
 protected:
    RField<double, RCustomSizedFloat> fField;
-   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource, std::size_t nBits, std::int64_t min, std::int64_t max)
+   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource, std::size_t nBits, std::int64_t min,
+               std::int64_t max)
       : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName(), nBits, min, max)
    {
       Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
@@ -309,6 +313,7 @@ public:
    ClusterSize_t operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
 };
 
+/// Used when reading from RField<std::vector<T>, RCustomSizedFloat> or RField<std::array<T, N>, RCustomSizedFloat>
 template <typename T>
 class RNTupleView<T, RCustomSizedFloat> {
    friend class RNTupleReader;
@@ -319,7 +324,8 @@ protected:
    Detail::RFieldValue fValue;
 
    RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource, std::size_t nBits, std::int64_t min, std::int64_t max)
-      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName(), nBits, min, max), fValue(fField.GenerateValue())
+      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName(), nBits, min, max),
+      fValue(fField.GenerateValue())
    {
       Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
       std::unordered_map<const Detail::RFieldBase *, DescriptorId_t> field2Id;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -120,7 +120,7 @@ to end().
 For simple types, template specializations let the reading become a pure mapping into a page buffer.
 */
 // clang-format on
-template <typename T>
+template <typename T, typename T2=void>
 class RNTupleView {
    friend class RNTupleReader;
    friend class RNTupleViewCollection;
@@ -129,7 +129,7 @@ protected:
    /**
     * fFieldId has fParent always set to null; views access nested fields without looking at the parent
     */
-   RField<T> fField;
+   RField<T, T2> fField;
    Detail::RFieldValue fValue;
 
    RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
@@ -189,6 +189,29 @@ public:
    float operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
 };
 
+template<>
+class RNTupleView<float, RCustomSizedFloat> {
+   friend class RNTupleReader;
+   friend class RNTupleViewCollection;
+
+protected:
+   RField<float, RCustomSizedFloat> fField;
+   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource, std::size_t nBits, std::int64_t min, std::int64_t max)
+      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName(), nBits, min, max)
+   {
+      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
+   }
+
+public:
+   RNTupleView(const RNTupleView& other) = delete;
+   RNTupleView(RNTupleView&& other) = default;
+   RNTupleView& operator=(const RNTupleView& other) = delete;
+   RNTupleView& operator=(RNTupleView&& other) = default;
+   ~RNTupleView() = default;
+
+   double operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
+   double operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
+};
 
 template <>
 class RNTupleView<double> {
@@ -214,6 +237,29 @@ public:
    double operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
 };
 
+template<>
+class RNTupleView<double, RCustomSizedFloat> {
+   friend class RNTupleReader;
+   friend class RNTupleViewCollection;
+
+protected:
+   RField<double, RCustomSizedFloat> fField;
+   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource, std::size_t nBits, std::int64_t min, std::int64_t max)
+      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName(), nBits, min, max)
+   {
+      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
+   }
+
+public:
+   RNTupleView(const RNTupleView& other) = delete;
+   RNTupleView(RNTupleView&& other) = default;
+   RNTupleView& operator=(const RNTupleView& other) = delete;
+   RNTupleView& operator=(RNTupleView&& other) = default;
+   ~RNTupleView() = default;
+
+   double operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
+   double operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
+};
 
 template <>
 class RNTupleView<std::int32_t> {
@@ -263,6 +309,46 @@ public:
    ClusterSize_t operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
 };
 
+template <typename T>
+class RNTupleView<T, RCustomSizedFloat> {
+   friend class RNTupleReader;
+   friend class RNTupleViewCollection;
+
+protected:
+   RField<T, RCustomSizedFloat> fField;
+   Detail::RFieldValue fValue;
+
+   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource, std::size_t nBits, std::int64_t min, std::int64_t max)
+      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName(), nBits, min, max), fValue(fField.GenerateValue())
+   {
+      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
+      std::unordered_map<const Detail::RFieldBase *, DescriptorId_t> field2Id;
+      field2Id[&fField] = fieldId;
+      for (auto &f : fField) {
+         auto subFieldId = pageSource->GetDescriptor().FindFieldId(f.GetName(), field2Id[f.GetParent()]);
+         Detail::RFieldFuse::Connect(subFieldId, *pageSource, f);
+         field2Id[&f] = subFieldId;
+      }
+   }
+
+public:
+   RNTupleView(const RNTupleView& other) = delete;
+   RNTupleView(RNTupleView&& other) = default;
+   RNTupleView& operator=(const RNTupleView& other) = delete;
+   RNTupleView& operator=(RNTupleView&& other) = default;
+   ~RNTupleView() = default;
+
+   const T& operator()(NTupleSize_t globalIndex) {
+      fField.Read(globalIndex, &fValue);
+      return *fValue.Get<T>();
+   }
+
+   const T& operator()(const RClusterIndex &clusterIndex) {
+      fField.Read(clusterIndex, &fValue);
+      return *fValue.Get<T>();
+   }
+};
+
 
 // clang-format off
 /**
@@ -310,6 +396,12 @@ public:
    RNTupleView<T> GetView(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName, fCollectionFieldId);
       return RNTupleView<T>(fieldId, fSource);
+   }
+   /// ViewCreator for floating point fields where the number of bits used to store data in storage is user-defined.
+   template <typename T, std::size_t nBits, std::int64_t min, std::int64_t max>
+   RNTupleView<T, RCustomSizedFloat> GetView(std::string_view fieldName) {
+      auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName, fCollectionFieldId);
+      return RNTupleView<T, RCustomSizedFloat>(fieldId, fSource, nBits, min, max);
    }
    RNTupleViewCollection GetViewCollection(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName, fCollectionFieldId);

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -23,43 +23,30 @@
 #include <limits>
 
 ROOT::Experimental::Detail::RColumnElementBase
-ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType type) {
+ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType type)
+{
    switch (type) {
-   case EColumnType::kReal32:
-      return RColumnElement<float, EColumnType::kReal32>(nullptr);
-   case EColumnType::kReal64:
-      return RColumnElement<double, EColumnType::kReal64>(nullptr);
-   case EColumnType::kByte:
-      return RColumnElement<std::uint8_t, EColumnType::kByte>(nullptr);
-   case EColumnType::kInt32:
-      return RColumnElement<std::int32_t, EColumnType::kInt32>(nullptr);
-   case EColumnType::kInt64:
-      return RColumnElement<std::int64_t, EColumnType::kInt64>(nullptr);
-   case EColumnType::kBit:
-      return RColumnElement<bool, EColumnType::kBit>(nullptr);
-   case EColumnType::kIndex:
-      return RColumnElement<ClusterSize_t, EColumnType::kIndex>(nullptr);
-   case EColumnType::kSwitch:
-      return RColumnElement<RColumnSwitch, EColumnType::kSwitch>(nullptr);
-   case EColumnType::kReal24:
-      return RColumnElement<float, EColumnType::kReal24>(nullptr);
-   case EColumnType::kReal16:
-      return RColumnElement<float, EColumnType::kReal16>(nullptr);
-   case EColumnType::kReal8:
-      return RColumnElement<float, EColumnType::kReal8>(nullptr);
-   case EColumnType::kCustomDouble:
-      return RColumnElement<double, EColumnType::kCustomDouble>(nullptr);
-   case EColumnType::kCustomFloat:
-      return RColumnElement<float, EColumnType::kCustomFloat>(nullptr);
-   default:
-      R__ASSERT(false);
+   case EColumnType::kReal32: return RColumnElement<float, EColumnType::kReal32>(nullptr);
+   case EColumnType::kReal64: return RColumnElement<double, EColumnType::kReal64>(nullptr);
+   case EColumnType::kByte: return RColumnElement<std::uint8_t, EColumnType::kByte>(nullptr);
+   case EColumnType::kInt32: return RColumnElement<std::int32_t, EColumnType::kInt32>(nullptr);
+   case EColumnType::kInt64: return RColumnElement<std::int64_t, EColumnType::kInt64>(nullptr);
+   case EColumnType::kBit: return RColumnElement<bool, EColumnType::kBit>(nullptr);
+   case EColumnType::kIndex: return RColumnElement<ClusterSize_t, EColumnType::kIndex>(nullptr);
+   case EColumnType::kSwitch: return RColumnElement<RColumnSwitch, EColumnType::kSwitch>(nullptr);
+   case EColumnType::kReal24: return RColumnElement<float, EColumnType::kReal24>(nullptr);
+   case EColumnType::kReal16: return RColumnElement<float, EColumnType::kReal16>(nullptr);
+   case EColumnType::kReal8: return RColumnElement<float, EColumnType::kReal8>(nullptr);
+   case EColumnType::kCustomDouble: return RColumnElement<double, EColumnType::kCustomDouble>(nullptr);
+   case EColumnType::kCustomFloat: return RColumnElement<float, EColumnType::kCustomFloat>(nullptr);
+   default: R__ASSERT(false);
    }
    // never here
    return RColumnElementBase();
 }
 
 void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Pack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    bool *boolArray = reinterpret_cast<bool *>(src);
    char *charArray = reinterpret_cast<char *>(dst);
@@ -79,7 +66,7 @@ void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColum
 }
 
 void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Unpack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    bool *boolArray = reinterpret_cast<bool *>(dst);
    char *charArray = reinterpret_cast<char *>(src);
@@ -94,149 +81,230 @@ void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColum
 
 // Way to pack: 1 sign bit, 7 exponent bits, 16 mantissa bits. (same as in Radeon R300 and R420)
 void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal24>::Pack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    R__ASSERT(sizeof(float) == 4);
    std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(src);
    unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
    for (std::size_t i = 0; i < count; ++i) {
-      std::bitset<32> floatFlags{ floatArray[i] };
-      std::bitset<8> flags{ 0 };
-      if (floatFlags.test(31)) flags.set(7);
-      if (floatFlags.test(30)) flags.set(6);
-      if (floatFlags.test(28)) flags.set(5);
-      if (floatFlags.test(27)) flags.set(4);
-      if (floatFlags.test(26)) flags.set(3);
-      if (floatFlags.test(25)) flags.set(2);
-      if (floatFlags.test(24)) flags.set(1);
-      if (floatFlags.test(23)) flags.set(0);
-      charArray[3*i] = flags.to_ulong();
-      charArray[3*i+1] = floatArray[i] >> 15;
-      charArray[3*i+2] = floatArray[i] >> 7;
+      std::bitset<32> floatFlags{floatArray[i]};
+      std::bitset<8> flags{0};
+      if (floatFlags.test(31))
+         flags.set(7);
+      if (floatFlags.test(30))
+         flags.set(6);
+      if (floatFlags.test(28))
+         flags.set(5);
+      if (floatFlags.test(27))
+         flags.set(4);
+      if (floatFlags.test(26))
+         flags.set(3);
+      if (floatFlags.test(25))
+         flags.set(2);
+      if (floatFlags.test(24))
+         flags.set(1);
+      if (floatFlags.test(23))
+         flags.set(0);
+      charArray[3 * i] = flags.to_ulong();
+      charArray[3 * i + 1] = floatArray[i] >> 15;
+      charArray[3 * i + 2] = floatArray[i] >> 7;
    }
 }
 
 void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal24>::Unpack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    R__ASSERT(sizeof(float) == 4);
    std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(dst);
    unsigned char *charArray = reinterpret_cast<unsigned char *>(src);
    for (std::size_t i = 0; i < count; ++i) {
-      std::bitset<32> floatFlags{ 0 };
-      std::bitset<8> flags{ static_cast<unsigned long long>(charArray[3*i]) };
-      std::bitset<7> exponent{ static_cast<unsigned long long>(charArray[3*i]) };
-      if (flags.test(0)) floatFlags.set(23);
-      if (flags.test(1)) floatFlags.set(24);
-      if (flags.test(2)) floatFlags.set(25);
-      if (flags.test(3)) floatFlags.set(26);
-      if (flags.test(4)) floatFlags.set(27);
-      if (flags.test(5)) floatFlags.set(28);
-      if (flags.test(6)) floatFlags.set(30);
-         else floatFlags.set(29);
-      if (flags.test(7)) floatFlags.set(31);
-      if (exponent.all()) floatFlags.set(29); // infinity and NaN case
-         else if (exponent.none()) floatFlags.reset(29); // zero and denormalized number case
-      floatArray[i] = floatFlags.to_ulong() + charArray[3*i+1]*256*128 + charArray[3*i+2]*128;
+      std::bitset<32> floatFlags{0};
+      std::bitset<8> flags{static_cast<unsigned long long>(charArray[3 * i])};
+      std::bitset<7> exponent{static_cast<unsigned long long>(charArray[3 * i])};
+      if (flags.test(0))
+         floatFlags.set(23);
+      if (flags.test(1))
+         floatFlags.set(24);
+      if (flags.test(2))
+         floatFlags.set(25);
+      if (flags.test(3))
+         floatFlags.set(26);
+      if (flags.test(4))
+         floatFlags.set(27);
+      if (flags.test(5))
+         floatFlags.set(28);
+      if (flags.test(6))
+         floatFlags.set(30);
+      else
+         floatFlags.set(29);
+      if (flags.test(7))
+         floatFlags.set(31);
+      if (exponent.all())
+         floatFlags.set(29); // infinity and NaN case
+      else if (exponent.none())
+         floatFlags.reset(29); // zero and denormalized number case
+      floatArray[i] = floatFlags.to_ulong() + charArray[3 * i + 1] * 256 * 128 + charArray[3 * i + 2] * 128;
    }
 }
 
 // Way to pack: 1 sign bit, 5 exponent bits, 10 mantissa bits (as in IEE 754-2008)
 void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal16>::Pack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    R__ASSERT(sizeof(float) == 4);
    std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(src);
    unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
    for (std::size_t i = 0; i < count; ++i) {
-      std::bitset<32> floatFlags{ floatArray[i] };
-      std::bitset<8> flags{ 0 };
-      if (floatFlags.test(31)) flags.set(7);
-      if (floatFlags.test(30)) flags.set(6);
-      if (floatFlags.test(26)) flags.set(5);
-      if (floatFlags.test(25)) flags.set(4);
-      if (floatFlags.test(24)) flags.set(3);
-      if (floatFlags.test(23)) flags.set(2);
-      if (floatFlags.test(22)) flags.set(1); // first mantissa bit
-      if (floatFlags.test(21)) flags.set(0); // second mantissa bit
-      charArray[2*i] = flags.to_ulong();
-      charArray[2*i+1] = floatArray[i] >> 13;
+      std::bitset<32> floatFlags{floatArray[i]};
+      std::bitset<8> flags{0};
+      if (floatFlags.test(31))
+         flags.set(7);
+      if (floatFlags.test(30))
+         flags.set(6);
+      if (floatFlags.test(26))
+         flags.set(5);
+      if (floatFlags.test(25))
+         flags.set(4);
+      if (floatFlags.test(24))
+         flags.set(3);
+      if (floatFlags.test(23))
+         flags.set(2);
+      if (floatFlags.test(22))
+         flags.set(1); // first mantissa bit
+      if (floatFlags.test(21))
+         flags.set(0); // second mantissa bit
+      charArray[2 * i] = flags.to_ulong();
+      charArray[2 * i + 1] = floatArray[i] >> 13;
    }
 }
 
 void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal16>::Unpack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    R__ASSERT(sizeof(float) == 4);
    std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(dst);
    unsigned char *charArray = reinterpret_cast<unsigned char *>(src);
    for (std::size_t i = 0; i < count; ++i) {
-      std::bitset<32> floatFlags{ 0 };
-      std::bitset<8> flags{ static_cast<unsigned long long>(charArray[2*i]) };
-      std::bitset<5> exponent{ static_cast<unsigned long long>(charArray[2*i] >> 2) };
-      if (flags.test(0)) floatFlags.set(21);
-      if (flags.test(1)) floatFlags.set(22);
-      if (flags.test(2)) floatFlags.set(23);
-      if (flags.test(3)) floatFlags.set(24);
-      if (flags.test(4)) floatFlags.set(25);
-      if (flags.test(5)) floatFlags.set(26);
-      if (flags.test(6)) floatFlags.set(30);
-         else { floatFlags.set(29); floatFlags.set(28); floatFlags.set(27); }
-      if (flags.test(7)) floatFlags.set(31);
-      if (exponent.all()) { floatFlags.set(29); floatFlags.set(28); floatFlags.set(27); } // infinity and NaN case
-         else if (exponent.none()) { floatFlags.reset(29); floatFlags.reset(28); floatFlags.reset(27); } // zero and denormalized number case
-      floatArray[i] = floatFlags.to_ulong() + charArray[2*i+1]*256*32;
+      std::bitset<32> floatFlags{0};
+      std::bitset<8> flags{static_cast<unsigned long long>(charArray[2 * i])};
+      std::bitset<5> exponent{static_cast<unsigned long long>(charArray[2 * i] >> 2)};
+      if (flags.test(0))
+         floatFlags.set(21);
+      if (flags.test(1))
+         floatFlags.set(22);
+      if (flags.test(2))
+         floatFlags.set(23);
+      if (flags.test(3))
+         floatFlags.set(24);
+      if (flags.test(4))
+         floatFlags.set(25);
+      if (flags.test(5))
+         floatFlags.set(26);
+      if (flags.test(6))
+         floatFlags.set(30);
+      else {
+         floatFlags.set(29);
+         floatFlags.set(28);
+         floatFlags.set(27);
+      }
+      if (flags.test(7))
+         floatFlags.set(31);
+      if (exponent.all()) {
+         floatFlags.set(29);
+         floatFlags.set(28);
+         floatFlags.set(27);
+      } // infinity and NaN case
+      else if (exponent.none()) {
+         floatFlags.reset(29);
+         floatFlags.reset(28);
+         floatFlags.reset(27);
+      } // zero and denormalized number case
+      floatArray[i] = floatFlags.to_ulong() + charArray[2 * i + 1] * 256 * 32;
    }
 }
 
 // Way to pack: 1 sign bit, 3 exponent bits, 4 mantissa bits (same as in G.711)
 void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal8>::Pack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(src);
    unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
    for (std::size_t i = 0; i < count; ++i) {
-      std::bitset<32> floatFlags{ floatArray[i] };
-      std::bitset<8> flags{ 0 };
-      if (floatFlags.test(31)) flags.set(7);
-      if (floatFlags.test(30)) flags.set(6);
-      if (floatFlags.test(24)) flags.set(5);
-      if (floatFlags.test(23)) flags.set(4);
-      if (floatFlags.test(22)) flags.set(3); // first mantissa bit
-      if (floatFlags.test(21)) flags.set(2); // second mantissa bit
-      if (floatFlags.test(20)) flags.set(1); // third mantissa bit
-      if (floatFlags.test(19)) flags.set(0); // fourth mantissa bit
+      std::bitset<32> floatFlags{floatArray[i]};
+      std::bitset<8> flags{0};
+      if (floatFlags.test(31))
+         flags.set(7);
+      if (floatFlags.test(30))
+         flags.set(6);
+      if (floatFlags.test(24))
+         flags.set(5);
+      if (floatFlags.test(23))
+         flags.set(4);
+      if (floatFlags.test(22))
+         flags.set(3); // first mantissa bit
+      if (floatFlags.test(21))
+         flags.set(2); // second mantissa bit
+      if (floatFlags.test(20))
+         flags.set(1); // third mantissa bit
+      if (floatFlags.test(19))
+         flags.set(0); // fourth mantissa bit
       charArray[i] = flags.to_ulong();
    }
 }
 
 void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal8>::Unpack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    R__ASSERT(sizeof(float) == 4);
    std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(dst);
    char *charArray = reinterpret_cast<char *>(src);
    for (std::size_t i = 0; i < count; ++i) {
-      std::bitset<32> floatFlags{ 0 };
-      std::bitset<8> flags{ static_cast<unsigned long long>(charArray[i]) };
-      std::bitset<3> exponent{ static_cast<unsigned long long>(charArray[i] >> 4) };
-      if (flags.test(0)) floatFlags.set(19);
-      if (flags.test(1)) floatFlags.set(20);
-      if (flags.test(2)) floatFlags.set(21);
-      if (flags.test(3)) floatFlags.set(22);
-      if (flags.test(4)) floatFlags.set(23);
-      if (flags.test(5)) floatFlags.set(24);
-      if (flags.test(6)) floatFlags.set(30);
-      else { floatFlags.set(29); floatFlags.set(28); floatFlags.set(27); floatFlags.set(26); floatFlags.set(25); }
-      if (flags.test(7)) floatFlags.set(31);
-      if (exponent.all()) { floatFlags.set(29); floatFlags.set(28); floatFlags.set(27); floatFlags.set(26); floatFlags.set(25); } // infinity and NaN case
-      else if (exponent.none()) { floatFlags.reset(29); floatFlags.reset(28); floatFlags.reset(27); floatFlags.reset(26); floatFlags.reset(25); } // zero and denormalized number case
+      std::bitset<32> floatFlags{0};
+      std::bitset<8> flags{static_cast<unsigned long long>(charArray[i])};
+      std::bitset<3> exponent{static_cast<unsigned long long>(charArray[i] >> 4)};
+      if (flags.test(0))
+         floatFlags.set(19);
+      if (flags.test(1))
+         floatFlags.set(20);
+      if (flags.test(2))
+         floatFlags.set(21);
+      if (flags.test(3))
+         floatFlags.set(22);
+      if (flags.test(4))
+         floatFlags.set(23);
+      if (flags.test(5))
+         floatFlags.set(24);
+      if (flags.test(6))
+         floatFlags.set(30);
+      else {
+         floatFlags.set(29);
+         floatFlags.set(28);
+         floatFlags.set(27);
+         floatFlags.set(26);
+         floatFlags.set(25);
+      }
+      if (flags.test(7))
+         floatFlags.set(31);
+      if (exponent.all()) {
+         floatFlags.set(29);
+         floatFlags.set(28);
+         floatFlags.set(27);
+         floatFlags.set(26);
+         floatFlags.set(25);
+      } // infinity and NaN case
+      else if (exponent.none()) {
+         floatFlags.reset(29);
+         floatFlags.reset(28);
+         floatFlags.reset(27);
+         floatFlags.reset(26);
+         floatFlags.reset(25);
+      } // zero and denormalized number case
       floatArray[i] = floatFlags.to_ulong();
    }
 }
 
 void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::EColumnType::kCustomDouble>::Pack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    double *doubleArray = reinterpret_cast<double *>(src);
    unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
@@ -245,29 +313,37 @@ void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::ECol
       int numCharUsedToStoreOneValue = kBitsOnStorage / 8;
       for (std::size_t i = 0; i < count; ++i) {
          std::size_t totalNumSteps;
-         if (std::isnan(doubleArray[i])) totalNumSteps = 2; // NaN
-         else if (doubleArray[i] > fMax) totalNumSteps = 0; // overflow/positive infinity
-         else if (doubleArray[i] < fMin) totalNumSteps = 1; // underflow/negative infinity
-         else totalNumSteps = std::llround( (doubleArray[i]-fMin) / fStep) + 3;
+         if (std::isnan(doubleArray[i]))
+            totalNumSteps = 2; // NaN
+         else if (doubleArray[i] > fMax)
+            totalNumSteps = 0; // overflow/positive infinity
+         else if (doubleArray[i] < fMin)
+            totalNumSteps = 1; // underflow/negative infinity
+         else
+            totalNumSteps = std::llround((doubleArray[i] - fMin) / fStep) + 3;
          for (int j = 0; j < numCharUsedToStoreOneValue; ++j) {
-            charArray[numCharUsedToStoreOneValue*i+j] = (totalNumSteps & 0xFF);
+            charArray[numCharUsedToStoreOneValue * i + j] = (totalNumSteps & 0xFF);
             totalNumSteps >>= 8;
          }
       }
    } else {
-      int index = 0; // of charArray, count is index of doubleArray.
+      int index = 0;                                 // of charArray, count is index of doubleArray.
       short bitsFilledInCurrentCharArrayUpToNow = 0; // takes values from 0 to 7
       for (std::size_t i = 0; i < count; ++i) {
          short unfilledNumBitsOfCurrentValue = kBitsOnStorage;
          std::size_t totalNumSteps;
-         if (std::isnan(doubleArray[i])) totalNumSteps = 2; // NaN
-         else if (doubleArray[i] > fMax) totalNumSteps = 0; // overflow/positive infinity
-         else if (doubleArray[i] < fMin) totalNumSteps = 1; // underflow/negative infinity
-         else totalNumSteps = std::llround( (doubleArray[i]-fMin) / fStep) + 3;
+         if (std::isnan(doubleArray[i]))
+            totalNumSteps = 2; // NaN
+         else if (doubleArray[i] > fMax)
+            totalNumSteps = 0; // overflow/positive infinity
+         else if (doubleArray[i] < fMin)
+            totalNumSteps = 1; // underflow/negative infinity
+         else
+            totalNumSteps = std::llround((doubleArray[i] - fMin) / fStep) + 3;
          if (bitsFilledInCurrentCharArrayUpToNow != 0) {
             std::size_t nBitsToFill = std::min((int)kBitsOnStorage, (8 - bitsFilledInCurrentCharArrayUpToNow));
-            short mask = (1 << nBitsToFill)-1;
-            unsigned char ToAdd {static_cast<unsigned char>(totalNumSteps & mask)};
+            short mask = (1 << nBitsToFill) - 1;
+            unsigned char ToAdd{static_cast<unsigned char>(totalNumSteps & mask)};
             ToAdd <<= (8 - bitsFilledInCurrentCharArrayUpToNow - nBitsToFill);
             charArray[index] += ToAdd; //>>= nBitsToFill);
             totalNumSteps >>= nBitsToFill;
@@ -282,7 +358,7 @@ void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::ECol
             }
          }
          // Fill where entire 8 bits can be filled at once, with while loop instead of a for loop.
-         while(unfilledNumBitsOfCurrentValue >= 8) {
+         while (unfilledNumBitsOfCurrentValue >= 8) {
             charArray[index] = (totalNumSteps & 0xFF);
             totalNumSteps >>= 8;
             ++index;
@@ -290,7 +366,7 @@ void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::ECol
          }
          // Fill remaining bits (smaller than 8).
          if (unfilledNumBitsOfCurrentValue != 0) {
-            charArray[index] = totalNumSteps << (8-unfilledNumBitsOfCurrentValue);
+            charArray[index] = totalNumSteps << (8 - unfilledNumBitsOfCurrentValue);
             bitsFilledInCurrentCharArrayUpToNow = unfilledNumBitsOfCurrentValue;
          }
       }
@@ -298,7 +374,7 @@ void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::ECol
 }
 
 void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::EColumnType::kCustomDouble>::Unpack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    double *doubleArray = reinterpret_cast<double *>(dst);
    unsigned char *charArray = reinterpret_cast<unsigned char *>(src);
@@ -306,29 +382,24 @@ void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::ECol
       const std::uint8_t numCharUsedToStoreOneValue = kBitsOnStorage / 8;
       for (std::size_t i = 0; i < count; ++i) {
          std::uint64_t totalNumSteps{0};
-         for (int j = numCharUsedToStoreOneValue -1; j >= 0; --j) {
+         for (int j = numCharUsedToStoreOneValue - 1; j >= 0; --j) {
             totalNumSteps <<= 8;
-            totalNumSteps += charArray[numCharUsedToStoreOneValue*i+j];
+            totalNumSteps += charArray[numCharUsedToStoreOneValue * i + j];
          }
 
          switch (totalNumSteps) {
-            case 0:
-               doubleArray[i] = std::numeric_limits<double>::infinity();
-               break;
-            case 1:
-               doubleArray[i] = std::numeric_limits<double>::infinity() * (-1);
-               break;
-            case 2:
-               doubleArray[i] = std::nan("");
-               break;
-            default:
-               totalNumSteps -= 3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
-               doubleArray[i] = fMin + fStep * totalNumSteps;
-               break;
+         case 0: doubleArray[i] = std::numeric_limits<double>::infinity(); break;
+         case 1: doubleArray[i] = std::numeric_limits<double>::infinity() * (-1); break;
+         case 2: doubleArray[i] = std::nan(""); break;
+         default:
+            totalNumSteps -=
+               3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
+            doubleArray[i] = fMin + fStep * totalNumSteps;
+            break;
          }
       }
    } else {
-      int index = 0; // of charArray, count is index of doubleArray.
+      int index = 0;                                 // of charArray, count is index of doubleArray.
       short bitsPassedInCurrentCharArrayUpToNow = 0; // takes values from 0 to 7
 
       for (std::size_t i = 0; i < count; ++i) {
@@ -338,7 +409,7 @@ void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::ECol
          if (bitsPassedInCurrentCharArrayUpToNow != 0) {
             short nBitsToRead = std::min(8 - bitsPassedInCurrentCharArrayUpToNow, (int)unfilledNumBitsOfCurrentValue);
             // e.g. get 3 bits with mask 0b 0000'0111
-            short mask = (1 << nBitsToRead)-1;
+            short mask = (1 << nBitsToRead) - 1;
             short numBitsToShiftMask = 8 - bitsPassedInCurrentCharArrayUpToNow - nBitsToRead;
             mask <<= numBitsToShiftMask;
             totalNumSteps += (charArray[index] & mask);
@@ -360,31 +431,26 @@ void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::ECol
          }
          // Phase 3: Only empty what you need.
          if (unfilledNumBitsOfCurrentValue != 0) {
-            std::size_t toFill = charArray[index] >> (8-unfilledNumBitsOfCurrentValue);
+            std::size_t toFill = charArray[index] >> (8 - unfilledNumBitsOfCurrentValue);
             totalNumSteps += toFill * ((std::size_t)1 << (kBitsOnStorage - unfilledNumBitsOfCurrentValue));
             bitsPassedInCurrentCharArrayUpToNow += unfilledNumBitsOfCurrentValue;
          }
          switch (totalNumSteps) {
-            case 0:
-               doubleArray[i] = std::numeric_limits<double>::infinity();
-               break;
-            case 1:
-               doubleArray[i] = std::numeric_limits<double>::infinity() * (-1);
-               break;
-            case 2:
-               doubleArray[i] = std::nan("");
-               break;
-            default:
-               totalNumSteps -= 3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
-               doubleArray[i] = fMin + fStep * totalNumSteps;
-               break;
+         case 0: doubleArray[i] = std::numeric_limits<double>::infinity(); break;
+         case 1: doubleArray[i] = std::numeric_limits<double>::infinity() * (-1); break;
+         case 2: doubleArray[i] = std::nan(""); break;
+         default:
+            totalNumSteps -=
+               3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
+            doubleArray[i] = fMin + fStep * totalNumSteps;
+            break;
          }
       }
    }
 }
 
 void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kCustomFloat>::Pack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    float *floatArray = reinterpret_cast<float *>(src);
    unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
@@ -393,29 +459,37 @@ void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColu
       int numCharUsedToStoreOneValue = kBitsOnStorage / 8;
       for (std::size_t i = 0; i < count; ++i) {
          std::size_t totalNumSteps;
-         if (std::isnan(floatArray[i])) totalNumSteps = 2; // NaN
-         else if (floatArray[i] > fMax) totalNumSteps = 0; // overflow/positive infinity
-         else if (floatArray[i] < fMin) totalNumSteps = 1; // underflow/negative infinity
-         else totalNumSteps = std::llround( (floatArray[i]-fMin) / fStep) + 3;
+         if (std::isnan(floatArray[i]))
+            totalNumSteps = 2; // NaN
+         else if (floatArray[i] > fMax)
+            totalNumSteps = 0; // overflow/positive infinity
+         else if (floatArray[i] < fMin)
+            totalNumSteps = 1; // underflow/negative infinity
+         else
+            totalNumSteps = std::llround((floatArray[i] - fMin) / fStep) + 3;
          for (int j = 0; j < numCharUsedToStoreOneValue; ++j) {
-            charArray[numCharUsedToStoreOneValue*i+j] = (totalNumSteps & 0xFF);
+            charArray[numCharUsedToStoreOneValue * i + j] = (totalNumSteps & 0xFF);
             totalNumSteps >>= 8;
          }
       }
    } else {
-      int index = 0; // of charArray, count is index of doubleArray.
+      int index = 0;                                 // of charArray, count is index of doubleArray.
       short bitsFilledInCurrentCharArrayUpToNow = 0; // takes values from 0 to 7
       for (std::size_t i = 0; i < count; ++i) {
          short unfilledNumBitsOfCurrentValue = kBitsOnStorage;
          std::size_t totalNumSteps;
-         if (std::isnan(floatArray[i])) totalNumSteps = 2; // NaN
-         else if (floatArray[i] > fMax) totalNumSteps = 0; // overflow/positive infinity
-         else if (floatArray[i] < fMin) totalNumSteps = 1; // underflow/negative infinity
-         else totalNumSteps = std::llround( (floatArray[i]-fMin) / fStep) + 3;
+         if (std::isnan(floatArray[i]))
+            totalNumSteps = 2; // NaN
+         else if (floatArray[i] > fMax)
+            totalNumSteps = 0; // overflow/positive infinity
+         else if (floatArray[i] < fMin)
+            totalNumSteps = 1; // underflow/negative infinity
+         else
+            totalNumSteps = std::llround((floatArray[i] - fMin) / fStep) + 3;
          if (bitsFilledInCurrentCharArrayUpToNow != 0) {
             std::size_t nBitsToFill = std::min((int)kBitsOnStorage, (8 - bitsFilledInCurrentCharArrayUpToNow));
-            short mask = (1 << nBitsToFill)-1;
-            unsigned char ToAdd {static_cast<unsigned char>(totalNumSteps & mask)};
+            short mask = (1 << nBitsToFill) - 1;
+            unsigned char ToAdd{static_cast<unsigned char>(totalNumSteps & mask)};
             ToAdd <<= (8 - bitsFilledInCurrentCharArrayUpToNow - nBitsToFill);
             charArray[index] += ToAdd; //>>= nBitsToFill);
             totalNumSteps >>= nBitsToFill;
@@ -430,7 +504,7 @@ void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColu
             }
          }
          // Fill where entire 8 bits can be filled at once, with while loop instead of a for loop.
-         while(unfilledNumBitsOfCurrentValue >= 8) {
+         while (unfilledNumBitsOfCurrentValue >= 8) {
             charArray[index] = (totalNumSteps & 0xFF);
             totalNumSteps >>= 8;
             ++index;
@@ -439,7 +513,7 @@ void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColu
 
          // Fill remaining bits (smaller than 8).
          if (unfilledNumBitsOfCurrentValue != 0) {
-            charArray[index] = totalNumSteps << (8-unfilledNumBitsOfCurrentValue);
+            charArray[index] = totalNumSteps << (8 - unfilledNumBitsOfCurrentValue);
             bitsFilledInCurrentCharArrayUpToNow = unfilledNumBitsOfCurrentValue;
          }
       }
@@ -447,7 +521,7 @@ void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColu
 }
 
 void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kCustomFloat>::Unpack(
-  void *dst, void *src, std::size_t count) const
+   void *dst, void *src, std::size_t count) const
 {
    float *floatArray = reinterpret_cast<float *>(dst);
    unsigned char *charArray = reinterpret_cast<unsigned char *>(src);
@@ -455,29 +529,24 @@ void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColu
       const std::uint8_t numCharUsedToStoreOneValue = kBitsOnStorage / 8;
       for (std::size_t i = 0; i < count; ++i) {
          std::uint64_t totalNumSteps{0};
-         for (int j = numCharUsedToStoreOneValue -1; j >= 0; --j) {
+         for (int j = numCharUsedToStoreOneValue - 1; j >= 0; --j) {
             totalNumSteps <<= 8;
-            totalNumSteps += charArray[numCharUsedToStoreOneValue*i+j];
+            totalNumSteps += charArray[numCharUsedToStoreOneValue * i + j];
          }
 
          switch (totalNumSteps) {
-            case 0:
-               floatArray[i] = std::numeric_limits<float>::infinity();
-               break;
-            case 1:
-               floatArray[i] = std::numeric_limits<float>::infinity() * (-1);
-               break;
-            case 2:
-               floatArray[i] = std::nan("");
-               break;
-            default:
-               totalNumSteps -= 3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
-               floatArray[i] = fMin + fStep * totalNumSteps;
-               break;
-         } // end switch
-      } // end for
-   } else { // end if
-      int index = 0; // of charArray, count is index of floatArray.
+         case 0: floatArray[i] = std::numeric_limits<float>::infinity(); break;
+         case 1: floatArray[i] = std::numeric_limits<float>::infinity() * (-1); break;
+         case 2: floatArray[i] = std::nan(""); break;
+         default:
+            totalNumSteps -=
+               3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
+            floatArray[i] = fMin + fStep * totalNumSteps;
+            break;
+         }                                           // end switch
+      }                                              // end for
+   } else {                                          // end if
+      int index = 0;                                 // of charArray, count is index of floatArray.
       short bitsPassedInCurrentCharArrayUpToNow = 0; // takes values from 0 to 7
 
       for (std::size_t i = 0; i < count; ++i) {
@@ -487,7 +556,7 @@ void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColu
          if (bitsPassedInCurrentCharArrayUpToNow != 0) {
             short nBitsToRead = std::min(8 - bitsPassedInCurrentCharArrayUpToNow, (int)unfilledNumBitsOfCurrentValue);
             // e.g. get 3 bits with mask 0b 0000'0111
-            short mask = (1 << nBitsToRead)-1;
+            short mask = (1 << nBitsToRead) - 1;
             short numBitsToShiftMask = 8 - bitsPassedInCurrentCharArrayUpToNow - nBitsToRead;
             mask <<= numBitsToShiftMask;
             totalNumSteps += (charArray[index] & mask);
@@ -509,24 +578,19 @@ void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColu
          }
          // Phase 3: Only empty what you need.
          if (unfilledNumBitsOfCurrentValue != 0) {
-            std::size_t toFill = charArray[index] >> (8-unfilledNumBitsOfCurrentValue);
+            std::size_t toFill = charArray[index] >> (8 - unfilledNumBitsOfCurrentValue);
             totalNumSteps += toFill * ((std::size_t)1 << (kBitsOnStorage - unfilledNumBitsOfCurrentValue));
             bitsPassedInCurrentCharArrayUpToNow += unfilledNumBitsOfCurrentValue;
          }
          switch (totalNumSteps) {
-            case 0:
-               floatArray[i] = std::numeric_limits<float>::infinity();
-               break;
-            case 1:
-               floatArray[i] = std::numeric_limits<float>::infinity() * (-1);
-               break;
-            case 2:
-               floatArray[i] = std::nan("");
-               break;
-            default:
-               totalNumSteps -= 3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
-               floatArray[i] = fMin + fStep * totalNumSteps;
-               break;
+         case 0: floatArray[i] = std::numeric_limits<float>::infinity(); break;
+         case 1: floatArray[i] = std::numeric_limits<float>::infinity() * (-1); break;
+         case 2: floatArray[i] = std::nan(""); break;
+         default:
+            totalNumSteps -=
+               3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
+            floatArray[i] = fMin + fStep * totalNumSteps;
+            break;
          }
       }
    }

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <bitset>
 #include <cstdint>
+#include <limits>
 
 ROOT::Experimental::Detail::RColumnElementBase
 ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType type) {
@@ -40,6 +41,16 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType type) {
       return RColumnElement<ClusterSize_t, EColumnType::kIndex>(nullptr);
    case EColumnType::kSwitch:
       return RColumnElement<RColumnSwitch, EColumnType::kSwitch>(nullptr);
+   case EColumnType::kReal24:
+      return RColumnElement<float, EColumnType::kReal24>(nullptr);
+   case EColumnType::kReal16:
+      return RColumnElement<float, EColumnType::kReal16>(nullptr);
+   case EColumnType::kReal8:
+      return RColumnElement<float, EColumnType::kReal8>(nullptr);
+   case EColumnType::kCustomDouble:
+      return RColumnElement<double, EColumnType::kCustomDouble>(nullptr);
+   case EColumnType::kCustomFloat:
+      return RColumnElement<float, EColumnType::kCustomFloat>(nullptr);
    default:
       R__ASSERT(false);
    }
@@ -77,6 +88,446 @@ void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColum
       bitSet = charArray[i / 8];
       for (std::size_t j = i; j < std::min(count, i + 8); ++j) {
          boolArray[j] = bitSet[j % 8];
+      }
+   }
+}
+
+// Way to pack: 1 sign bit, 7 exponent bits, 16 mantissa bits. (same as in Radeon R300 and R420)
+void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal24>::Pack(
+  void *dst, void *src, std::size_t count) const
+{
+   R__ASSERT(sizeof(float) == 4);
+   std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(src);
+   unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
+   for (std::size_t i = 0; i < count; ++i) {
+      std::bitset<32> floatFlags{ floatArray[i] };
+      std::bitset<8> flags{ 0 };
+      if (floatFlags.test(31)) flags.set(7);
+      if (floatFlags.test(30)) flags.set(6);
+      if (floatFlags.test(28)) flags.set(5);
+      if (floatFlags.test(27)) flags.set(4);
+      if (floatFlags.test(26)) flags.set(3);
+      if (floatFlags.test(25)) flags.set(2);
+      if (floatFlags.test(24)) flags.set(1);
+      if (floatFlags.test(23)) flags.set(0);
+      charArray[3*i] = flags.to_ulong();
+      charArray[3*i+1] = floatArray[i] >> 15;
+      charArray[3*i+2] = floatArray[i] >> 7;
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal24>::Unpack(
+  void *dst, void *src, std::size_t count) const
+{
+   R__ASSERT(sizeof(float) == 4);
+   std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(dst);
+   unsigned char *charArray = reinterpret_cast<unsigned char *>(src);
+   for (std::size_t i = 0; i < count; ++i) {
+      std::bitset<32> floatFlags{ 0 };
+      std::bitset<8> flags{ static_cast<unsigned long long>(charArray[3*i]) };
+      std::bitset<7> exponent{ static_cast<unsigned long long>(charArray[3*i]) };
+      if (flags.test(0)) floatFlags.set(23);
+      if (flags.test(1)) floatFlags.set(24);
+      if (flags.test(2)) floatFlags.set(25);
+      if (flags.test(3)) floatFlags.set(26);
+      if (flags.test(4)) floatFlags.set(27);
+      if (flags.test(5)) floatFlags.set(28);
+      if (flags.test(6)) floatFlags.set(30);
+         else floatFlags.set(29);
+      if (flags.test(7)) floatFlags.set(31);
+      if (exponent.all()) floatFlags.set(29); // infinity and NaN case
+         else if (exponent.none()) floatFlags.reset(29); // zero and denormalized number case
+      floatArray[i] = floatFlags.to_ulong() + charArray[3*i+1]*256*128 + charArray[3*i+2]*128;
+   }
+}
+
+// Way to pack: 1 sign bit, 5 exponent bits, 10 mantissa bits (as in IEE 754-2008)
+void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal16>::Pack(
+  void *dst, void *src, std::size_t count) const
+{
+   R__ASSERT(sizeof(float) == 4);
+   std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(src);
+   unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
+   for (std::size_t i = 0; i < count; ++i) {
+      std::bitset<32> floatFlags{ floatArray[i] };
+      std::bitset<8> flags{ 0 };
+      if (floatFlags.test(31)) flags.set(7);
+      if (floatFlags.test(30)) flags.set(6);
+      if (floatFlags.test(26)) flags.set(5);
+      if (floatFlags.test(25)) flags.set(4);
+      if (floatFlags.test(24)) flags.set(3);
+      if (floatFlags.test(23)) flags.set(2);
+      if (floatFlags.test(22)) flags.set(1); // first mantissa bit
+      if (floatFlags.test(21)) flags.set(0); // second mantissa bit
+      charArray[2*i] = flags.to_ulong();
+      charArray[2*i+1] = floatArray[i] >> 13;
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal16>::Unpack(
+  void *dst, void *src, std::size_t count) const
+{
+   R__ASSERT(sizeof(float) == 4);
+   std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(dst);
+   unsigned char *charArray = reinterpret_cast<unsigned char *>(src);
+   for (std::size_t i = 0; i < count; ++i) {
+      std::bitset<32> floatFlags{ 0 };
+      std::bitset<8> flags{ static_cast<unsigned long long>(charArray[2*i]) };
+      std::bitset<5> exponent{ static_cast<unsigned long long>(charArray[2*i] >> 2) };
+      if (flags.test(0)) floatFlags.set(21);
+      if (flags.test(1)) floatFlags.set(22);
+      if (flags.test(2)) floatFlags.set(23);
+      if (flags.test(3)) floatFlags.set(24);
+      if (flags.test(4)) floatFlags.set(25);
+      if (flags.test(5)) floatFlags.set(26);
+      if (flags.test(6)) floatFlags.set(30);
+         else { floatFlags.set(29); floatFlags.set(28); floatFlags.set(27); }
+      if (flags.test(7)) floatFlags.set(31);
+      if (exponent.all()) { floatFlags.set(29); floatFlags.set(28); floatFlags.set(27); } // infinity and NaN case
+         else if (exponent.none()) { floatFlags.reset(29); floatFlags.reset(28); floatFlags.reset(27); } // zero and denormalized number case
+      floatArray[i] = floatFlags.to_ulong() + charArray[2*i+1]*256*32;
+   }
+}
+
+// Way to pack: 1 sign bit, 3 exponent bits, 4 mantissa bits (same as in G.711)
+void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal8>::Pack(
+  void *dst, void *src, std::size_t count) const
+{
+   std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(src);
+   unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
+   for (std::size_t i = 0; i < count; ++i) {
+      std::bitset<32> floatFlags{ floatArray[i] };
+      std::bitset<8> flags{ 0 };
+      if (floatFlags.test(31)) flags.set(7);
+      if (floatFlags.test(30)) flags.set(6);
+      if (floatFlags.test(24)) flags.set(5);
+      if (floatFlags.test(23)) flags.set(4);
+      if (floatFlags.test(22)) flags.set(3); // first mantissa bit
+      if (floatFlags.test(21)) flags.set(2); // second mantissa bit
+      if (floatFlags.test(20)) flags.set(1); // third mantissa bit
+      if (floatFlags.test(19)) flags.set(0); // fourth mantissa bit
+      charArray[i] = flags.to_ulong();
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kReal8>::Unpack(
+  void *dst, void *src, std::size_t count) const
+{
+   R__ASSERT(sizeof(float) == 4);
+   std::uint32_t *floatArray = reinterpret_cast<std::uint32_t *>(dst);
+   char *charArray = reinterpret_cast<char *>(src);
+   for (std::size_t i = 0; i < count; ++i) {
+      std::bitset<32> floatFlags{ 0 };
+      std::bitset<8> flags{ static_cast<unsigned long long>(charArray[i]) };
+      std::bitset<3> exponent{ static_cast<unsigned long long>(charArray[i] >> 4) };
+      if (flags.test(0)) floatFlags.set(19);
+      if (flags.test(1)) floatFlags.set(20);
+      if (flags.test(2)) floatFlags.set(21);
+      if (flags.test(3)) floatFlags.set(22);
+      if (flags.test(4)) floatFlags.set(23);
+      if (flags.test(5)) floatFlags.set(24);
+      if (flags.test(6)) floatFlags.set(30);
+      else { floatFlags.set(29); floatFlags.set(28); floatFlags.set(27); floatFlags.set(26); floatFlags.set(25); }
+      if (flags.test(7)) floatFlags.set(31);
+      if (exponent.all()) { floatFlags.set(29); floatFlags.set(28); floatFlags.set(27); floatFlags.set(26); floatFlags.set(25); } // infinity and NaN case
+      else if (exponent.none()) { floatFlags.reset(29); floatFlags.reset(28); floatFlags.reset(27); floatFlags.reset(26); floatFlags.reset(25); } // zero and denormalized number case
+      floatArray[i] = floatFlags.to_ulong();
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::EColumnType::kCustomDouble>::Pack(
+  void *dst, void *src, std::size_t count) const
+{
+   double *doubleArray = reinterpret_cast<double *>(src);
+   unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
+   if (kBitsOnStorage % 8 == 0) { // use a faster procedure when %8 == 0
+      // check here for inf, nan, overflow
+      int numCharUsedToStoreOneValue = kBitsOnStorage / 8;
+      for (std::size_t i = 0; i < count; ++i) {
+         std::size_t totalNumSteps;
+         if (std::isnan(doubleArray[i])) totalNumSteps = 2; // NaN
+         else if (doubleArray[i] > fMax) totalNumSteps = 0; // overflow/positive infinity
+         else if (doubleArray[i] < fMin) totalNumSteps = 1; // underflow/negative infinity
+         else totalNumSteps = std::llround( (doubleArray[i]-fMin) / fStep) + 3;
+         for (int j = 0; j < numCharUsedToStoreOneValue; ++j) {
+            charArray[numCharUsedToStoreOneValue*i+j] = (totalNumSteps & 0xFF);
+            totalNumSteps >>= 8;
+         }
+      }
+   } else {
+      int index = 0; // of charArray, count is index of doubleArray.
+      short bitsFilledInCurrentCharArrayUpToNow = 0; // takes values from 0 to 7
+      for (std::size_t i = 0; i < count; ++i) {
+         short unfilledNumBitsOfCurrentValue = kBitsOnStorage;
+         std::size_t totalNumSteps;
+         if (std::isnan(doubleArray[i])) totalNumSteps = 2; // NaN
+         else if (doubleArray[i] > fMax) totalNumSteps = 0; // overflow/positive infinity
+         else if (doubleArray[i] < fMin) totalNumSteps = 1; // underflow/negative infinity
+         else totalNumSteps = std::llround( (doubleArray[i]-fMin) / fStep) + 3;
+         if (bitsFilledInCurrentCharArrayUpToNow != 0) {
+            std::size_t nBitsToFill = std::min((int)kBitsOnStorage, (8 - bitsFilledInCurrentCharArrayUpToNow));
+            short mask = (1 << nBitsToFill)-1;
+            unsigned char ToAdd {static_cast<unsigned char>(totalNumSteps & mask)};
+            ToAdd <<= (8 - bitsFilledInCurrentCharArrayUpToNow - nBitsToFill);
+            charArray[index] += ToAdd; //>>= nBitsToFill);
+            totalNumSteps >>= nBitsToFill;
+            bitsFilledInCurrentCharArrayUpToNow += nBitsToFill;
+            R__ASSERT(bitsFilledInCurrentCharArrayUpToNow <= 8);
+            unfilledNumBitsOfCurrentValue -= nBitsToFill;
+            if (bitsFilledInCurrentCharArrayUpToNow == 8) {
+               ++index;
+               bitsFilledInCurrentCharArrayUpToNow = 0;
+            } else {
+               continue;
+            }
+         }
+         // Fill where entire 8 bits can be filled at once, with while loop instead of a for loop.
+         while(unfilledNumBitsOfCurrentValue >= 8) {
+            charArray[index] = (totalNumSteps & 0xFF);
+            totalNumSteps >>= 8;
+            ++index;
+            unfilledNumBitsOfCurrentValue -= 8;
+         }
+         // Fill remaining bits (smaller than 8).
+         if (unfilledNumBitsOfCurrentValue != 0) {
+            charArray[index] = totalNumSteps << (8-unfilledNumBitsOfCurrentValue);
+            bitsFilledInCurrentCharArrayUpToNow = unfilledNumBitsOfCurrentValue;
+         }
+      }
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::EColumnType::kCustomDouble>::Unpack(
+  void *dst, void *src, std::size_t count) const
+{
+   double *doubleArray = reinterpret_cast<double *>(dst);
+   unsigned char *charArray = reinterpret_cast<unsigned char *>(src);
+   if (kBitsOnStorage % 8 == 0) {
+      const std::uint8_t numCharUsedToStoreOneValue = kBitsOnStorage / 8;
+      for (std::size_t i = 0; i < count; ++i) {
+         std::uint64_t totalNumSteps{0};
+         for (int j = numCharUsedToStoreOneValue -1; j >= 0; --j) {
+            totalNumSteps <<= 8;
+            totalNumSteps += charArray[numCharUsedToStoreOneValue*i+j];
+         }
+
+         switch (totalNumSteps) {
+            case 0:
+               doubleArray[i] = std::numeric_limits<double>::infinity();
+               break;
+            case 1:
+               doubleArray[i] = std::numeric_limits<double>::infinity() * (-1);
+               break;
+            case 2:
+               doubleArray[i] = std::nan("");
+               break;
+            default:
+               totalNumSteps -= 3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
+               doubleArray[i] = fMin + fStep * totalNumSteps;
+               break;
+         }
+      }
+   } else {
+      int index = 0; // of charArray, count is index of doubleArray.
+      short bitsPassedInCurrentCharArrayUpToNow = 0; // takes values from 0 to 7
+
+      for (std::size_t i = 0; i < count; ++i) {
+         short unfilledNumBitsOfCurrentValue = kBitsOnStorage;
+         std::uint64_t totalNumSteps{0};
+         // Phase 1: Use up unfinished char.
+         if (bitsPassedInCurrentCharArrayUpToNow != 0) {
+            short nBitsToRead = std::min(8 - bitsPassedInCurrentCharArrayUpToNow, (int)unfilledNumBitsOfCurrentValue);
+            // e.g. get 3 bits with mask 0b 0000'0111
+            short mask = (1 << nBitsToRead)-1;
+            short numBitsToShiftMask = 8 - bitsPassedInCurrentCharArrayUpToNow - nBitsToRead;
+            mask <<= numBitsToShiftMask;
+            totalNumSteps += (charArray[index] & mask);
+            totalNumSteps >>= numBitsToShiftMask;
+            unfilledNumBitsOfCurrentValue -= nBitsToRead;
+            bitsPassedInCurrentCharArrayUpToNow += nBitsToRead;
+            R__ASSERT(bitsPassedInCurrentCharArrayUpToNow <= 8);
+            if (bitsPassedInCurrentCharArrayUpToNow == 8) {
+               ++index;
+               bitsPassedInCurrentCharArrayUpToNow = 0;
+            }
+         }
+         // Phase 2: Empty full char at a time.
+         while (unfilledNumBitsOfCurrentValue > 8) {
+            std::size_t filledNumBitsOfCurrentValue = kBitsOnStorage - unfilledNumBitsOfCurrentValue;
+            totalNumSteps += (std::size_t)charArray[index] * ((std::size_t)1 << filledNumBitsOfCurrentValue);
+            unfilledNumBitsOfCurrentValue -= 8;
+            ++index;
+         }
+         // Phase 3: Only empty what you need.
+         if (unfilledNumBitsOfCurrentValue != 0) {
+            std::size_t toFill = charArray[index] >> (8-unfilledNumBitsOfCurrentValue);
+            totalNumSteps += toFill * ((std::size_t)1 << (kBitsOnStorage - unfilledNumBitsOfCurrentValue));
+            bitsPassedInCurrentCharArrayUpToNow += unfilledNumBitsOfCurrentValue;
+         }
+         switch (totalNumSteps) {
+            case 0:
+               doubleArray[i] = std::numeric_limits<double>::infinity();
+               break;
+            case 1:
+               doubleArray[i] = std::numeric_limits<double>::infinity() * (-1);
+               break;
+            case 2:
+               doubleArray[i] = std::nan("");
+               break;
+            default:
+               totalNumSteps -= 3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
+               doubleArray[i] = fMin + fStep * totalNumSteps;
+               break;
+         }
+      }
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kCustomFloat>::Pack(
+  void *dst, void *src, std::size_t count) const
+{
+   float *floatArray = reinterpret_cast<float *>(src);
+   unsigned char *charArray = reinterpret_cast<unsigned char *>(dst);
+   if (kBitsOnStorage % 8 == 0) { // use a faster procedure when %8 == 0
+      // check here for inf, nan, overflow
+      int numCharUsedToStoreOneValue = kBitsOnStorage / 8;
+      for (std::size_t i = 0; i < count; ++i) {
+         std::size_t totalNumSteps;
+         if (std::isnan(floatArray[i])) totalNumSteps = 2; // NaN
+         else if (floatArray[i] > fMax) totalNumSteps = 0; // overflow/positive infinity
+         else if (floatArray[i] < fMin) totalNumSteps = 1; // underflow/negative infinity
+         else totalNumSteps = std::llround( (floatArray[i]-fMin) / fStep) + 3;
+         for (int j = 0; j < numCharUsedToStoreOneValue; ++j) {
+            charArray[numCharUsedToStoreOneValue*i+j] = (totalNumSteps & 0xFF);
+            totalNumSteps >>= 8;
+         }
+      }
+   } else {
+      int index = 0; // of charArray, count is index of doubleArray.
+      short bitsFilledInCurrentCharArrayUpToNow = 0; // takes values from 0 to 7
+      for (std::size_t i = 0; i < count; ++i) {
+         short unfilledNumBitsOfCurrentValue = kBitsOnStorage;
+         std::size_t totalNumSteps;
+         if (std::isnan(floatArray[i])) totalNumSteps = 2; // NaN
+         else if (floatArray[i] > fMax) totalNumSteps = 0; // overflow/positive infinity
+         else if (floatArray[i] < fMin) totalNumSteps = 1; // underflow/negative infinity
+         else totalNumSteps = std::llround( (floatArray[i]-fMin) / fStep) + 3;
+         if (bitsFilledInCurrentCharArrayUpToNow != 0) {
+            std::size_t nBitsToFill = std::min((int)kBitsOnStorage, (8 - bitsFilledInCurrentCharArrayUpToNow));
+            short mask = (1 << nBitsToFill)-1;
+            unsigned char ToAdd {static_cast<unsigned char>(totalNumSteps & mask)};
+            ToAdd <<= (8 - bitsFilledInCurrentCharArrayUpToNow - nBitsToFill);
+            charArray[index] += ToAdd; //>>= nBitsToFill);
+            totalNumSteps >>= nBitsToFill;
+            bitsFilledInCurrentCharArrayUpToNow += nBitsToFill;
+            R__ASSERT(bitsFilledInCurrentCharArrayUpToNow <= 8);
+            unfilledNumBitsOfCurrentValue -= nBitsToFill;
+            if (bitsFilledInCurrentCharArrayUpToNow == 8) {
+               ++index;
+               bitsFilledInCurrentCharArrayUpToNow = 0;
+            } else {
+               continue;
+            }
+         }
+         // Fill where entire 8 bits can be filled at once, with while loop instead of a for loop.
+         while(unfilledNumBitsOfCurrentValue >= 8) {
+            charArray[index] = (totalNumSteps & 0xFF);
+            totalNumSteps >>= 8;
+            ++index;
+            unfilledNumBitsOfCurrentValue -= 8;
+         }
+
+         // Fill remaining bits (smaller than 8).
+         if (unfilledNumBitsOfCurrentValue != 0) {
+            charArray[index] = totalNumSteps << (8-unfilledNumBitsOfCurrentValue);
+            bitsFilledInCurrentCharArrayUpToNow = unfilledNumBitsOfCurrentValue;
+         }
+      }
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<float, ROOT::Experimental::EColumnType::kCustomFloat>::Unpack(
+  void *dst, void *src, std::size_t count) const
+{
+   float *floatArray = reinterpret_cast<float *>(dst);
+   unsigned char *charArray = reinterpret_cast<unsigned char *>(src);
+   if (kBitsOnStorage % 8 == 0) {
+      const std::uint8_t numCharUsedToStoreOneValue = kBitsOnStorage / 8;
+      for (std::size_t i = 0; i < count; ++i) {
+         std::uint64_t totalNumSteps{0};
+         for (int j = numCharUsedToStoreOneValue -1; j >= 0; --j) {
+            totalNumSteps <<= 8;
+            totalNumSteps += charArray[numCharUsedToStoreOneValue*i+j];
+         }
+
+         switch (totalNumSteps) {
+            case 0:
+               floatArray[i] = std::numeric_limits<float>::infinity();
+               break;
+            case 1:
+               floatArray[i] = std::numeric_limits<float>::infinity() * (-1);
+               break;
+            case 2:
+               floatArray[i] = std::nan("");
+               break;
+            default:
+               totalNumSteps -= 3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
+               floatArray[i] = fMin + fStep * totalNumSteps;
+               break;
+         } // end switch
+      } // end for
+   } else { // end if
+      int index = 0; // of charArray, count is index of floatArray.
+      short bitsPassedInCurrentCharArrayUpToNow = 0; // takes values from 0 to 7
+
+      for (std::size_t i = 0; i < count; ++i) {
+         short unfilledNumBitsOfCurrentValue = kBitsOnStorage;
+         std::uint64_t totalNumSteps{0};
+         // Phase 1: Use up unfinished char.
+         if (bitsPassedInCurrentCharArrayUpToNow != 0) {
+            short nBitsToRead = std::min(8 - bitsPassedInCurrentCharArrayUpToNow, (int)unfilledNumBitsOfCurrentValue);
+            // e.g. get 3 bits with mask 0b 0000'0111
+            short mask = (1 << nBitsToRead)-1;
+            short numBitsToShiftMask = 8 - bitsPassedInCurrentCharArrayUpToNow - nBitsToRead;
+            mask <<= numBitsToShiftMask;
+            totalNumSteps += (charArray[index] & mask);
+            totalNumSteps >>= numBitsToShiftMask;
+            unfilledNumBitsOfCurrentValue -= nBitsToRead;
+            bitsPassedInCurrentCharArrayUpToNow += nBitsToRead;
+            R__ASSERT(bitsPassedInCurrentCharArrayUpToNow <= 8);
+            if (bitsPassedInCurrentCharArrayUpToNow == 8) {
+               ++index;
+               bitsPassedInCurrentCharArrayUpToNow = 0;
+            }
+         }
+         // Phase 2: Empty full char at a time.
+         while (unfilledNumBitsOfCurrentValue > 8) {
+            std::size_t filledNumBitsOfCurrentValue = kBitsOnStorage - unfilledNumBitsOfCurrentValue;
+            totalNumSteps += (std::size_t)charArray[index] * ((std::size_t)1 << filledNumBitsOfCurrentValue);
+            unfilledNumBitsOfCurrentValue -= 8;
+            ++index;
+         }
+         // Phase 3: Only empty what you need.
+         if (unfilledNumBitsOfCurrentValue != 0) {
+            std::size_t toFill = charArray[index] >> (8-unfilledNumBitsOfCurrentValue);
+            totalNumSteps += toFill * ((std::size_t)1 << (kBitsOnStorage - unfilledNumBitsOfCurrentValue));
+            bitsPassedInCurrentCharArrayUpToNow += unfilledNumBitsOfCurrentValue;
+         }
+         switch (totalNumSteps) {
+            case 0:
+               floatArray[i] = std::numeric_limits<float>::infinity();
+               break;
+            case 1:
+               floatArray[i] = std::numeric_limits<float>::infinity() * (-1);
+               break;
+            case 2:
+               floatArray[i] = std::nan("");
+               break;
+            default:
+               totalNumSteps -= 3; // because 0, 1 and 2 have special meanings, totalNumSteps = 3 represents the same value as fMin.
+               floatArray[i] = fMin + fStep * totalNumSteps;
+               break;
+         }
       }
    }
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -87,6 +87,16 @@ static std::string GetColumnTypeName(ROOT::Experimental::EColumnType type)
       return "Index";
    case ROOT::Experimental::EColumnType::kSwitch:
       return "Switch";
+   case ROOT::Experimental::EColumnType::kReal24:
+      return "kReal24";
+   case ROOT::Experimental::EColumnType::kReal16:
+      return "kReal16";
+   case ROOT::Experimental::EColumnType::kReal8:
+      return "kReal8";
+   case ROOT::Experimental::EColumnType::kCustomDouble:
+      return "CustomDouble";
+   case ROOT::Experimental::EColumnType::kCustomFloat:
+      return "CustomFloat";
    default:
       return "UNKNOWN";
    }

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -17,6 +17,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(CustomStruct
                               LINKDEF CustomStructLinkDef.h
                               DEPENDENCIES RIO)
 ROOT_ADD_GTEST(ntuple ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+ROOT_ADD_GTEST(ntuple_float ntuple_float.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_packing ntuple_packing.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_pages ntuple_pages.cxx LIBRARIES ROOTNTuple)

--- a/tree/ntuple/v7/test/ntuple_float.cxx
+++ b/tree/ntuple/v7/test/ntuple_float.cxx
@@ -1,0 +1,514 @@
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <TFile.h>
+
+#include "gtest/gtest.h"
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+using RNTupleReader = ROOT::Experimental::RNTupleReader;
+using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
+using RNTupleModel = ROOT::Experimental::RNTupleModel;
+using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
+using float24_t = ROOT::Experimental::float24_t;
+using float16_t = ROOT::Experimental::float16_t;
+using float8_t = ROOT::Experimental::float8_t;
+using ENTupleInfo = ROOT::Experimental::ENTupleInfo;
+
+template <class T>
+using RField = ROOT::Experimental::RField<T>;
+
+namespace {
+
+/**
+ * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
+ * goes out of scope.
+ */
+class FileRaii {
+private:
+   std::string fPath;
+public:
+   explicit FileRaii(const std::string &path) : fPath(path) { }
+   FileRaii(const FileRaii&) = delete;
+   FileRaii& operator=(const FileRaii&) = delete;
+   ~FileRaii() { std::remove(fPath.c_str()); }
+   std::string GetPath() const { return fPath; }
+};
+
+} // anonymous namespace
+
+TEST(RNTupleFloat, float24_t)
+{
+   FileRaii fileGuard("test_ntuple_float_float24_t.root");
+   const std::string_view ntupleName{"float24_NTuple"};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float24_t>("ft24");
+      auto fieldVec = model->MakeField<std::vector<float24_t>>("ft24vec");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      for (int i = 0; i < 100; ++i) {
+         *fieldPt = i + 0.1 * i;
+         *fieldVec = { i+0.1*i, i+0.1*i};
+         ntuple->Fill();
+      }
+      for (int i = 0; i < 100; ++i) {
+         *fieldPt = i * 1200;
+         *fieldVec = { i*1200, i*1200, i*1200 };
+         ntuple->Fill();
+      }
+      *fieldPt = -1.0f/0; // negative infinity
+      *fieldVec = { -1.0f/0, -1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 1.0f/0; // positive infinity
+      *fieldVec = { 1.0f/0, 1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 0.0f/0; // NaN (Not A Number)
+      *fieldVec = { 0.0f/0 };
+      ntuple->Fill();
+   }
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float24_t>("ft24");
+   auto fieldVec = model->MakeField<std::vector<float24_t>>("ft24vec");
+   auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
+   auto float24View = ntuple->GetView<float24_t>("ft24");
+   auto vec24View = ntuple->GetView<std::vector<float24_t>>("ft24vec");
+   for (int i = 0; i < 100; ++i) {
+      EXPECT_NEAR(i + 0.1*i, float24View(i), 0.001); // EXPECT_FLOAT_EQ will fail here, so use EXPECT_NEAR instead.
+      EXPECT_NEAR(i + 0.1*i, vec24View(i).at(1), 0.001);
+      EXPECT_EQ(i*1200.0f, float24View(i+100));
+      EXPECT_EQ(i*1200.0f, vec24View(i+100).at(2));
+      ntuple->LoadEntry(i);
+      EXPECT_NEAR(i + 0.1*i, *fieldPt, 0.001);
+      EXPECT_NEAR(i + 0.1*i, (*fieldVec).at(1), 0.001);
+      ntuple->LoadEntry(i+100);
+      EXPECT_EQ(i*1200.0f, *fieldPt);
+      EXPECT_EQ(i*1200.0f, (*fieldVec).at(2));
+   }
+   EXPECT_EQ(true, std::isinf(float24View(200)));
+   EXPECT_EQ(true, std::isinf(vec24View(200).at(1)));
+   EXPECT_EQ(true, std::isinf(float24View(201)));
+   EXPECT_EQ(true, std::isinf(vec24View(201).at(1)));
+   EXPECT_EQ(true, std::isnan(float24View(202)));
+   EXPECT_EQ(true, std::isnan(vec24View(202).at(0)));
+   std::ostringstream os;
+   // Only check if calling PrintInfo does not lead to error.
+   ntuple->PrintInfo(ENTupleInfo::kSummary, os);
+   ntuple->PrintInfo(ENTupleInfo::kStorageDetails, os);
+   auto autoGenerateModel = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
+}
+
+TEST(RNTupleFloat, float16_t)
+{
+   FileRaii fileGuard("test_ntuple_float_float16_t.root");
+   const std::string_view ntupleName{"float16_t NTuple"};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float16_t>("ft16");
+      auto fieldVec = model->MakeField<std::array<float16_t, 2>>("ft16vec");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      for (int i = 0; i < 100; ++i) {
+         *fieldPt = 0.1 * i;
+         *fieldVec = { 0.1*i, 0.1*i };
+         ntuple->Fill();
+      }
+      for (int i = 0; i < 100; ++i) {
+         *fieldPt = i * 12;
+         *fieldVec = { 12*i, 12*i };
+         ntuple->Fill();
+      }
+      *fieldPt = -1.0f/0; // negative infinity
+      *fieldVec = { -1.0f/0, -1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 1.0f/0; // positive infinity
+      *fieldVec = { 1.0f/0, 1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 0.0f/0; // NaN (Not A Number)
+      *fieldVec = { 0.0f/0, 0.0f/0 };
+      ntuple->Fill();
+   }
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float16_t>("ft16");
+   auto fieldVec = model->MakeField<std::array<float16_t, 2>>("ft16vec");
+   auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
+   auto float16View = ntuple->GetView<float16_t>("ft16");
+   auto vec16View = ntuple->GetView<std::array<float16_t, 2>>("ft16vec");
+   for (int i = 0; i < 100; ++i) {
+      EXPECT_NEAR(0.1*i, float16View(i), 0.01); // EXPECT_FLOAT_EQ will fail here, so use EXPECT_NEAR instead.
+      EXPECT_NEAR(0.1*i, vec16View(i).at(1), 0.01);
+      EXPECT_EQ(i*12.0f, float16View(i+100));
+      EXPECT_EQ(i*12.0f, vec16View(i+100).at(1));
+      ntuple->LoadEntry(i);
+      EXPECT_NEAR(0.1*i, *fieldPt, 0.01);
+      EXPECT_NEAR(0.1*i, (*fieldVec).at(1), 0.01);
+      ntuple->LoadEntry(i+100);
+      EXPECT_EQ(i*12.0f, *fieldPt);
+      EXPECT_EQ(i*12.0f, (*fieldVec).at(1));
+   }
+   EXPECT_EQ(true, std::isinf(float16View(200)));
+   EXPECT_EQ(true, std::isinf(vec16View(200).at(1)));
+   EXPECT_EQ(true, std::isinf(float16View(201)));
+   EXPECT_EQ(true, std::isinf(vec16View(201).at(1)));
+   EXPECT_EQ(true, std::isnan(float16View(202)));
+   EXPECT_EQ(true, std::isnan(vec16View(202).at(1)));
+   std::ostringstream os;
+   // Only check if calling PrintInfo does not lead to error.
+   ntuple->PrintInfo(ENTupleInfo::kSummary, os);
+   ntuple->PrintInfo(ENTupleInfo::kStorageDetails, os);
+}
+
+TEST(RNTupleFloat, float8_t)
+{
+   FileRaii fileGuard("test_ntuple_float_float8_t.root");
+   const std::string_view ntupleName{"float8_t NTuple"};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float8_t>("ft8");
+      auto fieldVec = model->MakeField<std::vector<float8_t>>("ft8vec");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      for (int i = 0; i < 32; ++i) {
+         *fieldPt = 0.5f * i;
+         *fieldVec = { 0.5f * i, 0.5f * i, 0.5f * i };
+         ntuple->Fill();
+      }
+      *fieldPt = -1.0f/0; // negative infinity
+      *fieldVec = { -1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 1.0f/0; // positive infinity
+      *fieldVec = { 1.0f/0, 1.0f/0, 1.0f/0, 1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 0.0f/0; // NaN (Not A Number)
+      *fieldVec = { 0.0f/0 };
+      ntuple->Fill();
+   }
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float8_t>("ft8");
+   auto fieldVec = model->MakeField<std::vector<float8_t>>("ft8vec");
+   auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
+   auto float8View = ntuple->GetView<float8_t>("ft8");
+   auto vec8View = ntuple->GetView<std::vector<float8_t>>("ft8vec");
+   for (int i = 0; i < 32; ++i) {
+      EXPECT_EQ(0.5f*i, float8View(i)); // EXPECT_FLOAT_EQ will fail here, so use EXPECT_NEAR instead.
+      EXPECT_EQ(0.5f*i, vec8View(i).at(2));
+      ntuple->LoadEntry(i);
+      EXPECT_EQ(0.5f*i, *fieldPt);
+      EXPECT_EQ(0.5f*i, (*fieldVec).at(2));
+   }
+   EXPECT_EQ(true, std::isinf(float8View(32)));
+   EXPECT_EQ(true, std::isinf(vec8View(32).at(0)));
+   EXPECT_EQ(true, std::isinf(float8View(33)));
+   EXPECT_EQ(true, std::isinf(vec8View(33).at(3)));
+   EXPECT_EQ(true, std::isnan(float8View(34)));
+   EXPECT_EQ(true, std::isnan(vec8View(34).at(0)));
+   std::ostringstream os;
+   // Only check if calling PrintInfo does not lead to error.
+   ntuple->PrintInfo(ENTupleInfo::kSummary, os);
+   ntuple->PrintInfo(ENTupleInfo::kStorageDetails, os);
+}
+
+// Test the case where number of bits is divisible by 8.
+TEST(RNTupleMinMaxDefinedFloat, 24bitDouble)
+{
+   FileRaii fileGuard("test_ntuple_float_MinMaxDefinedFloat_24bit.root");
+   const std::string_view ntupleName{"CustomFloatNTuple24bit"};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<double, 24, 0, 1>("ftcustom");
+      auto fieldVec = model->MakeField<std::vector<double>, 24, 0, 1>("ftcustom2");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      for (int i = 0; i < 100; ++i) {
+         *fieldPt = i*0.01;
+         *fieldVec = { i*0.005, i*0.01 };
+         ntuple->Fill();
+      }
+      *fieldPt = -1.0/0; // negative infinity
+      *fieldVec = { -1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 1.0/0; // positive infinity
+      *fieldVec = { 1.0f/0, 1.0f/0, 1.0f/0, 1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 0.0/0; // NaN (Not A Number)
+      *fieldVec = { 0.0f/0 };
+      ntuple->Fill();
+   } // flush contents to .root file.
+
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<double, 24, 0, 1>("ftcustom");
+   auto fieldVec = model->MakeField<std::vector<double>, 24, 0, 1>("ftcustom2");
+   auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
+   auto view = ntuple->GetView<double, 24, 0, 1>("ftcustom");
+   for (int i = 0; i < 100; ++i) {
+      EXPECT_NEAR(i*0.01, view(i), 0.000001);
+      ntuple->LoadEntry(i);
+      EXPECT_NEAR(i*0.01, *fieldPt, 0.000001);
+      EXPECT_NEAR(i*0.01, (*fieldVec).at(1), 0.000001);
+   }
+   EXPECT_EQ(true, std::isinf(view(100)));
+   ntuple->LoadEntry(100);
+   EXPECT_EQ(true, std::isinf(*fieldPt));
+   EXPECT_EQ(true, std::isinf((*fieldVec).at(0)));
+   EXPECT_EQ(true, std::isinf(view(101)));
+   ntuple->LoadEntry(101);
+   EXPECT_EQ(true, std::isinf((*fieldVec).at(3)));
+   EXPECT_EQ(true, std::isnan(view(102)));
+   ntuple->LoadEntry(102);
+   EXPECT_EQ(true, std::isnan((*fieldVec).at(0)));
+}
+
+TEST(RNTupleMinMaxDefinedFloat, 47bit)
+{
+   FileRaii fileGuard("test_ntuple_float_MinMaxDefinedFloat_47bit.root");
+   const std::string_view ntupleName{"CustomFloatNTuple47bit"};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<double, 47, -50, 100>("ftcustom");
+      auto fieldVec = model->MakeField<std::vector<double>, 47, -50, 100>("ftcustom2");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      for (int i = -500; i <= 1000; ++i) {
+         *fieldPt = i*0.1;
+         *fieldVec = { 4.0, i*0.1 };
+         ntuple->Fill();
+      }
+      *fieldPt = -1.0/0; // negative infinity
+      *fieldVec = { -1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 1.0/0; // positive infinity
+      *fieldVec = { 1.0f/0, 1.0f/0, 1.0f/0, 1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 0.0/0; // NaN (Not A Number)
+      *fieldVec = { 0.0f/0 };
+      ntuple->Fill();
+   } // flush contents to .root file.
+
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<double, 47, -50, 100>("ftcustom");
+   auto fieldVec = model->MakeField<std::vector<double>, 47, -50, 100>("ftcustom2");
+   auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
+   auto view = ntuple->GetView<double, 47, -50, 100>("ftcustom");
+   auto viewVec = ntuple->GetView<std::vector<double>, 47, -50, 100>("ftcustom2");
+   for (int i = 0; i < 1501; ++i) {
+      EXPECT_NEAR(((int)i-500)*0.1, view(i), 0.000001);
+      EXPECT_NEAR(((int)i-500)*0.1, viewVec(i).at(1), 0.000001);
+      ntuple->LoadEntry(i);
+      EXPECT_NEAR(((int)i-500)*0.1, *fieldPt, 0.000001);
+      EXPECT_NEAR(((int)i-500)*0.1, (*fieldVec).at(1), 0.000001);
+   }
+   EXPECT_EQ(true, std::isinf(view(1501)));
+   EXPECT_EQ(true, std::isinf(viewVec(1501).at(0)));
+   ntuple->LoadEntry(1501);
+   EXPECT_EQ(true, std::isinf(*fieldPt));
+   EXPECT_EQ(true, std::isinf((*fieldVec).at(0)));
+   EXPECT_EQ(true, std::isinf(view(1502)));
+   EXPECT_EQ(true, std::isinf(viewVec(1502).at(3)));
+   ntuple->LoadEntry(1502);
+   EXPECT_EQ(true, std::isinf(*fieldPt));
+   EXPECT_EQ(true, std::isinf((*fieldVec).at(2)));
+   EXPECT_EQ(true, std::isnan(view(1503)));
+   EXPECT_EQ(true, std::isnan(viewVec(1503).at(0)));
+   ntuple->LoadEntry(1503);
+   EXPECT_EQ(true, std::isnan(*fieldPt));
+   EXPECT_EQ(true, std::isnan((*fieldVec).at(0)));
+   
+   // Only checks if calling these functions leads to error, output is not checked.
+   auto ntuple2 = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
+   std::ostringstream os;
+   ntuple->PrintInfo(ENTupleInfo::kSummary, os);
+   ntuple->PrintInfo(ENTupleInfo::kStorageDetails, os);
+}
+
+TEST(RNTupleMinMaxDefinedFloat, 7bit)
+{
+   FileRaii fileGuard("test_ntuple_float_MinMaxDefinedFloat_7bit.root");
+   const std::string_view ntupleName{"CustomFloatNTuple7bit"};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<double, 7, -101, -80>("ftcustom");
+      auto fieldArray = model->MakeField<std::array<double, 2>, 7, -101, -80>("ftcustom2");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      for (int i = -100; i <= -80; ++i) {
+         *fieldPt = i;
+         *fieldArray = {static_cast<double>(i), static_cast<double>(i)};
+         ntuple->Fill();
+      }
+      *fieldPt = -1.0/0; // negative infinity
+      *fieldArray = { -1.0/0 , 0};
+      ntuple->Fill();
+      *fieldPt = 1.0/0; // positive infinity
+      *fieldArray = { 1.0/0, 1.0/0 };
+      ntuple->Fill();
+      *fieldPt = 0.0/0; // NaN (Not A Number)
+      *fieldArray = { 0.0/0, 0 };
+      ntuple->Fill();
+   } // flush contents to .root file.
+
+   // generate model from descriptor
+   auto ntuple = RNTupleReader::Open( ntupleName, fileGuard.GetPath());
+   auto view = ntuple->GetView<double, 7, -101, -80>("ftcustom");
+   auto arrayView = ntuple->GetView<std::array<double, 2>, 7, -101, -80>("ftcustom2");
+   for (int i = -100; i <= -80; ++i) {
+      EXPECT_NEAR(i, view(i+100), 0.1);
+      EXPECT_NEAR(i, arrayView(i+100).at(1), 0.1);
+   }
+   EXPECT_EQ(true, std::isinf(view(21)));
+   EXPECT_EQ(true, std::isinf(arrayView(21).at(0)));
+   EXPECT_EQ(true, std::isinf(view(22)));
+   EXPECT_EQ(true, std::isinf(arrayView(22).at(1)));
+   EXPECT_EQ(true, std::isnan(view(23)));
+   EXPECT_EQ(true, std::isnan(arrayView(23).at(0)));
+}
+
+TEST(RNTupleMinMaxDefinedFloat, 40bitFloat)
+{
+   FileRaii fileGuard("test_ntuple_float_MinMaxDefinedFloat_40bitFloat.root");
+   const std::string_view ntupleName{"CustomFloatNTuple40bitFloat"};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float, 40, 0, 1>("ftcustom");
+      auto arrayField = model->MakeField<std::array<float, 3>, 40, 0, 1>("ftcustom2");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      for (int i = 0; i < 100; ++i) {
+         *fieldPt = i*0.01f;
+         *arrayField = {i*0.01f, i*0.005f, 0};
+         ntuple->Fill();
+      }
+      *fieldPt = -1.0f/0; // negative infinity
+      *arrayField = { -1.0f/0, 0, 0 };
+      ntuple->Fill();
+      *fieldPt = 1.0f/0; // positive infinity
+      *arrayField = { 1.0f/0, 1.0f/0, 1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 0.0f/0; // NaN (Not A Number)
+      *arrayField = { 0.0f/0, 0, 0.0f/0 };
+      ntuple->Fill();
+   } // flush contents to .root file.
+
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float, 40, 0, 1>("ftcustom");
+   auto arrayField = model->MakeField<std::array<float, 3>, 40, 0, 1>("ftcustom2");
+   auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
+   auto view = ntuple->GetView<float, 40, 0, 1>("ftcustom");
+   auto arrayView = ntuple->GetView<std::array<float, 3>, 40, 0, 1>("ftcustom2");
+   for (int i = 0; i < 100; ++i) {
+      EXPECT_NEAR(i*0.01, view(i), 0.000001);
+      EXPECT_NEAR(i*0.01, arrayView(i).at(0), 0.000001);
+      ntuple->LoadEntry(i);
+      EXPECT_NEAR(i*0.01, *fieldPt, 0.000001);
+      EXPECT_NEAR(i*0.01, (*arrayField).at(0), 0.000001);
+   }
+   EXPECT_EQ(true, std::isinf(view(100)));
+   EXPECT_EQ(true, std::isinf(arrayView(100).at(0)));
+   ntuple->LoadEntry(100);
+   EXPECT_EQ(true, std::isinf(*fieldPt));
+   EXPECT_EQ(true, std::isinf((*arrayField).at(0)));
+   EXPECT_EQ(true, std::isinf(view(101)));
+   EXPECT_EQ(true, std::isinf(arrayView(101).at(2)));
+   ntuple->LoadEntry(101);
+   EXPECT_EQ(true, std::isinf(*fieldPt));
+   EXPECT_EQ(true, std::isinf((*arrayField).at(2)));
+   EXPECT_EQ(true, std::isnan(view(102)));
+   EXPECT_EQ(true, std::isnan(arrayView(102).at(2)));
+   ntuple->LoadEntry(102);
+   EXPECT_EQ(true, std::isnan(*fieldPt));
+   EXPECT_EQ(true, std::isnan((*arrayField).at(2)));
+}
+
+TEST(RNTupleMinMaxDefinedFloat, 23bitFloat)
+{
+   FileRaii fileGuard("test_ntuple_float_MinMaxDefinedFloat_23bitFloat.root");
+   const std::string_view ntupleName{"CustomFloatNTuple23bitFloat"};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float, 23, -50, 100>("ftcustom");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      for (int i = -500; i <= 1000; ++i) {
+         *fieldPt = i*0.1;
+         ntuple->Fill();
+      }
+      *fieldPt = -1.0/0; // negative infinity
+      ntuple->Fill();
+      *fieldPt = 1.0/0; // positive infinity
+      ntuple->Fill();
+      *fieldPt = 0.0/0; // NaN (Not A Number)
+      ntuple->Fill();
+   } // flush contents to .root file.
+
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float, 23, -50, 100>("ftcustom");
+   auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
+   auto view = ntuple->GetView<float, 23, -50, 100>("ftcustom");
+   for (int i = 0; i < 1501; ++i) {
+      EXPECT_NEAR(((int)i-500)*0.1, view(i), 0.0001);
+      ntuple->LoadEntry(i);
+      EXPECT_NEAR(((int)i-500)*0.1, *fieldPt, 0.0001);
+   }
+   EXPECT_EQ(true, std::isinf(view(1501)));
+   ntuple->LoadEntry(1501);
+   EXPECT_EQ(true, std::isinf(*fieldPt));
+   EXPECT_EQ(true, std::isinf(view(1502)));
+   ntuple->LoadEntry(1502);
+   EXPECT_EQ(true, std::isinf(*fieldPt));
+   EXPECT_EQ(true, std::isnan(view(1503)));
+   ntuple->LoadEntry(1503);
+   EXPECT_EQ(true, std::isnan(*fieldPt));
+}
+
+TEST(RNTupleMinMaxDefinedFloat, 5bit)
+{
+   FileRaii fileGuard("test_ntuple_float_MinMaxDefinedFloat_5bitFloat.root");
+   const std::string_view ntupleName{"CustomFloatNTuple5bitFloat"};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float, 5, -101, -80>("ftcustom");
+      auto vecField = model->MakeField<std::vector<float>, 5, -101, -80>("ftcustom2");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
+      for (int i = -100; i <= -80; ++i) { // eig. bis 80
+         *fieldPt = static_cast<float>(i);
+         *vecField = { static_cast<float>(i), -100.0f };
+         ntuple->Fill();
+      }
+      *fieldPt = -1.0f/0; // negative infinity
+      *vecField = { -1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 1.0f/0; // positive infinity
+      *vecField = { 1.0f/0, 1.0f/0, 1.0f/0, 1.0f/0 };
+      ntuple->Fill();
+      *fieldPt = 0.0f/0; // NaN (Not A Number)
+      *vecField = { 0.0f/0 };
+      ntuple->Fill();
+   } // flush contents to .root file.
+   auto model = RNTupleModel::Create();
+   auto fieldPt = model->MakeField<float, 5, -101, -80>("ftcustom");
+   auto vecField = model->MakeField<std::vector<float>, 5, -101, -80>("ftcustom2");
+   auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
+   auto view = ntuple->GetView<float, 5, -101, -80>("ftcustom");
+   auto vecView = ntuple->GetView<std::vector<float>, 5, -101, -80>("ftcustom2");
+   for (int i = -100; i <= -80; ++i) {
+      EXPECT_NEAR(i, view(i+100), 0.25);
+      EXPECT_NEAR(i, vecView(i+100).at(0), 0.25);
+      ntuple->LoadEntry(i+100);
+      EXPECT_NEAR(i, *fieldPt, 0.25);
+      EXPECT_NEAR(i, (*vecField).at(0), 0.25);
+   }
+   EXPECT_EQ(true, std::isinf(view(21)));
+   EXPECT_EQ(true, std::isinf(vecView(21).at(0)));
+   ntuple->LoadEntry(21);
+   EXPECT_EQ(true, std::isinf(*fieldPt));
+   EXPECT_EQ(true, std::isinf((*vecField).at(0)));
+   EXPECT_EQ(true, std::isinf(view(22)));
+   EXPECT_EQ(true, std::isinf(vecView(22).at(3)));
+   ntuple->LoadEntry(22);
+   EXPECT_EQ(true, std::isinf(*fieldPt));
+   EXPECT_EQ(true, std::isinf((*vecField).at(3)));
+   EXPECT_EQ(true, std::isnan(view(23)));
+   EXPECT_EQ(true, std::isnan(vecView(23).at(0)));
+   ntuple->LoadEntry(23);
+   EXPECT_EQ(true, std::isnan(*fieldPt));
+   EXPECT_EQ(true, std::isnan((*vecField).at(0)));
+
+   // Only checks if calling these functions leads to error, output is not checked.
+   auto ntuple2 = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
+   std::ostringstream os;
+   ntuple->PrintInfo(ENTupleInfo::kSummary, os);
+   ntuple->PrintInfo(ENTupleInfo::kStorageDetails, os);
+}

--- a/tree/ntuple/v7/test/ntuple_float.cxx
+++ b/tree/ntuple/v7/test/ntuple_float.cxx
@@ -5,6 +5,7 @@
 #include "gtest/gtest.h"
 
 #include <cmath>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -49,23 +50,23 @@ TEST(RNTupleFloat, float24_t)
       auto fieldVec = model->MakeField<std::vector<float24_t>>("ft24vec");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
       for (int i = 0; i < 100; ++i) {
-         *fieldPt = i + 0.1 * i;
-         *fieldVec = { i+0.1*i, i+0.1*i};
+         *fieldPt = static_cast<float>(i + 0.1f * i);
+         *fieldVec = { *fieldPt, *fieldPt };
          ntuple->Fill();
       }
       for (int i = 0; i < 100; ++i) {
-         *fieldPt = i * 1200;
-         *fieldVec = { i*1200, i*1200, i*1200 };
+         *fieldPt = static_cast<float>(i * 1200);
+         *fieldVec = { *fieldPt, *fieldPt, *fieldPt };
          ntuple->Fill();
       }
-      *fieldPt = -1.0f/0; // negative infinity
-      *fieldVec = { -1.0f/0, -1.0f/0 };
+      *fieldPt = std::numeric_limits<float>::infinity() * (-1.0f); // negative infinity
+      *fieldVec = { *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 1.0f/0; // positive infinity
-      *fieldVec = { 1.0f/0, 1.0f/0 };
+      *fieldPt = std::numeric_limits<float>::infinity(); // positive infinity
+      *fieldVec = { *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 0.0f/0; // NaN (Not A Number)
-      *fieldVec = { 0.0f/0 };
+      *fieldPt = static_cast<float>(std::nanf("1")); // NaN (Not A Number)
+      *fieldVec = { *fieldPt };
       ntuple->Fill();
    }
    auto model = RNTupleModel::Create();
@@ -75,16 +76,16 @@ TEST(RNTupleFloat, float24_t)
    auto float24View = ntuple->GetView<float24_t>("ft24");
    auto vec24View = ntuple->GetView<std::vector<float24_t>>("ft24vec");
    for (int i = 0; i < 100; ++i) {
-      EXPECT_NEAR(i + 0.1*i, float24View(i), 0.001); // EXPECT_FLOAT_EQ will fail here, so use EXPECT_NEAR instead.
-      EXPECT_NEAR(i + 0.1*i, vec24View(i).at(1), 0.001);
-      EXPECT_EQ(i*1200.0f, float24View(i+100));
-      EXPECT_EQ(i*1200.0f, vec24View(i+100).at(2));
+      EXPECT_NEAR(static_cast<float>(i + 0.1*i), float24View(i), 0.001); // EXPECT_FLOAT_EQ will fail here, so use EXPECT_NEAR instead.
+      EXPECT_NEAR(static_cast<float>(i + 0.1*i), vec24View(i).at(1), 0.001);
+      EXPECT_EQ(static_cast<float>(i*1200.0f), float24View(i+100));
+      EXPECT_EQ(static_cast<float>(i*1200.0f), vec24View(i+100).at(2));
       ntuple->LoadEntry(i);
-      EXPECT_NEAR(i + 0.1*i, *fieldPt, 0.001);
-      EXPECT_NEAR(i + 0.1*i, (*fieldVec).at(1), 0.001);
+      EXPECT_NEAR(static_cast<float>(i + 0.1*i), *fieldPt, 0.001);
+      EXPECT_NEAR(static_cast<float>(i + 0.1*i), (*fieldVec).at(1), 0.001);
       ntuple->LoadEntry(i+100);
-      EXPECT_EQ(i*1200.0f, *fieldPt);
-      EXPECT_EQ(i*1200.0f, (*fieldVec).at(2));
+      EXPECT_EQ(static_cast<float>(i*1200.0f), *fieldPt);
+      EXPECT_EQ(static_cast<float>(i*1200.0f), (*fieldVec).at(2));
    }
    EXPECT_EQ(true, std::isinf(float24View(200)));
    EXPECT_EQ(true, std::isinf(vec24View(200).at(1)));
@@ -109,23 +110,23 @@ TEST(RNTupleFloat, float16_t)
       auto fieldVec = model->MakeField<std::array<float16_t, 2>>("ft16vec");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
       for (int i = 0; i < 100; ++i) {
-         *fieldPt = 0.1 * i;
-         *fieldVec = { 0.1*i, 0.1*i };
+         *fieldPt = static_cast<float>(0.1 * i);
+         *fieldVec = { *fieldPt, *fieldPt };
          ntuple->Fill();
       }
       for (int i = 0; i < 100; ++i) {
-         *fieldPt = i * 12;
-         *fieldVec = { 12*i, 12*i };
+         *fieldPt = static_cast<float>(i * 12);
+         *fieldVec = { *fieldPt, *fieldPt };
          ntuple->Fill();
       }
-      *fieldPt = -1.0f/0; // negative infinity
-      *fieldVec = { -1.0f/0, -1.0f/0 };
+      *fieldPt = std::numeric_limits<float>::infinity() * (-1.0f); // negative infinity
+      *fieldVec = { *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 1.0f/0; // positive infinity
-      *fieldVec = { 1.0f/0, 1.0f/0 };
+      *fieldPt = std::numeric_limits<float>::infinity(); // positive infinity
+      *fieldVec = { *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 0.0f/0; // NaN (Not A Number)
-      *fieldVec = { 0.0f/0, 0.0f/0 };
+      *fieldPt = static_cast<float>(std::nanf("1")); // NaN (Not A Number)
+      *fieldVec = { *fieldPt, *fieldPt };
       ntuple->Fill();
    }
    auto model = RNTupleModel::Create();
@@ -136,15 +137,15 @@ TEST(RNTupleFloat, float16_t)
    auto vec16View = ntuple->GetView<std::array<float16_t, 2>>("ft16vec");
    for (int i = 0; i < 100; ++i) {
       EXPECT_NEAR(0.1*i, float16View(i), 0.01); // EXPECT_FLOAT_EQ will fail here, so use EXPECT_NEAR instead.
-      EXPECT_NEAR(0.1*i, vec16View(i).at(1), 0.01);
-      EXPECT_EQ(i*12.0f, float16View(i+100));
-      EXPECT_EQ(i*12.0f, vec16View(i+100).at(1));
+      EXPECT_NEAR(static_cast<float>(0.1*i), vec16View(i).at(1), 0.01);
+      EXPECT_EQ(static_cast<float>(i*12.0f), float16View(i+100));
+      EXPECT_EQ(static_cast<float>(i*12.0f), vec16View(i+100).at(1));
       ntuple->LoadEntry(i);
-      EXPECT_NEAR(0.1*i, *fieldPt, 0.01);
-      EXPECT_NEAR(0.1*i, (*fieldVec).at(1), 0.01);
+      EXPECT_NEAR(static_cast<float>(0.1*i), *fieldPt, 0.01);
+      EXPECT_NEAR(static_cast<float>(0.1*i), (*fieldVec).at(1), 0.01);
       ntuple->LoadEntry(i+100);
-      EXPECT_EQ(i*12.0f, *fieldPt);
-      EXPECT_EQ(i*12.0f, (*fieldVec).at(1));
+      EXPECT_EQ(static_cast<float>(i*12.0f), *fieldPt);
+      EXPECT_EQ(static_cast<float>(i*12.0f), (*fieldVec).at(1));
    }
    EXPECT_EQ(true, std::isinf(float16View(200)));
    EXPECT_EQ(true, std::isinf(vec16View(200).at(1)));
@@ -168,18 +169,18 @@ TEST(RNTupleFloat, float8_t)
       auto fieldVec = model->MakeField<std::vector<float8_t>>("ft8vec");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
       for (int i = 0; i < 32; ++i) {
-         *fieldPt = 0.5f * i;
-         *fieldVec = { 0.5f * i, 0.5f * i, 0.5f * i };
+         *fieldPt = static_cast<float>(0.5f * i);
+         *fieldVec = { *fieldPt, *fieldPt, *fieldPt };
          ntuple->Fill();
       }
-      *fieldPt = -1.0f/0; // negative infinity
-      *fieldVec = { -1.0f/0 };
+      *fieldPt = std::numeric_limits<float>::infinity() * (-1.0f); // negative infinity
+      *fieldVec = { *fieldPt };
       ntuple->Fill();
-      *fieldPt = 1.0f/0; // positive infinity
-      *fieldVec = { 1.0f/0, 1.0f/0, 1.0f/0, 1.0f/0 };
+      *fieldPt = std::numeric_limits<float>::infinity(); // positive infinity
+      *fieldVec = { *fieldPt, *fieldPt, *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 0.0f/0; // NaN (Not A Number)
-      *fieldVec = { 0.0f/0 };
+      *fieldPt = static_cast<float>(std::nanf("1")); // NaN (Not A Number)
+      *fieldVec = { *fieldPt };
       ntuple->Fill();
    }
    auto model = RNTupleModel::Create();
@@ -189,11 +190,11 @@ TEST(RNTupleFloat, float8_t)
    auto float8View = ntuple->GetView<float8_t>("ft8");
    auto vec8View = ntuple->GetView<std::vector<float8_t>>("ft8vec");
    for (int i = 0; i < 32; ++i) {
-      EXPECT_EQ(0.5f*i, float8View(i)); // EXPECT_FLOAT_EQ will fail here, so use EXPECT_NEAR instead.
-      EXPECT_EQ(0.5f*i, vec8View(i).at(2));
+      EXPECT_EQ(static_cast<float>(0.5f*i), float8View(i)); // EXPECT_FLOAT_EQ will fail here, so use EXPECT_NEAR instead.
+      EXPECT_EQ(static_cast<float>(0.5f*i), vec8View(i).at(2));
       ntuple->LoadEntry(i);
-      EXPECT_EQ(0.5f*i, *fieldPt);
-      EXPECT_EQ(0.5f*i, (*fieldVec).at(2));
+      EXPECT_EQ(static_cast<float>(0.5f*i), *fieldPt);
+      EXPECT_EQ(static_cast<float>(0.5f*i), (*fieldVec).at(2));
    }
    EXPECT_EQ(true, std::isinf(float8View(32)));
    EXPECT_EQ(true, std::isinf(vec8View(32).at(0)));
@@ -218,18 +219,18 @@ TEST(RNTupleMinMaxDefinedFloat, 24bitDouble)
       auto fieldVec = model->MakeField<std::vector<double>, 24, 0, 1>("ftcustom2");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
       for (int i = 0; i < 100; ++i) {
-         *fieldPt = i*0.01;
-         *fieldVec = { i*0.005, i*0.01 };
+         *fieldPt = static_cast<double>(i*0.01);
+         *fieldVec = { static_cast<double>(i*0.005), static_cast<double>(i*0.01) };
          ntuple->Fill();
       }
-      *fieldPt = -1.0/0; // negative infinity
-      *fieldVec = { -1.0f/0 };
+      *fieldPt = std::numeric_limits<double>::infinity() * (-1.0); // negative infinity
+      *fieldVec = { *fieldPt };
       ntuple->Fill();
-      *fieldPt = 1.0/0; // positive infinity
-      *fieldVec = { 1.0f/0, 1.0f/0, 1.0f/0, 1.0f/0 };
+      *fieldPt = std::numeric_limits<double>::infinity(); // positive infinity
+      *fieldVec = { *fieldPt, *fieldPt, *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 0.0/0; // NaN (Not A Number)
-      *fieldVec = { 0.0f/0 };
+      *fieldPt = static_cast<double>(std::nan("1")); // NaN (Not A Number)
+      *fieldVec = { *fieldPt };
       ntuple->Fill();
    } // flush contents to .root file.
 
@@ -239,10 +240,10 @@ TEST(RNTupleMinMaxDefinedFloat, 24bitDouble)
    auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
    auto view = ntuple->GetView<double, 24, 0, 1>("ftcustom");
    for (int i = 0; i < 100; ++i) {
-      EXPECT_NEAR(i*0.01, view(i), 0.000001);
+      EXPECT_NEAR(static_cast<double>(i*0.01), view(i), 0.000001);
       ntuple->LoadEntry(i);
-      EXPECT_NEAR(i*0.01, *fieldPt, 0.000001);
-      EXPECT_NEAR(i*0.01, (*fieldVec).at(1), 0.000001);
+      EXPECT_NEAR(static_cast<double>(i*0.01), *fieldPt, 0.000001);
+      EXPECT_NEAR(static_cast<double>(i*0.01), (*fieldVec).at(1), 0.000001);
    }
    EXPECT_EQ(true, std::isinf(view(100)));
    ntuple->LoadEntry(100);
@@ -256,7 +257,7 @@ TEST(RNTupleMinMaxDefinedFloat, 24bitDouble)
    EXPECT_EQ(true, std::isnan((*fieldVec).at(0)));
 }
 
-TEST(RNTupleMinMaxDefinedFloat, 47bit)
+TEST(RNTupleMinMaxDefinedFloat, 47bitDouble)
 {
    FileRaii fileGuard("test_ntuple_float_MinMaxDefinedFloat_47bit.root");
    const std::string_view ntupleName{"CustomFloatNTuple47bit"};
@@ -266,18 +267,18 @@ TEST(RNTupleMinMaxDefinedFloat, 47bit)
       auto fieldVec = model->MakeField<std::vector<double>, 47, -50, 100>("ftcustom2");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
       for (int i = -500; i <= 1000; ++i) {
-         *fieldPt = i*0.1;
-         *fieldVec = { 4.0, i*0.1 };
+         *fieldPt = static_cast<double>(i*0.1);
+         *fieldVec = { static_cast<double>(4.0), static_cast<double>(i*0.1) };
          ntuple->Fill();
       }
-      *fieldPt = -1.0/0; // negative infinity
-      *fieldVec = { -1.0f/0 };
+      *fieldPt = std::numeric_limits<double>::infinity() * (-1.0); // negative infinity
+      *fieldVec = { *fieldPt };
       ntuple->Fill();
-      *fieldPt = 1.0/0; // positive infinity
-      *fieldVec = { 1.0f/0, 1.0f/0, 1.0f/0, 1.0f/0 };
+      *fieldPt = std::numeric_limits<double>::infinity(); // positive infinity
+      *fieldVec = { *fieldPt, *fieldPt, *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 0.0/0; // NaN (Not A Number)
-      *fieldVec = { 0.0f/0 };
+      *fieldPt = static_cast<double>(std::nan("1")); // NaN (Not A Number)
+      *fieldVec = { *fieldPt };
       ntuple->Fill();
    } // flush contents to .root file.
 
@@ -288,11 +289,11 @@ TEST(RNTupleMinMaxDefinedFloat, 47bit)
    auto view = ntuple->GetView<double, 47, -50, 100>("ftcustom");
    auto viewVec = ntuple->GetView<std::vector<double>, 47, -50, 100>("ftcustom2");
    for (int i = 0; i < 1501; ++i) {
-      EXPECT_NEAR(((int)i-500)*0.1, view(i), 0.000001);
-      EXPECT_NEAR(((int)i-500)*0.1, viewVec(i).at(1), 0.000001);
+      EXPECT_NEAR(static_cast<double>(((int)i-500)*0.1), view(i), 0.000001);
+      EXPECT_NEAR(static_cast<double>(((int)i-500)*0.1), viewVec(i).at(1), 0.000001);
       ntuple->LoadEntry(i);
-      EXPECT_NEAR(((int)i-500)*0.1, *fieldPt, 0.000001);
-      EXPECT_NEAR(((int)i-500)*0.1, (*fieldVec).at(1), 0.000001);
+      EXPECT_NEAR(static_cast<double>(((int)i-500)*0.1), *fieldPt, 0.000001);
+      EXPECT_NEAR(static_cast<double>(((int)i-500)*0.1), (*fieldVec).at(1), 0.000001);
    }
    EXPECT_EQ(true, std::isinf(view(1501)));
    EXPECT_EQ(true, std::isinf(viewVec(1501).at(0)));
@@ -317,7 +318,7 @@ TEST(RNTupleMinMaxDefinedFloat, 47bit)
    ntuple->PrintInfo(ENTupleInfo::kStorageDetails, os);
 }
 
-TEST(RNTupleMinMaxDefinedFloat, 7bit)
+TEST(RNTupleMinMaxDefinedFloat, 7bitDouble)
 {
    FileRaii fileGuard("test_ntuple_float_MinMaxDefinedFloat_7bit.root");
    const std::string_view ntupleName{"CustomFloatNTuple7bit"};
@@ -331,14 +332,14 @@ TEST(RNTupleMinMaxDefinedFloat, 7bit)
          *fieldArray = {static_cast<double>(i), static_cast<double>(i)};
          ntuple->Fill();
       }
-      *fieldPt = -1.0/0; // negative infinity
-      *fieldArray = { -1.0/0 , 0};
+      *fieldPt = std::numeric_limits<double>::infinity() * (-1.0); // negative infinity
+      *fieldArray = { *fieldPt , 0};
       ntuple->Fill();
-      *fieldPt = 1.0/0; // positive infinity
-      *fieldArray = { 1.0/0, 1.0/0 };
+      *fieldPt = std::numeric_limits<double>::infinity(); // positive infinity
+      *fieldArray = { *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 0.0/0; // NaN (Not A Number)
-      *fieldArray = { 0.0/0, 0 };
+      *fieldPt = static_cast<double>(std::nan("1")); // NaN (Not A Number)
+      *fieldArray = { *fieldPt, 0 };
       ntuple->Fill();
    } // flush contents to .root file.
 
@@ -347,8 +348,8 @@ TEST(RNTupleMinMaxDefinedFloat, 7bit)
    auto view = ntuple->GetView<double, 7, -101, -80>("ftcustom");
    auto arrayView = ntuple->GetView<std::array<double, 2>, 7, -101, -80>("ftcustom2");
    for (int i = -100; i <= -80; ++i) {
-      EXPECT_NEAR(i, view(i+100), 0.1);
-      EXPECT_NEAR(i, arrayView(i+100).at(1), 0.1);
+      EXPECT_NEAR(static_cast<double>(i), view(i+100), 0.1);
+      EXPECT_NEAR(static_cast<double>(i), arrayView(i+100).at(1), 0.1);
    }
    EXPECT_EQ(true, std::isinf(view(21)));
    EXPECT_EQ(true, std::isinf(arrayView(21).at(0)));
@@ -368,18 +369,18 @@ TEST(RNTupleMinMaxDefinedFloat, 40bitFloat)
       auto arrayField = model->MakeField<std::array<float, 3>, 40, 0, 1>("ftcustom2");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
       for (int i = 0; i < 100; ++i) {
-         *fieldPt = i*0.01f;
-         *arrayField = {i*0.01f, i*0.005f, 0};
+         *fieldPt = static_cast<float>(i*0.01f);
+         *arrayField = {static_cast<float>(i*0.01f), static_cast<float>(i*0.005f), static_cast<float>(0)};
          ntuple->Fill();
       }
-      *fieldPt = -1.0f/0; // negative infinity
-      *arrayField = { -1.0f/0, 0, 0 };
+      *fieldPt = std::numeric_limits<float>::infinity() * (-1.0f); // negative infinity
+      *arrayField = { *fieldPt, 0, 0 };
       ntuple->Fill();
-      *fieldPt = 1.0f/0; // positive infinity
-      *arrayField = { 1.0f/0, 1.0f/0, 1.0f/0 };
+      *fieldPt = std::numeric_limits<float>::infinity(); // positive infinity
+      *arrayField = { *fieldPt, *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 0.0f/0; // NaN (Not A Number)
-      *arrayField = { 0.0f/0, 0, 0.0f/0 };
+      *fieldPt = static_cast<float>(std::nanf("1")); // NaN (Not A Number)
+      *arrayField = { *fieldPt, 0, *fieldPt };
       ntuple->Fill();
    } // flush contents to .root file.
 
@@ -390,11 +391,11 @@ TEST(RNTupleMinMaxDefinedFloat, 40bitFloat)
    auto view = ntuple->GetView<float, 40, 0, 1>("ftcustom");
    auto arrayView = ntuple->GetView<std::array<float, 3>, 40, 0, 1>("ftcustom2");
    for (int i = 0; i < 100; ++i) {
-      EXPECT_NEAR(i*0.01, view(i), 0.000001);
-      EXPECT_NEAR(i*0.01, arrayView(i).at(0), 0.000001);
+      EXPECT_NEAR(static_cast<float>(i*0.01), view(i), 0.000001);
+      EXPECT_NEAR(static_cast<float>(i*0.01), arrayView(i).at(0), 0.000001);
       ntuple->LoadEntry(i);
-      EXPECT_NEAR(i*0.01, *fieldPt, 0.000001);
-      EXPECT_NEAR(i*0.01, (*arrayField).at(0), 0.000001);
+      EXPECT_NEAR(static_cast<float>(i*0.01), *fieldPt, 0.000001);
+      EXPECT_NEAR(static_cast<float>(i*0.01), (*arrayField).at(0), 0.000001);
    }
    EXPECT_EQ(true, std::isinf(view(100)));
    EXPECT_EQ(true, std::isinf(arrayView(100).at(0)));
@@ -422,14 +423,14 @@ TEST(RNTupleMinMaxDefinedFloat, 23bitFloat)
       auto fieldPt = model->MakeField<float, 23, -50, 100>("ftcustom");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, fileGuard.GetPath());
       for (int i = -500; i <= 1000; ++i) {
-         *fieldPt = i*0.1;
+         *fieldPt = static_cast<float>(i*0.1);
          ntuple->Fill();
       }
-      *fieldPt = -1.0/0; // negative infinity
+      *fieldPt = std::numeric_limits<float>::infinity() * (-1.0f); // negative infinity
       ntuple->Fill();
-      *fieldPt = 1.0/0; // positive infinity
+      *fieldPt = std::numeric_limits<float>::infinity(); // positive infinity
       ntuple->Fill();
-      *fieldPt = 0.0/0; // NaN (Not A Number)
+      *fieldPt = static_cast<float>(std::nanf("1")); // NaN (Not A Number)
       ntuple->Fill();
    } // flush contents to .root file.
 
@@ -438,9 +439,9 @@ TEST(RNTupleMinMaxDefinedFloat, 23bitFloat)
    auto ntuple = RNTupleReader::Open(std::move(model), ntupleName, fileGuard.GetPath());
    auto view = ntuple->GetView<float, 23, -50, 100>("ftcustom");
    for (int i = 0; i < 1501; ++i) {
-      EXPECT_NEAR(((int)i-500)*0.1, view(i), 0.0001);
+      EXPECT_NEAR(static_cast<float>(((int)i-500)*0.1), view(i), 0.0001);
       ntuple->LoadEntry(i);
-      EXPECT_NEAR(((int)i-500)*0.1, *fieldPt, 0.0001);
+      EXPECT_NEAR(static_cast<float>(((int)i-500)*0.1), *fieldPt, 0.0001);
    }
    EXPECT_EQ(true, std::isinf(view(1501)));
    ntuple->LoadEntry(1501);
@@ -453,7 +454,7 @@ TEST(RNTupleMinMaxDefinedFloat, 23bitFloat)
    EXPECT_EQ(true, std::isnan(*fieldPt));
 }
 
-TEST(RNTupleMinMaxDefinedFloat, 5bit)
+TEST(RNTupleMinMaxDefinedFloat, 5bitFloat)
 {
    FileRaii fileGuard("test_ntuple_float_MinMaxDefinedFloat_5bitFloat.root");
    const std::string_view ntupleName{"CustomFloatNTuple5bitFloat"};
@@ -467,14 +468,14 @@ TEST(RNTupleMinMaxDefinedFloat, 5bit)
          *vecField = { static_cast<float>(i), -100.0f };
          ntuple->Fill();
       }
-      *fieldPt = -1.0f/0; // negative infinity
-      *vecField = { -1.0f/0 };
+      *fieldPt = std::numeric_limits<float>::infinity() * (-1.0f); // negative infinity
+      *vecField = { *fieldPt };
       ntuple->Fill();
-      *fieldPt = 1.0f/0; // positive infinity
-      *vecField = { 1.0f/0, 1.0f/0, 1.0f/0, 1.0f/0 };
+      *fieldPt = std::numeric_limits<float>::infinity(); // positive infinity
+      *vecField = { *fieldPt, *fieldPt, *fieldPt, *fieldPt };
       ntuple->Fill();
-      *fieldPt = 0.0f/0; // NaN (Not A Number)
-      *vecField = { 0.0f/0 };
+      *fieldPt = static_cast<float>(std::nanf("1")); // NaN (Not A Number)
+      *vecField = { *fieldPt };
       ntuple->Fill();
    } // flush contents to .root file.
    auto model = RNTupleModel::Create();
@@ -484,11 +485,11 @@ TEST(RNTupleMinMaxDefinedFloat, 5bit)
    auto view = ntuple->GetView<float, 5, -101, -80>("ftcustom");
    auto vecView = ntuple->GetView<std::vector<float>, 5, -101, -80>("ftcustom2");
    for (int i = -100; i <= -80; ++i) {
-      EXPECT_NEAR(i, view(i+100), 0.25);
-      EXPECT_NEAR(i, vecView(i+100).at(0), 0.25);
+      EXPECT_NEAR(static_cast<float>(i), view(i+100), 0.25);
+      EXPECT_NEAR(static_cast<float>(i), vecView(i+100).at(0), 0.25);
       ntuple->LoadEntry(i+100);
-      EXPECT_NEAR(i, *fieldPt, 0.25);
-      EXPECT_NEAR(i, (*vecField).at(0), 0.25);
+      EXPECT_NEAR(static_cast<float>(i), *fieldPt, 0.25);
+      EXPECT_NEAR(static_cast<float>(i), (*vecField).at(0), 0.25);
    }
    EXPECT_EQ(true, std::isinf(view(21)));
    EXPECT_EQ(true, std::isinf(vecView(21).at(0)));


### PR DESCRIPTION
This PR implements following features:

1. `RField<ROOT::Experimental::float24_t>, RField<ROOT::Experimental::float16_t>, RField<ROOT::Experimental::float8_t>`
The syntax for creating such a field is: `auto fieldPtr = ntupleModel-> MakeField<ROOT::Experimental::float24_t>("fieldName");`

Syntax for other commands: `using float24_t = ROOT::Experimental::float24_t`
`auto view = ntupleReader->GetView<float24_t>("fieldName");`
`auto fieldPtr2 = ntupleModel->MakeField<std::array<float24_t, N>>("fieldName2");`
`auto view2 = ntupleReader->GetView<std::array<float24_t, N>>("fieldName2");`
`auto fieldPtr3 = ntupleModel->MakeField<std::vector<float24_t>>("fieldName3");`
`auto view3 = ntupleReader->GetView<std::vector<float24_t>>("fieldName3");`


2. The user can decide how many bits a floating-point value should occupy in storage by:
`auto fieldPtr = ntupleModel-> MakeField<double, 47, 0, 1>("fieldName");`,
where 47 is the number of bits in storage, 0 is the minimum value and 1 the maximum value to be stored. Outside of storage, the value is converted to a regular double with 64-bit precision.
3 < number of bits in storage < 65

Syntax for other commands:
`auto view = ntupleReader-> GetView<double, 47, 0, 1>("fieldName");`
`auto fieldPtr2 = ntupleModel-> MakeField<float, 23, -100, 100>("fieldName2");` Everything which can be done with `double` can also be done with `float`
`auto fieldPtr3 = ntupleModel-> MakeField<std::array<double, N>, nBits, min, max>("fieldName3");`
`auto view3 = ntupleReader-> GetView<std::array<double, N>, nBits, min, max>("fieldName3");`
`auto fieldPtr4 = ntupleModel-> MakeField<std::vector<double>, nBits, min, max>("fieldName4");`
`auto view4 = ntupleReader-> GetView<std::vector<double>, nBits, min, max>("fieldName4");`