### PR TITLE
[core] In ACLiC, do not reload loaded libraries.

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3379,7 +3379,7 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
       // the ACLiC library.
       if (useCxxModules && !produceRootmap) {
          std::function<bool(const char *)> LoadLibF = [](const char *dep) {
-            return gInterpreter->Load(dep, /*system*/ false) >= 0;
+            return gInterpreter->Load(dep, /*skipReload*/ true) >= 0;
          };
          ForeachSharedLibDep(lib, LoadLibF);
       }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1832,9 +1832,7 @@ void TCling::LoadPCM(std::string pcmFileNameFullPath)
       TMemFile pcmMemFile(RDictFileOpts.c_str(), range);
 
       LoadPCMImpl(pcmMemFile);
-      // FIXME: Uncomment this when we implement UnLoadPCM as per
-      // root-project/root#5420
-      //fPendingRdicts.erase(pendingRdict);
+      fPendingRdicts.erase(pendingRdict);
 
       return;
    }


### PR DESCRIPTION
TCling::Load reloads the library the `system` optional parameter is false. If the library is not marked as `system` TCling reloads it if was alread loaded. That is, it dlcloses and dlopens the library instead of doing nothing.

There is no point in reloading our library dependencies.

The regression was introduced in 9b6df8c originated from https://github.com/root-project/root/commit/e649f59e3160f829bc1a4813f8aa73bdd16b6cff