### PR TITLE
fix for 2nd part of ROOT-10528 

### DIFF
--- a/README/README.CXXMODULES.md
+++ b/README/README.CXXMODULES.md
@@ -192,7 +192,7 @@ namespace {
   void TriggerDictionaryInitialization_libFoo_Impl() {
     static const char* headers[] = {"Foo.h"}
     // More scaffolding
-    extern int __Cling_Autoloading_Map;
+    extern int __Cling_AutoLoading_Map;
     namespace foo{struct __attribute__((annotate("$clingAutoload$Foo.h"))) bar;}
     struct __attribute__((annotate("$clingAutoload$Foo.h"))) S;
     // More initialization scaffolding.
@@ -245,7 +245,7 @@ root [] namespace foo { };struct S;
 root [] foo::bar/*store parsing state*/
         gSystem->Load("Foo");
         // More scaffolding.
-        extern int __Cling_Autoloading_Map;
+        extern int __Cling_AutoLoading_Map;
         namespace foo{struct __attribute__((annotate("$clingAutoload$Foo.h"))) bar;}
         struct __attribute__((annotate("$clingAutoload$Foo.h"))) S;
         // More initialization scaffolding.
@@ -262,7 +262,7 @@ root [] namespace foo { };struct S;
 root [] foo::bar/*store parsing state*/
         gSystem->Load("Foo");
         // More scaffolding.
-        extern int __Cling_Autoloading_Map;
+        extern int __Cling_AutoLoading_Map;
         namespace foo{struct __attribute__((annotate("$clingAutoload$Foo.h"))) bar;}
         struct __attribute__((annotate("$clingAutoload$Foo.h"))) S;
         // More initialization scaffolding.

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -117,16 +117,16 @@ public:
    };
    virtual Bool_t IsAutoParsingSuspended() const = 0;
 
-   class SuspendAutoloadingRAII {
+   class SuspendAutoLoadingRAII {
       TInterpreter *fInterp = nullptr;
       bool fOldValue;
 
    public:
-      SuspendAutoloadingRAII(TInterpreter *interp) : fInterp(interp)
+      SuspendAutoLoadingRAII(TInterpreter *interp) : fInterp(interp)
       {
-         fOldValue = fInterp->SetClassAutoloading(false);
+         fOldValue = fInterp->SetClassAutoLoading(false);
       }
-      ~SuspendAutoloadingRAII() { fInterp->SetClassAutoloading(fOldValue); }
+      ~SuspendAutoLoadingRAII() { fInterp->SetClassAutoLoading(fOldValue); }
    };
 
    typedef int (*AutoLoadCallBack_t)(const char*);
@@ -258,7 +258,8 @@ public:
    virtual const char *MapCppName(const char*) const {return 0;}
    virtual void   SetAlloclockfunc(void (*)()) const {;}
    virtual void   SetAllocunlockfunc(void (*)()) const {;}
-   virtual int    SetClassAutoloading(int) const {return 0;}
+   virtual int    SetClassAutoLoading(int) const {return 0;}
+           int    SetClassAutoloading(int a) const { return SetClassAutoLoading(a); }  // Deprecated
    virtual int    SetClassAutoparsing(int) {return 0;};
    virtual void   SetErrmsgcallback(void * /* p */) const {;}
    virtual void   SetTempLevel(int /* val */) const {;}

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -2974,7 +2974,7 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent)
 
    if (!cl) {
       {
-         TInterpreter::SuspendAutoloadingRAII autoloadOff(gInterpreter);
+         TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
          TClassEdit::GetNormalizedName(normalizedName, name);
       }
       // Try the normalized name.
@@ -3178,15 +3178,15 @@ TClass *TClass::GetClass(const std::type_info& typeinfo, Bool_t load, Bool_t /* 
       }
    }
 
-   // try autoloading the typeinfo
-   int autoload_old = gCling->SetClassAutoloading(1);
+   // try AutoLoading the typeinfo
+   int autoload_old = gCling->SetClassAutoLoading(1);
    if (!autoload_old) {
       // Re-disable, we just meant to test
-      gCling->SetClassAutoloading(0);
+      gCling->SetClassAutoLoading(0);
    }
    if (autoload_old && gInterpreter->AutoLoad(typeinfo,kTRUE)) {
       // Disable autoload to avoid potential infinite recursion
-      TInterpreter::SuspendAutoloadingRAII autoloadOff(gInterpreter);
+      TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
       cl = GetClass(typeinfo, load);
       if (cl) {
          return cl;
@@ -4031,7 +4031,7 @@ void TClass::ReplaceWith(TClass *newcl) const
    // Since we are in the process of replacing a TClass by a TClass
    // coming from a dictionary, there is no point in loading any
    // libraries during this search.
-   TInterpreter::SuspendAutoloadingRAII autoloadOff(gInterpreter);
+   TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
    while ((acl = (TClass*)nextClass())) {
       if (acl == newcl) continue;
 
@@ -6076,7 +6076,7 @@ void TClass::SetUnloaded()
    // Disable the autoloader while calling SetClassInfo, to prevent
    // the library from being reloaded!
    {
-      TInterpreter::SuspendAutoloadingRAII autoloadOff(gInterpreter);
+      TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
       TInterpreter::SuspendAutoParsing autoParseRaii(gCling);
       gInterpreter->SetClassInfo(this,kTRUE);
    }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1346,7 +1346,7 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
          // this by accident.
          interpArgs.push_back("-Rmodule-build");
       }
-      // ROOT implements its autoloading upon module's link directives. We
+      // ROOT implements its AutoLoading upon module's link directives. We
       // generate module A { header "A.h" link "A.so" export * } where ROOT's
       // facilities use the link directive to dynamically load the relevant
       // library. So, we need to suppress clang's default autolink behavior.
@@ -1391,7 +1391,7 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
    // Don't check whether modules' files exist.
    fInterpreter->getCI()->getPreprocessorOpts().DisablePCHValidation = true;
 
-   // Until we can disable autoloading during Sema::CorrectTypo() we have
+   // Until we can disable AutoLoading during Sema::CorrectTypo() we have
    // to disable spell checking.
    fInterpreter->getCI()->getLangOpts().SpellChecking = false;
 
@@ -1479,7 +1479,7 @@ void TCling::Initialize()
    TClass::ReadRules(); // Read the default customization rules ...
 
    LoadLibraryMap();
-   SetClassAutoloading(true);
+   SetClassAutoLoading(true);
 }
 
 void TCling::ShutDown()
@@ -1703,7 +1703,7 @@ void TCling::LoadPCMImpl(TFile &pcmFile)
 
 void TCling::LoadPCM(std::string pcmFileNameFullPath)
 {
-   SuspendAutoloadingRAII autoloadOff(this);
+   SuspendAutoLoadingRAII autoloadOff(this);
    SuspendAutoParsing autoparseOff(this);
    assert(!pcmFileNameFullPath.empty());
    assert(llvm::sys::path::is_absolute(pcmFileNameFullPath));
@@ -1937,9 +1937,9 @@ void TCling::RegisterModule(const char* modulename,
    // better than nothing.
    fLookedUpClasses.clear();
 
-   // Make sure we do not set off autoloading or autoparsing during the
+   // Make sure we do not set off AutoLoading or autoparsing during the
    // module registration!
-   SuspendAutoloadingRAII autoLoadOff(this);
+   SuspendAutoLoadingRAII autoLoadOff(this);
 
    for (const char** inclPath = includePaths; *inclPath; ++inclPath) {
       TCling::AddIncludePath(*inclPath);
@@ -2913,7 +2913,7 @@ bool TCling::Declare(const char* code)
 {
    R__LOCKGUARD_CLING(gInterpreterMutex);
 
-   SuspendAutoloadingRAII autoLoadOff(this);
+   SuspendAutoLoadingRAII autoLoadOff(this);
    SuspendAutoParsing autoParseRaii(this);
 
    bool oldDynLookup = fInterpreter->isDynamicLookupEnabled();
@@ -3864,8 +3864,8 @@ TCling::CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamesp
       return kUnknown;
    }
 
-   // Do not turn on the autoloading if it is globally off.
-   autoload = autoload && IsClassAutoloadingEnabled();
+   // Do not turn on the AutoLoading if it is globally off.
+   autoload = autoload && IsClassAutoLoadingEnabled();
 
    // Avoid the double search below in case the name is a fundamental type
    // or typedef to a fundamental type.
@@ -3887,7 +3887,7 @@ TCling::CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamesp
 
    const char *classname = name;
 
-   int storeAutoload = SetClassAutoloading(autoload);
+   int storeAutoload = SetClassAutoLoading(autoload);
 
    // First we want to check whether the decl exist, but _without_
    // generating any template instantiation. However, the lookup
@@ -3933,14 +3933,14 @@ TCling::CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamesp
             // findscope.
             if (ROOT::TMetaUtils::IsSTLCont(*tmpltDecl)) {
                // For STL Collection we return kUnknown.
-               SetClassAutoloading(storeAutoload);
+               SetClassAutoLoading(storeAutoload);
                return kUnknown;
             }
          }
       }
       TClingClassInfo tci(GetInterpreterImpl(), *type);
       if (!tci.IsValid()) {
-         SetClassAutoloading(storeAutoload);
+         SetClassAutoLoading(storeAutoload);
          return kUnknown;
       }
       auto propertiesMask = isClassOrNamespaceOnly ? kIsClass | kIsStruct | kIsNamespace :
@@ -3967,19 +3967,19 @@ TCling::CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamesp
          // , hasClassDefInline);
 
          // We are now sure that the entry is not in fact an autoload entry.
-         SetClassAutoloading(storeAutoload);
+         SetClassAutoLoading(storeAutoload);
          if (hasClassDefInline)
             return kWithClassDefInline;
          else
             return kKnown;
       } else {
          // We are now sure that the entry is not in fact an autoload entry.
-         SetClassAutoloading(storeAutoload);
+         SetClassAutoLoading(storeAutoload);
          return kUnknown;
       }
    }
 
-   SetClassAutoloading(storeAutoload);
+   SetClassAutoLoading(storeAutoload);
    if (decl)
       return kKnown;
    else
@@ -3991,7 +3991,7 @@ TCling::CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamesp
    TClingTypedefInfo t(fInterpreter, name);
    if (t.IsValid() && !(t.Property() & kIsFundamental)) {
       delete[] classname;
-      SetClassAutoloading(storeAutoload);
+      SetClassAutoLoading(storeAutoload);
       return kTRUE;
    }
    */
@@ -4002,7 +4002,7 @@ TCling::CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamesp
 //      decl = lh.findScope(buf);
 //   }
 
-//   SetClassAutoloading(storeAutoload);
+//   SetClassAutoLoading(storeAutoload);
 //   return (decl);
 }
 
@@ -5345,7 +5345,7 @@ namespace {
    using namespace clang;
 
    class ExtVisibleStorageAdder: public RecursiveASTVisitor<ExtVisibleStorageAdder>{
-      // This class is to be considered an helper for autoloading.
+      // This class is to be considered an helper for AutoLoading.
       // It is a recursive visitor is used to inspect namespaces coming from
       // forward declarations in rootmaps and to set the external visible
       // storage flag for them.
@@ -5707,7 +5707,7 @@ Int_t TCling::UnloadLibraryMap(const char* library)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Register the autoloading information for a class.
+/// Register the AutoLoading information for a class.
 /// libs is a space separated list of libraries.
 
 Int_t TCling::SetClassSharedLibs(const char *cls, const char *libs)
@@ -5758,7 +5758,7 @@ TClass *TCling::GetClass(const std::type_info& typeinfo, Bool_t load) const
 
 Int_t TCling::AutoLoad(const std::type_info& typeinfo, Bool_t knowDictNotLoaded /* = kFALSE */)
 {
-   assert(IsClassAutoloadingEnabled() && "Calling when autoloading is off!");
+   assert(IsClassAutoLoadingEnabled() && "Calling when AutoLoading is off!");
 
    int err = 0;
    char* demangled_name_c = TClassEdit::DemangleTypeIdName(typeinfo, err);
@@ -5796,7 +5796,7 @@ Int_t TCling::AutoLoad(const char *cls, Bool_t knowDictNotLoaded /* = kFALSE */)
    // rootcling (in *_rdict.pcm file generation) it is a no op.
    // FIXME: We should avoid calling autoload when we know we are not supposed
    // to and transform this check into an assert.
-   if (!IsClassAutoloadingEnabled()) {
+   if (!IsClassAutoLoadingEnabled()) {
       // Never load any library from rootcling/genreflex.
       if (gDebug > 2) {
          Info("TCling::AutoLoad", "Explicitly disabled (the class name is %s)", cls);
@@ -5804,7 +5804,7 @@ Int_t TCling::AutoLoad(const char *cls, Bool_t knowDictNotLoaded /* = kFALSE */)
       return 0;
    }
 
-   assert(IsClassAutoloadingEnabled() && "Calling when autoloading is off!");
+   assert(IsClassAutoLoadingEnabled() && "Calling when AutoLoading is off!");
 
    R__LOCKGUARD(gInterpreterMutex);
 
@@ -5831,7 +5831,7 @@ Int_t TCling::AutoLoad(const char *cls, Bool_t knowDictNotLoaded /* = kFALSE */)
       return 0;
    }
    // Prevent the recursion when the library dictionary are loaded.
-   SuspendAutoloadingRAII autoLoadOff(this);
+   SuspendAutoLoadingRAII autoLoadOff(this);
    // Try using externally provided callback first.
    if (fAutoLoadCallBack) {
       int success = (*(AutoLoadCallBack_t)fAutoLoadCallBack)(cls);
@@ -6078,7 +6078,7 @@ Int_t TCling::AutoParse(const char *cls)
       return 0;
 
    if (!fHeaderParsingOnDemand || fIsAutoParsingSuspended) {
-      if (fClingCallbacks->IsAutoloadingEnabled()) {
+      if (fClingCallbacks->IsAutoLoadingEnabled()) {
          return AutoLoad(cls);
       } else {
          return 0;
@@ -6093,7 +6093,7 @@ Int_t TCling::AutoParse(const char *cls)
    }
 
    // The catalogue of headers is in the dictionary
-   if (fClingCallbacks->IsAutoloadingEnabled()
+   if (fClingCallbacks->IsAutoLoadingEnabled()
          && !gClassTable->GetDictNorm(cls)) {
       // Need RAII against recursive (dictionary payload) parsing (ROOT-8445).
       ROOT::Internal::ParsingStateRAII parsingStateRAII(fInterpreter->getParser(),
@@ -6102,7 +6102,7 @@ Int_t TCling::AutoParse(const char *cls)
    }
 
    // Prevent the recursion when the library dictionary are loaded.
-   SuspendAutoloadingRAII autoLoadOff(this);
+   SuspendAutoLoadingRAII autoLoadOff(this);
 
    // No recursive header parsing on demand; we require headers to be standalone.
    SuspendAutoParsing autoParseRAII(this);
@@ -6115,7 +6115,7 @@ Int_t TCling::AutoParse(const char *cls)
 }
 
 // This is a function which gets callback from cling when DynamicLibraryManager->loadLibrary failed for some reason.
-// Try to solve the problem by autoloading. Return true when autoloading success, return
+// Try to solve the problem by AutoLoading. Return true when AutoLoading success, return
 // false if not.
 bool TCling::LibraryLoadingFailed(const std::string& errmessage, const std::string& libStem, bool permanent, bool resolved)
 {
@@ -6298,7 +6298,7 @@ static std::string ResolveSymbol(const std::string& mangled_name,
    static BasePaths sPaths;
    static LibraryPaths sQueriedLibraries;
 
-   // For system header autoloading
+   // For system header AutoLoading
    static LibraryPaths sSysLibraries;
 
    if (sFirstRun) {
@@ -6583,7 +6583,7 @@ void TCling::UpdateClassInfoWithDecl(const NamedDecl* ND)
    // Supposedly we are being called while something is being
    // loaded ... let's now tell the autoloader to do the work
    // yet another time.
-   SuspendAutoloadingRAII autoLoadOff(this);
+   SuspendAutoLoadingRAII autoLoadOff(this);
    // FIXME: There can be more than one TClass for a single decl.
    // for example vector<double> and vector<Double32_t>
    TClass* cl = (TClass*)gROOT->GetListOfClasses()->FindObject(name.c_str());
@@ -6962,7 +6962,7 @@ const char* TCling::GetClassSharedLibs(const char* cls)
       if (className.contains("(lambda)"))
          return nullptr;
       // Limit the recursion which can be induced by GetClassSharedLibsForModule.
-      SuspendAutoloadingRAII AutoloadingDisabled(this);
+      SuspendAutoLoadingRAII AutoLoadingDisabled(this);
       cling::LookupHelper &LH = fInterpreter->getLookupHelper();
       std::string libs = GetClassSharedLibsForModule(cls, LH);
       if (!libs.empty()) {
@@ -7340,32 +7340,32 @@ void TCling::SetAllocunlockfunc(void (* /* p */ )()) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Returns if class autoloading is currently enabled.
+/// Returns if class AutoLoading is currently enabled.
 
-bool TCling::IsClassAutoloadingEnabled() const
+bool TCling::IsClassAutoLoadingEnabled() const
 {
    if (IsFromRootCling())
       return false;
    if (!fClingCallbacks)
       return false;
-   return fClingCallbacks->IsAutoloadingEnabled();
+   return fClingCallbacks->IsAutoLoadingEnabled();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Enable/Disable the Autoloading of libraries.
+/// Enable/Disable the AutoLoading of libraries.
 /// Returns the old value, i.e whether it was enabled or not.
 
-int TCling::SetClassAutoloading(int autoload) const
+int TCling::SetClassAutoLoading(int autoload) const
 {
    // If no state change is required, exit early.
    // FIXME: In future we probably want to complain if we made a request which
    // was with the same state as before in order to catch programming errors.
-   if ((bool) autoload == IsClassAutoloadingEnabled())
+   if ((bool) autoload == IsClassAutoLoadingEnabled())
       return autoload;
 
    assert(fClingCallbacks && "We must have callbacks!");
-   bool oldVal = fClingCallbacks->IsAutoloadingEnabled();
-   fClingCallbacks->SetAutoloadingEnabled(autoload);
+   bool oldVal = fClingCallbacks->IsAutoLoadingEnabled();
+   fClingCallbacks->SetAutoLoadingEnabled(autoload);
    return oldVal;
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3864,6 +3864,9 @@ TCling::CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamesp
       return kUnknown;
    }
 
+   // Do not turn on the autoloading if it is globally off.
+   autoload = autoload && IsClassAutoloadingEnabled();
+
    // Avoid the double search below in case the name is a fundamental type
    // or typedef to a fundamental type.
    THashTable *typeTable = dynamic_cast<THashTable*>( gROOT->GetListOfTypes() );

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -336,7 +336,7 @@ public: // Public Interface
    virtual const char* MapCppName(const char*) const;
    virtual void   SetAlloclockfunc(void (*)()) const;
    virtual void   SetAllocunlockfunc(void (*)()) const;
-   virtual int    SetClassAutoloading(int) const;
+   virtual int    SetClassAutoLoading(int) const;
    virtual int    SetClassAutoparsing(int) ;
            Bool_t IsAutoParsingSuspended() const { return fIsAutoParsingSuspended; }
    virtual void   SetErrmsgcallback(void* p) const;
@@ -572,13 +572,13 @@ private: // Private Utility Functions and Classes
                                         TListOfFunctionTemplates*,
                                         TListOfEnums*> &Lists, const clang::Decl *D);
 
-   class SuspendAutoloadingRAII {
+   class SuspendAutoLoadingRAII {
       TCling *fTCling = nullptr;
       bool fOldValue;
 
    public:
-      SuspendAutoloadingRAII(TCling *tcling) : fTCling(tcling) { fOldValue = fTCling->SetClassAutoloading(false); }
-      ~SuspendAutoloadingRAII() { fTCling->SetClassAutoloading(fOldValue); }
+      SuspendAutoLoadingRAII(TCling *tcling) : fTCling(tcling) { fOldValue = fTCling->SetClassAutoLoading(false); }
+      ~SuspendAutoLoadingRAII() { fTCling->SetClassAutoLoading(fOldValue); }
    };
 
    class TUniqueString {
@@ -614,7 +614,7 @@ private: // Private Utility Functions and Classes
    void InitRootmapFile(const char *name);
    int  ReadRootmapFile(const char *rootmapfile, TUniqueString* uniqueString = nullptr);
    Bool_t HandleNewTransaction(const cling::Transaction &T);
-   bool IsClassAutoloadingEnabled() const;
+   bool IsClassAutoLoadingEnabled() const;
    void ProcessClassesToUpdate();
    cling::Interpreter *GetInterpreterImpl() const { return fInterpreter.get(); }
    cling::MetaProcessor *GetMetaProcessorImpl() const { return fMetaProcessor.get(); }

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -40,8 +40,8 @@ private:
    void *fLastLookupCtx;
    clang::NamespaceDecl *fROOTSpecialNamespace;
    bool fFirstRun;
-   bool fIsAutoloading;
-   bool fIsAutoloadingRecursively;
+   bool fIsAutoLoading;
+   bool fIsAutoLoadingRecursively;
    bool fIsAutoParsingSuspended;
    bool fPPOldFlag;
    bool fPPChanged;
@@ -52,8 +52,8 @@ public:
 
    void Initialize();
 
-   void SetAutoloadingEnabled(bool val = true) { fIsAutoloading = val; }
-   bool IsAutoloadingEnabled() { return fIsAutoloading; }
+   void SetAutoLoadingEnabled(bool val = true) { fIsAutoLoading = val; }
+   bool IsAutoLoadingEnabled() { return fIsAutoLoading; }
 
    void SetAutoParsingSuspended(bool val = true) { fIsAutoParsingSuspended = val; }
    bool IsAutoParsingSuspended() { return fIsAutoParsingSuspended; }

--- a/documentation/users-guide/HTMLDoc.md
+++ b/documentation/users-guide/HTMLDoc.md
@@ -253,7 +253,7 @@ following will enumerate some of the highlights.
 When **`THtml`** generates documentation for classes it recognizes all
 class names known to ROOT. If **`THtml`** does not have sources for a
 class it determines the class's library name. This has to be set by
-means of `rootmap` files, see Library Autoloading of this User's Guide.
+means of `rootmap` files, see Library AutoLoading of this User's Guide.
 Given the library name, **`THtml`** searches for an entry in its map of
 libraries to documentation URLs. If it finds it, it will create a link
 to the documentation at that URL for all occurrences of a given class

--- a/documentation/users-guide/Introduction.md
+++ b/documentation/users-guide/Introduction.md
@@ -495,7 +495,7 @@ the plugin class of which an object will be created
 contains many plugin definitions, or by calls to
 `gROOT->GetPluginManager()->AddHandler()`.
 
-#### Library Autoloading
+#### Library AutoLoading
 
 When using a class in Cling, e.g. in an interpreted source file, ROOT
 will automatically load the library that defines this class. On

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -810,7 +810,7 @@ namespace cling {
     ///
     void runAtExitFuncs();
 
-    void GenerateAutoloadingMap(llvm::StringRef inFile, llvm::StringRef outFile,
+    void GenerateAutoLoadingMap(llvm::StringRef inFile, llvm::StringRef outFile,
                                 bool enableMacros = false, bool enableLogs = true);
 
     void forwardDeclare(Transaction& T, clang::Preprocessor& P,

--- a/interpreter/cling/lib/Interpreter/AutoloadCallback.cpp
+++ b/interpreter/cling/lib/Interpreter/AutoloadCallback.cpp
@@ -62,7 +62,7 @@ namespace cling {
     return false;
   }
 
-  class AutoloadingVisitor: public RecursiveASTVisitor<AutoloadingVisitor> {
+  class AutoLoadingVisitor: public RecursiveASTVisitor<AutoLoadingVisitor> {
   private:
     ///\brief Flag determining the visitor's actions. If true, register autoload
     /// entries, i.e. remember the connection between filename and the declaration
@@ -100,7 +100,7 @@ namespace cling {
 
     using Annotations_t = std::pair<llvm::StringRef,llvm::StringRef>;
 
-    void InsertIntoAutoloadingState(Decl* decl, Annotations_t FileNames) {
+    void InsertIntoAutoLoadingState(Decl* decl, Annotations_t FileNames) {
 
       assert(m_PP);
 
@@ -141,7 +141,7 @@ namespace cling {
           // by the user as an interface header to be available on the
           // run-time include path.
           cling::errs()
-          << "Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:\n"
+          << "Error in cling::AutoLoadingVisitor::InsertIntoAutoLoadingState:\n"
           "   Missing FileEntry for " << FileName << "\n";
           if (NamedDecl* ND = dyn_cast<NamedDecl>(decl)) {
             cling::errs() << "   requested to autoload type ";
@@ -173,7 +173,7 @@ namespace cling {
     }
 
   public:
-    AutoloadingVisitor():
+    AutoLoadingVisitor():
       m_IsStoringState(false), m_IsAutloadEntry(false), m_Map(0), m_PP(0),
     m_Sema(0), m_PrevFE({nullptr,nullptr})
     {}
@@ -228,7 +228,7 @@ namespace cling {
           }
         }
       }
-      InsertIntoAutoloadingState(D, annotations);
+      InsertIntoAutoLoadingState(D, annotations);
 
       return true;
     }
@@ -341,7 +341,7 @@ namespace cling {
     if (found == m_Map.end())
      return; // nothing to do, file not referred in any annotation
 
-    AutoloadingVisitor defaultArgsCleaner;
+    AutoLoadingVisitor defaultArgsCleaner;
     for (auto D : found->second) {
       defaultArgsCleaner.RemoveDefaultArgsOf(D, &getInterpreter()->getSema());
     }
@@ -359,20 +359,20 @@ namespace cling {
       return;
 
     // The first decl must be
-    //   extern int __Cling_Autoloading_Map;
-    bool HaveAutoloadingMapMarker = false;
+    //   extern int __Cling_AutoLoading_Map;
+    bool HaveAutoLoadingMapMarker = false;
     for (auto I = T.decls_begin(), E = T.decls_end();
-         !HaveAutoloadingMapMarker && I != E; ++I) {
+         !HaveAutoLoadingMapMarker && I != E; ++I) {
       if (I->m_Call != cling::Transaction::kCCIHandleTopLevelDecl)
         return;
       for (auto&& D: I->m_DGR) {
         if (isa<EmptyDecl>(D))
           continue;
         else if (auto VD = dyn_cast<VarDecl>(D)) {
-          HaveAutoloadingMapMarker
+          HaveAutoLoadingMapMarker
             = VD->hasExternalStorage() && VD->getIdentifier()
-              && VD->getName().equals("__Cling_Autoloading_Map");
-          if (!HaveAutoloadingMapMarker)
+              && VD->getName().equals("__Cling_AutoLoading_Map");
+          if (!HaveAutoLoadingMapMarker)
             return;
           break;
         } else
@@ -380,10 +380,10 @@ namespace cling {
       }
     }
 
-    if (!HaveAutoloadingMapMarker)
+    if (!HaveAutoLoadingMapMarker)
       return;
 
-    AutoloadingVisitor defaultArgsStateCollector;
+    AutoLoadingVisitor defaultArgsStateCollector;
     Preprocessor& PP = m_Interpreter->getCI()->getPreprocessor();
     for (auto I = T.decls_begin(), E = T.decls_end(); I != E; ++I)
       for (auto&& D: I->m_DGR)

--- a/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
@@ -54,7 +54,7 @@ namespace cling {
     Out() << "#pragma clang diagnostic ignored \"-Wignored-attributes\"" <<"\n";
     Out() << "#pragma clang diagnostic ignored \"-Wreturn-type-c-linkage\"" <<"\n";
     // Inject a special marker:
-    Out() << "extern int __Cling_Autoloading_Map;\n";
+    Out() << "extern int __Cling_AutoLoading_Map;\n";
 
     std::vector<std::string> macrodefs;
     if (printMacros) {

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -1723,7 +1723,7 @@ namespace cling {
     m_Executor->runAtExitFuncs();
   }
 
-  void Interpreter::GenerateAutoloadingMap(llvm::StringRef inFile,
+  void Interpreter::GenerateAutoLoadingMap(llvm::StringRef inFile,
                                            llvm::StringRef outFile,
                                            bool enableMacros,
                                            bool enableLogs) {

--- a/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
@@ -80,7 +80,7 @@ namespace cling {
 
   MetaSema::ActionResult MetaSema::actOnTCommand(llvm::StringRef inputFile,
                                                  llvm::StringRef outputFile) {
-    m_Interpreter.GenerateAutoloadingMap(inputFile, outputFile);
+    m_Interpreter.GenerateAutoLoadingMap(inputFile, outputFile);
     return AR_Success;
   }
 

--- a/interpreter/cling/test/Autoloading/AutoForwarding.C
+++ b/interpreter/cling/test/Autoloading/AutoForwarding.C
@@ -22,7 +22,7 @@ A<int> ai2;
 #include "fwd_Def2c.h"
 #include "Def2c.h"
 
-// In some implementations the AutoloadingVisitor was stripping the default
+// In some implementations the AutoLoadingVisitor was stripping the default
 // template parameter value from the class template definition leading to
 // compilation error at this next line:
 A<float> af2;
@@ -36,7 +36,7 @@ template <typename T> class WithDefaultAndFwd;
 .T Def2.h fwd_Def2.h
 #include "fwd_Def2.h"
 
-// In some implementation the AutoloadingVisitor, when called upon by the next
+// In some implementation the AutoLoadingVisitor, when called upon by the next
 // #includes, was not properly removing default value that was attached to
 // this following class template forward declaration (the default comes from
 // the forward declaration in fwd_Def2.h). See ROOT-8443.
@@ -59,11 +59,11 @@ TemplateWithAllDefault<> twad;
 WithDefaultInH1<> wdh1;
 WithDefaultInH2<> wdh2;
 
-// In some implementation the AutoloadingVisitor was not when Def2sub.h, which
+// In some implementation the AutoLoadingVisitor was not when Def2sub.h, which
 // contains the definition for CtorWithDefault, and then the implementation
 // was also looping over all element of the decl chain without skipping definition,
 // resulting in a loss of the default parameter values for the method/functions of
-// CtorWithDefault when AutoloadingVisitor was called upon because of the inclusion
+// CtorWithDefault when AutoLoadingVisitor was called upon because of the inclusion
 // Def2.h
 CtorWithDefault c;
 M::N::A mna;

--- a/interpreter/cling/test/Autoloading/ForwardDeclareAllInIncludePaths.C
+++ b/interpreter/cling/test/Autoloading/ForwardDeclareAllInIncludePaths.C
@@ -56,7 +56,7 @@ for (int i = 0; i < 1 /*includePaths.size()*/; ++i) { // We know STL is first.
         continue;
       if (ent->d_type == DT_REG && strcmp(ent->d_name, ".") && strcmp(ent->d_name, "..")) {
         fwdDeclFile = "/tmp/__cling_fwd_"; fwdDeclFile += ent->d_name;
-        gCling->GenerateAutoloadingMap(ent->d_name, fwdDeclFile);
+        gCling->GenerateAutoLoadingMap(ent->d_name, fwdDeclFile);
         // Run it in separate cling and assert it went all fine:
         sourceCode = " \"//expected-no-diagnostics\"";
         sourceCode += " '#include \"" + fwdDeclFile + "\"'";

--- a/proof/proofx/src/TXProofMgr.cxx
+++ b/proof/proofx/src/TXProofMgr.cxx
@@ -82,7 +82,7 @@ Bool_t TProofMgrInterruptHandler::Notify()
    return kTRUE;
 }
 
-// Autoloading hooks.
+// AutoLoading hooks.
 // These are needed to avoid using the plugin manager which may create
 // problems in multi-threaded environments.
 TProofMgr *GetTXProofMgr(const char *url, Int_t l, const char *al)

--- a/tree/treeplayer/src/TFormLeafInfo.cxx
+++ b/tree/treeplayer/src/TFormLeafInfo.cxx
@@ -2197,7 +2197,7 @@ TClass *TFormLeafInfoMethod::ReturnTClass(TMethodCall *mc)
    R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    {
-      TInterpreter::SuspendAutoloadingRAII autoloadOff(gInterpreter);
+      TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
       TClassEdit::GetNormalizedName(return_type, mc->GetMethod()->GetReturnTypeName());
    }
    // Beyhond this point we no longer 'need' the lock.


### PR DESCRIPTION
Mainly fix TClass::GetClass behavior when AutoLoading is disabled.