### PR TITLE
[CMake] Install pcms with file(GLOB ...) + install(FILES ...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,11 +414,10 @@ else()
   install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/dictpch DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 endif()
 
+file(GLOB ${pcms} "*.pcm")
 install(
-   DIRECTORY ${CMAKE_BINARY_DIR}/lib/
+   FILES ${pcms}
    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-   FILES_MATCHING PATTERN "*.pcm"
-   PATTERN "*_rdict.pcm" EXCLUDE
 )
 
 #---hsimple.root---------(use the executable for clearer dependencies and proper return code)---
@@ -586,7 +585,3 @@ ROOT_SHOW_ENABLED_OPTIONS()
 
 #---Packaging-------------------------------------------------------------------------------------
 include(RootCPack)
-
-# Exp PyROOT: remove empty directory wrongly created
-# Keep until we figure why it happens
-install(CODE "execute_process(COMMAND bash -c \"rm -rf ${CMAKE_INSTALL_PREFIX}/lib/python*\")")


### PR DESCRIPTION
Due to the default behavior of CMake

https://gitlab.kitware.com/cmake/cmake/issues/17122

when using install(DIRECTORY ... PATTERN), if there are some folders
that don't contain the given PATTERN they are also created as empty
folders.

This was causing the problem already addressed in 1d2e76.

As suggested in

https://stackoverflow.com/questions/55451084/cmake-files-matching-pattern-copies-empty-directories/55722518#55722518

we apply the workaround consisting in addressing the '*pcm' files with
file(GLOB ...) and then install them with install(FILES ...).