### PR TITLE
[DF] Always check that arg types in jitted code are valid

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -297,8 +297,7 @@ std::vector<bool> FindUndefinedDSColumns(const ColumnNames_t &requestedCols, con
 using ROOT::Detail::RDF::ColumnNames_t;
 
 template <typename T>
-void AddDSColumnsHelper(std::string_view name, RDFInternal::RBookedCustomColumns &currentCols, RDataSource &ds,
-                        unsigned int nSlots)
+void AddDSColumnsHelper(std::string_view name, RBookedCustomColumns &currentCols, RDataSource &ds, unsigned int nSlots)
 {
    auto readers = ds.GetColumnReaders<T>(name);
    auto getValue = [readers](unsigned int slot) { return *readers[slot]; };

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -292,6 +292,10 @@ std::shared_ptr<RNodeBase> UpcastNode(std::shared_ptr<RNodeBase> ptr);
 ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColumns, const ColumnNames_t &columns,
                                       const ColumnNames_t &validCustomColumns, RDataSource *ds);
 
+std::vector<std::string> GetValidatedArgTypes(const ColumnNames_t &colNames, const RBookedCustomColumns &customColumns,
+                                              TTree *tree, RDataSource *ds, const std::string &context,
+                                              bool vector2rvec);
+
 std::vector<bool> FindUndefinedDSColumns(const ColumnNames_t &requestedCols, const ColumnNames_t &definedDSCols);
 
 using ROOT::Detail::RDF::ColumnNames_t;


### PR DESCRIPTION
Snapshot, Cache, Define and Filter did not check that the types of
columns used as arguments in jitted code were valid (in particular,
that the type of custom columns was correctly understood by cling).
This patch provides a function that performs the validity check,
GetValidatedArgTypes, that is used everywhere instead of GetColumnTypes
(now unused and therefore deleted) and ColumnName2ColumnTypeName.

An exception with a user-friendly error message is thrown in case of
error, which fixes ROOT-10458.