### PR TITLE
[RVec][Exp PyROOT] Added virtual destructor to RVec class

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -319,6 +319,9 @@ public:
 
    RVec(std::initializer_list<T> init) : fData(init) {}
 
+   // destructors
+   virtual ~RVec() {}
+
    // assignment
    RVec<T> &operator=(const RVec<T> &v)
    {


### PR DESCRIPTION
As explained in:

https://sft.its.cern.ch/jira/browse/ROOT-10439

in new Cppyy it is not possible to define a Python class derived from a
C++ class if the latter does not implement a virtual destructor.

We implement it for RVec in case someone wants to define a Python class
derived from it.