### PR TITLE
Geometry - fix pcon shape creation [ROOT-10583]

### DIFF
--- a/geom/geom/inc/TGeoPcon.h
+++ b/geom/geom/inc/TGeoPcon.h
@@ -34,8 +34,8 @@ protected:
    Double_t              fCdphi;   //! Cosine of dphi
 
    // methods
-   TGeoPcon(const TGeoPcon&);
-   TGeoPcon& operator=(const TGeoPcon&);
+   TGeoPcon(const TGeoPcon&) = delete;
+   TGeoPcon& operator=(const TGeoPcon&) = delete;
 
    Bool_t                HasInsideSurface() const;
    void                  SetSegsAndPolsNoInside(TBuffer3D &buff) const;

--- a/geom/geom/inc/TGeoPcon.h
+++ b/geom/geom/inc/TGeoPcon.h
@@ -38,6 +38,7 @@ protected:
    TGeoPcon& operator=(const TGeoPcon&);
 
    Bool_t                HasInsideSurface() const;
+   void                  SetSegsAndPolsNoInside(TBuffer3D &buff) const;
 
 public:
    // constructors

--- a/geom/geom/inc/TGeoPcon.h
+++ b/geom/geom/inc/TGeoPcon.h
@@ -37,6 +37,8 @@ protected:
    TGeoPcon(const TGeoPcon&);
    TGeoPcon& operator=(const TGeoPcon&);
 
+   Bool_t                HasInsideSurface() const;
+
 public:
    // constructors
    TGeoPcon();

--- a/geom/geom/inc/TGeoPgon.h
+++ b/geom/geom/inc/TGeoPgon.h
@@ -48,7 +48,6 @@ protected:
    Bool_t                SliceCrossingIn(const Double_t *point, const Double_t *dir, Int_t ipl, Int_t nphi, Int_t *iphi, Double_t *sphi, Double_t &snext, Double_t stepmax) const;
    Bool_t                SliceCrossingZ(const Double_t *point, const Double_t *dir, Int_t nphi, Int_t *iphi, Double_t *sphi, Double_t &snext, Double_t stepmax) const;
    Bool_t                SliceCrossingInZ(const Double_t *point, const Double_t *dir, Int_t nphi, Int_t *iphi, Double_t *sphi, Double_t &snext, Double_t stepmax) const;
-   Bool_t                HasInsideSurface() const;
    void                  SetSegsAndPolsNoInside(TBuffer3D &buff) const;
 
 public:

--- a/geom/geom/src/TGeoPcon.cxx
+++ b/geom/geom/src/TGeoPcon.cxx
@@ -864,17 +864,10 @@ void TGeoPcon::InspectShape() const
 
 TBuffer3D *TGeoPcon::MakeBuffer3D() const
 {
-   const Int_t n = gGeoManager->GetNsegments()+1;
-   Int_t nz = GetNz();
-   if (nz < 2) return 0;
-   Int_t nbPnts = nz*2*n;
-   if (nbPnts <= 0) return 0;
-   Double_t dphi = GetDphi();
+   Int_t nbPnts, nbSegs, nbPols;
+   GetMeshNumbers(nbPnts, nbSegs, nbPols);
+   if (nbPnts <= 0) return nullptr;
 
-   Bool_t specialCase = TGeoShape::IsSameWithinTolerance(dphi,360);
-
-   Int_t nbSegs = 4*(nz*n-1+(specialCase ?  1 : 0));
-   Int_t nbPols = 2*(nz*n-1+(specialCase ?  1 : 0));
    TBuffer3D* buff = new TBuffer3D(TBuffer3DTypes::kGeneric,
                                    nbPnts, 3*nbPnts, nbSegs, 3*nbSegs, nbPols, 6*nbPols);
    if (buff)
@@ -1300,9 +1293,9 @@ void TGeoPcon::SetPoints(Float_t *points) const
 
 Int_t TGeoPcon::GetNmeshVertices() const
 {
-   Int_t n = gGeoManager->GetNsegments()+1;
-   Int_t numPoints = fNz*2*n;
-   return numPoints;
+   Int_t nvert, nsegs, npols;
+   GetMeshNumbers(nvert, nsegs, npols);
+   return nvert;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1335,13 +1328,9 @@ const TBuffer3D & TGeoPcon::GetBuffer3D(Int_t reqSections, Bool_t localFrame) co
    TGeoBBox::FillBuffer3D(buffer, reqSections, localFrame);
 
    if (reqSections & TBuffer3D::kRawSizes) {
-      const Int_t n = gGeoManager->GetNsegments()+1;
-      Int_t nz = GetNz();
-      Int_t nbPnts = nz*2*n;
-      if (nz >= 2 && nbPnts > 0) {
-         Bool_t specialCase = TGeoShape::IsSameWithinTolerance(GetDphi(),360);
-         Int_t nbSegs = 4*(nz*n-1+(specialCase ?  1 : 0));
-         Int_t nbPols = 2*(nz*n-1+(specialCase ?  1 : 0));
+      Int_t nbPnts, nbSegs, nbPols;
+      GetMeshNumbers(nbPnts, nbSegs, nbPols);
+      if (nbPnts > 0) {
          if (buffer.SetRawSizes(nbPnts, 3*nbPnts, nbSegs, 3*nbSegs, nbPols, 6*nbPols)) {
             buffer.SetSectionsValid(TBuffer3D::kRawSizes);
          }

--- a/geom/geom/src/TGeoPcon.cxx
+++ b/geom/geom/src/TGeoPcon.cxx
@@ -1014,16 +1014,15 @@ void TGeoPcon::SetSegsAndPols(TBuffer3D &buff) const
 
 void TGeoPcon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
 {
-   Int_t i, j;
    const Int_t n = gGeoManager->GetNsegments() + 1;
-   Int_t nz = GetNz();
-   if (nz < 2) return;
-   Int_t nbPnts = nz * n + 2;
-   if (nbPnts <= 0) return;
+   const Int_t nz = GetNz();
+   const Int_t nbPnts = nz * n + 2;
+
+   if ((nz < 2) || (nbPnts <= 0) || (n < 2)) return;
 
    Int_t c = GetBasicColor();
 
-   Int_t indx = 0, indx1 = 0, indx2 = 0;
+   Int_t indx = 0, indx1 = 0, indx2 = 0, i, j;
 
    //  outside circles, number of segments: nz*n
    for (i = 0; i < nz; i++) {

--- a/geom/geom/src/TGeoPcon.cxx
+++ b/geom/geom/src/TGeoPcon.cxx
@@ -1078,7 +1078,7 @@ void TGeoPcon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
       for (j = 1; j < n; j++) {
          buff.fSegs[indx++] = c;
          buff.fSegs[indx++] = indx2 + j - 1;
-         buff.fSegs[indx++] = indx2 + j;
+         buff.fSegs[indx++] = indx2 + j % (n-1);
       }
    }
 
@@ -1086,7 +1086,7 @@ void TGeoPcon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
    // bottom lines
    for (j = 0; j < n; j++) {
       buff.fSegs[indx++] = c;
-      buff.fSegs[indx++] = indx2 + j;
+      buff.fSegs[indx++] = indx2 + j % (n-1);
       buff.fSegs[indx++] = nbPnts - 2;
    }
 
@@ -1094,7 +1094,7 @@ void TGeoPcon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
    // top lines
    for (j = 0; j < n; j++) {
       buff.fSegs[indx++] = c;
-      buff.fSegs[indx++] = indx2 + j;
+      buff.fSegs[indx++] = indx2 + j % (n-1);
       buff.fSegs[indx++] = nbPnts - 1;
    }
 
@@ -1104,8 +1104,8 @@ void TGeoPcon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
       indx2 = i * n;
       for (j = 0; j < n; j++) {
          buff.fSegs[indx++] = c;
-         buff.fSegs[indx++] = indx2 + j;
-         buff.fSegs[indx++] = indx2 + n + j;
+         buff.fSegs[indx++] = indx2 + j % (n-1);
+         buff.fSegs[indx++] = indx2 + n + j % (n-1);
       }
    }
 

--- a/geom/geom/src/TGeoPcon.cxx
+++ b/geom/geom/src/TGeoPcon.cxx
@@ -1306,6 +1306,24 @@ void TGeoPcon::Sizeof3D() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Returns true when pgon has internal surface
+/// It will be only disabled when all Rmin values are 0
+
+Bool_t TGeoPcon::HasInsideSurface() const
+{
+   // only when full 360 is used, internal part can be excluded
+   Bool_t specialCase = TGeoShape::IsSameWithinTolerance(GetDphi(), 360);
+   if (!specialCase) return kTRUE;
+
+   for (Int_t i = 0; i < GetNz(); i++)
+      if (fRmin[i] > 0.)
+         return kTRUE;
+
+   return kFALSE;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Returns numbers of vertices, segments and polygons composing the shape mesh.
 
 void TGeoPcon::GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const

--- a/geom/geom/src/TGeoPcon.cxx
+++ b/geom/geom/src/TGeoPcon.cxx
@@ -70,9 +70,9 @@ TGeoPcon::TGeoPcon()
           fNz(0),
           fPhi1(0.),
           fDphi(0.),
-          fRmin(NULL),
-          fRmax(NULL),
-          fZ(NULL),
+          fRmin(nullptr),
+          fRmax(nullptr),
+          fZ(nullptr),
           fFullPhi(kFALSE),
           fC1(0.),
           fS1(0.),
@@ -93,9 +93,9 @@ TGeoPcon::TGeoPcon(Double_t phi, Double_t dphi, Int_t nz)
           fNz(nz),
           fPhi1(phi),
           fDphi(dphi),
-          fRmin(NULL),
-          fRmax(NULL),
-          fZ(NULL),
+          fRmin(nullptr),
+          fRmax(nullptr),
+          fZ(nullptr),
           fFullPhi(kFALSE),
           fC1(0.),
           fS1(0.),
@@ -134,9 +134,9 @@ TGeoPcon::TGeoPcon(const char *name, Double_t phi, Double_t dphi, Int_t nz)
           fNz(nz),
           fPhi1(phi),
           fDphi(dphi),
-          fRmin(NULL),
-          fRmax(NULL),
-          fZ(NULL),
+          fRmin(nullptr),
+          fRmax(nullptr),
+          fZ(nullptr),
           fFullPhi(kFALSE),
           fC1(0.),
           fS1(0.),
@@ -182,9 +182,9 @@ TGeoPcon::TGeoPcon(Double_t *param)
           fNz(0),
           fPhi1(0.),
           fDphi(0.),
-          fRmin(0),
-          fRmax(0),
-          fZ(0),
+          fRmin(nullptr),
+          fRmax(nullptr),
+          fZ(nullptr),
           fFullPhi(kFALSE),
           fC1(0.),
           fS1(0.),
@@ -200,60 +200,13 @@ TGeoPcon::TGeoPcon(Double_t *param)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///copy constructor
-
-TGeoPcon::TGeoPcon(const TGeoPcon& pc) :
-  TGeoBBox(pc),
-  fNz(0),
-  fPhi1(0.),
-  fDphi(0.),
-  fRmin(0),
-  fRmax(0),
-  fZ(0),
-  fFullPhi(kFALSE),
-  fC1(0.),
-  fS1(0.),
-  fC2(0.),
-  fS2(0.),
-  fCm(0.),
-  fSm(0.),
-  fCdphi(0.)
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///assignment operator
-
-TGeoPcon& TGeoPcon::operator=(const TGeoPcon& pc)
-{
-   if(this!=&pc) {
-      TGeoBBox::operator=(pc);
-      fNz=0;
-      fPhi1=0.;
-      fDphi=0.;
-      fRmin=0;
-      fRmax=0;
-      fZ=0;
-      fFullPhi=kFALSE;
-      fC1=0;
-      fS1=0;
-      fC2=0;
-      fS2=0;
-      fCm=0;
-      fSm=0;
-      fCdphi=0;
-   }
-   return *this;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// destructor
 
 TGeoPcon::~TGeoPcon()
 {
-   if (fRmin) {delete[] fRmin; fRmin = 0;}
-   if (fRmax) {delete[] fRmax; fRmax = 0;}
-   if (fZ)    {delete[] fZ; fZ = 0;}
+   if (fRmin) { delete[] fRmin; fRmin = nullptr; }
+   if (fRmax) { delete[] fRmax; fRmax = nullptr; }
+   if (fZ)    { delete[] fZ; fZ = nullptr; }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoPgon.cxx
+++ b/geom/geom/src/TGeoPgon.cxx
@@ -2045,23 +2045,6 @@ void TGeoPgon::SetPoints(Float_t *points) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Returns true when pgon has internal surface
-/// It will be only disabled when all Rmin values are 0
-
-Bool_t TGeoPgon::HasInsideSurface() const
-{
-   // only when full 360 is used, internal part can be excluded
-   Bool_t specialCase = TGeoShape::IsSameWithinTolerance(GetDphi(), 360);
-   if (!specialCase) return kTRUE;
-
-   for (Int_t i = 0; i < GetNz(); i++)
-      if (fRmin[i] > 0.)
-         return kTRUE;
-
-   return kFALSE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Returns numbers of vertices, segments and polygons composing the shape mesh.
 
 void TGeoPgon::GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const

--- a/geom/geom/src/TGeoPgon.cxx
+++ b/geom/geom/src/TGeoPgon.cxx
@@ -1622,16 +1622,15 @@ void TGeoPgon::SetSegsAndPols(TBuffer3D &buff) const
 
 void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
 {
-   Int_t i, j;
    const Int_t n = GetNedges() + 1;
-   Int_t nz = GetNz();
-   if (nz < 2) return;
-   Int_t nbPnts = nz * n + 2;
-   if (nbPnts <= 0) return;
+   const Int_t nz = GetNz();
+   const Int_t nbPnts = nz * n + 2;
+
+   if ((nz < 2) || (nbPnts <= 0) || (n < 2)) return;
 
    Int_t c = GetBasicColor();
 
-   Int_t indx = 0, indx1 = 0, indx2 = 0;
+   Int_t indx = 0, indx1 = 0, indx2 = 0, i, j;
 
    //  outside circles, number of segments: nz*n
    for (i = 0; i < nz; i++) {

--- a/geom/geom/src/TGeoPgon.cxx
+++ b/geom/geom/src/TGeoPgon.cxx
@@ -1639,7 +1639,7 @@ void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
       for (j = 1; j < n; j++) {
          buff.fSegs[indx++] = c;
          buff.fSegs[indx++] = indx2 + j - 1;
-         buff.fSegs[indx++] = indx2 + j;
+         buff.fSegs[indx++] = indx2 + j % (n-1);
       }
    }
 
@@ -1647,7 +1647,7 @@ void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
    // bottom lines
    for (j = 0; j < n; j++) {
       buff.fSegs[indx++] = c;
-      buff.fSegs[indx++] = indx2 + j;
+      buff.fSegs[indx++] = indx2 + j % (n-1);
       buff.fSegs[indx++] = nbPnts - 2;
    }
 
@@ -1655,7 +1655,7 @@ void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
    // top lines
    for (j = 0; j < n; j++) {
       buff.fSegs[indx++] = c;
-      buff.fSegs[indx++] = indx2 + j;
+      buff.fSegs[indx++] = indx2 + j % (n-1);
       buff.fSegs[indx++] = nbPnts - 1;
    }
 
@@ -1665,8 +1665,8 @@ void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
       indx2 = i * n;
       for (j = 0; j < n; j++) {
          buff.fSegs[indx++] = c;
-         buff.fSegs[indx++] = indx2 + j;
-         buff.fSegs[indx++] = indx2 + n + j;
+         buff.fSegs[indx++] = indx2 + j % (n-1);
+         buff.fSegs[indx++] = indx2 + n + j % (n-1);
       }
    }
 
@@ -1679,7 +1679,7 @@ void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
       buff.fPols[indx++] = c;
       buff.fPols[indx++] = 3;
       buff.fPols[indx++] = indx1 + j;
-      buff.fPols[indx++] = indx2 + j + 1;
+      buff.fPols[indx++] = indx2 + (j+1)%(n-1);
       buff.fPols[indx++] = indx2 + j;
    }
 
@@ -1691,7 +1691,7 @@ void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
       buff.fPols[indx++] = 3;
       buff.fPols[indx++] = indx1 + j; // last z layer
       buff.fPols[indx++] = indx2 + j;
-      buff.fPols[indx++] = indx2 + j + 1;
+      buff.fPols[indx++] = indx2 + (j+1)%(n-1);
    }
 
    // outside, number of polygons: (nz-1)*(n-1)
@@ -1704,7 +1704,7 @@ void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
          buff.fPols[indx++] = indx1 + j;
          buff.fPols[indx++] = indx2 + j;
          buff.fPols[indx++] = indx1 + j + (n-1);
-         buff.fPols[indx++] = indx2 + j + 1;
+         buff.fPols[indx++] = indx2 + (j+1)%(n-1);
       }
    }
 }

--- a/geom/geom/src/TGeoPgon.cxx
+++ b/geom/geom/src/TGeoPgon.cxx
@@ -1618,7 +1618,7 @@ void TGeoPgon::SetSegsAndPols(TBuffer3D &buff) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Fill TBuffer3D structure for segments and polygons.
+/// Fill TBuffer3D structure for segments and polygons, when no inner surface exists
 
 void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
 {


### PR DESCRIPTION
Same as #5050, but for pcon shape. Connected with ROOT-10583 issue.

Make further pcon/pgon improvements.
One have to build closed shape to be able use it with CSG.
Closed means that when building circle, first and last point has to be the same - it is not enough have two points with same coordinate. 
Problem only observed with CSG (when building composite shapes), in normal GL rendering it does not matters