### PR TITLE
Add a new function in Fitter to update minimizer options when refitting or when using Minos or Hesse

### DIFF
--- a/math/mathcore/inc/Fit/FitResult.h
+++ b/math/mathcore/inc/Fit/FitResult.h
@@ -95,7 +95,7 @@ public:
       Note that in this case MINOS is not re-run. If one wants to run also MINOS
       a new result must be created
     */
-   bool Update(const std::shared_ptr<ROOT::Math::Minimizer> & min, bool isValid, unsigned int ncalls = 0 );
+   bool Update(const std::shared_ptr<ROOT::Math::Minimizer> & min, const ROOT::Fit::FitConfig & fconfig, bool isValid, unsigned int ncalls = 0);
 
    /** minimization quantities **/
 
@@ -338,6 +338,9 @@ protected:
    /// used by Fitter class
    std::shared_ptr<IModelFunction> ModelFunction()  { return fFitFunc; }
    void SetModelFunction(const std::shared_ptr<IModelFunction> & func) { fFitFunc = func; }
+
+   // set the minimizer type string from FitConfig (Minimizer name / minimizer algo)
+   void SetMinimizerType(const FitConfig & fconfig);
 
 
    friend class Fitter;

--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -476,9 +476,10 @@ protected:
    bool DoMinimization(const ROOT::Math::IMultiGenFunction * chifunc = 0);
    // update config after fit
    void DoUpdateFitConfig();
+   // update minimizer options for re-fitting
+   bool DoUpdateMinimizerOptions(bool canDifferentMinim = true);
    // get function calls from the FCN
    int GetNCallsFromFCN();
-
 
    //set data for the fit
    void SetData(const FitData & data) {

--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -116,17 +116,7 @@ void FitResult::FillResult(const std::shared_ptr<ROOT::Math::Minimizer> & min, c
    fMinimizer= min;
    fFitFunc = func;
 
-
-
-   // set minimizer type
-   fMinimType = fconfig.MinimizerType();
-
-   // append algorithm name for minimizer that support it
-   if ( (fMinimType.find("Fumili") == std::string::npos) &&
-        (fMinimType.find("GSLMultiFit") == std::string::npos)
-      ) {
-      if (fconfig.MinimizerAlgoType() != "") fMinimType += " / " + fconfig.MinimizerAlgoType();
-   }
+   SetMinimizerType(fconfig);
 
    // replace ncalls if minimizer does not support it (they are taken then from the FitMethodFunction)
    if (fNCalls == 0) fNCalls = ncalls;
@@ -233,6 +223,18 @@ void FitResult::FillResult(const std::shared_ptr<ROOT::Math::Minimizer> & min, c
 
 }
 
+void FitResult::SetMinimizerType(const FitConfig & fconfig) { 
+   // set minimizer type
+   fMinimType = fconfig.MinimizerType();
+
+   // append algorithm name for minimizer that support it
+   if ( (fMinimType.find("Fumili") == std::string::npos) &&
+        (fMinimType.find("GSLMultiFit") == std::string::npos)
+      ) {
+      if (fconfig.MinimizerAlgoType() != "") fMinimType += " / " + fconfig.MinimizerAlgoType();
+   }
+}
+
 FitResult::~FitResult() {
    // destructor. FitResult manages the fit Function pointer
    //if (fFitFunc) delete fFitFunc;
@@ -288,11 +290,14 @@ FitResult & FitResult::operator = (const FitResult &rhs) {
 
 }
 
-bool FitResult::Update(const std::shared_ptr<ROOT::Math::Minimizer> & min, bool isValid, unsigned int ncalls) {
+bool FitResult::Update(const std::shared_ptr<ROOT::Math::Minimizer> & min, const ROOT::Fit::FitConfig & fconfig, bool isValid, unsigned int ncalls) {
    // update fit result with new status from minimizer
    // ncalls if it is not zero is used instead of value from minimizer
 
    fMinimizer = min;
+
+   // in case minimizer changes
+   SetMinimizerType(fconfig);
 
    const unsigned int npar = fParams.size();
    if (min->NDim() != npar ) {


### PR DESCRIPTION
This PR allows to change the minimiser options when doing a second fit or when calling Hesse or Minos. 

In case of Hesse the minimizer can also be changed but not in case of  Minos, because the minimizer requires a  a valid minimisation that is performed.