### PR TITLE
Improve the documentation for the `W` and `EX0` fit option

### DIFF
--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -244,7 +244,7 @@ TFitResultPtr HFit::Fit(FitObject * h1, TF1 *f1 , Foption_t & fitOption , const 
 
    // error normalization in case of zero error in the data
    if (fitdata->GetErrorType() == ROOT::Fit::BinData::kNoError) fitConfig.SetNormErrors(true);
-   // error normalization also in case of W1 option (weights = 1)
+   // error normalization also in case of W or WW options (weights = 1)
    if (fitdata->Opt().fErrors1)  fitConfig.SetNormErrors(true);
    // normalize errors also in case you are fitting a Ndim histo with a N-1 function
    if (int(fitdata->NDim())  == hdim -1 ) fitConfig.SetNormErrors(true);
@@ -781,6 +781,10 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
       if (opt.Contains("W")) fitOption.W1     = 1; // all non-empty bins have weight =1 (for chi2 fit)
    }
 
+   if (fitOption.PChi2 && fitOption.W1) {
+      Warning("FitOptionsMake", "Ignore option W or WW when used together with option P (Pearson chi2)");
+      fitOption.W1 = 0; // with Pearson chi2 W option is ignored
+   }
 
    if (opt.Contains("E")) fitOption.Errors  = 1;
    if (opt.Contains("R")) fitOption.Range   = 1;

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -1079,7 +1079,7 @@ TFitResultPtr TGraph::Fit(const char *fname, Option_t *option, Option_t *, Axis_
 ///
 /// option | description
 /// -------|------------
-/// "W" | Set all weights to 1; ignore error bars
+/// "W" | Ignore all point errors when fitting a TGraphErrors or TGraphAsymmErrors
 /// "U" | Use a User specified fitting algorithm (via SetFCN)
 /// "Q" | Quiet mode (minimum printing)
 /// "V" | Verbose mode (default is between Q and V)
@@ -1092,7 +1092,7 @@ TFitResultPtr TGraph::Fit(const char *fname, Option_t *option, Option_t *, Axis_
 /// "+" | Add this new fitted function to the list of fitted functions (by default, any previous function is deleted)
 /// "C" | In case of linear fitting, do not calculate the chisquare (saves time)
 /// "F" | If fitting a polN, use the minuit fitter
-/// "EX0" | When fitting a TGraphErrors or TGraphAsymErrors do not consider errors in the coordinate
+/// "EX0" | When fitting a TGraphErrors or TGraphAsymErrors do not consider errors in the X coordinates
 /// "ROB" | In case of linear fitting, compute the LTS regression coefficients (robust (resistant) regression), using the default fraction of good points "ROB=0.x" - compute the LTS regression coefficients, using 0.x as a fraction of good points
 /// "S" |  The result of the fit is returned in the TFitResultPtr (see below Access to the Fit Result)
 ///

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -787,7 +787,7 @@ TFitResultPtr TGraph2D::Fit(const char *fname, Option_t *option, Option_t *)
 ///
 /// | Option   | Description                                                       |
 /// |----------|-------------------------------------------------------------------|
-/// | "W"      | Set all weights to 1; ignore error bars |
+/// | "W"      | Ignore all point errors when fitting a TGraph2DErrors |
 /// | "U"      | Use a User specified fitting algorithm (via SetFCN) |
 /// | "Q"      | Quiet mode (minimum printing) |
 /// | "V"      | Verbose mode (default is between Q and V) |
@@ -796,7 +796,7 @@ TFitResultPtr TGraph2D::Fit(const char *fname, Option_t *option, Option_t *)
 /// | "0"      | Do not plot the result of the fit. By default the fitted function is drawn unless the option "N" above is specified. |
 /// | "+"      | Add this new fitted function to the list of fitted functions (by default, any previous function is deleted) |
 /// | "C"      | In case of linear fitting, not calculate the chisquare (saves time) |
-/// | "EX0"    | When fitting a TGraphErrors do not consider errors in the coordinate |
+/// | "EX0"    | When fitting a TGraph2DErrors do not consider errors in the X,Y coordinates |
 /// | "ROB"    | In case of linear fitting, compute the LTS regression coefficients (robust (resistant) regression), using the default fraction of good points "ROB=0.x" - compute the LTS regression coefficients, using 0.x as a fraction of good points |
 /// | "S"      | The result of the fit is returned in the TFitResultPtr (see below Access to the Fit Result) |
 ///

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3819,8 +3819,8 @@ TFitResultPtr TH1::Fit(const char *fname ,Option_t *option ,Option_t *goption, D
 /// Fit histogram with function f1.
 ///
 /// \param[in] option fit options is given in parameter option.
-///        - "W"  Set all weights to 1 for non empty bins; ignore error bars
-///        - "WW" Set all weights to 1 including empty bins; ignore error bars
+///        - "W"  Ignore the bin uncertainties when fitting using the default least square (chi2) method but skip empty bins
+///        - "WW" Ignore the bin uncertainties when fitting using the default least square (chi2) method and include also the empty bins
 ///        - "I"  Use integral of function in bin, normalized by the bin volume,
 ///          instead of value at bin center
 ///        -  "L"  Use Loglikelihood method (default is chisquare method)

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -584,7 +584,7 @@ TFitResultPtr TMultiGraph::Fit(const char *fname, Option_t *option, Option_t *, 
 ///  The list of fit options is given in parameter `option`which may takes the
 ///  following values:
 ///
-///   - "W"  Set all errors to 1
+///   - "W" Ignore all the point errors
 ///   - "U" Use a User specified fitting algorithm (via SetFCN)
 ///   - "Q" Quiet mode (minimum printing)
 ///   - "V" Verbose mode (default is between Q and V)


### PR DESCRIPTION
As suggested in https://root-forum.cern.ch/t/fitting-tgraphasymerrors-difference-between-w-and-ex0/38522