### PR TITLE
Fix: option name in the help differs from actual option

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -5669,7 +5669,7 @@ int GenReflexMain(int argc, char **argv)
          NOTYPE ,
          "" , "noGlobalUsingStd" ,
          ROOT::option::FullArg::None,
-         "--no-using-std\tDo not declare {using namespace std} in the dictionary global scope\n"
+         "--noGlobalUsingStd\tDo not declare {using namespace std} in the dictionary global scope\n"
          "      All header files must have sumbols from std:: namespace fully qualified\n"
       },
 


### PR DESCRIPTION
@vgvassilev this is a trivial fix-up, affecting only the rootcling help printout:
just noticed that when changing the option name I forgot to change also the help line, sorry. 