### PR TITLE
[DF] Make sure df103_NanoAODHiggsAnalysis.py do not erase canvas

### DIFF
--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.py
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.py
@@ -188,6 +188,8 @@ def plot(sig, bkg, data, x_label, filename):
     ROOT.gStyle.SetOptStat(0)
     ROOT.gStyle.SetTextFont(42)
     d = ROOT.TCanvas("d", "", 800, 700)
+    # Make sure the canvas stays in the list of canvases after the macro execution
+    ROOT.SetOwnership(d, False)
     d.SetLeftMargin(0.15)
 
     # Get signal and background histograms and stack them to show Higgs signal


### PR DESCRIPTION
When generating the reference guide tutorial pages the doxygen ROOT filter invokes the Python script makeimage.py to generate the pictures produce by the tutorials. This Python script relies on the fact the canvases produced by the tutorial (Python ones) are still in memory after execution. They are retrieved with ROOT.gROOT.GetListOfCanvases() .
In the case of most df*.py examples it works fine: the later command gives the list of canvases. But with df103_NanoAODHiggsAnalysis.py it gives an empty list of canvases because the canvases are created in a sub-function called plot. Python does some memory clean up at the end of plot and delete the canvas in memory. Adding ROOT.SetOwnership(d, False) allows to keep the canvases alive in the list of canvases after the macro execution.