### PR TITLE
Resolve ROOT-10108  and ROOT-10156 

### DIFF
--- a/graf3d/eve/inc/TEveTrackPropagator.h
+++ b/graf3d/eve/inc/TEveTrackPropagator.h
@@ -44,16 +44,20 @@ public:
       printf("v(%f, %f, %f) B(%f, %f, %f) \n", x, y, z, b.fX, b.fY, b.fZ);
    }
 
+   // Track propagator uses only GetFieldD() and GetMaxFieldMagD().
+   //
+   // Here, in this base-class, we have to keep float versions GetField() and GetMaxFieldMag() as
+   // primary sources of field data (for backward compatibility in ALICE and CMS).
+   //
+   // One only needs to redefine the double versions in subclasses.
+
+   virtual Double_t    GetMaxFieldMagD() const { return GetMaxFieldMag(); }
+   virtual TEveVectorD GetFieldD(Double_t x, Double_t y, Double_t z) const { return GetField(x, y, z); }
+
    TEveVectorD GetFieldD(const TEveVectorD &v) const { return GetFieldD(v.fX, v.fY, v.fZ); }
 
-   // Track propgator uses only GetFieldD() and GetMaxFieldMagD(). Have to keep/reuse
-   // GetField() and GetMaxFieldMag() because of backward compatibility.
-
-   virtual TEveVectorD GetFieldD(Double_t x, Double_t y, Double_t z) const { return GetField(x, y, z); }
-   virtual Double_t GetMaxFieldMagD() const { return GetMaxFieldMag(); } // not abstract because of backward compatibility
-
+   virtual Float_t    GetMaxFieldMag() const { return 4; }
    virtual TEveVector GetField(Float_t, Float_t, Float_t) const { return TEveVector(); }
-   virtual Float_t GetMaxFieldMag() const { return 4; } // not abstract because of backward compatibility
 
    ClassDef(TEveMagField, 0); // Abstract interface to magnetic field
 };
@@ -74,9 +78,8 @@ public:
    { fFieldConstant = kTRUE; }
    virtual ~TEveMagFieldConst() {}
 
-   using   TEveMagField::GetField;
+   virtual Double_t    GetMaxFieldMagD() const { return fB.Mag(); };
    virtual TEveVectorD GetFieldD(Double_t /*x*/, Double_t /*y*/, Double_t /*z*/) const { return fB; }
-   virtual Double_t GetMaxFieldMagD() const { return fB.Mag(); };
 
    ClassDef(TEveMagFieldConst, 0); // Interface to constant magnetic field.
 };
@@ -102,12 +105,10 @@ public:
    }
    virtual ~TEveMagFieldDuo() {}
 
-   using   TEveMagField::GetField;
+   virtual Double_t GetMaxFieldMagD() const { return std::max(fBIn.Mag(), fBOut.Mag()); }
+
    virtual TEveVectorD GetFieldD(Double_t x, Double_t y, Double_t /*z*/) const
    { return  ((x*x+y*y)<fR2) ? fBIn : fBOut; }
-
-   virtual Double_t GetMaxFieldMagD() const
-   { Double_t b1 = fBIn.Mag(), b2 = fBOut.Mag(); return b1 > b2 ? b1 : b2; }
 
    ClassDef(TEveMagFieldDuo, 0); // Interface to magnetic field with two different values depending on radius.
 };

--- a/graf3d/eve/src/TEveTrackPropagator.cxx
+++ b/graf3d/eve/src/TEveTrackPropagator.cxx
@@ -890,8 +890,9 @@ Bool_t TEveTrackPropagator::HelixIntersectPlane(const TEveVectorD& p,
       }
       if (new_d > 0)
       {
-         delta = forwV - pos;
-         itsect = pos + delta * (d / (d - new_d));
+         delta  = forwV - pos4;
+         itsect = pos4 + delta * ((point - pos4).Dot(n) / delta.Dot(n));
+
          return kTRUE;
       }
       pos4 = forwV;
@@ -942,7 +943,7 @@ Bool_t TEveTrackPropagator::IntersectPlane(const TEveVectorD& p,
                                            const TEveVectorD& normal,
                                                  TEveVectorD& itsect)
 {
-   if (fH.fCharge && fMagFieldObj && p.Perp2() > kPtMinSqr)
+   if (fH.fCharge && fMagFieldObj)
       return HelixIntersectPlane(p, point, normal, itsect);
    else
       return LineIntersectPlane(p, point, normal, itsect);

--- a/graf3d/eve/src/TEveTrackPropagator.cxx
+++ b/graf3d/eve/src/TEveTrackPropagator.cxx
@@ -22,7 +22,16 @@
 \ingroup TEve
 Abstract base-class for interfacing to magnetic field needed by the
 TEveTrackPropagator.
-See sub-classes for two simple implementations.
+
+To implement your own version, redefine the following virtual functions:
+   virtual Double_t    GetMaxFieldMagD() const;
+   virtual TEveVectorD GetFieldD(Double_t x, Double_t y, Double_t z) const;
+
+See sub-classes TEveMagFieldConst and TEveMagFieldDuo for two simple implementations.
+
+NOTE: For backward compatibility float versions are the primary
+sources of field information in this base-class. The float versions are
+not used in TEve and can be ignored in sub-classes.
 
 NOTE: Magnetic field direction convention is inverted.
 */

--- a/graf3d/eve7/inc/ROOT/REveTrackPropagator.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTrackPropagator.hxx
@@ -47,20 +47,10 @@ public:
       printf("v(%f, %f, %f) B(%f, %f, %f) \n", x, y, z, b.fX, b.fY, b.fZ);
    }
 
-   REveVectorD GetFieldD(const REveVectorD &v) const { return GetFieldD(v.fX, v.fY, v.fZ); }
+   virtual Double_t    GetMaxFieldMag() const = 0;
+   virtual REveVectorD GetField(Double_t x, Double_t y, Double_t z) const = 0;
 
-   // Track propgator uses only GetFieldD() and GetMaxFieldMagD(). Have to keep/reuse
-   // GetField() and GetMaxFieldMag() because of backward compatibility.
-
-   virtual REveVectorD GetFieldD(Double_t x, Double_t y, Double_t z) const { return GetField(x, y, z); }
-   virtual Double_t GetMaxFieldMagD() const
-   {
-      return GetMaxFieldMag();
-   } // not abstract because of backward compatibility
-
-   virtual REveVector GetField(Float_t, Float_t, Float_t) const { return REveVector(); }
-   virtual Float_t GetMaxFieldMag() const { return 4; } // not abstract because of backward compatibility
-
+   REveVectorD GetField(const REveVectorD &v) const { return GetField(v.fX, v.fY, v.fZ); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,9 +67,8 @@ public:
    REveMagFieldConst(Double_t x, Double_t y, Double_t z) : REveMagField(), fB(x, y, z) { fFieldConstant = kTRUE; }
    virtual ~REveMagFieldConst() {}
 
-   REveVectorD GetFieldD(Double_t /*x*/, Double_t /*y*/, Double_t /*z*/) const override { return fB; }
-
-   Double_t GetMaxFieldMagD() const override { return fB.Mag(); };
+   Double_t    GetMaxFieldMag() const override { return fB.Mag(); };
+   REveVectorD GetField(Double_t /*x*/, Double_t /*y*/, Double_t /*z*/) const override { return fB; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -102,15 +91,15 @@ public:
    }
    virtual ~REveMagFieldDuo() {}
 
-   REveVectorD GetFieldD(Double_t x, Double_t y, Double_t /*z*/) const override
-   {
-      return ((x * x + y * y) < fR2) ? fBIn : fBOut;
-   }
-
-   Double_t GetMaxFieldMagD() const override
+   Double_t GetMaxFieldMag() const override
    {
       Double_t b1 = fBIn.Mag(), b2 = fBOut.Mag();
       return b1 > b2 ? b1 : b2;
+   }
+
+   REveVectorD GetField(Double_t x, Double_t y, Double_t /*z*/) const override
+   {
+      return ((x * x + y * y) < fR2) ? fBIn : fBOut;
    }
 };
 
@@ -337,9 +326,6 @@ public:
    static Double_t fgDefMagField;        // Default value for constant solenoid magnetic field.
    static const Double_t fgkB2C;         // Constant for conversion of momentum to curvature.
    static REveTrackPropagator fgDefault; // Default track propagator.
-
-   static Double_t fgEditorMaxR; // Max R that can be set in GUI editor.
-   static Double_t fgEditorMaxZ; // Max Z that can be set in GUI editor.
 };
 
 //______________________________________________________________________________

--- a/graf3d/eve7/src/REveTrackPropagator.cxx
+++ b/graf3d/eve7/src/REveTrackPropagator.cxx
@@ -853,8 +853,8 @@ Bool_t REveTrackPropagator::HelixIntersectPlane(const REveVectorD& p,
       }
       if (new_d > 0)
       {
-         delta = forwV - pos;
-         itsect = pos + delta * (d / (d - new_d));
+         delta  = forwV - pos4;
+         itsect = pos4 + delta * ((point - pos4).Dot(n) / delta.Dot(n));
          return kTRUE;
       }
       pos4 = forwV;
@@ -905,7 +905,7 @@ Bool_t REveTrackPropagator::IntersectPlane(const REveVectorD& p,
                                            const REveVectorD& normal,
                                                  REveVectorD& itsect)
 {
-   if (fH.fCharge && fMagFieldObj && p.Perp2() > kPtMinSqr)
+   if (fH.fCharge && fMagFieldObj)
       return HelixIntersectPlane(p, point, normal, itsect);
    else
       return LineIntersectPlane(p, point, normal, itsect);

--- a/tutorials/eve/track.C
+++ b/tutorials/eve/track.C
@@ -45,7 +45,8 @@ class GappedField : public TEveMagField
 public:
    GappedField():TEveMagField(){}
    ~GappedField(){};
-   using   TEveMagField::GetField;
+
+   virtual Double_t    GetMaxFieldMagD() { return 4; }
 
    virtual TEveVectorD GetFieldD(Double_t /*x*/, Double_t /*y*/, Double_t z) const
    {
@@ -70,8 +71,8 @@ public:
       m_simpleModel(true){}
 
    virtual ~CmsMagField(){}
-   virtual Double_t   GetMaxFieldMagD() const { return m_magnetIsOn ? 3.8 : 0.0; }
-   void               setMagnetState( bool state )
+
+   void setMagnetState( bool state )
    {
       if (state != m_magnetIsOn)
       {
@@ -89,14 +90,14 @@ public:
    void setSimpleModel(bool simpleModel) { m_simpleModel = simpleModel; }
    bool isSimpleModel() const            { return m_simpleModel;}
 
-   using   TEveMagField::GetField;
+   virtual Double_t    GetMaxFieldMagD() const { return m_magnetIsOn ? 3.8 : 0.0; }
 
    virtual TEveVectorD GetFieldD(Double_t x, Double_t y, Double_t z) const
    {
       double R = sqrt(x*x+y*y);
-      double field = m_reverse?-GetMaxFieldMag():GetMaxFieldMag();
+      double field = m_reverse ? -GetMaxFieldMagD() : GetMaxFieldMagD();
       //barrel
-      if ( TMath::Abs(z)<724 )
+      if ( TMath::Abs(z) < 724 )
       {
          //inside solenoid
          if ( R < 300) return TEveVectorD(0,0,field);

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -260,7 +260,7 @@ public:
       float r = 300;
       float z = 300;
       auto prop = new REveTrackPropagator();
-      prop->SetMagFieldObj(new REveMagFieldDuo(350, -3.5, 2.0));
+      prop->SetMagFieldObj(new REveMagFieldDuo(350, 3.5, -2.0));
       prop->SetMaxR(r);
       prop->SetMaxZ(z);
       prop->SetMaxOrbs(6);

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -93,7 +93,7 @@ void addTracks()
 
    REX::REveElement* event = eveMng->GetEventScene();
    auto prop = new REX::REveTrackPropagator();
-   prop->SetMagFieldObj(new REX::REveMagFieldDuo(350, -3.5, 2.0));
+   prop->SetMagFieldObj(new REX::REveMagFieldDuo(350, 3.5, -2.0));
    prop->SetMaxR(300);
    prop->SetMaxZ(600);
    prop->SetMaxOrbs(6);
@@ -108,7 +108,7 @@ void addTracks()
    {
       TParticle* p = new TParticle();
 
-      int pdg = 11* (r.Integer(2) -1);
+      int pdg = 11 * (r.Integer(2) > 0 ? 1 : -1);
       p->SetPdgCode(pdg);
 
       p->SetProductionVertex(r.Uniform(-v,v), r.Uniform(-v,v), r.Uniform(-v,v), 1);

--- a/tutorials/eve7/tracks.C
+++ b/tutorials/eve7/tracks.C
@@ -19,10 +19,12 @@ void makeTracks(int N_Tracks, REX::REveElement* trackHolder)
 {
    TRandom &r = *gRandom;
    auto prop = new REX::REveTrackPropagator();
-   prop->SetMagFieldObj(new REX::REveMagFieldDuo(350, -3.5, 2.0));
+   prop->SetMagFieldObj(new REX::REveMagFieldDuo(350, 3.5, -2.0));
    prop->SetMaxR(300);
    prop->SetMaxZ(600);
    prop->SetMaxOrbs(6);
+   // Default is kHelix propagator.
+   // prop->SetStepper(REX::REveTrackPropagator::kRungeKutta);
 
    double v = 0.5;
    double m = 5;
@@ -31,7 +33,7 @@ void makeTracks(int N_Tracks, REX::REveElement* trackHolder)
    {
       auto p = new TParticle();
 
-      int pdg = 11*(r.Integer(2) -1);
+      int pdg = 11 * (r.Integer(2) > 0 ? 1 : -1);
       p->SetPdgCode(pdg);
 
       p->SetProductionVertex(r.Uniform(-v,v), r.Uniform(-v,v), r.Uniform(-v,v), 1);
@@ -39,7 +41,7 @@ void makeTracks(int N_Tracks, REX::REveElement* trackHolder)
       auto track = new REX::REveTrack(p, 1, prop);
       track->MakeTrack();
       track->SetMainColor(kBlue);
-      track->SetName(Form("RandomTrack_%d",i ));
+      track->SetName(Form("RandomTrack_%d", i));
       trackHolder->AddElement(track);
    }
 }
@@ -50,7 +52,7 @@ void tracks()
 
    auto trackHolder = new REX::REveElement("Tracks");
    eveMng->GetEventScene()->AddElement(trackHolder);
-   makeTracks(10, trackHolder);
+   makeTracks(100, trackHolder);
 
    eveMng->Show();
 }


### PR DESCRIPTION
Cleanup TEveMagField and REveMagField in response to ROOT-10108

- TEveMagField - clarify code, in-code comments and class documentation
  for TEveMagField.

- REveMagField - remove float versions of GetField() and clarify code.
  Remove notice about non-standard magnetic field direction.

- REveTrackPropagator - invert sense of magnetic field so it is in line
  with standard definition.

- Make corresponding changes in eve and eve-7 tutorials.
Commits on Apr 21, 2020


￼Make changes proposed in ROOT-10156

- TEveTrackPropagator::IntersectPlane() remove assumption that B-field is parallel to z.

- TEveTrackPropagator::HelixIntersectPlane() make calculation of intersect point
  more precise by using interpolation between the last two points in the approach sequence.