### PR TITLE
[Exp PyROOT] Fix import from JupyROOT and change '_threaded' to '__re…

### DIFF
--- a/bindings/jsmva/python/JsMVA/JPyInterface.py
+++ b/bindings/jsmva/python/JsMVA/JPyInterface.py
@@ -145,7 +145,7 @@ class functions:
     # from DataLoader and Factory modules
     @staticmethod
     def register(noOutput=False):
-        from JupyROOT.utils import transformers
+        from JupyROOT.helpers.utils import transformers
         functions.__register(ROOT.TMVA.DataLoader, DataLoader, *functions.__getMethods(DataLoader, "Draw"))
         functions.__register(ROOT.TMVA.Factory,    Factory,    *functions.__getMethods(Factory,    "Draw"))
         functions.__changeMethod(ROOT.TMVA.Factory,    Factory,    *functions.__getMethods(Factory,    "Change"))

--- a/bindings/jsmva/python/JsMVA/JPyInterface.py
+++ b/bindings/jsmva/python/JsMVA/JPyInterface.py
@@ -152,7 +152,7 @@ class functions:
         functions.__changeMethod(ROOT.TMVA.DataLoader, DataLoader, *functions.__getMethods(DataLoader, "Change"))
         for key in functions.ThreadedFunctions:
             for func in functions.ThreadedFunctions[key]:
-                setattr(getattr(getattr(ROOT.TMVA, key), func), "_threaded", True)
+                setattr(getattr(getattr(ROOT.TMVA, key), func), "__release_gil__", True)
         functions.__register(ROOT.TMVA.Factory, Factory, "BookDNN")
         if not noOutput:
             outputTransformer = OutputTransformer.transformTMVAOutputToHTML()
@@ -189,7 +189,7 @@ class functions:
 class JsDraw:
     ## Base repository
     __jsMVARepo = "https://root.cern.ch/js/jsmva/latest"
- 
+
     ## String containing the link to JavaScript files
     __jsMVASourceDir = __jsMVARepo + "/js"
 


### PR DESCRIPTION
…lease_gil__'

JupyROOT.utils -> JupyROOT.helpers.utils
libcppyy.CPPOverload._threaded -> libcppyy.CPPOverload.__release_gil__

Fixes https://sft.its.cern.ch/jira/browse/ROOT-10175?jql=text%20~%20%22jsmva%22