### PR TITLE
[IMT] Remove redundant call to EnableImplicitMT

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -415,8 +415,6 @@ namespace Internal {
    void EnableParBranchProcessing()
    {
 #ifdef R__USE_IMT
-      if (!IsImplicitMTEnabled())
-         EnableImplicitMT();
       static void (*sym)() = (void(*)())Internal::GetSymInLibImt("ROOT_TImplicitMT_EnableParBranchProcessing");
       if (sym)
          sym();


### PR DESCRIPTION
EnableParBranchProcessing is only called by TParBranchProcessingRAII's
constructor, which is only called by TTree::GetEntry if
ROOT::IsImplicitMTEnabled returns true. Plus, it's surprising that
a RAII object that is meant to activate locks also changes the state
of ROOT's thread-pool (permanently). As these facilities are in
ROOT::Internal, this change in behavior in TParBranchProcessingRAII
will not be user-visible.