### PR TITLE
[RF] Fix crash in RooAbsAnaConvPdf.

### DIFF
--- a/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
+++ b/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
@@ -100,7 +100,6 @@ protected:
 
   RooListProxy _convSet  ;             //  Set of (resModel (x) basisFunc) convolution objects
   RooArgList _basisList ;              //!  List of created basis functions
-  mutable RooArgSet* _convNormSet ;    //!  Subset of last normalization that applies to convolutions
 
 
   class CacheElem : public RooAbsCacheElement {

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -83,8 +83,7 @@ ClassImp(RooAbsAnaConvPdf);
 /// Default constructor, required for persistence
 
 RooAbsAnaConvPdf::RooAbsAnaConvPdf() :
-  _isCopy(kFALSE),
-  _convNormSet(nullptr)
+  _isCopy(kFALSE)
 {
 }
 
@@ -100,11 +99,9 @@ RooAbsAnaConvPdf::RooAbsAnaConvPdf(const char *name, const char *title,
   _model("!model","Original resolution model",this,(RooResolutionModel&)model,kFALSE,kFALSE),
   _convVar("!convVar","Convolution variable",this,cVar,kFALSE,kFALSE),
   _convSet("!convSet","Set of resModel X basisFunc convolutions",this),
-  _convNormSet(nullptr),
   _coefNormMgr(this,10),
   _codeReg(10)
 {
-  _convNormSet = new RooArgSet(cVar,"convNormSet") ;
   _model.absArg()->setAttribute("NOCacheAndTrack") ;
 }
 
@@ -117,8 +114,6 @@ RooAbsAnaConvPdf::RooAbsAnaConvPdf(const RooAbsAnaConvPdf& other, const char* na
   _model("!model",this,other._model),
   _convVar("!convVar",this,other._convVar),
   _convSet("!convSet",this,other._convSet),
-  // _basisList(other._basisList),
-  _convNormSet(other._convNormSet? new RooArgSet(*other._convNormSet) : new RooArgSet() ),
   _coefNormMgr(other._coefNormMgr,this),
   _codeReg(other._codeReg)
 {
@@ -136,10 +131,6 @@ RooAbsAnaConvPdf::RooAbsAnaConvPdf(const RooAbsAnaConvPdf& other, const char* na
 
 RooAbsAnaConvPdf::~RooAbsAnaConvPdf()
 {
-  if (_convNormSet) {
-    delete _convNormSet ;
-  }
-
   if (!_isCopy) {
     std::vector<RooAbsArg*> tmp(_convSet.begin(), _convSet.end());
 


### PR DESCRIPTION
RooAbsAnaConvPdf was carrying around a RooArgSet, which was
not used anywhere. This RooArgSet, however, was carrying around a
pointer to a variable, which becomes a dangling pointer when one creates
copies of the RooAbsAnaConvPdf and deletes the original.
Removing this member fixes crashes when invoking copy constructors.