### PR TITLE
[ROOT-10491][PyROOT] Don't set tp_iter for vector<bool>

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2538,7 +2538,10 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
       }
 
    // vector-optimized iterator protocol
-      ((PyTypeObject*)pyclass)->tp_iter     = (getiterfunc)vector_iter;
+   // Breaks for vector of bool since the "data" member function is not required in the STL.
+      if ( name.find("vector<bool>") == std::string::npos ) {
+         ((PyTypeObject*)pyclass)->tp_iter     = (getiterfunc)vector_iter;
+      }
 
    // helpers for iteration
       TypedefInfo_t* ti = gInterpreter->TypedefInfo_Factory( (name+"::value_type").c_str() );


### PR DESCRIPTION
tp_iter is used to implement an iterator protocol for Python using the
"data" member function of std::vector. However, the specialization
`vector<bool>` is not required to have this member function, which
breaks the iterator. Removing the tp_iter field does not break iterating
vector<bool> in Python, it falls back to the old iterator mechanism via
the get/setitem special functions.