### PR TITLE
Fix memory leak in TUrl::SetUrl()

### DIFF
--- a/core/base/src/TUrl.cxx
+++ b/core/base/src/TUrl.cxx
@@ -619,6 +619,9 @@ void TUrl::ParseOptions() const
    if (fOptionsMap) return;
 
    TString urloptions = GetOptions();
+   if (urloptions.IsNull())
+      return;
+
    TObjArray *objOptions = urloptions.Tokenize("&");
    for (Int_t n = 0; n < objOptions->GetEntries(); n++) {
       TString loption = ((TObjString *) objOptions->At(n))->GetName();
@@ -650,7 +653,7 @@ const char *TUrl::GetValueFromOptions(const char *key) const
    if (!key) return nullptr;
    ParseOptions();
    TObject *option = fOptionsMap ? fOptionsMap->GetValue(key) : nullptr;
-   return (option ? ((TObjString*)fOptionsMap->GetValue(key))->GetName(): nullptr);
+   return option ? option->GetName() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -662,7 +665,7 @@ Int_t TUrl::GetIntValueFromOptions(const char *key) const
    if (!key) return -1;
    ParseOptions();
    TObject *option = fOptionsMap ? fOptionsMap->GetValue(key) : nullptr;
-   return (option ? (atoi(((TObjString*)fOptionsMap->GetValue(key))->GetName())) : -1);
+   return option ? atoi(option->GetName()) : -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -673,9 +676,7 @@ Bool_t TUrl::HasOption(const char *key) const
    if (!key) return kFALSE;
    ParseOptions();
 
-   if (fOptionsMap && fOptionsMap->FindObject(key))
-      return kTRUE;
-   return kFALSE;
+   return fOptionsMap && fOptionsMap->FindObject(key);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TUrl.cxx
+++ b/core/base/src/TUrl.cxx
@@ -107,6 +107,7 @@ TUrl::~TUrl()
 
 void TUrl::SetUrl(const char *url, Bool_t defaultIsFile)
 {
+   delete fOptionsMap;
    fOptionsMap = nullptr;
 
    if (!url || !url[0]) {
@@ -373,6 +374,7 @@ TUrl &TUrl::operator=(const TUrl &rhs)
       fPort       = rhs.fPort;
       fFileOA     = rhs.fFileOA;
       fHostFQ     = rhs.fHostFQ;
+      delete fOptionsMap;
       fOptionsMap = nullptr;
    }
    return *this;
@@ -631,7 +633,7 @@ void TUrl::ParseOptions() const
          fOptionsMap->Add(new TObjString(key), new TObjString(value));
       } else {
          TString key = ((TObjString *) objTags->At(0))->GetName();
-         fOptionsMap->Add(new TObjString(key), 0);
+         fOptionsMap->Add(new TObjString(key), nullptr);
       }
       delete objTags;
    }


### PR DESCRIPTION
When url has options before, it was not correctly released
Following code always produced memory leak:

      TUrl url;
      url.SetUrl("http://server/file?arg=1&arg2=2");
      url.SetUrl("http://server/file?arg=1&arg2=2");

Simplify handling of options

