### PR TITLE
[MT] Call EnableThreadSafety from TThreadExecutor's ctor

### DIFF
--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -132,11 +132,17 @@ namespace ROOT {
 
    //////////////////////////////////////////////////////////////////////////
    /// Class constructor.
-   /// If the scheduler is active, gets a pointer to it and works with the current pool of threads.
-   /// If not, initializes the pool of threads, spawning nThreads. nThreads' default value, 0, initializes the
-   /// pool with as many logical threads as there should be available in the system (see NLogicalCores in TPoolManager.cxx).
+   /// If the scheduler is active (e.g. because another TThreadExecutor is in flight, or ROOT::EnableImplicitMT() was
+   /// called), work with the current pool of threads.
+   /// If not, initialize the pool of threads, spawning nThreads. nThreads' default value, 0, initializes the
+   /// pool with as many logical threads as are available in the system (see NLogicalCores in TPoolManager.cxx).
+   ///
+   /// At construction time, TThreadExecutor automatically enables ROOT's thread-safety locks as per calling
+   /// ROOT::EnableThreadSafety().
    TThreadExecutor::TThreadExecutor(UInt_t nThreads)
    {
+      ROOT::EnableThreadSafety();
+
       auto current = ROOT::Internal::TPoolManager::GetPoolSize();
       if (nThreads && current && (current != nThreads))
       {

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -193,8 +193,6 @@ TEST(TreeProcessorMT, TreeInSubDirectory)
       t.Write();
    }
 
-   ROOT::EnableThreadSafety();
-
    auto fullPath = "dir0/dir1/tree";
 
    // With a TTree

--- a/tutorials/multicore/mtbb001_fillHistos.C
+++ b/tutorials/multicore/mtbb001_fillHistos.C
@@ -18,7 +18,6 @@ const UInt_t nThreads = 4U;
 
 Int_t mtbb001_fillHistos()
 {
-   ROOT::EnableThreadSafety();
    // We define our work item
    auto workItem = [](UInt_t workerID) {
       // One generator, file and ntuple per worker

--- a/tutorials/multicore/mtbb101_fillNtuples.C
+++ b/tutorials/multicore/mtbb101_fillNtuples.C
@@ -32,7 +32,6 @@ void fillRandom(TNtuple &ntuple, TRandom3 &rndm, UInt_t n)
 
 Int_t mtbb101_fillNtuples()
 {
-   ROOT::EnableThreadSafety();
    // No nuisance for batch execution
    gROOT->SetBatch();
 

--- a/tutorials/multicore/mtbb201_parallelHistoFill.C
+++ b/tutorials/multicore/mtbb201_parallelHistoFill.C
@@ -15,7 +15,6 @@ const UInt_t poolSize = 4U;
 
 Int_t mtbb201_parallelHistoFill()
 {
-   ROOT::EnableThreadSafety();
    TH1::AddDirectory(false);
    ROOT::TThreadExecutor pool(poolSize);
    auto fillRandomHisto = [](int seed = 0) {


### PR DESCRIPTION
It simplifies usage of TThreadExecutor and, consequently, TTreeProcessorMT, and prevents bugs due to users forgetting to make the call.