### PR TITLE
Revert "[cxxmodules] Don't complain about redeclaration of declared annotated enum

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Sema/Sema.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Sema/Sema.h
@@ -2331,8 +2331,7 @@ public:
   bool CheckEnumRedeclaration(SourceLocation EnumLoc, bool IsScoped,
                               QualType EnumUnderlyingTy,
                               bool EnumUnderlyingIsImplicit,
-                              const EnumDecl *Prev,
-                              const EnumDecl *New);
+                              const EnumDecl *Prev);
 
   /// Determine whether the body of an anonymous enumeration should be skipped.
   /// \param II The name of the first enumerator.

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
@@ -12892,7 +12892,7 @@ bool Sema::CheckEnumUnderlyingType(TypeSourceInfo *TI) {
 /// \return true if the redeclaration was invalid.
 bool Sema::CheckEnumRedeclaration(
     SourceLocation EnumLoc, bool IsScoped, QualType EnumUnderlyingTy,
-    bool EnumUnderlyingIsImplicit, const EnumDecl *Prev, const EnumDecl *New) {
+    bool EnumUnderlyingIsImplicit, const EnumDecl *Prev) {
   bool IsFixed = !EnumUnderlyingTy.isNull();
 
   if (IsScoped != Prev->isScoped()) {
@@ -12940,11 +12940,6 @@ bool Sema::CheckEnumRedeclaration(
     };
 
     if (hasFwdDeclAnnotation(Prev))
-      return false;
-
-    // We have a definition coming from a module and a forward declaration
-    // coming after.
-    if (Prev->isFromASTFile() && hasFwdDeclAnnotation(New))
       return false;
 
     Diag(EnumLoc, diag::err_enum_redeclare_fixed_mismatch)
@@ -13674,8 +13669,7 @@ Decl *Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK,
           // in which case we want the caller to bail out.
           if (CheckEnumRedeclaration(NameLoc.isValid() ? NameLoc : KWLoc,
                                      ScopedEnum, EnumUnderlyingTy,
-                                     EnumUnderlyingIsImplicit, PrevEnum,
-                                     cast<EnumDecl>(SkipBody->New)))
+                                     EnumUnderlyingIsImplicit, PrevEnum))
             return TUK == TUK_Declaration ? PrevTagDecl : nullptr;
         }
 

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1049,8 +1049,7 @@ Decl *TemplateDeclInstantiator::VisitEnumDecl(EnumDecl *D) {
                           UnderlyingLoc, DeclarationName());
       SemaRef.CheckEnumRedeclaration(Def->getLocation(), Def->isScoped(),
                                      DefnUnderlying,
-                                     /*EnumUnderlyingIsImplicit=*/false, Enum,
-                                     Def);
+                                     /*EnumUnderlyingIsImplicit=*/false, Enum);
     }
   }
 


### PR DESCRIPTION
This reverts commit fb4583b7a74dc93ec0949b9ecd8b7f21f33aff77.

Causes segmentation violation during rootcling_stage1.

