### PR TITLE
[RF][ Remove unsafe casts in RooResolutionModel

### DIFF
--- a/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
+++ b/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
@@ -75,7 +75,12 @@ public:
                                        const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const ;
   virtual Bool_t changeModel(const RooResolutionModel& newModel) ;
 
-  const RooRealVar* convVar() const ;  //  Convolution variable 
+  /// Retrieve the convolution variable.
+  RooAbsRealLValue* convVar();
+  /// Retrieve the convolution variable.
+  const RooAbsRealLValue* convVar() const {
+    return const_cast<RooAbsAnaConvPdf*>(this)->convVar();
+  }
 
 protected:
   Double_t getCoefNorm(Int_t coefIdx, const RooArgSet* nset, const TNamed* rangeName) const ;

--- a/roofit/roofitcore/inc/RooConvGenContext.h
+++ b/roofit/roofitcore/inc/RooConvGenContext.h
@@ -24,7 +24,6 @@ class RooDataSet;
 class RooRealIntegral;
 class RooAcceptReject;
 class TRandom;
-class TIterator;
 class RooRealVar ;
 class RooNumConvPdf ;
 class RooFFTConvPdf ;
@@ -61,9 +60,9 @@ protected:
   RooArgSet* _modelVars ;       // Holder of resModel event
   RooArgSet* _pdfCloneSet ;     // Owner of PDF clone
   RooArgSet* _modelCloneSet ;   // Owner of resModel clone
-  RooRealVar* _cvModel ;         // Convolution variable in resModel event
-  RooRealVar* _cvPdf ;           // Convolution variable in PDFxTruth event
-  RooRealVar* _cvOut ;           // Convolution variable in output event
+  RooRealVar* _cvModel{nullptr};         // Convolution variable in resModel event
+  RooRealVar* _cvPdf{nullptr};           // Convolution variable in PDFxTruth event
+  RooRealVar* _cvOut{nullptr};           // Convolution variable in output event
 
   ClassDef(RooConvGenContext,0) // Context for generating a dataset from a PDF
 };

--- a/roofit/roofitcore/inc/RooResolutionModel.h
+++ b/roofit/roofitcore/inc/RooResolutionModel.h
@@ -17,7 +17,7 @@
 #define ROO_RESOLUTION_MODEL
 
 #include "RooAbsPdf.h"
-#include "RooRealProxy.h"
+#include "RooProxy.h"
 #include "RooRealVar.h"
 #include "RooFormulaVar.h"
 
@@ -39,7 +39,10 @@ public:
 
   Double_t getValV(const RooArgSet* nset=0) const ;
   virtual RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const ;
-  RooRealVar& convVar() const ;
+  /// Return the convolution variable of the resolution model.
+  const RooAbsRealLValue& convVar() const {return *x;}
+  /// Return the convolution variable of the resolution model.
+  RooAbsRealLValue& convVar() {return *x;}
   const RooRealVar& basisConvVar() const ;
 
   inline Bool_t isBasisSupported(const char* name) const { return basisCode(name)?kTRUE:kFALSE ; }

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -318,7 +318,7 @@ Bool_t RooAbsAnaConvPdf::isDirectGenSafe(const RooAbsArg& arg) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return a pointer to the convolution variable instance used in the resolution model
 
-const RooRealVar* RooAbsAnaConvPdf::convVar() const
+RooAbsRealLValue* RooAbsAnaConvPdf::convVar()
 {
   RooResolutionModel* conv = (RooResolutionModel*) _convSet.at(0) ;
   if (!conv) return 0 ;  

--- a/roofit/roofitcore/src/RooConvGenContext.cxx
+++ b/roofit/roofitcore/src/RooConvGenContext.cxx
@@ -71,9 +71,13 @@ RooConvGenContext::RooConvGenContext(const RooAbsAnaConvPdf &model, const RooArg
   }
 
   RooAbsAnaConvPdf* pdfClone = (RooAbsAnaConvPdf*) _pdfCloneSet->find(model.GetName()) ;
-  RooTruthModel truthModel("truthModel","Truth resolution model",(RooRealVar&)*pdfClone->convVar()) ;
+  RooTruthModel truthModel("truthModel","Truth resolution model",*pdfClone->convVar()) ;
   pdfClone->changeModel(truthModel) ;
-  ((RooRealVar*)pdfClone->convVar())->removeRange() ;
+  auto convV = dynamic_cast<RooRealVar*>(pdfClone->convVar());
+  if (!convV) {
+    throw std::runtime_error("RooConvGenContext only works with convolution variables of type RooRealVar.");
+  }
+  convV->removeRange();
 
   // Create generator for physics X truth model
   _pdfVars = (RooArgSet*) pdfClone->getObservables(&vars) ; ;
@@ -89,7 +93,11 @@ RooConvGenContext::RooConvGenContext(const RooAbsAnaConvPdf &model, const RooArg
     _modelCloneSet->find(model._convSet.at(0)->GetName())->Clone("smearing") ;
   _modelCloneSet->addOwned(*modelClone) ;
   modelClone->changeBasis(0) ;
-  modelClone->convVar().removeRange() ;
+  convV = dynamic_cast<RooRealVar*>(&modelClone->convVar());
+  if (!convV) {
+    throw std::runtime_error("RooConvGenContext only works with convolution variables of type RooRealVar.");
+  }
+  convV->removeRange();
 
   // Create generator for resolution model as PDF
   _modelVars = (RooArgSet*) modelClone->getObservables(&vars) ;

--- a/roofit/roofitcore/src/RooResolutionModel.cxx
+++ b/roofit/roofitcore/src/RooResolutionModel.cxx
@@ -241,17 +241,6 @@ const RooRealVar& RooResolutionModel::basisConvVar() const
 }
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return the convolution variable of the resolution model
-
-RooRealVar& RooResolutionModel::convVar() const 
-{
-  return (RooRealVar&) x.arg() ;
-}
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Modified version of RooAbsPdf::getValF(). If used as regular PDF, 
 /// call RooAbsPdf::getValF(), otherwise return unnormalized value


### PR DESCRIPTION
RooResolutionModels can accept RooAbsRealLValue as convolution variable,
but the function convVar() just returned a c-style cast to RooRealVar&.
Removing this required generalising a few other interfaces.