### PR TITLE
[ntuple] Improvements to ntuple views

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -212,6 +212,7 @@ public:
    std::string GetType() const { return fType; }
    ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }
+   NTupleSize_t GetNElements() const { return fPrincipalColumn->GetNElements(); }
    const RFieldBase *GetParent() const { return fParent; }
    std::vector<const RFieldBase *> GetSubFields() const;
    bool IsSimple() const { return fIsSimple; }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -133,7 +133,7 @@ public:
       }
    }
 
-   RNTupleGlobalRange GetViewRange() { return RNTupleGlobalRange(0, GetNEntries()); }
+   RNTupleGlobalRange GetEntryRange() { return RNTupleGlobalRange(0, GetNEntries()); }
 
    /// Provides access to an individual field that can contain either a scalar value or a collection, e.g.
    /// GetView<double>("particles.pt") or GetView<std::vector<double>>("particle").  It can as well be the index

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -22,6 +22,7 @@
 
 #include <iterator>
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include <unordered_map>
 
@@ -101,23 +102,38 @@ public:
 };
 
 
+namespace Internal {
+
+template <class FieldT>
+class IsMappable {
+public:
+   using RSuccess = char;
+   struct RFailure { char x[2]; };
+
+   template<class C, typename ... ArgsT>
+   using MapOverloadT = decltype(std::declval<C>().Map(std::declval<ArgsT>() ...)) (C::*)(ArgsT ...);
+
+   template <class C> static RSuccess Test(MapOverloadT<C, NTupleSize_t>);
+   template <class C> static RFailure Test(...);
+
+public:
+   static constexpr bool value = sizeof(Test<FieldT>(0)) == sizeof(RSuccess);
+};
+
+} // namespace Internal
+
+
 // clang-format off
 /**
 \class ROOT::Experimental::RNTupleView
 \ingroup NTuple
 \brief An RNTupleView provides read-only access to a single field of the ntuple
 
-(NB(jblomer): The ntuple view is very close to TTreeReader. Do we simply want to teach TTreeReader to deal with
-RNTuple?)
-
 The view owns a field and its underlying columns in order to fill an ntuple value object with data. Data can be
 accessed by index. For top level fields, the index refers to the entry number. Fields that are part of
 nested collections have global index numbers that are derived from their parent indexes.
 
-The RNTupleView object is an iterable. That means, all field values in the tree can be sequentially read from begin()
-to end().
-
-For simple types, template specializations let the reading become a pure mapping into a page buffer.
+Fields of simple types with a Map() method will use that and thus expose zero-copy access.
 */
 // clang-format on
 template <typename T>
@@ -125,11 +141,12 @@ class RNTupleView {
    friend class RNTupleReader;
    friend class RNTupleViewCollection;
 
-protected:
-   /**
-    * fFieldId has fParent always set to null; views access nested fields without looking at the parent
-    */
-   RField<T> fField;
+   using FieldT = RField<T>;
+
+private:
+   /// fFieldId has fParent always set to null; views access nested fields without looking at the parent
+   FieldT fField;
+   /// Used as a Read() destination for fields that are not mappable
    Detail::RFieldValue fValue;
 
    RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
@@ -152,115 +169,29 @@ public:
    RNTupleView& operator=(RNTupleView&& other) = default;
    ~RNTupleView() { fField.DestroyValue(fValue); }
 
-   const T& operator()(NTupleSize_t globalIndex) {
+   RNTupleGlobalRange GetFieldRange() const { return RNTupleGlobalRange(0, fField.GetNElements()); }
+
+   template <typename C = T>
+   typename std::enable_if_t<Internal::IsMappable<FieldT>::value, const C&>
+   operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
+
+   template <typename C = T>
+   typename std::enable_if_t<!Internal::IsMappable<FieldT>::value, const C&>
+   operator()(NTupleSize_t globalIndex) {
       fField.Read(globalIndex, &fValue);
       return *fValue.Get<T>();
    }
 
-   const T& operator()(const RClusterIndex &clusterIndex) {
+   template <typename C = T>
+   typename std::enable_if_t<Internal::IsMappable<FieldT>::value, const C&>
+   operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
+
+   template <typename C = T>
+   typename std::enable_if_t<!Internal::IsMappable<FieldT>::value, const C&>
+   operator()(const RClusterIndex &clusterIndex) {
       fField.Read(clusterIndex, &fValue);
       return *fValue.Get<T>();
    }
-};
-
-// Template specializations in order to directly map simple types into the page pool
-
-template <>
-class RNTupleView<float> {
-   friend class RNTupleReader;
-   friend class RNTupleViewCollection;
-
-protected:
-   RField<float> fField;
-   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
-      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName())
-   {
-      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
-   }
-
-public:
-   RNTupleView(const RNTupleView& other) = delete;
-   RNTupleView(RNTupleView&& other) = default;
-   RNTupleView& operator=(const RNTupleView& other) = delete;
-   RNTupleView& operator=(RNTupleView&& other) = default;
-   ~RNTupleView() = default;
-
-   float operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
-   float operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
-};
-
-
-template <>
-class RNTupleView<double> {
-   friend class RNTupleReader;
-   friend class RNTupleViewCollection;
-
-protected:
-   RField<double> fField;
-   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
-      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName())
-   {
-      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
-   }
-
-public:
-   RNTupleView(const RNTupleView& other) = delete;
-   RNTupleView(RNTupleView&& other) = default;
-   RNTupleView& operator=(const RNTupleView& other) = delete;
-   RNTupleView& operator=(RNTupleView&& other) = default;
-   ~RNTupleView() = default;
-
-   double operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
-   double operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
-};
-
-
-template <>
-class RNTupleView<std::int32_t> {
-   friend class RNTupleReader;
-   friend class RNTupleViewCollection;
-
-protected:
-   RField<std::int32_t> fField;
-   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
-      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName())
-   {
-      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
-   }
-
-public:
-   RNTupleView(const RNTupleView& other) = delete;
-   RNTupleView(RNTupleView&& other) = default;
-   RNTupleView& operator=(const RNTupleView& other) = delete;
-   RNTupleView& operator=(RNTupleView&& other) = default;
-   ~RNTupleView() = default;
-
-   std::int32_t operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
-   std::int32_t operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
-};
-
-template <>
-class RNTupleView<ClusterSize_t> {
-   friend class RNTupleReader;
-   friend class RNTupleViewCollection;
-
-protected:
-   RField<ClusterSize_t> fField;
-   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
-      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName())
-   {
-      Detail::RFieldFuse::Connect(fieldId, *pageSource, fField);
-   }
-
-public:
-   RNTupleView(const RNTupleView& other) = delete;
-   RNTupleView(RNTupleView&& other) = default;
-   RNTupleView& operator=(const RNTupleView& other) = delete;
-   RNTupleView& operator=(RNTupleView&& other) = default;
-   ~RNTupleView() = default;
-
-   ClusterSize_t operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
-   ClusterSize_t operator()(const RClusterIndex &clusterIndex) { return *fField.Map(clusterIndex); }
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -291,14 +291,14 @@ public:
    RNTupleViewCollection& operator=(RNTupleViewCollection&& other) = default;
    ~RNTupleViewCollection() = default;
 
-   RNTupleClusterRange GetViewRange(NTupleSize_t globalIndex) {
+   RNTupleClusterRange GetCollectionRange(NTupleSize_t globalIndex) {
       ClusterSize_t size;
       RClusterIndex collectionStart;
       fField.GetCollectionInfo(globalIndex, &collectionStart, &size);
       return RNTupleClusterRange(collectionStart.GetClusterId(), collectionStart.GetIndex(),
                                  collectionStart.GetIndex() + size);
    }
-   RNTupleClusterRange GetViewRange(const RClusterIndex &clusterIndex) {
+   RNTupleClusterRange GetCollectionRange(const RClusterIndex &clusterIndex) {
       ClusterSize_t size;
       RClusterIndex collectionStart;
       fField.GetCollectionInfo(clusterIndex, &collectionStart, &size);

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -518,8 +518,7 @@ TEST(RNTuple, View)
 
    auto viewJetElements = ntuple.GetView<std::int32_t>("jets.std::int32_t");
    n = 0;
-   // TODO(jblomer): fix view iteration
-   for (auto i : ROOT::Experimental::RNTupleGlobalRange(0, 3)) {
+   for (auto i : viewJetElements.GetFieldRange()) {
       n++;
       EXPECT_EQ(n, viewJetElements(i));
    }

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -478,9 +478,10 @@ TEST(RNTuple, View)
    auto model = RNTupleModel::Create();
    auto fieldPt = model->MakeField<float>("pt", 42.0);
    auto fieldTag = model->MakeField<std::string>("tag", "xyz");
-   auto fieldJets = model->MakeField<std::vector<float>>("jets");
-   fieldJets->push_back(1.0);
-   fieldJets->push_back(2.0);
+   auto fieldJets = model->MakeField<std::vector<std::int32_t>>("jets");
+   fieldJets->push_back(1);
+   fieldJets->push_back(2);
+   fieldJets->push_back(3);
 
    {
       RNTupleWriter ntuple(std::move(model),
@@ -500,19 +501,29 @@ TEST(RNTuple, View)
    }
    EXPECT_EQ(2, n);
 
-   auto viewJets = ntuple.GetView<std::vector<float>>("jets");
+   auto viewJets = ntuple.GetView<std::vector<std::int32_t>>("jets");
    n = 0;
    for (auto i : ntuple.GetEntryRange()) {
       if (i == 0) {
-         EXPECT_EQ(2U, viewJets(i).size());
-         EXPECT_EQ(1.0, viewJets(i)[0]);
-         EXPECT_EQ(2.0, viewJets(i)[1]);
+         EXPECT_EQ(3U, viewJets(i).size());
+         EXPECT_EQ(1, viewJets(i)[0]);
+         EXPECT_EQ(2, viewJets(i)[1]);
+         EXPECT_EQ(3, viewJets(i)[2]);
       } else {
          EXPECT_EQ(0U, viewJets(i).size());
       }
       n++;
    }
    EXPECT_EQ(2, n);
+
+   auto viewJetElements = ntuple.GetView<std::int32_t>("jets.std::int32_t");
+   n = 0;
+   // TODO(jblomer): fix view iteration
+   for (auto i : ROOT::Experimental::RNTupleGlobalRange(0, 3)) {
+      n++;
+      EXPECT_EQ(n, viewJetElements(i));
+   }
+   EXPECT_EQ(3, n);
 }
 
 TEST(RNTuple, Capture) {

--- a/tree/ntuple/v7/test/ntuple.cxx
+++ b/tree/ntuple/v7/test/ntuple.cxx
@@ -152,7 +152,7 @@ TEST(RNTuple, Multi)
    RNTupleReader ntupleFirst(std::make_unique<RPageSourceFile>("first", fileGuard.GetPath(), RNTupleReadOptions()));
    auto viewPt = ntupleFirst.GetView<float>("pt");
    int n = 0;
-   for (auto i : ntupleFirst.GetViewRange()) {
+   for (auto i : ntupleFirst.GetEntryRange()) {
       EXPECT_EQ(42.0, viewPt(i));
       n++;
    }
@@ -161,7 +161,7 @@ TEST(RNTuple, Multi)
    RNTupleReader ntupleSecond(std::make_unique<RPageSourceFile>("second", fileGuard.GetPath(), RNTupleReadOptions()));
    auto viewE = ntupleSecond.GetView<float>("E");
    n = 0;
-   for (auto i : ntupleSecond.GetViewRange()) {
+   for (auto i : ntupleSecond.GetEntryRange()) {
       EXPECT_EQ(1.0, viewE(i));
       n++;
    }
@@ -255,7 +255,7 @@ TEST(RNTuple, ClassVector)
    auto viewKlass = viewKlassVec.GetView<CustomStruct>("CustomStruct");
    auto viewKlassA = viewKlassVec.GetView<float>("CustomStruct.a");
 
-   for (auto entryId : ntuple.GetViewRange()) {
+   for (auto entryId : ntuple.GetEntryRange()) {
       EXPECT_EQ(42.0, viewKlass(entryId).a);
       EXPECT_EQ(2.0, viewKlass(entryId).v1[0]);
       EXPECT_EQ(42.0, viewKlassA(entryId));
@@ -494,7 +494,7 @@ TEST(RNTuple, View)
    RNTupleReader ntuple(std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
    auto viewPt = ntuple.GetView<float>("pt");
    int n = 0;
-   for (auto i : ntuple.GetViewRange()) {
+   for (auto i : ntuple.GetEntryRange()) {
       EXPECT_EQ(42.0, viewPt(i));
       n++;
    }
@@ -502,7 +502,7 @@ TEST(RNTuple, View)
 
    auto viewJets = ntuple.GetView<std::vector<float>>("jets");
    n = 0;
-   for (auto i : ntuple.GetViewRange()) {
+   for (auto i : ntuple.GetEntryRange()) {
       if (i == 0) {
          EXPECT_EQ(2U, viewJets(i).size());
          EXPECT_EQ(1.0, viewJets(i)[0]);
@@ -567,16 +567,16 @@ TEST(RNTuple, Composable)
    auto viewHitY = viewHits.GetView<float>("y");
 
    int nEv = 0;
-   for (auto e : ntuple->GetViewRange()) {
+   for (auto e : ntuple->GetEntryRange()) {
       EXPECT_EQ(float(nEv), viewPt(e));
       EXPECT_EQ(3U, viewTracks(e));
 
       int nTr = 0;
-      for (auto t : viewTracks.GetViewRange(e)) {
+      for (auto t : viewTracks.GetCollectionRange(e)) {
          EXPECT_EQ(nEv * nTr, viewTrackEnergy(t));
 
          EXPECT_EQ(2.0, viewHits(t));
-         for (auto h : viewHits.GetViewRange(t)) {
+         for (auto h : viewHits.GetCollectionRange(t)) {
             EXPECT_EQ(4.0, viewHitX(h));
             EXPECT_EQ(8.0, viewHitY(h));
          }
@@ -891,7 +891,7 @@ TEST(RNTuple, LargeFile)
    auto rdEnergy  = ntuple->GetView<double>("energy");
    double chksumRead = 0.0;
 
-   for (auto i : ntuple->GetViewRange()) {
+   for (auto i : ntuple->GetEntryRange()) {
       chksumRead += rdEnergy(i);
    }
 

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -106,7 +106,7 @@ void ntpl003_lhcbOpenData()
    TH1F h("h", "B Flight Distance", 200, 0, 140);
    h.SetFillColor(48);
 
-   for (auto i : ntuple->GetViewRange()) {
+   for (auto i : ntuple->GetEntryRange()) {
       // Note that we do not load an entry in this loop, i.e. we avoid the memory copy of loading the data into
       // the memory location given by the entry
       h.Fill(viewFlightDistance(i));


### PR DESCRIPTION
Implements the following two improvements to views and iteration of view values

- Make the type of iteration explicit: over the events, over the values of a collection within an event, or over all the values of a field, which for a nested field can be more or less than the number of entries.

- `RNTupleView` now uses automatically a field's `Map()` zero-copy access method, if such a method exists for the the field; replaces the template specializations of `RNTupleView`