### PR TITLE
We do not build a dictionary for GQuartz.

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -657,7 +657,7 @@ function (ROOT_CXXMODULES_APPEND_TO_MODULEMAP library library_headers)
   endif()
 
   # For modules GCocoa and GQuartz we need objc and cplusplus context.
-  if (NOT ${library} MATCHES "(GCocoa|GQuartz)")
+  if (NOT ${library} MATCHES "GCocoa")
     set (modulemap_entry "${modulemap_entry}\n  requires cplusplus\n")
   endif()
   if (library_headers)

--- a/graf2d/cocoa/CMakeLists.txt
+++ b/graf2d/cocoa/CMakeLists.txt
@@ -33,9 +33,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(GCocoa
     src/X11Events.mm
     src/XLFDParser.mm
   DEPENDENCIES
-    GQuartz
     Gui
   LIBRARIES
+    GQuartz
     "-framework Cocoa"
     "-framework OpenGL"
     ${FREETYPE_LIBRARIES}


### PR DESCRIPTION
ROOT_STANDARD_LIBRARY_PACKAGE passes all DEPENDENCIES to roocling via ROOT_GENERATE_DICTIONARY.

This is part of PR #5443