### PR TITLE
[Exp PyROOT] New cppyy does not copy into a Python str when iterating over a vector<string>

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rdataframe.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/pythonization/_rdataframe.py
@@ -58,7 +58,8 @@ def RDataFrameAsNumpy(df, columns=None, exclude=None):
 
     # Find all column names in the dataframe if no column are specified
     if not columns:
-        columns = [c for c in df.GetColumnNames()]
+        column_names = df.GetColumnNames()
+        columns = [c for c in column_names]
 
     # Exclude the specified columns
     if exclude == None:


### PR DESCRIPTION
As stated in

https://bitbucket.org/wlav/cppyy/issues/176/issue-with-python-list-created-from-vector

in Cppyy-1.5.6 when we do the following:

l = [e for e in cppyy.gbl.get_vec()]

where get_vec() is a C++ injected function that returns a C++
std::vector<std::string>, the variable 'e' that goes through the vector is
not a Python string, but a temporary object of type std::string.

Being 'e' a reference to a temporary, the vector goes out of scope.

The second of the two solutions suggested in the discussion is applied
where necessary.