### PR TITLE
Fix ROOT-10574, ResolveTypedef was stripping 2 char from name prefixed with ::

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1488,7 +1488,6 @@ static void ResolveTypedefImpl(const char *tname,
 
    if (len > 2 && strncmp(tname+cursor,"::",2) == 0) {
       cursor += 2;
-      len -= 2;
    }
 
    unsigned int start_of_type = cursor;


### PR DESCRIPTION


The code was advancing the cursor and reducing the length, hence ignoring
the last 2 characters.  This had a visible consequence only if the input
was a typedef (then it was not found/replaced when it should have)
or the input minus the last 2 characters was a typedef (then it was replaced
when it should not have).