### PR TITLE
[skip-ci] better documentation for kOverwrite and Purge

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -751,6 +751,9 @@ void TObject::UseCurrentStyle()
 ///  Using the kWriteDelete option a previous key with the same name is
 ///  deleted only after the new object has been written. This option
 ///  is safer than kOverwrite but it is slower.
+///  NOTE: Neither kOverwrite nor kWriteDelete reduces the size of a TFile--
+///  only the metadata is replaced, effectively making the data invisible
+///  without deleting it.
 ///  The kSingleKey option is only used by TCollection::Write() to write
 ///  a container with a single key instead of each object in the container
 ///  with its own key.

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -753,7 +753,10 @@ void TObject::UseCurrentStyle()
 ///  is safer than kOverwrite but it is slower.
 ///  NOTE: Neither kOverwrite nor kWriteDelete reduces the size of a TFile--
 ///  the space is simply freed up to be overwritten; in the case of a TTree,
-///  only the metadata is replaced, effectively making the data invisible
+///  it is more complicated. If one opens a TTree, appends some entries,
+///  then writes it out, the behaviour is effectively the same. If, however,
+///  one creates a new TTree and writes it out in this way,
+///  only the metadata is replaced, effectively making the old data invisible
 ///  without deleting it.
 ///  The kSingleKey option is only used by TCollection::Write() to write
 ///  a container with a single key instead of each object in the container

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -752,6 +752,7 @@ void TObject::UseCurrentStyle()
 ///  deleted only after the new object has been written. This option
 ///  is safer than kOverwrite but it is slower.
 ///  NOTE: Neither kOverwrite nor kWriteDelete reduces the size of a TFile--
+///  the space is simply freed up to be overwritten; in the case of a TTree,
 ///  only the metadata is replaced, effectively making the data invisible
 ///  without deleting it.
 ///  The kSingleKey option is only used by TCollection::Write() to write

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -757,7 +757,8 @@ void TObject::UseCurrentStyle()
 ///  then writes it out, the behaviour is effectively the same. If, however,
 ///  one creates a new TTree and writes it out in this way,
 ///  only the metadata is replaced, effectively making the old data invisible
-///  without deleting it.
+///  without deleting it. TTree::Delete() can be used to mark all disk space
+///  occupied by a TTree as free before overwriting its metadata this way.
 ///  The kSingleKey option is only used by TCollection::Write() to write
 ///  a container with a single key instead of each object in the container
 ///  with its own key.

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1232,6 +1232,9 @@ TDirectory *TDirectoryFile::mkdir(const char *name, const char *title, Bool_t re
 ///
 /// By default, only the highest cycle of a key is kept. Keys for which
 /// the "KEEP" flag has been set are not removed. See TKey::Keep().
+/// NOTE: This does not reduce the size of a TFile--
+/// only the metadata is replaced, effectively making the data invisible
+/// without deleting it.
 
 void TDirectoryFile::Purge(Short_t)
 {

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1233,9 +1233,7 @@ TDirectory *TDirectoryFile::mkdir(const char *name, const char *title, Bool_t re
 /// By default, only the highest cycle of a key is kept. Keys for which
 /// the "KEEP" flag has been set are not removed. See TKey::Keep().
 /// NOTE: This does not reduce the size of a TFile--
-/// the space is simply freed up to be overwritten; in the case of a TTree,
-/// only the metadata is replaced, effectively making the data invisible
-/// without deleting it.
+/// the space is simply freed up to be overwritten.
 
 void TDirectoryFile::Purge(Short_t)
 {

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1233,6 +1233,7 @@ TDirectory *TDirectoryFile::mkdir(const char *name, const char *title, Bool_t re
 /// By default, only the highest cycle of a key is kept. Keys for which
 /// the "KEEP" flag has been set are not removed. See TKey::Keep().
 /// NOTE: This does not reduce the size of a TFile--
+/// the space is simply freed up to be overwritten; in the case of a TTree,
 /// only the metadata is replaced, effectively making the data invisible
 /// without deleting it.
 


### PR DESCRIPTION
When calling `TObject::kOverwrite`, the data itself is not actually replaced--the metadata is changed to avoid multiple cycles, but the data persists invisibly. Similar for `Purge`. This documents that behavior.