### PR TITLE
[tcling][cling] Improve shutdown logic.

### DIFF
--- a/bindings/pyroot/src/Cppyy.cxx
+++ b/bindings/pyroot/src/Cppyy.cxx
@@ -74,6 +74,10 @@ namespace {
 class ApplicationStarter {
 public:
    ApplicationStarter() {
+      // Insure ROOT's atexit is executed *after* the atexit that calls
+      // ApplicationStarter's destructor, by forcing the ROOT's atexit
+      // registration now.
+      TROOT::Initialize();
       // setup dummy holders for global and std namespaces
       assert( g_classrefs.size() == GLOBAL_HANDLE );
       g_name2classrefidx[ "" ]      = GLOBAL_HANDLE;

--- a/bindings/pyroot_experimental/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot_experimental/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -109,6 +109,10 @@ namespace {
 class ApplicationStarter {
 public:
     ApplicationStarter() {
+     // Insure ROOT's atexit is executed *after* the atexit that calls
+     // ApplicationStarter's destructor, by forcing the ROOT's atexit
+     // registration now.
+        TROOT::Initialize();
     // setup dummy holders for global and std namespaces
         assert(g_classrefs.size() == GLOBAL_HANDLE);
         g_name2classrefidx[""]      = GLOBAL_HANDLE;

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -351,6 +351,7 @@ public:
    static void        SetMacroPath(const char *newpath);
    static Int_t       IncreaseDirLevel();
    static void        IndentLevel();
+   static void        Initialize();
    static Bool_t      Initialized();
    static Bool_t      MemCheck();
    static void        SetDirLevel(Int_t level = 0);

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1022,12 +1022,7 @@ TROOT::~TROOT()
       SafeDelete(fCleanups);
 #endif
 
-      // llvm::TimingGroup used for measuring the timing relies the destructors.
-      // In order to make use of this feature we have to call the destructor of
-      // TCling which will shut down clang, cling and llvm.
-      // gSystem->Getenv is not available anymore.
-      if (::getenv("ROOT_CLING_TIMING"))
-         delete fInterpreter;
+      delete fInterpreter;
 
 
       // Prints memory stats
@@ -2853,6 +2848,13 @@ Int_t TROOT::IncreaseDirLevel()
 void TROOT::IndentLevel()
 {
    for (int i = 0; i < fgDirLevel; i++) std::cout.put(' ');
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Initialize ROOT explicitly.
+
+void TROOT::Initialize() {
+   (void) gROOT;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2003,8 +2003,6 @@ static bool WriteAST(StringRef fileName, clang::CompilerInstance *compilerInstan
 
    // Make sure it hits disk now.
    out->flush();
-   bool deleteOutputFile = compilerInstance->getDiagnostics().hasErrorOccurred();
-   compilerInstance->clearOutputFiles(deleteOutputFile);
 
    return true;
 }
@@ -4977,7 +4975,6 @@ int RootClingMain(int argc,
    {
       cling::Interpreter::PushTransactionRAII RAII(&interp);
       CI->getSema().getASTConsumer().HandleTranslationUnit(CI->getSema().getASTContext());
-      CI->clearOutputFiles(CI->getDiagnostics().hasErrorOccurred());
    }
 
    // Add the warnings

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1438,6 +1438,10 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
 
 TCling::~TCling()
 {
+   // ROOT's atexit functions require the interepreter to be available.
+   // Run them before shutting down.
+   if (!IsFromRootCling())
+      GetInterpreterImpl()->runAtExitFuncs();
    fIsShuttingDown = true;
    delete fMapfile;
    delete fRootmapFiles;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -629,12 +629,6 @@ extern "C" const char* TCling__GetClassSharedLibs(const char* className)
    return ((TCling*)gCling)->GetClassSharedLibs(className);
 }
 
-// // Returns 0 for failure 1 for success
-// extern "C" int TCling__IsAutoLoadNamespaceCandidate(const char* name)
-// {
-//    return ((TCling*)gCling)->IsAutoLoadNamespaceCandidate(name);
-// }
-
 // Returns 0 for failure 1 for success
 extern "C" int TCling__IsAutoLoadNamespaceCandidate(const clang::NamespaceDecl* nsDecl)
 {
@@ -1447,7 +1441,6 @@ TCling::~TCling()
 {
    fIsShuttingDown = true;
    delete fMapfile;
-//    delete fMapNamespaces;
    delete fRootmapFiles;
    delete fMetaProcessor;
    delete fTemporaries;
@@ -5388,8 +5381,6 @@ Int_t TCling::LoadLibraryMap(const char* rootmapfile)
    if (!fMapfile) {
       fMapfile = new TEnv();
       fMapfile->IgnoreDuplicates(kTRUE);
-//       fMapNamespaces = new THashTable();
-//       fMapNamespaces->SetOwner();
       fRootmapFiles = new TObjArray;
       fRootmapFiles->SetOwner();
       InitRootmapFile(".rootmap");
@@ -5518,15 +5509,6 @@ Int_t TCling::LoadLibraryMap(const char* rootmapfile)
             }
             delete[] wlib;
          }
-         // Fill in the namespace candidate list
-//          Ssiz_t last = cls.Last(':');
-//          if (last != kNPOS) {
-//             // Please note that the funny op overload does substring.
-//             TString namespaceCand = cls(0, last - 1);
-//             // This is a reference to a substring that lives in fMapfile
-//             if (!fMapNamespaces->FindObject(namespaceCand.Data()))
-//                fMapNamespaces->Add(new TNamed(namespaceCand.Data(), ""));
-//          }
          delete tokens;
       }
       else if (!strncmp(cls.Data(), "Declare.", 8) && cls.Length() > 8) {
@@ -5742,8 +5724,6 @@ Int_t TCling::SetClassSharedLibs(const char *cls, const char *libs)
    if (!fMapfile) {
       fMapfile = new TEnv();
       fMapfile->IgnoreDuplicates(kTRUE);
-//       fMapNamespaces = new THashTable();
-//       fMapNamespaces->SetOwner();
 
       fRootmapFiles = new TObjArray;
       fRootmapFiles->SetOwner();
@@ -6503,16 +6483,6 @@ void* TCling::LazyFunctionCreatorAutoload(const std::string& mangled_name) {
    void* addr = llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(mangled_name.c_str());
    //fprintf(stderr, "addr: %016lx\n", reinterpret_cast<unsigned long>(addr));
    return addr;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-Bool_t TCling::IsAutoLoadNamespaceCandidate(const char* name)
-{
-//    if (fMapNamespaces){
-//       return fMapNamespaces->FindObject(name);
-//    }
-   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -2,7 +2,7 @@
 // Author: Axel Naumann, 2011-10-19
 
 /*************************************************************************
- * Copyright (C) 1995-2012, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -28,11 +28,10 @@
 
 #include <map>
 #include <memory>
-#include <tuple>
 #include <set>
-#include <unordered_set>
+#include <tuple>
 #include <unordered_map>
-#include <map>
+#include <unordered_set>
 #include <vector>
 
 #ifndef WIN32

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -608,8 +608,6 @@ private: // Private Utility Functions and Classes
    void AddFriendToClass(clang::FunctionDecl*, clang::CXXRecordDecl*) const;
 
    std::map<std::string, llvm::StringRef> fPendingRdicts;
-   friend void TCling__RegisterRdictForLoadPCM(const std::string &pcmFileNameFullPath, llvm::StringRef *pcmContent);
-   friend cling::Interpreter* TCling__GetInterpreter();
    void RegisterRdictForLoadPCM(const std::string &pcmFileNameFullPath, llvm::StringRef *pcmContent);
    void LoadPCM(std::string pcmFileNameFullPath);
    void LoadPCMImpl(TFile &pcmFile);
@@ -621,6 +619,9 @@ private: // Private Utility Functions and Classes
    void ProcessClassesToUpdate();
    cling::Interpreter *GetInterpreterImpl() const { return fInterpreter.get(); }
    cling::MetaProcessor *GetMetaProcessorImpl() const { return fMetaProcessor.get(); }
+
+   friend void TCling__RegisterRdictForLoadPCM(const std::string &pcmFileNameFullPath, llvm::StringRef *pcmContent);
+   friend cling::Interpreter* TCling__GetInterpreter();
 };
 
 #endif

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -184,9 +184,6 @@ public: // Public Interface
    TCling(const char* name, const char* title, const char* const argv[]);
    TCling(const char* name, const char* title): TCling(name, title, kNullArgv) {}
 
-   cling::Interpreter *GetInterpreterImpl() const { return fInterpreter.get(); }
-   cling::MetaProcessor *GetMetaProcessorImpl() const { return fMetaProcessor.get(); }
-
    void    AddIncludePath(const char* path);
    void   *GetAutoLoadCallBack() const { return fAutoLoadCallBack; }
    void   *SetAutoLoadCallBack(void* cb) { void* prev = fAutoLoadCallBack; fAutoLoadCallBack = cb; return prev; }
@@ -613,6 +610,7 @@ private: // Private Utility Functions and Classes
 
    std::map<std::string, llvm::StringRef> fPendingRdicts;
    friend void TCling__RegisterRdictForLoadPCM(const std::string &pcmFileNameFullPath, llvm::StringRef *pcmContent);
+   friend cling::Interpreter* TCling__GetInterpreter();
    void RegisterRdictForLoadPCM(const std::string &pcmFileNameFullPath, llvm::StringRef *pcmContent);
    void LoadPCM(std::string pcmFileNameFullPath);
    void LoadPCMImpl(TFile &pcmFile);
@@ -622,6 +620,8 @@ private: // Private Utility Functions and Classes
    Bool_t HandleNewTransaction(const cling::Transaction &T);
    bool IsClassAutoloadingEnabled() const;
    void ProcessClassesToUpdate();
+   cling::Interpreter *GetInterpreterImpl() const { return fInterpreter.get(); }
+   cling::MetaProcessor *GetMetaProcessorImpl() const { return fMetaProcessor.get(); }
 };
 
 #endif

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -19,7 +19,7 @@
 //                                                                      //
 // This class defines an interface to the cling C++ interpreter.        //
 //                                                                      //
-// Cling is a full ANSI compliant C++-11 interpreter based on           //
+// Cling is a full ANSI compliant C++ interpreter based on              //
 // clang/LLVM technology.                                               //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -192,7 +192,6 @@ public: // Public Interface
    Int_t   AutoParse(const char* cls);
    void*   LazyFunctionCreatorAutoload(const std::string& mangled_name);
    bool   LibraryLoadingFailed(const std::string&, const std::string&, bool, bool);
-   Bool_t  IsAutoLoadNamespaceCandidate(const char* name);
    Bool_t  IsAutoLoadNamespaceCandidate(const clang::NamespaceDecl* nsDecl);
    void    ClearFileBusy();
    void    ClearStack(); // Delete existing temporary values

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -26,6 +26,8 @@
 
 #include "TInterpreter.h"
 
+#include <map>
+#include <memory>
 #include <tuple>
 #include <set>
 #include <unordered_set>
@@ -124,8 +126,8 @@ private: // Data Members
    Bool_t          fLockProcessLine;  // True if ProcessLine should lock gInterpreterMutex.
    Bool_t          fCxxModulesEnabled;// True if C++ modules was enabled
 
-   cling::Interpreter*   fInterpreter;   // The interpreter.
-   cling::MetaProcessor* fMetaProcessor; // The metaprocessor.
+   std::unique_ptr<cling::Interpreter>   fInterpreter;   // The interpreter.
+   std::unique_ptr<cling::MetaProcessor> fMetaProcessor; // The metaprocessor.
 
    std::vector<cling::Value> *fTemporaries;    // Stack of temporaries
    ROOT::TMetaUtils::TNormalizedCtxt  *fNormalizedCtxt; // Which typedef to avoid stripping.
@@ -182,7 +184,8 @@ public: // Public Interface
    TCling(const char* name, const char* title, const char* const argv[]);
    TCling(const char* name, const char* title): TCling(name, title, kNullArgv) {}
 
-   cling::Interpreter *GetInterpreterImpl() { return fInterpreter; }
+   cling::Interpreter *GetInterpreterImpl() const { return fInterpreter.get(); }
+   cling::MetaProcessor *GetMetaProcessorImpl() const { return fMetaProcessor.get(); }
 
    void    AddIncludePath(const char* path);
    void   *GetAutoLoadCallBack() const { return fAutoLoadCallBack; }

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -55,7 +55,6 @@ extern "C" {
    int TCling__AutoLoadCallback(const char* className);
    int TCling__AutoParseCallback(const char* className);
    const char* TCling__GetClassSharedLibs(const char* className);
-//    int TCling__IsAutoLoadNamespaceCandidate(const char* name);
    int TCling__IsAutoLoadNamespaceCandidate(const clang::NamespaceDecl* name);
    int TCling__CompileMacro(const char *fileName, const char *options);
    void TCling__SplitAclicMode(const char* fileName, std::string &mode,

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -804,6 +804,12 @@ namespace cling {
     ///
     void AddAtExitFunc(void (*Func) (void*), void* Arg);
 
+    ///\brief Run once the list of registered atexit functions. This is useful
+    /// when an external process wants to control carefully the teardown because
+    /// the registered atexit functions require alive interpreter service.
+    ///
+    void runAtExitFuncs();
+
     void GenerateAutoloadingMap(llvm::StringRef inFile, llvm::StringRef outFile,
                                 bool enableMacros = false, bool enableLogs = true);
 

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -315,6 +315,10 @@ namespace cling {
     Transaction* Initialize(bool NoRuntime, bool SyntaxOnly,
                             llvm::SmallVectorImpl<llvm::StringRef>& Globals);
 
+    ///\ Shut down the interpreter runtime.
+    ///
+    void ShutDown();
+
     ///\brief The target constructor to be called from both the delegating
     /// constructors. parentInterp might be nullptr.
     ///

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -109,7 +109,7 @@ IncrementalExecutor::IncrementalExecutor(clang::DiagnosticsEngine& diags,
 // Keep in source: ~unique_ptr<ClingJIT> needs ClingJIT
 IncrementalExecutor::~IncrementalExecutor() {}
 
-void IncrementalExecutor::shuttingDown() {
+void IncrementalExecutor::runAtExitFuncs() {
   // It is legal to register an atexit handler from within another atexit
   // handler and furthor-more the standard says they need to run in reverse
   // order, so this function must be recursion safe.
@@ -126,7 +126,7 @@ void IncrementalExecutor::shuttingDown() {
       AtExit();
     // The standard says that they need to run in reverse order, which means
     // anything added from 'AtExit()' must now be run!
-    shuttingDown();
+    runAtExitFuncs();
   }
 }
 

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
@@ -208,13 +208,19 @@ namespace cling {
       m_JIT->addModule(module);
     }
 
-    ///\brief Tells the execution context that we are shutting down the system.
+    ///\brief Tells the execution to run all registered atexit functions once.
     ///
-    /// This that notification is needed because the execution context needs to
-    /// perform extra actions like delete all managed by it symbols, which might
-    /// still require alive system.
+    /// This rountine should be used with caution only when an external process
+    /// wants to carefully control the teardown. For example, if the process
+    /// has registered its own atexit functions which need the interpreter
+    /// service to be available when they are being executed.
     ///
-    void shuttingDown();
+    void runAtExitFuncs();
+
+    ///\brief A more meaningful synonym of runAtExitFuncs when used in a more
+    /// standard teardown.
+    ///
+    void shuttingDown() { runAtExitFuncs(); }
 
     ///\brief Gets the address of an existing global and whether it was JITted.
     ///

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -1718,6 +1718,11 @@ namespace cling {
     m_Executor->AddAtExitFunc(Func, Arg, getLatestTransaction()->getModule());
   }
 
+  void Interpreter::runAtExitFuncs() {
+    assert(!isInSyntaxOnlyMode() && "Must have JIT");
+    m_Executor->runAtExitFuncs();
+  }
+
   void Interpreter::GenerateAutoloadingMap(llvm::StringRef inFile,
                                            llvm::StringRef outFile,
                                            bool enableMacros,


### PR DESCRIPTION
We should follow the shutdown procedure from FrontendAction::EndSourceFile which ensures clang is properly torn down.

This patch allows us to write a module file without having to explicitly call CompilerInstance::clearOutputFiles.

This is part of a patch intending to lay down some infrastructure to fix the conditional build of the clang-internal module _Builtin_intrinsics.pcm in the context of cmssw. I've found an easier way to do so, however, this is of generic importance for ROOT.