### PR TITLE
[Exp PyROOT] Changed syntax in C++ header jitted in a test

### DIFF
--- a/bindings/pyroot_experimental/PyROOT/test/TreeHelper.h
+++ b/bindings/pyroot_experimental/PyROOT/test/TreeHelper.h
@@ -67,13 +67,13 @@ void CreateTTree(const char *filename, const char *treename, int nentries, int a
 void CreateTNtuple(const char *filename, const char *tuplename, int nentries, int more,
                    const char* openmode)
 {
-   std::stringstream ss;
-   ss << tuplename << "D";
-   auto tuplenamed = ss.str().c_str();
+
+   std::string tuplenamed(tuplename);
+   tuplenamed += "D";
 
    TFile f(filename, openmode);
    TNtuple ntuple(tuplename, "Test tuple", "x:y:z");
-   TNtupleD ntupled(tuplenamed, "Test tupled", "x:y:z");
+   TNtupleD ntupled(tuplenamed.c_str(), "Test tupled", "x:y:z");
 
    float x, y, z;
    for (int i = 0; i < nentries; ++i) {


### PR DESCRIPTION
In the following platform:

olhswep22.cern.ch

the two following tests:

pyunittests-pyroot-pyz-ttree-setbranchaddress
pyunittests-pyroot-pyz-ttree-branch-attr

were failing because a string was not properly created with the "<<"
operator. With the definition of a std::string object the problem is
solved.