### PR TITLE
Fix redirection (`.> blah.txt`) on Windows

### DIFF
--- a/core/textinput/src/textinput/TerminalDisplayWin.cpp
+++ b/core/textinput/src/textinput/TerminalDisplayWin.cpp
@@ -32,24 +32,21 @@ namespace textinput {
     DWORD mode;
     SetIsTTY(::GetConsoleMode(::GetStdHandle(STD_INPUT_HANDLE), &mode) != 0);
 
-    fOut = ::GetStdHandle(STD_OUTPUT_HANDLE);
-    bool isConsole = ::GetConsoleMode(fOut, &fOldMode) != 0;
-    if (!isConsole) {
-      // Prevent redirection from stealing our console handle,
-      // simply open our own.
-      fOut = ::CreateFile(filename, GENERIC_READ | GENERIC_WRITE,
-        FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL, NULL);
-      ::GetConsoleMode(fOut, &fOldMode);
-    } else {
-      // disable unicode (UTF-8) for the time being, since it causes
-      // problems on Windows 10
-      //::SetConsoleOutputCP(65001); // Force UTF-8 output
-    }
+    // Prevent redirection from stealing our console handle,
+    // simply open our own.
+    fOut = ::CreateFile(filename, GENERIC_READ | GENERIC_WRITE,
+      FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
+      FILE_ATTRIBUTE_NORMAL, NULL);
+    ::GetConsoleMode(fOut, &fOldMode);
+    // disable unicode (UTF-8) for the time being, since it causes
+    // problems on Windows 10
+    //::SetConsoleOutputCP(65001); // Force UTF-8 output
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     ::GetConsoleScreenBufferInfo(fOut, &csbi);
     fDefaultAttributes = csbi.wAttributes;
     assert(fDefaultAttributes != 0 && "~TerminalDisplayWin broken");
+    // adding the ENABLE_VIRTUAL_TERMINAL_PROCESSING flag would enable the ANSI control
+    // character sequences (e.g. `\033[39m`), but then it breaks the WRAP_AT_EOL_OUTPUT
     fMyMode = fOldMode | ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT;
     HandleResizeEvent();
   }

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -932,6 +932,8 @@ namespace {
          ::SetConsoleTitle("ROOT session");
       }
       hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+      // adding the ENABLE_VIRTUAL_TERMINAL_PROCESSING flag would enable the ANSI control
+      // character sequences (e.g. `\033[39m`), but then it breaks the WRAP_AT_EOL_OUTPUT
       ::SetConsoleMode(hStdout, ENABLE_PROCESSED_OUTPUT |
                        ENABLE_WRAP_AT_EOL_OUTPUT);
       if (!::GetConsoleScreenBufferInfo(hStdout, &csbiInfo))


### PR DESCRIPTION
Fix output redirection (`.> blah.txt`) which is curently freezing the console input on Windows
One could Enable Console Virtual Terminal Sequences (ANSI escape code) that can control cursor movement, color/font mode, and other operations when written to the output stream by adding the ENABLE_VIRTUAL_TERMINAL_PROCESSING flag, but then it breaks the WRAP_AT_EOL_OUTPUT. With this feature, the escape sequences like `\033[39m` would work in the Windows 10 command prompt as well.
This is a known issue, see https://github.com/microsoft/terminal/issues/349