### PR TITLE
 Fix the full training recurrent tests in TMVA/DNN/RNN

### DIFF
--- a/tmva/tmva/test/DNN/RNN/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/RNN/CMakeLists.txt
@@ -56,12 +56,13 @@ ROOT_ADD_TEST(TMVA-DNN-RNN-Forwaed-Cudnn COMMAND testRecurrentForwardPassCudnn)
 CUDA_ADD_EXECUTABLE(testRecurrentBackpropagationCudnn TestRecurrentBackpropagationCudnn.cxx)
 target_link_libraries(testRecurrentBackpropagationCudnn ${Libraries} ${DNN_CUDA_LIBRARIES})
 ROOT_ADD_TEST(TMVA-DNN-RNN-BackpropagationCudnn COMMAND testRecurrentBackpropagationCudnn)
-endif()
 
 # Full Test GPU
 CUDA_ADD_EXECUTABLE(testFullRNNCudnn TestFullRNNCudnn.cxx)
 target_link_libraries(testFullRNNCudnn ${Libraries} ${DNN_CUDA_LIBRARIES})
 ROOT_ADD_TEST(TMVA-DNN-RNN-Full-Cudnn COMMAND testFullRNNCudnn)
+
+endif()
 
 endif()
 

--- a/tmva/tmva/test/DNN/RNN/TestFullRNN.h
+++ b/tmva/tmva/test/DNN/RNN/TestFullRNN.h
@@ -86,6 +86,11 @@ auto testFullRNN(TString rnnType, size_t batchSize, size_t stateSize,
    // so make sure time = 1, in the current case
    size_t timeSteps = 1;
 
+   // fix random seed
+   TRandom3 rndm(12345);
+   UInt_t arch_seed = rndm.Integer(TMath::Limits<UInt_t>::Max());
+   Architecture::SetRandomSeed(arch_seed);
+
    Tensor_t XArch = Architecture::CreateTensor(batchSize, timeSteps, inputSize); // B x T x D
 
    randomBatch(XArch);


### PR DESCRIPTION
Fix test tolerance to avoid some failures observed in the last nightly builds 
Do not build cudnn full test for simple RNN when cudnn is not available