### PR TITLE
[PyROOT] Conditionally add thread to process ROOT events

### DIFF
--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/__init__.py
@@ -94,6 +94,12 @@ if _is_ipython:
 # Register cleanup
 import atexit
 def cleanup():
+    # If spawned, stop thread which processes ROOT events
+    facade = sys.modules[__name__]
+    if 'app' in facade.__dict__ and hasattr(facade.__dict__['app'], 'process_root_events'):
+        facade.__dict__['app'].keep_polling = False
+        facade.__dict__['app'].process_root_events.join()
+
     if 'libROOTPythonizations' in sys.modules:
         backend = sys.modules['libROOTPythonizations']
 

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_application.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_application.py
@@ -78,10 +78,11 @@ class PyROOTApplication(object):
         if self._is_ipython and 'IPython' in sys.modules and sys.modules['IPython'].version_info[0] >= 5:
             # ipython and notebooks, register our event processing with their hooks
             self._ipython_config()
-        elif sys.flags.interactive == 1 or not hasattr(__main__, '__file__'):
+        elif sys.flags.interactive == 1 or not hasattr(__main__, '__file__') or gSystem.InheritsFrom('TMacOSXSystem'):
             # Python in interactive mode, use the PyOS_InputHook to call our event processing
             # - sys.flags.interactive checks for the -i flags passed to python
             # - __main__ does not have the attribute __file__ if the Python prompt is started directly
+            # - MacOS does not allow to run a second thread to process events, fall back to the input hook
             self._inputhook_config()
         else:
             # Python in script mode, start a separate thread for the event processing

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_application.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_application.py
@@ -73,9 +73,27 @@ class PyROOTApplication(object):
     def init_graphics(self):
         """Configure ROOT graphics to be used interactively"""
 
+        # Note that we only end up in this function if gROOT.IsBatch() is false
+        import __main__
         if self._is_ipython and 'IPython' in sys.modules and sys.modules['IPython'].version_info[0] >= 5:
+            # ipython and notebooks, register our event processing with their hooks
             self._ipython_config()
-        else:
+        elif sys.flags.interactive == 1 or not hasattr(__main__, '__file__'):
+            # Python in interactive mode, use the PyOS_InputHook to call our event processing
+            # - sys.flags.interactive checks for the -i flags passed to python
+            # - __main__ does not have the attribute __file__ if the Python prompt is started directly
             self._inputhook_config()
+        else:
+            # Python in script mode, start a separate thread for the event processing
+            def _process_root_events(self):
+                while self.keep_polling:
+                    gSystem.ProcessEvents()
+                    time.sleep(0.01)
+            import threading
+            self.keep_polling = True # Used to shut down the thread safely at teardown time
+            update_thread = threading.Thread(None, _process_root_events, None, (self,))
+            self.process_root_events = update_thread # The thread is joined at teardown time
+            update_thread.daemon = True
+            update_thread.start()
 
         self._set_display_hook()

--- a/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot_experimental/pythonizations/python/ROOT/_facade.py
@@ -22,6 +22,7 @@ class PyROOTConfiguration(object):
         self.IgnoreCommandLineOptions = True
         self.ShutDown = True
         self.DisableRootLogon = False
+        self.StartGUIThread = True
 
 
 class _gROOTWrapper(object):
@@ -167,7 +168,7 @@ class ROOTFacade(types.ModuleType):
 
         # Setup interactive usage from Python
         self.__dict__['app'] = PyROOTApplication(self.PyConfig, self._is_ipython)
-        if not self.gROOT.IsBatch():
+        if not self.gROOT.IsBatch() and self.PyConfig.StartGUIThread:
             self.app.init_graphics()
 
         # Set memory policy to kUseHeuristics.


### PR DESCRIPTION
The PR spawns a separate thread to process ROOT events if we cannot
attach the update mechanism to an exisiting hook such as existing in the
interactive Python mode or for ipython/notebooks.

Related to ROOT-10774