### PR TITLE
Snapshot uses existing TDirectory when MT enabled

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -172,7 +172,7 @@ public:
    virtual Bool_t      IsModified() const { return kFALSE; }
    virtual Bool_t      IsWritable() const { return kFALSE; }
            void        ls(Option_t *option="") const override;
-   virtual TDirectory *mkdir(const char *name, const char *title="");
+   virtual TDirectory *mkdir(const char *name, const char *title="", Bool_t ifNotExist = kFALSE);
    virtual TFile      *OpenFile(const char * /*name*/, Option_t * /*option*/ = "",
                             const char * /*ftitle*/ = "", Int_t /*compress*/ = 1,
                             Int_t /*netopt*/ = 0) {return nullptr;}

--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -172,7 +172,7 @@ public:
    virtual Bool_t      IsModified() const { return kFALSE; }
    virtual Bool_t      IsWritable() const { return kFALSE; }
            void        ls(Option_t *option="") const override;
-   virtual TDirectory *mkdir(const char *name, const char *title="", Bool_t ifNotExist = kFALSE);
+   virtual TDirectory *mkdir(const char *name, const char *title="", Bool_t returnExistingDirectory = kFALSE);
    virtual TFile      *OpenFile(const char * /*name*/, Option_t * /*option*/ = "",
                             const char * /*ftitle*/ = "", Int_t /*compress*/ = 1,
                             Int_t /*netopt*/ = 0) {return nullptr;}

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1028,12 +1028,12 @@ void TDirectory::FillFullPath(TString& buf) const
 ///    gDirectory->cd("b");
 ///    gDirectory->mkdir("d");
 /// ~~~
-/// ifNotExist is just for compatibility with the TDirectoryFile override
+/// returnExistingDirectory is just for compatibility with the TDirectoryFile override
 
-TDirectory *TDirectory::mkdir(const char *name, const char *title, Bool_t ifNotExist)
+TDirectory *TDirectory::mkdir(const char *name, const char *title, Bool_t returnExistingDirectory)
 {
-   if (ifNotExist)
-      Error("mkdir", "ifNotExist only valid for TDirectoryFile mkdir", name);
+   if (returnExistingDirectory)
+      Error("mkdir", "returnExistingDirectory only valid for TDirectoryFile mkdir", name);
    if (!name || !title || !name[0]) return nullptr;
    if (!title[0]) title = name;
    TDirectory *newdir = nullptr;

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1028,9 +1028,11 @@ void TDirectory::FillFullPath(TString& buf) const
 ///    gDirectory->cd("b");
 ///    gDirectory->mkdir("d");
 /// ~~~
+/// ifNotExist is just for compatibility with the TDirectoryFile override
 
-TDirectory *TDirectory::mkdir(const char *name, const char *title)
+TDirectory *TDirectory::mkdir(const char *name, const char *title, Bool_t ifNotExist)
 {
+   if (ifNotExist) Error("mkdir","ifNotExist only valid for TDirectoryFile mkdir",name);
    if (!name || !title || !name[0]) return nullptr;
    if (!title[0]) title = name;
    TDirectory *newdir = nullptr;

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1015,6 +1015,7 @@ void TDirectory::FillFullPath(TString& buf) const
 ///
 /// Returns 0 in case of error or if a sub-directory (hierarchy) with the requested
 /// name already exists.
+/// returnExistingDirectory returns a pointer to an already existing sub-directory with the same name.
 /// Returns a pointer to the created sub-directory or to the top sub-directory of
 /// the hierarchy (in the above example, the returned TDirectory * always points
 /// to "a").
@@ -1028,12 +1029,22 @@ void TDirectory::FillFullPath(TString& buf) const
 ///    gDirectory->cd("b");
 ///    gDirectory->mkdir("d");
 /// ~~~
-/// returnExistingDirectory is just for compatibility with the TDirectoryFile override
+/// or
+/// ~~~ {.cpp}
+///    TFile * file = new TFile("afile","RECREATE");
+///    file->mkdir("a");
+///    file->cd("a");
+///    gDirectory->mkdir("b/c");
+///    gDirectory->mkdir("b/d", "", true);
+/// ~~~
 
 TDirectory *TDirectory::mkdir(const char *name, const char *title, Bool_t returnExistingDirectory)
 {
-   if (returnExistingDirectory)
-      Error("mkdir", "returnExistingDirectory only valid for TDirectoryFile mkdir", name);
+   if (returnExistingDirectory) {
+      auto existingdir = GetDirectory(name);
+      if (existingdir)
+        return existingdir;
+   }
    if (!name || !title || !name[0]) return nullptr;
    if (!title[0]) title = name;
    TDirectory *newdir = nullptr;

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1032,7 +1032,8 @@ void TDirectory::FillFullPath(TString& buf) const
 
 TDirectory *TDirectory::mkdir(const char *name, const char *title, Bool_t ifNotExist)
 {
-   if (ifNotExist) Error("mkdir","ifNotExist only valid for TDirectoryFile mkdir",name);
+   if (ifNotExist)
+      Error("mkdir", "ifNotExist only valid for TDirectoryFile mkdir", name);
    if (!name || !title || !name[0]) return nullptr;
    if (!title[0]) title = name;
    TDirectory *newdir = nullptr;

--- a/io/io/inc/TDirectoryFile.h
+++ b/io/io/inc/TDirectoryFile.h
@@ -103,7 +103,7 @@ public:
            Bool_t      IsModified() const override { return fModified; }
            Bool_t      IsWritable() const override { return fWritable; }
            void        ls(Option_t *option="") const override;
-           TDirectory *mkdir(const char *name, const char *title="", Bool_t ifNotExist = kFALSE) override;
+           TDirectory *mkdir(const char *name, const char *title="", Bool_t returnExistingDirectory = kFALSE) override;
            TFile      *OpenFile(const char *name, Option_t *option= "",
                             const char *ftitle = "", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose,
                             Int_t netopt = 0) override;

--- a/io/io/inc/TDirectoryFile.h
+++ b/io/io/inc/TDirectoryFile.h
@@ -103,7 +103,7 @@ public:
            Bool_t      IsModified() const override { return fModified; }
            Bool_t      IsWritable() const override { return fWritable; }
            void        ls(Option_t *option="") const override;
-           TDirectory *mkdir(const char *name, const char *title="") override;
+           TDirectory *mkdir(const char *name, const char *title="", Bool_t ifNotExist = kFALSE) override;
            TFile      *OpenFile(const char *name, Option_t *option= "",
                             const char *ftitle = "", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose,
                             Int_t netopt = 0) override;

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1197,7 +1197,7 @@ TDirectory *TDirectoryFile::mkdir(const char *name, const char *title, Bool_t re
    if (!title[0]) title = name;
    if (GetKey(name)) {
       if (returnExistingDirectory)
-         return (TDirectoryFile*) GetKey(name)->ReadObj();
+         return (TDirectoryFile*) GetDirectory(name);
       else {
         Error("mkdir","An object with name %s exists already",name);
         return nullptr;

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1196,7 +1196,8 @@ TDirectory *TDirectoryFile::mkdir(const char *name, const char *title, Bool_t if
    if (!name || !title || !name[0]) return nullptr;
    if (!title[0]) title = name;
    if (GetKey(name)) {
-      if(ifNotExist) return (TDirectoryFile*) GetKey(name)->ReadObj();
+      if (ifNotExist)
+         return (TDirectoryFile*) GetKey(name)->ReadObj();
       else {
         Error("mkdir","An object with name %s exists already",name);
         return nullptr;

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1186,7 +1186,7 @@ TFile *TDirectoryFile::OpenFile(const char *name, Option_t *option,const char *f
 ///
 /// Returns 0 in case of error or if a sub-directory (hierarchy) with the requested
 /// name already exists.
-/// ifNotExist returns a pointer to an extant sub-directory instead 0.
+/// ifNotExist returns a pointer to an already existing sub-directory instead of 0.
 /// Returns a pointer to the created sub-directory or to the top sub-directory of
 /// the hierarchy (in the above example, the returned TDirectory * always points
 /// to "a").

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1186,17 +1186,17 @@ TFile *TDirectoryFile::OpenFile(const char *name, Option_t *option,const char *f
 ///
 /// Returns 0 in case of error or if a sub-directory (hierarchy) with the requested
 /// name already exists.
-/// ifNotExist returns a pointer to an already existing sub-directory instead of 0.
+/// returnExistingDirectory returns a pointer to an already existing sub-directory instead of 0.
 /// Returns a pointer to the created sub-directory or to the top sub-directory of
 /// the hierarchy (in the above example, the returned TDirectory * always points
 /// to "a").
 
-TDirectory *TDirectoryFile::mkdir(const char *name, const char *title, Bool_t ifNotExist)
+TDirectory *TDirectoryFile::mkdir(const char *name, const char *title, Bool_t returnExistingDirectory)
 {
    if (!name || !title || !name[0]) return nullptr;
    if (!title[0]) title = name;
    if (GetKey(name)) {
-      if (ifNotExist)
+      if (returnExistingDirectory)
          return (TDirectoryFile*) GetKey(name)->ReadObj();
       else {
         Error("mkdir","An object with name %s exists already",name);

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1186,17 +1186,21 @@ TFile *TDirectoryFile::OpenFile(const char *name, Option_t *option,const char *f
 ///
 /// Returns 0 in case of error or if a sub-directory (hierarchy) with the requested
 /// name already exists.
+/// ifNotExist returns a pointer to an extant sub-directory instead 0.
 /// Returns a pointer to the created sub-directory or to the top sub-directory of
 /// the hierarchy (in the above example, the returned TDirectory * always points
 /// to "a").
 
-TDirectory *TDirectoryFile::mkdir(const char *name, const char *title)
+TDirectory *TDirectoryFile::mkdir(const char *name, const char *title, Bool_t ifNotExist)
 {
    if (!name || !title || !name[0]) return nullptr;
    if (!title[0]) title = name;
    if (GetKey(name)) {
-      Error("mkdir","An object with name %s exists already",name);
-      return nullptr;
+      if(ifNotExist) return (TDirectoryFile*) GetKey(name)->ReadObj();
+      else {
+        Error("mkdir","An object with name %s exists already",name);
+        return nullptr;
+      }
    }
    TDirectoryFile *newdir = nullptr;
    if (const char *slash = strchr(name,'/')) {

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -1625,15 +1625,14 @@ void stress17()
    TFile f("stress.root","update");
    TDirectory *motherdir = f.mkdir("motherdir");
    TDirectory *daughterdir = motherdir->mkdir("daughterdir");
-   // TDirectory *daughternull = motherdir->mkdir("daughterdir");  // would produce Error message and cause test to fail
    TDirectory *daughtersame = motherdir->mkdir("daughterdir", "", true);
    
    Bool_t OK = kTRUE;
-   if (/*daughternull != nullptr || */daughtersame != daughterdir || free_daughter2 == free_daughterdir || free_daughtersame != free_daughterdir) OK = kFALSE;
+   if (daughtersame != daughterdir || free_daughter2 == free_daughterdir || free_daughtersame != free_daughterdir) OK = kFALSE;
    if (OK) printf("OK\n");
    else    {
       printf("FAILED\n");
-      printf("%-8s free_daughterdir=%p, free_daughter2=%p, free_daughtersame=%p, daughterdir=%p, daughternull=%p, daughtersame=%p \n"," ",free_daughterdir,free_daughter2,free_daughtersame,daughterdir,0/*daughternull*/,daughtersame);
+      printf("%-8s free_daughterdir=%p, free_daughter2=%p, free_daughtersame=%p, daughterdir=%p, daughtersame=%p \n"," ",free_daughterdir,free_daughter2,free_daughtersame,daughterdir,daughtersame);
    }
    if (gPrintSubBench) { printf("Test 17 : "); gBenchmark->Show("stress");gBenchmark->Start("stress"); }
 }

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -1633,7 +1633,7 @@ void stress17()
    if (OK) printf("OK\n");
    else    {
       printf("FAILED\n");
-      printf("%-8s free_daughterdir=%d, free_daughter2=%d, free_daughtersame=%d, daughterdir=%d, daughternull=%d, daughtersame=%d \n"," ",free_daughterdir,free_daughter2,free_daughtersame,daughterdir,0/*daughternull*/,daughtersame);
+      printf("%-8s free_daughterdir=%d, free_daughter2=%d, free_daughtersame=%d, daughterdir=%d, daughternull=%d, daughtersame=%d \n"," ",(intptr_t)free_daughterdir,(intptr_t)free_daughter2,(intptr_t)free_daughtersame,(intptr_t)daughterdir,0/*(intptr_t)daughternull*/,(intptr_t)daughtersame);
    }
    if (gPrintSubBench) { printf("Test 17 : "); gBenchmark->Show("stress");gBenchmark->Start("stress"); }
 }

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -1625,15 +1625,15 @@ void stress17()
    TFile f("stress.root","update");
    TDirectory *motherdir = f.mkdir("motherdir");
    TDirectory *daughterdir = motherdir->mkdir("daughterdir");
-   TDirectory *daughternull = motherdir->mkdir("daughterdir");
+   // TDirectory *daughternull = motherdir->mkdir("daughterdir");  // would produce Error message and cause test to fail
    TDirectory *daughtersame = motherdir->mkdir("daughterdir", "", true);
    
    Bool_t OK = kTRUE;
-   if (daughternull != nullptr || daughtersame != daughterdir || free_daughter2 == free_daughterdir || free_daughtersame != free_daughterdir) OK = kFALSE;
+   if (/*daughternull != nullptr || */daughtersame != daughterdir || free_daughter2 == free_daughterdir || free_daughtersame != free_daughterdir) OK = kFALSE;
    if (OK) printf("OK\n");
    else    {
       printf("FAILED\n");
-      printf("%-8s free_daughterdir=%d, free_daughter2=%d, free_daughtersame=%d, daughterdir=%d, daughternull=%d, daughtersame=%d \n"," ",free_daughterdir,free_daughter2,free_daughtersame,daughterdir,daughternull,daughtersame);
+      printf("%-8s free_daughterdir=%d, free_daughter2=%d, free_daughtersame=%d, daughterdir=%d, daughternull=%d, daughtersame=%d \n"," ",free_daughterdir,free_daughter2,free_daughtersame,daughterdir,0/*daughternull*/,daughtersame);
    }
    if (gPrintSubBench) { printf("Test 17 : "); gBenchmark->Show("stress");gBenchmark->Start("stress"); }
 }

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -1633,7 +1633,7 @@ void stress17()
    if (OK) printf("OK\n");
    else    {
       printf("FAILED\n");
-      printf("%-8s free_daughterdir=%d, free_daughter2=%d, free_daughtersame=%d, daughterdir=%d, daughternull=%d, daughtersame=%d \n"," ",(intptr_t)free_daughterdir,(intptr_t)free_daughter2,(intptr_t)free_daughtersame,(intptr_t)daughterdir,0/*(intptr_t)daughternull*/,(intptr_t)daughtersame);
+      printf("%-8s free_daughterdir=%p, free_daughter2=%p, free_daughtersame=%p, daughterdir=%p, daughternull=%p, daughtersame=%p \n"," ",free_daughterdir,free_daughter2,free_daughtersame,daughterdir,0/*daughternull*/,daughtersame);
    }
    if (gPrintSubBench) { printf("Test 17 : "); gBenchmark->Show("stress");gBenchmark->Start("stress"); }
 }

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1293,7 +1293,7 @@ public:
       }
       TDirectory *treeDirectory = fOutputFiles[slot].get();
       if (!fDirName.empty()) {
-         // call ifNotExist=true since MT can end up making this call multiple times
+         // call returnExistingDirectory=true since MT can end up making this call multiple times
          treeDirectory = fOutputFiles[slot]->mkdir(fDirName.c_str(), "", true);
       }
       // re-create output tree as we need to create its branches again, with new input variables

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1293,7 +1293,8 @@ public:
       }
       TDirectory *treeDirectory = fOutputFiles[slot].get();
       if (!fDirName.empty()) {
-         treeDirectory = fOutputFiles[slot]->mkdir(fDirName.c_str());
+         // call ifNotExist=true since MT can end up making this call multiple times
+         treeDirectory = fOutputFiles[slot]->mkdir(fDirName.c_str(), "", true);
       }
       // re-create output tree as we need to create its branches again, with new input variables
       // TODO we could instead create the output tree and its branches, change addresses of input variables in each task

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -67,7 +67,7 @@ namespace TTraits = ROOT::TypeTraits;
 namespace RDFInternal = ROOT::Internal::RDF;
 
 using HeadNode_t = ::ROOT::RDF::RResultPtr<RInterface<RLoopManager, void>>;
-HeadNode_t CreateSnaphotRDF(const ColumnNames_t &validCols,
+HeadNode_t CreateSnapshotRDF(const ColumnNames_t &validCols,
                             std::string_view treeName,
                             std::string_view fileName,
                             bool isLazy,

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2451,7 +2451,7 @@ private:
 
       fLoopManager->Book(actionPtr.get());
 
-      return RDFInternal::CreateSnaphotRDF(validCols, fullTreename, filename, options.fLazy, *fLoopManager,
+      return RDFInternal::CreateSnapshotRDF(validCols, fullTreename, filename, options.fLazy, *fLoopManager,
                                            std::move(actionPtr));
    }
 

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -118,7 +118,7 @@ std::set<std::string> GetPotentialColumnNames(const std::string &expr)
 // the one in the vector
 class RActionBase;
 
-HeadNode_t CreateSnaphotRDF(const ColumnNames_t &validCols,
+HeadNode_t CreateSnapshotRDF(const ColumnNames_t &validCols,
                             std::string_view treeName,
                             std::string_view fileName,
                             bool isLazy,


### PR DESCRIPTION
This addresses the bug raised [in the forum](https://root-forum.cern.ch/t/error-writing-trees-with-snapshot-and-implicitmt/36965).

Adds option to `TDirectoryFile` to call `mkdir` with an existing directory name without raising an error, and implements this option when creating a `Snapshot` with multithreading enabled. Also changes `CreateSnaphotRDF` to `CreateSnapshotRDF`.