### PR TITLE
[Eve-7] Add missing bbox initalisation in REveBoxProjected

### DIFF
--- a/graf3d/eve7/src/REveBox.cxx
+++ b/graf3d/eve7/src/REveBox.cxx
@@ -159,6 +159,7 @@ REveBoxProjected::~REveBoxProjected()
 
 void REveBoxProjected::ComputeBBox()
 {
+   BBoxInit();
    for (auto &pnt: fPoints)
       BBoxCheckPoint(pnt.fX, pnt.fY, fDepth);
 }


### PR DESCRIPTION
Add missing bounding box initialisation in REveBoxProjected.