### PR TITLE
Re-enable switch to C-locale when searching for C++ includes (ROOT-10751)

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -104,7 +104,8 @@ namespace {
                                        llvm::SmallVectorImpl<char>& Buf,
                                        AdditionalArgList& Args,
                                        bool Verbose) {
-    std::string CppInclQuery(Compiler);
+    std::string CppInclQuery("LC_ALL=C ");
+    CppInclQuery.append(Compiler);
 
     CppInclQuery.append(" -xc++ -E -v /dev/null 2>&1 |"
                         " sed -n -e '/^.include/,${' -e '/^ \\/.*++/p' -e '}'");


### PR DESCRIPTION
Commit df0b689 simplified the search for the C++ include directories and
tried to use a locale independent regex.

However this regex doesn't work for all locales, for example in German
the string in the output is not

```
#include <...> search starts here:
```

but the word order is switched and we have

```
Suche für »#include <...>« beginnt hier:
```

As such I propose to go back to C-locale for this query to be completely
safe against weird locale settings.