### PR TITLE
[RHist] Don't duplicate RHistBufferedFillBase members in RHistBufferedFill

### DIFF
--- a/hist/histv7/inc/ROOT/RHistBufferedFill.hxx
+++ b/hist/histv7/inc/ROOT/RHistBufferedFill.hxx
@@ -87,9 +87,6 @@ public:
 
 private:
    HIST &fHist;
-   size_t fCursor = 0;
-   std::array<CoordArray_t, SIZE> fXBuf;
-   std::array<Weight_t, SIZE> fWBuf;
 
    friend class Internal::RHistBufferedFillBase<RHistBufferedFill<HIST, SIZE>, HIST, SIZE>;
    void FlushImpl() { fHist.FillN(this->GetCoords(), this->GetWeights()); }


### PR DESCRIPTION
Title says it all. I believe these data members are a remnant from a time where RHistBufferedFillBase did not exist.