### PR TITLE
[notebook] add custom colors and gStyle in JSROOT drawings [ROOT-10624][skip-ci]

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -242,6 +242,49 @@ def invokeAclic(cell):
     else:
         processCppCode(".L %s+" %fileName)
 
+def produceCanvasJson(canvas):
+   # Add extra primitives to canvas with custom colors, palette, gStyle
+   prim = canvas.GetListOfPrimitives()
+
+   style = ROOT.gStyle
+   colors = ROOT.gROOT.GetListOfColors()
+   palette = None
+
+   # always provide gStyle object
+   if prim.FindObject(style):
+      style = None
+   else:
+      prim.Add(style)
+
+   cnt = 0
+   for n in range(colors.GetLast()+1):
+      if colors.At(n): cnt = cnt+1
+        
+   # add all colors if there are more than 598 colors defined
+   if cnt < 599 or prim.FindObject(colors):
+      colors = None
+   else:
+      prim.Add(colors)
+
+   if colors:
+      pal = ROOT.TColor.GetPalette()
+      palette = ROOT.TObjArray()
+      palette.SetName("CurrentColorPalette")
+      for i in range(pal.GetSize()):
+         palette.Add(colors.At(pal[i]))
+      prim.Add(palette)
+
+   ROOT.TColor.DefinedColors()
+    
+   canvas_json = ROOT.TBufferJSON.ConvertToJSON(canvas, 3)
+
+   # Cleanup primitives after conversion
+   if style is not None: prim.Remove(style)
+   if colors is not None: prim.Remove(colors)
+   if palette is not None: prim.Remove(palette)
+     
+   return canvas_json
+
 transformers = []
 
 class StreamCapture(object):
@@ -410,48 +453,9 @@ class NotebookDrawer(object):
                     return False
         return True
 
-
     def _getJsCode(self):
-        # Add extra primitives to canvas with custom colors, palette, gStyle
-        prim = self.drawableObject.GetListOfPrimitives()
-
-        style = ROOT.gStyle
-        colors = ROOT.gROOT.GetListOfColors()
-        palette = None
-
-        # always provide gStyle object
-        if prim.FindObject(style):
-           style = None
-        else:
-           prim.Add(style)
-
-        cnt = 0
-        for n in range(colors.GetLast()+1):
-           if colors.At(n): cnt = cnt+1
-           
-        # add all colors if there are more than 598 colors defined
-        if cnt < 599 or prim.FindObject(colors):
-           colors = None
-        else:
-           prim.Add(colors)
-
-        if colors:
-           pal = ROOT.TColor.GetPalette()
-           palette = ROOT.TObjArray()
-           palette.SetName("CurrentColorPalette")
-           for i in range(pal.GetSize()):
-              palette.Add(colors.At(pal[i]))
-           prim.Add(palette)
-
-        ROOT.TColor.DefinedColors()
-       
-        # Workaround to have ConvertToJSON work
-        json = ROOT.TBufferJSON.ConvertToJSON(self.drawableObject, 3)
-
-        # Cleanup primitives after conversion
-        if style: prim.Remove(style)
-        if colors: prim.Remove(colors)
-        if palette: prim.Remove(palette)
+        # produce JSON for the canvas
+        json = produceCanvasJson(self.drawableObject)
 
         # Here we could optimise the string manipulation
         divId = 'root_plot_' + str(self._getUID())


### PR DESCRIPTION
When custom colors created in ROOT (in most cases - due to custom
palette), list of custom colors will be temporary inserted into canvas
list of primitives. Also current palette will be placed there.
And gStyle object inserted into list of primitives - it has defaults
which can affect produced JSROOT output