### PR TITLE
TLegend renders TMathText in canvases saved as .C

### DIFF
--- a/graf2d/graf/src/TLegendEntry.cxx
+++ b/graf2d/graf/src/TLegendEntry.cxx
@@ -121,8 +121,11 @@ void TLegendEntry::SaveEntry(std::ostream &out, const char* name )
    }
    TString objname = "NULL";
    if ( fObject ) objname = fObject->GetName();
+   TString tL(fLabel);
+   tL.ReplaceAll("\\","\\\\");
+   tL.ReplaceAll("\"","\\\"");
    out << name << "->AddEntry("<<quote<<objname<<quote<<","<<quote<<
-      fLabel.Data()<<quote<<","<<quote<<fOption.Data()<<quote<<");"<<std::endl;
+      tL.Data()<<quote<<","<<quote<<fOption.Data()<<quote<<");"<<std::endl;
    SaveFillAttributes(out,"entry",0,0);
    SaveLineAttributes(out,"entry",0,0,0);
    SaveMarkerAttributes(out,"entry",0,0,0);


### PR DESCRIPTION
Right now, `TLegendEntry::SaveEntry` fails to escape backslashes properly, causing `TMathText` to fail to be rendered by the output code from `TPad::SaveAs('.C')`. This PR corrects this, adding the escaping behavior implemented in `TH1::SavePrimitive` to `TLegendEntry::SaveEntry`.