### PR TITLE
[TCling] Add iterator of using declarations to TClingMethodInfo

### DIFF
--- a/core/meta/inc/TListOfFunctionTemplates.h
+++ b/core/meta/inc/TListOfFunctionTemplates.h
@@ -64,7 +64,7 @@ public:
    virtual TList     *GetListForObject(const char* name) const;
    virtual TList     *GetListForObject(const TObject* obj) const;
 
-   TFunctionTemplate *Get(DeclId_t id);
+   TFunctionTemplate *Get(DeclId_t id, bool verify = true);
 
    void       AddFirst(TObject *obj);
    void       AddFirst(TObject *obj, Option_t *opt);

--- a/core/meta/inc/TListOfFunctions.h
+++ b/core/meta/inc/TListOfFunctions.h
@@ -80,7 +80,7 @@ public:
 
 
    TFunction *Find(DeclId_t id) const;
-   TFunction *Get(DeclId_t id);
+   TFunction *Get(DeclId_t id, bool verify = true);
 
    void       AddFirst(TObject *obj);
    void       AddFirst(TObject *obj, Option_t *opt);

--- a/core/meta/src/TListOfFunctionTemplates.cxx
+++ b/core/meta/src/TListOfFunctionTemplates.cxx
@@ -250,16 +250,18 @@ TList* TListOfFunctionTemplates::GetListForObject(const TObject* obj) const
 /// Return (after creating it if necessary) the TMethod or TFunction
 /// describing the function corresponding to the Decl 'id'.
 
-TFunctionTemplate *TListOfFunctionTemplates::Get(DeclId_t id)
+TFunctionTemplate *TListOfFunctionTemplates::Get(DeclId_t id, bool verify)
 {
    if (!id) return 0;
 
    TFunctionTemplate *f = (TFunctionTemplate*)fIds->GetValue((Long64_t)id);
    if (!f) {
-      if (fClass) {
-         if (!gInterpreter->ClassInfo_Contains(fClass->GetClassInfo(),id)) return 0;
-      } else {
-         if (!gInterpreter->ClassInfo_Contains(0,id)) return 0;
+      if (verify) {
+         if (fClass) {
+            if (!gInterpreter->ClassInfo_Contains(fClass->GetClassInfo(),id)) return 0;
+         } else {
+            if (!gInterpreter->ClassInfo_Contains(0,id)) return 0;
+         }
       }
 
       R__LOCKGUARD(gInterpreterMutex);

--- a/core/meta/src/TListOfFunctions.cxx
+++ b/core/meta/src/TListOfFunctions.cxx
@@ -259,7 +259,7 @@ TFunction *TListOfFunctions::Find(DeclId_t id) const
 /// Return (after creating it if necessary) the TMethod or TFunction
 /// describing the function corresponding to the Decl 'id'.
 
-TFunction *TListOfFunctions::Get(DeclId_t id)
+TFunction *TListOfFunctions::Get(DeclId_t id, bool verify)
 {
    if (!id) return 0;
 
@@ -268,10 +268,12 @@ TFunction *TListOfFunctions::Get(DeclId_t id)
    TFunction *f = Find(id);
    if (f) return f;
 
-   if (fClass) {
-      if (!gInterpreter->ClassInfo_Contains(fClass->GetClassInfo(),id)) return 0;
-   } else {
-      if (!gInterpreter->ClassInfo_Contains(0,id)) return 0;
+   if (verify) {
+      if (fClass) {
+         if (!gInterpreter->ClassInfo_Contains(fClass->GetClassInfo(),id)) return 0;
+      } else {
+         if (!gInterpreter->ClassInfo_Contains(0,id)) return 0;
+      }
    }
 
    MethodInfo_t *m = gInterpreter->MethodInfo_Factory(id);
@@ -393,7 +395,7 @@ void TListOfFunctions::Load()
          TDictionary::DeclId_t mid = gInterpreter->GetDeclId(t);
          // Get will check if there is already there or create a new one
          // (or re-use a previously unloaded version).
-         Get(mid);
+         Get(mid, false /* verify */);
       }
    }
    gInterpreter->MethodInfo_Delete(t);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4178,7 +4178,13 @@ void TCling::LoadFunctionTemplates(TClass* cl) const
          for (clang::DeclContext::decl_iterator DI = (*declIter)->decls_begin(),
               DE = (*declIter)->decls_end(); DI != DE; ++DI) {
             if (const clang::FunctionTemplateDecl* FTD = dyn_cast<clang::FunctionTemplateDecl>(*DI)) {
-                  funcTempList->Get(FTD);
+               funcTempList->Get(FTD);
+            } else if (const clang::UsingDecl* UD = llvm::dyn_cast<clang::UsingDecl>(*DI)) {
+               for (auto it = UD->shadow_begin(); it != UD->shadow_end(); ++it) {
+                  if ((FTD = dyn_cast<clang::FunctionTemplateDecl>(it->getTargetDecl()))) {
+                     funcTempList->Get(FTD, false);
+                  }
+               }
             }
          }
       }

--- a/core/metacling/src/TClingMethodInfo.h
+++ b/core/metacling/src/TClingMethodInfo.h
@@ -54,6 +54,7 @@ class TClingTypeInfo;
 
 class TClingMethodInfo final : public TClingDeclInfo {
 private:
+   class UsingIterator;
    cling::Interpreter                          *fInterp; // Cling interpreter, we do *not* own.
    llvm::SmallVector<clang::DeclContext *, 2>   fContexts; // Set of DeclContext that we will iterate over.
    bool                                         fFirstTime; // Flag for first time incrementing iterator, cint semantics are weird.
@@ -61,6 +62,7 @@ private:
    clang::DeclContext::decl_iterator            fIter; // Our iterator.
    std::string                                  fTitle; // The meta info for the method.
    const clang::FunctionDecl                   *fTemplateSpec; // an all-default-template-args function.
+   UsingIterator                               *fUsingIter; // for internal loop over using functions. [We own]
    llvm::SmallVector<clang::Decl *,4>           fDefDataSpecFuns; // decl_begin() will skip these special members, materialized from DefinitionData
    llvm::SmallVector<clang::Decl *,4>::const_iterator fDefDataSpecFunIter; // Iterator over fDefDataSpecFuns
 
@@ -69,7 +71,7 @@ private:
 public:
    explicit TClingMethodInfo(cling::Interpreter *interp)
       : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fContextIdx(0U), fTitle(""),
-        fTemplateSpec(0) {}
+        fTemplateSpec(nullptr), fUsingIter(nullptr) {}
 
    TClingMethodInfo(const TClingMethodInfo&);
    TClingMethodInfo& operator=(const TClingMethodInfo &in);


### PR DESCRIPTION
Ported from a patch by Wim Lavrijsen:
https://bitbucket.org/wlav/cppyy-backend/src/00d65c73d303fde7069aacc32cf95bb0144bbe43/cling/patches/using_decls.diff

This PR supersedes #3640 and ports the changes to master.

The changes are a fix for the Jira ticket: https://sft.its.cern.ch/jira/browse/ROOT-10582

The reproducer (fails without the fix, prints `2` with the fix):

```python
import ROOT

ROOT.gInterpreter.Declare("""
class A {
   public:
      int val;
      A(int a): val(a) {}
      virtual ~A() {}
};
"""
)

class B(ROOT.A):
    pass

b = B(2)
print(b.val)
```

The PR also allows to remove workarounds to make RooFit work, see the pythonizations here:

https://github.com/root-project/root/blob/master/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_rooabspdf.py#L24-L25
https://github.com/root-project/root/blob/master/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_roodataset.py#L24
https://github.com/root-project/root/blob/master/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_roodatahist.py#L24