### PR TITLE
[cling] Fix clang::CodeGen EH assert on MacOS:

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
@@ -448,7 +448,7 @@ void CodeGenFunction::EmitStartEHSpec(const Decl *D) {
   ExceptionSpecificationType EST = Proto->getExceptionSpecType();
 
   // Might need to deserialize
-  if (EST == EST_Uninstantiated) {
+  if (EST == EST_Uninstantiated || EST == EST_Unevaluated) {
     FD = FD->getMostRecentDecl();
     Proto = FD->getType()->getAs<FunctionProtoType>();
     EST = Proto->getExceptionSpecType();


### PR DESCRIPTION
Force deserialization also for unevaluated ESTs.
Deserializing the decl chain (as part of the linkage spec calculation)
will update the EST between Start and End EH emission, causing an
asymmetry and triggering the assert. This forces the decl chain to be
loaded.

Fixes roottest/root/treeformula/stl/assertSparseSelection.C on MacOS.