### PR TITLE
More use of target_include_directories in cmake

### DIFF
--- a/graf2d/graf/CMakeLists.txt
+++ b/graf2d/graf/CMakeLists.txt
@@ -9,8 +9,6 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-include_directories(${FREETYPE_INCLUDE_DIRS})
-
 ROOT_STANDARD_LIBRARY_PACKAGE(Graf
   HEADERS
     TArc.h
@@ -101,3 +99,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Graf
   BUILTINS
     FREETYPE
 )
+
+target_include_directories(Graf PRIVATE ${FREETYPE_INCLUDE_DIRS})

--- a/graf2d/gviz/CMakeLists.txt
+++ b/graf2d/gviz/CMakeLists.txt
@@ -9,8 +9,6 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-include_directories(${GRAPHVIZ_INCLUDE_DIR}/graphviz)
-
 ROOT_STANDARD_LIBRARY_PACKAGE(Gviz
   HEADERS
     TGraphEdge.h
@@ -28,3 +26,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Gviz
     Hist
     Graf
 )
+
+target_include_directories(Gviz PRIVATE ${GRAPHVIZ_INCLUDE_DIR}/graphviz)

--- a/graf2d/x11ttf/CMakeLists.txt
+++ b/graf2d/x11ttf/CMakeLists.txt
@@ -9,8 +9,6 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-include_directories(${FREETYPE_INCLUDE_DIRS} ${X11_INCLUDE_DIR})
-
 ROOT_STANDARD_LIBRARY_PACKAGE(GX11TTF
   HEADERS
     TGX11TTF.h
@@ -29,3 +27,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(GX11TTF
     GX11
     Graf
 )
+
+target_include_directories(GX11TTF PRIVATE ${FREETYPE_INCLUDE_DIRS} ${X11_INCLUDE_DIR})

--- a/graf3d/ftgl/CMakeLists.txt
+++ b/graf3d/ftgl/CMakeLists.txt
@@ -8,8 +8,6 @@
 # CMakeLists.txt file for building ROOT graf3d/ftgl package
 ############################################################################
 
-include_directories(${FREETYPE_INCLUDE_DIRS})
-
 if(MACOSX_GLU_DEPRECATED)
   add_definitions(-Wno-deprecated-declarations)
 endif()
@@ -44,6 +42,11 @@ ROOT_LINKER_LIBRARY(FTGL
     ZLIB::ZLIB
   BUILTINS
     FREETYPE
+)
+
+target_include_directories(FTGL PRIVATE
+      ${FREETYPE_INCLUDE_DIRS}
+      ${OPENGL_INCLUDE_DIR}
 )
 
 ROOT_INSTALL_HEADERS()

--- a/graf3d/gl/CMakeLists.txt
+++ b/graf3d/gl/CMakeLists.txt
@@ -8,8 +8,6 @@
 # CMakeLists.txt file for building ROOT graf3d/gl package
 ############################################################################
 
-include_directories(${OPENGL_INCLUDE_DIR} ${FTGL_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIRS})
-
 if(WIN32 OR cocoa)
   set(installoptions FILTER "TX11GL")
 endif()
@@ -19,11 +17,9 @@ if(x11)
   set(RGL_EXTRA_SOURCES TX11GL.cxx)
 endif()
 
+
 if(builtin_gl2ps)
-  include_directories(src/gl2ps)
   set(RGL_EXTRA_SOURCES ${RGL_EXTRA_SOURCES} src/gl2ps.cxx)
-else()
-  include_directories(${GL2PS_INCLUDE_DIRS})
 endif()
 
 set_source_files_properties(src/TGLFontManager.cxx PROPERTIES COMPILE_FLAGS "${FTGL_CFLAGS}")
@@ -220,6 +216,19 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RGL
   INSTALL_OPTIONS
     ${installoptions}
 )
+
+target_include_directories(RGL PRIVATE
+     ${OPENGL_INCLUDE_DIR}
+     ${FTGL_INCLUDE_DIR}
+     ${FREETYPE_INCLUDE_DIRS}
+)
+
+if(builtin_gl2ps)
+  target_include_directories(RGL PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/gl2ps)
+else()
+  target_include_directories(RGL PRIVATE ${GL2PS_INCLUDE_DIRS})
+endif()
+
 
 if(MACOSX_GLU_DEPRECATED)
   target_compile_options(RGL PRIVATE -Wno-deprecated-declarations)

--- a/graf3d/x3d/CMakeLists.txt
+++ b/graf3d/x3d/CMakeLists.txt
@@ -8,8 +8,6 @@
 # CMakeLists.txt file for building ROOT graf3d/x3d package
 ############################################################################
 
-include_directories(${X11_INCLUDE_DIR})
-
 ROOT_STANDARD_LIBRARY_PACKAGE(X3d
   HEADERS
     TViewerX3D.h
@@ -24,3 +22,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(X3d
     Graf3d
     Gui
 )
+
+target_include_directories(X3d PRIVATE ${X11_INCLUDE_DIR})

--- a/gui/gui/CMakeLists.txt
+++ b/gui/gui/CMakeLists.txt
@@ -8,8 +8,6 @@
 # CMakeLists.txt file for building ROOT gui/gui package
 ############################################################################
 
-include_directories(${CMAKE_SOURCE_DIR}/gui/ged/inc)
-
 ROOT_STANDARD_LIBRARY_PACKAGE(Gui
   HEADERS
     HelpText.h
@@ -207,3 +205,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Gui
     Graf
     MathCore
 )
+
+target_include_directories(Gui PRIVATE ${CMAKE_SOURCE_DIR}/gui/ged/inc)

--- a/io/gfal/CMakeLists.txt
+++ b/io/gfal/CMakeLists.txt
@@ -8,8 +8,6 @@
 # CMakeLists.txt file for building ROOT io/gfal package
 ############################################################################
 
-include_directories(${GFAL_INCLUDE_DIRS})
-
 add_definitions(-D_FILE_OFFSET_BITS=64)
 
 ROOT_STANDARD_LIBRARY_PACKAGE(GFAL
@@ -17,3 +15,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(GFAL
                               SOURCES src/TGFALFile.cxx
                               LIBRARIES ${GFAL_LIBRARIES}
                               DEPENDENCIES Core Net RIO)
+
+target_include_directories(GFAL PRIVATE ${GFAL_INCLUDE_DIRS})

--- a/io/xmlparser/CMakeLists.txt
+++ b/io/xmlparser/CMakeLists.txt
@@ -9,9 +9,6 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-# needed to propagate includes to rootling
-include_directories(${LIBXML2_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIRS})
-
 ROOT_STANDARD_LIBRARY_PACKAGE(XMLParser
   HEADERS
      TDOMParser.h
@@ -29,6 +26,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(XMLParser
      src/TXMLParser.cxx
   DEPENDENCIES
     Core
+)
+
+# not needed to propagate includes to rootcling
+target_include_directories(XMLParser PRIVATE
+   ${LIBXML2_INCLUDE_DIR}
+   ${LIBXML2_INCLUDE_DIRS}
 )
 
 target_link_libraries(XMLParser

--- a/math/rtools/CMakeLists.txt
+++ b/math/rtools/CMakeLists.txt
@@ -21,5 +21,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Rtools
   NO_CXXMODULE
 )
 
+target_include_directories(Rtools PRIVATE ${R_INCLUDE_DIRS})
+
 file(COPY "${CMAKE_SOURCE_DIR}/etc/plugins/ROOT@@Math@@Minimizer/P090_RMinimizer.C"
   DESTINATION "${CMAKE_BINARY_DIR}/etc/plugins/ROOT@@Math@@Minimizer/")

--- a/math/vecops/CMakeLists.txt
+++ b/math/vecops/CMakeLists.txt
@@ -10,7 +10,6 @@
 
 if(builtin_vdt)
   link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-  include_directories(${HEADER_OUTPUT_PATH})
 endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTVecOps
@@ -26,11 +25,14 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTVecOps
     Core
 )
 
+if(builtin_vdt OR vdt)
+   target_include_directories(ROOTVecOps PRIVATE ${VDT_INCLUDE_DIRS} INTERFACE $<BUILD_INTERFACE:${VDT_INCLUDE_DIRS}>)
+endif()
+
 if(builtin_vdt)
   target_link_libraries(ROOTVecOps PRIVATE ${VDT_LIBRARIES})
 elseif(vdt)
   target_link_libraries(ROOTVecOps PUBLIC ${VDT_LIBRARIES})
-  target_include_directories(ROOTVecOps PUBLIC ${VDT_INCLUDE_DIRS})
 endif()
 
 if(MSVC)

--- a/montecarlo/pythia8/CMakeLists.txt
+++ b/montecarlo/pythia8/CMakeLists.txt
@@ -9,6 +9,9 @@
 # @author Pere Mato, CERN
 ############################################################################
 
+# required also for cling
+include_directories(${PYTHIA8_INCLUDE_DIR})
+
 ROOT_STANDARD_LIBRARY_PACKAGE(EGPythia8
   HEADERS
     TPythia8.h
@@ -30,5 +33,4 @@ ROOT_ADD_CXX_FLAG(_EGPythia8_FLAGS -Wno-overloaded-virtual)
 separate_arguments(_EGPythia8_FLAGS)
 
 target_compile_options(EGPythia8 PRIVATE ${_EGPythia8_FLAGS})
-target_include_directories(EGPythia8 PUBLIC ${PYTHIA8_INCLUDE_DIR})
 target_link_libraries(EGPythia8 PUBLIC ${PYTHIA8_LIBRARIES})

--- a/net/http/CMakeLists.txt
+++ b/net/http/CMakeLists.txt
@@ -9,14 +9,8 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-if(FASTCGI_FOUND)
-  include_directories(${FASTCGI_INCLUDE_DIR})
-else()
+if(NOT FASTCGI_FOUND)
   set(FASTCGI_LIBRARY "")
-endif()
-
-if(ssl)
-  include_directories(${OPENSSL_INCLUDE_DIR})
 endif()
 
 # look for the realtime extensions library and use it if it exists
@@ -59,6 +53,14 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RHTTP
     Thread
     Graf
 )
+
+if(ssl)
+  target_include_directories(RHTTP PRIVATE ${OPENSSL_INCLUDE_DIR})
+endif()
+
+if(FASTCGI_FOUND)
+  target_include_directories(RHTTP PRIVATE ${FASTCGI_INCLUDE_DIR})
+endif()
 
 target_compile_definitions(RHTTP PUBLIC -DUSE_WEBSOCKET)
 

--- a/net/netxng/CMakeLists.txt
+++ b/net/netxng/CMakeLists.txt
@@ -9,8 +9,6 @@
 # @author Lukasz Janyst <ljanyst@cern.ch>
 ############################################################################
 
-include_directories(${XROOTD_INCLUDE_DIRS})
-
 ROOT_STANDARD_LIBRARY_PACKAGE(NetxNG
   HEADERS
     TNetXNGFile.h
@@ -29,5 +27,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(NetxNG
   BUILTINS
     XROOTD
 )
+
+target_include_directories(NetxNG PRIVATE ${XROOTD_INCLUDE_DIRS})
 
 target_compile_options(NetxNG PRIVATE -Wno-shadow)


### PR DESCRIPTION
In many sub-projects `target_include_directories` can be used.
This "hides" special includes when doing dictionary generation.
Also in few places do `include_directories` when includes required by dictionary
Extraction of part of #5181 as requested by @vgvassilev 
I intentionally made many small commits to be able revert only some of them if fails