### PR TITLE
[core] Make libNew a static library.

### DIFF
--- a/core/newdelete/CMakeLists.txt
+++ b/core/newdelete/CMakeLists.txt
@@ -13,6 +13,8 @@ ROOT_LINKER_LIBRARY(New
   src/NewDelete.cxx
   DEPENDENCIES
     Core
+  TYPE
+    STATIC
 )
 
 target_include_directories(New PRIVATE ../clib/res)


### PR DESCRIPTION
libNew is a custom memory allocator used in ROOT to output more information about memory pressure. It essentially overrides the new and delete operators. The functionality of libNew is only available in *rootn.exe* and libNew is statically linked to the binary.

In root-project/root#4717 we discovered that dlopening libNew at random time can trigger earthquakes because it allows the dynamic linker to *sometimes* resolve new and delete to the symbols from libNew and libc++.

Since libNew was not designed to be dlopened we should make it a static library to enforce this protocol more strongly.