### PR TITLE
[cxxmodules] Preload the dependent modules if specified in rootcling.

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -479,7 +479,11 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   #---Get the library and module dependencies-----------------
   if(ARG_DEPENDENCIES)
     foreach(dep ${ARG_DEPENDENCIES})
-      set(newargs ${newargs} -m  ${libprefix}${dep}_rdict.pcm)
+      set(dependent_pcm ${libprefix}${dep}_rdict.pcm)
+      if (runtime_cxxmodules)
+        set(dependent_pcm ${dep}.pcm)
+      endif()
+      set(newargs ${newargs} -m  ${dependent_pcm})
     endforeach()
   endif()
 


### PR DESCRIPTION
This should allow us to build non-standard modules such as boost. This patch should enable building the cmssw third-party modules for external dependencies.

Cc: @oshadura, @davidlange6, @smuzaffar 