### PR TITLE
Move {std namespace} declaration after all includes [ROOT-10661]

### DIFF
--- a/README/ReleaseNotes/v622/index.md
+++ b/README/ReleaseNotes/v622/index.md
@@ -45,6 +45,7 @@ The following people have contributed to this new version:
 
 ## Core Libraries
 
+- The `ACLiC` can be configured to pass options to the `rootcling` invocation by enabling in the `.rootrc` the `ACLiC.ExtraRootclingFlags [-opts]` line.
 
 ## I/O Libraries
 

--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -389,6 +389,8 @@ ACLiC.Linkdef:          _linkdef
 #      needed libraries.
 # On Windows, the default is 3
 #ACLiC.LinkLibs:      1
+# Add extra options to rootcling invocation by ACLiC
+#ACLiC.ExtraRootclingFlags:      [-optA ... -optZ]
 
 # PROOF related variables
 #

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3560,6 +3560,12 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
    if (gEnv) {
       TString fromConfig = gEnv->GetValue("ACLiC.IncludePaths","");
       rcling.Append(fromConfig);
+      TString extraFlags = gEnv->GetValue("ACLiC.ExtraRootclingFlags","");
+      if (!extraFlags.IsNull()) {
+        extraFlags.Prepend(" ");
+        extraFlags.Append(" ");
+        rcling.Append(extraFlags);
+      }
    }
 
    // Create a modulemap


### PR DESCRIPTION
In order to avoid {namespace std} interfering with following include files,
when generating a dictionary file declare the {namespace std} only after
GenerateNecessaryIncludes method is called