### PR TITLE
Fix Multiclass classification for TMVA Deep Learning   

### DIFF
--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -615,8 +615,15 @@ void MethodDL::ParseDenseLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
          width = fml.Eval(inputSize);
       }
    }
-   // avoid zero width. assume is 1
-   if (width == 0) width = 1;
+   // avoid zero width. assume is last layer and give width = output width
+   // Determine the number of outputs
+   size_t outputSize = 1;
+   if (fAnalysisType == Types::kRegression && GetNTargets() != 0) {
+      outputSize = GetNTargets();
+   } else if (fAnalysisType == Types::kMulticlass && DataInfo().GetNClasses() >= 2) {
+      outputSize = DataInfo().GetNClasses();
+   }
+   if (width == 0) width = outputSize;
 
    // Add the dense layer, initialize the weights and biases and copy
    TDenseLayer<Architecture_t> *denseLayer = deepNet.AddDenseLayer(width, activationFunction);
@@ -1144,14 +1151,6 @@ void MethodDL::TrainDeepNet()
 
    bool debug = Log().GetMinType() == kDEBUG;
 
-
-   // Determine the number of outputs
-   // //    size_t outputSize = 1;
-   // //    if (fAnalysisType == Types::kRegression && GetNTargets() != 0) {
-   // //       outputSize = GetNTargets();
-   // //    } else if (fAnalysisType == Types::kMulticlass && DataInfo().GetNClasses() >= 2) {
-   // //       outputSize = DataInfo().GetNClasses();
-   // //    }
 
    // set the random seed for weight initialization
    Architecture_t::SetRandomSeed(fRandomSeed);

--- a/tutorials/tmva/TMVAMulticlass.C
+++ b/tutorials/tmva/TMVAMulticlass.C
@@ -97,7 +97,7 @@ void TMVAMulticlass( TString myMethodList = "" )
    dataloader->AddVariable( "var4", "Variable 4", "units", 'F' );
 
    TFile *input(0);
-   TString fname = "./tmva_example_multiple_background.root";
+   TString fname = "./tmva_example_multiclass.root";
    if (!gSystem->AccessPathName( fname )) {
       // first we try to find the file in the local directory
       std::cout << "--- TMVAMulticlass   : Accessing " << fname << std::endl;
@@ -108,7 +108,9 @@ void TMVAMulticlass( TString myMethodList = "" )
       TString createDataMacro = gROOT->GetTutorialDir() + "/tmva/createData.C";
       gROOT->ProcessLine(TString::Format(".L %s",createDataMacro.Data()));
       gROOT->ProcessLine("create_MultipleBackground(2000)");
-      std::cout << " created tmva_example_multiple_background.root for tests of the multiclass features"<<std::endl;
+      // rename file to avoid clash con other tutorials that need onlmy 200 events
+      gSystem->Exec("mv tmva_example_multiple_background.root tmva_example_multiclass.root"); 
+      std::cout << " created tmva_example_multiclass.root for tests of the multiclass features"<<std::endl;
       input = TFile::Open( fname );
    }
    if (!input) {

--- a/tutorials/tmva/TMVAMulticlass.C
+++ b/tutorials/tmva/TMVAMulticlass.C
@@ -52,13 +52,13 @@ void TMVAMulticlass( TString myMethodList = "" )
    Use["MLP"]             = 1;
    Use["BDTG"]            = 1;
 #ifdef R__HAS_TMVAGPU
-   Use["DL_CPU"]          = 0;
+   Use["DL_CPU"]          = 1;
    Use["DL_GPU"]          = 1;
 #else
    Use["DL_CPU"]          = 1;
    Use["DL_GPU"]          = 0;
 #endif
-   Use["FDA_GA"]          = 1;
+   Use["FDA_GA"]          = 0;
    Use["PDEFoam"]         = 1;
 
    //---------------------------------------------------------------
@@ -99,24 +99,17 @@ void TMVAMulticlass( TString myMethodList = "" )
    TFile *input(0);
    TString fname = "./tmva_example_multiclass.root";
    if (!gSystem->AccessPathName( fname )) {
-      // first we try to find the file in the local directory
-      std::cout << "--- TMVAMulticlass   : Accessing " << fname << std::endl;
-      input = TFile::Open( fname );
+      input = TFile::Open( fname ); // check if file in local directory exists
    }
    else {
-      std::cout << "Creating testdata...." << std::endl;
-      TString createDataMacro = gROOT->GetTutorialDir() + "/tmva/createData.C";
-      gROOT->ProcessLine(TString::Format(".L %s",createDataMacro.Data()));
-      gROOT->ProcessLine("create_MultipleBackground(2000)");
-      // rename file to avoid clash con other tutorials that need onlmy 200 events
-      gSystem->Exec("mv tmva_example_multiple_background.root tmva_example_multiclass.root"); 
-      std::cout << " created tmva_example_multiclass.root for tests of the multiclass features"<<std::endl;
-      input = TFile::Open( fname );
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_multiclass_example.root", "CACHEREAD");
    }
    if (!input) {
       std::cout << "ERROR: could not open data file" << std::endl;
       exit(1);
    }
+   std::cout << "--- TMVAMulticlass: Using input file: " << input->GetName() << std::endl;
 
    TTree *signalTree  = (TTree*)input->Get("TreeS");
    TTree *background0 = (TTree*)input->Get("TreeB0");
@@ -143,10 +136,8 @@ void TMVAMulticlass( TString myMethodList = "" )
 
    if (Use["DL_CPU"]) {
       TString layoutString("Layout=TANH|100,TANH|50,TANH|10,LINEAR");
-      TString training0("LearningRate=1e-3,Momentum=0.5,Repetitions=1,ConvergenceSteps=10,"
-                        "BatchSize=256,TestRepetitions=1");
-      TString trainingStrategyString("TrainingStrategy=");
-      trainingStrategyString += training0; // + "|" + training1;
+      TString trainingStrategyString("TrainingStrategy=Optimizer=ADAM,LearningRate=1e-3,"
+                                     "TestRepetitions=1,ConvergenceSteps=10,BatchSize=100");
       TString nnOptions("!H:V:ErrorStrategy=CROSSENTROPY:VarTransform=N:"
                         "WeightInitialization=XAVIERUNIFORM:Architecture=GPU");
       nnOptions.Append(":");
@@ -157,10 +148,8 @@ void TMVAMulticlass( TString myMethodList = "" )
    }
    if (Use["DL_GPU"]) {
       TString layoutString("Layout=TANH|100,TANH|50,TANH|10,LINEAR");
-      TString training0("LearningRate=1e-3,Momentum=0.5,Repetitions=1,ConvergenceSteps=10,"
-                        "BatchSize=256,TestRepetitions=1");
-      TString trainingStrategyString("TrainingStrategy=");
-      trainingStrategyString += training0;// + "|" + training1;
+      TString trainingStrategyString("TrainingStrategy=Optimizer=ADAM,LearningRate=1e-3,"
+                                     "TestRepetitions=1,ConvergenceSteps=10,BatchSize=100");
       TString nnOptions("!H:V:ErrorStrategy=CROSSENTROPY:VarTransform=N:"
                         "WeightInitialization=XAVIERUNIFORM:Architecture=GPU");
       nnOptions.Append(":");

--- a/tutorials/tmva/TMVAMulticlassApplication.C
+++ b/tutorials/tmva/TMVAMulticlassApplication.C
@@ -41,9 +41,10 @@ void TMVAMulticlassApplication( TString myMethodList = "" )
    std::map<std::string,int> Use;
    Use["MLP"]             = 1;
    Use["BDTG"]            = 1;
-   Use["DNN_CPU"] = 0;
-   Use["FDA_GA"]          = 0;
-   Use["PDEFoam"]         = 0;
+   Use["DL_CPU"]          = 1;
+   Use["DL_GPU"]          = 1;
+   Use["FDA_GA"]          = 1;
+   Use["PDEFoam"]         = 1;
    //---------------------------------------------------------------
 
    std::cout << std::endl;
@@ -86,18 +87,29 @@ void TMVAMulticlassApplication( TString myMethodList = "" )
       if (it->second) {
         TString methodName = TString(it->first) + TString(" method");
         TString weightfile = dir + prefix + TString("_") + TString(it->first) + TString(".weights.xml");
-        reader->BookMVA( methodName, weightfile );
+        // check if file existing (i.e. method has been trained)
+        if (!gSystem->AccessPathName( weightfile ))
+           // file exists
+           reader->BookMVA( methodName, weightfile );
+        else {
+           std::cout << "TMVAMultiClassApplication: Skip " << methodName << " since it has not been trained !" << std::endl;
+           it->second = 0;
+        }
       }
    }
 
    // book output histograms
    UInt_t nbin = 100;
-   TH1F *histMLP_signal(0), *histBDTG_signal(0), *histFDAGA_signal(0), *histPDEFoam_signal(0), *histDNNCPU_signal(0);
+   TH1F *histMLP_signal(0), *histBDTG_signal(0), *histFDAGA_signal(0), *histPDEFoam_signal(0);
+   TH1F *histDLCPU_signal(0), *histDLGPU_signal(0); 
    if (Use["MLP"])
       histMLP_signal    = new TH1F( "MVA_MLP_signal",    "MVA_MLP_signal",    nbin, 0., 1.1 );
    if (Use["BDTG"])
       histBDTG_signal  = new TH1F( "MVA_BDTG_signal",   "MVA_BDTG_signal",   nbin, 0., 1.1 );
-   if (Use["DNN_CPU"]) histDNNCPU_signal = new TH1F("MVA_DNNCPU_signal", "MVA_DNNCPU_signal", nbin, 0., 1.1);
+   if (Use["DL_CPU"])
+      histDLCPU_signal = new TH1F("MVA_DLCPU_signal", "MVA_DLCPU_signal", nbin, 0., 1.1);
+   if (Use["DL_GPU"])
+      histDLGPU_signal = new TH1F("MVA_DLGPU_signal", "MVA_DLGPU_signal", nbin, 0., 1.1);
    if (Use["FDA_GA"])
       histFDAGA_signal = new TH1F( "MVA_FDA_GA_signal", "MVA_FDA_GA_signal", nbin, 0., 1.1 );
    if (Use["PDEFoam"])
@@ -109,8 +121,12 @@ void TMVAMulticlassApplication( TString myMethodList = "" )
    if (!gSystem->AccessPathName( fname )) {
       input = TFile::Open( fname ); // check if file in local directory exists
    }
+   else {
+      TFile::SetCacheFileDir(".");
+      input = TFile::Open("http://root.cern.ch/files/tmva_multiclass_example.root", "CACHEREAD");
+   }
    if (!input) {
-      std::cout << "ERROR: could not open data file, please generate example data first!" << std::endl;
+      std::cout << "ERROR: could not open data file" << std::endl;
       exit(1);
    }
    std::cout << "--- TMVAMulticlassApp : Using input file: " << input->GetName() << std::endl;
@@ -141,7 +157,10 @@ void TMVAMulticlassApplication( TString myMethodList = "" )
          histMLP_signal->Fill((reader->EvaluateMulticlass( "MLP method" ))[0]);
       if (Use["BDTG"])
          histBDTG_signal->Fill((reader->EvaluateMulticlass( "BDTG method" ))[0]);
-      if (Use["DNN_CPU"]) histDNNCPU_signal->Fill((reader->EvaluateMulticlass("DNN_CPU method"))[0]);
+      if (Use["DL_CPU"])
+         histDLCPU_signal->Fill((reader->EvaluateMulticlass("DL_CPU method"))[0]);
+      if (Use["DL_GPU"])
+         histDLGPU_signal->Fill((reader->EvaluateMulticlass("DL_GPU method"))[0]);
       if (Use["FDA_GA"])
          histFDAGA_signal->Fill((reader->EvaluateMulticlass( "FDA_GA method" ))[0]);
       if (Use["PDEFoam"])
@@ -158,7 +177,10 @@ void TMVAMulticlassApplication( TString myMethodList = "" )
       histMLP_signal->Write();
    if (Use["BDTG"])
       histBDTG_signal->Write();
-   if (Use["DNN_CPU"]) histDNNCPU_signal->Write();
+   if (Use["DL_CPU"])
+      histDLCPU_signal->Write();
+   if (Use["DL_GPU"])
+      histDLGPU_signal->Write();
    if (Use["FDA_GA"])
       histFDAGA_signal->Write();
    if (Use["PDEFoam"])

--- a/tutorials/tmva/TMVAMulticlassApplication.C
+++ b/tutorials/tmva/TMVAMulticlassApplication.C
@@ -105,7 +105,7 @@ void TMVAMulticlassApplication( TString myMethodList = "" )
 
 
    TFile *input(0);
-   TString fname = "./tmva_example_multiple_background.root";
+   TString fname = "./tmva_example_multiclass.root";
    if (!gSystem->AccessPathName( fname )) {
       input = TFile::Open( fname ); // check if file in local directory exists
    }


### PR DESCRIPTION
Before the fix it was alsways used an output width by default equal to 1. Now the default output width of the last dense layer is set to the number of classes.

Update multiclass tutorial to use MethodDL