### PR TITLE
[Exp PyROOT] Fix installation bug introduced in 1d2e76

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,4 +589,6 @@ include(RootCPack)
 
 # Exp PyROOT: remove empty directory wrongly created
 # Keep until we figure why it happens
-install(CODE "execute_process(COMMAND bash -c \"rm -rf ${CMAKE_INSTALL_PREFIX}/lib/python*\")")
+if(pyroot_experimental AND (NOT "${CMAKE_INSTALL_PREFIX}" MATCHES "^/usr"))
+  install(CODE "execute_process(COMMAND bash -c \"rm -rf ${CMAKE_INSTALL_PREFIX}/lib/python*\")")
+endif()


### PR DESCRIPTION
As reported in:

https://sft.its.cern.ch/jira/projects/ROOT/issues/ROOT-10501?filter=allopenissues

commit 1d2e76 deletes the host's Python installation.

Here two conditions are introduced to run the command:

- the flag pyroot_experimental was specified during the configuration;
- the variable CMAKE_INSTALL_PREFIX doesn't start with "/usr", making
the command run only if the above mentioned variable was customized.