### PR TITLE
Fix the support in TMVA for GPU (Cuda)  when cuDNN is not available (ROOT-10597)

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -110,6 +110,7 @@ ROOT_BUILD_OPTION(clad ON "Build clad, the cling automatic differentiation plugi
 ROOT_BUILD_OPTION(cocoa OFF "Use native Cocoa/Quartz graphics backend (MacOS X only)")
 ROOT_BUILD_OPTION(coverage OFF "Enable compile flags for coverage testing")
 ROOT_BUILD_OPTION(cuda OFF "Enable support for CUDA (requires CUDA toolkit >= 7.5)")
+ROOT_BUILD_OPTION(cudnn ON "Enable support for cuDNN (default when Cuda is enabled)")
 ROOT_BUILD_OPTION(cxxmodules OFF "Enable support for C++ modules")
 ROOT_BUILD_OPTION(dataframe ON "Enable ROOT RDataFrame")
 ROOT_BUILD_OPTION(davix ON "Enable support for Davix (HTTP/WebDAV access)")

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -476,6 +476,11 @@ if (tmva-gpu)
 else()
   set(hastmvagpu undef)
 endif()
+if (tmva-cudnn)
+   set(hastmvacudnn define)
+else()
+   set(hastmvacudnn undef)
+endif()
 
 # clear cache to allow reconfiguring
 # with a different CMAKE_CXX_STANDARD

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1432,12 +1432,15 @@ if(cuda OR tmva-gpu)
     enable_language(CUDA)
 
     ### look for package CuDNN
-    find_package(CuDNN)
+    if (cudnn )
+      find_package(CuDNN)
 
-    if (CUDNN_FOUND)
-      message(STATUS "CuDNN library found: " ${CUDNN_LIBRARIES})
-    else()
-      message(STATUS "CuDNN library not found")
+      if (CUDNN_FOUND)
+	message(STATUS "CuDNN library found: " ${CUDNN_LIBRARIES})
+      	set(tmva-cudnn ON)
+      else()
+	message(STATUS "CuDNN library not found")
+      endif()
     endif()
 
 

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1440,6 +1440,7 @@ if(cuda OR tmva-gpu)
       	set(tmva-cudnn ON)
       else()
 	message(STATUS "CuDNN library not found")
+        set(cudnn OFF CACHE BOOL "Disabled because cudnn is not found" FORCE)
       endif()
     endif()
 

--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -62,6 +62,7 @@
 
 #@hastmvacpu@ R__HAS_TMVACPU /**/
 #@hastmvagpu@ R__HAS_TMVAGPU /**/
+#@hastmvacudnn@ R__HAS_CUDNN /**/
 
 
 #endif

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -458,7 +458,7 @@ if(tmva-gpu)
   target_link_libraries(TMVA PRIVATE ${CUDA_CUBLAS_LIBRARIES})
   	target_include_directories(TMVA PRIVATE ${CUDA_INCLUDE_DIRS})
   if (tmva-cudnn)
-    message(STATUS "using cudnn in tmva")
+    message(STATUS "Using cuDNN for TMVA Deep Learning on GPU")
 	 target_sources(TMVA PRIVATE
     src/DNN/Architectures/Cuda.cu
     src/DNN/Architectures/Cuda/CudaBuffers.cxx
@@ -467,7 +467,7 @@ if(tmva-gpu)
 	 src/DNN/Architectures/Cudnn.cu)
     target_link_libraries(TMVA PRIVATE ${CUDA_CUBLAS_LIBRARIES} ${CUDNN_LIBRARIES})
   else()
-   message(STATUS "cudnn not found - use only Cuda+Cublas")
+   message(STATUS "cuDNN not found or disabled - use only Cuda+Cublas for TMVA Deep Learning on GPU")
    target_compile_definitions(TMVA PRIVATE -DDNN_NO_CUDNN)
 	target_link_libraries(TMVA PRIVATE ${CUDA_CUBLAS_LIBRARIES})
 	target_sources(TMVA PRIVATE

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -457,7 +457,7 @@ endif()
 if(tmva-gpu)
   target_link_libraries(TMVA PRIVATE ${CUDA_CUBLAS_LIBRARIES})
   	target_include_directories(TMVA PRIVATE ${CUDA_INCLUDE_DIRS})
-  if (CUDNN_FOUND)
+  if (tmva-cudnn)
     message(STATUS "using cudnn in tmva")
 	 target_sources(TMVA PRIVATE
     src/DNN/Architectures/Cuda.cu

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -464,6 +464,7 @@ if(tmva-gpu)
     src/DNN/Architectures/Cuda/CudaBuffers.cxx
     src/DNN/Architectures/Cuda/CudaMatrix.cu
     src/DNN/Architectures/Cuda/CudaTensor.cu
+    src/DNN/Architectures/Cudnn/TensorDataLoader.cxx
 	 src/DNN/Architectures/Cudnn.cu)
     target_link_libraries(TMVA PRIVATE ${CUDA_CUBLAS_LIBRARIES} ${CUDNN_LIBRARIES})
   else()

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
@@ -106,7 +106,7 @@ public:
       return Tensor_t( {c,h*w,n}, GetTensorLayout());
    }
    static Tensor_t CreateTensor(DeviceBuffer_t buffer, size_t n, size_t c, size_t h, size_t w) {
-      return Tensor_t( buffer, {n,c,h,w}, GetTensorLayout(), 0, 0);
+      return Tensor_t( buffer, {c,h*w, n}, GetTensorLayout(), 0, 0);
    }
 
    // create a weight tensor/matrix  from another tensor using its shape

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaTensor.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaTensor.h
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <iostream>
 
+#include "RConfigure.h"
 #include "TMatrixT.h"
 #include "CudaBuffers.h"
 #include "CudaMatrix.h"

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/TCudnn.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/TCudnn.h
@@ -18,6 +18,12 @@
 #ifndef TMVA_DNN_ARCHITECTURES_CUDNN
 #define TMVA_DNN_ARCHITECTURES_CUDNN
 
+#include "RConfigure.h"   // for definition of R__HAS_CUDNN
+
+#ifndef R__HAS_CUDNN
+#error This file can be compiled only when cudnn is available in ROOT
+#else 
+
 #include "TMVA/DNN/Functions.h"
 #include "TMVA/DNN/CNN/ContextHandles.h"
 //#include "TMVA/DNN/CNN/Descriptors.h"
@@ -850,4 +856,5 @@ Long_t TCudnn<AFloat>::CNNOptions::ConvMaxWorkspaceSize = -1;  // -1 let use Cud
 } // namespace DNN
 } // namespace TMVA
 
+#endif
 #endif

--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -49,7 +49,9 @@
 
 #ifdef R__HAS_TMVAGPU
 #include "TMVA/DNN/Architectures/Cuda.h"
+#ifdef R__HAS_CUDNN
 #include "TMVA/DNN/Architectures/TCudnn.h"
+#endif
 #endif
 
 #include "TMVA/DNN/Functions.h"
@@ -82,8 +84,11 @@ private:
    // Key-Value vector type, contining the values for the training options
    using KeyValueVector_t = std::vector<std::map<TString, TString>>;
 // #ifdef R__HAS_TMVAGPU
+// #ifdef R__HAS_CUDNN
 //    using ArchitectureImpl_t = TMVA::DNN::TCudnn<Float_t>;
-//    //using ArchitectureImpl_t = TMVA::DNN::TCuda<Float_t>;
+// #else
+//   using ArchitectureImpl_t = TMVA::DNN::TCuda<Float_t>;
+// #endif
 // #else
 // do not use arch GPU for evaluation. It is too slow for batch size=1
    using ArchitectureImpl_t = TMVA::DNN::TCpu<Float_t>;

--- a/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/CudaBuffers.cxx
@@ -18,7 +18,9 @@
 
 #include "TMVA/DNN/TensorDataLoader.h"
 #include "TMVA/DNN/Architectures/Cuda.h"
+#ifdef R__HAS_CUDNN
 #include "TMVA/DNN/Architectures/TCudnn.h"
+#endif
 #include "TMVA/DNN/Architectures/Cuda/CudaBuffers.h"
 
 #include "cuda_runtime.h"
@@ -445,7 +447,7 @@ void TTensorDataLoader<TMVAInput_t, TCuda<float>>::CopyTensorInput(TCudaHostBuff
          sampleIterator++;
       }
    } else if (fBatchDepth == fBatchSize) {
-      // batchDepth is batch size 
+      // batchDepth is batch size
       for (size_t i = 0; i < fBatchDepth; i++) {
          size_t sampleIndex = *sampleIterator;
          Event * event = std::get<0>(fData)[sampleIndex];
@@ -462,7 +464,7 @@ void TTensorDataLoader<TMVAInput_t, TCuda<float>>::CopyTensorInput(TCudaHostBuff
    else {
       std::cout  << fBatchDepth << fBatchSize << fBatchHeight << std::endl;
       Error("TTensorDataLoader","Inconsistency between batch depth and batch size");
-      R__ASSERT(0); 
+      R__ASSERT(0);
    }
 }
 //______________________________________________________________________________
@@ -566,7 +568,7 @@ void TTensorDataLoader<TensorInput, TCuda<Double_t>>::CopyTensorWeights(TCudaHos
                                                                       IndexIterator_t sampleIterator)
 {
    const TMatrixT<Double_t> &weightMatrix = std::get<2>(fData);
-   
+
    for (size_t i = 0; i < fBatchSize; i++) {
       buffer[i] = weightMatrix(*sampleIterator, 0);
       sampleIterator++;
@@ -591,7 +593,7 @@ void TTensorDataLoader<TMVAInput_t, TCuda<Double_t>>::CopyTensorInput(TCudaHostB
          sampleIterator++;
       }
    } else if (fBatchDepth == fBatchSize) {
-      // batchDepth is batch size 
+      // batchDepth is batch size
       for (size_t i = 0; i < fBatchDepth; i++) {
          size_t sampleIndex = *sampleIterator;
          Event * event = std::get<0>(fData)[sampleIndex];
@@ -608,7 +610,7 @@ void TTensorDataLoader<TMVAInput_t, TCuda<Double_t>>::CopyTensorInput(TCudaHostB
    else {
       std::cout  << fBatchDepth << fBatchSize << fBatchHeight << std::endl;
       Error("TTensorDataLoader","Inconsistency between batch depth and batch size");
-      R__ASSERT(0); 
+      R__ASSERT(0);
    }
 }
 
@@ -664,10 +666,10 @@ void TTensorDataLoader<TMVAInput_t, TCuda<Double_t>>::CopyTensorWeights(TCudaHos
 template <>
 TTensorBatch<TCuda<float> > TTensorDataLoader<TensorInput, TCuda<float> >::GetTensorBatch()
 {
-   // After copying the data to the device, wrap the device buffer in the respective 
+   // After copying the data to the device, wrap the device buffer in the respective
    // architectures matrix type
    DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
-   
+
    std::vector<Matrix_t> inputTensor(std::get<0>(DeviceBuffers), fBatchSize, )
    size_t jump = fBatchHeight * fBatchWidth;
    for (size_t i = 0; i < fBatchSize; i++) {
@@ -685,10 +687,10 @@ TTensorBatch<TCuda<float> > TTensorDataLoader<TensorInput, TCuda<float> >::GetTe
 template <>
 TTensorBatch<TCuda<double> > TTensorDataLoader<TensorInput, TCuda<double> >::GetTensorBatch()
 {
-   // After copying the data to the device, wrap the device buffer in the respective 
+   // After copying the data to the device, wrap the device buffer in the respective
    // architectures matrix type
    DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
-   
+
    std::vector<Matrix_t> inputTensor;
    size_t jump = fBatchHeight * fBatchWidth;
    for (size_t i = 0; i < fBatchSize; i++) {
@@ -706,10 +708,10 @@ TTensorBatch<TCuda<double> > TTensorDataLoader<TensorInput, TCuda<double> >::Get
 template <>
 TTensorBatch<TCuda<float> > TTensorDataLoader<TMVAInput_t, TCuda<float> >::GetTensorBatch()
 {
-   // After copying the data to the device, wrap the device buffer in the respective 
+   // After copying the data to the device, wrap the device buffer in the respective
    // architectures matrix type
    DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
-   
+
    std::vector<Matrix_t> inputTensor;
    size_t jump = fBatchHeight * fBatchWidth;
    for (size_t i = 0; i < fBatchSize; i++) {
@@ -727,10 +729,10 @@ TTensorBatch<TCuda<float> > TTensorDataLoader<TMVAInput_t, TCuda<float> >::GetTe
 template <>
 TTensorBatch<TCuda<double> > TTensorDataLoader<TMVAInput_t, TCuda<double> >::GetTensorBatch()
 {
-   // After copying the data to the device, wrap the device buffer in the respective 
+   // After copying the data to the device, wrap the device buffer in the respective
    // architectures matrix type
    DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
-   
+
    std::vector<Matrix_t> inputTensor;
    size_t jump = fBatchHeight * fBatchWidth;
    for (size_t i = 0; i < fBatchSize; i++) {
@@ -745,371 +747,7 @@ TTensorBatch<TCuda<double> > TTensorDataLoader<TMVAInput_t, TCuda<double> >::Get
 }
 #endif
 
-//______________________________________________________________________________
-//
-// cuDNN
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TensorInput, TCudnn<float> >::CopyTensorInput(TCudaHostBuffer<float> &buffer,
-                                                                     IndexIterator_t sampleIterator)
-{
-   const std::vector<TMatrixT<Double_t> > &inputTensor = std::get<0>(fData);
-
-   if (fBatchDepth == 1) {
-      for (size_t i = 0; i < fBatchHeight; i++) {
-         size_t sampleIndex = *sampleIterator;
-         for (size_t j = 0; j < fBatchWidth; j++) {
-            size_t bufferIndex = j * fBatchHeight + i;
-            buffer[bufferIndex] = static_cast<float>(inputTensor[0](sampleIndex, j));
-         }
-         sampleIterator++;
-      }
-   } else {
-      for (size_t i = 0; i < fBatchDepth; i++) {
-         size_t sampleIndex = *sampleIterator;
-         for (size_t j = 0; j < fBatchHeight; j++) {
-            for (size_t k = 0; k < fBatchWidth; k++) {
-               size_t bufferIndex = i * fBatchHeight * fBatchWidth + k * fBatchHeight + j;
-               buffer[bufferIndex] = static_cast<float>(inputTensor[sampleIndex](j, k));
-            }
-         }
-         sampleIterator++;
-      }
-   }
-}
-
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TensorInput, TCudnn<float> >::CopyTensorOutput(TCudaHostBuffer<float> &buffer,
-                                                                      IndexIterator_t sampleIterator)
-{
-   const TMatrixT<Double_t> &outputMatrix = std::get<1>(fData);
-   size_t n = outputMatrix.GetNcols();
-
-   for (size_t i = 0; i < fBatchSize; i++) {
-      size_t sampleIndex = *sampleIterator;
-      for (size_t j = 0; j < n; j++) {
-         size_t bufferIndex = j * fBatchSize + i;
-         buffer[bufferIndex] = static_cast<float>(outputMatrix(sampleIndex, j));
-      }
-      sampleIterator++;
-   }
-}
-
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TensorInput, TCudnn<float> >::CopyTensorWeights(TCudaHostBuffer<float> &buffer,
-                                                                       IndexIterator_t sampleIterator)
-{
-   const TMatrixT<Double_t> &weightMatrix = std::get<2>(fData);
-   
-   for (size_t i = 0; i < fBatchSize; i++) {
-      buffer[i] = static_cast<float>(weightMatrix(*sampleIterator, 0));
-      sampleIterator++;
-   }
-}
-
-//______________________________________________________________________________
-template <> 
-void TTensorDataLoader<TMVAInput_t, TCudnn<float> >::CopyTensorInput(TCudaHostBuffer<float> &buffer,
-                                                                     IndexIterator_t sampleIterator)
-{
-   // Image has channel depth 1 -> they are ordered as row-vectors in a matrix (batchHeight = batchSize)
-   // one event, one  example in the batch
-   if (fBatchDepth == 1 && fBatchHeight == fBatchSize) {
-      for (size_t i = 0; i < fBatchHeight; i++) {
-         size_t sampleIndex = *sampleIterator;
-         Event * event = std::get<0>(fData)[sampleIndex];
-         for (size_t j = 0; j < fBatchWidth; j++) {
-            size_t bufferIndex = j * fBatchHeight + i;
-            buffer[bufferIndex] = event->GetValue(j);
-         }
-         sampleIterator++;
-      }
-   // A batch is made up by a single image with its channels
-   } else if (fBatchDepth == fBatchSize) {
-      for (size_t i = 0; i < fBatchSize; i++) {
-         size_t sampleIndex = *sampleIterator;
-         Event * event = std::get<0>(fData)[sampleIndex];
-         for (size_t j = 0; j < fBatchHeight; j++) {
-            for (size_t k = 0; k < fBatchWidth; k++) {
-               // Cudnn order is NCHW
-               size_t bufferIndex = i * fBatchHeight * fBatchWidth + j * fBatchWidth + k;
-               buffer[bufferIndex] = event->GetValue(j * fBatchWidth + k);
-            }
-         }
-         sampleIterator++;
-      }
-   }
-   else {
-      std::cout  << fBatchDepth << fBatchSize << fBatchHeight << std::endl;
-      Error("TTensorDataLoader","Inconsistency between batch depth and batch size");
-      R__ASSERT(0); 
-   }
-}
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TMVAInput_t, TCudnn<float> >::CopyTensorOutput(TCudaHostBuffer<float> &buffer,
-                                                                      IndexIterator_t sampleIterator)
-{
-   const DataSetInfo &info = std::get<1>(fData);
-   size_t n = buffer.GetSize() / fBatchSize;
-
-   // Copy target(s).
-   for (size_t i = 0; i < fBatchSize; i++) {
-      size_t sampleIndex = *sampleIterator++;
-      Event *event = std::get<0>(fData)[sampleIndex];
-      for (size_t j = 0; j < n; j++) {
-         // Copy output matrices.
-         size_t bufferIndex = j * fBatchSize + i;
-         // Classification
-         if (event->GetNTargets() == 0) {
-            if (n == 1) {
-               // Binary.
-               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
-            } else {
-               // Multiclass.
-               buffer[bufferIndex] = 0.0;
-               if (j == event->GetClass()) {
-                  buffer[bufferIndex] = 1.0;
-               }
-            }
-         } else {
-            buffer[bufferIndex] = static_cast<Float_t>(event->GetTarget(j));
-         }
-      }
-   }
-}
-
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TMVAInput_t, TCudnn<float> >::CopyTensorWeights(TCudaHostBuffer<float> &buffer,
-                                                                       IndexIterator_t sampleIterator)
-{
-   for (size_t i = 0; i < fBatchSize; i++) {
-      size_t sampleIndex = *sampleIterator++;
-      Event *event = std::get<0>(fData)[sampleIndex];
-      buffer[i] = event->GetWeight();
-   }
-}
-
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TensorInput, TCudnn<double> >::CopyTensorInput(TCudaHostBuffer<double> &buffer,
-                                                                      IndexIterator_t sampleIterator)
-{
-   const std::vector<TMatrixT<Double_t> > &inputTensor = std::get<0>(fData);
-
-   if (fBatchDepth == 1) {
-      for (size_t i = 0; i < fBatchHeight; i++) {
-         size_t sampleIndex = *sampleIterator;
-         for (size_t j = 0; j < fBatchWidth; j++) {
-            size_t bufferIndex = j * fBatchHeight + i;
-            buffer[bufferIndex] = static_cast<double>(inputTensor[0](sampleIndex, j));
-         }
-         sampleIterator++;
-      }
-   } else {
-      for (size_t i = 0; i < fBatchDepth; i++) {
-         size_t sampleIndex = *sampleIterator;
-         for (size_t j = 0; j < fBatchHeight; j++) {
-            for (size_t k = 0; k < fBatchWidth; k++) {
-               size_t bufferIndex = i * fBatchHeight * fBatchWidth + k * fBatchHeight + j;
-               buffer[bufferIndex] = static_cast<double>(inputTensor[sampleIndex](j, k));
-            }
-         }
-         sampleIterator++;
-      }
-   }
-}
-
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TensorInput, TCudnn<double> >::CopyTensorOutput(TCudaHostBuffer<double> &buffer,
-                                                                       IndexIterator_t sampleIterator)
-{
-   const TMatrixT<Double_t> &outputMatrix = std::get<1>(fData);
-   size_t n = outputMatrix.GetNcols();
-
-   for (size_t i = 0; i < fBatchSize; i++) {
-      size_t sampleIndex = *sampleIterator;
-      for (size_t j = 0; j < n; j++) {
-         size_t bufferIndex = j * fBatchSize + i;
-         buffer[bufferIndex] = outputMatrix(sampleIndex, j);
-      }
-      sampleIterator++;
-   }
-}
-
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TensorInput, TCudnn<double> >::CopyTensorWeights(TCudaHostBuffer<double> &buffer,
-                                                                        IndexIterator_t sampleIterator)
-{
-   const TMatrixT<Double_t> &weightMatrix = std::get<2>(fData);
-   for (size_t i = 0; i < fBatchSize; i++) {
-      buffer[i] = weightMatrix(*sampleIterator, 0);
-      sampleIterator++;
-   }
-}
-
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TMVAInput_t, TCudnn<double> >::CopyTensorInput(TCudaHostBuffer<double> &buffer,
-                                                                      IndexIterator_t sampleIterator)
-{
-   // one event, one  example in the batch
-   if (fBatchDepth == 1 && fBatchHeight == fBatchSize) {
-      for (size_t i = 0; i < fBatchHeight; i++) {
-         size_t sampleIndex = *sampleIterator;
-         Event * event = std::get<0>(fData)[sampleIndex];
-         for (size_t j = 0; j < fBatchWidth; j++) {
-            size_t bufferIndex = j * fBatchHeight + i;
-            buffer[bufferIndex] = event->GetValue(j);
-         }
-         sampleIterator++;
-      }
-   } else if (fBatchDepth == fBatchSize) {
-      // batchDepth is batch size 
-      for (size_t i = 0; i < fBatchDepth; i++) {
-         size_t sampleIndex = *sampleIterator;
-         Event * event = std::get<0>(fData)[sampleIndex];
-         for (size_t j = 0; j < fBatchHeight; j++) {
-            for (size_t k = 0; k < fBatchWidth; k++) {
-               // because of the column-major ordering
-               size_t bufferIndex = i * fBatchHeight * fBatchWidth + j * fBatchWidth + k;
-               buffer[bufferIndex] = event->GetValue(j * fBatchWidth + k);
-            }
-         }
-         sampleIterator++;
-      }
-   }
-   else {
-      Error("TTensorDataLoader","Inconsistency between batch depth and batch size");
-      R__ASSERT(0); 
-   }
-}
-
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TMVAInput_t, TCudnn<double> >::CopyTensorOutput(TCudaHostBuffer<double> &buffer,
-                                                                       IndexIterator_t sampleIterator)
-{
-   const DataSetInfo &info = std::get<1>(fData);
-   size_t n = buffer.GetSize() / fBatchSize;
-
-   // Copy target(s).
-
-   for (size_t i = 0; i < fBatchSize; i++) {
-      size_t sampleIndex = *sampleIterator++;
-      Event *event = std::get<0>(fData)[sampleIndex];
-      for (size_t j = 0; j < n; j++) {
-         // Copy output matrices.
-         size_t bufferIndex = j * fBatchSize + i;
-         // Classification
-         if (event->GetNTargets() == 0) {
-            if (n == 1) {
-               // Binary.
-               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
-            } else {
-               // Multiclass.
-               buffer[bufferIndex] = 0.0;
-               if (j == event->GetClass()) {
-                  buffer[bufferIndex] = 1.0;
-               }
-            }
-         } else {
-            buffer[bufferIndex] = static_cast<Double_t>(event->GetTarget(j));
-         }
-      }
-   }
-}
-
-//______________________________________________________________________________
-template <>
-void TTensorDataLoader<TMVAInput_t, TCudnn<double> >::CopyTensorWeights(TCudaHostBuffer<double> &buffer,
-                                                                        IndexIterator_t sampleIterator)
-{
-   for (size_t i = 0; i < fBatchSize; i++) {
-      size_t sampleIndex = *sampleIterator++;
-      Event *event = std::get<0>(fData)[sampleIndex];
-      buffer[i] = event->GetWeight();
-   }
-}
-
-#if 0 
-//______________________________________________________________________________
-template <>
-TTensorBatch<TCudnn<float> > TTensorDataLoader<TensorInput, TCudnn<float> >::GetTensorBatch()
-{
-   // Get buffer tuple on device that contains the data
-   DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
-   
-   std::vector<size_t> outputShape  {fBatchSize, 1, fNOutputFeatures, 1};
-   std::vector<size_t> wheightShape {fBatchSize, 1, 1, 1};
-   std::vector<TCudaTensor<float> > inputTensor(1, TCudaTensor<float>(std::get<0>(DeviceBuffers), 
-                                                this->GetTensorDim(),  fInputShape));
-   TCudaTensor<float> outputMatrix(std::get<1>(DeviceBuffers), this->GetTensorDim(), outputShape);
-   TCudaTensor<float> weightMatrix(std::get<2>(DeviceBuffers), this->GetTensorDim(), wheightShape);
-
-   fBatchIndex++;
-   return TTensorBatch<TCudnn<float> >(inputTensor, outputMatrix, weightMatrix);
-}
-
-//______________________________________________________________________________
-template <>
-TTensorBatch<TCudnn<double> > TTensorDataLoader<TensorInput, TCudnn<double> >::GetTensorBatch()
-{
-   // Get buffer tuple on device that contains the data
-   DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
-
-   std::vector<size_t> outputShape  {fBatchSize, 1, fNOutputFeatures, 1};
-   std::vector<size_t> wheightShape {fBatchSize, 1, 1, 1};
-   std::vector<TCudaTensor<double> > inputTensor(1, TCudaTensor<double>(std::get<0>(DeviceBuffers), 
-                                                 this->GetTensorDim(),  fInputShape));
-   TCudaTensor<double> outputMatrix(std::get<1>(DeviceBuffers), this->GetTensorDim(), outputShape);
-   TCudaTensor<double> weightMatrix(std::get<2>(DeviceBuffers), this->GetTensorDim(), wheightShape);
-
-   fBatchIndex++;
-   return TTensorBatch<TCudnn<double> >(inputTensor, outputMatrix, weightMatrix);
-}
-
-//______________________________________________________________________________
-template <>
-TTensorBatch<TCudnn<float> > TTensorDataLoader<TMVAInput_t, TCudnn<float> >::GetTensorBatch()
-{
-   // Get buffer tuple on device that contains the data
-   DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
-
-   std::vector<size_t> outputShape  {fBatchSize, 1, fNOutputFeatures, 1};
-   std::vector<size_t> wheightShape {fBatchSize, 1, 1, 1};
-   std::vector<TCudaTensor<float> > inputTensor(1, TCudaTensor<float>(std::get<0>(DeviceBuffers), 
-                                                this->GetTensorDim(),  fInputShape));
-   TCudaTensor<float> outputMatrix(std::get<1>(DeviceBuffers), this->GetTensorDim(), outputShape);
-   TCudaTensor<float> weightMatrix(std::get<2>(DeviceBuffers), this->GetTensorDim(), wheightShape);
-
-   fBatchIndex++;
-   return TTensorBatch<TCudnn<float> >(inputTensor, outputMatrix, weightMatrix);
-}
-
-//______________________________________________________________________________
-template <>
-TTensorBatch<TCudnn<double> > TTensorDataLoader<TMVAInput_t, TCudnn<double> >::GetTensorBatch()
-{
-   // Get buffer tuple on device that contains the data
-   DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
-   
-   std::vector<size_t> outputShape  {fBatchSize, 1, fNOutputFeatures, 1};
-   std::vector<size_t> wheightShape {fBatchSize, 1, 1, 1};
-   std::vector<TCudaTensor<double> > inputTensor(1, TCudaTensor<double>(std::get<0>(DeviceBuffers), 
-                                                 this->GetTensorDim(),  fInputShape));
-   TCudaTensor<double> outputMatrix(std::get<1>(DeviceBuffers), fNOutputFeatures + 2, outputShape);
-   TCudaTensor<double> weightMatrix(std::get<2>(DeviceBuffers), 3, wheightShape);
-
-   fBatchIndex++;
-   return TTensorBatch<TCudnn<double> >(inputTensor, outputMatrix, weightMatrix);
-}
-#endif
+// see file Cudnn/TensorDataLoader.cxx for Cudnn definitions
 
 //______________________________________________________________________________
 // Explicit Instantiations.
@@ -1129,10 +767,7 @@ template class TTensorDataLoader<TensorInput, TCuda<float> >;
 template class TTensorDataLoader<TMVAInput_t, TCuda<float> >;
 template class TTensorDataLoader<TensorInput, TCuda<double >>;
 template class TTensorDataLoader<TMVAInput_t, TCuda<double> >;
-// template class TTensorDataLoader<TensorInput, TCudnn<float> >;
-// template class TTensorDataLoader<TMVAInput_t, TCudnn<float> >;
-// template class TTensorDataLoader<TensorInput, TCudnn<double> >;
-// template class TTensorDataLoader<TMVAInput_t, TCudnn<double> >;
+
 
 } // TMVA
 } // DNN

--- a/tmva/tmva/src/DNN/Architectures/Cudnn/TensorDataLoader.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cudnn/TensorDataLoader.cxx
@@ -1,0 +1,400 @@
+// @(#)root/tmva/tmva/dnn:$Id$
+// Author: Lorenzo Moneta,
+
+
+////////////////////////////////////////////////////////////////////////
+// Implementation of TensorDataLoader functions for CUDA with CuDNN architecture.  //
+////////////////////////////////////////////////////////////////////////
+
+#include "TMVA/DataSetInfo.h"
+
+#include "TMVA/DNN/TensorDataLoader.h"
+#include "TMVA/DNN/Architectures/Cuda/CudaBuffers.h"
+
+#include "TMVA/DNN/Architectures/TCudnn.h"
+
+
+
+#include "cuda_runtime.h"
+#include <algorithm>
+
+namespace TMVA {
+namespace DNN {
+
+//______________________________________________________________________________
+//
+// cuDNN
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TensorInput, TCudnn<float> >::CopyTensorInput(TCudaHostBuffer<float> &buffer,
+                                                                     IndexIterator_t sampleIterator)
+{
+   const std::vector<TMatrixT<Double_t> > &inputTensor = std::get<0>(fData);
+
+   if (fBatchDepth == 1) {
+      for (size_t i = 0; i < fBatchHeight; i++) {
+         size_t sampleIndex = *sampleIterator;
+         for (size_t j = 0; j < fBatchWidth; j++) {
+            size_t bufferIndex = j * fBatchHeight + i;
+            buffer[bufferIndex] = static_cast<float>(inputTensor[0](sampleIndex, j));
+         }
+         sampleIterator++;
+      }
+   } else {
+      for (size_t i = 0; i < fBatchDepth; i++) {
+         size_t sampleIndex = *sampleIterator;
+         for (size_t j = 0; j < fBatchHeight; j++) {
+            for (size_t k = 0; k < fBatchWidth; k++) {
+               size_t bufferIndex = i * fBatchHeight * fBatchWidth + k * fBatchHeight + j;
+               buffer[bufferIndex] = static_cast<float>(inputTensor[sampleIndex](j, k));
+            }
+         }
+         sampleIterator++;
+      }
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TensorInput, TCudnn<float> >::CopyTensorOutput(TCudaHostBuffer<float> &buffer,
+                                                                      IndexIterator_t sampleIterator)
+{
+   const TMatrixT<Double_t> &outputMatrix = std::get<1>(fData);
+   size_t n = outputMatrix.GetNcols();
+
+   for (size_t i = 0; i < fBatchSize; i++) {
+      size_t sampleIndex = *sampleIterator;
+      for (size_t j = 0; j < n; j++) {
+         size_t bufferIndex = j * fBatchSize + i;
+         buffer[bufferIndex] = static_cast<float>(outputMatrix(sampleIndex, j));
+      }
+      sampleIterator++;
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TensorInput, TCudnn<float> >::CopyTensorWeights(TCudaHostBuffer<float> &buffer,
+                                                                       IndexIterator_t sampleIterator)
+{
+   const TMatrixT<Double_t> &weightMatrix = std::get<2>(fData);
+
+   for (size_t i = 0; i < fBatchSize; i++) {
+      buffer[i] = static_cast<float>(weightMatrix(*sampleIterator, 0));
+      sampleIterator++;
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TMVAInput_t, TCudnn<float> >::CopyTensorInput(TCudaHostBuffer<float> &buffer,
+                                                                     IndexIterator_t sampleIterator)
+{
+   // Image has channel depth 1 -> they are ordered as row-vectors in a matrix (batchHeight = batchSize)
+   // one event, one  example in the batch
+   if (fBatchDepth == 1 && fBatchHeight == fBatchSize) {
+      for (size_t i = 0; i < fBatchHeight; i++) {
+         size_t sampleIndex = *sampleIterator;
+         Event * event = std::get<0>(fData)[sampleIndex];
+         for (size_t j = 0; j < fBatchWidth; j++) {
+            size_t bufferIndex = j * fBatchHeight + i;
+            buffer[bufferIndex] = event->GetValue(j);
+         }
+         sampleIterator++;
+      }
+   // A batch is made up by a single image with its channels
+   } else if (fBatchDepth == fBatchSize) {
+      for (size_t i = 0; i < fBatchSize; i++) {
+         size_t sampleIndex = *sampleIterator;
+         Event * event = std::get<0>(fData)[sampleIndex];
+         for (size_t j = 0; j < fBatchHeight; j++) {
+            for (size_t k = 0; k < fBatchWidth; k++) {
+               // Cudnn order is NCHW
+               size_t bufferIndex = i * fBatchHeight * fBatchWidth + j * fBatchWidth + k;
+               buffer[bufferIndex] = event->GetValue(j * fBatchWidth + k);
+            }
+         }
+         sampleIterator++;
+      }
+   }
+   else {
+      std::cout  << fBatchDepth << fBatchSize << fBatchHeight << std::endl;
+      Error("TTensorDataLoader","Inconsistency between batch depth and batch size");
+      R__ASSERT(0);
+   }
+}
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TMVAInput_t, TCudnn<float> >::CopyTensorOutput(TCudaHostBuffer<float> &buffer,
+                                                                      IndexIterator_t sampleIterator)
+{
+   const DataSetInfo &info = std::get<1>(fData);
+   size_t n = buffer.GetSize() / fBatchSize;
+
+   // Copy target(s).
+   for (size_t i = 0; i < fBatchSize; i++) {
+      size_t sampleIndex = *sampleIterator++;
+      Event *event = std::get<0>(fData)[sampleIndex];
+      for (size_t j = 0; j < n; j++) {
+         // Copy output matrices.
+         size_t bufferIndex = j * fBatchSize + i;
+         // Classification
+         if (event->GetNTargets() == 0) {
+            if (n == 1) {
+               // Binary.
+               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
+            } else {
+               // Multiclass.
+               buffer[bufferIndex] = 0.0;
+               if (j == event->GetClass()) {
+                  buffer[bufferIndex] = 1.0;
+               }
+            }
+         } else {
+            buffer[bufferIndex] = static_cast<Float_t>(event->GetTarget(j));
+         }
+      }
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TMVAInput_t, TCudnn<float> >::CopyTensorWeights(TCudaHostBuffer<float> &buffer,
+                                                                       IndexIterator_t sampleIterator)
+{
+   for (size_t i = 0; i < fBatchSize; i++) {
+      size_t sampleIndex = *sampleIterator++;
+      Event *event = std::get<0>(fData)[sampleIndex];
+      buffer[i] = event->GetWeight();
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TensorInput, TCudnn<double> >::CopyTensorInput(TCudaHostBuffer<double> &buffer,
+                                                                      IndexIterator_t sampleIterator)
+{
+   const std::vector<TMatrixT<Double_t> > &inputTensor = std::get<0>(fData);
+
+   if (fBatchDepth == 1) {
+      for (size_t i = 0; i < fBatchHeight; i++) {
+         size_t sampleIndex = *sampleIterator;
+         for (size_t j = 0; j < fBatchWidth; j++) {
+            size_t bufferIndex = j * fBatchHeight + i;
+            buffer[bufferIndex] = static_cast<double>(inputTensor[0](sampleIndex, j));
+         }
+         sampleIterator++;
+      }
+   } else {
+      for (size_t i = 0; i < fBatchDepth; i++) {
+         size_t sampleIndex = *sampleIterator;
+         for (size_t j = 0; j < fBatchHeight; j++) {
+            for (size_t k = 0; k < fBatchWidth; k++) {
+               size_t bufferIndex = i * fBatchHeight * fBatchWidth + k * fBatchHeight + j;
+               buffer[bufferIndex] = static_cast<double>(inputTensor[sampleIndex](j, k));
+            }
+         }
+         sampleIterator++;
+      }
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TensorInput, TCudnn<double> >::CopyTensorOutput(TCudaHostBuffer<double> &buffer,
+                                                                       IndexIterator_t sampleIterator)
+{
+   const TMatrixT<Double_t> &outputMatrix = std::get<1>(fData);
+   size_t n = outputMatrix.GetNcols();
+
+   for (size_t i = 0; i < fBatchSize; i++) {
+      size_t sampleIndex = *sampleIterator;
+      for (size_t j = 0; j < n; j++) {
+         size_t bufferIndex = j * fBatchSize + i;
+         buffer[bufferIndex] = outputMatrix(sampleIndex, j);
+      }
+      sampleIterator++;
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TensorInput, TCudnn<double> >::CopyTensorWeights(TCudaHostBuffer<double> &buffer,
+                                                                        IndexIterator_t sampleIterator)
+{
+   const TMatrixT<Double_t> &weightMatrix = std::get<2>(fData);
+   for (size_t i = 0; i < fBatchSize; i++) {
+      buffer[i] = weightMatrix(*sampleIterator, 0);
+      sampleIterator++;
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TMVAInput_t, TCudnn<double> >::CopyTensorInput(TCudaHostBuffer<double> &buffer,
+                                                                      IndexIterator_t sampleIterator)
+{
+   // one event, one  example in the batch
+   if (fBatchDepth == 1 && fBatchHeight == fBatchSize) {
+      for (size_t i = 0; i < fBatchHeight; i++) {
+         size_t sampleIndex = *sampleIterator;
+         Event * event = std::get<0>(fData)[sampleIndex];
+         for (size_t j = 0; j < fBatchWidth; j++) {
+            size_t bufferIndex = j * fBatchHeight + i;
+            buffer[bufferIndex] = event->GetValue(j);
+         }
+         sampleIterator++;
+      }
+   } else if (fBatchDepth == fBatchSize) {
+      // batchDepth is batch size
+      for (size_t i = 0; i < fBatchDepth; i++) {
+         size_t sampleIndex = *sampleIterator;
+         Event * event = std::get<0>(fData)[sampleIndex];
+         for (size_t j = 0; j < fBatchHeight; j++) {
+            for (size_t k = 0; k < fBatchWidth; k++) {
+               // because of the column-major ordering
+               size_t bufferIndex = i * fBatchHeight * fBatchWidth + j * fBatchWidth + k;
+               buffer[bufferIndex] = event->GetValue(j * fBatchWidth + k);
+            }
+         }
+         sampleIterator++;
+      }
+   }
+   else {
+      Error("TTensorDataLoader","Inconsistency between batch depth and batch size");
+      R__ASSERT(0);
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TMVAInput_t, TCudnn<double> >::CopyTensorOutput(TCudaHostBuffer<double> &buffer,
+                                                                       IndexIterator_t sampleIterator)
+{
+   const DataSetInfo &info = std::get<1>(fData);
+   size_t n = buffer.GetSize() / fBatchSize;
+
+   // Copy target(s).
+
+   for (size_t i = 0; i < fBatchSize; i++) {
+      size_t sampleIndex = *sampleIterator++;
+      Event *event = std::get<0>(fData)[sampleIndex];
+      for (size_t j = 0; j < n; j++) {
+         // Copy output matrices.
+         size_t bufferIndex = j * fBatchSize + i;
+         // Classification
+         if (event->GetNTargets() == 0) {
+            if (n == 1) {
+               // Binary.
+               buffer[bufferIndex] = (info.IsSignal(event)) ? 1.0 : 0.0;
+            } else {
+               // Multiclass.
+               buffer[bufferIndex] = 0.0;
+               if (j == event->GetClass()) {
+                  buffer[bufferIndex] = 1.0;
+               }
+            }
+         } else {
+            buffer[bufferIndex] = static_cast<Double_t>(event->GetTarget(j));
+         }
+      }
+   }
+}
+
+//______________________________________________________________________________
+template <>
+void TTensorDataLoader<TMVAInput_t, TCudnn<double> >::CopyTensorWeights(TCudaHostBuffer<double> &buffer,
+                                                                        IndexIterator_t sampleIterator)
+{
+   for (size_t i = 0; i < fBatchSize; i++) {
+      size_t sampleIndex = *sampleIterator++;
+      Event *event = std::get<0>(fData)[sampleIndex];
+      buffer[i] = event->GetWeight();
+   }
+}
+
+#if 0
+//______________________________________________________________________________
+template <>
+TTensorBatch<TCudnn<float> > TTensorDataLoader<TensorInput, TCudnn<float> >::GetTensorBatch()
+{
+   // Get buffer tuple on device that contains the data
+   DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
+
+   std::vector<size_t> outputShape  {fBatchSize, 1, fNOutputFeatures, 1};
+   std::vector<size_t> wheightShape {fBatchSize, 1, 1, 1};
+   std::vector<TCudaTensor<float> > inputTensor(1, TCudaTensor<float>(std::get<0>(DeviceBuffers),
+                                                this->GetTensorDim(),  fInputShape));
+   TCudaTensor<float> outputMatrix(std::get<1>(DeviceBuffers), this->GetTensorDim(), outputShape);
+   TCudaTensor<float> weightMatrix(std::get<2>(DeviceBuffers), this->GetTensorDim(), wheightShape);
+
+   fBatchIndex++;
+   return TTensorBatch<TCudnn<float> >(inputTensor, outputMatrix, weightMatrix);
+}
+
+//______________________________________________________________________________
+template <>
+TTensorBatch<TCudnn<double> > TTensorDataLoader<TensorInput, TCudnn<double> >::GetTensorBatch()
+{
+   // Get buffer tuple on device that contains the data
+   DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
+
+   std::vector<size_t> outputShape  {fBatchSize, 1, fNOutputFeatures, 1};
+   std::vector<size_t> wheightShape {fBatchSize, 1, 1, 1};
+   std::vector<TCudaTensor<double> > inputTensor(1, TCudaTensor<double>(std::get<0>(DeviceBuffers),
+                                                 this->GetTensorDim(),  fInputShape));
+   TCudaTensor<double> outputMatrix(std::get<1>(DeviceBuffers), this->GetTensorDim(), outputShape);
+   TCudaTensor<double> weightMatrix(std::get<2>(DeviceBuffers), this->GetTensorDim(), wheightShape);
+
+   fBatchIndex++;
+   return TTensorBatch<TCudnn<double> >(inputTensor, outputMatrix, weightMatrix);
+}
+
+//______________________________________________________________________________
+template <>
+TTensorBatch<TCudnn<float> > TTensorDataLoader<TMVAInput_t, TCudnn<float> >::GetTensorBatch()
+{
+   // Get buffer tuple on device that contains the data
+   DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
+
+   std::vector<size_t> outputShape  {fBatchSize, 1, fNOutputFeatures, 1};
+   std::vector<size_t> wheightShape {fBatchSize, 1, 1, 1};
+   std::vector<TCudaTensor<float> > inputTensor(1, TCudaTensor<float>(std::get<0>(DeviceBuffers),
+                                                this->GetTensorDim(),  fInputShape));
+   TCudaTensor<float> outputMatrix(std::get<1>(DeviceBuffers), this->GetTensorDim(), outputShape);
+   TCudaTensor<float> weightMatrix(std::get<2>(DeviceBuffers), this->GetTensorDim(), wheightShape);
+
+   fBatchIndex++;
+   return TTensorBatch<TCudnn<float> >(inputTensor, outputMatrix, weightMatrix);
+}
+
+//______________________________________________________________________________
+template <>
+TTensorBatch<TCudnn<double> > TTensorDataLoader<TMVAInput_t, TCudnn<double> >::GetTensorBatch()
+{
+   // Get buffer tuple on device that contains the data
+   DeviceBufferTuple DeviceBuffers = CopyTensorBatches();
+
+   std::vector<size_t> outputShape  {fBatchSize, 1, fNOutputFeatures, 1};
+   std::vector<size_t> wheightShape {fBatchSize, 1, 1, 1};
+   std::vector<TCudaTensor<double> > inputTensor(1, TCudaTensor<double>(std::get<0>(DeviceBuffers),
+                                                 this->GetTensorDim(),  fInputShape));
+   TCudaTensor<double> outputMatrix(std::get<1>(DeviceBuffers), fNOutputFeatures + 2, outputShape);
+   TCudaTensor<double> weightMatrix(std::get<2>(DeviceBuffers), 3, wheightShape);
+
+   fBatchIndex++;
+   return TTensorBatch<TCudnn<double> >(inputTensor, outputMatrix, weightMatrix);
+}
+#endif
+
+
+//______________________________________________________________________________
+// Explicit Instantiations.
+
+template class TTensorDataLoader<TensorInput, TCudnn<float> >;
+template class TTensorDataLoader<TMVAInput_t, TCudnn<float> >;
+template class TTensorDataLoader<TensorInput, TCudnn<double> >;
+template class TTensorDataLoader<TMVAInput_t, TCudnn<double> >;
+
+} // TMVA
+} // DNN

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1642,7 +1642,11 @@ void MethodDL::Train()
    if (this->GetArchitectureString() == "GPU") {
 #ifdef R__HAS_TMVAGPU
       Log() << kINFO << "Start of deep neural network training on GPU." << Endl << Endl;
+#ifdef R__HAS_CUDNN
       TrainDeepNet<DNN::TCudnn<ScalarImpl_t> >();
+#else
+      TrainDeepNet<DNN::TCuda<ScalarImpl_t>>();
+#endif
 #else
       Log() << kFATAL << "CUDA backend not enabled. Please make sure "
          "you have CUDA installed and it was successfully "
@@ -2034,7 +2038,12 @@ std::vector<Double_t> MethodDL::GetMvaValues(Long64_t firstEvt, Long64_t lastEvt
    if (this->GetArchitectureString() == "GPU") {
 #ifdef R__HAS_TMVAGPU
       Log() << kINFO << "Evaluate deep neural network on GPU using batches with size = " <<  batchSize << Endl << Endl;
-      return PredictDeepNet<DNN::TCudnn<ScalarImpl_t> >(firstEvt, lastEvt, batchSize, logProgress);
+#ifdef R__HAS_CUDNN
+      return PredictDeepNet<DNN::TCudnn<ScalarImpl_t>>(firstEvt, lastEvt, batchSize, logProgress);
+#else
+      return PredictDeepNet<DNN::TCuda<ScalarImpl_t>>(firstEvt, lastEvt, batchSize, logProgress);
+#endif
+
 #endif
    } else if (this->GetArchitectureString() == "CPU") {
 //#ifdef R__HAS_TMVACPU

--- a/tmva/tmva/test/DNN/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/CMakeLists.txt
@@ -57,10 +57,8 @@ if (CUDA_FOUND AND tmva-gpu)
   TARGET_LINK_LIBRARIES(testBatchNormalizationCuda ${Libraries})
   ROOT_ADD_TEST(TMVA-DNN-BatchNormalization-Cuda COMMAND testBatchNormalizationCuda)
 
-   # DNN - Batch normalization Cudnn
-  CUDA_ADD_EXECUTABLE(testBatchNormalizationCudnn TestBatchNormalizationCudnn.cxx )
-  TARGET_LINK_LIBRARIES(testBatchNormalizationCudnn ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-BatchNormalization-Cudnn COMMAND testBatchNormalizationCudnn)
+
+
 
   # DNN - Minimization Cuda
   CUDA_ADD_EXECUTABLE(testMinimizationCuda TestMinimizationCuda.cxx)
@@ -84,16 +82,26 @@ if (CUDA_FOUND AND tmva-gpu)
    TARGET_LINK_LIBRARIES(testOptimizationCuda ${Libraries}  )
    ROOT_ADD_TEST(TMVA-DNN-Optimization-Cuda COMMAND testOptimizationCuda)
 
+#Cuda tests using CUDNN
+if (tmva-cudnn)
+
+   # DNN - Batch normalization Cudnn
+   CUDA_ADD_EXECUTABLE(testBatchNormalizationCudnn TestBatchNormalizationCudnn.cxx )
+   TARGET_LINK_LIBRARIES(testBatchNormalizationCudnn ${Libraries})
+   ROOT_ADD_TEST(TMVA-DNN-BatchNormalization-Cudnn COMMAND testBatchNormalizationCudnn)
+
    # DNN Optimization GPU Cudnn
 
-    CUDA_ADD_EXECUTABLE(testOptimizationCudnn TestOptimizationCudnn.cxx)
+   CUDA_ADD_EXECUTABLE(testOptimizationCudnn TestOptimizationCudnn.cxx)
    TARGET_LINK_LIBRARIES(testOptimizationCudnn ${Libraries}  )
    ROOT_ADD_TEST(TMVA-DNN-Optimization-Cudnn COMMAND testOptimizationCudnn)
 
-  # DNN - TensorDataLoader Cudnn
-  #CUDA_ADD_EXECUTABLE(testTensorDataLoaderCudnn TestTensorDataLoaderCudnn.cxx)
-  #TARGET_LINK_LIBRARIES(testTensorDataLoaderCudnn ${Libraries} ${DNN_CUDA_LIBRARIES})
-  #ROOT_ADD_TEST(TMVA-DNN-TensorDataLoaderCudnn COMMAND testTensorDataLoaderCudnn)
+   # DNN - TensorDataLoader Cudnn
+   #CUDA_ADD_EXECUTABLE(testTensorDataLoaderCudnn TestTensorDataLoaderCudnn.cxx)
+   #TARGET_LINK_LIBRARIES(testTensorDataLoaderCudnn ${Libraries} ${DNN_CUDA_LIBRARIES})
+   #ROOT_ADD_TEST(TMVA-DNN-TensorDataLoaderCudnn COMMAND testTensorDataLoaderCudnn)
+
+endif()
 
 endif ()
 

--- a/tmva/tmva/test/DNN/CNN/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/CNN/CMakeLists.txt
@@ -39,7 +39,6 @@ CUDA_ADD_EXECUTABLE(testForwardPassCuda TestForwardPassCuda.cxx)
 target_link_libraries(testForwardPassCuda ${Libraries} ${DNN_CUDA_LIBRARIES})
 ROOT_ADD_TEST(TMVA-DNN-CNN-ForwardCuda COMMAND testForwardPassCuda)
 
-
 CUDA_ADD_EXECUTABLE(testRotateWeightsCuda TestRotateWeightsCuda.cxx)
 target_link_libraries(testRotateWeightsCuda ${Libraries} ${DNN_CUDA_LIBRARIES})
 ROOT_ADD_TEST(TMVA-DNN-CNN-RotateWeightsCuda COMMAND testRotateWeightsCuda)
@@ -47,6 +46,12 @@ ROOT_ADD_TEST(TMVA-DNN-CNN-RotateWeightsCuda COMMAND testRotateWeightsCuda)
 CUDA_ADD_EXECUTABLE(testConvBackpropagationCuda TestConvBackpropagationCuda.cxx)
 target_link_libraries(testConvBackpropagationCuda ${Libraries} ${DNN_CUDA_LIBRARIES})
 ROOT_ADD_TEST(TMVA-DNN-CNN-ConvBackpropagationCuda COMMAND testConvBackpropagationCuda)
+
+if (tmva-cudnn)
+
+CUDA_ADD_EXECUTABLE(testForwardPassCudnn TestForwardPassCudnn.cxx)
+target_link_libraries(testForwardPassCudnn ${Libraries} ${DNN_CUDA_LIBRARIES})
+ROOT_ADD_TEST(TMVA-DNN-CNN-ForwardCudnn COMMAND testForwardPassCudnn)
 
 CUDA_ADD_EXECUTABLE(testConvBackpropagationCudnn TestConvBackpropagationCudnn.cxx)
 target_link_libraries(testConvBackpropagationCudnn ${Libraries} ${DNN_CUDA_LIBRARIES})
@@ -60,9 +65,12 @@ CUDA_ADD_EXECUTABLE(testPoolingLayerCudnn TestPoolingLayerCudnn.cxx)
 target_link_libraries(testPoolingLayerCudnn ${Libraries} ${DNN_CUDA_LIBRARIES})
 ROOT_ADD_TEST(TMVA-DNN-CNN-PoolingLayerCudnn COMMAND testPoolingLayerCudnn)
 
+# test mixed architecture Cudnn Cpu
 CUDA_ADD_EXECUTABLE(testMixedArchitectures TestMixedArchitectures.cxx)
 target_link_libraries(testMixedArchitectures ${Libraries} ${DNN_CUDA_LIBRARIES})
 ROOT_ADD_TEST(TMVA-DNN-CNN-MixedArchitectures COMMAND testMixedArchitectures)
+
+endif()
 
 include_directories(${ROOT_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS})
 

--- a/tmva/tmva/test/DNN/CNN/TestForwardPassCudnn.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestForwardPassCudnn.cxx
@@ -29,7 +29,7 @@
 ////////////////////////////////////////////////////////////////////
 
 #include <iostream>
-#include "TMVA/DNN/Architectures/Cuda.h"
+#include "TMVA/DNN/Architectures/TCudnn.h"
 
 #include "TestConvNet.h"
 
@@ -47,7 +47,7 @@ void test1()
    size_t batchHeight = imgDepthTest1;
    size_t batchWidth = imgHeightTest1 * imgWidthTest1;
 
-   testConvForwardPass<TCuda<float>>(batchSizeTest1, imgDepthTest1, imgHeightTest1, imgWidthTest1, batchDepth,
+   testConvForwardPass<TCudnn<float>>(batchSizeTest1, imgDepthTest1, imgHeightTest1, imgWidthTest1, batchDepth,
                                      batchHeight, batchWidth);
 }
 
@@ -62,13 +62,13 @@ void test2()
    size_t batchHeight = imgDepthTest2;
    size_t batchWidth = imgHeightTest2 * imgWidthTest2;
 
-   testConvForwardPass<TCuda<float>>(batchSizeTest2, imgDepthTest2, imgHeightTest2, imgWidthTest2, batchDepth,
+   testConvForwardPass<TCudnn<float>>(batchSizeTest2, imgDepthTest2, imgHeightTest2, imgWidthTest2, batchDepth,
                                      batchHeight, batchWidth);
 }
 
 int main()
 {
-   std::cout << "Testing CNN Forward Pass using Cuda:" << std::endl;
+   std::cout << "Testing CNN Forward Pass using Cudnn:" << std::endl;
 
    std::cout << "Test1" << std::endl;
    test1();

--- a/tmva/tmva/test/DNN/CNN/TestMethodDLCNN.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestMethodDLCNN.cxx
@@ -37,6 +37,9 @@ int main()
 
 #ifdef R__HAS_TMVAGPU
    std::cout << "Testing Method DL for GPU backend: " << std::endl;
+#ifdef R__HAS_CUDNN
+   std::cout << "Using cuDNN for the implementation of the convolution operators " << std::endl;
+#endif
 
    TString archGPU  = "GPU";
    testMethodDL_CNN(archGPU);

--- a/tmva/tmva/test/DNN/TestOptimizationCuda.cxx
+++ b/tmva/tmva/test/DNN/TestOptimizationCuda.cxx
@@ -25,7 +25,7 @@
  **********************************************************************************/
 
 #include "TestOptimization.h"
-#include "TMVA/DNN/Architectures/TCudnn.h"
+#include "TMVA/DNN/Architectures/Cuda.h"
 
 #include <iostream>
 


### PR DESCRIPTION
This PR fixes the bug ROOT-10597

We define a new configure preprocessor flag R__HAS_CUDNN that is set when Cudnn is found
If not set exclude all cudnn code in CudaTensor.cu and make sure that dense layers works in GPU without cudnn
Fix also the CNN for native Cuda. A bug was present creating the input tensor with TCuda architecture

Now ROOT/TMVA should compile when Cuda is on (tmva-gpu) and cudnn is not found.

Add also a new  cmake build option: cudnn. The option is by default enabled when cudsa is enabled.