### PR TITLE
[eve-7] Fix initialization in single view select

### DIFF
--- a/ui5/eve7/controller/GL.controller.js
+++ b/ui5/eve7/controller/GL.controller.js
@@ -118,7 +118,7 @@ sap.ui.define([
       OnEveManagerInit: function()
       {
          // called when manager was updated, need only in standalone modes to detect own element id
-         if (!this.standalone || this.elementid) return;
+         if (!this.standalone) return;
 
          let viewers = this.mgr.FindViewers();
 

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -625,10 +625,11 @@ sap.ui.define([], function() {
       if ( ! element) return;
 
       let scene = this.GetElement(element.fSceneId);
-
-      for (let r of scene.$receivers)
-      {
-         r.SelectElement(selection_obj, element_id, sec_idcs);
+      if (scene.$receivers) {
+         for (let r of scene.$receivers)
+         {
+            r.SelectElement(selection_obj, element_id, sec_idcs);
+         }
       }
 
       // console.log("EveManager.SelectElement", element, scene.$receivers[0].viewer.outline_pass.id2obj_map);
@@ -641,9 +642,11 @@ sap.ui.define([], function() {
 
       let scene = this.GetElement(element.fSceneId);
 
-      for (let r of scene.$receivers)
-      {
-         r.UnselectElement(selection_obj, element_id);
+      if (scene.$receivers) {
+         for (let r of scene.$receivers)
+         {
+            r.UnselectElement(selection_obj, element_id);
+         }
       }
 
       // console.log("EveManager.UnselectElement", element, scene.$receivers[0].viewer.outline_pass.id2obj_map);


### PR DESCRIPTION
A single view can be selected with given URL+#/view/<view-name>

Some checks have bee given in EveManager.SelectElement and EveManager.UnSelectElement to make highlight effect work.

In future, the checks in EveManager will be obsolete by client view subscription.
