### PR TITLE
[RF] Enable I/O for RooNDKeysPdf

### DIFF
--- a/roofit/roofit/inc/LinkDef1.h
+++ b/roofit/roofit/inc/LinkDef1.h
@@ -25,6 +25,7 @@
 #pragma link C++ class RooHistConstraint+ ;
 #pragma link C++ class RooKeysPdf+ ;
 #pragma link C++ class RooNDKeysPdf+ ;
+#pragma link C++ class RooNDKeysPdf::BoxInfo+;
 #pragma link C++ class RooLandau+ ;
 #pragma link C++ class RooNonCPEigenDecay+ ;
 #pragma link C++ class RooNovosibirsk+ ;

--- a/roofit/roofit/inc/RooNDKeysPdf.h
+++ b/roofit/roofit/inc/RooNDKeysPdf.h
@@ -54,18 +54,20 @@ public:
                MirrorAsymRight, MirrorLeftAsymRight,
                MirrorAsymBoth };
 
-  RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const RooAbsData &data,
+  RooNDKeysPdf() = default;
+
+  RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const RooDataSet &data,
                TString options = "ma", Double_t rho = 1, Double_t nSigma = 3, Bool_t rotate = kTRUE,
                Bool_t sortInput = kTRUE);
 
   RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const TH1 &hist, TString options = "ma",
                Double_t rho = 1, Double_t nSigma = 3, Bool_t rotate = kTRUE, Bool_t sortInput = kTRUE);
 
-  RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const RooAbsData &data,
+  RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const RooDataSet &data,
                const TVectorD &rho, TString options = "ma", Double_t nSigma = 3, Bool_t rotate = kTRUE,
                Bool_t sortInput = kTRUE);
 
-  RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const RooAbsData &data,
+  RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const RooDataSet &data,
                const RooArgList &rhoList, TString options = "ma", Double_t nSigma = 3, Bool_t rotate = kTRUE,
                Bool_t sortInput = kTRUE);
 
@@ -73,10 +75,10 @@ public:
                const RooArgList &rhoList, TString options = "ma", Double_t nSigma = 3, Bool_t rotate = kTRUE,
                Bool_t sortInput = kTRUE);
 
-  RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, const RooAbsData &data, Mirror mirror = NoMirror,
+  RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, const RooDataSet &data, Mirror mirror = NoMirror,
                Double_t rho = 1, Double_t nSigma = 3, Bool_t rotate = kTRUE, Bool_t sortInput = kTRUE);
 
-  RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, RooAbsReal &y, const RooAbsData &data,
+  RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, RooAbsReal &y, const RooDataSet &data,
                TString options = "ma", Double_t rho = 1.0, Double_t nSigma = 3, Bool_t rotate = kTRUE,
                Bool_t sortInput = kTRUE);
 
@@ -111,22 +113,19 @@ public:
 protected:
 
   RooListProxy _varList ;
-  TIterator* _varItr ;   //! do not persist
-
   RooListProxy _rhoList;
-  TIterator *_rhoItr; //! do not persist
 
   Double_t evaluate() const;
 
-  void createPdf(Bool_t firstCall = kTRUE) const;
-  void setOptions() const;
-  void initialize() const;
+  void createPdf(Bool_t firstCall = kTRUE);
+  void setOptions();
+  void initialize();
   void loadDataSet(Bool_t firstCall) const;
   void mirrorDataSet() const;
   void loadWeightSet() const;
   void calculateShell(BoxInfo *bi) const;
   void calculatePreNorm(BoxInfo *bi) const;
-  void sortDataIndices(BoxInfo *bi = 0) const;
+  void sortDataIndices(BoxInfo *bi = 0);
   void calculateBandWidth() const;
   Double_t gauss(std::vector<Double_t> &x, std::vector<std::vector<Double_t>> &weights) const;
   void loopRange(std::vector<Double_t> &x, std::map<Int_t, Bool_t> &ibMap) const;
@@ -134,24 +133,23 @@ protected:
   RooDataSet *createDatasetFromHist(const RooArgList &varList, const TH1 &hist) const;
   void updateRho() const;
 
-  mutable RooDataSet *_dataP; //! do not persist
-  const RooAbsData &_data;    //!
+  std::unique_ptr<RooDataSet> _ownedData{nullptr};
+  const RooDataSet* _data; //! do not persist
   mutable TString _options;
   mutable Double_t _widthFactor;
   mutable Double_t _nSigma;
 
-  mutable Bool_t _fixedShape;
-  mutable Bool_t _mirror;
-  mutable Bool_t _debug;
-  mutable Bool_t _verbose;
+  mutable Bool_t _fixedShape{false};
+  mutable Bool_t _mirror{false};
+  mutable Bool_t _debug{false};   //!
+  mutable Bool_t _verbose{false}; //!
 
-  mutable Double_t _sqrt2pi;
-  mutable Int_t _nDim;
-  mutable Int_t _nEvents;
-  mutable Int_t _nEventsM;
-  mutable Double_t _nEventsW;
-  mutable Double_t _d;
-  mutable Double_t _n;
+  mutable Int_t _nDim{0};
+  mutable Int_t _nEvents{0};
+  mutable Int_t _nEventsM{0};
+  mutable Double_t _nEventsW{0.};
+  mutable Double_t _d{0.};
+  mutable Double_t _n{0.};
 
   // cached info on variable
 
@@ -161,10 +159,7 @@ protected:
   mutable std::vector<std::vector<Double_t> > _weights1;
   mutable std::vector<std::vector<Double_t> >* _weights; //!
 
-#ifndef __CINT__
-  mutable std::vector<iiVec> _sortIdcs;   //!
-  mutable std::vector<itVec> _sortTVIdcs; //!
-#endif
+  std::vector<itVec> _sortTVIdcs; //!
 
   mutable std::vector<std::string> _varName;
   mutable std::vector<Double_t> _rho;
@@ -175,9 +170,9 @@ protected:
   mutable std::vector<Double_t> _xDatLo, _xDatHi;
   mutable std::vector<Double_t> _xDatLo3s, _xDatHi3s;
 
-  mutable Bool_t _netFluxZ;
-  mutable Double_t _nEventsBW;
-  mutable Double_t _nEventsBMSW;
+  mutable Bool_t _netFluxZ{false};
+  mutable Double_t _nEventsBW{0.};
+  mutable Double_t _nEventsBMSW{0.};
   mutable std::vector<Double_t> _xVarLo, _xVarHi;
   mutable std::vector<Double_t> _xVarLoM3s, _xVarLoP3s, _xVarHiM3s, _xVarHiP3s;
   mutable std::map<Int_t,Bool_t> _bpsIdcs;
@@ -190,36 +185,24 @@ protected:
   mutable BoxInfo _fullBoxInfo ;
 
   mutable std::vector<Int_t> _idx;
-  mutable Double_t _minWeight;
-  mutable Double_t _maxWeight;
+  mutable Double_t _minWeight{0.};
+  mutable Double_t _maxWeight{0.};
   mutable std::map<Int_t,Double_t> _wMap;
 
-  mutable TMatrixDSym* _covMat;
-  mutable TMatrixDSym* _corrMat;
-  mutable TMatrixD* _rotMat;
-  mutable TVectorD* _sigmaR;
-  mutable TVectorD* _dx;
-  mutable Double_t _sigmaAvgR;
+  mutable TMatrixDSym* _covMat{nullptr};
+  mutable TMatrixDSym* _corrMat{nullptr};
+  mutable TMatrixD* _rotMat{nullptr};
+  mutable TVectorD* _sigmaR{nullptr};
+  mutable TVectorD* _dx{nullptr};
+  mutable Double_t _sigmaAvgR{0.};
 
   mutable Bool_t _rotate;
   mutable Bool_t _sortInput;
   mutable Int_t _nAdpt;
 
-  mutable RooChangeTracker *_tracker; //! do not persist
+  mutable RooChangeTracker *_tracker{nullptr}; //
 
-  /// sorter function
-  struct SorterTV_L2H {
-    Int_t idx;
-
-    SorterTV_L2H (Int_t index) : idx(index) {}
-    bool operator() (const itPair& a, const itPair& b) {
-      const TVectorD& aVec = *(a.second);
-      const TVectorD& bVec = *(b.second);
-      return (aVec[idx]<bVec[idx]);
-    }
-  };
-
-  ClassDef(RooNDKeysPdf, 2) // General N-dimensional non-parametric kernel estimation p.d.f
+  ClassDef(RooNDKeysPdf, 1) // General N-dimensional non-parametric kernel estimation p.d.f
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooChangeTracker.h
+++ b/roofit/roofitcore/inc/RooChangeTracker.h
@@ -46,8 +46,6 @@ protected:
   std::vector<Int_t>    _catRef ;    // Reference valyes for categories
   Bool_t       _checkVal ;           // Check contents as well if true
 
-  mutable TIterator* _realSetIter ;     //! do not persist
-  mutable TIterator* _catSetIter ;     //! do not persist
   Bool_t        _init ; //!
 
   Double_t evaluate() const { return 1 ; }

--- a/roofit/roofitcore/src/RooChangeTracker.cxx
+++ b/roofit/roofitcore/src/RooChangeTracker.cxx
@@ -52,8 +52,6 @@ ClassImp(RooChangeTracker);
 
 RooChangeTracker::RooChangeTracker() : _checkVal(kFALSE), _init(kFALSE)
 {
-  _realSetIter = _realSet.createIterator() ;
-  _catSetIter = _catSet.createIterator() ;
 }
 
 
@@ -74,32 +72,23 @@ RooChangeTracker::RooChangeTracker(const char* name, const char* title, const Ro
   _checkVal(checkValues),
   _init(kFALSE)
 {
-  _realSetIter = _realSet.createIterator() ;
-  _catSetIter = _catSet.createIterator() ;
-
-  TIterator* iter = trackSet.createIterator() ;
-  RooAbsArg* arg ;
-  while((arg=(RooAbsArg*)iter->Next())) {
-    if (dynamic_cast<RooAbsReal*>(arg)) {
+for (const auto arg : trackSet) {
+    if (dynamic_cast<const RooAbsReal*>(arg)) {
       _realSet.add(*arg) ;      
     }
-    if (dynamic_cast<RooAbsCategory*>(arg)) {
+    if (dynamic_cast<const RooAbsCategory*>(arg)) {
       _catSet.add(*arg) ;      
     }
   }
-  delete iter ;
   
   if (_checkVal) {
-    RooAbsReal* real  ;
-    RooAbsCategory* cat  ;
-    Int_t i(0) ;
-    _realSetIter->Reset() ;
-    _catSetIter->Reset() ;
-    while((real=(RooAbsReal*)_realSetIter->Next())) {
+    for (unsigned int i=0; i < _realSet.size(); ++i) {
+      auto real = static_cast<const RooAbsReal*>(_realSet.at(i));
       _realRef[i++] = real->getVal() ;
     }
-    i=0 ;
-    while((cat=(RooAbsCategory*)_catSetIter->Next())) {
+
+    for (unsigned int i=0; i < _catSet.size(); ++i) {
+      auto cat = static_cast<const RooAbsCategory*>(_catSet.at(i));
       _catRef[i++] = cat->getIndex() ;
     }
   }
@@ -120,12 +109,6 @@ RooChangeTracker::RooChangeTracker(const RooChangeTracker& other, const char* na
   _checkVal(other._checkVal),
   _init(kFALSE)
 {
-  _realSetIter = _realSet.createIterator() ;
-  _catSetIter = _catSet.createIterator() ;
-
-//   _realSet.add(other._realSet) ;
-//   _catSet.add(other._catSet) ;
-
 }
 
 
@@ -157,32 +140,26 @@ Bool_t RooChangeTracker::hasChanged(Bool_t clearState)
   }
   
   // Compare values against reference
-  _realSetIter->Reset() ;  
-  _catSetIter->Reset() ;
-  RooAbsReal* real ;
-  RooAbsCategory* cat ;
-  Int_t i(0) ;
-
   if (clearState) {
 
     Bool_t valuesChanged(kFALSE) ;
 
     // Check if any of the real values changed
-    while ((real=(RooAbsReal*)_realSetIter->Next())) {
+    for (unsigned int i=0; i < _realSet.size(); ++i) {
+      auto real = static_cast<const RooAbsReal*>(_realSet.at(i));
       if (real->getVal() != _realRef[i]) {
-	// cout << "RooChangeTracker(" << this << "," << GetName() << ") value of " << real->GetName() << " has changed from " << _realRef[i] << " to " << real->getVal() << " clearState = " << (clearState?"T":"F") << endl ;
-	valuesChanged = kTRUE ;
-	_realRef[i] = real->getVal() ;
+        // cout << "RooChangeTracker(" << this << "," << GetName() << ") value of " << real->GetName() << " has changed from " << _realRef[i] << " to " << real->getVal() << " clearState = " << (clearState?"T":"F") << endl ;
+        valuesChanged = kTRUE ;
+        _realRef[i] = real->getVal() ;
       }
-      i++ ;
     }
     // Check if any of the categories changed
-    i=0 ;
-    while ((cat=(RooAbsCategory*)_catSetIter->Next())) {
-      if (cat->getIndex() != _catRef[i++]) {
-	// cout << "RooChangeTracker(" << this << "," << GetName() << ") value of " << cat->GetName() << " has changed from " << _catRef[i-1] << " to " << cat->getIndex() << endl ;
-	valuesChanged = kTRUE ;
-	_catRef[i-1] = cat->getIndex() ;
+    for (unsigned int i=0; i < _catSet.size(); ++i) {
+      auto cat = static_cast<const RooAbsCategory*>(_catSet.at(i));
+      if (cat->getIndex() != _catRef[i]) {
+        // cout << "RooChangeTracker(" << this << "," << GetName() << ") value of " << cat->GetName() << " has changed from " << _catRef[i-1] << " to " << cat->getIndex() << endl ;
+        valuesChanged = kTRUE ;
+        _catRef[i] = cat->getIndex() ;
       }
     }
 
@@ -203,16 +180,17 @@ Bool_t RooChangeTracker::hasChanged(Bool_t clearState)
     // Return true as soon as any input has changed
 
     // Check if any of the real values changed
-    while ((real=(RooAbsReal*)_realSetIter->Next())) {
-      if (real->getVal() != _realRef[i++]) {
-	return kTRUE ;
+    for (unsigned int i=0; i < _realSet.size(); ++i) {
+      auto real = static_cast<const RooAbsReal*>(_realSet.at(i));
+      if (real->getVal() != _realRef[i]) {
+        return kTRUE ;
       }
     }
     // Check if any of the categories changed
-    i=0 ;
-    while ((cat=(RooAbsCategory*)_catSetIter->Next())) {
-      if (cat->getIndex() != _catRef[i++]) {
-	return kTRUE ;
+    for (unsigned int i=0; i < _catSet.size(); ++i) {
+      auto cat = static_cast<const RooAbsCategory*>(_catSet.at(i));
+      if (cat->getIndex() != _catRef[i]) {
+        return kTRUE ;
       }
     }
    
@@ -228,8 +206,7 @@ Bool_t RooChangeTracker::hasChanged(Bool_t clearState)
 
 RooChangeTracker::~RooChangeTracker() 
 {
-  if (_realSetIter) delete _realSetIter ;
-  if (_catSetIter) delete _catSetIter ;
+
 }
 
 


### PR DESCRIPTION
[ROOT-10341] To enable serialisation, several members of RooNDKeysPdf
had to be removed or their type had to be changed. A few members
cannot be serialised and therefore have to be recomputed when necessary.
Some first cleaning up was also done.