### PR TITLE
Substitute deprecated tbb::task_scheduler_init with tbb::task_arena

### DIFF
--- a/core/imt/inc/ROOT/TPoolManager.hxx
+++ b/core/imt/inc/ROOT/TPoolManager.hxx
@@ -29,15 +29,19 @@
 #  error "Cannot use ROOT::TPoolManager without defining R__USE_IMT."
 # endif
 #else
-
 #include<memory>
 
-namespace tbb {
-   class task_scheduler_init;
-}
 
 namespace ROOT {
    namespace Internal {
+      /// Wrapper for tbb::task_arena.
+      ///
+      /// tbb::task_arena is an alias of tbb::interface7::task_arena, which doesn't allow
+      /// to forward declare tbb::task_arena. To avoid code breaking on tbb interface changes
+      /// we don't forward declare tbb::interface7::task_arena and instead we wrap tbb::task_arena
+      /// in the forward declared class RArena
+      class RArena;
+
       /**
       \class ROOT::TPoolManager
       \ingroup TPoolManager
@@ -52,6 +56,9 @@ namespace ROOT {
          friend std::shared_ptr<TPoolManager> GetPoolManager(UInt_t nThreads);
          /// Returns the number of threads running when the scheduler has been instantiated within ROOT.
          static UInt_t GetPoolSize();
+         RArena &Arena() {
+            return *fArena;
+         }
          /// Terminates the scheduler instantiated within ROOT.
          ~TPoolManager();
       private:
@@ -61,7 +68,7 @@ namespace ROOT {
          TPoolManager(UInt_t nThreads = 0);
          static UInt_t fgPoolSize;
          bool mustDelete = true;
-         tbb::task_scheduler_init *fSched = nullptr;
+         std::unique_ptr<RArena> fArena;
       };
       /// Get a shared pointer to the manager. Initialize the manager with nThreads if not active. If active,
       /// the number of threads, even if specified otherwise, will remain the same.

--- a/core/imt/inc/ROOT/TPoolManager.hxx
+++ b/core/imt/inc/ROOT/TPoolManager.hxx
@@ -40,7 +40,7 @@ namespace ROOT {
       /// to forward declare tbb::task_arena. To avoid code breaking on tbb interface changes
       /// we don't forward declare tbb::interface7::task_arena and instead we wrap tbb::task_arena
       /// in the forward declared class RArena
-      class RArena;
+      class RArenaPtr;
 
       /**
       \class ROOT::TPoolManager
@@ -56,7 +56,7 @@ namespace ROOT {
          friend std::shared_ptr<TPoolManager> GetPoolManager(UInt_t nThreads);
          /// Returns the number of threads running when the scheduler has been instantiated within ROOT.
          static UInt_t GetPoolSize();
-         RArena &Arena() {
+         RArenaPtr &Arena() {
             return *fArena;
          }
          /// Terminates the scheduler instantiated within ROOT.
@@ -68,7 +68,7 @@ namespace ROOT {
          TPoolManager(UInt_t nThreads = 0);
          static UInt_t fgPoolSize;
          bool mustDelete = true;
-         std::unique_ptr<RArena> fArena;
+         std::unique_ptr<RArenaPtr> fArena;
       };
       /// Get a shared pointer to the manager. Initialize the manager with nThreads if not active. If active,
       /// the number of threads, even if specified otherwise, will remain the same.

--- a/core/imt/src/RArena.hxx
+++ b/core/imt/src/RArena.hxx
@@ -1,20 +1,20 @@
 #include "tbb/task_arena.h"
 namespace ROOT {
-    namespace Internal {
-      // Wrapper for tbb::task_arena.
-      //
-      //tbb::task_arena is an alias of tbb::interface7::task_arena, which doesn't allow
-      // to forward declare tbb::task_arena. To avoid code breaking on tbb interface changes
-      // we don't forward declare tbb::interface7::task_arena and instead we wrap tbb::task_arena
-      // in the forward declared class RArena
-      class RArena {
-      public:
-        /// Access the wrapped object and allow to call its methods.
-        tbb::task_arena *operator->() {
-            return fTBBArena.get();
-        }
-      private:
-         std::unique_ptr<tbb::task_arena> fTBBArena{new tbb::task_arena()};
-      };
+namespace Internal {
+    // Wrapper for tbb::task_arena.
+    //
+    //tbb::task_arena is an alias of tbb::interface7::task_arena, which doesn't allow
+    // to forward declare tbb::task_arena. To avoid code breaking on tbb interface changes
+    // we don't forward declare tbb::interface7::task_arena and instead we wrap tbb::task_arena
+    // in the forward declared class RArena
+    class RArenaPtr {
+    public:
+    /// Access the wrapped object and allow to call its methods.
+    tbb::task_arena *operator->() {
+        return fTBBArena.get();
     }
+    private:
+        std::unique_ptr<tbb::task_arena> fTBBArena{new tbb::task_arena()};
+    };
+}
 }

--- a/core/imt/src/RArena.hxx
+++ b/core/imt/src/RArena.hxx
@@ -1,0 +1,20 @@
+#include "tbb/task_arena.h"
+namespace ROOT {
+    namespace Internal {
+      // Wrapper for tbb::task_arena.
+      //
+      //tbb::task_arena is an alias of tbb::interface7::task_arena, which doesn't allow
+      // to forward declare tbb::task_arena. To avoid code breaking on tbb interface changes
+      // we don't forward declare tbb::interface7::task_arena and instead we wrap tbb::task_arena
+      // in the forward declared class RArena
+      class RArena {
+      public:
+        /// Access the wrapped object and allow to call its methods.
+        tbb::task_arena *operator->() {
+            return fTBBArena.get();
+        }
+      private:
+         std::unique_ptr<tbb::task_arena> fTBBArena{new tbb::task_arena()};
+      };
+    }
+}

--- a/core/imt/src/TPoolManager.cxx
+++ b/core/imt/src/TPoolManager.cxx
@@ -65,7 +65,7 @@ namespace ROOT {
 
       UInt_t TPoolManager::fgPoolSize = 0;
 
-      TPoolManager::TPoolManager(UInt_t nThreads): fArena(new RArena())
+      TPoolManager::TPoolManager(UInt_t nThreads): fArena(new RArenaPtr())
       {
          //Is it there another instance of the tbb scheduler running?
          if ((*fArena)->is_active()) {

--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -1,11 +1,11 @@
 #include "ROOT/TThreadExecutor.hxx"
 #include "ROOT/TTaskGroup.hxx"
+#include "RArena.hxx"
 
 #if !defined(_MSC_VER)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
 #endif
-
 #include "tbb/tbb.h"
 
 #if !defined(_MSC_VER)
@@ -153,19 +153,25 @@ namespace ROOT {
 
    void TThreadExecutor::ParallelFor(unsigned int start, unsigned int end, unsigned step, const std::function<void(unsigned int i)> &f)
    {
-      tbb::this_task_arena::isolate([&]{
-         tbb::parallel_for(start, end, step, f);
+      fSched->Arena()->execute([&]{
+         tbb::this_task_arena::isolate([&]{
+            tbb::parallel_for(start, end, step, f);
+         });
       });
    }
 
    double TThreadExecutor::ParallelReduce(const std::vector<double> &objs, const std::function<double(double a, double b)> &redfunc)
    {
-      return ROOT::Internal::ParallelReduceHelper<double>(objs, redfunc);
+      return fSched->Arena()->execute([&]{
+               return ROOT::Internal::ParallelReduceHelper<double>(objs, redfunc);
+      });
    }
 
    float TThreadExecutor::ParallelReduce(const std::vector<float> &objs, const std::function<float(float a, float b)> &redfunc)
    {
-      return ROOT::Internal::ParallelReduceHelper<float>(objs, redfunc);
+      return fSched->Arena()->execute([&]{
+               return ROOT::Internal::ParallelReduceHelper<float>(objs, redfunc);
+      });
    }
 
    unsigned TThreadExecutor::GetPoolSize(){


### PR DESCRIPTION
replace all uses of the deprecated tbb_task_scheduler_init and its
implicit task_arena by explicit manipulation of our own central
instance of task_arena, as suggested by intel:
https://software.intel.com/sites/default/files/managed/b2/d2/TBBRevamp.pdf

work out some gymnastics to keep tbb out of the headers. We can't
forward-declare tbb::task_arena as it is an alias of a versioned
namespace dependent class (right now tbb::interface7::tbb_task_arena)

Interface details to discuss: Should we add an ExecuteIsolated and an Execute call to TPoolManager?
