### PR TITLE
[Exp PyROOT] Fixed source issue with zsh

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
@@ -117,7 +117,7 @@ if(package_installed EQUAL 0 AND setuptools_version GREATER_EQUAL 39.0)
 else()
     # create egg in a dummy way
     set(ROOT_egg "${CMAKE_CURRENT_BINARY_DIR}/PyROOT.egg")
-    file(WRITE ROOT_egg "PyROOT ${ROOT_VERSION}")
+    file(WRITE ${ROOT_egg} "PyROOT ${ROOT_VERSION}")
 endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -499,7 +499,6 @@ message(STATUS "Looking for python")
 if(pyroot_experimental)
   unset(PYTHON_INCLUDE_DIR CACHE)
   unset(PYTHON_LIBRARY CACHE)
-  unset(CMAKE_INSTALL_PYROOTDIR)
 endif()
 
 # Python is required by header and manpage generation


### PR DESCRIPTION
Due to the way it works by default, sourcing a root version built with
current pyroot was failing, due to the fact that operations such as:

for pyroot_libs_dir in ${old_rootsys}/lib/python*

were performed both in experimental and current.

In zsh, if a path specified with '*' is not found, an error like the
following is raised:

clean_environment:20: no matches found: zsh_build/lib/python*

and the program aborts, without sourcing anything.

With these change, such loops are performed only if root is built with
pyroot experimental.