### PR TITLE
Fix memory leak in TPad::Print() method

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -4824,7 +4824,6 @@ static Bool_t ContainsTImage(TList *li)
 void TPad::Print(const char *filenam, Option_t *option)
 {
    TString psname, fs1 = filenam;
-   const char *filename;
 
    // "[" and "]" are special characters for ExpandPathName. When they are at the end
    // of the file name (see help) they must be removed before doing ExpandPathName.
@@ -4839,26 +4838,24 @@ void TPad::Print(const char *filenam, Option_t *option)
    } else {
       gSystem->ExpandPathName(fs1);
    }
-   filename = fs1.Data();
 
    // Set the default option as "Postscript" (Should be a data member of TPad)
-   const char *opt_default="ps";
+   const char *opt_default = "ps";
 
-   Int_t lenfil =  filename ? strlen(filename) : 0;
-   TString opt = (!option) ? opt_default : option;
+   TString opt = !option ? opt_default : option;
    Bool_t image = kFALSE;
 
-   if ( !lenfil )  {
+   if (!fs1.Length())  {
       psname = GetName();
       psname += opt;
    } else {
-      psname = filename;
+      psname = fs1;
    }
 
    // lines below protected against case like c1->SaveAs( "../ps/cs.ps" );
    if (psname.BeginsWith('.') && (psname.Contains('/') == 0)) {
       psname = GetName();
-      psname.Append(filename);
+      psname.Append(fs1);
       psname.Prepend("/");
       psname.Prepend(gEnv->GetValue("Canvas.PrintDirectory","."));
    }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -4823,26 +4823,23 @@ static Bool_t ContainsTImage(TList *li)
 
 void TPad::Print(const char *filenam, Option_t *option)
 {
-   TString psname, fs1, fs2;
+   TString psname, fs1 = filenam;
    const char *filename;
 
    // "[" and "]" are special characters for ExpandPathName. When they are at the end
    // of the file name (see help) they must be removed before doing ExpandPathName.
-   fs1 = filenam;
    if (fs1.EndsWith("[")) {
       fs1.Replace((fs1.Length()-1),1," ");
-      fs2 = gSystem->ExpandPathName(fs1.Data());
-      fs2.Replace((fs2.Length()-1),1,"[");
+      gSystem->ExpandPathName(fs1);
+      fs1.Replace((fs1.Length()-1),1,"[");
    } else if (fs1.EndsWith("]")) {
       fs1.Replace((fs1.Length()-1),1," ");
-      fs2 = gSystem->ExpandPathName(fs1.Data());
-      fs2.Replace((fs2.Length()-1),1,"]");
+      gSystem->ExpandPathName(fs1);
+      fs1.Replace((fs1.Length()-1),1,"]");
    } else {
-      char* exppath = gSystem->ExpandPathName(fs1.Data());
-      fs2 = exppath;
-      delete [] exppath;
+      gSystem->ExpandPathName(fs1);
    }
-   filename = fs2.Data();
+   filename = fs1.Data();
 
    // Set the default option as "Postscript" (Should be a data member of TPad)
    const char *opt_default="ps";


### PR DESCRIPTION
One have to delete result of gSystem->ExpandPathName() function.
Or as in the patch - use other signature.
Little bit simplify the code