### PR TITLE
Eve-7: Major update for FireworksWeb and for standalone JS renderer.

### DIFF
--- a/graf3d/eve7/CMakeLists.txt
+++ b/graf3d/eve7/CMakeLists.txt
@@ -21,6 +21,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTEve
     ROOT/REveGeomViewer.hxx
     ROOT/REveGluTess.hxx
     ROOT/REveJetCone.hxx
+    ROOT/REveEllipsoid.hxx
     ROOT/REveLine.hxx
     ROOT/REveManager.hxx
     ROOT/REvePathMark.hxx
@@ -75,6 +76,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTEve
     src/REveGeomViewer.cxx
     src/REveGluTess.cxx
     src/REveJetCone.cxx
+    src/REveEllipsoid.cxx
     src/REveLine.cxx
     src/REveManager.cxx
     src/REvePathMark.cxx

--- a/graf3d/eve7/inc/LinkDef.h
+++ b/graf3d/eve7/inc/LinkDef.h
@@ -205,6 +205,10 @@
 #pragma link C++ class ROOT::Experimental::REveJetCone+;
 #pragma link C++ class ROOT::Experimental::REveJetConeProjected+;
 
+// Ellipse
+#pragma link C++ class ROOT::Experimental::REveEllipsoid+;
+#pragma link C++ class ROOT::Experimental::REveEllipsoidProjected+;
+
 // REveLineSet
 #pragma link C++ class ROOT::Experimental::REveStraightLineSet+;
 #pragma link C++ class ROOT::Experimental::REveStraightLineSetProjected+;

--- a/graf3d/eve7/inc/ROOT/REveDataClasses.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataClasses.hxx
@@ -91,7 +91,8 @@ public:
 
 //==============================================================================
 
-class REveDataItem : public REveElement
+class REveDataItem : public REveElement,
+                     public REveAuntAsList
 {
 protected:
    Bool_t fFiltered{false};
@@ -105,6 +106,8 @@ public:
 
    virtual void SetItemColorRGB(UChar_t r, UChar_t g, UChar_t b);
    virtual void SetItemRnrSelf(bool);
+
+   virtual void FillImpliedSelectedSet(Set_t& impSelSet) override;
 
    Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
 };

--- a/graf3d/eve7/inc/ROOT/REveDataProxyBuilderBase.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataProxyBuilderBase.hxx
@@ -79,8 +79,9 @@ protected:
    virtual void BuildViewType(const REveDataCollection* iItem, REveElement* product, std::string viewType, const REveViewContext*);
 
    virtual void ModelChanges(const REveDataCollection::Ids_t&, Product*);
+   virtual void LocalModelChanges(int idx, REveElement* el, const REveViewContext* ctx);
 
-  // utility
+   // Utility
    REveCompound* CreateCompound(bool set_color=true, bool propagate_color_to_all_children=false) const;
    virtual void Clean();
    virtual void CleanLocal();
@@ -92,7 +93,7 @@ private:
    const REveDataCollection *m_collection{nullptr};
 
    float                 m_layer;
-   //   REveDataInteractionList*  m_interactionList;
+   // REveDataInteractionList*  m_interactionList;
    bool                  m_haveWindow;
    bool                  m_modelsChanged;
 };

--- a/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilder.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilder.hxx
@@ -28,10 +28,11 @@ public:
 
 protected:
    void Build(const REveDataCollection* iCollection, REveElement* product, const REveViewContext*) override;
-   void BuildViewType(const REveDataCollection* iCollection, REveElement* product, std::string viewType, const REveViewContext*) override;
 
-   //called once for each collection in collection, the void* points to the
-   // object properly offset in memory
+  void BuildViewType(const REveDataCollection* iCollection, REveElement* product, std::string viewType, const REveViewContext*) override;
+
+   // Called once for every item in collection, the void* points to the
+   // item properly offset in memory.
    virtual void Build(const void* data, int index, REveElement* iCollectionHolder, const REveViewContext*) = 0;
    virtual void BuildViewType(const void* data, int index, REveElement* iCollectionHolder, std::string viewType, const REveViewContext*) = 0;
 

--- a/graf3d/eve7/inc/ROOT/REveEllipsoid.hxx
+++ b/graf3d/eve7/inc/ROOT/REveEllipsoid.hxx
@@ -1,0 +1,92 @@
+// @(#)root/eve7:$Id$
+// Author: Matevz Tadel, Alja Tadel
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_REveEllipsoid
+#define ROOT7_REveEllipsoid
+
+#include <ROOT/REveShape.hxx>
+#include <ROOT/REveVector.hxx>
+#include <ROOT/REveProjectionBases.hxx>
+#include <ROOT/REveStraightLineSet.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+//------------------------------------------------------------------------------
+// REveEllipsoid
+//------------------------------------------------------------------------------
+
+class REveEllipsoid : public REveStraightLineSet
+{
+   friend class REveEllipsoidProjected;
+
+private:
+   REveEllipsoid(const REveEllipsoid &);            // Not implemented
+   REveEllipsoid &operator=(const REveEllipsoid &); // Not implemented
+
+protected:
+   REveVector fV0;
+   REveVector fV1;
+   REveVector fV2;
+
+   float      fPhiStep;
+   void DrawArch(float phiStart, float phiEnd, float phiStep, REveVector& v0,  REveVector& v1, REveVector& v2);
+
+public:
+   REveEllipsoid(const std::string &n = "REveJetConeProjected", const std::string& t = "");
+   virtual ~REveEllipsoid() {};
+
+   virtual void Outline();
+   void SetBaseVectors(REveVector& v0, REveVector& v1, REveVector& v3);
+   void SetPhiStep(float ps);
+
+   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+
+   TClass *ProjectedClass(const REveProjection *p) const override;
+};
+
+//------------------------------------------------------------------------------
+// REveEllipsoidProjected
+//------------------------------------------------------------------------------
+
+class REveEllipsoidProjected :  public REveStraightLineSetProjected
+{
+private:
+   REveEllipsoidProjected(const REveEllipsoidProjected &);            // Not implemented
+   REveEllipsoidProjected &operator=(const REveEllipsoidProjected &); // Not implemented
+
+   void DrawArchProjected(float phiStart, float phiEnd, float phiStep, REveVector& v0,  REveVector& v1, REveVector& v2);
+   void GetSurfaceSize(REveVector& p1, REveVector& p2);
+
+   REveVector fMV0;
+   REveVector fMV1;
+
+   std::vector <REveVector> fArchPnts;
+   float GetEllipseSurface (const REveVector& v1, const REveVector& v2);
+
+public:
+   REveEllipsoidProjected(const std::string &n = "REveEllipsoidProjected", const std::string& t = "");
+   virtual ~REveEllipsoidProjected();
+
+   void BuildRenderData() override;
+
+   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+
+   virtual void OutlineProjected();
+   virtual void SetProjection(REveProjectionManager *mng, REveProjectable *model) override;
+   void UpdateProjection() override;
+   REveElement *GetProjectedAsElement() override { return this; }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -153,8 +153,6 @@ public:
    TFolder *GetMacroFolder() const { return fMacroFolder; }
    TMacro *GetMacro(const char *name) const;
 
-   void EditElement(REveElement *element);
-
    void DisableRedraw() { ++fRedrawDisabled; }
    void EnableRedraw()  { --fRedrawDisabled; if (fRedrawDisabled <= 0) Redraw3D(); }
 
@@ -168,11 +166,10 @@ public:
    void DoRedraw3D();
    void FullRedraw3D(Bool_t resetCameras = kFALSE, Bool_t dropLogicals = kFALSE);
 
+   void ClearAllSelections();
+
    Bool_t GetKeepEmptyCont() const   { return fKeepEmptyCont; }
    void   SetKeepEmptyCont(Bool_t k) { fKeepEmptyCont = k; }
-
-   void ElementChanged(REveElement* element, Bool_t update_scenes=kTRUE, Bool_t redraw=kFALSE);
-   void ScenesChanged(REveElement::List_t& scenes);
 
    void AddElement(REveElement *element, REveElement* parent = nullptr);
    void AddGlobalElement(REveElement *element, REveElement* parent = nullptr);
@@ -182,9 +179,6 @@ public:
    REveElement* FindElementById (ElementId_t id) const;
    void         AssignElementId (REveElement* element);
    void         PreDeleteElement(REveElement* element);
-
-   void   ElementSelect(REveElement* element);
-   Bool_t ElementPaste(REveElement* element);
 
    // VizDB - Visualization-parameter data-base.
    Bool_t       InsertVizDBEntry(const TString& tag, REveElement* model,

--- a/graf3d/eve7/inc/ROOT/REveProjectionManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveProjectionManager.hxx
@@ -67,8 +67,6 @@ public:
    void SetImportEmpty(Bool_t ie) { fImportEmpty = ie; }
    Bool_t GetImportEmpty() const { return fImportEmpty; }
 
-   Bool_t HandleElementPaste(REveElement *el) override;
-
    virtual REveElement *ImportElementsRecurse(REveElement *el, REveElement *parent);
    virtual REveElement *ImportElements(REveElement *el, REveElement *ext_list = nullptr);
 

--- a/graf3d/eve7/inc/ROOT/REveScalableStraightLineSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REveScalableStraightLineSet.hxx
@@ -5,6 +5,7 @@
 
 namespace ROOT {
 namespace Experimental {
+
 class REveScalableStraightLineSet : public REveStraightLineSet
 {
 private:

--- a/graf3d/eve7/inc/ROOT/REveScene.hxx
+++ b/graf3d/eve7/inc/ROOT/REveScene.hxx
@@ -62,12 +62,13 @@ protected:
 
    Bool_t fAcceptingChanges{kFALSE};       ///<!
    Bool_t fChanged{kFALSE};                ///<!
-   Set_t  fChangedElements;                ///<!
+   // Changed or/and added.
+   // XXXX can change to vector (element checks if already registered now).
+   List_t  fChangedElements;               ///<!
    // For the following two have to re-think how the hierarchy will be handled.
    // If I remove a parent, i have to remove all the children.
    // So this has to be done right on both sides (on eve element and here).
    // I might need a set, so i can easily check if parent is in the removed / added list already.
-   List_t fAddedElements;                     ///<!
    std::vector<ElementId_t> fRemovedElements; ///<!
 
    std::vector<std::unique_ptr<REveClient>> fSubscribers; ///<!
@@ -85,8 +86,6 @@ public:
    REveScene(const std::string &n = "REveScene", const std::string &t = "");
    virtual ~REveScene();
 
-   void CollectSceneParents(List_t &scenes);
-
    Bool_t SingleRnrState() const override { return kTRUE; }
 
    void   SetHierarchical(Bool_t h) { fHierarchical = h; }
@@ -98,7 +97,6 @@ public:
    Bool_t IsAcceptingChanges() const { return fAcceptingChanges; }
    void BeginAcceptingChanges();
    void SceneElementChanged(REveElement *element);
-   void SceneElementAdded(REveElement *element);
    void SceneElementRemoved(ElementId_t id);
    void EndAcceptingChanges();
    void ProcessChanges();

--- a/graf3d/eve7/inc/ROOT/REveSceneInfo.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSceneInfo.hxx
@@ -46,10 +46,7 @@ public:
 
    Bool_t SingleRnrState() const override { return kTRUE; }
 
-   void AddStamp(UChar_t bits) override;
-
    Bool_t AcceptElement(REveElement *el) override;
-   Bool_t HandleElementPaste(REveElement *el) override;
 };
 
 } // namespace Experimental

--- a/graf3d/eve7/inc/ROOT/REveSelection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSelection.hxx
@@ -72,7 +72,10 @@ private:
    REveSelection &operator=(const REveSelection &); // Not implemented
 
 protected:
-   Int_t            fPickToSelect{0};  ///<!
+   Color_t          fVisibleEdgeColor; ///<!
+   Color_t          fHiddenEdgeColor;  ///<!
+
+   std::vector<int> fPickToSelect;     ///<!
    Bool_t           fActive{kFALSE};   ///<!
    Bool_t           fIsMaster{kFALSE}; ///<!
 
@@ -90,17 +93,24 @@ protected:
    void RecheckImpliedSet(SelMap_i &entry);
 
 public:
-   REveSelection(const std::string &n = "REveSelection", const std::string &t = "", Color_t col = kViolet);
+   REveSelection(const std::string &n = "REveSelection", const std::string &t = "",
+                 Color_t col_visible = kViolet, Color_t col_hidden = kPink);
    virtual ~REveSelection();
+
+   void   SetVisibleEdgeColorRGB(UChar_t r, UChar_t g, UChar_t b);
+   void   SetHiddenEdgeColorRGB(UChar_t r, UChar_t g, UChar_t b);
 
    void   SetHighlightMode();
 
-   Int_t  GetPickToSelect()   const { return fPickToSelect; }
-   void   SetPickToSelect(Int_t ps) { fPickToSelect = ps; }
+   const std::vector<int>& RefPickToSelect()  const { return fPickToSelect; }
+   void   ClearPickToSelect()     { fPickToSelect.clear(); }
+   void   AddPickToSelect(int ps) { fPickToSelect.push_back(ps); }
 
    Bool_t GetIsMaster()   const { return fIsMaster; }
    void   SetIsMaster(Bool_t m) { fIsMaster = m; }
 
+   bool   IsEmpty()  const { return   fMap.empty(); }
+   bool   NotEmpty() const { return ! fMap.empty(); }
 
    // Abstract methods of REveAunt
    bool HasNiece(REveElement *el) const override;
@@ -135,6 +145,7 @@ public:
    virtual void UserUnPickedElement(REveElement *el);
 
    void NewElementPicked(ElementId_t id, bool multi, bool secondary, const std::set<int>& secondary_idcs={});
+   void ClearSelection();
 
    int  RemoveImpliedSelectedReferencesTo(REveElement *el);
 

--- a/graf3d/eve7/inc/ROOT/REveTableInfo.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTableInfo.hxx
@@ -60,7 +60,7 @@ public:
    REveTableHandle&
    column(const std::string &name, int precision, const std::string &expression)
    {
-      fSpecs[fCollectionName].emplace_back(name, precision, expression);
+      fSpecs[fClassName].emplace_back(name, precision, expression);
       return *this;
    }
 
@@ -69,14 +69,13 @@ public:
       return column(label, precision, label);
    }
 
-   REveTableHandle(std::string collectionName, Specs_t &specs)
-      :fCollectionName(collectionName), fSpecs(specs)
+   REveTableHandle(std::string className, Specs_t &specs)
+      :fClassName(className), fSpecs(specs)
    {
-      fSpecs[collectionName].clear();
    }
 
 protected:
-   std::string  fCollectionName;
+   std::string  fClassName;
    Specs_t&  fSpecs;
 };
 
@@ -104,9 +103,9 @@ public:
    REveTableHandle::Entries_t &RefTableEntries(std::string cname) { return fSpecs[cname]; }
 
    // filling
-   REveTableHandle table(std::string collectionName)
+   REveTableHandle table(std::string className)
    {
-      REveTableHandle handle(collectionName, fSpecs);
+      REveTableHandle handle(className, fSpecs);
       return handle;
    }
 

--- a/graf3d/eve7/inc/ROOT/REveTrackPropagator.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTrackPropagator.hxx
@@ -248,7 +248,7 @@ public:
 
    void CheckReferenceCount(const std::string &from = "<unknown>") override;
 
-   void ElementChanged(Bool_t update_scenes = kTRUE, Bool_t redraw = kFALSE) override;
+   void StampAllTracks();
 
    // propagation
    void InitTrack(const REveVectorD &v, Int_t charge);

--- a/graf3d/eve7/inc/ROOT/REveViewer.hxx
+++ b/graf3d/eve7/inc/ROOT/REveViewer.hxx
@@ -41,10 +41,6 @@ public:
 
    void RemoveElementLocal(REveElement *el) override;
    void RemoveElementsLocal() override;
-
-   Bool_t HandleElementPaste(REveElement* el) override;
-
-   // virtual const TGPicture* GetListTreeIcon(Bool_t open=kFALSE);
 };
 
 

--- a/graf3d/eve7/src/REveDataClasses.cxx
+++ b/graf3d/eve7/src/REveDataClasses.cxx
@@ -217,6 +217,21 @@ void REveDataItem::SetFiltered(bool f)
   }
 }
 
+void REveDataItem::FillImpliedSelectedSet(Set_t &impSelSet)
+{
+   for (auto &n : fNieces)
+   {
+      impSelSet.insert(n);
+      n->FillImpliedSelectedSet(impSelSet);
+
+      if (gDebug > 1)
+      {
+         printf("REveDataItem::FillImpliedSelectedSet added niece '%s' [%s]\n",
+                n->GetCName(), n->IsA()->GetName());
+      }
+   }
+}
+
 //==============================================================================
 // REveDataTable
 //==============================================================================

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -60,14 +60,15 @@ REveDataProxyBuilderBase::Product::~Product()
    m_elements->Annihilate();
 }
 
+//------------------------------------------------------------------------------
 
-//______________________________________________________________________________
 void REveDataProxyBuilderBase::SetCollection(REveDataCollection* c)
 {
    m_collection = c;
 }
 
-//______________________________________________________________________________
+//------------------------------------------------------------------------------
+
 /*
 void
 REveDataProxyBuilderBase::SetInteractionList(REveDataInteractionList* l, const std::string& purpose )
@@ -78,7 +79,8 @@ REveDataProxyBuilderBase::SetInteractionList(REveDataInteractionList* l, const s
 }
 */
 
-//______________________________________________________________________________
+//------------------------------------------------------------------------------
+
 void REveDataProxyBuilderBase::Build()
 {
    if (m_collection)
@@ -175,7 +177,8 @@ void REveDataProxyBuilderBase::Build()
    }
 }
 
-//______________________________________________________________________________
+//------------------------------------------------------------------------------
+
 void
 REveDataProxyBuilderBase::Build(const REveDataCollection*, REveElement*, const REveViewContext*)
 {
@@ -189,8 +192,7 @@ REveDataProxyBuilderBase::BuildViewType(const REveDataCollection*, REveElement*,
    assert("virtual BuildViewType(const FWEventItem*, TEveElementList*, FWViewType::EType, const FWViewContext*) not implemented by inherited class");
 }
 
-//______________________________________________________________________________
-
+//------------------------------------------------------------------------------
 
 REveElement*
 REveDataProxyBuilderBase::CreateProduct( std::string viewType, const REveViewContext* viewContext)
@@ -221,8 +223,10 @@ REveDataProxyBuilderBase::CreateProduct( std::string viewType, const REveViewCon
    return product->m_elements;
 }
 
-//______________________________________________________________________________
-namespace {
+//------------------------------------------------------------------------------
+
+namespace
+{
    void applyColorAttrToChildren(REveElement* p) {
       for (auto &it: p->RefChildren())
       {
@@ -260,15 +264,26 @@ REveDataProxyBuilderBase::ModelChanges(const REveDataCollection::Ids_t& iIds, Pr
       if (item->GetMainColor() != comp->GetMainColor()) comp->SetMainColor(item->GetMainColor());
       applyColorAttrToChildren(comp);
 
-      if (VisibilityModelChanges(itemIdx, comp, p->m_viewContext)) {
+      if (VisibilityModelChanges(itemIdx, comp, p->m_viewContext))
+      {
          elms->ProjectChild(comp);
          printf("---REveDataProxyBuilderBase project child\n");
+      }
+      else
+      {
+         LocalModelChanges(itemIdx, comp, p->m_viewContext);
       }
    }
 }
 
-//______________________________________________________________________________
+void
+REveDataProxyBuilderBase::LocalModelChanges(int, REveElement*, const REveViewContext*)
+{
+   // Nothing to be done in base class.
+   // Visibility, main color and main transparency are handled automatically throught compound.
+}
 
+//------------------------------------------------------------------------------
 
 void
 REveDataProxyBuilderBase::ModelChanges(const REveDataCollection::Ids_t& iIds)
@@ -312,7 +327,7 @@ REveDataProxyBuilderBase::SetupElement(REveElement* el, bool color) const
 {
    el->CSCTakeMotherAsMaster();
    el->SetPickable(true);
-   el->SetMainColor(m_collection->GetMainColor());
+
    if (color)
    {
       el->CSCApplyMainColorToMatchingChildren();
@@ -327,8 +342,7 @@ REveDataProxyBuilderBase::SetupElement(REveElement* el, bool color) const
 REveCompound*
 REveDataProxyBuilderBase::CreateCompound(bool set_color, bool propagate_color_to_all_children) const
 {
-   REveCompound* c = new REveCompound();
-   c->CSCTakeMotherAsMaster();
+   REveCompound *c = new REveCompound();
    c->CSCImplySelectAllChildren();
    c->SetPickable(true);
    if (set_color)
@@ -349,7 +363,7 @@ REveDataProxyBuilderBase::CreateCompound(bool set_color, bool propagate_color_to
    return c;
 }
 
-//______________________________________________________________________________
+//------------------------------------------------------------------------------
 
 void REveDataProxyBuilderBase::Clean()
 {

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -42,7 +42,9 @@ REveDataSimpleProxyBuilder::Build(const REveDataCollection *collection,
    auto pIdx = product->RefChildren().begin();
    for (int index = 0; index < size; ++index)
    {
+      auto di = Collection()->GetDataItem(index);
       REveElement *itemHolder = nullptr;
+
       if (index <  product->NumChildren())
       {
          itemHolder = *pIdx;
@@ -53,11 +55,14 @@ REveDataSimpleProxyBuilder::Build(const REveDataCollection *collection,
       {
          itemHolder = CreateCompound(true, true);
          itemHolder->SetMainColor(collection->GetMainColor());
-         SetupAddElement(itemHolder, product, true);
          itemHolder->SetName(Form("compound %d", index));
 
+         product->AddElement(itemHolder);
       }
-      auto di = Collection()->GetDataItem(index);
+
+      di->AddNiece(itemHolder);
+      itemHolder->SetSelectionMaster(di);
+
       if (di->GetRnrSelf() && !di->GetFiltered())
       {
          Build(collection->GetDataPtr(index), index, itemHolder, vc);
@@ -73,7 +78,9 @@ REveDataSimpleProxyBuilder::BuildViewType(const REveDataCollection* collection,
    auto pIdx = product->RefChildren().begin();
    for (int index = 0; index < size; ++index)
    {
+      auto di = Collection()->GetDataItem(index);
       REveElement* itemHolder = nullptr;
+
       if (index <  product->NumChildren())
       {
          itemHolder = *pIdx;
@@ -84,11 +91,14 @@ REveDataSimpleProxyBuilder::BuildViewType(const REveDataCollection* collection,
       {
          itemHolder = CreateCompound(true, true);
          itemHolder->SetMainColor(collection->GetMainColor());
-         SetupAddElement(itemHolder, product, true);
          itemHolder->SetName(Form("compound %d", index));
 
+         product->AddElement(itemHolder);
       }
-      auto di = Collection()->GetDataItem(index);
+
+      di->AddNiece(itemHolder);
+      itemHolder->SetSelectionMaster(di);
+
       if (di->GetRnrSelf() && !di->GetFiltered())
       {
          BuildViewType(collection->GetDataPtr(index), index, itemHolder, viewType, vc);

--- a/graf3d/eve7/src/REveElement.cxx
+++ b/graf3d/eve7/src/REveElement.cxx
@@ -97,10 +97,6 @@ REveElement::REveElement(const REveElement& e) :
 
 REveElement::~REveElement()
 {
-   if (fScene && fScene->IsAcceptingChanges()) {
-      fScene->SceneElementRemoved( fElementId);
-   }
-
    if (fDestructing != kAnnihilate)
    {
       fDestructing = kStandard;
@@ -109,6 +105,10 @@ REveElement::~REveElement()
       if (fMother) {
         fMother->RemoveElementLocal(this);
         fMother->fChildren.remove(this);
+      }
+
+      if (fScene) {
+         fScene->SceneElementRemoved( fElementId);
       }
 
       for (auto &au : fAunts)
@@ -147,7 +147,7 @@ void REveElement::assign_scene_recursively(REveScene* s)
    //           If yes, shouldn't we block it in AddElement() already?
    if (fDestructing == kNone && fScene && fScene->IsAcceptingChanges())
    {
-       s->SceneElementAdded(this);
+      StampElementAdded();
    }
    for (auto &c : fChildren)
       c->assign_scene_recursively(s);
@@ -495,31 +495,6 @@ void REveElement::VizDB_Insert(const std::string& tag, Bool_t replace, Bool_t up
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Returns the master element - that is:
-/// - master of projectable, if this is a projected;
-/// - master of compound, if fCompound is set;
-/// - master of mother, if kSCBTakeMotherAsMaster bit is set;
-/// If non of the above is true, *this* is returned.
-
-REveElement *REveElement::GetMaster()
-{
-   REveProjected* proj = dynamic_cast<REveProjected*>(this);
-   if (proj)
-   {
-      return dynamic_cast<REveElement*>(proj->GetProjectable())->GetMaster();
-   }
-   if (fCompound)
-   {
-      return fCompound->GetMaster();
-   }
-   if (TestCSCBits(kCSCBTakeMotherAsMaster) && fMother)
-   {
-      return fMother->GetMaster();
-   }
-   return this;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Add el into the list aunts.
 ///
 /// Adding aunt is subordinate to adding a niece.
@@ -564,17 +539,6 @@ void REveElement::CheckReferenceCount(const std::string& from)
       PreDeleteElement();
       delete this;
    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Collect all parents of class REveScene. This is needed to
-/// automatically detect which scenes need to be updated.
-///
-/// Overriden in REveScene to include itself and return.
-
-void REveElement::CollectScenes(List_t& scenes)
-{
-   if (fScene) scenes.push_back(fScene);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -917,11 +881,7 @@ void REveElement::RemoveElement(REveElement* el)
 
    RemoveElementLocal(el);
 
-   if (fScene && fScene->IsAcceptingChanges())
-   {
-      fScene->SceneElementRemoved(fElementId);
-   }
-
+   el->fScene->SceneElementRemoved(fElementId);
    el->fMother = nullptr;
    el->fScene  = nullptr;
 
@@ -961,11 +921,7 @@ void REveElement::RemoveElementsInternal()
 
    for (auto &c : fChildren)
    {
-      if (fScene && fScene->IsAcceptingChanges())
-      {
-         fScene->SceneElementRemoved(fElementId);
-      }
-
+      c->fScene->SceneElementRemoved(c->fElementId);
       c->fMother = nullptr;
       c->fScene  = nullptr;
 
@@ -1370,25 +1326,6 @@ void REveElement::DecDenyDestroy()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// React to element being pasted or dnd-ed.
-/// Return true if redraw is needed.
-
-Bool_t REveElement::HandleElementPaste(REveElement* el)
-{
-   REX::gEve->AddElement(el, this);
-   return kTRUE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Call this after an element has been changed so that the state
-/// can be propagated around the framework.
-
-void REveElement::ElementChanged(Bool_t update_scenes, Bool_t redraw)
-{
-   REX::gEve->ElementChanged(this, update_scenes, redraw);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Set pickable state on the element and all its children.
 
 void REveElement::SetPickableRecursively(Bool_t p)
@@ -1399,13 +1336,30 @@ void REveElement::SetPickableRecursively(Bool_t p)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Returns element to be selected when this element is chosen.
-/// If value is zero the selected object will follow rules in
-/// REveSelection (function MapPickedToSelected).
+/// Returns the master element - that is:
+/// - master of projectable, if this is a projected;
+/// - master of compound, if fCompound is set;
+/// - master of mother, if kSCBTakeMotherAsMaster bit is set;
+/// If non of the above is true, *this* is returned.
 
-REveElement* REveElement::ForwardSelection()
+REveElement *REveElement::GetSelectionMaster()
 {
-   return nullptr;
+   if (fSelectionMaster) return fSelectionMaster;
+
+   REveProjected* proj = dynamic_cast<REveProjected*>(this);
+   if (proj)
+   {
+      return dynamic_cast<REveElement*>(proj->GetProjectable())->GetSelectionMaster();
+   }
+   if (fCompound)
+   {
+      return fCompound->GetSelectionMaster();
+   }
+   if (TestCSCBits(kCSCBTakeMotherAsMaster) && fMother)
+   {
+      return fMother->GetSelectionMaster();
+   }
+   return this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1460,12 +1414,17 @@ void REveElement::RecheckImpliedSelections()
 
 void REveElement::AddStamp(UChar_t bits)
 {
-   if (fDestructing == kNone && fScene && fScene->IsAcceptingChanges()) {
-
+   if (fDestructing == kNone && fScene && fScene->IsAcceptingChanges())
+   {
       if (gDebug > 0)
          ::Info(Form("%s::AddStamp", GetCName()), "%d + (%d) -> %d", fChangeBits, bits, fChangeBits | bits);
+
+      if (fChangeBits == 0)
+      {
+         fScene->SceneElementChanged(this);
+      }
+
       fChangeBits |= bits;
-      fScene->SceneElementChanged(this);
    }
 }
 
@@ -1506,7 +1465,7 @@ Int_t REveElement::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
    j["fElementId"] = GetElementId();
    j["fMotherId"]  = get_mother_id();
    j["fSceneId"]   = get_scene_id();
-   j["fMasterId"]  = GetMaster()->GetElementId();
+   j["fMasterId"]  = GetSelectionMaster()->GetElementId();
 
    j["fRnrSelf"]     = GetRnrSelf();
    j["fRnrChildren"] = GetRnrChildren();

--- a/graf3d/eve7/src/REveEllipsoid.cxx
+++ b/graf3d/eve7/src/REveEllipsoid.cxx
@@ -1,0 +1,293 @@
+#include <ROOT/REveEllipsoid.hxx>
+#include <ROOT/REveTrans.hxx>
+#include <ROOT/REveProjectionManager.hxx>
+#include <ROOT/REveRenderData.hxx>
+
+#include "TMath.h"
+#include "TClass.h"
+
+#include <cassert>
+
+#include "json.hpp"
+
+using namespace ROOT::Experimental;
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveEllipsoid::REveEllipsoid(const std::string &n , const std::string &t):
+   REveStraightLineSet(n, t)
+{
+   fPhiStep = 0.01f;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Draw archade as straight line set.
+
+void REveEllipsoid::DrawArch(float phiStart, float phiEnd, float phiStep, REveVector& v0,  REveVector& v1, REveVector& v2)
+{
+   float phi = phiStart;
+
+   REveVector f =  v1;
+   while (phi < phiEnd ) {
+      REveVector v = v0 + v1*((float)cos(phi)) + v2*((float)sin(phi));
+      AddLine(f, v);
+      f=v;
+      phi += phiStep;
+   }
+   REveVector v = v0 + v1*((float)cos(phiEnd)) + v2*((float)sin(phiEnd));
+   AddLine(f, v);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set size of phi step in archade drawing.
+
+void REveEllipsoid::SetPhiStep(float ps)
+{
+   fPhiStep = ps;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Three defining base vectors of ellipse.
+
+void REveEllipsoid::SetBaseVectors(REveVector& v0, REveVector& v1, REveVector& v2)
+{
+   fV0 = v0;
+   fV1 = v1;
+   fV2 = v2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Draw archade around base vectors.
+
+void REveEllipsoid::Outline()
+{
+   REveVector v0;
+   DrawArch(0, TMath::TwoPi(),fPhiStep, v0, fV0, fV1);
+   DrawArch(0, TMath::TwoPi(),fPhiStep, v0, fV0, fV2);
+   DrawArch(0, TMath::TwoPi(),fPhiStep, v0, fV1, fV2);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Virtual from REveProjectable, returns REveEllipsoidProjected class.
+
+TClass* REveEllipsoid::ProjectedClass(const REveProjection*) const
+{
+   return TClass::GetClass<REveEllipsoidProjected>();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Fill core part of JSON representation.
+
+Int_t REveEllipsoid::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+{
+   Int_t ret = REveStraightLineSet::WriteCoreJson(j, rnr_offset);
+
+   j["fSecondarySelect"] = false;
+   // printf("REveStraightLineSet::WriteCoreJson %d \n", ret);
+   return ret;
+}
+
+//==============================================================================
+//==============================================================================
+//==============================================================================
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveEllipsoidProjected::REveEllipsoidProjected(const std::string& /*n*/, const std::string& /*t*/) :
+   REveStraightLineSetProjected()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Destructor.
+
+REveEllipsoidProjected::~REveEllipsoidProjected()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Draw archade around base vectors.
+
+void REveEllipsoidProjected::DrawArchProjected(float phiStart, float phiEnd, float phiStep, REveVector& v0,  REveVector& v1, REveVector& v2)
+{
+   float phi = phiStart;
+
+   REveVector f =  v1;
+   while (phi < phiEnd ) {
+      REveVector v = v0 + v1*((float)cos(phi)) + v2*((float)sin(phi));
+      fArchPnts.push_back(f);
+      fArchPnts.push_back(v);
+      f=v;
+      phi += phiStep;
+   }
+
+   REveVector v = v0 + v1*((float)cos(phiEnd)) + v2*((float)sin(phiEnd));
+   fArchPnts.push_back(f);
+   fArchPnts.push_back(v);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get surface size of projected ellipse
+
+float REveEllipsoidProjected::GetEllipseSurface (const REveVector& v1, const REveVector& v2)
+{
+   REveEllipsoid&     orig  = * dynamic_cast<REveEllipsoid*>(fProjectable);
+   REveTrans *    trans = orig.PtrMainTrans(kFALSE);
+   REveProjection&  proj  = * fManager->GetProjection();
+
+   // project center of ellipse
+   REveTrans trans0;
+   TVector3 v0 = trans->GetPos();
+   REveVector p0(v0.x(), v0.y(), v0.z());
+   proj.ProjectPointfv(&trans0, p0, p0, fDepth);
+
+   // first axis point
+   REveVector p1 = v1;
+   proj.ProjectPointfv(trans,v1, p1, fDepth);
+
+   // second axis point
+   REveVector p2 = v2;
+   proj.ProjectPointfv(trans, v2, p2, fDepth);
+
+   return  (p1-p0).Mag2()+ (p2-p0).Mag2();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Find longest projection of axes and draw an arch.
+
+void REveEllipsoidProjected::OutlineProjected()
+{
+   REveEllipsoid&     orig  = * dynamic_cast<REveEllipsoid*>(fProjectable);
+   // find ellipse with biggest surface
+   float max = 0;
+   {
+      REveVector v1 = orig.fV0;
+      REveVector v2 = orig.fV1;
+      float d = GetEllipseSurface(v1, v2);
+      if (d > max) {
+         fMV0 = v1;
+         fMV1 = v2;
+         max = d;
+      }
+   }
+   {
+      REveVector v1 = orig.fV1;
+      REveVector v2 = orig.fV2;
+      float d = GetEllipseSurface(v1, v2);
+      if (d > max) {
+         fMV0 = v1;
+         fMV1 = v2;
+         max = d;
+      }
+   }
+   {
+      REveVector v1 = orig.fV0;
+      REveVector v2 = orig.fV2;
+      float d = GetEllipseSurface(v1, v2);
+      if (d > max) {
+         fMV0 = v1;
+         fMV1 = v2;
+         max = d;
+      }
+   }
+   if (gDebug) {
+      printf("REveEllipsoidProjected::OutlineProjected, printing axes %s\n", GetCName());
+      fMV0.Dump();
+      fMV1.Dump();
+   }
+
+   REveVector p0;
+   DrawArchProjected(0, TMath::TwoPi(), orig.fPhiStep, p0, fMV0, fMV1);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Crates 3D point array for rendering.
+
+void  REveEllipsoidProjected::BuildRenderData()
+{
+   REveStraightLineSetProjected::BuildRenderData();
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// This is virtual method from base-class REveProjected.
+
+void REveEllipsoidProjected::SetProjection(REveProjectionManager* mng, REveProjectable* model)
+{
+   REveProjected::SetProjection(mng, model);
+   CopyVizParams(dynamic_cast<REveElement*>(model));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Callback that actually performs the projection.
+/// Called when projection parameters have been updated.
+
+void REveEllipsoidProjected::UpdateProjection()
+{
+   OutlineProjected();
+   REveProjection&      proj = * fManager->GetProjection();
+   REveEllipsoid& orig = * dynamic_cast<REveEllipsoid*>(fProjectable);
+
+   REveTrans *trans = orig.PtrMainTrans(kFALSE);
+
+   // Lines
+   Int_t num_lines = (int)fArchPnts.size();
+   if (proj.HasSeveralSubSpaces())
+      num_lines += TMath::Max(1, num_lines/10);
+   fLinePlex.Reset(sizeof(Line_t), num_lines);
+   REveVector p1, p2;
+   for (size_t i = 0; i <fArchPnts.size(); i+=2 )
+   {
+      proj.ProjectPointfv(trans, fArchPnts[i], p1, fDepth);
+      proj.ProjectPointfv(trans, fArchPnts[i+1], p2, fDepth);
+
+      if (proj.AcceptSegment(p1, p2, 0.1f))
+      {
+         AddLine(p1, p2);
+      }
+      else
+      {
+         REveVector bp1(fArchPnts[i]), bp2(fArchPnts[i+1]);
+         if (trans) {
+            trans->MultiplyIP(bp1);
+            trans->MultiplyIP(bp2);
+         }
+         proj.BisectBreakPoint(bp1, bp2, kTRUE, fDepth);
+
+         AddLine(p1, bp1);
+         AddLine(bp2, p2);
+      }
+   }
+   if (proj.HasSeveralSubSpaces())
+      fLinePlex.Refit();
+
+   // Markers
+   fMarkerPlex.Reset(sizeof(Marker_t), orig.GetMarkerPlex().Size());
+   REveChunkManager::iterator mi(orig.GetMarkerPlex());
+   REveVector pp;
+   while (mi.next())
+   {
+      Marker_t &m = * (Marker_t*) mi();
+
+      proj.ProjectPointfv(trans, m.fV, pp, fDepth);
+      AddMarker(pp, m.fLineId);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Fill core part of JSON representation.
+
+Int_t REveEllipsoidProjected::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+{
+   Int_t ret = REveStraightLineSet::WriteCoreJson(j, rnr_offset);
+
+   j["fSecondarySelect"] = false;
+   // printf("REveStraightLineSet::WriteCoreJson %d \n", ret);
+   return ret;
+}

--- a/graf3d/eve7/src/REveGeoShape.cxx
+++ b/graf3d/eve7/src/REveGeoShape.cxx
@@ -321,7 +321,7 @@ REveGeoShape *REveGeoShape::ImportShapeExtract(REveGeoShapeExtract* gse,
    REveGeoManagerHolder gmgr(fgGeoManager);
    REveManager::RRedrawDisabler redrawOff(REX::gEve);
    REveGeoShape* gsre = SubImportShapeExtract(gse, parent);
-   gsre->ElementChanged();
+   gsre->StampObjProps();
    return gsre;
 }
 

--- a/graf3d/eve7/src/REveLine.cxx
+++ b/graf3d/eve7/src/REveLine.cxx
@@ -119,9 +119,10 @@ void REveLine::SetRnrLine(Bool_t r)
       if (l)
       {
          l->SetRnrLine(r);
-         l->ElementChanged();
+         l->StampObjProps();
       }
    }
+   StampObjProps();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -136,9 +137,10 @@ void REveLine::SetRnrPoints(Bool_t r)
       if (l)
       {
          l->SetRnrPoints(r);
-         l->ElementChanged();
+         l->StampObjProps();
       }
    }
+   StampObjProps();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -153,9 +155,10 @@ void REveLine::SetSmooth(Bool_t r)
       if (l)
       {
          l->SetSmooth(r);
-         l->ElementChanged();
+         l->StampObjProps();
       }
    }
+   StampObjProps();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REveProjectionBases.cxx
+++ b/graf3d/eve7/src/REveProjectionBases.cxx
@@ -121,7 +121,7 @@ void REveProjectable::PropagateRenderState(Bool_t rnr_self, Bool_t rnr_children)
 {
    for (auto &&proj : fProjectedList) {
       if (proj->GetProjectedAsElement()->SetRnrSelfChildren(rnr_self, rnr_children))
-         proj->GetProjectedAsElement()->ElementChanged();
+         proj->GetProjectedAsElement()->StampVisibility();
    }
 }
 
@@ -131,8 +131,11 @@ void REveProjectable::PropagateRenderState(Bool_t rnr_self, Bool_t rnr_children)
 void REveProjectable::PropagateMainColor(Color_t color, Color_t old_color)
 {
    for (auto &&proj : fProjectedList) {
-      if (proj->GetProjectedAsElement()->GetMainColor() == old_color)
-         proj->GetProjectedAsElement()->SetMainColor(color);
+      auto p_as_el = proj->GetProjectedAsElement();
+      if (p_as_el->GetMainColor() == old_color) {
+         p_as_el->SetMainColor(color);
+         p_as_el->StampColorSelection();
+      }
    }
 }
 
@@ -143,8 +146,11 @@ void REveProjectable::PropagateMainColor(Color_t color, Color_t old_color)
 void REveProjectable::PropagateMainTransparency(Char_t t, Char_t old_t)
 {
    for (auto &&proj : fProjectedList) {
-      if (proj->GetProjectedAsElement()->GetMainTransparency() == old_t)
-         proj->GetProjectedAsElement()->SetMainTransparency(t);
+      auto p_as_el = proj->GetProjectedAsElement();
+      if (p_as_el->GetMainTransparency() == old_t) {
+         p_as_el->SetMainTransparency(t);
+         p_as_el->StampColorSelection();
+      }
    }
 }
 

--- a/graf3d/eve7/src/REveProjectionManager.cxx
+++ b/graf3d/eve7/src/REveProjectionManager.cxx
@@ -140,17 +140,6 @@ void REveProjectionManager::SetCenter(Float_t x, Float_t y, Float_t z)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// React to element being pasted or dnd-ed.
-/// Return true if redraw is needed (virtual method).
-
-Bool_t REveProjectionManager::HandleElementPaste(REveElement* el)
-{
-   List_t::size_type n_children  = fChildren.size();
-   ImportElements(el);
-   return n_children != fChildren.size();
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Returns true if element el should be imported.
 ///
 /// Behaviour depends on the value of the fImportEmpty member:
@@ -174,7 +163,7 @@ Bool_t REveProjectionManager::ShouldImport(REveElement *el)
 /// Update dependent elements' bounding box and mark scenes
 /// containing element root or its children as requiring a repaint.
 
-void REveProjectionManager::UpdateDependentElsAndScenes(REveElement *root)
+void REveProjectionManager::UpdateDependentElsAndScenes(REveElement */*root*/)
 {
    for (auto &d: fDependentEls) {
       TAttBBox* bbox = dynamic_cast<TAttBBox *>(d);
@@ -182,6 +171,11 @@ void REveProjectionManager::UpdateDependentElsAndScenes(REveElement *root)
          bbox->ComputeBBox();
    }
 
+   static int warn_count = 0;
+   if (++warn_count <= 5)
+      Warning("REveProjectionManager::UpdateDependentElsAndScenes",
+              "Figure out if scene stamping is still needed.");
+   /*
    List_t scenes;
    root->CollectScenes(scenes);
    if (root == this)
@@ -189,6 +183,7 @@ void REveProjectionManager::UpdateDependentElsAndScenes(REveElement *root)
          n->CollectScenes(scenes);
 
    REX::gEve->ScenesChanged(scenes);
+   */
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -354,7 +349,7 @@ void REveProjectionManager::ProjectChildrenRecurse(REveElement* el)
          BBoxCheckPoint(b[0], b[2], b[4]);
          BBoxCheckPoint(b[1], b[3], b[5]);
       }
-      el->ElementChanged(kFALSE);
+      el->StampObjProps();
    }
 
    for (auto &c : el->RefChildren())  ProjectChildrenRecurse(c);

--- a/graf3d/eve7/src/REveSceneInfo.cxx
+++ b/graf3d/eve7/src/REveSceneInfo.cxx
@@ -48,37 +48,12 @@ Int_t REveSceneInfo::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Override from REveElement.
-/// Process visibility changes and forward them to fGLScene.
-
-void REveSceneInfo::AddStamp(UChar_t bits)
-{
-   REveElement::AddStamp(bits);
-   // if (bits & kCBVisibility)
-   // {
-   //    fGLSceneInfo->SetActive(fRnrSelf);
-   // }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Virtual from REveElement.
 /// REveSceneInfo does not accept children.
 
 Bool_t REveSceneInfo::AcceptElement(REveElement* /*el*/)
 {
    static const REveException eH("REveSceneInfo::AcceptElement ");
-
-   // gEve->SetStatusLine(eH + "this class does not accept children.");
-   return kFALSE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Virtual from REveElement.
-/// REveSceneInfo does not accept children.
-
-Bool_t REveSceneInfo::HandleElementPaste(REveElement* /*el*/)
-{
-   static const REveException eH("REveSceneInfo::HandleElementPaste ");
 
    // gEve->SetStatusLine(eH + "this class does not accept children.");
    return kFALSE;

--- a/graf3d/eve7/src/REveStraightLineSet.cxx
+++ b/graf3d/eve7/src/REveStraightLineSet.cxx
@@ -165,6 +165,7 @@ Int_t REveStraightLineSet::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
    j["fLineStyle"] = fLineStyle;
    j["fMarkerSize"] = fMarkerSize;
    j["fMarkerStyle"] = fMarkerStyle;
+   j["fSecondarySelect"] = false;
    // printf("REveStraightLineSet::WriteCoreJson %d \n", ret);
    return ret;
 }
@@ -179,8 +180,9 @@ void REveStraightLineSet::BuildRenderData()
 
    // printf("REveStraightLineSet::BuildRenderData id = %d \n", GetElementId());
    REveChunkManager::iterator li(fLinePlex);
-   while (li.next()) {
-      Line_t* l = (Line_t*)li();
+   while (li.next())
+   {
+      Line_t *l = (Line_t*) li();
 
       fRenderData->PushV(l->fV1[0], l->fV1[1],l->fV1[2]);
       fRenderData->PushV(l->fV2[0], l->fV2[1],l->fV2[2]);
@@ -189,8 +191,9 @@ void REveStraightLineSet::BuildRenderData()
 
 
    REveChunkManager::iterator mi(fMarkerPlex);
-   while (mi.next()) {
-      Marker_t* m = (Marker_t*)mi();
+   while (mi.next())
+   {
+      Marker_t *m = (Marker_t*) mi();
       fRenderData->PushV(m->fV[0], m->fV[1], m->fV[2]);
       fRenderData->PushI(m->fLineId);
    }

--- a/graf3d/eve7/src/REveTableProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveTableProxyBuilder.cxx
@@ -44,7 +44,7 @@ void REveTableProxyBuilder::Build(const REveDataCollection* collection, REveElem
          auto c = new REveDataColumn(spec.fName.c_str());
          fTable->AddElement(c);
          using namespace std::string_literals;
-         std::string exp  = "i."s + spec.fExpression + "()"s;
+         std::string exp  =  spec.fExpression;
          c->SetExpressionAndType(exp.c_str(), spec.fType);
          c->SetPrecision(spec.fPrecision);
       }

--- a/graf3d/eve7/src/REveTrackPropagator.cxx
+++ b/graf3d/eve7/src/REveTrackPropagator.cxx
@@ -287,15 +287,13 @@ void REveTrackPropagator::CheckReferenceCount(const std::string& from)
 ////////////////////////////////////////////////////////////////////////////////
 /// Element-change notification.
 /// Stamp all tracks as requiring display-list regeneration.
-/// Virtual from REveElement.
 
-void REveTrackPropagator::ElementChanged(Bool_t update_scenes, Bool_t redraw)
+void REveTrackPropagator::StampAllTracks()
 {
    for (auto &i: fBackRefs) {
       auto track = dynamic_cast<REveTrack *>(i.first);
       if (track) track->StampObjProps();
    }
-   REveElement::ElementChanged(update_scenes, redraw);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REveViewer.cxx
+++ b/graf3d/eve7/src/REveViewer.cxx
@@ -97,25 +97,6 @@ void REveViewer::RemoveElementsLocal()
    // XXXXX Notify clients !!! Or will this be automatic?
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Receive a pasted object. REveViewer only accepts objects of
-/// class REveScene.
-/// Virtual from REveElement.
-
-Bool_t REveViewer::HandleElementPaste(REveElement* el)
-{
-   static const REveException eh("REveViewer::HandleElementPaste");
-
-   REveScene* scene = dynamic_cast<REveScene*>(el);
-   if (scene) {
-      AddScene(scene);
-      return kTRUE;
-   } else {
-      Warning("REveViewer::HandleElementPaste", "class REveViewer only accepts REveScene paste argument.");
-      return kFALSE;
-   }
-}
-
 
 /** \class REveViewerList
 \ingroup REve

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -12,21 +12,29 @@
 #include "TClass.h"
 #include "TRandom.h"
 #include "TGeoTube.h"
+#include "TGeoSphere.h"
 #include "TParticle.h"
 #include "TApplication.h"
+#include "TMatrixDSym.h"
+#include "TVector.h"
+#include "TMatrixDEigen.h"
 
 #include <ROOT/REveGeoShape.hxx>
 #include <ROOT/REveScene.hxx>
 #include <ROOT/REveViewer.hxx>
 #include <ROOT/REveElement.hxx>
 #include <ROOT/REveManager.hxx>
+#include <ROOT/REveUtil.hxx>
+#include <ROOT/REveGeoShape.hxx>
 #include <ROOT/REveProjectionManager.hxx>
 #include <ROOT/REveProjectionBases.hxx>
 #include <ROOT/REvePointSet.hxx>
 #include <ROOT/REveJetCone.hxx>
+#include <ROOT/REveTrans.hxx>
 
 #include <ROOT/REveTrack.hxx>
 #include <ROOT/REveTrackPropagator.hxx>
+#include <ROOT/REveEllipsoid.hxx>
 
 namespace REX = ROOT::Experimental;
 
@@ -42,9 +50,6 @@ REX::REveViewer *rhoZView = nullptr;
 const Double_t kR_min = 240;
 const Double_t kR_max = 250;
 const Double_t kZ_d   = 300;
-
-const Int_t N_Tracks =   40;
-const Int_t N_Jets   =   20;
 
 
 REX::REvePointSet *getPointSet(int npoints = 2, float s=2, int color=28)
@@ -92,9 +97,10 @@ void addTracks()
 
    auto trackHolder = new REX::REveElement("Tracks");
 
-   double v = 0.5;
+   double v = 0.2;
    double m = 5;
 
+   int N_Tracks = 10 + r.Integer(20);
    for (int i = 0; i < N_Tracks; i++)
    {
       TParticle* p = new TParticle();
@@ -121,6 +127,7 @@ void addJets()
    REX::REveElement *event = eveMng->GetEventScene();
    auto jetHolder = new REX::REveElement("Jets");
 
+   int N_Jets = 5 + r.Integer(5);
    for (int i = 0; i < N_Jets; i++)
    {
       auto jet = new REX::REveJetCone(Form("Jet_%d", i));
@@ -135,11 +142,62 @@ void addJets()
    event->AddElement(jetHolder);
 }
 
+void addVertex()
+{
+   float pos[3] = {1.46589e-06,-1.30522e-05,-1.98267e-05};
+
+   // symnetric matrix
+
+   double a[16] = {1.46589e-01,-1.30522e-02,-1.98267e-02, 0,
+                   -1.30522e-02, 4.22955e-02,-5.86628e-03, 0,
+                   -1.98267e-02,-5.86628e-03, 2.12836e-01, 0,
+                   0, 0, 0, 1};
+
+   REX::REveTrans t;
+   t.SetFrom(a);
+   TMatrixDSym xxx(3);
+   for(int i = 0; i < 3; i++)
+      for(int j = 0; j < 3; j++)
+      {
+         xxx(i,j) = t(i+1,j+1);
+      }
+
+   TMatrixDEigen eig(xxx);
+   TVectorD xxxEig ( eig.GetEigenValues() );
+   xxxEig = xxxEig.Sqrt();
+
+   TMatrixD vecEig = eig.GetEigenVectors();
+   REX::REveVector v[3]; int ei = 0;
+   for (int i = 0; i < 3; ++i)
+   {
+      v[i].Set(vecEig(0,i), vecEig(1,i), vecEig(2,i));
+      v[i] *=  xxxEig(i);
+   }
+   REX::REveEllipsoid* ell = new  REX::REveEllipsoid("VertexError");
+   ell->InitMainTrans();
+   ell->SetMainColor(kGreen + 10);
+   ell->SetLineWidth(2);
+   ell->SetBaseVectors(v[0], v[1], v[2]);
+   ell->Outline();
+   REX::REveElement *event = eveMng->GetEventScene();
+   event->AddElement(ell);
+   return;
+   //center
+   auto ps = new REX::REvePointSet();
+   ps->SetMainColor(kGreen + 10);
+   ps->SetNextPoint(pos[0], pos[1], pos[2]);
+   ps->SetMarkerStyle(4);
+   ps->SetMarkerSize(4);
+   event->AddElement(ps);
+}
+
+
 void makeEventScene()
 {
    addPoints();
    addTracks();
    addJets();
+   addVertex();
 }
 
 void makeGeometryScene()
@@ -218,22 +276,19 @@ public:
 
    virtual void NextEvent()
    {
-      printf("NEXT EVENT \n");
-
-      REveElement::List_t ev_scenes;
-      ev_scenes.push_back(eveMng->GetEventScene());
-      if (rPhiEventScene)
-         ev_scenes.push_back(rPhiEventScene);
-
-      if (rhoZEventScene)
-         ev_scenes.push_back(rhoZEventScene);
-      eveMng->DestroyElementsOf(ev_scenes);
-
+      eveMng->DisableRedraw();
+      auto scene =  eveMng->GetEventScene();
+      scene->DestroyElements();
       makeEventScene();
-      if (rPhiEventScene || rhoZEventScene)
-         projectScenes(false, true);
-
-      eveMng->BroadcastElementsOf(ev_scenes);
+      for (auto &ie : scene->RefChildren())
+      {
+         if (mngRhoPhi)
+         mngRhoPhi->ImportElements(ie, rPhiEventScene);
+         if (mngRhoZ)
+         mngRhoZ  ->ImportElements(ie, rhoZEventScene);
+      }
+      eveMng->EnableRedraw();
+      eveMng->DoRedraw3D();
    }
 
    virtual void QuitRoot()

--- a/ui5/eve7/controller/GL.controller.js
+++ b/ui5/eve7/controller/GL.controller.js
@@ -9,31 +9,36 @@ sap.ui.define([
 
    "use strict";
 
-   // for debug purposes - do not create geometry painter, just three.js renderer
-   var direct_threejs = false;
+   // Use THREE.js renderer, scene, camera, etc. directly instead of through JSRootGeoPainter.
+   var direct_threejs = true;
 
+   // EveScene constructor function.
    var EveScene = null;
 
-   return Controller.extend("rootui5.eve7.controller.GL", {
+   let maybe_proto = Controller.extend("rootui5.eve7.Controller.GL", {
+
+
+      //==============================================================================
+      // Initialization, bootstrap, destruction & cleanup.
+      //==============================================================================
 
       onInit : function()
       {
-         var id = this.getView().getId();
+         // var id = this.getView().getId();
 
-         var viewData = this.getView().getViewData();
-         if (viewData) {
-            this.createXXX(viewData);
-         } else {
-            var oRouter = UIComponent.getRouterFor(this);
-            oRouter.getRoute("View").attachPatternMatched(this._onObjectMatched, this);
+         let viewData = this.getView().getViewData();
+         if (viewData)
+         {
+            this.setupManagerAndViewType(viewData);
+         }
+         else
+         {
+            UIComponent.getRouterFor(this).getRoute("View").attachPatternMatched(this.onViewObjectMatched, this);
          }
 
-         ResizeHandler.register(this.getView(), this.onResize.bind(this));
-         this.fast_event = [];
-
          this._load_scripts = false;
-         this._render_html = false;
-         this.geo_painter = null;
+         this._render_html  = false;
+         this.geo_painter   = null;
 
          JSROOT.AssertPrerequisites("geom", this.onLoadScripts.bind(this));
       },
@@ -43,205 +48,65 @@ sap.ui.define([
          var pthis = this;
 
          // one only can load EveScene after geometry painter
-         sap.ui.define(['rootui5/eve7/lib/EveScene', 'rootui5/eve7/lib/OutlinePass', 'rootui5/eve7/lib/FXAAShader'], function (_EveScene) {
-            EveScene = _EveScene;
-            pthis._load_scripts = true;
-            pthis.checkViewReady();
-         });
+         sap.ui.define(['rootui5/eve7/lib/EveScene',    'rootui5/eve7/lib/OrbitControlsEve',
+                        'rootui5/eve7/lib/OutlinePass', 'rootui5/eve7/lib/FXAAShader'],
+                       function (eve_scene) {
+                          EveScene = eve_scene;
+                          pthis._load_scripts = true;
+                          pthis.checkViewReady();
+                       });
       },
 
-      _onObjectMatched: function(oEvent) {
-         var args = oEvent.getParameter("arguments");
+      onViewObjectMatched: function(oEvent)
+      {
+         let args = oEvent.getParameter("arguments");
 
-         this.createXXX(Component.getOwnerComponentFor(this.getView()).getComponentData(), args.viewName, JSROOT.$eve7tmp);
+         this.setupManagerAndViewType(Component.getOwnerComponentFor(this.getView()).getComponentData(),
+                                      args.viewName, JSROOT.$eve7tmp);
 
          delete JSROOT.$eve7tmp;
       },
 
-      createXXX: function(data, viewName, moredata) {
-
-         if (viewName) {
+      // Initialization that can be done immediately onInit or later through UI5 bootstrap callbacks.
+      setupManagerAndViewType: function(data, viewName, moredata)
+      {
+         if (viewName)
+         {
             data.standalone = viewName;
-            data.kind = viewName;
+            data.kind       = viewName;
          }
-         //var data = this.getView().getViewData();
+
          // console.log("VIEW DATA", data);
 
-         if (moredata && moredata.mgr) {
-            this.mgr = moredata.mgr;
-            this.elementid = moredata.elementid;
-            this.kind = moredata.kind;
+         if (moredata && moredata.mgr)
+         {
+            this.mgr        = moredata.mgr;
+            this.elementid  = moredata.elementid;
+            this.kind       = moredata.kind;
             this.standalone = viewName;
 
             this.checkViewReady();
-
-         } else if (data.standalone && data.conn_handle) {
-            this.mgr = new EveManager();
-            this.mgr.UseConnection(data.conn_handle);
-            this.standalone = data.standalone;
-            this.mgr.RegisterUpdate(this, "onManagerUpdate");
-         } else {
-            this.mgr = data.mgr;
-            this.elementid = data.elementid;
-            this.kind = data.kind;
          }
-
-      },
-
-      // MT-HAKA
-      createThreejsRenderer: function()
-      {
-         if (!direct_threejs || this.renderer) return;
-
-         this.scene      = new THREE.Scene();
-         this.camera     = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 100000 );
-         this.rot_center = new THREE.Vector3(0,0,0);
-
-         // this.controls = new THREE.OrbitControls( this.camera );
-         //var controls = new THREE.FirstPersonControls( camera );
-
-         this.renderer = new THREE.WebGLRenderer();
-         this.renderer.setPixelRatio( window.devicePixelRatio );
-         this.renderer.setSize( window.innerWidth, window.innerHeight );
-
-         // this.scene.fog = new THREE.FogExp2( 0xaaaaaa, 0.05 );
-         this.renderer.setClearColor( 0xffffff, 1 );
-
-         this.dom_registered = false;
-         //document.body.appendChild( this.renderer.domElement );
-
-         //document.getElementById('EveViewer9').appendChild( this.renderer.domElement );
-
-         // this.getView().getDomRef().appendChild( this.renderer.domElement );
-
-         // -------
-
-         // var sphere = new THREE.SphereGeometry( 0.1, 8, 8 );
-         // var lamp = new THREE.DirectionalLight( 0xff5050, 0.5 );
-         var lampR = new THREE.PointLight( 0xff5050, 0.7 );
-         // lampR.add(new THREE.Mesh( sphere, new THREE.MeshBasicMaterial( { color: lampR.color } ) ));
-         lampR.position.set(2, 2, -2);
-         this.scene.add( lampR );
-
-         var lampG = new THREE.PointLight( 0x50ff50, 0.7 );
-         // lampG.add(new THREE.Mesh( sphere, new THREE.MeshBasicMaterial( { color: lampG.color } ) ));
-         lampG.position.set(-2, 2, 2);
-         this.scene.add( lampG );
-
-         var lampB = new THREE.PointLight( 0x5050ff, 0.7 );
-         // lampB.add(new THREE.Mesh( sphere, new THREE.MeshBasicMaterial( { color: lampB.color } ) ));
-         lampB.position.set(2, 2, 2);
-         this.scene.add( lampB );
-
-         //var plane = new THREE.GridHelper(20, 20, 0x80d080, 0x8080d0);
-         //this.scene.add(plane);
-      },
-
-      /** returns container for 3d objects */
-      getThreejsContainer: function(name)
-      {
-         var prnt = null;
-
-         if (!direct_threejs)
-            prnt = this.geo_painter.getExtrasContainer();
-         else
-            prnt = this.scene;
-
-         for (var k=0;k<prnt.children.length;++k)
-            if (prnt.children[k]._eve_name === name)
-               return prnt.children[k];
-
-         var obj3d = new THREE.Object3D();
-         obj3d._eve_name = name;
-         prnt.add(obj3d);
-         return obj3d;
-      },
-
-      // MT-HAKA
-      render: function()
-      {
-         if (!direct_threejs) {
-            if (this.geo_painter) {
-               if (!this.first_time_render) {
-                  this.first_time_render = true;
-                  this.geo_painter.adjustCameraPosition(true);
-               }
-               this.geo_painter.Render3D();
-            }
-            return;
-         }
-
-         if ( ! this.dom_registered)
+         else if (data.standalone && data.conn_handle)
          {
-            this.getView().getDomRef().appendChild( this.renderer.domElement );
-
-            //this.controls = new THREE.OrbitControls( this.camera);
-            this.controls = new THREE.OrbitControls( this.camera, this.getView().getDomRef() );
-
-            this.controls.addEventListener( 'change', this.render.bind(this) );
-
-            this.dom_registered = true;
-
-            // Setup camera
-            var sbbox = new THREE.Box3();
-            sbbox.setFromObject( this.scene );
-
-            //var center = boundingBox.getCenter();
-            this.controls.target = this.rot_center;
-
-            var maxV = new THREE.Vector3; maxV.subVectors(sbbox.max, this.rot_center);
-            var minV = new THREE.Vector3; minV.subVectors(sbbox.min, this.rot_center);
-
-            var posV = new THREE.Vector3; posV = maxV.multiplyScalar(2);
-
-            this.camera.position.set( posV.x, posV.y, posV.z );
-            this.camera.lookAt(this.rot_center);
-
-            console.log("scene bbox ", sbbox, ", camera_pos ", posV, ", look_at ", this.rot_center);
+            this.mgr        = new EveManager();
+            this.standalone = data.standalone;
+            this.mgr.UseConnection(data.conn_handle);
+         }
+         else
+         {
+            this.mgr       = data.mgr;
+            this.elementid = data.elementid;
+            this.kind      = data.kind;
          }
 
-         // console.log(this.camera);
-
-         //console.log(this.controls);
-         //console.log(this.getView().getDomRef());
-         //console.log(this.renderer.domElement);
-
-         // requestAnimationFrame( this.render.bind(this) );
-
-         // this.controls.update( );
-
-         this.renderer.render( this.scene, this.camera );
+         this.mgr.RegisterController(this);
+         this.mgr.RegisterGlController(this);
       },
 
-      onManagerUpdate: function()
-      {
-         // called when manager was updated, need only in standalone modes to detect own element id
-         if (!this.standalone || this.elementid) return;
-
-         var viewers = this.mgr.FindViewers();
-
-         // first check number of views to create
-         var found = null;
-         for (var n=0;n<viewers.length;++n) {
-            if (viewers[n].fName.indexOf(this.standalone) == 0) { found = viewers[n]; break; }
-         }
-         if (!found) return;
-
-         this.elementid = found.fElementId;
-         this.kind = (found.fName == "Default Viewer") ? "3D" : "2D";
-         this.checkViewReady();
-
-      },
-
-      // function called from GuiPanelController
-      onExit: function()
-      {
-         if (this.mgr) this.mgr.Unregister(this);
-      },
-
+      // Called when HTML parent/container rendering is complete.
       onAfterRendering: function()
       {
-
          this._render_html = true;
 
          // TODO: should be specified somehow in XML file
@@ -250,54 +115,79 @@ sap.ui.define([
          this.checkViewReady();
       },
 
-      createScenes: function()
+      OnEveManagerInit: function()
       {
-         if (this.created_scenes !== undefined) return;
-         this.created_scenes = [];
+         // called when manager was updated, need only in standalone modes to detect own element id
+         if (!this.standalone || this.elementid) return;
 
-         // only when rendering completed - register for modify events
-         var element = this.mgr.GetElement(this.elementid);
+         let viewers = this.mgr.FindViewers();
 
-         // loop over scene and add dependency
-         for (var k=0;k<element.childs.length;++k)
+         // first check number of views to create
+         let found = null;
+         for (let n = 0; n < viewers.length; ++n)
          {
-            var scene = element.childs[k];
-
-            var handler = new EveScene(this.mgr, scene, this);
-
-            this.created_scenes.push(handler);
-            this.mgr.addSceneHandler(handler);
+            if (viewers[n].fName.indexOf(this.standalone) == 0)
+            {
+               found = viewers[n];
+               break;
+            }
          }
+         if ( ! found) return;
+
+         this.elementid = found.fElementId;
+         this.kind      = (found.fName == "Default Viewer") ? "3D" : "2D";
+
+         this.checkViewReady();
       },
 
-      redrawScenes: function() {
-         for (var k=0;k<this.created_scenes.length;++k)
-            this.created_scenes[k].redrawScene();
+      // Function called from GuiPanelController.
+      onExit: function()
+      {
+         // QQQQ EveManager does not have Unregister ... nor UnregisterController
+         if (this.mgr) this.mgr.Unregister(this);
+         // QQQQ plus, we should unregister this as gl-controller, too
       },
 
-
-      /** checks if all initialization is performed */
+      // Checks if all initialization is performed and startup renderer.
       checkViewReady: function()
       {
-         if (!this._load_scripts || !this._render_html || !this.elementid) return;
+         if ( ! this._load_scripts || ! this._render_html || ! this.elementid)
+         {
+            return;
+         }
 
-         if (direct_threejs) {
+         if (direct_threejs)
+         {
+            if (this.renderer) throw new Error("THREE renderer already created.");
+
+            if( ! rootui5.eve7.Controller.GL.g_global_init_done)
+            {
+               rootui5.eve7.Controller.GL.g_global_init(this);
+            }
+
             this.createThreejsRenderer();
             this.createScenes();
             this.redrawScenes();
-            return;
+            this.setupThreejsDomAndEventHandlers();
          }
+         else
+         {
+            if (this.geo_painter) throw new Error("GeoPainter already created.");
 
-         if (this.geo_painter) {
-            this.redrawScenes();
-            return;
+            this.createGeoPainter();
          }
+      },
 
 
-         var options = "outline";
+      //==============================================================================
+      // JSRoot GeoPainter creation etc
+      //==============================================================================
+
+      createGeoPainter: function()
+      {
+         let options = "outline";
          // options += " black, ";
          if (this.kind != "3D") options += ", ortho_camera";
-
 
          // TODO: should be specified somehow in XML file
          this.getView().$().css("overflow", "hidden").css("width", "100%").css("height", "100%");
@@ -305,25 +195,26 @@ sap.ui.define([
          this.geo_painter = JSROOT.Painter.CreateGeoPainter(this.getView().getDomRef(), null, options);
 
          // function used by TGeoPainter to create OutlineShader - for the moment remove from JSROOT
-         this.geo_painter.createOutline = function(w,h) {
-            this._outlinePass = new THREE.OutlinePass( new THREE.Vector2( w, h ), this._scene, this._camera );
-            this._outlinePass.edgeStrength = 5.5;
-            this._outlinePass.edgeGlow = 0.7;
-            this._outlinePass.edgeThickness = 1.5;
-            this._outlinePass.usePatternTexture = false;
-            this._outlinePass.downSampleRatio = 1;
-            this._outlinePass.glowDownSampleRatio = 3;
+         this.geo_painter.createOutline = function(w,h)
+         {
+            this.outline_pass = new THREE.OutlinePass( new THREE.Vector2( w, h ), this._scene, this._camera );
+            this.outline_pass.edgeStrength = 5.5;
+            this.outline_pass.edgeGlow = 0.7;
+            this.outline_pass.edgeThickness = 1.5;
+            this.outline_pass.usePatternTexture = false;
+            this.outline_pass.downSampleRatio = 1;
+            this.outline_pass.glowDownSampleRatio = 3;
 
             // const sh = THREE.OutlinePass.selection_enum["select"]; // doesnt stand for spherical harmonics :P
             // THREE.OutlinePass.selection_atts[sh].visibleEdgeColor.set('#dd1111');
             // THREE.OutlinePass.selection_atts[sh].hiddenEdgeColor.set('#1111dd');
 
-            this._effectComposer.addPass( this._outlinePass );
+            this._effectComposer.addPass( this.outline_pass );
 
-            this._effectFXAA = new THREE.ShaderPass( THREE.FXAAShader );
-            this._effectFXAA.uniforms[ 'resolution' ].value.set( 1 / w, 1 / h );
-            this._effectFXAA.renderToScreen = true;
-            this._effectComposer.addPass( this._effectFXAA );
+            this.fxaa_pass = new THREE.ShaderPass( THREE.FXAAShader );
+            this.fxaa_pass.uniforms[ 'resolution' ].value.set( 1 / w, 1 / h );
+            this.fxaa_pass.renderToScreen = true;
+            this._effectComposer.addPass( this.fxaa_pass );
          }
 
          // assign callback function - when needed
@@ -334,23 +225,28 @@ sap.ui.define([
          this.geo_painter.prepareObjectDraw(null); // and now start everything
       },
 
-      onGeoPainterReady: function(painter) {
+      onGeoPainterReady: function(painter)
+      {
+         console.log("GL_controller::onGeoPainterReady");
 
          // AMT temporary here, should be set in camera instantiation time
-         if (this.geo_painter._camera.type == "OrthographicCamera") {
-            this.geo_painter._camera.left = -this.getView().$().width();
-            this.geo_painter._camera.right = this.getView().$().width();
-            this.geo_painter._camera.top = this.getView().$().height();
+         if (this.geo_painter._camera.type == "OrthographicCamera")
+         {
+            this.geo_painter._camera.left   = -this.getView().$().width();
+            this.geo_painter._camera.right  =  this.getView().$().width();
+            this.geo_painter._camera.top    =  this.getView().$().height();
             this.geo_painter._camera.bottom = -this.getView().$().height();
             this.geo_painter._camera.updateProjectionMatrix();
          }
 
          painter.eveGLcontroller = this;
-         painter._controls.ProcessMouseMove = function(intersects) {
+         painter._controls.ProcessMouseMove = function(intersects)
+         {
             var active_mesh = null, tooltip = null, resolve = null, names = [], geo_object, geo_index;
 
             // try to find mesh from intersections
-            for (var k=0;k<intersects.length;++k) {
+            for (var k=0;k<intersects.length;++k)
+            {
                var obj = intersects[k].object, info = null;
                if (!obj) continue;
                if (obj.geo_object) info = obj.geo_name; else
@@ -376,7 +272,7 @@ sap.ui.define([
 
             // painter.HighlightMesh(active_mesh, undefined, geo_object, geo_index); AMT override
             if (active_mesh && active_mesh.get_ctrl()){
-               active_mesh.get_ctrl().setHighlight( 0xffaa33, geo_index);
+               active_mesh.get_ctrl().elementHighlighted( 0xffaa33, geo_index);
             }
             else {
                var sl = painter.eveGLcontroller.created_scenes;
@@ -401,50 +297,630 @@ sap.ui.define([
          // this.geo_painter._highlight_handlers = [ this ]; // register ourself for highlight handling
          this.last_highlight = null;
 
-         // outlinePass passthrough
-         this.outlinePass = this.geo_painter._outlinePass;
+         // outline_pass passthrough
+         this.outline_pass = this.geo_painter.outline_pass;
 
-         // this is try to remap standard THREE.js OutlinePass with specialized
-         /* if (this.outlinePass) {
-            this.outlinePass.id2obj_map = {}; // FIXME:!!!!!!!!
-
-            this.outlinePass.oldRender = this.outlinePass.render;
-
-            this.outlinePass.render = function() {
-               this._selectedObjects = Object.values(this.id2obj_map).flat();
-               this.oldRender.apply(this, arguments);
-            }
-         }
-         */
          var sz = this.geo_painter.size_for_3d();
          this.geo_painter._effectComposer.setSize( sz.width, sz.height);
-         this.geo_painter._effectFXAA.uniforms[ 'resolution' ].value.set( 1 / sz.width, 1 / sz.height );
+         this.geo_painter.fxaa_pass.uniforms[ 'resolution' ].value.set( 1 / sz.width, 1 / sz.height );
 
          // create only when geo painter is ready
          this.createScenes();
          this.redrawScenes();
+         this.geo_painter.adjustCameraPosition(true);
+         this.render();
       },
 
-      /// invoked from the manager
-      onResize: function(event) {
-         // use timeout
-         // console.log("resize painter")
+
+      //==============================================================================
+      // THREE renderer creation, DOM/event handler setup, reset
+      //==============================================================================
+
+      createThreejsRenderer: function()
+      {
+         var w = this.getView().$().width();
+         var h = this.getView().$().height();
+
+         // console.log("createThreejsRenderer", this.kind, "w=", w, "h=", h);
+
+         this.scene  = new THREE.Scene();
+         // this.scene.fog = new THREE.FogExp2( 0xaaaaaa, 0.05 );
+
+         if (this.kind === "3D")
+         {
+            this.camera = new THREE.PerspectiveCamera(75, w / h, 1, 5000);
+         }
+         else
+         {
+            this.camera = new THREE.OrthographicCamera(-w/2, w/2, -h/2, h/2, 0, 2000);
+         }
+         this.scene.add(this.camera);
+
+         this.rot_center = new THREE.Vector3(0,0,0);
+
+         this.renderer = new THREE.WebGLRenderer();
+         this.renderer.setPixelRatio( window.devicePixelRatio );
+         this.renderer.setSize( w, h );
+
+         this.renderer.setClearColor( 0xffffff, 1 );
+
+         // -------- Raycaster, lights, composer & FXAA and Outline passes.
+
+         this.raycaster = new THREE.Raycaster();
+         this.raycaster.params.Points.threshold = 4;   // ???
+         this.raycaster.linePrecision           = 2.5; // ???
+
+         // Lights are positioned in resetRenderer
+
+         this.point_lights = new THREE.Object3D;
+         this.point_lights.add( new THREE.PointLight( 0xff5050, 0.7 )); // R
+         this.point_lights.add( new THREE.PointLight( 0x50ff50, 0.7 )); // G
+         this.point_lights.add( new THREE.PointLight( 0x5050ff, 0.7 )); // B
+         this.scene.add(this.point_lights);
+
+         // var plane = new THREE.GridHelper(20, 20, 0x80d080, 0x8080d0);
+         // this.scene.add(plane);
+
+         this.composer = new THREE.EffectComposer(this.renderer);
+         this.composer.addPass(new THREE.RenderPass(this.scene, this.camera));
+
+         this.outline_pass = new THREE.OutlinePass(new THREE.Vector2(w, h), this.scene, this.camera);
+         this.outline_pass.edgeStrength        = 5.5;
+         this.outline_pass.edgeGlow            = 0.7;
+         this.outline_pass.edgeThickness       = 1.5;
+         this.outline_pass.usePatternTexture   = false;
+         this.outline_pass.downSampleRatio     = 1;
+         this.outline_pass.glowDownSampleRatio = 3;
+
+         // This does not work ... seems it is not standard pass?
+         // this.outline_pass.renderToScreen = true;
+         // Tried hacking with this, but would apparently need to load it somehow, sigh.
+         // var copyPass = new ShaderPass( CopyShader );
+         // this.composer.addPass( new THREE.ShaderPass(CopyShader) );
+
+         this.composer.addPass(this.outline_pass);
+
+         this.fxaa_pass = new THREE.ShaderPass( THREE.FXAAShader );
+         this.fxaa_pass.uniforms.resolution.value.set(0.5 / w, 0.5 / h);
+         this.fxaa_pass.renderToScreen = true;
+
+         this.composer.addPass( this.fxaa_pass );
+      },
+
+      setupThreejsDomAndEventHandlers: function()
+      {
+         this.getView().getDomRef().appendChild( this.renderer.domElement );
+
+         // Setup tooltip
+         this.ttip = document.createElement('div');
+         this.ttip.setAttribute('class', 'eve_tooltip');
+         this.ttip_text = document.createElement('div');
+         this.ttip.appendChild(this.ttip_text);
+         this.getView().getDomRef().appendChild(this.ttip);
+
+         // Setup controls
+         this.controls = new THREE.OrbitControlsEve( this.camera, this.getView().getDomRef() );
+
+         this.controls.addEventListener('change', this.render.bind(this));
+
+         // Setup some event pre-handlers
+         var glc = this;
+
+         this.renderer.domElement.addEventListener('mousemove', function(event) {
+
+            if (event.movementX == 0 && event.movementY == 0)
+               return;
+
+            glc.removeMouseMoveTimeout();
+            glc.clearHighlight();
+            glc.removeMouseupListener();
+
+            if (event.buttons === 0)
+            {
+               glc.mousemove_timeout = setTimeout(glc.onMouseMoveTimeout.bind(glc, event), 250);
+            }
+         });
+
+         this.renderer.domElement.addEventListener('mouseleave', function(event) {
+
+            glc.removeMouseMoveTimeout();
+            glc.clearHighlight();
+            glc.removeMouseupListener();
+         });
+
+         this.renderer.domElement.addEventListener('mousedown', function(event) {
+
+            glc.removeMouseMoveTimeout();
+            if (event.buttons != 1 && event.buttons != 2)  glc.clearHighlight();
+            glc.removeMouseupListener();
+
+            // console.log("GLC::mousedown", this, glc, event, event.offsetX, event.offsetY);
+
+            glc.mouseup_listener = function(event2)
+            {
+               this.removeEventListener('mouseup', glc.mouseup_listener);
+
+               if (event.buttons == 1) // Selection on mouseup without move
+               {
+                  glc.handleMouseSelect(event2);
+               }
+               else if (event.buttons == 2) // Context menu on delay without move
+               {
+                  // Was needed for "on press with timeout"
+                  // glc.controls.resetMouseDown(event);
+
+                  JSROOT.Painter.createMenu(glc, glc.showContextMenu.bind(glc, event2));
+               }
+            }
+
+            this.addEventListener('mouseup', glc.mouseup_listener);
+         });
+
+         this.renderer.domElement.addEventListener('dblclick', function(event) {
+
+            // console.log("GLC::dblclick", glc, event);
+            glc.resetThreejsRenderer();
+         });
+
+         // Key-handlers go on window ...
+
+         window.addEventListener('keydown', function(event) {
+
+            // console.log("GLC::keydown", event.key, event.code, event);
+
+            let handled = true;
+
+            if (event.key == "t")
+            {
+               glc.scene.traverse( function( node ) {
+
+                  if ( node.material && node.material.linewidth )
+                  {
+                     if ( ! node.material.linewidth_orig) node.material.linewidth_orig = node.material.linewidth;
+
+                     node.material.linewidth *= 1.2;
+                  }
+               });
+            }
+            else if (event.key == "e")
+            {
+               glc.scene.traverse( function( node ) {
+
+                  if ( node.material && node.material.linewidth )
+                  {
+                     if ( ! node.material.linewidth_orig) node.material.linewidth_orig = node.material.linewidth;
+
+                     node.material.linewidth *= 0.8;
+                  }
+               });
+            }
+            else if (event.key == "r")
+            {
+               glc.scene.traverse( function( node ) {
+
+                  if ( node.material && node.material.linewidth && node.material.linewidth_orig )
+                  {
+                     node.material.linewidth = node.material.linewidth_orig;
+                  }
+               });
+            }
+            else
+            {
+               handled = false;
+            }
+
+            if (handled)
+            {
+               // // // event.stopPropagation();
+               // event.preventDefault();
+               // event.stopImmediatePropagation();
+
+               glc.render();
+            }
+         });
+
+         // This will also call render().
+         this.resetThreejsRenderer();
+
+         ResizeHandler.register(this.getView(), this.onResize.bind(this));
+      },
+
+      /** Reset camera, lights based on scene bounding box. */
+      resetThreejsRenderer: function()
+      {
+         let sbbox = new THREE.Box3();
+         sbbox.setFromObject( this.scene );
+
+         let posV = new THREE.Vector3; posV.subVectors(sbbox.max, this.rot_center);
+         let negV = new THREE.Vector3; negV.subVectors(sbbox.min, this.rot_center);
+
+         let extV = new THREE.Vector3; extV = negV; extV.negate(); extV.max(posV);
+         let extR = extV.length();
+
+         let lc = this.point_lights.children;
+         lc[0].position.set( extR, extR, -extR);
+         lc[1].position.set(-extR, extR,  extR);
+         lc[2].position.set( extR, extR,  extR);
+
+         if (this.camera.isPerspectiveCamera)
+         {
+            let posC = new THREE.Vector3(-0.7 * extR, 0.5 * extR, -0.7 * extR);
+
+            this.camera.position.copy(posC);
+
+            this.controls.screenSpacePanning = true;
+
+            // console.log("resetThreejsRenderer 3D scene bbox ", sbbox, ", camera_pos ", posC, ", look_at ", this.rot_center);
+         }
+         else
+         {
+            let posC = new THREE.Vector3(0, 0, 1000);
+
+            this.camera.position.copy(posC);
+
+            let ey = 1.02 * extV.y;
+            let ex = ey / this.getView().$().height() * this.getView().$().width();
+            this.camera.left   = -ex;
+            this.camera.right  =  ex;
+            this.camera.top    =  ey;
+            this.camera.bottom = -ey;
+
+            this.controls.resetOrthoPanZoom();
+
+            this.controls.screenSpacePanning = true;
+            this.controls.enableRotate = false;
+
+            // console.log("resetThreejsRenderer 2D scene bbox ex ey", sbbox, ex, ey, ", camera_pos ", posC, ", look_at ", this.rot_center);
+         }
+         this.controls.target.copy( this.rot_center );
+
+         this.composer.reset();
+
+         this.controls.update();
+      },
+
+
+      //==============================================================================
+      // Common functions between THREE and GeoPainter
+      //==============================================================================
+
+      /** returns container for 3d objects */
+      // XXXX rename to getEveSceneContainer - fix also in EveScene.js
+      getThreejsContainer: function(scene_name)
+      {
+         let parent = direct_threejs ? this.scene : this.geo_painter.getExtrasContainer();
+
+         for (let k = 0; k < parent.children.length; ++k)
+         {
+            if (parent.children[k]._eve_name === scene_name)
+            {
+               return parent.children[k];
+            }
+         }
+
+         let obj3d = new THREE.Object3D();
+         obj3d._eve_name = scene_name;
+         parent.add(obj3d);
+         return obj3d;
+      },
+
+      /** Render (use GeoPainter or not, initialize dom / controls on first entry)
+          XXXX Init stuff needs to go elsewhere.
+          XXXX Camera pos etc should also be reset on first arrival of scenes.
+       */
+      render: function()
+      {
+         if (direct_threejs)
+         {
+            // console.log(this.camera, this.controls, this.controls.target);
+
+            // Render through composer:
+            this.composer.render( this.scene, this.camera );
+
+            // or directly through renderer:
+            // this.renderer.render( this.scene, this.camera );
+         }
+         else
+         {
+            if (this.geo_painter) {
+               this.geo_painter.Render3D();
+            }
+         }
+      },
+
+      createScenes: function()
+      {
+         if (this.created_scenes !== undefined) return;
+         this.created_scenes = [];
+
+         // only when rendering completed - register for modify events
+         let element = this.mgr.GetElement(this.elementid);
+
+         // loop over scene and add dependency
+         for (let scene of element.childs)
+         {
+            this.created_scenes.push(new EveScene(this.mgr, scene, this));
+         }
+      },
+
+      redrawScenes: function()
+      {
+         for (let s of this.created_scenes)
+         {
+            s.redrawScene();
+         }
+      },
+
+
+      /// invoked from ResizeHandler
+      onResize: function(event)
+      {
          if (this.resize_tmout) clearTimeout(this.resize_tmout);
-         this.resize_tmout = setTimeout(this.onResizeTimeout.bind(this), 300); // minimal latency
+         this.resize_tmout = setTimeout(this.onResizeTimeout.bind(this), 250); // minimal latency
       },
 
-      onResizeTimeout: function() {
+      onResizeTimeout: function()
+      {
          delete this.resize_tmout;
+
+         // console.log("onResizeTimeout", this.camera);
 
          // TODO: should be specified somehow in XML file
          this.getView().$().css("overflow", "hidden").css("width", "100%").css("height", "100%");
 
-         if (this.geo_painter){
+         if (this.geo_painter)
+         {
             this.geo_painter.CheckResize();
-            if (this.geo_painter._effectFXAA)
-               this.geo_painter._effectFXAA.uniforms[ 'resolution' ].value.set( 1 / this.geo_painter._scene_width, 1 / this.geo_painter._scene_height );
+            if (this.geo_painter.fxaa_pass)
+               this.geo_painter.fxaa_pass.uniforms[ 'resolution' ].value.set( 1 / this.geo_painter._scene_width, 1 / this.geo_painter._scene_height );
+            return;
+         }
+
+         let w = this.getView().$().width();
+         let h = this.getView().$().height();
+
+         if (this.camera.isPerspectiveCamera)
+         {
+            this.camera.aspect = w / h;
+         }
+         else
+         {
+            this.camera.left  =  this.camera.bottom / h * w;
+            this.camera.right = -this.camera.left;
+            this.camera.updateProjectionMatrix();
+         }
+         this.camera.updateProjectionMatrix();
+
+         this.renderer.setSize(w, h);
+         this.outline_pass.setSize(w, h);
+         this.fxaa_pass.uniforms.resolution.value.set(0.5 / w, 0.5 / h);
+
+         this.composer.reset();
+         this.controls.update();
+         this.render();
+      },
+
+
+      //==============================================================================
+      // THREE renderer event handlers etc.
+      //==============================================================================
+
+      //------------------------------------------------------------------------------
+      // Highlight & Mouse move timeout handling
+      //------------------------------------------------------------------------------
+
+      clearHighlight: function()
+      {
+         if (this.highlighted_scene)
+         {
+            this.highlighted_scene.clearHighlight(); // XXXX should go through manager
+            this.highlighted_scene = 0;
+
+            this.ttip.style.display = "none";
+        }
+      },
+
+      removeMouseMoveTimeout: function()
+      {
+         if (this.mousemove_timeout)
+         {
+            clearTimeout(this.mousemove_timeout);
+            this.mousemove_timeout = 0;
          }
       },
+
+      onMouseMoveTimeout: function(event)
+      {
+         this.mousemove_timeout = 0;
+
+         let x = event.offsetX;
+         let y = event.offsetY;
+         let w = this.getView().$().width();
+         let h = this.getView().$().height();
+
+         // console.log("GLC::onMouseMoveTimeout", this, event, x, y);
+
+         let mouse = new THREE.Vector2( ((x + 0.5) / w) * 2 - 1, -((y + 0.5) / h) * 2 + 1 );
+
+         this.raycaster.setFromCamera(mouse, this.camera);
+
+         let intersects = this.raycaster.intersectObjects(this.scene.children, true);
+
+         let o = null, c = null;
+
+         for (let i = 0; i < intersects.length; ++i)
+         {
+            o = intersects[i].object;
+            if (o.get_ctrl)
+            {
+               c = o.get_ctrl();
+               c.elementHighlighted(c.extractIndex(intersects[i]));
+
+               this.highlighted_scene = c.obj3d.scene;
+
+               break;
+            }
+         }
+
+         if (c)
+         {
+            this.ttip_text.innerHTML = c.obj3d.eve_el.fName;
+
+            let del  = this.getView().getDomRef();
+            let offs = (mouse.x > 0 || mouse.y < 0) ? this.getRelativeOffsets(del) : null;
+
+            if (mouse.x <= 0) {
+               this.ttip.style.left  = (x + del.offsetLeft + 10) + "px";
+               this.ttip.style.right = null;
+            } else {
+               this.ttip.style.right = (w - x + offs.right + 10) + "px";
+               this.ttip.style.left  = null;
+            }
+            if (mouse.y >= 0) {
+               this.ttip.style.top    = (y + del.offsetTop + 10) + "px";
+               this.ttip.style.bottom = null;
+            } else {
+               this.ttip.style.bottom = (h - y + offs.bottom + 10) + "px";
+               this.ttip.style.top = null;
+            }
+            this.ttip.style.display= "block";
+         }
+      },
+
+      getRelativeOffsets: function(elem)
+      {
+         // Based on:
+         // https://stackoverflow.com/questions/3000887/need-to-calculate-offsetright-in-javascript
+
+         let r = { left: 0, right: 0, top:0, bottom: 0 };
+
+         let parent = elem.offsetParent;
+
+         while (parent && getComputedStyle(parent).position === 'relative')
+         {
+            r.top    += elem.offsetTop;
+            r.left   += elem.offsetLeft;
+            r.right  += parent.offsetWidth  - (elem.offsetLeft + elem.offsetWidth);
+            r.bottom += parent.offsetHeight - (elem.offsetTop  + elem.offsetHeight);
+
+            elem   = parent;
+            parent = parent.offsetParent;
+         }
+
+         return r;
+      },
+
+      //------------------------------------------------------------------------------
+      // Mouse button handlers, selection, context menu
+      //------------------------------------------------------------------------------
+
+      removeMouseupListener: function()
+      {
+         if (this.mouseup_listener)
+         {
+            this.renderer.domElement.removeEventListener('mouseup', this.mouseup_listener);
+            this.mouseup_listener = 0;
+         }
+      },
+
+      showContextMenu: function(event, menu)
+      {
+         // console.log("GLC::showContextMenu", this, menu)
+
+         // See js/scripts/JSRootPainter.jquery.js JSROOT.Painter.createMenu(), menu.add()
+
+         menu.add("header:Context Menu");
+
+         menu.add("Reset camera", this.resetThreejsRenderer);
+
+         menu.add("separator");
+
+         let fff = this.defaultContextMenuAction;
+         menu.add("sub:Sub Test");
+         menu.add("Foo",     'foo', fff);
+         menu.add("Bar",     'bar', fff);
+         menu.add("Baz",     'baz', fff);
+         menu.add("endsub:");
+
+         menu.show(event);
+      },
+
+      defaultContextMenuAction: function(arg)
+      {
+         console.log("GLC::defaultContextMenuAction", this, arg);
+      },
+
+      handleMouseSelect: function(event)
+      {
+         let x = event.offsetX;
+         let y = event.offsetY;
+         let w = this.getView().$().width();
+         let h = this.getView().$().height();
+
+         // console.log("GLC::handleMouseSelect", this, event, x, y);
+
+         let mouse = new THREE.Vector2( ((x + 0.5) / w) * 2 - 1, -((y + 0.5) / h) * 2 + 1 );
+
+         this.raycaster.setFromCamera(mouse, this.camera);
+
+         let intersects = this.raycaster.intersectObjects(this.scene.children, true);
+
+         let o = null, c = null;
+
+         for (let i = 0; i < intersects.length; ++i)
+         {
+            o = intersects[i].object;
+
+            if (o.get_ctrl)
+            {
+               c = o.get_ctrl();
+               c.event = event;
+
+               c.elementSelected(c.extractIndex(intersects[i]));
+
+               this.highlighted_scene = o.scene;
+
+               break;
+            }
+         }
+
+         if ( ! c)
+         {
+            // XXXX HACK - handlersMIR senders should really be in the mgr
+
+            this.created_scenes[0].processElementSelected(null, [], event);
+         }
+      },
+
    });
 
+
+   //==============================================================================
+   // Global / non-prototype members
+   //==============================================================================
+
+   let GLC = rootui5.eve7.Controller.GL;
+
+   GLC.g_highlight_update = function(mgr)
+   {
+      let sa = THREE.OutlinePass.selection_atts;
+      let gs = mgr.GetElement(mgr.global_selection_id);
+      let gh = mgr.GetElement(mgr.global_highlight_id);
+
+      sa[0].visibleEdgeColor.setStyle(JSROOT.Painter.root_colors[gs.fVisibleEdgeColor]);
+      sa[0].hiddenEdgeColor .setStyle(JSROOT.Painter.root_colors[gs.fHiddenEdgeColor]);
+      sa[1].visibleEdgeColor.setStyle(JSROOT.Painter.root_colors[gh.fVisibleEdgeColor]);
+      sa[1].hiddenEdgeColor .setStyle(JSROOT.Painter.root_colors[gh.fHiddenEdgeColor]);
+   }
+
+   GLC.g_global_init = function(glc)
+   {
+      glc.mgr.RegisterSelectionChangeFoo(GLC.g_highlight_update);
+
+      GLC.g_highlight_update(glc.mgr);
+
+      GLC.g_global_init_done = true;
+   }
+
+   return maybe_proto;
 });

--- a/ui5/eve7/controller/Main.controller.js
+++ b/ui5/eve7/controller/Main.controller.js
@@ -6,8 +6,9 @@ sap.ui.define(['sap/ui/core/Component',
                'sap/m/library',
                'sap/m/Button',
                'sap/m/MenuItem',
+               'sap/m/MessageStrip',
                'rootui5/eve7/lib/EveManager'
-], function(Component, UIComponent, Controller, Splitter, SplitterLayoutData, MobileLibrary, mButton, mMenuItem, EveManager) {
+              ], function(Component, UIComponent, Controller, Splitter, SplitterLayoutData, MobileLibrary, mButton, mMenuItem, mMessageStrip, EveManager) {
 
    "use strict";
 
@@ -22,39 +23,40 @@ sap.ui.define(['sap/ui/core/Component',
          this.mgr.UseConnection(conn_handle);
          // this.mgr.UseConnection(this.getView().getViewData().conn_handle);
 
+         this.mgr.RegisterController(this);
          // method to found summary controller by ID and set manager to it
          var elem = this.byId("Summary");
          var ctrl = elem.getController();
          ctrl.SetMgr(this.mgr);
-
-         this.mgr.RegisterUpdate(this, "onManagerUpdate");
       },
 
-      getHandle: function () {
-         return this.handle;
+      onDisconnect : function() {
+         var t = this.byId("centerTitle");
+         t.setHtmlText("<strong style=\"color: red;\">Client Disconnected !</strong>");
       },
+
 
       UpdateCommandsButtons: function(cmds) {
-          if (!cmds || this.commands) return;
+         if (!cmds || this.commands) return;
 
-          var toolbar = this.byId("otb1");
+         var toolbar = this.byId("otb1");
 
-          this.commands = cmds;
-          for (var k=cmds.length-1;k>=0;--k) {
-             var btn = new mButton({
-                // text: "ButtonNew",
-                icon: cmds[k].icon,
-                tooltip: cmds[k].name,
-                press: this.mgr.executeCommand.bind(this.mgr, cmds[k])
-              });
-             toolbar.insertContent(btn, 0);
-          }
+         this.commands = cmds;
+         var pthis = this;
+         for (var k=cmds.length-1;k>=0;--k) {
+            var btn = new mButton({
+               icon: cmds[k].icon,
+               tooltip: cmds[k].name,
+               press: pthis.executeCommand.bind(pthis, cmds[k])
+            });
+            toolbar.insertContentLeft(btn, 0);
+         }
       },
-      
+
       viewItemPressed: function (elem, oEvent) {
          var item = oEvent.getSource();
          console.log('item pressed', item.getText(), elem);
-         
+
          var name = item.getText();
          if (name.indexOf(" ")>0) name = name.substr(0, name.indexOf(" "));
 
@@ -64,7 +66,7 @@ sap.ui.define(['sap/ui/core/Component',
          var oRouter = UIComponent.getRouterFor(this);
          oRouter.navTo("View", { viewName: name });
       },
-      
+
       updateViewers: function(loading_done) {
          var viewers = this.mgr.FindViewers();
 
@@ -75,14 +77,14 @@ sap.ui.define(['sap/ui/core/Component',
             if (!el.$view_created && el.fRnrSelf) staged.push(el);
          }
          if (staged.length == 0) return;
-         
+
          console.log("FOUND viewers", viewers.length, "not yet exists", staged.length);
-         
+
          if (staged.length > 1) {
             var vMenu = this.getView().byId("menuViewId");
             var item = new mMenuItem({text:"Browse to"});
             vMenu.addItem(item);
-            for (var n=0;n<staged.length;++n) 
+            for (var n=0;n<staged.length;++n)
                item.addItem(new mMenuItem({text: staged[n].fName, press: this.viewItemPressed.bind(this, staged[n]) }));
          }
 
@@ -101,12 +103,12 @@ sap.ui.define(['sap/ui/core/Component',
                oLd = new SplitterLayoutData({ resizable: true, size: "50%" });
 
             var vtype = "rootui5.eve7.view.GL";
-            if (elem.fName === "Table") 
+            if (elem.fName === "Table")
                vtype = "rootui5.eve7.view.EveTable"; // AMT temporary solution
             else
-               elem.view_kind = (n==0) ? "3D" : "2D"; // FIXME: should be property of GL view 
-            
-            
+               elem.view_kind = (n==0) ? "3D" : "2D"; // FIXME: should be property of GL view
+
+
             var oOwnerComponent = Component.getOwnerComponentFor(this.getView());
             var view = oOwnerComponent.runAsOwner(function() {
                return new sap.ui.xmlview({
@@ -131,7 +133,7 @@ sap.ui.define(['sap/ui/core/Component',
          }
       },
 
-      onManagerUpdate: function() {
+      OnEveManagerInit: function() {
          console.log("manager updated");
          this.UpdateCommandsButtons(this.mgr.commands);
          this.updateViewers();
@@ -185,8 +187,29 @@ sap.ui.define(['sap/ui/core/Component',
       showHelp : function(oEvent) {
          alert("User support: root-webgui@cern.ch");
       },
+
       showUserURL : function(oEvent) {
          MobileLibrary.URLHelper.redirect("https://github.com/alja/jsroot/blob/dev/eve7.md", true);
+      },
+
+      executeCommand : function(cmd) {
+         if (!cmd || !this.mgr.handle)
+            return;
+
+         // idealy toolbar shoulf be unactive, but thus is the role af web application
+         if (this.mgr.busyProcessingChanges) {
+            return;
+         }
+
+         var obj = { "mir": cmd.func, "fElementId": cmd.elementid, "class": cmd.elementclass };
+         // only for real connections send commands to server
+         // only with NextEvent command meaningful handling is possible
+         if ((this.mgr.handle.kind != "file") || (cmd.name == "NextEvent"))
+            this.mgr.SendMIR(obj);
+         if ((cmd.name == "QuitRoot") && window) {
+             window.close();
+         }
       }
+
    });
 });

--- a/ui5/eve7/controller/Summary.controller.js
+++ b/ui5/eve7/controller/Summary.controller.js
@@ -16,7 +16,6 @@ sap.ui.define([
             SplitterLayoutData, VerticalLayout, HorizontalLayout) {
 
    "use strict";
-
    var UI5PopupColors = {
          aliceblue: 'f0f8ff',
          antiquewhite: 'faebd7',
@@ -215,146 +214,85 @@ sap.ui.define([
          oTree.setIncludeItemInSelection(true);
          this.expandLevel = 2;
 
-         if (false) {
-            var oModel = new JSONModel();
-            oModel.setData([]);
-            oModel.setSizeLimit(10000);
-            this.getView().setModel(oModel, "treeModel");
+         var oModel = new JSONModel();
+         oModel.setData([]);
+         oModel.setSizeLimit(10000);
+         oModel.setDefaultBindingMode("OneWay");
+         this.getView().setModel(oModel, "treeModel");
 
-         } else {
-            var oModel = new JSONModel();
-            oModel.setData([]);
-            oModel.setSizeLimit(10000);
-            this.getView().setModel(oModel, "treeModel");
+         var oItemTemplate = new EveSummaryTreeItem({
+            title: "{treeModel>fName}",
+            visible: "{treeModel>fVisible}",
+            type: "{treeModel>fType}",
+            highlight: "{treeModel>fHighlight}",
+            background: "{treeModel>fBackground}"
+         });
+         oItemTemplate.attachDetailPress({}, this.onDetailPress, this);
+         oItemTemplate.attachBrowserEvent("mouseenter", this.onMouseEnter, this);
+         oItemTemplate.attachBrowserEvent("mouseleave", this.onMouseLeave, this);
+         oTree.bindItems("treeModel>/", oItemTemplate);
+         this.template = oItemTemplate;
 
-            var oItemTemplate = new EveSummaryTreeItem({
-               title: "{treeModel>fName}",
-               visible: "{treeModel>fVisible}",
-               type: "{treeModel>fType}",
-               highlight: "{treeModel>fHighlight}",
-               background: "{treeModel>fBackground}"
-            });
-            oItemTemplate.attachDetailPress({}, this.onDetailPress, this);
-            oItemTemplate.attachBrowserEvent("mouseenter", this.onMouseEnter, this);
-            oItemTemplate.attachBrowserEvent("mouseleave", this.onMouseLeave, this);
-            /*
-              var oDataTemplate = new sap.ui.core.CustomData({
-              key:"eveElement"
-              });
-              oDataTemplate.bindProperty("value", "answer");
-            */
-            oTree.bindItems("treeModel>/", oItemTemplate);
-         }
 
          this.oModelGED = new JSONModel({ "widgetlist" : [] });
          this.getView().setModel(this.oModelGED, "ged");
 
-         this.oGuiClassDef = {
-            "REveElement" : [{
-               name : "RnrSelf",
-               _type   : "Bool"
-            }, {
-               name : "RnrChildren",
-               _type   : "Bool"
-            }, {
-               name : "MainColor",
-               member: "fMainColor",
-               srv  : "SetMainColorRGB",
-               _type   : "Color"
-            }, {
-               name : "Destroy ",
-               member: "fElementId",
-               srv  : "Destroy",
-               _type   : "Action"
-            }],
-            "REveElementList" : [ {sub: ["REveElement"]}],
-            "REveGeoShape" : [ {sub: ["REveElement"]}, ],
-            "REveCompound" : [ {sub: ["REveElement"]}],
-            "REvePointSet" : [
-            {
-               sub: ["REveElement" ]
-            }, {
-               name : "MarkerSize",
-               _type   : "Number"
-            }],
-             "REveJetCone" : [
-            {
-               name : "RnrSelf",
-               _type   : "Bool"
-            }, {
-               name : "ConeColor",
-               member: "fMainColor",
-               srv  : "SetMainColorRGB",
-                _type   : "Color"
-            }, {
-               name : "NDiv",
-               _type   : "Number"
-            }],
-            "REveDataCollection" : [{
-               name : "FilterExpr",
-                _type   : "String",
-                quote : 1
-            },{
-                name : "CollectionVisible",
-                member:"fRnrSelf",
-               _type   : "Bool"
-            }, {
-               name : "Collection Color",
-               member: "fMainColor",
-               srv  : "SetCollectionColorRGB",
-               _type   : "Color"
-           }],
-           "REveDataItem" : [{
-               name : "ItemColor",
-               member: "fMainColor",
-               srv: "SetItemColorRGB",
-               _type   : "Color"
-           },{
-               name : "ItemRnrSelf",
-               member: "fRnrSelf",
-               _type   : "Bool"
-           },{
-               name : "Filtered",
-               _type   : "Bool"
-           }],
-           "REveTrack" : [
-            {
-               name : "RnrSelf",
-               _type   : "Bool"
-            }, {
-               name : "LineColor",
-               member: "fMainColor",
-               srv  : "SetMainColorRGB",
-               _type   : "Color"
-            }, {
-               name : "LineWidth",
-               _type   : "Number"
-            }, {
-               name : "Destroy ",
-               member: "fElementId",
-               srv  : "Destroy",
-               _type   : "Action"
-            }],
-           "REveDataGeoShape" : [{
-            }]
+         let make_col_obj = function(stem) {
+            return { name: stem, member: "f" + stem, srv: "Set" + stem + "RGB", _type: "Color" };
          };
 
+         let make_main_col_obj = function(label, use_main_setter) {
+            return { name: label, member: "fMainColor", srv: "Set" + (use_main_setter ? "MainColor" : label) + "RGB", _type: "Color" };
+         };
+
+         this.oGuiClassDef = {
+            "REveElement" : [
+               { name : "RnrSelf",     _type : "Bool" },
+               { name : "RnrChildren", _type : "Bool" },
+               make_main_col_obj("Color", true),
+               { name : "Destroy",  member : "fElementId", srv : "Destroy",  _type : "Action" },
+            ],
+            "REveElementList" : [ { sub: ["REveElement"] }, ],
+            "REveSelection"   : [ make_col_obj("VisibleEdgeColor"), make_col_obj("HiddenEdgeColor"), ],
+            "REveGeoShape"    : [ { sub: ["REveElement"] } ],
+            "REveCompound"    : [ { sub: ["REveElement"] } ],
+            "REvePointSet" : [
+               { sub: ["REveElement" ] },
+               { name : "MarkerSize", _type : "Number" }
+            ],
+            "REveJetCone" : [
+               { name : "RnrSelf", _type : "Bool" },
+               make_main_col_obj("ConeColor", true),
+               { name : "NDiv",    _type : "Number" }
+            ],
+            "REveDataCollection" : [
+               { name : "FilterExpr",  _type : "String",   quote : 1 },
+               { name : "CollectionVisible",  member :"fRnrSelf",  _type : "Bool" },
+               make_main_col_obj("CollectionColor")
+            ],
+            "REveDataItem" : [
+               make_main_col_obj("ItemColor"),
+               { name : "ItemRnrSelf",   member : "fRnrSelf",  _type : "Bool" },
+               { name : "Filtered",   _type : "Bool" }
+            ],
+            "REveTrack" : [
+               { name : "RnrSelf",   _type : "Bool" },
+               make_main_col_obj("LineColor", true),
+               { name : "LineWidth", _type : "Number" },
+               { name : "Destroy",  member : "fElementId",  srv : "Destroy", _type : "Action" }
+            ],
+         };
+         this.rebuild=false;
       },
 
       SetMgr: function(mgr) {
          this.mgr = mgr;
-
-         this.mgr.RegisterUpdate(this, "UpdateMgr");
-         this.mgr.RegisterElementUpdate(this, "updateGED");
-
+         this.mgr.RegisterController(this);
          this.selected = {}; // container of selected objects
-         // process scene-specific events
-         this.mgr.addSceneHandler(this);
+
       },
 
-      UpdateMgr: function(mgr) {
-
-         console.log('UPDATE MGR', (new Date).toTimeString());
+      OnEveManagerInit: function() {
          var model = this.getView().getModel("treeModel");
          model.setData(this.createSummaryModel());
          model.refresh();
@@ -367,6 +305,11 @@ sap.ui.define([
             var gedFrame =  this.gedVert;
             gedFrame.unbindElement();
             gedFrame.destroyContent();
+         }
+
+         var scenes = this.mgr.childs[0].childs[2].childs;
+         for (var i = 0; i < scenes.length; ++i ) {
+            this.mgr.RegisterSceneReceiver(scenes[i].fElementId, this);
          }
       },
 
@@ -472,71 +415,14 @@ sap.ui.define([
           this.oModelGED.setData({ "widgetlist": modelw });
       },
 
-      /** Selection of element in the other editors */
-      setElementSelected: function(mstrid, col, indx, from_interactive) {
-         if (!from_interactive)
-            this.selected[mstrid] = { id: mstrid, col: col, indx: indx };
-
-         var model = this.getView().getModel("treeModel");
-
-         this.iterateTreeModel(model.getData(), function(elem) {
-            if (elem.masterid == mstrid) elem.fHighlight = (col && mstrid) ? "Information" : "None";
-         });
-
-         model.refresh();
-      },
-
-      iterateTreeModel: function(data, func) {
-         if (!data) return;
-
-         for (var k=0;k<data.length;++k) {
-            func(data[k]);
-            if (data[k].childs)
-               this.iterateTreeModel(data[k].childs, func);
-         }
-      },
-
-      setElementHighlighted: function(mstrid, col, indx) {
-         var model = this.getView().getModel("treeModel");
-
-         this.iterateTreeModel(model.getData(), function(elem) {
-            if (elem.masterid == mstrid) elem.fBackground = (col && mstrid) ? "yellow" : "";
-         });
-
-         model.refresh();
-
-         /*
-         var items = this.getView().byId("tree").getItems();
-
-         for (var n = 0; n<items.length;++n) {
-            var item = items[n],
-                ctxt = item.getBindingContext("treeModel"),
-                path = ctxt.getPath(),
-                ttt = item.getBindingContext("treeModel").getProperty(path);
-
-            var h_col = (col && mstrid && (mstrid == ttt.masterid)) ? "yellow" : "";
-            if (!h_col && ttt.sel_color) h_col = ttt.sel_color;
-
-            item.$().css("background-color", h_col);
-         }
-         */
-      },
-
       onItemPressed: function(oEvent) {
          var model = oEvent.getParameter("listItem").getBindingContext("treeModel"),
              path =  model.getPath(),
              ttt = model.getProperty(path);
 
          console.log("Summary::onItemPressed ", this.mgr.GetElement(ttt.id));
-         if (!ttt || (ttt.childs !== undefined) || !ttt.masterid) return;
-
-         var sel_color = ttt.fHighlight == "None" ? "blue" : "";
-
-         this.setElementSelected(ttt.masterid, sel_color, undefined);
-
-         this.mgr.invokeInOtherScenes(this, "setElementSelected", ttt.masterid, sel_color, undefined);
-
-         // var obj = this.mgr.GetElement(ttt.id);
+         if (!ttt || (ttt.childs !== undefined) || !ttt.id) return;
+        // this.setElementSelected(ttt.id, sel_color, undefined);
       },
 
 
@@ -544,6 +430,7 @@ sap.ui.define([
       },
 
       onMouseEnter: function(oEvent) {
+         /*
          var items = this.getView().byId("tree").getItems(), item = null;
          for (var n = 0; n < items.length; ++n)
             if (items[n].getId() == oEvent.target.id) {
@@ -558,14 +445,15 @@ sap.ui.define([
 
          var ttt = item.getBindingContext("treeModel").getProperty(path);
 
-         var masterid = this.mgr.GetMasterId(ttt.id);
-
-         this.mgr.invokeInOtherScenes(this, "setElementHighlighted", masterid, "cyan");
+*/
       },
-
+      SelectElement: function(election_obj, element_id, sec_idcs) {
+      },
+      UnselectElement: function (selection_obj, element_id) {
+      },
       onMouseLeave: function(oEvent) {
          // actual call will be performed 100ms later and can be overwritten
-
+/*
          var items = this.getView().byId("tree").getItems(), item = null;
          for (var n = 0; n < items.length; ++n)
             if (items[n].getId() == oEvent.target.id) {
@@ -580,9 +468,7 @@ sap.ui.define([
 
          var ttt = item.getBindingContext("treeModel").getProperty(path);
 
-         var masterid = this.mgr.GetMasterId(ttt.id);
-
-         this.mgr.invokeInOtherScenes(this, "setElementHighlighted", masterid, null);
+*/
       },
 
       toggleEditor: function() {
@@ -878,9 +764,37 @@ sap.ui.define([
          return tgt;
       },
 
-      endChanges: function(rebuild) {
-         if (rebuild) updateManger(this.mgr);
-      }
+      beginChanges: function() {
+        // this.rebuild=false;
+      },
 
+      elementsRemoved: function(ids) {
+         this.rebuild=true;
+      },
+
+      endChanges: function() {
+         if (this.rebuild) {
+            var oTree = this.getView().byId("tree");
+            oTree.unbindItems();
+
+            var model = this.getView().getModel("treeModel");
+            model.setData(this.createSummaryModel());
+            model.refresh();
+
+            this.getView().setModel(model, "treeModel");
+            oTree.bindItems("treeModel>/", this.template);
+            oTree.setModel(model, "treeModel");
+
+            oTree.expandToLevel(this.expandLevel);
+
+            if (this.ged && this.ged.visible) {
+               var pp = this.byId("sumSplitter");
+               pp.removeContentArea(this.ged);
+               this.ged.visible = false;
+            }
+
+            this.rebuild=false;
+         }
+      }
    });
 });

--- a/ui5/eve7/css/eve.css
+++ b/ui5/eve7/css/eve.css
@@ -9,3 +9,18 @@
         font-family: "72",Arial,Helvetica,sans-serif;
         font-size: 0.775rem; 
 }
+
+.eve_tooltip {
+  position:      absolute;
+  min-width:     50px;
+  text-align:    left;
+  padding:       4px 4px;
+  font-family:   monospace;
+  background:    #c0c0c0;
+  display:       none;
+  opacity:       80;
+  border:        2px solid black;
+  box-shadow:    2px 2px 3px rgba(0, 0, 0, 0.5);
+  border-radius: 3px;
+  white-space:   pre;
+}

--- a/ui5/eve7/lib/EveScene.js
+++ b/ui5/eve7/lib/EveScene.js
@@ -19,12 +19,10 @@ sap.ui.define([
       this.viewer  = viewer;
       this.creator = new EveElements();
       this.creator.useIndexAsIs = (JSROOT.GetUrlOption('useindx') !== null);
-      this.id2obj_map  = {}; // base on element id
-      this.mid2obj_map = {}; // base on master id
+      this.id2obj_map  = new Map; // base on element id
+      this.mid2obj_map = new Map; // base on master id
 
       this.first_time = true;
-
-      this.selected = {}; // generic map of selected objects
 
       // register ourself for scene events
       this.mgr.RegisterSceneReceiver(scene.fSceneId, this);
@@ -33,37 +31,32 @@ sap.ui.define([
       scene.eve_scene = this;
    }
 
-   EveScene.prototype.hasRenderData = function(elem)
-   {
-      if (elem === undefined)
-         elem = this.mgr.GetElement(this.id);
-
-      if (!elem) return false;
-      if (elem.render_data) return true;
-      if (elem.childs)
-         for (var k = 0; k < elem.childs.length; ++k)
-            if (this.hasRenderData(elem.childs[k])) return true;
-      return false;
-   }
+   //==============================================================================
+   // Render object creation / management
+   //==============================================================================
 
    EveScene.prototype.makeGLRepresentation = function(elem)
    {
       if ( ! elem.render_data) return null;
 
-      var fname = elem.render_data.rnr_func;
-      var obj3d = this.creator[fname](elem, elem.render_data);
+      let fname = elem.render_data.rnr_func;
+      let obj3d = this.creator[fname](elem, elem.render_data);
 
       if (obj3d)
       {
+         // MT ??? why?, it can really be anything, even just container Object3D
          obj3d._typename = "THREE.Mesh";
+
+         // XXXX Sanitize these members!!!
 
          // SL: this is just identifier for highlight, required to show items on other places, set in creator
          obj3d.geo_object = elem.fMasterId || elem.fElementId;
          obj3d.geo_name   = elem.fName; // used for highlight
 
-         obj3d.scene = this; // required for get changes when highlight/selection is changed
+         obj3d.eve_el = elem;
+         obj3d.scene  = this; // required for get changes when highlight/selection is changed
 
-         //AMT: reference needed in MIR callback
+         // AMT: reference needed in MIR callback
          obj3d.eveId  = elem.fElementId;
          obj3d.mstrId = elem.fMasterId;
 
@@ -78,6 +71,12 @@ sap.ui.define([
       }
    }
 
+   EveScene.prototype.getObj3D = function(elementId, is_master)
+   {
+      let map = is_master ? this.mid2obj_map : this.id2obj_map;
+      return map.get(elementId);
+   }
+
    EveScene.prototype.create3DObjects = function(all_ancestor_children_visible, prnt, res3d)
    {
       if (prnt === undefined) {
@@ -87,19 +86,19 @@ sap.ui.define([
 
       if (!prnt || !prnt.childs) return res3d;
 
-      for (var k = 0; k < prnt.childs.length; ++k)
+      for (let k = 0; k < prnt.childs.length; ++k)
       {
-         var elem = prnt.childs[k];
+         let elem = prnt.childs[k];
          if (elem.render_data)
          {
-            var fname = elem.render_data.rnr_func, obj3d = null;
+            let fname = elem.render_data.rnr_func, obj3d = null;
             if (!this.creator[fname])
             {
                console.error("Function " + fname + " missing in creator");
             }
             else
             {
-               var obj3d = this.makeGLRepresentation(elem);
+               let obj3d = this.makeGLRepresentation(elem);
                if (obj3d)
                {
                   // MT - should maintain hierarchy ????
@@ -108,8 +107,8 @@ sap.ui.define([
 
                   res3d.push(obj3d);
 
-                  this.id2obj_map[elem.fElementId] = obj3d;
-                  if (elem.fMasterId) this.mid2obj_map[elem.fMasterId] = obj3d;
+                  this.id2obj_map.set(elem.fElementId, obj3d);
+                  if (elem.fMasterId) this.mid2obj_map.set(elem.fMasterId, obj3d);
 
                   obj3d.visible = elem.fRnrSelf && all_ancestor_children_visible;
                   obj3d.all_ancestor_children_visible = all_ancestor_children_visible;
@@ -123,43 +122,41 @@ sap.ui.define([
       return res3d;
    }
 
+   //==============================================================================
+
+   //==============================================================================
+
    /** method insert all objects into three.js container */
    EveScene.prototype.redrawScene = function()
    {
-      if (!this.viewer) return;
+      if ( ! this.viewer) return;
 
-      var res3d = this.create3DObjects(true);
-      if (!res3d.length && this.first_time) return;
+      let res3d = this.create3DObjects(true);
+      if ( ! res3d.length && this.first_time) return;
 
-      var cont = this.viewer.getThreejsContainer("scene" + this.id);
+      let cont = this.viewer.getThreejsContainer("scene" + this.id);
       while (cont.children.length > 0)
          cont.remove(cont.children[0]);
 
-      for (var k = 0; k < res3d.length; ++k)
+      for (let k = 0; k < res3d.length; ++k)
          cont.add(res3d[k]);
 
       this.applySelectionOnSceneCreate(this.mgr.global_selection_id);
       this.applySelectionOnSceneCreate(this.mgr.global_highlight_id);
-      this.viewer.render();
-      this.first_time = false;
-   }
 
-   EveScene.prototype.getObj3D = function(elementId, is_master)
-   {
-      var map = is_master ? this.mid2obj_map : this.id2obj_map;
-      return map[elementId];
+      this.first_time = false;
    }
 
    EveScene.prototype.update3DObjectsVisibility = function(arr, all_ancestor_children_visible)
    {
       if (!arr) return;
 
-      for (var k = 0; k < arr.length; ++k)
+      for (let k = 0; k < arr.length; ++k)
       {
-         var elem = arr[k];
+         let elem = arr[k];
          if (elem.render_data)
          {
-            var obj3d = this.getObj3D(elem.fElementId);
+            let obj3d = this.getObj3D(elem.fElementId);
             if (obj3d)
             {
                obj3d.visible = elem.fRnrSelf && all_ancestor_children_visible;
@@ -171,95 +168,141 @@ sap.ui.define([
       }
    }
 
-
-
-   EveScene.prototype.colorChanged = function(el)
+   EveScene.prototype.onSceneCreate = function(id)
    {
-      if (!el.render_data) return;
-      console.log("color change ", el.fElementId, el.fMainColor);
-
-      this.replaceElement(el);
+      this.redrawScene();
    }
 
-   EveScene.prototype.replaceElement = function(el)
+   //==============================================================================
+   // Scene changes processing
+   //==============================================================================
+
+   EveScene.prototype.beginChanges = function()
    {
-      if (!this.viewer) return;
+   }
 
-      var obj3d = this.getObj3D(el.fElementId);
-      var all_ancestor_children_visible = obj3d.all_ancestor_children_visible;
-
-      var container = this.viewer.getThreejsContainer("scene" + this.id);
-
-      container.remove(obj3d);
-
-      obj3d = this.makeGLRepresentation(el);
-      obj3d.all_ancestor_children_visible = obj3d;
-
-      container.add(obj3d);
-
-
-      this.id2obj_map[el.fElementId] = obj3d;
-      if (el.fMasterId) this.mid2obj_map[el.fMasterId] = obj3d;
-
-      this.viewer.render();
+   EveScene.prototype.endChanges = function()
+   {
+      if (this.viewer)
+         this.viewer.render();
    }
 
    EveScene.prototype.elementAdded = function(el)
    {
       if ( ! this.viewer) return;
 
-      var obj3d =  this.makeGLRepresentation(el);
+      let obj3d =  this.makeGLRepresentation(el);
       if ( ! obj3d) return;
 
       // AMT this is an overkill, temporary solution
-      var scene = this.mgr.GetElement(el.fSceneId);
+      let scene = this.mgr.GetElement(el.fSceneId);
       this.update3DObjectsVisibility(scene.childs, true);
 
-      var container = this.viewer.getThreejsContainer("scene" + this.id);
+      let container = this.viewer.getThreejsContainer("scene" + this.id);
 
       container.add(obj3d);
 
-      this.id2obj_map[el.fElementId] = obj3d;
-      if (el.fMasterId) this.mid2obj_map[el.fMasterId] = obj3d;
+      this.id2obj_map.set(el.fElementId, obj3d);
+      if (el.fMasterId) this.mid2obj_map.set(el.fMasterId, obj3d);
    }
 
-   EveScene.prototype.visibilityChanged = function(el)
+   EveScene.prototype.replaceElement = function(el)
    {
-      var obj3d = this.getObj3D( el.fElementId );
+      if ( ! this.viewer) return;
 
-      if (obj3d)
+      let obj3d = this.getObj3D(el.fElementId);
+      let all_ancestor_children_visible = obj3d.all_ancestor_children_visible;
+      let visible = obj3d.visible;
+
+      let container = this.viewer.getThreejsContainer("scene" + this.id);
+
+      container.remove(obj3d);
+
+      obj3d = this.makeGLRepresentation(el);
+      obj3d.all_ancestor_children_visible = all_ancestor_children_visible;
+      obj3d.visible = visible;
+      container.add(obj3d);
+
+
+      this.id2obj_map.set(el.fElementId, obj3d);
+      if (el.fMasterId) this.mid2obj_map.set(el.fMasterId, obj3d);
+
+      this.viewer.render();
+   }
+
+   EveScene.prototype.elementRemoved = function()
+   {
+      // XXXXX how is this empty? not called?
+   }
+
+   EveScene.prototype.elementsRemoved = function(ids)
+   {
+      for (let i = 0; i < ids.length; i++)
       {
-         obj3d.visible = obj3d.all_ancestor_children_visible && el.fRnrSelf;
+         let elId  = ids[i];
+         let obj3d = this.getObj3D(elId);
+         if ( ! obj3d)
+         {
+            let  el = this.mgr.GetElement(elId);
+            if (el.render_data) {
+               console.log("ERROR EveScene.prototype.elementsRemoved can't find obj3d ",this.mgr.GetElement(el));
+            }
+            continue;
+         }
+
+         let container = this.viewer.getThreejsContainer("scene" + this.id);
+         container.remove(obj3d);
+
+         this.id2obj_map.delete(elId);
       }
    }
 
-   EveScene.prototype.visibilityChildrenChanged = function(el)
+   EveScene.prototype.sceneElementChange = function(msg)
    {
-      console.log("visibility children changed ", this.mgr, el);
+      let el = this.mgr.GetElement(msg.fElementId);
 
-      if (el.childs)
-      {
-         // XXXX Overkill, but I don't have obj3d for all elements.
-         // Also, can do this traversal once for the whole update package,
-         // needs to be managed from EveManager.js.
-         // Or marked here and then recomputed before rendering (probably better).
+      // visibility
+      if (msg.changeBit & this.mgr.EChangeBits.kCBVisibility) {
+         // self
+         if (msg.rnr_self_changed)
+         {
+            let obj3d = this.getObj3D( el.fElementId );
+            if (obj3d)
+            {
+               obj3d.visible = obj3d.all_ancestor_children_visible && el.fRnrSelf;
+            }
+         }
+         // children
+         if (msg.rnr_children_changed && el.childs)
+         {
+            let scene = this.mgr.GetElement(el.fSceneId);
+            this.update3DObjectsVisibility(scene.childs, true);
+         }
+      }
 
-         var scene = this.mgr.GetElement(el.fSceneId);
-
-         this.update3DObjectsVisibility(scene.childs, true);
+      // other change bits
+      if (el.render_data) {
+         if ((el.changeBit & this.mgr.EChangeBits.kCBObjProp) || (el.changeBit & this.mgr.EChangeBits.kCBColorSelection))
+         {
+            this.replaceElement(el);
+         }
       }
    }
+
+   //==============================================================================
+   // Selection handling
+   //==============================================================================
 
    /** interactive handler. Calculates selection state, apply to element and distribute to other scene */
-   EveScene.prototype.processElementSelected = function(obj3d, col, indx, evnt)
+   EveScene.prototype.processElementSelected = function(obj3d, indx, event)
    {
       // MT BEGIN
       // console.log("EveScene.prototype.processElementSelected", obj3d, col, indx, evnt);
 
-      var is_multi  = evnt && evnt.ctrlKey;
-      var is_secsel = indx !== undefined;
+      let is_multi  = event && event.ctrlKey;
+      let is_secsel = indx !== undefined;
 
-      var fcall = "NewElementPicked(" + obj3d.eveId + `, ${is_multi}, ${is_secsel}`;
+      let fcall = "NewElementPicked(" + (obj3d ? obj3d.eveId : 0) + `, ${is_multi}, ${is_secsel}`;
       if (is_secsel)
       {
          fcall += ", { " + (Array.isArray(indx) ? indx.join(", ") : indx) + " }";
@@ -272,94 +315,26 @@ sap.ui.define([
                        });
 
       return true;
-/*
-      // MT END -- Sergey's code below
-
-      // first decide if element selected or not
-
-      var id  = obj3d.mstrId;
-      var sel = this.selected[id];
-
-      if (indx === undefined)
-      {
-         if ( ! sel)
-         {
-            sel = this.selected[id] = { id: id, col: col };
-         }
-         else
-         {
-            // means element selected, one should toggle back
-            sel.col = null;
-            delete this.selected[id];
-         }
-      }
-      else
-      {
-         if ( ! sel)
-         {
-            sel = this.selected[id] = { id: id, col: col, indx: [] };
-         }
-         if (evnt && evnt.ctrlKey)
-         {
-            var pos = sel.indx.indexOf(indx);
-            if (pos < 0) sel.indx.push(indx); else
-                         sel.indx.splice(pos, 1);
-         }
-         else if (evnt && evnt.shiftKey)
-         {
-            if (sel.indx.length != 1) {
-               sel.indx = [ indx ];
-            } else {
-               var min = Math.min(sel.indx[0], indx),
-                   max = Math.max(sel.indx[0], indx);
-               sel.indx = [];
-               if (min != max)
-                  for (var i=min;i<=max;++i)
-                     sel.indx.push(i);
-            }
-         }
-         else
-         {
-            if ((sel.indx.length == 1) && (sel.indx[0] == indx))
-               sel.indx = [];
-            else
-               sel.indx = [ indx ];
-         }
-
-         if ( ! sel.indx.length)
-         {
-            sel.col  = null;
-            sel.indx = undefined;
-            delete this.selected[id]; // remove selection
-         }
-      }
-
-      this.setElementSelected(id, sel.col, sel.indx, true);
-
-      this.mgr.invokeInOtherScenes(this, "setElementSelected", id, sel.col, sel.indx);
-
-      // when true returns, controller will not try to render itself
-      return true;
-*/
    }
 
    /** interactive handler */
-   EveScene.prototype.processElementHighlighted = function(obj3d, col, indx, evnt)
+   EveScene.prototype.processElementHighlighted = function(obj3d, indx, evnt)
    {
       // Need check for duplicates before call server, else server will un-higlight highlighted element
-      // console.log("EveScene.prototype.processElementHighlighted", obj3d.eveId, col, indx, evnt);
-      var is_multi  = false;
-      var is_secsel = indx !== undefined;
+      // console.log("EveScene.prototype.processElementHighlighted", obj3d.eveId, indx, evnt);
+      let is_multi  = false;
+      let is_secsel = indx !== undefined;
 
-      var so = this.mgr.GetElement(this.mgr.global_highlight_id);
-      var a = so ? so.prev_sel_list : null;
+      let so = this.mgr.GetElement(this.mgr.global_highlight_id);
+      let a  = so ? so.prev_sel_list : null;
 
       // AMT presume there is no multiple highlight and multiple secondary selections
       // if that is the case in the futre write data in set and comapre sets
 
       // console.log("EveScene.prototype.processElementHighlighted compare Reveselection ", a[0], "incoming ", obj3d.eveId,indx);
-      if (a && (a.length == 1)) {
-         var h = a[0];
+      if (a && (a.length == 1))
+      {
+         let h = a[0];
          if (h.primary == obj3d.eveId || h.primary == obj3d.mstrId ) {
             if (indx) {
                if (h.sec_idcs && h.sec_idcs[0] == indx) {
@@ -367,20 +342,19 @@ sap.ui.define([
                   return true;
                }
             }
-            if (!indx && !h.sec_idcs.length) {
+            if ( ! indx && ! h.sec_idcs.length) {
                // console.log("processElementHighlighted primARY SElection not changed ");
                return true;
             }
          }
       }
 
-      var fcall = "NewElementPicked(" + obj3d.eveId + `, ${is_multi}, ${is_secsel}`;
+      let fcall = "NewElementPicked(" + obj3d.eveId + `, ${is_multi}, ${is_secsel}`;
       if (is_secsel)
       {
          fcall += ", { " + (Array.isArray(indx) ? indx.join(", ") : indx) + " }";
       }
       fcall += ")";
-
 
       this.mgr.SendMIR({ "mir":        fcall,
                          "fElementId": this.mgr.global_highlight_id,
@@ -393,9 +367,20 @@ sap.ui.define([
 
    EveScene.prototype.clearHighlight = function()
    {
-      var so = this.mgr.GetElement(this.mgr.global_highlight_id);
-      if (so && so.prev_sel_list && so.prev_sel_list.length) {
-         this.mgr.SendMIR({ "mir":        "SelectionCleared()",
+      // QQQQ This will have to change for multi client support.
+      // Highlight will always be multi and we will have to track
+      // which highlight is due to our connection.
+
+      let is_multi  = false;
+      let is_secsel = false;
+
+      let so = this.mgr.GetElement(this.mgr.global_highlight_id);
+
+      if (so && so.prev_sel_list && so.prev_sel_list.length)
+      {
+         let fcall = "NewElementPicked(" + 0 + `, ${is_multi}, ${is_secsel}` + ")";
+
+         this.mgr.SendMIR({ "mir":        fcall,
                             "fElementId": this.mgr.global_highlight_id,
                             "class":      "ROOT::Experimental::REveSelection"
                           });
@@ -404,21 +389,26 @@ sap.ui.define([
       return true;
    }
 
-   EveScene.prototype.applySelectionOnSceneCreate =  function(selection_id)
+   EveScene.prototype.applySelectionOnSceneCreate = function(selection_id)
    {
-      var selection_obj = this.mgr.GetElement(selection_id);
-      if (!selection_obj || !selection_obj.prev_sel_list) return;
+      let selection_obj = this.mgr.GetElement(selection_id);
+      if ( ! selection_obj || ! selection_obj.prev_sel_list) return;
+
       var pthis = this;
       selection_obj.prev_sel_list.forEach(function(rec) {
-         var prl = pthis.mgr.GetElement(rec.primary);
-         if (prl && prl.fSceneId == pthis.id) {
+
+         let prl = pthis.mgr.GetElement(rec.primary);
+         if (prl && prl.fSceneId == pthis.id)
+         {
             pthis.SelectElement(selection_obj, rec.primary, rec.sec_idcs);
          }
-         else {
-            for (var impId of rec.implied)
+         else // XXXXX why else ... should we not process all of them?!!!!
+         {
+            for (let impId of rec.implied)
             {
-               var eli =  pthis.mgr.GetElement(impId);
-               if (eli && eli.fSceneId == pthis.id) {
+               let eli = pthis.mgr.GetElement(impId);
+               if (eli && eli.fSceneId == pthis.id)
+               {
                   // console.log("CHECK select IMPLIED", pthis);
                   pthis.SelectElement(selection_obj, impId, rec.sec_idcs);
                }
@@ -429,191 +419,56 @@ sap.ui.define([
 
    EveScene.prototype.SelectElement = function(selection_obj, element_id, sec_idcs)
    {
-      this.viewer.outlinePass.id2obj_map[element_id] = this.viewer.outlinePass.id2obj_map[element_id] || [];
+      let obj3d = this.getObj3D( element_id );
+      if ( ! obj3d) return;
 
-      // if(this.viewer.outlinePass.id2obj_map[element_id][selection_obj.fElementId] !== undefined) return;
+      this.viewer.outline_pass.id2obj_map[element_id] = this.viewer.outline_pass.id2obj_map[element_id] || [];
 
-      var stype = selection_obj.fName.endsWith("Selection") ? "select" : "highlight";
-      var estype = THREE.OutlinePass.selection_enum[stype];
+      if (this.viewer.outline_pass.id2obj_map[element_id][selection_obj.fElementId] !== undefined)
+      {
+         return;
+      }
 
-      // console.log("EveScene.SelectElement ", selection_obj.fName, element_id, selection_obj.fElementId, this.viewer.outlinePass.id2obj_map);
+      let stype  = selection_obj.fName.endsWith("Selection") ? "select" : "highlight";
+      let estype = THREE.OutlinePass.selection_enum[stype];
+
+      // console.log("EveScene.SelectElement ", selection_obj.fName, element_id, selection_obj.fElementId, this.viewer.outline_pass.id2obj_map);
 
       let res = {
-         "sel_type": estype,
-         "sec_sel": false,
-         "geom": []
+         "sel_type" : estype,
+         "sec_sel"  : false,
+         "geom"     : []
       };
-      var obj3d = this.getObj3D( element_id );
 
-      if(sec_idcs === undefined || sec_idcs.length == 0)
+      if (sec_idcs === undefined || sec_idcs.length == 0)
       {
          // exit if you try to highlight an object that has already been selected
-         if(estype == THREE.OutlinePass.selection_enum["highlight"] &&
-            this.viewer.outlinePass.id2obj_map[element_id][this.mgr.global_selection_id] !== undefined
-         ) return;
+         if (estype == THREE.OutlinePass.selection_enum["highlight"] &&
+            this.viewer.outline_pass.id2obj_map[element_id][this.mgr.global_selection_id] !== undefined)
+         {
+            return;
+         }
 
-         this.viewer.outlinePass.id2obj_map[element_id] = [];
+         this.viewer.outline_pass.id2obj_map[element_id] = [];
          res.geom.push(obj3d);
       }
       else
       {
-         var ctrl = obj3d.get_ctrl();
+         let ctrl = obj3d.get_ctrl();
          ctrl.DrawForSelection(sec_idcs, res.geom);
          res.sec_sel = true;
       }
-      this.viewer.outlinePass.id2obj_map[element_id][selection_obj.fElementId] = res;
+      this.viewer.outline_pass.id2obj_map[element_id][selection_obj.fElementId] = res;
    }
 
    EveScene.prototype.UnselectElement = function(selection_obj, element_id)
    {
-      // console.log("EveScene.UnselectElement ", selection_obj.fName, element_id, selection_obj.fElementId, this.viewer.outlinePass.id2obj_map);
-      if (this.viewer.outlinePass.id2obj_map[element_id] !== undefined)
+      // console.log("EveScene.UnselectElement ", selection_obj.fName, element_id, selection_obj.fElementId, this.viewer.outline_pass.id2obj_map);
+      if (this.viewer.outline_pass.id2obj_map[element_id] !== undefined)
       {
-	      delete this.viewer.outlinePass.id2obj_map[element_id][selection_obj.fElementId];
-      }
-   }
-   /** returns true if highlight index is differs from current */
-/*   EveScene.prototype.processCheckHighlight = function(obj3d, indx)
-   {
-      var id = obj3d.mstrId;
-      // id = obj3d.eveId;
-
-      if ( ! this.highlight || (this.highlight.id != id)) return true;
-
-      // TODO: make precise checks with all combinations
-      return (indx !== this.highlight.indx);
-   }
-*/
-   /** function called by changes from server or by changes from other scenes */
-  /* EveScene.prototype.setElementSelected = function(mstrid, col, indx, from_interactive)
-   {
-      if ( ! from_interactive)
-         this.selected[mstrid] = { id: mstrid, col: col, indx: indx };
-
-      this.drawSpecial(mstrid);
-   }*/
-
-   /** Called when processing changes from server or from interactive handler */
-   /*
-   EveScene.prototype.setElementHighlighted = function(mstrid, col, indx, from_interactive)
-   {
-      // check if other element was highlighted at same time - redraw it
-      if (this.highlight && (this.highlight.id != mstrid)) {
-         delete this.highlight;
-         this.drawSpecial(mstrid);
-      }
-
-      if ( ! col)
-         delete this.highlight;
-      else
-         this.highlight = { id: mstrid, col: col, indx: indx };
-
-      this.drawSpecial(mstrid, true);
-   }*/
-/*
-   EveScene.prototype.drawSpecial = function(mstrid, prefer_highlight)
-   {
-      var obj3d = this.getObj3D( mstrid, true );
-      if ( ! obj3d || ! obj3d.get_ctrl) obj3d = this.getObj3D( mstrid );
-      if ( ! obj3d || ! obj3d.get_ctrl) return false;
-
-      var h1 = this.highlight && (this.highlight.id == mstrid) ? this.highlight : null;
-      var h2 = this.selected[mstrid];
-      var ctrl = obj3d.get_ctrl();
-
-      var did_change = false;
-
-      if (ctrl.separateDraw)
-      {
-         var p2 = "s", p1 = "h";
-         // swap h1-h2
-         if (!prefer_highlight) { var h = h1; h1 = h2; h2 = h; p2 = "h"; p1 = "s"; }
-         if (ctrl.drawSpecial(h2 ? h2.col : null, h2 ? h2.indx : undefined, p2)) did_change = true;
-         if (ctrl.drawSpecial(h1 ? h1.col : null, h1 ? h1.indx : undefined, p1)) did_change = true;
-      }
-      else
-      {
-         var h = prefer_highlight ? (h1 || h2) : (h2 || h1);
-         did_change = ctrl.drawSpecial(h ? h.col : null, h ? h.indx : undefined);
-      }
-
-      if (did_change && this.viewer){
-         this.viewer.render();
-         if(!prefer_highlight){
-            if(!this.selected[mstrid]){
-               // delete if its not selected anymore?
-               delete this.viewer.outlinePass.id2obj_map[mstrid];
-            } else {
-               // is secondary selection
-               let sec_sel = this.selected[mstrid].indx;
-
-               // if its not secondary selection pass the object
-               if(!sec_sel)
-                  this.viewer.outlinePass.id2obj_map[mstrid] = obj3d;
-               // if its secondary selection pass all the new objects returned by 'drawSpecial'
-               else {
-                  this.viewer.outlinePass.id2obj_map[mstrid] = []; // reset
-                  if(false){
-                     if(obj3d.sl_special) this.viewer.outlinePass.id2obj_map[mstrid].push(obj3d.sl_special);
-                     if(obj3d.sm_special) this.viewer.outlinePass.id2obj_map[mstrid].push(obj3d.sm_special);
-                  } else {
-                     for(const child of obj3d.children){
-                        if(child.jsroot_special)
-                           this.viewer.outlinePass.id2obj_map[mstrid].push(child);
-                     }
-                  }
-                  // print the new elements
-                  console.log(this.viewer.outlinePass.id2obj_map[mstrid]);
-               }
-            }
-         }
-      }
-
-      return did_change;
-   }
-*/
-
-   EveScene.prototype.elementRemoved = function()
-   {
-   }
-
-   EveScene.prototype.beginChanges = function()
-   {
-   }
-
-   EveScene.prototype.endChanges = function()
-   {
-      if (this.viewer)
-         this.viewer.render();
-   }
-
-   EveScene.prototype.onSceneCreate = function(id)
-   {
-      this.redrawScene();
-   }
-
-   EveScene.prototype.sceneElementChange = function(msg)
-   {
-      var el = this.mgr.GetElement(msg.fElementId);
-      this[msg.tag](el);
-   }
-
-   EveScene.prototype.elementsRemoved = function(ids) {
-      for (var  i = 0; i < ids.length; i++)
-      {
-         var elId = ids[i];
-         var obj3d = this.getObj3D(elId);
-         if (!obj3d) {
-            console.log("ERROOR cant find obj3d");
-         }
-
-         var container = this.viewer.getThreejsContainer("scene" + this.id);
-         container.remove(obj3d);
-
-         delete this.id2obj_map[elId];
+	 delete this.viewer.outline_pass.id2obj_map[element_id][selection_obj.fElementId];
       }
    }
 
    return EveScene;
-
 });

--- a/ui5/eve7/lib/OrbitControlsEve.js
+++ b/ui5/eve7/lib/OrbitControlsEve.js
@@ -1,0 +1,1204 @@
+/**
+ * @author qiao / https://github.com/qiao
+ * @author mrdoob / http://mrdoob.com
+ * @author alteredq / http://alteredqualia.com/
+ * @author WestLangley / http://github.com/WestLangley
+ * @author erich666 / http://erichaines.com
+ * @author ScieCode / http://github.com/sciecode
+ * @author osschar
+ */
+
+// This set of controls performs orbiting, dollying (zooming), and panning.
+// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
+//
+//    Orbit - left mouse / touch: one-finger move
+//    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
+//    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
+
+
+// osschar 2019-09-27: Apparently those get lost during THREE "build".
+Object.assign(THREE.MOUSE, { ROTATE: 0, DOLLY: 1, PAN: 2 });
+THREE.TOUCH = { ROTATE: 0, PAN: 1, DOLLY_PAN: 2, DOLLY_ROTATE: 3 };
+
+
+THREE.OrbitControlsEve = function ( object, domElement ) {
+
+	this.object = object;
+
+	this.domElement = ( domElement !== undefined ) ? domElement : document;
+
+	// Set to false to disable this control
+	this.enabled = true;
+
+	// "target" sets the location of focus, where the object orbits around
+	this.target = new THREE.Vector3();
+
+	// How far you can dolly in and out ( PerspectiveCamera only )
+	this.minDistance = 0;
+	this.maxDistance = Infinity;
+
+	// How far you can zoom in and out ( OrthographicCamera only )
+	this.minZoom = 0;
+	this.maxZoom = Infinity;
+
+	// How far you can orbit vertically, upper and lower limits.
+	// Range is 0 to Math.PI radians.
+	this.minPolarAngle = 0; // radians
+	this.maxPolarAngle = Math.PI; // radians
+
+	// How far you can orbit horizontally, upper and lower limits.
+	// If set, must be a sub-interval of the interval [ - Math.PI, Math.PI ].
+	this.minAzimuthAngle = - Infinity; // radians
+	this.maxAzimuthAngle = Infinity; // radians
+
+	// Set to true to enable damping (inertia)
+	// If damping is enabled, you must call controls.update() in your animation loop
+	this.enableDamping = false;
+	this.dampingFactor = 0.05;
+
+	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
+	// Set to false to disable zooming
+	this.enableZoom = true;
+	this.zoomSpeed = 1.0;
+
+	// Set to false to disable rotating
+	this.enableRotate = true;
+	this.rotateSpeed = 1.0;
+
+	// Set to false to disable panning
+	this.enablePan = true;
+	this.panSpeed = 1.0;
+	this.screenSpacePanning = false; // if true, pan in screen-space
+	this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
+
+	// Set to true to automatically rotate around the target
+	// If auto-rotate is enabled, you must call controls.update() in your animation loop
+	this.autoRotate = false;
+	this.autoRotateSpeed = 2.0; // 30 seconds per round when fps is 60
+
+	// Set to false to disable use of the keys
+	this.enableKeys = true;
+
+	// The four arrow keys
+	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
+
+	// Mouse buttons
+	this.mouseButtons = { LEFT: THREE.MOUSE.ROTATE, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN };
+
+	// Touch fingers
+	this.touches = { ONE: THREE.TOUCH.ROTATE, TWO: THREE.TOUCH.DOLLY_PAN };
+
+	// for reset
+	this.target0 = this.target.clone();
+	this.position0 = this.object.position.clone();
+	this.zoom0 = this.object.zoom;
+
+	//
+	// public methods
+	//
+
+	this.getPolarAngle = function () {
+
+		return spherical.phi;
+
+	};
+
+	this.getAzimuthalAngle = function () {
+
+		return spherical.theta;
+
+	};
+
+	this.saveState = function () {
+
+		scope.target0.copy( scope.target );
+		scope.position0.copy( scope.object.position );
+		scope.zoom0 = scope.object.zoom;
+
+	};
+
+	this.reset = function () {
+
+		scope.target.copy( scope.target0 );
+		scope.object.position.copy( scope.position0 );
+		scope.object.zoom = scope.zoom0;
+
+		scope.object.updateProjectionMatrix();
+		scope.dispatchEvent( changeEvent );
+
+		scope.update();
+
+		state = STATE.NONE;
+
+	};
+
+        // osschar - need to reset internal panOffset
+        this.resetOrthoPanZoom = function ()
+        {
+           return function resetOrthoPan() {
+              panOffset.set(0,0,0);
+              scope.object.zoom = 1;
+              scope.object.updateProjectionMatrix();
+              zoomChanged = true;
+           }
+        }();
+
+        // osschar - fake mouse up event, needed for context menu on M3 down
+        this.resetMouseDown = function (event)
+        {
+           return function resetMouseDown(event) {
+              onMouseUp(event);
+           }
+        }();
+
+	// this method is exposed, but perhaps it would be better if we can make it private...
+	this.update = function () {
+
+		var offset = new THREE.Vector3();
+
+		// so camera.up is the orbit axis
+		var quat = new THREE.Quaternion().setFromUnitVectors( object.up, new THREE.Vector3( 0, 1, 0 ) );
+		var quatInverse = quat.clone().inverse();
+
+		var lastPosition = new THREE.Vector3();
+		var lastQuaternion = new THREE.Quaternion();
+
+		return function update() {
+
+			var position = scope.object.position;
+
+			offset.copy( position ).sub( scope.target );
+
+			// rotate offset to "y-axis-is-up" space
+			offset.applyQuaternion( quat );
+
+			// angle from z-axis around y-axis
+			spherical.setFromVector3( offset );
+
+			if ( scope.autoRotate && state === STATE.NONE ) {
+
+				rotateLeft( getAutoRotationAngle() );
+
+			}
+
+			if ( scope.enableDamping ) {
+
+				spherical.theta += sphericalDelta.theta * scope.dampingFactor;
+				spherical.phi += sphericalDelta.phi * scope.dampingFactor;
+
+			} else {
+
+				spherical.theta += sphericalDelta.theta;
+				spherical.phi += sphericalDelta.phi;
+
+			}
+
+			// restrict theta to be between desired limits
+			spherical.theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, spherical.theta ) );
+
+			// restrict phi to be between desired limits
+			spherical.phi = Math.max( scope.minPolarAngle, Math.min( scope.maxPolarAngle, spherical.phi ) );
+
+			spherical.makeSafe();
+
+
+			spherical.radius *= scale;
+
+			// restrict radius to be between desired limits
+			spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius ) );
+
+			// move target to panned location
+
+			if ( scope.enableDamping === true ) {
+
+				scope.target.addScaledVector( panOffset, scope.dampingFactor );
+
+			} else {
+
+				scope.target.add( panOffset );
+
+			}
+
+			offset.setFromSpherical( spherical );
+
+			// rotate offset back to "camera-up-vector-is-up" space
+			offset.applyQuaternion( quatInverse );
+
+			position.copy( scope.target ).add( offset );
+
+			scope.object.lookAt( scope.target );
+
+			if ( scope.enableDamping === true ) {
+
+				sphericalDelta.theta *= ( 1 - scope.dampingFactor );
+				sphericalDelta.phi *= ( 1 - scope.dampingFactor );
+
+				panOffset.multiplyScalar( 1 - scope.dampingFactor );
+
+			} else {
+
+				sphericalDelta.set( 0, 0, 0 );
+
+				panOffset.set( 0, 0, 0 );
+
+			}
+
+			scale = 1;
+
+			// update condition is:
+			// min(camera displacement, camera rotation in radians)^2 > EPS
+			// using small-angle approximation cos(x/2) = 1 - x^2 / 8
+
+			if ( zoomChanged ||
+				lastPosition.distanceToSquared( scope.object.position ) > EPS ||
+				8 * ( 1 - lastQuaternion.dot( scope.object.quaternion ) ) > EPS ) {
+
+				scope.dispatchEvent( changeEvent );
+
+				lastPosition.copy( scope.object.position );
+				lastQuaternion.copy( scope.object.quaternion );
+				zoomChanged = false;
+
+				return true;
+
+			}
+
+			return false;
+
+		};
+
+	}();
+
+	this.dispose = function () {
+
+		scope.domElement.removeEventListener( 'contextmenu', onContextMenu, false );
+		scope.domElement.removeEventListener( 'mousedown', onMouseDown, false );
+		scope.domElement.removeEventListener( 'wheel', onMouseWheel, false );
+
+		scope.domElement.removeEventListener( 'touchstart', onTouchStart, false );
+		scope.domElement.removeEventListener( 'touchend', onTouchEnd, false );
+		scope.domElement.removeEventListener( 'touchmove', onTouchMove, false );
+
+		document.removeEventListener( 'mousemove', onMouseMove, false );
+		document.removeEventListener( 'mouseup', onMouseUp, false );
+
+		window.removeEventListener( 'keydown', onKeyDown, false );
+
+		//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
+
+	};
+
+	//
+	// internals
+	//
+
+	var scope = this;
+
+	var changeEvent = { type: 'change' };
+	var startEvent = { type: 'start' };
+	var endEvent = { type: 'end' };
+
+	var STATE = {
+		NONE: - 1,
+		ROTATE: 0,
+		DOLLY: 1,
+		PAN: 2,
+		TOUCH_ROTATE: 3,
+		TOUCH_PAN: 4,
+		TOUCH_DOLLY_PAN: 5,
+		TOUCH_DOLLY_ROTATE: 6
+	};
+
+	var state = STATE.NONE;
+
+	var EPS = 0.000001;
+
+	// current position in spherical coordinates
+	var spherical = new THREE.Spherical();
+	var sphericalDelta = new THREE.Spherical();
+
+	var scale = 1;
+	var panOffset = new THREE.Vector3();
+	var zoomChanged = false;
+
+	var rotateStart = new THREE.Vector2();
+	var rotateEnd = new THREE.Vector2();
+	var rotateDelta = new THREE.Vector2();
+
+	var panStart = new THREE.Vector2();
+	var panEnd = new THREE.Vector2();
+	var panDelta = new THREE.Vector2();
+
+	var dollyStart = new THREE.Vector2();
+	var dollyEnd = new THREE.Vector2();
+	var dollyDelta = new THREE.Vector2();
+
+	function getAutoRotationAngle() {
+
+		return 2 * Math.PI / 60 / 60 * scope.autoRotateSpeed;
+
+	}
+
+	function getZoomScale() {
+
+		return Math.pow( 0.95, scope.zoomSpeed );
+
+	}
+
+	function rotateLeft( angle ) {
+
+		sphericalDelta.theta -= angle;
+
+	}
+
+	function rotateUp( angle ) {
+
+		sphericalDelta.phi -= angle;
+
+	}
+
+	var panLeft = function () {
+
+		var v = new THREE.Vector3();
+
+		return function panLeft( distance, objectMatrix ) {
+
+			v.setFromMatrixColumn( objectMatrix, 0 ); // get X column of objectMatrix
+			v.multiplyScalar( - distance );
+
+			panOffset.add( v );
+
+		};
+
+	}();
+
+	var panUp = function () {
+
+		var v = new THREE.Vector3();
+
+		return function panUp( distance, objectMatrix ) {
+
+			if ( scope.screenSpacePanning === true ) {
+
+				v.setFromMatrixColumn( objectMatrix, 1 );
+
+			} else {
+
+				v.setFromMatrixColumn( objectMatrix, 0 );
+				v.crossVectors( scope.object.up, v );
+
+			}
+
+			v.multiplyScalar( distance );
+
+			panOffset.add( v );
+
+		};
+
+	}();
+
+	// deltaX and deltaY are in pixels; right and down are positive
+	var pan = function () {
+
+		var offset = new THREE.Vector3();
+
+		return function pan( deltaX, deltaY ) {
+
+			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+			if ( scope.object.isPerspectiveCamera ) {
+
+				// perspective
+				var position = scope.object.position;
+				offset.copy( position ).sub( scope.target );
+				var targetDistance = offset.length();
+
+				// half of the fov is center to top of screen
+				targetDistance *= Math.tan( ( scope.object.fov / 2 ) * Math.PI / 180.0 );
+
+				// we use only clientHeight here so aspect ratio does not distort speed
+				panLeft( 2 * deltaX * targetDistance / element.clientHeight, scope.object.matrix );
+				panUp( 2 * deltaY * targetDistance / element.clientHeight, scope.object.matrix );
+
+			} else if ( scope.object.isOrthographicCamera ) {
+
+				// orthographic
+				panLeft( deltaX * ( scope.object.right - scope.object.left ) / scope.object.zoom / element.clientWidth, scope.object.matrix );
+				panUp( deltaY * ( scope.object.top - scope.object.bottom ) / scope.object.zoom / element.clientHeight, scope.object.matrix );
+
+			} else {
+
+				// camera neither orthographic nor perspective
+				console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - pan disabled.' );
+				scope.enablePan = false;
+
+			}
+
+		};
+
+	}();
+
+	function dollyIn( dollyScale ) {
+
+		if ( scope.object.isPerspectiveCamera ) {
+
+			scale /= dollyScale;
+
+		} else if ( scope.object.isOrthographicCamera ) {
+
+			scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom * dollyScale ) );
+			scope.object.updateProjectionMatrix();
+			zoomChanged = true;
+
+		} else {
+
+			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+			scope.enableZoom = false;
+
+		}
+
+	}
+
+	function dollyOut( dollyScale ) {
+
+		if ( scope.object.isPerspectiveCamera ) {
+
+			scale *= dollyScale;
+
+		} else if ( scope.object.isOrthographicCamera ) {
+
+			scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / dollyScale ) );
+			scope.object.updateProjectionMatrix();
+			zoomChanged = true;
+
+		} else {
+
+			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+			scope.enableZoom = false;
+
+		}
+
+	}
+
+	//
+	// event callbacks - update the object state
+	//
+
+	function handleMouseDownRotate( event ) {
+
+		rotateStart.set( event.clientX, event.clientY );
+
+	}
+
+	function handleMouseDownDolly( event ) {
+
+		dollyStart.set( event.clientX, event.clientY );
+
+	}
+
+	function handleMouseDownPan( event ) {
+
+		panStart.set( event.clientX, event.clientY );
+
+	}
+
+	function handleMouseMoveRotate( event ) {
+
+		rotateEnd.set( event.clientX, event.clientY );
+
+		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
+
+		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
+
+		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );
+
+		rotateStart.copy( rotateEnd );
+
+		scope.update();
+
+	}
+
+	function handleMouseMoveDolly( event ) {
+
+		dollyEnd.set( event.clientX, event.clientY );
+
+		dollyDelta.subVectors( dollyEnd, dollyStart );
+
+		if ( dollyDelta.y > 0 ) {
+
+			dollyIn( getZoomScale() );
+
+		} else if ( dollyDelta.y < 0 ) {
+
+			dollyOut( getZoomScale() );
+
+		}
+
+		dollyStart.copy( dollyEnd );
+
+		scope.update();
+
+	}
+
+	function handleMouseMovePan( event ) {
+
+		panEnd.set( event.clientX, event.clientY );
+
+		panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
+
+		pan( panDelta.x, panDelta.y );
+
+		panStart.copy( panEnd );
+
+		scope.update();
+
+	}
+
+	function handleMouseUp( /*event*/ ) {
+
+		// no-op
+
+	}
+
+	function handleMouseWheel( event ) {
+
+		if ( event.deltaY < 0 ) {
+
+			dollyOut( getZoomScale() );
+
+		} else if ( event.deltaY > 0 ) {
+
+			dollyIn( getZoomScale() );
+
+		}
+
+		scope.update();
+
+	}
+
+	function handleKeyDown( event ) {
+
+		var needsUpdate = false;
+
+		switch ( event.keyCode ) {
+
+			case scope.keys.UP:
+				pan( 0, scope.keyPanSpeed );
+				needsUpdate = true;
+				break;
+
+			case scope.keys.BOTTOM:
+				pan( 0, - scope.keyPanSpeed );
+				needsUpdate = true;
+				break;
+
+			case scope.keys.LEFT:
+				pan( scope.keyPanSpeed, 0 );
+				needsUpdate = true;
+				break;
+
+			case scope.keys.RIGHT:
+				pan( - scope.keyPanSpeed, 0 );
+				needsUpdate = true;
+				break;
+
+		}
+
+		if ( needsUpdate ) {
+
+			// prevent the browser from scrolling on cursor keys
+		        event.preventDefault();
+                        // and prevent others from consuming the event
+                        event.stopImmediatePropagation();
+			scope.update();
+
+		}
+
+
+	}
+
+	function handleTouchStartRotate( event ) {
+
+		if ( event.touches.length == 1 ) {
+
+			rotateStart.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+
+		} else {
+
+			var x = 0.5 * ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX );
+			var y = 0.5 * ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY );
+
+			rotateStart.set( x, y );
+
+		}
+
+	}
+
+	function handleTouchStartPan( event ) {
+
+		if ( event.touches.length == 1 ) {
+
+			panStart.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+
+		} else {
+
+			var x = 0.5 * ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX );
+			var y = 0.5 * ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY );
+
+			panStart.set( x, y );
+
+		}
+
+	}
+
+	function handleTouchStartDolly( event ) {
+
+		var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
+		var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
+
+		var distance = Math.sqrt( dx * dx + dy * dy );
+
+		dollyStart.set( 0, distance );
+
+	}
+
+	function handleTouchStartDollyPan( event ) {
+
+		if ( scope.enableZoom ) handleTouchStartDolly( event );
+
+		if ( scope.enablePan ) handleTouchStartPan( event );
+
+	}
+
+	function handleTouchStartDollyRotate( event ) {
+
+		if ( scope.enableZoom ) handleTouchStartDolly( event );
+
+		if ( scope.enableRotate ) handleTouchStartRotate( event );
+
+	}
+
+	function handleTouchMoveRotate( event ) {
+
+		if ( event.touches.length == 1 ) {
+
+			rotateEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+
+		} else {
+
+			var x = 0.5 * ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX );
+			var y = 0.5 * ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY );
+
+			rotateEnd.set( x, y );
+
+		}
+
+		rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
+
+		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
+
+		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );
+
+		rotateStart.copy( rotateEnd );
+
+	}
+
+	function handleTouchMovePan( event ) {
+
+		if ( event.touches.length == 1 ) {
+
+			panEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+
+		} else {
+
+			var x = 0.5 * ( event.touches[ 0 ].pageX + event.touches[ 1 ].pageX );
+			var y = 0.5 * ( event.touches[ 0 ].pageY + event.touches[ 1 ].pageY );
+
+			panEnd.set( x, y );
+
+		}
+
+		panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
+
+		pan( panDelta.x, panDelta.y );
+
+		panStart.copy( panEnd );
+
+	}
+
+	function handleTouchMoveDolly( event ) {
+
+		var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
+		var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
+
+		var distance = Math.sqrt( dx * dx + dy * dy );
+
+		dollyEnd.set( 0, distance );
+
+		dollyDelta.set( 0, Math.pow( dollyEnd.y / dollyStart.y, scope.zoomSpeed ) );
+
+		dollyIn( dollyDelta.y );
+
+		dollyStart.copy( dollyEnd );
+
+	}
+
+	function handleTouchMoveDollyPan( event ) {
+
+		if ( scope.enableZoom ) handleTouchMoveDolly( event );
+
+		if ( scope.enablePan ) handleTouchMovePan( event );
+
+	}
+
+	function handleTouchMoveDollyRotate( event ) {
+
+		if ( scope.enableZoom ) handleTouchMoveDolly( event );
+
+		if ( scope.enableRotate ) handleTouchMoveRotate( event );
+
+	}
+
+	function handleTouchEnd( /*event*/ ) {
+
+		// no-op
+
+	}
+
+	//
+	// event handlers - FSM: listen for events and reset state
+	//
+
+	function onMouseDown( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		// Prevent the browser from scrolling.
+
+		event.preventDefault();
+
+		// Manually set the focus since calling preventDefault above
+		// prevents the browser from setting it automatically.
+
+		scope.domElement.focus ? scope.domElement.focus() : window.focus();
+
+		switch ( event.button ) {
+
+			case 0:
+
+				switch ( scope.mouseButtons.LEFT ) {
+
+					case THREE.MOUSE.ROTATE:
+
+						if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+							if ( scope.enablePan === false ) return;
+
+							handleMouseDownPan( event );
+
+							state = STATE.PAN;
+
+						} else {
+
+							if ( scope.enableRotate === false ) return;
+
+							handleMouseDownRotate( event );
+
+							state = STATE.ROTATE;
+
+						}
+
+						break;
+
+					case THREE.MOUSE.PAN:
+
+						if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+							if ( scope.enableRotate === false ) return;
+
+							handleMouseDownRotate( event );
+
+							state = STATE.ROTATE;
+
+						} else {
+
+							if ( scope.enablePan === false ) return;
+
+							handleMouseDownPan( event );
+
+							state = STATE.PAN;
+
+						}
+
+						break;
+
+					default:
+
+						state = STATE.NONE;
+
+				}
+
+				break;
+
+
+			case 1:
+
+				switch ( scope.mouseButtons.MIDDLE ) {
+
+					case THREE.MOUSE.DOLLY:
+
+						if ( scope.enableZoom === false ) return;
+
+						handleMouseDownDolly( event );
+
+						state = STATE.DOLLY;
+
+						break;
+
+
+					default:
+
+						state = STATE.NONE;
+
+				}
+
+				break;
+
+			case 2:
+
+				switch ( scope.mouseButtons.RIGHT ) {
+
+					case THREE.MOUSE.ROTATE:
+
+						if ( scope.enableRotate === false ) return;
+
+						handleMouseDownRotate( event );
+
+						state = STATE.ROTATE;
+
+						break;
+
+					case THREE.MOUSE.PAN:
+
+						if ( scope.enablePan === false ) return;
+
+						handleMouseDownPan( event );
+
+						state = STATE.PAN;
+
+						break;
+
+					default:
+
+						state = STATE.NONE;
+
+				}
+
+				break;
+
+		}
+
+		if ( state !== STATE.NONE ) {
+
+			document.addEventListener( 'mousemove', onMouseMove, false );
+			document.addEventListener( 'mouseup', onMouseUp, false );
+
+			scope.dispatchEvent( startEvent );
+
+		}
+
+	}
+
+	function onMouseMove( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+
+		switch ( state ) {
+
+			case STATE.ROTATE:
+
+				if ( scope.enableRotate === false ) return;
+
+				handleMouseMoveRotate( event );
+
+				break;
+
+			case STATE.DOLLY:
+
+				if ( scope.enableZoom === false ) return;
+
+				handleMouseMoveDolly( event );
+
+				break;
+
+			case STATE.PAN:
+
+				if ( scope.enablePan === false ) return;
+
+				handleMouseMovePan( event );
+
+				break;
+
+		}
+
+	}
+
+	function onMouseUp( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		handleMouseUp( event );
+
+		document.removeEventListener( 'mousemove', onMouseMove, false );
+		document.removeEventListener( 'mouseup', onMouseUp, false );
+
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
+
+	}
+
+	function onMouseWheel( event ) {
+
+		if ( scope.enabled === false || scope.enableZoom === false || ( state !== STATE.NONE && state !== STATE.ROTATE ) ) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		scope.dispatchEvent( startEvent );
+
+		handleMouseWheel( event );
+
+		scope.dispatchEvent( endEvent );
+
+	}
+
+	function onKeyDown( event ) {
+
+		if ( scope.enabled === false || scope.enableKeys === false || scope.enablePan === false ) return;
+
+		handleKeyDown( event );
+
+	}
+
+	function onTouchStart( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+
+		switch ( event.touches.length ) {
+
+			case 1:
+
+				switch ( scope.touches.ONE ) {
+
+					case THREE.TOUCH.ROTATE:
+
+						if ( scope.enableRotate === false ) return;
+
+						handleTouchStartRotate( event );
+
+						state = STATE.TOUCH_ROTATE;
+
+						break;
+
+					case THREE.TOUCH.PAN:
+
+						if ( scope.enablePan === false ) return;
+
+						handleTouchStartPan( event );
+
+						state = STATE.TOUCH_PAN;
+
+						break;
+
+					default:
+
+						state = STATE.NONE;
+
+				}
+
+				break;
+
+			case 2:
+
+				switch ( scope.touches.TWO ) {
+
+					case THREE.TOUCH.DOLLY_PAN:
+
+						if ( scope.enableZoom === false && scope.enablePan === false ) return;
+
+						handleTouchStartDollyPan( event );
+
+						state = STATE.TOUCH_DOLLY_PAN;
+
+						break;
+
+					case THREE.TOUCH.DOLLY_ROTATE:
+
+						if ( scope.enableZoom === false && scope.enableRotate === false ) return;
+
+						handleTouchStartDollyRotate( event );
+
+						state = STATE.TOUCH_DOLLY_ROTATE;
+
+						break;
+
+					default:
+
+						state = STATE.NONE;
+
+				}
+
+				break;
+
+			default:
+
+				state = STATE.NONE;
+
+		}
+
+		if ( state !== STATE.NONE ) {
+
+			scope.dispatchEvent( startEvent );
+
+		}
+
+	}
+
+	function onTouchMove( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		switch ( state ) {
+
+			case STATE.TOUCH_ROTATE:
+
+				if ( scope.enableRotate === false ) return;
+
+				handleTouchMoveRotate( event );
+
+				scope.update();
+
+				break;
+
+			case STATE.TOUCH_PAN:
+
+				if ( scope.enablePan === false ) return;
+
+				handleTouchMovePan( event );
+
+				scope.update();
+
+				break;
+
+			case STATE.TOUCH_DOLLY_PAN:
+
+				if ( scope.enableZoom === false && scope.enablePan === false ) return;
+
+				handleTouchMoveDollyPan( event );
+
+				scope.update();
+
+				break;
+
+			case STATE.TOUCH_DOLLY_ROTATE:
+
+				if ( scope.enableZoom === false && scope.enableRotate === false ) return;
+
+				handleTouchMoveDollyRotate( event );
+
+				scope.update();
+
+				break;
+
+			default:
+
+				state = STATE.NONE;
+
+		}
+
+	}
+
+	function onTouchEnd( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		handleTouchEnd( event );
+
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
+
+	}
+
+	function onContextMenu( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+
+	}
+
+	//
+
+	scope.domElement.addEventListener( 'contextmenu', onContextMenu, false );
+
+	scope.domElement.addEventListener( 'mousedown', onMouseDown, false );
+	scope.domElement.addEventListener( 'wheel', onMouseWheel, false );
+
+	scope.domElement.addEventListener( 'touchstart', onTouchStart, false );
+	scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
+	scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
+
+        scope.domElement.addEventListener( 'mouseenter', function (event) {
+                window.addEventListener( 'keydown', onKeyDown );
+        });
+        scope.domElement.addEventListener( 'mouseleave', function (event) {
+                window.removeEventListener( 'keydown', onKeyDown );
+        });
+
+        // force an update at start
+
+	this.update();
+
+};
+
+THREE.OrbitControlsEve.prototype = Object.create( THREE.EventDispatcher.prototype );
+THREE.OrbitControlsEve.prototype.constructor = THREE.OrbitControlsEve;
+
+// osschar 2019-09-27: Why would one need this and could it interfere? Commenting out.
+
+// This set of controls performs orbiting, dollying (zooming), and panning.
+// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
+// This is very similar to OrbitControls, another set of touch behavior
+//
+//    Orbit - right mouse, or left mouse + ctrl/meta/shiftKey / touch: two-finger rotate
+//    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
+//    Pan - left mouse, or arrow keys / touch: one-finger move
+/*
+THREE.MapControls = function ( object, domElement ) {
+
+	THREE.OrbitControlsEve.call( this, object, domElement );
+
+	this.mouseButtons.LEFT = THREE.MOUSE.PAN;
+	this.mouseButtons.RIGHT = THREE.MOUSE.ROTATE;
+
+	this.touches.ONE = THREE.TOUCH.PAN;
+	this.touches.TWO = THREE.TOUCH.DOLLY_ROTATE;
+
+};
+
+THREE.MapControls.prototype = Object.create( THREE.EventDispatcher.prototype );
+THREE.MapControls.prototype.constructor = THREE.MapControls;
+*/

--- a/ui5/eve7/view/Main.view.xml
+++ b/ui5/eve7/view/Main.view.xml
@@ -5,9 +5,9 @@
           xmlns:l="sap.ui.layout"
           xmlns:commons="sap.ui.commons">
    <Page title="" showNavButton="false" showFooter="false"
-      showSubHeader="false" id="CanvasMainPage">
+      showSubHeader="false" id="CanvasMainPage" >
       <customHeader>
-         <OverflowToolbar id="otb1">
+         <Bar id="otb1">
             <!--  Button id="newEvent" icon="sap-icon://step" type="Transparent"
                tooltip="New event" press="newEvent" visible="false "/-->
               <!--
@@ -37,7 +37,9 @@
                </menu>
             </MenuButton>
             <Button text="Edit" type="Transparent" enabled="false" ></Button>
-            -->
+              -->
+
+              <contentLeft>
             <MenuButton text="View" type="Transparent"  enabled="true">
               <menu>
                 <Menu itemSelected="onViewMenuAction" id="menuViewId">
@@ -65,6 +67,12 @@
               </menu>
             </MenuButton>
             <ToolbarSpacer />
+            
+              </contentLeft>
+              <contentMiddle>
+                <FormattedText id="centerTitle" htmlText="ROOT Event Visalization Environment"/>
+              </contentMiddle>
+              <contentRight>
             <MenuButton text="Help" type="Default"  enabled="true">
               <menu>
                 <Menu >
@@ -75,7 +83,8 @@
                 </Menu>
               </menu>
             </MenuButton>
-         </OverflowToolbar>
+              </contentRight>
+         </Bar>
       </customHeader>
       <subHeader>
          <OverflowToolbar>


### PR DESCRIPTION
- Change implementation of next event. Simplify updates. Update summary tree on scene changes.

- Optimize streaming

- Detect web-socket close and warn user (red rectangle in topbar)

- Standalone THREE renderer:
  - ortho camera, compositing, camera reset, key and mouse handling (own copy of OrbitController needed)
  - picking, highlight and tooltips
  - selection and multiple selection

- Don't execute user input from main toolbar while scene changes are processing

- Add virtual function LocalModelChanges to controll model changes in the proxy builder

- Major cleanup of several JS classes

- New class REveEllipsod (error ellipse).

- Support changing of outline colors for selection/highlight.

- Review / improve REveData classes, esp. for selection and projections.

- REveSelection, allow a list of selection upward propagation modes, not just a single one.

- Validate expressions for table views, also, check TROOT::ProcessLine staus.

- Cleanup some TEve-stlye change propagation / update functions.

- Merge REveElement GetMaster() and ForwardSelection() through fSelectionMaster member.

- Use REveAuntAsList in REveDataItem to communicate selection between proxy builders and REveDataItem

- Improve selection handling for compounds and multi-Objec3D representations.