### PR TITLE
[cling] Move the diagnostic client init before potential source of diagnostics.

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1594,6 +1594,12 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
                                       PP.getTargetInfo().getTriple());
     }
 
+    // Tell the diagnostic client that we are entering file parsing mode as the
+    // handling of modulemap files may issue diagnostics.
+    // FIXME: Consider moving in SetupDiagnostics.
+    DiagnosticConsumer& DClient = CI->getDiagnosticClient();
+    DClient.BeginSourceFile(CI->getLangOpts(), &PP);
+
     for (const auto& Filename : FrontendOpts.ModuleMapFiles) {
       if (auto* File = FM.getFile(Filename))
         PP.getHeaderSearchInfo().loadModuleMapFile(File, /*IsSystem*/ false);

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -265,10 +265,6 @@ namespace cling {
         return;
     }
 
-    // Tell the diagnostic client that we are entering file parsing mode.
-    DiagnosticConsumer& DClient = getCI()->getDiagnosticClient();
-    DClient.BeginSourceFile(getCI()->getLangOpts(), &PP);
-
     bool usingCxxModules = getSema().getLangOpts().Modules;
     if (usingCxxModules) {
       // Explicitly create the modulemanager now. If we would create it later


### PR DESCRIPTION
Handling modulemap files may issue parsing errors or not found errors and our diagnostics client should be prepared for it.

This patch fixes an assertion in clang when we see duplicate modulemap files.