### PR TITLE
Use web-based geometry viewer when --web specified for root

### DIFF
--- a/etc/plugins/TVirtualGeoPainter/P010_TGeoPainter.C
+++ b/etc/plugins/TVirtualGeoPainter/P010_TGeoPainter.C
@@ -1,5 +1,5 @@
 void P010_TGeoPainter()
 {
-   gPluginMgr->AddHandler("TVirtualGeoPainter", "*", "TGeoPainter",
+   gPluginMgr->AddHandler("TVirtualGeoPainter", "root", "TGeoPainter",
       "GeomPainter", "TGeoPainter(TGeoManager*)");
 }

--- a/etc/plugins/TVirtualGeoPainter/P020_REveGeoPainter.C
+++ b/etc/plugins/TVirtualGeoPainter/P020_REveGeoPainter.C
@@ -1,0 +1,5 @@
+void P020_REveGeoPainter()
+{
+   gPluginMgr->AddHandler("TVirtualGeoPainter", "web", "ROOT::Experimental::REveGeoPainter",
+      "ROOTEve", "REveGeoPainter(TGeoManager*)");
+}

--- a/geom/geom/inc/TVirtualGeoPainter.h
+++ b/geom/geom/inc/TVirtualGeoPainter.h
@@ -8,6 +8,7 @@
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
+
 #ifndef ROOT_TVirtualGeoPainter
 #define ROOT_TVirtualGeoPainter
 
@@ -63,14 +64,13 @@ public:
    virtual void       CheckShape(TGeoShape *shape, Int_t testNo, Int_t nsamples, Option_t *option) = 0;
    virtual void       CheckBoundaryErrors(Int_t ntracks=1000000, Double_t radius=-1.) = 0;
    virtual void       CheckBoundaryReference(Int_t icheck=-1) = 0;
-   virtual void       CheckGeometryFull(Bool_t checkoverlaps=kTRUE, Bool_t checkcrossings=kTRUE, Int_t nrays=10000, const Double_t *vertex=NULL) = 0;
+   virtual void       CheckGeometryFull(Bool_t checkoverlaps=kTRUE, Bool_t checkcrossings=kTRUE, Int_t nrays=10000, const Double_t *vertex=nullptr) = 0;
    virtual void       CheckGeometry(Int_t nrays, Double_t startx, Double_t starty, Double_t startz) const = 0;
    virtual void       CheckOverlaps(const TGeoVolume *vol, Double_t ovlp=0.1, Option_t *option="") const = 0;
    virtual Int_t      CountVisibleNodes() = 0;
    virtual void       DefaultAngles() = 0;
    virtual void       DefaultColors() = 0;
    virtual Int_t      DistanceToPrimitiveVol(TGeoVolume *vol, Int_t px, Int_t py) = 0;
-   virtual void       Draw(Option_t *option="") = 0;
    virtual void       DrawBatemanSol(TGeoBatemanSol *sol, Option_t *option="") = 0;
    virtual void       DrawShape(TGeoShape *shape, Option_t *option="") = 0;
    virtual void       DrawOnly(Option_t *option="") = 0;
@@ -105,13 +105,13 @@ public:
                             Int_t nphi=90, Double_t phimin=0., Double_t phimax=360.,
                             Double_t rmin=0., Double_t rmax=9999999, Option_t *option="") = 0;
    virtual void       ModifiedPad(Bool_t update=kFALSE) const = 0;
-   virtual void       OpProgress(const char *opname, Long64_t current, Long64_t size, TStopwatch *watch=0, Bool_t last=kFALSE, Bool_t refresh=kFALSE, const char *msg="") = 0;
+   virtual void       OpProgress(const char *opname, Long64_t current, Long64_t size, TStopwatch *watch=nullptr, Bool_t last=kFALSE, Bool_t refresh=kFALSE, const char *msg="") = 0;
    virtual void       Paint(Option_t *option="") = 0;
-   virtual void       PaintNode(TGeoNode *node, Option_t *option="", TGeoMatrix* global=0) = 0;
+   virtual void       PaintNode(TGeoNode *node, Option_t *option="", TGeoMatrix* global=nullptr) = 0;
    virtual void       PaintShape(TGeoShape *shape, Option_t *option="") = 0;
    virtual void       PaintOverlap(void *ovlp, Option_t *option="")  = 0;
    virtual void       PrintOverlaps() const = 0;
-   virtual void       PaintVolume(TGeoVolume *vol, Option_t *option="", TGeoMatrix* global=0) = 0;
+   virtual void       PaintVolume(TGeoVolume *vol, Option_t *option="", TGeoMatrix* global=nullptr) = 0;
    virtual void       RandomPoints(const TGeoVolume *vol, Int_t npoints, Option_t *option="") = 0;
    virtual void       RandomRays(Int_t nrays, Double_t startx, Double_t starty, Double_t startz, const char *target_vol, Bool_t check_norm) = 0;
    virtual void       Raytrace(Option_t *option="") = 0;

--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -2687,15 +2687,19 @@ Int_t TGeoManager::GetByteCount(Option_t * /*option*/)
 TVirtualGeoPainter *TGeoManager::GetGeomPainter()
 {
    if (!fPainter) {
-      TPluginHandler *h;
-      if ((h = gROOT->GetPluginManager()->FindHandler("TVirtualGeoPainter"))) {
-         if (h->LoadPlugin() == -1)
-            return 0;
+      const char *kind = gROOT->IsWebDisplay() ? "web" : "root";
+      if (auto h = gROOT->GetPluginManager()->FindHandler("TVirtualGeoPainter", kind)) {
+         if (h->LoadPlugin() == -1) {
+            Error("GetGeomPainter", "could not load plugin for %s geo_painter", kind);
+            return nullptr;
+         }
          fPainter = (TVirtualGeoPainter*)h->ExecPlugin(1,this);
          if (!fPainter) {
-            Error("GetGeomPainter", "could not create painter");
-            return 0;
+            Error("GetGeomPainter", "could not create %s geo_painter", kind);
+            return nullptr;
          }
+      } else {
+         Error("GetGeomPainter", "not found plugin %s for geo_painter", kind);
       }
    }
    return fPainter;

--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -2687,7 +2687,8 @@ Int_t TGeoManager::GetByteCount(Option_t * /*option*/)
 TVirtualGeoPainter *TGeoManager::GetGeomPainter()
 {
    if (!fPainter) {
-      const char *kind = gROOT->IsWebDisplay() ? "web" : "root";
+      const char *kind = "root";
+      if (gROOT->IsWebDisplay() && !gROOT->IsWebDisplayBatch()) kind = "web";
       if (auto h = gROOT->GetPluginManager()->FindHandler("TVirtualGeoPainter", kind)) {
          if (h->LoadPlugin() == -1) {
             Error("GetGeomPainter", "could not load plugin for %s geo_painter", kind);

--- a/geom/geompainter/inc/TGeoPainter.h
+++ b/geom/geompainter/inc/TGeoPainter.h
@@ -66,110 +66,110 @@ private:
    TGeoShape         *fClippingShape;    // clipping shape
    TGeoVolume        *fTopVolume;        // top drawn volume
    TGeoVolume        *fLastVolume;       // last drawn volume
-   TGeoIteratorPlugin
-                     *fPlugin;           // User iterator plugin for changing pain volume properties
+   TGeoIteratorPlugin *fPlugin;          // User iterator plugin for changing pain volume properties
    TObjArray         *fVisVolumes;       // list of visible volumes
    Bool_t             fIsEditable;       // flag that geometry is editable
 
-   void               DefineColors() const;
-   void               LocalToMasterVect(const Double_t *local, Double_t *master) const;
+   void       DefineColors() const;
+   void       LocalToMasterVect(const Double_t *local, Double_t *master) const;
 
 protected:
-   virtual void       ClearVisibleVolumes();
+   void       ClearVisibleVolumes();
 
 public:
    TGeoPainter(TGeoManager *manager);
    virtual ~TGeoPainter();
-   virtual void       AddSize3D(Int_t numpoints, Int_t numsegs, Int_t numpolys);
-   virtual TVirtualGeoTrack *AddTrack(Int_t id, Int_t pdgcode, TObject *part);
-   virtual void       AddTrackPoint(Double_t *point, Double_t *box, Bool_t reset=kFALSE);
-   virtual void       BombTranslation(const Double_t *tr, Double_t *bombtr);
-   virtual void       CheckBoundaryErrors(Int_t ntracks=1000000, Double_t radius=-1.);
-   virtual void       CheckBoundaryReference(Int_t icheck=-1);
-   virtual void       CheckGeometryFull(Bool_t checkoverlaps=kTRUE, Bool_t checkcrossings=kTRUE, Int_t nrays=10000, const Double_t *vertex=NULL);
-   virtual void       CheckGeometry(Int_t nrays, Double_t startx, Double_t starty, Double_t startz) const;
-   void               CheckEdit();
-   virtual void       CheckPoint(Double_t x=0, Double_t y=0, Double_t z=0, Option_t *option="");
-   virtual void       CheckShape(TGeoShape *shape, Int_t testNo, Int_t nsamples, Option_t *option);
-   virtual void       CheckOverlaps(const TGeoVolume *vol, Double_t ovlp=0.1, Option_t *option="") const;
-   Int_t              CountNodes(TGeoVolume *vol, Int_t level) const;
-   virtual Int_t      CountVisibleNodes();
-   virtual void       DefaultAngles();
-   virtual void       DefaultColors();
-   virtual Int_t      DistanceToPrimitiveVol(TGeoVolume *vol, Int_t px, Int_t py);
-   virtual void       Draw(Option_t *option="");
-   virtual void       DrawBatemanSol(TGeoBatemanSol *sol, Option_t *option="");
-   virtual void       DrawOverlap(void *ovlp, Option_t *option="");
-   virtual void       DrawCurrentPoint(Int_t color);
-   virtual void       DrawOnly(Option_t *option="");
-   virtual void       DrawPanel();
-   virtual void       DrawPath(const char *path, Option_t *option="");
-   virtual void       DrawPolygon(const TGeoPolygon *poly);
-   virtual void       DrawShape(TGeoShape *shape, Option_t *option="");
-   virtual void       DrawVolume(TGeoVolume *vol, Option_t *option="");
-   virtual void       EditGeometry(Option_t *option="");
-   virtual void       EstimateCameraMove(Double_t tmin, Double_t tmax, Double_t *start, Double_t *end);
-   virtual void       ExecuteManagerEvent(TGeoManager *geom, Int_t event, Int_t px, Int_t py);
-   virtual void       ExecuteShapeEvent(TGeoShape *shape, Int_t event, Int_t px, Int_t py);
-   virtual void       ExecuteVolumeEvent(TGeoVolume *volume, Int_t event, Int_t px, Int_t py);
-   virtual const char*GetVolumeInfo(const TGeoVolume *volume, Int_t px, Int_t py) const;
-   virtual void       GetBombFactors(Double_t &bombx, Double_t &bomby, Double_t &bombz, Double_t &bombr) const
-                                    {bombx=fBombX; bomby=fBombY; bombz=fBombZ; bombr=fBombR;}
-   virtual Int_t      GetBombMode() const      {return fExplodedView;}
-   virtual TGeoNode  *GetCheckedNode() {return fCheckedNode;}
-   TGeoChecker       *GetChecker();
-   virtual Int_t      GetColor(Int_t base, Float_t light) const;
-   virtual const char *GetDrawPath() const     {return fVisBranch.Data();}
-   virtual TGeoVolume *GetDrawnVolume() const;
-   virtual TGeoVolume *GetTopVolume() const {return fTopVolume;}
-   virtual Int_t      GetVisLevel() const      {return fVisLevel;}
-   virtual Int_t      GetVisOption() const     {return fVisOption;}
-   Int_t              GetNsegments() const     {return fNsegments;}
-   virtual void       GrabFocus(Int_t nfr=0, Double_t dlong=0, Double_t dlat=0, Double_t dpsi=0);
-   virtual Double_t  *GetViewBox() {return &fCheckedBox[0];}
-   virtual void       GetViewAngles(Double_t &longitude, Double_t &latitude, Double_t &psi);
-   virtual Bool_t     IsExplodedView() const {return ((fExplodedView==kGeoVisDefault)?kFALSE:kTRUE);}
-   virtual Bool_t     IsRaytracing() const {return fIsRaytracing;}
-   virtual Bool_t     IsPaintingShape() const  {return fIsPaintingShape;}
-   TH2F              *LegoPlot(Int_t ntheta=60, Double_t themin=0., Double_t themax=180.,
-                            Int_t nphi=90, Double_t phimin=0., Double_t phimax=360.,
-                            Double_t rmin=0., Double_t rmax=9999999, Option_t *option="");
-   void               Lock(Bool_t flag = kTRUE) {fVisLock = flag;}
-   virtual void       ModifiedPad(Bool_t update=kFALSE) const;
-   virtual void       OpProgress(const char *opname, Long64_t current, Long64_t size, TStopwatch *watch=0, Bool_t last=kFALSE, Bool_t refresh=kFALSE, const char *msg="");
-   virtual void       Paint(Option_t *option="");
-   virtual void       PaintNode(TGeoNode *node, Option_t *option="", TGeoMatrix* global=0);
-   Bool_t             PaintShape(const TGeoShape & shape, Option_t * option) const;
-   virtual void       PaintShape(TGeoShape *shape, Option_t *option="");
-   virtual void       PaintOverlap(void *ovlp, Option_t *option="");
-   virtual void       PaintVolume(TGeoVolume *vol, Option_t *option="", TGeoMatrix* global=0);
-   virtual void       PrintOverlaps() const;
-   void               PaintPhysicalNode(TGeoPhysicalNode *node, Option_t *option="");
-   virtual void       RandomPoints(const TGeoVolume *vol, Int_t npoints, Option_t *option="");
-   virtual void       RandomRays(Int_t nrays, Double_t startx, Double_t starty, Double_t startz, const char *target_vol=0, Bool_t check_norm=kFALSE);
-   virtual void       Raytrace(Option_t *option="");
-   virtual TGeoNode  *SamplePoints(Int_t npoints, Double_t &dist, Double_t epsil, const char* g3path);
-   virtual void       SetBombFactors(Double_t bombx=1.3, Double_t bomby=1.3, Double_t bombz=1.3, Double_t bombr=1.3);
-   virtual void       SetClippingShape(TGeoShape *shape) {fClippingShape = shape;}
-   virtual void       SetExplodedView(Int_t iopt=0);
-   virtual void       SetNsegments(Int_t nseg=20);
-   virtual void       SetNmeshPoints(Int_t npoints);
-   virtual void       SetGeoManager(TGeoManager *geom) {fGeoManager=geom;}
-   virtual void       SetIteratorPlugin(TGeoIteratorPlugin *plugin) {fPlugin = plugin; ModifiedPad();}
-   virtual void       SetCheckedNode(TGeoNode *node);
-   virtual void       SetRaytracing(Bool_t flag=kTRUE) {fIsRaytracing = flag;}
-   virtual void       SetTopVisible(Bool_t vis=kTRUE);
-   virtual void       SetTopVolume(TGeoVolume *vol) {fTopVolume = vol;}
-   virtual void       SetVisLevel(Int_t level=3);
-   virtual void       SetVisOption(Int_t option=0);
-   virtual Int_t      ShapeDistancetoPrimitive(const TGeoShape *shape, Int_t numpoints, Int_t px, Int_t py) const;
-   virtual void       Test(Int_t npoints, Option_t *option);
-   virtual void       TestOverlaps(const char *path);
-   virtual Bool_t     TestVoxels(TGeoVolume *vol);
-   virtual void       UnbombTranslation(const Double_t *tr, Double_t *bombtr);
-   virtual Double_t   Weight(Double_t precision, Option_t *option="v");
 
-   ClassDef(TGeoPainter,0)  //geometry painter
+   void       AddSize3D(Int_t numpoints, Int_t numsegs, Int_t numpolys) override;
+   TVirtualGeoTrack *AddTrack(Int_t id, Int_t pdgcode, TObject *part) override;
+   void       AddTrackPoint(Double_t *point, Double_t *box, Bool_t reset=kFALSE) override;
+   void       BombTranslation(const Double_t *tr, Double_t *bombtr) override;
+   void       CheckBoundaryErrors(Int_t ntracks=1000000, Double_t radius=-1.) override;
+   void       CheckBoundaryReference(Int_t icheck=-1) override;
+   void       CheckGeometryFull(Bool_t checkoverlaps=kTRUE, Bool_t checkcrossings=kTRUE, Int_t nrays=10000, const Double_t *vertex=nullptr) override;
+   void       CheckGeometry(Int_t nrays, Double_t startx, Double_t starty, Double_t startz) const override;
+   void       CheckEdit();
+   void       CheckPoint(Double_t x=0, Double_t y=0, Double_t z=0, Option_t *option="") override;
+   void       CheckShape(TGeoShape *shape, Int_t testNo, Int_t nsamples, Option_t *option) override;
+   void       CheckOverlaps(const TGeoVolume *vol, Double_t ovlp=0.1, Option_t *option="") const override;
+   Int_t      CountNodes(TGeoVolume *vol, Int_t level) const;
+   Int_t      CountVisibleNodes() override;
+   void       DefaultAngles() override;
+   void       DefaultColors() override;
+   Int_t      DistanceToPrimitiveVol(TGeoVolume *vol, Int_t px, Int_t py) override;
+   void       Draw(Option_t *option="") override;
+   void       DrawBatemanSol(TGeoBatemanSol *sol, Option_t *option="") override;
+   void       DrawOverlap(void *ovlp, Option_t *option="") override;
+   void       DrawCurrentPoint(Int_t color) override;
+   void       DrawOnly(Option_t *option="") override;
+   void       DrawPanel() override;
+   void       DrawPath(const char *path, Option_t *option="") override;
+   void       DrawPolygon(const TGeoPolygon *poly) override;
+   void       DrawShape(TGeoShape *shape, Option_t *option="") override;
+   void       DrawVolume(TGeoVolume *vol, Option_t *option="") override;
+   void       EditGeometry(Option_t *option="") override;
+   void       EstimateCameraMove(Double_t tmin, Double_t tmax, Double_t *start, Double_t *end) override;
+   void       ExecuteManagerEvent(TGeoManager *geom, Int_t event, Int_t px, Int_t py) override;
+   void       ExecuteShapeEvent(TGeoShape *shape, Int_t event, Int_t px, Int_t py) override;
+   void       ExecuteVolumeEvent(TGeoVolume *volume, Int_t event, Int_t px, Int_t py) override;
+   const char *GetVolumeInfo(const TGeoVolume *volume, Int_t px, Int_t py) const override;
+   void       GetBombFactors(Double_t &bombx, Double_t &bomby, Double_t &bombz, Double_t &bombr) const override
+                                    {bombx=fBombX; bomby=fBombY; bombz=fBombZ; bombr=fBombR;}
+   Int_t      GetBombMode() const  override {return fExplodedView;}
+   TGeoNode  *GetCheckedNode() {return fCheckedNode;}
+   TGeoChecker       *GetChecker();
+   Int_t      GetColor(Int_t base, Float_t light) const override;
+   const char *GetDrawPath() const  override {return fVisBranch.Data();}
+   TGeoVolume *GetDrawnVolume() const override;
+   TGeoVolume *GetTopVolume() const override {return fTopVolume;}
+   Int_t      GetVisLevel() const  override     {return fVisLevel;}
+   Int_t      GetVisOption() const  override    {return fVisOption;}
+   Int_t      GetNsegments() const   override   {return fNsegments;}
+   void       GrabFocus(Int_t nfr=0, Double_t dlong=0, Double_t dlat=0, Double_t dpsi=0) override;
+   Double_t  *GetViewBox() override {return &fCheckedBox[0];}
+   void       GetViewAngles(Double_t &longitude, Double_t &latitude, Double_t &psi) override;
+   Bool_t     IsExplodedView() const  override {return (fExplodedView==kGeoVisDefault)?kFALSE:kTRUE;}
+   Bool_t     IsRaytracing() const override {return fIsRaytracing;}
+   Bool_t     IsPaintingShape() const  override {return fIsPaintingShape;}
+   TH2F      *LegoPlot(Int_t ntheta=60, Double_t themin=0., Double_t themax=180.,
+                       Int_t nphi=90, Double_t phimin=0., Double_t phimax=360.,
+                       Double_t rmin=0., Double_t rmax=9999999, Option_t *option="") override;
+   void       Lock(Bool_t flag = kTRUE) { fVisLock = flag; }
+   void       ModifiedPad(Bool_t update=kFALSE) const override;
+   void       OpProgress(const char *opname, Long64_t current, Long64_t size, TStopwatch *watch=nullptr, Bool_t last=kFALSE, Bool_t refresh=kFALSE, const char *msg="") override;
+   void       Paint(Option_t *option="") override;
+   void       PaintNode(TGeoNode *node, Option_t *option="", TGeoMatrix *global=nullptr) override;
+   Bool_t     PaintShape(const TGeoShape & shape, Option_t * option) const;
+   void       PaintShape(TGeoShape *shape, Option_t *option="") override;
+   void       PaintOverlap(void *ovlp, Option_t *option="") override;
+   void       PaintVolume(TGeoVolume *vol, Option_t *option="", TGeoMatrix *global=nullptr) override;
+   void       PrintOverlaps() const override;
+   void       PaintPhysicalNode(TGeoPhysicalNode *node, Option_t *option="");
+   void       RandomPoints(const TGeoVolume *vol, Int_t npoints, Option_t *option="") override;
+   void       RandomRays(Int_t nrays, Double_t startx, Double_t starty, Double_t startz, const char *target_vol = nullptr, Bool_t check_norm = kFALSE) override;
+   void       Raytrace(Option_t *option="") override;
+   TGeoNode  *SamplePoints(Int_t npoints, Double_t &dist, Double_t epsil, const char* g3path) override;
+   void       SetBombFactors(Double_t bombx=1.3, Double_t bomby=1.3, Double_t bombz=1.3, Double_t bombr=1.3) override;
+   void       SetClippingShape(TGeoShape *shape) override {fClippingShape = shape;}
+   void       SetExplodedView(Int_t iopt=0) override;
+   void       SetNsegments(Int_t nseg=20) override;
+   void       SetNmeshPoints(Int_t npoints) override;
+   void       SetGeoManager(TGeoManager *geom) override {fGeoManager=geom;}
+   void       SetIteratorPlugin(TGeoIteratorPlugin *plugin) override {fPlugin = plugin; ModifiedPad();}
+   void       SetCheckedNode(TGeoNode *node) override;
+   void       SetRaytracing(Bool_t flag=kTRUE) override {fIsRaytracing = flag;}
+   void       SetTopVisible(Bool_t vis=kTRUE) override;
+   void       SetTopVolume(TGeoVolume *vol) override {fTopVolume = vol;}
+   void       SetVisLevel(Int_t level=3) override;
+   void       SetVisOption(Int_t option=0) override;
+   Int_t      ShapeDistancetoPrimitive(const TGeoShape *shape, Int_t numpoints, Int_t px, Int_t py) const override;
+   void       Test(Int_t npoints, Option_t *option) override;
+   void       TestOverlaps(const char *path) override;
+   Bool_t     TestVoxels(TGeoVolume *vol) override;
+   void       UnbombTranslation(const Double_t *tr, Double_t *bombtr) override;
+   Double_t   Weight(Double_t precision, Option_t *option="v") override;
+
+   ClassDefOverride(TGeoPainter,0)  //geometry painter
 };
 
 #endif

--- a/geom/geompainter/src/TGeoPainter.cxx
+++ b/geom/geompainter/src/TGeoPainter.cxx
@@ -83,14 +83,14 @@ TGeoPainter::TGeoPainter(TGeoManager *manager) : TVirtualGeoPainter(manager)
    fIsRaytracing = kFALSE;
    fTopVisible = kFALSE;
    fPaintingOverlaps = kFALSE;
-   fPlugin = 0;
+   fPlugin = nullptr;
    fVisVolumes = new TObjArray();
-   fOverlap = 0;
+   fOverlap = nullptr;
    fGlobal = new TGeoHMatrix();
    fBuffer = new TBuffer3D(TBuffer3DTypes::kGeneric,20,3*20,0,0,0,0);
-   fClippingShape = 0;
-   fLastVolume = 0;
-   fTopVolume = 0;
+   fClippingShape = nullptr;
+   fLastVolume = nullptr;
+   fTopVolume = nullptr;
    fIsPaintingShape = kFALSE;
    memset(&fCheckedBox[0], 0, 6*sizeof(Double_t));
 
@@ -328,7 +328,7 @@ Int_t TGeoPainter::GetColor(Int_t base, Float_t light) const
 
 TGeoVolume *TGeoPainter::GetDrawnVolume() const
 {
-   if (!gPad) return 0;
+   if (!gPad) return nullptr;
    return fTopVolume;
 }
 
@@ -779,7 +779,7 @@ void TGeoPainter::DrawPolygon(const TGeoPolygon *poly)
 void TGeoPainter::DrawVolume(TGeoVolume *vol, Option_t *option)
 {
    fTopVolume = vol;
-   fLastVolume = 0;
+   fLastVolume = nullptr;
    fIsPaintingShape = kFALSE;
 //   if (fVisOption==kGeoVisOnly ||
 //       fVisOption==kGeoVisBranch) fGeoManager->SetVisOption(kGeoVisLeaves);
@@ -787,7 +787,7 @@ void TGeoPainter::DrawVolume(TGeoVolume *vol, Option_t *option)
    TString opt = option;
    opt.ToLower();
    fPaintingOverlaps = kFALSE;
-   fOverlap = 0;
+   fOverlap = nullptr;
 
    if (fVisLock) {
       ClearVisibleVolumes();
@@ -832,7 +832,7 @@ void TGeoPainter::DrawShape(TGeoShape *shape, Option_t *option)
    TString opt = option;
    opt.ToLower();
    fPaintingOverlaps = kFALSE;
-   fOverlap = 0;
+   fOverlap = nullptr;
    fIsPaintingShape = kTRUE;
 
    Bool_t has_pad = (gPad==0)?kFALSE:kTRUE;
@@ -1448,11 +1448,11 @@ void TGeoPainter::PaintVolume(TGeoVolume *top, Option_t *option, TGeoMatrix* glo
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint the supplied shape into the current 3D viewer
 
-Bool_t TGeoPainter::PaintShape(const TGeoShape & shape, Option_t *  option ) const
+Bool_t TGeoPainter::PaintShape(const TGeoShape &shape, Option_t *option) const
 {
    Bool_t addDaughters = kTRUE;
 
-   TVirtualViewer3D * viewer = gPad->GetViewer3D();
+   TVirtualViewer3D *viewer = gPad->GetViewer3D();
 
    if (!viewer || shape.IsA()==TGeoShapeAssembly::Class()) {
       return addDaughters;

--- a/graf3d/eve7/CMakeLists.txt
+++ b/graf3d/eve7/CMakeLists.txt
@@ -23,6 +23,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTEve
     ROOT/REveGeoShape.hxx
     ROOT/REveGeomData.hxx
     ROOT/REveGeomViewer.hxx
+    ROOT/REveGeoPainter.hxx
     ROOT/REveGluTess.hxx
     ROOT/REveJetCone.hxx
     ROOT/REveEllipsoid.hxx
@@ -83,6 +84,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTEve
     src/REveGeoShapeExtract.cxx
     src/REveGeomData.cxx
     src/REveGeomViewer.cxx
+    src/REveGeoPainter.cxx
     src/REveGluTess.cxx
     src/REveJetCone.cxx
     src/REveEllipsoid.cxx

--- a/graf3d/eve7/inc/LinkDef.h
+++ b/graf3d/eve7/inc/LinkDef.h
@@ -244,5 +244,7 @@
 #pragma link C++ class ROOT::Experimental::REveGeomRequest+;
 #pragma link C++ class ROOT::Experimental::REveGeomNodeInfo+;
 #pragma link C++ class ROOT::Experimental::REveGeomConfig+;
+#pragma link C++ class ROOT::Experimental::REveGeomViewer+;
+#pragma link C++ class ROOT::Experimental::REveGeoPainter+;
 
 #endif

--- a/graf3d/eve7/inc/ROOT/REveGeoPainter.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoPainter.hxx
@@ -23,87 +23,86 @@ public:
    REveGeoPainter(TGeoManager *manager);
    virtual ~REveGeoPainter();
 
-   void       AddSize3D(Int_t numpoints, Int_t numsegs, Int_t numpolys) override {}
-   TVirtualGeoTrack *AddTrack(Int_t id, Int_t pdgcode, TObject *particle) override { return nullptr; }
-   void       AddTrackPoint(Double_t *point, Double_t *box, Bool_t reset=kFALSE) override {}
-   virtual void       BombTranslation(const Double_t *tr, Double_t *bombtr) override {}
-   virtual void       CheckPoint(Double_t x=0, Double_t y=0, Double_t z=0, Option_t *option="") override {}
-   virtual void       CheckShape(TGeoShape *shape, Int_t testNo, Int_t nsamples, Option_t *option) override {}
-   virtual void       CheckBoundaryErrors(Int_t ntracks=1000000, Double_t radius=-1.) override {}
-   virtual void       CheckBoundaryReference(Int_t icheck=-1) override {}
-   virtual void       CheckGeometryFull(Bool_t checkoverlaps=kTRUE, Bool_t checkcrossings=kTRUE, Int_t nrays=10000, const Double_t *vertex=NULL) override {}
-   virtual void       CheckGeometry(Int_t nrays, Double_t startx, Double_t starty, Double_t startz) const override {}
-   virtual void       CheckOverlaps(const TGeoVolume *vol, Double_t ovlp=0.1, Option_t *option="") const override {}
-   virtual Int_t      CountVisibleNodes() override { return 0; }
-   virtual void       DefaultAngles() override {}
-   virtual void       DefaultColors() override {}
-   virtual Int_t      DistanceToPrimitiveVol(TGeoVolume *vol, Int_t px, Int_t py) override { return 0; }
-   virtual void       Draw(Option_t *option="") override {}
-   virtual void       DrawBatemanSol(TGeoBatemanSol *sol, Option_t *option="") override {}
-   virtual void       DrawShape(TGeoShape *shape, Option_t *option="") override {}
-   virtual void       DrawOnly(Option_t *option="") override {}
-   virtual void       DrawOverlap(void *ovlp, Option_t *option="") override {}
-   virtual void       DrawCurrentPoint(Int_t color) override {}
-   virtual void       DrawPanel() override {}
-   virtual void       DrawPath(const char *path, Option_t *option="") override {}
-   virtual void       DrawPolygon(const TGeoPolygon *poly) override {}
-   virtual void       DrawVolume(TGeoVolume *vol, Option_t *option="") override {}
-   virtual void       EditGeometry(Option_t *option="") override {}
-   virtual void       EstimateCameraMove(Double_t /*tmin*/, Double_t /*tmax*/, Double_t *, Double_t * ) override {}
-   virtual void       ExecuteShapeEvent(TGeoShape *shape, Int_t event, Int_t px, Int_t py) override {}
-   virtual void       ExecuteManagerEvent(TGeoManager *geom, Int_t event, Int_t px, Int_t py) override {}
-   virtual void       ExecuteVolumeEvent(TGeoVolume *volume, Int_t event, Int_t px, Int_t py) override {}
-   virtual Int_t      GetColor(Int_t base, Float_t light) const override { return 0; }
-   virtual Int_t      GetNsegments() const override { return 1; }
-   virtual void       GetBombFactors(Double_t &bombx, Double_t &bomby, Double_t &bombz, Double_t &bombr) const override {}
-   virtual Int_t      GetBombMode() const override { return 0; }
-   virtual const char *GetDrawPath() const override { return ""; }
-   virtual TGeoVolume *GetDrawnVolume() const override { return nullptr; }
-   virtual TGeoVolume *GetTopVolume() const override { return nullptr; }
-   virtual void       GetViewAngles(Double_t &/*longitude*/, Double_t &/*latitude*/, Double_t &/*psi*/) override {}
-   virtual Int_t      GetVisLevel() const override { return 0; }
-   virtual Int_t      GetVisOption() const override { return 0; }
-   virtual const char*GetVolumeInfo(const TGeoVolume *volume, Int_t px, Int_t py) const override { return "info"; }
-   virtual void       GrabFocus(Int_t nfr=0, Double_t dlong=0, Double_t dlat=0, Double_t dpsi=0) override {}
-   virtual Double_t  *GetViewBox() override { return nullptr; }
-   virtual Bool_t     IsPaintingShape() const override { return kFALSE; }
-   virtual Bool_t     IsRaytracing() const override { return kFALSE; }
-   virtual Bool_t     IsExplodedView() const override { return kFALSE; }
-   virtual TH2F      *LegoPlot(Int_t ntheta=60, Double_t themin=0., Double_t themax=180.,
-                            Int_t nphi=90, Double_t phimin=0., Double_t phimax=360.,
-                            Double_t rmin=0., Double_t rmax=9999999, Option_t *option="") override { return nullptr; }
-   virtual void       ModifiedPad(Bool_t update=kFALSE) const override {}
-   virtual void       OpProgress(const char *opname, Long64_t current, Long64_t size, TStopwatch *watch=0, Bool_t last=kFALSE, Bool_t refresh=kFALSE, const char *msg="") override {}
-   virtual void       Paint(Option_t *option="") override {}
-   virtual void       PaintNode(TGeoNode *node, Option_t *option="", TGeoMatrix* global=0) override {}
-   virtual void       PaintShape(TGeoShape *shape, Option_t *option="") override {}
-   virtual void       PaintOverlap(void *ovlp, Option_t *option="") override {}
-   virtual void       PrintOverlaps() const override {}
-   virtual void       PaintVolume(TGeoVolume *vol, Option_t *option="", TGeoMatrix* global=0) override {}
-   virtual void       RandomPoints(const TGeoVolume *vol, Int_t npoints, Option_t *option="") override {}
-   virtual void       RandomRays(Int_t nrays, Double_t startx, Double_t starty, Double_t startz, const char *target_vol, Bool_t check_norm) override {}
-   virtual void       Raytrace(Option_t *option="") override {}
-   virtual TGeoNode  *SamplePoints(Int_t npoints, Double_t &dist, Double_t epsil, const char* g3path) override { return nullptr; }
-   virtual void       SetBombFactors(Double_t bombx=1.3, Double_t bomby=1.3, Double_t bombz=1.3,
-                                     Double_t bombr=1.3) override {}
-   virtual void       SetClippingShape(TGeoShape *shape) override {}
-   virtual void       SetExplodedView(Int_t iopt=0) override {}
-   virtual void       SetGeoManager(TGeoManager *geom) override {}
-   virtual void       SetIteratorPlugin(TGeoIteratorPlugin *plugin) override {}
-   virtual void       SetCheckedNode(TGeoNode *node) override {}
-   virtual void       SetNsegments(Int_t nseg=20) override {}
-   virtual void       SetNmeshPoints(Int_t npoints) override {}
-   virtual void       SetRaytracing(Bool_t flag=kTRUE) override {}
-   virtual void       SetTopVisible(Bool_t vis=kTRUE) override {}
-   virtual void       SetTopVolume(TGeoVolume *vol) override {}
-   virtual void       SetVisLevel(Int_t level=3) override {}
-   virtual void       SetVisOption(Int_t option=0) override {}
-   virtual Int_t      ShapeDistancetoPrimitive(const TGeoShape *shape, Int_t numpoints, Int_t px, Int_t py) const override { return 0; }
-   virtual void       Test(Int_t npoints, Option_t *option) override {}
-   virtual void       TestOverlaps(const char *path) override {}
-   virtual Bool_t     TestVoxels(TGeoVolume *vol) override { return kFALSE; }
-   virtual void       UnbombTranslation(const Double_t *tr, Double_t *bombtr) override {}
-   virtual Double_t   Weight(Double_t precision, Option_t *option="v") override { return 0.; }
+   void       AddSize3D(Int_t, Int_t, Int_t) override {}
+   TVirtualGeoTrack *AddTrack(Int_t, Int_t, TObject *) override { return nullptr; }
+   void       AddTrackPoint(Double_t *, Double_t *, Bool_t =kFALSE) override {}
+   void       BombTranslation(const Double_t *, Double_t *) override {}
+   void       CheckPoint(Double_t =0, Double_t =0, Double_t =0, Option_t * ="") override {}
+   void       CheckShape(TGeoShape *, Int_t, Int_t, Option_t *) override {}
+   void       CheckBoundaryErrors(Int_t =1000000, Double_t =-1.) override {}
+   void       CheckBoundaryReference(Int_t =-1) override {}
+   void       CheckGeometryFull(Bool_t =kTRUE, Bool_t =kTRUE, Int_t =10000, const Double_t * = nullptr) override {}
+   void       CheckGeometry(Int_t, Double_t, Double_t, Double_t) const override {}
+   void       CheckOverlaps(const TGeoVolume *, Double_t =0.1, Option_t * ="") const override {}
+   Int_t      CountVisibleNodes() override { return 0; }
+   void       DefaultAngles() override {}
+   void       DefaultColors() override {}
+   Int_t      DistanceToPrimitiveVol(TGeoVolume *, Int_t, Int_t) override { return 0; }
+   void       Draw(Option_t * ="") override {}
+   void       DrawBatemanSol(TGeoBatemanSol *, Option_t * ="") override {}
+   void       DrawShape(TGeoShape *, Option_t * ="") override {}
+   void       DrawOnly(Option_t * ="") override {}
+   void       DrawOverlap(void *, Option_t * ="") override {}
+   void       DrawCurrentPoint(Int_t) override {}
+   void       DrawPanel() override {}
+   void       DrawPath(const char *, Option_t * ="") override {}
+   void       DrawPolygon(const TGeoPolygon *) override {}
+   void       DrawVolume(TGeoVolume *, Option_t * ="") override {}
+   void       EditGeometry(Option_t * ="") override {}
+   void       EstimateCameraMove(Double_t /*tmin*/, Double_t /*tmax*/, Double_t *, Double_t * ) override {}
+   void       ExecuteShapeEvent(TGeoShape *, Int_t, Int_t, Int_t) override {}
+   void       ExecuteManagerEvent(TGeoManager *, Int_t, Int_t, Int_t) override {}
+   void       ExecuteVolumeEvent(TGeoVolume *, Int_t, Int_t, Int_t) override {}
+   Int_t      GetColor(Int_t, Float_t) const override { return 0; }
+   Int_t      GetNsegments() const override { return 1; }
+   void       GetBombFactors(Double_t &, Double_t &, Double_t &, Double_t &) const override {}
+   Int_t      GetBombMode() const override { return 0; }
+   const char *GetDrawPath() const override { return ""; }
+   TGeoVolume *GetDrawnVolume() const override { return nullptr; }
+   TGeoVolume *GetTopVolume() const override { return nullptr; }
+   void       GetViewAngles(Double_t &/*longitude*/, Double_t &/*latitude*/, Double_t &/*psi*/) override {}
+   Int_t      GetVisLevel() const override { return 0; }
+   Int_t      GetVisOption() const override { return 0; }
+   const char *GetVolumeInfo(const TGeoVolume *, Int_t, Int_t) const override { return "info"; }
+   void       GrabFocus(Int_t =0, Double_t =0, Double_t =0, Double_t =0) override {}
+   Double_t  *GetViewBox() override { return nullptr; }
+   Bool_t     IsPaintingShape() const override { return kFALSE; }
+   Bool_t     IsRaytracing() const override { return kFALSE; }
+   Bool_t     IsExplodedView() const override { return kFALSE; }
+   TH2F      *LegoPlot(Int_t =60, Double_t =0., Double_t =180.,
+                       Int_t =90, Double_t =0., Double_t =360.,
+                       Double_t =0., Double_t =9999999, Option_t * ="") override { return nullptr; }
+   void       ModifiedPad(Bool_t =kFALSE) const override {}
+   void       OpProgress(const char *, Long64_t, Long64_t, TStopwatch * =nullptr, Bool_t =kFALSE, Bool_t =kFALSE, const char * ="") override {}
+   void       Paint(Option_t * ="") override {}
+   void       PaintNode(TGeoNode *, Option_t * ="", TGeoMatrix * = nullptr) override {}
+   void       PaintShape(TGeoShape *, Option_t * ="") override {}
+   void       PaintOverlap(void*, Option_t * ="") override {}
+   void       PrintOverlaps() const override {}
+   void       PaintVolume(TGeoVolume *, Option_t * = "", TGeoMatrix * = nullptr) override {}
+   void       RandomPoints(const TGeoVolume *, Int_t, Option_t * = "") override {}
+   void       RandomRays(Int_t, Double_t, Double_t, Double_t, const char *, Bool_t) override {}
+   void       Raytrace(Option_t* = "") override {}
+   TGeoNode  *SamplePoints(Int_t, Double_t &, Double_t, const char*) override { return nullptr; }
+   void       SetBombFactors(Double_t =1.3, Double_t =1.3, Double_t =1.3, Double_t =1.3) override {}
+   void       SetClippingShape(TGeoShape *) override {}
+   void       SetExplodedView(Int_t =0) override {}
+   void       SetGeoManager(TGeoManager *) override {}
+   void       SetIteratorPlugin(TGeoIteratorPlugin *) override {}
+   void       SetCheckedNode(TGeoNode *) override {}
+   void       SetNsegments(Int_t =20) override {}
+   void       SetNmeshPoints(Int_t) override {}
+   void       SetRaytracing(Bool_t =kTRUE) override {}
+   void       SetTopVisible(Bool_t =kTRUE) override {}
+   void       SetTopVolume(TGeoVolume *) override {}
+   void       SetVisLevel(Int_t =3) override {}
+   void       SetVisOption(Int_t =0) override {}
+   Int_t      ShapeDistancetoPrimitive(const TGeoShape *, Int_t, Int_t, Int_t) const override { return 0; }
+   void       Test(Int_t, Option_t *) override {}
+   void       TestOverlaps(const char *) override {}
+   Bool_t     TestVoxels(TGeoVolume *) override { return kFALSE; }
+   void       UnbombTranslation(const Double_t *, Double_t *) override {}
+   Double_t   Weight(Double_t, Option_t* = "v") override { return 0.; }
 
    ClassDefOverride(REveGeoPainter,0)  // Web-based geo painter
 };

--- a/graf3d/eve7/inc/ROOT/REveGeoPainter.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoPainter.hxx
@@ -14,10 +14,16 @@
 
 #include "TVirtualGeoPainter.h"
 
+#include <ROOT/REveGeomViewer.hxx>
+
 namespace ROOT {
 namespace Experimental {
 
 class REveGeoPainter : public TVirtualGeoPainter {
+
+   TGeoManager *fGeoManager{nullptr};
+
+   std::shared_ptr<REveGeomViewer> fViewer;
 
 public:
    REveGeoPainter(TGeoManager *manager);
@@ -47,7 +53,7 @@ public:
    void       DrawPanel() override {}
    void       DrawPath(const char *, Option_t * ="") override {}
    void       DrawPolygon(const TGeoPolygon *) override {}
-   void       DrawVolume(TGeoVolume *, Option_t * ="") override {}
+   void       DrawVolume(TGeoVolume *, Option_t * ="") override;
    void       EditGeometry(Option_t * ="") override {}
    void       EstimateCameraMove(Double_t /*tmin*/, Double_t /*tmax*/, Double_t *, Double_t * ) override {}
    void       ExecuteShapeEvent(TGeoShape *, Int_t, Int_t, Int_t) override {}
@@ -87,7 +93,7 @@ public:
    void       SetBombFactors(Double_t =1.3, Double_t =1.3, Double_t =1.3, Double_t =1.3) override {}
    void       SetClippingShape(TGeoShape *) override {}
    void       SetExplodedView(Int_t =0) override {}
-   void       SetGeoManager(TGeoManager *) override {}
+   void       SetGeoManager(TGeoManager *) override;
    void       SetIteratorPlugin(TGeoIteratorPlugin *) override {}
    void       SetCheckedNode(TGeoNode *) override {}
    void       SetNsegments(Int_t =20) override {}

--- a/graf3d/eve7/inc/ROOT/REveGeoPainter.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoPainter.hxx
@@ -1,0 +1,115 @@
+// @(#)root/eve7:$Id$
+// Author: Sergey Linev, 27.02.2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_REveGeoPainter
+#define ROOT7_REveGeoPainter
+
+#include "TVirtualGeoPainter.h"
+
+namespace ROOT {
+namespace Experimental {
+
+class REveGeoPainter : public TVirtualGeoPainter {
+
+public:
+   REveGeoPainter(TGeoManager *manager);
+   virtual ~REveGeoPainter();
+
+   void       AddSize3D(Int_t numpoints, Int_t numsegs, Int_t numpolys) override {}
+   TVirtualGeoTrack *AddTrack(Int_t id, Int_t pdgcode, TObject *particle) override { return nullptr; }
+   void       AddTrackPoint(Double_t *point, Double_t *box, Bool_t reset=kFALSE) override {}
+   virtual void       BombTranslation(const Double_t *tr, Double_t *bombtr) override {}
+   virtual void       CheckPoint(Double_t x=0, Double_t y=0, Double_t z=0, Option_t *option="") override {}
+   virtual void       CheckShape(TGeoShape *shape, Int_t testNo, Int_t nsamples, Option_t *option) override {}
+   virtual void       CheckBoundaryErrors(Int_t ntracks=1000000, Double_t radius=-1.) override {}
+   virtual void       CheckBoundaryReference(Int_t icheck=-1) override {}
+   virtual void       CheckGeometryFull(Bool_t checkoverlaps=kTRUE, Bool_t checkcrossings=kTRUE, Int_t nrays=10000, const Double_t *vertex=NULL) override {}
+   virtual void       CheckGeometry(Int_t nrays, Double_t startx, Double_t starty, Double_t startz) const override {}
+   virtual void       CheckOverlaps(const TGeoVolume *vol, Double_t ovlp=0.1, Option_t *option="") const override {}
+   virtual Int_t      CountVisibleNodes() override { return 0; }
+   virtual void       DefaultAngles() override {}
+   virtual void       DefaultColors() override {}
+   virtual Int_t      DistanceToPrimitiveVol(TGeoVolume *vol, Int_t px, Int_t py) override { return 0; }
+   virtual void       Draw(Option_t *option="") override {}
+   virtual void       DrawBatemanSol(TGeoBatemanSol *sol, Option_t *option="") override {}
+   virtual void       DrawShape(TGeoShape *shape, Option_t *option="") override {}
+   virtual void       DrawOnly(Option_t *option="") override {}
+   virtual void       DrawOverlap(void *ovlp, Option_t *option="") override {}
+   virtual void       DrawCurrentPoint(Int_t color) override {}
+   virtual void       DrawPanel() override {}
+   virtual void       DrawPath(const char *path, Option_t *option="") override {}
+   virtual void       DrawPolygon(const TGeoPolygon *poly) override {}
+   virtual void       DrawVolume(TGeoVolume *vol, Option_t *option="") override {}
+   virtual void       EditGeometry(Option_t *option="") override {}
+   virtual void       EstimateCameraMove(Double_t /*tmin*/, Double_t /*tmax*/, Double_t *, Double_t * ) override {}
+   virtual void       ExecuteShapeEvent(TGeoShape *shape, Int_t event, Int_t px, Int_t py) override {}
+   virtual void       ExecuteManagerEvent(TGeoManager *geom, Int_t event, Int_t px, Int_t py) override {}
+   virtual void       ExecuteVolumeEvent(TGeoVolume *volume, Int_t event, Int_t px, Int_t py) override {}
+   virtual Int_t      GetColor(Int_t base, Float_t light) const override { return 0; }
+   virtual Int_t      GetNsegments() const override { return 1; }
+   virtual void       GetBombFactors(Double_t &bombx, Double_t &bomby, Double_t &bombz, Double_t &bombr) const override {}
+   virtual Int_t      GetBombMode() const override { return 0; }
+   virtual const char *GetDrawPath() const override { return ""; }
+   virtual TGeoVolume *GetDrawnVolume() const override { return nullptr; }
+   virtual TGeoVolume *GetTopVolume() const override { return nullptr; }
+   virtual void       GetViewAngles(Double_t &/*longitude*/, Double_t &/*latitude*/, Double_t &/*psi*/) override {}
+   virtual Int_t      GetVisLevel() const override { return 0; }
+   virtual Int_t      GetVisOption() const override { return 0; }
+   virtual const char*GetVolumeInfo(const TGeoVolume *volume, Int_t px, Int_t py) const override { return "info"; }
+   virtual void       GrabFocus(Int_t nfr=0, Double_t dlong=0, Double_t dlat=0, Double_t dpsi=0) override {}
+   virtual Double_t  *GetViewBox() override { return nullptr; }
+   virtual Bool_t     IsPaintingShape() const override { return kFALSE; }
+   virtual Bool_t     IsRaytracing() const override { return kFALSE; }
+   virtual Bool_t     IsExplodedView() const override { return kFALSE; }
+   virtual TH2F      *LegoPlot(Int_t ntheta=60, Double_t themin=0., Double_t themax=180.,
+                            Int_t nphi=90, Double_t phimin=0., Double_t phimax=360.,
+                            Double_t rmin=0., Double_t rmax=9999999, Option_t *option="") override { return nullptr; }
+   virtual void       ModifiedPad(Bool_t update=kFALSE) const override {}
+   virtual void       OpProgress(const char *opname, Long64_t current, Long64_t size, TStopwatch *watch=0, Bool_t last=kFALSE, Bool_t refresh=kFALSE, const char *msg="") override {}
+   virtual void       Paint(Option_t *option="") override {}
+   virtual void       PaintNode(TGeoNode *node, Option_t *option="", TGeoMatrix* global=0) override {}
+   virtual void       PaintShape(TGeoShape *shape, Option_t *option="") override {}
+   virtual void       PaintOverlap(void *ovlp, Option_t *option="") override {}
+   virtual void       PrintOverlaps() const override {}
+   virtual void       PaintVolume(TGeoVolume *vol, Option_t *option="", TGeoMatrix* global=0) override {}
+   virtual void       RandomPoints(const TGeoVolume *vol, Int_t npoints, Option_t *option="") override {}
+   virtual void       RandomRays(Int_t nrays, Double_t startx, Double_t starty, Double_t startz, const char *target_vol, Bool_t check_norm) override {}
+   virtual void       Raytrace(Option_t *option="") override {}
+   virtual TGeoNode  *SamplePoints(Int_t npoints, Double_t &dist, Double_t epsil, const char* g3path) override { return nullptr; }
+   virtual void       SetBombFactors(Double_t bombx=1.3, Double_t bomby=1.3, Double_t bombz=1.3,
+                                     Double_t bombr=1.3) override {}
+   virtual void       SetClippingShape(TGeoShape *shape) override {}
+   virtual void       SetExplodedView(Int_t iopt=0) override {}
+   virtual void       SetGeoManager(TGeoManager *geom) override {}
+   virtual void       SetIteratorPlugin(TGeoIteratorPlugin *plugin) override {}
+   virtual void       SetCheckedNode(TGeoNode *node) override {}
+   virtual void       SetNsegments(Int_t nseg=20) override {}
+   virtual void       SetNmeshPoints(Int_t npoints) override {}
+   virtual void       SetRaytracing(Bool_t flag=kTRUE) override {}
+   virtual void       SetTopVisible(Bool_t vis=kTRUE) override {}
+   virtual void       SetTopVolume(TGeoVolume *vol) override {}
+   virtual void       SetVisLevel(Int_t level=3) override {}
+   virtual void       SetVisOption(Int_t option=0) override {}
+   virtual Int_t      ShapeDistancetoPrimitive(const TGeoShape *shape, Int_t numpoints, Int_t px, Int_t py) const override { return 0; }
+   virtual void       Test(Int_t npoints, Option_t *option) override {}
+   virtual void       TestOverlaps(const char *path) override {}
+   virtual Bool_t     TestVoxels(TGeoVolume *vol) override { return kFALSE; }
+   virtual void       UnbombTranslation(const Double_t *tr, Double_t *bombtr) override {}
+   virtual Double_t   Weight(Double_t precision, Option_t *option="v") override { return 0.; }
+
+   ClassDefOverride(REveGeoPainter,0)  // Web-based geo painter
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+
+#endif

--- a/graf3d/eve7/inc/ROOT/REveGeomViewer.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeomViewer.hxx
@@ -82,6 +82,7 @@ public:
 
 };
 
-}}
+} // namespace Experimental
+} // namespace ROOT
 
 #endif

--- a/graf3d/eve7/src/REveGeoPainter.cxx
+++ b/graf3d/eve7/src/REveGeoPainter.cxx
@@ -15,7 +15,7 @@ using namespace ROOT::Experimental;
 
 REveGeoPainter::REveGeoPainter(TGeoManager *manager) : TVirtualGeoPainter(manager)
 {
-
+   printf("DID CREATE REveGeoPainter\n");
 }
 
 REveGeoPainter::~REveGeoPainter()

--- a/graf3d/eve7/src/REveGeoPainter.cxx
+++ b/graf3d/eve7/src/REveGeoPainter.cxx
@@ -17,6 +17,7 @@ using namespace ROOT::Experimental;
 
 REveGeoPainter::REveGeoPainter(TGeoManager *manager) : TVirtualGeoPainter(manager)
 {
+   TVirtualGeoPainter::SetPainter(this);
    fGeoManager = manager;
 }
 
@@ -32,7 +33,7 @@ void REveGeoPainter::SetGeoManager(TGeoManager *mgr)
    fGeoManager = mgr;
 }
 
-void REveGeoPainter::DrawVolume(TGeoVolume *vol, Option_t *)
+void REveGeoPainter::DrawVolume(TGeoVolume *vol, Option_t *opt)
 {
    if (!fViewer)
       fViewer = std::make_shared<REveGeomViewer>(fGeoManager);
@@ -40,8 +41,12 @@ void REveGeoPainter::DrawVolume(TGeoVolume *vol, Option_t *)
    // select volume to draw
    fViewer->SetGeometry(fGeoManager, vol->GetName());
 
+   std::string drawopt = "";
+   if (opt && strstr(opt,"s"))
+      drawopt = "wire";
+
    // specify JSROOT draw options - here clipping on X,Y,Z axes
-   // viewer->SetDrawOptions("clipxyz");
+   fViewer->SetDrawOptions(drawopt);
 
    // set default limits for number of visible nodes and faces
    // when viewer created, initial values exported from TGeoManager

--- a/graf3d/eve7/src/REveGeoPainter.cxx
+++ b/graf3d/eve7/src/REveGeoPainter.cxx
@@ -1,0 +1,24 @@
+// @(#)root/eve7:$Id$
+// Author: Sergey Linev, 27.02.2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/REveGeoPainter.hxx>
+
+using namespace ROOT::Experimental;
+
+REveGeoPainter::REveGeoPainter(TGeoManager *manager) : TVirtualGeoPainter(manager)
+{
+
+}
+
+REveGeoPainter::~REveGeoPainter()
+{
+
+}

--- a/graf3d/eve7/src/REveGeoPainter.cxx
+++ b/graf3d/eve7/src/REveGeoPainter.cxx
@@ -11,14 +11,42 @@
 
 #include <ROOT/REveGeoPainter.hxx>
 
+#include "TGeoVolume.h"
+
 using namespace ROOT::Experimental;
 
 REveGeoPainter::REveGeoPainter(TGeoManager *manager) : TVirtualGeoPainter(manager)
 {
-   printf("DID CREATE REveGeoPainter\n");
+   fGeoManager = manager;
 }
 
 REveGeoPainter::~REveGeoPainter()
 {
+}
 
+void REveGeoPainter::SetGeoManager(TGeoManager *mgr)
+{
+   if (fViewer && (fGeoManager!=mgr))
+      fViewer->SetGeometry(fGeoManager);
+
+   fGeoManager = mgr;
+}
+
+void REveGeoPainter::DrawVolume(TGeoVolume *vol, Option_t *)
+{
+   if (!fViewer)
+      fViewer = std::make_shared<REveGeomViewer>(fGeoManager);
+
+   // select volume to draw
+   fViewer->SetGeometry(fGeoManager, vol->GetName());
+
+   // specify JSROOT draw options - here clipping on X,Y,Z axes
+   // viewer->SetDrawOptions("clipxyz");
+
+   // set default limits for number of visible nodes and faces
+   // when viewer created, initial values exported from TGeoManager
+   // viewer->SetLimits();
+
+   // start browser
+   fViewer->Show();
 }

--- a/graf3d/eve7/src/REveGeomViewer.cxx
+++ b/graf3d/eve7/src/REveGeomViewer.cxx
@@ -91,6 +91,8 @@ void ROOT::Experimental::REveGeomViewer::Show(const RWebDisplayArgs &args, bool 
 
    if ((fWebWindow->NumConnections(true) == 0) || always_start_new_browser)
       fWebWindow->Show(args);
+   else
+      Update();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REveGeomViewer.cxx
+++ b/graf3d/eve7/src/REveGeomViewer.cxx
@@ -131,7 +131,7 @@ void ROOT::Experimental::REveGeomViewer::SendGeometry(unsigned connid)
 
    auto &json = fDesc.GetDrawJson();
 
-   printf("Produce geometry JSON %d\n", (int) json.length());
+   R__DEBUG_HERE("webeve") << "Produce geometry JSON len: " << json.length();
 
    fWebWindow->Send(connid, json);
 }
@@ -144,8 +144,9 @@ void ROOT::Experimental::REveGeomViewer::SendGeometry(unsigned connid)
 void ROOT::Experimental::REveGeomViewer::SetDrawOptions(const std::string &opt)
 {
    fDesc.SetDrawOptions(opt);
-
-   fWebWindow->Send(0, "DROPT:"s + opt);
+   unsigned connid = fWebWindow->GetConnectionId();
+   if (connid)
+      fWebWindow->Send(connid, "DROPT:"s + opt);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When root started with `--web` option, web-based geometry viewer will be used instead of standard `TGeoPainter` class. For now only basic volume drawing is working.

Tutorials like `geomAlice.C` or `geomBrams.C` works this way.

Technically very tiny implementation of `TVirtualGeoPainter` is provided. 
Can be extend in the future.

Also use `override` specifiers for all `TVirtualGeoPainter` classes