### PR TITLE
[DF] Throw if Snapshot's output TTree is already present in output file

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1125,6 +1125,8 @@ inline void UpdateBoolArray(BoolArrayMap &boolArrays, RVec<bool> &v, const std::
    }
 }
 
+void ValidateSnapshotOutput(const RSnapshotOptions &opts, const std::string &treeName, const std::string &fileName);
+
 /// Helper object for a single-thread Snapshot action
 template <typename... BranchTypes>
 class SnapshotHelper : public RActionImpl<SnapshotHelper<BranchTypes...>> {
@@ -1150,6 +1152,7 @@ public:
         fOutputBranchNames(ReplaceDotWithUnderscore(bnames)), fBranches(vbnames.size(), nullptr),
         fBranchAddresses(vbnames.size(), nullptr)
    {
+      ValidateSnapshotOutput(fOptions, fTreeName, fFileName);
    }
 
    SnapshotHelper(const SnapshotHelper &) = delete;
@@ -1283,6 +1286,7 @@ public:
         fBranches(fNSlots, std::vector<TBranch *>(vbnames.size(), nullptr)), 
         fBranchAddresses(fNSlots, std::vector<void *>(vbnames.size(), nullptr))
    {
+      ValidateSnapshotOutput(fOptions, fTreeName, fFileName);
    }
    SnapshotHelperMT(const SnapshotHelperMT &) = delete;
    SnapshotHelperMT(SnapshotHelperMT &&) = default;

--- a/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
+++ b/tree/dataframe/inc/ROOT/RSnapshotOptions.hxx
@@ -24,9 +24,10 @@ struct RSnapshotOptions {
    RSnapshotOptions() = default;
    RSnapshotOptions(const RSnapshotOptions &) = default;
    RSnapshotOptions(RSnapshotOptions &&) = default;
-   RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy)
+   RSnapshotOptions(std::string_view mode, ECAlgo comprAlgo, int comprLevel, int autoFlush, int splitLevel, bool lazy,
+                    bool overwriteIfExists = false)
       : fMode(mode), fCompressionAlgorithm(comprAlgo), fCompressionLevel{comprLevel}, fAutoFlush(autoFlush),
-        fSplitLevel(splitLevel), fLazy(lazy)
+        fSplitLevel(splitLevel), fLazy(lazy), fOverwriteIfExists(overwriteIfExists)
    {
    }
    std::string fMode = "RECREATE";             ///< Mode of creation of output file
@@ -34,7 +35,8 @@ struct RSnapshotOptions {
    int fCompressionLevel = 1;                  ///< Compression level of output file
    int fAutoFlush = 0;                         ///< AutoFlush value for output tree
    int fSplitLevel = 99;                       ///< Split level of output tree
-   bool fLazy = false;                         ///< Delay the snapshot of the dataset
+   bool fLazy = false;                         ///< Do not start the event loop when Snapshot is called
+   bool fOverwriteIfExists = false; ///< If fMode is "UPDATE", overwrite object in output file if it already exists
 };
 } // ns RDF
 } // ns ROOT

--- a/tree/dataframe/src/RDFActionHelpers.cxx
+++ b/tree/dataframe/src/RDFActionHelpers.cxx
@@ -233,6 +233,37 @@ template class TakeHelper<float, float, std::vector<float>>;
 template class TakeHelper<double, double, std::vector<double>>;
 #endif
 
+void ValidateSnapshotOutput(const RSnapshotOptions &opts, const std::string &treeName, const std::string &fileName)
+{
+   TString fileMode = opts.fMode;
+   fileMode.ToLower();
+   if (fileMode != "update")
+      return;
+
+   // output file opened in "update" mode: must check whether output TTree is already present in file
+   std::unique_ptr<TFile> outFile{TFile::Open(fileName.c_str(), "update")};
+   if (!outFile || outFile->IsZombie())
+      throw std::invalid_argument("Snapshot: cannot open file \"" + fileName + "\" in update mode");
+
+   TObject *outTree = outFile->Get(treeName.c_str());
+   if (outTree == nullptr)
+      return;
+
+   // object called treeName is already present in the file
+   if (opts.fOverwriteIfExists) {
+      if (outTree->InheritsFrom("TTree")) {
+         static_cast<TTree *>(outTree)->Delete("all");
+      } else {
+         outFile->Delete(treeName.c_str());
+      }
+   } else {
+      const std::string msg = "Snapshot: tree \"" + treeName + "\" already present in file \"" + fileName +
+                              "\". If you want to delete the original tree and write another, please set "
+                              "RSnapshotOptions::fOverwriteIfExists to true.";
+      throw std::invalid_argument(msg);
+   }
+}
+
 } // end NS RDF
 } // end NS Internal
 } // end NS ROOT


### PR DESCRIPTION
...and add RSnapshotOptions::fOverwriteIfExists to give users the chance
to still write a TTree to a TFile opened in UPDATE mode, even if a TTree
with the same name is already present in the file, at the cost of deleting
the previous TTree from the file.

This fixes ROOT-10573.

~~EDIT: still missing a test for `fOverwriteIfExists`, coming soon~~