### PR TITLE
[Exp PyROOT] Protect import of numpy in RBDT pythonization

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rbdt.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rbdt.py
@@ -10,7 +10,6 @@
 
 from ROOT import pythonization
 from libROOTPythonizations import AsRVec
-import numpy as np
 
 
 try:
@@ -21,6 +20,12 @@ except:
 
 
 def Compute(self, x):
+    # Import numpy lazily
+    try:
+        import numpy as np
+    except:
+        raise ImportError("Failed to import numpy during call of RBDT::Compute.")
+
     # numpy.array is a factory and the actual type of a numpy array is numpy.ndarray
     if isinstance(x, np.ndarray):
         if len(x.shape) == 1:


### PR DESCRIPTION
Prevent numpy from being imported every time the pythonizor function is registered, and instead do it lazily and with an error check if the pythonized method is actually invoked.