### PR TITLE
[PyROOT][RF] Add pythonisations for methods in RooAbsPdf.

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2793,6 +2793,10 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
 
    else if ( name == "RooSimultaneous" )
       Utility::AddUsingToClass( pyclass, "plotOn" );
+   else if ( name == "RooAbsPdf" ) {
+      Utility::AddUsingToClass( pyclass, "createChi2" );
+      Utility::AddUsingToClass( pyclass, "chi2FitTo" );
+   }
 
    // TODO: store these on the pythonizations module, not on gRootModule
    // TODO: externalize this code and use update handlers on the python side

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rooabspdf.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rooabspdf.py
@@ -1,0 +1,27 @@
+# Author: Stephan Hagebock CERN 01/2020
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+from libROOTPythonizations import AddUsingToClass
+
+
+@pythonization()
+def pythonize_rooabspdf(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'RooAbsPdf':
+        # Add 'using' overloads for stuff that comes from RooAbsArg
+        AddUsingToClass(klass, 'createChi2')
+        AddUsingToClass(klass, 'chi2FitTo')
+
+    return True


### PR DESCRIPTION
Because of a `using` in RooAbsPdf, PyROOT didn't find 4 overloads of chi2FitTo.