### PR TITLE
Fix for ROOT-10494

### DIFF
--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2112,14 +2112,15 @@ void TChain::ParseTreeFilename(const char *name, TString &filename, TString &tre
                                Bool_t) const
 {
    Ssiz_t pIdx = kNPOS;
-   filename = name;
+   filename.Clear();
    treename.Clear();
    query.Clear();
    suffix.Clear();
 
    // General case
    TUrl url(name, kTRUE);
-
+   filename = url.GetUrl();
+   
    TString fn = url.GetFile();
    // Extract query, if any
    if (url.GetOptions() && (strlen(url.GetOptions()) > 0))

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2119,7 +2119,7 @@ void TChain::ParseTreeFilename(const char *name, TString &filename, TString &tre
 
    // General case
    TUrl url(name, kTRUE);
-   filename = url.GetUrl();
+   filename = (strcmp(url.GetProtocol(), "file")) ? url.GetUrl() : url.GetFileAndOptions();
    
    TString fn = url.GetFile();
    // Extract query, if any


### PR DESCRIPTION
TUrl silently removes double slashes ('//') in the file field.
This makes string comparisons later on failing unless everything is done with TUrl derived quantities.