### PR TITLE
Deprecate TInterpreter::EnableAutoLoading.

### DIFF
--- a/README/ReleaseNotes/v620/index.md
+++ b/README/ReleaseNotes/v620/index.md
@@ -73,6 +73,7 @@ or in `TBrowser` by opening `Browser Help → About ROOT`.
    the warning will become a hard error in the next releases.
  * The empty headers `Gtypes.h` and `Htypes.h` are deprecated. Please include
    `Rtypes.h`
+ * TInterpreter::EnableAutoLoading currently does nothing and is deprecated.
 
 ### Deprecated packages
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1467,8 +1467,19 @@ void TCling::Initialize()
 {
    fClingCallbacks->Initialize();
 
-   // We are set up. EnableAutoLoading() is checking for fromRootCling.
-   EnableAutoLoading();
+   // We are set up. Enable ROOT's AutoLoading.
+   if (IsFromRootCling())
+      return;
+
+   // Read the rules before enabling the auto loading to not inadvertently
+   // load the libraries for the classes concerned even-though the user is
+   // *not* using them.
+   // Note this call must happen before the first call to LoadLibraryMap.
+   assert(GetRootMapFiles() == 0 && "Must be called before LoadLibraryMap!");
+   TClass::ReadRules(); // Read the default customization rules ...
+
+   LoadLibraryMap();
+   SetClassAutoloading(true);
 }
 
 void TCling::ShutDown()
@@ -2925,18 +2936,11 @@ bool TCling::Declare(const char* code)
 
 void TCling::EnableAutoLoading()
 {
-   if (IsFromRootCling())
-      return;
-
-   // Read the rules before enabling the auto loading to not inadvertently
-   // load the libraries for the classes concerned even-though the user is
-   // *not* using them.
-   // Note this call must happen before the first call to LoadLibraryMap.
-   assert(GetRootMapFiles() == 0 && "Must be called before LoadLibraryMap!");
-   TClass::ReadRules(); // Read the default customization rules ...
-
-   LoadLibraryMap();
-   SetClassAutoloading(true);
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,21,00)
+   Warning("EnableAutoLoading()", "Call to deprecated interface does nothing. Please remove the call.");
+#else
+# error "Remove this deprecated code"
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The EnableAutoLoading interface needs to know about the internal TCling implementation to safely enable the autoloading facility in ROOT. Calling this interface cannot be user responsibility as he/she should not know the initialization details of TCling.

Make this interface a nop and add a deprecation warning. This should resolve ROOT-10514 and ROOT-10528.