### PR TITLE
 [MT] Deprecate GetImplicitMTPoolSize in favor of GetThreadPoolSize 

### DIFF
--- a/README/ReleaseNotes/v622/index.md
+++ b/README/ReleaseNotes/v622/index.md
@@ -40,6 +40,8 @@ The following people have contributed to this new version:
 
 ## Deprecation and Removal
 
+- `ROOT::GetImplicitMTPoolSize` has been deprecated in favor of the newly added `ROOT::GetThreadPoolSize` and
+  will be removed in v6.24.
 
 ## Core Libraries
 

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -96,7 +96,7 @@ namespace ROOT {
    void EnableImplicitMT(UInt_t numthreads = 0);
    void DisableImplicitMT();
    Bool_t IsImplicitMTEnabled();
-   UInt_t GetImplicitMTPoolSize();
+   UInt_t GetImplicitMTPoolSize() _R__DEPRECATED_624("Please use ROOT::GetThreadPoolSize() instead");
    UInt_t GetThreadPoolSize();
 }
 

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -97,6 +97,7 @@ namespace ROOT {
    void DisableImplicitMT();
    Bool_t IsImplicitMTEnabled();
    UInt_t GetImplicitMTPoolSize();
+   UInt_t GetThreadPoolSize();
 }
 
 class TROOT : public TDirectory {

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -608,11 +608,11 @@ namespace Internal {
    }
 
    ////////////////////////////////////////////////////////////////////////////////
-   /// Returns the size of the pool used for implicit multi-threading.
-   UInt_t GetImplicitMTPoolSize()
+   /// Returns the size of ROOT's thread pool
+   UInt_t GetThreadPoolSize()
    {
 #ifdef R__USE_IMT
-      static UInt_t (*sym)() = (UInt_t(*)())Internal::GetSymInLibImt("ROOT_TImplicitMT_GetImplicitMTPoolSize");
+      static UInt_t (*sym)() = (UInt_t(*)())Internal::GetSymInLibImt("ROOT_MT_GetThreadPoolSize");
       if (sym)
          return sym();
       else
@@ -622,7 +622,12 @@ namespace Internal {
 #endif
    }
 
-
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Returns the size of the pool used for implicit multi-threading.
+   UInt_t GetImplicitMTPoolSize()
+   {
+      return GetThreadPoolSize();
+   }
 } // end of ROOT namespace
 
 TROOT *ROOT::Internal::gROOTLocal = ROOT::GetROOT();

--- a/core/imt/src/TImplicitMT.cxx
+++ b/core/imt/src/TImplicitMT.cxx
@@ -29,6 +29,11 @@ static std::shared_ptr<ROOT::Internal::TPoolManager> &R__GetPoolManagerMT()
    return schedMT;
 }
 
+extern "C" UInt_t ROOT_MT_GetThreadPoolSize()
+{
+   return ROOT::Internal::TPoolManager::GetPoolSize();
+};
+
 static bool &GetImplicitMTFlag()
 {
    static bool enabled = false;
@@ -69,12 +74,6 @@ extern "C" void ROOT_TImplicitMT_DisableImplicitMT()
       ::Warning("ROOT_TImplicitMT_DisableImplicitMT", "Implicit multi-threading is already disabled");
    }
 };
-
-extern "C" UInt_t ROOT_TImplicitMT_GetImplicitMTPoolSize()
-{
-   return ROOT::Internal::TPoolManager::GetPoolSize();
-};
-
 
 extern "C" void ROOT_TImplicitMT_EnableParBranchProcessing()
 {

--- a/core/thread/inc/ROOT/TThreadedObject.hxx
+++ b/core/thread/inc/ROOT/TThreadedObject.hxx
@@ -190,7 +190,7 @@ namespace ROOT {
       {
          auto nslots = nslotsTag.fVal;
          if (nslotsTag == kIMTPoolSize) {
-            nslots = ROOT::GetImplicitMTPoolSize();
+            nslots = ROOT::GetThreadPoolSize();
             if (nslots == 0) {
                throw std::logic_error("Must enable IMT before constructing TThreadedObject(kIMT)!");
             }
@@ -205,7 +205,7 @@ namespace ROOT {
       template<class ...ARGS>
       TThreadedObject(ARGS&&... args) : fIsMerged(false)
       {
-         const auto imtPoolSize = ROOT::GetImplicitMTPoolSize();
+         const auto imtPoolSize = ROOT::GetThreadPoolSize();
          if (!imtPoolSize) {
             Warning("TThreadedObject()",
                "Use without IMT is deprecated, either enable IMT first, or use constructor overload taking TNumSlots!");

--- a/math/mathcore/src/FitUtil.cxx
+++ b/math/mathcore/src/FitUtil.cxx
@@ -1774,7 +1774,7 @@ void FitUtil::EvaluatePoissonLogLGradient(const IModelFunction &f, const BinData
 
 
 unsigned FitUtil::setAutomaticChunking(unsigned nEvents){
-      auto ncpu  = ROOT::GetImplicitMTPoolSize();
+      auto ncpu  = ROOT::GetThreadPoolSize();
       if (nEvents/ncpu < 1000) return ncpu;
       return nEvents/1000;
       //return ((nEvents/ncpu + 1) % 1000) *40 ; //arbitrary formula

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -310,7 +310,7 @@ public:
    /// The expression must be a callable of signature R(unsigned int, T1, T2, ...) where `T1, T2...` are the types
    /// of the columns that the expression takes as input. The first parameter is reserved for an unsigned integer
    /// representing a "slot number". RDataFrame guarantees that different threads will invoke the expression with
-   /// different slot numbers - slot numbers will range from zero to ROOT::GetImplicitMTPoolSize()-1.
+   /// different slot numbers - slot numbers will range from zero to ROOT::GetThreadPoolSize()-1.
    ///
    /// The following two calls are equivalent, although `DefineSlot` is slightly more performant:
    /// ~~~{.cpp}
@@ -339,7 +339,7 @@ public:
    /// columns. The expression must be a callable of signature R(unsigned int, ULong64_t, T1, T2, ...) where `T1, T2...`
    /// are the types of the columns that the expression takes as input. The first parameter is reserved for an unsigned
    /// integer representing a "slot number". RDataFrame guarantees that different threads will invoke the expression with
-   /// different slot numbers - slot numbers will range from zero to ROOT::GetImplicitMTPoolSize()-1. The second parameter
+   /// different slot numbers - slot numbers will range from zero to ROOT::GetThreadPoolSize()-1. The second parameter
    /// is reserved for a `ULong64_t` representing the current entry being processed by the current thread.
    ///
    /// The following two `Define`s are equivalent, although `DefineSlotEntry` is slightly more performant:

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -19,7 +19,7 @@
 #include "TClassRef.h"
 #include "TInterpreter.h"
 #include "TLeaf.h"
-#include "TROOT.h" // IsImplicitMTEnabled, GetImplicitMTPoolSize
+#include "TROOT.h" // IsImplicitMTEnabled, GetThreadPoolSize
 #include "TTree.h"
 
 #include <stdexcept>
@@ -258,7 +258,7 @@ unsigned int GetNSlots()
    unsigned int nSlots = 1;
 #ifdef R__USE_IMT
    if (ROOT::IsImplicitMTEnabled())
-      nSlots = ROOT::GetImplicitMTPoolSize();
+      nSlots = ROOT::GetThreadPoolSize();
 #endif // R__USE_IMT
    return nSlots;
 }

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -514,7 +514,7 @@ We can take advantage of `ForeachSlot` to evaluate a thread-safe root mean squar
 ~~~{.cpp}
 // Thread-safe evaluation of RMS of branch "b" using ForeachSlot
 ROOT::EnableImplicitMT();
-const unsigned int nSlots = ROOT::GetImplicitMTPoolSize();
+const unsigned int nSlots = ROOT::GetThreadPoolSize();
 std::vector<double> sumSqs(nSlots, 0.);
 std::vector<unsigned int> ns(nSlots, 0);
 
@@ -735,7 +735,7 @@ from the names of the variables specified by the user.
 It is possible to create custom columns also as a function of the processing slot and entry numbers. The methods that can
 be invoked are:
 - `DefineSlot(name, f, columnList)`. In this case the callable f has this signature `R(unsigned int, T1, T2, ...)`: the
-first parameter is the slot number which ranges from 0 to ROOT::GetImplicitMTPoolSize() - 1.
+first parameter is the slot number which ranges from 0 to ROOT::GetThreadPoolSize() - 1.
 - `DefineSlotEntry(name, f, columnList)`. In this case the callable f has this signature `R(unsigned int, ULong64_t,
 T1, T2, ...)`: the first parameter is the slot number while the second one the number of the entry being processed.
 
@@ -776,7 +776,7 @@ In order to facilitate writing of thread-safe operations, some RDataFrame featur
 offer thread-aware counterparts (`ForeachSlot`, `DefineSlot`, `OnPartialResultSlot`): their only difference is that they
 will pass an extra `slot` argument (an unsigned integer) to the user-defined expression. When calling user-defined code
 concurrently, `RDataFrame` guarantees that different threads will employ different values of the `slot` parameter,
-where `slot` will be a number between 0 and `ROOT::GetImplicitMTPoolSize() - 1`.
+where `slot` will be a number between 0 and `ROOT::GetThreadPoolSize() - 1`.
 In other words, within a slot, computation runs sequentially and events are processed sequentially.
 Note that the same slot might be associated to different threads over the course of a single event loop, but two threads
 will never receive the same slot at the same time.

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -624,7 +624,7 @@ public:
 TEST_P(RDFSimpleTests, BookCustomAction)
 {
    RDataFrame d(1);
-   const auto nWorkers = std::max(1u, ROOT::GetImplicitMTPoolSize());
+   const auto nWorkers = std::max(1u, ROOT::GetThreadPoolSize());
    const auto expected = nWorkers-1;
 
    auto maxSlot0 = d.Book<unsigned int>(MaxSlotHelper(nWorkers), {"tdfslot_"});

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -96,7 +96,7 @@ MakeClusters(const std::vector<std::string> &treeNames, const std::vector<std::s
    // 16 * 2 * TTreeProcessorMT::GetMaxTasksPerFilePerWorker() clusters will be created, at most
    // 16 * TTreeProcessorMT::GetMaxTasksPerFilePerWorker() per file.
 
-   const auto maxTasksPerFile = TTreeProcessorMT::GetMaxTasksPerFilePerWorker() * ROOT::GetImplicitMTPoolSize();
+   const auto maxTasksPerFile = TTreeProcessorMT::GetMaxTasksPerFilePerWorker() * ROOT::GetThreadPoolSize();
    std::vector<std::vector<EntryCluster>> eventRangesPerFile(clustersPerFile.size());
    auto clustersPerFileIt = clustersPerFile.begin();
    auto eventRangesPerFileIt = eventRangesPerFile.begin();

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -389,16 +389,16 @@ TEST(TreeProcessorMT, ChainWithFriendChain)
 
 TEST(TreeProcessorMT, SetNThreads)
 {
-   EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 0u);
+   EXPECT_EQ(ROOT::GetThreadPoolSize(), 0u);
    {
       ROOT::TTreeProcessorMT p("somefile", "sometree", 1u);
-      EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 1u);
+      EXPECT_EQ(ROOT::GetThreadPoolSize(), 1u);
    }
-   EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 0u);
+   EXPECT_EQ(ROOT::GetThreadPoolSize(), 0u);
 
    {
       ROOT::TTreeProcessorMT p({"somefile", "some_other"}, "sometree", 1u);
-      EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 1u);
+      EXPECT_EQ(ROOT::GetThreadPoolSize(), 1u);
    }
 
    {
@@ -409,7 +409,7 @@ TEST(TreeProcessorMT, SetNThreads)
       t.Write();
       TEntryList l;
       ROOT::TTreeProcessorMT p(t, l, 1u);
-      EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 1u);
+      EXPECT_EQ(ROOT::GetThreadPoolSize(), 1u);
       f.Close();
       gSystem->Unlink("treeprocmt_setnthreads.root");
    }
@@ -421,7 +421,7 @@ TEST(TreeProcessorMT, SetNThreads)
       TTree t("t", "t");
       t.Write();
       ROOT::TTreeProcessorMT p(t, 1u);
-      EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 1u);
+      EXPECT_EQ(ROOT::GetThreadPoolSize(), 1u);
       gSystem->Unlink("treeprocmt_setnthreads.root");
    }
 }

--- a/tutorials/dataframe/df013_InspectAnalysis.C
+++ b/tutorials/dataframe/df013_InspectAnalysis.C
@@ -15,7 +15,7 @@ using namespace ROOT; // RDataFrame lives in here
 void df013_InspectAnalysis()
 {
    ROOT::EnableImplicitMT();
-   const auto poolSize = ROOT::GetImplicitMTPoolSize();
+   const auto poolSize = ROOT::GetThreadPoolSize();
    const auto nSlots = 0 == poolSize ? 1 : poolSize;
 
    // ## Setup a simple RDataFrame

--- a/tutorials/dataframe/df018_customActions.C
+++ b/tutorials/dataframe/df018_customActions.C
@@ -33,7 +33,7 @@ public:
    THnHelper(std::string_view name, std::string_view title, std::array<int, NDIM> nbins, std::array<double, NDIM> xmins,
              std::array<double, NDIM> xmax)
    {
-      const auto nSlots = ROOT::IsImplicitMTEnabled() ? ROOT::GetImplicitMTPoolSize() : 1;
+      const auto nSlots = ROOT::IsImplicitMTEnabled() ? ROOT::GetThreadPoolSize() : 1;
       for (auto i : ROOT::TSeqU(nSlots)) {
          fHistos.emplace_back(std::make_shared<THn_t>(std::string(name).c_str(), std::string(title).c_str(),
                                                       NDIM, nbins.data(), xmins.data(), xmax.data()));

--- a/tutorials/dataframe/df022_useKahan.C
+++ b/tutorials/dataframe/df022_useKahan.C
@@ -37,7 +37,7 @@ public:
    {
       static_assert(std::is_floating_point<T>::value, "Kahan sum makes sense only on floating point numbers");
 
-      fNSlots = ROOT::IsImplicitMTEnabled() ? ROOT::GetImplicitMTPoolSize() : 1;
+      fNSlots = ROOT::IsImplicitMTEnabled() ? ROOT::GetThreadPoolSize() : 1;
       fPartialSums.resize(fNSlots, 0.);
       fCompensations.resize(fNSlots, 0.);
    }


### PR DESCRIPTION
TThreadExecutor does not activate implicit multi-threading
(ROOT::IsImplicitMTEnabled() is false after constructing a
TThreadExecutor) but it does change the size of the thread-pool, which
is not only used by implicit multi-threading features, but also by
TThreadExecutor and TTreeProcessorMT. So the thread pool is not the
"ImplicitMTPool" but it's really ROOT's one and only pool of threads,
so we prefer ROOT::GetThreadPoolSize to GetImplicitMTPoolSize.