### PR TITLE
[PyROOT] Forward compatibility changes: ROOT.Long & ROOT.Double

### DIFF
--- a/bindings/pyroot/src/Converters.cxx
+++ b/bindings/pyroot/src/Converters.cxx
@@ -291,6 +291,11 @@ Bool_t PyROOT::TLongRefConverter::SetArg(
    if ( TCustomInt_CheckExact( pyobject ) ) {
       para.fValue.fVoidp = (void*)&((PyIntObject*)pyobject)->ob_ival;
       para.fTypeCode = 'V';
+      if (PyErr_WarnEx(PyExc_FutureWarning,
+                       "ROOT.Long is deprecated and will disappear in a future version of ROOT. "
+                       "Instead, use ctypes.c_long for pass-by-ref of longs", 1) < 0) {
+         return kFALSE;
+      }
       return kTRUE;
    }
 #endif
@@ -337,6 +342,11 @@ Bool_t PyROOT::TIntRefConverter::SetArg(
    if ( TCustomInt_CheckExact( pyobject ) ) {
       para.fValue.fVoidp = (void*)&((PyIntObject*)pyobject)->ob_ival;
       para.fTypeCode = 'V';
+      if (PyErr_WarnEx(PyExc_FutureWarning,
+                       "ROOT.Long is deprecated and will disappear in a future version of ROOT. "
+                       "Instead, use ctypes.c_int for pass-by-ref of ints", 1) < 0) {
+         return kFALSE;
+      }
       return kTRUE;
    }
 #endif
@@ -452,6 +462,11 @@ Bool_t PyROOT::TDoubleRefConverter::SetArg(
    if ( TCustomFloat_CheckExact( pyobject ) ) {
       para.fValue.fVoidp = (void*)&((PyFloatObject*)pyobject)->ob_fval;
       para.fTypeCode = 'V';
+      if (PyErr_WarnEx(PyExc_FutureWarning,
+                       "ROOT.Double is deprecated and will disappear in a future version of ROOT. "
+                       "Instead, use ctypes.c_double for pass-by-ref of doubles", 1) < 0) {
+         return kFALSE;
+      }
       return kTRUE;
    }
 
@@ -462,7 +477,7 @@ Bool_t PyROOT::TDoubleRefConverter::SetArg(
       return kTRUE;
    }
 
-   PyErr_SetString( PyExc_TypeError, "use ROOT.Double for pass-by-ref of doubles" );
+   PyErr_SetString( PyExc_TypeError, "use ctypes.c_double for pass-by-ref of doubles" );
    return kFALSE;
 }
 

--- a/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/PyROOT/python/ROOT/_facade.py
@@ -33,7 +33,7 @@ class ROOTFacade(types.ModuleType):
         self.gROOT = gROOT
 
         # Expose some functionality from CPyCppyy extension module
-        self._cppyy_exports = [ 'Double', 'Long', 'nullptr', 'bind_object',
+        self._cppyy_exports = [ 'nullptr', 'bind_object',
                                 'SetMemoryPolicy', 'kMemoryHeuristics', 'kMemoryStrict',
                                 'SetOwnership' ]
         for name in self._cppyy_exports:

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -963,7 +963,6 @@ def _rootLsPrintLongLs(keyList,indent,treeListing):
             "timeWidth":maxCharTime+2, \
             "nameWidth":maxCharName+2, \
             "titleWidth":1}
-    date = ROOT.Long(0)
     for key in keyList:
         datime = key.GetDatime()
         time = datime.GetTime()

--- a/tutorials/pyroot/DynamicSlice.py
+++ b/tutorials/pyroot/DynamicSlice.py
@@ -16,13 +16,14 @@
 ## \macro_image
 ## \macro_code
 ##
-## \author Rene Brun, Johann Cohen-Tanugi, Wim Lavrijsen
+## \author Rene Brun, Johann Cohen-Tanugi, Wim Lavrijsen, Enric Tejedor
 
 import sys
+import ctypes
 
 from ROOT import gRandom, gPad, gROOT, gVirtualX
 from ROOT import kTRUE, kRed
-from ROOT import TCanvas, TH2, TH2F, Double
+from ROOT import TCanvas, TH2, TH2F
 
 
 class DynamicExec:
@@ -116,10 +117,11 @@ if __name__ == '__main__':
  # create a 2-d histogram, fill and draw it
    hpxpy  = TH2F( 'hpxpy', 'py vs px', 40, -4, 4, 40, -4, 4 )
    hpxpy.SetStats( 0 )
-   x, y = Double( 0.1 ), Double( 0.101 )
+   x, y = ctypes.c_double( 0.1 ), ctypes.c_double( 0.101 )
    for i in range( 50000 ):
+   # pass ctypes doubles by reference, then retrieve their modified values with .value
      gRandom.Rannor( x, y )
-     hpxpy.Fill( x, y )
+     hpxpy.Fill( x.value, y.value )
    hpxpy.Draw( 'COL' )
 
  # Add a TExec object to the canvas (explicit use of __main__ is for IPython)

--- a/tutorials/pyroot/hsimple.py
+++ b/tutorials/pyroot/hsimple.py
@@ -12,10 +12,11 @@
 ## \macro_image
 ## \macro_code
 ##
-## \author Wim Lavrijsen
+## \author Wim Lavrijsen, Enric Tejedor
 
 from ROOT import TCanvas, TFile, TProfile, TNtuple, TH1F, TH2F
-from ROOT import gROOT, gBenchmark, gRandom, gSystem, Double
+from ROOT import gROOT, gBenchmark, gRandom, gSystem
+import ctypes
 
 # Create a new canvas, and customize it.
 c1 = TCanvas( 'c1', 'Dynamic Filling Example', 200, 10, 700, 500 )
@@ -55,11 +56,15 @@ for name in histos:
    exec('%sFill = %s.Fill' % (name,name))
 
 # Fill histograms randomly.
-px, py = Double(), Double()
+px_ref, py_ref = ctypes.c_double(), ctypes.c_double()
 kUPDATE = 1000
 for i in range( 25000 ):
- # Generate random values.
-   rannor( px, py )
+ # Generate random values. Use ctypes to pass doubles by reference
+   rannor( px_ref, py_ref )
+ # Retrieve the generated values
+   px = px_ref.value
+   py = py_ref.value
+   
    pz = px*px + py*py
    random = rndm(1)
 


### PR DESCRIPTION
This PR:
- Adds a deprecation warning to the old PyROOT when `ROOT.Long` and `ROOT.Double` are used to pass by reference ints and floats, respectively.
- Removes `ROOT.Long` and `ROOT.Double` from the API of the new PyROOT, to comply with the requirements of the new Cppyy, where `ctypes` must be used instead.
- Shows how to use `ctypes` instead of `Long` and `Double` in the PyROOT tutorials.