### PR TITLE
[cppyy] Port upstream changes to fix inheritance in Python

### DIFF
--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/inc/CPyCppyy/API.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/inc/CPyCppyy/API.h
@@ -166,6 +166,9 @@ CPYCPPYY_EXTERN bool Scope_CheckExact(PyObject* pyobject);
 CPYCPPYY_EXTERN bool Instance_Check(PyObject* pyobject);
 CPYCPPYY_EXTERN bool Instance_CheckExact(PyObject* pyobject);
 
+// helper to verify expected safety of moving an instance into C++
+CPYCPPYY_EXTERN bool Instance_IsLively(PyObject* pyobject);
+
 // type verifiers for C++ Overload
 CPYCPPYY_EXTERN bool Overload_Check(PyObject* pyobject);
 CPYCPPYY_EXTERN bool Overload_CheckExact(PyObject* pyobject);

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/API.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/API.cxx
@@ -165,6 +165,21 @@ bool CPyCppyy::Instance_CheckExact(PyObject* pyobject)
 }
 
 //-----------------------------------------------------------------------------
+bool CPyCppyy::Instance_IsLively(PyObject* pyobject)
+{
+// Test whether the given instance can safely return to C++, or whether
+    if (!CPPInstance_Check(pyobject))
+        return true;    // simply don't know
+
+// the instance fails the lively test if it owns the C++ object while having a
+// reference count of 1 (meaning: it could delete the C++ instance any moment)
+    if (pyobject->ob_refcnt <= 1 && (((CPPInstance*)pyobject)->fFlags & CPPInstance::kIsOwner))
+        return false;
+
+    return true;
+}
+
+//-----------------------------------------------------------------------------
 bool CPyCppyy::Overload_Check(PyObject* pyobject)
 {
 // Test if the given pyobject is of CPPOverload derived type.

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
@@ -2725,7 +2725,7 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, dims
     }
 
 //-- special case: initializer list
-    if (realType.compare(0, 21, "std::initializer_list") == 0) {
+    if (realType.compare(0, 16, "initializer_list") == 0) {
     // get the type of the list and create a converter (TODO: get hold of value_type?)
         auto pos = realType.find('<');
         std::string value_type = realType.substr(pos+1, realType.size()-pos-2);

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/DeclareConverters.h
@@ -346,7 +346,7 @@ CPPYY_DECLARE_BASIC_CONVERTER(PyObject);
 
 
 #define CPPYY_DECLARE_STRING_CONVERTER(name, strtype)                        \
-class name##Converter : public InstancePtrConverter {                        \
+class name##Converter : public InstanceConverter {                           \
 public:                                                                      \
     name##Converter(bool keepControl = true);                                \
 public:                                                                      \

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Dispatcher.cxx
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Dispatcher.cxx
@@ -48,7 +48,7 @@ static inline void InjectMethod(Cppyy::TCppMethod_t method, const std::string& m
     code << ", NULL);\n    Py_DECREF(mtPyName);\n";
 
 // close
-    Utility::ConstructCallbackReturn(retType == "void", nArgs, code);
+    Utility::ConstructCallbackReturn(retType, nArgs, code);
 }
 
 //----------------------------------------------------------------------------

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Utility.h
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Utility.h
@@ -40,7 +40,7 @@ std::string ConstructTemplateArgs(
 // helper for generating callbacks
 void ConstructCallbackPreamble(const std::string& retType,
     const std::vector<std::string>& argtypes, std::ostringstream& code);
-void ConstructCallbackReturn(bool isVoid, int nArgs, std::ostringstream& code);
+void ConstructCallbackReturn(const std::string& retType, int nArgs, std::ostringstream& code);
 
 // initialize proxy type objects
 bool InitProxy(PyObject* module, PyTypeObject* pytype, const char* name);

--- a/bindings/pyroot_experimental/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot_experimental/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -1821,10 +1821,7 @@ std::string Cppyy::GetDatamemberType(TCppScope_t scope, TCppIndex_t idata)
         TGlobal* gbl = g_globalvars[idata];
         std::string fullType = gbl->GetFullTypeName();
 
-        if (fullType[fullType.size()-1] == '*' && \
-              fullType.compare(0, 4, "char") != 0)
-            fullType.append("*");
-        else if ((int)gbl->GetArrayDim() > 1)
+        if ((int)gbl->GetArrayDim() > 1)
             fullType.append("*");
         else if ((int)gbl->GetArrayDim() == 1) {
             std::ostringstream s;

--- a/bindings/pyroot_experimental/cppyy/patches/initializer_list_converter.patch
+++ b/bindings/pyroot_experimental/cppyy/patches/initializer_list_converter.patch
@@ -1,0 +1,13 @@
+diff --git a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
+index 8dbd9e5fa1..bc6c42efeb 100644
+--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
++++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/src/Converters.cxx
+@@ -2725,7 +2725,7 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, dims
+     }
+ 
+ //-- special case: initializer list
+-    if (realType.compare(0, 21, "std::initializer_list") == 0) {
++    if (realType.compare(0, 16, "initializer_list") == 0) {
+     // get the type of the list and create a converter (TODO: get hold of value_type?)
+         auto pos = realType.find('<');
+         std::string value_type = realType.substr(pos+1, realType.size()-pos-2);


### PR DESCRIPTION
* Fixing inheritance of C++ classes in Python and callbacks to C++ with
  object created in Python
* See upstream issue https://bitbucket.org/wlav/cppyy/issues/229/issue-with-python-class-that-derives-from
* Ports following commits of cppyy-backend: 4670bcf0d82d2f1650f739115576a884f51340f6
* Ports following commits of CPyCppyy:
  9d0eca19281a0f38c9cd80628279f1c76f5fe71c,
  398347bd01b693d0f4e7d2c6cef5c9d30adba2b5, 96de8a868b214eeb4be0f4be4914224ba7de6805