### PR TITLE
ROOT-10677: [cxxmodules] Don't mount a custom modulemap file if a module.modulemap exists

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -103,8 +103,12 @@ set(clinginclude ${CMAKE_SOURCE_DIR}/interpreter/cling/include)
 set(custom_modulemaps)
 if (runtime_cxxmodules)
   set(custom_modulemaps boost.modulemap tinyxml2.modulemap cuda.modulemap module.modulemap.build)
+  if (NOT libcxx)
+    set(custom_modulemaps ${custom_modulemaps} std.modulemap)
+  endif()
   if (NOT APPLE)
-    set(custom_modulemaps ${custom_modulemaps} libc.modulemap std.modulemap)
+    # Apple's libc is modularized
+    set(custom_modulemaps ${custom_modulemaps} libc.modulemap)
   endif()
 endif(runtime_cxxmodules)
 


### PR DESCRIPTION
OSX has modularized sdk (libc++ included) and there we prefer the modulemaps that libraries ship with. However, libc++ can be also used on other Unix platforms and we should not try to mount the std.modulemap file for it.

This patch fixes ROOT-10677.