### PR TITLE
[CmdLineUtils] Fix handling TObjects with multiple cycles.

### DIFF
--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -311,7 +311,7 @@ def manyOccurenceRemove(pathSplitList,fileName):
         for n in pathSplitList:
             if pathSplitList.count(n) != 1:
                 logging.warning(MANY_OCCURENCE_WARNING.format(joinPathSplit(n),fileName))
-                while n in pathSplitList: pathSplitList.remove(n)
+                while n in pathSplitList and pathSplitList.count(n) != 1 : pathSplitList.remove(n)
 
 def patternToPathSplitList(fileName,pattern):
     """


### PR DESCRIPTION
Fix for https://sft.its.cern.ch/jira/browse/ROOT-10654 and https://sft.its.cern.ch/jira/browse/ROOT-10599

I tested locally for a failing rootmv command i had and it works. 