### PR TITLE
Change compiler flags for Visual Studio 2019 v16.4.0 & v16.5.0

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -10,6 +10,13 @@
 
 include_directories(res ../foundation/res)
 
+if(MSVC_VERSION GREATER_EQUAL 1925)
+  # FIXME: since Visual Studio v16.5.0 the /O2 optimization flag makes most of the roofit/roostats tests failing
+  # Try to re-enable /O2 after the upgrade of llvm & clang, or when upgrading Visual Studio
+  string(REPLACE "-O2" "-O1 -Oi" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  string(REPLACE "-O2" "-O1 -Oi" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+endif()
+
 set(BASE_HEADERS
   ROOT/StringConv.hxx
   ROOT/TExecutor.hxx

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 include_directories(res ../foundation/res)
 
-if(MSVC_VERSION GREATER_EQUAL 1925)
+if(MSVC AND MSVC_VERSION GREATER_EQUAL 1925)
   # FIXME: since Visual Studio v16.5.0 the /O2 optimization flag makes most of the roofit/roostats tests failing
   # Try to re-enable /O2 after the upgrade of llvm & clang, or when upgrading Visual Studio
   string(REPLACE "-O2" "-O1 -Oi" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")

--- a/hist/histv7/test/CMakeLists.txt
+++ b/hist/histv7/test/CMakeLists.txt
@@ -10,8 +10,6 @@ if(MSVC AND MSVC_VERSION GREATER_EQUAL 1924)
   # '??$?8DU?$char_traits@D@std@@@__ROOT@experimental@std@@YA_NV?$basic_string_view@DU?$char_traits@D@std@@@012@0@Z'
   # Try to remove those lines when upgrading Visual Studio
   string(REPLACE "-Od" "-O2" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-  string(REPLACE "-O1 -Oi" "-O2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-  string(REPLACE "-O1 -Oi" "-O2" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 endif()
 
 ROOT_ADD_UNITTEST_DIR(ROOTHist)

--- a/hist/histv7/test/CMakeLists.txt
+++ b/hist/histv7/test/CMakeLists.txt
@@ -9,7 +9,7 @@ if(MSVC AND MSVC_VERSION GREATER_EQUAL 1924)
   # axis.obj : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT
   # '??$?8DU?$char_traits@D@std@@@__ROOT@experimental@std@@YA_NV?$basic_string_view@DU?$char_traits@D@std@@@012@0@Z'
   # Try to remove those lines when upgrading Visual Studio
-  string(REPLACE "-Od" "-O2" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  string(REPLACE "-Od -Z7" "-O2" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 endif()
 
 ROOT_ADD_UNITTEST_DIR(ROOTHist)

--- a/hist/histv7/test/CMakeLists.txt
+++ b/hist/histv7/test/CMakeLists.txt
@@ -4,4 +4,14 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
+if(MSVC AND MSVC_VERSION GREATER_EQUAL 1924)
+  # FIXME: using /O2 compiler flag prevent the followin error when building in debug mode:
+  # axis.obj : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT
+  # '??$?8DU?$char_traits@D@std@@@__ROOT@experimental@std@@YA_NV?$basic_string_view@DU?$char_traits@D@std@@@012@0@Z'
+  # Try to remove those lines when upgrading Visual Studio
+  string(REPLACE "-Od" "-O2" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  string(REPLACE "-O1 -Oi" "-O2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  string(REPLACE "-O1 -Oi" "-O2" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+endif()
+
 ROOT_ADD_UNITTEST_DIR(ROOTHist)

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -93,8 +93,8 @@ endif()
 if(MSVC)
   # FIXME: since Visual Studio v16.4.0 the /O2 optimization flag make many (25%) of the tests failing
   # Try to re-enable /O2 after the upgrade of llvm & clang
-  string(REPLACE "-O2" "-O1" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-  string(REPLACE "-O2" "-O1" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+  string(REPLACE "-O2" "-O1 -Oi" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  string(REPLACE "-O2" "-O1 -Oi" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
   # replace dashes in the -EH* and -GR* flags with slashes (/EH* /GR*)
   string(REPLACE " -EH" " /EH" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   string(REPLACE " -GR" " /GR" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
 - core/base: Since Visual Studio v16.5.0 the /O2 optimization flag makes most of the roofit/roostats tests failing
 - hist/histv7/test: Using /O2 compiler flag prevent the followin error when building in debug mode:
   axis.obj : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT '??$?8DU?$char_traits@D@std@@@__ROOT@experimental@std@@YA_NV?$basic_string_view@DU?$char_traits@D@std@@@012@0@Z'