### PR TITLE
Tessellated shape

### DIFF
--- a/geom/gdml/inc/TGDMLParse.h
+++ b/geom/gdml/inc/TGDMLParse.h
@@ -162,7 +162,8 @@ private:
    XMLNodePointer_t  Orb(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr);
    XMLNodePointer_t  Xtru(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr);
    XMLNodePointer_t  Reflection(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr);
-   XMLNodePointer_t  Ellipsoid(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr); //not really implemented: just approximation to a TGeoBBox
+   XMLNodePointer_t  Ellipsoid(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr);
+   XMLNodePointer_t  Tessellated(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr);
 
    //'structure' section
    XMLNodePointer_t  VolProcess(TXMLEngine* gdml, XMLNodePointer_t node);

--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -33,6 +33,7 @@
 #include "TGeoBoolNode.h"
 #include "TGeoCompositeShape.h"
 #include "TGeoScaledShape.h"
+#include "TGeoTessellated.h"
 #include "TGeoManager.h"
 #include "TGDMLMatrix.h"
 
@@ -193,6 +194,7 @@ private:
    XMLNodePointer_t CreateXtrusionN(TGeoXtru * geoShape);
    XMLNodePointer_t CreateEllipsoidN(TGeoCompositeShape * geoShape, TString elName);
    XMLNodePointer_t CreateElConeN(TGeoScaledShape * geoShape);
+   XMLNodePointer_t CreateTessellatedN(TGeoTessellated * geoShape);
    XMLNodePointer_t CreateOpticalSurfaceN(TGeoOpticalSurface * geoSurf);
    XMLNodePointer_t CreateSkinSurfaceN(TGeoSkinSurface * geoSurf);
    XMLNodePointer_t CreateBorderSurfaceN(TGeoBorderSurface * geoSurf);

--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -4278,7 +4278,7 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine* gdml, XMLNodePointer_t node
    TString name, vname, type;
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
       if (tempattr == "name") {
@@ -4296,7 +4296,7 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine* gdml, XMLNodePointer_t node
    XMLNodePointer_t child = gdml->GetChild(node);
    int nofacets = 0;
 
-   while (child != 0) {
+   while (child != nullptr) {
       tempattr = gdml->GetNodeName(child);
       tempattr.ToLower();
       if (tempattr == "triangular" || tempattr == "quadrangular" ) {
@@ -4305,12 +4305,13 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine* gdml, XMLNodePointer_t node
       child = gdml->GetNext(child);
    }
    
-   TGeoTessellated *tsl = new TGeoTessellated(NameShort(name), nofacets);
+   auto *tsl = new TGeoTessellated(NameShort(name), nofacets);
    TGeoTranslation *pos = nullptr;
    Tessellated::Vertex_t vertices[4];
 
    auto SetVertex = [&](int i, TGeoTranslation *trans)
    {
+      if (trans == nullptr) return;
       const double *tr = trans->GetTranslation();
       vertices[i].Set(tr[0], tr[1], tr[2]);
    };
@@ -4336,13 +4337,13 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine* gdml, XMLNodePointer_t node
 
    // Get facet attributes
    child = gdml->GetChild(node);
-   while (child != 0) {
+   while (child != nullptr) {
       tempattr = gdml->GetNodeName(child);
       tempattr.ToLower();
       if (tempattr == "triangular") {
          attr = gdml->GetFirstAttr(child);
 
-         while (attr != 0) {
+         while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
 
             if (tempattr == "vertex1") {
@@ -4381,7 +4382,7 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine* gdml, XMLNodePointer_t node
       else if (tempattr == "quadrangular") {
          attr = gdml->GetFirstAttr(child);
 
-         while (attr != 0) {
+         while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
 
             if (tempattr == "vertex1") {

--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -4307,7 +4307,7 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine* gdml, XMLNodePointer_t node
    
    TGeoTessellated *tsl = new TGeoTessellated(NameShort(name), nofacets);
    TGeoTranslation *pos = nullptr;
-   TGeoVector3 vertices[4];
+   Tessellated::Vertex_t vertices[4];
 
    auto SetVertex = [&](int i, TGeoTranslation *trans)
    {

--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -4305,7 +4305,7 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine* gdml, XMLNodePointer_t node
       child = gdml->GetNext(child);
    }
    
-   auto *tsl = new TGeoTessellated(NameShort(name), nofacets);
+   auto tsl = new TGeoTessellated(NameShort(name), nofacets);
    TGeoTranslation *pos = nullptr;
    Tessellated::Vertex_t vertices[4];
 

--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -382,7 +382,7 @@ const char* TGDMLParse::ParseGDML(TXMLEngine* gdml, XMLNodePointer_t node)
               ((strcmp(name, "firstposition")) != 0) && ((strcmp(name, "firstpositionref")) != 0) &&
               ((strcmp(name, "firstrotation")) != 0) && ((strcmp(name, "firstrotationref")) != 0) &&
               ((strcmp(name, "section")) != 0) && ((strcmp(name, "world")) != 0) &&
-              ((strcmp(name, "isotope")) != 0)) {
+              ((strcmp(name, "isotope")) != 0) && ((strcmp(name, "triangular")) != 0) && ((strcmp(name, "quadrangular")) != 0)) {
       std::cout << "Error: Unsupported GDML Tag Used :" << name << ". Please Check Geometry/Schema." << std::endl;
    }
 

--- a/geom/geom/CMakeLists.txt
+++ b/geom/geom/CMakeLists.txt
@@ -59,6 +59,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Geom
     TGeoVolume.h
     TGeoVoxelFinder.h
     TGeoXtru.h
+    TGeoTessellated.h
     TVirtualGeoConverter.h
     TVirtualGeoPainter.h
     TVirtualGeoTrack.h
@@ -110,6 +111,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Geom
     src/TGeoVolume.cxx
     src/TGeoVoxelFinder.cxx
     src/TGeoXtru.cxx
+    src/TGeoTessellated.cxx
     src/TVirtualGeoConverter.cxx
     src/TVirtualGeoPainter.cxx
     src/TVirtualGeoTrack.cxx

--- a/geom/geom/CMakeLists.txt
+++ b/geom/geom/CMakeLists.txt
@@ -60,6 +60,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Geom
     TGeoVoxelFinder.h
     TGeoXtru.h
     TGeoTessellated.h
+    TGeoVector3.h
     TVirtualGeoConverter.h
     TVirtualGeoPainter.h
     TVirtualGeoTrack.h
@@ -112,6 +113,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Geom
     src/TGeoVoxelFinder.cxx
     src/TGeoXtru.cxx
     src/TGeoTessellated.cxx
+    src/TGeoVector3.cxx
     src/TVirtualGeoConverter.cxx
     src/TVirtualGeoPainter.cxx
     src/TVirtualGeoTrack.cxx

--- a/geom/geom/inc/LinkDef1.h
+++ b/geom/geom/inc/LinkDef1.h
@@ -75,8 +75,8 @@
 #pragma link C++ class TGeoCompositeShape+;
 #pragma link C++ class TGeoPolygon+;
 #pragma link C++ class TGeoXtru+;
-#pragma link C++ struct TGeoVector3+;
-#pragma link C++ struct TGeoFacet+;
+#pragma link C++ class ROOT::Geom::Vertex_t+;
+#pragma link C++ class TGeoFacet+;
 #pragma link C++ class TGeoTessellated+;
 #pragma link C++ class TGeoShapeAssembly+;
 #pragma link C++ class TGeoScaledShape+;

--- a/geom/geom/inc/LinkDef1.h
+++ b/geom/geom/inc/LinkDef1.h
@@ -75,6 +75,9 @@
 #pragma link C++ class TGeoCompositeShape+;
 #pragma link C++ class TGeoPolygon+;
 #pragma link C++ class TGeoXtru+;
+#pragma link C++ struct TGeoVector3+;
+#pragma link C++ struct TGeoFacet+;
+#pragma link C++ class TGeoTessellated+;
 #pragma link C++ class TGeoShapeAssembly+;
 #pragma link C++ class TGeoScaledShape+;
 #pragma link C++ class TGeoVolume-;

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -20,7 +20,7 @@ class TGeoFacet {
    using VertexVec_t = std::vector<Vertex_t>;
 
 private:
-   Int_t     fIvert[4]    = {0};       // Vertex indices in the array
+   int     fIvert[4]    = {0};       // Vertex indices in the array
    VertexVec_t *fVertices = nullptr;   //! array of vertices
    int       fNvert       = 0;         // number of vertices (can be 3 or 4)
    bool      fShared      = false;     // Vector of vertices shared flag
@@ -34,7 +34,7 @@ public:
    const TGeoFacet &operator = (const TGeoFacet &other);
 
    // Triangular facet
-   TGeoFacet(const TGeoVector3 &pt0, const TGeoVector3 &pt1, const TGeoVector3 &pt2)
+   TGeoFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2)
       : fIvert{0, 1, 2}
    {
       fVertices = new VertexVec_t;
@@ -45,7 +45,7 @@ public:
    }
 
    // Quadrilateral facet
-   TGeoFacet(const TGeoVector3 &pt0, const TGeoVector3 &pt1, const TGeoVector3 &pt2, const TGeoVector3 &pt3)
+   TGeoFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2, const Vertex_t &pt3)
       : fIvert{0, 1, 2, 3}
    {
       fVertices = new VertexVec_t;
@@ -69,16 +69,16 @@ public:
       fShared   = true;
    }
    
-   TGeoVector3 ComputeNormal(bool &degenerated) const;
-   Int_t GetNvert() const { return fNvert; }
+   Vertex_t ComputeNormal(bool &degenerated) const;
+   int GetNvert() const { return fNvert; }
 
    Vertex_t &GetVertex(int ivert) { return fVertices->operator[](fIvert[ivert]); }
    const Vertex_t &GetVertex(int ivert) const { return fVertices->operator[](fIvert[ivert]); }
 
-   Int_t GetVertexIndex(int ivert) const { return fIvert[ivert]; }
+   int GetVertexIndex(int ivert) const { return fIvert[ivert]; }
    
    bool Check() const;
-   bool CheckNeighbour(const TGeoFacet $other) const;
+   bool IsNeighbour(const TGeoFacet &other, bool &flip) const;
 };
 
 std::ostream &operator<<(std::ostream &os, TGeoFacet const &facet);
@@ -94,11 +94,11 @@ private:
    std::vector<Vertex_t>  fVertices;        // List of vertices
    std::vector<TGeoFacet> fFacets;          // List of facets
 
-   virtual void FillBuffer3D(TBuffer3D & buffer, Int_t reqSections, Bool_t localFrame) const;
+   virtual void FillBuffer3D(TBuffer3D & buffer, int reqSections, Bool_t localFrame) const;
 public:
    // constructors
    TGeoTessellated() {}
-   TGeoTessellated(const char *name, Int_t nfacets);
+   TGeoTessellated(const char *name, int nfacets);
    // destructor
    virtual ~TGeoTessellated() {}
 
@@ -108,24 +108,25 @@ public:
    void ComputeBBox();
    void Close();
 
-   void AddFacet(const TGeoVector3 &pt0, const TGeoVector3 &pt1, const TGeoVector3 &pt2);
-   void AddFacet(const TGeoVector3 &pt0, const TGeoVector3 &pt1, const TGeoVector3 &pt2, const TGeoVector3 &pt3);
+   void AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2);
+   void AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2, const Vertex_t &pt3);
 
    int  GetNfacets() const { return fFacets.size(); }
    int  GetNsegments() const { return fNseg; }
    int  GetNvertices() const { return fNvert; }
-   const TGeoFacet &GetFacet(Int_t i) { return fFacets[i]; }
+   const TGeoFacet &GetFacet(int i) { return fFacets[i]; }
+   const Vertex_t &GetVertex(int i) { return fVertices[i]; }
 
    virtual void          AfterStreamer();
-   virtual Int_t         DistancetoPrimitive(Int_t, Int_t) { return 99999; }
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const { return fNvert; }
+   virtual int           DistancetoPrimitive(int, int) { return 99999; }
+   virtual const TBuffer3D &GetBuffer3D(int reqSections, Bool_t localFrame) const;
+   virtual void          GetMeshNumbers(int &nvert, int &nsegs, int &npols) const;
+   virtual int           GetNmeshVertices() const { return fNvert; }
    virtual void          InspectShape() const {}
    virtual TBuffer3D    *MakeBuffer3D() const;
    virtual void          SavePrimitive(std::ostream &, Option_t *) {}
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
+   virtual void          SetPoints(double *points) const;
+   virtual void          SetPoints(float *points) const;
    virtual void          SetSegsAndPols(TBuffer3D &buff) const;
    virtual void          Sizeof3D() const {}
    

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -99,8 +99,6 @@ private:
    std::vector<Vertex_t> fVertices; // List of vertices
    std::vector<TGeoFacet> fFacets;  // List of facets
 
-   virtual void FillBuffer3D(TBuffer3D &buffer, int reqSections, Bool_t localFrame) const;
-
 public:
    // constructors
    TGeoTessellated() {}

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -1,0 +1,99 @@
+// @(#)root/geom:$Id$
+// Author: Andrei Gheata   20/12/19
+
+/*************************************************************************
+ * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGeoTessellated
+#define ROOT_TGeoTessellated
+
+#include "TGeoVector3.h"
+#include "TGeoBBox.h"
+
+struct TGeoFacet {
+   using Vertex_t = TGeoVector3;
+   Vertex_t fVertices[4];   // array of vertices
+   int      fNvert = 0;     // number of vertices (can be 3 or 4)
+
+   TGeoFacet() {}
+   // Triangular facet
+   TGeoFacet(double x0, double y0, double z0,
+             double x1, double y1, double z1,
+             double x2, double y2, double z2)
+   {
+      fVertices[0].Set(x0, y0, z0);
+      fVertices[1].Set(x1, y1, z1);
+      fVertices[2].Set(x2, y2, z2);
+      fNvert = 3;
+   }
+
+   // Quadrilateral facet
+   TGeoFacet(double x0, double y0, double z0,
+             double x1, double y1, double z1,
+             double x2, double y2, double z2,
+             double x3, double y3, double z3)
+   {
+      fVertices[0].Set(x0, y0, z0);
+      fVertices[1].Set(x1, y1, z1);
+      fVertices[2].Set(x2, y2, z2);
+      fVertices[3].Set(x3, y3, z3);
+      fNvert = 4;
+   }
+
+   //bool Check();
+};
+
+class TGeoTessellated : public TGeoBBox
+{
+  using Vector3_t = TGeoVector3;
+
+private:
+   int fNfacets = 0;
+   int fNvert   = 0;
+   std::vector<TGeoFacet> fFacets;
+
+   virtual void FillBuffer3D(TBuffer3D & buffer, Int_t reqSections, Bool_t localFrame) const;
+public:
+   // constructors
+   TGeoTessellated() {}
+   TGeoTessellated(const char *name, Int_t nfacets);
+   // destructor
+   virtual ~TGeoTessellated() {}
+
+   TGeoTessellated(const TGeoTessellated&);
+   TGeoTessellated& operator=(const TGeoTessellated&);
+   
+   void ComputeBBox();
+   void Close() { ComputeBBox(); }
+
+   void AddFacet(double x0, double y0, double z0,
+                 double x1, double y1, double z1,
+                 double x2, double y2, double z2);
+   void AddFacet(double x0, double y0, double z0,
+                 double x1, double y1, double z1,
+                 double x2, double y2, double z2,
+                 double x3, double y3, double z3);
+   int  GetNfacets() const { return fFacets.size(); }
+   int  GetNvertices() const { return fNvert; }
+   const TGeoFacet &GetFacet(Int_t i) { return fFacets[i]; }
+
+   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
+   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
+   virtual Int_t         GetNmeshVertices() const { return fNvert; }
+   virtual void          InspectShape() const {}
+   virtual TBuffer3D    *MakeBuffer3D() const;
+   virtual void          SavePrimitive(std::ostream &, Option_t *) {}
+   virtual void          SetPoints(Double_t *points) const;
+   virtual void          SetPoints(Float_t *points) const;
+   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
+   virtual void          Sizeof3D() const {}
+   
+   ClassDef(TGeoTessellated, 1)         // tessellated shape class
+};
+
+#endif

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -13,29 +13,33 @@
 #define ROOT_TGeoTessellated
 
 #include "TGeoVector3.h"
+#include "TGeoTypedefs.h"
 #include "TGeoBBox.h"
 
 class TGeoFacet {
-   using Vertex_t    = TGeoVector3;
-   using VertexVec_t = std::vector<Vertex_t>;
+   using Vertex_t = Tessellated::Vertex_t;
+   using VertexVec_t = Tessellated::VertexVec_t;
 
 private:
-   int     fIvert[4]    = {0};       // Vertex indices in the array
-   VertexVec_t *fVertices = nullptr;   //! array of vertices
-   int       fNvert       = 0;         // number of vertices (can be 3 or 4)
-   bool      fShared      = false;     // Vector of vertices shared flag
+   int fIvert[4] = {0};              // Vertex indices in the array
+   VertexVec_t *fVertices = nullptr; //! array of vertices
+   int fNvert = 0;                   // number of vertices (can be 3 or 4)
+   bool fShared = false;             // Vector of vertices shared flag
 
 public:
    TGeoFacet() {}
    TGeoFacet(const TGeoFacet &other);
 
-   ~TGeoFacet() { if (!fShared) delete fVertices; }
+   ~TGeoFacet()
+   {
+      if (!fShared)
+         delete fVertices;
+   }
 
-   const TGeoFacet &operator = (const TGeoFacet &other);
+   const TGeoFacet &operator=(const TGeoFacet &other);
 
    // Triangular facet
-   TGeoFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2)
-      : fIvert{0, 1, 2}
+   TGeoFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2) : fIvert{0, 1, 2}
    {
       fVertices = new VertexVec_t;
       fVertices->push_back(pt0);
@@ -45,20 +49,20 @@ public:
    }
 
    // Quadrilateral facet
-   TGeoFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2, const Vertex_t &pt3)
-      : fIvert{0, 1, 2, 3}
+   TGeoFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2, const Vertex_t &pt3) : fIvert{0, 1, 2, 3}
    {
       fVertices = new VertexVec_t;
       fVertices->push_back(pt0);
       fVertices->push_back(pt1);
       fVertices->push_back(pt2);
-      fVertices->push_back(pt3);      
+      fVertices->push_back(pt3);
       fNvert = 4;
    }
-   
+
    void SetVertices(VertexVec_t *vertices, int i0 = -1, int i1 = -1, int i2 = -1, int i3 = -1)
    {
-      if (!fShared) delete fVertices;
+      if (!fShared)
+         delete fVertices;
       fVertices = vertices;
       if (i0 >= 0) {
          fIvert[0] = i0;
@@ -66,9 +70,9 @@ public:
          fIvert[2] = i2;
          fIvert[3] = i3;
       }
-      fShared   = true;
+      fShared = true;
    }
-   
+
    Vertex_t ComputeNormal(bool &degenerated) const;
    int GetNvert() const { return fNvert; }
 
@@ -76,25 +80,27 @@ public:
    const Vertex_t &GetVertex(int ivert) const { return fVertices->operator[](fIvert[ivert]); }
 
    int GetVertexIndex(int ivert) const { return fIvert[ivert]; }
-   
+
    bool Check() const;
    bool IsNeighbour(const TGeoFacet &other, bool &flip) const;
 };
 
 std::ostream &operator<<(std::ostream &os, TGeoFacet const &facet);
 
-class TGeoTessellated : public TGeoBBox
-{
-  using Vertex_t = TGeoVector3;
+class TGeoTessellated : public TGeoBBox {
+
+public:
+  using Vertex_t = Tessellated::Vertex_t;
 
 private:
    int fNfacets = 0;
-   int fNvert   = 0;
-   int fNseg    = 0;
-   std::vector<Vertex_t>  fVertices;        // List of vertices
-   std::vector<TGeoFacet> fFacets;          // List of facets
+   int fNvert = 0;
+   int fNseg = 0;
+   std::vector<Vertex_t> fVertices; // List of vertices
+   std::vector<TGeoFacet> fFacets;  // List of facets
 
-   virtual void FillBuffer3D(TBuffer3D & buffer, int reqSections, Bool_t localFrame) const;
+   virtual void FillBuffer3D(TBuffer3D &buffer, int reqSections, Bool_t localFrame) const;
+
 public:
    // constructors
    TGeoTessellated() {}
@@ -102,35 +108,35 @@ public:
    // destructor
    virtual ~TGeoTessellated() {}
 
-   TGeoTessellated(const TGeoTessellated&);
-   TGeoTessellated& operator=(const TGeoTessellated&);
-   
+   TGeoTessellated(const TGeoTessellated &);
+   TGeoTessellated &operator=(const TGeoTessellated &);
+
    void ComputeBBox();
    void Close();
 
    void AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2);
    void AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2, const Vertex_t &pt3);
 
-   int  GetNfacets() const { return fFacets.size(); }
-   int  GetNsegments() const { return fNseg; }
-   int  GetNvertices() const { return fNvert; }
+   int GetNfacets() const { return fFacets.size(); }
+   int GetNsegments() const { return fNseg; }
+   int GetNvertices() const { return fNvert; }
    const TGeoFacet &GetFacet(int i) { return fFacets[i]; }
    const Vertex_t &GetVertex(int i) { return fVertices[i]; }
 
-   virtual void          AfterStreamer();
-   virtual int           DistancetoPrimitive(int, int) { return 99999; }
+   virtual void AfterStreamer();
+   virtual int DistancetoPrimitive(int, int) { return 99999; }
    virtual const TBuffer3D &GetBuffer3D(int reqSections, Bool_t localFrame) const;
-   virtual void          GetMeshNumbers(int &nvert, int &nsegs, int &npols) const;
-   virtual int           GetNmeshVertices() const { return fNvert; }
-   virtual void          InspectShape() const {}
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual void          SavePrimitive(std::ostream &, Option_t *) {}
-   virtual void          SetPoints(double *points) const;
-   virtual void          SetPoints(float *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const {}
-   
-   ClassDef(TGeoTessellated, 1)         // tessellated shape class
+   virtual void GetMeshNumbers(int &nvert, int &nsegs, int &npols) const;
+   virtual int GetNmeshVertices() const { return fNvert; }
+   virtual void InspectShape() const {}
+   virtual TBuffer3D *MakeBuffer3D() const;
+   virtual void SavePrimitive(std::ostream &, Option_t *) {}
+   virtual void SetPoints(double *points) const;
+   virtual void SetPoints(float *points) const;
+   virtual void SetSegsAndPols(TBuffer3D &buff) const;
+   virtual void Sizeof3D() const {}
+
+   ClassDef(TGeoTessellated, 1) // tessellated shape class
 };
 
 #endif

--- a/geom/geom/inc/TGeoTypedefs.h
+++ b/geom/geom/inc/TGeoTypedefs.h
@@ -1,5 +1,5 @@
 // @(#)root/geom:$Id$
-// Author: Andrei Gheata   15/01/2020
+// Author: Andrei Gheata   20/01/2020
 
 /*************************************************************************
  * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
@@ -9,15 +9,12 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-/** \class  TGeoVector3
-\ingroup Geometry_classes
-Simple 3-vector representation
-*/
+/// Typedefs used by the geometry group
+#include <vector>
 
-#include "TGeoVector3.h"
+namespace Tessellated {
 
-std::ostream &operator<<(std::ostream &os, ROOT::Geom::Vertex_t const &vec)
-{
-   os << "{" << vec[0] << ", " << vec[1] << ", " << vec[2] << "}";
-   return os;
-}
+  using Vertex_t    = ROOT::Geom::Vertex_t;
+  using VertexVec_t = std::vector<Vertex_t>;
+
+} // namespace Tessellated

--- a/geom/geom/inc/TGeoVector3.h
+++ b/geom/geom/inc/TGeoVector3.h
@@ -12,6 +12,7 @@
 #ifndef ROOT_TGeoVector3
 #define ROOT_TGeoVector3
 
+#include <Riostream.h>
 #include <TMath.h>
 
 struct TGeoVector3 {
@@ -73,6 +74,9 @@ struct TGeoVector3 {
    double &z() { return fVec[2]; }
    double const &z() const { return fVec[2]; }
  
+   inline void CopyTo(double *dest) const
+   { dest[0] = fVec[0]; dest[1] = fVec[1]; dest[2] = fVec[2]; }
+
    void Set(double const &a, double const &b, double const &c)
    {
       fVec[0] = a;
@@ -153,13 +157,22 @@ struct TGeoVector3 {
    }
 };
 
-/*
-std::ostream &operator<<(std::ostream &os, TGeoVector3 const &vec)
+std::ostream &operator<<(std::ostream &os, TGeoVector3 const &vec);
+
+inline
+bool operator==(TGeoVector3 const &lhs, TGeoVector3 const &rhs)
 {
-   os << "(" << vec[0] << ", " << vec[1] << ", " << vec[2] << ")";
-   return os;
+  constexpr double kTolerance = 1.e-10;
+  return TMath::Abs(lhs[0] - rhs[0]) < kTolerance &&
+         TMath::Abs(lhs[1] - rhs[1]) < kTolerance &&
+         TMath::Abs(lhs[2] - rhs[2]) < kTolerance;
 }
-*/
+
+inline
+bool operator!=(TGeoVector3 const &lhs, TGeoVector3 const &rhs)
+{
+  return !(lhs == rhs);
+}
 
 #define TGEOVECTOR3_BINARY_OP(OPERATOR, INPLACE)                      \
 inline TGeoVector3 operator OPERATOR(const TGeoVector3 &lhs,          \

--- a/geom/geom/inc/TGeoVector3.h
+++ b/geom/geom/inc/TGeoVector3.h
@@ -21,11 +21,11 @@ namespace Geom {
 struct Vertex_t {
    double fVec[3] = {0.};
 
-   Vertex_t(const double x, const double y, const double z)
+   Vertex_t(const double a, const double b, const double c)
    {
-      fVec[0] = x;
-      fVec[1] = y;
-      fVec[2] = z;
+      fVec[0] = a;
+      fVec[1] = b;
+      fVec[2] = c;
    }
 
    Vertex_t(const double a = 0.)
@@ -35,32 +35,25 @@ struct Vertex_t {
       fVec[2] = a;
    }
 
-   Vertex_t(Vertex_t const &other)
-   {
-      fVec[0] = other[0];
-      fVec[1] = other[1];
-      fVec[2] = other[2];
-   }
-
    double &operator[](const int index) { return fVec[index]; }
    double const &operator[](const int index) const { return fVec[index]; }
 
    // Inplace binary operators
 
-#define Vertex_t_INPLACE_BINARY_OP(OPERATOR)                    \
+#define Vertex_t_INPLACE_BINARY_OP(OPERATOR)                 \
    inline Vertex_t &operator OPERATOR(const Vertex_t &other) \
-   {                                                               \
-      fVec[0] OPERATOR other.fVec[0];                              \
-      fVec[1] OPERATOR other.fVec[1];                              \
-      fVec[2] OPERATOR other.fVec[2];                              \
-      return *this;                                                \
-   }                                                               \
-   inline Vertex_t &operator OPERATOR(const double &scalar)     \
-   {                                                               \
-      fVec[0] OPERATOR scalar;                                     \
-      fVec[1] OPERATOR scalar;                                     \
-      fVec[2] OPERATOR scalar;                                     \
-      return *this;                                                \
+   {                                                         \
+      fVec[0] OPERATOR other.fVec[0];                        \
+      fVec[1] OPERATOR other.fVec[1];                        \
+      fVec[2] OPERATOR other.fVec[2];                        \
+      return *this;                                          \
+   }                                                         \
+   inline Vertex_t &operator OPERATOR(const double &scalar)  \
+   {                                                         \
+      fVec[0] OPERATOR scalar;                               \
+      fVec[1] OPERATOR scalar;                               \
+      fVec[2] OPERATOR scalar;                               \
+      return *this;                                          \
    }
    Vertex_t_INPLACE_BINARY_OP(+=)
    Vertex_t_INPLACE_BINARY_OP(-=)
@@ -172,24 +165,24 @@ inline bool operator!=(Vertex_t const &lhs, Vertex_t const &rhs)
    return !(lhs == rhs);
 }
 
-#define Vertex_t_BINARY_OP(OPERATOR, INPLACE)                                        \
+#define Vertex_t_BINARY_OP(OPERATOR, INPLACE)                                  \
    inline Vertex_t operator OPERATOR(const Vertex_t &lhs, const Vertex_t &rhs) \
-   {                                                                                    \
-      Vertex_t result(lhs);                                                          \
-      result INPLACE rhs;                                                               \
-      return result;                                                                    \
-   }                                                                                    \
-   inline Vertex_t operator OPERATOR(Vertex_t const &lhs, const double rhs)       \
-   {                                                                                    \
-      Vertex_t result(lhs);                                                          \
-      result INPLACE rhs;                                                               \
-      return result;                                                                    \
-   }                                                                                    \
-   inline Vertex_t operator OPERATOR(const double lhs, Vertex_t const &rhs)       \
-   {                                                                                    \
-      Vertex_t result(lhs);                                                          \
-      result INPLACE rhs;                                                               \
-      return result;                                                                    \
+   {                                                                           \
+      Vertex_t result(lhs);                                                    \
+      result INPLACE rhs;                                                      \
+      return result;                                                           \
+   }                                                                           \
+   inline Vertex_t operator OPERATOR(Vertex_t const &lhs, const double rhs)    \
+   {                                                                           \
+      Vertex_t result(lhs);                                                    \
+      result INPLACE rhs;                                                      \
+      return result;                                                           \
+   }                                                                           \
+   inline Vertex_t operator OPERATOR(const double lhs, Vertex_t const &rhs)    \
+   {                                                                           \
+      Vertex_t result(lhs);                                                    \
+      result INPLACE rhs;                                                      \
+      return result;                                                           \
    }
 Vertex_t_BINARY_OP(+, +=)
 Vertex_t_BINARY_OP(-, -=)

--- a/geom/geom/inc/TGeoVector3.h
+++ b/geom/geom/inc/TGeoVector3.h
@@ -1,0 +1,192 @@
+// @(#)root/geom:$Id$
+// Author: Andrei Gheata   20/12/19
+
+/*************************************************************************
+ * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGeoVector3
+#define ROOT_TGeoVector3
+
+#include <TMath.h>
+
+struct TGeoVector3 {
+   double fVec[3] = {0.};
+ 
+   TGeoVector3(const double x, const double y, const double z)
+   {
+      fVec[0] = x;
+      fVec[1] = y;
+      fVec[2] = z;
+   }
+
+   TGeoVector3(const double a = 0.)
+   {
+      fVec[0] = a;
+      fVec[1] = a;
+      fVec[2] = a;
+   }
+
+   TGeoVector3(TGeoVector3 const &other)
+   {
+      fVec[0] = other[0];
+      fVec[1] = other[1];
+      fVec[2] = other[2];
+   }
+  
+   double &operator[](const int index) { return fVec[index]; }
+   double const &operator[](const int index) const { return fVec[index]; }
+
+   // Inplace binary operators
+
+#define TGEOVECTOR3_INPLACE_BINARY_OP(OPERATOR)                       \
+   inline TGeoVector3 &operator OPERATOR(const TGeoVector3 &other)    \
+   {                                                                  \
+      fVec[0] OPERATOR other.fVec[0];                                 \
+      fVec[1] OPERATOR other.fVec[1];                                 \
+      fVec[2] OPERATOR other.fVec[2];                                 \
+      return *this;                                                   \
+   }                                                                  \
+   inline TGeoVector3 &operator OPERATOR(const double &scalar)        \
+   {                                                                  \
+      fVec[0] OPERATOR scalar;                                        \
+      fVec[1] OPERATOR scalar;                                        \
+      fVec[2] OPERATOR scalar;                                        \
+      return *this;                                                   \
+   }
+   TGEOVECTOR3_INPLACE_BINARY_OP(+=)
+   TGEOVECTOR3_INPLACE_BINARY_OP(-=)
+   TGEOVECTOR3_INPLACE_BINARY_OP(*=)
+   TGEOVECTOR3_INPLACE_BINARY_OP(/=)
+#undef TGEOVECTOR3_INPLACE_BINARY_OP
+
+   double &x() { return fVec[0]; }
+   double const &x() const { return fVec[0]; }
+
+   double &y() { return fVec[1]; }
+   double const &y() const { return fVec[1]; }
+
+   double &z() { return fVec[2]; }
+   double const &z() const { return fVec[2]; }
+ 
+   void Set(double const &a, double const &b, double const &c)
+   {
+      fVec[0] = a;
+      fVec[1] = b;
+      fVec[2] = c;
+   }
+
+   void Set(const double a) { Set(a, a, a); }
+
+
+   /// \Return the length squared perpendicular to z direction
+   double Perp2() const { return fVec[0] * fVec[0] + fVec[1] * fVec[1]; }
+
+   /// \Return the length perpendicular to z direction
+   double Perp() const { return TMath::Sqrt(Perp2()); }
+
+   /// The dot product of two vector objects
+   static double Dot(TGeoVector3 const &left, TGeoVector3 const &right)
+   {
+      return left[0] * right[0] + left[1] * right[1] + left[2] * right[2];
+   }
+
+   /// The dot product of two vector
+   double Dot(TGeoVector3 const &right) const { return Dot(*this, right); }
+
+   /// \return Squared magnitude of the vector.
+   double Mag2() const { return Dot(*this, *this); }
+
+   /// \return Magnitude of the vector.
+   double Mag() const { return TMath::Sqrt(Mag2()); }
+
+   double Length() const { return Mag(); }
+
+   double Length2() const { return Mag2(); }
+
+   /// Normalizes the vector by dividing each entry by the length.
+   void Normalize() { *this *= (1. / Length()); }
+
+   //TGeoVector3 Normalized() const { return TGeoVector3(*this) * (1. / Length()); }
+
+   // checks if vector is normalized
+   bool IsNormalized() const
+   {
+      double norm = Mag2();
+      constexpr double tolerance = 1.e-10;
+      return 1. - tolerance < norm && norm < 1 + tolerance;
+   }
+
+   /// \return Azimuthal angle between -pi and pi.
+   double Phi() const { return TMath::ATan2(fVec[1], fVec[0]); }
+
+   /// \return Polar angle between 0 and pi.
+   double Theta() const { return TMath::ACos(fVec[2] / Mag()); }
+
+   /// The cross (vector) product of two Vector3D<T> objects
+   static TGeoVector3 Cross(TGeoVector3 const &left, TGeoVector3 const &right)
+   {
+      return TGeoVector3(left[1] * right[2] - left[2] * right[1], left[2] * right[0] - left[0] * right[2],
+                         left[0] * right[1] - left[1] * right[0]);
+   }
+
+   TGeoVector3 Abs() const
+   {
+      return TGeoVector3(TMath::Abs(fVec[0]), TMath::Abs(fVec[1]), TMath::Abs(fVec[2]));
+   }
+
+   double Min() const { return TMath::Min(TMath::Min(fVec[0], fVec[1]) , fVec[2]); }
+
+   double Max() const { return TMath::Max(TMath::Max(fVec[0], fVec[1]) , fVec[2]); }
+
+   TGeoVector3 Unit() const
+   {
+      constexpr double kMinimum = std::numeric_limits<double>::min();
+      const double mag2 = Mag2();
+      TGeoVector3 output(*this);
+      output /= TMath::Sqrt(mag2 + kMinimum);
+      return output;
+   }
+};
+
+/*
+std::ostream &operator<<(std::ostream &os, TGeoVector3 const &vec)
+{
+   os << "(" << vec[0] << ", " << vec[1] << ", " << vec[2] << ")";
+   return os;
+}
+*/
+
+#define TGEOVECTOR3_BINARY_OP(OPERATOR, INPLACE)                      \
+inline TGeoVector3 operator OPERATOR(const TGeoVector3 &lhs,          \
+                                     const TGeoVector3 &rhs)          \
+{                                                                     \
+   TGeoVector3 result(lhs);                                           \
+   result INPLACE rhs;                                                \
+   return result;                                                     \
+}                                                                     \
+inline TGeoVector3 operator OPERATOR(TGeoVector3 const &lhs,          \
+                                     const double rhs)                \
+{                                                                     \
+   TGeoVector3 result(lhs);                                           \
+   result INPLACE rhs;                                                \
+   return result;                                                     \
+}                                                                     \
+inline TGeoVector3 operator OPERATOR(const double lhs,                \
+                                     TGeoVector3 const &rhs)          \
+{                                                                     \
+   TGeoVector3 result(lhs);                                           \
+   result INPLACE rhs;                                                \
+   return result;                                                     \
+}
+TGEOVECTOR3_BINARY_OP(+, +=)
+TGEOVECTOR3_BINARY_OP(-, -=)
+TGEOVECTOR3_BINARY_OP(*, *=)
+TGEOVECTOR3_BINARY_OP(/, /=)
+#undef TGEOVECTOR3_BINARY_OP
+
+#endif

--- a/geom/geom/inc/TGeoVector3.h
+++ b/geom/geom/inc/TGeoVector3.h
@@ -9,61 +9,64 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_TGeoVector3
-#define ROOT_TGeoVector3
+#ifndef ROOT_Vertex_t
+#define ROOT_Vertex_t
 
 #include <Riostream.h>
 #include <TMath.h>
 
-struct TGeoVector3 {
+namespace ROOT {
+namespace Geom {
+
+struct Vertex_t {
    double fVec[3] = {0.};
- 
-   TGeoVector3(const double x, const double y, const double z)
+
+   Vertex_t(const double x, const double y, const double z)
    {
       fVec[0] = x;
       fVec[1] = y;
       fVec[2] = z;
    }
 
-   TGeoVector3(const double a = 0.)
+   Vertex_t(const double a = 0.)
    {
       fVec[0] = a;
       fVec[1] = a;
       fVec[2] = a;
    }
 
-   TGeoVector3(TGeoVector3 const &other)
+   Vertex_t(Vertex_t const &other)
    {
       fVec[0] = other[0];
       fVec[1] = other[1];
       fVec[2] = other[2];
    }
-  
+
    double &operator[](const int index) { return fVec[index]; }
    double const &operator[](const int index) const { return fVec[index]; }
 
    // Inplace binary operators
 
-#define TGEOVECTOR3_INPLACE_BINARY_OP(OPERATOR)                       \
-   inline TGeoVector3 &operator OPERATOR(const TGeoVector3 &other)    \
-   {                                                                  \
-      fVec[0] OPERATOR other.fVec[0];                                 \
-      fVec[1] OPERATOR other.fVec[1];                                 \
-      fVec[2] OPERATOR other.fVec[2];                                 \
-      return *this;                                                   \
-   }                                                                  \
-   inline TGeoVector3 &operator OPERATOR(const double &scalar)        \
-   {                                                                  \
-      fVec[0] OPERATOR scalar;                                        \
-      fVec[1] OPERATOR scalar;                                        \
-      fVec[2] OPERATOR scalar;                                        \
-      return *this;                                                   \
+#define Vertex_t_INPLACE_BINARY_OP(OPERATOR)                    \
+   inline Vertex_t &operator OPERATOR(const Vertex_t &other) \
+   {                                                               \
+      fVec[0] OPERATOR other.fVec[0];                              \
+      fVec[1] OPERATOR other.fVec[1];                              \
+      fVec[2] OPERATOR other.fVec[2];                              \
+      return *this;                                                \
+   }                                                               \
+   inline Vertex_t &operator OPERATOR(const double &scalar)     \
+   {                                                               \
+      fVec[0] OPERATOR scalar;                                     \
+      fVec[1] OPERATOR scalar;                                     \
+      fVec[2] OPERATOR scalar;                                     \
+      return *this;                                                \
    }
-   TGEOVECTOR3_INPLACE_BINARY_OP(+=)
-   TGEOVECTOR3_INPLACE_BINARY_OP(-=)
-   TGEOVECTOR3_INPLACE_BINARY_OP(*=)
-   TGEOVECTOR3_INPLACE_BINARY_OP(/=)
-#undef TGEOVECTOR3_INPLACE_BINARY_OP
+   Vertex_t_INPLACE_BINARY_OP(+=)
+   Vertex_t_INPLACE_BINARY_OP(-=)
+   Vertex_t_INPLACE_BINARY_OP(*=)
+   Vertex_t_INPLACE_BINARY_OP(/=)
+#undef Vertex_t_INPLACE_BINARY_OP
 
    double &x() { return fVec[0]; }
    double const &x() const { return fVec[0]; }
@@ -73,9 +76,13 @@ struct TGeoVector3 {
 
    double &z() { return fVec[2]; }
    double const &z() const { return fVec[2]; }
- 
+
    inline void CopyTo(double *dest) const
-   { dest[0] = fVec[0]; dest[1] = fVec[1]; dest[2] = fVec[2]; }
+   {
+      dest[0] = fVec[0];
+      dest[1] = fVec[1];
+      dest[2] = fVec[2];
+   }
 
    void Set(double const &a, double const &b, double const &c)
    {
@@ -86,7 +93,6 @@ struct TGeoVector3 {
 
    void Set(const double a) { Set(a, a, a); }
 
-
    /// \Return the length squared perpendicular to z direction
    double Perp2() const { return fVec[0] * fVec[0] + fVec[1] * fVec[1]; }
 
@@ -94,13 +100,13 @@ struct TGeoVector3 {
    double Perp() const { return TMath::Sqrt(Perp2()); }
 
    /// The dot product of two vector objects
-   static double Dot(TGeoVector3 const &left, TGeoVector3 const &right)
+   static double Dot(Vertex_t const &left, Vertex_t const &right)
    {
       return left[0] * right[0] + left[1] * right[1] + left[2] * right[2];
    }
 
    /// The dot product of two vector
-   double Dot(TGeoVector3 const &right) const { return Dot(*this, right); }
+   double Dot(Vertex_t const &right) const { return Dot(*this, right); }
 
    /// \return Squared magnitude of the vector.
    double Mag2() const { return Dot(*this, *this); }
@@ -115,7 +121,7 @@ struct TGeoVector3 {
    /// Normalizes the vector by dividing each entry by the length.
    void Normalize() { *this *= (1. / Length()); }
 
-   //TGeoVector3 Normalized() const { return TGeoVector3(*this) * (1. / Length()); }
+   // Vertex_t Normalized() const { return Vertex_t(*this) * (1. / Length()); }
 
    // checks if vector is normalized
    bool IsNormalized() const
@@ -132,74 +138,68 @@ struct TGeoVector3 {
    double Theta() const { return TMath::ACos(fVec[2] / Mag()); }
 
    /// The cross (vector) product of two Vector3D<T> objects
-   static TGeoVector3 Cross(TGeoVector3 const &left, TGeoVector3 const &right)
+   static Vertex_t Cross(Vertex_t const &left, Vertex_t const &right)
    {
-      return TGeoVector3(left[1] * right[2] - left[2] * right[1], left[2] * right[0] - left[0] * right[2],
+      return Vertex_t(left[1] * right[2] - left[2] * right[1], left[2] * right[0] - left[0] * right[2],
                          left[0] * right[1] - left[1] * right[0]);
    }
 
-   TGeoVector3 Abs() const
-   {
-      return TGeoVector3(TMath::Abs(fVec[0]), TMath::Abs(fVec[1]), TMath::Abs(fVec[2]));
-   }
+   Vertex_t Abs() const { return Vertex_t(TMath::Abs(fVec[0]), TMath::Abs(fVec[1]), TMath::Abs(fVec[2])); }
 
-   double Min() const { return TMath::Min(TMath::Min(fVec[0], fVec[1]) , fVec[2]); }
+   double Min() const { return TMath::Min(TMath::Min(fVec[0], fVec[1]), fVec[2]); }
 
-   double Max() const { return TMath::Max(TMath::Max(fVec[0], fVec[1]) , fVec[2]); }
+   double Max() const { return TMath::Max(TMath::Max(fVec[0], fVec[1]), fVec[2]); }
 
-   TGeoVector3 Unit() const
+   Vertex_t Unit() const
    {
       constexpr double kMinimum = std::numeric_limits<double>::min();
       const double mag2 = Mag2();
-      TGeoVector3 output(*this);
+      Vertex_t output(*this);
       output /= TMath::Sqrt(mag2 + kMinimum);
       return output;
    }
 };
 
-std::ostream &operator<<(std::ostream &os, TGeoVector3 const &vec);
-
-inline
-bool operator==(TGeoVector3 const &lhs, TGeoVector3 const &rhs)
+inline bool operator==(Vertex_t const &lhs, Vertex_t const &rhs)
 {
-  constexpr double kTolerance = 1.e-10;
-  return TMath::Abs(lhs[0] - rhs[0]) < kTolerance &&
-         TMath::Abs(lhs[1] - rhs[1]) < kTolerance &&
-         TMath::Abs(lhs[2] - rhs[2]) < kTolerance;
+   constexpr double kTolerance = 1.e-10;
+   return TMath::Abs(lhs[0] - rhs[0]) < kTolerance && TMath::Abs(lhs[1] - rhs[1]) < kTolerance &&
+          TMath::Abs(lhs[2] - rhs[2]) < kTolerance;
 }
 
-inline
-bool operator!=(TGeoVector3 const &lhs, TGeoVector3 const &rhs)
+inline bool operator!=(Vertex_t const &lhs, Vertex_t const &rhs)
 {
-  return !(lhs == rhs);
+   return !(lhs == rhs);
 }
 
-#define TGEOVECTOR3_BINARY_OP(OPERATOR, INPLACE)                      \
-inline TGeoVector3 operator OPERATOR(const TGeoVector3 &lhs,          \
-                                     const TGeoVector3 &rhs)          \
-{                                                                     \
-   TGeoVector3 result(lhs);                                           \
-   result INPLACE rhs;                                                \
-   return result;                                                     \
-}                                                                     \
-inline TGeoVector3 operator OPERATOR(TGeoVector3 const &lhs,          \
-                                     const double rhs)                \
-{                                                                     \
-   TGeoVector3 result(lhs);                                           \
-   result INPLACE rhs;                                                \
-   return result;                                                     \
-}                                                                     \
-inline TGeoVector3 operator OPERATOR(const double lhs,                \
-                                     TGeoVector3 const &rhs)          \
-{                                                                     \
-   TGeoVector3 result(lhs);                                           \
-   result INPLACE rhs;                                                \
-   return result;                                                     \
-}
-TGEOVECTOR3_BINARY_OP(+, +=)
-TGEOVECTOR3_BINARY_OP(-, -=)
-TGEOVECTOR3_BINARY_OP(*, *=)
-TGEOVECTOR3_BINARY_OP(/, /=)
-#undef TGEOVECTOR3_BINARY_OP
+#define Vertex_t_BINARY_OP(OPERATOR, INPLACE)                                        \
+   inline Vertex_t operator OPERATOR(const Vertex_t &lhs, const Vertex_t &rhs) \
+   {                                                                                    \
+      Vertex_t result(lhs);                                                          \
+      result INPLACE rhs;                                                               \
+      return result;                                                                    \
+   }                                                                                    \
+   inline Vertex_t operator OPERATOR(Vertex_t const &lhs, const double rhs)       \
+   {                                                                                    \
+      Vertex_t result(lhs);                                                          \
+      result INPLACE rhs;                                                               \
+      return result;                                                                    \
+   }                                                                                    \
+   inline Vertex_t operator OPERATOR(const double lhs, Vertex_t const &rhs)       \
+   {                                                                                    \
+      Vertex_t result(lhs);                                                          \
+      result INPLACE rhs;                                                               \
+      return result;                                                                    \
+   }
+Vertex_t_BINARY_OP(+, +=)
+Vertex_t_BINARY_OP(-, -=)
+Vertex_t_BINARY_OP(*, *=)
+Vertex_t_BINARY_OP(/, /=)
+#undef Vertex_t_BINARY_OP
+
+} // namespace Geom
+} // namespace ROOT
+
+std::ostream &operator<<(std::ostream &os, ROOT::Geom::Vertex_t const &vec);
 
 #endif

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -1,0 +1,350 @@
+// @(#)root/geom:$Id$// Author: Andrei Gheata   24/10/01
+
+// Contains() and DistFromOutside/Out() implemented by Mihaela Gheata
+
+/*************************************************************************
+ * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/** \class TGeoTessellated
+\ingroup Geometry_classes
+
+Tessellated solid class. It is composed by a set of planar faces having triangular or
+quadrilateral shape. The class does not provide navigation functionality, it just wraps the data
+for the composing faces.
+*/
+
+#include "Riostream.h"
+
+#include "TGeoManager.h"
+#include "TGeoMatrix.h"
+#include "TGeoVolume.h"
+#include "TVirtualGeoPainter.h"
+#include "TGeoTessellated.h"
+#include "TVirtualPad.h"
+#include "TBuffer3D.h"
+#include "TBuffer3DTypes.h"
+#include "TMath.h"
+#include "TRandom.h"
+
+ClassImp(TGeoTessellated);
+
+
+/*
+bool TGeoFacet::Check()
+{
+   Int_t nvert = fNvert;
+   for (Int_t i = 0; i < fNvert; ++i) {
+      const TGeoVector3 vi(fVertices[(i + 1) % fNvert] - fVertices[i];
+      if (vi.Mag2() < kTolerance) {
+        nvert--;
+      }
+    }
+
+    if (nvert < 3) {
+      std::cout << "Tile degenerated: Length of sides of facet are too small." << std::endl;
+      return false;
+    }
+
+    // Compute normal using non-zero segments
+
+    bool degenerated = true;
+    for (size_t i = 0; i < NVERT - 1; ++i) {
+      Vector3D<T> e1 = fVertices[i + 1] - fVertices[i];
+      if (e1.Mag2() < kTolerance) continue;
+      for (size_t j = i + 1; j < NVERT; ++j) {
+        Vector3D<T> e2 = fVertices[(j + 1) % NVERT] - fVertices[j];
+        if (e2.Mag2() < kTolerance) continue;
+        fNormal = e1.Cross(e2);
+        // e1 and e2 may be colinear
+        if (fNormal.Mag2() < kTolerance) continue;
+        fNormal.Normalize();
+        degenerated = false;
+        break;
+      }
+      if (!degenerated) break;
+    }
+
+    if (degenerated) {
+      std::cout << "Tile degenerated 2: Length of sides of facet are too small." << std::endl;
+      return false;
+    }
+
+    // Compute side vectors
+    for (size_t i = 0; i < NVERT; ++i) {
+      Vector3D<T> e1 = fVertices[(i + 1) % NVERT] - fVertices[i];
+      if (e1.Mag2() < kTolerance) continue;
+      fSideVectors[i] = fNormal.Cross(e1).Normalized();
+      fDistance       = -fNormal.Dot(fVertices[i]);
+      for (size_t j = i + 1; j < i + NVERT; ++j) {
+        Vector3D<T> e2 = fVertices[(j + 1) % NVERT] - fVertices[j % NVERT];
+        if (e2.Mag2() < kTolerance)
+          fSideVectors[j % NVERT] = fSideVectors[(j - 1) % NVERT];
+        else
+          fSideVectors[j % NVERT] = fNormal.Cross(e2).Normalized();
+      }
+      break;
+    }
+
+    // Compute surface area
+    fSurfaceArea = 0.;
+    for (size_t i = 1; i < NVERT - 1; ++i) {
+      Vector3D<T> e1 = fVertices[i] - fVertices[0];
+      Vector3D<T> e2 = fVertices[i + 1] - fVertices[0];
+      fSurfaceArea += 0.5 * (e1.Cross(e2)).Mag();
+    }
+    assert(fSurfaceArea > kTolerance * kTolerance);
+
+    // Center of the tile
+    for (size_t i = 0; i < NVERT; ++i)
+      fCenter += fVertices[i];
+    fCenter /= NVERT;
+    return true;
+  }
+*/
+////////////////////////////////////////////////////////////////////////////////
+/// Default constructor
+
+TGeoTessellated::TGeoTessellated(const char *name, Int_t nfacets) : TGeoBBox(name, 0, 0, 0)
+{
+   fNfacets = nfacets;
+   fFacets.reserve(nfacets);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Copy constructor
+
+TGeoTessellated::TGeoTessellated(const TGeoTessellated &other) : TGeoBBox(other)
+{
+   fNvert   = other.fNvert;
+   fNfacets = other.fNfacets;
+   fFacets  = other.fFacets;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Assignment operator
+
+TGeoTessellated &TGeoTessellated::operator=(const TGeoTessellated &other)
+{
+   if (&other != this) {
+      TGeoBBox::operator=(other);
+      fNvert   = other.fNvert;
+      fNfacets = other.fNfacets;
+      fFacets  = other.fFacets;
+   }
+   return *this;
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Adding a triangular facet from vertex positions in absolute coordinates
+
+void TGeoTessellated::AddFacet(double x0, double y0, double z0,
+                               double x1, double y1, double z1,
+                               double x2, double y2, double z2)
+{
+   if (GetNfacets() == fNfacets) {
+      Error("AddFacet", "Already defined %d facets, cannot add more", fNfacets);
+      return;
+   }
+   fNvert += 3;
+   fFacets.emplace_back(x0, y0, z0, x1, y1, z1, x2, y2, z2);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Adding a quadrilateral facet from vertex positions in absolute coordinates
+
+void TGeoTessellated::AddFacet(double x0, double y0, double z0,
+                               double x1, double y1, double z1,
+                               double x2, double y2, double z2,
+                               double x3, double y3, double z3)
+{
+   if (GetNfacets() == fNfacets) {
+      Error("AddFacet", "Already defined %d facets, cannot add more", fNfacets);
+      return;
+   }
+   fNvert += 4;
+   fFacets.emplace_back(x0, y0, z0, x1, y1, z1, x2, y2, z2, x3, y3, z3);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute bounding box
+
+void TGeoTessellated::ComputeBBox()
+{
+   const double kBig = TGeoShape::Big();
+   double vmin[3] = { kBig, kBig, kBig };
+   double vmax[3] = { -kBig, -kBig, -kBig };
+   for (const auto &facet : fFacets) {
+      for (int i = 0; i < facet.fNvert; ++i) {
+         for (int j = 0; j < 3; ++j) {
+            vmin[j] = TMath::Min(vmin[j], facet.fVertices[i].operator[](j));
+            vmax[j] = TMath::Max(vmax[j], facet.fVertices[i].operator[](j));
+         }
+      }
+   }
+   fDX = 0.5 * (vmax[0] - vmin[0]);
+   fDY = 0.5 * (vmax[1] - vmin[1]);
+   fDZ = 0.5 * (vmax[2] - vmin[2]);
+   for (int i = 0; i < 3; ++i)
+      fOrigin[i] = 0.5 * (vmax[i] + vmin[i]);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns numbers of vertices, segments and polygons composing the shape mesh.
+
+void TGeoTessellated::GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const
+{
+   nvert = fNvert;
+   nsegs = fNvert;
+   npols = GetNfacets();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Creates a TBuffer3D describing *this* shape.
+/// Coordinates are in local reference frame.
+
+TBuffer3D *TGeoTessellated::MakeBuffer3D() const
+{
+   TBuffer3D* buff = new TBuffer3D(TBuffer3DTypes::kGeneric, 8, 24, 12, 36, 6, 36);
+   if (buff)
+   {
+      SetPoints(buff->fPnts);
+      SetSegsAndPols(*buff);
+   }
+
+   return buff;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Fills TBuffer3D structure for segments and polygons.
+
+void TGeoTessellated::SetSegsAndPols(TBuffer3D &buff) const
+{
+   Int_t c = GetBasicColor();
+
+   buff.fSegs[ 0] = c   ; buff.fSegs[ 1] = 0   ; buff.fSegs[ 2] = 1   ;
+   buff.fSegs[ 3] = c+1 ; buff.fSegs[ 4] = 1   ; buff.fSegs[ 5] = 2   ;
+   buff.fSegs[ 6] = c+1 ; buff.fSegs[ 7] = 2   ; buff.fSegs[ 8] = 3   ;
+   buff.fSegs[ 9] = c   ; buff.fSegs[10] = 3   ; buff.fSegs[11] = 0   ;
+   buff.fSegs[12] = c+2 ; buff.fSegs[13] = 4   ; buff.fSegs[14] = 5   ;
+   buff.fSegs[15] = c+2 ; buff.fSegs[16] = 5   ; buff.fSegs[17] = 6   ;
+   buff.fSegs[18] = c+3 ; buff.fSegs[19] = 6   ; buff.fSegs[20] = 7   ;
+   buff.fSegs[21] = c+3 ; buff.fSegs[22] = 7   ; buff.fSegs[23] = 4   ;
+   buff.fSegs[24] = c   ; buff.fSegs[25] = 0   ; buff.fSegs[26] = 4   ;
+   buff.fSegs[27] = c+2 ; buff.fSegs[28] = 1   ; buff.fSegs[29] = 5   ;
+   buff.fSegs[30] = c+1 ; buff.fSegs[31] = 2   ; buff.fSegs[32] = 6   ;
+   buff.fSegs[33] = c+3 ; buff.fSegs[34] = 3   ; buff.fSegs[35] = 7   ;
+
+   buff.fPols[ 0] = c   ; buff.fPols[ 1] = 4   ;  buff.fPols[ 2] = 0  ;
+   buff.fPols[ 3] = 9   ; buff.fPols[ 4] = 4   ;  buff.fPols[ 5] = 8  ;
+   buff.fPols[ 6] = c+1 ; buff.fPols[ 7] = 4   ;  buff.fPols[ 8] = 1  ;
+   buff.fPols[ 9] = 10  ; buff.fPols[10] = 5   ;  buff.fPols[11] = 9  ;
+   buff.fPols[12] = c   ; buff.fPols[13] = 4   ;  buff.fPols[14] = 2  ;
+   buff.fPols[15] = 11  ; buff.fPols[16] = 6   ;  buff.fPols[17] = 10 ;
+   buff.fPols[18] = c+1 ; buff.fPols[19] = 4   ;  buff.fPols[20] = 3  ;
+   buff.fPols[21] = 8   ; buff.fPols[22] = 7   ;  buff.fPols[23] = 11 ;
+   buff.fPols[24] = c+2 ; buff.fPols[25] = 4   ;  buff.fPols[26] = 0  ;
+   buff.fPols[27] = 3   ; buff.fPols[28] = 2   ;  buff.fPols[29] = 1  ;
+   buff.fPols[30] = c+3 ; buff.fPols[31] = 4   ;  buff.fPols[32] = 4  ;
+   buff.fPols[33] = 5   ; buff.fPols[34] = 6   ;  buff.fPols[35] = 7  ;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Fill tessellated points to an array.
+
+void TGeoTessellated::SetPoints(Double_t *points) const
+{
+   if (!points) return;
+   Double_t xmin,xmax,ymin,ymax,zmin,zmax;
+   xmin = -fDX+fOrigin[0];
+   xmax =  fDX+fOrigin[0];
+   ymin = -fDY+fOrigin[1];
+   ymax =  fDY+fOrigin[1];
+   zmin = -fDZ+fOrigin[2];
+   zmax =  fDZ+fOrigin[2];
+   points[ 0] = xmin; points[ 1] = ymin; points[ 2] = zmin;
+   points[ 3] = xmin; points[ 4] = ymax; points[ 5] = zmin;
+   points[ 6] = xmax; points[ 7] = ymax; points[ 8] = zmin;
+   points[ 9] = xmax; points[10] = ymin; points[11] = zmin;
+   points[12] = xmin; points[13] = ymin; points[14] = zmax;
+   points[15] = xmin; points[16] = ymax; points[17] = zmax;
+   points[18] = xmax; points[19] = ymax; points[20] = zmax;
+   points[21] = xmax; points[22] = ymin; points[23] = zmax;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Fill tessellated points in float.
+
+void TGeoTessellated::SetPoints(Float_t *points) const
+{
+   if (!points) return;
+   Double_t xmin,xmax,ymin,ymax,zmin,zmax;
+   xmin = -fDX+fOrigin[0];
+   xmax =  fDX+fOrigin[0];
+   ymin = -fDY+fOrigin[1];
+   ymax =  fDY+fOrigin[1];
+   zmin = -fDZ+fOrigin[2];
+   zmax =  fDZ+fOrigin[2];
+   points[ 0] = xmin; points[ 1] = ymin; points[ 2] = zmin;
+   points[ 3] = xmin; points[ 4] = ymax; points[ 5] = zmin;
+   points[ 6] = xmax; points[ 7] = ymax; points[ 8] = zmin;
+   points[ 9] = xmax; points[10] = ymin; points[11] = zmin;
+   points[12] = xmin; points[13] = ymin; points[14] = zmax;
+   points[15] = xmin; points[16] = ymax; points[17] = zmax;
+   points[18] = xmax; points[19] = ymax; points[20] = zmax;
+   points[21] = xmax; points[22] = ymin; points[23] = zmax;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Fills a static 3D buffer and returns a reference.
+
+const TBuffer3D & TGeoTessellated::GetBuffer3D(Int_t reqSections, Bool_t localFrame) const
+{
+   static TBuffer3D buffer(TBuffer3DTypes::kGeneric);
+
+   FillBuffer3D(buffer, reqSections, localFrame);
+
+   // TODO: A box itself has has nothing more as already described
+   // by bounding box. How will viewer interpret?
+   if (reqSections & TBuffer3D::kRawSizes) {
+      if (buffer.SetRawSizes(8, 3*8, 12, 3*12, 6, 6*6)) {
+         buffer.SetSectionsValid(TBuffer3D::kRawSizes);
+      }
+   }
+   if ((reqSections & TBuffer3D::kRaw) && buffer.SectionsValid(TBuffer3D::kRawSizes)) {
+      SetPoints(buffer.fPnts);
+      if (!buffer.fLocalFrame) {
+         TransformPoints(buffer.fPnts, buffer.NbPnts());
+      }
+
+      SetSegsAndPols(buffer);
+      buffer.SetSectionsValid(TBuffer3D::kRaw);
+   }
+
+   return buffer;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Fills the supplied buffer, with sections in desired frame
+/// See TBuffer3D.h for explanation of sections, frame etc.
+
+void TGeoTessellated::FillBuffer3D(TBuffer3D & buffer, Int_t reqSections, Bool_t localFrame) const
+{
+   TGeoShape::FillBuffer3D(buffer, reqSections, localFrame);
+
+   if (reqSections & TBuffer3D::kBoundingBox) {
+      Double_t halfLengths[3] = { fDX, fDY, fDZ };
+      buffer.SetAABoundingBox(fOrigin, halfLengths);
+
+      if (!buffer.fLocalFrame) {
+         TransformPoints(buffer.fBBVertex[0], 8);
+      }
+      buffer.SetSectionsValid(TBuffer3D::kBoundingBox);
+   }
+}

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -33,14 +33,15 @@ for the composing faces.
 
 ClassImp(TGeoTessellated)
 
-using Vertex_t = TGeoVector3;
+using Vertex_t = Tessellated::Vertex_t;
 
 std::ostream &operator<<(std::ostream &os, TGeoFacet const &facet)
 {
    os << "{";
    for (int i = 0; i < facet.GetNvert(); ++i) {
       os << facet.GetVertex(i);
-      if (i != facet.GetNvert()-1) os << ", ";
+      if (i != facet.GetNvert() - 1)
+         os << ", ";
    }
    os << "}";
    return os;
@@ -53,12 +54,12 @@ TGeoFacet::TGeoFacet(const TGeoFacet &other) : fVertices(other.fVertices), fNver
       fVertices = new VertexVec_t(*other.fVertices);
 }
 
-const TGeoFacet &TGeoFacet::operator = (const TGeoFacet &other)
+const TGeoFacet &TGeoFacet::operator=(const TGeoFacet &other)
 {
    if (&other != this) {
       fVertices = other.fVertices;
-      fNvert    = other.fNvert;
-      fShared   = other.fShared;
+      fNvert = other.fNvert;
+      fShared = other.fShared;
       if (!fShared)
          fVertices = new VertexVec_t(*other.fVertices);
    }
@@ -73,18 +74,22 @@ Vertex_t TGeoFacet::ComputeNormal(bool &degenerated) const
    Vertex_t normal;
    for (int i = 0; i < fNvert - 1; ++i) {
       Vertex_t e1 = GetVertex(i + 1) - GetVertex(i);
-      if (e1.Mag2() < kTolerance) continue;
+      if (e1.Mag2() < kTolerance)
+         continue;
       for (int j = i + 1; j < fNvert; ++j) {
          Vertex_t e2 = GetVertex((j + 1) % fNvert) - GetVertex(j);
-         if (e2.Mag2() < kTolerance) continue;
+         if (e2.Mag2() < kTolerance)
+            continue;
          normal = Vertex_t::Cross(e1, e2);
          // e1 and e2 may be colinear
-         if (normal.Mag2() < kTolerance) continue;
+         if (normal.Mag2() < kTolerance)
+            continue;
          normal.Normalize();
          degenerated = false;
          break;
       }
-      if (!degenerated) break;
+      if (!degenerated)
+         break;
    }
    return normal;
 }
@@ -150,7 +155,6 @@ bool TGeoFacet::IsNeighbour(const TGeoFacet &other, bool &flip) const
    return neighbour;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 
@@ -165,10 +169,10 @@ TGeoTessellated::TGeoTessellated(const char *name, int nfacets) : TGeoBBox(name,
 
 TGeoTessellated::TGeoTessellated(const TGeoTessellated &other) : TGeoBBox(other)
 {
-   fNvert    = other.fNvert;
-   fNfacets  = other.fNfacets;
+   fNvert = other.fNvert;
+   fNfacets = other.fNfacets;
    fVertices = other.fVertices;
-   fFacets   = other.fFacets;
+   fFacets = other.fFacets;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -178,10 +182,10 @@ TGeoTessellated &TGeoTessellated::operator=(const TGeoTessellated &other)
 {
    if (&other != this) {
       TGeoBBox::operator=(other);
-      fNvert    = other.fNvert;
-      fNfacets  = other.fNfacets;
+      fNvert = other.fNvert;
+      fNfacets = other.fNfacets;
       fVertices = other.fVertices;
-      fFacets   = other.fFacets;
+      fFacets = other.fFacets;
    }
    return *this;
 }
@@ -211,13 +215,13 @@ void TGeoTessellated::AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const V
    vert[2] = pt2;
    // Protect against adding degenerated facets
    for (int i = 0; i < 3; ++i) {
-      if (vert[(i+1)%3] == vert[i]) {
+      if (vert[(i + 1) % 3] == vert[i]) {
          Error("AddFacet", "Triangular facet at index %d degenerated. Not adding.", GetNfacets());
          return;
       }
    }
    fNvert += 3;
-   fNseg  += 3;
+   fNseg += 3;
    fFacets.emplace_back(pt0, pt1, pt2);
    if (GetNfacets() == fNfacets)
       Close();
@@ -239,19 +243,19 @@ void TGeoTessellated::AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const V
    vert[3] = pt3;
    int nvert = 4;
    for (int i = 0; i < 4; ++i) {
-      if (vert[(i+1)%4] == vert[i]) {
+      if (vert[(i + 1) % 4] == vert[i]) {
          if (nvert == 3) {
             Error("AddFacet", "Quadrilateral facet at index %d degenerated. Not adding.", GetNfacets());
             return;
          }
-         for (int j = i+2; j < nvert; ++j)
-            vert[j-1] = vert[j];
+         for (int j = i + 2; j < nvert; ++j)
+            vert[j - 1] = vert[j];
          nvert--;
       }
    }
 
    fNvert += nvert;
-   fNseg  += nvert;
+   fNseg += nvert;
    if (nvert == 3)
       fFacets.emplace_back(vert[0], vert[1], vert[2]);
    else
@@ -279,12 +283,12 @@ void TGeoTessellated::Close()
    invExtent[1] = 0.5 / (fDY + tolerance);
    invExtent[2] = 0.5 / (fDZ + tolerance);
 
-   auto AddVertex = [this](const Vertex_t &vertex)
-   {
+   auto AddVertex = [this](const Vertex_t &vertex) {
       // Check if vertex exists
       int ivert = 0;
       for (const auto &current_vert : fVertices) {
-         if (current_vert == vertex) return ivert;
+         if (current_vert == vertex)
+            return ivert;
          ivert++;
       }
       // Vertex new, just add it
@@ -292,14 +296,14 @@ void TGeoTessellated::Close()
       return ivert;
    };
 
-   auto GetHashIndex = [&, this](const Vertex_t &vertex)
-   {
+   auto GetHashIndex = [&, this](const Vertex_t &vertex) {
       // Get the hash index for a vertex in a 10x10x10 grid in the bounding box
       int index = 0;
       for (int i = 0; i < 3; ++i) {
          int ind = ngrid * (vertex[i] - minExtent[i]) * invExtent[i]; // between [0, ngrid-1]
          assert(ind < (int)ngrid);
-         for (int j = i + 1; j < 3; ++j) ind *= ngrid;
+         for (int j = i + 1; j < 3; ++j)
+            ind *= ngrid;
          index += ind;
       }
       return index;
@@ -335,9 +339,9 @@ void TGeoTessellated::Close()
                }
             }
             if (!isAdded) {
-              fVertices.push_back(vertex);
-              ind[i] = fVertices.size() - 1;
-              grid[hashind].push_back(ind[i]);
+               fVertices.push_back(vertex);
+               ind[i] = fVertices.size() - 1;
+               grid[hashind].push_back(ind[i]);
             }
          }
          facet.SetVertices(&fVertices, ind[0], ind[1], ind[2], ind[3]);
@@ -358,23 +362,28 @@ void TGeoTessellated::Close()
       nn[i] = 0;
       flipped[i] = false;
    }
-   
+
    for (int icrt = 0; icrt < fNfacets; ++icrt) {
       // all neighbours checked?
-      if (nn[icrt] >= fFacets[icrt].GetNvert()) continue;
-      for (int i = icrt+1; i < fNfacets; ++i) {
+      if (nn[icrt] >= fFacets[icrt].GetNvert())
+         continue;
+      for (int i = icrt + 1; i < fNfacets; ++i) {
          bool isneighbour = fFacets[icrt].IsNeighbour(fFacets[i], flipped[i]);
          if (isneighbour) {
-            if (flipped[icrt]) flipped[i] = !flipped[i];
-            if (flipped[i]) hasflipped = true;
+            if (flipped[icrt])
+               flipped[i] = !flipped[i];
+            if (flipped[i])
+               hasflipped = true;
             nn[icrt]++;
             nn[i]++;
-            if (nn[icrt] == fFacets[icrt].GetNvert()) break;
+            if (nn[icrt] == fFacets[icrt].GetNvert())
+               break;
          }
       }
-      if (nn[icrt] < fFacets[icrt].GetNvert()) hasorphans = true;
+      if (nn[icrt] < fFacets[icrt].GetNvert())
+         hasorphans = true;
    }
-   
+
    if (hasorphans) {
       Warning("Check", "Tessellated solid %s has following not fully connected facets:", GetName());
       for (int icrt = 0; icrt < fNfacets; ++icrt) {
@@ -385,11 +394,12 @@ void TGeoTessellated::Close()
    if (hasflipped) {
       Warning("Check", "Tessellated solid %s has following facets with flipped normals:", GetName());
       for (int icrt = 0; icrt < fNfacets; ++icrt) {
-         if (flipped[icrt]) std::cout << icrt << "\n";
+         if (flipped[icrt])
+            std::cout << icrt << "\n";
       }
    }
-   delete [] nn;
-   delete [] flipped;
+   delete[] nn;
+   delete[] flipped;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -398,9 +408,10 @@ void TGeoTessellated::Close()
 void TGeoTessellated::ComputeBBox()
 {
    const double kBig = TGeoShape::Big();
-   if (fVertices.size()) return;
-   double vmin[3] = { kBig, kBig, kBig };
-   double vmax[3] = { -kBig, -kBig, -kBig };
+   if (fVertices.size())
+      return;
+   double vmin[3] = {kBig, kBig, kBig};
+   double vmax[3] = {-kBig, -kBig, -kBig};
    for (const auto &facet : fFacets) {
       for (int i = 0; i < facet.GetNvert(); ++i) {
          for (int j = 0; j < 3; ++j) {
@@ -435,9 +446,8 @@ TBuffer3D *TGeoTessellated::MakeBuffer3D() const
    const int nvert = fNvert;
    const int nsegs = fNseg;
    const int npols = GetNfacets();
-   TBuffer3D* buff = new TBuffer3D(TBuffer3DTypes::kGeneric, nvert, 3*nvert, nsegs, 3*nsegs, npols, 6*npols);
-   if (buff)
-   {
+   TBuffer3D *buff = new TBuffer3D(TBuffer3DTypes::kGeneric, nvert, 3 * nvert, nsegs, 3 * nsegs, npols, 6 * npols);
+   if (buff) {
       SetPoints(buff->fPnts);
       SetSegsAndPols(*buff);
    }
@@ -455,7 +465,7 @@ void TGeoTessellated::SetSegsAndPols(TBuffer3D &buff) const
 
    int indseg = 0; // segment internal data index
    int indpol = 0; // polygon internal data index
-   int sind   = 0; // segment index
+   int sind = 0;   // segment index
    for (const auto &facet : fFacets) {
       auto nvert = facet.GetNvert();
       pols[indpol++] = c;
@@ -501,7 +511,7 @@ void TGeoTessellated::SetPoints(Float_t *points) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Fills a static 3D buffer and returns a reference.
 
-const TBuffer3D & TGeoTessellated::GetBuffer3D(int reqSections, Bool_t localFrame) const
+const TBuffer3D &TGeoTessellated::GetBuffer3D(int reqSections, Bool_t localFrame) const
 {
    static TBuffer3D buffer(TBuffer3DTypes::kGeneric);
 
@@ -512,7 +522,7 @@ const TBuffer3D & TGeoTessellated::GetBuffer3D(int reqSections, Bool_t localFram
    const int npols = GetNfacets();
 
    if (reqSections & TBuffer3D::kRawSizes) {
-      if (buffer.SetRawSizes(nvert, 3*nvert, nsegs, 3*nsegs, npols, 6*npols)) {
+      if (buffer.SetRawSizes(nvert, 3 * nvert, nsegs, 3 * nsegs, npols, 6 * npols)) {
          buffer.SetSectionsValid(TBuffer3D::kRawSizes);
       }
    }
@@ -533,12 +543,12 @@ const TBuffer3D & TGeoTessellated::GetBuffer3D(int reqSections, Bool_t localFram
 /// Fills the supplied buffer, with sections in desired frame
 /// See TBuffer3D.h for explanation of sections, frame etc.
 
-void TGeoTessellated::FillBuffer3D(TBuffer3D & buffer, int reqSections, Bool_t localFrame) const
+void TGeoTessellated::FillBuffer3D(TBuffer3D &buffer, int reqSections, Bool_t localFrame) const
 {
    TGeoShape::FillBuffer3D(buffer, reqSections, localFrame);
 
    if (reqSections & TBuffer3D::kBoundingBox) {
-      double halfLengths[3] = { fDX, fDY, fDZ };
+      double halfLengths[3] = {fDX, fDY, fDZ};
       buffer.SetAABoundingBox(fOrigin, halfLengths);
 
       if (!buffer.fLocalFrame) {

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -33,10 +33,12 @@ for the composing faces.
 
 ClassImp(TGeoTessellated)
 
+using Vertex_t = TGeoVector3;
+
 std::ostream &operator<<(std::ostream &os, TGeoFacet const &facet)
 {
    os << "{";
-   for (Int_t i = 0; i < facet.GetNvert(); ++i) {
+   for (int i = 0; i < facet.GetNvert(); ++i) {
       os << facet.GetVertex(i);
       if (i != facet.GetNvert()-1) os << ", ";
    }
@@ -46,7 +48,7 @@ std::ostream &operator<<(std::ostream &os, TGeoFacet const &facet)
 
 TGeoFacet::TGeoFacet(const TGeoFacet &other) : fVertices(other.fVertices), fNvert(other.fNvert), fShared(other.fShared)
 {
-   memcpy(fIvert, other.fIvert, 4 * sizeof(Int_t));
+   memcpy(fIvert, other.fIvert, 4 * sizeof(int));
    if (!fShared)
       fVertices = new VertexVec_t(*other.fVertices);
 }
@@ -63,19 +65,19 @@ const TGeoFacet &TGeoFacet::operator = (const TGeoFacet &other)
    return *this;
 }
 
-TGeoVector3 TGeoFacet::ComputeNormal(bool &degenerated) const
+Vertex_t TGeoFacet::ComputeNormal(bool &degenerated) const
 {
    // Compute normal using non-zero segments
-   constexpr Double_t kTolerance = 1.e-10;
+   constexpr double kTolerance = 1.e-10;
    degenerated = true;
-   TGeoVector3 normal;
-   for (Int_t i = 0; i < fNvert - 1; ++i) {
-      TGeoVector3 e1 = GetVertex(i + 1) - GetVertex(i);
+   Vertex_t normal;
+   for (int i = 0; i < fNvert - 1; ++i) {
+      Vertex_t e1 = GetVertex(i + 1) - GetVertex(i);
       if (e1.Mag2() < kTolerance) continue;
-      for (Int_t j = i + 1; j < fNvert; ++j) {
-         TGeoVector3 e2 = GetVertex((j + 1) % fNvert) - GetVertex(j);
+      for (int j = i + 1; j < fNvert; ++j) {
+         Vertex_t e2 = GetVertex((j + 1) % fNvert) - GetVertex(j);
          if (e2.Mag2() < kTolerance) continue;
-         normal = TGeoVector3::Cross(e1, e2);
+         normal = Vertex_t::Cross(e1, e2);
          // e1 and e2 may be colinear
          if (normal.Mag2() < kTolerance) continue;
          normal.Normalize();
@@ -89,20 +91,7 @@ TGeoVector3 TGeoFacet::ComputeNormal(bool &degenerated) const
 
 bool TGeoFacet::Check() const
 {
-   constexpr Double_t kTolerance = 1.e-10;
-   Int_t nvert = fNvert;
-   for (Int_t i = 0; i < fNvert; ++i) {
-      const TGeoVector3 vi(GetVertex((i + 1) % fNvert) - GetVertex(i));
-      if (vi.Mag2() < kTolerance) {
-        nvert--;
-      }
-   }
-
-   if (nvert < 3) {
-      std::cout << "Tile degenerated: Length of sides of facet are too small." << std::endl;
-      return false;
-   }
-
+   constexpr double kTolerance = 1.e-10;
    bool degenerated = true;
    ComputeNormal(degenerated);
    if (degenerated) {
@@ -111,21 +100,21 @@ bool TGeoFacet::Check() const
    }
 
    // Compute surface area
-   Double_t surfaceArea = 0.;
-   for (Int_t i = 1; i < fNvert - 1; ++i) {
-      TGeoVector3 e1 = GetVertex(i) - GetVertex(0);
-      TGeoVector3 e2 = GetVertex(i + 1) - GetVertex(0);
-      surfaceArea += 0.5 * TGeoVector3::Cross(e1, e2).Mag();
+   double surfaceArea = 0.;
+   for (int i = 1; i < fNvert - 1; ++i) {
+      Vertex_t e1 = GetVertex(i) - GetVertex(0);
+      Vertex_t e2 = GetVertex(i + 1) - GetVertex(0);
+      surfaceArea += 0.5 * Vertex_t::Cross(e1, e2).Mag();
    }
    if (surfaceArea < kTolerance) {
       std::cout << "Facet: " << *this << " has zero surface area\n";
-      return kFALSE;
+      return false;
    }
 
    // Center of the tile
    /*
-   TGeoVector3 center;
-   for (Int_t i = 0; i < fNvert; ++i)
+   Vertex_t center;
+   for (int i = 0; i < fNvert; ++i)
       center += GetVertex(i);
    center /= fNvert;
    */
@@ -135,35 +124,37 @@ bool TGeoFacet::Check() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if a connected neighbour facet has compatible normal
 
-bool TGeoFacet::CheckNeighbour(const TGeoFacet $other) const
+bool TGeoFacet::IsNeighbour(const TGeoFacet &other, bool &flip) const
 {
-/*
+
    // Find a connecting segment
-   Int_t line1[2], line2[2];
-   Int_t npoints = 0;
-   for (Int_t i = 0; i < fNvert; ++i) {
+   bool neighbour = false;
+   int line1[2], line2[2];
+   int npoints = 0;
+   for (int i = 0; i < fNvert; ++i) {
       auto ivert = GetVertexIndex(i);
-      // Skip if next vertex is the same (degenerated)
-      if (ivert == GetVertexIndex((i+1) % fNvert) continue;
       // Check if the other facet has the same vertex
-      for (Int_t j = 0; j < other.GetNvert(); ++j) {
+      for (int j = 0; j < other.GetNvert(); ++j) {
          if (ivert == other.GetVertexIndex(j)) {
             line1[npoints] = i;
             line2[npoints] = j;
             if (++npoints == 2) {
-
+               neighbour = true;
+               bool order1 = line1[1] == line1[0] + 1;
+               bool order2 = line2[1] == (line2[0] + 1) % other.GetNvert();
+               flip = (order1 == order2);
             }
          }
-
-*/
-   return true;
+      }
+   }
+   return neighbour;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 
-TGeoTessellated::TGeoTessellated(const char *name, Int_t nfacets) : TGeoBBox(name, 0, 0, 0)
+TGeoTessellated::TGeoTessellated(const char *name, int nfacets) : TGeoBBox(name, 0, 0, 0)
 {
    fNfacets = nfacets;
    fFacets.reserve(nfacets);
@@ -208,11 +199,22 @@ void TGeoTessellated::AfterStreamer()
 ////////////////////////////////////////////////////////////////////////////////
 /// Adding a triangular facet from vertex positions in absolute coordinates
 
-void TGeoTessellated::AddFacet(const TGeoVector3 &pt0, const TGeoVector3 &pt1, const TGeoVector3 &pt2)
+void TGeoTessellated::AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2)
 {
    if (GetNfacets() == fNfacets) {
       Error("AddFacet", "Already defined %d facets, cannot add more", fNfacets);
       return;
+   }
+   Vertex_t vert[3];
+   vert[0] = pt0;
+   vert[1] = pt1;
+   vert[2] = pt2;
+   // Protect against adding degenerated facets
+   for (int i = 0; i < 3; ++i) {
+      if (vert[(i+1)%3] == vert[i]) {
+         Error("AddFacet", "Triangular facet at index %d degenerated. Not adding.", GetNfacets());
+         return;
+      }
    }
    fNvert += 3;
    fNseg  += 3;
@@ -224,15 +226,36 @@ void TGeoTessellated::AddFacet(const TGeoVector3 &pt0, const TGeoVector3 &pt1, c
 ////////////////////////////////////////////////////////////////////////////////
 /// Adding a quadrilateral facet from vertex positions in absolute coordinates
 
-void TGeoTessellated::AddFacet(const TGeoVector3 &pt0, const TGeoVector3 &pt1, const TGeoVector3 &pt2, const TGeoVector3 &pt3)
+void TGeoTessellated::AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2, const Vertex_t &pt3)
 {
    if (GetNfacets() == fNfacets) {
       Error("AddFacet", "Already defined %d facets, cannot add more", fNfacets);
       return;
    }
-   fNvert += 4;
-   fNseg  += 4;
-   fFacets.emplace_back(pt0, pt1, pt2, pt3);
+   Vertex_t vert[4];
+   vert[0] = pt0;
+   vert[1] = pt1;
+   vert[2] = pt2;
+   vert[3] = pt3;
+   int nvert = 4;
+   for (int i = 0; i < 4; ++i) {
+      if (vert[(i+1)%4] == vert[i]) {
+         if (nvert == 3) {
+            Error("AddFacet", "Quadrilateral facet at index %d degenerated. Not adding.", GetNfacets());
+            return;
+         }
+         for (int j = i+2; j < nvert; ++j)
+            vert[j-1] = vert[j];
+         nvert--;
+      }
+   }
+
+   fNvert += nvert;
+   fNseg  += nvert;
+   if (nvert == 3)
+      fFacets.emplace_back(vert[0], vert[1], vert[2]);
+   else
+      fFacets.emplace_back(vert[0], vert[1], vert[2], vert[3]);
    if (GetNfacets() == fNfacets)
       Close();
 }
@@ -259,7 +282,7 @@ void TGeoTessellated::Close()
    auto AddVertex = [this](const Vertex_t &vertex)
    {
       // Check if vertex exists
-      Int_t ivert = 0;
+      int ivert = 0;
       for (const auto &current_vert : fVertices) {
          if (current_vert == vertex) return ivert;
          ivert++;
@@ -272,10 +295,10 @@ void TGeoTessellated::Close()
    auto GetHashIndex = [&, this](const Vertex_t &vertex)
    {
       // Get the hash index for a vertex in a 10x10x10 grid in the bounding box
-      Int_t index = 0;
+      int index = 0;
       for (int i = 0; i < 3; ++i) {
-         Int_t ind = ngrid * (vertex[i] - minExtent[i]) * invExtent[i]; // between [0, ngrid-1]
-         assert(ind < (Int_t)ngrid);
+         int ind = ngrid * (vertex[i] - minExtent[i]) * invExtent[i]; // between [0, ngrid-1]
+         assert(ind < (int)ngrid);
          for (int j = i + 1; j < 3; ++j) ind *= ngrid;
          index += ind;
       }
@@ -283,7 +306,7 @@ void TGeoTessellated::Close()
    };
 
    // In case the number of vertices is small, just compare with all others
-   Int_t ind[4];
+   int ind[4];
    if (fNvert < 1000) {
       for (auto &facet : fFacets) {
          ind[3] = -1; // not used for triangular facets
@@ -302,7 +325,7 @@ void TGeoTessellated::Close()
          for (int i = 0; i < facet.GetNvert(); ++i) {
             // Check if vertex exists already
             const Vertex_t &vertex = facet.GetVertex(i);
-            Int_t hashind = GetHashIndex(vertex);
+            int hashind = GetHashIndex(vertex);
             bool isAdded = false;
             for (auto ivert : grid[hashind]) {
                if (vertex == fVertices[ivert]) {
@@ -325,6 +348,48 @@ void TGeoTessellated::Close()
    for (auto &facet : fFacets) {
       facet.Check();
    }
+
+   // Check if we have flipped facets
+   int *nn = new int[fNfacets];
+   bool *flipped = new bool[fNfacets];
+   bool hasorphans = false;
+   bool hasflipped = false;
+   for (int i = 0; i < fNfacets; ++i) {
+      nn[i] = 0;
+      flipped[i] = false;
+   }
+   
+   for (int icrt = 0; icrt < fNfacets; ++icrt) {
+      // all neighbours checked?
+      if (nn[icrt] >= fFacets[icrt].GetNvert()) continue;
+      for (int i = icrt+1; i < fNfacets; ++i) {
+         bool isneighbour = fFacets[icrt].IsNeighbour(fFacets[i], flipped[i]);
+         if (isneighbour) {
+            if (flipped[icrt]) flipped[i] = !flipped[i];
+            if (flipped[i]) hasflipped = true;
+            nn[icrt]++;
+            nn[i]++;
+            if (nn[icrt] == fFacets[icrt].GetNvert()) break;
+         }
+      }
+      if (nn[icrt] < fFacets[icrt].GetNvert()) hasorphans = true;
+   }
+   
+   if (hasorphans) {
+      Warning("Check", "Tessellated solid %s has following not fully connected facets:", GetName());
+      for (int icrt = 0; icrt < fNfacets; ++icrt) {
+         if (nn[icrt] < fFacets[icrt].GetNvert())
+            std::cout << icrt << " (" << fFacets[icrt].GetNvert() << " edges, " << nn[icrt] << " neighbours)\n";
+      }
+   }
+   if (hasflipped) {
+      Warning("Check", "Tessellated solid %s has following facets with flipped normals:", GetName());
+      for (int icrt = 0; icrt < fNfacets; ++icrt) {
+         if (flipped[icrt]) std::cout << icrt << "\n";
+      }
+   }
+   delete [] nn;
+   delete [] flipped;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -354,7 +419,7 @@ void TGeoTessellated::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Returns numbers of vertices, segments and polygons composing the shape mesh.
 
-void TGeoTessellated::GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const
+void TGeoTessellated::GetMeshNumbers(int &nvert, int &nsegs, int &npols) const
 {
    nvert = fNvert;
    nsegs = fNseg;
@@ -367,9 +432,9 @@ void TGeoTessellated::GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) c
 
 TBuffer3D *TGeoTessellated::MakeBuffer3D() const
 {
-   const Int_t nvert = fNvert;
-   const Int_t nsegs = fNseg;
-   const Int_t npols = GetNfacets();
+   const int nvert = fNvert;
+   const int nsegs = fNseg;
+   const int npols = GetNfacets();
    TBuffer3D* buff = new TBuffer3D(TBuffer3DTypes::kGeneric, nvert, 3*nvert, nsegs, 3*nsegs, npols, 6*npols);
    if (buff)
    {
@@ -384,19 +449,19 @@ TBuffer3D *TGeoTessellated::MakeBuffer3D() const
 
 void TGeoTessellated::SetSegsAndPols(TBuffer3D &buff) const
 {
-   const Int_t c = GetBasicColor();
-   Int_t *segs = buff.fSegs;
-   Int_t *pols = buff.fPols;
+   const int c = GetBasicColor();
+   int *segs = buff.fSegs;
+   int *pols = buff.fPols;
 
-   Int_t indseg = 0; // segment internal data index
-   Int_t indpol = 0; // polygon internal data index
-   Int_t sind   = 0; // segment index
+   int indseg = 0; // segment internal data index
+   int indpol = 0; // polygon internal data index
+   int sind   = 0; // segment index
    for (const auto &facet : fFacets) {
       auto nvert = facet.GetNvert();
       pols[indpol++] = c;
       pols[indpol++] = nvert;
       for (auto j = 0; j < nvert; ++j) {
-         Int_t k = (j + 1) % nvert;
+         int k = (j + 1) % nvert;
          // segment made by next consecutive points
          segs[indseg++] = c;
          segs[indseg++] = facet.GetVertexIndex(j);
@@ -411,9 +476,9 @@ void TGeoTessellated::SetSegsAndPols(TBuffer3D &buff) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill tessellated points to an array.
 
-void TGeoTessellated::SetPoints(Double_t *points) const
+void TGeoTessellated::SetPoints(double *points) const
 {
-   Int_t ind = 0;
+   int ind = 0;
    for (const auto &vertex : fVertices) {
       vertex.CopyTo(&points[ind]);
       ind += 3;
@@ -425,7 +490,7 @@ void TGeoTessellated::SetPoints(Double_t *points) const
 
 void TGeoTessellated::SetPoints(Float_t *points) const
 {
-   Int_t ind = 0;
+   int ind = 0;
    for (const auto &vertex : fVertices) {
       points[ind++] = vertex.x();
       points[ind++] = vertex.y();
@@ -436,15 +501,15 @@ void TGeoTessellated::SetPoints(Float_t *points) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Fills a static 3D buffer and returns a reference.
 
-const TBuffer3D & TGeoTessellated::GetBuffer3D(Int_t reqSections, Bool_t localFrame) const
+const TBuffer3D & TGeoTessellated::GetBuffer3D(int reqSections, Bool_t localFrame) const
 {
    static TBuffer3D buffer(TBuffer3DTypes::kGeneric);
 
    FillBuffer3D(buffer, reqSections, localFrame);
 
-   const Int_t nvert = fNvert;
-   const Int_t nsegs = fNseg;
-   const Int_t npols = GetNfacets();
+   const int nvert = fNvert;
+   const int nsegs = fNseg;
+   const int npols = GetNfacets();
 
    if (reqSections & TBuffer3D::kRawSizes) {
       if (buffer.SetRawSizes(nvert, 3*nvert, nsegs, 3*nsegs, npols, 6*npols)) {
@@ -468,12 +533,12 @@ const TBuffer3D & TGeoTessellated::GetBuffer3D(Int_t reqSections, Bool_t localFr
 /// Fills the supplied buffer, with sections in desired frame
 /// See TBuffer3D.h for explanation of sections, frame etc.
 
-void TGeoTessellated::FillBuffer3D(TBuffer3D & buffer, Int_t reqSections, Bool_t localFrame) const
+void TGeoTessellated::FillBuffer3D(TBuffer3D & buffer, int reqSections, Bool_t localFrame) const
 {
    TGeoShape::FillBuffer3D(buffer, reqSections, localFrame);
 
    if (reqSections & TBuffer3D::kBoundingBox) {
-      Double_t halfLengths[3] = { fDX, fDY, fDZ };
+      double halfLengths[3] = { fDX, fDY, fDZ };
       buffer.SetAABoundingBox(fOrigin, halfLengths);
 
       if (!buffer.fLocalFrame) {

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -444,7 +444,7 @@ TBuffer3D *TGeoTessellated::MakeBuffer3D() const
    const int nvert = fNvert;
    const int nsegs = fNseg;
    const int npols = GetNfacets();
-   auto *buff = new TBuffer3D(TBuffer3DTypes::kGeneric, nvert, 3 * nvert, nsegs, 3 * nsegs, npols, 6 * npols);
+   auto buff = new TBuffer3D(TBuffer3DTypes::kGeneric, nvert, 3 * nvert, nsegs, 3 * nsegs, npols, 6 * npols);
    if (buff) {
       SetPoints(buff->fPnts);
       SetSegsAndPols(*buff);

--- a/geom/geom/src/TGeoVector3.cxx
+++ b/geom/geom/src/TGeoVector3.cxx
@@ -1,0 +1,23 @@
+// @(#)root/geom:$Id$
+// Author: Andrei Gheata   15/01/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/** \class  TGeoVector3
+\ingroup Geometry_classes
+Simple 3-vector representation
+*/
+
+#include "TGeoVector3.h"
+
+std::ostream &operator<<(std::ostream &os, TGeoVector3 const &vec)
+{
+   os << "{" << vec[0] << ", " << vec[1] << ", " << vec[2] << "}";
+   return os;
+}

--- a/tutorials/geom/geodemo.C
+++ b/tutorials/geom/geodemo.C
@@ -1646,10 +1646,10 @@ void tessellated()
    gGeoManager->SetTopVolume(top);
    TGeoTessellated *tsl = new TGeoTessellated("triaconthaedron", 30);
    const Double_t sqrt5 = TMath::Sqrt(5.);
-   std::vector<TGeoVector3> vert;
+   std::vector<Tessellated::Vertex_t> vert;
    vert.reserve(120);
-   vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, 0, 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, 1, -1); 
-   vert.emplace_back(1, 1, -1); vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5)); vert.emplace_back(1, 0, 0.5 * (-1 - sqrt5)); 
+   vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, 0, 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, 1, -1);
+   vert.emplace_back(1, 1, -1); vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5)); vert.emplace_back(1, 0, 0.5 * (-1 - sqrt5));
    vert.emplace_back(1, 1, -1); vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0.5 * (-1 + sqrt5),  0.5 * (1 + sqrt5), 0); vert.emplace_back(0.5 * (1 + sqrt5), 1, 0);
    vert.emplace_back(0.5 * (1 - sqrt5), 0.5 * (1 + sqrt5), 0); vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0.5 * (-1 + sqrt5), 0.5 * (1 + sqrt5), 0); vert.emplace_back(0, 0.5 * (1 + sqrt5), 1);
    vert.emplace_back(0.5 * (1 - sqrt5), 0.5 * (1 + sqrt5), 0); vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(-1, 1, -1); vert.emplace_back(0.5 * (-1 - sqrt5), 1, 0);
@@ -1678,7 +1678,6 @@ void tessellated()
    vert.emplace_back(0, 0.5 * (-1 - sqrt5), -1); vert.emplace_back(0.5 * (1 - sqrt5), 0.5 * (-1 - sqrt5), 0); vert.emplace_back(0, 0.5 * (-1 - sqrt5), 1); vert.emplace_back(0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5), 0);
    vert.emplace_back(1, -1, -1); vert.emplace_back(0.5 * (1 + sqrt5), -1, 0); vert.emplace_back(0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5), 0); vert.emplace_back(0, 0.5 * (-1 - sqrt5), -1);
    vert.emplace_back(0.5 * (1 + sqrt5), -1, 0); vert.emplace_back(1, -1, 1); vert.emplace_back(0, 0.5 * (-1 - sqrt5), 1); vert.emplace_back(0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5), 0);
-
 
    tsl->AddFacet(vert[0], vert[1], vert[2], vert[3]);
    tsl->AddFacet(vert[4], vert[7], vert[6], vert[5]);

--- a/tutorials/geom/geodemo.C
+++ b/tutorials/geom/geodemo.C
@@ -233,6 +233,7 @@ void geodemo ()
    bar->AddButton("Tube        ","tube()","A tube with inner and outer radius");
    bar->AddButton("Tube segment","tubeseg()","A tube segment");
    bar->AddButton("Twisted trap","gtra()","A twisted trapezoid");
+   bar->AddButton("Tessellated ","tessellated()","A tessellated shape");
    bar->AddButton("Aligned (ideal)","ideal()","An ideal (un-aligned) geometry");
    bar->AddButton("Un-aligned","align()","Some alignment operation");
    bar->AddButton("RAY-TRACE ON/OFF","raytrace()","Toggle ray-tracing mode");
@@ -1624,7 +1625,119 @@ void xtru()
    pt->Draw();
    c->cd(1);
 }
+//______________________________________________________________________________
+void tessellated()
+{
+   // Create a [triacontahedron solid](https://en.wikipedia.org/wiki/Rhombic_triacontahedron)
+   gROOT->GetListOfCanvases()->Delete();
+   TCanvas *c = new TCanvas("tessellated shape", "A tessellated shape", 700,1000);
+   if (comments) {
+      c->Divide(1,2,0,0);
+      c->cd(2);
+      gPad->SetPad(0,0,1,0.4);
+      c->cd(1);
+      gPad->SetPad(0,0.4,1,1);
+   }
+   if (gGeoManager) delete gGeoManager;
+   new TGeoManager("tessellated", "tessellated");
+   TGeoMaterial *mat = new TGeoMaterial("Al", 26.98,13,2.7);
+   TGeoMedium *med = new TGeoMedium("MED",1,mat);
+   TGeoVolume *top = gGeoManager->MakeBox("TOP",med,10,10,10);
+   gGeoManager->SetTopVolume(top);
+   TGeoTessellated *tsl = new TGeoTessellated("triaconthaedron", 30);
+   const Double_t sqrt5 = TMath::Sqrt(5.);
+   std::vector<TGeoVector3> vert;
+   vert.reserve(120);
+   vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, 0, 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, 1, -1); 
+   vert.emplace_back(1, 1, -1); vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5)); vert.emplace_back(1, 0, 0.5 * (-1 - sqrt5)); 
+   vert.emplace_back(1, 1, -1); vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0.5 * (-1 + sqrt5),  0.5 * (1 + sqrt5), 0); vert.emplace_back(0.5 * (1 + sqrt5), 1, 0);
+   vert.emplace_back(0.5 * (1 - sqrt5), 0.5 * (1 + sqrt5), 0); vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(0.5 * (-1 + sqrt5), 0.5 * (1 + sqrt5), 0); vert.emplace_back(0, 0.5 * (1 + sqrt5), 1);
+   vert.emplace_back(0.5 * (1 - sqrt5), 0.5 * (1 + sqrt5), 0); vert.emplace_back(0, 0.5 * (1 + sqrt5), -1); vert.emplace_back(-1, 1, -1); vert.emplace_back(0.5 * (-1 - sqrt5), 1, 0);
+   vert.emplace_back(1, 1, -1); vert.emplace_back(0.5 * (1 + sqrt5), 1, 0); vert.emplace_back(0.5 * (1 + sqrt5), 0, 0.5 * (1 - sqrt5)); vert.emplace_back(1, 0, 0.5 * (-1 - sqrt5));
+   vert.emplace_back(0.5 * (1 + sqrt5), 0, 0.5 * (1 - sqrt5)); vert.emplace_back(0.5 * (1 + sqrt5), -1, 0); vert.emplace_back(1, -1, -1); vert.emplace_back(1, 0, 0.5 * (-1 - sqrt5));
+   vert.emplace_back(1, -1, -1); vert.emplace_back(0, 0.5 * (-1 - sqrt5), -1); vert.emplace_back(0, 0.5 * (1 - sqrt5), 0.5 * (-1 - sqrt5)); vert.emplace_back(1, 0, 0.5 * (-1 - sqrt5));
+   vert.emplace_back(1, 0, 0.5 * (-1 - sqrt5)); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, 0, 0.5 * (-1 - sqrt5)); vert.emplace_back(0, 0.5 * (1 - sqrt5), 0.5 * (-1 - sqrt5));
+   vert.emplace_back(0.5 * (-1 + sqrt5), 0.5 * (1 + sqrt5), 0); vert.emplace_back(0.5 * (1 + sqrt5), 1, 0); vert.emplace_back(1, 1, 1); vert.emplace_back(0, 0.5 * (1 + sqrt5), 1);
+   vert.emplace_back(0.5 * (1 + sqrt5), 1, 0); vert.emplace_back(1, 1, 1); vert.emplace_back(1, 0, 0.5 * (1 + sqrt5)); vert.emplace_back(0.5 * (1 + sqrt5), 0, 0.5 * (-1 + sqrt5));
+   vert.emplace_back(0.5 * (1 + sqrt5), 0, 0.5 * (1 - sqrt5)); vert.emplace_back(0.5 * (1 + sqrt5), 1, 0); vert.emplace_back(0.5 * (1 + sqrt5), 0, 0.5 * (-1 + sqrt5)); vert.emplace_back(0.5 * (1 + sqrt5), -1, 0);
+   vert.emplace_back(0.5 * (1 - sqrt5), 0.5 * (1 + sqrt5), 0); vert.emplace_back(0, 0.5 * (1 + sqrt5), 1); vert.emplace_back(-1, 1, 1); vert.emplace_back(0.5 * (-1 - sqrt5), 1, 0);
+   vert.emplace_back(0, 0.5 * (1 + sqrt5), 1); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (1 + sqrt5)); vert.emplace_back(-1, 0, 0.5 * (1 + sqrt5)); vert.emplace_back(-1, 1, 1);
+   vert.emplace_back(1, 1, 1); vert.emplace_back(0, 0.5 * (1 + sqrt5), 1); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (1 + sqrt5)); vert.emplace_back(1, 0, 0.5 * (1 + sqrt5));
+   vert.emplace_back(0, 0.5 * (1 - sqrt5), 0.5 * (1 + sqrt5)); vert.emplace_back(-1, 0, 0.5 * (1 + sqrt5)); vert.emplace_back(0, 0.5 * (-1 + sqrt5), 0.5 * (1 + sqrt5)); vert.emplace_back(1, 0, 0.5 * (1 + sqrt5));
+   vert.emplace_back(0, 0.5 * (1 - sqrt5), 0.5 * (1 + sqrt5)); vert.emplace_back(1, 0, 0.5 * (1 + sqrt5)); vert.emplace_back(1, -1, 1); vert.emplace_back(0, 0.5 * (-1 - sqrt5), 1);
+   vert.emplace_back(0.5 * (1 + sqrt5), 0, 0.5 * (-1 + sqrt5)); vert.emplace_back(0.5 * (1 + sqrt5), -1, 0); vert.emplace_back(1, -1, 1); vert.emplace_back(1, 0, 0.5 * (1 + sqrt5));
+   vert.emplace_back(-1, 0, 0.5 * (1 + sqrt5)); vert.emplace_back(-1, 1, 1); vert.emplace_back(0.5 * (-1 - sqrt5), 1, 0); vert.emplace_back(0.5 * (-1 - sqrt5), 0, 0.5 * (-1 + sqrt5));
+   vert.emplace_back(-1, -1, 1); vert.emplace_back(-1, 0, 0.5 * (1 + sqrt5)); vert.emplace_back(0.5 * (-1 - sqrt5), 0, 0.5 * (-1 + sqrt5)); vert.emplace_back(0.5 * (-1 - sqrt5), -1, 0);
+   vert.emplace_back(0, 0.5 * (1 - sqrt5), 0.5 * (1 + sqrt5)); vert.emplace_back(-1, 0, 0.5 * (1 + sqrt5)); vert.emplace_back(-1, -1, 1); vert.emplace_back(0, 0.5 * (-1 - sqrt5), 1);
+   vert.emplace_back(0.5 * (-1 - sqrt5), -1, 0); vert.emplace_back(0.5 * (-1 - sqrt5), 0, 0.5 * (1 - sqrt5)); vert.emplace_back(0.5 * (-1 - sqrt5), 1, 0); vert.emplace_back(0.5 * (-1 - sqrt5), 0, 0.5 * (-1 + sqrt5));
+   vert.emplace_back(0.5 * (-1 - sqrt5), -1, 0); vert.emplace_back(0.5 * (-1 - sqrt5), 0, 0.5 * (1 - sqrt5)); vert.emplace_back(-1, 0, 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, -1, -1);
+   vert.emplace_back(0, 0.5 * (-1 - sqrt5), -1); vert.emplace_back(0.5 * (1 - sqrt5), 0.5 * (-1 - sqrt5), 0); vert.emplace_back(0.5 * (-1 - sqrt5), -1, 0); vert.emplace_back(-1, -1, -1);
+   vert.emplace_back(0.5 * (1 - sqrt5), 0.5 * (-1 - sqrt5), 0); vert.emplace_back(0.5 * (-1 - sqrt5), -1, 0); vert.emplace_back(-1, -1, 1); vert.emplace_back(0, 0.5 * (-1 - sqrt5), 1);
+   vert.emplace_back(-1, 1, -1); vert.emplace_back(-1, 0, 0.5 * (-1 - sqrt5)); vert.emplace_back(0.5 * (-1 - sqrt5), 0, 0.5 * (1 - sqrt5)); vert.emplace_back(0.5 * (-1 - sqrt5), 1, 0);
+   vert.emplace_back(0, 0.5 * (-1 - sqrt5), -1); vert.emplace_back(0, 0.5 * (1 - sqrt5), 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, 0, 0.5 * (-1 - sqrt5)); vert.emplace_back(-1, -1, -1);
+   vert.emplace_back(0, 0.5 * (-1 - sqrt5), -1); vert.emplace_back(0.5 * (1 - sqrt5), 0.5 * (-1 - sqrt5), 0); vert.emplace_back(0, 0.5 * (-1 - sqrt5), 1); vert.emplace_back(0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5), 0);
+   vert.emplace_back(1, -1, -1); vert.emplace_back(0.5 * (1 + sqrt5), -1, 0); vert.emplace_back(0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5), 0); vert.emplace_back(0, 0.5 * (-1 - sqrt5), -1);
+   vert.emplace_back(0.5 * (1 + sqrt5), -1, 0); vert.emplace_back(1, -1, 1); vert.emplace_back(0, 0.5 * (-1 - sqrt5), 1); vert.emplace_back(0.5 * (-1 + sqrt5), 0.5 * (-1 - sqrt5), 0);
 
+
+   tsl->AddFacet(vert[0], vert[1], vert[2], vert[3]);
+   tsl->AddFacet(vert[4], vert[7], vert[6], vert[5]);
+   tsl->AddFacet(vert[8], vert[9], vert[10], vert[11]);
+   tsl->AddFacet(vert[12], vert[15], vert[14], vert[13]);
+   tsl->AddFacet(vert[16], vert[17], vert[18], vert[19]);
+   tsl->AddFacet(vert[20], vert[21], vert[22], vert[23]);
+   tsl->AddFacet(vert[24], vert[25], vert[26], vert[27]);
+   tsl->AddFacet(vert[28], vert[29], vert[30], vert[31]);
+   tsl->AddFacet(vert[32], vert[35], vert[34], vert[33]);
+   tsl->AddFacet(vert[36], vert[39], vert[38], vert[37]);
+   tsl->AddFacet(vert[40], vert[41], vert[42], vert[43]);
+   tsl->AddFacet(vert[44], vert[45], vert[46], vert[47]);
+   tsl->AddFacet(vert[48], vert[51], vert[50], vert[49]);
+   tsl->AddFacet(vert[52], vert[55], vert[54], vert[53]);
+   tsl->AddFacet(vert[56], vert[57], vert[58], vert[59]);
+   tsl->AddFacet(vert[60], vert[63], vert[62], vert[61]);
+   tsl->AddFacet(vert[64], vert[67], vert[66], vert[65]);
+   tsl->AddFacet(vert[68], vert[71], vert[70], vert[69]);
+   tsl->AddFacet(vert[72], vert[73], vert[74], vert[75]);
+   tsl->AddFacet(vert[76], vert[77], vert[78], vert[79]);
+   tsl->AddFacet(vert[80], vert[81], vert[82], vert[83]);
+   tsl->AddFacet(vert[84], vert[87], vert[86], vert[85]);
+   tsl->AddFacet(vert[88], vert[89], vert[90], vert[91]);
+   tsl->AddFacet(vert[92], vert[93], vert[94], vert[95]);
+   tsl->AddFacet(vert[96], vert[99], vert[98], vert[97]);
+   tsl->AddFacet(vert[100], vert[101], vert[102], vert[103]);
+   tsl->AddFacet(vert[104], vert[107], vert[106], vert[105]);
+   tsl->AddFacet(vert[108], vert[111], vert[110], vert[109]);
+   tsl->AddFacet(vert[112], vert[113], vert[114], vert[115]);
+   tsl->AddFacet(vert[116], vert[117], vert[118], vert[119]);
+
+   TGeoVolume *vol = new TGeoVolume("TRIACONTHAEDRON", tsl, med);
+   vol->SetLineColor(randomColor());
+   vol->SetLineWidth(2);
+   top->AddNode(vol,1);
+   gGeoManager->CloseGeometry();
+   top->Draw();
+   MakePicture();
+   if (!comments) return;
+   c->cd(2);
+   TPaveText *pt = new TPaveText(0.01,0.01,0.99,0.99);
+   pt->SetLineColor(1);
+   TText *text = pt->AddText("TGeoTessellated - Tessellated shape class");
+   text->SetTextColor(2);
+   AddText(pt,"fNfacets",tsl->GetNfacets(),"number of facets");
+   AddText(pt,"fNvertices",tsl->GetNvertices(),"number of vertices");
+   pt->AddText("----- A tessellated shape is defined by the number of facets");
+   pt->AddText("-----    facets can be added using AddFacet");
+   pt->AddText("----- Create with:    TGeoTessellated *tsl = new TGeoTessellated(nfacets);");
+   pt->AddText(" ");
+   pt->SetAllWith("-----","color",2);
+   pt->SetAllWith("-----","font",72);
+   pt->SetAllWith("-----","size",0.04);
+   pt->SetTextAlign(12);
+   pt->SetTextSize(0.044);
+   pt->Draw();
+   c->cd(1);
+}
 //______________________________________________________________________________
 void composite()
 {


### PR DESCRIPTION
Implemented tessellated shape in TGeo, as a wrapper shape without navigation functionality, allowing future conversions to/from Geant4 and VecGeom done by frameworks such as DD4HEP. Currently missing navigation functionality, but having ROOT/GDML persistence support and visualization.