### PR TITLE
[RF] Two bugfixes.

### DIFF
--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -147,10 +147,7 @@
 */
 
 
-#include "RooFit.h"
-
-#include "TClass.h"
-#include "TStopwatch.h"
+#include "RooCustomizer.h"
 
 #include "RooAbsCategoryLValue.h" 
 #include "RooAbsCategory.h"
@@ -159,8 +156,7 @@
 #include "RooArgSet.h"
 #include "RooArgList.h"
 #include "RooMsgService.h"
-
-#include "RooCustomizer.h"
+#include "RooHelpers.h"
 
 #include "Riostream.h"
 #include "RooWorkspace.h"
@@ -352,10 +348,10 @@ void RooCustomizer::replaceArg(const RooAbsArg& orig, const RooAbsArg& subst)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Build a clone of the prototype executing all registered 'replace' rules
-/// If verbose is set a message is printed for each leaf or branch node
+/// Build a clone of the prototype executing all registered 'replace' rules.
+/// If verbose is set, a message is printed for each leaf or branch node
 /// modification. The returned head node owns all cloned branch nodes
-/// that were created in the cloning proces
+/// that were created in the cloning process.
 
 RooAbsArg* RooCustomizer::build(Bool_t verbose) 
 {
@@ -770,9 +766,10 @@ std::string RooCustomizer::CustIFace::create(RooFactoryWSTool& ft, const char* t
   if (instanceName) {
     // Set the desired name of the top level node
     targ->SetName(instanceName) ;
-    ft.ws().import(cust.cloneBranchList(),RooFit::Silence(),RooFit::NoRecursion(kTRUE)) ;
+    // Now import everything. What we didn't touch gets recycled, everything else was cloned here:
+    ft.ws().import(cust.cloneBranchList(), RooFit::Silence(true), RooFit::RecycleConflictNodes(true),    RooFit::NoRecursion(false));
   } else {
-    ft.ws().import(cust.cloneBranchList(),RooFit::Silence(),RooFit::RenameConflictNodes("orig",1),RooFit::NoRecursion(kTRUE)) ;    
+    ft.ws().import(cust.cloneBranchList(), RooFit::Silence(true), RooFit::RenameConflictNodes("orig",1), RooFit::NoRecursion(true));
   }
 
   return string(instanceName?instanceName:targ->GetName()) ;

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -243,8 +243,7 @@ void RooMinimizer::setOffsetting(Bool_t flag)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Choose the minimzer algorithm.
-
+/// Choose the minimiser algorithm.
 void RooMinimizer::setMinimizerType(const char* type)
 {
   _minimizerType = type;
@@ -308,12 +307,16 @@ RooFitResult* RooMinimizer::fit(const char* options)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-
+/// Minimise the function passed in the constructor.
+/// \param[in] type Type of fitter to use, e.g. "Minuit" "Minuit2".
+/// \attention This overrides the default fitter of this RooMinimizer.
+/// \param[in] alg  Fit algorithm to use. (Optional)
 Int_t RooMinimizer::minimize(const char* type, const char* alg)
 {
   _fcn->Synchronize(_theFitter->Config().ParamsSettings(),
 		    _optConst,_verbose) ;
 
+  _minimizerType = type;
   _theFitter->Config().SetMinimizer(type,alg);
 
   profileStart() ;
@@ -338,7 +341,7 @@ Int_t RooMinimizer::minimize(const char* type, const char* alg)
 /// Execute MIGRAD. Changes in parameter values
 /// and calculated errors are automatically
 /// propagated back the RooRealVars representing
-/// the floating parameters in the MINUIT operation
+/// the floating parameters in the MINUIT operation.
 
 Int_t RooMinimizer::migrad()
 {
@@ -367,7 +370,7 @@ Int_t RooMinimizer::migrad()
 /// Execute HESSE. Changes in parameter values
 /// and calculated errors are automatically
 /// propagated back the RooRealVars representing
-/// the floating parameters in the MINUIT operation
+/// the floating parameters in the MINUIT operation.
 
 Int_t RooMinimizer::hesse()
 {
@@ -404,7 +407,7 @@ Int_t RooMinimizer::hesse()
 /// Execute MINOS. Changes in parameter values
 /// and calculated errors are automatically
 /// propagated back the RooRealVars representing
-/// the floating parameters in the MINUIT operation
+/// the floating parameters in the MINUIT operation.
 
 Int_t RooMinimizer::minos()
 {
@@ -442,7 +445,7 @@ Int_t RooMinimizer::minos()
 /// Execute MINOS for given list of parameters. Changes in parameter values
 /// and calculated errors are automatically
 /// propagated back the RooRealVars representing
-/// the floating parameters in the MINUIT operation
+/// the floating parameters in the MINUIT operation.
 
 Int_t RooMinimizer::minos(const RooArgSet& minosParamList)
 {
@@ -501,7 +504,7 @@ Int_t RooMinimizer::minos(const RooArgSet& minosParamList)
 /// Execute SEEK. Changes in parameter values
 /// and calculated errors are automatically
 /// propagated back the RooRealVars representing
-/// the floating parameters in the MINUIT operation
+/// the floating parameters in the MINUIT operation.
 
 Int_t RooMinimizer::seek()
 {
@@ -530,7 +533,7 @@ Int_t RooMinimizer::seek()
 /// Execute SIMPLEX. Changes in parameter values
 /// and calculated errors are automatically
 /// propagated back the RooRealVars representing
-/// the floating parameters in the MINUIT operation
+/// the floating parameters in the MINUIT operation.
 
 Int_t RooMinimizer::simplex()
 {
@@ -559,7 +562,7 @@ Int_t RooMinimizer::simplex()
 /// Execute IMPROVE. Changes in parameter values
 /// and calculated errors are automatically
 /// propagated back the RooRealVars representing
-/// the floating parameters in the MINUIT operation
+/// the floating parameters in the MINUIT operation.
 
 Int_t RooMinimizer::improve()
 {


### PR DESCRIPTION
ROOT-7921
When using the RooCustomizer factory interface, deep trees couldn't be
reused in subsequent expressions.

ROOT-10670
Due to changes somewhere in math, the RooMinimizer in ROOT 6.20 falls
back to Minuit after using minimize() with a different minimiser.
   minim.minimize("Minuit2");
   minim.hesse(); // Users expected minuit2 here, but now minuit

The usual behaviour was restored by remembering the choice of minimiser
in `minimize`, which apparently happened behind the scenes in math in
the past.