### PR TITLE
[histv7] Make fFillFunc transient:

### DIFF
--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -172,8 +172,11 @@ public:
    }
 
 private:
-   std::unique_ptr<ImplBase_t> fImpl; ///< The actual histogram implementation.
-   FillFunc_t fFillFunc = nullptr;    ///< Pointer to RHistImpl::Fill() member function.
+   /// The actual histogram implementation.
+   std::unique_ptr<ImplBase_t> fImpl;
+
+   /// Pointer to RHistImpl::Fill() member function.
+   FillFunc_t fFillFunc = nullptr;    //!
 
    friend RHist HistFromImpl<>(std::unique_ptr<ImplBase_t>);
 };


### PR DESCRIPTION
Fixes error about missing dictionary for function type.