### PR TITLE
[Exp PyROOT][ROOT-10159] Revise check for IPython shell

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/__init__.py
@@ -60,10 +60,16 @@ def pythonization(lazy = True):
 for _, module_name, _ in  pkgutil.walk_packages(pyz.__path__):
     module = importlib.import_module(pyz.__name__ + '.' + module_name)
 
+# Check if we are in the IPython shell
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins # Py2
+_is_ipython = hasattr(builtins, '__IPYTHON__')
+
 # Configure ROOT facade module
 import sys
 from ._facade import ROOTFacade
-_is_ipython = hasattr(__builtins__, '__IPYTHON__') or 'IPython' in sys.modules
 sys.modules[__name__] = ROOTFacade(sys.modules[__name__], _is_ipython)
 
 # Configuration for usage from Jupyter notebooks

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_application.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_application.py
@@ -22,9 +22,11 @@ class PyROOTApplication(object):
     Configures the interactive usage of ROOT from Python.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, is_ipython):
         # Construct a TApplication for PyROOT
         InitApplication(config.IgnoreCommandLineOptions)
+
+        self._is_ipython = is_ipython
 
     @staticmethod
     def _ipython_config():
@@ -71,9 +73,7 @@ class PyROOTApplication(object):
     def init_graphics(self):
         """Configure ROOT graphics to be used interactively"""
 
-        is_ipython = hasattr(__builtins__, '__IPYTHON__') or 'IPython' in sys.modules
-
-        if is_ipython and 'IPython' in sys.modules and sys.modules['IPython'].version_info[0] >= 5:
+        if self._is_ipython and 'IPython' in sys.modules and sys.modules['IPython'].version_info[0] >= 5:
             self._ipython_config()
         else:
             self._inputhook_config()

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -132,7 +132,7 @@ class ROOTFacade(types.ModuleType):
 
     def _finalSetup(self):
         # Setup interactive usage from Python
-        self.__dict__['app'] = PyROOTApplication(self.PyConfig)
+        self.__dict__['app'] = PyROOTApplication(self.PyConfig, self._is_ipython)
         if not self.gROOT.IsBatch():
             self.app.init_graphics()
 


### PR DESCRIPTION
The new logic checks if we are in the IPython shell only via the
`builtins` module, thus eliminating the second condition check,
given that IPython can also be in `sys.modules` if it is imported
from the regular Python shell before importing ROOT.

Also, using the builtins module in Py3 should be done via
"import builtins" instead of `__builtins__`, since as explained here:

https://docs.python.org/3/library/builtins.html#module-builtins

`__builtins__` can be either the `builtins` module or its `__dict__`,
and in the latter case it does not have `'__IPYTHON__'` as attribute,
which causes the condition check for IPython to fail.