### PR TITLE
Add 3 new tutorials for TMVA deep learning:

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/DeepNet.h
+++ b/tmva/tmva/inc/TMVA/DNN/DeepNet.h
@@ -855,15 +855,9 @@ TBatchNormLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddBatchNorm
          for (size_t i = 3; i < shape.size(); ++i)
             shape[2] *= shape[i];
       }
-      // if  (axis == 1) {
-      //    shape[0] = batchSize;
-      //    shape[1] = inputDepth;
-      //    shape[2] = inputHeight * inputWidth;
-      // }
-      // for RNN ?
    }
-   std::cout << "addBNormLayer " << inputDepth << " , " << inputHeight << " , " << inputWidth << " , " << shape[0]
-             << "  " << shape[1] << "  " << shape[2] << std::endl;
+   // std::cout << "addBNormLayer " << inputDepth << " , " << inputHeight << " , " << inputWidth << " , " << shape[0]
+   //           << "  " << shape[1] << "  " << shape[2] << std::endl;
 
    auto bnormLayer =
       new TBatchNormLayer<Architecture_t>(batchSize, inputDepth, inputHeight, inputWidth, shape, axis, momentum, epsilon);

--- a/tutorials/tmva/TMVA_CNN_Classification.C
+++ b/tutorials/tmva/TMVA_CNN_Classification.C
@@ -1,0 +1,462 @@
+/***
+
+    # TMVA Classification Example Using a Convolutional Neural Network
+
+    This is an example of using a CNN in TMVA. We do classification using a toy image data set
+   that is generated when running the example macro
+
+**/
+
+
+/// function to create input images data
+/// we create a signal and background 2D histograms from 2d gaussians
+/// with a location (means in X and Y)  different for each event
+/// The difference between signal and background is in the gaussian width..
+/// The width for the bakgorund gaussian is slightly larger than the signal width
+
+void MakeImagesTree(int n, int nh, int nw ) {
+
+   // image size (nh x nw)
+   const int ntot = nh*nw;
+   const TString fileOutName = TString::Format("images_data_%dx%d.root",nh,nw);
+
+   const int nRndmEvts = 10000; // number of events we use to fill each image
+   double delta_sigma = 0.1;  // 5% difference in the sigma
+   double pixelNoise = 5;
+
+   double sX1 = 3;
+   double sY1 = 3;
+   double sX2 = sX1 + delta_sigma;
+   double sY2 = sY1 - delta_sigma;
+
+   auto h1 = new TH2D("h1","h1",nh,0,10,nw,0,10);
+   auto h2 = new TH2D("h2","h2",nh,0,10,nw,0,10);
+
+   auto f1 = new TF2("f1","xygaus");
+   auto f2 = new TF2("f2","xygaus");
+   TTree sgn("sig_tree","signal_tree");
+   TTree bkg("bkg_tree","bakground_tree");
+
+   TFile f(fileOutName,"RECREATE");
+
+   std::vector<float> x1(ntot);
+   std::vector<float> x2(ntot);
+
+   // create signal and background trees with a single branch
+   // an std::vector<float> of size nh x nw containing the image data
+
+   std::vector<float> * px1 = &x1;
+   std::vector<float> * px2 = &x2;
+
+   bkg.Branch("vars","std::vector<float>",&px1);
+   sgn.Branch("vars","std::vector<float>",&px2);
+
+   //std::cout << "create tree " << std::endl;
+
+   sgn.SetDirectory(&f);
+   bkg.SetDirectory(&f);
+
+   f1->SetParameters(1,5,sX1,5,sY1);
+   f2->SetParameters(1,5,sX2,5,sY2 );
+   gRandom->SetSeed(0);
+   std::cout << "Filling ROOT tree " << std::endl;
+   for (int i = 0; i < n; ++i) {
+      if (i % 100 == 0) std::cout << "Generating image event ... " << i << std::endl;
+      h1->Reset();
+      h2->Reset();
+      //generate random means in range [3,7] to be not too much on the border
+      f1->SetParameter(1,gRandom->Uniform(3,7));
+      f1->SetParameter(3,gRandom->Uniform(3,7));
+      f2->SetParameter(1,gRandom->Uniform(3,7));
+      f2->SetParameter(3,gRandom->Uniform(3,7));
+
+      h1->FillRandom("f1",nRndmEvts);
+      h2->FillRandom("f2",nRndmEvts);
+
+
+      for (int k = 0; k < nh ; ++k) {
+         for (int l = 0; l < nw ; ++l)  {
+            int m = k * nw + l;
+            // add some noise in each bin
+            x1[m] = h1->GetBinContent(k+1,l+1) + gRandom->Gaus(0, pixelNoise);
+            x2[m] = h2->GetBinContent(k+1,l+1) + gRandom->Gaus(0, pixelNoise);
+         }
+      }
+      sgn.Fill();
+      bkg.Fill();
+   }
+   sgn.Write();
+   bkg.Write();
+
+   Info("MakeImagesTree", "Signal and background tree with images data written to the file %s", f.GetName());
+   sgn.Print();
+   bkg.Print();
+   f.Close();
+}
+
+void TMVA_CNN_Classification( std::vector<bool> opt = {1,1,1,1})
+{
+
+   bool useTMVACNN =  (opt.size() > 0) ? opt[0] : false;
+   bool useKerasCNN = (opt.size() > 1) ? opt[1] : false;
+   bool useTMVADNN =  (opt.size() > 2) ? opt[2] : false;
+   bool useTMVABDT =  (opt.size() > 3) ? opt[3] : false;
+
+#ifndef R__HAS_TMVACPU
+#ifndef R__HAS_TMVAGPU
+   Warning("TMVA_CNN_Classification", "TMVA is not build with GPU or CPU multi-thread support. Cannot use TMVA Deep Learning");
+   useTMVACNN = false;
+   useTMVADNN = false;
+#endif
+#endif
+
+   bool writeOutputFile = true;
+
+   TMVA::Tools::Instance();
+
+   // do enable MT running
+   ROOT::EnableImplicitMT();
+
+   // for using Keras
+   gSystem->Setenv("KERAS_BACKEND", "tensorflow");
+   // for setting openblas in single thread on SWAN
+   gSystem->Setenv("OMP_NUM_THREADS", "1");
+   TMVA::PyMethodBase::PyInitialize();
+
+   TFile *outputFile = nullptr;
+   if (writeOutputFile)
+      outputFile = TFile::Open("TMVA_CNN_ClassificationOutput.root", "RECREATE");
+
+   /***
+       ## Create TMVA Factory
+
+    Create the Factory class. Later you can choose the methods
+    whose performance you'd like to investigate.
+
+    The factory is the major TMVA object you have to interact with. Here is the list of parameters you need to pass
+
+    - The first argument is the base of the name of all the output
+    weightfiles in the directory weight/ that will be created with the
+    method parameters
+
+    - The second argument is the output file for the training results
+
+    - The third argument is a string option defining some general configuration for the TMVA session.
+      For example all TMVA output can be suppressed by removing the "!" (not) in front of the "Silent" argument in the
+   option string
+
+    - note that we disable any pre-transformation of the input variables and we avoid computing correlations between input variables
+   ***/
+
+   TMVA::Factory factory("TMVA_CNN_Classification", outputFile,
+                         "!V:ROC:!Silent:Color:!DrawProgressBar:AnalysisType=Classification:Transformations=None:!Correlations");
+
+   /***
+
+       ## Declare DataLoader(s)
+
+       The next step is to declare the DataLoader class that deals with input variables
+
+       Define the input variables that shall be used for the MVA training
+       note that you may also use variable expressions, which can be parsed by TTree::Draw( "expression" )]
+
+       In this case the input data consists of an image of 16x16 pixels. Each single pixel is a branch in a ROOT TTree
+
+   **/
+
+   TMVA::DataLoader *loader = new TMVA::DataLoader("dataset");
+
+   /***
+
+       ## Setup Dataset(s)
+
+       Define input data file and signal and background trees
+
+   **/
+
+   int imgSize = 16 * 16;
+   TString inputFileName = "images_data_16x16.root";
+   //TString inputFileName = "/home/moneta/data/sample_images_32x32.gsoc.root";
+
+   bool fileExist = !gSystem->AccessPathName(inputFileName);
+
+   // if file does not exists create it
+   if (!fileExist) {
+      MakeImagesTree(5000, 16, 16);
+   }
+
+   // TString inputFileName = "tmva_class_example.root";
+
+   auto inputFile = TFile::Open(inputFileName);
+   if (!inputFile) {
+      Error("TMVA_CNN_Classification", "Error opening input file %s - exit", inputFileName.Data());
+      return;
+   }
+
+   // --- Register the training and test trees
+
+   TTree *signalTree = (TTree *)inputFile->Get("sig_tree");
+   TTree *backgroundTree = (TTree *)inputFile->Get("bkg_tree");
+
+   int nEventsSig = signalTree->GetEntries();
+   int nEventsBkg = backgroundTree->GetEntries();
+
+   // global event weights per tree (see below for setting event-wise weights)
+   Double_t signalWeight = 1.0;
+   Double_t backgroundWeight = 1.0;
+
+   // You can add an arbitrary number of signal or background trees
+   loader->AddSignalTree(signalTree, signalWeight);
+   loader->AddBackgroundTree(backgroundTree, backgroundWeight);
+
+   /// add event variables (image)
+   /// use new method (from ROOT 6.20 to add a variable array for all image data)
+   loader->AddVariablesArray("vars", imgSize);
+
+   // Set individual event weights (the variables must exist in the original TTree)
+   //    for signal    : factory->SetSignalWeightExpression    ("weight1*weight2");
+   //    for background: factory->SetBackgroundWeightExpression("weight1*weight2");
+   // loader->SetBackgroundWeightExpression( "weight" );
+
+   // Apply additional cuts on the signal and background samples (can be different)
+   TCut mycuts = ""; // for example: TCut mycuts = "abs(var1)<0.5 && abs(var2-0.5)<1";
+   TCut mycutb = ""; // for example: TCut mycutb = "abs(var1)<0.5";
+
+   // Tell the factory how to use the training and testing events
+   //
+   // If no numbers of events are given, half of the events in the tree are used
+   // for training, and the other half for testing:
+   //    loader->PrepareTrainingAndTestTree( mycut, "SplitMode=random:!V" );
+   // It is possible also to specify the number of training and testing events,
+   // note we disable the computation of the correlation matrix of the input variables
+
+   int nTrainSig = 0.8 * nEventsSig;
+   int nTrainBkg = 0.8 * nEventsBkg;
+
+   // build the string options for DataLoader::PrepareTrainingAndTestTree
+   TString prepareOptions =
+      TString::Format("nTrain_Signal=%d:nTrain_Background=%d:SplitMode=Random:SplitSeed=100:NormMode=NumEvents:!V:!CalcCorrelations",
+                      nTrainSig, nTrainBkg);
+
+   loader->PrepareTrainingAndTestTree(mycuts, mycutb, prepareOptions);
+
+
+   /***
+
+       DataSetInfo              : [dataset] : Added class "Signal"
+       : Add Tree sig_tree of type Signal with 10000 events
+       DataSetInfo              : [dataset] : Added class "Background"
+       : Add Tree bkg_tree of type Background with 10000 events
+
+
+
+   **/
+
+   // signalTree->Print();
+
+   /****
+        # Booking Methods
+
+        Here we book the TMVA methods. We book a Boosted Decision Tree method (BDT)
+
+   **/
+
+   // Boosted Decision Trees
+   if (useTMVABDT) {
+      factory.BookMethod(loader, TMVA::Types::kBDT, "BDT",
+                         "!V:NTrees=800:MinNodeSize=2.5%:MaxDepth=2:BoostType=AdaBoost:AdaBoostBeta=0.5:"
+                         "UseBaggedBoost:BaggedSampleFraction=0.5:SeparationType=GiniIndex:nCuts=20");
+   }
+   /**
+
+      #### Booking Deep Neural Network
+
+      Here we book the DNN of TMVA. See the example TMVA_Higgs_Classification.C for a detailed description of the
+   options
+
+   **/
+
+   if (useTMVADNN) {
+
+      TString inputLayoutString = "InputLayout=1|1|256";
+      TString batchLayoutString = "BatchLayout=1|100|256";
+      TString layoutString("Layout=DENSE|100|RELU,BNORM,DENSE|100|RELU,BNORM,DENSE|100|RELU,BNORM,DENSE|100|RELU,DENSE|1|LINEAR");
+
+      // Training strategies
+      // one can catenate several training strings with different parameters (e.g. learning rates or regularizations parameters)
+      // The training string must be concatenates with the `|` delimiter
+      TString trainingString1("LearningRate=1e-3,Momentum=0.9,Repetitions=1,"
+                        "ConvergenceSteps=5,BatchSize=100,TestRepetitions=1,"
+                        "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"
+                        "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.");
+
+      TString trainingStrategyString("TrainingStrategy=");
+      trainingStrategyString += trainingString1; // + "|" + trainingString2 + ....
+
+      // Build now the full DNN Option string
+
+      TString dnnOptions("!H:V:ErrorStrategy=CROSSENTROPY:VarTransform=None:"
+                         "WeightInitialization=XAVIER");
+      dnnOptions.Append(":");
+      dnnOptions.Append(inputLayoutString);
+      dnnOptions.Append(":");
+      dnnOptions.Append(batchLayoutString);
+      dnnOptions.Append(":");
+      dnnOptions.Append(layoutString);
+      dnnOptions.Append(":");
+      dnnOptions.Append(trainingStrategyString);
+
+      TString dnnMethodName = "TMVA_DNN_CPU";
+// use GPU if available
+#ifdef R__HAS_TMVAGPU
+      dnnOptions += ":Architecture=GPU";
+      dnnMethodName = "TMVA_DNN_GPU";
+#elif defined(R__HAS_TMVACPU)
+      dnnOptions += ":Architecture=CPU";
+#endif
+
+      factory.BookMethod(loader, TMVA::Types::kDL, dnnMethodName, dnnOptions);
+   }
+
+   /***
+    ### Book Convolutional Neural Network in TMVA
+
+    For building a CNN one needs to define
+
+    -  Input Layout :  number of channels (in this case = 1)  | image height | image width
+    -  Batch Layout :  batch size | number of channels | image size = (height*width)
+
+    Then one add Convolutional layers and MaxPool layers.
+
+    -  For Convolutional layer the option string has to be:
+       - CONV | number of units | filter height | filter width | stride height | stride width | padding height | paddig
+   width | activation function
+
+       - note in this case we are using a filer 3x3 and padding=1 and stride=1 so we get the output dimension of the
+   conv layer equal to the input
+
+      - note we use after the first convolutional layer a batch normalization layer. This seems to help significatly the convergence
+
+     - For the MaxPool layer:
+        - MAXPOOL  | pool height | pool width | stride height | stride width
+
+    The RESHAPE layer is needed to flatten the output before the Dense layer
+
+
+    Note that to run the CNN is required to have CPU  or GPU support
+
+   ***/
+
+   if (useTMVACNN) {
+
+      TString inputLayoutString("InputLayout=1|16|16");
+
+      // Batch Layout
+      TString batchLayoutString("BatchLayout=100|1|256");
+
+      TString layoutString("Layout=CONV|10|3|3|1|1|1|1|RELU,BNORM,CONV|10|3|3|1|1|1|1|RELU,MAXPOOL|2|2|1|1,"
+                           "RESHAPE|FLAT,DENSE|100|RELU,DENSE|1|LINEAR");
+
+      // Training strategies.
+      TString trainingString1("LearningRate=1e-3,Momentum=0.9,Repetitions=1,"
+                        "ConvergenceSteps=5,BatchSize=100,TestRepetitions=1,"
+                        "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"
+                        "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.0");
+
+      TString trainingStrategyString("TrainingStrategy=");
+      trainingStrategyString += trainingString1; // + "|" + trainingString2 + "|" + trainingString3; for concatenating more training strings
+
+      // Build full CNN Options.
+      TString cnnOptions("!H:V:ErrorStrategy=CROSSENTROPY:VarTransform=None:"
+                         "WeightInitialization=XAVIER");
+
+      cnnOptions.Append(":");
+      cnnOptions.Append(inputLayoutString);
+      cnnOptions.Append(":");
+      cnnOptions.Append(batchLayoutString);
+      cnnOptions.Append(":");
+      cnnOptions.Append(layoutString);
+      cnnOptions.Append(":");
+      cnnOptions.Append(trainingStrategyString);
+
+      //// New DL (CNN)
+      TString cnnMethodName = "TMVA_CNN_CPU";
+// use GPU if available
+#ifdef R__HAS_TMVAGPU
+      cnnOptions += ":Architecture=GPU";
+      cnnMethodName = "TMVA_CNN_GPU";
+#else
+      cnnOptions += ":Architecture=CPU";
+      cnnMethodName = "TMVA_CNN_CPU";
+#endif
+
+      factory.BookMethod(loader, TMVA::Types::kDL, cnnMethodName, cnnOptions);
+   }
+
+   /**
+      ### Book Convolutional Neural Network in Keras using a generated model
+
+   **/
+
+   if (useKerasCNN) {
+
+      Info("TMVA_CNN_Classification", "Building convolutional keras model");
+      // create python script which can be executed
+      // crceate 2 conv2d layer + maxpool + dense
+      TMacro m;
+      m.AddLine("import keras");
+      m.AddLine("from keras.models import Sequential");
+      m.AddLine("from keras.optimizers import Adam");
+      m.AddLine(
+         "from keras.layers import Input, Dense, Dropout, Flatten, Conv2D, MaxPooling2D, Reshape, BatchNormalization");
+      m.AddLine("");
+      m.AddLine("model = keras.models.Sequential() ");
+      m.AddLine("model.add(Reshape((16, 16, 1), input_shape = (256, )))");
+      m.AddLine("model.add(Conv2D(10, kernel_size = (3, 3), kernel_initializer = 'glorot_normal',activation = "
+                "'relu', padding = 'same'))");
+      m.AddLine("model.add(BatchNormalization())");
+      m.AddLine("model.add(Conv2D(10, kernel_size = (3, 3), kernel_initializer = 'glorot_normal',activation = "
+                "'relu', padding = 'same'))");
+      // m.AddLine("model.add(BatchNormalization())");
+      m.AddLine("model.add(MaxPooling2D(pool_size = (2, 2), strides = (1,1))) ");
+      m.AddLine("model.add(Flatten())");
+      m.AddLine("model.add(Dense(256, activation = 'relu')) ");
+      m.AddLine("model.add(Dense(2, activation = 'sigmoid')) ");
+      m.AddLine("model.compile(loss = 'binary_crossentropy', optimizer = Adam(lr = 0.001), metrics = ['accuracy'])");
+      m.AddLine("model.save('model_cnn.h5')");
+      m.AddLine("model.summary()");
+
+      m.SaveSource("make_cnn_model.py");
+      // execute
+      gSystem->Exec("python make_cnn_model.py");
+
+      if (gSystem->AccessPathName("model_cnn.h5")) {
+         Error("TMVA_CNN_Classification", "Error creating Keras model file - exit");
+         return;
+      }
+
+      factory.BookMethod(
+         loader, TMVA::Types::kPyKeras, "PyKeras",
+         "H:!V:VarTransform=None:FilenameModel=model_cnn.h5:"
+         "FilenameTrainedModel=trained_model_cnn.h5:NumEpochs=20:BatchSize=100:"
+         "GpuOptions=allow_growth=True");  // needed for RTX NVidia card and to avoid TF allocates all GPU memory
+   }
+
+   ////  ## Train Methods
+
+   factory.TrainAllMethods();
+
+   /// ## Test and Evaluate Methods
+
+   factory.TestAllMethods();
+
+   factory.EvaluateAllMethods();
+
+   /// ## Plot ROC Curve
+
+   auto c1 = factory.GetROCCurve(loader);
+   c1->Draw();
+
+   // close outputfile to save output file
+   outputFile->Close();
+}

--- a/tutorials/tmva/TMVA_CNN_Classification.C
+++ b/tutorials/tmva/TMVA_CNN_Classification.C
@@ -1,27 +1,40 @@
+/// \file
+/// \ingroup tutorial_tmva
+/// \notebook
+///  TMVA Classification Example Using a Convolutional Neural Network
+///
+/// This is an example of using a CNN in TMVA. We do classification using a toy image data set
+/// that is generated when running the example macro
+///
+/// \macro_image
+/// \macro_output
+/// \macro_code
+///
+/// \author Lorenzo Moneta
+
 /***
 
     # TMVA Classification Example Using a Convolutional Neural Network
 
-    This is an example of using a CNN in TMVA. We do classification using a toy image data set
-   that is generated when running the example macro
 
 **/
 
-
-/// function to create input images data
+/// Helper function to create input images data
 /// we create a signal and background 2D histograms from 2d gaussians
 /// with a location (means in X and Y)  different for each event
 /// The difference between signal and background is in the gaussian width..
-/// The width for the bakgorund gaussian is slightly larger than the signal width
-
-void MakeImagesTree(int n, int nh, int nw ) {
+/// The width for the bakground gaussian is slightly larger than the signal width by few % values
+///
+///
+void MakeImagesTree(int n, int nh, int nw)
+{
 
    // image size (nh x nw)
-   const int ntot = nh*nw;
-   const TString fileOutName = TString::Format("images_data_%dx%d.root",nh,nw);
+   const int ntot = nh * nw;
+   const TString fileOutName = TString::Format("images_data_%dx%d.root", nh, nw);
 
    const int nRndmEvts = 10000; // number of events we use to fill each image
-   double delta_sigma = 0.1;  // 5% difference in the sigma
+   double delta_sigma = 0.1;    // 5% difference in the sigma
    double pixelNoise = 5;
 
    double sX1 = 3;
@@ -29,15 +42,15 @@ void MakeImagesTree(int n, int nh, int nw ) {
    double sX2 = sX1 + delta_sigma;
    double sY2 = sY1 - delta_sigma;
 
-   auto h1 = new TH2D("h1","h1",nh,0,10,nw,0,10);
-   auto h2 = new TH2D("h2","h2",nh,0,10,nw,0,10);
+   auto h1 = new TH2D("h1", "h1", nh, 0, 10, nw, 0, 10);
+   auto h2 = new TH2D("h2", "h2", nh, 0, 10, nw, 0, 10);
 
-   auto f1 = new TF2("f1","xygaus");
-   auto f2 = new TF2("f2","xygaus");
-   TTree sgn("sig_tree","signal_tree");
-   TTree bkg("bkg_tree","bakground_tree");
+   auto f1 = new TF2("f1", "xygaus");
+   auto f2 = new TF2("f2", "xygaus");
+   TTree sgn("sig_tree", "signal_tree");
+   TTree bkg("bkg_tree", "bakground_tree");
 
-   TFile f(fileOutName,"RECREATE");
+   TFile f(fileOutName, "RECREATE");
 
    std::vector<float> x1(ntot);
    std::vector<float> x2(ntot);
@@ -45,41 +58,41 @@ void MakeImagesTree(int n, int nh, int nw ) {
    // create signal and background trees with a single branch
    // an std::vector<float> of size nh x nw containing the image data
 
-   std::vector<float> * px1 = &x1;
-   std::vector<float> * px2 = &x2;
+   std::vector<float> *px1 = &x1;
+   std::vector<float> *px2 = &x2;
 
-   bkg.Branch("vars","std::vector<float>",&px1);
-   sgn.Branch("vars","std::vector<float>",&px2);
+   bkg.Branch("vars", "std::vector<float>", &px1);
+   sgn.Branch("vars", "std::vector<float>", &px2);
 
-   //std::cout << "create tree " << std::endl;
+   // std::cout << "create tree " << std::endl;
 
    sgn.SetDirectory(&f);
    bkg.SetDirectory(&f);
 
-   f1->SetParameters(1,5,sX1,5,sY1);
-   f2->SetParameters(1,5,sX2,5,sY2 );
+   f1->SetParameters(1, 5, sX1, 5, sY1);
+   f2->SetParameters(1, 5, sX2, 5, sY2);
    gRandom->SetSeed(0);
    std::cout << "Filling ROOT tree " << std::endl;
    for (int i = 0; i < n; ++i) {
-      if (i % 100 == 0) std::cout << "Generating image event ... " << i << std::endl;
+      if (i % 1000 == 0)
+         std::cout << "Generating image event ... " << i << std::endl;
       h1->Reset();
       h2->Reset();
-      //generate random means in range [3,7] to be not too much on the border
-      f1->SetParameter(1,gRandom->Uniform(3,7));
-      f1->SetParameter(3,gRandom->Uniform(3,7));
-      f2->SetParameter(1,gRandom->Uniform(3,7));
-      f2->SetParameter(3,gRandom->Uniform(3,7));
+      // generate random means in range [3,7] to be not too much on the border
+      f1->SetParameter(1, gRandom->Uniform(3, 7));
+      f1->SetParameter(3, gRandom->Uniform(3, 7));
+      f2->SetParameter(1, gRandom->Uniform(3, 7));
+      f2->SetParameter(3, gRandom->Uniform(3, 7));
 
-      h1->FillRandom("f1",nRndmEvts);
-      h2->FillRandom("f2",nRndmEvts);
+      h1->FillRandom("f1", nRndmEvts);
+      h2->FillRandom("f2", nRndmEvts);
 
-
-      for (int k = 0; k < nh ; ++k) {
-         for (int l = 0; l < nw ; ++l)  {
+      for (int k = 0; k < nh; ++k) {
+         for (int l = 0; l < nw; ++l) {
             int m = k * nw + l;
             // add some noise in each bin
-            x1[m] = h1->GetBinContent(k+1,l+1) + gRandom->Gaus(0, pixelNoise);
-            x2[m] = h2->GetBinContent(k+1,l+1) + gRandom->Gaus(0, pixelNoise);
+            x1[m] = h1->GetBinContent(k + 1, l + 1) + gRandom->Gaus(0, pixelNoise);
+            x2[m] = h2->GetBinContent(k + 1, l + 1) + gRandom->Gaus(0, pixelNoise);
          }
       }
       sgn.Fill();
@@ -94,17 +107,18 @@ void MakeImagesTree(int n, int nh, int nw ) {
    f.Close();
 }
 
-void TMVA_CNN_Classification( std::vector<bool> opt = {1,1,1,1})
+void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
 {
 
-   bool useTMVACNN =  (opt.size() > 0) ? opt[0] : false;
+   bool useTMVACNN = (opt.size() > 0) ? opt[0] : false;
    bool useKerasCNN = (opt.size() > 1) ? opt[1] : false;
-   bool useTMVADNN =  (opt.size() > 2) ? opt[2] : false;
-   bool useTMVABDT =  (opt.size() > 3) ? opt[3] : false;
+   bool useTMVADNN = (opt.size() > 2) ? opt[2] : false;
+   bool useTMVABDT = (opt.size() > 3) ? opt[3] : false;
 
 #ifndef R__HAS_TMVACPU
 #ifndef R__HAS_TMVAGPU
-   Warning("TMVA_CNN_Classification", "TMVA is not build with GPU or CPU multi-thread support. Cannot use TMVA Deep Learning");
+   Warning("TMVA_CNN_Classification",
+           "TMVA is not build with GPU or CPU multi-thread support. Cannot use TMVA Deep Learning");
    useTMVACNN = false;
    useTMVADNN = false;
 #endif
@@ -145,11 +159,13 @@ void TMVA_CNN_Classification( std::vector<bool> opt = {1,1,1,1})
       For example all TMVA output can be suppressed by removing the "!" (not) in front of the "Silent" argument in the
    option string
 
-    - note that we disable any pre-transformation of the input variables and we avoid computing correlations between input variables
+    - note that we disable any pre-transformation of the input variables and we avoid computing correlations between
+   input variables
    ***/
 
-   TMVA::Factory factory("TMVA_CNN_Classification", outputFile,
-                         "!V:ROC:!Silent:Color:!DrawProgressBar:AnalysisType=Classification:Transformations=None:!Correlations");
+   TMVA::Factory factory(
+      "TMVA_CNN_Classification", outputFile,
+      "!V:ROC:!Silent:Color:!DrawProgressBar:AnalysisType=Classification:Transformations=None:!Correlations");
 
    /***
 
@@ -176,7 +192,7 @@ void TMVA_CNN_Classification( std::vector<bool> opt = {1,1,1,1})
 
    int imgSize = 16 * 16;
    TString inputFileName = "images_data_16x16.root";
-   //TString inputFileName = "/home/moneta/data/sample_images_32x32.gsoc.root";
+   // TString inputFileName = "/home/moneta/data/sample_images_32x32.gsoc.root";
 
    bool fileExist = !gSystem->AccessPathName(inputFileName);
 
@@ -234,12 +250,11 @@ void TMVA_CNN_Classification( std::vector<bool> opt = {1,1,1,1})
    int nTrainBkg = 0.8 * nEventsBkg;
 
    // build the string options for DataLoader::PrepareTrainingAndTestTree
-   TString prepareOptions =
-      TString::Format("nTrain_Signal=%d:nTrain_Background=%d:SplitMode=Random:SplitSeed=100:NormMode=NumEvents:!V:!CalcCorrelations",
-                      nTrainSig, nTrainBkg);
+   TString prepareOptions = TString::Format(
+      "nTrain_Signal=%d:nTrain_Background=%d:SplitMode=Random:SplitSeed=100:NormMode=NumEvents:!V:!CalcCorrelations",
+      nTrainSig, nTrainBkg);
 
    loader->PrepareTrainingAndTestTree(mycuts, mycutb, prepareOptions);
-
 
    /***
 
@@ -280,15 +295,16 @@ void TMVA_CNN_Classification( std::vector<bool> opt = {1,1,1,1})
 
       TString inputLayoutString = "InputLayout=1|1|256";
       TString batchLayoutString = "BatchLayout=1|100|256";
-      TString layoutString("Layout=DENSE|100|RELU,BNORM,DENSE|100|RELU,BNORM,DENSE|100|RELU,BNORM,DENSE|100|RELU,DENSE|1|LINEAR");
+      TString layoutString(
+         "Layout=DENSE|100|RELU,BNORM,DENSE|100|RELU,BNORM,DENSE|100|RELU,BNORM,DENSE|100|RELU,DENSE|1|LINEAR");
 
       // Training strategies
-      // one can catenate several training strings with different parameters (e.g. learning rates or regularizations parameters)
-      // The training string must be concatenates with the `|` delimiter
+      // one can catenate several training strings with different parameters (e.g. learning rates or regularizations
+      // parameters) The training string must be concatenates with the `|` delimiter
       TString trainingString1("LearningRate=1e-3,Momentum=0.9,Repetitions=1,"
-                        "ConvergenceSteps=5,BatchSize=100,TestRepetitions=1,"
-                        "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"
-                        "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.");
+                              "ConvergenceSteps=5,BatchSize=100,TestRepetitions=1,"
+                              "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"
+                              "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.");
 
       TString trainingStrategyString("TrainingStrategy=");
       trainingStrategyString += trainingString1; // + "|" + trainingString2 + ....
@@ -335,7 +351,8 @@ void TMVA_CNN_Classification( std::vector<bool> opt = {1,1,1,1})
        - note in this case we are using a filer 3x3 and padding=1 and stride=1 so we get the output dimension of the
    conv layer equal to the input
 
-      - note we use after the first convolutional layer a batch normalization layer. This seems to help significatly the convergence
+      - note we use after the first convolutional layer a batch normalization layer. This seems to help significatly the
+   convergence
 
      - For the MaxPool layer:
         - MAXPOOL  | pool height | pool width | stride height | stride width
@@ -359,12 +376,13 @@ void TMVA_CNN_Classification( std::vector<bool> opt = {1,1,1,1})
 
       // Training strategies.
       TString trainingString1("LearningRate=1e-3,Momentum=0.9,Repetitions=1,"
-                        "ConvergenceSteps=5,BatchSize=100,TestRepetitions=1,"
-                        "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"
-                        "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.0");
+                              "ConvergenceSteps=5,BatchSize=100,TestRepetitions=1,"
+                              "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"
+                              "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.0");
 
       TString trainingStrategyString("TrainingStrategy=");
-      trainingStrategyString += trainingString1; // + "|" + trainingString2 + "|" + trainingString3; for concatenating more training strings
+      trainingStrategyString +=
+         trainingString1; // + "|" + trainingString2 + "|" + trainingString3; for concatenating more training strings
 
       // Build full CNN Options.
       TString cnnOptions("!H:V:ErrorStrategy=CROSSENTROPY:VarTransform=None:"
@@ -431,15 +449,16 @@ void TMVA_CNN_Classification( std::vector<bool> opt = {1,1,1,1})
       gSystem->Exec("python make_cnn_model.py");
 
       if (gSystem->AccessPathName("model_cnn.h5")) {
-         Error("TMVA_CNN_Classification", "Error creating Keras model file - exit");
-         return;
+         Warning("TMVA_CNN_Classification", "Error creating Keras model file - skip using Keras");
+      } else {
+         // book PyKeras method only if Keras model could be created
+         Info("TMVA_CNN_Classification", "Booking Keras CNN model");
+         factory.BookMethod(
+            loader, TMVA::Types::kPyKeras, "PyKeras",
+            "H:!V:VarTransform=None:FilenameModel=model_cnn.h5:"
+            "FilenameTrainedModel=trained_model_cnn.h5:NumEpochs=20:BatchSize=100:"
+            "GpuOptions=allow_growth=True"); // needed for RTX NVidia card and to avoid TF allocates all GPU memory
       }
-
-      factory.BookMethod(
-         loader, TMVA::Types::kPyKeras, "PyKeras",
-         "H:!V:VarTransform=None:FilenameModel=model_cnn.h5:"
-         "FilenameTrainedModel=trained_model_cnn.h5:NumEpochs=20:BatchSize=100:"
-         "GpuOptions=allow_growth=True");  // needed for RTX NVidia card and to avoid TF allocates all GPU memory
    }
 
    ////  ## Train Methods

--- a/tutorials/tmva/TMVA_Higgs_Classification.C
+++ b/tutorials/tmva/TMVA_Higgs_Classification.C
@@ -1,0 +1,312 @@
+/// \file
+/// \ingroup tutorial_tmva
+/// Classification example of TNVA  using Higgs UCI dataset
+///  The UCI data set is a public HIGGS data set , see http://archive.ics.uci.edu/ml/datasets/HIGGS
+// used in this paper: Baldi, P., P. Sadowski, and D. Whiteson. “Searching for Exotic Particles in High-energy Physics
+///                     with Deep Learning.” Nature Communications 5 (July 2, 2014).
+///
+
+/***
+## Declare Factory
+
+Create the Factory class. Later you can choose the methods
+whose performance you'd like to investigate.
+
+The factory is the major TMVA object you have to interact with. Here is the list of parameters you need to pass
+
+ - The first argument is the base of the name of all the output
+weightfiles in the directory weight/ that will be created with the
+method parameters
+
+ - The second argument is the output file for the training results
+
+ - The third argument is a string option defining some general configuration for the TMVA session. For example all TMVA output can be suppressed by removing the "!" (not) in front of the "Silent" argument in the option string
+
+**/
+
+void TMVA_Higgs_Classification() {
+
+   // options to control used methods
+
+   bool useLikelihood = true;    // likelihood based discriminant
+   bool useLikelihoodKDE = false;    // likelihood based discriminant
+   bool useFischer = true;       // Fischer discriminant
+   bool useMLP = false;          // Multi Layer Perceptron (old TMVA NN implementation)
+   bool useBDT = true;           // BOosted Decision Tree
+   bool useDL = true;            // TMVA Deep learning ( CPU ot GPU)
+
+
+
+   TMVA::Tools::Instance();
+
+   auto outputFile = TFile::Open("Higgs_ClassificationOutput.root", "RECREATE");
+
+   TMVA::Factory factory("TMVA_Higgs_Classification", outputFile,
+                         "!V:ROC:!Silent:Color:!DrawProgressBar:AnalysisType=Classification" );
+
+/**
+
+## Setup Dataset(s)
+
+Define now input data file and signal and background trees
+
+ **/
+
+   TString downloadLinkFile = "https://cernbox.cern.ch/index.php/s/EJqhbcDdyXKeswy/download";
+
+
+   TString inputFileName = "Higgs_data.root";
+
+   auto inputFile = TFile::Open( inputFileName );
+
+   if (!inputFile) {
+      // download file from Cernbox location
+      Info("TMVA_Higgs_Classification","Download Higgs_data.root file");
+      gSystem->Exec( TString::Format("wget -O %s %s",inputFileName.Data(), downloadLinkFile.Data() ) );
+      inputFile = TFile::Open( inputFileName );
+      if (!inputFile) {
+         Error("TMVA_Higgs_Classification","Input file cannot be downloaded - exit");
+         return;
+      }
+   }
+
+// --- Register the training and test trees
+
+   TTree *signalTree     = (TTree*)inputFile->Get("sig_tree");
+   TTree *backgroundTree = (TTree*)inputFile->Get("bkg_tree");
+
+   signalTree->Print();
+
+/***
+## Declare DataLoader(s)
+
+The next step is to declare the DataLoader class that deals with input variables
+
+Define the input variables that shall be used for the MVA training
+note that you may also use variable expressions, which can be parsed by TTree::Draw( "expression" )]
+
+***/
+
+   TMVA::DataLoader * loader = new TMVA::DataLoader("dataset");
+
+   loader->AddVariable("m_jj");
+   loader->AddVariable("m_jjj");
+   loader->AddVariable("m_lv");
+   loader->AddVariable("m_jlv");
+   loader->AddVariable("m_bb");
+   loader->AddVariable("m_wbb");
+   loader->AddVariable("m_wwbb");
+
+/// We set now the input data trees in the TMVA DataLoader class
+
+// global event weights per tree (see below for setting event-wise weights)
+   Double_t signalWeight     = 1.0;
+   Double_t backgroundWeight = 1.0;
+
+// You can add an arbitrary number of signal or background trees
+   loader->AddSignalTree    ( signalTree,     signalWeight     );
+   loader->AddBackgroundTree( backgroundTree, backgroundWeight );
+
+
+// Set individual event weights (the variables must exist in the original TTree)
+//    for signal    : factory->SetSignalWeightExpression    ("weight1*weight2");
+//    for background: factory->SetBackgroundWeightExpression("weight1*weight2");
+//loader->SetBackgroundWeightExpression( "weight" );
+
+// Apply additional cuts on the signal and background samples (can be different)
+   TCut mycuts = ""; // for example: TCut mycuts = "abs(var1)<0.5 && abs(var2-0.5)<1";
+   TCut mycutb = ""; // for example: TCut mycutb = "abs(var1)<0.5";
+
+// Tell the factory how to use the training and testing events
+//
+// If no numbers of events are given, half of the events in the tree are used
+// for training, and the other half for testing:
+//    loader->PrepareTrainingAndTestTree( mycut, "SplitMode=random:!V" );
+// To also specify the number of testing events, use:
+
+   loader->PrepareTrainingAndTestTree( mycuts, mycutb,
+                                       "nTrain_Signal=7000:nTrain_Background=7000:SplitMode=Random:NormMode=NumEvents:!V" );
+
+/***
+## Booking Methods
+
+Here we book the TMVA methods. We book firat a Likelihood based on KDE (Kernel Density Estimation), a Fischer discriminant, a BDT
+and a shallow neural network
+
+ */
+
+
+// Likelihood ("naive Bayes estimator")
+if (useLikelihood) {
+   factory.BookMethod(loader, TMVA::Types::kLikelihood, "Likelihood",
+                           "H:!V:TransformOutput:PDFInterpol=Spline2:NSmoothSig[0]=20:NSmoothBkg[0]=20:NSmoothBkg[1]=10:NSmooth=1:NAvEvtPerBin=50" );
+}
+// Use a kernel density estimator to approximate the PDFs
+if (useLikelihoodKDE) {
+   factory.BookMethod(loader, TMVA::Types::kLikelihood, "LikelihoodKDE",
+                      "!H:!V:!TransformOutput:PDFInterpol=KDE:KDEtype=Gauss:KDEiter=Adaptive:KDEFineFactor=0.3:KDEborder=None:NAvEvtPerBin=50" );
+
+}
+
+// Fisher discriminant (same as LD)
+if (useFischer) {
+   factory.BookMethod(loader, TMVA::Types::kFisher, "Fisher", "H:!V:Fisher:VarTransform=None:CreateMVAPdfs:PDFInterpolMVAPdf=Spline2:NbinsMVAPdf=50:NsmoothMVAPdf=10" );
+}
+
+//Boosted Decision Trees
+if (useBDT) {
+   factory.BookMethod(loader,TMVA::Types::kBDT, "BDT",
+                      "!V:NTrees=200:MinNodeSize=2.5%:MaxDepth=2:BoostType=AdaBoost:AdaBoostBeta=0.5:UseBaggedBoost:BaggedSampleFraction=0.5:SeparationType=GiniIndex:nCuts=20" );
+}
+
+//Multi-Layer Perceptron (Neural Network)
+if (useMLP) {
+   factory.BookMethod(loader, TMVA::Types::kMLP, "MLP",
+                      "!H:!V:NeuronType=tanh:VarTransform=N:NCycles=100:HiddenLayers=N+5:TestRate=5:!UseRegulator" );
+}
+
+
+/// Here we book the new DNN of TMVA if we have support in ROOT. We will use GPU version if ROOT is enabled with GPU
+
+
+   /***
+
+## Booking Deep Neural Network
+
+Here we define the option string for builfing the Deep Neural network model.
+
+#### 1. Define DNN layout
+
+The DNN configuration os defined using a string. Note that whitespaces between characters are not allowed.
+
+We define first the DNN layout:
+
+- **input layout** :   this defines the input data format for the DNN as  ``input depth | height | width``.
+   In case of a dense layer as first layer the input layout should be  ``1 | 1 | number of input variables`` (features)
+- **batch layout**  : this defines how are the input batch. It is related to input layout but not the same.
+   If the first layer is dense it should be ``1 | batch size ! number of variables`` (fetures)
+
+   *(note the use of the character `|` as  separator of  input parameters for DNN layout)*
+
+note that in case of only dense layer the input layout could be omitted but it is required when defining more
+complex architectures
+
+- **layer layout** string defining the layer architecture. The syntax is
+   - layer type (e.g. DENSE, CONV, RNN)
+   - layer parameters (e.g. number of units)
+   - activation function (e.g  TANH, RELU,...)
+
+     *the different layers are separated by the ``","`` *
+
+#### 2. Define Trainining Strategy
+
+We define here the training strategy parameters for the DNN. The parameters are separated by the ``","`` separator.
+One can then concatenate different training strategy with different parameters. The training strategy are separated by
+the ``"|"`` separator.
+
+ - Optimizer
+ - Learning rate
+ - Momentum (valid for SGD and RMSPROP)
+ - Regularization and Weight Decay
+ - Dropout
+ - Max number of epochs
+ - Convergence steps. if the test error will not decrease after that value the training will stop
+ - Batch size (This value must be the same specified in the input layout)
+ - Test Repetitions (the interval when the test error will be computed)
+
+
+#### 3. Define general DNN options
+
+We define the general DNN options concateneting in the final string the previously defined layout and training strategy.
+Note we use the ``":"`` separator to separate the different higher level options, as in the other TMVA methods.
+In addition to input layout, batch layout and training strategy we add now:
+
+- Type of Loss function (e.g. cross entropy)
+- Weight Initizalization (e.g XAVIER, XAVIERUNIFORM, NORMAL )
+- Variable Transformation
+- Type of Architecture (e.g. CPU, GPU, Standard)
+
+We can then book the DL method using the built otion string
+
+    ***/
+
+   if (useDL) {
+
+      bool useDLCPU = false;
+      bool useDLGPU = false;
+#ifdef R__HAS_TMVACPU
+      useDLCPU = true;
+#endif
+#ifdef R__HAS_TMVAGPU
+      useDLGPU = true;
+#endif
+
+      // Define DNN layout
+      TString inputLayoutString = "InputLayout=1|1|7";
+      TString batchLayoutString= "BatchLayout=1|128|7";
+      TString layoutString ("Layout=DENSE|64|TANH,DENSE|64|TANH,DENSE|64|TANH,DENSE|64|TANH,DENSE|1|LINEAR");
+      // Define Training strategies
+      // one can catenate several training strategies
+      TString training1("LearningRate=1e-3,Momentum=0.9,Repetitions=1,"
+                        "ConvergenceSteps=10,BatchSize=128,TestRepetitions=1,"
+                        "MaxEpochs=30,WeightDecay=1e-4,Regularization=None,"
+                        "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.");
+      //     TString training2("LearningRate=1e-3,Momentum=0.9,Repetitions=1,"
+      //                       "ConvergenceSteps=10,BatchSize=128,TestRepetitions=1,"
+      //                       "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"
+      //                       "Optimizer=SGD,DropConfig=0.0+0.0+0.0+0.");
+
+      TString trainingStrategyString ("TrainingStrategy=");
+      trainingStrategyString += training1; // + "|" + training2;
+
+      // General Options.
+
+      TString dnnOptions ("!H:V:ErrorStrategy=CROSSENTROPY:VarTransform=G:"
+                          "WeightInitialization=XAVIER");
+      dnnOptions.Append (":"); dnnOptions.Append (inputLayoutString);
+      dnnOptions.Append (":"); dnnOptions.Append (batchLayoutString);
+      dnnOptions.Append (":"); dnnOptions.Append (layoutString);
+      dnnOptions.Append (":"); dnnOptions.Append (trainingStrategyString);
+
+      TString dnnMethodName = "DNN_CPU";
+      if (useDLGPU) {
+         dnnOptions += ":Architecture=GPU";
+         dnnMethodName = "DNN_GPU";
+      } else
+         dnnOptions += ":Architecture=CPU";
+
+      factory.BookMethod(loader, TMVA::Types::kDL, dnnMethodName, dnnOptions);
+
+   }
+
+   /**
+## Train Methods
+
+Here we train all the previously booked methods.
+
+    */
+
+   factory.TrainAllMethods();
+
+/**
+   ## Test  all methods
+
+ Now we test and evaluate all methods using the test data set
+*/
+
+   factory.TestAllMethods();
+
+   factory.EvaluateAllMethods();
+
+/// after we get the ROC curve and we display
+
+   auto c1 = factory.GetROCCurve(loader);
+   c1->Draw();
+
+/// at the end we close the output file which contains the evaluation result of all methods and it can be used by TMVAGUI
+/// to display additional plots
+
+   outputFile->Close();
+
+
+}

--- a/tutorials/tmva/TMVA_Higgs_Classification.C
+++ b/tutorials/tmva/TMVA_Higgs_Classification.C
@@ -1,10 +1,17 @@
 /// \file
 /// \ingroup tutorial_tmva
-/// Classification example of TNVA  using Higgs UCI dataset
+/// \notebook
+/// Classification example of TMVA based on public Higgs UCI dataset
+///
 ///  The UCI data set is a public HIGGS data set , see http://archive.ics.uci.edu/ml/datasets/HIGGS
-// used in this paper: Baldi, P., P. Sadowski, and D. Whiteson. “Searching for Exotic Particles in High-energy Physics
+/// used in this paper: Baldi, P., P. Sadowski, and D. Whiteson. “Searching for Exotic Particles in High-energy Physics
 ///                     with Deep Learning.” Nature Communications 5 (July 2, 2014).
 ///
+/// \macro_image
+/// \macro_output
+/// \macro_code
+///
+/// \author Lorenzo Moneta
 
 /***
 ## Declare Factory
@@ -33,7 +40,7 @@ void TMVA_Higgs_Classification() {
    bool useFischer = true;       // Fischer discriminant
    bool useMLP = false;          // Multi Layer Perceptron (old TMVA NN implementation)
    bool useBDT = true;           // BOosted Decision Tree
-   bool useDL = true;            // TMVA Deep learning ( CPU ot GPU)
+   bool useDL = true;            // TMVA Deep learning ( CPU or GPU)
 
 
 
@@ -57,7 +64,12 @@ Define now input data file and signal and background trees
 
    TString inputFileName = "Higgs_data.root";
 
-   auto inputFile = TFile::Open( inputFileName );
+   TFile *inputFile = nullptr;
+
+   if (!gSystem->AccessPathName(inputFileName)) {
+      // file exists
+      inputFile = TFile::Open( inputFileName );
+   }
 
    if (!inputFile) {
       // download file from Cernbox location
@@ -130,7 +142,7 @@ note that you may also use variable expressions, which can be parsed by TTree::D
 /***
 ## Booking Methods
 
-Here we book the TMVA methods. We book firat a Likelihood based on KDE (Kernel Density Estimation), a Fischer discriminant, a BDT
+Here we book the TMVA methods. We book first a Likelihood based on KDE (Kernel Density Estimation), a Fischer discriminant, a BDT
 and a shallow neural network
 
  */
@@ -173,11 +185,11 @@ if (useMLP) {
 
 ## Booking Deep Neural Network
 
-Here we define the option string for builfing the Deep Neural network model.
+Here we define the option string for building the Deep Neural network model.
 
 #### 1. Define DNN layout
 
-The DNN configuration os defined using a string. Note that whitespaces between characters are not allowed.
+The DNN configuration is defined using a string. Note that whitespaces between characters are not allowed.
 
 We define first the DNN layout:
 
@@ -221,12 +233,12 @@ We define the general DNN options concateneting in the final string the previous
 Note we use the ``":"`` separator to separate the different higher level options, as in the other TMVA methods.
 In addition to input layout, batch layout and training strategy we add now:
 
-- Type of Loss function (e.g. cross entropy)
+- Type of Loss function (e.g. CROSSENTROPY)
 - Weight Initizalization (e.g XAVIER, XAVIERUNIFORM, NORMAL )
 - Variable Transformation
 - Type of Architecture (e.g. CPU, GPU, Standard)
 
-We can then book the DL method using the built otion string
+We can then book the DL method using the built option string
 
     ***/
 

--- a/tutorials/tmva/TMVA_RNN_Classification.C
+++ b/tutorials/tmva/TMVA_RNN_Classification.C
@@ -1,0 +1,468 @@
+
+/***
+
+    # TMVA Classification Example Using a Recurrent Neural Network
+
+    This is an example of using a RNN in TMVA. We do classification using a toy  data set
+    containing a time series of data sample ntimes and with dimension ndim
+   that is generated when running the provided function `MakeTimeData (nevents, ntime, ndim)
+
+
+**/
+
+#include<TROOT.h>
+
+#include "TMVA/Factory.h"
+#include "TMVA/DataLoader.h"
+#include "TMVA/DataSetInfo.h"
+#include "TMVA/Config.h"
+#include "TMVA/MethodDL.h"
+
+
+#include "TFile.h"
+#include "TTree.h"
+
+// make some time data but not of fixed length.
+//  use a poisson with mu = 5 and troncated at 10
+//
+
+void MakeTimeData(int n, int ntime, int ndim )
+{
+
+   // const int ntime = 10;
+   // const int ndim = 30; // number of dim/time
+   TString fname = TString::Format("time_data_t%d_d%d.root", ntime, ndim);
+   std::vector<TH1 *> v1(ntime);
+   std::vector<TH1 *> v2(ntime);
+   int i = 0;
+   for (int i = 0; i < ntime; ++i) {
+      v1[i] = new TH1D(TString::Format("h1_%d", i), "h1", ndim, 0, 10);
+      v2[i] = new TH1D(TString::Format("h2_%d", i), "h2", ndim, 0, 10);
+   }
+
+   auto f1 = new TF1("f1", "gaus");
+   auto f2 = new TF1("f2", "gaus");
+
+   TTree sgn("sgn", "sgn");
+   TTree bkg("bkg", "bkg");
+   TFile f(fname, "RECREATE");
+
+   std::vector<std::vector<float>> x1(ntime);
+   std::vector<std::vector<float>> x2(ntime);
+
+   for (int i = 0; i < ntime; ++i) {
+      x1[i] = std::vector<float>(ndim);
+      x2[i] = std::vector<float>(ndim);
+   }
+
+   for (auto i = 0; i < ntime; i++) {
+      bkg.Branch(Form("vars_time%d", i), "std::vector<float>", &x1[i]);
+      sgn.Branch(Form("vars_time%d", i), "std::vector<float>", &x2[i]);
+   }
+
+   sgn.SetDirectory(&f);
+   bkg.SetDirectory(&f);
+   gRandom->SetSeed(0);
+
+   std::vector<double> mean1(ntime);
+   std::vector<double> mean2(ntime);
+   std::vector<double> sigma1(ntime);
+   std::vector<double> sigma2(ntime);
+   for (int j = 0; j < ntime; ++j) {
+      mean1[j] = 5. + 0.2 * sin(TMath::Pi() * j / double(ntime));
+      mean2[j] = 5. + 0.2 * cos(TMath::Pi() * j / double(ntime));
+      sigma1[j] = 4 + 0.3 * sin(TMath::Pi() * j / double(ntime));
+      sigma2[j] = 4 + 0.3 * cos(TMath::Pi() * j / double(ntime));
+   }
+   for (int i = 0; i < n; ++i) {
+
+      if (i % 1000 == 0)
+         std::cout << "Generating  event ... " << i << std::endl;
+
+      for (int j = 0; j < ntime; ++j) {
+         auto h1 = v1[j];
+         auto h2 = v2[j];
+         h1->Reset();
+         h2->Reset();
+
+         f1->SetParameters(1, mean1[j], sigma1[j]);
+         f2->SetParameters(1, mean2[j], sigma2[j]);
+
+         h1->FillRandom("f1", 1000);
+         h2->FillRandom("f2", 1000);
+
+         for (int k = 0; k < ndim; ++k) {
+            // std::cout << j*10+k << "   ";
+            x1[j][k] = h1->GetBinContent(k + 1) + gRandom->Gaus(0, 10);
+            x2[j][k] = h2->GetBinContent(k + 1) + gRandom->Gaus(0, 10);
+         }
+      }
+      // std::cout << std::endl;
+      sgn.Fill();
+      bkg.Fill();
+
+      if (n == 1) {
+         auto c1 = new TCanvas();
+         c1->Divide(ntime, 2);
+         for (int j = 0; j < ntime; ++j) {
+            c1->cd(j + 1);
+            v1[j]->Draw();
+         }
+         for (int j = 0; j < ntime; ++j) {
+            c1->cd(ntime + j + 1);
+            v2[j]->Draw();
+         }
+         gPad->Update();
+      }
+   }
+   if (n > 1) {
+      sgn.Write();
+      bkg.Write();
+      sgn.Print();
+      bkg.Print();
+      f.Close();
+   }
+}
+/// macro for performing a classification using a Recurrent Neural Network
+/// @param use_type
+///    use_type = 0    use Simple RNN network
+///    use_type = 1    use LSTM network
+///    use_type = 2    use GRU
+///    use_type = 3    build 3 different networks with RNN, LSTM and GRU
+
+void TMVA_RNN_Classification(int use_type = 1)  
+{
+
+   const int ninput = 30;
+   const int ntime = 10;
+   const int batchSize = 100;
+   const int maxepochs = 20;
+
+   int nTotEvts = 10000; // total events to be generated for signal or background
+
+   bool useKeras = true;
+
+
+   bool useTMVA_RNN = true;
+   bool useTMVA_DNN = true;
+   bool useTMVA_BDT = false;
+
+   std::vector<std::string> rnn_types = {"RNN", "LSTM", "GRU"};
+   std::vector<bool> use_rnn_type = {1, 1, 1};
+   if (use_type >=0 && use_type < 3) {
+      use_rnn_type = {0,0,0};
+      use_rnn_type[use_type] = 1;
+   }
+   bool useGPU = true;   // use GPU for TMVA if available
+
+#ifndef R__HAS_TMVAGPU
+   useGPU = false;
+#ifndef R__HAS_TMVACPU
+   Warning("TMVA_RNN_Classification", "TMVA is not build with GPU or CPU multi-thread support. Cannot use TMVA Deep Learning");
+   useTMVA_RNN = false;
+   useTMVA_DNN = false;
+#endif
+#endif
+
+
+   TString archString = (useGPU) ? "GPU" : "CPU";
+
+   bool writeOutputFile = true;
+
+
+
+   const char *rnn_type = "RNN";
+
+   TMVA::PyMethodBase::PyInitialize();
+
+   ROOT::EnableImplicitMT(1);
+   TMVA::Config::Instance();
+
+   std::cout << "nthreads  = " << ROOT::GetThreadPoolSize() << std::endl;
+
+   TString inputFileName = "time_data_t10_d30.root";
+   // TString inputFileName = "/home/moneta/data/sample_images_32x32.gsoc.root";
+
+   bool fileExist = !gSystem->AccessPathName(inputFileName);
+
+   // if file does not exists create it
+   if (!fileExist) {
+      MakeTimeData(nTotEvts,ntime, ninput);
+   }
+
+
+   auto inputFile = TFile::Open(inputFileName);
+   if (!inputFile) {
+      Error("TMVA_RNN_Classification", "Error opening input file %s - exit", inputFileName.Data());
+      return;
+   }
+
+
+   std::cout << "--- RNNClassification  : Using input file: " << inputFile->GetName() << std::endl;
+
+   // Create a ROOT output file where TMVA will store ntuples, histograms, etc.
+   TString outfileName(TString::Format("data_RNN_%s.root", archString.Data()));
+   TFile *outputFile = nullptr;
+   if (writeOutputFile) outputFile = TFile::Open(outfileName, "RECREATE");
+
+   /**
+    ## Declare Factory
+
+    Create the Factory class. Later you can choose the methods
+    whose performance you'd like to investigate.
+
+    The factory is the major TMVA object you have to interact with. Here is the list of parameters you need to
+pass
+
+    - The first argument is the base of the name of all the output
+    weightfiles in the directory weight/ that will be created with the
+    method parameters
+
+    - The second argument is the output file for the training results
+
+    - The third argument is a string option defining some general configuration for the TMVA session.
+      For example all TMVA output can be suppressed by removing the "!" (not) in front of the "Silent" argument in
+the option string
+
+    **/
+
+   // Creating the factory object
+   TMVA::Factory *factory = new TMVA::Factory("TMVAClassification", outputFile,
+                                              "!V:!Silent:Color:DrawProgressBar:Transformations=None:!Correlations:"
+                                              "AnalysisType=Classification:ModelPersistence");
+   TMVA::DataLoader *dataloader = new TMVA::DataLoader("dataset");
+
+   TTree *signalTree = (TTree *)inputFile->Get("sgn");
+   TTree *background = (TTree *)inputFile->Get("bkg");
+
+   const int nvar = ninput * ntime;
+
+   /// add variables - use new AddVariablesArray function
+   for (auto i = 0; i < ntime; i++) {
+      dataloader->AddVariablesArray(Form("vars_time%d", i), ninput);
+   }
+
+   dataloader->AddSignalTree(signalTree, 1.0);
+   dataloader->AddBackgroundTree(background, 1.0);
+
+   // check given input
+   auto &datainfo = dataloader->GetDataSetInfo();
+   auto vars = datainfo.GetListOfVariables();
+   std::cout << "number of variables is " << vars.size() << std::endl;
+   for (auto &v : vars)
+      std::cout << v << ",";
+   std::cout << std::endl;
+
+   int nTrainSig = 0.8 * nTotEvts;
+   int nTrainBkg = 0.8 *  nTotEvts;
+
+   // build the string options for DataLoader::PrepareTrainingAndTestTree
+   TString prepareOptions = TString::Format("nTrain_Signal=%d:nTrain_Background=%d:SplitMode=Random:SplitSeed=100:NormMode=NumEvents:!V:!CalcCorrelations", nTrainSig, nTrainBkg);
+
+   // Apply additional cuts on the signal and background samples (can be different)
+   TCut mycuts = ""; // for example: TCut mycuts = "abs(var1)<0.5 && abs(var2-0.5)<1";
+   TCut mycutb = "";
+
+   dataloader->PrepareTrainingAndTestTree(mycuts, mycutb, prepareOptions);
+
+   std::cout << "prepared DATA LOADER " << std::endl;
+
+   /**
+       ## Book TMVA  recurrent models
+
+      Book the different types of recurrent models in TMVA  (SimpleRNN, LSTM or GRU)
+
+ **/
+
+   if (useTMVA_RNN) {
+
+      for (int i = 0; i < 3; ++i) {
+
+         if (!use_rnn_type[i])
+            continue;
+
+         const char *rnn_type = rnn_types[i].c_str();
+
+         /// define the inputlayout string for RNN
+         /// the input data should be organize as   following:
+         //// input layout for RNN:    time x 1 x ndim
+         ///  batch layout for RNN     batchsize x time x ndim
+
+         TString inputLayoutString = TString::Format("InputLayout=%d|1|%d", ntime, ninput);
+         TString batchLayoutString = TString::Format("BatchLayout=%d|%d|%d", batchSize, ntime, ninput);
+
+         /// Define RNN layer layout
+         ///  it should be   LayerType (RNN or LSTM or GRU) |  number of units | number of inputs | time steps | remember output (typically no=0 | return full sequence
+         TString rnnLayout = TString::Format("%s|10|%d|%d|0|1", rnn_type, ninput, ntime);
+
+         /// add after RNN a reshape layer (needed top flatten the output) and a dense layer with 64 units and a last one
+         /// NOte the last layer is linear because  when using Crossentropy a Sigmoid is applied
+         TString layoutString = TString("Layout=") + rnnLayout + TString(",RESHAPE|FLAT,DENSE|64|TANH,LINEAR");
+
+         /// Defining Training strategies. Different training strings can be concatenate. Use however only one
+         TString trainingString1 = TString::Format("LearningRate=1e-3,Momentum=0.0,Repetitions=1,"
+                                             "ConvergenceSteps=5,BatchSize=%d,TestRepetitions=1,"
+                                             "WeightDecay=1e-2,Regularization=None,MaxEpochs=%d,"
+                                             "Optimizer=ADAM,DropConfig=0.0+0.+0.+0.",
+                                             batchSize,maxepochs);
+
+         TString trainingStrategyString("TrainingStrategy=");
+         trainingStrategyString += trainingString1; // + "|" + trainingString2
+
+         /// Define the full RN Noption string adding the final options for all network
+         TString rnnOptions("!H:V:ErrorStrategy=CROSSENTROPY:VarTransform=None:"
+                            "WeightInitialization=XAVIERUNIFORM:ValidationSize=0.2:RandomSeed=1234");
+
+         rnnOptions.Append(":");
+         rnnOptions.Append(inputLayoutString);
+         rnnOptions.Append(":");
+         rnnOptions.Append(batchLayoutString);
+         rnnOptions.Append(":");
+         rnnOptions.Append(layoutString);
+         rnnOptions.Append(":");
+         rnnOptions.Append(trainingStrategyString);
+         rnnOptions.Append(":");
+         rnnOptions.Append(TString::Format("Architecture=%s", archString.Data()));
+
+         TString rnnName = "TMVA_" + TString(rnn_type);
+         factory->BookMethod(dataloader, TMVA::Types::kDL, rnnName, rnnOptions);
+
+      }
+   }
+
+   /**
+      ## Book TMVA  fully connected dense layer  models
+
+   **/
+
+   if (useTMVA_DNN) {
+      // Method DL with Dense Layer
+      TString inputLayoutString = TString::Format("InputLayout=1|1|%d", ntime * ninput);
+      TString batchLayoutString = TString::Format("BatchLayout=1|256|%d", ntime * ninput);
+
+      TString layoutString("Layout=DENSE|64|TANH,DENSE|TANH|64,DENSE|TANH|64,LINEAR");
+      // Training strategies.
+      TString trainingString1("LearningRate=1e-3,Momentum=0.0,Repetitions=1,"
+                        "ConvergenceSteps=10,BatchSize=256,TestRepetitions=1,"
+                        "WeightDecay=1e-4,Regularization=None,MaxEpochs=20"
+                        "DropConfig=0.0+0.+0.+0.,Optimizer=ADAM");
+      TString trainingStrategyString("TrainingStrategy=");
+      trainingStrategyString += trainingString1; // + "|" + trainingString2
+
+      // General Options.
+      TString dnnOptions("!H:V:ErrorStrategy=CROSSENTROPY:VarTransform=None:"
+                         "WeightInitialization=XAVIER:RandomSeed=0");
+
+      dnnOptions.Append(":");
+      dnnOptions.Append(inputLayoutString);
+      dnnOptions.Append(":");
+      dnnOptions.Append(batchLayoutString);
+      dnnOptions.Append(":");
+      dnnOptions.Append(layoutString);
+      dnnOptions.Append(":");
+      dnnOptions.Append(trainingStrategyString);
+      dnnOptions.Append(":");
+      dnnOptions.Append(archString);
+
+      TString dnnName = "TMVA_DNN";
+      factory->BookMethod(dataloader, TMVA::Types::kDL, dnnName, dnnOptions);
+   }
+
+   /**
+    ## Book Keras recurrent models
+
+     Book the different types of recurrent models in Keras  (SimpleRNN, LSTM or GRU)
+
+   **/
+
+   if (useKeras) {
+
+      for (int i = 0; i < 3; i++) {
+
+         if (use_rnn_type[i]) {
+
+            TString modelName = TString::Format("model_%s.h5", rnn_types[i].c_str());
+            TString trainedModelName = TString::Format("trained_model_%s.h5", rnn_types[i].c_str());
+
+            Info("TMVA_RNN_Classification", "Building recurrent keras model of type %s",rnn_types[i].c_str());
+            // create python script which can be executed
+            // crceate 2 conv2d layer + maxpool + dense
+            TMacro m;
+            m.AddLine("import keras");
+            m.AddLine("from keras.models import Sequential");
+            m.AddLine("from keras.optimizers import Adam");
+            m.AddLine("from keras.layers import Input, Dense, Dropout, Flatten, SimpleRNN, GRU, LSTM, Reshape, "
+                      "BatchNormalization");
+            m.AddLine("");
+            m.AddLine("model = keras.models.Sequential() ");
+            m.AddLine("model.add(Reshape((10, 30), input_shape = (10*30, )))");
+            // add recurrent neural network depending on type / Use option to return the full output
+            if (rnn_types[i] == "LSTM")
+               m.AddLine("model.add(LSTM(units=10, return_sequences=True) )");
+            else if (rnn_types[i] == "GRU")
+               m.AddLine("model.add(GRU(units=10, return_sequences=True) )");
+            else
+               m.AddLine("model.add(SimpleRNN(units=10, return_sequences=True) )");
+
+            // m.AddLine("model.add(BatchNormalization())");
+            m.AddLine("model.add(Flatten())"); // needed if returning the full time output sequence
+            m.AddLine("model.add(Dense(64, activation = 'tanh')) ");
+            m.AddLine("model.add(Dense(2, activation = 'sigmoid')) ");
+            m.AddLine("model.compile(loss = 'binary_crossentropy', optimizer = Adam(lr = 0.001), metrics = ['accuracy'])");
+            m.AddLine(TString::Format("modelName = '%s'",modelName.Data()));
+            m.AddLine("model.save(modelName)");
+            m.AddLine("model.summary()");
+
+            m.SaveSource("make_rnn_model.py");
+            // execute
+            gSystem->Exec("python make_rnn_model.py");
+
+            if (gSystem->AccessPathName(modelName)) {
+               Error("TMVA_RNN_Classification", "Error creating Keras RNN model file - exit");
+               return;
+            }
+
+            std::cout << "Booking Keras recurrent model of type " << rnn_types[i] << std::endl;
+
+            factory->BookMethod(
+               dataloader, TMVA::Types::kPyKeras, TString::Format("PyKeras_%s", rnn_types[i].c_str()),
+               TString::Format("!H:!V:VarTransform=None:FilenameModel=%s:"
+                               "FilenameTrainedModel=%s:GpuOptions=allow_growth=True:"
+                               "NumEpochs=%d:BatchSize=%d", modelName.Data(), trainedModelName.Data(),
+                               maxepochs, batchSize));
+         }
+      }
+   }
+
+   /**
+         ## Book TMVA BDT
+   **/
+
+   if (useTMVA_BDT) {
+
+      factory->BookMethod(dataloader, TMVA::Types::kBDT, "BDTG",
+                          "!H:!V:NTrees=500:MinNodeSize=2.5%:BoostType=Grad:Shrinkage=0.10:UseBaggedBoost:"
+                          "BaggedSampleFraction=0.5:nCuts=20:"
+                          "MaxDepth=2");
+
+   }
+
+   /// Train all methods
+   factory->TrainAllMethods();
+
+   std::cout << "nthreads  = " << ROOT::GetThreadPoolSize() << std::endl;
+
+   // ---- Evaluate all MVAs using the set of test events
+   factory->TestAllMethods();
+
+   // ----- Evaluate and compare performance of all configured MVAs
+   factory->EvaluateAllMethods();
+
+   // check method
+
+   // plot ROC curve
+   auto c1 = factory->GetROCCurve(dataloader);
+   c1->Draw();
+
+   if (outputFile) outputFile->Close();
+}


### PR DESCRIPTION
  - TMVA_Higgs_Classification.C

   a tutorial using the public Higgs UCI dataset for a classification problem using a Deep Neural network from TMVA, that is  made with fully connected layers

 - TMVA_CNN_Classification.C

 Tutorial showing the usage of Convolutional neural network in TMVA.
 The macro generates on the fly some toys images (size 16x16) of two different classes and then a
 convolutional neural network is used for their classification.
 This example builds and uses also a CNN built on the fly using Keras through the ROOT PyKeras package
 This example shows also how to use a batch normalization layer in TMVA

- TMVA_RNN_Classification.C

 Tutorial showing the usage of Recurrent neural network in TMVA.
 Toys time dependednt data of two different classes are generated on the fly and then
 a recurrent neural network is used for classification.
 Both TMVA and PyKeras networks are built and used.
 The network uses by default one LSTM layer, but optionally it can be built with
 a simple RNN or a GRU layer or also 3 different recurrent networks for each recurrent layer type
 can be made