### PR TITLE
[CMake][Exp PyROOT] Hardcode PYTHON_EXECUTABLE in python scripts shebang

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -51,7 +51,7 @@ foreach(rawUtilName ${utils})
     # We need the .py only on Windows
     string(REPLACE ".py" "" utilName ${utilName})
   endif()
-  get_filename_component(python ${PYTHON_EXECUTABLE} NAME)
+  set(python ${PYTHON_EXECUTABLE})
   configure_file(${rawUtilName} ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/${utilName} @ONLY)
 
   install(FILES ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/${utilName}


### PR DESCRIPTION
The command

get_filename_component(python ${PYTHON_EXECUTABLE} NAME)

sets the variable "python" to e.g. "python3.6" if the value of
PYTHON_EXECUTABLE is "/usr/bin/python3.6".

The value of the variable "python" ends up in all the shebangs of the
python scripts (rootls, rootmkdir, ecc.).
With this approach, if the content of the variable "python" is a
symlink to a python interpreter different from the one used to build
ROOT, we see a crash everytime a python script with a shebang is called.

Reported here: https://sft.its.cern.ch/jira/browse/ROOT-10720