### PR TITLE
[RF] Fix ROOT-10676.

### DIFF
--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -58,9 +58,9 @@ public:
 
 
   // Constructor importing data from external ROOT Tree
-  RooDataSet(const char *name, const char *title, TTree *ntuple, const RooArgSet& vars, 
+  RooDataSet(const char *name, const char *title, TTree *tree, const RooArgSet& vars,
 	     const char *cuts=0, const char* wgtVarName=0); 
-  RooDataSet(const char *name, const char *title, TTree *t, const RooArgSet& vars, 
+  RooDataSet(const char *name, const char *title, TTree *tree, const RooArgSet& vars,
 	     const RooFormulaVar& cutVar, const char* wgtVarName=0) ;  
   
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -717,12 +717,12 @@ RooDataSet::RooDataSet(const char *name, const char *title, RooDataSet *dset,
 /// operating exclusively and directly on the data set dimensions, the equivalent
 /// constructor with a string based cut expression is recommended.
 
-RooDataSet::RooDataSet(const char *name, const char *title, TTree *intree, 
-		       const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName) :
+RooDataSet::RooDataSet(const char *name, const char *title, TTree *theTree,
+    const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
   // Create tree version of datastore 
-  RooTreeDataStore* tstore = new RooTreeDataStore(name,title,_vars,*intree,cutVar,wgtVarName) ;
+  RooTreeDataStore* tstore = new RooTreeDataStore(name,title,_vars,*theTree,cutVar,wgtVarName) ;
 
   // Convert to vector datastore if needed
   if (defaultStorageType==Tree) {
@@ -744,27 +744,33 @@ RooDataSet::RooDataSet(const char *name, const char *title, TTree *intree,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor of a data set from (part of) an ROOT TTRee. The dimensions
-/// of the data set are defined by the 'vars' RooArgSet. For each dimension
+/// Constructor of a data set from (part of) a ROOT TTree.
+///
+/// \param[in] name Name of this dataset.
+/// \param[in] title Title for e.g. plotting.
+/// \param[in] tree Tree to be imported.
+/// \param[in] vars Defines the columns of the data set. For each dimension
 /// specified, the TTree must have a branch with the same name. For category
 /// branches, this branch should contain the numeric index value. Real dimensions
 /// can be constructed from either 'Double_t' or 'Float_t' tree branches. In the
 /// latter case, an automatic conversion is applied.
-///
-/// The 'cuts' string is an optional
-/// RooFormula expression and can be used to select the subset of the data points 
-/// in 'dset' to be copied. The cut expression can refer to any variable in the
-/// vars argset. For cuts involving variables other than those contained in
-/// the vars argset, such as intermediate formula objects, use the 
-/// equivalent constructor accepting RooFormulaVar reference as cut specification
-///
-
-RooDataSet::RooDataSet(const char *name, const char *title, TTree *intree, 
-		       const RooArgSet& vars, const char *selExpr, const char* wgtVarName) :
+/// \param[in] cuts Optional RooFormula expression to select the subset of the data points
+/// to be imported. The cut expression can refer to any variable in `vars`.
+/// \warning The expression only evaluates variables that are also in `vars`.
+/// Passing e.g.
+/// ```
+/// RooDataSet("data", "data", tree, RooArgSet(x), "x>y")
+/// ```
+/// Will load `x` from the tree, but leave `y` at an undefined value.
+/// If other expressions are needed, such as intermediate formula objects, use
+/// RooDataSet::RooDataSet(const char*,const char*,TTree*,const RooArgSet&,const RooFormulaVar&,const char*)
+/// \param[in] wgtVarName Name of the variable in `vars` that represents an event weight.
+RooDataSet::RooDataSet(const char* name, const char* title, TTree* theTree,
+    const RooArgSet& vars, const char* cuts, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
   // Create tree version of datastore 
-  RooTreeDataStore* tstore = new RooTreeDataStore(name,title,_vars,*intree,selExpr,wgtVarName) ;
+  RooTreeDataStore* tstore = new RooTreeDataStore(name,title,_vars,*theTree,cuts,wgtVarName);
 
   // Convert to vector datastore if needed
   if (defaultStorageType==Tree) {

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -121,7 +121,7 @@ RooFormulaVar::RooFormulaVar(const RooFormulaVar& other, const char* name) :
   _formExpr(other._formExpr)
 {
   if (other._formula && other._formula->ok()) {
-    _formula.reset(new RooFormula(GetName(), _formExpr, _actualVars));
+    _formula.reset(new RooFormula(GetName(), _formExpr, _actualVars, /*checkVariables=*/false));
     _formExpr = _formula->formulaString().c_str();
   }
 }

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -163,7 +163,7 @@ RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const Ro
 
   if (selExpr && *selExpr) {
     // Create a RooFormulaVar cut from given cut expression
-    RooFormulaVar select(selExpr,selExpr,_vars) ;
+    RooFormulaVar select(selExpr, selExpr, _vars, /*checkVariables=*/false);
     loadValues(&t,&select);
   } else {
     loadValues(&t);
@@ -212,7 +212,7 @@ RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const Ro
 
   if (selExpr && *selExpr) {
     // Create a RooFormulaVar cut from given cut expression
-    RooFormulaVar select(selExpr,selExpr,_vars) ;
+    RooFormulaVar select(selExpr, selExpr, _vars, /*checkVariables=*/false);
     loadValues(&ads,&select);
   } else {
     loadValues(&ads);

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -15,4 +15,5 @@ ROOT_ADD_GTEST(testRooWrapperPdf testRooWrapperPdf.cxx LIBRARIES Gpad RooFitCore
 ROOT_ADD_GTEST(testGenericPdf testGenericPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooProxy testRooProxy.cxx LIBRARIES RooFitCore WILLFAIL)
 ROOT_ADD_GTEST(testRooAbsPdf testRooAbsPdf.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)
 

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -1,0 +1,46 @@
+// Tests for the RooDataSet
+// Authors: Stephan Hageboeck, CERN  04/2020
+
+#include "RooDataSet.h"
+#include "RooRealVar.h"
+#include "RooHelpers.h"
+#include "TTree.h"
+
+#include "gtest/gtest.h"
+
+/// ROOT-10676
+/// The RooDataSet warns that it's not using all variables if the selection string doesn't
+/// make use of all variables. Although true, the user has no way to suppress this.
+TEST(RooDataSet, ImportFromTreeWithCut)
+{
+  RooHelpers::HijackMessageStream hijack(RooFit::INFO, RooFit::InputArguments);
+
+  TTree tree("tree", "tree");
+  double thex, they;
+  tree.Branch("x", &thex);
+  tree.Branch("y", &they);
+  tree.Branch("z", &they);
+  thex = -0.337;
+  they = 1.;
+  tree.Fill();
+
+  thex = 0.337;
+  they = 1.;
+  tree.Fill();
+
+  thex = 1.337;
+  they = 1.;
+  tree.Fill();
+
+  RooRealVar x("x", "x", 0);
+  RooRealVar y("y", "y", 0);
+  RooRealVar z("z", "z", 0);
+  RooDataSet data("data", "data", &tree, RooArgSet(x, y, z), "x>y");
+
+  EXPECT_TRUE(hijack.str().empty()) << "Messages issued were: " << hijack.str();
+  EXPECT_EQ(data.numEntries(), 1);
+
+  RooRealVar* theX = dynamic_cast<RooRealVar*>(data.get(0)->find("x"));
+  ASSERT_NE(theX, nullptr);
+  EXPECT_FLOAT_EQ(theX->getVal(), 1.337);
+}


### PR DESCRIPTION
When importing a dataset from a TTree, selection strings can be passed.
When selection strings are not using *all* variables that are copied
into the dataset, the selection formula was warning that not all
variables are used in the selection. Given that this is likely intended,
the warning was removed.