### PR TITLE
[rootcling] Allow users to specify byproduct modules.

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -639,9 +639,10 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   #---call rootcint------------------------------------------
   add_custom_command(OUTPUT ${dictionary}.cxx ${pcm_name} ${rootmap_name} ${cpp_module_file}
                      COMMAND ${command} -v2 -f  ${dictionary}.cxx ${newargs} ${excludepathsargs} ${rootmapargs}
+                                        ${ARG_OPTIONS}
                                         ${definitions} "$<$<BOOL:${module_defs}>:-D$<JOIN:${module_defs},;-D>>"
                                         ${includedirs} "$<$<BOOL:${module_incs}>:-I$<JOIN:${module_incs},;-I>>"
-                                        ${ARG_OPTIONS} ${headerfiles} ${_linkdef}
+                                        ${headerfiles} ${_linkdef}
                      IMPLICIT_DEPENDS ${_implicitdeps}
                      DEPENDS ${_list_of_header_dependencies} ${_linkdef} ${ROOTCINTDEP}
                              ${MODULE_LIB_DEPENDENCY} ${ARG_EXTRA_DEPENDENCIES}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -198,6 +198,12 @@ else()
   target_include_directories(BaseTROOT PRIVATE ${CMAKE_SOURCE_DIR}/core/unix/inc)
 endif()
 
+if (runtime_cxxmodules)
+  list(APPEND core_implicit_modules "-mByproduct" "ROOT_Foundation_Stage1_NoRTTI")
+  list(APPEND core_implicit_modules "-mByproduct" "ROOT_Foundation_C")
+  list(APPEND core_implicit_modules "-mByproduct" "ROOT_Rtypes")
+endif(runtime_cxxmodules)
+
 ROOT_GENERATE_DICTIONARY(G__Core
   ${Core_dict_headers}
   ${Clib_dict_headers}
@@ -215,6 +221,7 @@ ROOT_GENERATE_DICTIONARY(G__Core
     Core
   OPTIONS
     -writeEmptyRootPCM
+    ${core_implicit_modules}
   LINKDEF
     base/inc/LinkDef.h
 )

--- a/sql/sqlite/CMakeLists.txt
+++ b/sql/sqlite/CMakeLists.txt
@@ -8,6 +8,10 @@
 # CMakeLists.txt file for building ROOT sql/pgsql package
 ############################################################################
 
+if(runtime_cxxmodules AND APPLE)
+  list(APPEND extra_dictionary_opts "-mByproduct" "SQLite3")
+endif()
+
 ROOT_STANDARD_LIBRARY_PACKAGE(RSQLite
   HEADERS
     TSQLiteResult.h
@@ -23,6 +27,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RSQLite
     Core
     Net
     RIO
+  DICTIONARY_OPTIONS
+    ${extra_dictionary_opts}
 )
 
 target_include_directories(RSQLite PUBLIC ${SQLITE_INCLUDE_DIR})


### PR DESCRIPTION
When building the foundation of frameworks often the dictionary modules require third party modules such as clhep, boost and tinyxml. Those modules do not require I/O information and it is permissible to be built as a part of another dictionary module build.

This patch relaxes the eager check for implicit module builds by adding a flag -mByproduct which turns of the diagnostic disallowing implicit module builds.

cc @oshadura, @davidlange6, @smuzaffar 