### PR TITLE
[Math] Replace add_subdirectory by ROOT_ADD_TEST_SUBDIRECTORY.

### DIFF
--- a/math/foam/CMakeLists.txt
+++ b/math/foam/CMakeLists.txt
@@ -28,4 +28,4 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Foam
     MathCore
 )
 
-add_subdirectory(test)
+ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
The tests for TFoam ended up in the wrong location, since
add_subdirectory is not setting the required property.