### PR TITLE
[IO] Remove TParTreeProcessingRAII locks from TFile::ReadProcessID

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1823,14 +1823,12 @@ TProcessID  *TFile::ReadProcessID(UShort_t pidf)
    TIter next(pidslist);
    TProcessID *p;
    bool found = false;
-   R__RWLOCK_ACQUIRE_READ(fgRwLock);
    while ((p = (TProcessID*)next())) {
       if (!strcmp(p->GetTitle(),pid->GetTitle())) {
          found = true;
          break;
       }
    }
-   R__RWLOCK_RELEASE_READ(fgRwLock);
 
    if (found) {
       delete pid;
@@ -1842,11 +1840,9 @@ TProcessID  *TFile::ReadProcessID(UShort_t pidf)
    pids->AddAtAndExpand(pid,pidf);
    pid->IncrementCount();
 
-   R__RWLOCK_ACQUIRE_WRITE(fgRwLock);
    pidslist->Add(pid);
    Int_t ind = pidslist->IndexOf(pid);
    pid->SetUniqueID((UInt_t)ind);
-   R__RWLOCK_RELEASE_WRITE(fgRwLock);
 
    return pid;
 }


### PR DESCRIPTION
These locks were only activated when inside TTreeProcessorMT::Process,
and they seem to protect the usecase in which the method is called
concurrently on the same object, which is not a valid usecase (anymore?).

**Note:** just checking that this change does not cause crashes for now