### PR TITLE
Fix in Minuit2::Minos when a new minimum is found

### DIFF
--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -198,18 +198,7 @@ void FitResult::FillResult(const std::shared_ptr<ROOT::Math::Minimizer> & min, c
             for (unsigned int j = 0; j <= i; ++j)
                fCovMatrix.push_back(min->CovMatrix(i,j) );
       }
-
-      // minos errors
-      if (fValid && fconfig.MinosErrors()) {
-         const std::vector<unsigned int> & ipars = fconfig.MinosParams();
-         unsigned int n = (ipars.size() > 0) ? ipars.size() : npar;
-         for (unsigned int i = 0; i < n; ++i) {
-          double elow, eup;
-          unsigned int index = (ipars.size() > 0) ? ipars[i] : i;
-          bool ret = min->GetMinosError(index, elow, eup);
-          if (ret) SetMinosError(index, elow, eup);
-         }
-      }
+      // minos errors are set separetly when calling Fitter::CalculateMinosErrors()
 
       // globalCC
       fGlobalCC.reserve(npar);
@@ -479,7 +468,10 @@ void FitResult::Print(std::ostream & os, bool doCovMatrix) const {
       else {
          if (fErrors.size() != 0)
             os << "   +/-   " << std::left << std::setw(nn) << fErrors[i] << std::right;
-         if (IsParameterBound(i) )
+         if (HasMinosError(i))
+            os << "  " << std::left  << std::setw(nn) << LowerError(i) << " +" << std::setw(nn) << UpperError(i)
+               << " (Minos) ";
+         if (IsParameterBound(i))
             os << " \t (limited)";
       }
       os << std::endl;

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -732,7 +732,7 @@ bool Fitter::CalculateMinosErrors() {
    // compute the Minos errors according to configuration
    // set in the parameters and append value in fit result
    // normally Minos errors are computed just after the minimization
-   // (in DoMinimization) when creating the FItResult if the
+   // (in DoMinimization) aftewr minimizing if the
    //  FitConfig::MinosErrors() flag is set
 
    if (!fMinimizer) {
@@ -758,7 +758,7 @@ bool Fitter::CalculateMinosErrors() {
 
    // set flag to compute Minos error to false in FitConfig to avoid that
    // following minimizaiton calls perform unwanted Minos error calculations
-   fConfig.SetMinosErrors(false);
+   /// fConfig.SetMinosErrors(false);
 
 
    const std::vector<unsigned int> & ipars = fConfig.MinosParams();
@@ -777,6 +777,7 @@ bool Fitter::CalculateMinosErrors() {
 
    // re-give a minimizer instance in case it has been changed
    // but maintain previous valid status. Do not set result to false if minos failed
+
    ok &= fResult->Update(fMinimizer, fConfig, fResult->IsValid());
 
    return ok;
@@ -883,17 +884,24 @@ bool Fitter::DoMinimization(const ROOT::Math::IMultiGenFunction * chi2func) {
 
    assert(fMinimizer );
 
-   bool ret = fMinimizer->Minimize();
+   bool isValid = fMinimizer->Minimize();
 
    // unsigned int ncalls =  ObjFuncTrait<ObjFunc>::NCalls(*fcn);
    // int fitType =  ObjFuncTrait<ObjFunc>::Type(objFunc);
 
    if (!fResult) fResult = std::make_shared<FitResult>();
-   fResult->FillResult(fMinimizer,fConfig, fFunc, ret, fDataSize, fBinFit, chi2func );
 
-   // when possible get ncalls from FCN and set in fit result
-   if (fResult->fNCalls == 0 && fFitType != ROOT::Math::FitMethodFunction::kUndefined ) {
-      fResult->fNCalls = GetNCallsFromFCN();
+   fResult->FillResult(fMinimizer,fConfig, fFunc, isValid, fDataSize, fBinFit, chi2func );
+
+   // if requested run Minos after minimization
+   if (isValid && fConfig.MinosErrors()) {
+      // minos error calculation will update also FitResult
+      CalculateMinosErrors();
+   }
+
+      // when possible get ncalls from FCN and set in fit result
+      if (fResult->fNCalls == 0 && fFitType != ROOT::Math::FitMethodFunction::kUndefined) {
+         fResult->fNCalls = GetNCallsFromFCN();
    }
 
    // fill information in fit result
@@ -909,9 +917,9 @@ bool Fitter::DoMinimization(const ROOT::Math::IMultiGenFunction * chi2func) {
       fResult->NormalizeErrors();
 
    // set also new parameter values and errors in FitConfig
-   if (fConfig.UpdateAfterFit() && ret) DoUpdateFitConfig();
+   if (fConfig.UpdateAfterFit() &&  isValid) DoUpdateFitConfig();
 
-   return ret;
+   return isValid;
 }
 
 bool Fitter::DoMinimization(const BaseFunc & objFunc, const ROOT::Math::IMultiGenFunction * chi2func) {

--- a/math/minuit/src/TMinuitMinimizer.cxx
+++ b/math/minuit/src/TMinuitMinimizer.cxx
@@ -827,6 +827,10 @@ bool TMinuitMinimizer::GetMinosError(unsigned int i, double & errLow, double & e
 
    fMinosRun = true;
 
+   // retrieve parameters in case a new minimum has been found
+   if (fMinuit->fCstatu == "SUCCESSFUL")
+      RetrieveParams();
+
    double errParab = 0;
    double gcor = 0;
    // what returns if parameter fixed or constant or at limit ?

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -841,7 +841,7 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
          maxfcn_used = 2*(nvar+1)*(200 + 100*nvar + 5*nvar*nvar);
       }
       // print an empty line above
-      std::cout << "*****************************************************\n";
+      std::cout << "******************************************************************************************************\n";
       std::string txt = (runLower) ? "lower" : "upper";
       if (runLower && runUpper) txt = "lower and upper";
       std::cout << "Minuit2Minimizer::GetMinosError - Run MINOS " << txt << " error for parameter #" << i << " : " << par_name

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -526,6 +526,7 @@ bool Minuit2Minimizer::Minimize() {
    // -2 is the highest low invalid value for gErrorIgnoreLevel
    if (prev_level > -2) RestoreGlobalPrintLevel(prev_level);
 
+   // copy minimum state (parameter values and errors)
    fState = fMinimum->UserState();
    bool ok =  ExamineMinimum(*fMinimum);
    //fMinimum = 0;
@@ -839,7 +840,11 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
          int nvar = fState.VariableParameters();
          maxfcn_used = 2*(nvar+1)*(200 + 100*nvar + 5*nvar*nvar);
       }
-      std::cout << "Minuit2Minimizer::GetMinosError for parameter " << i << "  " << par_name
+      // print an empty line above
+      std::cout << "*****************************************************\n";
+      std::string txt = (runLower) ? "lower" : "upper";
+      if (runLower && runUpper) txt = "lower and upper";
+      std::cout << "Minuit2Minimizer::GetMinosError - Run MINOS " << txt << " error for parameter #" << i << " : " << par_name
                 << " using max-calls " << maxfcn_used << ", tolerance " << tol << std::endl;
    }
 
@@ -865,12 +870,12 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
          if(me.AtLowerLimit())
             std::cout << "Minos:  Parameter : " << par_name << "  is at Lower limit."<<std::endl;
          if(me.AtLowerMaxFcn())
-            std::cout << "Minos:  Maximum number of function calls exceeded when running for lower error" <<std::endl;
+            std::cout << "Minos:  Maximum number of function calls exceeded when running for lower error for parameter " << par_name << std::endl;
          if(me.LowerNewMin() )
-            std::cout << "Minos:  New Minimum found while running Minos for lower error" <<std::endl;
+            std::cout << "Minos:  New Minimum found while running Minos for lower error for parameter " << par_name << std::endl;
 
-         if (debugLevel > 1)  std::cout << "Minos: Lower error for parameter " << par_name << "  :  " << me.Lower() << std::endl;
-
+         if (debugLevel > 1 && me.LowerValid())
+            std::cout << "Minos: Lower error for parameter " << par_name << "  :  " << me.Lower() << std::endl;
       }
       if (runUpper) {
          if (!me.UpperValid() )
@@ -878,11 +883,12 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
          if(me.AtUpperLimit())
             std::cout << "Minos:  Parameter " << par_name << " is at Upper limit."<<std::endl;
          if(me.AtUpperMaxFcn())
-            std::cout << "Minos:  Maximum number of function calls exceeded when running for upper error" <<std::endl;
+            std::cout << "Minos:  Maximum number of function calls exceeded when running for upper error for parameter " << par_name << std::endl;
          if(me.UpperNewMin() )
-            std::cout << "Minos:  New Minimum found while running Minos for upper error" <<std::endl;
+            std::cout << "Minos:  New Minimum found while running Minos for upper error for parameter " << par_name << std::endl;
 
-         if (debugLevel > 1)  std::cout << "Minos: Upper error for parameter " << par_name << "  :  " << me.Upper() << std::endl;
+         if (debugLevel > 1 && me.UpperValid())
+            std::cout << "Minos: Upper error for parameter " << par_name << "  :  " << me.Upper() << std::endl;
       }
 
    }
@@ -910,8 +916,42 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
       fStatus += 10*mstatus;
    }
 
-   errLow = me.Lower();
-   errUp = me.Upper();
+   if (runLower) errLow = me.Lower();
+   if (runUpper) errUp = me.Upper();
+
+   // in case of new minimum update minimum state
+   int iflagNewMinimum = 0;
+   if (  ( runLower && me.LowerNewMin()) && (runUpper && me.UpperNewMin() ) ) {
+      iflagNewMinimum = 3;
+      // take state with lower function value
+      fState = (low.State().Fval() < up.State().Fval()) ? low.State() : up.State();
+   } else if ( runLower && me.LowerNewMin() ) {
+      iflagNewMinimum = 1;
+      fState = low.State();
+   } else if ( runUpper && me.UpperNewMin() ) {
+      iflagNewMinimum = 2;
+      fState = up.State();
+   }
+
+   // run gain the Minimization
+   if (iflagNewMinimum > 0) {
+      MN_INFO_MSG2("Minuit2Minimizer::GetMinosError",
+                   "Found a new minimum: run again the Minimization  starting from the new  point ");
+      if (debugLevel > 1) {
+         std::cout << "New minimum point found by Minos : " << std::endl;
+         std::cout << "FVAL  = " << fState.Fval() << std::endl;
+         for (auto & par : fState.MinuitParameters() ) {
+            std::cout << par.Name() << "\t  = " << par.Value() << std::endl;
+         }
+      }
+      // release parameter that was fixed in the returned state from Minos
+      ReleaseVariable(i);
+      bool ok = Minimize();
+      if (!ok)  return false;
+      // run again Minos from new Minimum (also lower error needs to be re-computed)
+      MN_INFO_MSG2("Minuit2Minimizer::GetMinosError", "Run now again Minos from the new found Minimum");
+      GetMinosError(i, errLow, errUp, runopt);
+   }
 
    bool isValid = (runLower && me.LowerValid() ) || (runUpper && me.UpperValid() );
    return isValid;

--- a/math/minuit2/src/MnFunctionCross.cxx
+++ b/math/minuit2/src/MnFunctionCross.cxx
@@ -116,6 +116,8 @@ MnCross MnFunctionCross::operator()(const std::vector<unsigned int>& par, const 
    std::cout << "MnFunctionCross: after Migrad on n-1  minimum is " << min0 << std::endl;
 #endif
 
+   if (min0.Fval() < fFval + tlf)  // case of new minimum found
+      return MnCross(min0.UserState(), nfcn, MnCross::CrossNewMin());
    if(min0.HasReachedCallLimit())
       return MnCross(min0.UserState(), nfcn, MnCross::CrossFcnLimit());
    if(!min0.IsValid()) return MnCross(fState, nfcn);
@@ -159,6 +161,8 @@ MnCross MnFunctionCross::operator()(const std::vector<unsigned int>& par, const 
    std::cout << "MnFunctionCross: after Migrad on n-1  minimum is " << min1 << std::endl;
 #endif
 
+   if (min1.Fval() < fFval + tlf) // case of new minimum found
+      return MnCross(min1.UserState(), nfcn, MnCross::CrossNewMin());
    if(min1.HasReachedCallLimit())
       return MnCross(min1.UserState(), nfcn, MnCross::CrossFcnLimit());
    if(!min1.IsValid()) return MnCross(fState, nfcn);
@@ -211,7 +215,8 @@ L300:
    std::cout << "MnFunctionCross: after Migrad on n-1  minimum is " << min1 << std::endl;
    std::cout << "nfcn = " << nfcn << std::endl;
 #endif
-
+            if (min1.Fval() < fFval + tlf) // case of new minimum found
+               return MnCross(min1.UserState(), nfcn, MnCross::CrossNewMin());
             if(min1.HasReachedCallLimit())
                return MnCross(min1.UserState(), nfcn, MnCross::CrossFcnLimit());
             if(!min1.IsValid()) return MnCross(fState, nfcn);
@@ -277,6 +282,8 @@ L460:
    std::cout << "nfcn = " << nfcn << std::endl;
 #endif
 
+   if (min2.Fval() < fFval + tlf) // case of new minimum found
+      return MnCross(min2.UserState(), nfcn, MnCross::CrossNewMin());
    if(min2.HasReachedCallLimit())
       return MnCross(min2.UserState(), nfcn, MnCross::CrossFcnLimit());
    if(!min2.IsValid()) return MnCross(fState, nfcn);
@@ -480,6 +487,8 @@ L500:
    std::cout << "nfcn = " << nfcn << std::endl;
 #endif
 
+         if (min2.Fval() < fFval + tlf) // case of new minimum found
+            return MnCross(min2.UserState(), nfcn, MnCross::CrossNewMin());
          if(min2.HasReachedCallLimit())
             return MnCross(min2.UserState(), nfcn, MnCross::CrossFcnLimit());
          if(!min2.IsValid()) return MnCross(fState, nfcn);


### PR DESCRIPTION
This PR handles the case in Minos when a lower function value is found. 
The iteration to find the crossing function point (in MnFunctionCross) is stopped and the new found point state with lower function value is returned. 
The Minuit2Minimizer then handles the case by re-minimizing t he function from the new point and then run again Minos from the new found minimum.

In the case of TMinuit this was handles, although maybe not in the optimal case. 

Fix also when a new Minimum is found that both in Minimizer and Fitter that the result with the new minimum is updated. 


