### PR TITLE
[Exp PyROOT] Fixes for "make package"

### DIFF
--- a/bindings/jsmva/CMakeLists.txt
+++ b/bindings/jsmva/CMakeLists.txt
@@ -11,4 +11,4 @@
 set(JsMVADirName python/JsMVA)
 
 file(COPY ${JsMVADirName} DESTINATION ${localruntimedir})
-install(DIRECTORY ${JsMVADirName} DESTINATION ${install_dir_lib})
+install(DIRECTORY ${JsMVADirName} DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)

--- a/bindings/jupyroot/CMakeLists.txt
+++ b/bindings/jupyroot/CMakeLists.txt
@@ -30,9 +30,6 @@ set(py_sources
 set(JupyROOTPySrcDir python/JupyROOT)
 file(COPY ${JupyROOTPySrcDir} DESTINATION ${localruntimedir})
 
-# Install .py source files
-install(DIRECTORY ${JupyROOTPySrcDir} DESTINATION ${install_dir_lib})
-
 foreach(val RANGE ${how_many_pythons})
   list(GET python_under_version_strings ${val} python_under_version_string)
   list(GET python_include_dirs ${val} python_include_dir)
@@ -54,13 +51,18 @@ foreach(val RANGE ${how_many_pythons})
     target_compile_options(${libname} PRIVATE -Wno-deprecated-register)
   endif()
 
-  # Install compiled .py files
+  # Compile .py files
   foreach(py_source ${py_sources})
-    install(CODE "execute_process(COMMAND ${python_executable} -m py_compile ${install_dir_lib}/${py_source})")
-    install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${install_dir_lib}/${py_source})")
+    install(CODE "execute_process(COMMAND ${python_executable} -m py_compile ${localruntimedir}/${py_source})")
+    install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${localruntimedir}/${py_source})")
   endforeach()
 
   # Install library
   install(TARGETS ${libname} EXPORT ${CMAKE_PROJECT_NAME}Exports DESTINATION ${runtimedir})
 
 endforeach()
+
+# Install Python sources and bytecode
+install(DIRECTORY ${localruntimedir}/JupyROOT
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT libraries)

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
@@ -98,7 +98,10 @@ foreach(val RANGE ${how_many_pythons})
   set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS ${libname})
 
   # Install library
-  install(TARGETS ${libname} EXPORT ${CMAKE_PROJECT_NAME}Exports DESTINATION ${runtimedir})
+  install(TARGETS ${libname} EXPORT ${CMAKE_PROJECT_NAME}Exports
+                             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries
+                             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
+                             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 endforeach()
 
 file(COPY ${headers} DESTINATION ${CMAKE_BINARY_DIR}/include/CPyCppyy)

--- a/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
@@ -42,7 +42,10 @@ foreach(val RANGE ${how_many_pythons})
   set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS ${libname})
 
   # Install library
-  install(TARGETS ${libname} EXPORT ROOTExports DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(TARGETS ${libname} EXPORT ${CMAKE_PROJECT_NAME}Exports
+                             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries
+                             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
+                             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 
   # Install compiled .py files
   foreach(py_source ${py_sources})

--- a/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
@@ -16,7 +16,10 @@ set(py_sources
 )
 
 set(cppyy_backendPySrcDir cling/python/cppyy_backend)
-file(COPY ${cppyy_backendPySrcDir} DESTINATION ${localruntimedir})
+file(COPY ${cppyy_backendPySrcDir}
+     DESTINATION ${localruntimedir}
+     PATTERN "cmake" EXCLUDE
+     PATTERN "pkg_templates" EXCLUDE)
 
 # Install .py source files
 foreach(py_source ${py_sources})

--- a/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
@@ -21,11 +21,6 @@ file(COPY ${cppyy_backendPySrcDir}
      PATTERN "cmake" EXCLUDE
      PATTERN "pkg_templates" EXCLUDE)
 
-# Install .py source files
-foreach(py_source ${py_sources})
-  install(FILES cling/python/${py_source} DESTINATION ${install_dir_lib}/cppyy_backend)
-endforeach()
-
 foreach(val RANGE ${how_many_pythons})
   list(GET python_under_version_strings ${val} python_under_version_string)
   list(GET python_executables ${val} python_executable)
@@ -47,9 +42,14 @@ foreach(val RANGE ${how_many_pythons})
                              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
                              ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 
-  # Install compiled .py files
+  # Compile .py files
   foreach(py_source ${py_sources})
-    install(CODE "execute_process(COMMAND ${python_executable} -m py_compile ${install_dir_lib}/${py_source})")
-    install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${install_dir_lib}/${py_source})")
+    install(CODE "execute_process(COMMAND ${python_executable} -m py_compile ${localruntimedir}/${py_source})")
+    install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${localruntimedir}/${py_source})")
   endforeach()
 endforeach()
+
+# Install Python sources and bytecode
+install(DIRECTORY ${localruntimedir}/cppyy_backend
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT libraries)

--- a/bindings/pyroot_experimental/cppyy/cppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/cppyy/CMakeLists.txt
@@ -19,17 +19,17 @@ set(py_sources
 set(cppyyPySrcDir python/cppyy)
 file(COPY ${cppyyPySrcDir} DESTINATION ${localruntimedir})
 
-# Install .py source files
-foreach(py_source ${py_sources})
-  install(FILES python/${py_source} DESTINATION ${install_dir_lib}/cppyy)
-endforeach()
-
 foreach(val RANGE ${how_many_pythons})
   list(GET python_executables ${val} python_executable)
 
-  # Install compiled .py files
+  # Compile .py files
   foreach(py_source ${py_sources})
-    install(CODE "execute_process(COMMAND ${python_executable} -m py_compile ${install_dir_lib}/${py_source})")
-    install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${install_dir_lib}/${py_source})")
+    install(CODE "execute_process(COMMAND ${python_executable} -m py_compile ${localruntimedir}/${py_source})")
+    install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${localruntimedir}/${py_source})")
   endforeach()
 endforeach()
+
+# Install Python sources and bytecode
+install(DIRECTORY ${localruntimedir}/cppyy
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT libraries)

--- a/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
@@ -85,9 +85,6 @@ file(COPY ${ROOTPySrcDir} DESTINATION ${localruntimedir})
 # Copy headers inside build_dir/include/ROOT
 file(COPY ${ROOT_headers_dir}/ DESTINATION ${CMAKE_BINARY_DIR}/include/ROOT)
 
-# Install .py source files
-install(DIRECTORY ${ROOTPySrcDir} DESTINATION ${install_dir_lib})
-
 foreach(val RANGE ${how_many_pythons})
   list(GET python_under_version_strings ${val} python_under_version_string)
   list(GET python_include_dirs ${val} python_include_dir)
@@ -113,12 +110,17 @@ foreach(val RANGE ${how_many_pythons})
     target_compile_options(${libname} PRIVATE -Wno-deprecated-register)
   endif()
 
-  # Install compiled .py files
+  # Compile .py files
   foreach(py_source ${py_sources})
-    install(CODE "execute_process(COMMAND ${python_executable} -m py_compile ${install_dir_lib}/${py_source})")
-    install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${install_dir_lib}/${py_source})")
+    install(CODE "execute_process(COMMAND ${python_executable} -m py_compile ${localruntimedir}/${py_source})")
+    install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${localruntimedir}/${py_source})")
   endforeach()
 
 endforeach()
+
+# Install Python sources and bytecode
+install(DIRECTORY ${localruntimedir}/ROOT
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT libraries)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
The commits in this PR propose a unified solution for the installation of the PyROOT libraries, sources and bytecodes that works both with "make install" and "make package".
