### PR TITLE
[ntuple] WIP simplify offset column indexing

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -195,25 +195,27 @@ public:
    /// For offset columns only, look at the two adjacent values that define a collection's coordinates
    void GetCollectionInfo(const NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *collectionSize)
    {
-      auto idxStart = (globalIndex == 0) ? 0 : *Map<ClusterSize_t, EColumnType::kIndex>(globalIndex - 1);
-      auto idxEnd = *Map<ClusterSize_t, EColumnType::kIndex>(globalIndex);
+      auto idxStart = *Map<ClusterSize_t, EColumnType::kIndex>(globalIndex);
+      auto idxEnd = *Map<ClusterSize_t, EColumnType::kIndex>(globalIndex + 1);
       auto selfOffset = fCurrentPage.GetClusterInfo().GetIndexOffset();
       if (globalIndex == selfOffset) {
          // Passed cluster boundary
-         idxStart = 0;
+         // idxStart = 0;
+         printf("passed cluster boundary\n");
       }
       *collectionSize = idxEnd - idxStart;
       *collectionStart = RClusterIndex(fCurrentPage.GetClusterInfo().GetId(), idxStart);
+      printf("global_info  | start: %d; end: %d size: %d collection_start: %u\n", idxStart, idxEnd, *collectionSize, collectionStart->GetIndex());
    }
 
    void GetCollectionInfo(const RClusterIndex &clusterIndex,
                           RClusterIndex *collectionStart, ClusterSize_t *collectionSize)
    {
-      auto index = clusterIndex.GetIndex();
-      auto idxStart = (index == 0) ? 0 : *Map<ClusterSize_t, EColumnType::kIndex>(clusterIndex - 1);
-      auto idxEnd = *Map<ClusterSize_t, EColumnType::kIndex>(clusterIndex);
+      auto idxStart = *Map<ClusterSize_t, EColumnType::kIndex>(clusterIndex);
+      auto idxEnd = *Map<ClusterSize_t, EColumnType::kIndex>(clusterIndex + 1);
       *collectionSize = idxEnd - idxStart;
       *collectionStart = RClusterIndex(clusterIndex.GetClusterId(), idxStart);
+      printf("cluster_info | start: %d; end: %d size: %d collection_start: %u\n", idxStart, idxEnd, *collectionSize, collectionStart->GetIndex());
    }
 
    /// Get the currently active cluster id

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -940,7 +940,12 @@ public:
 
    size_t GetValueSize() const final { return sizeof(std::vector<bool>); }
    size_t GetAlignment() const final { return std::alignment_of<std::vector<bool>>(); }
-   void CommitCluster() final { fNWritten = 0; }
+   void CommitCluster() final {
+        Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
+        fColumns[0]->Append(elemIndex);
+        printf("commitCluster: just appended: %d\n", fNWritten);
+   }
+
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
    void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const {
       fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
@@ -971,8 +976,9 @@ protected:
          fSubFields[0]->Append(itemValue);
       }
       Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
-      fNWritten += count;
       fColumns[0]->Append(elemIndex);
+      printf("just appended: %d\n", fNWritten);
+      fNWritten += count;
    }
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final {
       auto typedValue = value->Get<ContainerT>();
@@ -1023,7 +1029,11 @@ public:
       if (!dtorOnly)
          free(vec);
    }
-   void CommitCluster() final { fNWritten = 0; }
+   void CommitCluster() final {
+        Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
+        fColumns[0]->Append(elemIndex);
+        printf("just appended: %d\n", fNWritten);
+   }
 
    static std::string TypeName() { return "ROOT::VecOps::RVec<" + RField<ItemT>::TypeName() + ">"; }
 
@@ -1062,8 +1072,9 @@ protected:
          fSubFields[0]->Append(itemValue);
       }
       Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
-      fNWritten += count;
       fColumns[0]->Append(elemIndex);
+      printf("just appended: %d\n", fNWritten);
+      fNWritten += count;
    }
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final {
       auto typedValue = value->Get<ContainerT>();
@@ -1104,7 +1115,11 @@ public:
       if (!dtorOnly)
          free(vec);
    }
-   void CommitCluster() final { fNWritten = 0; }
+   void CommitCluster() final {
+        Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
+        fColumns[0]->Append(elemIndex);
+        printf("just appended: %d\n", fNWritten);
+   }
 
    static std::string TypeName() { return "ROOT::VecOps::RVec<bool>"; }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -448,8 +448,9 @@ void ROOT::Experimental::RField<std::string>::AppendImpl(const ROOT::Experimenta
    auto length = typedValue->length();
    Detail::RColumnElement<char, EColumnType::kByte> elemChars(const_cast<char*>(typedValue->data()));
    fColumns[1]->AppendV(elemChars, length);
-   fIndex += length;
    fColumns[0]->Append(fElemIndex);
+   printf("just appended: %d\n", fIndex);
+   fIndex += length;
 }
 
 void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(
@@ -470,7 +471,8 @@ void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(
 
 void ROOT::Experimental::RField<std::string>::CommitCluster()
 {
-   fIndex = 0;
+   fColumns[0]->Append(fElemIndex);
+   printf("just appended: %d\n", fIndex);
 }
 
 void ROOT::Experimental::RField<std::string>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -608,8 +610,9 @@ void ROOT::Experimental::RFieldVector::AppendImpl(const Detail::RFieldValue& val
       fSubFields[0]->Append(itemValue);
    }
    Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
-   fNWritten += count;
    fColumns[0]->Append(elemIndex);
+   printf("just appended: %d\n", fNWritten);
+   fNWritten += count;
 }
 
 void ROOT::Experimental::RFieldVector::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value)
@@ -674,7 +677,9 @@ ROOT::Experimental::RFieldVector::SplitValue(const Detail::RFieldValue &value) c
 
 void ROOT::Experimental::RFieldVector::CommitCluster()
 {
-   fNWritten = 0;
+   Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
+   fColumns[0]->Append(elemIndex);
+   printf("just appended: %d\n", fNWritten);
 }
 
 void ROOT::Experimental::RFieldVector::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -702,8 +707,9 @@ void ROOT::Experimental::RField<std::vector<bool>>::AppendImpl(const Detail::RFi
       fSubFields[0]->Append(itemValue);
    }
    Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
-   fNWritten += count;
    fColumns[0]->Append(elemIndex);
+   printf("just appended: %d\n", fNWritten);
+   fNWritten += count;
 }
 
 void ROOT::Experimental::RField<std::vector<bool>>::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue* value)

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -205,8 +205,8 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster()
 {
    if (fNEntries == fLastCommitted) return;
    for (auto& field : *fModel->GetRootField()) {
-      field.Flush();
       field.CommitCluster();
+      field.Flush();
    }
    fSink->CommitCluster(fNEntries);
    fLastCommitted = fNEntries;


### PR DESCRIPTION
Work in progress branch for simplifying offset column indexing. All the basic vector tests are passing, but I think there is a problem with cluster indexes. There are three failing tests that trigger an assertion at the page storage level: 
https://github.com/root-project/root/blob/7e50fa81489e6b33e086d925046548158709d3b7/tree/ntuple/v7/src/RPageStorageFile.cxx#L263

1. https://github.com/root-project/root/blob/7e50fa81489e6b33e086d925046548158709d3b7/tree/ntuple/v7/test/ntuple.cxx#L359
2. https://github.com/root-project/root/blob/7e50fa81489e6b33e086d925046548158709d3b7/tree/ntuple/v7/test/ntuple.cxx#L534
3. https://github.com/root-project/root/blob/7e50fa81489e6b33e086d925046548158709d3b7/tree/ntuple/v7/test/ntuple_raw.cxx#L75

which I think means I'm creating bad `clusterIndex` values at some point, probably from `GetCollectionInfo`. 

@jblomer would you mind taking a look?  I am a little confused about columnIndexes inside `GetCollectionInfo`. I think the problem might be from when we pass a cluster boundary, `idxStart` should be set to some sensible value based on the cluster (0 wasn't working for me). 