### PR TITLE
[json] properly handle error when reading object

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1890,8 +1890,8 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
 
       if (objClass && (jsonClass != objClass)) {
          if (obj || (jsonClass->GetBaseClassOffset(objClass) != 0)) {
-            Error("JsonReadObject", "Class mismatch between provided %s and in JSON %s",
-                    objClass->GetName(), jsonClass->GetName());
+            Error("JsonReadObject", "Not possible to read %s and cast to %s pointer",
+                    jsonClass->GetName(), objClass->GetName());
             if (process_stl)
                PopStack();
             return obj;

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1889,7 +1889,7 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
          jsonClassVersion = json->at(fTypeVersionTag.Data()).get<int>();
 
       if (objClass && (jsonClass != objClass)) {
-         if (obj || !jsonClass->InheritsFrom(objClass)) {
+         if (obj || (jsonClass->GetBaseClassOffset(objClass) != 0)) {
             Error("JsonReadObject", "Class mismatch between provided %s and in JSON %s",
                     objClass->GetName(), jsonClass->GetName());
             if (process_stl)

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1890,8 +1890,12 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
 
       if (objClass && (jsonClass != objClass)) {
          if (obj || (jsonClass->GetBaseClassOffset(objClass) != 0)) {
-            Error("JsonReadObject", "Not possible to read %s and cast to %s pointer",
-                    jsonClass->GetName(), objClass->GetName());
+            if (jsonClass->GetBaseClassOffset(objClass) < 0) 
+               Error("JsonReadObject", "Not possible to read %s and casting to %s pointer as the two classes are unrelated",
+                     jsonClass->GetName(), objClass->GetName());
+            else 
+               Error("JsonReadObject", "Reading %s and casting to %s pointer is currently not supported",
+                     jsonClass->GetName(), objClass->GetName());
             if (process_stl)
                PopStack();
             return obj;

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1889,8 +1889,13 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
          jsonClassVersion = json->at(fTypeVersionTag.Data()).get<int>();
 
       if (objClass && (jsonClass != objClass)) {
-         Error("JsonReadObject", "Class mismatch between provided %s and in JSON %s", objClass->GetName(),
-               jsonClass->GetName());
+         if (obj || !jsonClass->InheritsFrom(objClass)) {
+            Error("JsonReadObject", "Class mismatch between provided %s and in JSON %s",
+                    objClass->GetName(), jsonClass->GetName());
+            if (process_stl)
+               PopStack();
+            return obj;
+         }
       }
 
       if (!obj)


### PR DESCRIPTION
If provided pointer type does not match with type read
from JSON check inheritance. It can be that pointer type
is parent class.

In case of error return  - do not try to read data for wrong object