### PR TITLE
[PyROOT][ROOT-7983] Inject missing overloads for createHistogram

### DIFF
--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -2797,6 +2797,9 @@ Bool_t PyROOT::Pythonize( PyObject* pyclass, const std::string& name )
       Utility::AddUsingToClass( pyclass, "createChi2" );
       Utility::AddUsingToClass( pyclass, "chi2FitTo" );
    }
+   else if ( name == "RooDataSet" ) {
+      Utility::AddUsingToClass( pyclass, "createHistogram" );
+   }
 // Same for TH2
    else if ( name == "TH2" ) {
       Utility::AddUsingToClass( pyclass, "GetBinErrorUp" );

--- a/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
@@ -28,6 +28,7 @@ set(py_sources
   ROOT/pythonization/_rbdt.py
   ROOT/pythonization/_rooabscollection.py
   ROOT/pythonization/_roodatahist.py
+  ROOT/pythonization/_roodataset.py
   ROOT/pythonization/_rvec.py
   ROOT/pythonization/_stl_vector.py
   ROOT/pythonization/_tarray.py

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_roodataset.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_roodataset.py
@@ -1,0 +1,26 @@
+# Author: Enric Tejedor CERN  02/2020
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+from libROOTPythonizations import AddUsingToClass
+
+
+@pythonization()
+def pythonize_roodataset(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'RooDataSet':
+        # Add 'using' overloads for createHistogram from RooAbsData
+        AddUsingToClass(klass, 'createHistogram')
+
+    return True


### PR DESCRIPTION
From RooAbsData into RooDataSet. This pythonization will be
removed when the addition of the using overloads is automatically
handled by the bindings.

Done both in current PyROOT and experimental.