### PR TITLE
RCanvas - first RFrame attributes

### DIFF
--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -23,6 +23,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RAttrLine.hxx
     ROOT/RAttrFill.hxx
     ROOT/RAttrMarker.hxx
+    ROOT/RAttrMargins.hxx
     ROOT/RAttrText.hxx
     ROOT/RPalette.hxx
     ROOT/RDrawable.hxx

--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -19,6 +19,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RDisplayItem.hxx
     ROOT/RAttrMap.hxx
     ROOT/RAttrBase.hxx
+    ROOT/RAttrAxis.hxx
     ROOT/RAttrBox.hxx
     ROOT/RAttrLine.hxx
     ROOT/RAttrFill.hxx

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -71,6 +71,7 @@
 #pragma link C++ class ROOT::Experimental::RAttrBox+;
 #pragma link C++ class ROOT::Experimental::RAttrMarker+;
 #pragma link C++ class ROOT::Experimental::RAttrText+;
+#pragma link C++ class ROOT::Experimental::RAttrAxis+;
 #pragma link C++ class ROOT::Experimental::RAttrMargins+;
 
 #endif

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -71,5 +71,7 @@
 #pragma link C++ class ROOT::Experimental::RAttrBox+;
 #pragma link C++ class ROOT::Experimental::RAttrMarker+;
 #pragma link C++ class ROOT::Experimental::RAttrText+;
+#pragma link C++ class ROOT::Experimental::RAttrLength+;
+#pragma link C++ class ROOT::Experimental::RAttrMargins+;
 
 #endif

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -71,7 +71,6 @@
 #pragma link C++ class ROOT::Experimental::RAttrBox+;
 #pragma link C++ class ROOT::Experimental::RAttrMarker+;
 #pragma link C++ class ROOT::Experimental::RAttrText+;
-#pragma link C++ class ROOT::Experimental::RAttrLength+;
 #pragma link C++ class ROOT::Experimental::RAttrMargins+;
 
 #endif

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -1,0 +1,62 @@
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RAttrAxis
+#define ROOT7_RAttrAxis
+
+#include <ROOT/RAttrBase.hxx>
+#include <ROOT/RAttrLine.hxx>
+#include <ROOT/RAttrText.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+/** \class RAttrAxis
+\ingroup GpadROOT7
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-02-20
+\brief All kind of drawing a axis: line, text, ticks, min/max, log, invert, ...
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RAttrAxis : public RAttrBase {
+
+   RAttrLine fAttrLine{this, "line_"};   ///<!  axis line attributes
+   RAttrText fAttrText{this, "text_"};   ///<!  axis text attributes
+
+   R__ATTR_CLASS(RAttrAxis, "axis_", AddDefaults(fAttrLine).AddDefaults(fAttrText).AddDouble("min", 0.).AddDouble("max", 1.).AddBool("log", false).AddBool("invert", false));
+
+   const RAttrLine &GetAttrLine() const { return fAttrLine; }
+   RAttrAxis &SetAttrLine(const RAttrLine &line) { fAttrLine = line; return *this; }
+   RAttrLine &AttrLine() { return fAttrLine; }
+
+   const RAttrText &GetAttrText() const { return fAttrText; }
+   RAttrAxis &SetAttrText(const RAttrText &text) { fAttrText = text; return *this; }
+   RAttrText &AttrText() { return fAttrText; }
+
+   // min range, graphics will not show value less then this
+   void SetMin(double min) { SetValue("min", min); }
+   void SetMax(double max) { SetValue("max", max); }
+   double GetMin() const { return GetValue<double>("min"); }
+   double GetMax() const { return GetValue<double>("max"); }
+
+   void SetMinMax(double min, double max) { SetMin(min); SetMax(max); }
+   void ClearMinMax() { ClearValue("min"); ClearValue("max"); }
+
+   void SetLog(bool on = true) { SetValue("log", on); }
+   bool GetLog() const { return GetValue<bool>("log"); }
+
+   void SetInvert(bool on = true) { SetValue("invert", on); }
+   bool GetInvert() const { return GetValue<bool>("invert"); }
+
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf2d/gpadv7/inc/ROOT/RAttrBox.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBox.hxx
@@ -27,7 +27,7 @@ namespace Experimental {
 class RAttrBox : public RAttrBase {
 
    RAttrLine fAttrBorder{this, "border_"};   ///<!
-   RAttrFill fAttrFill{this, "fill_"};           ///<!
+   RAttrFill fAttrFill{this, "fill_"};       ///<!
 
    R__ATTR_CLASS(RAttrBox, "box_", AddDefaults(fAttrBorder).AddDefaults(fAttrFill));
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
@@ -23,66 +23,45 @@ namespace Experimental {
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RAttrLength : public RAttrBase {
+class RAttrMargins : public RAttrBase {
 
-   RPadLength fLength;      ///<! current position
+   R__ATTR_CLASS(RAttrMargins, "margin_", AddString("left","").AddString("right","").AddString("top","").AddString("bottom",""));
 
-   R__ATTR_CLASS(RAttrLength, "shift_", AddDouble("norm", 0.).AddDouble("px", 0));
+   RAttrMargins &SetLeft(const RPadLength &pos) { SetMargin("left", pos); return *this; }
+   RPadLength GetLeft() const { return GetMargin("left"); }
 
-   RAttrLength &Set(const RPadLength &pos)
+   RAttrMargins &SetRight(const RPadLength &pos) { SetMargin("right", pos); return *this; }
+   RPadLength GetRight() const { return GetMargin("right"); }
+
+   RAttrMargins &SetTop(const RPadLength &pos) { SetMargin("top", pos); return *this; }
+   RPadLength GetTop() const { return GetMargin("top"); }
+
+   RAttrMargins &SetBottom(const RPadLength &pos) { SetMargin("bottom", pos); return *this; }
+   RPadLength GetBottom() const { return GetMargin("bottom"); }
+
+protected:
+
+   RAttrMargins &SetMargin(const std::string &name, const RPadLength &pos)
    {
-      if (pos.HasNormal())
-         SetValue("norm", pos.GetNormal());
+      if (pos.Empty())
+         ClearValue(name);
       else
-         ClearValue("norm");
-
-      if (pos.HasPixel())
-         SetValue("px", pos.GetPixel());
-      else
-         ClearValue("px");
+         SetValue(name, pos.AsString());
 
       return *this;
    }
 
-   RPadLength Get() const
+   RPadLength GetMargin(const std::string &name) const
    {
       RPadLength res;
 
-      auto norm = GetValue<double>("norm");
-      auto px = GetValue<double>("px");
+      auto value = GetValue<std::string>(name);
 
-      if (px) res.SetPixel(px);
-      if (norm) res.SetNormal(norm);
+      if (!value.empty())
+         res.ParseString(value);
 
       return res;
    }
-
-};
-
-class RAttrMargins : public RAttrBase {
-
-   RAttrLength fLeft{this, "left_"}; ///<! left margin
-   RAttrLength fRight{this, "right_"}; ///<! right margin
-   RAttrLength fTop{this, "top_"}; ///<! top margin
-   RAttrLength fBottom{this, "bottom_"}; ///<! bottom margin
-
-   R__ATTR_CLASS(RAttrMargins, "margin_", AddDefaults(fLeft).AddDefaults(fRight).AddDefaults(fTop).AddDefaults(fBottom));
-
-   RAttrMargins &SetLeft(const RPadLength &pos) { fLeft.Set(pos); return *this; }
-   RPadLength GetLeft() const { return fLeft.Get(); }
-   RAttrLength &Left() { return fLeft; }
-
-   RAttrMargins &SetRight(const RPadLength &pos) { fRight.Set(pos); return *this; }
-   RPadLength GetRight() const { return fRight.Get(); }
-   RAttrLength &Right() { return fRight; }
-
-   RAttrMargins &SetTop(const RPadLength &pos) { fTop.Set(pos); return *this; }
-   RPadLength GetTop() const { return fTop.Get(); }
-   RAttrLength &Top() { return fTop; }
-
-   RAttrMargins &SetBottom(const RPadLength &pos) { fBottom.Set(pos); return *this; }
-   RPadLength GetBottom() const { return fBottom.Get(); }
-   RAttrLength &Bottom() { return fBottom; }
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
@@ -27,16 +27,16 @@ class RAttrMargins : public RAttrBase {
 
    R__ATTR_CLASS(RAttrMargins, "margin_", AddString("left","").AddString("right","").AddString("top","").AddString("bottom",""));
 
-   RAttrMargins &SetLeft(const RPadLength &pos) { SetMargin("left", pos); return *this; }
+   RAttrMargins &SetLeft(const RPadLength &pos) { return SetMargin("left", pos); }
    RPadLength GetLeft() const { return GetMargin("left"); }
 
-   RAttrMargins &SetRight(const RPadLength &pos) { SetMargin("right", pos); return *this; }
+   RAttrMargins &SetRight(const RPadLength &pos) { return SetMargin("right", pos); }
    RPadLength GetRight() const { return GetMargin("right"); }
 
-   RAttrMargins &SetTop(const RPadLength &pos) { SetMargin("top", pos); return *this; }
+   RAttrMargins &SetTop(const RPadLength &pos) { return SetMargin("top", pos); }
    RPadLength GetTop() const { return GetMargin("top"); }
 
-   RAttrMargins &SetBottom(const RPadLength &pos) { SetMargin("bottom", pos); return *this; }
+   RAttrMargins &SetBottom(const RPadLength &pos) { return SetMargin("bottom", pos); }
    RPadLength GetBottom() const { return GetMargin("bottom"); }
 
 protected:

--- a/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
@@ -1,0 +1,92 @@
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RAttrMargins
+#define ROOT7_RAttrMargins
+
+#include <ROOT/RAttrBase.hxx>
+#include <ROOT/RPadLength.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+/** \class RAttrMargins
+\ingroup GpadROOT7
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-02-20
+\brief A margins attributes. Only relative and pixel coordinates are allowed
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RAttrLength : public RAttrBase {
+
+   RPadLength fLength;      ///<! current position
+
+   R__ATTR_CLASS(RAttrLength, "shift_", AddDouble("norm", 0.).AddDouble("px", 0));
+
+   RAttrLength &Set(const RPadLength &pos)
+   {
+      if (pos.HasNormal())
+         SetValue("norm", pos.GetNormal());
+      else
+         ClearValue("norm");
+
+      if (pos.HasPixel())
+         SetValue("px", pos.GetPixel());
+      else
+         ClearValue("px");
+
+      return *this;
+   }
+
+   RPadLength Get() const
+   {
+      RPadLength res;
+
+      auto norm = GetValue<double>("norm");
+      auto px = GetValue<double>("px");
+
+      if (px) res.SetPixel(px);
+      if (norm) res.SetNormal(norm);
+
+      return res;
+   }
+
+};
+
+class RAttrMargins : public RAttrBase {
+
+   RAttrLength fLeft{this, "left_"}; ///<! left margin
+   RAttrLength fRight{this, "right_"}; ///<! right margin
+   RAttrLength fTop{this, "top_"}; ///<! top margin
+   RAttrLength fBottom{this, "bottom_"}; ///<! bottom margin
+
+   R__ATTR_CLASS(RAttrMargins, "margin_", AddDefaults(fLeft).AddDefaults(fRight).AddDefaults(fTop).AddDefaults(fBottom));
+
+   RAttrMargins &SetLeft(const RPadLength &pos) { fLeft.Set(pos); return *this; }
+   RPadLength GetLeft() const { return fLeft.Get(); }
+   RAttrLength &Left() { return fLeft; }
+
+   RAttrMargins &SetRight(const RPadLength &pos) { fRight.Set(pos); return *this; }
+   RPadLength GetRight() const { return fRight.Get(); }
+   RAttrLength &Right() { return fRight; }
+
+   RAttrMargins &SetTop(const RPadLength &pos) { fTop.Set(pos); return *this; }
+   RPadLength GetTop() const { return fTop.Get(); }
+   RAttrLength &Top() { return fTop; }
+
+   RAttrMargins &SetBottom(const RPadLength &pos) { fBottom.Set(pos); return *this; }
+   RPadLength GetBottom() const { return fBottom.Get(); }
+   RAttrLength &Bottom() { return fBottom; }
+
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -28,7 +28,7 @@ namespace Experimental {
 
 class RAttrText : public RAttrBase {
 
-   RColor fColor{this, "color_"}; ///<! line color, will access container from line attributes
+   RColor fColor{this, "color_"}; ///<! text color, will access container from text attributes
 
    R__ATTR_CLASS(RAttrText, "text_", AddDouble("size", 12.).AddDouble("angle", 0.).AddInt("align", 22).AddInt("font", 41).AddDefaults(fColor));
 

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -14,6 +14,7 @@
 #include "ROOT/RAttrLine.hxx"
 #include "ROOT/RAttrFill.hxx"
 #include "ROOT/RAttrMargins.hxx"
+#include "ROOT/RAttrAxis.hxx"
 
 #include "ROOT/RPadUserAxis.hxx"
 #include "ROOT/RPalette.hxx"
@@ -38,6 +39,9 @@ private:
    RAttrMargins fMargins{this, "margin_"};     ///<!
    RAttrLine fAttrBorder{this, "border_"};     ///<!
    RAttrFill fAttrFill{this, "fill_"};         ///<!
+   RAttrAxis fAttrX{this, "x_"};               ///<!
+   RAttrAxis fAttrY{this, "y_"};               ///<!
+   RAttrAxis fAttrZ{this, "z_"};               ///<!
 
    /// Mapping of user coordinates to normal coordinates, one entry per dimension.
    std::vector<std::unique_ptr<RPadUserAxisBase>> fUserCoord;
@@ -66,6 +70,20 @@ public:
    const RAttrFill &GetAttrFill() const { return fAttrFill; }
    RFrame &SetAttrFill(const RAttrFill &fill) { fAttrFill = fill; return *this; }
    RAttrFill &AttrFill() { return fAttrFill; }
+
+   const RAttrAxis &GetAttrX() const { return fAttrX; }
+   RFrame &SetAttrX(const RAttrAxis &axis) { fAttrX = axis; return *this; }
+   RAttrAxis &AttrX() { return fAttrX; }
+
+   const RAttrAxis &GetAttrY() const { return fAttrY; }
+   RFrame &SetAttrY(const RAttrAxis &axis) { fAttrY = axis; return *this; }
+   RAttrAxis &AttrY() { return fAttrY; }
+
+   const RAttrAxis &GetAttrZ() const { return fAttrZ; }
+   RFrame &SetAttrZ(const RAttrAxis &axis) { fAttrZ = axis; return *this; }
+   RAttrAxis &AttrZ() { return fAttrZ; }
+
+
 
    /// Create `nDimensions` default axes for the user coordinate system.
    void GrowToDimensions(size_t nDimensions);

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -11,7 +11,10 @@
 
 #include "ROOT/RDrawable.hxx"
 
-#include "ROOT/RAttrBox.hxx"
+#include "ROOT/RAttrLine.hxx"
+#include "ROOT/RAttrFill.hxx"
+#include "ROOT/RAttrMargins.hxx"
+
 #include "ROOT/RPadUserAxis.hxx"
 #include "ROOT/RPalette.hxx"
 
@@ -32,9 +35,9 @@ class RFrame : public RDrawable  {
 public:
 
 private:
-
-   RAttrLine fAttrBorder{this, "border_"};   ///<!
-   RAttrFill fAttrFill{this, "fill_"};       ///<!
+   RAttrMargins fMargins{this, "margin_"};     ///<!
+   RAttrLine fAttrBorder{this, "border_"};     ///<!
+   RAttrFill fAttrFill{this, "fill_"};         ///<!
 
    /// Mapping of user coordinates to normal coordinates, one entry per dimension.
    std::vector<std::unique_ptr<RPadUserAxisBase>> fUserCoord;
@@ -51,6 +54,10 @@ public:
 
    /// Constructor taking user coordinate system, position and extent.
    explicit RFrame(std::vector<std::unique_ptr<RPadUserAxisBase>> &&coords);
+
+   const RAttrMargins &GetMargins() const { return fMargins; }
+   RFrame &SetMargins(const RAttrMargins &margins) { fMargins = margins; return *this; }
+   RAttrMargins &Margins() { return fMargins; }
 
    const RAttrLine &GetAttrBorder() const { return fAttrBorder; }
    RFrame &SetAttrBorder(const RAttrLine &border) { fAttrBorder = border; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -32,6 +32,10 @@ class RFrame : public RDrawable  {
 public:
 
 private:
+
+   RAttrLine fAttrBorder{this, "border_"};   ///<!
+   RAttrFill fAttrFill{this, "fill_"};       ///<!
+
    /// Mapping of user coordinates to normal coordinates, one entry per dimension.
    std::vector<std::unique_ptr<RPadUserAxisBase>> fUserCoord;
 
@@ -47,6 +51,14 @@ public:
 
    /// Constructor taking user coordinate system, position and extent.
    explicit RFrame(std::vector<std::unique_ptr<RPadUserAxisBase>> &&coords);
+
+   const RAttrLine &GetAttrBorder() const { return fAttrBorder; }
+   RFrame &SetAttrBorder(const RAttrLine &border) { fAttrBorder = border; return *this; }
+   RAttrLine &AttrBorder() { return fAttrBorder; }
+
+   const RAttrFill &GetAttrFill() const { return fAttrFill; }
+   RFrame &SetAttrFill(const RAttrFill &fill) { fAttrFill = fill; return *this; }
+   RAttrFill &AttrFill() { return fAttrFill; }
 
    /// Create `nDimensions` default axes for the user coordinate system.
    void GrowToDimensions(size_t nDimensions);

--- a/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
@@ -44,9 +44,6 @@ private:
 
    std::vector<Primitive_t> fPrimitives;
 
-   /// RFrame with user coordinate system, if used by this pad.
-   std::unique_ptr<RFrame> fFrame;
-
    /// Disable copy construction.
    RPadBase(const RPadBase &) = delete;
 
@@ -168,10 +165,9 @@ public:
    /// Wipe the pad by clearing the list of primitives.
    void Wipe() { fPrimitives.clear(); }
 
-   void CreateFrameIfNeeded();
-
-   RFrame *GetOrCreateFrame();
-   const RFrame *GetFrame() const { return fFrame.get(); }
+   std::shared_ptr<RFrame> GetOrCreateFrame();
+   std::shared_ptr<RFrame> GetFrame();
+   const std::shared_ptr<RFrame> GetFrame() const;
 
    RPadUserAxisBase* GetOrCreateAxis(size_t dimension);
    RPadUserAxisBase* GetAxis(size_t dimension) const;
@@ -200,10 +196,7 @@ public:
    virtual RCanvas *GetCanvas() = 0;
 
    /// Convert user coordinates to normal coordinates.
-   std::array<RPadLength::Normal, 2> UserToNormal(const std::array<RPadLength::User, 2> &pos) const
-   {
-      return fFrame->UserToNormal(pos);
-   }
+   std::array<RPadLength::Normal, 2> UserToNormal(const std::array<RPadLength::User, 2> &pos) const;
 
    void AssignAutoColors();
 

--- a/graf2d/gpadv7/inc/ROOT/RPadDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadDisplayItem.hxx
@@ -10,7 +10,6 @@
 #define ROOT7_RPadDisplayItem
 
 #include <ROOT/RDisplayItem.hxx>
-#include <ROOT/RFrame.hxx>
 #include <ROOT/RPad.hxx>
 #include "ROOT/RStyle.hxx"
 
@@ -32,14 +31,12 @@ public:
    using PadPrimitives_t = std::vector<std::unique_ptr<RDisplayItem>>;
 
 protected:
-   const RFrame *fFrame{nullptr};       ///< temporary pointer on frame object
    const RAttrMap *fAttr{nullptr};      ///< temporary pointer on attributes
    PadPrimitives_t fPrimitives;         ///< display items for all primitives in the pad
    std::vector<std::shared_ptr<RStyle>> fStyles; ///<! locked styles of the objects and pad until streaming is performed
 public:
    RPadBaseDisplayItem() = default;
    virtual ~RPadBaseDisplayItem() = default;
-   void SetFrame(const RFrame *f) { fFrame = f; }
    void SetAttributes(const RAttrMap *f) { fAttr = f; }
    /// Add display item and style which should be used for it
    void Add(std::unique_ptr<RDisplayItem> &&item, std::shared_ptr<RStyle> &&style)

--- a/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
@@ -169,6 +169,8 @@ public:
 
    void Clear() { fArr.clear(); }
 
+   bool Empty() const { return fArr.size() == 0; }
+
    /// Add two `RPadLength`s.
    friend RPadLength operator+(RPadLength lhs, const RPadLength &rhs)
    {
@@ -236,6 +238,10 @@ public:
       if (HasNormal()) SetNormal(scale*GetNormal());
       return *this;
    }
+
+   std::string AsString() const;
+
+   bool ParseString(const std::string &val);
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
@@ -155,7 +155,17 @@ public:
    double GetPixel() const { return fArr.size() > 1 ? fArr[1] : 0.; }
    double GetUser() const { return fArr.size() > 2 ? fArr[2] : 0.; }
 
-   void ClearUser() { if (fArr.size()>2) fArr.resize(2); }
+   void ClearUser()
+   {
+      if (fArr.size() > 2)
+         fArr.resize(2);
+   }
+
+   void ClearPixelAndUser()
+   {
+      if (fArr.size() > 1)
+         fArr.resize(1);
+   }
 
    void Clear() { fArr.clear(); }
 

--- a/graf2d/gpadv7/src/RDrawable.cxx
+++ b/graf2d/gpadv7/src/RDrawable.cxx
@@ -37,7 +37,7 @@ bool ROOT::Experimental::RDrawable::MatchSelector(const std::string &selector) c
 
 /////////////////////////////////////////////////////////////////////////////
 /// Creates display item for drawable
-/// By default item contains drawble data itself
+/// By default item contains drawable data itself
 
 std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RDrawable::Display() const
 {

--- a/graf2d/gpadv7/src/RPadLength.cxx
+++ b/graf2d/gpadv7/src/RPadLength.cxx
@@ -70,8 +70,7 @@ bool ROOT::Experimental::RPadLength::ParseString(const std::string &value)
 
    while (!val.empty()) {
       // skip empty spaces
-
-      while (pos < val.length() && (val[pos] == ' ') || (val[pos] == '\t'))
+      while ((pos < val.length()) && ((val[pos] == ' ') || (val[pos] == '\t')))
          ++pos;
 
       if (pos >= val.length())

--- a/graf2d/gpadv7/src/RPadLength.cxx
+++ b/graf2d/gpadv7/src/RPadLength.cxx
@@ -8,3 +8,116 @@
 
 #include "ROOT/RPadLength.hxx"
 
+#include "ROOT/RLogger.hxx"
+
+#include <string>
+
+///////////////////////////////////////////////////////////////////////
+/// Converts RPadLength to string like "0.1 + 25px"
+/// User coordinates not (yet) supported
+
+std::string ROOT::Experimental::RPadLength::AsString() const
+{
+   std::string res;
+
+   if (HasNormal()) {
+      double v = GetNormal();
+      if (v) res = std::to_string(v);
+   }
+
+   if (HasPixel()) {
+      double v = GetPixel();
+      if ((v > 0) && !res.empty())
+         res += " + ";
+
+      if ((v != 0) || res.empty()) {
+         res += std::to_string(v);
+         res += "px";
+      }
+   }
+
+   if (!Empty() && res.empty())
+      res = "0";
+
+   return res;
+}
+
+///////////////////////////////////////////////////////////////////////
+/// Parse string and fill RPadLength attributes
+/// String can be like "0.1 + 25px"
+/// User coordinates not (yet) supported
+
+bool ROOT::Experimental::RPadLength::ParseString(const std::string &value)
+{
+   Clear();
+
+   if (value.empty())
+      return true;
+
+   if (value == "0") {
+      SetNormal(0);
+      return true;
+   }
+
+   if (value == "0px") {
+      SetPixel(0);
+      return true;
+   }
+
+   std::size_t pos = 0;
+   std::string val = value;
+   int operand = 0;
+
+   while (!val.empty()) {
+      // skip empty spaces
+
+      while (pos < val.length() && (val[pos] == ' ') || (val[pos] == '\t'))
+         ++pos;
+
+      if (pos >= val.length())
+         break;
+
+      if ((val[pos] == '-') || (val[pos] == '+')) {
+         if (operand) {
+            Clear();
+            R__ERROR_HERE("gpadv7") << "Fail to parse RPadLength " << value;
+            return false;
+         }
+         operand = (val[pos] == '-') ? -1 : 1;
+         pos++;
+         continue;
+      }
+
+      if (pos > 0) {
+         val.erase(0, pos);
+         pos = 0;
+      }
+
+      double v = 0;
+
+      try {
+         v = std::stod(val, &pos);
+      } catch (...) {
+         Clear();
+         return false;
+      }
+
+      val.erase(0, pos);
+      pos = 0;
+      if (!operand) operand = 1;
+
+      if ((val.length() > 0) && (val[0] == '%')) {
+         val.erase(0, 1);
+         SetNormal(GetNormal() + operand*0.01*v);
+      } else if ((val.length() > 1) && (val[0] == 'p') && (val[1] == 'x')) {
+         val.erase(0, 2);
+         SetPixel(GetPixel() + operand*v);
+      } else {
+         SetNormal(GetNormal() + operand*v);
+      }
+
+      operand = 0;
+   }
+
+   return true;
+}

--- a/graf2d/primitivesv7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RBox.hxx
@@ -29,7 +29,6 @@ namespace Experimental {
 
 class RBox : public RDrawable {
 
-   /// Box's coordinates
    RPadPos fP1, fP2;                    ///< box corners coordinates
    RAttrBox fAttrBox{this, "box_"};     ///<! box attributes
 

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -651,7 +651,24 @@ std::string ROOT::Experimental::RCanvasPainter::CreateSnapshot(const ROOT::Exper
    canvitem->BuildFullId(""); // create object id which unique identify it via pointer and position in subpads
    canvitem->SetObjectID("canvas"); // for canvas itself use special id
 
-   TString res = TBufferJSON::ToJSON(canvitem.get(), fJsonComp);
+   TBufferJSON json;
+   json.SetCompact(fJsonComp);
+
+   static std::vector<const TClass *> exclude_classes = {
+      TClass::GetClass<ROOT::Experimental::RAttrMap::BoolValue_t>(),
+      TClass::GetClass<ROOT::Experimental::RAttrMap::IntValue_t>(),
+      TClass::GetClass<ROOT::Experimental::RAttrMap::DoubleValue_t>(),
+      TClass::GetClass<ROOT::Experimental::RAttrMap::StringValue_t>(),
+      TClass::GetClass<ROOT::Experimental::RAttrMap>(),
+      TClass::GetClass<ROOT::Experimental::RPadPos>(),
+      TClass::GetClass<ROOT::Experimental::RPadLength>(),
+      TClass::GetClass<std::unordered_map<std::string,ROOT::Experimental::RAttrMap::Value_t*>>()
+   };
+
+   for (auto cl : exclude_classes)
+      json.SetSkipClassInfo(cl);
+
+   auto res = json.StoreObject(canvitem.get(), TClass::GetClass<RCanvasDisplayItem>());
 
    return std::string(res.Data());
 }

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -660,6 +660,7 @@ std::string ROOT::Experimental::RCanvasPainter::CreateSnapshot(const ROOT::Exper
       TClass::GetClass<ROOT::Experimental::RAttrMap::DoubleValue_t>(),
       TClass::GetClass<ROOT::Experimental::RAttrMap::StringValue_t>(),
       TClass::GetClass<ROOT::Experimental::RAttrMap>(),
+      TClass::GetClass<ROOT::Experimental::RStyle::Block_t>(),
       TClass::GetClass<ROOT::Experimental::RPadPos>(),
       TClass::GetClass<ROOT::Experimental::RPadLength>(),
       TClass::GetClass<std::unordered_map<std::string,ROOT::Experimental::RAttrMap::Value_t*>>()

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1437,7 +1437,7 @@ void TBufferJSON::JsonWriteObject(const void *obj, const TClass *cl, Bool_t chec
          bool first = true;
 
          fValue = "{";
-         if (fTypeNameTag.Length() > 0) {
+         if ((fTypeNameTag.Length() > 0) && !IsSkipClassInfo(cl)) {
             fValue.Append("\"");
             fValue.Append(fTypeNameTag);
             fValue.Append("\"");

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 17/02/2020";
+   JSROOT.version = "dev 20/02/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootPainter.js
+++ b/js/scripts/JSRootPainter.js
@@ -3597,8 +3597,12 @@
       if (svg_p.empty()) return true;
 
       var pp = svg_p.property('pad_painter');
-      if (pp && (pp !== this))
+      if (pp && (pp !== this)) {
          pp.painters.push(this);
+         // workround to provide style for next object draing
+         if (!this.rstyle && pp.next_rstyle)
+            this.rstyle = pp.next_rstyle;
+      }
 
       if (((is_main === 1) || (is_main === 4) || (is_main === 5)) && !svg_p.property('mainpainter'))
          // when this is first main painter in the pad

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -62,6 +62,29 @@
       return this.v7EvalAttr(name + "_name", "") || dflt;
    }
 
+   /** Create this.fillatt object based on v7 fill attributes */
+   JSROOT.TObjectPainter.prototype.createv7AttFill = function(prefix) {
+      if (!prefix || (typeof prefix != "string")) prefix = "fill_";
+
+      var fill_color = this.v7EvalColor(prefix + "color", "white");
+
+      this.createAttFill({ pattern: 1001, color: 0 });
+
+      this.fillatt.SetSolidColor(fill_color);
+   }
+
+   /** Create this.lineatt object based on v7 line attributes */
+   JSROOT.TObjectPainter.prototype.createv7AttLine = function(prefix) {
+      if (!prefix || (typeof prefix != "string")) prefix = "line_";
+
+      var line_color = this.v7EvalColor(prefix + "color", "black"),
+          line_width = this.v7EvalAttr(prefix + "width", 1),
+          line_style = this.v7EvalAttr(prefix + "style", 1);
+
+      this.createAttLine({ color: line_color, width: line_width, style: line_style });
+   }
+
+
 
    function TAxisPainter(axis, embedded) {
       JSROOT.TObjectPainter.call(this, axis);
@@ -907,14 +930,10 @@
          }
       }
 
-      if (this.fillatt === undefined) {
-         this.createAttFill({ pattern: 1001, color: 0 });
+      if (!this.fillatt)
+         this.createv7AttFill("fill_");
 
-         // TODO: provide real fill color
-         this.fillatt.SetSolidColor('white');
-      }
-
-      this.createAttLine({ color: 'black' });
+      this.createv7AttLine("border_");
    }
 
    TFramePainter.prototype.ProjectAitoff2xy = function(l, b) {
@@ -3327,7 +3346,6 @@
 
          this.draw_object = padattr;
          this.pad = padattr;
-         this.pad_frame = snap.fFrame;
 
          if (this.batch_mode && this.iscan)
              this._fixed_size = true;
@@ -4328,6 +4346,7 @@
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RBox", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawBox", opt: "", direct: true, csstype: "box" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RMarker", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawMarker", opt: "", direct: true, csstype: "marker" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RLegend", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawLegend", opt: "", direct: true, csstype: "legend" });
+   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RFrame", icon: "img_frame", func: "JSROOT.v7.drawFrame", opt: "" });
 
    JSROOT.v7.TAxisPainter = TAxisPainter;
    JSROOT.v7.TFramePainter = TFramePainter;

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -920,14 +920,24 @@
       var tframe = this.GetObject();
 
       if ((this.fX1NDC === undefined) || (force && !this.modified_NDC)) {
-         JSROOT.extend(this, JSROOT.gStyle.FrameNDC);
 
-         if (tframe && tframe.fPos && tframe.fSize) {
-            this.fX1NDC = tframe.fPos.fHoriz.fNormal.fVal;
-            this.fX2NDC = this.fX1NDC + tframe.fSize.fHoriz.fNormal.fVal;
-            this.fY1NDC = tframe.fPos.fVert.fNormal.fVal;
-            this.fY2NDC = this.fY1NDC + tframe.fSize.fVert.fNormal.fVal;
+
+         var pthis = this, padw = this.pad_width(), padh = this.pad_height();
+
+         /** Evalue RAttrLength which consists of normalized and pxel coordinates, return pixel value */
+         function evalLength(name, size, dflt) {
+            var norm = pthis.v7EvalAttr("margin_" + name + "_norm", dflt),
+                px = pthis.v7EvalAttr("margin_" + name + "_px", 0 ),
+                res = 0;
+            if (norm) res = size*norm;
+            if (px) res += px;
+            return size > 0 ? res/size : 0.;
          }
+
+         this.fX1NDC = evalLength("left", padw, JSROOT.gStyle.FrameNDC.fX1NDC);
+         this.fY1NDC = evalLength("bottom", padh, JSROOT.gStyle.FrameNDC.fY1NDC);
+         this.fX2NDC = 1 - evalLength("right", padw, 1-JSROOT.gStyle.FrameNDC.fX2NDC);
+         this.fY2NDC = 1 - evalLength("top", padh, 1-JSROOT.gStyle.FrameNDC.fY2NDC);
       }
 
       if (!this.fillatt)

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -937,7 +937,7 @@
 
             while (val.length > 0) {
                // skip empty spaces
-               while (pos < val.length && (val[pos] == ' ') || (val[pos] == '\t'))
+               while ((pos < val.length) && ((val[pos] == ' ') || (val[pos] == '\t')))
                   ++pos;
 
                if (pos >= val.length)

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -21,7 +21,6 @@
 
    JSROOT.sources.push("v7hist");
 
-
    // =============================================================
 
    function THistPainter(histo) {
@@ -41,11 +40,8 @@
    THistPainter.prototype.PrepareFrame = function(divid) {
       this.SetDivId(divid, -1);
 
-      if (!this.frame_painter()) {
-         var pad = this.root_pad(),
-             fr = pad ? pad.fFrame : null;
-         JSROOT.v7.drawFrame(divid, fr);
-      }
+      if (!this.frame_painter())
+         JSROOT.v7.drawFrame(divid, null);
 
       return this.SetDivId(divid, 1);
    }

--- a/tutorials/v7/draw.cxx
+++ b/tutorials/v7/draw.cxx
@@ -42,6 +42,11 @@ void draw()
 
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
+
+   canvas->GetOrCreateFrame()->AttrFill().SetColor(RColor::kBlue);
+   canvas->GetOrCreateFrame()->AttrBorder().SetColor(RColor::kRed);
+   canvas->GetOrCreateFrame()->AttrBorder().SetWidth(3);
+
    auto draw1 = canvas->Draw(pHist);
    draw1->AttrLine().SetColor(RColor::kRed);
 

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -19,15 +19,18 @@
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/RColor.hxx"
 #include "ROOT/RHistDrawable.hxx"
+#include "ROOT/RStyle.hxx"
 
 // macro must be here while cling is not capable to load
 // library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
 
+using namespace ROOT::Experimental;
+
+auto style = std::make_shared<RStyle>(); // keep here to avoid destroy when leaving function scope
+
 void draw_frame()
 {
-   using namespace ROOT::Experimental;
-
    // Create the histogram.
    RAxisConfig xaxis("x", 10, 0., 1.);
    RAxisConfig yaxis("y", {0., 1., 2., 3., 10.});
@@ -43,21 +46,34 @@ void draw_frame()
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
 
-   auto frame = canvas->GetOrCreateFrame();
-   frame->AttrFill().SetColor(RColor::kBlue);
-   frame->AttrBorder().SetColor(RColor::kRed);
-   frame->AttrBorder().SetWidth(3);
-   frame->Margins().SetTop(0.3_normal);
-   frame->Margins().SetBottom(0.1_normal);
-   frame->Margins().SetLeft(0.2_normal);
-   frame->Margins().SetRight(0.2_normal);
+   // Make divisions
+   auto subpads = canvas->Divide(2,1);
 
-   auto draw1 = canvas->Draw(pHist);
+   // configure RFrame with direct API calls
+   auto frame1 = subpads[0][0]->GetOrCreateFrame();
+   frame1->AttrFill().SetColor(RColor::kBlue);
+   frame1->AttrBorder().SetColor(RColor::kRed);
+   frame1->AttrBorder().SetWidth(3);
+   frame1->Margins().SetTop(0.3_normal);
+   frame1->Margins().SetBottom(0.1_normal);
+   frame1->Margins().SetLeft(0.2_normal);
+   frame1->Margins().SetRight(0.2_normal);
+
+   frame1->AttrX().AttrLine().SetColor(RColor::kGreen);
+   frame1->AttrY().AttrLine().SetColor(RColor::kBlue);
+
+   auto draw1 = subpads[0][0]->Draw(pHist);
    draw1->AttrLine().SetColor(RColor::kRed);
 
-   auto other = std::make_shared<RH2D>(*pHist);
-   auto draw2 = canvas->Draw(other);
+   // create frame before drawing histograms
+   auto frame2 = subpads[1][0]->GetOrCreateFrame();
+
+   auto draw2 = subpads[1][0]->Draw(pHist);
    draw2->AttrLine().SetColor(RColor::kBlue).SetWidth(12);
+
+   style->ParseString("frame { margin_left: 0.3; margin_right: 0.3; x_line_color_name: blue; y_line_color_name: green; }");
+
+   canvas->UseStyle(style);
 
    canvas->Show();
 }

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -3,10 +3,10 @@
 ///
 /// \macro_code
 ///
-/// \date 2015-03-22
+/// \date 2020-02-20
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
-/// \author Axel Naumann <axel@cern.ch>
+/// \author Sergey Linev <s.linev@gsi.de>
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
@@ -24,7 +24,7 @@
 // library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
 
-void draw()
+void draw_frame()
 {
    using namespace ROOT::Experimental;
 
@@ -42,6 +42,16 @@ void draw()
 
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
+
+   auto frame = canvas->GetOrCreateFrame();
+   frame->AttrFill().SetColor(RColor::kBlue);
+   frame->AttrBorder().SetColor(RColor::kRed);
+   frame->AttrBorder().SetWidth(3);
+   frame->Margins().SetTop(0.3_normal);
+   frame->Margins().SetBottom(0.1_normal);
+   frame->Margins().SetLeft(0.2_normal);
+   frame->Margins().SetRight(0.2_normal);
+
    auto draw1 = canvas->Draw(pHist);
    draw1->AttrLine().SetColor(RColor::kRed);
 


### PR DESCRIPTION
Before I code too far away 

This is first showcase, how new attributes will be introduced to `RFrame`.

First important change. `RFrame` is normal drawable and will be inserted into list of primitives. 
In the future we could enforce `RFrame` have to be always on the first place (to be discuss)

`RFrame` is not required to draw histogram. All defaults can be obtained via `RStyle`, therefore object can be created on the client side and all necessary attributes  can be obtained.

As first members of `RFrame` I introduce `RAttrMargin` and `RAttrAxis` attributes.
`RAttrMargin` contains margins from pad borders and can be defined as `RPadLength` without user components. In the CSS one could use syntax like: `frame { margin_left: 0.1 + 10px; }`  
As Idea: one also can allow something like: `frame { margin: 0; }`  to set all sides at same time

`RAttrAxis` are graphical axis attributes plus min/max range, lin/log scale, invert flag, ...
For now only line attributes are really used. 

Idea for next steps with `RAttrAxis`.
When min/max values not specified, axis ranges defined by first drawable like histogram or graph.
One should be able to set only min or only max value. Also visible range should be able to specify same way. 

You can see how code will look like in new macro: `draw_frame.cxx`.  It drawing in two sub-pads. On first sub-pad RFrame configured programatically, on second sub-pad - via CSS file.



