### PR TITLE
Fix "unknown pragma" warnings on Windows

### DIFF
--- a/tmva/tmva/src/DNN/Architectures/Cpu/Arithmetic.hxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/Arithmetic.hxx
@@ -22,12 +22,14 @@
 #include "TMVA/DNN/Architectures/Reference.h"
 #endif
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
 
 //#include "tbb/tbb.h"
 
 #pragma GCC diagnostic pop
+#endif
 
 namespace TMVA
 {


### PR DESCRIPTION
This fixes the following Warnings on Windows:
"C:\Users\bellenot\build\debug\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\Users\bellenot\build\debug\math\genetic\G__Genetic.vcxproj" (default target) (322) ->
"C:\Users\bellenot\build\debug\tmva\tmva\TMVA.vcxproj" (default target) (323) ->
  C:\Users\bellenot\git\master\tmva\tmva\src\DNN\Architectures\Cpu/Arithmetic.hxx(25,9): warning C4068: unknown pragma
[C:\Users\bellenot\build\debug\tmva\tmva\TMVA.vcxproj]
 C:\Users\bellenot\git\master\tmva\tmva\src\DNN\Architectures\Cpu/Arithmetic.hxx(26,9): warning C4068: unknown pragma
[C:\Users\bellenot\build\debug\tmva\tmva\TMVA.vcxproj]
  C:\Users\bellenot\git\master\tmva\tmva\src\DNN\Architectures\Cpu/Arithmetic.hxx(30,9): warning C4068: unknown pragma