### PR TITLE
[cxxmodules] Keep the pending rdict files to be re-read on reload.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1832,8 +1832,9 @@ void TCling::LoadPCM(std::string pcmFileNameFullPath)
       TMemFile pcmMemFile(RDictFileOpts.c_str(), range);
 
       LoadPCMImpl(pcmMemFile);
-
-      fPendingRdicts.erase(pendingRdict);
+      // FIXME: Uncomment this when we implement UnLoadPCM as per
+      // root-project/root#5420
+      //fPendingRdicts.erase(pendingRdict);
 
       return;
    }


### PR DESCRIPTION
When a library is re-loaded (via .L) we should reload the corresponding rdict file. However current ROOT (without modules) just re-reads the rdict file.

This patch brings this behavior for modules and is intended to be a quick fix for the os nightly failures of kind:

Error in TCling::LoadPCM: ROOT PCM /.../libTree_rdict.pcm file does not exist
Info in TCling::LoadPCM: In-memory ROOT PCM candidate /.../libASImageGui_rdict.pcm
Info in TCling::LoadPCM: In-memory ROOT PCM candidate /.../libASImage_rdict.pcmError in TCling::LoadPCM: ROOT PCM /.../libTree_rdict.pcm file does not exist
Info in TCling::LoadPCM: In-memory ROOT PCM candidate /.../libASImageGui_rdict.pcm
Info in TCling::LoadPCM: In-memory ROOT PCM candidate /.../libASImage_rdict.pcm

The continuation of this work is in root-project/root#5420