### PR TITLE
[RF] Modernise RooExtendPdf

### DIFF
--- a/roofit/roofitcore/inc/RooExtendPdf.h
+++ b/roofit/roofitcore/inc/RooExtendPdf.h
@@ -23,8 +23,8 @@ class RooExtendPdf : public RooAbsPdf {
 public:
 
   RooExtendPdf() ;
-  RooExtendPdf(const char *name, const char *title, const RooAbsPdf& pdf, 
-	       const RooAbsReal& norm, const char* rangeName=0) ;
+  RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
+	       RooAbsReal& norm, const char* rangeName=0) ;
   RooExtendPdf(const RooExtendPdf& other, const char* name=0) ;
   virtual TObject* clone(const char* newname) const { return new RooExtendPdf(*this,newname) ; }
   virtual ~RooExtendPdf() ;
@@ -34,11 +34,11 @@ public:
   Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const { return kTRUE ; }
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const {
     // Forward determination of analytical integration capabilities to input p.d.f
-    return ((RooAbsPdf&)_pdf.arg()).getAnalyticalIntegralWN(allVars, analVars, normSet, rangeName) ;
+    return _pdf->getAnalyticalIntegralWN(allVars, analVars, normSet, rangeName) ;
   }
   Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const {
     // Forward calculation of analytical integrals to input p.d.f
-    return ((RooAbsPdf&)_pdf.arg()).analyticalIntegralWN(code, normSet, rangeName) ;
+    return _pdf->analyticalIntegralWN(code, normSet, rangeName) ;
   }
   
   virtual Bool_t selfNormalized() const { return kTRUE ; }
@@ -49,12 +49,12 @@ public:
 
 protected:
 
-  RooRealProxy _pdf ;        // Input p.d.f
-  RooRealProxy _n ;          // Number of expected events
+  RooTemplateProxy<RooAbsPdf>  _pdf;        // Input p.d.f
+  RooTemplateProxy<RooAbsReal> _n;          // Number of expected events
   const TNamed* _rangeName ; // Name of subset range
 
 
-  ClassDef(RooExtendPdf,1) // Wrapper p.d.f adding an extended likelihood term to an existing p.d.f
+  ClassDef(RooExtendPdf,2) // Wrapper p.d.f adding an extended likelihood term to an existing p.d.f
 };
 
 #endif

--- a/roofit/roofitcore/src/RooExtendPdf.cxx
+++ b/roofit/roofitcore/src/RooExtendPdf.cxx
@@ -69,17 +69,17 @@ RooExtendPdf::RooExtendPdf() : _rangeName(0)
 /// \param[in] norm   Expected number of events
 /// \param[in] rangeName  If given, the number of events denoted by `norm` is interpreted as
 /// the number of events in this range only
-RooExtendPdf::RooExtendPdf(const char *name, const char *title, const RooAbsPdf& pdf,
-			   const RooAbsReal& norm, const char* rangeName) :
+RooExtendPdf::RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
+			   RooAbsReal& norm, const char* rangeName) :
   RooAbsPdf(name,title),
-  _pdf("pdf","PDF",this,(RooAbsReal&)pdf),
-  _n("n","Normalization",this,(RooAbsReal&)norm),
+  _pdf("pdf", "PDF", this, pdf),
+  _n("n","Normalization",this,norm),
   _rangeName(RooNameReg::ptr(rangeName))
 {
 
   // Copy various setting from pdf
-  setUnit(_pdf.arg().getUnit()) ;
-  setPlotLabel(_pdf.arg().getPlotLabel()) ;
+  setUnit(_pdf->getUnit()) ;
+  setPlotLabel(_pdf->getPlotLabel()) ;
 }
 
 
@@ -115,7 +115,7 @@ RooExtendPdf::~RooExtendPdf()
 /// If the nested PDF can be extended, \f$ N \f$ is further scaled by its expected number of events.
 Double_t RooExtendPdf::expectedEvents(const RooArgSet* nset) const 
 {
-  RooAbsPdf& pdf = (RooAbsPdf&)_pdf.arg() ;
+  const RooAbsPdf& pdf = *_pdf;
 
   if (_rangeName && (!nset || nset->getSize()==0)) {
     coutW(InputArguments) << "RooExtendPdf::expectedEvents(" << GetName() << ") WARNING: RooExtendPdf needs non-null normalization set to calculate fraction in range " 

--- a/roofit/roofitcore/test/testRooProxy.cxx
+++ b/roofit/roofitcore/test/testRooProxy.cxx
@@ -80,24 +80,6 @@ TEST(RooTemplateProxy, CategoryProxy) {
 }
 
 
-// Read a simple v6.20 workspace to test proxy schema evolution
-TEST(RooTemplateProxy, Read6_20) {
-  TFile file("testProxiesAndCategories_1.root", "READ");
-  ASSERT_TRUE(file.IsOpen());
-
-  RooWorkspace* ws = nullptr;
-  file.GetObject("ws", ws);
-  ASSERT_NE(ws, nullptr);
-
-  auto pdf = ws->pdf("gaus");
-  EXPECT_NE(pdf, nullptr);
-  const char* names[3] = {"x", "m", "s"};
-  for (int i=0; i<3; ++i) {
-    ASSERT_NE(pdf->findServer(names[i]), nullptr);
-  }
-}
-
-
 TEST(RooTemplateProxy, DISABLED_CategoryProxyBatchAccess) {
   RooCategory myCat("myCat", "A category");
   myCat.defineType("A", 1);


### PR DESCRIPTION
Old proxy classes constantly require casting when the pointee of the
proxy is used. Now, the correct type is stored, and constness of the
public interface has been improved.