### PR TITLE
[Exp PyROOT] PyUnicode_AsWideChar changed in 3.2, not 3.5

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPyCppyy.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPyCppyy.h
@@ -209,8 +209,8 @@ static inline const char* CPyCppyy_PyText_AsStringAndSize(PyObject* pystr, Py_ss
 #define Py_TYPE(ob)             (((PyObject*)(ob))->ob_type)
 #endif
 
-// API changes in 2.5 (int -> Py_ssize_t) and 3.5 (PyUnicodeObject -> PyObject)
-#if PY_VERSION_HEX < 0x03050000
+// API changes in 2.5 (int -> Py_ssize_t) and 3.2 (PyUnicodeObject -> PyObject)
+#if PY_VERSION_HEX < 0x03020000
 static inline Py_ssize_t CPyCppyy_PyUnicode_AsWideChar(PyObject* pyobj, wchar_t* w, Py_ssize_t size)
 {
 #if PY_VERSION_HEX < 0x02050000


### PR DESCRIPTION
`PyUnicode_AsWideChar` receives a `PyObject*` since Python3.2, see:

https://github.com/python/cpython/blob/3.1/Objects/unicodeobject.c#L1085
vs
https://github.com/python/cpython/blob/3.2/Objects/unicodeobject.c#L1311

This fixes the Ubuntu14 build, which uses Python3.4 :
http://cdash.cern.ch/viewBuildError.php?buildid=816301

The changes will be submitted to upstream Cppyy too.