### PR TITLE
Fix directory name for correct installation of ROOT

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -814,8 +814,8 @@ if (XROOTD_FOUND AND XROOTD_NOMAIN)
                  DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
-install(FILES ${CMAKE_BINARY_DIR}/include/RConfigOptions.h
-              ${CMAKE_BINARY_DIR}/include/compiledata.h
+install(FILES ${CMAKE_BINARY_DIR}/ginclude/RConfigOptions.h
+              ${CMAKE_BINARY_DIR}/ginclude/compiledata.h
               DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(FILES ${CMAKE_BINARY_DIR}/etc/root.mimes


### PR DESCRIPTION
```-- Installing: /workspace/install/ROOT/HEAD/x86_64-centos7-gcc7-opt/bin/roots
-- Installing: /workspace/install/ROOT/HEAD/x86_64-centos7-gcc7-opt/bin/proofserv
-- Installing: /workspace/install/ROOT/HEAD/x86_64-centos7-gcc7-opt/bin/xproofd
CMake Error at cmake_install.cmake:111 (file):
  file INSTALL cannot find
  "/workspace/build/projects/ROOT-HEAD/src/ROOT-HEAD-build/include/RConfigOptions.h":
  No such file or directory.
```