### PR TITLE
Fix TClassEdit::DemangleName() on Windows

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2546,10 +2546,6 @@ int  ExtractClassesListAndDeclLines(RScanner &scan,
                      if (strstr(demangledTIName, typeinfoNameFor)) {
                         std::string demangledName = demangledTIName;
                         demangledName.erase(demangledName.end() - strlen(typeinfoNameFor), demangledName.end());
-                        if (demangledName.compare(0, 6, "class ") == 0)
-                           demangledName.erase(0, 6);
-                        else if (demangledName.compare(0, 7, "struct ") == 0)
-                           demangledName.erase(0, 7);
 #else
                   char* demangledTIName = TClassEdit::DemangleName(mangledName.c_str(), errDemangle);
                   if (!errDemangle && demangledTIName) {

--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -214,6 +214,12 @@ namespace TClassEdit {
       errorCode = -1;
       return nullptr;
    }
+   std::string demangledName = demangled_name;
+   if (demangledName.compare(0, 6, "class ") == 0)
+      demangledName.erase(0, 6);
+   else if (demangledName.compare(0, 7, "struct ") == 0)
+      demangledName.erase(0, 7);
+   strcpy(demangled_name, demangledName.c_str());
 #else
    char *demangled_name = abi::__cxa_demangle(mangled_name, 0, 0, &errorCode);
    if (!demangled_name || errorCode) {

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -386,7 +386,7 @@ TEST(RDataFrameInterface, UnusedJittedNodes)
 
 // ROOT-10458
 #ifdef _WIN32
-const std::string symbol = "struct `private: virtual void __thiscall RDataFrameInterface_TypeUnknownToInterpreter_Test::TestBody(void)'::`2'::SimpleType";
+const std::string symbol = "`private: virtual void __thiscall RDataFrameInterface_TypeUnknownToInterpreter_Test::TestBody(void)'::`2'::SimpleType";
 #else
 const std::string symbol = "RDataFrameInterface_TypeUnknownToInterpreter_Test::TestBody()::SimpleType";
 #endif

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -14,11 +14,7 @@ TEST(RNTuple, TypeName)
 {
    EXPECT_STREQ("float", ROOT::Experimental::RField<float>::TypeName().c_str());
    EXPECT_STREQ("std::vector<std::string>", ROOT::Experimental::RField<std::vector<std::string>>::TypeName().c_str());
-#if defined(_MSC_VER) && !defined(R__ENABLE_BROKEN_WIN_TESTS)
-   EXPECT_STREQ("struct CustomStruct", ROOT::Experimental::RField<CustomStruct>::TypeName().c_str());
-#else
    EXPECT_STREQ("CustomStruct", ROOT::Experimental::RField<CustomStruct>::TypeName().c_str());
-#endif
 }
 
 


### PR DESCRIPTION
Remove extra `class` and `struct` prefixes in demangled name and fix related tests