### PR TITLE
Fix memory allocation failure in Oracle

### DIFF
--- a/net/net/inc/TSQLServer.h
+++ b/net/net/inc/TSQLServer.h
@@ -41,20 +41,18 @@ class TList;
 class TSQLServer : public TObject {
 
 protected:
-   TString   fType;       // type of DBMS (MySQL, Oracle, SysBase, ...)
-   TString   fHost;       // host to which we are connected
-   TString   fDB;         // currently selected DB
-   Int_t     fPort;       // port to which we are connected
-   Int_t     fErrorCode;  // error code of last operation
-   TString   fErrorMsg;   // error message of last operation
-   Bool_t    fErrorOut;   // enable error output
+   TString   fType;             // type of DBMS (MySQL, Oracle, SysBase, ...)
+   TString   fHost;             // host to which we are connected
+   TString   fDB;               // currently selected DB
+   Int_t     fPort{-1};         // port to which we are connected
+   Int_t     fErrorCode{0};     // error code of last operation
+   TString   fErrorMsg;         // error message of last operation
+   Bool_t    fErrorOut{kTRUE}; // enable error output
 
-   TSQLServer()
-     : fType(), fHost(), fDB(), fPort(-1), fErrorCode(0),
-     fErrorMsg(), fErrorOut(kTRUE) { ClearError(); }
+   TSQLServer() {} // not allowed to use =default for TObject-derived classes
 
    void                ClearError();
-   void                SetError(Int_t code, const char* msg, const char* method = 0);
+   void                SetError(Int_t code, const char* msg, const char *method = nullptr);
 
    static const char* fgFloatFmt;          //!  printf argument for floats and doubles, either "%f" or "%e" or "%10f" and so on
 
@@ -73,19 +71,19 @@ public:
 
    virtual ~TSQLServer() { }
 
-   virtual void        Close(Option_t *option="") = 0;
+   virtual void        Close(Option_t *option = "") = 0;
    virtual TSQLResult *Query(const char *sql) = 0;
    virtual Bool_t      Exec(const char* sql);
    virtual TSQLStatement *Statement(const char*, Int_t = 100)
-                           { AbstractMethod("Statement"); return 0; }
+                           { AbstractMethod("Statement"); return nullptr; }
    virtual Bool_t      HasStatement() const { return kFALSE; }
    virtual Int_t       SelectDataBase(const char *dbname) = 0;
-   virtual TSQLResult *GetDataBases(const char *wild = 0) = 0;
-   virtual TSQLResult *GetTables(const char *dbname, const char *wild = 0) = 0;
-   virtual TList      *GetTablesList(const char* wild = 0);
+   virtual TSQLResult *GetDataBases(const char *wild = nullptr) = 0;
+   virtual TSQLResult *GetTables(const char *dbname, const char *wild = nullptr) = 0;
+   virtual TList      *GetTablesList(const char* wild = nullptr);
    virtual Bool_t      HasTable(const char* tablename);
    virtual TSQLTableInfo *GetTableInfo(const char* tablename);
-   virtual TSQLResult *GetColumns(const char *dbname, const char *table, const char *wild = 0) = 0;
+   virtual TSQLResult *GetColumns(const char *dbname, const char *table, const char *wild = nullptr) = 0;
    virtual Int_t       GetMaxIdentifierLength() { return 20; }
    virtual Int_t       CreateDataBase(const char *dbname) = 0;
    virtual Int_t       DropDataBase(const char *dbname) = 0;

--- a/net/net/inc/TSQLStatement.h
+++ b/net/net/inc/TSQLStatement.h
@@ -16,23 +16,22 @@
 #include "TString.h"
 #include "TDatime.h"
 #include "TTimeStamp.h"
-#include<vector>
+#include <vector>
 
 class TSQLStatement : public TObject {
 
 protected:
-   TSQLStatement(Bool_t errout = kTRUE) : TObject(), fErrorCode(0),
-     fErrorMsg(), fErrorOut(errout) { ClearError(); }
+   TSQLStatement(Bool_t errout = kTRUE) { fErrorOut = errout; }
 
-   Int_t     fErrorCode;  // error code of last operation
-   TString   fErrorMsg;   // error message of last operation
-   Bool_t    fErrorOut;   // enable error output
+   Int_t     fErrorCode{0};      // error code of last operation
+   TString   fErrorMsg;          // error message of last operation
+   Bool_t    fErrorOut{kFALSE};  // enable error output
 
    void                ClearError();
-   void                SetError(Int_t code, const char* msg, const char* method = 0);
+   void                SetError(Int_t code, const char* msg, const char *method = nullptr);
 
 public:
-   virtual ~TSQLStatement() {}
+   virtual ~TSQLStatement() = default;
 
    virtual Int_t       GetBufferLength() const = 0;
    virtual Int_t       GetNumParameters() = 0;
@@ -61,14 +60,13 @@ public:
    virtual void        SetTimeFormating(const char*) {}
    virtual Bool_t      SetBinary(Int_t, void*, Long_t, Long_t = 0x1000) { return kFALSE; }
    virtual Bool_t      SetLargeObject(Int_t col, void* mem, Long_t size, Long_t maxsize = 0x1000) { return SetBinary(col, mem, size, maxsize); }
-#ifndef __MAKECINT__
+
    virtual Bool_t      SetVInt(Int_t, const std::vector<Int_t>, const char*, const char*) { return kFALSE; }
    virtual Bool_t      SetVUInt(Int_t, const std::vector<UInt_t>, const char*, const char*) { return kFALSE; }
    virtual Bool_t      SetVLong(Int_t, const std::vector<Long_t>, const char*, const char*) { return kFALSE; }
    virtual Bool_t      SetVLong64(Int_t, const std::vector<Long64_t>, const char*, const char*) { return kFALSE; }
    virtual Bool_t      SetVULong64(Int_t, const std::vector<ULong64_t>, const char*, const char*) { return kFALSE; }
    virtual Bool_t      SetVDouble(Int_t, const std::vector<Double_t>, const char*, const char*) { return kFALSE; }
-#endif
 
    virtual Bool_t      Process() = 0;
    virtual Int_t       GetNumAffectedRows() { return 0; }
@@ -104,14 +102,12 @@ public:
    virtual Bool_t      GetTimestamp(Int_t, Int_t&, Int_t&, Int_t&, Int_t&, Int_t&, Int_t&, Int_t&);
    virtual Bool_t      GetTimestamp(Int_t, TTimeStamp&);
            TDatime     GetTimestamp(Int_t);
-#ifndef __MAKECINT__
    virtual Bool_t      GetVInt(Int_t, std::vector<Int_t>&) { return kFALSE; }
    virtual Bool_t      GetVUInt(Int_t, std::vector<UInt_t>&) { return kFALSE; }
    virtual Bool_t      GetVLong(Int_t, std::vector<Long_t>&) { return kFALSE; }
    virtual Bool_t      GetVLong64(Int_t, std::vector<Long64_t>&) { return kFALSE; }
    virtual Bool_t      GetVULong64(Int_t, std::vector<ULong64_t>&) { return kFALSE; }
    virtual Bool_t      GetVDouble(Int_t, std::vector<Double_t>&) { return kFALSE; }
-#endif
 
    virtual Bool_t      IsError() const { return GetErrorCode()!=0; }
    virtual Int_t       GetErrorCode() const;

--- a/net/net/inc/TSQLStatement.h
+++ b/net/net/inc/TSQLStatement.h
@@ -39,6 +39,8 @@ public:
 
    virtual Bool_t      NextIteration() = 0;
 
+   virtual   void      Close(Option_t * = "") {}
+
    virtual Bool_t      SetNull(Int_t) { return kFALSE; }
    virtual Bool_t      SetInt(Int_t, Int_t) { return kFALSE; }
    virtual Bool_t      SetUInt(Int_t, UInt_t) { return kFALSE; }

--- a/net/net/src/TSQLServer.cxx
+++ b/net/net/src/TSQLServer.cxx
@@ -61,7 +61,7 @@ const char* TSQLServer::fgFloatFmt = "%e";
 TSQLServer *TSQLServer::Connect(const char *db, const char *uid, const char *pw)
 {
    TPluginHandler *h;
-   TSQLServer *serv = 0;
+   TSQLServer *serv = nullptr;
 
    if ((h = gROOT->GetPluginManager()->FindHandler("TSQLServer", db))) {
       if (h->LoadPlugin() == -1)
@@ -71,7 +71,7 @@ TSQLServer *TSQLServer::Connect(const char *db, const char *uid, const char *pw)
 
    if (serv && serv->IsZombie()) {
       delete serv;
-      serv = 0;
+      serv = nullptr;
    }
 
    return serv;
@@ -79,13 +79,13 @@ TSQLServer *TSQLServer::Connect(const char *db, const char *uid, const char *pw)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Execute sql query.
-/// Usefull for commands like DROP TABLE or INSERT, where result set
+/// Useful for commands like DROP TABLE or INSERT, where result set
 /// is not interested. Return kTRUE if no error
 
 Bool_t TSQLServer::Exec(const char* sql)
 {
    TSQLResult* res = Query(sql);
-   if (res==0) return kFALSE;
+   if (!res) return kFALSE;
 
    delete res;
 
@@ -110,7 +110,7 @@ Int_t TSQLServer::GetErrorCode() const
 
 const char* TSQLServer::GetErrorMsg() const
 {
-   return GetErrorCode()==0 ? 0 : fErrorMsg.Data();
+   return GetErrorCode()==0 ? nullptr : fErrorMsg.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -166,7 +166,7 @@ Bool_t TSQLServer::Rollback()
 /// Parameter wild specifies wildcard for table names.
 /// It either contains exact table name to verify that table is exists or
 /// wildcard with "%" (any number of symbols) and "_" (exactly one symbol).
-/// Example of vaild wildcards: "%", "%name","___user__".
+/// Example of valid wildcards: "%", "%name","___user__".
 /// If wild=="", list of all available tables will be produced.
 /// List contain just tables names in the TObjString.
 /// List must be deleted by the user.
@@ -182,13 +182,13 @@ Bool_t TSQLServer::Rollback()
 TList* TSQLServer::GetTablesList(const char* wild)
 {
    TSQLResult* res = GetTables(fDB.Data(), wild);
-   if (res==0) return 0;
+   if (!res) return nullptr;
 
-   TList* lst = 0;
-   TSQLRow* row = 0;
-   while ((row = res->Next())!=0) {
+   TList *lst = nullptr;
+   TSQLRow *row = nullptr;
+   while ((row = res->Next())!=nullptr) {
       const char* tablename = row->GetField(0);
-      if (lst==0) {
+      if (!lst) {
          lst = new TList;
          lst->SetOwner(kTRUE);
       }
@@ -207,21 +207,21 @@ TList* TSQLServer::GetTablesList(const char* wild)
 
 Bool_t TSQLServer::HasTable(const char* tablename)
 {
-   if ((tablename==0) || (strlen(tablename)==0)) return kFALSE;
+   if (!tablename || (strlen(tablename)==0)) return kFALSE;
 
-   TList* lst = GetTablesList(tablename);
-   if (lst==0) return kFALSE;
+   TList *lst = GetTablesList(tablename);
+   if (!lst) return kFALSE;
 
    Bool_t res = kFALSE;
 
-   TObject* obj = 0;
+   TObject* obj = nullptr;
    TIter iter(lst);
 
    // Can be, that tablename contains "_" or "%" symbols, which are wildcards in SQL,
    // therefore more than one table can be returned as result.
    // One should check that exactly same name is appears
 
-   while ((obj = iter()) != 0)
+   while ((obj = iter()) != nullptr)
       if (strcmp(tablename, obj->GetName())==0) res = kTRUE;
 
    delete lst;
@@ -229,22 +229,22 @@ Bool_t TSQLServer::HasTable(const char* tablename)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Producec TSQLTableInfo object, which contain info about
+/// Produce TSQLTableInfo object, which contain info about
 /// table itself and each table column
 /// Object must be deleted by user.
 
 TSQLTableInfo* TSQLServer::GetTableInfo(const char* tablename)
 {
-   if ((tablename==0) || (*tablename==0)) return 0;
+   if (!tablename || (*tablename==0)) return 0;
 
    TSQLResult* res = GetColumns(fDB.Data(), tablename);
-   if (res==0) return 0;
+   if (!res) return nullptr;
 
-   TList* lst = 0;
-   TSQLRow* row = 0;
-   while ((row = res->Next())!=0) {
-      const char* columnname = row->GetField(0);
-      if (lst==0) lst = new TList;
+   TList* lst = nullptr;
+   TSQLRow* row = nullptr;
+   while ((row = res->Next())!=nullptr) {
+      const char *columnname = row->GetField(0);
+      if (!lst) lst = new TList;
       lst->Add(new TSQLColumnInfo(columnname));
       delete row;
    }
@@ -259,7 +259,7 @@ TSQLTableInfo* TSQLServer::GetTableInfo(const char* tablename)
 
 void TSQLServer::SetFloatFormat(const char* fmt)
 {
-   if (fmt==0) fmt = "%e";
+   if (!fmt) fmt = "%e";
    fgFloatFmt = fmt;
 }
 

--- a/net/net/src/TSQLStatement.cxx
+++ b/net/net/src/TSQLStatement.cxx
@@ -243,7 +243,7 @@ Int_t TSQLStatement::GetErrorCode() const
 
 const char* TSQLStatement::GetErrorMsg() const
 {
-   return GetErrorCode()==0 ? 0 : fErrorMsg.Data();
+   return GetErrorCode()==0 ? nullptr : fErrorMsg.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -263,7 +263,7 @@ void TSQLStatement::SetError(Int_t code, const char* msg, const char* method)
 {
    fErrorCode = code;
    fErrorMsg = msg;
-   if ((method!=0) && fErrorOut)
+   if (method && fErrorOut)
       Error(method,"Code: %d  Msg: %s", code, (msg ? msg : "No message"));
 }
 

--- a/sql/mysql/inc/TMySQLResult.h
+++ b/sql/mysql/inc/TMySQLResult.h
@@ -19,8 +19,8 @@
 class TMySQLResult : public TSQLResult {
 
 private:
-   MYSQL_RES   *fResult;      // query result (rows)
-   MYSQL_FIELD *fFieldInfo;   // info for each field in the row
+   MYSQL_RES   *fResult{nullptr};      // query result (rows)
+   MYSQL_FIELD *fFieldInfo{nullptr};   // info for each field in the row
 
    Bool_t  IsValid(Int_t field);
 
@@ -28,12 +28,12 @@ public:
    TMySQLResult(void *result);
    ~TMySQLResult();
 
-   void        Close(Option_t *opt="");
-   Int_t       GetFieldCount();
-   const char *GetFieldName(Int_t field);
-   TSQLRow    *Next();
+   void        Close(Option_t *opt="") final;
+   Int_t       GetFieldCount() final;
+   const char *GetFieldName(Int_t field) final;
+   TSQLRow    *Next() final;
 
-   ClassDef(TMySQLResult,0)  // MySQL query result
+   ClassDefOverride(TMySQLResult,0)  // MySQL query result
 };
 
 #endif

--- a/sql/mysql/inc/TMySQLRow.h
+++ b/sql/mysql/inc/TMySQLRow.h
@@ -19,9 +19,9 @@
 class TMySQLRow : public TSQLRow {
 
 private:
-   MYSQL_RES   *fResult;       // current result set
-   MYSQL_ROW    fFields;       // current row
-   ULong_t     *fFieldLength;  // length of each field in the row
+   MYSQL_RES   *fResult{nullptr};      // current result set
+   MYSQL_ROW    fFields;               // current row
+   ULong_t     *fFieldLength{nullptr}; // length of each field in the row
 
    Bool_t  IsValid(Int_t field);
 
@@ -29,11 +29,11 @@ public:
    TMySQLRow(void *result, ULong_t rowHandle);
    ~TMySQLRow();
 
-   void        Close(Option_t *opt="");
-   ULong_t     GetFieldLength(Int_t field);
-   const char *GetField(Int_t field);
+   void        Close(Option_t *opt="") final;
+   ULong_t     GetFieldLength(Int_t field) final;
+   const char *GetField(Int_t field) final;
 
-   ClassDef(TMySQLRow,0)  // One row of MySQL query result
+   ClassDefOverride(TMySQLRow,0)  // One row of MySQL query result
 };
 
 #endif

--- a/sql/mysql/inc/TMySQLServer.h
+++ b/sql/mysql/inc/TMySQLServer.h
@@ -51,39 +51,39 @@
 class TMySQLServer : public TSQLServer {
 
 protected:
-   MYSQL     *fMySQL;    // connection to MySQL server
-   TString    fInfo;     // server info string
+   MYSQL     *fMySQL{nullptr};   // connection to MySQL server
+   TString    fInfo;             // server info string
 
 public:
    TMySQLServer(const char *db, const char *uid, const char *pw);
    ~TMySQLServer();
 
-   void           Close(Option_t *opt="");
-   TSQLResult    *Query(const char *sql);
-   Bool_t         Exec(const char* sql);
-   TSQLStatement *Statement(const char *sql, Int_t = 100);
-   Bool_t         HasStatement() const;
-   Int_t          SelectDataBase(const char *dbname);
-   TSQLResult    *GetDataBases(const char *wild = 0);
-   TSQLResult    *GetTables(const char *dbname, const char *wild = 0);
-   TList         *GetTablesList(const char* wild = 0);
-   TSQLTableInfo *GetTableInfo(const char* tablename);
-   TSQLResult    *GetColumns(const char *dbname, const char *table, const char *wild = 0);
-   Int_t          GetMaxIdentifierLength() { return 64; }
-   Int_t          CreateDataBase(const char *dbname);
-   Int_t          DropDataBase(const char *dbname);
-   Int_t          Reload();
-   Int_t          Shutdown();
-   const char    *ServerInfo();
+   void           Close(Option_t *opt="") final;
+   TSQLResult    *Query(const char *sql) final;
+   Bool_t         Exec(const char* sql) final;
+   TSQLStatement *Statement(const char *sql, Int_t = 100) final;
+   Bool_t         HasStatement() const final;
+   Int_t          SelectDataBase(const char *dbname) final;
+   TSQLResult    *GetDataBases(const char *wild = nullptr) final;
+   TSQLResult    *GetTables(const char *dbname, const char *wild = nullptr) final;
+   TList         *GetTablesList(const char* wild = nullptr) final;
+   TSQLTableInfo *GetTableInfo(const char* tablename) final;
+   TSQLResult    *GetColumns(const char *dbname, const char *table, const char *wild = nullptr) final;
+   Int_t          GetMaxIdentifierLength() final { return 64; }
+   Int_t          CreateDataBase(const char *dbname) final;
+   Int_t          DropDataBase(const char *dbname) final;
+   Int_t          Reload() final;
+   Int_t          Shutdown() final;
+   const char    *ServerInfo() final;
 
-   Bool_t         StartTransaction();
-   Bool_t         Commit();
-   Bool_t         Rollback();
+   Bool_t         StartTransaction() final;
+   Bool_t         Commit() final;
+   Bool_t         Rollback() final;
 
-   Bool_t         PingVerify();
-   Int_t          Ping();
+   Bool_t         PingVerify() final;
+   Int_t          Ping() final;
 
-   ClassDef(TMySQLServer,0)  // Connection to MySQL server
+   ClassDefOverride(TMySQLServer,0)  // Connection to MySQL server
 };
 
 #endif

--- a/sql/mysql/inc/TMySQLStatement.h
+++ b/sql/mysql/inc/TMySQLStatement.h
@@ -42,7 +42,7 @@ protected:
       ULong_t       fResLength{0};        //! length argument
       my_bool       fResNull{false};      //! indicates if argument is null
       char         *fStrBuffer{nullptr};  //! special buffer to be used for string conversions
-      char         *fFieldName{nullptr};  //! buffer for field name
+      std::string   fFieldName;           //! buffer for field name
    };
 
    MYSQL_STMT      *fStmt{nullptr};       //! executed statement

--- a/sql/mysql/inc/TMySQLStatement.h
+++ b/sql/mysql/inc/TMySQLStatement.h
@@ -35,23 +35,23 @@ class TMySQLStatement : public TSQLStatement {
 protected:
 
    struct TParamData {
-      void*         fMem;        //! allocated data buffer
-      Int_t         fSize;       //! size of allocated data
-      Int_t         fSqlType;     //! sqltype of parameter
-      Bool_t        fSign;        //! signed - not signed type
-      ULong_t       fResLength;  //! length argument
-      my_bool       fResNull;    //! indicates if argument is null
-      char*         fStrBuffer;  //! special buffer to be used for string conversions
-      char*         fFieldName;  //! buffer for field name
+      void         *fMem{nullptr};        //! allocated data buffer
+      Int_t         fSize{0};             //! size of allocated data
+      Int_t         fSqlType{0};          //! sqltype of parameter
+      Bool_t        fSign{kFALSE};        //! signed - not signed type
+      ULong_t       fResLength{0};        //! length argument
+      my_bool       fResNull{false};      //! indicates if argument is null
+      char         *fStrBuffer{nullptr};  //! special buffer to be used for string conversions
+      char         *fFieldName{nullptr};  //! buffer for field name
    };
 
-   MYSQL_STMT           *fStmt;          //! executed statement
-   Int_t                 fNumBuffers; //! number of statement parameters
-   MYSQL_BIND           *fBind;          //! array of bind data
-   TParamData           *fBuffer;         //! parameter definition structures
-   Int_t                 fWorkingMode;   //! 1 - setting parameters, 2 - retrieving results
-   Int_t                 fIterationCount;//! number of iteration
-   Bool_t                fNeedParBind;   //! indicates when parameters bind should be called
+   MYSQL_STMT      *fStmt{nullptr};       //! executed statement
+   Int_t            fNumBuffers{0};       //! number of statement parameters
+   MYSQL_BIND      *fBind{nullptr};       //! array of bind data
+   TParamData      *fBuffer{nullptr};     //! parameter definition structures
+   Int_t            fWorkingMode{0};      //! 1 - setting parameters, 2 - retrieving results
+   Int_t            fIterationCount{-1};  //! number of iteration
+   Bool_t           fNeedParBind{kFALSE}; //! indicates when parameters bind should be called
 
    Bool_t      IsSetParsMode() const { return fWorkingMode==1; }
    Bool_t      IsResultSetMode() const { return fWorkingMode==2; }
@@ -69,8 +69,8 @@ protected:
    static ULong64_t fgAllocSizeLimit;
 
 private:
-   TMySQLStatement(const TMySQLStatement&);            // Not implemented.
-   TMySQLStatement &operator=(const TMySQLStatement&); // Not implemented.
+   TMySQLStatement(const TMySQLStatement&) = delete;
+   TMySQLStatement &operator=(const TMySQLStatement&) = delete;
 
 public:
    TMySQLStatement(MYSQL_STMT* stmt, Bool_t errout = kTRUE);
@@ -79,52 +79,52 @@ public:
    static ULong_t GetAllocSizeLimit() { return fgAllocSizeLimit; }
    static void SetAllocSizeLimit(ULong_t sz) { fgAllocSizeLimit = sz; }
 
-   virtual void        Close(Option_t * = "");
+   void        Close(Option_t * = "") final;
 
-   virtual Int_t       GetBufferLength() const { return 1; }
-   virtual Int_t       GetNumParameters();
+   Int_t       GetBufferLength() const final { return 1; }
+   Int_t       GetNumParameters() final;
 
-   virtual Bool_t      SetNull(Int_t npar);
-   virtual Bool_t      SetInt(Int_t npar, Int_t value);
-   virtual Bool_t      SetUInt(Int_t npar, UInt_t value);
-   virtual Bool_t      SetLong(Int_t npar, Long_t value);
-   virtual Bool_t      SetLong64(Int_t npar, Long64_t value);
-   virtual Bool_t      SetULong64(Int_t npar, ULong64_t value);
-   virtual Bool_t      SetDouble(Int_t npar, Double_t value);
-   virtual Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256);
-   virtual Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000);
-   virtual Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day);
-   virtual Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec);
-   virtual Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec);
+   Bool_t      SetNull(Int_t npar) final;
+   Bool_t      SetInt(Int_t npar, Int_t value) final;
+   Bool_t      SetUInt(Int_t npar, UInt_t value) final;
+   Bool_t      SetLong(Int_t npar, Long_t value) final;
+   Bool_t      SetLong64(Int_t npar, Long64_t value) final;
+   Bool_t      SetULong64(Int_t npar, ULong64_t value) final;
+   Bool_t      SetDouble(Int_t npar, Double_t value) final;
+   Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256) final;
+   Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000) final;
+   Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day) final;
+   Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec) final;
+   Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec) final;
    using TSQLStatement::SetTimestamp;
-   virtual Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0);
+   Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0) final;
 
-   virtual Bool_t      NextIteration();
+   Bool_t      NextIteration() final;
 
-   virtual Bool_t      Process();
-   virtual Int_t       GetNumAffectedRows();
+   Bool_t      Process() final;
+   Int_t       GetNumAffectedRows() final;
 
-   virtual Bool_t      StoreResult();
-   virtual Int_t       GetNumFields();
-   virtual const char *GetFieldName(Int_t nfield);
-   virtual Bool_t      NextResultRow();
+   Bool_t      StoreResult() final;
+   Int_t       GetNumFields() final;
+   const char *GetFieldName(Int_t nfield) final;
+   Bool_t      NextResultRow() final;
 
-   virtual Bool_t      IsNull(Int_t npar);
-   virtual Int_t       GetInt(Int_t npar);
-   virtual UInt_t      GetUInt(Int_t npar);
-   virtual Long_t      GetLong(Int_t npar);
-   virtual Long64_t    GetLong64(Int_t npar);
-   virtual ULong64_t   GetULong64(Int_t npar);
-   virtual Double_t    GetDouble(Int_t npar);
-   virtual const char *GetString(Int_t npar);
-   virtual Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size);
-   virtual Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day);
-   virtual Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec);
-   virtual Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec);
+   Bool_t      IsNull(Int_t npar) final;
+   Int_t       GetInt(Int_t npar) final;
+   UInt_t      GetUInt(Int_t npar) final;
+   Long_t      GetLong(Int_t npar) final;
+   Long64_t    GetLong64(Int_t npar) final;
+   ULong64_t   GetULong64(Int_t npar) final;
+   Double_t    GetDouble(Int_t npar) final;
+   const char *GetString(Int_t npar) final;
+   Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size) final;
+   Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day) final;
+   Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec) final;
+   Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec) final;
    using TSQLStatement::GetTimestamp;
-   virtual Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t&);
+   Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t&) final;
 
-   ClassDef(TMySQLStatement, 0);  // SQL statement class for MySQL DB
+   ClassDefOverride(TMySQLStatement, 0);  // SQL statement class for MySQL DB
 };
 
 #endif

--- a/sql/mysql/inc/TMySQLStatement.h
+++ b/sql/mysql/inc/TMySQLStatement.h
@@ -41,7 +41,7 @@ protected:
       Bool_t        fSign{kFALSE};        //! signed - not signed type
       ULong_t       fResLength{0};        //! length argument
       my_bool       fResNull{false};      //! indicates if argument is null
-      char         *fStrBuffer{nullptr};  //! special buffer to be used for string conversions
+      std::string   fStrBuffer;           //! special buffer to be used for string conversions
       std::string   fFieldName;           //! buffer for field name
    };
 

--- a/sql/mysql/src/TMySQLResult.cxx
+++ b/sql/mysql/src/TMySQLResult.cxx
@@ -22,7 +22,7 @@ TMySQLResult::TMySQLResult(void *result)
 {
    fResult    = (MYSQL_RES *) result;
    fRowCount  = fResult ? mysql_num_rows(fResult) : 0;
-   fFieldInfo = 0;
+   fFieldInfo = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -43,8 +43,8 @@ void TMySQLResult::Close(Option_t *)
       return;
 
    mysql_free_result(fResult);
-   fResult    = 0;
-   fFieldInfo = 0;
+   fResult    = nullptr;
+   fFieldInfo = nullptr;
    fRowCount  = 0;
 }
 
@@ -82,14 +82,14 @@ Int_t TMySQLResult::GetFieldCount()
 const char *TMySQLResult::GetFieldName(Int_t field)
 {
    if (!IsValid(field))
-      return 0;
+      return nullptr;
 
    if (!fFieldInfo)
       fFieldInfo = mysql_fetch_fields(fResult);
 
    if (!fFieldInfo) {
       Error("GetFieldName", "cannot get field info");
-      return 0;
+      return nullptr;
    }
 
    return fFieldInfo[field].name;
@@ -101,15 +101,13 @@ const char *TMySQLResult::GetFieldName(Int_t field)
 
 TSQLRow *TMySQLResult::Next()
 {
-   MYSQL_ROW row;
-
    if (!fResult) {
       Error("Next", "result set closed");
-      return 0;
+      return nullptr;
    }
-   row = mysql_fetch_row(fResult);
+   MYSQL_ROW row = mysql_fetch_row(fResult);
    if (!row)
-      return 0;
-   else
-      return new TMySQLRow((void *) fResult, (ULong_t) row);
+      return nullptr;
+
+   return new TMySQLRow((void *) fResult, (ULong_t) row);
 }

--- a/sql/mysql/src/TMySQLRow.cxx
+++ b/sql/mysql/src/TMySQLRow.cxx
@@ -41,8 +41,8 @@ void TMySQLRow::Close(Option_t *)
    if (!fFields)
       return;
 
-   fFields      = 0;
-   fResult      = 0;
+   fFields      = nullptr;
+   fResult      = nullptr;
    fFieldLength = 0;
 }
 
@@ -87,7 +87,7 @@ ULong_t TMySQLRow::GetFieldLength(Int_t field)
 const char *TMySQLRow::GetField(Int_t field)
 {
    if (!IsValid(field))
-      return 0;
+      return nullptr;
 
    return fFields[field];
 }

--- a/sql/mysql/src/TMySQLServer.cxx
+++ b/sql/mysql/src/TMySQLServer.cxx
@@ -82,7 +82,7 @@ ClassImp(TMySQLServer);
 
 TMySQLServer::TMySQLServer(const char *db, const char *uid, const char *pw)
 {
-   fMySQL = 0;
+   fMySQL = nullptr;
    fInfo = "MySQL";
 
    TUrl url(db);
@@ -102,7 +102,7 @@ TMySQLServer::TMySQLServer(const char *db, const char *uid, const char *pw)
    }
 
    const char* dbase = url.GetFile();
-   if (dbase!=0)
+   if (dbase)
       if (*dbase=='/') dbase++; //skip leading "/" if appears
 
    fMySQL = new MYSQL;
@@ -341,7 +341,7 @@ TSQLResult *TMySQLServer::GetTables(const char *dbname, const char *wild)
 {
    CheckConnect("GetTables", 0);
 
-   if (SelectDataBase(dbname) != 0) return 0;
+   if (SelectDataBase(dbname) != 0) return nullptr;
 
    MYSQL_RES *res = mysql_list_tables(fMySQL, wild);
 
@@ -364,15 +364,15 @@ TList* TMySQLServer::GetTablesList(const char* wild)
 
    MYSQL_ROW row = mysql_fetch_row(res);
 
-   TList* lst = 0;
+   TList *lst = nullptr;
 
    while (row!=0) {
       CheckErrNo("GetTablesList", kFALSE, lst);
 
       const char* tablename = row[0];
 
-      if (tablename!=0) {
-         if (lst==0) {
+      if (!tablename) {
+         if (!lst) {
             lst = new TList();
             lst->SetOwner(kTRUE);
          }
@@ -395,7 +395,7 @@ TSQLTableInfo *TMySQLServer::GetTableInfo(const char* tablename)
 {
    CheckConnect("GetTableInfo", 0);
 
-   if ((tablename==0) || (*tablename==0)) return 0;
+   if (!tablename || (*tablename==0)) return nullptr;
 
    TString sql;
    sql.Form("SELECT * FROM `%s` LIMIT 1", tablename);
@@ -413,16 +413,16 @@ TSQLTableInfo *TMySQLServer::GetTableInfo(const char* tablename)
    sql.Form("SHOW COLUMNS FROM `%s`", tablename);
    TSQLResult* showres = Query(sql.Data());
 
-   if (showres==0) {
+   if (!showres) {
       mysql_free_result(res);
-      return 0;
+      return nullptr;
    }
 
-   TList* lst = 0;
+   TList *lst = nullptr;
 
    unsigned int nfield = 0;
 
-   TSQLRow* row = 0;
+   TSQLRow* row = nullptr;
 
    while ((row = showres->Next()) != 0) {
       const char* column_name = row->GetField(0);
@@ -591,7 +591,7 @@ TSQLResult *TMySQLServer::GetColumns(const char *dbname, const char *table,
 {
    CheckConnect("GetColumns", 0);
 
-   if (SelectDataBase(dbname) != 0) return 0;
+   if (SelectDataBase(dbname) != 0) return nullptr;
 
    TString sql;
    if (wild)
@@ -707,14 +707,14 @@ TSQLStatement *TMySQLServer::Statement(const char *sql, Int_t)
 #if MYSQL_VERSION_ID < 40100
    ClearError();
    SetError(-1, "Statement class does not supported by MySQL version < 4.1", "Statement");
-   return 0;
+   return nullptr;
 #else
 
    CheckConnect("Statement", 0);
 
    if (!sql || !*sql) {
       SetError(-1, "no query string specified","Statement");
-      return 0;
+      return nullptr;
    }
 
    MYSQL_STMT *stmt = mysql_stmt_init(fMySQL);
@@ -724,7 +724,7 @@ TSQLStatement *TMySQLServer::Statement(const char *sql, Int_t)
    if (mysql_stmt_prepare(stmt, sql, strlen(sql))) {
       SetError(mysql_errno(fMySQL), mysql_error(fMySQL), "Statement");
       mysql_stmt_close(stmt);
-      return 0;
+      return nullptr;
    }
 
    return new TMySQLStatement(stmt, fErrorOut);

--- a/sql/mysql/src/TMySQLStatement.cxx
+++ b/sql/mysql/src/TMySQLStatement.cxx
@@ -331,7 +331,7 @@ const char *TMySQLStatement::ConvertToString(Int_t npar)
       (fBind[npar].buffer_type==MYSQL_TYPE_VAR_STRING))
       return (const char *) addr;
 
-   const int kSize = 100;
+   constexpr int kSize = 100;
    char buf[kSize];
    int len = 0;
 

--- a/sql/mysql/src/TMySQLStatement.cxx
+++ b/sql/mysql/src/TMySQLStatement.cxx
@@ -275,8 +275,6 @@ void TMySQLStatement::FreeBuffers()
    if (fBuffer) {
       for (Int_t n=0; n<fNumBuffers;n++) {
          free(fBuffer[n].fMem);
-         if (fBuffer[n].fStrBuffer)
-            delete[] fBuffer[n].fStrBuffer;
       }
       delete[] fBuffer;
    }
@@ -310,7 +308,7 @@ void TMySQLStatement::SetBuffersNumber(Int_t numpars)
       fBuffer[n].fSign = kFALSE;
       fBuffer[n].fResLength = 0;
       fBuffer[n].fResNull = false;
-      fBuffer[n].fStrBuffer = nullptr;
+      fBuffer[n].fStrBuffer.clear();
       fBuffer[n].fFieldName.clear();
    }
 }
@@ -331,10 +329,7 @@ const char *TMySQLStatement::ConvertToString(Int_t npar)
       (fBind[npar].buffer_type==MYSQL_TYPE_VAR_STRING))
       return (const char *) addr;
 
-   if (!fBuffer[npar].fStrBuffer)
-      fBuffer[npar].fStrBuffer = new char[100];
-
-   char *buf = fBuffer[npar].fStrBuffer;
+   char buf[100];
 
    switch(fBind[npar].buffer_type) {
       case MYSQL_TYPE_LONG:
@@ -382,7 +377,10 @@ const char *TMySQLStatement::ConvertToString(Int_t npar)
       default:
          return nullptr;
    }
-   return buf;
+
+   fBuffer[npar].fStrBuffer = buf;
+
+   return fBuffer[npar].fStrBuffer.c_str();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -726,7 +724,7 @@ Bool_t TMySQLStatement::SetSQLParamType(Int_t npar, int sqltype, Bool_t sig, ULo
    fBuffer[npar].fSize = 0;
    fBuffer[npar].fResLength = 0;
    fBuffer[npar].fResNull = false;
-   fBuffer[npar].fStrBuffer = nullptr;
+   fBuffer[npar].fStrBuffer.clear();
 
    ULong64_t allocsize = 0;
 

--- a/sql/odbc/inc/TODBCResult.h
+++ b/sql/odbc/inc/TODBCResult.h
@@ -31,19 +31,19 @@ class TODBCResult : public TSQLResult {
 
 protected:
    SQLHSTMT    fHstmt;
-   Int_t       fFieldCount;
+   Int_t       fFieldCount{0};
    TString     fNameBuffer;
 
 public:
    TODBCResult(SQLHSTMT stmt);
    virtual ~TODBCResult();
 
-   void        Close(Option_t *opt="");
-   Int_t       GetFieldCount() { return fFieldCount; }
-   const char *GetFieldName(Int_t field);
-   TSQLRow    *Next();
+   void        Close(Option_t *opt="") final;
+   Int_t       GetFieldCount() final { return fFieldCount; }
+   const char *GetFieldName(Int_t field) final;
+   TSQLRow    *Next() final;
 
-   ClassDef(TODBCResult,0)  // ODBC query result
+   ClassDefOverride(TODBCResult,0)  // ODBC query result
 };
 
 #endif

--- a/sql/odbc/inc/TODBCRow.h
+++ b/sql/odbc/inc/TODBCRow.h
@@ -29,25 +29,25 @@ class TODBCRow : public TSQLRow {
 
 protected:
    SQLHSTMT   fHstmt;
-   Int_t      fFieldCount;
-   char      **fBuffer;
-   ULong_t    *fLengths;
+   Int_t      fFieldCount{0};
+   char      **fBuffer{nullptr};
+   ULong_t    *fLengths{nullptr};
 
    void        CopyFieldValue(Int_t field);
 
 private:
-   TODBCRow(const TODBCRow&);            // Not implemented.
-   TODBCRow &operator=(const TODBCRow&); // Not implemented.
+   TODBCRow(const TODBCRow&) = delete;
+   TODBCRow &operator=(const TODBCRow&) = delete;
 
 public:
    TODBCRow(SQLHSTMT stmt, Int_t fieldcount);
    virtual ~TODBCRow();
 
-   void        Close(Option_t *opt="");
-   ULong_t     GetFieldLength(Int_t field);
-   const char *GetField(Int_t field);
+   void        Close(Option_t *opt="") final;
+   ULong_t     GetFieldLength(Int_t field) final;
+   const char *GetField(Int_t field) final;
 
-   ClassDef(TODBCRow,0)  // One row of ODBC query result
+   ClassDefOverride(TODBCRow,0)  // One row of ODBC query result
 };
 
 #endif

--- a/sql/odbc/inc/TODBCServer.h
+++ b/sql/odbc/inc/TODBCServer.h
@@ -50,29 +50,29 @@ public:
    static TList* GetDataSources();
    static void PrintDataSources();
 
-   void        Close(Option_t *opt="");
-   TSQLResult *Query(const char *sql);
-   Bool_t      Exec(const char* sql);
-   TSQLStatement *Statement(const char *sql, Int_t = 100);
-   Bool_t      HasStatement() const { return kTRUE; }
-   Int_t       SelectDataBase(const char *dbname);
-   TSQLResult *GetDataBases(const char *wild = 0);
-   TSQLResult *GetTables(const char *dbname, const char *wild = 0);
-   TList      *GetTablesList(const char* wild = 0);
-   TSQLTableInfo* GetTableInfo(const char* tablename);
-   TSQLResult *GetColumns(const char *dbname, const char *table, const char *wild = 0);
-   Int_t       GetMaxIdentifierLength();
-   Int_t       CreateDataBase(const char *dbname);
-   Int_t       DropDataBase(const char *dbname);
-   Int_t       Reload();
-   Int_t       Shutdown();
-   const char *ServerInfo();
+   void        Close(Option_t *opt="") final;
+   TSQLResult *Query(const char *sql) final;
+   Bool_t      Exec(const char* sql) final;
+   TSQLStatement *Statement(const char *sql, Int_t = 100) final;
+   Bool_t      HasStatement() const final { return kTRUE; }
+   Int_t       SelectDataBase(const char *dbname) final;
+   TSQLResult *GetDataBases(const char *wild = nullptr) final;
+   TSQLResult *GetTables(const char *dbname, const char *wild = nullptr) final;
+   TList      *GetTablesList(const char* wild = nullptr) final;
+   TSQLTableInfo* GetTableInfo(const char* tablename) final;
+   TSQLResult *GetColumns(const char *dbname, const char *table, const char *wild = nullptr) final;
+   Int_t       GetMaxIdentifierLength() final;
+   Int_t       CreateDataBase(const char *dbname) final;
+   Int_t       DropDataBase(const char *dbname) final;
+   Int_t       Reload() final;
+   Int_t       Shutdown() final;
+   const char *ServerInfo() final;
 
-   Bool_t      StartTransaction();
-   Bool_t      Commit();
-   Bool_t      Rollback();
+   Bool_t      StartTransaction() final;
+   Bool_t      Commit() final;
+   Bool_t      Rollback() final;
 
-   ClassDef(TODBCServer,0)  // Connection to MySQL server
+   ClassDefOverride(TODBCServer,0)  // Connection to MySQL server
 };
 
 #endif

--- a/sql/odbc/inc/TODBCStatement.h
+++ b/sql/odbc/inc/TODBCStatement.h
@@ -48,16 +48,16 @@ protected:
 
 protected:
    SQLHSTMT         fHstmt;
-   Int_t            fBufferPreferredSize;
-   ODBCBufferRec_t *fBuffer;
-   Int_t            fNumBuffers;
-   Int_t            fBufferLength;     // number of entries for each parameter/column
-   Int_t            fBufferCounter;    // used to indicate position in buffers
-   SQLUSMALLINT    *fStatusBuffer;
-   Int_t            fWorkingMode;      // 1 - setting parameters, 2 - reading results, 0 - unknown
-   SQLUINTEGER      fNumParsProcessed; // contains number of parameters, affected by last operation
-   SQLUINTEGER      fNumRowsFetched;   // indicates number of fetched rows
-   ULong64_t        fLastResultRow;    // stores values of row number after last fetch operation
+   Int_t            fBufferPreferredSize{0};
+   ODBCBufferRec_t *fBuffer{nullptr};
+   Int_t            fNumBuffers{0};
+   Int_t            fBufferLength{0};     // number of entries for each parameter/column
+   Int_t            fBufferCounter{0};    // used to indicate position in buffers
+   SQLUSMALLINT    *fStatusBuffer{nullptr};
+   Int_t            fWorkingMode{0};      // 1 - setting parameters, 2 - reading results, 0 - unknown
+   SQLUINTEGER      fNumParsProcessed{0};  // contains number of parameters, affected by last operation
+   SQLUINTEGER      fNumRowsFetched{0};    // indicates number of fetched rows
+   ULong64_t        fLastResultRow{0};     // stores values of row number after last fetch operation
 
    void       *GetParAddr(Int_t npar, Int_t roottype = 0, Int_t length = 0);
    long double ConvertToNumeric(Int_t npar);
@@ -78,52 +78,52 @@ public:
    TODBCStatement(SQLHSTMT stmt, Int_t rowarrsize, Bool_t errout = kTRUE);
    virtual ~TODBCStatement();
 
-   virtual void        Close(Option_t * = "");
+   virtual void        Close(Option_t * = "") final;
 
-   virtual Int_t       GetBufferLength() const { return fBufferLength; }
-   virtual Int_t       GetNumParameters();
+   Int_t       GetBufferLength() const final { return fBufferLength; }
+   Int_t       GetNumParameters() final;
 
-   virtual Bool_t      SetNull(Int_t npar);
-   virtual Bool_t      SetInt(Int_t npar, Int_t value);
-   virtual Bool_t      SetUInt(Int_t npar, UInt_t value);
-   virtual Bool_t      SetLong(Int_t npar, Long_t value);
-   virtual Bool_t      SetLong64(Int_t npar, Long64_t value);
-   virtual Bool_t      SetULong64(Int_t npar, ULong64_t value);
-   virtual Bool_t      SetDouble(Int_t npar, Double_t value);
-   virtual Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256);
-   virtual Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000);
-   virtual Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day);
-   virtual Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec);
-   virtual Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec);
+   Bool_t      SetNull(Int_t npar) final;
+   Bool_t      SetInt(Int_t npar, Int_t value) final;
+   Bool_t      SetUInt(Int_t npar, UInt_t value) final;
+   Bool_t      SetLong(Int_t npar, Long_t value) final;
+   Bool_t      SetLong64(Int_t npar, Long64_t value) final;
+   Bool_t      SetULong64(Int_t npar, ULong64_t value) final;
+   Bool_t      SetDouble(Int_t npar, Double_t value) final;
+   Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256) final;
+   Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000) final;
+   Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day) final;
+   Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec) final;
+   Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec) final;
    using TSQLStatement::SetTimestamp;
-   virtual Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0);
+   Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0) final;
 
-   virtual Bool_t      NextIteration();
+   Bool_t      NextIteration() final;
 
-   virtual Bool_t      Process();
-   virtual Int_t       GetNumAffectedRows();
+   Bool_t      Process() final;
+   Int_t       GetNumAffectedRows() final;
 
-   virtual Bool_t      StoreResult();
-   virtual Int_t       GetNumFields();
-   virtual const char *GetFieldName(Int_t nfield);
-   virtual Bool_t      NextResultRow();
+   Bool_t      StoreResult() final;
+   Int_t       GetNumFields() final;
+   const char *GetFieldName(Int_t nfield) final;
+   Bool_t      NextResultRow() final;
 
-   virtual Bool_t      IsNull(Int_t);
-   virtual Int_t       GetInt(Int_t npar);
-   virtual UInt_t      GetUInt(Int_t npar);
-   virtual Long_t      GetLong(Int_t npar);
-   virtual Long64_t    GetLong64(Int_t npar);
-   virtual ULong64_t   GetULong64(Int_t npar);
-   virtual Double_t    GetDouble(Int_t npar);
-   virtual const char *GetString(Int_t npar);
-   virtual Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size);
-   virtual Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day);
-   virtual Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec);
-   virtual Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec);
+   Bool_t      IsNull(Int_t) final;
+   Int_t       GetInt(Int_t npar) final;
+   UInt_t      GetUInt(Int_t npar) final;
+   Long_t      GetLong(Int_t npar) final;
+   Long64_t    GetLong64(Int_t npar) final;
+   ULong64_t   GetULong64(Int_t npar) final;
+   Double_t    GetDouble(Int_t npar) final;
+   const char *GetString(Int_t npar) final;
+   Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size) final;
+   Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day) final;
+   Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec) final;
+   Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec) final;
    using TSQLStatement::GetTimestamp;
-   virtual Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t&);
+   Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t&) final;
 
-   ClassDef(TODBCStatement, 0); //ODBC implementation of TSQLStatement
+   ClassDefOverride(TODBCStatement, 0); //ODBC implementation of TSQLStatement
 };
 
 #endif

--- a/sql/odbc/src/TODBCStatement.cxx
+++ b/sql/odbc/src/TODBCStatement.cxx
@@ -115,7 +115,7 @@ void TODBCStatement::Close(Option_t *)
 
    SQLFreeHandle(SQL_HANDLE_STMT, fHstmt);
 
-   fHstmt=0;
+   fHstmt = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -368,7 +368,7 @@ void TODBCStatement::SetNumBuffers(Int_t isize, Int_t ilen)
       fBuffer[n].fBroottype = 0;
       fBuffer[n].fBsqltype = 0;
       fBuffer[n].fBsqlctype = 0;
-      fBuffer[n].fBbuffer = 0;
+      fBuffer[n].fBbuffer = nullptr;
       fBuffer[n].fBelementsize = 0;
       fBuffer[n].fBlenarray = 0;
       fBuffer[n].fBstrbuffer = 0;
@@ -385,7 +385,7 @@ void TODBCStatement::FreeBuffers()
 {
    if (fBuffer==0) return;
    for (Int_t n=0;n<fNumBuffers;n++) {
-      if (fBuffer[n].fBbuffer!=0)
+      if (fBuffer[n].fBbuffer)
         free(fBuffer[n].fBbuffer);
       delete[] fBuffer[n].fBlenarray;
       delete[] fBuffer[n].fBstrbuffer;
@@ -394,10 +394,10 @@ void TODBCStatement::FreeBuffers()
 
    delete[] fStatusBuffer;
    delete[] fBuffer;
-   fBuffer = 0;
+   fBuffer = nullptr;
    fNumBuffers = 0;
    fBufferLength = 0;
-   fStatusBuffer = 0;
+   fStatusBuffer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sql/oracle/inc/TOracleResult.h
+++ b/sql/oracle/inc/TOracleResult.h
@@ -38,15 +38,15 @@ class TList;
 class TOracleResult : public TSQLResult {
 
 private:
-   oracle::occi::Connection*fConn;        // connection to Oracle
-   oracle::occi::Statement *fStmt;        // executed statement
-   oracle::occi::ResultSet *fResult;      // query result (rows)
-   std::vector<oracle::occi::MetaData> *fFieldInfo;   // info for each field in the row
-   Int_t                  fFieldCount;  // num of fields in resultset
-   UInt_t                 fUpdateCount; // for dml query, mutual exclusive with above
-   Int_t                  fResultType;  // 0 - nothing; 1 - Select; 2 - table metainfo, 3 - update counter
-   TList                 *fPool;        // array of results, produced when number of rows are requested
-   std::string           fNameBuffer; // buffer for GetFieldName() argument
+   oracle::occi::Connection   *fConn{nullptr};               // connection to Oracle
+   oracle::occi::Statement    *fStmt{nullptr};               // executed statement
+   oracle::occi::ResultSet    *fResult{nullptr};             // query result (rows)
+   std::vector<oracle::occi::MetaData> *fFieldInfo{nullptr}; // info for each field in the row
+   Int_t                       fFieldCount{0};               // num of fields in resultset
+   UInt_t                      fUpdateCount{0};              // for dml query, mutual exclusive with above
+   Int_t                       fResultType{0};               // 0 - nothing; 1 - Select; 2 - table metainfo, 3 - update counter
+   TList                      *fPool{nullptr};               // array of results, produced when number of rows are requested
+   std::string                 fNameBuffer;                  // buffer for GetFieldName() argument
 
    Bool_t  IsValid(Int_t field);
 
@@ -62,15 +62,15 @@ public:
    TOracleResult(oracle::occi::Connection *conn, const char *tableName);
    ~TOracleResult();
 
-   void        Close(Option_t *opt="");
-   Int_t       GetFieldCount();
-   const char *GetFieldName(Int_t field);
-   virtual Int_t GetRowCount() const;
-   TSQLRow    *Next();
+   void        Close(Option_t *opt="") final;
+   Int_t       GetFieldCount() final;
+   const char *GetFieldName(Int_t field) final;
+   Int_t       GetRowCount() const final;
+   TSQLRow    *Next() final;
 
-   Int_t       GetUpdateCount() { return fUpdateCount; }
+   Int_t       GetUpdateCount() const { return fUpdateCount; }
 
-   ClassDef(TOracleResult,0)  // Oracle query result
+   ClassDefOverride(TOracleResult,0)  // Oracle query result
 };
 
 #endif

--- a/sql/oracle/inc/TOracleRow.h
+++ b/sql/oracle/inc/TOracleRow.h
@@ -29,15 +29,15 @@ class MetaData;
 class TOracleRow : public TSQLRow {
 
 private:
-   oracle::occi::ResultSet *fResult;      // current result set
-   std::vector<oracle::occi::MetaData> *fFieldInfo;   // metadata for columns
-   Int_t                    fFieldCount;
-   char                   **fFieldsBuffer;
+   oracle::occi::ResultSet *fResult{nullptr};      // current result set
+   std::vector<oracle::occi::MetaData> *fFieldInfo{nullptr};   // metadata for columns
+   Int_t                    fFieldCount{0};
+   char                   **fFieldsBuffer{nullptr};
 
    Bool_t  IsValid(Int_t field);
 
-   TOracleRow(const TOracleRow&);            // Not implemented.
-   TOracleRow &operator=(const TOracleRow&); // Not implemented.
+   TOracleRow(const TOracleRow&) = delete;            // Not implemented.
+   TOracleRow &operator=(const TOracleRow&)= delete; // Not implemented.
 
 protected:
    void        GetRowData();
@@ -47,11 +47,11 @@ public:
               std::vector<oracle::occi::MetaData> *fieldMetaData);
    ~TOracleRow();
 
-   void        Close(Option_t *opt="");
-   ULong_t     GetFieldLength(Int_t field);
-   const char *GetField(Int_t field);
+   void        Close(Option_t *opt="") final;
+   ULong_t     GetFieldLength(Int_t field) final;
+   const char *GetField(Int_t field) final;
 
-   ClassDef(TOracleRow,0)  // One row of Oracle query result
+   ClassDefOverride(TOracleRow,0)  // One row of Oracle query result
 };
 
 #endif

--- a/sql/oracle/inc/TOracleServer.h
+++ b/sql/oracle/inc/TOracleServer.h
@@ -33,8 +33,8 @@ class Connection;
 class TOracleServer : public TSQLServer {
 
 private:
-   oracle::occi::Environment  *fEnv;    // environment of Oracle access
-   oracle::occi::Connection   *fConn;   // connection to Oracle server
+   oracle::occi::Environment  *fEnv{nullptr};    // environment of Oracle access
+   oracle::occi::Connection   *fConn{nullptr};   // connection to Oracle server
    TString       fInfo;  // info string with Oracle version information
 
    static const char* fgDatimeFormat; //! format for converting date and time stamps into string
@@ -43,33 +43,33 @@ public:
    TOracleServer(const char *db, const char *uid, const char *pw);
    ~TOracleServer();
 
-   void        Close(Option_t *opt="");
-   TSQLResult *Query(const char *sql);
-   Bool_t      Exec(const char* sql);
-   TSQLStatement *Statement(const char *sql, Int_t niter = 100);
-   Bool_t      IsConnected() const { return (fConn!=0) && (fEnv!=0); }
-   Bool_t      HasStatement() const { return kTRUE; }
-   Int_t       SelectDataBase(const char *dbname);
-   TSQLResult *GetDataBases(const char *wild = 0);
-   TSQLResult *GetTables(const char *dbname, const char *wild = 0);
-   TList      *GetTablesList(const char* wild = 0);
-   TSQLTableInfo *GetTableInfo(const char* tablename);
-   TSQLResult *GetColumns(const char *dbname, const char *table, const char *wild = 0);
-   Int_t       GetMaxIdentifierLength() { return 30; }
-   Int_t       CreateDataBase(const char *dbname);
-   Int_t       DropDataBase(const char *dbname);
-   Int_t       Reload();
-   Int_t       Shutdown();
-   const char *ServerInfo();
+   void        Close(Option_t *opt="") final;
+   TSQLResult *Query(const char *sql) final;
+   Bool_t      Exec(const char* sql) final;
+   TSQLStatement *Statement(const char *sql, Int_t niter = 100) final;
+   Bool_t      IsConnected() const final { return (fConn!=0) && (fEnv!=0); }
+   Bool_t      HasStatement() const final { return kTRUE; }
+   Int_t       SelectDataBase(const char *dbname) final;
+   TSQLResult *GetDataBases(const char *wild = nullptr) final;
+   TSQLResult *GetTables(const char *dbname, const char *wild = nullptr) final;
+   TList      *GetTablesList(const char* wild = nullptr) final;
+   TSQLTableInfo *GetTableInfo(const char* tablename) final;
+   TSQLResult *GetColumns(const char *dbname, const char *table, const char *wild = nullptr) final;
+   Int_t       GetMaxIdentifierLength() final { return 30; }
+   Int_t       CreateDataBase(const char *dbname) final;
+   Int_t       DropDataBase(const char *dbname) final;
+   Int_t       Reload() final;
+   Int_t       Shutdown() final;
+   const char *ServerInfo() final;
 
-   Bool_t      StartTransaction();
-   Bool_t      Commit();
-   Bool_t      Rollback();
+   Bool_t      StartTransaction() final;
+   Bool_t      Commit() final;
+   Bool_t      Rollback() final;
 
    static    void     SetDatimeFormat(const char* fmt = "MM/DD/YYYY, HH24:MI:SS");
    static const char* GetDatimeFormat();
 
-   ClassDef(TOracleServer,0)  // Connection to Oracle server
+   ClassDefOverride(TOracleServer,0)  // Connection to Oracle server
 };
 
 #endif

--- a/sql/oracle/inc/TOracleStatement.h
+++ b/sql/oracle/inc/TOracleStatement.h
@@ -34,22 +34,22 @@ class TOracleStatement : public TSQLStatement {
 protected:
 
    struct TBufferRec {
-      char* strbuf;
-      Long_t strbufsize;
-      char* namebuf;
+      char* strbuf{nullptr};
+      Long_t strbufsize{0};
+      char* namebuf{nullptr};
    };
 
-   oracle::occi::Environment *fEnv;         // environment
-   oracle::occi::Connection  *fConn;        // connection to Oracle
-   oracle::occi::Statement   *fStmt;        // executed statement
-   oracle::occi::ResultSet   *fResult;      // query result (rows)
-   std::vector<oracle::occi::MetaData> *fFieldInfo;   // info for each field in the row
-   TBufferRec            *fBuffer;       // buffer of values and field names
-   Int_t                  fBufferSize;   // size of fBuffer
-   Int_t                  fNumIterations;  // size of internal statement buffer
-   Int_t                  fIterCounter; //counts nextiteration calls and process iterations, if required
-   Int_t                  fWorkingMode; // 1 - settingpars, 2 - getting results
-   TString                fTimeFmt;     // format for date to string conversion, default "MM/DD/YYYY, HH24:MI:SS"
+   oracle::occi::Environment *fEnv{nullptr};                 // environment
+   oracle::occi::Connection  *fConn{nullptr};                // connection to Oracle
+   oracle::occi::Statement   *fStmt{nullptr};                // executed statement
+   oracle::occi::ResultSet   *fResult{nullptr};              // query result (rows)
+   std::vector<oracle::occi::MetaData> *fFieldInfo{nullptr}; // info for each field in the row
+   TBufferRec            *fBuffer{nullptr};                  // buffer of values and field names
+   Int_t                  fBufferSize{0};                    // size of fBuffer
+   Int_t                  fNumIterations{0};                 // size of internal statement buffer
+   Int_t                  fIterCounter{0};                   //counts nextiteration calls and process iterations, if required
+   Int_t                  fWorkingMode{0};                   // 1 - settingpars, 2 - getting results
+   TString                fTimeFmt;                          // format for date to string conversion, default "MM/DD/YYYY, HH24:MI:SS"
 
    Bool_t      IsParSettMode() const { return fWorkingMode==1; }
    Bool_t      IsResultSet() const { return (fWorkingMode==2) && (fResult!=0); }
@@ -64,66 +64,69 @@ public:
                     Int_t niter, Bool_t errout = kTRUE);
    virtual ~TOracleStatement();
 
-   virtual void        Close(Option_t * = "");
+   TOracleStatement(const TOracleStatement &) = delete;
+   TOracleStatement& operator=(const TOracleStatement &) = delete;
 
-   virtual Int_t       GetBufferLength() const { return fNumIterations; }
-   virtual Int_t       GetNumParameters();
+   virtual     void        Close(Option_t * = "");
 
-   virtual Bool_t      SetNull(Int_t npar);
-   virtual Bool_t      SetInt(Int_t npar, Int_t value);
-   virtual Bool_t      SetUInt(Int_t npar, UInt_t value);
-   virtual Bool_t      SetLong(Int_t npar, Long_t value);
-   virtual Bool_t      SetLong64(Int_t npar, Long64_t value);
-   virtual Bool_t      SetULong64(Int_t npar, ULong64_t value);
-   virtual Bool_t      SetDouble(Int_t npar, Double_t value);
-   virtual Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256);
-   virtual Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000);
-   virtual Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day);
-   virtual Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec);
-   virtual Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec);
+   Int_t       GetBufferLength() const final { return fNumIterations; }
+   Int_t       GetNumParameters() final;
+
+   Bool_t      SetNull(Int_t npar) final;
+   Bool_t      SetInt(Int_t npar, Int_t value) final;
+   Bool_t      SetUInt(Int_t npar, UInt_t value) final;
+   Bool_t      SetLong(Int_t npar, Long_t value) final;
+   Bool_t      SetLong64(Int_t npar, Long64_t value) final;
+   Bool_t      SetULong64(Int_t npar, ULong64_t value) final;
+   Bool_t      SetDouble(Int_t npar, Double_t value) final;
+   Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256) final;
+   Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000) final;
+   Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day) final;
+   Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec) final;
+   Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec) final;
    using TSQLStatement::SetTimestamp;
-   virtual Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0);
-   virtual void        SetTimeFormating(const char* fmt) { fTimeFmt = fmt; }
-   virtual Bool_t      SetVInt(Int_t npar, const std::vector<Int_t> value, const char* schemaName, const char* typeName);
-   virtual Bool_t      SetVUInt(Int_t npar, const std::vector<UInt_t> value, const char* schemaName, const char* typeName);
-   virtual Bool_t      SetVLong(Int_t npar, const std::vector<Long_t> value, const char* schemaName, const char* typeName);
-   virtual Bool_t      SetVLong64(Int_t npar, const std::vector<Long64_t> value, const char* schemaName, const char* typeName);
-   virtual Bool_t      SetVULong64(Int_t npar, const std::vector<ULong64_t> value, const char* schemaName, const char* typeName);
-   virtual Bool_t      SetVDouble(Int_t npar, const std::vector<Double_t> value, const char* schemaName, const char* typeName);
+   Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0) final;
+   void        SetTimeFormating(const char *fmt) final { fTimeFmt = fmt; }
+   Bool_t      SetVInt(Int_t npar, const std::vector<Int_t> value, const char* schemaName, const char* typeName) final;
+   Bool_t      SetVUInt(Int_t npar, const std::vector<UInt_t> value, const char* schemaName, const char* typeName) final;
+   Bool_t      SetVLong(Int_t npar, const std::vector<Long_t> value, const char* schemaName, const char* typeName) final;
+   Bool_t      SetVLong64(Int_t npar, const std::vector<Long64_t> value, const char* schemaName, const char* typeName) final;
+   Bool_t      SetVULong64(Int_t npar, const std::vector<ULong64_t> value, const char* schemaName, const char* typeName) final;
+   Bool_t      SetVDouble(Int_t npar, const std::vector<Double_t> value, const char* schemaName, const char* typeName) final;
 
-   virtual Bool_t      NextIteration();
+   Bool_t      NextIteration() final;
 
-   virtual Bool_t      Process();
-   virtual Int_t       GetNumAffectedRows();
+   Bool_t      Process() final;
+   Int_t       GetNumAffectedRows() final;
 
-   virtual Bool_t      StoreResult();
-   virtual Int_t       GetNumFields();
-   virtual const char *GetFieldName(Int_t nfield);
-   virtual Bool_t      SetMaxFieldSize(Int_t nfield, Long_t maxsize);
-   virtual Bool_t      NextResultRow();
+   Bool_t      StoreResult() final;
+   Int_t       GetNumFields() final;
+   const char *GetFieldName(Int_t nfield) final;
+   Bool_t      SetMaxFieldSize(Int_t nfield, Long_t maxsize) final;
+   Bool_t      NextResultRow() final;
 
-   virtual Bool_t      IsNull(Int_t);
-   virtual Int_t       GetInt(Int_t npar);
-   virtual UInt_t      GetUInt(Int_t npar);
-   virtual Long_t      GetLong(Int_t npar);
-   virtual Long64_t    GetLong64(Int_t npar);
-   virtual ULong64_t   GetULong64(Int_t npar);
-   virtual Double_t    GetDouble(Int_t npar);
-   virtual const char *GetString(Int_t npar);
-   virtual Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size);
-   virtual Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day);
-   virtual Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec);
-   virtual Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec);
+   Bool_t      IsNull(Int_t) final;
+   Int_t       GetInt(Int_t npar) final;
+   UInt_t      GetUInt(Int_t npar) final;
+   Long_t      GetLong(Int_t npar) final;
+   Long64_t    GetLong64(Int_t npar) final;
+   ULong64_t   GetULong64(Int_t npar) final;
+   Double_t    GetDouble(Int_t npar) final;
+   const char *GetString(Int_t npar) final;
+   Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size) final;
+   Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day) final;
+   Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec) final;
+   Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec) final;
    using TSQLStatement::GetTimestamp;
-   virtual Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t& frac);
-   virtual Bool_t      GetVInt(Int_t npar, std::vector<Int_t> &value);
-   virtual Bool_t      GetVUInt(Int_t npar, std::vector<UInt_t> &value);
-   virtual Bool_t      GetVLong(Int_t npar, std::vector<Long_t> &value);
-   virtual Bool_t      GetVLong64(Int_t npar, std::vector<Long64_t> &value);
-   virtual Bool_t      GetVULong64(Int_t npar, std::vector<ULong64_t> &value);
-   virtual Bool_t      GetVDouble(Int_t npar, std::vector<Double_t> &value);
+   Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t& frac) final;
+   Bool_t      GetVInt(Int_t npar, std::vector<Int_t> &value) final;
+   Bool_t      GetVUInt(Int_t npar, std::vector<UInt_t> &value) final;
+   Bool_t      GetVLong(Int_t npar, std::vector<Long_t> &value) final;
+   Bool_t      GetVLong64(Int_t npar, std::vector<Long64_t> &value) final;
+   Bool_t      GetVULong64(Int_t npar, std::vector<ULong64_t> &value) final;
+   Bool_t      GetVDouble(Int_t npar, std::vector<Double_t> &value) final;
 
-   ClassDef(TOracleStatement, 0); // SQL statement class for Oracle
+   ClassDefOverride(TOracleStatement, 0); // SQL statement class for Oracle
 };
 
 #endif

--- a/sql/oracle/inc/TOracleStatement.h
+++ b/sql/oracle/inc/TOracleStatement.h
@@ -67,7 +67,7 @@ public:
    TOracleStatement(const TOracleStatement &) = delete;
    TOracleStatement& operator=(const TOracleStatement &) = delete;
 
-   virtual     void        Close(Option_t * = "");
+   void        Close(Option_t * = "") final;
 
    Int_t       GetBufferLength() const final { return fNumIterations; }
    Int_t       GetNumParameters() final;

--- a/sql/oracle/inc/TOracleStatement.h
+++ b/sql/oracle/inc/TOracleStatement.h
@@ -35,8 +35,8 @@ protected:
 
    struct TBufferRec {
       char* strbuf{nullptr};
-      Long_t strbufsize{0};
-      char* namebuf{nullptr};
+      Long_t strbufsize{-1};
+      std::string namebuf;
    };
 
    oracle::occi::Environment *fEnv{nullptr};                 // environment

--- a/sql/oracle/inc/TOracleStatement.h
+++ b/sql/oracle/inc/TOracleStatement.h
@@ -34,8 +34,8 @@ class TOracleStatement : public TSQLStatement {
 protected:
 
    struct TBufferRec {
-      char* strbuf{nullptr};
-      Long_t strbufsize{-1};
+      void *membuf{nullptr};
+      Long_t bufsize{-1};
       std::string namebuf;
    };
 

--- a/sql/oracle/src/TOracleResult.cxx
+++ b/sql/oracle/src/TOracleResult.cxx
@@ -52,11 +52,11 @@ void TOracleResult::initResultSet(Statement *stmt)
 TOracleResult::TOracleResult(Connection *conn, Statement *stmt)
 {
    fConn        = conn;
-   fResult      = 0;
-   fStmt        = 0;
-   fPool        = 0;
+   fResult      = nullptr;
+   fStmt        = nullptr;
+   fPool        = nullptr;
    fRowCount    = 0;
-   fFieldInfo   = 0;
+   fFieldInfo   = nullptr;
    fResultType  = 0;
    fUpdateCount = 0;
 
@@ -70,12 +70,12 @@ TOracleResult::TOracleResult(Connection *conn, Statement *stmt)
 
 TOracleResult::TOracleResult(Connection *conn, const char *tableName)
 {
-   fResult      = 0;
-   fStmt        = 0;
-   fConn        = 0;
-   fPool        = 0;
+   fResult      = nullptr;
+   fStmt        = nullptr;
+   fConn        = nullptr;
+   fPool        = nullptr;
    fRowCount    = 0;
-   fFieldInfo   = 0;
+   fFieldInfo   = nullptr;
    fResultType  = 0;
    fUpdateCount = 0;
    fFieldCount  = 0;
@@ -118,10 +118,10 @@ void TOracleResult::Close(Option_t *)
 
    fResultType = 0;
 
-   fStmt = 0;
-   fResult = 0;
-   fFieldInfo = 0;
-   fPool = 0;
+   fStmt = nullptr;
+   fResult = nullptr;
+   fFieldInfo = nullptr;
+   fPool = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -150,7 +150,7 @@ Int_t TOracleResult::GetFieldCount()
 const char *TOracleResult::GetFieldName(Int_t field)
 {
    if (!IsValid(field))
-      return 0;
+      return nullptr;
    fNameBuffer = (*fFieldInfo)[field].getString(MetaData::ATTR_NAME);
    return fNameBuffer.c_str();
 }
@@ -180,7 +180,7 @@ TSQLRow *TOracleResult::Next()
       Error("Next", "%s", (oraex.getMessage()).c_str());
       MakeZombie();
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -189,7 +189,7 @@ Int_t TOracleResult::GetRowCount() const
 {
    if (!fResult) return 0;
 
-   if (fPool==0) ((TOracleResult*) this)->ProducePool();
+   if (!fPool) ((TOracleResult*) this)->ProducePool();
 
    return fRowCount;
 }
@@ -198,11 +198,11 @@ Int_t TOracleResult::GetRowCount() const
 
 void TOracleResult::ProducePool()
 {
-   if (fPool!=0) return;
+   if (fPool) return;
 
    TList* pool = new TList;
-   TSQLRow* res = 0;
-   while ((res = Next()) !=0) {
+   TSQLRow* res = nullptr;
+   while ((res = Next()) != nullptr) {
       pool->Add(res);
    }
 

--- a/sql/oracle/src/TOracleRow.cxx
+++ b/sql/oracle/src/TOracleRow.cxx
@@ -29,7 +29,7 @@ TOracleRow::TOracleRow(ResultSet *rs, vector<MetaData> *fieldMetaData)
    fFieldInfo   = fieldMetaData;
    fFieldCount  = fFieldInfo->size();
 
-   fFieldsBuffer = 0;
+   fFieldsBuffer = nullptr;
 
    GetRowData();
 }
@@ -47,15 +47,17 @@ TOracleRow::~TOracleRow()
 
 void TOracleRow::Close(Option_t *)
 {
-   if (fFieldsBuffer!=0) {
+   if (fFieldsBuffer) {
       for (int n=0;n<fFieldCount;n++)
-        if (fFieldsBuffer[n]) delete[] fFieldsBuffer[n];
-      delete[] fFieldsBuffer;
+        if (fFieldsBuffer[n])
+           delete[] fFieldsBuffer[n];
+      delete [] fFieldsBuffer;
    }
 
-   fFieldInfo   = 0;
+   fFieldsBuffer = nullptr;
+   fFieldInfo   = nullptr;
    fFieldCount  = 0;
-   fResult      = 0;
+   fResult      = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -93,10 +95,10 @@ const char* TOracleRow::GetField(Int_t field)
 {
    if ((field<0) || (field>=fFieldCount)) {
       Error("TOracleRow","GetField(): out-of-range or No RowData/ResultSet/MetaData");
-      return 0;
+      return nullptr;
    }
 
-   return fFieldsBuffer ? fFieldsBuffer[field] : 0;
+   return fFieldsBuffer ? fFieldsBuffer[field] : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sql/oracle/src/TOracleServer.cxx
+++ b/sql/oracle/src/TOracleServer.cxx
@@ -85,9 +85,6 @@ const char* TOracleServer::fgDatimeFormat = "MM/DD/YYYY, HH24:MI:SS";
 
 TOracleServer::TOracleServer(const char *db, const char *uid, const char *pw)
 {
-   fEnv = 0;
-   fConn = 0;
-
    if (gDebug>0) {
       // this code is necessary to guarantee, that libclntsh.so will be
       // linked to libOracle.so.
@@ -114,7 +111,7 @@ TOracleServer::TOracleServer(const char *db, const char *uid, const char *pw)
    }
 
    const char *conn_str = url.GetFile();
-   if (conn_str!=0)
+   if (conn_str)
      if (*conn_str == '/') conn_str++; //skip leading "/" if appears
 
    try {
@@ -176,7 +173,7 @@ TSQLStatement *TOracleServer::Statement(const char *sql, Int_t niter)
 
    if (!sql || !*sql) {
       SetError(-1, "no query string specified","Statement");
-      return 0;
+      return nullptr;
    }
 
    try {
@@ -188,7 +185,7 @@ TSQLStatement *TOracleServer::Statement(const char *sql, Int_t niter)
 
    } CatchError("Statement")
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -201,15 +198,15 @@ TSQLResult *TOracleServer::Query(const char *sql)
 
    if (!sql || !*sql) {
       SetError(-1, "no query string specified","Query");
-      return 0;
+      return nullptr;
    }
 
    try {
       oracle::occi::Statement *stmt = fConn->createStatement();
 
       // NOTE: before special COUNT query was executed to define number of
-      // rows in result set. Now it is not requried, while TOracleResult class
-      // will automatically fetch all rows from resultset when
+      // rows in result set. Now it is not required, while TOracleResult class
+      // will automatically fetch all rows from result set when
       // GetRowCount() will be called first time.
       // It is better do not use GetRowCount() to avoid unnecessary memory usage.
 
@@ -222,11 +219,11 @@ TSQLResult *TOracleServer::Query(const char *sql)
       return res;
    } CatchError("Query")
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Execute sql command wich does not produce any result set.
+/// Execute sql command which does not produce any result set.
 /// Return kTRUE if successful
 
 Bool_t TOracleServer::Exec(const char* sql)
@@ -238,7 +235,7 @@ Bool_t TOracleServer::Exec(const char* sql)
       return kFALSE;
    }
 
-   oracle::occi::Statement *stmt = 0;
+   oracle::occi::Statement *stmt = nullptr;
 
    Bool_t res = kFALSE;
 
@@ -290,16 +287,16 @@ TList* TOracleServer::GetTablesList(const char* wild)
       cmd+=Form(" WHERE table_name LIKE '%s'", wild);
 
    TSQLStatement* stmt = Statement(cmd);
-   if (stmt==0) return 0;
+   if (!stmt) return nullptr;
 
-   TList* lst = 0;
+   TList *lst = nullptr;
 
    if (stmt->Process()) {
       stmt->StoreResult();
       while (stmt->NextResultRow()) {
          const char* tablename = stmt->GetString(0);
-         if (tablename==0) continue;
-         if (lst==0) {
+         if (!tablename) continue;
+         if (!lst) {
             lst = new TList;
             lst->SetOwner(kTRUE);
          }
@@ -320,7 +317,7 @@ TSQLTableInfo *TOracleServer::GetTableInfo(const char* tablename)
 {
    CheckConnect("GetTableInfo",0);
 
-   if ((tablename==0) || (*tablename==0)) return 0;
+   if (!tablename || (*tablename==0)) return nullptr;
 
    TString table(tablename);
    table.ToUpper();
@@ -328,14 +325,14 @@ TSQLTableInfo *TOracleServer::GetTableInfo(const char* tablename)
    sql.Form("SELECT COLUMN_NAME, DATA_TYPE, DATA_LENGTH, DATA_PRECISION, DATA_SCALE, NULLABLE, CHAR_COL_DECL_LENGTH FROM user_tab_columns WHERE table_name = '%s' ORDER BY COLUMN_ID", table.Data());
 
    TSQLStatement* stmt = Statement(sql.Data(), 10);
-   if (stmt==0) return 0;
+   if (!stmt) return nullptr;
 
    if (!stmt->Process()) {
       delete stmt;
-      return 0;
+      return nullptr;
    }
 
-   TList* lst = 0;
+   TList *lst = nullptr;
 
    stmt->StoreResult();
 
@@ -421,7 +418,7 @@ TSQLTableInfo *TOracleServer::GetTableInfo(const char* tablename)
                             data_scale,
                             data_sign);
 
-      if (lst==0) lst = new TList;
+      if (!lst) lst = new TList;
       lst->Add(info);
    }
 
@@ -444,7 +441,7 @@ TSQLResult *TOracleServer::GetColumns(const char * /*dbname*/, const char *table
 //  make no sense, while method is not implemented
 //   if (SelectDataBase(dbname) != 0) {
 //      SetError(-1, "Database is not connected","GetColumns");
-//      return 0;
+//      return nullptr;
 //   }
 
    TString sql;
@@ -480,7 +477,7 @@ TSQLResult *TOracleServer::GetDataBases(const char * /*wild*/)
 {
    CheckConnect("GetDataBases",0);
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sql/oracle/src/TOracleStatement.cxx
+++ b/sql/oracle/src/TOracleStatement.cxx
@@ -39,13 +39,7 @@ TOracleStatement::TOracleStatement(Environment* env, Connection* conn, Statement
    fEnv(env),
    fConn(conn),
    fStmt(stmt),
-   fResult(0),
-   fFieldInfo(0),
-   fBuffer(0),
-   fBufferSize(0),
    fNumIterations(niter),
-   fIterCounter(0),
-   fWorkingMode(0),
    fTimeFmt(TOracleServer::GetDatimeFormat())
 {
    if (fStmt) {
@@ -81,11 +75,11 @@ void TOracleStatement::Close(Option_t *)
 
    CloseBuffer();
 
-   fConn = 0;
-   fStmt = 0;
-   fResult = 0;
-   fFieldInfo = 0;
-   fIterCounter = 0;
+   fConn = nullptr;
+   fStmt =  nullptr;
+   fResult = nullptr;
+   fFieldInfo = nullptr;
+   fIterCounter = nullptr;
 }
 
 // Check that statement is ready for use

--- a/sql/oracle/src/TOracleStatement.cxx
+++ b/sql/oracle/src/TOracleStatement.cxx
@@ -134,8 +134,8 @@ void TOracleStatement::SetBufferSize(Int_t size)
     fBufferSize = size;
     fBuffer = new TBufferRec[size];
     for (Int_t n=0;n<fBufferSize;n++) {
-       fBuffer[n].strbuf = nullptr;
-       fBuffer[n].strbufsize = -1;
+       fBuffer[n].membuf = nullptr;
+       fBuffer[n].bufsize = -1;
     }
 }
 
@@ -146,12 +146,13 @@ void TOracleStatement::CloseBuffer()
 {
    if (fBuffer) {
       for (Int_t n=0;n<fBufferSize;n++) {
-         delete[] fBuffer[n].strbuf;
+         if (fBuffer[n].membuf)
+            free(fBuffer[n].membuf);
       }
 
       delete[] fBuffer;
    }
-   fBuffer = 0;
+   fBuffer = nullptr;
    fBufferSize = 0;
 }
 
@@ -684,10 +685,11 @@ Bool_t TOracleStatement::NextResultRow()
 
    try {
       for (int n=0;n<fBufferSize;n++) {
-        if (fBuffer[n].strbuf)
-           delete[] fBuffer[n].strbuf;
-        fBuffer[n].strbuf = 0;
-        fBuffer[n].strbufsize = -1;
+        if (fBuffer[n].membuf) {
+           free(fBuffer[n].membuf);
+           fBuffer[n].membuf = nullptr;
+        }
+        fBuffer[n].bufsize = -1;
       }
       if (fResult->next() == oracle::occi::ResultSet::END_OF_FETCH) {
          fWorkingMode = 0;
@@ -844,7 +846,8 @@ const char* TOracleStatement::GetString(Int_t npar)
 {
    CheckGetField("GetString", 0);
 
-   if (fBuffer[npar].strbuf!=0) return fBuffer[npar].strbuf;
+   if (fBuffer[npar].membuf)
+      return (const char *) fBuffer[npar].membuf;
 
    try {
       if (fResult->isNull(npar+1)) return 0;
@@ -889,13 +892,13 @@ const char* TOracleStatement::GetString(Int_t npar)
 
       int len = res.length();
 
-      if (len>0) {
-          fBuffer[npar].strbuf = new char[len+1];
-          fBuffer[npar].strbufsize = len+1;
-          strcpy(fBuffer[npar].strbuf, res.c_str());
+      if (len > 0) {
+          fBuffer[npar].membuf = malloc(len+1);
+          fBuffer[npar].bufsize = len+1;
+          strncpy((char *) fBuffer[npar].membuf, res.c_str(), len+1);
       }
 
-      return fBuffer[npar].strbuf;
+      return (const char *)fBuffer[npar].membuf;
 
    } catch (SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetString");
@@ -917,9 +920,9 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
 
    CheckGetField("GetBinary", kFALSE);
 
-   if (fBuffer[npar].strbufsize>=0) {
-      mem = fBuffer[npar].strbuf;
-      size = fBuffer[npar].strbufsize;
+   if (fBuffer[npar].bufsize >= 0) {
+      mem = fBuffer[npar].membuf;
+      size = fBuffer[npar].bufsize;
       return kTRUE;
    }
 
@@ -934,14 +937,14 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
 
             size = parbytes.length();
 
-            fBuffer[npar].strbufsize = size;
+            fBuffer[npar].bufsize = size;
 
-            if (size>0) {
+            if (size > 0) {
                mem = malloc(size);
 
-               fBuffer[npar].strbuf = (char*) mem;
+               fBuffer[npar].membuf = mem;
 
-               parbytes.getBytes((unsigned char*) mem, size);
+               parbytes.getBytes((unsigned char *) mem, size);
             }
 
             break;
@@ -952,14 +955,14 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
 
             size = parblob.length();
 
-            fBuffer[npar].strbufsize = size;
+            fBuffer[npar].bufsize = size;
 
-            if (size>0) {
+            if (size > 0) {
                mem = malloc(size);
 
-               fBuffer[npar].strbuf = (char*) mem;
+               fBuffer[npar].membuf = mem;
 
-               parblob.read(size, (unsigned char*) mem, size);
+               parblob.read(size, (unsigned char *) mem, size);
             }
 
             break;
@@ -970,14 +973,14 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
 
             size = parclob.length();
 
-            fBuffer[npar].strbufsize = size;
+            fBuffer[npar].bufsize = size;
 
-            if (size>0) {
+            if (size > 0) {
                mem = malloc(size);
 
-               fBuffer[npar].strbuf = (char*) mem;
+               fBuffer[npar].membuf = mem;
 
-               parclob.read(size, (unsigned char*) mem, size);
+               parclob.read(size, (unsigned char *) mem, size);
             }
 
             break;
@@ -990,14 +993,14 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
 
             size = parbfile.length();
 
-            fBuffer[npar].strbufsize = size;
+            fBuffer[npar].bufsize = size;
 
             if (size>0) {
                mem = malloc(size);
 
-               fBuffer[npar].strbuf = (char*) mem;
+               fBuffer[npar].membuf = mem;
 
-               parbfile.read(size, (unsigned char*) mem, size);
+               parbfile.read(size, (unsigned char *) mem, size);
             }
 
             break;

--- a/sql/pgsql/inc/TPgSQLResult.h
+++ b/sql/pgsql/inc/TPgSQLResult.h
@@ -24,8 +24,8 @@ struct PGresult;
 class TPgSQLResult : public TSQLResult {
 
 private:
-   PGresult   *fResult;      // query result (rows)
-   ULong_t     fCurrentRow;  // info to result row
+   PGresult   *fResult{nullptr};      // query result (rows)
+   ULong_t     fCurrentRow{0};        // info to result row
 
    Bool_t  IsValid(Int_t field);
 
@@ -33,12 +33,12 @@ public:
    TPgSQLResult(void *result);
    ~TPgSQLResult();
 
-   void        Close(Option_t *opt="");
-   Int_t       GetFieldCount();
-   const char *GetFieldName(Int_t field);
-   TSQLRow    *Next();
+   void        Close(Option_t *opt="") final;
+   Int_t       GetFieldCount() final;
+   const char *GetFieldName(Int_t field) final;
+   TSQLRow    *Next() final;
 
-   ClassDef(TPgSQLResult, 0)  // PgSQL query result
+   ClassDefOverride(TPgSQLResult, 0)  // PgSQL query result
 };
 
 #endif

--- a/sql/pgsql/inc/TPgSQLRow.h
+++ b/sql/pgsql/inc/TPgSQLRow.h
@@ -25,8 +25,8 @@ typedef char **PGresAttValue;
 class TPgSQLRow : public TSQLRow {
 
 private:
-   PGresult *fResult;       // current result set
-   ULong_t   fRowNum;       // row number
+   PGresult *fResult{nullptr};       // current result set
+   ULong_t   fRowNum{0};       // row number
 
    Bool_t  IsValid(Int_t field);
 
@@ -34,11 +34,11 @@ public:
    TPgSQLRow(void *result, ULong_t rowHandle);
    ~TPgSQLRow();
 
-   void        Close(Option_t *opt="");
-   ULong_t     GetFieldLength(Int_t field);
-   const char *GetField(Int_t field);
+   void        Close(Option_t *opt="") final;
+   ULong_t     GetFieldLength(Int_t field) final;
+   const char *GetField(Int_t field) final;
 
-   ClassDef(TPgSQLRow,0)  // One row of PgSQL query result
+   ClassDefOverride(TPgSQLRow,0)  // One row of PgSQL query result
 };
 
 #endif

--- a/sql/pgsql/inc/TPgSQLServer.h
+++ b/sql/pgsql/inc/TPgSQLServer.h
@@ -24,33 +24,32 @@ struct PGconn;
 #endif
 
 
-
 class TPgSQLServer : public TSQLServer {
 
 private:
-   PGconn  *fPgSQL;    // connection to PgSQL server
+   PGconn  *fPgSQL{nullptr};    // connection to PgSQL server
    TString  fSrvInfo;  // Server info
    std::map<Int_t,std::string> fOidTypNameMap; // Map of oid to typname, used in GetTableInfo()
 public:
    TPgSQLServer(const char *db, const char *uid, const char *pw);
    ~TPgSQLServer();
 
-   void           Close(Option_t *opt="");
-   TSQLResult    *Query(const char *sql);
-   TSQLStatement *Statement(const char *sql, Int_t = 100);
-   Bool_t         HasStatement() const;
-   Int_t          SelectDataBase(const char *dbname);
-   TSQLResult    *GetDataBases(const char *wild = 0);
-   TSQLResult    *GetTables(const char *dbname, const char *wild = 0);
-   TSQLResult    *GetColumns(const char *dbname, const char *table, const char *wild = 0);
-   TSQLTableInfo *GetTableInfo(const char* tablename);
-   Int_t          CreateDataBase(const char *dbname);
-   Int_t          DropDataBase(const char *dbname);
-   Int_t          Reload();
-   Int_t          Shutdown();
-   const char    *ServerInfo();
+   void           Close(Option_t *opt="") final;
+   TSQLResult    *Query(const char *sql) final;
+   TSQLStatement *Statement(const char *sql, Int_t = 100) final;
+   Bool_t         HasStatement() const final;
+   Int_t          SelectDataBase(const char *dbname) final;
+   TSQLResult    *GetDataBases(const char *wild = nullptr) final;
+   TSQLResult    *GetTables(const char *dbname, const char *wild = nullptr) final;
+   TSQLResult    *GetColumns(const char *dbname, const char *table, const char *wild = nullptr) final;
+   TSQLTableInfo *GetTableInfo(const char* tablename) final;
+   Int_t          CreateDataBase(const char *dbname) final;
+   Int_t          DropDataBase(const char *dbname) final;
+   Int_t          Reload() final;
+   Int_t          Shutdown() final;
+   const char    *ServerInfo() final;
 
-   ClassDef(TPgSQLServer,0)  // Connection to PgSQL server
+   ClassDefOverride(TPgSQLServer,0)  // Connection to PgSQL server
 };
 
 #endif

--- a/sql/pgsql/inc/TPgSQLStatement.h
+++ b/sql/pgsql/inc/TPgSQLStatement.h
@@ -30,16 +30,16 @@ struct PgSQL_Stmt_t {
 class TPgSQLStatement : public TSQLStatement {
 
 private:
-   PgSQL_Stmt_t         *fStmt;          //! executed statement
-   Int_t                 fNumBuffers;    //! number of statement parameters
-   char                **fBind;          //! array of data for input
-   char                **fFieldName;     //! array of column names
-   Int_t                 fWorkingMode;   //! 1 - setting parameters, 2 - retrieving results
-   Int_t                 fIterationCount;//! number of iteration
-   int                  *fParamLengths;  //! length of column
-   int                  *fParamFormats;  //! data type (OID)
-   Int_t                 fNumResultRows;
-   Int_t                 fNumResultCols;
+   PgSQL_Stmt_t         *fStmt{nullptr};          //! executed statement
+   Int_t                 fNumBuffers{0};          //! number of statement parameters
+   char                **fBind{nullptr};          //! array of data for input
+   char                **fFieldName{nullptr};     //! array of column names
+   Int_t                 fWorkingMode{0};         //! 1 - setting parameters, 2 - retrieving results
+   Int_t                 fIterationCount{0};      //! number of iteration
+   int                  *fParamLengths{nullptr};  //! length of column
+   int                  *fParamFormats{nullptr};  //! data type (OID)
+   Int_t                 fNumResultRows{0};
+   Int_t                 fNumResultCols{0};
 
    Bool_t      IsSetParsMode() const { return fWorkingMode==1; }
    Bool_t      IsResultSetMode() const { return fWorkingMode==2; }
@@ -58,54 +58,54 @@ public:
    TPgSQLStatement(PgSQL_Stmt_t* stmt, Bool_t errout = kTRUE);
    virtual ~TPgSQLStatement();
 
-   virtual void        Close(Option_t * = "");
+   void        Close(Option_t * = "") final;
 
-   virtual Int_t       GetBufferLength() const { return 1; }
-   virtual Int_t       GetNumParameters();
+   Int_t       GetBufferLength() const final { return 1; }
+   Int_t       GetNumParameters() final;
 
-   virtual Bool_t      SetNull(Int_t npar);
-   virtual Bool_t      SetInt(Int_t npar, Int_t value);
-   virtual Bool_t      SetUInt(Int_t npar, UInt_t value);
-   virtual Bool_t      SetLong(Int_t npar, Long_t value);
-   virtual Bool_t      SetLong64(Int_t npar, Long64_t value);
-   virtual Bool_t      SetULong64(Int_t npar, ULong64_t value);
-   virtual Bool_t      SetDouble(Int_t npar, Double_t value);
-   virtual Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256);
-   virtual Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000);
-   virtual Bool_t      SetLargeObject(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000);
-   virtual Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day);
-   virtual Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec);
-   virtual Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec);
-   virtual Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0);
-   virtual Bool_t      SetTimestamp(Int_t npar, const TTimeStamp& tm);
+   Bool_t      SetNull(Int_t npar) final;
+   Bool_t      SetInt(Int_t npar, Int_t value) final;
+   Bool_t      SetUInt(Int_t npar, UInt_t value) final;
+   Bool_t      SetLong(Int_t npar, Long_t value) final;
+   Bool_t      SetLong64(Int_t npar, Long64_t value) final;
+   Bool_t      SetULong64(Int_t npar, ULong64_t value) final;
+   Bool_t      SetDouble(Int_t npar, Double_t value) final;
+   Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256) final;
+   Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000) final;
+   Bool_t      SetLargeObject(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000) final;
+   Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day) final;
+   Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec) final;
+   Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec) final;
+   Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0) final;
+   Bool_t      SetTimestamp(Int_t npar, const TTimeStamp& tm) final;
 
-   virtual Bool_t      NextIteration();
+   Bool_t      NextIteration() final;
 
-   virtual Bool_t      Process();
-   virtual Int_t       GetNumAffectedRows();
+   Bool_t      Process() final;
+   Int_t       GetNumAffectedRows() final;
 
-   virtual Bool_t      StoreResult();
-   virtual Int_t       GetNumFields();
-   virtual const char *GetFieldName(Int_t nfield);
-   virtual Bool_t      NextResultRow();
+   Bool_t      StoreResult() final;
+   Int_t       GetNumFields() final;
+   const char *GetFieldName(Int_t nfield) final;
+   Bool_t      NextResultRow() final;
 
-   virtual Bool_t      IsNull(Int_t npar);
-   virtual Int_t       GetInt(Int_t npar);
-   virtual UInt_t      GetUInt(Int_t npar);
-   virtual Long_t      GetLong(Int_t npar);
-   virtual Long64_t    GetLong64(Int_t npar);
-   virtual ULong64_t   GetULong64(Int_t npar);
-   virtual Double_t    GetDouble(Int_t npar);
-   virtual const char *GetString(Int_t npar);
-   virtual Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size);
-   virtual Bool_t      GetLargeObject(Int_t npar, void* &mem, Long_t& size);
-   virtual Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day);
-   virtual Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec);
-   virtual Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec);
-   virtual Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t&);
-   virtual Bool_t      GetTimestamp(Int_t npar, TTimeStamp& tm);
+   Bool_t      IsNull(Int_t npar) final;
+   Int_t       GetInt(Int_t npar) final;
+   UInt_t      GetUInt(Int_t npar) final;
+   Long_t      GetLong(Int_t npar) final;
+   Long64_t    GetLong64(Int_t npar) final;
+   ULong64_t   GetULong64(Int_t npar) final;
+   Double_t    GetDouble(Int_t npar) final;
+   const char *GetString(Int_t npar) final;
+   Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size) final;
+   Bool_t      GetLargeObject(Int_t npar, void* &mem, Long_t& size) final;
+   Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day) final;
+   Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec) final;
+   Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec) final;
+   Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t&) final;
+   Bool_t      GetTimestamp(Int_t npar, TTimeStamp& tm) final;
 
-   ClassDef(TPgSQLStatement, 0);  // SQL statement class for PgSQL DB
+   ClassDefOverride(TPgSQLStatement, 0);  // SQL statement class for PgSQL DB
 };
 
 #endif

--- a/sql/pgsql/src/TPgSQLStatement.cxx
+++ b/sql/pgsql/src/TPgSQLStatement.cxx
@@ -85,14 +85,14 @@ void TPgSQLStatement::Close(Option_t *)
    if (fStmt->fRes)
       PQclear(fStmt->fRes);
 
-   fStmt->fRes = 0;
+   fStmt->fRes = nullptr;
 
    PGresult *res=PQexec(fStmt->fConn,"DEALLOCATE preparedstmt;");
    PQclear(res);
 
    FreeBuffers();
    //TPgSQLServers responsibility to free connection
-   fStmt->fConn=0;
+   fStmt->fConn = nullptr;
    delete fStmt;
 }
 
@@ -312,11 +312,11 @@ void TPgSQLStatement::FreeBuffers()
    if (fParamFormats)
       delete [] fParamFormats;
 
-   fFieldName = 0;
-   fBind = 0;
+   fFieldName = nullptr;
+   fBind = nullptr;
    fNumBuffers = 0;
-   fParamLengths = 0;
-   fParamFormats = 0;
+   fParamLengths = nullptr;
+   fParamFormats = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sql/sqlite/inc/TSQLiteResult.h
+++ b/sql/sqlite/inc/TSQLiteResult.h
@@ -24,7 +24,7 @@ struct sqlite3_stmt;
 class TSQLiteResult : public TSQLResult {
 
 private:
-   sqlite3_stmt   *fResult;  // query result (rows)
+   sqlite3_stmt   *fResult{nullptr};  // query result (rows)
 
    Bool_t  IsValid(Int_t field);
 
@@ -32,13 +32,13 @@ public:
    TSQLiteResult(void *result);
    ~TSQLiteResult();
 
-   void        Close(Option_t *opt="");
-   Int_t       GetFieldCount();
-   const char *GetFieldName(Int_t field);
-   Int_t       GetRowCount() const;
-   TSQLRow    *Next();
+   void        Close(Option_t *opt="") final;
+   Int_t       GetFieldCount() final;
+   const char *GetFieldName(Int_t field) final;
+   Int_t       GetRowCount() const final;
+   TSQLRow    *Next() final;
 
-   ClassDef(TSQLiteResult, 0)  // SQLite query result
+   ClassDefOverride(TSQLiteResult, 0)  // SQLite query result
 };
 
 #endif

--- a/sql/sqlite/inc/TSQLiteRow.h
+++ b/sql/sqlite/inc/TSQLiteRow.h
@@ -19,18 +19,18 @@ struct sqlite3_stmt;
 class TSQLiteRow : public TSQLRow {
 
 private:
-   sqlite3_stmt *fResult;       // current result set
+   sqlite3_stmt *fResult{nullptr};       // current result set
    Bool_t        IsValid(Int_t field);
 
 public:
    TSQLiteRow(void *result, ULong_t rowHandle);
    ~TSQLiteRow();
 
-   void        Close(Option_t *opt="");
-   ULong_t     GetFieldLength(Int_t field);
-   const char *GetField(Int_t field);
+   void        Close(Option_t *opt="") final;
+   ULong_t     GetFieldLength(Int_t field) final;
+   const char *GetField(Int_t field) final;
 
-   ClassDef(TSQLiteRow,0)  // One row of SQLite query result
+   ClassDefOverride(TSQLiteRow,0)  // One row of SQLite query result
 };
 
 #endif

--- a/sql/sqlite/inc/TSQLiteServer.h
+++ b/sql/sqlite/inc/TSQLiteServer.h
@@ -20,36 +20,34 @@
 struct sqlite3;
 #endif
 
-
-
 class TSQLiteServer : public TSQLServer {
 
  private:
    TString   fSrvInfo;   // Server info string
-   sqlite3  *fSQLite;    // connection to SQLite DB
+   sqlite3  *fSQLite{nullptr};    // connection to SQLite DB
 
  public:
-   TSQLiteServer(const char *db, const char *uid=NULL, const char *pw=NULL);
+   TSQLiteServer(const char *db, const char *uid = nullptr, const char *pw = nullptr);
    ~TSQLiteServer();
 
-   void           Close(Option_t *opt="");
-   Bool_t         StartTransaction();
-   TSQLResult    *Query(const char *sql);
-   Bool_t         Exec(const char *sql);
-   TSQLStatement *Statement(const char *sql, Int_t = 100);
-   Bool_t         HasStatement() const;
-   Int_t          SelectDataBase(const char *dbname);
-   TSQLResult    *GetDataBases(const char *wild = 0);
-   TSQLResult    *GetTables(const char *dbname, const char *wild = 0);
-   TSQLResult    *GetColumns(const char *dbname, const char *table, const char *wild = 0);
-   TSQLTableInfo *GetTableInfo(const char* tablename);
-   Int_t          CreateDataBase(const char *dbname);
-   Int_t          DropDataBase(const char *dbname);
-   Int_t          Reload();
-   Int_t          Shutdown();
-   const char    *ServerInfo();
+   void           Close(Option_t *opt = "") final;
+   Bool_t         StartTransaction() final;
+   TSQLResult    *Query(const char *sql) final;
+   Bool_t         Exec(const char *sql) final;
+   TSQLStatement *Statement(const char *sql, Int_t = 100) final;
+   Bool_t         HasStatement() const final;
+   Int_t          SelectDataBase(const char *dbname) final;
+   TSQLResult    *GetDataBases(const char *wild = nullptr);
+   TSQLResult    *GetTables(const char *dbname, const char *wild = nullptr) final;
+   TSQLResult    *GetColumns(const char *dbname, const char *table, const char *wild = nullptr) final;
+   TSQLTableInfo *GetTableInfo(const char* tablename) final;
+   Int_t          CreateDataBase(const char *dbname) final;
+   Int_t          DropDataBase(const char *dbname) final;
+   Int_t          Reload() final;
+   Int_t          Shutdown() final;
+   const char    *ServerInfo() final;
 
-   ClassDef(TSQLiteServer,0);  // Connection to SQLite DB
+   ClassDefOverride(TSQLiteServer,0);  // Connection to SQLite DB
 };
 
 #endif

--- a/sql/sqlite/inc/TSQLiteServer.h
+++ b/sql/sqlite/inc/TSQLiteServer.h
@@ -37,7 +37,7 @@ class TSQLiteServer : public TSQLServer {
    TSQLStatement *Statement(const char *sql, Int_t = 100) final;
    Bool_t         HasStatement() const final;
    Int_t          SelectDataBase(const char *dbname) final;
-   TSQLResult    *GetDataBases(const char *wild = nullptr);
+   TSQLResult    *GetDataBases(const char *wild = nullptr) final;
    TSQLResult    *GetTables(const char *dbname, const char *wild = nullptr) final;
    TSQLResult    *GetColumns(const char *dbname, const char *table, const char *wild = nullptr) final;
    TSQLTableInfo *GetTableInfo(const char* tablename) final;

--- a/sql/sqlite/inc/TSQLiteStatement.h
+++ b/sql/sqlite/inc/TSQLiteStatement.h
@@ -25,10 +25,10 @@ struct SQLite3_Stmt_t {
 class TSQLiteStatement : public TSQLStatement {
 
 private:
-   SQLite3_Stmt_t       *fStmt;           //! executed statement
-   Int_t                 fWorkingMode;    //! 1 - setting parameters, 2 - retrieving results
-   Int_t                 fNumPars;        //! Number of bindable / gettable parameters
-   Int_t                 fIterationCount; //! Iteration count
+   SQLite3_Stmt_t       *fStmt{nullptr};     //! executed statement
+   Int_t                 fWorkingMode{0};    //! 1 - setting parameters, 2 - retrieving results
+   Int_t                 fNumPars{0};        //! Number of bindable / gettable parameters
+   Int_t                 fIterationCount{0}; //! Iteration count
 
    Bool_t      IsSetParsMode() const { return fWorkingMode==1; }
    Bool_t      IsResultSetMode() const { return fWorkingMode==2; }
@@ -44,52 +44,52 @@ public:
    TSQLiteStatement(SQLite3_Stmt_t* stmt, Bool_t errout = kTRUE);
    virtual ~TSQLiteStatement();
 
-   virtual void        Close(Option_t * = "");
+   void        Close(Option_t * = "") final;
 
-   virtual Int_t       GetBufferLength() const { return 1; }
-   virtual Int_t       GetNumParameters();
+   Int_t       GetBufferLength() const final { return 1; }
+   Int_t       GetNumParameters() final;
 
-   virtual Bool_t      SetNull(Int_t npar);
-   virtual Bool_t      SetInt(Int_t npar, Int_t value);
-   virtual Bool_t      SetUInt(Int_t npar, UInt_t value);
-   virtual Bool_t      SetLong(Int_t npar, Long_t value);
-   virtual Bool_t      SetLong64(Int_t npar, Long64_t value);
-   virtual Bool_t      SetULong64(Int_t npar, ULong64_t value);
-   virtual Bool_t      SetDouble(Int_t npar, Double_t value);
-   virtual Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256);
-   virtual Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000);
-   virtual Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day);
-   virtual Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec);
-   virtual Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec);
+   Bool_t      SetNull(Int_t npar) final;
+   Bool_t      SetInt(Int_t npar, Int_t value) final;
+   Bool_t      SetUInt(Int_t npar, UInt_t value) final;
+   Bool_t      SetLong(Int_t npar, Long_t value) final;
+   Bool_t      SetLong64(Int_t npar, Long64_t value) final;
+   Bool_t      SetULong64(Int_t npar, ULong64_t value) final;
+   Bool_t      SetDouble(Int_t npar, Double_t value) final;
+   Bool_t      SetString(Int_t npar, const char* value, Int_t maxsize = 256) final;
+   Bool_t      SetBinary(Int_t npar, void* mem, Long_t size, Long_t maxsize = 0x1000) final;
+   Bool_t      SetDate(Int_t npar, Int_t year, Int_t month, Int_t day) final;
+   Bool_t      SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec) final;
+   Bool_t      SetDatime(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec) final;
    using TSQLStatement::SetTimestamp;
-   virtual Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0);
+   Bool_t      SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t day, Int_t hour, Int_t min, Int_t sec, Int_t frac = 0) final;
 
-   virtual Bool_t      NextIteration();
+   Bool_t      NextIteration() final;
 
-   virtual Bool_t      Process();
-   virtual Int_t       GetNumAffectedRows();
+   Bool_t      Process() final;
+   Int_t       GetNumAffectedRows() final;
 
-   virtual Bool_t      StoreResult();
-   virtual Int_t       GetNumFields();
-   virtual const char *GetFieldName(Int_t nfield);
-   virtual Bool_t      NextResultRow();
+   Bool_t      StoreResult() final;
+   Int_t       GetNumFields() final;
+   const char *GetFieldName(Int_t nfield) final;
+   Bool_t      NextResultRow() final;
 
-   virtual Bool_t      IsNull(Int_t npar);
-   virtual Int_t       GetInt(Int_t npar);
-   virtual UInt_t      GetUInt(Int_t npar);
-   virtual Long_t      GetLong(Int_t npar);
-   virtual Long64_t    GetLong64(Int_t npar);
-   virtual ULong64_t   GetULong64(Int_t npar);
-   virtual Double_t    GetDouble(Int_t npar);
-   virtual const char *GetString(Int_t npar);
-   virtual Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size);
-   virtual Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day);
-   virtual Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec);
-   virtual Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec);
+   Bool_t      IsNull(Int_t npar) final;
+   Int_t       GetInt(Int_t npar) final;
+   UInt_t      GetUInt(Int_t npar) final;
+   Long_t      GetLong(Int_t npar) final;
+   Long64_t    GetLong64(Int_t npar) final;
+   ULong64_t   GetULong64(Int_t npar) final;
+   Double_t    GetDouble(Int_t npar) final;
+   const char *GetString(Int_t npar) final;
+   Bool_t      GetBinary(Int_t npar, void* &mem, Long_t& size) final;
+   Bool_t      GetDate(Int_t npar, Int_t& year, Int_t& month, Int_t& day) final;
+   Bool_t      GetTime(Int_t npar, Int_t& hour, Int_t& min, Int_t& sec) final;
+   Bool_t      GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec) final;
    using TSQLStatement::GetTimestamp;
-   virtual Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t&);
+   Bool_t      GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int_t& day, Int_t& hour, Int_t& min, Int_t& sec, Int_t&) final;
 
-   ClassDef(TSQLiteStatement, 0);  // SQL statement class for SQLite DB
+   ClassDefOverride(TSQLiteStatement, 0);  // SQL statement class for SQLite DB
 };
 
 #endif

--- a/sql/sqlite/src/TSQLiteResult.cxx
+++ b/sql/sqlite/src/TSQLiteResult.cxx
@@ -43,7 +43,7 @@ void TSQLiteResult::Close(Option_t *)
       return;
 
    sqlite3_finalize(fResult);
-   fResult     = 0;
+   fResult     = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -81,7 +81,7 @@ const char *TSQLiteResult::GetFieldName(Int_t field)
 {
    if (!fResult) {
       Error("GetFieldName", "result set closed");
-      return 0;
+      return nullptr;
    }
    return sqlite3_column_name(fResult, field);
 }
@@ -103,17 +103,17 @@ TSQLRow *TSQLiteResult::Next()
 {
    if (!fResult) {
       Error("Next", "result set closed");
-      return 0;
+      return nullptr;
    }
 
    int ret = sqlite3_step(fResult);
    if ((ret != SQLITE_DONE) && (ret != SQLITE_ROW)) {
       Error("Statement", "SQL Error: %d %s", ret, sqlite3_errmsg(sqlite3_db_handle(fResult)));
-      return NULL;
+      return nullptr;
    }
    if (ret == SQLITE_DONE) {
       // Finished executing, no other row!
-      return NULL;
+      return nullptr;
    }
    return new TSQLiteRow((void *) fResult, -1);
 }

--- a/sql/sqlite/src/TSQLiteRow.cxx
+++ b/sql/sqlite/src/TSQLiteRow.cxx
@@ -38,7 +38,7 @@ TSQLiteRow::~TSQLiteRow()
 
 void TSQLiteRow::Close(Option_t *)
 {
-   fResult = 0;
+   fResult = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -81,7 +81,7 @@ ULong_t TSQLiteRow::GetFieldLength(Int_t field)
 const char *TSQLiteRow::GetField(Int_t field)
 {
    if (!IsValid(field))
-      return 0;
+      return nullptr;
 
    return reinterpret_cast<const char*>(sqlite3_column_text(fResult, field));
 }

--- a/sql/sqlite/src/TSQLiteServer.cxx
+++ b/sql/sqlite/src/TSQLiteServer.cxx
@@ -30,7 +30,7 @@ ClassImp(TSQLiteServer);
 
 TSQLiteServer::TSQLiteServer(const char *db, const char* /*uid*/, const char* /*pw*/)
 {
-   fSQLite = NULL;
+   fSQLite = nullptr;
    fSrvInfo = "SQLite ";
    fSrvInfo += sqlite3_libversion();
 
@@ -91,7 +91,7 @@ void TSQLiteServer::Close(Option_t *)
       sqlite3_close(fSQLite);
       // Mark as disconnected:
       fPort = -1;
-      fSQLite = NULL;
+      fSQLite = nullptr;
    }
 }
 
@@ -116,7 +116,7 @@ TSQLResult *TSQLiteServer::Query(const char *sql)
       return 0;
    }
 
-   sqlite3_stmt *preparedStmt = NULL;
+   sqlite3_stmt *preparedStmt = nullptr;
 
    // -1 as we read until we encounter a \0.
    // NULL because we do not check which char was read last.
@@ -214,7 +214,7 @@ TSQLResult *TSQLiteServer::GetColumns(const char* /*dbname*/, const char* table,
 
    if (wild) {
       Error("GetColumns", "Not implementable for SQLite as a query with wildcard, use GetFieldNames() after SELECT instead!");
-      return NULL;
+      return nullptr;
    } else {
       TString sql = Form("PRAGMA table_info('%s')", table);
       return Query(sql);
@@ -232,21 +232,21 @@ TSQLTableInfo *TSQLiteServer::GetTableInfo(const char* tablename)
       return 0;
    }
 
-   if ((tablename==0) || (*tablename==0)) return 0;
+   if ((tablename==0) || (*tablename==0)) return nullptr;
 
    TSQLResult *columnRes = GetColumns("", tablename);
 
-   if (columnRes == NULL) {
+   if (columnRes == nullptr) {
       Error("GetTableInfo", "could not query columns");
-      return NULL;
+      return nullptr;
    }
 
-   TList* lst = NULL;
+   TList* lst = nullptr;
 
    TSQLRow *columnRow;
 
-   while ((columnRow = columnRes->Next()) != NULL) {
-      if (lst == NULL) {
+   while ((columnRow = columnRes->Next()) != nullptr) {
+      if (!lst) {
          lst = new TList();
       }
 
@@ -340,15 +340,15 @@ TSQLStatement* TSQLiteServer::Statement(const char *sql, Int_t)
 {
    if (!sql || !*sql) {
       SetError(-1, "no query string specified", "Statement");
-      return 0;
+      return nullptr;
    }
 
    if (!IsConnected()) {
       Error("Statement", "not connected");
-      return 0;
+      return nullptr;
    }
 
-   sqlite3_stmt *preparedStmt = NULL;
+   sqlite3_stmt *preparedStmt = nullptr;
 
    // -1 as we read until we encounter a \0.
    // NULL because we do not check which char was read last.
@@ -359,7 +359,7 @@ TSQLStatement* TSQLiteServer::Statement(const char *sql, Int_t)
 #endif
    if (retVal != SQLITE_OK) {
       Error("Statement", "SQL Error: %d %s", retVal, sqlite3_errmsg(fSQLite));
-      return 0;
+      return nullptr;
    }
 
    SQLite3_Stmt_t *stmt = new SQLite3_Stmt_t;

--- a/sql/sqlite/src/TSQLiteStatement.cxx
+++ b/sql/sqlite/src/TSQLiteStatement.cxx
@@ -66,8 +66,8 @@ void TSQLiteStatement::Close(Option_t *)
       sqlite3_finalize(fStmt->fRes);
    }
 
-   fStmt->fRes = 0;
-   fStmt->fConn = 0;
+   fStmt->fRes = nullptr;
+   fStmt->fConn = nullptr;
    delete fStmt;
 }
 
@@ -224,7 +224,7 @@ Bool_t TSQLiteStatement::NextResultRow()
 {
    ClearError();
 
-   if ((fStmt == 0) || !IsResultSetMode()) return kFALSE;
+   if (!fStmt || !IsResultSetMode()) return kFALSE;
 
    if (fIterationCount == 0) {
       // The interface says user should call NextResultRow() before getting any data,


### PR DESCRIPTION
When calling TOracleStatement::GetBinary() function, memory was
allocated with `malloc(len)` operator, but released with `delete [] buf`
Definitely wrong. Nobody was using it before - or clib was doing
something wrong

Adjust Oracle/MySQL/SQLite/ODBC/PgSQL classes to c++11.