### PR TITLE
Make xtimec.h and xthreads.h textual in std_msvc.modulemap

### DIFF
--- a/interpreter/cling/include/cling/std_msvc.modulemap
+++ b/interpreter/cling/include/cling/std_msvc.modulemap
@@ -486,12 +486,12 @@ module "std" [system] {
   module "xthreads.h" {
     requires !header_existence
     export *
-    header "xthreads.h"
+    textual header "xthreads.h"
   }
   module "xtimec.h" {
     requires !header_existence
     export *
-    header "xtimec.h"
+    textual header "xtimec.h"
   }
   module "xtr1common" {
     export *


### PR DESCRIPTION
This PR makes the xtimec.h and xthreads.h headers textual in std_msvc.modulemap.

This is required as including xtimec.h and xthreads.h cause problems on newer Windows SDKs.

@vgvassilev @bellenot 