### PR TITLE
Move changes to TTreeCache data members in apparently better positions

### DIFF
--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1125,7 +1125,8 @@ Bool_t TTreeCache::FillBuffer()
          }
       }
       if (fIsLearning) { //  Learning mode
-         entry = 0;
+         // The learning phase should start from the minimum entry in the cache
+         entry = fEntryMin;
       }
       if (fFirstTime) {
          //try to detect if it is normal or reverse read
@@ -1243,17 +1244,17 @@ Bool_t TTreeCache::FillBuffer()
    auto entryCurrent = clusterIter();
    auto entryNext    = clusterIter.GetNextEntry();
 
-   // Moving this before the if fixes the wrong cache behaviour with TTreeReader/RDataFrame
-   // but introduces the "Inconsistency Error" at line 1277 when using only TTree/TChain 
-   fEntryCurrent = entryCurrent;
-   fEntryNext = entryNext;
-
    if (entryNext < fEntryMin || fEntryMax < entryCurrent) {
       // There is no overlap between the cluster we found [entryCurrent, entryNext[
       // and the authorized range [fEntryMin, fEntryMax]
       // so we have nothing to do
       return kFALSE;
    }
+
+   // If there is overlap between the found cluster and the authorized range
+   // update the cache data members with the information about the current cluster.
+   fEntryCurrent = entryCurrent;
+   fEntryNext = entryNext;
 
    auto firstClusterEnd = fEntryNext;
    if (showMore || gDebug > 6)

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1243,16 +1243,17 @@ Bool_t TTreeCache::FillBuffer()
    auto entryCurrent = clusterIter();
    auto entryNext    = clusterIter.GetNextEntry();
 
+   // Moving this before the if fixes the wrong cache behaviour with TTreeReader/RDataFrame
+   // but introduces the "Inconsistency Error" at line 1277 when using only TTree/TChain 
+   fEntryCurrent = entryCurrent;
+   fEntryNext = entryNext;
+
    if (entryNext < fEntryMin || fEntryMax < entryCurrent) {
       // There is no overlap between the cluster we found [entryCurrent, entryNext[
       // and the authorized range [fEntryMin, fEntryMax]
       // so we have nothing to do
       return kFALSE;
    }
-
-   fEntryCurrent = entryCurrent;
-   fEntryNext = entryNext;
-
 
    auto firstClusterEnd = fEntryNext;
    if (showMore || gDebug > 6)

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -400,6 +400,10 @@ TTreeReader::EEntryStatus TTreeReader::SetEntriesRange(Long64_t beginEntry, Long
    if (beginEntry - 1 < 0)
       Restart();
    else {
+      // SetEntry() calls internally SetProxies() which in turn calls SetCacheEntryRange
+      // with fBeginEntry as an arg. If we do not set fBeginEntry to beginEntry in the
+      // next line the Cache will have wrong information about the first entry.
+      fBeginEntry = beginEntry; 
       EEntryStatus es = SetEntry(beginEntry - 1);
       if (es != kEntryValid) {
          Error("SetEntriesRange()", "Error setting first entry %lld: %s",

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -393,17 +393,20 @@ TTreeReader::EEntryStatus TTreeReader::SetEntriesRange(Long64_t beginEntry, Long
       return kEntryNotFound;
    }
 
+   // Update data members to correctly reflect the defined range
    if (endEntry > beginEntry)
       fEndEntry = endEntry;
    else
       fEndEntry = -1;
-   if (beginEntry - 1 < 0)
+
+   fBeginEntry = beginEntry;
+
+   if (beginEntry - 1 < 0) 
+      // Reset the cache if reading from the first entry of the tree
       Restart();
    else {
-      // SetEntry() calls internally SetProxies() which in turn calls SetCacheEntryRange
-      // with fBeginEntry as an arg. If we do not set fBeginEntry to beginEntry in the
-      // next line the Cache will have wrong information about the first entry.
-      fBeginEntry = beginEntry; 
+      // Load the first entry in the range. SetEntry() will also call SetProxies(),
+      // thus adding all the branches to the cache and triggering the learning phase.
       EEntryStatus es = SetEntry(beginEntry - 1);
       if (es != kEntryValid) {
          Error("SetEntriesRange()", "Error setting first entry %lld: %s",
@@ -411,8 +414,6 @@ TTreeReader::EEntryStatus TTreeReader::SetEntriesRange(Long64_t beginEntry, Long
          return es;
       }
    }
-
-   fBeginEntry = beginEntry;
 
    return kEntryValid;
 }


### PR DESCRIPTION
These minor changes seem to affect the way in which TTreeCache interacts with different IO classes, e.g. TTree/TChain vs TTreeReader.

In `TTreeCache::FillBuffer` the change in values of `fEntryCurrent` and `fEntryNext`, respectively the first entry of the current cluster and the first entry of the next cluster, has been moved before an `if` condition that was causing an early exit from the function.
This, in conjunction with the change in `TTreeReader::SetEntriesRange` apparently fixes the issues with the cache when running a simple program that uses only TTreeReader.

At the same time, the changes affect the interaction of the cache with a TTree-only program in a way that now is throwing a log error:
```Error in <TTreeCache::FillBuffer>: Inconsistency: fCurrentClusterStart=821695 fEntryCurrent=821695 fNextClusterStart=1643390 but fEntryCurrent should not be in between the two```

I'm not sure why these changes affect positively the TTreeReader examples and negatively the TTree ones. Some links to these examples follow.