### PR TITLE
[metacling] Also iterate over implicit spec funcs (ROOT-10488):

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
@@ -85,7 +85,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_rvec_asrvec rvec_asrvec.py)
 
 # RDataFrame and subclasses pythonizations
 if (dataframe)
-    #ROOT_ADD_PYUNITTEST(pyroot_pyz_rdataframe_asnumpy rdataframe_asnumpy.py)
+    ROOT_ADD_PYUNITTEST(pyroot_pyz_rdataframe_asnumpy rdataframe_asnumpy.py)
     ROOT_ADD_PYUNITTEST(pyroot_pyz_rdataframe_makenumpy rdataframe_makenumpy.py)
 endif()
 

--- a/core/metacling/src/TClingMethodInfo.h
+++ b/core/metacling/src/TClingMethodInfo.h
@@ -40,6 +40,7 @@ namespace cling {
 
 namespace clang {
    class FunctionDecl;
+   class CXXMethodDecl;
 }
 
 namespace ROOT {
@@ -60,6 +61,8 @@ private:
    clang::DeclContext::decl_iterator            fIter; // Our iterator.
    std::string                                  fTitle; // The meta info for the method.
    const clang::FunctionDecl                   *fTemplateSpec; // an all-default-template-args function.
+   llvm::SmallVector<clang::Decl *,4>           fDefDataSpecFuns; // decl_begin() will skip these special members, materialized from DefinitionData
+   llvm::SmallVector<clang::Decl *,4>::const_iterator fDefDataSpecFunIter; // Iterator over fDefDataSpecFuns
 
    const clang::Decl* GetDeclSlow() const;
 


### PR DESCRIPTION
CXXRecordDecls will synthesize special functions through lookup, but
do not expose them as part of the DeclContext iteration. Synthesize them,
and inject them into the iteration of TClingMethodInfo. This is especially
needed for modules which aggressively prune these special functions, relying
on DefinitionData instead.

This also fixes roottest/root/meta/runMemberComments.