### PR TITLE
Load dependent libraries as part of AutoLoading.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5837,6 +5837,80 @@ Int_t TCling::AutoLoad(const std::type_info& typeinfo, Bool_t knowDictNotLoaded 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Get the list of 'published'/'known' library for the class and load them.
+Int_t TCling::ShallowAutoLoadImpl(const char *cls)
+{
+   Int_t status = 0;
+
+   // lookup class to find list of dependent libraries
+   TString deplibs = GetClassSharedLibs(cls);
+   if (!deplibs.IsNull()) {
+      TString delim(" ");
+      TObjArray* tokens = deplibs.Tokenize(delim);
+      for (Int_t i = (tokens->GetEntriesFast() - 1); i > 0; --i) {
+         const char* deplib = ((TObjString*)tokens->At(i))->GetName();
+         if (gROOT->LoadClass(cls, deplib) == 0) {
+            if (gDebug > 0) {
+               Info("TCling::AutoLoad",
+                  "loaded dependent library %s for %s", deplib, cls);
+            }
+         }
+         else {
+            Error("TCling::AutoLoad",
+                  "failure loading dependent library %s for %s",
+                  deplib, cls);
+         }
+      }
+      const char* lib = ((TObjString*)tokens->At(0))->GetName();
+      if (lib && lib[0]) {
+         if (gROOT->LoadClass(cls, lib) == 0) {
+            if (gDebug > 0) {
+               Info("TCling::AutoLoad",
+                  "loaded library %s for %s", lib, cls);
+            }
+            status = 1;
+         }
+         else {
+            Error("TCling::AutoLoad",
+                  "failure loading library %s for %s", lib, cls);
+         }
+      }
+      delete tokens;
+   }
+
+   return status;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Iterate through the data member of the class (either through the TProtoClass
+// or through Cling) and trigger, recursively, the loading the necessary libraries.
+Int_t TCling::DeepAutoLoadImpl(const char *cls)
+{
+   Int_t status = ShallowAutoLoadImpl(cls);
+   if (status) {
+      // Now look through the TProtoClass to load the required library/dictionary
+      TProtoClass *proto = TClassTable::GetProto(cls);
+      if (proto) {
+         for(auto element : proto->GetData()) {
+            const char *subtypename = element->GetTypeName();
+            if (!element->IsBasic() && !TClassTable::GetDictNorm(subtypename)) {
+               // Failure to load a dictionary is not (quite) a failure load
+               // the top-level library.  If we return false here, then
+               // we would end up in a situation where the library and thus
+               // the dictionary is loaded for "cls" but the TClass is
+               // not created and/or marked as unavailable (in case where
+               // AutoLoad is called from TClass::GetClass).
+               (void) DeepAutoLoadImpl(subtypename);
+            }
+         }
+      }
+      // NOTE:  Need to test if adding use of ClassInfo here would be
+      // 'bad'
+   }
+   return status;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Load library containing the specified class. Returns 0 in case of error
 /// and 1 in case if success.
 
@@ -5888,44 +5962,8 @@ Int_t TCling::AutoLoad(const char *cls, Bool_t knowDictNotLoaded /* = kFALSE */)
       if (success)
          return success;
    }
-   // lookup class to find list of dependent libraries
-   Int_t status = 0;
-   TString deplibs = GetClassSharedLibs(cls);
-   if (!deplibs.IsNull()) {
-      TString delim(" ");
-      TObjArray* tokens = deplibs.Tokenize(delim);
-      for (Int_t i = (tokens->GetEntriesFast() - 1); i > 0; --i) {
-         const char* deplib = ((TObjString*)tokens->At(i))->GetName();
-         if (gROOT->LoadClass(cls, deplib) == 0) {
-            if (gDebug > 0) {
-               Info("TCling::AutoLoad",
-                    "loaded dependent library %s for %s", deplib, cls);
-            }
-         }
-         else {
-            Error("TCling::AutoLoad",
-                  "failure loading dependent library %s for %s",
-                  deplib, cls);
-         }
-      }
-      const char* lib = ((TObjString*)tokens->At(0))->GetName();
-      if (lib && lib[0]) {
-         if (gROOT->LoadClass(cls, lib) == 0) {
-            if (gDebug > 0) {
-               Info("TCling::AutoLoad",
-                    "loaded library %s for %s", lib, cls);
-            }
-            status = 1;
-         }
-         else {
-            Error("TCling::AutoLoad",
-                  "failure loading library %s for %s", lib, cls);
-         }
-      }
-      delete tokens;
-   }
 
-   return status;
+   return DeepAutoLoadImpl(cls);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5888,24 +5888,55 @@ Int_t TCling::DeepAutoLoadImpl(const char *cls)
 {
    Int_t status = ShallowAutoLoadImpl(cls);
    if (status) {
-      // Now look through the TProtoClass to load the required library/dictionary
-      TProtoClass *proto = TClassTable::GetProto(cls);
-      if (proto) {
-         for(auto element : proto->GetData()) {
-            const char *subtypename = element->GetTypeName();
-            if (!element->IsBasic() && !TClassTable::GetDictNorm(subtypename)) {
-               // Failure to load a dictionary is not (quite) a failure load
-               // the top-level library.  If we return false here, then
-               // we would end up in a situation where the library and thus
-               // the dictionary is loaded for "cls" but the TClass is
-               // not created and/or marked as unavailable (in case where
-               // AutoLoad is called from TClass::GetClass).
-               (void) DeepAutoLoadImpl(subtypename);
+
+      // This routine should be called only from AutoLoad which has already
+      // taken the main ROOT lock so this should not have any race condition.
+      // If the lock is removed from AutoLoad, a spin lock should be introduced here.
+      // Note that it is actually alright if another thread is populating this
+      // set since we can then exclude both the infinite recursion (the main goal)
+      // and duplicate work.
+      static std::set<std::string> gClassOnStack;  
+      auto insertResult = gClassOnStack.insert(std::string(cls));
+      if (insertResult.second) {
+         // Now look through the TProtoClass to load the required library/dictionary
+         TProtoClass *proto = TClassTable::GetProto(cls);
+         if (proto) {
+            for(auto element : proto->GetData()) {
+               const char *subtypename = element->GetTypeName();
+               if (!element->IsBasic() && !TClassTable::GetDictNorm(subtypename)) {
+                  // Failure to load a dictionary is not (quite) a failure load
+                  // the top-level library.  If we return false here, then
+                  // we would end up in a situation where the library and thus
+                  // the dictionary is loaded for "cls" but the TClass is
+                  // not created and/or marked as unavailable (in case where
+                  // AutoLoad is called from TClass::GetClass).
+                  (void) DeepAutoLoadImpl(subtypename);
+               }
             }
+         } else {
+            auto classinfo = gInterpreter->ClassInfo_Factory(cls);
+            if (classinfo && gInterpreter->ClassInfo_IsValid(classinfo)
+                && !(gInterpreter->ClassInfo_Property(classinfo) & kIsEnum))
+            {
+               DataMemberInfo_t *memberinfo = gInterpreter->DataMemberInfo_Factory(classinfo);
+               while (gInterpreter->DataMemberInfo_Next(memberinfo)) {
+                  auto membertypename = TClassEdit::GetLong64_Name(gInterpreter->TypeName(gInterpreter->DataMemberInfo_TypeTrueName(memberinfo)));
+                  if (!(gInterpreter->DataMemberInfo_TypeProperty(memberinfo) & ::kIsFundamental)
+                      && !TClassTable::GetDictNorm(membertypename.c_str()))
+                  {
+                     // Failure to load a dictionary is not (quite) a failure load
+                     // the top-level library.   See detailed comment in the TProtoClass
+                     // branch (above).
+                     (void)DeepAutoLoadImpl(membertypename.c_str());
+                  }
+               }
+               gInterpreter->DataMemberInfo_Delete(memberinfo);
+            }
+            gInterpreter->ClassInfo_Delete(classinfo);
          }
+         // Because they could have been failures, allow for another try later
+         gClassOnStack.erase(insertResult.first);
       }
-      // NOTE:  Need to test if adding use of ClassInfo here would be
-      // 'bad'
    }
    return status;
 }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5843,7 +5843,7 @@ Int_t TCling::ShallowAutoLoadImpl(const char *cls)
    Int_t status = 0;
 
    // lookup class to find list of dependent libraries
-   TString deplibs = GetClassSharedLibs(cls);
+   TString deplibs = gCling->GetClassSharedLibs(cls);
    if (!deplibs.IsNull()) {
       TString delim(" ");
       TObjArray* tokens = deplibs.Tokenize(delim);
@@ -5851,28 +5851,28 @@ Int_t TCling::ShallowAutoLoadImpl(const char *cls)
          const char* deplib = ((TObjString*)tokens->At(i))->GetName();
          if (gROOT->LoadClass(cls, deplib) == 0) {
             if (gDebug > 0) {
-               Info("TCling::AutoLoad",
-                  "loaded dependent library %s for %s", deplib, cls);
+               gCling->Info("TCling::AutoLoad",
+                            "loaded dependent library %s for %s", deplib, cls);
             }
          }
          else {
-            Error("TCling::AutoLoad",
-                  "failure loading dependent library %s for %s",
-                  deplib, cls);
+            gCling->Error("TCling::AutoLoad",
+                          "failure loading dependent library %s for %s",
+                          deplib, cls);
          }
       }
       const char* lib = ((TObjString*)tokens->At(0))->GetName();
       if (lib && lib[0]) {
          if (gROOT->LoadClass(cls, lib) == 0) {
             if (gDebug > 0) {
-               Info("TCling::AutoLoad",
-                  "loaded library %s for %s", lib, cls);
+               gCling->Info("TCling::AutoLoad",
+                            "loaded library %s for %s", lib, cls);
             }
             status = 1;
          }
          else {
-            Error("TCling::AutoLoad",
-                  "failure loading library %s for %s", lib, cls);
+            gCling->Error("TCling::AutoLoad",
+                          "failure loading library %s for %s", lib, cls);
          }
       }
       delete tokens;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5963,6 +5963,14 @@ Int_t TCling::AutoLoad(const char *cls, Bool_t knowDictNotLoaded /* = kFALSE */)
          return success;
    }
 
+   // During the 'Deep' part of the search we will call GetClassSharedLibsForModule
+   // (when module are enabled) which might end up calling AutoParsing but
+   // that should only be for the cases where the library has no generated pcm
+   // and in that case a rootmap should be available.
+   // This avoids a very costly operation (for generally no gain) but reduce the
+   // quality of the search (i.e. bad in case of library with no pcm and no rootmap
+   // file).
+   TInterpreter::SuspendAutoParsing autoParseRaii(this);
    return DeepAutoLoadImpl(cls);
 }
 

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -166,8 +166,8 @@ private: // Data Members
 
    DeclId_t GetDeclId(const llvm::GlobalValue *gv) const;
 
-   Int_t DeepAutoLoadImpl(const char *cls);
-   Int_t ShallowAutoLoadImpl(const char *cls);
+   static Int_t DeepAutoLoadImpl(const char *cls);
+   static Int_t ShallowAutoLoadImpl(const char *cls);
 
    Bool_t fHeaderParsingOnDemand;
    Bool_t fIsAutoParsingSuspended;

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -166,6 +166,9 @@ private: // Data Members
 
    DeclId_t GetDeclId(const llvm::GlobalValue *gv) const;
 
+   Int_t DeepAutoLoadImpl(const char *cls);
+   Int_t ShallowAutoLoadImpl(const char *cls);
+
    Bool_t fHeaderParsingOnDemand;
    Bool_t fIsAutoParsingSuspended;
 


### PR DESCRIPTION
Since the proper creation of the TClass will require the dictionary for all its component let
load all the dependent library too.  Note that even with explicit linking, the dictionary may
not be loaded as part of the 'main' library when the dictionary is a library separate from the
classes' code (see ATLAS setup for example)

This solves ROOT-10663.