### PR TITLE
[CMake] Fix bb0d9ae

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -309,7 +309,7 @@ endif()
 
 # Pyroot requires python-dev package; force to OFF if it was not found
 # PYTHONLIBS_FOUND is used for cmake < 3.12
-if(NOT PYTHONLIBS_FOUND AND NOT Python_Development_FOUND AND NOT Python2_Development_FOUND)
+if(NOT PYTHONLIBS_FOUND AND NOT Python3_Development_FOUND AND NOT Python2_Development_FOUND)
   set(pyroot_defvalue OFF)
   set(pyroot_experimental_defvalue OFF)
   set(tmva-pymva_defvalue OFF)

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1525,10 +1525,10 @@ endif()
 
 #---Check for Pyroot Exp---------------------------------------------------------------------
 if(pyroot_experimental)
-  if(fail-on-missing AND (NOT PYTHONLIBS_FOUND AND NOT Python2_Development_FOUND AND NOT Python_Development_FOUND))
+  if(fail-on-missing AND (NOT PYTHONLIBS_FOUND AND NOT Python2_Development_FOUND AND NOT Python3_Development_FOUND))
     message(FATAL_ERROR "PyROOT: Python development package not found and pyroot component required"
                         " (python executable: ${PYTHON_EXECUTABLE})")
-  elseif(NOT PYTHONLIBS_FOUND AND NOT Python2_Development_FOUND AND NOT Python_Development_FOUND)
+  elseif(NOT PYTHONLIBS_FOUND AND NOT Python2_Development_FOUND AND NOT Python3_Development_FOUND)
     message(STATUS "PyROOT: Python development package not found for python ${PYTHON_EXECUTABLE}. Switching off pyroot_experimental option")
     set(pyroot_experimental OFF CACHE BOOL "Disabled because Python development package was not found" FORCE)
   endif()

--- a/cmake/modules/SearchRootCoreDeps.cmake
+++ b/cmake/modules/SearchRootCoreDeps.cmake
@@ -15,7 +15,7 @@ endif()
 
 # Python is required by header and manpage generation
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14 AND NOT MSVC)
 
   # Determine whether we should prefer Python 2 or Python 3:
   set(PYTHON_PREFER_VERSION "3")
@@ -58,14 +58,14 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14)
     set(NUMPY_FOUND ${Python2_NumPy_FOUND} CACHE INTERNAL "" FORCE)
     set(NUMPY_INCLUDE_DIRS "${Python2_NumPy_INCLUDE_DIRS}" CACHE INTERNAL "" FORCE)
   else()
-    if(PYTHON_EXECUTABLE AND NOT Python_EXECUTABLE)
-      set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+    if(PYTHON_EXECUTABLE AND NOT Python3_EXECUTABLE)
+      set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE}")
     endif()
-    if(PYTHON_INCLUDE_DIRS AND NOT Python_INCLUDE_DIRS)
-      set(Python_INCLUDE_DIRS "${PYTHON_INCLUDE_DIRS}")
+    if(PYTHON_INCLUDE_DIRS AND NOT Python3_INCLUDE_DIRS)
+      set(Python3_INCLUDE_DIRS "${PYTHON_INCLUDE_DIRS}")
     endif()
-    if(PYTHON_LIBRARIES AND NOT Python_LIBRARIES)
-      set(Python_LIBRARIES "${PYTHON_LIBRARIES}")
+    if(PYTHON_LIBRARIES AND NOT Python3_LIBRARIES)
+      set(Python3_LIBRARIES "${PYTHON_LIBRARIES}")
     endif()
     find_package(Python3 COMPONENTS Interpreter REQUIRED)
     # Search for NumPy and Development, but not required:


### PR DESCRIPTION
The missing changes did not allow to choose the Python3 version
(PYTHON_EXECUTABLE was ignored) and automatically switched off pyroot,
pyroot_experimental and py-tmva.

Fixes what reported here: https://sft.its.cern.ch/jira/browse/ROOT-10725