### PR TITLE
[tree] avoid dependency from TreePlayer

### DIFF
--- a/tree/tree/inc/TVirtualIndex.h
+++ b/tree/tree/inc/TVirtualIndex.h
@@ -41,8 +41,7 @@ public:
    virtual Long64_t       GetEntryNumberWithBestIndex(Long64_t major, Long64_t minor) const = 0;
    virtual const char    *GetMajorName()    const = 0;
    virtual const char    *GetMinorName()    const = 0;
-   virtual TTreeFormula  *GetMajorFormulaParent(const TTree *parent) = 0;
-   virtual TTreeFormula  *GetMinorFormulaParent(const TTree *parent) = 0;
+   virtual Bool_t         IsValidFor(const TTree *parent) = 0;
    virtual Long64_t       GetN()            const = 0;
    virtual TTree         *GetTree()         const {return fTree;}
    virtual void           UpdateFormulaLeaves(const TTree *parent) = 0;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -402,7 +402,6 @@ End_Macro
 #include "TTreeCloner.h"
 #include "TTreeCache.h"
 #include "TTreeCacheUnzip.h"
-#include "TTreeFormula.h"
 #include "TVirtualCollectionProxy.h"
 #include "TEmulatedCollectionProxy.h"
 #include "TVirtualIndex.h"
@@ -1220,14 +1219,7 @@ bool CheckReshuffling(TTree &mainTree, TTree &friendTree)
    const auto isFriendReshuffled = friendTree.TestBit(TTree::kEntriesReshuffled);
    const auto friendHasValidIndex = [&] {
       auto idx = friendTree.GetTreeIndex();
-      if (idx == nullptr)
-         return false;
-      auto *majorFormula = idx->GetMajorFormulaParent(&mainTree);
-      auto *minorFormula = idx->GetMinorFormulaParent(&mainTree);
-      if ((majorFormula == nullptr || majorFormula->GetNdim() == 0) ||
-          (minorFormula == nullptr || minorFormula->GetNdim() == 0))
-         return false;
-      return true;
+      return idx ? idx->IsValidFor(&mainTree) : kFALSE;
    }();
 
    if ((isMainReshuffled || isFriendReshuffled) && !friendHasValidIndex) {

--- a/tree/treeplayer/inc/TChainIndex.h
+++ b/tree/treeplayer/inc/TChainIndex.h
@@ -71,6 +71,9 @@ protected:
    void ReleaseSubTreeIndex(TVirtualIndex* index, Int_t treeNo) const;
    void DeleteIndices();
 
+   TTreeFormula  *GetMajorFormulaParent(const TTree *parent);
+   TTreeFormula  *GetMinorFormulaParent(const TTree *parent);
+
 public:
    TChainIndex();
    TChainIndex(const TTree *T, const char *majorname, const char *minorname);
@@ -82,8 +85,6 @@ public:
    const char            *GetMajorName()    const {return fMajorName.Data();}
    const char            *GetMinorName()    const {return fMinorName.Data();}
    virtual Long64_t       GetN()            const {return fEntries.size();}
-   virtual TTreeFormula  *GetMajorFormulaParent(const TTree *parent);
-   virtual TTreeFormula  *GetMinorFormulaParent(const TTree *parent);
    virtual Bool_t         IsValidFor(const TTree *parent);
    virtual void           UpdateFormulaLeaves(const TTree *parent);
    virtual void           SetTree(const TTree *T);

--- a/tree/treeplayer/inc/TChainIndex.h
+++ b/tree/treeplayer/inc/TChainIndex.h
@@ -84,6 +84,7 @@ public:
    virtual Long64_t       GetN()            const {return fEntries.size();}
    virtual TTreeFormula  *GetMajorFormulaParent(const TTree *parent);
    virtual TTreeFormula  *GetMinorFormulaParent(const TTree *parent);
+   virtual Bool_t         IsValidFor(const TTree *parent);
    virtual void           UpdateFormulaLeaves(const TTree *parent);
    virtual void           SetTree(const TTree *T);
 

--- a/tree/treeplayer/inc/TTreeIndex.h
+++ b/tree/treeplayer/inc/TTreeIndex.h
@@ -64,6 +64,7 @@ public:
    virtual TTreeFormula  *GetMinorFormula();
    virtual TTreeFormula  *GetMajorFormulaParent(const TTree *parent);
    virtual TTreeFormula  *GetMinorFormulaParent(const TTree *parent);
+   virtual Bool_t         IsValidFor(const TTree *parent);
    virtual void           Print(Option_t *option="") const;
    virtual void           UpdateFormulaLeaves(const TTree *parent);
    virtual void           SetTree(const TTree *T);

--- a/tree/treeplayer/inc/TTreeIndex.h
+++ b/tree/treeplayer/inc/TTreeIndex.h
@@ -40,6 +40,9 @@ protected:
    TTreeFormula  *fMajorFormulaParent;  //! Pointer to major TreeFormula in Parent tree (if any)
    TTreeFormula  *fMinorFormulaParent;  //! Pointer to minor TreeFormula in Parent tree (if any)
 
+   TTreeFormula  *GetMajorFormulaParent(const TTree *parent);
+   TTreeFormula  *GetMinorFormulaParent(const TTree *parent);
+
 private:
    TTreeIndex(const TTreeIndex&) = delete;            // Not implemented.
    TTreeIndex &operator=(const TTreeIndex&) = delete; // Not implemented.
@@ -62,8 +65,6 @@ public:
    virtual Long64_t       GetN()            const {return fN;}
    virtual TTreeFormula  *GetMajorFormula();
    virtual TTreeFormula  *GetMinorFormula();
-   virtual TTreeFormula  *GetMajorFormulaParent(const TTree *parent);
-   virtual TTreeFormula  *GetMinorFormulaParent(const TTree *parent);
    virtual Bool_t         IsValidFor(const TTree *parent);
    virtual void           Print(Option_t *option="") const;
    virtual void           UpdateFormulaLeaves(const TTree *parent);

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -365,6 +365,19 @@ TTreeFormula *TChainIndex::GetMinorFormulaParent(const TTree *parent)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return kTRUE if index can be applied to the TTree
+
+Bool_t TChainIndex::IsValidFor(const TTree *parent)
+{
+   auto *majorFormula = GetMajorFormulaParent(parent);
+   auto *minorFormula = GetMinorFormulaParent(parent);
+   if ((majorFormula == nullptr || majorFormula->GetNdim() == 0) ||
+       (minorFormula == nullptr || minorFormula->GetNdim() == 0))
+         return kFALSE;
+   return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Updates the parent formulae.
 /// Called by TChain::LoadTree when the parent chain changes it's tree.
 

--- a/tree/treeplayer/src/TTreeIndex.cxx
+++ b/tree/treeplayer/src/TTreeIndex.cxx
@@ -495,6 +495,18 @@ TTreeFormula *TTreeIndex::GetMinorFormulaParent(const TTree *parent)
    return fMinorFormulaParent;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Return kTRUE if index can be applied to the TTree
+
+Bool_t TTreeIndex::IsValidFor(const TTree *parent)
+{
+   auto *majorFormula = GetMajorFormulaParent(parent);
+   auto *minorFormula = GetMinorFormulaParent(parent);
+   if ((majorFormula == nullptr || majorFormula->GetNdim() == 0) ||
+       (minorFormula == nullptr || minorFormula->GetNdim() == 0))
+         return kFALSE;
+   return kTRUE;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Print the table with : serial number, majorname, minorname.


### PR DESCRIPTION
One need virtual method in `TVirtualIndex` to extract Ndim from the
`TTreeFormula`. Otherwise one has link `Tree` lib again `TreePlayer` and
`Hist`, making circular dependency