### PR TITLE
Renormalize fitted parameters error when using the option "W"  in TH1::Fit

### DIFF
--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -244,6 +244,8 @@ TFitResultPtr HFit::Fit(FitObject * h1, TF1 *f1 , Foption_t & fitOption , const 
 
    // error normalization in case of zero error in the data
    if (fitdata->GetErrorType() == ROOT::Fit::BinData::kNoError) fitConfig.SetNormErrors(true);
+   // error normalization also in case of W1 option (weights = 1)
+   if (fitdata->Opt().fErrors1)  fitConfig.SetNormErrors(true);
    // normalize errors also in case you are fitting a Ndim histo with a N-1 function
    if (int(fitdata->NDim())  == hdim -1 ) fitConfig.SetNormErrors(true);
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3826,6 +3826,9 @@ TFitResultPtr TH1::Fit(const char *fname ,Option_t *option ,Option_t *goption, D
 ///        -  "L"  Use Loglikelihood method (default is chisquare method)
 ///        - "WL" Use Loglikelihood method and bin contents are not integer,
 ///          i.e. histogram is weighted (must have Sumw2() set)
+///        -"MULTI" Use Loglikelihood method based on multi-nomial distribution.
+///              In this case function must be normalized and one fits only the function shape (a not extended binned
+///              likelihood fit)
 ///        - "P"  Use Pearson chi2 (using expected errors instead of observed errors)
 ///        - "U"  Use a User specified fitting algorithm (via SetFCN)
 ///        - "Q"  Quiet mode (minimum printing)
@@ -3895,12 +3898,13 @@ TFitResultPtr TH1::Fit(const char *fname ,Option_t *option ,Option_t *goption, D
 /// When the lower limit and upper limit are equal, the parameter is fixed.
 /// However to fix a parameter to 0, one must call the FixParameter function.
 ///
-/// Note that option "I" gives better results but is slower.
 ///
 /// #### Changing the fitting objective function
 ///
 /// By default a chi square function is used for fitting. When option "L" (or "LL") is used
 /// a Poisson likelihood function (see note below) is used.
+/// Using option "MULTI" a multinomial likelihood fit is used. In this case the function normalization is not fitted
+/// but only the function shape. Therefore the provided function must be normalized.
 /// The functions are defined in the header Fit/Chi2Func.h or Fit/PoissonLikelihoodFCN and they
 /// are implemented using the routines FitUtil::EvaluateChi2 or FitUtil::EvaluatePoissonLogL in
 /// the file math/mathcore/src/FitUtil.cxx.
@@ -3927,9 +3931,9 @@ TFitResultPtr TH1::Fit(const char *fname ,Option_t *option ,Option_t *goption, D
 /// \f]
 ///
 /// where y(i) is the bin content for each bin i, x(i) is the bin center and e(i) is the bin error (sqrt(y(i) for
-/// an un-weighted histogram. Bins with zero errors are excluded from the fit. See also later the note on the treatment of empty bins.
-/// When using option "I" the residual is computed not using the function value at the bin center, f (x(i) | p), but the integral
-/// of the function in the bin,   Integral{ f(x|p)dx } divided by the bin volume
+/// an un-weighted histogram. Bins with zero errors are excluded from the fit. See also later the note on the treatment
+/// of empty bins. When using option "I" the residual is computed not using the function value at the bin center, f
+/// (x(i) | p), but the integral of the function in the bin,   Integral{ f(x|p)dx } divided by the bin volume
 ///
 /// #### Likelihood Fits
 ///
@@ -3967,14 +3971,18 @@ TFitResultPtr TH1::Fit(const char *fname ,Option_t *option ,Option_t *goption, D
 /// Note that if the histogram is having bins with zero content and non zero-errors they are considered as
 /// any other bins in the fit. Instead bins with zero error and non-zero content are excluded in the chi2 fit.
 /// A likelihood fit should also not be performed on such an histogram, since we are assuming a wrong pdf for each bin.
-/// In general, one should not fit an histogram with non-empty bins and zero errors, apart if all the bins have zero errors.
-/// In this case one could use the option "w", which gives a weight=1 for each bin (unweighted least-square fit).
+/// In general, one should not fit an histogram with non-empty bins and zero errors, apart if all the bins have zero
+/// errors. In this case one could use the option "w", which gives a weight=1 for each bin (unweighted least-square
+/// fit).
+/// Note that in case of histogram with no errors (chi2 fit with option W or W1) the resulting fitted parameter errors
+/// are corrected by the obtained chi2 value using this  expression:  errorp *= sqrt(chisquare/(ndf-1))
 ///
 /// #### Fitting a histogram of dimension N with a function of dimension N-1
 ///
 /// It is possible to fit a TH2 with a TF1 or a TH3 with a TF2.
 /// In this case the option "Integral" is not allowed and each cell has
-/// equal weight.
+/// equal weight. Also in this case th eobtained parameter error are corrected as in the case when the
+/// option "W" is used (see above)
 ///
 /// #### Associated functions
 ///


### PR DESCRIPTION
Renormalize the fitted errors in case the histogram has no error (i.e. when using the fit option "W")
In this case the parameter errors are corrected using the obtained chi2 value

error = error* sqrt( chi2/(ndf-1)

- Add in the documentation also option "MULTI"  (Multinomial likelihood fit) 