### PR TITLE
Pin the vtable of IPruneTool.

### DIFF
--- a/tmva/tmva/inc/TMVA/IPruneTool.h
+++ b/tmva/tmva/inc/TMVA/IPruneTool.h
@@ -109,8 +109,6 @@ Any tool which implements the interface should provide two modes for tree prunin
       S(0),
       B(0)
          {}
-   inline IPruneTool::~IPruneTool( ) {}
-
 }
 
 #endif

--- a/tmva/tmva/src/ExpectedErrorPruneTool.cxx
+++ b/tmva/tmva/src/ExpectedErrorPruneTool.cxx
@@ -54,6 +54,9 @@ than that of the sum of the error in its descendants.
 
 #include <map>
 
+// pin the vtable here.
+TMVA::IPruneTool::~IPruneTool() {}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 TMVA::ExpectedErrorPruneTool::ExpectedErrorPruneTool() :


### PR DESCRIPTION
The weak vtable forces to compiler to duplicate the vtable for every TU which includes the header and the deserializer to deserialize the entries from PCH/PCM at startup.