### PR TITLE
Remove ifdef CINT protection in SQL includes

### DIFF
--- a/sql/oracle/inc/TOracleResult.h
+++ b/sql/oracle/inc/TOracleResult.h
@@ -16,21 +16,14 @@
 
 #include <vector>
 
-#if !defined(__CINT__)
 #ifndef R__WIN32
 #include <sys/time.h>
 #endif
+
 #include <occi.h>
+
 #ifdef CONST
 #undef CONST
-#endif
-#else
-namespace oracle { namespace occi {
-class Connection;
-class Statement;
-class ResultSet;
-class MetaData;
-   }}
 #endif
 
 class TList;

--- a/sql/oracle/inc/TOracleRow.h
+++ b/sql/oracle/inc/TOracleRow.h
@@ -14,16 +14,10 @@
 
 #include "TSQLRow.h"
 
-#if !defined(__CINT__)
 #include <occi.h>
+
 #ifdef CONST
 #undef CONST
-#endif
-#else
-namespace oracle { namespace occi {
-class ResultSet;
-class MetaData;
-   }}
 #endif
 
 class TOracleRow : public TSQLRow {

--- a/sql/oracle/inc/TOracleServer.h
+++ b/sql/oracle/inc/TOracleServer.h
@@ -14,21 +14,15 @@
 
 #include "TSQLServer.h"
 
-#if !defined(__CINT__)
 #ifndef R__WIN32
 #include <sys/time.h>
 #endif
+
 #include <occi.h>
+
 #ifdef CONST
 #undef CONST
 #endif
-#else
-namespace oracle { namespace occi {
-class Environment;
-class Connection;
-}}
-#endif
-
 
 class TOracleServer : public TSQLServer {
 

--- a/sql/oracle/inc/TOracleStatement.h
+++ b/sql/oracle/inc/TOracleStatement.h
@@ -14,19 +14,10 @@
 
 #include "TSQLStatement.h"
 
-#if !defined(__CINT__)
 #include <occi.h>
+
 #ifdef CONST
 #undef CONST
-#endif
-#else
-namespace oracle { namespace occi {
-class Environment;
-class Connection;
-class Statement;
-class ResultSet;
-class MetaData;
-   }}
 #endif
 
 class TOracleStatement : public TSQLStatement {

--- a/sql/pgsql/inc/TPgSQLResult.h
+++ b/sql/pgsql/inc/TPgSQLResult.h
@@ -14,12 +14,7 @@
 
 #include "TSQLResult.h"
 
-#if !defined(__CINT__)
 #include <libpq-fe.h>
-#else
-struct PGresult;
-#endif
-
 
 class TPgSQLResult : public TSQLResult {
 

--- a/sql/pgsql/inc/TPgSQLRow.h
+++ b/sql/pgsql/inc/TPgSQLRow.h
@@ -14,13 +14,7 @@
 
 #include "TSQLRow.h"
 
-#if !defined(__CINT__)
 #include <libpq-fe.h>
-#else
-struct PGresult;
-typedef char **PGresAttValue;
-#endif
-
 
 class TPgSQLRow : public TSQLRow {
 

--- a/sql/pgsql/inc/TPgSQLServer.h
+++ b/sql/pgsql/inc/TPgSQLServer.h
@@ -17,12 +17,7 @@
 #include <map>
 #include <string>
 
-#if !defined(__CINT__)
 #include <libpq-fe.h>
-#else
-struct PGconn;
-#endif
-
 
 class TPgSQLServer : public TSQLServer {
 

--- a/sql/pgsql/inc/TPgSQLStatement.h
+++ b/sql/pgsql/inc/TPgSQLStatement.h
@@ -17,19 +17,16 @@
 #include <libpq-fe.h>
 #include <pg_config.h> // to get PG_VERSION_NUM
 
-#define pgsql_success(x) (((x) == PGRES_EMPTY_QUERY) \
-                        || ((x) == PGRES_COMMAND_OK) \
-                        || ((x) == PGRES_TUPLES_OK))
-
 struct PgSQL_Stmt_t {
    PGconn   *fConn;
    PGresult *fRes;
 };
 
-
 class TPgSQLStatement : public TSQLStatement {
 
 private:
+
+
    PgSQL_Stmt_t         *fStmt{nullptr};          //! executed statement
    Int_t                 fNumBuffers{0};          //! number of statement parameters
    char                **fBind{nullptr};          //! array of data for input

--- a/sql/pgsql/src/TPgSQLServer.cxx
+++ b/sql/pgsql/src/TPgSQLServer.cxx
@@ -19,6 +19,11 @@
 #include "TUrl.h"
 #include "TList.h"
 
+#define pgsql_success(x) (((x) == PGRES_EMPTY_QUERY) \
+                        || ((x) == PGRES_COMMAND_OK) \
+                        || ((x) == PGRES_TUPLES_OK))
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// PluginManager generator function
 

--- a/sql/pgsql/src/TPgSQLStatement.cxx
+++ b/sql/pgsql/src/TPgSQLStatement.cxx
@@ -25,6 +25,11 @@
 
 #include <stdlib.h>
 
+#define pgsql_success(x) (((x) == PGRES_EMPTY_QUERY) \
+                        || ((x) == PGRES_COMMAND_OK) \
+                        || ((x) == PGRES_TUPLES_OK))
+
+
 ClassImp(TPgSQLStatement);
 
 #ifdef PG_VERSION_NUM

--- a/sql/sqlite/inc/TSQLiteResult.h
+++ b/sql/sqlite/inc/TSQLiteResult.h
@@ -14,12 +14,7 @@
 
 #include "TSQLResult.h"
 
-#if !defined(__CINT__)
 #include <sqlite3.h>
-#else
-struct sqlite3_stmt;
-#endif
-
 
 class TSQLiteResult : public TSQLResult {
 

--- a/sql/sqlite/inc/TSQLiteRow.h
+++ b/sql/sqlite/inc/TSQLiteRow.h
@@ -14,12 +14,12 @@
 
 #include "TSQLRow.h"
 
-struct sqlite3_stmt;
+#include <sqlite3.h>
 
 class TSQLiteRow : public TSQLRow {
 
 private:
-   sqlite3_stmt *fResult{nullptr};       // current result set
+   sqlite3_stmt *fResult{nullptr};       ///<! current result set
    Bool_t        IsValid(Int_t field);
 
 public:

--- a/sql/sqlite/inc/TSQLiteServer.h
+++ b/sql/sqlite/inc/TSQLiteServer.h
@@ -14,11 +14,7 @@
 
 #include "TSQLServer.h"
 
-#if !defined(__CINT__)
 #include <sqlite3.h>
-#else
-struct sqlite3;
-#endif
 
 class TSQLiteServer : public TSQLServer {
 

--- a/sql/sqlite/inc/TSQLiteStatement.h
+++ b/sql/sqlite/inc/TSQLiteStatement.h
@@ -21,7 +21,6 @@ struct SQLite3_Stmt_t {
    sqlite3_stmt *fRes;
 };
 
-
 class TSQLiteStatement : public TSQLStatement {
 
 private:


### PR DESCRIPTION
Long time ago this protection was introduced to avoid parsing of complex SQL includes.
With a cling this protection no longer work properly.
Remove it completely 