### PR TITLE
[hist] Formatted the files realted to TGraphMultiErrors

### DIFF
--- a/hist/hist/inc/TGraphMultiErrors.h
+++ b/hist/hist/inc/TGraphMultiErrors.h
@@ -28,33 +28,34 @@ class TArrayD;
 class TGraphMultiErrors : public TGraph {
 
 protected:
-   Int_t fNYErrors;                  ///< The amount of different y-errors
-   Int_t fSumErrorsMode;             ///< How y errors are summed: kOnlyFirst = Only First; kSquareSum = Squared Sum; kSum = Absolute Addition
-   Double_t *fExL;                   ///<[fNpoints] array of X low errors
-   Double_t *fExH;                   ///<[fNpoints] array of X high errors
-   std::vector<TArrayD> fEyL;        ///< two dimensional array of Y low errors
-   std::vector<TArrayD> fEyH;        ///< two dimensional array of Y high errors
+   Int_t fNYErrors;           ///< The amount of different y-errors
+   Int_t fSumErrorsMode;      ///< How y errors are summed: kOnlyFirst = Only First; kSquareSum = Squared Sum; kSum =
+                              ///< Absolute Addition
+   Double_t *fExL;            ///<[fNpoints] array of X low errors
+   Double_t *fExH;            ///<[fNpoints] array of X high errors
+   std::vector<TArrayD> fEyL; ///< two dimensional array of Y low errors
+   std::vector<TArrayD> fEyH; ///< two dimensional array of Y high errors
    mutable Double_t *fEyLSum = nullptr; ///<! array of summed Y low errors for fitting
    mutable Double_t *fEyHSum = nullptr; ///<! array of summed Y high errors for fitting
-   std::vector<TAttFill> fAttFill;   ///< the AttFill attributes of the different errors
-   std::vector<TAttLine> fAttLine;   ///< the AttLine attributes of the different errors
+   std::vector<TAttFill> fAttFill;      ///< the AttFill attributes of the different errors
+   std::vector<TAttLine> fAttLine;      ///< the AttLine attributes of the different errors
 
    virtual Double_t **Allocate(Int_t size);
-   Bool_t             CtorAllocate();
+   Bool_t CtorAllocate();
 
-   virtual void       CopyAndRelease(Double_t **newarrays, Int_t ibegin, Int_t iend, Int_t obegin);
-   virtual Bool_t     CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend, Int_t obegin);
-   virtual void       FillZero(Int_t begin, Int_t end, Bool_t from_ctor = kTRUE);
+   virtual void CopyAndRelease(Double_t **newarrays, Int_t ibegin, Int_t iend, Int_t obegin);
+   virtual Bool_t CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend, Int_t obegin);
+   virtual void FillZero(Int_t begin, Int_t end, Bool_t from_ctor = kTRUE);
 
-   void               CalcYErrorsSum() const;
-   virtual Bool_t     DoMerge(const TGraph *tg);
-   virtual void       SwapPoints(Int_t pos1, Int_t pos2);
+   void CalcYErrorsSum() const;
+   virtual Bool_t DoMerge(const TGraph *tg);
+   virtual void SwapPoints(Int_t pos1, Int_t pos2);
 
 public:
    enum ESummationModes {
       kOnlyFirst = 0, ///< Only take errors from first dimension
       kSquareSum = 1, ///< Calculate the square sum of all errors
-      kAbsSum    = 2  ///< Calculate the absolute sum of all errors
+      kAbsSum = 2     ///< Calculate the absolute sum of all errors
    };
 
    TGraphMultiErrors();
@@ -62,29 +63,55 @@ public:
    TGraphMultiErrors(Int_t np, Int_t ne = 1);
    TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne = 1);
 
-   TGraphMultiErrors(Int_t np, const Float_t *x, const Float_t *y, const Float_t *exL = nullptr, const Float_t *exH = nullptr, const Float_t *eyL = nullptr, const Float_t *eyH = nullptr, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, const Float_t *x, const Float_t *y, const Float_t *exL = nullptr, const Float_t *exH = nullptr, const Float_t *eyL = nullptr, const Float_t *eyH = nullptr, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(Int_t np, const Double_t *x, const Double_t *y, const Double_t *exL = nullptr, const Double_t *exH = nullptr, const Double_t *eyL = nullptr, const Double_t *eyH = nullptr, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, const Double_t *x, const Double_t *y, const Double_t *exL = nullptr, const Double_t *exH = nullptr, const Double_t *eyL = nullptr, const Double_t *eyH = nullptr, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(Int_t np, const Float_t *x, const Float_t *y, const Float_t *exL = nullptr,
+                     const Float_t *exH = nullptr, const Float_t *eyL = nullptr, const Float_t *eyH = nullptr,
+                     Int_t m = kOnlyFirst);
+   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, const Float_t *x, const Float_t *y,
+                     const Float_t *exL = nullptr, const Float_t *exH = nullptr, const Float_t *eyL = nullptr,
+                     const Float_t *eyH = nullptr, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(Int_t np, const Double_t *x, const Double_t *y, const Double_t *exL = nullptr,
+                     const Double_t *exH = nullptr, const Double_t *eyL = nullptr, const Double_t *eyH = nullptr,
+                     Int_t m = kOnlyFirst);
+   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, const Double_t *x, const Double_t *y,
+                     const Double_t *exL = nullptr, const Double_t *exH = nullptr, const Double_t *eyL = nullptr,
+                     const Double_t *eyH = nullptr, Int_t m = kOnlyFirst);
 
-   TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, std::vector<std::vector<Float_t>> eyL, std::vector<std::vector<Float_t>> eyH, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, std::vector<std::vector<Float_t>> eyL, std::vector<std::vector<Float_t>> eyH, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, std::vector<std::vector<Double_t>> eyL, std::vector<std::vector<Double_t>> eyH, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, std::vector<std::vector<Double_t>> eyL, std::vector<std::vector<Double_t>> eyH, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH,
+                     std::vector<std::vector<Float_t>> eyL, std::vector<std::vector<Float_t>> eyH,
+                     Int_t m = kOnlyFirst);
+   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Float_t *x, const Float_t *y,
+                     const Float_t *exL, const Float_t *exH, std::vector<std::vector<Float_t>> eyL,
+                     std::vector<std::vector<Float_t>> eyH, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH,
+                     std::vector<std::vector<Double_t>> eyL, std::vector<std::vector<Double_t>> eyH,
+                     Int_t m = kOnlyFirst);
+   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Double_t *x, const Double_t *y,
+                     const Double_t *exL, const Double_t *exH, std::vector<std::vector<Double_t>> eyL,
+                     std::vector<std::vector<Double_t>> eyH, Int_t m = kOnlyFirst);
 
-   TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, std::vector<TArrayF> eyL, std::vector<TArrayF> eyH, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, std::vector<TArrayF> eyL, std::vector<TArrayF> eyH, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, std::vector<TArrayD> eyL, std::vector<TArrayD> eyH, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, std::vector<TArrayD> eyL, std::vector<TArrayD> eyH, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH,
+                     std::vector<TArrayF> eyL, std::vector<TArrayF> eyH, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Float_t *x, const Float_t *y,
+                     const Float_t *exL, const Float_t *exH, std::vector<TArrayF> eyL, std::vector<TArrayF> eyH,
+                     Int_t m = kOnlyFirst);
+   TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH,
+                     std::vector<TArrayD> eyL, std::vector<TArrayD> eyH, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Double_t *x, const Double_t *y,
+                     const Double_t *exL, const Double_t *exH, std::vector<TArrayD> eyL, std::vector<TArrayD> eyH,
+                     Int_t m = kOnlyFirst);
 
-   TGraphMultiErrors(const TVectorF &tvX, const TVectorF &tvY, const TVectorF &tvExL, const TVectorF &tvExH, const TVectorF &tvEyL, const TVectorF &tvEyH, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(const TVectorD &tvX, const TVectorD &tvY, const TVectorD &tvExL, const TVectorD &tvExH, const TVectorD &tvEyL, const TVectorD &tvEyH, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(const TVectorF &tvX, const TVectorF &tvY, const TVectorF &tvExL, const TVectorF &tvExH,
+                     const TVectorF &tvEyL, const TVectorF &tvEyH, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(const TVectorD &tvX, const TVectorD &tvY, const TVectorD &tvExL, const TVectorD &tvExH,
+                     const TVectorD &tvEyL, const TVectorD &tvEyH, Int_t m = kOnlyFirst);
 
-   TGraphMultiErrors(Int_t ne, const TVectorF &tvX, const TVectorF &tvY, const TVectorF &tvExL, const TVectorF &tvExH, const TVectorF *tvEyL, const TVectorF *tvEyH, Int_t m = kOnlyFirst);
-   TGraphMultiErrors(Int_t ne, const TVectorD &tvX, const TVectorD &tvY, const TVectorD &tvExL, const TVectorD &tvExH, const TVectorD *tvEyL, const TVectorD *tvEyH, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(Int_t ne, const TVectorF &tvX, const TVectorF &tvY, const TVectorF &tvExL, const TVectorF &tvExH,
+                     const TVectorF *tvEyL, const TVectorF *tvEyH, Int_t m = kOnlyFirst);
+   TGraphMultiErrors(Int_t ne, const TVectorD &tvX, const TVectorD &tvY, const TVectorD &tvExL, const TVectorD &tvExH,
+                     const TVectorD *tvEyL, const TVectorD *tvEyH, Int_t m = kOnlyFirst);
 
    TGraphMultiErrors(const TGraphMultiErrors &tgme);
-   TGraphMultiErrors& operator=(const TGraphMultiErrors &tgme);
+   TGraphMultiErrors &operator=(const TGraphMultiErrors &tgme);
 
    TGraphMultiErrors(const TH1 *th, Int_t ne = 1);
    TGraphMultiErrors(const TH1 *pass, const TH1 *total, Int_t ne = 1, Option_t *option = "");
@@ -94,7 +121,7 @@ public:
    virtual void AddYError(Int_t np, const Double_t *eyL = nullptr, const Double_t *eyH = nullptr);
    virtual void Apply(TF1 *f);
    virtual void BayesDivide(const TH1 *pass, const TH1 *total, Option_t *opt = "");
-   void         Divide(const TH1 *pass, const TH1 *total, Option_t *opt = "cp");
+   void Divide(const TH1 *pass, const TH1 *total, Option_t *opt = "cp");
    virtual void ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const;
    virtual void DeleteYError(Int_t e);
 
@@ -139,7 +166,8 @@ public:
    virtual void Print(Option_t *chopt = "") const;
    virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
 
-   virtual void SetPointError(Double_t exL, Double_t exH, Double_t eyL1, Double_t eyH1, Double_t eyL2 = 0., Double_t eyH2 = 0., Double_t eyL3 = 0., Double_t eyH3 = 0.); // *MENU*
+   virtual void SetPointError(Double_t exL, Double_t exH, Double_t eyL1, Double_t eyH1, Double_t eyL2 = 0.,
+                              Double_t eyH2 = 0., Double_t eyL3 = 0., Double_t eyH3 = 0.); // *MENU*
    virtual void SetPointError(Int_t i, Int_t ne, Double_t exL, Double_t exH, const Double_t *eyL, const Double_t *eyH);
 
    virtual void SetPointEX(Int_t i, Double_t exL, Double_t exH);
@@ -156,7 +184,11 @@ public:
    virtual void SetEYlow(Int_t e, Int_t np, const Double_t *eyL);
    virtual void SetEYhigh(Int_t e, Int_t np, const Double_t *eyH);
 
-   virtual void SetSumErrorsMode(Int_t m) { fSumErrorsMode = m; CalcYErrorsSum(); }
+   virtual void SetSumErrorsMode(Int_t m)
+   {
+      fSumErrorsMode = m;
+      CalcYErrorsSum();
+   }
 
    virtual void SetAttFill(Int_t e, TAttFill *taf);
    virtual void SetAttLine(Int_t e, TAttLine *tal);

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -72,15 +72,15 @@ Begin_Macro(source)
 }
 End_Macro
 */
-
-///////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 /// TGraphMultiErrors default constructor.
 
-TGraphMultiErrors::TGraphMultiErrors() : TGraph(), fNYErrors(0), fSumErrorsMode(TGraphMultiErrors::kOnlyFirst), fExL(nullptr), fExH(nullptr)
+TGraphMultiErrors::TGraphMultiErrors()
+   : TGraph(), fNYErrors(0), fSumErrorsMode(TGraphMultiErrors::kOnlyFirst), fExL(nullptr), fExH(nullptr)
 {
 }
 
-///////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 /// TGraphMultiErrors default constructor with name and title.
 
 TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title) : TGraphMultiErrors()
@@ -93,7 +93,8 @@ TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title) : 
 ///
 /// All values are initialized to 0.
 
-TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne) : TGraph(np), fNYErrors(ne), fSumErrorsMode(TGraphMultiErrors::kOnlyFirst)
+TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne)
+   : TGraph(np), fNYErrors(ne), fSumErrorsMode(TGraphMultiErrors::kOnlyFirst)
 {
    CtorAllocate();
 }
@@ -103,7 +104,8 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne) : TGraph(np), fNYErrors
 ///
 /// All values are initialized to 0.
 
-TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne) : TGraphMultiErrors(np, ne)
+TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne)
+   : TGraphMultiErrors(np, ne)
 {
    SetNameTitle(name, title);
 }
@@ -114,20 +116,30 @@ TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, In
 /// The signature of this constructor is equal to the corresponding constructor of TGraphAsymmErrors.
 /// If exL,H or eyL,H are NULL, the corresponding values are preset to zero.
 
-TGraphMultiErrors::TGraphMultiErrors(Int_t np, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, const Float_t *eyL, const Float_t *eyH, Int_t m) : TGraph(np, x, y), fNYErrors(1), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(Int_t np, const Float_t *x, const Float_t *y, const Float_t *exL,
+                                     const Float_t *exH, const Float_t *eyL, const Float_t *eyH, Int_t m)
+   : TGraph(np, x, y), fNYErrors(1), fSumErrorsMode(m)
 {
    if (!CtorAllocate())
       return;
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      if (exL) fExL[i] = exL[i];
-      else     fExL[i] = 0.;
-      if (exH) fExH[i] = exH[i];
-      else     fExH[i] = 0.;
-      if (eyL) fEyL[0][i] = eyL[i];
-      else     fEyL[0][i] = 0.;
-      if (eyH) fEyH[0][i] = eyH[i];
-      else     fEyH[0][i] = 0.;
+      if (exL)
+         fExL[i] = exL[i];
+      else
+         fExL[i] = 0.;
+      if (exH)
+         fExH[i] = exH[i];
+      else
+         fExH[i] = 0.;
+      if (eyL)
+         fEyL[0][i] = eyL[i];
+      else
+         fEyL[0][i] = 0.;
+      if (eyH)
+         fEyH[0][i] = eyH[i];
+      else
+         fEyH[0][i] = 0.;
    }
 
    CalcYErrorsSum();
@@ -138,7 +150,10 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t np, const Float_t *x, const Float_t *
 ///
 /// If exL,H or eyL,H are NULL, the corresponding values are preset to zero.
 
-TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, const Float_t *eyL, const Float_t *eyH, Int_t m) : TGraphMultiErrors(np, x, y, exL, exH, eyL, eyH, m)
+TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, const Float_t *x,
+                                     const Float_t *y, const Float_t *exL, const Float_t *exH, const Float_t *eyL,
+                                     const Float_t *eyH, Int_t m)
+   : TGraphMultiErrors(np, x, y, exL, exH, eyL, eyH, m)
 {
    SetNameTitle(name, title);
 }
@@ -149,23 +164,33 @@ TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, In
 /// The signature of this constructor is equal to the corresponding constructor of TGraphAsymmErrors.
 /// If exL,H or eyL,H are NULL, the corresponding values are preset to zero.
 
-TGraphMultiErrors::TGraphMultiErrors(Int_t np, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, const Double_t *eyL, const Double_t *eyH, Int_t m) : TGraph(np, x, y), fNYErrors(1), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(Int_t np, const Double_t *x, const Double_t *y, const Double_t *exL,
+                                     const Double_t *exH, const Double_t *eyL, const Double_t *eyH, Int_t m)
+   : TGraph(np, x, y), fNYErrors(1), fSumErrorsMode(m)
 {
    if (!CtorAllocate())
       return;
 
    Int_t n = fNpoints * sizeof(Double_t);
 
-   if (exL) memcpy(fExL, exL, n);
-   else     memset(fExL, 0, n);
-   if (exH) memcpy(fExH, exH, n);
-   else     memset(fExH, 0, n);
+   if (exL)
+      memcpy(fExL, exL, n);
+   else
+      memset(fExL, 0, n);
+   if (exH)
+      memcpy(fExH, exH, n);
+   else
+      memset(fExH, 0, n);
 
-   if (eyL) fEyL[0].Set(fNpoints, eyL);
-   else     fEyL[0].Reset(0.);
+   if (eyL)
+      fEyL[0].Set(fNpoints, eyL);
+   else
+      fEyL[0].Reset(0.);
 
-   if (eyH) fEyH[0].Set(fNpoints, eyH);
-   else     fEyH[0].Reset(0.);
+   if (eyH)
+      fEyH[0].Set(fNpoints, eyH);
+   else
+      fEyH[0].Reset(0.);
 
    CalcYErrorsSum();
 }
@@ -175,7 +200,10 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t np, const Double_t *x, const Double_t
 ///
 /// If exL,H or eyL,H are NULL, the corresponding values are preset to zero.
 
-TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, const Double_t *eyL, const Double_t *eyH, Int_t m) : TGraphMultiErrors(np, x, y, exL, exH, eyL, eyH, m)
+TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, const Double_t *x,
+                                     const Double_t *y, const Double_t *exL, const Double_t *exH, const Double_t *eyL,
+                                     const Double_t *eyH, Int_t m)
+   : TGraphMultiErrors(np, x, y, exL, exH, eyL, eyH, m)
 {
    SetNameTitle(name, title);
 }
@@ -186,26 +214,33 @@ TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, In
 /// If exL,H are NULL, the corresponding values are preset to zero.
 /// The multiple y-errors are passed as std::vectors of std::vectors.
 
-TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, std::vector<std::vector<Float_t>> eyL, std::vector<std::vector<Float_t>> eyH, Int_t m) : TGraph(np, x, y), fNYErrors(ne), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL,
+                                     const Float_t *exH, std::vector<std::vector<Float_t>> eyL,
+                                     std::vector<std::vector<Float_t>> eyH, Int_t m)
+   : TGraph(np, x, y), fNYErrors(ne), fSumErrorsMode(m)
 {
    if (!CtorAllocate())
       return;
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      if (exL) fExL[i] = exL[i];
-      else     fExL[i] = 0.;
-      if (exH) fExH[i] = exH[i];
-      else     fExH[i] = 0.;
+      if (exL)
+         fExL[i] = exL[i];
+      else
+         fExL[i] = 0.;
+      if (exH)
+         fExH[i] = exH[i];
+      else
+         fExH[i] = 0.;
 
       for (Int_t j = 0; j < fNYErrors; j++) {
-	 if (Int_t(eyL.size()) > j && Int_t(eyL[j].size()) > i)
-	    fEyL[j][i] = eyL[j][i];
-	 else
-	    fEyL[j][i] = 0.;
-	 if (Int_t(eyH.size()) > j && Int_t(eyH[j].size()) > i)
-	    fEyH[j][i] = eyH[j][i];
-	 else
-	    fEyH[j][i] = 0.;
+         if (Int_t(eyL.size()) > j && Int_t(eyL[j].size()) > i)
+            fEyL[j][i] = eyL[j][i];
+         else
+            fEyL[j][i] = 0.;
+         if (Int_t(eyH.size()) > j && Int_t(eyH[j].size()) > i)
+            fEyH[j][i] = eyH[j][i];
+         else
+            fEyH[j][i] = 0.;
       }
    }
 
@@ -218,7 +253,11 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const
 /// If exL,H are NULL, the corresponding values are preset to zero.
 /// The multiple y-errors are passed as std::vectors of std::vectors.
 
-TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, std::vector<std::vector<Float_t>> eyL, std::vector<std::vector<Float_t>> eyH, Int_t m) : TGraphMultiErrors(np, ne, x, y, exL, exH, eyL, eyH, m)
+TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Float_t *x,
+                                     const Float_t *y, const Float_t *exL, const Float_t *exH,
+                                     std::vector<std::vector<Float_t>> eyL, std::vector<std::vector<Float_t>> eyH,
+                                     Int_t m)
+   : TGraphMultiErrors(np, ne, x, y, exL, exH, eyL, eyH, m)
 {
    SetNameTitle(name, title);
 }
@@ -229,28 +268,35 @@ TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, In
 /// If exL,H are NULL, the corresponding values are preset to zero.
 /// The multiple y-errors are passed as std::vectors of std::vectors.
 
-TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, std::vector<std::vector<Double_t>> eyL, std::vector<std::vector<Double_t>> eyH, Int_t m) : TGraph(np, x, y), fNYErrors(ne), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL,
+                                     const Double_t *exH, std::vector<std::vector<Double_t>> eyL,
+                                     std::vector<std::vector<Double_t>> eyH, Int_t m)
+   : TGraph(np, x, y), fNYErrors(ne), fSumErrorsMode(m)
 {
    if (!CtorAllocate())
       return;
 
    Int_t n = fNpoints * sizeof(Double_t);
 
-   if (exL) memcpy(fExL, exL, n);
-   else     memset(fExL, 0, n);
-   if (exH) memcpy(fExH, exH, n);
-   else     memset(fExH, 0, n);
+   if (exL)
+      memcpy(fExL, exL, n);
+   else
+      memset(fExL, 0, n);
+   if (exH)
+      memcpy(fExH, exH, n);
+   else
+      memset(fExH, 0, n);
 
    for (Int_t i = 0; i < fNpoints; i++) {
       for (Int_t j = 0; j < fNYErrors; j++) {
-	 if (Int_t(eyL.size()) > j && Int_t(eyL[j].size()) > i)
-	    fEyL[j][i] = eyL[j][i];
-	 else
-	    fEyL[j][i] = 0.;
-	 if (Int_t(eyH.size()) > j && Int_t(eyH[j].size()) > i)
-	    fEyH[j][i] = eyH[j][i];
-	 else
-	    fEyH[j][i] = 0.;
+         if (Int_t(eyL.size()) > j && Int_t(eyL[j].size()) > i)
+            fEyL[j][i] = eyL[j][i];
+         else
+            fEyL[j][i] = 0.;
+         if (Int_t(eyH.size()) > j && Int_t(eyH[j].size()) > i)
+            fEyH[j][i] = eyH[j][i];
+         else
+            fEyH[j][i] = 0.;
       }
    }
 
@@ -263,7 +309,11 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, cons
 /// If exL,H are NULL, the corresponding values are preset to zero.
 /// The multiple y-errors are passed as std::vectors of std::vectors.
 
-TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, std::vector<std::vector<Double_t>> eyL, std::vector<std::vector<Double_t>> eyH, Int_t m) : TGraphMultiErrors(np, ne, x, y, exL, exH, eyL, eyH, m)
+TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Double_t *x,
+                                     const Double_t *y, const Double_t *exL, const Double_t *exH,
+                                     std::vector<std::vector<Double_t>> eyL, std::vector<std::vector<Double_t>> eyH,
+                                     Int_t m)
+   : TGraphMultiErrors(np, ne, x, y, exL, exH, eyL, eyH, m)
 {
    SetNameTitle(name, title);
 }
@@ -274,26 +324,32 @@ TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, In
 /// If exL,H are NULL, the corresponding values are preset to zero.
 /// The multiple y-errors are passed as std::vectors of TArrayF objects.
 
-TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, std::vector<TArrayF> eyL, std::vector<TArrayF> eyH, Int_t m) : TGraph(np, x, y), fNYErrors(ne), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL,
+                                     const Float_t *exH, std::vector<TArrayF> eyL, std::vector<TArrayF> eyH, Int_t m)
+   : TGraph(np, x, y), fNYErrors(ne), fSumErrorsMode(m)
 {
    if (!CtorAllocate())
       return;
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      if (exL) fExL[i] = exL[i];
-      else     fExL[i] = 0.;
-      if (exH) fExH[i] = exH[i];
-      else     fExH[i] = 0.;
+      if (exL)
+         fExL[i] = exL[i];
+      else
+         fExL[i] = 0.;
+      if (exH)
+         fExH[i] = exH[i];
+      else
+         fExH[i] = 0.;
 
       for (Int_t j = 0; j < fNYErrors; j++) {
-	 if (Int_t(eyL.size()) > j && eyL[j].GetSize() > i)
-	    fEyL[j][i] = eyL[j][i];
-	 else
-	    fEyL[j][i] = 0.;
-	 if (Int_t(eyH.size()) > j && eyH[j].GetSize() > i)
-	    fEyH[j][i] = eyH[j][i];
-	 else
-	    fEyH[j][i] = 0.;
+         if (Int_t(eyL.size()) > j && eyL[j].GetSize() > i)
+            fEyL[j][i] = eyL[j][i];
+         else
+            fEyL[j][i] = 0.;
+         if (Int_t(eyH.size()) > j && eyH[j].GetSize() > i)
+            fEyH[j][i] = eyH[j][i];
+         else
+            fEyH[j][i] = 0.;
       }
    }
 
@@ -306,7 +362,10 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Float_t *x, const
 /// If exL,H are NULL, the corresponding values are preset to zero.
 /// The multiple y-errors are passed as std::vectors of TArrayF objects.
 
-TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Float_t *x, const Float_t *y, const Float_t *exL, const Float_t *exH, std::vector<TArrayF> eyL, std::vector<TArrayF> eyH, Int_t m) : TGraphMultiErrors(np, ne, x, y, exL, exH, eyL, eyH, m)
+TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Float_t *x,
+                                     const Float_t *y, const Float_t *exL, const Float_t *exH, std::vector<TArrayF> eyL,
+                                     std::vector<TArrayF> eyH, Int_t m)
+   : TGraphMultiErrors(np, ne, x, y, exL, exH, eyL, eyH, m)
 {
    SetNameTitle(name, title);
 }
@@ -317,28 +376,34 @@ TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, In
 /// If exL,H are NULL, the corresponding values are preset to zero.
 /// The multiple y-errors are passed as std::vectors of TArrayD objects.
 
-TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, std::vector<TArrayD> eyL, std::vector<TArrayD> eyH, Int_t m) : TGraph(np, x, y), fNYErrors(ne), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL,
+                                     const Double_t *exH, std::vector<TArrayD> eyL, std::vector<TArrayD> eyH, Int_t m)
+   : TGraph(np, x, y), fNYErrors(ne), fSumErrorsMode(m)
 {
    if (!CtorAllocate())
       return;
 
    Int_t n = fNpoints * sizeof(Double_t);
 
-   if (exL) memcpy(fExL, exL, n);
-   else     memset(fExL, 0, n);
-   if (exH) memcpy(fExH, exH, n);
-   else     memset(fExH, 0, n);
+   if (exL)
+      memcpy(fExL, exL, n);
+   else
+      memset(fExL, 0, n);
+   if (exH)
+      memcpy(fExH, exH, n);
+   else
+      memset(fExH, 0, n);
 
    for (Int_t i = 0; i < fNpoints; i++) {
       for (Int_t j = 0; j < fNYErrors; j++) {
-	 if (Int_t(eyL.size()) > j && eyL[j].GetSize() > i)
-	    fEyL[j][i] = eyL[j][i];
-	 else
-	    fEyL[j][i] = 0.;
-	 if (Int_t(eyH.size()) > j && eyH[j].GetSize() > i)
-	    fEyH[j][i] = eyH[j][i];
-	 else
-	    fEyH[j][i] = 0.;
+         if (Int_t(eyL.size()) > j && eyL[j].GetSize() > i)
+            fEyL[j][i] = eyL[j][i];
+         else
+            fEyL[j][i] = 0.;
+         if (Int_t(eyH.size()) > j && eyH[j].GetSize() > i)
+            fEyH[j][i] = eyH[j][i];
+         else
+            fEyH[j][i] = 0.;
       }
    }
 
@@ -351,7 +416,10 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t np, Int_t ne, const Double_t *x, cons
 /// If exL,H are NULL, the corresponding values are preset to zero.
 /// The multiple y-errors are passed as std::vectors of TArrayD objects.
 
-TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Double_t *x, const Double_t *y, const Double_t *exL, const Double_t *exH, std::vector<TArrayD> eyL, std::vector<TArrayD> eyH, Int_t m) : TGraphMultiErrors(np, ne, x, y, exL, exH, eyL, eyH, m)
+TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, Int_t np, Int_t ne, const Double_t *x,
+                                     const Double_t *y, const Double_t *exL, const Double_t *exH,
+                                     std::vector<TArrayD> eyL, std::vector<TArrayD> eyH, Int_t m)
+   : TGraphMultiErrors(np, ne, x, y, exL, exH, eyL, eyH, m)
 {
    SetNameTitle(name, title);
 }
@@ -364,7 +432,9 @@ TGraphMultiErrors::TGraphMultiErrors(const Char_t *name, const Char_t *title, In
 /// The number of points in the graph is the minimum of number of points
 /// in tvX and tvY.
 
-TGraphMultiErrors::TGraphMultiErrors(const TVectorF &tvX, const TVectorF &tvY, const TVectorF &tvExL, const TVectorF &tvExH, const TVectorF &tvEyL, const TVectorF &tvEyH, Int_t m) : TGraph(), fNYErrors(1), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(const TVectorF &tvX, const TVectorF &tvY, const TVectorF &tvExL,
+                                     const TVectorF &tvExH, const TVectorF &tvEyL, const TVectorF &tvEyH, Int_t m)
+   : TGraph(), fNYErrors(1), fSumErrorsMode(m)
 {
    fNpoints = TMath::Min(tvX.GetNrows(), tvY.GetNrows());
 
@@ -401,7 +471,9 @@ TGraphMultiErrors::TGraphMultiErrors(const TVectorF &tvX, const TVectorF &tvY, c
 /// The number of points in the graph is the minimum of number of points
 /// in tvX and tvY.
 
-TGraphMultiErrors::TGraphMultiErrors(const TVectorD &tvX, const TVectorD &tvY, const TVectorD &tvExL, const TVectorD &tvExH, const TVectorD &tvEyL, const TVectorD &tvEyH, Int_t m) : TGraph(), fNYErrors(1), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(const TVectorD &tvX, const TVectorD &tvY, const TVectorD &tvExL,
+                                     const TVectorD &tvExH, const TVectorD &tvEyL, const TVectorD &tvEyH, Int_t m)
+   : TGraph(), fNYErrors(1), fSumErrorsMode(m)
 {
    fNpoints = TMath::Min(tvX.GetNrows(), tvY.GetNrows());
 
@@ -437,7 +509,9 @@ TGraphMultiErrors::TGraphMultiErrors(const TVectorD &tvX, const TVectorD &tvY, c
 /// The number of points in the graph is the minimum of number of points
 /// in tvX and tvY.
 
-TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorF &tvX, const TVectorF &tvY, const TVectorF &tvExL, const TVectorF &tvExH, const TVectorF *tvEyL, const TVectorF *tvEyH, Int_t m) : TGraph(), fNYErrors(ne), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorF &tvX, const TVectorF &tvY, const TVectorF &tvExL,
+                                     const TVectorF &tvExH, const TVectorF *tvEyL, const TVectorF *tvEyH, Int_t m)
+   : TGraph(), fNYErrors(ne), fSumErrorsMode(m)
 {
    fNpoints = TMath::Min(tvX.GetNrows(), tvY.GetNrows());
 
@@ -474,7 +548,9 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorF &tvX, const TVecto
 /// The number of points in the graph is the minimum of number of points
 /// in tvX and tvY.
 
-TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorD &tvX, const TVectorD &tvY, const TVectorD &tvExL, const TVectorD &tvExH, const TVectorD *tvEyL, const TVectorD *tvEyH, Int_t m) : TGraph(), fNYErrors(ne), fSumErrorsMode(m)
+TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorD &tvX, const TVectorD &tvY, const TVectorD &tvExL,
+                                     const TVectorD &tvExH, const TVectorD *tvEyL, const TVectorD *tvEyH, Int_t m)
+   : TGraph(), fNYErrors(ne), fSumErrorsMode(m)
 {
    fNpoints = TMath::Min(tvX.GetNrows(), tvY.GetNrows());
 
@@ -509,7 +585,7 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorD &tvX, const TVecto
 
 TGraphMultiErrors::TGraphMultiErrors(const TGraphMultiErrors &tgme) : TGraph(tgme)
 {
-   fNYErrors      = tgme.fNYErrors;
+   fNYErrors = tgme.fNYErrors;
    fSumErrorsMode = tgme.fSumErrorsMode;
 
    if (!CtorAllocate())
@@ -537,12 +613,16 @@ TGraphMultiErrors &TGraphMultiErrors::operator=(const TGraphMultiErrors &tgme)
    if (this != &tgme) {
       TGraph::operator=(tgme);
       // delete arrays
-      if (fExL) delete[] fExL;
-      if (fExH) delete[] fExH;
-      if (fEyLSum) delete[] fEyLSum;
-      if (fEyHSum) delete[] fEyHSum;
+      if (fExL)
+         delete[] fExL;
+      if (fExH)
+         delete[] fExH;
+      if (fEyLSum)
+         delete[] fEyLSum;
+      if (fEyHSum)
+         delete[] fEyHSum;
 
-      fNYErrors      = tgme.fNYErrors;
+      fNYErrors = tgme.fNYErrors;
       fSumErrorsMode = tgme.fSumErrorsMode;
 
       if (!CtorAllocate())
@@ -554,9 +634,9 @@ TGraphMultiErrors &TGraphMultiErrors::operator=(const TGraphMultiErrors &tgme)
 
       for (Int_t j = 0; j < fNYErrors; j++) {
          fEyL[j] = tgme.fEyL[j];
-	 fEyH[j] = tgme.fEyH[j];
-	 tgme.fAttFill[j].Copy(fAttFill[j]);
-	 tgme.fAttLine[j].Copy(fAttLine[j]);
+         fEyH[j] = tgme.fEyH[j];
+         tgme.fAttFill[j].Copy(fAttFill[j]);
+         tgme.fAttLine[j].Copy(fAttLine[j]);
       }
 
       CalcYErrorsSum();
@@ -568,7 +648,8 @@ TGraphMultiErrors &TGraphMultiErrors::operator=(const TGraphMultiErrors &tgme)
 /// TGraphMultiErrors constructor importing its parameters from the TH1 object passed as argument
 /// the low and high errors are set to the bin error of the histogram.
 
-TGraphMultiErrors::TGraphMultiErrors(const TH1 *h, Int_t ne) : TGraph(h), fNYErrors(ne), fSumErrorsMode(TGraphMultiErrors::kOnlyFirst)
+TGraphMultiErrors::TGraphMultiErrors(const TH1 *h, Int_t ne)
+   : TGraph(h), fNYErrors(ne), fSumErrorsMode(TGraphMultiErrors::kOnlyFirst)
 {
    if (!CtorAllocate())
       return;
@@ -595,7 +676,8 @@ TGraphMultiErrors::TGraphMultiErrors(const TH1 *h, Int_t ne) : TGraph(h), fNYErr
 /// Creates a TGraphMultiErrors by dividing two input TH1 histograms:
 /// pass/total. (see TGraphMultiErrors::Divide)
 
-TGraphMultiErrors::TGraphMultiErrors(const TH1 *pass, const TH1 *total, Int_t ne, Option_t *option) : TGraph(pass ? pass->GetNbinsX() : 0), fNYErrors(ne), fSumErrorsMode(TGraphMultiErrors::kOnlyFirst)
+TGraphMultiErrors::TGraphMultiErrors(const TH1 *pass, const TH1 *total, Int_t ne, Option_t *option)
+   : TGraph(pass ? pass->GetNbinsX() : 0), fNYErrors(ne), fSumErrorsMode(TGraphMultiErrors::kOnlyFirst)
 {
    if (!pass || !total) {
       Error("TGraphMultiErrors", "Invalid histogram pointers");
@@ -626,12 +708,16 @@ TGraphMultiErrors::TGraphMultiErrors(const TH1 *pass, const TH1 *total, Int_t ne
 
 TGraphMultiErrors::~TGraphMultiErrors()
 {
-   if (fExL) delete[] fExL;
-   if (fExH) delete[] fExH;
+   if (fExL)
+      delete[] fExL;
+   if (fExH)
+      delete[] fExH;
    fEyL.resize(0);
    fEyH.resize(0);
-   if (fEyLSum) delete[] fEyLSum;
-   if (fEyHSum) delete[] fEyHSum;
+   if (fEyLSum)
+      delete[] fEyLSum;
+   if (fEyHSum)
+      delete[] fEyHSum;
    fAttFill.resize(0);
    fAttLine.resize(0);
 }
@@ -738,8 +824,10 @@ void TGraphMultiErrors::FillZero(Int_t begin, Int_t end, Bool_t from_ctor)
 
 void TGraphMultiErrors::CalcYErrorsSum() const
 {
-   if (fEyLSum) delete[] fEyLSum;
-   if (fEyHSum) delete[] fEyHSum;
+   if (fEyLSum)
+      delete[] fEyLSum;
+   if (fEyHSum)
+      delete[] fEyHSum;
 
    fEyLSum = new Double_t[fNpoints];
    fEyHSum = new Double_t[fNpoints];
@@ -773,7 +861,8 @@ Bool_t TGraphMultiErrors::DoMerge(const TGraph *tg)
 
       return kTRUE;
    } else {
-      Warning("DoMerge", "Merging a %s is not compatible with a TGraphMultiErrors - Errors will be ignored", tg->IsA()->GetName());
+      Warning("DoMerge", "Merging a %s is not compatible with a TGraphMultiErrors - Errors will be ignored",
+              tg->IsA()->GetName());
       return TGraph::DoMerge(tg);
    }
 
@@ -817,7 +906,6 @@ Double_t **TGraphMultiErrors::Allocate(Int_t size)
 {
    return AllocateArrays(4, size);
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Apply a function to all data points `y = f(x,y)`
@@ -1143,8 +1231,8 @@ void TGraphMultiErrors::Divide(const TH1 *pass, const TH1 *total, Option_t *opt)
 
       // use bin contents
       else {
-	  t = TMath::Nint(total->GetBinContent(b));
-	  p = TMath::Nint(pass->GetBinContent(b));
+         t = TMath::Nint(total->GetBinContent(b));
+         p = TMath::Nint(pass->GetBinContent(b));
 
          if (bPoissonRatio)
             t += p;
@@ -1636,7 +1724,8 @@ void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
       out << "   tgme->SetPointEX(" << i << ", " << fExL[i] << ", " << fExH[i] << ");" << std::endl;
 
       for (Int_t j = 0; j < fNYErrors; j++)
-         out << "   tgme->SetPointEY(" << i << ", " << j << ", " << fEyL[j][i] << ", " << fEyH[j][i] << ");" << std::endl;
+         out << "   tgme->SetPointEY(" << i << ", " << j << ", " << fEyL[j][i] << ", " << fEyH[j][i] << ");"
+             << std::endl;
    }
 
    static Int_t frameNumber = 0;
@@ -1674,7 +1763,8 @@ void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
 ///
 /// Up to 3 y error dimensions possible.
 
-void TGraphMultiErrors::SetPointError(Double_t exL, Double_t exH, Double_t eyL1, Double_t eyH1, Double_t eyL2, Double_t eyH2, Double_t eyL3, Double_t eyH3)
+void TGraphMultiErrors::SetPointError(Double_t exL, Double_t exH, Double_t eyL1, Double_t eyH1, Double_t eyL2,
+                                      Double_t eyH2, Double_t eyL3, Double_t eyH3)
 {
    Int_t px = gPad->GetEventX();
    Int_t py = gPad->GetEventY();
@@ -1710,7 +1800,8 @@ void TGraphMultiErrors::SetPointError(Double_t exL, Double_t exH, Double_t eyL1,
 ////////////////////////////////////////////////////////////////////////////////
 /// Set ex and ey values for point i.
 
-void TGraphMultiErrors::SetPointError(Int_t i, Int_t ne, Double_t exL, Double_t exH, const Double_t *eyL, const Double_t *eyH)
+void TGraphMultiErrors::SetPointError(Int_t i, Int_t ne, Double_t exL, Double_t exH, const Double_t *eyL,
+                                      const Double_t *eyH)
 {
    SetPointEX(i, exL, exH);
    SetPointEY(i, ne, eyL, eyH);
@@ -1772,8 +1863,10 @@ void TGraphMultiErrors::SetPointEY(Int_t i, Int_t ne, const Double_t *eyL, const
 void TGraphMultiErrors::SetPointEYlow(Int_t i, Int_t ne, const Double_t *eyL)
 {
    for (Int_t j = 0; j < fNYErrors; j++) {
-      if (j < ne) SetPointEYlow(i, j, eyL[j]);
-      else     	  SetPointEYlow(i, j, 0.);
+      if (j < ne)
+         SetPointEYlow(i, j, eyL[j]);
+      else
+         SetPointEYlow(i, j, 0.);
    }
 }
 
@@ -1783,8 +1876,10 @@ void TGraphMultiErrors::SetPointEYlow(Int_t i, Int_t ne, const Double_t *eyL)
 void TGraphMultiErrors::SetPointEYhigh(Int_t i, Int_t ne, const Double_t *eyH)
 {
    for (Int_t j = 0; j < fNYErrors; j++) {
-      if (j < ne) SetPointEYhigh(i, j, eyH[j]);
-      else        SetPointEYhigh(i, j, 0.);
+      if (j < ne)
+         SetPointEYhigh(i, j, eyH[j]);
+      else
+         SetPointEYhigh(i, j, 0.);
    }
 }
 
@@ -1813,8 +1908,10 @@ void TGraphMultiErrors::SetPointEYlow(Int_t i, Int_t e, Double_t eyL)
       AddYError(fNpoints);
 
    fEyL[e][i] = eyL;
-   if (fEyLSum) fEyLSum[i] = GetErrorYlow(i);
-   else         CalcYErrorsSum();
+   if (fEyLSum)
+      fEyLSum[i] = GetErrorYlow(i);
+   else
+      CalcYErrorsSum();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1833,8 +1930,10 @@ void TGraphMultiErrors::SetPointEYhigh(Int_t i, Int_t e, Double_t eyH)
       AddYError(fNpoints);
 
    fEyH[e][i] = eyH;
-   if (fEyHSum) fEyHSum[i] = GetErrorYhigh(i);
-   else         CalcYErrorsSum();
+   if (fEyHSum)
+      fEyHSum[i] = GetErrorYhigh(i);
+   else
+      CalcYErrorsSum();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1852,8 +1951,10 @@ void TGraphMultiErrors::SetEY(Int_t e, Int_t np, const Double_t *eyL, const Doub
 void TGraphMultiErrors::SetEYlow(Int_t e, Int_t np, const Double_t *eyL)
 {
    for (Int_t i = 0; i < fNpoints; i++) {
-      if (i < np) SetPointEYlow(i, e, eyL[i]);
-      else        SetPointEYlow(i, e, 0.);
+      if (i < np)
+         SetPointEYlow(i, e, eyL[i]);
+      else
+         SetPointEYlow(i, e, 0.);
    }
 }
 
@@ -1863,8 +1964,10 @@ void TGraphMultiErrors::SetEYlow(Int_t e, Int_t np, const Double_t *eyL)
 void TGraphMultiErrors::SetEYhigh(Int_t e, Int_t np, const Double_t *eyH)
 {
    for (Int_t i = 0; i < fNpoints; i++) {
-      if (i < np) SetPointEYhigh(i, e, eyH[i]);
-      else        SetPointEYhigh(i, e, 0.);
+      if (i < np)
+         SetPointEYhigh(i, e, eyH[i]);
+      else
+         SetPointEYhigh(i, e, 0.);
    }
 }
 

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -2821,6 +2821,10 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
 
          if (!yline[j]) {
             Error("Paint", "too many points, out of memory");
+            delete[] xline;
+            for (Int_t k = 0; k < j; k++)
+               if (yline[k])
+                  delete[] yline[k];
             return;
          }
       }

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -2643,7 +2643,7 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
       return;
    }
 
-   auto tg = (TGraphMultiErrors*) theGraph;
+   auto tg = (TGraphMultiErrors *)theGraph;
 
    Int_t NYErrors = tg->GetNYErrors();
    if (NYErrors <= 0) {
@@ -2677,8 +2677,8 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
    for (Int_t i = filled; i <= NYErrors; i++)
       options[i] = "";
 
-   Double_t* xline = nullptr;
-   std::vector<Double_t*> yline(NYErrors);
+   Double_t *xline = nullptr;
+   std::vector<Double_t *> yline(NYErrors);
    Int_t if1 = 0;
    Int_t if2 = 0;
    Double_t xb[4], yb[4];
@@ -2687,14 +2687,14 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
    Double_t s2x, s2y, symbolsize, sbase;
    Double_t x, y, xl1, xl2, xr1, xr2, yup1, yup2, ylow1, ylow2, tx, ty;
    static Float_t cxx[15] = {1., 1., 0.6, 0.6, 1., 1., 0.6, 0.5, 1., 0.6, 0.6, 1., 0.6, 1., 1.};
-   static Float_t cyy[15] = {1., 1., 1. , 1. , 1., 1., 1. , 1. , 1., 0.5, 0.6, 1., 1. , 1., 1.};
+   static Float_t cyy[15] = {1., 1., 1., 1., 1., 1., 1., 1., 1., 0.5, 0.6, 1., 1., 1., 1.};
    Int_t theNpoints = tg->GetN();
-   Double_t* theX   = tg->GetX();
-   Double_t* theY   = tg->GetY();
-   Double_t* theExL = tg->GetEXlow();
-   Double_t* theExH = tg->GetEXhigh();
-   std::vector<Double_t*> theEyL(NYErrors);
-   std::vector<Double_t*> theEyH(NYErrors);
+   Double_t *theX = tg->GetX();
+   Double_t *theY = tg->GetY();
+   Double_t *theExL = tg->GetEXlow();
+   Double_t *theExH = tg->GetEXhigh();
+   std::vector<Double_t *> theEyL(NYErrors);
+   std::vector<Double_t *> theEyH(NYErrors);
 
    Bool_t theEyExists = kTRUE;
    for (Int_t j = 0; j < NYErrors; j++) {
@@ -2714,7 +2714,7 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
    std::vector<Bool_t> Braticks(NYErrors);
    std::vector<Bool_t> Brackets(NYErrors);
    std::vector<Bool_t> EndLines(NYErrors);
-   std::vector<Char_t*> ArrowOpt(NYErrors);
+   std::vector<Char_t *> ArrowOpt(NYErrors);
    std::vector<Bool_t> Option5(NYErrors);
    std::vector<Bool_t> Option4(NYErrors);
    std::vector<Bool_t> Option3(NYErrors);
@@ -2728,35 +2728,35 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
 
    for (Int_t j = 0; j < NYErrors; j++) {
       if (options[j + 1].Contains("s=")) {
-        sscanf(strstr(options[j + 1].Data(), "s="), "s=%lf", &Scale[j]);
-        options[j + 1].ReplaceAll(options[j + 1](ScaleRegExp), "");
+         sscanf(strstr(options[j + 1].Data(), "s="), "s=%lf", &Scale[j]);
+         options[j + 1].ReplaceAll(options[j + 1](ScaleRegExp), "");
       } else
-        Scale[j] = 1.;
+         Scale[j] = 1.;
 
       DrawErrors[j] = !options[j + 1].Contains("x");
-      AnyErrors    |=  DrawErrors[j];
-      Braticks[j]   =  options[j + 1].Contains("[]");
-      Brackets[j]   =  options[j + 1].Contains("||") || Braticks[j];
-      EndLines[j]   = !options[j + 1].Contains("z");
+      AnyErrors |= DrawErrors[j];
+      Braticks[j] = options[j + 1].Contains("[]");
+      Brackets[j] = options[j + 1].Contains("||") || Braticks[j];
+      EndLines[j] = !options[j + 1].Contains("z");
 
-      if      (options[j + 1].Contains("|>"))
-        ArrowOpt[j] = (Char_t*) "|>";
+      if (options[j + 1].Contains("|>"))
+         ArrowOpt[j] = (Char_t *)"|>";
       else if (options[j + 1].Contains(">"))
-        ArrowOpt[j] = (Char_t*) ">";
+         ArrowOpt[j] = (Char_t *)">";
       else
-        ArrowOpt[j] = nullptr;
+         ArrowOpt[j] = nullptr;
 
-      Option5[j]    = options[j + 1].Contains("5");
-      Option4[j]    = options[j + 1].Contains("4");
-      Option3[j]    = options[j + 1].Contains("3") || Option4[j];
-      AnyOption3   |= Option3[j];
-      Option2[j]    = options[j + 1].Contains("2") || Option5[j];
-      Option0[j]    = options[j + 1].Contains("0");
-      AnyOption0   |= Option0[j];
+      Option5[j] = options[j + 1].Contains("5");
+      Option4[j] = options[j + 1].Contains("4");
+      Option3[j] = options[j + 1].Contains("3") || Option4[j];
+      AnyOption3 |= Option3[j];
+      Option2[j] = options[j + 1].Contains("2") || Option5[j];
+      Option0[j] = options[j + 1].Contains("0");
+      AnyOption0 |= Option0[j];
 
-      NoErrorsX    &=  (Option3[j] || Option2[j]);
-      Option0X     |= !(Option3[j] || Option2[j]) && Option0[j];
-      DrawMarker   |= !(Brackets[j] || Option3[j] || Option2[j]);
+      NoErrorsX &= (Option3[j] || Option2[j]);
+      Option0X |= !(Option3[j] || Option2[j]) && Option0[j];
+      DrawMarker |= !(Brackets[j] || Option3[j] || Option2[j]);
    }
 
    Bool_t Draw0PointsX = !options[0].Contains("x0") && (gPad->GetLogx() == 0);
@@ -2764,14 +2764,16 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
    options[0].ReplaceAll("x0", "");
    options[0].ReplaceAll("y0", "");
 
-   Bool_t DrawErrorsX  = !options[0].Contains("x");
-   Bool_t BraticksX    =  options[0].Contains("[]");
-   Bool_t BracketsX    =  options[0].Contains("||") || BraticksX;
-   Bool_t EndLinesX    = !options[0].Contains("z");
+   Bool_t DrawErrorsX = !options[0].Contains("x");
+   Bool_t BraticksX = options[0].Contains("[]");
+   Bool_t BracketsX = options[0].Contains("||") || BraticksX;
+   Bool_t EndLinesX = !options[0].Contains("z");
 
-   Char_t* ArrowOptX = nullptr;
-   if      (options[0].Contains("|>")) ArrowOptX = (Char_t*) "|>";
-   else if (options[0].Contains(">"))  ArrowOptX = (Char_t*) ">";
+   Char_t *ArrowOptX = nullptr;
+   if (options[0].Contains("|>"))
+      ArrowOptX = (Char_t *)"|>";
+   else if (options[0].Contains(">"))
+      ArrowOptX = (Char_t *)">";
 
    Double_t ScaleX = 1.;
    if (options[0].Contains("s=")) {
@@ -2784,7 +2786,7 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
       return;
    }
 
-   Bool_t DrawAxis         = options[0].Contains("a");
+   Bool_t DrawAxis = options[0].Contains("a");
    Bool_t IndividualStyles = options[0].Contains("s");
 
    if (DrawAxis)
@@ -2796,30 +2798,31 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
       x = gPad->XtoPad(theX[i]);
       y = gPad->YtoPad(theY[i]);
 
-      if ((x >= gPad->GetUxmin()) && (x <= gPad->GetUxmax()) && (y >= gPad->GetUymin()) && (y <= gPad->GetUymax()) && (Draw0PointsX || theX[i] != 0.) && (Draw0PointsY || theY[i] != 0.))
-        NPointsInside++;
+      if ((x >= gPad->GetUxmin()) && (x <= gPad->GetUxmax()) && (y >= gPad->GetUymin()) && (y <= gPad->GetUymax()) &&
+          (Draw0PointsX || theX[i] != 0.) && (Draw0PointsY || theY[i] != 0.))
+         NPointsInside++;
    }
 
    if (AnyOption3) {
-      xline = new Double_t[2*NPointsInside];
+      xline = new Double_t[2 * NPointsInside];
 
       if (!xline) {
-        Error("Paint", "too many points, out of memory");
-        return;
+         Error("Paint", "too many points, out of memory");
+         return;
       }
 
       if1 = 1;
-      if2 = 2*NPointsInside;
+      if2 = 2 * NPointsInside;
    }
 
    for (Int_t j = 0; j < NYErrors; j++) {
       if (Option3[j] && DrawErrors[j]) {
-        yline[j] = new Double_t[2*NPointsInside];
+         yline[j] = new Double_t[2 * NPointsInside];
 
-        if (!yline[j]) {
-           Error("Paint", "too many points, out of memory");
-           return;
-        }
+         if (!yline[j]) {
+            Error("Paint", "too many points, out of memory");
+            return;
+         }
       }
    }
 
@@ -2837,9 +2840,9 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
    box.SetFillColor(tg->GetFillColor());
    box.SetFillStyle(tg->GetFillStyle());
 
-   symbolsize  = tg->GetMarkerSize();
-   sbase       = symbolsize * kBASEMARKER;
-   Int_t mark  = tg->GetMarkerStyle();
+   symbolsize = tg->GetMarkerSize();
+   sbase = symbolsize * kBASEMARKER;
+   Int_t mark = tg->GetMarkerStyle();
    Double_t cx = 0.;
    Double_t cy = 0.;
 
@@ -2849,11 +2852,11 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
    }
 
    // Define the offset of the error bars due to the symbol size
-   s2x =  gPad->PixeltoX(Int_t(0.5 * sbase)) - gPad->PixeltoX(0);
+   s2x = gPad->PixeltoX(Int_t(0.5 * sbase)) - gPad->PixeltoX(0);
    s2y = -gPad->PixeltoY(Int_t(0.5 * sbase)) + gPad->PixeltoY(0);
    auto dxend = Int_t(gStyle->GetEndErrorSize());
-   tx  =  gPad->PixeltoX(dxend) - gPad->PixeltoX(0);
-   ty  = -gPad->PixeltoY(dxend) + gPad->PixeltoY(0);
+   tx = gPad->PixeltoX(dxend) - gPad->PixeltoX(0);
+   ty = -gPad->PixeltoY(dxend) + gPad->PixeltoY(0);
    Float_t asize = 0.6 * symbolsize * kBASEMARKER / gPad->GetWh();
 
    gPad->SetBit(TGraph::kClipFrame, tg->TestBit(TGraph::kClipFrame));
@@ -2862,185 +2865,202 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
       x = gPad->XtoPad(theX[i]);
       y = gPad->YtoPad(theY[i]);
 
-      Bool_t isOutside = (x < gPad->GetUxmin()) || (x > gPad->GetUxmax()) || (y < gPad->GetUymin()) || (y > gPad->GetUymax());
+      Bool_t isOutside =
+         (x < gPad->GetUxmin()) || (x > gPad->GetUxmax()) || (y < gPad->GetUymin()) || (y > gPad->GetUymax());
 
       if ((isOutside && !AnyOption0) || (!Draw0PointsX && theX[i] == 0.) || (!Draw0PointsY && theY[i] == 0.))
-        continue;
+         continue;
 
       if (AnyOption3) {
-        if (isOutside) {
-           if (x < gPad->GetUxmin())
-              x = gPad->GetUxmin();
-           if (x > gPad->GetUxmax())
-              x = gPad->GetUxmax();
-           if (y < gPad->GetUymin())
-              y = gPad->GetUymin();
-           if (y > gPad->GetUymax())
-              y = gPad->GetUymax();
-        }
+         if (isOutside) {
+            if (x < gPad->GetUxmin())
+               x = gPad->GetUxmin();
+            if (x > gPad->GetUxmax())
+               x = gPad->GetUxmax();
+            if (y < gPad->GetUymin())
+               y = gPad->GetUymin();
+            if (y > gPad->GetUymax())
+               y = gPad->GetUymax();
+         }
 
-        xline[if1 - 1] = x;
-        xline[if2 - 1] = x;
+         xline[if1 - 1] = x;
+         xline[if2 - 1] = x;
 
-        if1++;
-        if2--;
+         if1++;
+         if2--;
       }
 
       for (Int_t j = 0; j < NYErrors; j++) {
-        if (!DrawErrors[j])
-           continue;
+         if (!DrawErrors[j])
+            continue;
 
-        //  draw the error rectangles
-        if (Option2[j] && (!isOutside || Option0[j])) {
-           if (IndividualStyles) {
-              box.SetLineWidth(tg->GetLineWidth(j));
-              box.SetLineColor(tg->GetLineColor(j));
-              box.SetFillColor(tg->GetFillColor(j));
-              box.SetFillStyle(tg->GetFillStyle(j));
-           }
+         //  draw the error rectangles
+         if (Option2[j] && (!isOutside || Option0[j])) {
+            if (IndividualStyles) {
+               box.SetLineWidth(tg->GetLineWidth(j));
+               box.SetLineColor(tg->GetLineColor(j));
+               box.SetFillColor(tg->GetFillColor(j));
+               box.SetFillStyle(tg->GetFillStyle(j));
+            }
 
-           x1b = gPad->XtoPad(theX[i] - Scale[j] * theExL[i]);
-           y1b = gPad->YtoPad(theY[i] - theEyL[j][i]);
-           x2b = gPad->XtoPad(theX[i] + Scale[j] * theExH[i]);
-           y2b = gPad->YtoPad(theY[i] + theEyH[j][i]);
-           if (x1b < gPad->GetUxmin())
-              x1b = gPad->GetUxmin();
-           if (x1b > gPad->GetUxmax())
-              x1b = gPad->GetUxmax();
-           if (y1b < gPad->GetUymin())
-              y1b = gPad->GetUymin();
-           if (y1b > gPad->GetUymax())
-              y1b = gPad->GetUymax();
-           if (x2b < gPad->GetUxmin())
-              x2b = gPad->GetUxmin();
-           if (x2b > gPad->GetUxmax())
-              x2b = gPad->GetUxmax();
-           if (y2b < gPad->GetUymin())
-              y2b = gPad->GetUymin();
-           if (y2b > gPad->GetUymax())
-              y2b = gPad->GetUymax();
-           if (Option5[j])
-              box.PaintBox(x1b, y1b, x2b, y2b, "l");
-           else
-              box.PaintBox(x1b, y1b, x2b, y2b);
-        }
+            x1b = gPad->XtoPad(theX[i] - Scale[j] * theExL[i]);
+            y1b = gPad->YtoPad(theY[i] - theEyL[j][i]);
+            x2b = gPad->XtoPad(theX[i] + Scale[j] * theExH[i]);
+            y2b = gPad->YtoPad(theY[i] + theEyH[j][i]);
+            if (x1b < gPad->GetUxmin())
+               x1b = gPad->GetUxmin();
+            if (x1b > gPad->GetUxmax())
+               x1b = gPad->GetUxmax();
+            if (y1b < gPad->GetUymin())
+               y1b = gPad->GetUymin();
+            if (y1b > gPad->GetUymax())
+               y1b = gPad->GetUymax();
+            if (x2b < gPad->GetUxmin())
+               x2b = gPad->GetUxmin();
+            if (x2b > gPad->GetUxmax())
+               x2b = gPad->GetUxmax();
+            if (y2b < gPad->GetUymin())
+               y2b = gPad->GetUymin();
+            if (y2b > gPad->GetUymax())
+               y2b = gPad->GetUymax();
+            if (Option5[j])
+               box.PaintBox(x1b, y1b, x2b, y2b, "l");
+            else
+               box.PaintBox(x1b, y1b, x2b, y2b);
+         }
 
-        //  keep points for fill area drawing
-        if (Option3[j]) {
-           if (!isOutside || Option0[j]) {
-              yline[j][if1 - 2] = gPad->YtoPad(theY[i] + theEyH[j][i]);
-              yline[j][if2]     = gPad->YtoPad(theY[i] - theEyL[j][i]);
-           } else {
-              yline[j][if1 - 2] = gPad->GetUymin();
-              yline[j][if2]     = gPad->GetUymin();
-           }
-        }
+         //  keep points for fill area drawing
+         if (Option3[j]) {
+            if (!isOutside || Option0[j]) {
+               yline[j][if1 - 2] = gPad->YtoPad(theY[i] + theEyH[j][i]);
+               yline[j][if2] = gPad->YtoPad(theY[i] - theEyL[j][i]);
+            } else {
+               yline[j][if1 - 2] = gPad->GetUymin();
+               yline[j][if2] = gPad->GetUymin();
+            }
+         }
 
-        if (IndividualStyles) {
-           tg->GetAttLine(j)->Modify();
+         if (IndividualStyles) {
+            tg->GetAttLine(j)->Modify();
 
-           arrow.SetLineWidth(tg->GetLineWidth(j));
-           arrow.SetLineColor(tg->GetLineColor(j));
-           arrow.SetFillColor(tg->GetFillColor(j));
-        }
+            arrow.SetLineWidth(tg->GetLineWidth(j));
+            arrow.SetLineColor(tg->GetLineColor(j));
+            arrow.SetFillColor(tg->GetFillColor(j));
+         }
 
-        ylow1 = y - s2y*cy;
-        ylow2 = gPad->YtoPad(theY[i] - theEyL[j][i]);
-        if (ylow2 < gPad->GetUymin())
-           ylow2 = gPad->GetUymin();
-        if (ylow2 < ylow1 && DrawErrors[j] && !Option2[j] && !Option3[j] && (!isOutside || Option0[j])) {
-           if (ArrowOpt[j])
-              arrow.PaintArrow(x, ylow1, x, ylow2, asize, ArrowOpt[j]);
-           else {
-              if (!Brackets[j])
-                gPad->PaintLine(x, ylow1, x, ylow2);
-              if (EndLines[j]) {
-                if (Braticks[j]) {
-                   xb[0] = x - tx; yb[0] = ylow2 + ty;
-                   xb[1] = x - tx; yb[1] = ylow2;
-                   xb[2] = x + tx; yb[2] = ylow2;
-                   xb[3] = x + tx; yb[3] = ylow2 + ty;
-                   gPad->PaintPolyLine(4, xb, yb);
-                } else
-                   gPad->PaintLine(x - tx, ylow2, x + tx, ylow2);
-              }
-           }
-        }
+         ylow1 = y - s2y * cy;
+         ylow2 = gPad->YtoPad(theY[i] - theEyL[j][i]);
+         if (ylow2 < gPad->GetUymin())
+            ylow2 = gPad->GetUymin();
+         if (ylow2 < ylow1 && DrawErrors[j] && !Option2[j] && !Option3[j] && (!isOutside || Option0[j])) {
+            if (ArrowOpt[j])
+               arrow.PaintArrow(x, ylow1, x, ylow2, asize, ArrowOpt[j]);
+            else {
+               if (!Brackets[j])
+                  gPad->PaintLine(x, ylow1, x, ylow2);
+               if (EndLines[j]) {
+                  if (Braticks[j]) {
+                     xb[0] = x - tx;
+                     yb[0] = ylow2 + ty;
+                     xb[1] = x - tx;
+                     yb[1] = ylow2;
+                     xb[2] = x + tx;
+                     yb[2] = ylow2;
+                     xb[3] = x + tx;
+                     yb[3] = ylow2 + ty;
+                     gPad->PaintPolyLine(4, xb, yb);
+                  } else
+                     gPad->PaintLine(x - tx, ylow2, x + tx, ylow2);
+               }
+            }
+         }
 
-        yup1 = y + s2y*cy;
-        yup2 = gPad->YtoPad(theY[i] + theEyH[j][i]);
-        if (yup2 > gPad->GetUymax())
-           yup2 = gPad->GetUymax();
-        if (yup2 > yup1 && DrawErrors[j] && !Option2[j] && !Option3[j] && (!isOutside || Option0[j])) {
-           if (ArrowOpt[j])
-              arrow.PaintArrow(x, yup1, x, yup2, asize, ArrowOpt[j]);
-           else {
-              if (!Brackets[j])
-                gPad->PaintLine(x, yup1, x, yup2);
-              if (EndLines[j]) {
-                if (Braticks[j]) {
-                   xb[0] = x - tx; yb[0] = yup2 - ty;
-                   xb[1] = x - tx; yb[1] = yup2;
-                   xb[2] = x + tx; yb[2] = yup2;
-                   xb[3] = x + tx; yb[3] = yup2 - ty;
-                   gPad->PaintPolyLine(4, xb, yb);
-                } else
-                   gPad->PaintLine(x - tx, yup2, x + tx, yup2);
-              }
-           }
-        }
+         yup1 = y + s2y * cy;
+         yup2 = gPad->YtoPad(theY[i] + theEyH[j][i]);
+         if (yup2 > gPad->GetUymax())
+            yup2 = gPad->GetUymax();
+         if (yup2 > yup1 && DrawErrors[j] && !Option2[j] && !Option3[j] && (!isOutside || Option0[j])) {
+            if (ArrowOpt[j])
+               arrow.PaintArrow(x, yup1, x, yup2, asize, ArrowOpt[j]);
+            else {
+               if (!Brackets[j])
+                  gPad->PaintLine(x, yup1, x, yup2);
+               if (EndLines[j]) {
+                  if (Braticks[j]) {
+                     xb[0] = x - tx;
+                     yb[0] = yup2 - ty;
+                     xb[1] = x - tx;
+                     yb[1] = yup2;
+                     xb[2] = x + tx;
+                     yb[2] = yup2;
+                     xb[3] = x + tx;
+                     yb[3] = yup2 - ty;
+                     gPad->PaintPolyLine(4, xb, yb);
+                  } else
+                     gPad->PaintLine(x - tx, yup2, x + tx, yup2);
+               }
+            }
+         }
       }
 
       if (DrawErrorsX) {
-        if (IndividualStyles) {
-           tg->TAttLine::Modify();
+         if (IndividualStyles) {
+            tg->TAttLine::Modify();
 
-           arrow.SetLineWidth(tg->GetLineWidth());
-           arrow.SetLineColor(tg->GetLineColor());
-           arrow.SetFillColor(tg->GetFillColor());
-        }
+            arrow.SetLineWidth(tg->GetLineWidth());
+            arrow.SetLineColor(tg->GetLineColor());
+            arrow.SetFillColor(tg->GetFillColor());
+         }
 
-        xl1 = x - s2x*cx;
-        xl2 = gPad->XtoPad(theX[i] - ScaleX * theExL[i]);
-        if (xl1 > xl2 && !NoErrorsX && (!isOutside || Option0X)) {
-           if (ArrowOptX)
-              arrow.PaintArrow(xl1, y, xl2, y, asize, ArrowOptX);
-           else {
-              if (!BracketsX)
-                gPad->PaintLine(xl1, y, xl2, y);
-              if (EndLinesX) {
-                if (BraticksX) {
-                   xb[0] = xl2 + tx; yb[0] = y - ty;
-                   xb[1] = xl2;      yb[1] = y - ty;
-                   xb[2] = xl2;      yb[2] = y + ty;
-                   xb[3] = xl2 + tx; yb[3] = y + ty;
-                   gPad->PaintPolyLine(4, xb, yb);
-                } else
-                   gPad->PaintLine(xl2, y - ty, xl2, y + ty);
-              }
-           }
-        }
+         xl1 = x - s2x * cx;
+         xl2 = gPad->XtoPad(theX[i] - ScaleX * theExL[i]);
+         if (xl1 > xl2 && !NoErrorsX && (!isOutside || Option0X)) {
+            if (ArrowOptX)
+               arrow.PaintArrow(xl1, y, xl2, y, asize, ArrowOptX);
+            else {
+               if (!BracketsX)
+                  gPad->PaintLine(xl1, y, xl2, y);
+               if (EndLinesX) {
+                  if (BraticksX) {
+                     xb[0] = xl2 + tx;
+                     yb[0] = y - ty;
+                     xb[1] = xl2;
+                     yb[1] = y - ty;
+                     xb[2] = xl2;
+                     yb[2] = y + ty;
+                     xb[3] = xl2 + tx;
+                     yb[3] = y + ty;
+                     gPad->PaintPolyLine(4, xb, yb);
+                  } else
+                     gPad->PaintLine(xl2, y - ty, xl2, y + ty);
+               }
+            }
+         }
 
-        xr1 = x + s2x*cx;
-        xr2 = gPad->XtoPad(theX[i] + ScaleX * theExH[i]);
-        if (xr1 < xr2 && !NoErrorsX && (!isOutside || Option0X)) {
-           if (ArrowOptX)
-              arrow.PaintArrow(xr1, y, xr2, y, asize, ArrowOptX);
-           else {
-              if (!BracketsX)
-                gPad->PaintLine(xr1, y, xr2, y);
-              if (EndLinesX) {
-                if (BraticksX) {
-                   xb[0] = xr2 - tx; yb[0] = y - ty;
-                   xb[1] = xr2;      yb[1] = y - ty;
-                   xb[2] = xr2;      yb[2] = y + ty;
-                   xb[3] = xr2 - tx; yb[3] = y + ty;
-                   gPad->PaintPolyLine(4, xb, yb);
-                } else
-                   gPad->PaintLine(xr2, y - ty, xr2, y + ty);
-              }
-           }
-        }
+         xr1 = x + s2x * cx;
+         xr2 = gPad->XtoPad(theX[i] + ScaleX * theExH[i]);
+         if (xr1 < xr2 && !NoErrorsX && (!isOutside || Option0X)) {
+            if (ArrowOptX)
+               arrow.PaintArrow(xr1, y, xr2, y, asize, ArrowOptX);
+            else {
+               if (!BracketsX)
+                  gPad->PaintLine(xr1, y, xr2, y);
+               if (EndLinesX) {
+                  if (BraticksX) {
+                     xb[0] = xr2 - tx;
+                     yb[0] = y - ty;
+                     xb[1] = xr2;
+                     yb[1] = y - ty;
+                     xb[2] = xr2;
+                     yb[2] = y + ty;
+                     xb[3] = xr2 - tx;
+                     yb[3] = y + ty;
+                     gPad->PaintPolyLine(4, xb, yb);
+                  } else
+                     gPad->PaintLine(xr2, y - ty, xr2, y + ty);
+               }
+            }
+         }
       }
    }
 
@@ -3055,29 +3075,29 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
 
    for (Int_t j = 0; j < NYErrors; j++) {
       if (Option3[j] && DrawErrors[j]) {
-        if (IndividualStyles) {
-           tg->GetAttFill(j)->Copy(*tgDummy);
-           tg->GetAttLine(j)->Copy(*tgDummy);
-        }
+         if (IndividualStyles) {
+            tg->GetAttFill(j)->Copy(*tgDummy);
+            tg->GetAttLine(j)->Copy(*tgDummy);
+         }
 
-        Int_t logx = gPad->GetLogx();
-        Int_t logy = gPad->GetLogy();
-        gPad->SetLogx(0);
-        gPad->SetLogy(0);
-        if (Option4[j])
-           PaintGraph(tgDummy, 2*NPointsInside, xline, yline[j], "FC");
-        else
-           PaintGraph(tgDummy, 2*NPointsInside, xline, yline[j], "F");
-        gPad->SetLogx(logx);
-        gPad->SetLogy(logy);
-        delete [] yline[j];
+         Int_t logx = gPad->GetLogx();
+         Int_t logy = gPad->GetLogy();
+         gPad->SetLogx(0);
+         gPad->SetLogy(0);
+         if (Option4[j])
+            PaintGraph(tgDummy, 2 * NPointsInside, xline, yline[j], "FC");
+         else
+            PaintGraph(tgDummy, 2 * NPointsInside, xline, yline[j], "F");
+         gPad->SetLogx(logx);
+         gPad->SetLogy(logy);
+         delete[] yline[j];
       }
    }
 
    delete tgDummy;
 
    if (AnyOption3)
-      delete [] xline;
+      delete[] xline;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR serves the same purpose as this one: #4695 
However, I think that older PR was never merged, because it was opened before the hotfix #4698 and therefore was not able to compile.

In this PR I simply format all code that has been added for the TGraphMultiErrors class using clang-format and the format settings file provided by ROOT.