### PR TITLE
[CMake][Exp PyROOT] Re-introduce ROOT_LINKER_LIBRARY in JupyROOT's CM…

### DIFF
--- a/bindings/jupyroot/CMakeLists.txt
+++ b/bindings/jupyroot/CMakeLists.txt
@@ -41,12 +41,9 @@ foreach(val RANGE ${how_many_pythons})
 
   set(libname JupyROOT${python_under_version_string})
 
-  add_library(${libname} SHARED src/IOHandler.cxx)
-
   # libJupyROOT uses ROOT headers from source dirs and depends on Core
+  ROOT_LINKER_LIBRARY(${libname} src/IOHandler.cxx LIBRARIES ${python_library} DEPENDENCIES Core CMAKENOEXPORT)
   target_include_directories(${libname} PRIVATE ${python_include_dir})
-
-  target_link_libraries(${libname} ${python_library} Core ${CMAKE_DL_LIBS})
 
   # Disables warnings originating from deprecated register keyword in Python
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)


### PR DESCRIPTION
…akeLists.txt

This commit reverts some of the changes introduced in c9cedcc.
ROOT_LINKER_LIBRARY insures that the shared library is generated with
the suffix '.so', avoiding troubles in MacOS where it would be generated
with '.dylib' otherwise.