### PR TITLE
Deprecate  MethodDNN in TMVA and improve handling of input layout string

### DIFF
--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -401,7 +401,14 @@ void MethodDL::ProcessOptions()
       fInputShape[2] = 1;
       fInputShape[3] = GetNVariables();
    }
+   // case when batch layout is not provided (all zero)
+   // batch layout can be determined by the input layout + batch size
+   // case DNN : { 1, B, W }
+   // case CNN :  { B, C, H*W}
+   // case RNN :  { B, T, H*W } 
+   
    if (fBatchWidth == 0 && fBatchHeight == 0 && fBatchDepth == 0) {
+      // case first layer is DENSE 
       if (fInputShape[2] == 1 && fInputShape[1] == 1) {
          // case of (1, batchsize, input features)
          fBatchDepth  = 1;
@@ -409,6 +416,7 @@ void MethodDL::ProcessOptions()
          fBatchWidth  = fInputShape[3];
       }
       else { // more general cases (e.g. for CNN)
+         // case CONV or RNN
          fBatchDepth  = fTrainingSettings.front().batchSize;
          fBatchHeight = fInputShape[1];
          fBatchWidth  = fInputShape[3]*fInputShape[2];
@@ -443,13 +451,24 @@ void MethodDL::ParseInputLayout()
    int subDim = 1;
    std::vector<size_t> inputShape;
    inputShape.reserve(inputLayoutString.Length()/2 + 2);
-   inputShape.push_back(30);    // Will be set by Trainingsettings, use default now
+   inputShape.push_back(30);    // Will be set later by Trainingsettings, use 0 value now
    for (; inputDimString != nullptr; inputDimString = (TObjString *)nextInputDim()) {
       // size_t is unsigned
       subDim = (size_t) abs(inputDimString->GetString().Atoi());
       // Size among unused dimensions should be set to 1 for cudnn
       //if (subDim == 0) subDim = 1;
       inputShape.push_back(subDim);
+   }
+   // it is expected that empty Shape has at least 4 dimensions. We pad the missing one's with 1
+   // for example in case of dense layer input layouts
+   // when we will support 3D convolutions we would need to add extra 1's
+   if (inputShape.size() == 2) {
+      // case of dense layer where only width is specified 
+      inputShape.insert(inputShape.begin() + 1, {1,1});
+   }
+   else if (inputShape.size() == 3) {
+      //e.g. case of RNN T,W -> T,1,W
+      inputShape.insert(inputShape.begin() + 2, 1);
    }
 
    this->SetInputShape(inputShape);

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -120,7 +120,13 @@ Bool_t TMVA::MethodDNN::HasAnalysisType(Types::EAnalysisType type,
 ////////////////////////////////////////////////////////////////////////////////
 /// default initializations
 
-void TMVA::MethodDNN::Init() {}
+void TMVA::MethodDNN::Init() {
+      Log() << kWARNING
+            << "MethodDNN is deprecated and it will be removed in future ROOT version. "
+               "Please use MethodDL ( TMVA::kDL)"
+            << Endl;
+
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Options to be set in the option string:

--- a/tutorials/tmva/TMVA_CNN_Classification.C
+++ b/tutorials/tmva/TMVA_CNN_Classification.C
@@ -303,8 +303,6 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
 
    if (useTMVADNN) {
 
-      TString inputLayoutString = "InputLayout=1|1|256";
-      TString batchLayoutString = "BatchLayout=1|100|256";
       TString layoutString(
          "Layout=DENSE|100|RELU,BNORM,DENSE|100|RELU,BNORM,DENSE|100|RELU,BNORM,DENSE|100|RELU,DENSE|1|LINEAR");
 
@@ -323,10 +321,6 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
 
       TString dnnOptions("!H:V:ErrorStrategy=CROSSENTROPY:VarTransform=None:"
                          "WeightInitialization=XAVIER");
-      dnnOptions.Append(":");
-      dnnOptions.Append(inputLayoutString);
-      dnnOptions.Append(":");
-      dnnOptions.Append(batchLayoutString);
       dnnOptions.Append(":");
       dnnOptions.Append(layoutString);
       dnnOptions.Append(":");
@@ -379,7 +373,7 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
       TString inputLayoutString("InputLayout=1|16|16");
 
       // Batch Layout
-      TString batchLayoutString("BatchLayout=100|1|256");
+      //TString batchLayoutString("BatchLayout=100|1|256");
 
       TString layoutString("Layout=CONV|10|3|3|1|1|1|1|RELU,BNORM,CONV|10|3|3|1|1|1|1|RELU,MAXPOOL|2|2|1|1,"
                            "RESHAPE|FLAT,DENSE|100|RELU,DENSE|1|LINEAR");
@@ -400,8 +394,8 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
 
       cnnOptions.Append(":");
       cnnOptions.Append(inputLayoutString);
-      cnnOptions.Append(":");
-      cnnOptions.Append(batchLayoutString);
+      // cnnOptions.Append(":");
+      // cnnOptions.Append(batchLayoutString);
       cnnOptions.Append(":");
       cnnOptions.Append(layoutString);
       cnnOptions.Append(":");

--- a/tutorials/tmva/TMVA_RNN_Classification.C
+++ b/tutorials/tmva/TMVA_RNN_Classification.C
@@ -307,11 +307,9 @@ the option string
 
          /// define the inputlayout string for RNN
          /// the input data should be organize as   following:
-         //// input layout for RNN:    time x 1 x ndim
-         ///  batch layout for RNN     batchsize x time x ndim
+         //// input layout for RNN:    time x ndim
 
-         TString inputLayoutString = TString::Format("InputLayout=%d|1|%d", ntime, ninput);
-         TString batchLayoutString = TString::Format("BatchLayout=%d|%d|%d", batchSize, ntime, ninput);
+         TString inputLayoutString = TString::Format("InputLayout=%d|%d", ntime, ninput);
 
          /// Define RNN layer layout
          ///  it should be   LayerType (RNN or LSTM or GRU) |  number of units | number of inputs | time steps | remember output (typically no=0 | return full sequence
@@ -338,8 +336,6 @@ the option string
          rnnOptions.Append(":");
          rnnOptions.Append(inputLayoutString);
          rnnOptions.Append(":");
-         rnnOptions.Append(batchLayoutString);
-         rnnOptions.Append(":");
          rnnOptions.Append(layoutString);
          rnnOptions.Append(":");
          rnnOptions.Append(trainingStrategyString);
@@ -360,7 +356,6 @@ the option string
    if (useTMVA_DNN) {
       // Method DL with Dense Layer
       TString inputLayoutString = TString::Format("InputLayout=1|1|%d", ntime * ninput);
-      TString batchLayoutString = TString::Format("BatchLayout=1|256|%d", ntime * ninput);
 
       TString layoutString("Layout=DENSE|64|TANH,DENSE|TANH|64,DENSE|TANH|64,LINEAR");
       // Training strategies.
@@ -377,8 +372,6 @@ the option string
 
       dnnOptions.Append(":");
       dnnOptions.Append(inputLayoutString);
-      dnnOptions.Append(":");
-      dnnOptions.Append(batchLayoutString);
       dnnOptions.Append(":");
       dnnOptions.Append(layoutString);
       dnnOptions.Append(":");


### PR DESCRIPTION
Add a warning message to indicate that MethodDNN is deprecated and now MethodDL should be used

Improve handling of inputShapeLayout. InputBatchLayout is not really needed anymore and it is now removed from the tutorials 