### PR TITLE
[v7] add ROOT base exception and RResult<T> class

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -201,7 +201,11 @@ endif()
 if(root7)
   list(APPEND BASE_HEADERS
       ROOT/RDirectoryEntry.hxx
+      ROOT/RError.hxx
       ROOT/RIndexIter.hxx)
+  list(APPEND BASE_SOURCES
+       v7/src/RError.cxx)
+  ROOT_ADD_TEST_SUBDIRECTORY(v7/test)
 endif()
 
 

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -135,7 +135,6 @@ class RResultBase {
 protected:
    /// This is the nullptr for an RResult representing success
    std::unique_ptr<RError> fError;
-   /// RResult<T> has a T data member, the union ensures that T is aligned
    /// Switches to true once the user of an RResult object checks the object status
    /// Declaring it mutable is safe because checking an RResult is not a multi-threaded operation
    /// The alternative, making the bool operator non-const, has unwanted effects when using an RResult, e.g.

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -1,0 +1,202 @@
+/// \file ROOT/RError.h
+/// \ingroup Base ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2019-12-11
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RError
+#define ROOT7_RError
+
+#include <ROOT/RConfig.hxx>
+
+#include <cerrno>
+#include <cstddef>
+#include <new>
+#include <stdexcept>
+#include <string>
+
+namespace ROOT {
+namespace Experimental {
+
+// clang-format off
+/**
+\class ROOT::Experimental::RException
+\ingroup Base
+\brief Base class for all ROOT issued exceptions
+*/
+// clang-format on
+class RException : public std::runtime_error {
+public:
+   explicit RException(const std::string &what)
+      : std::runtime_error(what + " [errno: " + std::to_string(errno) + "]") {}
+};
+
+
+namespace Detail {
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RStatusType
+\ingroup Base
+\brief Values of this type have a distinct value that indicates an error, such as -1 for system calls
+*/
+// clang-format on
+template <typename T>
+class RStatusType {
+protected:
+   T fValue;
+
+public:
+   using ValueType_t = T;
+
+   RStatusType() { SetError(); };
+   explicit RStatusType(const T &value) : fValue(value) {};
+   const T &Get() const { return fValue; }
+
+   // Template specializations need to select the error value
+   bool IsError() const { return true; }
+   void SetError() {}
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RStatusTypeBool
+\ingroup Base
+\brief For routines that indicate success by returning true
+*/
+// clang-format on
+class RStatusTypeBool : public RStatusType<bool> {
+public:
+   RStatusTypeBool() = default;
+   explicit RStatusTypeBool(bool value) : RStatusType<bool>(value) {}
+   bool IsError() const { return fValue == false; }
+   void SetError() { fValue = false; }
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RStatusTypeSyscall
+\ingroup Base
+\brief For system calls that return 0 (or a meaningful integer) on success
+*/
+// clang-format on
+class RStatusTypeSyscall : public RStatusType<int> {
+public:
+   RStatusTypeSyscall() = default;
+   explicit RStatusTypeSyscall(int value) : RStatusType<int>(value) {}
+   bool IsError() const { return fValue < 0; }
+   void SetError() { fValue = -1; }
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RStatusBase
+\ingroup Base
+\brief Type-independent logic of the RStatus wrapper
+*/
+// clang-format on
+class RStatusBase {
+protected:
+   static thread_local bool fgThrowInstantExceptions; /* true by default */
+public:
+   static void SetThrowInstantExceptions(bool value) { fgThrowInstantExceptions = value; }
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RStatus
+\ingroup Base
+\brief Wraps a return value such that unchecked error states trigger an exception
+
+The Status wrapper itself is movable but not copyable to prevent multiple exceptions from being thrown.
+The wrapper is also only stack allocatable because throwing an exception depends on the object going out of scope.
+
+If the class should be used like a C return type, it has to be cleared by a call to IsError() or IsValid() or
+ClearError().  Otherwise, an error state will throw an exception nevertheless when the object goes out of scope.
+*/
+// clang-format on
+template <typename T> // Has to be RStatusType
+class RStatus : public RStatusBase {
+   T fStatus;
+   bool fIsChecked = false;
+
+public:
+   // Named constructor for error cases
+   static RStatus Fail(const std::string &why)
+   {
+      RStatus status;
+      status.MayThrow(why);
+      return status;
+   }
+
+   RStatus() = default;
+   RStatus(const RStatus &other) = delete;
+   RStatus(RStatus &&other) = default;
+   RStatus &operator =(const RStatus &other) = delete;
+   RStatus &operator =(RStatus &&other) = default;
+
+   // Construct from return value
+   explicit RStatus(const typename T::ValueType_t &value) : fStatus(value) {}
+   // Assign a return value
+   RStatus &operator =(const typename T::ValueType_t &value) { this->fStatus = value; }
+
+   ~RStatus() noexcept(false)
+   {
+      if (!fIsChecked && fStatus.IsError()) {
+         // Prevent from throwing if the object is deconstructed in the course of stack unwinding for another exception
+#if __cplusplus >= 201703L
+         if (std::uncaught_exceptions() == 0)
+#else
+         if (!std::uncaught_exception())
+#endif
+         {
+            throw RException("unchecked error");
+         }
+      }
+   }
+
+   void MayThrow(const std::string &why)
+   {
+      fStatus.SetError();
+      // Fast path reserved for return code checking
+      if (R__unlikely(fgThrowInstantExceptions))
+         throw RException(why);
+   }
+
+   bool IsError()
+   {
+      fIsChecked = true;
+      return fStatus.IsError();
+   }
+   bool IsValid() { return !IsError(); }
+   void ClearError() { fIsChecked = true; }
+
+   operator typename T::ValueType_t() const { return fStatus.Get(); }
+
+   // Prevent heap construction of RStatus objects
+   void *operator new(std::size_t size) = delete;
+   void *operator new(std::size_t, void *) = delete;
+   void *operator new[](std::size_t) = delete;
+   void *operator new[](std::size_t, void *) = delete;
+};
+
+} // namespace Detail
+
+void SetThrowInstantExceptions(bool value);
+
+using RStatusBool = Detail::RStatus<Detail::RStatusTypeBool>;
+using RStatusSyscall = Detail::RStatus<Detail::RStatusTypeSyscall>;
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -37,7 +37,7 @@
 //     {
 //        int rv = syscall(...);
 //        if (rv == -1)
-//           R__FAIL("user-facing error message");
+//           return R__FAIL("user-facing error message");
 //        if (rv == kShortcut)
 //           return 42;
 //        return R__FORWARD_RESULT(FuncThatReturnsRResultOfInt());
@@ -58,7 +58,7 @@
 //     RResult<void> DoSomething()
 //     {
 //        if (failure)
-//           R__FAIL("user-facing error messge");
+//           return R__FAIL("user-facing error messge");
 //        return RResult<void>::Success();
 //     }
 
@@ -136,7 +136,6 @@ protected:
    /// This is the nullptr for an RResult representing success
    std::unique_ptr<RError> fError;
    /// Switches to true once the user of an RResult object checks the object status
-   /// Declaring it mutable is safe because checking an RResult is not a multi-threaded operation
    bool fIsChecked{false};
 
    RResultBase() = default;
@@ -251,7 +250,7 @@ public:
 };
 
 /// Short-hand to return an RResult<T> in an error state; the RError is implicitly converted into RResult<T>
-#define R__FAIL(msg) return ROOT::Experimental::RError(msg, {R__LOG_PRETTY_FUNCTION, __FILE__, __LINE__})
+#define R__FAIL(msg) ROOT::Experimental::RError(msg, {R__LOG_PRETTY_FUNCTION, __FILE__, __LINE__})
 /// Short-hand to return an RResult<T> value from a subroutine to the calling stack frame
 #define R__FORWARD_RESULT(res) std::move(res.Forward(res, {R__LOG_PRETTY_FUNCTION, __FILE__, __LINE__}))
 } // namespace Experimental

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RError
 
 #include <ROOT/RConfig.hxx>
+#include <ROOT/RLogger.hxx> // for R__LOG_PRETTY_FUNCTION
 
 #include <cstddef>
 #include <memory>
@@ -204,7 +205,7 @@ public:
 
    void Throw() { throw RException(*fError); }
 
-   // Help prevent heap construction of RResult objects. Unchecked RResult objects in failure state should throw
+   // Help to prevent heap construction of RResult objects. Unchecked RResult objects in failure state should throw
    // an exception close to the error location. For stack allocated RResult objects, an exception is thrown
    // the latest when leaving the scope. Heap allocated ill RResult objects can live much longer making it difficult
    // to trace back the original failure.
@@ -217,9 +218,10 @@ public:
 /// Short-hand to return an RResult<void> indicating success
 #define R__SUCCESS return ROOT::Experimental::RResult<void>();
 /// Short-hand to return an RResult<T> in an error state; the RError is implicitly converted into RResult<T>
-#define R__FAIL(msg) return ROOT::Experimental::RError(msg, __func__, __FILE__, __LINE__)
+#define R__FAIL(msg) return ROOT::Experimental::RError(msg, R__LOG_PRETTY_FUNCTION, __FILE__, __LINE__)
 /// Short-hand to return an RResult<T> value from a subroutine to the calling stack frame
-#define R__FORWARD_RESULT(res) if (res.GetError()) { res.GetError()->AddFrame(__func__, __FILE__, __LINE__); } \
+#define R__FORWARD_RESULT(res) if (res.GetError()) \
+      { res.GetError()->AddFrame(R__LOG_PRETTY_FUNCTION, __FILE__, __LINE__); } \
    return res
 
 } // namespace Experimental

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -161,7 +161,8 @@ public:
    ~RResultBase() noexcept(false);
 
    RError *GetError() { return fError.get(); }
-   void Throw() { throw RException(*fError); }
+   /// Throws an RException with fError
+   void Throw();
 
    // Help to prevent heap construction of RResult objects. Unchecked RResult objects in failure state should throw
    // an exception close to the error location. For stack allocated RResult objects, an exception is thrown

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -128,6 +128,7 @@ protected:
    T fValue;
    explicit RResultType() = default;
    explicit RResultType(const T &value) : fValue(value) {}
+   explicit RResultType(T &&value) : fValue(std::move(value)) {}
 };
 
 template <>
@@ -168,7 +169,9 @@ public:
    /// Constructor is _not_ explicit in order to allow for `return T();` for functions returning RResult<T>
    /// Only available if T is not void
    template <typename Dummy = T, typename = typename std::enable_if_t<!std::is_void<T>::value, Dummy>>
-   RResult(const Dummy &value) : Internal::RResultType<T>(value) {}
+   RResult(const Dummy &value) : Internal::RResultType<T>(value) { }
+   template <typename Dummy = T, typename = typename std::enable_if_t<!std::is_void<T>::value, Dummy>>
+   RResult(Dummy &&value) : Internal::RResultType<T>(std::move(value)) { }
    /// Constructor is _not_ explicit such that the RError returned by R__FAIL can be converted into an RResult<T>
    /// for any T
    RResult(RError &&error) : fError(std::make_unique<RError>(std::move(error))) {}

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -138,7 +138,7 @@ public:
    RError *GetError() { return fError.get(); }
    void Throw() { throw RException(*fError); }
 
-   // Prevent heap construction of RStatus objects
+   // Prevent heap construction of RResult objects
    void *operator new(std::size_t size) = delete;
    void *operator new(std::size_t, void *) = delete;
    void *operator new[](std::size_t) = delete;

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -99,7 +99,7 @@ public:
    /// Used by R__FORWARD_RESULT
    void AddFrame(RLocation &&sourceLocation);
    /// Add more information to the diagnostics
-   void AppendMessage(const std::string &info) { fMessage += info; }
+   void AppendToMessage(const std::string &info) { fMessage += info; }
    /// Format a dignostics report, e.g. for an exception message
    std::string GetReport() const;
    const std::vector<RLocation> &GetStackTrace() const { return fStackTrace; }
@@ -192,7 +192,7 @@ public:
    Get()
    {
       if (R__unlikely(fError)) {
-         fError->AppendMessage(" (invalid access)");
+         fError->AppendToMessage(" (invalid access)");
          throw RException(*fError);
       }
       return Internal::RResultType<T>::fValue;

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -150,8 +150,8 @@ class RResult : public Internal::RResultType<T> {
 private:
    /// This is the nullptr for an RResult representing success
    std::unique_ptr<RError> fError;
-   /// This is safe because checking an RResult is not a multi-threaded operation
-   mutable bool fIsChecked{false};
+   /// Switches to true once the user of an RResult object checks the object status
+   bool fIsChecked{false};
 
 public:
    /// Constructor is _not_ explicit in order to allow for `return T();` for functions returning RResult<T>
@@ -198,7 +198,7 @@ public:
       return Internal::RResultType<T>::fValue;
    }
 
-   explicit operator bool() const
+   explicit operator bool()
    {
       fIsChecked = true;
       return !fError;

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -16,7 +16,7 @@
 #ifndef ROOT7_RError
 #define ROOT7_RError
 
-#include <ROOT/RConfig.hxx>
+#include <ROOT/RConfig.hxx> // for R__[un]likely
 #include <ROOT/RLogger.hxx> // for R__LOG_PRETTY_FUNCTION
 
 #include <cstddef>

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -156,7 +156,7 @@ public:
    RResult(const Dummy &value) : Internal::RResultType<T>(value) {}
    /// Constructor is _not_ explicit such that the RError returned by R__FAIL can be converted into an RResult<T>
    /// for any T
-   RResult(std::unique_ptr<RError> error) : fError(std::move(error)) {}
+   RResult(const RError &error) : fError(std::make_unique<RError>(error)) {}
 
    /// RResult<void> has a default contructor that creates an object representing success
    template <typename Dummy = T, typename = typename std::enable_if_t<std::is_void<T>::value, Dummy>>
@@ -217,7 +217,7 @@ public:
 /// Short-hand to return an RResult<void> indicating success
 #define R__SUCCESS return ROOT::Experimental::RResult<void>();
 /// Short-hand to return an RResult<T> in an error state; the RError is implicitly converted into RResult<T>
-#define R__FAIL(msg) return std::make_unique<ROOT::Experimental::RError>(msg, __func__, __FILE__, __LINE__)
+#define R__FAIL(msg) return ROOT::Experimental::RError(msg, __func__, __FILE__, __LINE__)
 /// Short-hand to return an RResult<T> value from a subroutine to the calling stack frame
 #define R__FORWARD_RESULT(res) if (res.GetError()) { res.GetError()->AddFrame(__func__, __FILE__, __LINE__); } \
    return res

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -112,7 +112,7 @@ public:
       if (R__unlikely(fError && !fIsChecked)) {
          // Prevent from throwing if the object is deconstructed in the course of stack unwinding for another exception
 #if __cplusplus >= 201703L
-         if (std::uncaught_exceptions() == 0): std::runtime_error(what) {}
+         if (std::uncaught_exceptions() == 0)
 #else
          if (!std::uncaught_exception())
 #endif

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -130,7 +130,7 @@ public:
       }
       return fValue;
    }
-   operator bool() const
+   explicit operator bool() const
    {
       fIsChecked = true;
       return !fError;

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -137,17 +137,13 @@ protected:
    std::unique_ptr<RError> fError;
    /// Switches to true once the user of an RResult object checks the object status
    /// Declaring it mutable is safe because checking an RResult is not a multi-threaded operation
-   /// The alternative, making the bool operator non-const, has unwanted effects when using an RResult, e.g.
-   ///     auto res = Func();
-   ///     ASSERT_TRUE(res);
-   /// would not work anymore
-   mutable bool fIsChecked{false};
+   bool fIsChecked{false};
 
    RResultBase() = default;
    explicit RResultBase(RError &&error) : fError(std::make_unique<RError>(std::move(error))) {}
 
    /// Used by the RResult<T> bool operator
-   bool Check() const {
+   bool Check() {
       fIsChecked = true;
       return !fError;
    }
@@ -223,7 +219,7 @@ public:
       return fValue;
    }
 
-   explicit operator bool() const { return Check(); }
+   explicit operator bool() { return Check(); }
 };
 
 /// RResult<void> has no data member and no Get() method but instead a Success() factory method
@@ -251,7 +247,7 @@ public:
       return result;
    }
 
-   explicit operator bool() const { return Check(); }
+   explicit operator bool() { return Check(); }
 };
 
 /// Short-hand to return an RResult<T> in an error state; the RError is implicitly converted into RResult<T>

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -140,9 +140,9 @@ struct RResultType<void> {};
 \ingroup Base
 \brief The class is used as a return type for operations that can fail; wraps a value of type T or an RError
 
-The RResult enforces checking whether it contains a valid value or an error state. If the RResult leaves the scope
+RResult enforces checking whether it contains a valid value or an error state. If the RResult leaves the scope
 unchecked, it will throw an exception.  RResult should only be allocated on the stack, which is helped by deleting the
-new operator.  RResult is movable but not copyable to avoid throwing exceptions multiple times.
+new operator.  RResult is movable but not copyable to avoid throwing multiple exceptions about the same failure.
 */
 // clang-format on
 template <typename T>

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -18,7 +18,6 @@
 
 #include <ROOT/RConfig.hxx>
 
-#include <cerrno>
 #include <cstddef>
 #include <new>
 #include <stdexcept>
@@ -36,8 +35,7 @@ namespace Experimental {
 // clang-format on
 class RException : public std::runtime_error {
 public:
-   explicit RException(const std::string &what)
-      : std::runtime_error(what + " [errno: " + std::to_string(errno) + "]") {}
+   explicit RException(const std::string &what) : std::runtime_error(what) {}
 };
 
 

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -172,10 +172,8 @@ public:
    void *operator new(std::size_t, void *) = delete;
    void *operator new[](std::size_t) = delete;
    void *operator new[](std::size_t, void *) = delete;
-};
-
+}; // class RResultBase
 } // namespace Internal
-
 
 
 // clang-format off

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -78,12 +78,12 @@ class RError {
 public:
    struct RLocation {
       RLocation() = default;
-      RLocation(const std::string &func, const std::string &file, int line)
+      RLocation(const char *func, const char *file, int line)
          : fFunction(func), fSourceFile(file), fSourceLine(line) {}
 
       // TODO(jblomer) use std::source_location once available
-      std::string fFunction;
-      std::string fSourceFile;
+      const char *fFunction;
+      const char *fSourceFile;
       int fSourceLine;
    };
 

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -23,8 +23,45 @@
 #include <new>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
+
+// The RResult<T> class and their related classes are used for call chains that can throw exceptions,
+// such as I/O code paths.  Throwing of the exception is deferred to allow for `if (result)` style error
+// checking where it makes sense.
+//
+// A function returning an RResult might look like this:
+//
+//     RResult<int> MyIOFunc()
+//     {
+//        int rv = syscall(...);
+//        if (rv == -1)
+//           R__FAIL("user-facing error message");
+//        if (rv == kShortcut)
+//           return 42;
+//        R__FORWARD_RESULT(FuncThatReturnsRResultOfInt());
+//     }
+//
+// Code using MyIOFunc might look like this:
+//
+//     auto result = MyIOOperation();
+//     if (!result) {
+//        /* custom error handling or result.Throw() */
+//     }
+//     switch (result.Get()) {
+//        ...
+//     }
+//
+// Note that RResult<void> can be used for a function without return value, like this
+//
+//     RResult<void> DoSomething()
+//     {
+//        if (failure)
+//           R__FAIL("user-facing error messge");
+//        R__SUCCESS
+//     }
+
 
 namespace ROOT {
 namespace Experimental {
@@ -79,6 +116,20 @@ public:
    const RError &GetError() const { return fError; }
 };
 
+
+/// Wrapper class that generates a data member of type T in RResult<T> for all Ts except T == void
+namespace Internal {
+template <typename T>
+struct RResultType {
+   RResultType() = default;
+   explicit RResultType(const T &value) : fValue(value) {}
+   T fValue;
+};
+
+class RResultTypeVoid {};
+} // namespace Internal
+
+
 // clang-format off
 /**
 \class ROOT::Experimental::RResult
@@ -86,21 +137,30 @@ public:
 \brief The class is used as a return type for operations that can fail; wraps a value of type T or an RError
 
 The RResult enforces checking whether it contains a valid value or an error state. If the RResult leaves the scope
-unchecked, it will throw an exception.  RResult can only be allocated on the stack, which is enforced by deleting the
+unchecked, it will throw an exception.  RResult should only be allocated on the stack, which is helped by deleting the
 new operator.  RResult is movable but not copyable to avoid throwing exceptions multiple times.
 */
 // clang-format on
 template <typename T>
-class RResult {
+class RResult : public std::conditional_t<std::is_void<T>::value, Internal::RResultTypeVoid, Internal::RResultType<T>> {
 private:
-   T fValue;
+   /// This is the nullptr for an RResult representing success
    std::unique_ptr<RError> fError;
    /// This is safe because checking an RResult is not a multi-threaded operation
    mutable bool fIsChecked{false};
 
 public:
-   RResult(const T &value) : fValue(value) {}
+   /// Constructor is _not_ explicit in order to allow for `return T();` for functions returning RResult<T>
+   /// Only available if T is not void
+   template <typename Dummy = T, typename = typename std::enable_if_t<!std::is_void<T>::value, Dummy>>
+   RResult(const Dummy &value) : Internal::RResultType<T>(value) {}
+   /// Constructor is _not_ explicit such that the RError returned by R__FAIL can be converted into an RResult<T>
+   /// for any T
    RResult(std::unique_ptr<RError> error) : fError(std::move(error)) {}
+
+   /// RResult<void> has a default contructor that creates an object representing success
+   template <typename Dummy = T, typename = typename std::enable_if_t<std::is_void<T>::value, Dummy>>
+   RResult() {}
 
    RResult(const RResult &other) = delete;
    RResult(RResult &&other) = default;
@@ -122,30 +182,41 @@ public:
       }
    }
 
-   const T &Get()
+   /// Only available if T is not void
+   template <typename Dummy = T>
+   typename std::enable_if_t<!std::is_void<T>::value, const Dummy &>
+   Get()
    {
       if (R__unlikely(fError)) {
          fError->AppendMessage(" (invalid access)");
          throw RException(*fError);
       }
-      return fValue;
+      return Internal::RResultType<T>::fValue;
    }
+
    explicit operator bool() const
    {
       fIsChecked = true;
       return !fError;
    }
+
    RError *GetError() { return fError.get(); }
+
    void Throw() { throw RException(*fError); }
 
-   // Prevent heap construction of RResult objects
+   // Help prevent heap construction of RResult objects. Unchecked RResult objects in failure state should throw
+   // an exception close to the error location. For stack allocated RResult objects, an exception is thrown
+   // the latest when leaving the scope. Heap allocated ill RResult objects can live much longer making it difficult
+   // to trace back the original failure.
    void *operator new(std::size_t size) = delete;
    void *operator new(std::size_t, void *) = delete;
    void *operator new[](std::size_t) = delete;
    void *operator new[](std::size_t, void *) = delete;
 };
 
-/// Short-hand to return an RResult<T> in an error state
+/// Short-hand to return an RResult<void> indicating success
+#define R__SUCCESS return ROOT::Experimental::RResult<void>();
+/// Short-hand to return an RResult<T> in an error state; the RError is implicitly converted into RResult<T>
 #define R__FAIL(msg) return std::make_unique<ROOT::Experimental::RError>(msg, __func__, __FILE__, __LINE__)
 /// Short-hand to return an RResult<T> value from a subroutine to the calling stack frame
 #define R__FORWARD_RESULT(res) if (res.GetError()) { res.GetError()->AddFrame(__func__, __FILE__, __LINE__); } \

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -17,7 +17,7 @@
 #define ROOT7_RError
 
 #include <ROOT/RConfig.hxx> // for R__[un]likely
-#include <ROOT/RLogger.hxx> // for R__LOG_PRETTY_FUNCTION
+#include <ROOT/RLogger.hxx> // for R__LOG_PRETTY_FUNCTION, R__WARNING_HERE
 
 #include <cstddef>
 #include <memory>
@@ -192,6 +192,8 @@ public:
 #endif
          {
             throw RException(*fError);
+         } else {
+            R__WARNING_HERE("RError") << "unhandled RResult exception during stack unwinding";
          }
       }
    }
@@ -209,6 +211,10 @@ public:
    Get()
    {
       if (R__unlikely(fError)) {
+         // Get() can be wrapped in a try-catch block, so throwing the exception here is akin to checking the error.
+         // Setting fIsChecked to true also avoids a spurious warning in the RResult destructor
+         fIsChecked = true;
+
          fError->AppendToMessage(" (unchecked RResult access!)");
          throw RException(*fError);
       }

--- a/core/base/v7/src/RError.cxx
+++ b/core/base/v7/src/RError.cxx
@@ -1,0 +1,23 @@
+/// \file RError.cxx
+/// \ingroup Base ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2019-12-11
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RError.hxx"
+
+thread_local bool ROOT::Experimental::Detail::RStatusBase::fgThrowInstantExceptions = true;
+
+void ROOT::Experimental::SetThrowInstantExceptions(bool value)
+{
+   Detail::RStatusBase::SetThrowInstantExceptions(value);
+}

--- a/core/base/v7/src/RError.cxx
+++ b/core/base/v7/src/RError.cxx
@@ -64,3 +64,9 @@ ROOT::Experimental::Internal::RResultBase::~RResultBase() noexcept(false)
       }
    }
 }
+
+
+void ROOT::Experimental::Internal::RResultBase::Throw()
+{
+   throw ROOT::Experimental::RException(*fError);
+}

--- a/core/base/v7/src/RError.cxx
+++ b/core/base/v7/src/RError.cxx
@@ -16,6 +16,7 @@
 #include "ROOT/RError.hxx"
 
 #include <string>
+#include <utility>
 
 std::string ROOT::Experimental::RError::GetReport() const
 {
@@ -27,14 +28,14 @@ std::string ROOT::Experimental::RError::GetReport() const
 }
 
 ROOT::Experimental::RError::RError(
-   const std::string &message, const std::string &func, const std::string &file, int line)
+   const std::string &message, RLocation &&sourceLocation)
    : fMessage(message)
 
 {
-   AddFrame(func, file, line);
+   AddFrame(std::move(sourceLocation));
 }
 
-void ROOT::Experimental::RError::AddFrame(const std::string &func, const std::string &file, int line)
+void ROOT::Experimental::RError::AddFrame(RLocation &&sourceLocation)
 {
-   fStackTrace.emplace_back(RLocation(func, file, line));
+   fStackTrace.emplace_back(sourceLocation);
 }

--- a/core/base/v7/src/RError.cxx
+++ b/core/base/v7/src/RError.cxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/core/base/v7/src/RError.cxx
+++ b/core/base/v7/src/RError.cxx
@@ -15,9 +15,26 @@
 
 #include "ROOT/RError.hxx"
 
-thread_local bool ROOT::Experimental::Detail::RStatusBase::fgThrowInstantExceptions = true;
+#include <string>
 
-void ROOT::Experimental::SetThrowInstantExceptions(bool value)
+std::string ROOT::Experimental::RError::GetReport() const
 {
-   Detail::RStatusBase::SetThrowInstantExceptions(value);
+   auto report = fMessage + "\nAt:\n";
+   for (const auto &loc : fStackTrace) {
+      report += "  " + loc.fFunction + " [" + loc.fSourceFile + ":" + std::to_string(loc.fSourceLine) + "]\n";
+   }
+   return report;
+}
+
+ROOT::Experimental::RError::RError(
+   const std::string &message, const std::string &func, const std::string &file, int line)
+   : fMessage(message)
+
+{
+   AddFrame(func, file, line);
+}
+
+void ROOT::Experimental::RError::AddFrame(const std::string &func, const std::string &file, int line)
+{
+   fStackTrace.emplace_back(RLocation(func, file, line));
 }

--- a/core/base/v7/src/RError.cxx
+++ b/core/base/v7/src/RError.cxx
@@ -22,7 +22,8 @@ std::string ROOT::Experimental::RError::GetReport() const
 {
    auto report = fMessage + "\nAt:\n";
    for (const auto &loc : fStackTrace) {
-      report += "  " + loc.fFunction + " [" + loc.fSourceFile + ":" + std::to_string(loc.fSourceLine) + "]\n";
+      report += "  " + std::string(loc.fFunction) + " [" + std::string(loc.fSourceFile) + ":" +
+         std::to_string(loc.fSourceLine) + "]\n";
    }
    return report;
 }
@@ -32,6 +33,8 @@ ROOT::Experimental::RError::RError(
    : fMessage(message)
 
 {
+   // Avoid frequent reallocations as we move up the call stack
+   fStackTrace.reserve(32);
    AddFrame(std::move(sourceLocation));
 }
 

--- a/core/base/v7/test/CMakeLists.txt
+++ b/core/base/v7/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# All rights reserved.
+#
+# For the licensing terms see $ROOTSYS/LICENSE.
+# For the list of contributors see $ROOTSYS/README/CREDITS.
+
+# @author Jakob Blomer CERN
+
+ROOT_ADD_GTEST(base_exception base_exception.cxx LIBRARIES Core)

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -47,8 +47,10 @@ TEST(Exception, Report)
    } catch (const RException& e) {
       exceptionThrown = true;
       ASSERT_EQ(2U, e.GetError().GetStackTrace().size());
-      EXPECT_EQ("TestSyscall", e.GetError().GetStackTrace().at(0).fFunction);
-      EXPECT_EQ("TestChain", e.GetError().GetStackTrace().at(1).fFunction);
+      EXPECT_EQ("ROOT::Experimental::RResult<int> {anonymous}::TestSyscall(bool)",
+                e.GetError().GetStackTrace().at(0).fFunction);
+      EXPECT_EQ("ROOT::Experimental::RResult<int> {anonymous}::TestChain(bool)",
+                e.GetError().GetStackTrace().at(1).fFunction);
    }
    EXPECT_TRUE(exceptionThrown);
 }

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -1,0 +1,105 @@
+#include "gtest/gtest.h"
+
+#include <ROOT/RError.hxx>
+
+#include <cerrno>
+#include <stdexcept>
+
+using RException = ROOT::Experimental::RException;
+using RStatusBool = ROOT::Experimental::RStatusBool;
+using RStatusSyscall = ROOT::Experimental::RStatusSyscall;
+
+namespace {
+
+static RStatusBool TestFailure()
+{
+   return RStatusBool(false);
+}
+
+static RStatusBool TestSuccess()
+{
+   return RStatusBool(true);
+}
+
+static RStatusSyscall MockFileOpen(bool succeed)
+{
+   if (succeed)
+      return RStatusSyscall(42);
+   errno = EPERM;
+   return RStatusSyscall::Fail("Not allowed to succeed");
+}
+
+class ExceptionX : public std::runtime_error {
+public:
+   explicit ExceptionX(const std::string &what) : std::runtime_error(what) {}
+};
+
+} // anonymous namespace
+
+
+TEST(Exception, InstantExceptions)
+{
+   ROOT::Experimental::SetThrowInstantExceptions(true); // the default
+   bool passedFailure = false;
+
+   try {
+      TestFailure();
+      passedFailure = true;
+   } catch (const RException&) {
+   }
+   EXPECT_FALSE(passedFailure);
+}
+
+
+TEST(Exception, DiscardReturnValue)
+{
+   ROOT::Experimental::SetThrowInstantExceptions(false);
+   bool exceptionThrown;
+
+   try {
+      exceptionThrown = false;
+      TestFailure();
+   } catch (const RException&) {
+      exceptionThrown = true;
+   }
+   EXPECT_TRUE(exceptionThrown);
+
+   try {
+      exceptionThrown = false;
+      TestSuccess();
+   } catch (const RException&) {
+      exceptionThrown = true;
+   }
+   EXPECT_FALSE(exceptionThrown);
+}
+
+
+TEST(Exception, CheckReturnValue)
+{
+   ROOT::Experimental::SetThrowInstantExceptions(false);
+   auto rv = TestFailure();
+   EXPECT_TRUE(rv.IsError());
+   // No exception / crash when the scope closes
+}
+
+
+TEST(Exception, DoubleThrow)
+{
+   ROOT::Experimental::SetThrowInstantExceptions(false);
+   try {
+      auto rv = TestFailure();
+      throw ExceptionX("something else went wrong");
+   } catch (const ExceptionX&) {
+      // This will not catch RException, so that the program crashes if rv throws
+   }
+}
+
+
+TEST(Exception, Syscall)
+{
+   ROOT::Experimental::SetThrowInstantExceptions(true);
+   auto fd = MockFileOpen(true);
+   EXPECT_EQ(42, fd);
+
+   EXPECT_THROW(MockFileOpen(false), RException);
+}

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -22,7 +22,7 @@ int ComplexReturnType::gNCopies = 0;
 
 static ROOT::Experimental::RResult<void> TestFailure()
 {
-   R__FAIL("test failure");
+   return R__FAIL("test failure");
 }
 
 static ROOT::Experimental::RResult<void> TestSuccess()
@@ -34,7 +34,7 @@ static ROOT::Experimental::RResult<int> TestSyscall(bool succeed)
 {
    if (succeed)
       return 42;
-   R__FAIL("failure");
+   return R__FAIL("failure");
 }
 
 static ROOT::Experimental::RResult<int> TestChain(bool succeed)

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -1,4 +1,5 @@
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 #include <ROOT/RError.hxx>
 
@@ -47,10 +48,8 @@ TEST(Exception, Report)
    } catch (const RException& e) {
       exceptionThrown = true;
       ASSERT_EQ(2U, e.GetError().GetStackTrace().size());
-      EXPECT_EQ("ROOT::Experimental::RResult<int> {anonymous}::TestSyscall(bool)",
-                e.GetError().GetStackTrace().at(0).fFunction);
-      EXPECT_EQ("ROOT::Experimental::RResult<int> {anonymous}::TestChain(bool)",
-                e.GetError().GetStackTrace().at(1).fFunction);
+      EXPECT_THAT(e.GetError().GetStackTrace().at(0).fFunction, ::testing::HasSubstr("TestSyscall(bool)"));
+      EXPECT_THAT(e.GetError().GetStackTrace().at(1).fFunction, ::testing::HasSubstr("TestChain(bool)"));
    }
    EXPECT_TRUE(exceptionThrown);
 }

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -8,14 +8,14 @@ using RException = ROOT::Experimental::RException;
 
 namespace {
 
-static ROOT::Experimental::RResult<bool> TestFailure()
+static ROOT::Experimental::RResult<void> TestFailure()
 {
    R__FAIL("test failure");
 }
 
-static ROOT::Experimental::RResult<bool> TestSuccess()
+static ROOT::Experimental::RResult<void> TestSuccess()
 {
-   return true;
+   R__SUCCESS
 }
 
 static ROOT::Experimental::RResult<int> TestSyscall(bool succeed)

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -53,6 +53,14 @@ TEST(Exception, Report)
 }
 
 
+TEST(Exception, ForwardResult)
+{
+   auto res = TestChain(true);
+   ASSERT_TRUE(res);
+   EXPECT_EQ(42, res.Get());
+}
+
+
 TEST(Exception, DiscardReturnValue)
 {
    EXPECT_THROW(TestFailure(), RException);

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -44,7 +44,7 @@ TEST(Exception, Report)
 {
    try {
       TestChain(false);
-      EXPECT_EQ("Above line should have thrown!", nullptr);
+      EXPECT_TRUE(false) << "Above line should have thrown!";
    } catch (const RException& e) {
       ASSERT_EQ(2U, e.GetError().GetStackTrace().size());
       EXPECT_THAT(e.GetError().GetStackTrace().at(0).fFunction, ::testing::HasSubstr("TestSyscall(bool)"));

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -24,7 +24,7 @@ static RStatusSyscall MockFileOpen(bool succeed)
 {
    if (succeed)
       return RStatusSyscall(42);
-   return RStatusSyscall::Fail("Not allowed to succeed");
+   return RStatusSyscall::Fail(-1, "Not allowed to succeed");
 }
 
 class ExceptionX : public std::runtime_error {

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -72,7 +72,7 @@ TEST(Exception, Report)
 TEST(Exception, ForwardResult)
 {
    auto res = TestChain(true);
-   ASSERT_TRUE(res);
+   ASSERT_TRUE(static_cast<bool>(res));
    EXPECT_EQ(42, res.Get());
 }
 

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -16,7 +16,7 @@ static ROOT::Experimental::RResult<void> TestFailure()
 
 static ROOT::Experimental::RResult<void> TestSuccess()
 {
-   R__SUCCESS
+   return ROOT::Experimental::RResult<void>::Success();
 }
 
 static ROOT::Experimental::RResult<int> TestSyscall(bool succeed)
@@ -42,16 +42,14 @@ public:
 
 TEST(Exception, Report)
 {
-   bool exceptionThrown = false;
    try {
       TestChain(false);
+      EXPECT_EQ("Above line should have thrown!", nullptr);
    } catch (const RException& e) {
-      exceptionThrown = true;
       ASSERT_EQ(2U, e.GetError().GetStackTrace().size());
       EXPECT_THAT(e.GetError().GetStackTrace().at(0).fFunction, ::testing::HasSubstr("TestSyscall(bool)"));
       EXPECT_THAT(e.GetError().GetStackTrace().at(1).fFunction, ::testing::HasSubstr("TestChain(bool)"));
    }
-   EXPECT_TRUE(exceptionThrown);
 }
 
 

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -29,7 +29,7 @@ static ROOT::Experimental::RResult<int> TestSyscall(bool succeed)
 static ROOT::Experimental::RResult<int> TestChain(bool succeed)
 {
    auto rv = TestSyscall(succeed);
-   R__FORWARD_RESULT(rv);
+   return R__FORWARD_RESULT(rv);
 }
 
 class ExceptionX : public std::runtime_error {

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -2,7 +2,6 @@
 
 #include <ROOT/RError.hxx>
 
-#include <cerrno>
 #include <stdexcept>
 
 using RException = ROOT::Experimental::RException;
@@ -25,7 +24,6 @@ static RStatusSyscall MockFileOpen(bool succeed)
 {
    if (succeed)
       return RStatusSyscall(42);
-   errno = EPERM;
    return RStatusSyscall::Fail("Not allowed to succeed");
 }
 

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -57,23 +57,8 @@ TEST(Exception, Report)
 
 TEST(Exception, DiscardReturnValue)
 {
-   bool exceptionThrown;
-
-   try {
-      exceptionThrown = false;
-      TestFailure();
-   } catch (const RException&) {
-      exceptionThrown = true;
-   }
-   EXPECT_TRUE(exceptionThrown);
-
-   try {
-      exceptionThrown = false;
-      TestSuccess();
-   } catch (const RException&) {
-      exceptionThrown = true;
-   }
-   EXPECT_FALSE(exceptionThrown);
+   EXPECT_THROW(TestFailure(), RException);
+   EXPECT_NO_THROW(TestSuccess());
 }
 
 


### PR DESCRIPTION
The RException class is supposed to serve as base class for all ROOT
exceptions. It contains an `RError` member with diagnostic information.
The `RResult<T>` class can be used as a return value of operations that
may fail. The `RResult<T>` object wraps either a valid value or an `RError`.
If an error state remains unchecked, the `RResult` class will throw an
exception on destruction.