### PR TITLE
[CMake] Temporary solution for installing pcms without using install(DIRECTORY ...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,12 +414,6 @@ else()
   install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/dictpch DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 endif()
 
-file(GLOB ${pcms} "*.pcm")
-install(
-   FILES ${pcms}
-   DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
 #---hsimple.root---------(use the executable for clearer dependencies and proper return code)---
 add_custom_target(hsimple ALL DEPENDS tutorials/hsimple.root)
 add_dependencies(hsimple onepcm)


### PR DESCRIPTION
The changes introduced in 4ce57e copy in the installation directory empty copies of all the directories found in the build directory. This was found out only recently when the MultiPython PR was merged.

The solution introduced in 14366b does not work, since the globbing is performed at configuration time, when the build directory is still empty.

Since commit 4ce57e was introduced only to install the ~10 pcms listed in ll. 4237-4253 of core/dictgen/src/rootcling_impl.cxx, here we find a more suitable solution to achieve this goal.