### PR TITLE
Fix ROOT-10753, "Wrong entries are loaded in case of TChain+TEntryList"

### DIFF
--- a/tree/dataframe/test/dataframe_entrylist.cxx
+++ b/tree/dataframe/test/dataframe_entrylist.cxx
@@ -44,14 +44,16 @@ void TestTreeWithEntryList(bool isMT = false)
 
    RMTRAII gomt(isMT);
 
-   TEntryList elist("e", "e", treename, filename);
-   elist.Enter(0);
-   elist.Enter(nEntries - 1);
-
+   // do NOT pass treename and filename to the TEntryList here, see ROOT-10775
+   TEntryList elist("e", "e");
    TFile f(filename);
    auto t = f.Get<TTree>(treename);
    t->SetEntryList(&elist);
    ASSERT_TRUE(elist.GetLists() == nullptr) << "Failure in setting up the TEntryList";
+
+   // entries must be added to the TEntryList AFTER it is associated to the TTree, otherwise subentrylists are created
+   elist.Enter(0);
+   elist.Enter(nEntries - 1);
 
    auto entries = ROOT::RDataFrame(*t).Take<int>("e").GetValue();
    std::sort(entries.begin(), entries.end()); // could be out of order in MT runs

--- a/tree/dataframe/test/dataframe_entrylist.cxx
+++ b/tree/dataframe/test/dataframe_entrylist.cxx
@@ -10,13 +10,13 @@
 #include <algorithm> // std::sort
 #include <vector>
 
-// Write to disk file filename with TTree "t" with nEntries of branch "e" assuming integer values [0..nEntries).
-void MakeInputFile(const std::string &filename, int nEntries)
+// Write to disk one file for each filename, with TTree "t" with nEntries of branch "e" with increasing values
+// starting at valueStart
+void MakeInputFile(const std::string &filename, int nEntries, int valueStart = 0)
 {
+   int e = valueStart;
    const auto treename = "t";
-   auto d = ROOT::RDataFrame(nEntries)
-               .Define("e", [](ULong64_t e) { return int(e); }, {"rdfentry_"})
-               .Snapshot<int>(treename, filename, {"e"});
+   auto d = ROOT::RDataFrame(nEntries).Define("e", [&] { return e++; }).Snapshot<int>(treename, filename, {"e"});
 }
 
 class RMTRAII {
@@ -61,12 +61,17 @@ void TestTreeWithEntryList(bool isMT = false)
 
 void TestChainWithEntryList(bool isMT = false)
 {
+   // The test might seem contrived, because it is. We want to check:
+   // - that we read the correct entries from the correct trees, so we need to read different entries per tree
+   // - that TTreeProcessorMT re-builds TEntryLists correctly for each file/cluster, so we need a different number
+   //   of entries and we need to select, via TEntryList, entries of tree2 that do not exist in tree1
+
    const auto nEntries = 10;
    const auto treename = "t";
    const auto file1 = "rdfentrylist1.root";
    const auto file2 = "rdfentrylist2.root";
    MakeInputFile(file1, nEntries);
-   MakeInputFile(file2, nEntries);
+   MakeInputFile(file2, nEntries * 2, /*valueStart=*/nEntries);
 
    RMTRAII gomt(isMT);
 
@@ -74,8 +79,8 @@ void TestChainWithEntryList(bool isMT = false)
    elist1.Enter(0);
    elist1.Enter(nEntries - 1);
    TEntryList elist2("e", "e", treename, file2);
-   elist2.Enter(0);
-   elist2.Enter(nEntries - 1);
+   elist2.Enter(nEntries + 1);
+   elist2.Enter(2 * nEntries - 1);
 
    // make a TEntryList that contains two TEntryLists in its list of TEntryLists,
    // as required by TChain (see TEntryList's doc)
@@ -85,12 +90,12 @@ void TestChainWithEntryList(bool isMT = false)
 
    TChain c(treename);
    c.Add(file1, nEntries);
-   c.Add(file2, nEntries);
+   c.Add(file2, nEntries * 2);
    c.SetEntryList(&elists);
 
    auto entries = ROOT::RDataFrame(c).Take<int>("e").GetValue();
    std::sort(entries.begin(), entries.end()); // could be out of order in MT runs
-   EXPECT_EQ(entries, std::vector<int>({0, 0, nEntries - 1, nEntries - 1}));
+   EXPECT_EQ(entries, std::vector<int>({0, nEntries - 1, 2 * nEntries + 1, 3 * nEntries - 1}));
 
    gSystem->Unlink(file1);
    gSystem->Unlink(file2);

--- a/tree/dataframe/test/dataframe_entrylist.cxx
+++ b/tree/dataframe/test/dataframe_entrylist.cxx
@@ -51,6 +51,7 @@ void TestTreeWithEntryList(bool isMT = false)
    TFile f(filename);
    auto t = f.Get<TTree>(treename);
    t->SetEntryList(&elist);
+   ASSERT_TRUE(elist.GetLists() == nullptr) << "Failure in setting up the TEntryList";
 
    auto entries = ROOT::RDataFrame(*t).Take<int>("e").GetValue();
    std::sort(entries.begin(), entries.end()); // could be out of order in MT runs

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -155,8 +155,7 @@ public:
 
    TTreeReader(TTree* tree, TEntryList* entryList = nullptr);
    TTreeReader(const char* keyname, TDirectory* dir, TEntryList* entryList = nullptr);
-   TTreeReader(const char* keyname, TEntryList* entryList = nullptr):
-   TTreeReader(keyname, nullptr, entryList) {}
+   TTreeReader(const char *keyname, TEntryList *entryList = nullptr) : TTreeReader(keyname, nullptr, entryList) {}
 
    ~TTreeReader();
 

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -2,7 +2,7 @@
 // Authors: Enric Tejedor, Enrico Guiraud CERN  05/06/2018
 
 /*************************************************************************
- * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -503,10 +503,19 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
          fEntryStatus = kEntryNotFound;
          return fEntryStatus;
       }
-      if (entry >= 0) entryAfterList = fEntryList->GetEntry(entry);
-      if (local && IsChain()) {
-         // Must translate the entry list's entry to the current TTree's entry number.
-         local = kFALSE;
+      if (entry >= 0) {
+         if (fEntryList->GetLists()) {
+            R__ASSERT(IsChain());
+            int treenum = -1;
+            entryAfterList = fEntryList->GetEntryAndTree(entry, treenum);
+            entryAfterList += static_cast<TChain *>(fTree)->GetTreeOffset()[treenum];
+            // We always translate local entry numbers to global entry numbers for TChain+TEntryList with sublists
+            local = false;
+         } else {
+            // Could be a TTree or a TChain (TTreeReader also supports single TEntryLists for TChains).
+            // In both cases, we are using the global entry numbers coming from the single TEntryList.
+            entryAfterList = fEntryList->GetEntry(entry);
+         }
       }
    }
 

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -191,6 +191,13 @@ TTreeReader::TTreeReader() : fNotify(this) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Access data from tree.
+///
+/// \param tree The TTree or TChain to read from
+/// \param entryList It can be a single TEntryList with global entry numbers (supported, as
+///                  an extension, also in the case of a TChain) or, if the first parameter
+///                  is a TChain, a TEntryList with sub-TEntryLists with local entry numbers.
+///                  In the latter case, the TEntryList must be associated to the TChain, as
+///                  per chain.SetEntryList(&entryList).
 
 TTreeReader::TTreeReader(TTree* tree, TEntryList* entryList /*= nullptr*/):
    fTree(tree),
@@ -208,6 +215,14 @@ TTreeReader::TTreeReader(TTree* tree, TEntryList* entryList /*= nullptr*/):
 /// Access data from the tree called keyname in the directory (e.g. TFile)
 /// dir, or the current directory if dir is NULL. If keyname cannot be
 /// found, or if it is not a TTree, IsInvalid() will return true.
+///
+/// \param keyname The name of the TTree to read from file
+/// \param dir The TDirectory to read keyname from
+/// \param entryList It can be a single TEntryList with global entry numbers (supported, as
+///                  an extension, also in the case of a TChain) or, if the first parameter
+///                  is a TChain, a TEntryList with sub-TEntryLists with local entry numbers.
+///                  In the latter case, the TEntryList must be associated to the TChain, as
+///                  per chain.SetEntryList(&entryList).
 
 TTreeReader::TTreeReader(const char* keyname, TDirectory* dir, TEntryList* entryList /*= nullptr*/):
    fEntryList(entryList),
@@ -374,7 +389,8 @@ Bool_t TTreeReader::SetProxies() {
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the range of entries to be loaded by `Next()`; end will not be loaded.
 ///
-/// If end <= begin, `end` is ignored (set to `-1`) and only `begin` is used.
+/// If end <= begin, `end` is ignored (set to `-1`, i.e. will run on all entries from `begin` onwards).
+///
 /// Example:
 ///
 /// ~~~ {.cpp}
@@ -383,6 +399,11 @@ Bool_t TTreeReader::SetProxies() {
 ///   // Will load entries 3 and 4.
 /// }
 /// ~~~
+///
+/// Note that if a TEntryList is present, beginEntry and endEntry refer to the beginEntry-th/endEntry-th entries of the
+/// TEntryList (or the main TEntryList in case it has sub-entrylists). In other words, SetEntriesRange can
+/// be used to only loop over part of the TEntryList, but not to further restrict the actual TTree/TChain entry numbers
+/// considered.
 ///
 /// \param beginEntry The first entry to be loaded by `Next()`.
 /// \param endEntry   The entry where `Next()` will return kFALSE, not loading it.

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -263,6 +263,12 @@ void TTreeReader::Initialize()
    fLoadTreeStatus = kLoadTreeNone;
    if (fTree->InheritsFrom(TChain::Class())) {
       SetBit(kBitIsChain);
+   } else if (fEntryList && fEntryList->GetLists()) {
+      Error("Initialize", "We are not processing a TChain but the TEntryList contains sublists. Please "
+                          "provide a simple TEntryList with no sublists instead.");
+      fEntryStatus = kEntryNoTree;
+      fLoadTreeStatus = kNoTree;
+      return;
    }
 
    fDirector = new ROOT::Internal::TBranchProxyDirector(fTree, -1);

--- a/tree/treeplayer/test/basic.cxx
+++ b/tree/treeplayer/test/basic.cxx
@@ -308,6 +308,127 @@ TEST(TTreeReaderBasic, EntryListBeyondEnd) {
    EXPECT_EQ(TTreeReader::kEntryNotFound, aReader.GetEntryStatus());
 }
 
+// two files treereader_entrylists{1,2}.root with branch "x" and values {0,1} and {2,3}
+struct InputFilesRAII {
+   const char *fNames[2] = {"treereader_entrylists1.root", "treereader_entrylists2.root"};
+
+   InputFilesRAII()
+   {
+      int x = 0;
+      for (const auto fName : fNames) {
+         TFile f(fName, "recreate");
+         TTree t("t", "t");
+         t.Branch("x", &x);
+         t.Fill();
+         ++x;
+         t.Fill();
+         ++x;
+         t.Write();
+      }
+   }
+
+   ~InputFilesRAII()
+   {
+      gSystem->Unlink(fNames[0]);
+      gSystem->Unlink(fNames[1]);
+   }
+};
+
+void TestWithEntryList(TEntryList &l, const InputFilesRAII &files)
+{
+   TChain c("t");
+   c.Add(files.fNames[0]);
+   c.Add(files.fNames[1]);
+   if (l.GetLists()) // must associate with TChain if there are sub-entrylists
+      c.SetEntryList(&l);
+
+   TTreeReader r(&c, &l);
+   TTreeReaderValue<int> xv(r, "x");
+   const std::vector<int> values({0, 2});
+   int i = 0;
+   while (r.Next())
+      EXPECT_EQ(*xv, values.at(i++));
+}
+
+TEST(TTreeReaderBasic, TChainWithGlobalEntryList)
+{
+   InputFilesRAII files;
+
+   // if using a global list with a TChain, no need to specify treename and filename to the TEntryList (but harmless)
+   TEntryList l;
+   l.Enter(0);
+   l.Enter(2);
+
+   TestWithEntryList(l, files);
+}
+
+TEST(TTreeReaderBasic, TChainWithSubEntryLists)
+{
+   InputFilesRAII files;
+
+   TEntryList l1("l1", "l1", "t", files.fNames[0]);
+   l1.Enter(0);
+   TEntryList l2("l2", "l2", "t", files.fNames[1]);
+   l2.Enter(0);
+
+   TEntryList l;
+   l.Add(&l1);
+   l.Add(&l2);
+
+   TestWithEntryList(l, files);
+}
+
+TEST(TTreeReaderBasic, EntryListAndEntryRange)
+{
+   TTree t("t", "t");
+   int x = 0;
+   t.Branch("x", &x);
+   for (x = 0; x < 10; ++x)
+      t.Fill();
+
+   TEntryList l;
+   t.SetEntryList(&l);
+   l.Enter(1);
+   l.Enter(2);
+   l.Enter(8);
+   l.Enter(9);
+
+   TTreeReader r(&t, &l);
+   r.SetEntriesRange(1, 3);
+   TTreeReaderValue<int> rv(r, "x");
+   EXPECT_TRUE(r.Next());
+   EXPECT_EQ(*rv, 2);
+   EXPECT_TRUE(r.Next());
+   EXPECT_EQ(*rv, 8);
+   EXPECT_FALSE(r.Next());
+}
+
+TEST(TTreeReaderBasic, TChainWithSubEntryListsAndEntryRange)
+{
+   InputFilesRAII files;
+
+   TEntryList l1("l1", "l1", "t", files.fNames[0]);
+   l1.Enter(1);
+   TEntryList l2("l2", "l2", "t", files.fNames[1]);
+   l2.Enter(0);
+   l2.Enter(1);
+
+   TEntryList l;
+   l.Add(&l1);
+   l.Add(&l2);
+
+   TChain c("t");
+   c.Add(files.fNames[0]);
+   c.Add(files.fNames[1]);
+   c.SetEntryList(&l); // strictly required!
+
+   TTreeReader r(&c, &l);
+   TTreeReaderValue<int> xv(r, "x");
+   r.SetEntriesRange(1, 2);
+   EXPECT_TRUE(r.Next());
+   EXPECT_EQ(*xv, 2);
+   EXPECT_FALSE(r.Next());
+}
 
 TEST(TTreeReaderBasic, Values) {
    auto tree = MakeTree();


### PR DESCRIPTION
...and add tests and documentation for TTreeReader+TEntryList usage.

The behavior of `TTreeReader` and `TTreeProcessorMT` is changed from always assuming that entry numbers stored in `TEntryList` are global entry numbers to treating them as `TTree`-local entry numbers if they come from sub-entrylists.

This fixes ROOT-10753.

- [x] do entry range -> entry-list entry range transformation once for all taks
- [x] fix test failures
- [ ] check what happens with sub-entrylists in shuffled order w.r.t. TTrees in a TChain