### PR TITLE
Fix memory leak in TGraph2DPainter::GetContourList

### DIFF
--- a/hist/histpainter/inc/LinkDef.h
+++ b/hist/histpainter/inc/LinkDef.h
@@ -19,10 +19,4 @@
 #pragma link C++ class THistPainter;
 #pragma link C++ class TPaletteAxis+;
 
-// needed since new class definition of TGraph2DPainter
-#pragma extra_include "TGraph2D.h";
-#pragma extra_include "TGraphDelaunay.h";
-#pragma extra_include "TGraphDelaunay2D.h";
-
-
 #endif

--- a/hist/histpainter/inc/TGraph2DPainter.h
+++ b/hist/histpainter/inc/TGraph2DPainter.h
@@ -57,9 +57,9 @@ protected:
    Int_t      *fMTried;       //!Pointer to fDelaunay->fMTried
 
 
-   TGraphDelaunay   *fDelaunay; // Pointer to the TGraphDelaunay2D to be painted
-   TGraphDelaunay2D *fDelaunay2D; // Pointer to the TGraphDelaunay2D to be painted
-   TGraph2D *fGraph2D;        // Pointer to the TGraph2D in fDelaunay
+   TGraphDelaunay   *fDelaunay; //! Pointer to the TGraphDelaunay2D to be painted
+   TGraphDelaunay2D *fDelaunay2D; //! Pointer to the TGraphDelaunay2D to be painted
+   TGraph2D *fGraph2D;        //! Pointer to the TGraph2D in fDelaunay
 
    void     FindTriangles();
    void     PaintLevels(Int_t *v, Double_t *x, Double_t *y, Int_t nblev=0, Double_t *glev=0);
@@ -84,7 +84,7 @@ public:
    void   PaintPolyLine(Option_t *option);
    void   PaintTriangles(Option_t *option);
 
-   ClassDef(TGraph2DPainter,1)  // TGraph2D painter
+   ClassDef(TGraph2DPainter,0)  // TGraph2D painter
 };
 
 #endif

--- a/hist/histpainter/src/TGraph2DPainter.cxx
+++ b/hist/histpainter/src/TGraph2DPainter.cxx
@@ -207,9 +207,8 @@ TList *TGraph2DPainter::GetContourList(Double_t contour)
 
    if (!fNdt) FindTriangles();
 
-   TGraph *graph = 0;           // current graph
+   TGraph *graph = nullptr;     // current graph
    Int_t npg     = 0;           // number of points in the current graph
-   TList *list   = new TList(); // list holding all the graphs
 
    // Find all the segments making the contour
 
@@ -264,7 +263,7 @@ TList *TGraph2DPainter::GetContourList(Double_t contour)
             delete [] ys0;
             delete [] xs1;
             delete [] ys1;
-            return 0;
+            return nullptr;
          } else {
             i1 = 3-i2-i0;
          }
@@ -326,7 +325,7 @@ TList *TGraph2DPainter::GetContourList(Double_t contour)
             delete [] ys0;
             delete [] xs1;
             delete [] ys1;
-            return 0;
+            return nullptr;
          } else {
             i1 = 3-i2-i0;
          }
@@ -364,6 +363,8 @@ TList *TGraph2DPainter::GetContourList(Double_t contour)
          }
       }
    }
+
+   TList *list   = new TList(); // list holding all the graphs
 
    Int_t *segUsed = new Int_t[fNdt];
    for(i=0; i<fNdt; i++) segUsed[i]=kFALSE;

--- a/hist/histpainter/src/TGraph2DPainter.cxx
+++ b/hist/histpainter/src/TGraph2DPainter.cxx
@@ -252,7 +252,7 @@ TList *TGraph2DPainter::GetContourList(Double_t contour)
 
          // Order along Z axis the points (xi,yi,zi) where "i" belongs to {0,1,2}
          // After this z0 < z1 < z2
-         i0=0, i1=0, i2=0;
+         i0 = i1 = i2 = 0;
          if (fZ[p1]<=z0) {z0=fZ[p1]; x0=fX[p1]; y0=fY[p1]; i0=1;}
          if (fZ[p1]>z2)  {z2=fZ[p1]; x2=fX[p1]; y2=fY[p1]; i2=1;}
          if (fZ[p2]<=z0) {z0=fZ[p2]; x0=fX[p2]; y0=fY[p2]; i0=2;}
@@ -314,7 +314,7 @@ TList *TGraph2DPainter::GetContourList(Double_t contour)
 
          // Order along Z axis the points (xi,yi,zi) where "i" belongs to {0,1,2}
          // After this z0 < z1 < z2
-         i0=0, i1=0, i2=0;
+         i0 = i1 = i2 = 0;
          if (fZ[p[1]]<=z0) {z0=fZ[p[1]]; x0=fX[p[1]]; y0=fY[p[1]]; i0=1;}
          if (fZ[p[1]]>z2)  {z2=fZ[p[1]]; x2=fX[p[1]]; y2=fY[p[1]]; i2=1;}
          if (fZ[p[2]]<=z0) {z0=fZ[p[2]]; x0=fX[p[2]]; y0=fY[p[2]]; i0=2;}


### PR DESCRIPTION
Also simplify LinkDef.h file for TGraph2DPainter.
One can use ClassDef(TGraph2DPainter,0) to avoid complication by dictionary generation.
Class is not intend to be stored in the ROOT file