### PR TITLE
[Exp PyROOT] Pythonised RooWorkspace.Import()

### DIFF
--- a/README/ReleaseNotes/v622/index.md
+++ b/README/ReleaseNotes/v622/index.md
@@ -65,7 +65,15 @@ The following people have contributed to this new version:
 
 ## RooFit Libraries
 
-### Type safe proxies to RooFit objects
+### RooWorkspace::Import() for Python
+`RooWorkspace.import()` cannot be used in Python, since it is a reserved keyword. Users therefore had to resort
+to
+    getattr(workspace, 'import')(...)
+Now,
+    workspace.Import(...)
+has been defined for the new PyROOT, which makes calling the function easier.
+
+### Type-safe proxies for RooFit objects
 RooFit's proxy classes have been modernised. The new class `RooProxy` allows for access to other RooFit objects
 similarly to a smart pointer. In older versions of RooFit, the objects held by *e.g.* `RooRealProxy` had to be
 accessed like this:

--- a/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
@@ -31,6 +31,7 @@ set(py_sources
   ROOT/pythonization/_rooabscollection.py
   ROOT/pythonization/_roodatahist.py
   ROOT/pythonization/_roodataset.py
+  ROOT/pythonization/_rooworkspace.py
   ROOT/pythonization/_rvec.py
   ROOT/pythonization/_stl_vector.py
   ROOT/pythonization/_tarray.py

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rooworkspace.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rooworkspace.py
@@ -1,0 +1,22 @@
+# Author: Stephan Hageboeck, CERN 04/2020
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+
+@pythonization()
+def pythonize_rooworkspace(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    if name == 'RooWorkspace':
+        # Support the C++ `import()` as `Import()` in python
+        klass.Import = getattr(klass, 'import')

--- a/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
@@ -110,6 +110,9 @@ if(roofit)
 
   # RooDataHist pythonisations
   ROOT_ADD_PYUNITTEST(pyroot_pyz_roodatahist_ploton roodatahist_ploton.py)
+
+  # RooWorkspace pythonizations
+  ROOT_ADD_PYUNITTEST(pyroot_pyz_rooworkspace rooworkspace.py)
 endif()
 
 # std::string_view backport in CPyCppyy

--- a/bindings/pyroot_experimental/pythonizations/test/rooworkspace.py
+++ b/bindings/pyroot_experimental/pythonizations/test/rooworkspace.py
@@ -1,0 +1,43 @@
+import unittest
+import ROOT
+
+class RooWorkspace_test(unittest.TestCase):
+    """
+    Test for the pythonizations of RooWorkspace.
+    """
+
+    # Setup
+    def setUp(self):
+       self.x = ROOT.RooRealVar("x", "x", 1.337, 0, 10)
+       self.ws = ROOT.RooWorkspace("ws", "A workspace")
+
+    # Tests
+    def test_import(self):
+       self.ws.Import(self.x)
+       x = self.ws.var('x')
+       self.assertEqual(x.GetName(), 'x')
+       self.assertEqual(x.getVal(), self.x.getVal())
+    
+    def test_import_with_arg(self):
+       # Prepare workspace with variables and a PDF
+       self.ws.Import(self.x)
+       rename = ROOT.RooFit.RenameAllVariables('exp')
+       exp = ROOT.RooExponential("exp", "exp", self.x, self.x)
+       self.ws.Import(exp, rename)
+       
+       # Test that rename argument has worked
+       x = self.ws.var('x_exp')
+       self.assertEqual(x.getVal(), self.x.getVal())
+       pdf = self.ws.pdf('exp')
+       self.assertGreater(pdf.getVal(), 0)
+
+    def test_import_argset(self):
+       argSet = ROOT.RooArgSet(self.x)
+       self.ws.Import(argSet)
+       x = self.ws.arg('x')
+       self.assertEqual(x.GetName(), 'x')
+       self.assertEqual(x.getVal(), self.x.getVal())
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -252,7 +252,7 @@ RooWorkspace::~RooWorkspace()
 ////////////////////////////////////////////////////////////////////////////////
 /// Import a RooAbsArg or RooAbsData set from a workspace in a file. Filespec should be constructed as "filename:wspacename:objectname"
 /// The arguments will be passed to the relevant import() or import(RooAbsData&, ...) import calls
-
+/// \note From python, use `Import()`, since `import` is a reserved keyword.
 Bool_t RooWorkspace::import(const char* fileSpec,
 			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
 			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
@@ -314,7 +314,7 @@ Bool_t RooWorkspace::import(const char* fileSpec,
 ////////////////////////////////////////////////////////////////////////////////
 /// Import multiple RooAbsArg objects into workspace. For details on arguments see documentation
 /// of import() method for single RooAbsArg
-
+/// \note From python, use `Import()`, since `import` is a reserved keyword.
 Bool_t RooWorkspace::import(const RooArgSet& args,
 			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
 			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
@@ -356,6 +356,7 @@ Bool_t RooWorkspace::import(const RooArgSet& args,
 ///  The RenameConflictNodes, RenameNodes and RecycleConflictNodes arguments are mutually exclusive. The RenameVariable argument can be repeated
 ///  as often as necessary to rename multiple variables. Alternatively, a single RenameVariable argument can be given with
 ///  two comma separated lists.
+/// \note From python, use `Import()`, since `import` is a reserved keyword.
 Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
 			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
@@ -753,7 +754,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 /// <tr><td> `Rename(const char* suffix)` <td> Rename dataset upon insertion
 /// <tr><td> `RenameVariable(const char* inputName, const char* outputName)` <td> Change names of observables in dataset upon insertion
 /// <tr><td> `Silence` <td> Be quiet, except in case of errors
-
+/// \note From python, use `Import()`, since `import` is a reserved keyword.
 Bool_t RooWorkspace::import(RooAbsData& inData,
 			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
 			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,

--- a/tutorials/roofit/rf502_wspacewrite.py
+++ b/tutorials/roofit/rf502_wspacewrite.py
@@ -53,10 +53,10 @@ data = model.generate(ROOT.RooArgSet(x), 1000)
 w = ROOT.RooWorkspace("w", "workspace")
 
 # Import model and all its components into the workspace
-getattr(w, 'import')(model)
+w.Import(model)
 
 # Import data into the workspace
-getattr(w, 'import')(data)
+w.Import(data)
 
 # Print workspace contents
 w.Print()

--- a/tutorials/roofit/rf504_simwstool.py
+++ b/tutorials/roofit/rf504_simwstool.py
@@ -47,7 +47,7 @@ d.defineType("bar")
 
 # Import ingredients in a workspace
 w = ROOT.RooWorkspace("w", "w")
-getattr(w, 'import')(ROOT.RooArgSet(model, c, d))
+w.Import(ROOT.RooArgSet(model, c, d))
 
 # Make Sim builder tool
 sct = ROOT.RooSimWSTool(w)

--- a/tutorials/roofit/rf509_wsinteractive.py
+++ b/tutorials/roofit/rf509_wsinteractive.py
@@ -50,7 +50,7 @@ def fillWorkspace(w):
             sig),
         ROOT.RooArgList(bkgfrac))
 
-    getattr(w, 'import')(model)
+    w.Import(model)
 
 
 # Create and fill workspace

--- a/tutorials/roofit/rf511_wsfactory_basic.py
+++ b/tutorials/roofit/rf511_wsfactory_basic.py
@@ -57,7 +57,7 @@ else:
 # Make a dummy dataset p.d.f. 'model' and import it in the workspace
 data = w.pdf("model").generate(ROOT.RooArgSet(w.var("x")), 1000)
 # Cannot call 'import' directly because this is a python keyword:
-getattr(w, 'import')(data, ROOT.RooFit.Rename("data"))
+w.Import(data, ROOT.RooFit.Rename("data"))
 
 # Construct a KEYS p.d.f. passing a dataset name and an enum type defining the
 # mirroring strategy
@@ -65,7 +65,7 @@ getattr(w, 'import')(data, ROOT.RooFit.Rename("data"))
 # Workaround for pyROOT
 x = w.var("x")
 k = ROOT.RooKeysPdf("k", "k", x, data, ROOT.RooKeysPdf.NoMirror, 0.2)
-getattr(w, 'import')(k, ROOT.RooFit.RenameAllNodes("workspace"))
+w.Import(k, ROOT.RooFit.RenameAllNodes("workspace"))
 
 # Print workspace contents
 w.Print()


### PR DESCRIPTION
[Exp PyROOT] Add pythonisation for RooWorkspace.

RooWorkspace.import() cannot be called from Python. This adds a
pythonisation called RooWorkspace.Import() instead.

@etejedor I updated the tutorials accordingly (they also serve as a test). A potential problem is that I didn't write a pythonisation for old PyROOT, so the tutorials won't work if somebody switches back.
Do we want to support also old PyROOT, or do we move on?