### PR TITLE
Fix TMath::Poisson in case n=0 and mu is negative

### DIFF
--- a/math/mathcore/inc/Math/PdfFuncMathCore.h
+++ b/math/mathcore/inc/Math/PdfFuncMathCore.h
@@ -524,7 +524,7 @@ namespace Math {
   inline double poisson_pdf(unsigned int n, double mu) {
     // Inlined to enable clad-auto-derivation for this function.
 
-    if (n > 0)
+    if (n > 0 && mu >= 0)
       return std::exp (n*std::log(mu) - ROOT::Math::lgamma(n+1) - mu);
 
     //  when  n = 0 and mu = 0,  1 is returned
@@ -532,7 +532,7 @@ namespace Math {
       return std::exp(-mu);
 
     // return a nan for mu < 0 since it does not make sense
-    return std::log(mu);
+    return std::numeric_limits<double>::quiet_NaN();
   }
 
 

--- a/math/mathcore/src/TMath.cxx
+++ b/math/mathcore/src/TMath.cxx
@@ -550,12 +550,8 @@ Double_t TMath::Normalize(Double_t v[3])
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute the Poisson distribution function for (x,par)
 /// The Poisson PDF is implemented by means of Euler's Gamma-function
-/// (for the factorial), so for any x integer argument it is correct.
-/// BUT for non-integer x values, it IS NOT equal to the Poisson distribution.
-/// see TMath::PoissonI to get a non-smooth function.
-/// Note that for large values of par, it is better to call
-///
-///     TMath::Gaus(x,par,sqrt(par),kTRUE)
+/// (for the factorial), so for any x integer argument it is the correct Poisson distribution.
+/// BUT for non-integer x values, it IS NOT equal to the Poisson distribution !
 ///
 /// Begin_Macro
 /// {
@@ -567,12 +563,21 @@ Double_t TMath::Normalize(Double_t v[3])
 
 Double_t TMath::Poisson(Double_t x, Double_t par)
 {
-   return ::ROOT::Math::poisson_pdf(x,par);
+   if (par < 0)
+      return TMath::QuietNaN();
+   if (x < 0)
+      return 0;
+   else if (x == 0.0 )
+      return Exp(-par);
+   else
+   {
+      return Exp( x * log(par) - LnGamma(x + 1.) - par);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Compute the Poisson distribution function for (x,par)
-/// This is a non-smooth function.
+/// Compute the Discrete Poisson distribution function for (x,par)
+/// This is a dicreate and a non-smooth function.
 /// This function is equivalent to ROOT::Math::poisson_pdf
 ///
 /// Begin_Macro

--- a/math/mathcore/src/TMath.cxx
+++ b/math/mathcore/src/TMath.cxx
@@ -567,19 +567,7 @@ Double_t TMath::Normalize(Double_t v[3])
 
 Double_t TMath::Poisson(Double_t x, Double_t par)
 {
-   if (x<0)
-      return 0;
-   else if (x == 0.0)
-      return 1./Exp(par);
-   else {
-      Double_t lnpoisson = x*log(par)-par-LnGamma(x+1.);
-      return Exp(lnpoisson);
-   }
-   // An alternative strategy is to transition to a Gaussian approximation for
-   // large values of par ...
-   //   else {
-   //     return Gaus(x,par,Sqrt(par),kTRUE);
-   //   }
+   return ::ROOT::Math::poisson_pdf(x,par);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/math/mathcore/src/TMath.cxx
+++ b/math/mathcore/src/TMath.cxx
@@ -548,7 +548,7 @@ Double_t TMath::Normalize(Double_t v[3])
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Compute the Poisson distribution function for (x,par)
+/// Compute the Poisson distribution function for (x,par).
 /// The Poisson PDF is implemented by means of Euler's Gamma-function
 /// (for the factorial), so for any x integer argument it is the correct Poisson distribution.
 /// BUT for non-integer x values, it IS NOT equal to the Poisson distribution !
@@ -576,8 +576,8 @@ Double_t TMath::Poisson(Double_t x, Double_t par)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Compute the Discrete Poisson distribution function for (x,par)
-/// This is a dicreate and a non-smooth function.
+/// Compute the Discrete Poisson distribution function for (x,par).
+/// This is a discrete and a non-smooth function.
 /// This function is equivalent to ROOT::Math::poisson_pdf
 ///
 /// Begin_Macro


### PR DESCRIPTION
Math::Poisson It was returning by mistake exp(-mu), a very large value for n=0 and mu negative. 
This is wrong, it should return a NaN.

Now TMath uses ROOT::Math::poisson_pdf(n,mu) that returns a NaN 
Fix to return a quiet NaN and not a signalling NaN as before 

This fixes ROOT-10718