### PR TITLE
[ntuple] Implement Show function for RNTuple

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -16,6 +16,9 @@
 #ifndef ROOT7_RFieldVisitor
 #define ROOT7_RFieldVisitor
 
+#include <ROOT/RField.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -24,10 +27,8 @@
 
 namespace ROOT {
 namespace Experimental {
-class RFieldRoot;
+class RNTupleReader;
 namespace Detail {
-class RFieldBase;
-
 
 // clang-format off
 /**
@@ -42,6 +43,19 @@ class RNTupleVisitor {
 public:
    virtual void VisitField(const Detail::RFieldBase &field, int level) = 0;
    virtual void VisitRootField(const RFieldRoot &field, int level) = 0;
+   virtual void VisitArrayField(const RFieldArray &field, int level) { VisitField(field, level); }
+   virtual void VisitBoolField(const RField<bool> &field, int level) { VisitField(field, level); }
+   virtual void VisitBoolVecField(const RField<std::vector<bool>> &field, int level) { VisitField(field, level); }
+   virtual void VisitClassField(const RFieldClass &field, int level) { VisitField(field, level); }
+   virtual void VisitClusterSizeField(const RField<ClusterSize_t> &field, int level) { VisitField(field, level); }
+   virtual void VisitDoubleField(const RField<double> &field, int level) { VisitField(field, level); }
+   virtual void VisitFloatField(const RField<float> &field, int level) { VisitField(field, level); }
+   virtual void VisitIntField(const RField<int> &field, int level) { VisitField(field, level); }
+   virtual void VisitStringField(const RField<std::string> &field, int level) { VisitField(field, level); }
+   virtual void VisitUIntField(const RField<std::uint32_t> &field, int level) { VisitField(field, level); }
+   virtual void VisitUInt64Field(const RField<std::uint64_t> &field, int level) { VisitField(field, level); }
+   virtual void VisitUInt8Field(const RField<std::uint8_t> &field, int level) { VisitField(field, level); }
+   virtual void VisitVectorField(const RFieldVector &field, int level) { VisitField(field, level); }
 };
 } // namespace Detail
 // clang-format off
@@ -53,16 +67,17 @@ public:
  Currently used for RPrintVisitor in RNTupleReader::Print() to collect information about levels, maximal depth etc.
 */
 // clang-format on
-class RPrepareVisitor: public Detail::RNTupleVisitor {
+class RPrepareVisitor : public Detail::RNTupleVisitor {
 private:
    int fDeepestLevel;
    int fNumFields;
+
 public:
-   RPrepareVisitor(int deepestLevel=0, int numFields=0): fDeepestLevel{deepestLevel}, fNumFields{numFields} { }
+   RPrepareVisitor(int deepestLevel = 0, int numFields = 0) : fDeepestLevel{deepestLevel}, fNumFields{numFields} {}
    void VisitField(const Detail::RFieldBase &field, int level) final;
-   void VisitRootField(const RFieldRoot &/*field*/, int /*level*/) final { }
-   int GetDeepestLevel() const {return fDeepestLevel;}
-   int GetNumFields() const {return fNumFields;}
+   void VisitRootField(const RFieldRoot & /*field*/, int /*level*/) final {}
+   int GetDeepestLevel() const { return fDeepestLevel; }
+   int GetNumFields() const { return fNumFields; }
 };
 
 // clang-format off
@@ -92,53 +107,130 @@ private:
    // * |   |__Field <- '|' in position 1, but no '|' in position 2
    // * |__Field 2.4
    // *   |__Field 2 <- no '|' in position 1
-   // *     |__Field
+   // *     |__Field <- no '|' in position 1 and 2
    std::vector<bool> fFlagForVerticalLines;
    /// KeyString refers to the left side containing the word "Field" and its hierarchial order
    std::string MakeKeyString(const Detail::RFieldBase &field, int level);
    /// ValueString refers to the right side containing the type and name
    std::string MakeValueString(const Detail::RFieldBase &field);
+
 public:
-   RPrintVisitor(std::ostream &out = std::cout, char fillSymbol = '*', int width = 80, int deepestLevel = 1, int numFields = 1)
-   : fOutput{out}, fFrameSymbol{fillSymbol}, fWidth{width}, fDeepestLevel{deepestLevel}, fNumFields{numFields}
-   {SetAvailableSpaceForStrings();}
+   RPrintVisitor(std::ostream &out = std::cout, char fillSymbol = '*', int width = 80, int deepestLevel = 1,
+                 int numFields = 1)
+      : fOutput{out}, fFrameSymbol{fillSymbol}, fWidth{width}, fDeepestLevel{deepestLevel}, fNumFields{numFields}
+   {
+      SetAvailableSpaceForStrings();
+   }
    /// Prints summary of Field
    void VisitField(const Detail::RFieldBase &field, int level) final;
-   void VisitRootField(const RFieldRoot &/*field*/, int /*level*/) final { };
-   void SetFrameSymbol(char s) {fFrameSymbol = s;}
-   void SetWidth(int w) {fWidth = w;}
+   void VisitRootField(const RFieldRoot & /*field*/, int /*level*/) final{};
+   void SetFrameSymbol(char s) { fFrameSymbol = s; }
+   void SetWidth(int w) { fWidth = w; }
    void SetDeepestLevel(int d);
    void SetNumFields(int n);
-   /// Computes how many characters should be placed between the frame symbol and ':' for left and right side of ':' for visually pleasing output.
+   /// Computes how many characters should be placed between the frame symbol and ':' for left and right side of ':' for
+   /// visually pleasing output.
    // E.g.
    // * Field 1       : vpx (std::vector<float>)                                     *
    // * |__Field 1.1  : vpx/vpx (float)                                              *
    // int fAvailableSpaceKeyString (num characters on left side between "* " and " : ")
    //    deepestlevel here is 2 (1.1 is deepest and has 2 numbers).
-   //    For every additional level an additional "|_" and ".1" (4 characters) is added, so the number of required additional characters is 4 * fDeepestLevel.
-   //    For level 1, 8 characters are required ("Field 1 "), so an additional + 4 is added.
-   //    To account for cases where the total number of fields is not a single digit number and more space is required to output big numbers, fNumFields is incorporated into the calculation.
-   //    To make sure that there is still enough space for the right side of " : ", an std::min comparision with fWidth - 15 is done.
+   //    For every additional level an additional "|_" and ".1" (4 characters) is added, so the number of required
+   //    additional characters is 4 * fDeepestLevel. For level 1, 8 characters are required ("Field 1 "), so an
+   //    additional + 4 is added. To account for cases where the total number of fields is not a single digit number and
+   //    more space is required to output big numbers, fNumFields is incorporated into the calculation. To make sure
+   //    that there is still enough space for the right side of " : ", an std::min comparision with fWidth - 15 is done.
    // int fAvailableSpaceValueString(num characters on right side between " : " and '*')
    //    The 6 subtracted characters are "* " (2) in the beginning,  " : " (3) and '*' (1) on the far right.
-   void SetAvailableSpaceForStrings() {
-      fAvailableSpaceKeyString = std::min(4 * fDeepestLevel + 4 + static_cast<int>(std::to_string(fNumFields).size()), fWidth - 15);
+   void SetAvailableSpaceForStrings()
+   {
+      fAvailableSpaceKeyString =
+         std::min(4 * fDeepestLevel + 4 + static_cast<int>(std::to_string(fNumFields).size()), fWidth - 15);
       fAvailableSpaceValueString = fWidth - 6 - fAvailableSpaceKeyString;
    }
 };
+// clang-format off
+/**
+\class ROOT::Experimental::RValueVisitor
+\ingroup NTuple
+\brief Traverses through an ntuple to display its entries.
 
-   
+Each visit outputs the entry of a single field as in a .json file. Used when RNTupleReader::Show() is called to show a single entry.
+*/
+// clang-format on
+
+/*
+ * A few notes on why this type procedure was chosen:
+ * 1. Overloading the streaming operator "<<" for array and vector would have been possible, but it wouldn't have been
+ * able to overload them for objects.
+ * 2. Creating a RField::GetView-function was not possible, because when objects are generated from the descriptor, the
+ * RField for vectors and arrays are untemplated (RFieldArray, RFieldVector). (This would have allowed to call
+ * vectorName.size() to get the length instead of doing complicated arithmetics.)
+ * 3. By not using RField::Read() and RField::GenerateValue(), const_cast in not required.
+ * 4. Mulitidimensional vectors could be displayed with gInterpreter but using gInterpreter for vectors would have not
+ * allowed to show vectors of objects.
+ *
+ * How it works:
+ * For every field type its appropriate visitor is called.
+ * For Objects, it doesn't print any values and lets its subfields print the values.
+ * For Vectors and Arrays the values are obtained from the most bottom level field where a basic data type is stored.
+ *    The index from which the data should be read from the most bottom level field and how long a vector/array is is
+ * obtained from the upper level vector and array fields.
+ */
+
+class RValueVisitor : public Detail::RNTupleVisitor {
+private:
+   RNTupleReader *fReader;
+   /// The output is directed to fOutput which may differ from std::cout.
+   std::ostream &fOutput;
+   /// The fIndex-th element should be displayed.
+   std::int32_t fIndex;
+   /// Used when priting the value of a std::array and std::vector field. It tells the visitor to only print the value
+   /// of the subfield and not create a new line for each element in the array/vector.
+   bool fPrintOnlyValue;
+   /// When printing the contents of a std::array or std::vector, this index is used to get the values in its itemField.
+   std::size_t fCollectionIndex;
+
+public:
+   RValueVisitor(std::ostream &output, RNTupleReader *reader, std::int32_t index, bool onlyValue,
+                 std::size_t collectionIndex)
+      : fReader{reader}, fOutput{output}, fIndex{index}, fPrintOnlyValue{onlyValue}, fCollectionIndex{collectionIndex}
+   {
+   }
+   void VisitField(const Detail::RFieldBase &field, int level) final;
+   void VisitRootField(const RFieldRoot & /*fField*/, int /*level*/) final {}
+   void VisitArrayField(const RFieldArray &field, int level) final;
+   void VisitBoolField(const RField<bool> &field, int level) final;
+   void VisitBoolVecField(const RField<std::vector<bool>> &field, int level) final;
+   void VisitClassField(const RFieldClass &field, int level) final;
+   void VisitClusterSizeField(const RField<ClusterSize_t> &field, int level) final;
+   void VisitDoubleField(const RField<double> &field, int level) final;
+   void VisitFloatField(const RField<float> &field, int level) final;
+   void VisitIntField(const RField<int> &field, int level) final;
+   void VisitStringField(const RField<std::string> &field, int level) final;
+   void VisitUIntField(const RField<std::uint32_t> &field, int level) final;
+   void VisitUInt64Field(const RField<std::uint64_t> &field, int level) final;
+   void VisitUInt8Field(const RField<std::uint8_t> &field, int level) final;
+   void VisitVectorField(const RFieldVector &field, int level) final;
+   std::ostream &GetOutput() { return fOutput; }
+   /// Get startIndex from next non-vector/non-array itemfield
+   void SetCollectionIndex(const Detail::RFieldBase &field);
+   // Necessary to convert RClusterIndexes obtained from RFieldVector::GetCollectionInfo()
+   std::size_t ConvertClusterIndexToGlobalIndex(RClusterIndex cluterIndex) const;
+};
+
 // clang-format off
 /**
 \class ROOT::Experimental::RNTupleFormatter
 \ingroup NTuple
 \brief Contains helper functions for RNTupleReader::PrintInfo() and RPrintVisitor::VisitField()
     
- The functions in this class format strings which are displayed when RNTupleReader::PrinfInfo() is called.
+ The functions in this class format strings which are displayed when RNTupleReader::PrintInfo() or RNTupleReader::Show() is called.
 */
 // clang-format on
 class RNTupleFormatter {
 public:
+   static std::string FieldHierarchy(const Detail::RFieldBase &field);
    static std::string FitString(const std::string &str, int availableSpace);
    static std::string HierarchialFieldOrder(const Detail::RFieldBase &field);
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -83,6 +83,13 @@ enum class ENTupleInfo {
    kStorageDetails, // size on storage, page sizes, compression factor, etc.
    kMetrics, // internals performance counters, requires that EnableMetrics() was called
 };
+   
+/**
+* Listing of the different options that can be returned by RNTupleReader::Show()
+*/
+enum class ENTupleFormat {
+   kJSON,      // prints a single entry/row in JSON format.
+};
 
 
 // clang-format off
@@ -140,7 +147,11 @@ public:
    const RNTupleDescriptor &GetDescriptor() const { return fSource->GetDescriptor(); }
 
    /// Prints a detailed summary of the ntuple, including a list of fields.
-   void PrintInfo(const ENTupleInfo what = ENTupleInfo::kSummary, std::ostream &output = std::cout);
+   void PrintInfo(const ENTupleInfo format = ENTupleInfo::kSummary, std::ostream &output = std::cout);
+
+   /// Shows the values of the i-th entry/row, where i = index. format = ENTupleInfo::kJSON
+   /// (default) prints the output in JSON-like format.
+   void Show(NTupleSize_t index, const ENTupleFormat format = ENTupleFormat::kJSON, std::ostream &output = std::cout);
 
    /// Analogous to Fill(), fills the default entry of the model. Returns false at the end of the ntuple.
    /// On I/O errors, raises an expection.

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -204,6 +204,13 @@ void ROOT::Experimental::Detail::RFieldBase::Attach(
    fSubFields.emplace_back(std::move(child));
 }
 
+const ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::Detail::RFieldBase::GetFirstChild() const
+{
+   if (fSubFields.size())
+      return fSubFields[0].get();
+   return nullptr;
+}
+
 void ROOT::Experimental::Detail::RFieldBase::Flush() const
 {
    for (auto& column : fColumns) {
@@ -223,8 +230,66 @@ void ROOT::Experimental::Detail::RFieldBase::TraverseVisitor(RNTupleVisitor &vis
 
 void ROOT::Experimental::Detail::RFieldBase::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
 {
-    visitor.VisitField(*this, level);
+   visitor.VisitField(*this, level);
 }
+
+void ROOT::Experimental::Detail::RFieldBase::TraverseValueVisitor(RValueVisitor &visitor, int level) const
+{
+   // subfields of a std::vector (kCollection) and std::array shouldn't be displayed
+   if ((GetLevelInfo().GetLevel() != 0) && (GetParent()->GetStructure() == ENTupleStructure::kCollection
+      || GetParent()->GetType().compare(0, 11, "std::array<") == 0))
+      return;
+
+   if (this->GetLevelInfo().GetOrder() == 1)
+   {
+      for (int i = 1; i < level; ++i) visitor.GetOutput() << "  ";
+      visitor.GetOutput() << '{' << std::endl;
+   }
+
+   this->AcceptVisitor(visitor, level);
+   ++level;
+   for (const auto &fieldPtr: fSubFields) {
+      fieldPtr->TraverseValueVisitor(visitor, level);
+   }
+
+   // Close bracket for last field among siblings
+   if (this->GetLevelInfo().GetOrder() == this->GetLevelInfo().GetNumSiblings())
+   {
+      for(int i = 1; i < level-1; ++i)
+         visitor.GetOutput() << "  ";
+      visitor.GetOutput() << '}';
+      // for a certain special case (*), do not start a newline
+      // (*) When there is an array or vector of objects a ',' after a '{' is desired. Example:
+      // ObjVec:{
+      //          {
+      //             7.0,
+      //             4
+      //          },             <- no newline after '}'
+      //          {
+      //             8.9,
+      //             8
+      //          }
+      //        }
+      if (GetParent()->GetParent()) {
+         std::string grandParentType = GetParent()->GetParent()->GetType();
+         if ((grandParentType.compare(0, 12, "std::vector<") != 0) && (grandParentType.compare(0, 11, "std::array<") != 0)) {
+            visitor.GetOutput() << std::endl;
+         }
+      } else {
+         visitor.GetOutput() << std::endl;
+      }
+   }
+}
+
+/// When printing an array or vector of objects, only the contents in the subfields should be displayed -> skip top level field
+void ROOT::Experimental::Detail::RFieldBase::NotVisitTopFieldTraverseValueVisitor(RValueVisitor &visitor, int level) const
+{
+   ++level;
+   for (const auto &fieldPtr: fSubFields) {
+      fieldPtr->TraverseValueVisitor(visitor, level);
+   }
+}
+
 
 ROOT::Experimental::Detail::RFieldBase::RIterator ROOT::Experimental::Detail::RFieldBase::begin()
 {
@@ -304,6 +369,11 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::DoGenerateCo
    fPrincipalColumn = fColumns[0].get();
 }
 
+void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitClusterSizeField(*this, level);
+}
+
 //------------------------------------------------------------------------------
 
 void ROOT::Experimental::RField<std::uint8_t>::DoGenerateColumns()
@@ -314,6 +384,10 @@ void ROOT::Experimental::RField<std::uint8_t>::DoGenerateColumns()
    fPrincipalColumn = fColumns[0].get();
 }
 
+void ROOT::Experimental::RField<std::uint8_t>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitUInt8Field(*this, level);
+}
 
 //------------------------------------------------------------------------------
 
@@ -326,6 +400,10 @@ void ROOT::Experimental::RField<bool>::DoGenerateColumns()
    fPrincipalColumn = fColumns[0].get();
 }
 
+void ROOT::Experimental::RField<bool>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitBoolField(*this, level);
+}
 
 //------------------------------------------------------------------------------
 
@@ -338,6 +416,11 @@ void ROOT::Experimental::RField<float>::DoGenerateColumns()
    fPrincipalColumn = fColumns[0].get();
 }
 
+void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitFloatField(*this, level);
+}
+
 //------------------------------------------------------------------------------
 
 void ROOT::Experimental::RField<double>::DoGenerateColumns()
@@ -348,6 +431,10 @@ void ROOT::Experimental::RField<double>::DoGenerateColumns()
    fPrincipalColumn = fColumns[0].get();
 }
 
+void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitDoubleField(*this, level);
+}
 
 //------------------------------------------------------------------------------
 
@@ -357,6 +444,11 @@ void ROOT::Experimental::RField<std::int32_t>::DoGenerateColumns()
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
       std::int32_t, EColumnType::kInt32>(model, 0)));
    fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::int32_t>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitIntField(*this, level);
 }
 
 //------------------------------------------------------------------------------
@@ -369,6 +461,11 @@ void ROOT::Experimental::RField<std::uint32_t>::DoGenerateColumns()
    fPrincipalColumn = fColumns[0].get();
 }
 
+void ROOT::Experimental::RField<std::uint32_t>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitUIntField(*this, level);
+}
+
 //------------------------------------------------------------------------------
 
 void ROOT::Experimental::RField<std::uint64_t>::DoGenerateColumns()
@@ -377,6 +474,11 @@ void ROOT::Experimental::RField<std::uint64_t>::DoGenerateColumns()
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<std::uint64_t, EColumnType::kInt64>(model, 0)));
    fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::uint64_t>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitUInt64Field(*this, level);
 }
 
 //------------------------------------------------------------------------------
@@ -421,6 +523,10 @@ void ROOT::Experimental::RField<std::string>::CommitCluster()
    fIndex = 0;
 }
 
+void ROOT::Experimental::RField<std::string>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitStringField(*this, level);
+}
 
 //------------------------------------------------------------------------------
 
@@ -504,6 +610,10 @@ size_t ROOT::Experimental::RFieldClass::GetValueSize() const
    return fClass->GetClassSize();
 }
 
+void ROOT::Experimental::RFieldClass::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitClassField(*this, level);
+}
 
 //------------------------------------------------------------------------------
 
@@ -588,6 +698,11 @@ void ROOT::Experimental::RFieldVector::CommitCluster()
    fNWritten = 0;
 }
 
+void ROOT::Experimental::RFieldVector::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitVectorField(*this, level);
+}
+
 
 //------------------------------------------------------------------------------
 
@@ -643,6 +758,11 @@ void ROOT::Experimental::RField<std::vector<bool>>::DestroyValue(const Detail::R
    vec->~vector();
    if (!dtorOnly)
       free(vec);
+}
+
+void ROOT::Experimental::RField<std::vector<bool>>::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitBoolVecField(*this, level);
 }
 
 
@@ -721,6 +841,10 @@ ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RFieldArray::Capture
    return Detail::RFieldValue(true /* captureFlag */, this, where);
 }
 
+void ROOT::Experimental::RFieldArray::AcceptVisitor(Detail::RNTupleVisitor &visitor, int level) const
+{
+   visitor.VisitArrayField(*this, level);
+}
 
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -1,6 +1,6 @@
 /// \file RFieldVisitor.cxx
 /// \ingroup NTuple ROOT7
-/// \author Simon Leisibach <simon.satoshi.rene.leisibach@cern.ch>
+/// \author Simon Leisibach <simon.leisibach@gmail.com>
 /// \date 2019-06-11
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
@@ -13,26 +13,28 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <algorithm>
-#include <iomanip>
+#include <ROOT/RField.hxx>
+#include <ROOT/RFieldValue.hxx>
+#include <ROOT/RFieldVisitor.hxx>
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleUtil.hxx>
+#include <ROOT/RNTupleView.hxx>
+
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
 
-#include "ROOT/RField.hxx"
-#include "ROOT/RFieldVisitor.hxx"
-#include "ROOT/RNTuple.hxx"
-
-
 //---------------------------- RPrintVisitor ------------------------------------
 
-void ROOT::Experimental::RPrintVisitor::SetDeepestLevel(int d) {
+void ROOT::Experimental::RPrintVisitor::SetDeepestLevel(int d)
+{
    fDeepestLevel = d;
    fFlagForVerticalLines.resize(d - 1);
 }
 
-void ROOT::Experimental::RPrintVisitor::SetNumFields(int n) {
+void ROOT::Experimental::RPrintVisitor::SetNumFields(int n)
+{
    fNumFields = n;
    SetAvailableSpaceForStrings();
 }
@@ -40,17 +42,18 @@ void ROOT::Experimental::RPrintVisitor::SetNumFields(int n) {
 std::string ROOT::Experimental::RPrintVisitor::MakeKeyString(const Detail::RFieldBase &field, int level)
 {
    std::string result{""};
-   if (level==1) {
+   if (level == 1) {
       result += "Field ";
       result += std::to_string(field.GetLevelInfo().GetOrder());
    } else {
-      if (field.GetLevelInfo().GetOrder() == field.GetLevelInfo().GetNumSiblings()) { fFlagForVerticalLines.at(level-2) = false;
+      if (field.GetLevelInfo().GetOrder() == field.GetLevelInfo().GetNumSiblings()) {
+         fFlagForVerticalLines.at(level - 2) = false;
       } else {
-         fFlagForVerticalLines.at(level-2) = true;
+         fFlagForVerticalLines.at(level - 2) = true;
       }
-      for(int i = 0; i < level-2; ++i) {
+      for (int i = 0; i < level - 2; ++i) {
          if (fFlagForVerticalLines.at(i)) {
-            result+= "| ";
+            result += "| ";
          } else {
             result += "  ";
          }
@@ -70,8 +73,7 @@ std::string ROOT::Experimental::RPrintVisitor::MakeValueString(const Detail::RFi
 // Entire function only prints 1 Line, when if statement is disregarded.
 void ROOT::Experimental::RPrintVisitor::VisitField(const Detail::RFieldBase &field, int level)
 {
-   if (level == 1)
-   {
+   if (level == 1) {
       for (int i = 0; i < fWidth; ++i) {
          fOutput << fFrameSymbol;
       }
@@ -86,18 +88,489 @@ void ROOT::Experimental::RPrintVisitor::VisitField(const Detail::RFieldBase &fie
 
 //---------------------- RPrepareVisitor -------------------------------
 
-
-void ROOT::Experimental::RPrepareVisitor::VisitField(const Detail::RFieldBase &/*field*/, int level)
+void ROOT::Experimental::RPrepareVisitor::VisitField(const Detail::RFieldBase & /*field*/, int level)
 {
    ++fNumFields;
    if (level > fDeepestLevel)
       fDeepestLevel = level;
 }
 
+//------------------------ RValueVisitor --------------------------------
+
+void ROOT::Experimental::RValueVisitor::VisitField(const Detail::RFieldBase &field, int level)
+{
+   if (fPrintOnlyValue) {
+      fOutput << "no support for " << field.GetType();
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": no support for " << field.GetType();
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitArrayField(const RFieldArray &field, int level)
+{
+   // When fPrintOnlyValue is true, int level gets a new meaning. It is used in VisitVectorField for multidimentional
+   // vectors and array of vectors.
+   if (fPrintOnlyValue) {
+      fOutput << "[ ";
+
+      // iterate through the elements of the array
+      for (std::size_t i = 0; i < field.GetLength() - 1; ++i) {
+         // The expression (i + fIndex*field.GetLength()) is passed as level. When passed to a field with basic data
+         // type it is unused, but for multidimensional vectors it denotes the index of a subvector.
+         field.FirstSubFieldAcceptVisitor(*this, i + fIndex * field.GetLength());
+         fOutput << ", ";
+         ++fCollectionIndex;
+      }
+      // don't print ", " for the last element
+      field.FirstSubFieldAcceptVisitor(*this, field.GetLength() - 1 + fIndex * field.GetLength());
+      fOutput << " ]";
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": [";
+   // Get startIndex from next non-vector/non-array itemfield.
+   SetCollectionIndex(field);
+
+   for (std::size_t i = 0; i < field.GetLength() - 1; ++i) {
+      field.FirstSubFieldAcceptVisitor(*this, i + fIndex * field.GetLength());
+      fOutput << ", ";
+      ++fCollectionIndex;
+   }
+   // don't print ", " for the last element
+   field.FirstSubFieldAcceptVisitor(*this, field.GetLength() - 1 + fIndex * field.GetLength());
+
+   if (field.GetFirstChild()->GetStructure() == ENTupleStructure::kRecord) {
+      fOutput << std::endl;
+      for (int i = 0; i < level; ++i)
+         fOutput << "  ";
+   }
+   fOutput << "]";
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+
+   fPrintOnlyValue = false;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitBoolField(const RField<bool> &field, int level)
+{
+   if (fPrintOnlyValue) {
+      auto view = fReader->GetView<bool>(RNTupleFormatter::FieldHierarchy(field));
+      if (view(fCollectionIndex) == 0) {
+         fOutput << "false";
+      } else {
+         fOutput << "true";
+      }
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": ";
+
+   auto view = fReader->GetView<bool>(RNTupleFormatter::FieldHierarchy(field));
+   if (view(fIndex) == 0) {
+      fOutput << "false";
+   } else {
+      fOutput << "true";
+   }
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+// Visited when encountering a field with a custom object with dictionary.
+void ROOT::Experimental::RValueVisitor::VisitClassField(const RFieldClass &field, int level)
+{
+   if (fPrintOnlyValue) {
+      fOutput << std::endl;
+      // Create new RValueVisitor to have 2 different fCollectionIndexes (allows to display vector of objects which
+      // contain vectors themselves)
+      RValueVisitor visitor(fOutput, fReader, level /*fIndex*/, false, 0);
+      field.NotVisitTopFieldTraverseValueVisitor(visitor, field.GetLevelInfo().GetLevel());
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": " << std::endl;
+   // A custom object (represented by RFieldClass) should let its subfields display
+   // its entries instead of displaying all by itself.
+   // So the field of the custom object should only display its name and make an early quit here.
+   return;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitClusterSizeField(const RField<ROOT::Experimental::ClusterSize_t> &field,
+                                                              int level)
+{
+   if (fPrintOnlyValue) {
+      auto view = fReader->GetView<ClusterSize_t>(RNTupleFormatter::FieldHierarchy(field));
+      fOutput << view(fCollectionIndex);
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": ";
+
+   auto view = fReader->GetView<ClusterSize_t>(RNTupleFormatter::FieldHierarchy(field));
+   fOutput << view(fIndex);
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitDoubleField(const RField<double> &field, int level)
+{
+   if (fPrintOnlyValue) {
+      auto view = fReader->GetView<double>(RNTupleFormatter::FieldHierarchy(field));
+      fOutput << view(fCollectionIndex);
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": ";
+
+   auto view = fReader->GetView<double>(RNTupleFormatter::FieldHierarchy(field));
+   fOutput << view(fIndex);
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitFloatField(const RField<float> &field, int level)
+{
+   if (fPrintOnlyValue) {
+      auto view = fReader->GetView<float>(RNTupleFormatter::FieldHierarchy(field));
+      fOutput << view(fCollectionIndex);
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": ";
+
+   auto view = fReader->GetView<float>(RNTupleFormatter::FieldHierarchy(field));
+   fOutput << view(fIndex);
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitIntField(const RField<int> &field, int level)
+{
+   if (fPrintOnlyValue) {
+      auto view = fReader->GetView<std::int32_t>(RNTupleFormatter::FieldHierarchy(field));
+      fOutput << view(fCollectionIndex);
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": ";
+
+   auto view = fReader->GetView<int>(RNTupleFormatter::FieldHierarchy(field));
+   fOutput << view(fIndex);
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitStringField(const RField<std::string> &field, int level)
+{
+   if (fPrintOnlyValue) {
+      auto view = fReader->GetView<std::string>(RNTupleFormatter::FieldHierarchy(field));
+      fOutput << "\"" << view(fCollectionIndex) << "\"";
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": ";
+
+   auto view = fReader->GetView<std::string>(RNTupleFormatter::FieldHierarchy(field));
+   fOutput << "\"" << view(fIndex) << "\"";
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitUIntField(const RField<std::uint32_t> &field, int level)
+{
+   if (fPrintOnlyValue) {
+      auto view = fReader->GetView<std::uint32_t>(RNTupleFormatter::FieldHierarchy(field));
+      fOutput << view(fCollectionIndex);
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": ";
+
+   auto view = fReader->GetView<std::uint32_t>(RNTupleFormatter::FieldHierarchy(field));
+   fOutput << view(fIndex);
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitUInt64Field(const RField<std::uint64_t> &field, int level)
+{
+   if (fPrintOnlyValue) {
+      auto view = fReader->GetView<std::uint64_t>(RNTupleFormatter::FieldHierarchy(field));
+      fOutput << view(fCollectionIndex);
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": ";
+
+   auto view = fReader->GetView<std::uint64_t>(RNTupleFormatter::FieldHierarchy(field));
+   fOutput << view(fIndex);
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitUInt8Field(const RField<std::uint8_t> &field, int level)
+{
+   if (fPrintOnlyValue) {
+      auto view = fReader->GetView<std::uint8_t>(RNTupleFormatter::FieldHierarchy(field));
+      fOutput << "'" << view(fCollectionIndex) << "'";
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": ";
+
+   auto view = fReader->GetView<std::uint8_t>(RNTupleFormatter::FieldHierarchy(field));
+   fOutput << "'" << view(fIndex) << "'";
+
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+}
+
+void ROOT::Experimental::RValueVisitor::VisitVectorField(const RFieldVector &field, int level)
+{
+   if (fPrintOnlyValue) {
+      fOutput << "{ ";
+      RClusterIndex dummyCluster;
+      ClusterSize_t nItems;
+      field.GetCollectionInfo(level, &dummyCluster, &nItems);
+
+      for (std::size_t i = 0; i < nItems - 1; ++i) {
+         // The level parameter has a different meaning when fPrintOnlyValue = true. i + dummyCluster.GetIndex() is used
+         // to get the index of the subvector when dealing with multidimensional vectors.
+         field.FirstSubFieldAcceptVisitor(*this, i + dummyCluster.GetIndex() /*level*/);
+         fOutput << ", ";
+         ++fCollectionIndex;
+      }
+      // don't print ", " for the last element
+      field.FirstSubFieldAcceptVisitor(*this, nItems - 1 + dummyCluster.GetIndex() /*level*/);
+      fOutput << " }";
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": {";
+
+   ClusterSize_t nItems;
+   RClusterIndex dummyIndex;
+   field.GetCollectionInfo(fIndex, &dummyIndex, &nItems);
+   SetCollectionIndex(field);
+
+   for (std::size_t i = 0; i < nItems - 1; ++i) {
+      field.FirstSubFieldAcceptVisitor(*this, i + dummyIndex.GetIndex());
+      fOutput << ", ";
+      ++fCollectionIndex;
+   }
+   // don't print ", " for the last element
+   field.FirstSubFieldAcceptVisitor(*this, nItems - 1 + dummyIndex.GetIndex());
+
+   // Cosmetics for case where a vector of objects should be displayed.
+   if (field.GetFirstChild()->GetStructure() == ENTupleStructure::kRecord) {
+      fOutput << std::endl;
+      for (int i = 0; i < level; ++i)
+         fOutput << "  ";
+   }
+   fOutput << "}";
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fOutput << std::endl;
+
+   fPrintOnlyValue = false;
+}
+
+// See RValueVisitor::VisitVectorField for comments
+void ROOT::Experimental::RValueVisitor::VisitBoolVecField(const RField<std::vector<bool>> &field, int level)
+{
+   if (fPrintOnlyValue) {
+      fOutput << "{ ";
+      RClusterIndex dummyIndex;
+      ClusterSize_t nItems;
+      field.GetCollectionInfo(level, &dummyIndex, &nItems);
+
+      for (std::size_t i = 0; i < nItems - 1; ++i) {
+         field.FirstSubFieldAcceptVisitor(*this, i + dummyIndex.GetIndex() /* level*/);
+         fOutput << ", ";
+         ++fCollectionIndex;
+      }
+      // don't print ", " for the last element
+      field.FirstSubFieldAcceptVisitor(*this, nItems - 1 + dummyIndex.GetIndex() /* level*/);
+      fOutput << " }";
+      return;
+   }
+
+   for (int i = 0; i < level; ++i)
+      fOutput << "  ";
+   fOutput << "\"" << field.GetName() << "\": {";
+
+   ClusterSize_t nItems;
+   RClusterIndex dummyIndex;
+   field.GetCollectionInfo(fIndex, &dummyIndex, &nItems);
+   SetCollectionIndex(field);
+   for (std::size_t i = 0; i < nItems - 1; ++i) {
+      field.FirstSubFieldAcceptVisitor(*this, i + dummyIndex.GetIndex());
+      fOutput << ", ";
+      ++fCollectionIndex;
+   }
+   field.FirstSubFieldAcceptVisitor(*this, nItems - 1 + dummyIndex.GetIndex());
+
+   if (field.GetFirstChild()->GetStructure() == ENTupleStructure::kRecord) {
+      fOutput << std::endl;
+      for (int i = 0; i < level; ++i)
+         fOutput << "  ";
+   }
+   fOutput << "}";
+   if (field.GetLevelInfo().GetNumSiblings() != field.GetLevelInfo().GetOrder())
+      fOutput << ',';
+   fPrintOnlyValue = false;
+}
+
+// Quick formulas for calculating the startIndex of the first non-array/non-vector itemfield:
+// vector of vector: itemFieldIndex
+//                   MainFieldPtr->GetCollectionInfo(fIndex, &clusterIndex, &nItems)
+//                   subfieldIndex = ConvertClusterIndexToGlobalIndex(clusterIndex)
+//                   SubFieldPtr->GetCollectionInfo(subFieldIndex, &clusterIndex2, &nItems)
+//                   itemFieldIndex = ConvertClusterIndexToGlobalIndex(clusterIndex2)
+//                   (for higher dimensional vectors successivley plugIn the clusterIndex to GetCollectionInfo.
+// array of array: fIndex * fLength1 * fLength2
+// vector of array:  subfieldIndex * fLength2
+//                   MainFieldPtr->GetCollectionInfo(fIndex, &clusterIndex, &nItems)
+//                   subfieldIndex = ConvertClusterIndexToGlobalIndex(clusterIndex)
+// array of vector:  itemFieldIndex
+//                   SubFieldPtr->GetCollectionInfo(fIndex * fLength1, &clusterIndex, &nItems)
+//                   itemFieldIndex = ConvertClusterIndexToGlobalIndex(clusterIndex)
+void ROOT::Experimental::RValueVisitor::SetCollectionIndex(const Detail::RFieldBase &field)
+{
+   const Detail::RFieldBase *fieldPtr = &field;
+   const Detail::RFieldBase *childPtr = field.GetFirstChild();
+   if (childPtr == nullptr)
+      assert(false);
+
+   std::string typeName = field.GetType();
+   if (typeName.compare(0, 11, "std::array<") == 0) {
+      auto arrayFieldPtr = reinterpret_cast<const RFieldArray *>(fieldPtr);
+      fPrintOnlyValue = true;
+      fCollectionIndex = fIndex * arrayFieldPtr->GetLength();
+   } else if (typeName.compare(0, 17, "std::vector<bool>") == 0) {
+      auto boolVecFieldPtr = reinterpret_cast<const RField<std::vector<bool>> *>(fieldPtr);
+      fPrintOnlyValue = true;
+      ClusterSize_t nItems;
+      RClusterIndex dummyIndex;
+      boolVecFieldPtr->GetCollectionInfo(fIndex, &dummyIndex, &nItems);
+      fCollectionIndex = ConvertClusterIndexToGlobalIndex(dummyIndex);
+      return;
+   } else if (typeName.compare(0, 12, "std::vector<") == 0) {
+      auto vecFieldPtr = reinterpret_cast<const RFieldVector *>(fieldPtr);
+      fPrintOnlyValue = true;
+      ClusterSize_t nItems;
+      RClusterIndex dummyIndex;
+      vecFieldPtr->GetCollectionInfo(fIndex, &dummyIndex, &nItems);
+      fCollectionIndex = ConvertClusterIndexToGlobalIndex(dummyIndex);
+   } else {
+      return;
+   }
+   std::string childTypeName = childPtr->GetType();
+   while ((childTypeName.compare(0, 11, "std::array<") == 0) || (childTypeName.compare(0, 12, "std::vector<") == 0)) {
+      fieldPtr = childPtr;
+      childPtr = fieldPtr->GetFirstChild();
+      typeName = fieldPtr->GetType();
+      if (typeName.compare(0, 11, "std::array<") == 0) {
+         auto arrayFieldPtr = reinterpret_cast<const RFieldArray *>(fieldPtr);
+         fCollectionIndex = fCollectionIndex * arrayFieldPtr->GetLength();
+      } else if (typeName.compare(0, 17, "std::vector<bool>") == 0) {
+         auto boolVecFieldPtr = reinterpret_cast<const RField<std::vector<bool>> *>(fieldPtr);
+         ClusterSize_t nItems;
+         RClusterIndex dummyIndex;
+         boolVecFieldPtr->GetCollectionInfo(fCollectionIndex, &dummyIndex, &nItems);
+         fCollectionIndex = ConvertClusterIndexToGlobalIndex(dummyIndex);
+         return;
+      } else if (typeName.compare(0, 12, "std::vector<") == 0) {
+         auto vecFieldPtr = reinterpret_cast<const RFieldVector *>(fieldPtr);
+         ClusterSize_t nItems;
+         RClusterIndex dummyIndex;
+         vecFieldPtr->GetCollectionInfo(fCollectionIndex, &dummyIndex, &nItems);
+         fCollectionIndex = ConvertClusterIndexToGlobalIndex(dummyIndex);
+      } else {
+         return;
+      }
+      childTypeName = childPtr->GetType();
+   }
+   return;
+}
+
+std::size_t ROOT::Experimental::RValueVisitor::ConvertClusterIndexToGlobalIndex(RClusterIndex clusterIndex) const
+{
+   auto &desc = fReader->GetDescriptor();
+   std::size_t globalIndex = static_cast<std::size_t>(clusterIndex.GetIndex());
+   for (std::size_t i = 0; i < clusterIndex.GetClusterId(); ++i) {
+      globalIndex += desc.GetClusterDescriptor(i).GetNEntries();
+   }
+   return globalIndex;
+}
+
 //------------------------ RNTupleFormatter -----------------------------
 
-//E.g. ("ExampleString" , space= 8) => "Examp..."
-std::string ROOT::Experimental::RNTupleFormatter::FitString(const std::string &str, int availableSpace) {
+// Returns std::string of form "SubFieldofRootFieldName. ... .ParentFieldName.FieldName"
+std::string ROOT::Experimental::RNTupleFormatter::FieldHierarchy(const Detail::RFieldBase &field)
+{
+   std::string qualifiedName{field.GetName()};
+   if (!field.GetParent())
+      return qualifiedName;
+   const Detail::RFieldBase *parentField{field.GetParent()};
+   for (int i = field.GetLevelInfo().GetLevel(); i > 1; --i) {
+      qualifiedName = parentField->GetName() + "." + qualifiedName;
+      parentField = parentField->GetParent();
+   }
+   return qualifiedName;
+}
+
+// E.g. ("ExampleString" , space= 8) => "Examp..."
+std::string ROOT::Experimental::RNTupleFormatter::FitString(const std::string &str, int availableSpace)
+{
    int strSize{static_cast<int>(str.size())};
    if (strSize <= availableSpace)
       return str + std::string(availableSpace - strSize, ' ');
@@ -107,11 +580,13 @@ std::string ROOT::Experimental::RNTupleFormatter::FitString(const std::string &s
 }
 
 // Returns std::string of form "1" or "2.1.1"
-std::string ROOT::Experimental::RNTupleFormatter::HierarchialFieldOrder(const ROOT::Experimental::Detail::RFieldBase &field)
+std::string
+ROOT::Experimental::RNTupleFormatter::HierarchialFieldOrder(const ROOT::Experimental::Detail::RFieldBase &field)
 {
    std::string hierarchialOrder{std::to_string(field.GetLevelInfo().GetOrder())};
-   const ROOT::Experimental::Detail::RFieldBase* parentPtr{field.GetParent()};
-   // To avoid having the index of the RootField (-1) in the return value, it is checked if the grandparent is a nullptr (in that case RootField is parent)
+   const Detail::RFieldBase *parentPtr{field.GetParent()};
+   // To avoid having the index of the RootField (-1) in the return value, it is checked if the grandparent is a nullptr
+   // (in that case RootField is parent)
    while (parentPtr && (parentPtr->GetLevelInfo().GetOrder() != -1)) {
       hierarchialOrder = std::to_string(parentPtr->GetLevelInfo().GetOrder()) + "." + hierarchialOrder;
       parentPtr = parentPtr->GetParent();

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -20,5 +20,5 @@ ROOT_ADD_GTEST(ntuple ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore Cus
 ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_packing ntuple_packing.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_pages ntuple_pages.cxx LIBRARIES ROOTNTuple)
-ROOT_ADD_GTEST(ntuple_print ntuple_print.cxx LIBRARIES ROOTNTuple)
+ROOT_ADD_GTEST(ntuple_print ntuple_print.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_raw ntuple_raw.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore)

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -5,8 +5,8 @@
  * Used to test serialization and deserialization of classes in RNTuple with TClass
  */
 struct CustomStruct {
-  float a = 0.0;
-  std::vector<float> v1;
-  std::vector<std::vector<float>> v2;
-  std::string s;
+   float a = 0.0;
+   std::vector<float> v1;
+   std::vector<std::vector<float>> v2;
+   std::string s;
 };

--- a/tree/ntuple/v7/test/ntuple_print.cxx
+++ b/tree/ntuple/v7/test/ntuple_print.cxx
@@ -1,6 +1,9 @@
+#include "CustomStruct.hxx"
+
 #include <ROOT/RFieldVisitor.hxx>
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleUtil.hxx>
 #include <TFile.h>
 
 #include "gtest/gtest.h"
@@ -9,6 +12,7 @@
 #include <sstream>
 #include <vector>
 
+using ClusterSize_t = ROOT::Experimental::ClusterSize_t;
 using RNTupleReader = ROOT::Experimental::RNTupleReader;
 using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
 using RNTupleModel = ROOT::Experimental::RNTupleModel;
@@ -163,7 +167,7 @@ TEST(RNtuplePrint, NarrowManyEntriesVecVecTraverse)
    EXPECT_EQ(expected, os.str());
 }
 
-/* Currently the width can't be set by PrintInfo(). Will be enabled when this feature is added.
+/* Currently the width can't be set by PrintInfo(). This test will be enabled when this feature is added.
 TEST(RNTuplePrint, TooShort)
 {
 FileRaii fileGuard("test.root");
@@ -179,3 +183,374 @@ std::string fString{"The width is too small! Should be at least 30.\n"};
 EXPECT_EQ(fString, os.str());
 }
 */
+
+TEST(RNTupleShow, Empty)
+{
+   std::string rootFileName{"empty.root"};
+   std::string ntupleName{"EmptyNTuple"};
+   FileRaii fileGuard(rootFileName);
+   {
+      auto model = RNTupleModel::Create();
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
+      ntuple->Fill();
+      ntuple->Fill();
+   }
+   auto model2 = RNTupleModel::Create();
+   auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
+   
+   std::ostringstream os;
+   ntuple2->Show(0, ROOT::Experimental::ENTupleFormat::kJSON, os);
+   std::string fString{"The NTuple is empty.\n"};
+   EXPECT_EQ(fString, os.str());
+   
+   std::ostringstream os1;
+   ntuple2->Show(1, ROOT::Experimental::ENTupleFormat::kJSON, os1);
+   std::string fString1{"The NTuple is empty.\n"};
+   EXPECT_EQ(fString1, os1.str());
+}
+
+
+TEST(RNTupleShow, BasicTypes)
+{
+   std::string rootFileName{"basictypes.root"};
+   std::string ntupleName{"SimpleTypesNtuple"};
+   FileRaii fileGuard(rootFileName);
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float>("pt");
+      auto fielddb = model->MakeField<double>("db");
+      auto fieldint = model->MakeField<int>("int");
+      auto fielduint = model->MakeField<unsigned>("uint");
+      auto field64uint = model->MakeField<std::uint64_t>("uint64");
+      auto fieldstring = model->MakeField<std::string>("string");
+      auto fieldbool = model->MakeField<bool>("boolean");
+      auto fieldchar = model->MakeField<uint8_t>("uint8");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
+      
+      *fieldPt = 5.0f;
+      *fielddb = 9.99;
+      *fieldint = -4;
+      *fielduint = 3;
+      *field64uint = 44444444444ull;
+      *fieldstring = "TestString";
+      *fieldbool = true;
+      *fieldchar = 97;
+      ntuple->Fill();
+      
+      *fieldPt = 8.5f;
+      *fielddb = 9.998;
+      *fieldint = -94;
+      *fielduint = -30;
+      *field64uint = 2299994967294ull;
+      *fieldstring = "TestString2";
+      *fieldbool = false;
+      *fieldchar = 98;
+      ntuple->Fill();
+   }
+   auto model2 = RNTupleModel::Create();
+   auto fieldPt2 = model2->MakeField<float>("pt");
+   auto fielddb = model2->MakeField<double>("db");
+   auto fieldint = model2->MakeField<int>("int");
+   auto fielduint = model2->MakeField<unsigned>("uint");
+   auto field64uint = model2->MakeField<std::uint64_t>("uint64");
+   auto fieldstring = model2->MakeField<std::string>("string");
+   auto fieldbool = model2->MakeField<bool>("boolean");
+   auto fieldchar = model2->MakeField<uint8_t>("uint8");
+   auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
+   
+   std::ostringstream os;
+   ntuple2->Show(0, ROOT::Experimental::ENTupleFormat::kJSON, os);
+   std::string fString{ std::string("")
+      + "{\n"
+      + "  \"pt\": 5,\n"
+      + "  \"db\": 9.99,\n"
+      + "  \"int\": -4,\n"
+      + "  \"uint\": 3,\n"
+      + "  \"uint64\": 44444444444,\n"
+      + "  \"string\": \"TestString\",\n"
+      + "  \"boolean\": true,\n"
+      + "  \"uint8\": 'a'\n"
+      + "}\n" };
+   EXPECT_EQ(fString, os.str());
+   
+   std::ostringstream os1;
+   ntuple2->Show(1, ROOT::Experimental::ENTupleFormat::kJSON, os1);
+   std::string fString1{ std::string("")
+      + "{\n"
+      + "  \"pt\": 8.5,\n"
+      + "  \"db\": 9.998,\n"
+      + "  \"int\": -94,\n"
+      + "  \"uint\": 4294967266,\n"
+      + "  \"uint64\": 2299994967294,\n"
+      + "  \"string\": \"TestString2\",\n"
+      + "  \"boolean\": false,\n"
+      + "  \"uint8\": 'b'\n"
+      + "}\n" };
+   EXPECT_EQ(fString1, os1.str());
+   
+   std::ostringstream os2;
+   ntuple2->Show(10, ROOT::Experimental::ENTupleFormat::kJSON, os2);
+   std::string fString2{ "Index exceeds maximum number of entries. (2)\n" };
+   EXPECT_EQ(fString2, os2.str());
+}
+
+TEST(RNTupleShow, VectorFields)
+{
+   std::string rootFileName{"ShowVector.root"};
+   std::string ntupleName{"VecNTuple"};
+   FileRaii fileGuard(rootFileName);
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldIntVec = model->MakeField<std::vector<int>>("intVec");
+      auto fieldFloatVecVec = model->MakeField<std::vector<std::vector<float>>>("floatVecVec");
+      auto fieldBoolVecVec = model->MakeField<std::vector<std::vector<bool>>>("booleanVecVec");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
+      
+      *fieldIntVec = std::vector<int>{4, 5, 6};
+      *fieldFloatVecVec = std::vector<std::vector<float>>{std::vector<float>{0.1, 0.2}, std::vector<float>{1.1, 1.2}};
+      *fieldBoolVecVec = std::vector<std::vector<bool>>{std::vector<bool>{false, true, false}, std::vector<bool>{false, true}, std::vector<bool>{true, false, false }};
+      ntuple->Fill();
+      
+      fieldIntVec->emplace_back(7);
+      fieldFloatVecVec->emplace_back(std::vector<float>{2.2, 2.3});
+      fieldBoolVecVec->emplace_back(std::vector<bool>{false, true});
+      ntuple->Fill();
+   }
+   auto model2 = RNTupleModel::Create();
+   auto fieldIntVec = model2->MakeField<std::vector<int>>("intVec");
+   auto fieldFloatVecVec = model2->MakeField<std::vector<std::vector<float>>>("floatVecVec");
+   auto fieldBoolVecVec = model2->MakeField<std::vector<std::vector<bool>>>("booleanVecVec");
+   auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
+   
+   std::ostringstream os;
+   ntuple2->Show(0, ROOT::Experimental::ENTupleFormat::kJSON, os);
+   std::string fString{ std::string("")
+      + "{\n"
+      + "  \"intVec\": {4, 5, 6},\n"
+      + "  \"floatVecVec\": {{ 0.1, 0.2 }, { 1.1, 1.2 }},\n"
+      + "  \"booleanVecVec\": {{ false, true, false }, { false, true }, { true, false, false }}\n"
+      + "}\n" };
+   EXPECT_EQ(fString, os.str());
+   
+   std::ostringstream os1;
+   ntuple2->Show(1, ROOT::Experimental::ENTupleFormat::kJSON, os1);
+   std::string fString1{ std::string("")
+      + "{\n"
+      + "  \"intVec\": {4, 5, 6, 7},\n"
+      + "  \"floatVecVec\": {{ 0.1, 0.2 }, { 1.1, 1.2 }, { 2.2, 2.3 }},\n"
+      + "  \"booleanVecVec\": {{ false, true, false }, { false, true }, { true, false, false }, { false, true }}\n"
+      + "}\n" };
+   EXPECT_EQ(fString1, os1.str());
+}
+
+TEST(RNTupleShow, stdArrayAndClusterSize)
+{
+   std::string rootFileName{"arrayAndCluster.root"};
+   std::string ntupleName{"ArrayAndClusterNTuple"};
+   FileRaii fileGuard(rootFileName);
+   {
+      auto model = RNTupleModel::Create();
+      auto Intarrayfield = model->MakeField<std::array<int, 2>>("IntArray");
+      auto Floatarrayfield = model->MakeField<std::array<float, 3>>("FloatArray");
+      auto Vecarrayfield = model->MakeField<std::array<std::vector<double>, 4>>("ArrayOfVec");
+      auto StringArray = model->MakeField<std::array<std::string, 2>>("stringArray");
+      auto ClusterSize = model->MakeField<ClusterSize_t>("ClusterSizeField");
+      auto arrayOfArray = model->MakeField<std::array<std::array<bool, 2>, 3>>("ArrayOfArray");
+      auto arrayVecfield = model->MakeField<std::vector<std::array<float, 2>>>("VecOfArray");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
+      
+      *Intarrayfield = {1, 3};
+      *Floatarrayfield = {3.5f, 4.6f, 5.7f};
+      *Vecarrayfield = {std::vector<double>{1, 2}, std::vector<double>{4, 5}, std::vector<double>{7, 8, 9}, std::vector<double>{11} };
+      *StringArray = {"First", "Second"};
+      *ClusterSize = ClusterSize_t(44);
+      *arrayOfArray = { std::array<bool,2>{ true, false }, std::array<bool,2>{ false, true }, std::array<bool,2>{ false, false } };
+      *arrayVecfield = { std::array<float, 2>{ 0, 1 }, std::array<float, 2>{ 2, 3 }, std::array<float, 2>{ 4, 5 } };
+      ntuple->Fill();
+      
+      *Intarrayfield = {2, 5};
+      *Floatarrayfield = {2.3f, 5.7f, 11.13f};
+      *Vecarrayfield = {std::vector<double>{17, 19}, std::vector<double>{23, 29}, std::vector<double>{31, 37, 41}, std::vector<double>{43} };
+      *StringArray = {"Third", "Fourth"};
+      *ClusterSize = ClusterSize_t(32);
+      *arrayOfArray = { std::array<bool,2>{ true, true }, std::array<bool,2>{ false, true }, std::array<bool,2>{ true, true } };
+      *arrayVecfield = { std::array<float, 2>{ 6, 7 }, std::array<float, 2>{ 8, 9 } };
+      ntuple->Fill();
+   }
+   auto model2 = RNTupleModel::Create();
+   auto Intarrayfield = model2->MakeField<std::array<int, 2>>("IntArray");
+   auto Floatarrayfield = model2->MakeField<std::array<float, 3>>("FloatArray");
+   auto Vecarrayfield = model2->MakeField<std::array<std::vector<double>, 4>>("ArrayOfVec");
+   auto StringArray = model2->MakeField<std::array<std::string, 2>>("stringArray");
+   auto ClusterSize = model2->MakeField<ClusterSize_t>("ClusterSizeField");
+   auto arrayOfArray = model2->MakeField<std::array<std::array<bool, 2>, 3>>("ArrayOfArray");
+   auto arrayVecfield = model2->MakeField<std::vector<std::array<float, 2>>>("VecOfArray");
+   auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
+   
+   std::ostringstream os;
+   ntuple2->Show(0, ROOT::Experimental::ENTupleFormat::kJSON, os);
+   std::string fString{ std::string("")
+      + "{\n"
+      + "  \"IntArray\": [1, 3],\n"
+      + "  \"FloatArray\": [3.5, 4.6, 5.7],\n"
+      + "  \"ArrayOfVec\": [{ 1, 2 }, { 4, 5 }, { 7, 8, 9 }, { 11 }],\n"
+      + "  \"stringArray\": [\"First\", \"Second\"],\n"
+      + "  \"ClusterSizeField\": 44,\n"
+      + "  \"ArrayOfArray\": [[ true, false ], [ false, true ], [ false, false ]],\n"
+      + "  \"VecOfArray\": {[ 0, 1 ], [ 2, 3 ], [ 4, 5 ]}\n"
+      + "}\n"};
+   EXPECT_EQ(fString, os.str());
+   
+   std::ostringstream os1;
+   ntuple2->Show(1, ROOT::Experimental::ENTupleFormat::kJSON, os1);
+   std::string fString1{ std::string("")
+      + "{\n"
+      + "  \"IntArray\": [2, 5],\n"
+      + "  \"FloatArray\": [2.3, 5.7, 11.13],\n"
+      + "  \"ArrayOfVec\": [{ 17, 19 }, { 23, 29 }, { 31, 37, 41 }, { 43 }],\n"
+      + "  \"stringArray\": [\"Third\", \"Fourth\"],\n"
+      + "  \"ClusterSizeField\": 32,\n"
+      + "  \"ArrayOfArray\": [[ true, true ], [ false, true ], [ true, true ]],\n"
+      + "  \"VecOfArray\": {[ 6, 7 ], [ 8, 9 ]}\n"
+      + "}\n"};
+   EXPECT_EQ(fString1, os1.str());
+}
+
+TEST(RNTupleShow, ObjectFields)
+{
+   std::string rootFileName{"ShowObject.root"};
+   std::string ntupleName{"ClassContainingNTuple"};
+   FileRaii fileGuard(rootFileName);
+   {
+      auto model = RNTupleModel::Create();
+      auto customStructfield = model->MakeField<CustomStruct>("CustomStruct");
+      auto customStructVec = model->MakeField<std::vector<CustomStruct>>("CustomStructVec");
+      auto customStructArray = model->MakeField<std::array<CustomStruct, 2>>("CustomStructArray");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
+      
+      *customStructfield = CustomStruct{4.1f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example1String"};
+      *customStructVec = {
+         CustomStruct{4.2f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example2String"},
+         CustomStruct{4.3f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "Example3String"},
+         CustomStruct{4.4f, std::vector<float>{0.1f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example4String"}
+      };
+      *customStructArray = {
+      CustomStruct{4.5f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "AnotherString1"},
+      CustomStruct{4.6f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "AnotherString2"}
+      };
+      ntuple->Fill();
+      
+      *customStructfield = CustomStruct{5.1f, std::vector<float>{3.1f, 3.2f, 3.3f}, std::vector<std::vector<float>>{{4.1f, 4.2f, 4.3f}, {5.1f, 5.2f, 5.3f}}, "AnotherString"};
+      *customStructVec = {
+         CustomStruct{5.2f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example5String"},
+         CustomStruct{5.3f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.3f}}, "Example6String"},
+         CustomStruct{5.4f, std::vector<float>{0.1f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example7String"}
+      };
+      *customStructArray = {
+      CustomStruct{5.5f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f}}, "AnotherString3"},
+      CustomStruct{5.6f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "AnotherString4"}
+      };
+      ntuple->Fill();
+   }
+   auto model2 = RNTupleModel::Create();
+   auto customStructfield = model2->MakeField<CustomStruct>("CustomStruct");
+   auto customStructVec = model2->MakeField<std::vector<CustomStruct>>("CustomStructVec");
+   auto customStructArray = model2->MakeField<std::array<CustomStruct, 2>>("CustomStructArray");
+   auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
+   
+   std::ostringstream os;
+   ntuple2->Show(0, ROOT::Experimental::ENTupleFormat::kJSON, os);
+   std::string fString{ std::string("")
+      + "{\n"
+      + "  \"CustomStruct\": \n"
+      + "  {\n"
+      + "    \"a\": 4.1,\n"
+      + "    \"v1\": {0.1, 0.2, 0.3},\n"
+      + "    \"v2\": {{ 1.1, 1.2, 1.3 }, { 2.1, 2.2, 2.3 }},\n"
+      + "    \"s\": \"Example1String\"\n"
+      + "  }\n"
+      + "  \"CustomStructVec\": {\n"
+      + "    {\n"
+      + "      \"a\": 4.2,\n"
+      + "      \"v1\": {0.1, 0.2, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.3 }, { 2.1, 2.2, 2.3 }},\n"
+      + "      \"s\": \"Example2String\"\n"
+      + "    }, \n"
+      + "    {\n"
+      + "      \"a\": 4.3,\n"
+      + "      \"v1\": {0.1, 0.2, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.2, 1.3 }, { 2.1, 2.3 }},\n"
+      + "      \"s\": \"Example3String\"\n"
+      + "    }, \n"
+      + "    {\n"
+      + "      \"a\": 4.4,\n"
+      + "      \"v1\": {0.1, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.2, 1.3 }, { 2.1, 2.2, 2.3 }},\n"
+      + "      \"s\": \"Example4String\"\n"
+      + "    }\n"
+      + "  },\n"
+      + "  \"CustomStructArray\": [\n"
+      + "    {\n"
+      + "      \"a\": 4.5,\n"
+      + "      \"v1\": {0.1, 0.2, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.3 }, { 2.1, 2.2, 2.3 }},\n"
+      + "      \"s\": \"AnotherString1\"\n"
+      + "    }, \n"
+      + "    {\n"
+      + "      \"a\": 4.6,\n"
+      + "      \"v1\": {0.1, 0.2, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.2, 1.3 }, { 2.1, 2.3 }},\n"
+      + "      \"s\": \"AnotherString2\"\n"
+      + "    }\n"
+      + "  ]\n"
+      + "}\n" };
+   EXPECT_EQ(fString, os.str());
+   
+   std::ostringstream os1;
+   ntuple2->Show(1, ROOT::Experimental::ENTupleFormat::kJSON, os1);
+   std::string fString1{ std::string("")
+      + "{\n"
+      + "  \"CustomStruct\": \n"
+      + "  {\n"
+      + "    \"a\": 5.1,\n"
+      + "    \"v1\": {3.1, 3.2, 3.3},\n"
+      + "    \"v2\": {{ 4.1, 4.2, 4.3 }, { 5.1, 5.2, 5.3 }},\n"
+      + "    \"s\": \"AnotherString\"\n"
+      + "  }\n"
+      + "  \"CustomStructVec\": {\n"
+      + "    {\n"
+      + "      \"a\": 5.2,\n"
+      + "      \"v1\": {0.1, 0.2, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.3 }, { 2.1, 2.2, 2.3 }},\n"
+      + "      \"s\": \"Example5String\"\n"
+      + "    }, \n"
+      + "    {\n"
+      + "      \"a\": 5.3,\n"
+      + "      \"v1\": {0.1, 0.2, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.3 }, { 2.1, 2.3 }},\n"
+      + "      \"s\": \"Example6String\"\n"
+      + "    }, \n"
+      + "    {\n"
+      + "      \"a\": 5.4,\n"
+      + "      \"v1\": {0.1, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.2, 1.3 }, { 2.1, 2.2, 2.3 }},\n"
+      + "      \"s\": \"Example7String\"\n"
+      + "    }\n"
+      + "  },\n"
+      + "  \"CustomStructArray\": [\n"
+      + "    {\n"
+      + "      \"a\": 5.5,\n"
+      + "      \"v1\": {0.1, 0.2, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.3 }, { 2.1, 2.2 }},\n"
+      + "      \"s\": \"AnotherString3\"\n"
+      + "    }, \n"
+      + "    {\n"
+      + "      \"a\": 5.6,\n"
+      + "      \"v1\": {0.1, 0.2, 0.3},\n"
+      + "      \"v2\": {{ 1.1, 1.2, 1.3 }, { 2.1, 2.3 }},\n"
+      + "      \"s\": \"AnotherString4\"\n"
+      + "    }\n"
+      + "  ]\n"
+      + "}\n" };
+   EXPECT_EQ(fString1, os1.str());
+}

--- a/tutorials/v7/ntuple/ntpl001_staff.C
+++ b/tutorials/v7/ntuple/ntpl001_staff.C
@@ -93,7 +93,10 @@ void Analyze() {
 
    // Quick overview of the ntuple and list of fields.
    ntuple->PrintInfo();
-   // In a future version of RNTuple, there will be support for ntuple->Show() and ntuple->Scan()
+   
+   std::cout << "The first entry in JSON format:" << std::endl;
+   ntuple->Show(0);
+   // In a future version of RNTuple, there will be support for ntuple->Scan()
 
    auto c = new TCanvas("c", "", 200, 10, 700, 500);
    TH1I h("h", "Age Distribution CERN, 1988", 100, 0, 100);

--- a/tutorials/v7/ntuple/ntpl002_vector.C
+++ b/tutorials/v7/ntuple/ntpl002_vector.C
@@ -121,7 +121,10 @@ void Read()
 
    // Quick overview of the ntuple's key meta-data
    ntuple->PrintInfo();
-   // In a future version of RNTuple, there will be support for ntuple->Show() and ntuple->Scan()
+   
+   std::cout << "The entry No.42 in JSON format:" << std::endl;
+   ntuple->Show(41);
+   // In a future version of RNTuple, there will be support for ntuple->Scan()
 
    TCanvas *c2 = new TCanvas("c2", "Dynamic Filling Example", 200, 10, 700, 500);
    TH1F h("h", "This is the px distribution", 100, -4, 4);


### PR DESCRIPTION
This PR implements the Show-function and can display the type values of all existing fields except for VecOps and std::variant. It can also display vectors of vectors, arrays of arrays, vectors of arrays, arrays of vectors, array of objects which contain vectors of vectors and vector of objects which contain vectors of vectors. Unlike previous versions of the Show-function, it does not require gInterpreter and const_cast.

Syntax:
RNTupleReaderPtr->Show(std::uint64_t entryNumberToShow);

Sorry for the previous messed up PR...