### PR TITLE
Suppress Vc compilation warnings observed in gcc version 10

### DIFF
--- a/math/mathcore/inc/Math/Types.h
+++ b/math/mathcore/inc/Math/Types.h
@@ -10,6 +10,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wconditional-uninitialized"


### PR DESCRIPTION
The warnings are coming when including the Vc/Vc header :

warning: ‘V2 Vc_1::Vector<T, Vc_1::VectorAbi::Scalar>::reinterpretCast() const’ is deprecated: use reinterpret_components_cast instead [-Wdeprecated-declarations]

Add a pragma to suppress  -Wdeprecated-declarations in Types.h