### PR TITLE
[ROOT-10534] Add GetNRuns feature to RDataFrame

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1989,6 +1989,12 @@ public:
    /// ~~~
    unsigned int GetNSlots() const { return fLoopManager->GetNSlots(); }
 
+   /// \brief Gets the number of event loops run
+   /// \return The number of event loops run by this RDataFrame instance
+   ///
+   /// This method returns the number of events loops run so far by this RDataFrame instance.
+   unsigned int GetNRuns() const { return fLoopManager->GetNRuns(); }
+
    // clang-format off
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Execute a user-defined accumulation operation on the processed column values in each processing slot

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -118,6 +118,7 @@ class RLoopManager : public RNodeBase {
    /// A unique ID that identifies the computation graph that starts with this RLoopManager.
    /// Used, for example, to jit objects in a namespace reserved for this computation graph
    const unsigned int fID = GetNextID();
+   unsigned int fNRuns{0}; ///< Number of event loops run
 
    std::vector<RCustomColumnBase *> fCustomColumns; ///< Non-owning container of all custom columns created so far.
    /// Cache of the tree/chain branch names. Never access directy, always use GetBranchNames().
@@ -174,6 +175,7 @@ public:
    const std::map<std::string, std::string> &GetAliasMap() const { return fAliasColumnNameMap; }
    void RegisterCallback(ULong64_t everyNEvents, std::function<void(unsigned int)> &&f);
    unsigned int GetID() const { return fID; }
+   unsigned int GetNRuns() const { return fNRuns; }
 
    /// End of recursive chain of calls, does nothing
    void AddFilterName(std::vector<std::string> &) {}

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -515,6 +515,8 @@ void RLoopManager::Run()
    }
 
    CleanUpNodes();
+
+   fNRuns++;
 }
 
 /// Return the list of default columns -- empty if none was provided when constructing the RDataFrame

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -422,6 +422,20 @@ TEST_P(RDFSimpleTests, GetNSlots)
    EXPECT_EQ(NSLOTS, ROOT::Internal::RDF::GetNSlots());
 }
 
+TEST_P(RDFSimpleTests, GetNRuns)
+{
+   RDataFrame df(3);
+   EXPECT_EQ(df.GetNRuns(), 0u);
+
+   auto sum1 = df.Sum("rdfentry_");
+   sum1.GetValue();
+   EXPECT_EQ(df.GetNRuns(), 1u);
+
+   auto sum2 = df.Sum("rdfentry_");
+   sum2.GetValue();
+   EXPECT_EQ(df.GetNRuns(), 2u);
+}
+
 TEST_P(RDFSimpleTests, CArraysFromTree)
 {
    auto filename = "dataframe_simple_3.root";


### PR DESCRIPTION
The feature tracks the number of runs executed by this RDataFrame instance,
more precisely by this RLoopManager instance of the dataframe.