### PR TITLE
Use cend() from the correct std::unordered_map

### DIFF
--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -838,7 +838,7 @@ public:
 
       // Otherwise, we must check the labels of the other axis too
       for (const auto &kv: other.fLabelsIndex)
-         if (fLabelsIndex.find(kv.first) == other.fLabelsIndex.cend())
+         if (fLabelsIndex.find(kv.first) == fLabelsIndex.cend())
             return LabelsCmpFlags(result | kLabelsCmpSuperset);
       return result;
    }


### PR DESCRIPTION
This patch fixes the histhistv7testUnit test, which was failing with the following errors:

77: [       OK ] AxisTest.Irregular (0 ms)
77: [ RUN      ] AxisTest.Labels
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(531): Labeled axis w/o title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(469): error:       Expected: caxis.CompareBinLabels(RAxisLabels(one_extra_label))
77:       Which is: 0
77: To be equal to: RAxisLabels::kLabelsCmpSuperset
77:       Which is: 2
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(477): error:       Expected: caxis.CompareBinLabels(RAxisLabels(changed_one_label))
77:       Which is: 1
77: To be equal to: RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset
77:       Which is: 3
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(484): error:       Expected: caxis.CompareBinLabels(RAxisLabels(swapped_labels))
77:       Which is: 4
77: To be equal to: RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered
77:       Which is: 6
77: Google Test trace:
77: C:\Users\bellenot\git\master\hist\histv7\test\axis.cxx(537): Labeled axis with title
77: [  FAILED  ] AxisTest.Labels (53 ms)
77: [ RUN      ] AxisTest.SameBinning
77: [       OK ] AxisTest.SameBinning (0 ms)