### PR TITLE
[Exp PyROOT] Tranfer rootlogon option from old PyROOT

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -1,5 +1,6 @@
 import types
 import sys
+import os
 from functools import partial
 
 import libcppyy as cppyy_backend
@@ -15,6 +16,7 @@ class PyROOTConfiguration(object):
     def __init__(self):
         self.IgnoreCommandLineOptions = False
         self.ShutDown = True
+        self.DisableRootLogon = False
 
 
 class _gROOTWrapper(object):
@@ -161,6 +163,9 @@ class ROOTFacade(types.ModuleType):
         self.__class__.__getattr__ = self._fallback_getattr
         self.__class__.__setattr__ = lambda self, name, val: setattr(gbl_namespace, name, val)
 
+        # Run rootlogon if exists
+        self._run_rootlogon()
+
     def _getattr(self, name):
         # Special case, to allow "from ROOT import gROOT" w/o starting the graphics
         if name == '__path__':
@@ -174,6 +179,32 @@ class ROOTFacade(types.ModuleType):
         self._finalSetup()
 
         return setattr(self, name, val)
+
+    def _run_rootlogon(self):
+        hasargv = hasattr(sys, 'argv')
+        # custom logon file (must be after creation of ROOT globals)
+        if hasargv and not '-n' in sys.argv and not self.PyConfig.DisableRootLogon:
+            rootlogon = os.path.expanduser('~/.rootlogon.py')
+            if os.path.exists(rootlogon):
+                # could also have used execfile, but import is likely to give fewer surprises
+                import imp
+                imp.load_module('rootlogon', open(rootlogon, 'r'), rootlogon, ('.py','r',1))
+                del imp
+            else:
+                # if the .py version of rootlogon exists, the .C is ignored (the user can
+                # load the .C from the .py, if so desired)
+                # system logon, user logon, and local logon (skip Rint.Logon)
+                name = '.rootlogon.C'
+                logons = [
+                    os.path.join(str(self.TROOT.GetEtcDir()), 'system' + name),
+                    os.path.expanduser(os.path.join('~', name))
+                    ]
+                if logons[-1] != os.path.join(os.getcwd(), name):
+                    logons.append(name)
+                for rootlogon in logons:
+                    if os.path.exists(rootlogon):
+                        self.TApplication.ExecuteFile(rootlogon)
+                del rootlogon, logons
 
     # Inject version as __version__ property in ROOT module
     @property

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -184,12 +184,20 @@ class ROOTFacade(types.ModuleType):
         # Run custom logon file (must be after creation of ROOT globals)
         hasargv = hasattr(sys, 'argv')
         if hasargv and not '-n' in sys.argv and not self.PyConfig.DisableRootLogon:
-            rootlogon = os.path.expanduser('~/.rootlogon.py')
-            if os.path.exists(rootlogon):
+            file_path = os.path.expanduser('~/.rootlogon.py')
+            if os.path.exists(file_path):
                 # Could also have used execfile, but import is likely to give fewer surprises
-                import imp
-                imp.load_module('rootlogon', open(rootlogon, 'r'), rootlogon, ('.py','r',1))
-                del imp
+                module_name = 'rootlogon'
+                if sys.version_info >= (3,5):
+                    import importlib.util
+                    spec = importlib.util.spec_from_file_location(module_name, file_path)
+                    module = importlib.util.module_from_spec(spec)
+                    sys.modules[module_name] = module
+                    spec.loader.exec_module(module)
+                else:
+                    import imp
+                    imp.load_module(module_name, open(file_path, 'r'), file_path, ('.py','r',1))
+                    del imp
             else:
                 # If the .py version of rootlogon exists, the .C is ignored (the user can
                 # load the .C from the .py, if so desired).

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -183,6 +183,7 @@ class ROOTFacade(types.ModuleType):
     def _run_rootlogon(self):
         # Run custom logon file (must be after creation of ROOT globals)
         hasargv = hasattr(sys, 'argv')
+        # -n disables the reading of the logon file, just like with root
         if hasargv and not '-n' in sys.argv and not self.PyConfig.DisableRootLogon:
             file_path = os.path.expanduser('~/.rootlogon.py')
             if os.path.exists(file_path):

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -204,7 +204,6 @@ class ROOTFacade(types.ModuleType):
                 for rootlogon in logons:
                     if os.path.exists(rootlogon):
                         self.TApplication.ExecuteFile(rootlogon)
-                del rootlogon, logons
 
     # Inject version as __version__ property in ROOT module
     @property

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -181,19 +181,19 @@ class ROOTFacade(types.ModuleType):
         return setattr(self, name, val)
 
     def _run_rootlogon(self):
+        # Run custom logon file (must be after creation of ROOT globals)
         hasargv = hasattr(sys, 'argv')
-        # custom logon file (must be after creation of ROOT globals)
         if hasargv and not '-n' in sys.argv and not self.PyConfig.DisableRootLogon:
             rootlogon = os.path.expanduser('~/.rootlogon.py')
             if os.path.exists(rootlogon):
-                # could also have used execfile, but import is likely to give fewer surprises
+                # Could also have used execfile, but import is likely to give fewer surprises
                 import imp
                 imp.load_module('rootlogon', open(rootlogon, 'r'), rootlogon, ('.py','r',1))
                 del imp
             else:
-                # if the .py version of rootlogon exists, the .C is ignored (the user can
-                # load the .C from the .py, if so desired)
-                # system logon, user logon, and local logon (skip Rint.Logon)
+                # If the .py version of rootlogon exists, the .C is ignored (the user can
+                # load the .C from the .py, if so desired).
+                # System logon, user logon, and local logon (skip Rint.Logon)
                 name = '.rootlogon.C'
                 logons = [
                     os.path.join(str(self.TROOT.GetEtcDir()), 'system' + name),


### PR DESCRIPTION
When the first lookup is triggered, check if .rootlogon.py (or, if it
does not exist, .rootlogon.C) exist in the home directory and runs it.