### PR TITLE
Several Windows-related fixes for ROOT7 classes

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RColor.hxx
@@ -179,13 +179,13 @@ public:
       ClearAuto();
    }
 
-   static constexpr RGB_t kRed{{255, 0, 0}};
-   static constexpr RGB_t kGreen{{0, 255, 0}};
-   static constexpr RGB_t kBlue{{0, 0, 255}};
-   static constexpr RGB_t kWhite{{255, 255, 255}};
-   static constexpr RGB_t kBlack{{0, 0, 0}};
-   static constexpr double kTransparent{0.};
-   static constexpr double kOpaque{1.};
+   static RGB_t kRed;
+   static RGB_t kGreen;
+   static RGB_t kBlue;
+   static RGB_t kWhite;
+   static RGB_t kBlack;
+   static double kTransparent;
+   static double kOpaque;
 
    friend bool operator==(const RColor &lhs, const RColor &rhs)
    {

--- a/graf2d/gpadv7/inc/ROOT/RPalette.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPalette.hxx
@@ -71,7 +71,7 @@ public:
 
    /// Tag value used to signal that the palette's colors should not be interpolated. Can be passed to the
    /// constructor: `RPalette palette(RPalette::kDiscrete, {{-100., RColor::kWhite}, {100., RColor::kRed}})`
-   static constexpr const Discrete_t kDiscrete{};
+   static const Discrete_t kDiscrete;
 
    RPalette() = default;
 

--- a/graf2d/gpadv7/src/RColor.cxx
+++ b/graf2d/gpadv7/src/RColor.cxx
@@ -10,13 +10,13 @@
 
 using namespace ROOT::Experimental;
 
-constexpr RColor::RGB_t RColor::kRed;
-constexpr RColor::RGB_t RColor::kGreen;
-constexpr RColor::RGB_t RColor::kBlue;
-constexpr RColor::RGB_t RColor::kWhite;
-constexpr RColor::RGB_t RColor::kBlack;
-constexpr double RColor::kTransparent;
-constexpr double RColor::kOpaque;
+RColor::RGB_t RColor::kRed = {255, 0, 0};
+RColor::RGB_t RColor::kGreen = {0, 255, 0};
+RColor::RGB_t RColor::kBlue = {0, 0, 255};
+RColor::RGB_t RColor::kWhite = {255, 255, 255};
+RColor::RGB_t RColor::kBlack = {0, 0, 0};
+double RColor::kTransparent = 0.;
+double RColor::kOpaque = 1.;
 
 ///////////////////////////////////////////////////////////////////////////
 /// Converts integer from 0 to 255 into hex format with two digits like 00

--- a/graf2d/gpadv7/src/RPalette.cxx
+++ b/graf2d/gpadv7/src/RPalette.cxx
@@ -17,6 +17,8 @@
 
 using namespace ROOT::Experimental;
 
+const RPalette::Discrete_t RPalette::kDiscrete = {};
+
 RPalette::RPalette(bool interpolate, bool knownNormalized, const std::vector<RPalette::OrdinalAndColor> &points)
    : fColors(points), fInterpolate(interpolate), fNormalized(knownNormalized)
 {

--- a/gui/browsable/inc/ROOT/Browsable/RSysFile.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RSysFile.hxx
@@ -19,7 +19,12 @@ namespace ROOT {
 namespace Experimental {
 namespace Browsable {
 
+class RSysDirLevelIter;
+
 class RSysFile : public RElement {
+
+   friend class RSysDirLevelIter;
+
    FileStat_t fStat;       ///<! file stat object
    std::string fDirName;   ///<! fully-qualified directory name
    std::string fFileName;  ///<! file name in current dir
@@ -29,9 +34,7 @@ class RSysFile : public RElement {
 public:
    RSysFile(const std::string &filename);
 
-   RSysFile(const FileStat_t& stat, const std::string &dirname, const std::string &filename) : fStat(stat), fDirName(dirname), fFileName(filename)
-   {
-   }
+   RSysFile(const FileStat_t& stat, const std::string &dirname, const std::string &filename);
 
    virtual ~RSysFile() = default;
 
@@ -47,6 +50,8 @@ public:
    std::unique_ptr<RLevelIter> GetChildsIter() override;
 
    std::string GetContent(const std::string &kind) override;
+
+   static std::string GetFileIcon(const std::string &fname);
 
    static std::string ProvideTopEntries(std::shared_ptr<RGroup> &comp, const std::string &workdir = "");
 

--- a/tutorials/v7/browser.cxx
+++ b/tutorials/v7/browser.cxx
@@ -16,6 +16,9 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+// macro must be here to let macro work on Windows
+R__LOAD_LIBRARY(libROOTBrowserv7)
+
 #include <ROOT/RBrowser.hxx>
 #include <ROOT/RDirectory.hxx>
 

--- a/tutorials/v7/filedialog.cxx
+++ b/tutorials/v7/filedialog.cxx
@@ -15,13 +15,17 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RFileDialog.hxx>
-
 // Show how RFileDialog can be used in sync and async modes
 // Normally file dialogs will be used inside other widgets as ui5 dialogs
 // By default, dialog starts in async mode - means macro immediately returns to command line
 // To start OpenFile dialog in sync mode, call `root "filedialog.cxx(1)" -q`.
 // Once file is selected, root execution will be stopped
+
+
+// macro must be here to let macro work on Windows
+R__LOAD_LIBRARY(libROOTBrowserv7)
+
+#include <ROOT/RFileDialog.hxx>
 
 
 using namespace ROOT::Experimental;


### PR DESCRIPTION
1. Avoid usage of `static constexpr` in header files. MSVC compiler is not happy about such construct
2. Add R__LOAD_LIBRARY to test macros (like brower.cxx) to let it run in Windows
3. Add handling of ".lnk" files in RBrowser