### PR TITLE
[Exp PyROOT][ROOT-9516] Do not delete proxied object if cppyy does it

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/src/TMemoryRegulator.cxx
+++ b/bindings/pyroot_experimental/pythonizations/src/TMemoryRegulator.cxx
@@ -98,10 +98,13 @@ void PyROOT::TMemoryRegulator::ClearProxiedObjects()
 
       if (pyobj && (pyobj->fFlags & CPPInstance::kIsOwner)) {
          // Only delete the C++ object if the Python proxy owns it.
-         // Invoke RecursiveRemove on it first so that proxy cleanup is done
+         // If it is a value, cppyy deletes it in RecursiveRemove as part of
+         // the proxy cleanup.
          auto o = static_cast<TObject *>(cppobj);
+         bool isValue = pyobj->fFlags & CPPInstance::kIsValue;
          RecursiveRemove(o);
-         delete o;
+         if (!isValue)
+            delete o;
       }
       else {
          // Non-owning proxy, just unregister to clean tables.


### PR DESCRIPTION
In the reproducer in ROOT-9516, there is a call to the Roofit::Minimizer function
that returns a RooCmdArg object by value. In such a case, we must
not delete the C++ object in TMemoryRegulator::RecursiveRemove,
since cppyy already does it as part of its RecursiveRemove.
