### PR TITLE
Fix handling of global vs local print level in VariableMetricBuilder.

### DIFF
--- a/math/minuit2/inc/Minuit2/MinimumBuilder.h
+++ b/math/minuit2/inc/Minuit2/MinimumBuilder.h
@@ -11,6 +11,7 @@
 #define ROOT_Minuit2_MinimumBuilder
 
 #include "Minuit2/MnTraceObject.h"
+#include "Minuit2/MnPrint.h"
 
 namespace ROOT {
 
@@ -51,6 +52,18 @@ public:
    void TraceIteration(int iter, const MinimumState & state) const {
       if (fTracer) (*fTracer)(iter, state);
    }
+
+protected:
+   // use an internal structure to control local vs global print level
+   // when the structure is created the global printlevel will be synhronized to the given value
+   // and when it is deleted it will be reset to the original value
+   struct BuilderPrintLevelConf {
+      BuilderPrintLevelConf(int printLevel);
+
+      ~BuilderPrintLevelConf();
+
+      int fPrevGlobLevel = 0; // cache previous global print level
+   };
 
 private:
 

--- a/math/minuit2/src/FumiliBuilder.cxx
+++ b/math/minuit2/src/FumiliBuilder.cxx
@@ -51,6 +51,9 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn& fcn, const GradientCalculato
    edmval *= 0.0001;
    //edmval *= 0.1; // use small factor for Fumili
 
+   // synchronize print levels
+   int printLevel = PrintLevel();
+   BuilderPrintLevelConf plconf(printLevel);
 
 #ifdef DEBUG
    std::cout<<"FumiliBuilder convergence when edm < "<<edmval<<std::endl;
@@ -79,7 +82,6 @@ FunctionMinimum FumiliBuilder::Minimum(const MnFcn& fcn, const GradientCalculato
 
    result.push_back( seed.State() );
 
-   int printLevel = PrintLevel();
    if (printLevel >1) {
       std::cout << "Fumili: start iterating until Edm is < " << edmval << std::endl;
       MnPrint::PrintState(std::cout, seed.State(), "Fumili: Initial state  ");

--- a/math/minuit2/src/MinimumBuilder.cxx
+++ b/math/minuit2/src/MinimumBuilder.cxx
@@ -21,6 +21,17 @@ namespace ROOT {
          fTracer(0)
       {}
 
+      MinimumBuilder::BuilderPrintLevelConf::BuilderPrintLevelConf(int printLevel)
+      {
+         // set global printlevel to be same as local
+         //std::cout << "set global print level to " << printLevel << std::endl;
+         fPrevGlobLevel = MnPrint::SetLevel(printLevel);
+      }
+      MinimumBuilder::BuilderPrintLevelConf::~BuilderPrintLevelConf()
+      {
+         //std::cout << "reset global print level to " << fPrevGlobLevel << std::endl;
+         MnPrint::SetLevel(fPrevGlobLevel);
+      }
 
    }  // namespace Minuit2
 

--- a/math/minuit2/src/SimplexBuilder.cxx
+++ b/math/minuit2/src/SimplexBuilder.cxx
@@ -32,6 +32,10 @@ FunctionMinimum SimplexBuilder::Minimum(const MnFcn& mfcn, const GradientCalcula
    // method to find initial simplex is slightly different than in the orginal Fortran
    // Minuit since has not been proofed that one to be better
 
+   // synchronize print levels
+   int printLevel = PrintLevel();
+   BuilderPrintLevelConf plconf(printLevel);
+
 #ifdef DEBUG
    std::cout << "Running Simplex with maxfcn = " << maxfcn << " minedm = " << minedm << std::endl;
 #endif
@@ -99,7 +103,7 @@ FunctionMinimum SimplexBuilder::Minimum(const MnFcn& mfcn, const GradientCalcula
 
       // trace the iterations (need to create a MinimunState although errors and gradient are not existing)
       if (TraceIter() ) TraceIteration(niterations, MinimumState(MinimumParameters(simplex(jl).second,simplex(jl).first), simplex.Edm(), mfcn.NumOfCalls()) );
-      if (PrintLevel() > 1) MnPrint::PrintState(std::cout,simplex(jl).first, simplex.Edm(),mfcn.NumOfCalls(),"Simplex: Iteration # ", niterations);
+      if (printLevel > 1) MnPrint::PrintState(std::cout,simplex(jl).first, simplex.Edm(),mfcn.NumOfCalls(),"Simplex: Iteration # ", niterations);
       niterations++;
 
 
@@ -203,7 +207,7 @@ FunctionMinimum SimplexBuilder::Minimum(const MnFcn& mfcn, const GradientCalcula
 
    MinimumState st(MinimumParameters(pbar, dirin, ybar), simplex.Edm(), mfcn.NumOfCalls());
 
-   if (PrintLevel() > 1)
+   if (printLevel > 1)
       MnPrint::PrintState(std::cout,st,"Simplex: Final iteration");
    if (TraceIter() ) TraceIteration(niterations, st);
 

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -39,6 +39,7 @@ namespace ROOT {
 
 double inner_product(const LAVector&, const LAVector&);
 
+
 void VariableMetricBuilder::AddResult( std::vector<MinimumState>& result, const MinimumState & state) const {
    // // if (!store) store = StorageLevel();
    // // store |= (result.size() == 0);
@@ -67,6 +68,10 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn& fcn, const GradientC
    edmval *= 0.002;
 
    int printLevel = PrintLevel();
+   // set global printlevel to the local one so all calls to MN_INFO_MSG can be controlled in the same way
+   // at exit of this function the BuilderPrintLevelConf object is destructed and automatically the
+   // previous level will be restored
+   BuilderPrintLevelConf plconf(printLevel);
 
 
 #ifdef DEBUG
@@ -264,7 +269,7 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn& fcn, const GradientC
    MnAlgebraicVector prevStep(initialState.Gradient().Vec().size());
 
    MinimumState s0 = result.back();
-   assert(s0.IsValid() ); 
+   assert(s0.IsValid() );
 
    do {
 
@@ -312,11 +317,11 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn& fcn, const GradientC
 #endif
          if(gdel > 0.) {
             AddResult(result, s0);
-               
+
             return FunctionMinimum(seed, result, fcn.Up());
          }
       }
-      
+
       MnParabolaPoint pp = lsearch(fcn, s0.Parameters(), step, gdel, prec);
 
       // <= needed for case 0 <= 0
@@ -326,7 +331,7 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn& fcn, const GradientC
 #endif
          // no improvement exit   (is it really needed LM ? in vers. 1.22 tried alternative )
          // add new state when only fcn changes
-         if (result.size() <= 1 ) 
+         if (result.size() <= 1 )
             AddResult(result, MinimumState(s0.Parameters(), s0.Error(), s0.Gradient(), s0.Edm(), fcn.NumOfCalls()));
          else
             // no need to re-store the state
@@ -382,7 +387,7 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn& fcn, const GradientC
 
       // update the state
       s0 =  MinimumState(p, e, g, edm, fcn.NumOfCalls());
-      if (StorageLevel() || result.size() <= 1) 
+      if (StorageLevel() || result.size() <= 1)
          AddResult(result, s0);
       else
          // use a reduced state for not-final iterations
@@ -401,7 +406,7 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn& fcn, const GradientC
 
    // save last result in case of no complete final states
    if ( ! result.back().IsValid() )
-      result.back() = s0; 
+      result.back() = s0;
 
 
    if(fcn.NumOfCalls() >= maxfcn) {


### PR DESCRIPTION
When calling Minimize the global prnit level is synchronized to the local one and
then re-set to its original value.

This PR replaces #2305 