### PR TITLE
v6.20: Fix potential startup error messages on Windows

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1189,7 +1189,9 @@ static void RegisterPreIncludedHeaders(cling::Interpreter &clingInterp)
 
    // We must include it even when we have modules because it is marked as
    // textual in the modulemap due to the nature of the assert header.
+#ifndef R__WIN32
    PreIncludes += "#include <cassert>\n";
+#endif
    PreIncludes += "using namespace std;\n";
    clingInterp.declare(PreIncludes);
 }


### PR DESCRIPTION
Fix the following error messages displayed when starting ROOT compiled with a different version of Visual Studio than the one installed on the system:
```
In file included from input_line_3:38:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\\include\cassert:9:
In file included from C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\assert.h:12:
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h:142:12: error: redefinition of '_CrtEnableIf<true, _Ty>'
    struct _CrtEnableIf<true, _Ty>
           ^~~~~~~~~~~~~~~~~~~~~~~
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h:142:12: note: previous definition is here
    struct _CrtEnableIf<true, _Ty>
           ^
In file included from input_line_3:38:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\\include\cassert:9:
In file included from C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\assert.h:12:
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h:517:16: error: redefinition of '__crt_locale_data_public'
typedef struct __crt_locale_data_public
               ^
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\include\crtdefs.h:10:10: note: 'C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h' included multiple times, additional include
      site here
         ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\assert.h:12:10: note: 'C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h' included multiple times, additional include
      site here
         ^
In file included from input_line_3:38:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\\include\cassert:9:
In file included from C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\assert.h:12:
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h:524:16: error: redefinition of '__crt_locale_pointers'
typedef struct __crt_locale_pointers
               ^
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\include\crtdefs.h:10:10: note: 'C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h' included multiple times, additional include
      site here
         ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\assert.h:12:10: note: 'C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h' included multiple times, additional include
      site here
         ^
In file included from input_line_3:38:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\\include\cassert:9:
In file included from C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\assert.h:12:
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h:532:16: error: redefinition of '_Mbstatet'
typedef struct _Mbstatet
               ^
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\include\crtdefs.h:10:10: note: 'C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h' included multiple times, additional include
      site here
         ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\assert.h:12:10: note: 'C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\ucrt\corecrt.h' included multiple times, additional include
      site here
         ^
```