### PR TITLE
[PyROOT exp] Remove unnecessary extern declaration

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h
@@ -220,9 +220,6 @@ public:
     virtual bool ToMemory(PyObject* value, void* address);
 };
 
-extern template class InstancePtrPtrConverter<true>;
-extern template class InstancePtrPtrConverter<false>;
-
 class InstanceArrayConverter : public InstancePtrConverter {
 public:
     InstanceArrayConverter(Cppyy::TCppType_t klass, dims_t dims, bool keepControl = false) :


### PR DESCRIPTION
- Breaks compilation with clang9 (explicit instantiation declaration
with external linkage)
- Fix is as well applied upstream in CPyCppyy 1.9.5 (we are on 1.9.3)