### PR TITLE
[cxxmodules] Delay constexpr evaluation of exception spec when deseri…

### DIFF
--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -223,3 +223,15 @@ TEST_F(TClingTests, GetSharedLibDeps)
    EXPECT_ROOT_ERROR(ASSERT_TRUE(nullptr == GetLibDeps("   ")),
                      "Error in <TCling__GetSharedLibImmediateDepsSlow>: Cannot find library '   '\n");
 }
+
+// Check the interface which interacts with the cling::LookupHelper.
+TEST_F(TClingTests, ClingLookupHelper) {
+  // Exception spec evaluation.
+  // Emulate the LookupHelper sequence:
+  // auto S = LookupHelper::findScope("ROOT::Internal::RDF", diag)
+  // LookupHelper::findAnyFunction(S, "RDataFrameTake<float>", diag)
+  // LookupHelper::findAnyFunction(S, "RDataFrameTake<std::vector<float>>", diag)
+  auto *cl = gCling->ClassInfo_Factory("ROOT::Internal::RDF");
+  gCling->GetFunction(cl, "RDataFrameTake<float>");
+  gCling->GetFunction(cl, "RDataFrameTake<std::vector<float>>");
+}

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
@@ -499,11 +499,21 @@ private:
   /// that we needed but hadn't loaded yet.
   llvm::DenseMap<void *, PendingFakeDefinitionKind> PendingFakeDefinitionData;
 
+  struct PendingExceptionSpecUpdateInfo {
+    FunctionDecl *m_FD = nullptr;
+    bool ShouldUpdateESI = false;
+    FunctionProtoType::ExceptionSpecInfo m_ESI;
+    PendingExceptionSpecUpdateInfo(FunctionDecl *FD,
+                                  FunctionProtoType::ExceptionSpecInfo ESI)
+      : m_FD(FD), m_ESI(ESI), ShouldUpdateESI(true) { }
+    PendingExceptionSpecUpdateInfo(FunctionDecl *FD) : m_FD(FD) { }
+  };
   /// \brief Exception specification updates that have been loaded but not yet
   /// propagated across the relevant redeclaration chain. The map key is the
   /// canonical declaration (used only for deduplication) and the value is a
   /// declaration that has an exception specification.
-  llvm::SmallMapVector<Decl *, FunctionDecl *, 4> PendingExceptionSpecUpdates;
+  llvm::SmallMapVector<Decl *, PendingExceptionSpecUpdateInfo, 4>
+      PendingExceptionSpecUpdates;
 
   /// \brief Declarations that have been imported and have typedef names for
   /// linkage purposes.

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -4136,14 +4136,11 @@ void ASTDeclReader::UpdateDecl(Decl *D,
       // FIXME: If the exception specification is already present, check that it
       // matches.
       if (isUnresolvedExceptionSpec(FPT->getExceptionSpecType())) {
-        FD->setType(Reader.getContext().getFunctionType(
-            FPT->getReturnType(), FPT->getParamTypes(),
-            FPT->getExtProtoInfo().withExceptionSpec(ESI)));
-
         // When we get to the end of deserializing, see if there are other decls
         // that we need to propagate this exception specification onto.
         Reader.PendingExceptionSpecUpdates.insert(
-            std::make_pair(FD->getCanonicalDecl(), FD));
+          std::make_pair(FD->getCanonicalDecl(),
+                         ASTReader::PendingExceptionSpecUpdateInfo(FD,ESI)));
       }
       break;
     }


### PR DESCRIPTION
…alizing.

When we deserialize a function with noexcept(constant_expression) qualifier the
constant_expression itself might trigger deserialization. Triggering nested
deserializations is not supported in clang.

Currently we just removed the assert but this shows problems when we go to
higher version of stl's (such as the one in ubuntu19) which more heavily
rely on constexpr. We segfault in cases where we do equivalent of:
```
  cling::Interpreter *interp = ((TCling*)gCling)->GetInterpreterImpl();
  auto& lh = interp->getLookupHelper();
  auto diag = cling::LookupHelper::WithDiagnostics;
  auto S = lh.findScope("ROOT::Internal::RDF", diag);
  lh.findAnyFunction(S, "RDataFrameTake<float>", diag);
  lh.findAnyFunction(S, "RDataFrameTake<std::vector<float>>", diag);
```

This patch delays the unsafe computation of type of the deserialized function
and thus the evaluation of the exception qualifier. This should fix the failing
pyunittests-pyroot-rdataframe-asnumpy nightly on ubuntu 19.

The red pill is applying llvm-mirror/clang@5d50602a8de220e1f0bbdd136e9a7be21a1b63c0

This will happen after releasing v6.20.