### PR TITLE
[PyROOT][ROOT-10774] Enable input hook for PyROOTApplication

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_application.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_application.py
@@ -52,6 +52,9 @@ class PyROOTApplication(object):
         # PyOS_InputHook-based mechanism
         # Point to a function which will be called when Python's interpreter prompt
         # is about to become idle and wait for user input from the terminal
+        # We have to import the readline module, which starts calling the PyOS_InputHook
+        # also if Python is in script mode and not in interactive mode.
+        import readline
         InstallGUIEventInputHook()
 
     @staticmethod


### PR DESCRIPTION
The issue is that Python in script mode, e.g., for rootbrowse, does not
call the PyOS_InputHook such as in the interactive mode. This can be
triggered by importing the readline module, which is the same module
than used in the interactive mode.