### PR TITLE
[RF] Fix warning when opening files with <v6.20 RooFit objects.

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -171,7 +171,8 @@
 #pragma link C++ class RooRealConstant+ ;
 #pragma link C++ class RooRealIntegral+ ;
 #pragma link C++ class RooRealMPFE+ ;
-#pragma link C++ class RooTemplateProxy<RooAbsReal>+;
+#pragma link C++ class RooRealProxy+;
+#pragma read sourceClass="RooRealProxy" targetClass="RooTemplateProxy<RooAbsReal>";
 #pragma link C++ class RooTemplateProxy<RooAbsPdf>+;
 #pragma read sourceClass="RooRealProxy" targetClass="RooTemplateProxy<RooAbsPdf>";
 #pragma link C++ class RooTemplateProxy<RooAbsRealLValue>+;


### PR DESCRIPTION
When RooFit's proxies were made more type safe, a typedef was introduced
to make the most type-general proxy equivalent to RooFit's previous
"RooRealProxy". This ensures backward compatibility.
However, the typedef and not the actual template instantiation has to be
mentioned in LinkDef.h. Otherwise, users will get a warning when reading
files.

This fixes the warning that e.g. appears in #5530.