### PR TITLE
TProcessID::RecursiveRemove: prevent spurrious error msg.

### DIFF
--- a/core/base/src/TProcessID.cxx
+++ b/core/base/src/TProcessID.cxx
@@ -414,7 +414,7 @@ void TProcessID::RecursiveRemove(TObject *obj)
    UInt_t uid = obj->GetUniqueID() & 0xffffff;
    if (obj == GetObjectWithID(uid)) {
       R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
-      if (fgObjPIDs) {
+      if (fgObjPIDs && ((obj->GetUniqueID()&0xff000000)==0xff000000)) {
          ULong64_t hash = Void_Hash(obj);
          fgObjPIDs->Remove(hash,(Long64_t)obj);
       }

--- a/core/base/src/TProcessID.cxx
+++ b/core/base/src/TProcessID.cxx
@@ -414,6 +414,10 @@ void TProcessID::RecursiveRemove(TObject *obj)
    UInt_t uid = obj->GetUniqueID() & 0xffffff;
    if (obj == GetObjectWithID(uid)) {
       R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
+      // Only attempt to remove from the map the items that are already
+      // registered (because they are associated with a TProcessID with index 
+      // greater than 255.  Attempting to remove an item that is not in the map
+      // issues a Warning message.  
       if (fgObjPIDs && ((obj->GetUniqueID()&0xff000000)==0xff000000)) {
          ULong64_t hash = Void_Hash(obj);
          fgObjPIDs->Remove(hash,(Long64_t)obj);


### PR DESCRIPTION
Prior to this change, TProcessID::RecursiveRemove would call TExMap::Remove without checking whether the object was in that map or not.  In addition TExMap::Remove complains if it can not be found.
This resulted in spurious error message when the number of TProcessID increased passed 255 but some of the object with lower index TProcessID were deleted.

See https://root-forum.cern.ch/t/resetting-tprocessid-objectcount-in-multihtreading-environment/38899
for a concrete example.