### PR TITLE
add fOverwrite option to Snapshot

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1242,9 +1242,9 @@ public:
       if (fOutputFile && fOutputTree) {
          ::TDirectory::TContext ctxt(fOutputFile->GetDirectory(fDirName.c_str()));
          if (fOptions.fOverwrite)
-           fOutputTree->Write("", TObject::kOverwrite);
+            fOutputTree->Write("", TObject::kOverwrite);
          else
-           fOutputTree->Write();
+            fOutputTree->Write();
          // must destroy the TTree first, otherwise TFile will delete it too leading to a double delete
          fOutputTree.reset();
          fOutputFile->Close();
@@ -1330,9 +1330,9 @@ public:
    {
       if (fOutputTrees[slot]->GetEntries() > 0) {
          if (fOptions.fOverwrite)
-           fOutputFiles[slot]->Write("", TObject::kOverwrite);
+            fOutputFiles[slot]->Write("", TObject::kOverwrite);
          else
-           fOutputFiles[slot]->Write();
+            fOutputFiles[slot]->Write();
       }
       // clear now to avoid concurrent destruction of output trees and input tree (which has them listed as fClones)
       fOutputTrees[slot].reset(nullptr);

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1241,7 +1241,10 @@ public:
    {
       if (fOutputFile && fOutputTree) {
          ::TDirectory::TContext ctxt(fOutputFile->GetDirectory(fDirName.c_str()));
-         fOutputTree->Write();
+         if (fOptions.fOverwrite)
+           fOutputTree->Write("", TObject::kOverwrite);
+         else
+           fOutputTree->Write();
          // must destroy the TTree first, otherwise TFile will delete it too leading to a double delete
          fOutputTree.reset();
          fOutputFile->Close();
@@ -1325,8 +1328,12 @@ public:
 
    void FinalizeTask(unsigned int slot)
    {
-      if (fOutputTrees[slot]->GetEntries() > 0)
-         fOutputFiles[slot]->Write();
+      if (fOutputTrees[slot]->GetEntries() > 0) {
+         if (fOptions.fOverwrite)
+           fOutputFiles[slot]->Write("", TObject::kOverwrite);
+         else
+           fOutputFiles[slot]->Write();
+      }
       // clear now to avoid concurrent destruction of output trees and input tree (which has them listed as fClones)
       fOutputTrees[slot].reset(nullptr);
    }

--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -24,9 +24,9 @@ struct RSnapshotOptions {
    RSnapshotOptions() = default;
    RSnapshotOptions(const RSnapshotOptions &) = default;
    RSnapshotOptions(RSnapshotOptions &&) = default;
-   RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy)
+   RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy, bool overwrite)
       : fMode(mode), fCompressionAlgorithm(comprAlgo), fCompressionLevel{comprLevel}, fAutoFlush(autoFlush),
-        fSplitLevel(splitLevel), fLazy(lazy)
+        fSplitLevel(splitLevel), fLazy(lazy), fOverwrite(overwrite)
    {
    }
    std::string fMode = "RECREATE";             ///< Mode of creation of output file
@@ -35,6 +35,7 @@ struct RSnapshotOptions {
    int fAutoFlush = 0;                         ///< AutoFlush value for output tree
    int fSplitLevel = 99;                       ///< Split level of output tree
    bool fLazy = false;                         ///< Delay the snapshot of the dataset
+   bool fOverwrite = false;                    ///< Use TObject::kOverwrite to avoid saving multiple cycles
 };
 } // ns RDF
 } // ns ROOT

--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -24,7 +24,7 @@ struct RSnapshotOptions {
    RSnapshotOptions() = default;
    RSnapshotOptions(const RSnapshotOptions &) = default;
    RSnapshotOptions(RSnapshotOptions &&) = default;
-   RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy, bool overwrite)
+   RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy, bool overwrite=false)
       : fMode(mode), fCompressionAlgorithm(comprAlgo), fCompressionLevel{comprLevel}, fAutoFlush(autoFlush),
         fSplitLevel(splitLevel), fLazy(lazy), fOverwrite(overwrite)
    {


### PR DESCRIPTION
When one updates a file using `Snapshot`, one ends up with multiple cycles:
```python
In [10]: f.hi.ls()
TDirectoryFile*		hi	hi
 KEY: TTree	there;2	there
 KEY: TTree	there;1	there
```
This adds the `fOverwrite` option to the `RSnapshotOptions` class to overwrite an existing `TTree`. First mentioned in the forum [here](https://root-forum.cern.ch/t/no-way-to-overwrite-using-snapshot/37936).
