### PR TITLE
[Cocoa] Implement crosshair cursor on MacOS Catalina

### DIFF
--- a/README/ReleaseNotes/v622/index.md
+++ b/README/ReleaseNotes/v622/index.md
@@ -29,6 +29,7 @@ The following people have contributed to this new version:
  Axel Naumann, CERN/SFT,\
  Vincenzo Eduardo Padulano, Bicocca/SFT,\
  Danilo Piparo, CERN/SFT,\
+ Timur Pocheptsoff, Qt Company,\
  Fons Rademakers, CERN/SFT,\
  Oksana Shadura, Nebraska,\
  Enric Tejedor Saavedra, CERN/SFT,\
@@ -106,7 +107,10 @@ into RooFit's message stream number 2. The verbosity can therefore be adjusted u
 
 ## 2D Graphics Libraries
 
- * Universal time (correct time zone and daylight saving time) in PDF file.
+  - Universal time (correct time zone and daylight saving time) in PDF file. Implemented by
+    Jan Musinsky.
+  - The crosshair type cursor type did not work on MacOS Catalina. This has been fixed by
+    Timur Pocheptsoff.
 
 ## 3D Graphics Libraries
 

--- a/graf2d/cocoa/inc/QuartzWindow.h
+++ b/graf2d/cocoa/inc/QuartzWindow.h
@@ -19,6 +19,31 @@
 #include "X11Events.h"
 #include "GuiTypes.h"
 
+/////////////////////////////////////////////////////////////////////
+//                                                                 //
+// CrosshairView comprises the content view of a CrosshairWindow.  //
+// It's purpose is to render two lines ... a crosshair.            //
+//                                                                 //
+/////////////////////////////////////////////////////////////////////
+@interface CrosshairView: NSView
+// Line1:
+@property (nonatomic, assign)NSPoint start1;
+@property (nonatomic, assign)NSPoint end1;
+// Line2:
+@property (nonatomic, assign)NSPoint start2;
+@property (nonatomic, assign)NSPoint end2;
+@end
+
+// CrosshairWindow is a special window: a transparent
+// transient child window that we attach to a canvas
+// to draw a crosshair on top of the pad's contents.
+// It's transparent to all mouse events and can never
+// be main or a key window. It has a transparent
+// background.
+@interface CrosshairWindow : NSWindow
+- (instancetype) init;
+@end
+
 ////////////////////////////////////////////////
 //                                            //
 // QuartzWindow class : top-level window.     //
@@ -90,6 +115,12 @@
 
 - (unsigned char *) readColorBits : (ROOT::MacOSX::X11::Rectangle) area;
 
+// Trick for crosshair drawing in TCanvas ("pseudo-XOR")
+- (void) addCrosshairWindow;
+- (void) adjustCrosshairWindowGeometry;
+- (void) adjustCrosshairWindowGeometry : (CrosshairWindow *)win;
+- (void) removeCrosshairWindow;
+- (CrosshairWindow *) findCrosshairWindow;
 
 //X11Window protocol.
 

--- a/graf2d/cocoa/inc/X11Buffer.h
+++ b/graf2d/cocoa/inc/X11Buffer.h
@@ -229,6 +229,9 @@ public:
 
    void Execute()const;
    void Execute(CGContextRef ctx)const;
+
+   Point start() const {return fP1;}
+   Point end() const {return fP2;}
 };
 
 class CommandBuffer {
@@ -271,12 +274,11 @@ public:
    {
       return fCommands.size();
    }
+
+   void ClearXOROperations();
 private:
    void ClearCommands();
-   void ClearXOROperations();
-
    //Clip related stuff.
-
    struct WidgetRect {
       int fX1;
       int fY1;

--- a/graf2d/cocoa/src/TGCocoa.mm
+++ b/graf2d/cocoa/src/TGCocoa.mm
@@ -3466,7 +3466,17 @@ void TGCocoa::SetDrawMode(EDrawMode mode)
 {
    // Sets the drawing mode.
    //
-   //EDrawMode{kCopy, kXor};
+   //EDrawMode{kCopy, kXor, kInvert};
+   if (fDrawMode == kInvert && mode != kInvert) {
+       // Remove previously added CrosshairWindow.
+       auto windows = NSApplication.sharedApplication.windows;
+       for (NSWindow *candidate : windows) {
+           if ([candidate isKindOfClass:QuartzWindow.class])
+               [(QuartzWindow *)candidate removeCrosshairWindow];
+       }
+       fPimpl->fX11CommandBuffer.ClearXOROperations();
+   }
+
    fDrawMode = mode;
 }
 

--- a/graf2d/cocoa/src/TGQuartz.mm
+++ b/graf2d/cocoa/src/TGQuartz.mm
@@ -247,8 +247,17 @@ void TGQuartz::DrawLine(Int_t x1, Int_t y1, Int_t x2, Int_t y2)
    // x2,y2        : end of line
 
    if (fDirectDraw) {
-      if (!fPimpl->GetDrawable(fSelectedDrawable).fIsPixmap)
+      if (!fPimpl->GetDrawable(fSelectedDrawable).fIsPixmap) {
+         QuartzView * const view = (QuartzView *)fPimpl->GetWindow(fSelectedDrawable).fContentView;
+         if (!view) {
+             ::Warning("DrawLine", "Invalid view/window for XOR-mode");
+             return;
+         }
+
+         [view.fQuartzWindow addCrosshairWindow];
          fPimpl->fX11CommandBuffer.AddDrawLineXor(fSelectedDrawable, x1, y1, x2, y2);
+      }
+
       return;
    }
 

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -1539,8 +1539,11 @@ void TPad::DrawCrosshair()
       pymin = 0;
       pymax = cpad->GetWh();
    }
+#ifndef R__HAS_COCOA
+   // Not needed, no XOR with Cocoa.
    if(pxold) gVirtualX->DrawLine(pxold,pymin,pxold,pymax);
    if(pyold) gVirtualX->DrawLine(pxmin,pyold,pxmax,pyold);
+#endif // R__HAS_COCOA
    if (cpad->GetEvent() == kButton1Down ||
        cpad->GetEvent() == kButton1Up   ||
        cpad->GetEvent() == kMouseLeave) {


### PR DESCRIPTION
The graphics cursor type "crosshair" did not work on MacOS Catalina. 

This was reported on the forum here: https://root-forum.cern.ch/t/crosshair-not-working-on-mac-os-catalina/ 

To see the crosshair cursor type select "SetCrosshair" in the canvas pop up menu. 

This fix was provided by Timur Pocheptsoff (Qt Company).