### PR TITLE
[CMake][PyROOT] Disable roofit tutorials in old PyROOT

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -505,6 +505,16 @@ if(ROOT_pyroot_FOUND)
              sql/sqlfilldb.py       # same as the C++ case
              sql/sqlselect.py       # same as the C++ case
              )
+
+  if(NOT pyroot_experimental)
+    # Disable in old PyROOT, which lacks Import pythonization
+    list(APPEND pyveto
+        roofit/rf502_wspacewrite.py
+        roofit/rf504_simwstool.py
+        roofit/rf509_wsinteractive.py
+        roofit/rf511_wsfactory_basic.py)
+  endif()
+
   if(NOT ROOT_mathmore_FOUND)
     list(APPEND pyveto math/Legendre.py)
     list(APPEND pyveto math/Bessel.py)


### PR DESCRIPTION
The following tutorials need to be disabled in old PyROOT because they
use a pythonization available only in experimental:

~~tutorials/roofit/rf501_simultaneouspdf.py~~
tutorials/roofit/rf502_wspacewrite.py
tutorials/roofit/rf504_simwstool.py
tutorials/roofit/rf509_wsinteractive.py
tutorials/roofit/rf511_wsfactory_basic.py

Reported here: https://sft.its.cern.ch/jira/browse/ROOT-10736