### PR TITLE
Fix ROOT-10586

### DIFF
--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RAxis
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <string>
 #include <unordered_map>

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -402,7 +402,7 @@ protected:
    /// \param lighOrLow - second axis boundary
    static double GetInvBinWidth(int nbinsNoOver, double lowOrHigh, double highOrLow)
    {
-      return nbinsNoOver / std::abs(highOrLow - lowOrHigh);
+      return nbinsNoOver / std::fabs(highOrLow - lowOrHigh);
    }
 
    /// See RAxisBase::HasSameBinBordersAs


### PR DESCRIPTION
[ROOT-10586](https://sft.its.cern.ch/jira/browse/ROOT-10586) is caused by a missing `<cmath>` include, which resulted in old GCC 6 not "seeing" the floating-point overloads of `std::abs` and getting confused at which integer overload of `std::abs` it should pick when a `double` is passed in.

This was not caught during testing because we test on recent compilers with a C++17-compatible STL implementation, where if you see some overloads of `std::abs`, you see all of them.

By switching to `std::fabs` in addition to fixing the include, I guarantee that if this happens again during an overeager include cleanup, the compiler error message will be clearer. Old compilers will now complain about a missing declaration of `std::fabs`, rather than a failed overload resolution of integer `std::abs`.

Fixes ROOT-10586.