### PR TITLE
v618: Also capture SFINAE error counts (ROOT-10754):

### DIFF
--- a/core/metacling/src/ClingRAII.h
+++ b/core/metacling/src/ClingRAII.h
@@ -26,6 +26,7 @@ namespace ROOT {
           decltype(clang::Sema::MaybeODRUseExprs) fMaybeODRUseExprs;
           decltype(clang::Sema::FunctionScopes) fFunctionScopes;
           decltype(clang::Sema::UndefinedButUsed) fUndefinedButUsed;
+          clang::Sema::SFINAETrap fSFINAETrap;
           clang::Sema& fSema;
           void Swapem() {
              std::swap(fCleanup, fSema.Cleanup);
@@ -34,7 +35,7 @@ namespace ROOT {
              std::swap(fFunctionScopes, fSema.FunctionScopes);
              std::swap(fUndefinedButUsed, fSema.UndefinedButUsed);
           }
-          SemaExprCleanupsRAII(clang::Sema& S): fSema(S) {
+          SemaExprCleanupsRAII(clang::Sema& S): fSFINAETrap(S), fSema(S) {
              fFunctionScopes.push_back(new clang::sema::FunctionScopeInfo(S.Diags));
              Swapem();
           };


### PR DESCRIPTION
When doing lookup on templates, instantiation can fail.
This can be triggered during templarte instantiation somewhere
in clang, autoloading, cling-lookup - and SFINAE errors that
occurr in cling-lookup must not bubble up to clang, or else
clang will think that there was a problem (where there was
none - just e.g. ROOT trying to autoload a bogus template).

In this concrete case, a template specialized with a lambda
was not found by clang, was tried to be autoloaded, TMetaUtils
produced a broken normalized type name, lookup on the broken
type name failed with a SFINAE error - and that ended up being
swallowed by a clang SFINAETrap by the topmost lookup.

Instead, keep SFINAE errors to ourselves.