### PR TITLE
[PyROOT] Add libexpat to known libraries

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot_experimental/pythonizations/test/import_load_libs.py
@@ -58,6 +58,7 @@ class ImportLoadLibs(unittest.TestCase):
             'cStringIO',
             'binascii',
             'libbz2',
+            'libexpat',
             # System libraries and others
             'libnss_.*',
             'ld.*',


### PR DESCRIPTION
* Pulled in, e.g., by libpython3.8 on Ubuntu 20.04

```bash
$ lddtree /lib/x86_64-linux-gnu/libpython3.8.so.1.0
libpython3.8.so.1.0 => /lib/x86_64-linux-gnu/libpython3.8.so.1.0 (interpreter => none)
    libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1
    libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0
        ld-linux-x86-64.so.2 => /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
    libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2
    libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1
    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6
```