### PR TITLE
Remove an assert in TMVA/DNN that is not needed. 

### DIFF
--- a/tmva/tmva/src/DNN/Architectures/Cpu/Initialization.hxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/Initialization.hxx
@@ -101,7 +101,6 @@ void TCpu<AFloat>::InitializeGlorotNormal(TCpuMatrix<AFloat> & A)
       do {
          value = rand.Gaus(0.0, sigma);
       } while (std::abs(value) > 2 * sigma);
-      R__ASSERT(std::abs(value) < 2 * sigma);
       A.GetRawDataPointer()[i] = value;
    }
 }

--- a/tmva/tmva/src/DNN/Architectures/Cuda/Initialization.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/Initialization.cu
@@ -104,7 +104,6 @@ void TCuda<AFloat>::InitializeGlorotNormal(TCudaMatrix<AFloat> & A)
          do {
             value = rand.Gaus(0.0, sigma);
          } while ( std::abs(value) > 2*sigma);
-         R__ASSERT( std::abs(value) < 2*sigma);
          B(i,j) = value;
       }
    }

--- a/tmva/tmva/src/DNN/Architectures/Cudnn/Initialization.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cudnn/Initialization.cu
@@ -114,7 +114,6 @@ void TCudnn<AFloat>::InitializeGlorotNormal(TCudaTensor<AFloat> & A)
          do {
             value = rand.Gaus(0.0, sigma);
          } while ( std::abs(value) > 2*sigma);
-         R__ASSERT( std::abs(value) < 2*sigma);
          xhost[i] = value;
    }
    A.GetDeviceBuffer().CopyFrom(xhost);


### PR DESCRIPTION
The assert is not needed and it could also fail, if for some random number generated value==2*sigma.

This could explain some failure observed in TMVA CNN tutorial