### PR TITLE
Add config switch to disable (x)proofd. Default OFF.

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -178,6 +178,7 @@ ROOT_BUILD_OPTION(winrtdebug OFF "Link against the Windows debug runtime library
 ROOT_BUILD_OPTION(x11 ON "Enable support for X11/Xft")
 ROOT_BUILD_OPTION(xml ON "Enable support for XML (requires libxml2)")
 ROOT_BUILD_OPTION(xrootd ON "Enable support for XRootD file server and client")
+ROOT_BUILD_OPTION(xproofd OFF "Enable LEGACY support for XProofD file server and client (requires XRootD v4 with private-devel)")
 
 option(all "Enable all optional components by default" OFF)
 option(clingtest "Enable cling tests (Note: that this makes llvm/clang symbols visible in libCling)" OFF)
@@ -260,6 +261,7 @@ if(all)
  set(x11_defvalue ON)
  set(xml_defvalue ON)
  set(xrootd_defvalue ON)
+ set(xproofd_defvalue OFF)
 endif()
 
 #--- The 'builtin_all' option swithes ON old the built in options-------------------------------
@@ -306,6 +308,7 @@ if(WIN32)
   set(vdt_defvalue OFF)
   set(x11_defvalue OFF)
   set(xrootd_defvalue OFF)
+  set(xproofd_defvalue OFF)
 elseif(APPLE)
   set(cocoa_defvalue ON)
   set(x11_defvalue OFF)

--- a/proof/CMakeLists.txt
+++ b/proof/CMakeLists.txt
@@ -9,7 +9,7 @@ add_subdirectory(proofplayer) # special CMakeListst.txt
 if(NOT WIN32)
   add_subdirectory(proofbench) # special CMakeListst.txt
 endif()
-if(xrootd AND ssl)
+if(xproofd AND xrootd AND ssl)
   add_subdirectory(proofd)
   add_subdirectory(proofx)
 endif()

--- a/proof/proof/src/TProof.cxx
+++ b/proof/proof/src/TProof.cxx
@@ -657,19 +657,21 @@ TProof::~TProof()
    if (TestBit(TProof::kIsClient)) {
       // iterate over all packages
       TList *epl = fPackMgr->GetListOfEnabled();
-      TIter nxp(epl);
-      while (TObjString *pck = (TObjString *)(nxp())) {
-         FileStat_t stat;
-         if (gSystem->GetPathInfo(pck->String(), stat) == 0) {
-            // check if symlink, if so unlink
-            // NOTE: GetPathInfo() returns 1 in case of symlink that does not point to
-            // existing file or to a directory, but if fIsLink is true the symlink exists
-            if (stat.fIsLink)
-               gSystem->Unlink(pck->String());
+      if (epl) {
+         TIter nxp(epl);
+         while (TObjString *pck = (TObjString *)(nxp())) {
+            FileStat_t stat;
+            if (gSystem->GetPathInfo(pck->String(), stat) == 0) {
+               // check if symlink, if so unlink
+               // NOTE: GetPathInfo() returns 1 in case of symlink that does not point to
+               // existing file or to a directory, but if fIsLink is true the symlink exists
+               if (stat.fIsLink)
+                  gSystem->Unlink(pck->String());
+            }
          }
+         epl->Delete();
+         delete epl;
       }
-      epl->Delete();
-      delete epl;
    }
 
    Close();


### PR DESCRIPTION
This patch disables default building proofd and proofx modules, the PROOF ones requiring XRootD. The possibility to build these modules is provided as legacy and controlled by the switch 'xproofd' (-Dxproofd=ON). Note that these modules require XRootD v4 and the xrootd-private-devel RPM installed (or equivalent on Debian systems). Or -Dbuiltin_xrootd=ON .

The patch also fixes a possible segv introduced last February.