### PR TITLE
[RF] Fix ROOT-10668.

### DIFF
--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1355,7 +1355,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   if (weightedData && doSumW2==-1 && doAsymptotic==-1) {
     coutW(InputArguments) << "RooAbsPdf::fitTo(" << GetName() << ") WARNING: a likelihood fit is requested of what appears to be weighted data.\n"
                           << "       While the estimated values of the parameters will always be calculated taking the weights into account,\n"
-			  << "       there are multiple ways to estimate the errors of the parameters. You are advised to make an'n"
+			  << "       there are multiple ways to estimate the errors of the parameters. You are advised to make an \n"
 			  << "       explicit choice for the error calculation:\n"
 			  << "           - Either provide SumW2Error(true), to calculate a sum-of-weights-corrected HESSE error matrix\n"
 			  << "             (error will be proportional to the number of events in MC).\n"
@@ -1495,9 +1495,9 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
 	std::vector<std::unique_ptr<RooDerivative> > derivatives;
 	const RooArgList& floated = rw->floatParsFinal();
 	std::unique_ptr<RooArgSet> floatingparams( (RooArgSet*)getParameters(data)->selectByAttrib("Constant", false) );
-	for (int k=0; k<floated.getSize(); k++) {	   
-	   RooRealVar* paramresult = (RooRealVar*)floated.at(k);
-	   RooRealVar* paraminternal = (RooRealVar*)floatingparams->find(paramresult->getTitle());
+	for (const auto paramresult : floated) {
+	   auto paraminternal = static_cast<RooRealVar*>(floatingparams->find(*paramresult));
+	   assert(floatingparams->find(*paramresult)->IsA() == RooRealVar::Class());
 	   std::unique_ptr<RooDerivative> deriv( derivative(*paraminternal, *obs, 1) );
 	   derivatives.push_back(std::move(deriv));
 	}
@@ -1508,9 +1508,9 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
 	   *obs = *data.get(j);
 	   //Determine first derivatives
 	   std::vector<Double_t> diffs(floated.getSize(), 0.0);
-	   for (int k=0; k<floated.getSize(); k++) {
-	      RooRealVar* paramresult = (RooRealVar*)floated.at(k);
-	      RooRealVar* paraminternal = (RooRealVar*)floatingparams->find(paramresult->getTitle());
+	   for (int k=0; k < floated.getSize(); k++) {
+	      const auto paramresult = static_cast<RooRealVar*>(floated.at(k));
+	      auto paraminternal = static_cast<RooRealVar*>(floatingparams->find(*paramresult));
 	      //first derivative to parameter k at best estimate point for this measurement
 	      Double_t diff = derivatives.at(k)->getVal();
 	      //need to reset to best fit point after differentiation
@@ -1524,7 +1524,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
 	         num(k,l) += data.weight()*data.weight()*diffs.at(k)*diffs.at(l)/(prob*prob);
 	      }
 	   }
-	}	
+	}
 	num.Similarity(matV);
 
 	//Propagate corrected errors to parameters objects

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -14,4 +14,5 @@ endif()
 ROOT_ADD_GTEST(testRooWrapperPdf testRooWrapperPdf.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testGenericPdf testGenericPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooProxy testRooProxy.cxx LIBRARIES RooFitCore WILLFAIL)
+ROOT_ADD_GTEST(testRooAbsPdf testRooAbsPdf.cxx LIBRARIES RooFitCore)
 

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -1,0 +1,42 @@
+// Tests for RooAbsPdf
+// Author: Stephan Hageboeck, CERN 04/2020
+
+#include "RooRealVar.h"
+#include "RooGenericPdf.h"
+#include "RooFormulaVar.h"
+#include "RooDataSet.h"
+#include "RooFitResult.h"
+
+#include "gtest/gtest.h"
+
+#include <memory>
+
+// ROOT-10668: Asympt. correct errors don't work when title and name differ
+TEST(RooAbsPdf, AsymptoticallyCorrectErrors)
+{
+  RooRealVar x("x", "xxx", 0, 0, 10);
+  RooRealVar a("a", "aaa", 2, 0, 10);
+  // Cannot play with RooAbsPdf, since abstract.
+  RooGenericPdf pdf("pdf", "std::pow(x,a)", RooArgSet(x, a));
+  RooFormulaVar formula("w", "(x-5)*(x-5)*1.2", RooArgSet(x));
+
+  std::unique_ptr<RooDataSet> data(pdf.generate(x, 5000));
+  data->addColumn(formula);
+  RooRealVar w("w", "weight", 1, 0, 20);
+  RooDataSet weightedData("weightedData", "weightedData",
+      RooArgSet(x, w), RooFit::Import(*data), RooFit::WeightVar(w));
+
+  ASSERT_TRUE(weightedData.isWeighted());
+  weightedData.get(0);
+  ASSERT_NE(weightedData.weight(), 1);
+
+  a = 1.2;
+  auto result = pdf.fitTo(weightedData, RooFit::Save(), RooFit::AsymptoticError(true));
+  const double aError = a.getError();
+  a = 1.2;
+  auto result2 = pdf.fitTo(weightedData, RooFit::Save());
+
+  EXPECT_TRUE(result->isIdentical(*result2)) << "Fit results should be very similar.";
+  EXPECT_GT(aError, a.getError()*2.) << "Asymptotically correct errors should be significantly larger.";
+}
+

--- a/tutorials/roofit/rf611_weightedfits.C
+++ b/tutorials/roofit/rf611_weightedfits.C
@@ -3,6 +3,50 @@
 /// \notebook -js
 /// Likelihood and minimization: Parameter uncertainties for weighted unbinned ML fits
 ///
+/// ## Parameter uncertainties for weighted unbinned ML fits
+///
+/// Based on example from https://arxiv.org/abs/1911.01303
+///
+/// This example compares different approaches to determining parameter uncertainties in weighted unbinned maximum likelihood fits.
+/// Performing a weighted unbinned maximum likelihood fits can be useful to account for acceptance effects and to statistically subtract background events using the sPlot formalism.
+/// It is however well known that the inverse Hessian matrix does not yield parameter uncertainties with correct coverage in the presence of event weights.
+/// Three approaches to the determination of parameter uncertainties are compared in this example:
+///
+/// 1. Using the inverse weighted Hessian matrix [`SumW2Error(false)`]
+///
+/// 2. Using the expression [`SumW2Error(true)`]
+///    \f[
+///      V_{ij} = H_{ik}^{-1} C_{kl} H_{lj}^{-1}
+///    \f]
+///    where H is the weighted Hessian matrix and C is the Hessian matrix with squared weights
+///
+/// 3. The asymptotically correct approach (for details please see https://arxiv.org/abs/1911.01303) [`Asymptotic(true)`]
+///    \f[
+///      V_{ij} = H_{ik}^{-1} D_{kl} H_{lj}^{-1}
+///    \f]
+///    where H is the weighted Hessian matrix and D is given by
+///    \f[
+///      D_{kl} = \sum_{e=1}^{N} w_e^2 \frac{\partial \log(P)}{\partial \lambda_k}\frac{\partial \log(P)}{\partial \lambda_l}
+///    \f]
+///    with the event weight \f$w_e\f$.
+///
+/// The example performs the fit of a second order polynomial in the angle cos(theta) [-1,1] to a weighted data set.
+/// The polynomial is given by
+/// \f[
+///   P = \frac{ 1 + c_0 \cdot \cos(\theta) + c_1 \cdot \cos(\theta) \cdot \cos(\theta) }{\mathrm{Norm}}
+/// \f]
+/// The two coefficients \f$ c_0 \f$ and \f$ c_1 \f$ and their uncertainties are to be determined in the fit.
+///
+/// The per-event weight is used to correct for an acceptance effect, two different acceptance models can be studied:
+/// - `acceptancemodel==1`: eff = \f$ 0.3 + 0.7 \cdot \cos(\theta) \cdot \cos(\theta) \f$
+/// - `acceptancemodel==2`: eff = \f$ 1.0 - 0.7 \cdot \cos(\theta) \cdot \cos(\theta) \f$
+/// The data is generated to be flat before the acceptance effect.
+///
+/// The performance of the different approaches to determine parameter uncertainties is compared using the pull distributions from a large number of pseudoexperiments.
+/// The pull is defined as \f$ (\lambda_i - \lambda_{gen})/\sigma(\lambda_i) \f$, where \f$ \lambda_i \f$ is the fitted parameter and \f$ \sigma(\lambda_i) \f$ its
+/// uncertainty for pseudoexperiment number i.
+/// If the fit is unbiased and the parameter uncertainties are estimated correctly, the pull distribution should be a Gaussian centered around zero with a width of one.
+///
 /// \macro_image
 /// \macro_output
 /// \macro_code
@@ -23,43 +67,6 @@ using namespace RooFit;
 
 
 int rf611_weightedfits(int acceptancemodel=2) {
-  // P a r a m e t e r   u n c e r t a i n t i e s   f o r   w e i g h t e d   u n b i n n e d   M L   f i t s
-  // ---------------------------------------------------------------------------------------------------------
-  //
-  //Based on example from https://arxiv.org/abs/1911.01303 
-  //
-  //This example compares different approaches to determining parameter uncertainties in weighted unbinned maximum likelihood fits.
-  //Performing a weighted unbinned maximum likelihood fits can be useful to account for acceptance effects and to statistically subtract background events using the sPlot formalism. 
-  //It is however well known that the inverse Hessian matrix does not yield parameter uncertainties with correct coverage in the presence of event weights.
-  //Three approaches to the determination of parameter uncertainties are compared in this example:
-  //
-  //1. Using the inverse weighted Hessian matrix [SumW2Error(false)]
-  //
-  //2. Using the expression [SumW2Error(true)]
-  //   V_{ij} = H_{ik}^{-1} C_{kl} H_{lj}^{-1}
-  //   where H is the weighted Hessian matrix and C is the Hessian matrix with squared weights
-  //
-  //3. The asymptotically correct approach (for details please see https://arxiv.org/abs/1911.01303) [Asymptotic(true)]
-  //   V_{ij} = H_{ik}^{-1} D_{kl} H_{lj}^{-1}
-  //   where H is the weighted Hessian matrix and D is given by
-  //   D_{kl} = sum_{e=1}^{N} w_e^2 \frac{\partial log P}{\partial lambda_k}\frac{\partial log P}{\partial lambda_l}
-  //   with the event weight w_e
-  //
-  //The example performs the fit of a second order polynomial in the angle cos(theta) [-1,1] to a weighted data set.
-  //The polynomial is given by
-  //  P = (1 + c0*cos(theta) + c1*cos(theta)*cos(theta)) / Norm
-  //The two coefficients c0 and c1 and their uncertainties are to be determined in the fit.
-  //
-  //The per-event weight is used to correct for an acceptance effect, two different acceptance models can be studied:
-  //  acceptancemodel==1: eff = 0.3+0.7*cos(theta)*cos(theta)
-  //  acceptancemodel==2: eff = 1.0-0.7*cos(theta)*cos(theta)
-  //The data is generated to be flat before the acceptance effect.
-  //
-  //The performance of the different approaches to determine parameter uncertainties is compared using the pull distributions from a large number of pseudoexperiments.
-  //The pull is defined as (lambda_i-\lambda_{gen})/\sigma(\lambda_i), where \lambda_i is the fitted parameter and \sigma(\lambda_i) its uncertainty for pseudoexperiment number i.
-  //If the fit is unbiased and the parameter uncertainties are estimated correctly, the pull distribution should be a Gaussian centered around zero with a width of one.
-
-  
   // I n i t i a l i s a t i o n   a n d   S e t u p
   //------------------------------------------------  
 
@@ -98,73 +105,82 @@ int rf611_weightedfits(int acceptancemodel=2) {
   TH1D* hc1pull3 = new TH1D("hc1pull3", "Asymptotically correct approach [Asymptotic(true)];Pull (c_{1}^{fit}-c_{1}^{gen})/#sigma(c_{1});", 20, -5.0, 5.0);
 
   //number of pseudoexperiments (toys) and number of events per pseudoexperiment
-  unsigned int ntoys = 500;
-  unsigned int nstats = 5000;
+  constexpr unsigned int ntoys = 500;
+  constexpr unsigned int nstats = 5000;
   //parameters used in the generation
-  double c0gen = 0.0;
-  double c1gen = 0.0;
+  constexpr double c0gen = 0.0;
+  constexpr double c1gen = 0.0;
 
-  // M a i n   l o o p   o v e r   a l l   p s e u d o e x p e r i m e n t s
-  //------------------------------------------------------------------------
-  for (unsigned int i=0; i<ntoys; i++)
-    {
-      //S e t u p   p a r a m e t e r s   a n d   P D F
-      //-----------------------------------------------
-      //angle theta and the weight to account for the acceptance effect
-      RooRealVar costheta("costheta","costheta", -1.0, 1.0);
-      RooRealVar weight("weight","weight", 0.0, 1000.0);
+  // Silence fitting and minimisation messages
+  auto& msgSv = RooMsgService::instance();
+  msgSv.getStream(1).removeTopic(RooFit::Minimization);
+  msgSv.getStream(1).removeTopic(RooFit::Fitting);
 
-      //initialise parameters to fit
-      RooRealVar c0("c0","c0", c0gen, -1.0, 1.0);
-      RooRealVar c1("c1","c1", c1gen, -1.0, 1.0);
-      c0.setError(0.01);
-      c1.setError(0.01);
-      //create simple second order polynomial as probability density function
-      RooPolynomial pol("pol", "pol", costheta, RooArgList(c0, c1), 1);
+  std::cout << "Running " << ntoys*3 << " toy fits ..." << std::endl;
 
-      //G e n e r a t e   d a t a   s e t   f o r   p s e u d o e x p e r i m e n t   i
-      //-------------------------------------------------------------------------------
-      RooDataSet data("data","data",RooArgSet(costheta, weight), WeightVar("weight"));
-      //generate nstats events 
-      for (unsigned int j=0; j<nstats; j++)
-	{
-	  bool finished = false;
-	  //use simple accept/reject for generation
-	  while (!finished)
-	    {
-	      costheta = 2.0*rnd->Rndm()-1.0;
-	      //efficiency for the specific value of cos(theta)
-	      double eff = 1.0;
-	      if (acceptancemodel == 1)
-		eff = 1.0 - 0.7 * costheta.getValV()*costheta.getValV();
-	      else
-		eff = 0.3 + 0.7 * costheta.getValV()*costheta.getValV();
-	      //use 1/eff as weight to account for acceptance
-	      weight = 1.0/eff;
-	      //accept/reject
-	      if (10.0*rnd->Rndm() < eff*pol.getValV())
-		finished = true;
-	    }
-	  haccepted->Fill(costheta.getValV());
-	  hweighted->Fill(costheta.getValV(), weight.getValV());
-	  data.add(RooArgSet(costheta, weight), weight.getValV());
-	}
+  // M a i n   l o o p :   r u n   p s e u d o e x p e r i m e n t s
+  //----------------------------------------------------------------
+  for (unsigned int i=0; i<ntoys; i++) {
+    //S e t u p   p a r a m e t e r s   a n d   P D F
+    //-----------------------------------------------
+    //angle theta and the weight to account for the acceptance effect
+    RooRealVar costheta("costheta","costheta", -1.0, 1.0);
+    RooRealVar weight("weight","weight", 0.0, 1000.0);
 
-      //F i t   t o y   u s i n g   t h e   t h r e e   d i f f e r e n t   a p p r o a c h e s   t o   u n c e r t a i n t y   d e t e r m i n a t i o n
-      //-------------------------------------------------------------------------------------------------------------------------------------------------
-      RooFitResult* result = pol.fitTo(data, Save(true), SumW2Error(false));//this uses the inverse weighted Hessian matrix
-      hc0pull1->Fill((c0.getValV()-c0gen)/c0.getError());
-      hc1pull1->Fill((c1.getValV()-c1gen)/c1.getError());
-      
-      result = pol.fitTo(data, Save(true), SumW2Error(true));//this uses the correction with the Hesse matrix with squared weights
-      hc0pull2->Fill((c0.getValV()-c0gen)/c0.getError());
-      hc1pull2->Fill((c1.getValV()-c1gen)/c1.getError());
-      
-      result = pol.fitTo(data, Save(true), AsymptoticError(true));//this uses the asymptotically correct approach
-      hc0pull3->Fill((c0.getValV()-c0gen)/c0.getError());
-      hc1pull3->Fill((c1.getValV()-c1gen)/c1.getError());      
+    //initialise parameters to fit
+    RooRealVar c0("c0","0th-order coefficient", c0gen, -1.0, 1.0);
+    RooRealVar c1("c1","1st-order coefficient", c1gen, -1.0, 1.0);
+    c0.setError(0.01);
+    c1.setError(0.01);
+    //create simple second-order polynomial as probability density function
+    RooPolynomial pol("pol", "pol", costheta, RooArgList(c0, c1), 1);
+
+    //G e n e r a t e   d a t a   s e t   f o r   p s e u d o e x p e r i m e n t   i
+    //-------------------------------------------------------------------------------
+    RooDataSet data("data","data",RooArgSet(costheta, weight), WeightVar("weight"));
+    //generate nstats events
+    for (unsigned int j=0; j<nstats; j++) {
+      bool finished = false;
+      //use simple accept/reject for generation
+      while (!finished) {
+        costheta = 2.0*rnd->Rndm()-1.0;
+        //efficiency for the specific value of cos(theta)
+        double eff = 1.0;
+        if (acceptancemodel == 1)
+          eff = 1.0 - 0.7 * costheta.getVal()*costheta.getVal();
+        else
+          eff = 0.3 + 0.7 * costheta.getVal()*costheta.getVal();
+        //use 1/eff as weight to account for acceptance
+        weight = 1.0/eff;
+        //accept/reject
+        if (10.0*rnd->Rndm() < eff*pol.getVal())
+          finished = true;
+      }
+      haccepted->Fill(costheta.getVal());
+      hweighted->Fill(costheta.getVal(), weight.getVal());
+      data.add(RooArgSet(costheta, weight), weight.getVal());
     }
+
+    //F i t   t o y   u s i n g   t h e   t h r e e   d i f f e r e n t   a p p r o a c h e s   t o   u n c e r t a i n t y   d e t e r m i n a t i o n
+    //-------------------------------------------------------------------------------------------------------------------------------------------------
+    //this uses the inverse weighted Hessian matrix
+    RooFitResult* result = pol.fitTo(data, Save(true), SumW2Error(false), PrintLevel(-1), BatchMode(true));
+    hc0pull1->Fill((c0.getVal()-c0gen)/c0.getError());
+    hc1pull1->Fill((c1.getVal()-c1gen)/c1.getError());
+
+    //this uses the correction with the Hesse matrix with squared weights
+    result = pol.fitTo(data, Save(true), SumW2Error(true), PrintLevel(-1), BatchMode(true));
+    hc0pull2->Fill((c0.getVal()-c0gen)/c0.getError());
+    hc1pull2->Fill((c1.getVal()-c1gen)/c1.getError());
+
+    //this uses the asymptotically correct approach
+    result = pol.fitTo(data, Save(true), AsymptoticError(true), PrintLevel(-1), BatchMode(true));
+    hc0pull3->Fill((c0.getVal()-c0gen)/c0.getError());
+    hc1pull3->Fill((c1.getVal()-c1gen)/c1.getError());
+  }
   
+  std::cout << "... done." << std::endl;
+
   // P l o t   o u t p u t   d i s t r i b u t i o n s
   //--------------------------------------------------
   


### PR DESCRIPTION
When asymptotically correct errors are used, the current implementation
breaks if variables don't have identical name and title. This is solved
by always using the name.