### PR TITLE
Fix compilation error on Windows

### DIFF
--- a/graf2d/win32gdk/CMakeLists.txt
+++ b/graf2d/win32gdk/CMakeLists.txt
@@ -4,7 +4,7 @@
 ############################################################################
 include_directories(${FREETYPE_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/gdk/src 
 					${CMAKE_CURRENT_SOURCE_DIR}/gdk/src/gdk
-					${CMAKE_CURRENT_BINARY_DIR}/gdk/src/glib)
+					${CMAKE_CURRENT_SOURCE_DIR}/gdk/src/glib)
 
 set(iconvlib  ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/iconv-1.3.lib)
 set(iconvdll  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/iconv-1.3.dll)


### PR DESCRIPTION
This patch fixes the following error:

  In file included from input_line_12:3:
  In file included from C:/build/night/LABEL/windows10/SPEC/default/V/6-18/build/include\TGWin32.h:24:
  In file included from C:/build/night/LABEL/windows10/SPEC/default/V/6-18/root/graf2d/win32gdk/gdk/src\gdk/gdk.h:30:
  In file included from C:/build/night/LABEL/windows10/SPEC/default/V/6-18/root/graf2d/win32gdk/gdk/src\gdk/gdkcc.h:4:
  C:/build/night/LABEL/windows10/SPEC/default/V/6-18/root/graf2d/win32gdk/gdk/src\gdk/gdktypes.h:32:10: fatal error: 'glib.h' file not found
  #include <glib.h>
           ^~~~~~~~
CUSTOMBUILD : error : C:/build/night/LABEL/windows10/SPEC/default/V/6-18/build/bin/rootcling.exe: compilation failure (C:/build/night/LABEL/windows10/SPEC/default/V/6-18/build/bin/libWin32gdk1fec221199_dictUmbrella.h) [C:\build\night\LABEL\windows10\SPEC\default\V\6-18\build\graf2d\win32gdk\G__Win32gdk.vcxproj]