### PR TITLE
Remove dangerous thread-unsafe accessors of RHistConcurrentFiller

### DIFF
--- a/hist/histv7/inc/ROOT/RHistConcurrentFill.hxx
+++ b/hist/histv7/inc/ROOT/RHistConcurrentFill.hxx
@@ -58,9 +58,6 @@ public:
    /// The buffer is full, flush it out.
    void Flush() { fManager.FillN(this->GetCoords(), this->GetWeights()); }
 
-   HIST &GetHist() { return fManager->GetHist(); }
-   operator HIST &() { return GetHist(); }
-
    static constexpr int GetNDim() { return HIST::GetNDim(); }
 };
 


### PR DESCRIPTION
As discussed in [ROOT-10409](https://sft.its.cern.ch/jira/browse/ROOT-10409), these accessors are very dangerous and aren't backed by a clear use case right now. Therefore, @Axel-Naumann and I think it's best to just remove them for now.