### PR TITLE
[cxxmodules] Improve ROOT startup time by not merging identifier tables

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderInternals.h
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderInternals.h
@@ -42,7 +42,7 @@ class ASTDeclContextNameLookupTrait {
   
 public:
   // Maximum number of lookup tables we allow before condensing the tables.
-  static const int MaxTables = 4;
+  static const int MaxTables = 256;
 
   /// The lookup result is a list of global declaration IDs.
   typedef llvm::SmallVector<DeclID, 4> data_type;


### PR DESCRIPTION
Each module has a set of identifier tables which aid lookup. Based on this information clang decides if it needs a declaration to be deserialized.

Namespace partitions and other C++ entities may have semantically the same identifier lookup tables across multiple modules. Since lookup is a heavily used operation in compilers clang tries to optimize it as much as possible. In case it sees more than 4 such lookup tables it merges them together into a single table aiming to keep the lookup algorithmic complexity of O(1).

This logic approach has several assumptions:
  * The progam will use only a small superset of the modules it needs;
  * The program will be compiled in multiple TUs and merging of tables will not be called often;

In the interpreter context where we make all module available the merging of such tables becomes CPU intense operation at runtime which produces a lot of temporary reallocations. Moreover, we have seen a lot of profiles where the merging operation dominates (by around 18%).

This patch tries to make the merging far less often. On some short benchmarks ran locally we get (70-80%) runtime improvement and ~10% reduction in memory.