### PR TITLE
[Tree] Print Error message if a friend has kEntriesReshuffled set

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1303,6 +1303,7 @@ public:
       // TODO we could instead create the output tree and its branches, change addresses of input variables in each task
       fOutputTrees[slot] =
          std::make_unique<TTree>(fTreeName.c_str(), fTreeName.c_str(), fOptions.fSplitLevel, /*dir=*/treeDirectory);
+      fOutputTrees[slot]->SetBit(TTree::kEntriesReshuffled);
       // TODO can be removed when RDF supports interleaved TBB task execution properly, see ROOT-10269
       fOutputTrees[slot]->SetImplicitMT(false);
       if (fOptions.fAutoFlush)

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -158,7 +158,6 @@ TEST_F(RDFSnapshot, Snapshot_nocolumnmatch)
    const auto fname = "snapshotnocolumnmatch.root";
    RDataFrame d(1);
    auto op = [&](){
-      testing::internal::CaptureStderr();
       d.Snapshot("t", fname, "x");
    };
    EXPECT_ANY_THROW(op());
@@ -775,8 +774,9 @@ TEST(RDFSnapshotMore, ColsWithCustomTitlesMT)
 TEST(RDFSnapshotMore, TreeWithFriendsMT)
 {
    const auto fname = "treewithfriendsmt.root";
-   ROOT::EnableImplicitMT();
    RDataFrame(10).Define("x", []() { return 0; }).Snapshot<int>("t", fname, {"x"});
+
+   ROOT::EnableImplicitMT();
 
    TFile file(fname);
    auto tree = file.Get<TTree>("t");

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -636,6 +636,40 @@ TEST_F(RDFSnapshotMT, Snapshot_action_with_options)
    test_snapshot_options(tdf);
 }
 
+TEST_F(RDFSnapshotMT, Reshuffled_friends)
+{
+   const auto fname = "snapshot_reshuffled_friends.root";
+   tdf.Snapshot("t", fname);
+
+   {
+      // add reshuffled tree as friend
+      testing::internal::CaptureStderr();
+      TFile f(fname);
+      TTree *t = f.Get<TTree>("t");
+      TTree t2("t2", "t2");
+      t2.AddFriend(t);
+      const std::string err = testing::internal::GetCapturedStderr();
+      const auto expected = "Error in <AddFriend>: Tree 't' has the kEntriesReshuffled bit set, and cannot be used as "
+                            "friend nor can be added as a friend unless the main tree has a TTreeIndex on the friend "
+                            "tree 't'. You can also unset the bit manually if you know what you are doing.\n";
+      EXPECT_EQ(err, expected);
+   }
+
+   {
+      // add friend to reshuffled tree
+      testing::internal::CaptureStderr();
+      TFile f(fname);
+      TTree *t = f.Get<TTree>("t");
+      TTree t2("t2", "t2");
+      t->AddFriend(&t2); // should throw
+      const std::string err = testing::internal::GetCapturedStderr();
+      const auto expected = "Error in <AddFriend>: Tree 't' has the kEntriesReshuffled bit set, and cannot be used as "
+                            "friend nor can be added as a friend unless the main tree has a TTreeIndex on the friend "
+                            "tree 't2'. You can also unset the bit manually if you know what you are doing.\n";
+      EXPECT_EQ(err, expected);
+   }
+}
+
 TEST(RDFSnapshotMore, ManyTasksPerThread)
 {
    const auto nSlots = 4u;

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -239,7 +239,12 @@ public:
       /// If set, the branch's buffers will grow until an event cluster boundary is hit,
       /// guaranteeing a basket per cluster.  This mode does not provide any guarantee on the
       /// memory bounds in the case of extremely large events.
-      kOnlyFlushAtCluster = BIT(14)
+      kOnlyFlushAtCluster = BIT(14),
+      /// If set, signals that this TTree is the output of the processing of another TTree, and
+      /// the entries are reshuffled w.r.t. to the original TTree. As a safety measure, a TTree
+      /// with this bit set cannot add friends nor can be added as a friend. If you know what
+      /// you are doing, you can manually unset this bit with `ResetBit(EStatusBits::kEntriesReshuffled)`.
+      kEntriesReshuffled = BIT(19) // bits 15-18 are used by TChain
    };
 
    // Split level modifier

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -236,9 +236,10 @@ public:
    enum EStatusBits {
       kForceRead = BIT(11),
       kCircular = BIT(12),
-      kOnlyFlushAtCluster = BIT(14) // If set, the branch's buffers will grow until an event cluster boundary is hit,
-      // guaranteeing a basket per cluster.  This mode does not provide any guarantee on the
-      // memory bounds in the case of extremely large events.
+      /// If set, the branch's buffers will grow until an event cluster boundary is hit,
+      /// guaranteeing a basket per cluster.  This mode does not provide any guarantee on the
+      /// memory bounds in the case of extremely large events.
+      kOnlyFlushAtCluster = BIT(14)
    };
 
    // Split level modifier

--- a/tree/tree/inc/TVirtualIndex.h
+++ b/tree/tree/inc/TVirtualIndex.h
@@ -25,6 +25,7 @@
 #include "TNamed.h"
 
 class TTree;
+class TTreeFormula;
 
 class TVirtualIndex : public TNamed {
 
@@ -40,6 +41,8 @@ public:
    virtual Long64_t       GetEntryNumberWithBestIndex(Long64_t major, Long64_t minor) const = 0;
    virtual const char    *GetMajorName()    const = 0;
    virtual const char    *GetMinorName()    const = 0;
+   virtual TTreeFormula  *GetMajorFormulaParent(const TTree *parent) = 0;
+   virtual TTreeFormula  *GetMinorFormulaParent(const TTree *parent) = 0;
    virtual Long64_t       GetN()            const = 0;
    virtual TTree         *GetTree()         const {return fTree;}
    virtual void           UpdateFormulaLeaves(const TTree *parent) = 0;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -1287,16 +1287,20 @@ TFriendElement *TTree::AddFriend(const char *treename, const char *filename)
    }
    TFriendElement *fe = new TFriendElement(this, treename, filename);
 
-   fFriends->Add(fe);
    TTree *t = fe->GetTree();
+   bool canAddFriend = true;
    if (t) {
       if (!t->GetTreeIndex() && (t->GetEntries() < fEntries)) {
          Warning("AddFriend", "FriendElement %s in file %s has less entries %lld than its parent Tree: %lld", treename,
                  filename, t->GetEntries(), fEntries);
       }
    } else {
-      Warning("AddFriend", "Cannot add FriendElement %s in file %s", treename, filename);
+      Error("AddFriend", "Cannot find tree '%s' in file '%s', friend not added", treename, filename);
+      canAddFriend = false;
    }
+
+   if (canAddFriend)
+      fFriends->Add(fe);
    return fe;
 }
 
@@ -1316,16 +1320,20 @@ TFriendElement *TTree::AddFriend(const char *treename, TFile *file)
    }
    TFriendElement *fe = new TFriendElement(this, treename, file);
    R__ASSERT(fe);
-   fFriends->Add(fe);
    TTree *t = fe->GetTree();
+   bool canAddFriend = true;
    if (t) {
       if (!t->GetTreeIndex() && (t->GetEntries() < fEntries)) {
          Warning("AddFriend", "FriendElement %s in file %s has less entries %lld than its parent tree: %lld", treename,
                  file->GetName(), t->GetEntries(), fEntries);
       }
    } else {
-      Warning("AddFriend", "unknown tree '%s' in file '%s'", treename, file->GetName());
+      Error("AddFriend", "Cannot find tree '%s' in file '%s', friend not added", treename, filename);
+      canAddFriend = false;
    }
+
+   if (canAddFriend)
+      fFriends->Add(fe);
    return fe;
 }
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -1280,18 +1280,19 @@ void TTree::AddClone(TTree* clone)
 ///     tree.Draw("var:ft1.var:ft2.var")
 /// ~~~
 
-TFriendElement* TTree::AddFriend(const char* treename, const char* filename)
+TFriendElement *TTree::AddFriend(const char *treename, const char *filename)
 {
    if (!fFriends) {
       fFriends = new TList();
    }
-   TFriendElement* fe = new TFriendElement(this, treename, filename);
+   TFriendElement *fe = new TFriendElement(this, treename, filename);
 
    fFriends->Add(fe);
-   TTree* t = fe->GetTree();
+   TTree *t = fe->GetTree();
    if (t) {
       if (!t->GetTreeIndex() && (t->GetEntries() < fEntries)) {
-         Warning("AddFriend", "FriendElement %s in file %s has less entries %lld than its parent Tree: %lld", treename, filename, t->GetEntries(), fEntries);
+         Warning("AddFriend", "FriendElement %s in file %s has less entries %lld than its parent Tree: %lld", treename,
+                 filename, t->GetEntries(), fEntries);
       }
    } else {
       Warning("AddFriend", "Cannot add FriendElement %s in file %s", treename, filename);
@@ -1308,7 +1309,7 @@ TFriendElement* TTree::AddFriend(const char* treename, const char* filename)
 /// - reads a Tree with name treename from the file
 /// - adds the Tree to the list of friends
 
-TFriendElement* TTree::AddFriend(const char* treename, TFile* file)
+TFriendElement *TTree::AddFriend(const char *treename, TFile *file)
 {
    if (!fFriends) {
       fFriends = new TList();
@@ -1319,9 +1320,10 @@ TFriendElement* TTree::AddFriend(const char* treename, TFile* file)
    TTree *t = fe->GetTree();
    if (t) {
       if (!t->GetTreeIndex() && (t->GetEntries() < fEntries)) {
-         Warning("AddFriend", "FriendElement %s in file %s has less entries %lld than its parent tree: %lld", treename, file->GetName(), t->GetEntries(), fEntries);
+         Warning("AddFriend", "FriendElement %s in file %s has less entries %lld than its parent tree: %lld", treename,
+                 file->GetName(), t->GetEntries(), fEntries);
       }
-  } else {
+   } else {
       Warning("AddFriend", "unknown tree '%s' in file '%s'", treename, file->GetName());
    }
    return fe;
@@ -1333,7 +1335,7 @@ TFriendElement* TTree::AddFriend(const char* treename, TFile* file)
 /// The TTree is managed by the user (e.g., the user must delete the file).
 /// For a complete description see AddFriend(const char *, const char *).
 
-TFriendElement* TTree::AddFriend(TTree* tree, const char* alias, Bool_t warn)
+TFriendElement *TTree::AddFriend(TTree *tree, const char *alias, Bool_t warn)
 {
    if (!tree) {
       return 0;
@@ -1341,13 +1343,14 @@ TFriendElement* TTree::AddFriend(TTree* tree, const char* alias, Bool_t warn)
    if (!fFriends) {
       fFriends = new TList();
    }
-   TFriendElement* fe = new TFriendElement(this, tree, alias);
+   TFriendElement *fe = new TFriendElement(this, tree, alias);
    R__ASSERT(fe); // this assert is for historical reasons. Don't remove it unless you understand all the consequences.
    fFriends->Add(fe);
-   TTree* t = fe->GetTree();
+   TTree *t = fe->GetTree();
    if (warn && (t->GetEntries() < fEntries)) {
       Warning("AddFriend", "FriendElement '%s' in file '%s' has less entries %lld than its parent tree: %lld",
-              tree->GetName(), fe->GetFile() ? fe->GetFile()->GetName() : "(memory resident)", t->GetEntries(), fEntries);
+              tree->GetName(), fe->GetFile() ? fe->GetFile()->GetName() : "(memory resident)", t->GetEntries(),
+              fEntries);
    }
    tree->RegisterExternalFriend(fe);
    return fe;


### PR DESCRIPTION
The TTree::kEntriesReshuffled bit signals that a TTree is the output
of the processing of another TTree, and its entries are reshuffled
w.r.t. to the original TTree. As a safety measure, a TTree with this
bit set cannot add friends nor can be added as a friend.

MT Snapshot, in RDataFrame, sets kEntriesReshuffled for the output tree to true. This fixes ROOT-9556.