### PR TITLE
 [cling] Teach cling to give unique source locations.

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -391,10 +391,10 @@ namespace cling {
     return m_Consumer->getTransaction();
   }
 
-  SourceLocation IncrementalParser::getLastMemoryBufferEndLoc() const {
+  SourceLocation IncrementalParser::getNextAvailableUniqueSourceLoc() {
     const SourceManager& SM = getCI()->getSourceManager();
     SourceLocation Result = SM.getLocForStartOfFile(m_VirtualFileID);
-    return Result.getLocWithOffset(m_MemoryBuffers.size() + 1);
+    return Result.getLocWithOffset(m_VirtualFileLocOffset++);
   }
 
   IncrementalParser::~IncrementalParser() {
@@ -809,7 +809,7 @@ namespace cling {
 
     // Create SourceLocation, which will allow clang to order the overload
     // candidates for example
-    SourceLocation NewLoc = getLastMemoryBufferEndLoc().getLocWithOffset(1);
+    SourceLocation NewLoc = getNextAvailableUniqueSourceLoc();
 
     llvm::MemoryBuffer* MBNonOwn = MB.get();
 

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.h
@@ -70,6 +70,9 @@ namespace cling {
     // file ID of the memory buffer
     clang::FileID m_VirtualFileID;
 
+    // The next available unique sourcelocation offset.
+    unsigned m_VirtualFileLocOffset = 1; // skip the system sloc 0.
+
     // CI owns it
     DeclCollector* m_Consumer;
 
@@ -123,7 +126,12 @@ namespace cling {
     clang::Parser* getParser() const { return m_Parser.get(); }
     clang::CodeGenerator* getCodeGenerator() const { return m_CodeGen; }
     bool hasCodeGenerator() const { return m_CodeGen; }
-    clang::SourceLocation getLastMemoryBufferEndLoc() const;
+
+    /// Returns the next available unique source location. It is an offset into
+    /// the limitless virtual file. Each time this interface is used it bumps
+    /// an internal counter. This is very useful for using the various API in
+    /// clang which expect valid source locations.
+    clang::SourceLocation getNextAvailableUniqueSourceLoc();
 
     /// \{
     /// \name Transaction Support

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -888,11 +888,9 @@ namespace cling {
     IdentifierInfo* II = PP.getIdentifierInfo(M->Name);
     SourceLocation ValidLoc = getNextAvailableLoc();
     Interpreter::PushTransactionRAII RAII(this);
-    bool success = !getCI()
-                        ->getSema()
-                        .ActOnModuleImport(ValidLoc, ValidLoc,
-                                           std::make_pair(II, ValidLoc))
-                        .isInvalid();
+    bool success =
+       !getSema().ActOnModuleImport(ValidLoc, ValidLoc,
+                                    std::make_pair(II, ValidLoc)).isInvalid();
 
     if (success) {
       // Also make the module visible in the preprocessor to export its macros.

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -153,7 +153,7 @@ namespace cling {
   }
 
   clang::SourceLocation Interpreter::getNextAvailableLoc() const {
-    return m_IncrParser->getLastMemoryBufferEndLoc().getLocWithOffset(1);
+    return m_IncrParser->getNextAvailableUniqueSourceLoc();
   }
 
   bool Interpreter::isInSyntaxOnlyMode() const {
@@ -886,7 +886,7 @@ namespace cling {
     // this functionality.
     Preprocessor& PP = getCI()->getPreprocessor();
     IdentifierInfo* II = PP.getIdentifierInfo(M->Name);
-    SourceLocation ValidLoc = M->DefinitionLoc;
+    SourceLocation ValidLoc = getNextAvailableLoc();
     Interpreter::PushTransactionRAII RAII(this);
     bool success = !getCI()
                         ->getSema()


### PR DESCRIPTION
In number of cases over the last years we have seen a need to call clang APIs with valid source locations. The interpreter generates code and valid locations can be problematic.

This patch allows cling to return a valid source location even when no code was processed. This way we can provide our modules infrastructure proper source locations to activate the module visibility rules on locations which have common predecessor. The common predecessor is essential when we compare entities for diagnostics or reasoning about module visibility.

This PR should fix the nightly failures.