### PR TITLE
[DF] Fix use after delete of RLoopManager in RCustomColumnBase

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -307,7 +307,6 @@ void AddDSColumnsHelper(RLoopManager &lm, std::string_view name, RDFInternal::RB
    auto newCol = std::make_shared<NewCol_t>(&lm, name, ds.GetTypeName(name), std::move(getValue), ColumnNames_t{},
                                             nSlots, currentCols, /*isDSColumn=*/true);
 
-   lm.RegisterCustomColumn(newCol.get());
    currentCols.AddName(name);
    currentCols.AddColumn(newCol, name);
 }

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -304,8 +304,8 @@ void AddDSColumnsHelper(RLoopManager &lm, std::string_view name, RDFInternal::RB
    auto getValue = [readers](unsigned int slot) { return *readers[slot]; };
    using NewCol_t = RCustomColumn<decltype(getValue), CustomColExtraArgs::Slot>;
 
-   auto newCol = std::make_shared<NewCol_t>(&lm, name, ds.GetTypeName(name), std::move(getValue), ColumnNames_t{},
-                                            nSlots, currentCols, /*isDSColumn=*/true);
+   auto newCol = std::shared_ptr<RCustomColumnBase>(new NewCol_t(
+      &lm, name, ds.GetTypeName(name), std::move(getValue), ColumnNames_t{}, nSlots, currentCols, /*isDSColumn=*/true));
 
    currentCols.AddName(name);
    currentCols.AddColumn(newCol, name);

--- a/tree/dataframe/inc/ROOT/RDF/RCustomColumn.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RCustomColumn.hxx
@@ -114,6 +114,7 @@ public:
       if (!fIsInitialized[slot]) {
          fIsInitialized[slot] = true;
          RDFInternal::InitRDFValues(slot, fValues[slot], r, fColumnNames, fCustomColumns, TypeInd_t(), fIsCustomColumn);
+         fLastCheckedEntry[slot] = -1;
       }
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -382,8 +382,6 @@ public:
       newCols.AddName(name);
       newCols.AddColumn(jittedCustomColumn, name);
 
-      fLoopManager->RegisterCustomColumn(jittedCustomColumn.get());
-
       RInterface<Proxied, DS_t> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 
       return newInterface;
@@ -2234,8 +2232,6 @@ private:
       newCols.AddName(entryColName);
       newCols.AddColumn(entryColumn, entryColName);
 
-      fLoopManager->RegisterCustomColumn(entryColumn.get());
-
       // Slot number column
       const std::string slotColName = "rdfslot_";
       const std::string slotColType = "unsigned int";
@@ -2247,8 +2243,6 @@ private:
 
       newCols.AddName(slotColName);
       newCols.AddColumn(slotColumn, slotColName);
-
-      fLoopManager->RegisterCustomColumn(slotColumn.get());
 
       fCustomColumns = std::move(newCols);
 
@@ -2365,7 +2359,6 @@ private:
                                                   validColumnNames, fLoopManager->GetNSlots(), newCols);
 
 
-      fLoopManager->RegisterCustomColumn(newColumn.get());
       newCols.AddName(name);
       newCols.AddColumn(newColumn, name);
 

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -177,13 +177,6 @@ public:
    /// For all the actions, either booked or run
    std::vector<RDFInternal::RActionBase *> GetAllActions();
 
-   void RegisterCustomColumn(RCustomColumnBase *column) { fCustomColumns.push_back(column); }
-
-   void DeRegisterCustomColumn(RCustomColumnBase *column)
-   {
-      fCustomColumns.erase(std::remove(fCustomColumns.begin(), fCustomColumns.end(), column), fCustomColumns.end());
-   }
-
    std::vector<RDFInternal::RActionBase *> GetBookedActions() { return fBookedActions; }
    std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> GetGraph();
 

--- a/tree/dataframe/src/RCustomColumnBase.cxx
+++ b/tree/dataframe/src/RCustomColumnBase.cxx
@@ -33,14 +33,10 @@ RCustomColumnBase::RCustomColumnBase(RLoopManager *lm, std::string_view name, st
    : fLoopManager(lm), fName(name), fType(type), fNSlots(nSlots), fIsDataSourceColumn(isDSColumn),
      fLastCheckedEntry(fNSlots, -1), fCustomColumns(customColumns), fIsInitialized(nSlots, false)
 {
-   fLoopManager->RegisterCustomColumn(this);
 }
 
 // pin vtable. Work around cling JIT issue.
-RCustomColumnBase::~RCustomColumnBase()
-{
-   fLoopManager->DeRegisterCustomColumn(this);
-}
+RCustomColumnBase::~RCustomColumnBase() {}
 
 std::string RCustomColumnBase::GetName() const
 {

--- a/tree/dataframe/src/RCustomColumnBase.cxx
+++ b/tree/dataframe/src/RCustomColumnBase.cxx
@@ -31,7 +31,7 @@ RCustomColumnBase::RCustomColumnBase(RLoopManager *lm, std::string_view name, st
                                      unsigned int nSlots, bool isDSColumn,
                                      const RDFInternal::RBookedCustomColumns &customColumns)
    : fLoopManager(lm), fName(name), fType(type), fNSlots(nSlots), fIsDataSourceColumn(isDSColumn),
-     fCustomColumns(customColumns), fIsInitialized(nSlots, false)
+     fLastCheckedEntry(fNSlots, -1), fCustomColumns(customColumns), fIsInitialized(nSlots, false)
 {
    fLoopManager->RegisterCustomColumn(this);
 }
@@ -54,5 +54,4 @@ std::string RCustomColumnBase::GetTypeName() const
 
 void RCustomColumnBase::InitNode()
 {
-   fLastCheckedEntry = std::vector<Long64_t>(fNSlots, -1);
 }


### PR DESCRIPTION
Before this patch, RCustomColumnBase's destructor could access
RLoopManager after deletion in some cases, e.g. when jitting code after
the computation graph was already out of scope or when the RLoopManager
was kept alive only by another node's shared_ptr to it. I think we never
saw a crash due to this bug because the use is _right after_ deletion,
and there is never an allocation between deletion and use. Valgrind
still sees it though.

Thanks to the previous commit, all the logic that entangled RLoopManager
and RCustomColumns can actually be removed, and in particular
RCustomColumnBase's destructor does not need to access RLoopManager
anymore, fixing the use after delete.

A minimal reproducer for the use after delete:

```cpp
auto f = ROOT::RDataFrame(1).Filter([] { return true; });
```

Before RFilter is destructed, it deletes its fPrevNode (shared_ptr to
the previous node), which triggers destruction of RLoopManager. Later,
RFilterBase is destructed, which triggers destruction of its registered
custom columns (in this case, the default "rdfentry_" or "rdfslot_"
columns) and ~RCustomColumnBase tries to access RLoopManager.