### PR TITLE
[core] Hide libNew from symbol resolution.

### DIFF
--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -870,6 +870,11 @@ void TClingCallbacks::UnlockCompilationDuringUserCodeExecution(void *StateInfo)
    TCling__UnlockCompilationDuringUserCodeExecution(StateInfo);
 }
 
+static bool shouldIgnore(llvm::StringRef FileName) {
+   llvm::StringRef fileStem = llvm::sys::path::stem(FileName);
+   return fileStem.startswith("libNew");
+}
+
 static void SearchAndAddPath(const std::string& Path,
       std::vector<std::pair<uint32_t, std::string>> &sLibraries, std::vector<std::string> &sPaths,
       std::unordered_set<std::string>& alreadyLookedPath, cling::DynamicLibraryManager* dyLibManager)
@@ -896,6 +901,10 @@ static void SearchAndAddPath(const std::string& Path,
       // for symbols that cannot be found (neither by dlsym nor in the JIT).
       if (dyLibManager->isLibraryLoaded(FileName.c_str()))
          continue;
+
+      if (shouldIgnore(FileName))
+         continue;
+
       sLibraries.push_back(std::make_pair(sPaths.size(), llvm::sys::path::filename(FileName)));
       flag = true;
    }

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -202,21 +202,21 @@ TEST_F(TClingTests, GetSharedLibDeps)
    std::string SeenDeps
       = MakeDepLibsPlatformIndependent(GetLibDeps("libGenVector.so"));
 #ifdef R__MACOSX
-   ASSERT_TRUE(llvm::StringRef(SeenDeps).startswith("GenVector New"));
+   // It may depend on tbb
+   ASSERT_TRUE(llvm::StringRef(SeenDeps).startswith("GenVector"));
 #else
-   // Depends only on libCore.so but libCore.so is loaded and thus missing.
-   ASSERT_STREQ("GenVector", SeenDeps.c_str());
+    // Depends only on libCore.so but libCore.so is loaded and thus missing.
+    ASSERT_STREQ("GenVector", SeenDeps.c_str());
 #endif
 
    SeenDeps = MakeDepLibsPlatformIndependent(GetLibDeps("libTreePlayer.so"));
    llvm::StringRef SeenDepsRef = SeenDeps;
 
    // Depending on the configuration we expect:
-   // TreePlayer Gpad Graf Graf3d Hist [Imt] [MathCore] MultiProc Net [New] Tree [tbb]..
+   // TreePlayer Gpad Graf Graf3d Hist [Imt] [MathCore] MultiProc Net Tree [tbb]..
    // FIXME: We should add a generic gtest regex matcher and use a regex here.
    ASSERT_TRUE(SeenDepsRef.startswith("TreePlayer Gpad Graf Graf3d Hist"));
-   ASSERT_TRUE(SeenDepsRef.contains("MultiProc Net"));
-   ASSERT_TRUE(SeenDepsRef.contains("Tree"));
+   ASSERT_TRUE(SeenDepsRef.contains("MultiProc Net Tree"));
 
    EXPECT_ROOT_ERROR(ASSERT_TRUE(nullptr == GetLibDeps("")),
                      "Error in <TCling__GetSharedLibImmediateDepsSlow>: Cannot find library ''\n");


### PR DESCRIPTION
libNew is a custom memory allocator used in ROOT to output more information about memory pressure and used for interprocess communication in TMapFile. It essentially overrides the new and delete operators.

We discovered that dlopening libNew at random time can trigger earthquakes because it allows the dynamic linker to sometimes resolve new and delete to the symbols from libNew and libc++.

Patch by Alexander Penev (@alexander-penev) and me!