### PR TITLE
Fix problems in hist painter (TF3)

### DIFF
--- a/hist/hist/src/TF3.cxx
+++ b/hist/hist/src/TF3.cxx
@@ -26,7 +26,7 @@
 ClassImp(TF3);
 
 /** \class TF3
-    \ingroup Hist 
+    \ingroup Hist
 A 3-Dim function with parameters
 */
 
@@ -54,7 +54,7 @@ TF3::TF3(const char *name,const char *formula, Double_t xmin, Double_t xmax, Dou
    fNpz    = 30;
    Int_t ndim = GetNdim();
    // accept 1-d or 2-d formula
-   if (ndim < 3) fNdim = 3; 
+   if (ndim < 3) fNdim = 3;
    if (ndim > 3 && xmin < xmax && ymin < ymax && zmin < zmax) {
       Error("TF3","function: %s/%s has dimension %d instead of 3",name,formula,ndim);
       MakeZombie();
@@ -97,9 +97,9 @@ TF3::TF3(const char *name,Double_t (*fcn)(Double_t *, Double_t *), Double_t xmin
 
 TF3::TF3(const char *name,Double_t (*fcn)(const Double_t *, const Double_t *), Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax, Int_t npar, Int_t ndim)
    : TF2(name,fcn,xmin,xmax,ymin,ymax,npar,ndim),
-   fZmin(zmin), 
-   fZmax(zmax), 
-   fNpz(30) 
+   fZmin(zmin),
+   fZmax(zmax),
+   fNpz(30)
 {
 }
 
@@ -113,17 +113,17 @@ TF3::TF3(const char *name,Double_t (*fcn)(const Double_t *, const Double_t *), D
 /// WARNING! A function created with this constructor cannot be Cloned.
 
 TF3::TF3(const char *name, ROOT::Math::ParamFunctor f, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax, Int_t npar, Int_t ndim)
-   : TF2(name, f, xmin, xmax, ymin, ymax,  npar, ndim), 
-   fZmin(zmin), 
-   fZmax(zmax), 
-   fNpz(30) 
+   : TF2(name, f, xmin, xmax, ymin, ymax,  npar, ndim),
+   fZmin(zmin),
+   fZmax(zmax),
+   fNpz(30)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TF3& TF3::operator=(const TF3 &rhs) 
+TF3& TF3::operator=(const TF3 &rhs)
 {
    if (this != &rhs) {
       rhs.Copy(*this);
@@ -197,9 +197,9 @@ void TF3::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 /// Return minimum/maximum value of the function
 ///
 /// To find the minimum on a range, first set this range via the SetRange function
-/// If a vector x of coordinate is passed it will be used as starting point for the minimum. 
+/// If a vector x of coordinate is passed it will be used as starting point for the minimum.
 /// In addition on exit x will contain the coordinate values at the minimuma
-/// If x is NULL or x is inifinity or NaN, first, a grid search is performed to find the initial estimate of the 
+/// If x is NULL or x is inifinity or NaN, first, a grid search is performed to find the initial estimate of the
 /// minimum location. The range of the function is divided into fNpx and fNpy
 /// sub-ranges. If the function is "good" (or "bad"), these values can be changed
 /// by SetNpx and SetNpy functions
@@ -213,46 +213,46 @@ Double_t TF3::FindMinMax(Double_t *x, Bool_t findmax) const
 {
    //First do a grid search with step size fNpx and fNpy
 
-   Double_t xx[3]; 
+   Double_t xx[3];
    Double_t rsign = (findmax) ? -1. : 1.;
    TF3 & function = const_cast<TF3&>(*this); // needed since EvalPar is not const
-   Double_t xxmin = 0, yymin = 0, zzmin = 0, ttmin = 0; 
-   if (x == NULL || ( (x!= NULL) && ( !TMath::Finite(x[0]) || !TMath::Finite(x[1]) || !TMath::Finite(x[2]) ) ) ){ 
+   Double_t xxmin = 0, yymin = 0, zzmin = 0, ttmin = 0;
+   if (x == NULL || ( (x!= NULL) && ( !TMath::Finite(x[0]) || !TMath::Finite(x[1]) || !TMath::Finite(x[2]) ) ) ){
       Double_t dx = (fXmax - fXmin)/fNpx;
       Double_t dy = (fYmax - fYmin)/fNpy;
       Double_t dz = (fZmax - fZmin)/fNpz;
       xxmin = fXmin;
       yymin = fYmin;
-      zzmin = fZmin; 
-      ttmin = rsign * TMath::Infinity(); 
+      zzmin = fZmin;
+      ttmin = rsign * TMath::Infinity();
       for (Int_t i=0; i<fNpx; i++){
          xx[0]=fXmin + (i+0.5)*dx;
          for (Int_t j=0; j<fNpy; j++){
             xx[1]=fYmin+(j+0.5)*dy;
             for (Int_t k=0; k<fNpz; k++){
                xx[2] = fZmin+(k+0.5)*dz;
-               Double_t tt = function(xx); 
+               Double_t tt = function(xx);
                if (rsign*tt < rsign*ttmin) {xxmin = xx[0], yymin = xx[1]; zzmin = xx[2]; ttmin=tt;}
             }
          }
       }
-      
+
       xxmin = TMath::Min(fXmax, xxmin);
       yymin = TMath::Min(fYmax, yymin);
       zzmin = TMath::Min(fZmax, zzmin);
    }
    else {
-      xxmin = x[0]; 
+      xxmin = x[0];
       yymin = x[1];
       zzmin = x[2];
       zzmin = function(xx);
    }
-   xx[0] = xxmin; 
-   xx[1] = yymin; 
-   xx[2] = zzmin; 
-      
+   xx[0] = xxmin;
+   xx[1] = yymin;
+   xx[2] = zzmin;
+
    double fmin = GetMinMaxNDim(xx,findmax);
-   if (rsign*fmin < rsign*zzmin) { 
+   if (rsign*fmin < rsign*zzmin) {
       if (x) {x[0] = xx[0]; x[1] = xx[1]; x[2] = xx[2];}
       return fmin;
    }
@@ -269,9 +269,9 @@ Double_t TF3::FindMinMax(Double_t *x, Bool_t findmax) const
 /// To find the minimum on a subrange, use the SetRange() function first.
 ///
 /// Method:
-///   First, a grid search is performed to find the initial estimate of the 
-///   minimum location. The range of the function is divided 
-///   into fNpx,fNpy and fNpz sub-ranges. If the function is "good" (or "bad"), 
+///   First, a grid search is performed to find the initial estimate of the
+///   minimum location. The range of the function is divided
+///   into fNpx,fNpy and fNpz sub-ranges. If the function is "good" (or "bad"),
 ///   these values can be changed by SetNpx(), SetNpy() and SetNpz() functions.
 ///   Then, Minuit minimization is used with starting values found by the grid search
 ///
@@ -316,9 +316,9 @@ Double_t TF3::GetMaximumXYZ(Double_t &x, Double_t &y, Double_t &z)
 ///
 ///  IMPORTANT NOTE
 ///
-///  The integral of the function is computed at fNpx * fNpy * fNpz points. 
-///  If the function has sharp peaks, you should increase the number of 
-///  points (SetNpx, SetNpy, SetNpz) such that the peak is correctly tabulated 
+///  The integral of the function is computed at fNpx * fNpy * fNpz points.
+///  If the function has sharp peaks, you should increase the number of
+///  points (SetNpx, SetNpy, SetNpz) such that the peak is correctly tabulated
 ///  at several points.
 
 void TF3::GetRandom3(Double_t &xrandom, Double_t &yrandom, Double_t &zrandom)
@@ -445,7 +445,7 @@ Double_t TF3::GetSave(const Double_t *xx)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return Integral of a 3d function in range [ax,bx],[ay,by],[az,bz]
-/// with a desired relative accuracy. 
+/// with a desired relative accuracy.
 
 Double_t TF3::Integral(Double_t ax, Double_t bx, Double_t ay, Double_t by, Double_t az, Double_t bz, Double_t epsrel)
 {
@@ -508,12 +508,11 @@ void TF3::Paint(Option_t *option)
    }
 
    fHistogram->GetPainter(option)->ProcessMessage("SetF3",this);
-   if (opt.Length() == 0 ) {
-      fHistogram->Paint("tf3");
-   } else {
-      opt += "tf3";
-      fHistogram->Paint(opt.Data());
-   }
+
+   if (opt.Index("tf3") == kNPOS)
+      opt.Append("tf3");
+
+   fHistogram->Paint(opt.Data());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -535,12 +534,12 @@ void TF3::SetClippingBoxOff()
 
 void TF3::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax)
 {
-   if (!fSave.empty()) fSave.clear(); 
+   if (!fSave.empty()) fSave.clear();
    Int_t nsave = (fNpx+1)*(fNpy+1)*(fNpz+1);
    Int_t fNsave = nsave+9;
-   assert(fNsave > 9); 
+   assert(fNsave > 9);
    //fSave  = new Double_t[fNsave];
-   fSave.resize(fNsave); 
+   fSave.resize(fNsave);
    Int_t i,j,k,l=0;
    Double_t dx = (xmax-xmin)/fNpx;
    Double_t dy = (ymax-ymin)/fNpy;
@@ -607,14 +606,14 @@ void TF3::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       if (GetFillColor() > 228) {
          TColor::SaveColor(out, GetFillColor());
          out<<"   "<<GetName()<<"->SetFillColor(ci);" << std::endl;
-      } else 
+      } else
          out<<"   "<<GetName()<<"->SetFillColor("<<GetFillColor()<<");"<<std::endl;
    }
    if (GetLineColor() != 1) {
       if (GetLineColor() > 228) {
          TColor::SaveColor(out, GetLineColor());
          out<<"   "<<GetName()<<"->SetLineColor(ci);" << std::endl;
-      } else 
+      } else
          out<<"   "<<GetName()<<"->SetLineColor("<<GetLineColor()<<");"<<std::endl;
    }
    if (GetNpz() != 100) {
@@ -647,7 +646,7 @@ void TF3::SetClippingBoxOn(Double_t xclip, Double_t yclip, Double_t zclip)
                                                     ,fNpz,fZmin,fZmax);
       fHistogram->SetDirectory(0);
    }
-   
+
    TVectorD v(3);
    v(0) = xclip;
    v(1) = yclip;
@@ -660,7 +659,7 @@ void TF3::SetClippingBoxOn(Double_t xclip, Double_t yclip, Double_t zclip)
 ///
 /// The default number of points along x is 30 for 2-d/3-d functions.
 /// You can increase this value to get a better resolution when drawing
-/// pictures with sharp peaks or to get a better result when using TF3::GetRandom2   
+/// pictures with sharp peaks or to get a better result when using TF3::GetRandom2
 /// the minimum number of points is 4, the maximum is 10000 for 2-d/3-d functions
 
 void TF3::SetNpz(Int_t npz)

--- a/hist/histpainter/inc/THistPainter.h
+++ b/hist/histpainter/inc/THistPainter.h
@@ -35,6 +35,8 @@ class TGaxis;
 class TPainter3dAlgorithms;
 class TGraph2DPainter;
 class TPie;
+class TF3;
+
 const Int_t kMaxCuts = 16;
 
 struct THistRenderingRegion
@@ -65,6 +67,7 @@ protected:
    TString               fShowOption;        //Option to draw the projection
    Int_t                 fXHighlightBin;     //X highlight bin
    Int_t                 fYHighlightBin;     //Y highlight bin
+   TF3                  *fCurrentF3;         //current TF3 function
 
 private:
    mutable TString fObjectInfo;

--- a/hist/histpainter/inc/TPainter3dAlgorithms.h
+++ b/hist/histpainter/inc/TPainter3dAlgorithms.h
@@ -106,7 +106,6 @@ public:
    void    SurfaceFunction(Int_t ia, Int_t ib, Double_t *f, Double_t *t);
    void    SurfaceSpherical(Int_t ipsdr, Int_t iordr, Int_t na, Int_t nb, const char *chopt);
 
-   static void    SetF3(TF3 *f3);
    static void    SetF3ClippingBoxOff();
    static void    SetF3ClippingBoxOn(Double_t xclip, Double_t yclip, Double_t zclip);
 

--- a/hist/histpainter/inc/TPainter3dAlgorithms.h
+++ b/hist/histpainter/inc/TPainter3dAlgorithms.h
@@ -55,8 +55,6 @@ private:
    static Double_t fgF3XClip;      /// Clipping plane along X
    static Double_t fgF3YClip;      /// Clipping plane along Y
    static Double_t fgF3ZClip;      /// Clipping plane along Y
-   static TF3      *fgCurrentF3;   /// Pointer to the 3D function to be paint.
-
 
 public:
    typedef void (TPainter3dAlgorithms::*DrawFaceFunc_t)(Int_t *, Double_t *, Int_t, Int_t *, Double_t *);
@@ -85,7 +83,7 @@ public:
    void    DrawFaceRaster1(Int_t *icodes, Double_t *xyz, Int_t np, Int_t *iface, Double_t *tt);
    void    DrawFaceRaster2(Int_t *icodes, Double_t *xyz, Int_t np, Int_t *iface, Double_t *tt);
    void    GouraudFunction(Int_t ia, Int_t ib, Double_t *f, Double_t *t);
-   void    ImplicitFunction(Double_t *rmin, Double_t *rmax, Int_t nx, Int_t ny, Int_t nz, const char *chopt);
+   void    ImplicitFunction(TF3 *f3, Double_t *rmin, Double_t *rmax, Int_t nx, Int_t ny, Int_t nz, const char *chopt);
    void    IsoSurface (Int_t ns, Double_t *s, Int_t nx, Int_t ny, Int_t nz, Double_t *x, Double_t *y, Double_t *z, const char *chopt);
    void    LegoCartesian(Double_t ang, Int_t nx, Int_t ny, const char *chopt);
    void    LegoFunction(Int_t ia, Int_t ib, Int_t &nv, Double_t *ab, Double_t *vv, Double_t *t);
@@ -189,11 +187,11 @@ private:
    Int_t       fIfrast;    // flag, if it not zero them the algorithm is off
    Int_t       *fRaster;   // pointer to raster buffer
    Int_t       fJmask[30]; // indices of subsets of n-bit masks (n is from 1 to 30)
-   Int_t       fMask[465]; // set of masks (30+29+28+...+1)=465 
+   Int_t       fMask[465]; // set of masks (30+29+28+...+1)=465
 
 //        Marching Cubes 33 - constrction of iso-surfaces, see publication CERN-CN-95-17
 //
-public: 
+public:
    void    MarchingCube(Double_t fiso, Double_t p[8][3], Double_t f[8], Double_t g[8][3], Int_t &nnod, Int_t &ntria, Double_t xyz[][3], Double_t grad[][3], Int_t itria[][3]);
 
 protected:

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -3143,6 +3143,7 @@ THistPainter::THistPainter()
    }
    fXHighlightBin = -1;
    fYHighlightBin = -1;
+   fCurrentF3 = nullptr;
 
    gStringEntries          = gEnv->GetValue("Hist.Stats.Entries",          "Entries");
    gStringMean             = gEnv->GetValue("Hist.Stats.Mean",             "Mean");
@@ -3172,6 +3173,7 @@ THistPainter::THistPainter()
 
 THistPainter::~THistPainter()
 {
+   if (fPie) delete fPie;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4120,7 +4122,6 @@ Int_t THistPainter::MakeChopt(Option_t *choptin)
       memcpy(l,"    ",3);
       l = strstr(chopt,"FB");   if (l) { Hoption.FrontBox = 0; memcpy(l,"  ",2); }
       l = strstr(chopt,"BB");   if (l) { Hoption.BackBox = 0;  memcpy(l,"  ",2); }
-      printf("drawing tf3 %s\n", chopt);
    }
 
    l = strstr(chopt,"ISO");
@@ -6895,7 +6896,10 @@ void THistPainter::PaintH3(Option_t *option)
    opt.ToLower();
    Int_t irep;
 
-   if (Hoption.Box || Hoption.Lego) {
+   if (fCurrentF3) {
+      PaintTF3();
+      return;
+   } else if (Hoption.Box || Hoption.Lego) {
       if (Hoption.Box == 11 || Hoption.Lego == 11) {
          PaintH3Box(1);
       } else if (Hoption.Box == 12 || Hoption.Lego == 12) {
@@ -10041,9 +10045,9 @@ void THistPainter::PaintTF3()
 
    fLego->SetDrawFace(&TPainter3dAlgorithms::DrawFaceMode1);
 
-   fLego->ImplicitFunction(fXbuf, fYbuf, fH->GetNbinsX(),
-                                         fH->GetNbinsY(),
-                                         fH->GetNbinsZ(), "BF");
+   fLego->ImplicitFunction(fCurrentF3, fXbuf, fYbuf, fH->GetNbinsX(),
+                                       fH->GetNbinsY(),
+                                       fH->GetNbinsZ(), "BF");
 
    if (Hoption.FrontBox) {
       fLego->InitMoveScreen(-1.1,1.1);
@@ -10164,7 +10168,7 @@ void THistPainter::ProcessMessage(const char *mess, const TObject *obj)
 {
 
    if (!strcmp(mess,"SetF3")) {
-      TPainter3dAlgorithms::SetF3((TF3*)obj);
+      fCurrentF3 = (TF3 *)obj;
    } else if (!strcmp(mess,"SetF3ClippingBoxOff")) {
       TPainter3dAlgorithms::SetF3ClippingBoxOff();
    } else if (!strcmp(mess,"SetF3ClippingBoxOn")) {

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -2892,7 +2892,7 @@ The supported option is:
 
 | Option   | Description                                                       |
 |----------|-------------------------------------------------------------------|
-| "GLTF3"  | Draw a TF3.|
+| "GL"     | Draw a TF3.|
 
 
 
@@ -4117,12 +4117,15 @@ Int_t THistPainter::MakeChopt(Option_t *choptin)
 
    l = strstr(chopt,"TF3");
    if (l) {
+      memcpy(l,"    ",3);
       l = strstr(chopt,"FB");   if (l) { Hoption.FrontBox = 0; memcpy(l,"  ",2); }
       l = strstr(chopt,"BB");   if (l) { Hoption.BackBox = 0;  memcpy(l,"  ",2); }
+      printf("drawing tf3 %s\n", chopt);
    }
 
    l = strstr(chopt,"ISO");
    if (l) {
+      memcpy(l,"    ",3);
       l = strstr(chopt,"FB");   if (l) { Hoption.FrontBox = 0; memcpy(l,"  ",2); }
       l = strstr(chopt,"BB");   if (l) { Hoption.BackBox = 0;  memcpy(l,"  ",2); }
    }

--- a/hist/histpainter/src/TPainter3dAlgorithms.cxx
+++ b/hist/histpainter/src/TPainter3dAlgorithms.cxx
@@ -3200,23 +3200,17 @@ L400:
 
 void TPainter3dAlgorithms::Luminosity(Double_t *anorm, Double_t &flum)
 {
+   flum = 0;
+
    /* Local variables */
    Double_t cosn, cosr;
    Int_t i;
    Double_t s, vl[3], vn[3];
-   TView *view = 0;
-
-   if (gPad) view = gPad->GetView();
-   if (!view) return;
-
-   /* Parameter adjustments */
-   --anorm;
-
-   flum = 0;
-   if (fLoff != 0) return;
+   TView *view = gPad ? gPad->GetView() : nullptr;
+   if (!view || fLoff) return;
 
    //          T R A N S F E R   N O R M A L  T O   SCREEN COORDINATES
-   view->NormalWCtoNDC(&anorm[1], vn);
+   view->NormalWCtoNDC(anorm, vn);
    s = TMath::Sqrt(vn[0]*vn[0] + vn[1]*vn[1] + vn[2]*vn[2]);
    if (vn[2] < 0) s = -(Double_t)s;
    vn[0] /= s;
@@ -4158,7 +4152,7 @@ void TPainter3dAlgorithms::ImplicitFunction(TF3 *f3, Double_t *rmin, Double_t *r
    Int_t icodes[3], i, i1, i2, k, nnod, ntria;
    Double_t x1=0, x2=0, y1, y2, z1, z2;
    Double_t dx, dy, dz;
-   Double_t p[8][3], pf[8], pn[8][3], t[3], fsurf, w;
+   Double_t p[8][3], pf[8], pn[8][3], t[3], fsurf, w = 0;
 
    Double_t xyz[kNmaxp][3], xyzn[kNmaxp][3], grad[kNmaxp][3];
    Double_t dtria[kNmaxt][6], abcd[kNmaxt][4];


### PR DESCRIPTION
1. Memory leak - when "pie" draw option is used, created TPie object is not destroyed
2. When tf3 draw option provided to histogram, it crashes `h3->Draw("tf3")` 
3. "TF3" and "ISO" strings does not correctly suppressed from options when decoded
4. TF3 pointer remains in global variable and not cleared when TF3 is deleted
