### PR TITLE
[http] Fix files reading on Windows

### DIFF
--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -1273,7 +1273,7 @@ char *THttpServer::ReadFileContent(const char *filename, Int_t &len)
 {
    len = 0;
 
-   std::ifstream is(filename);
+   std::ifstream is(filename, std::ios::in | std::ios::binary);
    if (!is)
       return nullptr;
 
@@ -1297,7 +1297,7 @@ char *THttpServer::ReadFileContent(const char *filename, Int_t &len)
 
 std::string THttpServer::ReadFileContent(const std::string &filename)
 {
-   std::ifstream is(filename);
+   std::ifstream is(filename, std::ios::in | std::ios::binary);
    std::string res;
    if (is) {
       is.seekg(0, std::ios::end);


### PR DESCRIPTION
One has to use binary mode to be able read file content,
otherwise Windows may change lines ending and 
result will not fit into the preallocated string.

Has to be applied to all previous ROOT versions
Without that commit THttpServer does not work for me (Windows10/MSVC 2019).