### PR TITLE
Fix handling of MinimizerOptions in ROOT::Fit Fitting classes

### DIFF
--- a/math/mathcore/inc/Fit/FitConfig.h
+++ b/math/mathcore/inc/Fit/FitConfig.h
@@ -192,6 +192,10 @@ public:
    */
    const std::string & MinimizerAlgoType() const { return fMinimizerOpts.MinimizerAlgorithm(); }
 
+   /**
+    * return Minimizer full name (type / algorithm)
+    */
+   std::string MinimizerName() const;
 
    /**
       flag to check if resulting errors are be normalized according to chi2/ndf

--- a/math/mathcore/inc/Fit/FitResult.h
+++ b/math/mathcore/inc/Fit/FitResult.h
@@ -339,10 +339,6 @@ protected:
    std::shared_ptr<IModelFunction> ModelFunction()  { return fFitFunc; }
    void SetModelFunction(const std::shared_ptr<IModelFunction> & func) { fFitFunc = func; }
 
-   // set the minimizer type string from FitConfig (Minimizer name / minimizer algo)
-   void SetMinimizerType(const FitConfig & fconfig);
-
-
    friend class Fitter;
 
 

--- a/math/mathcore/src/FitConfig.cxx
+++ b/math/mathcore/src/FitConfig.cxx
@@ -175,10 +175,17 @@ ROOT::Math::Minimizer * FitConfig::CreateMinimizer() {
    // create minimizer according to the chosen configuration using the
    // plug-in manager
 
-   const std::string & minimType = fMinimizerOpts.MinimizerType();
+   // in case of empty string usesd default values
+   if (fMinimizerOpts.MinimizerType().empty())
+      fMinimizerOpts.SetMinimizerType(ROOT::Math::MinimizerOptions::DefaultMinimizerType().c_str());
+   if (fMinimizerOpts.MinimizerAlgorithm().empty())
+      fMinimizerOpts.SetMinimizerAlgorithm(ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo().c_str());
+
+   const std::string &minimType = fMinimizerOpts.MinimizerType();
    const std::string & algoType  = fMinimizerOpts.MinimizerAlgorithm();
 
    std::string  defaultMinim = ROOT::Math::MinimizerOptions::DefaultMinimizerType();
+
    ROOT::Math::Minimizer * min = ROOT::Math::Factory::CreateMinimizer(minimType, algoType);
    // check if a different minimizer is used (in case a default value is passed, then set correctly in FitConfig)
    const std::string & minim_newDefault = ROOT::Math::MinimizerOptions::DefaultMinimizerType();
@@ -228,6 +235,19 @@ ROOT::Math::Minimizer * FitConfig::CreateMinimizer() {
    return min;
 }
 
+std::string FitConfig::MinimizerName() const
+{
+   // set minimizer type
+   std::string name = MinimizerType();
+
+   // append algorithm name for minimizer that support it
+   if ((name.find("Fumili") == std::string::npos) && (name.find("GSLMultiFit") == std::string::npos)) {
+      if (MinimizerAlgoType() != "")
+         name += " / " + MinimizerAlgoType();
+   }
+   return name;
+}
+
 void FitConfig::SetDefaultMinimizer(const char * type, const char *algo ) {
    // set the default minimizer type and algorithms
    ROOT::Math::MinimizerOptions::SetDefaultMinimizer(type, algo);
@@ -249,4 +269,3 @@ std::vector<double> FitConfig::ParamsValues() const {
    } // end namespace Fit
 
 } // end namespace ROOT
-

--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -116,7 +116,7 @@ void FitResult::FillResult(const std::shared_ptr<ROOT::Math::Minimizer> & min, c
    fMinimizer= min;
    fFitFunc = func;
 
-   SetMinimizerType(fconfig);
+   fMinimType = fconfig.MinimizerName();
 
    // replace ncalls if minimizer does not support it (they are taken then from the FitMethodFunction)
    if (fNCalls == 0) fNCalls = ncalls;
@@ -223,18 +223,6 @@ void FitResult::FillResult(const std::shared_ptr<ROOT::Math::Minimizer> & min, c
 
 }
 
-void FitResult::SetMinimizerType(const FitConfig & fconfig) { 
-   // set minimizer type
-   fMinimType = fconfig.MinimizerType();
-
-   // append algorithm name for minimizer that support it
-   if ( (fMinimType.find("Fumili") == std::string::npos) &&
-        (fMinimType.find("GSLMultiFit") == std::string::npos)
-      ) {
-      if (fconfig.MinimizerAlgoType() != "") fMinimType += " / " + fconfig.MinimizerAlgoType();
-   }
-}
-
 FitResult::~FitResult() {
    // destructor. FitResult manages the fit Function pointer
    //if (fFitFunc) delete fFitFunc;
@@ -297,7 +285,7 @@ bool FitResult::Update(const std::shared_ptr<ROOT::Math::Minimizer> & min, const
    fMinimizer = min;
 
    // in case minimizer changes
-   SetMinimizerType(fconfig);
+   fMinimType = fconfig.MinimizerName();
 
    const unsigned int npar = fParams.size();
    if (min->NDim() != npar ) {
@@ -745,4 +733,3 @@ bool FitResult::Contour(unsigned int ipar, unsigned int jpar, unsigned int &npoi
    } // end namespace Fit
 
 } // end namespace ROOT
-

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -852,17 +852,17 @@ bool Fitter::DoUpdateMinimizerOptions(bool canDifferentMinim ) {
 
    // create a new minimizer if it is different type
    // minimizer type string stored in FitResult is "minimizer name" + " / " + minimizer algo
-   std::string newMinimType = fConfig.MinimizerType() + " / " + fConfig.MinimizerAlgoType(); 
-   if (fMinimizer && fResult && newMinimType != fResult->MinimizerType() ) {
+   std::string newMinimType = fConfig.MinimizerName();
+   if (fMinimizer && fResult && newMinimType != fResult->MinimizerType()) {
       // if a different minimizer is allowed (e.g. when calling Hesse)
-      if (canDifferentMinim) { 
-         std::string msg = "Using now " + newMinimType; 
-         MATH_INFO_MSG("Fitter::DoUpdateMinimizerOptions", msg.c_str());
+      if (canDifferentMinim) {
+         std::string msg = "Using now " + newMinimType;
+         MATH_INFO_MSG("Fitter::DoUpdateMinimizerOptions: ", msg.c_str());
          if (!DoInitMinimizer() )
             return false;
       }
-      else { 
-         std::string msg = "Cannot change minimizer. Continue using " + fResult->MinimizerType();   
+      else {
+         std::string msg = "Cannot change minimizer. Continue using " + fResult->MinimizerType();
          MATH_WARN_MSG("Fitter::DoUpdateMinimizerOptions",msg.c_str());
       }
    }


### PR DESCRIPTION
New fix for the minimizer options. Set correctly the name when using the default algorithm (Migrad) in Minuit

Fix when running Hesse to not re-initialize fully the minimizer which will start with different step sizes.
The re-initialization was caused by a bug in handling the full name. Fix this by adding a new function : FitConfig::MinimizerName()