### PR TITLE
ROOT-10514: Call TClass::ReadRules before the rootmap files to be read. 

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2142,11 +2142,6 @@ void TROOT::InitInterpreter()
    GetModuleHeaderInfoBuffer().clear();
 
    fInterpreter->Initialize();
-
-   // Read the rules before enabling the auto loading to not inadvertently
-   // load the libraries for the classes concerned even-though the user is
-   // *not* using them.
-   TClass::ReadRules(); // Read the default customization rules ...
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2146,7 +2146,6 @@ void TROOT::InitInterpreter()
    // Read the rules before enabling the auto loading to not inadvertently
    // load the libraries for the classes concerned even-though the user is
    // *not* using them.
-   TInterpreter::SuspendAutoloadingRAII autoloadOff(gInterpreter);
    TClass::ReadRules(); // Read the default customization rules ...
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1439,9 +1439,6 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       // e.g. because of an RPATH build.
       fInterpreter->getDynamicLibraryManager()->addSearchPath(TROOT::GetLibDir().Data());
    }
-
-   // We are set up. EnableAutoLoading() is checking for fromRootCling.
-   EnableAutoLoading();
 }
 
 
@@ -1469,6 +1466,9 @@ TCling::~TCling()
 void TCling::Initialize()
 {
    fClingCallbacks->Initialize();
+
+   // We are set up. EnableAutoLoading() is checking for fromRootCling.
+   EnableAutoLoading();
 }
 
 void TCling::ShutDown()
@@ -2927,6 +2927,13 @@ void TCling::EnableAutoLoading()
 {
    if (IsFromRootCling())
       return;
+
+   // Read the rules before enabling the auto loading to not inadvertently
+   // load the libraries for the classes concerned even-though the user is
+   // *not* using them.
+   // Note this call must happen before the first call to LoadLibraryMap.
+   assert(GetRootMapFiles() == 0 && "Must be called before LoadLibraryMap!");
+   TClass::ReadRules(); // Read the default customization rules ...
 
    LoadLibraryMap();
    SetClassAutoloading(true);


### PR DESCRIPTION
This avoid loading the library containing the dictionary and avoids leaving the TClass::GetClass("HepMC::GenVertex") meta information in an odd state.

This should bring the v6.18 behavior unintentionally broken in the refactoring commit c8cce31.

This should fix ROOT-10514 completely.