### PR TITLE
[cxxmodules] Resolve weak symbols from the non-system libs.

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -707,6 +707,7 @@ endif()
 
 if(APPLE AND runtime_cxxmodules)
   # Modules have superior dynamic linker and they can resolve undefined symbols upon library loading.
+  set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -undefined dynamic_lookup")
   set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
 endif()
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6342,8 +6342,7 @@ static std::string ResolveSymbol(const std::string& mangled_name,
       // not strictly require symbols from those sections. Enable after checking
       // performance!
       if (FindSymbol(LibName, mangled_name, /*ignore*/
-                     llvm::object::SymbolRef::SF_Undefined |
-                     llvm::object::SymbolRef::SF_Weak)) {
+                     llvm::object::SymbolRef::SF_Undefined)) {
          sQueriedLibraries.push_back(P);
          return LibName;
       }


### PR DESCRIPTION
This should fix a good number of tests on osx.

cc: @Axel-Naumann 