### PR TITLE
[eve-7] Create more informative REveDataItem tooltip in REveDataSimpleProxyBuilder

### DIFF
--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -55,7 +55,7 @@ REveDataSimpleProxyBuilder::Build(const REveDataCollection *collection,
       {
          itemHolder = CreateCompound(true, true);
          itemHolder->SetMainColor(collection->GetMainColor());
-         itemHolder->SetName(Form("compound %d", index));
+         itemHolder->SetName(Form("%s %d", collection->GetCName(), index));
 
          product->AddElement(itemHolder);
       }
@@ -91,7 +91,7 @@ REveDataSimpleProxyBuilder::BuildViewType(const REveDataCollection* collection,
       {
          itemHolder = CreateCompound(true, true);
          itemHolder->SetMainColor(collection->GetMainColor());
-         itemHolder->SetName(Form("compound %d", index));
+         itemHolder->SetName(Form("%s %d", collection->GetCName(), index));
 
          product->AddElement(itemHolder);
       }

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -207,9 +207,6 @@ class XYJetProxyBuilder: public REveDataSimpleProxyBuilderTemplate<XYJet>
          SetupAddElement(marker, iItemHolder, true);
          marker->SetName(Form("line %s %d", Collection()->GetCName(), idx));
       }
-
-      iItemHolder->SetName(Form("comp %s %d", Collection()->GetCName(), idx));
-      jet->SetName(Form("jet %s %d", Collection()->GetCName(), idx));
    }
 
 
@@ -231,14 +228,9 @@ class TrackProxyBuilder : public REveDataSimpleProxyBuilderTemplate<TParticle>
    void Build(const TParticle& p, int idx, REveElement* iItemHolder, const REveViewContext* context) override
    {
       const TParticle *x = &p;
-      // printf("==============  BUILD track %s (pt=%f, eta=%f) \n", iItemHolder->GetCName(), p.Pt(), p.Eta());
       auto track = new REveTrack((TParticle*)(x), 1, context->GetPropagator());
       track->MakeTrack();
       SetupAddElement(track, iItemHolder, true);
-      // iItemHolder->AddElement(track);
-      
-      iItemHolder->SetName(Form("comp %s %d", Collection()->GetCName(), idx));
-      track->SetName(Form("track %s id=%d", Collection()->GetCName(), idx));
    }
 };
 


### PR DESCRIPTION
The tooltips in Graphical views are auto-generated in  REveDataSimpleProxyBuilder: containing Collection name and item's index.