### PR TITLE
[DF] Re-use jitted lambdas for new RDF expressions with same logic

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RCustomColumn.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RCustomColumn.hxx
@@ -95,9 +95,10 @@ class RCustomColumn final : public RCustomColumnBase {
    }
 
 public:
-   RCustomColumn(RLoopManager *lm, std::string_view name, F expression, const ColumnNames_t &columns,
-                 unsigned int nSlots, const RDFInternal::RBookedCustomColumns &customColumns, bool isDSColumn = false)
-      : RCustomColumnBase(lm, name, nSlots, isDSColumn, customColumns), fExpression(std::move(expression)),
+   RCustomColumn(RLoopManager *lm, std::string_view name, std::string_view type, F expression,
+                 const ColumnNames_t &columns, unsigned int nSlots,
+                 const RDFInternal::RBookedCustomColumns &customColumns, bool isDSColumn = false)
+      : RCustomColumnBase(lm, name, type, nSlots, isDSColumn, customColumns), fExpression(std::move(expression)),
         fColumnNames(columns), fLastResults(fNSlots), fValues(fNSlots), fIsCustomColumn()
    {
       const auto nColumns = fColumnNames.size();

--- a/tree/dataframe/inc/ROOT/RDF/RCustomColumnBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RCustomColumnBase.hxx
@@ -33,6 +33,7 @@ protected:
    RLoopManager *fLoopManager; ///< A raw pointer to the RLoopManager at the root of this functional graph. It is only
                                /// guaranteed to contain a valid address during an event loop.
    const std::string fName; ///< The name of the custom column
+   const std::string fType; ///< The type of the custom column as a text string
    unsigned int fNChildren{0};      ///< number of nodes of the functional graph hanging from this object
    unsigned int fNStopsReceived{0}; ///< number of times that a children node signaled to stop processing entries.
    const unsigned int fNSlots;      ///< number of thread slots used by this node, inherited from parent node.
@@ -47,8 +48,8 @@ protected:
    static unsigned int GetNextID();
 
 public:
-   RCustomColumnBase(RLoopManager *lm, std::string_view name, const unsigned int nSlots, const bool isDSColumn,
-                     const RDFInternal::RBookedCustomColumns &customColumns);
+   RCustomColumnBase(RLoopManager *lm, std::string_view name, std::string_view type, unsigned int nSlots,
+                     bool isDSColumn, const RDFInternal::RBookedCustomColumns &customColumns);
 
    RCustomColumnBase &operator=(const RCustomColumnBase &) = delete;
    RCustomColumnBase &operator=(RCustomColumnBase &&) = delete;
@@ -58,6 +59,7 @@ public:
    virtual const std::type_info &GetTypeId() const = 0;
    RLoopManager *GetLoopManagerUnchecked() const;
    std::string GetName() const;
+   std::string GetTypeName() const;
    virtual void Update(unsigned int slot, Long64_t entry) = 0;
    virtual void ClearValueReaders(unsigned int slot) = 0;
    bool IsDataSourceColumn() const { return fIsDataSourceColumn; }

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -374,11 +374,8 @@ public:
                                      fLoopManager->GetAliasMap(),
                                      fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
 
-      auto jittedCustomColumn =
-         std::make_shared<RDFDetail::RJittedCustomColumn>(fLoopManager, name, fLoopManager->GetNSlots());
-
-      RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, jittedCustomColumn, fCustomColumns,
-                                 fLoopManager->GetBranchNames());
+      auto jittedCustomColumn = RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, fCustomColumns,
+                                                           fLoopManager->GetBranchNames());
 
       RDFInternal::RBookedCustomColumns newCols(fCustomColumns);
       newCols.AddName(name);
@@ -504,16 +501,14 @@ public:
                << ") = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNodeBase>*>("
                << RDFInternal::PrettyPrintAddr(&upcastInterface) << ")->Snapshot<";
 
-      const auto &customCols = fCustomColumns.GetNames();
-      const auto dontConvertVector = false;
 
       const auto validColumnNames = GetValidatedColumnNames(columnList.size(), columnList);
 
+      const auto dontConvertVector = false;
       for (auto &c : validColumnNames) {
-         const auto isCustom = std::find(customCols.begin(), customCols.end(), c) != customCols.end();
-         const auto customColID = isCustom ? fCustomColumns.GetColumns().at(c)->GetID() : 0;
-         snapCall << RDFInternal::ColumnName2ColumnTypeName(c, tree, fDataSource, isCustom, dontConvertVector,
-                                                            customColID)
+         RDFDetail::RCustomColumnBase *customCol =
+            fCustomColumns.HasName(c) ? fCustomColumns.GetColumns().at(c).get() : nullptr;
+         snapCall << RDFInternal::ColumnName2ColumnTypeName(c, tree, fDataSource, customCol, dontConvertVector)
                   << ", ";
       };
       if (!columnList.empty())
@@ -641,13 +636,11 @@ public:
                 << ") = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNodeBase>*>("
                 << RDFInternal::PrettyPrintAddr(&upcastInterface) << ")->Cache<";
 
-      const auto &customCols = fCustomColumns.GetNames();
       const auto validColumnNames = GetValidatedColumnNames(columnList.size(), columnList);
       for (auto &c : validColumnNames) {
-         const auto isCustom = std::find(customCols.begin(), customCols.end(), c) != customCols.end();
-         const auto customColID = isCustom ? fCustomColumns.GetColumns().at(c)->GetID() : 0;
-         cacheCall << RDFInternal::ColumnName2ColumnTypeName(c, tree, fDataSource, isCustom,
-                                                             /*vector2rvec=*/true, customColID)
+         RDFDetail::RCustomColumnBase *customCol =
+            fCustomColumns.HasName(c) ? fCustomColumns.GetColumns().at(c).get() : nullptr;
+         cacheCall << RDFInternal::ColumnName2ColumnTypeName(c, tree, fDataSource, customCol, /*vector2rvec=*/true)
                    << ", ";
       };
       if (!columnList.empty())
@@ -1878,21 +1871,12 @@ public:
    ///
    std::string GetColumnType(std::string_view column)
    {
-      const auto &customCols = fCustomColumns.GetNames();
+      const auto col = std::string(column);
       const bool convertVector2RVec = true;
-      const auto isCustom = std::find(customCols.begin(), customCols.end(), column) != customCols.end();
-      if (!isCustom) {
-         return RDFInternal::ColumnName2ColumnTypeName(std::string(column), fLoopManager->GetTree(),
-                                                       fLoopManager->GetDataSource(), isCustom, convertVector2RVec);
-      } else {
-         // must convert the alias "__rdf::column_type" to a readable type
-         const auto colID = std::to_string(fCustomColumns.GetColumns().at(std::string(column))->GetID());
-         const auto call =
-            "ROOT::Internal::RDF::TypeID2TypeName(typeid(__rdf::" + std::string(column) + colID + "_type))";
-         fLoopManager->JitDeclarations(); // some type aliases might be needed by the code jitted in the next line
-         const auto calcRes = RDFInternal::InterpreterCalc(call);
-         return *reinterpret_cast<std::string *>(calcRes); // copy result to stack
-      }
+      RDFDetail::RCustomColumnBase *customCol =
+         fCustomColumns.HasName(column) ? fCustomColumns.GetColumns().at(col).get() : nullptr;
+      return RDFInternal::ColumnName2ColumnTypeName(col, fLoopManager->GetTree(), fLoopManager->GetDataSource(),
+                                                    customCol, convertVector2RVec);
    }
 
    /// \brief Returns the names of the filters created.
@@ -2240,28 +2224,26 @@ private:
 
       // Entry number column
       const std::string entryColName = "rdfentry_";
+      const std::string entryColType = "ULong64_t";
       auto entryColGen = [](unsigned int, ULong64_t entry) { return entry; };
       using NewColEntry_t =
          RDFDetail::RCustomColumn<decltype(entryColGen), RDFDetail::CustomColExtraArgs::SlotAndEntry>;
 
-      auto entryColumn = std::make_shared<NewColEntry_t>(fLoopManager, entryColName, std::move(entryColGen),
-                                                         ColumnNames_t{}, fLoopManager->GetNSlots(), newCols);
+      auto entryColumn =
+         std::make_shared<NewColEntry_t>(fLoopManager, entryColName, entryColType, std::move(entryColGen),
+                                         ColumnNames_t{}, fLoopManager->GetNSlots(), newCols);
       newCols.AddName(entryColName);
       newCols.AddColumn(entryColumn, entryColName);
 
       fLoopManager->RegisterCustomColumn(entryColumn.get());
 
-      // Declare return type to the interpreter, for future use by jitted actions
-      auto retTypeDeclaration = "namespace __rdf { using " + entryColName +
-                                std::to_string(entryColumn->GetID()) + "_type = ULong64_t; }\n";
-      fLoopManager->ToJitDeclare(retTypeDeclaration);
-
       // Slot number column
       const std::string slotColName = "rdfslot_";
+      const std::string slotColType = "unsigned int";
       auto slotColGen = [](unsigned int slot) { return slot; };
       using NewColSlot_t = RDFDetail::RCustomColumn<decltype(slotColGen), RDFDetail::CustomColExtraArgs::Slot>;
 
-      auto slotColumn = std::make_shared<NewColSlot_t>(fLoopManager, slotColName, std::move(slotColGen),
+      auto slotColumn = std::make_shared<NewColSlot_t>(fLoopManager, slotColName, slotColType, std::move(slotColGen),
                                                        ColumnNames_t{}, fLoopManager->GetNSlots(), newCols);
 
       newCols.AddName(slotColName);
@@ -2270,11 +2252,6 @@ private:
       fLoopManager->RegisterCustomColumn(slotColumn.get());
 
       fCustomColumns = std::move(newCols);
-
-      // Declare return type to the interpreter, for future use by jitted actions
-      retTypeDeclaration = "namespace __rdf { using " + slotColName +
-                           std::to_string(slotColumn->GetID()) + "_type = unsigned int; }";
-      fLoopManager->ToJitDeclare(retTypeDeclaration);
 
       fLoopManager->AddColumnAlias("tdfentry_", entryColName);
       fCustomColumns.AddName("tdfentry_");
@@ -2372,11 +2349,6 @@ private:
 
       auto newColumns = CheckAndFillDSColumns(validColumnNames, std::make_index_sequence<nColumns>(), ColTypes_t());
 
-      using NewCol_t = RDFDetail::RCustomColumn<F, CustomColumnType>;
-      RDFInternal::RBookedCustomColumns newCols(newColumns);
-      auto newColumn = std::make_shared<NewCol_t>(fLoopManager, name, std::forward<F>(expression), validColumnNames,
-                                                  fLoopManager->GetNSlots(), newCols);
-
       // Declare return type to the interpreter, for future use by jitted actions
       auto retTypeName = RDFInternal::TypeID2TypeName(typeid(RetType));
       if (retTypeName.empty()) {
@@ -2387,9 +2359,12 @@ private:
          retTypeName = "void /* The type of column \"" + std::string(name) + "\" (" + demangledType +
                        ") is not known to the interpreter. */";
       }
-      const auto retTypeDeclaration = "namespace __rdf { using " + std::string(name) +
-                                      std::to_string(newColumn->GetID()) + "_type = " + retTypeName + "; }\n";
-      fLoopManager->ToJitDeclare(retTypeDeclaration);
+
+      using NewCol_t = RDFDetail::RCustomColumn<F, CustomColumnType>;
+      RDFInternal::RBookedCustomColumns newCols(newColumns);
+      auto newColumn = std::make_shared<NewCol_t>(fLoopManager, name, retTypeName, std::forward<F>(expression),
+                                                  validColumnNames, fLoopManager->GetNSlots(), newCols);
+
 
       fLoopManager->RegisterCustomColumn(newColumn.get());
       newCols.AddName(name);

--- a/tree/dataframe/inc/ROOT/RDF/RJittedCustomColumn.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedCustomColumn.hxx
@@ -34,8 +34,8 @@ class RJittedCustomColumn : public RCustomColumnBase {
    std::unique_ptr<RCustomColumnBase> fConcreteCustomColumn = nullptr;
 
 public:
-   RJittedCustomColumn(RLoopManager *lm, std::string_view name, unsigned int nSlots)
-      : RCustomColumnBase(lm, name, nSlots, /*isDSColumn=*/false, RDFInternal::RBookedCustomColumns())
+   RJittedCustomColumn(RLoopManager *lm, std::string_view name, std::string_view type, unsigned int nSlots)
+      : RCustomColumnBase(lm, name, type, nSlots, /*isDSColumn=*/false, RDFInternal::RBookedCustomColumns())
    {
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -100,8 +100,8 @@ const std::type_info &TypeName2TypeID(const std::string &name);
 
 std::string TypeID2TypeName(const std::type_info &id);
 
-std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *, RDataSource *, bool isCustomColumn,
-                                      bool vector2rvec = true, unsigned int customColID = 0);
+std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *, RDataSource *, RCustomColumnBase *,
+                                      bool vector2rvec = true);
 
 char TypeName2ROOTTypeName(const std::string &b);
 

--- a/tree/dataframe/src/RCustomColumnBase.cxx
+++ b/tree/dataframe/src/RCustomColumnBase.cxx
@@ -27,10 +27,11 @@ unsigned int RCustomColumnBase::GetNextID()
    return id;
 }
 
-RCustomColumnBase::RCustomColumnBase(RLoopManager *lm, std::string_view name, const unsigned int nSlots,
-                                     const bool isDSColumn, const RDFInternal::RBookedCustomColumns &customColumns)
-   : fLoopManager(lm), fName(name), fNSlots(nSlots), fIsDataSourceColumn(isDSColumn), fCustomColumns(customColumns),
-     fIsInitialized(nSlots, false)
+RCustomColumnBase::RCustomColumnBase(RLoopManager *lm, std::string_view name, std::string_view type,
+                                     unsigned int nSlots, bool isDSColumn,
+                                     const RDFInternal::RBookedCustomColumns &customColumns)
+   : fLoopManager(lm), fName(name), fType(type), fNSlots(nSlots), fIsDataSourceColumn(isDSColumn),
+     fCustomColumns(customColumns), fIsInitialized(nSlots, false)
 {
    fLoopManager->RegisterCustomColumn(this);
 }
@@ -44,6 +45,11 @@ RCustomColumnBase::~RCustomColumnBase()
 std::string RCustomColumnBase::GetName() const
 {
    return fName;
+}
+
+std::string RCustomColumnBase::GetTypeName() const
+{
+   return fType;
 }
 
 void RCustomColumnBase::InitNode()

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -71,7 +71,7 @@ struct ParsedExpression {
    /// The list of valid column names that were used in the original string expression.
    /// Duplicates are removed and column aliases (created with Alias calls) are resolved.
    ColumnNames_t fUsedCols;
-   /// The list of variable names used in fExpr, with same ordering and size as fVarUsedCols
+   /// The list of variable names used in fExpr, with same ordering and size as fUsedCols
    ColumnNames_t fVarNames;
 };
 

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -10,6 +10,7 @@
 
 #include "RConfigure.h" // R__USE_IMT
 #include "ROOT/RDataSource.hxx"
+#include "ROOT/RDF/RCustomColumnBase.hxx"
 #include "ROOT/RDF/RLoopManager.hxx"
 #include "RtypesCore.h"
 #include "TBranch.h"
@@ -194,8 +195,8 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
 /// vector2rvec specifies whether typename 'std::vector<T>' should be converted to 'RVec<T>' or returned as is
 /// customColID is only used if isCustomColumn is true, and must correspond to the custom column's unique identifier
 /// returned by its `GetID()` method.
-std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *tree, RDataSource *ds, bool isCustomColumn,
-                                      bool vector2rvec, unsigned int customColID)
+std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *tree, RDataSource *ds,
+                                      RCustomColumnBase *customColumn, bool vector2rvec)
 {
    std::string colType;
 
@@ -213,9 +214,8 @@ std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *tree, R
       }
    }
 
-   if (colType.empty() && isCustomColumn) {
-      // this must be a temporary branch, we know there is an alias for its type
-      colType = "__rdf::" + colName + std::to_string(customColID) + "_type";
+   if (colType.empty() && customColumn) {
+      colType = customColumn->GetTypeName();
    }
 
    if (colType.empty())

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -73,7 +73,10 @@ public:
 
    void RemoveCodeForLoopManager(const RLoopManager *lm)
    {
-      fCodeToDeclare.erase(lm);
+      // fCodeToDeclare for old RLoopManagers is left in fCodeToDeclare, as it might contain
+      // the definition of lambdas that are also used by other RLoopManagers. It's not expensive
+      // to jit-declare a bit more than strictly needed. fCodeToExec for RLoopManagers that went out
+      // of scope must be erased: it would refer to variables that are not in scope anymore.
       fCodeToExec.erase(lm);
    }
 };

--- a/tree/dataframe/src/RRootDS.cxx
+++ b/tree/dataframe/src/RRootDS.cxx
@@ -65,7 +65,7 @@ std::string RRootDS::GetTypeName(std::string_view colName) const
    // TODO: we need to factor out the routine for the branch alone...
    // Maybe a cache for the names?
    auto typeName = ROOT::Internal::RDF::ColumnName2ColumnTypeName(std::string(colName), &fModelChain, /*ds=*/nullptr,
-                                                                  /*isCustomCol=*/false);
+                                                                  /*customCol=*/nullptr);
    // We may not have yet loaded the library where the dictionary of this type is
    TClass::GetClass(typeName.c_str());
    return typeName;

--- a/tree/dataframe/test/dataframe_utils.cxx
+++ b/tree/dataframe/test/dataframe_utils.cxx
@@ -72,8 +72,7 @@ TEST(RDataFrameUtils, DeduceAllPODsFromColumns)
                                                      {"vararrint.a", "ROOT::VecOps::RVec<Int_t>"}};
 
    for (auto &nameType : nameTypes) {
-      auto typeName = RDFInt::ColumnName2ColumnTypeName(nameType.first, &t, /*ds=*/nullptr,
-                                                        /*custom=*/false);
+      auto typeName = RDFInt::ColumnName2ColumnTypeName(nameType.first, &t, /*ds=*/nullptr, /*customCol=*/nullptr);
       EXPECT_STREQ(nameType.second, typeName.c_str());
    }
 }
@@ -100,8 +99,7 @@ TEST(RDataFrameUtils, DeduceTypeOfBranchesWithCustomTitle)
                                                      {"vararrint.a", "ROOT::VecOps::RVec<Int_t>"}};
 
    for (auto &nameType : nameTypes) {
-      auto typeName = RDFInt::ColumnName2ColumnTypeName(nameType.first, &t, /*ds=*/nullptr,
-                                                        /*custom=*/false);
+      auto typeName = RDFInt::ColumnName2ColumnTypeName(nameType.first, &t, /*ds=*/nullptr, /*customCol=*/nullptr);
       EXPECT_STREQ(nameType.second, typeName.c_str());
    }
 }


### PR DESCRIPTION
This reduces the time required by jitting dramatically in many common scenarios, as we do not need a different template specialization of types that are expensive to instantiate for each Define or Filter expression.

Performance measurements available [here](https://indico.cern.ch/event/909884/)