### PR TITLE
Documentation updates

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -152,10 +152,12 @@ public:
       return static_cast<T*>(GetObjectChecked(namecycle, TClass::GetClass<T>()));
    }
    virtual TDirectory *GetDirectory(const char *namecycle, Bool_t printError = false, const char *funcname = "GetDirectory");
-   template <class T> inline void GetObject(const char* namecycle, T*& ptr) // See TDirectory::Get for information
-      {
-         ptr = (T *)GetObjectChecked(namecycle, TClass::GetClass<T>());
-      }
+   /// Get an object with proper type checking. If the object doesn't exist in the file or if the type doesn't match,
+   /// a `nullptr` is returned. Also see TDirectory::Get().
+   template <class T> inline void GetObject(const char* namecycle, T*& ptr)
+   {
+      ptr = (T *)GetObjectChecked(namecycle, TClass::GetClass<T>());
+   }
    virtual void       *GetObjectChecked(const char *namecycle, const char* classname);
    virtual void       *GetObjectChecked(const char *namecycle, const TClass* cl);
    virtual void       *GetObjectUnchecked(const char *namecycle);
@@ -209,7 +211,12 @@ public:
 private:
            Int_t       WriteObject(void *obj, const char* name, Option_t *option="", Int_t bufsize=0); // Intentionally not implemented.
 public:
-   template <class T> inline Int_t WriteObject(const T* obj, const char* name, Option_t *option="", Int_t bufsize=0) // see TDirectory::WriteTObject or TDirectoryWriteObjectAny for explanation
+   /// Write an object with proper type checking.
+   /// \param[in] obj Pointer to an object to be written.
+   /// \param[in] name Name of the object in the file.
+   /// \param[in] option Options. See TDirectory::WriteTObject() or TDirectoryWriteObjectAny().
+   /// \param[in] bufsize Buffer size. See TDirectory::WriteTObject().
+   template <class T> inline Int_t WriteObject(const T* obj, const char* name, Option_t *option="", Int_t bufsize=0)
       {
          return WriteObjectAny(obj, TClass::GetClass<T>(), name, option, bufsize);
       }

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1302,7 +1302,7 @@ void TDirectory::RegisterContext(TContext *ctxt) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// See TDirectoryFile::WriteTObject for details
+/// \copydoc TDirectory::WriteTObject().
 
 Int_t TDirectory::WriteTObject(const TObject *obj, const char *name, Option_t * /*option*/, Int_t /*bufsize*/)
 {

--- a/hist/hist/src/TProfile.cxx
+++ b/hist/hist/src/TProfile.cxx
@@ -31,37 +31,47 @@ ClassImp(TProfile);
  Profile Histogram.
  Profile histograms are used to display the mean
  value of Y and its error for each bin in X. The displayed error is by default the
- standard error on the mean (i.e. the standard deviation divided by the sqrt(n) )
+ standard error on the mean (i.e. the standard deviation divided by the sqrt(n) ).
  Profile histograms are in many cases an
- elegant replacement of two-dimensional histograms : the inter-relation of two
+ elegant replacement of two-dimensional histograms. The inter-relation of two
  measured quantities X and Y can always be visualized by a two-dimensional
- histogram or scatter-plot; its representation on the line-printer is not particularly
- satisfactory, except for sparse data. If Y is an unknown (but single-valued)
+ histogram or scatter plot, but if Y is an unknown (but single-valued)
  approximate function of X, this function is displayed by a profile histogram with
- much better precision than by a scatter-plot.
+ much better precision than by a scatter plot.
 
  The following formulae show the cumulated contents (capital letters) and the values
- displayed by the printing or plotting routines (small letters) of the elements for bin J.
-
-                                                   2
-       H(J)  =  sum Y                  E(J)  =  sum Y
-       l(J)  =  sum l                  L(J)  =  sum l
-       h(J)  =  H(J)/L(J)                     mean of Y,
-       s(J)  =  sqrt(E(J)/L(J)- h(J)**2)      standard deviation of Y  (e.g. RMS)
-       e(J)  =  s(J)/sqrt(L(J))               standard error on the mean
-
- The displayed bin content for bin J of a TProfile is always h(J). The corresponding bin error is by default
- e(J). In case the option "s" is used (in the constructor or by calling TProfile::BuildOptions)
- the displayed error is  s(J)
-
- In the special case where s(J) is zero (eg, case of 1 entry only in one bin)
- the bin error e(J) is computed from the average of the s(J) for all bins if
- the static function TProfile::Approximate has been called.
+ displayed by the printing or plotting routines (small letters) of the elements for bin j.
+ \f[
+  \begin{align}
+       H(j)  &=  \sum w \cdot Y \\
+       E(j)  &=  \sum w \cdot Y^2 \\
+       W(j)  &=  \sum w \\
+       h(j)  &=  H(j) / W(j)              & &\text{mean of Y,} \\
+       s(j)  &=  \sqrt{E(j)/W(j)- h(j)^2} & &\text{standard deviation of Y} \\
+       e(j)  &=  s(j)/\sqrt{W(j)}         & &\text{standard error on the mean} \\
+  \end{align}
+ \f]
+ The bin content is always the mean of the Y values, but errors change depending on options:
+ \f[
+    \begin{align}
+      \text{GetBinContent}(j) &= h(j) \\
+      \text{GetBinError}(j) &=
+        \begin{cases}
+          e(j)                 &\text{if option="" (default). Error of the mean of all y values.} \\
+          s(j)                 &\text{if option="s". Standard deviation of all y values.} \\
+          \begin{cases} e(j) &\text{if } h(j) \ne 0 \\ 1/\sqrt{12 N} &\text{if } h(j)=0 \end{cases}       &\text{if option="i". This is useful for storing integers such as ADC counts.} \\
+          1/\sqrt{W(j)}           &\text{if option="g". Error of a weighted mean for combining measurements with variances of } w. \\
+        \end{cases}
+    \end{align}
+ \f]
+ In the special case where s(j) is zero (eg, case of 1 entry only in one bin)
+ the bin error e(j) is computed from the average of the s(j) for all bins if
+ the static function TProfile::Approximate() has been called.
  This simple/crude approximation was suggested in order to keep the bin
  during a fit operation. But note that this approximation is not the default behaviour.
-  See also TProfile::BuildOptions for other error options and more detailed explanations
+ See also TProfile::BuildOptions for more on error options.
 
-  Example of a profile histogram with its graphics output
+  ### Creating and drawing a profile histogram
 ~~~{.cpp}
 {
   auto c1 = new TCanvas("c1","Profile histogram example",200,10,700,500);
@@ -107,10 +117,10 @@ TProfile::~TProfile()
 /// has the same effect as calling the special TProfile constructor below
 /// where ymin and ymax are specified.
 ///
-/// H(J) is printed as the channel contents. The errors displayed are s(J) if CHOPT='S'
-/// (spread option), or e(J) if CHOPT=' ' (error on mean).
+/// H(j) is printed as the channel contents. The errors displayed are s(j) if `option`='S'
+/// (spread option), or e(j) if `CHOPT`='' (error on mean).
 ///
-/// See TProfile::BuildOptions for explanation of parameters
+/// See TProfile::BuildOptions() for explanation of parameters
 ///
 /// see also comments in the TH1 base class constructors
 
@@ -123,7 +133,7 @@ TProfile::TProfile(const char *name,const char *title,Int_t nbins,Double_t xlow,
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor for Profile histograms with variable bin size.
 ///
-/// See TProfile::BuildOptions for more explanations on errors
+/// See TProfile::BuildOptions() for more explanations on errors
 /// see also comments in the TH1 base class constructors
 
 TProfile::TProfile(const char *name,const char *title,Int_t nbins,const Float_t *xbins,Option_t *option)
@@ -195,7 +205,7 @@ TProfile::TProfile(const char *name,const char *title,Int_t nbins,Double_t xlow,
 ///           This approximation assumes that the Y values are integer (e.g. ADC counts)
 ///           and have an implicit uncertainty of y +/- 0.5. With the assumption that the probability that y
 ///           takes any value between y-0.5 and y+0.5 is uniform, its standard error is 1/SQRT(12)
-///         - 'g' Errors are 1./SQRT(W) where W is the sum of the weights for the bin J
+///         - 'g' Errors are 1./SQRT(W) where W is the sum of the weights for the bin j
 ///           W is obtained as from TProfile::GetBinEntries(ibin)
 ///           This errors corresponds to the standard deviation of weighted mean where each
 ///           measurement Y is uncorrelated and has an error sigma, which is expressed in the

--- a/hist/hist/src/TProfile2D.cxx
+++ b/hist/hist/src/TProfile2D.cxx
@@ -27,7 +27,7 @@ ClassImp(TProfile2D);
 /** \class TProfile2D
     \ingroup Hist
  Profile2D histograms are used to display the mean
- value of Z and its RMS for each cell in X,Y.
+ value of Z and its error for each cell in X,Y.
  Profile2D histograms are in many cases an
  elegant replacement of three-dimensional histograms : the inter-relation of three
  measured quantities X, Y and Z can always be visualized by a three-dimensional
@@ -37,12 +37,30 @@ ClassImp(TProfile2D);
  much better precision than by a scatter-plot.
 
  The following formulae show the cumulated contents (capital letters) and the values
- displayed by the printing or plotting routines (small letters) of the elements for cell I, J.
-
-       H(I,J)  =  sum Z                  E(I,J)  =  sum Z
-       l(I,J)  =  sum l                  L(I,J)  =  sum l
-       h(I,J)  =  H(I,J)/L(I,J)          s(I,J)  =  sqrt(E(I,J)/L(I,J)- h(I,J)**2)
-       e(I,J)  =  s(I,J)/sqrt(L(I,J))
+ displayed by the printing or plotting routines (small letters) of the elements for cell i, j.
+ \f[
+  \begin{align}
+       H(i,j)  &=  \sum w \cdot Z  \\
+       E(i,j)  &=  \sum w \cdot Z^2 \\
+       W(i,j)  &=  \sum w \\
+       h(i,j)  &=  \frac{H(i,j)}{W(i,j)} \\
+       s(i,j)  &=  \sqrt{E(i,j)/W(i,j)- h(i,j)^2} \\
+       e(i,j)  &=  \frac{s(i,j)}{\sqrt{W(i,j)}}
+  \end{align}
+ \f]
+  The bin content is always the mean of the Z values, but errors change depending on options:
+ \f[
+    \begin{align}
+      \text{GetBinContent}(i,j) &= h(i,j) \\
+      \text{GetBinError}(i,j) &=
+        \begin{cases}
+          e(i,j)                 &\text{if option="" (default). Error of the mean of all z values.} \\
+          s(i,j)                 &\text{if option="s". Standard deviation of z values.} \\
+          \begin{cases} e(j) &\text{if } h(i,j) \ne 0 \\ 1/\sqrt{12 N} &\text{if } h(i,j)=0 \end{cases}       &\text{if option="i". This is useful for storing integers such as ADC counts.} \\
+          1/\sqrt{W(i,j)}           &\text{if option="g". Error of a weighted mean when combining measurements with variances of } w. \\
+        \end{cases}
+    \end{align}
+ \f]
 
  In the special case where s(I,J) is zero (eg, case of 1 entry only in one cell)
  the bin error e(I,J) is computed from the average of the s(I,J) for all cells
@@ -50,7 +68,7 @@ ClassImp(TProfile2D);
  This simple/crude approximation was suggested in order to keep the cell
  during a fit operation. But note that this approximation is not the default behaviour.
 
- Example of a profile2D histogram
+ ### Creating and drawing a 2D profile
  ~~~~{.cpp}
  {
     auto c1 = new TCanvas("c1","Profile histogram example",200,10,700,500);

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -864,10 +864,10 @@ TObject *TDirectoryFile::FindObjectAny(const char *aname) const
 ///   - cycle = "" or cycle = 9999 ==> apply to a memory object
 ///
 /// Examples:
-/// | Pattern | Explanation |
-/// |---------|-------------|
-/// |  foo    | get object named foo in memory if object is not in memory, try with highest cycle from file |
-/// |  foo;1  | get cycle 1 of foo on file |
+/// | %Pattern | Explanation |
+/// |----------|-------------|
+/// |   foo    | get object named foo in memory if object is not in memory, try with highest cycle from file |
+/// |   foo;1  | get cycle 1 of foo on file |
 ///
 /// The retrieved object should in principle derive from TObject.
 /// If not, the function TDirectoryFile::Get<T> should be called.

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -257,6 +257,24 @@ public:
   }
 
 
+  // Server redirection interface
+  Bool_t redirectServers(const RooAbsCollection& newServerList, Bool_t mustReplaceAll=kFALSE, Bool_t nameChange=kFALSE, Bool_t isRecursionStep=kFALSE) ;
+  Bool_t recursiveRedirectServers(const RooAbsCollection& newServerList, Bool_t mustReplaceAll=kFALSE, Bool_t nameChange=kFALSE, Bool_t recurseInNewSet=kTRUE) ;
+  virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) { return kFALSE ; } ;
+  virtual void serverNameChangeHook(const RooAbsArg* /*oldServer*/, const RooAbsArg* /*newServer*/) { } ;
+
+  void addServer(RooAbsArg& server, Bool_t valueProp=kTRUE, Bool_t shapeProp=kFALSE, std::size_t refCount = 1);
+  void addServerList(RooAbsCollection& serverList, Bool_t valueProp=kTRUE, Bool_t shapeProp=kFALSE) ;
+  void replaceServer(RooAbsArg& oldServer, RooAbsArg& newServer, Bool_t valueProp, Bool_t shapeProp) ;
+  void changeServer(RooAbsArg& server, Bool_t valueProp, Bool_t shapeProp) ;
+  void removeServer(RooAbsArg& server, Bool_t force=kFALSE) ;
+  RooAbsArg *findNewServer(const RooAbsCollection &newSet, Bool_t nameChange) const;
+
+
+  /// @}
+  ///////////////////////////////////////////////////////////////////////////////
+
+
   // Parameter & observable interpretation of servers
   friend class RooProdPdf ;
   friend class RooAddPdf ;
@@ -504,18 +522,7 @@ public:
   void SetNameTitle(const char *name, const char *title) ;
 
 
-  // Server redirection interface
-  Bool_t redirectServers(const RooAbsCollection& newServerList, Bool_t mustReplaceAll=kFALSE, Bool_t nameChange=kFALSE, Bool_t isRecursionStep=kFALSE) ;
-  Bool_t recursiveRedirectServers(const RooAbsCollection& newServerList, Bool_t mustReplaceAll=kFALSE, Bool_t nameChange=kFALSE, Bool_t recurseInNewSet=kTRUE) ;
-  virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) { return kFALSE ; } ;
-  virtual void serverNameChangeHook(const RooAbsArg* /*oldServer*/, const RooAbsArg* /*newServer*/) { } ;
 
-  void addServer(RooAbsArg& server, Bool_t valueProp=kTRUE, Bool_t shapeProp=kFALSE, std::size_t refCount = 1);
-  void addServerList(RooAbsCollection& serverList, Bool_t valueProp=kTRUE, Bool_t shapeProp=kFALSE) ;
-  void replaceServer(RooAbsArg& oldServer, RooAbsArg& newServer, Bool_t valueProp, Bool_t shapeProp) ;
-  void changeServer(RooAbsArg& server, Bool_t valueProp, Bool_t shapeProp) ;
-  void removeServer(RooAbsArg& server, Bool_t force=kFALSE) ;
-  RooAbsArg *findNewServer(const RooAbsCollection &newSet, Bool_t nameChange) const;
 
   RooExpensiveObjectCache& expensiveObjectCache() const ;
   virtual void setExpensiveObjectCache(RooExpensiveObjectCache &cache) { _eocache = &cache; }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -672,11 +672,11 @@ RooArgSet* RooAbsArg::getObservables(const RooArgSet* dataList, Bool_t valueOnly
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Create a RooArgSet with all components (branch nodes) of the
+/// expression tree headed by this object.
 RooArgSet* RooAbsArg::getComponents() const
 {
-  // Return a RooArgSet with all component (branch nodes) of the
-  // expression tree headed by this object
-
   TString name(GetName()) ;
   name.Append("_components") ;
 

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -15,28 +15,29 @@
  *****************************************************************************/
 
 //////////////////////////////////////////////////////////////////////////////
+/// \class RooAddModel
 ///
 /// RooAddModel is an efficient implementation of a sum of PDFs of the form
 /// \f[
-///  c_1*\mathrm{PDF}_1 + c_2*\mathrm{PDF}_2 + ... c_n*\mathrm{PDF}_n
-/// \]f
+///  c_1 \cdot \mathrm{PDF}_1 + c_2 \cdot \mathrm{PDF}_2 + ... + c_n \cdot \mathrm{PDF}_n
+/// \f]
 /// or
 /// \f[
-///  c_1*\mathrm{PDF}_1 + c_2*\mathrm{PDF}_2 + ... (1-\sum(c_1, \ldots, c_{n-1}))*\mathrm{PDF}_n
+///  c_1 \cdot \mathrm{PDF}_1 + c_2 \cdot \mathrm{PDF}_2 + ... + \left( 1-\sum_{i=1}^{n-1} c_i \right) \cdot \mathrm{PDF}_n
 /// \f]
 /// The first form is for extended likelihood fits, where the
 /// expected number of events is \f$ \sum_i c_i \f$. The coefficients \f$ c_i \f$
 /// can either be explicitly provided, or, if all components support
-/// extended likelihood fits, they can be calculated the contribution
+/// extended likelihood fits, they can be calculated from the contribution
 /// of each PDF to the total number of expected events.
 ///
 /// In the second form, the sum of the coefficients is enforced to be one,
 /// and the coefficient of the last PDF is calculated from that condition.
 ///
-/// RooAddPdf relies on each component PDF to be normalized and will perform
+/// RooAddModel relies on each component PDF to be normalized, and will perform
 /// no normalization other than calculating the proper last coefficient \f$ c_n \f$, if requested.
 /// An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ is independent
-/// of each coefficient i.
+/// of each coefficient \f$ i \f$.
 ///
 ///
 
@@ -82,7 +83,7 @@ RooAddModel::RooAddModel() :
 /// The number of coefficients must be either equal to the number of PDFs,
 /// in which case extended MLL fitting is enabled, or be one less.
 ///
-/// All PDFs must inherit from RooAbsPdf. All coefficients must inherit from RooAbsReal
+/// All PDFs must inherit from RooAbsPdf. All coefficients must inherit from RooAbsReal.
 
 RooAddModel::RooAddModel(const char *name, const char *title, const RooArgList& inPdfList, const RooArgList& inCoefList, Bool_t ownPdfList) :
   RooResolutionModel(name,title,((RooResolutionModel*)inPdfList.at(0))->convVar()),
@@ -189,7 +190,7 @@ RooAddModel::~RooAddModel()
 /// By default the interpretation of the fraction coefficients is
 /// performed in the contextual choice of observables. This makes the
 /// shape of the p.d.f explicitly dependent on the choice of
-/// observables. This method instructs RooAddPdf to freeze the
+/// observables. This method instructs RooAddModel to freeze the
 /// interpretation of the coefficients to be done in the given set of
 /// observables. If frozen, fractions are automatically transformed
 /// from the reference normalization set to the contextual normalization
@@ -213,10 +214,10 @@ void RooAddModel::fixCoefNormalization(const RooArgSet& refCoefNorm)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// By default the interpretation of the fraction coefficients is
-/// performed in the default range. This make the shape of a RooAddPdf
+/// performed in the default range. This make the shape of a RooAddModel
 /// explicitly dependent on the range of the observables. To allow
 /// a range independent definition of the fraction this function
-/// instructs RooAddPdf to freeze its interpretation in the given
+/// instructs RooAddModel to freeze its interpretation in the given
 /// named range. If the current normalization range is different
 /// from the reference range, the appropriate fraction coefficients
 /// are automically calculation from the reference fractions using
@@ -852,7 +853,7 @@ void RooAddModel::selectNormalizationRange(const char* rangeName, Bool_t force)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return specialized context to efficiently generate toy events from RooAddPdfs
+/// Return specialized context to efficiently generate toy events from RooAddModels.
 
 RooAbsGenContext* RooAddModel::genContext(const RooArgSet &vars, const RooDataSet *prototype, 
 					const RooArgSet* auxProto, Bool_t verbose) const 


### PR DESCRIPTION
Several documentation updates.

For TProfile, a ^2 was missing in the formulae, and weights weren't mentioned anywhere.
The TProfile one now typesets as follows:
![image](https://user-images.githubusercontent.com/16205615/82306058-da170880-99be-11ea-9f37-4e90259e7f12.png)

And TProfile2D:
![image](https://user-images.githubusercontent.com/16205615/82306124-edc26f00-99be-11ea-9ecc-4745c374abf8.png)
