### PR TITLE
[RF] Prevent access into empty vector in ConfidenceBelt.

### DIFF
--- a/roofit/roostats/inc/RooStats/FeldmanCousins.h
+++ b/roofit/roostats/inc/RooStats/FeldmanCousins.h
@@ -89,6 +89,7 @@ namespace RooStats {
    return fPointsToTest;
       }
 
+      /// Get the confidence belt. This requires that CreateConfBelt() has been set.
       ConfidenceBelt* GetConfidenceBelt() {return fConfBelt;}
 
       void UseAdaptiveSampling(bool flag=true){fAdaptiveSampling=flag;}

--- a/roofit/roostats/inc/RooStats/NeymanConstruction.h
+++ b/roofit/roostats/inc/RooStats/NeymanConstruction.h
@@ -95,8 +95,8 @@ namespace RooStats {
       /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
       virtual void SetConfidenceLevel(Double_t cl) {fSize = 1.-cl;}
 
-      /// get confidence belt
-      ConfidenceBelt* GetConfidenceBelt() {return fConfBelt;}
+      /// Get confidence belt. This requires that CreateConfBelt() has been called.
+      ConfidenceBelt* GetConfidenceBelt() {return fCreateBelt ? fConfBelt : nullptr;}
 
       /// adaptive sampling algorithm to speed up interval calculation
       void UseAdaptiveSampling(bool flag=true){fAdaptiveSampling=flag;}

--- a/roofit/roostats/src/ConfidenceBelt.cxx
+++ b/roofit/roostats/src/ConfidenceBelt.cxx
@@ -229,7 +229,10 @@ AcceptanceRegion* ConfidenceBelt::GetAcceptanceRegion(RooArgSet &parameterPoint,
     //    RooStats::SetParameters(&parameterPoint, const_cast<RooArgSet*>(hist->get()));
     //    Int_t index = hist->calcTreeIndex(); // get index
     int index = hist->getIndex(parameterPoint); // get index
-    return &(fSamplingSummaries.at(index).GetAcceptanceRegion());
+    if (index >= fSamplingSummaries.size())
+      throw std::runtime_error("ConfidenceBelt::GetAcceptanceRegion: Sampling summaries are not filled yet. Switch on NeymanConstruction::CreateConfBelt() or FeldmanCousins::CreateConfBelt().");
+
+    return &(fSamplingSummaries[index].GetAcceptanceRegion());
   }
   else if( tree ){
     // need a way to get index for given point
@@ -249,7 +252,10 @@ AcceptanceRegion* ConfidenceBelt::GetAcceptanceRegion(RooArgSet &parameterPoint,
    break;
     }
 
-    return &(fSamplingSummaries.at(index).GetAcceptanceRegion());
+    if (index >= fSamplingSummaries.size())
+      throw std::runtime_error("ConfidenceBelt::GetAcceptanceRegion: Sampling summaries are not filled yet. Switch on NeymanConstruction::CreateConfBelt() or FeldmanCousins::CreateConfBelt().");
+
+    return &(fSamplingSummaries[index].GetAcceptanceRegion());
   }
   else {
       std::cout << "dataset is not initialized properly" << std::endl;

--- a/roofit/roostats/src/ConfidenceBelt.cxx
+++ b/roofit/roostats/src/ConfidenceBelt.cxx
@@ -229,7 +229,7 @@ AcceptanceRegion* ConfidenceBelt::GetAcceptanceRegion(RooArgSet &parameterPoint,
     //    RooStats::SetParameters(&parameterPoint, const_cast<RooArgSet*>(hist->get()));
     //    Int_t index = hist->calcTreeIndex(); // get index
     int index = hist->getIndex(parameterPoint); // get index
-    if (index >= fSamplingSummaries.size())
+    if (index >= (int)fSamplingSummaries.size())
       throw std::runtime_error("ConfidenceBelt::GetAcceptanceRegion: Sampling summaries are not filled yet. Switch on NeymanConstruction::CreateConfBelt() or FeldmanCousins::CreateConfBelt().");
 
     return &(fSamplingSummaries[index].GetAcceptanceRegion());
@@ -252,7 +252,7 @@ AcceptanceRegion* ConfidenceBelt::GetAcceptanceRegion(RooArgSet &parameterPoint,
    break;
     }
 
-    if (index >= fSamplingSummaries.size())
+    if (index >= (int)fSamplingSummaries.size())
       throw std::runtime_error("ConfidenceBelt::GetAcceptanceRegion: Sampling summaries are not filled yet. Switch on NeymanConstruction::CreateConfBelt() or FeldmanCousins::CreateConfBelt().");
 
     return &(fSamplingSummaries[index].GetAcceptanceRegion());

--- a/roofit/roostats/src/FeldmanCousins.cxx
+++ b/roofit/roostats/src/FeldmanCousins.cxx
@@ -72,7 +72,7 @@ FeldmanCousins::FeldmanCousins(RooAbsData& data, ModelConfig& model) :
   fTestStatSampler(0),
   fPointsToTest(0),
   fPOIToTest(0),
-  fConfBelt(0),
+  fConfBelt(nullptr),
   fAdaptiveSampling(false),
   fAdditionalNToysFactor(1.),
   fNbins(10),
@@ -254,7 +254,9 @@ PointSetInterval* FeldmanCousins::GetInterval() const {
   nc.AdditionalNToysFactor(fAdditionalNToysFactor);
   nc.SaveBeltToFile(fSaveBeltToFile);
   nc.CreateConfBelt(fCreateBelt);
-  fConfBelt = nc.GetConfidenceBelt();
+  if (fCreateBelt)
+    fConfBelt = nc.GetConfidenceBelt();
+
   // use it
   return nc.GetInterval();
 }


### PR DESCRIPTION
When not setting CreateConfBelt() for FeldmanCousins or
NeymanConstruction, GetConfidenceBelt() returns nullptr instead of a
broken belt. The documentation also reflects this now.