### PR TITLE
[cxxmodules] Convert filename to a module name.

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3940,7 +3940,8 @@ static llvm::StringRef GetModuleNameFromRdictName(llvm::StringRef rdictName)
    // Try to get the module name in the modulemap based on the filepath.
    llvm::StringRef moduleName = llvm::sys::path::filename(rdictName);
    moduleName.consume_front("lib");
-   moduleName.consume_back("_rdict.pcm");
+   moduleName.consume_back(".pcm");
+   moduleName.consume_back("_rdict");
    return moduleName;
 }
 


### PR DESCRIPTION
This fixes the Module X not found rootcling diagnostic when rootcling -m X.pcm is specified.

This PR fixes an issue introduced in 39fe86316f49250664eaaaaece8a3f382912e768.

cc: @oshadura, @davidlange6, @smuzaffar  