### PR TITLE
Introducing RHistStatBox for RCanvas

### DIFF
--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -13,7 +13,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
   HEADERS
     ROOT/RCanvas.hxx
     ROOT/RFrame.hxx
-    ROOT/RMenuItem.hxx
+    ROOT/RMenuItems.hxx
     ROOT/RObjectDrawable.hxx
     ROOT/RColor.hxx
     ROOT/RDisplayItem.hxx
@@ -30,6 +30,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RPalette.hxx
     ROOT/RPaletteDrawable.hxx
     ROOT/RDrawable.hxx
+    ROOT/RDrawableRequest.hxx
     ROOT/RStyle.hxx
     ROOT/RPadDisplayItem.hxx
     ROOT/RPadExtent.hxx
@@ -42,11 +43,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
   SOURCES
     src/RCanvas.cxx
     src/RFrame.cxx
-    src/RMenuItem.cxx
+    src/RMenuItems.cxx
     src/RObjectDrawable.cxx
     src/RColor.cxx
     src/RDisplayItem.cxx
     src/RDrawable.cxx
+    src/RDrawableRequest.cxx
     src/RAttrMap.cxx
     src/RAttrBase.cxx
     src/RPalette.cxx

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -29,6 +29,7 @@
 #pragma link C++ class ROOT::Experimental::RDrawable+;
 #pragma link C++ class ROOT::Experimental::RDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RDrawableDisplayItem+;
+#pragma link C++ class ROOT::Experimental::RIndirectDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RObjectDisplayItem+;
 
 #pragma link C++ class ROOT::Experimental::Internal::RIOSharedBase+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -31,6 +31,7 @@
 #pragma link C++ class ROOT::Experimental::RDrawableDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RIndirectDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RObjectDisplayItem+;
+#pragma link C++ class ROOT::Experimental::RDrawableReply+;
 #pragma link C++ class ROOT::Experimental::RDrawableRequest+;
 
 #pragma link C++ class ROOT::Experimental::Internal::RIOSharedBase+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -45,6 +45,7 @@
 #pragma link C++ class std::vector<ROOT::Experimental::Detail::RMenuArgument>+;
 #pragma link C++ class ROOT::Experimental::Detail::RArgsMenuItem+;
 #pragma link C++ class ROOT::Experimental::RMenuItems+;
+#pragma link C++ class ROOT::Experimental::RDrawableMenuRequest+;
 #pragma link C++ class ROOT::Experimental::RObjectDrawable+;
 #pragma link C++ class ROOT::Experimental::RPadUserAxisBase+;
 #pragma link C++ class ROOT::Experimental::RPadCartesianUserAxis+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -50,7 +50,7 @@
 #pragma link C++ class ROOT::Experimental::RPadCartesianUserAxis+;
 #pragma link C++ class ROOT::Experimental::RPadExtent+;
 #pragma link C++ class ROOT::Experimental::RPadPos+;
-#pragma link C++ struct ROOT::Experimental::RChangeAttr+;
+#pragma link C++ class ROOT::Experimental::RChangeAttrRequest+;
 #pragma link C++ class ROOT::Experimental::RPadBase+;
 #pragma link C++ class ROOT::Experimental::RPad+;
 #pragma link C++ class ROOT::Experimental::RCanvas+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -36,7 +36,6 @@
 #pragma link C++ class ROOT::Experimental::Internal::RIOShared<TObject>+;
 #pragma link C++ class ROOT::Experimental::Internal::RIOShared<ROOT::Experimental::RDrawable>+;
 
-
 #pragma link C++ class ROOT::Experimental::Detail::RMenuItem+;
 #pragma link C++ class std::vector<ROOT::Experimental::Detail::RMenuItem*>+;
 #pragma link C++ class ROOT::Experimental::Detail::RCheckedMenuItem+;
@@ -49,6 +48,7 @@
 #pragma link C++ class ROOT::Experimental::RPadCartesianUserAxis+;
 #pragma link C++ class ROOT::Experimental::RPadExtent+;
 #pragma link C++ class ROOT::Experimental::RPadPos+;
+#pragma link C++ struct ROOT::Experimental::RChangeAttr+;
 #pragma link C++ class ROOT::Experimental::RPadBase+;
 #pragma link C++ class ROOT::Experimental::RPad+;
 #pragma link C++ class ROOT::Experimental::RCanvas+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -33,6 +33,7 @@
 #pragma link C++ class ROOT::Experimental::RObjectDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RDrawableReply+;
 #pragma link C++ class ROOT::Experimental::RDrawableRequest+;
+#pragma link C++ class ROOT::Experimental::RDrawableExecRequest+;
 
 #pragma link C++ class ROOT::Experimental::Internal::RIOSharedBase+;
 #pragma link C++ class ROOT::Experimental::Internal::RIOShared<TObject>+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -31,6 +31,7 @@
 #pragma link C++ class ROOT::Experimental::RDrawableDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RIndirectDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RObjectDisplayItem+;
+#pragma link C++ class ROOT::Experimental::RDrawableRequest+;
 
 #pragma link C++ class ROOT::Experimental::Internal::RIOSharedBase+;
 #pragma link C++ class ROOT::Experimental::Internal::RIOShared<TObject>+;

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -43,26 +43,26 @@ class RAttrAxis : public RAttrBase {
    RAttrText &AttrText() { return fAttrText; }
 
    // min range, graphics will not show value less then this
-   void SetMin(double min) { SetValue("min", min); }
-   void SetMax(double max) { SetValue("max", max); }
+   RAttrAxis &SetMin(double min) { SetValue("min", min); return *this; }
+   RAttrAxis &SetMax(double max) { SetValue("max", max); return *this; }
    double GetMin() const { return GetValue<double>("min"); }
    double GetMax() const { return GetValue<double>("max"); }
 
-   void SetMinMax(double min, double max) { SetMin(min); SetMax(max); }
+   RAttrAxis &SetMinMax(double min, double max) { SetMin(min); SetMax(max); return *this; }
    void ClearMinMax() { ClearValue("min"); ClearValue("max"); }
 
-   void SetZoomMin(double min) { SetValue("zoommin", min); }
-   void SetZoomMax(double max) { SetValue("zoommax", max); }
+   RAttrAxis &SetZoomMin(double min) { SetValue("zoommin", min); return *this; }
+   RAttrAxis &SetZoomMax(double max) { SetValue("zoommax", max); return *this; }
    double GetZoomMin() const { return GetValue<double>("zoommin"); }
    double GetZoomMax() const { return GetValue<double>("zoommax"); }
 
-   void SetZoomMinMax(double min, double max) { SetZoomMin(min); SetZoomMax(max); }
+   RAttrAxis &SetZoomMinMax(double min, double max) { SetZoomMin(min); SetZoomMax(max); return *this; }
    void ClearZoomMinMax() { ClearValue("zoommin"); ClearValue("zoommax"); }
 
-   void SetLog(bool on = true) { SetValue("log", on); }
+   RAttrAxis &SetLog(bool on = true) { SetValue("log", on); return *this; }
    bool GetLog() const { return GetValue<bool>("log"); }
 
-   void SetInvert(bool on = true) { SetValue("invert", on); }
+   RAttrAxis &SetInvert(bool on = true) { SetValue("invert", on); return *this; }
    bool GetInvert() const { return GetValue<bool>("invert"); }
 
 };

--- a/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
@@ -151,6 +151,7 @@ protected:
    void SetValue(const std::string &name, double value);
    void SetValue(const std::string &name, int value);
    void SetValue(const std::string &name, const std::string &value);
+   void SetValue(const std::string &name, const RPadLength &value);
 
    const std::string &GetPrefix() const { return fPrefix; }
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -13,6 +13,8 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+
+#include <ROOT/RPadLength.hxx>
 #include <ROOT/RMakeUnique.hxx>
 
 namespace ROOT {
@@ -142,6 +144,7 @@ public:
    RAttrMap &AddInt(const std::string &name, int value) { m[name] = std::make_unique<IntValue_t>(value); return *this; }
    RAttrMap &AddDouble(const std::string &name, double value) { m[name] = std::make_unique<DoubleValue_t>(value); return *this; }
    RAttrMap &AddString(const std::string &name, const std::string &value) { m[name] = std::make_unique<StringValue_t>(value); return *this; }
+   RAttrMap &AddPadLength(const std::string &name, const RPadLength &value) { m[name] = std::make_unique<StringValue_t>(value.AsString()); return *this; }
    RAttrMap &AddDefaults(const RAttrBase &vis);
 
    RAttrMap(const RAttrMap &src)
@@ -182,20 +185,20 @@ template<> bool RAttrMap::Value_t::Get<bool>() const;
 template<> int RAttrMap::Value_t::Get<int>() const;
 template<> double RAttrMap::Value_t::Get<double>() const;
 template<> std::string RAttrMap::Value_t::Get<std::string>() const;
+template<> RPadLength RAttrMap::Value_t::Get<RPadLength>() const;
 
 template<> bool RAttrMap::Value_t::GetValue<bool,void>(const Value_t *rec);
 template<> int RAttrMap::Value_t::GetValue<int,void>(const Value_t *rec);
 template<> double RAttrMap::Value_t::GetValue<double,void>(const Value_t *rec);
 template<> std::string RAttrMap::Value_t::GetValue<std::string,void>(const Value_t *rec);
+template<> RPadLength RAttrMap::Value_t::GetValue<RPadLength,void>(const Value_t *rec);
+
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,void>(const Value_t *rec);
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,bool>(const Value_t *rec);
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,int>(const Value_t *rec);
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,double>(const Value_t *rec);
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,std::string>(const Value_t *rec);
-
-
-//////////////////////////////////////////////////////////////////////////
-
+template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,RPadLength>(const Value_t *rec);
 
 } // namespace Experimental
 } // namespace ROOT

--- a/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
@@ -164,12 +164,15 @@ public:
       return (entry != m.end()) ? entry->second.get() : nullptr;
    }
 
+   /** Clear specified attribute */
    void Clear(const std::string &name)
    {
       auto entry = m.find(name);
       if (entry != m.end())
          m.erase(entry);
    }
+
+   bool Change(const std::string &name, Value_t *value = nullptr);
 
    auto begin() const { return m.begin(); }
    auto end() const { return m.end(); }

--- a/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
@@ -19,6 +19,12 @@
 namespace ROOT {
 namespace Experimental {
 
+struct RChangeAttr {
+   std::string id;      ///< drawable id where attribute is changed
+   std::string name;    ///< attribute name
+   std::unique_ptr<RAttrMap::Value_t> value;  ///< kind of the value
+};
+
 /** \class RCanvas
 \ingroup GpadROOT7
 \brief A window's topmost `RPad`.
@@ -38,7 +44,7 @@ private:
    std::array<RPadLength::Pixel, 2> fSize;
 
    /// Modify counter, incremented every time canvas is changed
-   uint64_t fModified{0}; ///<!
+   Version_t fModified{1}; ///<!
 
    /// The painter of this canvas, bootstrapping the graphics connection.
    /// Unmapped canvases (those that never had `Draw()` invoked) might not have
@@ -50,6 +56,11 @@ private:
 
    /// Disable assignment for now.
    RCanvas &operator=(const RCanvas &) = delete;
+
+   bool ApplyAttrChanges(const std::vector<RChangeAttr> &vect);
+
+   // Increment modify counter
+   uint64_t IncModified() { return ++fModified; }
 
 public:
    static std::shared_ptr<RCanvas> Create(const std::string &title);
@@ -102,8 +113,11 @@ public:
       return fPainter->AddPanel(panel->GetWindow());
    }
 
-   // Indicates that primitives list was changed or any primitive was modified
-   void Modified() { fModified++; }
+   // Get modify counter
+   uint64_t GetModified() const { return fModified; }
+
+   // Set newest version to all primitives
+   void Modified() { SetDrawableVersion(IncModified()); }
 
    // Return if canvas was modified and not yet updated
    bool IsModified() const;

--- a/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
@@ -21,9 +21,6 @@ namespace ROOT {
 namespace Experimental {
 
 class RChangeAttrRequest : public RDrawableRequest {
-   /* FIXME: values from vectors can be packed as special simple class like RChangeAttr
-      But such class with std::unique_ptr<RAttrMap::Value_t> as member fails for TCollectionProxy
-      Need to be fixed in the future */
    std::vector<std::string> ids;    ///< array of ids
    std::vector<std::string> names;  ///< array of attribute names
    std::vector<std::unique_ptr<RAttrMap::Value_t>> values; ///< array of values
@@ -31,6 +28,8 @@ class RChangeAttrRequest : public RDrawableRequest {
    RChangeAttrRequest(const RChangeAttrRequest &) = delete;
    RChangeAttrRequest& operator=(const RChangeAttrRequest &) = delete;
 public:
+   RChangeAttrRequest() = default; // for I/O
+   virtual ~RChangeAttrRequest() = default;
    std::unique_ptr<RDrawableReply> Process() override;
    bool NeedCanvasUpdate() const override { return fNeedUpdate; }
 };

--- a/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
@@ -11,6 +11,7 @@
 
 #include "ROOT/RPadBase.hxx"
 #include "ROOT/RVirtualCanvasPainter.hxx"
+#include "ROOT/RDrawableRequest.hxx"
 
 #include <memory>
 #include <string>

--- a/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
@@ -18,6 +18,7 @@ namespace Experimental {
 
 class RDrawable;
 class RStyle;
+class RAttrMap;
 
 /** \class RDisplayItem
 \ingroup GpadROOT7
@@ -75,6 +76,30 @@ public:
    }
 
 };
+
+
+/** \class RDrawableDisplayItem
+\ingroup GpadROOT7
+\brief Generic display item for RDrawable, just reference drawable itself
+\author Sergey Linev <s.linev@gsi.de>
+\date 2017-05-31
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RIndirectDisplayItem : public RDisplayItem {
+protected:
+
+   const RAttrMap *fAttr{nullptr};        ///< pointer on drawable attributes
+   const std::string *fCssClass{nullptr}; ///< pointer on drawable class
+   const std::string *fId{nullptr};       ///< pointer on drawable id
+
+public:
+
+   RIndirectDisplayItem() = default;
+
+   RIndirectDisplayItem(const RDrawable &dr);
+};
+
 
 /** \class RObjectDisplayItem
 \ingroup GpadROOT7

--- a/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
@@ -33,9 +33,11 @@ protected:
    std::string fObjectID;   ///< unique object identifier
    RStyle *fStyle{nullptr}; ///< style object
    unsigned fIndex{0};      ///<! index inside current pad, used to produce fully-qualified id, not send to client
+   bool fDummy{false};      ///< if true, just placeholder for drawable which does not changed
 
 public:
    RDisplayItem() = default;
+   RDisplayItem(bool dummy) : RDisplayItem() { fDummy = dummy; }
    virtual ~RDisplayItem() {}
 
    void SetObjectID(const std::string &id) { fObjectID = id; }

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -27,6 +27,7 @@ class RDisplayItem;
 class RIndirectDisplayItem;
 class RLegend;
 class RCanvas;
+class RChangeAttrRequest;
 
 namespace Internal {
 
@@ -105,7 +106,7 @@ friend class RAttrBase;
 friend class RStyle;
 friend class RLegend; // to access CollectShared method
 friend class RIndirectDisplayItem;  // to access attributes and other members
-friend class RCanvas; // access SetDrawableVersion
+friend class RChangeAttrRequest; // access SetDrawableVersion and AttrMap
 
 public:
 
@@ -190,7 +191,6 @@ class RDrawableRequest {
 
 protected:
 
-
    /// Returns canvas assign to request, should be accessed from Process method
    const RCanvas *GetCanvas() const { return fCanvas; }
 
@@ -210,7 +210,12 @@ public:
 
    virtual ~RDrawableRequest();
 
+   bool ShouldBeReplyed() const { return GetRequestId() > 0; }
+
    virtual std::unique_ptr<RDrawableReply> Process() { return nullptr; }
+
+   virtual bool NeedCanvasUpdate() const { return false; }
+
 };
 
 

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -173,90 +173,6 @@ inline auto GetDrawable(const std::shared_ptr<DRAWABLE> &drawable)
 {
    return drawable;
 }
-
-
-
-/** \class RDrawableReply
-\ingroup GpadROOT7
-\brief Base class for replies on RDrawableRequest
-\author Sergey Linev <s.linev@gsi.de>
-\date 2020-04-14
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-*/
-
-class RDrawableReply {
-   uint64_t reqid{0}; ///< request id
-
-public:
-
-   void SetRequestId(uint64_t _reqid) { reqid = _reqid; }
-   uint64_t GetRequestId() const { return reqid; }
-
-   virtual ~RDrawableReply();
-};
-
-
-/** \class RDrawableRequest
-\ingroup GpadROOT7
-\brief Base class for requests which can be submitted from the clients
-\author Sergey Linev <s.linev@gsi.de>
-\date 2020-04-14
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-*/
-
-class RDrawableRequest {
-   std::string id; ///< drawable id
-   uint64_t reqid{0}; ///< request id
-
-   const RCanvas *fCanvas{nullptr}; ///<! pointer on canvas, can be used in Process
-   const RPadBase *fPad{nullptr};   ///<! pointer on pad with drawable, can be used in Process
-   RDrawable *fDrawable{nullptr};   ///<! pointer on drawable, can be used in Process
-
-protected:
-
-   /// Returns canvas assign to request, should be accessed from Process method
-   const RCanvas *GetCanvas() const { return fCanvas; }
-
-   /// Returns canvas assign to request, should be accessed from Process method
-   const RPadBase *GetPad() const { return fPad; }
-
-   /// Returns drawable assign to request, should be accessed from Process method
-   RDrawable *GetDrawable() { return fDrawable; }
-
-public:
-   const std::string &GetId() const { return id; }
-   uint64_t GetRequestId() const { return reqid; }
-
-   void SetCanvas(const RCanvas *canv) { fCanvas = canv; }
-   void SetPad(const RPadBase *pad) { fPad = pad; }
-   void SetDrawable(RDrawable *dr) { fDrawable = dr; }
-
-   virtual ~RDrawableRequest();
-
-   bool ShouldBeReplyed() const { return GetRequestId() > 0; }
-
-   virtual std::unique_ptr<RDrawableReply> Process() { return nullptr; }
-
-   virtual bool NeedCanvasUpdate() const { return false; }
-};
-
-
-/** \class RDrawableExecRequest
-\ingroup GpadROOT7
-\brief Base class for requests which can be submitted from the clients
-\author Sergey Linev <s.linev@gsi.de>
-\date 2020-04-14
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-*/
-
-class RDrawableExecRequest : public RDrawableRequest {
-   std::string exec; ///< that to execute
-
-public:
-
-   std::unique_ptr<RDrawableReply> Process() override;
-
-};
 
 } // namespace Experimental
 } // namespace ROOT

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -28,6 +28,7 @@ class RIndirectDisplayItem;
 class RLegend;
 class RCanvas;
 class RChangeAttrRequest;
+class RDrawableMenuRequest;
 
 namespace Internal {
 
@@ -107,6 +108,7 @@ friend class RStyle;
 friend class RLegend; // to access CollectShared method
 friend class RIndirectDisplayItem;  // to access attributes and other members
 friend class RChangeAttrRequest; // access SetDrawableVersion and AttrMap
+friend class RDrawableMenuRequest; // access PopulateMenu method
 
 public:
 
@@ -136,6 +138,9 @@ protected:
    virtual void SetDrawableVersion(Version_t vers) { fVersion = vers; }
    Version_t GetVersion() const { return fVersion; }
 
+   /** Method can be used to provide menu items for the drawn object */
+   virtual void PopulateMenu(RMenuItems &) {}
+
 public:
 
    explicit RDrawable(const std::string &type) : fCssType(type) {}
@@ -143,9 +148,6 @@ public:
    virtual ~RDrawable();
 
    // copy constructor and assign operator !!!
-
-   /** Method can be used to provide menu items for the drawn object */
-   virtual void PopulateMenu(RMenuItems &) {}
 
    virtual void Execute(const std::string &);
 
@@ -215,11 +217,7 @@ public:
    virtual std::unique_ptr<RDrawableReply> Process() { return nullptr; }
 
    virtual bool NeedCanvasUpdate() const { return false; }
-
 };
-
-
-
 
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -168,22 +168,49 @@ inline auto GetDrawable(const std::shared_ptr<DRAWABLE> &drawable)
    return drawable;
 }
 
+class RDrawableReply {
+   uint64_t reqid{0}; ///< request id
+
+public:
+
+   void SetRequestId(uint64_t _reqid) { reqid = _reqid; }
+   uint64_t GetRequestId() const { return reqid; }
+
+   virtual ~RDrawableReply();
+};
+
+
 class RDrawableRequest {
    std::string id; ///< drawable id
    uint64_t reqid{0}; ///< request id
+
+   const RCanvas *fCanvas{nullptr}; ///<! pointer on canvas, can be used in Process
+   const RPadBase *fPad{nullptr};   ///<! pointer on pad with drawable, can be used in Process
+   RDrawable *fDrawable{nullptr};   ///<! pointer on drawable, can be used in Process
+
+protected:
+
+
+   /// Returns canvas assign to request, should be accessed from Process method
+   const RCanvas *GetCanvas() const { return fCanvas; }
+
+   /// Returns canvas assign to request, should be accessed from Process method
+   const RPadBase *GetPad() const { return fPad; }
+
+   /// Returns drawable assign to request, should be accessed from Process method
+   RDrawable *GetDrawable() { return fDrawable; }
+
 public:
    const std::string &GetId() const { return id; }
    uint64_t GetRequestId() const { return reqid; }
 
-   void CopyIds(const RDrawableRequest *src)
-   {
-      id = src->id;
-      reqid = src->reqid;
-   }
+   void SetCanvas(const RCanvas *canv) { fCanvas = canv; }
+   void SetPad(const RPadBase *pad) { fPad = pad; }
+   void SetDrawable(RDrawable *dr) { fDrawable = dr; }
 
    virtual ~RDrawableRequest();
 
-   virtual std::unique_ptr<RDrawableRequest> Process(std::shared_ptr<RDrawable> &) { return nullptr; }
+   virtual std::unique_ptr<RDrawableReply> Process() { return nullptr; }
 };
 
 

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -29,6 +29,7 @@ class RLegend;
 class RCanvas;
 class RChangeAttrRequest;
 class RDrawableMenuRequest;
+class RDrawableExecRequest;
 
 namespace Internal {
 
@@ -109,6 +110,7 @@ friend class RLegend; // to access CollectShared method
 friend class RIndirectDisplayItem;  // to access attributes and other members
 friend class RChangeAttrRequest; // access SetDrawableVersion and AttrMap
 friend class RDrawableMenuRequest; // access PopulateMenu method
+friend class RDrawableExecRequest; // access Execute() method
 
 public:
 
@@ -138,18 +140,18 @@ protected:
    virtual void SetDrawableVersion(Version_t vers) { fVersion = vers; }
    Version_t GetVersion() const { return fVersion; }
 
-   /** Method can be used to provide menu items for the drawn object */
-   virtual void PopulateMenu(RMenuItems &) {}
+   virtual void PopulateMenu(RMenuItems &);
+
+   virtual void Execute(const std::string &);
+
+   RDrawable(const RDrawable &) = delete;
+   RDrawable &operator=(const RDrawable &) = delete;
 
 public:
 
    explicit RDrawable(const std::string &type) : fCssType(type) {}
 
    virtual ~RDrawable();
-
-   // copy constructor and assign operator !!!
-
-   virtual void Execute(const std::string &);
 
    virtual void UseStyle(const std::shared_ptr<RStyle> &style) { fStyle = style; }
    void ClearStyle() { UseStyle(nullptr); }
@@ -165,11 +167,22 @@ public:
 
 /// Central method to insert drawable in list of pad primitives
 /// By default drawable placed as is.
+
 template <class DRAWABLE, std::enable_if_t<std::is_base_of<RDrawable, DRAWABLE>{}>* = nullptr>
 inline auto GetDrawable(const std::shared_ptr<DRAWABLE> &drawable)
 {
    return drawable;
 }
+
+
+
+/** \class RDrawableReply
+\ingroup GpadROOT7
+\brief Base class for replies on RDrawableRequest
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-14
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RDrawableReply {
    uint64_t reqid{0}; ///< request id
@@ -182,6 +195,14 @@ public:
    virtual ~RDrawableReply();
 };
 
+
+/** \class RDrawableRequest
+\ingroup GpadROOT7
+\brief Base class for requests which can be submitted from the clients
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-14
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RDrawableRequest {
    std::string id; ///< drawable id
@@ -219,6 +240,23 @@ public:
    virtual bool NeedCanvasUpdate() const { return false; }
 };
 
+
+/** \class RDrawableExecRequest
+\ingroup GpadROOT7
+\brief Base class for requests which can be submitted from the clients
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-14
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RDrawableExecRequest : public RDrawableRequest {
+   std::string exec; ///< that to execute
+
+public:
+
+   std::unique_ptr<RDrawableReply> Process() override;
+
+};
 
 } // namespace Experimental
 } // namespace ROOT

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -86,7 +86,8 @@ public:
    void reset() { fShared.reset(); fIO = nullptr; }
 };
 
-}
+} // namespace Internal
+
 
 /** \class RDrawable
 \ingroup GpadROOT7
@@ -166,6 +167,28 @@ inline auto GetDrawable(const std::shared_ptr<DRAWABLE> &drawable)
 {
    return drawable;
 }
+
+class RDrawableRequest {
+   std::string id; ///< drawable id
+   uint64_t reqid{0}; ///< request id
+public:
+   const std::string &GetId() const { return id; }
+   uint64_t GetRequestId() const { return reqid; }
+
+   void CopyIds(const RDrawableRequest *src)
+   {
+      id = src->id;
+      reqid = src->reqid;
+   }
+
+   virtual ~RDrawableRequest();
+
+   virtual std::unique_ptr<RDrawableRequest> Process(std::shared_ptr<RDrawable> &) { return nullptr; }
+};
+
+
+
+
 
 } // namespace Experimental
 } // namespace ROOT

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -26,7 +26,7 @@ class RAttrBase;
 class RDisplayItem;
 class RIndirectDisplayItem;
 class RLegend;
-
+class RCanvas;
 
 namespace Internal {
 
@@ -104,6 +104,11 @@ friend class RAttrBase;
 friend class RStyle;
 friend class RLegend; // to access CollectShared method
 friend class RIndirectDisplayItem;  // to access attributes and other members
+friend class RCanvas; // access SetDrawableVersion
+
+public:
+
+using Version_t = uint64_t;
 
 private:
    RAttrMap fAttr;               ///< attributes values
@@ -111,6 +116,7 @@ private:
    std::string fCssType;         ///<! drawable type, not stored in the root file, must be initialized in constructor
    std::string fCssClass;        ///< user defined drawable class, can later go inside map
    std::string fId;              ///< optional object identifier, may be used in CSS as well
+   Version_t fVersion{1};        ///<! drawable version, changed from the canvas
 
 protected:
 
@@ -123,7 +129,10 @@ protected:
 
    bool MatchSelector(const std::string &selector) const;
 
-   virtual std::unique_ptr<RDisplayItem> Display(const RPadBase &) const;
+   virtual std::unique_ptr<RDisplayItem> Display(const RPadBase &, Version_t) const;
+
+   virtual void SetDrawableVersion(Version_t vers) { fVersion = vers; }
+   Version_t GetVersion() const { return fVersion; }
 
 public:
 
@@ -148,7 +157,6 @@ public:
 
    const std::string &GetId() const { return fId; }
    void SetId(const std::string &id) { fId = id; }
-
 };
 
 /// Central method to insert drawable in list of pad primitives

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -24,6 +24,7 @@ class RMenuItems;
 class RPadBase;
 class RAttrBase;
 class RDisplayItem;
+class RIndirectDisplayItem;
 class RLegend;
 
 
@@ -102,6 +103,7 @@ friend class RPadBase; // to access Display method and IsFrameRequired
 friend class RAttrBase;
 friend class RStyle;
 friend class RLegend; // to access CollectShared method
+friend class RIndirectDisplayItem;  // to access attributes and other members
 
 private:
    RAttrMap fAttr;               ///< attributes values
@@ -121,7 +123,7 @@ protected:
 
    bool MatchSelector(const std::string &selector) const;
 
-   virtual std::unique_ptr<RDisplayItem> Display() const;
+   virtual std::unique_ptr<RDisplayItem> Display(const RPadBase &) const;
 
 public:
 

--- a/graf2d/gpadv7/inc/ROOT/RDrawableRequest.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawableRequest.hxx
@@ -1,0 +1,110 @@
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RDrawableRequest
+#define ROOT7_RDrawableRequest
+
+#include <string>
+#include <cstdint>
+#include <memory>
+
+namespace ROOT {
+namespace Experimental {
+
+class RCanvas;
+class RPadBase;
+class RDrawable;
+
+/** \class RDrawableReply
+\ingroup GpadROOT7
+\brief Base class for replies on RDrawableRequest
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-14
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RDrawableReply {
+   uint64_t reqid{0}; ///< request id
+
+public:
+
+   void SetRequestId(uint64_t _reqid) { reqid = _reqid; }
+   uint64_t GetRequestId() const { return reqid; }
+
+   virtual ~RDrawableReply();
+};
+
+
+/** \class RDrawableRequest
+\ingroup GpadROOT7
+\brief Base class for requests which can be submitted from the clients
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-14
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RDrawableRequest {
+   std::string id; ///< drawable id
+   uint64_t reqid{0}; ///< request id
+
+   const RCanvas *fCanvas{nullptr}; ///<! pointer on canvas, can be used in Process
+   const RPadBase *fPad{nullptr};   ///<! pointer on pad with drawable, can be used in Process
+   RDrawable *fDrawable{nullptr};   ///<! pointer on drawable, can be used in Process
+
+protected:
+
+   /// Returns canvas assign to request, should be accessed from Process method
+   const RCanvas *GetCanvas() const { return fCanvas; }
+
+   /// Returns canvas assign to request, should be accessed from Process method
+   const RPadBase *GetPad() const { return fPad; }
+
+   /// Returns drawable assign to request, should be accessed from Process method
+   RDrawable *GetDrawable() { return fDrawable; }
+
+public:
+   const std::string &GetId() const { return id; }
+   uint64_t GetRequestId() const { return reqid; }
+
+   void SetCanvas(const RCanvas *canv) { fCanvas = canv; }
+   void SetPad(const RPadBase *pad) { fPad = pad; }
+   void SetDrawable(RDrawable *dr) { fDrawable = dr; }
+
+   virtual ~RDrawableRequest();
+
+   bool ShouldBeReplyed() const { return GetRequestId() > 0; }
+
+   virtual std::unique_ptr<RDrawableReply> Process() { return nullptr; }
+
+   virtual bool NeedCanvasUpdate() const { return false; }
+};
+
+
+/** \class RDrawableExecRequest
+\ingroup GpadROOT7
+\brief Base class for requests which can be submitted from the clients
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-14
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RDrawableExecRequest : public RDrawableRequest {
+   std::string exec; ///< that to execute
+
+public:
+
+   std::unique_ptr<RDrawableReply> Process() override;
+
+};
+
+
+} // namespace Experimental
+} // namespace ROOT
+
+
+#endif

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -27,8 +27,9 @@ namespace Experimental {
 
 /** \class RFrame
 \ingroup GpadROOT7
-\brief Holds a user coordinate system with a palette.
+\brief Holds an area where drawing on user coordinate-system can be performed.
 \author Axel Naumann <axel@cern.ch>
+\author Sergey Linev <s.linev@gsi.de>
 \date 2017-09-26
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
@@ -37,6 +38,11 @@ class RFrame : public RDrawable  {
 
    friend class RPadBase;
 
+   class RFrameAttrs : public RAttrBase {
+      friend class RFrame;
+      R__ATTR_CLASS(RFrameAttrs, "", AddBool("gridx", false).AddBool("gridy",false));
+   };
+
 private:
    RAttrMargins fMargins{this, "margin_"};     ///<!
    RAttrLine fAttrBorder{this, "border_"};     ///<!
@@ -44,6 +50,8 @@ private:
    RAttrAxis fAttrX{this, "x_"};               ///<!
    RAttrAxis fAttrY{this, "y_"};               ///<!
    RAttrAxis fAttrZ{this, "z_"};               ///<!
+   RFrameAttrs fAttr{this,""};                 ///<! own frame attributes
+
 
    /// Mapping of user coordinates to normal coordinates, one entry per dimension.
    std::vector<std::unique_ptr<RPadUserAxisBase>> fUserCoord;
@@ -87,6 +95,12 @@ public:
    const RAttrAxis &GetAttrZ() const { return fAttrZ; }
    RFrame &SetAttrZ(const RAttrAxis &axis) { fAttrZ = axis; return *this; }
    RAttrAxis &AttrZ() { return fAttrZ; }
+
+   RFrame &SetGridX(bool on = true) { fAttr.SetValue("gridx", on); return *this; }
+   bool GetGridX() const { return fAttr.GetValue<bool>("gridx"); }
+
+   RFrame &SetGridY(bool on = true) { fAttr.SetValue("gridy", on); return *this; }
+   bool GetGridY() const { return fAttr.GetValue<bool>("gridy"); }
 
    void PopulateMenu(RMenuItems &) override;
 

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -68,6 +68,10 @@ private:
    /// Constructor taking user coordinate system, position and extent.
    explicit RFrame(std::vector<std::unique_ptr<RPadUserAxisBase>> &&coords);
 
+protected:
+
+   void PopulateMenu(RMenuItems &) override;
+
 public:
 
    RFrame(TRootIOCtor*) : RFrame() {}
@@ -101,8 +105,6 @@ public:
 
    RFrame &SetGridY(bool on = true) { fAttr.SetValue("gridy", on); return *this; }
    bool GetGridY() const { return fAttr.GetValue<bool>("gridy"); }
-
-   void PopulateMenu(RMenuItems &) override;
 
    void Execute(const std::string &) override;
 

--- a/graf2d/gpadv7/inc/ROOT/RMenuItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RMenuItem.hxx
@@ -13,6 +13,8 @@
 #include <vector>
 #include <memory>
 
+#include <ROOT/RDrawable.hxx>
+
 class TClass;
 
 namespace ROOT {
@@ -148,16 +150,24 @@ public:
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RMenuItems {
+class RMenuItems : public RDrawableReply {
 protected:
    std::string fId;                                        ///< object identifier
+   std::string fSpecifier;                                 ///<! extra specifier, used only on server
    std::vector<std::unique_ptr<Detail::RMenuItem>> fItems; ///< list of items in the menu
 public:
-   void SetFullId(const std::string &id) { fId = id; }
-   const std::string &GetFullId() const { return fId; }
+   RMenuItems() = default;
 
-   std::string GetDrawableId();
-   std::string GetSpecifier();
+   RMenuItems(const std::string &_id, const std::string &_specifier)
+   {
+      fId = _id;
+      fSpecifier = _specifier;
+   }
+
+   virtual ~RMenuItems();
+
+   const std::string &GetFullId() const { return fId; }
+   const std::string &GetSpecifier() const { return fSpecifier; }
 
    auto Size() const { return fItems.size(); }
 
@@ -179,6 +189,23 @@ public:
 
    void PopulateObjectMenu(void *obj, TClass *cl);
 };
+
+
+/** \class RDrawableMenuRequest
+\ingroup GpadROOT7
+\brief Request menu items for the drawable object
+\author Sergey Linev
+\date 2020-04-14
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RDrawableMenuRequest : public RDrawableRequest {
+   std::string menukind;
+   std::string menureqid;
+public:
+   std::unique_ptr<RDrawableReply> Process() override;
+};
+
 
 } // namespace Experimental
 } // namespace ROOT

--- a/graf2d/gpadv7/inc/ROOT/RMenuItems.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RMenuItems.hxx
@@ -1,19 +1,19 @@
 /*************************************************************************
- * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_RMenuItem
-#define ROOT7_RMenuItem
+#ifndef ROOT7_RMenuItems
+#define ROOT7_RMenuItems
 
 #include <string>
 #include <vector>
 #include <memory>
 
-#include <ROOT/RDrawable.hxx>
+#include <ROOT/RDrawableRequest.hxx>
 
 class TClass;
 

--- a/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
@@ -36,7 +36,7 @@ protected:
 
    void CollectShared(Internal::RIOSharedVector_t &vect) final { vect.emplace_back(&fObj); }
 
-   std::unique_ptr<RDisplayItem> Display() const override;
+   std::unique_ptr<RDisplayItem> Display(const RPadBase &) const override;
 
 public:
    RObjectDrawable() : RDrawable("tobject") {}

--- a/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
@@ -36,7 +36,7 @@ protected:
 
    void CollectShared(Internal::RIOSharedVector_t &vect) final { vect.emplace_back(&fObj); }
 
-   std::unique_ptr<RDisplayItem> Display(const RPadBase &) const override;
+   std::unique_ptr<RDisplayItem> Display(const RPadBase &, Version_t) const override;
 
 public:
    RObjectDrawable() : RDrawable("tobject") {}

--- a/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
@@ -38,16 +38,15 @@ protected:
 
    std::unique_ptr<RDisplayItem> Display(const RPadBase &, Version_t) const override;
 
-   /// Fill menu items for the object
    void PopulateMenu(RMenuItems &) final;
+
+   void Execute(const std::string &) final;
 
 public:
    RObjectDrawable() : RDrawable("tobject") {}
 
    RObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : RDrawable("tobject"), fObj(obj), fOpts(opt) {}
 
-   /// Executes menu item
-   void Execute(const std::string &) final;
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
@@ -38,13 +38,13 @@ protected:
 
    std::unique_ptr<RDisplayItem> Display(const RPadBase &, Version_t) const override;
 
+   /// Fill menu items for the object
+   void PopulateMenu(RMenuItems &) final;
+
 public:
    RObjectDrawable() : RDrawable("tobject") {}
 
    RObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : RDrawable("tobject"), fObj(obj), fOpts(opt) {}
-
-   /// Fill menu items for the object
-   void PopulateMenu(RMenuItems &) final;
 
    /// Executes menu item
    void Execute(const std::string &) final;

--- a/graf2d/gpadv7/inc/ROOT/RPad.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPad.hxx
@@ -34,7 +34,7 @@ class RPad: public RPadBase {
 
 protected:
 
-   std::unique_ptr<RDisplayItem> Display() const final;
+   std::unique_ptr<RDisplayItem> Display(const RPadBase &) const final;
 
 
 public:

--- a/graf2d/gpadv7/inc/ROOT/RPad.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPad.hxx
@@ -34,8 +34,7 @@ class RPad: public RPadBase {
 
 protected:
 
-   std::unique_ptr<RDisplayItem> Display(const RPadBase &) const final;
-
+   std::unique_ptr<RDisplayItem> Display(const RPadBase &, Version_t) const final;
 
 public:
    /// Create a topmost, non-paintable pad.

--- a/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
@@ -134,6 +134,8 @@ public:
 
    std::shared_ptr<RDrawable> FindPrimitiveByDisplayId(const std::string &display_id) const;
 
+   const RPadBase *FindPadForPrimitiveWithDisplayId(const std::string &display_id) const;
+
    /// Get all primitives contained in the pad.
    auto GetPrimitives() const
    {

--- a/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
@@ -62,7 +62,9 @@ protected:
 
    void CollectShared(Internal::RIOSharedVector_t &) override;
 
-   void DisplayPrimitives(RPadBaseDisplayItem &paditem) const;
+   void DisplayPrimitives(RPadBaseDisplayItem &paditem, Version_t vers) const;
+
+   void SetDrawableVersion(Version_t vers) override;
 
 public:
 

--- a/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
@@ -113,6 +113,9 @@ public:
    /// Constructor from a `Normal` coordinate.
    RPadLength(Normal normal): RPadLength() { SetNormal(normal.fVal); }
 
+   /// By default all numeric values are normal values
+   RPadLength(double normal): RPadLength() { SetNormal(normal); }
+
    /// Constructor from a `Pixel` coordinate.
    RPadLength(Pixel px): RPadLength() { SetPixel(px.fVal); }
 
@@ -125,6 +128,9 @@ public:
    /// Constructor for normal, pixel and user coordinate.
    RPadLength(Normal normal, Pixel px, User user): RPadLength() { SetUser(user.fVal); SetPixel(px.fVal); SetNormal(normal.fVal);  }
 
+   /// Constructor from string representation
+   RPadLength(const std::string &csscode) : RPadLength() { if (!csscode.empty()) ParseString(csscode); }
+
    bool HasNormal() const { return fArr.size() > 0; }
    bool HasPixel() const { return fArr.size() > 1; }
    bool HasUser() const { return fArr.size() > 2; }
@@ -136,6 +142,7 @@ public:
       fArr[0] = v;
       return *this;
    }
+
    RPadLength &SetPixel(double v)
    {
       if (fArr.size() < 2)
@@ -143,6 +150,7 @@ public:
       fArr[1] = v;
       return *this;
    }
+
    RPadLength &SetUser(double v)
    {
       if (fArr.size() < 3)
@@ -231,6 +239,7 @@ public:
       return *this;
    };
 
+   /// Multiply a `RPadLength`.
    RPadLength &operator*=(double scale)
    {
       if (HasUser()) SetUser(scale*GetUser());

--- a/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
@@ -33,7 +33,7 @@ class RPaletteDrawable final : public RDrawable {
 
    class ROwnAttrs : public RAttrBase {
       friend class RPaletteDrawable;
-      R__ATTR_CLASS(ROwnAttrs, "", AddBool("visible", true).AddString("margin","0.02").AddString("size","0.05"));
+      R__ATTR_CLASS(ROwnAttrs, "", AddBool("visible", true).AddPadLength("margin",0.02).AddPadLength("size",0.05));
    };
 
    RPalette   fPalette;                     ///  color palette to draw
@@ -57,40 +57,24 @@ public:
 
    RPaletteDrawable &SetMargin(const RPadLength &pos)
    {
-      if (pos.Empty())
-         fAttr.ClearValue("margin");
-      else
-         fAttr.SetValue("margin", pos.AsString());
-
+      fAttr.SetValue("margin", pos);
       return *this;
    }
 
    RPadLength GetMargin() const
    {
-      RPadLength res;
-      auto value = fAttr.GetValue<std::string>("margin");
-      if (!value.empty())
-         res.ParseString(value);
-      return res;
+      return fAttr.GetValue<RPadLength>("margin");
    }
 
    RPaletteDrawable &SetSize(const RPadLength &sz)
    {
-      if (sz.Empty())
-         fAttr.ClearValue("size");
-      else
-         fAttr.SetValue("size", sz.AsString());
-
+      fAttr.SetValue("size", sz);
       return *this;
    }
 
    RPadLength GetSize() const
    {
-      RPadLength res;
-      auto value = fAttr.GetValue<std::string>("size");
-      if (!value.empty())
-         res.ParseString(value);
-      return res;
+      return fAttr.GetValue<RPadLength>("size");
    }
 
    const RAttrAxis &GetAttrAxis() const { return fAttrAxis; }

--- a/graf2d/gpadv7/inc/ROOT/RVirtualCanvasPainter.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RVirtualCanvasPainter.hxx
@@ -36,7 +36,7 @@ protected:
    class Generator {
    public:
       /// Abstract interface to create a RVirtualCanvasPainter implementation.
-      virtual std::unique_ptr<RVirtualCanvasPainter> Create(const RCanvas &canv) const = 0;
+      virtual std::unique_ptr<RVirtualCanvasPainter> Create(RCanvas &canv) const = 0;
       /// Default destructor.
       virtual ~Generator();
    };
@@ -72,7 +72,7 @@ public:
    virtual bool AddPanel(std::shared_ptr<RWebWindow>) { return false; }
 
    /// Loads the plugin that implements this class.
-   static std::unique_ptr<RVirtualCanvasPainter> Create(const RCanvas &canv);
+   static std::unique_ptr<RVirtualCanvasPainter> Create(RCanvas &canv);
 };
 } // namespace Internal
 } // namespace Experimental

--- a/graf2d/gpadv7/src/RAttrBase.cxx
+++ b/graf2d/gpadv7/src/RAttrBase.cxx
@@ -164,6 +164,17 @@ void ROOT::Experimental::RAttrBase::SetValue(const std::string &name, const std:
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// Set PadLength value
+
+void ROOT::Experimental::RAttrBase::SetValue(const std::string &name, const RPadLength &value)
+{
+   if (value.Empty())
+      ClearValue(name);
+   else
+      SetValue(name, value.AsString());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// Clear all respective values from drawable. Only defaults can be used
 
 void ROOT::Experimental::RAttrBase::Clear()

--- a/graf2d/gpadv7/src/RAttrMap.cxx
+++ b/graf2d/gpadv7/src/RAttrMap.cxx
@@ -19,22 +19,24 @@ using namespace ROOT::Experimental;
 
 using namespace std::string_literals;
 
-
 template<> bool RAttrMap::Value_t::Get<bool>() const { return GetBool(); }
 template<> int RAttrMap::Value_t::Get<int>() const { return GetInt(); }
 template<> double RAttrMap::Value_t::Get<double>() const { return GetDouble(); }
 template<> std::string RAttrMap::Value_t::Get<std::string>() const { return GetString(); }
+template<> RPadLength RAttrMap::Value_t::Get<RPadLength>() const { return GetString(); }
 
 template<> bool RAttrMap::Value_t::GetValue<bool,void>(const Value_t *rec) { return rec ? rec->GetBool() : false; }
 template<> int RAttrMap::Value_t::GetValue<int,void>(const Value_t *rec) { return rec ? rec->GetInt() : 0; }
 template<> double RAttrMap::Value_t::GetValue<double,void>(const Value_t *rec) { return rec ? rec->GetDouble() : 0.; }
-template<> std::string RAttrMap::Value_t::GetValue<std::string,void>(const Value_t *rec) { return rec ? rec->GetString() : ""; }
+template<> std::string RAttrMap::Value_t::GetValue<std::string,void>(const Value_t *rec) { return rec ? rec->GetString() : ""s; }
+template<> RPadLength RAttrMap::Value_t::GetValue<RPadLength,void>(const Value_t *rec) { return rec ? rec->GetString() : ""s; }
 
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,void>(const Value_t *rec) { return rec; }
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,bool>(const Value_t *rec) { return rec && rec->CanConvertTo(RAttrMap::kBool) ? rec : nullptr; }
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,int>(const Value_t *rec) { return rec && rec->CanConvertTo(RAttrMap::kInt) ? rec : nullptr; }
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,double>(const Value_t *rec) { return rec && rec->CanConvertTo(RAttrMap::kDouble) ? rec : nullptr; }
 template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,std::string>(const Value_t *rec) { return rec && rec->CanConvertTo(RAttrMap::kString) ? rec : nullptr; }
+template<> const RAttrMap::Value_t *RAttrMap::Value_t::GetValue<const RAttrMap::Value_t *,RPadLength>(const Value_t *rec) { return rec && rec->CanConvertTo(RAttrMap::kString) ? rec : nullptr; }
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpadv7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/src/RCanvas.cxx
@@ -245,6 +245,7 @@ void ROOT::Experimental::RCanvas::ResolveSharedPtrs()
    }
 }
 
+
 /////////////////////////////////////////////////////////////////////////////////////////////////
 /// Apply attributes changes to the drawable
 /// Return mask with actions which were really applied
@@ -278,7 +279,5 @@ std::unique_ptr<ROOT::Experimental::RDrawableReply> ROOT::Experimental::RChangeA
 
    fNeedUpdate = (vers > 0);
 
-   printf("RCanvas::Change attributes vers %d needupdate %d\n", (int) vers, (int) fNeedUpdate);
-
-   return nullptr;
+   return nullptr; // no need for any reply
 }

--- a/graf2d/gpadv7/src/RDisplayItem.cxx
+++ b/graf2d/gpadv7/src/RDisplayItem.cxx
@@ -21,13 +21,30 @@ void ROOT::Experimental::RDisplayItem::SetObjectIDAsPtr(const void *ptr)
    SetObjectID(ObjectIDFromPtr(ptr));
 }
 
+////////////////////////////////////////////////////////////////////////////
+/// Build full id, including prefix and object index
+
 void ROOT::Experimental::RDisplayItem::BuildFullId(const std::string &prefix)
 {
    SetObjectID(prefix + std::to_string(GetIndex()) + "_" + GetObjectID());
 }
+
+////////////////////////////////////////////////////////////////////////////
+/// Construct fillid using pointer value
 
 std::string ROOT::Experimental::RDisplayItem::ObjectIDFromPtr(const void *ptr)
 {
    auto hash = TString::Hash(&ptr, sizeof(ptr));
    return std::to_string(hash);
 }
+
+///////////////////////////////////////////////////////////
+/// Constructor
+
+ROOT::Experimental::RIndirectDisplayItem::RIndirectDisplayItem(const RDrawable &dr)
+{
+   fAttr = &dr.fAttr;
+   fCssClass = &dr.fCssClass;
+   fId = &dr.fId;
+}
+

--- a/graf2d/gpadv7/src/RDrawable.cxx
+++ b/graf2d/gpadv7/src/RDrawable.cxx
@@ -14,10 +14,12 @@
 #include <string>
 
 
-// pin vtable
-ROOT::Experimental::RDrawable::~RDrawable() {}
+using namespace ROOT::Experimental;
 
-void ROOT::Experimental::RDrawable::Execute(const std::string &)
+// pin vtable
+RDrawable::~RDrawable() {}
+
+void RDrawable::Execute(const std::string &)
 {
    assert(false && "Did not expect a menu item to be invoked!");
 }
@@ -30,7 +32,7 @@ void ROOT::Experimental::RDrawable::Execute(const std::string &)
 ///       id is drawable identifier, specified with RDrawable::SetId() method
 ///       class_name is drawable class name, specified with RDrawable::SetCssClass() method
 
-bool ROOT::Experimental::RDrawable::MatchSelector(const std::string &selector) const
+bool RDrawable::MatchSelector(const std::string &selector) const
 {
    return (selector == fCssType) || (!fCssClass.empty() && (selector == std::string(".") + fCssClass)) || (!fId.empty() && (selector == std::string("#") + fId));
 }
@@ -39,7 +41,10 @@ bool ROOT::Experimental::RDrawable::MatchSelector(const std::string &selector) c
 /// Creates display item for drawable
 /// By default item contains drawable data itself
 
-std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RDrawable::Display(const RPadBase &) const
+std::unique_ptr<RDisplayItem> RDrawable::Display(const RPadBase &, Version_t vers) const
 {
-   return std::make_unique<RDrawableDisplayItem>(*this);
+   if (GetVersion() > vers)
+      return std::make_unique<RDrawableDisplayItem>(*this);
+
+   return nullptr;
 }

--- a/graf2d/gpadv7/src/RDrawable.cxx
+++ b/graf2d/gpadv7/src/RDrawable.cxx
@@ -16,10 +16,14 @@
 
 using namespace ROOT::Experimental;
 
-// pin vtable
+
+// destructor, pin vtable
+RDrawableReply::~RDrawableReply() = default;
+
+// destructor, pin vtable
 RDrawableRequest::~RDrawableRequest() = default;
 
-// pin vtable
+// destructor, pin vtable
 RDrawable::~RDrawable() = default;
 
 void RDrawable::Execute(const std::string &)

--- a/graf2d/gpadv7/src/RDrawable.cxx
+++ b/graf2d/gpadv7/src/RDrawable.cxx
@@ -17,7 +17,10 @@
 using namespace ROOT::Experimental;
 
 // pin vtable
-RDrawable::~RDrawable() {}
+RDrawableRequest::~RDrawableRequest() = default;
+
+// pin vtable
+RDrawable::~RDrawable() = default;
 
 void RDrawable::Execute(const std::string &)
 {

--- a/graf2d/gpadv7/src/RDrawable.cxx
+++ b/graf2d/gpadv7/src/RDrawable.cxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -8,7 +8,7 @@
 
 #include "ROOT/RDrawable.hxx"
 #include "ROOT/RDisplayItem.hxx"
-#include "ROOT/RMenuItem.hxx"
+#include "ROOT/RMenuItems.hxx"
 #include "ROOT/RLogger.hxx"
 #include "ROOT/RCanvas.hxx"
 
@@ -22,14 +22,7 @@
 using namespace ROOT::Experimental;
 
 // destructor, pin vtable
-RDrawableReply::~RDrawableReply() = default;
-
-// destructor, pin vtable
-RDrawableRequest::~RDrawableRequest() = default;
-
-// destructor, pin vtable
 RDrawable::~RDrawable() = default;
-
 
 /////////////////////////////////////////////////////////////////////
 // Fill context menu items for the ROOT class
@@ -76,21 +69,6 @@ std::unique_ptr<RDisplayItem> RDrawable::Display(const RPadBase &, Version_t ver
 {
    if (GetVersion() > vers)
       return std::make_unique<RDrawableDisplayItem>(*this);
-
-   return nullptr;
-}
-
-
-/////////////////////////////////////////////////////////////////////////////
-/// Execute method of the drawable
-
-std::unique_ptr<RDrawableReply> RDrawableExecRequest::Process()
-{
-   if (!exec.empty() && GetDrawable())
-      GetDrawable()->Execute(exec);
-
-   if (GetCanvas())
-      const_cast<RCanvas*>(GetCanvas())->Modified();
 
    return nullptr;
 }

--- a/graf2d/gpadv7/src/RDrawable.cxx
+++ b/graf2d/gpadv7/src/RDrawable.cxx
@@ -39,7 +39,7 @@ bool ROOT::Experimental::RDrawable::MatchSelector(const std::string &selector) c
 /// Creates display item for drawable
 /// By default item contains drawable data itself
 
-std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RDrawable::Display() const
+std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RDrawable::Display(const RPadBase &) const
 {
    return std::make_unique<RDrawableDisplayItem>(*this);
 }

--- a/graf2d/gpadv7/src/RDrawableRequest.cxx
+++ b/graf2d/gpadv7/src/RDrawableRequest.cxx
@@ -1,0 +1,40 @@
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RDrawableRequest.hxx"
+
+#include "ROOT/RDrawable.hxx"
+#include "ROOT/RCanvas.hxx"
+
+using namespace ROOT::Experimental;
+
+
+/////////////////////////////////////////////////////////////////////////////
+/// destructor, pin vtable
+
+RDrawableReply::~RDrawableReply() = default;
+
+/////////////////////////////////////////////////////////////////////////////
+/// destructor, pin vtable
+
+RDrawableRequest::~RDrawableRequest() = default;
+
+
+/////////////////////////////////////////////////////////////////////////////
+/// Execute method of the drawable
+
+std::unique_ptr<RDrawableReply> RDrawableExecRequest::Process()
+{
+   if (!exec.empty() && GetDrawable())
+      GetDrawable()->Execute(exec);
+
+   if (GetCanvas())
+      const_cast<RCanvas*>(GetCanvas())->Modified();
+
+   return nullptr;
+}

--- a/graf2d/gpadv7/src/RFrame.cxx
+++ b/graf2d/gpadv7/src/RFrame.cxx
@@ -10,7 +10,7 @@
 
 #include "ROOT/RLogger.hxx"
 #include "ROOT/RPadUserAxis.hxx"
-#include "ROOT/RMenuItem.hxx"
+#include "ROOT/RMenuItems.hxx"
 
 #include "TROOT.h"
 

--- a/graf2d/gpadv7/src/RMenuItem.cxx
+++ b/graf2d/gpadv7/src/RMenuItem.cxx
@@ -15,36 +15,18 @@
 #include "TMethod.h"
 #include "TMethodArg.h"
 #include "TMethodCall.h"
-#include "TBufferJSON.h"
+
+using namespace ROOT::Experimental;
 
 //////////////////////////////////////////////////////////
-/// Returns drawable id coded, fullid can include # with extra specifier
+/// destructor - pin vtable
 
-std::string ROOT::Experimental::RMenuItems::GetDrawableId()
-{
-   auto p = fId.find("#");
-   if (p == std::string::npos)
-      return fId;
-   return fId.substr(0, p);
-}
-
-
-//////////////////////////////////////////////////////////
-/// Returns specifier string after # in fullid
-
-std::string ROOT::Experimental::RMenuItems::GetSpecifier()
-{
-   auto p = fId.find("#");
-   if (p == std::string::npos)
-      return "";
-   return fId.substr(p+1);
-}
-
+RMenuItems::~RMenuItems() = default;
 
 //////////////////////////////////////////////////////////
 /// Fill menu for provided object, using *MENU* as indicator in method comments
 
-void ROOT::Experimental::RMenuItems::PopulateObjectMenu(void *obj, TClass *cl)
+void RMenuItems::PopulateObjectMenu(void *obj, TClass *cl)
 {
    fItems.clear();
 
@@ -109,4 +91,19 @@ void ROOT::Experimental::RMenuItems::PopulateObjectMenu(void *obj, TClass *cl)
          }
       }
    }
+}
+
+//////////////////////////////////////////////////////////
+/// fill menu items for the drawable
+
+std::unique_ptr<RDrawableReply> RDrawableMenuRequest::Process()
+{
+   auto drawable = GetDrawable();
+   if (!drawable) return nullptr;
+
+   auto items = std::make_unique<RMenuItems>(menureqid, menukind);
+
+   drawable->PopulateMenu(*items);
+
+   return items;
 }

--- a/graf2d/gpadv7/src/RMenuItems.cxx
+++ b/graf2d/gpadv7/src/RMenuItems.cxx
@@ -1,12 +1,14 @@
 /*************************************************************************
- * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/RMenuItem.hxx"
+#include "ROOT/RMenuItems.hxx"
+
+#include "ROOT/RDrawable.hxx"
 
 #include "TROOT.h"
 #include "TString.h"

--- a/graf2d/gpadv7/src/RObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/RObjectDrawable.cxx
@@ -20,7 +20,7 @@
 #include <iostream>
 
 
-std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RObjectDrawable::Display() const
+std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RObjectDrawable::Display(const RPadBase &) const
 {
    return std::make_unique<RObjectDisplayItem>(fObj.get(), fOpts);
 }

--- a/graf2d/gpadv7/src/RObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/RObjectDrawable.cxx
@@ -14,24 +14,27 @@
 
 #include "TROOT.h"
 
-
 #include <exception>
 #include <sstream>
 #include <iostream>
 
 
-std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RObjectDrawable::Display(const RPadBase &) const
+using namespace ROOT::Experimental;
+
+std::unique_ptr<RDisplayItem> RObjectDrawable::Display(const RPadBase &, Version_t vers) const
 {
-   return std::make_unique<RObjectDisplayItem>(fObj.get(), fOpts);
+   if (GetVersion() > vers)
+      return std::make_unique<RObjectDisplayItem>(fObj.get(), fOpts);
+   return nullptr;
 }
 
-void ROOT::Experimental::RObjectDrawable::PopulateMenu(RMenuItems &items)
+void RObjectDrawable::PopulateMenu(RMenuItems &items)
 {
    // fill context menu items for the ROOT class
    items.PopulateObjectMenu(fObj.get(), fObj.get()->IsA());
 }
 
-void ROOT::Experimental::RObjectDrawable::Execute(const std::string &exec)
+void RObjectDrawable::Execute(const std::string &exec)
 {
    TObject *obj = fObj.get();
 
@@ -40,6 +43,3 @@ void ROOT::Experimental::RObjectDrawable::Execute(const std::string &exec)
    std::cout << "RObjectDrawable::Execute Obj " << obj->GetName() << "Cmd " << cmd.str() << std::endl;
    gROOT->ProcessLine(cmd.str().c_str());
 }
-
-
-

--- a/graf2d/gpadv7/src/RObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/RObjectDrawable.cxx
@@ -10,7 +10,7 @@
 
 #include <ROOT/RDisplayItem.hxx>
 #include <ROOT/RLogger.hxx>
-#include <ROOT/RMenuItem.hxx>
+#include <ROOT/RMenuItems.hxx>
 
 #include "TROOT.h"
 

--- a/graf2d/gpadv7/src/RPad.cxx
+++ b/graf2d/gpadv7/src/RPad.cxx
@@ -22,7 +22,7 @@ ROOT::Experimental::RPad::~RPad() = default;
 /////////////////////////////////////////////////////////////////////////////////////////////////
 /// Create pad display item
 
-std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RPad::Display() const
+std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RPad::Display(const RPadBase &) const
 {
    auto paditem = std::make_unique<RPadDisplayItem>();
 

--- a/graf2d/gpadv7/src/RPad.cxx
+++ b/graf2d/gpadv7/src/RPad.cxx
@@ -15,6 +15,8 @@
 #include <cassert>
 #include <limits>
 
+using namespace ROOT::Experimental;
+
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 ROOT::Experimental::RPad::~RPad() = default;
@@ -22,14 +24,13 @@ ROOT::Experimental::RPad::~RPad() = default;
 /////////////////////////////////////////////////////////////////////////////////////////////////
 /// Create pad display item
 
-std::unique_ptr<ROOT::Experimental::RDisplayItem> ROOT::Experimental::RPad::Display(const RPadBase &) const
+std::unique_ptr<RDisplayItem> RPad::Display(const RPadBase &, Version_t vers) const
 {
    auto paditem = std::make_unique<RPadDisplayItem>();
 
-   DisplayPrimitives(*paditem.get());
+   DisplayPrimitives(*paditem.get(), vers);
 
    paditem->SetPadPosSize(&fPos, &fSize);
 
    return paditem;
 }
-

--- a/graf2d/gpadv7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/src/RPadBase.cxx
@@ -117,7 +117,7 @@ void ROOT::Experimental::RPadBase::DisplayPrimitives(RPadBaseDisplayItem &padite
    unsigned indx = 0;
 
    for (auto &drawable : fPrimitives) {
-      auto item = drawable->Display();
+      auto item = drawable->Display(*this);
       if (item) {
          item->SetObjectIDAsPtr(drawable.get());
          item->SetIndex(indx);

--- a/graf2d/gpadv7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/src/RPadBase.cxx
@@ -80,6 +80,29 @@ std::shared_ptr<ROOT::Experimental::RDrawable> ROOT::Experimental::RPadBase::Fin
 }
 
 ///////////////////////////////////////////////////////////////////////////
+/// Find subpad which contains primitive with given display id
+
+const ROOT::Experimental::RPadBase *ROOT::Experimental::RPadBase::FindPadForPrimitiveWithDisplayId(const std::string &id) const
+{
+   auto p = id.find("_");
+   if (p == std::string::npos)
+      return nullptr;
+
+   auto prim = GetPrimitive(std::stoul(id.substr(0,p)));
+   if (!prim)
+      return nullptr;
+
+   auto subid = id.substr(p+1);
+
+   if (RDisplayItem::ObjectIDFromPtr(prim.get()) == subid)
+      return this;
+
+   auto subpad = std::dynamic_pointer_cast<RPadBase>(prim);
+
+   return subpad ? subpad->FindPadForPrimitiveWithDisplayId(subid) : nullptr;
+}
+
+///////////////////////////////////////////////////////////////////////////
 /// Method collect existing colors and assign new values if required
 
 void ROOT::Experimental::RPadBase::AssignAutoColors()

--- a/graf2d/gpadv7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/src/RPadBase.cxx
@@ -121,7 +121,7 @@ void ROOT::Experimental::RPadBase::DisplayPrimitives(RPadBaseDisplayItem &padite
       auto item = drawable->Display(*this, vers);
 
       if (!item)
-         item = std::make_unique<RDisplayItem>();
+         item = std::make_unique<RDisplayItem>(true);
 
       item->SetObjectIDAsPtr(drawable.get());
       item->SetIndex(indx++);

--- a/graf2d/gpadv7/src/RVirtualCanvasPainter.cxx
+++ b/graf2d/gpadv7/src/RVirtualCanvasPainter.cxx
@@ -26,20 +26,19 @@ static void LoadCanvasPainterLibrary() {
 }
 } // unnamed namespace
 
+using namespace ROOT::Experimental::Internal;
 
 /// The implementation is here to pin the vtable.
-ROOT::Experimental::Internal::RVirtualCanvasPainter::~RVirtualCanvasPainter() = default;
+RVirtualCanvasPainter::~RVirtualCanvasPainter() = default;
 
-std::unique_ptr<ROOT::Experimental::Internal::RVirtualCanvasPainter::Generator>
-   &ROOT::Experimental::Internal::RVirtualCanvasPainter::GetGenerator()
+std::unique_ptr<RVirtualCanvasPainter::Generator> &RVirtualCanvasPainter::GetGenerator()
 {
    /// The generator for implementations.
    static std::unique_ptr<Generator> generator;
    return generator;
 }
 
-std::unique_ptr<ROOT::Experimental::Internal::RVirtualCanvasPainter> ROOT::Experimental::Internal::
-   RVirtualCanvasPainter::Create(const RCanvas &canv)
+std::unique_ptr<RVirtualCanvasPainter> RVirtualCanvasPainter::Create(ROOT::Experimental::RCanvas &canv)
 {
    if (!GetGenerator()) {
       LoadCanvasPainterLibrary();
@@ -52,5 +51,5 @@ std::unique_ptr<ROOT::Experimental::Internal::RVirtualCanvasPainter> ROOT::Exper
 }
 
 /// The implementation is here to pin the vtable.
-ROOT::Experimental::Internal::RVirtualCanvasPainter::Generator::~Generator() = default;
+RVirtualCanvasPainter::Generator::~Generator() = default;
 

--- a/graf2d/gpadv7/test/palette.cxx
+++ b/graf2d/gpadv7/test/palette.cxx
@@ -7,6 +7,7 @@ TEST(Palette, DiscreteTrivial)
 {
    using namespace ROOT::Experimental;
    RPalette p1(RPalette::kDiscrete, {RColor::kWhite, RColor::kBlack});
+   EXPECT_EQ(p1.IsDiscrete(), true);
    EXPECT_EQ(p1.GetColor(0.), RColor::kWhite);
    EXPECT_EQ(p1.GetColor(1.), RColor::kBlack);
 }
@@ -15,8 +16,25 @@ TEST(Palette, DiscretePlaced)
 {
    using namespace ROOT::Experimental;
    RPalette p1(RPalette::kDiscrete, {{0., RColor::kWhite}, {.3, RColor::kRed}, {.7, RColor::kBlue}, {1., RColor::kBlack}});
+   EXPECT_EQ(p1.IsDiscrete(), true);
    EXPECT_EQ(p1.GetColor(0.), RColor::kWhite);
    EXPECT_EQ(p1.GetColor(.3), RColor::kRed);
    EXPECT_EQ(p1.GetColor(.7), RColor::kBlue);
    EXPECT_EQ(p1.GetColor(1.), RColor::kBlack);
 }
+
+TEST(Palette, InterpolateSimple)
+{
+   using namespace ROOT::Experimental;
+   RPalette p1({RColor::kRed, RColor::kBlue});
+
+   EXPECT_EQ(p1.IsGradient(), true);
+   EXPECT_EQ(p1.GetColor(0.), RColor::kRed);
+   EXPECT_EQ(p1.GetColor(0.2), RColor(0xcc,0x00,0x33));
+   EXPECT_EQ(p1.GetColor(0.4), RColor(0x99,0x00,0x66));
+   EXPECT_EQ(p1.GetColor(0.5), RColor(0x80,0x00,0x80));
+   EXPECT_EQ(p1.GetColor(0.6), RColor(0x66,0x00,0x99));
+   EXPECT_EQ(p1.GetColor(0.8), RColor(0x33,0x00,0xcc));
+   EXPECT_EQ(p1.GetColor(1.), RColor::kBlue);
+}
+

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -99,7 +99,7 @@ private:
 
    typedef std::vector<ROOT::Experimental::Detail::RMenuItem> MenuItemsVector;
 
-   const RCanvas &fCanvas; ///<!  Canvas we are painting, *this will be owned by canvas
+   RCanvas &fCanvas; ///<!  Canvas we are painting, *this will be owned by canvas
 
    std::shared_ptr<RWebWindow> fWindow; ///!< configured display
 
@@ -137,7 +137,7 @@ private:
    void FrontCommandReplied(const std::string &reply);
 
 public:
-   RCanvasPainter(const RCanvas &canv);
+   RCanvasPainter(RCanvas &canv);
 
    virtual ~RCanvasPainter();
 
@@ -168,7 +168,7 @@ public:
    class GeneratorImpl : public Generator {
    public:
       /// Create a new RCanvasPainter to paint the given RCanvas.
-      std::unique_ptr<RVirtualCanvasPainter> Create(const ROOT::Experimental::RCanvas &canv) const override
+      std::unique_ptr<RVirtualCanvasPainter> Create(ROOT::Experimental::RCanvas &canv) const override
       {
          return std::make_unique<RCanvasPainter>(canv);
       }
@@ -201,7 +201,7 @@ struct TNewCanvasPainterReg {
 /////////////////////////////////////////////////////////////////////////////////////////////
 /// constructor
 
-ROOT::Experimental::RCanvasPainter::RCanvasPainter(const RCanvas &canv) : fCanvas(canv)
+ROOT::Experimental::RCanvasPainter::RCanvasPainter(RCanvas &canv) : fCanvas(canv)
 {
    auto comp = gEnv->GetValue("WebGui.JsonComp", -1);
    if (comp >= 0) fJsonComp = comp;
@@ -500,8 +500,8 @@ void ROOT::Experimental::RCanvasPainter::ProcessData(unsigned connid, const std:
          if (drawable && (cdata.length() > 0)) {
             R__DEBUG_HERE("CanvasPainter") << "execute " << cdata << " for drawable " << id;
             drawable->Execute(cdata);
-            const_cast<RCanvas*>(&fCanvas)->Modified();
-            const_cast<RCanvas*>(&fCanvas)->Update(true);
+            fCanvas.Modified();
+            fCanvas.Update(true);
          } else if (id == "canvas") {
             R__DEBUG_HERE("CanvasPainter") << "execute " << cdata << " for canvas itself (ignored)";
          }
@@ -509,8 +509,8 @@ void ROOT::Experimental::RCanvasPainter::ProcessData(unsigned connid, const std:
    } else if (check_header("ATTRCHANGE:")) {
       auto vect = TBufferJSON::FromJSON<std::vector<RChangeAttr>>(cdata);
       if (vect) {
-         if (const_cast<RCanvas*>(&fCanvas)->ApplyAttrChanges(*vect))
-            const_cast<RCanvas*>(&fCanvas)->Update(true);
+         if (fCanvas.ApplyAttrChanges(*vect))
+            fCanvas.Update(true);
       } else {
          R__ERROR_HERE("CanvasPainter") << "Fail to parse vector<RChangeAttr>";
       }

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -452,7 +452,7 @@ void ROOT::Experimental::RCanvasPainter::ProcessData(unsigned connid, const std:
    auto check_header = [&arg, &cdata](const std::string &header) {
       if (arg.compare(0, header.length(), header) != 0)
          return false;
-      cdata = arg.substr(arg.length());
+      cdata = arg.substr(header.length());
       return true;
    };
 

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -18,7 +18,7 @@
 #include <ROOT/RLogger.hxx>
 #include <ROOT/RDisplayItem.hxx>
 #include <ROOT/RPadDisplayItem.hxx>
-#include <ROOT/RMenuItem.hxx>
+#include <ROOT/RMenuItems.hxx>
 #include <ROOT/RWebDisplayArgs.hxx>
 #include <ROOT/RWebDisplayHandle.hxx>
 #include <ROOT/RWebWindow.hxx>

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -478,22 +478,6 @@ void RCanvasPainter::ProcessData(unsigned connid, const std::string &arg)
       }
    } else if (check_header("SAVE:")) {
       SaveCreatedFile(cdata);
-   } else if (check_header("OBJEXEC:")) {
-      size_t pos = cdata.find(':');
-
-      if ((pos != std::string::npos) && (pos > 0)) {
-         std::string id(cdata, 0, pos);
-         cdata.erase(0, pos + 1);
-         auto drawable = FindPrimitive(fCanvas, id);
-         if (drawable && (cdata.length() > 0)) {
-            R__DEBUG_HERE("CanvasPainter") << "execute " << cdata << " for drawable " << id;
-            drawable->Execute(cdata);
-            fCanvas.Modified();
-            fCanvas.Update(true);
-         } else if (id == "canvas") {
-            R__DEBUG_HERE("CanvasPainter") << "execute " << cdata << " for canvas itself (ignored)";
-         }
-      }
    } else if (check_header("REQ:")) {
       auto req = TBufferJSON::FromJSON<RDrawableRequest>(cdata);
       if (req) {

--- a/hist/histdrawv7/CMakeLists.txt
+++ b/hist/histdrawv7/CMakeLists.txt
@@ -11,8 +11,10 @@
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTHistDraw
   HEADERS
     ROOT/RHistDrawable.hxx
+    ROOT/RHistStatBox.hxx
   SOURCES
     src/RHistDrawable.cxx
+    src/RHistStatBox.cxx
   DICTIONARY_OPTIONS
     -writeEmptyRootPCM
   DEPENDENCIES

--- a/hist/histdrawv7/inc/LinkDef.h
+++ b/hist/histdrawv7/inc/LinkDef.h
@@ -28,5 +28,7 @@
 #pragma link C++ class ROOT::Experimental::RHist1Drawable+;
 #pragma link C++ class ROOT::Experimental::RHist2Drawable+;
 
+#pragma link C++ class ROOT::Experimental::RHistStatBox+;
+
 
 #endif

--- a/hist/histdrawv7/inc/LinkDef.h
+++ b/hist/histdrawv7/inc/LinkDef.h
@@ -28,11 +28,16 @@
 #pragma link C++ class ROOT::Experimental::RHist1Drawable+;
 #pragma link C++ class ROOT::Experimental::RHist2Drawable+;
 
+#pragma link C++ class ROOT::Experimental::RHistStatRequest+;
+#pragma link C++ class ROOT::Experimental::RHistStatReply+;
+#pragma link C++ class ROOT::Experimental::RDisplayHistStat+;
+
+#pragma link C++ class ROOT::Experimental::RHistStatBoxBase+;
+
 #pragma link C++ class ROOT::Experimental::RHistStatBox<1>+;
 #pragma link C++ class ROOT::Experimental::RHistStatBox<2>+;
 #pragma link C++ class ROOT::Experimental::RHistStatBox<3>+;
 
-#pragma link C++ class ROOT::Experimental::RDisplayHistStat+;
 #pragma link C++ class ROOT::Experimental::RHist1StatBox+;
 #pragma link C++ class ROOT::Experimental::RHist2StatBox+;
 #pragma link C++ class ROOT::Experimental::RHist3StatBox+;

--- a/hist/histdrawv7/inc/LinkDef.h
+++ b/hist/histdrawv7/inc/LinkDef.h
@@ -28,7 +28,13 @@
 #pragma link C++ class ROOT::Experimental::RHist1Drawable+;
 #pragma link C++ class ROOT::Experimental::RHist2Drawable+;
 
-#pragma link C++ class ROOT::Experimental::RHistStatBox+;
+#pragma link C++ class ROOT::Experimental::RHistStatBox<1>+;
+#pragma link C++ class ROOT::Experimental::RHistStatBox<2>+;
+#pragma link C++ class ROOT::Experimental::RHistStatBox<3>+;
 
+#pragma link C++ class ROOT::Experimental::RDisplayHistStat+;
+#pragma link C++ class ROOT::Experimental::RHist1StatBox+;
+#pragma link C++ class ROOT::Experimental::RHist2StatBox+;
+#pragma link C++ class ROOT::Experimental::RHist3StatBox+;
 
 #endif

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -49,6 +49,11 @@ protected:
 
    bool IsFrameRequired() const final { return true; }
 
+   void PopulateMenu(RMenuItems &) override
+   {
+      // populate menu
+   }
+
 public:
    RHistDrawable();
    virtual ~RHistDrawable() = default;
@@ -60,11 +65,6 @@ public:
    }
 
    std::shared_ptr<HistImpl_t> GetHist() const { return fHistImpl.get_shared(); }
-
-   void PopulateMenu(RMenuItems &) override
-   {
-      // populate menu
-   }
 
    void Execute(const std::string &) override
    {

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -20,7 +20,7 @@
 #include <ROOT/RAttrLine.hxx>
 #include <ROOT/RHist.hxx>
 #include <ROOT/RHistImpl.hxx>
-#include <ROOT/RMenuItem.hxx>
+#include <ROOT/RMenuItems.hxx>
 
 #include <memory>
 

--- a/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
@@ -26,6 +26,13 @@
 namespace ROOT {
 namespace Experimental {
 
+/** \class ROOT::Experimental::RHistStatRequest
+\ingroup GrafROOT7
+\brief Data request from stat box, send when client starts drawing
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-17
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RHistStatRequest : public RDrawableRequest {
    std::vector<double> xmin; // vector of axis min values
@@ -39,15 +46,31 @@ public:
    double GetMax(unsigned indx) const { return indx < xmax.size() ? xmax[indx] : 0; }
 };
 
+/** \class ROOT::Experimental::RHistStatReply
+\ingroup GrafROOT7
+\brief Reply of stat box on RHistStatRequest, contains text lines to display
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-17
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
 class RHistStatReply : public RDrawableReply {
    std::vector<std::string> lines;   ///< text lines displayed in the stat box
 public:
 
    void AddLine(const std::string &line) { lines.emplace_back(line); }
 
-   // pin vtable
+   // virtual destructor - required to pin vtable
    virtual ~RHistStatReply() = default;
 };
+
+/** \class ROOT::Experimental::RDisplayHistStat
+\ingroup GrafROOT7
+\brief Object send to client for display of RHistStat, required to avoid sending histogram to the client
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-17
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
 
 class RDisplayHistStat : public RIndirectDisplayItem {
 public:
@@ -73,7 +96,7 @@ private:
 
    class RHistStatBoxAttrs : public RAttrBase {
       friend class RHistStatBoxBase;
-      R__ATTR_CLASS(RHistStatBoxAttrs, "", AddString("cornerx","0.02").AddString("cornery","0.02").AddString("width","0.5").AddString("height","0.2"));
+      R__ATTR_CLASS(RHistStatBoxAttrs, "", AddPadLength("cornerx",0.02).AddPadLength("cornery",0.02).AddPadLength("width",0.5).AddPadLength("height",0.2));
    };
 
    std::string fTitle;                       ///< stat box title
@@ -81,7 +104,7 @@ private:
    RAttrText fAttrText{this, "text_"};       ///<! text attributes
    RAttrLine fAttrBorder{this, "border_"};   ///<! border attributes
    RAttrFill fAttrFill{this, "fill_"};       ///<! line attributes
-   RHistStatBoxAttrs fAttr{this,""};         ///<! stat box direct attributes
+   RHistStatBoxAttrs fAttr{this, ""};        ///<! stat box direct attributes
 
 protected:
 
@@ -104,78 +127,46 @@ public:
 
    RHistStatBoxBase &SetCornerX(const RPadLength &pos)
    {
-      if (pos.Empty())
-         fAttr.ClearValue("cornerx");
-      else
-         fAttr.SetValue("cornerx", pos.AsString());
-
+      fAttr.SetValue("cornerx", pos);
       return *this;
    }
 
    RPadLength GetCornerX() const
    {
-      RPadLength res;
-      auto value = fAttr.template GetValue<std::string>("cornerx");
-      if (!value.empty())
-         res.ParseString(value);
-      return res;
+      return fAttr.template GetValue<RPadLength>("cornerx");
    }
 
    RHistStatBoxBase &SetCornerY(const RPadLength &pos)
    {
-      if (pos.Empty())
-         fAttr.ClearValue("cornery");
-      else
-         fAttr.SetValue("cornery", pos.AsString());
-
+      fAttr.SetValue("cornery", pos);
       return *this;
    }
 
    RPadLength GetCornerY() const
    {
-      RPadLength res;
-      auto value = fAttr.template GetValue<std::string>("cornery");
-      if (!value.empty())
-         res.ParseString(value);
-      return res;
+      return fAttr.template GetValue<RPadLength>("cornery");
    }
 
-   RHistStatBoxBase &SetWidth(const RPadLength &pos)
+   RHistStatBoxBase &SetWidth(const RPadLength &width)
    {
-      if (pos.Empty())
-         fAttr.ClearValue("width");
-      else
-         fAttr.SetValue("width", pos.AsString());
-
+      fAttr.SetValue("width", width);
       return *this;
    }
 
    RPadLength GetWidth() const
    {
-      RPadLength res;
-      auto value = fAttr.template GetValue<std::string>("width");
-      if (!value.empty())
-         res.ParseString(value);
-      return res;
+      return fAttr.template GetValue<RPadLength>("width");
    }
 
-   RHistStatBoxBase &SetHeight(const RPadLength &pos)
+   RHistStatBoxBase &SetHeight(const RPadLength &height)
    {
-      if (pos.Empty())
-         fAttr.ClearValue("height");
-      else
-         fAttr.SetValue("height", pos.AsString());
-
+      fAttr.SetValue("height", height);
       return *this;
    }
 
    RPadLength GetHeight() const
    {
-      RPadLength res;
-      auto value = fAttr.template GetValue<std::string>("height");
-      if (!value.empty())
-         res.ParseString(value);
-      return res;
+      return fAttr.template GetValue<RPadLength>("height");
    }
 
    const RAttrText &GetAttrText() const { return fAttrText; }

--- a/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
@@ -10,6 +10,7 @@
 #define ROOT7_RHistStatBox
 
 #include <ROOT/RDrawable.hxx>
+#include <ROOT/RDrawableRequest.hxx>
 #include <ROOT/RAttrText.hxx>
 #include <ROOT/RAttrLine.hxx>
 #include <ROOT/RAttrFill.hxx>

--- a/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
@@ -73,7 +73,7 @@ protected:
 
    virtual void FillStatistic(RDisplayHistStat &, const RPadBase &) const {}
 
-   std::unique_ptr<RDisplayItem> Display(const RPadBase &pad) const override
+   std::unique_ptr<RDisplayItem> Display(const RPadBase &pad, Version_t) const override
    {
       auto res = std::make_unique<RDisplayHistStat>(*this);
 

--- a/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
@@ -14,12 +14,27 @@
 #include <ROOT/RAttrLine.hxx>
 #include <ROOT/RAttrFill.hxx>
 #include <ROOT/RPadPos.hxx>
+#include <ROOT/RDisplayItem.hxx>
+#include <ROOT/RHist.hxx>
+#include <ROOT/RHistImpl.hxx>
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace ROOT {
 namespace Experimental {
+
+class RDisplayHistStat : public RIndirectDisplayItem {
+   std::vector<std::string> fLines;   ///< text lines displayed in the stat box
+public:
+   RDisplayHistStat() = default;
+
+   RDisplayHistStat(const RDrawable &box) : RIndirectDisplayItem(box) {}
+
+   void AddLine(const std::string &line) { fLines.emplace_back(line); }
+};
+
 
 /** \class ROOT::Experimental::RHistStatBox
 \ingroup GrafROOT7
@@ -30,14 +45,22 @@ namespace Experimental {
 */
 
 
-class RHistStatBox final : public RDrawable {
+template <int DIMENSIONS>
+class RHistStatBox : public RDrawable {
+public:
+   using HistImpl_t = Detail::RHistImplPrecisionAgnosticBase<DIMENSIONS>;
+
+private:
+   Internal::RIOShared<HistImpl_t> fHistImpl;  ///< I/O capable reference on histogram
 
    class RHistStatBoxAttrs : public RAttrBase {
-      friend class RHistStatBox;
+      // friend class RHistStatBox<DIMENSIONS>;
       R__ATTR_CLASS(RHistStatBoxAttrs, "", AddString("cornerx","0.02").AddString("cornery","0.02").AddString("width","0.5").AddString("height","0.2"));
    };
 
-   RAttrText  fAttrText{this, "text_"};      ///<! text attributes
+   std::string fTitle;                       ///< stat box title
+
+   RAttrText fAttrText{this, "text_"};       ///<! text attributes
    RAttrLine fAttrBorder{this, "border_"};   ///<! border attributes
    RAttrFill fAttrFill{this, "fill_"};       ///<! line attributes
    RHistStatBoxAttrs fAttr{this,""};         ///<! title direct attributes
@@ -46,9 +69,38 @@ protected:
 
    bool IsFrameRequired() const final { return true; }
 
+   void CollectShared(Internal::RIOSharedVector_t &vect) override { vect.emplace_back(&fHistImpl); }
+
+   virtual void FillStatistic(RDisplayHistStat &, const RPadBase &) const {}
+
+   std::unique_ptr<RDisplayItem> Display(const RPadBase &pad) const override
+   {
+      auto res = std::make_unique<RDisplayHistStat>(*this);
+
+      if (!GetTitle().empty())
+         res->AddLine(GetTitle());
+
+      FillStatistic(*res.get(), pad);
+
+      return res;
+   }
+
 public:
 
    RHistStatBox() : RDrawable("stats") {}
+
+   template <class HIST>
+   RHistStatBox(const std::shared_ptr<HIST> &hist, const std::string &title = "") : RHistStatBox()
+   {
+      fHistImpl = std::shared_ptr<HistImpl_t>(hist, hist->GetImpl());
+      SetTitle(title);
+   }
+
+   std::shared_ptr<HistImpl_t> GetHist() const { return fHistImpl.get_shared(); }
+
+
+   void SetTitle(const std::string &title) { fTitle = title; }
+   const std::string &GetTitle() const { return fTitle; }
 
    RHistStatBox &SetCornerX(const RPadLength &pos)
    {
@@ -63,7 +115,7 @@ public:
    RPadLength GetCornerX() const
    {
       RPadLength res;
-      auto value = fAttr.GetValue<std::string>("cornerx");
+      auto value = fAttr.template GetValue<std::string>("cornerx");
       if (!value.empty())
          res.ParseString(value);
       return res;
@@ -82,7 +134,7 @@ public:
    RPadLength GetCornerY() const
    {
       RPadLength res;
-      auto value = fAttr.GetValue<std::string>("cornery");
+      auto value = fAttr.template GetValue<std::string>("cornery");
       if (!value.empty())
          res.ParseString(value);
       return res;
@@ -101,7 +153,7 @@ public:
    RPadLength GetWidth() const
    {
       RPadLength res;
-      auto value = fAttr.GetValue<std::string>("width");
+      auto value = fAttr.template GetValue<std::string>("width");
       if (!value.empty())
          res.ParseString(value);
       return res;
@@ -120,7 +172,7 @@ public:
    RPadLength GetHeight() const
    {
       RPadLength res;
-      auto value = fAttr.GetValue<std::string>("height");
+      auto value = fAttr.template GetValue<std::string>("height");
       if (!value.empty())
          res.ParseString(value);
       return res;
@@ -138,6 +190,43 @@ public:
    RHistStatBox &SetAttrFill(const RAttrFill &fill) { fAttrFill = fill; return *this; }
    RAttrFill &AttrFill() { return fAttrFill; }
 };
+
+
+class RHist1StatBox final : public RHistStatBox<1> {
+protected:
+   void FillStatistic(RDisplayHistStat &, const RPadBase &) const override;
+public:
+   RHist1StatBox() = default;
+   template <class HIST>
+   RHist1StatBox(const std::shared_ptr<HIST> &hist, const std::string &title = "") : RHistStatBox<1>(hist, title) {}
+};
+
+
+class RHist2StatBox final : public RHistStatBox<2> {
+protected:
+
+   void FillStatistic(RDisplayHistStat &, const RPadBase &) const override;
+
+public:
+   RHist2StatBox() = default;
+
+   template <class HIST>
+   RHist2StatBox(const std::shared_ptr<HIST> &hist, const std::string &title = "") : RHistStatBox<2>(hist, title) {}
+};
+
+class RHist3StatBox final : public RHistStatBox<3> {
+protected:
+
+   void FillStatistic(RDisplayHistStat &, const RPadBase &) const override;
+
+public:
+   RHist3StatBox() = default;
+
+   template <class HIST>
+   RHist3StatBox(const std::shared_ptr<HIST> &hist, const std::string &title = "") : RHistStatBox<3>(hist, title) {}
+};
+
+
 
 } // namespace Experimental
 } // namespace ROOT

--- a/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
@@ -1,0 +1,145 @@
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RHistStatBox
+#define ROOT7_RHistStatBox
+
+#include <ROOT/RDrawable.hxx>
+#include <ROOT/RAttrText.hxx>
+#include <ROOT/RAttrLine.hxx>
+#include <ROOT/RAttrFill.hxx>
+#include <ROOT/RPadPos.hxx>
+
+#include <memory>
+#include <string>
+
+namespace ROOT {
+namespace Experimental {
+
+/** \class ROOT::Experimental::RHistStatBox
+\ingroup GrafROOT7
+\brief Statistic box for RHist class
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-04-01
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+
+class RHistStatBox final : public RDrawable {
+
+   class RHistStatBoxAttrs : public RAttrBase {
+      friend class RHistStatBox;
+      R__ATTR_CLASS(RHistStatBoxAttrs, "", AddString("cornerx","0.02").AddString("cornery","0.02").AddString("width","0.5").AddString("height","0.2"));
+   };
+
+   RAttrText  fAttrText{this, "text_"};      ///<! text attributes
+   RAttrLine fAttrBorder{this, "border_"};   ///<! border attributes
+   RAttrFill fAttrFill{this, "fill_"};       ///<! line attributes
+   RHistStatBoxAttrs fAttr{this,""};         ///<! title direct attributes
+
+protected:
+
+   bool IsFrameRequired() const final { return true; }
+
+public:
+
+   RHistStatBox() : RDrawable("stats") {}
+
+   RHistStatBox &SetCornerX(const RPadLength &pos)
+   {
+      if (pos.Empty())
+         fAttr.ClearValue("cornerx");
+      else
+         fAttr.SetValue("cornerx", pos.AsString());
+
+      return *this;
+   }
+
+   RPadLength GetCornerX() const
+   {
+      RPadLength res;
+      auto value = fAttr.GetValue<std::string>("cornerx");
+      if (!value.empty())
+         res.ParseString(value);
+      return res;
+   }
+
+   RHistStatBox &SetCornerY(const RPadLength &pos)
+   {
+      if (pos.Empty())
+         fAttr.ClearValue("cornery");
+      else
+         fAttr.SetValue("cornery", pos.AsString());
+
+      return *this;
+   }
+
+   RPadLength GetCornerY() const
+   {
+      RPadLength res;
+      auto value = fAttr.GetValue<std::string>("cornery");
+      if (!value.empty())
+         res.ParseString(value);
+      return res;
+   }
+
+   RHistStatBox &SetWidth(const RPadLength &pos)
+   {
+      if (pos.Empty())
+         fAttr.ClearValue("width");
+      else
+         fAttr.SetValue("width", pos.AsString());
+
+      return *this;
+   }
+
+   RPadLength GetWidth() const
+   {
+      RPadLength res;
+      auto value = fAttr.GetValue<std::string>("width");
+      if (!value.empty())
+         res.ParseString(value);
+      return res;
+   }
+
+   RHistStatBox &SetHeight(const RPadLength &pos)
+   {
+      if (pos.Empty())
+         fAttr.ClearValue("height");
+      else
+         fAttr.SetValue("height", pos.AsString());
+
+      return *this;
+   }
+
+   RPadLength GetHeight() const
+   {
+      RPadLength res;
+      auto value = fAttr.GetValue<std::string>("height");
+      if (!value.empty())
+         res.ParseString(value);
+      return res;
+   }
+
+   const RAttrText &GetAttrText() const { return fAttrText; }
+   RHistStatBox &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
+   RAttrText &AttrText() { return fAttrText; }
+
+   const RAttrLine &GetAttrBorder() const { return fAttrBorder; }
+   RHistStatBox &SetAttrBorder(const RAttrLine &border) { fAttrBorder = border; return *this; }
+   RAttrLine &AttrBorder() { return fAttrBorder; }
+
+   const RAttrFill &GetAttrFill() const { return fAttrFill; }
+   RHistStatBox &SetAttrFill(const RAttrFill &fill) { fAttrFill = fill; return *this; }
+   RAttrFill &AttrFill() { return fAttrFill; }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
@@ -32,13 +32,13 @@ class RHistStatRequest : public RDrawableRequest {
 
 public:
 
-   std::unique_ptr<RDrawableRequest> Process(std::shared_ptr<RDrawable> &drawable) override;
+   std::unique_ptr<RDrawableReply> Process() override;
 
    double GetMin(unsigned indx) const { return indx < xmin.size() ? xmin[indx] : 0; }
    double GetMax(unsigned indx) const { return indx < xmax.size() ? xmax[indx] : 0; }
 };
 
-class RHistStatReply : public RDrawableRequest {
+class RHistStatReply : public RDrawableReply {
    std::vector<std::string> lines;   ///< text lines displayed in the stat box
 public:
 

--- a/hist/histdrawv7/src/RHistStatBox.cxx
+++ b/hist/histdrawv7/src/RHistStatBox.cxx
@@ -8,4 +8,40 @@
 
 #include "ROOT/RHistStatBox.hxx"
 
+using namespace ROOT::Experimental;
+
+
+void RHist1StatBox::FillStatistic(RDisplayHistStat &stat, const RPadBase &) const
+{
+   // need to implement statistic fill for RHist1
+
+   stat.AddLine("Entries = 1");
+   stat.AddLine("Mean = 2");
+   stat.AddLine("Std dev = 3");
+}
+
+
+void RHist2StatBox::FillStatistic(RDisplayHistStat &stat, const RPadBase &) const
+{
+   // need to implement statistic fill for RHist2
+
+   stat.AddLine("Entries = 1");
+   stat.AddLine("Mean x = 2");
+   stat.AddLine("Mean y = 3");
+   stat.AddLine("Std dev x = 4");
+   stat.AddLine("Std dev y = 5");
+}
+
+void RHist3StatBox::FillStatistic(RDisplayHistStat &stat, const RPadBase &) const
+{
+   // need to implement statistic fill for RHist3
+
+   stat.AddLine("Entries = 1");
+   stat.AddLine("Mean x = 2");
+   stat.AddLine("Mean y = 3");
+   stat.AddLine("Mean z = 4");
+   stat.AddLine("Std dev x = 5");
+   stat.AddLine("Std dev y = 6");
+   stat.AddLine("Std dev z = 7");
+}
 

--- a/hist/histdrawv7/src/RHistStatBox.cxx
+++ b/hist/histdrawv7/src/RHistStatBox.cxx
@@ -13,9 +13,9 @@
 using namespace ROOT::Experimental;
 using namespace std::string_literals;
 
-std::unique_ptr<RDrawableRequest> RHistStatRequest::Process(std::shared_ptr<RDrawable> &drawable)
+std::unique_ptr<RDrawableReply> RHistStatRequest::Process()
 {
-   auto stat = std::dynamic_pointer_cast<RHistStatBoxBase>(drawable);
+   auto stat = dynamic_cast<RHistStatBoxBase *>(GetDrawable());
 
    auto reply = std::make_unique<RHistStatReply>();
 
@@ -24,7 +24,6 @@ std::unique_ptr<RDrawableRequest> RHistStatRequest::Process(std::shared_ptr<RDra
 
    return reply;
 }
-
 
 void RHist1StatBox::FillStatistic(const RHistStatRequest &req, RHistStatReply &reply) const
 {

--- a/hist/histdrawv7/src/RHistStatBox.cxx
+++ b/hist/histdrawv7/src/RHistStatBox.cxx
@@ -19,45 +19,98 @@ std::unique_ptr<RDrawableReply> RHistStatRequest::Process()
 
    auto reply = std::make_unique<RHistStatReply>();
 
-   if (stat)
-      stat->FillStatistic(*this, *reply.get());
+   if (stat) {
+      stat->fShowMask = GetMask();
+
+      if (GetMask() & RHistStatBoxBase::kShowTitle)
+         reply->AddLine(stat->GetTitle());
+
+      stat->FillStatistic(*this, *reply);
+   }
 
    return reply;
 }
 
+
+const std::vector<std::string> &RHistStatBoxBase::GetEntriesNames() const
+{
+   static const std::vector<std::string> sEntries = {"Title","Entries", "Mean","Deviation", "Ranges"};
+   return sEntries;
+}
+
+
 void RHist1StatBox::FillStatistic(const RHistStatRequest &req, RHistStatReply &reply) const
 {
-   // need to implement statistic fill for RHist1
+   // TODO: need to implement statistic fill for RHist1
 
-   reply.AddLine("Entries = 1");
-   reply.AddLine("Mean = 2");
-   reply.AddLine("Std dev = 3");
-   reply.AddLine("X min = "s + std::to_string(req.GetMin(0)));
-   reply.AddLine("X max = "s + std::to_string(req.GetMax(0)));
+   if (req.GetMask() & kShowEntries)
+      reply.AddLine("Entries = 1");
+
+   if (req.GetMask() & kShowMean)
+      reply.AddLine("Mean = 2");
+
+   if (req.GetMask() & kShowDev)
+      reply.AddLine("Std dev = 3");
+
+   if (req.GetMask() & kShowRange) {
+      reply.AddLine("X min = "s + std::to_string(req.GetMin(0)));
+      reply.AddLine("X max = "s + std::to_string(req.GetMax(0)));
+   }
 }
 
 
 void RHist2StatBox::FillStatistic(const RHistStatRequest &req, RHistStatReply &reply) const
 {
-   // need to implement statistic fill for RHist2
+   // TODO: need to implement statistic fill for RHist2
 
-   reply.AddLine("Entries = 1");
-   reply.AddLine("X min = "s + std::to_string(req.GetMin(0)));
-   reply.AddLine("X max = "s + std::to_string(req.GetMax(0)));
-   reply.AddLine("Y min = "s + std::to_string(req.GetMin(1)));
-   reply.AddLine("Y max = "s + std::to_string(req.GetMax(1)));
+   if (req.GetMask() & kShowEntries)
+      reply.AddLine("Entries = 1");
+
+   if (req.GetMask() & kShowMean) {
+      reply.AddLine("Mean x = 2");
+      reply.AddLine("Mean y = 3");
+   }
+
+   if (req.GetMask() & kShowDev) {
+      reply.AddLine("Std dev x = 5");
+      reply.AddLine("Std dev y = 6");
+   }
+
+   if (req.GetMask() & kShowRange) {
+      reply.AddLine("X min = "s + std::to_string(req.GetMin(0)));
+      reply.AddLine("X max = "s + std::to_string(req.GetMax(0)));
+      reply.AddLine("Y min = "s + std::to_string(req.GetMin(1)));
+      reply.AddLine("Y max = "s + std::to_string(req.GetMax(1)));
+   }
 }
 
-void RHist3StatBox::FillStatistic(const RHistStatRequest &, RHistStatReply &reply) const
+void RHist3StatBox::FillStatistic(const RHistStatRequest &req, RHistStatReply &reply) const
 {
-   // need to implement statistic fill for RHist3
+   // TODO: need to implement statistic fill for RHist3
 
-   reply.AddLine("Entries = 1");
-   reply.AddLine("Mean x = 2");
-   reply.AddLine("Mean y = 3");
-   reply.AddLine("Mean z = 4");
-   reply.AddLine("Std dev x = 5");
-   reply.AddLine("Std dev y = 6");
-   reply.AddLine("Std dev z = 7");
+   if (req.GetMask() & kShowEntries)
+      reply.AddLine("Entries = 1");
+
+   if (req.GetMask() & kShowMean) {
+      reply.AddLine("Mean x = 2");
+      reply.AddLine("Mean y = 3");
+      reply.AddLine("Mean z = 4");
+   }
+
+   if (req.GetMask() & kShowDev) {
+      reply.AddLine("Std dev x = 5");
+      reply.AddLine("Std dev y = 6");
+      reply.AddLine("Std dev z = 7");
+   }
+
+   if (req.GetMask() & kShowRange) {
+      reply.AddLine("X min = "s + std::to_string(req.GetMin(0)));
+      reply.AddLine("X max = "s + std::to_string(req.GetMax(0)));
+      reply.AddLine("Y min = "s + std::to_string(req.GetMin(1)));
+      reply.AddLine("Y max = "s + std::to_string(req.GetMax(1)));
+      reply.AddLine("Z min = "s + std::to_string(req.GetMin(2)));
+      reply.AddLine("Z max = "s + std::to_string(req.GetMax(2)));
+   }
+
 }
 

--- a/hist/histdrawv7/src/RHistStatBox.cxx
+++ b/hist/histdrawv7/src/RHistStatBox.cxx
@@ -8,40 +8,57 @@
 
 #include "ROOT/RHistStatBox.hxx"
 
+#include <string>
+
 using namespace ROOT::Experimental;
+using namespace std::string_literals;
+
+std::unique_ptr<RDrawableRequest> RHistStatRequest::Process(std::shared_ptr<RDrawable> &drawable)
+{
+   auto stat = std::dynamic_pointer_cast<RHistStatBoxBase>(drawable);
+
+   auto reply = std::make_unique<RHistStatReply>();
+
+   if (stat)
+      stat->FillStatistic(*this, *reply.get());
+
+   return reply;
+}
 
 
-void RHist1StatBox::FillStatistic(RDisplayHistStat &stat, const RPadBase &) const
+void RHist1StatBox::FillStatistic(const RHistStatRequest &req, RHistStatReply &reply) const
 {
    // need to implement statistic fill for RHist1
 
-   stat.AddLine("Entries = 1");
-   stat.AddLine("Mean = 2");
-   stat.AddLine("Std dev = 3");
+   reply.AddLine("Entries = 1");
+   reply.AddLine("Mean = 2");
+   reply.AddLine("Std dev = 3");
+   reply.AddLine("X min = "s + std::to_string(req.GetMin(0)));
+   reply.AddLine("X max = "s + std::to_string(req.GetMax(0)));
 }
 
 
-void RHist2StatBox::FillStatistic(RDisplayHistStat &stat, const RPadBase &) const
+void RHist2StatBox::FillStatistic(const RHistStatRequest &req, RHistStatReply &reply) const
 {
    // need to implement statistic fill for RHist2
 
-   stat.AddLine("Entries = 1");
-   stat.AddLine("Mean x = 2");
-   stat.AddLine("Mean y = 3");
-   stat.AddLine("Std dev x = 4");
-   stat.AddLine("Std dev y = 5");
+   reply.AddLine("Entries = 1");
+   reply.AddLine("X min = "s + std::to_string(req.GetMin(0)));
+   reply.AddLine("X max = "s + std::to_string(req.GetMax(0)));
+   reply.AddLine("Y min = "s + std::to_string(req.GetMin(1)));
+   reply.AddLine("Y max = "s + std::to_string(req.GetMax(1)));
 }
 
-void RHist3StatBox::FillStatistic(RDisplayHistStat &stat, const RPadBase &) const
+void RHist3StatBox::FillStatistic(const RHistStatRequest &, RHistStatReply &reply) const
 {
    // need to implement statistic fill for RHist3
 
-   stat.AddLine("Entries = 1");
-   stat.AddLine("Mean x = 2");
-   stat.AddLine("Mean y = 3");
-   stat.AddLine("Mean z = 4");
-   stat.AddLine("Std dev x = 5");
-   stat.AddLine("Std dev y = 6");
-   stat.AddLine("Std dev z = 7");
+   reply.AddLine("Entries = 1");
+   reply.AddLine("Mean x = 2");
+   reply.AddLine("Mean y = 3");
+   reply.AddLine("Mean z = 4");
+   reply.AddLine("Std dev x = 5");
+   reply.AddLine("Std dev y = 6");
+   reply.AddLine("Std dev z = 7");
 }
 

--- a/hist/histdrawv7/src/RHistStatBox.cxx
+++ b/hist/histdrawv7/src/RHistStatBox.cxx
@@ -1,0 +1,11 @@
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RHistStatBox.hxx"
+
+

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 9/04/2020";
+   JSROOT.version = "dev 14/04/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 11/03/2020";
+   JSROOT.version = "dev 2/04/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 14/04/2020";
+   JSROOT.version = "dev 17/04/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 2/04/2020";
+   JSROOT.version = "dev 9/04/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootPainter.js
+++ b/js/scripts/JSRootPainter.js
@@ -4186,12 +4186,9 @@
    TObjectPainter.prototype.WebCanvasExec = function(exec, snapid) {
       if (!exec || (typeof exec != 'string')) return;
 
-      if (!snapid) snapid = this.snapid;
-      if (!snapid || (typeof snapid != 'string')) return;
-
       var canp = this.canv_painter();
-      if (canp && !canp._readonly && canp._websocket)
-         canp.SendWebsocket("OBJEXEC:" + snapid + ":" + exec);
+      if (canp && (typeof canp.SubmitExec == "function"))
+         canp.SubmitExec(this, exec, snapid);
    }
 
    /** @summary Fill object menu in web canvas

--- a/js/scripts/JSRootPainter.js
+++ b/js/scripts/JSRootPainter.js
@@ -2727,8 +2727,20 @@
 
    TObjectPainter.prototype = Object.create(TBasePainter.prototype);
 
+   /** @summary Assign object to the painter */
+
    TObjectPainter.prototype.AssignObject = function(obj) {
-      this.draw_object = ((obj!==undefined) && (typeof obj == 'object')) ? obj : null;
+      this.draw_object = ((obj !== undefined) && (typeof obj == 'object')) ? obj : null;
+   }
+
+   /** @summary Assign snapid to the painter
+   *
+   * @desc Identifier used to communicate with server side and identifies object on the server
+   * @private
+   */
+
+   TObjectPainter.prototype.AssignSnapId = function(id) {
+      this.snapid = id;
    }
 
    /** @summary Generic method to cleanup painter.
@@ -4188,7 +4200,7 @@
 
       var canvp = this.canv_painter();
 
-      if (!this.snapid || !canvp || canvp._readonly || !canvp._websocket || canvp._getmenu_callback)
+      if (!this.snapid || !canvp || canvp._readonly || !canvp._websocket)
          return JSROOT.CallBack(call_back);
 
       function DoExecMenu(arg) {
@@ -4217,8 +4229,8 @@
       function DoFillMenu(_menu, _reqid, _call_back, reply) {
 
          // avoid multiple call of the callback after timeout
-         if (!canvp._getmenu_callback) return;
-         delete canvp._getmenu_callback;
+         if (this._got_menu) return;
+         this._got_menu = true;
 
          if (reply && (_reqid !== reply.fId))
             console.error('missmatch between request ' + _reqid + ' and reply ' + reply.fId + ' identifiers');
@@ -4261,15 +4273,18 @@
       var reqid = this.snapid;
       if (kind) reqid += "#" + kind; // use # to separate object id from member specifier like 'x' or 'z'
 
+      var menu_callback = DoFillMenu.bind(this, menu, reqid, call_back);
+
+      this._got_menu = false;
+
       // if menu painter differs from this, remember it for further usage
       if (menu.painter)
          menu.painter.exec_painter = (menu.painter !== this) ? this : undefined;
 
-      canvp._getmenu_callback = DoFillMenu.bind(this, menu, reqid, call_back);
+      canvp.SubmitMenuRequest(this, kind, reqid, menu_callback);
 
-      canvp.SendWebsocket('GETMENU:' + reqid); // request menu items for given painter
-
-      setTimeout(canvp._getmenu_callback, 2000); // set timeout to avoid menu hanging
+      // set timeout to avoid menu hanging
+      setTimeout(menu_callback, 2000);
    }
 
    /** @summary remove all created draw attributes

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -4603,6 +4603,15 @@
       this.SendWebsocket('GETMENU:' + reqid); // request menu items for given painter
    }
 
+   TCanvasPainter.prototype.SubmitExec = function(painter, exec, snapid) {
+      if (this._readonly || !painter) return;
+
+      if (!snapid) snapid = painter.snapid;
+      if (!snapid || (typeof snapid != 'string')) return;
+
+      this.SendWebsocket("OBJEXEC:" + snapid + ":" + exec);
+   }
+
    TCanvasPainter.prototype.WindowBeforeUnloadHanlder = function() {
       // when window closed, close socket
       this.CloseWebsocket(true);

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -3124,9 +3124,14 @@
 
    TPadPainter.prototype.CheckSpecial = function(obj) {
 
-      if (!obj || (obj._typename!=="TObjArray")) return false;
+      if (!obj) return false;
 
-      if (obj.name == "ListOfColors") {
+      if (obj._typename == "TStyle") {
+         JSROOT.extend(JSROOT.gStyle, style);
+         return true;
+      }
+
+      if ((obj._typename == "TObjArray") && (obj.name == "ListOfColors")) {
 
          if (this.options && this.options.CreatePalette) {
             var arr = [];
@@ -3147,7 +3152,7 @@
          return true;
       }
 
-      if (obj.name == "CurrentColorPalette") {
+      if ((obj._typename == "TObjArray") && (obj.name == "CurrentColorPalette")) {
          var arr = [], missing = false;
          for (var n = 0; n < obj.arr.length; ++n) {
             var col = obj.arr[n];

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -4596,6 +4596,13 @@
       this.SendWebsocket("PRODUCE:" + fname);
    }
 
+   TCanvasPainter.prototype.SubmitMenuRequest = function(painter, kind, reqid, call_back) {
+      // only single request can be handled
+      this._getmenu_callback = call_back;
+
+      this.SendWebsocket('GETMENU:' + reqid); // request menu items for given painter
+   }
+
    TCanvasPainter.prototype.WindowBeforeUnloadHanlder = function() {
       // when window closed, close socket
       this.CloseWebsocket(true);
@@ -4664,8 +4671,10 @@
       } else if (msg.substr(0,5)=='MENU:') {
          // this is menu with exact identifier for object
          var lst = JSROOT.parse(msg.substr(5));
-         if (typeof this._getmenu_callback == 'function')
+         if (typeof this._getmenu_callback == 'function') {
             this._getmenu_callback(lst);
+            delete this._getmenu_callback;
+         }
       } else if (msg.substr(0,4)=='CMD:') {
          msg = msg.substr(4);
          var p1 = msg.indexOf(":"),

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -1117,14 +1117,16 @@
 
       var h = this.frame_height(),
           w = this.frame_width(),
-          grid, grid_style = JSROOT.gStyle.fGridStyle,
+          gridx = this.v7EvalAttr("gridx", false),
+          gridy = this.v7EvalAttr("gridy", false),
+          grid_style = JSROOT.gStyle.fGridStyle,
           grid_color = (JSROOT.gStyle.fGridColor > 0) ? this.get_color(JSROOT.gStyle.fGridColor) : "black";
 
       if ((grid_style < 0) || (grid_style >= JSROOT.Painter.root_line_styles.length)) grid_style = 11;
 
       // add a grid on x axis, if the option is set
-      if (this.x_handle) {
-         grid = "";
+      if (this.x_handle && gridx) {
+         var grid = "";
          for (var n=0;n<this.x_handle.ticks.length;++n)
             if (this.swap_xy)
                grid += "M0,"+this.x_handle.ticks[n]+"h"+w;
@@ -1140,8 +1142,8 @@
       }
 
       // add a grid on y axis, if the option is set
-      if (this.y_handle) {
-         grid = "";
+      if (this.y_handle && gridy) {
+         var grid = "";
          for (var n=0;n<this.y_handle.ticks.length;++n)
             if (this.swap_xy)
                grid += "M"+this.y_handle.ticks[n]+",0v"+h;
@@ -3376,7 +3378,7 @@
             if (snap._typename == "ROOT::Experimental::RPadDisplayItem")  // subpad
                return objpainter.RedrawPadSnap(snap, draw_callback);
 
-            if (objpainter.UpdateObject(snap.fDrawable || snap.fObject, snap.fOption || ""))
+            if (objpainter.UpdateObject(snap.fDrawable || snap.fObject || snap, snap.fOption || ""))
                objpainter.Redraw();
 
             continue; // call next
@@ -3425,7 +3427,7 @@
 
 
          // TODO - fDrawable is v7, fObject from v6, maybe use same data member?
-         objpainter = JSROOT.draw(this.divid, snap.fDrawable || snap.fObject, snap.fOption || "", handle);
+         objpainter = JSROOT.draw(this.divid, snap.fDrawable || snap.fObject || snap, snap.fOption || "", handle);
 
          if (!handle.completed) return; // if callback will be invoked, break while loop
       }
@@ -4633,6 +4635,7 @@
 
    });
 
+   // =============================================================
 
    function RPalettePainter(palette) {
       JSROOT.TObjectPainter.call(this, palette);
@@ -4669,8 +4672,6 @@
 
       // zmin = Math.min(contour[0], framep.zmin);
       // zmax = Math.max(contour[contour.length-1], framep.zmax);
-
-
 
       var fx = this.frame_x(),
           fy = this.frame_y(),
@@ -4837,6 +4838,7 @@
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RText", icon: "img_text", prereq: "v7more", func: "JSROOT.v7.drawText", opt: "", direct: true, csstype: "text" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RFrameTitle", icon: "img_text", func: drawFrameTitle, opt: "", direct: true, csstype: "title" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RPaletteDrawable", icon: "img_text", func: drawPalette, opt: "" });
+   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RDisplayHistStat", icon: "img_pavetext", prereq: "v7hist", func: "JSROOT.v7.drawHistStats", opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RLine", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawLine", opt: "", direct: true, csstype: "line" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RBox", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawBox", opt: "", direct: true, csstype: "box" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RMarker", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawMarker", opt: "", direct: true, csstype: "marker" });

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -3472,8 +3472,9 @@
       if (pp && pp._fast_drawing) return false;
 
       var fp = this.frame_painter();
+      if (!fp) return false;
 
-      if (fp && this.v7CanSubmitRequest()) {
+      if (this.v7CommMode() == JSROOT.v7.CommMode.kNormal) {
          // submit request to server
          // last request will be always submittef
          var req = {
@@ -3481,7 +3482,7 @@
             xmin: [fp.scale_xmin, fp.scale_ymin],
             xmax: [fp.scale_xmax, fp.scale_ymax]
          };
-         this.v7SubmitRequest("stat", req, this.UpdateStatistic);
+         this.v7SubmitRequest("stat", req, this.UpdateStatistic.bind(this));
          return !!this.stats_lines; // if old statistic there - show it
       }
 

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -3479,6 +3479,7 @@
          // last request will be always submittef
          var req = {
             _typename: "ROOT::Experimental::RHistStatRequest",
+            mask: this.GetObject().fShowMask,
             xmin: [fp.scale_xmin, fp.scale_ymin],
             xmax: [fp.scale_xmax, fp.scale_ymax]
          };
@@ -3565,6 +3566,38 @@
 
       if (this.FillStatistic())
          this.DrawStatistic(this.stats_lines);
+
+      if (JSROOT.gStyle.ContextMenu)
+         this.draw_g.on("contextmenu", this.ShowContextMenu.bind(this));
+   }
+
+   RHistStatsPainter.prototype.ChangeMask = function(nbit) {
+      var obj = this.GetObject(), mask = (1<<nbit);
+      if (obj.fShowMask & mask)
+         obj.fShowMask = obj.fShowMask & ~mask;
+      else
+         obj.fShowMask = obj.fShowMask | mask;
+
+      if (this.FillStatistic())
+         this.DrawStatistic(this.stats_lines);
+   }
+
+   RHistStatsPainter.prototype.ShowContextMenu = function() {
+      d3.event.preventDefault();
+      d3.event.stopPropagation(); // disable main context menu
+      var evnt = d3.event;
+
+      JSROOT.Painter.createMenu(this, function(menu) {
+         var obj = menu.painter.GetObject(),
+             action = menu.painter.ChangeMask.bind(menu.painter);
+
+         menu.add("header: StatBox");
+
+         for (var n=0;n<obj.fEntries.length; ++n)
+            menu.addchk((obj.fShowMask & (1<<n)), obj.fEntries[n], n, action);
+
+         menu.painter.FillObjectExecMenu(menu, "", function() { menu.show(evnt); });
+      });
    }
 
    RHistStatsPainter.prototype.DrawStatistic = function(lines) {

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -45,10 +45,16 @@ void draw_rh2_colz()
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
 
-   // should we made special style for frame with palette?
-   canvas->GetOrCreateFrame()->Margins().SetRight(0.2_normal);
+   auto frame = canvas->GetOrCreateFrame();
 
-   canvas->GetOrCreateFrame()->SetGridX(true).SetGridY(false);
+   // should we made special style for frame with palette?
+   frame->Margins().SetRight(0.2_normal);
+
+   frame->SetGridX(true).SetGridY(false);
+
+   frame->AttrX().SetZoomMinMax(2.,8.);
+
+   frame->AttrY().SetZoomMinMax(2.,8.);
 
    canvas->Draw<RFrameTitle>("2D histogram with color palette");
 

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -47,6 +47,8 @@ void draw_rh2_colz()
    // should we made special style for frame with palette?
    canvas->GetOrCreateFrame()->Margins().SetRight(0.2_normal);
 
+   canvas->GetOrCreateFrame()->SetGridX(true).SetGridY(false);
+
    canvas->Draw<RFrameTitle>("2D histogram with color palette");
 
    canvas->Draw<RPaletteDrawable>(RPalette::GetPalette(), true);

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -22,6 +22,7 @@
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/RFrameTitle.hxx"
 #include "ROOT/RPaletteDrawable.hxx"
+#include "ROOT/RHistStatBox.hxx"
 #include "ROOT/RFrame.hxx"
 #include "TRandom.h"
 
@@ -53,7 +54,10 @@ void draw_rh2_colz()
 
    canvas->Draw<RPaletteDrawable>(RPalette::GetPalette(), true);
 
-   auto draw1 = canvas->Draw(pHist);
+   canvas->Draw(pHist);
+
+   auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist2");
+   stat->AttrFill().SetColor(RColor::kRed);
 
    canvas->Show("1000x700");
 }


### PR DESCRIPTION
This is special drawable, which I used as playground for new functionality.

`RHistStatBox` class is drawable, which hold reference to histogram and can calculate statistic in range, selected in the `RFrame` on the client side. If there are several clients (several web browsers with shown canvas) each client will be able to select zoomed range individually and get right statistic. If necessary, several `RHistStatBox` for different histograms can be shown on the RCanvas - even if only one histogram is displayed.

`RHistStatBox` object instance is not send to client as simple `RText` or `RLine`. Instead - only css attributes (fill, line, text colors etc) are send. This is necessary, while otherwise histogram will be send - and it can be huge. 

Special `RDrawableRequest` / `RDrawableReply` classes are introduced. They allow to submit any kind of request to selected drawable from the client. Now it is universal method to access C++ functionality from JavaScript. It is replacement to `gROOT->ProcessLine()` which was used up to now. 

Dedicated `RStatBoxRequest` class used to get statbox lines every time when zooming is changed. Via `friend class` relation it can access private methods in `RHistStatBox`. This is solution for methods which should remain protected from user.

For the future. `RHistStatBox` can be generalized - one can extract `RStatBox` base class and use it to implement statbox for `RGraph`, `RProfile` or any other classes where it make sense.

Here is actual screenshot:
![Canvas](https://user-images.githubusercontent.com/4936580/79573534-181ec500-80bf-11ea-9326-659b06fcbdf2.png)

