### PR TITLE
[travis][skip-ci]Remove the exclude clause

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,6 @@ matrix:
   # Abort all builds on a single failing matrix entry.
   fast_finish: true
 
-  exclude:
-    # Note: Workaround travis-ci/travis-ci#4681
-    # Exclude default job which lacks our included environment variables.
-    - os: linux
-
   include:
     - env: TOOL=clang-format
       script: &format_script


### PR DESCRIPTION
The exclude clause was a workaround travis-ci/travis-ci#4681 but it causes travis-ci/travis-ci#8536 in recent travis.