### PR TITLE
[TreeProcMT] Only run test w/ remote file reads if xrootd is ON

### DIFF
--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -12,4 +12,7 @@ endif()
 
 if(imt)
    ROOT_ADD_GTEST(treeprocessormt treeprocmt/treeprocessormt.cxx LIBRARIES TreePlayer)
+   if(xrootd)
+      ROOT_ADD_GTEST(treeprocessormt_remotefiles treeprocmt/treeprocessormt_remotefiles.cxx LIBRARIES TreePlayer)
+   endif()
 endif()

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -288,24 +288,6 @@ TEST(TreeProcessorMT, LimitNTasks_CheckClusters)
    gSystem->Unlink(filename);
 }
 
-#if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
-TEST(TreeProcessorMT, PathName)
-{
-   auto fname = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/ZZTo4mu.root";
-   auto f = std::unique_ptr<TFile>(TFile::Open(fname));
-   ASSERT_TRUE(f != nullptr) << "Could not open remote file\n";
-   auto tree = f->Get<TTree>("Events");
-   ROOT::TTreeProcessorMT p(*tree);
-   std::atomic<unsigned int> n(0U);
-   auto func = [&n](TTreeReader &t) {
-      while (t.Next())
-         n++;
-   };
-   p.Process(func);
-   EXPECT_EQ(n.load(), 1499064U) << "Wrong number of events processed!\n";
-}
-#endif
-
 TEST(TreeProcessorMT, TreeWithFriendTree)
 {
    std::vector<std::string> fileNames = {"TreeWithFriendTree_Tree.root", "TreeWithFriendTree_Friend.root"};

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt_remotefiles.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt_remotefiles.cxx
@@ -1,0 +1,25 @@
+#include <ROOT/TTreeProcessorMT.hxx>
+#include <TTree.h>
+
+#include <atomic>
+
+#include "gtest/gtest.h"
+
+class TTree;
+class TTreeReader;
+
+TEST(TreeProcessorMT, PathName)
+{
+   auto fname = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/ZZTo4mu.root";
+   auto f = std::unique_ptr<TFile>(TFile::Open(fname));
+   ASSERT_TRUE(f != nullptr) << "Could not open remote file\n";
+   auto tree = f->Get<TTree>("Events");
+   ROOT::TTreeProcessorMT p(*tree);
+   std::atomic<unsigned int> n(0U);
+   auto func = [&n](TTreeReader &t) {
+      while (t.Next())
+         n++;
+   };
+   p.Process(func);
+   EXPECT_EQ(n.load(), 1499064U) << "Wrong number of events processed!\n";
+}


### PR DESCRIPTION
This fixes ROOT-10733.