### PR TITLE
[ROOT-10545] .qqqqqq should not show a stack trace

### DIFF
--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -2153,6 +2153,7 @@ void TUnixSystem::Exit(int code, Bool_t mode)
 
 void TUnixSystem::Abort(int)
 {
+   IgnoreSignal(kSigAbort);
    ::abort();
 }
 
@@ -3631,6 +3632,8 @@ void TUnixSystem::DispatchSignals(ESignals sig)
       if (gExceptionHandler)
          gExceptionHandler->HandleException(sig);
       else {
+         if (sig == kSigAbort)
+            return;
          Break("TUnixSystem::DispatchSignals", "%s", UnixSigname(sig));
          StackTrace();
          if (gApplication)

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -1757,6 +1757,8 @@ void TWinNTSystem::DispatchSignals(ESignals sig)
          if (sig == kSigFloatingException) _fpreset();
          gExceptionHandler->HandleException(sig);
       } else {
+         if (sig == kSigAbort)
+            return;
          //map to the real signal code + set the
          //high order bit to indicate a signal (?)
          StackTrace();
@@ -3891,6 +3893,7 @@ void TWinNTSystem::Exit(int code, Bool_t mode)
 
 void TWinNTSystem::Abort(int)
 {
+   IgnoreSignal(kSigAbort);
    ::abort();
 }
 


### PR DESCRIPTION
Do not handle SIGABRT unless an exception handler has been defined, which is the case for PyROOT. In the case of typing .qqqqqq in the ROOT prompt, which throws a SIGABRT, no stack trace will be printed.
