### PR TITLE
Remove  math/minuit2/.gitignore [skip-ci]

### DIFF
--- a/math/minuit2/.gitignore
+++ b/math/minuit2/.gitignore
@@ -1,7 +1,0 @@
-*build*
-src/math/*.cxx
-inc/Math/*
-inc/Fit/*
-LGPL2_1.txt
-LICENSE
-version_number

--- a/math/minuit2/DEVELOP.md
+++ b/math/minuit2/DEVELOP.md
@@ -12,13 +12,14 @@ cmake .. -Dminuit2_standalone=ON
 This will fill in the `math/minuit2` directory with all the files needed for Minuit2, copied from the corresponding ROOT files, as part of the configure step.
 At this point, you could continue to build (using `make`). Note that the CMake option `minuit2_inroot` will automatically be set to `ON` if you are inside the ROOT source tree. Setting `minuit2_standalone` requires that this be inside the ROOT source tree. As always, any manual setting of a cached variable in CMake will be remembered as long as the `CMakeCache.txt` file is not removed.
 
-You can remove the copied files using:
+Remember that after building a tarball or a binary package you should remove the copied files using:
 
 ```bash
 make purge
 ```
 
-(The files are ignored by git, so standard git tools to remove untracked files work as well.)
+Otherwise git shows the file as untracked, unless you explicitly remove their tracking yourself with a .gitignore file
+
 
 ## Building a tarball
 


### PR DESCRIPTION
 Remove a .gitignore file in minuit2 which can cause the remaining of duplicate files in local repo after having build a standalone minuit2 tarball.

The file was used to mask files which are copied inside the minuit2 source directory when building the standalone distribution. 
These files should be deleted after building the standalone distribution by a `make purge` command. 

Update the documentation of building minui2 tarballs