### PR TITLE
Clarify that TMathText cannot be used in PDF files

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -4647,7 +4647,7 @@ void TPad::Pop()
 ///  - if filename is "", the file produced is padname.ps
 ///  - if filename starts with a dot, the padname is added in front
 ///  - if filename contains .eps, an Encapsulated Postscript file is produced
-///  - if filename contains .pdf, a PDF file is produced
+///  - if filename contains .pdf, a PDF file is produced NOTE: TMathText will be converted to TLatex; q.e.d., symbols only available in TMathText will not render properly.
 ///  - if filename contains .svg, a SVG file is produced
 ///  - if filename contains .tex, a TeX file is produced
 ///  - if filename contains .gif, a GIF file is produced
@@ -4702,7 +4702,7 @@ static Bool_t ContainsTImage(TList *li)
 ///  -        "eps"  an Encapsulated Postscript file is produced
 ///  -    "Preview"  an Encapsulated Postscript file with preview is produced.
 ///  - "EmbedFonts"  a PDF file with embedded fonts is generated.
-///  -        "pdf"  a PDF file is produced
+///  -        "pdf"  a PDF file is produced NOTE: TMathText will be converted to TLatex; q.e.d., symbols only available in TMathText will not render properly.
 ///  -        "svg"  a SVG file is produced
 ///  -        "tex"  a TeX file is produced
 ///  -        "gif"  a GIF file is produced
@@ -5559,7 +5559,7 @@ void TPad::ResizePad(Option_t *option)
 ///  - if filename is "", the file produced is padname.ps
 ///  - if filename starts with a dot, the padname is added in front
 ///  - if filename contains .eps, an Encapsulated Postscript file is produced
-///  - if filename contains .pdf, a PDF file is produced
+///  - if filename contains .pdf, a PDF file is produced NOTE: TMathText will be converted to TLatex; q.e.d., symbols only available in TMathText will not render properly.
 ///  - if filename contains .svg, a SVG file is produced
 ///  - if filename contains .tex, a TeX file is produced
 ///  - if filename contains .gif, a GIF file is produced

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -4647,14 +4647,19 @@ void TPad::Pop()
 ///  - if filename is "", the file produced is padname.ps
 ///  - if filename starts with a dot, the padname is added in front
 ///  - if filename contains .eps, an Encapsulated Postscript file is produced
+///  - if filename contains .pdf, a PDF file is produced
+///  - if filename contains .svg, a SVG file is produced
+///  - if filename contains .tex, a TeX file is produced
 ///  - if filename contains .gif, a GIF file is produced
-///  - if filename contains .gif+NN, an animated GIF file is produced
-///       See comments in TASImage::WriteImage for meaning of NN and other
-///       .gif suffix variants
+///  - if filename contains .gif+NN, an  animated GIF file is produced See comments in TASImage::WriteImage for meaning of NN and other .gif sufix variants
+///  - if filename contains .xpm, a XPM file is produced
+///  - if filename contains .png, a PNG file is produced
+///  - if filename contains .jpg, a JPEG file is produced NOTE: JPEG's lossy compression will make all sharp edges fuzzy.
+///  - if filename contains .tiff, a TIFF file is produced
 ///  - if filename contains .C or .cxx, a C++ macro file is produced
 ///  - if filename contains .root, a Root file is produced
-///  - if filename contains .xml,  a XML file is produced
-///  - if filename contains .json,  a JSON file is produced
+///  - if filename contains .xml, a XML file is produced
+///  - if filename contains .json, a JSON file is produced
 ///
 ///  See comments in TPad::SaveAs or the TPad::Print function below
 
@@ -5566,6 +5571,7 @@ void TPad::ResizePad(Option_t *option)
 ///  - if filename contains .C or .cxx, a C++ macro file is produced
 ///  - if filename contains .root, a Root file is produced
 ///  - if filename contains .xml, a XML file is produced
+///  - if filename contains .json, a JSON file is produced
 ///
 ///   See comments in TPad::Print for the Postscript formats
 


### PR DESCRIPTION
Forum post [here](https://root-forum.cern.ch/t/saveas-pdf-cannot-handle-tmathtext/38905).