### PR TITLE
meta: Prevent CheckClassInfo from autoloading if it is globally disab…

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3875,6 +3875,9 @@ TCling::CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamesp
       return kUnknown;
    }
 
+   // Do not turn on the autoloading if it is globally off.
+   autoload = autoload && IsClassAutoloadingEnabled();
+
    // Avoid the double search below in case the name is a fundamental type
    // or typedef to a fundamental type.
    THashTable *typeTable = dynamic_cast<THashTable*>( gROOT->GetListOfTypes() );


### PR DESCRIPTION
…led.

Commit 04576cbe952993832153b4455f934f267a7c259e (silently) extended the semantic of 'disabling class autoloading',
in addition to preventing calls to AutoLoad it also made AutoLoad itself to return immediately when the autoloading
(i.e. "AutoLoad" becomes "MaybeAutoLoad").

However, it left untouched the code in CheckClassInfo that handled its "autoload" parameter and which still explicitly
enabled AutoLoading when requested.

This inconsistency lead to the 2nd part of ROOT-10528 where a class to TClass::GetClass for enums when the AutoLoading
was disabled lead to a broken State where an "interpreted" TClass (for the namespace holding the enum) even though a
library is available for it.  This happened because TClass::GetClass explicit auto-loading attempt failed but
CheckClassInfo's autoloading and search for the namespace succeeded.