### PR TITLE
[cling] Also capture SFINAE error counts (ROOT-10754)

### DIFF
--- a/core/metacling/src/ClingRAII.h
+++ b/core/metacling/src/ClingRAII.h
@@ -26,6 +26,7 @@ namespace ROOT {
           decltype(clang::Sema::MaybeODRUseExprs) fMaybeODRUseExprs;
           decltype(clang::Sema::FunctionScopes) fFunctionScopes;
           decltype(clang::Sema::UndefinedButUsed) fUndefinedButUsed;
+          clang::Sema::SFINAETrap fSFINAETrap;
           clang::Sema& fSema;
           void Swapem() {
              std::swap(fCleanup, fSema.Cleanup);
@@ -34,7 +35,7 @@ namespace ROOT {
              std::swap(fFunctionScopes, fSema.FunctionScopes);
              std::swap(fUndefinedButUsed, fSema.UndefinedButUsed);
           }
-          SemaExprCleanupsRAII(clang::Sema& S): fSema(S) {
+          SemaExprCleanupsRAII(clang::Sema& S): fSFINAETrap(S), fSema(S) {
              fFunctionScopes.push_back(new clang::sema::FunctionScopeInfo(S.Diags));
              Swapem();
           };

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -307,9 +307,8 @@ void AddDSColumnsHelper(std::string_view name, RBookedCustomColumns &currentCols
    auto getValue = [readers](unsigned int slot) { return *readers[slot]; };
    using NewCol_t = RCustomColumn<decltype(getValue), CustomColExtraArgs::Slot>;
 
-   auto newCol = std::shared_ptr<RCustomColumnBase>(new NewCol_t(
-      name, ds.GetTypeName(name), std::move(getValue), ColumnNames_t{}, nSlots, currentCols, /*isDSColumn=*/true));
-
+   auto newCol = std::make_shared<NewCol_t>(name, ds.GetTypeName(name), std::move(getValue), ColumnNames_t{}, nSlots,
+                                            currentCols, /*isDSColumn=*/true);
    currentCols.AddName(name);
    currentCols.AddColumn(newCol, name);
 }

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2219,10 +2219,10 @@ private:
       using NewColEntry_t =
          RDFDetail::RCustomColumn<decltype(entryColGen), RDFDetail::CustomColExtraArgs::SlotAndEntry>;
 
-      std::shared_ptr<RDFDetail::RCustomColumnBase> entryColumn{new NewColEntry_t(
-         entryColName, entryColType, std::move(entryColGen), ColumnNames_t{}, fLoopManager->GetNSlots(), newCols)};
+      auto entryColumn = std::make_shared<NewColEntry_t>(entryColName, entryColType, std::move(entryColGen),
+                                                         ColumnNames_t{}, fLoopManager->GetNSlots(), newCols);
       newCols.AddName(entryColName);
-      newCols.AddColumn(std::move(entryColumn), entryColName);
+      newCols.AddColumn(entryColumn, entryColName);
 
       // Slot number column
       const std::string slotColName = "rdfslot_";
@@ -2230,11 +2230,10 @@ private:
       auto slotColGen = [](unsigned int slot) { return slot; };
       using NewColSlot_t = RDFDetail::RCustomColumn<decltype(slotColGen), RDFDetail::CustomColExtraArgs::Slot>;
 
-      std::shared_ptr<RDFDetail::RCustomColumnBase> slotColumn{new NewColSlot_t(
-         slotColName, slotColType, std::move(slotColGen), ColumnNames_t{}, fLoopManager->GetNSlots(), newCols)};
-
+      auto slotColumn = std::make_shared<NewColSlot_t>(slotColName, slotColType, std::move(slotColGen), ColumnNames_t{},
+                                                       fLoopManager->GetNSlots(), newCols);
       newCols.AddName(slotColName);
-      newCols.AddColumn(std::move(slotColumn), slotColName);
+      newCols.AddColumn(slotColumn, slotColName);
 
       fCustomColumns = std::move(newCols);
 
@@ -2345,11 +2344,11 @@ private:
 
       using NewCol_t = RDFDetail::RCustomColumn<F, CustomColumnType>;
       RDFInternal::RBookedCustomColumns newCols(newColumns);
-      std::shared_ptr<RDFDetail::RCustomColumnBase> newColumn{new NewCol_t(
-         name, retTypeName, std::forward<F>(expression), validColumnNames, fLoopManager->GetNSlots(), newCols)};
+      auto newColumn = std::make_shared<NewCol_t>(name, retTypeName, std::forward<F>(expression), validColumnNames,
+                                                  fLoopManager->GetNSlots(), newCols);
 
       newCols.AddName(name);
-      newCols.AddColumn(std::move(newColumn), name);
+      newCols.AddColumn(newColumn, name);
 
       RInterface<Proxied> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 


### PR DESCRIPTION
When doing lookup on templates, instantiation can fail.
This can be triggered during templarte instantiation somewhere
in clang, autoloading, cling-lookup - and SFINAE errors that
occurr in cling-lookup must not bubble up to clang, or else
clang will think that there was a problem (where there was
none - just e.g. ROOT trying to autoload a bogus template).

In this concrete case, a template specialized with a lambda
was not found by clang, was tried to be autoloaded, TMetaUtils
produced a broken normalized type name, lookup on the broken
type name failed with a SFINAE error - and that ended up being
swallowed by a clang SFINAETrap by the topmost lookup.

Instead, keep SFINAE errors to ourselves.

This fixes ROOT-10754.