### PR TITLE
[wincxxmodules] Fix Core.pcm on Windows

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <fcntl.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 #endif

--- a/core/foundation/inc/ROOT/RWrap_libcpp_string_view.h
+++ b/core/foundation/inc/ROOT/RWrap_libcpp_string_view.h
@@ -425,7 +425,7 @@ inline namespace __1 {
          __pos += __n;
       else
          __pos = __sz;
-      const _CharT* __r = _VSTD::__find_end(
+      const _CharT* __r = _VSTD::find_end(
                                             __p, __p + __pos, __s, __s + __n, _Traits::eq,
                                             random_access_iterator_tag(), random_access_iterator_tag());
       if (__n > 0 && __r == __p + __pos)

--- a/interpreter/cling/include/cling/libc_msvc.modulemap
+++ b/interpreter/cling/include/cling/libc_msvc.modulemap
@@ -39,10 +39,6 @@ module "libc" [system] [extern_c] [no_undeclared_includes] {
     export *
     header "corecrt_wstdlib.h"
   }
-  module "float.h" {
-    export *
-    header "float.h"
-  }
   module "minmax.h" {
     export *
     header "minmax.h"

--- a/interpreter/cling/include/cling/std_msvc.modulemap
+++ b/interpreter/cling/include/cling/std_msvc.modulemap
@@ -176,6 +176,10 @@ module "std" [system] {
     export *
     header "execution"
   }
+  module "float.h" {
+    export *
+    header "float.h"
+  }
   module "filesystem" {
     requires cplusplus17, !header_existence
     export *


### PR DESCRIPTION
This PR fixes building of Core module on Windows. 

```
/.../build/include\ROOT/RWrap_libcpp_string_view.h(428,34): error G1A4676F8: no member named '__find_end' in namespace 'std'; did you mean 'find_end'?
        const _CharT* __r = _VSTD::__find_end(
                            ~~~~~~~^~~~~~~~~~
                                   find_end
```

@vgvassilev @bellenot 