### PR TITLE
Fix dependency of Mathcore from Mathmore

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -68,11 +68,8 @@ set(HEADERS
   Math/MultiDimParamFunctionAdapter.h
   Math/OneDimFunctionAdapter.h
   Math/ParamFunctor.h
-  Math/PdfFunc.h
   Math/PdfFuncMathCore.h
-  Math/ProbFunc.h
   Math/ProbFuncMathCore.h
-  Math/QuantFunc.h
   Math/QuantFuncMathCore.h
   Math/Random.h
   Math/RandomFunctions.h

--- a/math/mathcore/src/RandomFunctions.cxx
+++ b/math/mathcore/src/RandomFunctions.cxx
@@ -16,7 +16,7 @@
 //
 #include "Math/RandomFunctions.h"
 
-#include "Math/DistFunc.h"
+#include "Math/DistFuncMathCore.h"
 
 #include "TMath.h"
 

--- a/math/mathcore/test/testMathRandom.cxx
+++ b/math/mathcore/test/testMathRandom.cxx
@@ -5,7 +5,7 @@
 //#include "Math/MyMixMaxEngine.h"
 //#include "Math/GSLRndmEngines.h"
 #include "Math/GoFTest.h"
-#include "Math/ProbFunc.h"
+#include "Math/ProbFuncMathCore.h"
 #include "TH1.h"
 #include "TCanvas.h"
 

--- a/math/mathcore/test/testSpecFuncBeta.cxx
+++ b/math/mathcore/test/testSpecFuncBeta.cxx
@@ -5,7 +5,7 @@
 #include <cmath>
 
 #include <TMath.h>
-#include <Math/SpecFunc.h>
+#include <Math/SpecFuncMathCore.h>
 
 #include <TApplication.h>
 

--- a/math/mathcore/test/testSpecFuncBetaI.cxx
+++ b/math/mathcore/test/testSpecFuncBetaI.cxx
@@ -5,7 +5,7 @@
 #include <cmath>
 
 #include <TMath.h>
-#include <Math/SpecFunc.h>
+#include <Math/SpecFuncMathCore.h>
 
 #include <TApplication.h>
 

--- a/math/mathcore/test/testSpecFuncErf.cxx
+++ b/math/mathcore/test/testSpecFuncErf.cxx
@@ -5,7 +5,7 @@
 #include <cmath>
 
 #include <TMath.h>
-#include <Math/SpecFunc.h>
+#include <Math/SpecFuncMathCore.h>
 
 // #include "SpecFuncCephes.h"
 

--- a/math/mathcore/test/testSpecFuncSiCi.cxx
+++ b/math/mathcore/test/testSpecFuncSiCi.cxx
@@ -1,4 +1,4 @@
-#include "Math/SpecFunc.h"
+#include "Math/SpecFuncMathCore.h"
 #include <iostream>
 #include <cmath>
 


### PR DESCRIPTION
This PR removes a dependency which was wrongly added in Mathcore from Mathmore. 
Mathcore should use their own headers (e.g. PdfFuncMathCore instead of PdfFunc.h)

In addition, the files PdfFunc.h, ProbFunc.h and QuantFunc.h should not also be used when building the mathcore dictionary