### PR TITLE
[RF] Fix plotting slices of RooSimultaneous

### DIFF
--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -756,6 +756,11 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
     Bool_t first(kTRUE) ;
     for (const auto arg : *idxCompSliceSet) {
       auto idxComp = static_cast<RooCategory*>(arg);
+      RooAbsArg* slicedComponent = nullptr;
+      if (sliceSet && (slicedComponent = sliceSet->find(*idxComp)) != nullptr) {
+        auto theCat = static_cast<const RooAbsCategory*>(slicedComponent);
+        idxComp->setIndex(theCat->getIndex(), false);
+      }
 
       if (!first) {
         cutString.Append("&&") ;


### PR DESCRIPTION
[ROOT-10605] When selecting a slice of a RooSimultaneous for plotting,
the last-active slice was plotted, ignoring the selection.

Duplicates: [ROOT-2936]

The first commit doesn't change functionality, it just cleans up old loops, introduces `unique_ptr`, and moves code that is common to both branches of the `if` into the section before the if. The second commit actually applies the missing component selection.