### PR TITLE
[RF] Add validity checks for RooFormula.

### DIFF
--- a/roofit/roofitcore/inc/RooFormula.h
+++ b/roofit/roofitcore/inc/RooFormula.h
@@ -80,7 +80,7 @@ private:
   std::string processFormula(std::string origFormula) const;
   RooArgList  usedVariables() const;
   std::string reconstructFormula(std::string internalRepr) const;
-  std::vector<bool> findCategoryServers(const RooAbsCollection& collection) const;
+  void installFormulaOrThrow(const std::string& formulaa);
 
   RooArgList _origList; //! Original list of dependents
   std::vector<bool> _isCategory; //! Whether an element of the _origList is a category.

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -16,4 +16,5 @@ ROOT_ADD_GTEST(testGenericPdf testGenericPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooProxy testRooProxy.cxx LIBRARIES RooFitCore WILLFAIL)
 ROOT_ADD_GTEST(testRooAbsPdf testRooAbsPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)
+ROOT_ADD_GTEST(testRooFormula testRooFormula.cxx LIBRARIES RooFitCore)
 

--- a/roofit/roofitcore/test/testRooFormula.cxx
+++ b/roofit/roofitcore/test/testRooFormula.cxx
@@ -1,0 +1,33 @@
+// Tests for the RooFormula
+// Author: Stephan Hageboeck, CERN  2020
+
+#include "RooFormula.h"
+#include "RooRealVar.h"
+
+#include "gtest/gtest.h"
+
+/// Since TFormula does very surprising things,
+/// RooFit needs to do safety checks.
+/// ```
+/// TFormula form("form", "x+y");
+/// form.Eval(3.);
+/// ```
+/// is, for example, legal, and silently uses an undefined
+/// value for y. RooFit needs to detect this.
+TEST(RooFormula, TestInvalidFormulae) {
+  RooRealVar x("x", "x", 1.337);
+  RooRealVar y("y", "y", -1.);
+  RooFormula form("form", "x+10", x);
+  EXPECT_FLOAT_EQ(form.eval(nullptr), 11.337);
+
+  ASSERT_ANY_THROW(RooFormula("form", "x+y", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
+  ASSERT_ANY_THROW(RooFormula("form", "x+z", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
+  ASSERT_ANY_THROW(RooFormula("form", "x+t", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
+  ASSERT_ANY_THROW(RooFormula("form", "x+a", x)) << "Formulae with unknown variable cannot work.";
+
+  RooFormula* form6 = nullptr;
+  ASSERT_NO_THROW( form6 = new RooFormula("form", "x+y", RooArgSet(x,y))) << "Formula with x,y must work.";
+  ASSERT_NE(form6, nullptr);
+  EXPECT_FLOAT_EQ(form6->eval(nullptr), 1.337 - 1.);
+  delete form6;
+}


### PR DESCRIPTION
Since TFormula accepts seriously broken formulae, "x+t" is, for example,
interpreted as a four-dimensional formula that can be evaluated
using Eval(x=2), using undefined values for {y,z,t}, RooFit needs to do
some safety checks. This formula would otherwise be valid in RooFit:
  RooFormula form("form", "x<y", x);

That's an aftermath to #5360, where Enrico correctly raised that point that only writing a warning in the documentation will not help most users.