### PR TITLE
Fix Jira issue #ROOT-10561 [TTreeProcessorMT] Breaks without EnableIm…

### DIFF
--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -491,6 +491,7 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    const std::vector<Internal::NameAlias> &friendNames = fFriendInfo.fFriendNames;
    const std::vector<std::vector<std::string>> &friendFileNames = fFriendInfo.fFriendFileNames;
 
+   TThreadExecutor pool;
    // If an entry list or friend trees are present, we need to generate clusters with global entry numbers,
    // so we do it here for all files.
    const bool hasFriends = !friendNames.empty();
@@ -505,7 +506,6 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    const auto friendEntries =
       hasFriends ? Internal::GetFriendEntries(friendNames, friendFileNames) : std::vector<std::vector<Long64_t>>{};
 
-   TThreadExecutor pool;
    // Parent task, spawns tasks that process each of the entry clusters for each input file
    using Internal::EntryCluster;
    auto processFile = [&](std::size_t fileIdx) {


### PR DESCRIPTION
…plicitMT on

Move the creation of `TThreadExecutor pool` before the call of `Internal::MakeClusters()`, to make sure it is properly initialized when calling `ROOT::Internal::TPoolManager::GetPoolSize()` (via `ROOT::GetImplicitMTPoolSize()`)
This fix a crash with the `gtest-tree-treeplayer-test-treeprocessormt` test on Windows, due to a division by zero at line 224 in `TTreeProcessorMT`