### PR TITLE
Fix small leak in TLeaf::GenerateOffsetArrayBase

### DIFF
--- a/tree/tree/src/TLeaf.cxx
+++ b/tree/tree/src/TLeaf.cxx
@@ -169,6 +169,7 @@ Int_t *TLeaf::GenerateOffsetArrayBase(Int_t base, Int_t events) const
 
    Int_t *retval = new Int_t[events];
    if (R__unlikely(!retval || !fLeafCount)) {
+      delete [] retval;
       return nullptr;
    }
 
@@ -178,6 +179,7 @@ Int_t *TLeaf::GenerateOffsetArrayBase(Int_t base, Int_t events) const
    if (!countValues || ((Int_t)countValues->size()) < events) {
       Error("GenerateOffsetArrayBase", "The leaf %s could not retrieve enough entries from its branch count (%s), ask for %d and got %ld",
             GetName(), fLeafCount->GetName(), events, (long)(countValues ? countValues->size() : -1));
+      delete [] retval;
       return nullptr;
    }
 

--- a/tree/tree/src/TTreeRow.cxx
+++ b/tree/tree/src/TTreeRow.cxx
@@ -102,6 +102,8 @@ void TTreeRow::Close(Option_t *)
    if (fFields) delete [] fFields;
    fColumnCount = 0;
    fOriginal = 0;
+   fRow = nullptr;
+   fFields = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -160,6 +162,7 @@ void TTreeRow::SetRow(const Int_t *fields, const char *row)
    Int_t nch    = fields[fColumnCount-1];
    fFields      = new Int_t[fColumnCount];
    fOriginal    = 0;
+   if (fRow) delete [] fRow;
    fRow         = new char[nch];
    for (Int_t i=0;i<fColumnCount;i++) fFields[i] = fields[i];
    memcpy(fRow,row,nch);


### PR DESCRIPTION
Appears when method returns nullptr, but buffer is not released.
Also improve TTreeRow methods concerning reallocation or cleaning of memory