### PR TITLE
[RF] Fix reading trees with long branch names.

### DIFF
--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1848,14 +1848,7 @@ TString RooAbsArg::cleanBranchName() const
   cleanName.ReplaceAll("{","L") ;
   cleanName.ReplaceAll("}","R") ;
 
-  if (cleanName.Length()<=60) return cleanName ;
-
-  // Name is too long, truncate and include CRC32 checksum of full name in clean name
-  static char buf[1024] ;
-  strlcpy(buf,cleanName.Data(),1024) ;
-  snprintf(buf+46,1024-46,"_CRC%08x",crc32(cleanName.Data())) ;
-
-  return TString(buf) ;
+  return cleanName;
 }
 
 


### PR DESCRIPTION
[ROOT-10413] In 2001, long branch names in TTrees were apparently not
supported. RooFit was therefore truncating them. Now, this leads to
problems, so the truncation was removed.

(cherry picked from commit 0d5f523b43be0b8a579fa93b6267b849a7243129)