### PR TITLE
Fix rf102_dataimport.C on Windows

### DIFF
--- a/tutorials/roofit/rf102_dataimport.C
+++ b/tutorials/roofit/rf102_dataimport.C
@@ -97,7 +97,7 @@ void rf102_dataimport()
    // ------------------------------------------------------------------------------------
    {
       // Write data to output stream
-      std::ofstream outstream("/tmp/rf102_testData.txt");
+      std::ofstream outstream("rf102_testData.txt");
       // Optionally, adjust the stream here (e.g. std::setprecision)
       ds.write(outstream);
       outstream.close();
@@ -107,7 +107,7 @@ void rf102_dataimport()
    // to the RooDataSet::read() function.
    std::cout << "\n-----------------------\nReading data from ASCII\n";
    RooDataSet *dataReadBack =
-      RooDataSet::read("/tmp/rf102_testData.txt",
+      RooDataSet::read("rf102_testData.txt",
                        RooArgList(x, y), // variables to be read. If the file has more fields, these are ignored.
                        "D"); // Prints if a RooFit message stream listens for debug messages. Use Q for quiet.
 


### PR DESCRIPTION
The "/tmp/" directory doesn't exist on Windows. Using current directory should be fine.