### PR TITLE
Address TTree::Scan part of ROOT-10702

### DIFF
--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -3740,7 +3740,7 @@ void TBranchElement::Print(Option_t* option) const
       Int_t ind = parent ? parent->GetListOfBranches()->IndexOf(this) : -1;
       TVirtualStreamerInfo *info = ((TBranchElement*)this)->GetInfoImp();
 
-      Printf("%-16s %2d %4d %-16s %-16s %8x %8x %s\n",
+      Printf("%-16s %2d %4d %-16s %-16s %8x %8x %p\n",
              info ? info->GetName() : "StreamerInfo unvailable", GetID(), GetType(),
              GetClassName(), GetParentName(),
              (fBranchOffset&&parent && ind>=0) ? parent->fBranchOffset[ind] : 0,

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -2592,7 +2592,8 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
                cnames[ncols].Append( lf->GetBranch()->GetName() );
             }
          }
-         if (strcmp( lf->GetBranch()->GetName(), lf->GetName() ) != 0 ) {
+         if (lf->GetBranch()->IsA() == TBranch::Class() ||
+             strcmp( lf->GetBranch()->GetName(), lf->GetName() ) != 0 ) {
             cnames[ncols].Append('.');
             cnames[ncols].Append( lf->GetName() );
          }


### PR DESCRIPTION
Fix ROOT-10702 (Scan of of leaf with duplicate names.) 
leaf from leaflist requested via Scan("*") have their branch name included