### PR TITLE
Fix TGLVContainer::SelectEntry()

### DIFF
--- a/gui/gui/inc/TGListView.h
+++ b/gui/gui/inc/TGListView.h
@@ -224,8 +224,7 @@ public:
 
    virtual void AddItem(TGLVEntry *item)
                   { AddFrame(item, fItemLayout); item->SetColumns(fCpos, fJmode); fTotal++; }
-   virtual void SelectEntry(TGLVEntry *item)
-                  { ActivateItem(item->GetFrameElement()); }
+   virtual void SelectEntry(TGLVEntry *item);
 
    virtual void  SetListView(TGListView *lv) { fListView = lv; }
    virtual void  RemoveItemWithData(void *userData);

--- a/gui/gui/src/TGListView.cxx
+++ b/gui/gui/src/TGListView.cxx
@@ -1144,6 +1144,23 @@ TGDimension TGLVContainer::GetPageDimension() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Select the TGLVEntry given as argument and de-select the previous one if
+/// the container is not in multi-selection mode.
+
+void TGLVContainer::SelectEntry(TGLVEntry *item)
+{
+   // select (activate) the item passed as argument and deactivate the currently
+   // active one if not in multi-select mode
+
+   if ( !fMultiSelect ) {
+      TGFrameElement *old = fLastActiveEl;
+      if (old)
+         DeActivateItem(old);
+   }
+   ActivateItem(item->GetFrameElement());
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Create a list view widget.
 
 TGListView::TGListView(const TGWindow *p, UInt_t w, UInt_t h,


### PR DESCRIPTION
Select the TGLVEntry given as argument and de-select the previous one if the container is not in multi-selection mode. This should fix the [issue reported on the forum](https://root-forum.cern.ch/t/getting-selection-in-tglistview/18510/18):