### PR TITLE
[Exp PyROOT] Prepend CMAKE_INSTALL_PREFIX if runtimedir is not absolute

### DIFF
--- a/bindings/jsmva/CMakeLists.txt
+++ b/bindings/jsmva/CMakeLists.txt
@@ -11,4 +11,4 @@
 set(JsMVADirName python/JsMVA)
 
 file(COPY ${JsMVADirName} DESTINATION ${localruntimedir})
-install(DIRECTORY ${JsMVADirName} DESTINATION ${runtimedir})
+install(DIRECTORY ${JsMVADirName} DESTINATION ${install_dir_lib})

--- a/bindings/jupyroot/CMakeLists.txt
+++ b/bindings/jupyroot/CMakeLists.txt
@@ -31,7 +31,7 @@ set(JupyROOTPySrcDir python/JupyROOT)
 file(COPY ${JupyROOTPySrcDir} DESTINATION ${localruntimedir})
 
 # Install .py source files
-install(DIRECTORY ${JupyROOTPySrcDir} DESTINATION ${runtimedir})
+install(DIRECTORY ${JupyROOTPySrcDir} DESTINATION ${install_dir_lib})
 
 foreach(val RANGE ${how_many_pythons})
   list(GET python_under_version_strings ${val} python_under_version_string)

--- a/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
@@ -20,7 +20,7 @@ file(COPY ${cppyy_backendPySrcDir} DESTINATION ${localruntimedir})
 
 # Install .py source files
 foreach(py_source ${py_sources})
-  install(FILES cling/python/${py_source} DESTINATION ${runtimedir}/cppyy_backend)
+  install(FILES cling/python/${py_source} DESTINATION ${install_dir_lib}/cppyy_backend)
 endforeach()
 
 foreach(val RANGE ${how_many_pythons})

--- a/bindings/pyroot_experimental/cppyy/cppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/cppyy/CMakeLists.txt
@@ -21,7 +21,7 @@ file(COPY ${cppyyPySrcDir} DESTINATION ${localruntimedir})
 
 # Install .py source files
 foreach(py_source ${py_sources})
-  install(FILES python/${py_source} DESTINATION ${runtimedir}/cppyy)
+  install(FILES python/${py_source} DESTINATION ${install_dir_lib}/cppyy)
 endforeach()
 
 foreach(val RANGE ${how_many_pythons})

--- a/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
@@ -86,7 +86,7 @@ file(COPY ${ROOTPySrcDir} DESTINATION ${localruntimedir})
 file(COPY ${ROOT_headers_dir}/ DESTINATION ${CMAKE_BINARY_DIR}/include/ROOT)
 
 # Install .py source files
-install(DIRECTORY ${ROOTPySrcDir} DESTINATION ${runtimedir})
+install(DIRECTORY ${ROOTPySrcDir} DESTINATION ${install_dir_lib})
 
 foreach(val RANGE ${how_many_pythons})
   list(GET python_under_version_strings ${val} python_under_version_string)


### PR DESCRIPTION
When running "make package", it was observed that copying the
Python source files to runtimedir was incorrect, and the generation
of the bytecodes was failing later too as a consequence.

This change ensures that the Python sources are installed
correctly.