### PR TITLE
[Exp PyROOT][ROOT-10681] Make AddressOf and addressof consistent with old PyROOT

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -82,17 +82,12 @@ class ROOTFacade(types.ModuleType):
         self._set_import_hook()
 
     def AddressOf(self, *args):
-        # Return an array of size 1 which contains the address of the object in args
-        if sys.version_info >= (3, 3):
-            import array
-            return array.array('q', [ self.addressof(*args) ])
-        else:
-            # In Python<3.3, array.array does not support long long type, fall back to NumPy
-            try:
-                import numpy as np
-            except ImportError:
-                raise RuntimeError("Error importing NumPy: in Python<3.3, AddressOf requires NumPy")
-            return np.array([ self.addressof(*args) ], dtype=np.longlong)
+        # Return a bytearray that can fit a long long, which is what addressof
+        # returns (wrapped in a Python integer). The bytes of the bytearray
+        # correspond to the address of the object in args
+        import struct
+        ad = self.addressof(*args)
+        return bytearray(struct.pack('q', ad))
 
     def _set_import_hook(self):
         # This hook allows to write e.g:

--- a/bindings/pyroot_experimental/pythonizations/test/ttree_branch.py
+++ b/bindings/pyroot_experimental/pythonizations/test/ttree_branch.py
@@ -2,7 +2,7 @@ import unittest
 from array import array
 
 import ROOT
-from libcppyy import SetOwnership, addressof
+from ROOT import SetOwnership, addressof
 import numpy as np
 
 


### PR DESCRIPTION
Both `AddressOf` and `addressof` exist in old PyROOT, and they can be used to obtain the address of the address of a C++ object from its Python proxy. In the case of `addressof`, the address is returned as a value, while for `AddressOf` it is returned as an indexable buffer.

This PR proposes to implement `AddressOf` in terms of `addressof` (which is the only one provided by cppyy), just by creating an array of one position and storing the address in that position.
