### PR TITLE
[ROOT-10491] Fix vector<bool> iteration for current PyROOT

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2538,7 +2538,10 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
       }
 
    // vector-optimized iterator protocol
-      ((PyTypeObject*)pyclass)->tp_iter     = (getiterfunc)vector_iter;
+   // Breaks for vector of bool since the "data" member function is not required in the STL.
+      if ( name.find("vector<bool>") == std::string::npos ) {
+         ((PyTypeObject*)pyclass)->tp_iter     = (getiterfunc)vector_iter;
+      }
 
    // helpers for iteration
       TypedefInfo_t* ti = gInterpreter->TypedefInfo_Factory( (name+"::value_type").c_str() );

--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2539,7 +2539,7 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
 
    // vector-optimized iterator protocol
    // Breaks for vector of bool since the "data" member function is not required in the STL.
-      if ( name.find("vector<bool>") == std::string::npos ) {
+      if ( name.find("vector<bool>") == std::string::npos && name.find("RVec<bool>") == std::string::npos ) {
          ((PyTypeObject*)pyclass)->tp_iter     = (getiterfunc)vector_iter;
       }
 

--- a/bindings/pyroot/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot/test/rdataframe_asnumpy.py
@@ -61,6 +61,12 @@ class RDataFrameAsNumpy(unittest.TestCase):
         for col in col_names:
             self.assertTrue(all(npy[col] == ref[col]))
 
+    def test_branch_bool(self):
+        df = ROOT.RDataFrame(2).Define("x", "bool(rdfentry_)")
+        npy = df.AsNumpy()
+        self.assertTrue(bool(npy["x"][0]) == False)
+        self.assertTrue(bool(npy["x"][1]) == True)
+
     def test_read_array(self):
         ROOT.gInterpreter.Declare("""
         std::array<unsigned int, 3> create_array(unsigned int n) {

--- a/bindings/pyroot_experimental/pythonizations/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot_experimental/pythonizations/test/rdataframe_asnumpy.py
@@ -80,6 +80,16 @@ class RDataFrameAsNumpy(unittest.TestCase):
         for col in col_names:
             self.assertTrue(all(npy[col] == ref[col]))
 
+    def test_branch_bool(self):
+        """
+        Test bool data-type as a special case since we cannot adopt
+        the std::vector<bool> with numpy arrays
+        """
+        df = ROOT.RDataFrame(2).Define("x", "bool(rdfentry_)")
+        npy = df.AsNumpy()
+        self.assertTrue(bool(npy["x"][0]) == False)
+        self.assertTrue(bool(npy["x"][1]) == True)
+
     def test_read_array(self):
         """
         Testing reading a std::array


### PR DESCRIPTION
Jira: https://sft.its.cern.ch/jira/browse/ROOT-10491

We miss the test for reading boolean branches with `RDataFrame.AsNumpy`! Added the test and start investigating when it breaks - such as reported in the Jira ticket.

Following the discussion on the forum [here](https://root-forum.cern.ch/t/asnumpy-fails-with-boolean-branches/37282), we see that the error shows a missing `data` member for the `std::vector<bool>`:

```
df.AsNumpy()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-10-e856f5516a02> in <module>()
----> 1 df.AsNumpy()

/Applications/root_build/lib/ROOT.pyc in _RDataFrameAsNumpy(df, columns, exclude)
    429         else:
    430             tmp = numpy.empty(len(cpp_reference), dtype=numpy.object)
--> 431             for i, x in enumerate(cpp_reference):
    432                 tmp[i] = x # This creates only the wrapping of the objects and does not copy.
    433             py_arrays[column] = ndarray(tmp, result_ptrs[column])

AttributeError: 'vector<bool>' object has no attribute 'data'
```

The error seems to be triggered when iterating over `std::vector<bool>` in python. My guess is some weirdness in the given std version of macOS 10.15.

@etejedor We should add a test for this at the right place not only for `AsNumpy`

Edit: Added a fix for current PyROOT by protecting the tp_iter field for `vector<bool>`.