### PR TITLE
[Exp PyROOT/thisroot.sh] Added missing part of the path that did not allow 'out of the box' correct source

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -322,7 +322,7 @@ fi
 
 
 # Check if we are in build or installation directory
-if [ ! -d "CMakeFiles" ]; then
+if [ ! -d "$ROOTSYS/CMakeFiles" ]; then
    pyroot_dir=@CMAKE_INSTALL_FULL_PYROOTDIR@
 else
    pyroot_dir=@libdir@/python${ROOT_PYTHON_VERSION}


### PR DESCRIPTION
…allow 'out of the box' correct source

Checking only for the existance of 'CMakeFiles' without including
ROOTSYS in the path was causing the addition of wrong paths in case of
out-of-the-box source