### PR TITLE
Don't use `win_broken_tests` to change compiler flags [skip-ci]

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -91,12 +91,10 @@ if(NOT "${ROOT_CLING_TARGET}" STREQUAL "all")
 endif()
 
 if(MSVC)
-  if(NOT win_broken_tests)
-    # FIXME: since Visual Studio v16.4.0 the /O2 optimization flag make many (25%) of the tests failing
-    # Try to re-enable /O2 after the upgrade of llvm & clang
-    string(REPLACE "-O2" "-O1" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-    string(REPLACE "-O2" "-O1" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-  endif()
+  # FIXME: since Visual Studio v16.4.0 the /O2 optimization flag make many (25%) of the tests failing
+  # Try to re-enable /O2 after the upgrade of llvm & clang
+  string(REPLACE "-O2" "-O1" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  string(REPLACE "-O2" "-O1" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
   # replace dashes in the -EH* and -GR* flags with slashes (/EH* /GR*)
   string(REPLACE " -EH" " /EH" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   string(REPLACE " -GR" " /GR" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
otherwise it doesn't build at all (the compilation fails)