### PR TITLE
[genvector] Do not warn if end is unused.

### DIFF
--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -182,18 +182,10 @@ More details about the GenVector package can be found [here](Vector.html).
        /**
           Set internal data based on 4 Scalars at *begin to *end
        */
-//#ifdef NDEBUG
-          //this does not compile in CINT
-//        template< class IT >
-//        LorentzVector<CoordSystem>& SetCoordinates( IT begin, IT /* end */  ) {
-// #endif
        template< class IT >
-#ifndef NDEBUG
        LorentzVector<CoordSystem>& SetCoordinates( IT begin, IT end  ) {
-#else
-       LorentzVector<CoordSystem>& SetCoordinates( IT begin, IT /* end */  ) {
-#endif
           IT a = begin; IT b = ++begin; IT c = ++begin; IT d = ++begin;
+          (void)end;
           assert (++begin==end);
           SetCoordinates (*a,*b,*c,*d);
           return *this;
@@ -215,12 +207,9 @@ More details about the GenVector package can be found [here](Vector.html).
           get internal data into 4 Scalars at *begin to *end
        */
        template <class IT>
-#ifndef NDEBUG
        void GetCoordinates( IT begin, IT end ) const
-#else
-       void GetCoordinates( IT begin, IT /* end */ ) const
-#endif
        { IT a = begin; IT b = ++begin; IT c = ++begin; IT d = ++begin;
+       (void)end;
        assert (++begin==end);
        GetCoordinates (*a,*b,*c,*d);
        }

--- a/math/genvector/inc/Math/GenVector/PositionVector3D.h
+++ b/math/genvector/inc/Math/GenVector/PositionVector3D.h
@@ -185,12 +185,9 @@ namespace ROOT {
          Set internal data based on 3 Scalars at *begin to *end
        */
       template <class IT>
-#ifndef NDEBUG
       PositionVector3D<CoordSystem, Tag>& SetCoordinates( IT begin, IT end )
-#else
-      PositionVector3D<CoordSystem, Tag>& SetCoordinates( IT begin, IT /* end */ )
-#endif
       { IT a = begin; IT b = ++begin; IT c = ++begin;
+        (void)end;
         assert (++begin==end);
         SetCoordinates (*a,*b,*c);
         return *this;
@@ -212,12 +209,9 @@ namespace ROOT {
          get internal data into 3 Scalars at *begin to *end (3 past begin)
        */
       template <class IT>
-#ifndef NDEBUG
       void GetCoordinates( IT begin, IT end ) const
-#else
-      void GetCoordinates( IT begin, IT /* end */ ) const
-#endif
       { IT a = begin; IT b = ++begin; IT c = ++begin;
+        (void)end;
         assert (++begin==end);
         GetCoordinates (*a,*b,*c);
       }


### PR DESCRIPTION
This fixes a nightly build issue on OSX with -Druntime_cxxmodules=On by default. There rootcling still needs to parse the assert statement even if NDEBUG is defined.