### PR TITLE
[DF] Eagerly declare jitted lambdas

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -518,7 +518,6 @@ public:
                << RDFInternal::PrettyPrintAddr(&columnList) << "),"
                << "*reinterpret_cast<ROOT::RDF::RSnapshotOptions*>(" << RDFInternal::PrettyPrintAddr(&options) << "));";
       // jit snapCall, return result
-      fLoopManager->JitDeclarations(); // some type aliases might be needed by the code jitted in the next line
       RDFInternal::InterpreterCalc(snapCall.str(), "Snapshot");
       return resPtr;
    }
@@ -648,7 +647,6 @@ public:
       cacheCall << ">(*reinterpret_cast<std::vector<std::string>*>(" // vector<string> should be ColumnNames_t
                 << RDFInternal::PrettyPrintAddr(&columnList) << "));";
       // jit cacheCall, return result
-      fLoopManager->JitDeclarations(); // some type aliases might be needed by the code jitted in the next line
       RDFInternal::InterpreterCalc(cacheCall.str(), "Cache");
       return resRDF;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -164,7 +164,6 @@ public:
    void SetTree(const std::shared_ptr<TTree> &tree) { fTree = tree; }
    void IncrChildrenCount() final { ++fNChildren; }
    void StopProcessing() final { ++fNStopsReceived; }
-   void ToJitDeclare(const std::string &) const;
    void ToJitExec(const std::string &) const;
    void AddColumnAlias(const std::string &alias, const std::string &colName) { fAliasColumnNameMap[alias] = colName; }
    const std::map<std::string, std::string> &GetAliasMap() const { return fAliasColumnNameMap; }

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -21,7 +21,6 @@
 #include <TFriendElement.h>
 #include <TInterpreter.h>
 #include <TObject.h>
-#include <TRegexp.h>
 #include <TPRegexp.h>
 #include <TString.h>
 #include <TTree.h>
@@ -210,9 +209,8 @@ BuildLambdaString(const std::string &expr, const ColumnNames_t &vars, const Colu
 {
    R__ASSERT(vars.size() == varTypes.size());
 
-   TRegexp re("[^a-zA-Z0-9_]?return[^a-zA-Z0-9_]");
-   Ssiz_t matchedLen;
-   const bool hasReturnStmt = re.Index(expr, &matchedLen) != -1;
+   TPRegexp re(R"(\breturn\b)");
+   const bool hasReturnStmt = re.Match(expr) == 1;
 
    std::stringstream ss;
    ss << "[](";
@@ -387,7 +385,7 @@ ColumnNames_t ConvertRegexToColumns(const RDFInternal::RBookedCustomColumns & cu
    selectedColumns.reserve(32);
 
    // Since we support gcc48 and it does not provide in its stl std::regex,
-   // we need to use TRegexp
+   // we need to use TPRegexp
    TPRegexp regexp(theRegex);
    for (auto &&branchName : customColumns.GetNames()) {
       if ((isEmptyRegex || 0 != regexp.Match(branchName.c_str())) &&

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -34,51 +34,37 @@ using namespace ROOT::Internal::RDF;
 
 namespace {
 /// A helper class to let different RLoopManager instances share the code to just-in-time compile.
-/// We want RLoopManagers to be able to add their code to global lists of "code to declare to cling"
-/// and "code to execute via cling", so that, lazily, we can jit everything that's needed by all RDFs
-/// in one go, which is potentially much faster than jitting each RLoopManager's code separately.
+/// We want RLoopManagers to be able to add their code to global lists of "code to execute via cling",
+/// so that, lazily, we can jit everything that's needed by all RDFs in one go, which is potentially
+/// much faster than jitting each RLoopManager's code separately.
 /// When RLoopManagers go out of scope, they will inform the global CodeToJit instance so that their
 /// outstanding code snippets can be removed from the lists.
 class CodeToJit {
    using LoopManagerToCodeMap = std::unordered_map<const RLoopManager *, std::string>;
-   LoopManagerToCodeMap fCodeToDeclare;
-   LoopManagerToCodeMap fCodeToExec;
+   LoopManagerToCodeMap fCode;
 
-   std::string PopCode(LoopManagerToCodeMap &c) {
+public:
+   void AddCodeToExec(const RLoopManager *ptr, const std::string &code) { fCode[ptr].append(code); }
+
+   /// Retrieve all code registered for execution. Clears the list of code to execute.
+   std::string PopCodeToExec()
+   {
       std::size_t size = 0;
-      for (auto e : c)
+      for (auto e : fCode)
          size += e.second.size();
 
       std::string code;
       code.reserve(size);
 
-      for (auto e: c)
+      for (auto e : fCode)
          code.append(e.second);
 
-      c.clear();
+      fCode.clear();
 
       return code;
    }
 
-public:
-   void AddCodeToDeclare(const RLoopManager *ptr, const std::string &code) { fCodeToDeclare[ptr].append(code); }
-
-   void AddCodeToExec(const RLoopManager *ptr, const std::string &code) { fCodeToExec[ptr].append(code); }
-
-   /// Retrieve all code registered for declaration. Clears the list of code to declare.
-   std::string PopCodeToDeclare() { return PopCode(fCodeToDeclare); }
-
-   /// Retrieve all code registered for execution. Clears the list of code to execute.
-   std::string PopCodeToExec() { return PopCode(fCodeToExec); }
-
-   void RemoveCodeForLoopManager(const RLoopManager *lm)
-   {
-      // fCodeToDeclare for old RLoopManagers is left in fCodeToDeclare, as it might contain
-      // the definition of lambdas that are also used by other RLoopManagers. It's not expensive
-      // to jit-declare a bit more than strictly needed. fCodeToExec for RLoopManagers that went out
-      // of scope must be erased: it would refer to variables that are not in scope anymore.
-      fCodeToExec.erase(lm);
-   }
+   void RemoveCodeForLoopManager(const RLoopManager *lm) { fCode.erase(lm); }
 };
 
 CodeToJit &GetCodeToJit()
@@ -560,25 +546,14 @@ void RLoopManager::CleanUpTask(unsigned int slot)
       ptr->ClearTask(slot);
 }
 
-/// Declare to the interpreter type aliases and other entities required by RDF jitted nodes.
-void RLoopManager::JitDeclarations()
-{
-   const auto code = GetCodeToJit().PopCodeToDeclare();
-   if (code.empty())
-      return;
-
-   RDFInternal::InterpreterDeclare(code);
-}
-
 /// Add RDF nodes that require just-in-time compilation to the computation graph.
-/// This method also invokes JitDeclarations() if needed, and clears the contents of GetCodeToJitExec().
+/// This method also clears the contents of GetCodeToJitExec().
 void RLoopManager::Jit()
 {
    const auto code = GetCodeToJit().PopCodeToExec();
    if (code.empty())
       return; // if nothing needs to be executed, we don't need the declarations either. can return early
 
-   JitDeclarations();
    RDFInternal::InterpreterCalc(code, "RLoopManager::Run");
 }
 
@@ -696,11 +671,6 @@ void RLoopManager::Report(ROOT::RDF::RCutFlowReport &rep) const
 {
    for (const auto &fPtr : fBookedNamedFilters)
       fPtr->FillReport(rep);
-}
-
-void RLoopManager::ToJitDeclare(const std::string &code) const
-{
-   GetCodeToJit().AddCodeToDeclare(this, code);
 }
 
 void RLoopManager::ToJitExec(const std::string &code) const


### PR DESCRIPTION
Before this patch RDF would first, eagerly, declare a dummy lambda
that contained the user-defined expression to check verify the cling
could understand it; then, lazily, the actual lambda variable used
by the nodes of the computation graph was jitted, together with all
other declarations required by RDF, just before the event loop.

With this patch, the first declaration serves both purposes: it checks
that the expression is just-in-time compilable _and_ jits precisely the
definition that will be required during the event loop. This removes
redundant logic and results in strictly less work required of the
interpreter.