### PR TITLE
Use `EnableImplicitMT` instead of `EnableThreadSafety`

### DIFF
--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -245,7 +245,7 @@ TEST(TreeProcessorMT, TreeWithFriendTree)
       f.Close();
    }
 
-   ROOT::EnableThreadSafety();
+   ROOT::EnableImplicitMT(1);
    auto procLambda = [](TTreeReader &r) {
       while (r.Next())
          ;
@@ -275,7 +275,7 @@ TEST(TreeProcessorMT, ChainWithFriendChain)
       f.Close();
    }
 
-   ROOT::EnableThreadSafety();
+   ROOT::EnableImplicitMT(1);
    auto procLambda = [](TTreeReader &r) {
       while (r.Next())
          ;


### PR DESCRIPTION
This properly initialize the thread pool manager, and fixes the crash in `gtest-tree-treeplayer-test-treeprocessormt` on Windows, but the Jira issue ROOT-10561 has still to be fixed