### PR TITLE
[cxxmodules] Allow externally-provided modulemaps via CLING_MODULEMAP…

### DIFF
--- a/core/foundation/res/ROOT/FoundationUtils.hxx
+++ b/core/foundation/res/ROOT/FoundationUtils.hxx
@@ -49,6 +49,17 @@ namespace FoundationUtils {
       return gPathSeparator;
    }
 
+   ///\returns the path separator for the PATH environment variable on the
+   /// platform.
+   inline const char& GetEnvPathSeparator() {
+#ifdef WIN32
+      static const char gEnvPathSeparator = ';';
+#else
+      static const char gEnvPathSeparator = ':';
+#endif
+      return gEnvPathSeparator;
+   }
+
    ///\returns the fallback directory in the installation (eg. /usr/local/root/).
    const std::string& GetFallbackRootSys();
 


### PR DESCRIPTION
…_PATH.

The environment variable can be set like CLING_MODULEMAP_PATH=/a:./b/. In this
case ROOT will initialize with
-fmodule-map-file=/a/module.modulemap -fmodule-map-file=./b/module.modulemap.

If the files do not exist ROOT will print an error.

cc: @davidlange6, @oshadura 