### PR TITLE
WebGui - do not produce error output when chrome not installed

### DIFF
--- a/gui/cefdisplay/src/simple_app.cxx
+++ b/gui/cefdisplay/src/simple_app.cxx
@@ -469,6 +469,9 @@ protected:
          //   return nullptr;
          // }
 
+         if (args.IsHeadless())
+            return nullptr;
+
          if (fCefApp) {
             if (gHandlingServer != args.GetHttpServer()) {
                R__ERROR_HERE("CEF") << "CEF do not allows to use different THttpServer instances";

--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -83,6 +83,7 @@ protected:
 
       std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args) override
       {
+         // up to know headless mode not supported by QWebEngine
          if (args.IsHeadless())
             return nullptr;
 
@@ -138,19 +139,9 @@ protected:
 
          auto handle = std::make_unique<RQt5WebDisplayHandle>(fullurl.toLatin1().constData());
 
-         if (args.IsHeadless()) {
-            RootWebPage *page = new RootWebPage();
-            #if QT_VERSION >= 0x050700
-            page->settings()->resetAttribute(QWebEngineSettings::WebGLEnabled);
-            page->settings()->resetAttribute(QWebEngineSettings::Accelerated2dCanvasEnabled);
-            #endif
-            page->settings()->resetAttribute(QWebEngineSettings::PluginsEnabled);
-            page->load(QUrl(fullurl));
-         } else {
-            RootWebView *view = new RootWebView(qparent, args.GetWidth(), args.GetHeight(), args.GetX(), args.GetY());
-            view->load(QUrl(fullurl));
-            view->show();
-         }
+         RootWebView *view = new RootWebView(qparent, args.GetWidth(), args.GetHeight(), args.GetX(), args.GetY());
+         view->load(QUrl(fullurl));
+         view->show();
 
          return handle;
       }

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -534,7 +534,7 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> ROOT::Experimental::RWebD
    }
 
    if ((args.GetBrowserKind() == RWebDisplayArgs::kChrome) || (args.GetBrowserKind() == RWebDisplayArgs::kFirefox)) {
-      R__ERROR_HERE("WebDisplay") << "Neither Chrome nor Firefox browser cannot be started to provide display";
+      // R__ERROR_HERE("WebDisplay") << "Neither Chrome nor Firefox browser cannot be started to provide display";
       return handle;
    }
 
@@ -715,7 +715,7 @@ bool ROOT::Experimental::RWebDisplayHandle::ProduceImage(const std::string &fnam
    auto handle = ROOT::Experimental::RWebDisplayHandle::Display(args);
 
    if (!handle) {
-      R__ERROR_HERE("CanvasPainter") << "Fail to start chrome to produce image " << fname;
+      R__DEBUG_HERE("CanvasPainter") << "Cannot start Chrome to produce image " << fname;
       return false;
    }
 


### PR DESCRIPTION
Avoid failure of v7/line.cxx tutorial in such case

Disable headless in CEF and QWebEngine plugins.
Both do not provide any functionality without X-server running