### PR TITLE
[ROOT-10508] Fix TTreeProcessorMT with friends

### DIFF
--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -36,7 +36,7 @@ void WriteFileManyClusters(unsigned int nevents, const char *treename, const cha
    TFile file(filename, "recreate");
    TTree t(treename, treename);
    t.Branch("v", &v);
-   //t.SetAutoFlush(1);
+   // t.SetAutoFlush(1);
    for (auto i = 0U; i < nevents; ++i) {
       t.Fill();
       t.FlushBaskets();
@@ -45,101 +45,101 @@ void WriteFileManyClusters(unsigned int nevents, const char *treename, const cha
    file.Close();
 }
 
-   void DeleteFiles(const std::vector<std::string> &filenames)
-   {
-      for (const auto &f : filenames)
-         gSystem->Unlink(f.c_str());
-   }
+void DeleteFiles(const std::vector<std::string> &filenames)
+{
+   for (const auto &f : filenames)
+      gSystem->Unlink(f.c_str());
+}
 
-   TEST(TreeProcessorMT, EmptyTChain)
-   {
-      TChain c("mytree");
-      auto exceptionFired(false);
-      try {
-         ROOT::TTreeProcessorMT proc(c);
-      } catch (...) {
-         exceptionFired = true;
+TEST(TreeProcessorMT, EmptyTChain)
+{
+   TChain c("mytree");
+   auto exceptionFired(false);
+   try {
+      ROOT::TTreeProcessorMT proc(c);
+   } catch (...) {
+      exceptionFired = true;
+   }
+   EXPECT_TRUE(exceptionFired);
+}
+
+TEST(TreeProcessorMT, ManyFiles)
+{
+   const auto nFiles = 100u;
+   const std::string treename = "t";
+   std::vector<std::string> filenames;
+   for (auto i = 0u; i < nFiles; ++i)
+      filenames.emplace_back("treeprocmt_" + std::to_string(i) + ".root");
+
+   WriteFiles(treename, filenames);
+
+   std::atomic_int sum(0);
+   std::atomic_int count(0);
+   auto sumValues = [&sum, &count](TTreeReader &r) {
+      TTreeReaderValue<int> v(r, "v");
+      std::random_device seed;
+      std::default_random_engine eng(seed());
+      std::uniform_int_distribution<> rand(1, 100);
+      while (r.Next()) {
+         std::this_thread::sleep_for(std::chrono::nanoseconds(rand(eng)));
+         sum += *v;
+         ++count;
       }
-      EXPECT_TRUE(exceptionFired);
-   }
+   };
 
-   TEST(TreeProcessorMT, ManyFiles)
+   // TTreeProcMT requires a vector<string_view>
+   std::vector<std::string_view> fnames;
+   for (const auto &f : filenames)
+      fnames.emplace_back(f);
+
+   ROOT::TTreeProcessorMT proc(fnames, treename);
+   proc.Process(sumValues);
+
+   EXPECT_EQ(count.load(), int(nFiles * 10)); // 10 entries per file
+   EXPECT_EQ(sum.load(), 500500);             // sum 1..nFiles*10
+
+   DeleteFiles(filenames);
+}
+
+TEST(TreeProcessorMT, TreeInSubDirectory)
+{
+   auto filename = "fileTreeInSubDirectory.root";
+   auto procLambda = [](TTreeReader &r) {
+      while (r.Next())
+         ;
+   };
+
    {
-      const auto nFiles = 100u;
-      const std::string treename = "t";
-      std::vector<std::string> filenames;
-      for (auto i = 0u; i < nFiles; ++i)
-         filenames.emplace_back("treeprocmt_" + std::to_string(i) + ".root");
-
-      WriteFiles(treename, filenames);
-
-      std::atomic_int sum(0);
-      std::atomic_int count(0);
-      auto sumValues = [&sum, &count](TTreeReader &r) {
-         TTreeReaderValue<int> v(r, "v");
-         std::random_device seed;
-         std::default_random_engine eng(seed());
-         std::uniform_int_distribution<> rand(1, 100);
-         while (r.Next()) {
-            std::this_thread::sleep_for(std::chrono::nanoseconds(rand(eng)));
-            sum += *v;
-            ++count;
-         }
-      };
-
-      // TTreeProcMT requires a vector<string_view>
-      std::vector<std::string_view> fnames;
-      for (const auto &f : filenames)
-         fnames.emplace_back(f);
-
-      ROOT::TTreeProcessorMT proc(fnames, treename);
-      proc.Process(sumValues);
-
-      EXPECT_EQ(count.load(), int(nFiles * 10)); // 10 entries per file
-      EXPECT_EQ(sum.load(), 500500);             // sum 1..nFiles*10
-
-      DeleteFiles(filenames);
+      TFile f(filename, "RECREATE");
+      auto dir0 = f.mkdir("dir0");
+      dir0->cd();
+      auto dir1 = dir0->mkdir("dir1");
+      dir1->cd();
+      TTree t("tree", "tree");
+      t.Write();
    }
 
-   TEST(TreeProcessorMT, TreeInSubDirectory)
-   {
-      auto filename = "fileTreeInSubDirectory.root";
-      auto procLambda = [](TTreeReader &r) {
-         while (r.Next())
-            ;
-      };
+   ROOT::EnableThreadSafety();
 
-      {
-         TFile f(filename, "RECREATE");
-         auto dir0 = f.mkdir("dir0");
-         dir0->cd();
-         auto dir1 = dir0->mkdir("dir1");
-         dir1->cd();
-         TTree t("tree", "tree");
-         t.Write();
-      }
+   auto fullPath = "dir0/dir1/tree";
 
-      ROOT::EnableThreadSafety();
+   // With a TTree
+   TFile f(filename);
+   auto t = (TTree *)f.Get(fullPath);
+   ROOT::TTreeProcessorMT tp(*t);
+   tp.Process(procLambda);
 
-      auto fullPath = "dir0/dir1/tree";
+   // With a TChain
+   std::string chainElementName = filename;
+   chainElementName += "/";
+   chainElementName += fullPath;
+   TChain chain;
+   chain.Add(chainElementName.c_str());
+   ROOT::TTreeProcessorMT tpc(chain);
+   tpc.Process(procLambda);
 
-      // With a TTree
-      TFile f(filename);
-      auto t = (TTree *)f.Get(fullPath);
-      ROOT::TTreeProcessorMT tp(*t);
-      tp.Process(procLambda);
-
-      // With a TChain
-      std::string chainElementName = filename;
-      chainElementName += "/";
-      chainElementName += fullPath;
-      TChain chain;
-      chain.Add(chainElementName.c_str());
-      ROOT::TTreeProcessorMT tpc(chain);
-      tpc.Process(procLambda);
-
-      gSystem->Unlink(filename);
-   }
+   gSystem->Unlink(filename);
+}
 
 TEST(TreeProcessorMT, LimitNTasks_CheckEntries)
 {
@@ -152,10 +152,11 @@ TEST(TreeProcessorMT, LimitNTasks_CheckEntries)
    std::mutex theMutex;
    auto f = [&](TTreeReader &t) {
       auto nentries = 0U;
-      while(t.Next()) nentries++;
+      while (t.Next())
+         nentries++;
       std::lock_guard<std::mutex> lg(theMutex);
       nTasks++;
-      if(!nEntriesCountsMap.insert({nentries, 1U}).second) {
+      if (!nEntriesCountsMap.insert({nentries, 1U}).second) {
          nEntriesCountsMap[nentries]++;
       }
    };
@@ -174,7 +175,7 @@ TEST(TreeProcessorMT, LimitNTasks_CheckEntries)
    ROOT::DisableImplicitMT();
 }
 
-void CheckClusters(std::vector<std::pair<Long64_t, Long64_t>>& clusters, Long64_t entries)
+void CheckClusters(std::vector<std::pair<Long64_t, Long64_t>> &clusters, Long64_t entries)
 {
    using R = std::pair<Long64_t, Long64_t>;
    // sort them
@@ -182,7 +183,7 @@ void CheckClusters(std::vector<std::pair<Long64_t, Long64_t>>& clusters, Long64_
    // check each end corresponds to the next start
    const auto nClusters = clusters.size();
    for (auto i = 0u; i < nClusters - 1; ++i)
-      EXPECT_EQ(clusters[i].second, clusters[i+1].first);
+      EXPECT_EQ(clusters[i].second, clusters[i + 1].first);
    // check start and end correspond to true start and end
    EXPECT_EQ(clusters.front().first, 0LL);
    EXPECT_EQ(clusters.back().second, entries);
@@ -224,8 +225,11 @@ TEST(TreeProcessorMT, PathName)
    auto f = std::unique_ptr<TFile>(TFile::Open(fname));
    auto tree = f->Get<TTree>("Events");
    ROOT::TTreeProcessorMT p(*tree);
-   std::atomic<unsigned int> n (0U);
-   auto func = [&n](TTreeReader &t) { while (t.Next()) n++;};
+   std::atomic<unsigned int> n(0U);
+   auto func = [&n](TTreeReader &t) {
+      while (t.Next())
+         n++;
+   };
    p.Process(func);
    EXPECT_EQ(n.load(), 1499064U) << "Wrong number of events processed!\n";
 }


### PR DESCRIPTION
Add a test to reproduce the issue described in [ROOT-10508](https://sft.its.cern.ch/jira/browse/ROOT-10508?jql=project%20%3D%20ROOT%20AND%20issuetype%20%3D%20Bug%20AND%20status%20%3D%20Open%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22RDataFrame%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC).

Fixed the issue for the case if the friend chain is unnamed since then the current logic does not retrieve the name of the underlying tree correctly. See the jira ticket for the full discussion.