### PR TITLE
Explicitly disable autoloading when processing TClass rules.

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2146,6 +2146,7 @@ void TROOT::InitInterpreter()
    // Read the rules before enabling the auto loading to not inadvertently
    // load the libraries for the classes concerned even-though the user is
    // *not* using them.
+   TInterpreter::SuspendAutoloadingRAII autoloadOff(gInterpreter);
    TClass::ReadRules(); // Read the default customization rules ...
 }
 


### PR DESCRIPTION
This should resolve ROOT-10514.