### PR TITLE
v6.20: Fix potential crash at startup on Windows

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -683,10 +683,11 @@ ROOT::TMetaUtils::TNormalizedCtxtImpl::TNormalizedCtxtImpl(const cling::LookupHe
    keepTypedef(lh, "ULong64_t", true);
 
    clang::QualType toSkip = lh.findType("string", cling::LookupHelper::WithDiagnostics);
-   if (const clang::TypedefType* TT
-       = llvm::dyn_cast_or_null<clang::TypedefType>(toSkip.getTypePtr()))
-      fConfig.m_toSkip.insert(TT->getDecl());
-
+   if (!toSkip.isNull()) {
+      if (const clang::TypedefType* TT
+          = llvm::dyn_cast_or_null<clang::TypedefType>(toSkip.getTypePtr()))
+         fConfig.m_toSkip.insert(TT->getDecl());
+   }
    toSkip = lh.findType("std::string", cling::LookupHelper::WithDiagnostics);
    if (!toSkip.isNull()) {
       if (const clang::TypedefType* TT


### PR DESCRIPTION
When starting root.exe on Windows with a version of Visual Studio different than the one used to build ROOT, it mighty crash with the following error:
Assertion failed: !isNull() && "Cannot retrieve a NULL type pointer", file C:\build\ws\BUILDTYPE\Debug\LABEL\windows10\V\6-20\root\interpreter\llvm\src\tools\clang\include\clang/AST/Type.h, line 630
This patch fixes the issue.