### PR TITLE
[RF] Optimise importing of large expression trees.

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -22,6 +22,7 @@
 #include "RooCmdArg.h"
 #include "RooLinkedListIter.h"
 #include <string>
+#include <unordered_map>
 
 class RooCmdArg;
 
@@ -53,13 +54,15 @@ public:
   RooAbsCollection *snapshot(Bool_t deepCopy=kTRUE) const ;
   Bool_t snapshot(RooAbsCollection& output, Bool_t deepCopy=kTRUE) const ;
 
-  /// \deprecated Without effect.
-  void setHashTableSize(Int_t) {
-    // Set size of internal hash table to i (should be a prime number)
+  /// Set the size at which the collection will automatically start using an extra
+  /// lookup table instead of performing a linear search.
+  void setHashTableSize(Int_t number) {
+    _sizeThresholdForMapSearch = number;
   }
-  /// \deprecated Without effect.
+  /// Query the size at which the collection will automatically start using an extra
+  /// lookup table instead of performing a linear search.
   Int_t getHashTableSize() const { 
-    return 0;
+    return _sizeThresholdForMapSearch;
   }
 
   // List content management
@@ -93,12 +96,13 @@ public:
   RooAbsArg *find(const char *name) const ;
   RooAbsArg *find(const RooAbsArg&) const ;
 
+  /// Check if collection contains an argument with the same name as var.
+  /// To check for a specific instance, use containsInstance().
   Bool_t contains(const RooAbsArg& var) const { 
-    // Returns true if object with same name as var is contained in this collection
-    return (0 == find(var)) ? kFALSE:kTRUE; 
+    return find(var) != nullptr;
   }
+  /// Check if this exact instance is in this collection.
   Bool_t containsInstance(const RooAbsArg& var) const { 
-    // Returns true if var is contained in this collection
     return std::find(_list.begin(), _list.end(), &var) != _list.end();
   }
   RooAbsCollection* selectByAttrib(const char* name, Bool_t value) const ;
@@ -189,14 +193,7 @@ public:
     return index(&arg);
   }
 
-  /// Returns index of arg with given name, or -1 if arg is not in the collection.
-  inline Int_t index(const char* name) const {
-    const std::string theName(name);
-    auto item = std::find_if(_list.begin(), _list.end(), [&theName](const RooAbsArg * elm){
-      return elm->GetName() == theName;
-    });
-    return item != _list.end() ? item - _list.begin() : -1;
-  }
+  Int_t index(const char* name) const;
 
   inline virtual void Print(Option_t *options= 0) const {
     // Printing interface (human readable)
@@ -245,6 +242,8 @@ public:
 
   virtual void RecursiveRemove(TObject *obj);
 
+  void useHashMapForFind(bool flag) const;
+
 protected:
   Storage_t _list; // Actual object storage
   using LegacyIterator_t = TIteratorToSTLInterface<Storage_t>;
@@ -271,6 +270,10 @@ protected:
   
 private:
   std::unique_ptr<LegacyIterator_t> makeLegacyIterator (bool forward = true) const;
+  mutable std::unique_ptr<std::unordered_map<const TNamed*, Storage_t::value_type>> _nameToItemMap; //!
+  std::size_t _sizeThresholdForMapSearch; //!
+  void insert(RooAbsArg*);
+  RooAbsArg* tryFastFind(const TNamed* namePtr) const;
 
   ClassDef(RooAbsCollection,3) // Collection of RooAbsArg objects
 };

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -135,6 +135,7 @@ public:
     return static_cast<RooArgSet*>(RooAbsCollection::snapshot(deepCopy));
   }
 
+  /// \copydoc RooAbsCollection::snapshot()
   Bool_t snapshot(RooAbsCollection& output, Bool_t deepCopy=kTRUE) const {
     return RooAbsCollection::snapshot(output, deepCopy);
   }

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -131,6 +131,15 @@ public:
 
   Bool_t writeToFile(const char* fileName, Bool_t recreate=kTRUE) ;
 
+  /// Make internal collection use an unordered_map for
+  /// faster searching. Important when large trees are
+  /// imported / or modified in the workspace.
+  /// Note that RooAbsCollection may eventually switch
+  /// this on by itself.
+  void useFindsWithHashLookup(bool flag) {
+    _allOwnedNodes.useHashMapForFind(flag);
+  }
+
   virtual void RecursiveRemove(TObject *obj);
 
   // Tools management

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -922,20 +922,15 @@ Bool_t RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, Bool_t mus
 
       if (string("REMOVAL_DUMMY")==arg->GetName()) {
 
-	if (arg->getAttribute("REMOVE_ALL")) {
-// 	  cout << "RooAbsArg::redir including remove_all node " << arg->GetName() << endl ;
-	  newSet->add(*arg) ;
-	} else if (arg->getAttribute(Form("REMOVE_FROM_%s",getStringAttribute("ORIGNAME")))) {
-// 	  cout << "RooAbsArg::redir including remove_from_" << GetName() << " node " << arg->GetName() << endl ;
-	  newSet->add(*arg) ;
-	}
+        if (arg->getAttribute("REMOVE_ALL")) {
+          newSet->add(*arg) ;
+        } else if (arg->getAttribute(Form("REMOVE_FROM_%s",getStringAttribute("ORIGNAME")))) {
+          newSet->add(*arg) ;
+        }
       } else {
-	newSet->add(*arg) ;
+        newSet->add(*arg) ;
       }
     }
-
-//     cout << "RooAbsArg::redirect with name change(" << GetName() << ") newSet = " << newSet << " origSet = " << newSetOrig << endl ;
-
   } else {
     newSet = (RooAbsCollection*) &newSetOrig ;
   }
@@ -968,13 +963,13 @@ Bool_t RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, Bool_t mus
 
     if (newServer && _verboseDirty) {
       cxcoutD(LinkStateMgmt) << "RooAbsArg::redirectServers(" << (void*)this << "," << GetName() << "): server " << oldServer->GetName()
-			     << " redirected from " << oldServer << " to " << newServer << endl ;
+			         << " redirected from " << oldServer << " to " << newServer << endl ;
     }
 
     if (!newServer) {
       if (mustReplaceAll) {
         coutE(LinkStateMgmt) << "RooAbsArg::redirectServers(" << (void*)this << "," << GetName() << "): server " << oldServer->GetName()
-			       << " (" << (void*)oldServer << ") not redirected" << (nameChange?"[nameChange]":"") << endl ;
+			           << " (" << (void*)oldServer << ") not redirected" << (nameChange?"[nameChange]":"") << endl ;
         ret = kTRUE ;
       }
       continue ;
@@ -985,7 +980,7 @@ Bool_t RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, Bool_t mus
     };
     bool propValue = std::any_of(origServerValue.begin(), origServerValue.end(), findByNamePtr);
     bool propShape = std::any_of(origServerShape.begin(), origServerShape.end(), findByNamePtr);
-    // cout << "replaceServer with name " << oldServer->GetName() << " old=" << oldServer << " new=" << newServer << endl ;
+
     if (newServer != this) {
       replaceServer(*oldServer,*newServer,propValue,propShape) ;
     }
@@ -1004,8 +999,8 @@ Bool_t RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, Bool_t mus
     if (mustReplaceAll && !ret2) {
       auto ap = dynamic_cast<const RooArgProxy*>(p);
       coutE(LinkStateMgmt) << "RooAbsArg::redirectServers(" << GetName()
-          << "): ERROR, proxy '" << p->name()
-          << "' with arg '" << (ap ? ap->absArg()->GetName() : "<could not cast>") << "' could not be adjusted" << endl;
+              << "): ERROR, proxy '" << p->name()
+              << "' with arg '" << (ap ? ap->absArg()->GetName() : "<could not cast>") << "' could not be adjusted" << endl;
       ret = kTRUE ;
     }
   }
@@ -1047,16 +1042,16 @@ RooAbsArg *RooAbsArg::findNewServer(const RooAbsCollection &newSet, Bool_t nameC
 
       // Check if any match was found
       if (tmp->getSize()==0) {
-	delete tmp ;
-	return 0 ;
+        delete tmp ;
+        return 0 ;
       }
 
       // Check if match is unique
       if(tmp->getSize()>1) {
-	coutF(LinkStateMgmt) << "RooAbsArg::redirectServers(" << GetName() << "): FATAL Error, " << tmp->getSize() << " servers with "
-			     << nameAttrib << " attribute" << endl ;
-	tmp->Print("v") ;
-	assert(0) ;
+        coutF(LinkStateMgmt) << "RooAbsArg::redirectServers(" << GetName() << "): FATAL Error, " << tmp->getSize() << " servers with "
+            << nameAttrib << " attribute" << endl ;
+        tmp->Print("v") ;
+        assert(0) ;
       }
 
       // use the unique element in the set

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -219,10 +219,9 @@ RooAbsCollection* RooAbsCollection::snapshot(Bool_t deepCopy) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Take a snap shot of current collection contents:
-/// An owning collection is returned containing clones of
-///
+/// A collection that owns its elements is returned containing clones of
 ///     - Elements in this collection
-///     - External dependents of all elements
+///     - External dependents of those elements
 ///       and recursively any dependents of those dependents
 ///       (if deepCopy flag is set)
 ///

--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -675,7 +675,7 @@ void RooCustomizer::printMultiline(ostream& os, Int_t /*content*/, Bool_t /*verb
 void RooCustomizer::setCloneBranchSet(RooArgSet& cloneBranchSet) 
 {
   _cloneBranchList = &cloneBranchSet ;
-  _cloneBranchList->setHashTableSize(1000) ;
+  _cloneBranchList->useHashMapForFind(true);
 }
 
 

--- a/roofit/roofitcore/src/RooDirItem.cxx
+++ b/roofit/roofitcore/src/RooDirItem.cxx
@@ -52,32 +52,13 @@ void RooDirItem::removeFromDir(TObject* obj)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Append object to directory. If forceMemoryResident is
-/// true, force addition to ROOT memory directory if that
-/// is not the current directory
-
+/// true, nothing happens.
 void RooDirItem::appendToDir(TObject* obj, Bool_t forceMemoryResident) 
 {
   if (forceMemoryResident) {
-    // Append self forcibly to memory directory
-
-    TString pwd(gDirectory->GetPath()) ;
-    TString memDir(gROOT->GetName()) ;
-    memDir.Append(":/") ;
-    Bool_t notInMemNow= (pwd!=memDir) ;
-
-    //cout << "RooDirItem::appendToDir pwd=" << pwd << " memDir=" << memDir << endl ;
-
-    if (notInMemNow) { 
-      gDirectory->cd(memDir) ;
-    }
-
-    _dir = gDirectory ;
-    gDirectory->Append(obj) ;
-    
-    if (notInMemNow) {
-      gDirectory->cd(pwd) ;    
-    }
-
+    // If we are not going into a file, appending to a directory
+    // doesn't make sense. It only creates global state and congestion.
+    return;
   } else {
     // Append self to present gDirectory
     _dir = gDirectory ;

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -439,7 +439,6 @@ void RooFFTConvPdf::fillCacheObject(RooAbsCachedPdf::PdfCacheElem& cache) const
   RooAbsArg* histArg = otherObs.find(_x.arg().GetName()) ;
   if (histArg) {
     otherObs.remove(*histArg,kTRUE,kTRUE) ;
-    delete histArg ;
   } 
 
   //cout << "RooFFTConvPdf::fillCacheObject() otherObs = " << otherObs << endl ;

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -506,8 +506,8 @@ std::list<Double_t>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, Double_t 
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Check if our datahist is already in the workspace
-
+/// Check if our datahist is already in the workspace.
+/// In case of error, return true.
 Bool_t RooHistFunc::importWorkspaceHook(RooWorkspace& ws) 
 {  
   std::list<RooAbsData*> allData = ws.allEmbeddedData() ;
@@ -530,18 +530,18 @@ Bool_t RooHistFunc::importWorkspaceHook(RooWorkspace& ws)
       // Check if histograms are identical
       if (areIdentical((RooDataHist&)*wsdata,*_dataHist)) {
 
-	// Exists and is of correct type, and identical -- adjust internal pointer to WS copy
-	_dataHist = (RooDataHist*) wsdata ;
+        // Exists and is of correct type, and identical -- adjust internal pointer to WS copy
+        _dataHist = (RooDataHist*) wsdata ;
       } else {
 
-	// not identical, clone rename and import
-	TString uniqueName = Form("%s_%s",_dataHist->GetName(),GetName()) ;
-	Bool_t flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.Data()),RooFit::Embedded()) ;
-	if (flag) {
-	  coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << endl ;
-	  return kTRUE ;
-	}
-	_dataHist = (RooDataHist*) ws.embeddedData(uniqueName.Data()) ;
+        // not identical, clone rename and import
+        TString uniqueName = Form("%s_%s",_dataHist->GetName(),GetName()) ;
+        Bool_t flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.Data()),RooFit::Embedded()) ;
+        if (flag) {
+          coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << endl ;
+          return kTRUE ;
+        }
+        _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.Data()) ;
       }
 
     } else {
@@ -550,18 +550,18 @@ Bool_t RooHistFunc::importWorkspaceHook(RooWorkspace& ws)
       TString uniqueName = Form("%s_%s",_dataHist->GetName(),GetName()) ;
       Bool_t flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.Data()),RooFit::Embedded()) ;
       if (flag) {
-	coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << endl ;
-	return kTRUE ;
+        coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << endl ;
+        return kTRUE ;
       }
       _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.Data()) ;
-      
+
     }
     return kFALSE ;
   }
-  
+
   // We need to import our datahist into the workspace
   ws.import(*_dataHist,RooFit::Embedded()) ;
-  
+
   // Redirect our internal pointer to the copy in the workspace
   _dataHist = (RooDataHist*) ws.embeddedData(_dataHist->GetName()) ;
   return kFALSE ;

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -510,19 +510,13 @@ std::list<Double_t>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, Double_t 
 /// In case of error, return true.
 Bool_t RooHistFunc::importWorkspaceHook(RooWorkspace& ws) 
 {  
-  std::list<RooAbsData*> allData = ws.allEmbeddedData() ;
-  std::list<RooAbsData*>::const_iterator iter ;
-  for (iter = allData.begin() ; iter != allData.end() ; ++iter) {
-    // If your dataset is already in this workspace nothing needs to be done
-    if (*iter == _dataHist) {
-      return kFALSE ;
-    }
-  }
-
   // Check if dataset with given name already exists
   RooAbsData* wsdata = ws.embeddedData(_dataHist->GetName()) ;
 
   if (wsdata) {
+    // If our data is exactly the same, we are done:
+    if (static_cast<RooDataHist*>(wsdata) == _dataHist)
+      return false;
 
     // Yes it exists - now check if it is identical to our internal histogram 
     if (wsdata->InheritsFrom(RooDataHist::Class())) {

--- a/roofit/roofitcore/src/RooSimPdfBuilder.cxx
+++ b/roofit/roofitcore/src/RooSimPdfBuilder.cxx
@@ -463,9 +463,9 @@ ClassImp(RooSimPdfBuilder);
 RooSimPdfBuilder::RooSimPdfBuilder(const RooArgSet& protoPdfSet) :
   _protoPdfSet(protoPdfSet)
 {
-  _compSplitCatSet.setHashTableSize(1000) ;
-  _splitNodeList.setHashTableSize(10000) ;
-  _splitNodeListOwned.setHashTableSize(10000) ;
+  _compSplitCatSet.useHashMapForFind(true);
+  _splitNodeList.useHashMapForFind(true);
+  _splitNodeListOwned.useHashMapForFind(true);
 }
 
 

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -501,7 +501,9 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   }
 
   // Now create a working copy of the incoming object tree
-  RooArgSet* cloneSet = RooArgSet(inArg).snapshot(noRecursion==kFALSE) ;
+  RooArgSet* cloneSet = new RooArgSet();
+  cloneSet->useHashMapForFind(true); // Accelerate finding
+  RooArgSet(inArg).snapshot(*cloneSet, !noRecursion);
   RooAbsArg* cloneTop = cloneSet->find(inArg.GetName()) ;
 
   // Mark all nodes for renaming if we are not in conflictOnly mode
@@ -607,7 +609,9 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   }
 
   // Now clone again with renaming effective
-  RooArgSet* cloneSet2 = (RooArgSet*) RooArgSet(*cloneTop).snapshot(noRecursion==kFALSE) ;
+  RooArgSet* cloneSet2 = new RooArgSet();
+  cloneSet2->useHashMapForFind(true); // Faster finding
+  RooArgSet(*cloneTop).snapshot(*cloneSet2, !noRecursion);
   RooAbsArg* cloneTop2 = cloneSet2->find(topName2.c_str()) ;
 
   // Make final check list of conflicting nodes
@@ -634,8 +638,6 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
       return kTRUE ;
     }
   }
-
-  if (cloneSet2->getSize()+_allOwnedNodes.getSize() > 999) _allOwnedNodes.setHashTableSize(1000);
 
   RooArgSet recycledNodes ;
   RooArgSet nodesToBeDeleted ;

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -357,9 +357,9 @@ Bool_t RooWorkspace::import(const RooArgSet& args,
 ///  two comma separated lists.
 /// \note From python, use `Import()`, since `import` is a reserved keyword.
 Bool_t RooWorkspace::import(const RooAbsArg& inArg,
-			    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
-			    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
-			    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9)
+    const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
+    const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
+    const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9)
 {
   RooLinkedList args ;
   args.Add((TObject*)&arg1) ;
@@ -445,7 +445,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
     RooAbsArg* v ;
     while((v=(RooAbsArg*)iter->Next())) {
       if (exceptVarNames.find(v->GetName())==exceptVarNames.end()) {
-	varMap[v->GetName()] = Form("%s_%s",v->GetName(),suffixV) ;
+        varMap[v->GetName()] = Form("%s_%s",v->GetName(),suffixV) ;
       }
     }
     delete iter ;
@@ -466,14 +466,14 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   if (!suffix && wsarg && !useExistingNodes && !(inArg.isFundamental() && varMap[inArg.GetName()]!="")) {
     if (!factoryMatch) {
       if (wsarg!=&inArg) {
-	coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR importing object named " << inArg.GetName()
-			      << ": another instance with same name already in the workspace and no conflict resolution protocol specified" << endl ;
-	return kTRUE ;
+        coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR importing object named " << inArg.GetName()
+			          << ": another instance with same name already in the workspace and no conflict resolution protocol specified" << endl ;
+        return kTRUE ;
       } else {
-	if (!silence) {
-	  coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") Object " << inArg.GetName() << " is already in workspace!" << endl ;
-	}
-	return kTRUE ;
+        if (!silence) {
+          coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") Object " << inArg.GetName() << " is already in workspace!" << endl ;
+        }
+        return kTRUE ;
       }
     } else {
       coutI(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") Recycling existing object " << inArg.GetName() << " created with identical factory specification" << endl ;
@@ -500,9 +500,9 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 
   // Terminate here if there are conflicts and no resolution protocol
   if (conflictNodes.getSize()>0 && !suffix && !useExistingNodes) {
-      coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << inArg.GetName() << ": component(s) "
-	   << conflictNodes << " already in the workspace and no conflict resolution protocol specified" << endl ;
-      return kTRUE ;
+    coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << inArg.GetName() << ": component(s) "
+        << conflictNodes << " already in the workspace and no conflict resolution protocol specified" << endl ;
+    return kTRUE ;
   }
 
   // Now create a working copy of the incoming object tree
@@ -529,19 +529,19 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
       string tag = Form("ORIGNAME:%s",origName.c_str()) ;
       cnode2->setAttribute(tag.c_str()) ;
       if (!cnode2->getStringAttribute("origName")) {
-	string tag2 = Form("%s",origName.c_str()) ;
-	cnode2->setStringAttribute("origName",tag2.c_str()) ;
+        string tag2 = Form("%s",origName.c_str()) ;
+        cnode2->setStringAttribute("origName",tag2.c_str()) ;
       }
 
       // Save name of new top level node for later use
       if (cnode2==cloneTop) {
-	topName2 = cnode2->GetName() ;
+        topName2 = cnode2->GetName() ;
       }
 
       if (!silence) {
-	coutI(ObjectHandling) << "RooWorkspace::import(" << GetName()
-			      << ") Resolving name conflict in workspace by changing name of imported node  "
-			      << origName << " to " << cnode2->GetName() << endl ;
+        coutI(ObjectHandling) << "RooWorkspace::import(" << GetName()
+			          << ") Resolving name conflict in workspace by changing name of imported node  "
+			          << origName << " to " << cnode2->GetName() << endl ;
       }
     }
     delete citer ;
@@ -556,34 +556,34 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
       RooAbsArg* wsnode = _allOwnedNodes.find(origName.c_str()) ;
       if (wsnode) {
 
-	if (!wsnode->getStringAttribute("origName")) {
-	  wsnode->setStringAttribute("origName",wsnode->GetName()) ;
-	}
+        if (!wsnode->getStringAttribute("origName")) {
+          wsnode->setStringAttribute("origName",wsnode->GetName()) ;
+        }
 
-	if (!_allOwnedNodes.find(Form("%s_%s",cnode->GetName(),suffix))) {
-	  wsnode->SetName(Form("%s_%s",cnode->GetName(),suffix)) ;
-	  wsnode->SetTitle(Form("%s (%s)",cnode->GetTitle(),suffix)) ;
-	} else {
-	  // Name with suffix already taken, add additional suffix
-	  Int_t n=1 ;
-	  while (true) {
-	    string newname = Form("%s_%s_%d",cnode->GetName(),suffix,n) ;
-	    if (!_allOwnedNodes.find(newname.c_str())) {
-	      wsnode->SetName(newname.c_str()) ;
-	      wsnode->SetTitle(Form("%s (%s %d)",cnode->GetTitle(),suffix,n)) ;
-	      break ;
-	    }
-	    n++ ;
-	  }
-	}
-	if (!silence) {
-	  coutI(ObjectHandling) << "RooWorkspace::import(" << GetName()
-				<< ") Resolving name conflict in workspace by changing name of original node "
-				<< origName << " to " << wsnode->GetName() << endl ;
-	}
+        if (!_allOwnedNodes.find(Form("%s_%s",cnode->GetName(),suffix))) {
+          wsnode->SetName(Form("%s_%s",cnode->GetName(),suffix)) ;
+          wsnode->SetTitle(Form("%s (%s)",cnode->GetTitle(),suffix)) ;
+        } else {
+          // Name with suffix already taken, add additional suffix
+          Int_t n=1 ;
+          while (true) {
+            string newname = Form("%s_%s_%d",cnode->GetName(),suffix,n) ;
+            if (!_allOwnedNodes.find(newname.c_str())) {
+              wsnode->SetName(newname.c_str()) ;
+              wsnode->SetTitle(Form("%s (%s %d)",cnode->GetTitle(),suffix,n)) ;
+              break ;
+            }
+            n++ ;
+          }
+        }
+        if (!silence) {
+          coutI(ObjectHandling) << "RooWorkspace::import(" << GetName()
+				    << ") Resolving name conflict in workspace by changing name of original node "
+				    << origName << " to " << wsnode->GetName() << endl ;
+        }
       } else {
-	coutW(ObjectHandling) << "RooWorkspce::import(" << GetName() << ") Internal error: expected to find existing node "
-			      << origName << " to be renamed, but didn't find it..." << endl ;
+        coutW(ObjectHandling) << "RooWorkspce::import(" << GetName() << ") Internal error: expected to find existing node "
+            << origName << " to be renamed, but didn't find it..." << endl ;
       }
 
     }
@@ -600,23 +600,23 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
     while ((cnode=(RooAbsArg*)cliter->Next())) {
 
       if (varMap.find(cnode->GetName())!=varMap.end()) {
-	string origName = cnode->GetName() ;
-	cnode->SetName(varMap[cnode->GetName()].c_str()) ;
-	string tag = Form("ORIGNAME:%s",origName.c_str()) ;
-	cnode->setAttribute(tag.c_str()) ;
-	if (!cnode->getStringAttribute("origName")) {
-	  string tag2 = Form("%s",origName.c_str()) ;
-	  cnode->setStringAttribute("origName",tag2.c_str()) ;
-	}
+        string origName = cnode->GetName() ;
+        cnode->SetName(varMap[cnode->GetName()].c_str()) ;
+        string tag = Form("ORIGNAME:%s",origName.c_str()) ;
+        cnode->setAttribute(tag.c_str()) ;
+        if (!cnode->getStringAttribute("origName")) {
+          string tag2 = Form("%s",origName.c_str()) ;
+          cnode->setStringAttribute("origName",tag2.c_str()) ;
+        }
 
-	if (!silence) {
-	  coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") Changing name of variable "
-				<< origName << " to " << cnode->GetName() << " on request" << endl ;
-	}
+        if (!silence) {
+          coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") Changing name of variable "
+              << origName << " to " << cnode->GetName() << " on request" << endl ;
+        }
 
-	if (cnode==cloneTop) {
-	  topName2 = cnode->GetName() ;
-	}
+        if (cnode==cloneTop) {
+          topName2 = cnode->GetName() ;
+        }
 
       }
     }
@@ -643,7 +643,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   // Terminate here if there are conflicts and no resolution protocol
   if (conflictNodes2.getSize()) {
     coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << inArg.GetName() << ": component(s) "
-			  << conflictNodes2 << " cause naming conflict after conflict resolution protocol was executed" << endl ;
+        << conflictNodes2 << " cause naming conflict after conflict resolution protocol was executed" << endl ;
     return kTRUE ;
   }
 
@@ -655,7 +655,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   while((node=(RooAbsArg*)iter->Next())) {
     if (node->importWorkspaceHook(*this)) {
       coutE(ObjectHandling) << "RooWorkSpace::import(" << GetName() << ") ERROR object named " << node->GetName()
-			    << " has an error in importing in one or more of its auxiliary objects, aborting" << endl ;
+			        << " has an error in importing in one or more of its auxiliary objects, aborting" << endl ;
       return kTRUE ;
     }
   }
@@ -669,8 +669,8 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
 
     if (_autoClass) {
       if (!_classes.autoImportClass(node->IsA())) {
-	coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") WARNING: problems import class code of object "
-			      << node->IsA()->GetName() << "::" << node->GetName() << ", reading of workspace will require external definition of class" << endl ;
+        coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") WARNING: problems import class code of object "
+            << node->IsA()->GetName() << "::" << node->GetName() << ", reading of workspace will require external definition of class" << endl ;
       }
     }
 
@@ -685,9 +685,9 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
     if (wsnode) {
       // Do not import node, add not to list of nodes that require reconnection
       if (!silence && useExistingNodes) {
-	coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") using existing copy of " << node->IsA()->GetName()
-			      << "::" << node->GetName() << " for import of " << cloneTop2->IsA()->GetName() << "::"
-			      << cloneTop2->GetName() << endl ;
+        coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") using existing copy of " << node->IsA()->GetName()
+			          << "::" << node->GetName() << " for import of " << cloneTop2->IsA()->GetName() << "::"
+			          << cloneTop2->GetName() << endl ;
       }
       recycledNodes.add(*_allOwnedNodes.find(node->GetName())) ;
 
@@ -699,19 +699,19 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
     } else {
       // Import node
       if (!silence) {
-	coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") importing " << node->IsA()->GetName() << "::"
-			      << node->GetName() << endl ;
+        coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") importing " << node->IsA()->GetName() << "::"
+            << node->GetName() << endl ;
       }
       _allOwnedNodes.addOwned(*node) ;
       if (_openTrans) {
-	_sandboxNodes.add(*node) ;
+        _sandboxNodes.add(*node) ;
       } else {
-	if (_dir && node->IsA() != RooConstVar::Class()) {
-	  _dir->InternalAppend(node) ;
-	}
-	if (_doExport && node->IsA() != RooConstVar::Class()) {
-	  exportObj(node) ;
-	}
+        if (_dir && node->IsA() != RooConstVar::Class()) {
+          _dir->InternalAppend(node) ;
+        }
+        if (_doExport && node->IsA() != RooConstVar::Class()) {
+          exportObj(node) ;
+        }
       }
     }
   }
@@ -723,7 +723,7 @@ Bool_t RooWorkspace::import(const RooAbsArg& inArg,
   RooFIter cloneSet_iter = cloneSet->fwdIterator() ;
   RooAbsArg* cloneNode ;
   while ((cloneNode=(RooAbsArg*)cloneSet_iter.next())) {
-     delete cloneNode;
+    delete cloneNode;
   }
   delete cloneSet ;
 

--- a/roofit/roofitcore/test/testWorkspace.cxx
+++ b/roofit/roofitcore/test/testWorkspace.cxx
@@ -192,3 +192,42 @@ TEST_F(TestRooWorkspaceWithGaussian, RooCustomiserInterface) {
   EXPECT_FALSE(model_constrained_orig->dependsOn(*ws->var("mu2")));
   EXPECT_NE(ws->pdf("Gauss_editPdf_orig"), nullptr);
 }
+
+
+/// Test that things still work when hash lookup for elements
+/// is performed.
+TEST_F(TestRooWorkspaceWithGaussian, HashLookupInWorkspace) {
+  TFile file(_filename, "READ");
+  RooWorkspace* ws;
+  file.GetObject("ws", ws);
+  ASSERT_NE(ws, nullptr);
+
+  ws->useFindsWithHashLookup(true);
+
+  // Prepare
+  ASSERT_NE(ws->factory("SUM:sum(a[0.5,0,1]*Gauss,Gauss)"), nullptr);
+  ASSERT_NE(ws->factory("expr:sig2(\"1 + @0 * @1\", {sigma_alpha[0.1], theta_alpha[0, -5, 5]})"), nullptr);
+  ASSERT_NE(ws->factory("EDIT::editPdf(sum, sigma=sig2)"), nullptr);
+  ASSERT_NE(ws->factory("Gaussian::constraint_alpha(global_alpha[0], theta_alpha, 1)"), nullptr);
+
+  // Build a product using the edited pdf. This failed because of ROOT-7921
+  // Problem was in RooCustomizer::CustIFace::create
+  EXPECT_NE(ws->factory("PROD::model_constrained(editPdf, constraint_alpha)"), nullptr);
+
+  // Test the other code path in RooCustomizer::CustIFace::create.
+  // Edit the top-level pdf in-place, replacing all existing conflicting nodes in the workspace by <node>_orig
+  ASSERT_NE(ws->factory("EDIT::model_constrained(model_constrained, mu=mu2[-1,-10,10])"), nullptr);
+
+  // Test that the new model_constrained has been altered
+  auto model_constrained = ws->pdf("model_constrained");
+  ASSERT_NE(model_constrained, nullptr);
+  EXPECT_TRUE(model_constrained->dependsOn(*ws->var("mu2")));
+  EXPECT_FALSE(model_constrained->dependsOn(*ws->var("mu")));
+
+  // Test that the old model still exists suffixed with _orig
+  auto model_constrained_orig = ws->pdf("model_constrained_orig");
+  ASSERT_NE(model_constrained_orig, nullptr);
+  EXPECT_TRUE(model_constrained_orig->dependsOn(*ws->var("mu")));
+  EXPECT_FALSE(model_constrained_orig->dependsOn(*ws->var("mu2")));
+  EXPECT_NE(ws->pdf("Gauss_editPdf_orig"), nullptr);
+}


### PR DESCRIPTION
Got a report about very slow importing of objects into workspaces. Turns out that considerable time is wasted with finding objects by name in vectors (which unfortunately cannot be sorted by name).
This adds a `std::unordered_map` for heavy searching and modernises old-style loops in RooWorkspace::import().

[prof_20200526.pdf](https://github.com/root-project/root/files/4683875/prof_20200526.pdf)
