### PR TITLE
[cmake] do not use source dir in include paths

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -553,8 +553,15 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     target_compile_definitions(${dictionary} PRIVATE
       ${definitions} $<TARGET_PROPERTY:${ARG_MODULE},COMPILE_DEFINITIONS>)
 
+    # remove all -I prefixes from list of include dirs
+    set(pureincdirs)
+    foreach(dir ${includedirs})
+      string(SUBSTRING ${dir} 2 -1 dir0)
+      set(pureincdirs ${pureincdirs} ${dir0})
+    endforeach()
+
     target_include_directories(${dictionary} PRIVATE
-      ${includedirs} $<TARGET_PROPERTY:${ARG_MODULE},INCLUDE_DIRECTORIES>)
+      ${pureincdirs} $<TARGET_PROPERTY:${ARG_MODULE},INCLUDE_DIRECTORIES>)
   else()
     add_custom_target(${dictionary} DEPENDS ${dictionary}.cxx ${pcm_name} ${rootmap_name} ${cpp_module_file})
   endif()

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -841,23 +841,23 @@ endfunction()
 function(ROOT_ADD_INCLUDE_DIRECTORIES library)
   if(PROJECT_NAME STREQUAL "ROOT")
 
-    if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc)
-      target_include_directories(${library}
-        PRIVATE
-          ${CMAKE_CURRENT_SOURCE_DIR}/inc
-        INTERFACE
-          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-      )
-    endif()
+#    if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+#      target_include_directories(${library}
+#        PRIVATE
+#          ${CMAKE_CURRENT_SOURCE_DIR}/inc
+#        INTERFACE
+#          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+#      )
+#    endif()
 
-    if(root7 AND IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc)
-      target_include_directories(${library}
-        PRIVATE
-          ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc
-        INTERFACE
-          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/v7/inc>
-      )
-    endif()
+#    if(root7 AND IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc)
+#      target_include_directories(${library}
+#        PRIVATE
+#          ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc
+#        INTERFACE
+#          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/v7/inc>
+#      )
+#    endif()
 
     if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/res)
       target_include_directories(${library}

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -266,7 +266,7 @@ endfunction(ROOT_GET_INSTALL_DIR)
 #---------------------------------------------------------------------------------------------------
 function(ROOT_GENERATE_DICTIONARY dictionary)
   CMAKE_PARSE_ARGUMENTS(ARG "STAGE1;MULTIDICT;NOINSTALL;NO_CXXMODULE"
-    "MODULE;LINKDEF" "NODEPHEADERS;OPTIONS;DEPENDENCIES;EXTRA_DEPENDENCIES;BUILTINS;INCDIRS" ${ARGN})
+    "MODULE;LINKDEF" "NODEPHEADERS;OPTIONS;DEPENDENCIES;EXTRA_DEPENDENCIES;BUILTINS" ${ARGN})
 
   # Check if OPTIONS start with a dash.
   if (ARG_OPTIONS)
@@ -299,18 +299,14 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     endforeach()
   endif()
 
-  if (ARG_INCDIRS)
-    foreach(dir ${ARG_INCDIRS})
-       list(APPEND incdirs ${dir})
-    endforeach()
-  endif(ARG_INCDIRS)
- 
+  set(headerdirs_dflt)
+
   if(CMAKE_PROJECT_NAME STREQUAL ROOT)
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/inc)
-       list(APPEND incdirs ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+       list(APPEND headerdirs_dflt ${CMAKE_CURRENT_SOURCE_DIR}/inc)
     endif()
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc)
-       list(APPEND incdirs ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc)
+       list(APPEND headerdirs_dflt ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc)
     endif()
   endif()
 
@@ -335,7 +331,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
         set(headerFile ${fp})
       else()
         set(incdirs_in_build)
-        set(incdirs_in_prefix)
+        set(incdirs_in_prefix ${headerdirs_dflt})
         string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" _source_dir "${CMAKE_SOURCE_DIR}")
         string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" _binary_dir "${CMAKE_BINARY_DIR}")
         string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" _curr_binary_dir "${CMAKE_CURRENT_BINARY_DIR}")
@@ -385,22 +381,22 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   endif()
 
   if(CMAKE_PROJECT_NAME STREQUAL ROOT)
-    set(includedirs -I${CMAKE_SOURCE_DIR}
-                    -I${CMAKE_BINARY_DIR}/etc/cling/ # This is for the RuntimeUniverse
-                    -I${CMAKE_BINARY_DIR}/include)
+    list(APPEND includedirs -I${CMAKE_BINARY_DIR}/include)
+    list(APPEND includedirs -I${CMAKE_BINARY_DIR}/etc/cling) # This is for the RuntimeUniverse
+#    list(APPEND includedirs -I${CMAKE_SOURCE_DIR})
     set(excludepaths ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
   elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/inc)
     set(includedirs -I${CMAKE_CURRENT_SOURCE_DIR}/inc)
   endif()
   foreach( d ${incdirs})
-   set(includedirs ${includedirs} -I${d})
+    list(APPEND includedirs -I${d})
   endforeach()
 
   foreach(dep ${ARG_DEPENDENCIES})
     if(TARGET ${dep})
       get_property(dep_include_dirs TARGET ${dep} PROPERTY INCLUDE_DIRECTORIES)
       foreach(d ${dep_include_dirs})
-        set(includedirs ${includedirs} -I${d})
+         list(APPEND includedirs -I${d})
       endforeach()
     endif()
   endforeach()

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -266,7 +266,7 @@ endfunction(ROOT_GET_INSTALL_DIR)
 #---------------------------------------------------------------------------------------------------
 function(ROOT_GENERATE_DICTIONARY dictionary)
   CMAKE_PARSE_ARGUMENTS(ARG "STAGE1;MULTIDICT;NOINSTALL;NO_CXXMODULE"
-    "MODULE;LINKDEF" "NODEPHEADERS;OPTIONS;DEPENDENCIES;EXTRA_DEPENDENCIES;BUILTINS" ${ARGN})
+    "MODULE;LINKDEF" "NODEPHEADERS;OPTIONS;DEPENDENCIES;EXTRA_DEPENDENCIES;BUILTINS;INCDIRS" ${ARGN})
 
   # Check if OPTIONS start with a dash.
   if (ARG_OPTIONS)
@@ -297,6 +297,21 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
         list(APPEND incdirs ${dir})
       endif()
     endforeach()
+  endif()
+
+  if (ARG_INCDIRS)
+    foreach(dir ${ARG_INCDIRS})
+       list(APPEND incdirs ${dir})
+    endforeach()
+  endif(ARG_INCDIRS)
+ 
+  if(CMAKE_PROJECT_NAME STREQUAL ROOT)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+       list(APPEND incdirs ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+    endif()
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc)
+       list(APPEND incdirs ${CMAKE_CURRENT_SOURCE_DIR}/v7/inc)
+    endif()
   endif()
 
   #---Get the list of header files-------------------------

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1202,7 +1202,9 @@ function(ROOT_STANDARD_LIBRARY_PACKAGE libname)
   # Dictionary might include things from the current src dir, e.g. tests. Alas
   # there is no way to set the include directory for a source file (except for
   # the generic COMPILE_FLAGS), so this needs to be glued to the target.
-  target_include_directories(${libname} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  if(NOT (CMAKE_PROJECT_NAME STREQUAL ROOT))
+     target_include_directories(${libname} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
 
   # Install headers if we have any headers and if the user didn't explicitly
   # disabled this.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -167,7 +167,7 @@ ROOT_GENERATE_DICTIONARY(G__Core
 )
 
 # This is needed because LinkDef.h includes other LinkDef starting from ${CMAKE_SOURCE_DIR}
-target_include_directories(Core PRIVATE ${CMAKE_SOURCE_DIR})
+# target_include_directories(Core PRIVATE ${CMAKE_SOURCE_DIR})
 
 target_link_libraries(Core
   PRIVATE

--- a/core/base/inc/LinkDef.h
+++ b/core/base/inc/LinkDef.h
@@ -1,16 +1,16 @@
-#include "core/base/inc/LinkDef1.h"
-#include "core/base/inc/LinkDef2.h"
-#include "core/base/inc/LinkDef3.h"
-#include "core/cont/inc/LinkDef.h"
-#include "core/meta/inc/LinkDef.h"
+#include "./LinkDef1.h"
+#include "./LinkDef2.h"
+#include "./LinkDef3.h"
+#include "../../cont/inc/LinkDef.h"
+#include "../../meta/inc/LinkDef.h"
 
 #if defined(SYSTEM_TYPE_winnt)
-#include "core/winnt/inc/LinkDef.h"
+#include "../../winnt/inc/LinkDef.h"
 #elif defined(SYSTEM_TYPE_macosx)
-#include "core/macosx/inc/LinkDef.h"
-#include "core/unix/inc/LinkDef.h"
+#include "../../macosx/inc/LinkDef.h"
+#include "../../unix/inc/LinkDef.h"
 #elif defined(SYSTEM_TYPE_unix)
-#include "core/unix/inc/LinkDef.h"
+#include "../../unix/inc/LinkDef.h"
 #else
 # error "Unsupported system type."
 #endif

--- a/geom/geom/inc/LinkDef.h
+++ b/geom/geom/inc/LinkDef.h
@@ -1,2 +1,2 @@
-#include "geom/geom/inc/LinkDef1.h"
-#include "geom/geom/inc/LinkDef2.h"
+#include "./LinkDef1.h"
+#include "./LinkDef2.h"

--- a/graf3d/eve/inc/LinkDef.h
+++ b/graf3d/eve/inc/LinkDef.h
@@ -1,2 +1,2 @@
-#include "graf3d/eve/inc/LinkDef1.h"
-#include "graf3d/eve/inc/LinkDef2.h"
+#include "./LinkDef1.h"
+#include "./LinkDef2.h"

--- a/gui/gui/inc/LinkDef.h
+++ b/gui/gui/inc/LinkDef.h
@@ -1,3 +1,3 @@
-#include "gui/gui/inc/LinkDef1.h"
-#include "gui/gui/inc/LinkDef2.h"
-#include "gui/gui/inc/LinkDef3.h"
+#include "./LinkDef1.h"
+#include "./LinkDef2.h"
+#include "./LinkDef3.h"


### PR DESCRIPTION
Fully exclude source directory from include paths - for dictionary generation and for objects compilation. Significantly reduce list of dirs in CXX flags.
Makes dependency files very clear - `${CMAKE_BINARY_DIR}/include` used in 99%, rest are special includes from `res/` subfolders.
Tested with and without cxx modules

