### PR TITLE
ROOT-10677: [cxxmodules] Support libcxx with glibc on unix.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -148,6 +148,15 @@ add_subdirectory(rootcling_stage1)
 #-------------------------------------------------------------------------------
 ROOT_LINKER_LIBRARY(Core $<TARGET_OBJECTS:BaseTROOT> ${objectlibs} BUILTINS LZMA)
 
+if (libcxx AND NOT APPLE)
+  # In case we use libcxx and glibc together there is a mismatch of the
+  # signatures of functions in the header wchar.h. This macro tweaks the
+  # header in rootcling resource directory to be compatible with the one from
+  # libc++.
+  target_compile_definitions(Core PRIVATE __CORRECT_ISO_CPP_WCHAR_H_PROTO)
+endif()
+
+
 ROOT_GENERATE_DICTIONARY(G__Core
   ${Core_dict_headers}
   ${Clib_dict_headers}

--- a/interpreter/cling/include/cling/libc.modulemap
+++ b/interpreter/cling/include/cling/libc.modulemap
@@ -42,6 +42,10 @@ module "libc" [system] [extern_c] [no_undeclared_includes] {
     export *
     header "signal.h"
   }
+  module "stddef.h" {
+    export *
+    textual header "stddef.h"
+  }
   module "stdio.h" {
     export *
     header "stdio.h"


### PR DESCRIPTION
This patch works around compatibility issues between libcxx and glibc. It should fix the set up of the FNAL ART framework.

Thanks to Chris Green (@chissg) this patch should resolve ROOT-10677.