### PR TITLE
[PyROOT] Remove ROOT.Numba feature for python <= 2.7.5

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -9,7 +9,10 @@ from cppyy import cppdef
 from libROOTPythonizations import gROOT, CreateBufferFromAddress
 
 from ._application import PyROOTApplication
-from ._numbadeclare import _NumbaDeclareDecorator
+_numba_pyversion = (2, 7, 5)
+if sys.version_info[:3] > _numba_pyversion:
+    # Python <= 2.7.5 cannot use exec in an inner function
+    from ._numbadeclare import _NumbaDeclareDecorator
 
 
 class PyROOTConfiguration(object):
@@ -275,6 +278,8 @@ class ROOTFacade(types.ModuleType):
     # Create and overload Numba namespace
     @property
     def Numba(self):
+        if sys.version_info[:3] <= _numba_pyversion:
+            raise Exception('ROOT.Numba requires Python above version {}.{}.{}'.format(*_numba_pyversion))
         cppdef('namespace Numba {}')
         ns = self._fallback_getattr('Numba')
         ns.Declare = staticmethod(_NumbaDeclareDecorator)

--- a/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
@@ -122,7 +122,7 @@ if (dataframe)
 endif()
 
 # Test wrapping Python callables for use in C++ using numba
-if (dataframe)
+if (dataframe AND ${PYTHON_VERSION_STRING} VERSION_GREATER 2.7.5)
     ROOT_ADD_PYUNITTEST(pyroot_numbadeclare numbadeclare.py)
 endif()
 

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -530,6 +530,11 @@ if(ROOT_pyroot_FOUND)
         pyroot/pyroot004_NumbaDeclare.py)
   endif()
 
+  if(${PYTHON_VERSION_STRING} VERSION_LESS_EQUAL 2.7.5)
+    list(REMOVE_ITEM pytutorials
+        pyroot/pyroot004_NumbaDeclare.py)
+  endif()
+
   find_python_module(xgboost QUIET)
   if (NOT PY_XGBOOST_FOUND OR NOT dataframe)
     file(GLOB tmva_veto_py RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} dataframe/*.py tmva/tmva10*.py)


### PR DESCRIPTION
This python version does not allow to use exec in an inner function,
potentially classified as interpreter bug (https://bugs.python.org/issue21591).