### PR TITLE
Add support for DiagnosticEngine state change within recursive parsing.

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Basic/Diagnostic.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Basic/Diagnostic.cpp
@@ -173,11 +173,16 @@ void DiagnosticsEngine::DiagStateMap::append(SourceManager &SrcMgr,
     F->HasLocalTransitions = true;
     auto &Last = F->StateTransitions.back();
     if (Last.Offset > Offset) {
-      // Deal with a state change induce by recursive parsing.  The first parsing is
-      // suspended and a (recursive) parsing is started between associated (in the upper/outer
-      // file) with a newer line (hence greater offset).  After the end of the recursive
-      // parsing, we go back to the first parsing and any state change will done 'earlier'
-      // and trigger:
+      // Deal with a state change induced by recursive parsing.
+      // When the first parsing is suspended and a (recursive) parsing is
+      // started, a state change during that 2nd parsing will be associated (in
+      // the upper/outer file) with a newer line (so for that upper/outer file,
+      // the 2nd parsing correspond to a larger offset than the offset
+      // associated with the inclusion of the files processed by the 1st
+      // parsing).
+      // After the end of the recursive parsing, we go back to the
+      // first parsing and any state change will be reported as being done 'earlier'
+      // and was triggering the following assert:
       //   assert(Last.Offset <= Offset && "state transitions added out of order");
       auto OnePastIt = std::upper_bound(
         F->StateTransitions.begin(), F->StateTransitions.end(), Offset,


### PR DESCRIPTION
This fixes ROOT-10504.

the script:
```

namespace boost { namespace mpl {

// Commenting the next line make the assert failure go away
struct TTUBE {};

}}

```
reproduce the problem with 'just' ROOT.  The trigger is the auto-loading of a library that has a dictionary with has forward decl string .. which all starts with:
```
    static const char* fwdDeclCode = R"DICTFWDDCLS(
extern int __Cling_Autoloading_Map;
....
```

The order of parsing is (with many ellipsis):
```
"<<< cling interactive line includer >>>" : line 9  : #include “standalone.C”
standalone.C : line 1 : #pragma GCC diagnostic push
standalone.C : line 2 : #pragma GCC diagnostic ignored "-Wuninitialized"    // Inserted in Diag map
standalone.C : line 3 : #pragma GCC diagnostic ignored "-Wsign-conversion"  // Inserted in Diag map
standalone.C : line 8 : struct TTUBE {} ; // triggers auto-loading and thus recursive parsing.

"<<< cling interactive line includer >>>" : line 10  : parse dict fwd declare string
input_line_9 : line 2 : #pragma clang diagnostic ignored "-Wkeyword-compat"        // Inserted in Diag map
input_line_9 : line 3 : #pragma clang diagnostic ignored "-Wignored-attributes"    // Inserted in Diag map
input_line_9 : line 4 : #pragma clang diagnostic ignored "-Wreturn-type-c-linkage" // Inserted in Diag map

end of file

standalone.C : line 12 : #pragma GCC diagnostic pop // Inserted in Diag map
```
The last line triggers the assert because when recording the state change, it records it as being from
```
   standalone.C : line 12
   "<<< cling interactive line includer >>>" : line 9
```
but when recording the last one, it notices that the last state change that happened, indirectly, for the file '<<< cling interactive line includer >>>' happened at line 10 (because of the pragma in input_line_9 which is 'recorded' as being included by line 10),
which makes that the state change for ```standalone.C:12``` happens 'ealier' than the last state change as far as the pseudo-file "<<< cling interactive line includer >>>" is concerned.  For that pseudo-file, the last state change happened line 10 but the state change bbeing processed happens line 9 (where Standalone.C is being included).