### PR TITLE
[HF] Fix ROOT-10779, cannot update model with new histograms.

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
@@ -11,14 +11,17 @@
 #ifndef HISTFACTORY_CHANNEL_H
 #define HISTFACTORY_CHANNEL_H
 
-#include <string>
-#include <fstream>
-#include <iostream>
-
-
 #include "RooStats/HistFactory/Data.h"
 #include "RooStats/HistFactory/Sample.h"
 #include "RooStats/HistFactory/Systematics.h"
+
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <memory>
+
+class TFile;
 
 namespace RooStats{
 namespace HistFactory {
@@ -95,7 +98,8 @@ protected:
   /// Open a file and copy a histogram
   TH1* GetHistogram( std::string InputFile, std::string HistoPath, std::string HistoName );
 
-
+private:
+  std::map<std::string,std::unique_ptr<TFile>> fFileHandles; //! Handles to open files for collecting histograms.
 };
 
   extern Channel BadChannel;


### PR DESCRIPTION
When writing a histfactory model to a file and retrieving it,
histograms are deserialised. If in the mean time new instances of those
histograms have been written to the file, the new instances cannot be
picked up. This is because Channel::GetHistogram() was `Get()`-ting
histograms from the directory. This may return a memory-resident
histograms.
Since histograms are always read when deserialising, there is always a
memory-resident histograms.

The problem has been fixed by reading from file using TKey.

Co-authored-by: Philippe Canal <pcanal@fnal.gov>
(cherry picked from commit 35105feb3d7cbfefa8bf29178b2b9d42851ede6f)