### PR TITLE
Fix the tmva CrossValidation tutorials

### DIFF
--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -186,7 +186,9 @@ TCanvas* TMVA::CrossValidationResult::Draw(const TString name) const
 //
 TCanvas* TMVA::CrossValidationResult::DrawAvgROCCurve(Bool_t drawFolds, TString title) const
 {
-   TMultiGraph rocs{};
+   // note this function will create memory leak for the TMultiGraph
+   // but it needs to be kept alive in order to display the canvas
+   TMultiGraph *rocs = new TMultiGraph();
 
    // Potentially add the folds
    if (drawFolds) {
@@ -194,7 +196,7 @@ TCanvas* TMVA::CrossValidationResult::DrawAvgROCCurve(Bool_t drawFolds, TString 
          TGraph * foldRocGraph = dynamic_cast<TGraph *>(foldRocObj->Clone());
          foldRocGraph->SetLineColor(1);
          foldRocGraph->SetLineWidth(1);
-         rocs.Add(foldRocGraph);
+         rocs->Add(foldRocGraph);
       }
    }
 
@@ -203,7 +205,7 @@ TCanvas* TMVA::CrossValidationResult::DrawAvgROCCurve(Bool_t drawFolds, TString 
    avgRocGraph->SetTitle("Avg ROC Curve");
    avgRocGraph->SetLineColor(2);
    avgRocGraph->SetLineWidth(3);
-   rocs.Add(avgRocGraph);
+   rocs->Add(avgRocGraph);
 
    // Draw
    TCanvas *c = new TCanvas();
@@ -212,14 +214,15 @@ TCanvas* TMVA::CrossValidationResult::DrawAvgROCCurve(Bool_t drawFolds, TString 
       title = "Cross Validation Average ROC Curve";
    }
 
-   rocs.SetTitle(title);
-   rocs.GetXaxis()->SetTitle("Signal Efficiency");
-   rocs.GetYaxis()->SetTitle("Background Rejection");
-   rocs.DrawClone("AL");
+   rocs->SetName("cv_rocs");
+   rocs->SetTitle(title);
+   rocs->GetXaxis()->SetTitle("Signal Efficiency");
+   rocs->GetYaxis()->SetTitle("Background Rejection");
+   rocs->DrawClone("AL");
 
    // Build legend
    TLegend *leg = new TLegend();
-   TList *ROCCurveList = rocs.GetListOfGraphs();
+   TList *ROCCurveList = rocs->GetListOfGraphs();
 
    if (drawFolds) {
       Int_t nCurves = ROCCurveList->GetSize();

--- a/tmva/tmva/src/MethodCrossValidation.cxx
+++ b/tmva/tmva/src/MethodCrossValidation.cxx
@@ -226,6 +226,8 @@ void TMVA::MethodCrossValidation::ReadWeightsFromXML(void *parent)
    // SplitExpr
    if (fSplitExprString != TString("")) {
       fSplitExpr = std::unique_ptr<CvSplitKFoldsExpr>(new CvSplitKFoldsExpr(DataInfo(), fSplitExprString));
+   } else {
+      Log() << kFATAL << "MethodCrossValidation supports XML reading only for deterministic splitting !" << Endl;
    }
 }
 


### PR DESCRIPTION
By default use now a deterministic splitting instead of random one so the following tutorial
TMVACrossValidationApplication.C can be run

In addition fix the drawing of the ROC curves in CrossValidationResult::DrawAvgROCCurve
The multigraph was deleted at the end of the function and that was causing a crash when drawing the ROC average curve canvas 