### PR TITLE
Zmin and Zmax did not take into account the Z errors

### DIFF
--- a/README/ReleaseNotes/v622/index.md
+++ b/README/ReleaseNotes/v622/index.md
@@ -122,6 +122,7 @@ into RooFit's message stream number 2. The verbosity can therefore be adjusted u
     Jan Musinsky.
   - The crosshair type cursor type did not work on MacOS Catalina. This has been fixed by
     Timur Pocheptsoff.
+  - Take into account the Z errors when defining the frame to paint a TGraph2DErrors.
 
 ## 3D Graphics Libraries
 

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1168,12 +1168,12 @@ TH2D *TGraph2D::GetHistogram(Option_t *option)
       if (fMinimum != -1111) {
          hzmin = fMinimum;
       } else {
-         hzmin = GetZmin();
+         hzmin = GetZminE();
       }
       if (fMaximum != -1111) {
          hzmax = fMaximum;
       } else {
-         hzmax = GetZmax();
+         hzmax = GetZmaxE();
       }
       if (hzmin == hzmax) {
          Double_t hz = hzmin;

--- a/hist/histpainter/src/TGraph2DPainter.cxx
+++ b/hist/histpainter/src/TGraph2DPainter.cxx
@@ -531,8 +531,8 @@ void TGraph2DPainter::Paint(Option_t *option)
    fYmin = yaxis->GetBinLowEdge(first);
    if (Hoption.Logy && fYmin <= 0) fYmin = yaxis->GetBinUpEdge(yaxis->FindFixBin(0.01*yaxis->GetBinWidth(first)));
    fYmax = yaxis->GetBinUpEdge(yaxis->GetLast());
-   fZmax = fGraph2D->GetZmax();
-   fZmin = fGraph2D->GetZmin();
+   fZmax = fGraph2D->GetZmaxE();
+   fZmin = fGraph2D->GetZminE();
    if (Hoption.Logz && fZmin <= 0) fZmin = TMath::Min((Double_t)1, (Double_t)0.001*fGraph2D->GetZmax());
 
    if (triangles) PaintTriangles(option);


### PR DESCRIPTION
Zmin and Zmax did not take into account the Z errors for TGrap2DErrors (X and Y axis were fine).
reproducer:
```
{
   const Int_t n = 10;
   Double_t x[n], y[n], z[10];
   Double_t ex[n], ey[n], ez[10];

   for (Int_t i=0;i<n;i++) {
     x[i] = i*0.1;
     y[i] = 10*sin(x[i]+0.2)-5;
     z[i] = i;
     ex[i] = i+1;
     ey[i] = i+1;
     ez[i] = i+1;
   }

   auto *gr2d = new TGraph2DErrors(n,x,y,z,ex,ey,ez);
   gr2d->Draw("P0 ERR");
}
```