### PR TITLE
Unset GLEW_FOUND in case of Mac OS X builds with CMake 3.17 (to avoid…

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -516,8 +516,9 @@ if(opengl AND NOT builtin_glew)
     # Bug was reported on newer version of CMake on Mac OS X:
     # https://gitlab.kitware.com/cmake/cmake/-/issues/19662
     # https://github.com/microsoft/vcpkg/pull/7967
-    if(APPLE AND CMAKE_VERSION VERSION_GREATER 3.15)
+    if(GLEW_FOUND AND APPLE AND CMAKE_VERSION VERSION_GREATER 3.15)
       message(FATAL_ERROR "Please enable builtin Glew due bug in latest CMake (use cmake option -Dbuiltin_glew=ON).")
+      unset(GLEW_FOUND)
     endif()
     if(NOT GLEW_FOUND)
       # set variables to emulate find_package(GLEW)


### PR DESCRIPTION
… GLEW from brew)