### PR TITLE
[IO] Always protect MT usage of TFile

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -75,16 +75,6 @@ namespace Internal {
       TParBranchProcessingRAII()  { EnableParBranchProcessing();  }
       ~TParBranchProcessingRAII() { DisableParBranchProcessing(); }
    };
-
-   // Manage parallel tree processing
-   void EnableParTreeProcessing();
-   void DisableParTreeProcessing();
-   Bool_t IsParTreeProcessingEnabled();
-   class TParTreeProcessingRAII {
-   public:
-      TParTreeProcessingRAII()  { EnableParTreeProcessing();  }
-      ~TParTreeProcessingRAII() { DisableParTreeProcessing(); }
-   };
 } } // End ROOT::Internal
 
 namespace ROOT {

--- a/core/base/inc/TVirtualMutex.h
+++ b/core/base/inc/TVirtualMutex.h
@@ -124,16 +124,4 @@ public:
 #define R__LOCKGUARD_IMT2(mutex) { }
 #endif
 
-#ifdef R__USE_IMT
-#define R__RWLOCK_ACQUIRE_READ(rwlock)  if (ROOT::Internal::IsParTreeProcessingEnabled()) rwlock.ReadLock();
-#define R__RWLOCK_RELEASE_READ(rwlock)  if (ROOT::Internal::IsParTreeProcessingEnabled()) rwlock.ReadUnLock();
-#define R__RWLOCK_ACQUIRE_WRITE(rwlock) if (ROOT::Internal::IsParTreeProcessingEnabled()) rwlock.WriteLock();
-#define R__RWLOCK_RELEASE_WRITE(rwlock) if (ROOT::Internal::IsParTreeProcessingEnabled()) rwlock.WriteUnLock();
-#else
-#define R__RWLOCK_ACQUIRE_READ(rwlock)  { }
-#define R__RWLOCK_RELEASE_READ(rwlock)  { }
-#define R__RWLOCK_ACQUIRE_WRITE(rwlock) { }
-#define R__RWLOCK_RELEASE_WRITE(rwlock) { }
-#endif
-
 #endif

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -453,53 +453,6 @@ namespace Internal {
    }
 
    ////////////////////////////////////////////////////////////////////////////////
-   /// Globally enables the parallel tree processing, which is a case of
-   /// implicit multi-threading in ROOT, activating the required locks.
-   /// This IMT use case, implemented in TTreeProcessor::Process, receives a user
-   /// function and applies it to subranges of the tree, which correspond to its
-   /// clusters. Hence, for every cluster, a task is spawned to potentially
-   /// process it in parallel with the other clusters.
-   void EnableParTreeProcessing()
-   {
-#ifdef R__USE_IMT
-      static void (*sym)() = (void(*)())Internal::GetSymInLibImt("ROOT_TImplicitMT_EnableParTreeProcessing");
-      if (sym)
-         sym();
-#else
-      ::Warning("EnableParTreeProcessing", "Cannot enable parallel tree processing, please build ROOT with -Dimt=ON");
-#endif
-   }
-
-   //////////////////////////////////////////////////////////////////////////////
-   /// Globally disables the IMT use case of parallel branch processing,
-   /// deactivating the corresponding locks.
-   void DisableParTreeProcessing()
-   {
-#ifdef R__USE_IMT
-      static void (*sym)() = (void(*)())Internal::GetSymInLibImt("ROOT_TImplicitMT_DisableParTreeProcessing");
-      if (sym)
-         sym();
-#else
-      ::Warning("DisableParTreeProcessing", "Cannot disable parallel tree processing, please build ROOT with -Dimt=ON");
-#endif
-   }
-
-   ////////////////////////////////////////////////////////////////////////////////
-   /// Returns true if parallel tree processing is enabled.
-   Bool_t IsParTreeProcessingEnabled()
-   {
-#ifdef R__USE_IMT
-      static Bool_t (*sym)() = (Bool_t(*)())Internal::GetSymInLibImt("ROOT_TImplicitMT_IsParTreeProcessingEnabled");
-      if (sym)
-         return sym();
-      else
-         return kFALSE;
-#else
-      return kFALSE;
-#endif
-   }
-
-   ////////////////////////////////////////////////////////////////////////////////
    /// Keeps track of the status of ImplicitMT w/o resorting to the load of
    /// libImt
    static Bool_t &IsImplicitMTEnabledImpl()

--- a/core/imt/src/TImplicitMT.cxx
+++ b/core/imt/src/TImplicitMT.cxx
@@ -41,12 +41,6 @@ static std::atomic_int &GetParBranchProcessingCount()
    return count;
 }
 
-static std::atomic_int &GetParTreeProcessingCount()
-{
-   static std::atomic_int count(0);
-   return count;
-}
-
 extern "C" void ROOT_TImplicitMT_EnableImplicitMT(UInt_t numthreads)
 {
    if (!GetImplicitMTFlag()) {
@@ -89,19 +83,4 @@ extern "C" void ROOT_TImplicitMT_DisableParBranchProcessing()
 extern "C" bool ROOT_TImplicitMT_IsParBranchProcessingEnabled()
 {
    return GetParBranchProcessingCount() > 0;
-};
-
-extern "C" void ROOT_TImplicitMT_EnableParTreeProcessing()
-{
-   ++GetParTreeProcessingCount();
-};
-
-extern "C" void ROOT_TImplicitMT_DisableParTreeProcessing()
-{
-   --GetParTreeProcessingCount();
-};
-
-extern "C" bool ROOT_TImplicitMT_IsParTreeProcessingEnabled()
-{
-   return GetParTreeProcessingCount() > 0;
 };

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -108,7 +108,6 @@ protected:
    TList           *fOpenPhases{nullptr};     ///<!Time info about open phases
 
 #ifdef R__USE_IMT
-   static ROOT::TRWSpinLock                   fgRwLock;     ///<!Read-write lock to protect global PID list
    std::mutex                                 fWriteMutex;  ///<!Lock for writing baskets / keys into the file.
    static ROOT::Internal::RConcurrentHashColl fgTsSIHashes; ///<!TS Set of hashes built from read streamer infos
 #endif

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1823,14 +1823,16 @@ TProcessID  *TFile::ReadProcessID(UShort_t pidf)
    TIter next(pidslist);
    TProcessID *p;
    bool found = false;
-   R__RWLOCK_ACQUIRE_READ(fgRwLock);
-   while ((p = (TProcessID*)next())) {
-      if (!strcmp(p->GetTitle(),pid->GetTitle())) {
-         found = true;
-         break;
+
+   {
+      R__READ_LOCKGUARD(ROOT::gCoreMutex);
+      while ((p = (TProcessID*)next())) {
+         if (!strcmp(p->GetTitle(),pid->GetTitle())) {
+            found = true;
+            break;
+         }
       }
    }
-   R__RWLOCK_RELEASE_READ(fgRwLock);
 
    if (found) {
       delete pid;
@@ -1842,11 +1844,12 @@ TProcessID  *TFile::ReadProcessID(UShort_t pidf)
    pids->AddAtAndExpand(pid,pidf);
    pid->IncrementCount();
 
-   R__RWLOCK_ACQUIRE_WRITE(fgRwLock);
-   pidslist->Add(pid);
-   Int_t ind = pidslist->IndexOf(pid);
-   pid->SetUniqueID((UInt_t)ind);
-   R__RWLOCK_RELEASE_WRITE(fgRwLock);
+   {
+      R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
+      pidslist->Add(pid);
+      Int_t ind = pidslist->IndexOf(pid);
+      pid->SetUniqueID((UInt_t)ind);
+   }
 
    return pid;
 }

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -150,7 +150,6 @@ Bool_t   TFile::fgCacheFileDisconnected = kTRUE;
 UInt_t   TFile::fgOpenTimeout = TFile::kEternalTimeout;
 Bool_t   TFile::fgOnlyStaged = kFALSE;
 #ifdef R__USE_IMT
-ROOT::TRWSpinLock TFile::fgRwLock;
 ROOT::Internal::RConcurrentHashColl TFile::fgTsSIHashes;
 #endif
 

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -574,9 +574,6 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    std::vector<std::size_t> fileIdxs(fFileNames.size());
    std::iota(fileIdxs.begin(), fileIdxs.end(), 0u);
 
-   // Enable this IMT use case (activate its locks)
-   Internal::TParTreeProcessingRAII ptpRAII;
-
    fPool.Foreach(processFile, fileIdxs);
 }
 


### PR DESCRIPTION
Currently, some sections of TFile::ReadProcessID are only protected
from concurrent access if Internal::IsParTreeProcessingEnabled()
is true. The only entity that enables ParTreeProcessing in ROOT
is TTreeProcessorMT::Process.

With this patch, concurrent access to TFile::ReadProcessID is always protected.

Rationale: if TTreeProcessorMT::Process needs that protection, everyone needs it.

Note that `TParTreeProcessing` is unused after this change, so if you agree the change can go in, I'll add a commit that removes `TParTreeProcessing` from ROOT.

If you _don't_ agree the change can go in: why does `TTreeProcessorMT::Process` need this protection but other usecases do not (note that `TParTreeProcessing` is in `ROOT::Internal`, so we do not expect users to activate these locks)?