### PR TITLE
[DF] Do not move a RInterface data member in Count

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -877,8 +877,8 @@ public:
       auto cSPtr = std::make_shared<ULong64_t>(0);
       using Helper_t = RDFInternal::CountHelper;
       using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
-      auto action =
-         std::make_unique<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), fProxiedPtr, std::move(fCustomColumns));
+      auto action = std::make_unique<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), fProxiedPtr,
+                                               RDFInternal::RBookedCustomColumns(fCustomColumns));
       fLoopManager->Book(action.get());
       return MakeResultPtr(cSPtr, *fLoopManager, std::move(action));
    }

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -366,3 +366,11 @@ TEST(RDataFrameInterface, DefineAliasedColumn)
    auto r1 = r0.Alias("newVar", "myVar");
    EXPECT_ANY_THROW(r0.Define("newVar", [](int i){return i;}, {"myVar"})) << "No exception thrown when defining a column with a name which is already an alias.";
 }
+
+// ROOT-10678
+TEST(RDataFrameInterface, CountAndCustomColumns)
+{
+   ROOT::RDataFrame df(10);
+   df.Count().GetValue();
+   df.Filter([](ULong64_t e) { return e == 0; }, {"rdfslot_"}).Count().GetValue();
+}


### PR DESCRIPTION
The logic here was plain wrong, calling Count() should not modify the state of RInterface. One could probably craft an example in which this std::move leads to a crash.