### PR TITLE
[TMacro] Make TMacro class "mergeable"

### DIFF
--- a/core/base/inc/TMacro.h
+++ b/core/base/inc/TMacro.h
@@ -26,6 +26,7 @@
 class TList;
 class TObjString;
 class TMD5;
+class TCollection;
 
 
 class TMacro : public TNamed {
@@ -49,6 +50,8 @@ public:
    virtual Bool_t       Load() const; //*MENU*
    virtual Long_t       Exec(const char *params = 0, Int_t* error = 0); //*MENU*
    TList               *GetListOfLines() const {return fLines;}
+   virtual const char  *GetParams() const { return fParams; }
+   virtual Int_t        Merge(TCollection *list);
    virtual void         Paint(Option_t *option="");
    virtual void         Print(Option_t *option="") const;  //*MENU*
    virtual Int_t        ReadFile(const char *filename);

--- a/core/base/src/TMacro.cxx
+++ b/core/base/src/TMacro.cxx
@@ -337,11 +337,11 @@ Int_t TMacro::Merge(TCollection *list)
       auto m = (TMacro*) obj;
       TMD5 *checksum = m->Checksum();
       if (!(*thischecksum == *checksum))
-         Warning("Merge", Form("TMacro objects with name %s have different file content!", GetName()));
+         Warning("Merge", "TMacro objects with name %s have different file content!", GetName());
       delete checksum;
 
       if (fParams.CompareTo(m->GetParams()) != 0)
-         Warning("Merge", Form("TMacro objects with name %s have different default parameters!", GetName()));
+         Warning("Merge", "TMacro objects with name %s have different default parameters!", GetName());
 
       n++;
    }

--- a/core/base/src/TMacro.cxx
+++ b/core/base/src/TMacro.cxx
@@ -327,14 +327,14 @@ Int_t TMacro::Merge(TCollection *list)
    TMD5 *thischecksum = Checksum();
    TIter macros(list);
 
-   while (TObject* obj = macros()) {
+   while (TObject *obj = macros()) {
       if (!obj)
          continue;
 
       if (!obj->IsA()->InheritsFrom(TMacro::Class()))
          continue;
 
-      TMacro* m = (TMacro*) obj;
+      auto m = (TMacro*) obj;
       TMD5 *checksum = m->Checksum();
       if (!(*thischecksum == *checksum))
          Warning("Merge", Form("TMacro objects with name %s have different file content!", GetName()));


### PR DESCRIPTION
Hello,

this is a rather small, but I think very useful addition.
One application of the TMacro class is to store the code that generated a ROOT file in the file itself to be later able to reproduce the analysis.
However, in parallel computing you often execute the same macro several times and at the end merge the resulting files using the TFileMerger or a tool like hadd. Up to now the TMacro class was not mergeable and therefore merging 1000 files would create 1000 cycles of TMacro objects with the exact same content, which makes it hard to browse the ROOT file in a TBrowser for example.

Of course I am aware that you cannot actually merge two different macros, but since the name of a TMacro is usually the filename of the macro stored, I cannot think of any valid case in which two TMacro objects with the same name in two files that are supposed to be merged would have different contents. Furthermore, the parameter attribute of the class is described as "default parameters to execute this macro" in TMacro::SetParams, so they should also not differ for two instances of the same macro.

My implementation of the Merge function for the TMacro class just compares the TMacro objects that are supposed to be merged and issues warnings if there there are differences. The file contents are compared using the checksum of the TMacro object.

All the best,
Simon