### PR TITLE
add MathMore dependency to roofit

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -198,7 +198,7 @@ target_include_directories(MathCore PRIVATE ${VecCore_INCLUDE_DIRS})
 list(APPEND math_incl ${Vc_INCLUDE_DIR})
 list(APPEND math_incl ${VecCore_INCLUDE_DIRS})
 
-foreach(inlc ${math_incl})
+foreach(incl ${math_incl})
    target_include_directories(MathCore PUBLIC $<BUILD_INTERFACE:${incl}>)
 endforeach()
 

--- a/roofit/roofit/CMakeLists.txt
+++ b/roofit/roofit/CMakeLists.txt
@@ -9,6 +9,10 @@
 # @author Pere Mato, CERN
 ############################################################################
 
+if(mathmore)
+   set(roofit_more MathMore)
+endif()
+
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
   HEADERS
     Roo2DKeysPdf.h
@@ -141,6 +145,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
     RIO
     Matrix
     MathCore
+    ${roofit_more}
 )
 
 if(vdt AND NOT builtin_vdt)

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -472,7 +472,7 @@ if(vdt OR builtin_vdt)
    list(APPEND fitcore_incl ${VDT_INCLUDE_DIRS})
 endif()
 
-foreach(inlc ${fitcore_incl})
+foreach(incl ${fitcore_incl})
    target_include_directories(RooFitCore PUBLIC $<BUILD_INTERFACE:${incl}>)
 endforeach()
 


### PR DESCRIPTION
When MathMore compiled, rootfit uses includes from MathMore
To do this, roofit has to depend on `MathMore`