### PR TITLE
Avoid {using namespace std} in global scope of dictionary [ROOT-10661]

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4598,6 +4598,12 @@ int RootClingMain(int argc,
       }
    }
 
+   if (!gOptNoGlobalUsingStd) {
+     AddNamespaceSTDdeclaration(dictStream);
+     if (gOptSplit) {
+       AddNamespaceSTDdeclaration(splitDictStream);
+     }
+   }
    //---------------------------------------------------------------------------
    // Parse the linkdef or selection.xml file.
    /////////////////////////////////////////////////////////////////////////////
@@ -4850,7 +4856,12 @@ int RootClingMain(int argc,
          AddNamespaceSTDdeclaration(*splitDictStream);
       }
    }
-
+   if (!gOptIgnoreExistingDict && gOptNoGlobalUsingStd) {
+     AddNamespaceSTDdeclaration(dictStream);
+     if (gOptSplit) {
+       AddNamespaceSTDdeclaration(splitDictStream);
+     }
+   }
    if (gOptGeneratePCH) {
       AnnotateAllDeclsForPCH(interp, scan);
    } else if (gOptInterpreterOnly) {


### PR DESCRIPTION
In order to avoid {namespace std} interfering with following include files,
when generating a dictionary file add the {using namespace std;} only after
GenerateNecessaryIncludes method is called.

Since many legacy root header files do require this global {using namespace std;}
to complete the tests, old behaviour is kept by default and the global
{using namespace std} can be avoided by adding -noGlobalUsingStd to rootcling invocation.

Allow passing ACLiC RootCling flags via .rootrc (Vassil)

This is a special patch tailored for v6-20-02