### PR TITLE
Add a new option in PyKeras to execute  user python code before loading the model

### DIFF
--- a/tmva/pymva/inc/TMVA/MethodPyKeras.h
+++ b/tmva/pymva/inc/TMVA/MethodPyKeras.h
@@ -90,7 +90,7 @@ namespace TMVA {
       TString fTensorBoard;          // Store log files during training
       TString fNumValidationString;  // option string defining the number of validation events
       TString fGpuOptions;    // GPU options (for Tensorflow to set in session_config.gpu_options)
-      TString fUserCodeName; // filename of an optional user sctipt that will be executed before loading the Keras model
+      TString fUserCodeName; // filename of an optional user script that will be executed before loading the Keras model
 
       bool fModelIsSetup = false; // flag whether model is loaded, needed for getMvaValue during evaluation
       float* fVals = nullptr; // variables array used for GetMvaValue

--- a/tmva/pymva/inc/TMVA/MethodPyKeras.h
+++ b/tmva/pymva/inc/TMVA/MethodPyKeras.h
@@ -90,6 +90,7 @@ namespace TMVA {
       TString fTensorBoard;          // Store log files during training
       TString fNumValidationString;  // option string defining the number of validation events
       TString fGpuOptions;    // GPU options (for Tensorflow to set in session_config.gpu_options)
+      TString fUserCodeName; // filename of an optional user sctipt that will be executed before loading the Keras model
 
       bool fModelIsSetup = false; // flag whether model is loaded, needed for getMvaValue during evaluation
       float* fVals = nullptr; // variables array used for GetMvaValue

--- a/tmva/pymva/src/MethodPyKeras.cxx
+++ b/tmva/pymva/src/MethodPyKeras.cxx
@@ -94,7 +94,7 @@ void MethodPyKeras::DeclareOptions() {
                     "Specify as 0.2 or 20% to use a fifth of the data set as validation set. "
                     "Specify as 100 to use exactly 100 events. (Default: 20%)");
    DeclareOptionRef(fUserCodeName = "", "UserCode",
-                    "Optional pythin code provided by the user to be executed before loading the Keras model");
+                    "Optional python code provided by the user to be executed before loading the Keras model");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/pymva/src/MethodPyKeras.cxx
+++ b/tmva/pymva/src/MethodPyKeras.cxx
@@ -93,9 +93,9 @@ void MethodPyKeras::DeclareOptions() {
    DeclareOptionRef(fNumValidationString = "20%", "ValidationSize", "Part of the training data to use for validation. "
                     "Specify as 0.2 or 20% to use a fifth of the data set as validation set. "
                     "Specify as 100 to use exactly 100 events. (Default: 20%)");
-
+   DeclareOptionRef(fUserCodeName = "", "UserCode",
+                    "Optional pythin code provided by the user to be executed before loading the Keras model");
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Validation of the ValidationSize option. Allowed formats are 20%, 0.2 and
@@ -231,6 +231,21 @@ void MethodPyKeras::SetupKerasModel(bool loadTrainedModel) {
     * Load Keras model from file
     */
 
+   Log() << kINFO << " Setup Keras Model " << Endl;
+
+   PyRunString("load_model_custom_objects=None");
+
+
+   // run some python code provided by user for model initialization if needed
+   if (!fUserCodeName.IsNull()) {
+      Log() << kINFO << " Executing user initialization code from  " << fUserCodeName << Endl;
+
+      PyRunString("exec(open('" + fUserCodeName + "').read())");
+   }
+
+   ///PyRunString("print('custom objects for loading model : ',load_model_custom_objects)");
+   //PyRunString("print(K)");
+
    // Load initial model or already trained model
    TString filenameLoadModel;
    if (loadTrainedModel) {
@@ -239,9 +254,12 @@ void MethodPyKeras::SetupKerasModel(bool loadTrainedModel) {
    else {
       filenameLoadModel = fFilenameModel;
    }
-   PyRunString("model = keras.models.load_model('"+filenameLoadModel+"')",
+
+   Log() << kINFO << " Loading Keras Model " << Endl;
+
+   PyRunString("model = keras.models.load_model('"+filenameLoadModel+"', custom_objects=load_model_custom_objects)",
                "Failed to load Keras model from file: "+filenameLoadModel);
-   Log() << kINFO << "Load model from file: " << filenameLoadModel << Endl;
+   Log() << kINFO << "Loaded model from file: " << filenameLoadModel << Endl;
 
 
    /*

--- a/tmva/pymva/src/MethodPyKeras.cxx
+++ b/tmva/pymva/src/MethodPyKeras.cxx
@@ -169,8 +169,11 @@ void MethodPyKeras::ProcessOptions() {
    // check first if using tensorflow backend
    if (GetKerasBackend() == kTensorFlow) {
       Log() << kINFO << "Using TensorFlow backend - setting special configuration options "  << Endl;
-      PyRunString("import tensorflow as tf");
+      PyRunString("import tensorflow as tf","Error importing tensorflow");
       PyRunString("from keras.backend import tensorflow_backend as K");
+      // run these above lines also in global namespace to make them visible overall
+      PyRun_String("import tensorflow as tf", Py_single_input, fGlobalNS, fGlobalNS);
+      PyRun_String("from keras.backend import tensorflow_backend as K", Py_single_input, fGlobalNS, fGlobalNS);
 
       // check tensorflow version
       PyRunString("tf_major_version = int(tf.__version__.split('.')[0])");
@@ -236,15 +239,22 @@ void MethodPyKeras::SetupKerasModel(bool loadTrainedModel) {
    PyRunString("load_model_custom_objects=None");
 
 
-   // run some python code provided by user for model initialization if needed
+
+
    if (!fUserCodeName.IsNull()) {
       Log() << kINFO << " Executing user initialization code from  " << fUserCodeName << Endl;
 
-      PyRunString("exec(open('" + fUserCodeName + "').read())");
+
+        // run some python code provided by user for model initialization if needed
+      TString cmd = "exec(open('" + fUserCodeName + "').read())";
+      TString errmsg = "Error executing the provided user code";
+      PyRunString(cmd, errmsg);
+
+      PyRunString("print('custom objects for loading model : ',load_model_custom_objects)");
    }
 
-   ///PyRunString("print('custom objects for loading model : ',load_model_custom_objects)");
-   //PyRunString("print(K)");
+
+
 
    // Load initial model or already trained model
    TString filenameLoadModel;
@@ -300,6 +310,10 @@ void MethodPyKeras::Init() {
    // NOTE: sys.argv has to be cleared because otherwise TensorFlow breaks
    PyRunString("import sys; sys.argv = ['']", "Set sys.argv failed");
    PyRunString("import keras", "Import Keras failed");
+   // do import also in global namespace
+   auto ret = PyRun_String("import keras", Py_single_input, fGlobalNS, fGlobalNS);
+   if (!ret)
+      Log() << kFATAL << "Import Keras in global namespace fsailed " << Endl;
 
    // Set flag that model is not setup
    fModelIsSetup = false;


### PR DESCRIPTION
One use case for this is to to add custom object when we loading a compiled  Keras model in Pymva

For example if the model is compiled with metrics containing users functions, then these functions must be defined also when loading the model inside MethodPyKers. 

A concrete example (from Tommaso Diotalevi) : 
define precision and recall functions:

```
def precision(y_true, y_pred): #taken from old keras source code
    true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
    predicted_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
    precision = true_positives / (predicted_positives + K.epsilon())
    return precision
def recall(y_true, y_pred): #taken from old keras source code
    true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
    possible_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
    recall = true_positives / (possible_positives + K.epsilon())
    return recall
```

compile the model : 

```
model.compile(loss='binary_crossentropy', optimizer=Adam(lr=0.001), metrics=['accuracy',precision,recall])
```

When loading the model in `keras.load_model` the user provided functions must be known and passed as a dictionary, for example: 

```
load_model_custom_objects = {'precision': precision, 'recall': recall}

model = keras.models.load_model('model_dense.h5', custom_objects=load_model_custum_objects)
```

This PR provdes a way to the user to give Python code (e.g. defining the users functions and 
the variable `load_model_custom_object` ) that then can be executed in MethodPyKeras in its initialization. 
