### PR TITLE
[RF] Remove deprecated RooAbsPdf::traceEvalHook().

### DIFF
--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -196,7 +196,6 @@ public:
   RooAbsReal* createScanCdf(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
 
   // Function evaluation support
-  virtual Bool_t R__DEPRECATED(6,22,"Call traceEvalPdf() instead.") traceEvalHook(Double_t value) const ;
   virtual Double_t getValV(const RooArgSet* set=0) const ;
   virtual Double_t getLogVal(const RooArgSet* set=0) const ;
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -623,39 +623,6 @@ Bool_t RooAbsPdf::syncNormalization(const RooArgSet* nset, Bool_t adjustProxies)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// WVE 08/21/01 Probably obsolete now.
-
-Bool_t RooAbsPdf::traceEvalHook(Double_t value) const 
-{
-  // Floating point error checking and tracing for given float value
-
-  // check for a math error or negative value
-  Bool_t error= TMath::IsNaN(value) || (value < 0);
-
-  // do nothing if we are no longer tracing evaluations and there was no error
-  if(!error && _traceCount <= 0) return error ;
-
-  // otherwise, print out this evaluations input values and result
-  if(error && ++_errorCount <= 10) {
-    cxcoutD(Tracing) << "*** Evaluation Error " << _errorCount << " ";
-    if(_errorCount == 10) ccoutD(Tracing) << "(no more will be printed) ";
-  }
-  else if(_traceCount > 0) {
-    ccoutD(Tracing) << '[' << _traceCount-- << "] ";
-  }
-  else {
-    return error ;
-  }
-
-  Print() ;
-
-  return error ;
-}
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Reset error counter to given value, limiting the number
 /// of future error messages for this pdf to 'resetValue'
 


### PR DESCRIPTION
RooAbsPdf::traceEvalHook() is marked obsolete in a comment since 2001.
It isn't used inside of RooFit, was deprecated in root 6.20,
and is removed entirely now.