### PR TITLE
[math] Always specify the parameter name used in the assert statement.

### DIFF
--- a/math/genvector/inc/Math/GenVector/AxisAngle.h
+++ b/math/genvector/inc/Math/GenVector/AxisAngle.h
@@ -113,14 +113,11 @@ public:
       The axis vector is automatically normalized to be a unit vector
    */
    template<class IT>
-#ifndef NDEBUG
    void SetComponents(IT begin, IT end) {
-#else
-   void SetComponents(IT begin, IT ) {
-#endif
       IT a = begin; IT b = ++begin; IT c = ++begin;
       fAxis.SetCoordinates(*a,*b,*c);
       fAngle = *(++begin);
+      (void)end;
       assert (++begin==end);
       // re-normalize the vector
       double tot = fAxis.R();
@@ -132,14 +129,11 @@ public:
       and another to the end of the desired data (4 past start).
    */
    template<class IT>
-#ifndef NDEBUG
    void GetComponents(IT begin, IT end) const {
-#else
-   void GetComponents(IT begin, IT ) const {
-#endif
       IT a = begin; IT b = ++begin; IT c = ++begin;
       fAxis.GetCoordinates(*a,*b,*c);
       *(++begin) = fAngle;
+      (void)end;
       assert (++begin==end);
    }
 

--- a/math/genvector/inc/Math/GenVector/Boost.h
+++ b/math/genvector/inc/Math/GenVector/Boost.h
@@ -161,12 +161,9 @@ public:
      an array of three Scalars to use as beta_x,beta _y, and beta_z
    */
   template<class IT>
-#ifndef NDEBUG
   void SetComponents(IT begin, IT end) {
-#else
-  void SetComponents(IT begin, IT ) {
-#endif
     IT a = begin; IT b = ++begin; IT c = ++begin;
+    (void)end;
     assert (++begin==end);
     SetComponents (*a, *b, *c);
   }
@@ -176,12 +173,9 @@ public:
      an array of three Scalars into which to place beta_x, beta_y, and beta_z
    */
   template<class IT>
-#ifndef NDEBUG
   void GetComponents(IT begin, IT end) const {
-#else
-  void GetComponents(IT begin, IT ) const {
-#endif
     IT a = begin; IT b = ++begin; IT c = ++begin;
+    (void)end;
     assert (++begin==end);
     GetComponents (*a, *b, *c);
   }

--- a/math/genvector/inc/Math/GenVector/DisplacementVector3D.h
+++ b/math/genvector/inc/Math/GenVector/DisplacementVector3D.h
@@ -208,12 +208,9 @@ namespace ROOT {
          Set internal data based on 3 Scalars at *begin to *end
        */
       template <class IT>
-#ifndef NDEBUG
       DisplacementVector3D<CoordSystem, Tag>& SetCoordinates( IT begin, IT end  )
-#else
-      DisplacementVector3D<CoordSystem, Tag>& SetCoordinates( IT begin, IT /* end */  )
-#endif
       { IT a = begin; IT b = ++begin; IT c = ++begin;
+        (void)end;
         assert (++begin==end);
         SetCoordinates (*a,*b,*c);
         return *this;
@@ -235,12 +232,9 @@ namespace ROOT {
          get internal data into 3 Scalars at *begin to *end (3 past begin)
        */
       template <class IT>
-#ifndef NDEBUG
       void GetCoordinates( IT begin, IT end ) const
-#else
-      void GetCoordinates( IT begin, IT /* end */ ) const
-#endif
       { IT a = begin; IT b = ++begin; IT c = ++begin;
+        (void)end;
         assert (++begin==end);
         GetCoordinates (*a,*b,*c);
       }

--- a/math/genvector/inc/Math/GenVector/EulerAngles.h
+++ b/math/genvector/inc/Math/GenVector/EulerAngles.h
@@ -148,14 +148,11 @@ public:
       defining the beginning and end of an array of three Scalars.
    */
    template<class IT>
-#ifndef NDEBUG
    void SetComponents(IT begin, IT end) {
-#else
-   void SetComponents(IT begin, IT ) {
-#endif
       fPhi   = *begin++;
       fTheta = *begin++;
       fPsi   = *begin++;
+      (void)end;
       assert(begin == end);
       Rectify(); // Added 27 Jan. 06   JMM
    }
@@ -165,14 +162,11 @@ public:
       and another to the end of the desired data (4 past start).
    */
    template<class IT>
-#ifndef NDEBUG
    void GetComponents(IT begin, IT end) const {
-#else
-   void GetComponents(IT begin, IT ) const {
-#endif
       *begin++ = fPhi;
       *begin++ = fTheta;
       *begin++ = fPsi;
+      (void)end;
       assert(begin == end);
    }
 

--- a/math/genvector/inc/Math/GenVector/LorentzRotation.h
+++ b/math/genvector/inc/Math/GenVector/LorentzRotation.h
@@ -252,15 +252,12 @@ public:
      the desired data, and another to the end (16 past start).
    */
   template<class IT>
-#ifndef NDEBUG
   void SetComponents(IT begin, IT end) {
-#else
-  void SetComponents(IT begin, IT ) {
-#endif
      for (int i = 0; i <16; ++i) {
         fM[i] = *begin;
         ++begin;
      }
+     (void)end;
      assert (end==begin);
   }
 
@@ -269,15 +266,12 @@ public:
      and another to the end of the desired data (16 past start).
    */
   template<class IT>
-#ifndef NDEBUG
   void GetComponents(IT begin, IT end) const {
-#else
-  void GetComponents(IT begin, IT ) const {
-#endif
      for (int i = 0; i <16; ++i) {
         *begin = fM[i];
         ++begin;
      }
+     (void)end;
      assert (end==begin);
   }
 

--- a/math/genvector/inc/Math/GenVector/Quaternion.h
+++ b/math/genvector/inc/Math/GenVector/Quaternion.h
@@ -108,15 +108,12 @@ public:
       the desired data, and another to the end (4 past start).
    */
    template<class IT>
-#ifndef NDEBUG
    void SetComponents(IT begin, IT end) {
-#else
-   void SetComponents(IT begin, IT ) {
-#endif
       fU = *begin++;
       fI = *begin++;
       fJ = *begin++;
       fK = *begin++;
+      (void)end;
       assert (end==begin);
    }
 
@@ -125,15 +122,12 @@ public:
       and another to the end of the desired data (4 past start).
    */
    template<class IT>
-#ifndef NDEBUG
    void GetComponents(IT begin, IT end) const {
-#else
-   void GetComponents(IT begin, IT ) const {
-#endif
       *begin++ = fU;
       *begin++ = fI;
       *begin++ = fJ;
       *begin++ = fK;
+      (void)end;
       assert (end==begin);
    }
 

--- a/math/genvector/inc/Math/GenVector/Rotation3D.h
+++ b/math/genvector/inc/Math/GenVector/Rotation3D.h
@@ -259,15 +259,12 @@ public:
       the desired data, and another to the end (9 past start).
    */
    template<class IT>
-#ifndef NDEBUG
    void SetComponents(IT begin, IT end) {
-#else
-   void SetComponents(IT begin, IT ) {
-#endif
       for (int i = 0; i <9; ++i) {
          fM[i] = *begin;
          ++begin;
       }
+      (void)end;
       assert (end==begin);
    }
 
@@ -276,15 +273,12 @@ public:
       and another to the end of the desired data (9 past start).
    */
    template<class IT>
-#ifndef NDEBUG
    void GetComponents(IT begin, IT end) const {
-#else
-   void GetComponents(IT begin, IT ) const {
-#endif
       for (int i = 0; i <9; ++i) {
          *begin = fM[i];
          ++begin;
       }
+      (void)end;
       assert (end==begin);
    }
 

--- a/math/genvector/inc/Math/GenVector/RotationZYX.h
+++ b/math/genvector/inc/Math/GenVector/RotationZYX.h
@@ -121,14 +121,11 @@ public:
       defining the beginning and end of an array of three Scalars.
    */
    template<class IT>
-#ifndef NDEBUG
    void SetComponents(IT begin, IT end) {
-#else
-   void SetComponents(IT begin, IT ) {
-#endif
       fPhi   = *begin++;
       fTheta = *begin++;
       fPsi   = *begin++;
+      (void)end;
       assert(begin == end);
       Rectify();
    }
@@ -138,14 +135,11 @@ public:
       and another to the end of the desired data (4 past start).
    */
    template<class IT>
-#ifndef NDEBUG
    void GetComponents(IT begin, IT end) const {
-#else
-   void GetComponents(IT begin, IT ) const {
-#endif
       *begin++ = fPhi;
       *begin++ = fTheta;
       *begin++ = fPsi;
+      (void)end;
       assert(begin == end);
    }
 

--- a/math/genvector/inc/Math/GenVector/Transform3D.h
+++ b/math/genvector/inc/Math/GenVector/Transform3D.h
@@ -468,15 +468,12 @@ public:
       the desired data, and another to the end (12 past start).
    */
    template<class IT>
-#ifndef NDEBUG
    void SetComponents(IT begin, IT end) {
-#else
-   void SetComponents(IT begin, IT ) {
-#endif
       for (int i = 0; i <12; ++i) {
          fM[i] = *begin;
          ++begin;
       }
+      (void)end;
       assert (end==begin);
    }
 
@@ -485,15 +482,12 @@ public:
       and another to the end of the desired data (12 past start).
    */
    template<class IT>
-#ifndef NDEBUG
    void GetComponents(IT begin, IT end) const {
-#else
-   void GetComponents(IT begin, IT ) const {
-#endif
       for (int i = 0; i <12; ++i) {
          *begin = fM[i];
          ++begin;
       }
+      (void)end;
       assert (end==begin);
    }
 

--- a/math/smatrix/inc/Math/SVector.icc
+++ b/math/smatrix/inc/Math/SVector.icc
@@ -91,11 +91,8 @@ SVector<T,D>::SVector(InputIterator begin, unsigned int size) {
 #else
 
 template <class T, unsigned int D>
-#ifdef NDEBUG
-SVector<T,D>::SVector(const T* a, unsigned int) {
-#else
 SVector<T,D>::SVector(const T* a, unsigned int len) {
-#endif
+   (void)len;
    assert(len == D);
    for(unsigned int i=0; i<D; ++i)
       fArray[i] = a[i];


### PR DESCRIPTION
The intent of this code seemed to be avoiding a CINT issue. Now cling can handle such constructs.

This fixes an issue with runtime_cxxmodules on OSX sdk where even when NDEBUG is defined the assert still checks the identifier.