### PR TITLE
Fix ROOT-10552 incorrect StreamerInfoList update.

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -3541,7 +3541,7 @@ void TFile::ReadStreamerInfo()
             Int_t asize = fClassIndex->GetSize();
             if (uid >= asize && uid <100000) fClassIndex->Set(2*asize);
             if (uid >= 0 && uid < fClassIndex->GetSize()) fClassIndex->fArray[uid] = 1;
-            else {
+            else if (!isstl) {
                printf("ReadStreamerInfo, class:%s, illegal uid=%d\n",info->GetName(),uid);
             }
             if (gDebug > 0) printf(" -class: %s version: %d info read at slot %d\n",info->GetName(), info->GetClassVersion(),uid);

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -142,7 +142,7 @@ enum class EUniquePtrOffset : char
 
 TStreamerInfo::TStreamerInfo()
 {
-   fNumber   = fgCount;
+   fNumber   = -2;
    fClass    = 0;
    fElements = 0;
    fComp     = 0;
@@ -1194,6 +1194,10 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */)
       // We got here, thus we are a perfect alias for the current streamerInfo,
       // but we might had odd v5 style name spelling, so let's prefer the
       // current one.
+      auto maininfo = fClass->GetStreamerInfo();
+      if (maininfo) {
+         fNumber = maininfo->GetNumber(); // For ReadStreamerInfo to record the expected slot.
+      }
       SetBit(kCanDelete);
       return;
    }
@@ -2760,6 +2764,8 @@ TObject *TStreamerInfo::Clone(const char *newname) const
          }
       }
    }
+   ++fgCount;
+   newinfo->fNumber = fgCount;
    return newinfo;
 }
 
@@ -3087,7 +3093,7 @@ void TStreamerInfo::ComputeSize()
 
 void TStreamerInfo::ForceWriteInfo(TFile* file, Bool_t force)
 {
-   if (!file) {
+   if (!file || fNumber < 0) {
       return;
    }
    // Get the given file's list of streamer infos marked for writing.

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -2989,6 +2989,10 @@ void TStreamerInfo::Compile()
    fNfulldata = 0;
 
    TObjArray* infos = (TObjArray*) gROOT->GetListOfStreamerInfo();
+   if (fNumber < 0) {
+      ++fgCount;
+      fNumber = fgCount;
+   }
    if (fNumber >= infos->GetSize()) {
       infos->AddAtAndExpand(this, fNumber);
    } else {


### PR DESCRIPTION
Prior to this update if a StreamerInfo on file was the exact same
as one in memory, it would get recorded in an arbitrary slot in
the 'record those StreamerInfo array'.