### PR TITLE
v6.20: Filter out non existing library name (there is only a dll)

### DIFF
--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -4294,7 +4294,8 @@ const char *TWinNTSystem::GetLibraries(const char *regexp, const char *options,
             }
             if (!ntlibs.IsNull()) ntlibs.Append(" ");
             if ((s.Index("python") == kNPOS) && (s.Index("cppyy") == kNPOS) &&
-                (s.Index("vcruntime") == kNPOS) && (s.Index(".pyd") == kNPOS))
+                (s.Index("vcruntime") == kNPOS) && (s.Index(".pyd") == kNPOS) &&
+                (s.Index("msvcp") == kNPOS))
               ntlibs.Append(s);
          }
          start += end+1;


### PR DESCRIPTION
This fixes an issue with ACLiC trying to link against `msvcp140.lib` which doesn't exist (there is only `msvcp140.dll`)