### PR TITLE
[cling] Capture/reset expression eval context (ROOT-10511):

### DIFF
--- a/interpreter/cling/include/cling/Utils/ParserStateRAII.h
+++ b/interpreter/cling/include/cling/Utils/ParserStateRAII.h
@@ -42,6 +42,7 @@ namespace cling {
     unsigned OldTemplateParameterDepth;
     bool OldInNonInstantiationSFINAEContext;
     bool SkipToEOF;
+    clang::EnterExpressionEvaluationContext ResetExprEvalCtx;
 
   public:
     ParserStateRAII(clang::Parser& p, bool skipToEOF);

--- a/interpreter/cling/lib/Utils/ParserStateRAII.cpp
+++ b/interpreter/cling/lib/Utils/ParserStateRAII.cpp
@@ -30,7 +30,8 @@ cling::ParserStateRAII::ParserStateRAII(Parser& p, bool skipToEOF)
   OldTemplateParameterDepth(p.TemplateParameterDepth),
   OldInNonInstantiationSFINAEContext(P->getActions()
                                      .InNonInstantiationSFINAEContext),
-  SkipToEOF(skipToEOF)
+  SkipToEOF(skipToEOF),
+  ResetExprEvalCtx(p.getActions(), clang::Sema::ExpressionEvaluationContext::PotentiallyEvaluated)
 {
   // Set to defaults, reset to previous values by ~ParserStateRAII().
   OldTemplateIds.swap(P->TemplateIds);


### PR DESCRIPTION
Without resetting the eval context to the Parser default (PotentiallyEvaluated),
recursive parsing can potentially assume wrong context and not emit referenced entities.