### PR TITLE
Try to remove #include <cassert> to see if it's still needed

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1272,11 +1272,6 @@ static void RegisterPreIncludedHeaders(cling::Interpreter &clingInterp)
    if (!hasCxxModules)
       PreIncludes += "#include <string>\n";
 
-   // We must include it even when we have modules because it is marked as
-   // textual in the modulemap due to the nature of the assert header.
-#ifndef R__WIN32
-   PreIncludes += "#include <cassert>\n";
-#endif
    PreIncludes += "using namespace std;\n";
    clingInterp.declare(PreIncludes);
 }


### PR DESCRIPTION
Since it has been successfully removed on Windows (git commit [#9709188476ed](https://github.com/root-project/root/commit/9709188476ed)), make sure it is still needed on other platforms