### PR TITLE
[DF] More working around cling+shared_ptr issues

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2226,11 +2226,11 @@ private:
       using NewColEntry_t =
          RDFDetail::RCustomColumn<decltype(entryColGen), RDFDetail::CustomColExtraArgs::SlotAndEntry>;
 
-      auto entryColumn =
-         std::make_shared<NewColEntry_t>(fLoopManager, entryColName, entryColType, std::move(entryColGen),
-                                         ColumnNames_t{}, fLoopManager->GetNSlots(), newCols);
+      std::shared_ptr<RDFDetail::RCustomColumnBase> entryColumn{
+         new NewColEntry_t(fLoopManager, entryColName, entryColType, std::move(entryColGen), ColumnNames_t{},
+                           fLoopManager->GetNSlots(), newCols)};
       newCols.AddName(entryColName);
-      newCols.AddColumn(entryColumn, entryColName);
+      newCols.AddColumn(std::move(entryColumn), entryColName);
 
       // Slot number column
       const std::string slotColName = "rdfslot_";
@@ -2238,11 +2238,12 @@ private:
       auto slotColGen = [](unsigned int slot) { return slot; };
       using NewColSlot_t = RDFDetail::RCustomColumn<decltype(slotColGen), RDFDetail::CustomColExtraArgs::Slot>;
 
-      auto slotColumn = std::make_shared<NewColSlot_t>(fLoopManager, slotColName, slotColType, std::move(slotColGen),
-                                                       ColumnNames_t{}, fLoopManager->GetNSlots(), newCols);
+      std::shared_ptr<RDFDetail::RCustomColumnBase> slotColumn{new NewColSlot_t(fLoopManager, slotColName, slotColType,
+                                                                                std::move(slotColGen), ColumnNames_t{},
+                                                                                fLoopManager->GetNSlots(), newCols)};
 
       newCols.AddName(slotColName);
-      newCols.AddColumn(slotColumn, slotColName);
+      newCols.AddColumn(std::move(slotColumn), slotColName);
 
       fCustomColumns = std::move(newCols);
 
@@ -2355,12 +2356,12 @@ private:
 
       using NewCol_t = RDFDetail::RCustomColumn<F, CustomColumnType>;
       RDFInternal::RBookedCustomColumns newCols(newColumns);
-      auto newColumn = std::make_shared<NewCol_t>(fLoopManager, name, retTypeName, std::forward<F>(expression),
-                                                  validColumnNames, fLoopManager->GetNSlots(), newCols);
-
+      std::shared_ptr<RDFDetail::RCustomColumnBase> newColumn{
+         new NewCol_t(fLoopManager, name, retTypeName, std::forward<F>(expression), validColumnNames,
+                      fLoopManager->GetNSlots(), newCols)};
 
       newCols.AddName(name);
-      newCols.AddColumn(newColumn, name);
+      newCols.AddColumn(std::move(newColumn), name);
 
       RInterface<Proxied> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 


### PR DESCRIPTION
Should fix errors such as those at https://bit.ly/2W6cZoc :

```
/home/sftnight/build/night/LABEL/ROOT-centos8/SPEC/default/V/master/build/include/ROOT/RDF/RInterface.hxx:2363:25:
error: no viable conversion from
'shared_ptr<ROOT::Detail::RDF::RCustomColumn<ROOT::VecOps::RVec<ROOT::VecOps::RVec<unsigned
long> > (*)(const ROOT::VecOps::RVec<float> &, const
ROOT::VecOps::RVec<float> &, const ROOT::VecOps::RVec<float> &, const
ROOT::VecOps::RVec<float> &, const ROOT::VecOps::RVec<int> &),
ROOT::Detail::RDF::CustomColExtraArgs::None>>' to 'const
shared_ptr<RDFDetail::RCustomColumnBase>'
      newCols.AddColumn(newColumn, name);
                              ^~~~~~~~~
```