### PR TITLE
Use std::numeric_limits<double>::epsilon for machine precision in Minuit2

### DIFF
--- a/math/minuit2/inc/Minuit2/MnMachinePrecision.h
+++ b/math/minuit2/inc/Minuit2/MnMachinePrecision.h
@@ -18,8 +18,14 @@ namespace ROOT {
 
 
 /**
-    determines the relative floating point arithmetic precision. The
-    SetPrecision() method can be used to override Minuit's own determination,
+    Sets the relative floating point (double) arithmetic precision.
+    By default the precision values are obtained from the standard functions
+    std::numeric_limits<double>::epsilon.
+    The values can optionally be computed directly using the ComputePrecision()
+    member function. For a IEEE standard floating point arithmetic the computed values and
+    the one from std::numeric_limits<double>::epsilon  are the same.
+
+    SetPrecision() method can instead be used to override Minuit's own determination,
     when the user knows that the {FCN} function Value is not calculated to
     the nominal machine accuracy.
  */
@@ -51,6 +57,10 @@ public:
     fEpsMac = prec;
     fEpsMa2 = 2.*sqrt(fEpsMac);
   }
+
+   /// compute Machine precision directly instead
+   /// of using default values from std::numeric_limits
+   void ComputePrecision(); 
 
 private:
 

--- a/math/minuit2/inc/Minuit2/MnMachinePrecision.h
+++ b/math/minuit2/inc/Minuit2/MnMachinePrecision.h
@@ -36,15 +36,6 @@ public:
 
   MnMachinePrecision();
 
-  ~MnMachinePrecision() {}
-
-  MnMachinePrecision(const MnMachinePrecision& prec) : fEpsMac(prec.fEpsMac), fEpsMa2(prec.fEpsMa2) {}
-
-  MnMachinePrecision& operator=(const MnMachinePrecision& prec) {
-    fEpsMac = prec.fEpsMac;
-    fEpsMa2 = prec.fEpsMa2;
-    return *this;
-  }
 
   /// eps returns the smallest possible number so that 1.+eps > 1.
   double Eps() const {return fEpsMac;}

--- a/math/minuit2/src/MnMachinePrecision.cxx
+++ b/math/minuit2/src/MnMachinePrecision.cxx
@@ -9,24 +9,30 @@
 
 #include "Minuit2/MnMachinePrecision.h"
 #include "Minuit2/MnTiny.h"
+#include <limits>
 
 namespace ROOT {
 
    namespace Minuit2 {
 
 
-MnMachinePrecision::MnMachinePrecision() :
-   fEpsMac(4.0E-7),
-   fEpsMa2(2.*sqrt(4.0E-7)) {
+MnMachinePrecision::MnMachinePrecision() {
+   // use double precision values from the numeric_limits standard
+   // and do not determine it anymore using ComputePrecision
+   fEpsMac = 8 * std::numeric_limits<double>::epsilon();
+   fEpsMa2 = 2.*sqrt(fEpsMac);
+}
+void MnMachinePrecision::ComputePrecision() {
+   fEpsMac = 4.0E-7;
+   fEpsMa2 = 2.*sqrt(fEpsMac);
 
    //determine machine precision
    /*
+       // use DLAMACH LAPACK function
        char e[] = {"e"};
        fEpsMac = 8.*dlamch_(e);
        fEpsMa2 = 2.*sqrt(fEpsMac);
    */
-
-   //   std::cout<<"machine precision eps: "<<Eps()<<std::endl;
 
    MnTiny mytiny;
 

--- a/math/minuit2/src/MnMachinePrecision.cxx
+++ b/math/minuit2/src/MnMachinePrecision.cxx
@@ -19,16 +19,20 @@ namespace ROOT {
 MnMachinePrecision::MnMachinePrecision() {
    // use double precision values from the numeric_limits standard
    // and do not determine it anymore using ComputePrecision
-   fEpsMac = 8 * std::numeric_limits<double>::epsilon();
+   // epsilon from stundard
+   // note that there is a factor of 2 in the definition of
+   // std::numeric_limitys::epsilon w.r.t DLAMCH epsilon
+   
+   fEpsMac = 4. * std::numeric_limits<double>::epsilon();
    fEpsMa2 = 2.*sqrt(fEpsMac);
 }
 void MnMachinePrecision::ComputePrecision() {
    fEpsMac = 4.0E-7;
    fEpsMa2 = 2.*sqrt(fEpsMac);
 
-   //determine machine precision
+   //determine machine precision using
+   // code similar to DLAMCH LAPACK Fortran function
    /*
-       // use DLAMACH LAPACK function
        char e[] = {"e"};
        fEpsMac = 8.*dlamch_(e);
        fEpsMa2 = 2.*sqrt(fEpsMac);


### PR DESCRIPTION
This PR replace #2215 from @HDembinski as suggested by him. 

There is no need to compute the precision in Minuit2. 
For testing and comparison the previous code to compute the numerical precision is now put in a new function MnMachinePrecision::ComputePrecision()