### PR TITLE
Do not veto xrootd tutorials when using built-in xrootd

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -127,7 +127,7 @@ if(NOT ROOT_mpi_FOUND)
   set(mpi_veto io/testTMPIFile.C)
 endif()
 
-if(NOT XROOTD_FOUND)
+if(NOT xrootd)
   set(xrootd_veto dataframe/df101_h1Analysis.C
                   dataframe/df102_NanoAODDimuonAnalysis.C
                   dataframe/df103_NanoAODHiggsAnalysis.C


### PR DESCRIPTION
`XROOTD_FOUND` is only set if using external xrootd.
`xrootd` is set by both external xrootd and built-in xrootd.