### PR TITLE
Bugfixes for RooFit

### DIFF
--- a/core/foundation/res/TSchemaRuleProcessor.h
+++ b/core/foundation/res/TSchemaRuleProcessor.h
@@ -13,6 +13,7 @@
 #include <utility>
 #include <cstdlib>
 #include <iostream>
+#include <algorithm>
 #include "RtypesCore.h"
 
 #include "TSchemaType.h"
@@ -234,18 +235,17 @@ namespace Internal {
          }
 
          //---------------------------------------------------------------------
-         static bool IsANumber( const std::string& source )
+         /// Check if given string consists of digits.
+         static bool IsANumber( const std::string& source, bool acceptHex = false )
          {
-            // check if given string si consisted of digits
-
             if( source.empty() )
                return false;
 
-            std::string::size_type i;
-            for( i = 0; i < source.size(); ++i )
-               if( !isdigit( source[i] ) )
-                  return false;
-            return true;
+            if( acceptHex && source.size() > 2 && source[0] == '0' && source[1] == 'x'
+                   && std::all_of(source.begin()+2, source.end(), [](unsigned char c){return std::isxdigit(c);}) )
+               return true;
+
+            return std::all_of(source.begin(), source.end(), [](unsigned char c){return std::isdigit(c);});
          }
    };
 } // namespace Internal

--- a/core/foundation/src/RConversionRuleParser.cxx
+++ b/core/foundation/src/RConversionRuleParser.cxx
@@ -282,7 +282,6 @@ namespace ROOT
 
       std::map<std::string, std::string>::const_iterator it1, it2;
       std::list<std::string>                             lst;
-      std::list<std::string>::iterator                   lsIt;
 
       it1 = rule.find( "targetClass" );
       if( it1 == rule.end() ) {
@@ -336,12 +335,13 @@ namespace ROOT
             error_string += warning + " - the list of checksums is empty\n";
          }
 
-         for( lsIt = lst.begin(); lsIt != lst.end(); ++lsIt )
-            if( !TSchemaRuleProcessor::IsANumber( *lsIt ) ) {
-               error_string = warning + " - " + *lsIt + " is not a valid value";
-               error_string += " of checksum parameter - an integer expected";
+         for( const auto& chk : lst ) {
+            if( !TSchemaRuleProcessor::IsANumber(chk, true) ) {
+               error_string = warning + " - " + chk + " is not a valid value";
+               error_string += " of checksum parameter - an integer (decimal/hex) expected";
                return false;
             }
+         }
       }
 
       //-----------------------------------------------------------------------
@@ -364,9 +364,9 @@ namespace ROOT
             error_string = warning + " - the list of versions is empty";
          }
 
-         for( lsIt = lst.begin(); lsIt != lst.end(); ++lsIt )
-            if( !TSchemaRuleProcessor::ProcessVersion( *lsIt, ver ) ) {
-               error_string = warning + " - " + *lsIt + " is not a valid value";
+         for( const auto& version : lst )
+            if( !TSchemaRuleProcessor::ProcessVersion( version, ver ) ) {
+               error_string = warning + " - " + version + " is not a valid value";
                error_string += " of version parameter";
                return false;
             }

--- a/core/meta/inc/TSchemaRule.h
+++ b/core/meta/inc/TSchemaRule.h
@@ -98,6 +98,7 @@ namespace ROOT {
 
          Bool_t ProcessVersion( const TString& version ) const;
          Bool_t ProcessChecksum( const TString& checksum ) const;
+         UInt_t ParseChecksum( const char* checksum ) const;
          static void ProcessList( TObjArray* array, const TString& list );
          static void ProcessDeclaration( TObjArray* array, const TString& list );
 

--- a/core/meta/src/TSchemaRule.cxx
+++ b/core/meta/src/TSchemaRule.cxx
@@ -16,6 +16,7 @@
 #include <list>
 #include <string>
 #include <cstdlib>
+#include <sstream>
 #include "TROOT.h"
 #include "Riostream.h"
 
@@ -913,16 +914,38 @@ Bool_t TSchemaRule::ProcessChecksum( const TString& checksum ) const
    // Check the validity of each list element
    /////////////////////////////////////////////////////////////////////////////
 
-   std::list<std::string>::iterator it;
-   for( it = checksums.begin(); it != checksums.end(); ++it ) {
-      if( !Internal::TSchemaRuleProcessor::IsANumber( *it ) ) {
+   for( const auto& checksumStr : checksums ) {
+      auto chksum = ParseChecksum( checksumStr.c_str() );
+      if (chksum == 0u) {
          delete fChecksumVect;
-         fChecksumVect = 0;
+         fChecksumVect = nullptr;
          return kFALSE;
       }
-      fChecksumVect->push_back( atoi( it->c_str() ) );
+
+      fChecksumVect->push_back( chksum );
    }
    return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Parse the checksum in the given string. Returns either the checksum or zero
+/// if the string is not a hex or decimal number.
+
+UInt_t TSchemaRule::ParseChecksum(const char* checksum) const {
+  std::istringstream converter(checksum);
+  UInt_t chksum;
+  converter >> std::hex >> chksum;
+  if (converter.fail()) {
+    converter.clear();
+    converter.seekg(0);
+    converter >> std::dec >> chksum;
+  }
+
+  if( converter.fail() ) {
+    return 0u;
+  }
+
+  return chksum;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/histfactory/inc/LinkDef.h
+++ b/roofit/histfactory/inc/LinkDef.h
@@ -41,6 +41,12 @@
 #pragma link C++ class RooStats::HistFactory::StatErrorConfig+ ;
 #pragma link C++ class RooStats::HistFactory::PreprocessFunction+ ;
 #pragma link C++ class RooStats::HistFactory::HistogramUncertaintyBase+ ;
+#pragma link C++ class RooStats::HistFactory::HistoSys+ ;
+#pragma read sourceClass="RooStats::HistFactory::HistoSys" checksum="[0xa79a9653]" \
+    source="RooStats::HistFactory::HistRef fhLow; RooStats::HistFactory::HistRef fhHigh" \
+    targetClass="RooStats::HistFactory::HistoSys" target="" \
+    code="{newObj->SetHistoLow ( onfile.fhLow.ReleaseObject() ); \
+           newObj->SetHistoHigh( onfile.fhHigh.ReleaseObject() ); }"
 
 #pragma link C++ class std::vector< RooStats::HistFactory::Channel >+ ;
 #pragma link C++ class std::vector< RooStats::HistFactory::Sample >+ ;

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistRef.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistRef.h
@@ -63,6 +63,11 @@ public:
    /// operator= passing an object pointer :  user gives away its ownerhisp 
    void operator= (TH1 * h) { SetObject(h); } 
 
+   /// Release ownership of object.
+   TH1* ReleaseObject() {
+     return fHist.release();
+   }
+
    
 
 private:

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -61,7 +61,7 @@ public:
   TTree *GetClonedTree() const;
 
   void convertToVectorStore() ;
-  void convertToTreeStore();
+  virtual void convertToTreeStore();
 
   void attachBuffers(const RooArgSet& extObs) ;
   void resetBuffers() ;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -138,6 +138,8 @@ public:
 
   static void cleanup();
 
+  void convertToTreeStore() override;
+
 protected:
 
   virtual RooAbsData* cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName=0) override;

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -2379,7 +2379,7 @@ TTree *RooAbsData::GetClonedTree() const
 void RooAbsData::convertToTreeStore()
 {
    if (storageType != RooAbsData::Tree) {
-      RooTreeDataStore *newStore = new RooTreeDataStore(GetName(), GetTitle(), *get(), *_dstore);
+      RooTreeDataStore *newStore = new RooTreeDataStore(GetName(), GetTitle(), _vars, *_dstore);
       delete _dstore;
       _dstore = newStore;
       storageType = RooAbsData::Tree;

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -2044,3 +2044,18 @@ void RooDataSet::Streamer(TBuffer &R__b)
    }
 }
 
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Convert vector-based storage to tree-based storage. This implementation overrides the base class
+/// implementation because the latter doesn't transfer weights.
+void RooDataSet::convertToTreeStore()
+{
+   if (storageType != RooAbsData::Tree) {
+      RooTreeDataStore *newStore = new RooTreeDataStore(GetName(), GetTitle(), _vars, *_dstore, nullptr, _wgtVar ? _wgtVar->GetName() : nullptr);
+      delete _dstore;
+      _dstore = newStore;
+      storageType = RooAbsData::Tree;
+   }
+}
+

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -68,6 +68,7 @@ RooGenericPdf::RooGenericPdf(const char *name, const char *title, const RooArgLi
   _formExpr(title)
 {  
   _actualVars.add(dependents) ; 
+  formula();
 
   if (_actualVars.getSize()==0) _value = traceEval(0) ;
 }
@@ -83,7 +84,8 @@ RooGenericPdf::RooGenericPdf(const char *name, const char *title,
   _actualVars("actualVars","Variables used by PDF expression",this),
   _formExpr(inFormula)
 {  
-  _actualVars.add(dependents) ; 
+  _actualVars.add(dependents) ;
+  formula();
 
   if (_actualVars.getSize()==0) _value = traceEval(0) ;
 }
@@ -98,6 +100,7 @@ RooGenericPdf::RooGenericPdf(const RooGenericPdf& other, const char* name) :
   _actualVars("actualVars",this,other._actualVars),
   _formExpr(other._formExpr)
 {
+  formula();
 }
 
 
@@ -108,7 +111,6 @@ RooFormula& RooGenericPdf::formula() const
   if (!_formula) {
     const_cast<std::unique_ptr<RooFormula>&>(_formula).reset(
         new RooFormula(GetName(),_formExpr.Data(),_actualVars));
-
     const_cast<TString&>(_formExpr) = _formula->formulaString().c_str();
   }
   return *_formula ;

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -415,6 +415,7 @@ void RooTreeDataStore::createTree(const char* name, const char* title)
     _tree = new TTree(name,title);
     _tree->ResetBit(kCanDelete);
     _tree->ResetBit(kMustCleanup);
+    _tree->SetDirectory(nullptr);
   }
 
   TString pwd(gDirectory->GetPath()) ;

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -1373,11 +1373,14 @@ void RooTreeDataStore::Streamer(TBuffer &R__b)
       // Large trees cannot be written because of the 1Gb I/O limitation.
       // Here, we take the tree away from our instance, write it, and continue
       // to write the rest of the class normally
+      auto tmpDir = _tree->GetDirectory();
       TFile* parent = dynamic_cast<TFile*>(R__b.GetParent());
       assert(parent);
+
       _tree->SetDirectory(parent);
       _tree->FlushBaskets(false);
       parent->WriteObject(_tree, makeTreeName().c_str());
+      _tree->SetDirectory(tmpDir);
       _tree = nullptr;
     }
 


### PR DESCRIPTION
These are four bugfixes for RooFit, and an extension of schema evolution conversion rules.

@pcanal, please review the following:
https://github.com/root-project/root/commit/4922063626badad3934edb5965aced6ea678c7c3

> [core] Allow hex numbers for checksums in schema rules.
> 
> When streamer infos are printed, checksums appear in hex. When rules are
> parsed, hex values were not accepted, though. This allows both hex and
> decimal checksums in conversion rules.

Is this useful? If not, the checksum in one of the bugfixes has to be converted to decimal.