### PR TITLE
Actually use a name unique to the tutorial.

### DIFF
--- a/tutorials/multicore/mt101_fillNtuples.C
+++ b/tutorials/multicore/mt101_fillNtuples.C
@@ -42,7 +42,7 @@ Int_t mt101_fillNtuples()
 
    // Create a random generator and and Ntuple to hold the numbers
    TRandom3 rndm(1);
-   TFile ofile("mp101_singleCore.root", "RECREATE");
+   TFile ofile("mt101_singleCore.root", "RECREATE");
    TNtuple randomNumbers("singleCore", "Random Numbers", "r");
    fillRandom(randomNumbers, rndm, nNumbers);
    randomNumbers.Write();


### PR DESCRIPTION
mp101_singleCore.root was (of course) also use by mp101_fillNtuples.C

This will prevent the errors:
```
Processing /data/sftnight/workspace/manual/root/tutorials/multicore/mp101_fillNtuples.C...
Error in <TFile::TFile>: file mp101_singleCore.root already exists
Error in <TROOT::WriteTObject>: The current directory (Rint) is not associated with a file. The object (singleCore) has not been written.
(int) 0
```