### PR TITLE
Fix the memory management of internal histograms in TMVA::ROCCalc class

### DIFF
--- a/tmva/tmva/inc/TMVA/ROCCalc.h
+++ b/tmva/tmva/inc/TMVA/ROCCalc.h
@@ -23,52 +23,52 @@ namespace TMVA {
 
 
    class ROCCalc {
-    
+
    public:
       ROCCalc(TH1* mvaS, TH1* mvaB);
-    
+
       ~ROCCalc();
-    
+
 
       TH1D* GetROC();
       // return the signal eff for a given backgr. efficiency
       Double_t GetEffSForEffBof(Double_t effBref, Double_t &effSerr);
-      // return the cut value 
-      Double_t GetSignalReferenceCut(){return fSignalCut;} 
+      // return the cut value
+      Double_t GetSignalReferenceCut(){return fSignalCut;}
       // return the area under the ROC curve
       Double_t GetROCIntegral();
       // return the statistical significance as function of the mva cut value
       TH1* GetSignificance( Int_t nStot, Int_t nBtot);
       TH1* GetPurity(Int_t nStot, Int_t nBtot);
-    
+
       void ApplySignalAndBackgroundStyle( TH1* sig, TH1* bkg, TH1* any = 0 );
-    
-      TH1* GetMvaSpdf(){return fmvaSpdf;}
-      TH1* GetMvaBpdf(){return fmvaBpdf;}
-    
+
+      TH1 *GetMvaSpdf();
+      TH1 *GetMvaBpdf();
+
       //false if is found some error in mvaS or mvaB
       Bool_t GetStatus(){return fStatus;}
       void ResetStatus(){fStatus=kTRUE;}
-    
+
    private:
       Double_t        Root(Double_t);
       Double_t        GetEffForRoot( Double_t theCut );
       Int_t           fMaxIter;  // maximum number of iterations
       Double_t        fAbsTol;   // absolute tolerance deviation
-    
-      Bool_t          fStatus; //false if is found some error in mvaS or mvaB 
-    
+
+      Bool_t          fStatus; //false if is found some error in mvaS or mvaB
+
       UInt_t          fNbins;
       Bool_t          fUseSplines;
 
       TH1*            fmvaS, *fmvaB;       // the input mva distributions
       TH1*            fmvaSpdf, *fmvaBpdf;       // the normalized (and rebinned) input mva distributions
-      Float_t         fXmin, fXmax;       // min and max of the mva distribution  
+      Float_t         fXmin, fXmax;       // min and max of the mva distribution
       Double_t        fNevtS;             // number of signal events (used in error calculation)
       Int_t           fCutOrientation;    //+1 if larger mva value means more signal like, -1 otherwise
       TSpline*        fSplS, *fSplB;
       TSpline*        fSplmvaCumS, *fSplmvaCumB;  // spline of cumulated mva distributions
-      TSpline*        fSpleffBvsS;    
+      TSpline*        fSpleffBvsS;
       TH1*            fmvaScumul, *fmvaBcumul;
       Int_t           fnStot, fnBtot;
       TH1*            fSignificance;
@@ -80,7 +80,7 @@ namespace TMVA {
       Double_t        fSignalCut;  // MVA cut value for last demanded background rejection or signal efficiency
 
       mutable MsgLogger* fLogger;   //! message logger
-      MsgLogger& Log() const { return *fLogger; }                       
+      MsgLogger& Log() const { return *fLogger; }
 
    };
 }

--- a/tmva/tmva/src/ROCCalc.cxx
+++ b/tmva/tmva/src/ROCCalc.cxx
@@ -46,9 +46,10 @@ using namespace std;
 ////////////////////////////////////////////////////////////////////////////////
 
 TMVA::ROCCalc::ROCCalc(TH1 *mvaS, TH1 *mvaB)
-   : fMaxIter(100), fAbsTol(0.0), fStatus(kTRUE), fmvaS(0), fmvaB(0), fmvaSpdf(0), fmvaBpdf(0), fSplS(0), fSplB(0),
-     fSplmvaCumS(0), fSplmvaCumB(0), fSpleffBvsS(0), fmvaScumul(0), fmvaBcumul(0), fnStot(0), fnBtot(0), fSignificance(0),
-     fPurity(0), effBvsS(0), rejBvsS(0), inveffBvsS(0), fLogger(new TMVA::MsgLogger("ROCCalc"))
+   : fMaxIter(100), fAbsTol(0.0), fStatus(kTRUE), fmvaS(nullptr), fmvaB(nullptr), fmvaSpdf(nullptr), fmvaBpdf(nullptr),
+     fSplS(nullptr), fSplB(nullptr), fSplmvaCumS(nullptr), fSplmvaCumB(nullptr), fSpleffBvsS(nullptr), fmvaScumul(nullptr),
+     fmvaBcumul(nullptr), fnStot(0), fnBtot(0), fSignificance(nullptr), fPurity(nullptr),
+     effBvsS(nullptr), rejBvsS(nullptr), inveffBvsS(nullptr), fLogger(new TMVA::MsgLogger("ROCCalc"))
 {
    fUseSplines = kTRUE;
    fNbins      = 100;
@@ -453,7 +454,7 @@ TH1* TMVA::ROCCalc::GetPurity( Int_t nStot, Int_t nBtot)
 
 TH1 *  TMVA::ROCCalc::GetSignificance(Int_t nStot, Int_t nBtot)
 {
-   if (fnStot==nStot && fnBtot==nBtot && !fSignificance) return (TH1*) fSignificance->Clone();
+   if (fnStot==nStot && fnBtot==nBtot && fSignificance) return (TH1*) fSignificance->Clone();
    fnStot=nStot; fnBtot=nBtot;
 
    fSignificance = (TH1*) fmvaScumul->Clone("Significance"); fSignificance->SetTitle("Significance");
@@ -463,7 +464,7 @@ TH1 *  TMVA::ROCCalc::GetSignificance(Int_t nStot, Int_t nBtot)
    fSignificance->SetLineColor(2);
    fSignificance->SetLineWidth(5);
 
-   fPurity = (TH1*) fmvaScumul->Clone("_Purity"); fPurity->SetTitle("Purity");
+   fPurity = (TH1*) fmvaScumul->Clone("Purity"); fPurity->SetTitle("Purity");
    fPurity->Reset(); fPurity->SetFillStyle(0);
    fPurity->SetXTitle("mva cut value");
    fPurity->SetYTitle("Purity: S/(S+B)");


### PR DESCRIPTION
Some of the histograms cretaed internally by the TMVA ROCCalc class were deleted and others not.
For example the ROC curve histogram returned by ROCCalc::GetROCCurve was deleted in the destructor of
ROCCalc. This was causing a crash when exiting.

Some other histograms instead were not deleted