### PR TITLE
[ROOT-10474] GCC9: Lazily add comparison operators for iterators

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -1300,6 +1300,11 @@ static int PyObject_Compare( PyObject* one, PyObject* other ) {
 
    PyObject* StlIterIsEqual( PyObject* self, PyObject* other )
    {
+      if (other != Py_None) {
+         if (Utility::AddBinaryOperator(self, other, "==", "__eq__", nullptr, true))
+            return PyObject_CallMethodObjArgs(self, PyStrings::gEq, other, nullptr);
+      }
+
       return PyErr_Format( PyExc_LookupError,
          "No operator==(const %s&, const %s&) available in the dictionary!",
          Utility::ClassName( self ).c_str(), Utility::ClassName( other ).c_str()  );
@@ -1311,6 +1316,11 @@ static int PyObject_Compare( PyObject* one, PyObject* other ) {
 
    PyObject* StlIterIsNotEqual( PyObject* self, PyObject* other )
    {
+      if (other != Py_None) {
+         if (Utility::AddBinaryOperator(self, other, "!=", "__ne__", nullptr, true))
+            return PyObject_CallMethodObjArgs(self, PyStrings::gNe, other, nullptr);
+      }
+
       return PyErr_Format( PyExc_LookupError,
          "No operator!=(const %s&, const %s&) available in the dictionary!",
          Utility::ClassName( self ).c_str(), Utility::ClassName( other ).c_str()  );

--- a/bindings/pyroot/src/Utility.h
+++ b/bindings/pyroot/src/Utility.h
@@ -33,11 +33,11 @@ namespace PyROOT {
 
       // helpers for dynamically constructing binary operators
       Bool_t AddBinaryOperator( PyObject* left, PyObject* right,
-         const char* op, const char* label, const char* alt_label = NULL );
+         const char* op, const char* label, const char* alt_label = NULL, bool lazy = false );
       Bool_t AddBinaryOperator( PyObject* pyclass,
-         const char* op, const char* label, const char* alt_label = NULL );
+         const char* op, const char* label, const char* alt_label = NULL, bool lazy = false );
       Bool_t AddBinaryOperator( PyObject* pyclass, const std::string& lcname, const std::string& rcname,
-         const char* op, const char* label, const char* alt_label = NULL );
+         const char* op, const char* label, const char* alt_label = NULL, bool lazy = false );
 
    // helper for template classes and methods
       enum ArgPreference { kNone, kPointer, kReference, kValue };


### PR DESCRIPTION
In GCC9, operator== and operator!= are no longer member functions of STL iterators (seen in _Rb_tree_iterator). This means they cannot be obtained anymore with GetListOfMethods of the iterator class.

Such change broke the iteration of STL classes from Python when using (old) cppyy alone in GCC9. The addition of the operators to the iterator class still happened when importing ROOT because
in that case gApplication is initialized to TPyROOTApplication, which is required in Utility::AddBinaryOperator to add the operators.

This PR adds the necessary logic so that operator== and operator!= are also added to the iterator proxy class when using cppyy alone in GCC9. The addition is done lazily as a last attempt before throwing an error in the comparison.