### PR TITLE
[rootcling] Remove unused information from the rdict files.

### DIFF
--- a/core/dictgen/res/rootcling_impl.h
+++ b/core/dictgen/res/rootcling_impl.h
@@ -30,7 +30,6 @@ namespace RootCling {
       void (*fAddStreamerInfoToROOTFile)(const char *normName) = nullptr;
       void (*fAddTypedefToROOTFile)(const char *tdname) = nullptr;
       void (*fAddEnumToROOTFile)(const char *tdname) = nullptr;
-      void (*fAddAncestorPCMROOTFile)(const char *pcmName) = nullptr;
       bool (*fCloseStreamerInfoROOTFile)(bool writeEmptyRootPCM) = nullptr;
    };
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4416,12 +4416,6 @@ int RootClingMain(int argc,
                                  gOptUmbrellaInput.ArgStr.data());
    }
 
-
-   if (gDriverConfig->fAddAncestorPCMROOTFile) {
-      for (const auto & baseModule : gOptModuleDependencies)
-         gDriverConfig->fAddAncestorPCMROOTFile(baseModule.c_str());
-   }
-
    // We have a multiDict request. This implies generating a pcm which is of the form
    // dictName_libname_rdict.pcm
    if (gOptMultiDict) {

--- a/io/rootpcm/res/rootclingIO.h
+++ b/io/rootpcm/res/rootclingIO.h
@@ -21,7 +21,6 @@ extern "C" {
    void AddStreamerInfoToROOTFile(const char *normName);
    void AddTypedefToROOTFile(const char *tdname);
    void AddEnumToROOTFile(const char *tdname);
-   void AddAncestorPCMROOTFile(const char *pcmName);
    bool CloseStreamerInfoROOTFile(bool writeEmptyRootPCM);
 }
 

--- a/io/rootpcm/src/rootclingIO.cxx
+++ b/io/rootpcm/src/rootclingIO.cxx
@@ -26,7 +26,6 @@ std::string gPCMFilename;
 std::vector<std::string> gClassesToStore;
 std::vector<std::string> gTypedefsToStore;
 std::vector<std::string> gEnumsToStore;
-std::vector<std::string> gAncestorPCMNames;
 
 extern "C"
 void InitializeStreamerInfoROOTFile(const char *filename)
@@ -52,12 +51,6 @@ extern "C"
 void AddEnumToROOTFile(const char *enumname)
 {
    gEnumsToStore.emplace_back(enumname);
-}
-
-extern "C"
-void AddAncestorPCMROOTFile(const char *pcmName)
-{
-   gAncestorPCMNames.emplace_back(pcmName);
 }
 
 static bool IsUniquePtrOffsetZero()
@@ -252,9 +245,6 @@ bool CloseStreamerInfoROOTFile(bool writeEmptyRootPCM)
    protoClasses.Delete();
    typedefs.Write("__Typedefs", TObject::kSingleKey);
    enums.Write("__Enums", TObject::kSingleKey);
-
-   dictFile.WriteObjectAny(&gAncestorPCMNames, "std::vector<std::string>", "__AncestorPCMNames");
-
 
    return true;
 }

--- a/main/src/rootcling.cxx
+++ b/main/src/rootcling.cxx
@@ -38,7 +38,6 @@ int main(int argc, char **argv)
    config.fAddStreamerInfoToROOTFile = &AddStreamerInfoToROOTFile;
    config.fAddTypedefToROOTFile = &AddTypedefToROOTFile;
    config.fAddEnumToROOTFile = &AddEnumToROOTFile;
-   config.fAddAncestorPCMROOTFile = &AddAncestorPCMROOTFile;
    config.fCloseStreamerInfoROOTFile = &CloseStreamerInfoROOTFile;
 
    return ROOT_rootcling_Driver(argc, argv, config);


### PR DESCRIPTION
rootcling writes dependency information which is never read/used when loading the rdict file.