### PR TITLE
[CMake] Add automatic FAILREGEX for gtests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,6 +600,10 @@ endif()
 configure_file(${CMAKE_SOURCE_DIR}/cmake/modules/CTestCustom.cmake ${CMAKE_BINARY_DIR} COPYONLY)
 if(testing)
   include(RootCTest)
+
+  # ROOTUnitTestSupport for google tests:
+  add_subdirectory(test/unit_testing_support)
+
   if(roottest)
     #---Is the roottest source directory around?
     if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/roottest)

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1757,12 +1757,6 @@ function(ROOT_ADD_GTEST test_suite)
     "REPEATS;FAILREGEX"
     "COPY_TO_BUILDDIR;LIBRARIES;LABELS;INCLUDE_DIRS" ${ARGN})
 
-  # ROOTUnitTestSupport
-  if(NOT TARGET ROOTUnitTestSupport)
-    add_library(ROOTUnitTestSupport INTERFACE)
-    target_include_directories(ROOTUnitTestSupport INTERFACE ${CMAKE_SOURCE_DIR}/test/unit_testing_support)
-  endif()
-
   ROOT_GET_SOURCES(source_files . ${ARG_UNPARSED_ARGUMENTS})
   # Note we cannot use ROOT_EXECUTABLE without user-specified set of LIBRARIES to link with.
   # The test suites should choose this in their specific CMakeLists.txt file.

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1742,15 +1742,20 @@ endfunction()
 
 #----------------------------------------------------------------------------
 # function ROOT_ADD_GTEST(<testsuite> source1 source2...
-#                        [WILLFAIL]
-#                        [COPY_TO_BUILDDIR file1 file2...] -- files to copy in the build directory
+#                        [WILLFAIL] Negate output of test
+#                        [COPY_TO_BUILDDIR file1 file2] Copy listed files when ctest invokes the test.
 #                        [LIBRARIES lib1 lib2...] -- Libraries to link against
 #                        [LABELS label1 label2...] -- Labels to annotate the test
 #                        [INCLUDE_DIRS label1 label2...] -- Extra target include directories
 #                        [REPEATS number] -- Repeats testsuite `number` times, stopping at the first failure.
-
+#                        [FAILREGEX ...] Fail test if this regex matches.
+# Creates a new googletest exectuable, and registers it as a test.
+#----------------------------------------------------------------------------
 function(ROOT_ADD_GTEST test_suite)
-  CMAKE_PARSE_ARGUMENTS(ARG "WILLFAIL" "REPEATS" "COPY_TO_BUILDDIR;LIBRARIES;LABELS;INCLUDE_DIRS" ${ARGN})
+  cmake_parse_arguments(ARG
+    "WILLFAIL"
+    "REPEATS;FAILREGEX"
+    "COPY_TO_BUILDDIR;LIBRARIES;LABELS;INCLUDE_DIRS" ${ARGN})
 
   # ROOTUnitTestSupport
   if(NOT TARGET ROOTUnitTestSupport)
@@ -1795,6 +1800,7 @@ function(ROOT_ADD_GTEST test_suite)
     COPY_TO_BUILDDIR ${ARG_COPY_TO_BUILDDIR}
     ${willfail}
     ${labels}
+    FAILREGEX ${ARG_FAILREGEX}
   )
 endfunction()
 

--- a/core/base/test/TStringTest.cxx
+++ b/core/base/test/TStringTest.cxx
@@ -12,7 +12,6 @@ TEST(TString, Basics)
    TString p("Test", 1);
    EXPECT_STREQ("T", p);
    TString a = "test";
-   a.Append("s", -5);
-   EXPECT_STREQ("test", a);
    ROOT_EXPECT_ERROR(a.Append("s", -5), "TString::Replace", "Negative number of replacement characters!");
+   EXPECT_STREQ("test", a);
 }

--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -39,14 +39,14 @@
 
 class TVirtualMutex;
 
-const Int_t kUnset    =  -1;
-const Int_t kPrint    =   0;
-const Int_t kInfo     =   1000;
-const Int_t kWarning  =   2000;
-const Int_t kError    =   3000;
-const Int_t kBreak    =   4000;
-const Int_t kSysError =   5000;
-const Int_t kFatal    =   6000;
+constexpr Int_t kUnset    =  -1;
+constexpr Int_t kPrint    =   0;
+constexpr Int_t kInfo     =   1000;
+constexpr Int_t kWarning  =   2000;
+constexpr Int_t kError    =   3000;
+constexpr Int_t kBreak    =   4000;
+constexpr Int_t kSysError =   5000;
+constexpr Int_t kFatal    =   6000;
 
 
 // TROOT sets the error ignore level handler, the system error message handler, and the error abort handler on

--- a/core/foundation/v7/test/base_exception.cxx
+++ b/core/foundation/v7/test/base_exception.cxx
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
+#include "ROOTUnitTestSupport.h"
+
 #include <ROOT/RError.hxx>
 
 #include <memory>
@@ -125,6 +127,11 @@ TEST(Exception, CheckReturnValue)
 
 TEST(Exception, DoubleThrow)
 {
+   // We have to suppress a warning because of the double throw.
+   ROOTUnitTestSupport::FilterDiagsRAII filterDiags{ [](int /*severity*/, bool, const char* /*location*/, const char* msg) {
+      EXPECT_STREQ(msg, "unhandled RResult exception during stack unwinding");
+   }};
+
    try {
       auto rv = TestFailure();
       // Throwing ExceptionX will destruct rv along the way. Since rv carries an error state, it would normally

--- a/core/imt/test/CMakeLists.txt
+++ b/core/imt/test/CMakeLists.txt
@@ -4,4 +4,6 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-ROOT_ADD_GTEST(testImt testRTaskArena.cxx testTBBGlobalControl.cxx testTFuture.cxx testTTaskGroup.cxx LIBRARIES Imt ${TBB_LIBRARIES})
+ROOT_ADD_GTEST(testImt testTFuture.cxx testTTaskGroup.cxx LIBRARIES Imt)
+ROOT_ADD_GTEST(testTaskArena testRTaskArena.cxx LIBRARIES Imt ${TBB_LIBRARIES} FAILREGEX "")
+ROOT_ADD_GTEST(testTBBGlobalControl testTBBGlobalControl.cxx LIBRARIES Imt ${TBB_LIBRARIES})

--- a/core/imt/test/testRTaskArena.cxx
+++ b/core/imt/test/testRTaskArena.cxx
@@ -2,6 +2,9 @@
 #include "ROOT/RTaskArena.hxx"
 #include "ROOT/TThreadExecutor.hxx"
 #include "../src/ROpaqueTaskArena.hxx"
+
+#include "ROOTUnitTestSupport.h"
+
 #include <fstream>
 #include <random>
 #include <thread>
@@ -15,6 +18,11 @@
 const unsigned maxConcurrency = ROOT::Internal::LogicalCPUBandwithControl();
 std::mt19937 randGenerator(0);                                      // seed the generator
 std::uniform_int_distribution<> plausibleNCores(1, maxConcurrency); // define the range
+
+/// Suppress the task arena diagnostics for tests where we try to create the task arena multiple times.
+#define SUPPRESS_DIAG \
+   ROOTUnitTestSupport::CheckDiagsRAII raii; \
+   raii.optionalDiag(kWarning, "RTaskArenaWrapper", "There's already an active task arena", false);
 
 TEST(RTaskArena, Size0WhenNoInstance)
 {
@@ -52,6 +60,7 @@ TEST(RTaskArena, Reconstruction)
 
 TEST(RTaskArena, SingleInstance)
 {
+   SUPPRESS_DIAG;
    const unsigned nCores = plausibleNCores(randGenerator);
    auto gTAInstance1 = ROOT::Internal::GetGlobalTaskArena(nCores);
    auto gTAInstance2 = ROOT::Internal::GetGlobalTaskArena(plausibleNCores(randGenerator));
@@ -68,6 +77,7 @@ TEST(RTaskArena, AccessWorkingTBBtaskArena)
 
 TEST(RTaskArena, KeepSize)
 {
+   SUPPRESS_DIAG
    const unsigned nCores = plausibleNCores(randGenerator);
    auto gTAInstance1 = ROOT::Internal::GetGlobalTaskArena(nCores);
    auto gTAInstance2 = ROOT::Internal::GetGlobalTaskArena(plausibleNCores(randGenerator));
@@ -79,6 +89,7 @@ TEST(RTaskArena, KeepSize)
 
 TEST(RTaskArena, CorrectSizeIMT)
 {
+   SUPPRESS_DIAG
    auto gTAInstance1 = ROOT::Internal::GetGlobalTaskArena();
    ROOT::EnableImplicitMT(plausibleNCores(randGenerator));
    ASSERT_EQ(ROOT::Internal::RTaskArenaWrapper::TaskArenaSize(), maxConcurrency);
@@ -87,6 +98,7 @@ TEST(RTaskArena, CorrectSizeIMT)
 
 TEST(RTaskArena, KeepSizeTThreadExecutor)
 {
+   SUPPRESS_DIAG
    const unsigned nCores = plausibleNCores(randGenerator);
    auto gTAInstance = ROOT::Internal::GetGlobalTaskArena(nCores);
    ROOT::TThreadExecutor threadExecutor(plausibleNCores(randGenerator));
@@ -95,6 +107,7 @@ TEST(RTaskArena, KeepSizeTThreadExecutor)
 
 TEST(RTaskArena, InterleaveAndNest)
 {
+   SUPPRESS_DIAG
    unsigned nCores;
 
    // IMT + GTA

--- a/core/meta/test/testHashRecursiveRemove.cxx
+++ b/core/meta/test/testHashRecursiveRemove.cxx
@@ -164,6 +164,10 @@ void DeclareFailingClasses()
 
 TEST(HashRecursiveRemove, GetClassClassDefInline)
 {
+   // On windows, the following might trigger a warning. Suppress it here:
+   ROOTUnitTestSupport::CheckDiagsRAII diagRAII;
+   diagRAII.optionalDiag(kWarning, "TClassTable::Add", "class WrongSetup already in TClassTable");
+
    DeclareFailingClasses();
 
    auto getcl = TClass::GetClass("FirstOverload");

--- a/core/meta/test/testStatusBitsChecker.cxx
+++ b/core/meta/test/testStatusBitsChecker.cxx
@@ -2,6 +2,7 @@
 
 #include "TClass.h"
 #include "TInterpreter.h"
+#include "ROOTUnitTestSupport.h"
 
 #include "gtest/gtest.h"
 
@@ -26,6 +27,10 @@ TEST(StatusBitsChecker,NoOverlap)
 
 TEST(StatusBitsChecker,Overlap)
 {
+   ROOTUnitTestSupport::CheckDiagsRAII diags;
+   diags.requiredDiag(kError, "TStatusBitsChecker", "ClassWithOverlap", /*matchFullMessage=*/false);
+   diags.requiredDiag(kError, "TStatusBitsChecker", "13 used in",       /*matchFullMessage=*/false);
+
    MakeClassWithOverlap();
    EXPECT_NE(nullptr,TClass::GetClass("ClassWithOverlap"));
    EXPECT_FALSE(ROOT::Detail::TStatusBitsChecker::Check("ClassWithOverlap"));

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -282,8 +282,8 @@ TEST(TClingCallFunc, FunctionWrapperNodiscard)
    {
       using ::testing::Not;
       using ::testing::HasSubstr;
-      FilterDiagsRAII RAII([] (int /*level*/, Bool_t /*abort*/,
-                               const char * /*location*/, const char *msg) {
+      ROOTUnitTestSupport::FilterDiagsRAII RAII([] (int /*level*/, Bool_t /*abort*/,
+                                                    const char * /*location*/, const char *msg) {
          EXPECT_THAT(msg, Not(HasSubstr("-Wunused-result")));
       });
       ASSERT_TRUE(gInterpreter->Declare(wrapper.c_str()));

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -5,6 +5,8 @@
 #include "TROOT.h"
 #include "TSystem.h"
 
+#include "gmock/gmock.h"
+
 #include <sstream>
 #include <string>
 #include <vector>

--- a/hist/hist/test/TFormulaGradientTests.cxx
+++ b/hist/hist/test/TFormulaGradientTests.cxx
@@ -22,6 +22,9 @@
 #include <TF1.h>
 #include <TFitResult.h>
 
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
 TEST(TFormulaGradientPar, Sanity)
 {
    TFormula f("f", "x*std::sin([0]) - y*std::cos([1])");

--- a/hist/hist/test/TFormulaHessianTests.cxx
+++ b/hist/hist/test/TFormulaHessianTests.cxx
@@ -20,6 +20,9 @@
 #include <Math/MinimizerOptions.h>
 #include <TFormula.h>
 
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
 TEST(TFormulaHessianPar, Sanity)
 {
    TFormula f("f", "x*std::sin([0]) - y*std::cos([1])");

--- a/hist/hist/test/test_tf1.cxx
+++ b/hist/hist/test/test_tf1.cxx
@@ -117,7 +117,10 @@ void test_setRange()
    TF1 f2("f2", "CONV(gaus, breitwigner)", 0, 1);
    f2.SetParameters(1, 1, 1, 1, 1, 1);
    f2.SetRange(-100, 100); // making our convolution much more accurate
-   EXPECT_NEAR(f2.Integral(-20, 20), 2.466, .005);
+   // Numeric integration of this function suffers from roundoff errors, so the default 1.E-12 accuracy won't be reached.
+   // By reducing the tolerance, we get rid of a GSL warning, which was picked up by the log checkers.
+   constexpr double tolerance = 1.E-6;
+   EXPECT_NEAR(f2.Integral(-20, 20, tolerance), 2.466, .005);
 }
 
 // Test that we can copy and clone TF1 objects based on NSUM and CONV

--- a/hist/hist/test/test_tf1.cxx
+++ b/hist/hist/test/test_tf1.cxx
@@ -28,7 +28,7 @@ double functionConst(const double *x, const double *p)
    return *x + *p;
 }
 
-Float_t delta = 0.00000000001;
+constexpr Float_t delta = 1.E-11f;
 
 void coeffNamesGeneric(TString &formula, TObjArray *coeffNames)
 {

--- a/math/mathcore/inc/Math/RootFinder.h
+++ b/math/mathcore/inc/Math/RootFinder.h
@@ -221,6 +221,16 @@ namespace ROOT {
 
 #include "Math/Functor.h"
 
+/**
+ * Solve `f(x) = 0`, given a derivative `d`.
+ * @param f Function whose root should be found.
+ * @param d Derivative of the function.
+ * @param start Starting point for iteration.
+ * @param maxIter Maximum number of iterations, passed to Solve(int,double,double)
+ * @param absTol Absolute tolerance, as in Solve(int,double,double)
+ * @param relTol Relative tolerance, passed to Solve(int,double,double)
+ * @return true if a root was found. Retrieve the result using Root().
+ */
 template<class Function, class Derivative>
 bool ROOT::Math::RootFinder::Solve(Function &f, Derivative &d, double start,
                                   int maxIter, double absTol, double relTol)
@@ -232,6 +242,16 @@ bool ROOT::Math::RootFinder::Solve(Function &f, Derivative &d, double start,
    return Solve(maxIter, absTol, relTol);
 }
 
+/**
+ * Solve `f(x) = 0` numerically.
+ * @param f Function whose root should be found.
+ * @param min Minimum allowed value of `x`.
+ * @param max Maximum allowed value of `x`.
+ * @param maxIter Maximum number of iterations, passed to Solve(int,double,double)
+ * @param absTol Absolute tolerance, as in Solve(int,double,double)
+ * @param relTol Relative tolerance, passed to Solve(int,double,double)
+ * @return true if a root was found. Retrieve the result using Root().
+ */
 template<class Function>
 bool ROOT::Math::RootFinder::Solve(Function &f, double min, double max,
                                   int maxIter, double absTol, double relTol)

--- a/roofit/roofit/test/testRooExponential.cxx
+++ b/roofit/roofit/test/testRooExponential.cxx
@@ -12,6 +12,7 @@
 
 #include <numeric>
 
+#include "ROOTUnitTestSupport.h"
 #include "gtest/gtest.h"
 
 double simpleIntegration(RooRealVar& intVar, const RooAbsPdf& pdf) {
@@ -87,6 +88,12 @@ TEST(RooExponential, Integral)
 
 
 TEST(RooExponential, IO) {
+  // Suppress all streamer info warnings. Revert if possible!
+  ROOTUnitTestSupport::CheckDiagsRAII diags;
+  diags.optionalDiag(kWarning, "TStreamerInfo::BuildCheck", "Do not try to write objects with the current class definition", false);
+  diags.optionalDiag(kWarning, "TStreamerInfo::CompareContent", "The following data member of", false);
+  diags.optionalDiag(kWarning, "TClass::Init", "no dictionary for class", false);
+
   TFile file("./exponentialPdf.root");
   ASSERT_TRUE(file.IsOpen());
 

--- a/roofit/roofitcore/test/testProxiesAndCategories.cxx
+++ b/roofit/roofitcore/test/testProxiesAndCategories.cxx
@@ -14,6 +14,7 @@
 #include "TFile.h"
 #include "TMemFile.h"
 
+#include "ROOTUnitTestSupport.h"
 #include "gtest/gtest.h"
 
 
@@ -79,6 +80,13 @@ public:
       outfile.WriteObject(&data, "data")
    */
   void SetUp() override {
+    // Suppress all streamer info warnings. Revert if possible!
+    ROOTUnitTestSupport::CheckDiagsRAII diags;
+    diags.optionalDiag(kWarning, "TStreamerInfo::BuildCheck", "Do not try to write objects with the current class definition", false);
+    diags.optionalDiag(kWarning, "TStreamerInfo::BuildCheck", "has a different checksum than the previously loaded StreamerInfo", false);
+    diags.optionalDiag(kWarning, "TStreamerInfo::CompareContent", "The following data member of", false);
+    diags.optionalDiag(kError,   "TBufferFile::CheckByteCount", "read too few bytes", false);
+
     TFile file(GetParam(), "READ");
     ASSERT_TRUE(file.IsOpen());
 
@@ -228,6 +236,14 @@ TEST(RooTemplateProxy, CategoryProxy) {
 
 // Read a simple v6.20 workspace to test proxy schema evolution
 TEST(RooProxy, Read6_20) {
+  // Suppress all streamer info warnings. Revert if possible!
+  ROOTUnitTestSupport::CheckDiagsRAII diags;
+  diags.optionalDiag(kWarning, "TStreamerInfo::BuildCheck", "Do not try to write objects with the current class definition", false);
+  diags.optionalDiag(kWarning, "TStreamerInfo::BuildCheck", "has a different checksum than the previously loaded StreamerInfo", false);
+  diags.optionalDiag(kWarning, "TStreamerInfo::CompareContent", "The following data member of", false);
+  diags.optionalDiag(kError,   "TBufferFile::CheckByteCount", "read too few bytes", false);
+  diags.optionalDiag(kWarning, "TClass::Init", "no dictionary for class", false);
+
   TFile file("testProxiesAndCategories_1.root", "READ");
   ASSERT_TRUE(file.IsOpen());
 

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -16,6 +16,7 @@
 #include "TMath.h"
 #include "TFile.h"
 
+#include "ROOTUnitTestSupport.h"
 #include "gtest/gtest.h"
 
 #include <algorithm>
@@ -183,6 +184,14 @@ TEST(RooDataHist, WeightedEntries)
 class RooDataHistIO : public testing::TestWithParam<const char*> {
 public:
   void SetUp() override {
+    // Suppress all streamer info warnings. Revert if possible!
+    ROOTUnitTestSupport::CheckDiagsRAII diags;
+    diags.optionalDiag(kWarning, "TStreamerInfo::BuildCheck", "Do not try to write objects with the current class definition", false);
+    diags.optionalDiag(kWarning, "TStreamerInfo::BuildCheck", "has a different checksum than the previously loaded StreamerInfo", false);
+    diags.optionalDiag(kWarning, "TStreamerInfo::CompareContent", "The following data member of", false);
+    diags.optionalDiag(kError,   "TBufferFile::CheckByteCount", "read too few bytes", false);
+    diags.optionalDiag(kWarning, "TClass::Init", "no dictionary for class", false);
+
     TFile file(GetParam(), "READ");
     ASSERT_TRUE(file.IsOpen());
 
@@ -199,7 +208,6 @@ protected:
 };
 
 TEST_P(RooDataHistIO, ReadLegacy) {
-
   RooDataHist& dataHist = *legacy;
 
   constexpr double targetBinContent = 20.;

--- a/roofit/roofitcore/test/testRooFormula.cxx
+++ b/roofit/roofitcore/test/testRooFormula.cxx
@@ -4,6 +4,8 @@
 #include "RooFormula.h"
 #include "RooRealVar.h"
 
+#include "ROOTUnitTestSupport.h"
+
 #include "gtest/gtest.h"
 
 /// Since TFormula does very surprising things,
@@ -15,6 +17,13 @@
 /// is, for example, legal, and silently uses an undefined
 /// value for y. RooFit needs to detect this.
 TEST(RooFormula, TestInvalidFormulae) {
+  ROOTUnitTestSupport::CheckDiagsRAII checkDiag;
+  checkDiag.requiredDiag(kError, "prepareMethod", "Can't compile function TFormula", false);
+  checkDiag.requiredDiag(kError, "TFormula::InputFormulaIntoCling", "Error compiling formula expression in Cling", true);
+  checkDiag.requiredDiag(kError, "TFormula::ProcessFormula", " is invalid", false);
+  checkDiag.requiredDiag(kError, "TFormula::ProcessFormula", "has not been matched in the formula expression", false);
+  checkDiag.requiredDiag(kError, "cling", "undeclared identifier", false);
+
   RooRealVar x("x", "x", 1.337);
   RooRealVar y("y", "y", -1.);
   RooFormula form("form", "x+10", x);

--- a/roofit/roofitcore/test/testRooRealVar.cxx
+++ b/roofit/roofitcore/test/testRooRealVar.cxx
@@ -7,6 +7,7 @@
 
 #include <TFile.h>
 
+#include "ROOTUnitTestSupport.h"
 #include "gtest/gtest.h"
 
 /// ROOT-10781
@@ -54,6 +55,12 @@ TEST(RooRealVar, AlternativeBinnings)
 TEST(RooRealVar, AlternativeBinningsPersistency) {
   RooArgSet localCopy;
   {
+    // Suppress all streamer info warnings. Revert if possible!
+    ROOTUnitTestSupport::CheckDiagsRAII diags;
+    diags.optionalDiag(kWarning, "TStreamerInfo::BuildCheck", "Do not try to write objects with the current class definition", false);
+    diags.optionalDiag(kWarning, "TStreamerInfo::CompareContent", "The following data member of", false);
+    diags.optionalDiag(kWarning, "TClass::Init", "no dictionary for class", false);
+
     TFile infile("testRooRealVar_data1.root");
     ASSERT_TRUE(infile.IsOpen());
 

--- a/roofit/roostats/test/testHypoTestInvResult.cxx
+++ b/roofit/roostats/test/testHypoTestInvResult.cxx
@@ -3,6 +3,7 @@
 
 #include "TFile.h"
 
+#include "ROOTUnitTestSupport.h"
 #include "gtest/gtest.h"
 
 using namespace RooStats;
@@ -10,6 +11,12 @@ using namespace RooStats;
 /// Test that we can correctly read a HypoTestInverterResult
 TEST(HypoTestInvResult, ReadFromFile)
 {
+  // Suppress all streamer info warnings. Revert if possible!
+  ROOTUnitTestSupport::CheckDiagsRAII diags;
+  diags.optionalDiag(kWarning, "TStreamerInfo::BuildCheck", "Do not try to write objects with the current class definition", false);
+  diags.optionalDiag(kWarning, "TStreamerInfo::CompareContent", "The following data member of", false);
+  diags.optionalDiag(kWarning, "TClass::Init", "no dictionary for class", false);
+
   const char* filename = "testHypoTestInvResult_1.root";
 
   TFile file(filename, "READ");

--- a/test/unit_testing_support/CMakeLists.txt
+++ b/test/unit_testing_support/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(ROOTUnitTestSupport OBJECT ROOTUnitTestSupport.cxx)
+target_include_directories(ROOTUnitTestSupport INTERFACE .)
+target_link_libraries(ROOTUnitTestSupport PUBLIC Core gtest)
+

--- a/test/unit_testing_support/ROOTUnitTestSupport.cxx
+++ b/test/unit_testing_support/ROOTUnitTestSupport.cxx
@@ -60,6 +60,12 @@ static struct ForbidDiagnostics {
         return;
       }
 
+      // FIXME: DOAS backend is exprimental.
+      if (level == kWarning
+          && strstr(msg, "The DAOS backend is experimental and still under development") != nullptr) {
+        std::cerr << "Warning in " << location << " " << msg << std::endl;
+        return;
+      }
 
       FAIL() << "Received unexpected diagnostic of severity "
          << level

--- a/test/unit_testing_support/ROOTUnitTestSupport.cxx
+++ b/test/unit_testing_support/ROOTUnitTestSupport.cxx
@@ -47,6 +47,12 @@ static struct ForbidDiagnostics {
          ::abort();
       }
 
+      // FIXME: Windows has problem finding PCMs.
+      if (level == kError && strcmp(location, "TCling::LoadPCM") == 0 && strstr(msg, "file does not exist") != nullptr) {
+        std::cerr << "Error in " << location << " " << msg << std::endl;
+        return;
+      }
+
       FAIL() << "Received unexpected diagnostic of severity "
          << level
          << " at '" << location << "' reading '" << msg << "'.\n"

--- a/test/unit_testing_support/ROOTUnitTestSupport.cxx
+++ b/test/unit_testing_support/ROOTUnitTestSupport.cxx
@@ -1,0 +1,80 @@
+/// \brief This file contains a specialised ROOT message handler to test for diagnostic in unit tests.
+///
+/// \author Stephan Hageboeck <stephan.hageboeck@cern.ch>
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOTUnitTestSupport.h"
+
+#include <algorithm>
+#include <iostream>
+#include <iomanip>
+
+namespace ROOTUnitTestSupport {
+
+CheckDiagsRAII * CheckDiagsRAII::sActiveInstance = nullptr;
+
+CheckDiagsRAII::~CheckDiagsRAII() {
+   sActiveInstance = fOldInstance;
+   ::SetErrorHandler(fOldErrorHandler);
+   gInterpreter->ReportDiagnosticsToErrorHandler(/*enable=*/false);
+
+   if (!fUnexpectedDiags.empty()) ADD_FAILURE() << "ROOTUnitTestSupport::CheckDiagsRAII: Unexpected diagnostic messages received.";
+
+   const bool missingDiag = std::any_of(fExpectedDiags.begin(), fExpectedDiags.end(), [](const Diag_t & diag){ return !diag.optional && diag.receivedCount < 1; });
+   if (missingDiag) ADD_FAILURE() << "ROOTUnitTestSupport::CheckDiagsRAII: Diagnostic message missing.";
+
+   if (!fUnexpectedDiags.empty() || missingDiag) {
+      std::cout << "-------------------------\nPre-registered messages:\n";
+      printDiags(fExpectedDiags);
+      std::cout << "Unexpected messages received:\n";
+      printDiags(fUnexpectedDiags);
+      std::cout << "-------------------------" << std::endl;
+   }
+}
+
+/// Search list of expected diagnostics for given arguments, and increase the receivedCount.
+/// If no matching predefined diagnostic is found, this will trigger an unexpected diagnostic error on exit.
+void CheckDiagsRAII::checkDiag(int severity, const char * location, const char * msg) {
+   // Check that this received diagnostics was expected
+   const std::string message = msg;
+   const auto expectedMatch = std::find_if(fExpectedDiags.begin(), fExpectedDiags.end(), [=](const Diag_t& expectedDiag){
+         return expectedDiag.severity == severity
+         && strstr(location, expectedDiag.location.c_str()) != nullptr
+         && (expectedDiag.matchFullString ? expectedDiag.message == message : (message.find(expectedDiag.message) != std::string::npos));
+         });
+
+    if (expectedMatch != fExpectedDiags.end()) {
+       expectedMatch->receivedCount += 1;
+    } else if (severity <= kInfo) {
+       fOldErrorHandler(severity, false, location, msg);
+    } else {
+       fUnexpectedDiags.push_back({severity, location, std::move(message)});
+    }
+}
+
+void CheckDiagsRAII::printDiags(std::vector<Diag_t> const & diags) const {
+   std::map<int, std::string> dict = {
+      {kInfo, "kInfo"},
+      {kWarning, "kWarning"},
+      {kError, "kError"},
+      {kSysError, "kSysError"}
+   };
+
+   for (auto const & diag : diags) {
+      std::cout << std::setw(10) << dict[diag.severity] << "\t";
+      if (diag.receivedCount >=  0) {
+         std::cout << diag.receivedCount << "x received\t"
+            << "(" << (diag.optional ? "optional" : "required") << ", " << (diag.matchFullString ? "fullMatch" : "subMatch") << ")\t";
+      }
+      std::cout << "'" << diag.location << "' msg='" << diag.message << "'\n";
+   }
+}
+
+}

--- a/test/unit_testing_support/ROOTUnitTestSupport.cxx
+++ b/test/unit_testing_support/ROOTUnitTestSupport.cxx
@@ -53,6 +53,14 @@ static struct ForbidDiagnostics {
         return;
       }
 
+      // FIXME: RNTuple warns that it's in beta stage.
+      if (level == kWarning
+          && strstr(msg, "The RNTuple file format will change. Do not store real data with this version of RNTuple!") != nullptr) {
+        std::cerr << "Warning in " << location << " " << msg << std::endl;
+        return;
+      }
+
+
       FAIL() << "Received unexpected diagnostic of severity "
          << level
          << " at '" << location << "' reading '" << msg << "'.\n"

--- a/test/unit_testing_support/ROOTUnitTestSupport.h
+++ b/test/unit_testing_support/ROOTUnitTestSupport.h
@@ -4,6 +4,7 @@
 ///
 /// \author Pratyush Das <reikdas@gmail.com>
 /// \author Vassil Vassilev <vvasilev@cern.ch>
+/// \author Stephan Hageboeck <stephan.hageboeck@cern.ch>
 ///
 /// \date April, 2020
 
@@ -21,17 +22,14 @@
 #include "TError.h"
 #include "TInterpreter.h"
 
+#include <stdexcept>
+#include <vector>
+
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
-namespace {
-using testing::StartsWith;
-using testing::StrEq;
-using testing::internal::GetCapturedStderr;
-using testing::internal::CaptureStderr;
-using testing::internal::RE;
+namespace ROOTUnitTestSupport {
 
-/// \brief Allows a user function to filter ROOT/cling diagnostics, e.g.
+/// \brief Allows a user function to catch and filter/analyse ROOT and cling diagnostics, e.g.
 /// ```c++
 /// FilterDiagsRAII RAII([] (int level, Bool_t abort,
 ///                          const char *location, const char *msg) {
@@ -40,7 +38,7 @@ using testing::internal::RE;
 /// ```
 class FilterDiagsRAII {
    ErrorHandlerFunc_t fPrevHandler;
-public:
+   public:
    FilterDiagsRAII(ErrorHandlerFunc_t fn) : fPrevHandler(::GetErrorHandler()) {
       ::SetErrorHandler(fn);
       gInterpreter->ReportDiagnosticsToErrorHandler();
@@ -51,112 +49,144 @@ public:
    }
 };
 
-class ExpectedDiagRAII {
-public:
-   enum ExpectedDiagKind {
-      EDK_NoDiag = 0,
-      EDK_Info,
-      EDK_Warning,
-      EDK_Error,
-      EDK_SysError
-   };
-private:
-   ExpectedDiagKind fDiagKind;
-   std::string fExpectedRoutine;
-   std::string fExpectedDiag;
-   void pop()
+/// Install a ROOT diagnostic handler to analyse diagnostics.
+/// It will record all diagnostics during its lifetime, and analyse them at destruction.
+/// Required and/or optional diagnostics need to be predefined with expected location and message.
+/// Unexpected or missing diagnostics will lead to gtest failures.
+///
+/// Example:
+/// ```c++
+/// CheckDiagsRAII diagRAII{CheckDiagsRAII::EDK_Error, "TFile::TFile", "<Expected message>"};
+/// diagRAII.optionalDiag(kInfo, "TFile::TFile", "Message that is issued only sometimes");
+/// <test code>
+///
+/// ```
+class CheckDiagsRAII {
+   public:
+      /// Register this instance as diagnostic handler.
+      /// With no further action, any diagnostic will lead to a test failure.
+      CheckDiagsRAII():
+         fOldInstance(sActiveInstance),
+         fOldErrorHandler(::GetErrorHandler())
    {
-      // Diagnostics in ROOT have the format:
-      // Error|Warning|Info|...| in <Routine>: free text
-      std::string Seen = GetCapturedStderr();
+      sActiveInstance = this;
+      ::SetErrorHandler(CheckDiagsRAII::callback);
+      gInterpreter->ReportDiagnosticsToErrorHandler(/*enable=*/true);
+   }
 
-      // Try to reconstruct the precise expected string.
-      std::string Expected;
-      switch(fDiagKind) {
-      default:
-         assert (0 && "Unsupported diag kind.");
-         break;
-      case EDK_NoDiag:
-         EXPECT_THAT(Seen, StrEq(""));
-         return;
-      case EDK_Error:
-         Expected = "Error";
-         break;
-      case EDK_Warning:
-         Expected = "Warning";
-         break;
-      case EDK_Info:
-         Expected = "Info";
-         break;
-      case EDK_SysError:
-         Expected = "SysError";
-         break;
+      /// Construct from ROOT's `kWarning, kError, ...` and strings specifying location and message.
+      CheckDiagsRAII(int severity, std::string inRoutine, std::string E)
+         : CheckDiagsRAII()
+      {
+         requiredDiag(severity, inRoutine, E);
       }
 
-      // Check if the Diag kind matches what we saw.
-      EXPECT_THAT(Seen, StartsWith(Expected));
+      ~CheckDiagsRAII();
 
-      Expected += " in ";
-      Expected += "<" + fExpectedRoutine + ">: ";
+      /// Register a new diagnostic to check for.
+      /// \param severity One of kInfo kWarning kError kSysError.
+      /// \param location Function name where the diagnostic should be issued.
+      /// \param message Diagnostic message.
+      /// \param matchFullMessage If true, the message must be exactly identical.
+      ///        If false, it's sufficient that `message` is a substring of the diagnostic message.
+      void requiredDiag(int severity, std::string location, std::string message, bool matchFullMessage = true) {
+         if (severity != kInfo && severity != kWarning && severity != kError && severity != kSysError)
+            throw std::invalid_argument("ExpectedDiagRAII::requiredDiag(): severity is none of kInfo, kWarning, kError, kSysError");
 
-      // Check if the routine matches what we saw.
-      EXPECT_THAT(Seen, StartsWith(Expected));
+         fExpectedDiags.push_back({severity, std::move(location), std::move(message), matchFullMessage, false, 0});
+      }
 
-      Expected += fExpectedDiag;
+      /// Register a diagnostic that can, but need not necessarily be issued.
+      /// \param severity One of kInfo kWarning kError kSysError.
+      /// \param location Function name where the diagnostic should be issued.
+      /// \param message Diagnostic message.
+      /// \param matchFullMessage If true, the message must be exactly identical.
+      ///        If false, it's sufficient that `message` is a substring of the diagnostic message.
+      void optionalDiag(int severity, std::string location, std::string message, bool matchFullMessage = true) {
+         if (severity != kInfo && severity != kWarning && severity != kError && severity != kSysError)
+            throw std::invalid_argument("ExpectedDiagRAII::optionalDiag(): severity is none of kInfo, kWarning, kError, kSysError");
 
-      // The captured stderr also includes new lines.
-      Expected += "\n";
+         fExpectedDiags.push_back({severity, std::move(location), std::move(message), matchFullMessage, true, 0});
+      }
 
-      EXPECT_THAT(Seen, StrEq(Expected));
-   }
+   private:
+      struct Diag_t {
+         int severity;
+         std::string location;
+         std::string message;
+         bool matchFullString = true;
+         bool optional = false;
+         int receivedCount = -1;
+      };
 
-public:
-   ExpectedDiagRAII(ExpectedDiagKind DiagKind): fDiagKind(DiagKind) {
-      assert(DiagKind == ExpectedDiagRAII::EDK_NoDiag);
-      CaptureStderr();
-   }
+      /// Message handler that hands over all diagnostics to the currently active instance.
+      static void callback(int severity, bool abort, const char * location, const char * msg) {
+         if (sActiveInstance) {
+            sActiveInstance->checkDiag(severity, location, msg);
+         } else {
+            throw std::logic_error("ExpectedDiagRAII::callback called without an active message handler.");
+         }
 
-   ExpectedDiagRAII(ExpectedDiagKind DiagKind, std::string InRoutine,
-                    std::string E)
-      : fDiagKind(DiagKind), fExpectedRoutine(InRoutine), fExpectedDiag(E) {
-      CaptureStderr();
-   }
-   ~ExpectedDiagRAII() { pop(); }
+         if (abort) {
+            std::cerr << "ROOTUnitTestSupport::CheckDiagsRAII: Forced to abort because of diagnostic with severity "
+               << severity << " in '" << location << "' reading '" << msg << "'\n";
+            ::abort();
+         }
+      }
+
+      /// Check all received diags against list of expected ones.
+      void checkDiag(int severity, const char * location, const char * msg);
+      /// Print the diags in `diags` to the terminal.
+      void printDiags(std::vector<Diag_t> const & diags) const;
+
+      std::vector<Diag_t> fExpectedDiags;
+      std::vector<Diag_t> fUnexpectedDiags;
+
+      CheckDiagsRAII * const fOldInstance;       /// Last active handler in case handlers are nested.
+      ErrorHandlerFunc_t const fOldErrorHandler; /// Last active error handler function.
+
+      static CheckDiagsRAII * sActiveInstance;   /// Instance that will receive ROOT's callbacks.
 };
+
 }
 
-#define ROOT_EXPECT_ERROR(expression, where, expected_diag )            \
-   {                                                                    \
-      ExpectedDiagRAII EE(ExpectedDiagRAII::EDK_Error, where,           \
-                          expected_diag);                               \
-      expression;                                                       \
-   }
+#define ROOT_EXPECT_ERROR(expression, where, expected_diag )       \
+{                                                                  \
+   using namespace ROOTUnitTestSupport;                            \
+   CheckDiagsRAII EE(kError, where,                                \
+         expected_diag);                                           \
+   expression;                                                     \
+}
 
-#define ROOT_EXPECT_WARNING(expression, where, expected_diag)           \
-   {                                                                    \
-      ExpectedDiagRAII EE(ExpectedDiagRAII::EDK_Warning, where,         \
-                          expected_diag);                               \
-      expression;                                                       \
-   }
+#define ROOT_EXPECT_WARNING(expression, where, expected_diag)      \
+{                                                                  \
+   using namespace ROOTUnitTestSupport;                            \
+   CheckDiagsRAII EE(kWarning, where,                              \
+         expected_diag);                                           \
+   expression;                                                     \
+}
 
-#define ROOT_EXPECT_INFO(expression, where, expected_diag)              \
-   {                                                                    \
-      ExpectedDiagRAII EE(ExpectedDiagRAII::EDK_Info, where,            \
-                          expected_diag);                               \
-      expression;                                                       \
-   }
+#define ROOT_EXPECT_INFO(expression, where, expected_diag)           \
+{                                                                    \
+   using namespace ROOTUnitTestSupport;                              \
+   CheckDiagsRAII EE(kInfo, where,                                   \
+         expected_diag);                                             \
+   expression;                                                       \
+}
 
-#define ROOT_EXPECT_NODIAG(expression)                                  \
-   {                                                                    \
-      ExpectedDiagRAII EE(ExpectedDiagRAII::EDK_NoDiag);                \
-      expression;                                                       \
-   }
+#define ROOT_EXPECT_NODIAG(expression)                               \
+{                                                                    \
+   using namespace ROOTUnitTestSupport;                              \
+   CheckDiagsRAII EE{};                                              \
+   expression;                                                       \
+}
 
-#define ROOT_EXPECT_SYSERROR(expression, where, expected_diag)          \
-   {                                                                    \
-      ExpectedDiagRAII EE(ExpectedDiagRAII::EDK_SysError, where,        \
-                          expected_diag);                               \
-      expression;                                                       \
-   }
+#define ROOT_EXPECT_SYSERROR(expression, where, expected_diag)       \
+{                                                                    \
+   using namespace ROOTUnitTestSupport;                              \
+   CheckDiagsRAII EE(kSysError, where,                               \
+         expected_diag);                                             \
+   expression;                                                       \
+}
 
 #endif // ROOT_UNITTESTSUPPORT_H

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -847,16 +847,17 @@ TEST_P(RDFSimpleTests, NonExistingFileInChain)
    const auto errmsg = "file %s/doesnotexist.root does not exist";
    TString expecteddiag;
    expecteddiag.Form(errmsg, gSystem->pwd());
+   ROOTUnitTestSupport::CheckDiagsRAII diagRAII{kError, "TFile::TFile", expecteddiag.Data()};
    // in the single-thread case the error happens when TTreeReader is calling LoadTree the first time
    // otherwise we notice the file does not exist beforehand, e.g. in TTreeProcessorMT
    if (!ROOT::IsImplicitMTEnabled())
-      expecteddiag += "\nWarning in <TTreeReader::SetEntryBase()>: There was an issue opening the last file associated "
-                      "to the TChain being processed.";
+      diagRAII.requiredDiag(kWarning, "TTreeReader::SetEntryBase()", "There was an issue opening the last file associated "
+                                                                     "to the TChain being processed.");
 
    bool exceptionCaught = false;
    try {
-      ROOT_EXPECT_ERROR(df.Count().GetValue(), "TFile::TFile", expecteddiag.Data());
-   } catch (const std::runtime_error &e) {
+      df.Count().GetValue();
+   } catch (const std::exception &e) {
       const std::string expected_msg =
          ROOT::IsImplicitMTEnabled()
             ? "TTreeProcessorMT::Process: an error occurred while opening file \"doesnotexist.root\""

--- a/tree/dataframe/test/dataframe_splitcoll_arrayview.cxx
+++ b/tree/dataframe/test/dataframe_splitcoll_arrayview.cxx
@@ -7,6 +7,7 @@
 #include "TSystem.h"
 #include "TROOT.h"
 #include "gtest/gtest.h"
+#include "ROOTUnitTestSupport.h"
 
 #include "TwoFloats.h"
 
@@ -28,17 +29,23 @@ void fill_tree(const char *filename, const char *treeName)
 
 void test_splitcoll_arrayview(const std::string &fileName, const std::string &treeName)
 {
-   ROOT::RDataFrame d1(treeName, fileName, {"v.a"});
-   auto c1 = d1.Filter([](ROOT::VecOps::RVec<float> d) {
-                  float ex_v = 0.f;
-                  for (auto v : d) {
-                     EXPECT_DOUBLE_EQ(v, ex_v);
-                     ex_v += 1.f;
-                  }
-                  return d[0] > 5;
-               })
-                .Count();
-   EXPECT_EQ(*c1, 0ull);
+   {
+      ROOTUnitTestSupport::CheckDiagsRAII diagRAII;
+      diagRAII.optionalDiag(kWarning,
+          "RTreeColumnReader::Get",
+          "Branch v.a hangs from a non-split branch. A copy is being performed in order to properly read the content.");
+      ROOT::RDataFrame d1(treeName, fileName, {"v.a"});
+      auto c1 = d1.Filter([](ROOT::VecOps::RVec<float> d) {
+                     float ex_v = 0.f;
+                     for (auto v : d) {
+                        EXPECT_DOUBLE_EQ(v, ex_v);
+                        ex_v += 1.f;
+                     }
+                     return d[0] > 5;
+                  })
+                   .Count();
+      EXPECT_EQ(*c1, 0ull);
+   }
 
    ROOT::RDataFrame d2(treeName, fileName, {"v"});
    auto c2 = d2.Filter([](ROOT::VecOps::RVec<TwoFloats> d) {

--- a/tree/dataframe/test/datasource_sqlite.cxx
+++ b/tree/dataframe/test/datasource_sqlite.cxx
@@ -202,6 +202,7 @@ TEST(RSqliteDS, IMT)
    const auto nSlots = 4U;
    ROOT::EnableImplicitMT(nSlots);
 
+   ROOTUnitTestSupport::CheckDiagsRAII diagRAII{kWarning, "SetNSlots", "Currently the SQlite data source faces performance degradation in multi-threaded mode. Consider turning off IMT."};
    auto rdf = MakeSqliteDataFrame(fileName0, query0);
    EXPECT_EQ(3, *rdf.Sum("fint"));
    EXPECT_NEAR(3.0, *rdf.Sum("freal"), epsilon);

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -1,8 +1,13 @@
 #include "ntuple_test.hxx"
 #include <ROOT/RPageStorageDaos.hxx>
+#include "ROOTUnitTestSupport.h"
 
 TEST(RPageStorageDaos, Basics)
 {
+   ROOTUnitTestSupport::CheckDiagsRAII diags;
+   diags.requiredDiag(kWarning, "in int daos_init()", "This RNTuple build uses libdaos_mock. Use only for testing!");
+   diags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos", "The DAOS backend is experimental and still under development.", false);
+
    std::string daosUri("daos://" R__DAOS_TEST_POOL ":1/a947484e-e3bc-48cb-8f71-3292c19b59a4");
 
    auto model = RNTupleModel::Create();

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -7,6 +7,7 @@
 #include "TMemFile.h"
 #include "TTree.h"
 
+#include "ROOTUnitTestSupport.h"
 #include "gtest/gtest.h"
 
 #include <vector>
@@ -141,6 +142,10 @@ TEST(TBasket, CreateAndGetBasket)
 
 TEST(TBasket, TestUnsupportedIO)
 {
+   ROOTUnitTestSupport::CheckDiagsRAII diags;
+   diags.requiredDiag(kError, "TBasket::Streamer", "indicating this was written with a newer version of ROOT utilizing critical IO features this version of ROOT does not support", /*matchFullMessage=*/false);
+   diags.requiredDiag(kError, "TBranch::GetBasket", "File: tbasket_test.root at byte:", /*matchFullMessage=*/false);
+
    TMemFile *f;
    // Create a file; not using the CreateSampleFile helper as
    // we must corrupt the basket here.
@@ -283,6 +288,9 @@ UChar_t GetFeatures(const ROOT::TIOFeatures &settings) {
 
 TEST(TBasket, TestSettingIOBits)
 {
+   ROOTUnitTestSupport::CheckDiagsRAII diags;
+   diags.requiredDiag(kError, "TestFeature", "A feature is being tested for that is not supported or known.");
+
    TMemFile *f;
    // Create a file; not using the CreateSampleFile helper as
    // we want to change around the IOBits

--- a/tree/tree/test/TOffsetGeneration.cxx
+++ b/tree/tree/test/TOffsetGeneration.cxx
@@ -6,6 +6,7 @@
 #include "TLeafElement.h"
 #include "TRandom.h"
 
+#include "ROOTUnitTestSupport.h"
 #include "gtest/gtest.h"
 
 #include "ElementStruct.h"
@@ -13,6 +14,16 @@
 class TOffsetGeneration : public ::testing::Test {
 protected:
    static constexpr int fEventCount = 10000;
+
+   // FIXME: Global suppression of PCM-related warnings for windows
+   static void SetUpTestSuite() {
+      // Suppress file-related warning on Windows throughout
+      // this entire test suite
+      static ROOTUnitTestSupport::CheckDiagsRAII diags;
+      diags.optionalDiag(kError,
+         "TCling::LoadPCM",
+         "ROOT PCM", false);
+   }
 
    virtual void SetUp()
    {

--- a/tree/treeplayer/test/basic.cxx
+++ b/tree/treeplayer/test/basic.cxx
@@ -11,6 +11,7 @@
 #include "TSystem.h"
 
 #include "gtest/gtest.h"
+#include "ROOTUnitTestSupport.h"
 #include <stdlib.h>
 #include <memory>
 
@@ -118,6 +119,8 @@ TEST(TTreeReaderBasic, Interfaces) {
 
 
 TEST(TTreeReaderBasic, ErrorProbing) {
+   ROOTUnitTestSupport::CheckDiagsRAII diags{ kError, "TTreeReader::TTreeReader", "No TTree called doesNotExist was found in the selected TDirectory." };
+
    TTreeReader tr("doesNotExist", gROOT);
    EXPECT_EQ(TTreeReader::kEntryNoTree, tr.GetEntryStatus());
    EXPECT_EQ(nullptr, tr.GetTree());
@@ -463,6 +466,8 @@ TEST(TTreeReaderBasic, InfLoop)
 // ROOT-10019
 TEST(TTreeReaderBasic, DisappearingBranch)
 {
+   ROOTUnitTestSupport::CheckDiagsRAII diags{ kError, "TTreeReader::SetEntryBase()", "There was an error while notifying the proxies." };
+   diags.requiredDiag(kWarning, "TTreeReader::SetEntryBase()", "Unexpected error '-6' in TChain::LoadTree");
 
    auto createFile = [](const char *fileName, int ncols) {
       // auto r = ROOT::RDataFrame(1).Define("col0",[](){return 0;}).Snapshot<int>("t","f1.root",{"col0"});


### PR DESCRIPTION
gtests can print errors using ROOT's message system, but these get
ignored completely.
Several problems could have been caught automatically, but they went undetected.

This adds a default regex to all gtests that checks for
"(Fatal|Error|Warning) in <", unless an explicit FAILREGEX is passed to
ROOT_ADD_GTEST.

### How to fix the tests:
- [Easy, but unsafe] Add `FAILREGEX ""` to `ROOT_ADD_GTEST`. In that case, we will not grep for anything.
- [Safe] Use the macros from https://github.com/root-project/root/blob/master/test/unit_testing_support/ROOTUnitTestSupport.h and catch the diagnostics 
- Fix what triggers the warnings/errors