### PR TITLE
[TMVA-Gui]Training history filename bugfix

### DIFF
--- a/tmva/tmvagui/src/training_history.cxx
+++ b/tmva/tmvagui/src/training_history.cxx
@@ -38,7 +38,7 @@ void TMVA::plot_training_history(TString dataset, TFile* /*file*/, TDirectory* B
 
    TString ftit = "Training History";
 
-   TString hNameRef = "";//training_history";
+   TString hNameRef = "TrainingHistory";
 
    TList xhists;
    TList xmethods;


### PR DESCRIPTION
A minor detail was missing from the merged PR #4337, the training history plots automatically saved by TMVA-Gui were missing a filename. I recommend this fix to be merged into v6-20-00 soon since the 'Training History' feature is now in that branch


Test:

```
. bin/thisroot.sh
cd tutorials/tmva/
make
./TMVAClassification
root -l
TMVA::TMVAGui("TMVA.root")
//Click on Training History... See the DNN_CPU_valError and trainingError plotted, not that data points are only added for every epoch printed in MethodDNN.cxx 
```
Result excerpt:

> Info in TCanvas::Print: eps file dataset/plots/TrainingHistory.eps has been created
> Info in TCanvas::Print: file dataset/plots/TrainingHistory.png has been created
 

Previously read:

> Info in TCanvas::Print: eps file dataset/plots/.eps has been created
> Info in TCanvas::Print: file dataset/plots/.png has been created

Any questions please ask