### PR TITLE
[PyROOT] Add test for implicit import from the ROOT namespace

### DIFF
--- a/bindings/pyroot/pythonizations/test/root_module.py
+++ b/bindings/pyroot/pythonizations/test/root_module.py
@@ -44,3 +44,15 @@ class ROOTModule(unittest.TestCase):
         import ROOT
         self.assertEqual(ROOT.PyConfig.IgnoreCommandLineOptions, True)
         ROOT.PyConfig.IgnoreCommandLineOptions = False
+
+    def test_implicit_root_namespace(self):
+        """
+        Test importing implicitely from the ROOT namespace
+        """
+        import ROOT
+        ROOT.RVec
+        ROOT.ROOT.RVec
+        ROOT.VecOps.RVec
+        ROOT.ROOT.VecOps.RVec
+        ROOT.EnableImplicitMT()
+        ROOT.ROOT.EnableImplicitMT()


### PR DESCRIPTION
I see some import failures from `ROOT.RVec` in #5310, added a test here.