### PR TITLE
[CMake] Correctly return real (safe) install paths at runtime

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -678,22 +678,30 @@ file(RELATIVE_PATH ROOT_CMAKE_TO_INCLUDE_DIR "${CMAKE_INSTALL_FULL_CMAKEDIR}" "$
 file(RELATIVE_PATH ROOT_CMAKE_TO_LIB_DIR "${CMAKE_INSTALL_FULL_CMAKEDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}")
 file(RELATIVE_PATH ROOT_CMAKE_TO_BIN_DIR "${CMAKE_INSTALL_FULL_CMAKEDIR}" "${CMAKE_INSTALL_FULL_BINDIR}")
 
+# '_' prefixed variables are used to construct the paths,
+# while the normal variants evaluate to full paths at runtime
 set(ROOT_INCLUDE_DIR_SETUP "
 # ROOT configured for the install with relative paths, so use these
-get_filename_component(ROOT_INCLUDE_DIRS \"\${_thisdir}/${ROOT_CMAKE_TO_INCLUDE_DIR}\" ABSOLUTE)
+get_filename_component(_ROOT_INCLUDE_DIRS \"\${_thisdir}/${ROOT_CMAKE_TO_INCLUDE_DIR}\" REALPATH)
+# resolve relative paths to absolute system paths
+get_filename_component(ROOT_INCLUDE_DIRS \"\${_ROOT_INCLUDE_DIRS}\" REALPATH)
 ")
 set(ROOT_LIBRARY_DIR_SETUP "
 # ROOT configured for the install with relative paths, so use these
-get_filename_component(ROOT_LIBRARY_DIR \"\${_thisdir}/${ROOT_CMAKE_TO_LIB_DIR}\" ABSOLUTE)
+get_filename_component(_ROOT_LIBRARY_DIR \"\${_thisdir}/${ROOT_CMAKE_TO_LIB_DIR}\" REALPATH)
+# resolve relative paths to absolute system paths
+get_filename_component(ROOT_LIBRARY_DIR \"\${_ROOT_LIBRARY_DIR}\" REALPATH)
 ")
 set(ROOT_BINDIR_SETUP "
 # ROOT configured for the install with relative paths, so use these
-get_filename_component(ROOT_BINDIR \"\${_thisdir}/${ROOT_CMAKE_TO_BIN_DIR}\" ABSOLUTE)
+get_filename_component(_ROOT_BINDIR \"\${_thisdir}/${ROOT_CMAKE_TO_BIN_DIR}\" REALPATH)
+# resolve relative paths to absolute system paths
+get_filename_component(ROOT_BINDIR \"\${_ROOT_BINDIR}\" REALPATH)
 ")
 # Deprecated value ROOT_BINARY_DIR
 set(ROOT_BINARY_DIR_SETUP "
 # Deprecated value, please don't use it and use ROOT_BINDIR instead.
-get_filename_component(ROOT_BINARY_DIR \"\${ROOT_BINDIR}\" ABSOLUTE)
+get_filename_component(ROOT_BINARY_DIR \"\${ROOT_BINDIR}\" REALPATH)
 ")
 
 # used by ROOTConfig.cmake from the build directory


### PR DESCRIPTION
Currently when installed with `-Dgnuinstall=ON` ROOT ends up exporting relative paths from the `${CMAKE_INSTALL_CMAKEDIR}` to the relevant binary, include and library directories. This can be a problem, especially when these paths may be evaluated from a different system folder assumed by CMake (e.g. when `CMAKE_INTSTALL_CMAKEDIR` is not the same for ROOT and CMake) as well as in other cases, when relative paths are not appropriate.

Thus, it is safer in the general case to have these relative paths resolved to absolute system paths immediately before being passed to a caller. This merge request tries to accomplish just that with complete transparency and zero side-effects.

It has been tested and deployed in Arch Linux x86_64, CMake 3.16.4, GCC 9.2.1:
 - resulting relevant CMake config:
```cmake
#----------------------------------------------------------------------------
# Configure the path to the ROOT headers, using a relative path if possible.
# This is only known at CMake time, so we expand a CMake supplied variable.
#

# ROOT configured for the install with relative paths, so use these
get_filename_component(_ROOT_INCLUDE_DIRS "${_thisdir}/../../../include" REALPATH)


# resolve relative paths to absolute system paths
get_filename_component(ROOT_INCLUDE_DIRS "${_ROOT_INCLUDE_DIRS}" REALPATH)


# ROOT configured for the install with relative paths, so use these
get_filename_component(_ROOT_LIBRARY_DIR "${_thisdir}/../../root" REALPATH)


# resolve relative paths to absolute system paths
get_filename_component(ROOT_LIBRARY_DIR "${_ROOT_LIBRARY_DIR}" REALPATH)


# ROOT configured for the install with relative paths, so use these
get_filename_component(_ROOT_BINDIR "${_thisdir}/../../../bin" REALPATH)


# resolve relative paths to absolute system paths
get_filename_component(ROOT_BINDIR "${_ROOT_BINDIR}" REALPATH)


# Deprecated value, please don't use it and use ROOT_BINDIR instead.
get_filename_component(ROOT_BINARY_DIR "${ROOT_BINDIR}" REALPATH)
```
 - CMake runtime check:
```bash
$ cmake --find-package -DNAME=ROOT -DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=EXIST --log-level=DEBUG -N --trace-expand 2>&1 | grep ROOT_BIN
/usr/lib64/cmake/ROOT/ROOTConfig.cmake(83):  get_filename_component(_ROOT_BINDIR /usr/lib64/cmake/ROOT/../../../bin REALPATH )
/usr/lib64/cmake/ROOT/ROOTConfig.cmake(87):  get_filename_component(ROOT_BINDIR /usr/bin REALPATH )
/usr/lib64/cmake/ROOT/ROOTConfig.cmake(91):  get_filename_component(ROOT_BINARY_DIR /usr/bin REALPATH )

$ cmake --find-package -DNAME=ROOT -DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=EXIST --log-level=DEBUG -N --trace-expand 2>&1 | grep ROOT_INC
/usr/lib64/cmake/ROOT/ROOTConfig.cmake(67):  get_filename_component(_ROOT_INCLUDE_DIRS /usr/lib64/cmake/ROOT/../../../include REALPATH )
/usr/lib64/cmake/ROOT/ROOTConfig.cmake(71):  get_filename_component(ROOT_INCLUDE_DIRS /usr/include REALPATH )

$ cmake --find-package -DNAME=ROOT -DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=EXIST --log-level=DEBUG -N --trace-expand 2>&1 | grep ROOT_LIB
/usr/lib64/cmake/ROOT/ROOTConfig.cmake(75):  get_filename_component(_ROOT_LIBRARY_DIR /usr/lib64/cmake/ROOT/../../root REALPATH )
/usr/lib64/cmake/ROOT/ROOTConfig.cmake(79):  get_filename_component(ROOT_LIBRARY_DIR /usr/lib/root REALPATH )
```