### PR TITLE
[ROOT-10472] Fix building clingutils tests with builtin_clang=OFF

### DIFF
--- a/core/clingutils/test/CMakeLists.txt
+++ b/core/clingutils/test/CMakeLists.txt
@@ -26,4 +26,8 @@ if(APPLE)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -w")
 endif()
 
+if(NOT builtin_clang)
+  link_directories("${LLVM_LIBRARY_DIR}")
+endif()
+
 ROOT_ADD_UNITTEST_DIR(Core RIO ${CLING_LIBRARIES} $<TARGET_OBJECTS:ClingUtils>)

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -7,19 +7,19 @@
 #------------------------------------------------------------------------------
 
 set(CLING_DEPEND_LIBS
-  clangAnalysis
-  clangAST
-  clangBasic
   clangCodeGen
   clangDriver
-  clangEdit
   clangFrontend
-  clangLex
   clangParse
+  clangSema
+  clangAnalysis
+  clangEdit
   clangRewrite
   clangRewriteFrontend
-  clangSema
   clangSerialization
+  clangAST
+  clangBasic
+  clangLex
   CACHE STRING "Dependency Clang libraries for Cling"
 )
 

--- a/interpreter/cling/lib/Utils/CMakeLists.txt
+++ b/interpreter/cling/lib/Utils/CMakeLists.txt
@@ -5,16 +5,41 @@
 # of Illinois Open Source License or the GNU Lesser General Public License. See
 # LICENSE.TXT for details.
 #------------------------------------------------------------------------------
-set( LLVM_LINK_COMPONENTS
+set(LLVM_LINK_COMPONENTS
+  analysis
+  core
+  coroutines
+  coverage
+  executionengine
+  ipo
+  lto
+  mc
+  object
+  option
+  orcjit
+  runtimedyld
+  scalaropts
   support
+  target
+  transformutils
+  binaryformat
+  ${LLVM_TARGETS_TO_BUILD}
 )
 
-set( LIBS
-  clangSema
-  clangAST
-  clangLex
-  clangBasic
+set(LIBS
+  clangCodeGen
+  clangDriver
+  clangFrontend
   clangParse
+  clangSema
+  clangAnalysis
+  clangEdit
+  clangRewrite
+  clangRewriteFrontend
+  clangSerialization
+  clangAST
+  clangBasic
+  clangLex
 )
 
 find_library(DL_LIBRARY_PATH dl)


### PR DESCRIPTION
See [this comment](https://sft.its.cern.ch/jira/browse/ROOT-10472?focusedCommentId=106666&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-106666) on JIRA for an explanation.

Closes #4702.
Closes #4750.
