### PR TITLE
Fix makeimage.py for python scripts using argparse

### DIFF
--- a/documentation/doxygen/makeimage.py
+++ b/documentation/doxygen/makeimage.py
@@ -3,6 +3,7 @@
 import ROOT
 import shutil
 import os
+import sys
 
 def makeimage(MacroName, ImageName, OutDir, cp, py, batch):
     '''Generates the ImageName output of the macro MacroName'''
@@ -12,6 +13,7 @@ def makeimage(MacroName, ImageName, OutDir, cp, py, batch):
     if batch:
         ROOT.gROOT.SetBatch(1)
 
+    sys.argv = [MacroName]
     if py: exec(open(MacroName).read(), globals())
     else: ROOT.gInterpreter.ProcessLine(".x " + MacroName)
 
@@ -20,6 +22,7 @@ def makeimage(MacroName, ImageName, OutDir, cp, py, batch):
         MNBase = os.path.basename(MN)
         shutil.copyfile("%s" %MN,"%s/macros/%s" %(OutDir,MNBase))
 
+    ImageNum = 0
     s = open ("ImagesSizes.dat","w")
 
     canvases = ROOT.gROOT.GetListOfCanvases()

--- a/documentation/doxygen/makeimage.py
+++ b/documentation/doxygen/makeimage.py
@@ -13,9 +13,11 @@ def makeimage(MacroName, ImageName, OutDir, cp, py, batch):
     if batch:
         ROOT.gROOT.SetBatch(1)
 
-    sys.argv = [MacroName]
-    if py: exec(open(MacroName).read(), globals())
-    else: ROOT.gInterpreter.ProcessLine(".x " + MacroName)
+    if py:
+        sys.argv = [MacroName]
+        exec(open(MacroName).read(), globals())
+    else:
+        ROOT.gInterpreter.ProcessLine(".x " + MacroName)
 
     if cp:
         MN = MacroName.split("(")[0]


### PR DESCRIPTION
Some tutorials written in python use argparse (like df105*). 
This fix allows to run them from "makeimage.py".