### PR TITLE
[PyROOT] Add libxxhash to known libraries after import ROOT

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot_experimental/pythonizations/test/import_load_libs.py
@@ -15,6 +15,7 @@ class ImportLoadLibs(unittest.TestCase):
             'libCore',
             'libm',
             'liblz4',
+            'libxxhash',
             'liblzma',
             'libzstd',
             'libz',


### PR DESCRIPTION
This fixes the nightlies from today: http://cdash.cern.ch/testSummary.php?project=1&name=pyunittests-pyroot-import-load-libs&date=2020-04-08