### PR TITLE
[TTreeReader] Make ESetupStatus values non-ambiguous

### DIFF
--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -46,7 +46,7 @@ Base class of TTreeReaderValue.
       enum ESetupStatus {
          kSetupNotSetup = -7, /// No initialization has happened yet.
          kSetupTreeDestructed = -8, /// The TTreeReader has been destructed / not set.
-         kSetupMakeClassModeMismatch = -7, // readers disagree on whether TTree::SetMakeBranch() should be on
+         kSetupMakeClassModeMismatch = -9, // readers disagree on whether TTree::SetMakeBranch() should be on
          kSetupMissingCounterBranch = -6, /// The array cannot find its counter branch: Array[CounterBranch]
          kSetupMissingBranch = -5, /// The specified branch cannot be found.
          kSetupInternalError = -4, /// Some other error - hopefully the error message helps.
@@ -54,7 +54,7 @@ Base class of TTreeReaderValue.
          kSetupMismatch = -2, /// Mismatch of branch type and reader template type.
          kSetupNotACollection = -1, /// The branch class type is not a collection.
          kSetupMatch = 0, /// This branch has been set up, branch data type and reader template type match, reading should succeed.
-         kSetupMatchBranch = 0, /// This branch has been set up, branch data type and reader template type match, reading should succeed.
+         kSetupMatchBranch = 7, /// This branch has been set up, branch data type and reader template type match, reading should succeed.
          //kSetupMatchConversion = 1, /// This branch has been set up, the branch data type can be converted to the reader template type, reading should succeed.
          //kSetupMatchConversionCollection = 2, /// This branch has been set up, the data type of the branch's collection elements can be converted to the reader template type, reading should succeed.
          //kSetupMakeClass = 3, /// This branch has been set up, enabling MakeClass mode for it, reading should succeed.

--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -76,7 +76,11 @@ Base class of TTreeReaderValue.
       template <BranchProxyRead_t Func>
       ROOT::Internal::TTreeReaderValueBase::EReadStatus ProxyReadTemplate();
 
+      /// Return true if the branch was setup \em and \em read correctly.
+      /// Use GetSetupStatus() to only check the setup status.
       Bool_t IsValid() const { return fProxy && 0 == (int)fSetupStatus && 0 == (int)fReadStatus; }
+      /// Return this TTreeReaderValue's setup status.
+      /// Use this method to check e.g. whether the TTreeReaderValue is correctly setup and ready for reading.
       ESetupStatus GetSetupStatus() const { return fSetupStatus; }
       virtual EReadStatus GetReadStatus() const { return fReadStatus; }
 


### PR DESCRIPTION
TTreeReaderValueBase::ESetupStatus contained two enumerators with value -7
and two with value 0. In both cases, one of the ambiguous enumerators was
actually unused, and it was changed to have an unambiguous value.

Also add docs for `IsValid` and `GetSetupStatus`.