### PR TITLE
TDirectory file space should never be released.

### DIFF
--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -115,6 +115,11 @@ TBasket::~TBasket()
       delete fCompressedBufferRef;
       fCompressedBufferRef = 0;
    }
+   // TKey::~TKey will use fMotherDir to attempt to remove they key
+   // from the directory's list of key.  A basket is never in that list
+   // and in some cases (eg. f = new TFile(); TTree t; delete f;) the
+   // directory is gone before the TTree.
+   fMotherDir = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -1494,7 +1494,7 @@ Long64_t TTree::AutoSave(Option_t* option)
       nbytes = fDirectory->WriteTObject(this,"","overwrite");
    } else {
       nbytes = fDirectory->WriteTObject(this); //nbytes will be 0 if Write failed (disk space exceeded)
-      if (nbytes && key) {
+      if (nbytes && key && strcmp(ClassName(), key->GetClassName()) == 0) {
          key->Delete();
          delete key;
       }


### PR DESCRIPTION
In https://root-forum.cern.ch/t/re-r-unzip-header-error/38463, the file contains a TDirectory and
a TTree with the same name.  Consequently the TKey for the TDirectory was deleted by AutoSave
leading to the corresponding portion of the file to be reused (for the 2nd basket of the branch ped_id) but TDirectory assumes that they key is never ever deleted and thus is rewriting ontop of the basket.