### PR TITLE
[Exp PyROOT] New exception handler - cppyy patch

### DIFF
--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -54,7 +54,7 @@ class TString;
 
 //Moved from TSystem.
 enum ESysConstants {
-   kMAXSIGNALS       = 15,
+   kMAXSIGNALS       = 16,
    kMAXPATHLEN       = 8192,
    kBUFFERSIZE       = 8192,
    kItimerResolution = 10      // interval-timer resolution in ms

--- a/core/base/inc/TException.h
+++ b/core/base/inc/TException.h
@@ -73,6 +73,14 @@ struct ExceptionContext_t {
 
 R__EXTERN ExceptionContext_t *gException;
 
-extern void Throw(int code);
+R__EXTERN void Throw(int code);
+
+class TExceptionHandler {
+public:
+   virtual ~TExceptionHandler() {}
+   virtual void HandleException(int sig) = 0;
+};
+
+R__EXTERN TExceptionHandler* gExceptionHandler;
 
 #endif

--- a/core/base/inc/TSysEvtHandler.h
+++ b/core/base/inc/TSysEvtHandler.h
@@ -110,6 +110,7 @@ enum ESignals {
    kSigSystem,
    kSigPipe,
    kSigIllegalInstruction,
+   kSigAbort,
    kSigQuit,
    kSigInterrupt,
    kSigWindowChanged,

--- a/core/base/src/TException.cxx
+++ b/core/base/src/TException.cxx
@@ -18,19 +18,13 @@ exception handling functionality.
 
 #include "TException.h"
 
-#ifdef WIN32
-#define R__DLLEXPORT __declspec(dllexport)
-#else
-#define R__DLLEXPORT
-#endif
-
-R__DLLEXPORT ExceptionContext_t *gException;
+ExceptionContext_t *gException = nullptr;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// If an exception context has been set (using the TRY and RETRY macros)
 /// jump back to where it was set.
 
-R__DLLEXPORT void Throw(int code)
+void Throw(int code)
 {
    if (gException)
 #ifdef NEED_SIGJMP
@@ -40,4 +34,4 @@ R__DLLEXPORT void Throw(int code)
 #endif
 }
 
-R__DLLEXPORT TExceptionHandler* gExceptionHandler = nullptr;
+TExceptionHandler* gExceptionHandler = nullptr;

--- a/core/base/src/TException.cxx
+++ b/core/base/src/TException.cxx
@@ -18,13 +18,19 @@ exception handling functionality.
 
 #include "TException.h"
 
-ExceptionContext_t *gException;
+#ifdef WIN32
+#define R__DLLEXPORT __declspec(dllexport)
+#else
+#define R__DLLEXPORT
+#endif
+
+R__DLLEXPORT ExceptionContext_t *gException;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// If an exception context has been set (using the TRY and RETRY macros)
 /// jump back to where it was set.
 
-void Throw(int code)
+R__DLLEXPORT void Throw(int code)
 {
    if (gException)
 #ifdef NEED_SIGJMP
@@ -34,4 +40,4 @@ void Throw(int code)
 #endif
 }
 
-
+R__DLLEXPORT TExceptionHandler* gExceptionHandler = nullptr;

--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -15,4 +15,5 @@ endif()
 ROOT_ADD_GTEST(CoreBaseTests
   TNamedTests.cxx
   TQObjectTests.cxx
+  TExceptionHandlerTests.cxx
   LIBRARIES Core Cling RIO ${dllib})

--- a/core/base/test/TExceptionHandlerTests.cxx
+++ b/core/base/test/TExceptionHandlerTests.cxx
@@ -1,0 +1,46 @@
+#include "gtest/gtest.h"
+
+#include "TException.h"
+#include "TSysEvtHandler.h"
+#include "Rtypes.h"
+
+#include <csignal>
+
+class TestExceptionHandler : public TExceptionHandler {
+private:
+   Int_t currentSignal;
+public:
+   void HandleException(Int_t sig)
+   {
+      EXPECT_EQ(sig, currentSignal);
+      Throw(sig);
+   }
+
+   void SetCurrentSignal(Int_t sig)
+   {
+      currentSignal = sig;
+   }
+};
+
+
+TEST(TExceptionHandler, HandleException)
+{
+   // Set exception handler
+   auto handler = new TestExceptionHandler();
+   gExceptionHandler = handler;
+
+   // Trigger signals
+   handler->SetCurrentSignal(kSigSegmentationViolation);
+   TRY {
+      std::raise(SIGSEGV);
+   } CATCH(excode) {
+      EXPECT_EQ(excode, kSigSegmentationViolation);
+   } ENDTRY;
+
+   handler->SetCurrentSignal(kSigAbort);
+   TRY {
+      std::raise(SIGABRT);
+   } CATCH(excode) {
+      EXPECT_EQ(excode, kSigAbort);
+   } ENDTRY;
+}

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -1089,15 +1089,17 @@ Bool_t TWinNTSystem::Init()
    // signal. Signals don't have one. If we don't handle them, Windows will
    // raise an exception, which has a context, and which is handled by
    // ExceptionFilter.
-   //WinNTSignal(kSigChild,                 SigHandler);
-   //WinNTSignal(kSigBus,                   SigHandler);
+   /*
+   WinNTSignal(kSigChild,                 SigHandler);
+   WinNTSignal(kSigBus,                   SigHandler);
    WinNTSignal(kSigSegmentationViolation, SigHandler);
    WinNTSignal(kSigIllegalInstruction,    SigHandler);
    WinNTSignal(kSigAbort,                 SigHandler);
-   //WinNTSignal(kSigSystem,                SigHandler);
-   //WinNTSignal(kSigPipe,                  SigHandler);
-   //WinNTSignal(kSigAlarm,                 SigHandler);
+   WinNTSignal(kSigSystem,                SigHandler);
+   WinNTSignal(kSigPipe,                  SigHandler);
+   WinNTSignal(kSigAlarm,                 SigHandler);
    WinNTSignal(kSigFloatingException,     SigHandler);
+   */
    ::SetUnhandledExceptionFilter(ExceptionFilter);
 
    fSigcnt = 0;


### PR DESCRIPTION
Based on the following patch by @wlav :
https://bitbucket.org/wlav/cppyy-backend/src/master/cling/patches/signaltrycatch.diff

Adds a new exception handler used by cppyy to provide a better debugging experience in presence of errors:
https://cppyy.readthedocs.io/en/latest/debugging.html

It also adds SIGABRT and provides support for signal handling on Windows.

The original cppyy patch has been modified to make it backwards compatible, since it eliminated the use of gApplication for exception handling in Unix. In this version, if there is an exception handler (e.g. we are using PyROOT, which defines it via cppyy) we will rely on that handler to treat the exception,
otherwise we fall back to the previous behaviour which relied on gApplication.

Windows-related changes to be reviewed by @bellenot.