### PR TITLE
Compile Interpreter.cpp with exception on.  Fix script with exception…

### DIFF
--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -107,6 +107,7 @@ add_cling_library(clingInterpreter OBJECT
 
 if (UNIX)
   set_source_files_properties(Exception.cpp COMPILE_FLAGS "-fexceptions -frtti")
+  set_source_files_properties(Interpreter.cpp COMPILE_FLAGS "-fexceptions")
 
   # Remove all -I from CMAKE_CXX_FLAGS
   string(REPLACE ";" " " __flags "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
… with ROOT Mutex on.

Compiling Interpreter.cpp allows RunFunction and friends to be actually seen during stack unwind after an
exception has been thrown, directly or indirectly, by interpreter code.  This allows for the RAII objects to be
properly tear down.

In particular, without this patch, EnterUserCodeRAII was not tear down and thus the callbacks were not executed.
Consequently the "Restore the ROOT global Mutex" callback was not executed leaving the Mutex in an invalid state.

In case of ART application, in most cases, they customize the ROOT error handler to throw an exception.  This
resulted (without this fix) in crash when import a GDML file with an error in it.

In practice what we have is:

    call to TGeo Import
       which calls the interpreter for some of its functionality
          which calls gdml code
            which reports an error
               which leads the error handler to thrown an exception.
       ... some of the stack are properly unwound ... some are not (because they were not compiled with exception support on)  ....
       ... so the ROOT Mutex goes into an incorrect state ...
       ... unwinding continues
       ... unwinding reached a frame that Unlock the mutex
         Mutex notices it is an incorrect state.
            so it reports the Error
               the Error handler throw an exception .......

and because this exception is being thrown during the unwind, it is fatal.