### PR TITLE
[hist] Fixed a possible segmentation violation in TGraphMultiErrors

### DIFF
--- a/hist/hist/inc/TGraphMultiErrors.h
+++ b/hist/hist/inc/TGraphMultiErrors.h
@@ -184,11 +184,7 @@ public:
    virtual void SetEYlow(Int_t e, Int_t np, const Double_t *eyL);
    virtual void SetEYhigh(Int_t e, Int_t np, const Double_t *eyH);
 
-   virtual void SetSumErrorsMode(Int_t m)
-   {
-      fSumErrorsMode = m;
-      CalcYErrorsSum();
-   }
+   virtual void SetSumErrorsMode(Int_t m);
 
    virtual void SetAttFill(Int_t e, TAttFill *taf);
    virtual void SetAttLine(Int_t e, TAttLine *tal);


### PR DESCRIPTION
Hello,

the bug this PR is adressing could be seen by random failures of the test gtest-hist-hist-test-TGraphMultiErrorsTests:
- https://epsft-jenkins.cern.ch/job/root-pullrequests-build/74654/testReport/projectroot.hist.hist/test/gtest_hist_hist_test_TGraphMultiErrorsTests/
-  https://epsft-jenkins.cern.ch/job/root-pullrequests-build/74449/testReport/projectroot.hist.hist/test/gtest_hist_hist_test_TGraphMultiErrorsTests/
- https://epsft-jenkins.cern.ch/job/root-pullrequests-build/73886/testReport/projectroot.hist.hist/test/gtest_hist_hist_test_TGraphMultiErrorsTests/

I have to apologize for this bug. It was caused by using an attribute to allocate an array before its value had been updated.

All the best,
Simon