### PR TITLE
[cmake,cling] Hide C and C++ symbols alike:

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -114,7 +114,8 @@ if(clingtest)
                                        ENVIRONMENT ${CLINGTEST_EXECUTABLE})
 else()
   #---Build LLVM/Clang with symbol visibility=hidden--------------------------------------------------
-  ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS -fvisibility=hidden)
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  set(CMAKE_C_VISIBILITY_PRESET hidden)
 endif()
 
 #--- Build LLVM/Clang with modules -----------------------------------------------------------------

--- a/interpreter/cling/CMakeLists.txt
+++ b/interpreter/cling/CMakeLists.txt
@@ -311,6 +311,9 @@ string(REGEX REPLACE "[0-9].([0-9]+)~[a-zA-Z]+" "\\1" CLING_VERSION_MINOR ${CLIN
 if(DEFINED ROOT_BINARY_DIR)
   # Building as part of ROOT.
   set(CLING_VERSION ROOT_${CLING_VERSION})
+  set(CMAKE_CXX_VISIBILITY_PRESET default)
+  set(CMAKE_C_VISIBILITY_PRESET default)
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN "ON")
 endif()
 message(STATUS "Cling version (from VERSION file): ${CLING_VERSION}")
 


### PR DESCRIPTION
We had symbols exposed, which in turn meant symbols were resolved by the dynamic loader,
which in turn meant another libllvm.so could interfere with those of cling. By hiding these
symbols, all symbols are self-contained and not external symbols leak into libCling.