### PR TITLE
 Reimplement "[cxxmodules] Don't complain about redeclaration of declared annotated enum."

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Sema/Sema.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Sema/Sema.h
@@ -2331,8 +2331,7 @@ public:
   bool CheckEnumRedeclaration(SourceLocation EnumLoc, bool IsScoped,
                               QualType EnumUnderlyingTy,
                               bool EnumUnderlyingIsImplicit,
-                              const EnumDecl *Prev,
-                              const EnumDecl *New);
+                              const EnumDecl *Prev);
 
   /// Determine whether the body of an anonymous enumeration should be skipped.
   /// \param II The name of the first enumerator.

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
@@ -12942,6 +12942,13 @@ bool Sema::CheckEnumRedeclaration(
     if (hasFwdDeclAnnotation(Prev))
       return false;
 
+    // We have a definition coming from a module and the annotated forward
+    // declaration coming after. We can try to limit the filter to only the
+    // enums which come from a module *and* the new enum candidate has an
+    // explicit type (eg enum L1GtObject : unsigned int;).
+    if (Prev->isFromASTFile() && !EnumUnderlyingIsImplicit)
+       return false;
+
     Diag(EnumLoc, diag::err_enum_redeclare_fixed_mismatch)
       << Prev->isFixed();
     Diag(Prev->getLocation(), diag::note_previous_declaration);

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp
@@ -12892,7 +12892,7 @@ bool Sema::CheckEnumUnderlyingType(TypeSourceInfo *TI) {
 /// \return true if the redeclaration was invalid.
 bool Sema::CheckEnumRedeclaration(
     SourceLocation EnumLoc, bool IsScoped, QualType EnumUnderlyingTy,
-    bool EnumUnderlyingIsImplicit, const EnumDecl *Prev, const EnumDecl *New) {
+    bool EnumUnderlyingIsImplicit, const EnumDecl *Prev) {
   bool IsFixed = !EnumUnderlyingTy.isNull();
 
   if (IsScoped != Prev->isScoped()) {
@@ -12940,11 +12940,6 @@ bool Sema::CheckEnumRedeclaration(
     };
 
     if (hasFwdDeclAnnotation(Prev))
-      return false;
-
-    // We have a definition coming from a module and a forward declaration
-    // coming after.
-    if (Prev->isFromASTFile() && New && hasFwdDeclAnnotation(New))
       return false;
 
     Diag(EnumLoc, diag::err_enum_redeclare_fixed_mismatch)
@@ -13674,8 +13669,7 @@ Decl *Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK,
           // in which case we want the caller to bail out.
           if (CheckEnumRedeclaration(NameLoc.isValid() ? NameLoc : KWLoc,
                                      ScopedEnum, EnumUnderlyingTy,
-                                     EnumUnderlyingIsImplicit, PrevEnum,
-                                     cast_or_null<EnumDecl>(SkipBody->New)))
+                                     EnumUnderlyingIsImplicit, PrevEnum))
             return TUK == TUK_Declaration ? PrevTagDecl : nullptr;
         }
 

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1049,8 +1049,7 @@ Decl *TemplateDeclInstantiator::VisitEnumDecl(EnumDecl *D) {
                           UnderlyingLoc, DeclarationName());
       SemaRef.CheckEnumRedeclaration(Def->getLocation(), Def->isScoped(),
                                      DefnUnderlying,
-                                     /*EnumUnderlyingIsImplicit=*/false, Enum,
-                                     Def);
+                                     /*EnumUnderlyingIsImplicit=*/false, Enum);
     }
   }
 


### PR DESCRIPTION
Original commit message:
"[cxxmodules] Don't complain about redeclaration of declared annotated enum.

Extend c14934e to support the case where the enum is deserialized from a module and the currently parsed enum comes from an annotated forward declaration.

This patch should allow enabling the cmssw DataFormats/PatCandidates module which currently complains with:

scripts/edmCheckClassVersion -l libCondFormatsL1TObjects.so -x CondFormats/L1TObjects/src/classes_def.xml
DataFormatsL1GlobalTrigger_xr dictionary forward declarations' payload:9:216: error: enumeration previously declared with nonfixed underlying type
...__attribute__((annotate("$clingAutoload$DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"))) L1GtObject : unsigned int;
                                                                                                                      ^
DataFormats/L1GlobalTrigger/interface/L1GtObject.h:28:6: note: previous declaration is here
enum L1GtObject {
     ^

cc: @oshadura, @davidlange6, @smuzaffar, @mrodozov