### PR TITLE
[Exp PyROOT][ROOT-10606] Fix STL sequence iterator (used by RooArgSet)

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
@@ -2792,7 +2792,12 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, dims
 
         if (!result) {
         // CLING WORKAROUND -- special case for STL iterators
-            if (realType.find("__gnu_cxx::__normal_iterator", 0) /* vector */ == 0) {
+            if (realType.rfind("__gnu_cxx::__normal_iterator", 0) /* vector */ == 0
+#ifdef __APPLE__
+                || realType.rfind("__wrap_iter", 0) == 0
+#endif
+                // TODO: Windows?
+               ) {
                 static STLIteratorConverter c;
                 result = &c;
             } else

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/TypeManip.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/TypeManip.cxx
@@ -19,8 +19,12 @@ std::string::size_type find_qualifier_index(const std::string& name)
     std::string::size_type i = name.size() - 1;
     for ( ; 0 < i; --i) {
         std::string::value_type c = name[i];
-        if (is_varchar(c) || c == '>')
-            break;
+        if (is_varchar(c) || c == '>') {
+            if (c == 't' && 6 < i && !is_varchar(name[i-5]) && name.substr(i-4, 5) == "const")
+                i -= 4;      // this skips 'const' on a pointer type
+            else
+                break;
+        }
     }
 
     return i+1;


### PR DESCRIPTION
Fixes SQL iterator applied to RooArgSet.

Cherry picked from:
https://bitbucket.org/wlav/cpycppyy/commits/7dc2bdb36eb153ff8d2812dae181f97f77961b4a