### PR TITLE
Fix compiling tutorials with Python 3

### DIFF
--- a/geom/gdml/writer.py
+++ b/geom/gdml/writer.py
@@ -97,7 +97,7 @@ class writer(object):
     def addCutTube(self, name, rmin, rmax, z, startphi, deltaphi, lowX, lowY, lowZ, highX, highY, highZ):
         self.solids[2].append(['cutTube',{'name':name, 'rmin':rmin, 'rmax':rmax,
                                           'z':z, 'startphi':startphi, 'deltaphi':deltaphi,
-					  'lowX':lowX, 'lowY':lowY, 'lowZ':lowZ, 'highX':highX, 'highY':highY, 'highZ':highZ, 'lunit':'cm', 'aunit':'deg'},[]])
+                                          'lowX':lowX, 'lowY':lowY, 'lowZ':lowZ, 'highX':highX, 'highY':highY, 'highZ':highZ, 'lunit':'cm', 'aunit':'deg'},[]])
 
     def addPolycone(self, name, startphi, deltaphi, zplanes):
         zpls = []
@@ -117,14 +117,14 @@ class writer(object):
         self.solids[2].append(['polyhedra',{'name':name,
                                             'startphi':startphi, 'deltaphi':deltaphi,
                                             'numsides':numsides, 'lunit':'cm', 'aunit':'deg'}, zpls])
-					    
+                        
     def addXtrusion(self, name, vertices, sections):
         elems = []
-	for vertex in vertices:
-	    elems.append( ['twoDimVertex',{'x':vertex[0], 'y':vertex[1]},[]] )
-	for section in sections:
-	    elems.append( ['section',{'zOrder':section[0], 'zPosition':section[1], 'xOffset':section[2], 'yOffset':section[3], 'scalingFactor':section[4]},[]] )
-	self.solids[2].append(['xtru',{'name':name, 'lunit':'cm'}, elems])
+        for vertex in vertices:
+            elems.append( ['twoDimVertex',{'x':vertex[0], 'y':vertex[1]},[]] )
+        for section in sections:
+            elems.append( ['section',{'zOrder':section[0], 'zPosition':section[1], 'xOffset':section[2], 'yOffset':section[3], 'scalingFactor':section[4]},[]] )
+        self.solids[2].append(['xtru',{'name':name, 'lunit':'cm'}, elems])
 
     def addEltube(self, name, x, y, z):
         self.solids[2].append( ['eltube', {'name':name, 'dx':x, 'dy':y, 'dz':z, 'lunit':'cm'},[]] )
@@ -218,5 +218,3 @@ class writer(object):
 
         file.write('<?xml version="1.0" encoding="UTF-8" ?>\n')
         writeElement(self.document,'')
-	
-

--- a/tutorials/histfactory/makeQuickModel.py
+++ b/tutorials/histfactory/makeQuickModel.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 #
 # A pyROOT script that allows one to
 # make quick measuremenst.
@@ -9,6 +8,7 @@
 # as well as potentially uncertainties on those
 # values, and returns a fitted signal value
 # and errors
+from __future__ import print_function
 
 
 def main():
@@ -110,8 +110,8 @@ def MakeSimpleMeasurement( signal_val, background_val, data_val, signal_uncertai
 
     try:
         import ROOT
-    except:
-        print "It seems that pyROOT isn't properly configured"
+    except ImportError:
+        print("It seems that pyROOT isn't properly configured")
         return
 
     # Create and name a measurement

--- a/tutorials/pyroot/gui_ex.py
+++ b/tutorials/pyroot/gui_ex.py
@@ -5,6 +5,7 @@
 ## \macro_code
 ##
 ## \author Wim Lavrijsen
+from __future__ import print_function
 
 import os, sys, ROOT
 
@@ -17,7 +18,7 @@ def pygaus( x, par ):
 
       gauss = arg3*arg2*math.exp(-0.5*arg1*arg1)
    else:
-      print 'returning 0'
+      print('returning 0')
       gauss = 0.
    return gauss
 

--- a/tutorials/pyroot/parse_CSV_file_with_TTree_ReadStream.py
+++ b/tutorials/pyroot/parse_CSV_file_with_TTree_ReadStream.py
@@ -35,6 +35,7 @@
 ## \macro_code
 ##
 ## \author Michael Marino
+from __future__ import print_function
 
 import ROOT
 import sys
@@ -83,13 +84,13 @@ def parse_CSV_file_with_TTree_ReadStream(tree_name, afile):
     branch_descriptor = ':'.join([header_mapping_dictionary[row][0]+'/'+
                            type_mapping_dictionary[header_mapping_dictionary[row][1]]
                            for row in header_row])
-    #print branch_descriptor
+    #print(branch_descriptor)
 
     # Handling the input and output names.  Using the same
     # base name for the ROOT output file.
     output_ROOT_file_name  = os.path.splitext(afile)[0] + '.root'
     output_file            = ROOT.TFile(output_ROOT_file_name, 'recreate')
-    print "Outputting %s -> %s" % (afile, output_ROOT_file_name)
+    print("Outputting %s -> %s" % (afile, output_ROOT_file_name))
 
     output_tree            = ROOT.TTree(tree_name, tree_name)
     file_lines             = open(afile).readlines()
@@ -107,7 +108,7 @@ def parse_CSV_file_with_TTree_ReadStream(tree_name, afile):
     # Removing NaN, setting these entries to 0.0.
     # Also joining the list of strings into one large string.
     file_as_string = ('\n'.join(file_lines)).replace('NaN', str(0.0))
-    #print file_as_string
+    #print(file_as_string)
 
     # creating an istringstream to pass into ReadStream
     istring        = ROOT.istringstream(file_as_string)
@@ -121,7 +122,7 @@ def parse_CSV_file_with_TTree_ReadStream(tree_name, afile):
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:
-        print "Usage: %s file_to_parse.dat" % sys.argv[0]
+        print("Usage: %s file_to_parse.dat" % sys.argv[0])
         sys.exit(1)
     parse_CSV_file_with_TTree_ReadStream("example_tree", sys.argv[1])
 


### PR DESCRIPTION
Fixes the errors currently seen when building for conda. After the build `pyc` files are generated and this step fails for some of the tutorials with the following errors:
```
compiling .pyc files...
  File "tutorials/pyroot/gui_ex.py", line 20
    print 'returning 0'
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print('returning 0')?

  File "tutorials/pyroot/parse_CSV_file_with_TTree_ReadStream.py", line 92
    print "Outputting %s -> %s" % (afile, output_ROOT_file_name)
          ^
SyntaxError: invalid syntax

Sorry: TabError: inconsistent use of tabs and spaces in indentation (ROOTwriter.py, line 63)
  File "tutorials/histfactory/makeQuickModel.py", line 114
    print "It seems that pyROOT isn't properly configured"
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("It seems that pyROOT isn't properly configured")?

Sorry: TabError: inconsistent use of tabs and spaces in indentation (writer.py, line 123)
number of files: 6175
```