### PR TITLE
Support (TRootIOCtor*) constructor signature for interpreted classes

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -349,7 +349,7 @@ clang::QualType AddDefaultParameters(clang::QualType instanceType,
 //______________________________________________________________________________
 llvm::StringRef DataMemberInfo__ValidArrayIndex(const clang::DeclaratorDecl &m, int *errnum = 0, llvm::StringRef  *errstr = 0);
 
-enum class EIOCtorCategory : short {kAbsent, kDefault, kIOPtrType, kIORefType};
+enum class EIOCtorCategory : short {kAbsent, kDefault, kIOPtrType, kIORefType, kIOVoidType };
 
 //______________________________________________________________________________
 EIOCtorCategory CheckConstructor(const clang::CXXRecordDecl*, const RConstructorType&, const cling::Interpreter& interp);

--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -355,6 +355,10 @@ enum class EIOCtorCategory : short {kAbsent, kDefault, kIOPtrType, kIORefType, k
 EIOCtorCategory CheckConstructor(const clang::CXXRecordDecl*, const RConstructorType&, const cling::Interpreter& interp);
 
 //______________________________________________________________________________
+bool CheckDefaultConstructor(const clang::CXXRecordDecl*, const cling::Interpreter& interp);
+
+
+//______________________________________________________________________________
 const clang::FunctionDecl* ClassInfo__HasMethod(const clang::DeclContext *cl, char const*, const cling::Interpreter& interp);
 
 //______________________________________________________________________________

--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -349,7 +349,7 @@ clang::QualType AddDefaultParameters(clang::QualType instanceType,
 //______________________________________________________________________________
 llvm::StringRef DataMemberInfo__ValidArrayIndex(const clang::DeclaratorDecl &m, int *errnum = 0, llvm::StringRef  *errstr = 0);
 
-enum class EIOCtorCategory : short {kAbsent, kDefault, kIOPtrType, kIORefType, kIOVoidType };
+enum class EIOCtorCategory : short { kAbsent, kDefault, kIOPtrType, kIORefType };
 
 //______________________________________________________________________________
 EIOCtorCategory CheckConstructor(const clang::CXXRecordDecl*, const RConstructorType&, const cling::Interpreter& interp);

--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -357,6 +357,8 @@ EIOCtorCategory CheckConstructor(const clang::CXXRecordDecl*, const RConstructor
 //______________________________________________________________________________
 bool CheckDefaultConstructor(const clang::CXXRecordDecl*, const cling::Interpreter& interp);
 
+//______________________________________________________________________________
+EIOCtorCategory CheckIOConstructor(const clang::CXXRecordDecl*, const char *, const clang::CXXRecordDecl *, const cling::Interpreter& interp);
 
 //______________________________________________________________________________
 const clang::FunctionDecl* ClassInfo__HasMethod(const clang::DeclContext *cl, char const*, const cling::Interpreter& interp);

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -1010,7 +1010,7 @@ ROOT::TMetaUtils::EIOCtorCategory ROOT::TMetaUtils::CheckConstructor(const clang
       return EIOCtorCategory::kAbsent;
    }
 
-   for (clang::CXXRecordDecl::ctor_iterator iter = cl->ctor_begin(), end = cl->ctor_end();
+   for (auto iter = cl->ctor_begin(), end = cl->ctor_end();
           iter != end;
           ++iter)
       {
@@ -1043,7 +1043,6 @@ ROOT::TMetaUtils::EIOCtorCategory ROOT::TMetaUtils::CheckConstructor(const clang
                   clarg += arg;
                   if (realArg == clarg) {
                      return ioCtorCategory;
-
                   }
                }
             }
@@ -1116,7 +1115,7 @@ bool ROOT::TMetaUtils::HasIOConstructor(const clang::CXXRecordDecl *cl,
       } else {
          // I/O constructors can take pointers or references to ctorTypes
         proto += " *";
-        if (EIOCtorCategory::kIOPtrType == ioCtorCat){
+        if (EIOCtorCategory::kIOPtrType == ioCtorCat) {
            arg = "( ("; //(MyType*)nullptr
         } else if (EIOCtorCategory::kIORefType == ioCtorCat) {
            arg = "( *("; //*(MyType*)nullptr

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -1100,15 +1100,14 @@ bool ROOT::TMetaUtils::HasIOConstructor(const clang::CXXRecordDecl *cl,
 {
    if (cl->isAbstract()) return false;
 
-   for (RConstructorTypes::const_iterator ctorTypeIt = ctorTypes.begin();
-        ctorTypeIt!=ctorTypes.end(); ++ctorTypeIt) {
+   for (auto & ctorType : ctorTypes) {
 
-      auto ioCtorCat = ROOT::TMetaUtils::CheckConstructor(cl, *ctorTypeIt, interp);
+      auto ioCtorCat = ROOT::TMetaUtils::CheckConstructor(cl, ctorType, interp);
 
       if (EIOCtorCategory::kAbsent == ioCtorCat)
          continue;
 
-      std::string proto( ctorTypeIt->GetName() );
+      std::string proto( ctorType.GetName() );
       bool defaultCtor = proto.empty();
       if (defaultCtor) {
          arg.clear();

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4803,9 +4803,9 @@ int RootClingMain(int argc,
       // is significant.  The list is sorted by with the highest
       // priority first.
       if (!gOptInterpreterOnly) {
-         constructorTypes.push_back(ROOT::TMetaUtils::RConstructorType("TRootIOCtor", interp));
-         constructorTypes.push_back(ROOT::TMetaUtils::RConstructorType("__void__", interp)); // ROOT-7723
-         constructorTypes.push_back(ROOT::TMetaUtils::RConstructorType("", interp));
+         constructorTypes.emplace_back("TRootIOCtor", interp);
+         constructorTypes.emplace_back("__void__", interp); // ROOT-7723
+         constructorTypes.emplace_back("", interp);
       }
    }
 

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -376,7 +376,7 @@ public:
    TVirtualStreamerInfo     *GetConversionStreamerInfo( const TClass* onfile_cl, Int_t version ) const;
    TVirtualStreamerInfo     *FindConversionStreamerInfo( const TClass* onfile_cl, UInt_t checksum ) const;
    Bool_t             HasDataMemberInfo() const { return fHasRootPcmInfo || HasInterpreterInfo(); }
-   Bool_t             HasDefaultConstructor() const;
+   Bool_t             HasDefaultConstructor(Bool_t testio = kFALSE) const;
    Bool_t             HasInterpreterInfoInMemory() const { return 0 != fClassInfo; }
    Bool_t             HasInterpreterInfo() const { return fCanLoadClassInfo || fClassInfo; }
    UInt_t             GetCheckSum(ECheckSum code = kCurrentCheckSum) const;

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -404,8 +404,8 @@ public:
    virtual Long_t   ClassInfo_GetBaseOffset(ClassInfo_t* /* fromDerived */,
                                             ClassInfo_t* /* toBase */, void* /* address */ = 0, bool /*isderived*/ = true) const {return 0;}
    virtual int    ClassInfo_GetMethodNArg(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Bool_t /* objectIsConst */ = false, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
-   virtual Bool_t ClassInfo_HasDefaultConstructor(ClassInfo_t * /* info */) const {return 0;}
-   virtual Bool_t ClassInfo_HasMethod(ClassInfo_t * /* info */, const char * /* name */) const {return 0;}
+   virtual Bool_t ClassInfo_HasDefaultConstructor(ClassInfo_t * /* info */, Bool_t = kFALSE) const {return kFALSE;}
+   virtual Bool_t ClassInfo_HasMethod(ClassInfo_t * /* info */, const char * /* name */) const {return kFALSE;}
    virtual void   ClassInfo_Init(ClassInfo_t * /* info */, const char * /* funcname */) const {;}
    virtual void   ClassInfo_Init(ClassInfo_t * /* info */, int /* tagnum */) const {;}
    virtual Bool_t ClassInfo_IsBase(ClassInfo_t * /* info */, const char * /* name */) const {return 0;}

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -7092,7 +7092,7 @@ Bool_t ROOT::Internal::HasConsistentHashMember(TClass &clRef)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return true if we have access to a constructor useable for I/O.  This is
+/// Return true if we have access to a constructor usable for I/O.  This is
 /// typically the default constructor but can also be a constructor specifically
 /// marked for I/O (for example a constructor taking a TRootIOCtor* as an
 /// argument).  In other words, if this routine returns true, TClass::New is
@@ -7108,14 +7108,14 @@ Bool_t ROOT::Internal::HasConsistentHashMember(TClass &clRef)
 ///    gInterpreter->ClassInfo_HasDefaultConstructor(aClass->GetClassInfo());
 /// \code
 
-Bool_t TClass::HasDefaultConstructor() const
+Bool_t TClass::HasDefaultConstructor(Bool_t testio) const
 {
 
    if (fNew) return kTRUE;
 
    if (HasInterpreterInfo()) {
       R__LOCKGUARD(gInterpreterMutex);
-      return gCling->ClassInfo_HasDefaultConstructor(GetClassInfo());
+      return gCling->ClassInfo_HasDefaultConstructor(GetClassInfo(), testio);
    }
    if (fCollectionProxy) {
       return kTRUE;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8093,7 +8093,7 @@ int TCling::ClassInfo_GetMethodNArg(ClassInfo_t* cinfo, const char* method, cons
 bool TCling::ClassInfo_HasDefaultConstructor(ClassInfo_t* cinfo, Bool_t testio) const
 {
    TClingClassInfo *TClinginfo = (TClingClassInfo *) cinfo;
-   return TClinginfo->HasDefaultConstructor(testio) != ROOT::TMetaUtils::EIOCtorCategory::kAbsent;
+   return TClinginfo->HasDefaultConstructor(testio) != ECtorCategory::kAbsent;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8093,7 +8093,7 @@ int TCling::ClassInfo_GetMethodNArg(ClassInfo_t* cinfo, const char* method, cons
 bool TCling::ClassInfo_HasDefaultConstructor(ClassInfo_t* cinfo) const
 {
    TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
-   return TClinginfo->HasDefaultConstructor();
+   return TClinginfo->HasDefaultConstructor() != ROOT::TMetaUtils::EIOCtorCategory::kAbsent;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8090,10 +8090,10 @@ int TCling::ClassInfo_GetMethodNArg(ClassInfo_t* cinfo, const char* method, cons
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TCling::ClassInfo_HasDefaultConstructor(ClassInfo_t* cinfo) const
+bool TCling::ClassInfo_HasDefaultConstructor(ClassInfo_t* cinfo, Bool_t testio) const
 {
-   TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
-   return TClinginfo->HasDefaultConstructor() != ROOT::TMetaUtils::EIOCtorCategory::kAbsent;
+   TClingClassInfo *TClinginfo = (TClingClassInfo *) cinfo;
+   return TClinginfo->HasDefaultConstructor(testio) != ROOT::TMetaUtils::EIOCtorCategory::kAbsent;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8093,7 +8093,7 @@ int TCling::ClassInfo_GetMethodNArg(ClassInfo_t* cinfo, const char* method, cons
 bool TCling::ClassInfo_HasDefaultConstructor(ClassInfo_t* cinfo, Bool_t testio) const
 {
    TClingClassInfo *TClinginfo = (TClingClassInfo *) cinfo;
-   return TClinginfo->HasDefaultConstructor(testio) != ECtorCategory::kAbsent;
+   return TClinginfo->HasDefaultConstructor(testio) != ROOT::TMetaUtils::EIOCtorCategory::kAbsent;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -408,7 +408,7 @@ public: // Public Interface
    virtual ClassInfo_t*  ClassInfo_Factory(DeclId_t declid) const;
    virtual Long_t   ClassInfo_GetBaseOffset(ClassInfo_t* fromDerived, ClassInfo_t* toBase, void * address, bool isDerivedObject) const;
    virtual int    ClassInfo_GetMethodNArg(ClassInfo_t* info, const char* method, const char* proto, Bool_t objectIsConst = false, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
-   virtual bool   ClassInfo_HasDefaultConstructor(ClassInfo_t* info) const;
+   virtual bool   ClassInfo_HasDefaultConstructor(ClassInfo_t* info, Bool_t testio = kFALSE) const;
    virtual bool   ClassInfo_HasMethod(ClassInfo_t* info, const char* name) const;
    virtual void   ClassInfo_Init(ClassInfo_t* info, const char* funcname) const;
    virtual void   ClassInfo_Init(ClassInfo_t* info, int tagnum) const;

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1104,7 +1104,8 @@ tcling_callfunc_Wrapper_t TClingCallFunc::make_wrapper()
    return (tcling_callfunc_Wrapper_t)F;
 }
 
-tcling_callfunc_ctor_Wrapper_t TClingCallFunc::make_ctor_wrapper(const TClingClassInfo *info, ECtorCategory kind)
+tcling_callfunc_ctor_Wrapper_t TClingCallFunc::make_ctor_wrapper(const TClingClassInfo *info,
+      ROOT::TMetaUtils::EIOCtorCategory kind, const std::string &type_name)
 {
    // Make a code string that follows this pattern:
    //
@@ -1210,12 +1211,10 @@ tcling_callfunc_ctor_Wrapper_t TClingCallFunc::make_ctor_wrapper(const TClingCla
    }
 
    string constr_arg;
-   if (kind == ECtorCategory::kTRootIOPtr)
-      constr_arg = "((TRootIOCtor*)nullptr)";
-   else if (kind == ECtorCategory::kTRootIORef)
-      constr_arg = "(*((TRootIOCtor*)arena))";
-   else if (kind == ECtorCategory::kVoidRef)
-      constr_arg = "(*((__void__*)arena))";
+   if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIOPtrType)
+      constr_arg = string("((") + type_name + "*)nullptr)";
+   else if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIORefType)
+      constr_arg = string("(*((") + type_name + "*)arena))";
 
    //
    //  Write the wrapper code.
@@ -2145,7 +2144,8 @@ void TClingCallFunc::ExecWithReturn(void *address, void *ret/*= 0*/)
 }
 
 void *TClingCallFunc::ExecDefaultConstructor(const TClingClassInfo *info,
-                                             ECtorCategory kind,
+                                             ROOT::TMetaUtils::EIOCtorCategory kind,
+                                             const std::string &type_name,
                                              void *address /*=0*/, unsigned long nary /*= 0UL*/)
 {
    if (!info->IsValid()) {
@@ -2168,7 +2168,7 @@ void *TClingCallFunc::ExecDefaultConstructor(const TClingClassInfo *info,
       if (I != gCtorWrapperStore.end()) {
          wrapper = (tcling_callfunc_ctor_Wrapper_t) I->second;
       } else {
-         wrapper = make_ctor_wrapper(info, kind);
+         wrapper = make_ctor_wrapper(info, kind, type_name);
       }
    }
    if (!wrapper) {

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1213,9 +1213,9 @@ tcling_callfunc_ctor_Wrapper_t TClingCallFunc::make_ctor_wrapper(const TClingCla
    if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIOPtrType)
       constr_arg = "((TRootIOCtor*)nullptr)";
    else if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIORefType)
-      constr_arg = "(*((TRootIOCtor*)nullptr))";
+      constr_arg = "(*((TRootIOCtor*)arena))";
    else if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIOVoidType)
-      constr_arg = "(*((__void__*)nullptr))";
+      constr_arg = "(*((__void__*)arena))";
 
    //
    //  Write the wrapper code.

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1212,9 +1212,10 @@ tcling_callfunc_ctor_Wrapper_t TClingCallFunc::make_ctor_wrapper(const TClingCla
    string constr_arg;
    if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIOPtrType)
       constr_arg = "((TRootIOCtor*)nullptr)";
-   else if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIORefType) {
+   else if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIORefType)
       constr_arg = "(*((TRootIOCtor*)nullptr))";
-   }
+   else if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIOVoidType)
+      constr_arg = "(*((__void__*)nullptr))";
 
    //
    //  Write the wrapper code.

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1104,7 +1104,7 @@ tcling_callfunc_Wrapper_t TClingCallFunc::make_wrapper()
    return (tcling_callfunc_Wrapper_t)F;
 }
 
-tcling_callfunc_ctor_Wrapper_t TClingCallFunc::make_ctor_wrapper(const TClingClassInfo *info, ROOT::TMetaUtils::EIOCtorCategory kind)
+tcling_callfunc_ctor_Wrapper_t TClingCallFunc::make_ctor_wrapper(const TClingClassInfo *info, ECtorCategory kind)
 {
    // Make a code string that follows this pattern:
    //
@@ -1210,11 +1210,11 @@ tcling_callfunc_ctor_Wrapper_t TClingCallFunc::make_ctor_wrapper(const TClingCla
    }
 
    string constr_arg;
-   if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIOPtrType)
+   if (kind == ECtorCategory::kTRootIOPtr)
       constr_arg = "((TRootIOCtor*)nullptr)";
-   else if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIORefType)
+   else if (kind == ECtorCategory::kTRootIORef)
       constr_arg = "(*((TRootIOCtor*)arena))";
-   else if (kind == ROOT::TMetaUtils::EIOCtorCategory::kIOVoidType)
+   else if (kind == ECtorCategory::kVoidRef)
       constr_arg = "(*((__void__*)arena))";
 
    //
@@ -2145,7 +2145,7 @@ void TClingCallFunc::ExecWithReturn(void *address, void *ret/*= 0*/)
 }
 
 void *TClingCallFunc::ExecDefaultConstructor(const TClingClassInfo *info,
-                                             ROOT::TMetaUtils::EIOCtorCategory kind,
+                                             ECtorCategory kind,
                                              void *address /*=0*/, unsigned long nary /*= 0UL*/)
 {
    if (!info->IsValid()) {

--- a/core/metacling/src/TClingCallFunc.h
+++ b/core/metacling/src/TClingCallFunc.h
@@ -113,7 +113,7 @@ private:
    tcling_callfunc_Wrapper_t make_wrapper();
 
    tcling_callfunc_ctor_Wrapper_t
-   make_ctor_wrapper(const TClingClassInfo* info, ECtorCategory);
+   make_ctor_wrapper(const TClingClassInfo *, ROOT::TMetaUtils::EIOCtorCategory, const std::string &);
 
    tcling_callfunc_dtor_Wrapper_t
    make_dtor_wrapper(const TClingClassInfo* info);
@@ -177,7 +177,8 @@ public:
    TClingCallFunc &operator=(const TClingCallFunc &rhs) = delete;
 
    void* ExecDefaultConstructor(const TClingClassInfo* info,
-                                ECtorCategory kind,
+                                ROOT::TMetaUtils::EIOCtorCategory kind,
+                                const std::string &type_name,
                                 void* address = nullptr, unsigned long nary = 0UL);
    void ExecDestructor(const TClingClassInfo* info, void* address = nullptr,
                        unsigned long nary = 0UL, bool withFree = true);

--- a/core/metacling/src/TClingCallFunc.h
+++ b/core/metacling/src/TClingCallFunc.h
@@ -30,6 +30,7 @@
 
 #include "TClingMethodInfo.h"
 #include "TClingClassInfo.h"
+#include "TClingUtils.h"
 #include "TInterpreter.h"
 
 #include "cling/Interpreter/Value.h"
@@ -112,7 +113,7 @@ private:
    tcling_callfunc_Wrapper_t make_wrapper();
 
    tcling_callfunc_ctor_Wrapper_t
-   make_ctor_wrapper(const TClingClassInfo* info);
+   make_ctor_wrapper(const TClingClassInfo* info, ROOT::TMetaUtils::EIOCtorCategory);
 
    tcling_callfunc_dtor_Wrapper_t
    make_dtor_wrapper(const TClingClassInfo* info);
@@ -175,11 +176,12 @@ public:
 
    TClingCallFunc &operator=(const TClingCallFunc &rhs) = delete;
 
-   void* ExecDefaultConstructor(const TClingClassInfo* info, void* address = 0,
-                                unsigned long nary = 0UL);
-   void ExecDestructor(const TClingClassInfo* info, void* address = 0,
+   void* ExecDefaultConstructor(const TClingClassInfo* info,
+                                ROOT::TMetaUtils::EIOCtorCategory kind,
+                                void* address = nullptr, unsigned long nary = 0UL);
+   void ExecDestructor(const TClingClassInfo* info, void* address = nullptr,
                        unsigned long nary = 0UL, bool withFree = true);
-   void ExecWithReturn(void* address, void* ret = 0);
+   void ExecWithReturn(void* address, void *ret = nullptr);
    void ExecWithArgsAndReturn(void* address,
                               const void* args[] = 0,
                               int nargs = 0,

--- a/core/metacling/src/TClingCallFunc.h
+++ b/core/metacling/src/TClingCallFunc.h
@@ -113,7 +113,7 @@ private:
    tcling_callfunc_Wrapper_t make_wrapper();
 
    tcling_callfunc_ctor_Wrapper_t
-   make_ctor_wrapper(const TClingClassInfo* info, ROOT::TMetaUtils::EIOCtorCategory);
+   make_ctor_wrapper(const TClingClassInfo* info, ECtorCategory);
 
    tcling_callfunc_dtor_Wrapper_t
    make_dtor_wrapper(const TClingClassInfo* info);
@@ -177,7 +177,7 @@ public:
    TClingCallFunc &operator=(const TClingCallFunc &rhs) = delete;
 
    void* ExecDefaultConstructor(const TClingClassInfo* info,
-                                ROOT::TMetaUtils::EIOCtorCategory kind,
+                                ECtorCategory kind,
                                 void* address = nullptr, unsigned long nary = 0UL);
    void ExecDestructor(const TClingClassInfo* info, void* address = nullptr,
                        unsigned long nary = 0UL, bool withFree = true);

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -1073,8 +1073,8 @@ void *TClingClassInfo::New(const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) co
 
       if (kind == ROOT::TMetaUtils::EIOCtorCategory::kAbsent) {
          // FIXME: We fail roottest root/io/newdelete if we issue this message!
-         Error("TClingClassInfo::New()", "Class has no default constructor: %s",
-               FullyQualifiedName(GetDecl()).c_str());
+         // Error("TClingClassInfo::New()", "Class has no default constructor: %s",
+         //       FullyQualifiedName(GetDecl()).c_str());
          return nullptr;
       }
    } // End of Lock section.

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -684,21 +684,17 @@ ROOT::TMetaUtils::EIOCtorCategory TClingClassInfo::HasDefaultConstructor(bool ch
    if (!CRD)
       return EIOCtorCategory::kAbsent;
 
-   const RConstructorType ioctortype_dflt("", *fInterp);
-   auto kind = CheckConstructor(CRD, ioctortype_dflt, *fInterp);
-
-   if (checkio && (kind == EIOCtorCategory::kAbsent)) {
+   if (checkio) {
       const RConstructorType ioctortype_io("TRootIOCtor", *fInterp);
-      kind = CheckConstructor(CRD, ioctortype_io, *fInterp);
+      auto kind = CheckConstructor(CRD, ioctortype_io, *fInterp);
+      if (kind != EIOCtorCategory::kAbsent) return kind;
 
-      if (kind == EIOCtorCategory::kAbsent) {
-         const RConstructorType ioctortype_io2("__void__", *fInterp);
-         if (CheckConstructor(CRD, ioctortype_io2, *fInterp) == EIOCtorCategory::kIORefType)
-            kind = EIOCtorCategory::kIOVoidType;
-      }
+      const RConstructorType ioctortype_io2("__void__", *fInterp);
+      if (CheckConstructor(CRD, ioctortype_io2, *fInterp) == EIOCtorCategory::kIORefType)
+         return EIOCtorCategory::kIOVoidType;
    }
 
-   return kind;
+   return CheckDefaultConstructor(CRD, *fInterp) ? EIOCtorCategory::kDefault: EIOCtorCategory::kAbsent;
 }
 
 bool TClingClassInfo::HasMethod(const char *name) const

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -690,6 +690,12 @@ ROOT::TMetaUtils::EIOCtorCategory TClingClassInfo::HasDefaultConstructor(bool ch
    if (checkio && (kind == EIOCtorCategory::kAbsent)) {
       const RConstructorType ioctortype_io("TRootIOCtor", *fInterp);
       kind = CheckConstructor(CRD, ioctortype_io, *fInterp);
+
+      if (kind == EIOCtorCategory::kAbsent) {
+         const RConstructorType ioctortype_io2("__void__", *fInterp);
+         if (CheckConstructor(CRD, ioctortype_io2, *fInterp) == EIOCtorCategory::kIORefType)
+            kind = EIOCtorCategory::kIOVoidType;
+      }
    }
 
    return kind;

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -53,6 +53,8 @@ namespace ROOT {
 
 extern "C" typedef ptrdiff_t (*OffsetPtrFunc_t)(void*, bool);
 
+enum class ECtorCategory : short { kAbsent, kDefault, kTRootIOPtr, kTRootIORef, kVoidRef };
+
 class TClingClassInfo final : public TClingDeclInfo {
 
 private:
@@ -126,7 +128,7 @@ public:
    ptrdiff_t            GetBaseOffset(TClingClassInfo* toBase, void* address, bool isDerivedObject);
    const clang::Type   *GetType() const { return fType; } // Underlying representation with Double32_t
    std::vector<std::string> GetUsingNamespaces();
-   ROOT::TMetaUtils::EIOCtorCategory      HasDefaultConstructor(bool checkio = false) const;
+   ECtorCategory        HasDefaultConstructor(bool checkio = false) const;
    bool                 HasMethod(const char *name) const;
    void                 Init(const char *name);
    void                 Init(const clang::Decl*);

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -27,6 +27,7 @@
 
 #include "TClingDeclInfo.h"
 #include "TClingMethodInfo.h"
+#include "TClingUtils.h"
 #include "TDataType.h"
 #include "TDictionary.h"
 
@@ -125,7 +126,7 @@ public:
    ptrdiff_t            GetBaseOffset(TClingClassInfo* toBase, void* address, bool isDerivedObject);
    const clang::Type   *GetType() const { return fType; } // Underlying representation with Double32_t
    std::vector<std::string> GetUsingNamespaces();
-   bool                 HasDefaultConstructor() const;
+   ROOT::TMetaUtils::EIOCtorCategory      HasDefaultConstructor() const;
    bool                 HasMethod(const char *name) const;
    void                 Init(const char *name);
    void                 Init(const clang::Decl*);

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -126,7 +126,7 @@ public:
    ptrdiff_t            GetBaseOffset(TClingClassInfo* toBase, void* address, bool isDerivedObject);
    const clang::Type   *GetType() const { return fType; } // Underlying representation with Double32_t
    std::vector<std::string> GetUsingNamespaces();
-   ROOT::TMetaUtils::EIOCtorCategory      HasDefaultConstructor() const;
+   ROOT::TMetaUtils::EIOCtorCategory      HasDefaultConstructor(bool checkio = false) const;
    bool                 HasMethod(const char *name) const;
    void                 Init(const char *name);
    void                 Init(const clang::Decl*);

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -53,8 +53,6 @@ namespace ROOT {
 
 extern "C" typedef ptrdiff_t (*OffsetPtrFunc_t)(void*, bool);
 
-enum class ECtorCategory : short { kAbsent, kDefault, kTRootIOPtr, kTRootIORef, kVoidRef };
-
 class TClingClassInfo final : public TClingDeclInfo {
 
 private:
@@ -128,7 +126,7 @@ public:
    ptrdiff_t            GetBaseOffset(TClingClassInfo* toBase, void* address, bool isDerivedObject);
    const clang::Type   *GetType() const { return fType; } // Underlying representation with Double32_t
    std::vector<std::string> GetUsingNamespaces();
-   ECtorCategory        HasDefaultConstructor(bool checkio = false) const;
+   ROOT::TMetaUtils::EIOCtorCategory HasDefaultConstructor(bool checkio = false, std::string *type_name = nullptr) const;
    bool                 HasMethod(const char *name) const;
    void                 Init(const char *name);
    void                 Init(const clang::Decl*);

--- a/hist/histv7/inc/ROOT/RHistImpl.hxx
+++ b/hist/histv7/inc/ROOT/RHistImpl.hxx
@@ -376,7 +376,7 @@ private:
    std::tuple<AXISCONFIG...> fAxes; ///< The histogram's axes
 
 public:
-   RHistImpl(TRootIOCtor * = nullptr);
+   RHistImpl(TRootIOCtor *);
    RHistImpl(AXISCONFIG... axisArgs);
    RHistImpl(std::string_view title, AXISCONFIG... axisArgs);
 

--- a/io/io/src/TBufferFile.cxx
+++ b/io/io/src/TBufferFile.cxx
@@ -2518,7 +2518,7 @@ void TBufferFile::WriteObjectClass(const void *actualObjectStart, const TClass *
          // A warning to let the user know it will need to change the class code
          // to  be able to read this back.
          if (!actualClass->HasDefaultConstructor(kTRUE)) {
-            Warning("WriteObjectClass", "since %s has no public constructor\n"
+            Warning("WriteObjectAny", "since %s has no public constructor\n"
                "\twhich can be called without argument, objects of this class\n"
                "\tcan not be read with the current library. You will need to\n"
                "\tadd a default constructor before attempting to read it.",

--- a/io/io/src/TBufferFile.cxx
+++ b/io/io/src/TBufferFile.cxx
@@ -2517,8 +2517,8 @@ void TBufferFile::WriteObjectClass(const void *actualObjectStart, const TClass *
 
          // A warning to let the user know it will need to change the class code
          // to  be able to read this back.
-         if (!actualClass->HasDefaultConstructor()) {
-            Warning("WriteObjectAny", "since %s has no public constructor\n"
+         if (!actualClass->HasDefaultConstructor(kTRUE)) {
+            Warning("WriteObjectClass", "since %s has no public constructor\n"
                "\twhich can be called without argument, objects of this class\n"
                "\tcan not be read with the current library. You will need to\n"
                "\tadd a default constructor before attempting to read it.",


### PR DESCRIPTION
root7 `RHist` class in highly templated, therefore it is not possible to provide dictionary for all combinations. At the same time it does not provide default constructor - only special signature `(TRootIOCtor*)`. This constructor should be used when reading RHist from the file.
This PR is attempt to implement such feature. 

Also add support of constructor with signature `(__void__&)`