### PR TITLE
[CMake] REFLEX_GENERATE_DICTIONARY: support include directories from targets

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -125,7 +125,7 @@ endfunction()
 #  COMPILE_DEFINITIONS are used to create the appropriate -I and -D flags
 #
 #---------------------------------------------------------------------------------------------------
-macro(REFLEX_GENERATE_DICTIONARY dictionary)
+function(REFLEX_GENERATE_DICTIONARY dictionary)
   CMAKE_PARSE_ARGUMENTS(ARG "" "SELECTION" "OPTIONS;DEPENDS;USES" ${ARGN})
   #---Get List of header files---------------
   set(headerfiles)
@@ -172,7 +172,6 @@ macro(REFLEX_GENERATE_DICTIONARY dictionary)
     endif()
   endforeach()
 
-  set(definitions)
   get_directory_property(defs COMPILE_DEFINITIONS)
   foreach( d ${defs})
    list(APPEND definitions ${d})
@@ -195,6 +194,8 @@ macro(REFLEX_GENERATE_DICTIONARY dictionary)
     COMMAND_EXPAND_LISTS
     )
 
+  set(gensrcdict ${dictionary}.cxx PARENT_SCOPE)
+
   #---roottest compability---------------------------------
   if(CMAKE_ROOTTEST_DICT)
     ROOTTEST_TARGETNAME_FROM_FILE(targetname ${dictionary})
@@ -209,7 +210,7 @@ macro(REFLEX_GENERATE_DICTIONARY dictionary)
     add_custom_target(${targetname} ALL DEPENDS ${gensrcdict})
   endif()
 
-endmacro()
+endfunction()
 
 #---------------------------------------------------------------------------------------------------
 #---ROOT_GET_LIBRARY_OUTPUT_DIR( result_var )

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -194,6 +194,9 @@ function(REFLEX_GENERATE_DICTIONARY dictionary)
   IF(TARGET ${dictionary})
     target_sources(${dictionary} PRIVATE ${gensrcdict})
   ENDIF()
+  # FIXME: Do not set gensrcdict variable to the outer scope but use an argument to
+  # REFLEX_GENERATE_DICTIONARY passed from the outside. Note this would be a
+  # breaking change for roottest and other external users.
   set(gensrcdict ${dictionary}.cxx PARENT_SCOPE)
 
   #---roottest compability---------------------------------

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -116,10 +116,17 @@ function(ROOT_GET_SOURCES variable cwd )
 endfunction()
 
 #---------------------------------------------------------------------------------------------------
-#---REFLEX_GENERATE_DICTIONARY( dictionary headerfiles SELECTION selectionfile OPTIONS opt1 opt2 ...)
+#---REFLEX_GENERATE_DICTIONARY( dictionary headerfiles SELECTION selectionfile OPTIONS opt1 opt2 ...
+#                               DEPENDS dependency1 dependency2 ...
+#                               USES target1 target2 ...
+#                             )
+#
+#  USES takes a list of targets. From the targets the properties INCLUDE_DIRECTORIES and
+#  COMPILE_DEFINITIONS are used to create the appropriate -I and -D flags
+#
 #---------------------------------------------------------------------------------------------------
 macro(REFLEX_GENERATE_DICTIONARY dictionary)
-  CMAKE_PARSE_ARGUMENTS(ARG "" "SELECTION" "OPTIONS;DEPENDS" ${ARGN})
+  CMAKE_PARSE_ARGUMENTS(ARG "" "SELECTION" "OPTIONS;DEPENDS;USES" ${ARGN})
   #---Get List of header files---------------
   set(headerfiles)
   foreach(fp ${ARG_UNPARSED_ARGUMENTS})
@@ -157,25 +164,36 @@ macro(REFLEX_GENERATE_DICTIONARY dictionary)
     set(rootmapopts --rootmap=${rootmapname} --rootmap-lib=${libprefix}${dictionary}Dict)
   endif()
 
-  set(include_dirs -I${CMAKE_CURRENT_SOURCE_DIR})
+  set(include_dirs ${CMAKE_CURRENT_SOURCE_DIR})
   get_directory_property(incdirs INCLUDE_DIRECTORIES)
   foreach(d ${incdirs})
     if(NOT "${d}" MATCHES "^(AFTER|BEFORE|INTERFACE|PRIVATE|PUBLIC|SYSTEM)$")
-      set(include_dirs ${include_dirs} -I${d})
+      list(APPEND include_dirs ${d})
     endif()
   endforeach()
 
+  set(definitions)
   get_directory_property(defs COMPILE_DEFINITIONS)
   foreach( d ${defs})
-   set(definitions ${definitions} -D${d})
+   list(APPEND definitions ${d})
+  endforeach()
+
+  foreach(DEP ${ARG_USES})
+    LIST(APPEND include_dirs $<TARGET_PROPERTY:${DEP},INCLUDE_DIRECTORIES>)
+    LIST(APPEND definitions $<TARGET_PROPERTY:${DEP},COMPILE_DEFINITIONS>)
   endforeach()
 
   add_custom_command(
     OUTPUT ${gensrcdict} ${rootmapname}
     COMMAND ${ROOT_genreflex_CMD}
     ARGS ${headerfiles} -o ${gensrcdict} ${rootmapopts} --select=${selectionfile}
-         --gccxmlpath=${GCCXML_home}/bin ${ARG_OPTIONS} ${include_dirs} ${definitions}
-    DEPENDS ${headerfiles} ${selectionfile} ${ARG_DEPENDS})
+         --gccxmlpath=${GCCXML_home}/bin ${ARG_OPTIONS}
+         "-I$<JOIN:${include_dirs},;-I>"
+         "$<$<BOOL:$<JOIN:${definitions},>>:-D$<JOIN:${definitions},;-D>>"
+    DEPENDS ${headerfiles} ${selectionfile} ${ARG_DEPENDS}
+
+    COMMAND_EXPAND_LISTS
+    )
 
   #---roottest compability---------------------------------
   if(CMAKE_ROOTTEST_DICT)


### PR DESCRIPTION
As far as I can tell, it is currently not possible to use the REFLEX_GENERATE_DICTIONARY without variables that define include directories (or compile definitions). I would like to be able to let those be extract from target properties. I would also like to be not forced to set directory properties to have a more fine grained handle on dependencies.

Even with directory properties extracting, e.g., include directories doesn't work when the generator expression comes out to be a list of directories.
E.g.
```cmake
include_directories(  $<TARGET_PROPERTY:podio::podio,INCLUDE_DIRECTORIES>  )
```
would lead to `... -I dir1;dir2`.

Joining by hand (`$<JOIN....>`) also doesn't work because either the whitespace is not treated correctly, or COMMAND_EXPAND_LISTS is not part of ADD_CUSTOM_COMMAND, but that wouldn't solve my problem with using directory properties in the first place.

So I propose the contained changes, which then lets one do
E.g.
```cmake
add_library(edm4hep SHARED ${sources} ${headers})
target_link_libraries(edm4hep
  PUBLIC
  podio::podio
  )
target_include_directories(edm4hep
  PUBLIC
  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/edm4hep>
  $<INSTALL_INTERFACE:edm4hep>
)
REFLEX_GENERATE_DICTIONARY(edm4hep ${headers} SELECTION src/selection.xml
  USES edm4hep
  )
```
And all the required include directories are derived automatically from the edm4hep target given to `USES`