### PR TITLE
[jsroot] provide default RPalette [skip-ci]

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -4,6 +4,7 @@
 1. Support RX and RY drawing option together with COL of TH2
 2. Add support of #overline, #underline, #strike into TLatex parsing (#196)
 3. Add support of TGeoTessellated shape
+4. Major changes in v7 drawing: RFrame, RPalette, RColor, ...
 
 
 ## Changes in 5.8.0

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -2163,6 +2163,13 @@
       return m;
    }
 
+   /** @summary Add methods for specified type.
+    * Will be automatically applied when decoding JSON string
+    * @private */
+   JSROOT.registerMethods = function(typename, m) {
+      JSROOT.methodsCache[typename] = m;
+   }
+
    /** @summary Returns true if object represents basic ROOT collections
     * @private */
    JSROOT.IsRootCollection = function(lst, typename) {
@@ -2183,7 +2190,7 @@
     * @private
     */
    JSROOT.addMethods = function(obj, typename) {
-      this.extend(obj, JSROOT.getMethods(typename || obj._typename, obj));
+      this.extend(obj, this.getMethods(typename || obj._typename, obj));
    }
 
    JSROOT.lastFFormat = "";

--- a/js/scripts/JSRootPainter.js
+++ b/js/scripts/JSRootPainter.js
@@ -4515,13 +4515,13 @@
     * @desc used to find title drawing
     * @private */
    TObjectPainter.prototype.FindInPrimitives = function(objname) {
-
       var painter = this.pad_painter();
-      if (!painter || !painter.pad) return null;
 
-      if (painter.pad.fPrimitives)
-         for (var n=0;n<painter.pad.fPrimitives.arr.length;++n) {
-            var prim = painter.pad.fPrimitives.arr[n];
+      var arr = painter && painter.pad && painter.pad.fPrimitives ? painter.pad.fPrimitives.arr : null;
+
+      if (arr && arr.length)
+         for (var n=0;n<arr.length;++n) {
+            var prim = arr[n];
             if (('fName' in prim) && (prim.fName === objname)) return prim;
          }
 

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -493,12 +493,6 @@
       return true;
    }
 
-   THistPainter.prototype.GetPalette = function(force) {
-      var pp = this.FindPainterFor(undefined, undefined, "ROOT::Experimental::RPaletteDrawable");
-
-      return pp ? pp.GetPalette() : null;
-   }
-
    THistPainter.prototype.UpdatePaletteDraw = function() {
       var pp = this.FindPainterFor(undefined, undefined, "ROOT::Experimental::RPaletteDrawable");
       if (pp) pp.DrawPalette();
@@ -662,7 +656,7 @@
          }
       }
 
-      res.palette = this.GetPalette();
+      res.palette = pmain.GetPalette();
 
       if (res.palette)
          this.CreateContour(pmain, res.palette, args.scatter_plot);
@@ -2364,9 +2358,10 @@
 
    TH2Painter.prototype.DrawBinsContour = function(frame_w,frame_h) {
       var handle = this.PrepareColorDraw({ rounding: false, extra: 100, original: this.options.Proj != 0 }),
-          palette = this.GetPalette(),
+          main = this.frame_painter(),
+          palette = main.GetPalette(),
           levels = palette.GetContour(),
-          painter = this, main = this.frame_painter();
+          painter = this;
 
       function BuildPath(xp,yp,iminus,iplus) {
          var cmd = "", last = null, pnt = null, i;
@@ -2512,7 +2507,7 @@
           colPaths = [], textbins = [],
           colindx, cmd, bin, item,
           i, len = histo.fBins.arr.length,
-          palette = this.GetPalette();
+          palette = pmain.GetPalette();
 
       // force recalculations of contours
       // use global coordinates


### PR DESCRIPTION
When palette does not explicitly provided in drawables,
create default RPalette and associated it with RFrame.
Fixes drawing of several v7 tutorials - only client side was affected