### PR TITLE
Revert "Pass reference to fstat() in RetryAfterSignal()"

### DIFF
--- a/interpreter/llvm/src/lib/Support/Unix/Process.inc
+++ b/interpreter/llvm/src/lib/Support/Unix/Process.inc
@@ -207,7 +207,7 @@ std::error_code Process::FixupStandardFileDescriptors() {
   for (int StandardFD : StandardFDs) {
     struct stat st;
     errno = 0;
-    if (RetryAfterSignal(-1, &fstat, StandardFD, &st) < 0) {
+    if (RetryAfterSignal(-1, fstat, StandardFD, &st) < 0) {
       assert(errno && "expected errno to be set if fstat failed!");
       // fstat should return EBADF if the file descriptor is closed.
       if (errno != EBADF)


### PR DESCRIPTION
This reverts commit 408075b9e4b27c96f54bd2d1a25eebb1474fc893.
It's unclear why it is needed; this was always passing the address.
Even if this should get proposed for upstream llvm first.