### PR TITLE
[DF] Do not move a RInterface data member in Count

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -877,8 +877,8 @@ public:
       auto cSPtr = std::make_shared<ULong64_t>(0);
       using Helper_t = RDFInternal::CountHelper;
       using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
-      auto action =
-         std::make_unique<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), fProxiedPtr, std::move(fCustomColumns));
+      auto action = std::make_unique<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), fProxiedPtr,
+                                               RDFInternal::RBookedCustomColumns(fCustomColumns));
       fLoopManager->Book(action.get());
       return MakeResultPtr(cSPtr, *fLoopManager, std::move(action));
    }

--- a/tree/dataframe/src/RActionBase.cxx
+++ b/tree/dataframe/src/RActionBase.cxx
@@ -14,7 +14,7 @@
 using namespace ROOT::Internal::RDF;
 
 RActionBase::RActionBase(RLoopManager *lm, const ColumnNames_t &colNames, RBookedCustomColumns &&customColumns)
-   : fLoopManager(lm), fNSlots(lm->GetNSlots()), fColumnNames(colNames), fCustomColumns(customColumns) { }
+   : fLoopManager(lm), fNSlots(lm->GetNSlots()), fColumnNames(colNames), fCustomColumns(std::move(customColumns)) { }
 
 // outlined to pin virtual table
 RActionBase::~RActionBase() {}


### PR DESCRIPTION
The logic here was plain wrong, calling Count() should not modify
the state of RInterface. It only happened to work because RActionBase's
constructor forgot to actually move-construct its data member (also
fixed).

This is a corrected version of #5346 