### PR TITLE
[RF] Fix plotting when running ranged fits multiple times.

### DIFF
--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -290,27 +290,26 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
   if (rangeName && strlen(rangeName)) {    
     cxcoutI(Fitting) << "RooAbsOptTestStatistic::ctor(" << GetName() << ") constructing test statistic for sub-range named " << rangeName << endl ;    
 
+    bool observablesKnowRange = false;
     // Adjust FUNC normalization ranges to requested fitRange, store original ranges for RooAddPdf coefficient interpretation
     for (const auto arg : *_funcObsSet) {
 
       RooRealVar* realObs = dynamic_cast<RooRealVar*>(arg) ;
       if (realObs) {
 
-	// If no explicit range is given for RooAddPdf coefficients, create explicit named range equivalent to original observables range
+        observablesKnowRange |= realObs->hasRange(rangeName);
+
+        // If no explicit range is given for RooAddPdf coefficients, create explicit named range equivalent to original observables range
         if (!(addCoefRangeName && strlen(addCoefRangeName))) {
-	  realObs->setRange(Form("NormalizationRangeFor%s",rangeName),realObs->getMin(),realObs->getMax()) ;
-// 	  cout << "RAOTS::ctor() setting range " << Form("NormalizationRangeFor%s",rangeName) << " on observable " 
-// 	       << realObs->GetName() << " to [" << realObs->getMin() << "," << realObs->getMax() << "]" << endl ;
-	}
+          realObs->setRange(Form("NormalizationRangeFor%s",rangeName),realObs->getMin(),realObs->getMax()) ;
+        }
 
-	// Adjust range of function observable to those of given named range
-	realObs->setRange(realObs->getMin(rangeName),realObs->getMax(rangeName)) ;	
-//  	cout << "RAOTS::ctor() setting normalization range on observable " 
-//  	     << realObs->GetName() << " to [" << realObs->getMin() << "," << realObs->getMax() << "]" << endl ;
+        // Adjust range of function observable to those of given named range
+        realObs->setRange(realObs->getMin(rangeName),realObs->getMax(rangeName)) ;
 
-	// Adjust range of data observable to those of given named range
-	RooRealVar* dataObs = (RooRealVar*) dataObsSet->find(realObs->GetName()) ;
-	dataObs->setRange(realObs->getMin(rangeName),realObs->getMax(rangeName)) ;	
+        // Adjust range of data observable to those of given named range
+        RooRealVar* dataObs = (RooRealVar*) dataObsSet->find(realObs->GetName()) ;
+        dataObs->setRange(realObs->getMin(rangeName),realObs->getMax(rangeName)) ;
        
         // Keep track of list of fit ranges in string attribute fit range of original p.d.f.
         if (!_splitRange) {
@@ -329,6 +328,9 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
         }
       }
     }
+
+    if (!observablesKnowRange)
+      coutW(Fitting) << "None of the fit observables seem to know the range '" << rangeName << "'. This means that the full range will be used." << std::endl;
   }
   delete origObsSet ;
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1026,6 +1026,10 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
       RooRealVar* rrv =  dynamic_cast<RooRealVar*>(arg) ;
       if (rrv) rrv->setRange("fit",rangeLo,rangeHi) ;
     }
+
+    // Clear possible range attributes from previous fits.
+    setStringAttribute("fitrange", nullptr);
+
     // Set range name to be fitted to "fit"
     rangeName = "fit" ;
   }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2726,6 +2726,7 @@ void removeRangeOverlap(std::vector<std::pair<double, double>>& ranges) {
 /// <tr><td> `ProjectionRange(const char* rn)`  <td>  Override default range of projection integrals to a different
 ///               range specified by given range name. This technique allows you to project a finite width slice in a real-valued observable
 /// <tr><td> `NormRange(const char* name)`      <td>  Calculate curve normalization w.r.t. specified range[s].
+///               See the tutorial rf212_rangesAndBlinding.C
 ///               \note A Range() by default sets a NormRange() on the same range, but this option allows
 ///               to override the default, or specify normalization ranges when the full curve is to be drawn.
 ///

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2933,13 +2933,15 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
       }
 
       if (hasCustomRange && adjustNorm) {
+        // If overlapping ranges were given, remove them now
         const std::size_t oldSize = rangeLim.size();
         removeRangeOverlap(rangeLim);
 
-        if (oldSize != rangeLim.size()) {
+        if (oldSize != rangeLim.size() && !pc.hasProcessed("NormRange")) {
           // User gave overlapping ranges. This leads to double-counting events and integrals, and must
-          // therefore be avoided.
-          coutE(Plotting) << "Requested ranges overlap. For correct plotting, new ranges "
+          // therefore be avoided. If a NormRange has been given, the overlap is alreay gone.
+          // It's safe to plot even with overlap now.
+          coutE(Plotting) << "Requested plot/integration ranges overlap. For correct plotting, new ranges "
               "will be defined." << std::endl;
           auto plotVar = dynamic_cast<RooRealVar*>(frame->getPlotVar());
           assert(plotVar);

--- a/tutorials/roofit/rf212_rangesAndBlinding.C
+++ b/tutorials/roofit/rf212_rangesAndBlinding.C
@@ -1,0 +1,90 @@
+/// \ingroup tutorial_roofit
+/// \notebook -js
+/// Plot a PDF in disjunct ranges, and get normalisation right.
+///
+/// When comparing a fit to data, one should first plot the data, and then the PDF. In this case, the PDF can be normalised
+/// to match the number of data events. However, when e.g. a signal region has to be blinded, and the fit only runs in two
+/// side bands, what should the PDF be normalised to when being plotted?
+/// In this tutorial, we show how one can choose what a PDF is normalised to.
+///
+/// \macro_image
+/// \macro_code
+/// \macro_output
+/// \author 03/2020 - Stephan Hageboeck.
+/// Thanks to Marc Escalier for providing a part of the code and for asking how to do this.
+
+#include <RooDataSet.h>
+#include <RooExponential.h>
+#include <RooPlot.h>
+#include <RooRealVar.h>
+#include <TCanvas.h>
+
+using namespace RooFit;
+
+void rf212_rangesAndBlinding()
+{
+  // Make a fit model
+  RooRealVar x("x", "The observable", 1, 30);
+  RooRealVar tau("tau", "The exponent", -0.1337, -10., -0.1);
+  RooExponential exp("exp", "A falling exponential function", x, tau);
+  
+  // Define the sidebands (e.g. background regions)
+  x.setRange("full", 1, 30);
+  x.setRange("left", 1, 10);
+  x.setRange("right", 20, 30);
+
+  // Generate toy data 
+  RooDataSet* data = exp.generate(x, 1000);
+  auto blindedData = data->reduce(CutRange("left,right")); 
+  
+  // Kick tau to a different value, and run a blinded fit.
+  // ----------------------------------------------------------------------------------------------------------
+  tau.setVal(-2.);
+  exp.fitTo(*blindedData);
+ 
+
+  // Here we will plot the results
+  TCanvas *canvas=new TCanvas("canvas","canvas",800,600);
+  canvas->Divide(2,1);
+  
+
+  // Wrong:
+  // Plotting each slice on its own normalises the PDF over its plotting range. For the full curve, that means
+  // that the blinded region where data is missing is included in the normalisation calculation. The PDF therefore
+  // comes out too low, and doesn't match up with the slices in the side bands, which are normalised to "their" data.
+  // ----------------------------------------------------------------------------------------------------------
+ 
+  std::cout << "Now plotting with unique normalisation for each slice." << std::endl;
+  canvas->cd(1);
+  RooPlot* plotFrame = x.frame(RooFit::Title("Wrong: Each slice normalised over its plotting range"));
+  
+  // Plot only the blinded data, and then plot the PDF over the full range as well as both sidebands
+  blindedData->plotOn(plotFrame);
+  exp.plotOn(plotFrame, LineColor(kRed),   Range("full"));
+  exp.plotOn(plotFrame, LineColor(kBlue),  Range("left"));
+  exp.plotOn(plotFrame, LineColor(kGreen), Range("right"));
+  
+  plotFrame->Draw();
+
+  // Right:
+  // Make the same plot, but normalise each piece with respect to the regions "left" AND "right". This requires setting
+  // a "NormRange", which tells RooFit over which range the PDF has to be integrated to normalise.
+  // This is means that the normalisation of the blue and green curves is slightly different from the left plot,
+  // because they get a common scale factor.
+  // ----------------------------------------------------------------------------------------------------------
+ 
+  std::cout << "\n\nNow plotting with correct norm ranges:" << std::endl;
+  canvas->cd(2);
+  RooPlot* plotFrameWithNormRange = x.frame(RooFit::Title("Right: All slices have common normalisation"));
+  
+  // Plot only the blinded data, and then plot the PDF over the full range as well as both sidebands
+  blindedData->plotOn(plotFrameWithNormRange);
+  exp.plotOn(plotFrameWithNormRange, LineColor(kBlue),  Range("left"),  RooFit::NormRange("left,right"));
+  exp.plotOn(plotFrameWithNormRange, LineColor(kGreen), Range("right"), RooFit::NormRange("left,right"));
+  exp.plotOn(plotFrameWithNormRange, LineColor(kRed),   Range("full"),  RooFit::NormRange("left,right"), LineStyle(10));
+  
+  plotFrameWithNormRange->Draw();
+
+  canvas->Draw(); 
+
+}


### PR DESCRIPTION
[ROOT-10550] When a ranged fit is repeated, RooAbsOptTestStatistic would
attach the fit range to the PDF for each iteration. This makes the fit
range string grow with every iteration.