### PR TITLE
[core] The dictionary for the namespace partition and the enum may di…

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1658,10 +1658,15 @@ void TCling::LoadPCMImpl(TFile &pcmFile)
                   listOfGlobals->Add(enumConstant);
                }
             }
-         } else {
-            // This enum is in a namespace. A TClass entry is bootstrapped if
-            // none exists yet and the enum is added to it
-            TClass *nsTClassEntry = TClass::GetClass(enumScope);
+         } else { // This enum is in a namespace.
+            // Do not load when checking for
+            // existence because if the namespace is forward declared (eg
+            // rootmaps) ROOT will create a TClass in kInterpreted mode and at
+            // teardown complain if the dictionary was not loaded, that is
+            // we did not called TClass::GetClass(enumScope) with autoloading on.
+            // To avoid that, a TClass entry in special mode is created and the
+            // enum is added to it.
+            TClass *nsTClassEntry = TClass::GetClass(enumScope, /*load=*/ false);
             if (!nsTClassEntry) {
                nsTClassEntry = new TClass(enumScope, 0, TClass::kNamespaceForMeta, true);
             }


### PR DESCRIPTION
…ffer.

This patch avoids asking ROOT to create a TClass entry in interpreted mode when loading an enum from a given namespace. This is dangerous in case no call to TClass::GetClass("enum::namespace") is not called in a context where autoloading is enabled.

This should fix ROOT-10528 where GaudiMath::Interpolation is available across dictionaries. When reading the LHCbMathDict_rdict.pcm we find an enum GaudiMath::Interpolation::Type. This in turn creates a never used TClass entry for GaudiMath::Interpolation for which ROOT complains at teardown with:

Fatal in <TClass::SetUnloaded>: The TClass for GaudiMath::Interpolation is being unloaded when in state 3

Patch by Marco Clemencic(@pikacic) and me!

cc: @smuzaffar