### PR TITLE
[Eve-7] Enable control of REveDataCollection and its items throug tree not check boxes

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveDataClasses.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataClasses.hxx
@@ -59,6 +59,9 @@ public:
    REveDataCollection(const std::string& n = "REveDataCollection", const std::string& t = "");
    virtual ~REveDataCollection() {}
 
+   bool SingleRnrState() const override { return true; }
+   bool SetRnrState(bool) override;
+
    TClass *GetItemClass() const { return fItemClass; }
    void SetItemClass(TClass *cls) { fItemClass = cls; }
 
@@ -75,8 +78,7 @@ public:
 
    Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
 
-   virtual void SetCollectionColorRGB(UChar_t r, UChar_t g, UChar_t b);
-   virtual void SetCollectionVisible(bool);
+   void SetMainColor(Color_t) override;
    virtual void ItemChanged(REveDataItem *item);
 
    void SetHandlerFunc (std::function<void (REveDataCollection*)> handler_func)
@@ -105,7 +107,7 @@ public:
    void   SetFiltered(Bool_t f);
 
    virtual void SetItemColorRGB(UChar_t r, UChar_t g, UChar_t b);
-   virtual void SetItemRnrSelf(bool);
+   bool SetRnrSelf(bool) override;
 
    virtual void FillImpliedSelectedSet(Set_t& impSelSet) override;
 

--- a/graf3d/eve7/src/REveDataClasses.cxx
+++ b/graf3d/eve7/src/REveDataClasses.cxx
@@ -95,7 +95,7 @@ void REveDataCollection::ApplyFilter()
       ids.push_back(idx++);
    }
    StampObjProps();
-   if ( _handler_func_ids) _handler_func_ids( this , ids);
+   if (_handler_func_ids) _handler_func_ids( this , ids);
 }
 
 //______________________________________________________________________________
@@ -173,33 +173,27 @@ Int_t REveDataCollection::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
 
 //______________________________________________________________________________
 
-void REveDataCollection::SetCollectionColorRGB(UChar_t r, UChar_t g, UChar_t b)
+void REveDataCollection::SetMainColor(Color_t newv)
 {
-   Color_t oldv = GetMainColor();
-   Color_t newv = TColor::GetColor(r, g, b);
    int idx = 0;
    Ids_t ids;
    for (auto & chld : fChildren)
    {
-      // if (chld->GetMainColor() == oldv) {
-         chld->SetMainColor(newv);
-         printf(" REveDataCollection::SetCollectionColorRGB going to change color for idx %d --------------------\n", idx);
-         ids.push_back(idx);
-         // }
-
+      chld->SetMainColor(newv);
+      ids.push_back(idx);
       idx++;
    }
 
    REveElement::SetMainColor(newv);
-   printf("REveDataCollection::SetCollectionColorRGB color ched to %d ->%d\n", oldv, GetMainColor());
-   _handler_func_ids( this , ids);
+   // printf("REveDataCollection::SetCollectionColorRGB color ched to %d ->%d\n", oldv, GetMainColor());
+    if ( _handler_func_ids) _handler_func_ids( this , ids);
 }
 
 //______________________________________________________________________________
 
-void REveDataCollection::SetCollectionVisible(bool iRnrSelf)
+bool REveDataCollection::SetRnrState(bool iRnrSelf)
 {
-   SetRnrSelf(iRnrSelf);
+   bool ret = REveElement::SetRnrState(iRnrSelf);
 
    Ids_t ids;
 
@@ -209,6 +203,8 @@ void REveDataCollection::SetCollectionVisible(bool iRnrSelf)
    }
 
    _handler_func_ids( this , ids);
+
+   return ret;
 }
 
 
@@ -255,11 +251,12 @@ void REveDataItem::SetItemColorRGB(UChar_t r, UChar_t g, UChar_t b)
    c->ItemChanged(this);
 }
 
-void REveDataItem::SetItemRnrSelf(bool iRnrSelf)
+bool REveDataItem::SetRnrSelf(bool iRnrSelf)
 {
-   REveElement::SetRnrSelf(iRnrSelf);
+   bool r = REveElement::SetRnrSelf(iRnrSelf);
    REveDataCollection* c = dynamic_cast<REveDataCollection*>(fMother);
    c->ItemChanged(this);
+   return r;
 }
 
 void REveDataItem::SetFiltered(bool f)

--- a/ui5/eve7/controller/Ged.controller.js
+++ b/ui5/eve7/controller/Ged.controller.js
@@ -475,13 +475,12 @@ sap.ui.define([
          { name : "NDiv",    _type : "Number" }
       ],
       "REveDataCollection" : [
-         { name : "FilterExpr",  _type : "String",   quote : 1 },
-         { name : "CollectionVisible",  member :"fRnrSelf",  _type : "Bool" },
-         make_main_col_obj("CollectionColor")
+         { sub: ["REveElement"] },
+         { name : "FilterExpr",  _type : "String",   quote : 1 }
       ],
       "REveDataItem" : [
          make_main_col_obj("ItemColor"),
-         { name : "ItemRnrSelf",   member : "fRnrSelf",  _type : "Bool" },
+         { name : "RnrSelf",   member : "fRnrSelf",  _type : "Bool" },
          { name : "Filtered",   _type : "Bool" }
       ],
       "REveTrack" : [


### PR DESCRIPTION
Use REveElement render state interface so user can control visibility of collection through checkbox in the tree node.