### PR TITLE
[Old PyROOT] Fix -Wmissing-field-initializers in python bindings for Py3.8/3.9

### DIFF
--- a/bindings/pyroot/src/MethodProxy.cxx
+++ b/bindings/pyroot/src/MethodProxy.cxx
@@ -845,7 +845,8 @@ PyTypeObject MethodProxy_Type = {
    sizeof(MethodProxy),       // tp_basicsize
    0,                         // tp_itemsize
    (destructor)mp_dealloc,    // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -893,6 +894,12 @@ PyTypeObject MethodProxy_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/ObjectProxy.cxx
+++ b/bindings/pyroot/src/ObjectProxy.cxx
@@ -398,7 +398,8 @@ PyTypeObject ObjectProxy_Type = {
    sizeof(ObjectProxy),       // tp_basicsize
    0,                         // tp_itemsize
    (destructor)op_dealloc,    // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -449,6 +450,12 @@ PyTypeObject ObjectProxy_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/PropertyProxy.cxx
+++ b/bindings/pyroot/src/PropertyProxy.cxx
@@ -133,7 +133,8 @@ PyTypeObject PropertyProxy_Type = {
    sizeof(PropertyProxy),     // tp_basicsize
    0,                         // tp_itemsize
    (destructor)pp_dealloc,    // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -181,6 +182,12 @@ PyTypeObject PropertyProxy_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/PyRootType.cxx
+++ b/bindings/pyroot/src/PyRootType.cxx
@@ -232,7 +232,8 @@ PyTypeObject PyRootType_Type = {
    sizeof(PyROOT::PyRootClass),// tp_basicsize
    0,                         // tp_itemsize
    0,                         // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -280,6 +281,12 @@ PyTypeObject PyRootType_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/Pythonize.cxx
+++ b/bindings/pyroot/src/Pythonize.cxx
@@ -944,6 +944,12 @@ namespace {
 #if PY_VERSION_HEX >= 0x03040000
       , 0                        // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+      , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+      , 0                        // tp_print (python 3.8 only)
+#endif
+#endif
    };
 
    static PyObject* vector_iter( PyObject* v ) {

--- a/bindings/pyroot/src/RootModule.cxx
+++ b/bindings/pyroot/src/RootModule.cxx
@@ -134,6 +134,12 @@ static PyTypeObject PyNullPtr_t_Type = {
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
+#endif
 };
 
 PyObject _PyROOT_NullPtrStruct = {

--- a/bindings/pyroot/src/TCustomPyTypes.cxx
+++ b/bindings/pyroot/src/TCustomPyTypes.cxx
@@ -19,7 +19,8 @@ PyTypeObject TCustomFloat_Type = {     // python float is a C/C++ double
    0,                         // tp_basicsize
    0,                         // tp_itemsize
    0,                         // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -69,6 +70,12 @@ PyTypeObject TCustomFloat_Type = {     // python float is a C/C++ double
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
 #endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
+#endif
 };
 
 //= long type allowed for reference passing ==================================
@@ -78,7 +85,8 @@ PyTypeObject TCustomInt_Type = {       // python int is a C/C++ long
    0,                         // tp_basicsize
    0,                         // tp_itemsize
    0,                         // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -127,6 +135,12 @@ PyTypeObject TCustomInt_Type = {       // python int is a C/C++ long
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 
@@ -277,7 +291,8 @@ PyTypeObject TCustomInstanceMethod_Type = {
    0,                         // tp_basicsize
    0,                         // tp_itemsize
    (destructor)im_dealloc,    // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -326,6 +341,12 @@ PyTypeObject TCustomInstanceMethod_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/TTupleOfInstances.cxx
+++ b/bindings/pyroot/src/TTupleOfInstances.cxx
@@ -42,7 +42,8 @@ PyTypeObject TTupleOfInstances_Type = {
    0,                         // tp_basicsize
    0,                         // tp_itemsize
    0,                         // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -91,6 +92,12 @@ PyTypeObject TTupleOfInstances_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 

--- a/bindings/pyroot/src/TemplateProxy.cxx
+++ b/bindings/pyroot/src/TemplateProxy.cxx
@@ -492,7 +492,8 @@ PyTypeObject TemplateProxy_Type = {
    sizeof(TemplateProxy),     // tp_basicsize
    0,                         // tp_itemsize
    (destructor)tpp_dealloc,   // tp_dealloc
-   0,                         // tp_print
+   0,                         // tp_print (python < 3.8)
+                              // tp_vectorcall_offset (python >= 3.8)
    0,                         // tp_getattr
    0,                         // tp_setattr
    0,                         // tp_compare
@@ -540,6 +541,12 @@ PyTypeObject TemplateProxy_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03040000
    , 0                        // tp_finalize
+#endif
+#if PY_VERSION_HEX >= 0x03080000
+   , 0                        // tp_vectorcall
+#if PY_VERSION_HEX < 0x03090000
+   , 0                        // tp_print (python 3.8 only)
+#endif
 #endif
 };
 


### PR DESCRIPTION
This PR is based on:

https://github.com/root-project/root/pull/5158

by @ellert but it keeps only the changes for the old PyROOT. As discussed in the PR above, the new warnings in Py3.8/3.9 are already taken care of in experimental PyROOT.