### PR TITLE
[cmake] [bugfix] provide correct args for target_include_directories call

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -554,6 +554,8 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
       ${definitions} $<TARGET_PROPERTY:${ARG_MODULE},COMPILE_DEFINITIONS>)
 
     # remove all -I prefixes from list of include dirs
+    # otherwise generated make files will look like:
+    # CXX_INCLUDES = -I/home/user/git/root6/io/io/-I/home/user/git/root6 ...
     set(pureincdirs)
     foreach(dir ${includedirs})
       string(SUBSTRING ${dir} 2 -1 dir0)

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -553,8 +553,15 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     target_compile_definitions(${dictionary} PRIVATE
       ${definitions} $<TARGET_PROPERTY:${ARG_MODULE},COMPILE_DEFINITIONS>)
 
+    # remove all -I prefixes from list of include dirs
+    set(pureincdirs)
+    foreach(dir ${includedirs})
+      string(SUBSTRING ${dir} 2 -1 dir0)
+      set(pureincdirs ${pureincdirs} ${dir0})
+    endforeach()
+
     target_include_directories(${dictionary} PRIVATE
-      ${includedirs} $<TARGET_PROPERTY:${ARG_MODULE},INCLUDE_DIRECTORIES>)
+      ${pureincdirs} $<TARGET_PROPERTY:${ARG_MODULE},INCLUDE_DIRECTORIES>)
   else()
     add_custom_target(${dictionary} DEPENDS ${dictionary}.cxx ${pcm_name} ${rootmap_name} ${cpp_module_file})
   endif()


### PR DESCRIPTION
One has to exclude "-I" prefix which was required for direct
command for dicitionary generation. 
When calling `target_include_directories()`, it has to be removed. 
Otherwise list of includes for dictionary compilation looks:
```
CXX_INCLUDES = -I/home/linev/git/root6/io/io/-I/home/linev/git/root6 -I/home/linev/git/root6/io/io/-I/home/linev/build/root6/etc/cling -I/home/linev/git/root6/io/io/-I/home/linev/build/root6/include -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/io/io -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/io/io/res -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/clib/res -I/home/linev/git/root6/io/io/-I/usr/include -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/base/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/base/v7/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/clib/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/cont/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/foundation/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/macosx/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/unix/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/winnt/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/clingutils/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/meta/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/gui/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/textinput/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/thread/inc -I/home/linev/git/root6/io/io/-I/home/linev/git/root6/core/thread -I/home/linev/git/root6/io/io/res -I/home/linev/build/root6/include -I/home/linev/git/root6/core/clib/res
```
