### PR TITLE
Replace /O2 with /O1 compiler flag on Windows

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -91,6 +91,12 @@ if(NOT "${ROOT_CLING_TARGET}" STREQUAL "all")
 endif()
 
 if(MSVC)
+  if(NOT win_broken_tests)
+    # FIXME: since Visual Studio v16.4.0 the /O2 optimization flag make many (25%) of the tests failing
+    # Try to re-enable /O2 after the upgrade of llvm & clang
+    string(REPLACE "-O2" "-O1" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+    string(REPLACE "-O2" "-O1" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+  endif()
   # replace dashes in the -EH* and -GR* flags with slashes (/EH* /GR*)
   string(REPLACE " -EH" " /EH" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   string(REPLACE " -GR" " /GR" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
After the update to Visual Studio v16.4.0, the /O2 optimization flag in the interpreter make many (25%) of the tests failing.
Try to re-enable /O2 after the upgrade of llvm & clang, or after updating Visual Studio (v16.5.0-pre.2.0 still doesn't work)