### PR TITLE
[DF] Always use namespace __rdf for jitting

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -251,7 +251,7 @@ std::string PrettyPrintAddr(const void *const addr);
 void BookFilterJit(RJittedFilter *jittedFilter, void *prevNodeOnHeap, std::string_view name,
                    std::string_view expression, const std::map<std::string, std::string> &aliasMap,
                    const ColumnNames_t &branches, const RDFInternal::RBookedCustomColumns &customCols, TTree *tree,
-                   RDataSource *ds, unsigned int namespaceID);
+                   RDataSource *ds);
 
 void BookDefineJit(std::string_view name, std::string_view expression, RLoopManager &lm, RDataSource *ds,
                    const std::shared_ptr<RJittedCustomColumn> &jittedCustomColumn,
@@ -260,7 +260,7 @@ void BookDefineJit(std::string_view name, std::string_view expression, RLoopMana
 std::string JitBuildAction(const ColumnNames_t &bl, void *prevNode, const std::type_info &art, const std::type_info &at,
                            void *r, TTree *tree, const unsigned int nSlots,
                            const RDFInternal::RBookedCustomColumns &customColumns, RDataSource *ds,
-                           std::shared_ptr<RJittedAction> *jittedActionOnHeap, unsigned int namespaceID);
+                           std::shared_ptr<RJittedAction> *jittedActionOnHeap);
 
 // allocate a shared_ptr on the heap, return a reference to it. the user is responsible of deleting the shared_ptr*.
 // this function is meant to only be used by RInterface's action methods, and should be deprecated as soon as we find

--- a/tree/dataframe/inc/ROOT/RDF/RColumnValue.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnValue.hxx
@@ -107,7 +107,7 @@ public:
       fCustomColumn = customColumn;
       // Here we compare names and not typeinfos since they may come from two different contexts: a compiled
       // and a jitted one.
-      const auto diffTypes = (0 != strcmp(customColumn->GetTypeId().name(), typeid(T).name()));
+      const auto diffTypes = (0 != std::strcmp(customColumn->GetTypeId().name(), typeid(T).name()));
       auto inheritedType = [&](){
          auto colTClass = TClass::GetClass(customColumn->GetTypeId());
          return colTClass && colTClass->InheritsFrom(TClass::GetClass<T>());

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -115,9 +115,6 @@ class RLoopManager : public RNodeBase {
    std::map<std::string, std::string> fAliasColumnNameMap; ///< ColumnNameAlias-columnName pairs
    std::vector<TCallback> fCallbacks;                      ///< Registered callbacks
    std::vector<TOneTimeCallback> fCallbacksOnce; ///< Registered callbacks to invoke just once before running the loop
-   /// A unique ID that identifies the computation graph that starts with this RLoopManager.
-   /// Used, for example, to jit objects in a namespace reserved for this computation graph
-   const unsigned int fID = GetNextID();
    unsigned int fNRuns{0}; ///< Number of event loops run
 
    std::vector<RCustomColumnBase *> fCustomColumns; ///< Non-owning container of all custom columns created so far.
@@ -137,7 +134,6 @@ class RLoopManager : public RNodeBase {
    void CleanUpNodes();
    void CleanUpTask(unsigned int slot);
    void EvalChildrenCounts();
-   static unsigned int GetNextID();
 
 public:
    RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);
@@ -174,7 +170,6 @@ public:
    void AddColumnAlias(const std::string &alias, const std::string &colName) { fAliasColumnNameMap[alias] = colName; }
    const std::map<std::string, std::string> &GetAliasMap() const { return fAliasColumnNameMap; }
    void RegisterCallback(ULong64_t everyNEvents, std::function<void(unsigned int)> &&f);
-   unsigned int GetID() const { return fID; }
    unsigned int GetNRuns() const { return fNRuns; }
 
    /// End of recursive chain of calls, does nothing

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -100,8 +100,8 @@ const std::type_info &TypeName2TypeID(const std::string &name);
 
 std::string TypeID2TypeName(const std::type_info &id);
 
-std::string ColumnName2ColumnTypeName(const std::string &colName, unsigned int namespaceID, TTree *, RDataSource *,
-                                      bool isCustomColumn, bool vector2rvec = true, unsigned int customColID = 0);
+std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *, RDataSource *, bool isCustomColumn,
+                                      bool vector2rvec = true, unsigned int customColID = 0);
 
 char TypeName2ROOTTypeName(const std::string &b);
 

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -193,8 +193,8 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
 /// vector2rvec specifies whether typename 'std::vector<T>' should be converted to 'RVec<T>' or returned as is
 /// customColID is only used if isCustomColumn is true, and must correspond to the custom column's unique identifier
 /// returned by its `GetID()` method.
-std::string ColumnName2ColumnTypeName(const std::string &colName, unsigned int namespaceID, TTree *tree,
-                                      RDataSource *ds, bool isCustomColumn, bool vector2rvec, unsigned int customColID)
+std::string ColumnName2ColumnTypeName(const std::string &colName, TTree *tree, RDataSource *ds, bool isCustomColumn,
+                                      bool vector2rvec, unsigned int customColID)
 {
    std::string colType;
 
@@ -214,7 +214,7 @@ std::string ColumnName2ColumnTypeName(const std::string &colName, unsigned int n
 
    if (colType.empty() && isCustomColumn) {
       // this must be a temporary branch, we know there is an alias for its type
-      colType = "__rdf" + std::to_string(namespaceID) + "::" + colName + std::to_string(customColID) + "_type";
+      colType = "__rdf::" + colName + std::to_string(customColID) + "_type";
    }
 
    if (colType.empty())

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -24,6 +24,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <cstring>
 #include <typeinfo>
 
 using namespace ROOT::Detail::RDF;
@@ -175,7 +176,7 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
             if (mother && mother->InheritsFrom(tbranchelement)) {
                auto beMom = static_cast<TBranchElement *>(mother);
                auto beMomClass = beMom->GetClass();
-               if (beMomClass && 0 == strcmp("TClonesArray", beMomClass->GetName()))
+               if (beMomClass && 0 == std::strcmp("TClonesArray", beMomClass->GetName()))
                   return be->GetTypeName();
             }
             return be->GetClassName();

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -534,13 +534,6 @@ void RLoopManager::EvalChildrenCounts()
       namedFilterPtr->TriggerChildrenCount();
 }
 
-unsigned int RLoopManager::GetNextID()
-{
-   static unsigned int id = 0;
-   ++id;
-   return id;
-}
-
 namespace {
 static void ThrowIfPoolSizeChanged(unsigned int nSlots)
 {

--- a/tree/dataframe/src/RRootDS.cxx
+++ b/tree/dataframe/src/RRootDS.cxx
@@ -64,9 +64,8 @@ std::string RRootDS::GetTypeName(std::string_view colName) const
    }
    // TODO: we need to factor out the routine for the branch alone...
    // Maybe a cache for the names?
-   auto typeName =
-      ROOT::Internal::RDF::ColumnName2ColumnTypeName(std::string(colName), /*nsID=*/0, &fModelChain, /*ds=*/nullptr,
-                                                     /*isCustomCol=*/false);
+   auto typeName = ROOT::Internal::RDF::ColumnName2ColumnTypeName(std::string(colName), &fModelChain, /*ds=*/nullptr,
+                                                                  /*isCustomCol=*/false);
    // We may not have yet loaded the library where the dictionary of this type is
    TClass::GetClass(typeName.c_str());
    return typeName;

--- a/tree/dataframe/test/dataframe_utils.cxx
+++ b/tree/dataframe/test/dataframe_utils.cxx
@@ -72,7 +72,7 @@ TEST(RDataFrameUtils, DeduceAllPODsFromColumns)
                                                      {"vararrint.a", "ROOT::VecOps::RVec<Int_t>"}};
 
    for (auto &nameType : nameTypes) {
-      auto typeName = RDFInt::ColumnName2ColumnTypeName(nameType.first, /*nsID=*/0, &t, /*ds=*/nullptr,
+      auto typeName = RDFInt::ColumnName2ColumnTypeName(nameType.first, &t, /*ds=*/nullptr,
                                                         /*custom=*/false);
       EXPECT_STREQ(nameType.second, typeName.c_str());
    }
@@ -100,8 +100,8 @@ TEST(RDataFrameUtils, DeduceTypeOfBranchesWithCustomTitle)
                                                      {"vararrint.a", "ROOT::VecOps::RVec<Int_t>"}};
 
    for (auto &nameType : nameTypes) {
-      auto typeName = RDFInt::ColumnName2ColumnTypeName(nameType.first, /*nsID=*/0, &t, /*ds=*/nullptr,
-                                                                     /*custom=*/false);
+      auto typeName = RDFInt::ColumnName2ColumnTypeName(nameType.first, &t, /*ds=*/nullptr,
+                                                        /*custom=*/false);
       EXPECT_STREQ(nameType.second, typeName.c_str());
    }
 }


### PR DESCRIPTION
Before this patch, aliases of defined columns were jitted in namespace
__rdfX with X monotonously increasing. That is strictly unnecessary,
as every alias already contains a unique ID.

This patch makes RDF more consistent (everything is jitted in the same namespace), and as a consequence we can simplify the signature of several helper functions and can remove a data member and relative getter from RLoopManager.
The change also helps with re-usage of jitted lambdas ([ROOT-10657](https://sft.its.cern.ch/jira/browse/ROOT-10657) as the type signatures of jitted lambdas of different RDF computation graphs will not contain different namespaces anymore.