### PR TITLE
[DF] Move test_splitcoll_arrayview to gtests from roottest (backport for v6.16)

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -14,6 +14,12 @@ ROOT_ADD_GTEST(dataframe_snapshot dataframe_snapshot.cxx LIBRARIES ROOTDataFrame
 ROOT_ADD_GTEST(dataframe_utils dataframe_utils.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_report dataframe_report.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_helpers dataframe_helpers.cxx LIBRARIES ROOTDataFrame)
+if(NOT runtime_cxxmodules)
+  # This test fails with runtime C++ modules on in v6.18, runs fine in v6.20 and above. Won't fix.
+  ROOT_GENERATE_DICTIONARY(TwoFloatsDict TwoFloats.h LINKDEF TwoFloatsLinkDef.h OPTIONS -inlineInputHeader)
+  ROOT_ADD_GTEST(dataframe_splitcoll_arrayview dataframe_splitcoll_arrayview.cxx TwoFloatsDict.cxx LIBRARIES ROOTDataFrame)
+  target_include_directories(dataframe_splitcoll_arrayview PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 ROOT_ADD_GTEST(dataframe_ranges dataframe_ranges.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_leaves dataframe_leaves.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_vecops dataframe_vecops.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/TwoFloats.h
+++ b/tree/dataframe/test/TwoFloats.h
@@ -1,0 +1,17 @@
+#include "Rtypes.h"
+
+class TwoFloats {
+public:
+   virtual ~TwoFloats() {} // to make dictionary generation happy
+   float a = 0;
+   float b = 0;
+   TwoFloats(){};
+   TwoFloats(float d) : a(d), b(2 * d){};
+   void Set(float d)
+   {
+      a = d;
+      b = 2 * d;
+   }
+   ClassDef(TwoFloats, 2)
+};
+

--- a/tree/dataframe/test/TwoFloatsLinkDef.h
+++ b/tree/dataframe/test/TwoFloatsLinkDef.h
@@ -1,0 +1,6 @@
+#ifdef __ROOTCLING__
+
+#pragma link C++ class TwoFloats+;
+#pragma link C++ class vector<TwoFloats>+;
+
+#endif

--- a/tree/dataframe/test/dataframe_splitcoll_arrayview.cxx
+++ b/tree/dataframe/test/dataframe_splitcoll_arrayview.cxx
@@ -1,0 +1,65 @@
+// this test was roottest's root/dataframe/test_splitcoll_arrayview.C
+#include "ROOT/RDataFrame.hxx"
+#include "TFile.h"
+#include "TTree.h"
+#include "ROOT/TSeq.hxx"
+#include "ROOT/RVec.hxx"
+#include "TSystem.h"
+#include "TROOT.h"
+#include "gtest/gtest.h"
+
+#include "TwoFloats.h"
+
+#include <iostream>
+
+void fill_tree(const char *filename, const char *treeName)
+{
+   TFile f(filename, "RECREATE");
+   TTree t(treeName, treeName);
+   std::vector<TwoFloats> v;
+   t.Branch("v", "vector<TwoFloats>", &v, 32000, 2);
+   for (auto i : ROOT::TSeqI(10)) {
+      v.emplace_back(i);
+      t.Fill();
+   }
+   t.Write();
+   f.Close();
+}
+
+void test_splitcoll_arrayview(const std::string &fileName, const std::string &treeName)
+{
+   ROOT::RDataFrame d1(treeName, fileName, {"v.a"});
+   auto c1 = d1.Filter([](ROOT::VecOps::RVec<float> d) {
+                  float ex_v = 0.f;
+                  for (auto v : d) {
+                     EXPECT_DOUBLE_EQ(v, ex_v);
+                     ex_v += 1.f;
+                  }
+                  return d[0] > 5;
+               })
+                .Count();
+   EXPECT_EQ(*c1, 0ull);
+
+   ROOT::RDataFrame d2(treeName, fileName, {"v"});
+   auto c2 = d2.Filter([](ROOT::VecOps::RVec<TwoFloats> d) {
+                  int q = 0;
+                  float ex_a = 0.f;
+                  for (auto v : d) {
+                     EXPECT_DOUBLE_EQ(v.a, ex_a);
+                     q += int(v.a);
+                     ex_a += 1.f;
+                  }
+                  return 0 == q % 3;
+               })
+                .Count();
+   EXPECT_EQ(*c2, 7ull);
+}
+
+TEST(RDFSimpleTests, SplitCollectionArrayView)
+{
+   auto fileName = "myfile_test_splitcoll_arrayview.root";
+   auto treeName = "myTree";
+   fill_tree(fileName, treeName);
+   test_splitcoll_arrayview(fileName, treeName);
+   gSystem->Unlink(fileName);
+}


### PR DESCRIPTION
This test fails with runtime C++ modules on in v6.18, runs fine in v6.20 and above.
Won't fix it in older versions, so it's also disabled if runtime C++ modules are on
in v6.16, just to be sure/consistent.