### PR TITLE
Apply  fixes in MethodPyKeras for Python3

### DIFF
--- a/tmva/pymva/src/MethodPyKeras.cxx
+++ b/tmva/pymva/src/MethodPyKeras.cxx
@@ -449,18 +449,27 @@ void MethodPyKeras::Train() {
    PyObject* PyNkeys=PyDict_GetItemString(fLocalNS, "number_of_keys");
    int nkeys=PyLong_AsLong(PyNkeys);
    for (iHis=0; iHis<nkeys; iHis++) {
-      std::cout<<"Getting his:"<<iHis<<std::endl;
-      PyRunString(TString::Format("copy_string=history.history.keys()[%d]",iHis));
+
+      PyRunString(TString::Format("copy_string=str(list(history.history.keys())[%d])",iHis));
+      //PyRunString("print (copy_string)");
       PyObject* stra=PyDict_GetItemString(fLocalNS, "copy_string");
       if(!stra) break;
-      const char* name = PyBytes_AsString(stra);
-      PyRunString("print(history.history.keys())","Failed to do printing of history");
-      PyRunString(TString::Format("for i,p in enumerate(history.history['%s']):\n   HistoryOutput[i]=p\n",name),
+#if PY_MAJOR_VERSION < 3   // for Python2
+      const char *name = PyBytes_AsString(stra);
+#else   // for Python3
+      PyObject* repr = PyObject_Repr(stra);
+      PyObject* str = PyUnicode_AsEncodedString(repr, "utf-8", "~E~");
+      const char *name = PyBytes_AsString(str);
+#endif
+
+      std::cout << "Getting his:" << iHis << " name = " << name << std::endl;
+      PyRunString(TString::Format("for i,p in enumerate(history.history[%s]):\n   HistoryOutput[i]=p\n",name),
                   TString::Format("Failed to get %s from training history",name));
       for (size_t i=0; i<fHistory.size(); i++)
          fTrainHistory.AddValue(name,i+1,fHistory[i]);
 
    }
+//#endif
 
    /*
     * Store trained model to file (only if option 'SaveBestOnly' is NOT activated,

--- a/tmva/pymva/src/MethodPyKeras.cxx
+++ b/tmva/pymva/src/MethodPyKeras.cxx
@@ -455,14 +455,17 @@ void MethodPyKeras::Train() {
       PyObject* stra=PyDict_GetItemString(fLocalNS, "copy_string");
       if(!stra) break;
 #if PY_MAJOR_VERSION < 3   // for Python2
-      const char *name = PyBytes_AsString(stra);
+      const char *stra_name = PyBytes_AsString(stra);
+      // need to add string delimiter for Python2
+      TString sname = TString::Format("'%s'",stra_name);
+      const char * name = sname.Data(); 
 #else   // for Python3
       PyObject* repr = PyObject_Repr(stra);
       PyObject* str = PyUnicode_AsEncodedString(repr, "utf-8", "~E~");
       const char *name = PyBytes_AsString(str);
 #endif
 
-      std::cout << "Getting his:" << iHis << " name = " << name << std::endl;
+      Log() << kINFO << "Getting training history for item:" << iHis << " name = " << name << Endl;
       PyRunString(TString::Format("for i,p in enumerate(history.history[%s]):\n   HistoryOutput[i]=p\n",name),
                   TString::Format("Failed to get %s from training history",name));
       for (size_t i=0; i<fHistory.size(); i++)


### PR DESCRIPTION
Fix in MethodPyKeras the conversion from PyObject representing strings in Python to strings in C++. 
The way of converting is different between Python2 and Python3