### PR TITLE
[RDF] Clean-up tutorials

### DIFF
--- a/tutorials/dataframe/df001_introduction.C
+++ b/tutorials/dataframe/df001_introduction.C
@@ -159,12 +159,12 @@ int df001_introduction()
    // It is possible at any moment to read the entry number and the processing
    // slot number. The latter may change when implicit multithreading is active.
    // The special columns which provide the entry number and the slot index are
-   // called "tdfentry_" and "tdfslot_" respectively. Their types are an unsigned
+   // called "rdfentry_" and "rdfslot_" respectively. Their types are an unsigned
    // 64 bit integer and an unsigned integer.
    auto printEntrySlot = [](ULong64_t iEntry, unsigned int slot) {
       std::cout << "Entry: " << iEntry << " Slot: " << slot << std::endl;
    };
-   d.Foreach(printEntrySlot, {"tdfentry_", "tdfslot_"});
+   d.Foreach(printEntrySlot, {"rdfentry_", "rdfslot_"});
 
    return 0;
 }

--- a/tutorials/dataframe/df001_introduction.py
+++ b/tutorials/dataframe/df001_introduction.py
@@ -15,9 +15,9 @@ import ROOT
 
 # A simple helper function to fill a test tree: this makes the example stand-alone.
 def fill_tree(treeName, fileName):
-    tdf = ROOT.ROOT.RDataFrame(10)
-    tdf.Define("b1", "(double) tdfentry_")\
-       .Define("b2", "(int) tdfentry_ * tdfentry_").Snapshot(treeName, fileName)
+    df = ROOT.RDataFrame(10)
+    df.Define("b1", "(double) rdfentry_")\
+      .Define("b2", "(int) rdfentry_ * rdfentry_").Snapshot(treeName, fileName)
 
 # We prepare an input tree to run on
 fileName = "df001_introduction_py.root"
@@ -27,8 +27,7 @@ fill_tree(treeName, fileName)
 
 # We read the tree from the file and create a RDataFrame, a class that
 # allows us to interact with the data contained in the tree.
-RDF = ROOT.ROOT.RDataFrame
-d = RDF(treeName, fileName)
+d = ROOT.RDataFrame(treeName, fileName)
 
 # Operations on the dataframe
 # We now review some *actions* which can be performed on the data frame.

--- a/tutorials/dataframe/df002_dataModel.py
+++ b/tutorials/dataframe/df002_dataModel.py
@@ -57,8 +57,7 @@ ROOT.fill_tree(fileName, treeName)
 
 # We read the tree from the file and create a RDataFrame, a class that
 # allows us to interact with the data contained in the tree.
-RDF = ROOT.ROOT.RDataFrame
-d = RDF(treeName, fileName)
+d = ROOT.RDataFrame(treeName, fileName)
 
 # Operating on branches which are collection of objects
 # Here we deal with the simplest of the cuts: we decide to accept the event

--- a/tutorials/dataframe/df003_profiles.py
+++ b/tutorials/dataframe/df003_profiles.py
@@ -16,7 +16,7 @@ import ROOT
 # A simple helper function to fill a test tree: this makes the example
 # stand-alone.
 def fill_tree(treeName, fileName):
-    d = ROOT.ROOT.RDataFrame(25000)
+    d = ROOT.RDataFrame(25000)
     d.Define("px", "gRandom->Gaus()")\
      .Define("py", "gRandom->Gaus()")\
      .Define("pz", "sqrt(px * px + py * py)")\
@@ -34,7 +34,7 @@ columns = ROOT.vector('string')()
 columns.push_back("px")
 columns.push_back("py")
 columns.push_back("pz")
-d = ROOT.ROOT.RDataFrame(treeName, fileName, columns)
+d = ROOT.RDataFrame(treeName, fileName, columns)
 
 # Create the profiles
 hprof1d = d.Profile1D(("hprof1d", "Profile of pz versus px", 64, -4, 4))

--- a/tutorials/dataframe/df004_cutFlowReport.py
+++ b/tutorials/dataframe/df004_cutFlowReport.py
@@ -13,9 +13,9 @@
 import ROOT
 
 def fill_tree(treeName, fileName):
-    tdf = ROOT.ROOT.RDataFrame(50)
-    tdf.Define("b1", "(double) tdfentry_")\
-       .Define("b2", "(int) tdfentry_ * tdfentry_").Snapshot(treeName, fileName)
+    df = ROOT.RDataFrame(50)
+    df.Define("b1", "(double) rdfentry_")\
+      .Define("b2", "(int) rdfentry_ * rdfentry_").Snapshot(treeName, fileName)
 
 # We prepare an input tree to run on
 fileName = 'df004_cutFlowReport_py.root'
@@ -24,8 +24,7 @@ fill_tree(treeName, fileName)
 
 # We read the tree from the file and create a RDataFrame, a class that
 # allows us to interact with the data contained in the tree.
-RDF = ROOT.ROOT.RDataFrame
-d = RDF(treeName, fileName)
+d = ROOT.RDataFrame(treeName, fileName)
 
 # ## Define cuts and create the report
 # An optional string parameter name can be passed to the Filter method to create a named filter.

--- a/tutorials/dataframe/df006_ranges.py
+++ b/tutorials/dataframe/df006_ranges.py
@@ -12,9 +12,9 @@
 import ROOT
 
 def fill_tree(treeName, fileName):
-    tdf = ROOT.ROOT.RDataFrame(100)
-    tdf.Define("b1", "(int) tdfentry_")\
-       .Define("b2", "(float) tdfentry_ * tdfentry_").Snapshot(treeName, fileName)
+    df = ROOT.RDataFrame(100)
+    df.Define("b1", "(int) rdfentry_")\
+      .Define("b2", "(float) rdfentry_ * rdfentry_").Snapshot(treeName, fileName)
 
 
 # We prepare an input tree to run on
@@ -24,8 +24,7 @@ treeName = "myTree"
 fill_tree(treeName, fileName)
 
 # We read the tree from the file and create a RDataFrame.
-RDF = ROOT.ROOT.RDataFrame
-d = RDF(treeName, fileName)
+d = ROOT.RDataFrame(treeName, fileName)
 
 # ## Usage of ranges
 # Now we'll count some entries using ranges

--- a/tutorials/dataframe/df007_snapshot.C
+++ b/tutorials/dataframe/df007_snapshot.C
@@ -75,7 +75,7 @@ int df007_snapshot()
    // Open the new file and list the columns of the tree
    TFile f2(outFileNameAllColumns);
    t = f2.Get<TTree>(treeName);
-   std::cout << "These are all the columns available to this tdf:" << std::endl;
+   std::cout << "These are all the columns available to this dataframe:" << std::endl;
    for (auto branch : *t->GetListOfBranches()) {
       std::cout << "Branch: " << branch->GetName() << std::endl;
    }
@@ -85,8 +85,8 @@ int df007_snapshot()
    // analysis chain from it. The default columns are the one selected.
    // Notice also how we can decide to be more explicit with the types of the
    // columns.
-   auto snapshot_tdf = d2.Snapshot<int>(treeName, outFileName, {"b1_square"});
-   auto h = snapshot_tdf->Histo1D();
+   auto snapshot_df = d2.Snapshot<int>(treeName, outFileName, {"b1_square"});
+   auto h = snapshot_df->Histo1D();
    auto c = new TCanvas();
    h->DrawClone();
 

--- a/tutorials/dataframe/df007_snapshot.py
+++ b/tutorials/dataframe/df007_snapshot.py
@@ -11,9 +11,8 @@ import ROOT
 
 # A simple helper function to fill a test tree: this makes the example stand-alone.
 def fill_tree(treeName, fileName):
-    tdf = ROOT.ROOT.RDataFrame(10000)
-    tdf.Define("b1", "(int) tdfentry_")\
-       .Define("b2", "(float) tdfentry_ * tdfentry_").Snapshot(treeName, fileName)
+    df.Define("b1", "(int) rdfentry_")\
+      .Define("b2", "(float) rdfentry_ * rdfentry_").Snapshot(treeName, fileName)
 
 # We prepare an input tree to run on
 fileName = "df007_snapshot_py.root"
@@ -23,8 +22,7 @@ treeName = "myTree"
 fill_tree(treeName, fileName)
 
 # We read the tree from the file and create a RDataFrame.
-RDF = ROOT.ROOT.RDataFrame
-d = RDF(treeName, fileName)
+d = ROOT.RDataFrame(treeName, fileName)
 
 # ## Select entries
 # We now select some entries in the dataset
@@ -73,7 +71,7 @@ d2.Snapshot(treeName, outFileNameAllColumns)
 # Open the new file and list the columns of the tree
 f2 = ROOT.TFile(outFileNameAllColumns)
 t = f2.myTree
-print("These are all the columns available to this tdf:")
+print("These are all the columns available to this dataframe:")
 for branch in t.GetListOfBranches():
     print("Branch: %s" %branch.GetName())
 
@@ -84,8 +82,8 @@ f2.Close()
 
 branchList.clear()
 branchList.push_back("b1_square")
-snapshot_tdf = d2.Snapshot(treeName, outFileName, branchList);
-h = snapshot_tdf.Histo1D("b1_square")
+snapshot_df = d2.Snapshot(treeName, outFileName, branchList);
+h = snapshot_df.Histo1D("b1_square")
 c = ROOT.TCanvas()
 h.Draw()
 

--- a/tutorials/dataframe/df008_createDataSetFromScratch.C
+++ b/tutorials/dataframe/df008_createDataSetFromScratch.C
@@ -11,12 +11,12 @@
 void df008_createDataSetFromScratch()
 {
    // We create an empty data frame of 100 entries
-   ROOT::RDataFrame tdf(100);
+   ROOT::RDataFrame df(100);
 
    // We now fill it with random numbers
    gRandom->SetSeed(1);
-   auto tdf_1 = tdf.Define("rnd", []() { return gRandom->Gaus(); });
+   auto df_1 = df.Define("rnd", []() { return gRandom->Gaus(); });
 
    // And we write out the dataset on disk
-   tdf_1.Snapshot("randomNumbers", "df008_createDataSetFromScratch.root");
+   df_1.Snapshot("randomNumbers", "df008_createDataSetFromScratch.root");
 }

--- a/tutorials/dataframe/df008_createDataSetFromScratch.py
+++ b/tutorials/dataframe/df008_createDataSetFromScratch.py
@@ -11,12 +11,11 @@
 import ROOT
 
 # We create an empty data frame of 100 entries
-tdf = ROOT.ROOT.RDataFrame(100)
+df = ROOT.RDataFrame(100)
 
 # We now fill it with random numbers
 ROOT.gRandom.SetSeed(1)
-tdf_1 = tdf.Define("rnd", "gRandom->Gaus()")
+df_1 = df.Define("rnd", "gRandom->Gaus()")
 
 # And we write out the dataset on disk
-tdf_1.Snapshot("randomNumbers", "df008_createDataSetFromScratch_py.root")
-
+df_1.Snapshot("randomNumbers", "df008_createDataSetFromScratch_py.root")

--- a/tutorials/dataframe/df009_FromScratchVSTTree.C
+++ b/tutorials/dataframe/df009_FromScratchVSTTree.C
@@ -52,11 +52,11 @@ void classicWay()
 // write a new dataset becomes very easy to do.
 void RDFWay()
 {
-   ROOT::RDataFrame tdf(10);
+   ROOT::RDataFrame df(10);
    auto b = 0.;
-   tdf.Define("b1", [&b]() { return b++; })
-      .Define("b2", "(int) b1 * b1") // This can even be a string
-      .Snapshot("treeName", "df009_FromScratchVSTTree_tdf.root");
+   df.Define("b1", [&b]() { return b++; })
+     .Define("b2", "(int) b1 * b1") // This can even be a string
+     .Snapshot("treeName", "df009_FromScratchVSTTree_df.root");
 }
 
 void df009_FromScratchVSTTree()

--- a/tutorials/dataframe/df011_ROOTDataSource.py
+++ b/tutorials/dataframe/df011_ROOTDataSource.py
@@ -17,8 +17,8 @@ import ROOT
 
 # A simple helper function to fill a test tree: this makes the example stand-alone.
 def fill_tree(treeName, fileName):
-    tdf = ROOT.ROOT.RDataFrame(10000)
-    tdf.Define("b1", "(int) tdfentry_").Snapshot(treeName, fileName)
+    df = ROOT.RDataFrame(10000)
+    df.Define("b1", "(int) rdfentry_").Snapshot(treeName, fileName)
 
 
 # We prepare an input tree to run on
@@ -27,7 +27,7 @@ treeName = "myTree"
 fill_tree(treeName, fileName)
 
 # Create the data frame
-MakeRootDataFrame = ROOT.ROOT.RDF.MakeRootDataFrame
+MakeRootDataFrame = ROOT.RDF.MakeRootDataFrame
 
 d = MakeRootDataFrame(treeName, fileName)
 

--- a/tutorials/dataframe/df012_DefinesAndFiltersAsStrings.C
+++ b/tutorials/dataframe/df012_DefinesAndFiltersAsStrings.C
@@ -21,7 +21,7 @@ void df012_DefinesAndFiltersAsStrings()
    // of radius 1.0)
 
    size_t npoints = 10000000;
-   ROOT::RDataFrame tdf(npoints);
+   ROOT::RDataFrame df(npoints);
 
    // Define what we want inside the dataframe. We do not need to define p as an array,
    // but we do it here to demonstrate how to use jitting with RDataFrame
@@ -31,10 +31,10 @@ void df012_DefinesAndFiltersAsStrings()
    // if the local variable and the data column are of different types or the
    // local x variable is declared in the global scope of the lambda function
 
-   auto pidf = tdf.Define("x", "gRandom->Uniform(-1.0, 1.0)")
-                  .Define("y", "gRandom->Uniform(-1.0, 1.0)")
-                  .Define("p", "std::array<double, 2> v{x, y}; return v;")
-                  .Define("r", "double r2 = 0.0; for (auto&& x : p) r2 += x*x; return sqrt(r2);");
+   auto pidf = df.Define("x", "gRandom->Uniform(-1.0, 1.0)")
+                 .Define("y", "gRandom->Uniform(-1.0, 1.0)")
+                 .Define("p", "std::array<double, 2> v{x, y}; return v;")
+                 .Define("r", "double r2 = 0.0; for (auto&& x : p) r2 += x*x; return sqrt(r2);");
 
    // Now we have a dataframe with columns x, y, p (which is a point based on x
    // and y), and the radius r = sqrt(x*x + y*y). In order to approximate pi, we

--- a/tutorials/dataframe/df012_DefinesAndFiltersAsStrings.py
+++ b/tutorials/dataframe/df012_DefinesAndFiltersAsStrings.py
@@ -21,15 +21,15 @@ import ROOT
 ## circle).
 
 npoints = 10000000
-tdf = ROOT.ROOT.RDataFrame(npoints)
+df = ROOT.RDataFrame(npoints)
 
 ## Define what data we want inside the dataframe. We do not need to define p
 ## as an array, but we do it here to demonstrate how to use jitting with RDataFrame
 
-pidf = tdf.Define("x", "gRandom->Uniform(-1.0, 1.0)") \
-          .Define("y", "gRandom->Uniform(-1.0, 1.0)") \
-          .Define("p", "std::array<double, 2> v{x, y}; return v;") \
-          .Define("r", "double r2 = 0.0; for (auto&& w : p) r2 += w*w; return sqrt(r2);")
+pidf = df.Define("x", "gRandom->Uniform(-1.0, 1.0)") \
+         .Define("y", "gRandom->Uniform(-1.0, 1.0)") \
+         .Define("p", "std::array<double, 2> v{x, y}; return v;") \
+         .Define("r", "double r2 = 0.0; for (auto&& w : p) r2 += w*w; return sqrt(r2);")
 
 ## Now we have a dataframe with columns x, y, p (which is a point based on x
 ## and y), and the radius r = sqrt(x*x + y*y). In order to approximate pi, we

--- a/tutorials/dataframe/df013_InspectAnalysis.C
+++ b/tutorials/dataframe/df013_InspectAnalysis.C
@@ -32,13 +32,13 @@ void df013_InspectAnalysis()
    };
 
    // Let's define a column "x" produced by invoking `heavyWork` for each event
-   // `tdf` stores a modified data-frame that contains "x"
-   auto tdf = d.Define("x", heavyWork);
+   // `df` stores a modified data-frame that contains "x"
+   auto df = d.Define("x", heavyWork);
 
    // Now we register a histogram-filling action with the RDataFrame.
    // `h` can be used just like a pointer to TH1D but it is actually a TResultProxy<TH1D>, a smart object that triggers
    // an event-loop to fill the pointee histogram if needed.
-   auto h = tdf.Histo1D<double>({"browserHisto", "", 100, -2., 2.}, "x");
+   auto h = df.Histo1D<double>({"browserHisto", "", 100, -2., 2.}, "x");
 
    // ## Use the callback mechanism to draw the histogram on a TBrowser while it is being filled
    // So far we have registered a column "x" to a data-frame with `nEvents` events and we registered the filling of a
@@ -49,8 +49,8 @@ void df013_InspectAnalysis()
    // - another callback is responsible of updating a simple progress bar from multiple threads
 
    // First off we create a TBrowser that contains a "RDFResults" directory
-   auto tdfDirectory = new TMemFile("RDFResults", "RECREATE");
-   auto browser = new TBrowser("b", tdfDirectory);
+   auto dfDirectory = new TMemFile("RDFResults", "RECREATE");
+   auto browser = new TBrowser("b", dfDirectory);
    // The global pad should now be set to the TBrowser's canvas, let's store its value in a local variable
    auto browserPad = gPad;
 
@@ -60,8 +60,8 @@ void df013_InspectAnalysis()
    // increasing number of events.
    // Instead of requesting the callback to be executed every N entries, this time we use the special value `kOnce` to
    // request that it is executed once right before starting the event-loop.
-   // The callback is a C++11 lambda that registers the partial result object in `tdfDirectory`.
-   h.OnPartialResult(h.kOnce, [tdfDirectory](TH1D &h_) { tdfDirectory->Add(&h_); });
+   // The callback is a C++11 lambda that registers the partial result object in `dfDirectory`.
+   h.OnPartialResult(h.kOnce, [dfDirectory](TH1D &h_) { dfDirectory->Add(&h_); });
    // Note that we called `OnPartialResult` with a dot, `.`, since this is a method of `TResultProxy` itself.
    // We do not want to call `OnPartialResult` on the pointee histogram!)
 
@@ -111,10 +111,10 @@ void df013_InspectAnalysis()
 
    // Finally, some book-keeping: in the TMemFile that we are using as TBrowser directory, we substitute the partial
    // result with a clone of the final result (the "original" final result will be deleted at the end of the macro).
-   tdfDirectory->Clear();
+   dfDirectory->Clear();
    auto clone = static_cast<TH1D *>(h->Clone());
    clone->SetDirectory(nullptr);
-   tdfDirectory->Add(clone);
+   dfDirectory->Add(clone);
    if (!browserPad)
       return; // in case root -b was invoked
    browserPad->cd();

--- a/tutorials/dataframe/df014_CSVDataSource.C
+++ b/tutorials/dataframe/df014_CSVDataSource.C
@@ -25,15 +25,15 @@ int df014_CSVDataSource()
    auto fileName = "df014_CsvDataSource_MuRun2010B_cpp.csv";
    if(gSystem->AccessPathName(fileName))
       TFile::Cp(fileNameUrl, fileName);
-   auto tdf = ROOT::RDF::MakeCsvDataFrame(fileName);
+   auto df = ROOT::RDF::MakeCsvDataFrame(fileName);
 
    // Now we will apply a first filter based on two columns of the CSV,
    // and we will define a new column that will contain the invariant mass.
    // Note how the new invariant mass column is defined from several other
    // columns that already existed in the CSV file.
    auto filteredEvents =
-      tdf.Filter("Q1 * Q2 == -1")
-         .Define("m", "sqrt(pow(E1 + E2, 2) - (pow(px1 + px2, 2) + pow(py1 + py2, 2) + pow(pz1 + pz2, 2)))");
+      df.Filter("Q1 * Q2 == -1")
+        .Define("m", "sqrt(pow(E1 + E2, 2) - (pow(px1 + px2, 2) + pow(py1 + py2, 2) + pow(pz1 + pz2, 2)))");
 
    // Next we create a histogram to hold the invariant mass values and we draw it.
    auto invMass =

--- a/tutorials/dataframe/df014_CSVDataSource.py
+++ b/tutorials/dataframe/df014_CSVDataSource.py
@@ -27,15 +27,15 @@ fileName = "df014_CsvDataSource_MuRun2010B_py.csv"
 if not os.path.isfile(fileName):
     ROOT.TFile.Cp(fileNameUrl, fileName)
 
-MakeCsvDataFrame = ROOT.ROOT.RDF.MakeCsvDataFrame
-tdf = MakeCsvDataFrame(fileName)
+MakeCsvDataFrame = ROOT.RDF.MakeCsvDataFrame
+df = MakeCsvDataFrame(fileName)
 
 # Now we will apply a first filter based on two columns of the CSV,
 # and we will define a new column that will contain the invariant mass.
 # Note how the new invariant mass column is defined from several other
 # columns that already existed in the CSV file.
-filteredEvents = tdf.Filter("Q1 * Q2 == -1") \
-                    .Define("m", "sqrt(pow(E1 + E2, 2) - (pow(px1 + px2, 2) + pow(py1 + py2, 2) + pow(pz1 + pz2, 2)))")
+filteredEvents = df.Filter("Q1 * Q2 == -1") \
+                   .Define("m", "sqrt(pow(E1 + E2, 2) - (pow(px1 + px2, 2) + pow(py1 + py2, 2) + pow(pz1 + pz2, 2)))")
 
 # Next we create a histogram to hold the invariant mass values and we draw it.
 invMass = filteredEvents.Histo1D(("invMass", "CMS Opendata: #mu#mu mass;#mu#mu mass [GeV];Events", 512, 2, 110), "m")

--- a/tutorials/dataframe/df015_LazyDataSource.C
+++ b/tutorials/dataframe/df015_LazyDataSource.C
@@ -38,12 +38,12 @@ int df015_LazyDataSource()
 
    // Now we create a new dataframe built on top of the columns above. Note that up to now, no event loop
    // has been carried out!
-   auto tdf = MakeLazyDataFrame(std::make_pair(px1Name, px1), std::make_pair(py1Name, py1));
+   auto df = MakeLazyDataFrame(std::make_pair(px1Name, px1), std::make_pair(py1Name, py1));
 
    // We build a histogram of the transverse momentum the muons.
    auto ptFormula = [](double px, double py) { return sqrt(px * px + py * py); };
-   auto pt_h = tdf.Define("pt", ptFormula, {"px1", "py1"})
-                  .Histo1D<double>({"pt", "Muon p_{T};p_{T} [GeV/c];", 128, 0, 128}, "pt");
+   auto pt_h = df.Define("pt", ptFormula, {"px1", "py1"})
+                 .Histo1D<double>({"pt", "Muon p_{T};p_{T} [GeV/c];", 128, 0, 128}, "pt");
 
    auto can = new TCanvas();
    can->SetLogy();

--- a/tutorials/dataframe/df016_vecOps.py
+++ b/tutorials/dataframe/df016_vecOps.py
@@ -12,13 +12,13 @@
 
 import ROOT
 
-tdf = ROOT.RDataFrame(1024)
+df = ROOT.RDataFrame(1024)
 coordDefineCode = '''ROOT::VecOps::RVec<double> {0}(len);
                      std::transform({0}.begin(), {0}.end(), {0}.begin(), [](double){{return gRandom->Uniform(-1.0, 1.0);}});
                      return {0};'''
-d = tdf.Define("len", "gRandom->Uniform(0, 16)")\
-       .Define("x", coordDefineCode.format("x"))\
-       .Define("y", coordDefineCode.format("y"))
+d = df.Define("len", "gRandom->Uniform(0, 16)")\
+      .Define("x", coordDefineCode.format("x"))\
+      .Define("y", coordDefineCode.format("y"))
 
 # Now we have in hands d, a RDataFrame with two columns, x and y, which
 # hold collections of coordinates. The size of these collections vary.

--- a/tutorials/dataframe/df017_vecOpsHEP.py
+++ b/tutorials/dataframe/df017_vecOpsHEP.py
@@ -26,7 +26,7 @@ def WithPyROOT(filename):
     h.DrawCopy()
 
 def WithRDataFrameVecOpsJit(treename, filename):
-    f = ROOT.ROOT.RDataFrame(treename, filename)
+    f = ROOT.RDataFrame(treename, filename)
     h = f.Define("good_pt", "sqrt(px*px + py*py)[E>100]")\
          .Histo1D(("pt", "pt", 16, 0, 4), "good_pt")
     h.DrawCopy()

--- a/tutorials/dataframe/df019_Cache.py
+++ b/tutorials/dataframe/df019_Cache.py
@@ -22,12 +22,11 @@
 ## \author Danilo Piparo
 
 import ROOT
-RDataFrame = ROOT.ROOT.RDataFrame
 import os
 
 # We create a data frame on top of the hsimple example
 hsimplePath = os.path.join(str(ROOT.gROOT.GetTutorialDir().Data()), "hsimple.root")
-df = RDataFrame("ntuple", hsimplePath)
+df = ROOT.RDataFrame("ntuple", hsimplePath)
 
 #We apply a simple cut and define a new column
 df_cut = df.Filter("py > 0.f")\

--- a/tutorials/dataframe/df021_createTGraph.py
+++ b/tutorials/dataframe/df021_createTGraph.py
@@ -12,7 +12,7 @@
 import ROOT
 
 ROOT.ROOT.EnableImplicitMT(2)
-d = ROOT.ROOT.RDataFrame(160)
+d = ROOT.RDataFrame(160)
 
 # Create a trivial parabola
 dd = d.Alias("x", "rdfentry_").Define("y", "x*x")

--- a/tutorials/dataframe/df024_Display.C
+++ b/tutorials/dataframe/df024_Display.C
@@ -16,17 +16,17 @@ void df024_Display()
    int x = 1;
    double w = 1;
    double z = 1;
-   ROOT::RDataFrame tdf(10);
-   auto d = tdf.Define("y", [&y]() { return y *= 100; }) // A column with ulongs
-               .Define("x",
-                       [&x]() {
-                          return std::vector<int>({x++, x++, x++, x++});
-                       })                                // A column with four-elements collection
-               .Define("w", [&w]() { return w *= 1.8; }) // A column with doubles
-               .Define("z", [&z]() {
-                  z *= 1.1;
-                  return std::vector<std::vector<double>>({{z, ++z}, {z, ++z}, {z, ++z}});
-               }); // A column of matrices
+   ROOT::RDataFrame df(10);
+   auto d = df.Define("y", [&y]() { return y *= 100; }) // A column with ulongs
+              .Define("x",
+                      [&x]() {
+                         return std::vector<int>({x++, x++, x++, x++});
+                      })                                // A column with four-elements collection
+              .Define("w", [&w]() { return w *= 1.8; }) // A column with doubles
+              .Define("z", [&z]() {
+                 z *= 1.1;
+                 return std::vector<std::vector<double>>({{z, ++z}, {z, ++z}, {z, ++z}});
+              }); // A column of matrices
 
    // Preparing the RResultPtr<RDisplay> object with all columns and default number of entries
    auto d1 = d.Display("");

--- a/tutorials/dataframe/df024_Display.py
+++ b/tutorials/dataframe/df024_Display.py
@@ -17,17 +17,17 @@ ROOT.gInterpreter.ProcessLine('''
    int x = 1;
    double w = 1;
    double z = 1;
-   ROOT::RDataFrame tdf(10);
-   auto d = tdf.Define("y", [&y]() { return y *= 100; }) // A column with ulongs
-               .Define("x",
-                       [&x]() {
-                          return std::vector<int>({x++, x++, x++, x++});
-                       })                                // A column with four-elements collection
-               .Define("w", [&w]() { return w *= 1.8; }) // A column with doubles
-               .Define("z", [&z]() {
-                  z *= 1.1;
-                  return std::vector<std::vector<double>>({{z, ++z}, {z, ++z}, {z, ++z}});
-               }); // A column of matrices
+   ROOT::RDataFrame df(10);
+   auto d = df.Define("y", [&y]() { return y *= 100; }) // A column with ulongs
+              .Define("x",
+                      [&x]() {
+                         return std::vector<int>({x++, x++, x++, x++});
+                      })                                // A column with four-elements collection
+              .Define("w", [&w]() { return w *= 1.8; }) // A column with doubles
+              .Define("z", [&z]() {
+                 z *= 1.1;
+                 return std::vector<std::vector<double>>({{z, ++z}, {z, ++z}, {z, ++z}});
+              }); // A column of matrices
 ''')
 
 d = ROOT.d

--- a/tutorials/dataframe/df027_SQliteDependencyOverVersion.C
+++ b/tutorials/dataframe/df027_SQliteDependencyOverVersion.C
@@ -2,7 +2,7 @@
 /// \ingroup tutorial_dataframe
 /// \notebook -jss
 /// Plot the ROOT downloads based on the version reading a remote sqlite3 file with RSqliteDS.
-/// This tutorial uses the Reduce method which allows to extract the minimum time 
+/// This tutorial uses the Reduce method which allows to extract the minimum time
 /// stored in the SQlite3 database.
 /// The next step is to create a TH1F Histogram, which will be filled with the values stored in
 /// two different columns from the database. This procedure is simplified with a lambda
@@ -19,7 +19,7 @@ void df027_SQliteDependencyOverVersion () {
    auto rdfb = ROOT::RDF::MakeSqliteDataFrame("http://root.cern/files/root_download_stats.sqlite", "SELECT * FROM accesslog;" );
 
    auto minTimeStr = *rdfb.Reduce([](std::string a, std::string b) {return std::min(a, b);}, "Time", std::string("Z"));
-   
+
    std::cout << "Minimum time is '" << minTimeStr << "'" << std::endl;
 
    double minTime = TDatime(minTimeStr.c_str()).Convert();

--- a/tutorials/dataframe/df031_Stats.C
+++ b/tutorials/dataframe/df031_Stats.C
@@ -6,7 +6,7 @@
 ///
 /// \macro_code
 /// \macro_output
-/// 
+///
 /// \date April 2019
 /// \author Danilo Piparo
 
@@ -16,7 +16,7 @@ void df031_Stats() {
     ROOT::RDataFrame r(256);
     auto rr = r.Define("v", [](ULong64_t e){return e;}, {"rdfentry_"})
                .Define("w", [](ULong64_t e){return 1./(e+1);}, {"v"});
-    
+
     // Now extract the statistics, weighted, unweighted - with and without explicit types.
     auto stats_eu = rr.Stats<ULong64_t>("v");
     auto stats_ew = rr.Stats<ULong64_t, double>("v", "w");

--- a/tutorials/dataframe/df031_Stats.py
+++ b/tutorials/dataframe/df031_Stats.py
@@ -14,10 +14,10 @@
 import ROOT
 
 # Create a data frame and add two columns: one for the values and one for the weight.
-r = ROOT.ROOT.RDataFrame(256);
+r = ROOT.RDataFrame(256);
 rr = r.Define("v", "rdfentry_")\
       .Define("w", "return 1./(v+1)")
-    
+
 # Now extract the statistics, weighted, unweighted
 stats_iu = rr.Stats("v")
 stats_iw = rr.Stats("v", "w")

--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.py
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.py
@@ -30,7 +30,7 @@ ROOT.ROOT.EnableImplicitMT()
 files = ROOT.std.vector("string")(2)
 files[0] = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root"
 files[1] = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012C_DoubleMuParked.root"
-df = ROOT.ROOT.RDataFrame("Events", files)
+df = ROOT.RDataFrame("Events", files)
 
 # For simplicity, select only events with exactly two muons and require opposite charge
 df_2mu = df.Filter("nMuon == 2", "Events with exactly two muons")

--- a/tutorials/dataframe/df104_HiggsToTwoPhotons.py
+++ b/tutorials/dataframe/df104_HiggsToTwoPhotons.py
@@ -73,7 +73,7 @@ for p in processes:
 
     # Book histogram of the invariant mass with this selection
     hists[p] = df[p].Histo1D(
-            ROOT.ROOT.RDF.TH1DModel(p, "Diphoton invariant mass; m_{#gamma#gamma} [GeV];Events", 30, 105, 160),
+            ROOT.RDF.TH1DModel(p, "Diphoton invariant mass; m_{#gamma#gamma} [GeV];Events", 30, 105, 160),
             "m_yy", "weight")
 
 # Run the event loop

--- a/tutorials/dataframe/df105_WBosonAnalysis.py
+++ b/tutorials/dataframe/df105_WBosonAnalysis.py
@@ -102,7 +102,7 @@ float ComputeTransverseMass(float met_et, float met_phi, float lep_pt, float lep
 histos = {}
 for s in samples:
     df[s] = df[s].Define("mt_w", "ComputeTransverseMass(met_et, met_phi, lep_pt[idx], lep_eta[idx], lep_phi[idx], lep_E[idx])")
-    histos[s] = df[s].Histo1D(ROOT.ROOT.RDF.TH1DModel(s, "mt_w", 40, 60, 180), "mt_w", "weight")
+    histos[s] = df[s].Histo1D(ROOT.RDF.TH1DModel(s, "mt_w", 40, 60, 180), "mt_w", "weight")
 
 # Run the event loop and merge histograms of the respective processes
 


### PR DESCRIPTION
* Remove ROOT.ROOT calls in the Python tutorials
* Use rdfentry_ instead of tdfentry_
* Use df for variables instead of tdf

@etejedor Fine by you? The tutorials will now break with the old PyROOT.