### PR TITLE
[Exp PyROOT][ROOT-10395] Clear PyErr after getting __cpp_name__

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Utility.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Utility.cxx
@@ -813,7 +813,10 @@ std::string CPyCppyy::Utility::ClassName(PyObject* pyobj)
     std::string clname = "<unknown>";
     PyObject* pyclass = (PyObject*)Py_TYPE(pyobj);
     PyObject* pyname = PyObject_GetAttr(pyclass, PyStrings::gCppName);
-    if (!pyname) pyname = PyObject_GetAttr(pyclass, PyStrings::gName);
+    if (!pyname) {
+        PyErr_Clear();
+        pyname = PyObject_GetAttr(pyclass, PyStrings::gName);
+    }
     if (pyname) {
         clname = CPyCppyy_PyText_AsString(pyname);
         Py_DECREF(pyname);


### PR DESCRIPTION
Discovered when running PyCool/PyCoral tests.

The fix is already in master of CPyCppyy (1.9.7).