### PR TITLE
[RHist] Fix histogram merging

### DIFF
--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -449,21 +449,8 @@ protected:
       return nbinsNoOver / std::abs(highOrLow - lowOrHigh);
    }
 
-   // See RAxisBase documentation
-   bool HasSameBinBordersAs(const RAxisBase& other) const override {
-      // This is an optimized override for the equidistant-equidistant case,
-      // fall back to the default implementation if we're not in that case.
-      auto other_eq_ptr = dynamic_cast<const RAxisEquidistant*>(&other);
-      if (!other_eq_ptr)
-         return RAxisBase::HasSameBinBordersAs(other);
-      const RAxisEquidistant& other_eq = *other_eq_ptr;
-
-      // Can directly compare equidistant/growable axis properties in this case
-      return fInvBinWidth == other_eq.fInvBinWidth &&
-             fLow == other_eq.fLow &&
-             fNBinsNoOver == other_eq.fNBinsNoOver &&
-             CanGrow() == other_eq.CanGrow();
-   }
+   /// See RAxisBase::HasSameBinBordersAs
+   bool HasSameBinBordersAs(const RAxisBase& other) const override;
 
 public:
    RAxisEquidistant() = default;
@@ -649,18 +636,8 @@ private:
    std::vector<double> fBinBorders;
 
 protected:
-   // See RAxisBase documentation
-   bool HasSameBinBordersAs(const RAxisBase& other) const override {
-      // This is an optimized override for the irregular-irregular case,
-      // fall back to the default implementation if we're not in that case.
-      auto other_irr_ptr = dynamic_cast<const RAxisIrregular*>(&other);
-      if (!other_irr_ptr)
-         return RAxisBase::HasSameBinBordersAs(other);
-      const RAxisIrregular& other_irr = *other_irr_ptr;
-
-      // Only need to compare bin borders in this specialized case
-      return fBinBorders == other_irr.fBinBorders;
-   }
+   /// See RAxisBase::HasSameBinBordersAs
+   bool HasSameBinBordersAs(const RAxisBase& other) const override;
 
 public:
    RAxisIrregular() = default;
@@ -811,40 +788,11 @@ private:
    std::unordered_map<std::string, int /*bin number*/> fLabelsIndex;
 
 protected:
-   // See RAxisBase documentation
-   bool HasSameBinMetadataAs(const RAxisBase& other) const noexcept override {
-      // If this axis has bin labels, `other` must have bin labels too
-      auto other_labels_ptr = dynamic_cast<const RAxisLabels*>(&other);
-      if (!other_labels_ptr)
-         return false;
-      const auto& other_labels = *other_labels_ptr;
+   /// See RAxisBase::HasSameBinMetadataAs
+   bool HasSameBinMetadataAs(const RAxisBase& other) const noexcept override;
 
-      // The bin labels and label->bin associations must also be the same.
-      //
-      // We know that the number of bins is the same, per HasSameBinMetadataAs
-      // virtual interface contract, so we only need to check that each bin from
-      // `this` exists identically in `other`.
-      //
-      for (const auto &kv: fLabelsIndex) {
-         auto iter = other_labels.fLabelsIndex.find(kv.first);
-         if ((iter == fLabelsIndex.cend()) || (iter->second != kv.second))
-            return false;
-      }
-      return true;
-   }
-
-   // See RAxisBase documentation
-   bool AlsoHasSameBinMetadataAs(const RAxisBase& other) const noexcept override {
-      // If this axis has bin labels, `other` must have bin labels too
-      //
-      // That's all we need to check because we can assume that a call to
-      // `other.HasSameBinMetadataAs(*this)` has already completed successfully.
-      // Hence, if `other` is an `RAxisLabels`, the bin labels have already been
-      // compared by this previous call.
-      //
-      auto other_labels_ptr = dynamic_cast<const RAxisLabels*>(&other);
-      return (other_labels_ptr != nullptr);
-   }
+   /// See RAxisBase::AlsoHasSameBinMetadataAs
+   bool AlsoHasSameBinMetadataAs(const RAxisBase& other) const noexcept override;
 
 public:
    /// Construct a RAxisLables from a `vector` of `string_view`s, with title.

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -101,7 +101,7 @@ protected:
    /// Default implementation should work for any RAxis type, but is a little
    /// bit stupid. RAxis implementations are encouraged to provide optimized
    /// overrides for common comparison scenarios.
-   virtual bool HasSameBinBordersAs(const RAxisBase& other) const noexcept {
+   virtual bool HasSameBinBordersAs(const RAxisBase& other) const {
       // Axis growability (and thus under/overflow bin existence) must match
       if (CanGrow() != other.CanGrow()) return false;
 
@@ -338,28 +338,28 @@ public:
 
    /// Get the bin center for the given bin index.
    /// The result of this method on an overflow or underflow bin is unspecified
-   virtual double GetBinCenter(int bin) const noexcept = 0;
+   virtual double GetBinCenter(int bin) const = 0;
 
    /// Get the low bin border ("left edge") for the given bin index.
    /// The result of this method on an underflow bin is unspecified
-   virtual double GetBinFrom(int bin) const noexcept = 0;
+   virtual double GetBinFrom(int bin) const = 0;
 
    /// Get the high bin border ("right edge") for the given bin index.
    /// The result of this method on an overflow bin is unspecified
-   double GetBinTo(int bin) const noexcept { return GetBinFrom(bin + 1); }
+   double GetBinTo(int bin) const { return GetBinFrom(bin + 1); }
 
    /// Get the low end of the axis range.
-   double GetMinimum() const noexcept { return GetBinTo(GetUnderflowBin()); }
+   double GetMinimum() const { return GetBinTo(GetUnderflowBin()); }
 
    /// Get the high end of the axis range.
-   double GetMaximum() const noexcept { return GetBinFrom(GetOverflowBin()); }
+   double GetMaximum() const { return GetBinFrom(GetOverflowBin()); }
 
    /// Check if two axes use the same binning convention, i.e.
    ///
    /// - Either they are both growable or neither of them is growable.
    /// - Minimum, maximum, and all bin borders in the middle are the same.
    /// - Any metadata attached to the bin (e.g. bin labels) must match.
-   bool HasSameBinningAs(const RAxisBase& other) const noexcept {
+   bool HasSameBinningAs(const RAxisBase& other) const {
       // Bin borders must match
       if (!HasSameBinBordersAs(other)) return false;
 
@@ -444,7 +444,7 @@ protected:
    }
 
    // See RAxisBase documentation
-   bool HasSameBinBordersAs(const RAxisBase& other) const noexcept override {
+   bool HasSameBinBordersAs(const RAxisBase& other) const override {
       // This is an optimized override for the equidistant-equidistant case,
       // fall back to the default implementation if we're not in that case.
       auto other_eq_ptr = dynamic_cast<const RAxisEquidistant*>(&other);
@@ -516,13 +516,13 @@ public:
    /// For the bin == 1 (the first bin) of 2 bins for an axis (0., 1.), this
    /// returns 0.25.
    /// The result of this method on an overflow or underflow bin is unspecified
-   double GetBinCenter(int bin) const noexcept final override { return fLow + (bin - *begin() + 0.5) / fInvBinWidth; }
+   double GetBinCenter(int bin) const final override { return fLow + (bin - *begin() + 0.5) / fInvBinWidth; }
 
    /// Get the low bin border for the given bin index.
    /// For the bin == 1 (the first bin) of 2 bins for an axis (0., 1.), this
    /// returns 0.
    /// The result of this method on an underflow bin is unspecified
-   double GetBinFrom(int bin) const noexcept final override { return fLow + (bin - *begin()) / fInvBinWidth; }
+   double GetBinFrom(int bin) const final override { return fLow + (bin - *begin()) / fInvBinWidth; }
 
    /// If the coordinate `x` is within 10 ULPs of a bin low edge coordinate,
    /// return the bin for which this is a low edge. If it's not a bin edge,
@@ -643,7 +643,7 @@ private:
 
 protected:
    // See RAxisBase documentation
-   bool HasSameBinBordersAs(const RAxisBase& other) const noexcept override {
+   bool HasSameBinBordersAs(const RAxisBase& other) const override {
       // This is an optimized override for the irregular-irregular case,
       // fall back to the default implementation if we're not in that case.
       auto other_irr_ptr = dynamic_cast<const RAxisIrregular*>(&other);
@@ -734,7 +734,7 @@ public:
    /// Similarly, for the bin at index N + 1 (i.e. the overflow bin), a bin
    /// center of `std::numeric_limits<double>::max()` is returned, i.e. the
    /// largest value that can be held in a double.
-   double GetBinCenter(int bin) const noexcept final override
+   double GetBinCenter(int bin) const final override
    {
       if (IsUnderflowBin(bin))
          return std::numeric_limits<double>::lowest();
@@ -751,7 +751,7 @@ public:
    /// Similarly, for the bin at index N + 2 (i.e. after the overflow bin), a
    /// lower bin border of `std::numeric_limits<double>::max()` is returned,
    /// i.e. the largest value that can be held in a double.
-   double GetBinFrom(int bin) const noexcept final override
+   double GetBinFrom(int bin) const final override
    {
       if (IsUnderflowBin(bin))
          return std::numeric_limits<double>::lowest();

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -827,7 +827,7 @@ public:
       // Otherwise, we must check the labels of the other axis too
       for (const auto &kv: other.fLabelsIndex)
          if (fLabelsIndex.find(kv.first) == other.fLabelsIndex.cend())
-            result = LabelComparisonFlags(result | kSuperset);
+            return LabelComparisonFlags(result | kSuperset);
       return result;
    }
 };

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -791,21 +791,25 @@ public:
       return vec;
    }
 
-   /// Result of an RAxisLabels label comparison
-   enum LabelComparisonFlags {
-      kSame = 0,  ///< The two axes have the same labels in the same order
+   /// Result of an RAxisLabels label set comparison
+   enum LabelsCmpFlags {
+      /// Both axes have the same labels, mapping to the same bins
+      kLabelsCmpSame = 0,
 
-      kSubset = 0b1,  ///< Other axis doesn't have some labels of this axis
+      /// The other axis doesn't have some labels from this axis
+      kLabelsCmpSubset = 0b1,
 
-      kSuperset = 0b10,  ///< Other axis has some labels this axis doesn't have
+      /// The other axis has some labels which this axis doesn't have
+      kLabelsCmpSuperset = 0b10,
 
-      kDisordered = 0b100,  ///< Common subset of labels is ordered differently
+      /// The labels shared by both axes do not map into the same bins
+      kLabelsCmpDisordered = 0b100,
    };
 
    /// Compare the labels of this axis with those of another axis
-   LabelComparisonFlags CompareBinLabels(const RAxisLabels& other) const noexcept {
+   LabelsCmpFlags CompareBinLabels(const RAxisLabels& other) const noexcept {
       // This will eventually contain the results of the labels comparison
-      LabelComparisonFlags result = kSame;
+      LabelsCmpFlags result = kLabelsCmpSame;
       size_t missing_in_other = 0;
 
       // First, check how this axis' labels map into the other axis
@@ -814,11 +818,11 @@ public:
          if (iter == other.fLabelsIndex.cend()) {
             ++missing_in_other;
          } else if (iter->second != kv.second) {
-            result = LabelComparisonFlags(result | kDisordered);
+            result = LabelsCmpFlags(result | kLabelsCmpDisordered);
          }
       }
       if (missing_in_other > 0)
-         result = LabelComparisonFlags(result | kSubset);
+         result = LabelsCmpFlags(result | kLabelsCmpSubset);
 
       // If this covered all labels in the other axis, we're done
       if (fLabelsIndex.size() == other.fLabelsIndex.size() + missing_in_other)
@@ -827,7 +831,7 @@ public:
       // Otherwise, we must check the labels of the other axis too
       for (const auto &kv: other.fLabelsIndex)
          if (fLabelsIndex.find(kv.first) == other.fLabelsIndex.cend())
-            return LabelComparisonFlags(result | kSuperset);
+            return LabelsCmpFlags(result | kLabelsCmpSuperset);
       return result;
    }
 };

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -792,7 +792,7 @@ enum class EAxisCompatibility {
 };
 
 /// Whether (and how) the source axis can be merged into the target axis.
-EAxisCompatibility CanMap(RAxisEquidistant &target, RAxisEquidistant &source) noexcept;
+EAxisCompatibility CanMap(const RAxisEquidistant &target, const RAxisEquidistant &source) noexcept;
 ///\}
 
 } // namespace Experimental

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -98,9 +98,10 @@ protected:
 
    /// Check if two axis have the same bin borders
    ///
-   /// Default implementation should work for any RAxis type, but is a little
-   /// bit stupid. RAxis implementations are encouraged to provide optimized
-   /// overrides for common comparison scenarios.
+   /// Default implementation should work for any RAxis type, but is quite
+   /// inefficient as it does virtual GetBinFrom calls in a loop. RAxis
+   /// implementations are encouraged to provide optimized overrides for common
+   /// axis binning comparison scenarios.
    virtual bool HasSameBinBordersAs(const RAxisBase& other) const {
       // Axis growability (and thus under/overflow bin existence) must match
       if (CanGrow() != other.CanGrow())

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -103,18 +103,21 @@ protected:
    /// overrides for common comparison scenarios.
    virtual bool HasSameBinBordersAs(const RAxisBase& other) const {
       // Axis growability (and thus under/overflow bin existence) must match
-      if (CanGrow() != other.CanGrow()) return false;
+      if (CanGrow() != other.CanGrow())
+         return false;
 
       // Number of normal bins must match
-      if (GetNBinsNoOver() != other.GetNBinsNoOver()) return false;
+      if (GetNBinsNoOver() != other.GetNBinsNoOver())
+         return false;
 
       // Left borders of normal bins must match
-      for (int bin: *this) {
-         if (GetBinFrom(bin) != other.GetBinFrom(bin)) return false;
-      }
+      for (int bin: *this)
+         if (GetBinFrom(bin) != other.GetBinFrom(bin))
+            return false;
 
       // Right border of the last normal bin (aka maximum) must also match
-      if (GetMaximum() != other.GetMaximum()) return false;
+      if (GetMaximum() != other.GetMaximum())
+         return false;
 
       // If all of these checks passed, the two axes have the same bin borders
       return true;
@@ -361,12 +364,15 @@ public:
    /// - Any metadata attached to the bin (e.g. bin labels) must match.
    bool HasSameBinningAs(const RAxisBase& other) const {
       // Bin borders must match
-      if (!HasSameBinBordersAs(other)) return false;
+      if (!HasSameBinBordersAs(other))
+         return false;
 
       // If either `this` or `other` provides supplementary bin metadata, such
       // as bin labels, make sure that it is present on both sides.
-      if (!HasSameBinMetadataAs(other)) return false;
-      if (!other.AlsoHasSameBinMetadataAs(*this)) return false;
+      if (!HasSameBinMetadataAs(other))
+         return false;
+      if (!other.AlsoHasSameBinMetadataAs(*this))
+         return false;
 
       // If all of the above matched, we're good.
       return true;
@@ -448,7 +454,8 @@ protected:
       // This is an optimized override for the equidistant-equidistant case,
       // fall back to the default implementation if we're not in that case.
       auto other_eq_ptr = dynamic_cast<const RAxisEquidistant*>(&other);
-      if (!other_eq_ptr) return RAxisBase::HasSameBinBordersAs(other);
+      if (!other_eq_ptr)
+         return RAxisBase::HasSameBinBordersAs(other);
       const RAxisEquidistant& other_eq = *other_eq_ptr;
 
       // Can directly compare equidistant/growable axis properties in this case
@@ -647,7 +654,8 @@ protected:
       // This is an optimized override for the irregular-irregular case,
       // fall back to the default implementation if we're not in that case.
       auto other_irr_ptr = dynamic_cast<const RAxisIrregular*>(&other);
-      if (!other_irr_ptr) return RAxisBase::HasSameBinBordersAs(other);
+      if (!other_irr_ptr)
+         return RAxisBase::HasSameBinBordersAs(other);
       const RAxisIrregular& other_irr = *other_irr_ptr;
 
       // Only need to compare bin borders in this specialized case
@@ -807,7 +815,8 @@ protected:
    bool HasSameBinMetadataAs(const RAxisBase& other) const noexcept override {
       // If this axis has bin labels, `other` must have bin labels too
       auto other_labels_ptr = dynamic_cast<const RAxisLabels*>(&other);
-      if (!other_labels_ptr) return false;
+      if (!other_labels_ptr)
+         return false;
       const auto& other_labels = *other_labels_ptr;
 
       // The bin labels and label->bin associations must also be the same.

--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -303,13 +303,16 @@ using RH3LL = RHist<3, int64_t, RHistStatContent>;
 /// Add two histograms.
 ///
 /// This operation may currently only be performed if the two histograms have
-/// the same axis configuration and record the same statistics.
+/// the same axis configuration, use the same precision, and if `from` records
+/// at least the same statistics as `to` (recording more stats is fine).
 ///
 /// In the future, we may either adopt a more relaxed definition of histogram
 /// addition or provide a mechanism to convert from one histogram type to
 /// another. We currently favor the latter path.
-template <int DIMENSIONS, class PRECISION, template <int D_, class P_> class... STAT>
-void Add(RHist<DIMENSIONS, PRECISION, STAT...> &to, const RHist<DIMENSIONS, PRECISION, STAT...> &from)
+template <int DIMENSIONS, class PRECISION,
+          template <int D_, class P_> class... STAT_TO,
+          template <int D_, class P_> class... STAT_FROM>
+void Add(RHist<DIMENSIONS, PRECISION, STAT_TO...> &to, const RHist<DIMENSIONS, PRECISION, STAT_FROM...> &from)
 {
    // Enforce "same axis configuration" policy.
    auto& toImpl = *to.GetImpl();

--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -22,6 +22,7 @@
 #include "ROOT/RHistImpl.hxx"
 #include "ROOT/RHistData.hxx"
 #include <initializer_list>
+#include <stdexcept>
 
 namespace ROOT {
 namespace Experimental {
@@ -306,6 +307,10 @@ using RH3LL = RHist<3, int64_t, RHistStatContent>;
 /// the same axis configuration, use the same precision, and if `from` records
 /// at least the same statistics as `to` (recording more stats is fine).
 ///
+/// Adding histograms with incompatible axis binning will be reported at runtime
+/// with an `std::runtime_error`. Insufficient statistics in the source
+/// histogram will be detected at compile-time and result in a compiler error.
+///
 /// In the future, we may either adopt a more relaxed definition of histogram
 /// addition or provide a mechanism to convert from one histogram type to
 /// another. We currently favor the latter path.
@@ -319,9 +324,7 @@ void Add(RHist<DIMENSIONS, PRECISION, STAT_TO...> &to, const RHist<DIMENSIONS, P
    const auto& fromImpl = *from.GetImpl();
    for (int dim = 0; dim < DIMENSIONS; ++dim) {
       if (!toImpl.GetAxis(dim).HasSameBinningAs(fromImpl.GetAxis(dim))) {
-         R__ERROR_HERE("HIST") << "Incompatible axis types";
-         // FIXME: Shouldn't this throw an exception or something?
-         return;
+         throw std::runtime_error("Attempted to add RHists with incompatible axis binning");
       }
    }
 

--- a/hist/histv7/inc/ROOT/RHistData.hxx
+++ b/hist/histv7/inc/ROOT/RHistData.hxx
@@ -485,10 +485,13 @@ public:
       (void)trigger_base_fill{(STAT<DIMENSIONS, PRECISION>::Fill(x, binidx, weight), 0)...};
    }
 
-   /// Merge with other statistics of the same type.
+   /// Integrate other statistical data into the current data.
    ///
-   /// The implementation assumes that the number of bins is equal.
-   void Add(const RHistData &other)
+   /// The implementation assumes that the other statistics were recorded with
+   /// the same binning configuration, and that the statistics of `OtherData`
+   /// are a superset of those recorded by the active `RHistData` instance.
+   template <typename OtherData>
+   void Add(const OtherData &other)
    {
       // Call Add() on all base classes, using the same tricks as Fill().
       using trigger_base_add = int[];

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -51,7 +51,7 @@ ROOT::Experimental::EAxisCompatibility ROOT::Experimental::CanMap(const RAxisEqu
                                                                   const RAxisEquidistant &source) noexcept
 {
    // First, let's get the common "all parameters are equal" case out of the way
-   if (source == target)
+   if (source.HasSameBinningAs(target))
       return EAxisCompatibility::kIdentical;
 
    // Do the source min/max boundaries correspond to target bin boundaries?

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -47,19 +47,23 @@ int ROOT::Experimental::RAxisEquidistant::GetBinIndexForLowEdge(double x) const 
    return binIdx;
 }
 
-ROOT::Experimental::EAxisCompatibility ROOT::Experimental::CanMap(RAxisEquidistant &target,
-                                                                  RAxisEquidistant &source) noexcept
+ROOT::Experimental::EAxisCompatibility ROOT::Experimental::CanMap(const RAxisEquidistant &target,
+                                                                  const RAxisEquidistant &source) noexcept
 {
+   // First, let's get the common "all parameters are equal" case out of the way
    if (source == target)
       return EAxisCompatibility::kIdentical;
 
+   // Do the source min/max boundaries correspond to target bin boundaries?
    int idxTargetLow = target.GetBinIndexForLowEdge(source.GetMinimum());
    int idxTargetHigh = target.GetBinIndexForLowEdge(source.GetMaximum());
    if (idxTargetLow < 0 || idxTargetHigh < 0)
+      // If not, the source is incompatible with the target since the first or
+      // last source bin does not map into a target axis bin.
       return EAxisCompatibility::kIncompatible;
 
-   // If both low and high exist in both axes and the bin width is identical then
-   // one axis contains the other.
+   // If so, and if the bin width is the same, then since we've eliminated the
+   // care where min/max/width are equal, source must be a subset of target.
    if (source.GetInverseBinWidth() == target.GetInverseBinWidth())
       return EAxisCompatibility::kContains;
 

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -33,7 +33,8 @@ bool ROOT::Experimental::RAxisBase::HasSameBinningAs(const RAxisBase& other) con
    if (bool(lbl_ptr) != bool(other_lbl_ptr)) {
       return false;
    } else if (lbl_ptr) {
-      return lbl_ptr->CompareBinLabels(*other_lbl_ptr) == RAxisLabels::kSame;
+      auto lbl_cmp = lbl_ptr->CompareBinLabels(*other_lbl_ptr);
+      return (lbl_cmp == RAxisLabels::kLabelsCmpSame);
    } else {
       return true;
    }

--- a/hist/histv7/test/add.cxx
+++ b/hist/histv7/test/add.cxx
@@ -6,26 +6,32 @@
 TEST(HistAddTest, AddEmptyHist) {
   ROOT::Experimental::RH1F hFrom({100,0.,1});
   ROOT::Experimental::RH1F hTo({100,0.,1});
-  hFrom.Fill({0.1111}, .42f);
+  hFrom.Fill({0.1111}, 0.12f);
+  hFrom.Fill({0.1111}, 0.34f);
   ROOT::Experimental::Add(hTo, hFrom);
-  EXPECT_FLOAT_EQ(0.42f, hTo.GetBinContent({0.1111}));
+  EXPECT_EQ(2, hTo.GetEntries());
+  EXPECT_FLOAT_EQ(0.46f, hTo.GetBinContent({0.1111}));
 }
 
 // Test "x + 0 = x"
 TEST(HistAddTest, AddEmptySelf) {
    ROOT::Experimental::RH1F hFrom({100,0.,1});
    ROOT::Experimental::RH1F hTo({100,0.,1});
-   hTo.Fill({0.1111}, .42f);
+   hTo.Fill({0.1111}, 0.12f);
+   hTo.Fill({0.1111}, 0.34f);
    ROOT::Experimental::Add(hTo, hFrom);
-   EXPECT_FLOAT_EQ(0.42f, hTo.GetBinContent({0.1111}));
+   EXPECT_EQ(2, hTo.GetEntries());
+   EXPECT_FLOAT_EQ(0.46f, hTo.GetBinContent({0.1111}));
 }
 
 // Test "x + x = 2*x"
 TEST(HistAddTest, AddSelfHist) {
    ROOT::Experimental::RH1F hist({100,0.,1});
-   hist.Fill({0.1111}, .42f);
+   hist.Fill({0.1111}, .12f);
+   hist.Fill({0.1111}, .34f);
    ROOT::Experimental::Add(hist, hist);
-   EXPECT_FLOAT_EQ(0.84f, hist.GetBinContent({0.1111}));
+   EXPECT_EQ(4, hist.GetEntries());
+   EXPECT_FLOAT_EQ(0.92f, hist.GetBinContent({0.1111}));
 }
 
 // Test "x - x = 0"
@@ -35,6 +41,7 @@ TEST(HistAddTest, SubstractSelfHist) {
    hFrom.Fill({0.1111}, -.42f);
    hTo.Fill({0.1111}, .42f);
    ROOT::Experimental::Add(hTo, hFrom);
+   EXPECT_EQ(2, hTo.GetEntries());
    EXPECT_FLOAT_EQ(.00f, hTo.GetBinContent({0.1111}));
 }
 
@@ -46,10 +53,6 @@ TEST(HistAddTest, AddHist) {
    hFrom.Fill({0.1111}, .42f);
    hTo.Fill({0.1111}, .17f);
    ROOT::Experimental::Add(hTo, hFrom);
+   EXPECT_EQ(2, hTo.GetEntries());
    EXPECT_FLOAT_EQ(0.59f, hTo.GetBinContent({0.1111}));
-}
-
-// Test addition of a hist range
-TEST(HistAddTest, AddView) {
-  EXPECT_EQ(1, 1);
 }

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -446,6 +446,32 @@ TEST(AxisTest, Labels) {
         EXPECT_EQ(caxis.GetBinLabels()[i], expected_labels[i]);
       }
 
+      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(expected_labels)),
+                RAxisLabels::kSame);
+      const std::vector<std::string_view> missing_last_label(
+        expected_labels.cbegin(), expected_labels.cend() - 1);
+      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(missing_last_label)),
+                RAxisLabels::kSubset);
+      auto one_extra_label = expected_labels;
+      one_extra_label.push_back("I AM ROOT");
+      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(one_extra_label)),
+                RAxisLabels::kSuperset);
+      auto swapped_labels = expected_labels;
+      std::swap(swapped_labels[0], swapped_labels[expected_labels.size()-1]);
+      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
+                RAxisLabels::kDisordered);
+      auto changed_one_label = expected_labels;
+      changed_one_label[0] = "I AM ROOT";
+      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(changed_one_label)),
+                RAxisLabels::kSubset | RAxisLabels::kSuperset);
+      auto removed_first = expected_labels;
+      removed_first.erase(removed_first.cbegin());
+      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(removed_first)),
+                RAxisLabels::kSubset | RAxisLabels::kDisordered);
+      swapped_labels.push_back("I AM ROOT");
+      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
+                RAxisLabels::kSuperset | RAxisLabels::kDisordered);
+
       RAxisConfig cfg(caxis);
       EXPECT_EQ(cfg.GetTitle(), title);
       EXPECT_EQ(cfg.GetNBinsNoOver(), static_cast<int>(expected_labels.size()));

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -335,18 +335,6 @@ TEST(AxisTest, Equidistant) {
     SCOPED_TRACE("Equidistant axis with title");
     test(RAxisEquidistant("RITLE_E2", 10, 1.2, 3.4), "RITLE_E2");
   }
-
-  // Only RAxisEquidistant currently has an equality operator defined
-  RAxisEquidistant axis1("Title", 12, 3.4, 5.6);
-  EXPECT_EQ(axis1, RAxisEquidistant("Ritle", 12, 3.4, 5.6));
-
-  // Title is ignored by the equality operator, and CanMap relies on this
-  EXPECT_EQ(axis1, RAxisEquidistant("Ritl", 12, 3.4, 5.6));
-
-  // Everything else is taken into account by the equality operator
-  EXPECT_NE(axis1, RAxisEquidistant("Ritle", 13, 3.4, 5.6));
-  EXPECT_NE(axis1, RAxisEquidistant("Ritle", 12, 3.5, 5.6));
-  EXPECT_NE(axis1, RAxisEquidistant("Ritle", 12, 3.4, 5.7));
 }
 
 TEST(AxisTest, Growable) {

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -447,30 +447,30 @@ TEST(AxisTest, Labels) {
       }
 
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(expected_labels)),
-                RAxisLabels::kSame);
+                RAxisLabels::kLabelsCmpSame);
       const std::vector<std::string_view> missing_last_label(
         expected_labels.cbegin(), expected_labels.cend() - 1);
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(missing_last_label)),
-                RAxisLabels::kSubset);
+                RAxisLabels::kLabelsCmpSubset);
       auto one_extra_label = expected_labels;
       one_extra_label.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(one_extra_label)),
-                RAxisLabels::kSuperset);
+                RAxisLabels::kLabelsCmpSuperset);
       auto swapped_labels = expected_labels;
       std::swap(swapped_labels[0], swapped_labels[expected_labels.size()-1]);
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
-                RAxisLabels::kDisordered);
+                RAxisLabels::kLabelsCmpDisordered);
       auto changed_one_label = expected_labels;
       changed_one_label[0] = "I AM ROOT";
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(changed_one_label)),
-                RAxisLabels::kSubset | RAxisLabels::kSuperset);
+                RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset);
       auto removed_first = expected_labels;
       removed_first.erase(removed_first.cbegin());
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(removed_first)),
-                RAxisLabels::kSubset | RAxisLabels::kDisordered);
+                RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpDisordered);
       swapped_labels.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
-                RAxisLabels::kSuperset | RAxisLabels::kDisordered);
+                RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered);
 
       RAxisConfig cfg(caxis);
       EXPECT_EQ(cfg.GetTitle(), title);

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -515,6 +515,59 @@ TEST(AxisTest, Labels) {
   }
 }
 
+TEST(AxisTest, SameBinning) {
+  using EqAxis = RAxisEquidistant;
+  using GrowAxis = RAxisGrow;
+  using IrrAxis = RAxisIrregular;
+  using LabAxis = RAxisLabels;
+
+  auto test_eq = [](const RAxisBase& base, bool grow) {
+    EXPECT_EQ(base.HasSameBinningAs(EqAxis(4, 1.2, 3.4)), !grow);
+    EXPECT_EQ(base.HasSameBinningAs(EqAxis("RitleEq", 4, 1.2, 3.4)), !grow);
+    EXPECT_EQ(base.HasSameBinningAs(GrowAxis(4, 1.2, 3.4)), grow);
+    EXPECT_EQ(base.HasSameBinningAs(GrowAxis("RitleGrow", 4, 1.2, 3.4)), grow);
+    // NOTE: Whether an IrrAxis with the "same" bin boundaries is considered to
+    //       have the same binning is left unspecified for now.
+    EXPECT_FALSE(base.HasSameBinningAs(EqAxis(6, 1.2, 3.4)));
+    EXPECT_FALSE(base.HasSameBinningAs(EqAxis(4, 1.7, 3.4)));
+    EXPECT_FALSE(base.HasSameBinningAs(EqAxis(4, 1.2, 3.9)));
+    EXPECT_FALSE(base.HasSameBinningAs(IrrAxis({0.1, 2.3, 4.5, 6.7, 8.9})));
+    // FIXME: Workaround for RAxisLabels constructor ambiguity
+    const std::vector<std::string_view> four_labels({"a", "bc", "def", "g"});
+    EXPECT_FALSE(base.HasSameBinningAs(LabAxis(four_labels)));
+  };
+  {
+    SCOPED_TRACE("Equidistant axis");
+    test_eq(EqAxis(4, 1.2, 3.4), false);
+  }
+  {
+    SCOPED_TRACE("Growable axis");
+    test_eq(GrowAxis(4, 1.2, 3.4), true);
+  }
+
+  const IrrAxis irr({1.2, 3.4, 5.6});
+  const RAxisBase& ibase = irr;
+  EXPECT_TRUE(ibase.HasSameBinningAs(IrrAxis({1.2, 3.4, 5.6})));
+  EXPECT_TRUE(ibase.HasSameBinningAs(IrrAxis("RitleIrr", {1.2, 3.4, 5.6})));
+  // NOTE: Whether an EqAxis with the "same" bin boundaries is considered to
+  //       have the same binning is left unspecified for now.
+  EXPECT_FALSE(ibase.HasSameBinningAs(EqAxis(2, 1.2, 3.4)));
+  EXPECT_FALSE(ibase.HasSameBinningAs(GrowAxis(2, 1.2, 3.4)));
+  // FIXME: Workaround for RAxisLabels constructor ambiguity
+  const std::vector<std::string_view> two_labels({"abc", "d"});
+  EXPECT_FALSE(ibase.HasSameBinningAs(LabAxis(two_labels)));
+
+  // FIXME: Workaround for RAxisLabels constructor ambiguity
+  const std::vector<std::string_view> three_labels({"ab", "cde" "f"});
+  const LabAxis lab(three_labels);
+  const RAxisBase& lbase = lab;
+  EXPECT_TRUE(lbase.HasSameBinningAs(LabAxis(three_labels)));
+  EXPECT_TRUE(lbase.HasSameBinningAs(LabAxis("RitleLab", three_labels)));
+  EXPECT_FALSE(lbase.HasSameBinningAs(EqAxis(3, 0., 3.)));
+  EXPECT_FALSE(lbase.HasSameBinningAs(GrowAxis(3, 0., 3.)));
+  EXPECT_FALSE(lbase.HasSameBinningAs(IrrAxis({0., 1., 2., 3.})));
+}
+
 TEST(AxisTest, ReverseBinLimits) {
   {
     RAxisConfig cfg(10, 3.4, 1.2);

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -340,7 +340,7 @@ TEST(AxisTest, Equidistant) {
   RAxisEquidistant axis1("Title", 12, 3.4, 5.6);
   EXPECT_EQ(axis1, RAxisEquidistant("Ritle", 12, 3.4, 5.6));
 
-  // Title is ignored by the equality operator
+  // Title is ignored by the equality operator, and CanMap relies on this
   EXPECT_EQ(axis1, RAxisEquidistant("Ritl", 12, 3.4, 5.6));
 
   // Everything else is taken into account by the equality operator


### PR DESCRIPTION
As reported in [ROOT-10490](https://sft.its.cern.ch/jira/browse/ROOT-10490), the way we currently merge histogram statistics in `Add(RHist, RHist)` yields incorrect results.

Following discussion with @Axel-Naumann, this PR proposes to resolve this problem by reducing the scope of histogram merging, only accepting the merging of histograms with the same axis configuration (more precisely with identical axis binning), which allows use of a much simpler statistics summation rule.

Once accepted, it will resolve [ROOT-10490](https://sft.its.cern.ch/jira/browse/ROOT-10490).

cc @rete