### PR TITLE
[Exp PyROOT] CPPInstance_FromVoidPtr temprorarily moved to PyzCppHelpers

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.cxx
@@ -14,8 +14,8 @@ Set of helper functions that are invoked from the C++ implementation of
 pythonizations.
 
 */
-
 #include "PyzCppHelpers.hxx"
+#include "ProxyWrappers.h"
 
 // Call method with signature: obj->meth()
 PyObject *CallPyObjMethod(PyObject *obj, const char *meth)
@@ -153,4 +153,19 @@ bool CheckEndianessFromTypestr(const std::string& typestr)
       return false;
    }
    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Bind the addr to a python object of class defined by classname.
+
+PyObject *CPPInstance_FromVoidPtr(void *addr, const char *classname, Bool_t python_owns)
+{
+   // perform cast (the call will check TClass and addr, and set python errors)
+   PyObject *pyobject = CPyCppyy::BindCppObjectNoCast(addr, Cppyy::GetScope(classname), false);
+
+   // give ownership, for ref-counting, to the python side, if so requested
+   if (python_owns && CPyCppyy::CPPInstance_Check(pyobject))
+      ((CPyCppyy::CPPInstance *)pyobject)->PythonOwns();
+
+   return pyobject;
 }

--- a/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.hxx
+++ b/bindings/pyroot_experimental/PyROOT/src/PyzCppHelpers.hxx
@@ -29,4 +29,7 @@ std::string GetTypestrFromArrayInterface(PyObject *obj);
 unsigned int GetDatatypeSizeFromTypestr(const std::string& typestr);
 bool CheckEndianessFromTypestr(const std::string& typestr);
 
+// void* to CPPInstance conversion, returns a new reference
+PyObject *CPPInstance_FromVoidPtr(void *addr, const char *classname, Bool_t python_owns = kFALSE);
+
 #endif // PYROOT_PYZCPPHELPERS

--- a/bindings/pyroot_experimental/PyROOT/src/RDataFramePyz.cxx
+++ b/bindings/pyroot_experimental/PyROOT/src/RDataFramePyz.cxx
@@ -15,7 +15,7 @@
 #include "PyROOTPythonize.h"
 #include "RConfig.h"
 #include "TInterpreter.h"
-#include "CPyCppyy/API.h"
+#include "PyzCppHelpers.hxx"
 
 #include <utility> // std::pair
 #include <sstream> // std::stringstream
@@ -98,7 +98,7 @@ PyObject *PyROOT::MakeNumpyDataFrame(PyObject * /*self*/, PyObject * pydata)
    const auto codeStr = code.str();
    auto address = (void*) gInterpreter->Calc(codeStr.c_str());
    const auto pythonOwns = true;
-   auto pyobj = TPython::CPPInstance_FromVoidPtr(address, "ROOT::RDataFrame", pythonOwns);
+   auto pyobj = CPPInstance_FromVoidPtr(address, "ROOT::RDataFrame", pythonOwns);
 
    // Bind pyobject holding adopted memory to the RVec
    if (PyObject_SetAttrString(pyobj, "__data__", pyvecs)) {


### PR DESCRIPTION
This change is done in order to avoid that the pythonizations modules
depend on methods defined in TPython.

This commit can be descarded when we will update to CPyCppyy-1.9.7,
since TPython::CPPInstance_FromVoidPtr will become
CPyCppyy::CPPInstance_FromVoidPtr.