### PR TITLE
[Python] Add requirements.txt and test

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -14,6 +14,9 @@ endif()
 # Test ROOT module
 ROOT_ADD_PYUNITTEST(pyroot_root_module root_module.py)
 
+# Test versions of Python dependencies
+ROOT_ADD_PYUNITTEST(pyroot_dependency_versions dependency_versions.py)
+
 # General pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py DEPENDENCIES_FOUND ${NUMPY_FOUND})

--- a/bindings/pyroot/pythonizations/test/dependency_versions.py
+++ b/bindings/pyroot/pythonizations/test/dependency_versions.py
@@ -5,6 +5,18 @@ import os
 import sys
 
 
+# Compile list of packages to be ignored in the test
+ignore = []
+
+if sys.version_info[0] == 2 and "ROOTTEST_IGNORE_NUMBA_PY2" in os.environ or \
+   sys.version_info[0] == 3 and "ROOTTEST_IGNORE_NUMBA_PY3" in os.environ:
+       ignore += ['numba', 'cffi']
+
+if sys.version_info[0] == 2 and "ROOTTEST_IGNORE_JUPYTER_PY2" in os.environ or \
+   sys.version_info[0] == 3 and "ROOTTEST_IGNORE_JUPYTER_PY3" in os.environ:
+       ignore += ['notebook', 'metakernel']
+
+
 class DependencyVersions(unittest.TestCase):
     def test_versions(self):
         '''
@@ -25,9 +37,13 @@ class DependencyVersions(unittest.TestCase):
         requirements = pkg_resources.parse_requirements(f)
         errors = []
         for requirement in requirements:
-            name = str(requirement)
+            requirement_str = str(requirement)
+            name = requirement.project_name
+            if name in ignore:
+                print('Ignore dependency {}'.format(requirement_str))
+                continue
             try:
-                pkg_resources.require(name)
+                pkg_resources.require(requirement_str)
             except Exception as e:
                 errors.append(e)
         f.close()

--- a/bindings/pyroot/pythonizations/test/dependency_versions.py
+++ b/bindings/pyroot/pythonizations/test/dependency_versions.py
@@ -1,0 +1,43 @@
+import unittest
+import pkg_resources
+import subprocess
+import os
+import sys
+
+
+class DependencyVersions(unittest.TestCase):
+    def test_versions(self):
+        '''
+        Test the versions of the installed packages versus the
+        requirements file in ROOT
+        '''
+        # For implementation details see
+        # https://stackoverflow.com/questions/16294819/check-if-my-python-has-all-required-packages/45474387#45474387
+
+        # Get source directory with requirements.txt
+        p = subprocess.Popen(['root-config', '--srcdir'], stdout=subprocess.PIPE)
+        r, _ = p.communicate()
+        rootsrc = r.decode('UTF-8').strip()
+
+        # Check each requirement separately
+        path = os.path.join(rootsrc, 'requirements.txt')
+        f = open(path)
+        requirements = pkg_resources.parse_requirements(f)
+        errors = []
+        for requirement in requirements:
+            name = str(requirement)
+            try:
+                pkg_resources.require(name)
+            except Exception as e:
+                errors.append(e)
+        f.close()
+        if errors:
+            print()
+            print('Full path to requirements.txt: {}'.format(path))
+            print('Details about not matched dependencies:')
+            print('\n'.join([' - ' + e.report() for e in errors]))
+            raise Exception('Found not matched dependencies declared in the requirements.txt, see test output for details')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# ROOT requirements for third-party Python packages
+
+# PyROOT: ROOT.Numba.Declare decorator
+numba>=0.47.0
+cffi>=1.9.1
+
+# Notebooks: ROOT C++ kernel
+notebook>=4.4.1
+metakernel>=0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 # ROOT requirements for third-party Python packages
 
+# PyROOT: Interoperability with numpy arrays
+# TMVA: PyMVA interfaces
+numpy>=1.4.1
+
 # PyROOT: ROOT.Numba.Declare decorator
 numba>=0.47.0
 cffi>=1.9.1


### PR DESCRIPTION
Proposal to add a `requirements.txt` file and a corresponding test checking the dependencies also by the version requirement.

The test throws an error for each dependency seperately due to the `SubTest`. A single exception looks like this:

```
3: pkg_resources.VersionConflict: (xgboost 0.80 (/home/stefan/.local/lib/python3.8/site-packages), Requirement.parse('xgboost>=0.81'))
```

@eguiraud @Axel-Naumann @etejedor @oshadura Ping :)