### PR TITLE
Fix error message in Brent root finder algorithm ( used by TF1::GetX)

### DIFF
--- a/math/mathcore/src/BrentMethods.cxx
+++ b/math/mathcore/src/BrentMethods.cxx
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <algorithm>
 
+#include "Math/Util.h"
 #include "Math/Error.h"
 
 #include <iostream>
@@ -113,12 +114,16 @@ namespace BrentMethods {
    //std::cout << "bracketing result " << xmin << "  " << xmax  << "middle value " <<  xmiddle << std::endl;
    if (!foundInterval) {
       MATH_INFO_MSG("BrentMethods::MinimStep", "Grid search failed to find a root in the  interval ");
-      std::cout << "xmin = " << xmin << " xmax = " << xmax << " npts = " <<  npx << std::endl;
+      std::string msg = "xmin = ";
+      msg += ROOT::Math::Util::ToString(xmin);
+      msg += std::string(" xmax = ");
+      msg += ROOT::Math::Util::ToString(xmax);
+      msg += std::string(" npts = ");
+      msg += ROOT::Math::Util::ToString(npx);
+      MATH_INFO_MSG("BrentMethods::MinimStep", msg.c_str());
       xmin = 1;
       xmax = 0; 
    }
-   // else 
-   //    std::cout << " root found !!! " << std::endl;
 
    return xmiddle;
 }


### PR DESCRIPTION
When a root is not found in a given interval, an error message is produced written some information in the standard output. This is now fixed and the ROOT  error message reporting system is now used, so the message can in case be suppressed. 
Thanks for the user that reported in https://root-forum.cern.ch/t/turn-off-error-messages-from-tf1-getx/38175