### PR TITLE
[PyROOT][ROOT-10731] Fix getting a bool buffer from a numpy array

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
@@ -696,7 +696,7 @@ bool CPyCppyy::name##RefConverter::SetArg(                                   \
 }                                                                            \
 CPPYY_IMPL_REFCONVERTER_FROM_MEMORY(name, ctype)
 
-CPPYY_IMPL_REFCONVERTER(Bool,    c_bool,       bool,               'b');
+CPPYY_IMPL_REFCONVERTER(Bool,    c_bool,       bool,               '?');
 CPPYY_IMPL_REFCONVERTER(Char,    c_char,       char,               'b');
 CPPYY_IMPL_REFCONVERTER(WChar,   c_wchar,      wchar_t,            'u');
 CPPYY_IMPL_REFCONVERTER(Char16,  c_uint16,     char16_t,           'H');
@@ -1552,7 +1552,7 @@ bool CPyCppyy::name##ArrayPtrConverter::SetArg(                              \
 
 
 //----------------------------------------------------------------------------
-CPPYY_IMPL_ARRAY_CONVERTER(Bool,     c_bool,       bool,                 'b') // signed char
+CPPYY_IMPL_ARRAY_CONVERTER(Bool,     c_bool,       bool,                 '?')
 CPPYY_IMPL_ARRAY_CONVERTER(SChar,    c_char,       signed char,          'b')
 CPPYY_IMPL_ARRAY_CONVERTER(UChar,    c_ubyte,      unsigned char,        'B')
 #if __cplusplus > 201402L


### PR DESCRIPTION
The converter for bool in CPyCppyy expects the type code 'b' for bool
though we get from numpy the identifier '?'.

I'll also make a PR upstream, let's see whether he sees any issues with it or knows a better solution.