### PR TITLE
TSystem interface improvements

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -202,14 +202,13 @@ struct ProcInfo_t {
 };
 
 struct RedirectHandle_t {
-   TString   fFile;        // File where the output was redirected
-   TString   fStdOutTty;   // tty associated with stdout, if any (e.g. from ttyname(...))
-   TString   fStdErrTty;   // tty associated with stderr, if any (e.g. from ttyname(...))
-   Int_t     fStdOutDup;   // Duplicated descriptor for stdout
-   Int_t     fStdErrDup;   // Duplicated descriptor for stderr
-   Int_t     fReadOffSet;  // Offset where to start reading the file (used by ShowOutput(...))
-   RedirectHandle_t(const char *n = 0) : fFile(n), fStdOutTty(), fStdErrTty(), fStdOutDup(-1),
-                                         fStdErrDup(-1), fReadOffSet(-1) { }
+   TString   fFile;            // File where the output was redirected
+   TString   fStdOutTty;       // tty associated with stdout, if any (e.g. from ttyname(...))
+   TString   fStdErrTty;       // tty associated with stderr, if any (e.g. from ttyname(...))
+   Int_t     fStdOutDup{-1};   // Duplicated descriptor for stdout
+   Int_t     fStdErrDup{-1};   // Duplicated descriptor for stderr
+   Int_t     fReadOffSet{-1};  // Offset where to start reading the file (used by ShowOutput(...))
+   RedirectHandle_t(const char *n = nullptr) : fFile(n) { }
    void Reset() { fFile = ""; fStdOutTty = ""; fStdErrTty = "";
                   fStdOutDup = -1; fStdErrDup = -1; fReadOffSet = -1; }
 };
@@ -324,8 +323,8 @@ protected:
    TString &GetLastErrorString();             //Last system error message (thread local).
    const TString &GetLastErrorString() const; //Last system error message (thread local).
 
-   TSystem               *FindHelper(const char *path, void *dirptr = 0);
-   virtual Bool_t         ConsistentWith(const char *path, void *dirptr = 0);
+   TSystem               *FindHelper(const char *path, void *dirptr = nullptr);
+   virtual Bool_t         ConsistentWith(const char *path, void *dirptr = nullptr);
    virtual const char    *ExpandFileName(const char *fname);
    virtual Bool_t         ExpandFileName(TString &fname);
    virtual void           SigAlarmInterruptsSyscalls(Bool_t) { }
@@ -418,20 +417,20 @@ public:
    virtual Bool_t          ChangeDirectory(const char *path);
    virtual const char     *WorkingDirectory();
    virtual std::string     GetWorkingDirectory() const;
-   virtual const char     *HomeDirectory(const char *userName = 0);
-   virtual std::string     GetHomeDirectory(const char *userName = 0) const;
+   virtual const char     *HomeDirectory(const char *userName = nullptr);
+   virtual std::string     GetHomeDirectory(const char *userName = nullptr) const;
    virtual int             mkdir(const char *name, Bool_t recursive = kFALSE);
    Bool_t                  cd(const char *path) { return ChangeDirectory(path); }
    const char             *pwd() { return WorkingDirectory(); }
    virtual const char     *TempDirectory() const;
-   virtual FILE           *TempFileName(TString &base, const char *dir = 0);
+   virtual FILE           *TempFileName(TString &base, const char *dir = nullptr);
 
    //---- Paths & Files
    virtual const char     *BaseName(const char *pathname);
    virtual const char     *DirName(const char *pathname);
    virtual char           *ConcatFileName(const char *dir, const char *name);
    virtual Bool_t          IsAbsoluteFileName(const char *dir);
-   virtual Bool_t          IsFileInIncludePath(const char *name, char **fullpath = 0);
+   virtual Bool_t          IsFileInIncludePath(const char *name, char **fullpath = nullptr);
    virtual const char     *PrependPathName(const char *dir, TString& name);
    virtual Bool_t          ExpandPathName(TString &path);
    virtual char           *ExpandPathName(const char *path);
@@ -455,14 +454,14 @@ public:
    virtual TList          *GetVolumes(Option_t *) const { return 0; }
 
    //---- Users & Groups
-   virtual Int_t           GetUid(const char *user = 0);
-   virtual Int_t           GetGid(const char *group = 0);
+   virtual Int_t           GetUid(const char *user = nullptr);
+   virtual Int_t           GetGid(const char *group = nullptr);
    virtual Int_t           GetEffectiveUid();
    virtual Int_t           GetEffectiveGid();
    virtual UserGroup_t    *GetUserInfo(Int_t uid);
-   virtual UserGroup_t    *GetUserInfo(const char *user = 0);
+   virtual UserGroup_t    *GetUserInfo(const char *user = nullptr);
    virtual UserGroup_t    *GetGroupInfo(Int_t gid);
-   virtual UserGroup_t    *GetGroupInfo(const char *group = 0);
+   virtual UserGroup_t    *GetGroupInfo(const char *group = nullptr);
 
    //---- Environment Manipulation
    virtual void            Setenv(const char *name, const char *value);
@@ -475,7 +474,7 @@ public:
    virtual void            Closelog();
 
    //---- Standard Output redirection
-   virtual Int_t           RedirectOutput(const char *name, const char *mode = "a", RedirectHandle_t *h = 0);
+   virtual Int_t           RedirectOutput(const char *name, const char *mode = "a", RedirectHandle_t *h = nullptr);
    virtual void            ShowOutput(RedirectHandle_t *h);
 
    //---- Dynamic Loading

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -274,52 +274,52 @@ public:
    };
 
 protected:
-   TFdSet          *fReadmask;         //!Files that should be checked for read events
-   TFdSet          *fWritemask;        //!Files that should be checked for write events
-   TFdSet          *fReadready;        //!Files with reads waiting
-   TFdSet          *fWriteready;       //!Files with writes waiting
-   TFdSet          *fSignals;          //!Signals that were trapped
-   Int_t            fNfd;              //Number of fd's in masks
-   Int_t            fMaxrfd;           //Largest fd in read mask
-   Int_t            fMaxwfd;           //Largest fd in write mask
-   Int_t            fSigcnt;           //Number of pending signals
-   TString          fWdpath;           //Working directory
-   TString          fHostname;         //Hostname
-   Bool_t           fInsideNotify;     //Used by DispatchTimers()
-   Int_t            fBeepFreq;         //Used by Beep()
-   Int_t            fBeepDuration;     //Used by Beep()
+   TFdSet          *fReadmask{nullptr};         //!Files that should be checked for read events
+   TFdSet          *fWritemask{nullptr};        //!Files that should be checked for write events
+   TFdSet          *fReadready{nullptr};        //!Files with reads waiting
+   TFdSet          *fWriteready{nullptr};       //!Files with writes waiting
+   TFdSet          *fSignals{nullptr};          //!Signals that were trapped
+   Int_t            fNfd{0};                    //Number of fd's in masks
+   Int_t            fMaxrfd{-1};                //Largest fd in read mask
+   Int_t            fMaxwfd{-1};                //Largest fd in write mask
+   Int_t            fSigcnt{0};                 //Number of pending signals
+   TString          fWdpath;                    //Working directory
+   TString          fHostname;                  //Hostname
+   Bool_t           fInsideNotify{kFALSE};      //Used by DispatchTimers()
+   Int_t            fBeepFreq{0};               //Used by Beep()
+   Int_t            fBeepDuration{0};           //Used by Beep()
 
-   Bool_t           fInControl;        //True if in eventloop
-   Bool_t           fDone;             //True if eventloop should be finished
-   Int_t            fLevel;            //Level of nested eventloops
+   Bool_t           fInControl{kFALSE};         //True if in eventloop
+   Bool_t           fDone{kFALSE};              //True if eventloop should be finished
+   Int_t            fLevel{0};                  //Level of nested eventloops
 
-   TSeqCollection  *fTimers;           //List of timers
-   TSeqCollection  *fSignalHandler;    //List of signal handlers
-   TSeqCollection  *fFileHandler;      //List of file handlers
-   TSeqCollection  *fStdExceptionHandler; //List of std::exception handlers
-   TSeqCollection  *fOnExitList;       //List of items to be cleaned-up on exit
+   TSeqCollection  *fTimers{nullptr};           //List of timers
+   TSeqCollection  *fSignalHandler{nullptr};    //List of signal handlers
+   TSeqCollection  *fFileHandler{nullptr};      //List of file handlers
+   TSeqCollection  *fStdExceptionHandler{nullptr}; //List of std::exception handlers
+   TSeqCollection  *fOnExitList{nullptr};       //List of items to be cleaned-up on exit
 
-   TString          fListLibs;         //List shared libraries, cache used by GetLibraries
+   TString          fListLibs;                  //List shared libraries, cache used by GetLibraries
 
-   TString          fBuildArch;        //Architecure for which ROOT was built (passed to ./configure)
-   TString          fBuildCompiler;    // Compiler used to build this ROOT
-   TString          fBuildCompilerVersion; //Compiler version used to build this ROOT
-   TString          fBuildNode;        //Detailed information where ROOT was built
-   TString          fBuildDir;         //Location where to build ACLiC shared library and use as scratch area.
-   TString          fFlagsDebug;       //Flags for debug compilation
-   TString          fFlagsOpt;         //Flags for optimized compilation
-   TString          fListPaths;        //List of all include (fIncludePath + interpreter include path). Cache used by GetIncludePath
-   TString          fIncludePath;      //Used to expand $IncludePath in the directives given to SetMakeSharedLib and SetMakeExe
-   TString          fLinkedLibs;       //Used to expand $LinkedLibs in the directives given to SetMakeSharedLib and SetMakeExe
-   TString          fSoExt;            //Extension of shared library (.so, .sl, .a, .dll, etc.)
-   TString          fObjExt;           //Extension of object files (.o, .obj, etc.)
-   EAclicMode       fAclicMode;        //Whether the compilation should be done debug or opt
-   TString          fMakeSharedLib;    //Directive used to build a shared library
-   TString          fMakeExe;          //Directive used to build an executable
-   TString          fLinkdefSuffix;    //Default suffix for linkdef files to be used by ACLiC (see EACLiCProperties)
-   Int_t            fAclicProperties;  //Various boolean flag for change ACLiC's behavior.
-   TSeqCollection  *fCompiled;         //List of shared libs from compiled macros to be deleted
-   TSeqCollection  *fHelpers;          //List of helper classes for alternative file/directory access
+   TString          fBuildArch;                 //Architecture for which ROOT was built (passed to ./configure)
+   TString          fBuildCompiler;             // Compiler used to build this ROOT
+   TString          fBuildCompilerVersion;      //Compiler version used to build this ROOT
+   TString          fBuildNode;                 //Detailed information where ROOT was built
+   TString          fBuildDir;                  //Location where to build ACLiC shared library and use as scratch area.
+   TString          fFlagsDebug;                //Flags for debug compilation
+   TString          fFlagsOpt;                  //Flags for optimized compilation
+   TString          fListPaths;                 //List of all include (fIncludePath + interpreter include path). Cache used by GetIncludePath
+   TString          fIncludePath;               //Used to expand $IncludePath in the directives given to SetMakeSharedLib and SetMakeExe
+   TString          fLinkedLibs;                //Used to expand $LinkedLibs in the directives given to SetMakeSharedLib and SetMakeExe
+   TString          fSoExt;                     //Extension of shared library (.so, .sl, .a, .dll, etc.)
+   TString          fObjExt;                    //Extension of object files (.o, .obj, etc.)
+   EAclicMode       fAclicMode{kDefault};       //Whether the compilation should be done debug or opt
+   TString          fMakeSharedLib;             //Directive used to build a shared library
+   TString          fMakeExe;                   //Directive used to build an executable
+   TString          fLinkdefSuffix;             //Default suffix for linkdef files to be used by ACLiC (see EACLiCProperties)
+   Int_t            fAclicProperties{0};        //Various boolean flag for change ACLiC's behavior.
+   TSeqCollection  *fCompiled{nullptr};         //List of shared libs from compiled macros to be deleted
+   TSeqCollection  *fHelpers{nullptr};          //List of helper classes for alternative file/directory access
 
    TString &GetLastErrorString();             //Last system error message (thread local).
    const TString &GetLastErrorString() const; //Last system error message (thread local).
@@ -337,8 +337,8 @@ protected:
    }
 
 private:
-   TSystem(const TSystem&);              // not implemented
-   TSystem& operator=(const TSystem&);   // not implemented
+   TSystem(const TSystem&) = delete;              // not implemented
+   TSystem& operator=(const TSystem&) = delete;   // not implemented
    Bool_t ExpandFileName(const char *fname, char *xname, const int kBufSize);
 
 public:

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -426,7 +426,7 @@ public:
    //---- Paths & Files
    virtual const char     *BaseName(const char *pathname);
    virtual const char     *DirName(const char *pathname);
-   virtual std::string     GetDirName(const char *pathname);
+   virtual TString         GetDirName(const char *pathname);
    virtual char           *ConcatFileName(const char *dir, const char *name);
    virtual Bool_t          IsAbsoluteFileName(const char *dir);
    virtual Bool_t          IsFileInIncludePath(const char *name, char **fullpath = nullptr);

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -331,9 +331,7 @@ protected:
    virtual const char    *GetLinkedLibraries();
    virtual void           DoBeep(Int_t /*freq*/=-1, Int_t /*duration*/=-1) const { printf("\a"); fflush(stdout); }
 
-   static const char *StripOffProto(const char *path, const char *proto) {
-      return !strncmp(path, proto, strlen(proto)) ? path + strlen(proto) : path;
-   }
+   static const char     *StripOffProto(const char *path, const char *proto);
 
 private:
    TSystem(const TSystem&) = delete;              // not implemented

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -32,7 +32,6 @@
 #endif
 
 #include "TNamed.h"
-#include "TString.h"
 #include "TInetAddress.h"
 #include "TTimer.h"
 #include "ThreadLocalStorage.h"
@@ -109,7 +108,7 @@ enum EFileModeMask {
    kS_IXGRP  = 00010,     // group has execute permission
    kS_IRWXO  = 00007,     // mask for permissions for others (not in group)
    kS_IROTH  = 00004,     // others have read permission
-   kS_IWOTH  = 00002,     // others have write permisson
+   kS_IWOTH  = 00002,     // others have write permission
    kS_IXOTH  = 00001      // others have execute permission
 };
 
@@ -269,7 +268,7 @@ class TSystem : public TNamed {
 public:
    enum EAclicMode { kDefault, kDebug, kOpt };
    enum EAclicProperties {
-      kFlatBuildDir = BIT(0)           // If set and a BuildDir is selected, then do not created subdirectories
+      kFlatBuildDir = BIT(0)           // If set and a BuildDir is selected, then do not created sub-directories
    };
 
 protected:
@@ -411,7 +410,7 @@ public:
    virtual void           *OpenDirectory(const char *name);
    virtual void            FreeDirectory(void *dirp);
    virtual const char     *GetDirEntry(void *dirp);
-   virtual void           *GetDirPtr() const { return 0; }
+   virtual void           *GetDirPtr() const { return nullptr; }
    virtual Bool_t          ChangeDirectory(const char *path);
    virtual const char     *WorkingDirectory();
    virtual std::string     GetWorkingDirectory() const;
@@ -521,7 +520,7 @@ public:
    //---- ACLiC (Automatic Compiler of Shared Library for CINT)
    virtual void            AddIncludePath(const char *includePath);
    virtual void            AddLinkedLibs(const char *linkedLib);
-   virtual int             CompileMacro(const char *filename, Option_t *opt="", const char* library_name = "", const char* build_dir = "", UInt_t dirmode = 0);
+   virtual int             CompileMacro(const char *filename, Option_t *opt = "", const char *library_name = "", const char *build_dir = "", UInt_t dirmode = 0);
    virtual Int_t           GetAclicProperties() const;
    virtual const char     *GetBuildArch() const;
    virtual const char     *GetBuildCompiler() const;

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -426,6 +426,7 @@ public:
    //---- Paths & Files
    virtual const char     *BaseName(const char *pathname);
    virtual const char     *DirName(const char *pathname);
+   virtual std::string     GetDirName(const char *pathname);
    virtual char           *ConcatFileName(const char *dir, const char *name);
    virtual Bool_t          IsAbsoluteFileName(const char *dir);
    virtual Bool_t          IsFileInIncludePath(const char *name, char **fullpath = nullptr);

--- a/core/base/src/TFileCollection.cxx
+++ b/core/base/src/TFileCollection.cxx
@@ -166,7 +166,7 @@ Int_t TFileCollection::Add(const char *dir)
 
    FileStat_t st;
    FileStat_t tmp;
-   TString baseDir = gSystem->DirName(dir);
+   TString baseDir = gSystem->GetDirName(dir);
    // if the 'dir' or its base dir exist
    if (gSystem->GetPathInfo(dir, st) == 0 ||
        gSystem->GetPathInfo(baseDir, tmp) == 0) {
@@ -180,11 +180,11 @@ Int_t TFileCollection::Add(const char *dir)
          Update();
          return nf;
       } else {
-         void *dataSetDir = gSystem->OpenDirectory(gSystem->DirName(dir));
+         void *dataSetDir = gSystem->OpenDirectory(gSystem->GetDirName(dir).Data());
          if (!dataSetDir) {
             // directory cannot be opened
             Error("Add", "directory %s cannot be opened",
-                  gSystem->DirName(dir));
+                  gSystem->GetDirName(dir).Data());
          } else {
             const char *ent;
             TString filesExp(TString("^") + gSystem->BaseName(dir) + "$");
@@ -194,7 +194,7 @@ Int_t TFileCollection::Add(const char *dir)
                TString entryString(ent);
                if (entryString.Index(rg) != kNPOS) {
                   // matching dir entry
-                  TString fn = gSystem->DirName(dir);
+                  TString fn = gSystem->GetDirName(dir);
                   fn += "/";
                   fn += ent;
                   gSystem->GetPathInfo(fn, st);

--- a/core/base/src/TRemoteObject.cxx
+++ b/core/base/src/TRemoteObject.cxx
@@ -162,7 +162,7 @@ TList *TRemoteObject::Browse()
             if (!strcmp(fname.Data(), "."))
                sdirpath = name;
             else if (!strcmp(fname.Data(), ".."))
-               sdirpath = gSystem->DirName(name);
+               sdirpath = gSystem->GetDirName(name);
             else {
                sdirpath =  name;
                if (!sdirpath.EndsWith("/"))

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -102,7 +102,7 @@ Bool_t TProcessEventTimer::ProcessEvents()
 
 ClassImp(TSystem);
 
-TVirtualMutex* gSystemMutex = 0;
+TVirtualMutex* gSystemMutex = nullptr;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a new OS interface.
@@ -159,7 +159,7 @@ TSystem::~TSystem()
    }
 
    if (gSystem == this)
-      gSystem = 0;
+      gSystem = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -279,7 +279,7 @@ void TSystem::ResetErrno()
 
 void TSystem::RemoveOnExit(TObject *obj)
 {
-   if (fOnExitList == 0)
+   if (!fOnExitList)
       fOnExitList = new TOrdCollection;
    if (fOnExitList->FindObject(obj) == 0)
       fOnExitList->Add(obj);
@@ -458,7 +458,7 @@ TTime TSystem::Now()
 
 void TSystem::AddTimer(TTimer *ti)
 {
-   if (ti && fTimers && (fTimers->FindObject(ti) == 0))
+   if (ti && fTimers && (fTimers->FindObject(ti) == nullptr))
       fTimers->Add(ti);
 }
 
@@ -472,7 +472,7 @@ TTimer *TSystem::RemoveTimer(TTimer *ti)
       TTimer *tr = (TTimer*) fTimers->Remove(ti);
       return tr;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -484,7 +484,7 @@ Long_t TSystem::NextTimeOut(Bool_t mode)
    if (!fTimers) return -1;
 
    TOrdCollectionIter it((TOrdCollection*)fTimers);
-   TTimer *t, *to = 0;
+   TTimer *t, *to = nullptr;
    Long64_t tt, tnow = Now();
    Long_t   timeout = -1;
 
@@ -519,7 +519,7 @@ Long_t TSystem::NextTimeOut(Bool_t mode)
 
 void TSystem::AddSignalHandler(TSignalHandler *h)
 {
-   if (h && fSignalHandler && (fSignalHandler->FindObject(h) == 0))
+   if (h && fSignalHandler && (fSignalHandler->FindObject(h) == nullptr))
       fSignalHandler->Add(h);
 }
 
@@ -532,7 +532,7 @@ TSignalHandler *TSystem::RemoveSignalHandler(TSignalHandler *h)
    if (fSignalHandler)
       return (TSignalHandler *)fSignalHandler->Remove(h);
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -554,7 +554,7 @@ TFileHandler *TSystem::RemoveFileHandler(TFileHandler *h)
    if (fFileHandler)
       return (TFileHandler *)fFileHandler->Remove(h);
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -611,7 +611,7 @@ TStdExceptionHandler *TSystem::RemoveStdExceptionHandler(TStdExceptionHandler *e
    if (fStdExceptionHandler)
       return (TStdExceptionHandler *)fStdExceptionHandler->Remove(eh);
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -650,7 +650,7 @@ int TSystem::Exec(const char*)
 FILE *TSystem::OpenPipe(const char*, const char*)
 {
    AbstractMethod("OpenPipe");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -740,7 +740,7 @@ TSystem *TSystem::FindHelper(const char *path, void *dirptr)
       if (!GetDirPtr()) {
          TUrl url(path, kTRUE);
          if (!strcmp(url.GetProtocol(), "file"))
-            return 0;
+            return nullptr;
       }
    }
 
@@ -751,7 +751,7 @@ TSystem *TSystem::FindHelper(const char *path, void *dirptr)
          return helper;
 
    if (!path)
-      return 0;
+      return nullptr;
 
    // create new helper
    TRegexp re("^root.*:");  // also roots, rootk, etc
@@ -760,12 +760,12 @@ TSystem *TSystem::FindHelper(const char *path, void *dirptr)
       // (x)rootd daemon ...
       if ((h = gROOT->GetPluginManager()->FindHandler("TSystem", path))) {
          if (h->LoadPlugin() == -1)
-            return 0;
+            return nullptr;
          helper = (TSystem*) h->ExecPlugin(2, path, kFALSE);
       }
    } else if ((h = gROOT->GetPluginManager()->FindHandler("TSystem", path))) {
       if (h->LoadPlugin() == -1)
-         return 0;
+         return nullptr;
       helper = (TSystem*) h->ExecPlugin(0);
    }
 
@@ -811,16 +811,16 @@ int TSystem::MakeDirectory(const char*)
 ////////////////////////////////////////////////////////////////////////////////
 /// Open a directory. Returns 0 if directory does not exist.
 
-void *TSystem::OpenDirectory(const char*)
+void *TSystem::OpenDirectory(const char *)
 {
    AbstractMethod("OpenDirectory");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Free a directory.
 
-void TSystem::FreeDirectory(void*)
+void TSystem::FreeDirectory(void *)
 {
    AbstractMethod("FreeDirectory");
 }
@@ -828,16 +828,16 @@ void TSystem::FreeDirectory(void*)
 ////////////////////////////////////////////////////////////////////////////////
 /// Get a directory entry. Returns 0 if no more entries.
 
-const char *TSystem::GetDirEntry(void*)
+const char *TSystem::GetDirEntry(void *)
 {
    AbstractMethod("GetDirEntry");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Change directory.
 
-Bool_t TSystem::ChangeDirectory(const char*)
+Bool_t TSystem::ChangeDirectory(const char *)
 {
    AbstractMethod("ChangeDirectory");
    return kFALSE;
@@ -848,7 +848,7 @@ Bool_t TSystem::ChangeDirectory(const char*)
 
 const char *TSystem::WorkingDirectory()
 {
-   return 0;
+   return  nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -862,9 +862,9 @@ std::string TSystem::GetWorkingDirectory() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the user's home directory.
 
-const char *TSystem::HomeDirectory(const char*)
+const char *TSystem::HomeDirectory(const char *)
 {
-   return 0;
+   return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -920,7 +920,7 @@ const char *TSystem::BaseName(const char *name)
       return name;
    }
    Error("BaseName", "name = 0");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1042,7 +1042,7 @@ char *TSystem::ConcatFileName(const char *dir, const char *name)
 const char *TSystem::PrependPathName(const char *, TString&)
 {
    AbstractMethod("PrependPathName");
-   return 0;
+   return nullptr;
 }
 
 
@@ -1245,7 +1245,7 @@ Bool_t TSystem::ExpandPathName(TString&)
 
 char *TSystem::ExpandPathName(const char *)
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1443,7 +1443,7 @@ int TSystem::GetFsInfo(const char *, Long_t *, Long_t *, Long_t *, Long_t *)
 const char *TSystem::TempDirectory() const
 {
    AbstractMethod("TempDirectory");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1458,7 +1458,7 @@ const char *TSystem::TempDirectory() const
 FILE *TSystem::TempFileName(TString &, const char *)
 {
    AbstractMethod("TempFileName");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1497,7 +1497,7 @@ int TSystem::Utime(const char *, Long_t, Long_t)
 const char *TSystem::FindFile(const char *, TString&, EAccessMode)
 {
    AbstractMethod("FindFile");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1508,7 +1508,8 @@ char *TSystem::Which(const char *search, const char *wfil, EAccessMode mode)
 {
    TString wfilString(wfil);
    FindFile(search, wfilString, mode);
-   if (wfilString.IsNull()) return 0;
+   if (wfilString.IsNull())
+      return nullptr;
    return StrDup(wfilString.Data());
 }
 
@@ -1559,7 +1560,7 @@ Int_t TSystem::GetEffectiveGid()
 UserGroup_t *TSystem::GetUserInfo(Int_t /*uid*/)
 {
    AbstractMethod("GetUserInfo");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1570,7 +1571,7 @@ UserGroup_t *TSystem::GetUserInfo(Int_t /*uid*/)
 UserGroup_t *TSystem::GetUserInfo(const char * /*user*/)
 {
    AbstractMethod("GetUserInfo");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1583,7 +1584,7 @@ UserGroup_t *TSystem::GetUserInfo(const char * /*user*/)
 UserGroup_t *TSystem::GetGroupInfo(Int_t /*gid*/)
 {
    AbstractMethod("GetGroupInfo");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1596,7 +1597,7 @@ UserGroup_t *TSystem::GetGroupInfo(Int_t /*gid*/)
 UserGroup_t *TSystem::GetGroupInfo(const char * /*group*/)
 {
    AbstractMethod("GetGroupInfo");
-   return 0;
+   return nullptr;
 }
 
 //---- environment manipulation ------------------------------------------------
@@ -1623,7 +1624,7 @@ void TSystem::Unsetenv(const char *name)
 const char *TSystem::Getenv(const char*)
 {
    AbstractMethod("Getenv");
-   return 0;
+   return nullptr;
 }
 
 //---- System Logging ----------------------------------------------------------
@@ -1695,7 +1696,7 @@ void TSystem::ShowOutput(RedirectHandle_t *h)
    }
 
    // Open the file
-   FILE *f = 0;
+   FILE *f = nullptr;
    if (!(f = fopen(h->fFile.Data(), "r"))) {
       Error("ShowOutput", "file '%s' cannot be open", h->fFile.Data());
       return;
@@ -1753,7 +1754,7 @@ void TSystem::AddDynamicPath(const char *)
 const char* TSystem::GetDynamicPath()
 {
    AbstractMethod("GetDynamicPath");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1993,7 +1994,7 @@ char *TSystem::DynamicPathName(const char *lib, Bool_t quiet /*=kFALSE*/)
    TString sLib(lib);
    if (FindDynamicLibrary(sLib, quiet))
       return StrDup(sLib);
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2005,7 +2006,7 @@ char *TSystem::DynamicPathName(const char *lib, Bool_t quiet /*=kFALSE*/)
 const char *TSystem::FindDynamicLibrary(TString&, Bool_t)
 {
    AbstractMethod("FindDynamicLibrary");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2341,7 +2342,7 @@ int TSystem::GetServiceByName(const char *)
 char *TSystem::GetServiceByPort(int)
 {
    AbstractMethod("GetServiceByPort");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3984,8 +3985,10 @@ const char *TSystem::GetObjExt() const
 void TSystem::SetBuildDir(const char* build_dir, Bool_t isflat)
 {
    fBuildDir = build_dir;
-   if (isflat) fAclicProperties |= (kFlatBuildDir & kBitMask);
-   else fAclicProperties &= ~(kFlatBuildDir & kBitMask);
+   if (isflat)
+      fAclicProperties |= (kFlatBuildDir & kBitMask);
+   else
+      fAclicProperties &= ~(kFlatBuildDir & kBitMask);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4210,37 +4213,37 @@ TString TSystem::SplitAclicMode(const char* filename, TString &aclicMode,
       bool inString = false;
       Ssiz_t posArgBegin = posArgEnd - 1;
       for (; parenNestCount && posArgBegin >= 0; --posArgBegin) {
-	 // Escaped if the previous character is a `\` - but not if it
-	 // itself is preceded by a `\`!
-	 if (posArgBegin > 0 && filenameCopy[posArgBegin] == '\\' &&
-	     (posArgBegin == 1 || filenameCopy[posArgBegin - 1] != '\\')) {
-	    // skip escape.
-	    --posArgBegin;
-	    continue;
-	 }
-	 switch (filenameCopy[posArgBegin]) {
-	 case ')':
-	    if (!inString)
-	       ++parenNestCount;
-	    break;
-	 case '(':
-	    if (!inString)
-	       --parenNestCount;
-	    break;
-	 case '"': inString = !inString; break;
-	 }
+         // Escaped if the previous character is a `\` - but not if it
+         // itself is preceded by a `\`!
+         if (posArgBegin > 0 && filenameCopy[posArgBegin] == '\\' &&
+             (posArgBegin == 1 || filenameCopy[posArgBegin - 1] != '\\')) {
+            // skip escape.
+            --posArgBegin;
+            continue;
+         }
+         switch (filenameCopy[posArgBegin]) {
+         case ')':
+            if (!inString)
+               ++parenNestCount;
+            break;
+         case '(':
+            if (!inString)
+               --parenNestCount;
+            break;
+         case '"': inString = !inString; break;
+         }
       }
       if (parenNestCount || inString) {
-	 Error("SplitAclicMode", "Cannot parse argument in %s", filename);
+         Error("SplitAclicMode", "Cannot parse argument in %s", filename);
       } else {
-	 arguments = filenameCopy(posArgBegin + 1, posArgEnd - 1);
-	 fname[posArgBegin + 1] = 0;
+         arguments = filenameCopy(posArgBegin + 1, posArgEnd - 1);
+         fname[posArgBegin + 1] = 0;
       }
    }
 
    // strip off I/O redirect tokens from filename
    {
-      char *s2   = 0;
+      char *s2   = nullptr;
       char *s3;
       s2 = strstr(fname, ">>");
       if (!s2) s2 = strstr(fname, "2>");

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -1026,6 +1026,40 @@ const char *TSystem::DirName(const char *pathname)
    return ".";
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return the directory name in pathname.
+/// DirName of /user/root is /user.
+/// DirName of /user/root/ is also /user.
+/// In case no dirname is specified "." is returned.
+
+std::string TSystem::GetDirName(const char *pathname)
+{
+   if (!pathname || !strchr(pathname, '/'))
+      return ".";
+
+   auto pathlen = strlen(pathname);
+
+   const char *r = pathname + pathlen - 1;
+   // First skip the trailing '/'
+   while ((r > pathname) && (*r == '/'))
+      --r;
+   // Then find the next non slash
+   while ((r > pathname) && (*r != '/'))
+      --r;
+
+   // Then skip duplicate slashes
+   // Note the 'r>buf' is a strict comparison to allows '/topdir' to return '/'
+   while ((r > pathname) && (*r == '/'))
+      --r;
+   // If all was cut away, we encountered a rel. path like 'subdir/'
+   // and ended up at '.'.
+   if ((r == pathname) && (*r != '/'))
+      return ".";
+
+   return std::string(pathname, r + 1 - pathname);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Convert from a local pathname to a Unix pathname. E.g. from `\user\root` to
 /// `/user/root`.

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -30,13 +30,10 @@ allows a simple partial implementation for new OS'es.
 #include "TClass.h"
 #include "TClassTable.h"
 #include "TEnv.h"
-#include "TBrowser.h"
-#include "TString.h"
 #include "TOrdCollection.h"
 #include "TObject.h"
 #include "TInterpreter.h"
 #include "TRegexp.h"
-#include "TTimer.h"
 #include "TObjString.h"
 #include "TError.h"
 #include "TPluginManager.h"
@@ -290,7 +287,7 @@ void TSystem::RemoveOnExit(TObject *obj)
 {
    if (!fOnExitList)
       fOnExitList = new TOrdCollection;
-   if (fOnExitList->FindObject(obj) == 0)
+   if (!fOnExitList->FindObject(obj))
       fOnExitList->Add(obj);
 }
 
@@ -550,7 +547,7 @@ TSignalHandler *TSystem::RemoveSignalHandler(TSignalHandler *h)
 
 void TSystem::AddFileHandler(TFileHandler *h)
 {
-   if (h && fFileHandler && (fFileHandler->FindObject(h) == 0))
+   if (h && fFileHandler && !fFileHandler->FindObject(h))
       fFileHandler->Add(h);
 }
 
@@ -607,7 +604,7 @@ void TSystem::IgnoreInterrupt(Bool_t ignore)
 
 void TSystem::AddStdExceptionHandler(TStdExceptionHandler *eh)
 {
-   if (eh && fStdExceptionHandler && (fStdExceptionHandler->FindObject(eh) == 0))
+   if (eh && fStdExceptionHandler && !fStdExceptionHandler->FindObject(eh))
       fStdExceptionHandler->Add(eh);
 }
 
@@ -744,7 +741,7 @@ TSystem *TSystem::FindHelper(const char *path, void *dirptr)
       fHelpers = new TOrdCollection;
 
    TPluginHandler *h;
-   TSystem *helper = 0;
+   TSystem *helper = nullptr;
    if (path) {
       if (!GetDirPtr()) {
          TUrl url(path, kTRUE);
@@ -2894,9 +2891,9 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
       if (strchr(opt,'c')!=0) {
          loadLib = kFALSE;
       }
-      withInfo = strchr(opt, 's') == 0;
-      verbose = strchr(opt, 'v') != 0;
-      internalDebug = strchr(opt, 'd') != 0;
+      withInfo = strchr(opt, 's') == nullptr;
+      verbose = strchr(opt, 'v') != nullptr;
+      internalDebug = strchr(opt, 'd') != nullptr;
    }
    if (mode==kDefault) {
       TString rootbuild = ROOTBUILD;

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -209,7 +209,6 @@ Bool_t TSystem::Init()
 void TSystem::SetProgname(const char *name)
 {
    delete [] gProgName;
-
    gProgName = StrDup(name);
 }
 

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -107,34 +107,10 @@ TVirtualMutex* gSystemMutex = 0;
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a new OS interface.
 
-TSystem::TSystem(const char *name, const char *title) : TNamed(name, title), fAclicProperties(0)
+TSystem::TSystem(const char *name, const char *title) : TNamed(name, title)
 {
    if (gSystem && name[0] != '-' && strcmp(name, "Generic"))
       Error("TSystem", "only one instance of TSystem allowed");
-
-   fOnExitList          = 0;
-   fSignalHandler       = 0;
-   fFileHandler         = 0;
-   fStdExceptionHandler = 0;
-   fTimers              = 0;
-   fCompiled            = 0;
-   fHelpers             = 0;
-   fInsideNotify        = kFALSE;
-   fBeepDuration        = 0;
-   fBeepFreq            = 0;
-   fReadmask            = 0;
-   fWritemask           = 0;
-   fReadready           = 0;
-   fWriteready          = 0;
-   fSignals             = 0;
-   fDone                = kFALSE;
-   fAclicMode           = kDefault;
-   fInControl           = kFALSE;
-   fLevel               = 0;
-   fMaxrfd              = -1;
-   fMaxwfd              = -1;
-   fNfd                 = 0;
-   fSigcnt              = 0;
 
    if (!gLibraryVersion) {
       gLibraryVersion = new Int_t [gLibraryVersionMax];

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -104,6 +104,16 @@ ClassImp(TSystem);
 
 TVirtualMutex* gSystemMutex = nullptr;
 
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Strip off protocol string from specified path
+
+const char *TSystem::StripOffProto(const char *path, const char *proto)
+{
+   return !strncmp(path, proto, strlen(proto)) ? path + strlen(proto) : path;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a new OS interface.
 

--- a/core/base/src/TSystemDirectory.cxx
+++ b/core/base/src/TSystemDirectory.cxx
@@ -95,7 +95,7 @@ TList *TSystemDirectory::GetListOfFiles() const
          if (file[0] == '.' && file[1] == '\0')
             sdirpath = GetTitle();
          else if (file[0] == '.' && file[1] == '.' && file[2] == '.')
-            sdirpath = gSystem->DirName(GetTitle());
+            sdirpath = gSystem->GetDirName(GetTitle());
          else {
             sdirpath = GetTitle();
             if (!sdirpath.EndsWith("/"))
@@ -172,7 +172,7 @@ void TSystemDirectory::Browse(TBrowser *b)
          if (!strcmp(file, "."))
             sdirpath = name;
          else if (!strcmp(file, ".."))
-            sdirpath = gSystem->DirName(name);
+            sdirpath = gSystem->GetDirName(name);
          else {
             sdirpath =  name;
             if (!sdirpath.EndsWith("/"))

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -761,14 +761,14 @@ int TCling_GenerateDictionary(const std::vector<std::string> &classes,
       for (it = unknown.begin(); it != unknown.end(); ++it) {
          TClass* cl = TClass::GetClass(it->c_str());
          if (cl && cl->GetDeclFileName()) {
-            TString header(gSystem->BaseName(cl->GetDeclFileName()));
-            TString dir(gSystem->DirName(cl->GetDeclFileName()));
+            TString header = gSystem->BaseName(cl->GetDeclFileName());
+            TString dir = gSystem->GetDirName(cl->GetDeclFileName());
             TString dirbase(gSystem->BaseName(dir));
             while (dirbase.Length() && dirbase != "."
                    && dirbase != "include" && dirbase != "inc"
                    && dirbase != "prec_stl") {
                gSystem->PrependPathName(dirbase, header);
-               dir = gSystem->DirName(dir);
+               dir = gSystem->GetDirName(dir);
             }
             fileContent += TString("#include \"") + header + "\"\n";
          }

--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -1486,16 +1486,15 @@ TString TTabCom::DeterminePath(const TString & fileName,
       gSystem->ExpandPathName(path);
       Int_t end = path.Length()-1;
       if (end>0 && path[end]!='/' && path[end]!='\\') {
-         path = gSystem->DirName(path);
+         path = gSystem->GetDirName(path);
       }
       return path;
    } else {
-      TString newBase;
-      TString extendedPath;
+      TString newBase, extendedPath;
       if (fileName.Contains("/")) {
          Int_t end = fileName.Length()-1;
          if (fileName[end] != '/' && fileName[end] != '\\') {
-            newBase = gSystem->DirName(fileName);
+            newBase = gSystem->GetDirName(fileName);
          } else {
             newBase = fileName;
          }

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -34,8 +34,8 @@ private:
    void FillWithCwd(char *cwd) const;
 
 protected:
-   const char    *FindDynamicLibrary(TString &lib, Bool_t quiet = kFALSE);
-   const char    *GetLinkedLibraries();
+   const char    *FindDynamicLibrary(TString &lib, Bool_t quiet = kFALSE) override;
+   const char    *GetLinkedLibraries() override;
 
    // static functions providing semi-low level interface to raw Unix
    static int          UnixMakedir(const char *name);
@@ -74,146 +74,146 @@ public:
    virtual ~TUnixSystem();
 
    //---- Misc -------------------------------------------------
-   Bool_t            Init();
-   void              SetProgname(const char *name);
-   void              SetDisplay();
-   const char       *GetError();
-   const char       *HostName();
+   Bool_t            Init() override;
+   void              SetProgname(const char *name) override;
+   void              SetDisplay() override;
+   const char       *GetError() override;
+   const char       *HostName() override;
 
    //---- EventLoop --------------------------------------------
-   void              DispatchOneEvent(Bool_t pendingOnly = kFALSE);
-   Int_t             Select(TList *active, Long_t timeout);
-   Int_t             Select(TFileHandler *fh, Long_t timeout);
+   void              DispatchOneEvent(Bool_t pendingOnly = kFALSE) override;
+   Int_t             Select(TList *active, Long_t timeout) override;
+   Int_t             Select(TFileHandler *fh, Long_t timeout) override;
 
    //---- Handling of system events ----------------------------
    void              CheckChilds();
    Bool_t            CheckSignals(Bool_t sync);
    Bool_t            CheckDescriptors();
    void              DispatchSignals(ESignals sig);
-   void              AddSignalHandler(TSignalHandler *sh);
-   TSignalHandler   *RemoveSignalHandler(TSignalHandler *sh);
-   void              ResetSignal(ESignals sig, Bool_t reset = kTRUE);
-   void              ResetSignals();
-   void              IgnoreSignal(ESignals sig, Bool_t ignore = kTRUE);
-   void              SigAlarmInterruptsSyscalls(Bool_t set);
-   void              AddFileHandler(TFileHandler *fh);
-   TFileHandler     *RemoveFileHandler(TFileHandler *fh);
+   void              AddSignalHandler(TSignalHandler *sh) override;
+   TSignalHandler   *RemoveSignalHandler(TSignalHandler *sh) override;
+   void              ResetSignal(ESignals sig, Bool_t reset = kTRUE) override;
+   void              ResetSignals() override;
+   void              IgnoreSignal(ESignals sig, Bool_t ignore = kTRUE) override;
+   void              SigAlarmInterruptsSyscalls(Bool_t set) override;
+   void              AddFileHandler(TFileHandler *fh) override;
+   TFileHandler     *RemoveFileHandler(TFileHandler *fh) override;
 
    //---- Floating Point Exceptions Control --------------------
-   Int_t             GetFPEMask();
-   Int_t             SetFPEMask(Int_t mask = kDefaultMask);
+   Int_t             GetFPEMask() override;
+   Int_t             SetFPEMask(Int_t mask = kDefaultMask) override;
 
    //---- Time & Date ------------------------------------------
-   TTime             Now();
-   void              AddTimer(TTimer *ti);
-   TTimer           *RemoveTimer(TTimer *ti);
-   void              ResetTimer(TTimer *ti);
+   TTime             Now() override;
+   void              AddTimer(TTimer *ti) override;
+   TTimer           *RemoveTimer(TTimer *ti) override;
+   void              ResetTimer(TTimer *ti) override;
    Bool_t            DispatchTimers(Bool_t mode);
-   void              Sleep(UInt_t milliSec);
+   void              Sleep(UInt_t milliSec) override;
 
    //---- Processes --------------------------------------------
-   Int_t             Exec(const char *shellcmd);
-   FILE             *OpenPipe(const char *shellcmd, const char *mode);
-   int               ClosePipe(FILE *pipe);
-   void              Exit(int code, Bool_t mode = kTRUE);
-   void              Abort(int code = 0);
-   int               GetPid();
-   void              StackTrace();
+   Int_t             Exec(const char *shellcmd) override;
+   FILE             *OpenPipe(const char *shellcmd, const char *mode) override;
+   int               ClosePipe(FILE *pipe) override;
+   void              Exit(int code, Bool_t mode = kTRUE) override;
+   void              Abort(int code = 0) override;
+   int               GetPid() override;
+   void              StackTrace() override;
 
    //---- Directories ------------------------------------------
-   int               MakeDirectory(const char *name);
-   void             *OpenDirectory(const char *name);
-   void              FreeDirectory(void *dirp);
-   const char       *GetDirEntry(void *dirp);
-   Bool_t            ChangeDirectory(const char *path);
-   const char       *WorkingDirectory();
-   std::string       GetWorkingDirectory() const;
-   const char       *HomeDirectory(const char *userName = 0);
-   std::string       GetHomeDirectory(const char *userName = 0) const;
-   const char       *TempDirectory() const;
-   FILE             *TempFileName(TString &base, const char *dir = 0);
+   int               MakeDirectory(const char *name) override;
+   void             *OpenDirectory(const char *name) override;
+   void              FreeDirectory(void *dirp) override;
+   const char       *GetDirEntry(void *dirp) override;
+   Bool_t            ChangeDirectory(const char *path) override;
+   const char       *WorkingDirectory() override;
+   std::string       GetWorkingDirectory() const override;
+   const char       *HomeDirectory(const char *userName = 0) override;
+   std::string       GetHomeDirectory(const char *userName = 0) const override;
+   const char       *TempDirectory() const override;
+   FILE             *TempFileName(TString &base, const char *dir = 0) override;
 
    //---- Paths & Files ----------------------------------------
-   const char       *PrependPathName(const char *dir, TString& name);
-   Bool_t            ExpandPathName(TString &patbuf);
-   char             *ExpandPathName(const char *path);
-   Bool_t            AccessPathName(const char *path, EAccessMode mode = kFileExists);
-   Bool_t            IsPathLocal(const char *path);
-   int               CopyFile(const char *from, const char *to, Bool_t overwrite = kFALSE);
-   int               Rename(const char *from, const char *to);
-   int               Link(const char *from, const char *to);
-   int               Symlink(const char *from, const char *to);
-   int               Unlink(const char *name);
-   int               GetPathInfo(const char *path, FileStat_t &buf);
+   const char       *PrependPathName(const char *dir, TString& name) override;
+   Bool_t            ExpandPathName(TString &patbuf) override;
+   char             *ExpandPathName(const char *path) override;
+   Bool_t            AccessPathName(const char *path, EAccessMode mode = kFileExists) override;
+   Bool_t            IsPathLocal(const char *path) override;
+   int               CopyFile(const char *from, const char *to, Bool_t overwrite = kFALSE) override;
+   int               Rename(const char *from, const char *to) override;
+   int               Link(const char *from, const char *to) override;
+   int               Symlink(const char *from, const char *to) override;
+   int               Unlink(const char *name) override;
+   int               GetPathInfo(const char *path, FileStat_t &buf) override;
    int               GetFsInfo(const char *path, Long_t *id, Long_t *bsize,
-                               Long_t *blocks, Long_t *bfree);
-   int               Chmod(const char *file, UInt_t mode);
-   int               Umask(Int_t mask);
-   int               Utime(const char *file, Long_t modtime, Long_t actime);
-   const char       *FindFile(const char *search, TString& file, EAccessMode mode = kFileExists);
+                               Long_t *blocks, Long_t *bfree) override;
+   int               Chmod(const char *file, UInt_t mode) override;
+   int               Umask(Int_t mask) override;
+   int               Utime(const char *file, Long_t modtime, Long_t actime) override;
+   const char       *FindFile(const char *search, TString& file, EAccessMode mode = kFileExists) override;
 
    //---- Users & Groups ---------------------------------------
-   Int_t             GetUid(const char *user = 0);
-   Int_t             GetGid(const char *group = 0);
-   Int_t             GetEffectiveUid();
-   Int_t             GetEffectiveGid();
-   UserGroup_t      *GetUserInfo(Int_t uid);
-   UserGroup_t      *GetUserInfo(const char *user = 0);
-   UserGroup_t      *GetGroupInfo(Int_t gid);
-   UserGroup_t      *GetGroupInfo(const char *group = 0);
+   Int_t             GetUid(const char *user = 0) override;
+   Int_t             GetGid(const char *group = 0) override;
+   Int_t             GetEffectiveUid() override;
+   Int_t             GetEffectiveGid() override;
+   UserGroup_t      *GetUserInfo(Int_t uid) override;
+   UserGroup_t      *GetUserInfo(const char *user = 0) override;
+   UserGroup_t      *GetGroupInfo(Int_t gid) override;
+   UserGroup_t      *GetGroupInfo(const char *group = 0) override;
 
    //---- Environment Manipulation -----------------------------
-   const char       *Getenv(const char *name);
-   void              Setenv(const char *name, const char *value);
-   void              Unsetenv(const char *name);
+   const char       *Getenv(const char *name) override;
+   void              Setenv(const char *name, const char *value) override;
+   void              Unsetenv(const char *name) override;
 
    //---- System Logging ---------------------------------------
-   void              Openlog(const char *name, Int_t options, ELogFacility facility);
-   void              Syslog(ELogLevel level, const char *mess);
-   void              Closelog();
+   void              Openlog(const char *name, Int_t options, ELogFacility facility) override;
+   void              Syslog(ELogLevel level, const char *mess) override;
+   void              Closelog() override;
 
    //---- Standard Output redirection --------------------------
    Int_t             RedirectOutput(const char *name, const char *mode = "a",
-                                    RedirectHandle_t *h = 0);
+                                    RedirectHandle_t *h = 0) override;
 
    //---- Dynamic Loading --------------------------------------
-   void              AddDynamicPath(const char *lib);
-   const char       *GetDynamicPath();
-   void              SetDynamicPath(const char *lib);
-   Func_t            DynFindSymbol(const char *module, const char *entry);
-   int               Load(const char *module, const char *entry = "", Bool_t system = kFALSE);
-   void              Unload(const char *module);
-   void              ListSymbols(const char *module, const char *re = "");
-   void              ListLibraries(const char *regexp = "");
+   void              AddDynamicPath(const char *lib) override;
+   const char       *GetDynamicPath() override;
+   void              SetDynamicPath(const char *lib) override;
+   Func_t            DynFindSymbol(const char *module, const char *entry) override;
+   int               Load(const char *module, const char *entry = "", Bool_t system = kFALSE) override;
+   void              Unload(const char *module) override;
+   void              ListSymbols(const char *module, const char *re = "") override;
+   void              ListLibraries(const char *regexp = "") override;
 
    //---- RPC --------------------------------------------------
-   TInetAddress      GetHostByName(const char *server);
-   TInetAddress      GetPeerName(int sock);
-   TInetAddress      GetSockName(int sock);
-   int               GetServiceByName(const char *service);
-   char             *GetServiceByPort(int port);
+   TInetAddress      GetHostByName(const char *server) override;
+   TInetAddress      GetPeerName(int sock) override;
+   TInetAddress      GetSockName(int sock) override;
+   int               GetServiceByName(const char *service) override;
+   char             *GetServiceByPort(int port) override;
    int               ConnectService(const char *server, int port, int tcpwindowsize, const char *protocol = "tcp");
-   int               OpenConnection(const char *server, int port, int tcpwindowsize = -1, const char *protocol = "tcp");
-   int               AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1);
-   int               AnnounceUdpService(int port, int backlog);
-   int               AnnounceUnixService(int port, int backlog);
-   int               AnnounceUnixService(const char *sockpath, int backlog);
-   int               AcceptConnection(int sock);
-   void              CloseConnection(int sock, Bool_t force = kFALSE);
-   int               RecvRaw(int sock, void *buffer, int length, int flag);
-   int               SendRaw(int sock, const void *buffer, int length, int flag);
-   int               RecvBuf(int sock, void *buffer, int length);
-   int               SendBuf(int sock, const void *buffer, int length);
-   int               SetSockOpt(int sock, int option, int val);
-   int               GetSockOpt(int sock, int option, int *val);
+   int               OpenConnection(const char *server, int port, int tcpwindowsize = -1, const char *protocol = "tcp") override;
+   int               AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1) override;
+   int               AnnounceUdpService(int port, int backlog) override;
+   int               AnnounceUnixService(int port, int backlog) override;
+   int               AnnounceUnixService(const char *sockpath, int backlog) override;
+   int               AcceptConnection(int sock) override;
+   void              CloseConnection(int sock, Bool_t force = kFALSE) override;
+   int               RecvRaw(int sock, void *buffer, int length, int flag) override;
+   int               SendRaw(int sock, const void *buffer, int length, int flag) override;
+   int               RecvBuf(int sock, void *buffer, int length) override;
+   int               SendBuf(int sock, const void *buffer, int length) override;
+   int               SetSockOpt(int sock, int option, int val) override;
+   int               GetSockOpt(int sock, int option, int *val) override;
 
    //---- System, CPU and Memory info
-   int               GetSysInfo(SysInfo_t *info) const;
-   int               GetCpuInfo(CpuInfo_t *info, Int_t sampleTime = 1000) const;
-   int               GetMemInfo(MemInfo_t *info) const;
-   int               GetProcInfo(ProcInfo_t *info) const;
+   int               GetSysInfo(SysInfo_t *info) const override;
+   int               GetCpuInfo(CpuInfo_t *info, Int_t sampleTime = 1000) const override;
+   int               GetMemInfo(MemInfo_t *info) const override;
+   int               GetProcInfo(ProcInfo_t *info) const override;
 
-   ClassDef(TUnixSystem,0)  //Interface to Unix OS services
+   ClassDefOverride(TUnixSystem,0)  //Interface to Unix OS services
 };
 
 #endif

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -40,7 +40,7 @@ protected:
    static int          UnixMakedir(const char *name);
    static void        *UnixOpendir(const char *name);
    static const char  *UnixGetdirentry(void *dir);
-   static const char  *UnixHomedirectory(const char *user = 0);
+   static const char  *UnixHomedirectory(const char *user = nullptr);
    static const char  *UnixHomedirectory(const char *user, char *path, char *mydir);
    static Long64_t     UnixNow();
    static int          UnixWaitchild();
@@ -127,10 +127,10 @@ public:
    Bool_t            ChangeDirectory(const char *path) override;
    const char       *WorkingDirectory() override;
    std::string       GetWorkingDirectory() const override;
-   const char       *HomeDirectory(const char *userName = 0) override;
-   std::string       GetHomeDirectory(const char *userName = 0) const override;
+   const char       *HomeDirectory(const char *userName = nullptr) override;
+   std::string       GetHomeDirectory(const char *userName = nullptr) const override;
    const char       *TempDirectory() const override;
-   FILE             *TempFileName(TString &base, const char *dir = 0) override;
+   FILE             *TempFileName(TString &base, const char *dir = nullptr) override;
 
    //---- Paths & Files ----------------------------------------
    const char       *PrependPathName(const char *dir, TString& name) override;
@@ -152,14 +152,14 @@ public:
    const char       *FindFile(const char *search, TString& file, EAccessMode mode = kFileExists) override;
 
    //---- Users & Groups ---------------------------------------
-   Int_t             GetUid(const char *user = 0) override;
-   Int_t             GetGid(const char *group = 0) override;
+   Int_t             GetUid(const char *user = nullptr) override;
+   Int_t             GetGid(const char *group = nullptr) override;
    Int_t             GetEffectiveUid() override;
    Int_t             GetEffectiveGid() override;
    UserGroup_t      *GetUserInfo(Int_t uid) override;
-   UserGroup_t      *GetUserInfo(const char *user = 0) override;
+   UserGroup_t      *GetUserInfo(const char *user = nullptr) override;
    UserGroup_t      *GetGroupInfo(Int_t gid) override;
-   UserGroup_t      *GetGroupInfo(const char *group = 0) override;
+   UserGroup_t      *GetGroupInfo(const char *group = nullptr) override;
 
    //---- Environment Manipulation -----------------------------
    const char       *Getenv(const char *name) override;
@@ -173,7 +173,7 @@ public:
 
    //---- Standard Output redirection --------------------------
    Int_t             RedirectOutput(const char *name, const char *mode = "a",
-                                    RedirectHandle_t *h = 0) override;
+                                    RedirectHandle_t *h = nullptr) override;
 
    //---- Dynamic Loading --------------------------------------
    void              AddDynamicPath(const char *lib) override;

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -34,7 +34,6 @@ private:
    void FillWithCwd(char *cwd) const;
 
 protected:
-   const char    *FindDynamicLibrary(TString &lib, Bool_t quiet = kFALSE) override;
    const char    *GetLinkedLibraries() override;
 
    // static functions providing semi-low level interface to raw Unix
@@ -180,6 +179,7 @@ public:
    void              AddDynamicPath(const char *lib) override;
    const char       *GetDynamicPath() override;
    void              SetDynamicPath(const char *lib) override;
+   const char       *FindDynamicLibrary(TString &lib, Bool_t quiet = kFALSE) override;
    Func_t            DynFindSymbol(const char *module, const char *entry) override;
    int               Load(const char *module, const char *entry = "", Bool_t system = kFALSE) override;
    void              Unload(const char *module) override;

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -464,8 +464,8 @@ static void SetRootSys()
          if (!gSystem->Getenv("ROOTSYS"))
             ::SysError("TUnixSystem::SetRootSys", "error getting realpath of libCore, please set ROOTSYS in the shell");
       } else {
-         TString rs = gSystem->DirName(respath);
-         gSystem->Setenv("ROOTSYS", gSystem->DirName(rs));
+         TString rs = gSystem->GetDirName(respath);
+         gSystem->Setenv("ROOTSYS", gSystem->GetDirName(rs.Data()).Data());
       }
    }
 #ifdef ROOTPREFIX
@@ -507,8 +507,8 @@ static void DylibAdded(const struct mach_header *mh, intptr_t /* vmaddr_slide */
          if (!gSystem->Getenv("ROOTSYS"))
             ::SysError("TUnixSystem::DylibAdded", "error getting realpath of libCore, please set ROOTSYS in the shell");
       } else {
-         TString rs = gSystem->DirName(respath);
-         gSystem->Setenv("ROOTSYS", gSystem->DirName(rs));
+         TString rs = gSystem->GetDirName(respath);
+         gSystem->Setenv("ROOTSYS", gSystem->GetDirName(rs.Data()).Data());
       }
    }
 #ifdef ROOTPREFIX

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -291,7 +291,7 @@ struct TUtmpContent {
             return ue;
          ue++;
       }
-      return 0;
+      return nullptr;
    }
 
    int ReadUtmpFile()
@@ -760,7 +760,7 @@ void TUnixSystem::AddFileHandler(TFileHandler *h)
 
 TFileHandler *TUnixSystem::RemoveFileHandler(TFileHandler *h)
 {
-   if (!h) return 0;
+   if (!h) return nullptr;
 
    R__LOCKGUARD2(gSystemMutex);
 
@@ -805,7 +805,7 @@ void TUnixSystem::AddSignalHandler(TSignalHandler *h)
 
 TSignalHandler *TUnixSystem::RemoveSignalHandler(TSignalHandler *h)
 {
-   if (!h) return 0;
+   if (!h) return nullptr;
 
    R__LOCKGUARD2(gSystemMutex);
 
@@ -1382,7 +1382,7 @@ const char *TUnixSystem::GetDirEntry(void *dirp)
    if (dirp)
       return UnixGetdirentry(dirp);
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1489,10 +1489,10 @@ FILE *TUnixSystem::TempFileName(TString &base, const char *dir)
 
    if (fd == -1) {
       SysError("TempFileName", "%s", base.Data());
-      return 0;
+      return nullptr;
    } else {
       FILE *fp = fdopen(fd, "w+");
-      if (fp == 0)
+      if (!fp)
          SysError("TempFileName", "converting filedescriptor (%d)", fd);
       return fp;
    }
@@ -1512,7 +1512,8 @@ const char *TUnixSystem::PrependPathName(const char *dir, TString& name)
       return name.Data();
    }
 
-   if (!dir || !dir[0]) dir = "/";
+   if (!dir || !dir[0])
+      dir = "/";
    else if (dir[strlen(dir) - 1] != '/')
       name.Prepend('/');
    name.Prepend(dir);
@@ -1834,7 +1835,7 @@ char *TUnixSystem::ExpandPathName(const char *path)
 {
    TString patbuf = path;
    if (ExpandPathName(patbuf))
-      return 0;
+      return nullptr;
    return StrDup(patbuf.Data());
 }
 
@@ -1900,10 +1901,10 @@ const char *TUnixSystem::FindFile(const char *search, TString& wfil, EAccessMode
       if (show != "")
          Printf("%s <not found>", show.Data());
       wfil = "";
-      return 0;
+      return nullptr;
    }
 
-   if (search == 0)
+   if (!search)
       search = ".";
 
    TString apwd(gSystem->WorkingDirectory());
@@ -1945,7 +1946,7 @@ const char *TUnixSystem::FindFile(const char *search, TString& wfil, EAccessMode
    if (show != "")
       Printf("%s <not found>", show.Data());
    wfil = "";
-   return 0;
+   return nullptr;
 }
 
 //---- Users & Groups ----------------------------------------------------------
@@ -2027,7 +2028,7 @@ UserGroup_t *TUnixSystem::GetUserInfo(Int_t uid)
       gUserInfo[uid] = *ug;
       return ug;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2057,7 +2058,7 @@ UserGroup_t *TUnixSystem::GetGroupInfo(Int_t gid)
       gr->fGroup = grp->gr_name;
       return gr;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2815,12 +2816,12 @@ const char *TUnixSystem::GetLinkedLibraries()
       return linkedLibs;
 
    if (once)
-      return 0;
+      return nullptr;
 
 #if !defined(R__MACOSX)
    const char *exe = GetExePath();
    if (!exe || !*exe)
-      return 0;
+      return nullptr;
 #endif
 
 #if defined(R__MACOSX)
@@ -2907,7 +2908,7 @@ const char *TUnixSystem::GetLinkedLibraries()
    once = kTRUE;
 
    if (linkedLibs.IsNull())
-      return 0;
+      return nullptr;
 
    return linkedLibs;
 }
@@ -2967,7 +2968,7 @@ void TUnixSystem::AddTimer(TTimer *ti)
 
 TTimer *TUnixSystem::RemoveTimer(TTimer *ti)
 {
-   if (!ti) return 0;
+   if (!ti) return nullptr;
 
    R__LOCKGUARD2(gSystemMutex);
 
@@ -3931,7 +3932,7 @@ const char *TUnixSystem::UnixHomedirectory(const char *name, char *path, char *m
          return mydir;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3954,10 +3955,10 @@ void *TUnixSystem::UnixOpendir(const char *dir)
    const char *edir = StripOffProto(dir, "file:");
 
    if (stat(edir, &finfo) < 0)
-      return 0;
+      return nullptr;
 
    if (!S_ISDIR(finfo.st_mode))
-      return 0;
+      return nullptr;
 
    return (void*) opendir(edir);
 }
@@ -3985,13 +3986,13 @@ const char *TUnixSystem::UnixGetdirentry(void *dirp1)
    if (dirp) {
       for (;;) {
          dp = readdir(dirp);
-         if (dp == 0)
-            return 0;
+         if (!dp)
+            return nullptr;
          if (REAL_DIR_ENTRY(dp))
             return dp->d_name;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 //---- files -------------------------------------------------------------------
@@ -4702,7 +4703,7 @@ const char *TUnixSystem::FindDynamicLibrary(TString& sLib, Bool_t quiet)
       if (!quiet)
          Error("FindDynamicLibrary",
                "%s does not exist in %s", searchFor.Data(), GetDynamicPath());
-      return 0;
+      return nullptr;
    }
    static const char* exts[] = {
       ".so", ".dll", ".dylib", ".sl", ".dl", ".a", 0 };
@@ -4722,7 +4723,7 @@ const char *TUnixSystem::FindDynamicLibrary(TString& sLib, Bool_t quiet)
             "%s[.so | .dll | .dylib | .sl | .dl | .a] does not exist in %s",
             searchFor.Data(), GetDynamicPath());
 
-   return 0;
+   return nullptr;
 }
 
 //---- System, CPU and Memory info ---------------------------------------------

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -276,7 +276,7 @@ struct TUtmpContent {
    STRUCT_UTMP *fUtmpContents;
    UInt_t       fEntries; // Number of entries in utmp file.
 
-   TUtmpContent() : fUtmpContents(0), fEntries(0) {}
+   TUtmpContent() : fUtmpContents(nullptr), fEntries(0) {}
    ~TUtmpContent() { free(fUtmpContents); }
 
    STRUCT_UTMP *SearchUtmpEntry(const char *tty)

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -167,6 +167,7 @@ public:
    Bool_t            ChangeDirectory(const char *path) override;
    const char       *GetDirEntry(void *dirp) override;
    const char       *DirName(const char *pathname) override;
+   std::string       GetDirName(const char *pathname) override;
    void              FreeDirectory(void *dirp) override;
    void             *OpenDirectory(const char *name) override;
    const char       *WorkingDirectory(char driveletter);

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -88,19 +88,19 @@ private:
    Bool_t            CheckDescriptors();
    Bool_t            CheckSignals(Bool_t sync);
    Bool_t            CountMembers(const char *lpszGroupName);
-   const char       *GetLinkedLibraries();
+   const char       *GetLinkedLibraries() override;
    Bool_t            GetNbGroups();
    Long_t            LookupSID (const char *lpszAccountName, int what, int &groupIdx, int &memberIdx);
    Bool_t            CollectMembers(const char *lpszGroupName, int &groupIdx, int &memberIdx);
    Bool_t            CollectGroups();
    Bool_t            InitUsersGroups();
-   void              DoBeep(Int_t freq=-1, Int_t duration=-1) const;
+   void              DoBeep(Int_t freq=-1, Int_t duration=-1) const override;
 
    static void       ThreadStub(void *Parameter) {((TWinNTSystem *)Parameter)->TimerThread();}
    void              TimerThread();
    void              FillWithHomeDirectory(const char *userName, char *mydir) const;
    char             *GetWorkingDirectory(char driveletter) const;
-   
+
 
 protected:
    static int        WinNTUnixConnect(int port);
@@ -116,150 +116,150 @@ public:
    Bool_t            HandleConsoleEvent();
 
    //---- Misc -------------------------------------------------
-   Bool_t            Init();
-   const char       *BaseName(const char *name);
-   void              SetProgname(const char *name);
-   const char       *GetError();
-   const char       *HostName();
+   Bool_t            Init() override;
+   const char       *BaseName(const char *name) override;
+   void              SetProgname(const char *name) override;
+   const char       *GetError() override;
+   const char       *HostName() override;
    void             *GetGUIThreadHandle() const {return fGUIThreadHandle;}
    ULong_t           GetGUIThreadId() const {return fGUIThreadId;}
    void              SetGUIThreadMsgHandler(ThreadMsgFunc_t func);
-   void              NotifyApplicationCreated();
+   void              NotifyApplicationCreated() override;
 
 
    //---- EventLoop --------------------------------------------
-   Bool_t            ProcessEvents();
-   void              DispatchOneEvent(Bool_t pendingOnly = kFALSE);
-   void              ExitLoop();
-   Int_t             Select(TList *active, Long_t timeout);
-   Int_t             Select(TFileHandler *fh, Long_t timeout);
+   Bool_t            ProcessEvents() override;
+   void              DispatchOneEvent(Bool_t pendingOnly = kFALSE) override;
+   void              ExitLoop() override;
+   Int_t             Select(TList *active, Long_t timeout) override;
+   Int_t             Select(TFileHandler *fh, Long_t timeout) override;
 
    //---- Handling of system events ----------------------------
    void              DispatchSignals(ESignals sig);
-   void              AddSignalHandler(TSignalHandler *sh);
-   TSignalHandler   *RemoveSignalHandler(TSignalHandler *sh);
-   void              ResetSignal(ESignals sig, Bool_t reset = kTRUE);
-   void              ResetSignals();
-   void              IgnoreSignal(ESignals sig, Bool_t ignore = kTRUE);
-   void              AddFileHandler(TFileHandler *fh);
-   TFileHandler     *RemoveFileHandler(TFileHandler *fh);
-   void              StackTrace();
+   void              AddSignalHandler(TSignalHandler *sh) override;
+   TSignalHandler   *RemoveSignalHandler(TSignalHandler *sh) override;
+   void              ResetSignal(ESignals sig, Bool_t reset = kTRUE) override;
+   void              ResetSignals() override;
+   void              IgnoreSignal(ESignals sig, Bool_t ignore = kTRUE) override;
+   void              AddFileHandler(TFileHandler *fh) override;
+   TFileHandler     *RemoveFileHandler(TFileHandler *fh) override;
+   void              StackTrace() override;
 
    //---- Floating Point Exceptions Control --------------------
-   Int_t             GetFPEMask();
-   Int_t             SetFPEMask(Int_t mask = kDefaultMask);
+   Int_t             GetFPEMask() override;
+   Int_t             SetFPEMask(Int_t mask = kDefaultMask) override;
 
    //---- Processes --------------------------------------------
-   int               Exec(const char *shellcmd);
-   FILE             *OpenPipe(const char *shellcmd, const char *mode);
-   int               ClosePipe(FILE *pipe);
-   void              Exit(int code, Bool_t mode = kTRUE);
-   void              Abort(int code = 0);
-   int               GetPid();
+   int               Exec(const char *shellcmd) override;
+   FILE             *OpenPipe(const char *shellcmd, const char *mode) override;
+   int               ClosePipe(FILE *pipe) override;
+   void              Exit(int code, Bool_t mode = kTRUE) override;
+   void              Abort(int code = 0) override;
+   int               GetPid() override;
 
    //---- Environment manipulation -----------------------------
-   const char       *Getenv(const char *name);
-   void              Setenv(const char *name, const char *value);
+   const char       *Getenv(const char *name) override;
+   void              Setenv(const char *name, const char *value) override;
 
    //---- Directories ------------------------------------------
-   int               mkdir(const char *name, Bool_t recursive = kFALSE);
-   int               MakeDirectory(const char *name);
-   Bool_t            ChangeDirectory(const char *path);
-   const char       *GetDirEntry(void *dirp);
-   const char       *DirName(const char *pathname);
-   void              FreeDirectory(void *dirp);
-   void             *OpenDirectory(const char *name);
+   int               mkdir(const char *name, Bool_t recursive = kFALSE) override;
+   int               MakeDirectory(const char *name) override;
+   Bool_t            ChangeDirectory(const char *path) override;
+   const char       *GetDirEntry(void *dirp) override;
+   const char       *DirName(const char *pathname) override;
+   void              FreeDirectory(void *dirp) override;
+   void             *OpenDirectory(const char *name) override;
    const char       *WorkingDirectory(char driveletter);
-   const char       *WorkingDirectory();
-   std::string       GetWorkingDirectory() const;
-   const char       *HomeDirectory(const char *userName=0);
-   std::string       GetHomeDirectory(const char *userName=0) const;
-   const char       *TempDirectory() const;
-   FILE             *TempFileName(TString &base, const char *dir = 0);
+   const char       *WorkingDirectory() override;
+   std::string       GetWorkingDirectory() const override;
+   const char       *HomeDirectory(const char *userName=0) override;
+   std::string       GetHomeDirectory(const char *userName=0) const override;
+   const char       *TempDirectory() const override;
+   FILE             *TempFileName(TString &base, const char *dir = 0) override;
 
    //---- Users & Groups ---------------------------------------
-   Int_t             GetUid(const char *user = 0);
-   Int_t             GetGid(const char *group = 0);
-   Int_t             GetEffectiveUid();
-   Int_t             GetEffectiveGid();
-   UserGroup_t      *GetUserInfo(Int_t uid);
-   UserGroup_t      *GetUserInfo(const char *user = 0);
-   UserGroup_t      *GetGroupInfo(Int_t gid);
-   UserGroup_t      *GetGroupInfo(const char *group = 0);
+   Int_t             GetUid(const char *user = 0) override;
+   Int_t             GetGid(const char *group = 0) override;
+   Int_t             GetEffectiveUid() override;
+   Int_t             GetEffectiveGid() override;
+   UserGroup_t      *GetUserInfo(Int_t uid) override;
+   UserGroup_t      *GetUserInfo(const char *user = 0) override;
+   UserGroup_t      *GetGroupInfo(Int_t gid) override;
+   UserGroup_t      *GetGroupInfo(const char *group = 0) override;
 
    //---- Paths & Files ----------------------------------------
    const char        DriveName(const char *pathname="/");
-   const char       *PrependPathName(const char *dir, TString& name);
-   Bool_t            ExpandPathName(TString &patbuf);
-   char             *ExpandPathName(const char *path);
-   Bool_t            AccessPathName(const char *path, EAccessMode mode = kFileExists);
-   Bool_t            IsPathLocal(const char *path);
-   Bool_t            IsAbsoluteFileName(const char *dir);
-   int               CopyFile(const char *from, const char *to, Bool_t overwrite = kFALSE);
-   int               Rename(const char *from, const char *to);
-   int               Link(const char *from, const char *to);
-   int               Symlink(const char *from, const char *to);
-   int               Unlink(const char *name);
+   const char       *PrependPathName(const char *dir, TString& name) override;
+   Bool_t            ExpandPathName(TString &patbuf) override;
+   char             *ExpandPathName(const char *path) override;
+   Bool_t            AccessPathName(const char *path, EAccessMode mode = kFileExists) override;
+   Bool_t            IsPathLocal(const char *path) override;
+   Bool_t            IsAbsoluteFileName(const char *dir) override;
+   int               CopyFile(const char *from, const char *to, Bool_t overwrite = kFALSE) override;
+   int               Rename(const char *from, const char *to) override;
+   int               Link(const char *from, const char *to) override;
+   int               Symlink(const char *from, const char *to) override;
+   int               Unlink(const char *name) override;
    int               SetNonBlock(int fd);
-   int               GetPathInfo(const char *path, FileStat_t &buf);
+   int               GetPathInfo(const char *path, FileStat_t &buf) override;
    int               GetFsInfo(const char *path, Long_t *id, Long_t *bsize,
-                                 Long_t *blocks, Long_t *bfree);
-   int               Chmod(const char *file, UInt_t mode);
-   int               Umask(Int_t mask);
-   int               Utime(const char *file, Long_t modtime, Long_t actime);
-   const char       *UnixPathName(const char *unixpathname);
-   const char       *FindFile(const char *search, TString& file, EAccessMode mode = kFileExists);
-   TList            *GetVolumes(Option_t *opt = "") const;
+                                 Long_t *blocks, Long_t *bfree) override;
+   int               Chmod(const char *file, UInt_t mode) override;
+   int               Umask(Int_t mask) override;
+   int               Utime(const char *file, Long_t modtime, Long_t actime) override;
+   const char       *UnixPathName(const char *unixpathname) override;
+   const char       *FindFile(const char *search, TString& file, EAccessMode mode = kFileExists) override;
+   TList            *GetVolumes(Option_t *opt = "") const override;
 
    //---- Standard Output redirection --------------------------
-   Int_t             RedirectOutput(const char *name, const char *mode = "a", RedirectHandle_t *h = 0);
+   Int_t             RedirectOutput(const char *name, const char *mode = "a", RedirectHandle_t *h = 0) override;
 
    //---- Dynamic Loading --------------------------------------
-   void              AddDynamicPath(const char *dir);
-   const char       *GetDynamicPath();
-   void              SetDynamicPath(const char *path);
-   const char       *FindDynamicLibrary(TString &lib, Bool_t quiet = kFALSE);
-   int               Load(const char *module, const char *entry = "", Bool_t system = kFALSE);
+   void              AddDynamicPath(const char *dir) override;
+   const char       *GetDynamicPath() override;
+   void              SetDynamicPath(const char *path) override;
+   const char       *FindDynamicLibrary(TString &lib, Bool_t quiet = kFALSE) override;
+   int               Load(const char *module, const char *entry = "", Bool_t system = kFALSE) override;
    const char       *GetLibraries(const char *regexp = "",
                                   const char *option = "",
-                                  Bool_t isRegexp = kTRUE);
+                                  Bool_t isRegexp = kTRUE) override;
 
    //---- Time & Date -------------------------------------------
-   TTime             Now();
-   void              AddTimer(TTimer *ti);
-   TTimer           *RemoveTimer(TTimer *ti);
-   void              Sleep(UInt_t milliSec);
+   TTime             Now() override;
+   void              AddTimer(TTimer *ti) override;
+   TTimer           *RemoveTimer(TTimer *ti) override;
+   void              Sleep(UInt_t milliSec) override;
    Double_t          GetRealTime();
    Double_t          GetCPUTime();
 
    //---- RPC --------------------------------------------------
    int               ConnectService(const char *servername, int port, int tcpwindowsize, const char *protocol = "tcp");
-   TInetAddress      GetHostByName(const char *server);
-   TInetAddress      GetPeerName(int sock);
-   TInetAddress      GetSockName(int sock);
-   int               GetServiceByName(const char *service);
-   char              *GetServiceByPort(int port);
-   int               OpenConnection(const char *server, int port, int tcpwindowsize = -1, const char *protocol = "tcp");
-   int               AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1);
-   int               AnnounceUdpService(int port, int backlog);
-   int               AnnounceUnixService(int port, int backlog);
-   int               AnnounceUnixService(const char *sockpath, int backlog);
-   int               AcceptConnection(int sock);
-   void              CloseConnection(int sock, Bool_t force = kFALSE);
-   int               RecvRaw(int sock, void *buffer, int length, int flag);
-   int               SendRaw(int sock, const void *buffer, int length, int flag);
-   int               RecvBuf(int sock, void *buffer, int length);
-   int               SendBuf(int sock, const void *buffer, int length);
-   int               SetSockOpt(int sock, int opt, int val);
-   int               GetSockOpt(int sock, int opt, int *val);
+   TInetAddress      GetHostByName(const char *server) override;
+   TInetAddress      GetPeerName(int sock) override;
+   TInetAddress      GetSockName(int sock) override;
+   int               GetServiceByName(const char *service) override;
+   char              *GetServiceByPort(int port) override;
+   int               OpenConnection(const char *server, int port, int tcpwindowsize = -1, const char *protocol = "tcp") override;
+   int               AnnounceTcpService(int port, Bool_t reuse, int backlog, int tcpwindowsize = -1) override;
+   int               AnnounceUdpService(int port, int backlog) override;
+   int               AnnounceUnixService(int port, int backlog) override;
+   int               AnnounceUnixService(const char *sockpath, int backlog) override;
+   int               AcceptConnection(int sock) override;
+   void              CloseConnection(int sock, Bool_t force = kFALSE) override;
+   int               RecvRaw(int sock, void *buffer, int length, int flag) override;
+   int               SendRaw(int sock, const void *buffer, int length, int flag) override;
+   int               RecvBuf(int sock, void *buffer, int length) override;
+   int               SendBuf(int sock, const void *buffer, int length) override;
+   int               SetSockOpt(int sock, int opt, int val) override;
+   int               GetSockOpt(int sock, int opt, int *val) override;
 
    //---- System, CPU and Memory info
-   Int_t             GetSysInfo(SysInfo_t *info) const;
-   Int_t             GetCpuInfo(CpuInfo_t *info, Int_t sampleTime = 1000) const;
-   Int_t             GetMemInfo(MemInfo_t *info) const;
-   Int_t             GetProcInfo(ProcInfo_t *info) const;
+   Int_t             GetSysInfo(SysInfo_t *info) const override;
+   Int_t             GetCpuInfo(CpuInfo_t *info, Int_t sampleTime = 1000) const override;
+   Int_t             GetMemInfo(MemInfo_t *info) const override;
+   Int_t             GetProcInfo(ProcInfo_t *info) const override;
 
-   ClassDef(TWinNTSystem, 0)
+   ClassDefOverride(TWinNTSystem, 0)
 };
 
 R__EXTERN ULong_t gConsoleWindow;   // console window handle

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -167,7 +167,7 @@ public:
    Bool_t            ChangeDirectory(const char *path) override;
    const char       *GetDirEntry(void *dirp) override;
    const char       *DirName(const char *pathname) override;
-   std::string       GetDirName(const char *pathname) override;
+   TString           GetDirName(const char *pathname) override;
    void              FreeDirectory(void *dirp) override;
    void             *OpenDirectory(const char *name) override;
    const char       *WorkingDirectory(char driveletter);

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -70,19 +70,19 @@ public:
    typedef Bool_t (*ThreadMsgFunc_t)(MSG*);
 
 private:
-   struct group     *fGroups;           // Groups on local computer
-   struct passwd    *fPasswords;        // Users on local computer
-   int               fNbUsers;          // Number of users on local computer
-   int               fNbGroups;         // Number of groups on local computer
-   int               fActUser;          // Index of actual user in User list
-   Bool_t            fGroupsInitDone;   // Flag used for Users and Groups initialization
-   Bool_t            fFirstFile;        // Flag used by OpenDirectory/GetDirEntry
+   struct group     *fGroups{nullptr};           // Groups on local computer
+   struct passwd    *fPasswords{nullptr};        // Users on local computer
+   int               fNbUsers{0};                // Number of users on local computer
+   int               fNbGroups{0};               // Number of groups on local computer
+   int               fActUser{-1};               // Index of actual user in User list
+   Bool_t            fGroupsInitDone{kFALSE};    // Flag used for Users and Groups initialization
+   Bool_t            fFirstFile{kFALSE};         // Flag used by OpenDirectory/GetDirEntry
 
-   HANDLE            fhProcess;         // Handle of the current process
-   void             *fGUIThreadHandle;  // handle of GUI server (aka command) thread
-   ULong_t           fGUIThreadId;      // id of GUI server (aka command) thread
-   char             *fDirNameBuffer;    // The string buffer to hold path name
-   WIN32_FIND_DATA   fFindFileData;     // Structure to look for files (aka OpenDir under UNIX)
+   HANDLE            fhProcess;                  // Handle of the current process
+   void             *fGUIThreadHandle{nullptr};  // handle of GUI server (aka command) thread
+   ULong_t           fGUIThreadId{0};            // id of GUI server (aka command) thread
+   char             *fDirNameBuffer{nullptr};    // The string buffer to hold path name
+   WIN32_FIND_DATA   fFindFileData;              // Structure to look for files (aka OpenDir under UNIX)
 
    Bool_t            DispatchTimers(Bool_t mode);
    Bool_t            CheckDescriptors();
@@ -173,19 +173,19 @@ public:
    const char       *WorkingDirectory() override;
    std::string       GetWorkingDirectory() const override;
    const char       *HomeDirectory(const char *userName=0) override;
-   std::string       GetHomeDirectory(const char *userName=0) const override;
+   std::string       GetHomeDirectory(const char *userName = nullptr) const override;
    const char       *TempDirectory() const override;
-   FILE             *TempFileName(TString &base, const char *dir = 0) override;
+   FILE             *TempFileName(TString &base, const char *dir = nullptr) override;
 
    //---- Users & Groups ---------------------------------------
-   Int_t             GetUid(const char *user = 0) override;
-   Int_t             GetGid(const char *group = 0) override;
+   Int_t             GetUid(const char *user = nullptr) override;
+   Int_t             GetGid(const char *group = nullptr) override;
    Int_t             GetEffectiveUid() override;
    Int_t             GetEffectiveGid() override;
    UserGroup_t      *GetUserInfo(Int_t uid) override;
-   UserGroup_t      *GetUserInfo(const char *user = 0) override;
+   UserGroup_t      *GetUserInfo(const char *user = nullptr) override;
    UserGroup_t      *GetGroupInfo(Int_t gid) override;
-   UserGroup_t      *GetGroupInfo(const char *group = 0) override;
+   UserGroup_t      *GetGroupInfo(const char *group = nullptr) override;
 
    //---- Paths & Files ----------------------------------------
    const char        DriveName(const char *pathname="/");
@@ -212,7 +212,7 @@ public:
    TList            *GetVolumes(Option_t *opt = "") const override;
 
    //---- Standard Output redirection --------------------------
-   Int_t             RedirectOutput(const char *name, const char *mode = "a", RedirectHandle_t *h = 0) override;
+   Int_t             RedirectOutput(const char *name, const char *mode = "a", RedirectHandle_t *h = nullptr) override;
 
    //---- Dynamic Loading --------------------------------------
    void              AddDynamicPath(const char *dir) override;

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -81,7 +81,7 @@ private:
    HANDLE            fhProcess;                  // Handle of the current process
    void             *fGUIThreadHandle{nullptr};  // handle of GUI server (aka command) thread
    ULong_t           fGUIThreadId{0};            // id of GUI server (aka command) thread
-   char             *fDirNameBuffer{nullptr};    // The string buffer to hold path name
+   std::string       fDirNameBuffer;             // The string buffer to hold path name
    WIN32_FIND_DATA   fFindFileData;              // Structure to look for files (aka OpenDir under UNIX)
 
    Bool_t            DispatchTimers(Bool_t mode);

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -2377,7 +2377,7 @@ const char *TWinNTSystem::DirName(const char *pathname)
 /// Return the directory name in pathname. DirName of c:/user/root is /user.
 /// DirName of c:/user/root/ is /user/root.
 
-std::string TWinNTSystem::GetDirName(const char *pathname)
+TString TWinNTSystem::GetDirName(const char *pathname)
 {
    // Create a buffer to keep the path name
    if (pathname) {
@@ -2397,7 +2397,7 @@ std::string TWinNTSystem::GetDirName(const char *pathname)
          }
          int len =  r - pathname;
          if (len > 0)
-            return std::string(pathname, len);
+            return TString(pathname, len);
       }
    }
    return "";

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -1064,11 +1064,8 @@ TWinNTSystem::~TWinNTSystem()
 
 Bool_t TWinNTSystem::Init()
 {
-   const char *dir = 0;
-
-   if (TSystem::Init()) {
+   if (TSystem::Init())
       return kTRUE;
-   }
 
    fReadmask = new TFdSet;
    fWritemask = new TFdSet;

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -2412,6 +2412,36 @@ const char *TWinNTSystem::DirName(const char *pathname)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return the directory name in pathname. DirName of c:/user/root is /user.
+/// DirName of c:/user/root/ is /user/root.
+
+std::string TWinNTSystem::GetDirName(const char *pathname)
+{
+   // Create a buffer to keep the path name
+   if (pathname) {
+      if (strchr(pathname, '/') || strchr(pathname, '\\')) {
+         const char *rslash = strrchr(pathname, '/');
+         const char *bslash = strrchr(pathname, '\\');
+         const char *r = std::max(rslash, bslash);
+         const char *ptr = pathname;
+         while (ptr <= r) {
+            if (*ptr == ':') {
+               // Windows path may contain a drive letter
+               // For NTFS ":" may be a "stream" delimiter as well
+               pathname =  ptr + 1;
+               break;
+            }
+            ptr++;
+         }
+         int len =  r - pathname;
+         if (len > 0)
+            return std::string(pathname, len);
+      }
+   }
+   return "";
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return the drive letter in pathname. DriveName of 'c:/user/root' is 'c'
 ///
 ///   Input:

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -971,11 +971,9 @@ Bool_t TWinNTSystem::HandleConsoleEvent()
 ////////////////////////////////////////////////////////////////////////////////
 /// ctor
 
-TWinNTSystem::TWinNTSystem() : TSystem("WinNT", "WinNT System"),
-fGUIThreadHandle(0), fGUIThreadId(0)
+TWinNTSystem::TWinNTSystem() : TSystem("WinNT", "WinNT System")
 {
    fhProcess = ::GetCurrentProcess();
-   fDirNameBuffer = 0;
 
    WSADATA WSAData;
    int initwinsock = 0;
@@ -1052,7 +1050,7 @@ TWinNTSystem::~TWinNTSystem()
 
    if (fDirNameBuffer) {
       delete [] fDirNameBuffer;
-      fDirNameBuffer = 0;
+      fDirNameBuffer = nullptr;
    }
 
    if (gGlobalEvent) {
@@ -1168,7 +1166,7 @@ const char *TWinNTSystem::BaseName(const char *name)
          }
       } else {
          Error("BaseName", "name = 0");
-         return 0;
+         return nullptr;
       }
       char *cp;
       char *bslash = (char *)strrchr(&symbol[idx],'\\');
@@ -1181,7 +1179,7 @@ const char *TWinNTSystem::BaseName(const char *name)
       return &symbol[idx];
    }
    Error("BaseName", "name = 0");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1191,9 +1189,9 @@ const char *TWinNTSystem::BaseName(const char *name)
 void TWinNTSystem::SetProgname(const char *name)
 {
    ULong_t  idot = 0;
-   char *dot = 0;
+   char *dot = nullptr;
    char *progname;
-   char *fullname = 0; // the program name with extension
+   char *fullname = nullptr; // the program name with extension
 
   // On command prompt the progname can be supplied with no extension (under Windows)
    ULong_t namelen=name ? strlen(name) : 0;
@@ -1208,7 +1206,7 @@ void TWinNTSystem::SetProgname(const char *name)
       dot = strrchr(progname, '.');
       idot = dot ? (ULong_t)(dot - progname) : strlen(progname);
 
-      char *which = 0;
+      char *which = nullptr;
 
       if (IsAbsoluteFileName(fullname) && !AccessPathName(fullname)) {
          which = StrDup(fullname);
@@ -1342,7 +1340,7 @@ void TWinNTSystem::AddFileHandler(TFileHandler *h)
 
 TFileHandler *TWinNTSystem::RemoveFileHandler(TFileHandler *h)
 {
-   if (!h) return 0;
+   if (!h) return nullptr;
 
    TFileHandler *oh = TSystem::RemoveFileHandler(h);
    if (oh) {       // found
@@ -1386,7 +1384,7 @@ void TWinNTSystem::AddSignalHandler(TSignalHandler *h)
 
 TSignalHandler *TWinNTSystem::RemoveSignalHandler(TSignalHandler *h)
 {
-   if (!h) return 0;
+   if (!h) return nullptr;
 
    int sig = h->GetSignal();
 
@@ -1953,7 +1951,7 @@ const char *TWinNTSystem::GetDirEntry(void *dirp)
          return (const char *)fFindFileData.cFileName;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2069,10 +2067,9 @@ void *TWinNTSystem::OpenDirectory(const char *fdir)
       if (_stati64(entry, &finfo) < 0) {
          delete [] entry;
          delete [] dir;
-         return 0;
+         return nullptr;
       }
-   }
-   else {
+   } else {
       strlcpy(entry, dir,nche);
       if ((entry[strlen(dir)-1] == '/') || (entry[strlen(dir)-1] == '\\' )) {
          if(!PathIsRoot(entry))
@@ -2081,7 +2078,7 @@ void *TWinNTSystem::OpenDirectory(const char *fdir)
       if (_stati64(entry, &finfo) < 0) {
          delete [] entry;
          delete [] dir;
-         return 0;
+         return nullptr;
       }
    }
 
@@ -2100,17 +2097,17 @@ void *TWinNTSystem::OpenDirectory(const char *fdir)
          ((TWinNTSystem *)gSystem)->Error( "Unable to find' for reading:", entry);
          delete [] entry;
          delete [] dir;
-         return 0;
+         return nullptr;
       }
       delete [] entry;
       delete [] dir;
       fFirstFile = kTRUE;
       return searchFile;
-   } else {
-      delete [] entry;
-      delete [] dir;
-      return 0;
    }
+
+   delete [] entry;
+   delete [] dir;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2160,7 +2157,7 @@ const char *TWinNTSystem::WorkingDirectory(char driveletter)
 
 char *TWinNTSystem::GetWorkingDirectory(char driveletter) const
 {
-   char *wdpath = 0;
+   char *wdpath = nullptr;
    char drive = driveletter ? toupper( driveletter ) - 'A' + 1 : 0;
 
    // don't use cache as user can call chdir() directly somewhere else
@@ -2170,7 +2167,7 @@ char *TWinNTSystem::GetWorkingDirectory(char driveletter) const
    if (!(wdpath = ::_getdcwd( (int)drive, wdpath, kMAXPATHLEN))) {
       free(wdpath);
       Warning("WorkingDirectory", "getcwd() failed");
-      return 0;
+      return nullptr;
    }
 
    return wdpath;
@@ -2201,7 +2198,7 @@ std::string TWinNTSystem::GetHomeDirectory(const char *userName) const
 
 void TWinNTSystem::FillWithHomeDirectory(const char *userName, char *mydir) const
 {
-   const char *h = 0;
+   const char *h = nullptr;
    if (!(h = ::getenv("home"))) h = ::getenv("HOME");
 
    if (h) {
@@ -2379,8 +2376,8 @@ const char *TWinNTSystem::DirName(const char *pathname)
 {
    // Delete old buffer
    if (fDirNameBuffer) {
-      // delete [] fDirNameBuffer;
-      fDirNameBuffer = 0;
+      // delete [] fDirNameBuffer;   // FIXME: this is memory leak!!!
+      fDirNameBuffer = nullptr;
    }
 
    // Create a buffer to keep the path name
@@ -2898,7 +2895,7 @@ Bool_t TWinNTSystem::ExpandPathName(TString &patbuf0)
 {
    const char *patbuf = (const char *)patbuf0;
    const char *p;
-   char   *cmd = 0;
+   char   *cmd = nullptr;
    char  *q;
 
    Int_t old_level = gErrorIgnoreLevel;
@@ -3015,7 +3012,8 @@ char *TWinNTSystem::ExpandPathName(const char *path)
    else
       strlcpy(newpath, path, MAX_PATH);
    TString patbuf = newpath;
-   if (ExpandPathName(patbuf)) return 0;
+   if (ExpandPathName(patbuf))
+      return nullptr;
 
    return StrDup(patbuf.Data());
 }
@@ -3073,9 +3071,9 @@ const char *TWinNTSystem::FindFile(const char *search, TString& infile, EAccessM
    // Check whether this infile has the absolute path first
    if (IsAbsoluteFileName(infile.Data()) ) {
       if (!AccessPathName(infile.Data(), mode))
-      return infile.Data();
+         return infile.Data();
       infile = "";
-      return 0;
+      return nullptr;
    }
    TString exsearch(search);
    gSystem->ExpandPathName(exsearch);
@@ -3096,7 +3094,7 @@ const char *TWinNTSystem::FindFile(const char *search, TString& infile, EAccessM
    // Check access
    struct stat finfo;
    char name[kMAXPATHLEN];
-   char *lpFilePart = 0;
+   char *lpFilePart = nullptr;
    if (::SearchPath(exsearch.Data(), infile.Data(), NULL, kMAXPATHLEN, name, &lpFilePart) &&
        ::access(name, mode) == 0 && stat(name, &finfo) == 0 &&
        finfo.st_mode & S_IFREG) {
@@ -3107,7 +3105,7 @@ const char *TWinNTSystem::FindFile(const char *search, TString& infile, EAccessM
       return infile.Data();
    }
    infile = "";
-   return 0;
+   return nullptr;
 }
 
 //---- Users & Groups ----------------------------------------------------------
@@ -3548,7 +3546,7 @@ Int_t TWinNTSystem::GetUid(const char *user)
    if (!user || !user[0])
       return fPasswords[fActUser].pw_uid;
    else {
-      struct passwd *pwd = 0;
+      struct passwd *pwd = nullptr;
       for(int i=0;i<fNbUsers;i++) {
          if (!stricmp (user, fPasswords[i].pw_name)) {
             pwd = &fPasswords[i];
@@ -3616,7 +3614,7 @@ Int_t TWinNTSystem::GetGid(const char *group)
    if (!group || !group[0])
       return fPasswords[fActUser].pw_gid;
    else {
-      struct group *grp = 0;
+      struct group *grp = nullptr;
       for(int i=0;i<fNbGroups;i++) {
          if (!stricmp (group, fGroups[i].gr_name)) {
             grp = &fGroups[i];
@@ -3715,7 +3713,7 @@ UserGroup_t *TWinNTSystem::GetUserInfo(Int_t uid)
       ug->fGroup    = pwd->pw_group;
       return ug;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3762,7 +3760,7 @@ UserGroup_t *TWinNTSystem::GetGroupInfo(Int_t gid)
       gr->fUid = 0;
       return gr;
    }
-   struct group *grp = 0;
+   struct group *grp = nullptr;
    for(int i=0;i<fNbGroups;i++) {
       if (gid == fGroups[i].gr_gid) {
          grp = &fGroups[i];
@@ -3776,8 +3774,7 @@ UserGroup_t *TWinNTSystem::GetGroupInfo(Int_t gid)
       gr->fGroup = grp->gr_name;
       return gr;
    }
-   return 0;
-
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4071,13 +4068,13 @@ const char *TWinNTSystem::FindDynamicLibrary(TString &sLib, Bool_t quiet)
    int len = sLib.Length();
    if (len > 4 && (!stricmp(sLib.Data()+len-4, ".dll"))) {
       if (gSystem->FindFile(GetDynamicPath(), sLib, kReadPermission))
-         return sLib;
+         return sLib.Data();
    } else {
       TString sLibDll(sLib);
       sLibDll += ".dll";
       if (gSystem->FindFile(GetDynamicPath(), sLibDll, kReadPermission)) {
          sLibDll.Swap(sLib);
-         return sLib;
+         return sLib.Data();
       }
    }
 
@@ -4086,7 +4083,7 @@ const char *TWinNTSystem::FindDynamicLibrary(TString &sLib, Bool_t quiet)
             "%s does not exist in %s,\nor has wrong file extension (.dll)",
              sLib.Data(), GetDynamicPath());
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4113,7 +4110,7 @@ const char *TWinNTSystem::GetLinkedLibraries()
    char winName[256];
    char winExt[256];
 
-   if (!gApplication) return 0;
+   if (!gApplication) return nullptr;
 
    static Bool_t once = kFALSE;
    static TString linkedLibs;
@@ -4122,13 +4119,13 @@ const char *TWinNTSystem::GetLinkedLibraries()
       return linkedLibs;
 
    if (once)
-      return 0;
+      return nullptr;
 
    char *exe = gSystem->Which(Getenv("PATH"), gApplication->Argv(0),
                               kExecutePermission);
    if (!exe) {
       once = kTRUE;
-      return 0;
+      return nullptr;
    }
 
    HANDLE hFile, hMapping;
@@ -4136,18 +4133,18 @@ const char *TWinNTSystem::GetLinkedLibraries()
 
    if((hFile = CreateFile(exe,GENERIC_READ,FILE_SHARE_READ,0,OPEN_EXISTING,FILE_FLAG_SEQUENTIAL_SCAN,0))==INVALID_HANDLE_VALUE) {
       delete [] exe;
-      return 0;
+      return nullptr;
    }
    if(!(hMapping = CreateFileMapping(hFile,0,PAGE_READONLY|SEC_COMMIT,0,0,0))) {
       CloseHandle(hFile);
       delete [] exe;
-      return 0;
+      return nullptr;
    }
    if(!(basepointer = MapViewOfFile(hMapping,FILE_MAP_READ,0,0,0))) {
       CloseHandle(hMapping);
       CloseHandle(hFile);
       delete [] exe;
-      return 0;
+      return nullptr;
    }
 
    int sect;
@@ -4163,29 +4160,29 @@ const char *TWinNTSystem::GetLinkedLibraries()
 
    if(dos_head->e_magic!='ZM') {
       delete [] exe;
-      return 0;
+      return nullptr;
    }  // verify DOS-EXE-Header
    // after end of DOS-EXE-Header: offset to PE-Header
    pheader = (struct header *)((char*)dos_head + dos_head->e_lfanew);
 
    if(IsBadReadPtr(pheader,sizeof(struct header))) { // start of PE-Header
       delete [] exe;
-      return 0;
+      return nullptr;
    }
    if(pheader->signature!=IMAGE_NT_SIGNATURE) {      // verify PE format
       switch((unsigned short)pheader->signature) {
          case IMAGE_DOS_SIGNATURE:
             delete [] exe;
-            return 0;
+            return nullptr;
          case IMAGE_OS2_SIGNATURE:
             delete [] exe;
-            return 0;
+            return nullptr;
          case IMAGE_OS2_SIGNATURE_LE:
             delete [] exe;
-            return 0;
+            return nullptr;
          default: // unknown signature
             delete [] exe;
-            return 0;
+            return nullptr;
       }
    }
 #define isin(address,start,length) ((address)>=(start) && (address)<(start)+(length))
@@ -4243,7 +4240,7 @@ const char *TWinNTSystem::GetLinkedLibraries()
    once = kTRUE;
 
    if (linkedLibs.IsNull())
-      return 0;
+      return nullptr;
 
    return linkedLibs;
 }
@@ -4331,7 +4328,7 @@ void TWinNTSystem::AddTimer(TTimer *ti)
 
 TTimer *TWinNTSystem::RemoveTimer(TTimer *ti)
 {
-   if (!ti) return 0;
+   if (!ti) return nullptr;
 
    TTimer *t = TSystem::RemoveTimer(ti);
    return t;
@@ -4496,7 +4493,7 @@ Int_t TWinNTSystem::Select(TList *act, Long_t to)
    TFdSet rd, wr;
    Int_t mxfd = -1;
    TIter next(act);
-   TFileHandler *h = 0;
+   TFileHandler *h = nullptr;
    while ((h = (TFileHandler *) next())) {
       Int_t fd = h->GetFd();
       if (h->HasReadInterest())
@@ -5533,10 +5530,10 @@ static const char *GetWindowsVersion()
    SYSTEM_INFO si;
    PGNSI pGNSI;
    BOOL bOsVersionInfoEx;
-   static char *strReturn = 0;
+   static char *strReturn = nullptr;
    char temp[512];
 
-   if (strReturn == 0)
+   if (!strReturn)
       strReturn = new char[2048];
    else
       return strReturn;

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -1212,12 +1212,12 @@ void TWinNTSystem::SetProgname(const char *name)
       if (which) {
          TString dirname;
          char driveletter = DriveName(which);
-         const char *d = DirName(which);
+         TString d = GetDirName(which);
 
          if (driveletter) {
-            dirname.Form("%c:%s", driveletter, d);
+            dirname.Form("%c:%s", driveletter, d.Data());
          } else {
-            dirname.Form("%s", d);
+            dirname = d;
          }
 
          gProgPath = StrDup(dirname);
@@ -1857,7 +1857,7 @@ Bool_t TWinNTSystem::CheckDescriptors()
 int TWinNTSystem::mkdir(const char *name, Bool_t recursive)
 {
    if (recursive) {
-      TString dirname = DirName(name);
+      TString dirname = GetDirName(name);
       if (dirname.Length() == 0) {
          // well we should not have to make the root of the file system!
          // (and this avoid infinite recursions!)

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -1048,11 +1048,6 @@ TWinNTSystem::~TWinNTSystem()
    // Clean up the WinSocket connectios
    ::WSACleanup();
 
-   if (fDirNameBuffer) {
-      delete [] fDirNameBuffer;
-      fDirNameBuffer = nullptr;
-   }
-
    if (gGlobalEvent) {
       ::ResetEvent(gGlobalEvent);
       ::CloseHandle(gGlobalEvent);
@@ -2374,41 +2369,8 @@ TList *TWinNTSystem::GetVolumes(Option_t *opt) const
 
 const char *TWinNTSystem::DirName(const char *pathname)
 {
-   // Delete old buffer
-   if (fDirNameBuffer) {
-      // delete [] fDirNameBuffer;   // FIXME: this is memory leak!!!
-      fDirNameBuffer = nullptr;
-   }
-
-   // Create a buffer to keep the path name
-   if (pathname) {
-      if (strchr(pathname, '/') || strchr(pathname, '\\')) {
-         const char *rslash = strrchr(pathname, '/');
-         const char *bslash = strrchr(pathname, '\\');
-         const char *r = (std::max)(rslash, bslash);
-         const char *ptr = pathname;
-         while (ptr <= r) {
-            if (*ptr == ':') {
-               // Windows path may contain a drive letter
-               // For NTFS ":" may be a "stream" delimiter as well
-               pathname =  ptr + 1;
-               break;
-            }
-            ptr++;
-         }
-         int len =  r - pathname;
-         if (len > 0) {
-            fDirNameBuffer = new char[len+1];
-            memcpy(fDirNameBuffer, pathname, len);
-            fDirNameBuffer[len] = 0;
-         }
-      }
-   }
-   if (!fDirNameBuffer) {
-      fDirNameBuffer = new char[1];
-      *fDirNameBuffer = '\0'; // Set the empty default response
-   }
-   return fDirNameBuffer;
+   fDirNameBuffer = GetDirName(pathname);
+   return fDirNameBuffer.c_str();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/etc/html/saveScriptOutput.C
+++ b/etc/html/saveScriptOutput.C
@@ -26,7 +26,7 @@ int saveScriptOutput(const char* script, const char* outdir, Bool_t compiled)
    };
 
    TString pwd(gSystem->pwd());
-   if (!gSystem->cd(gSystem->DirName(script)))
+   if (!gSystem->cd(gSystem->GetDirName(script)))
       return kScriptDirNotFound;
    Int_t err = 0;
    TString cmd(".x ");

--- a/gui/gui/src/TGFileBrowser.cxx
+++ b/gui/gui/src/TGFileBrowser.cxx
@@ -1118,7 +1118,7 @@ TString TGFileBrowser::DirName(TGListTreeItem* item)
    _splitpath(fullpath.Data(), winDrive, winDir, winName, winExt);
    dirname = TString::Format("%s%s", winDrive, winDir);
 #else
-   dirname = gSystem->DirName(fullpath);
+   dirname = gSystem->GetDirName(fullpath);
 #endif
    return dirname;
 }

--- a/gui/gui/src/TGIcon.cxx
+++ b/gui/gui/src/TGIcon.cxx
@@ -46,15 +46,14 @@ ClassImp(TGIcon);
 
 TGIcon::TGIcon(const TGWindow *p, const char *image) : TGFrame(p, 1, 1)
 {
-   fPic = 0;
-   char *path;
+   fPic = nullptr;
 
    if (!image)
       image = "bld_rgb.xpm";
 
-   path = StrDup(image);
+   char *path = StrDup(image);
 
-   fPath = gSystem->DirName(path);
+   fPath = gSystem->GetDirName(path);
 
    fImage = TImage::Open(path);
    if (fImage) {
@@ -91,7 +90,7 @@ void TGIcon::SetImage(const char *img)
 {
    //delete fImage;
    TImage *i = TImage::Open(img);
-   fPath = gSystem->DirName(img);
+   fPath = gSystem->GetDirName(img);
 
    SetImage(i);
 }

--- a/gui/gui/src/TGTextEditor.cxx
+++ b/gui/gui/src/TGTextEditor.cxx
@@ -823,7 +823,7 @@ void TGTextEditor::ExecuteMacro()
    TString savdir = gSystem->WorkingDirectory();
    TString tmpfile = gSystem->BaseName(fFilename.Data());
    tmpfile += "_exec";
-   gSystem->ChangeDirectory(gSystem->DirName(fFilename.Data()));
+   gSystem->ChangeDirectory(gSystem->GetDirName(fFilename.Data()).Data());
    fTextEdit->SaveFile(tmpfile.Data(), kFALSE);
    gROOT->SetExecutingMacro(kTRUE);
    gROOT->Macro(tmpfile.Data());

--- a/gui/gui/src/TRootBrowserLite.cxx
+++ b/gui/gui/src/TRootBrowserLite.cxx
@@ -1617,11 +1617,10 @@ void TRootBrowserLite::DisplayDirectory()
    if (fListLevel) {
       // disable/enable up level navigation
       TGButton *btn = fToolBar->GetButton(kOneLevelUp);
-      const char *dirname = gSystem->DirName(p);
-      Bool_t disableUp;
+      TString dirname = gSystem->GetDirName(p);
 
       TObject *obj = (TObject*)fListLevel->GetUserData();
-      disableUp = (strlen(dirname) == 1) && (*dirname == '/');
+      Bool_t disableUp = dirname == "/";
 
       // normal file directory
       if (disableUp && (obj) && (obj->IsA() == TSystemDirectory::Class())) {
@@ -1945,7 +1944,7 @@ Bool_t TRootBrowserLite::ProcessMessage(Long_t msg, Long_t parm1, Long_t parm2)
                         fClient->NeedRedraw(fLt, kTRUE);
                      } else {
                         obj = (TObject *)fListLevel->GetUserData();
-                        if (obj) ToSystemDirectory(gSystem->DirName(obj->GetTitle()));
+                        if (obj) ToSystemDirectory(gSystem->GetDirName(obj->GetTitle()));
                      }
                      break;
                   }
@@ -2574,7 +2573,6 @@ void TRootBrowserLite::Checked(TObject *obj, Bool_t checked)
 void TRootBrowserLite::IconBoxAction(TObject *obj)
 {
    Bool_t browsable = kFALSE;
-   const char *dirname = 0;
    if (obj) {
 
       TRootBrowserCursorSwitcher cursorSwitcher(fIconBox, fLt);
@@ -2621,7 +2619,7 @@ void TRootBrowserLite::IconBoxAction(TObject *obj)
                   fListLevel = 0;
                }
             } else {
-               dirname = gSystem->DirName(gSystem->pwd());
+               TString dirname = gSystem->GetDirName(gSystem->pwd());
                ToSystemDirectory(dirname);
                return;
             }
@@ -2630,7 +2628,7 @@ void TRootBrowserLite::IconBoxAction(TObject *obj)
 
       if (obj && obj->IsFolder()) {
          fIconBox->RemoveAll();
-         TGListTreeItem *itm = 0;
+         TGListTreeItem *itm = nullptr;
 
          if (fListLevel) {
             fLt->OpenItem(fListLevel);

--- a/gui/guibuilder/src/TGuiBldDragManager.cxx
+++ b/gui/guibuilder/src/TGuiBldDragManager.cxx
@@ -6304,7 +6304,7 @@ void TGuiBldDragManager::ChangeImage(TGIcon *fr)
       }
    } else {
       fr->SetImage(img);
-      fr->SetImagePath(gSystem->DirName(fname.Data()));
+      fr->SetImagePath(gSystem->GetDirName(fname.Data()));
    }
 
    root->SetEditable(kTRUE);

--- a/gui/sessionviewer/src/TSessionDialogs.cxx
+++ b/gui/sessionviewer/src/TSessionDialogs.cxx
@@ -1078,7 +1078,7 @@ void TUploadDataSetDlg::AddFiles(const char *fileName)
       return;
    if (strstr(fileName,"*.")) {
       // wildcarding case
-      void *filesDir = gSystem->OpenDirectory(gSystem->DirName(fileName));
+      void *filesDir = gSystem->OpenDirectory(gSystem->GetDirName(fileName));
       const char* ent;
       TString filesExp(gSystem->BaseName(fileName));
       filesExp.ReplaceAll("*",".*");
@@ -1086,10 +1086,10 @@ void TUploadDataSetDlg::AddFiles(const char *fileName)
       while ((ent = gSystem->GetDirEntry(filesDir))) {
          TString entryString(ent);
          if (entryString.Index(rg) != kNPOS &&
-             gSystem->AccessPathName(Form("%s/%s", gSystem->DirName(fileName),
+             gSystem->AccessPathName(Form("%s/%s", gSystem->GetDirName(fileName).Data(),
                 ent), kReadPermission) == kFALSE) {
             TString text = TString::Format("%s/%s",
-               gSystem->UnixPathName(gSystem->DirName(fileName)), ent);
+               gSystem->UnixPathName(gSystem->GetDirName(fileName)), ent);
             if (!fLVContainer->FindItem(text.Data())) {
                TGLVEntry *entry = new TGLVEntry(fLVContainer, text.Data(), text.Data());
                entry->SetPictures(gClient->GetPicture("rootdb_t.xpm"),
@@ -1123,7 +1123,7 @@ void TUploadDataSetDlg::AddFiles(TList *fileList)
    TIter next(fileList);
    while ((el = (TObjString *) next())) {
       TString fileName = TString::Format("%s/%s",
-                  gSystem->UnixPathName(gSystem->DirName(el->GetString())),
+                  gSystem->UnixPathName(gSystem->GetDirName(el->GetString())),
                   gSystem->BaseName(el->GetString()));
       // single file
       if (!fLVContainer->FindItem(fileName.Data())) {

--- a/html/src/TDocDirective.cxx
+++ b/html/src/TDocDirective.cxx
@@ -371,9 +371,9 @@ TString TDocMacroDirective::CreateSubprocessInputFile() {
    const char* pathDelimiter = ":"; // use ":" even on windows
    TObjArray* arrDirs(macroPath.Tokenize(pathDelimiter));
    TIter iDir(arrDirs);
-   TObjString* osDir = 0;
+   TObjString* osDir = nullptr;
    macroPath = "";
-   TString filenameDirPart(gSystem->DirName(filename));
+   TString filenameDirPart = gSystem->GetDirName(filename);
    filenameDirPart.Prepend('/'); // as dir delimiter, not as root dir
    while ((osDir = (TObjString*)iDir())) {
       if (osDir->String().EndsWith("\\"))

--- a/html/src/THtml.cxx
+++ b/html/src/THtml.cxx
@@ -131,7 +131,7 @@ bool THtml::TModuleDefinition::GetModule(TClass* cl, TFileSysEntry* fse,
    }
 
    // take the directory name without "/" or leading "."
-   out_modulename = gSystem->DirName(filename);
+   out_modulename = gSystem->GetDirName(filename);
 
    while (out_modulename[0] == '.')
       out_modulename.Remove(0, 1);
@@ -483,7 +483,7 @@ bool THtml::TFileDefinition::GetFileName(const TClass* cl, bool decl,
          possiblePath += "src/";
       out_filename = possiblePath + "/" + possibleFileName;
    } else {
-      possiblePath = gSystem->DirName(clfile);
+      possiblePath = gSystem->GetDirName(clfile);
       possibleFileName = gSystem->BaseName(clfile);
    }
 
@@ -627,7 +627,7 @@ bool THtml::TPathDefinition::GetFileNameFromInclude(const char* included, TStrin
    const TList* bucket = GetOwner()->GetLocalFiles()->GetEntries().GetListForObject(incBase);
    if (!bucket) return false;
 
-   TString alldir(gSystem->DirName(included));
+   TString alldir = gSystem->GetDirName(included);
    TObjArray* arrSubDirs = alldir.Tokenize("/");
    TIter iEntry(bucket);
    TFileSysEntry* entry = 0;
@@ -1746,8 +1746,8 @@ void THtml::CreateListOfClasses(const char* filter)
       if (!module) {
          bool moduleSelected = cdi->IsSelected();
 
-         TString parentModuleName(gSystem->DirName(modulename));
-         TModuleDocInfo* super = 0;
+         TString parentModuleName = gSystem->GetDirName(modulename);
+         TModuleDocInfo* super = nullptr;
          if (parentModuleName.Length() && parentModuleName != ".") {
             super = (TModuleDocInfo*) fDocEntityInfo.fModules.FindObject(parentModuleName);
             if (!super) {

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -2576,7 +2576,7 @@ void TFile::MakeProject(const char *dirname, const char * /*classes*/,
       // Create a PAR file
       parname = gSystem->BaseName(dirname);
       if (parname.EndsWith(".par")) parname.ReplaceAll(".par","");
-      pardir = gSystem->DirName(dirname);
+      pardir = gSystem->GetDirName(dirname);
       // Cleanup or prepare the dirs
       TString path, filepath;
       void *dir = gSystem->OpenDirectory(pardir);
@@ -3739,7 +3739,7 @@ TFile *TFile::OpenFromCache(const char *name, Option_t *, const char *ftitle,
          TString cachefilepathbasedir;
          cachefilepath = fgCacheFileDir;
          cachefilepath += fileurl.GetFile();
-         cachefilepathbasedir = gSystem->DirName(cachefilepath);
+         cachefilepathbasedir = gSystem->GetDirName(cachefilepath);
          if ((gSystem->mkdir(cachefilepathbasedir, kTRUE) < 0) &&
                (gSystem->AccessPathName(cachefilepathbasedir, kFileExists))) {
             ::Warning("TFile::OpenFromCache","you want to read through a cache, but I "

--- a/net/alien/src/TAlienCollection.cxx
+++ b/net/alien/src/TAlienCollection.cxx
@@ -213,7 +213,7 @@ TGridCollection *TAlienCollection::OpenQuery(TGridResult * queryresult,
       if (!filemap->GetValue("lfn"))
          continue;
       TString dname =
-          gSystem->DirName(filemap->GetValue("lfn")->GetName());
+          gSystem->GetDirName(filemap->GetValue("lfn")->GetName());
       TString bname =
           gSystem->BaseName(filemap->GetValue("lfn")->GetName());
       filemap->Add(new TObjString("name"), new TObjString(bname.Data()));
@@ -1526,9 +1526,9 @@ const char *TAlienCollection::GetOutputFileName(const char *infile,
 
    Reset();
    while (Next()) {
-      TString s1(gSystem->DirName(GetLFN("")));
+      TString s1 = gSystem->GetDirName(GetLFN(""));
       TString s2(gSystem->BaseName(s1.Data()));
-      TString s3(gSystem->DirName(s1.Data()));
+      TString s3 = gSystem->GetDirName(s1.Data());
       TString s4(gSystem->BaseName(s3.Data()));
       nevents++;
       if (first) {
@@ -1549,7 +1549,7 @@ const char *TAlienCollection::GetOutputFileName(const char *infile,
       char rootfile[4096];
       Int_t item;
       while ((item = fscanf(fp, "%4095s", rootfile)) == 1) {
-         TString rootdir(gSystem->DirName(rootfile));
+         TString rootdir = gSystem->GetDirName(rootfile);
          TString rootbase(gSystem->BaseName(rootfile));
          TString rootbasenosuffix;
          rootbasenosuffix = rootbase(0, rootbase.First('.'));;

--- a/proof/proof/src/TDataSetManagerFile.cxx
+++ b/proof/proof/src/TDataSetManagerFile.cxx
@@ -520,7 +520,7 @@ Int_t TDataSetManagerFile::CreateLsFile(const char *group, const char *user,
 #ifndef WIN32
       // Make sure that the ownership and permissions are those expected
       FileStat_t udirst;
-      if (!fIsRemote && gSystem->GetPathInfo(gSystem->DirName(tmpfile), udirst) == 0) {
+      if (!fIsRemote && gSystem->GetPathInfo(gSystem->GetDirName(tmpfile), udirst) == 0) {
          if (chown(lsfile.Data(), udirst.fUid, udirst.fGid) != 0) {
             Warning("CreateLsFile", "problems setting ownership on file '%s' (errno: %d)",
                                     lsfile.Data(), TSystem::GetErrno());

--- a/proof/proof/src/TProofLite.cxx
+++ b/proof/proof/src/TProofLite.cxx
@@ -1614,7 +1614,7 @@ Int_t TProofLite::CopyMacroToCache(const char *macro, Int_t headerRequired,
 
    // Update the macro path
    TString mp(TROOT::GetMacroPath());
-   TString np(gSystem->DirName(name));
+   TString np = gSystem->GetDirName(name);
    if (!np.IsNull()) {
       np += ":";
       if (!mp.BeginsWith(np) && !mp.Contains(":"+np)) {
@@ -1826,7 +1826,7 @@ Int_t TProofLite::CleanupSandbox()
 
    TSortedList *olddirs = new TSortedList(kFALSE);
 
-   TString sandbox = gSystem->DirName(fWorkDir.Data());
+   TString sandbox = gSystem->GetDirName(fWorkDir.Data());
 
    void *dirp = gSystem->OpenDirectory(sandbox);
    if (dirp) {

--- a/proof/proof/src/TProofMgr.cxx
+++ b/proof/proof/src/TProofMgr.cxx
@@ -937,7 +937,7 @@ TFileCollection *TProofMgr::UploadFiles(TList *src,
 
          // Now replace the subdirs, if required
          if (dirph.GetSize() > 0)
-            TProofMgr::ReplaceSubdirs(gSystem->DirName(furl->GetFile()), fdst, dirph);
+            TProofMgr::ReplaceSubdirs(gSystem->GetDirName(furl->GetFile()), fdst, dirph);
 
          // Check double slashes in the file field (Turl sets things correctly inside)
          TUrl u(fdst);

--- a/proof/proof/src/TProofOutputFile.cxx
+++ b/proof/proof/src/TProofOutputFile.cxx
@@ -144,7 +144,7 @@ void TProofOutputFile::Init(const char *path, const char *dsname)
       // For local files, the user is allowed to create files under the specified directory.
       // If this is not the case, the file is rooted automatically to the assigned dir which
       // is the datadir for dataset creation runs, and the working dir for merging runs
-      TString dirPath = gSystem->DirName(fFileName);
+      TString dirPath = gSystem->GetDirName(fFileName);
       fFileName = gSystem->BaseName(fFileName);
       if (AssertDir(dirPath) != 0)
          Error("Init", "problems asserting path '%s'", dirPath.Data());
@@ -518,7 +518,7 @@ Int_t TProofOutputFile::AssertDir(const char *dirpath)
    TList subPaths;
    while (existsPath != "/" && existsPath != "." && gSystem->AccessPathName(existsPath)) {
       subPaths.AddFirst(new TObjString(gSystem->BaseName(existsPath)));
-      existsPath = gSystem->DirName(existsPath);
+      existsPath = gSystem->GetDirName(existsPath);
    }
    subPaths.SetOwner(kTRUE);
    FileStat_t st;

--- a/proof/proof/src/TProofServ.cxx
+++ b/proof/proof/src/TProofServ.cxx
@@ -1510,7 +1510,7 @@ Int_t TProofServ::HandleSocketInput(TMessage *mess, Bool_t all)
                ProcessLine(str);
                if (hasfn) {
                   gSystem->ChangeDirectory(ocwd);
-                  fCacheLock->Unlock();                 
+                  fCacheLock->Unlock();
                }
             }
 
@@ -2977,7 +2977,7 @@ Int_t TProofServ::SetupCommon()
          TString compiler = COMPILER;
          if (compiler.Index("is ") != kNPOS)
             compiler.Remove(0, compiler.Index("is ") + 3);
-         compiler = gSystem->DirName(compiler);
+         compiler = gSystem->GetDirName(compiler);
          if (icomp == 1) {
             if (!bindir.IsNull()) bindir += ":";
             bindir += compiler;

--- a/proof/proof/src/TProofServLite.cxx
+++ b/proof/proof/src/TProofServLite.cxx
@@ -524,7 +524,7 @@ Int_t TProofServLite::SetupOnFork(const char *ord)
       fLogFileDes = -1;
    }
 
-   TString sdir = gSystem->DirName(fSessionDir.Data());
+   TString sdir = gSystem->GetDirName(fSessionDir.Data());
    RedirectOutput(sdir.Data(), "a");
    // If for some reason we failed setting a redirection file for the logs
    // we cannot continue

--- a/proof/proof/src/TQueryResultManager.cxx
+++ b/proof/proof/src/TQueryResultManager.cxx
@@ -284,7 +284,7 @@ Int_t TQueryResultManager::ApplyMaxQueries(Int_t mxq)
          if (gSystem->GetPathInfo(fn, st)) {
             PDB(kGlobal, 1)
                Info("ApplyMaxQueries","file '%s' cannot be stated: remove it", fn.Data());
-            gSystem->Unlink(gSystem->DirName(fn));
+            gSystem->Unlink(gSystem->GetDirName(fn));
             continue;
          }
 
@@ -317,8 +317,8 @@ Int_t TQueryResultManager::ApplyMaxQueries(Int_t mxq)
          if (nm) {
             gSystem->Unlink(nm->GetTitle());
             // Update dir counters
-            TString tdir(gSystem->DirName(nm->GetTitle()));
-            tdir = gSystem->DirName(tdir.Data());
+            TString tdir = gSystem->GetDirName(nm->GetTitle());
+            tdir = gSystem->GetDirName(tdir.Data());
             TParameter<Int_t> *nq = dynamic_cast<TParameter<Int_t>*>(dl->FindObject(tdir));
             if (nq) {
                Int_t val = nq->GetVal();

--- a/proof/proofbench/src/TProofBench.cxx
+++ b/proof/proofbench/src/TProofBench.cxx
@@ -1400,7 +1400,7 @@ Int_t TProofBench::MakeDataSet(const char *dset, Long64_t nevt, const char *fnro
       } else {
          fnr = gSystem->BaseName(ur.GetFile());
          // We need to set the basedir
-         TString bdir(gSystem->DirName(fnroot));
+         TString bdir = gSystem->GetDirName(fnroot);
          bdir += "/<fn>";
          fProof->SetParameter("PROOF_BenchmarkBaseDir", bdir.Data());
          // Flag as remote, if so

--- a/proof/proofbench/src/TProofPerfAnalysis.cxx
+++ b/proof/proofbench/src/TProofPerfAnalysis.cxx
@@ -241,7 +241,7 @@ TProofPerfAnalysis::TProofPerfAnalysis(const char *perffile,
 
    // Set the subdirectory name, if any
    if (fTreeName.Contains("/")) {
-      fDirName = gSystem->DirName(fTreeName);
+      fDirName = gSystem->GetDirName(fTreeName);
       fTreeName = gSystem->BaseName(fTreeName);
    }
 
@@ -1417,8 +1417,8 @@ void TProofPerfAnalysis::DoDraw(TObject *o, Option_t *opt, const char *name)
       if (f) delete f;
       gDirectory = curdir;
    }
-} 
- 
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Set save result mode and validate 'file' according to 'mode'.
 /// Return 0 on success, -1 if any problem with the file is encountered

--- a/proof/proofplayer/src/TProofMonSenderML.cxx
+++ b/proof/proofplayer/src/TProofMonSenderML.cxx
@@ -466,7 +466,7 @@ Int_t TProofMonSenderML::SendFileInfo(TDSet *dset, TList *missing,
          if (hmiss.FindObject(fne)) status = 0;
          // Prepare the parameters list
          nm_lnf->SetTitle(gSystem->BaseName(fne));
-         nm_path->SetTitle(gSystem->DirName(fne));
+         nm_path->SetTitle(gSystem->GetDirName(fne));
          pi_status->SetVal(status);
          fneh.Form("file_%x", TString(TUrl(fne.Data()).GetFile()).Hash());
          if (!(rc = fWriter->SendParameters(&values, fneh.Data()))) break;
@@ -482,7 +482,7 @@ Int_t TProofMonSenderML::SendFileInfo(TDSet *dset, TList *missing,
             if (hmiss.FindObject(fne)) status = 0;
             // Prepare the parameters list
             nm_lnf->SetTitle(gSystem->BaseName(fne));
-            nm_path->SetTitle(gSystem->DirName(fne));
+            nm_path->SetTitle(gSystem->GetDirName(fne));
             pi_status->SetVal(status);
             fneh.Form("file_%x", TString(TUrl(fne.Data()).GetFile()).Hash());
             if (!(rc = fWriter->SendParameters(&values, fneh.Data()))) break;

--- a/proof/proofplayer/src/TProofMonSenderSQL.cxx
+++ b/proof/proofplayer/src/TProofMonSenderSQL.cxx
@@ -462,10 +462,10 @@ Int_t TProofMonSenderSQL::SendFileInfo(TDSet *dset, TList *missing,
          status = "Ok";
          if (hmiss.FindObject(fne)) status = "Failed";
          if (fFileInfoVrs == 0)
-            ent.Form("'%s','%s','%s','%s'", gSystem->BaseName(fne), gSystem->DirName(fne),
+            ent.Form("'%s','%s','%s','%s'", gSystem->BaseName(fne), gSystem->GetDirName(fne).Data(),
                      qid, status.Data());
          else
-            ent.Form("'%s','%s','%s','%s','%s'", gSystem->BaseName(fne), gSystem->DirName(fne),
+            ent.Form("'%s','%s','%s','%s','%s'", gSystem->BaseName(fne), gSystem->GetDirName(fne).Data(),
                      qid, begin, status.Data());
          values.Add(new TObjString(ent.Data()));
       } else if ((dsete = dynamic_cast<TDSet *>(o))) {
@@ -479,10 +479,10 @@ Int_t TProofMonSenderSQL::SendFileInfo(TDSet *dset, TList *missing,
             status = "Ok";
             if (hmiss.FindObject(fne)) status = "Failed";
             if (fFileInfoVrs == 0)
-               ent.Form("'%s','%s','%s','%s'", gSystem->BaseName(fne), gSystem->DirName(fne),
+               ent.Form("'%s','%s','%s','%s'", gSystem->BaseName(fne), gSystem->GetDirName(fne).Data(),
                         qid, status.Data());
             else
-               ent.Form("'%s','%s','%s','%s','%s'", gSystem->BaseName(fne), gSystem->DirName(fne),
+               ent.Form("'%s','%s','%s','%s','%s'", gSystem->BaseName(fne), gSystem->GetDirName(fne).Data(),
                         qid, begin, status.Data());
             values.Add(new TObjString(ent.Data()));
          }

--- a/proof/proofplayer/src/TProofPlayer.cxx
+++ b/proof/proofplayer/src/TProofPlayer.cxx
@@ -982,7 +982,7 @@ Int_t TProofPlayer::AssertSelector(const char *selector_file)
          gSystem->ChangeDirectory(ocwd);
          gProofServ->GetCacheLock()->Unlock();
       }
- 
+
       if (!fSelector) {
          Error("AssertSelector", "cannot load: %s", selector_file );
         return -1;
@@ -1831,7 +1831,7 @@ void TProofPlayerRemote::SetMerging(Bool_t on)
             fQuery->SetMergeTime(rt);
             fQuery->SetNumMergers(fNumMergers);
          } else {
-            // In a standard client we save the transfer-to-client time 
+            // In a standard client we save the transfer-to-client time
             fQuery->SetRecvTime(rt);
          }
          PDB(kGlobal,2) fQuery->Print("F");
@@ -3069,7 +3069,7 @@ Bool_t TProofPlayerRemote::SendSelector(const char* selector_file)
 
    // Update the macro path
    TString mp(TROOT::GetMacroPath());
-   TString np(gSystem->DirName(selec));
+   TString np = gSystem->GetDirName(selec);
    if (!np.IsNull()) {
       np += ":";
       if (!mp.BeginsWith(np) && !mp.Contains(":"+np)) {
@@ -3211,11 +3211,11 @@ void TProofPlayerRemote::MergeOutput(Bool_t saveMemValues)
             // The ordinal
             pf->SetWorkerOrdinal("0");
             // The dir
-            pf->SetDir(gSystem->DirName(pf->GetOutputFileName()));
+            pf->SetDir(gSystem->GetDirName(pf->GetOutputFileName()));
             // The filename and raw dir
             TUrl u(pf->GetOutputFileName(), kTRUE);
             pf->SetFileName(gSystem->BaseName(u.GetFile()));
-            pf->SetDir(gSystem->DirName(u.GetFile()), kTRUE);
+            pf->SetDir(gSystem->GetDirName(u.GetFile()), kTRUE);
             // Notify the output path
             Printf("\nOutput file: %s", pf->GetOutputFileName());
          }
@@ -4202,7 +4202,7 @@ TDSetElement *TProofPlayerRemote::GetNextPacket(TSlave *slave, TMessage *r)
    TDSetElement *e = fPacketizer->GetNextPacket( slave, r );
 
    if (e == 0) {
-      PDB(kPacketizer,2) 
+      PDB(kPacketizer,2)
          Info("GetNextPacket","%s: done!", slave->GetOrdinal());
    } else if (e == (TDSetElement*) -1) {
       PDB(kPacketizer,2)

--- a/proof/proofx/src/TXProofServ.cxx
+++ b/proof/proofx/src/TXProofServ.cxx
@@ -708,7 +708,7 @@ Int_t TXProofServ::Setup()
       fTopSessionTag = "";
       // Try to extract it from log file path (for backward compatibility)
       if (gSystem->Getenv("ROOTPROOFLOGFILE")) {
-         fTopSessionTag = gSystem->DirName(gSystem->Getenv("ROOTPROOFLOGFILE"));
+         fTopSessionTag = gSystem->GetDirName(gSystem->Getenv("ROOTPROOFLOGFILE"));
          Ssiz_t lstl;
          if ((lstl = fTopSessionTag.Last('/')) != kNPOS) fTopSessionTag.Remove(0, lstl + 1);
          if (fTopSessionTag.BeginsWith("session-")) {

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -27,7 +27,7 @@ in the workspace are connected to each other. Easy accessor methods like
 `pdf()`, `var()` and `data()` allow to refer to the contents of the workspace by
 object name. The entire RooWorkspace can be saved into a ROOT TFile and organises
 the consistent streaming of its contents without duplication.
-If a RooWorkspace contains custom classes, i.e. classes not in the 
+If a RooWorkspace contains custom classes, i.e. classes not in the
 ROOT distribution, portability of workspaces can be enhanced by
 storing the source code of those classes in the workspace as well.
 This process is also organized by the workspace through the
@@ -91,7 +91,7 @@ Bool_t RooWorkspace::_autoClass = kFALSE ;
 ////////////////////////////////////////////////////////////////////////////////
 /// Add `dir` to search path for class declaration (header) files. This is needed
 /// to find class headers custom classes are imported into the workspace.
-void RooWorkspace::addClassDeclImportDir(const char* dir) 
+void RooWorkspace::addClassDeclImportDir(const char* dir)
 {
   _classDeclDirList.push_back(dir) ;
 }
@@ -100,7 +100,7 @@ void RooWorkspace::addClassDeclImportDir(const char* dir)
 ////////////////////////////////////////////////////////////////////////////////
 /// Add `dir` to search path for class implementation (.cxx) files. This is needed
 /// to find class headers custom classes are imported into the workspace.
-void RooWorkspace::addClassImplImportDir(const char* dir) 
+void RooWorkspace::addClassImplImportDir(const char* dir)
 {
   _classImplDirList.push_back(dir) ;
 }
@@ -111,7 +111,7 @@ void RooWorkspace::addClassImplImportDir(const char* dir)
 /// code is unpacked and compiled. The specified string may contain
 /// one '%s' token which will be substituted by the workspace name
 
-void RooWorkspace::setClassFileExportDir(const char* dir) 
+void RooWorkspace::setClassFileExportDir(const char* dir)
 {
   if (dir) {
     _classFileExportDir = dir ;
@@ -126,9 +126,9 @@ void RooWorkspace::setClassFileExportDir(const char* dir)
 /// is automatically imported if on object of such a class is imported
 /// in the workspace
 
-void RooWorkspace::autoImportClassCode(Bool_t flag) 
+void RooWorkspace::autoImportClassCode(Bool_t flag)
 {
-  _autoClass = flag ; 
+  _autoClass = flag ;
 }
 
 
@@ -145,13 +145,13 @@ RooWorkspace::RooWorkspace() : _classes(this), _dir(nullptr), _factory(nullptr),
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct empty workspace with given name and title
 
-RooWorkspace::RooWorkspace(const char* name, const char* title) : 
+RooWorkspace::RooWorkspace(const char* name, const char* title) :
   TNamed(name,title?title:name), _classes(this), _dir(nullptr), _factory(nullptr), _doExport(kFALSE), _openTrans(kFALSE)
 {
 }
 
 
-RooWorkspace::RooWorkspace(const char* name, Bool_t doCINTExport)  : 
+RooWorkspace::RooWorkspace(const char* name, Bool_t doCINTExport)  :
   TNamed(name,name), _classes(this), _dir(nullptr), _factory(nullptr), _doExport(kFALSE), _openTrans(kFALSE)
 {
   // Construct empty workspace with given name and option to export reference to all workspace contents to a CINT namespace with the same name
@@ -164,7 +164,7 @@ RooWorkspace::RooWorkspace(const char* name, Bool_t doCINTExport)  :
 ////////////////////////////////////////////////////////////////////////////////
 /// Workspace copy constructor
 
-RooWorkspace::RooWorkspace(const RooWorkspace& other) : 
+RooWorkspace::RooWorkspace(const RooWorkspace& other) :
   TNamed(other), _uuid(other._uuid), _classes(other._classes,this), _dir(nullptr), _factory(nullptr), _doExport(kFALSE), _openTrans(kFALSE)
 {
   // Copy owned nodes
@@ -210,7 +210,7 @@ RooWorkspace::RooWorkspace(const RooWorkspace& other) :
     _genObjects.Add(theClone);
   }
   delete iter4 ;
-  
+
 }
 
 
@@ -218,9 +218,9 @@ RooWorkspace::RooWorkspace(const RooWorkspace& other) :
 ////////////////////////////////////////////////////////////////////////////////
 /// Workspace destructor
 
-RooWorkspace::~RooWorkspace() 
+RooWorkspace::~RooWorkspace()
 {
-  // Delete references to variables that were declared in CINT 
+  // Delete references to variables that were declared in CINT
   if (_doExport) {
     unExport() ;
   }
@@ -242,10 +242,10 @@ RooWorkspace::~RooWorkspace()
 /// Import a RooAbsArg or RooAbsData set from a workspace in a file. Filespec should be constructed as "filename:wspacename:objectname"
 /// The arguments will be passed to the relevant import() or import(RooAbsData&, ...) import calls
 
-Bool_t RooWorkspace::import(const char* fileSpec, 
-			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3, 
-			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6, 
-			    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9) 
+Bool_t RooWorkspace::import(const char* fileSpec,
+			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
+			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
+			    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9)
 {
   // Parse file/workspace/objectname specification
   std::vector<std::string> tokens = RooHelpers::tokenise(fileSpec, ":");
@@ -275,7 +275,7 @@ Bool_t RooWorkspace::import(const char* fileSpec,
   // That that file contains workspace
   RooWorkspace* w = dynamic_cast<RooWorkspace*>(f->Get(wsname.c_str())) ;
   if (w==0) {
-    coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR: No object named " << wsname << " in file " << filename 
+    coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR: No object named " << wsname << " in file " << filename
 			  << " or object is not a RooWorkspace" << endl ;
     return 0 ;
   }
@@ -285,18 +285,18 @@ Bool_t RooWorkspace::import(const char* fileSpec,
   if (warg) {
     Bool_t ret = import(*warg,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9) ;
     delete f ;
-    return ret ;    
+    return ret ;
   }
   RooAbsData* wdata = w->data(objname.c_str()) ;
   if (wdata) {
     Bool_t ret = import(*wdata,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9) ;
     delete f ;
-    return ret ;    
+    return ret ;
   }
 
-  coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR: No RooAbsArg or RooAbsData object named " << objname 
+  coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR: No RooAbsArg or RooAbsData object named " << objname
 			<< " in workspace " << wsname << " in file " << filename << endl ;
-  return kTRUE ;  
+  return kTRUE ;
 }
 
 
@@ -305,9 +305,9 @@ Bool_t RooWorkspace::import(const char* fileSpec,
 /// of import() method for single RooAbsArg
 
 Bool_t RooWorkspace::import(const RooArgSet& args,
-			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3, 
-			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6, 
-			    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9) 
+			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
+			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
+			    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9)
 {
   unique_ptr<TIterator> iter(args.createIterator()) ;
   RooAbsArg* oneArg ;
@@ -323,9 +323,9 @@ Bool_t RooWorkspace::import(const RooArgSet& args,
 ////////////////////////////////////////////////////////////////////////////////
 ///  Import a RooAbsArg object, e.g. function, p.d.f or variable into the workspace. This import function clones the input argument and will
 ///  own the clone. If a composite object is offered for import, e.g. a p.d.f with parameters and observables, the
-///  complete tree of objects is imported. If any of the _variables_ of a composite object (parameters/observables) are already 
-///  in the workspace the imported p.d.f. is connected to the already existing variables. If any of the _function_ objects (p.d.f, formulas) 
-///  to be imported already exists in the workspace an error message is printed and the import of the entire tree of objects is cancelled. 
+///  complete tree of objects is imported. If any of the _variables_ of a composite object (parameters/observables) are already
+///  in the workspace the imported p.d.f. is connected to the already existing variables. If any of the _function_ objects (p.d.f, formulas)
+///  to be imported already exists in the workspace an error message is printed and the import of the entire tree of objects is cancelled.
 ///  Several optional arguments can be provided to modify the import procedure.
 ///
 ///  <table>
@@ -347,9 +347,9 @@ Bool_t RooWorkspace::import(const RooArgSet& args,
 ///  two comma separated lists.
 
 Bool_t RooWorkspace::import(const RooAbsArg& inArg,
-			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3, 
-			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6, 
-			    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9) 
+			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
+			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
+			    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9)
 {
   RooLinkedList args ;
   args.Add((TObject*)&arg1) ;
@@ -362,7 +362,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   args.Add((TObject*)&arg8) ;
   args.Add((TObject*)&arg9) ;
 
-  // Select the pdf-specific commands 
+  // Select the pdf-specific commands
   RooCmdConfig pc(Form("RooWorkspace::import(%s)",GetName())) ;
 
   pc.defineString("conflictSuffix","RenameConflictNodes",0) ;
@@ -381,7 +381,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   pc.defineMutex("RenameAllNodes","RecycleConflictNodes") ;
   pc.defineMutex("RenameVariable","RenameAllVariables") ;
 
-  // Process and check varargs 
+  // Process and check varargs
   pc.process(args) ;
   if (!pc.ok(kTRUE)) {
     return kTRUE ;
@@ -400,17 +400,17 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   Int_t noRecursion = pc.getInt("noRecursion") ;
 
 
-  // Turn zero length strings into null pointers 
+  // Turn zero length strings into null pointers
   if (suffixC && strlen(suffixC)==0) suffixC = 0 ;
   if (suffixA && strlen(suffixA)==0) suffixA = 0 ;
 
   Bool_t conflictOnly = suffixA ? kFALSE : kTRUE ;
   const char* suffix = suffixA ? suffixA : suffixC ;
 
-  // Process any change in variable names 
+  // Process any change in variable names
   map<string,string> varMap ;
   if (strlen(varChangeIn)>0) {
-    
+
     // Parse comma separated lists into map<string,string>
     const std::vector<std::string> tokIn = RooHelpers::tokenise(varChangeIn, ", ");
     const std::vector<std::string> tokOut = RooHelpers::tokenise(varChangeOut, ", ");
@@ -421,7 +421,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
     assert(tokIn.size() == tokOut.size());
   }
 
-  // Process RenameAllVariables argument if specified  
+  // Process RenameAllVariables argument if specified
   // First convert exception list if provided
   std::set<string> exceptVarNames ;
   if (exceptVars && strlen(exceptVars)) {
@@ -441,7 +441,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
     delete iter ;
     delete vars ;
   }
-  
+
   // Scan for overlaps with current contents
   RooAbsArg* wsarg = _allOwnedNodes.find(inArg.GetName()) ;
 
@@ -456,14 +456,14 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   if (!suffix && wsarg && !useExistingNodes && !(inArg.isFundamental() && varMap[inArg.GetName()]!="")) {
     if (!factoryMatch) {
       if (wsarg!=&inArg) {
-	coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR importing object named " << inArg.GetName() 
+	coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR importing object named " << inArg.GetName()
 			      << ": another instance with same name already in the workspace and no conflict resolution protocol specified" << endl ;
-	return kTRUE ;    
+	return kTRUE ;
       } else {
 	if (!silence) {
 	  coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") Object " << inArg.GetName() << " is already in workspace!" << endl ;
 	}
-	return kTRUE ;    
+	return kTRUE ;
       }
     } else {
       coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") Recycling existing object " << inArg.GetName() << " created with identical factory specification" << endl ;
@@ -487,17 +487,17 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
     }
   }
   delete iter ;
-  
+
   // Terminate here if there are conflicts and no resolution protocol
   if (conflictNodes.getSize()>0 && !suffix && !useExistingNodes) {
-      coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << inArg.GetName() << ": component(s) " 
-	   << conflictNodes << " already in the workspace and no conflict resolution protocol specified" << endl ;      
+      coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << inArg.GetName() << ": component(s) "
+	   << conflictNodes << " already in the workspace and no conflict resolution protocol specified" << endl ;
       return kTRUE ;
   }
-    
+
   // Now create a working copy of the incoming object tree
   RooArgSet* cloneSet = (RooArgSet*) RooArgSet(inArg).snapshot(noRecursion==kFALSE) ;
-  RooAbsArg* cloneTop = cloneSet->find(inArg.GetName()) ;  
+  RooAbsArg* cloneTop = cloneSet->find(inArg.GetName()) ;
 
   // Mark all nodes for renaming if we are not in conflictOnly mode
   if (!conflictOnly) {
@@ -522,18 +522,18 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 	string tag2 = Form("%s",origName.c_str()) ;
 	cnode2->setStringAttribute("origName",tag2.c_str()) ;
       }
-      
+
       // Save name of new top level node for later use
       if (cnode2==cloneTop) {
-	topName2 = cnode2->GetName() ;      
+	topName2 = cnode2->GetName() ;
       }
-      
+
       if (!silence) {
-	coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() 
-			      << ") Resolving name conflict in workspace by changing name of imported node  " 
+	coutI(ObjectHandling) << "RooWorkspace::import(" << GetName()
+			      << ") Resolving name conflict in workspace by changing name of imported node  "
 			      << origName << " to " << cnode2->GetName() << endl ;
       }
-    }  
+    }
     delete citer ;
   } else {
 
@@ -543,17 +543,17 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
     while ((cnode=(RooAbsArg*)citer->Next())) {
 
       string origName = cnode->GetName() ;
-      RooAbsArg* wsnode = _allOwnedNodes.find(origName.c_str()) ;      
-      if (wsnode) {	
-	
+      RooAbsArg* wsnode = _allOwnedNodes.find(origName.c_str()) ;
+      if (wsnode) {
+
 	if (!wsnode->getStringAttribute("origName")) {
 	  wsnode->setStringAttribute("origName",wsnode->GetName()) ;
 	}
-	
+
 	if (!_allOwnedNodes.find(Form("%s_%s",cnode->GetName(),suffix))) {
 	  wsnode->SetName(Form("%s_%s",cnode->GetName(),suffix)) ;
 	  wsnode->SetTitle(Form("%s (%s)",cnode->GetTitle(),suffix)) ;
-	} else {	  
+	} else {
 	  // Name with suffix already taken, add additional suffix
 	  Int_t n=1 ;
 	  while (true) {
@@ -567,29 +567,29 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 	  }
 	}
 	if (!silence) {
-	  coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() 
-				<< ") Resolving name conflict in workspace by changing name of original node " 
+	  coutI(ObjectHandling) << "RooWorkspace::import(" << GetName()
+				<< ") Resolving name conflict in workspace by changing name of original node "
 				<< origName << " to " << wsnode->GetName() << endl ;
 	}
       } else {
-	coutW(ObjectHandling) << "RooWorkspce::import(" << GetName() << ") Internal error: expected to find existing node " 
+	coutW(ObjectHandling) << "RooWorkspce::import(" << GetName() << ") Internal error: expected to find existing node "
 			      << origName << " to be renamed, but didn't find it..." << endl ;
       }
-      
-    }  
+
+    }
     delete citer ;
 
   }
 
-  // Process any change in variable names 
+  // Process any change in variable names
   if (strlen(varChangeIn)>0 || (suffixV && strlen(suffixV)>0)) {
-    
+
     // Process all changes in variable names
     TIterator* cliter = cloneSet->createIterator() ;
     RooAbsArg* cnode ;
     while ((cnode=(RooAbsArg*)cliter->Next())) {
-      
-      if (varMap.find(cnode->GetName())!=varMap.end()) { 	
+
+      if (varMap.find(cnode->GetName())!=varMap.end()) {
 	string origName = cnode->GetName() ;
 	cnode->SetName(varMap[cnode->GetName()].c_str()) ;
 	string tag = Form("ORIGNAME:%s",origName.c_str()) ;
@@ -600,7 +600,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 	}
 
 	if (!silence) {
-	  coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") Changing name of variable " 
+	  coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") Changing name of variable "
 				<< origName << " to " << cnode->GetName() << " on request" << endl ;
 	}
 
@@ -608,11 +608,11 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 	  topName2 = cnode->GetName() ;
 	}
 
-      }    
+      }
     }
     delete cliter ;
   }
-  
+
   // Now clone again with renaming effective
   RooArgSet* cloneSet2 = (RooArgSet*) RooArgSet(*cloneTop).snapshot(noRecursion==kFALSE) ;
   RooAbsArg* cloneTop2 = cloneSet2->find(topName2.c_str()) ;
@@ -632,19 +632,19 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 
   // Terminate here if there are conflicts and no resolution protocol
   if (conflictNodes2.getSize()) {
-    coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << inArg.GetName() << ": component(s) " 
-			  << conflictNodes2 << " cause naming conflict after conflict resolution protocol was executed" << endl ;      
+    coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << inArg.GetName() << ": component(s) "
+			  << conflictNodes2 << " cause naming conflict after conflict resolution protocol was executed" << endl ;
     return kTRUE ;
   }
-    
+
   // Print a message for each imported node
   iter = cloneSet2->createIterator() ;
-  
+
   // Perform any auxiliary imports at this point
   RooAbsArg* node ;
   while((node=(RooAbsArg*)iter->Next())) {
     if (node->importWorkspaceHook(*this)) {
-      coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << node->GetName() 
+      coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << node->GetName()
 			    << " has an error in importing in one or more of its auxiliary objects, aborting" << endl ;
       return kTRUE ;
     }
@@ -659,14 +659,14 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 
     if (_autoClass) {
       if (!_classes.autoImportClass(node->IsA())) {
-	coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") WARNING: problems import class code of object " 
+	coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") WARNING: problems import class code of object "
 			      << node->IsA()->GetName() << "::" << node->GetName() << ", reading of workspace will require external definition of class" << endl ;
       }
     }
 
     // Point expensiveObjectCache to copy in this workspace
     RooExpensiveObjectCache& oldCache = node->expensiveObjectCache() ;
-    node->setExpensiveObjectCache(_eocache) ;    
+    node->setExpensiveObjectCache(_eocache) ;
     _eocache.importCacheObjects(oldCache,node->GetName(),kTRUE) ;
 
     // Check if node is already in workspace (can only happen for variables or identical instances, unless RecycleConflictNodes is specified)
@@ -675,9 +675,9 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
     if (wsnode) {
       // Do not import node, add not to list of nodes that require reconnection
       if (!silence && useExistingNodes) {
-	coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") using existing copy of " << node->IsA()->GetName() 
-			      << "::" << node->GetName() << " for import of " << cloneTop2->IsA()->GetName() << "::" 
-			      << cloneTop2->GetName() << endl ;      
+	coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") using existing copy of " << node->IsA()->GetName()
+			      << "::" << node->GetName() << " for import of " << cloneTop2->IsA()->GetName() << "::"
+			      << cloneTop2->GetName() << endl ;
       }
       recycledNodes.add(*_allOwnedNodes.find(node->GetName())) ;
 
@@ -685,18 +685,18 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
       nodesToBeDeleted.addOwned(*node) ;
 
       //cout << "WV: recycling existing node " << existingNode << " = " << existingNode->GetName() << " for imported node " << node << endl ;
-      
+
     } else {
       // Import node
       if (!silence) {
-	coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") importing " << node->IsA()->GetName() << "::" 
+	coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") importing " << node->IsA()->GetName() << "::"
 			      << node->GetName() << endl ;
       }
       _allOwnedNodes.addOwned(*node) ;
       if (_openTrans) {
 	_sandboxNodes.add(*node) ;
       } else {
-	if (_dir && node->IsA() != RooConstVar::Class()) {	
+	if (_dir && node->IsA() != RooConstVar::Class()) {
 	  _dir->InternalAppend(node) ;
 	}
 	if (_doExport && node->IsA() != RooConstVar::Class()) {
@@ -707,7 +707,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   }
 
   // Release working copy
-  // no need to do a safe list since it was generated from a snapshot 
+  // no need to do a safe list since it was generated from a snapshot
   // just take ownership and delte elements by hand
   cloneSet->releaseOwnership() ;
   RooFIter cloneSet_iter = cloneSet->fwdIterator() ;
@@ -727,7 +727,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   delete iter ;
 
   cloneSet2->releaseOwnership() ;
-  delete cloneSet2 ;  
+  delete cloneSet2 ;
 
   return kFALSE ;
 }
@@ -744,10 +744,10 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 /// <tr><td> `RenameVariable(const char* inputName, const char* outputName)` <td> Change names of observables in dataset upon insertion
 /// <tr><td> `Silence` <td> Be quiet, except in case of errors
 
-Bool_t RooWorkspace::import(RooAbsData& inData, 
-			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3, 
-			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6, 
-			    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9) 
+Bool_t RooWorkspace::import(RooAbsData& inData,
+			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
+			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
+			    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9)
 
 {
 
@@ -762,7 +762,7 @@ Bool_t RooWorkspace::import(RooAbsData& inData,
   args.Add((TObject*)&arg8) ;
   args.Add((TObject*)&arg9) ;
 
-  // Select the pdf-specific commands 
+  // Select the pdf-specific commands
   RooCmdConfig pc(Form("RooWorkspace::import(%s)",GetName())) ;
 
   pc.defineString("dsetName","Rename",0,"") ;
@@ -771,7 +771,7 @@ Bool_t RooWorkspace::import(RooAbsData& inData,
   pc.defineInt("embedded","Embedded",0,0) ;
   pc.defineInt("silence","Silence",0,0) ;
 
-  // Process and check varargs 
+  // Process and check varargs
   pc.process(args) ;
   if (!pc.ok(kTRUE)) {
     return kTRUE ;
@@ -791,7 +791,7 @@ Bool_t RooWorkspace::import(RooAbsData& inData,
   if (dsetName && strlen(dsetName)==0) {
     dsetName=0 ;
   }
-  
+
   RooLinkedList& dataList = embedded ? _embeddedDataList : _dataList ;
 
   // Check that no dataset with target name already exists
@@ -815,7 +815,7 @@ Bool_t RooWorkspace::import(RooAbsData& inData,
   }
 
 
-  // Process any change in variable names 
+  // Process any change in variable names
   if (strlen(varChangeIn)>0) {
     // Parse comma separated lists of variable name changes
     const std::vector<std::string> tokIn  = RooHelpers::tokenise(varChangeIn, ",");
@@ -840,7 +840,7 @@ Bool_t RooWorkspace::import(RooAbsData& inData,
   }
 
   dataList.Add(clone) ;
-  if (_dir) {	
+  if (_dir) {
     _dir->InternalAppend(clone) ;
   }
   if (_doExport) {
@@ -865,7 +865,7 @@ Bool_t RooWorkspace::import(RooAbsData& inData,
 /// of aset that are not in the workspace will be imported, otherwise an error is returned
 /// for missing components
 
-Bool_t RooWorkspace::defineSet(const char* name, const RooArgSet& aset, Bool_t importMissing) 
+Bool_t RooWorkspace::defineSet(const char* name, const RooArgSet& aset, Bool_t importMissing)
 {
   // Check if set was previously defined, if so print warning
   map<string,RooArgSet>::iterator i = _namedSets.find(name) ;
@@ -884,19 +884,19 @@ Bool_t RooWorkspace::defineSet(const char* name, const RooArgSet& aset, Bool_t i
       if (importMissing) {
 	import(*sarg) ;
       } else {
-	coutE(InputArguments) << "RooWorkspace::defineSet(" << GetName() << ") ERROR set constituent \"" << sarg->GetName() 
+	coutE(InputArguments) << "RooWorkspace::defineSet(" << GetName() << ") ERROR set constituent \"" << sarg->GetName()
 			      << "\" is not in workspace and importMissing option is disabled" << endl ;
 	return kTRUE ;
       }
     }
-    wsargs.add(*arg(sarg->GetName())) ;    
+    wsargs.add(*arg(sarg->GetName())) ;
   }
   delete iter ;
 
   // Install named set
   _namedSets[name].removeAll() ;
   _namedSets[name].add(wsargs) ;
-   
+
   return kFALSE ;
 }
 
@@ -925,7 +925,7 @@ Bool_t RooWorkspace::defineSetInternal(const char *name, const RooArgSet &aset)
 /// Define a named set in the work space through a comma separated list of
 /// names of objects already in the workspace
 
-Bool_t RooWorkspace::defineSet(const char* name, const char* contentList) 
+Bool_t RooWorkspace::defineSet(const char* name, const char* contentList)
 {
   // Check if set was previously defined, if so print warning
   map<string,RooArgSet>::iterator i = _namedSets.find(name) ;
@@ -949,7 +949,7 @@ Bool_t RooWorkspace::defineSet(const char* name, const char* contentList)
   // Install named set
   _namedSets[name].removeAll() ;
   _namedSets[name].add(wsargs) ;
-   
+
   return kFALSE ;
 }
 
@@ -960,7 +960,7 @@ Bool_t RooWorkspace::defineSet(const char* name, const char* contentList)
 /// Define a named set in the work space through a comma separated list of
 /// names of objects already in the workspace
 
-Bool_t RooWorkspace::extendSet(const char* name, const char* newContents) 
+Bool_t RooWorkspace::extendSet(const char* name, const char* newContents)
 {
   RooArgSet wsargs ;
 
@@ -977,7 +977,7 @@ Bool_t RooWorkspace::extendSet(const char* name, const char* newContents)
 
   // Extend named set
   _namedSets[name].add(wsargs,kTRUE) ;
-   
+
   return kFALSE ;
 }
 
@@ -987,7 +987,7 @@ Bool_t RooWorkspace::extendSet(const char* name, const char* newContents)
 /// Return pointer to previously defined named set with given nmame
 /// If no such set is found a null pointer is returned
 
-const RooArgSet* RooWorkspace::set(const char* name) 
+const RooArgSet* RooWorkspace::set(const char* name)
 {
   map<string,RooArgSet>::iterator i = _namedSets.find(name) ;
   return (i!=_namedSets.end()) ? &(i->second) : 0 ;
@@ -999,7 +999,7 @@ const RooArgSet* RooWorkspace::set(const char* name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Rename set to a new name
 
-Bool_t RooWorkspace::renameSet(const char* name, const char* newName) 
+Bool_t RooWorkspace::renameSet(const char* name, const char* newName)
 {
   // First check if set exists
   if (!set(name)) {
@@ -1030,7 +1030,7 @@ Bool_t RooWorkspace::renameSet(const char* name, const char* newName)
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove a named set from the workspace
 
-Bool_t RooWorkspace::removeSet(const char* name) 
+Bool_t RooWorkspace::removeSet(const char* name)
 {
   // First check if set exists
   if (!set(name)) {
@@ -1052,12 +1052,12 @@ Bool_t RooWorkspace::removeSet(const char* name)
 /// Open an import transaction operations. Returns kTRUE if successful, kFALSE
 /// if there is already an ongoing transaction
 
-Bool_t RooWorkspace::startTransaction() 
+Bool_t RooWorkspace::startTransaction()
 {
   // Check that there was no ongoing transaction
   if (_openTrans) {
     return kFALSE ;
-  } 
+  }
 
   // Open transaction
   _openTrans = kTRUE ;
@@ -1072,7 +1072,7 @@ Bool_t RooWorkspace::startTransaction()
 /// will be removed and the transaction will be terminated. Return kTRUE if cancel operation
 /// succeeds, return kFALSE if there was no open transaction
 
-Bool_t RooWorkspace::cancelTransaction() 
+Bool_t RooWorkspace::cancelTransaction()
 {
   // Check that there is an ongoing transaction
   if (!_openTrans) {
@@ -1087,14 +1087,14 @@ Bool_t RooWorkspace::cancelTransaction()
   }
   delete iter ;
   _sandboxNodes.removeAll() ;
-  
+
   // Mark transaction as finished
   _openTrans = kFALSE ;
 
   return kTRUE ;
 }
 
-Bool_t RooWorkspace::commitTransaction() 
+Bool_t RooWorkspace::commitTransaction()
 {
   // Commit an ongoing import transaction. Returns kTRUE if commit succeeded,
   // return kFALSE if there was no ongoing transaction
@@ -1104,16 +1104,16 @@ Bool_t RooWorkspace::commitTransaction()
     return kFALSE ;
   }
 
-  // Publish sandbox nodes in directory and/or CINT if requested 
+  // Publish sandbox nodes in directory and/or CINT if requested
   TIterator* iter = _sandboxNodes.createIterator() ;
   RooAbsArg* sarg ;
   while((sarg=(RooAbsArg*)iter->Next())) {
-    if (_dir && sarg->IsA() != RooConstVar::Class()) {	
+    if (_dir && sarg->IsA() != RooConstVar::Class()) {
       _dir->InternalAppend(sarg) ;
     }
     if (_doExport && sarg->IsA() != RooConstVar::Class()) {
       exportObj(sarg) ;
-    }    
+    }
   }
   delete iter ;
 
@@ -1131,7 +1131,7 @@ Bool_t RooWorkspace::commitTransaction()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Bool_t RooWorkspace::importClassCode(TClass* theClass, Bool_t doReplace) 
+Bool_t RooWorkspace::importClassCode(TClass* theClass, Bool_t doReplace)
 {
   return _classes.autoImportClass(theClass,doReplace) ;
 }
@@ -1144,7 +1144,7 @@ Bool_t RooWorkspace::importClassCode(TClass* theClass, Bool_t doReplace)
 /// the standard ROOT distribution. If doReplace is true any existing
 /// class code saved in the workspace is replaced
 
-Bool_t RooWorkspace::importClassCode(const char* pat, Bool_t doReplace)  
+Bool_t RooWorkspace::importClassCode(const char* pat, Bool_t doReplace)
 {
   Bool_t ret(kTRUE) ;
 
@@ -1154,11 +1154,11 @@ Bool_t RooWorkspace::importClassCode(const char* pat, Bool_t doReplace)
   while((carg=(RooAbsArg*)iter->Next())) {
     TString className = carg->IsA()->GetName() ;
     if (className.Index(re)>=0 && !_classes.autoImportClass(carg->IsA(),doReplace)) {
-      coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") WARNING: problems import class code of object " 
+      coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") WARNING: problems import class code of object "
 			    << carg->IsA()->GetName() << "::" << carg->GetName() << ", reading of workspace will require external definition of class" << endl ;
       ret = kFALSE ;
     }
-  }  
+  }
   delete iter ;
 
   return ret ;
@@ -1172,7 +1172,7 @@ Bool_t RooWorkspace::importClassCode(const char* pat, Bool_t doReplace)
 /// Save snapshot of values and attributes (including "Constant") of given parameters.
 /// \param[in] name Name of the snapshot.
 /// \param[in] paramNames Comma-separated list of parameter names to be snapshot.
-Bool_t RooWorkspace::saveSnapshot(const char* name, const char* paramNames) 
+Bool_t RooWorkspace::saveSnapshot(const char* name, const char* paramNames)
 {
   return saveSnapshot(name,argSet(paramNames),kFALSE) ;
 }
@@ -1187,7 +1187,7 @@ Bool_t RooWorkspace::saveSnapshot(const char* name, const char* paramNames)
 /// saved. If importValues is TRUE, the values of the objects passed in the 'params'
 /// argument are saved
 
-Bool_t RooWorkspace::saveSnapshot(const char* name, const RooArgSet& params, Bool_t importValues) 
+Bool_t RooWorkspace::saveSnapshot(const char* name, const RooArgSet& params, Bool_t importValues)
 {
   RooArgSet* actualParams = (RooArgSet*) _allOwnedNodes.selectCommon(params) ;
   RooArgSet* snapshot = (RooArgSet*) actualParams->snapshot() ;
@@ -1218,7 +1218,7 @@ Bool_t RooWorkspace::saveSnapshot(const char* name, const RooArgSet& params, Boo
 /// Load the values and attributes of the parameters in the snapshot saved with
 /// the given name
 
-Bool_t RooWorkspace::loadSnapshot(const char* name) 
+Bool_t RooWorkspace::loadSnapshot(const char* name)
 {
   RooArgSet* snap = (RooArgSet*) _snapshots.find(name) ;
   if (!snap) {
@@ -1255,10 +1255,10 @@ const RooArgSet* RooWorkspace::getSnapshot(const char* name) const
 
 
 // //_____________________________________________________________________________
-// RooAbsPdf* RooWorkspace::joinPdf(const char* jointPdfName, const char* indexName, const char* inputMapping) 
+// RooAbsPdf* RooWorkspace::joinPdf(const char* jointPdfName, const char* indexName, const char* inputMapping)
 // {
 //   // Join given list of p.d.f.s into a simultaneous p.d.f with given name. If the named index category
-//   // does not exist, it is created. 
+//   // does not exist, it is created.
 //   //
 //   //  Example : joinPdf("simPdf","expIndex","A=pdfA,B=pdfB") ;
 //   //
@@ -1270,7 +1270,7 @@ const RooArgSet* RooWorkspace::getSnapshot(const char* name) const
 // }
 
 // //_____________________________________________________________________________
-// RooAbsData* RooWorkspace::joinData(const char* jointDataName, const char* indexName, const char* inputMapping) 
+// RooAbsData* RooWorkspace::joinData(const char* jointDataName, const char* indexName, const char* inputMapping)
 // {
 //   // Join given list of dataset into a joint dataset for use with a simultaneous pdf
 //   // (as e.g. created by joingPdf"
@@ -1288,17 +1288,17 @@ const RooArgSet* RooWorkspace::getSnapshot(const char* name) const
 /// Retrieve p.d.f (RooAbsPdf) with given name. A null pointer is returned if not found
 
 RooAbsPdf* RooWorkspace::pdf(const char* name) const
-{ 
-  return dynamic_cast<RooAbsPdf*>(_allOwnedNodes.find(name)) ; 
+{
+  return dynamic_cast<RooAbsPdf*>(_allOwnedNodes.find(name)) ;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieve function (RooAbsReal) with given name. Note that all RooAbsPdfs are also RooAbsReals. A null pointer is returned if not found.
 
-RooAbsReal* RooWorkspace::function(const char* name) const 
-{ 
-  return dynamic_cast<RooAbsReal*>(_allOwnedNodes.find(name)) ; 
+RooAbsReal* RooWorkspace::function(const char* name) const
+{
+  return dynamic_cast<RooAbsReal*>(_allOwnedNodes.find(name)) ;
 }
 
 
@@ -1306,8 +1306,8 @@ RooAbsReal* RooWorkspace::function(const char* name) const
 /// Retrieve real-valued variable (RooRealVar) with given name. A null pointer is returned if not found
 
 RooRealVar* RooWorkspace::var(const char* name) const
-{ 
-  return dynamic_cast<RooRealVar*>(_allOwnedNodes.find(name)) ; 
+{
+  return dynamic_cast<RooRealVar*>(_allOwnedNodes.find(name)) ;
 }
 
 
@@ -1315,8 +1315,8 @@ RooRealVar* RooWorkspace::var(const char* name) const
 /// Retrieve discrete variable (RooCategory) with given name. A null pointer is returned if not found
 
 RooCategory* RooWorkspace::cat(const char* name) const
-{ 
-  return dynamic_cast<RooCategory*>(_allOwnedNodes.find(name)) ; 
+{
+  return dynamic_cast<RooCategory*>(_allOwnedNodes.find(name)) ;
 }
 
 
@@ -1325,7 +1325,7 @@ RooCategory* RooWorkspace::cat(const char* name) const
 
 RooAbsCategory* RooWorkspace::catfunc(const char* name) const
 {
-  return dynamic_cast<RooAbsCategory*>(_allOwnedNodes.find(name)) ; 
+  return dynamic_cast<RooAbsCategory*>(_allOwnedNodes.find(name)) ;
 }
 
 
@@ -1449,9 +1449,9 @@ RooArgSet RooWorkspace::allFunctions() const
   TIterator* iter = _allOwnedNodes.createIterator() ;
   RooAbsArg* parg ;
   while((parg=(RooAbsArg*)iter->Next())) {
-    if (parg->IsA()->InheritsFrom(RooAbsReal::Class()) && 
-	!parg->IsA()->InheritsFrom(RooAbsPdf::Class()) && 
-	!parg->IsA()->InheritsFrom(RooConstVar::Class()) && 
+    if (parg->IsA()->InheritsFrom(RooAbsReal::Class()) &&
+	!parg->IsA()->InheritsFrom(RooAbsPdf::Class()) &&
+	!parg->IsA()->InheritsFrom(RooConstVar::Class()) &&
 	!parg->IsA()->InheritsFrom(RooRealVar::Class())) {
       ret.add(*parg) ;
     }
@@ -1471,8 +1471,8 @@ RooArgSet RooWorkspace::allCatFunctions() const
   // Split list of components in pdfs, functions and variables
   TIterator* iter = _allOwnedNodes.createIterator() ;
   RooAbsArg* parg ;
-  while((parg=(RooAbsArg*)iter->Next())) {  
-    if (parg->IsA()->InheritsFrom(RooAbsCategory::Class()) && 
+  while((parg=(RooAbsArg*)iter->Next())) {
+    if (parg->IsA()->InheritsFrom(RooAbsCategory::Class()) &&
 	!parg->IsA()->InheritsFrom(RooCategory::Class())) {
       ret.add(*parg) ;
     }
@@ -1492,7 +1492,7 @@ RooArgSet RooWorkspace::allResolutionModels() const
   // Split list of components in pdfs, functions and variables
   TIterator* iter = _allOwnedNodes.createIterator() ;
   RooAbsArg* parg ;
-  while((parg=(RooAbsArg*)iter->Next())) {  
+  while((parg=(RooAbsArg*)iter->Next())) {
     if (parg->IsA()->InheritsFrom(RooResolutionModel::Class())) {
       if (!((RooResolutionModel*)parg)->isConvolved()) {
 	ret.add(*parg) ;
@@ -1513,7 +1513,7 @@ RooArgSet RooWorkspace::allPdfs() const
   // Split list of components in pdfs, functions and variables
   TIterator* iter = _allOwnedNodes.createIterator() ;
   RooAbsArg* parg ;
-  while((parg=(RooAbsArg*)iter->Next())) {  
+  while((parg=(RooAbsArg*)iter->Next())) {
     if (parg->IsA()->InheritsFrom(RooAbsPdf::Class()) &&
 	!parg->IsA()->InheritsFrom(RooResolutionModel::Class())) {
       ret.add(*parg) ;
@@ -1527,7 +1527,7 @@ RooArgSet RooWorkspace::allPdfs() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return list of all dataset in the workspace
 
-list<RooAbsData*> RooWorkspace::allData() const 
+list<RooAbsData*> RooWorkspace::allData() const
 {
   list<RooAbsData*> ret ;
   TIterator* iter = _dataList.MakeIterator() ;
@@ -1543,7 +1543,7 @@ list<RooAbsData*> RooWorkspace::allData() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return list of all dataset in the workspace
 
-list<RooAbsData*> RooWorkspace::allEmbeddedData() const 
+list<RooAbsData*> RooWorkspace::allEmbeddedData() const
 {
   list<RooAbsData*> ret ;
   TIterator* iter = _embeddedDataList.MakeIterator() ;
@@ -1560,12 +1560,12 @@ list<RooAbsData*> RooWorkspace::allEmbeddedData() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return list of all generic objects in the workspace
 
-list<TObject*> RooWorkspace::allGenericObjects() const 
+list<TObject*> RooWorkspace::allGenericObjects() const
 {
   list<TObject*> ret ;
   TIterator* iter = _genObjects.MakeIterator() ;
   TObject* gobj ;
-  while((gobj=(RooAbsData*)iter->Next())) {    
+  while((gobj=(RooAbsData*)iter->Next())) {
 
     // If found object is wrapper, return payload
     if (gobj->IsA()==RooTObjWrap::Class()) {
@@ -1589,7 +1589,7 @@ list<TObject*> RooWorkspace::allGenericObjects() const
 /// files respectively. If files cannot be found, abort with error status, otherwise update the internal
 /// class-to-file map and import the contents of the files, if they are not imported yet.
 
-Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace) 
+Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
 {
 
   oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") request to import code of class " << tc->GetName() << endl ;
@@ -1615,7 +1615,7 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
 
   // Check that file names are not empty
   if (implfile.empty() || declfile.empty()) {
-    oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") ERROR: cannot retrieve code file names for class " 
+    oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") ERROR: cannot retrieve code file names for class "
 				   << tc->GetName() << " through ROOT TClass interface, unable to import code" << endl ;
     return kFALSE ;
   }
@@ -1632,13 +1632,13 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
   // (We also need a default ctor of abstract classes, but cannot check that through is interface
   //  as TClass::HasDefaultCtor only returns true for callable default ctors)
   if (!(tc->Property() & kIsAbstract) && !tc->HasDefaultConstructor()) {
-    oocoutW(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() << ") WARNING cannot import class " 
+    oocoutW(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() << ") WARNING cannot import class "
 				    << tc->GetName() << " : it cannot be persisted because it doesn't have a default constructor. Please fix " << endl ;
-    return kFALSE ;      
+    return kFALSE ;
   }
 
 
-  // *** PHASE 2 *** Check if declaration and implementation files can be located 
+  // *** PHASE 2 *** Check if declaration and implementation files can be located
 
   char* declpath = 0 ;
 
@@ -1650,8 +1650,8 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
     list<string>::iterator diter = RooWorkspace::_classDeclDirList.begin() ;
 
     while(diter!= RooWorkspace::_classDeclDirList.end()) {
-      
-      declpath = gSystem->ConcatFileName(diter->c_str(),declfile.c_str()) ;      
+
+      declpath = gSystem->ConcatFileName(diter->c_str(),declfile.c_str()) ;
       if (!gSystem->AccessPathName(declpath)) {
 	// found declaration file
 	break ;
@@ -1662,10 +1662,10 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
 
       ++diter ;
     }
-    
+
     // Header file cannot be found anywhere, warn user and abort operation
     if (!declpath) {
-      oocoutW(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() << ") WARNING Cannot access code of class " 
+      oocoutW(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() << ") WARNING Cannot access code of class "
 				      << tc->GetName() << " because header file " << declfile << " is not found in current directory nor in $ROOTSYS" ;
       if (_classDeclDirList.size()>0) {
 	ooccoutW(_wspace,ObjectHandling) << ", nor in the search path " ;
@@ -1682,12 +1682,12 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
       }
       ooccoutW(_wspace,ObjectHandling) << ". To fix this problem, add the required directory to the search "
 				       << "path using RooWorkspace::addClassDeclImportDir(const char* dir)" << endl ;
-      
+
       return kFALSE ;
     }
   }
 
-  
+
   // Check if implementation file can be found in specified location
   // If not, scan through list of 'class implementation' paths in RooWorkspace
   if (gSystem->AccessPathName(implfile.c_str())) {
@@ -1696,8 +1696,8 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
     list<string>::iterator iiter = RooWorkspace::_classImplDirList.begin() ;
 
     while(iiter!= RooWorkspace::_classImplDirList.end()) {
-      
-      implpath = gSystem->ConcatFileName(iiter->c_str(),implfile.c_str()) ;      
+
+      implpath = gSystem->ConcatFileName(iiter->c_str(),implfile.c_str()) ;
       if (!gSystem->AccessPathName(implpath)) {
 	// found implementation file
 	break ;
@@ -1708,10 +1708,10 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
 
       ++iiter ;
     }
-     
+
     // Implementation file cannot be found anywhere, warn user and abort operation
     if (!implpath) {
-      oocoutW(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() << ") WARNING Cannot access code of class " 
+      oocoutW(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() << ") WARNING Cannot access code of class "
 				      << tc->GetName() << " because implementation file " << implfile << " is not found in current directory nor in $ROOTSYS" ;
       if (_classDeclDirList.size()>0) {
 	ooccoutW(_wspace,ObjectHandling) << ", nor in the search path " ;
@@ -1727,7 +1727,7 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
 	}
       }
       ooccoutW(_wspace,ObjectHandling) << ". To fix this problem add the required directory to the search "
-				       << "path using RooWorkspace::addClassImplImportDir(const char* dir)" << endl ;    
+				       << "path using RooWorkspace::addClassImplImportDir(const char* dir)" << endl ;
       return kFALSE ;
     }
   }
@@ -1759,28 +1759,28 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
 
     // Open declaration file
     fstream fdecl(declpath?declpath:declfile.c_str()) ;
-    
+
     // Abort import if declaration file cannot be opened
     if (!fdecl) {
-      oocoutE(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() 
+      oocoutE(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
 				      << ") ERROR opening declaration file " <<  declfile << endl ;
-      return kFALSE ;      
+      return kFALSE ;
     }
-    
-    oocoutI(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() 
-				    << ") importing code of class " << tc->GetName() 
-				    << " from " << (implpath?implpath:implfile.c_str()) 
+
+    oocoutI(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
+				    << ") importing code of class " << tc->GetName()
+				    << " from " << (implpath?implpath:implfile.c_str())
 				    << " and " << (declpath?declpath:declfile.c_str()) << endl ;
-    
-    
+
+
     // Read entire file into an stl string
     string decl ;
     while(fdecl.getline(buf,1023)) {
-      
+
       // Look for include state of self
       Bool_t processedInclude = kFALSE ;
       char* extincfile = 0 ;
-      
+
       // Look for include of declaration file corresponding to this implementation file
       if (strstr(buf,"#include")) {
 	// Process #include statements here
@@ -1804,37 +1804,37 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
       }
    }
       }
-      
+
       if (processedInclude) {
 	decl += "// external include file below retrieved from workspace code storage\n" ;
-	decl += Form("#include \"%s\"\n",extincfile) ; 
+	decl += Form("#include \"%s\"\n",extincfile) ;
       } else {
 	decl += buf ;
 	decl += '\n' ;
       }
     }
-    
+
     // Open implementation file
     fstream fimpl(implpath?implpath:implfile.c_str()) ;
-    
+
     // Abort import if implementation file cannot be opened
     if (!fimpl) {
-      oocoutE(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() 
+      oocoutE(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
 				      << ") ERROR opening implementation file " <<  implfile << endl ;
-      return kFALSE ;      
+      return kFALSE ;
     }
-    
-    
+
+
     // Import entire implentation file into stl string
     string impl ;
     while(fimpl.getline(buf,1023)) {
       // Process #include statements here
-      
+
       // Look for include state of self
       Bool_t foundSelfInclude=kFALSE ;
       Bool_t processedInclude = kFALSE ;
       char* extincfile = 0 ;
-      
+
       // Look for include of declaration file corresponding to this implementation file
       if (strstr(buf,"#include")) {
 	// Process #include statements here
@@ -1863,26 +1863,26 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
       }
    }
       }
-      
+
       // Explicitly rewrite include of own declaration file to string
       // any directory prefixes, copy all other lines verbatim in stl string
       if (foundSelfInclude) {
-	// If include of self is found, substitute original include 
+	// If include of self is found, substitute original include
 	// which may have directory structure with a plain include
 	impl += "// class declaration include file below retrieved from workspace code storage\n" ;
 	impl += Form("#include \"%s.%s\"\n",declfilebase.c_str(),declfileext.c_str()) ;
       } else if (processedInclude) {
 	impl += "// external include file below retrieved from workspace code storage\n" ;
-	impl += Form("#include \"%s\"\n",extincfile) ; 
+	impl += Form("#include \"%s\"\n",extincfile) ;
       } else {
 	impl += buf ;
 	impl += '\n' ;
       }
     }
-            
+
     // Create entry in file map
     _fmap[declfilebase]._hfile = decl ;
-    _fmap[declfilebase]._cxxfile = impl ;   
+    _fmap[declfilebase]._cxxfile = impl ;
     _fmap[declfilebase]._hext = declfileext ;
 
     // Process extra includes now
@@ -1894,8 +1894,8 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
 	fstream fehdr(ehiter->c_str()) ;
 	string ehimpl ;
 	char buf2[1024] ;
-	while(fehdr.getline(buf2,1023)) {	  
-	  
+	while(fehdr.getline(buf2,1023)) {
+
 	  // Look for include of declaration file corresponding to this implementation file
 	  if (strstr(buf2,"#include")) {
 	    // Process #include statements here
@@ -1931,19 +1931,19 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
   } else {
 
     // Inform that existing file entry is being recycled because it already contained class code
-    oocoutI(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName() 
-				    << ") code of class " << tc->GetName() 
-				    << " was already imported from " << (implpath?implpath:implfile.c_str()) 
+    oocoutI(_wspace,ObjectHandling) << "RooWorkspace::autoImportClass(" << _wspace->GetName()
+				    << ") code of class " << tc->GetName()
+				    << " was already imported from " << (implpath?implpath:implfile.c_str())
 				    << " and " << (declpath?declpath:declfile.c_str()) << endl ;
-    
+
   }
 
 
-  // *** PHASE 4 *** Import stl strings with code into workspace 
+  // *** PHASE 4 *** Import stl strings with code into workspace
   //
   // If multiple classes are declared in a single code unit, there will be
-  // multiple _c2fmap entries all pointing to the same _fmap entry.  
-  
+  // multiple _c2fmap entries all pointing to the same _fmap entry.
+
   // Make list of all immediate base classes of this class
   TString baseNameList ;
   TList* bl = tc->GetListOfBases() ;
@@ -1957,12 +1957,12 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
     baseNameList += base->GetClassPointer()->GetName() ;
     bases.push_back(base->GetClassPointer()) ;
   }
-  
+
   // Map class name to above _fmap entries, along with list of base classes
   // in _c2fmap
   _c2fmap[tc->GetName()]._baseName = baseNameList ;
   _c2fmap[tc->GetName()]._fileBase = declfilebase ;
-  
+
   // Recursive store all base classes.
   list<TClass*>::iterator biter = bases.begin() ;
   while(biter!=bases.end()) {
@@ -1970,7 +1970,7 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
     ++biter ;
   }
 
-  // Cleanup 
+  // Cleanup
   if (implpath) {
     delete[] implpath ;
   }
@@ -1993,13 +1993,13 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
 /// when constructed. This will give error messages when done in a workspace
 /// directory.
 
-Bool_t RooWorkspace::makeDir() 
+Bool_t RooWorkspace::makeDir()
 {
   if (_dir) return kTRUE ;
 
   TString title= Form("TDirectory representation of RooWorkspace %s",GetName()) ;
   _dir = new WSDir(GetName(),title.Data(),this) ;
-  
+
   TIterator* iter = componentIterator() ;
   RooAbsArg* darg ;
   while((darg=(RooAbsArg*)iter->Next())) {
@@ -2007,28 +2007,28 @@ Bool_t RooWorkspace::makeDir()
       _dir->InternalAppend(darg) ;
     }
   }
-  
+
   return kTRUE ;
 }
- 
- 
+
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Import a clone of a generic TObject into workspace generic object container. Imported
 /// object can be retrieved by name through the obj() method. The object is cloned upon
 /// importation and the input argument does not need to live beyond the import call
-/// 
+///
 /// Returns kTRUE if an error has occurred.
 
-Bool_t RooWorkspace::import(TObject& object, Bool_t replaceExisting) 
+Bool_t RooWorkspace::import(TObject& object, Bool_t replaceExisting)
 {
   // First check if object with given name already exists
   TObject* oldObj = _genObjects.FindObject(object.GetName()) ;
   if (oldObj && !replaceExisting) {
-    coutE(InputArguments) << "RooWorkspace::import(" << GetName() << ") generic object with name " 
+    coutE(InputArguments) << "RooWorkspace::import(" << GetName() << ") generic object with name "
 			  << object.GetName() << " is already in workspace and replaceExisting flag is set to false" << endl ;
     return kTRUE ;
-  }  
+  }
 
   // Grab the current state of the directory Auto-Add
   ROOT::DirAutoAdd_t func = object.IsA()->GetDirectoryAutoAdd();
@@ -2053,31 +2053,31 @@ Bool_t RooWorkspace::import(TObject& object, Bool_t replaceExisting)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Import a clone of a generic TObject into workspace generic object container. 
+/// Import a clone of a generic TObject into workspace generic object container.
 /// The imported object will be stored under the given alias name rather than its
-/// own name. Imported object can be retrieved its alias name through the obj() method. 
+/// own name. Imported object can be retrieved its alias name through the obj() method.
 /// The object is cloned upon importation and the input argument does not need to live beyond the import call
 /// This method is mostly useful for importing objects that do not have a settable name such as TMatrix
-/// 
+///
 /// Returns kTRUE if an error has occurred.
 
-Bool_t RooWorkspace::import(TObject& object, const char* aliasName, Bool_t replaceExisting) 
+Bool_t RooWorkspace::import(TObject& object, const char* aliasName, Bool_t replaceExisting)
 {
   // First check if object with given name already exists
   TObject* oldObj = _genObjects.FindObject(object.GetName()) ;
   if (oldObj && !replaceExisting) {
-    coutE(InputArguments) << "RooWorkspace::import(" << GetName() << ") generic object with name " 
+    coutE(InputArguments) << "RooWorkspace::import(" << GetName() << ") generic object with name "
 			  << object.GetName() << " is already in workspace and replaceExisting flag is set to false" << endl ;
     return kTRUE ;
-  }  
-  
+  }
+
   TH1::AddDirectory(kFALSE) ;
   RooTObjWrap* wrapper = new RooTObjWrap(object.Clone()) ;
   TH1::AddDirectory(kTRUE) ;
   wrapper->setOwning(kTRUE) ;
   wrapper->SetName(aliasName) ;
   wrapper->SetTitle(aliasName) ;
-    
+
   if (oldObj) {
     _genObjects.Replace(oldObj,wrapper) ;
     delete oldObj ;
@@ -2093,7 +2093,7 @@ Bool_t RooWorkspace::import(TObject& object, const char* aliasName, Bool_t repla
 ////////////////////////////////////////////////////////////////////////////////
 /// Insert RooStudyManager module
 
-Bool_t RooWorkspace::addStudy(RooAbsStudy& study) 
+Bool_t RooWorkspace::addStudy(RooAbsStudy& study)
 {
   RooAbsStudy* clone = (RooAbsStudy*) study.Clone() ;
   _studyMods.Add(clone) ;
@@ -2106,7 +2106,7 @@ Bool_t RooWorkspace::addStudy(RooAbsStudy& study)
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove all RooStudyManager modules
 
-void RooWorkspace::clearStudies() 
+void RooWorkspace::clearStudies()
 {
   _studyMods.Delete() ;
 }
@@ -2154,7 +2154,7 @@ TObject* RooWorkspace::genobj(const char* name)  const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Bool_t RooWorkspace::cd(const char* path) 
+Bool_t RooWorkspace::cd(const char* path)
 {
   makeDir() ;
   return _dir->cd(path) ;
@@ -2165,17 +2165,17 @@ Bool_t RooWorkspace::cd(const char* path)
 ////////////////////////////////////////////////////////////////////////////////
 /// Save this current workspace into given file
 
-Bool_t RooWorkspace::writeToFile(const char* fileName, Bool_t recreate) 
+Bool_t RooWorkspace::writeToFile(const char* fileName, Bool_t recreate)
 {
   TFile f(fileName,recreate?"RECREATE":"UPDATE") ;
   Write() ;
   return kFALSE ;
 }
- 
- 
+
+
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return instance to factory tool 
+/// Return instance to factory tool
 
 RooFactoryWSTool& RooWorkspace::factory()
 {
@@ -2202,9 +2202,9 @@ RooAbsArg* RooWorkspace::factory(const char* expr)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Print contents of the workspace 
+/// Print contents of the workspace
 
-void RooWorkspace::Print(Option_t* opts) const 
+void RooWorkspace::Print(Option_t* opts) const
 {
   Bool_t treeMode(kFALSE) ;
   Bool_t verbose(kFALSE);
@@ -2216,7 +2216,7 @@ void RooWorkspace::Print(Option_t* opts) const
   }
 
   cout << endl << "RooWorkspace(" << GetName() << ") " << GetTitle() << " contents" << endl << endl  ;
-  
+
   RooAbsArg* parg ;
 
   RooArgSet pdfSet ;
@@ -2234,7 +2234,7 @@ void RooWorkspace::Print(Option_t* opts) const
     //---------------
 
     if (treeMode) {
-      
+
       // In tree mode, only add nodes with no clients to the print lists
 
       if (parg->IsA()->InheritsFrom(RooAbsPdf::Class())) {
@@ -2242,20 +2242,20 @@ void RooWorkspace::Print(Option_t* opts) const
 	  pdfSet.add(*parg) ;
 	}
       }
-      
-      if (parg->IsA()->InheritsFrom(RooAbsReal::Class()) && 
-	  !parg->IsA()->InheritsFrom(RooAbsPdf::Class()) && 
-	  !parg->IsA()->InheritsFrom(RooConstVar::Class()) && 
+
+      if (parg->IsA()->InheritsFrom(RooAbsReal::Class()) &&
+	  !parg->IsA()->InheritsFrom(RooAbsPdf::Class()) &&
+	  !parg->IsA()->InheritsFrom(RooConstVar::Class()) &&
 	  !parg->IsA()->InheritsFrom(RooRealVar::Class())) {
 	if (!parg->hasClients()) {
 	  funcSet.add(*parg) ;
 	}
       }
-      
-      
-      if (parg->IsA()->InheritsFrom(RooAbsCategory::Class()) && 
+
+
+      if (parg->IsA()->InheritsFrom(RooAbsCategory::Class()) &&
 	  !parg->IsA()->InheritsFrom(RooCategory::Class())) {
-	if (!parg->hasClients()) {	
+	if (!parg->hasClients()) {
 	  catfuncSet.add(*parg) ;
 	}
       }
@@ -2269,20 +2269,20 @@ void RooWorkspace::Print(Option_t* opts) const
 	  resoSet.add(*parg) ;
 	}
       }
-      
+
       if (parg->IsA()->InheritsFrom(RooAbsPdf::Class()) &&
 	  !parg->IsA()->InheritsFrom(RooResolutionModel::Class())) {
 	pdfSet.add(*parg) ;
       }
-      
-      if (parg->IsA()->InheritsFrom(RooAbsReal::Class()) && 
-	  !parg->IsA()->InheritsFrom(RooAbsPdf::Class()) && 
-	  !parg->IsA()->InheritsFrom(RooConstVar::Class()) && 
+
+      if (parg->IsA()->InheritsFrom(RooAbsReal::Class()) &&
+	  !parg->IsA()->InheritsFrom(RooAbsPdf::Class()) &&
+	  !parg->IsA()->InheritsFrom(RooConstVar::Class()) &&
 	  !parg->IsA()->InheritsFrom(RooRealVar::Class())) {
 	funcSet.add(*parg) ;
       }
-      
-      if (parg->IsA()->InheritsFrom(RooAbsCategory::Class()) && 
+
+      if (parg->IsA()->InheritsFrom(RooAbsCategory::Class()) &&
 	  !parg->IsA()->InheritsFrom(RooCategory::Class())) {
 	catfuncSet.add(*parg) ;
       }
@@ -2414,7 +2414,7 @@ void RooWorkspace::Print(Option_t* opts) const
       Bool_t first(kTRUE) ;
       while((a=(RooAbsArg*)aiter->Next())) {
 	if (first) { first=kFALSE ; } else { cout << "," ; }
-	cout << a->GetName() << "=" ; 
+	cout << a->GetName() << "=" ;
 	a->printValue(cout) ;
 	if (a->isConstant()) {
 	  cout << "[C]" ;
@@ -2436,11 +2436,11 @@ void RooWorkspace::Print(Option_t* opts) const
           cout << it->first << ":" << it->second << endl;
        }
     }
-    
+
     cout << endl ;
   }
 
- 
+
   if (_genObjects.GetSize()>0) {
     cout << "generic objects" << endl ;
     cout << "---------------" << endl ;
@@ -2455,7 +2455,7 @@ void RooWorkspace::Print(Option_t* opts) const
     }
     delete iter ;
     cout << endl ;
-    
+
   }
 
   if (_studyMods.GetSize()>0) {
@@ -2468,12 +2468,12 @@ void RooWorkspace::Print(Option_t* opts) const
     }
     delete iter ;
     cout << endl ;
-    
+
   }
 
   if (_classes.listOfClassNames().size()>0) {
     cout << "embedded class code" << endl ;
-    cout << "-------------------" << endl ;    
+    cout << "-------------------" << endl ;
     cout << _classes.listOfClassNames() << endl ;
     cout << endl ;
   }
@@ -2504,28 +2504,28 @@ void RooWorkspace::CodeRepo::Streamer(TBuffer &R__b)
    if (R__b.IsReading()) {
 
      UInt_t R__s, R__c;
-     Version_t R__v =  R__b.ReadVersion(&R__s, &R__c); 
+     Version_t R__v =  R__b.ReadVersion(&R__s, &R__c);
 
      // Stream contents of ClassFiles map
      Int_t count(0) ;
      R__b >> count ;
      while(count--) {
        TString name ;
-       name.Streamer(R__b) ;       
+       name.Streamer(R__b) ;
        _fmap[name]._hext.Streamer(R__b) ;
        _fmap[name]._hfile.Streamer(R__b) ;
-       _fmap[name]._cxxfile.Streamer(R__b) ;    
-     }     
- 
+       _fmap[name]._cxxfile.Streamer(R__b) ;
+     }
+
      // Stream contents of ClassRelInfo map
      count=0 ;
      R__b >> count ;
      while(count--) {
        TString name ;
-       name.Streamer(R__b) ;       
+       name.Streamer(R__b) ;
        _c2fmap[name]._baseName.Streamer(R__b) ;
        _c2fmap[name]._fileBase.Streamer(R__b) ;
-     }     
+     }
 
      if (R__v==2) {
 
@@ -2533,10 +2533,10 @@ void RooWorkspace::CodeRepo::Streamer(TBuffer &R__b)
        R__b >> count ;
        while(count--) {
 	 TString name ;
-	 name.Streamer(R__b) ;       
+	 name.Streamer(R__b) ;
 	 _ehmap[name]._hname.Streamer(R__b) ;
 	 _ehmap[name]._hfile.Streamer(R__b) ;
-       }                  
+       }
      }
 
      R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
@@ -2545,15 +2545,15 @@ void RooWorkspace::CodeRepo::Streamer(TBuffer &R__b)
      _compiledOK = !compileClasses() ;
 
    } else {
-     
+
      UInt_t R__c;
      R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
-     
+
      // Stream contents of ClassFiles map
      UInt_t count = _fmap.size() ;
      R__b << count ;
      map<TString,ClassFiles>::iterator iter = _fmap.begin() ;
-     while(iter!=_fmap.end()) {       
+     while(iter!=_fmap.end()) {
        TString key_copy(iter->first) ;
        key_copy.Streamer(R__b) ;
        iter->second._hext.Streamer(R__b) ;
@@ -2562,7 +2562,7 @@ void RooWorkspace::CodeRepo::Streamer(TBuffer &R__b)
 
        ++iter ;
      }
-     
+
      // Stream contents of ClassRelInfo map
      count = _c2fmap.size() ;
      R__b << count ;
@@ -2588,7 +2588,7 @@ void RooWorkspace::CodeRepo::Streamer(TBuffer &R__b)
      }
 
      R__b.SetByteCount(R__c, kTRUE);
-     
+
    }
 }
 
@@ -2597,7 +2597,7 @@ void RooWorkspace::CodeRepo::Streamer(TBuffer &R__b)
 /// Stream an object of class RooWorkspace. This is a standard ROOT streamer for the
 /// I/O part. This custom function exists to detach all external client links
 /// from the payload prior to writing the payload so that these client links
-/// are not persisted. (Client links occur if external function objects use 
+/// are not persisted. (Client links occur if external function objects use
 /// objects contained in the workspace as input)
 /// After the actual writing, these client links are restored.
 
@@ -2606,7 +2606,7 @@ void RooWorkspace::Streamer(TBuffer &R__b)
    if (R__b.IsReading()) {
 
       R__b.ReadClassBuffer(RooWorkspace::Class(),this);
-            
+
       // Perform any pass-2 schema evolution here
       RooFIter fiter = _allOwnedNodes.fwdIterator() ;
       RooAbsArg* node ;
@@ -2614,7 +2614,7 @@ void RooWorkspace::Streamer(TBuffer &R__b)
 	node->ioStreamerPass2() ;
       }
       RooAbsArg::ioStreamerPass2Finalize() ;
-      
+
       // Make expensive object cache of all objects point to intermal copy.
       // Somehow this doesn't work OK automatically
       TIterator* iter = _allOwnedNodes.createIterator() ;
@@ -2692,7 +2692,7 @@ void RooWorkspace::Streamer(TBuffer &R__b)
 
      // Reinstate clients here
 
-     
+
      for (auto iterx : extClients) {
        for (auto client : iterx.second) {
          iterx.first->_clientList.Add(client);
@@ -2720,7 +2720,7 @@ void RooWorkspace::Streamer(TBuffer &R__b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return STL string with last of class names contained in the code repository
 
-std::string RooWorkspace::CodeRepo::listOfClassNames() const 
+std::string RooWorkspace::CodeRepo::listOfClassNames() const
 {
   string ret ;
   map<TString,ClassRelInfo>::const_iterator iter = _c2fmap.begin() ;
@@ -2728,10 +2728,10 @@ std::string RooWorkspace::CodeRepo::listOfClassNames() const
     if (ret.size()>0) {
       ret += ", " ;
     }
-    ret += iter->first ;    
+    ret += iter->first ;
     ++iter ;
-  }  
-  
+  }
+
   return ret ;
 }
 
@@ -2833,7 +2833,7 @@ UInt_t crc32(const char* data)
 /// instructions for user how to fix errors and recover workspace and
 /// abort import procedure.
 
-Bool_t RooWorkspace::CodeRepo::compileClasses() 
+Bool_t RooWorkspace::CodeRepo::compileClasses()
 {
   Bool_t haveDir=kFALSE ;
 
@@ -2850,7 +2850,7 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
 
     // If class is already known, don't load
     if (gClassTable->GetDict(iter->first.Data())) {
-      oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Embedded class " 
+      oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Embedded class "
 				      << iter->first << " already in ROOT class table, skipping" << endl ;
       ++iter ;
       continue ;
@@ -2859,16 +2859,16 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
     // Check that export directory exists
     if (!haveDir) {
 
-      // If not, make local directory to extract files 
+      // If not, make local directory to extract files
       if (!gSystem->AccessPathName(dirName.c_str())) {
-	oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() reusing code export directory " << dirName.c_str() 
+	oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() reusing code export directory " << dirName.c_str()
 					<< " to extract coded embedded in workspace" << endl ;
       } else {
-	if (gSystem->MakeDirectory(dirName.c_str())==0) { 
-	  oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() creating code export directory " << dirName.c_str() 
+	if (gSystem->MakeDirectory(dirName.c_str())==0) {
+	  oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() creating code export directory " << dirName.c_str()
 					  << " to extract coded embedded in workspace" << endl ;
 	} else {
-	  oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR creating code export directory " << dirName.c_str() 
+	  oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR creating code export directory " << dirName.c_str()
 					  << " to extract coded embedded in workspace" << endl ;
 	  return kFALSE ;
 	}
@@ -2877,10 +2877,10 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
 
     }
 
-    // First write any extra header files 
-    if (!writeExtraHeaders) {      
+    // First write any extra header files
+    if (!writeExtraHeaders) {
       writeExtraHeaders = kTRUE ;
-      
+
       map<TString,ExtraHeader>::iterator eiter = _ehmap.begin() ;
       while(eiter!=_ehmap.end()) {
 
@@ -2906,7 +2906,7 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
                                        << fdname << endl;
 
       // Extra headers may contain non-existing path - create first to be sure
-      gSystem->MakeDirectory(gSystem->DirName(fdname.c_str()));
+      gSystem->MakeDirectory(gSystem->GetDirName(fdname.c_str()));
 
       ofstream fdecl(fdname.c_str());
       if (!fdecl) {
@@ -2920,16 +2920,16 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
    ++eiter;
       }
     }
-    
+
 
     // Navigate from class to file
     ClassFiles& cfinfo = _fmap[iter->second._fileBase] ;
 
     oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() now processing file with base " << iter->second._fileBase << endl ;
-    
+
     // If file is already processed, skip to next class
     if (cfinfo._extracted) {
-      oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() file with base name " << iter->second._fileBase 
+      oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() file with base name " << iter->second._fileBase
 					 << " has already been extracted, skipping to next class" << endl ;
       continue ;
     }
@@ -2944,18 +2944,18 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
       while (ifdecl.getline(buf, 64000)) {
          contents += buf;
          contents += "\n";
-      }      
+      }
       UInt_t crcFile = crc32(contents.Data()) ;
       UInt_t crcWS   = crc32(cfinfo._hfile.Data()) ;
       needDeclWrite = (crcFile!=crcWS) ;
     }
 
-    // Write declaration file if required 
+    // Write declaration file if required
     if (needDeclWrite) {
       oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Extracting declaration code of class " << iter->first << ", file " << fdname << endl ;
       ofstream fdecl(fdname.c_str()) ;
       if (!fdecl) {
-	oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR opening file " 
+	oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR opening file "
 					<< fdname << " for writing" << endl ;
 	return kFALSE ;
       }
@@ -2973,7 +2973,7 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
       while (ifimpl.getline(buf, 64000)) {
          contents += buf;
          contents += "\n";
-      }      
+      }
       UInt_t crcFile = crc32(contents.Data()) ;
       UInt_t crcWS   = crc32(cfinfo._cxxfile.Data()) ;
       needImplWrite = (crcFile!=crcWS) ;
@@ -2984,7 +2984,7 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
       oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Extracting implementation code of class " << iter->first << ", file " << finame << endl ;
       ofstream fimpl(finame.c_str()) ;
       if (!fimpl) {
-	oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR opening file" 
+	oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR opening file"
 					<< finame << " for writing" << endl ;
 	return kFALSE ;
       }
@@ -2999,10 +2999,10 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
     // Compile class
     oocoutI(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() Compiling code unit " << iter->second._fileBase.Data() << " to define class " << iter->first << endl ;
     Bool_t ok = gSystem->CompileMacro(finame.c_str(),"k") ;
-    
+
     if (!ok) {
-      oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR compiling class " << iter->first.Data() << ", to fix this you can do the following: " << endl 
-				      << "  1) Fix extracted source code files in directory " << dirName.c_str() << "/" << endl 
+      oocoutE(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo::compileClasses() ERROR compiling class " << iter->first.Data() << ", to fix this you can do the following: " << endl
+				      << "  1) Fix extracted source code files in directory " << dirName.c_str() << "/" << endl
 				      << "  2) In clean ROOT session compiled fixed classes by hand using '.x " << dirName.c_str() << "/ClassName.cxx+'" << endl
 				      << "  3) Reopen file with RooWorkspace with broken source code in UPDATE mode. Access RooWorkspace to force loading of class" << endl
 				      << "     Broken instances in workspace will _not_ be compiled, instead precompiled fixed instances will be used." << endl
@@ -3010,7 +3010,7 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
 				      << "  5) Reopen file in clean ROOT session to confirm that problems are fixed" << endl ;
 	return kFALSE ;
     }
-    
+
     ++iter ;
   }
 
@@ -3022,7 +3022,7 @@ Bool_t RooWorkspace::CodeRepo::compileClasses()
 ////////////////////////////////////////////////////////////////////////////////
 /// Internal access to TDirectory append method
 
-void RooWorkspace::WSDir::InternalAppend(TObject* obj) 
+void RooWorkspace::WSDir::InternalAppend(TObject* obj)
 {
   TDirectory::Append(obj,kFALSE) ;
 }
@@ -3031,20 +3031,20 @@ void RooWorkspace::WSDir::InternalAppend(TObject* obj)
 ////////////////////////////////////////////////////////////////////////////////
 /// Overload TDirectory interface method to prohibit insertion of objects in read-only directory workspace representation
 
-void RooWorkspace::WSDir::Add(TObject* obj,Bool_t) 
+void RooWorkspace::WSDir::Add(TObject* obj,Bool_t)
 {
   if (dynamic_cast<RooAbsArg*>(obj) || dynamic_cast<RooAbsData*>(obj)) {
     coutE(ObjectHandling) << "RooWorkspace::WSDir::Add(" << GetName() << ") ERROR: Directory is read-only representation of a RooWorkspace, use RooWorkspace::import() to add objects" << endl ;
   } else {
     InternalAppend(obj) ;
   }
-} 
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Overload TDirectory interface method to prohibit insertion of objects in read-only directory workspace representation
 
-void RooWorkspace::WSDir::Append(TObject* obj,Bool_t) 
+void RooWorkspace::WSDir::Append(TObject* obj,Bool_t)
 {
   if (dynamic_cast<RooAbsArg*>(obj) || dynamic_cast<RooAbsData*>(obj)) {
     coutE(ObjectHandling) << "RooWorkspace::WSDir::Add(" << GetName() << ") ERROR: Directory is read-only representation of a RooWorkspace, use RooWorkspace::import() to add objects" << endl ;
@@ -3059,7 +3059,7 @@ void RooWorkspace::WSDir::Append(TObject* obj,Bool_t)
 /// Activate export of workspace symbols to CINT in a namespace with given name. If no name
 /// is given the namespace will have the same name as the workspace
 
-void RooWorkspace::exportToCint(const char* nsname) 
+void RooWorkspace::exportToCint(const char* nsname)
 {
   // If export is already active, do nothing
   if (_doExport) {
@@ -3074,7 +3074,7 @@ void RooWorkspace::exportToCint(const char* nsname)
   if (!nsname) nsname = GetName() ;
   _exportNSName = nsname ;
 
-  coutI(ObjectHandling) << "RooWorkspace::exportToCint(" << GetName() 
+  coutI(ObjectHandling) << "RooWorkspace::exportToCint(" << GetName()
 			<< ") INFO: references to all objects in this workspace will be created in CINT in 'namespace " << _exportNSName << "'" << endl ;
 
   // Export present contents of workspace to CINT
@@ -3082,12 +3082,12 @@ void RooWorkspace::exportToCint(const char* nsname)
   TObject* wobj ;
   while((wobj=iter->Next())) {
     exportObj(wobj) ;
-  }  
+  }
   delete iter ;
   iter = _dataList.MakeIterator() ;
   while((wobj=iter->Next())) {
     exportObj(wobj) ;
-  }  
+  }
   delete iter ;
 }
 
@@ -3116,7 +3116,7 @@ void RooWorkspace::exportObj(TObject* wobj)
 
   // Declare correctly typed reference to object in CINT in the namespace associated with this workspace
   string cintExpr = Form("namespace %s { %s& %s = *(%s *)0x%lx ; }",_exportNSName.c_str(),wobj->IsA()->GetName(),wobj->GetName(),wobj->IsA()->GetName(),(ULong_t)wobj) ;
-  gROOT->ProcessLine(cintExpr.c_str()) ;  
+  gROOT->ProcessLine(cintExpr.c_str()) ;
 }
 
 
@@ -3124,7 +3124,7 @@ void RooWorkspace::exportObj(TObject* wobj)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if given name is a valid C++ identifier name
 
-Bool_t RooWorkspace::isValidCPPID(const char* name)   
+Bool_t RooWorkspace::isValidCPPID(const char* name)
 {
   string oname(name) ;
   if (isdigit(oname[0])) {
@@ -3134,14 +3134,14 @@ Bool_t RooWorkspace::isValidCPPID(const char* name)
       char c = oname[i] ;
       if (!isalnum(c) && (c!='_')) {
 	return kFALSE ;
-      }    
+      }
     }
   }
   return kTRUE ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Delete exported reference in CINT namespace 
+/// Delete exported reference in CINT namespace
 
 void RooWorkspace::unExport()
 {

--- a/test/stressHistFactory_tests.cxx
+++ b/test/stressHistFactory_tests.cxx
@@ -261,7 +261,7 @@ private:
     TString cmd = "tar -xf ";
     TString tarFile = fTestDirectory + "/HistFactoryTest.tar";
     cmd.Append(tarFile);
-    gSystem->ChangeDirectory(gSystem->DirName(tarFile));
+    gSystem->ChangeDirectory(gSystem->GetDirName(tarFile));
 
     return (gSystem->Exec(cmd) == 0);
   }

--- a/test/stressProof.cxx
+++ b/test/stressProof.cxx
@@ -206,7 +206,7 @@ static TString gPack3("/proof/packtest3.par");
 int stressProof(const char *url = 0,
                 const char *tests = 0, Int_t nwrks = -1,
                 const char *verbose = "1", const char *logfile = 0,
-                Bool_t dyn = kFALSE, Bool_t skipds = kTRUE, 
+                Bool_t dyn = kFALSE, Bool_t skipds = kTRUE,
                 const char *h1src = 0, const char *eventsrc = 0,
                 Bool_t dryrun = kFALSE, Bool_t showcpu = kFALSE,
                 Bool_t clearcache = kFALSE, Bool_t useprogress = kTRUE,
@@ -331,7 +331,7 @@ int main(int argc,const char *argv[])
          if (i+1 == argc || argv[i+1][0] == '-') {
             printf(" -l should be followed by a path: ignoring \n");
             i++;
-         } else { 
+         } else {
             logfile = argv[i+1];
             i += 2;
          }
@@ -362,7 +362,7 @@ int main(int argc,const char *argv[])
          if (i+1 == argc || argv[i+1][0] == '-') {
             printf(" -t should be followed by a string or a number: ignoring \n");
             i++;
-         } else { 
+         } else {
             tests = argv[i+1];
             i += 2;
          }
@@ -370,7 +370,7 @@ int main(int argc,const char *argv[])
          if (i+1 == argc || argv[i+1][0] == '-') {
             printf(" -h1 should be followed by a path: ignoring \n");
             i++;
-         } else { 
+         } else {
             h1src = argv[i+1];
             i += 2;
          }
@@ -378,7 +378,7 @@ int main(int argc,const char *argv[])
          if (i+1 == argc || argv[i+1][0] == '-') {
             printf(" -event should be followed by a path: ignoring \n");
             i++;
-         } else { 
+         } else {
             eventsrc = argv[i+1];
             i += 2;
          }
@@ -401,7 +401,7 @@ int main(int argc,const char *argv[])
          if (i+1 == argc || argv[i+1][0] == '-') {
             printf(" -tut should be followed by a path: ignoring \n");
             i++;
-         } else { 
+         } else {
             tutdir = argv[i+1];
             i += 2;
          }
@@ -462,7 +462,7 @@ void PrintEmptyProgress(Long64_t, Long64_t, Float_t, Long64_t)
 {
    return;
 }
-   
+
 // Guard class
 class SwitchProgressGuard {
 public:
@@ -483,7 +483,7 @@ void CleanupSelector(const char *selpath)
 {
    if (!selpath) return;
 
-   TString dirpath(gSystem->DirName(selpath));
+   TString dirpath = gSystem->GetDirName(selpath);
    if (gSystem->AccessPathName(dirpath)) return;
    TString selname(gSystem->BaseName(selpath));
    selname.ReplaceAll(".C", "_C");
@@ -544,9 +544,9 @@ public:
    Double_t fCpu;
    Double_t fReal;
    RunTimes(Double_t c = -1., Double_t r = -1.) : fCpu(c), fReal(r) { }
-   
+
    void Set(Double_t c = -1., Double_t r = -1.) { if (c > -1.) fCpu = c; if (r > -1.) fReal = r; }
-   void Print(const char *tag = "") { printf("%s real: %f s, cpu: %f s\n", tag, fReal, fCpu); }  
+   void Print(const char *tag = "") { printf("%s real: %f s, cpu: %f s\n", tag, fReal, fCpu); }
 };
 RunTimes operator-(const RunTimes &rt1, const RunTimes &rt2) {
    RunTimes rt(rt1.fCpu - rt2.fCpu, rt1.fReal - rt2.fReal);
@@ -570,7 +570,7 @@ private:
    Double_t        fRefReal; // Ref Real time used for PROOF marks
    Double_t        fProofMarks; // PROOF marks
    Bool_t          fUseForMarks; // Use in the calculation of the average PROOF marks
-   
+
    static Double_t gRefReal[PT_NUMTEST]; // Reference Cpu times
 
 public:
@@ -591,7 +591,7 @@ public:
    Int_t  Num() const { return fSeq; }
 
    Int_t  Run(Bool_t dryrun = kFALSE, Bool_t showcpu = kFALSE);
-   
+
    Double_t ProofMarks() const { return fProofMarks; }
    Bool_t UseForMarks() const { return fUseForMarks; }
 };
@@ -605,8 +605,8 @@ Double_t ProofTest::gRefReal[PT_NUMTEST] = {
    0.276155,   // #4:  Dataset handling with H1 files
    5.355514,   // #5:  H1: chain processing
    2.414207,   // #6:  H1: file collection processing
-   3.381990,   // #7:  H1: file collection, TPacketizerAdaptive 
-   3.227942,   // #8:  H1: by-name processing 
+   3.381990,   // #7:  H1: file collection, TPacketizerAdaptive
+   3.227942,   // #8:  H1: by-name processing
    3.944204,   // #9:  H1: multi dataset processing
    9.146988,   // #10: H1: multi dataset and entry list
    2.703881,   // #11: Package management with 'event'
@@ -823,7 +823,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
 
    // Use defaults or environment settings where required
    if (!url) {
-      url = getenv("STRESSPROOF_URL"); 
+      url = getenv("STRESSPROOF_URL");
       if (!url) url = urldef;
    }
    // Set dynamic mode
@@ -886,14 +886,14 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
    } else {
      gSkipDataSetTest = gLocalCluster;
    }
-   
+
    // Clear cache
    gClearCache = clearcache;
 
    // Log file path
    Bool_t usedeflog = kTRUE;
    FILE *flog = 0;
-   if (!logfile) logfile = getenv("STRESSPROOF_LOGFILE"); 
+   if (!logfile) logfile = getenv("STRESSPROOF_LOGFILE");
    if (logfile && strlen(logfile) > 0 && !dryrun) {
       usedeflog = kFALSE;
       glogfile = logfile;
@@ -951,7 +951,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
       printf("*  PROOF-Lite session (tests #15 and #16 skipped)               **\n");
       printf("******************************************************************\n");
    }
-   if (!h1src) h1src = getenv("STRESSPROOF_H1SRC"); 
+   if (!h1src) h1src = getenv("STRESSPROOF_H1SRC");
    if (h1src && strlen(h1src)) {
       if (!strcmp(h1src, "download") && extcluster) {
          if (gverbose > 0) {
@@ -967,7 +967,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
          gh1ok = kFALSE;
       }
    }
-   if (!eventsrc) eventsrc = getenv("STRESSPROOF_EVENT"); 
+   if (!eventsrc) eventsrc = getenv("STRESSPROOF_EVENT");
    if (eventsrc && strlen(eventsrc)) {
       if (!strcmp(eventsrc, "download") && extcluster) {
          if (gverbose > 0) {
@@ -983,7 +983,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
          geventok = kFALSE;
       }
    }
-   if (!tutdir) tutdir = getenv("STRESSPROOF_TUTORIALDIR"); 
+   if (!tutdir) tutdir = getenv("STRESSPROOF_TUTORIALDIR");
    if (tutdir && strlen(tutdir)) {
       if (!(gTutDir == tutdir)) {
          if (gverbose > 0) {
@@ -1104,7 +1104,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
    ProofTest *t = 0, *treq = 0;
    TIter nxt(testList);
    Bool_t all = kTRUE;
-   if (!tests) tests = getenv("STRESSPROOF_TESTS"); 
+   if (!tests) tests = getenv("STRESSPROOF_TESTS");
    if (tests && strlen(tests)) {
       TString tts(tests), tsg, ts, ten;
       Ssiz_t from = 0;
@@ -1188,7 +1188,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
                   if (!dryrun) CleanupSelector(nm->GetTitle());
                   if (gverbose > 0) {
                      tit = nm->GetName(); tit.Resize(18);
-                     printf("*     %s in %s\n", tit.Data(), gSystem->DirName(nm->GetTitle()));
+                     printf("*     %s in %s\n", tit.Data(), gSystem->GetDirName(nm->GetTitle()).Data());
                   }
                   cleaned += TString::Format(":%s:", nm->GetTitle());
                }
@@ -1202,7 +1202,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
          printf("*                                                               **\r");
          printf("*  Running only test(s) %s (and related)\n", ten.Data());
          printf("******************************************************************\n");
-      }      
+      }
    }
    if (all) {
       // Clean all the selectors
@@ -1213,7 +1213,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
          if (!dryrun) CleanupSelector(nm->GetTitle());
          if (gverbose > 0) {
             tit = nm->GetName(); tit.Resize(18);
-            printf("*     %s in %s\n", tit.Data(), gSystem->DirName(nm->GetTitle()));
+            printf("*     %s in %s\n", tit.Data(), gSystem->GetDirName(nm->GetTitle()).Data());
          }
       }
    }
@@ -1227,7 +1227,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
       printf("******************************************************************\n");
       return 0;
    }
-   
+
    // Add the ACLiC option to the selector strings
    gH1Sel += "+";
    gEventSel += "+";
@@ -1286,7 +1286,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
          }
       } else {
          printf("+++ Warning: could not attach to manager to get the session logs\n");
-      }         
+      }
       printf("******************************************************************\n");
       printf(" Main log file kept at %s (Proof logs in %s)\n", glogfile.Data(), logfiles.Data());
       if (catlog) {
@@ -1347,7 +1347,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
             }
          }
       if (navg > 0) avgmarks /= navg;
-      
+
       gProof->GetStatistics((gverbose > 0));
       // Reference time measured on a HP DL580 24 core (4 x Intel(R) Xeon(R) CPU X7460
       // @ 2.132 GHz, 48GB RAM, 1 Gb/s NIC) with 4 workers.
@@ -1380,7 +1380,7 @@ int stressProof(const char *url, const char *tests, Int_t nwrks,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Release memory cache associated with the H1 files at 'h1src', if it 
+/// Release memory cache associated with the H1 files at 'h1src', if it
 /// makes any sense, i.e. are local ...
 
 Int_t PT_H1ReleaseCache(const char *h1src)
@@ -1423,7 +1423,7 @@ Int_t PT_H1AssertFiles(const char *h1src)
    // Locality
    TUrl u(h1src, kTRUE);
    gh1local = (!strcmp(u.GetProtocol(), "file")) ? kTRUE : kFALSE;
-   
+
    gh1sep = '/';
    // Special cases
    if (!strncmp(h1src,"download",8)) {
@@ -1502,7 +1502,7 @@ Int_t PT_H1AssertFiles(const char *h1src)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Release memory cache associated with the event files at 'eventsrc', if it 
+/// Release memory cache associated with the event files at 'eventsrc', if it
 /// makes any sense, i.e. are local ...
 
 Int_t PT_EventReleaseCache(const char *eventsrc, Int_t nf = 10)
@@ -1511,7 +1511,7 @@ Int_t PT_EventReleaseCache(const char *eventsrc, Int_t nf = 10)
       printf("\n >>> Test failure: src dir undefined\n");
       return -1;
    }
-   
+
    if (nf > 50) {
       printf("\n >>> Test failure: max 50 event files can be checked\n");
       return -1;
@@ -1542,7 +1542,7 @@ Int_t PT_EventAssertFiles(const char *eventsrc, Int_t nf = 10)
       printf("\n >>> Test failure: src dir undefined\n");
       return -1;
    }
-   
+
    if (nf > 50) {
       printf("\n >>> Test failure: max 50 event files can be checked\n");
       return -1;
@@ -1607,7 +1607,7 @@ Int_t PT_EventAssertFiles(const char *eventsrc, Int_t nf = 10)
    geventok = kTRUE;
    return 0;
 }
-      
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Make sure that the needed files are available under the specified
 /// tutorial directory, setting the relevant variables
@@ -1652,7 +1652,7 @@ Int_t PT_AssertTutorialDir(const char *tutdir)
    gAuxSel.Insert(0, tutdir);
    gSystem->ExpandPathName(gAuxSel);
    if (gSystem->AccessPathName(gAuxSel)) return -1;
-   
+
    // Special class
    gProcFileElem.Insert(0, tutdir);
    gSystem->ExpandPathName(gProcFileElem);
@@ -1763,7 +1763,7 @@ Int_t PT_CheckSimpleNtuple(TQueryResult *qr, Long64_t nevt, const char *dsname)
       printf("\n >>> Test failure: output list not found\n");
       return -1;
    }
-   
+
    // Get the file collection
    PutPoint();
    TFileCollection *fc = dynamic_cast<TFileCollection *>(out->FindObject(dsname));
@@ -1772,7 +1772,7 @@ Int_t PT_CheckSimpleNtuple(TQueryResult *qr, Long64_t nevt, const char *dsname)
              " found in the output list\n", dsname);
       return -1;
    }
-   
+
    // Check the default tree name
    const char *tname = "/ntuple";
    PutPoint();
@@ -1789,7 +1789,7 @@ Int_t PT_CheckSimpleNtuple(TQueryResult *qr, Long64_t nevt, const char *dsname)
              fc->GetTotalEntries(tname), nevt);
       return -1;
    }
-   
+
    // Check 'pz' histo
    TH1F *hpx = new TH1F("PT_px", "PT_px", 20, -5., 5.);
    PutPoint();
@@ -1799,7 +1799,7 @@ Int_t PT_CheckSimpleNtuple(TQueryResult *qr, Long64_t nevt, const char *dsname)
              hpx->GetMean(), hpx->GetRMS());
       return -1;
    }
-      
+
    // Check 'pz' histo
    TH1F *hpz = new TH1F("PT_pz", "PT_pz", 20, 0., 20.);
    PutPoint();
@@ -1823,10 +1823,10 @@ Int_t PT_CheckSimpleNtuple(TQueryResult *qr, Long64_t nevt, const char *dsname)
    SafeDelete(hpx);
    SafeDelete(hpz);
    SafeDelete(hpr);
-     
+
    // Clear dsname
    gProof->ClearData(TProof::kDataset |TProof::kForceClear, dsname);
-   
+
    // Done
    PutPoint();
    return 0;
@@ -1965,7 +1965,7 @@ Int_t PT_CheckNtuple(TQueryResult *qr, Long64_t nevt)
       printf("\n >>> Test failure: TProofOutputFile not found in the output list\n");
       return -1;
    }
-   
+
    // Get the file full path
    TString outputFile(pof->GetOutputFileName());
    TString outputName(pof->GetName());
@@ -1985,7 +1985,7 @@ Int_t PT_CheckNtuple(TQueryResult *qr, Long64_t nevt)
       printf("\n >>> Test failure: 'ntuple' not found\n");
       return -1;
    }
-   
+
    // Check the ntuple content by filling some histos
    TH1F *h1s[3] = {0};
    h1s[0] = new TH1F("h1_1", "3*px+2 with px**2+py**2>1", 50, -15., 15.);
@@ -2005,7 +2005,7 @@ Int_t PT_CheckNtuple(TQueryResult *qr, Long64_t nevt)
       if (px*px+py*py > 4. && py > 0.) h1s[2]->Fill(1.3*px + 2.);
       // Go next
       ent++;
-   } 
+   }
 
    Int_t rch1s = 0;
    TString emsg;
@@ -2025,10 +2025,10 @@ Int_t PT_CheckNtuple(TQueryResult *qr, Long64_t nevt)
          rch1s = -1;
          break;
       }
-   }   
+   }
 
    // Cleanup
-   for (Int_t i = 0; i < 3; i++) delete h1s[i];   
+   for (Int_t i = 0; i < 3; i++) delete h1s[i];
    f->Close();
    delete f;
 
@@ -2037,7 +2037,7 @@ Int_t PT_CheckNtuple(TQueryResult *qr, Long64_t nevt)
       printf("\n >>> Test failure: %s\n", emsg.Data());
       return -1;
    }
-   
+
    // Done
    PutPoint();
    return 0;
@@ -2070,7 +2070,7 @@ Int_t PT_CheckDataset(TQueryResult *qr, Long64_t nevt)
       printf("\n >>> Test failure: dataset '%s' not found in the repository\n", dsname);
       return -1;
    }
-   // ... and that the default tree is 'ntuple' 
+   // ... and that the default tree is 'ntuple'
    gProof->SetDataSetTreeName(dsname, "ntuple");
 
    // Create the histos
@@ -2088,7 +2088,7 @@ Int_t PT_CheckDataset(TQueryResult *qr, Long64_t nevt)
       PutPoint();
       gProof->DrawSelect(dsname, "1.3*px+2 >> h1s2","(px^2+py^2>4) && py>0");
    }
-    
+
    Int_t rch1s = 0;
    TString emsg;
    // Check the histogram entries and mean values
@@ -2097,7 +2097,7 @@ Int_t PT_CheckDataset(TQueryResult *qr, Long64_t nevt)
    Double_t prec = 10. / TMath::Sqrt(nevt);  // ~10 sigma ... conservative
    for (Int_t i = 0; i < 3; i++) {
       Double_t ent = h1s[i]->GetEntries();
-      if (TMath::Abs(ent - hent[i] * nevt) / ent > prec) { 
+      if (TMath::Abs(ent - hent[i] * nevt) / ent > prec) {
          emsg.Form("'%s' histo: wrong number"
                " of entries (%lld: expected %lld)",
                 h1s[i]->GetName(), (Long64_t) ent, (Long64_t)(hent[i] *nevt));
@@ -2111,17 +2111,17 @@ Int_t PT_CheckDataset(TQueryResult *qr, Long64_t nevt)
          rch1s = -1;
          break;
       }
-   }   
+   }
 
    // Cleanup
-   for (Int_t i = 0; i < 3; i++) delete h1s[i];   
+   for (Int_t i = 0; i < 3; i++) delete h1s[i];
 
    // Check the result
    if (rch1s != 0) {
       printf("\n >>> Test failure: %s\n", emsg.Data());
       return -1;
    }
-   
+
    // Done
    PutPoint();
    return 0;
@@ -2185,7 +2185,7 @@ Int_t PT_CheckFriends(TQueryResult *qr, Long64_t nevt, bool withfriends)
          rchs = -1;
          break;
       }
-   }   
+   }
 
    if (rchs != 0) {
       printf("\n >>> Test failure: %s\n", emsg.Data());
@@ -2212,7 +2212,7 @@ Int_t PT_Open(void *args, RunTimes &tt)
 
    // Temp dir for PROOF tutorials
    PutPoint();
-#if defined(R__MACOSX) 
+#if defined(R__MACOSX)
    // Force '/tmp' under macosx, to avoid problems with lengths and symlinks
    TString tmpdir("/tmp"), uspid;
 #else
@@ -2221,7 +2221,7 @@ Int_t PT_Open(void *args, RunTimes &tt)
    UserGroup_t *ug = gSystem->GetUserInfo(gSystem->GetUid());
    if (!ug) {
       printf("\n >>> Test failure: could not get user info");
-      return -1;      
+      return -1;
    }
    if (!tmpdir.EndsWith(ug->fUser.Data())) {
       uspid.Form("/%s/%d", ug->fUser.Data(), gSystem->GetPid());
@@ -2230,7 +2230,7 @@ Int_t PT_Open(void *args, RunTimes &tt)
       uspid.Form("/%d", gSystem->GetPid());
    }
    tmpdir += uspid;
-#if !defined(R__MACOSX) 
+#if !defined(R__MACOSX)
    gtutdir.Form("%s/.proof-tutorial", tmpdir.Data());
 #else
    gtutdir.Form("%s/.proof", tmpdir.Data());
@@ -2260,7 +2260,7 @@ Int_t PT_Open(void *args, RunTimes &tt)
       printf("\n >>> Test failure: could not start the session\n");
       return -1;
    }
-   
+
    // Re-check locality: if the logged user name is different from the local one, we may
    // not have all the rights we need, so we go no-local
    if (gLocalCluster) {
@@ -2270,7 +2270,7 @@ Int_t PT_Open(void *args, RunTimes &tt)
          delete pw;
       }
    }
-   
+
    // Check if it is in dynamic startup mode
    Int_t dyn = 0;
    p->GetRC("Proof.DynamicStartup", dyn);
@@ -2312,13 +2312,13 @@ Int_t PT_Open(void *args, RunTimes &tt)
       printf("\n >>> Test failure: no sandbox dir found\n");
       return -1;
    }
-   gsandbox = gSystem->DirName(gsandbox);
-   gsandbox = gSystem->DirName(gsandbox);
+   gsandbox = gSystem->GetDirName(gsandbox);
+   gsandbox = gSystem->GetDirName(gsandbox);
    PutPoint();
 
    // Fill times
    PT_GetLastTimes(tt);
-   
+
    // Done
    PutPoint();
    return 0;
@@ -2371,7 +2371,7 @@ Int_t PT_Simple(void *opts, RunTimes &tt)
    }
 
    PT_Option_t *ptopt = (PT_Option_t *) opts;
-   
+
    // Setup submergers if required
    if (ptopt && ptopt->fOne > 0) {
       gProof->SetParameter("PROOF_UseMergers", 0);
@@ -2429,7 +2429,7 @@ Int_t PT_OutputHandlingViaFile(void *opts, RunTimes &tt)
    PutPoint();
 
    PT_Option_t *ptopt = (PT_Option_t *) opts;
-   
+
    // Setup submergers if required
    if (ptopt && ptopt->fOne > 0) {
       gProof->SetParameter("PROOF_UseMergers", 0);
@@ -2468,7 +2468,7 @@ Int_t PT_OutputHandlingViaFile(void *opts, RunTimes &tt)
       // Remove file
       gSystem->Unlink("proofsimple.root");
    }
-      
+
    // Test dataset creationg with a ntuple
    const char *dsname = "PT_ds_proofsimple";
    if (gProof->GetQueryResults()) gProof->GetQueryResults()->Clear();
@@ -2624,7 +2624,7 @@ Int_t PT_H1FileCollection(void *arg, RunTimes &tt)
       gProof->Process(fc, gH1Sel.Data());
       gTimer.Stop();
    }
-   
+
    // Restore settings
    gProof->DeleteParameters("PROOF_Packetizer");
    gProof->DeleteParameters("PROOF_PacketizerStrategy");
@@ -2764,7 +2764,7 @@ Int_t PT_H1MultiDSetEntryList(void *, RunTimes &tt)
 
    // Set/unset the parallel unzip flag
    AssertParallelUnzip();
-   
+
    // Multiple dataset used to create the entry list
    TString dsname("h1dseta|h1dsetb");
 
@@ -2785,7 +2785,7 @@ Int_t PT_H1MultiDSetEntryList(void *, RunTimes &tt)
       gProof->Process(dsname, gH1Sel.Data(), "fillList=elist.root");
       gTimer.Stop();
    }
-   
+
    // Cleanup entry-list from the input list
    TIter nxi(gProof->GetInputList());
    TObject *o = 0;
@@ -3455,7 +3455,7 @@ Int_t PT_PackageArguments(void *, RunTimes &tt)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Test run for the H1 and Simple analysis in asynchronous mode 
+/// Test run for the H1 and Simple analysis in asynchronous mode
 
 Int_t PT_H1SimpleAsync(void *arg, RunTimes &tt)
 {
@@ -3777,7 +3777,7 @@ Int_t PT_AdminFunc(void *, RunTimes &tt)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Test processing of sub-samples (entries-from-first) from files with the
-/// 'event' structures 
+/// 'event' structures
 
 Int_t PT_EventRange(void *arg, RunTimes &tt)
 {
@@ -3850,7 +3850,7 @@ Int_t PT_EventRange(void *arg, RunTimes &tt)
    TString flst = TString::Format("%s/event_%d.root?lst=%lld", geventsrc.Data(), ilst, elst);
    gProof->SetParameter("Range_Last_File", flst.Data());
    gProof->SetParameter("Range_Num_Files", (Int_t) (ilst - ifst + 1));
-   
+
    // Process
    PutPoint();
    chain->SetProof();
@@ -3886,7 +3886,7 @@ Int_t PT_EventRange(void *arg, RunTimes &tt)
    // Register the dataset
    PutPoint();
    gProof->RegisterDataSet("dsevent", fc);
-   
+
    // Check the result
    if (!gProof->ExistsDataSet("dsevent")) {
       printf("\n >>> Test failure: could not register 'dsevent'\n");
@@ -3906,7 +3906,7 @@ Int_t PT_EventRange(void *arg, RunTimes &tt)
       printf("\n >>> Test failure: could not clear memory cache for the event files\n");
       return -1;
    }
-   
+
    // Process
    PutPoint();
    {  SwitchProgressGuard spg;
@@ -3926,7 +3926,7 @@ Int_t PT_EventRange(void *arg, RunTimes &tt)
 
    // The runtimes
    PT_GetLastProofTimes(tt);
-  
+
    // Check the results
    PutPoint();
    return PT_CheckEvent(gProof->GetQueryResult(), pack);
@@ -3946,7 +3946,7 @@ Int_t PT_POFNtuple(void *opts, RunTimes &tt)
    }
 
    PT_Option_t *ptopt = (PT_Option_t *) opts;
-   
+
    // Setup submergers if required
    if (ptopt && ptopt->fTwo > 0) {
       gProof->SetParameter("PROOF_UseMergers", 0);
@@ -3960,7 +3960,7 @@ Int_t PT_POFNtuple(void *opts, RunTimes &tt)
    gProof->SetInputDataFile(gNtpRndm);
    // Set the related parameter
    gProof->SetParameter("PROOF_USE_NTP_RNDM","yes");
-   
+
    // Define the number of events and histos
    Long64_t nevt = 1000;
 
@@ -4003,7 +4003,7 @@ Int_t PT_POFDataset(void *, RunTimes &tt)
       printf("\n >>> Test failure: no PROOF session found\n");
       return -1;
    }
-   
+
    const char *dsname = "testNtuple";
    // Clean-up any existing dataset with that name
    if (gProof->ExistsDataSet(dsname)) gProof->RemoveDataSet(dsname);
@@ -4197,7 +4197,7 @@ Int_t PT_Friends(void *sf, RunTimes &tt)
       printf("\n >>> Test failure: could not get the list of information about the workers\n");
       return -1;
    }
-   
+
    // Create the map
    TString fntree;
    TMap *files = new TMap;
@@ -4268,13 +4268,13 @@ Int_t PT_Friends(void *sf, RunTimes &tt)
             dsetf->Add(os->GetName());
       }
    }
-   
+
    // If we did not found the main or the friend meta info we fail
    if (!foundMain || !foundFriend) {
       printf("\n >>> Test failure: 'main' or 'friend' meta info missing!\n");
       return -1;
    }
-   
+
    // Connect the two datasets for processing
    dset->AddFriend(dsetf, "friend");
 
@@ -4332,7 +4332,7 @@ Int_t PT_TreeSubDirs(void*, RunTimes &tt)
       printf("\n >>> Test failure: could not get the list of information about the workers\n");
       return -1;
    }
-   
+
    // Create the map
    TString fntree;
    TMap *files = new TMap;
@@ -4388,7 +4388,7 @@ Int_t PT_TreeSubDirs(void*, RunTimes &tt)
       }
    }
    dset->SetProof();
-   
+
    // If we did not found the main or the friend meta info we fail
    if (!foundMain) {
       printf("\n >>> Test failure: 'main' meta info missing!\n");

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -514,7 +514,7 @@ TMVA::CrossValidationFoldResult TMVA::CrossValidation::ProcessFold(UInt_t iFold,
    TFile *foldOutputFile = nullptr;
 
    if (fFoldFileOutput && fOutputFile != nullptr) {
-      TString path = std::string("") + gSystem->DirName(fOutputFile->GetName()) + "/" + foldTitle + ".root";
+      TString path = gSystem->GetDirName(fOutputFile->GetName()) + "/" + foldTitle + ".root";
       foldOutputFile = TFile::Open(path, "RECREATE");
       Log() << kINFO << "Creating fold output at:" << path << Endl;
       fFoldFactory = std::make_unique<TMVA::Factory>(fJobName, foldOutputFile, fCvFactoryOptions);

--- a/tmva/tmva/src/MethodCrossValidation.cxx
+++ b/tmva/tmva/src/MethodCrossValidation.cxx
@@ -119,7 +119,7 @@ TString TMVA::MethodCrossValidation::GetWeightFileNameForFold(UInt_t iFold) cons
    }
 
    TString foldStr = Form("fold%i", iFold + 1);
-   TString fileDir = gSystem->DirName(GetWeightFileName());
+   TString fileDir = gSystem->GetDirName(GetWeightFileName());
    TString weightfile = fileDir + "/" + fJobName + "_" + fEncapsulatedMethodName + "_" + foldStr + ".weights.xml";
 
    return weightfile;

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1419,8 +1419,8 @@ Bool_t TBranch::SupportsBulkRead() const {
 /// NOTES:
 /// - This interface is meant to be used by higher-level, type-safe wrappers, not
 ///   by end-users.
-/// - This only returns events 
-/// 
+/// - This only returns events
+///
 
 Int_t TBranch::GetBulkEntries(Long64_t entry, TBuffer &user_buf)
 {
@@ -1917,7 +1917,7 @@ TString TBranch::GetRealFileName() const
          // to the branch file name
          char *tname = gSystem->ExpandPathName(tfn);
          if (gSystem->IsAbsoluteFileName(tname) || strstr(tname, ":/")) {
-            bFileName = gSystem->DirName(tname);
+            bFileName = gSystem->GetDirName(tname);
             bFileName += "/";
             bFileName += fFileName;
          }

--- a/tree/tree/src/TEntryList.cxx
+++ b/tree/tree/src/TEntryList.cxx
@@ -1452,8 +1452,8 @@ Int_t TEntryList::ScanPaths(TList *roots, Bool_t notify)
    }
    // Apply to ourselves
    Bool_t newobjs = kTRUE;
-   TString path = gSystem->DirName(fFileName), com;
-   TObjString *objs = 0;
+   TString path = gSystem->GetDirName(fFileName), com;
+   TObjString *objs = nullptr;
    TIter nxr(xrl);
    while ((objs = (TObjString *) nxr())) {
       Int_t rc = 0;

--- a/tree/treeplayer/src/TTreeProxyGenerator.cxx
+++ b/tree/treeplayer/src/TTreeProxyGenerator.cxx
@@ -1585,7 +1585,7 @@ namespace Internal {
          return;
       }
 
-      TString fileLocation = gSystem->DirName(fScript);
+      TString fileLocation = gSystem->GetDirName(fScript);
 
       TString incPath = gSystem->GetIncludePath(); // of the form -Idir1  -Idir2 -Idir3
       incPath.Append(":").Prepend(" ");
@@ -1596,16 +1596,16 @@ namespace Internal {
       incPath.Prepend(fileLocation+":.:");
 
       const char *filename = gSystem->Which(incPath,fScript);
-      if (filename==0) {
+      if (!filename) {
          Error("WriteProxy","Can not find the user's script: %s",fScript.Data());
          return;
       }
-      const char *cutfilename = 0;
+      const char *cutfilename = nullptr;
       if (fCutScript.Length()) {
-         fileLocation = gSystem->DirName(fCutScript);
+         fileLocation = gSystem->GetDirName(fCutScript);
          incPath.Prepend(fileLocation+":.:");
          cutfilename = gSystem->Which(incPath,fCutScript);
-         if (cutfilename==0) {
+         if (!cutfilename) {
             Error("WriteProxy","Can not find the user's cut script: %s",fCutScript.Data());
             delete [] filename;
             return;

--- a/tutorials/gui/exec_macro.C
+++ b/tutorials/gui/exec_macro.C
@@ -33,7 +33,7 @@ Int_t exec_macro(const char *macro, Bool_t comp = kFALSE, Bool_t save = kTRUE)
    if (gROOT->IsBatch() || !(gClient))
       return kCannotRunScript;
    TString pwd(gSystem->pwd());
-   if (!gSystem->cd(gSystem->DirName(macro)))
+   if (!gSystem->cd(gSystem->GetDirName(macro)))
       return kScriptDirNotFound;
    Int_t err = 0;
    TString cmd(".x ");

--- a/tutorials/proof/ProofAux.C
+++ b/tutorials/proof/ProofAux.C
@@ -156,7 +156,7 @@ Bool_t ProofAux::Process(Long64_t entry)
       // The output filename
       TString fnf(fnt);
       TString xf = gSystem->BaseName(fnf);
-      fnf = gSystem->DirName(fnf);
+      fnf = gSystem->GetDirName(fnf);
       if (xf.Contains("tree")) {
          xf.ReplaceAll("tree", "friend");
       } else {
@@ -251,7 +251,7 @@ Int_t ProofAux::GenerateTree(const char *fnt, Long64_t ent, TString &fn)
       // Insert data directory
       fn.Insert(0, TString::Format("%s/", gProofServ->GetDataDir()));
       // Make sure the directory exists
-      TString dir = gSystem->DirName(fn);
+      TString dir = gSystem->GetDirName(fn);
       if (gSystem->AccessPathName(dir, kWritePermission)) {
          if (gSystem->mkdir(dir, kTRUE) != 0) {
             Error("GenerateTree", "problems creating directory %s to store the file", dir.Data());
@@ -367,7 +367,7 @@ Int_t ProofAux::GenerateFriend(const char *fnt, const char *fnf)
       sameFile = kFALSE;
       openMain = "READ";
       // Make sure the directory exists
-      TString dir = gSystem->DirName(fout);
+      TString dir = gSystem->GetDirName(fout);
       if (gSystem->AccessPathName(dir, kWritePermission)) {
          if (gSystem->mkdir(dir, kTRUE) != 0) {
             Error("GenerateFriend", "problems creating directory %s to store the file", dir.Data());

--- a/tutorials/proof/finalizeProof.C
+++ b/tutorials/proof/finalizeProof.C
@@ -95,8 +95,8 @@ void finalizeProof(const char *what = "simple",
       Printf("runProof: root.exe not found: please check the environment!");
       return;
    }
-   TString rootsys(gSystem->DirName(rootbin));
-   rootsys = gSystem->DirName(rootsys);
+   TString rootsys = gSystem->GetDirName(rootbin);
+   rootsys = gSystem->GetDirName(rootsys);
    TString tutorials(Form("%s/tutorials", rootsys.Data()));
    delete[] rootbin;
 

--- a/tutorials/proof/runProof.C
+++ b/tutorials/proof/runProof.C
@@ -479,8 +479,8 @@ void runProof(const char *what = "simple",
       Printf("runProof: root.exe not found: please check the environment!");
       return;
    }
-   TString rootsys(gSystem->DirName(rootbin));
-   rootsys = gSystem->DirName(rootsys);
+   TString rootsys = gSystem->GetDirName(rootbin);
+   rootsys = gSystem->GetDirName(rootsys);
    TString tutorials(Form("%s/tutorials", rootsys.Data()));
    delete[] rootbin;
 

--- a/tutorials/tmva/TMVAClassificationCategory.C
+++ b/tutorials/tmva/TMVAClassificationCategory.C
@@ -86,7 +86,7 @@ void TMVAClassificationCategory()
 
    // Load the signal and background event samples from ROOT trees
    TFile *input(0);
-   TString fname = TString(gSystem->DirName(__FILE__) ) + "/data/";
+   TString fname = gSystem->GetDirName(__FILE__) + "/data/";
    if (gSystem->AccessPathName( fname + "toy_sigbkg_categ_offset.root")) {
       // if directory data not found try using tutorials dir
       fname = gROOT->GetTutorialDir() + "/tmva/data/";

--- a/tutorials/tmva/TMVAClassificationCategoryApplication.C
+++ b/tutorials/tmva/TMVAClassificationCategoryApplication.C
@@ -82,7 +82,7 @@ void TMVAClassificationCategoryApplication()
    // in this example, there is a toy tree with signal and one with background events
    // we'll later on use only the "signal" events for the test in this example.
    //
-   TString fname = TString(gSystem->DirName(__FILE__) ) + "/data/";
+   TString fname = gSystem->GetDirName(__FILE__) + "/data/";
    // if directory data not found try using tutorials dir
    if (gSystem->AccessPathName( fname + "toy_sigbkg_categ_offset.root"  )) {
       fname = gROOT->GetTutorialDir() + "/tmva/data/";

--- a/tutorials/tree/bill.C
+++ b/tutorials/tree/bill.C
@@ -123,7 +123,7 @@ void billtr(const char *billtname, Int_t compress) {
 
 void bill() {
 
-   TString dir = gSystem->DirName(gSystem->UnixPathName(__FILE__));
+   TString dir = gSystem->GetDirName(gSystem->UnixPathName(__FILE__));
    TString bill = dir + "/bill.root";
    TString billt = dir + "/billt.root";
 

--- a/tutorials/tree/run_h1analysis.C
+++ b/tutorials/tree/run_h1analysis.C
@@ -36,7 +36,7 @@ void run_h1analysis(int type = 0, const char * h1dir = 0) {
    chain.Add("$H1/dstarp1b.root");
    chain.Add("$H1/dstarp2.root");
 
-   TString selectionMacro = TString(gSystem->DirName(__FILE__) ) + "/h1analysis.C";
+   TString selectionMacro = gSystem->GetDirName(__FILE__) + "/h1analysis.C";
 
    if (type == 0)
       chain.Process(selectionMacro);

--- a/tutorials/unfold/testUnfold6.C
+++ b/tutorials/unfold/testUnfold6.C
@@ -51,7 +51,7 @@ void testUnfold6()
   ofstream dtdFile("tunfoldbinning.dtd");
   TUnfoldBinningXML::WriteDTD(dtdFile);
   dtdFile.close();
-  TString dir = gSystem->UnixPathName(gSystem->DirName(__FILE__));
+  TString dir = gSystem->UnixPathName(gSystem->GetDirName(__FILE__));
   Int_t error=parser.ParseFile(dir+"/testUnfold6binning.xml");
   if(error) cout<<"error="<<error<<" from TDOMParser\n";
   TXMLDocument const *XMLdocument=parser.GetXMLDocument();

--- a/tutorials/unfold/testUnfold7b.C
+++ b/tutorials/unfold/testUnfold7b.C
@@ -116,8 +116,8 @@ void testUnfold7b()
   // read binning schemes in XML format
 
   TDOMParser parser;
-  TString dir = gSystem->UnixPathName(gSystem->DirName(__FILE__));
-  Int_t error=parser.ParseFile(dir+"/testUnfold7binning.xml");
+  TString dir = gSystem->UnixPathName(gSystem->GetDirName(__FILE__));
+  Int_t error = parser.ParseFile(dir+"/testUnfold7binning.xml");
   if(error) {
      cout<<"error="<<error<<" from TDOMParser\n";
      cout<<"==============================================================\n";


### PR DESCRIPTION
There are several methods in TSystem, which returns `char *` as return value, which has to be deleted. These are:
* `ExapndPathName()`
* `DirName()` (Windows only, actually a bug)
* `Which()`
* `ConcatFileName()`

There are many places in ROOT which does not do it correctly, making memory leaks.
I tried to fixed all these bugs - still open PRs are #4853, #4854, #4861, #4862, #4863 

Idea to modernize TSystem interface, providing thread-safe alternatives to all mentioned methods.
Means return TString instead of `char *` or `const char *`.
Keep old methods for a while, but replace in ROOT code to new one.
Later old methods should be declared as deprecated.

This PR introduces `TString TSystem::GetDirName(const char *)` as replacement of `const char * TSystem::DirName(const char *)`. Solving Windows issue, which has memory leak. Replaces all places where DirName used by GetDirName - in most cases TString used anyway as storage for return value. 

Also using more C++11 in declaration of TSystem classes.

If we agreed on this approach, next methods can be refactored in same way. 