### PR TITLE
Fix setttings  parameter limits  when using TBinomialEfficiencyFitter. (ROOT-10481)

### DIFF
--- a/hist/hist/src/TBinomialEfficiencyFitter.cxx
+++ b/hist/hist/src/TBinomialEfficiencyFitter.cxx
@@ -86,7 +86,7 @@ weighted histograms (because the likelihood computation will be incorrect).
 #include "TFitResult.h"
 #include "Math/Functor.h"
 #include "Math/Functor.h"
-#include "Math/WrappedTF1.h"
+#include "Math/WrappedMultiTF1.h"
 
 #include <limits>
 
@@ -250,18 +250,24 @@ TFitResultPtr TBinomialEfficiencyFitter::Fit(TF1 *f1, Option_t* option)
 
       Double_t plow, pup;
       f1->GetParLimits(i,plow,pup);
-      if (plow*pup != 0 && plow >= pup) { // this is a limitation - cannot fix a parameter to zero value
+      // when a parameter is fixed is having plow and pup equal to the value (if this is not zero)
+      // we handle special case when fixed parameter has zero value (in that case plow=1 and pup =1 )
+      if (plow >= pup && (plow==f1->GetParameter(i) || pup==f1->GetParameter(i) ||
+      ( f1->GetParameter(i) == 0 && plow==1. && pup == 1.) ) ) {
          parameters.back().Fix();
-      }
-      else if (plow < pup ) {
+         Info("Fit", "Fixing parameter %s to value %f", f1->GetParName(i), f1->GetParameter(i));
+      } else if (plow < pup) {
          parameters.back().SetLimits(plow,pup);
+         Info("Fit", "Setting limits for parameter %s to [%f,%f]", f1->GetParName(i), plow,pup);
       }
    }
 
    // fcn must be set after setting the parameters
    ROOT::Math::Functor fcnFunction(this, &TBinomialEfficiencyFitter::EvaluateFCN, npar);
-   fFitter->SetFCN(static_cast<ROOT::Math::IMultiGenFunction&>(fcnFunction));
 
+   // set also model function in fitter to have it in FitResult
+   // in this way one can compute for example the confidence intervals
+   fFitter->SetFCN(static_cast<ROOT::Math::IMultiGenFunction &>(fcnFunction), ROOT::Math::WrappedMultiTF1(*f1));
 
    // in case default value of 1.0 is used
    if (fFitter->Config().MinimizerOptions().ErrorDef() == 1.0 ) {
@@ -274,10 +280,6 @@ TFitResultPtr TBinomialEfficiencyFitter::Fit(TF1 *f1, Option_t* option)
    else if (quiet) {
       fFitter->Config().MinimizerOptions().SetPrintLevel(0);
    }
-
-   // set model function in fitter to have it in FitResult
-   // in this way one can compute for example the confidence intervals   
-   fFitter->SetFunction(ROOT::Math::WrappedTF1(*f1), false); 
 
    // perform the actual fit
 
@@ -452,4 +454,3 @@ void TBinomialEfficiencyFitter::ComputeFCN(Double_t& f, const Double_t* par)
 
    fFunction->SetNumberFitPoints(npoints);
 }
-

--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -252,8 +252,7 @@ public:
       Note that passing a params != 0 will set the parameter settings to the new value AND also the
       step sizes to some pre-defined value (stepsize = 0.3 * abs(parameter_value) )
     */
-   bool FitFCN(const ROOT::Math::IMultiGenFunction & fcn, const double * params = 0, unsigned int dataSize = 0, bool
-      chi2fit = false);
+   bool FitFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = 0, unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
        Fit using a FitMethodFunction interface. Same as method above, but now extra information
@@ -266,7 +265,17 @@ public:
       (ROOT::Math::IMultiGenFunction) and optionally the initial parameters
       See also note above for the initial parameters for FitFCN
     */
-   bool SetFCN(const ROOT::Math::IMultiGenFunction & fcn, const double * params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+   bool SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+
+   /**
+      Set the FCN function represented by a multi-dimensional function interface
+     (ROOT::Math::IMultiGenFunction) and optionally the initial parameters
+      See also note above for the initial parameters for FitFCN
+      With this interface we pass in addition a ModelFunction that will be attached to the FitResult and
+      used to compute confidence interval of the fit
+   */
+   bool SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const IModelFunction & func, const double *params = 0,
+               unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
        Set the objective function (FCN)  using a FitMethodFunction interface.
@@ -280,7 +289,7 @@ public:
       gradient information provided by the function.
       For the options same consideration as in the previous method
     */
-   bool FitFCN(const ROOT::Math::IMultiGradFunction & fcn, const double * params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+   bool FitFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params = 0, unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
        Fit using a FitMethodGradFunction interface. Same as method above, but now extra information
@@ -290,10 +299,20 @@ public:
 
    /**
       Set the FCN function represented by a multi-dimensional gradient function interface
-      (ROOT::Math::IMultiGenFunction) and optionally the initial parameters
+      (ROOT::Math::IMultiGradFunction) and optionally the initial parameters
       See also note above for the initial parameters for FitFCN
     */
-   bool SetFCN(const ROOT::Math::IMultiGradFunction & fcn, const double * params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+   bool SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+
+   /**
+      Set the FCN function represented by a multi-dimensional gradient function interface
+     (ROOT::Math::IMultiGradFunction) and optionally the initial parameters
+      See also note above for the initial parameters for FitFCN
+      With this interface we pass in addition a ModelFunction that will be attached to the FitResult and
+      used to compute confidence interval of the fit
+   */
+   bool SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const IModelFunction &func, const double *params = 0,
+               unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
        Set the objective function (FCN)  using a FitMethodGradFunction interface.

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -212,9 +212,10 @@ bool Fitter::SetFCN(const ROOT::Math::IMultiGenFunction & fcn, const double * pa
 
 bool Fitter::SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const IModelFunction & func, const double *params, unsigned int dataSize, bool chi2fit) {
    // set the objective function for the fit and a model function
-   SetFCN(fcn, params, dataSize, chi2fit);
+   if (!SetFCN(fcn, params, dataSize, chi2fit) ) return false; 
    // need to set fFunc afterwards because SetFCN could reset fFUnc
    fFunc = std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction *>(func.Clone()));
+   return (fFunc != nullptr); 
 }
 
 bool Fitter::SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params, unsigned int dataSize,
@@ -232,8 +233,9 @@ bool Fitter::SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const IModelFunct
                     unsigned int dataSize, bool chi2fit)
 {
    // set the objective function for the fit and a model function
-   SetFCN(fcn, params, dataSize, chi2fit);
+   if (!SetFCN(fcn, params, dataSize, chi2fit) ) return false;
    fFunc = std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction *>(func.Clone()));
+   return (fFunc != nullptr); 
 }
 
 bool Fitter::SetFCN(const ROOT::Math::FitMethodFunction &fcn, const double *params)


### PR DESCRIPTION
By calling SetFunction after SetFCN the parameter settings are reset. 
This is now solved by adding a new API in SetFCN where  the model function is
also passed and Fitter::SetFunction does not need to be called anymore.
The bug was introduced few months ago (for 6.18) with this commit: 
https://github.com/root-project/root/commit/e864d6d546de78aa0a278a7f534d2271f972cd5a#diff-bb181d7808f6c937d67b336b5e91ed11

The model function is used in FitResult for computiong  confidence intervals after fitting.

This fixes ROOT-10481