### PR TITLE
Fix TH1::GetStdDev with negative weights (ROOT-8412)

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -7121,7 +7121,8 @@ Double_t TH1::GetStdDev(Int_t axis) const
    Int_t ax[3] = {2,4,7};
    Int_t axm = ax[axis%10 - 1];
    x    = stats[axm]/stats[0];
-   stddev2 = TMath::Abs(stats[axm+1]/stats[0] -x*x);
+   // for negative stddev (e.g. when having negative weights) - return stdev=0
+   stddev2 = TMath::Max( stats[axm+1]/stats[0] -x*x, 0.0 );
    if (axis<10)
       return TMath::Sqrt(stddev2);
    else {


### PR DESCRIPTION
When the variance is negative (this can happen when having negative weights) return 0 as standard deviation instead of making the sqrt of the abs of the variance. 
This fixes ROOT-8412 