### PR TITLE
Fix SearchBranchWithCompositeName handling of [unsigned long long] leaf.

### DIFF
--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -27,6 +27,7 @@
 #include "TStreamerInfo.h"
 #include "TStreamerElement.h"
 #include "TNtuple.h"
+#include "TROOT.h"
 #include <vector>
 
 // clang-format off
@@ -407,8 +408,8 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
          return nullptr;
       }
       else {
-         TDictionary *tempDict = TDictionary::GetDictionary(myLeaf->GetTypeName());
-         if (tempDict && tempDict->IsA() == TDataType::Class() && TDictionary::GetDictionary(((TDataType*)tempDict)->GetTypeName()) == fDict){
+         TDataType *tempDict = gROOT->GetType(myLeaf->GetTypeName());
+         if (tempDict && fDict->IsA() == TDataType::Class() && tempDict->GetType() == ((TDataType*)fDict)->GetType()) {
             //fLeafOffset = myLeaf->GetOffset() / 4;
             branchActualType = fDict;
             fLeaf = myLeaf;


### PR DESCRIPTION
Previously the checks that the type of the readerValue and the leaf (part of a leaflist) was susceptible to the
'difference' between '[U]Long64_t' and '[unsigned] long long'.

The previous check did not account for TDictionary::GetDictionary returning 'typedef' information.

So instead rely on the numerical/enum version of the type.

This addresses https://root-forum.cern.ch/t/issues-with-automatically-constructed-makeselector/37033
and https://root-forum.cern.ch/t/how-to-read-unsigned-long-using-ttreereader/21850

*Br    0 :SelectOpHitBkgInfo : deltat0/D:deltat/D:t0/D:te/D:tabs/D:PEs/D:    *
*         | event/l:run/l:subRun/l:chan/l:bar/l

TTreeReaderValue<ULong64_t> event = {fReader, "SelectOpHitBkgInfo.event"};

was leading to

Error in <TTreeReaderValueBase::CreateProxy()>: Leaf of type ULong64_t cannot be read by TTreeReaderValue<unsigned long long>.