### PR TITLE
[TChain] Do not try to retrieve the cache of a nullptr fTree

### DIFF
--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -192,7 +192,7 @@ TChain::~TChain()
    fFiles = 0;
 
    //first delete cache if exists
-   auto tc = fFile ? fTree->GetReadCache(fFile) : nullptr;
+   auto tc = fFile && fTree ? fTree->GetReadCache(fFile) : nullptr;
    if (tc) {
       delete tc;
       fFile->SetCacheRead(0, fTree);


### PR DESCRIPTION
The following sequence of calls results in c1 having a null fTree
but a non-null fFile.

```cpp
TChain* c1 = new TChain("T");
c1->Add("Event.root");

TChain* c2 = new TChain("T2");
c2->Add("Event2.root/T");
c1->AddFriend(c2);

c1->LoadTree(0);
c1->RemoveFriend(c2);

delete c1;
```

In this situation, ~TChain ended up calling TTree::GetReadCache on
a null fTree. We now check that both fFile and fTree are valid before
trying to retrieve fTree's cache.