### PR TITLE
[treeplayer] Try harder to find leaf count (ROOT-10397):

### DIFF
--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -214,13 +214,47 @@ namespace {
                        ARGS&&... args):
          BASE(std::forward<ARGS>(args)...)
       {
-         if (TLeaf* sizeLeaf = treeReader->GetTree()->FindLeaf(leafName)) {
-            fIsUnsigned = sizeLeaf->IsUnsigned();
-            if (fIsUnsigned) {
-               fSizeReader.reset(new TTreeReaderValue<UInt_t>(*treeReader, leafName));
-            } else {
-               fSizeReader.reset(new TTreeReaderValue<Int_t>(*treeReader, leafName));
+         std::string foundLeafName = leafName;
+         TLeaf* sizeLeaf = treeReader->GetTree()->FindLeaf(foundLeafName.c_str());
+
+         if (!sizeLeaf) {
+            // leafName might be "top.currentParent.N". But "N" might really be "top.N"!
+            // Strip parents until we find the leaf.
+            std::string leafNameNoParent = leafName;
+            std::string parent;
+            auto posLastDot = leafNameNoParent.rfind('.');
+            if (posLastDot != leafNameNoParent.npos) {
+               parent = leafNameNoParent.substr(0, posLastDot);
+               leafNameNoParent.erase(0, posLastDot + 1);
             }
+
+            do {
+               if (!sizeLeaf && !parent.empty()) {
+                  auto posLastDotParent = parent.rfind('.');
+                  if (posLastDotParent != parent.npos)
+                     parent = parent.substr(0, posLastDot);
+                  else
+                     parent.clear();
+               }
+
+               foundLeafName = parent;
+               if (!parent.empty())
+                  foundLeafName += ".";
+               foundLeafName += leafNameNoParent;
+               sizeLeaf = treeReader->GetTree()->FindLeaf(foundLeafName.c_str());
+            } while (!sizeLeaf && !parent.empty());
+         }
+
+         if (!sizeLeaf) {
+            Error("TUIntOrIntReader", "Cannot find leaf count for %s or any parent branch!", leafName);
+            return;
+         }
+
+         fIsUnsigned = sizeLeaf->IsUnsigned();
+         if (fIsUnsigned) {
+            fSizeReader.reset(new TTreeReaderValue<UInt_t>(*treeReader, foundLeafName.c_str()));
+         } else {
+            fSizeReader.reset(new TTreeReaderValue<Int_t>(*treeReader, foundLeafName.c_str()));
          }
       }
 

--- a/tree/treeplayer/test/array.cxx
+++ b/tree/treeplayer/test/array.cxx
@@ -208,3 +208,24 @@ TEST(TTreeReaderArray, Float16_t)
       }
    }
 }
+
+TEST(TTreeReaderArray, ROOT10397)
+{
+   TTree t("t", "t");
+   float x[10];
+   int n;
+   t.Branch("n", &n, "n/I");
+   t.Branch("x", &x, "y[n]/F");
+   for (int i = 7; i < 10; i++) {
+      n = i;
+      for (int j = 0; j < n; j++) {
+         x[j] = j;
+      }
+      t.Fill();
+   };
+
+   TTreeReader r(&t);
+   TTreeReaderArray<float> xr(r, "x.y");
+   r.Next();
+   EXPECT_EQ(xr.GetSize(), 7);
+}

--- a/tree/treeplayer/test/array.cxx
+++ b/tree/treeplayer/test/array.cxx
@@ -214,18 +214,28 @@ TEST(TTreeReaderArray, ROOT10397)
    TTree t("t", "t");
    float x[10];
    int n;
+   struct {
+      int n = 10;
+      float z[10];
+   } z;
    t.Branch("n", &n, "n/I");
    t.Branch("x", &x, "y[n]/F");
+   t.Branch("z", &z, "n/I:z[n]/F");
    for (int i = 7; i < 10; i++) {
       n = i;
       for (int j = 0; j < n; j++) {
          x[j] = j;
       }
+      z.n = 13 - i;
+      for (int j = 0; j < 10; ++j)
+         z.z[j] = z.n;
       t.Fill();
    };
 
    TTreeReader r(&t);
    TTreeReaderArray<float> xr(r, "x.y");
+   TTreeReaderArray<float> zr(r, "z.z");
    r.Next();
    EXPECT_EQ(xr.GetSize(), 7);
+   EXPECT_EQ(zr.GetSize(), 13 - 7);
 }


### PR DESCRIPTION
Before, the leaf count was assumed to exist at the same level as the leaf to be read,
e.g. a.b.x[n] would look for a.b.n. That fails if n is coming from a "higher level".
Now, TUIntOrIntReader also looks for a.n and n, if a.b.n is not found.

And add the repro test for this.