### PR TITLE
Fix in 6.20 tmva include files for cudnn

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1421,21 +1421,17 @@ endif()
 
 #---Check for CUDA-----------------------------------------------------------------------
 # if tmva-gpu is off and cuda is on cuda is searched but not used in tmva
-#  if cuda is off but tmva-gpu is on cuda is searched and activated if found ! 
-
+#  if cuda is off but tmva-gpu is on cuda is searched and activated if found !
+#
 if(cuda OR tmva-gpu)
-
   find_package(CUDA)
-
   if(CUDA_FOUND)
     if(NOT DEFINED CMAKE_CUDA_STANDARD)
       set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
     endif()
-
     enable_language(CUDA)
-
     set(cuda ON CACHE BOOL "Found Cuda for TMVA GPU" FORCE)
-
+    ###
     ### look for package CuDNN
     if (cudnn)
       if (fail-on-missing)
@@ -1443,7 +1439,6 @@ if(cuda OR tmva-gpu)
       else()
         find_package(CuDNN)
       endif()
-
       if (CUDNN_FOUND)
         message(STATUS "CuDNN library found: " ${CUDNN_LIBRARIES})
 	### set tmva-cudnn flag only if tmva-gpu is on!
@@ -1455,25 +1450,21 @@ if(cuda OR tmva-gpu)
         set(cudnn OFF CACHE BOOL "Disabled because cudnn is not found" FORCE)
       endif()
     endif()
-
   elseif(fail-on-missing)
     message(FATAL_ERROR "CUDA not found. Ensure that the installation of CUDA is in the CMAKE_PREFIX_PATH")
   endif()
-
 else()
   set(cudnn OFF)
 endif()
-
+#
 #---TMVA and its dependencies------------------------------------------------------------
 if (tmva AND NOT mlp)
   message(FATAL_ERROR "The 'tmva' option requires 'mlp', please enable mlp with -Dmlp=ON")
 endif()
-
 if(tmva)
   if(tmva-cpu AND imt)
     message(STATUS "Looking for BLAS for optional parts of TMVA")
     find_package(BLAS)
-
     if(NOT BLAS_FOUND)
       if (GSL_FOUND)
         message(STATUS "Using GSL CBLAS for optional parts of TMVA")
@@ -1484,12 +1475,10 @@ if(tmva)
   else()
     set(tmva-cpu OFF CACHE BOOL "Disabled because 'imt' is disabled (${tmva-cpu_description})" FORCE)
   endif()
-
   if(tmva-gpu AND NOT CUDA_FOUND)
     set(tmva-gpu OFF CACHE BOOL "Disabled because cuda not found" FORCE)
   endif()
-
-  if(tmva-pymva)
+  if(python AND tmva-pymva)
     if(fail-on-missing AND NOT NUMPY_FOUND)
       message(FATAL_ERROR "TMVA: numpy python package not found and tmva-pymva component required"
                           " (python executable: ${PYTHON_EXECUTABLE})")
@@ -1498,7 +1487,6 @@ if(tmva)
       set(tmva-pymva OFF CACHE BOOL "Disabled because Numpy was not found (${tmva-pymva_description})" FORCE)
     endif()
   endif()
-
   if(tmva-rmva AND NOT R_FOUND)
     set(tmva-rmva  OFF CACHE BOOL "Disabled because R was not found (${tmva-rmva_description})"  FORCE)
   endif()

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1454,7 +1454,10 @@ if(cuda OR tmva-gpu)
     message(FATAL_ERROR "CUDA not found. Ensure that the installation of CUDA is in the CMAKE_PREFIX_PATH")
   endif()
 else()
-  set(cudnn OFF)
+  if (cudnn)
+    message(STATUS "Cannot select cudnn without selecting cuda or tmva-gpu. Option is ignored")
+    set(cudnn OFF)
+  endif()
 endif()
 #
 #---TMVA and its dependencies------------------------------------------------------------

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -455,28 +455,27 @@ if(tmva-cpu)
 endif()
 
 if(tmva-gpu)
-  target_link_libraries(TMVA PRIVATE ${CUDA_CUBLAS_LIBRARIES})
-  	target_include_directories(TMVA PRIVATE ${CUDA_INCLUDE_DIRS})
   if (tmva-cudnn)
-    message(STATUS "Using cuDNN for TMVA Deep Learning on GPU")
-	 target_sources(TMVA PRIVATE
-    src/DNN/Architectures/Cuda.cu
-    src/DNN/Architectures/Cuda/CudaBuffers.cxx
-    src/DNN/Architectures/Cuda/CudaMatrix.cu
-    src/DNN/Architectures/Cuda/CudaTensor.cu
-    src/DNN/Architectures/Cudnn/TensorDataLoader.cxx
-	 src/DNN/Architectures/Cudnn.cu)
+    message(STATUS "Using Cuda+cuDNN for TMVA Deep Learning on GPU")
+    target_sources(TMVA PRIVATE
+                   src/DNN/Architectures/Cuda.cu
+                   src/DNN/Architectures/Cuda/CudaBuffers.cxx
+                   src/DNN/Architectures/Cuda/CudaMatrix.cu
+                   src/DNN/Architectures/Cuda/CudaTensor.cu
+                   src/DNN/Architectures/Cudnn/TensorDataLoader.cxx
+		   src/DNN/Architectures/Cudnn.cu)
+    target_include_directories(TMVA PRIVATE ${CUDA_INCLUDE_DIRS} ${CUDNN_INCLUDE_DIRS} )
     target_link_libraries(TMVA PRIVATE ${CUDA_CUBLAS_LIBRARIES} ${CUDNN_LIBRARIES})
   else()
-   message(STATUS "cuDNN not found or disabled - use only Cuda+Cublas for TMVA Deep Learning on GPU")
-   target_compile_definitions(TMVA PRIVATE -DDNN_NO_CUDNN)
-	target_link_libraries(TMVA PRIVATE ${CUDA_CUBLAS_LIBRARIES})
-	target_sources(TMVA PRIVATE
-    src/DNN/Architectures/Cuda.cu
-    src/DNN/Architectures/Cuda/CudaBuffers.cxx
-    src/DNN/Architectures/Cuda/CudaMatrix.cu
-    src/DNN/Architectures/Cuda/CudaTensor.cu )
-  endif()
+    message(STATUS "cuDNN not found or disabled - use only Cuda+Cublas for TMVA Deep Learning on GPU")
+    target_include_directories(TMVA PRIVATE ${CUDA_INCLUDE_DIRS})
+    target_link_libraries(TMVA PRIVATE ${CUDA_CUBLAS_LIBRARIES})
+    target_sources(TMVA PRIVATE
+                   src/DNN/Architectures/Cuda.cu
+    		   src/DNN/Architectures/Cuda/CudaBuffers.cxx
+                   src/DNN/Architectures/Cuda/CudaMatrix.cu
+                   src/DNN/Architectures/Cuda/CudaTensor.cu )
+   endif()
 endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -252,7 +252,7 @@ void MethodDL::ProcessOptions()
 #ifndef R__HAS_TMVAGPU    // case TMVA does not support GPU
       Log() << kERROR << "CUDA backend not enabled. Please make sure "
          "you have CUDA installed and it was successfully "
-         "detected by CMAKE by using -Dcuda=On "
+         "detected by CMAKE by using -Dtmva-gpu=On  "
             << Endl;
 #ifdef R__HAS_TMVACPU
       fArchitectureString = "CPU";
@@ -267,9 +267,9 @@ void MethodDL::ProcessOptions()
    }
   else if (fArchitectureString == "CUDNN") {
 #ifndef R__HAS_TMVAGPU    // case TMVA does not support GPU
-      Log() << kERROR << "CUDA backend not enabled. Please make sure "
+      Log() << kERROR << "CUDA+CUDNN backend not enabled. Please make sure "
             "you have CUDNN and CUDA installed and that the GPU capability/CUDA "
-            "was successfully detected by CMAKE by using -Dcuda=On"
+            "was successfully detected by CMAKE by using -Dtmva-gpu=On"
             << Endl;
 #ifdef R__HAS_TMVACPU
       fArchitectureString = "CPU";


### PR DESCRIPTION
This PR fixes when the cudnn include files are located in a separate directory than the cuda include dirs by adding CDNN_INCLUDE_DIRS to the compiler include path 