### PR TITLE
[webgui] do install of openui5 libs

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1589,4 +1589,5 @@ if(webgui)
      BUILD_COMMAND ""
      INSTALL_COMMAND ""
      SOURCE_DIR ${CMAKE_BINARY_DIR}/ui5/distribution)
+  install(DIRECTORY ${CMAKE_BINARY_DIR}/ui5/distribution/ DESTINATION ${CMAKE_INSTALL_OPENUI5DIR}/distribution/ COMPONENT libraries FILES_MATCHING PATTERN "*")
 endif()


### PR DESCRIPTION
Problem described here:

https://root-forum.cern.ch/t/root-web-offline-does-not-work/37197

Works for me now.