### PR TITLE
Fix a TMathText issue in batch mode

### DIFF
--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -590,6 +590,11 @@ void TMathText::PaintMathText(Double_t x, Double_t y, Double_t angle,
    Short_t saveAlign = fTextAlign;
 
    TAttText::Modify();
+   if (gVirtualPS) { // Initialise TMathTextRenderer
+      if (gPad->IsBatch()) {
+         if (gVirtualPS->InheritsFrom("TImageDump")) gPad->PaintText(0, 0, "");
+      }
+   }
 
    // Do not use Latex if font is low precision.
    if (fTextFont % 10 < 2) {


### PR DESCRIPTION
Fix Jira report [7435]
In batch mode bit map output like png produced wrong TMathText rendering 
in some specific case like the following:
```
{
   gROOT->SetBatch(1);
   TCanvas *c = new TCanvas("cname", "ctitle");
   TMathText *mt = new TMathText(.4,.5,"TM1");
   mt->Draw(); mt->SetTextColor(kRed);
   c->Print("tinytex.png");
}
```
In the file `tinytex.png` the characters T,M and 1 were all at the same place. 