### PR TITLE
[RF] Add missing include of stdexcept (backport v6.20)

### DIFF
--- a/roofit/roofitcore/inc/RooLinkedListIter.h
+++ b/roofit/roofitcore/inc/RooLinkedListIter.h
@@ -20,6 +20,7 @@
 #include "RooLinkedList.h"
 
 #include <memory>
+#include <stdexcept>
 #include <assert.h>
 
 /// Interface for RooFIter-compatible iterators


### PR DESCRIPTION
Starting with gcc10 stdexcept is not anymore implicitly included by
other STL headers

See here: https://gcc.gnu.org/gcc-10/porting_to.html

Jira: https://sft.its.cern.ch/jira/browse/ROOT-10782