### PR TITLE
[RF] Fix crash in RoofitUnBinnedBenchmark.

### DIFF
--- a/roofit/roofit/src/RooBMixDecay.cxx
+++ b/roofit/roofit/src/RooBMixDecay.cxx
@@ -57,15 +57,15 @@ RooBMixDecay::RooBMixDecay(const char *name, const char *title,
 {
   switch(type) {
   case SingleSided:
-    _basisExp = declareBasis("exp(-@0/@1)",RooArgList(tau,dm)) ;
+    _basisExp = declareBasis("exp(-@0/@1)",RooArgList(tau)) ;
     _basisCos = declareBasis("exp(-@0/@1)*cos(@0*@2)",RooArgList(tau,dm)) ;
     break ;
   case Flipped:
-    _basisExp = declareBasis("exp(@0/@1)",RooArgList(tau,dm)) ;
+    _basisExp = declareBasis("exp(@0/@1)",RooArgList(tau)) ;
     _basisCos = declareBasis("exp(@0/@1)*cos(@0*@2)",RooArgList(tau,dm)) ;
     break ;
   case DoubleSided:
-    _basisExp = declareBasis("exp(-abs(@0)/@1)",RooArgList(tau,dm)) ;
+    _basisExp = declareBasis("exp(-abs(@0)/@1)",RooArgList(tau)) ;
     _basisCos = declareBasis("exp(-abs(@0)/@1)*cos(@0*@2)",RooArgList(tau,dm)) ;
     break ;
   }

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -60,13 +60,11 @@
 ///  Please see RooAbsPdf for additional details. Advertised analytical integrals must be
 ///  valid for all coefficients.
 
+#include "RooAbsAnaConvPdf.h"
 
 #include "RooFit.h"
 #include "RooMsgService.h"
-
 #include "Riostream.h"
-#include "Riostream.h"
-#include "RooAbsAnaConvPdf.h"
 #include "RooResolutionModel.h"
 #include "RooRealVar.h"
 #include "RooFormulaVar.h"
@@ -188,15 +186,12 @@ Int_t RooAbsAnaConvPdf::declareBasis(const char* expression, const RooArgList& p
   basisArgs.add(params) ;
 
   TString basisName(expression) ;
-  TIterator* iter = basisArgs.createIterator() ;
-  RooAbsArg* arg  ;
-  while(((arg=(RooAbsArg*)iter->Next()))) {
+  for (const auto arg : basisArgs) {
     basisName.Append("_") ;
     basisName.Append(arg->GetName()) ;
   }
-  delete iter ;  
 
-  RooFormulaVar* basisFunc = new RooFormulaVar(basisName,expression,basisArgs) ;
+  RooFormulaVar* basisFunc = new RooFormulaVar(basisName, expression, basisArgs);
   basisFunc->setAttribute("RooWorkspace::Recycle") ;
   basisFunc->setAttribute("NOCacheAndTrack") ;
   basisFunc->setOperMode(operMode()) ;

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -651,7 +651,7 @@ Bool_t RooAddModel::checkObservables(const RooArgSet* nset) const
 {
   Bool_t ret(kFALSE) ;
 
-  for (unsigned int i = 0; i < _pdfList.size(); ++i) {
+  for (unsigned int i = 0; i < _coefList.size(); ++i) {
     auto pdf = &_pdfList[i];
     auto coef = &_coefList[i];
 


### PR DESCRIPTION
Fixed a faulty loop condition in RooAddModel that lead to a crash in
RoofitUnBinnedBenchmark.
Further, fix the definition of basis functions in RooBMixDecay, which
lead to an info message about not using a parameter in a RooFormulaVar.