### PR TITLE
Fix leak shown in ROOT-10696.

### DIFF
--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -741,6 +741,20 @@ TObject *TKey::ReadObj()
       return (TObject*)ReadObjectAny(0);
    }
 
+   struct CleanUp {
+      TKey *fKey;
+      CleanUp(TKey *key) : fKey(key) {}
+      ~CleanUp() {
+         delete fKey->fBufferRef;
+         fKey->fBufferRef = nullptr;
+         // This 'if' is why we can't use TKey::DeleteBuffer
+         if (fKey->fObjlen > fKey->fNbytes - fKey->fKeylen)
+            delete [] fKey->fBuffer;
+         fKey->fBuffer = nullptr;
+      }
+   };
+   CleanUp clean(this);
+
    fBufferRef = new TBufferFile(TBuffer::kRead, fObjlen+fKeylen);
    if (!fBufferRef) {
       Error("ReadObj", "Cannot allocate buffer: fObjlen = %d", fObjlen);
@@ -884,6 +898,20 @@ TObject *TKey::ReadObjWithBuffer(char *bufferRead)
       return (TObject*)ReadObjectAny(0);
    }
 
+   struct CleanUp {
+      TKey *fKey;
+      CleanUp(TKey *key) : fKey(key) {}
+      ~CleanUp() {
+         delete fKey->fBufferRef;
+         fKey->fBufferRef = nullptr;
+         // This 'if' is why we can't use TKey::DeleteBuffer
+         if (fKey->fObjlen > fKey->fNbytes - fKey->fKeylen)
+            delete [] fKey->fBuffer;
+         fKey->fBuffer = nullptr;
+      }
+   };
+   CleanUp clean(this);
+
    fBufferRef = new TBufferFile(TBuffer::kRead, fObjlen+fKeylen);
    if (!fBufferRef) {
       Error("ReadObjWithBuffer", "Cannot allocate buffer: fObjlen = %d", fObjlen);
@@ -1009,6 +1037,20 @@ CLEAR:
 
 void *TKey::ReadObjectAny(const TClass* expectedClass)
 {
+   struct CleanUp {
+      TKey *fKey;
+      CleanUp(TKey *key) : fKey(key) {}
+      ~CleanUp() {
+         delete fKey->fBufferRef;
+         fKey->fBufferRef = nullptr;
+         // This 'if' is why we can't use TKey::DeleteBuffer
+         if (fKey->fObjlen > fKey->fNbytes - fKey->fKeylen)
+            delete [] fKey->fBuffer;
+         fKey->fBuffer = nullptr;
+      }
+   };
+   CleanUp clean(this);
+
    fBufferRef = new TBufferFile(TBuffer::kRead, fObjlen+fKeylen);
    if (!fBufferRef) {
       Error("ReadObj", "Cannot allocate buffer: fObjlen = %d", fObjlen);
@@ -1148,6 +1190,20 @@ void *TKey::ReadObjectAny(const TClass* expectedClass)
 Int_t TKey::Read(TObject *obj)
 {
    if (!obj || (GetFile()==0)) return 0;
+
+   struct CleanUp {
+      TKey *fKey;
+      CleanUp(TKey *key) : fKey(key) {}
+      ~CleanUp() {
+         delete fKey->fBufferRef;
+         fKey->fBufferRef = nullptr;
+         // This 'if' is why we can't use TKey::DeleteBuffer
+         if (fKey->fObjlen > fKey->fNbytes - fKey->fKeylen)
+            delete [] fKey->fBuffer;
+         fKey->fBuffer = nullptr;
+      }
+   };
+   CleanUp clean(this);
 
    fBufferRef = new TBufferFile(TBuffer::kRead, fObjlen+fKeylen);
    fBufferRef->SetParent(GetFile());


### PR DESCRIPTION
In the error code pass of TKey::Read*, the buffer cleanup was not done (it
was suppposed to be done via a goto!