### PR TITLE
FIx TMVA Deep Learning  for builds without IMT and/or BLAS +  tutorials fixes

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuMatrix.h
@@ -124,6 +124,9 @@ public:
     *  course match. */
    TCpuMatrix(const TCpuBuffer<AFloat> &buffer, size_t m, size_t n);
 
+   /** copy from a TMAtrixT . Deep copy without re-creating a new buffer */
+   TCpuMatrix<AFloat> &operator=(const TMatrixT<AFloat> &);
+
    // N.B the default copy constructor does a shallow copy (NOT a deep one) !
    TCpuMatrix(const TCpuMatrix &) = default;
    TCpuMatrix(TCpuMatrix &&) = default;

--- a/tmva/tmva/src/DNN/Architectures/Cpu/CpuMatrix.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/CpuMatrix.cxx
@@ -68,6 +68,17 @@ TCpuMatrix<AReal>::operator TMatrixT<AReal>() const
    return B;
 }
 
+//____________________________________________________________________________
+template <typename AReal>
+TCpuMatrix<AReal> & TCpuMatrix<AReal>::operator=(const TMatrixT<AReal> &B)
+{
+   for (size_t j = 0; j < fNCols; j++) {
+      for (size_t i = 0; i < fNRows; i++) {
+         (*this)(i, j) = B(i, j);
+      }
+   }
+   return *this;
+}
 
 //____________________________________________________________________________
 template<typename AReal>

--- a/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.hxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.hxx
@@ -66,7 +66,7 @@ void TCpu<AFloat>::MultiplyTranspose(TCpuMatrix<AFloat> &output, const TCpuMatri
    ::TMVA::DNN::Blas::Gemm(&transa, &transb, &m, &n, &k, &alpha, A, &m, B, &n, &beta, C, &m);
 #else
    TMatrixT<AFloat> tmp(output.GetNrows(), output.GetNcols());
-   tmp.MultT( input,Weights);
+   tmp.MultT(input, Weights);
    output = tmp;
 #endif
 }
@@ -90,7 +90,7 @@ void TCpu<AFloat>::AddRowWise(TCpuMatrix<AFloat> &output, const TCpuMatrix<AFloa
 
    ::TMVA::DNN::Blas::Ger(&m, &n, &alpha, x, &inc, y, &inc, A, &m);
 #else
-   TMatrixT<AFloat> tmp;
+   TMatrixT<AFloat> tmp = output;
    TReference<AFloat>::AddRowWise(tmp, biases);
    output = tmp;
 #endif

--- a/tmva/tmva/test/DNN/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/CMakeLists.txt
@@ -104,96 +104,77 @@ endif ()
 
 #--- CPU tests. ----------------------------
 #
-# always run them
-#if ( (BLAS_FOUND OR mathmore) AND imt AND tmva-cpu)
-#  include_directories(${TBB_INCLUDE_DIRS})
+# always run the Cpu tests. If tmva-cpu is off (no Blas or no imt)
+# they will work using TMatrix operations
 
-  # DNN - Arithmetic Functions CPU
-  ROOT_EXECUTABLE(testArithmeticCpu TestMatrixArithmeticCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Arithmetic-Cpu COMMAND testArithmeticCpu)
+# DNN - Arithmetic Functions CPU
+ROOT_EXECUTABLE(testArithmeticCpu TestMatrixArithmeticCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Arithmetic-Cpu COMMAND testArithmeticCpu)
 
-  # DNN - Activation Functions CPU
-  ROOT_EXECUTABLE(testActivationFunctionsCpu TestActivationFunctionsCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Activation-Functions-Cpu COMMAND testActivationFunctionsCpu)
+# DNN - Activation Functions CPU
+ROOT_EXECUTABLE(testActivationFunctionsCpu TestActivationFunctionsCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Activation-Functions-Cpu COMMAND testActivationFunctionsCpu)
 
-  # DNN - Loss Functions CPU
-  ROOT_EXECUTABLE(testLossFunctionsCpu TestLossFunctionsCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Loss-Functions-Cpu COMMAND testLossFunctionsCpu)
+# DNN - Loss Functions CPU
+ROOT_EXECUTABLE(testLossFunctionsCpu TestLossFunctionsCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Loss-Functions-Cpu COMMAND testLossFunctionsCpu)
 
-  # DNN - Derivatives CPU
-  ROOT_EXECUTABLE(testDerivativesCpu TestDerivativesCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Derivatives-Cpu COMMAND testDerivativesCpu)
+# DNN - Derivatives CPU
+ROOT_EXECUTABLE(testDerivativesCpu TestDerivativesCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Derivatives-Cpu COMMAND testDerivativesCpu)
 
-  # DNN - Backpropagation CPU
-  ROOT_EXECUTABLE(testBackpropagationCpu TestBackpropagationCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Backpropagation-Cpu COMMAND testBackpropagationCpu)
+# DNN - Backpropagation CPU
+ROOT_EXECUTABLE(testBackpropagationCpu TestBackpropagationCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Backpropagation-Cpu COMMAND testBackpropagationCpu)
 
-  # DNN - BackpropagationDL CPU
-  ROOT_EXECUTABLE(testBackpropagationDLCpu TestBackpropagationDLCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Backpropagation-DL-Cpu COMMAND testBackpropagationDLCpu)
+# DNN - BackpropagationDL CPU
+ROOT_EXECUTABLE(testBackpropagationDLCpu TestBackpropagationDLCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Backpropagation-DL-Cpu COMMAND testBackpropagationDLCpu)
 
-    # DNN - Batch normalization
-  ROOT_EXECUTABLE(testBatchNormalizationCpu TestBatchNormalizationCpu.cxx LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-BatchNormalization-Cpu COMMAND testBatchNormalizationCpu)
-
-if ( old-dnn-test )
-  # DNN - DataLoader CPU
-  ROOT_EXECUTABLE(testDataLoaderCpu TestDataLoaderCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Data-Loader-Cpu COMMAND testDataLoaderCpu)
-
-  # DNN - Minimization CPU
-  ROOT_EXECUTABLE(testMinimizationCpu TestMinimizationCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Minimization-Cpu COMMAND testMinimizationCpu)
-
-endif ()
+# DNN - Batch normalization
+ROOT_EXECUTABLE(testBatchNormalizationCpu TestBatchNormalizationCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-BatchNormalization-Cpu COMMAND testBatchNormalizationCpu)
 
 
+# DNN - Optimization CPU
+ROOT_EXECUTABLE(testOptimizationCpu TestOptimizationCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Optimization-Cpu COMMAND testOptimizationCpu)
 
-  # DNN - Optimization CPU
-  ROOT_EXECUTABLE(testOptimizationCpu TestOptimizationCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Optimization-Cpu COMMAND testOptimizationCpu)
+# DNN - MethodDL SGD Optimization CPU
+ROOT_EXECUTABLE(testMethodDLSGDOptimizationCpu TestMethodDLSGDOptimizationCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-MethodDL-SGD-Optimization-Cpu COMMAND testMethodDLSGDOptimizationCpu)
 
-  # DNN - MethodDL SGD Optimization CPU
-  ROOT_EXECUTABLE(testMethodDLSGDOptimizationCpu TestMethodDLSGDOptimizationCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-MethodDL-SGD-Optimization-Cpu COMMAND testMethodDLSGDOptimizationCpu)
+# DNN - MethodDL Adam Optimization CPU
+ROOT_EXECUTABLE(testMethodDLAdamOptimizationCpu TestMethodDLAdamOptimizationCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-MethodDL-Adam-Optimization-Cpu COMMAND testMethodDLAdamOptimizationCpu)
 
-  # DNN - MethodDL Adam Optimization CPU
-  ROOT_EXECUTABLE(testMethodDLAdamOptimizationCpu TestMethodDLAdamOptimizationCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-MethodDL-Adam-Optimization-Cpu COMMAND testMethodDLAdamOptimizationCpu)
+# DNN - MethodDL Adagrad Optimization CPU
+ROOT_EXECUTABLE(testMethodDLAdagradOptimizationCpu TestMethodDLAdagradOptimizationCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-MethodDL-Adagrad-Optimization-Cpu COMMAND testMethodDLAdagradOptimizationCpu)
 
-  # DNN - MethodDL Adagrad Optimization CPU
-  ROOT_EXECUTABLE(testMethodDLAdagradOptimizationCpu TestMethodDLAdagradOptimizationCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-MethodDL-Adagrad-Optimization-Cpu COMMAND testMethodDLAdagradOptimizationCpu)
+# DNN - MethodDL RMSProp Optimization CPU
+ROOT_EXECUTABLE(testMethodDLRMSPropOptimizationCpu TestMethodDLRMSPropOptimizationCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-MethodDL-RMSProp-Optimization-Cpu COMMAND testMethodDLRMSPropOptimizationCpu)
 
-  # DNN - MethodDL RMSProp Optimization CPU
-  ROOT_EXECUTABLE(testMethodDLRMSPropOptimizationCpu TestMethodDLRMSPropOptimizationCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-MethodDL-RMSProp-Optimization-Cpu COMMAND testMethodDLRMSPropOptimizationCpu)
+# DNN - MethodDL Adadelta Optimization CPU
+ROOT_EXECUTABLE(testMethodDLAdadeltaOptimizationCpu TestMethodDLAdadeltaOptimizationCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-MethodDL-Adadelta-Optimization-Cpu COMMAND testMethodDLAdadeltaOptimizationCpu)
 
-  # DNN - MethodDL Adadelta Optimization CPU
-  ROOT_EXECUTABLE(testMethodDLAdadeltaOptimizationCpu TestMethodDLAdadeltaOptimizationCpu.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-MethodDL-Adadelta-Optimization-Cpu COMMAND testMethodDLAdadeltaOptimizationCpu)
+# DNN - Regression CPU
+ROOT_EXECUTABLE(testRegressionCpu TestRegressionMethodDL.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Regression-Cpu COMMAND testRegressionCpu)
 
-  # DNN - Regression CPU
-  ROOT_EXECUTABLE(testRegressionCpu TestRegressionMethodDL.cxx
-    LIBRARIES ${Libraries})
-  ROOT_ADD_TEST(TMVA-DNN-Regression-Cpu COMMAND testRegressionCpu)
+#( old-dnn-test )
+# DNN - DataLoader CPU
+ROOT_EXECUTABLE(testDataLoaderCpu TestDataLoaderCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Data-Loader-Cpu COMMAND testDataLoaderCpu)
 
-####endif()
+# DNN - Minimization CPU
+ROOT_EXECUTABLE(testMinimizationCpu TestMinimizationCpu.cxx LIBRARIES ${Libraries})
+ROOT_ADD_TEST(TMVA-DNN-Minimization-Cpu COMMAND testMinimizationCpu)
 
+
+# tests using TReference architecture
 if ( reference-tests)
 
   # DNN - Activation Functions

--- a/tmva/tmva/test/DNN/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/CMakeLists.txt
@@ -103,8 +103,10 @@ endif()
 endif ()
 
 #--- CPU tests. ----------------------------
-if ( (BLAS_FOUND OR mathmore) AND imt AND tmva-cpu)
-  include_directories(${TBB_INCLUDE_DIRS})
+#
+# always run them
+#if ( (BLAS_FOUND OR mathmore) AND imt AND tmva-cpu)
+#  include_directories(${TBB_INCLUDE_DIRS})
 
   # DNN - Arithmetic Functions CPU
   ROOT_EXECUTABLE(testArithmeticCpu TestMatrixArithmeticCpu.cxx
@@ -190,7 +192,7 @@ endif ()
     LIBRARIES ${Libraries})
   ROOT_ADD_TEST(TMVA-DNN-Regression-Cpu COMMAND testRegressionCpu)
 
-endif ()
+####endif()
 
 if ( reference-tests)
 

--- a/tutorials/tmva/TMVA_CNN_Classification.C
+++ b/tutorials/tmva/TMVA_CNN_Classification.C
@@ -118,9 +118,8 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
 #ifndef R__HAS_TMVACPU
 #ifndef R__HAS_TMVAGPU
    Warning("TMVA_CNN_Classification",
-           "TMVA is not build with GPU or CPU multi-thread support. Cannot use TMVA Deep Learning");
+           "TMVA is not build with GPU or CPU multi-thread support. Cannot use TMVA Deep Learning for CNN");
    useTMVACNN = false;
-   useTMVADNN = false;
 #endif
 #endif
 
@@ -165,7 +164,7 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
 
    TMVA::Factory factory(
       "TMVA_CNN_Classification", outputFile,
-      "!V:ROC:!Silent:Color:!DrawProgressBar:AnalysisType=Classification:Transformations=None:!Correlations");
+      "!V:ROC:!Silent:Color:AnalysisType=Classification:Transformations=None:!Correlations");
 
    /***
 
@@ -279,7 +278,7 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
    // Boosted Decision Trees
    if (useTMVABDT) {
       factory.BookMethod(loader, TMVA::Types::kBDT, "BDT",
-                         "!V:NTrees=800:MinNodeSize=2.5%:MaxDepth=2:BoostType=AdaBoost:AdaBoostBeta=0.5:"
+                         "!V:NTrees=400:MinNodeSize=2.5%:MaxDepth=2:BoostType=AdaBoost:AdaBoostBeta=0.5:"
                          "UseBaggedBoost:BaggedSampleFraction=0.5:SeparationType=GiniIndex:nCuts=20");
    }
    /**

--- a/tutorials/tmva/TMVA_Higgs_Classification.C
+++ b/tutorials/tmva/TMVA_Higgs_Classification.C
@@ -49,7 +49,7 @@ void TMVA_Higgs_Classification() {
    auto outputFile = TFile::Open("Higgs_ClassificationOutput.root", "RECREATE");
 
    TMVA::Factory factory("TMVA_Higgs_Classification", outputFile,
-                         "!V:ROC:!Silent:Color:!DrawProgressBar:AnalysisType=Classification" );
+                         "!V:ROC:!Silent:Color:AnalysisType=Classification" );
 
 /**
 
@@ -59,10 +59,8 @@ Define now input data file and signal and background trees
 
  **/
 
-   TString downloadLinkFile = "https://cernbox.cern.ch/index.php/s/EJqhbcDdyXKeswy/download";
-
-
    TString inputFileName = "Higgs_data.root";
+   TString inputFileLink = "http://root.cern.ch/files/" + inputFileName;
 
    TFile *inputFile = nullptr;
 
@@ -74,8 +72,9 @@ Define now input data file and signal and background trees
    if (!inputFile) {
       // download file from Cernbox location
       Info("TMVA_Higgs_Classification","Download Higgs_data.root file");
-      gSystem->Exec( TString::Format("wget -O %s %s",inputFileName.Data(), downloadLinkFile.Data() ) );
-      inputFile = TFile::Open( inputFileName );
+      inputFile = TFile::Open(inputFileLink, "CACHEREAD");
+      //gSystem->Exec( TString::Format("wget -O %s %s",inputFileName.Data(), downloadLinkFile.Data() ) );
+      //inputFile = TFile::Open( inputFileName);
       if (!inputFile) {
          Error("TMVA_Higgs_Classification","Input file cannot be downloaded - exit");
          return;
@@ -244,11 +243,7 @@ We can then book the DL method using the built option string
 
    if (useDL) {
 
-      bool useDLCPU = false;
       bool useDLGPU = false;
-#ifdef R__HAS_TMVACPU
-      useDLCPU = true;
-#endif
 #ifdef R__HAS_TMVAGPU
       useDLGPU = true;
 #endif
@@ -284,8 +279,9 @@ We can then book the DL method using the built option string
       if (useDLGPU) {
          dnnOptions += ":Architecture=GPU";
          dnnMethodName = "DNN_GPU";
-      } else
+      } else  {
          dnnOptions += ":Architecture=CPU";
+      }
 
       factory.BookMethod(loader, TMVA::Types::kDL, dnnMethodName, dnnOptions);
 

--- a/tutorials/tmva/TMVA_RNN_Classification.C
+++ b/tutorials/tmva/TMVA_RNN_Classification.C
@@ -170,9 +170,8 @@ void TMVA_RNN_Classification(int use_type = 1)
 #ifndef R__HAS_TMVAGPU
    useGPU = false;
 #ifndef R__HAS_TMVACPU
-   Warning("TMVA_RNN_Classification", "TMVA is not build with GPU or CPU multi-thread support. Cannot use TMVA Deep Learning");
+   Warning("TMVA_RNN_Classification", "TMVA is not build with GPU or CPU multi-thread support. Cannot use TMVA Deep Learning for RNN");
    useTMVA_RNN = false;
-   useTMVA_DNN = false;
 #endif
 #endif
 
@@ -432,6 +431,7 @@ the option string
 
             if (gSystem->AccessPathName(modelName)) {
                Warning("TMVA_RNN_Classification", "Error creating Keras recurrennt model file - Skip using Keras");
+               useKeras = false;
             } else {
                // book PyKeras method only if Keras model could be created
                Info("TMVA_RNN_Classification", "Booking Keras %s model", rnn_types[i].c_str());
@@ -446,6 +446,10 @@ the option string
       }
    }
 
+   // use BDT in case not using Keras or TMVA DL
+   if (!useKeras || !useTMVA_BDT)
+      useTMVA_BDT = true;
+
    /**
          ## Book TMVA BDT
    **/
@@ -453,7 +457,7 @@ the option string
    if (useTMVA_BDT) {
 
       factory->BookMethod(dataloader, TMVA::Types::kBDT, "BDTG",
-                          "!H:!V:NTrees=500:MinNodeSize=2.5%:BoostType=Grad:Shrinkage=0.10:UseBaggedBoost:"
+                          "!H:!V:NTrees=100:MinNodeSize=2.5%:BoostType=Grad:Shrinkage=0.10:UseBaggedBoost:"
                           "BaggedSampleFraction=0.5:nCuts=20:"
                           "MaxDepth=2");
 


### PR DESCRIPTION
- Fix the computation in case of imt or blas is not available.  

Use still TCpuMatrix class (TCpu architecture) but use TMatrix for matrix multiplication instead of BLAS\
  Only dense layers architectures are supported in this case

  - Fix tutorials for the no-imt case

-   Use Higgs data file from root.cern.ch