### PR TITLE
Add support for C++ 17  CPU compilation and Cuda compilation with C++14. This fixes ROOT-10209 

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
@@ -19,6 +19,13 @@
 #ifndef TMVA_DNN_ARCHITECTURES_CUDA_CUDAMATRIX
 #define TMVA_DNN_ARCHITECTURES_CUDA_CUDAMATRIX
 
+// in case we compile C++ code with std-17 and cuda with lower standard
+#include "RConfigure.h"
+#ifdef R__HAS_STD_STRING_VIEW
+#undef R__HAS_STD_STRING_VIEW
+#define R__HAS_STD_EXPERIMENTAL_STRING_VIEW
+#endif
+
 #include "cuda.h"
 #include "cuda_runtime.h"
 #include "cublas_v2.h"
@@ -108,7 +115,7 @@ private:
    static size_t          fNOnes;        ///< Current length of the one vector.
    static curandState_t * fCurandStates;
    static size_t          fNCurandStates;
-   
+
 
    size_t                    fNRows;
    size_t                    fNCols;
@@ -155,7 +162,7 @@ public:
    size_t GetNrows() const {return fNRows;}
    size_t GetNcols() const {return fNCols;}
    size_t GetNoElements() const {return fNRows * fNCols;}
-    
+
    const AFloat * GetDataPointer() const {return fElementBuffer;}
    AFloat *       GetDataPointer()       {return fElementBuffer;}
    const cublasHandle_t & GetCublasHandle() const    {return fCublasHandle;}
@@ -167,9 +174,9 @@ public:
     *  on all streams. Only used for testing. */
    TCudaDeviceReference<AFloat> operator()(size_t i, size_t j) const;
 
-   void Print() const { 
-      TMatrixT<AFloat> mat(*this); 
-      mat.Print(); 
+   void Print() const {
+      TMatrixT<AFloat> mat(*this);
+      mat.Print();
    }
 
    void Zero() {

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaTensor.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaTensor.h
@@ -25,10 +25,10 @@
 #include <cassert>
 #include <iostream>
 
-#include "RConfigure.h"
+#include "CudaMatrix.h"
 #include "TMatrixT.h"
 #include "CudaBuffers.h"
-#include "CudaMatrix.h"
+
 //#include "TMVA/RTensor.hxx"
 
 #ifdef R__HAS_CUDNN

--- a/tmva/tmva/inc/TMVA/DNN/GeneralLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/GeneralLayer.h
@@ -505,8 +505,9 @@ auto VGeneralLayer<Architecture_t>::WriteTensorToXML(void * node, const char * n
       auto & mat = tensor[i];
       for (Int_t row = 0; row < mat.GetNrows(); row++) {
          for (Int_t col = 0; col < mat.GetNcols(); col++) {
-            TString tmp = TString::Format( "%5.15e ", (mat)(row,col) );
-            s << tmp.Data();
+            // TString tmp = TString::Format( "%5.15e ", (mat)(row,col) );
+            // s << tmp.Data();
+            s << std::scientific << mat(row, col) << " ";
          }
       }
    }

--- a/tmva/tmva/src/DNN/Architectures/Cuda.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cuda.cu
@@ -14,6 +14,13 @@
 // for Double_t and Float_t floating point types.               //
 /////////////////////////////////////////////////////////////////
 
+// in case we compile C++ code with std-17 and cuda with lower standard
+#include "RConfigure.h"
+#ifdef R__HAS_STD_STRING_VIEW
+#undef R__HAS_STD_STRING_VIEW
+#define R__HAS_STD_EXPERIMENTAL_STRING_VIEW
+#endif
+
 #include "TMVA/DNN/Architectures/Cuda.h"
 #include "Cuda/Propagation.cu"
 #include "Cuda/Arithmetic.cu"
@@ -33,8 +40,8 @@ template class TCuda<Double_t>;
 
 
 #ifndef R__HAS_TMVAGPU
-   // if R__HAS_TMVAGPU is not defined this file should not be compiled 
-   static_assert(false,"GPU/CUDA architecture is not enabled"); 
+   // if R__HAS_TMVAGPU is not defined this file should not be compiled
+   static_assert(false,"GPU/CUDA architecture is not enabled");
 #endif
 
 

--- a/tmva/tmva/src/DNN/Architectures/Cudnn.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cudnn.cu
@@ -14,7 +14,12 @@
 // for Double_t and Real_t floating point types.                 //
 ///////////////////////////////////////////////////////////////////
 
-
+// in case we compile C++ code with std-17 and cuda with lower standard
+#include "RConfigure.h"
+#ifdef R__HAS_STD_STRING_VIEW
+#undef R__HAS_STD_STRING_VIEW
+#define R__HAS_STD_EXPERIMENTAL_STRING_VIEW
+#endif
 
 #include "TMVA/DNN/Architectures/TCudnn.h"
 #include "Cudnn/Propagate.cu"

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -2262,7 +2262,7 @@ void MethodDL::ReadWeightsFromXML(void * rootXML)
          // use some dammy value which will be overwrittem in BatchNormLayer::ReadWeightsFromXML
          fNet->AddBatchNormLayer(0., 0.0);
       }
-      // read eventually weights and biases
+      // read weights and biases
       fNet->GetLayers().back()->ReadWeightsFromXML(layerXML);
 
       // read next layer


### PR DESCRIPTION
Fix the compilation of Cuda with C++14 when normal ROOT is compile with C++17 which has std::string_view.

Support compilation when configuting with: 
 cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_CUDA_STANDARD=14

The fix is done by modifying the pre-processor macros defined in RConfigure.h when compiling  Cuda.
A better fix would be to remove the TString dependency in the Cuda compiled  code. TString is used only when doing I/O of the DeepNet layers to XML. In principle this code could be moved out of Cuda.
Something to be done in a future code re-factoring