### PR TITLE
[clad] Bump clad version to v0.6.

### DIFF
--- a/hist/hist/test/TFormulaGradientTests.cxx
+++ b/hist/hist/test/TFormulaGradientTests.cxx
@@ -198,45 +198,8 @@ TEST(TFormulaGradientPar, GausCrossCheck)
    ASSERT_FLOAT_EQ(result_num[2], result_clad[2]);
 }
 
-// FIXME: See vgvassilev/clad#105
-static void InitBreitWigner() {
-   static bool FirstCall = true;
-   if (FirstCall) {
-      std::string clad_breitwigner_pdf_grad = R"code(
-namespace custom_derivatives {
-   void breitwigner_pdf_grad(double x, double gamma, double x0, double *_result) {
-      double _t0 = 1 / (3.1415926535897931 * ((x - x0) * (x - x0) + (gamma / 2.) * (gamma / 2.)));
-      double _t1 = _t0 / 2.;
-      _result[1UL] += _t1;
-      double _t2 = _t0 * -gamma / (2. * 2.);
-      double _t3 = 1 * -(gamma / 2.) / ((3.1415926535897931 * ((x - x0) * (x - x0) + (gamma / 2.) * (gamma / 2.))) * (3.1415926535897931 * ((x - x0) * (x - x0) + (gamma / 2.) * (gamma / 2.))));
-      double _t4 = _t3 * ((x - x0) * (x - x0) + (gamma / 2.) * (gamma / 2.));
-      double _t5 = 3.1415926535897931 * _t3;
-      double _t6 = _t5 * (x - x0);
-      _result[0UL] += _t6;
-      _result[2UL] += -_t6;
-      double _t7 = (x - x0) * _t5;
-      _result[0UL] += _t7;
-      _result[2UL] += -_t7;
-      double _t8 = _t5 * (gamma / 2.);
-      double _t9 = _t8 / 2.;
-      _result[1UL] += _t9;
-      double _t10 = _t8 * -gamma / (2. * 2.);
-      double _t11 = (gamma / 2.) * _t5;
-      double _t12 = _t11 / 2.;
-      _result[1UL] += _t12;
-      double _t13 = _t11 * -gamma / (2. * 2.);
-   }
-}
-)code";
-   gInterpreter->Declare(clad_breitwigner_pdf_grad.c_str());
-   FirstCall = false;
-   }
-}
-
 TEST(TFormulaGradientPar, BreitWignerCrossCheck)
 {
-   InitBreitWigner();
    auto h = new TF1("f1", "breitwigner");
    double p[] = {3, 1, 2.1};
    h->SetParameters(p);
@@ -254,7 +217,6 @@ TEST(TFormulaGradientPar, BreitWignerCrossCheck)
 
 TEST(TFormulaGradientPar, BreitWignerCrossCheckAccuracyDemo)
 {
-   InitBreitWigner();
    auto h = new TF1("f1", "breitwigner");
    double p[] = {3, 1, 2};
    h->SetParameters(p);

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -29,10 +29,12 @@ if(MSVC)
   ExternalProject_Add(
     clad
     GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-    GIT_TAG v0.5
+    GIT_TAG v0.6
     UPDATE_COMMAND ""
-    CMAKE_ARGS -G ${CMAKE_GENERATOR} -DCLAD_BUILD_STATIC_ONLY=ON
+    CMAKE_ARGS -G ${CMAKE_GENERATOR}
+               -DCLAD_BUILD_STATIC_ONLY=ON
                -DCMAKE_INSTALL_PREFIX=${clad_install_dir}/plugins
+               -DClang_DIR=${LLVM_BINARY_DIR}/tools/clang/
                -DCLAD_PATH_TO_LLVM_BUILD=${LLVM_BINARY_DIR}
                -DCLANG_INCLUDE_DIRS=${CLANG_INCLUDE_DIRS}
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${_clad_build_type}
@@ -59,7 +61,7 @@ else()
   ExternalProject_Add(
     clad
     GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-    GIT_TAG v0.5
+    GIT_TAG v0.6
     UPDATE_COMMAND ""
     CMAKE_ARGS -G ${CMAKE_GENERATOR}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -68,7 +70,7 @@ else()
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-               -DCLAD_PATH_TO_LLVM_BUILD=${LLVM_BINARY_DIR}
+               -DClang_DIR=${LLVM_BINARY_DIR}/tools/clang/
                -DCLANG_INCLUDE_DIRS=${CLANG_INCLUDE_DIRS}
                -DCLAD_BUILD_STATIC_ONLY=ON
                ${_clad_extra_cmake_args}


### PR DESCRIPTION
The new release includes some improvements in Reverse mode:
  * Reduce the quadratic cloning complexity to linear.
  * Support variable reassignments pontentially depending on control flow.
  * Support operators `+=`, `-=`, `*=`, `/=`, `,`, `++`, `--`.
  * Allow assignments to array subscripts.
  * Support nested assignments in expressions `a = b * ((c ? d : e) = f = g);`
  * Enable differentiation of for-loops

See more at: https://github.com/vgvassilev/clad/blob/v0.6/docs/ReleaseNotes.md

This patch enables us to upgrade to llvm9. Clad supports from clang5 to clang9.