### PR TITLE
rootcling: Apply 6b70c867ac to c7ca01fdfa.

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4569,7 +4569,7 @@ int RootClingMain(int argc,
          CreateDictHeader(*splitDictStream, main_dictname);
 
       if (!gOptNoGlobalUsingStd) {
-         AddNamespaceSTDdeclaration(*dictStream);
+         AddNamespaceSTDdeclaration(dictStream);
          if (gOptSplit) {
             AddNamespaceSTDdeclaration(*splitDictStream);
          }
@@ -4823,7 +4823,7 @@ int RootClingMain(int argc,
    }
    if (!gOptIgnoreExistingDict && gOptNoGlobalUsingStd) {
       if (dictStream) {
-         AddNamespaceSTDdeclaration(*dictStream);
+         AddNamespaceSTDdeclaration(dictStream);
       }
       if (gOptSplit && splitDictStream) {
          AddNamespaceSTDdeclaration(*splitDictStream);


### PR DESCRIPTION
Fix rootcling compilation.

See
     https://github.com/root-project/root/pull/5345
     https://github.com/root-project/root/pull/5296