### PR TITLE
Move RRawFile from Experimental::Detail to Internal

### DIFF
--- a/etc/plugins/ROOT@@Detail@@RRawFile/P010_RRawFileDavix.C
+++ b/etc/plugins/ROOT@@Detail@@RRawFile/P010_RRawFileDavix.C
@@ -7,10 +7,10 @@ void P010_RRawFileDavix()
        !gEnv->GetValue("Davix.UseOldClient", 0)) {
 
       gPluginMgr->AddHandler(
-         "ROOT::Experimental::Detail::RRawFile",
+         "ROOT::Detail::RRawFile",
          "^http[s]?:",
-         "ROOT::Experimental::Detail::RRawFileDavix",
+         "ROOT::Detail::RRawFileDavix",
          "RDAVIX",
-         "RRawFileDavix(std::string_view, ROOT::Experimental::Detail::RRawFile::ROptions)");
+         "RRawFileDavix(std::string_view, ROOT::Detail::RRawFile::ROptions)");
    }
 }

--- a/etc/plugins/ROOT@@Internal@@RRawFile/P010_RRawFileDavix.C
+++ b/etc/plugins/ROOT@@Internal@@RRawFile/P010_RRawFileDavix.C
@@ -7,10 +7,10 @@ void P010_RRawFileDavix()
        !gEnv->GetValue("Davix.UseOldClient", 0)) {
 
       gPluginMgr->AddHandler(
-         "ROOT::Detail::RRawFile",
+         "ROOT::Internal::RRawFile",
          "^http[s]?:",
-         "ROOT::Detail::RRawFileDavix",
+         "ROOT::Internal::RRawFileDavix",
          "RDAVIX",
-         "RRawFileDavix(std::string_view, ROOT::Detail::RRawFile::ROptions)");
+         "RRawFileDavix(std::string_view, ROOT::Internal::RRawFile::ROptions)");
    }
 }

--- a/io/io/inc/LinkDef.h
+++ b/io/io/inc/LinkDef.h
@@ -52,7 +52,7 @@
 #pragma link C++ class TStreamerInfoActions::TConfiguredAction+;
 #pragma link C++ class TStreamerInfoActions::TActionSequence+;
 #pragma link C++ class TStreamerInfoActions::TConfiguration-;
-#pragma link C++ class ROOT::Detail::RRawFile+;
+#pragma link C++ class ROOT::Internal::RRawFile+;
 #pragma link C++ class ROOT::Experimental::TBufferMerger;
 #pragma link C++ class ROOT::Experimental::TBufferMergerFile;
 

--- a/io/io/inc/LinkDef.h
+++ b/io/io/inc/LinkDef.h
@@ -52,7 +52,7 @@
 #pragma link C++ class TStreamerInfoActions::TConfiguredAction+;
 #pragma link C++ class TStreamerInfoActions::TActionSequence+;
 #pragma link C++ class TStreamerInfoActions::TConfiguration-;
-#pragma link C++ class ROOT::Experimental::Detail::RRawFile+;
+#pragma link C++ class ROOT::Detail::RRawFile+;
 #pragma link C++ class ROOT::Experimental::TBufferMerger;
 #pragma link C++ class ROOT::Experimental::TBufferMergerFile;
 

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -20,7 +20,7 @@
 #include <string>
 
 namespace ROOT {
-namespace Detail {
+namespace Internal {
 
 /**
  * \class RRawFile RRawFile.hxx
@@ -179,7 +179,7 @@ public:
    bool Readln(std::string &line);
 }; // class RRawFile
 
-} // namespace Detail
+} // namespace Internal
 } // namespace ROOT
 
 #endif

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -20,10 +20,7 @@
 #include <string>
 
 namespace ROOT {
-namespace Experimental {
 namespace Detail {
-
-class RRawFile;
 
 /**
  * \class RRawFile RRawFile.hxx
@@ -180,10 +177,9 @@ public:
 
    /// Read the next line starting from the current value of fFilePos. Returns false if the end of the file is reached.
    bool Readln(std::string &line);
-};
+}; // class RRawFile
 
 } // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/io/io/inc/ROOT/RRawFileUnix.hxx
+++ b/io/io/inc/ROOT/RRawFileUnix.hxx
@@ -19,7 +19,6 @@
 #include <cstdint>
 
 namespace ROOT {
-namespace Experimental {
 namespace Detail {
 
 /**
@@ -48,7 +47,6 @@ public:
 };
 
 } // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/io/io/inc/ROOT/RRawFileUnix.hxx
+++ b/io/io/inc/ROOT/RRawFileUnix.hxx
@@ -19,7 +19,7 @@
 #include <cstdint>
 
 namespace ROOT {
-namespace Detail {
+namespace Internal {
 
 /**
  * \class RRawFileUnix RRawFileUnix.hxx
@@ -46,7 +46,7 @@ public:
    int GetFeatures() const final { return kFeatureHasSize | kFeatureHasMmap; }
 };
 
-} // namespace Detail
+} // namespace Internal
 } // namespace ROOT
 
 #endif

--- a/io/io/inc/ROOT/RRawFileWin.hxx
+++ b/io/io/inc/ROOT/RRawFileWin.hxx
@@ -20,7 +20,7 @@
 #include <cstdio>
 
 namespace ROOT {
-namespace Detail {
+namespace Internal {
 
 /**
  * \class RRawFileWin RRawFileWin.hxx
@@ -46,7 +46,7 @@ public:
    int GetFeatures() const final { return kFeatureHasSize; }
 };
 
-} // namespace Detail
+} // namespace Internal
 } // namespace ROOT
 
 #endif

--- a/io/io/inc/ROOT/RRawFileWin.hxx
+++ b/io/io/inc/ROOT/RRawFileWin.hxx
@@ -20,7 +20,6 @@
 #include <cstdio>
 
 namespace ROOT {
-namespace Experimental {
 namespace Detail {
 
 /**
@@ -48,7 +47,6 @@ public:
 };
 
 } // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/io/io/src/RRawFile.cxx
+++ b/io/io/src/RRawFile.cxx
@@ -43,7 +43,7 @@ constexpr unsigned int kLineBreakTokenSizes[] = {0, 1, 1, 2};
 constexpr unsigned int kLineBuffer = 128; // On Readln, look for line-breaks in chunks of 128 bytes
 } // anonymous namespace
 
-size_t ROOT::Experimental::Detail::RRawFile::RBlockBuffer::CopyTo(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFile::RBlockBuffer::CopyTo(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    if (offset < fBufferOffset)
       return 0;
@@ -58,19 +58,19 @@ size_t ROOT::Experimental::Detail::RRawFile::RBlockBuffer::CopyTo(void *buffer, 
    return copiedBytes;
 }
 
-ROOT::Experimental::Detail::RRawFile::RRawFile(std::string_view url, ROptions options)
+ROOT::Detail::RRawFile::RRawFile(std::string_view url, ROptions options)
    : fBlockBufferIdx(0), fBufferSpace(nullptr), fFileSize(kUnknownFileSize), fIsOpen(false), fUrl(url),
      fOptions(options), fFilePos(0)
 {
 }
 
-ROOT::Experimental::Detail::RRawFile::~RRawFile()
+ROOT::Detail::RRawFile::~RRawFile()
 {
    delete[] fBufferSpace;
 }
 
-ROOT::Experimental::Detail::RRawFile *
-ROOT::Experimental::Detail::RRawFile::Create(std::string_view url, ROptions options)
+ROOT::Detail::RRawFile *
+ROOT::Detail::RRawFile::Create(std::string_view url, ROptions options)
 {
    std::string transport = GetTransport(url);
    if (transport == "file") {
@@ -81,7 +81,7 @@ ROOT::Experimental::Detail::RRawFile::Create(std::string_view url, ROptions opti
 #endif
    }
    if (transport == "http" || transport == "https") {
-      if (TPluginHandler *h = gROOT->GetPluginManager()->FindHandler("ROOT::Experimental::Detail::RRawFile")) {
+      if (TPluginHandler *h = gROOT->GetPluginManager()->FindHandler("ROOT::Detail::RRawFile")) {
          if (h->LoadPlugin() == 0) {
             return reinterpret_cast<RRawFile *>(h->ExecPlugin(2, &url, &options));
          }
@@ -92,25 +92,25 @@ ROOT::Experimental::Detail::RRawFile::Create(std::string_view url, ROptions opti
    throw std::runtime_error("Unsupported transport protocol: " + transport);
 }
 
-void *ROOT::Experimental::Detail::RRawFile::MapImpl(size_t /* nbytes */, std::uint64_t /* offset */,
+void *ROOT::Detail::RRawFile::MapImpl(size_t /* nbytes */, std::uint64_t /* offset */,
    std::uint64_t& /* mapdOffset */)
 {
    throw std::runtime_error("Memory mapping unsupported");
 }
 
-void ROOT::Experimental::Detail::RRawFile::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
+void ROOT::Detail::RRawFile::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
    for (unsigned i = 0; i < nReq; ++i) {
       ioVec[i].fOutBytes = ReadAt(ioVec[i].fBuffer, ioVec[i].fSize, ioVec[i].fOffset);
    }
 }
 
-void ROOT::Experimental::Detail::RRawFile::UnmapImpl(void * /* region */, size_t /* nbytes */)
+void ROOT::Detail::RRawFile::UnmapImpl(void * /* region */, size_t /* nbytes */)
 {
    throw std::runtime_error("Memory mapping unsupported");
 }
 
-std::string ROOT::Experimental::Detail::RRawFile::GetLocation(std::string_view url)
+std::string ROOT::Detail::RRawFile::GetLocation(std::string_view url)
 {
    auto idx = url.find(kTransportSeparator);
    if (idx == std::string_view::npos)
@@ -118,7 +118,7 @@ std::string ROOT::Experimental::Detail::RRawFile::GetLocation(std::string_view u
    return std::string(url.substr(idx + strlen(kTransportSeparator)));
 }
 
-std::uint64_t ROOT::Experimental::Detail::RRawFile::GetSize()
+std::uint64_t ROOT::Detail::RRawFile::GetSize()
 {
    if (!fIsOpen)
       OpenImpl();
@@ -129,7 +129,7 @@ std::uint64_t ROOT::Experimental::Detail::RRawFile::GetSize()
    return fFileSize;
 }
 
-std::string ROOT::Experimental::Detail::RRawFile::GetTransport(std::string_view url)
+std::string ROOT::Detail::RRawFile::GetTransport(std::string_view url)
 {
    auto idx = url.find(kTransportSeparator);
    if (idx == std::string_view::npos)
@@ -139,7 +139,7 @@ std::string ROOT::Experimental::Detail::RRawFile::GetTransport(std::string_view 
    return transport;
 }
 
-void *ROOT::Experimental::Detail::RRawFile::Map(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
+void *ROOT::Detail::RRawFile::Map(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
 {
    if (!fIsOpen)
       OpenImpl();
@@ -147,14 +147,14 @@ void *ROOT::Experimental::Detail::RRawFile::Map(size_t nbytes, std::uint64_t off
    return MapImpl(nbytes, offset, mapdOffset);
 }
 
-size_t ROOT::Experimental::Detail::RRawFile::Read(void *buffer, size_t nbytes)
+size_t ROOT::Detail::RRawFile::Read(void *buffer, size_t nbytes)
 {
    size_t res = ReadAt(buffer, nbytes, fFilePos);
    fFilePos += res;
    return res;
 }
 
-size_t ROOT::Experimental::Detail::RRawFile::ReadAt(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFile::ReadAt(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    if (!fIsOpen)
       OpenImpl();
@@ -200,7 +200,7 @@ size_t ROOT::Experimental::Detail::RRawFile::ReadAt(void *buffer, size_t nbytes,
    return totalBytes;
 }
 
-void ROOT::Experimental::Detail::RRawFile::ReadV(RIOVec *ioVec, unsigned int nReq)
+void ROOT::Detail::RRawFile::ReadV(RIOVec *ioVec, unsigned int nReq)
 {
    if (!fIsOpen)
       OpenImpl();
@@ -208,7 +208,7 @@ void ROOT::Experimental::Detail::RRawFile::ReadV(RIOVec *ioVec, unsigned int nRe
    ReadVImpl(ioVec, nReq);
 }
 
-bool ROOT::Experimental::Detail::RRawFile::Readln(std::string &line)
+bool ROOT::Detail::RRawFile::Readln(std::string &line)
 {
    if (fOptions.fLineBreak == ELineBreaks::kAuto) {
       // Auto-detect line breaks according to the break discovered in the first line
@@ -241,12 +241,12 @@ bool ROOT::Experimental::Detail::RRawFile::Readln(std::string &line)
    return !line.empty();
 }
 
-void ROOT::Experimental::Detail::RRawFile::Seek(std::uint64_t offset)
+void ROOT::Detail::RRawFile::Seek(std::uint64_t offset)
 {
    fFilePos = offset;
 }
 
-void ROOT::Experimental::Detail::RRawFile::Unmap(void *region, size_t nbytes)
+void ROOT::Detail::RRawFile::Unmap(void *region, size_t nbytes)
 {
    if (!fIsOpen)
       throw std::runtime_error("Cannot unmap, file not open");

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -29,23 +29,23 @@ namespace {
 constexpr int kDefaultBlockSize = 4096; // If fstat() does not provide a block size hint, use this value instead
 } // anonymous namespace
 
-ROOT::Detail::RRawFileUnix::RRawFileUnix(std::string_view url, ROptions options)
-   : ROOT::Detail::RRawFile(url, options), fFileDes(-1)
+ROOT::Internal::RRawFileUnix::RRawFileUnix(std::string_view url, ROptions options)
+   : RRawFile(url, options), fFileDes(-1)
 {
 }
 
-ROOT::Detail::RRawFileUnix::~RRawFileUnix()
+ROOT::Internal::RRawFileUnix::~RRawFileUnix()
 {
    if (fFileDes >= 0)
       close(fFileDes);
 }
 
-std::unique_ptr<ROOT::Detail::RRawFile> ROOT::Detail::RRawFileUnix::Clone() const
+std::unique_ptr<ROOT::Internal::RRawFile> ROOT::Internal::RRawFileUnix::Clone() const
 {
    return std::make_unique<RRawFileUnix>(fUrl, fOptions);
 }
 
-std::uint64_t ROOT::Detail::RRawFileUnix::GetSizeImpl()
+std::uint64_t ROOT::Internal::RRawFileUnix::GetSizeImpl()
 {
    struct stat info;
    int res = fstat(fFileDes, &info);
@@ -54,7 +54,7 @@ std::uint64_t ROOT::Detail::RRawFileUnix::GetSizeImpl()
    return info.st_size;
 }
 
-void *ROOT::Detail::RRawFileUnix::MapImpl(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
+void *ROOT::Internal::RRawFileUnix::MapImpl(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
 {
    static std::uint64_t szPageBitmap = sysconf(_SC_PAGESIZE) - 1;
    mapdOffset = offset & ~szPageBitmap;
@@ -66,7 +66,7 @@ void *ROOT::Detail::RRawFileUnix::MapImpl(size_t nbytes, std::uint64_t offset, s
    return result;
 }
 
-void ROOT::Detail::RRawFileUnix::OpenImpl()
+void ROOT::Internal::RRawFileUnix::OpenImpl()
 {
    fFileDes = open(GetLocation(fUrl).c_str(), O_RDONLY);
    if (fFileDes < 0) {
@@ -88,7 +88,7 @@ void ROOT::Detail::RRawFileUnix::OpenImpl()
    }
 }
 
-size_t ROOT::Detail::RRawFileUnix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Internal::RRawFileUnix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    size_t total_bytes = 0;
    while (nbytes) {
@@ -109,7 +109,7 @@ size_t ROOT::Detail::RRawFileUnix::ReadAtImpl(void *buffer, size_t nbytes, std::
    return total_bytes;
 }
 
-void ROOT::Detail::RRawFileUnix::UnmapImpl(void *region, size_t nbytes)
+void ROOT::Internal::RRawFileUnix::UnmapImpl(void *region, size_t nbytes)
 {
    int rv = munmap(region, nbytes);
    if (rv != 0)

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -29,23 +29,23 @@ namespace {
 constexpr int kDefaultBlockSize = 4096; // If fstat() does not provide a block size hint, use this value instead
 } // anonymous namespace
 
-ROOT::Experimental::Detail::RRawFileUnix::RRawFileUnix(std::string_view url, ROptions options)
-   : ROOT::Experimental::Detail::RRawFile(url, options), fFileDes(-1)
+ROOT::Detail::RRawFileUnix::RRawFileUnix(std::string_view url, ROptions options)
+   : ROOT::Detail::RRawFile(url, options), fFileDes(-1)
 {
 }
 
-ROOT::Experimental::Detail::RRawFileUnix::~RRawFileUnix()
+ROOT::Detail::RRawFileUnix::~RRawFileUnix()
 {
    if (fFileDes >= 0)
       close(fFileDes);
 }
 
-std::unique_ptr<ROOT::Experimental::Detail::RRawFile> ROOT::Experimental::Detail::RRawFileUnix::Clone() const
+std::unique_ptr<ROOT::Detail::RRawFile> ROOT::Detail::RRawFileUnix::Clone() const
 {
    return std::make_unique<RRawFileUnix>(fUrl, fOptions);
 }
 
-std::uint64_t ROOT::Experimental::Detail::RRawFileUnix::GetSizeImpl()
+std::uint64_t ROOT::Detail::RRawFileUnix::GetSizeImpl()
 {
    struct stat info;
    int res = fstat(fFileDes, &info);
@@ -54,7 +54,7 @@ std::uint64_t ROOT::Experimental::Detail::RRawFileUnix::GetSizeImpl()
    return info.st_size;
 }
 
-void *ROOT::Experimental::Detail::RRawFileUnix::MapImpl(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
+void *ROOT::Detail::RRawFileUnix::MapImpl(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
 {
    static std::uint64_t szPageBitmap = sysconf(_SC_PAGESIZE) - 1;
    mapdOffset = offset & ~szPageBitmap;
@@ -66,7 +66,7 @@ void *ROOT::Experimental::Detail::RRawFileUnix::MapImpl(size_t nbytes, std::uint
    return result;
 }
 
-void ROOT::Experimental::Detail::RRawFileUnix::OpenImpl()
+void ROOT::Detail::RRawFileUnix::OpenImpl()
 {
    fFileDes = open(GetLocation(fUrl).c_str(), O_RDONLY);
    if (fFileDes < 0) {
@@ -88,7 +88,7 @@ void ROOT::Experimental::Detail::RRawFileUnix::OpenImpl()
    }
 }
 
-size_t ROOT::Experimental::Detail::RRawFileUnix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFileUnix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    size_t total_bytes = 0;
    while (nbytes) {
@@ -109,7 +109,7 @@ size_t ROOT::Experimental::Detail::RRawFileUnix::ReadAtImpl(void *buffer, size_t
    return total_bytes;
 }
 
-void ROOT::Experimental::Detail::RRawFileUnix::UnmapImpl(void *region, size_t nbytes)
+void ROOT::Detail::RRawFileUnix::UnmapImpl(void *region, size_t nbytes)
 {
    int rv = munmap(region, nbytes);
    if (rv != 0)

--- a/io/io/src/RRawFileWin.cxx
+++ b/io/io/src/RRawFileWin.cxx
@@ -26,23 +26,23 @@ namespace {
 constexpr int kDefaultBlockSize = 4096; // Read files in 4k pages unless told otherwise
 } // anonymous namespace
 
-ROOT::Detail::RRawFileWin::RRawFileWin(std::string_view url, ROptions options)
-   : ROOT::Detail::RRawFile(url, options), fFilePtr(nullptr)
+ROOT::Internal::RRawFileWin::RRawFileWin(std::string_view url, ROptions options)
+   : RRawFile(url, options), fFilePtr(nullptr)
 {
 }
 
-ROOT::Detail::RRawFileWin::~RRawFileWin()
+ROOT::Internal::RRawFileWin::~RRawFileWin()
 {
    if (fFilePtr != nullptr)
       fclose(fFilePtr);
 }
 
-std::unique_ptr<ROOT::Detail::RRawFile> ROOT::Detail::RRawFileWin::Clone() const
+std::unique_ptr<ROOT::Internal::RRawFile> ROOT::Internal::RRawFileWin::Clone() const
 {
    return std::make_unique<RRawFileWin>(fUrl, fOptions);
 }
 
-std::uint64_t ROOT::Detail::RRawFileWin::GetSizeImpl()
+std::uint64_t ROOT::Internal::RRawFileWin::GetSizeImpl()
 {
    Seek(0L, SEEK_END);
    long size = ftell(fFilePtr);
@@ -53,7 +53,7 @@ std::uint64_t ROOT::Detail::RRawFileWin::GetSizeImpl()
    return size;
 }
 
-void ROOT::Detail::RRawFileWin::OpenImpl()
+void ROOT::Internal::RRawFileWin::OpenImpl()
 {
    fFilePtr = fopen(GetLocation(fUrl).c_str(), "rb");
    if (fFilePtr == nullptr)
@@ -65,7 +65,7 @@ void ROOT::Detail::RRawFileWin::OpenImpl()
       fOptions.fBlockSize = kDefaultBlockSize;
 }
 
-size_t ROOT::Detail::RRawFileWin::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Internal::RRawFileWin::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    Seek(offset, SEEK_SET);
    size_t res = fread(buffer, 1, nbytes, fFilePtr);
@@ -76,7 +76,7 @@ size_t ROOT::Detail::RRawFileWin::ReadAtImpl(void *buffer, size_t nbytes, std::u
    return res;
 }
 
-void ROOT::Detail::RRawFileWin::Seek(long offset, int whence)
+void ROOT::Internal::RRawFileWin::Seek(long offset, int whence)
 {
    int res = fseek(fFilePtr, offset, whence);
    if (res != 0)

--- a/io/io/src/RRawFileWin.cxx
+++ b/io/io/src/RRawFileWin.cxx
@@ -26,23 +26,23 @@ namespace {
 constexpr int kDefaultBlockSize = 4096; // Read files in 4k pages unless told otherwise
 } // anonymous namespace
 
-ROOT::Experimental::Detail::RRawFileWin::RRawFileWin(std::string_view url, ROptions options)
-   : ROOT::Experimental::Detail::RRawFile(url, options), fFilePtr(nullptr)
+ROOT::Detail::RRawFileWin::RRawFileWin(std::string_view url, ROptions options)
+   : ROOT::Detail::RRawFile(url, options), fFilePtr(nullptr)
 {
 }
 
-ROOT::Experimental::Detail::RRawFileWin::~RRawFileWin()
+ROOT::Detail::RRawFileWin::~RRawFileWin()
 {
    if (fFilePtr != nullptr)
       fclose(fFilePtr);
 }
 
-std::unique_ptr<ROOT::Experimental::Detail::RRawFile> ROOT::Experimental::Detail::RRawFileWin::Clone() const
+std::unique_ptr<ROOT::Detail::RRawFile> ROOT::Detail::RRawFileWin::Clone() const
 {
    return std::make_unique<RRawFileWin>(fUrl, fOptions);
 }
 
-std::uint64_t ROOT::Experimental::Detail::RRawFileWin::GetSizeImpl()
+std::uint64_t ROOT::Detail::RRawFileWin::GetSizeImpl()
 {
    Seek(0L, SEEK_END);
    long size = ftell(fFilePtr);
@@ -53,7 +53,7 @@ std::uint64_t ROOT::Experimental::Detail::RRawFileWin::GetSizeImpl()
    return size;
 }
 
-void ROOT::Experimental::Detail::RRawFileWin::OpenImpl()
+void ROOT::Detail::RRawFileWin::OpenImpl()
 {
    fFilePtr = fopen(GetLocation(fUrl).c_str(), "rb");
    if (fFilePtr == nullptr)
@@ -65,7 +65,7 @@ void ROOT::Experimental::Detail::RRawFileWin::OpenImpl()
       fOptions.fBlockSize = kDefaultBlockSize;
 }
 
-size_t ROOT::Experimental::Detail::RRawFileWin::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFileWin::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    Seek(offset, SEEK_SET);
    size_t res = fread(buffer, 1, nbytes, fFilePtr);
@@ -76,7 +76,7 @@ size_t ROOT::Experimental::Detail::RRawFileWin::ReadAtImpl(void *buffer, size_t 
    return res;
 }
 
-void ROOT::Experimental::Detail::RRawFileWin::Seek(long offset, int whence)
+void ROOT::Detail::RRawFileWin::Seek(long offset, int whence)
 {
    int res = fseek(fFilePtr, offset, whence);
    if (res != 0)

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -13,7 +13,7 @@
 
 #include "gtest/gtest.h"
 
-using namespace ROOT::Detail;
+using namespace ROOT::Internal;
 
 namespace {
 

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -13,7 +13,7 @@
 
 #include "gtest/gtest.h"
 
-using namespace ROOT::Experimental::Detail;
+using namespace ROOT::Detail;
 
 namespace {
 

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -13,7 +13,7 @@
 
 #include "gtest/gtest.h"
 
-using namespace ROOT::Internal;
+using RRawFile = ROOT::Internal::RRawFile;
 
 namespace {
 

--- a/net/davix/inc/LinkDef.h
+++ b/net/davix/inc/LinkDef.h
@@ -6,6 +6,6 @@
 
 #pragma link C++ class TDavixFile+;
 #pragma link C++ class TDavixSystem+;
-#pragma link C++ class ROOT::Experimental::Detail::RRawFileDavix+;
+#pragma link C++ class ROOT::Detail::RRawFileDavix+;
 
 #endif

--- a/net/davix/inc/LinkDef.h
+++ b/net/davix/inc/LinkDef.h
@@ -6,6 +6,6 @@
 
 #pragma link C++ class TDavixFile+;
 #pragma link C++ class TDavixSystem+;
-#pragma link C++ class ROOT::Detail::RRawFileDavix+;
+#pragma link C++ class ROOT::Internal::RRawFileDavix+;
 
 #endif

--- a/net/davix/inc/ROOT/RRawFileDavix.hxx
+++ b/net/davix/inc/ROOT/RRawFileDavix.hxx
@@ -20,12 +20,9 @@
 #include <memory>
 
 namespace ROOT {
-
 namespace Internal {
-struct RDavixFileDes;
-}
 
-namespace Detail {
+struct RDavixFileDes;
 
 /**
  * \class RRawFileDavix RRawFileDavix.hxx
@@ -51,7 +48,7 @@ public:
    int GetFeatures() const final { return kFeatureHasSize; }
 };
 
-} // namespace Detail
+} // namespace Internal
 } // namespace ROOT
 
 #endif

--- a/net/davix/inc/ROOT/RRawFileDavix.hxx
+++ b/net/davix/inc/ROOT/RRawFileDavix.hxx
@@ -20,12 +20,12 @@
 #include <memory>
 
 namespace ROOT {
-namespace Experimental {
-namespace Detail {
 
 namespace Internal {
 struct RDavixFileDes;
 }
+
+namespace Detail {
 
 /**
  * \class RRawFileDavix RRawFileDavix.hxx
@@ -52,7 +52,6 @@ public:
 };
 
 } // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/net/davix/src/RRawFileDavix.cxx
+++ b/net/davix/src/RRawFileDavix.cxx
@@ -24,8 +24,6 @@ constexpr int kDefaultBlockSize = 128 * 1024; // Read in relatively large 128k b
 } // anonymous namespace
 
 namespace ROOT {
-namespace Experimental {
-namespace Detail {
 namespace Internal {
 
 struct RDavixFileDes {
@@ -40,27 +38,25 @@ struct RDavixFileDes {
 };
 
 } // namespace Internal
-} // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
-ROOT::Experimental::Detail::RRawFileDavix::RRawFileDavix(std::string_view url, ROptions options)
+ROOT::Detail::RRawFileDavix::RRawFileDavix(std::string_view url, ROptions options)
    : RRawFile(url, options), fFileDes(new Internal::RDavixFileDes())
 {
 }
 
-ROOT::Experimental::Detail::RRawFileDavix::~RRawFileDavix()
+ROOT::Detail::RRawFileDavix::~RRawFileDavix()
 {
    if (fFileDes->fd != nullptr)
       fFileDes->pos.close(fFileDes->fd, nullptr);
 }
 
-std::unique_ptr<ROOT::Experimental::Detail::RRawFile> ROOT::Experimental::Detail::RRawFileDavix::Clone() const
+std::unique_ptr<ROOT::Detail::RRawFile> ROOT::Detail::RRawFileDavix::Clone() const
 {
    return std::make_unique<RRawFileDavix>(fUrl, fOptions);
 }
 
-std::uint64_t ROOT::Experimental::Detail::RRawFileDavix::GetSizeImpl()
+std::uint64_t ROOT::Detail::RRawFileDavix::GetSizeImpl()
 {
    struct stat buf;
    Davix::DavixError *err = nullptr;
@@ -70,7 +66,7 @@ std::uint64_t ROOT::Experimental::Detail::RRawFileDavix::GetSizeImpl()
    return buf.st_size;
 }
 
-void ROOT::Experimental::Detail::RRawFileDavix::OpenImpl()
+void ROOT::Detail::RRawFileDavix::OpenImpl()
 {
    Davix::DavixError *err = nullptr;
    fFileDes->fd = fFileDes->pos.open(nullptr, fUrl, O_RDONLY, &err);
@@ -81,7 +77,7 @@ void ROOT::Experimental::Detail::RRawFileDavix::OpenImpl()
       fOptions.fBlockSize = kDefaultBlockSize;
 }
 
-size_t ROOT::Experimental::Detail::RRawFileDavix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFileDavix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    Davix::DavixError *err = nullptr;
    auto retval = fFileDes->pos.pread(fFileDes->fd, buffer, nbytes, offset, &err);
@@ -91,7 +87,7 @@ size_t ROOT::Experimental::Detail::RRawFileDavix::ReadAtImpl(void *buffer, size_
    return static_cast<size_t>(retval);
 }
 
-void ROOT::Experimental::Detail::RRawFileDavix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
+void ROOT::Detail::RRawFileDavix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
    Davix::DavixError *davixErr = NULL;
    Davix::DavIOVecInput in[nReq];

--- a/net/davix/src/RRawFileDavix.cxx
+++ b/net/davix/src/RRawFileDavix.cxx
@@ -40,23 +40,24 @@ struct RDavixFileDes {
 } // namespace Internal
 } // namespace ROOT
 
-ROOT::Detail::RRawFileDavix::RRawFileDavix(std::string_view url, ROptions options)
-   : RRawFile(url, options), fFileDes(new Internal::RDavixFileDes())
+
+ROOT::Internal::RRawFileDavix::RRawFileDavix(std::string_view url, ROptions options)
+   : RRawFile(url, options), fFileDes(new RDavixFileDes())
 {
 }
 
-ROOT::Detail::RRawFileDavix::~RRawFileDavix()
+ROOT::Internal::RRawFileDavix::~RRawFileDavix()
 {
    if (fFileDes->fd != nullptr)
       fFileDes->pos.close(fFileDes->fd, nullptr);
 }
 
-std::unique_ptr<ROOT::Detail::RRawFile> ROOT::Detail::RRawFileDavix::Clone() const
+std::unique_ptr<ROOT::Internal::RRawFile> ROOT::Internal::RRawFileDavix::Clone() const
 {
    return std::make_unique<RRawFileDavix>(fUrl, fOptions);
 }
 
-std::uint64_t ROOT::Detail::RRawFileDavix::GetSizeImpl()
+std::uint64_t ROOT::Internal::RRawFileDavix::GetSizeImpl()
 {
    struct stat buf;
    Davix::DavixError *err = nullptr;
@@ -66,7 +67,7 @@ std::uint64_t ROOT::Detail::RRawFileDavix::GetSizeImpl()
    return buf.st_size;
 }
 
-void ROOT::Detail::RRawFileDavix::OpenImpl()
+void ROOT::Internal::RRawFileDavix::OpenImpl()
 {
    Davix::DavixError *err = nullptr;
    fFileDes->fd = fFileDes->pos.open(nullptr, fUrl, O_RDONLY, &err);
@@ -77,7 +78,7 @@ void ROOT::Detail::RRawFileDavix::OpenImpl()
       fOptions.fBlockSize = kDefaultBlockSize;
 }
 
-size_t ROOT::Detail::RRawFileDavix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Internal::RRawFileDavix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    Davix::DavixError *err = nullptr;
    auto retval = fFileDes->pos.pread(fFileDes->fd, buffer, nbytes, offset, &err);
@@ -87,7 +88,7 @@ size_t ROOT::Detail::RRawFileDavix::ReadAtImpl(void *buffer, size_t nbytes, std:
    return static_cast<size_t>(retval);
 }
 
-void ROOT::Detail::RRawFileDavix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
+void ROOT::Internal::RRawFileDavix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
    Davix::DavixError *davixErr = NULL;
    Davix::DavIOVecInput in[nReq];

--- a/net/davix/test/RRawFileDavix.cxx
+++ b/net/davix/test/RRawFileDavix.cxx
@@ -5,7 +5,8 @@
 
 #include "gtest/gtest.h"
 
-using namespace ROOT::Internal;
+using RRawFile = ROOT::Internal::RRawFile;
+using RRawFileDavix = ROOT::Internal::RRawFileDavix;
 
 TEST(RRawFileDavix, Idle)
 {

--- a/net/davix/test/RRawFileDavix.cxx
+++ b/net/davix/test/RRawFileDavix.cxx
@@ -5,7 +5,7 @@
 
 #include "gtest/gtest.h"
 
-using namespace ROOT::Detail;
+using namespace ROOT::Internal;
 
 TEST(RRawFileDavix, Idle)
 {

--- a/net/davix/test/RRawFileDavix.cxx
+++ b/net/davix/test/RRawFileDavix.cxx
@@ -5,7 +5,7 @@
 
 #include "gtest/gtest.h"
 
-using namespace ROOT::Experimental::Detail;
+using namespace ROOT::Detail;
 
 TEST(RRawFileDavix, Idle)
 {

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -27,11 +27,12 @@
 class TFile;
 
 namespace ROOT {
-namespace Experimental {
 
 namespace Detail {
 class RRawFile;
 }
+
+namespace Experimental {
 
 // clang-format off
 /**
@@ -100,7 +101,7 @@ RNTuple data keys.
 class RMiniFileReader {
 private:
    /// The raw file used to read byte ranges
-   Detail::RRawFile *fRawFile = nullptr;
+   ROOT::Detail::RRawFile *fRawFile = nullptr;
    /// Indicates whether the file is a TFile container or an RNTuple bare file
    bool fIsBare = false;
    /// Used when the file container turns out to be a bare file
@@ -111,7 +112,7 @@ private:
 public:
    RMiniFileReader() = default;
    /// Uses the given raw file to read byte ranges
-   explicit RMiniFileReader(Detail::RRawFile *rawFile);
+   explicit RMiniFileReader(ROOT::Detail::RRawFile *rawFile);
    /// Extracts header and footer location for the RNTuple identified by ntupleName
    RNTuple GetNTuple(std::string_view ntupleName);
    /// Reads a given byte range from the file into the provided memory buffer

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -28,7 +28,7 @@ class TFile;
 
 namespace ROOT {
 
-namespace Detail {
+namespace Internal {
 class RRawFile;
 }
 
@@ -101,7 +101,7 @@ RNTuple data keys.
 class RMiniFileReader {
 private:
    /// The raw file used to read byte ranges
-   ROOT::Detail::RRawFile *fRawFile = nullptr;
+   ROOT::Internal::RRawFile *fRawFile = nullptr;
    /// Indicates whether the file is a TFile container or an RNTuple bare file
    bool fIsBare = false;
    /// Used when the file container turns out to be a bare file
@@ -112,7 +112,7 @@ private:
 public:
    RMiniFileReader() = default;
    /// Uses the given raw file to read byte ranges
-   explicit RMiniFileReader(ROOT::Detail::RRawFile *rawFile);
+   explicit RMiniFileReader(ROOT::Internal::RRawFile *rawFile);
    /// Extracts header and footer location for the RNTuple identified by ntupleName
    RNTuple GetNTuple(std::string_view ntupleName);
    /// Reads a given byte range from the file into the provided memory buffer

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -31,6 +31,11 @@
 class TFile;
 
 namespace ROOT {
+
+namespace Detail {
+class RRawFile;
+}
+
 namespace Experimental {
 namespace Detail {
 
@@ -118,7 +123,7 @@ private:
    /// Helper to unzip pages and header/footer; comprises a 16MB unzip buffer
    RNTupleDecompressor fDecompressor;
    /// An RRawFile is used to request the necessary byte ranges from a local or a remote file
-   std::unique_ptr<RRawFile> fFile;
+   std::unique_ptr<ROOT::Detail::RRawFile> fFile;
    /// Takes the fFile to read ntuple blobs from it
    Internal::RMiniFileReader fReader;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -32,7 +32,7 @@ class TFile;
 
 namespace ROOT {
 
-namespace Detail {
+namespace Internal {
 class RRawFile;
 }
 
@@ -123,7 +123,7 @@ private:
    /// Helper to unzip pages and header/footer; comprises a 16MB unzip buffer
    RNTupleDecompressor fDecompressor;
    /// An RRawFile is used to request the necessary byte ranges from a local or a remote file
-   std::unique_ptr<ROOT::Detail::RRawFile> fFile;
+   std::unique_ptr<ROOT::Internal::RRawFile> fFile;
    /// Takes the fFile to read ntuple blobs from it
    Internal::RMiniFileReader fReader;
 

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -895,7 +895,7 @@ struct RTFileControlBlock {
 } // namespace Internal
 
 
-ROOT::Experimental::Internal::RMiniFileReader::RMiniFileReader(ROOT::Detail::RRawFile *rawFile)
+ROOT::Experimental::Internal::RMiniFileReader::RMiniFileReader(ROOT::Internal::RRawFile *rawFile)
    : fRawFile(rawFile)
 {
 }

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -895,7 +895,7 @@ struct RTFileControlBlock {
 } // namespace Internal
 
 
-ROOT::Experimental::Internal::RMiniFileReader::RMiniFileReader(Detail::RRawFile *rawFile)
+ROOT::Experimental::Internal::RMiniFileReader::RMiniFileReader(ROOT::Detail::RRawFile *rawFile)
    : fRawFile(rawFile)
 {
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -210,7 +210,7 @@ ROOT::Experimental::Detail::RPageSourceFile::RPageSourceFile(std::string_view nt
    const RNTupleReadOptions &options)
    : RPageSourceFile(ntupleName, options)
 {
-   fFile = std::unique_ptr<RRawFile>(RRawFile::Create(path));
+   fFile = std::unique_ptr<ROOT::Detail::RRawFile>(ROOT::Detail::RRawFile::Create(path));
    R__ASSERT(fFile);
    fReader = Internal::RMiniFileReader(fFile.get());
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -210,7 +210,7 @@ ROOT::Experimental::Detail::RPageSourceFile::RPageSourceFile(std::string_view nt
    const RNTupleReadOptions &options)
    : RPageSourceFile(ntupleName, options)
 {
-   fFile = std::unique_ptr<ROOT::Detail::RRawFile>(ROOT::Detail::RRawFile::Create(path));
+   fFile = std::unique_ptr<ROOT::Internal::RRawFile>(ROOT::Internal::RRawFile::Create(path));
    R__ASSERT(fFile);
    fReader = Internal::RMiniFileReader(fFile.get());
 }

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -12,7 +12,7 @@ using ENTupleContainerFormat = ROOT::Experimental::ENTupleContainerFormat;
 using RMiniFileReader = ROOT::Experimental::Internal::RMiniFileReader;
 using RNTupleFileWriter = ROOT::Experimental::Internal::RNTupleFileWriter;
 using RNTuple = ROOT::Experimental::RNTuple;
-using RRawFile = ROOT::Detail::RRawFile;
+using RRawFile = ROOT::Internal::RRawFile;
 
 namespace {
 

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -12,7 +12,7 @@ using ENTupleContainerFormat = ROOT::Experimental::ENTupleContainerFormat;
 using RMiniFileReader = ROOT::Experimental::Internal::RMiniFileReader;
 using RNTupleFileWriter = ROOT::Experimental::Internal::RNTupleFileWriter;
 using RNTuple = ROOT::Experimental::RNTuple;
-using RRawFile = ROOT::Experimental::Detail::RRawFile;
+using RRawFile = ROOT::Detail::RRawFile;
 
 namespace {
 


### PR DESCRIPTION
In preparation for fixing ROOT-10520, this PR moves the `RRawFile` classes out of the `Experimental` namespace into `Internal`.  A follow-up pull request will modify the RDF SQLite data source such that it uses RRawFile, which in turn uses the plugin infrastructure to load the Davix libraries when necessary.

Should be merged before #4878.