### PR TITLE
[CMake] Fix SearchInstalledSoftware for old CMake versions.

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1614,8 +1614,13 @@ if (testing)
       target_compile_options(${lib} INTERFACE -Wno-deprecated-copy)
     endif()
   endforeach()
-  target_include_directories(gtest INTERFACE ${GTEST_INCLUDE_DIR})
-  target_include_directories(gmock INTERFACE ${GMOCK_INCLUDE_DIR})
+  # Once we require at least cmake 3.11, target_include_directories will work for imported targets
+  # Because of https://gitlab.kitware.com/cmake/cmake/-/merge_requests/1264
+  # We need this workaround:
+  SET_PROPERTY(TARGET gtest APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${GTEST_INCLUDE_DIR})
+  SET_PROPERTY(TARGET gmock APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${GMOCK_INCLUDE_DIR})
+  #target_include_directories(gtest INTERFACE ${GTEST_INCLUDE_DIR})
+  #target_include_directories(gmock INTERFACE ${GMOCK_INCLUDE_DIR})
 
   set_property(TARGET gtest PROPERTY IMPORTED_LOCATION ${_G_LIBRARY_PATH}/gtest/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX})
   set_property(TARGET gtest_main PROPERTY IMPORTED_LOCATION ${_G_LIBRARY_PATH}/gtest/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX})


### PR DESCRIPTION
In cmake < 3.11, one cannot use `target_include_directories` for
imported targets. Therefore, a workaround explicitly setting the
properties was necessary.
The PR CI apparently didn't catch this, since for now it's only failing on ubuntu 18.04.