### PR TITLE
Fix the update of time step for DL optimizer 

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Optimizer.h
+++ b/tmva/tmva/inc/TMVA/DNN/Optimizer.h
@@ -72,8 +72,6 @@ public:
    /*! Increments the global step. */
    void IncrementGlobalStep() { this->fGlobalStep++; }
 
-   void ResetGlobalStep() { this->fGlobalStep = 0; }
-
    /*! Getters */
    Scalar_t GetLearningRate() const
    {

--- a/tmva/tmva/inc/TMVA/DNN/Optimizer.h
+++ b/tmva/tmva/inc/TMVA/DNN/Optimizer.h
@@ -72,8 +72,13 @@ public:
    /*! Increments the global step. */
    void IncrementGlobalStep() { this->fGlobalStep++; }
 
+   void ResetGlobalStep() { this->fGlobalStep = 0; }
+
    /*! Getters */
-   Scalar_t GetLearningRate() const { return fLearningRate; }
+   Scalar_t GetLearningRate() const
+   {
+      return fLearningRate;
+   }
    size_t GetGlobalStep() const { return fGlobalStep; }
    std::vector<Layer_t *> &GetLayers() { return fDeepNet.GetLayers(); }
    Layer_t *GetLayerAt(size_t i) { return fDeepNet.GetLayerAt(i); }

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1429,7 +1429,6 @@ void MethodDL::TrainDeepNet()
       size_t nTrainEpochs = 0;
       while (!converged) {
          nTrainEpochs++;
-         //optimizer->ResetGlobalStep();
          trainingData.Shuffle(rng);
 
          // execute all epochs
@@ -1489,6 +1488,7 @@ void MethodDL::TrainDeepNet()
             if (debugFirstEpoch)
                std::cout << "- doing optimizer update  \n";
 
+            // increment optimizer step that is used in some algorithms (e.g. ADAM)
             optimizer->IncrementGlobalStep();
             optimizer->Step();
 


### PR DESCRIPTION
The update of the time step for the optimizer must be each batch update  and not for each epoch. 
This affects the correction for the bias applied to the computed first and second momentum when using ADam. (see https://root.cern.ch/doc/master/Adam_8h_source.html#l00147 ). 

After this correction the obtained convergence results look better and compatible with what obtained when using when using Keras 