### PR TITLE
[graph] Outline virtual function:

### DIFF
--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -190,8 +190,4 @@ public:
    ClassDef(TGraph,4)  //Graph graphics class
 };
 
-inline Double_t **TGraph::Allocate(Int_t newsize) {
-   return AllocateArrays(2, newsize);
-}
-
 #endif

--- a/hist/hist/inc/TGraphAsymmErrors.h
+++ b/hist/hist/inc/TGraphAsymmErrors.h
@@ -85,8 +85,4 @@ public:
    ClassDef(TGraphAsymmErrors,3)  //A graph with asymmetric error bars
 };
 
-inline Double_t** TGraphAsymmErrors::Allocate(Int_t size) {
-   return AllocateArrays(6, size);
-}
-
 #endif

--- a/hist/hist/inc/TGraphMultiErrors.h
+++ b/hist/hist/inc/TGraphMultiErrors.h
@@ -182,8 +182,4 @@ public:
    ClassDef(TGraphMultiErrors, 1) // A Graph with asymmetric error bars and multiple y error dimensions
 };
 
-inline Double_t **TGraphMultiErrors::Allocate(Int_t size)
-{
-   return AllocateArrays(4, size);
-}
 #endif // ROOT_TGraphMultiErrors

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -525,6 +525,13 @@ TGraph::~TGraph()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Allocate internal data structures for `newsize` points.
+
+Double_t **TGraph::Allocate(Int_t newsize) {
+   return AllocateArrays(2, newsize);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Allocate arrays.
 
 Double_t** TGraph::AllocateArrays(Int_t Narrays, Int_t arraySize)

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -439,6 +439,12 @@ TGraphAsymmErrors::~TGraphAsymmErrors()
    if(fEYhigh) delete [] fEYhigh;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Allocate internal data structures for `size` points.
+
+Double_t** TGraphAsymmErrors::Allocate(Int_t size) {
+   return AllocateArrays(6, size);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Apply a function to all data points `y = f(x,y)`

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -806,6 +806,14 @@ void TGraphMultiErrors::AddYError(Int_t np, const Double_t *eyL, const Double_t 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Allocate internal data structures for `size` points.
+Double_t **TGraphMultiErrors::Allocate(Int_t size)
+{
+   return AllocateArrays(4, size);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Apply a function to all data points `y = f(x,y)`
 ///
 /// Errors are calculated as `eyh = f(x,y+eyh)-f(x,y)` and


### PR DESCRIPTION
Fixes "missing symbol _ZN6TGraph14AllocateArraysEii on non-module builds,
as codegening the vtable required libHist already during TCling startup.