### PR TITLE
[RF] Fix plotting slices of RooSimultaneous.

### DIFF
--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -763,6 +763,14 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
     RooAbsCategory* idxComp ;
     Bool_t first(kTRUE) ;
     while((idxComp=(RooAbsCategory*)compIter->Next())) {
+      RooAbsArg* slicedComponent = nullptr;
+      if (sliceSet && (slicedComponent = sliceSet->find(*idxComp)) != nullptr) {
+        auto theCat = static_cast<const RooAbsCategory*>(slicedComponent);
+        auto idxCompLV = dynamic_cast<RooAbsCategoryLValue*>(idxComp);
+        if (idxCompLV)
+          idxCompLV->setIndex(theCat->getIndex(), false);
+      }
+
       if (!first) {
         cutString.Append("&&") ;
       } else {


### PR DESCRIPTION
[ROOT-10605] When selecting a slice of a RooSimultaneous for plotting,
the last-active slice was plotted, ignoring the selection.

This PR is already in master, and will be tested there on Thursday. This will allow merging the backport in time for Friday.
(Automated testing is tricky, since it's about plotting.)

Duplicates: [ROOT-2936]