### PR TITLE
 [TreeProcMT] Add nThreads argument to all constructors

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -99,10 +99,11 @@ private:
    static unsigned int fgMaxTasksPerFilePerWorker;
 
 public:
-   TTreeProcessorMT(std::string_view filename, std::string_view treename = "");
-   TTreeProcessorMT(const std::vector<std::string_view> &filenames, std::string_view treename = "");
-   TTreeProcessorMT(TTree &tree, const TEntryList &entries);
-   TTreeProcessorMT(TTree &tree);
+   TTreeProcessorMT(std::string_view filename, std::string_view treename = "", UInt_t nThreads = 0u);
+   TTreeProcessorMT(const std::vector<std::string_view> &filenames, std::string_view treename = "",
+                    UInt_t nThreads = 0u);
+   TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_t nThreads = 0u);
+   TTreeProcessorMT(TTree &tree, UInt_t nThreads = 0u);
 
    void Process(std::function<void(TTreeReader &)> func);
    static void SetMaxTasksPerFilePerWorker(unsigned int m);

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -387,3 +387,43 @@ TEST(TreeProcessorMT, ChainWithFriendChain)
    // Clean-up
    DeleteFiles(fileNames);
 }
+
+TEST(TreeProcessorMT, SetNThreads)
+{
+   ROOT::DisableImplicitMT();
+   EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 0u);
+   {
+      ROOT::TTreeProcessorMT p("somefile", "sometree", 1u);
+      EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 1u);
+   }
+   EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 0u);
+
+   {
+      ROOT::TTreeProcessorMT p({"somefile", "some_other"}, "sometree", 1u);
+      EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 1u);
+   }
+
+   {
+      // we need a file because in-memory trees are not supported
+      // (and are detected at TTreeProcessorMT construction time)
+      TFile f("treeprocmt_setnthreads.root", "recreate");
+      TTree t("t", "t");
+      t.Write();
+      TEntryList l;
+      ROOT::TTreeProcessorMT p(t, l, 1u);
+      EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 1u);
+      f.Close();
+      gSystem->Unlink("treeprocmt_setnthreads.root");
+   }
+
+   {
+      // we need a file because in-memory trees are not supported
+      // (and are detected at TTreeProcessorMT construction time)
+      TFile f("treeprocmt_setnthreads.root", "recreate");
+      TTree t("t", "t");
+      t.Write();
+      ROOT::TTreeProcessorMT p(t, 1u);
+      EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 1u);
+      gSystem->Unlink("treeprocmt_setnthreads.root");
+   }
+}


### PR DESCRIPTION
...and add a test.

The new argument is to make TTreeProcessorMT consistent with other
multi-threading interfaces, namely TThreadExecutor. This is the last
ingredient required to fix ROOT-10561.