### PR TITLE
[DF] Make RLoopManager's code to jit a static global

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -109,8 +109,6 @@ class RLoopManager : public RNodeBase {
    const unsigned int fNSlots{1};
    bool fMustRunNamedFilters{true};
    const ELoopType fLoopType; ///< The kind of event loop that is going to be run (e.g. on ROOT files, on no files)
-   std::string fToJitDeclare; ///< Code that should be just-in-time declared right before the event loop
-   std::string fToJitExec;    ///< Code that should be just-in-time executed right before the event loop
    const std::unique_ptr<RDataSource> fDataSource; ///< Owning pointer to a data-source object. Null if no data-source
    std::map<std::string, std::string> fAliasColumnNameMap; ///< ColumnNameAlias-columnName pairs
    std::vector<TCallback> fCallbacks;                      ///< Registered callbacks
@@ -141,6 +139,7 @@ public:
    RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches);
    RLoopManager(const RLoopManager &) = delete;
    RLoopManager &operator=(const RLoopManager &) = delete;
+   ~RLoopManager();
 
    void JitDeclarations();
    void Jit();
@@ -165,8 +164,8 @@ public:
    void SetTree(const std::shared_ptr<TTree> &tree) { fTree = tree; }
    void IncrChildrenCount() final { ++fNChildren; }
    void StopProcessing() final { ++fNStopsReceived; }
-   void ToJitDeclare(const std::string &s) { fToJitDeclare.append(s); }
-   void ToJitExec(const std::string &s) { fToJitExec.append(s); }
+   void ToJitDeclare(const std::string &) const;
+   void ToJitExec(const std::string &) const;
    void AddColumnAlias(const std::string &alias, const std::string &colName) { fAliasColumnNameMap[alias] = colName; }
    const std::map<std::string, std::string> &GetAliasMap() const { return fAliasColumnNameMap; }
    void RegisterCallback(ULong64_t everyNEvents, std::function<void(unsigned int)> &&f);

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -289,7 +289,9 @@ std::vector<std::string> ReplaceDotWithUnderscore(const std::vector<std::string>
 void InterpreterDeclare(const std::string &code)
 {
    if (!gInterpreter->Declare(code.c_str())) {
-      const auto msg = "\nAn error occurred while jitting. The lines above might indicate the cause of the crash\n";
+      const auto msg =
+         "\nRDataFrame: An error occurred during just-in-time compilation. The lines above might indicate the cause of "
+         "the crash\n All RDF objects that have not run an event loop yet should be considered in an invalid state.\n";
       throw std::runtime_error(msg);
    }
 }
@@ -299,10 +301,11 @@ Long64_t InterpreterCalc(const std::string &code, const std::string &context)
    TInterpreter::EErrorCode errorCode(TInterpreter::kNoError);
    auto res = gInterpreter->Calc(code.c_str(), &errorCode);
    if (errorCode != TInterpreter::EErrorCode::kNoError) {
-      std::string msg = "\nAn error occurred while jitting";
+      std::string msg = "\nAn error occurred during just-in-time compilation";
       if (!context.empty())
          msg += " in " + context;
-      msg += ". The lines above might indicate the cause of the crash\n";
+      msg += ". The lines above might indicate the cause of the crash\nAll RDF objects that have not run their event "
+             "loop yet should be considered in an invalid state.\n";
       throw std::runtime_error(msg);
    }
    return res;

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -5,6 +5,7 @@
 
 #include <mutex>
 #include <thread>
+#include <stdexcept> // std::runtime_error
 
 #include "gtest/gtest.h"
 
@@ -47,15 +48,11 @@ TEST(RDataFrameNodes, RLoopManagerGetLoopManagerUnchecked)
    ASSERT_EQ(&lm, lm.GetLoopManagerUnchecked());
 }
 
-TEST(RDataFrameNodes, RLoopManagerJit)
+TEST(RDataFrameNodes, RLoopManagerJitWrongCode)
 {
    ROOT::Detail::RDF::RLoopManager lm(nullptr, {});
    lm.ToJitExec("souble d = 3.14");
-   auto op = [&](){
-      testing::internal::CaptureStderr();
-      lm.Run();
-   };
-   EXPECT_ANY_THROW(op()) << "Bogus C++ code was jitted and nothing was detected!";
+   EXPECT_THROW(lm.Run(), std::runtime_error) << "Bogus C++ code was jitted and nothing was detected!";
 }
 
 TEST(RDataFrameNodes, DoubleEvtLoop)


### PR DESCRIPTION
In the future, we want separate computation graphs to share and re-use already
jitted lambdas. Without this patch, however, we would have an ordering
problem or a redefinition problem, because RDF2 might want to re-use/redefine
a lambda that RDF1 is _going to_ declare, but (since we delay all
jitting to right before an RDF's event loop) that might happen too late
for RDF2.

With this change, all RDFs can jit all code that has been booked by all
other RDFs, resolving that problem. In addition, making less, "fatter"
call to the interpreter is a performance optimization in itself.