### PR TITLE
Fix -Wmissing-field-initializers in python bindings for Python 3.8 and 3.9

### DIFF
--- a/bindings/pyroot/src/MethodProxy.cxx
+++ b/bindings/pyroot/src/MethodProxy.cxx
@@ -845,7 +845,8 @@ PyTypeObject MethodProxy_Type = {
    sizeof(MethodProxy),       // tp_basicsize
    0,                         // tp_itemsize
    (destructor)mp_dealloc,    // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -893,6 +894,12 @@ PyTypeObject MethodProxy_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/ObjectProxy.cxx
+++ b/bindings/pyroot/src/ObjectProxy.cxx
@@ -398,7 +398,8 @@ PyTypeObject ObjectProxy_Type = {
    sizeof(ObjectProxy),       // tp_basicsize
    0,                         // tp_itemsize
    (destructor)op_dealloc,    // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -449,6 +450,12 @@ PyTypeObject ObjectProxy_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/PropertyProxy.cxx
+++ b/bindings/pyroot/src/PropertyProxy.cxx
@@ -133,7 +133,8 @@ PyTypeObject PropertyProxy_Type = {
    sizeof(PropertyProxy),     // tp_basicsize
    0,                         // tp_itemsize
    (destructor)pp_dealloc,    // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -181,6 +182,12 @@ PyTypeObject PropertyProxy_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/PyRootType.cxx
+++ b/bindings/pyroot/src/PyRootType.cxx
@@ -232,7 +232,8 @@ PyTypeObject PyRootType_Type = {
    sizeof(PyROOT::PyRootClass),// tp_basicsize
    0,                         // tp_itemsize
    0,                         // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -280,6 +281,12 @@ PyTypeObject PyRootType_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -944,6 +944,12 @@ namespace {
 #if PY_VERSION_HEX >= 0x03040000
       , 0                        // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+      , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+      , 0                        // tp_print (python 3.8 only)
+#endif
+#endif
    };
 
    static PyObject* vector_iter( PyObject* v ) {

--- a/bindings/pyroot/src/RootModule.cxx
+++ b/bindings/pyroot/src/RootModule.cxx
@@ -134,6 +134,12 @@ static PyTypeObject PyNullPtr_t_Type = {
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
+#endif
 };
 
 PyObject _PyROOT_NullPtrStruct = {

--- a/bindings/pyroot/src/TCustomPyTypes.cxx
+++ b/bindings/pyroot/src/TCustomPyTypes.cxx
@@ -19,7 +19,8 @@ PyTypeObject TCustomFloat_Type = {     // python float is a C/C++ double
    0,                         // tp_basicsize
    0,                         // tp_itemsize
    0,                         // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -69,6 +70,12 @@ PyTypeObject TCustomFloat_Type = {     // python float is a C/C++ double
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
+#endif
 };
 
 //= long type allowed for reference passing ==================================
@@ -78,7 +85,8 @@ PyTypeObject TCustomInt_Type = {       // python int is a C/C++ long
    0,                         // tp_basicsize
    0,                         // tp_itemsize
    0,                         // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -127,6 +135,12 @@ PyTypeObject TCustomInt_Type = {       // python int is a C/C++ long
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 
@@ -277,7 +291,8 @@ PyTypeObject TCustomInstanceMethod_Type = {
    0,                         // tp_basicsize
    0,                         // tp_itemsize
    (destructor)im_dealloc,    // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -326,6 +341,12 @@ PyTypeObject TCustomInstanceMethod_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/TTupleOfInstances.cxx
+++ b/bindings/pyroot/src/TTupleOfInstances.cxx
@@ -42,7 +42,8 @@ PyTypeObject TTupleOfInstances_Type = {
    0,                         // tp_basicsize
    0,                         // tp_itemsize
    0,                         // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -91,6 +92,12 @@ PyTypeObject TTupleOfInstances_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/TemplateProxy.cxx
+++ b/bindings/pyroot/src/TemplateProxy.cxx
@@ -492,7 +492,8 @@ PyTypeObject TemplateProxy_Type = {
    sizeof(TemplateProxy),     // tp_basicsize
    0,                         // tp_itemsize
    (destructor)tpp_dealloc,   // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -540,6 +541,12 @@ PyTypeObject TemplateProxy_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
@@ -71,11 +71,6 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_STANDARD GREATER_EQU
     target_compile_options(cppyy PRIVATE -Wno-deprecated-register)
 endif()
 
-# Disables warnings due to new field tp_vectorcall in Python 3.8
-if(NOT MSVC AND ${PYTHON_VERSION_STRING} VERSION_GREATER_EQUAL "3.8")
-  target_compile_options(cppyy PRIVATE -Wno-missing-field-initializers)
-endif()
-
 target_include_directories(cppyy PRIVATE ${CMAKE_BINARY_DIR}/include) # needed for string_view backport
 
 target_include_directories(cppyy PUBLIC ${PYTHON_INCLUDE_DIRS}

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPDataMember.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPDataMember.cxx
@@ -167,7 +167,8 @@ PyTypeObject CPPDataMember_Type = {
     sizeof(CPPDataMember),         // tp_basicsize
     0,                             // tp_itemsize
     (destructor)pp_dealloc,        // tp_dealloc
-    0,                             // tp_print
+    0,                             // tp_print (python < 3.8)
+                                   // tp_vectorcall_offset (python >= 3.8)
     0,                             // tp_getattr
     0,                             // tp_setattr
     0,                             // tp_compare
@@ -215,6 +216,12 @@ PyTypeObject CPPDataMember_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPExcInstance.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPExcInstance.cxx
@@ -158,7 +158,8 @@ PyTypeObject CPPExcInstance_Type = {
     sizeof(CPPExcInstance),        // tp_basicsize
     0,                             // tp_itemsize
     (destructor)ep_dealloc,        // tp_dealloc
-    0,                             // tp_print
+    0,                             // tp_print (python < 3.8)
+                                   // tp_vectorcall_offset (python >= 3.8)
     0,                             // tp_getattr
     0,                             // tp_setattr
     0,                             // tp_compare
@@ -210,6 +211,12 @@ PyTypeObject CPPExcInstance_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPInstance.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPInstance.cxx
@@ -746,7 +746,8 @@ PyTypeObject CPPInstance_Type = {
     sizeof(CPPInstance),           // tp_basicsize
     0,                             // tp_itemsize
     (destructor)op_dealloc,        // tp_dealloc
-    0,                             // tp_print
+    0,                             // tp_print (python < 3.8)
+                                   // tp_vectorcall_offset (python >= 3.8)
     0,                             // tp_getattr
     0,                             // tp_setattr
     0,                             // tp_compare
@@ -797,6 +798,12 @@ PyTypeObject CPPInstance_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -866,7 +866,8 @@ PyTypeObject CPPOverload_Type = {
     sizeof(CPPOverload),           // tp_basicsize
     0,                             // tp_itemsize
     (destructor)mp_dealloc,        // tp_dealloc
-    0,                             // tp_print
+    0,                             // tp_print (python < 3.8)
+                                   // tp_vectorcall_offset (python >= 3.8)
     0,                             // tp_getattr
     0,                             // tp_setattr
     0,                             // tp_compare
@@ -914,6 +915,12 @@ PyTypeObject CPPOverload_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPScope.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPPScope.cxx
@@ -606,7 +606,8 @@ PyTypeObject CPPScope_Type = {
     sizeof(CPyCppyy::CPPScope),    // tp_basicsize
     0,                             // tp_itemsize
     0,                             // tp_dealloc
-    0,                             // tp_print
+    0,                             // tp_print (python < 3.8)
+                                   // tp_vectorcall_offset (python >= 3.8)
     0,                             // tp_getattr
     0,                             // tp_setattr
     0,                             // tp_compare
@@ -658,6 +659,12 @@ PyTypeObject CPPScope_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -141,6 +141,12 @@ static PyTypeObject PyNullPtr_t_Type = {
 #if PY_VERSION_HEX >= 0x03040000
     , 0                  // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                  // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                  // tp_print (python 3.8 only)
+#endif
+#endif
 };
 
 namespace {

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/CustomPyTypes.cxx
@@ -34,6 +34,12 @@ PyTypeObject RefFloat_Type = {     // python float is a C/C++ double
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
+#endif
 };
 
 //= long type allowed for reference passing ==================================
@@ -59,6 +65,12 @@ PyTypeObject RefInt_Type = {       // python int is a C/C++ long
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
 #endif
 };
 
@@ -89,6 +101,12 @@ PyTypeObject TypedefPointerToClass_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                           // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                           // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                           // tp_print (python 3.8 only)
+#endif
 #endif
 };
 
@@ -255,6 +273,12 @@ PyTypeObject CustomInstanceMethod_Type = {
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
+#endif
 };
 
 
@@ -304,6 +328,12 @@ PyTypeObject IndexIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                           // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                           // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                           // tp_print (python 3.8 only)
+#endif
 #endif
 };
 
@@ -363,6 +393,12 @@ PyTypeObject VectorIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                           // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                           // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                           // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/LowLevelViews.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/LowLevelViews.cxx
@@ -651,7 +651,8 @@ PyTypeObject LowLevelView_Type = {
     sizeof(CPyCppyy::LowLevelView),// tp_basicsize
     0,                             // tp_itemsize
     (destructor)ll_dealloc,        // tp_dealloc
-    0,                             // tp_print
+    0,                             // tp_print (python < 3.8)
+                                   // tp_vectorcall_offset (python >= 3.8)
     0,                             // tp_getattr
     0,                             // tp_setattr
     0,                             // tp_compare
@@ -700,6 +701,12 @@ PyTypeObject LowLevelView_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -730,7 +730,8 @@ PyTypeObject TemplateProxy_Type = {
    sizeof(TemplateProxy),     // tp_basicsize
    0,                         // tp_itemsize
    (destructor)tpp_dealloc,   // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -778,6 +779,12 @@ PyTypeObject TemplateProxy_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/TupleOfInstances.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/TupleOfInstances.cxx
@@ -82,6 +82,12 @@ PyTypeObject InstanceArrayIter_Type = {
 #if PY_VERSION_HEX >= 0x03040000
     , 0                           // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                           // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                           // tp_print (python 3.8 only)
+#endif
+#endif
 };
 
 
@@ -161,7 +167,8 @@ PyTypeObject TupleOfInstances_Type = {
     0,                             // tp_basicsize
     0,                             // tp_itemsize
     0,                             // tp_dealloc
-    0,                             // tp_print
+    0,                             // tp_print (python < 3.8)
+                                   // tp_vectorcall_offset (python >= 3.8)
     0,                             // tp_getattr
     0,                             // tp_setattr
     0,                             // tp_compare
@@ -210,6 +217,12 @@ PyTypeObject TupleOfInstances_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
     , 0                            // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+    , 0                            // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+    , 0                            // tp_print (python 3.8 only)
+#endif
 #endif
 };
 


### PR DESCRIPTION
Warnings with python 3.8:
.../bindings/pyroot/src/MethodProxy.cxx:891:1: warning: missing initializer for member '_typeobject::tp_vectorcall' [-Wmissing-field-initializers]
.../bindings/pyroot/src/MethodProxy.cxx:891:1: warning: missing initializer for member '_typeobject::tp_print' [-Wmissing-field-initializers]

Warnings with python 3.9:
.../bindings/pyroot/src/MethodProxy.cxx:891:1: warning: missing initializer for member '_typeobject::tp_vectorcall' [-Wmissing-field-initializers]