### PR TITLE
[PyROOT][ROOT-10693] Add __iter__ pythonization for iterators

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -1147,6 +1147,8 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
     else if (name.find("iterator") != std::string::npos || gIteratorTypes.find(name) != gIteratorTypes.end()) {
         ((PyTypeObject*)pyclass)->tp_iternext = (iternextfunc)StlIterNext;
         Utility::AddToClass(pyclass, CPPYY__next__, (PyCFunction)StlIterNext, METH_NOARGS);
+        ((PyTypeObject*)pyclass)->tp_iter = (getiterfunc)PyObject_SelfIter;
+        Utility::AddToClass(pyclass, "__iter__", (PyCFunction)PyObject_SelfIter, METH_NOARGS);
     }
 
     else if (name == "string" || name == "std::string") { // TODO: ask backend as well

--- a/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
@@ -88,6 +88,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_str_repr tobjstring_str_repr.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tobjstring_comparisonops tobjstring_comparisonops.py)
 
 # RVec and subclasses pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_rvec rvec.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_rvec_asrvec rvec_asrvec.py DEPENDENCIES_FOUND ${NUMPY_FOUND})
 
 # RDataFrame and subclasses pythonizations

--- a/bindings/pyroot_experimental/pythonizations/test/rvec.py
+++ b/bindings/pyroot_experimental/pythonizations/test/rvec.py
@@ -1,0 +1,31 @@
+import unittest
+import ROOT
+
+
+class RVec(unittest.TestCase):
+    fundamental_types = ['int', 'unsigned int', 'long', 'long long', 'Long64_t', 'unsigned long',
+                         'unsigned long long', 'ULong64_t', 'float', 'double']
+    extra_types = ['bool']
+
+
+    def test_iteriter(self):
+        '''
+        Test the iteration over the iterator of an iterator
+
+        This breaks if __iter__ or tp_iter is not defined for the iterator and causes
+        issues, e.g., in comparison to numpy arrays.
+        '''
+
+        for dtype in self.fundamental_types + self.extra_types:
+            rvec = ROOT.VecOps.RVec[dtype](3)
+            it = iter(rvec)
+            it2 = iter(it)
+            self.assertEqual(it, it2)
+            c = 0 # Prevent potential optimization of the loop
+            for x in it2:
+                c += 1
+            self.assertEqual(c, 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Returning for an iterator itself with `__iter__` ensures that we can
iterate over an iterator with an iterator, which happens for example
if you call `for x in iter(foo)`.

The upstream PR can be found here: https://bitbucket.org/wlav/cpycppyy/pull-requests/33/