### PR TITLE
In StreamerInfoActions always respect vector's custom-allocator

### DIFF
--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -45,6 +45,12 @@ using namespace TStreamerInfoActions;
 
 namespace TStreamerInfoActions
 {
+   bool IsDefaultVector(TVirtualCollectionProxy &proxy)
+   {
+      return ((proxy.GetCollectionType() == ROOT::kSTLvector && !(proxy.GetProperties() & TVirtualCollectionProxy::kCustomAlloc))
+              || (proxy.GetProperties() & TVirtualCollectionProxy::kIsEmulated) );
+   }
+
    template <typename From>
    struct WithFactorMarker {
       typedef From Value_t;
@@ -3883,7 +3889,7 @@ TStreamerInfoActions::TActionSequence *TStreamerInfoActions::TActionSequence::Cr
 
    UInt_t ndata = info->GetElements()->GetEntries();
    TStreamerInfoActions::TActionSequence *sequence = new TStreamerInfoActions::TActionSequence(info,ndata);
-   if ( (proxy.GetCollectionType() == ROOT::kSTLvector) || (proxy.GetProperties() & TVirtualCollectionProxy::kIsEmulated) )
+   if (IsDefaultVector(proxy))
    {
       if (proxy.HasPointers()) {
          // Instead of the creating a new one let's copy the one from the StreamerInfo.
@@ -4000,7 +4006,7 @@ TStreamerInfoActions::TActionSequence *TStreamerInfoActions::TActionSequence::Cr
       TStreamerInfo *sinfo = static_cast<TStreamerInfo*>(info);
       TStreamerInfoActions::TActionSequence *sequence = new TStreamerInfoActions::TActionSequence(info,ndata);
 
-      if ( (proxy.GetCollectionType() == ROOT::kSTLvector) || (proxy.GetProperties() & TVirtualCollectionProxy::kIsEmulated) )
+      if (IsDefaultVector(proxy))
       {
          if (proxy.HasPointers()) {
             // Instead of the creating a new one let's copy the one from the StreamerInfo.
@@ -4063,7 +4069,7 @@ TStreamerInfoActions::TActionSequence *TStreamerInfoActions::TActionSequence::Cr
                oldType += TVirtualStreamerInfo::kSkip;
             }
          }
-         if ( (proxy.GetCollectionType() == ROOT::kSTLvector) || (proxy.GetProperties() & TVirtualCollectionProxy::kIsEmulated)
+         if ( IsDefaultVector(proxy)
                /*|| (proxy.GetCollectionType() == ROOT::kSTLset || proxy.GetCollectionType() == ROOT::kSTLmultiset
                || proxy.GetCollectionType() == ROOT::kSTLmap || proxy.GetCollectionType() == ROOT::kSTLmultimap) */ )
          {
@@ -4136,7 +4142,7 @@ TStreamerInfoActions::TActionSequence *TStreamerInfoActions::TActionSequence::Cr
             }
          }
 #else
-         if ( (proxy.GetCollectionType() == ROOT::kSTLvector) || (proxy.GetProperties() & TVirtualCollectionProxy::kIsEmulated)
+         if ( IsDefaultVector(proxy)
                /*|| (proxy.GetCollectionType() == ROOT::kSTLset || proxy.GetCollectionType() == ROOT::kSTLmultiset
                 || proxy.GetCollectionType() == ROOT::kSTLmap || proxy.GetCollectionType() == ROOT::kSTLmultimap)*/ )
          {

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -47,8 +47,12 @@ namespace TStreamerInfoActions
 {
    bool IsDefaultVector(TVirtualCollectionProxy &proxy)
    {
-      return ((proxy.GetCollectionType() == ROOT::kSTLvector && !(proxy.GetProperties() & TVirtualCollectionProxy::kCustomAlloc))
-              || (proxy.GetProperties() & TVirtualCollectionProxy::kIsEmulated) );
+      const auto props = proxy.GetProperties();
+      const bool isVector = proxy.GetCollectionType() == ROOT::kSTLvector;
+      const bool hasDefaultAlloc = !(props & TVirtualCollectionProxy::kCustomAlloc);
+      const bool isEmulated = props & TVirtualCollectionProxy::kIsEmulated;
+
+      return isEmulated || (isVector && hasDefaultAlloc);
    }
 
    template <typename From>


### PR DESCRIPTION
Previously the handling was inconsistent resulting in mis-matches
and thus memory errors.

This fixes ROOT-10526.