### PR TITLE
TNetXNGFile - read archive member size instead of the whole archive

### DIFF
--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -18,6 +18,7 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "TArchiveFile.h"
 #include "TNetXNGFile.h"
 #include "TEnv.h"
 #include "TSystem.h"
@@ -275,6 +276,10 @@ void TNetXNGFile::Init(Bool_t create)
 
 Long64_t TNetXNGFile::GetSize() const
 {
+   if (fArchive && fArchive->GetMember()) {
+     return fArchive->GetMember()->GetDecompressedSize();
+   }
+
    using namespace XrdCl;
 
    // Check the file isn't a zombie or closed


### PR DESCRIPTION
There seems to be a problem in TNetXNGFile when accessing archive members directly, the file size corresponds to the whole archive instead of the archive member. Because of that, there is mismatch of how much data ROOT requests from XRootD, and how much XRootD client returns, so the transfer fails.

With TXNetFile, the GetSize() method is implemented in TFile, while TNetXNGFile overrides it. The code in this PR is adding the same functionality from TFile::GetSize() to TNetXNGFile::GetSize().