### PR TITLE
[io] Protect out-of-bounds access in R__WriteDestructorBody:

### DIFF
--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -3528,7 +3528,8 @@ static void R__WriteDestructorBody(FILE *file, TIter &next)
                   std::vector<std::string> inside;
                   int nestedLoc;
                   TClassEdit::GetSplit(enamebasic, inside, nestedLoc, TClassEdit::kLong64);
-                  if (inside[1][inside[1].size()-1]=='*' || inside[2][inside[2].size()-1]=='*') {
+                  if ((!inside[1].empty() && inside[1][inside[1].size()-1]=='*')
+                     || (!inside[2].empty() && inside[2][inside[2].size()-1]=='*')) {
                      fprintf(file,"   std::for_each( (%s %s).rbegin(), (%s %s).rend(), DeleteObjectFunctor() );\n",prefix,ename,prefix,ename);
                   }
                }


### PR DESCRIPTION
Fixes assert in roottest/root/meta/MakeProject/runcms310.C
```
/builddir/build/BUILD/gcc-8.3.1-20190223/obj-x86_64-redhat-linux/x86_64-redhat-linux/libstdc++-v3/include/bits/basic_string.h:1067: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator[](std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::reference = char&; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]: Assertion '__pos <= size()' failed.
#3  0x00007ffff78c7c11 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator[](unsigned long) () from /lib64/libstdc++.so.6
#4  0x00007ffff67fb9c3 in R__WriteDestructorBody (file=0x1e01c10, next=...)
    at /mnt/build/wsincrmaster/LABEL/ROOT-fedora29/SPEC/python3/root/io/io/src/TStreamerInfo.cxx:3531
#5  0x00007ffff67fcfcf in TStreamerInfo::GenerateDeclaration (this=0x2b1e950, fp=0x1d7ddc0, sfp=0x1e01c10,
    subClasses=0x7fffffff8db0, top=true)
    at /mnt/build/wsincrmaster/LABEL/ROOT-fedora29/SPEC/python3/root/io/io/src/TStreamerInfo.cxx:3772
#6  0x00007ffff67fe2bf in TStreamerInfo::GenerateHeaderFile (this=0x2b1e950, dirname=0x7fffffff92d9 "cms310",
    subClasses=0x7fffffff8db0, extrainfos=0x7fffffff9210)
    at /mnt/build/wsincrmaster/LABEL/ROOT-fedora29/SPEC/python3/root/io/io/src/TStreamerInfo.cxx:3976
#7  0x00007ffff67a99bf in TFile::MakeProject (this=0x158e280, dirname=0x7ffff793204c "cms310", option=0x7ffff7932055 "RECREATE+")
    at /mnt/build/wsincrmaster/LABEL/ROOT-fedora29/SPEC/python3/root/io/io/src/TFile.cxx:2843
```