### PR TITLE
Add project name to CMake file of Minuit2

### DIFF
--- a/math/minuit2/CMakeLists.txt
+++ b/math/minuit2/CMakeLists.txt
@@ -5,6 +5,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 cmake_minimum_required(VERSION 3.1)
+project(Minuit2)
 
 option(minuit2_mpi "Enable support for MPI in Minuit2")
 option(minuit2_omp "Enable support for OpenMP in Minuit2")

--- a/math/minuit2/CMakeLists.txt
+++ b/math/minuit2/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
-  project(Minuit2 VERSION ${ROOT_VERSION} LANGUAGES CXX)
+  project(Minuit2 LANGUAGES CXX)
 endif(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
 
 option(minuit2_mpi "Enable support for MPI in Minuit2")

--- a/math/minuit2/CMakeLists.txt
+++ b/math/minuit2/CMakeLists.txt
@@ -5,7 +5,10 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 cmake_minimum_required(VERSION 3.1)
-project(Minuit2)
+
+if(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
+  project(Minuit2 VERSION ${ROOT_VERSION} LANGUAGES CXX)
+endif(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
 
 option(minuit2_mpi "Enable support for MPI in Minuit2")
 option(minuit2_omp "Enable support for OpenMP in Minuit2")


### PR DESCRIPTION
All CMake files should have a call to the `project()` command.  In particular,
not having the `project()` call here makes it impossible to configure standalone
Minuit2 with Clang for macOS, see
https://gitlab.kitware.com/cmake/cmake/issues/17712#note_371862