### PR TITLE
Fix potential memleak in TGeoFacet

### DIFF
--- a/geom/geom/inc/TGeoElement.h
+++ b/geom/geom/inc/TGeoElement.h
@@ -52,8 +52,8 @@ protected:
    Double_t                 fRadTsai;    // Tsai formula for the radiation length
 
 private:
-   TGeoElement(const TGeoElement &other);
-   TGeoElement &operator=(const TGeoElement &other);
+   TGeoElement(const TGeoElement &other) = delete;
+   TGeoElement &operator=(const TGeoElement &other) = delete;
 
    // Compute the Coulomb correction factor
    void                     ComputeCoulombFactor();
@@ -67,7 +67,7 @@ public:
    TGeoElement(const char *name, const char *title, Int_t nisotopes);
    TGeoElement(const char *name, const char *title, Int_t z, Int_t n, Double_t a);
    // destructor
-   virtual ~TGeoElement()             {;}
+   virtual ~TGeoElement();
    // methods
    virtual Int_t            ENDFCode()    const { return 0;}
    Int_t                    Z() const {return fZ;}

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -124,9 +124,6 @@ public:
    // destructor
    virtual ~TGeoTessellated() {}
 
-   TGeoTessellated(const TGeoTessellated &);
-   TGeoTessellated &operator=(const TGeoTessellated &);
-
    void ComputeBBox();
    void CloseShape(bool check = true, bool fixFlipped = true, bool verbose = true);
 

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -21,7 +21,7 @@ class TGeoFacet {
    using VertexVec_t = Tessellated::VertexVec_t;
 
 private:
-   int fIvert[4] = {0};              // Vertex indices in the array
+   int fIvert[4] = {0, 0, 0, 0};     // Vertex indices in the array
    VertexVec_t *fVertices = nullptr; //! array of vertices
    int fNvert = 0;                   // number of vertices (can be 3 or 4)
    bool fShared = false;             // Vector of vertices shared flag

--- a/geom/geom/inc/TGeoXtru.h
+++ b/geom/geom/inc/TGeoXtru.h
@@ -52,8 +52,8 @@ protected:
    mutable Int_t                      fThreadSize; //! size of thread-specific array
    mutable std::mutex                 fMutex;      //! mutex for thread data
 
-   TGeoXtru(const TGeoXtru&);
-   TGeoXtru& operator=(const TGeoXtru&);
+   TGeoXtru(const TGeoXtru&) = delete;
+   TGeoXtru& operator=(const TGeoXtru&) = delete;
 
    // methods
    Double_t              DistToPlane(const Double_t *point, const Double_t *dir, Int_t iz, Int_t ivert, Double_t stepmax, Bool_t in) const;

--- a/geom/geom/src/TGDMLMatrix.cxx
+++ b/geom/geom/src/TGDMLMatrix.cxx
@@ -60,15 +60,16 @@ TGDMLMatrix& TGDMLMatrix::operator=(const TGDMLMatrix& rhs)
    fNelem = fNrows * fNcols;
    if (rhs.fMatrix)
    {
-     fMatrix = new Double_t[fNelem];
-     memcpy(fMatrix, rhs.fMatrix, fNelem * sizeof(Double_t));
+      delete [] fMatrix;
+      fMatrix = new Double_t[fNelem];
+      memcpy(fMatrix, rhs.fMatrix, fNelem * sizeof(Double_t));
    }
    return *this;
 }
 
 //_____________________________________________________________________________
 void TGDMLMatrix::Set(size_t r, size_t c, Double_t a)
-{ 
+{
    assert(r < fNrows && c < fNcols);
    fMatrix[fNcols*r+c] = a;
 }

--- a/geom/geom/src/TGeoElement.cxx
+++ b/geom/geom/src/TGeoElement.cxx
@@ -157,10 +157,7 @@ TGeoElement::TGeoElement(const char *name, const char *title, Int_t z, Int_t n, 
 
 TGeoElement::~TGeoElement()
 {
-   if (fIsotopes) {
-      // fIsotopes->Delete(); // Andrei, check if isotopes shhould be deleted as well
-      delete fIsotopes;
-   }
+   delete fIsotopes;
    delete [] fAbundances;
 }
 

--- a/geom/geom/src/TGeoElement.cxx
+++ b/geom/geom/src/TGeoElement.cxx
@@ -151,6 +151,20 @@ TGeoElement::TGeoElement(const char *name, const char *title, Int_t z, Int_t n, 
    fAbundances = NULL;
    ComputeDerivedQuantities();
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// destructor
+
+TGeoElement::~TGeoElement()
+{
+   if (fIsotopes) {
+      // fIsotopes->Delete(); // Andrei, check if isotopes shhould be deleted as well
+      delete fIsotopes;
+   }
+   delete [] fAbundances;
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate properties for an atomic number
 

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -202,37 +202,6 @@ TGeoTessellated::TGeoTessellated(const char *name, const std::vector<Vertex_t> &
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor
-
-TGeoTessellated::TGeoTessellated(const TGeoTessellated &other) : TGeoBBox(other)
-{
-   fNfacets = other.fNfacets;
-   fNvert = other.fNvert;
-   fNseg = other.fNseg;
-   fDefined = other.fDefined;
-   fClosedBody = other.fClosedBody;
-   fVertices = other.fVertices;
-   fFacets = other.fFacets;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Assignment operator
-
-TGeoTessellated &TGeoTessellated::operator=(const TGeoTessellated &other)
-{
-   if (&other != this) {
-      TGeoBBox::operator=(other);
-      fNvert = other.fNvert;
-      fNseg = other.fNseg;
-      fDefined = other.fDefined;
-      fClosedBody = other.fClosedBody;
-      fVertices = other.fVertices;
-      fFacets = other.fFacets;
-   }
-   return *this;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Function to be called after reading tessellated volumes from the geometry file
 
 void TGeoTessellated::AfterStreamer()

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -51,18 +51,22 @@ std::ostream &operator<<(std::ostream &os, TGeoFacet const &facet)
 TGeoFacet::TGeoFacet(const TGeoFacet &other) : fVertices(other.fVertices), fNvert(other.fNvert), fShared(other.fShared)
 {
    memcpy(fIvert, other.fIvert, 4 * sizeof(int));
-   if (!fShared)
+   if (!fShared && other.fVertices)
       fVertices = new VertexVec_t(*other.fVertices);
 }
 
 const TGeoFacet &TGeoFacet::operator=(const TGeoFacet &other)
 {
    if (&other != this) {
-      fVertices = other.fVertices;
+      if (!fShared)
+         delete fVertices;
       fNvert = other.fNvert;
       fShared = other.fShared;
-      if (!fShared)
+      memcpy(fIvert, other.fIvert, 4 * sizeof(int));
+      if (!fShared && other.fVertices)
          fVertices = new VertexVec_t(*other.fVertices);
+      else
+         fVertices = other.fVertices;
    }
    return *this;
 }

--- a/geom/geom/src/TGeoXtru.cxx
+++ b/geom/geom/src/TGeoXtru.cxx
@@ -229,46 +229,6 @@ TGeoXtru::TGeoXtru(Double_t *param)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///copy constructor
-
-TGeoXtru::TGeoXtru(const TGeoXtru& xt) :
-  TGeoBBox(xt),
-  fNvert(0),
-  fNz(0),
-  fZcurrent(0),
-  fX(0),
-  fY(0),
-  fZ(0),
-  fScale(0),
-  fX0(0),
-  fY0(0),
-  fThreadData(0),
-  fThreadSize(0)
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///assignment operator
-
-TGeoXtru& TGeoXtru::operator=(const TGeoXtru& xt)
-{
-   if(this!=&xt) {
-      TGeoBBox::operator=(xt);
-      fNvert=0;
-      fNz=0;
-      fZcurrent=0;
-      fX=0;
-      fY=0;
-      fZ=0;
-      fScale=0;
-      fX0=0;
-      fY0=0;
-      fThreadSize=0;
-   }
-   return *this;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
 TGeoXtru::~TGeoXtru()

--- a/geom/geompainter/src/TGeoChecker.cxx
+++ b/geom/geompainter/src/TGeoChecker.cxx
@@ -941,6 +941,7 @@ void TGeoChecker::CheckGeometry(Int_t nrays, Double_t startx, Double_t starty, D
    }
    delete [] array1;
    delete [] array2;
+   delete pma; // markers are drawn on the pad
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/vecgeom/src/TGeoVGShape.cxx
+++ b/geom/vecgeom/src/TGeoVGShape.cxx
@@ -322,6 +322,8 @@ vecgeom::cxx::VUnplacedVolume* TGeoVGShape::Convert(TGeoShape const *const shape
             }
          }
          unplaced_volume = new UnplacedSExtruVolume(p->GetNvert(), x, y, p->GetZ()[0], p->GetZ()[1]);
+         delete [] x;
+         delete [] y;
       }
    }
 


### PR DESCRIPTION
I just looked in the code while want to add support of TGeoTesselated to JSROOT.
Here is first attempt: https://jsroot.gsi.de/dev/examples.htm#tgeo_tess

Found and fixed issues:
* Fix potential memory access problem in new TGeoFacet
* In assign operator one should release memory before allocating new one
* `fIvert` member was not copied in assign operator
* Eliminate copy constructor and assign operator for TGeoTesselated (not used, default is ok)

For several TGeo classes like TGeoPolygon, TGeoPcon, TGeoPgon one should declare assign operator and copy constructor as deleted or really implement them. Otherwise if anybody use them, this will produce memory leak / seg. violation.

