### PR TITLE
Fix documentation for TMVA::Timer (ROOT-9974)

### DIFF
--- a/tmva/tmva/src/Timer.cxx
+++ b/tmva/tmva/src/Timer.cxx
@@ -32,6 +32,8 @@ Timing information for training and evaluation of MVA methods
 Usage:
 
 ~~~ {.cpp}
+   TMVA::gConfig().SetDrawProgressBar(true);
+
    TMVA::Timer timer( Nloops, "MyClassName" );
    for (Int_t i=0; i<Nloops; i++) {
      ... // some code
@@ -49,6 +51,11 @@ Usage:
 
 Remark: in batch mode, the progress bar is quite ugly; you may
         want to use the text output then
+
+Note that by default in TMVA::Config the drawing of the
+progress bar is switched off. To have the progress bar visible you need 
+to enable it by calling TMVA::gConfig().SetDrawProgressBar(true)
+
 */
 
 #include "TMVA/Timer.h"


### PR DESCRIPTION
Update the documentation of the TImer class showing that one needs to call 
TMVA::gConfig().SetDrawProgressBar(true);

to have the progress bar visible. 

This fixes ROOT-9974