### PR TITLE
WebEve: clairfy code

### DIFF
--- a/ui5/eve7/controller/EveTable.controller.js
+++ b/ui5/eve7/controller/EveTable.controller.js
@@ -30,11 +30,11 @@ sap.ui.define([
          this._render_html = false;
 
          this.mgr = data.mgr;
-         this.elementid = data.elementid;
+         this.eveViewerId = data.eveViewerId;
          this.kind = data.kind;
          
          this.bindTableColumns = true;
-         var element = this.mgr.GetElement(this.elementid);
+         var element = this.mgr.GetElement(this.eveViewerId);
          // loop over scene and add dependency
          for (var k=0;k<element.childs.length;++k) {
             var scene = element.childs[k];
@@ -46,7 +46,7 @@ sap.ui.define([
       locateEveTable: function()
       {
          this.eveTable = 0;
-         var element = this.mgr.GetElement(this.elementid);
+         var element = this.mgr.GetElement(this.eveViewerId);
          var sceneInfo = element.childs[0];
          var scene = this.mgr.GetElement(sceneInfo.fSceneId);
          // console.log(">>>table scene", scene);
@@ -148,7 +148,7 @@ sap.ui.define([
 
          for (var i = 0; i < clist.childs.length; i++)
          {
-            mData.itemx.push({"text" :clist.childs[i].fName, "key": clist.childs[i].fName, "elementId":clist.childs[i].fElementId });
+            mData.itemx.push({"text" :clist.childs[i].fName, "key": clist.childs[i].fName, "collectionEveId":clist.childs[i].fElementId });
          }
          oModel.setData(mData);
          this.getView().setModel(oModel, "collections");
@@ -176,21 +176,13 @@ sap.ui.define([
       },
 
       UpdateMgr : function(mgr) {
-         var elem = mgr.map[this.elementid];
+         var elem = mgr.map[this.eveViewerId];
          var scene = mgr.map[ elem.fMotherId];
          this.mgr = mgr;
       },
 
       onAfterRendering: function() {
          this._render_html = true;
-
-         // this.getView().$().css("overflow", "hidden");
-
-         // this.getView().$().parent().css("overflow", "hidden");
-
-         // only when rendering completed - register for modify events
-         var element = this.mgr.GetElement(this.elementid);
-
          this.checkScenes();
       },
 
@@ -370,7 +362,7 @@ sap.ui.define([
          var model = oEvent.oSource.getSelectedItem().getBindingContext("collections");
          var path = model.getPath();
          var entry = model.getProperty(path);
-         var coll = entry.elementId;
+         var coll = entry.collectionEveId;
          var mng =  this.viewInfo;
 
          var mir = "SetDisplayedCollection(" + coll + ")";

--- a/ui5/eve7/controller/GL.controller.js
+++ b/ui5/eve7/controller/GL.controller.js
@@ -81,7 +81,7 @@ sap.ui.define([
          if (moredata && moredata.mgr)
          {
             this.mgr        = moredata.mgr;
-            this.elementid  = moredata.elementid;
+            this.eveViewerId  = moredata.eveViewerId;
             this.kind       = moredata.kind;
             this.standalone = viewName;
 
@@ -96,7 +96,7 @@ sap.ui.define([
          else
          {
             this.mgr       = data.mgr;
-            this.elementid = data.elementid;
+            this.eveViewerId = data.eveViewerId;
             this.kind      = data.kind;
          }
 
@@ -134,7 +134,7 @@ sap.ui.define([
          }
          if ( ! found) return;
 
-         this.elementid = found.fElementId;
+         this.eveViewerId = found.fElementId;
          this.kind      = (found.fName == "Default Viewer") ? "3D" : "2D";
 
          this.checkViewReady();
@@ -151,7 +151,7 @@ sap.ui.define([
       // Checks if all initialization is performed and startup renderer.
       checkViewReady: function()
       {
-         if ( ! this._load_scripts || ! this._render_html || ! this.elementid)
+         if ( ! this._load_scripts || ! this._render_html || ! this.eveViewerId)
          {
             return;
          }
@@ -634,7 +634,7 @@ sap.ui.define([
          this.created_scenes = [];
 
          // only when rendering completed - register for modify events
-         let element = this.mgr.GetElement(this.elementid);
+         let element = this.mgr.GetElement(this.eveViewerId);
 
          // loop over scene and add dependency
          for (let scene of element.childs)

--- a/ui5/eve7/controller/Main.controller.js
+++ b/ui5/eve7/controller/Main.controller.js
@@ -114,7 +114,7 @@ sap.ui.define(['sap/ui/core/Component',
                return new sap.ui.xmlview({
                   id: viewid,
                   viewName: vtype,
-                  viewData: { mgr: main.mgr, elementid: elem.fElementId, kind: elem.view_kind },
+                  viewData: { mgr: main.mgr, eveViewerId: elem.fElementId, kind: elem.view_kind },
                   layoutData: oLd
                });
             });

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -683,9 +683,3 @@ sap.ui.define([], function() {
    return EveManager;
 
 });
-
-// Matevz's notes ... here for lack of better ideas.
-//
-// 1. elementid, fElementId, eveId --> this is ultra confusing, decide and use consistently.
-//    Maybe also on the eve side. m_eid ?
-//    Ditto for fMasterId, mstrId, something else, probably

--- a/ui5/eve7/lib/EveScene.js
+++ b/ui5/eve7/lib/EveScene.js
@@ -47,18 +47,13 @@ sap.ui.define([
          // MT ??? why?, it can really be anything, even just container Object3D
          obj3d._typename = "THREE.Mesh";
 
-         // XXXX Sanitize these members!!!
+         // add reference to a streamed eve element to obj3d
+         obj3d.eve_el = elem;
 
          // SL: this is just identifier for highlight, required to show items on other places, set in creator
          obj3d.geo_object = elem.fMasterId || elem.fElementId;
          obj3d.geo_name   = elem.fName; // used for highlight
-
-         obj3d.eve_el = elem;
          obj3d.scene  = this; // required for get changes when highlight/selection is changed
-
-         // AMT: reference needed in MIR callback
-         obj3d.eveId  = elem.fElementId;
-         obj3d.mstrId = elem.fMasterId;
 
          if (elem.render_data.matrix)
          {
@@ -302,7 +297,7 @@ sap.ui.define([
       let is_multi  = event && event.ctrlKey;
       let is_secsel = indx !== undefined;
 
-      let fcall = "NewElementPicked(" + (obj3d ? obj3d.eveId : 0) + `, ${is_multi}, ${is_secsel}`;
+      let fcall = "NewElementPicked(" + (obj3d ? obj3d.eve_el.fElementId : 0) + `, ${is_multi}, ${is_secsel}`;
       if (is_secsel)
       {
          fcall += ", { " + (Array.isArray(indx) ? indx.join(", ") : indx) + " }";
@@ -321,7 +316,7 @@ sap.ui.define([
    EveScene.prototype.processElementHighlighted = function(obj3d, indx, evnt)
    {
       // Need check for duplicates before call server, else server will un-higlight highlighted element
-      // console.log("EveScene.prototype.processElementHighlighted", obj3d.eveId, indx, evnt);
+      // console.log("EveScene.prototype.processElementHighlighted", obj3d.eve_el.fElementId, indx, evnt);
       let is_multi  = false;
       let is_secsel = indx !== undefined;
 
@@ -335,7 +330,7 @@ sap.ui.define([
       if (a && (a.length == 1))
       {
          let h = a[0];
-         if (h.primary == obj3d.eveId || h.primary == obj3d.mstrId ) {
+         if (h.primary == obj3d.eve_el.fElementId || h.primary == obj3d.eve_el.fMasterId) {
             if (indx) {
                if (h.sec_idcs && h.sec_idcs[0] == indx) {
                   // console.log("EveScene.prototype.processElementHighlighted processElementHighlighted same index ");
@@ -349,7 +344,7 @@ sap.ui.define([
          }
       }
 
-      let fcall = "NewElementPicked(" + obj3d.eveId + `, ${is_multi}, ${is_secsel}`;
+      let fcall = "NewElementPicked(" + obj3d.eve_el.fElementId + `, ${is_multi}, ${is_secsel}`;
       if (is_secsel)
       {
          fcall += ", { " + (Array.isArray(indx) ? indx.join(", ") : indx) + " }";


### PR DESCRIPTION
Give more informative member names to avoid confusion (e.g. eveId, elementId, eve_id)
Remove redundant member in object3d: eveId and mstrId, which can be accessed ad eve_el.fElementId, and eve_el.fMasterId

This PR is not a design change.