### PR TITLE
[PyROOT] Warn when instantiating with parenthesis, add a case when using brackets

### DIFF
--- a/bindings/pyroot/src/TemplateProxy.cxx
+++ b/bindings/pyroot/src/TemplateProxy.cxx
@@ -402,6 +402,7 @@ namespace {
          nArgs = 1;
          auto item = args;
          args = PyTuple_New(nArgs);
+         Py_INCREF(item);
          PyTuple_SET_ITEM(args, 0, item);
       } else {
          nArgs = PyTuple_GET_SIZE(args);

--- a/bindings/pyroot/src/TemplateProxy.cxx
+++ b/bindings/pyroot/src/TemplateProxy.cxx
@@ -251,6 +251,12 @@ namespace {
          pymeth = PyObject_GetAttr( pytmpl->fSelf ? pytmpl->fSelf : pytmpl->fPyClass, pyname_v1 );
          if ( pymeth ) { // overloads stop here, as this is an explicit match
             Py_DECREF( pyname_v1 );
+            if (PyErr_WarnEx(PyExc_FutureWarning,
+                       "Instantiating a function template with parentheses ( f(type1, ..., typeN) ) "
+                       "is deprecated and will not be supported in a future version of ROOT. "
+                       "Instead, use square brackets: f[type1, ..., typeN]", 1) < 0) {
+               return nullptr;
+            }
             return pymeth;         // callable method, next step is by user
          }
       }
@@ -338,6 +344,12 @@ namespace {
             Py_DECREF( pymeth );
             pymeth = PyObject_GetAttr( pytmpl->fSelf ? pytmpl->fSelf : pytmpl->fPyClass, pyname_v1 );
             Py_DECREF( pyname_v1 );
+            if (PyErr_WarnEx(PyExc_FutureWarning,
+                       "Instantiating a function template with parentheses ( f(type1, ..., typeN) ) "
+                       "is deprecated and will not be supported in a future version of ROOT. "
+                       "Instead, use square brackets: f[type1, ..., typeN]", 1) < 0) {
+               return nullptr;
+            }
             return pymeth;         // callable method, next step is by user
          }
          Py_DECREF( pyname_v1 );


### PR DESCRIPTION
This PR introduces two changes to old PyROOT:
1. Issue a deprecation warning when instantiating a template with the parenthesis syntax. This was suggested in the ROOT retreat in December, for users to be fully aware that the parenthesis syntax is going to disappear in favour of the square brackets one.
2. Add a missing case when instantiating templates with square brackets. It corresponds to the case when the template has not been previously instantiated with the type/s we want.