### PR TITLE
sleep is defined in unistd.h

### DIFF
--- a/core/thread/inc/TThreadPool.h
+++ b/core/thread/inc/TThreadPool.h
@@ -31,6 +31,8 @@
 #include <sstream>
 #ifdef _MSC_VER
 #define sleep(s) _sleep(s)
+#else
+#include <unistd.h>
 #endif
 
 


### PR DESCRIPTION
This should fix the runtime_cxxmodules on osx.