### PR TITLE
Fix installation of PCMs with pyroot_experimental

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,11 +414,17 @@ else()
   install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/dictpch DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 endif()
 
+# FIXME: move installation of PCMS in ROOT_GENERATE_DICTIONARY().
+# We are excluding directories, which are accidentaly copied via unxpected behaviour of install(DIRECTORY ..)
 install(
    DIRECTORY ${CMAKE_BINARY_DIR}/lib/
    DESTINATION ${CMAKE_INSTALL_LIBDIR}
    FILES_MATCHING PATTERN "*.pcm"
-   PATTERN "*_rdict.pcm" EXCLUDE
+   PATTERN "JupyROOT" EXCLUDE
+   PATTERN "JsMVA" EXCLUDE
+   PATTERN "python*" EXCLUDE
+   PATTERN "cmake" EXCLUDE
+   PATTERN "pkgconfig" EXCLUDE
 )
 
 #---hsimple.root---------(use the executable for clearer dependencies and proper return code)---


### PR DESCRIPTION
Content of install directory with this PR: 
https://gist.github.com/oshadura/7737bdcc90fed501869656808a5c514a

Next step will be to move installation of PCMs in ROOT_GENERATE_DICTIONARY().