### PR TITLE
TH1::Fill Avoid redundancy

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -212,9 +212,8 @@ public:
    virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
    virtual void     ExtendAxis(Double_t x, TAxis *axis);
    virtual TH1     *FFT(TH1* h_output, Option_t *option);
-   virtual Int_t    Fill(Double_t x);
-   virtual Int_t    Fill(Double_t x, Double_t w);
-   virtual Int_t    Fill(const char *name, Double_t w);
+   virtual Int_t    Fill(Double_t x, Double_t w = 1.);
+   virtual Int_t    Fill(const char *name, Double_t w = 1.);
    virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride=1);
    virtual void     FillN(Int_t, const Double_t *, const Double_t *, const Double_t *, Int_t) {;}
    virtual void     FillRandom(const char *fname, Int_t ntimes=5000);

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -214,7 +214,7 @@ public:
    virtual TH1     *FFT(TH1* h_output, Option_t *option);
    virtual Int_t    Fill(Double_t x);
    virtual Int_t    Fill(Double_t x, Double_t w);
-   virtual Int_t    Fill(const char *name, Double_t w);
+   virtual Int_t    Fill(const char *name, Double_t w = 1.);
    virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride=1);
    virtual void     FillN(Int_t, const Double_t *, const Double_t *, const Double_t *, Int_t) {;}
    virtual void     FillRandom(const char *fname, Int_t ntimes=5000);

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -212,8 +212,9 @@ public:
    virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
    virtual void     ExtendAxis(Double_t x, TAxis *axis);
    virtual TH1     *FFT(TH1* h_output, Option_t *option);
-   virtual Int_t    Fill(Double_t x, Double_t w = 1.);
-   virtual Int_t    Fill(const char *name, Double_t w = 1.);
+   virtual Int_t    Fill(Double_t x);
+   virtual Int_t    Fill(Double_t x, Double_t w);
+   virtual Int_t    Fill(const char *name, Double_t w);
    virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride=1);
    virtual void     FillN(Int_t, const Double_t *, const Double_t *, const Double_t *, Int_t) {;}
    virtual void     FillRandom(const char *fname, Int_t ntimes=5000);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3246,38 +3246,6 @@ TH1* TH1::FFT(TH1* h_output, Option_t *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Increment bin with abscissa X by 1.
-///
-/// if x is less than the low-edge of the first bin, the Underflow bin is incremented
-/// if x is equal to or greater than the upper edge of last bin, the Overflow bin is incremented
-///
-/// If the storage of the sum of squares of weights has been triggered,
-/// via the function Sumw2, then the sum of the squares of weights is incremented
-/// by 1 in the bin corresponding to x.
-///
-/// The function returns the corresponding bin number which has its content incremented by 1
-
-Int_t TH1::Fill(Double_t x)
-{
-   if (fBuffer)  return BufferFill(x,1);
-
-   Int_t bin;
-   fEntries++;
-   bin =fXaxis.FindBin(x);
-   if (bin <0) return -1;
-   AddBinContent(bin);
-   if (fSumw2.fN) ++fSumw2.fArray[bin];
-   if (bin == 0 || bin > fXaxis.GetNbins()) {
-      if (!GetStatOverflowsBehaviour()) return -1;
-   }
-   ++fTsumw;
-   ++fTsumw2;
-   fTsumwx  += x;
-   fTsumwx2 += x*x;
-   return bin;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Increment bin with abscissa X with a weight w.
 ///
 /// if x is less than the low-edge of the first bin, the Underflow bin is incremented

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3246,6 +3246,38 @@ TH1* TH1::FFT(TH1* h_output, Option_t *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Increment bin with abscissa X by 1.
+///
+/// if x is less than the low-edge of the first bin, the Underflow bin is incremented
+/// if x is equal to or greater than the upper edge of last bin, the Overflow bin is incremented
+///
+/// If the storage of the sum of squares of weights has been triggered,
+/// via the function Sumw2, then the sum of the squares of weights is incremented
+/// by 1 in the bin corresponding to x.
+///
+/// The function returns the corresponding bin number which has its content incremented by 1
+
+Int_t TH1::Fill(Double_t x)
+{
+   if (fBuffer)  return BufferFill(x,1);
+
+   Int_t bin;
+   fEntries++;
+   bin =fXaxis.FindBin(x);
+   if (bin <0) return -1;
+   AddBinContent(bin);
+   if (fSumw2.fN) ++fSumw2.fArray[bin];
+   if (bin == 0 || bin > fXaxis.GetNbins()) {
+      if (!GetStatOverflowsBehaviour()) return -1;
+   }
+   ++fTsumw;
+   ++fTsumw2;
+   fTsumwx  += x;
+   fTsumwx2 += x*x;
+   return bin;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Increment bin with abscissa X with a weight w.
 ///
 /// if x is less than the low-edge of the first bin, the Underflow bin is incremented


### PR DESCRIPTION
Hello there. I fail to see the difference between:
```
h->Fill(3.1415)
``` 
and 
```
h->Fill(3.1415,1.)
```  
Why are we using defining different functions for both of them? I came across this when performing `h->Fill("StringBarLabelHere")` which fails as I always have to set the weight to `1.` in every call.