### PR TITLE
[DF] Fix Snapshot output TTree ctor in case of sub-directory 

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1221,18 +1221,18 @@ public:
          TFile::Open(fFileName.c_str(), fOptions.fMode.c_str(), /*ftitle=*/"",
                      ROOT::CompressionSettings(fOptions.fCompressionAlgorithm, fOptions.fCompressionLevel)));
 
+      TDirectory *outputDir = fOutputFile.get();
       if (!fDirName.empty()) {
          TString checkupdate = fOptions.fMode;
          checkupdate.ToLower();
          if (checkupdate == "update")
-            fOutputFile->mkdir(fDirName.c_str(), "", true);  // do not overwrite existing directory
+            outputDir = fOutputFile->mkdir(fDirName.c_str(), "", true);  // do not overwrite existing directory
          else
-            fOutputFile->mkdir(fDirName.c_str());
-         fOutputFile->cd(fDirName.c_str());
+            outputDir = fOutputFile->mkdir(fDirName.c_str());
       }
 
       fOutputTree =
-         std::make_unique<TTree>(fTreeName.c_str(), fTreeName.c_str(), fOptions.fSplitLevel, /*dir=*/fOutputFile.get());
+         std::make_unique<TTree>(fTreeName.c_str(), fTreeName.c_str(), fOptions.fSplitLevel, /*dir=*/outputDir);
 
       if (fOptions.fAutoFlush)
          fOutputTree->SetAutoFlush(fOptions.fAutoFlush);

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1241,8 +1241,8 @@ public:
    void Finalize()
    {
       if (fOutputFile && fOutputTree) {
-         ::TDirectory::TContext ctxt(fOutputFile->GetDirectory(fDirName.c_str()));
-         fOutputTree->Write();
+         // because TTree::Write writes in gDirectory, not in fDirectory
+         fOutputTree->AutoSave("flushbaskets");
          // must destroy the TTree first, otherwise TFile will delete it too leading to a double delete
          fOutputTree.reset();
          fOutputFile->Close();


### PR DESCRIPTION
We need to pass the sub-directory, not the main file.
This fixes ROOT-10790.