### PR TITLE
Resolve ROOT-10524 TChain::LoadTree perf with multiple friends of same name

### DIFF
--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -44,7 +44,6 @@ protected:
    TObjArray   *fFiles;            ///< -> List of file names containing the trees (TChainElement, owned)
    TList       *fStatus;           ///< -> List of active/inactive branches (TChainElement, owned)
    TChain      *fProofChain;       ///<! chain proxy when going to be processed by PROOF
-   TList       *fExternalFriends;  ///<! List of TFriendsElement pointing to us and need to be notified of LoadTree.  Content not owned.
 
 private:
    TChain(const TChain&);            // not implemented
@@ -132,8 +131,6 @@ public:
    virtual Long64_t  Process(const char *filename, Option_t *option="", Long64_t nentries=kMaxEntries, Long64_t firstentry=0); // *MENU*
    virtual Long64_t  Process(TSelector* selector, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
    virtual void      RecursiveRemove(TObject *obj);
-   virtual void      RegisterExternalFriend(TFriendElement *);
-   virtual void      RemoveExternalFriend(TFriendElement *fe) { if (fExternalFriends) fExternalFriends->Remove((TObject*)fe); }
    virtual void      RemoveFriend(TTree*);
    virtual void      Reset(Option_t *option="");
    virtual void      ResetAfterMerge(TFileMergeInfo *);

--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -44,6 +44,7 @@ protected:
    TObjArray   *fFiles;            ///< -> List of file names containing the trees (TChainElement, owned)
    TList       *fStatus;           ///< -> List of active/inactive branches (TChainElement, owned)
    TChain      *fProofChain;       ///<! chain proxy when going to be processed by PROOF
+   TList       *fExternalFriends;  ///<! List of TFriendsElement pointing to us and need to be notified of LoadTree.  Content not owned.
 
 private:
    TChain(const TChain&);            // not implemented
@@ -131,6 +132,8 @@ public:
    virtual Long64_t  Process(const char *filename, Option_t *option="", Long64_t nentries=kMaxEntries, Long64_t firstentry=0); // *MENU*
    virtual Long64_t  Process(TSelector* selector, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
    virtual void      RecursiveRemove(TObject *obj);
+   virtual void      RegisterExternalFriend(TFriendElement *);
+   virtual void      RemoveExternalFriend(TFriendElement *fe) { if (fExternalFriends) fExternalFriends->Remove((TObject*)fe); }
    virtual void      RemoveFriend(TTree*);
    virtual void      Reset(Option_t *option="");
    virtual void      ResetAfterMerge(TFileMergeInfo *);

--- a/tree/tree/inc/TFriendElement.h
+++ b/tree/tree/inc/TFriendElement.h
@@ -45,7 +45,10 @@ protected:
    friend void TFriendElement__SetTree(TTree *tree, TList *frlist);
 
 public:
-   enum EStatusBits { kFromChain = BIT(11) };
+   enum EStatusBits {
+      kFromChain = BIT(9),  // Indicates a TChain inserted this element in one of its content TTree
+      kUpdated   = BIT(10)  // Indicates that the chain 'fTree' went through a LoadTree
+   };
    TFriendElement();
    TFriendElement(TTree *tree, const char *treename, const char *filename);
    TFriendElement(TTree *tree, const char *treename, TFile *file);
@@ -58,6 +61,10 @@ public:
    virtual TTree      *GetTree();
    virtual const char *GetTreeName() const {return fTreeName.Data();}
    virtual void        ls(Option_t *option="") const;
+           void        Reset() { fTree = nullptr; fFile = nullptr; }
+           Bool_t      IsUpdated() const { return TestBit(kUpdated); }
+           void        ResetUpdated() { ResetBit(kUpdated); }
+           void        MarkUpdated() { SetBit(kUpdated); }
 
    ClassDef(TFriendElement,2)  //A friend element of another TTree
 };

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -546,8 +546,10 @@ public:
    virtual Long64_t        ReadFile(const char* filename, const char* branchDescriptor = "", char delimiter = ' ');
    virtual Long64_t        ReadStream(std::istream& inputStream, const char* branchDescriptor = "", char delimiter = ' ');
    virtual void            Refresh();
-   virtual void            RecursiveRemove(TObject *obj);
+   virtual void            RegisterExternalFriend(TFriendElement *) {}
+   virtual void            RemoveExternalFriend(TFriendElement *) {}
    virtual void            RemoveFriend(TTree*);
+   virtual void            RecursiveRemove(TObject *obj);
    virtual void            Reset(Option_t* option = "");
    virtual void            ResetAfterMerge(TFileMergeInfo *);
    virtual void            ResetBranchAddress(TBranch *);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -118,6 +118,7 @@ protected:
    TArrayI        fIndex;                 ///<  Index of sorted values
    TVirtualIndex *fTreeIndex;             ///<  Pointer to the tree Index (if any)
    TList         *fFriends;               ///<  pointer to list of friend elements
+   TList         *fExternalFriends;       ///<! List of TFriendsElement pointing to us and need to be notified of LoadTree.  Content not owned.
    TVirtualPerfStats *fPerfStats;         ///<! pointer to the current perf stats object
    TList         *fUserInfo;              ///<  pointer to a list of user objects associated to this Tree
    TVirtualTreePlayer *fPlayer;           ///<! Pointer to current Tree player
@@ -546,8 +547,8 @@ public:
    virtual Long64_t        ReadFile(const char* filename, const char* branchDescriptor = "", char delimiter = ' ');
    virtual Long64_t        ReadStream(std::istream& inputStream, const char* branchDescriptor = "", char delimiter = ' ');
    virtual void            Refresh();
-   virtual void            RegisterExternalFriend(TFriendElement *) {}
-   virtual void            RemoveExternalFriend(TFriendElement *) {}
+   virtual void            RegisterExternalFriend(TFriendElement *);
+   virtual void            RemoveExternalFriend(TFriendElement *fe) { if (fExternalFriends) fExternalFriends->Remove((TObject*)fe); }
    virtual void            RemoveFriend(TTree*);
    virtual void            RecursiveRemove(TObject *obj);
    virtual void            Reset(Option_t* option = "");

--- a/tree/tree/src/TFriendElement.cxx
+++ b/tree/tree/src/TFriendElement.cxx
@@ -170,7 +170,7 @@ TTree *TFriendElement::DisConnect()
 {
    // At this point, if the condition is not meant, fTree is usually already
    // deleted (hence the need for a local bit describing fTree)
-   if (TestBit(kFromChain) && fTree)
+   if (fTree)
       fTree->RemoveExternalFriend(this);
    if (fOwnFile) delete fFile;
    fFile = 0;
@@ -226,6 +226,9 @@ TTree *TFriendElement::GetTree()
 
    // This could be a memory tree or chain
    fTree = dynamic_cast<TTree*>( gROOT->FindObject(GetTreeName()) );
+
+   if (fTree)
+      fTree->RegisterExternalFriend(this);
 
    return fTree;
 }


### PR DESCRIPTION
Switch from heuristics discovery of a friend state change (i.e. a friend that is a TChain and move from one file to the other) to a push notification of the change (via the TFriendElement object).

This increase coupling between the main and friend TTree/TChain and thus need to be thoroughly tested before being considered for backport.