### PR TITLE
[Exp PyROOT] Add patch for TROOT::Initialize in clingwrapper

### DIFF
--- a/bindings/pyroot_experimental/cppyy/patches/troot_initialize.patch
+++ b/bindings/pyroot_experimental/cppyy/patches/troot_initialize.patch
@@ -1,0 +1,15 @@
+diff --git a/bindings/pyroot_experimental/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx b/bindings/pyroot_experimental/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+index 3559a45..a4f7a88 100644
+--- a/bindings/pyroot_experimental/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
++++ b/bindings/pyroot_experimental/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+@@ -109,6 +109,10 @@ namespace {
+ class ApplicationStarter {
+ public:
+     ApplicationStarter() {
++    // Insure ROOT's atexit is executed *after* the atexit that calls
++    // ApplicationStarter's destructor, by forcing the ROOT's atexit
++    // registration now.
++        TROOT::Initialize();
+     // setup dummy holders for global and std namespaces
+         assert(g_classrefs.size() == GLOBAL_HANDLE);
+         g_name2classrefidx[""]      = GLOBAL_HANDLE;


### PR DESCRIPTION
The following PR introduced some changes in the TCling shutdown
logic:
https://github.com/root-project/root/pull/4675

One of these changes affects clingwrapper.cxx in Cppyy, but the
functionality it relies on (TROOT::Initialize) is not yet in the
mini-ROOT of Cppyy, which is at the moment working with ROOT 6.18,
so we cannot push the clingwrapper change to upstream Cppyy now.

For that reason, until Cppyy updates its ROOT to 6.20, we need to
keep this patch to modify our copy of Cppyy to invoke
TROOT::Initialize in the constructor of ApplicationStarter.