### PR TITLE
[cxxmodules] Teach ACLiC to work when not all dependent libs are resolved.

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -705,6 +705,11 @@ endif()
 
 #---compiledata.h--------------------------------------------------------------------------------------------
 
+if(APPLE AND runtime_cxxmodules)
+  # Modules have superior dynamic linker and they can resolve undefined symbols upon library loading.
+  set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
+endif()
+
 if(WIN32)
   # We cannot use the compiledata.sh script for windows
   configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/compiledata.win32.in ${CMAKE_BINARY_DIR}/include/compiledata.h NEWLINE_STYLE UNIX)


### PR DESCRIPTION
The non-modules system iterates over all available rootmap files and adds their libraries as potential dependencies to the library which ACLiC builds. The built library relies on the explicit linking to load its dependencies when it is dlopened.

This is necessary because we have no other way to resolve symbols. Fortunately, the modules dynamic linker has superior symbol resolution. We can rely on it when loading a shared library.

This patch fixes failing tests on OSX when runtime_cxxmodules are on.