### PR TITLE
correct for Logx when drawing histogram errors

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -6344,6 +6344,10 @@ void THistPainter::PaintErrors(Option_t *)
       // apply offset on errors for bar histograms
       Double_t xminTmp = gPad->XtoPad(fXaxis->GetBinLowEdge(k));
       Double_t xmaxTmp = gPad->XtoPad(fXaxis->GetBinUpEdge(k));
+      if (Hoption.Logx) {
+        xminTmp = TMath::Power(10, xminTmp);
+        xmaxTmp = TMath::Power(10, xmaxTmp);
+      }
       Double_t w    = (xmaxTmp-xminTmp)*width;
       xminTmp += offset*(xmaxTmp-xminTmp);
       xmaxTmp = xminTmp + w;


### PR DESCRIPTION
Fixes the issue raised in the [forum](https://root-forum.cern.ch/t/error-bars-drawn-in-wrong-place-if-setlogx/37507?u=mwilkins) where error bars were drawn in the wrong place if using a log scale in x.
Resolves the [JIRA task](https://sft.its.cern.ch/jira/browse/ROOT-10505).