### PR TITLE
Ensure PYTHON_PREFER_VERSION matches the version from PYTHON_EXECUTABLE

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -511,16 +511,16 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14)
   # If so, it will be passed to find_package(Python) below. Otherwise,
   # check what `python` points to: Python 2 or 3:
   if(NOT PYTHON_EXECUTABLE)
-    find_program(PYTHON_BINARY_IN_PATH "python")
-    if(PYTHON_BINARY_IN_PATH)
-      execute_process(COMMAND ${PYTHON_BINARY_IN_PATH} -c "import sys;print(sys.version_info[0])"
-                      OUTPUT_VARIABLE PYTHON_PREFER_VERSION
-                      ERROR_VARIABLE PYTHON_PREFER_VERSION_ERR)
-      if(PYTHON_PREFER_VERSION_ERR)
-        message(WARNING "Unable to determine version of ${PYTHON_BINARY_IN_PATH}: ${PYTHON_PREFER_VERSION_ERR}")
-      endif()
-      string(STRIP "${PYTHON_PREFER_VERSION}" PYTHON_PREFER_VERSION)
+    find_program(PYTHON_EXECUTABLE "python")
+  endif()
+  if(PYTHON_EXECUTABLE)
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import sys;print(sys.version_info[0])"
+                    OUTPUT_VARIABLE PYTHON_PREFER_VERSION
+                    ERROR_VARIABLE PYTHON_PREFER_VERSION_ERR)
+    if(PYTHON_PREFER_VERSION_ERR)
+      message(WARNING "Unable to determine version of ${PYTHON_EXECUTABLE}: ${PYTHON_PREFER_VERSION_ERR}")
     endif()
+    string(STRIP "${PYTHON_PREFER_VERSION}" PYTHON_PREFER_VERSION)
   endif()
 
   if(python)


### PR DESCRIPTION
When passing `-DPYTHON_EXECUTABLE=/my/path/to/python2` on macOS ROOT fails to configure with newer CMake versions with a bizarre error of:
```
-- Preferring Python version 3
-- Found Python: /Users/christopherburr/miniconda3/conda-bld/root_1579698021552/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/bin/python2.7 (found version "2.7.15") found components:  Interpreter Development
-- Could NOT find Python (missing: Development) (found version "2.7.15")
-- Looking for OpenGL
-- Could NOT find OpenGL (missing: OPENGL_gl_LIBRARY OPENGL_INCLUDE_DIR)
CMake Error at cmake/modules/SearchInstalledSoftware.cmake:610 (message):
  OpenGL package (with GLU) not found and opengl option required
Call Stack (most recent call first):
  CMakeLists.txt:167 (include)
```
Looking at the variables I see a weird mixture of python 2 and python 3:
```
//
PYTHON_EXECUTABLE-CACHED:STRING=/Users/christopherburr/miniconda3/conda-bld/root_1579698021552/_h_env/bin/python

// Path to a program.
Python_EXECUTABLE:FILEPATH=/Users/christopherburr/miniconda3/conda-bld/root_1579698021552/_h_env/bin/python2.7

// Path to a file.
Python_INCLUDE_DIR:PATH=/usr/local/Cellar/python/3.7.6/Frameworks/Python.framework/Versions/3.7/include/python3.7m

// Path to a library.
Python_LIBRARY_DEBUG:FILEPATH=Python_LIBRARY_DEBUG-NOTFOUND

// Path to a library.
Python_LIBRARY_RELEASE:FILEPATH=/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7m.dylib

// Path to a file.
Python_NumPy_INCLUDE_DIR:PATH=/Users/christopherburr/miniconda3/conda-bld/root_1579698021552/_h_env/lib/python2.7/site-packages/numpy/core/include
```
This PR includes one way of fixing the issue.