### PR TITLE
[Exp PyROOT] Implement Address via LowLevelView

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
@@ -74,6 +74,7 @@ set(cpp_sources
     src/PyzCppHelpers.cxx
     src/PyzPythonHelpers.cxx
     src/CPPInstancePyz.cxx
+    src/FacadeHelpers.cxx
     ${PYROOT_EXTRA_SOURCE}
 )
 

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import libcppyy as cppyy_backend
 from cppyy import gbl as gbl_namespace
-from libROOTPythonizations import gROOT
+from libROOTPythonizations import gROOT, CreateBufferFromAddress
 
 from ._application import PyROOTApplication
 
@@ -90,20 +90,8 @@ class ROOTFacade(types.ModuleType):
         # addr is the address of the address of the object
         addr = self.addressof(instance = obj, byref = True)
 
-        # get_llv returns a buffer (LowLevelView)
-        try:
-            get_llv = gbl_namespace.PyROOT.get_llv
-        except AttributeError:
-            gbl_namespace.gInterpreter.Declare("""
-            namespace PyROOT {
-               long long *get_llv(long long addr) {
-                  return reinterpret_cast<long long*>(addr);
-               }
-            }
-            """)
-            get_llv = gbl_namespace.PyROOT.get_llv
-
-        return get_llv(addr)
+        # Create a buffer (LowLevelView) from address
+        return CreateBufferFromAddress(addr)
 
     def _set_import_hook(self):
         # This hook allows to write e.g:

--- a/bindings/pyroot_experimental/pythonizations/src/FacadeHelpers.cxx
+++ b/bindings/pyroot_experimental/pythonizations/src/FacadeHelpers.cxx
@@ -1,0 +1,46 @@
+// Author: Enric Tejedor CERN  04/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+// Bindings
+#include "FacadeHelpers.hxx"
+
+// Cppyy
+#include "LowLevelViews.h"
+
+// ROOT
+#include "RtypesCore.h"
+#include "ROOT/RConfig.hxx"
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Get a buffer starting at a given address
+/// \param[in] self Always null, since this is a module function.
+/// \param[in] addr Address to create buffer from
+///
+/// Returns a cppyy LowLevelView object on the received address, i.e. an
+/// indexable buffer starting at that address.
+PyObject *PyROOT::CreateBufferFromAddress(PyObject * /* self */, PyObject *addr)
+{
+   if (!addr) {
+      PyErr_SetString(PyExc_RuntimeError, "Unable to create buffer from invalid address");
+      return NULL;
+   }
+
+   Long64_t cAddr = PyLong_AsLongLong(addr);
+   if (cAddr == -1 && PyErr_Occurred()) {
+      PyErr_SetString(PyExc_RuntimeError, "Unable to create buffer: address is not a valid integer");
+      return NULL;
+   }
+
+#ifdef R__B64
+   return CPyCppyy::CreateLowLevelView((Long64_t*)cAddr);
+#else
+   return CPyCppyy::CreateLowLevelView((Int_t*)cAddr);
+#endif
+}

--- a/bindings/pyroot_experimental/pythonizations/src/FacadeHelpers.cxx
+++ b/bindings/pyroot_experimental/pythonizations/src/FacadeHelpers.cxx
@@ -23,8 +23,8 @@
 /// \param[in] self Always null, since this is a module function.
 /// \param[in] addr Address to create buffer from
 ///
-/// Returns a cppyy LowLevelView object on the received address, i.e. an
-/// indexable buffer starting at that address.
+/// \return A cppyy LowLevelView object on the received address, i.e. an
+///         indexable buffer starting at that address.
 PyObject *PyROOT::CreateBufferFromAddress(PyObject * /* self */, PyObject *addr)
 {
    if (!addr) {

--- a/bindings/pyroot_experimental/pythonizations/src/FacadeHelpers.hxx
+++ b/bindings/pyroot_experimental/pythonizations/src/FacadeHelpers.hxx
@@ -1,0 +1,23 @@
+// Author: Enric Tejedor CERN  04/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef PYROOT_FACADEHELPERS_H
+#define PYROOT_FACADEHELPERS_H
+
+#include "Python.h"
+
+namespace PyROOT {
+
+// Create an indexable buffer starting at the received address
+PyObject *CreateBufferFromAddress(PyObject *self, PyObject *addr);
+
+} // namespace PyROOT
+
+#endif // !PYROOT_FACADEHELPERS_H

--- a/bindings/pyroot_experimental/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot_experimental/pythonizations/src/PyROOTModule.cxx
@@ -14,6 +14,7 @@
 #include "PyROOTStrings.h"
 #include "PyROOTWrapper.h"
 #include "RPyROOTApplication.h"
+#include "FacadeHelpers.hxx"
 
 // Cppyy
 #include "CPyCppyy.h"
@@ -86,6 +87,8 @@ static PyMethodDef gPyROOTMethods[] = {
     (char *)"Deserialize a pickled object"},
    {(char *)"ClearProxiedObjects", (PyCFunction)PyROOT::ClearProxiedObjects, METH_NOARGS,
     (char *)"Clear proxied objects regulated by PyROOT"},
+   {(char *)"CreateBufferFromAddress", (PyCFunction)PyROOT::CreateBufferFromAddress, METH_O,
+    (char *)"Create a LowLevelView object on the received address"},
    {NULL, NULL, 0, NULL}};
 
 #define QuoteIdent(ident) #ident

--- a/tutorials/pyroot/staff.py
+++ b/tutorials/pyroot/staff.py
@@ -14,7 +14,7 @@
 
 import re, array, os
 import ROOT
-from ROOT import TFile, TTree, gROOT, AddressOf
+from ROOT import TFile, TTree, gROOT, addressof
 
 ## A C/C++ structure is required, to allow memory based access
 gROOT.ProcessLine(
@@ -43,8 +43,8 @@ def staff():
     f = TFile( 'staff.root', 'RECREATE' )
     tree = TTree( 'T', 'staff data from ascii file' )
     tree.Branch( 'staff', staff, 'Category/I:Flag:Age:Service:Children:Grade:Step:Hrweek:Cost' )
-    tree.Branch( 'Divisions', AddressOf( staff, 'Division' ), 'Division/C' )
-    tree.Branch( 'Nation', AddressOf( staff, 'Nation' ), 'Nation/C' )
+    tree.Branch( 'Divisions', addressof( staff, 'Division' ), 'Division/C' )
+    tree.Branch( 'Nation', addressof( staff, 'Nation' ), 'Nation/C' )
 
     # note that the branches Division and Nation cannot be on the first branch
     fname = os.path.join(str(ROOT.gROOT.GetTutorialDir()), 'tree', 'cernstaff.dat')


### PR DESCRIPTION
The previous implementation, based on a bytearray, did not consider
that, in the old PyROOT, the address of the buffer returned by
AddressOf is the same as the address of the address of the object
being inspected. This is required by DataFormats.FWLite in CMSSW.

In the new implementation, we obtain the address of the address of
the object via addressof (and its parameter byref = True), and
then we just create a cppyy LowLevelView from it, which is the
buffer we return. The first (and only) element of that buffer
contains the address of the object.