### PR TITLE
[cmake] set variable in parent scope at very end of function

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -196,10 +196,6 @@ function(REFLEX_GENERATE_DICTIONARY dictionary)
   IF(TARGET ${dictionary})
     target_sources(${dictionary} PRIVATE ${gensrcdict})
   ENDIF()
-  # FIXME: Do not set gensrcdict variable to the outer scope but use an argument to
-  # REFLEX_GENERATE_DICTIONARY passed from the outside. Note this would be a
-  # breaking change for roottest and other external users.
-  set(gensrcdict ${dictionary}.cxx PARENT_SCOPE)
 
   #---roottest compability---------------------------------
   if(CMAKE_ROOTTEST_DICT)
@@ -214,6 +210,11 @@ function(REFLEX_GENERATE_DICTIONARY dictionary)
     # well before the dependent libraries of the dictionary are build
     add_custom_target(${targetname} ALL DEPENDS ${gensrcdict})
   endif()
+
+  # FIXME: Do not set gensrcdict variable to the outer scope but use an argument to
+  # REFLEX_GENERATE_DICTIONARY passed from the outside. Note this would be a
+  # breaking change for roottest and other external users.
+  set(gensrcdict ${dictionary}.cxx PARENT_SCOPE)
 
 endfunction()
 


### PR DESCRIPTION
Command set variable in parent scope which is identical with variable in local scope. I suspect, that sometime `cmake` makes failure. In principle, it is the only place in roottest - we could just avoid usage of that variable at all. 

Trying to fix sporadic problem like [here](https://lcgapp-services.cern.ch/root-jenkins/job/root-pullrequests-build/81406/testReport/projectroot.roottest.root/multicore/roottest_root_multicore_tclass_methods_libgen_build/)

Output is:
```
Generating tclass_methods.cxx, tclass_methods.rootmap
Building CXX object roottest/root/multicore/CMakeFiles/roottest-root-multicore-tclass_methods-libgen.dir/tclass_methods.cxx.o
clang: error: no such file or directory: '/Users/sftnight/build/workspace/root-pullrequests-build/build/roottest/root/multicore/tclass_methods.cxx'
clang: error: no input files
make[1]: *** [roottest/root/multicore/CMakeFiles/roottest-root-multicore-tclass_methods-libgen.dir/tclass_methods.cxx.o] Error 1
make: *** [roottest-root-multicore-tclass_methods-libgen/fast] Error 2
```

