### PR TITLE
[RF] Fix crash in RooLinTransBinning due to uninitialised pointer.

### DIFF
--- a/roofit/roofitcore/inc/RooLinTransBinning.h
+++ b/roofit/roofitcore/inc/RooLinTransBinning.h
@@ -22,11 +22,9 @@
 class RooLinTransBinning : public RooAbsBinning {
 public:
 
-  RooLinTransBinning(const char* name=0) : RooAbsBinning(name) {
-    // coverity[UNINIT_CTOR]
-  } ; 
-  RooLinTransBinning(const RooAbsBinning& input, Double_t slope=1.0, Double_t offset=0.0, const char* name=0) ;
-  RooLinTransBinning(const RooLinTransBinning&, const char* name=0) ;
+  RooLinTransBinning(const char* name=0) : RooAbsBinning(name) { }
+  RooLinTransBinning(const RooAbsBinning& input, Double_t slope=1.0, Double_t offset=0.0, const char* name=0);
+  RooLinTransBinning(const RooLinTransBinning&, const char* name=0);
   virtual RooAbsBinning* clone(const char* name=0) const { return new RooLinTransBinning(*this,name) ; }
   virtual ~RooLinTransBinning() ;
 
@@ -55,10 +53,10 @@ protected:
   inline Double_t trans(Double_t x) const { return x*_slope + _offset ; }
   inline Double_t invTrans(Double_t x) const { if (_slope==0.) return 0 ; return (x-_offset)/_slope ; }
 
-  Double_t _slope ;         // Slope of transformation
-  Double_t _offset ;        // Offset of tranformation
-  RooAbsBinning* _input ;   // Input binning
-  mutable Double_t *_array ; //! Array of transformed bin boundaries
+  Double_t _slope{0.};   // Slope of transformation
+  Double_t _offset{0.};  // Offset of transformation
+  RooAbsBinning* _input{nullptr};    // Input binning
+  mutable Double_t *_array{nullptr}; //! Array of transformed bin boundaries
 
   ClassDef(RooLinTransBinning,1) // Linear transformation of binning specification
 };

--- a/roofit/roofitcore/src/RooLinTransBinning.cxx
+++ b/roofit/roofitcore/src/RooLinTransBinning.cxx
@@ -42,8 +42,7 @@ ClassImp(RooLinTransBinning);
 /// construct the linear transformation
 
 RooLinTransBinning::RooLinTransBinning(const RooAbsBinning& input, Double_t slope, Double_t offset, const char* name) :
-  RooAbsBinning(name),
-  _array(0) 
+  RooAbsBinning(name)
 {
   updateInput(input,slope,offset) ;
 }
@@ -54,8 +53,7 @@ RooLinTransBinning::RooLinTransBinning(const RooAbsBinning& input, Double_t slop
 /// Copy constructor
 
 RooLinTransBinning::RooLinTransBinning(const RooLinTransBinning& other, const char* name) :
-  RooAbsBinning(name),
-  _array(0)
+  RooAbsBinning(name)
 {
   _input = other._input ;
   _slope = other._slope ;
@@ -87,25 +85,24 @@ void RooLinTransBinning::setRange(Double_t /*xlo*/, Double_t /*xhi*/)
 
 Double_t* RooLinTransBinning::array() const 
 {
-  Int_t n = numBoundaries() ;
+  const int n = numBoundaries();
   // Return array with boundary values
   if (_array) delete[] _array ;
   _array = new Double_t[n] ;
 
-  Double_t* inputArray = _input->array() ;
+  const double* inputArray = _input->array() ;
 
-  Int_t i ;
   if (_slope>0) {
-    for (i=0 ; i<n ; i++) {
+    for (int i=0; i < n; i++) {
       _array[i] = trans(inputArray[i]) ;
     }
   } else {
-    for (i=0 ; i<n ; i++) {
+    for (int i=0; i < n; i++) {
       _array[i] = trans(inputArray[n-i-1]) ;
     }
   }
-  return _array ;
 
+  return _array;
 }
 
 


### PR DESCRIPTION
[ROOT-7520] The empty constructor of RooLinTransBinning was not
initialising a pointer to an array. When streaming, this pointer is not
streamed, keeping the dangling pointer around. Initialising it with
nullptr fixes the problem.

(cherry picked from commit 3a14813d23a41b8a6799e08ed11242531c4ec01f)