### PR TITLE
[io] Revert introduction of kCustomBrowse bit

### DIFF
--- a/io/io/inc/TDirectoryFile.h
+++ b/io/io/inc/TDirectoryFile.h
@@ -55,10 +55,7 @@ private:
 
 public:
    // TDirectory status bits
-   enum EStatusBits {
-      kCloseDirectory = BIT(7),
-      kCustomBrowse   = BIT(9)
-   };
+   enum EStatusBits { kCloseDirectory = BIT(7) };
 
    TDirectoryFile();
    TDirectoryFile(const char *name, const char *title, Option_t *option="", TDirectory* motherDir = nullptr);

--- a/tree/ntuple/v7/src/RPageStorageRoot.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRoot.cxx
@@ -58,9 +58,6 @@ ROOT::Experimental::Detail::RPageSinkRoot::~RPageSinkRoot()
 void ROOT::Experimental::Detail::RPageSinkRoot::DoCreate(const RNTupleModel & /* model */)
 {
    fDirectory = fFile->mkdir(fNTupleName.c_str());
-   // In TBrowser, use RNTupleBrowser(TDirectory *directory) in order to show the ntuple contents
-   fDirectory->SetBit(TDirectoryFile::kCustomBrowse);
-   fDirectory->SetTitle("ROOT::Experimental::Detail::RNTupleBrowser");
 
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
    auto szHeader = descriptor.SerializeHeader(nullptr);


### PR DESCRIPTION
It turns out that RNTuple data should better not be stored in custom directories because

1. It is hard to get the TBrowser integration correctly; the TBrowser can only know the special status of the directory when looking at the object, looking at its key is not enough
2. All the page keys get added to the directory's key list, which is inefficient

Instead, RNTuple will be changed to replicate the TTree approach: an ntuple is represented by a single, small `RNTuple` object, but the actual page data is stored in anonymous keys.