### PR TITLE
Fix ACLiC on Windows (taken from master)

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3948,7 +3948,15 @@ const char *TSystem::GetMakeExe() const
 const char *TSystem::GetIncludePath()
 {
    fListPaths = fIncludePath;
+#ifndef _MSC_VER
+   // FIXME: This is a temporary fix for the following error with ACLiC
+   // (and this is apparently not needed anyway):
+   // 48: input_line_12:8:38: error: use of undeclared identifier 'IC'
+   // 48: "C:/Users/bellenot/build/debug/etc" -IC:/Users/bellenot/build/debug/etc//cling -IC:/Users/bellenot/build/debug/include"",
+   // 48:                                      ^
+   // 48: Error in <ACLiC>: Dictionary generation failed!
    fListPaths.Append(" ").Append(gInterpreter->GetIncludePath());
+#endif
    return fListPaths;
 }
 


### PR DESCRIPTION
Fix the following error with ACLiC:

input_line_12:8:38: error: use of undeclared identifier 'IC'
"C:/Users/bellenot/build/debug/etc" -IC:/Users/bellenot/build/debug/etc//cling -IC:/Users/bellenot/build/debug/include"",
                                     ^
Error in <ACLiC>: Dictionary generation failed!