### PR TITLE
[asan] Disable "alloc-dealloc-mismatch" in address sanitizer builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ if(asan)
     message(WARNING "Address sanitizer builds only tested with gcc and Clang")
   endif()
 
-  set(ASAN_EXTRA_LD_PRELOAD "${ASAN_RUNTIME_LIBRARY}:${CMAKE_BINARY_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}ROOTSanitizerConfig${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  set(ASAN_EXTRA_LD_PRELOAD "${CMAKE_BINARY_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}ROOTSanitizerConfig${CMAKE_SHARED_LIBRARY_SUFFIX}:${ASAN_RUNTIME_LIBRARY}")
 
   foreach(item IN LISTS ASAN_EXTRA_CXX_FLAGS)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${item}>)

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1533,9 +1533,14 @@ function(ROOT_ADD_TEST test)
   set(_command ${_command} -DSYS=${ROOTSYS})
 
   #- Handle ENVIRONMENT argument
-  if(ASAN_EXTRA_LD_PRELOAD AND _command MATCHES python)
+  if(ASAN_EXTRA_LD_PRELOAD)
     # Address sanitizer runtime needs to be preloaded in all python tests
-    list(APPEND ARG_ENVIRONMENT ${ld_preload}=${ASAN_EXTRA_LD_PRELOAD})
+    # Check now if the -DCMD= contains "python[0-9.] "
+    set(theCommand ${_command})
+    list(FILTER theCommand INCLUDE REGEX "^-DCMD=.*python[0-9.]*[\\^]")
+    if(theCommand OR _command MATCHES roottest/python/cmdLineUtils)
+      list(APPEND ARG_ENVIRONMENT ${ld_preload}=${ASAN_EXTRA_LD_PRELOAD})
+    endif()
   endif()
 
   if(ARG_ENVIRONMENT)

--- a/cmake/modules/SetUpLinux.cmake
+++ b/cmake/modules/SetUpLinux.cmake
@@ -170,11 +170,11 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   endif()
 
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
-  
+
   if(asan)
     # See also core/sanitizer/README.md for what's happening.
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
-    set(ASAN_EXTRA_CXX_FLAGS -fsanitize=address -fno-omit-frame-pointer -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/build/ASan_blacklist.txt)
+    set(ASAN_EXTRA_CXX_FLAGS -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/build/ASan_blacklist.txt)
     set(ASAN_EXTRA_SHARED_LINKER_FLAGS "-fsanitize=address -static-libsan -z undefs")
     set(ASAN_EXTRA_EXE_LINKER_FLAGS "-fsanitize=address -static-libsan -z undefs -Wl,--undefined=__asan_default_options -Wl,--undefined=__lsan_default_options -Wl,--undefined=__lsan_default_suppressions")
   endif()

--- a/cmake/modules/SetUpMacOS.cmake
+++ b/cmake/modules/SetUpMacOS.cmake
@@ -98,7 +98,7 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
        #This should be the right way to do it, but clang 10 seems to have a bug
        #execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan_osx_dynamic.dylib OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
        execute_process(COMMAND mdfind -name libclang_rt.asan_osx_dynamic.dylib OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
-       set(ASAN_EXTRA_CXX_FLAGS -fsanitize=address -fno-omit-frame-pointer -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/build/ASan_blacklist.txt)
+       set(ASAN_EXTRA_CXX_FLAGS -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/build/ASan_blacklist.txt)
        set(ASAN_EXTRA_SHARED_LINKER_FLAGS "-fsanitize=address -static-libsan")
        set(ASAN_EXTRA_EXE_LINKER_FLAGS "-fsanitize=address -static-libsan -Wl,-u,___asan_default_options -Wl,-u,___lsan_default_options -Wl,-u,___lsan_default_suppressions")
      endif()

--- a/core/sanitizer/SanitizerSetup.cxx
+++ b/core/sanitizer/SanitizerSetup.cxx
@@ -11,20 +11,23 @@
 extern "C" {
 
 /// Default options when address sanitizer starts up in ROOT executables.
-/// This is relevant when ROOT's build options `asan` is on.
+/// This is relevant when ROOT's build option `asan` is on.
 /// These can be overridden / augmented by the ASAN_OPTIONS environment variable.
 /// Using ASAN_OPTIONS=help=1 and starting an instrumented ROOT exectuable, available options will be printed.
-const char *__asan_default_options() { 
-   return "strict_string_checks=1"
+const char* __asan_default_options() { 
+
+#ifdef ASAN_DETECT_LEAKS
+#define DETECT_LEAKS ":detect_leaks=1"
+#else
+#define DETECT_LEAKS ":detect_leaks=0"
+#endif
+
+  return "strict_string_checks=1"
          ":detect_stack_use_after_return=1"
          ":check_initialization_order=1"
-#ifdef ASAN_DETECT_LEAKS
-         ":detect_leaks=1"
-#else
-         ":detect_leaks=0"
-#endif
          ":detect_container_overflow=1"
-         ":verbose=1";
+         ":alloc_dealloc_mismatch=0"
+         DETECT_LEAKS;
 }
 
 /// Default options when leak sanitizer starts up in ROOT exectuables.

--- a/core/sanitizer/SanitizerSetup.cxx
+++ b/core/sanitizer/SanitizerSetup.cxx
@@ -27,7 +27,8 @@ const char* __asan_default_options() {
          ":check_initialization_order=1"
          ":detect_container_overflow=1"
          ":alloc_dealloc_mismatch=0"
-         DETECT_LEAKS;
+         DETECT_LEAKS
+         ":verify_asan_link_order=0";
 }
 
 /// Default options when leak sanitizer starts up in ROOT exectuables.


### PR DESCRIPTION
Bring down the number of address sanitizer failures to ~ 36.

In detail:
- Add use-after-scope checks for clang builds.
- Disable new/delete and malloc/free consistency checks.
Since interpreted code cannot be instrumented, address sanitizer cannot
check whether memory is managed consistently.
(Technical details: asan replaces new, delete, malloc and free. In non-instrumented code, the new/delete replacement doesn't work, though. To asan it therefore looks like something was `new`ed in instrumented code, but `free`d in JITted code and vice versa.)
- Change the order in which libaries are `LD_PRELOADED`. Address sanitizer needs the config first, and runtimes later. Otherwise, it will ignore the configs.
- Fix a regex, so address sanitizer is `LD_PRELOADED` only when python is used. Before, it would be loaded twice for command lines such as `root.exe .... ..../python/....`