### PR TITLE
Avoid template instantiation during tear down.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3874,7 +3874,8 @@ void TCling::SetClassInfo(TClass* cl, Bool_t reload)
 
    }
 
-   TClingClassInfo* info = new TClingClassInfo(GetInterpreterImpl(), name.c_str());
+   bool instantiateTemplate = !cl->TestBit(TClass::kUnloading);
+   TClingClassInfo* info = new TClingClassInfo(GetInterpreterImpl(), name.c_str(), instantiateTemplate);
    if (!info->IsValid()) {
       if (cl->fState != TClass::kHasTClassInit) {
          if (cl->fStreamerInfo->GetEntries() != 0) {

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3875,6 +3875,10 @@ void TCling::SetClassInfo(TClass* cl, Bool_t reload)
    }
 
    bool instantiateTemplate = !cl->TestBit(TClass::kUnloading);
+   // FIXME: Rather than adding an option to the TClingClassInfo, we should consider combining code 
+   // that is currently in the caller (like SetUnloaded) that disable AutoLoading and AutoParsing and
+   // code is in the callee (disabling template instantiation) and end up with a more explicit class:
+   //      TClingClassInfoReadOnly.
    TClingClassInfo* info = new TClingClassInfo(GetInterpreterImpl(), name.c_str(), instantiateTemplate);
    if (!info->IsValid()) {
       if (cl->fState != TClass::kHasTClassInit) {

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -79,7 +79,7 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, Bool_t all)
    fType = 0;
 }
 
-TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name)
+TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name, bool intantiateTemplate /* = true */)
    : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE), fIsIter(false),
      fType(0), fTitle(""), fOffsetCache(0)
 {
@@ -88,14 +88,14 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name)
    const Decl *decl = lh.findScope(name,
                                    gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                                    : cling::LookupHelper::NoDiagnostics,
-                                   &type, /* intantiateTemplate= */ true );
+                                   &type, intantiateTemplate);
    if (!decl) {
       std::string buf = TClassEdit::InsertStd(name);
       if (buf != name) {
          decl = lh.findScope(buf,
                              gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                              : cling::LookupHelper::NoDiagnostics,
-                             &type, /* intantiateTemplate= */ true );
+                             &type, intantiateTemplate);
       }
    }
    if (!decl && type) {

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -81,7 +81,7 @@ public: // Types
 public:
 
    explicit TClingClassInfo(cling::Interpreter *, Bool_t all = kTRUE);
-   explicit TClingClassInfo(cling::Interpreter *, const char *);
+   explicit TClingClassInfo(cling::Interpreter *, const char *classname, bool intantiateTemplate = kTRUE);
    explicit TClingClassInfo(cling::Interpreter *, const clang::Type &);
    explicit TClingClassInfo(cling::Interpreter *, const clang::Decl *);
    void                 AddBaseOffsetFunction(const clang::Decl* decl, OffsetPtrFunc_t func) { fOffsetCache[decl] = std::make_pair(0L, func); }


### PR DESCRIPTION
This fixes ROOT-10712.

Note, that the problem appears if
```
TClass::GetClass(""art::Wrapper<art::Assns<string,int,void> >")->SetUnloaded();
```
is called right before main; so it is not due to Cling/Clang being partially tore down.

Also calling
```
TClass::GetClass(""art::Wrapper<art::Assns<string,int,void> >")->GetClassInfo();
```
works properly.

This indicates that thes parts of SetUnloaded are "triggering" the problem:

```
InsertTClassInRegistryRAII insertRAII(fState, fName, fNoInfoOrEmuOrFwdDeclNameRegistry);

   // Make sure SetClassInfo, re-calculated the state.
   fState = kForwardDeclared;

   delete fIsA; fIsA = 0;
   // Disable the autoloader while calling SetClassInfo, to prevent
   // the library from being reloaded!
   {
      TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
      TInterpreter::SuspendAutoParsing autoParseRaii(gCling);
      gInterpreter->SetClassInfo(this,kTRUE);
   }
```

Likely disabling template instantiation inside SetClassInfo in this use case.

```
art: /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/include/clang/AST/DeclTemplate.h:1837: void clang::ClassTemplateSpecializationDecl::setInstantiationOf(clang::ClassTemplatePartialSpecializationDecl*, const clang::TemplateArgumentList*): Assertion `!SpecializedTemplate.is<SpecializedPartialSpecialization*>() && "Already set to a class template partial specialization!"' failed.

 

Program received signal SIGABRT, Aborted.

0x00007ffff089a377 in raise () from /lib64/libc.so.6

 

#1  0x00007ffff089ba68 in abort () from /lib64/libc.so.6

#2  0x00007ffff0893196 in __assert_fail_base () from /lib64/libc.so.6

#3  0x00007ffff0893242 in __assert_fail () from /lib64/libc.so.6

#4  0x00007fffe33d590f in clang::ClassTemplateSpecializationDecl::setInstantiationOf (this=0x7e8b810, PartialSpec=0x3b75340, TemplateArgs=0x7e91418)

    at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/include/clang/AST/DeclTemplate.h:1837

#5  0x00007fffe3d4911d in getPatternForClassTemplateSpecialization (S=..., PointOfInstantiation=..., ClassTemplateSpec=0x7e8b810, TSK=clang::TSK_ImplicitInstantiation, Complain=true)

    at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplateInstantiate.cpp:2500

#6  0x00007fffe3d492c6 in clang::Sema::InstantiateClassTemplateSpecialization (this=0x7da020, PointOfInstantiation=..., ClassTemplateSpec=0x7e8b810, TSK=clang::TSK_ImplicitInstantiation, Complain=true)

    at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplateInstantiate.cpp:2538

#7  0x00007fffe3e0b218 in clang::Sema::RequireCompleteTypeImpl (this=0x7da020, Loc=..., T=..., Diagnoser=0x7fffffff53a0)

    at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaType.cpp:7331

#8  0x00007fffe3e0a679 in clang::Sema::RequireCompleteType (this=0x7da020, Loc=..., T=..., Diagnoser=...) at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaType.cpp:7109

#9  0x00007fffe3e0b5cb in clang::Sema::RequireCompleteType (this=0x7da020, Loc=..., T=..., DiagID=2479) at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaType.cpp:7398

#10 0x00007fffe363cdc7 in clang::Sema::CheckFieldDecl (this=0x7da020, Name=..., T=..., TInfo=0x7e913e0, Record=0x7e8ed10, Loc=..., Mutable=false, BitWidth=0x0, InitStyle=clang::ICIS_ListInit, TSSL=..., AS=clang::AS_private,

    PrevDecl=0x0, D=0x0) at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaDecl.cpp:14482

#11 0x00007fffe3d8c4de in clang::TemplateDeclInstantiator::VisitFieldDecl (this=0x7fffffff59f0, D=0x51e8548)

    at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp:810

#12 0x00007fffe3d807a6 in clang::declvisitor::Base<clang::declvisitor::make_ptr, clang::TemplateDeclInstantiator, clang::Decl*>::Visit (this=0x7fffffff59f0, D=0x51e8548)

    at /scratch/greenc/test-products/root/v6_20_04/build/Linux64bit+3.10-2.17-e20-p382-debug/interpreter/llvm/src/tools/clang/include/clang/AST/DeclNodes.inc:369

#13 0x00007fffe3d4796c in clang::Sema::InstantiateClass (this=0x7da020, PointOfInstantiation=..., Instantiation=0x7e8ed10, Pattern=0x51e4900, TemplateArgs=..., TSK=clang::TSK_ImplicitInstantiation, Complain=true)

    at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplateInstantiate.cpp:2083

#14 0x00007fffe3d49340 in clang::Sema::InstantiateClassTemplateSpecialization (this=0x7da020, PointOfInstantiation=..., ClassTemplateSpec=0x7e8ed10, TSK=clang::TSK_ImplicitInstantiation, Complain=true)

    at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplateInstantiate.cpp:2543

#15 0x00007fffe3e0b218 in clang::Sema::RequireCompleteTypeImpl (this=0x7da020, Loc=..., T=..., Diagnoser=0x7fffffff5ff0)

    at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaType.cpp:7331

#16 0x00007fffe3e0a679 in clang::Sema::RequireCompleteType (this=0x7da020, Loc=..., T=..., Diagnoser=...) at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaType.cpp:7109

#17 0x00007fffe35607f9 in clang::Sema::RequireCompleteType<clang::SourceRange> (this=0x7da020, Loc=..., T=..., DiagID=2588)

    at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/include/clang/Sema/Sema.h:1653

--Type <RET> for more, q to quit, c to continue without paging--c

#18 0x00007fffe355c52a in clang::Sema::RequireCompleteDeclContext (this=0x7da020, SS=..., DC=@0x7fffffff61e0: 0x7e8ed48) at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/llvm/src/tools/clang/lib/Sema/SemaCXXScopeSpec.cpp:235

#19 0x00007fffe28426bb in cling::LookupHelper::findScope (this=0x78a0e0, className=..., diagOnOff=cling::LookupHelper::NoDiagnostics, resultType=0x7fffffff65f0, instantiateTemplate=true) at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/interpreter/cling/lib/Interpreter/LookupHelper.cpp:703

#20 0x00007fffe26b2ba8 in TClingClassInfo::TClingClassInfo (this=0x3e04b90, interp=0x77e5d0, name=0x6a1ad0 "art::Wrapper<art::Assns<string,int,void> >") at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/core/metacling/src/TClingClassInfo.cxx:95

#21 0x00007fffe26cacba in TCling::SetClassInfo (this=0x77bdf0, cl=0x3983b80, reload=true) at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/core/metacling/src/TCling.cxx:3785

#22 0x00007ffff74d245f in TClass::SetUnloaded (this=0x3983b80) at /scratch/greenc/test-products/root/v6_20_04/source/root-6.20.04/core/meta/src/TClass.cxx:6081

#23 0x00000000004025f5 in main (argc=3, argv=0x7fffffff68f8) at /scratch/greenc/build/mrb-art-devel/e20-debug/build_slf7.x86_64/art/art/Framework/Art/art.cc:26

```