### PR TITLE
[Doc] Fix making images for tutorials

### DIFF
--- a/documentation/doxygen/makeimage.py
+++ b/documentation/doxygen/makeimage.py
@@ -12,7 +12,7 @@ def makeimage(MacroName, ImageName, OutDir, cp, py, batch):
     if batch:
         ROOT.gROOT.SetBatch(1)
 
-    if py: exec(compile(open(MacroName, "rb").read(), MacroName, 'exec'))
+    if py: exec(open(MacroName).read(), globals())
     else: ROOT.gInterpreter.ProcessLine(".x " + MacroName)
 
     if cp:


### PR DESCRIPTION
* Just using `exec` fixes the issue on my machine
* Warning from the Python docs: "It is possible to crash the Python interpreter with a sufficiently large/complex string when compiling to an AST object due to stack depth limitations in Python’s AST compiler."

@couet Please check on the docs machine that this fixes the issue.