### PR TITLE
[PyROOT][ROOT-10109] Inject missing overloads in TH2 and more

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2797,6 +2797,11 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
       Utility::AddUsingToClass( pyclass, "createChi2" );
       Utility::AddUsingToClass( pyclass, "chi2FitTo" );
    }
+// Same for TH2
+   else if ( name == "TH2" ) {
+      Utility::AddUsingToClass( pyclass, "GetBinErrorUp" );
+      Utility::AddUsingToClass( pyclass, "GetBinErrorLow" );
+   }
 
    // TODO: store these on the pythonizations module, not on gRootModule
    // TODO: externalize this code and use update handlers on the python side

--- a/bindings/pyroot_experimental/cppyy/cppyy/python/cppyy/__init__.py
+++ b/bindings/pyroot_experimental/cppyy/cppyy/python/cppyy/__init__.py
@@ -75,11 +75,6 @@ sys.modules['cppyy.gbl'] = gbl
 sys.modules['cppyy.gbl.std'] = gbl.std
 
 
-#- enable auto-loading -------------------------------------------------------
-try:    gbl.gInterpreter.EnableAutoLoading()
-except: pass
-
-
 #- external typemap ----------------------------------------------------------
 from . import _typemap
 _typemap.initialize(_backend)

--- a/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
@@ -39,6 +39,7 @@ set(py_sources
   ROOT/pythonization/_tfile.py
   ROOT/pythonization/_tgraph.py
   ROOT/pythonization/_th1.py
+  ROOT/pythonization/_th2.py
   ROOT/pythonization/_titer.py
   ROOT/pythonization/_tobject.py
   ROOT/pythonization/_tobjstring.py

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_th2.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_th2.py
@@ -1,0 +1,27 @@
+# Author: Enric Tejedor CERN  02/2020
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+from libROOTPythonizations import AddUsingToClass
+
+
+@pythonization()
+def pythonize_th2(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: name of the class
+
+    if name == 'TH2':
+        # Add 'using' overloads from TH1
+        AddUsingToClass(klass, 'GetBinErrorUp')
+        AddUsingToClass(klass, 'GetBinErrorLow')
+
+    return True


### PR DESCRIPTION
In order to solve ROOT-10109, and until #3640 is completed and merged, we temporarily add a pythonisation both in PyROOT and experimental PyROOT to get the overloads for GetBinErrorUp
and GetBinErrorLow of TH1 obtained via using declarations from TH2.

On the other hand (and unrelated to the change above), we eliminate the use of `TInterpreter::EnableAutoLoading` from cppyy in experimental PyROOT, given the tests failures seen last night:
https://epsft-jenkins.cern.ch/job/root-exp-pyroot/393/
due to the deprecation introduced by https://github.com/root-project/root/pull/4868