### PR TITLE
Fix  storing and retrieving the running means and variances of the BacthNorm layer

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
@@ -112,6 +112,8 @@ public:
 
    static void InitializeOneVector(size_t n);
 
+   TCpuMatrix() : fNCols(0), fNRows(0) {}
+
    /** Construct matrix and allocate space for its elements. */
    TCpuMatrix(size_t nRows, size_t nCols);
    /** Construct a TCpuMatrix object by (deeply) copying from a

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1283,13 +1283,7 @@ void MethodDL::TrainDeepNet()
       if (trainingPhase > 1) {
          // copy initial weights from fNet to deepnet
          for (size_t i = 0; i < deepNet.GetDepth(); ++i) {
-            const auto & nLayer = fNet->GetLayerAt(i);
-            const auto & dLayer = deepNet.GetLayerAt(i);
-            // could use a traits for detecting equal architectures
-           // dLayer->CopyWeights(nLayer->GetWeights());
-           //  dLayer->CopyBiases(nLayer->GetBiases());
-            Architecture_t::CopyDiffArch(dLayer->GetWeights(), nLayer->GetWeights() );
-            Architecture_t::CopyDiffArch(dLayer->GetBiases(), nLayer->GetBiases() );
+            deepNet.GetLayerAt(i)->CopyParameters(*fNet->GetLayerAt(i));
          }
       }
 
@@ -1551,14 +1545,11 @@ void MethodDL::TrainDeepNet()
                Log() << std::setw(10) << optimizer->GetGlobalStep()
                      << " Minimum Test error found - save the configuration " << Endl;
                for (size_t i = 0; i < deepNet.GetDepth(); ++i) {
-                  const auto & nLayer = fNet->GetLayerAt(i);
-                  const auto & dLayer = deepNet.GetLayerAt(i);
-                  ArchitectureImpl_t::CopyDiffArch(nLayer->GetWeights(), dLayer->GetWeights() );
-                  ArchitectureImpl_t::CopyDiffArch(nLayer->GetBiases(), dLayer->GetBiases() );
-                  // std::cout << "Weights for layer " << i << std::endl;
-                  // for (size_t k = 0; k < dlayer->GetWeights().size(); ++k)
-                  //    dLayer->GetWeightsAt(k).Print();
-                  // debug tensors
+                  fNet->GetLayerAt(i)->CopyParameters(*deepNet.GetLayerAt(i));
+                  // if (i == 0 && deepNet.GetLayerAt(0)->GetWeights().size() > 1) {
+                  //    Architecture_t::PrintTensor(deepNet.GetLayerAt(0)->GetWeightsAt(0), " input weights");
+                  //    Architecture_t::PrintTensor(deepNet.GetLayerAt(0)->GetWeightsAt(1), " state weights");
+                  // }
                }
                // Architecture_t::PrintTensor(deepNet.GetLayerAt(1)->GetWeightsAt(0), " cudnn weights");
                // ArchitectureImpl_t::PrintTensor(fNet->GetLayerAt(1)->GetWeightsAt(0), " cpu weights");
@@ -1855,10 +1846,11 @@ std::vector<Double_t> MethodDL::PredictDeepNet(Long64_t firstEvt, Long64_t lastE
 
    // copy weights from the saved fNet to the built DeepNet
    for (size_t i = 0; i < deepNet.GetDepth(); ++i) {
-      const auto & nLayer = fNet->GetLayerAt(i);
-      const auto & dLayer = deepNet.GetLayerAt(i);
-      Architecture_t::CopyDiffArch(dLayer->GetWeights(), nLayer->GetWeights() );
-      Architecture_t::CopyDiffArch(dLayer->GetBiases(), nLayer->GetBiases() );
+      deepNet.GetLayerAt(i)->CopyParameters(*fNet->GetLayerAt(i));
+      // if (i == 0 && deepNet.GetLayerAt(0)->GetWeights().size() > 1) {
+      //    Architecture_t::PrintTensor(deepNet.GetLayerAt(0)->GetWeightsAt(0), "Inference: input weights");
+      //    Architecture_t::PrintTensor(deepNet.GetLayerAt(0)->GetWeightsAt(1), "Inference: state weights");
+      // }
    }
 
    size_t n1 = deepNet.GetBatchHeight();


### PR DESCRIPTION
In this case of the BatchNormLayer there are some parameters (mu and variance) which are computed during training but they are not weights. 
They need however to be stored in the xml file.
For doing this, a virtual function to get and set extra parameters has been defined in the GeneralLayer
and it is re-implemented in the BatchNormLayer

A new function GeneralLayer::CopyParameters has been introduced and it allows to copy all parameters (weights , bias + extras) when saving a model