### PR TITLE
TGraph::InsertPointBefore: Tail insertion

### DIFF
--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -1797,9 +1797,14 @@ void TGraph::InsertPointBefore(Int_t ipoint, Double_t x, Double_t y)
       return;
    }
 
-   if (ipoint > fNpoints-1) {
-      Error("TGraph", "Inserted point index should be <= %d", fNpoints-1);
+   if (ipoint > fNpoints) {
+      Error("TGraph", "Inserted point index should be <= %d", fNpoints);
       return;
+   }
+
+   if (ipoint == fNpoints) {
+       SetPoint(ipoint, x, y);
+       return;
    }
 
    Double_t **ps = ExpandAndCopy(fNpoints + 1, ipoint);


### PR DESCRIPTION
When user invoke `InsertPointBefore(0, x, y)` with an empty TGraph (fNpoints==0), they will receive a message: 

> Error in <TGraph::TGraph>: Inserted point index should be <= -1

This is confusing. The point index can not be -1. It also prevents insertion to an empty graph. People who familiar with `std::vector` may expect the behavior likes `vec.insert(vec.end(), value)`.