### PR TITLE
[ROOT-10640] OpenGL/Glew should be working only with X11

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -330,6 +330,15 @@ if(UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 4)
     set(dataframe_defvalue OFF)
 endif()
 
+# OpenGL should be working only with x11 (Linux),
+# in case when -Dall=ON -Dx11=OFF, we will just disable opengl.
+if(NOT WIN32 AND NOT APPLE)
+  if(opengl AND NOT x11)
+    message(STATUS "OpenGL was disabled, since it is required to have enabled x11 on Linux")
+    set(opengl OFF CACHE BOOL "OpenGL requires to have enabled x11" FORCE)
+  endif()
+endif()
+
 #---Options depending of CMake Generator-------------------------------------------------------
 if( CMAKE_GENERATOR STREQUAL Ninja)
    set(fortran_defvalue OFF)

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -511,6 +511,7 @@ if(opengl)
 endif()
 
 #---Check for GLEW -------------------------------------------------------------------
+# Opengl is "must" requirement for Glew.
 if(opengl AND NOT builtin_glew)
   message(STATUS "Looking for GLEW")
   if(fail-on-missing)


### PR DESCRIPTION
It fixes next Jira issue https://sft.its.cern.ch/jira/browse/ROOT-10640 (where looks like OpenGL works only with X11 for ROOT)  and since Glew depends on OpenGL, then it is transitively depends on X11: http://cdash.cern.ch/buildSummary.php?buildid=866822 (build was built with `-Dbuiltin_glew=ON -Dx11=OFF`)