### PR TITLE
Fix different memory leaks in GUI and related classes

### DIFF
--- a/graf3d/gl/src/TGLSAViewer.cxx
+++ b/graf3d/gl/src/TGLSAViewer.cxx
@@ -755,7 +755,7 @@ Bool_t TGLSAViewer::ProcessFrameMessage(Long_t msg, Long_t parm1, Long_t)
             {
                TGFileInfo fi;
                fi.fFileTypes   = gGLSaveAsTypes;
-               fi.fIniDir      = StrDup(fDirName);
+               fi.SetIniDir(fDirName);
                fi.fFileTypeIdx = fTypeIdx;
                fi.fOverwrite   = fOverwrite;
                new TGFileDialog(gClient->GetDefaultRoot(), fFrame, kFDSave, &fi);

--- a/gui/ged/src/TStyleManager.cxx
+++ b/gui/ged/src/TStyleManager.cxx
@@ -918,7 +918,7 @@ void TStyleManager::DoExport()
    char* tmpFileName;
    const char* tmpBaseName;
    do {
-      fCurMacro->fFilename = StrDup(newName.Data());
+      fCurMacro->SetFilename(newName.Data());
 
       // Open a dialog to ask the user to choose an output file.
       new TGFileDialog(gClient->GetRoot(), this, kFDSave, fCurMacro);
@@ -931,7 +931,7 @@ void TStyleManager::DoExport()
    if (tmpBaseName != 0) {
       // Export the style.
       fCurSelStyle->SaveSource(gSystem->UnixPathName(tmpFileName));
-      fCurMacro->fFilename = StrDup(tmpBaseName);
+      fCurMacro->SetFilename(tmpBaseName);
       fStyleChanged = kFALSE;
    }
 
@@ -1013,7 +1013,7 @@ void TStyleManager::DoImportCanvas()
       CreateMacro();
       TString newName;
       newName.Form("Style_%s.C", fCurSelStyle->GetName());
-      fCurMacro->fFilename = StrDup(newName.Data());
+      fCurMacro->SetFilename(newName.Data());
       fCurSelStyle->SaveSource(gSystem->UnixPathName(fCurMacro->fFilename));
    } else {
       BuildList(fCurSelStyle);
@@ -1027,10 +1027,9 @@ void TStyleManager::CreateMacro()
 {
    if (fCurMacro) delete fCurMacro;
    fCurMacro = new TGFileInfo();
-   TString dir(".");
    fCurMacro->fFileTypes = kFiletypes;
-   fCurMacro->fIniDir    = StrDup(dir);
-   fCurMacro->fFilename  = 0;
+   fCurMacro->SetIniDir(".");
+   fCurMacro->SetFilename(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4336,12 +4335,12 @@ void TStyleManager::DoImportMacro(Bool_t create)
       if (!create) {
          TString newName;
          newName.Form("Style_%s.C", fCurSelStyle->GetName());
-         fCurMacro->fFilename = StrDup(newName.Data());
+         fCurMacro->SetFilename(newName.Data());
       }
       new TGFileDialog(gClient->GetRoot(), this, kFDOpen, fCurMacro);
-      if (fCurMacro->fFilename != 0) {
+      if (fCurMacro->fFilename) {
          gROOT->ProcessLine(Form(".x %s", fCurMacro->fFilename));
-         fCurMacro->fFilename = StrDup(gSystem->BaseName(fCurMacro->fFilename));
+         fCurMacro->SetFilename(gSystem->BaseName(fCurMacro->fFilename));
       }
    }
 

--- a/gui/gui/inc/TGFileBrowser.h
+++ b/gui/gui/inc/TGFileBrowser.h
@@ -38,8 +38,7 @@ public:
    typedef std::list<TGListTreeItem*> sLTI_t;
    typedef sLTI_t::iterator           sLTI_i;
    typedef sLTI_t::reverse_iterator   sLTI_ri;
-   typedef std::map<TGListTreeItem*, const char *> mFiltered_t;
-   typedef mFiltered_t::iterator      mFiltered_i;
+   typedef std::map<TGListTreeItem*, std::string> mFiltered_t;
 
 protected:
    TRootBrowser      *fNewBrowser;        // Pointer back to the Browser

--- a/gui/gui/inc/TGFileDialog.h
+++ b/gui/gui/inc/TGFileDialog.h
@@ -71,6 +71,7 @@ public:
 
    void SetFilename(const char *fname);
    void SetIniDir(const char *inidir);
+   void DeleteFileNamesList();
 
    void SetMultipleSelection(Bool_t option);
 };

--- a/gui/gui/inc/TGFileDialog.h
+++ b/gui/gui/inc/TGFileDialog.h
@@ -54,21 +54,23 @@ class TGFSComboBox;
 class TGFileInfo {
 
 private:
-   TGFileInfo(const TGFileInfo&);              // not implemented
-   TGFileInfo& operator=(const TGFileInfo&);   // not implemented
+   TGFileInfo(const TGFileInfo&) = delete;              // not implemented
+   TGFileInfo& operator=(const TGFileInfo&) = delete;   // not implemented
 
 public:
-   char         *fFilename;            // selected file name
-   char         *fIniDir;              // on input: initial directory, on output: new directory
-   const char  **fFileTypes;           // file types used to filter selectable files
-   Int_t         fFileTypeIdx;         // selected file type, index in fFileTypes
-   Bool_t        fOverwrite;           // if true overwrite the file with existing name on save
-   Bool_t        fMultipleSelection;   // if true, allow multiple file selection
-   TList        *fFileNamesList;       // list of selected file names
+   char         *fFilename{nullptr};            // selected file name
+   char         *fIniDir{nullptr};              // on input: initial directory, on output: new directory
+   const char  **fFileTypes{nullptr};           // file types used to filter selectable files
+   Int_t         fFileTypeIdx{0};               // selected file type, index in fFileTypes
+   Bool_t        fOverwrite{kFALSE};            // if true overwrite the file with existing name on save
+   Bool_t        fMultipleSelection{kFALSE};    // if true, allow multiple file selection
+   TList        *fFileNamesList{nullptr};       // list of selected file names
 
-   TGFileInfo() : fFilename(0), fIniDir(0), fFileTypes(0), fFileTypeIdx(0),
-                  fOverwrite(kFALSE), fMultipleSelection(0), fFileNamesList(0) { }
+   TGFileInfo() = default;
    ~TGFileInfo();
+
+   void SetFilename(const char *fname);
+   void SetIniDir(const char *inidir);
 
    void SetMultipleSelection(Bool_t option);
 };

--- a/gui/gui/inc/TGSimpleTableInterface.h
+++ b/gui/gui/inc/TGSimpleTableInterface.h
@@ -13,12 +13,15 @@
 
 #include "TVirtualTableInterface.h"
 
+#include "TString.h"
+
 class TGSimpleTableInterface : public TVirtualTableInterface {
 
 private:
    Double_t **fData; // Pointer to 2 dimensional array of Double_t
    UInt_t fNRows;
    UInt_t fNColumns;
+   TString fBuffer;
 
 protected:
 
@@ -27,14 +30,14 @@ public:
                           UInt_t ncolumns = 2);
    virtual ~TGSimpleTableInterface();
 
-   virtual Double_t    GetValue(UInt_t row, UInt_t column);
-   virtual const char *GetValueAsString(UInt_t row, UInt_t column);
-   virtual const char *GetRowHeader(UInt_t row);
-   virtual const char *GetColumnHeader(UInt_t column);
-   virtual UInt_t      GetNRows() { return fNRows; }
-   virtual UInt_t      GetNColumns() { return fNColumns; }
+   Double_t    GetValue(UInt_t row, UInt_t column) override;
+   const char *GetValueAsString(UInt_t row, UInt_t column) override;
+   const char *GetRowHeader(UInt_t row) override;
+   const char *GetColumnHeader(UInt_t column) override;
+   UInt_t      GetNRows() override { return fNRows; }
+   UInt_t      GetNColumns() override { return fNColumns; }
 
-   ClassDef(TGSimpleTableInterface, 0) // Interface to data in a 2D array of Double_t
+   ClassDefOverride(TGSimpleTableInterface, 0) // Interface to data in a 2D array of Double_t
 };
 
 #endif

--- a/gui/gui/src/TGFileDialog.cxx
+++ b/gui/gui/src/TGFileDialog.cxx
@@ -84,21 +84,27 @@ void TGFileInfo::SetMultipleSelection(Bool_t option)
 {
    if ( fMultipleSelection != option ) {
       fMultipleSelection = option;
-      if ( fMultipleSelection == kTRUE )
-         fFileNamesList = new TList();
-      else {
+      if (fFileNamesList) {
          fFileNamesList->Delete();
          delete fFileNamesList;
-         fFileNamesList = 0;
+         fFileNamesList = nullptr;
       }
+      if (fMultipleSelection)
+         fFileNamesList = new TList();
    }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set file name
 
 void TGFileInfo::SetFilename(const char *fname)
 {
    delete [] fFilename;
    fFilename = fname ? StrDup(fname) : nullptr;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set directory name
 
 void TGFileInfo::SetIniDir(const char *inidir)
 {

--- a/gui/gui/src/TGFileDialog.cxx
+++ b/gui/gui/src/TGFileDialog.cxx
@@ -71,7 +71,7 @@ TGFileInfo::~TGFileInfo()
 {
    delete [] fFilename;
    delete [] fIniDir;
-   if ( fFileNamesList != 0 ) {
+   if (fFileNamesList) {
       fFileNamesList->Delete();
       delete fFileNamesList;
    }
@@ -92,6 +92,18 @@ void TGFileInfo::SetMultipleSelection(Bool_t option)
          fFileNamesList = 0;
       }
    }
+}
+
+void TGFileInfo::SetFilename(const char *fname)
+{
+   delete [] fFilename;
+   fFilename = fname ? StrDup(fname) : nullptr;
+}
+
+void TGFileInfo::SetIniDir(const char *inidir)
+{
+   delete [] fIniDir;
+   fIniDir = inidir ? StrDup(inidir) : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1512,7 +1512,7 @@ Bool_t TGMainFrame::SaveFrameAsCodeOrImage()
       TGFileInfo fi;
       TGMainFrame *main = (TGMainFrame*)GetMainFrame();
       fi.fFileTypes = gSaveMacroTypes;
-      fi.fIniDir    = StrDup(dir);
+      fi.SetIniDir(dir);
       fi.fOverwrite = overwr;
       new TGFileDialog(fClient->GetDefaultRoot(), this, kFDSave, &fi);
       if (!fi.fFilename) return kFALSE;

--- a/gui/gui/src/TGSimpleTableInterface.cxx
+++ b/gui/gui/src/TGSimpleTableInterface.cxx
@@ -53,10 +53,8 @@ Double_t TGSimpleTableInterface::GetValue(UInt_t row, UInt_t column)
    if ((row > fNRows) || (column > fNColumns)) {
       Error("TGSimpleTableInterface","Non existing value requested.");
       return 0;
-   } else {
-      Double_t temp = fData[row][column];
-      return temp;
    }
+   return fData[row][column];
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -66,7 +64,8 @@ const char *TGSimpleTableInterface::GetValueAsString(UInt_t row, UInt_t column)
 {
    // FIXME use template string for string format instead of hardcoded format
 
-   return StrDup(TString::Format("%5.2f", GetValue(row, column)));
+   fBuffer.Form("%5.2f", GetValue(row, column));
+   return fBuffer.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -74,7 +73,8 @@ const char *TGSimpleTableInterface::GetValueAsString(UInt_t row, UInt_t column)
 
 const char *TGSimpleTableInterface::GetRowHeader(UInt_t row)
 {
-   return StrDup(TString::Format("DRow %d", row));
+   fBuffer.Form("DRow %d", row);
+   return fBuffer.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -82,5 +82,6 @@ const char *TGSimpleTableInterface::GetRowHeader(UInt_t row)
 
 const char *TGSimpleTableInterface::GetColumnHeader(UInt_t column)
 {
-   return StrDup(TString::Format("DCol %d", column));
+   fBuffer.Form("DCol %d", column);
+   return fBuffer.Data();
 }

--- a/gui/gui/src/TGTextEdit.cxx
+++ b/gui/gui/src/TGTextEdit.cxx
@@ -393,7 +393,7 @@ Bool_t TGTextEdit::SaveFile(const char *filename, Bool_t saveas)
          static Bool_t overwr = kFALSE;
          TGFileInfo fi;
          fi.fFileTypes = gFiletypes;
-         fi.fIniDir    = StrDup(dir);
+         fi.SetIniDir(dir);
          fi.fOverwrite = overwr;
          new TGFileDialog(fClient->GetDefaultRoot(), this, kFDSave, &fi);
          overwr = fi.fOverwrite;

--- a/gui/gui/src/TGTextEdit.cxx
+++ b/gui/gui/src/TGTextEdit.cxx
@@ -49,12 +49,12 @@ static const char *gFiletypes[] = { "All files",     "*",
                                     "Text files",    "*.txt",
                                     "ROOT macros",   "*.C",
                                     0,               0 };
-static char *gPrinter      = 0;
-static char *gPrintCommand = 0;
+static char *gPrinter      = nullptr;
+static char *gPrintCommand = nullptr;
 
 
-TGGC *TGTextEdit::fgCursor0GC;
-TGGC *TGTextEdit::fgCursor1GC;
+TGGC *TGTextEdit::fgCursor0GC = nullptr;
+TGGC *TGTextEdit::fgCursor1GC = nullptr;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGTextEditor.cxx
+++ b/gui/gui/src/TGTextEditor.cxx
@@ -584,7 +584,7 @@ Bool_t TGTextEditor::SaveFileAs()
    static Bool_t overwr = kFALSE;
    TGFileInfo fi;
    fi.fFileTypes = ed_filetypes;
-   fi.fIniDir    = StrDup(dir);
+   fi.SetIniDir(dir);
    fi.fOverwrite = overwr;
    new TGFileDialog(fClient->GetDefaultRoot(), this, kFDSave, &fi);
    gSystem->ChangeDirectory(workdir.Data());

--- a/gui/gui/src/TRootBrowser.cxx
+++ b/gui/gui/src/TRootBrowser.cxx
@@ -687,7 +687,7 @@ void TRootBrowser::HandleMenu(Int_t id)
             static TString dir(".");
             TGFileInfo fi;
             fi.fFileTypes = gOpenFileTypes;
-            fi.fIniDir    = StrDup(dir);
+            fi.SetIniDir(dir);
             new TGFileDialog(gClient->GetDefaultRoot(), this,
                              kFDOpen,&fi);
             dir = fi.fIniDir;
@@ -789,7 +789,7 @@ void TRootBrowser::HandleMenu(Int_t id)
             static TString dir(".");
             TGFileInfo fi;
             fi.fFileTypes = gPluginFileTypes;
-            fi.fIniDir    = StrDup(dir);
+            fi.SetIniDir(dir);
             new TGFileDialog(gClient->GetDefaultRoot(), this,
                              kFDOpen,&fi);
             dir = fi.fIniDir;

--- a/gui/gui/src/TRootBrowserLite.cxx
+++ b/gui/gui/src/TRootBrowserLite.cxx
@@ -1812,7 +1812,7 @@ Bool_t TRootBrowserLite::ProcessMessage(Long_t msg, Long_t parm1, Long_t parm2)
                         static TString dir(".");
                         TGFileInfo fi;
                         fi.fFileTypes = gOpenTypes;
-                        fi.fIniDir    = StrDup(dir);
+                        fi.SetIniDir(dir);
                         new TGFileDialog(fClient->GetDefaultRoot(), this,
                                          kFDOpen,&fi);
                         dir = fi.fIniDir;

--- a/gui/gui/src/TRootCanvas.cxx
+++ b/gui/gui/src/TRootCanvas.cxx
@@ -836,7 +836,7 @@ Bool_t TRootCanvas::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
                         static TString dir(".");
                         TGFileInfo fi;
                         fi.fFileTypes = gOpenTypes;
-                        fi.fIniDir    = StrDup(dir);
+                        fi.SetIniDir(dir);
                         new TGFileDialog(fClient->GetDefaultRoot(), this, kFDOpen,&fi);
                         if (!fi.fFilename) return kTRUE;
                         dir = fi.fIniDir;
@@ -861,7 +861,7 @@ Bool_t TRootCanvas::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
                            }
                         }
                         fi.fFileTypes   = gSaveAsTypes;
-                        fi.fIniDir      = StrDup(dir);
+                        fi.SetIniDir(dir);
                         fi.fFileTypeIdx = typeidx;
                         fi.fOverwrite = overwr;
                         new TGFileDialog(fClient->GetDefaultRoot(), this, kFDSave, &fi);

--- a/gui/guibuilder/src/TGuiBldDragManager.cxx
+++ b/gui/guibuilder/src/TGuiBldDragManager.cxx
@@ -2340,7 +2340,7 @@ Bool_t TGuiBldDragManager::HandleKey(Event_t *event)
    CloseMenus();
 
    fi.fFileTypes = gSaveMacroTypes;
-   fi.fIniDir    = StrDup(dir);
+   fi.SetIniDir(dir);
    fi.fOverwrite = overwr;
 
    gVirtualX->LookupString(event, tmp, sizeof(tmp), keysym);
@@ -3308,7 +3308,7 @@ Bool_t TGuiBldDragManager::Save(const char *file)
       TGFileInfo fi;
 
       fi.fFileTypes = gSaveMacroTypes;
-      fi.fIniDir    = StrDup(dir);
+      fi.SetIniDir(dir);
       fi.fOverwrite = overwr;
       new TGFileDialog(fClient->GetDefaultRoot(), this, kFDSave, &fi);
 
@@ -3379,7 +3379,7 @@ Bool_t TGuiBldDragManager::SaveFrame(const char *file)
       TGFileInfo fi;
 
       fi.fFileTypes = gSaveMacroTypes;
-      fi.fIniDir    = StrDup(dir);
+      fi.SetIniDir(dir);
       fi.fOverwrite = overwr;
       new TGFileDialog(fClient->GetDefaultRoot(), frame, kFDSave, &fi);
 
@@ -5994,7 +5994,7 @@ void TGuiBldDragManager::ChangePicture(TGPictureButton *fr)
    TString fname;
 
    fi.fFileTypes = gImageTypes;
-   fi.fIniDir    = StrDup(dir);
+   fi.SetIniDir(dir);
    fi.fOverwrite = overwr;
 
    TGWindow *root = (TGWindow*)fClient->GetRoot();
@@ -6273,7 +6273,7 @@ void TGuiBldDragManager::ChangeImage(TGIcon *fr)
    TString fname;
 
    fi.fFileTypes = gImageTypes;
-   fi.fIniDir    = StrDup(dir);
+   fi.SetIniDir(dir);
    fi.fOverwrite = overwr;
 
    TGWindow *root = (TGWindow*)fClient->GetRoot();

--- a/gui/guibuilder/src/TRootGuiBuilder.cxx
+++ b/gui/guibuilder/src/TRootGuiBuilder.cxx
@@ -360,10 +360,10 @@ void TGuiBldPopupMenu::DrawEntry(TGMenuEntry *entry)
       case kMenuPopup:
       case kMenuLabel:
       case kMenuEntry:
-         if ((entry->GetStatus() & kMenuActiveMask) && 
+         if ((entry->GetStatus() & kMenuActiveMask) &&
              entry->GetType() != kMenuLabel) {
             if (entry->GetStatus() & kMenuEnableMask) {
-               gVirtualX->FillRectangle(fId, 
+               gVirtualX->FillRectangle(fId,
                               TRootGuiBuilder::GetPopupHlghtGC()->GetGC(),
                               entry->GetEx()+1, entry->GetEy(),
                               fMenuWidth-6, h - 1);
@@ -392,19 +392,19 @@ void TGuiBldPopupMenu::DrawEntry(TGMenuEntry *entry)
             }
 
             entry->GetLabel()->Draw(fId,
-                           (entry->GetStatus() & kMenuEnableMask) ? fSelGC : 
+                           (entry->GetStatus() & kMenuEnableMask) ? fSelGC :
                             GetShadowGC()(), tx, ty);
             if (entry->GetShortcut())
                entry->GetShortcut()->Draw(fId,
-                           (entry->GetStatus() & kMenuEnableMask) ? fSelGC : 
+                           (entry->GetStatus() & kMenuEnableMask) ? fSelGC :
                            GetShadowGC()(), fMenuWidth - tw, ty);
          } else {
             if ( entry->GetType() != kMenuLabel) {
-               gVirtualX->FillRectangle(fId, 
+               gVirtualX->FillRectangle(fId,
                            TRootGuiBuilder::GetBgndGC()->GetGC(),
                            entry->GetEx()+1, entry->GetEy()-1, tx-4, h);
 
-               gVirtualX->FillRectangle(fId, 
+               gVirtualX->FillRectangle(fId,
                            TRootGuiBuilder::GetPopupBgndGC()->GetGC(),
                            tx-1, entry->GetEy()-1, fMenuWidth-tx-1, h);
             } else { // we need some special background for labels
@@ -1558,7 +1558,7 @@ Bool_t TRootGuiBuilder::OpenProject(Event_t *event)
    TString fname;
 
    fi.fFileTypes = gSaveMacroTypes;
-   fi.fIniDir    = StrDup(dir);
+   fi.SetIniDir(dir);
    fi.fOverwrite = overwr;
    TGWindow *root = (TGWindow*)fClient->GetRoot();
    root->SetEditable(kFALSE);
@@ -1626,7 +1626,7 @@ Bool_t TRootGuiBuilder::SaveProject(Event_t *event)
    root->SetEditable(kFALSE);
 
    fi.fFileTypes = gSaveMacroTypes;
-   fi.fIniDir    = StrDup(dir);
+   fi.SetIniDir(dir);
    fi.fOverwrite = overwr;
 
    new TGFileDialog(fClient->GetDefaultRoot(), this, kFDSave, &fi);

--- a/gui/guihtml/src/TGHtmlBrowser.cxx
+++ b/gui/guihtml/src/TGHtmlBrowser.cxx
@@ -624,7 +624,7 @@ Bool_t TGHtmlBrowser::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
                         static TString dir(".");
                         TGFileInfo fi;
                         fi.fFileTypes = gHtmlFTypes;
-                        fi.fIniDir    = StrDup(dir);
+                        fi.SetIniDir(dir);
                         new TGFileDialog(fClient->GetRoot(), this,
                                          kFDOpen, &fi);
                         dir = fi.fIniDir;
@@ -640,7 +640,7 @@ Bool_t TGHtmlBrowser::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
                         static TString sdir(".");
                         TGFileInfo fi;
                         fi.fFileTypes = gHtmlFTypes;
-                        fi.fIniDir    = StrDup(sdir);
+                        fi.SetIniDir(sdir);
                         new TGFileDialog(fClient->GetRoot(), this,
                                          kFDSave, &fi);
                         sdir = fi.fIniDir;

--- a/gui/sessionviewer/src/TSessionDialogs.cxx
+++ b/gui/sessionviewer/src/TSessionDialogs.cxx
@@ -1147,7 +1147,7 @@ void TUploadDataSetDlg::BrowseFiles()
 {
    TGFileInfo fi;
    fi.fFileTypes = gDatasetTypes;
-   fi.fFilename  = strdup("*.root");
+   fi.SetFilename("*.root");
    new TGFileDialog(fClient->GetRoot(), this, kFDOpen, &fi);
    if (fi.fMultipleSelection && fi.fFileNamesList) {
       AddFiles(fi.fFileNamesList);

--- a/gui/sessionviewer/src/TSessionViewer.cxx
+++ b/gui/sessionviewer/src/TSessionViewer.cxx
@@ -5637,8 +5637,8 @@ Bool_t TSessionViewer::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
                   case kFileLoadConfig:
                      {
                         TGFileInfo fi;
-                        fi.fFilename = strdup((char *)gSystem->BaseName(fConfigFile));
-                        fi.fIniDir = strdup((char *)gSystem->HomeDirectory());
+                        fi.SetFilename(gSystem->BaseName(fConfigFile));
+                        fi.SetIniDir(gSystem->HomeDirectory());
                         fi.fFileTypes = conftypes;
                         new TGFileDialog(fClient->GetRoot(), this, kFDOpen, &fi);
                         if (fi.fFilename) {
@@ -5652,8 +5652,8 @@ Bool_t TSessionViewer::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
                   case kFileSaveConfig:
                      {
                         TGFileInfo fi;
-                        fi.fFilename = strdup((char *)gSystem->BaseName(fConfigFile));
-                        fi.fIniDir = strdup((char *)gSystem->HomeDirectory());
+                        fi.SetFilename(gSystem->BaseName(fConfigFile));
+                        fi.SetIniDir(gSystem->HomeDirectory());
                         fi.fFileTypes = conftypes;
                         new TGFileDialog(fClient->GetRoot(), this, kFDSave, &fi);
                         if (fi.fFilename) {

--- a/test/RootIDE/TGRootIDE.cxx
+++ b/test/RootIDE/TGRootIDE.cxx
@@ -1723,7 +1723,8 @@ void TGRootIDE::DirChanged()
 {
    const char *string = fDir->GetText();
    if (string) {
-      DirSelected(StrDup(string));
+      TString buf = string;
+      DirSelected(buf.Data());
    }
 }
 
@@ -1849,7 +1850,8 @@ void TGRootIDE::URLChanged()
 {
    const char *string = fURL->GetText();
    if (string) {
-      Selected(StrDup(gSystem->UnixPathName(string)));
+      TString buf = gSystem->UnixPathName(string);
+      Selected(buf.Data());
    }
 }
 

--- a/test/RootIDE/TGRootIDE.cxx
+++ b/test/RootIDE/TGRootIDE.cxx
@@ -993,7 +993,7 @@ Bool_t TGRootIDE::SaveFileAs()
    static Bool_t overwr = kFALSE;
    TGFileInfo fi;
    fi.fFileTypes = ed_filetypes;
-   fi.fIniDir    = StrDup(dir);
+   fi.SetIniDir(dir);
    fi.fOverwrite = overwr;
    new TGFileDialog(fClient->GetDefaultRoot(), this, kFDSave, &fi);
    overwr = fi.fOverwrite;

--- a/test/guitest.cxx
+++ b/test/guitest.cxx
@@ -730,7 +730,7 @@ Bool_t TestMainFrame::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
                         static TString dir(".");
                         TGFileInfo fi;
                         fi.fFileTypes = filetypes;
-                        fi.fIniDir    = StrDup(dir);
+                        fi.SetIniDir(dir);
                         new TGFileDialog(fClient->GetRoot(), this, kFDOpen, &fi);
                         printf("Open file: %s (dir: %s)\n", fi.fFilename,
                                fi.fIniDir);

--- a/test/periodic/XSGui.cxx
+++ b/test/periodic/XSGui.cxx
@@ -166,7 +166,7 @@ XSGui::ProcessMenuMessage( Long_t param )
          static TString dir(".");
          TGFileInfo fi;
          fi.fFileTypes = filetypes;
-         fi.fIniDir    = StrDup(dir);
+         fi.SetIniDir(dir);
          new TGFileDialog(fClient->GetRoot(), this, kFDOpen, &fi);
          dir = fi.fIniDir;
       }

--- a/test/rhtml/LinkDef.h
+++ b/test/rhtml/LinkDef.h
@@ -4,6 +4,6 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class TGHtmlBrowser;
+#pragma link C++ class TGHtmlBrowserTest;
 
 #endif

--- a/test/rhtml/rhtml.cxx
+++ b/test/rhtml/rhtml.cxx
@@ -102,9 +102,9 @@ const char *HtmlError[] = {
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-/// TGHtmlBrowser constructor.
+/// TGHtmlBrowserTest constructor.
 
-TGHtmlBrowser::TGHtmlBrowser(const char *filename, const TGWindow *p, UInt_t w, UInt_t h)
+TGHtmlBrowserTest::TGHtmlBrowserTest(const char *filename, const TGWindow *p, UInt_t w, UInt_t h)
              : TGMainFrame(p, w, h)
 {
    SetCleanup(kDeepCleanup);
@@ -153,31 +153,31 @@ TGHtmlBrowser::TGHtmlBrowser(const char *filename, const TGWindow *p, UInt_t w, 
    fBack->SetStyle(gClient->GetStyle());
    fBack->SetToolTipText("Go Back");
    fHorizontalFrame->AddFrame(fBack, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsCenterY,2,2,2,2));
-   fBack->Connect("Clicked()", "TGHtmlBrowser", this, "Back()");
+   fBack->Connect("Clicked()", "TGHtmlBrowserTest", this, "Back()");
 
    fForward = new TGPictureButton(fHorizontalFrame,gClient->GetPicture("GoForward.gif"));
    fForward->SetStyle(gClient->GetStyle());
    fForward->SetToolTipText("Go Forward");
    fHorizontalFrame->AddFrame(fForward, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsCenterY,2,2,2,2));
-   fForward->Connect("Clicked()", "TGHtmlBrowser", this, "Forward()");
+   fForward->Connect("Clicked()", "TGHtmlBrowserTest", this, "Forward()");
 
    fReload = new TGPictureButton(fHorizontalFrame,gClient->GetPicture("ReloadPage.gif"));
    fReload->SetStyle(gClient->GetStyle());
    fReload->SetToolTipText("Reload Page");
    fHorizontalFrame->AddFrame(fReload, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsCenterY,2,2,2,2));
-   fReload->Connect("Clicked()", "TGHtmlBrowser", this, "Reload()");
+   fReload->Connect("Clicked()", "TGHtmlBrowserTest", this, "Reload()");
 
    fStop = new TGPictureButton(fHorizontalFrame,gClient->GetPicture("StopLoading.gif"));
    fStop->SetStyle(gClient->GetStyle());
    fStop->SetToolTipText("Stop Loading");
    fHorizontalFrame->AddFrame(fStop, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsCenterY,2,2,2,2));
-   fStop->Connect("Clicked()", "TGHtmlBrowser", this, "Stop()");
+   fStop->Connect("Clicked()", "TGHtmlBrowserTest", this, "Stop()");
 
    fHome = new TGPictureButton(fHorizontalFrame,gClient->GetPicture("GoHome.gif"));
    fHome->SetStyle(gClient->GetStyle());
    fHome->SetToolTipText("Go to ROOT HomePage\n  (http://root.cern.ch)");
    fHorizontalFrame->AddFrame(fHome, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsCenterY,2,2,2,2));
-   fHome->Connect("Clicked()", "TGHtmlBrowser", this, "Selected(=\"http://root.cern.ch/drupal/\")");
+   fHome->Connect("Clicked()", "TGHtmlBrowserTest", this, "Selected(=\"http://root.cern.ch/drupal/\")");
 
    // combo box
    fURLBuf   = new TGTextBuffer(256);
@@ -185,13 +185,13 @@ TGHtmlBrowser::TGHtmlBrowser(const char *filename, const TGWindow *p, UInt_t w, 
    fURL      = fComboBox->GetTextEntry();
    fURLBuf   = fURL->GetBuffer();
    fComboBox->Resize(200, fURL->GetDefaultHeight());
-   fURL->Connect("ReturnPressed()", "TGHtmlBrowser", this, "URLChanged()");
+   fURL->Connect("ReturnPressed()", "TGHtmlBrowserTest", this, "URLChanged()");
 
    fComboBox->AddEntry(filename,1);
    fURL->SetText(filename);
 
    fComboBox->Select(0);
-   fComboBox->Connect("Selected(char *)", "TGHtmlBrowser", this, "Selected(char *)");
+   fComboBox->Connect("Selected(char *)", "TGHtmlBrowserTest", this, "Selected(char *)");
 
    fHorizontalFrame->AddFrame(fComboBox, new TGLayoutHints(kLHintsLeft | kLHintsCenterY | kLHintsExpandX,2,2,2,2));
 
@@ -209,8 +209,8 @@ TGHtmlBrowser::TGHtmlBrowser(const char *filename, const TGWindow *p, UInt_t w, 
    fStatusBar->SetParts(partsusBar,2);
    AddFrame(fStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX));
 
-   fHtml->Connect("MouseOver(char *)", "TGHtmlBrowser", this, "MouseOver(char *)");
-   fHtml->Connect("MouseDown(char *)", "TGHtmlBrowser", this, "MouseDown(char *)");
+   fHtml->Connect("MouseOver(char *)", "TGHtmlBrowserTest", this, "MouseOver(char *)");
+   fHtml->Connect("MouseDown(char *)", "TGHtmlBrowserTest", this, "MouseDown(char *)");
 
    Selected(filename);
 
@@ -221,9 +221,9 @@ TGHtmlBrowser::TGHtmlBrowser(const char *filename, const TGWindow *p, UInt_t w, 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Close TGHtmlBrowser window.
+/// Close TGHtmlBrowserTest window.
 
-void TGHtmlBrowser::CloseWindow()
+void TGHtmlBrowserTest::CloseWindow()
 {
    Cleanup();
    delete this;
@@ -268,7 +268,7 @@ static char *ReadRemote(const char *url)
 ////////////////////////////////////////////////////////////////////////////////
 /// Open (browse) selected URL.
 
-void TGHtmlBrowser::Selected(const char *uri)
+void TGHtmlBrowserTest::Selected(const char *uri)
 {
    char *buf = 0;
    FILE *f;
@@ -341,18 +341,19 @@ void TGHtmlBrowser::Selected(const char *uri)
 ////////////////////////////////////////////////////////////////////////////////
 /// URL combobox has changed.
 
-void TGHtmlBrowser::URLChanged()
+void TGHtmlBrowserTest::URLChanged()
 {
    const char *string = fURL->GetText();
    if (string) {
-      Selected(StrDup(gSystem->UnixPathName(string)));
+      TString buf = gSystem->UnixPathName(string);
+      Selected(buf.Data());
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle "Back" navigation button.
 
-void TGHtmlBrowser::Back()
+void TGHtmlBrowserTest::Back()
 {
    Int_t index = 0;
    const char *string = fURL->GetText();
@@ -373,7 +374,7 @@ void TGHtmlBrowser::Back()
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle "Forward" navigation button.
 
-void TGHtmlBrowser::Forward()
+void TGHtmlBrowserTest::Forward()
 {
    Int_t index = 0;
    const char *string = fURL->GetText();
@@ -394,7 +395,7 @@ void TGHtmlBrowser::Forward()
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle "Reload" navigation button.
 
-void TGHtmlBrowser::Reload()
+void TGHtmlBrowserTest::Reload()
 {
    const char *string = fURL->GetText();
    if (string)
@@ -404,14 +405,14 @@ void TGHtmlBrowser::Reload()
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle "Reload" navigation button.
 
-void TGHtmlBrowser::Stop()
+void TGHtmlBrowserTest::Stop()
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle "MouseOver" TGHtml signal.
 
-void TGHtmlBrowser::MouseOver(char *url)
+void TGHtmlBrowserTest::MouseOver(char *url)
 {
    fStatusBar->SetText(url, 0);
 }
@@ -419,7 +420,7 @@ void TGHtmlBrowser::MouseOver(char *url)
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle "MouseDown" TGHtml signal.
 
-void TGHtmlBrowser::MouseDown(char *url)
+void TGHtmlBrowserTest::MouseDown(char *url)
 {
    Selected(url);
 }
@@ -427,7 +428,7 @@ void TGHtmlBrowser::MouseDown(char *url)
 ////////////////////////////////////////////////////////////////////////////////
 /// Process Events.
 
-Bool_t TGHtmlBrowser::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
+Bool_t TGHtmlBrowserTest::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
 {
    switch (GET_MSG(msg)) {
    case kC_COMMAND:
@@ -453,8 +454,8 @@ Bool_t TGHtmlBrowser::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
                                          kFDOpen, &fi);
                         dir = fi.fIniDir;
                         if (fi.fFilename) {
-                           Selected(StrDup(Form("file://%s",
-                              gSystem->UnixPathName(fi.fFilename))));
+                           TString buf = TString::Format("file://%s", gSystem->UnixPathName(fi.fFilename));
+                           Selected(buf.Data());
                         }
                      }
                      break;
@@ -518,7 +519,7 @@ Bool_t TGHtmlBrowser::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
 int main(int argc, char **argv)
 {
    TApplication theApp("App", &argc, argv);
-   new TGHtmlBrowser("http://root.cern.ch/drupal/");
+   new TGHtmlBrowserTest("http://root.cern/");
    theApp.Run();
    return 0;
 }

--- a/test/rhtml/rhtml.cxx
+++ b/test/rhtml/rhtml.cxx
@@ -448,7 +448,7 @@ Bool_t TGHtmlBrowser::ProcessMessage(Long_t msg, Long_t parm1, Long_t)
                         static TString dir(".");
                         TGFileInfo fi;
                         fi.fFileTypes = filetypes;
-                        fi.fIniDir    = StrDup(dir);
+                        fi.SetIniDir(dir);
                         new TGFileDialog(fClient->GetRoot(), this,
                                          kFDOpen, &fi);
                         dir = fi.fIniDir;

--- a/test/rhtml/rhtml.h
+++ b/test/rhtml/rhtml.h
@@ -9,12 +9,12 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_TGHtmlBrowser
-#define ROOT_TGHtmlBrowser
+#ifndef ROOT_TGHtmlBrowserTest
+#define ROOT_TGHtmlBrowserTest
 
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
-// TGHtmlBrowser                                                        //
+// TGHtmlBrowserTest                                                        //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
@@ -31,7 +31,7 @@ class TGTextEntry;
 class TGPictureButton;
 class TGHtml;
 
-class TGHtmlBrowser : public TGMainFrame {
+class TGHtmlBrowserTest : public TGMainFrame {
 
 protected:
 
@@ -55,9 +55,9 @@ protected:
    Int_t              fNbFavorites;       // number of favorites in the menu
 
 public:
-   TGHtmlBrowser(const char *filename = 0, const TGWindow *p = 0,
+   TGHtmlBrowserTest(const char *filename = 0, const TGWindow *p = 0,
                  UInt_t w = 900, UInt_t h = 600);
-   virtual ~TGHtmlBrowser() { ; }
+   virtual ~TGHtmlBrowserTest() { ; }
 
    virtual void      CloseWindow();
    virtual Bool_t    ProcessMessage(Long_t msg, Long_t parm1, Long_t);
@@ -70,7 +70,7 @@ public:
    void              MouseOver(char *);
    void              MouseDown(char *);
 
-   ClassDef(TGHtmlBrowser, 0) // very simple html browser
+   ClassDef(TGHtmlBrowserTest, 0) // very simple html browser
 };
 
 #endif

--- a/tree/treeviewer/src/TTreeViewer.cxx
+++ b/tree/treeviewer/src/TTreeViewer.cxx
@@ -1991,7 +1991,7 @@ Bool_t TTreeViewer::ProcessMessage(Long_t msg, Long_t parm1, Long_t parm2)
                         static TString dir(".");
                         TGFileInfo info;
                         info.fFileTypes = gOpenTypes;
-                        info.fIniDir    = StrDup(dir);
+                        info.SetIniDir(dir);
                         new TGFileDialog(fClient->GetRoot(), this, kFDOpen, &info);
                         if (!info.fFilename) return kTRUE;
                         dir = info.fIniDir;
@@ -2019,7 +2019,7 @@ Bool_t TTreeViewer::ProcessMessage(Long_t msg, Long_t parm1, Long_t parm2)
                         static TString dir(".");
                         TGFileInfo info;
                         info.fFileTypes = gMacroTypes;
-                        info.fIniDir    = StrDup(dir);
+                        info.SetIniDir(dir);
                         new TGFileDialog(fClient->GetRoot(), this, kFDOpen, &info);
                         if (!info.fFilename) return kTRUE;
                         dir = info.fIniDir;

--- a/tutorials/eve/SplitGLView.C
+++ b/tutorials/eve/SplitGLView.C
@@ -926,7 +926,7 @@ void SplitGLView::HandleMenu(Int_t id)
             static TString dir(".");
             TGFileInfo fi;
             fi.fFileTypes = filetypes;
-            fi.fIniDir    = StrDup(dir);
+            fi.SetIniDir(dir);
             new TGFileDialog(gClient->GetRoot(), this, kFDOpen, &fi);
             if (fi.fFilename)
                OpenFile(fi.fFilename);
@@ -938,8 +938,8 @@ void SplitGLView::HandleMenu(Int_t id)
          {
             TGFileInfo fi;
             fi.fFileTypes = rcfiletypes;
-            fi.fIniDir    = StrDup(rcdir);
-            fi.fFilename  = StrDup(rcfile);
+            fi.SetIniDir(rcdir);
+            fi.SetFilename(rcfile);
             new TGFileDialog(gClient->GetRoot(), this, kFDOpen, &fi);
             if (fi.fFilename) {
                rcfile = fi.fFilename;
@@ -953,8 +953,8 @@ void SplitGLView::HandleMenu(Int_t id)
          {
             TGFileInfo fi;
             fi.fFileTypes = rcfiletypes;
-            fi.fIniDir    = StrDup(rcdir);
-            fi.fFilename  = StrDup(rcfile);
+            fi.SetIniDir(rcdir);
+            fi.SetFilename(rcfile);
             new TGFileDialog(gClient->GetRoot(), this, kFDSave, &fi);
             if (fi.fFilename) {
                rcfile = fi.fFilename;

--- a/tutorials/gui/drag_and_drop.C
+++ b/tutorials/gui/drag_and_drop.C
@@ -3,7 +3,7 @@
 /// This tutorial illustrates how to use drag and drop within ROOT.
 /// Select a list tree item with a mouse press, drag it (move the mouse while keeping the mouse button pressed)
 /// and release the mouse button in any pad inside the canvas or in the top list tree item ("Base").
-/// When the button is released, the selected data is "dropped" at that location, 
+/// When the button is released, the selected data is "dropped" at that location,
 /// displaying the object in the canvas or adding (copying) it in the list tree.
 ///
 /// \macro_code
@@ -365,7 +365,7 @@ void DNDMainFrame::HandleMenu(Int_t menu_id)
    static TString dir(".");
    TGFileInfo fi;
    fi.fFileTypes = dnd_types;
-   fi.fIniDir    = StrDup(dir);
+   fi.SetIniDir(dir);
 
    switch (menu_id) {
       case M_FILE_EXIT:

--- a/tutorials/gui/guitest.C
+++ b/tutorials/gui/guitest.C
@@ -820,7 +820,7 @@ void TestMainFrame::HandleMenu(Int_t id)
             static TString dir(".");
             TGFileInfo fi;
             fi.fFileTypes = filetypes;
-            fi.fIniDir    = StrDup(dir);
+            fi.SetIniDir(dir);
             printf("fIniDir = %s\n", fi.fIniDir);
             new TGFileDialog(gClient->GetRoot(), fMain, kFDOpen, &fi);
             printf("Open file: %s (dir: %s)\n", fi.fFilename, fi.fIniDir);


### PR DESCRIPTION
Most leaks are due to wrong management of allocated `char*` buffers via StrDup - thats how I detect them. Better to be applied after #4874 