### PR TITLE
[cmake] Bump openssl to 1.1.1g:

### DIFF
--- a/builtins/openssl/CMakeLists.txt
+++ b/builtins/openssl/CMakeLists.txt
@@ -13,9 +13,9 @@ foreach(suffix FOUND INCLUDE_DIR INCLUDE_DIRS CRYPTO_LIBRARY SSL_LIBRARY LIBRARY
   unset(OPENSSL_${suffix} PARENT_SCOPE)
 endforeach()
 
-set(OPENSSL_VERSION "1.1.1f")
+set(OPENSSL_VERSION "1.1.1g")
 set(OPENSSL_URL "http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources/openssl-${OPENSSL_VERSION}.tar.gz")
-set(OPENSSL_URLHASH "SHA256=186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35")
+set(OPENSSL_URLHASH "SHA256=ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46")
 set(OPENSSL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/OPENSSL-prefix)
 
 foreach(lib ssl crypto)


### PR DESCRIPTION
https://www.openssl.org/news/secadv/20200421.txt