### PR TITLE
Fix missing standalone flag for standalone Minuit2

### DIFF
--- a/math/minuit2/.ci/make_and_test.sh
+++ b/math/minuit2/.ci/make_and_test.sh
@@ -1,5 +1,7 @@
 # This is run by the CI system from the main Minuit2 directory
 
+set -evx
+
 mkdir build
 cd build
 cmake .. -Dminuit2_standalone=OFF -DCMAKE_INSTALL_PREFIX=install

--- a/math/minuit2/src/math/CMakeLists.txt
+++ b/math/minuit2/src/math/CMakeLists.txt
@@ -76,6 +76,7 @@ target_compile_definitions(
     Minuit2Math
     PUBLIC
     ROOT_Math_VecTypes
+    MATHCORE_STANDALONE
     )
 
 target_link_libraries(Minuit2Math PUBLIC Minuit2Common)


### PR DESCRIPTION
This is missing from the standalone build - the Error.h file has:

https://github.com/root-project/root/blob/803df004f43cfbb7c16e455ca30f2c250cc7fd8d/math/mathcore/inc/Math/Error.h#L27

But this is not being added by the standalone CMake build.

It seems that this was changed from `USE_ROOT_ERROR` missing to a check for `MATHCORE_STANDALONE` (https://github.com/root-project/root/pull/2545).