### PR TITLE
[Cling] Enable tarball-tag flag to build cling using LLVM binary release.

### DIFF
--- a/interpreter/cling/tools/packaging/cpt.py
+++ b/interpreter/cling/tools/packaging/cpt.py
@@ -2437,8 +2437,14 @@ if args['tarball_tag']:
         "https://raw.githubusercontent.com/root-project/cling/%s/LastKnownGoodLLVMSVNRevision.txt" % args[
             'tarball_tag']).readline().strip().decode(
         'utf-8')
-    fetch_llvm(llvm_revision)
-    fetch_clang(llvm_revision)
+    if is_llvm_binary_compatible() and args["with_binary_llvm"]:
+        compile = compile_for_binary
+        install_prefix = install_prefix_for_binary
+        fetch_clang(llvm_revision)
+        allow_clang_tool()
+    else:
+        fetch_llvm(llvm_revision)
+        fetch_clang(llvm_revision)
     fetch_cling(args['tarball_tag'])
 
     set_version()
@@ -2455,6 +2461,8 @@ if args['tarball_tag']:
 
     install_prefix()
     if not args['no_test']:
+        if is_llvm_binary_compatible() and args['with_binary_llvm']:
+            build_filecheck()
         test_cling()
     tarball()
     cleanup()


### PR DESCRIPTION
Fixes Cling's nightly releases sync test.