### PR TITLE
TDirectory::mkdir should always return the created directory.

### DIFF
--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1060,8 +1060,7 @@ TDirectory *TDirectory::mkdir(const char *name, const char *title, Bool_t return
       delete[] workname;
       if (!tmpdir) return nullptr;
       if (!newdir) newdir = tmpdir;
-      tmpdir->mkdir(slash+1);
-      return newdir;
+      return tmpdir->mkdir(slash+1);
    }
 
    TDirectory::TContext ctxt(this);


### PR DESCRIPTION
Previously it would retun the parent directory in case where a sub-directory creation was requested.

See https://root-forum.cern.ch/t/subdirectories/15665/11.