### PR TITLE
[ROOT-10791][dyld] Do not try to compare two realpaths.

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -687,7 +687,6 @@ namespace cling {
   }
 
   bool Dyld::ShouldPermanentlyIgnore(const std::string& FileName) const {
-    assert(FileName == getRealPath(FileName));
     assert(!m_ExecutableFormat.empty() && "Failed to find the object format!");
 
     if (llvm::sys::fs::is_directory(FileName))


### PR DESCRIPTION
This conservative assert intended to capture future uses of the shouldPermanentlyIgnore routine and check if we have specified an absolute non-symlinked path.

Turns out that when we scan for libraries we iterate a given folder which may move files around. Then the iterable (official) filename's real path might differ at the point of iteration and the point of the check. Some file systems use a temporary filename while copying/moving file and the rename it to the real filename preserving atomicity of the operations.

It looks like this exactly happens in the description of ROOT-10791 -- the iterator gives the expected real path of the filename which is not yet available when we ask for the real path of that path we get something different (using the same inode) eg: `mathsymb.ps` vs `mathsymb.ps_tmp_4810`.

Instead of asserting, let the file system handles this instead.

Kudos to Philippe Canal (@pcanal) for investigating this sporadic failure.