### PR TITLE
[TThreadedObject] Fix usage of condition variable in test

### DIFF
--- a/core/thread/test/testTThreadedObject.cxx
+++ b/core/thread/test/testTThreadedObject.cxx
@@ -170,7 +170,10 @@ TEST(TThreadedObject, GetNSlots)
    std::vector<std::thread> threads;
    for (int i = 0; i < 4; ++i)
       threads.emplace_back(task);
-   ready = true;
+   {
+      std::lock_guard<std::mutex> lk(m);
+      ready = true;
+   }
    cv.notify_all();
    for (auto &t : threads)
       t.join();


### PR DESCRIPTION
Setting the flag must be protected by a lock.

This is a recently-introduced test, and I think this bug caused the test to hang indefinitely in rare cases as in here (note the timeout): http://cdash.cern.ch/testDetails.php?test=85891275&build=874661

The stacktrace of the threads when the test was hanging was the following:

```
Thread 2 (Thread 0xa2784b40 (LWP 4590)):
#0  0xb7fa1d61 in __kernel_vsyscall ()
#1  0xb6ab9462 in futex_wait_cancelable (private=0, expected=0, futex_word=0xbf9af3e4) at ../sysdeps/unix/sysv/linux/futex-internal.h:88
#2  __pthread_cond_wait_common (abstime=0x0, mutex=0xbf9af424, cond=0xbf9af3bc) at pthread_cond_wait.c:502
#3  __pthread_cond_wait (cond=0xbf9af3bc, mutex=0xbf9af424) at pthread_cond_wait.c:655
#4  0xb69c905e in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/i386-linux-gnu/libstdc++.so.6
#5  0x0047e8d7 in std::condition_variable::wait<TThreadedObject_GetNSlots_Test::TestBody()::<lambda()>::<lambda()> >(std::unique_lock<std::mutex> &, TThreadedObject_GetNSlots_Test::<lambda()>::<lambda()>) (this=0xbf9af3bc, __lock=..., __p=...) at /usr/include/c++/8/condition_variable:99
#6  0x0047e11a in TThreadedObject_GetNSlots_Test::<lambda()>::operator()(void) const (__closure=0xa1e00674)
    at /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/root/core/thread/test/testTThreadedObject.cxx:167
#7  0x0047f5fc in std::__invoke_impl<void, TThreadedObject_GetNSlots_Test::TestBody()::<lambda()> >(std::__invoke_other, TThreadedObject_GetNSlots_Test::<lambda()> &&) (
    __f=...) at /usr/include/c++/8/bits/invoke.h:60
#8  0x0047f2b8 in std::__invoke<TThreadedObject_GetNSlots_Test::TestBody()::<lambda()> >(TThreadedObject_GetNSlots_Test::<lambda()> &&) (__fn=...)
    at /usr/include/c++/8/bits/invoke.h:95
#9  0x00480966 in std::thread::_Invoker<std::tuple<TThreadedObject_GetNSlots_Test::TestBody()::<lambda()> > >::_M_invoke<0>(std::_Index_tuple<0>) (this=0xa1e00674)
    at /usr/include/c++/8/thread:244
#10 0x0048090b in std::thread::_Invoker<std::tuple<TThreadedObject_GetNSlots_Test::TestBody()::<lambda()> > >::operator()(void) (this=0xa1e00674)
    at /usr/include/c++/8/thread:253
#11 0x004808c1 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<TThreadedObject_GetNSlots_Test::TestBody()::<lambda()> > > >::_M_run(void) (this=0xa1e00670)
    at /usr/include/c++/8/thread:196
#12 0xb69cef1d in ?? () from /lib/i386-linux-gnu/libstdc++.so.6
#13 0xb6ab2fd2 in start_thread (arg=<optimized out>) at pthread_create.c:486
#14 0xb67236d6 in clone () at ../sysdeps/unix/sysv/linux/i386/clone.S:108

Thread 1 (Thread 0xb64429c0 (LWP 4562)):
#0  0xb7fa1d61 in __kernel_vsyscall ()
#1  0xb6ab449e in __GI___pthread_timedjoin_ex (threadid=2725792576, thread_return=0x0, abstime=0x0, block=true) at pthread_join_common.c:89
#2  0xb6ab4244 in __pthread_join (threadid=2725792576, thread_return=0x0) at pthread_join.c:24
#3  0xb69cf185 in std::thread::join() () from /lib/i386-linux-gnu/libstdc++.so.6
#4  0x0047e4d8 in TThreadedObject_GetNSlots_Test::TestBody (this=0x139bb90)
    at /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/root/core/thread/test/testTThreadedObject.cxx:176
#5  0x004ba0ff in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ()
#6  0x004aec42 in testing::Test::Run() [clone .part.608] ()
#7  0x004af0ab in testing::TestInfo::Run() [clone .part.609] ()
#8  0x004af2ce in testing::TestSuite::Run() [clone .part.610] ()
#9  0x004b03cf in testing::internal::UnitTestImpl::RunAllTests() ()
#10 0x004b0696 in testing::UnitTest::Run() ()
#11 0x0047beb1 in main ()
```