### PR TITLE
Gtest requires to have one TEST() invocation declared while to be reg…

### DIFF
--- a/core/foundation/test/testNotFn.cxx
+++ b/core/foundation/test/testNotFn.cxx
@@ -1,9 +1,5 @@
 #include "ROOT/RNotFn.hxx"
 
-// libc++ does not define __cpp_lib_not_fn.
-// Assume we have not_fn if
-#if defined(R__NOTFN_BACKPORT)
-
 #include "gtest/gtest.h"
 
 bool retTrue(){return true;}
@@ -11,6 +7,9 @@ bool retFlip(bool b){return !b;}
 
 TEST(NotFn, Simple)
 {
+// libc++ does not define __cpp_lib_not_fn.
+// Assume we have not_fn if
+#if defined(R__NOTFN_BACKPORT)
    EXPECT_TRUE(true);
    EXPECT_TRUE(std::not_fn([]() { return false; })());
 
@@ -27,7 +26,6 @@ TEST(NotFn, Simple)
 
    EXPECT_TRUE(std::not_fn(std::not_fn(retFlip))(false));
    EXPECT_FALSE(std::not_fn(std::not_fn(retFlip))(true));
-
+#endif
 }
 
-#endif


### PR DESCRIPTION
…istered with gtest_main.a

Error message is not obvious: usr/bin/ld: ../../../googletest-prefix/src/googletest-build/lib//libgtest_main.a(gtest_main.cc.o): in function main:gtest_main.cc:(.text.startup+0x26): undefined reference to testing::InitGoogleTest(int*, char**)