### PR TITLE
[IMT] Let TThreadedObject grow the number of slots as needed 

### DIFF
--- a/core/thread/inc/ROOT/TThreadedObject.hxx
+++ b/core/thread/inc/ROOT/TThreadedObject.hxx
@@ -25,6 +25,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -350,8 +351,6 @@ namespace ROOT {
    template<class T> Internal::TThreadedObjectUtils::MaxSlots_t TThreadedObject<T>::fgMaxSlots{64};
 
 } // End ROOT namespace
-
-#include <sstream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Print a TThreadedObject at the prompt:

--- a/core/thread/inc/ROOT/TThreadedObject.hxx
+++ b/core/thread/inc/ROOT/TThreadedObject.hxx
@@ -163,7 +163,7 @@ namespace ROOT {
     * \ingroup Multicore
     *
     * A wrapper which makes objects thread private. The methods of the underlying
-    * object can be invoked via the the arrow operator. The object is created in
+    * object can be invoked via the arrow operator. The object is created in
     * a specific thread lazily, i.e. upon invocation of one of its methods.
     * The correct object pointer from within a particular thread can be accessed
     * with the overloaded arrow operator or with the Get method.
@@ -215,9 +215,8 @@ namespace ROOT {
          Create(nslots, args...);
       }
 
-      /// Access a particular processing slot. This
-      /// method is *thread-unsafe*: it cannot be invoked from two different
-      /// threads with the same argument.
+      /// Access a particular processing slot. This method is thread-safe as long as
+      /// concurrent calls request different slots (i.e. pass a different argument).
       std::shared_ptr<T> GetAtSlot(unsigned i)
       {
          if ( i >= fObjPointers.size()) {

--- a/core/thread/test/testTThreadedObject.cxx
+++ b/core/thread/test/testTThreadedObject.cxx
@@ -6,7 +6,7 @@
 
 using namespace ROOT;
 
-void IsSameHist(const TH1F &a, const TH1F &b)
+void IsHistEqual(const TH1F &a, const TH1F &b)
 {
    EXPECT_STREQ(a.GetName(), b.GetName()) << "The names of the histograms differ: " << a.GetName() << " " << b.GetName()
                                           << std::endl;
@@ -43,7 +43,7 @@ TEST(TThreadedObject, Get)
    TH1F model("h", "h", 64, -4, 4);
    ROOT::TThreadedObject<TH1F> tto("h", "h", 64, -4, 4);
    auto h = tto.Get();
-   IsSameHist(model, *h);
+   IsHistEqual(model, *h);
 }
 
 TEST(TThreadedObject, GetAtSlot)
@@ -51,7 +51,7 @@ TEST(TThreadedObject, GetAtSlot)
    TH1F model("h", "h", 64, -4, 4);
    ROOT::TThreadedObject<TH1F> tto("h", "h", 64, -4, 4);
    auto h = tto.GetAtSlot(0);
-   IsSameHist(model, *h);
+   IsHistEqual(model, *h);
 }
 
 TEST(TThreadedObject, GetAtSlotUnchecked)
@@ -60,7 +60,7 @@ TEST(TThreadedObject, GetAtSlotUnchecked)
    ROOT::TThreadedObject<TH1F> tto("h", "h", 64, -4, 4);
    tto->SetName("h");
    auto h = tto.GetAtSlot(0);
-   IsSameHist(model, *h);
+   IsHistEqual(model, *h);
 }
 
 TEST(TThreadedObject, GetAtSlotRaw)
@@ -69,7 +69,7 @@ TEST(TThreadedObject, GetAtSlotRaw)
    ROOT::TThreadedObject<TH1F> tto("h", "h", 64, -4, 4);
    tto->SetName("h");
    auto h = tto.GetAtSlotRaw(0);
-   IsSameHist(model, *h);
+   IsHistEqual(model, *h);
 }
 
 TEST(TThreadedObject, SetAtSlot)
@@ -78,7 +78,7 @@ TEST(TThreadedObject, SetAtSlot)
    tto.SetAtSlot(1, std::make_shared<TH1F>("h", "h", 64, -4, 4));
    auto h0 = tto.GetAtSlot(0);
    auto h1 = tto.GetAtSlot(1);
-   IsSameHist(*h0, *h1);
+   IsHistEqual(*h0, *h1);
 }
 
 TEST(TThreadedObject, Merge)
@@ -99,7 +99,7 @@ TEST(TThreadedObject, Merge)
    tto->FillRandom("gaus");
    tto.GetAtSlot(1)->FillRandom("gaus");
    auto hsum = tto.Merge();
-   IsSameHist(*hsum, m0);
+   IsHistEqual(*hsum, m0);
 }
 
 TEST(TThreadedObject, SnapshotMerge)
@@ -120,9 +120,9 @@ TEST(TThreadedObject, SnapshotMerge)
    tto->FillRandom("gaus", 100);
    tto.GetAtSlot(1)->FillRandom("gaus", 100);
    auto hsum0 = tto.SnapshotMerge();
-   IsSameHist(*hsum0, m0);
+   IsHistEqual(*hsum0, m0);
    auto hsum1 = tto.SnapshotMerge();
-   IsSameHist(*hsum1, m0);
-   IsSameHist(*hsum1, *hsum0);
+   IsHistEqual(*hsum1, m0);
+   IsHistEqual(*hsum1, *hsum0);
    EXPECT_TRUE(hsum1 != hsum0);
 }

--- a/core/thread/test/testTThreadedObject.cxx
+++ b/core/thread/test/testTThreadedObject.cxx
@@ -28,7 +28,6 @@ void IsHistEqual(const TH1F &a, const TH1F &b)
       auto bineb = b.GetBinError(i);
       EXPECT_DOUBLE_EQ(binea, bineb) << "The error of bin " << i << "  of the histograms differ: " << binea << " "
                                      << bineb << std::endl;
-      ;
    }
 }
 

--- a/core/thread/test/testTThreadedObject.cxx
+++ b/core/thread/test/testTThreadedObject.cxx
@@ -4,7 +4,6 @@
 
 #include "gtest/gtest.h"
 
-using namespace ROOT;
 
 void IsHistEqual(const TH1F &a, const TH1F &b)
 {

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -91,8 +91,9 @@ private:
    const Internal::FriendInfo fFriendInfo;
    ROOT::TThreadExecutor fPool; ///<! Thread pool for processing.
 
+   /// Thread-local TreeViews
    // Must be declared after fPool, for IMT to be initialized first!
-   ROOT::TThreadedObject<ROOT::Internal::TTreeView> fTreeView{ROOT::kIMTPoolSize}; ///<! Thread-local TreeViews
+   ROOT::TThreadedObject<ROOT::Internal::TTreeView> fTreeView{TNumSlots{ROOT::GetThreadPoolSize()}};
 
    Internal::FriendInfo GetFriendInfo(TTree &tree);
    std::vector<std::string> FindTreeNames();


### PR DESCRIPTION
TThreadedObject currently has a fixed amount of available slots,
the number of which can be set at construction time. This makes
it impossible to use TThreadedObject inside TBB tasks safely, because
TBB can potentially swap out worker threads for different threads at
runtime, resulting in TThreadedObject counting more thread ID's than
slots, and therefore in out-of-bound accesses to its contents.

With this patch, TThreadedObject just appends a new slot when needed,
so it nevers runs out.