### PR TITLE
[HF] Remove unnecessary member from HistFactory::Channel.

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
@@ -95,11 +95,7 @@ protected:
 
   std::vector< RooStats::HistFactory::Sample > fSamples;
 
-  /// Open a file and copy a histogram
-  TH1* GetHistogram( std::string InputFile, std::string HistoPath, std::string HistoName );
-
-private:
-  std::map<std::string,std::unique_ptr<TFile>> fFileHandles; //! Handles to open files for collecting histograms.
+  TH1* GetHistogram( std::string InputFile, std::string HistoPath, std::string HistoName, std::map<std::string, std::unique_ptr<TFile>>& lsof);
 };
 
   extern Channel BadChannel;


### PR DESCRIPTION
Although 35105feb3d7cb fixes a problem in HistFactory, it has the
disadvantage that the assignment operator of Channel gets deactivated.
By passing the list of open TFiles as argument instead of making it a
member, the class can stay as it was.

(cherry picked from commit 31f55ff0c1fbae1a0573a1c8bf136be4d77fc06b)

**Update**:
Added also a cherry pick of the fix for ROOT-3579