### PR TITLE
v620: Avoid template instantiation during tear down.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3782,7 +3782,8 @@ void TCling::SetClassInfo(TClass* cl, Bool_t reload)
 
    }
 
-   TClingClassInfo* info = new TClingClassInfo(GetInterpreterImpl(), name.c_str());
+   bool instantiateTemplate = !cl->TestBit(TClass::kUnloading);
+   TClingClassInfo* info = new TClingClassInfo(GetInterpreterImpl(), name.c_str(), instantiateTemplate);
    if (!info->IsValid()) {
       if (cl->fState != TClass::kHasTClassInit) {
          if (cl->fStreamerInfo->GetEntries() != 0) {

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -79,7 +79,7 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, Bool_t all)
    fType = 0;
 }
 
-TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name)
+TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name, bool intantiateTemplate /* = true */)
    : TClingDeclInfo(nullptr), fInterp(interp), fFirstTime(true), fDescend(false), fIterAll(kTRUE), fIsIter(false),
      fType(0), fTitle(""), fOffsetCache(0)
 {
@@ -88,14 +88,14 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name)
    const Decl *decl = lh.findScope(name,
                                    gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                                    : cling::LookupHelper::NoDiagnostics,
-                                   &type, /* intantiateTemplate= */ true );
+                                   &type, intantiateTemplate);
    if (!decl) {
       std::string buf = TClassEdit::InsertStd(name);
       if (buf != name) {
          decl = lh.findScope(buf,
                              gDebug > 5 ? cling::LookupHelper::WithDiagnostics
                              : cling::LookupHelper::NoDiagnostics,
-                             &type, /* intantiateTemplate= */ true );
+                             &type, intantiateTemplate);
       }
    }
    if (!decl && type) {

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -80,7 +80,7 @@ public: // Types
 public:
 
    explicit TClingClassInfo(cling::Interpreter *, Bool_t all = kTRUE);
-   explicit TClingClassInfo(cling::Interpreter *, const char *);
+   explicit TClingClassInfo(cling::Interpreter *, const char *classname, bool intantiateTemplate = kTRUE);
    explicit TClingClassInfo(cling::Interpreter *, const clang::Type &);
    explicit TClingClassInfo(cling::Interpreter *, const clang::Decl *);
    void                 AddBaseOffsetFunction(const clang::Decl* decl, OffsetPtrFunc_t func) { fOffsetCache[decl] = std::make_pair(0L, func); }


### PR DESCRIPTION
This fixes ROOT-10712.

Note, that the problem appears if
```
TClass::GetClass(""art::Wrapper<art::Assns<string,int,void> >")->SetUnloaded();
```
is called right before main; so it is not due to Cling/Clang being partially tore down.

Also calling
```
TClass::GetClass(""art::Wrapper<art::Assns<string,int,void> >")->GetClassInfo();
```
works properly.

This indicates that thes parts of SetUnloaded are "triggering" the problem:

```
InsertTClassInRegistryRAII insertRAII(fState, fName, fNoInfoOrEmuOrFwdDeclNameRegistry);

   // Make sure SetClassInfo, re-calculated the state.
   fState = kForwardDeclared;

   delete fIsA; fIsA = 0;
   // Disable the autoloader while calling SetClassInfo, to prevent
   // the library from being reloaded!
   {
      TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
      TInterpreter::SuspendAutoParsing autoParseRaii(gCling);
      gInterpreter->SetClassInfo(this,kTRUE);
   }
```

Likely disabling template instantiation inside SetClassInfo in this use case.