### PR TITLE
[tcling] Improve symbol resolution.

### DIFF
--- a/README/CREDITS
+++ b/README/CREDITS
@@ -776,6 +776,11 @@ N: Iulia Pasov
 E: iulia.pasov@gmail.com
 D: prototyping JavaScript graphics with d3.js
 
+N: Alexander Penev
+E: alexander_penev@yahoo.com
+D: Dyld symbol resolution facilities in cling and TCling
+D: runtime c++ modules on osx
+
 N: Marc Paterno
 E: paterno@fnal.gov
 D: implement utility functions used by TGraphAsymmErrors::BayesDivide

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -34,6 +34,8 @@
 
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Object/ObjectFile.h"
+
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 
@@ -74,9 +76,6 @@ extern "C" {
    void TCling__RestoreInterpreterMutex(void *state);
    void *TCling__LockCompilationDuringUserCodeExecution();
    void TCling__UnlockCompilationDuringUserCodeExecution(void *state);
-   void TCling__FindLoadedLibraries(std::vector<std::pair<uint32_t, std::string>> &sLibraries,
-                                    std::vector<std::string> &sPaths,
-                                    cling::Interpreter &interpreter, bool searchSystem);
 }
 
 TClingCallbacks::TClingCallbacks(cling::Interpreter *interp, bool hasCodeGen) : InterpreterCallbacks(interp)
@@ -920,104 +919,4 @@ void *TClingCallbacks::LockCompilationDuringUserCodeExecution()
 void TClingCallbacks::UnlockCompilationDuringUserCodeExecution(void *StateInfo)
 {
    TCling__UnlockCompilationDuringUserCodeExecution(StateInfo);
-}
-
-static bool shouldIgnore(const std::string& FileName,
-                         const cling::DynamicLibraryManager& dyLibManager) {
-   if (llvm::sys::fs::is_directory(FileName))
-     return true;
-
-   if (!cling::DynamicLibraryManager::isSharedLibrary(FileName))
-     return true;
-
-   // No need to check linked libraries, as this function is only invoked
-   // for symbols that cannot be found (neither by dlsym nor in the JIT).
-   if (dyLibManager.isLibraryLoaded(FileName.c_str()))
-      return true;
-
-
-   auto ObjF = llvm::object::ObjectFile::createObjectFile(FileName);
-   if (!ObjF) {
-      if (gDebug > 1)
-         ROOT::TMetaUtils::Warning("[DyLD]", "Failed to read object file %s",
-                                   FileName.c_str());
-      return true;
-   }
-
-   llvm::object::ObjectFile *file = ObjF.get().getBinary();
-
-   if (isa<llvm::object::ELFObjectFileBase>(*file)) {
-      for (auto S : file->sections()) {
-         StringRef name;
-         S.getName(name);
-         if (name == ".text") {
-            // Check if the library has only debug symbols, usually when
-            // stripped with objcopy --only-keep-debug. This check is done by
-            // reading the manual of objcopy and inspection of stripped with
-            // objcopy libraries.
-            auto SecRef = static_cast<llvm::object::ELFSectionRef&>(S);
-            if (SecRef.getType() == llvm::ELF::SHT_NOBITS)
-               return true;
-
-            return (SecRef.getFlags() & llvm::ELF::SHF_ALLOC) == 0;
-         }
-      }
-      return true;
-   }
-   //FIXME: Handle osx using isStripped after upgrading to llvm9.
-
-   llvm::StringRef fileStem = llvm::sys::path::stem(FileName);
-   return fileStem.startswith("libNew") || fileStem.startswith("libcppyy_backend");
-}
-
-static void SearchAndAddPath(const std::string& Path,
-      std::vector<std::pair<uint32_t, std::string>> &sLibraries, std::vector<std::string> &sPaths,
-      std::unordered_set<std::string>& alreadyLookedPath, cling::DynamicLibraryManager* dyLibManager)
-{
-   // Already searched?
-   auto it = alreadyLookedPath.insert(Path);
-   if (!it.second)
-      return;
-   StringRef DirPath(Path);
-   if (!llvm::sys::fs::is_directory(DirPath))
-      return;
-
-   bool flag = false;
-   std::error_code EC;
-   for (llvm::sys::fs::directory_iterator DirIt(DirPath, EC), DirEnd;
-         DirIt != DirEnd && !EC; DirIt.increment(EC)) {
-
-      std::string FileName(DirIt->path());
-      if (shouldIgnore(FileName, *dyLibManager))
-         continue;
-
-      sLibraries.push_back(std::make_pair(sPaths.size(), llvm::sys::path::filename(FileName)));
-      flag = true;
-   }
-
-   if (flag)
-      sPaths.push_back(Path);
-}
-
-// Extracted here to circumvent ODR clash between
-// std::Sp_counted_ptr_inplace<llvm::sys::fs::detail::DirIterState, std::allocator<llvm::sys::fs::detail::DirIterState>, (_gnu_cxx::_Lock_policy)2>::_M_get_deleter(std::type_info const&)
-// coming from a no-rtti and a rtti build in libstdc++ from GCC >= 8.1.
-// In its function body, rtti uses `arg0 == typeid(...)` protected by #ifdef __cpp_rtti. Depending
-// on which symbol (with or without rtti) the linker picks up, the argument `arg0` is a valid
-// type_info - or not, in which case this comparison crashes.
-// Circumvent this by removing the rtti-use of this function:
-void TCling__FindLoadedLibraries(std::vector<std::pair<uint32_t, std::string>> &sLibraries,
-                                 std::vector<std::string> &sPaths,
-                                 cling::Interpreter &interpreter, bool searchSystem)
-{
-   // Store the information of path so that we don't have to iterate over the same path again and again.
-   static std::unordered_set<std::string> alreadyLookedPath;
-   cling::DynamicLibraryManager* dyLibManager = interpreter.getDynamicLibraryManager();
-
-   const auto &searchPaths = dyLibManager->getSearchPath();
-   for (const cling::DynamicLibraryManager::SearchPathInfo &Info : searchPaths) {
-      if (!Info.IsUser && !searchSystem)
-         continue;
-      SearchAndAddPath(Info.Path, sLibraries, sPaths, alreadyLookedPath, dyLibManager);
-   }
 }

--- a/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
@@ -11,6 +11,7 @@
 #define CLING_DYNAMIC_LIBRARY_MANAGER_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 
@@ -43,7 +44,12 @@ namespace cling {
       /// True if the Path is on the LD_LIBRARY_PATH.
       ///
       bool IsUser;
+
+      bool operator==(const SearchPathInfo& Other) const {
+        return IsUser == Other.IsUser && Path == Other.Path;
+      }
     };
+    using SearchPathInfos = llvm::SmallVector<SearchPathInfo, 32>;
   private:
     typedef const void* DyLibHandle;
     typedef llvm::DenseMap<DyLibHandle, std::string> DyLibs;
@@ -58,7 +64,7 @@ namespace cling {
 
     ///\brief System's include path, get initialized at construction time.
     ///
-    llvm::SmallVector<SearchPathInfo, 32> m_SearchPaths;
+    SearchPathInfos m_SearchPaths;
 
     InterpreterCallbacks* m_Callbacks;
 
@@ -80,6 +86,11 @@ namespace cling {
     ///\returns the canonical path to the file or empty string if not found
     ///
     std::string lookupLibMaybeAddExt(llvm::StringRef filename) const;
+
+    /// On a success returns to full path to a shared object that holds the
+    /// symbol pointed by func.
+    ///
+    static std::string getSymbolLocation(void* func);
   public:
     DynamicLibraryManager(const InvocationOptions& Opts);
     ~DynamicLibraryManager();
@@ -91,7 +102,7 @@ namespace cling {
     ///
     ///\returns System include paths.
     ///
-    const llvm::SmallVectorImpl<SearchPathInfo>& getSearchPath() {
+    const SearchPathInfos& getSearchPaths() const {
        return m_SearchPaths;
     }
 
@@ -128,6 +139,26 @@ namespace cling {
     ///
     bool isLibraryLoaded(llvm::StringRef fullPath) const;
 
+    /// Initialize the dyld.
+    ///
+    ///\param [in] shouldPermanentlyIgnore - a callback deciding if a library
+    ///            should be ignored from the result set. Useful for ignoring
+    ///            dangerous libraries such as the ones overriding malloc.
+    ///
+    void
+    initializeDyld(std::function<bool(llvm::StringRef)> shouldPermanentlyIgnore)
+      const;
+
+    /// Find the first not-yet-loaded shared object that contains the symbol
+    ///
+    ///\param[in] mangledName - the mangled name to look for.
+    ///\param[in] searchSystem - whether to decend into system libraries.
+    ///
+    ///\returns the library name if found, and empty string otherwise.
+    ///
+    std::string searchLibrariesForSymbol(const std::string& mangledName,
+                                         bool searchSystem = true) const;
+
     ///\brief Explicitly tell the execution engine to use symbols from
     ///       a shared library that would otherwise not be used for symbol
     ///       resolution, e.g. because it was dlopened with RTLD_LOCAL.
@@ -145,6 +176,15 @@ namespace cling {
     ///            is a library but of incompatible file format.
     ///
     static bool isSharedLibrary(llvm::StringRef libFullPath, bool* exists = 0);
+
+    /// On a success returns to full path to a shared object that holds the
+    /// symbol pointed by func.
+    ///
+    template <class T>
+    static std::string getSymbolLocation(T func) {
+      static_assert(std::is_pointer<T>::value, "Must be a function pointer!");
+      return getSymbolLocation(reinterpret_cast<void*>(func));
+    }
   };
 } // end namespace cling
 #endif // CLING_DYNAMIC_LIBRARY_MANAGER_H

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -76,6 +76,7 @@ add_cling_library(clingInterpreter OBJECT
   DeclUnloader.cpp
   DeviceKernelInliner.cpp
   DynamicLibraryManager.cpp
+  DynamicLibraryManagerSymbol.cpp
   DynamicLookup.cpp
   DynamicExprInfo.cpp
   Exception.cpp

--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -1,0 +1,961 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:  Vassil Vassilev <vvasilev@cern.ch>
+// author:  Alexander Penev <alexander_penev@yahoo.com>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#include "cling/Interpreter/DynamicLibraryManager.h"
+#include "cling/Utils/Output.h"
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/DynamicLibrary.h"
+#include "llvm/Support/Path.h"
+
+#include <algorithm>
+#include <list>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "llvm/Config/config.h" // Get configuration settings
+
+#if defined(HAVE_DLFCN_H) && defined(HAVE_DLOPEN)
+#include <dlfcn.h>
+#endif
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif // HAVE_UNISTD_H
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif // __APPLE__
+
+#ifdef LLVM_ON_WIN32
+#include <libloaderapi.h> // For GetModuleFileNameA
+#include <memoryapi.h> // For VirtualQuery
+#endif
+
+// FIXME: Implement debugging output stream in cling.
+constexpr unsigned DEBUG = 0;
+
+namespace {
+
+using BasePath = std::string;
+
+// This is a GNU implementation of hash used in bloom filter!
+static uint32_t GNUHash(llvm::StringRef S) {
+  uint32_t H = 5381;
+  for (uint8_t C : S)
+    H = (H << 5) + H + C;
+  return H;
+}
+
+constexpr uint32_t log2u(std::uint32_t n) {
+  return (n > 1) ? 1 + log2u(n >> 1) : 0;
+}
+
+struct BloomFilter {
+
+  // https://hur.st/bloomfilter
+  //
+  // n = ceil(m / (-k / log(1 - exp(log(p) / k))))
+  // p = pow(1 - exp(-k / (m / n)), k)
+  // m = ceil((n * log(p)) / log(1 / pow(2, log(2))));
+  // k = round((m / n) * log(2));
+  //
+  // n = symbolsCount
+  // p = 0.02
+  // k = 2 (k1=GNUHash and k2=GNUHash >> bloomShift)
+  // m = ceil((symbolsCount * log(p)) / log(1 / pow(2, log(2))));
+  // bloomShift = min(5 for bits=32 or 6 for bits=64, log2(symbolsCount))
+  // bloomSize = ceil((-1.44 * n * log2f(p)) / bits)
+
+  const int m_Bits = 8 * sizeof(uint64_t);
+  const float m_P = 0.02;
+
+  bool m_IsInitialized = false;
+  uint32_t m_SymbolsCount = 0;
+  uint32_t m_BloomSize = 0;
+  uint32_t m_BloomShift = 0;
+  std::vector<uint64_t> m_BloomTable;
+
+  bool TestHash(uint32_t hash) const {
+    // This function is superhot. No branches here, breaks inlining and makes
+    // overall performance around 4x slower.
+    assert(m_IsInitialized && "Not yet initialized!");
+    uint32_t hash2 = hash >> m_BloomShift;
+    uint32_t n = (hash >> log2u(m_Bits)) % m_BloomSize;
+    uint64_t mask = ((1ULL << (hash % m_Bits)) | (1ULL << (hash2 % m_Bits)));
+    return (mask & m_BloomTable[n]) == mask;
+  }
+
+  void AddHash(uint32_t hash) {
+    assert(m_IsInitialized && "Not yet initialized!");
+    uint32_t hash2 = hash >> m_BloomShift;
+    uint32_t n = (hash >> log2u(m_Bits)) % m_BloomSize;
+    uint64_t mask = ((1ULL << (hash % m_Bits)) | (1ULL << (hash2 % m_Bits)));
+    m_BloomTable[n] |= mask;
+  }
+
+  void ResizeTable(uint32_t newSymbolsCount) {
+    assert(m_SymbolsCount == 0 && "Not supported yet!");
+    m_SymbolsCount = newSymbolsCount;
+    m_BloomSize = ceil((-1.44f * m_SymbolsCount * log2f(m_P)) / m_Bits);
+    m_BloomShift = std::min(6u, log2u(m_SymbolsCount));
+    m_BloomTable.resize(m_BloomSize);
+  }
+
+};
+
+
+/// An efficient representation of a full path to a library which does not
+/// duplicate common path patterns reducing the overall memory footprint.
+///
+/// For example, `/home/.../lib/libA.so`, m_Path will contain a pointer
+/// to  `/home/.../lib/`
+/// will be stored and .second `libA.so`.
+/// This approach reduces the duplicate paths as at one location there may be
+/// plenty of libraries.
+struct LibraryPath {
+  const BasePath& m_Path;
+  std::string m_LibName;
+  BloomFilter m_Filter;
+  llvm::StringSet<> m_Symbols;
+
+  LibraryPath(const BasePath& Path, const std::string& LibName)
+    : m_Path(Path), m_LibName(LibName) { }
+
+  bool operator==(const LibraryPath &other) const {
+    return (&m_Path == &other.m_Path || m_Path == other.m_Path) &&
+      m_LibName == other.m_LibName;
+  }
+
+  std::string GetFullName() const {
+    llvm::SmallString<512> Vec(m_Path);
+    llvm::sys::path::append(Vec, llvm::StringRef(m_LibName));
+    return Vec.str().str();
+  }
+
+  void AddBloom(llvm::StringRef symbol) {
+    m_Filter.AddHash(GNUHash(symbol));
+  }
+
+  llvm::StringRef AddSymbol(const std::string& symbol) {
+    auto it = m_Symbols.insert(symbol);
+    return it.first->getKey();
+  }
+
+  bool isBloomFilterEmpty() const {
+    assert(m_Filter.m_IsInitialized && "Bloom filter not initialized!");
+    return m_Filter.m_SymbolsCount == 0;
+  }
+
+  void InitializeBloomFilter(uint32_t newSymbolsCount) {
+    assert(isBloomFilterEmpty() && "Cannot re-initialize non-empty filter!");
+    assert(!m_Filter.m_IsInitialized &&
+           "Cannot re-initialize non-empty filter!");
+    m_Filter.m_IsInitialized = true;
+    m_Filter.ResizeTable(newSymbolsCount);
+  }
+
+  bool MayExistSymbol(uint32_t hash) const {
+    // The library had no symbols and the bloom filter is empty.
+    if (isBloomFilterEmpty())
+      return false;
+
+    return m_Filter.TestHash(hash);
+  }
+
+  bool ExistSymbol(llvm::StringRef symbol) const {
+    return m_Symbols.find(symbol) != m_Symbols.end();
+  }
+};
+
+
+/// A helper class keeping track of loaded libraries. It implements a fast
+/// search O(1) while keeping deterministic iterability in a memory efficient
+/// way. The underlying set uses a custom hasher for better efficiency given the
+/// specific problem where the library names (m_LibName) are relatively short
+/// strings and the base paths (m_Path) are repetitive long strings.
+class LibraryPaths {
+  struct LibraryPathHashFn {
+    size_t operator()(const LibraryPath& item) const {
+      return std::hash<size_t>()(item.m_Path.length()) ^
+        std::hash<std::string>()(item.m_LibName);
+    }
+  };
+
+  std::vector<const LibraryPath*> m_Libs;
+  std::unordered_set<LibraryPath, LibraryPathHashFn> m_LibsH;
+public:
+  bool HasRegisteredLib(const LibraryPath& Lib) const {
+    return m_LibsH.count(Lib);
+  }
+
+  void RegisterLib(const LibraryPath& Lib) {
+    auto it = m_LibsH.insert(Lib);
+    assert(it.second && "Already registered!");
+    m_Libs.push_back(&*it.first);
+  }
+
+  void UnregisterLib(const LibraryPath& Lib) {
+    auto found = m_LibsH.find(Lib);
+    if (found == m_LibsH.end())
+      return;
+
+    m_Libs.erase(std::find(m_Libs.begin(), m_Libs.end(), &*found));
+    m_LibsH.erase(found);
+  }
+
+  size_t size() const {
+    assert(m_Libs.size() == m_LibsH.size());
+    return m_Libs.size();
+  }
+
+  const std::vector<const LibraryPath*>& GetLibraries() const {
+    return m_Libs;
+  }
+};
+
+class Dyld {
+
+  struct BasePathHashFunction {
+    size_t operator()(const BasePath& item) const {
+      return std::hash<std::string>()(item);
+    }
+  };
+
+  struct BasePathEqFunction {
+    size_t operator()(const BasePath& l, const BasePath& r) const {
+      return &l == &r || l == r;
+    }
+  };
+  /// A memory efficient llvm::VectorSet. The class provides O(1) search
+  /// complexity. It is tuned to compare BasePaths first by checking the
+  /// address and then the representation which models the base path reuse.
+  class BasePaths {
+    std::unordered_set<BasePath, BasePathHashFunction,
+                       BasePathEqFunction> m_Paths;
+
+  public:
+    const BasePath& RegisterBasePath(const std::string& Path,
+                                     bool* WasInserted = nullptr) {
+      auto it = m_Paths.insert(Path);
+      if (WasInserted)
+        *WasInserted = it.second;
+
+      return *it.first;
+    }
+
+    bool Contains (const std::string& Path) {
+      return m_Paths.count(Path);
+    }
+  };
+
+  bool m_FirstRun = true;
+  bool m_FirstRunSysLib = true;
+  bool m_UseBloomFilter = true;
+  bool m_UseHashTable = true;
+
+  const cling::DynamicLibraryManager& m_DynamicLibraryManager;
+
+  /// The basename of `/home/.../lib/libA.so`,
+  /// m_BasePaths will contain `/home/.../lib/`
+  BasePaths m_BasePaths;
+
+  LibraryPaths m_Libraries;
+  LibraryPaths m_SysLibraries;
+  /// Contains a set of libraries which we gave to the user via ResolveSymbol
+  /// call and next time we should check if the user loaded them to avoid
+  /// useless iterations.
+  std::vector<LibraryPath> m_QueriedLibraries;
+
+  /// Scan for shared objects which are not yet loaded. They are a our symbol
+  /// resolution candidate sources.
+  /// NOTE: We only scan not loaded shared objects.
+  /// \param[in] searchSystemLibraries - whether to decent to standard system
+  ///            locations for shared objects.
+  void ScanForLibraries(bool searchSystemLibraries = false);
+
+  /// Builds a bloom filter lookup optimization.
+  void BuildBloomFilter(LibraryPath* Lib, llvm::object::ObjectFile *BinObjFile,
+                        unsigned IgnoreSymbolFlags = 0) const;
+
+
+  /// Looks up symbols from a an object file, representing the library.
+  ///\param[in] Lib - full path to the library.
+  ///\param[in] mangledName - the mangled name to look for.
+  ///\param[in] IgnoreSymbolFlags - The symbols to ignore upon a match.
+  ///\returns true on success.
+  bool ContainsSymbol(const LibraryPath* Lib, const std::string &mangledName,
+                      unsigned IgnoreSymbolFlags = 0) const;
+
+protected:
+  Dyld(const cling::DynamicLibraryManager &DLM)
+    : m_DynamicLibraryManager(DLM) { }
+
+  ~Dyld() = default;
+
+public:
+  static Dyld& getInstance(const cling::DynamicLibraryManager &DLM) {
+    static Dyld instance(DLM);
+
+#ifndef NDEBUG
+    auto &NewSearchPaths = DLM.getSearchPaths();
+    auto &OldSearchPaths = instance.m_DynamicLibraryManager.getSearchPaths();
+    // FIXME: Move the Dyld logic to the cling::DynamicLibraryManager itself!
+    assert(std::equal(OldSearchPaths.begin(), OldSearchPaths.end(),
+                      NewSearchPaths.begin()) && "Path was added/removed!");
+#endif
+
+    return instance;
+  }
+
+  // delete copy and move constructors and assign operators
+  Dyld(Dyld const&) = delete;
+  Dyld(Dyld&&) = delete;
+  Dyld& operator=(Dyld const&) = delete;
+  Dyld& operator=(Dyld &&) = delete;
+
+  std::string searchLibrariesForSymbol(const std::string& mangledName,
+                                       bool searchSystem);
+};
+
+
+static bool s_IsDyldInitialized = false;
+static std::function<bool(llvm::StringRef)> s_ShouldPermanentlyIgnoreCallback;
+
+
+static std::string getRealPath(llvm::StringRef path) {
+  llvm::SmallString<512> realPath;
+  llvm::sys::fs::real_path(path, realPath, /*expandTilde*/true);
+  return realPath.str().str();
+}
+
+static llvm::StringRef s_ExecutableFormat;
+
+static bool shouldPermanentlyIgnore(const std::string& FileName,
+                            const cling::DynamicLibraryManager& dyLibManager) {
+  assert(FileName == getRealPath(FileName));
+  assert(!s_ExecutableFormat.empty() && "Failed to find the object format!");
+
+  if (llvm::sys::fs::is_directory(FileName))
+    return true;
+
+  if (!cling::DynamicLibraryManager::isSharedLibrary(FileName))
+    return true;
+
+  // No need to check linked libraries, as this function is only invoked
+  // for symbols that cannot be found (neither by dlsym nor in the JIT).
+  if (dyLibManager.isLibraryLoaded(FileName.c_str()))
+    return true;
+
+
+  auto ObjF = llvm::object::ObjectFile::createObjectFile(FileName);
+  if (!ObjF) {
+    if (DEBUG > 1)
+      cling::errs() << "[DyLD] Failed to read object file "
+                    << FileName << "\n";
+    return true;
+  }
+
+  llvm::object::ObjectFile *file = ObjF.get().getBinary();
+
+  if (DEBUG > 1)
+     cling::errs() << "Current executable format: " << s_ExecutableFormat
+                   << ". Executable format of " << FileName << " : "
+                   << file->getFileFormatName() << "\n";
+
+  // Ignore libraries with different format than the executing one.
+  if (s_ExecutableFormat != file->getFileFormatName())
+    return true;
+
+  if (llvm::isa<llvm::object::ELFObjectFileBase>(*file)) {
+    for (auto S : file->sections()) {
+      llvm::StringRef name;
+      S.getName(name);
+      if (name == ".text") {
+        // Check if the library has only debug symbols, usually when
+        // stripped with objcopy --only-keep-debug. This check is done by
+        // reading the manual of objcopy and inspection of stripped with
+        // objcopy libraries.
+        auto SecRef = static_cast<llvm::object::ELFSectionRef&>(S);
+        if (SecRef.getType() == llvm::ELF::SHT_NOBITS)
+          return true;
+
+        return (SecRef.getFlags() & llvm::ELF::SHF_ALLOC) == 0;
+      }
+    }
+    return true;
+  }
+
+  //FIXME: Handle osx using isStripped after upgrading to llvm9.
+
+  return s_ShouldPermanentlyIgnoreCallback(FileName);
+}
+
+void Dyld::ScanForLibraries(bool searchSystemLibraries/* = false*/) {
+
+  // #ifndef NDEBUG
+  //   if (!m_FirstRun && !m_FirstRunSysLib)
+  //     assert(0 && "Already initialized");
+  //   if (m_FirstRun && !m_Libraries->size())
+  //     assert(0 && "Not initialized but m_Libraries is non-empty!");
+  //   // assert((m_FirstRun || m_FirstRunSysLib) && (m_Libraries->size() ||
+  //             m_SysLibraries.size())
+  //   //        && "Already scanned and initialized!");
+  // #endif
+
+  const auto &searchPaths = m_DynamicLibraryManager.getSearchPaths();
+  for (const cling::DynamicLibraryManager::SearchPathInfo &Info : searchPaths) {
+    if (Info.IsUser || searchSystemLibraries) {
+      // Examples which we should handle.
+      // File                      Real
+      // /lib/1/1.so               /lib/1/1.so  // file
+      // /lib/1/2.so->/lib/1/1.so  /lib/1/1.so  // file local link
+      // /lib/1/3.so->/lib/3/1.so  /lib/3/1.so  // file external link
+      // /lib/2->/lib/1                         // path link
+      // /lib/2/1.so               /lib/1/1.so  // path link, file
+      // /lib/2/2.so->/lib/1/1.so  /lib/1/1.so  // path link, file local link
+      // /lib/2/3.so->/lib/3/1.so  /lib/3/1.so  // path link, file external link
+      //
+      // /lib/3/1.so
+      // /lib/3/2.so->/system/lib/s.so
+      // /lib/3/3.so
+      // /system/lib/1.so
+      //
+      // Paths = /lib/1 : /lib/2 : /lib/3
+
+      // m_BasePaths = ["/lib/1", "/lib/3", "/system/lib"]
+      // m_*Libraries  = [<0,"1.so">, <1,"1.so">, <2,"s.so">, <1,"3.so">]
+      std::string RealPath = getRealPath(Info.Path);
+      llvm::StringRef DirPath(RealPath);
+
+      if (!llvm::sys::fs::is_directory(DirPath) || DirPath.empty())
+        continue;
+
+      // Already searched?
+      bool WasInserted;
+      m_BasePaths.RegisterBasePath(RealPath, &WasInserted);
+
+      if (!WasInserted)
+        continue;
+
+      std::error_code EC;
+      for (llvm::sys::fs::directory_iterator DirIt(DirPath, EC), DirEnd;
+           DirIt != DirEnd && !EC; DirIt.increment(EC)) {
+
+        // FIXME: Use a StringRef here!
+        std::string FileName = getRealPath(DirIt->path());
+        assert(!llvm::sys::fs::is_symlink_file(FileName));
+
+        if (shouldPermanentlyIgnore(FileName, m_DynamicLibraryManager))
+          continue;
+
+        std::string FileRealPath = llvm::sys::path::parent_path(FileName);
+        FileName = llvm::sys::path::filename(FileName);
+        const BasePath& BaseP = m_BasePaths.RegisterBasePath(FileRealPath);
+        LibraryPath LibPath(BaseP, FileName);
+        if (m_SysLibraries.HasRegisteredLib(LibPath) ||
+            m_Libraries.HasRegisteredLib(LibPath))
+          continue;
+
+        if (searchSystemLibraries)
+          m_SysLibraries.RegisterLib(LibPath);
+        else
+          m_Libraries.RegisterLib(LibPath);
+      }
+    }
+  }
+}
+
+void Dyld::BuildBloomFilter(LibraryPath* Lib,
+                            llvm::object::ObjectFile *BinObjFile,
+                            unsigned IgnoreSymbolFlags /*= 0*/) const {
+  assert(m_UseBloomFilter && "Bloom filter is disabled");
+  assert(Lib->isBloomFilterEmpty() && "Already built!");
+
+  using namespace llvm;
+  using namespace llvm::object;
+
+  // If BloomFilter is empty then build it.
+  // Count Symbols and generate BloomFilter
+  uint32_t SymbolsCount = 0;
+  std::list<std::string> symbols;
+  for (const llvm::object::SymbolRef &S : BinObjFile->symbols()) {
+    uint32_t Flags = S.getFlags();
+    // Do not insert in the table symbols flagged to ignore.
+    if (Flags & IgnoreSymbolFlags)
+      continue;
+
+    // Note, we are at last resort and loading library based on a weak
+    // symbol is allowed. Otherwise, the JIT will issue an unresolved
+    // symbol error.
+    //
+    // There are other weak symbol kinds (marked as 'V') to denote
+    // typeinfo and vtables. It is unclear whether we should load such
+    // libraries or from which library we should resolve the symbol.
+    // We seem to not have a way to differentiate it from the symbol API.
+
+    llvm::Expected<llvm::StringRef> SymNameErr = S.getName();
+    if (!SymNameErr) {
+      cling::errs()<< "Dyld::BuildBloomFilter: Failed to read symbol "
+                   << SymNameErr.get() << "\n";
+      continue;
+    }
+
+    if (SymNameErr.get().empty())
+      continue;
+
+    ++SymbolsCount;
+    symbols.push_back(SymNameErr.get());
+  }
+
+  if (BinObjFile->isELF()) {
+    // ELF file format has .dynstr section for the dynamic symbol table.
+    const auto *ElfObj = cast<llvm::object::ELFObjectFileBase>(BinObjFile);
+
+    for (const object::SymbolRef &S : ElfObj->getDynamicSymbolIterators()) {
+      uint32_t Flags = S.getFlags();
+      // DO NOT insert to table if symbol was undefined
+      if (Flags & llvm::object::SymbolRef::SF_Undefined)
+        continue;
+
+      // Note, we are at last resort and loading library based on a weak
+      // symbol is allowed. Otherwise, the JIT will issue an unresolved
+      // symbol error.
+      //
+      // There are other weak symbol kinds (marked as 'V') to denote
+      // typeinfo and vtables. It is unclear whether we should load such
+      // libraries or from which library we should resolve the symbol.
+      // We seem to not have a way to differentiate it from the symbol API.
+
+      llvm::Expected<StringRef> SymNameErr = S.getName();
+      if (!SymNameErr) {
+        cling::errs() << "Dyld::BuildBloomFilter: Failed to read symbol "
+                      <<SymNameErr.get() << "\n";
+        continue;
+      }
+
+      if (SymNameErr.get().empty())
+        continue;
+
+      ++SymbolsCount;
+      symbols.push_back(SymNameErr.get());
+    }
+  }
+
+  if (!SymbolsCount) {
+     if (DEBUG > 7)
+        cling::errs() << "Dyld::BuildBloomFilter: No symbols!\n";
+     return;
+  }
+
+  if (DEBUG > 7) {
+    cling::errs() << "Dyld::BuildBloomFilter: Symbols:\n";
+    for (auto it : symbols)
+      cling::errs() << "Dyld::BuildBloomFilter" <<  "- " <<  it << "\n";
+  }
+
+  Lib->InitializeBloomFilter(SymbolsCount);
+  // Generate BloomFilter
+  for (const auto &S : symbols) {
+    if (m_UseHashTable)
+      Lib->AddBloom(Lib->AddSymbol(S));
+    else
+      Lib->AddBloom(S);
+  }
+}
+
+
+static llvm::StringRef GetGnuHashSection(llvm::object::ObjectFile *file) {
+  for (auto S : file->sections()) {
+    llvm::StringRef name;
+    S.getName(name);
+    if (name == ".gnu.hash") {
+      llvm::StringRef content;
+      S.getContents(content);
+      return content;
+    }
+  }
+  return "";
+}
+
+/// Bloom filter in a stohastic data structure which can tell us if a symbol
+/// name does not exist in a library with 100% certainty. If it tells us it
+/// exists this may not be true:
+/// https://blogs.oracle.com/solaris/gnu-hash-elf-sections-v2
+///
+/// ELF has this optimization in the new linkers by default, It is stored in the
+/// gnu.hash section of the object file.
+///
+///\returns true if the symbol may be in the library.
+static bool MayExistInElfObjectFile(llvm::object::ObjectFile *soFile,
+                                 uint32_t hash) {
+  assert(soFile->isELF() && "Not ELF");
+
+  // LLVM9: soFile->makeTriple().is64Bit()
+  const int bits = 8 * soFile->getBytesInAddress();
+
+  llvm::StringRef contents = GetGnuHashSection(soFile);
+  if (contents.size() < 16)
+    // We need to search if the library doesn't have .gnu.hash section!
+    return true;
+  const char* hashContent = contents.data();
+
+  // See https://flapenguin.me/2017/05/10/elf-lookup-dt-gnu-hash/ for .gnu.hash
+  // table layout.
+  uint32_t maskWords = *reinterpret_cast<const uint32_t *>(hashContent + 8);
+  uint32_t shift2 = *reinterpret_cast<const uint32_t *>(hashContent + 12);
+  uint32_t hash2 = hash >> shift2;
+  uint32_t n = (hash / bits) % maskWords;
+
+  const char *bloomfilter = hashContent + 16;
+  const char *hash_pos = bloomfilter + n*(bits/8); // * (Bits / 8)
+  uint64_t word = *reinterpret_cast<const uint64_t *>(hash_pos);
+  uint64_t bitmask = ( (1ULL << (hash % bits)) | (1ULL << (hash2 % bits)));
+  return  (bitmask & word) == bitmask;
+}
+
+bool Dyld::ContainsSymbol(const LibraryPath* Lib,
+                          const std::string &mangledName,
+                          unsigned IgnoreSymbolFlags /*= 0*/) const {
+  const std::string library_filename = Lib->GetFullName();
+
+  if (DEBUG > 7) {
+    cling::errs() << "Dyld::ContainsSymbol: Find symbol: lib="
+                  << library_filename << ", mangled="
+                  << mangledName << "\n";
+  }
+
+  auto ObjF = llvm::object::ObjectFile::createObjectFile(library_filename);
+  if (llvm::Error Err = ObjF.takeError()) {
+    if (DEBUG > 1) {
+      std::string Message;
+      handleAllErrors(std::move(Err), [&](llvm::ErrorInfoBase &EIB) {
+          Message += EIB.message() + "; ";
+        });
+      cling::errs() << "Dyld::ContainsSymbol: Failed to read object file "
+                    << library_filename << " Errors: " << Message << "\n";
+    }
+    return false;
+  }
+
+  llvm::object::ObjectFile *BinObjFile = ObjF.get().getBinary();
+
+  uint32_t hashedMangle = GNUHash(mangledName);
+  // Check for the gnu.hash section if ELF.
+  // If the symbol doesn't exist, exit early.
+  if (BinObjFile->isELF() && !MayExistInElfObjectFile(BinObjFile, hashedMangle))
+    return false;
+
+  if (m_UseBloomFilter) {
+    // Use our bloom filters and create them if necessary.
+    if (Lib->isBloomFilterEmpty())
+      BuildBloomFilter(const_cast<LibraryPath*>(Lib), BinObjFile,
+                       IgnoreSymbolFlags);
+
+    // If the symbol does not exist, exit early. In case it may exist, iterate.
+    if (!Lib->MayExistSymbol(hashedMangle)) {
+      if (DEBUG > 7)
+        cling::errs() << "Dyld::ContainsSymbol: BloomFilter: Skip symbol.\n";
+      return false;
+    }
+    if (DEBUG > 7)
+      cling::errs() << "Dyld::ContainsSymbol: BloomFilter: Symbol May exist."
+                    << " Search for it.";
+  }
+
+  if (m_UseHashTable) {
+    bool result = Lib->ExistSymbol(mangledName);
+    if (DEBUG > 7)
+      cling::errs() << "Dyld::ContainsSymbol: HashTable: Symbol "
+                    << (result ? "Exist" : "Not exist") << "\n";
+    return result;
+  }
+
+  // Symbol may exist. Iterate.
+
+  // If no hash symbol then iterate to detect symbol
+  // We Iterate only if BloomFilter and/or SymbolHashTable are not supported.
+  for (const llvm::object::SymbolRef &S : BinObjFile->symbols()) {
+    uint32_t Flags = S.getFlags();
+    // Do not insert in the table symbols flagged to ignore.
+    if (Flags & IgnoreSymbolFlags)
+      continue;
+
+    // Note, we are at last resort and loading library based on a weak
+    // symbol is allowed. Otherwise, the JIT will issue an unresolved
+    // symbol error.
+    //
+    // There are other weak symbol kinds (marked as 'V') to denote
+    // typeinfo and vtables. It is unclear whether we should load such
+    // libraries or from which library we should resolve the symbol.
+    // We seem to not have a way to differentiate it from the symbol API.
+
+    llvm::Expected<llvm::StringRef> SymNameErr = S.getName();
+    if (!SymNameErr) {
+      cling::errs() << "Dyld::ContainsSymbol: Failed to read symbol "
+                    << mangledName << "\n";
+      continue;
+    }
+
+    if (SymNameErr.get().empty())
+      continue;
+
+    if (SymNameErr.get() == mangledName) {
+      if (DEBUG > 1) {
+        cling::errs() << "Dyld::ContainsSymbol: Symbol "
+                      << mangledName << " found in "
+                      << library_filename << "\n";
+        return true;
+      }
+    }
+  }
+
+  if (!BinObjFile->isELF())
+    return false;
+
+  // ELF file format has .dynstr section for the dynamic symbol table.
+  const auto *ElfObj = llvm::cast<llvm::object::ELFObjectFileBase>(BinObjFile);
+
+  for (const llvm::object::SymbolRef &S : ElfObj->getDynamicSymbolIterators()) {
+    uint32_t Flags = S.getFlags();
+    // DO NOT insert to table if symbol was undefined
+    if (Flags & llvm::object::SymbolRef::SF_Undefined)
+      continue;
+
+    // Note, we are at last resort and loading library based on a weak
+    // symbol is allowed. Otherwise, the JIT will issue an unresolved
+    // symbol error.
+    //
+    // There are other weak symbol kinds (marked as 'V') to denote
+    // typeinfo and vtables. It is unclear whether we should load such
+    // libraries or from which library we should resolve the symbol.
+    // We seem to not have a way to differentiate it from the symbol API.
+
+    llvm::Expected<llvm::StringRef> SymNameErr = S.getName();
+    if (!SymNameErr) {
+      cling::errs() << "Dyld::ContainsSymbol: Failed to read symbol "
+                    << mangledName << "\n";
+      continue;
+    }
+
+    if (SymNameErr.get().empty())
+      continue;
+
+    if (SymNameErr.get() == mangledName)
+      return true;
+  }
+  return false;
+}
+
+std::string Dyld::searchLibrariesForSymbol(const std::string& mangledName,
+                                           bool searchSystem/* = true*/) {
+  assert(!llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(mangledName) &&
+         "Library already loaded, please use dlsym!");
+  assert(!mangledName.empty());
+  using namespace llvm::sys::path;
+  using namespace llvm::sys::fs;
+
+  if (m_FirstRun) {
+    ScanForLibraries(/* SearchSystemLibraries= */ false);
+    m_FirstRun = false;
+  }
+
+  if (!m_QueriedLibraries.empty()) {
+    // Last call we were asked if a library contains a symbol. Usually, the
+    // caller wants to load this library. Check if was loaded and remove it
+    // from our lists of not-yet-loaded libs.
+
+    if (DEBUG > 7) {
+      cling::errs() << "Dyld::ResolveSymbol: m_QueriedLibraries:\n";
+      size_t x = 0;
+      for (auto item : m_QueriedLibraries) {
+        cling::errs() << "Dyld::ResolveSymbol - [" << x++ << "]:"
+                      << &item << ": " << item.m_Path << ", "
+                      << item.m_LibName << "\n";
+      }
+    }
+
+    for (const LibraryPath& P : m_QueriedLibraries) {
+      const std::string LibName = P.GetFullName();
+      if (!m_DynamicLibraryManager.isLibraryLoaded(LibName))
+        continue;
+
+      m_Libraries.UnregisterLib(P);
+      m_SysLibraries.UnregisterLib(P);
+    }
+  }
+
+  // Iterate over files under this path. We want to get each ".so" files
+  for (const LibraryPath* P : m_Libraries.GetLibraries()) {
+    const std::string LibName = P->GetFullName();
+
+    if (ContainsSymbol(P, mangledName, /*ignore*/
+                       llvm::object::SymbolRef::SF_Undefined)) {
+      m_QueriedLibraries.push_back(*P);
+      return LibName;
+    }
+  }
+
+  if (!searchSystem)
+    return "";
+
+  if (DEBUG > 7)
+    cling::errs() << "Dyld::ResolveSymbol: SearchSystem!\n";
+
+  // Lookup in non-system libraries failed. Expand the search to the system.
+  if (m_FirstRunSysLib) {
+    ScanForLibraries(/* SearchSystemLibraries= */ true);
+    m_FirstRunSysLib = false;
+  }
+
+  for (const LibraryPath* P : m_SysLibraries.GetLibraries()) {
+    const std::string LibName = P->GetFullName();
+    if (ContainsSymbol(P, mangledName, /*ignore*/
+                       llvm::object::SymbolRef::SF_Undefined |
+                       llvm::object::SymbolRef::SF_Weak)) {
+      m_QueriedLibraries.push_back(*P);
+      return LibName;
+    }
+  }
+
+  if (DEBUG > 7)
+    cling::errs() << "Dyld::ResolveSymbol: Search found no match!\n";
+
+  /*
+    if (DEBUG > 7) {
+    cling::errs() << "Dyld::ResolveSymbol: Structs after ResolveSymbol:\n");
+
+    cling::errs() << "Dyld::ResolveSymbol - sPaths:\n");
+    size_t x = 0;
+    for (const auto &item : sPaths.GetPaths())
+    cling::errs() << "Dyld::ResolveSymbol << [" x++ << "]: " << item << "\n";
+
+    cling::errs() << "Dyld::ResolveSymbol - sLibs:\n");
+    x = 0;
+    for (const auto &item : sLibraries.GetLibraries())
+    cling::errs() << "Dyld::ResolveSymbol ["
+    << x++ << "]: " << item->Path << ", "
+    << item->LibName << "\n";
+
+    cling::errs() << "Dyld::ResolveSymbol - sSysLibs:");
+    x = 0;
+    for (const auto &item : sSysLibraries.GetLibraries())
+    cling::errs() << "Dyld::ResolveSymbol ["
+    << x++ << "]: " << item->Path << ", "
+    << item->LibName << "\n";
+
+    Info("Dyld::ResolveSymbol", "- sQueriedLibs:");
+    x = 0;
+    for (const auto &item : sQueriedLibraries)
+    cling::errs() << "Dyld::ResolveSymbol ["
+    << x++ << "]: " << item->Path << ", "
+    << item->LibName << "\n";
+    }
+  */
+
+  return ""; // Search found no match.
+}
+} // anon namespace
+
+// This function isn't referenced outside its translation unit, but it
+// can't use the "static" keyword because its address is used for
+// GetMainExecutable (since some platforms don't support taking the
+// address of main, and some platforms can't implement GetMainExecutable
+// without being given the address of a function in the main executable).
+std::string GetExecutablePath() {
+   // This just needs to be some symbol in the binary; C++ doesn't
+   // allow taking the address of ::main however.
+   return cling::DynamicLibraryManager::getSymbolLocation(&GetExecutablePath);
+}
+
+namespace cling {
+  void DynamicLibraryManager::initializeDyld(
+           std::function<bool(llvm::StringRef)> shouldPermanentlyIgnore) const {
+    assert(!s_IsDyldInitialized);
+    s_ShouldPermanentlyIgnoreCallback = shouldPermanentlyIgnore;
+
+    std::string exeP = GetExecutablePath();
+    auto ObjF =
+      cantFail(llvm::object::ObjectFile::createObjectFile(exeP));
+       s_ExecutableFormat = ObjF.getBinary()->getFileFormatName();
+
+    s_IsDyldInitialized = true;
+  }
+
+  std::string
+  DynamicLibraryManager::searchLibrariesForSymbol(const std::string& mangledName,
+                                           bool searchSystem/* = true*/) const {
+    assert(s_IsDyldInitialized && "Must call initialize dyld before!");
+    static Dyld& dyld = Dyld::getInstance(*this);
+    return dyld.searchLibrariesForSymbol(mangledName, searchSystem);
+  }
+
+  std::string DynamicLibraryManager::getSymbolLocation(void *func) {
+#if defined(__CYGWIN__) && defined(__GNUC__)
+    return {};
+#elif defined(LLVM_ON_WIN32)
+    MEMORY_BASIC_INFORMATION mbi;
+    if (!VirtualQuery (func, &mbi, sizeof (mbi)))
+      return {};
+
+    HMODULE hMod = (HMODULE) mbi.AllocationBase;
+    char moduleName[MAX_PATH];
+
+    if (!GetModuleFileNameA (hMod, moduleName, sizeof (moduleName)))
+      return {};
+
+    return getRealPath(moduleName);
+#else
+    // assume we have  defined HAVE_DLFCN_H and HAVE_DLADDR
+    Dl_info info;
+    if (dladdr((void*)func, &info) == 0) {
+      // Not in a known shared library, let's give up
+      return {};
+    } else {
+      if (strchr(info.dli_fname, '/'))
+        return getRealPath(info.dli_fname);
+      // Else absolute path. For all we know that's a binary.
+      // Some people have dictionaries in binaries, this is how we find their
+      // path: (see also https://stackoverflow.com/a/1024937/6182509)
+# if defined(__APPLE__)
+      char buf[PATH_MAX] = { 0 };
+      uint32_t bufsize = sizeof(buf);
+      if (_NSGetExecutablePath(buf, &bufsize) >= 0)
+        return getRealPath(buf);
+      return getRealPath(info.dli_fname);
+# elif defined(LLVM_ON_UNIX)
+      char buf[PATH_MAX] = { 0 };
+      // Cross our fingers that /proc/self/exe exists.
+      if (readlink("/proc/self/exe", buf, sizeof(buf)) > 0)
+        return getRealPath(buf);
+      std::string pipeCmd = std::string("which \"") + info.dli_fname + "\"";
+      FILE* pipe = popen(pipeCmd.c_str(), "r");
+      if (!pipe)
+        return getRealPath(info.dli_fname);
+      std::string result;
+      while (fgets(buf, sizeof(buf), pipe))
+         result += buf;
+
+      pclose(pipe);
+      return getRealPath(result);
+# else
+#  error "Unsupported platform."
+# endif
+      return {};
+   }
+#endif
+  }
+
+} // namespace cling


### PR DESCRIPTION
This patch consolidates the symbol resolution facilities throughout TCling into
a new singleton class Dyld part of the cling's DynamicLibraryManager.

The new dyld is responsible for:
  * Symlink resolution -- it implements a memory efficient representation of
    the full path to shared objects allowing search at constant time O(1). This
    also fixes issues when resolving symbols from OSX where the system libraries
    contain multiple levels of symlinks.
  * Bloom filter optimization -- it uses a stohastic data structure which gives
    a definitive answer if a symbol is not in the set. The implementation checks
    the .gnu.hash section in ELF which is the GNU implementation of a bloom
    filter and uses it. If the symbol is not in the bloom filter, the
    implementation builds its own and uses it. The measured performance of the
    bloom filter is 30% speed up for 2mb more memory. The custom bloom filter on
    top of the .gnu.hash filter gives 1-2% better performance.
    The advantage for the custom bloom filter is that it works on all
    implementations which do not support .gnu.hash (windows and osx). It is also
    customizable if we want to further reduce the false positive rates
    (currently at p=2%).
  * Hash table optimization -- we build a hash table which contains all symbols
    for a given library. This allows us to avoid the fallback symbol iteration
    if multiple symbols from the same library are requested. The hash table
    optimization targets to optimize the case where the bloom filter tells us
    the symbol is *maybe* in the library.

Patch by Alexander Penev (@alexander-penev) and me!

Performance Report
===

|platform|test|PCH-time|Module-time|Module-PR-time|
|:--------|:---|:---------:|:-----------:|:---------------|
|osx 10.14|roottest-python-pythonizations|22,82|26,89|20,08|
|osx 10.14| roottest-cling| 589,67|452,97|307,34|
|osx 10.14| roottest-python| 377,69|475,78|311,5|
|osx 10.14| roottest-root-hist| 60,59|90,98|49,65|
|osx 10.14| roottest-root-math| 106,18|140,41|73,96|
|osx 10.14| roottest-root-tree| 1287,53|1861|1149,35|
|osx 10.14| roottest-root-treeformula | 568,43|907,46|531|
|osx 10.15| root-io-stdarray| - | 126.02 | 31.42|
|osx 10.15| roottest-root-treeformula| - | 327.08 | 231.14 |

The effect of running ctest -j8:
|platform|test|PCH-time|Module-time|Module-PR-time|
|:--------|:---|:---------:|:-----------:|:---------------|
|osx 10.14|roottest-python-pythonizations|14,45|18,89|13,03|
|osx 10.14| roottest-cling| 88,96|118,94|100,1|
|osx 10.14| roottest-python| 107,57|60,93|100,88|
|osx 10.14| roottest-root-hist| 10,25|23,25|11,77|
|osx 10.14| roottest-root-math| 8,33|21,23|9,27|
|osx 10.14| roottest-root-tree| 555|840,89|510,97|
|osx 10.14| roottest-root-treeformula | 235,44|402,82|228,91|

We think in `-j8` we lose the advantage of the new PR because the PCH had the rootmaps read in memory and restarting the processes allowed the kernel efficiently reuse that memory. Whereas, the modules and this PR scans the libraries from disk and builds in-memory optimization data structures. Reading from disk seems to be the bottleneck (not verified) but if that's an issue in future we can write out the index making subsequent runs at *almost* zero cost.