### PR TITLE
[RF] Change observable type for RooResolutionModel

### DIFF
--- a/roofit/roofit/inc/RooGExpModel.h
+++ b/roofit/roofit/inc/RooGExpModel.h
@@ -42,21 +42,21 @@ public:
     // coverity[UNINIT_CTOR]
   }
 
-  RooGExpModel(const char *name, const char *title, RooRealVar& x,
+  RooGExpModel(const char *name, const char *title, RooAbsRealLValue& x,
           RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& rlife,
           RooAbsReal& meanSF, RooAbsReal& sigmaSF, RooAbsReal& rlifeSF,
           Bool_t nlo=kFALSE, Type type=Normal) ;
 
-  RooGExpModel(const char *name, const char *title, RooRealVar& x,
+  RooGExpModel(const char *name, const char *title, RooAbsRealLValue& x,
           RooAbsReal& sigma, RooAbsReal& rlife,
           Bool_t nlo=kFALSE, Type type=Normal) ;
 
-  RooGExpModel(const char *name, const char *title, RooRealVar& x,
+  RooGExpModel(const char *name, const char *title, RooAbsRealLValue& x,
           RooAbsReal& sigma, RooAbsReal& rlife,
           RooAbsReal& srSF,
           Bool_t nlo=kFALSE, Type type=Normal) ;
 
-  RooGExpModel(const char *name, const char *title, RooRealVar& x,
+  RooGExpModel(const char *name, const char *title, RooAbsRealLValue& x,
           RooAbsReal& sigma, RooAbsReal& rlife,
           RooAbsReal& sigmaSF, RooAbsReal& rlifeSF,
           Bool_t nlo=kFALSE, Type type=Normal) ;

--- a/roofit/roofit/inc/RooGaussModel.h
+++ b/roofit/roofit/inc/RooGaussModel.h
@@ -39,11 +39,11 @@ public:
 
   // Constructors, assignment etc
   inline RooGaussModel() : _flatSFInt(kFALSE), _asympInt(kFALSE) { }
-  RooGaussModel(const char *name, const char *title, RooRealVar& x,
+  RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
       RooAbsReal& mean, RooAbsReal& sigma) ;
-  RooGaussModel(const char *name, const char *title, RooRealVar& x,
+  RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
       RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& msSF) ;
-  RooGaussModel(const char *name, const char *title, RooRealVar& x,
+  RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
       RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& meanSF, RooAbsReal& sigmaSF) ;
   RooGaussModel(const RooGaussModel& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooGaussModel(*this,newname) ; }

--- a/roofit/roofit/src/RooGExpModel.cxx
+++ b/roofit/roofit/src/RooGExpModel.cxx
@@ -58,7 +58,7 @@ ClassImp(RooGExpModel);
 /// \param[in] rlifeSF Scale factor for rlife.
 /// \param[in] nlo   Include next-to-leading order for higher accuracy of convolution.
 /// \param[in] type  Switch between normal and flipped model.
-RooGExpModel::RooGExpModel(const char *name, const char *title, RooRealVar& xIn,
+RooGExpModel::RooGExpModel(const char *name, const char *title, RooAbsRealLValue& xIn,
     RooAbsReal& meanIn, RooAbsReal& sigmaIn, RooAbsReal& rlifeIn,
     RooAbsReal& meanSF, RooAbsReal& sigmaSF, RooAbsReal& rlifeSF,
     Bool_t nlo, Type type) :
@@ -87,7 +87,7 @@ RooGExpModel::RooGExpModel(const char *name, const char *title, RooRealVar& xIn,
 /// \param[in] rlife Lifetime constant \f$ \tau \f$.
 /// \param[in] nlo   Include next-to-leading order for higher accuracy of convolution.
 /// \param[in] type  Switch between normal and flipped model.
-RooGExpModel::RooGExpModel(const char *name, const char *title, RooRealVar& xIn,
+RooGExpModel::RooGExpModel(const char *name, const char *title, RooAbsRealLValue& xIn,
             RooAbsReal& _sigma, RooAbsReal& _rlife,
             Bool_t nlo, Type type) :
   RooResolutionModel(name,title,xIn),
@@ -112,7 +112,7 @@ RooGExpModel::RooGExpModel(const char *name, const char *title, RooRealVar& xIn,
 /// \param[in] srSF Scale factor for both sigma and tau.
 /// \param[in] nlo   Include next-to-leading order for higher accuracy of convolution.
 /// \param[in] type  Switch between normal and flipped model.
-RooGExpModel::RooGExpModel(const char *name, const char *title, RooRealVar& xIn,
+RooGExpModel::RooGExpModel(const char *name, const char *title, RooAbsRealLValue& xIn,
             RooAbsReal& _sigma, RooAbsReal& _rlife,
             RooAbsReal& _rsSF,
             Bool_t nlo, Type type) :
@@ -142,7 +142,7 @@ RooGExpModel::RooGExpModel(const char *name, const char *title, RooRealVar& xIn,
 /// \param[in] rlifeSF Scale factor for rlife.
 /// \param[in] nlo   Include next-to-leading order for higher accuracy of convolution.
 /// \param[in] type  Switch between normal and flipped model.
-RooGExpModel::RooGExpModel(const char *name, const char *title, RooRealVar& xIn,
+RooGExpModel::RooGExpModel(const char *name, const char *title, RooAbsRealLValue& xIn,
             RooAbsReal& _sigma, RooAbsReal& _rlife,
             RooAbsReal& _sigmaSF, RooAbsReal& _rlifeSF,
             Bool_t nlo, Type type) :

--- a/roofit/roofit/src/RooGaussModel.cxx
+++ b/roofit/roofit/src/RooGaussModel.cxx
@@ -39,7 +39,7 @@ ClassImp(RooGaussModel);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooGaussModel::RooGaussModel(const char *name, const char *title, RooRealVar& xIn,
+RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsRealLValue& xIn,
               RooAbsReal& _mean, RooAbsReal& _sigma) :
   RooResolutionModel(name,title,xIn),
   _flatSFInt(kFALSE),
@@ -53,7 +53,7 @@ RooGaussModel::RooGaussModel(const char *name, const char *title, RooRealVar& xI
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooGaussModel::RooGaussModel(const char *name, const char *title, RooRealVar& xIn,
+RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsRealLValue& xIn,
               RooAbsReal& _mean, RooAbsReal& _sigma,
               RooAbsReal& _msSF) :
   RooResolutionModel(name,title,xIn),
@@ -68,7 +68,7 @@ RooGaussModel::RooGaussModel(const char *name, const char *title, RooRealVar& xI
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooGaussModel::RooGaussModel(const char *name, const char *title, RooRealVar& xIn,
+RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsRealLValue& xIn,
               RooAbsReal& _mean, RooAbsReal& _sigma,
               RooAbsReal& _meanSF, RooAbsReal& _sigmaSF) :
   RooResolutionModel(name,title,xIn),

--- a/roofit/roofitcore/inc/LinkDef3.h
+++ b/roofit/roofitcore/inc/LinkDef3.h
@@ -15,8 +15,14 @@
 #pragma link C++ class RooRealMPFE+ ;
 #pragma link C++ class RooRealProxy+ ;
 #pragma link C++ class RooPdfProxy+;
+#pragma read sourceClass="RooRealProxy" targetClass="RooPdfProxy" version="[1]" \
+  source="" target=""
 #pragma link C++ class RooLVarProxy+;
+#pragma read sourceClass="RooRealProxy" targetClass="RooLVarProxy" version="[1]" \
+  source="" target=""
 #pragma link C++ class RooRealVarProxy+;
+#pragma read sourceClass="RooRealProxy" targetClass="RooRealVarProxy" version="[1]" \
+  source="" target=""
 #pragma link C++ class RooRealVar- ;
 #pragma link C++ class RooRealVarSharedProperties+ ;
 #pragma link C++ class RooRefCountList+ ;

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -132,9 +132,7 @@ protected:
 
   RooListProxy _pdfList ;   //  List of component PDFs
   RooListProxy _coefList ;  //  List of coefficients
-  mutable RooArgList* _snormList ;  //!  List of supplemental normalization factors
-  TIterator* _pdfIter ;     //! Iterator over PDF list
-  TIterator* _coefIter ;    //! Iterator over coefficient list
+  mutable RooArgList* _snormList{nullptr};  //!  List of supplemental normalization factors
   
   Bool_t _haveLastCoef ;    //  Flag indicating if last PDFs coefficient was supplied in the ctor
   Bool_t _allExtendable ;   //  Flag indicating if all PDF components are extendable

--- a/roofit/roofitcore/inc/RooResolutionModel.h
+++ b/roofit/roofitcore/inc/RooResolutionModel.h
@@ -28,7 +28,7 @@ public:
 
   // Constructors, assignment etc
   inline RooResolutionModel() : _basis(0) { }
-  RooResolutionModel(const char *name, const char *title, RooRealVar& x) ; 
+  RooResolutionModel(const char *name, const char *title, RooAbsRealLValue& x) ;
   RooResolutionModel(const RooResolutionModel& other, const char* name=0);
   virtual TObject* clone(const char* newname) const = 0 ;
   virtual ~RooResolutionModel();
@@ -61,7 +61,7 @@ protected:
 
   friend class RooConvGenContext ;
   friend class RooAddModel ;
-  RooRealProxy x ;                   // Dependent/convolution variable
+  RooLVarProxy x ;                   // Dependent/convolution variable
 
   virtual Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
 //  Bool_t traceEvalHook(Double_t value) const ;

--- a/roofit/roofitcore/inc/RooResolutionModel.h
+++ b/roofit/roofitcore/inc/RooResolutionModel.h
@@ -73,7 +73,7 @@ protected:
   RooFormulaVar* _basis ;    // Basis function convolved with this resolution model
   Bool_t _ownBasis ;         // Flag indicating ownership of _basis 
 
-  ClassDef(RooResolutionModel,1) // Abstract Resolution Model
+  ClassDef(RooResolutionModel, 2) // Abstract Resolution Model
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooTemplateProxy.h
+++ b/roofit/roofitcore/inc/RooTemplateProxy.h
@@ -121,16 +121,16 @@ private:
     return lvptr_impl(static_cast<T*>(nullptr));
   }
 
-  /// Overload with RooAbsRealLValue and derived types. Just returns the pointer.
+  /// Overload when the class template parameter is RooAbsRealLValue or more derived. Just returns the pointer.
   RooAbsRealLValue* lvptr_impl(RooAbsRealLValue*) const {
-    return _arg;
+    return static_cast<RooAbsRealLValue*>(_arg);
   }
 
-  /// Overload with base types. Attempts a cast.
-  /// \deprecated The payload of this proxy should be at least RooAbsRealLValue or more derived for
-  /// this function to be called safely.
+  /// Overload for cases where the class template parameter is does not derive from RooAbsRealLValue. Attempts a cast.
+  /// \deprecated Instead of using a proxy with a base type like RooAbsReal, change the template parameter to a type that
+  /// makes downcasting to RooAbsRealLValue unnecessary.
   RooAbsRealLValue* lvptr_impl(RooAbsArg*) const
-    R__SUGGEST_ALTERNATIVE("The template argument of RooTemplateProxy needs to derive from RooAbsRealLValue.") {
+    R__SUGGEST_ALTERNATIVE("Change the template parameter to RooAbsRealLValue or more derived when using functions that assume that the proxied object is RooAbsRealLValue.") {
 #ifdef NDEBUG
     return static_cast<RooAbsRealLValue*>(_arg);
 #else

--- a/roofit/roofitcore/inc/RooTruthModel.h
+++ b/roofit/roofitcore/inc/RooTruthModel.h
@@ -36,7 +36,7 @@ public:
 
   // Constructors, assignment etc
   inline RooTruthModel() { }
-  RooTruthModel(const char *name, const char *title, RooRealVar& x) ; 
+  RooTruthModel(const char *name, const char *title, RooAbsRealLValue& x) ;
   RooTruthModel(const RooTruthModel& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooTruthModel(*this,newname) ; }
   virtual ~RooTruthModel();

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2768,8 +2768,8 @@ void removeRangeOverlap(std::vector<std::pair<double, double>>& ranges) {
 ///               states with indices -1 and +1 or three states with indeces -1,0 and +1.
 /// <tr><td> `ShiftToZero(Bool_t flag)`         <td>  Shift entire curve such that lowest visible point is at exactly zero.
 ///               Mostly useful when plotting -log(L) or \f$ \chi^2 \f$ distributions
-/// <tr><td> `AddTo(const char* name, double_t wgtSelf, double_t wgtOther)`  <td>  Add constructed projection to
-///               already existing curve with given name and relative weight factors
+/// <tr><td> `AddTo(const char* name, double_t wgtSelf, double_t wgtOther)`  <td>  Create a projection of this PDF onto the x-axis, but
+///               instead of plotting it directly, add it to an existing curve with given name (and relative weight factors).
 /// <tr><td> `Components(const char* names)`  <td>  When plotting sums of PDFs, plot only the named components (*e.g.* only
 ///                                                 the signal of a signal+background model).
 /// <tr><td> `Components(const RooArgSet& compSet)` <td> As above, but pass a RooArgSet of the components themselves.

--- a/roofit/roofitcore/src/RooAddGenContext.cxx
+++ b/roofit/roofitcore/src/RooAddGenContext.cxx
@@ -117,14 +117,12 @@ RooAddGenContext::RooAddGenContext(const RooAddModel &model, const RooArgSet &va
   _pdfSet = (RooArgSet*) RooArgSet(model).snapshot(kTRUE) ;
   _pdf = (RooAbsPdf*) _pdfSet->find(model.GetName()) ;
 
-
-  model._pdfIter->Reset() ;
-  RooAbsPdf* pdf ;
   _nComp = model._pdfList.getSize() ;
   _coefThresh = new Double_t[_nComp+1] ;
   _vars = (RooArgSet*) vars.snapshot(kFALSE) ;
 
-  while((pdf=(RooAbsPdf*)model._pdfIter->Next())) {
+  for (const auto obj : model._pdfList) {
+    auto pdf = static_cast<RooAbsPdf*>(obj);
     RooAbsGenContext* cx = pdf->genContext(vars,prototype,auxProto,verbose) ;
     _gcList.push_back(cx) ;
   }  

--- a/roofit/roofitcore/src/RooResolutionModel.cxx
+++ b/roofit/roofitcore/src/RooResolutionModel.cxx
@@ -34,30 +34,31 @@
  *  \f[
  *    \mathrm{PDF}(x,\bar a, \bar b, \bar c) = \sum_k \mathrm{coef}_k(\bar a) * R_k(x, \bar b, \bar c)
  *  \f]
+ *
  *  A minimal implementation of a RooResolutionModel consists of a
  *  ```
  *    Int_t basisCode(const char* name)
  *  ```
- *  function indication which basis functions this resolution model supports, and
+ *  function indicating which basis functions this resolution model supports, and
  *  ```
- *    Double_t evaluate()
+ *    Double_t evaluate(),
  *  ```
- *  Implementing the resolution model, optionally convoluted with one of the
- *  supported basis functions. RooResolutionModel objects can be used as regular
+ *  which should implement the resolution model (optionally convoluted with one of the
+ *  supported basis functions). RooResolutionModel objects can be used as regular
  *  PDFs (They inherit from RooAbsPdf), or as resolution model convoluted with
  *  a basis function. The implementation of evaluate() can identify the requested
- *  from of use from the basisCode() function. If zero, the regular PDF value
- *  should be calculated. If non-zero, the models value convoluted with the
+ *  mode using basisCode(). If zero, the regular PDF value
+ *  should be calculated. If non-zero, the model's value convoluted with the
  *  basis function identified by the code should be calculated.
  *
  *  Optionally, analytical integrals can be advertised and implemented, in the
  *  same way as done for regular PDFS (see RooAbsPdf for further details).
- *  Also in getAnalyticalIntegral()/analyticalIntegral() the implementation
+ *  Also in getAnalyticalIntegral() / analyticalIntegral(), the implementation
  *  should use basisCode() to determine for which scenario the integral is
  *  requested.
  *
  *  The choice of basis returned by basisCode() is guaranteed not to change
- *  of the lifetime of a RooResolutionModel object.
+ *  during the lifetime of a RooResolutionModel object.
  *
  */
 
@@ -75,9 +76,11 @@ ClassImp(RooResolutionModel);
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor with convolution variable 'x'
-
-RooResolutionModel::RooResolutionModel(const char *name, const char *title, RooRealVar& _x) : 
+/// Constructor with convolution variable 'x'.
+/// The convolution variable needs to be convertable to real values, and be able
+/// to give information about its range. This is supported by e.g. RooRealVar or RooLinearVar, which
+/// accepts offsetting and scaling an observable.
+RooResolutionModel::RooResolutionModel(const char *name, const char *title, RooAbsRealLValue& _x) :
   RooAbsPdf(name,title), 
   x("x","Dependent or convolution variable",this,_x),
   _basisCode(0), _basis(0), 

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -20,7 +20,7 @@
 \ingroup Roofitcore
 
 RooTruthModel is an implementation of RooResolution
-model that provides a delta-function resolution model
+model that provides a delta-function resolution model.
 The truth model supports <i>all</i> basis functions because it evaluates each basis function as  
 as a RooFormulaVar.  The 6 basis functions used in B mixing and decay and 2 basis
 functions used in D mixing have been hand coded for increased execution speed.
@@ -46,7 +46,7 @@ ClassImp(RooTruthModel);
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor of a truth resolution model, i.e. a delta function in observable 'xIn'
 
-RooTruthModel::RooTruthModel(const char *name, const char *title, RooRealVar& xIn) : 
+RooTruthModel::RooTruthModel(const char *name, const char *title, RooAbsRealLValue& xIn) :
   RooResolutionModel(name,title,xIn)
 {  
 }


### PR DESCRIPTION
RooResolutionModel was using RooRealVar as the type for the convolution
observable. That is an unneccessary restriction, as scaling and shifting
using e.g. RooLinearVar is possible. By accepting the base type
RooAbsRealLValue as convolution observable, all observables of resolution
models can now be scaled and shifted.