### PR TITLE
Allow to set the name in reproducible TFile

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -292,6 +292,13 @@ TFile::TFile() : TDirectoryFile(), fCompress(ROOT::RCompressionSetting::EAlgorit
 /// values for creation and modification date of TKey/TDirectory objects and
 /// null value for TUUID objects inside TFile. As drawback, TRef objects stored
 /// in such file cannot be read correctly.
+///
+/// In case the name of the file is not reproducible either (in case of
+/// creating temporary filenames) a value can be passed to the reproducible
+/// option to replace the name stored in the file.
+/// ~~~{.cpp}
+///   TFile *f = TFile::Open("tmpname.root?reproducible=fixedname","RECREATE","File title");
+/// ~~~
 
 TFile::TFile(const char *fname1, Option_t *option, const char *ftitle, Int_t compress)
            : TDirectoryFile(), fCompress(compress), fUrl(fname1,kTRUE)
@@ -400,6 +407,14 @@ TFile::TFile(const char *fname1, Option_t *option, const char *ftitle, Int_t com
    } else {
       Error("TFile", "error expanding path %s", fname1);
       goto zombie;
+   }
+
+   // If the user supplied a value to the option take it as the name to set for
+   // the file instead of the actual filename
+   if (TestBit(kReproducible)) {
+      if(auto name=fUrl.GetValueFromOptions("reproducible")) {
+         SetName(name);
+      }
    }
 
    if (recreate) {


### PR DESCRIPTION
Rationale
---------

We create a number of small root files to serve as conditions data. The
algorithm tells the framework to save the data to be valid for a given interval of
time.

To de-duplicate files we use the md5 checksum: same checksum, same
content, so no new file needed. Technically we create the file as a
temporary file, calculate the checksum and use a directory structure
similar to git objects: if no file with the checksum as name exists,
rename, otherwise just use the existing name.

For this to work we need the md5 checksum independent of the name of the
TFile. And since we rename the file anyway it really doesn't matter what
TFile thinks its name is.

Implementation
--------------

This tries to be the minimal change to the current feature of
reproducible files (thanks again): We piggyback on the same flag but if
the flag also has a value instead of jut being present we use it as the
name to put in the file.