### PR TITLE
[cling] Expose ROOTLIBDIR to cling::DynamicLibraryManager:

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1437,7 +1437,13 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
    fClingCallbacks->SetAutoParsingSuspended(fIsAutoParsingSuspended);
    fInterpreter->setCallbacks(std::move(clingCallbacks));
 
-   // We are set up.
+   if (!fromRootCling) {
+      // Make sure cling looks into ROOT's libdir, even if not part of LD_LIBRARY_PATH
+      // e.g. because of an RPATH build.
+      fInterpreter->getDynamicLibraryManager()->addSearchPath(TROOT::GetLibDir().Data());
+   }
+
+   // We are set up. EnableAutoLoading() is checking for fromRootCling.
    EnableAutoLoading();
 }
 

--- a/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
@@ -96,7 +96,7 @@ namespace cling {
     }
 
     void addSearchPath(llvm::StringRef dir) {
-      m_SearchPaths.emplace_back(SearchPathInfo{dir, /*IsUser*/true});
+      m_SearchPaths.emplace_back(SearchPathInfo{dir, /*IsUser*/ true});
     }
 
     ///\brief Looks up a library taking into account the current include paths

--- a/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
@@ -95,6 +95,10 @@ namespace cling {
        return m_SearchPaths;
     }
 
+    void addSearchPath(llvm::StringRef dir) {
+      m_SearchPaths.emplace_back(SearchPathInfo{dir, /*IsUser*/true});
+    }
+
     ///\brief Looks up a library taking into account the current include paths
     /// and the system include paths.
     ///\param[in] libStem - The filename being looked up


### PR DESCRIPTION
DynamicLibraryManager only looks at LD_LIBRARY_PATH and friends, but for install / prefix
builds that might not point to the ROOT library dir. Make it explicit that the
DynamicLibraryManager is supposed to look at the directory containing ROOT libraries.
Fixes install-with-prefix builds with RPATH, that now do not need a fake LD_LIBRARY_PATH
anymore.