### PR TITLE
[Cocoa] Fix compilation problem on MacOsX 10.13

### DIFF
--- a/graf2d/cocoa/src/X11Buffer.mm
+++ b/graf2d/cocoa/src/X11Buffer.mm
@@ -640,10 +640,6 @@ void CommandBuffer::FlushXOROps(Details::CocoaPrivate *impl)
    for (auto &point : cross) {
       // From the view's coordinates to window's:
       point = [view convertPoint : point toView : nil];
-      // To screen coordinates:
-      point = [window convertPointToScreen : point];
-      // To crosshair window's:
-      point = [crosshairWindow convertPointFromScreen : point];
    }
 
    CrosshairView *cv = (CrosshairView *)crosshairWindow.contentView;


### PR DESCRIPTION
On MacOsX 10.13 the previous fix for crosshair. This new version is simpler and does not require
to use functions not available on 10.13.