### PR TITLE
Avoid Snapshot errors when updating directories

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1224,9 +1224,9 @@ public:
          TString checkupdate = fOptions.fMode;
          checkupdate.ToLower();
          if (checkupdate == "update")
-             fOutputFile->mkdir(fDirName.c_str(), "", true);  // do not overwrite existing directory
+            fOutputFile->mkdir(fDirName.c_str(), "", true);  // do not overwrite existing directory
          else
-             fOutputFile->mkdir(fDirName.c_str());
+            fOutputFile->mkdir(fDirName.c_str());
          fOutputFile->cd(fDirName.c_str());
       }
 

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1221,7 +1221,12 @@ public:
                      ROOT::CompressionSettings(fOptions.fCompressionAlgorithm, fOptions.fCompressionLevel)));
 
       if (!fDirName.empty()) {
-         fOutputFile->mkdir(fDirName.c_str());
+         TString checkupdate = fOptions.fMode;
+         checkupdate.ToLower();
+         if (checkupdate == "update")
+             fOutputFile->mkdir(fDirName.c_str(), "", true);  // do not overwrite existing directory
+         else
+             fOutputFile->mkdir(fDirName.c_str());
          fOutputFile->cd(fDirName.c_str());
       }
 


### PR DESCRIPTION
If one tries to update a directory inside an existing file, Snapshot complains:
`Error in <TFile::mkdir>: An object with name hi exists already`

This fixes the problem by using the `returnExistingDirectory` option in `mkdir`.

First mentioned in the forum [here](https://root-forum.cern.ch/t/snapshot-complains-when-updating-existing-directory/37935). Similar to [PR4649](https://github.com/root-project/root/pull/4649).