### PR TITLE
[TMVA][PyKeras] Keras Visualization used is outdate

### DIFF
--- a/tutorials/tmva/keras/GenerateModel.py
+++ b/tutorials/tmva/keras/GenerateModel.py
@@ -14,6 +14,7 @@ from keras.models import Sequential
 from keras.layers.core import Dense, Activation
 from keras.regularizers import l2
 from keras.optimizers import SGD
+from keras.utils import plot_model
 
 # Setup the model here
 num_input_nodes = 4
@@ -57,7 +58,6 @@ model.summary()
 
 # Visualize model as graph
 try:
-    from keras.utils import plot_model
     plot_model(model, to_file='model.png', show_shapes=True)
 except:
     print('[INFO] Failed to make model plot')

--- a/tutorials/tmva/keras/GenerateModel.py
+++ b/tutorials/tmva/keras/GenerateModel.py
@@ -57,7 +57,7 @@ model.summary()
 
 # Visualize model as graph
 try:
-    from keras.utils.visualize_util import plot
-    plot(model, to_file='model.png', show_shapes=True)
+    from keras.utils import plot_model
+    plot_model(model, to_file='model.png', show_shapes=True)
 except:
     print('[INFO] Failed to make model plot')


### PR DESCRIPTION
In root/tutorials/tmva/keras/GenerateModel.py line 60:
from keras.utils.visualize_util import plot 
is outdated and hence shows error:
 File "./GenerateModel.py", line 17, in <module>
    from keras.utils.visualize_util import plot
ModuleNotFoundError: No module named 'keras.utils.visualize_util'
Instead, use:
from keras.utils import plot_model
plot_model(model, to_file='model.png', show_shapes=True)