### PR TITLE
Fix handling of cuda and cudnn in make

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1431,6 +1431,9 @@ if(cuda OR tmva-gpu)
 
     enable_language(CUDA)
 
+    set(cuda ON CACHE BOOL "Found Cuda for TMVA GPU" FORCE)
+
+
     ### look for package CuDNN
     if (cudnn )
       find_package(CuDNN)
@@ -1449,6 +1452,8 @@ if(cuda OR tmva-gpu)
     message(FATAL_ERROR "CUDA not found. Ensure that the installation of CUDA is in the CMAKE_PREFIX_PATH")
   endif()
 
+else()
+  set(cudnn OFF)
 endif()
 
 #---TMVA and its dependencies------------------------------------------------------------


### PR DESCRIPTION
 - when cuda or tmva-gpu is on : look by default for cuda and cudnn
 - if cuda is not found set tmva-gpu to OFF
 - if cudnn is not found set tmva-cudnn to OFF

- if cuda is OFF set also cudnn to OFF