### PR TITLE
[Metacling] Integrate cppyy patch for lambdas

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1530,6 +1530,18 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
    fClingCallbacks->SetAutoParsingSuspended(fIsAutoParsingSuspended);
    fInterpreter->setCallbacks(std::move(clingCallbacks));
 
+   // helper for lambdas
+   if (!fromRootCling) { fInterpreter->declare(
+      "#ifndef CLING_INTERNAL_DECLARE_FT\n"
+      "#define CLING_INTERNAL_DECLARE_FT\n"
+      "#include <functional>\n"
+      "namespace __cling_internal { template <typename F>"
+      "struct FT : public FT<decltype(&F::operator())> {};"
+      "template <typename C, typename R, typename... Args>"
+      "struct FT<R(C::*)(Args...) const> { typedef std::function<R(Args...)> F; };}\n"
+      "#endif\n"
+   ); }
+
    if (!fromRootCling) {
       // Make sure cling looks into ROOT's libdir, even if not part of LD_LIBRARY_PATH
       // e.g. because of an RPATH build.


### PR DESCRIPTION
This is a port of the cppyy patch which enables accessing lambdas in PyROOT.

The patch: https://bitbucket.org/wlav/cppyy-backend/src/master/cling/patches/lambda.diff

Reproducer:
```python
import cppyy
cppyy.cppdef("auto l = []{cout << 100 << endl;};")
cppyy.gbl.l()
```
Related Jira issue: https://sft.its.cern.ch/jira/browse/ROOT-7704

The PR is for now mainly meant as a proof of concept and to identify the missing feature in ROOT meta to get this working.

Edit:

Here an updated link to the diff:

https://bitbucket.org/wlav/cppyy-backend/src/clingwrapper-1.12.0/cling/patches/lambda.diff