### PR TITLE
Fix memory leak in TGraph2DPainter::PaintContour

### DIFF
--- a/hist/histpainter/src/TGraph2DPainter.cxx
+++ b/hist/histpainter/src/TGraph2DPainter.cxx
@@ -581,6 +581,7 @@ void TGraph2DPainter::PaintContour(Option_t * /*option*/)
             g->Paint("l");
          }
       }
+      if (l) { l->Delete(); delete l; }
    }
 }
 


### PR DESCRIPTION
Appears when TGrpah2D drawn with "cont5" option
Many TGraph objects are leaked, especially when zooming is performed