### PR TITLE
Correct broken assert statements

### DIFF
--- a/math/mathcore/src/FitData.cxx
+++ b/math/mathcore/src/FitData.cxx
@@ -200,9 +200,9 @@ namespace ROOT {
       /// dummy virtual destructor
       FitData::~FitData()
       {
+         assert(fWrapped == fCoords.empty());
          for (unsigned int i = 0; i < fDim; i++) {
-            assert(fWrapped == fCoords.empty());
-            assert(fCoords.empty() || &fCoords[i].front() == fCoordsPtr[i]);
+            assert(fWrapped || fCoords[i].empty() || &fCoords[i].front() == fCoordsPtr[i]);
          }
          if (fpTmpCoordVector)  delete[] fpTmpCoordVector;
 


### PR DESCRIPTION
Fixes the following test failures.

The following tests FAILED:
	 71 - mathcore-SparseDataComparer (Failed)
	 72 - mathcore-SparseFit4 (Failed)
	 73 - mathcore-SparseFit3 (Failed)
	149 - test-stresshistogram (Failed)
	150 - test-stresshistogram-interpreted (Failed)
	169 - test-stresshistofit (Failed)
	170 - test-stresshistofit-interpreted (Failed)
Errors while running CTest
