### PR TITLE
[PyROOT] Simplify lookup logic

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -132,18 +132,16 @@ class ROOTFacade(types.ModuleType):
             # Make the attributes of the facade be injected in the
             # caller module
             raise AttributeError()
-
-        try:
+        # Note that hasattr caches the lookup for getattr
+        elif hasattr(gbl_namespace, name):
             return getattr(gbl_namespace, name)
-        except AttributeError as err:
-            try:
-                return getattr(gbl_namespace.ROOT, name)
-            except AttributeError:
-                res = gROOT.FindObject(name)
-                if res:
-                    return res
-                else:
-                    raise AttributeError(str(err))
+        elif hasattr(gbl_namespace.ROOT, name):
+            return getattr(gbl_namespace.ROOT, name)
+        else:
+            res = gROOT.FindObject(name)
+            if res:
+                return res
+        raise AttributeError("Failed to get attribute {} from ROOT".format(name))
 
     def _finalSetup(self):
         # Prevent this method from being re-entered through the gROOT wrapper


### PR DESCRIPTION
I'm looking into the facade to fix [ROOT-10629](https://sft.its.cern.ch/jira/browse/ROOT-10629). However, we can improve in the lookup logic. Especially to throw more meaningful error messages. In short: Imho, stacking `try` blocks is not a good idea.

The behaviour now:

```bash
>>> import ROOT
>>> ROOT.foo
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stefan/builds/root-dev/lib/python3.8/ROOT/_facade.py", line 171, in _getattr
    return getattr(self, name)
  File "/home/stefan/builds/root-dev/lib/python3.8/ROOT/_facade.py", line 144, in _fallback_getattr
    raise AttributeError("Failed to import {} from ROOT".format(name))
AttributeError: Failed to import foo from ROOT
```

The behaviour before:

```bash
>>> import ROOT
>>> ROOT.foo
Traceback (most recent call last):
  File "/home/stefan/builds/root-dev/lib/python3.8/ROOT/_facade.py", line 137, in _fallback_getattr
    return getattr(gbl_namespace, name)
AttributeError: <namespace cppyy.gbl at 0x5641444c41f0> has no attribute 'foo'. Full details:
  type object '' has no attribute 'foo'
  'foo' is not a known C++ class
  'foo' is not a known C++ template
  'foo' is not a known C++ enum

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/stefan/builds/root-dev/lib/python3.8/ROOT/_facade.py", line 140, in _fallback_getattr
    return getattr(gbl_namespace.ROOT, name)
AttributeError: <namespace cppyy.gbl.ROOT at 0x564145da5680> has no attribute 'foo'. Full details:
  type object 'ROOT' has no attribute 'foo'
  'ROOT::foo' is not a known C++ class
  'foo' is not a known C++ template
  'foo' is not a known C++ enum

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stefan/builds/root-dev/lib/python3.8/ROOT/_facade.py", line 173, in _getattr
    return getattr(self, name)
  File "/home/stefan/builds/root-dev/lib/python3.8/ROOT/_facade.py", line 146, in _fallback_getattr
    raise AttributeError(str(err))
AttributeError: <namespace cppyy.gbl at 0x5641444c41f0> has no attribute 'foo'. Full details:
  type object '' has no attribute 'foo'
  'foo' is not a known C++ class
  'foo' is not a known C++ template
  'foo' is not a known C++ enum
```