### PR TITLE
[WIP] Load libCling with RTLD_DEEPBIND to avoid collissions of LLVM symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ if(ccache)
   endif()
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+
 #---Enable test coverage -----------------------------------------------------------------------
 if(coverage)
   set(GCC_COVERAGE_COMPILE_FLAGS "-fprofile-arcs -ftest-coverage")


### PR DESCRIPTION
This is an alternative approach to solve the problem of colliding LLVM symbols, if other libraries bring in their own LLVM.
The original approach was to force other LLVM libraries to be compiled with -fvisibility=hidden or being opened with dlopen after TROOT::InitInterpreter().

This patch solves the issue on the ROOT side, which seems to me the much cleaner approach because we do not pose any limitations on 3rd party libraries.

I tried it locally and it works for me.

Marked as "Work in Progress", since this might need some more thought, in particular for other OS, and for old glibc versions that do not support RTLD_DEEPBIND.