### PR TITLE
[Exp PyROOT][ROOT-9040] Don't set kMustCleanup to force RecursiveRemove

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/src/TMemoryRegulator.cxx
+++ b/bindings/pyroot_experimental/pythonizations/src/TMemoryRegulator.cxx
@@ -41,8 +41,6 @@ std::pair<bool, bool> PyROOT::TMemoryRegulator::RegisterHook(Cppyy::TCppObject_t
    if (Cppyy::IsSubtype(klass, tobjectTypeID)) {
       ObjectMap_t::iterator ppo = fObjectMap.find(cppobj);
       if (ppo == fObjectMap.end()) {
-         // Set cleanup bit so RecursiveRemove is tried on registered object
-         ((TObject*)cppobj)->SetBit(TObject::kMustCleanup);
          fObjectMap.insert({cppobj, klass});
       }
    }
@@ -100,8 +98,10 @@ void PyROOT::TMemoryRegulator::ClearProxiedObjects()
 
       if (pyobj && (pyobj->fFlags & CPPInstance::kIsOwner)) {
          // Only delete the C++ object if the Python proxy owns it.
-         // The deletion will trigger RecursiveRemove on the object
-         delete static_cast<TObject *>(cppobj);
+         // Invoke RecursiveRemove on it first so that proxy cleanup is done
+         auto o = static_cast<TObject *>(cppobj);
+         RecursiveRemove(o);
+         delete o;
       }
       else {
          // Non-owning proxy, just unregister to clean tables.


### PR DESCRIPTION
Both in current PyROOT and experimental, TMemoryRegulator sets
the kMustCleanup bit to true for objects it is tracking (proxied
objects). This is done to make sure RecursiveRemove is called on
them when they are deleted.

ROOT-9040 points to a case when this is a problem: when calling
TMultiGraph::GetListOfGraphs(), the kMustCleanup bit of the returned
list is set to true (initially it was false) and this causes
the list to go through RecursiveRemove, which ends up in a crash.

This commit tries to solve the issue by not setting kMustCleanup
in TMemoryRegulator nor relying on the delete operation on a
proxied object to call RecursiveRemove. Instead, the call to
RecursiveRemove is done explicitly before deleting the object.
