### PR TITLE
[DF] Use RRawFile in SQlite data source

### DIFF
--- a/etc/plugins/ROOT@@Detail@@RRawFile/P010_RRawFileDavix.C
+++ b/etc/plugins/ROOT@@Detail@@RRawFile/P010_RRawFileDavix.C
@@ -7,10 +7,10 @@ void P010_RRawFileDavix()
        !gEnv->GetValue("Davix.UseOldClient", 0)) {
 
       gPluginMgr->AddHandler(
-         "ROOT::Experimental::Detail::RRawFile",
+         "ROOT::Detail::RRawFile",
          "^http[s]?:",
-         "ROOT::Experimental::Detail::RRawFileDavix",
+         "ROOT::Detail::RRawFileDavix",
          "RDAVIX",
-         "RRawFileDavix(std::string_view, ROOT::Experimental::Detail::RRawFile::ROptions)");
+         "RRawFileDavix(std::string_view, ROOT::Detail::RRawFile::ROptions)");
    }
 }

--- a/io/io/inc/LinkDef.h
+++ b/io/io/inc/LinkDef.h
@@ -52,7 +52,7 @@
 #pragma link C++ class TStreamerInfoActions::TConfiguredAction+;
 #pragma link C++ class TStreamerInfoActions::TActionSequence+;
 #pragma link C++ class TStreamerInfoActions::TConfiguration-;
-#pragma link C++ class ROOT::Experimental::Detail::RRawFile+;
+#pragma link C++ class ROOT::Detail::RRawFile+;
 #pragma link C++ class ROOT::Experimental::TBufferMerger;
 #pragma link C++ class ROOT::Experimental::TBufferMergerFile;
 

--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -20,10 +20,7 @@
 #include <string>
 
 namespace ROOT {
-namespace Experimental {
 namespace Detail {
-
-class RRawFile;
 
 /**
  * \class RRawFile RRawFile.hxx
@@ -180,10 +177,9 @@ public:
 
    /// Read the next line starting from the current value of fFilePos. Returns false if the end of the file is reached.
    bool Readln(std::string &line);
-};
+}; // class RRawFile
 
 } // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/io/io/inc/ROOT/RRawFileUnix.hxx
+++ b/io/io/inc/ROOT/RRawFileUnix.hxx
@@ -19,7 +19,6 @@
 #include <cstdint>
 
 namespace ROOT {
-namespace Experimental {
 namespace Detail {
 
 /**
@@ -48,7 +47,6 @@ public:
 };
 
 } // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/io/io/inc/ROOT/RRawFileWin.hxx
+++ b/io/io/inc/ROOT/RRawFileWin.hxx
@@ -20,7 +20,6 @@
 #include <cstdio>
 
 namespace ROOT {
-namespace Experimental {
 namespace Detail {
 
 /**
@@ -48,7 +47,6 @@ public:
 };
 
 } // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/io/io/src/RRawFile.cxx
+++ b/io/io/src/RRawFile.cxx
@@ -43,7 +43,7 @@ constexpr unsigned int kLineBreakTokenSizes[] = {0, 1, 1, 2};
 constexpr unsigned int kLineBuffer = 128; // On Readln, look for line-breaks in chunks of 128 bytes
 } // anonymous namespace
 
-size_t ROOT::Experimental::Detail::RRawFile::RBlockBuffer::CopyTo(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFile::RBlockBuffer::CopyTo(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    if (offset < fBufferOffset)
       return 0;
@@ -58,19 +58,19 @@ size_t ROOT::Experimental::Detail::RRawFile::RBlockBuffer::CopyTo(void *buffer, 
    return copiedBytes;
 }
 
-ROOT::Experimental::Detail::RRawFile::RRawFile(std::string_view url, ROptions options)
+ROOT::Detail::RRawFile::RRawFile(std::string_view url, ROptions options)
    : fBlockBufferIdx(0), fBufferSpace(nullptr), fFileSize(kUnknownFileSize), fIsOpen(false), fUrl(url),
      fOptions(options), fFilePos(0)
 {
 }
 
-ROOT::Experimental::Detail::RRawFile::~RRawFile()
+ROOT::Detail::RRawFile::~RRawFile()
 {
    delete[] fBufferSpace;
 }
 
-ROOT::Experimental::Detail::RRawFile *
-ROOT::Experimental::Detail::RRawFile::Create(std::string_view url, ROptions options)
+ROOT::Detail::RRawFile *
+ROOT::Detail::RRawFile::Create(std::string_view url, ROptions options)
 {
    std::string transport = GetTransport(url);
    if (transport == "file") {
@@ -81,7 +81,7 @@ ROOT::Experimental::Detail::RRawFile::Create(std::string_view url, ROptions opti
 #endif
    }
    if (transport == "http" || transport == "https") {
-      if (TPluginHandler *h = gROOT->GetPluginManager()->FindHandler("ROOT::Experimental::Detail::RRawFile")) {
+      if (TPluginHandler *h = gROOT->GetPluginManager()->FindHandler("ROOT::Detail::RRawFile")) {
          if (h->LoadPlugin() == 0) {
             return reinterpret_cast<RRawFile *>(h->ExecPlugin(2, &url, &options));
          }
@@ -92,25 +92,25 @@ ROOT::Experimental::Detail::RRawFile::Create(std::string_view url, ROptions opti
    throw std::runtime_error("Unsupported transport protocol: " + transport);
 }
 
-void *ROOT::Experimental::Detail::RRawFile::MapImpl(size_t /* nbytes */, std::uint64_t /* offset */,
+void *ROOT::Detail::RRawFile::MapImpl(size_t /* nbytes */, std::uint64_t /* offset */,
    std::uint64_t& /* mapdOffset */)
 {
    throw std::runtime_error("Memory mapping unsupported");
 }
 
-void ROOT::Experimental::Detail::RRawFile::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
+void ROOT::Detail::RRawFile::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
    for (unsigned i = 0; i < nReq; ++i) {
       ioVec[i].fOutBytes = ReadAt(ioVec[i].fBuffer, ioVec[i].fSize, ioVec[i].fOffset);
    }
 }
 
-void ROOT::Experimental::Detail::RRawFile::UnmapImpl(void * /* region */, size_t /* nbytes */)
+void ROOT::Detail::RRawFile::UnmapImpl(void * /* region */, size_t /* nbytes */)
 {
    throw std::runtime_error("Memory mapping unsupported");
 }
 
-std::string ROOT::Experimental::Detail::RRawFile::GetLocation(std::string_view url)
+std::string ROOT::Detail::RRawFile::GetLocation(std::string_view url)
 {
    auto idx = url.find(kTransportSeparator);
    if (idx == std::string_view::npos)
@@ -118,7 +118,7 @@ std::string ROOT::Experimental::Detail::RRawFile::GetLocation(std::string_view u
    return std::string(url.substr(idx + strlen(kTransportSeparator)));
 }
 
-std::uint64_t ROOT::Experimental::Detail::RRawFile::GetSize()
+std::uint64_t ROOT::Detail::RRawFile::GetSize()
 {
    if (!fIsOpen)
       OpenImpl();
@@ -129,7 +129,7 @@ std::uint64_t ROOT::Experimental::Detail::RRawFile::GetSize()
    return fFileSize;
 }
 
-std::string ROOT::Experimental::Detail::RRawFile::GetTransport(std::string_view url)
+std::string ROOT::Detail::RRawFile::GetTransport(std::string_view url)
 {
    auto idx = url.find(kTransportSeparator);
    if (idx == std::string_view::npos)
@@ -139,7 +139,7 @@ std::string ROOT::Experimental::Detail::RRawFile::GetTransport(std::string_view 
    return transport;
 }
 
-void *ROOT::Experimental::Detail::RRawFile::Map(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
+void *ROOT::Detail::RRawFile::Map(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
 {
    if (!fIsOpen)
       OpenImpl();
@@ -147,14 +147,14 @@ void *ROOT::Experimental::Detail::RRawFile::Map(size_t nbytes, std::uint64_t off
    return MapImpl(nbytes, offset, mapdOffset);
 }
 
-size_t ROOT::Experimental::Detail::RRawFile::Read(void *buffer, size_t nbytes)
+size_t ROOT::Detail::RRawFile::Read(void *buffer, size_t nbytes)
 {
    size_t res = ReadAt(buffer, nbytes, fFilePos);
    fFilePos += res;
    return res;
 }
 
-size_t ROOT::Experimental::Detail::RRawFile::ReadAt(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFile::ReadAt(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    if (!fIsOpen)
       OpenImpl();
@@ -200,7 +200,7 @@ size_t ROOT::Experimental::Detail::RRawFile::ReadAt(void *buffer, size_t nbytes,
    return totalBytes;
 }
 
-void ROOT::Experimental::Detail::RRawFile::ReadV(RIOVec *ioVec, unsigned int nReq)
+void ROOT::Detail::RRawFile::ReadV(RIOVec *ioVec, unsigned int nReq)
 {
    if (!fIsOpen)
       OpenImpl();
@@ -208,7 +208,7 @@ void ROOT::Experimental::Detail::RRawFile::ReadV(RIOVec *ioVec, unsigned int nRe
    ReadVImpl(ioVec, nReq);
 }
 
-bool ROOT::Experimental::Detail::RRawFile::Readln(std::string &line)
+bool ROOT::Detail::RRawFile::Readln(std::string &line)
 {
    if (fOptions.fLineBreak == ELineBreaks::kAuto) {
       // Auto-detect line breaks according to the break discovered in the first line
@@ -241,12 +241,12 @@ bool ROOT::Experimental::Detail::RRawFile::Readln(std::string &line)
    return !line.empty();
 }
 
-void ROOT::Experimental::Detail::RRawFile::Seek(std::uint64_t offset)
+void ROOT::Detail::RRawFile::Seek(std::uint64_t offset)
 {
    fFilePos = offset;
 }
 
-void ROOT::Experimental::Detail::RRawFile::Unmap(void *region, size_t nbytes)
+void ROOT::Detail::RRawFile::Unmap(void *region, size_t nbytes)
 {
    if (!fIsOpen)
       throw std::runtime_error("Cannot unmap, file not open");

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -29,23 +29,23 @@ namespace {
 constexpr int kDefaultBlockSize = 4096; // If fstat() does not provide a block size hint, use this value instead
 } // anonymous namespace
 
-ROOT::Experimental::Detail::RRawFileUnix::RRawFileUnix(std::string_view url, ROptions options)
-   : ROOT::Experimental::Detail::RRawFile(url, options), fFileDes(-1)
+ROOT::Detail::RRawFileUnix::RRawFileUnix(std::string_view url, ROptions options)
+   : ROOT::Detail::RRawFile(url, options), fFileDes(-1)
 {
 }
 
-ROOT::Experimental::Detail::RRawFileUnix::~RRawFileUnix()
+ROOT::Detail::RRawFileUnix::~RRawFileUnix()
 {
    if (fFileDes >= 0)
       close(fFileDes);
 }
 
-std::unique_ptr<ROOT::Experimental::Detail::RRawFile> ROOT::Experimental::Detail::RRawFileUnix::Clone() const
+std::unique_ptr<ROOT::Detail::RRawFile> ROOT::Detail::RRawFileUnix::Clone() const
 {
    return std::make_unique<RRawFileUnix>(fUrl, fOptions);
 }
 
-std::uint64_t ROOT::Experimental::Detail::RRawFileUnix::GetSizeImpl()
+std::uint64_t ROOT::Detail::RRawFileUnix::GetSizeImpl()
 {
    struct stat info;
    int res = fstat(fFileDes, &info);
@@ -54,7 +54,7 @@ std::uint64_t ROOT::Experimental::Detail::RRawFileUnix::GetSizeImpl()
    return info.st_size;
 }
 
-void *ROOT::Experimental::Detail::RRawFileUnix::MapImpl(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
+void *ROOT::Detail::RRawFileUnix::MapImpl(size_t nbytes, std::uint64_t offset, std::uint64_t &mapdOffset)
 {
    static std::uint64_t szPageBitmap = sysconf(_SC_PAGESIZE) - 1;
    mapdOffset = offset & ~szPageBitmap;
@@ -66,7 +66,7 @@ void *ROOT::Experimental::Detail::RRawFileUnix::MapImpl(size_t nbytes, std::uint
    return result;
 }
 
-void ROOT::Experimental::Detail::RRawFileUnix::OpenImpl()
+void ROOT::Detail::RRawFileUnix::OpenImpl()
 {
    fFileDes = open(GetLocation(fUrl).c_str(), O_RDONLY);
    if (fFileDes < 0) {
@@ -88,7 +88,7 @@ void ROOT::Experimental::Detail::RRawFileUnix::OpenImpl()
    }
 }
 
-size_t ROOT::Experimental::Detail::RRawFileUnix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFileUnix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    size_t total_bytes = 0;
    while (nbytes) {
@@ -109,7 +109,7 @@ size_t ROOT::Experimental::Detail::RRawFileUnix::ReadAtImpl(void *buffer, size_t
    return total_bytes;
 }
 
-void ROOT::Experimental::Detail::RRawFileUnix::UnmapImpl(void *region, size_t nbytes)
+void ROOT::Detail::RRawFileUnix::UnmapImpl(void *region, size_t nbytes)
 {
    int rv = munmap(region, nbytes);
    if (rv != 0)

--- a/io/io/src/RRawFileWin.cxx
+++ b/io/io/src/RRawFileWin.cxx
@@ -26,23 +26,23 @@ namespace {
 constexpr int kDefaultBlockSize = 4096; // Read files in 4k pages unless told otherwise
 } // anonymous namespace
 
-ROOT::Experimental::Detail::RRawFileWin::RRawFileWin(std::string_view url, ROptions options)
-   : ROOT::Experimental::Detail::RRawFile(url, options), fFilePtr(nullptr)
+ROOT::Detail::RRawFileWin::RRawFileWin(std::string_view url, ROptions options)
+   : ROOT::Detail::RRawFile(url, options), fFilePtr(nullptr)
 {
 }
 
-ROOT::Experimental::Detail::RRawFileWin::~RRawFileWin()
+ROOT::Detail::RRawFileWin::~RRawFileWin()
 {
    if (fFilePtr != nullptr)
       fclose(fFilePtr);
 }
 
-std::unique_ptr<ROOT::Experimental::Detail::RRawFile> ROOT::Experimental::Detail::RRawFileWin::Clone() const
+std::unique_ptr<ROOT::Detail::RRawFile> ROOT::Detail::RRawFileWin::Clone() const
 {
    return std::make_unique<RRawFileWin>(fUrl, fOptions);
 }
 
-std::uint64_t ROOT::Experimental::Detail::RRawFileWin::GetSizeImpl()
+std::uint64_t ROOT::Detail::RRawFileWin::GetSizeImpl()
 {
    Seek(0L, SEEK_END);
    long size = ftell(fFilePtr);
@@ -53,7 +53,7 @@ std::uint64_t ROOT::Experimental::Detail::RRawFileWin::GetSizeImpl()
    return size;
 }
 
-void ROOT::Experimental::Detail::RRawFileWin::OpenImpl()
+void ROOT::Detail::RRawFileWin::OpenImpl()
 {
    fFilePtr = fopen(GetLocation(fUrl).c_str(), "rb");
    if (fFilePtr == nullptr)
@@ -65,7 +65,7 @@ void ROOT::Experimental::Detail::RRawFileWin::OpenImpl()
       fOptions.fBlockSize = kDefaultBlockSize;
 }
 
-size_t ROOT::Experimental::Detail::RRawFileWin::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFileWin::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    Seek(offset, SEEK_SET);
    size_t res = fread(buffer, 1, nbytes, fFilePtr);
@@ -76,7 +76,7 @@ size_t ROOT::Experimental::Detail::RRawFileWin::ReadAtImpl(void *buffer, size_t 
    return res;
 }
 
-void ROOT::Experimental::Detail::RRawFileWin::Seek(long offset, int whence)
+void ROOT::Detail::RRawFileWin::Seek(long offset, int whence)
 {
    int res = fseek(fFilePtr, offset, whence);
    if (res != 0)

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -13,7 +13,7 @@
 
 #include "gtest/gtest.h"
 
-using namespace ROOT::Experimental::Detail;
+using namespace ROOT::Detail;
 
 namespace {
 

--- a/net/davix/inc/LinkDef.h
+++ b/net/davix/inc/LinkDef.h
@@ -6,6 +6,6 @@
 
 #pragma link C++ class TDavixFile+;
 #pragma link C++ class TDavixSystem+;
-#pragma link C++ class ROOT::Experimental::Detail::RRawFileDavix+;
+#pragma link C++ class ROOT::Detail::RRawFileDavix+;
 
 #endif

--- a/net/davix/inc/ROOT/RRawFileDavix.hxx
+++ b/net/davix/inc/ROOT/RRawFileDavix.hxx
@@ -20,12 +20,12 @@
 #include <memory>
 
 namespace ROOT {
-namespace Experimental {
-namespace Detail {
 
 namespace Internal {
 struct RDavixFileDes;
 }
+
+namespace Detail {
 
 /**
  * \class RRawFileDavix RRawFileDavix.hxx
@@ -52,7 +52,6 @@ public:
 };
 
 } // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
 #endif

--- a/net/davix/src/RRawFileDavix.cxx
+++ b/net/davix/src/RRawFileDavix.cxx
@@ -24,8 +24,6 @@ constexpr int kDefaultBlockSize = 128 * 1024; // Read in relatively large 128k b
 } // anonymous namespace
 
 namespace ROOT {
-namespace Experimental {
-namespace Detail {
 namespace Internal {
 
 struct RDavixFileDes {
@@ -40,27 +38,25 @@ struct RDavixFileDes {
 };
 
 } // namespace Internal
-} // namespace Detail
-} // namespace Experimental
 } // namespace ROOT
 
-ROOT::Experimental::Detail::RRawFileDavix::RRawFileDavix(std::string_view url, ROptions options)
+ROOT::Detail::RRawFileDavix::RRawFileDavix(std::string_view url, ROptions options)
    : RRawFile(url, options), fFileDes(new Internal::RDavixFileDes())
 {
 }
 
-ROOT::Experimental::Detail::RRawFileDavix::~RRawFileDavix()
+ROOT::Detail::RRawFileDavix::~RRawFileDavix()
 {
    if (fFileDes->fd != nullptr)
       fFileDes->pos.close(fFileDes->fd, nullptr);
 }
 
-std::unique_ptr<ROOT::Experimental::Detail::RRawFile> ROOT::Experimental::Detail::RRawFileDavix::Clone() const
+std::unique_ptr<ROOT::Detail::RRawFile> ROOT::Detail::RRawFileDavix::Clone() const
 {
    return std::make_unique<RRawFileDavix>(fUrl, fOptions);
 }
 
-std::uint64_t ROOT::Experimental::Detail::RRawFileDavix::GetSizeImpl()
+std::uint64_t ROOT::Detail::RRawFileDavix::GetSizeImpl()
 {
    struct stat buf;
    Davix::DavixError *err = nullptr;
@@ -70,7 +66,7 @@ std::uint64_t ROOT::Experimental::Detail::RRawFileDavix::GetSizeImpl()
    return buf.st_size;
 }
 
-void ROOT::Experimental::Detail::RRawFileDavix::OpenImpl()
+void ROOT::Detail::RRawFileDavix::OpenImpl()
 {
    Davix::DavixError *err = nullptr;
    fFileDes->fd = fFileDes->pos.open(nullptr, fUrl, O_RDONLY, &err);
@@ -81,7 +77,7 @@ void ROOT::Experimental::Detail::RRawFileDavix::OpenImpl()
       fOptions.fBlockSize = kDefaultBlockSize;
 }
 
-size_t ROOT::Experimental::Detail::RRawFileDavix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
+size_t ROOT::Detail::RRawFileDavix::ReadAtImpl(void *buffer, size_t nbytes, std::uint64_t offset)
 {
    Davix::DavixError *err = nullptr;
    auto retval = fFileDes->pos.pread(fFileDes->fd, buffer, nbytes, offset, &err);
@@ -91,7 +87,7 @@ size_t ROOT::Experimental::Detail::RRawFileDavix::ReadAtImpl(void *buffer, size_
    return static_cast<size_t>(retval);
 }
 
-void ROOT::Experimental::Detail::RRawFileDavix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
+void ROOT::Detail::RRawFileDavix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
    Davix::DavixError *davixErr = NULL;
    Davix::DavIOVecInput in[nReq];

--- a/net/davix/test/RRawFileDavix.cxx
+++ b/net/davix/test/RRawFileDavix.cxx
@@ -5,7 +5,7 @@
 
 #include "gtest/gtest.h"
 
-using namespace ROOT::Experimental::Detail;
+using namespace ROOT::Detail;
 
 TEST(RRawFileDavix, Idle)
 {

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -113,18 +113,6 @@ if(sqlite)
   target_sources(ROOTDataFrame PRIVATE src/RSqliteDS.cxx)
   target_include_directories(ROOTDataFrame PRIVATE ${SQLITE_INCLUDE_DIR})
   target_link_libraries(ROOTDataFrame PRIVATE ${SQLITE_LIBRARIES})
-  if (davix)
-    # TODO(jblomer): Use Davix through an abstraction layer in RDAVIX to avoid linking issues
-    if (builtin_davix)
-      # The builtin version is statically linked, thus we link against RDAVIX to avoid a symbol conflict
-      # if libROOTDataFrame and libRDAVIX are used together.
-      target_include_directories(ROOTDataFrame PRIVATE ${DAVIX_INCLUDE_DIRS})
-      target_link_libraries(ROOTDataFrame PRIVATE RDAVIX)
-    else()
-      # If the system libDavix is used, RDAVIX does not contain the Davix symbols itself
-      target_link_libraries(ROOTDataFrame PRIVATE Davix::Davix)
-    endif()
-  endif()
 endif()
 
 if(root7)

--- a/tree/dataframe/src/RSqliteDS.cxx
+++ b/tree/dataframe/src/RSqliteDS.cxx
@@ -20,6 +20,7 @@
 #include <ROOT/RConfig.hxx>
 #include <ROOT/RDF/Utils.hxx>
 #include <ROOT/RMakeUnique.hxx>
+#include <ROOT/RRawFile.hxx>
 
 #include "TError.h"
 #include "TRandom.h"
@@ -34,9 +35,6 @@
 #include <stdexcept>
 #include <utility>
 
-#ifdef R__HAS_DAVIX
-#include <davix.hpp>
-#endif
 #include <sqlite3.h>
 
 namespace {
@@ -46,17 +44,15 @@ namespace {
 // for ROOT -- an abstraction of the operating system interface.
 //
 // SQlite allows for registering custom VFS modules, which are a set of C callback functions that SQlite invokes when
-// it needs to reads from a file, write to a file, etc. More information is available under https://sqlite.org/vfs.html
+// it needs to read from a file, write to a file, etc. More information is available under https://sqlite.org/vfs.html
 //
 // In the context of a data source, SQlite will only ever call reading functions from the VFS module, the sqlite
 // files are not modified. Therefore, only a subset of the callback functions provide a non-trivial implementation.
-// The custom VFS module is only used for HTTP(S) input paths; local paths are served by the default SQlite VFS.
+// The custom VFS module uses a RRawFile for the byte access, thereby it can access local and remote files.
 
 ////////////////////////////////////////////////////////////////////////////
 /// SQlite VFS modules are identified by string names. The name has to be unique for the entire application.
 constexpr char const *gSQliteVfsName = "ROOT-Davix-readonly";
-
-#ifdef R__HAS_DAVIX
 
 ////////////////////////////////////////////////////////////////////////////
 /// Holds the state of an open sqlite database. Objects of this struct are created in VfsRdOnlyOpen()
@@ -65,13 +61,10 @@ constexpr char const *gSQliteVfsName = "ROOT-Davix-readonly";
 /// this particular VFS module. Every callback here thus casts the sqlite3_file input parameter to its "derived"
 /// type VfsRootFile.
 struct VfsRootFile {
-   VfsRootFile() : pos(&c) {}
-   sqlite3_file pFile;
+   VfsRootFile() = default;
 
-   DAVIX_FD *fd;
-   uint64_t size; /// Caches the file size on open
-   Davix::Context c;
-   Davix::DavPosix pos;
+   sqlite3_file pFile;
+   std::unique_ptr<ROOT::Detail::RRawFile> fRawFile;
 };
 
 // The following callbacks implement the I/O operations of an open database
@@ -80,22 +73,19 @@ struct VfsRootFile {
 /// Releases the resources associated to a file opened with davix
 int VfsRdOnlyClose(sqlite3_file *pFile)
 {
-   Davix::DavixError *err = nullptr;
    VfsRootFile *p = reinterpret_cast<VfsRootFile *>(pFile);
-   auto retval = p->pos.close(p->fd, &err);
    // We can't use delete because the storage for p is managed by sqlite
    p->~VfsRootFile();
-   return (retval == -1) ? SQLITE_IOERR_CLOSE : SQLITE_OK;
+   return SQLITE_OK;
 }
 
 ////////////////////////////////////////////////////////////////////////////
-/// Issues an HTTP range request to read a chunk from a remote file
+/// Issues a byte range request for a chunk to the raw file
 int VfsRdOnlyRead(sqlite3_file *pFile, void *zBuf, int count, sqlite_int64 offset)
 {
-   Davix::DavixError *err = nullptr;
    VfsRootFile *p = reinterpret_cast<VfsRootFile *>(pFile);
-   auto retval = p->pos.pread(p->fd, zBuf, count, offset, &err);
-   return (retval == -1) ? SQLITE_IOERR : SQLITE_OK;
+   auto nbytes = p->fRawFile->ReadAt(zBuf, count, offset);
+   return (nbytes != static_cast<unsigned int>(count)) ? SQLITE_IOERR : SQLITE_OK;
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -124,7 +114,7 @@ int VfsRdOnlySync(sqlite3_file * /*pFile*/, int /*flags*/)
 int VfsRdOnlyFileSize(sqlite3_file *pFile, sqlite_int64 *pSize)
 {
    VfsRootFile *p = reinterpret_cast<VfsRootFile *>(pFile);
-   *pSize = p->size;
+   *pSize = p->fRawFile->GetSize();
    return SQLITE_OK;
 }
 
@@ -207,19 +197,16 @@ int VfsRdOnlyOpen(sqlite3_vfs * /*vfs*/, const char *zName, sqlite3_file *pFile,
    if (flags & (SQLITE_OPEN_READWRITE | SQLITE_OPEN_DELETEONCLOSE | SQLITE_OPEN_EXCLUSIVE))
       return SQLITE_IOERR;
 
-   Davix::DavixError *err = nullptr;
-   p->fd = p->pos.open(nullptr, zName, O_RDONLY, &err);
-
-   if (!p->fd) {
-      ::Error("VfsRdOnlyOpen", "%s\n", err->getErrMsg().c_str());
+   p->fRawFile = std::unique_ptr<ROOT::Detail::RRawFile>(ROOT::Detail::RRawFile::Create(zName));
+   if (!p->fRawFile) {
+      ::Error("VfsRdOnlyOpen", "Cannot open %s\n", zName);
       return SQLITE_IOERR;
    }
 
-   struct stat buf;
-   if (p->pos.stat(nullptr, zName, &buf, nullptr) == -1) {
+   if (!(p->fRawFile->GetFeatures() & ROOT::Detail::RRawFile::kFeatureHasSize)) {
+      ::Error("VfsRdOnlyOpen", "cannot determine file size of %s\n", zName);
       return SQLITE_IOERR;
    }
-   p->size = buf.st_size;
 
    p->pFile.pMethods = &io_methods;
    return SQLITE_OK;
@@ -331,26 +318,11 @@ static struct sqlite3_vfs kSqlite3Vfs = {
    nullptr, // xNextSystemCall
 };
 
-#endif // R__HAS_DAVIX
-
-bool RegisterDavixVfs()
+static bool RegisterSqliteVfs()
 {
-#ifdef R__HAS_DAVIX
    int retval;
    retval = sqlite3_vfs_register(&kSqlite3Vfs, false);
    return (retval == SQLITE_OK);
-#else
-   return false;
-#endif
-}
-
-bool IsURL(const std::string &fileName)
-{
-   if (fileName.compare(0, 7, "http://") == 0)
-      return true;
-   if (fileName.compare(0, 8, "https://") == 0)
-      return true;
-   return false;
 }
 
 } // anonymous namespace
@@ -392,19 +364,14 @@ constexpr char const *RSqliteDS::fgTypeNames[];
 RSqliteDS::RSqliteDS(const std::string &fileName, const std::string &query)
    : fDataSet(std::make_unique<Internal::RSqliteDSDataSet>()), fNSlots(0), fNRow(0)
 {
-   static bool isDavixAvailable = RegisterDavixVfs();
+   static bool hasSqliteVfs = RegisterSqliteVfs();
+   if (!hasSqliteVfs)
+      throw std::runtime_error("Cannot register SQlite VFS in RSqliteDS");
+
    int retval;
 
-   // Open using the custom vfs module
-   if (IsURL(fileName)) {
-      if (!isDavixAvailable)
-         throw std::runtime_error("Processing remote files is not available. "
-                                  "Please compile ROOT with Davix support to read from HTTP(S) locations.");
-      retval =
-        sqlite3_open_v2(fileName.c_str(), &fDataSet->fDb, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, gSQliteVfsName);
-   } else {
-      retval = sqlite3_open_v2(fileName.c_str(), &fDataSet->fDb, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nullptr);
-   }
+   retval = sqlite3_open_v2(fileName.c_str(), &fDataSet->fDb, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX,
+                            gSQliteVfsName);
    if (retval != SQLITE_OK)
       SqliteError(retval);
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageRaw.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageRaw.hxx
@@ -26,12 +26,16 @@
 #include <memory>
 
 namespace ROOT {
+
+namespace Detail {
+class RRawFile;
+}
+
 namespace Experimental {
 namespace Detail {
 
 class RPageAllocatorHeap;
 class RPagePool;
-class RRawFile;
 
 // clang-format off
 /**
@@ -102,7 +106,7 @@ private:
    std::unique_ptr<RPageAllocatorFile> fPageAllocator;
    std::shared_ptr<RPagePool> fPagePool;
    std::unique_ptr<std::array<unsigned char, kMaxPageSize>> fUnzipBuffer;
-   std::unique_ptr<RRawFile> fFile;
+   std::unique_ptr<ROOT::Detail::RRawFile> fFile;
 
    RNTupleMetrics fMetrics;
    RNTuplePlainCounter *fCtrNRead = nullptr;

--- a/tree/ntuple/v7/src/RPageStorageRaw.cxx
+++ b/tree/ntuple/v7/src/RPageStorageRaw.cxx
@@ -194,9 +194,9 @@ ROOT::Experimental::Detail::RPageSourceRaw::RPageSourceRaw(std::string_view ntup
    const RNTupleReadOptions &options)
    : RPageSourceRaw(ntupleName, options)
 {
-   fFile = std::unique_ptr<RRawFile>(RRawFile::Create(path));
+   fFile = std::unique_ptr<ROOT::Detail::RRawFile>(ROOT::Detail::RRawFile::Create(path));
    R__ASSERT(fFile);
-   R__ASSERT(fFile->GetFeatures() & RRawFile::kFeatureHasSize);
+   R__ASSERT(fFile->GetFeatures() & ROOT::Detail::RRawFile::kFeatureHasSize);
 }
 
 
@@ -219,7 +219,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceRaw
 {
    unsigned char postscript[RNTupleDescriptor::kNBytesPostscript];
    auto fileSize = fFile->GetSize();
-   R__ASSERT(fileSize != RRawFile::kUnknownFileSize);
+   R__ASSERT(fileSize != ROOT::Detail::RRawFile::kUnknownFileSize);
    R__ASSERT(fileSize >= RNTupleDescriptor::kNBytesPostscript);
    auto offset = fileSize - RNTupleDescriptor::kNBytesPostscript;
    Read(postscript, RNTupleDescriptor::kNBytesPostscript, offset);


### PR DESCRIPTION
This is the follow-up to #4877. It removes the hard Davix dependency from RDataFrame.