### PR TITLE
[wincxxmodules] Fix std and libc modules on Windows

### DIFF
--- a/interpreter/cling/include/cling/libc_msvc.modulemap
+++ b/interpreter/cling/include/cling/libc_msvc.modulemap
@@ -2,73 +2,248 @@ module "libc" [system] [extern_c] [no_undeclared_includes] {
   requires windows
 
   export *
-  //FIXME: Contains macros, should probably be textual.
-  module "corecrt.h" {
-    export *
-    header "corecrt.h"
-  }
-  //FIXME: Contains macros, should probably be textual.
-  module "corecrt_stdio_config.h" {
-    export *
-    header "corecrt_stdio_config.h"
-  }
+
   module "assert.h" {
     export *
-    textual header "assert.h"
+    header "assert.h"
   }
-  module "string.h" {
+  module "corecrt_search.h" {
     export *
-    header "string.h"
+    header "corecrt_search.h"
   }
-  module "ctype.h" {
+  module "corecrt_wstdio.h" {
     export *
-    header "ctype.h"
-  }
-  module "errno.h" {
-    export *
-    header "errno.h"
+    header "corecrt_wstdio.h"
   }
   module "fenv.h" {
     export *
     header "fenv.h"
   }
-  module "inttypes.h" {
+  module "memory.h" {
     export *
-    textual header "inttypes.h"
-  }
-  module "math.h" {
-    export *
-    header "math.h"
-  }
-  module "signal.h" {
-    export *
-    header "signal.h"
+    header "memory.h"
   }
   module "stdio.h" {
     export *
     header "stdio.h"
   }
+  module "complex.h" {
+    export *
+    header "complex.h"
+  }
+  module "corecrt_share.h" {
+    export *
+    header "corecrt_share.h"
+  }
+  module "corecrt_wstdlib.h" {
+    export *
+    header "corecrt_wstdlib.h"
+  }
+  module "float.h" {
+    export *
+    header "float.h"
+  }
+  module "minmax.h" {
+    export *
+    header "minmax.h"
+  }
   module "stdlib.h" {
     export *
     header "stdlib.h"
+  }
+  module "conio.h" {
+    export *
+    header "conio.h"
+  }
+  module "corecrt_startup.h" {
+    export *
+    header "corecrt_startup.h"
+  }
+  module "corecrt_wstring.h" {
+    export *
+    header "corecrt_wstring.h"
+  }
+  module "fpieee.h" {
+    export *
+    header "fpieee.h"
+  }
+  module "new.h" {
+    export *
+    header "new.h"
+  }
+  module "string.h" {
+    export *
+    header "string.h"
+  }
+  module "corecrt.h" {
+    export *
+    header "corecrt.h"
+  }
+  module "corecrt_stdio_config.h" {
+    export *
+    header "corecrt_stdio_config.h"
+  }
+  module "corecrt_wtime.h" {
+    export *
+    header "corecrt_wtime.h"
+  }
+  module "inttypes.h" {
+    export *
+    header "inttypes.h"
+  }
+  module "process.h" {
+    export *
+    header "process.h"
+  }
+  module "corecrt_io.h" {
+    export *
+    header "corecrt_io.h"
+  }
+  module "corecrt_terminate.h" {
+    export *
+    header "corecrt_terminate.h"
+  }
+  module "crtdbg.h" {
+    export *
+    header "crtdbg.h"
+  }
+  module "io.h" {
+    export *
+    header "io.h"
+  }
+  module "tchar.h" {
+    export *
+    header "tchar.h"
+  }
+  module "corecrt_malloc.h" {
+    export *
+    header "corecrt_malloc.h"
+  }
+  module "corecrt_wconio.h" {
+    export *
+    header "corecrt_wconio.h"
+  }
+  module "ctype.h" {
+    export *
+    header "ctype.h"
+  }
+  module "locale.h" {
+    export *
+    header "locale.h"
+  }
+  module "tgmath.h" {
+    export *
+    header "tgmath.h"
+  }
+  module "corecrt_math.h" {
+    export *
+    header "corecrt_math.h"
+  }
+  module "corecrt_wctype.h" {
+    export *
+    header "corecrt_wctype.h"
+  }
+  module "direct.h" {
+    export *
+    header "direct.h"
+  }
+  module "malloc.h" {
+    export *
+    header "malloc.h"
+  }
+  module "search.h" {
+    export *
+    header "search.h"
   }
   module "time.h" {
     export *
     header "time.h"
   }
-  // FIXME: Uncomment when we resolve wchar.h:181 --
-  //  where FILE* from `_In_opt_ FILE* _F` is defined.
-  /*module "wchar.h" {
+  module "corecrt_math_defines.h" {
+    export *
+    header "corecrt_math_defines.h"
+  }
+  module "corecrt_wdirect.h" {
+    export *
+    header "corecrt_wdirect.h"
+  }
+  module "dos.h" {
+    export *
+    header "dos.h"
+  }
+  module "math.h" {
+    export *
+    header "math.h"
+  }
+  module "share.h" {
+    export *
+    header "share.h"
+  }
+  module "uchar.h" {
+    export *
+    header "uchar.h"
+  }
+  module "corecrt_memcpy_s.h" {
+    export *
+    header "corecrt_memcpy_s.h"
+  }
+  module "corecrt_wio.h" {
+    export *
+    header "corecrt_wio.h"
+  }
+  module "errno.h" {
+    export *
+    header "errno.h"
+  }
+  module "mbctype.h" {
+    export *
+    header "mbctype.h"
+  }
+  module "signal.h" {
+    export *
+    header "signal.h"
+  }
+  module "wchar.h" {
     export *
     header "wchar.h"
-  }*/
+  }
+  module "corecrt_memory.h" {
+    export *
+    header "corecrt_memory.h"
+  }
+  module "corecrt_wprocess.h" {
+    export *
+    header "corecrt_wprocess.h"
+  }
+  module "fcntl.h" {
+    export *
+    header "fcntl.h"
+  }
+  module "mbstring.h" {
+    export *
+    header "mbstring.h"
+  }
+  module "stddef.h" {
+    export *
+    header "stddef.h"
+  }
+  module "wctype.h" {
+    export *
+    header "wctype.h"
+  }
+  module "stdint.h" {
+    export *
+    header "stdint.h"
+  }
 
-  use "xlocale.h"
+  use "vcruntime"
+  use "crtdefs.h"
 }
 
-// glib specific header. In it's own module because it
-// doesn't exist on some systems with unpatched glib 2.26+
-module "xlocale.h" [system] [extern_c] {
+// crtdefs.h: In it's own module because
+// it is imported by libc and std both
+// and it is not found in the ucrt directory
+module "crtdefs.h" [system] {
   export *
-  header "xlocale.h"
+  header "crtdefs.h"
 }

--- a/interpreter/cling/include/cling/std_msvc.modulemap
+++ b/interpreter/cling/include/cling/std_msvc.modulemap
@@ -484,6 +484,7 @@ module "std" [system] {
     header "xstring"
   }
   module "xthreads.h" {
+    requires !header_existence
     export *
     header "xthreads.h"
   }

--- a/interpreter/cling/include/cling/std_msvc.modulemap
+++ b/interpreter/cling/include/cling/std_msvc.modulemap
@@ -489,6 +489,7 @@ module "std" [system] {
     header "xthreads.h"
   }
   module "xtimec.h" {
+    requires !header_existence
     export *
     header "xtimec.h"
   }

--- a/interpreter/cling/include/cling/std_msvc.modulemap
+++ b/interpreter/cling/include/cling/std_msvc.modulemap
@@ -2,9 +2,14 @@ module "std" [system] {
   requires windows
 
   export *
+
   module "algorithm" {
     export *
     header "algorithm"
+  }
+  module "any" {
+    export *
+    header "any"
   }
   module "array" {
     export *
@@ -14,11 +19,19 @@ module "std" [system] {
     export *
     header "atomic"
   }
+  module "bit" {
+    requires cplusplus20, !header_existence
+    export *
+    header "bit"
+  }
   module "bitset" {
     export *
     header "bitset"
   }
-  // no module for cassert to stay consistent with the OS X modulemap
+  module "cassert" {
+    export *
+    header "cassert"
+  }
   module "ccomplex" {
     export *
     header "ccomplex"
@@ -38,6 +51,11 @@ module "std" [system] {
   module "cfloat" {
     export *
     header "cfloat"
+  }
+  module "charconv" {
+    requires cplusplus17, !header_existence
+    export *
+    header "charconv"
   }
   module "chrono" {
     export *
@@ -63,11 +81,25 @@ module "std" [system] {
     export *
     header "cmath"
   }
+  module "codecvt" {
+    export *
+    header "codecvt"
+  }
+  module "compare" {
+    requires cplusplus20, !header_existence
+    export *
+    header "compare"
+  }
   module "complex" {
     export *
     header "complex"
   }
-    module "condition_variable" {
+  module "concepts" {
+    requires cplusplus20, !header_existence
+    export *
+    header "concepts"
+  }
+  module "condition_variable" {
     export *
     header "condition_variable"
   }
@@ -80,7 +112,6 @@ module "std" [system] {
     header "csignal"
   }
   module "cstdalign" {
-    requires !cplusplus17, !header_existence
     export *
     header "cstdalign"
   }
@@ -104,16 +135,9 @@ module "std" [system] {
     export *
     header "cstdio"
   }
-  // Causes a cycle between clang's builtin modules
-  // and the STL as clang's builtin modules include
-  // this header (and in turn, the STL also includes
-  // clang's builtin headers).
-  // See the include for stdlib.h (which is forwarded
-  // to this C++ header) in clang's mm_malloc.h for the
-  // problematic code which we can't fix.
   module "cstdlib" {
     export *
-    textual header "cstdlib"
+    header "cstdlib"
   }
   module "cstring" {
     export *
@@ -127,10 +151,10 @@ module "std" [system] {
     export *
     header "ctime"
   }
-//  module "ctype.h" {
-//    export *
-//    header "ctype.h"
-//  }
+  module "cuchar" {
+    export *
+    header "cuchar"
+  }
   module "cwchar" {
     export *
     header "cwchar"
@@ -146,6 +170,16 @@ module "std" [system] {
   module "exception" {
     export *
     header "exception"
+  }
+  module "execution" {
+    requires cplusplus17, !header_existence
+    export *
+    header "execution"
+  }
+  module "filesystem" {
+    requires cplusplus17, !header_existence
+    export *
+    header "filesystem"
   }
   module "forward_list" {
     export *
@@ -163,15 +197,6 @@ module "std" [system] {
     export *
     header "future"
   }
-/*  module "hash_map" {
-    export *
-    header "hash_map"
-  }
-  module "hash_set" {
-    export *
-    header "hash_set"
-  }
-  */
   module "initializer_list" {
     export *
     header "initializer_list"
@@ -192,10 +217,10 @@ module "std" [system] {
     export *
     header "iostream"
   }
-//  module "iostream.h" {
-//    export *
-//    header "iostream.h"
-//  }
+  module "iso646.h" {
+    export *
+    header "iso646.h"
+  }
   module "istream" {
     export *
     header "istream"
@@ -216,25 +241,18 @@ module "std" [system] {
     export *
     header "locale"
   }
-//  module "locale.h" {
-//    export *
-//    header "locale.h"
-//  }
   module "map" {
     export *
     header "map"
   }
-//  module "math.h" {
-//    export *
-//    header "math.h"
-//  }
   module "memory" {
     export *
     header "memory"
   }
-  module "xmemory" {
+  module "memory_resource" {
+    requires cplusplus17, !header_existence
     export *
-    header "xmemory"
+    header "memory_resource"
   }
   module "mutex" {
     export *
@@ -244,9 +262,19 @@ module "std" [system] {
     export *
     header "new"
   }
+  module "numbers" {
+    requires cplusplus20, !header_existence
+    export *
+    header "numbers"
+  }
   module "numeric" {
     export *
     header "numeric"
+  }
+  module "optional" {
+    requires cplusplus17, !header_existence
+    export *
+    header "optional"
   }
   module "ostream" {
     export *
@@ -260,6 +288,11 @@ module "std" [system] {
     export *
     header "random"
   }
+  module "ranges" {
+    requires cplusplus20, !header_existence
+    export *
+    header "ranges"
+  }
   module "ratio" {
     export *
     header "ratio"
@@ -272,14 +305,18 @@ module "std" [system] {
     export *
     header "scoped_allocator"
   }
+  module "setjmp.h" {
+    export *
+    header "setjmp.h"
+  }
   module "set" {
     export *
     header "set"
   }
-//  module "setjmp.h" {
-//    export *
-//    header "setjmp.h"
-//  }
+  module "shared_mutex" {
+    export *
+    header "shared_mutex"
+  }
   module "sstream" {
     export *
     header "sstream"
@@ -301,22 +338,18 @@ module "std" [system] {
     header "string"
   }
   module "string_view" {
-    requires !header_existence
+    requires cplusplus17, !header_existence
     export *
     textual header "string_view"
   }
-//  module "string.h" {
-//    export *
-//    header "string.h"
-// }
+  module "strstream" {
+    export *
+    header "strstream"
+  }
   module "system_error" {
     export *
     header "system_error"
   }
-//  module "tgmath.h" {
-//    export *
-//    header "tgmath.h"
-//  }
   module "thread" {
     export *
     header "thread"
@@ -345,6 +378,10 @@ module "std" [system] {
     export *
     header "unordered_set"
   }
+  module "use_ansi.h" {
+    export *
+    header "use_ansi.h"
+  }
   module "utility" {
     export *
     header "utility"
@@ -353,26 +390,129 @@ module "std" [system] {
     export *
     header "valarray"
   }
+  module "variant" {
+    requires cplusplus17, !header_existence
+    export *
+    header "variant"
+  }
   module "vector" {
     export *
     header "vector"
   }
-  module "codecvt" {
-    requires !header_existence
+  module "version" {
     export *
-    header "codecvt"
+    header "version"
   }
-  module "cuchar" {
-    requires !header_existence
+  module "xatomic.h" {
     export *
-    header "cuchar"
+    header "xatomic.h"
   }
-  module "yvals_core.h" {
+  module "xbit_ops.h" {
     export *
-    header "yvals_core.h"
+    header "xbit_ops.h"
+  }
+  module "xerrc.h" {
+    export *
+    header "xerrc.h"
+  }
+  module "xfacet" {
+    export *
+    header "xfacet"
+  }
+  module "xhash" {
+    export *
+    header "xhash"
+  }
+  module "xiosbase" {
+    export *
+    header "xiosbase"
+  }
+  module "xkeycheck.h" {
+    export *
+    header "xkeycheck.h"
+  }
+  module "xlocale" {
+    export *
+    header "xlocale"
+  }
+  module "xlocbuf" {
+    export *
+    header "xlocbuf"
+  }
+  module "xlocinfo" {
+    export *
+    header "xlocinfo"
+  }
+  module "xlocinfo.h" {
+    export *
+    header "xlocinfo.h"
+  }
+  module "xlocmes" {
+    export *
+    header "xlocmes"
+  }
+  module "xlocmon" {
+    export *
+    header "xlocmon"
+  }
+  module "xlocnum" {
+    export *
+    header "xlocnum"
+  }
+  module "xloctime" {
+    export *
+    header "xloctime"
+  }
+  module "xmemory" {
+    export *
+    header "xmemory"
+  }
+  module "xpolymorphic_allocator.h" {
+    export *
+    header "xpolymorphic_allocator.h"
+  }
+  module "xsmf_control.h" {
+    export *
+    header "xsmf_control.h"
+  }
+  module "xstddef" {
+    export *
+    header "xstddef"
+  }
+  module "xstring" {
+    export *
+    header "xstring"
+  }
+  module "xthreads.h" {
+    export *
+    header "xthreads.h"
+  }
+  module "xtimec.h" {
+    export *
+    header "xtimec.h"
+  }
+  module "xtr1common" {
+    export *
+    header "xtr1common"
+  }
+  module "xtree" {
+    export *
+    header "xtree"
+  }
+  module "xutility" {
+    export *
+    header "xutility"
+  }
+  module "ymath.h" {
+    export *
+    header "ymath.h"
   }
   module "yvals.h" {
     export *
     header "yvals.h"
+  }
+  module "yvals_core.h" {
+    export *
+    header "yvals_core.h"
   }
 }

--- a/interpreter/cling/include/cling/vcruntime.modulemap
+++ b/interpreter/cling/include/cling/vcruntime.modulemap
@@ -1,14 +1,37 @@
 module "vcruntime" [system] {
   requires windows
   
+  module "sal.h" {
+    export *
+    header "sal.h"
+  }
+  module "vadefs.h" {
+    export *
+    header "vadefs.h"
+  }
   module "vcruntime.h" {
     export *
     header "vcruntime.h"
   }
-  
+  module "vcruntime_new.h" {
+    export *
+    header "vcruntime_new.h"
+  }
+  module "vcruntime_new_debug.h" {
+    export *
+    header "vcruntime_new_debug.h"
+  }
+  module "vcruntime_startup.h" {
+    export *
+    header "vcruntime_startup.h"
+  }
   module "vcruntime_string.h" {
     export *
     header "vcruntime_string.h"
   }
-  
+  module "vcruntime_typeinfo.h" {
+    export *
+    textual header "vcruntime_typeinfo.h"
+  }
+
 }


### PR DESCRIPTION
This PR fixes compilation issues of std.modulemap and libc.modulemap on Windows. This is a core step towards Enabling the Modules support in Windows.

@vgvassilev @bellenot 