### PR TITLE
RBrowser: fix layout, avoid use of private data members

### DIFF
--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -743,7 +743,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
          if (!fullpath) return;
 
-         if (row._bHasChildren) {
+         // do not use row._bHasChildren while it is not documented member of m.Row object
+         if (!prop.isLeaf) {
             if (!prop.fullpath.endsWith(".root/")) {
 
                let oBreadcrumbs = this.getView().byId("breadcrumbs");

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -162,15 +162,9 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             onAfterRendering: function() { this.assignRowHandlers(); }
          }, this);
 
-         // FIXME: one have to find direct method to configure this
-         this.byId("browserMaster").addEventDelegate({
-            onAfterRendering: function() { this.getView().byId("treeTableBox").$().children().first().css('flex-grow',1); }
-         }, this);
+         this.newCodeEditor();
 
-            this.newCodeEditor();
-
-            this.drawingOptions = { TH1: 'hist', TH2: 'COL', TProfile: 'E0'};
-
+         this.drawingOptions = { TH1: 'hist', TH2: 'COL', TProfile: 'E0'};
       },
 
       /* ========================================================= */

--- a/ui5/browser/model/BrowserModel.js
+++ b/ui5/browser/model/BrowserModel.js
@@ -348,9 +348,9 @@ sap.ui.define([
                     fullpath: path,
                     index: id,
                     _elem: elem,
+                    isLeaf: !elem.nchilds,
                     // these are required by list binding, should be eliminated in the future
                     type: elem.nchilds ? "folder" : "file",
-                    isLeaf: !elem.nchilds,
                     level: lvl,
                     context: pthis.getContext("/nodes/" + id),
                     nodeState: {

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -37,26 +37,23 @@
             <layoutData>
               <FlexItemData baseSize="25px"/>
             </layoutData>
-
             <Breadcrumbs id="breadcrumbs" separatorStyle="GreaterThan">
             </Breadcrumbs>
           </Toolbar>
-          <VBox id="treeTableBox">
-            <layoutData>
-              <FlexItemData growFactor="1"/>
-            </layoutData>
-            <t:TreeTable
-                id="treeTable"
-                columnHeaderVisible="true"
-                editable="false"
-                enableSelectAll="false"
-                selectionBehavior="RowOnly"
-                selectionMode="Single"
-                visibleRowCountMode="Auto"
-                showColumnVisibilityMenu="true"
-                rows="{/nodes}">
-             </t:TreeTable>
-          </VBox>
+          <t:TreeTable
+              id="treeTable"
+              columnHeaderVisible="true"
+              editable="false"
+              enableSelectAll="false"
+              selectionBehavior="RowOnly"
+              selectionMode="Single"
+              visibleRowCountMode="Auto"
+              showColumnVisibilityMenu="true"
+              rows="{/nodes}">
+              <t:layoutData>
+                 <FlexItemData growFactor="1"/>
+              </t:layoutData>
+          </t:TreeTable>
         </FlexBox>
       </Page>
     </masterPages>

--- a/ui5/eve7/controller/GeomViewer.controller.js
+++ b/ui5/eve7/controller/GeomViewer.controller.js
@@ -127,11 +127,6 @@ sap.ui.define(['sap/ui/core/Component',
             t.addEventDelegate({
                onAfterRendering: function() { this.assignRowHandlers(); }
             }, this);
-
-            // FIXME: one have to find direct method to configure this
-            this.byId("geomHierarchy").addEventDelegate({
-               onAfterRendering: function() { this.getView().byId("treeTableBox").$().children().first().css('flex-grow',1); }
-            }, this);
          }
 
          JSROOT.AssertPrerequisites("geom", function() {
@@ -827,10 +822,6 @@ sap.ui.define(['sap/ui/core/Component',
       },
 
       onAfterMasterOpen: function() {
-         console.log('Get MAster open');
-         // FIXME: one have to find direct method to configure this
-         this.getView().byId("treeTableBox").$().children().first().css('flex-grow',1);
-
       },
 
       checkSendRequest: function(force) {

--- a/ui5/eve7/view/GeomViewer.view.xml
+++ b/ui5/eve7/view/GeomViewer.view.xml
@@ -33,19 +33,16 @@
                      <ToolbarSpacer />
                      <SearchField liveChange="onSearch" />
                   </Toolbar>
-                  <VBox id="treeTableBox">
-                     <layoutData>
+                  <t:TreeTable id="treeTable"
+                     columnHeaderVisible="false" editable="false"
+                     enableSelectAll="false" selectionBehavior="RowOnly"
+                     selectionMode="Single" visibleRowCountMode="Auto"
+                     cellClick="onCellClick"
+                     rows="{/nodes}">
+                     <t:layoutData>
                         <FlexItemData growFactor="1"/>
-                     </layoutData>
-
-                     <t:TreeTable id="treeTable"
-                        columnHeaderVisible="false" editable="false"
-                        enableSelectAll="false" selectionBehavior="RowOnly"
-                        selectionMode="Single" visibleRowCountMode="Auto"
-                        cellClick="onCellClick"
-                        rows="{/nodes}">
-                     </t:TreeTable>
-                  </VBox>
+                     </t:layoutData>
+                  </t:TreeTable>
                </FlexBox>
             </content>
          </Page>


### PR DESCRIPTION
* Correctly configure layout properties for the TreeTable in RBrowser and RGeometryViewer
* Do not use row._bHasChildren field which is private and may be changed/removed in future ui5 versions