### PR TITLE
[cling] Shadow only prompt definitions:

### DIFF
--- a/interpreter/cling/lib/Interpreter/DefinitionShadower.cpp
+++ b/interpreter/cling/lib/Interpreter/DefinitionShadower.cpp
@@ -83,8 +83,9 @@ namespace cling {
     for (auto Prev : Previous) {
       if (Prev == D)
         continue;
-      if (isDefinition(Prev)
-          && (!isDefinition(D) || !isClingShadowNamespace(Prev->getDeclContext())))
+      if (!isClingShadowNamespace(Prev->getDeclContext()))
+        continue;
+      if (isDefinition(Prev) && !isDefinition(D))
         continue;
       // If the found declaration is a function overload, do not invalidate it.
       // For templated functions, Sema::IsOverload() does the right thing as per


### PR DESCRIPTION
This prevents an assert (isClingShadowNamespace(D->getDeclContext()) && "D not in a __cling_N5xxx namespace?"), function hideDecl, file /build/jenkins/night/LABEL/mac1014/SPEC/soversion/V/master/root/interpreter/cling/lib/Interpreter/DefinitionShadower.cpp, line 61