### PR TITLE
Disable SetLibraryPath for RPATH builds

### DIFF
--- a/rootx/CMakeLists.txt
+++ b/rootx/CMakeLists.txt
@@ -56,3 +56,7 @@ if(x11 OR cocoa)
     ${CMAKE_BINARY_DIR}/include/rootCommandLineOptionsHelp.h
   )
 endif()
+
+if(rpath)
+  add_definitions(-DIS_RPATH_BUILD=1)
+endif()

--- a/rootx/src/rootx.cxx
+++ b/rootx/src/rootx.cxx
@@ -148,7 +148,7 @@ static void SetRootSys()
    }
 }
 
-
+#ifndef IS_RPATH_BUILD
 static void SetLibraryPath()
 {
 #ifdef ROOTPREFIX
@@ -207,6 +207,7 @@ static void SetLibraryPath()
    }
 #endif
 }
+#endif
 
 extern "C" {
    static void SigUsr1(int);
@@ -451,8 +452,10 @@ int main(int argc, char **argv)
       argvv[1+i] = argv[i];
    argvv[1+i] = 0;
 
+#ifndef IS_RPATH_BUILD
    // Make sure library path is set
    SetLibraryPath();
+#endif
 
    // Execute actual ROOT module
    execv(arg0, argvv);


### PR DESCRIPTION
As discussed with @Axel-Naumann on mattermost: https://mattermost.web.cern.ch/root/pl/3en1hqnc9tbftqakg3s3jy4b4c

The conda build has been patching this out since it was first released. There was some issues when building with `runtime_cxxmodules` but those were fixed in #4710.