### PR TITLE
Remove TCling_UnloadMarker (ROOT-10659)

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -197,23 +197,6 @@ extern "C" {
 #endif
 
 //______________________________________________________________________________
-// Infrastructure to detect and react to libCling being teared down.
-//
-namespace {
-   class TCling_UnloadMarker {
-   public:
-      ~TCling_UnloadMarker() {
-         if (ROOT::Internal::gROOTLocal) {
-            ROOT::Internal::gROOTLocal->~TROOT();
-         }
-      }
-   };
-   static TCling_UnloadMarker gTClingUnloadMarker;
-}
-
-
-
-//______________________________________________________________________________
 // These functions are helpers for debugging issues with non-LLVMDEV builds.
 //
 R__DLLEXPORT clang::DeclContext* TCling__DEBUG__getDeclContext(clang::Decl* D) {


### PR DESCRIPTION
In the Belle2 Software the libraries are linked with `--as-needed`
linker arguments and in conjunction with the weird loading order (binary
depends on ROOT, load python, load library depending on ROOT) we seem to
run into problems that libCling is unloaded earlier than expected.

Since the `TCling_UnloadMarker` was introduced for Belle2 and removal
doesn't seem to cause any problems we discussed in [ROOT-10659](https://sft.its.cern.ch/jira/browse/ROOT-10659) to remove
this again and it so far all tests on our software stack didn't show any
problems with that.