### PR TITLE
[cmake] Enable colored diagnostics also for Ninja:

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -88,6 +88,14 @@ if (CMAKE_COMPILER_IS_GNUCXX)
   endif()
   message(STATUS "Found GCC. Major version ${GCC_MAJOR}, minor version ${GCC_MINOR}")
   set(COMPILER_VERSION gcc${GCC_MAJOR}${GCC_MINOR}${GCC_PATCH})
+  if("${GCC_MAJOR}.${GCC_MINOR}" VERSION_GREATER_EQUAL 4.9
+      AND CMAKE_GENERATOR STREQUAL "Ninja")
+    # GCC checks automatically if we are in interactive terminal mode.
+    # We use color output only for Ninja, because Ninja by default is buffering the output,
+    # so Clang disables colors as it is sure whether the output goes to a file or to a terminal.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=always")
+  endif()
 else()
   set(GCC_MAJOR 0)
   set(GCC_MINOR 0)

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -129,7 +129,6 @@ if (UNIX)
     # Remove absolute path from CMAKE_CXX_COMPILER
     get_filename_component(_name ${CMAKE_CXX_COMPILER} NAME)
     get_filename_component(_path ${CMAKE_CXX_COMPILER} PATH)
-
     # This should probably be more general...but how?
     if(_name STREQUAL "ccache" OR _name STREQUAL "distcc")
       separate_arguments(_arg_list UNIX_COMMAND "${CMAKE_CXX_COMPILER_ARG1}")
@@ -249,7 +248,9 @@ if (UNIX)
       set(CLING_CXX_PATH "${CLING_CXX_PATH} ${CLING_CXX_PATH_ARGS}")
     else()
       # convert CMAKE_CXX_FLAGS to a list for execute_process
-      string(REPLACE " " ";" cling_tmp_arg_list ${CMAKE_CXX_FLAGS})
+      string(REPLACE "-fdiagnostics-color=always" "" cling_tmp_arg_list ${CMAKE_CXX_FLAGS})
+      string(REPLACE "-fcolor-diagnosics" "" cling_tmp_arg_list ${cling_tmp_arg_list})
+      string(REPLACE " " ";" cling_tmp_arg_list ${cling_tmp_arg_list})
       execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} ${cling_tmp_arg_list} -xc++ -E -v /dev/null
                       OUTPUT_QUIET ERROR_VARIABLE CLING_CXX_HEADERS)
     endif()


### PR DESCRIPTION
Ninja buffers compiler output, and compilers then think they should
not use colored output (because no terminal). Force it on them.

And let cling survive: it's parsing compiler output, and the ANSI
color escapes confuse the regexes.