### PR TITLE
Avoid streaming a copy of the TPaveStats parent during the TH1 cloning process.

### DIFF
--- a/graf2d/graf/inc/TPaveStats.h
+++ b/graf2d/graf/inc/TPaveStats.h
@@ -13,9 +13,9 @@
 
 
 #include "TPaveText.h"
+#include "TVirtualPaveStats.h"
 
-
-class TPaveStats : public TPaveText {
+class TPaveStats : public TPaveText, public TVirtualPaveStats {
 
 protected:
    Int_t         fOptFit;            ///< option Fit
@@ -36,7 +36,7 @@ public:
    virtual const char  *GetStatFormat() const {return fStatFormat.Data();}
    Int_t            GetOptFit() const;
    Int_t            GetOptStat() const;
-   TObject         *GetParent() const {return fParent;}
+   virtual TObject *GetParent() const {return fParent;}
    virtual void     Paint(Option_t *option="");
    virtual void     InsertText(const char *) { }
    virtual void     InsertLine() { }
@@ -49,10 +49,10 @@ public:
    virtual void     SetStatFormat(const char *format="6.4g");   // *MENU*
    void             SetOptFit(Int_t fit=1);                     // *MENU*
    void             SetOptStat(Int_t stat=1);                   // *MENU*
-   void             SetParent(TObject*obj) {fParent = obj;}
+   virtual void     SetParent(TObject*obj) {fParent = obj;}
    virtual void     UseCurrentStyle();
 
-   ClassDef(TPaveStats,4)  //A special TPaveText to draw histogram statistics.
+   ClassDef(TPaveStats,5)  //A special TPaveText to draw histogram statistics.
 };
 
 #endif

--- a/hist/hist/CMakeLists.txt
+++ b/hist/hist/CMakeLists.txt
@@ -84,6 +84,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Hist
     TVirtualFitter.h
     TVirtualGraphPainter.h
     TVirtualHistPainter.h
+    TVirtualPaveStats.h
     Math/WrappedMultiTF1.h
     Math/WrappedTF1.h
     v5/TF1Data.h

--- a/hist/hist/inc/LinkDef.h
+++ b/hist/hist/inc/LinkDef.h
@@ -165,6 +165,7 @@
 #pragma link C++ class TVirtualHistPainter+;
 #pragma link C++ class TVirtualGraphPainter+;
 #pragma link C++ class TVirtualFitter+;
+#pragma link C++ class TVirtualPaveStats+;
 #pragma link C++ class TBackCompFitter+;
 #pragma link C++ class TSVDUnfold+;
 #pragma link C++ class TEfficiency+;

--- a/hist/hist/inc/TVirtualPaveStats.h
+++ b/hist/hist/inc/TVirtualPaveStats.h
@@ -1,0 +1,39 @@
+// @(#)root/hist:$Id$
+// Author: Rene Brun   31/08/99
+
+/*************************************************************************
+ * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TVirtualPaveStats
+#define ROOT_TVirtualPaveStats
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TVirtualPaveStats                                                    //
+//                                                                      //
+// Abstract base class for PaveStats                                    //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+
+#include "Rtypes.h"
+
+class TObject;
+
+class TVirtualPaveStats { 
+
+public:
+   virtual ~TVirtualPaveStats() = default;
+   
+   virtual TObject *GetParent() const = 0;;
+   virtual void SetParent(TObject *) = 0;
+
+   ClassDef(TVirtualPaveStats, 0)  //Abstract interface for TPaveStats
+};
+
+#endif

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -41,6 +41,7 @@
 #include "TError.h"
 #include "TVirtualHistPainter.h"
 #include "TVirtualFFT.h"
+#include "TVirtualPaveStats.h"
 #include "TSystem.h"
 
 #include "HFitInterface.h"
@@ -2675,7 +2676,23 @@ TObject* TH1::Clone(const char* newname) const
       // when dictionary information is initialized, so we need to
       // keep obj->fFunction valid during its execution and
       // protect the update with the write lock.
+
+      // Reset stats parent - else cloning the stats will clone this histogram, too. 
+      auto oldstats = dynamic_cast<TVirtualPaveStats*>(fFunctions->FindObject("stats"));
+      TObject *oldparent = nullptr;
+      if (oldstats) {
+         oldparent = oldstats->GetParent();
+         oldstats->SetParent(nullptr);
+      }
+
       auto newlist = (TList*)fFunctions->Clone();
+
+      if (oldstats)
+         oldstats->SetParent(oldparent);
+      auto newstats = dynamic_cast<TVirtualPaveStats*>(obj->fFunctions->FindObject("stats"));
+      if (newstats)
+         newstats->SetParent(obj);
+
       auto oldlist = obj->fFunctions;
       {
          R__WRITE_LOCKGUARD(ROOT::gCoreMutex);


### PR DESCRIPTION

This solves ROOT-9535.

During the cloning process the TPaveStats (as part of fFunctions) is cloned and its member fParent point to the TH1 being
cloned. Since that TH1 was not part of the I/O transaction this leads the cloned TPaveStats parent to point to yet another
copy of the TH1.  In the case of ROOT-9535, that copy held stale pointer to object that were removed and deleted in a subsequent
call to Reset.

The exact order.

Create a TH1 h1 containing a TPaveStats s1 and a TPaletteAxis p1.
Then Clone h1 into h2 which now contains TPaveStats s2 and a TPalettesAxis p2.

Since s1.fParent was also cloned s2.fParent points to another histogram h3.
h3.fFunctions contains a pointer to s2 and to p2 since they were streamed during
the same I/O operation (the Clone via TBuffer of fFunctions).

When h2 is Reset, it deletes p2 and remove it from h2.fFunctions,
however (since it is not even supposed to exist) h3 is not informed and
keep a (stale) pointer to p2.  The Reset, however, keeps the TPaveStats
as is.

Then during the cloning of h2, p2 is traversed and thus h3 is traversed
and thus the (stale) pointer to p2 is accessed.