### PR TITLE
add a function to retrieve the number of logical cores available

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -97,7 +97,6 @@ namespace ROOT {
    void DisableImplicitMT();
    Bool_t IsImplicitMTEnabled();
    UInt_t GetImplicitMTPoolSize();
-   UInt_t NLogicalCores();
 }
 
 class TROOT : public TDirectory {

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -97,6 +97,7 @@ namespace ROOT {
    void DisableImplicitMT();
    Bool_t IsImplicitMTEnabled();
    UInt_t GetImplicitMTPoolSize();
+   UInt_t NLogicalCores();
 }
 
 class TROOT : public TDirectory {

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -72,9 +72,14 @@ of a main program creating an interactive version is shown below:
 #include "RVersion.h"
 #include "RGitCommit.h"
 
+#include <fstream>
 #include <string>
 #include <map>
 #include <stdlib.h>
+#ifdef R__LINUX
+#include <sched.h>
+#include <unistd.h>
+#endif
 #ifdef WIN32
 #include <io.h>
 #include "Windows4Root.h"
@@ -628,7 +633,46 @@ namespace Internal {
 #endif
    }
 
-}
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Returns the available number of logical cores.
+   ///
+   ///  Performs the following checks in order:
+   ///  - Checks processor affinity (linux only)
+   ///  - Checks if there is CFS bandwith control in place (linux only, assuming standard paths)
+   ///  - If none of the cases above are true (or if Windows/MacOS), returns the number of logical cores provided by bare metal.
+   ////////////////////////////////////////////////////////////////////////////////
+   UInt_t NLogicalCores()
+   {
+#ifdef R__LINUX
+      // Check for processor affinity
+      cpu_set_t cpuset;
+      CPU_ZERO(&cpuset);
+      if(0 == sched_getaffinity(getpid(), sizeof(cpu_set_t), &cpuset)) {
+            return CPU_COUNT(&cpuset);
+      } else {
+         // Check for bandwith control
+         std::ifstream f;
+         std::string quotaFile("/sys/fs/cgroup/cpuacct/cpu.cfs_quota_us");
+         f.open(quotaFile);
+         int cfs_quota;
+         f>>cfs_quota;
+         f.close();
+         if(cfs_quota != -1) {
+            std::string periodFile("/sys/fs/cgroup/cpuacct/cpu.cfs_period_us");
+            f.open(periodFile);
+            int cfs_period;
+            f>>cfs_period;
+            f.close();
+            return cfs_quota/cfs_period;
+         }
+      }
+#endif
+      // return bare metal logical cpus
+      SysInfo_t info;
+      gSystem->GetSysInfo(&info);
+      return info.fCpus;
+   }
+} // end of ROOT namespace
 
 TROOT *ROOT::Internal::gROOTLocal = ROOT::GetROOT();
 

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -658,13 +658,13 @@ namespace Internal {
          // Does the file exist?
          if(stat(quotaFile.c_str(), &buffer) == 0) {
             f.open(quotaFile);
-            int cfs_quota;
+            float cfs_quota;
             f>>cfs_quota;
             f.close();
-            if(cfs_quota != -1) {
+            if(cfs_quota > 0) {
                std::string periodFile("/sys/fs/cgroup/cpuacct/cpu.cfs_period_us");
                f.open(periodFile);
-               int cfs_period;
+               float cfs_period;
                f>>cfs_period;
                f.close();
                return cfs_quota/cfs_period;

--- a/core/imt/src/TPoolManager.cxx
+++ b/core/imt/src/TPoolManager.cxx
@@ -48,7 +48,7 @@ namespace ROOT {
                float cfs_period;
                f>>cfs_period;
                f.close();
-               return (cfs_quota+cfs_period-1)/cfs_period;
+               return static_cast<int>(std::ceil(cfs_quota/cfs_period));
             }
          }
       #endif

--- a/core/imt/src/TPoolManager.cxx
+++ b/core/imt/src/TPoolManager.cxx
@@ -24,7 +24,7 @@ namespace ROOT {
             mustDelete = false;
          }
 
-         nThreads = nThreads != 0 ? nThreads : tbb::task_scheduler_init::default_num_threads();
+         nThreads = nThreads != 0 ? nThreads : ROOT::NLogicalCores();
          fSched ->initialize(nThreads);
          fgPoolSize = nThreads;
       };

--- a/core/imt/src/TPoolManager.cxx
+++ b/core/imt/src/TPoolManager.cxx
@@ -2,11 +2,59 @@
 #include "TError.h"
 #include "TROOT.h"
 #include <algorithm>
+#include <fstream>
+#ifdef R__LINUX
+#include <unistd.h>
+#include <sys/stat.h>
+#endif
 #include "tbb/task_scheduler_init.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns the available number of logical cores.
+///
+///  - Checks if there is CFS bandwith control in place (linux, via cgroups,
+///    assuming standard paths)
+///  - Otherwise, returns the number of logical cores provided by tbb by default.
+///    This is processor affinity aware, at least in Linux.
+////////////////////////////////////////////////////////////////////////////////
+
 
 namespace ROOT {
 
    namespace Internal {
+
+      //Returns the available number of logical cores.
+      // - Checks if there is CFS bandwith control in place (linux, via cgroups,
+      //   assuming standard paths)
+      // - Otherwise, returns the number of logical cores provided by tbb by default.
+      //   This is processor affinity aware, at least in Linux.
+      Int_t NLogicalCores()
+      {
+      #ifdef R__LINUX
+         // Check for CFS bandwith control
+         std::ifstream f;
+         std::string quotaFile("/sys/fs/cgroup/cpuacct/cpu.cfs_quota_us");
+         struct stat buffer;
+         // Does the file exist?
+         if(stat(quotaFile.c_str(), &buffer) == 0) {
+            f.open(quotaFile);
+            float cfs_quota;
+            f>>cfs_quota;
+            f.close();
+            if(cfs_quota > 0) {
+               std::string periodFile("/sys/fs/cgroup/cpuacct/cpu.cfs_period_us");
+               f.open(periodFile);
+               float cfs_period;
+               f>>cfs_period;
+               f.close();
+               return (cfs_quota+cfs_period-1)/cfs_period;
+            }
+         }
+      #endif
+         return tbb::task_scheduler_init::default_num_threads();
+      }
+
       //Returns the weak_ptr reflecting a shared_ptr to the only instance of the Pool Manager.
       //This will allow to check if the shared_ptr is still alive, solving the dangling pointer problem.
       std::weak_ptr<TPoolManager> &GetWP()
@@ -24,7 +72,7 @@ namespace ROOT {
             mustDelete = false;
          }
 
-         nThreads = nThreads != 0 ? nThreads : ROOT::NLogicalCores();
+         nThreads = nThreads != 0 ? nThreads : NLogicalCores();
          fSched ->initialize(nThreads);
          fgPoolSize = nThreads;
       };


### PR DESCRIPTION
Added a function in TROOT to retrieve the correct number of logical cores, taking into account (in linux) CPU affinity and CFS bandwith control.