### PR TITLE
[RS] Add global config object for RooStats.

### DIFF
--- a/roofit/roostats/inc/RooStats/RooStatsUtils.h
+++ b/roofit/roostats/inc/RooStats/RooStatsUtils.h
@@ -21,7 +21,6 @@
 #include "RooArgSet.h"
 #include "RooRealVar.h"
 #include "RooAbsCollection.h"
-#include "TIterator.h"
 #include "RooStats/ModelConfig.h"
 #include "RooProdPdf.h"
 #include "RooDataSet.h"
@@ -38,7 +37,14 @@ In addition the namespace contain a set of utility functions.
 */
 
 namespace RooStats {
+   struct RooStatsConfig {
+      bool useLikelihoodOffset{false}; /// Offset the likelihood by passing RooFit::Offset to fitTo().
+      bool useEvalErrorWall{true};     /// Use the error wall RooFit::EvalErrorWall to drive the fitter away from disallowed parameter values.
+   };
 
+   /// Retrieve the config object which can be used to set flags for things like offsetting the likelihood
+   /// or using the error wall for the minimiser.
+   RooStatsConfig& GetGlobalRooStatsConfig();
 
    /// returns one-sided significance corresponding to a p-value
    inline Double_t PValueToSignificance(Double_t pvalue){

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -94,9 +94,11 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
       RooArgSet globalObs;
       if (fNullModel->GetGlobalObservables()) globalObs.add(*fNullModel->GetGlobalObservables());
 
+      auto& config = GetGlobalRooStatsConfig();
       RooAbsReal* nll = fNullModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(kFALSE), RooFit::Constrain(*allParams),
                                                         RooFit::GlobalObservables(globalObs),
-                                                        RooFit::ConditionalObservables(conditionalObs), RooFit::Offset(RooStats::IsNLLOffset()) );
+                                                        RooFit::ConditionalObservables(conditionalObs),
+                                                        RooFit::Offset(config.useLikelihoodOffset));
       RooProfileLL* profile = dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance));
       profile->getVal(); // this will do fit and set nuisance parameters to profiled values
 
@@ -201,10 +203,11 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
       RooArgSet globalObs;
       if (fAltModel->GetGlobalObservables()) globalObs.add(*fAltModel->GetGlobalObservables());
 
-
+      const auto& config = GetGlobalRooStatsConfig();
       RooAbsReal* nll = fAltModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(kFALSE), RooFit::Constrain(*allParams),
                                                        RooFit::GlobalObservables(globalObs),
-                                                       RooFit::ConditionalObservables(conditionalObs), RooFit::Offset(RooStats::IsNLLOffset()));
+                                                       RooFit::ConditionalObservables(conditionalObs),
+                                                       RooFit::Offset(config.useLikelihoodOffset));
 
       RooProfileLL* profile = dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance));
       profile->getVal(); // this will do fit and set nuisance parameters to profiled values

--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -253,8 +253,10 @@ bool LikelihoodInterval::CreateMinimizer() {
       }
    }
 
+   const auto& config = GetGlobalRooStatsConfig();
+
    // now do binding of NLL with a functor for Minimizer
-   if (RooStats::IsNLLOffset() ) {
+   if (config.useLikelihoodOffset) {
       ccoutI(InputArguments) << "LikelihoodInterval: using nll offset - set all RooAbsReal to hide the offset  " << std::endl;
       RooAbsReal::setHideOffset(kFALSE); // need to keep this false
    }

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -136,8 +136,9 @@ RooAbsReal *  ProfileLikelihoodCalculator::DoGlobalFit() const {
    if (!constrainedParams) return 0;
    RemoveConstantParameters(constrainedParams);
 
-
-   RooAbsReal * nll = pdf->createNLL(*data, CloneData(true), Constrain(*constrainedParams),ConditionalObservables(fConditionalObs), GlobalObservables(fGlobalObs), Offset(RooStats::IsNLLOffset() ) );
+   const auto& config = GetGlobalRooStatsConfig();
+   RooAbsReal * nll = pdf->createNLL(*data, CloneData(true), Constrain(*constrainedParams),ConditionalObservables(fConditionalObs), GlobalObservables(fGlobalObs),
+       RooFit::Offset(config.useLikelihoodOffset) );
 
    // check if global fit has been already done
    if (fFitResult && fGlobalFitDone) {
@@ -176,11 +177,14 @@ RooFitResult * ProfileLikelihoodCalculator::DoMinimizeNLL(RooAbsReal * nll)  {
    oocoutP((TObject*)0,Minimization) << "ProfileLikelihoodCalcultor::DoMinimizeNLL - using " << minimType << " / " << minimAlgo << " with strategy " << strategy << std::endl;
    // do global fit and store fit result for further use
 
+   const auto& config = GetGlobalRooStatsConfig();
+
    RooMinimizer minim(*nll);
    minim.setStrategy(strategy);
    minim.setEps(tolerance);
    minim.setPrintLevel(level);
    minim.optimizeConst(2); // to optimize likelihood calculations
+   minim.setEvalErrorWall(config.useEvalErrorWall);
 
    int status = -1;
    for (int tries = 1, maxtries = 4; tries <= maxtries; ++tries) {

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -299,8 +299,10 @@ Double_t RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type
 
 RooFitResult* RooStats::ProfileLikelihoodTestStat::GetMinNLL() {
 
+   const auto& config = GetGlobalRooStatsConfig();
    RooMinimizer minim(*fNll);
    minim.setStrategy(fStrategy);
+   minim.setEvalErrorWall(config.useEvalErrorWall);
    //LM: RooMinimizer.setPrintLevel has +1 offset - so subtract  here -1 + an extra -1
    int level = (fPrintLevel == 0) ? -1 : fPrintLevel -2;
    minim.setPrintLevel(level);

--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -27,11 +27,12 @@ NamespaceImp(RooStats)
 
 using namespace std;
 
-// this file is only for the documentation of RooStats namespace
-
 namespace RooStats {
 
-   bool gUseOffset = false;
+   RooStatsConfig& GetGlobalRooStatsConfig() {
+      static RooStatsConfig theConfig;
+      return theConfig;
+   }
 
    Double_t AsimovSignificance(Double_t s, Double_t b, Double_t sigma_b ) {
    // Asimov significance
@@ -55,14 +56,14 @@ namespace RooStats {
       return std::sqrt(za2); 
    }
 
-
+   /// Use an offset in NLL calculations.
    void UseNLLOffset(bool on) {
-      // use offset in NLL calculations
-      gUseOffset = on;
+      GetGlobalRooStatsConfig().useLikelihoodOffset = on;
    }
 
+   /// Test of RooStats should by default offset NLL calculations.
    bool IsNLLOffset() {
-      return gUseOffset;
+      return GetGlobalRooStatsConfig().useLikelihoodOffset;
    }
 
    void FactorizePdf(const RooArgSet &observables, RooAbsPdf &pdf, RooArgList &obsTerms, RooArgList &constraints) {


### PR DESCRIPTION
RooStats was using a global bool to switch on/off offsetting of
likelihoods. Now, this was moved into a function-local static config
struct that now also holds a flag to check if the error wall should be
presented to the minimiser.