### PR TITLE
[ROOT-10469] Introduce two teardown modes for PyROOT: soft and hard

### DIFF
--- a/bindings/pyroot/src/RootModule.cxx
+++ b/bindings/pyroot/src/RootModule.cxx
@@ -798,6 +798,8 @@ static PyMethodDef gPyROOTMethods[] = {
      METH_NOARGS, (char*) "PyROOT internal function" },
    { (char*) "_ResetRootModule", (PyCFunction)RootModuleResetCallback,
      METH_NOARGS, (char*) "PyROOT internal function" },
+   { (char*) "ClearProxiedObjects", (PyCFunction)ClearProxiedObjects,
+     METH_NOARGS, (char*) "PyROOT internal function" },
    { (char*) "AddressOf", (PyCFunction)AddressOf,
      METH_VARARGS, (char*) "Retrieve address of held object in a buffer" },
    { (char*) "addressof", (PyCFunction)addressof,

--- a/bindings/pyroot/src/RootWrapper.cxx
+++ b/bindings/pyroot/src/RootWrapper.cxx
@@ -175,6 +175,11 @@ namespace {
 } // unnamed namespace
 
 
+static TMemoryRegulator &GetMemoryRegulator() {
+   static TMemoryRegulator m;
+   return m;
+}
+
 //- public functions ---------------------------------------------------------
 void PyROOT::InitRoot()
 {
@@ -182,8 +187,7 @@ void PyROOT::InitRoot()
    PyEval_InitThreads();
 
 // memory management
-   static TMemoryRegulator m;
-   gROOT->GetListOfCleanups()->Add( &m );
+   gROOT->GetListOfCleanups()->Add( &GetMemoryRegulator() );
 
 // bind ROOT globals that are needed in ROOT.py
    AddToGlobalScope( "gROOT", "TROOT.h", gROOT, Cppyy::GetScope( gROOT->IsA()->GetName() ) );
@@ -808,6 +812,15 @@ PyObject* PyROOT::GetCppGlobal( const std::string& name )
 // nothing found
    PyErr_Format( PyExc_LookupError, "no such global: %s", name.c_str() );
    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Delete all memory-regulated objects
+
+PyObject *PyROOT::ClearProxiedObjects()
+{
+   GetMemoryRegulator().ClearProxiedObjects();
+   Py_RETURN_NONE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/bindings/pyroot/src/RootWrapper.h
+++ b/bindings/pyroot/src/RootWrapper.h
@@ -27,6 +27,9 @@ namespace PyROOT {
    PyObject* GetCppGlobal( const std::string& name );
    PyObject* GetCppGlobal( PyObject*, PyObject* args );
 
+// clean up all objects controlled by TMemoryRegulator
+   PyObject *ClearProxiedObjects();
+
 // bind a ROOT object into a Python object
    PyObject* BindCppObjectNoCast( Cppyy::TCppObject_t object, Cppyy::TCppType_t klass,
       Bool_t isRef = kFALSE, Bool_t isValue = kFALSE );

--- a/bindings/pyroot/src/TMemoryRegulator.h
+++ b/bindings/pyroot/src/TMemoryRegulator.h
@@ -8,7 +8,7 @@
 #include "TObject.h"
 
 // Standard
-#include <map>
+#include <unordered_map>
 
 
 namespace PyROOT {
@@ -29,6 +29,9 @@ namespace PyROOT {
    // callback for ROOT/CINT
       virtual void RecursiveRemove( TObject* object );
 
+   // cleanup of all tracked objects
+      void ClearProxiedObjects();
+
    // add a python object to the table of managed objects
       static Bool_t RegisterObject( ObjectProxy* pyobj, TObject* object );
 
@@ -42,8 +45,8 @@ namespace PyROOT {
       static PyObject* ObjectEraseCallback( PyObject*, PyObject* pyref );
 
    private:
-      typedef std::map< TObject*, PyObject* > ObjectMap_t;
-      typedef std::map< PyObject*, ObjectMap_t::iterator > WeakRefMap_t;
+      typedef std::unordered_map< TObject*, PyObject* > ObjectMap_t;
+      typedef std::unordered_map< PyObject*, ObjectMap_t::iterator > WeakRefMap_t;
 
       static ObjectMap_t*  fgObjectTable;
       static WeakRefMap_t* fgWeakRefTable;


### PR DESCRIPTION
Motivation: we need to make sure that, if PyROOT is used from another process that will keep on living after the Python interpreter dies, PyROOT does not shut down the ROOT interpreter via `TROOT::EndOfProcessCleanups` when running its atexit handler.

In that sense, this PR adds a configuration option to tell PyROOT if the teardown needs to be soft, i.e. we do not want to shut down the ROOT interpreter. Instead, in the soft mode, we only want (and need) to clean the objects that are controlled by PyROOT via its `TMemoryRegulator`.

@Axel-Naumann @pcanal just one new thing with respect to what we discussed: in the function that does the cleanup of the objects in `TMemoryRegulator`, called `RecursiveRemoveAll` in my commit, we can only delete a C++ object found in the map if the corresponding Python proxy **owns** the C++ object. Otherwise we will have a double delete (if the proxy does not own is because the deletion will happen somewhere else, so our `RecursiveRemoveAll` can't delete too).