### PR TITLE
Revert changes done for installations of pcms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,10 +414,11 @@ else()
   install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/dictpch DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 endif()
 
-file(GLOB ${pcms} "*.pcm")
 install(
-   FILES ${pcms}
+   DIRECTORY ${CMAKE_BINARY_DIR}/lib/
    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   FILES_MATCHING PATTERN "*.pcm"
+   PATTERN "*_rdict.pcm" EXCLUDE
 )
 
 #---hsimple.root---------(use the executable for clearer dependencies and proper return code)---
@@ -585,3 +586,7 @@ ROOT_SHOW_ENABLED_OPTIONS()
 
 #---Packaging-------------------------------------------------------------------------------------
 include(RootCPack)
+
+# Exp PyROOT: remove empty directory wrongly created
+# Keep until we figure why it happens
+install(CODE "execute_process(COMMAND bash -c \"rm -rf ${CMAKE_INSTALL_PREFIX}/lib/python*\")")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,7 +586,3 @@ ROOT_SHOW_ENABLED_OPTIONS()
 
 #---Packaging-------------------------------------------------------------------------------------
 include(RootCPack)
-
-# Exp PyROOT: remove empty directory wrongly created
-# Keep until we figure why it happens
-install(CODE "execute_process(COMMAND bash -c \"rm -rf ${CMAKE_INSTALL_PREFIX}/lib/python*\")")

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -428,7 +428,10 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     endif(ARG_MULTIDICT)
 
     if(runtime_cxxmodules)
-      set(pcm_name)
+      # Currently we are not able to build R C++ module, so we still need to be able to install it's _rdict.pcm.
+      if(NOT ARG_NO_CXXMODULE)
+        set(pcm_name)
+      endif()
       if(cpp_module)
         set(cpp_module_file ${library_output_dir}/${cpp_module}.pcm)
         if (APPLE)

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -428,7 +428,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     endif(ARG_MULTIDICT)
 
     if(runtime_cxxmodules)
-      # Currently we are not able to build R C++ module, so we still need to be able to install it's _rdict.pcm.
+      # If we specify NO_CXXMODULE we should be able to still install the produced _rdict.pcm file.
       if(NOT ARG_NO_CXXMODULE)
         set(pcm_name)
       endif()


### PR DESCRIPTION
Currently we are not ready for this cleanup, since we have a special PCMS are generated via rootcling call for Core as extra PCMS, that leaves no trace in ROOT build system and we can't properly control it.
We need urgently move generation of special PCMs to use proper CMake targets (it will be enabled after 6.20).