### PR TITLE
[Exp PyROOT][ROOT-9447] Do not parse command line args by default

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -19,7 +19,7 @@ class PyROOTConfiguration(object):
     """Class for configuring PyROOT"""
 
     def __init__(self):
-        self.IgnoreCommandLineOptions = False
+        self.IgnoreCommandLineOptions = True
         self.ShutDown = True
         self.DisableRootLogon = False
 

--- a/bindings/pyroot_experimental/pythonizations/test/root_module.py
+++ b/bindings/pyroot_experimental/pythonizations/test/root_module.py
@@ -42,5 +42,5 @@ class ROOTModule(unittest.TestCase):
         Test module flag to ignore command line options
         """
         import ROOT
-        self.assertEqual(ROOT.PyConfig.IgnoreCommandLineOptions, False)
-        ROOT.PyConfig.IgnoreCommandLineOptions = True
+        self.assertEqual(ROOT.PyConfig.IgnoreCommandLineOptions, True)
+        ROOT.PyConfig.IgnoreCommandLineOptions = False

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -574,7 +574,7 @@ if(ROOT_pyroot_FOUND)
     endif()
 
     ROOT_ADD_TEST(${tutorial_name}
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${t} -b
+                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/launcher.py ${CMAKE_CURRENT_SOURCE_DIR}/${t}
                 PASSRC ${rc} FAILREGEX "Error in" ": error:" "segmentation violation"
                 LABELS tutorial
                 DEPENDS ${${tname}-depends}

--- a/tutorials/launcher.py
+++ b/tutorials/launcher.py
@@ -1,0 +1,37 @@
+# Module to launch python tutorials.
+# It serves the purpose of enabling batch mode,
+# since PyROOT does not parse anymore by default
+# the command line arguments
+
+import sys, os
+
+if len(sys.argv) < 2:
+    raise RuntimeError('Please specify tutorial file path as only argument of this script')
+
+# Get path to the tutorial file
+file_path = os.path.expanduser(sys.argv[1])
+
+if os.path.exists(file_path):
+    # Module needs to run as main.
+    # Some tutorials have "if __name__ == '__main__'"
+    module_name = "__main__"
+
+    # Ensure batch mode (some tutorials use graphics)
+    import ROOT
+    ROOT.gROOT.SetBatch(True)
+
+    # Prevent import from generating .pyc files in source directory
+    sys.dont_write_bytecode = True
+
+    # Execute test
+    if sys.version_info >= (3,5):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    else:
+        import imp
+        imp.load_module(module_name, open(file_path, 'r'), file_path, ('.py','r',1))
+else:
+    raise RuntimeError('Cannot execute test, {} is not a valid tutorial file path'.format(file_path))


### PR DESCRIPTION
As requested by:

https://sft.its.cern.ch/jira/browse/ROOT-9447

and several other users, this PR changes the default of the argument parsing feature of PyROOT. After these changes, only when asked explicitly PyROOT will parse our arguments and pass them to its PyROOTApplication.

Here we also change the way tutorials are launched, since PyROOT will no longer parse by default the "-b" flag that enables the batch mode. Instead, we create a launcher module to ensure batch mode when running the tutorials.
