### PR TITLE
[Exp PyROOT] Fixes for AsNumpy test

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_generic.py
@@ -41,7 +41,9 @@ def pythonizegeneric(klass, name):
     # name: string containing the name of the class
 
     # Add pretty printing via setting the __str__ special function
-    AddPrettyPrintingPyz(klass)
+    exclude = [ 'std::string' ]
+    if name not in exclude:
+        AddPrettyPrintingPyz(klass)
 
     return True
 

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rdataframe.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rdataframe.py
@@ -58,8 +58,7 @@ def RDataFrameAsNumpy(df, columns=None, exclude=None):
 
     # Find all column names in the dataframe if no column are specified
     if not columns:
-        column_names = df.GetColumnNames()
-        columns = [c for c in column_names]
+        columns = [c for c in df.GetColumnNames()]
 
     # Exclude the specified columns
     if exclude == None:

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rdataframe.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rdataframe.py
@@ -58,7 +58,7 @@ def RDataFrameAsNumpy(df, columns=None, exclude=None):
 
     # Find all column names in the dataframe if no column are specified
     if not columns:
-        columns = [c for c in df.GetColumnNames()]
+        columns = [str(c) for c in df.GetColumnNames()]
 
     # Exclude the specified columns
     if exclude == None:

--- a/bindings/pyroot_experimental/pythonizations/test/pretty_printing.py
+++ b/bindings/pyroot_experimental/pythonizations/test/pretty_printing.py
@@ -35,6 +35,13 @@ class PrettyPrinting(unittest.TestCase):
         self._print(x)
         self.assertIn("foo", x.__str__())
 
+    def test_STLString(self):
+         # std::string is not pythonized with the pretty printing, because:
+         # 1. gInterpreter->ToString("s") returns ""s""
+         # 2. cppyy already does the right thing
+         s = ROOT.std.string("x")
+         self.assertEqual(str(s), "x")
+
     def test_TH1F(self):
         x = ROOT.TH1F("name", "title", 10, 0, 1)
         self._print(x)


### PR DESCRIPTION
A few fixes concerning the AsNumpy functionality, related to the iteration of a `vector<string>` and the use of stl strings as keys of Python dictionaries.

This should fix the AsNumpy test failure here:
https://github.com/root-project/root/pull/5036#issuecomment-588256573