### PR TITLE
[ipython] disable key handling in JSROOT

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -58,6 +58,7 @@ _jsCode = """
  require(['JSRootCore'],
      function(Core) {{
        var obj = Core.JSONR_unref({jsonContent});
+       Core.key_handling = false;
        Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
      }}
  );

--- a/bindings/pyroot/JupyROOT/helpers/utils.py
+++ b/bindings/pyroot/JupyROOT/helpers/utils.py
@@ -92,6 +92,7 @@ function display_{jsDivId}() {{
     require(['scripts/JSRootCore'],
         function(Core) {{
             var obj = Core.JSONR_unref({jsonContent});
+            Core.key_handling = false;
             Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
         }}
     );


### PR DESCRIPTION
While iPython notebook web page typically has scrolling and edit area,
keyboard events are used for different operations. Therefore JSROOT should
not process there events for zooming or camera moving in 3D.

Will have an effect after merging of #5565, where latest JSROOT with correspondent feature is provided.

Solves problem, reported [on the forum](https://root-forum.cern.ch/t/39201)