### PR TITLE
WebEve - use JSROOT renderer, improve highlight

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveChunkManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveChunkManager.hxx
@@ -28,8 +28,8 @@ namespace Experimental {
 class REveChunkManager
 {
 private:
-   REveChunkManager(const REveChunkManager&);            // Not implemented
-   REveChunkManager& operator=(const REveChunkManager&); // Not implemented
+   REveChunkManager(const REveChunkManager&) = delete;
+   REveChunkManager& operator=(const REveChunkManager&) = delete;
 
 protected:
    Int_t fS;        // Size of atom
@@ -122,8 +122,8 @@ template<class T>
 class REveChunkVector : public REveChunkManager
 {
 private:
-   REveChunkVector(const REveChunkVector&);            // Not implemented
-   REveChunkVector& operator=(const REveChunkVector&); // Not implemented
+   REveChunkVector(const REveChunkVector&) = delete;
+   REveChunkVector& operator=(const REveChunkVector&) = delete;
 
 public:
    REveChunkVector() = default;

--- a/graf3d/eve7/inc/ROOT/REveCompound.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCompound.hxx
@@ -27,8 +27,8 @@ class REveCompound : public REveElement,
                      public REveProjectable
 {
 private:
-   REveCompound(const REveCompound &);            // Not implemented
-   REveCompound &operator=(const REveCompound &); // Not implemented
+   REveCompound(const REveCompound &) = delete;
+   REveCompound &operator=(const REveCompound &) = delete;
 
 protected:
    Short_t fCompoundOpen{0}; // If more than zero, tag new children as compound members.
@@ -65,8 +65,8 @@ class REveCompoundProjected : public REveCompound,
                               public REveProjected
 {
 private:
-   REveCompoundProjected(const REveCompoundProjected &);            // Not implemented
-   REveCompoundProjected &operator=(const REveCompoundProjected &); // Not implemented
+   REveCompoundProjected(const REveCompoundProjected &) = delete;
+   REveCompoundProjected &operator=(const REveCompoundProjected &) = delete;
 
 public:
    REveCompoundProjected();

--- a/graf3d/eve7/inc/ROOT/REveElement.hxx
+++ b/graf3d/eve7/inc/ROOT/REveElement.hxx
@@ -71,7 +71,7 @@ class REveElement
    friend class REveManager;
    friend class REveScene;
 
-   REveElement& operator=(const REveElement&); // Not implemented
+   REveElement& operator=(const REveElement&) = delete;
 
 public:
    typedef std::list<REveElement*>              List_t;

--- a/graf3d/eve7/inc/ROOT/REveEllipsoid.hxx
+++ b/graf3d/eve7/inc/ROOT/REveEllipsoid.hxx
@@ -29,8 +29,8 @@ class REveEllipsoid : public REveStraightLineSet
    friend class REveEllipsoidProjected;
 
 private:
-   REveEllipsoid(const REveEllipsoid &);            // Not implemented
-   REveEllipsoid &operator=(const REveEllipsoid &); // Not implemented
+   REveEllipsoid(const REveEllipsoid &) = delete;
+   REveEllipsoid &operator=(const REveEllipsoid &) = delete;
 
 protected:
    REveVector fV0;
@@ -60,8 +60,8 @@ public:
 class REveEllipsoidProjected :  public REveStraightLineSetProjected
 {
 private:
-   REveEllipsoidProjected(const REveEllipsoidProjected &);            // Not implemented
-   REveEllipsoidProjected &operator=(const REveEllipsoidProjected &); // Not implemented
+   REveEllipsoidProjected(const REveEllipsoidProjected &) = delete;
+   REveEllipsoidProjected &operator=(const REveEllipsoidProjected &) = delete;
 
    void DrawArchProjected(float phiStart, float phiEnd, float phiStep, REveVector& v0,  REveVector& v1, REveVector& v2);
    void GetSurfaceSize(REveVector& p1, REveVector& p2);

--- a/graf3d/eve7/inc/ROOT/REveGeoPolyShape.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoPolyShape.hxx
@@ -28,8 +28,8 @@ class REveRenderData;
 class REveGeoPolyShape : public TGeoBBox
 {
 private:
-   REveGeoPolyShape(const REveGeoPolyShape&);            // Not implemented
-   REveGeoPolyShape& operator=(const REveGeoPolyShape&); // Not implemented
+   REveGeoPolyShape(const REveGeoPolyShape&) = delete;
+   REveGeoPolyShape& operator=(const REveGeoPolyShape&) = delete;
 
 protected:
    std::vector<Double_t> fVertices;

--- a/graf3d/eve7/inc/ROOT/REveGeoShape.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoShape.hxx
@@ -34,8 +34,8 @@ class REveGeoShape : public REveShape,
                      public REveProjectable
 {
 private:
-   REveGeoShape(const REveGeoShape &);            // Not implemented
-   REveGeoShape &operator=(const REveGeoShape &); // Not implemented
+   REveGeoShape(const REveGeoShape &) = delete;
+   REveGeoShape &operator=(const REveGeoShape &) = delete;
 
 protected:
    Int_t fNSegments{0};
@@ -84,8 +84,8 @@ public:
 
 class REveGeoShapeProjected : public REveShape, public REveProjected {
 private:
-   REveGeoShapeProjected(const REveGeoShapeProjected &);            // Not implemented
-   REveGeoShapeProjected &operator=(const REveGeoShapeProjected &); // Not implemented
+   REveGeoShapeProjected(const REveGeoShapeProjected &) = delete;
+   REveGeoShapeProjected &operator=(const REveGeoShapeProjected &) = delete;
 
 protected:
    std::unique_ptr<TBuffer3D> fBuff;    //! 3d buffer

--- a/graf3d/eve7/inc/ROOT/REveGeoShapeExtract.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoShapeExtract.hxx
@@ -22,8 +22,8 @@ namespace Experimental {
 
 class REveGeoShapeExtract : public TNamed
 {
-   REveGeoShapeExtract(const REveGeoShapeExtract&);            // Not implemented
-   REveGeoShapeExtract& operator=(const REveGeoShapeExtract&); // Not implemented
+   REveGeoShapeExtract(const REveGeoShapeExtract&) = delete;
+   REveGeoShapeExtract& operator=(const REveGeoShapeExtract&) = delete;
 
 protected:
    Double_t    fTrans[16];   // Transformation matrix, 4x4 column major.

--- a/graf3d/eve7/inc/ROOT/REveJetCone.hxx
+++ b/graf3d/eve7/inc/ROOT/REveJetCone.hxx
@@ -28,8 +28,8 @@ class REveJetCone : public REveShape,
    friend class REveJetConeProjected;
 
 private:
-   REveJetCone(const REveJetCone &);            // Not implemented
-   REveJetCone &operator=(const REveJetCone &); // Not implemented
+   REveJetCone(const REveJetCone &) = delete;
+   REveJetCone &operator=(const REveJetCone &) = delete;
 
 protected:
    REveVector fApex;   // Apex of the cone.
@@ -83,8 +83,8 @@ class REveJetConeProjected : public REveShape,
                              public REveProjected
 {
 private:
-   REveJetConeProjected(const REveJetConeProjected &);            // Not implemented
-   REveJetConeProjected &operator=(const REveJetConeProjected &); // Not implemented
+   REveJetConeProjected(const REveJetConeProjected &) = delete;
+   REveJetConeProjected &operator=(const REveJetConeProjected &) = delete;
 
 protected:
    void SetDepthLocal(Float_t d) override;

--- a/graf3d/eve7/inc/ROOT/REveLine.hxx
+++ b/graf3d/eve7/inc/ROOT/REveLine.hxx
@@ -29,7 +29,7 @@ class REveLine : public REvePointSet,
                  public TAttLine
 {
 private:
-   REveLine &operator=(const REveLine &); // Not implemented
+   REveLine &operator=(const REveLine &) = delete;
 
 protected:
    Bool_t fRnrLine;
@@ -80,8 +80,8 @@ public:
 
 class REveLineProjected : public REveLine, public REveProjected {
 private:
-   REveLineProjected(const REveLineProjected &);            // Not implemented
-   REveLineProjected &operator=(const REveLineProjected &); // Not implemented
+   REveLineProjected(const REveLineProjected &) = delete;
+   REveLineProjected &operator=(const REveLineProjected &) = delete;
 
 protected:
    void SetDepthLocal(Float_t d) override;

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -42,14 +42,14 @@ class REveGeomViewer;
 
 class REveManager
 {
-   REveManager(const REveManager&);            // Not implemented
-   REveManager& operator=(const REveManager&); // Not implemented
+   REveManager(const REveManager&) = delete;
+   REveManager& operator=(const REveManager&) = delete;
 
 public:
    class RRedrawDisabler {
    private:
-      RRedrawDisabler(const RRedrawDisabler &);            // Not implemented
-      RRedrawDisabler &operator=(const RRedrawDisabler &); // Not implemented
+      RRedrawDisabler(const RRedrawDisabler &) = delete;
+      RRedrawDisabler &operator=(const RRedrawDisabler &) = delete;
 
       REveManager *fMgr{nullptr};
 
@@ -171,12 +171,12 @@ public:
    Bool_t GetKeepEmptyCont() const   { return fKeepEmptyCont; }
    void   SetKeepEmptyCont(Bool_t k) { fKeepEmptyCont = k; }
 
-   void AddElement(REveElement *element, REveElement* parent = nullptr);
-   void AddGlobalElement(REveElement *element, REveElement* parent = nullptr);
+   void AddElement(REveElement *element, REveElement *parent = nullptr);
+   void AddGlobalElement(REveElement *element, REveElement *parent = nullptr);
 
-   void RemoveElement(REveElement* element, REveElement* parent);
+   void RemoveElement(REveElement* element, REveElement *parent);
 
-   REveElement* FindElementById (ElementId_t id) const;
+   REveElement *FindElementById (ElementId_t id) const;
    void         AssignElementId (REveElement* element);
    void         PreDeleteElement(REveElement* element);
 
@@ -184,7 +184,7 @@ public:
    Bool_t       InsertVizDBEntry(const TString& tag, REveElement* model,
                                  Bool_t replace, Bool_t update);
    Bool_t       InsertVizDBEntry(const TString& tag, REveElement* model);
-   REveElement* FindVizDBEntry  (const TString& tag);
+   REveElement *FindVizDBEntry  (const TString& tag);
 
    void         LoadVizDB(const TString& filename, Bool_t replace, Bool_t update);
    void         LoadVizDB(const TString& filename);
@@ -197,9 +197,9 @@ public:
 
 
    // Geometry management.
-   TGeoManager* GetGeometry(const TString& filename);
-   TGeoManager* GetGeometryByAlias(const TString& alias);
-   TGeoManager* GetDefaultGeometry();
+   TGeoManager *GetGeometry(const TString& filename);
+   TGeoManager *GetGeometryByAlias(const TString& alias);
+   TGeoManager *GetDefaultGeometry();
    void         RegisterGeometryAlias(const TString& alias, const TString& filename);
 
    void ClearROOTClassSaved();
@@ -207,7 +207,7 @@ public:
    void AddLocation(const std::string& name, const std::string& path);
    void SetDefaultHtmlPage(const std::string& path);
    void SetClientVersion(const std::string& version);
-   
+
    static REveManager* Create();
    static void         Terminate();
 

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -179,6 +179,7 @@ public:
    REveElement *FindElementById (ElementId_t id) const;
    void         AssignElementId (REveElement* element);
    void         PreDeleteElement(REveElement* element);
+   void         BrowseElement(ElementId_t id);
 
    // VizDB - Visualization-parameter data-base.
    Bool_t       InsertVizDBEntry(const TString& tag, REveElement* model,

--- a/graf3d/eve7/inc/ROOT/REvePointSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REvePointSet.hxx
@@ -39,7 +39,7 @@ class REvePointSet : public REveElement,
    friend class REvePointSetArray;
 
 private:
-   REvePointSet &operator=(const REvePointSet &); // Not implemented
+   REvePointSet &operator=(const REvePointSet &) = delete;
 
 protected:
    std::vector<REveVector> fPoints;
@@ -94,8 +94,8 @@ class REvePointSetArray : public REveElement,
                           public REveProjectable,
                           public TAttMarker
 {
-   REvePointSetArray(const REvePointSetArray &);            // Not implemented
-   REvePointSetArray &operator=(const REvePointSetArray &); // Not implemented
+   REvePointSetArray(const REvePointSetArray &) = delete;
+   REvePointSetArray &operator=(const REvePointSetArray &) = delete;
 
 protected:
    REvePointSet **fBins{nullptr};       //  Pointers to subjugated REvePointSet's.
@@ -147,8 +147,8 @@ class REvePointSetProjected : public REvePointSet,
                               public REveProjected
 {
 private:
-   REvePointSetProjected(const REvePointSetProjected &);            // Not implemented
-   REvePointSetProjected &operator=(const REvePointSetProjected &); // Not implemented
+   REvePointSetProjected(const REvePointSetProjected &) = delete;
+   REvePointSetProjected &operator=(const REvePointSetProjected &) = delete;
 
 protected:
    void SetDepthLocal(Float_t d) override;

--- a/graf3d/eve7/inc/ROOT/REvePolygonSetProjected.hxx
+++ b/graf3d/eve7/inc/ROOT/REvePolygonSetProjected.hxx
@@ -31,8 +31,8 @@ class REvePolygonSetProjected : public REveShape,
                                 public REveProjected
 {
 private:
-   REvePolygonSetProjected(const REvePolygonSetProjected &);            // Not implemented
-   REvePolygonSetProjected &operator=(const REvePolygonSetProjected &); // Not implemented
+   REvePolygonSetProjected(const REvePolygonSetProjected &) = delete;
+   REvePolygonSetProjected &operator=(const REvePolygonSetProjected &) = delete;
 
 protected:
    struct Polygon_t {

--- a/graf3d/eve7/inc/ROOT/REveProjectionBases.hxx
+++ b/graf3d/eve7/inc/ROOT/REveProjectionBases.hxx
@@ -37,7 +37,7 @@ class REveProjectionManager;
 class REveProjectable
 {
 private:
-   REveProjectable &operator=(const REveProjectable &); // Not implemented
+   REveProjectable &operator=(const REveProjectable &) = delete;
 
 public:
    typedef std::list<REveProjected *> ProjList_t;
@@ -80,8 +80,8 @@ public:
 
 class REveProjected {
 private:
-   REveProjected(const REveProjected &);            // Not implemented
-   REveProjected &operator=(const REveProjected &); // Not implemented
+   REveProjected(const REveProjected &) = delete;
+   REveProjected &operator=(const REveProjected &) = delete;
 
 protected:
    REveProjectionManager *fManager{nullptr}; // manager

--- a/graf3d/eve7/inc/ROOT/REveProjectionManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveProjectionManager.hxx
@@ -29,8 +29,8 @@ class REveProjectionManager : public REveElement,
                               public TAttBBox
 {
 private:
-   REveProjectionManager(const REveProjectionManager &);            // Not implemented
-   REveProjectionManager &operator=(const REveProjectionManager &); // Not implemented
+   REveProjectionManager(const REveProjectionManager &) = delete;
+   REveProjectionManager &operator=(const REveProjectionManager &) = delete;
 
 protected:
    REveProjection *fProjections[REveProjection::kPT_End];

--- a/graf3d/eve7/inc/ROOT/REveScalableStraightLineSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REveScalableStraightLineSet.hxx
@@ -9,8 +9,8 @@ namespace Experimental {
 class REveScalableStraightLineSet : public REveStraightLineSet
 {
 private:
-   REveScalableStraightLineSet(const REveScalableStraightLineSet&);            // Not implemented
-   REveScalableStraightLineSet& operator=(const REveScalableStraightLineSet&); // Not implemented
+   REveScalableStraightLineSet(const REveScalableStraightLineSet&) = delete;
+   REveScalableStraightLineSet& operator=(const REveScalableStraightLineSet&) = delete;
 
 protected:
    Double_t      fCurrentScale;

--- a/graf3d/eve7/inc/ROOT/REveScene.hxx
+++ b/graf3d/eve7/inc/ROOT/REveScene.hxx
@@ -35,8 +35,8 @@ class REveScene : public REveElement
    friend class REveManager;
 
 private:
-   REveScene(const REveScene &);            // Not implemented
-   REveScene &operator=(const REveScene &); // Not implemented
+   REveScene(const REveScene &) = delete;
+   REveScene &operator=(const REveScene &) = delete;
 
 protected:
    struct SceneCommand
@@ -45,7 +45,7 @@ protected:
       std::string fIcon;
       std::string fElementClass;
       std::string fAction;
-      ElementId_t fElementId;
+      ElementId_t fElementId{0};
 
       SceneCommand(const std::string& name, const std::string& icon,
                    const REveElement* element, const std::string& action) :
@@ -130,12 +130,12 @@ public:
 class REveSceneList : public REveElement
 {
 private:
-   REveSceneList(const REveSceneList &);            // Not implemented
-   REveSceneList &operator=(const REveSceneList &); // Not implemented
+   REveSceneList(const REveSceneList &) = delete;
+   REveSceneList &operator=(const REveSceneList &) = delete;
 
 protected:
 public:
-   REveSceneList(const std::string& n = "REveSceneList", const std::string& t = "");
+   REveSceneList(const std::string &n = "REveSceneList", const std::string &t = "");
    virtual ~REveSceneList() {}
 
    void DestroyScenes();

--- a/graf3d/eve7/inc/ROOT/REveSceneInfo.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSceneInfo.hxx
@@ -28,8 +28,8 @@ class REveScene;
 class REveSceneInfo : public REveElement
 {
 private:
-   REveSceneInfo(const REveSceneInfo &);            // Not implemented
-   REveSceneInfo &operator=(const REveSceneInfo &); // Not implemented
+   REveSceneInfo(const REveSceneInfo &) = delete;
+   REveSceneInfo &operator=(const REveSceneInfo &) = delete;
 
 protected:
    REveViewer *fViewer{nullptr};   ///<!

--- a/graf3d/eve7/inc/ROOT/REveSecondarySelectable.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSecondarySelectable.hxx
@@ -24,8 +24,8 @@ namespace Experimental {
 class REveSecondarySelectable
 {
 private:
-   REveSecondarySelectable(const REveSecondarySelectable &);            // Not implemented
-   REveSecondarySelectable &operator=(const REveSecondarySelectable &); // Not implemented
+   REveSecondarySelectable(const REveSecondarySelectable &) = delete;
+   REveSecondarySelectable &operator=(const REveSecondarySelectable &) = delete;
 
 public:
    typedef std::set<Int_t>                SelectionSet_t;

--- a/graf3d/eve7/inc/ROOT/REveSelection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSelection.hxx
@@ -68,8 +68,8 @@ public:
    typedef SelMap_t::iterator              SelMap_i;
 
 private:
-   REveSelection(const REveSelection &);            // Not implemented
-   REveSelection &operator=(const REveSelection &); // Not implemented
+   REveSelection(const REveSelection &) = delete;
+   REveSelection &operator=(const REveSelection &) = delete;
 
 protected:
    Color_t          fVisibleEdgeColor; ///<!

--- a/graf3d/eve7/inc/ROOT/REveShape.hxx
+++ b/graf3d/eve7/inc/ROOT/REveShape.hxx
@@ -30,8 +30,8 @@ class REveShape : public REveElement,
                   public TAttBBox
 {
 private:
-   REveShape(const REveShape &);            // Not implemented
-   REveShape &operator=(const REveShape &); // Not implemented
+   REveShape(const REveShape &) = delete;
+   REveShape &operator=(const REveShape &) = delete;
 
 public:
    typedef std::vector<REveVector2> vVector2_t;

--- a/graf3d/eve7/inc/ROOT/REveStraightLineSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REveStraightLineSet.hxx
@@ -39,8 +39,8 @@ class REveStraightLineSet : public REveElement,
                             public TAttBBox
 {
 private:
-   REveStraightLineSet(const REveStraightLineSet&);            // Not implemented
-   REveStraightLineSet& operator=(const REveStraightLineSet&); // Not implemented
+   REveStraightLineSet(const REveStraightLineSet&) = delete;
+   REveStraightLineSet& operator=(const REveStraightLineSet&) = delete;
 
 public:
    struct Line_t
@@ -52,8 +52,8 @@ public:
       Line_t(Float_t x1, Float_t y1, Float_t z1,
              Float_t x2, Float_t y2, Float_t z2) : fId(-1)
       {
-         fV1[0] = x1, fV1[1] = y1, fV1[2] = z1;
-         fV2[0] = x2, fV2[1] = y2, fV2[2] = z2;
+         fV1[0] = x1; fV1[1] = y1; fV1[2] = z1;
+         fV2[0] = x2; fV2[1] = y2; fV2[2] = z2;
       }
    };
 
@@ -64,7 +64,7 @@ public:
 
       Marker_t(Float_t x, Float_t y, Float_t z, Int_t line_id) : fLineId(line_id)
       {
-         fV[0] = x, fV[1] = y, fV[2] = z;
+         fV[0] = x; fV[1] = y; fV[2] = z;
       }
    };
 
@@ -129,8 +129,8 @@ class REveStraightLineSetProjected : public REveStraightLineSet,
                                      public REveProjected
 {
 private:
-   REveStraightLineSetProjected(const REveStraightLineSetProjected&);            // Not implemented
-   REveStraightLineSetProjected& operator=(const REveStraightLineSetProjected&); // Not implemented
+   REveStraightLineSetProjected(const REveStraightLineSetProjected&) = delete;
+   REveStraightLineSetProjected& operator=(const REveStraightLineSetProjected&) = delete;
 
 protected:
    void SetDepthLocal(Float_t d) override;

--- a/graf3d/eve7/inc/ROOT/REveTrack.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTrack.hxx
@@ -42,7 +42,7 @@ class REveTrack : public REveLine
    friend class REveTrackList;
 
 private:
-   REveTrack &operator=(const REveTrack &); // Not implemented
+   REveTrack &operator=(const REveTrack &) = delete;
 
 public:
    typedef std::vector<REvePathMarkD> vPathMark_t;
@@ -145,8 +145,8 @@ class REveTrackList : public REveElement,
                       public TAttLine
 {
 private:
-   REveTrackList(const REveTrackList &);            // Not implemented
-   REveTrackList &operator=(const REveTrackList &); // Not implemented
+   REveTrackList(const REveTrackList &) = delete;
+   REveTrackList &operator=(const REveTrackList &) = delete;
 
 protected:
    REveTrackPropagator *fPropagator{nullptr}; // Basic track rendering parameters, not enforced to elements.

--- a/graf3d/eve7/inc/ROOT/REveTrackProjected.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTrackProjected.hxx
@@ -27,8 +27,8 @@ class REveTrackProjected : public REveTrack,
                            public REveProjected
 {
 private:
-   REveTrackProjected(const REveTrackProjected &);            // Not implemented
-   REveTrackProjected &operator=(const REveTrackProjected &); // Not implemented
+   REveTrackProjected(const REveTrackProjected &) = delete;
+   REveTrackProjected &operator=(const REveTrackProjected &) = delete;
 
    Int_t GetBreakPointIdx(Int_t start);
 
@@ -64,8 +64,8 @@ public:
 
 class REveTrackListProjected : public REveTrackList, public REveProjected {
 private:
-   REveTrackListProjected(const REveTrackListProjected &);            // Not implemented
-   REveTrackListProjected &operator=(const REveTrackListProjected &); // Not implemented
+   REveTrackListProjected(const REveTrackListProjected &) = delete;
+   REveTrackListProjected &operator=(const REveTrackListProjected &) = delete;
 
 protected:
    void SetDepthLocal(Float_t d) override;

--- a/graf3d/eve7/inc/ROOT/REveTrackPropagator.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTrackPropagator.hxx
@@ -171,8 +171,8 @@ protected:
    };
 
 private:
-   REveTrackPropagator(const REveTrackPropagator &);            // Not implemented
-   REveTrackPropagator &operator=(const REveTrackPropagator &); // Not implemented
+   REveTrackPropagator(const REveTrackPropagator &) = delete;
+   REveTrackPropagator &operator=(const REveTrackPropagator &) = delete;
 
    void DistributeOffset(const REveVectorD &off, Int_t first_point, Int_t np, REveVectorD &p);
 

--- a/graf3d/eve7/inc/ROOT/REveTreeTools.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTreeTools.hxx
@@ -25,8 +25,8 @@ namespace Experimental {
 
 class REveSelectorToEventList : public TSelectorDraw
 {
-   REveSelectorToEventList(const REveSelectorToEventList &);            // Not implemented
-   REveSelectorToEventList &operator=(const REveSelectorToEventList &); // Not implemented
+   REveSelectorToEventList(const REveSelectorToEventList &) = delete;
+   REveSelectorToEventList &operator=(const REveSelectorToEventList &) = delete;
 
 protected:
    TEventList *fEvList{nullptr};
@@ -75,8 +75,8 @@ public:
 
 class REvePointSelector : public TSelectorDraw
 {
-   REvePointSelector(const REvePointSelector &);            // Not implemented
-   REvePointSelector &operator=(const REvePointSelector &); // Not implemented
+   REvePointSelector(const REvePointSelector &) = delete;
+   REvePointSelector &operator=(const REvePointSelector &) = delete;
 
 protected:
    TTree *fTree{nullptr};

--- a/graf3d/eve7/inc/ROOT/REveVSD.hxx
+++ b/graf3d/eve7/inc/ROOT/REveVSD.hxx
@@ -23,8 +23,8 @@ namespace ROOT {
 namespace Experimental {
 
 class REveVSD : public TObject {
-   REveVSD(const REveVSD &);            // Not implemented
-   REveVSD &operator=(const REveVSD &); // Not implemented
+   REveVSD(const REveVSD &) = delete;
+   REveVSD &operator=(const REveVSD &) = delete;
 
 protected:
    TFile *fFile{nullptr};           //!

--- a/graf3d/eve7/inc/ROOT/REveViewer.hxx
+++ b/graf3d/eve7/inc/ROOT/REveViewer.hxx
@@ -27,8 +27,8 @@ class REveScene;
 class REveViewer : public REveElement
 {
 private:
-   REveViewer(const REveViewer&);            // Not implemented
-   REveViewer& operator=(const REveViewer&); // Not implemented
+   REveViewer(const REveViewer&) = delete;
+   REveViewer& operator=(const REveViewer&) = delete;
 
 public:
    REveViewer(const std::string &n="REveViewer", const std::string &t="");
@@ -52,8 +52,8 @@ public:
 class REveViewerList : public REveElement
 {
 private:
-   REveViewerList(const REveViewerList&);            // Not implemented
-   REveViewerList& operator=(const REveViewerList&); // Not implemented
+   REveViewerList(const REveViewerList&) = delete;
+   REveViewerList& operator=(const REveViewerList&) = delete;
 
 protected:
    Bool_t        fShowTooltip;

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -58,6 +58,7 @@ Following parameters can be specified in .rootrc file
 WebEve.JsRootRender:  1  # use JSROOT Geometry Painter for GL drawings, default off
 WebEve.DisableShow:   1  # do not start new web browser when REveManager::Show is called
 WebEve.HTimeout:     200 # timeout in ms for elements highlight
+WebEve.TableRowHeight: 33  # size of each row in pixels in the Table view, can be used to make design more compact
 */
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -146,7 +147,8 @@ REveManager::REveManager() : // (Bool_t map_window, Option_t* opt) :
 
    Int_t js_render = gEnv->GetValue("WebEve.JsRootRender", 0);
    Int_t htimeout = gEnv->GetValue("WebEve.HTimeout", 250);
-   fWebWindow->SetUserArgs(Form("{ JsRootRender: %d, HTimeout: %d }", js_render, htimeout));
+   Int_t table_row_height = gEnv->GetValue("WebEve.TableRowHeight", 0);
+   fWebWindow->SetUserArgs(Form("{ JsRootRender: %d, HTimeout: %d, TableRowHeight: %d }", js_render, htimeout, table_row_height));
 
    // this is call-back, invoked when message received via websocket
    fWebWindow->SetCallBacks([this](unsigned connid) { WindowConnect(connid); },

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -45,15 +45,18 @@
 using namespace ROOT::Experimental;
 namespace REX = ROOT::Experimental;
 
-REveManager* REX::gEve = 0;
-
-
+REveManager *REX::gEve = nullptr;
 
 
 /** \class REveManager
 \ingroup REve
 Central application manager for Eve.
 Manages elements, GUI, GL scenes and GL viewers.
+
+Following parameters can be specified in .rootrc file
+
+WebEve.JsRootRender:  1  # use JSROOT Geometry Painter for GL drawings, default off
+WebEve.DisableShow:   1  # do not start new web browser when REveManager::Show is called
 */
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -139,6 +142,9 @@ REveManager::REveManager() : // (Bool_t map_window, Option_t* opt) :
 
    fWebWindow = RWebWindow::Create();
    fWebWindow->SetDefaultPage("file:rootui5sys/eve7/index.html");
+
+   Int_t js_render = gEnv->GetValue("WebEve.JsRootRender", 0);
+   fWebWindow->SetUserArgs(Form("{ JsRootRender: %d }", js_render));
 
    // this is call-back, invoked when message received via websocket
    fWebWindow->SetCallBacks([this](unsigned connid) { WindowConnect(connid); },
@@ -232,7 +238,7 @@ void REveManager::DoRedraw3D()
 {
    static const REveException eh("REveManager::DoRedraw3D ");
    nlohmann::json jobj = {};
-   
+
    jobj["content"] = "BeginChanges";
    fWebWindow->Send(0, jobj.dump());
 

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -57,6 +57,7 @@ Following parameters can be specified in .rootrc file
 
 WebEve.JsRootRender:  1  # use JSROOT Geometry Painter for GL drawings, default off
 WebEve.DisableShow:   1  # do not start new web browser when REveManager::Show is called
+WebEve.HTimeout:     200 # timeout in ms for elements highlight
 */
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -144,7 +145,8 @@ REveManager::REveManager() : // (Bool_t map_window, Option_t* opt) :
    fWebWindow->SetDefaultPage("file:rootui5sys/eve7/index.html");
 
    Int_t js_render = gEnv->GetValue("WebEve.JsRootRender", 0);
-   fWebWindow->SetUserArgs(Form("{ JsRootRender: %d }", js_render));
+   Int_t htimeout = gEnv->GetValue("WebEve.HTimeout", 250);
+   fWebWindow->SetUserArgs(Form("{ JsRootRender: %d, HTimeout: %d }", js_render, htimeout));
 
    // this is call-back, invoked when message received via websocket
    fWebWindow->SetCallBacks([this](unsigned connid) { WindowConnect(connid); },

--- a/js/scripts/JSRoot3DPainter.js
+++ b/js/scripts/JSRoot3DPainter.js
@@ -368,6 +368,8 @@
             this.domElement.removeEventListener( 'mouseup', control_mouseup);
          }
 
+         if (this.lstn_click)
+            this.domElement.removeEventListener('click', this.lstn_click);
          this.domElement.removeEventListener('dblclick', this.lstn_dblclick);
          this.domElement.removeEventListener('contextmenu', this.lstn_contextmenu);
          this.domElement.removeEventListener('mousemove', this.lstn_mousemove);
@@ -714,6 +716,26 @@
          this.ProcessDblClick(evnt);
       }
 
+      if (painter && painter.options && painter.options.mouse_click) {
+         control.ProcessClick = function(mouse) {
+            if (typeof this.ProcessSingleClick == 'function') {
+               var intersects = this.GetMouseIntersects(mouse);
+               this.ProcessSingleClick(intersects);
+            }
+         }
+
+         control.lstn_click = function(evnt) {
+            if (this.single_click_tm) {
+               clearTimeout(this.single_click_tm);
+               delete this.single_click_tm;
+            }
+
+            // if normal event, set longer timeout waiting if double click not detected
+            if (evnt.detail != 2)
+               this.single_click_tmout = setTimeout(this.ProcessClick.bind(this, this.GetMousePos(evnt, {})), 300);
+         }.bind(control);
+      }
+
       control.addEventListener( 'change', control.ChangeEvent.bind(control));
       control.addEventListener( 'start', control.StartEvent.bind(control));
       control.addEventListener( 'end', control.EndEvent.bind(control));
@@ -723,6 +745,8 @@
       control.lstn_mousemove = control.MainProcessMouseMove.bind(control);
       control.lstn_mouseleave = control.MainProcessMouseLeave.bind(control);
 
+      if (control.lstn_click)
+         renderer.domElement.addEventListener('click', control.lstn_click);
       renderer.domElement.addEventListener('dblclick', control.lstn_dblclick);
       renderer.domElement.addEventListener('contextmenu', control.lstn_contextmenu);
       renderer.domElement.addEventListener('mousemove', control.lstn_mousemove);

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 4/02/2020";
+   JSROOT.version = "dev 11/02/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootGeoPainter.js
+++ b/js/scripts/JSRootGeoPainter.js
@@ -467,6 +467,7 @@
 
       if (d.check("ORTHO_CAMERA_ROTATE")) { res.ortho_camera = true; res.can_rotate = true; }
       if (d.check("ORTHO_CAMERA")) { res.ortho_camera = true; res.can_rotate = false; }
+      if (d.check("MOUSE_CLICK")) res.mouse_click = true;
 
       if (d.check("DEPTHRAY") || d.check("DRAY")) res.depthMethod = "ray";
       if (d.check("DEPTHBOX") || d.check("DBOX")) res.depthMethod = "box";

--- a/ui5/eve7/controller/EveTable.controller.js
+++ b/ui5/eve7/controller/EveTable.controller.js
@@ -33,6 +33,10 @@ sap.ui.define([
          this.eveViewerId = data.eveViewerId;
          this.kind = data.kind;
 
+         var rh = this.mgr.handle.GetUserArgs("TableRowHeight");
+         if (rh && (rh>0))
+            this.getView().byId("table").setRowHeight(rh);
+
          this.bindTableColumns = true;
          var element = this.mgr.GetElement(this.eveViewerId);
          // loop over scene and add dependency

--- a/ui5/eve7/controller/GL.controller.js
+++ b/ui5/eve7/controller/GL.controller.js
@@ -336,6 +336,8 @@ sap.ui.define([
       /** Called from JSROOT context menu when object selected for browsing */
       jsrootBrowse: function(obj_id) {
          console.log('Do browsing', obj_id);
+
+         this.mgr.SendMIR("BrowseElement(" + obj_id + ")", 0, "ROOT::Experimental::REveManager");
       },
 
       /** Used together with the geo painter for processing context menu */

--- a/ui5/eve7/controller/Summary.controller.js
+++ b/ui5/eve7/controller/Summary.controller.js
@@ -495,22 +495,15 @@ sap.ui.define([
 
       /** Invoked via EveManager when specified element should be focused */
       BrowseElement: function(elid) {
-         console.log('WANT to BROWSE', elid);
-
          var summaryElement = this.summaryElements[elid];
-
          if (!summaryElement) return;
 
+         var oTree = this.getView().byId("tree"),
+             element_path = summaryElement.path,
+             bestindx = 1, bestlen = 0;
 
-         console.log('Found element', summaryElement.path)
-
-         var element_path = summaryElement.path;
-
-         var oTree = this.getView().byId("tree"), bestindx = 1, bestlen = 0;
-
-         
          while (bestindx >= 0) {
-            
+
             bestindx = -1;
 
             var items = oTree.getItems();
@@ -521,8 +514,8 @@ sap.ui.define([
                    path = model.getPath();
 
                if (element_path == path) {
-                  item.$()[0].scrollIntoView();
-                  console.log('FOUND !!!');
+                  var dom = item.$()[0];
+                  if (dom) dom.scrollIntoView();
                   return;
                }
 
@@ -531,7 +524,7 @@ sap.ui.define([
                   bestlen = path.length;
                }
             }
-            
+
             if (bestindx >= 0) oTree.expand(bestindx);
          }
 

--- a/ui5/eve7/controller/Summary.controller.js
+++ b/ui5/eve7/controller/Summary.controller.js
@@ -83,11 +83,11 @@ sap.ui.define([
          oTree.bindItems("treeModel>/", oItemTemplate);
          this.template = oItemTemplate;
 
-         let make_col_obj = function(stem) {
+         var make_col_obj = function(stem) {
             return { name: stem, member: "f" + stem, srv: "Set" + stem + "RGB", _type: "Color" };
          };
 
-         let make_main_col_obj = function(label, use_main_setter) {
+         var make_main_col_obj = function(label, use_main_setter) {
             return { name: label, member: "fMainColor", srv: "Set" + (use_main_setter ? "MainColor" : label) + "RGB", _type: "Color" };
          };
 
@@ -176,8 +176,8 @@ sap.ui.define([
          if (this.ged)
             this.ged.getController().closeGedEditor();
 
-         var scenes = this.mgr.childs[0].childs[2].childs;
-         for (var i = 0; i < scenes.length; ++i ) {
+         var scenes = this.mgr.getSceneElements();
+         for (var i = 0; i < scenes.length; ++i) {
             this.mgr.RegisterSceneReceiver(scenes[i].fElementId, this);
          }
       },
@@ -302,18 +302,18 @@ sap.ui.define([
       },
 
       SelectElement: function(selection_obj, element_id, sec_idcs) {
-         let item = this.FindTreeItemForEveElement(element_id);
+         var item = this.FindTreeItemForEveElement(element_id);
          if (item) {
-            let color = this.GetSelectionColor(selection_obj);
+            var color = this.GetSelectionColor(selection_obj);
             item.$().css("background-color", color);
          }
       },
 
       UnselectElement: function (selection_obj, element_id) {
-         let item = this.FindTreeItemForEveElement(element_id);
+         var item = this.FindTreeItemForEveElement(element_id);
          if (item) {
-            let color = this.GetSelectionColor(selection_obj);
-            let cc = item.$().css("background-color");
+            var color = this.GetSelectionColor(selection_obj);
+            var cc = item.$().css("background-color");
             if (cc == color)
                item.$().css("background-color", "");
          }
@@ -491,6 +491,50 @@ sap.ui.define([
 
             this.any_changed = false;
          }
+      },
+
+      /** Invoked via EveManager when specified element should be focused */
+      BrowseElement: function(elid) {
+         console.log('WANT to BROWSE', elid);
+
+         var summaryElement = this.summaryElements[elid];
+
+         if (!summaryElement) return;
+
+
+         console.log('Found element', summaryElement.path)
+
+         var element_path = summaryElement.path;
+
+         var oTree = this.getView().byId("tree"), bestindx = 1, bestlen = 0;
+
+         
+         while (bestindx >= 0) {
+            
+            bestindx = -1;
+
+            var items = oTree.getItems();
+
+            for (var k = 0; k < items.length; ++k) {
+               var item = items[k],
+                   model = item.getBindingContext("treeModel"),
+                   path = model.getPath();
+
+               if (element_path == path) {
+                  item.$()[0].scrollIntoView();
+                  console.log('FOUND !!!');
+                  return;
+               }
+
+               if ((element_path.substr(0, path.length) == path) && (path.length > bestlen)) {
+                  bestindx = k;
+                  bestlen = path.length;
+               }
+            }
+            
+            if (bestindx >= 0) oTree.expand(bestindx);
+         }
+
       }
    });
 });

--- a/ui5/eve7/lib/EveElements.js
+++ b/ui5/eve7/lib/EveElements.js
@@ -24,7 +24,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
    EveElemControl.prototype.invokeSceneMethod = function(fname, arg)
    {
-      if ( ! this.obj3d) return false;
+      if (!this.obj3d) return false;
 
       var s = this.obj3d.scene;
       if (s && (typeof s[fname] == "function"))

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -126,10 +126,10 @@ sap.ui.define([], function() {
       else if (resp.content == "EndChanges")
       {
          this.ServerEndRedrawCallback();
-         return;
       }
-      else
-      {
+      else if (resp.content == "BrowseElement") {
+         this.BrowseElement(resp.id);
+      } else {
          console.log("OnWebsocketMsg Unhandled message type: msg len=", msg.length, " txt:", msg.substr(0,120), "...");
       }
    }
@@ -139,7 +139,7 @@ sap.ui.define([], function() {
     * Special handling for offline case - some methods can be tried to handle without server */
    EveManager.prototype.SendMIR = function(mir_call, element_id, element_class)
    {
-      if (!mir_call || ! this.handle || !element_class) return;
+      if (!mir_call || !this.handle || !element_class) return;
 
       // Sergey: NextEvent() here just to handle data recording in event_demo.C
 
@@ -169,6 +169,13 @@ sap.ui.define([], function() {
 
       if (elem.$receivers.indexOf(receiver)<0)
          elem.$receivers.push(receiver);
+   }
+
+   /** Returns list of scene elements */
+   EveManager.prototype.getSceneElements = function()
+   {
+      if (!this.childs) return [];
+      return this.childs[0].childs[2].childs;
    }
 
    /** Invoke function on all receiver of scene events - when such function exists */
@@ -681,6 +688,16 @@ sap.ui.define([], function() {
       this.busyProcessingChanges = false;
    }
 
+   /** Method invoked from server message to browse to element elid */
+   EveManager.prototype.BrowseElement = function(elid) {
+      var scenes = this.getSceneElements();
+
+      for (var i = 0; i < scenes.length; ++i) {
+         var scene = this.GetElement(scenes[i].fElementId);
+         this.callSceneReceivers(scene, "BrowseElement", elid);
+         break; // normally default scene is enough
+      }
+   }
 
    //==============================================================================
    // END protoype functions

--- a/ui5/eve7/lib/EveScene.js
+++ b/ui5/eve7/lib/EveScene.js
@@ -294,8 +294,8 @@ sap.ui.define([
       // MT BEGIN
       // console.log("EveScene.prototype.processElementSelected", obj3d, col, indx, evnt);
 
-      let is_multi  = event && event.ctrlKey;
-      let is_secsel = indx !== undefined;
+      var is_multi  = event && event.ctrlKey ? true : false;
+      var is_secsel = indx !== undefined;
 
       let fcall = "NewElementPicked(" + (obj3d ? obj3d.eve_el.fElementId : 0) + `, ${is_multi}, ${is_secsel}`;
       if (is_secsel)

--- a/ui5/eve7/view/EveTable.view.xml
+++ b/ui5/eve7/view/EveTable.view.xml
@@ -27,6 +27,7 @@
         class="sapUiNoMarginTop"
         selectionMode="None"
         editable="false"
+        rowHeight="22"
         showColumnVisibilityMenu="true"
         visibleRowCountMode="Auto">
       <table:layoutData>


### PR DESCRIPTION
Now several parameters can be configured via rootrc file:

```
WebEve.JsRootRender:  1  # use JSROOT Geometry Painter for GL drawings, default off
WebEve.DisableShow:   1  # do not start new web browser when REveManager::Show is called
WebEve.HTimeout:     200 # timeout in ms for elements highlight
WebEve.TableRowHeight: 33  # size of each row in pixels in the Table view, can be used to make design more compact
```

Provide context menu, which activate browser at specified element
Improve/repair functionality with JSROOT GeoPainter. 
Provide single-click mouse handler, used for tracks/jets selection
Improve highlight handling in plain three.js mode
Make possibility to specify table row width via rootrc
