### PR TITLE
[backport] Partially backport "[cxxmodules] Use real modulemap names if ..."

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -604,8 +604,10 @@ namespace {
       assert(llvm::sys::fs::exists(originalLoc.str()) && "Must exist!");
       assert(llvm::sys::fs::exists(SystemDir) && "Must exist!");
 
+      std::string modulemapFilename
+        = HSOpts.ImplicitModuleMaps ? "module.modulemap" : Filename;
       llvm::SmallString<512> systemLoc(SystemDir);
-      llvm::sys::path::append(systemLoc, "module.modulemap");
+      llvm::sys::path::append(systemLoc, modulemapFilename);
       // Check if we need to mount a custom modulemap. We may have it, for
       // instance when we are on osx or using libc++.
       if (llvm::sys::fs::exists(systemLoc.str())) {
@@ -620,7 +622,7 @@ namespace {
         overlay += ",\n";
 
       overlay += "{ 'name': '" + SystemDir.str() + "', 'type': 'directory',\n";
-      overlay += "'contents': [\n   { 'name': 'module.modulemap', ";
+      overlay += "'contents': [\n   { 'name': '" + modulemapFilename + "', ";
       overlay += "'type': 'file',\n  'external-contents': '";
       overlay += originalLoc.str().str() + "'\n";
       overlay += "}\n ]\n }";
@@ -666,12 +668,12 @@ namespace {
     llvm::sys::path::append(resourceDirLoc, "include", "module.modulemap");
     ModuleMapFiles.push_back(resourceDirLoc.str().str());
     // FIXME: Move these calls in maybeAppendOverlayEntry.
-    llvm::sys::path::append(cIncLoc, "module.modulemap");
+    llvm::sys::path::append(cIncLoc, "libc.modulemap");
     ModuleMapFiles.push_back(cIncLoc.str().str());
-    llvm::sys::path::append(stdIncLoc, "module.modulemap");
+    llvm::sys::path::append(stdIncLoc, "std.modulemap");
     ModuleMapFiles.push_back(stdIncLoc.str().str());
     if (!cudaIncLoc.empty()) {
-      llvm::sys::path::append(cudaIncLoc, "module.modulemap");
+      llvm::sys::path::append(cudaIncLoc, "cuda.modulemap");
       ModuleMapFiles.push_back(cudaIncLoc.str().str());
     }
     llvm::sys::path::append(clingIncLoc, "module.modulemap");


### PR DESCRIPTION
Original commit message:
"
 The current logic of pseudo-automatic modulemap discovery is a little fragile
 as it mounts a virtual file named module.modulemap in the location where the
 a give system library header is found (cuda.h, etc). However, if the libraries
 are squashed into a single folder then we end up mounting a file over another
 virtual file. This should be a hard error, however, on systems such as OSX some
 libraries already come with modulemap files and we should just not mount our
 predefined ones. This makes it very difficult to distinguish when to issue the
 hard error.

 While this patch is not a solution for the general when the modulemaps are
 automatically discovered (-fimplicit-module-maps), we can use the real file
 stems in cases where we are called with -fno-implicit-module-maps.

 As a side effect this fixes the *non-recommended* squashing of library header
 files into a single folder.
"