### PR TITLE
[Exp PyROOT] TFile: throw exception when trying to open a non-existin…

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_tfile.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/pythonization/_tfile.py
@@ -1,4 +1,4 @@
-# Author: Danilo Piparo CERN  08/2018
+# Author: Danilo Piparo, Massimiliano Galli CERN  08/2018
 
 ################################################################################
 # Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.                      #
@@ -15,12 +15,45 @@
 
 from libROOTPythonizations import AddFileOpenPyz
 from ROOT import pythonization
+from libcppyy import bind_object
+
+def _TFileConstructor(self, *args):
+    # Redefinition of ROOT.TFile(str, ...):
+    # check if the instance of TFile has IsZombie() = True
+    # and raise OSError if so.
+    # Parameters:
+    # self: instance of TFile class
+    # *args: arguments passed to the constructor
+    self._OriginalConstructor(*args)
+    if len(args) >= 1:
+        if self.IsZombie():
+            raise OSError('Failed to open file {}'.format(args[0]))
+
+def _TFileOpen(klass, *args):
+    # Redefinition of ROOT.TFile.Open(str, ...):
+    # check if the instance of TFile is a C++ nullptr and raise a
+    # OSError if this is the case.
+    # Parameters:
+    # klass: TFile class
+    # *args: arguments passed to the constructor
+    f = klass._OriginalOpen(*args)
+    if f == bind_object(0, klass):
+        # args[0] can be either a string or a TFileOpenHandle
+        raise OSError('Failed to open file {}'.format(str(args[0])))
+    return f
 
 # Pythonizor function
 @pythonization()
 def pythonize_tfile(klass, name):
 
     if name == 'TFile':
-       AddFileOpenPyz(klass)
+        # Pythonizations for TFile::Open
+        AddFileOpenPyz(klass)
+        klass._OriginalOpen = klass.Open
+        klass.Open = classmethod(_TFileOpen)
+
+        # Pythonization for TFile constructor
+        klass._OriginalConstructor = klass.__init__
+        klass.__init__ = _TFileConstructor
 
     return True

--- a/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/test/CMakeLists.txt
@@ -29,6 +29,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tclass_dynamiccast tclass_dynamiccast.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tdirectory_attrsyntax tdirectory_attrsyntax.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tdirectoryfile_attrsyntax_get tdirectoryfile_attrsyntax_get.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tfile_attrsyntax_get_writeobject_open tfile_attrsyntax_get_writeobject_open.py)
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tfile_constructor tfile_constructor.py)
 
 # TTree and subclasses pythonizations
 file(COPY TreeHelper.h DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/bindings/pyroot_experimental/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
+++ b/bindings/pyroot_experimental/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
@@ -68,6 +68,13 @@ class TFileOpenReadWrite(unittest.TestCase):
         # inside the directory
         self.assertEqual(f.__dict__['h'], f.h)
 
+    def test_oserror(self):
+        # check that an OSError is raised when an inexistent file is opened
+        # both with a string and an instance of TFileOpenHandle as arguments
+        self.assertRaises(OSError, ROOT.TFile.Open, 'inexistent_file.root')
+        handle = ROOT.TFile.AsyncOpen("inexistent_file.root")
+        self.assertRaises(OSError, ROOT.TFile.Open, handle)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/pyroot_experimental/pythonizations/test/tfile_constructor.py
+++ b/bindings/pyroot_experimental/pythonizations/test/tfile_constructor.py
@@ -1,0 +1,18 @@
+import unittest
+
+import ROOT
+
+
+class TFileConstructor(unittest.TestCase):
+    """
+    Test for the TFile constructor
+    """
+
+    def test_oserror(self):
+        # check that an OSError is raised when the string passed as argument
+        # refers to an inexistent file
+        self.assertRaises(OSError, ROOT.TFile, 'inexistent_file.root')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…g file

An error is raised when ROOT.TFile(file_name) and
ROOT.TFile.Open(file_name) try to open a non-existing file, as suggested
in https://sft.its.cern.ch/jira/browse/ROOT-9915

It is open to discussion whether we should return the object anyways (i.e. keep the C++ behavior) or just raise an error (like it is done here).