### PR TITLE
Add RCoordArray constructor for C++ arrays

### DIFF
--- a/hist/histv7/inc/ROOT/RHistUtils.hxx
+++ b/hist/histv7/inc/ROOT/RHistUtils.hxx
@@ -35,8 +35,8 @@ struct RCoordArray: std::array<double, DIMENSIONS> {
 
    /// Fallback constructor, invoked if the one above fails because of the wrong number of
    /// arguments / coordinates.
-   template<class T, class...ELEMENTS, class = typename std::enable_if<sizeof...(ELEMENTS) + 1 != DIMENSIONS>::type>
-   RCoordArray(T, ELEMENTS...) {
+   template<class...ELEMENTS, class = typename std::enable_if<sizeof...(ELEMENTS) + 1 != DIMENSIONS>::type>
+   RCoordArray(double, ELEMENTS...) {
       static_assert(sizeof...(ELEMENTS) + 1 == DIMENSIONS, "Number of coordinates does not match DIMENSIONS");
    }
 

--- a/hist/histv7/inc/ROOT/RHistUtils.hxx
+++ b/hist/histv7/inc/ROOT/RHistUtils.hxx
@@ -42,6 +42,10 @@ struct RCoordArray: std::array<double, DIMENSIONS> {
 
    /// Construction from a C-style array.
    RCoordArray(double (&arr)[DIMENSIONS]): Base_t(arr) {}
+
+   /// Copy-construction from a C++-style array.
+   /// (No need for a move-constructor, it isn't any better for doubles)
+   RCoordArray(const std::array<double, DIMENSIONS>& arr) : Base_t(arr) {}
 };
 
 template <int DIMENSIONS>

--- a/hist/histv7/inc/ROOT/RHistUtils.hxx
+++ b/hist/histv7/inc/ROOT/RHistUtils.hxx
@@ -45,7 +45,7 @@ struct RCoordArray: std::array<double, DIMENSIONS> {
 
    /// Copy-construction from a C++-style array.
    /// (No need for a move-constructor, it isn't any better for doubles)
-   RCoordArray(const std::array<double, DIMENSIONS>& arr) : Base_t(arr) {}
+   RCoordArray(const std::array<double, DIMENSIONS>& arr): Base_t(arr) {}
 };
 
 template <int DIMENSIONS>

--- a/hist/histv7/inc/ROOT/RHistUtils.hxx
+++ b/hist/histv7/inc/ROOT/RHistUtils.hxx
@@ -35,8 +35,8 @@ struct RCoordArray: std::array<double, DIMENSIONS> {
 
    /// Fallback constructor, invoked if the one above fails because of the wrong number of
    /// arguments / coordinates.
-   template<class...ELEMENTS, class = typename std::enable_if<sizeof...(ELEMENTS) + 1 != DIMENSIONS>::type>
-   RCoordArray(double, ELEMENTS...) {
+   template<class T, class...ELEMENTS, class = typename std::enable_if<sizeof...(ELEMENTS) + 1 != DIMENSIONS>::type>
+   RCoordArray(T, ELEMENTS...) {
       static_assert(sizeof...(ELEMENTS) + 1 == DIMENSIONS, "Number of coordinates does not match DIMENSIONS");
    }
 


### PR DESCRIPTION
Since we already accept C-style arrays, there's little reason not to accept the std::array equivalent as well.