### PR TITLE
[shutdown] TCling_UnloadMarker is called too late when there is no gROOT.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -196,22 +196,6 @@ extern "C" {
 #endif
 #endif
 
-//______________________________________________________________________________
-// Infrastructure to detect and react to libCling being teared down.
-//
-namespace {
-   class TCling_UnloadMarker {
-   public:
-      ~TCling_UnloadMarker() {
-         if (ROOT::Internal::gROOTLocal) {
-            ROOT::Internal::gROOTLocal->~TROOT();
-         }
-      }
-   };
-   static TCling_UnloadMarker gTClingUnloadMarker;
-}
-
-
 
 //______________________________________________________________________________
 // These functions are helpers for debugging issues with non-LLVMDEV builds.


### PR DESCRIPTION
We do not need TCling_UnloadMarker infrastructure anymore. It was originally fixing a problem of Belle II, however, now it breaks their code. The reason it was necessary was that `--as-needed` linker option was used which affected the new teardown order of ROOT.

This patch removes the TCling_UnloadMarker and resolves ROOT-10659.