### PR TITLE
[DF] Ensure TTreeProcessorMT's pool is created with expected number of threads

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -296,7 +296,7 @@ void RLoopManager::RunTreeProcessorMT()
    CheckIndexedFriends();
    RSlotStack slotStack(fNSlots);
    const auto &entryList = fTree->GetEntryList() ? *fTree->GetEntryList() : TEntryList();
-   auto tp = std::make_unique<ROOT::TTreeProcessorMT>(*fTree, entryList);
+   auto tp = std::make_unique<ROOT::TTreeProcessorMT>(*fTree, entryList, fNSlots);
 
    std::atomic<ULong64_t> entryCount(0ull);
 


### PR DESCRIPTION
At construction time, RDataFrame sets its number of processing slots
equal to ROOT::GetImplicitMTPoolSize(). We always want to
construct TTreeProcessorMT's thread pool with a size equal to
RDF::GetNSlots().

Besides being more robus (less reliance on shared global state),
this patch guarantees that if the number of threads in the thread pool
is different than what RDF requests, we get a warning from TThreadExecutor.