### PR TITLE
[Notebooks][ROOT-9659] Make sure canvas display happens in helper thread

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/handlers.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/handlers.py
@@ -12,12 +12,13 @@ from threading import Thread
 from time import sleep as timeSleep
 from sys import platform
 from os import path
-import weakref
 import sys
 if sys.hexversion >= 0x3000000:
     import queue
 else:
     import Queue as queue
+
+from JupyROOT import helpers
 
 _lib = CDLL(path.join(path.dirname(path.dirname(path.dirname(__file__))), 'libJupyROOT.so'))
 
@@ -75,27 +76,35 @@ class IOHandler(object):
        return outDict,errDict
 
 class Poller(Thread):
-    def __init__(self, runner_obj, name):
-        Thread.__init__(self, group=None, target=None, name=name)
+    def __init__(self):
+        Thread.__init__(self, group=None, target=None, name="JupyROOT Poller Thread")
         self.poll = True
-        self.ro_ref = weakref.ref(runner_obj)
+        self.is_running = False
+        self.queue = queue.Queue()
+
     def run(self):
         while self.poll:
-            work_item_argument = self.ro_ref().argument_queue.get()
-            if work_item_argument is not None:
-                self.ro_ref().is_running = True
-                self.ro_ref().Run(work_item_argument)
-                self.ro_ref().is_running = False
+            work_item = self.queue.get()
+            if work_item is not None:
+                function, argument = work_item
+                self.is_running = True
+                function(argument)
+                self.is_running = False
             else:
                 self.poll = False
-        return
+
+    def Stop(self):
+        if self.is_alive():
+            self.queue.put(None)
+            self.join() 
 
 class Runner(object):
     ''' Asynchrously run functions
     >>> import time
     >>> def f(code):
     ...    print(code)
-    >>> r= Runner(f)
+    >>> p = Poller(); p.start()
+    >>> r= Runner(f, p)
     >>> r.Run("ss")
     ss
     >>> r.AsyncRun("ss");time.sleep(1)
@@ -103,7 +112,7 @@ class Runner(object):
     >>> def g(msg):
     ...    time.sleep(.5)
     ...    print(msg)
-    >>> r= Runner(g)
+    >>> r= Runner(g, p)
     >>> r.AsyncRun("Asynchronous");print("Synchronous");time.sleep(1)
     Synchronous
     Asynchronous
@@ -113,74 +122,78 @@ class Runner(object):
     Asynchronous
     >>> print(r.HasFinished())
     True
-    >>> r.Stop()
+    >>> p.Stop()
     '''
-    def __init__(self, function):
+    def __init__(self, function, poller):
         self.function = function
-        self.is_running = False
-        self.argument_queue = queue.Queue()
-        self.poller = Poller(runner_obj=self, name = "JupyROOT Runner Thread")
-        self.poller.start()
-
-    def __del__(self):
-        if self.poller.is_alive():
-            self.Stop()
-        self.poller.join()
+        self.poller = poller
 
     def Run(self, argument):
         return self.function(argument)
 
     def AsyncRun(self, argument):
-        self.is_running = True
-        self.argument_queue.put(argument)
+        self.poller.is_running = True
+        self.poller.queue.put((self.Run, argument))
 
     def Wait(self):
-        while self.is_running: pass
+        while self.poller.is_running:
+            timeSleep(.1)
 
     def HasFinished(self):
-        if self.is_running: return False
-        return True
-
-    def Stop(self):
-        self.Wait()
-        self.argument_queue.put(None)
-        self.Wait()
-
+        return not self.poller.is_running
 
 class JupyROOTDeclarer(Runner):
     ''' Asynchrously execute declarations
     >>> import ROOT
-    >>> d = JupyROOTDeclarer()
+    >>> p = Poller(); p.start()
+    >>> d = JupyROOTDeclarer(p)
     >>> d.Run("int f(){return 3;}".encode("utf-8"))
     1
     >>> ROOT.f()
     3
-    >>> d.Stop()
+    >>> p.Stop()
     '''
-    def __init__(self):
-       super(JupyROOTDeclarer, self).__init__(_lib.JupyROOTDeclarer)
+    def __init__(self, poller):
+       super(JupyROOTDeclarer, self).__init__(_lib.JupyROOTDeclarer, poller)
 
 class JupyROOTExecutor(Runner):
     r''' Asynchrously execute process lines
     >>> import ROOT
-    >>> d = JupyROOTExecutor()
+    >>> p = Poller(); p.start()
+    >>> d = JupyROOTExecutor(p)
     >>> d.Run('cout << "Here am I" << endl;'.encode("utf-8"))
     1
-    >>> d.Stop()
+    >>> p.Stop()
     '''
-    def __init__(self):
-       super(JupyROOTExecutor, self).__init__(_lib.JupyROOTExecutor)
+    def __init__(self, poller):
+       super(JupyROOTExecutor, self).__init__(_lib.JupyROOTExecutor, poller)
 
-def RunAsyncAndPrint(executor, code, ioHandler, printFunction, silent = False, timeout = 0.1):
-   ioHandler.Clear()
-   ioHandler.InitCapture()
-   executor.AsyncRun(code)
-   while not executor.HasFinished():
-         ioHandler.Poll()
-         if not silent:
+def display_drawables(displayFunction):
+    drawers = helpers.utils.GetDrawers()
+    for drawer in drawers:
+        for dobj in drawer.GetDrawableObjects():
+            displayFunction(dobj)
+
+class JupyROOTDisplayer(Runner):
+    ''' Display all canvases'''
+    def __init__(self, poller):
+       super(JupyROOTDisplayer, self).__init__(display_drawables, poller)
+
+def RunAsyncAndPrint(executor, code, ioHandler, printFunction, displayFunction, silent = False, timeout = 0.1):
+    ioHandler.Clear()
+    ioHandler.InitCapture()
+    executor.AsyncRun(code)
+    while not executor.HasFinished():
+        ioHandler.Poll()
+        if not silent:
             printFunction(ioHandler)
             ioHandler.Clear()
-         if executor.HasFinished(): break
-         timeSleep(.1)
-   executor.Wait()
-   ioHandler.EndCapture()
+        if executor.HasFinished(): break
+        timeSleep(.1)
+    executor.Wait()
+    ioHandler.EndCapture()
+
+def Display(displayer, displayFunction):
+    displayer.AsyncRun(displayFunction)
+    displayer.Wait()
+

--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -254,7 +254,9 @@ class StreamCapture(object):
         self.outString = ""
         self.errString = ""
 
-        self.asyncCapturer = handlers.Runner(self.syncCapture)
+        self.poller = handlers.Poller()
+        self.poller.start()
+        self.asyncCapturer = handlers.Runner(self.syncCapture, self.poller)
 
         self.isFirstPreExecute = True
         self.isFirstPostExecute = True
@@ -310,6 +312,8 @@ class StreamCapture(object):
         self.shell.events.register('pre_execute', self.pre_execute)
         self.shell.events.register('post_execute', self.post_execute)
 
+    def __del__(self):
+        self.poller.Stop()
 
 def GetCanvasDrawers():
     lOfC = ROOT.gROOT.GetListOfCanvases()

--- a/bindings/jupyroot/python/JupyROOT/kernel/rootkernel.py
+++ b/bindings/jupyroot/python/JupyROOT/kernel/rootkernel.py
@@ -24,9 +24,9 @@ except ImportError:
 import ROOT
 
 from JupyROOT.helpers.utils import setStyle, invokeAclic, GetDrawers
-from JupyROOT.helpers.handlers import RunAsyncAndPrint
+from JupyROOT.helpers.handlers import RunAsyncAndPrint, Display
 from JupyROOT.helpers.cppcompleter import CppCompleter
-from JupyROOT.kernel.utils import GetIOHandler, GetExecutor, GetDeclarer, MagicLoader
+from JupyROOT.kernel.utils import GetIOHandler, GetPoller, GetExecutor, GetDeclarer, GetDisplayer, MagicLoader
 
 import IPython
 
@@ -57,16 +57,17 @@ class ROOTKernel(MetaKernel):
         MetaKernel.__init__(self,**kwargs)
         setStyle()
         self.ioHandler = GetIOHandler()
-        self.Executor  = GetExecutor()
-        self.Declarer  = GetDeclarer()#required for %%cpp -d magic
+        self.Poller    = GetPoller()
+        self.Executor  = GetExecutor(self.Poller)
+        self.Declarer  = GetDeclarer(self.Poller) #required for %%cpp -d magic
+        self.Displayer = GetDisplayer(self.Poller)
         self.ACLiC     = invokeAclic
         self.magicloader = MagicLoader(self)
         self.completer = CppCompleter()
         self.completer.activate()
 
     def __del__(self):
-        self.Executor.Stop()
-        self.Declarer.Stop()
+        self.Poller.Stop()
 
     def get_completions(self, info):
         return self.completer._completeImpl(info['code'])
@@ -90,10 +91,7 @@ class ROOTKernel(MetaKernel):
                              silent,
                              .1)
 
-            drawers = GetDrawers()
-            for drawer in drawers:
-                for dobj in drawer.GetDrawableObjects():
-                    self.Display(dobj)
+            Display(self.Displayer, self.Display)
 
         except KeyboardInterrupt:
             ROOT.gROOT.SetInterrupt()

--- a/bindings/jupyroot/python/JupyROOT/kernel/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/kernel/utils.py
@@ -14,13 +14,15 @@ from glob import glob
 
 import importlib
 
-from JupyROOT.helpers.handlers import IOHandler, JupyROOTDeclarer, JupyROOTExecutor
+from JupyROOT.helpers.handlers import IOHandler, Poller, JupyROOTDeclarer, JupyROOTExecutor, JupyROOTDisplayer
 
 import ROOT
 
 _ioHandler = None
+_Poller    = None
 _Executor  = None
 _Declarer  = None
+_Displayer = None
 
 def GetIOHandler():
     global _ioHandler
@@ -28,17 +30,30 @@ def GetIOHandler():
         _ioHandler = IOHandler()
     return _ioHandler
 
-def GetExecutor():
+def GetPoller():
+    global _Poller
+    if not _Poller:
+        _Poller = Poller()
+        _Poller.start()
+    return _Poller
+
+def GetExecutor(poller):
     global _Executor
     if not _Executor:
-        _Executor = JupyROOTExecutor()
+        _Executor = JupyROOTExecutor(poller)
     return _Executor
 
-def GetDeclarer():
+def GetDeclarer(poller):
     global _Declarer
     if not _Declarer:
-        _Declarer = JupyROOTDeclarer()
+        _Declarer = JupyROOTDeclarer(poller)
     return _Declarer
+
+def GetDisplayer(poller):
+    global _Displayer
+    if not _Displayer:
+        _Displayer = JupyROOTDisplayer(poller)
+    return _Displayer
 
 class MagicLoader(object):
     '''Class to load JupyROOT Magics'''


### PR DESCRIPTION
The ROOT C++ kernel uses a helper thread to run the content of
the cells. In addition, from the main thread, the canvases that
have been modified as a result of executing a cell are displayed
in the output of that cell.

This commit transfers the responsibility of displaying the canvases
to the helper thread because, as explained in ROOT-9659, if a
cell executes TThread::Initialize (or EnableImplicitMT), gPad
becomes a thread local variable and the changes to gPad done
in the helper thread are not visible to the main thread. This
causes a crash when running TPad::SaveAs in the main thread
since gPad is null in that thread.