### PR TITLE
[TreeProcMT] Do not EnableImplicitMT when running event loop 

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -462,8 +462,6 @@ namespace Internal {
    void EnableParTreeProcessing()
    {
 #ifdef R__USE_IMT
-      if (!IsImplicitMTEnabled())
-         EnableImplicitMT();
       static void (*sym)() = (void(*)())Internal::GetSymInLibImt("ROOT_TImplicitMT_EnableParTreeProcessing");
       if (sym)
          sym();

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -422,6 +422,7 @@ TTreeProcessorMT::TTreeProcessorMT(std::string_view filename, std::string_view t
    : fFileNames({std::string(filename)}),
      fTreeNames(treename.empty() ? FindTreeNames() : std::vector<std::string>{std::string(treename)}), fFriendInfo(), fPool(nThreads)
 {
+   ROOT::EnableThreadSafety();
 }
 
 std::vector<std::string> CheckAndConvert(const std::vector<std::string_view> &views)
@@ -454,6 +455,7 @@ TTreeProcessorMT::TTreeProcessorMT(const std::vector<std::string_view> &filename
                                  : std::vector<std::string>(fFileNames.size(), std::string(treename))),
      fFriendInfo(), fPool(nThreads)
 {
+   ROOT::EnableThreadSafety();
 }
 
 std::vector<std::string> GetFilesFromTree(TTree &tree)
@@ -492,6 +494,7 @@ TTreeProcessorMT::TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_
    : fFileNames(GetFilesFromTree(tree)), fTreeNames(GetTreeFullPaths(tree)), fEntryList(entries),
      fFriendInfo(GetFriendInfo(tree)), fPool(nThreads)
 {
+   ROOT::EnableThreadSafety();
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -420,7 +420,8 @@ std::vector<std::string> TTreeProcessorMT::FindTreeNames()
 ///                     the same as for TThreadExecutor.
 TTreeProcessorMT::TTreeProcessorMT(std::string_view filename, std::string_view treename, UInt_t nThreads)
    : fFileNames({std::string(filename)}),
-     fTreeNames(treename.empty() ? FindTreeNames() : std::vector<std::string>{std::string(treename)}), fFriendInfo(), fPool(nThreads)
+     fTreeNames(treename.empty() ? FindTreeNames() : std::vector<std::string>{std::string(treename)}), fFriendInfo(),
+     fPool(nThreads)
 {
    ROOT::EnableThreadSafety();
 }

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -233,7 +233,6 @@ TEST(TreeProcessorMT, LimitNTasks_CheckEntries)
       }
    };
 
-   ROOT::DisableImplicitMT();
    ROOT::EnableImplicitMT(4);
 
    ROOT::TTreeProcessorMT p(filename, treename);
@@ -276,7 +275,6 @@ TEST(TreeProcessorMT, LimitNTasks_CheckClusters)
    };
 
    for (auto nThreads = 0; nThreads <= 4; ++nThreads) {
-      ROOT::DisableImplicitMT();
       ROOT::EnableImplicitMT(nThreads);
 
       ROOT::TTreeProcessorMT p(filename, treename);
@@ -284,10 +282,10 @@ TEST(TreeProcessorMT, LimitNTasks_CheckClusters)
 
       CheckClusters(clusters, nEvents);
       clusters.clear();
+      ROOT::DisableImplicitMT();
    }
 
    gSystem->Unlink(filename);
-   ROOT::DisableImplicitMT();
 }
 
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
@@ -335,7 +333,9 @@ TEST(TreeProcessorMT, TreeWithFriendTree)
    ROOT::TTreeProcessorMT tp(*t1);
    tp.Process(procLambda);
 
+   // Clean-up
    DeleteFiles(fileNames);
+   ROOT::DisableImplicitMT();
 }
 
 TEST(TreeProcessorMT, ChainWithFriendChain)
@@ -384,11 +384,11 @@ TEST(TreeProcessorMT, ChainWithFriendChain)
 
    // Clean-up
    DeleteFiles(fileNames);
+   ROOT::DisableImplicitMT();
 }
 
 TEST(TreeProcessorMT, SetNThreads)
 {
-   ROOT::DisableImplicitMT();
    EXPECT_EQ(ROOT::GetImplicitMTPoolSize(), 0u);
    {
       ROOT::TTreeProcessorMT p("somefile", "sometree", 1u);


### PR DESCRIPTION
Before this patch, TTreeProcessorMT::Process activated implicit
multi-threading features (and never disabled them). One undesired
side-effect was that ROOT's thread-pool was not destructed after
TTreeProcessorMT was destructed. After this patch, TTreeProcessorMT
multi-thread TTree processing and activation of implicit
multi-threading features are disentangled, and users are
required to call EnableImplicitMT explicitly to activate IMT.
This is consistent with TThreadExecutor's behavior.
This fixes ROOT-10656.