### PR TITLE
Split RColor on RColor and RAttrColor

### DIFF
--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -21,6 +21,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RAttrBase.hxx
     ROOT/RAttrAxis.hxx
     ROOT/RAttrBox.hxx
+    ROOT/RAttrColor.hxx
     ROOT/RAttrLine.hxx
     ROOT/RAttrFill.hxx
     ROOT/RAttrMarker.hxx

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -69,6 +69,7 @@
 #pragma read sourceClass="ROOT::Experimental::RCanvas" targetClass="ROOT::Experimental::RCanvas" source="" target="" code="{ newObj->ResolveSharedPtrs() ; }"
 
 #pragma link C++ class ROOT::Experimental::RColor+;
+#pragma link C++ class ROOT::Experimental::RAttrColor+;
 #pragma link C++ class ROOT::Experimental::RAttrFill+;
 #pragma link C++ class ROOT::Experimental::RAttrLine+;
 #pragma link C++ class ROOT::Experimental::RAttrBox+;

--- a/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -36,6 +36,7 @@ class RAttrColor : public RAttrBase {
                  AddString("rgb", "").AddString("a", "").AddString("name", "").AddBool("auto", false));
 
 protected:
+
    /** Set color as plain SVG name like "white" or "lightblue". Clears RGB component before */
    void SetName(const std::string &_name) { SetValue("name", _name); }
 
@@ -51,6 +52,7 @@ protected:
    /** Set color as hex string like 00FF00 */
    void SetHex(const std::string &_hex) { SetValue("rgb", _hex); }
 
+   /** Remove color hex value */
    void ClearHex() { ClearValue("rgb"); }
 
    /** Returns true if color hex value was  specified */
@@ -65,9 +67,10 @@ protected:
    /** Set color alpha (opacity) value - from 0 to 1 */
    void SetAlpha(float alpha) { return SetAlphaHex(RColor::toHex((uint8_t)(alpha * 255))); }
 
-   /** Set color alpha (opacity) value - from 0 to 1 */
+   /** Set color alpha (opacity) value as hex */
    void SetAlphaHex(const std::string &val) { SetValue("a", val); }
 
+   /** Remove color alpha value */
    void ClearAlpha() { ClearValue("a"); }
 
 public:
@@ -88,6 +91,7 @@ public:
 
    }
 
+   /** Extract RColor for given attribute */
    RColor GetColor() const
    {
       RColor res;
@@ -101,6 +105,7 @@ public:
       return res;
    }
 
+   /** Remove all values which can correspond to RColor value */
    void Clear()
    {
       ClearHex();

--- a/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
@@ -1,0 +1,140 @@
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RAttrColor
+#define ROOT7_RAttrColor
+
+#include <ROOT/RAttrBase.hxx>
+
+#include <ROOT/RColor.hxx>
+
+#include <array>
+
+namespace ROOT {
+namespace Experimental {
+
+// TODO: see also imagemagick's C++ interface for RColor operations!
+// https://www.imagemagick.org/api/magick++-classes.php
+
+/** \class RAttrColor
+\ingroup GpadROOT7
+\brief Access RColor from drawable attributes
+\author Sergey Linev <S.Linev@gsi.de>
+\date 2020-03-09
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
+*/
+
+class RAttrColor : public RAttrBase {
+
+   R__ATTR_CLASS(RAttrColor, "color_",
+                 AddString("rgb", "").AddString("a", "").AddString("name", "").AddBool("auto", false));
+
+protected:
+   /** Set color as plain SVG name like "white" or "lightblue". Clears RGB component before */
+   void SetName(const std::string &_name) { SetValue("name", _name); }
+
+   /** Returns color as plain SVG name like "white" or "lightblue" */
+   std::string GetName() const { return GetValue<std::string>("name"); }
+
+   /** Clear color plain SVG name (if any) */
+   void ClearName() { ClearValue("name"); }
+
+   /** Returns true if color name was  specified */
+   bool HasName() const { return HasValue("name"); }
+
+   /** Set color as hex string like 00FF00 */
+   void SetHex(const std::string &_hex) { SetValue("rgb", _hex); }
+
+   void ClearHex() { ClearValue("rgb"); }
+
+   /** Returns true if color hex value was  specified */
+   bool HasHex() const { return HasValue("rgb"); }
+
+   /** Returns color alpha (opacity) as hex string like FF. Default is empty */
+   std::string GetAlphaHex() const { return GetValue<std::string>("a"); }
+
+   /** Returns true if color alpha (opacity) was specified */
+   bool HasAlpha() const { return HasValue("a"); }
+
+   /** Set color alpha (opacity) value - from 0 to 1 */
+   void SetAlpha(float alpha) { return SetAlphaHex(RColor::toHex((uint8_t)(alpha * 255))); }
+
+   /** Set color alpha (opacity) value - from 0 to 1 */
+   void SetAlphaHex(const std::string &val) { SetValue("a", val); }
+
+   void ClearAlpha() { ClearValue("a"); }
+
+public:
+   /** Set r/g/b components of color as hex code, default for the color */
+   RAttrColor &SetColor(const RColor &col)
+   {
+      Clear();
+
+      if (!col.GetName().empty()) {
+         SetName(col.GetName());
+      } else {
+         auto rgba = col.GetRGBA();
+         if (rgba.size() > 2) SetHex(RColor::toHex(rgba[0]) + RColor::toHex(rgba[1]) + RColor::toHex(rgba[2]));
+         if (rgba.size() == 4) SetAlphaHex(RColor::toHex(rgba[3]));
+      }
+
+      return *this;
+
+   }
+
+   RColor GetColor() const
+   {
+      RColor res;
+      if (HasName())
+         res.SetName(GetName());
+      else if (HasHex()) {
+         res.SetRGBHex(GetHex());
+         if (HasAlpha())
+            res.SetAlphaHex(GetAlphaHex());
+      }
+      return res;
+   }
+
+   void Clear()
+   {
+      ClearHex();
+      ClearAlpha();
+      ClearName();
+      ClearAuto();
+   }
+
+   /** Return color as hex string like 00FF00 */
+   std::string GetHex() const { return GetValue<std::string>("rgb"); }
+
+
+   /** Returns true if color should get auto value when primitive drawing is performed */
+   bool IsAuto() const { return GetValue<bool>("auto"); }
+
+   /** Set automatic mode for RAttrColor, will be assigned before primitive painted on the canvas */
+   void SetAuto(bool on = true) { SetValue("auto", on); }
+
+   /** Clear auto flag of the RAttrColor */
+   void ClearAuto() { ClearValue("auto"); }
+
+
+   friend bool operator==(const RAttrColor &lhs, const RAttrColor &rhs) { return lhs.GetColor() == rhs.GetColor(); }
+
+
+   RAttrColor &operator=(const RColor &col)
+   {
+      SetColor(col);
+      return *this;
+   }
+
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
@@ -10,7 +10,7 @@
 #define ROOT7_RAttrFill
 
 #include <ROOT/RAttrBase.hxx>
-#include <ROOT/RColor.hxx>
+#include <ROOT/RAttrColor.hxx>
 
 namespace ROOT {
 namespace Experimental {
@@ -25,7 +25,7 @@ namespace Experimental {
 
 class RAttrFill : public RAttrBase {
 
-   RColor fColor{this, "color_"}; ///<! line color, will access container from line attributes
+   RAttrColor fColor{this, "color_"}; ///<! line color, will access container from line attributes
 
    R__ATTR_CLASS(RAttrFill, "fill_", AddInt("style", 1).AddDefaults(fColor));
 
@@ -35,8 +35,8 @@ class RAttrFill : public RAttrBase {
 
    ///The fill color
    RAttrFill &SetColor(const RColor &color) { fColor = color; return *this; }
-   const RColor &GetColor() const { return fColor; }
-   RColor &Color() { return fColor; }
+   RColor GetColor() const { return fColor.GetColor(); }
+   RAttrColor &AttrColor() { return fColor; }
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
@@ -10,7 +10,7 @@
 #define ROOT7_RAttrLine
 
 #include <ROOT/RAttrBase.hxx>
-#include <ROOT/RColor.hxx>
+#include <ROOT/RAttrColor.hxx>
 
 namespace ROOT {
 namespace Experimental {
@@ -25,7 +25,7 @@ namespace Experimental {
 
 class RAttrLine : public RAttrBase {
 
-   RColor fColor{this, "color_"}; ///<! line color, will access container from line attributes
+   RAttrColor fColor{this, "color_"}; ///<! line color, will access container from line attributes
 
    R__ATTR_CLASS(RAttrLine, "line_", AddDouble("width", 1.).AddInt("style", 1).AddDefaults(fColor));
 
@@ -44,8 +44,8 @@ class RAttrLine : public RAttrBase {
 
    ///The color of the line.
    RAttrLine &SetColor(const RColor &color) { fColor = color; return *this; }
-   const RColor &GetColor() const { return fColor; }
-   RColor &Color() { return fColor; }
+   RColor GetColor() const { return fColor.GetColor(); }
+   RAttrColor &AttrColor() { return fColor; }
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
@@ -10,7 +10,7 @@
 #define ROOT7_RAttrMarker
 
 #include <ROOT/RAttrBase.hxx>
-#include <ROOT/RColor.hxx>
+#include <ROOT/RAttrColor.hxx>
 
 namespace ROOT {
 namespace Experimental {
@@ -25,13 +25,13 @@ namespace Experimental {
 
 class RAttrMarker : public RAttrBase {
 
-   RColor fColor{this, "color_"}; ///<! marker color, will access container from line attributes
+   RAttrColor fColor{this, "color_"}; ///<! marker color, will access container from line attributes
 
    R__ATTR_CLASS(RAttrMarker, "marker_", AddDouble("size", 1.).AddInt("style", 1).AddDefaults(fColor));
 
    RAttrMarker &SetColor(const RColor &color) { fColor = color; return *this; }
-   const RColor &GetColor() const { return fColor; }
-   RColor &Color() { return fColor; }
+   RColor GetColor() const { return fColor.GetColor(); }
+   RAttrColor &AttrColor() { return fColor; }
 
    /// The size of the marker.
    RAttrMarker &SetSize(float size) { SetValue("size", size); return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -10,7 +10,7 @@
 #define ROOT7_RAttrText
 
 #include <ROOT/RAttrBase.hxx>
-#include <ROOT/RColor.hxx>
+#include <ROOT/RAttrColor.hxx>
 
 #include <string>
 
@@ -28,7 +28,7 @@ namespace Experimental {
 
 class RAttrText : public RAttrBase {
 
-   RColor fColor{this, "color_"}; ///<! text color, will access container from text attributes
+   RAttrColor fColor{this, "color_"}; ///<! text color, will access container from text attributes
 
    R__ATTR_CLASS(RAttrText, "text_", AddDouble("size", 12.).AddDouble("angle", 0.).AddInt("align", 22).AddInt("font", 41).AddDefaults(fColor));
 
@@ -50,8 +50,8 @@ class RAttrText : public RAttrBase {
 
    ///The color of the text.
    RAttrText &SetColor(const RColor &color) { fColor = color; return *this; }
-   const RColor &GetColor() const { return fColor; }
-   RColor &Color() { return fColor; }
+   RColor GetColor() const { return fColor.GetColor(); }
+   RAttrColor &AttrColor() { return fColor; }
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RColor.hxx
@@ -202,12 +202,24 @@ public:
       fName.clear();
    }
 
-   static constexpr RGB_t kRed{{255, 0, 0}};
-   static constexpr RGB_t kGreen{{0, 255, 0}};
-   static constexpr RGB_t kBlue{{0, 0, 255}};
-   static constexpr RGB_t kWhite{{255, 255, 255}};
    static constexpr RGB_t kBlack{{0, 0, 0}};
+   static constexpr RGB_t kGreen{{0, 0x80, 0}};
+   static constexpr RGB_t kLime{{0, 0xFF, 0}};
+   static constexpr RGB_t kAqua{{0, 0xFF, 0xFF}};
+   static constexpr RGB_t kPurple{{0x80, 0, 0x80}};
+   static constexpr RGB_t kGrey{{0x80, 0x80, 0x80}};
+   static constexpr RGB_t kFuchsia{{0xFF, 0, 0xFF}};
+   static constexpr RGB_t kNavy{{0, 0, 0x80}};
+   static constexpr RGB_t kBlue{{0, 0, 0xff}};
+   static constexpr RGB_t kTeal{{0, 0x80, 0x80}};
+   static constexpr RGB_t kOlive{{0x80, 0x80, 0}};
+   static constexpr RGB_t kSilver{{0xc0, 0xc0, 0xc0}};
+   static constexpr RGB_t kMaroon{{0x80, 0, 0}};
+   static constexpr RGB_t kRed{{0xff, 0, 0}};
+   static constexpr RGB_t kYellow{{0xff, 0xff, 0}};
+   static constexpr RGB_t kWhite{{0xff, 0xff, 0xff}};
    static constexpr float kTransparent{0.};
+   static constexpr float kSemiTransparent{0.5};
    static constexpr float kOpaque{1.};
 
    friend bool operator==(const RColor &lhs, const RColor &rhs)

--- a/graf2d/gpadv7/inc/ROOT/RColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RColor.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -14,11 +14,10 @@
 #include <string>
 #include <array>
 
-
-class RAttrColor;
-
 namespace ROOT {
 namespace Experimental {
+
+class RAttrColor;
 
 // TODO: see also imagemagick's C++ interface for RColor operations!
 // https://www.imagemagick.org/api/magick++-classes.php
@@ -92,19 +91,18 @@ public:
       SetAlpha(alpha);
    }
 
+   /** Set alpha as float value from range 0..1 */
    void SetAlphaFloat(float alpha)
    {
-      uint8_t v = 0;
       if (alpha <= 0.)
-         v  = 0;
+         SetAlpha(0);
       else if (alpha >= 1.)
-         v  = 255;
+         SetAlpha(255);
       else
-         v  = (uint8_t) (alpha * 255);
-
-      SetAlpha(v);
+         SetAlpha((uint8_t)(alpha * 255));
    }
 
+   /** Set alpha as value from range 0..255 */
    void SetAlpha(uint8_t alpha)
    {
       if (fRGBA.empty()) {
@@ -124,8 +122,10 @@ public:
    /** Returns true if no color is specified */
    bool IsEmpty() const { return fName.empty() && (fRGBA.size() == 0); }
 
+   /** Returns color as RGBA array - when exists */
    const std::vector<uint8_t> &GetRGBA() const { return fRGBA; }
 
+   /** Returns color as RGBA array, trying also convert color name into RGBA value */
    std::vector<uint8_t> AsRGBA() const;
 
    /** Returns red color component 0..255 */
@@ -133,6 +133,7 @@ public:
    {
       if (fRGBA.size() > 2)
          return fRGBA[0];
+
       std::vector<uint8_t> rgb;
       return ConvertToRGB(fName, rgb) ? rgb[0] : 0;
    }
@@ -157,20 +158,20 @@ public:
       return ConvertToRGB(fName, rgb) ? rgb[2] : 0;
    }
 
-   /** Returns color alpha (opacity) as float from 0. to 1. */
+   /** Returns color alpha (opacity) as uint8_t 0..255 */
    uint8_t GetAlpha() const
    {
       if (fRGBA.size() > 0)
          return fRGBA.size() == 4 ? fRGBA[3] : 255;
 
       std::vector<uint8_t> rgba;
-      if (ConvertToRGB(fName, rgba) && rgba.size() == 3)
+      if (ConvertToRGB(fName, rgba) && (rgba.size() == 3))
          return rgba[3];
 
       return 255;
    }
 
-   /** Returns color alpha (opacity) as float from 0. to 1. */
+   /** Returns color alpha (opacity) as float from 0..1 */
    float GetAlphaFloat() const
    {
       return GetAlpha() / 255.;

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -17,9 +17,10 @@
 #include "ROOT/RAttrAxis.hxx"
 
 #include "ROOT/RPadUserAxis.hxx"
-#include "ROOT/RPalette.hxx"
 
 #include <memory>
+
+class TRootIOCtor;
 
 namespace ROOT {
 namespace Experimental {
@@ -47,13 +48,8 @@ private:
    /// Mapping of user coordinates to normal coordinates, one entry per dimension.
    std::vector<std::unique_ptr<RPadUserAxisBase>> fUserCoord;
 
-   /// Palette used to visualize user coordinates.
-   RPalette fPalette;
-
    RFrame(const RFrame &) = delete;
    RFrame &operator=(const RFrame &) = delete;
-
-public:
 
    // Default constructor
    RFrame() : RDrawable("frame")
@@ -63,6 +59,10 @@ public:
 
    /// Constructor taking user coordinate system, position and extent.
    explicit RFrame(std::vector<std::unique_ptr<RPadUserAxisBase>> &&coords);
+
+public:
+
+   RFrame(TRootIOCtor*) : RFrame() {}
 
    const RAttrMargins &GetMargins() const { return fMargins; }
    RFrame &SetMargins(const RAttrMargins &margins) { fMargins = margins; return *this; }

--- a/graf2d/gpadv7/src/RColor.cxx
+++ b/graf2d/gpadv7/src/RColor.cxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/graf2d/gpadv7/src/RColor.cxx
+++ b/graf2d/gpadv7/src/RColor.cxx
@@ -8,16 +8,30 @@
 
 #include "ROOT/RColor.hxx"
 
+#include <unordered_map>
+
 using namespace ROOT::Experimental;
 
 using namespace std::string_literals;
 
-constexpr RColor::RGB_t RColor::kRed;
-constexpr RColor::RGB_t RColor::kGreen;
-constexpr RColor::RGB_t RColor::kBlue;
-constexpr RColor::RGB_t RColor::kWhite;
 constexpr RColor::RGB_t RColor::kBlack;
+constexpr RColor::RGB_t RColor::kGreen;
+constexpr RColor::RGB_t RColor::kLime;
+constexpr RColor::RGB_t RColor::kAqua;
+constexpr RColor::RGB_t RColor::kPurple;
+constexpr RColor::RGB_t RColor::kGrey;
+constexpr RColor::RGB_t RColor::kFuchsia;
+constexpr RColor::RGB_t RColor::kNavy;
+constexpr RColor::RGB_t RColor::kBlue;
+constexpr RColor::RGB_t RColor::kTeal;
+constexpr RColor::RGB_t RColor::kOlive;
+constexpr RColor::RGB_t RColor::kSilver;
+constexpr RColor::RGB_t RColor::kMaroon;
+constexpr RColor::RGB_t RColor::kRed;
+constexpr RColor::RGB_t RColor::kYellow;
+constexpr RColor::RGB_t RColor::kWhite;
 constexpr float RColor::kTransparent;
+constexpr float RColor::kSemiTransparent;
 constexpr float RColor::kOpaque;
 
 
@@ -31,16 +45,55 @@ bool RColor::ConvertToRGB(const std::string &name, std::vector<uint8_t> &rgba)
       return false;
    }
 
+   if (name[0] == '#') {
+      if ((name.length() != 7) && (name.length() != 9)) return false;
+
+      rgba.resize((name.length() == 7) ? 3 : 4);
+
+      try {
+        rgba[0] = std::stoi(name.substr(1,2), nullptr, 16);
+        rgba[1] = std::stoi(name.substr(3,2), nullptr, 16);
+        rgba[2] = std::stoi(name.substr(5,2), nullptr, 16);
+        if (name.length() == 9)
+           rgba[3] = std::stoi(name.substr(7,2), nullptr, 16);
+      } catch(...) {
+         return false;
+      }
+
+      return true;
+   }
+
+   // see https://www.december.com/html/spec/colorsvghex.html
+
+   static std::unordered_map<std::string,RGB_t> known_colors = {
+      {"black", kWhite},
+      {"green", kGreen},
+      {"lime", kLime},
+      {"aqua", kAqua},
+      {"purple", kPurple},
+      {"grey", kGrey},
+      {"fuchsia", kFuchsia},
+      {"navy", kNavy},
+      {"blue", kBlue},
+      {"teal", kTeal},
+      {"olive", kOlive},
+      {"silver", kSilver},
+      {"maroon", kMaroon},
+      {"red", kRed},
+      {"yellow", kYellow},
+      {"white", kWhite}
+   };
+
    rgba.resize(3);
    rgba[0] = rgba[1] = rgba[2] = 0;
 
-   if (name == "red") { rgba[0] = 255; rgba[1] = 0; rgba[2] = 0; }
-   else if (name == "green") { rgba[0] = 0; rgba[1] = 255; rgba[2] = 0; }
-   else if (name == "blue") { rgba[0] = 0; rgba[1] = 0; rgba[2] = 255; }
-   else if (name == "black") { rgba[0] = rgba[1] = rgba[2] = 0; }
-   else if (name == "white") { rgba[0] = rgba[1] = rgba[2] = 255; }
-   else if (name == "grey") { rgba[0] = rgba[1] = rgba[2] = 127; }
-   else return false;
+   auto known = known_colors.find(name);
+   if (known != known_colors.end()) {
+      rgba[0] = known->second[0];
+      rgba[1] = known->second[1];
+      rgba[2] = known->second[2];
+      return true;
+   }
 
    return true;
 }
@@ -66,9 +119,13 @@ bool RColor::SetRGBHex(const std::string &hex)
 {
    if (hex.length() != 6) return false;
 
-   SetRGB( std::stoi(hex.substr(0,2), nullptr, 16),
-           std::stoi(hex.substr(2,2), nullptr, 16),
-           std::stoi(hex.substr(4,2), nullptr, 16));
+   try {
+      SetRGB( std::stoi(hex.substr(0,2), nullptr, 16),
+              std::stoi(hex.substr(2,2), nullptr, 16),
+              std::stoi(hex.substr(4,2), nullptr, 16));
+   } catch (...) {
+      return false;
+   }
    return true;
 }
 

--- a/graf2d/gpadv7/src/RFrame.cxx
+++ b/graf2d/gpadv7/src/RFrame.cxx
@@ -19,8 +19,7 @@
 
 ROOT::Experimental::RFrame::RFrame(std::vector<std::unique_ptr<RPadUserAxisBase>> &&coords) : RFrame()
 {
-   fUserCoord=  std::move(coords);
-   fPalette = RPalette::GetPalette("default");
+   fUserCoord = std::move(coords);
 }
 
 void ROOT::Experimental::RFrame::Execute(const std::string &arg)

--- a/graf2d/gpadv7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/src/RPadBase.cxx
@@ -99,7 +99,7 @@ void ROOT::Experimental::RPadBase::AssignAutoColors()
               case 1: col = RColor::kGreen; break;
               case 2: col = RColor::kBlue; break;
             }
-            drawable->fAttr.AddString(attr.first.substr(0,pos) + "_color_rgb", col.GetHex());
+            drawable->fAttr.AddString(attr.first.substr(0,pos) + "_color_rgb", col.AsHex());
          }
       }
    }

--- a/graf2d/gpadv7/test/rcolor.cxx
+++ b/graf2d/gpadv7/test/rcolor.cxx
@@ -18,8 +18,8 @@ using namespace ROOT::Experimental;
 // Test usage of empty color
 TEST(RColor, Empty) {
    RColor col;
-   EXPECT_EQ(col.GetHex(), "");
-   EXPECT_DOUBLE_EQ(col.GetAlpha(), 1.);
+   EXPECT_EQ(col.AsHex(), "");
+   EXPECT_FLOAT_EQ(col.GetAlphaFloat(), 1.);
    EXPECT_EQ(col.GetName(), "");
 }
 
@@ -27,19 +27,19 @@ TEST(RColor, Empty) {
 TEST(RColor, AsHex) {
    RColor col;
    col.SetRGB(0,0,0);
-   EXPECT_EQ(col.GetHex(), "000000");
+   EXPECT_EQ(col.AsHex(), "000000");
    col.SetRGB(1,7,15);
-   EXPECT_EQ(col.GetHex(), "01070F");
+   EXPECT_EQ(col.AsHex(), "01070F");
    col.SetRGB(127,127,127);
-   EXPECT_EQ(col.GetHex(), "7F7F7F");
+   EXPECT_EQ(col.AsHex(), "7F7F7F");
    col.SetRGB(255,255,255);
-   EXPECT_EQ(col.GetHex(), "FFFFFF");
+   EXPECT_EQ(col.AsHex(), "FFFFFF");
 }
 
-// Test usage of empty color
+// Test usage of color components
 TEST(RColor, Components) {
    RColor col;
-   col.SetHex("012345");
+   col.SetRGB(0x01, 0x23, 0x45);
    EXPECT_EQ(col.GetRed(), 0x01);
    EXPECT_EQ(col.GetGreen(), 0x23);
    EXPECT_EQ(col.GetBlue(), 0x45);
@@ -50,34 +50,35 @@ TEST(RColor, Alpha) {
    static constexpr double delta = 0.01; // approx precision of alpha storage
 
    RColor col;
-   col.SetAlpha(0);
-   EXPECT_DOUBLE_EQ(col.GetAlpha(), 0.);
+   col.SetAlphaFloat(0.);
+   EXPECT_DOUBLE_EQ(col.GetAlphaFloat(), 0.);
 
-   col.SetAlpha(1);
-   EXPECT_DOUBLE_EQ(col.GetAlpha(), 1.);
+   col.SetAlphaFloat(1.);
+   EXPECT_DOUBLE_EQ(col.GetAlphaFloat(), 1.);
 
-   col.SetAlpha(0.1);
-   EXPECT_NEAR(0.1,col.GetAlpha(), delta);
+   col.SetAlphaFloat(0.1);
+   EXPECT_NEAR(0.1,col.GetAlphaFloat(), delta);
 
-   col.SetAlpha(0.5);
-   EXPECT_NEAR(0.5,col.GetAlpha(), delta);
+   col.SetAlphaFloat(0.5);
+   EXPECT_NEAR(0.5,col.GetAlphaFloat(), delta);
 
-   col.SetAlpha(0.8);
-   EXPECT_NEAR(0.8,col.GetAlpha(), delta);
+   col.SetAlphaFloat(0.8);
+   EXPECT_NEAR(0.8,col.GetAlphaFloat(), delta);
 }
 
 
 TEST(RColor, Predef) {
    {
       RColor col{RColor::kRed};
-      EXPECT_EQ(col.GetHex(), "FF0000");
+      EXPECT_EQ(col.AsHex(), "FF0000");
       EXPECT_EQ(col.HasAlpha(), false);
    }
 
    {
       RColor col{RColor::kBlue};
       col.SetAlpha(RColor::kTransparent);
-      EXPECT_EQ(col.GetHex(), "0000FF");
-      EXPECT_FLOAT_EQ(col.GetAlpha(), 0.);
+      EXPECT_EQ(col.AsHex(), "0000FF");
+      EXPECT_EQ(col.HasAlpha(), true);
+      EXPECT_FLOAT_EQ(col.GetAlphaFloat(), 0.);
    }
 }

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -18,7 +18,6 @@ TEST(Primitives, RBox)
    box->AttrBox().AttrBorder().SetColor(RColor::kRed).SetWidth(5.).SetStyle(7);
    box->AttrBox().AttrFill().SetColor(RColor::kBlue).SetStyle(6);
 
-
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(box->GetAttrBox().GetAttrBorder().GetColor(), RColor::kRed);
@@ -87,9 +86,9 @@ TEST(Primitives, SameColor)
    auto line2 = canv.Draw<RLine>(RPadPos(0.1_normal, 0.9_normal), RPadPos(0.9_normal,0.1_normal));
    auto line3 = canv.Draw<RLine>(RPadPos(0.9_normal, 0.1_normal), RPadPos(0.1_normal,0.9_normal));
 
-   line1->AttrLine().Color().SetAuto();
-   line2->AttrLine().Color().SetAuto();
-   line3->AttrLine().Color().SetAuto();
+   line1->AttrLine().AttrColor().SetAuto();
+   line2->AttrLine().AttrColor().SetAuto();
+   line3->AttrLine().AttrColor().SetAuto();
 
    canv.AssignAutoColors();
 


### PR DESCRIPTION
RColor is pure color storage - RGBA or name.
RAttrColor is attribute class to extract colors from RDrawable attributes
Should simplify code. Provide several more "well-known" colors.