### PR TITLE
[code] Add missing #include to operator+= probe

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -520,10 +520,12 @@ else()
 endif()
 
 if(found_stdstringview)
-  CHECK_CXX_SOURCE_COMPILES("#include <string_view>
+  CHECK_CXX_SOURCE_COMPILES("#include <string>
+     #include <string_view>
      int main() { std::string s; std::string_view v; s += v; return 0;}" found_opplusequal_stringview)
 elseif(found_stdexpstringview)
-  CHECK_CXX_SOURCE_COMPILES("#include <experimental/string_view>
+  CHECK_CXX_SOURCE_COMPILES("#include <string>
+     #include <experimental/string_view>
      int main() { std::string s; std::experimental::string_view v; s += v; return 0;}" found_opplusequal_stringview)
 else()
   set(found_opplusequal_stringview false)


### PR DESCRIPTION
Fix for 30593ff51704cdfdd22f7511200a0f0e0f70755e