### PR TITLE
[Exp PyROOT][ROOT-8011] Turn libJupyROOT into a C extension module

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -5,16 +5,22 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 if(pyroot)
-# Machinery necessary to loop in parallel over multiple lists
-# This will be used in the CMakeLists of pythonizations,
-# cppyy, cppyy-backend and CPyCppyy to build and install targets
-# for multiple Python versions (only 2 and 3 for now)
-list(LENGTH python_executables len)
-math(EXPR how_many_pythons "${len} - 1")
-
   if(NOT pyroot_experimental)
     add_subdirectory(pyroot)
   else()
+    # Machinery necessary to loop in parallel over multiple lists
+    # This will be used in the CMakeLists of pythonizations,
+    # cppyy, cppyy-backend and CPyCppyy to build and install targets
+    # for multiple Python versions (only 2 and 3 for now)
+    list(LENGTH python_executables len)
+    math(EXPR how_many_pythons "${len} - 1")
+
+    if(IS_ABSOLUTE ${runtimedir})
+      set(d $ENV{DESTDIR}/${runtimedir})
+    else()
+      set(d $ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/${runtimedir})
+    endif()
+
     add_subdirectory(pyroot_experimental)
     add_subdirectory(tpython)
     add_subdirectory(jupyroot)

--- a/bindings/jupyroot/CMakeLists.txt
+++ b/bindings/jupyroot/CMakeLists.txt
@@ -10,7 +10,57 @@
 
 set(JupyROOTDirName python/JupyROOT)
 
-ROOT_LINKER_LIBRARY(JupyROOT src/IOHandler.cxx DEPENDENCIES Core CMAKENOEXPORT)
+set(py_sources
+  JupyROOT/__init__.py
+  JupyROOT/helpers/__init__.py
+  JupyROOT/helpers/cppcompleter.py
+  JupyROOT/helpers/handlers.py
+  JupyROOT/helpers/utils.py
+  JupyROOT/html/__init__.py
+  JupyROOT/html/cpphighlighter.py
+  JupyROOT/kernel/__init__.py
+  JupyROOT/kernel/rootkernel.py
+  JupyROOT/kernel/utils.py
+  JupyROOT/kernel/magics/__init__.py
+  JupyROOT/kernel/magics/cppmagic.py
+  JupyROOT/kernel/magics/jsrootmagic.py
+  JupyROOT/magics/__init__.py
+  JupyROOT/magics/cppmagic.py
+  JupyROOT/magics/jsrootmagic.py
+)
+
+foreach(val RANGE ${how_many_pythons})
+  list(GET python_under_version_strings ${val} python_under_version_string)
+  list(GET python_include_dirs ${val} python_include_dir)
+  list(GET python_executables ${val} python_executable)
+  list(GET python_libraries ${val} python_library)
+
+  set(libname JupyROOT${python_under_version_string})
+
+  add_library(${libname} SHARED src/IOHandler.cxx)
+
+  # libJupyROOT uses ROOT headers from binary directory
+  add_dependencies(${libname} move_headers)
+  target_include_directories(${libname} PRIVATE ${CMAKE_BINARY_DIR}/include)
+  target_include_directories(${libname} PRIVATE ${python_include_dir})
+
+  target_link_libraries(${libname} ${python_library} Core ${CMAKE_DL_LIBS})
+
+  # Disables warnings originating from deprecated register keyword in Python
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
+    target_compile_options(${libname} PRIVATE -Wno-register)
+  endif()
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
+    target_compile_options(${libname} PRIVATE -Wno-register)
+    target_compile_options(${libname} PRIVATE -Wno-deprecated-register)
+  endif()
+
+  foreach(py_source ${py_sources})
+    install(CODE "execute_process(COMMAND ${python_executable} -m py_compile ${d}/${py_source})")
+    install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${d}/${py_source})")
+  endforeach()
+
+endforeach()
 
 file(COPY ${JupyROOTDirName} DESTINATION ${localruntimedir})
 install(DIRECTORY ${JupyROOTDirName} DESTINATION ${runtimedir})

--- a/bindings/jupyroot/python/JupyROOT/helpers/handlers.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/handlers.py
@@ -7,7 +7,6 @@
 #
 #  The full license is in the file COPYING.rst, distributed with this software.
 #-----------------------------------------------------------------------------
-from ctypes import CDLL, c_char_p
 from threading import Thread
 from time import sleep as timeSleep
 from sys import platform
@@ -20,7 +19,12 @@ else:
 
 from JupyROOT import helpers
 
-_lib = CDLL(path.join(path.dirname(path.dirname(path.dirname(__file__))), 'libJupyROOT.so'))
+# import libJupyROOT with Python version number
+import importlib
+major, minor = sys.version_info[0:2]
+libjupyroot_mod_name = 'libJupyROOT{}_{}'.format(major, minor)
+_lib = importlib.import_module(libjupyroot_mod_name)
+
 
 class IOHandler(object):
     r'''Class used to capture output from C/C++ libraries.
@@ -35,9 +39,6 @@ class IOHandler(object):
     >>> del h
     '''
     def __init__(self):
-        for cfunc in [_lib.JupyROOTExecutorHandler_GetStdout,
-                      _lib.JupyROOTExecutorHandler_GetStderr]:
-           cfunc.restype = c_char_p
         _lib.JupyROOTExecutorHandler_Ctor()
 
     def __del__(self):
@@ -55,18 +56,11 @@ class IOHandler(object):
     def EndCapture(self):
         _lib.JupyROOTExecutorHandler_EndCapture()
 
-    def Decode(self, obj):
-        import sys
-        if sys.version_info >= (3, 0):
-            return obj.decode('utf-8')
-        else:
-            return obj
-
     def GetStdout(self):
-       return self.Decode(_lib.JupyROOTExecutorHandler_GetStdout())
+       return _lib.JupyROOTExecutorHandler_GetStdout()
 
     def GetStderr(self):
-       return self.Decode(_lib.JupyROOTExecutorHandler_GetStderr())
+       return _lib.JupyROOTExecutorHandler_GetStderr()
 
     def GetStreamsDicts(self):
        out = self.GetStdout()
@@ -147,7 +141,7 @@ class JupyROOTDeclarer(Runner):
     >>> import ROOT
     >>> p = Poller(); p.start()
     >>> d = JupyROOTDeclarer(p)
-    >>> d.Run("int f(){return 3;}".encode("utf-8"))
+    >>> d.Run("int f(){return 3;}")
     1
     >>> ROOT.f()
     3
@@ -161,7 +155,7 @@ class JupyROOTExecutor(Runner):
     >>> import ROOT
     >>> p = Poller(); p.start()
     >>> d = JupyROOTExecutor(p)
-    >>> d.Run('cout << "Here am I" << endl;'.encode("utf-8"))
+    >>> d.Run('cout << "Here am I" << endl;')
     1
     >>> p.Stop()
     '''

--- a/bindings/jupyroot/python/JupyROOT/kernel/magics/cppmagic.py
+++ b/bindings/jupyroot/python/JupyROOT/kernel/magics/cppmagic.py
@@ -38,7 +38,7 @@ class CppMagics(Magic):
 
              self.kernel.ioHandler.Clear()
              self.kernel.ioHandler.InitCapture()
-             execFunc(self.code.encode('utf8'))
+             execFunc(self.code)
              self.kernel.ioHandler.EndCapture()
              self.kernel.print_output(self.kernel.ioHandler)
 

--- a/bindings/jupyroot/python/JupyROOT/kernel/rootkernel.py
+++ b/bindings/jupyroot/python/JupyROOT/kernel/rootkernel.py
@@ -85,7 +85,7 @@ class ROOTKernel(MetaKernel):
         status = 'ok'
         try:
             RunAsyncAndPrint(self.Executor,
-                             code.encode('utf8'),
+                             code,
                              self.ioHandler,
                              self.print_output,
                              silent,

--- a/bindings/jupyroot/src/IOHandler.cxx
+++ b/bindings/jupyroot/src/IOHandler.cxx
@@ -1,4 +1,6 @@
-// Author: Danilo Piparo, Omar Zapata   16/12/2015
+// Author: Danilo Piparo, Omar Zapata, Enric Tejedor   16/12/2015
+
+#include <Python.h>
 
 #include <fcntl.h>
 #ifdef _MSC_VER // Visual Studio
@@ -18,6 +20,11 @@
 #include <string>
 #include <iostream>
 #include "TInterpreter.h"
+
+
+//////////////////////////
+// MODULE FUNCTIONALITY //
+//////////////////////////
 
 bool JupyROOTExecutorImpl(const char *code);
 bool JupyROOTDeclarerImpl(const char *code);
@@ -130,7 +137,6 @@ std::string &JupyROOTExecutorHandler::GetStderr()
 
 JupyROOTExecutorHandler *JupyROOTExecutorHandler_ptr = nullptr;
 
-////////////////////////////////////////////////////////////////////////////////
 bool JupyROOTExecutorImpl(const char *code)
 {
    auto status = false;
@@ -164,61 +170,174 @@ bool JupyROOTDeclarerImpl(const char *code)
    return status;
 }
 
-extern "C" {
+#if PY_MAJOR_VERSION >= 3
+    #define PyInt_FromLong PyLong_FromLong
+    #define PyText_FromString PyUnicode_FromString
+#else
+    #define PyText_FromString PyString_FromString
+#endif
 
-   int JupyROOTExecutor(const char *code)
-   {
-      return JupyROOTExecutorImpl(code);
-   }
-   int JupyROOTDeclarer(const char *code)
-   {
-      return JupyROOTDeclarerImpl(code);
-   }
+PyObject *JupyROOTExecutor(PyObject * /*self*/, PyObject * args)
+{
+   const char *code;
+   if (!PyArg_ParseTuple(args, "s", &code))
+      return NULL;
 
-   void JupyROOTExecutorHandler_Clear()
-   {
-      JupyROOTExecutorHandler_ptr->Clear();
-   }
+   auto res = JupyROOTExecutorImpl(code);
 
-   void JupyROOTExecutorHandler_Ctor()
-   {
-      if (!JupyROOTExecutorHandler_ptr) {
-         JupyROOTExecutorHandler_ptr = new JupyROOTExecutorHandler();
-         // Fixes for ROOT-7999
-         gInterpreter->ProcessLine("SetErrorHandler((ErrorHandlerFunc_t)&DefaultErrorHandler);");
-      }
-   }
+   return PyInt_FromLong(res);
+}
 
-   void JupyROOTExecutorHandler_Poll()
-   {
-      JupyROOTExecutorHandler_ptr->Poll();
-   }
+PyObject *JupyROOTDeclarer(PyObject * /*self*/, PyObject *args)
+{
+   const char *code;
+   if (!PyArg_ParseTuple(args, "s", &code))
+      return NULL;
 
-   void JupyROOTExecutorHandler_EndCapture()
-   {
-      JupyROOTExecutorHandler_ptr->EndCapture();
-   }
+   auto res = JupyROOTDeclarerImpl(code);
 
-   void JupyROOTExecutorHandler_InitCapture()
-   {
-      JupyROOTExecutorHandler_ptr->InitCapture();
-   }
+   return PyInt_FromLong(res);
+}
 
-   const char *JupyROOTExecutorHandler_GetStdout()
-   {
-      return JupyROOTExecutorHandler_ptr->GetStdout().c_str();
+PyObject *JupyROOTExecutorHandler_Clear(PyObject * /*self*/, PyObject * /*args*/)
+{
+   JupyROOTExecutorHandler_ptr->Clear();
+   Py_RETURN_NONE;
+}
+
+PyObject *JupyROOTExecutorHandler_Ctor(PyObject * /*self*/, PyObject * /*args*/)
+{
+   if (!JupyROOTExecutorHandler_ptr) {
+      JupyROOTExecutorHandler_ptr = new JupyROOTExecutorHandler();
+      // Fixes for ROOT-7999
+      gInterpreter->ProcessLine("SetErrorHandler((ErrorHandlerFunc_t)&DefaultErrorHandler);");
    }
 
-   const char *JupyROOTExecutorHandler_GetStderr()
-   {
-      return JupyROOTExecutorHandler_ptr->GetStderr().c_str();
-   }
+   Py_RETURN_NONE;
+}
 
-   void JupyROOTExecutorHandler_Dtor()
-   {
-      if (!JupyROOTExecutorHandler_ptr) return;
-      delete JupyROOTExecutorHandler_ptr;
-      JupyROOTExecutorHandler_ptr = nullptr;
-   }
+PyObject *JupyROOTExecutorHandler_Poll(PyObject * /*self*/, PyObject * /*args*/)
+{
+   JupyROOTExecutorHandler_ptr->Poll();
+   Py_RETURN_NONE;
+}
 
+PyObject *JupyROOTExecutorHandler_EndCapture(PyObject * /*self*/, PyObject * /*args*/)
+{
+   JupyROOTExecutorHandler_ptr->EndCapture();
+   Py_RETURN_NONE;
+}
+
+PyObject *JupyROOTExecutorHandler_InitCapture(PyObject * /*self*/, PyObject * /*args*/)
+{
+   JupyROOTExecutorHandler_ptr->InitCapture();
+   Py_RETURN_NONE;
+}
+
+PyObject *JupyROOTExecutorHandler_GetStdout(PyObject * /*self*/, PyObject * /*args*/)
+{
+   auto out = JupyROOTExecutorHandler_ptr->GetStdout().c_str();
+   return PyText_FromString(out);
+}
+
+PyObject *JupyROOTExecutorHandler_GetStderr(PyObject * /*self*/, PyObject * /*args*/)
+{
+   auto err = JupyROOTExecutorHandler_ptr->GetStderr().c_str();
+   return PyText_FromString(err);
+}
+
+PyObject *JupyROOTExecutorHandler_Dtor(PyObject * /*self*/, PyObject * /*args*/)
+{
+   if (!JupyROOTExecutorHandler_ptr)
+      Py_RETURN_NONE;
+
+   delete JupyROOTExecutorHandler_ptr;
+   JupyROOTExecutorHandler_ptr = nullptr;
+
+   Py_RETURN_NONE;
+}
+
+
+//////////////////////
+// MODULE INTERFACE //
+//////////////////////
+
+PyObject *gJupyRootModule = 0;
+
+// Methods offered by the interface
+static PyMethodDef gJupyROOTMethods[] = {
+   {(char *)"JupyROOTExecutor", (PyCFunction)JupyROOTExecutor, METH_VARARGS,
+    (char *)"Create JupyROOTExecutor"},
+   {(char *)"JupyROOTDeclarer", (PyCFunction)JupyROOTDeclarer, METH_VARARGS,
+    (char *)"Create JupyROOTDeclarer"},
+   {(char *)"JupyROOTExecutorHandler_Clear", (PyCFunction)JupyROOTExecutorHandler_Clear, METH_NOARGS,
+    (char *)"Clear JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_Ctor", (PyCFunction)JupyROOTExecutorHandler_Ctor, METH_NOARGS,
+    (char *)"Create JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_Poll", (PyCFunction)JupyROOTExecutorHandler_Poll, METH_NOARGS,
+    (char *)"Poll JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_EndCapture", (PyCFunction)JupyROOTExecutorHandler_EndCapture, METH_NOARGS,
+    (char *)"End capture JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_InitCapture", (PyCFunction)JupyROOTExecutorHandler_InitCapture, METH_NOARGS,
+    (char *)"Init capture JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_GetStdout", (PyCFunction)JupyROOTExecutorHandler_GetStdout, METH_NOARGS,
+    (char *)"Get stdout JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_GetStderr", (PyCFunction)JupyROOTExecutorHandler_GetStderr, METH_NOARGS,
+    (char *)"Get stderr JupyROOTExecutorHandler"},
+   {(char *)"JupyROOTExecutorHandler_Dtor", (PyCFunction)JupyROOTExecutorHandler_Dtor, METH_NOARGS,
+    (char *)"Destruct JupyROOTExecutorHandler"},
+   {NULL, NULL, 0, NULL}};
+
+#define QuoteIdent(ident) #ident
+#define QuoteMacro(macro) QuoteIdent(macro)
+#define LIBJUPYROOT_NAME "libJupyROOT" QuoteMacro(PY_MAJOR_VERSION) "_" QuoteMacro(PY_MINOR_VERSION)
+
+#define CONCAT(a, b, c, d) a##b##c##d
+#define LIBJUPYROOT_INIT_FUNCTION(a, b, c, d) CONCAT(a, b, c, d)
+
+#if PY_VERSION_HEX >= 0x03000000
+struct module_state {
+   PyObject *error;
+};
+
+#define GETSTATE(m) ((struct module_state *)PyModule_GetState(m))
+
+static int jupyrootmodule_traverse(PyObject *m, visitproc visit, void *arg)
+{
+   Py_VISIT(GETSTATE(m)->error);
+   return 0;
+}
+
+static int jupyrootmodule_clear(PyObject *m)
+{
+   Py_CLEAR(GETSTATE(m)->error);
+   return 0;
+}
+
+static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,       LIBJUPYROOT_NAME,     NULL,
+                                       sizeof(struct module_state), gJupyROOTMethods,     NULL,
+                                       jupyrootmodule_traverse,     jupyrootmodule_clear, NULL};
+
+/// Initialization of extension module libJupyROOT
+
+#define JUPYROOT_INIT_ERROR return NULL
+LIBJUPYROOT_INIT_FUNCTION(extern "C" PyObject *PyInit_libJupyROOT, PY_MAJOR_VERSION, _, PY_MINOR_VERSION) ()
+#else // PY_VERSION_HEX >= 0x03000000
+#define JUPYROOT_INIT_ERROR return
+LIBJUPYROOT_INIT_FUNCTION(extern "C" void initlibJupyROOT, PY_MAJOR_VERSION, _, PY_MINOR_VERSION) ()
+#endif
+{
+// setup PyROOT
+#if PY_VERSION_HEX >= 0x03000000
+   gJupyRootModule = PyModule_Create(&moduledef);
+#else
+   gJupyRootModule = Py_InitModule(const_cast<char *>(LIBJUPYROOT_NAME), gJupyROOTMethods);
+#endif
+   if (!gJupyRootModule)
+      JUPYROOT_INIT_ERROR;
+
+#if PY_VERSION_HEX >= 0x03000000
+   Py_INCREF(gJupyRootModule);
+   return gJupyRootModule;
+#endif
 }

--- a/bindings/pyroot_experimental/CMakeLists.txt
+++ b/bindings/pyroot_experimental/CMakeLists.txt
@@ -4,11 +4,5 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-if(IS_ABSOLUTE ${runtimedir})
-  set(d $ENV{DESTDIR}/${runtimedir})
-else()
-  set(d $ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/${runtimedir})
-endif()
-
 add_subdirectory(cppyy)
 add_subdirectory(pythonizations)

--- a/bindings/pyroot_experimental/cppyy/patches/multi_python_cppyy.patch
+++ b/bindings/pyroot_experimental/cppyy/patches/multi_python_cppyy.patch
@@ -53,7 +53,7 @@ diff --git a/bindings/pyroot_experimental/cppyy/cppyy/python/cppyy/__init__.py b
 index 1558c3269c..b3b1b84251 100644
 --- a/bindings/pyroot_experimental/cppyy/cppyy/python/cppyy/__init__.py
 +++ b/bindings/pyroot_experimental/cppyy/cppyy/python/cppyy/__init__.py
-@@ -49,39 +49,6 @@ __all__ = [
+@@ -49,72 +49,23 @@ __all__ = [
  from ._version import __version__
  
  import os, sys, sysconfig, warnings
@@ -69,7 +69,21 @@ index 1558c3269c..b3b1b84251 100644
 -sys.modules['libcppyy'] = sys.modules[libcppyy_mod_name]
 -
 -# tell cppyy that libcppyy_backend is versioned
+-def _check_py_version(lib_name, cbl_var):
+-    import re
+-    if re.match('^libcppyy_backend\d_\d$', lib_name):
+-       # library name already has version
+-       if lib_name.endswith(py_version_str):
+-           return ''
+-       else:
+-           raise RuntimeError('CPPYY_BACKEND_LIBRARY variable ({})'
+-                              ' does not match Python version {}.{}'
+-                              .format(cbl_var, major, minor))
+-    else:
+-       return py_version_str
+-
 -if 'CPPYY_BACKEND_LIBRARY' in os.environ:
+-    clean_cbl = False
 -    cbl_var = os.environ['CPPYY_BACKEND_LIBRARY']
 -    start = 0
 -    last_sep = cbl_var.rfind(os.path.sep)
@@ -81,15 +95,34 @@ index 1558c3269c..b3b1b84251 100644
 -        # suffix = so | ...
 -        lib_name = cbl_var[:first_dot]
 -        suff = cbl_var[first_dot+1:]
--        if lib_name.find(py_version_str, start) < 0:
--            lib_name += py_version_str
+-        ver = _check_py_version(lib_name[start:], cbl_var)
 -        os.environ['CPPYY_BACKEND_LIBRARY'] = '.'.join([
--            lib_name, suff])
+-            lib_name + ver, suff])
 -    else:
--        if cbl_var.find(py_version_str, start) < 0:
--            os.environ['CPPYY_BACKEND_LIBRARY'] += py_version_str
+-        ver = _check_py_version(cbl_var[start:], cbl_var)
+-        os.environ['CPPYY_BACKEND_LIBRARY'] += ver
 -else:
+-    clean_cbl = True
 -    os.environ['CPPYY_BACKEND_LIBRARY'] = 'libcppyy_backend' + py_version_str
  
  if not 'CLING_STANDARD_PCH' in os.environ:
      local_pch = os.path.join(os.path.dirname(__file__), 'allDict.cxx.pch')
+     if os.path.exists(local_pch):
+         os.putenv('CLING_STANDARD_PCH', local_pch)
+         os.environ['CLING_STANDARD_PCH'] = local_pch
+
+try:
+    import __pypy__
+    del __pypy__
+    ispypy = True
+except ImportError:
+    ispypy = False
+
+# import separately instead of in the above try/except block for easier to
+# understand tracebacks
+if ispypy:
+    from ._pypy_cppyy import *
+else:
+    from ._cpython_cppyy import *
+-if clean_cbl:
+-    del os.environ['CPPYY_BACKEND_LIBRARY'] # we set it, so clean it


### PR DESCRIPTION
As discussed in ROOT-8011, TPython can't work with the ROOT C++
kernel for Jupyter because the current implementation relies
on a plain shared library to run the cell code and capture
its output and error. In particular, a crash happens when
the library, libJupyROOT, tries to get the __main__ module
in TPython's initialization.

Turning libJupyROOT into a C extension module makes TPython's
initialization succeed, since Python is fully operational.

This PR also fixes an issue when setting the CPPYY_BACKEND_LIBRARY variable.