### PR TITLE
[WIP] More sophisticated RHist binning comparisons

### DIFF
--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -216,6 +216,26 @@ protected:
       return CompareBinBorders(x, borderPos, leftBinWidth, rightBinWidth);
    }
 
+   /// Compare the numerical bin borders of one axis with that of another for
+   /// the purpose of evaluating an histogram merging scenario
+   ///
+   /// Since histogram merging has asymmetric properties, this axis is the
+   /// target axis, and the other axis is the source axis.
+   ///
+   /// Growable RAxis subclasses **must** override this method in a manner which
+   /// evaluates possible axis growth scenarios, before calling back
+   /// `CompareNumericalBinningAfterGrowth()`, which implements the actual
+   /// binning comparison, on a simulated grown axis.
+   ///
+   // FIXME: As of 2020-05-27, every RAxis type is considered to have numerical
+   //        bin borders, but that doesn't make sense for RAxisLabels. This will
+   //        be fixed by adding a lower-level base class which doesn't assume
+   //        the existence of floating-point bin borders, which will also lay
+   //        out the groundwork for supporting boolean/integer bin borders.
+   //
+   virtual NumericBinningCmpResult
+   CompareNumericalBinning(const RAxisBase& source) const;
+
 public:
    /**
     \class const_iterator
@@ -800,7 +820,7 @@ public:
    //       I did for HasSameBinning. Most likely some kind of CompareBinBorders
    //       virtual method?
    //
-   BinningCmpFlags CompareBinningWith(const RAxisBase& source) const;
+   BinningCmpFlags CompareBinning(const RAxisBase& source) const;
 
 private:
    std::string fTitle;    ///< Title of this axis, used for graphics / text.

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -707,8 +707,6 @@ public:
    /// Since histogram merging has asymmetric properties, this axis is the
    /// target axis, and the other axis is the source axis.
    ///
-   // TODO: Write the implementation
-   //
    // TODO: Figure out proper way to allow performance-motivated overrides, as
    //       I did for HasSameBinning. Most likely some kind of CompareBinBorders
    //       virtual method?

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -769,6 +769,48 @@ public:
          , fLabeled(labeled)
       {}
 
+      // Handle copies and moves
+      BinningCompatibility(const BinningCompatibility& other) {
+         *this = other;
+      }
+      BinningCompatibility(BinningCompatibility&& other) {
+         *this = std::move(other);
+      }
+      BinningCompatibility& operator=(const BinningCompatibility& other) {
+         this->~BinningCompatibility();
+         switch (other.fKind) {
+            case CompatKind::kIncompatible:
+               new(this) BinningCompatibility();
+               break;
+
+            case CompatKind::kNumeric:
+               new(this) BinningCompatibility(other.fNumeric);
+               break;
+
+            case CompatKind::kLabeled:
+               new(this) BinningCompatibility(other.fLabeled);
+               break;
+         };
+         return *this;
+      }
+      BinningCompatibility& operator=(BinningCompatibility&& other) {
+         this->~BinningCompatibility();
+         switch (other.fKind) {
+            case CompatKind::kIncompatible:
+               new(this) BinningCompatibility();
+               break;
+
+            case CompatKind::kNumeric:
+               new(this) BinningCompatibility(std::move(other.fNumeric));
+               break;
+
+            case CompatKind::kLabeled:
+               new(this) BinningCompatibility(std::move(other.fLabeled));
+               break;
+         };
+         return *this;
+      }
+
       /// Destroy any inner data on destruction
       ~BinningCompatibility() {
          switch (fKind) {

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -714,7 +714,11 @@ public:
       /// associated bin data) so that it matches the order of source bins.
       ///
       /// Any reordering should be performed after adding missing source axis
-      /// labels (see `SourceHasExtraLabels()`) to the target axis.
+      /// labels (see `SourceHasExtraLabels()`) to the target axis. Note that
+      /// newly added labels may have the wrong index, so adding labels from the
+      /// source axis may create target axis order issues that weren't there
+      /// before, so target axis reordering should take place whether this flag
+      /// or the previous one was true.
       ///
       bool LabelOrderDiffers() const {
          CheckKind(CmpKind::kLabels);

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -824,7 +824,23 @@ public:
             case CompatKind::kLabeled:
                fLabeled.~LabeledBinningCompatibility();
                break;
-         };
+         }
+      }
+
+      /// Check if two comparisons led to the same result
+      bool operator==(const BinningCompatibility& other) const {
+         if (other.fKind != fKind) return false;
+         switch (fKind) {
+            case CompatKind::kIncompatible:
+               return true;
+
+            case CompatKind::kNumeric:
+               return fNumeric == other.fNumeric;
+
+            case CompatKind::kLabeled:
+               return fLabeled == other.fLabeled;
+         }
+         return false;
       }
 
       /// Broad classification of possible axis comparisons

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -191,8 +191,8 @@ protected:
    }
 
 public:
-   /// Result of comparing two axes with numerical bin borders for the purpose
-   /// of evaluating histogram merging possibilities.
+   /// Result of comparing two axes with numerical bin borders for histogram
+   /// merging
    class NumericBinningCompatibility {
    public:
       /// Build a numerical binning comparison result
@@ -415,7 +415,7 @@ protected:
    ///
    /// Growable RAxis subclasses **must** override this method in a manner which
    /// evaluates possible axis growth scenarios, before calling back
-   /// `CompareNumericalBinningAfterGrowth()`, which implements the actual
+   /// `CheckFixedNumericalBinningCompat()`, which implements the actual
    /// binning comparison, on a simulated grown axis.
    ///
    // FIXME: As of 2020-05-27, every RAxis type is considered to have numerical
@@ -425,20 +425,20 @@ protected:
    //        out the groundwork for supporting boolean/integer bin borders.
    //
    virtual NumericBinningCompatibility
-   CompareNumericalBinning(const RAxisBase& source) const {
+   CheckNumericalBinningCompat(const RAxisBase& source) const {
       assert(!CanGrow());
-      return CompareNumericalBinningAfterGrowth(source, false);
+      return CheckFixedNumericalBinningCompat(source, false);
    }
 
-   /// Callback of `CompareNumericalBinning()` containing the actual bin border
-   /// comparison logic, to be invoked after simulating any required axis growth
-   /// scenarios, on the grown target axis.
+   /// Callback of `CheckNumericalBinningCompat()` containing the actual bin
+   /// border comparison logic, to be invoked after simulating any required axis
+   /// growth scenarios, on the grown target axis.
    ///
    /// This method can be overriden for performance optimization purposes.
    ///
    virtual NumericBinningCompatibility
-   CompareNumericalBinningAfterGrowth(const RAxisBase& source,
-                                      bool growthOccured) const;
+   CheckFixedNumericalBinningCompat(const RAxisBase& source,
+                                    bool growthOccured) const;
 
 public:
    /**
@@ -641,7 +641,7 @@ public:
    /// return `kInvalidBin`.
    virtual int GetBinIndexForLowEdge(double x) const noexcept = 0;
 
-   /// Result of comparing two labeled axis
+   /// Result of comparing two labeled axis for histogram merging
    class LabeledBinningCompatibility {
    public:
       /// Build a labeled axis comparison result
@@ -743,7 +743,7 @@ public:
       } fFlags;
    };
 
-   /// Result of an axis binning comparison
+   /// Result of comparing two axes for histogram merging
    //
    // TODO: Replace with std::variant once RHist goes C++17
    //
@@ -844,7 +844,7 @@ public:
    /// Since histogram merging has asymmetric properties, this axis is the
    /// target axis, and the other axis is the source axis.
    ///
-   BinningCompatibility CompareBinning(const RAxisBase& source) const;
+   BinningCompatibility CheckBinningCompat(const RAxisBase& source) const;
 
 private:
    std::string fTitle;    ///< Title of this axis, used for graphics / text.
@@ -1081,9 +1081,9 @@ public:
    /// This axis kind can increase its range.
    bool CanGrow() const noexcept final override { return true; }
 
-   /// CompareNumericalBinning must be overriden to handle axis growth
+   /// CheckNumericalBinningCompat must be overriden to handle axis growth
    NumericBinningCompatibility
-   CompareNumericalBinning(const RAxisBase& source) const final override;
+   CheckNumericalBinningCompat(const RAxisBase& source) const final override;
 };
 
 namespace Internal {
@@ -1320,7 +1320,8 @@ public:
 
    /// Compare the labels of this axis with those of another axis for the
    /// purpose of investigating a histogram merging scenario
-   LabeledBinningCompatibility CompareBinLabels(const RAxisLabels& source) const noexcept {
+   LabeledBinningCompatibility
+   CheckLabeledBinningCompat(const RAxisLabels& source) const noexcept {
       // For each axis, we must carefully distinguish the number of bins from
       // the number of labels. An RAxisLabels may have more bin labels than it
       // has bins if a label has been queried (which automatically allocates a

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -235,6 +235,7 @@ protected:
    //
    virtual NumericBinningCmpResult
    CompareNumericalBinning(const RAxisBase& source) const {
+      assert(!CanGrow());
       return CompareNumericalBinningAfterGrowth(source, false);
    }
 

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -171,7 +171,7 @@ protected:
       }
 
       // Get regular bin border comparison parameters
-      double borderPos, leftBinWidth, rightBinWidth;
+      double borderPos = 0., leftBinWidth = 0., rightBinWidth = 0.;
       switch (side) {
          case BinSide::kFrom:
             borderPos = GetBinFrom(bin);

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -234,7 +234,9 @@ protected:
    //        out the groundwork for supporting boolean/integer bin borders.
    //
    virtual NumericBinningCmpResult
-   CompareNumericalBinning(const RAxisBase& source) const;
+   CompareNumericalBinning(const RAxisBase& source) const {
+      return CompareNumericalBinningAfterGrowth(source, false);
+   }
 
    /// Callback of `CompareNumericalBinning()` containing the actual bin border
    /// comparison logic, to be invoked after simulating any required axis growth
@@ -1067,6 +1069,10 @@ public:
 
    /// This axis kind can increase its range.
    bool CanGrow() const noexcept final override { return true; }
+
+   /// CompareNumericalBinning must be overriden to handle axis growth
+   NumericBinningCmpResult
+   CompareNumericalBinning(const RAxisBase& source) const final override;
 };
 
 namespace Internal {

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -119,7 +119,7 @@ protected:
 
    /// Compare two axis bin borders
    ///
-   /// Given a target axis bin border position, a source axis bin border
+   /// Given a  source axis bin border position, a target axis bin border
    /// position, and the target axis' bin width on both sides of the bin border
    /// under consideration, tell if the source bin border should be considered
    /// to be located before (-1), at the same position (0), or after (+1) the
@@ -129,8 +129,8 @@ protected:
    /// it is an under/overflow bin, or if you do not care about the result on
    /// that side, please leave the corresponding bin width to a negative value.
    ///
-   static int CompareBinBorders(double targetBorder,
-                                double sourceBorder,
+   static int CompareBinBorders(double sourceBorder,
+                                double targetBorder,
                                 double leftTargetBinWidth = -1.,
                                 double rightTargetBinWidth = -1.) {
       // Current tolerance policy when there is no bin on one side
@@ -138,12 +138,12 @@ protected:
       if (rightTargetBinWidth < 0.) rightTargetBinWidth = 1.;
 
       // Perform an approximate bin border comparison
-      const double borderDelta = sourceBorder - targetBorder;
+      const double sourceOffset = sourceBorder - targetBorder;
       const double tolerance = 1e-6;
-      if borderDelta < 0. {
-         return -static_cast<int>(borderDelta < -leftTargetBinWidth*tolerance);
+      if sourceOffset < 0. {
+         return -static_cast<int>(sourceOffset < -leftTargetBinWidth*tolerance);
       } else {
-         return static_cast<int>(borderDelta > rightTargetBinWidth*tolerance);
+         return static_cast<int>(sourceOffset > rightTargetBinWidth*tolerance);
       }
    }
 

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -830,10 +830,6 @@ public:
    /// Since histogram merging has asymmetric properties, this axis is the
    /// target axis, and the other axis is the source axis.
    ///
-   // TODO: Figure out proper way to allow performance-motivated overrides, as
-   //       I did for HasSameBinning. Most likely some kind of CompareBinBorders
-   //       virtual method?
-   //
    BinningCmpFlags CompareBinning(const RAxisBase& source) const;
 
 private:

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RAxis
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <limits>
 #include <string>

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -270,7 +271,8 @@ public:
       //       bin index conversions in the histogram merging implementation.
       //
       bool HasRegularBinBijection() const {
-         assert(HasTrivialRegularBinMapping());
+         if (fFlags & kRegularBinBijection)
+            assert(HasTrivialRegularBinMapping());
          return fFlags & kRegularBinBijection;
       }
 
@@ -305,7 +307,8 @@ public:
       //       common case of merging two histograms with identical axis config.
       //
       bool HasFullBinBijection() const {
-         assert(HasRegularBinBijection());
+         if (fFlags & kFullBinBijection)
+            assert(HasRegularBinBijection());
          return fFlags & kFullBinBijection;
       }
 
@@ -678,7 +681,9 @@ public:
       /// This property implies `TargetMustGrow()`.
       ///
       const std::vector<std::string_view>& SourceOnlyLabels() const {
-         assert(TargetMustGrow());
+         if (!fSourceOnlyLabels.empty()) {
+            assert(TargetMustGrow());
+         }
          return fSourceOnlyLabels;
       }
 
@@ -749,7 +754,7 @@ public:
       /// See the methods of this class for a more detailed description of what
       /// each of these flags mean.
       ///
-      BinningCompatibility(NumericBinningCompatibility numeric)
+      explicit BinningCompatibility(NumericBinningCompatibility numeric)
          : fKind(CompatKind::kNumeric)
          , fNumeric(numeric)
       {}
@@ -759,7 +764,7 @@ public:
       /// See the methods of this class for a more detailed description of what
       /// each of these flags mean.
       ///
-      BinningCompatibility(LabeledBinningCompatibility labeled)
+      explicit BinningCompatibility(LabeledBinningCompatibility labeled)
          : fKind(CompatKind::kLabeled)
          , fLabeled(labeled)
       {}
@@ -1420,5 +1425,19 @@ struct AxisConfigToType<RAxisConfig::kLabels> {
 
 } // namespace Experimental
 } // namespace ROOT
+
+// Display operator for nicer test assertion errors
+std::ostream& operator<<(
+   std::ostream&,
+   const ROOT::Experimental::RAxisBase::NumericBinningCompatibility&
+);
+std::ostream& operator<<(
+   std::ostream&,
+   const ROOT::Experimental::RAxisBase::LabeledBinningCompatibility&
+);
+std::ostream& operator<<(
+   std::ostream&,
+   const ROOT::Experimental::RAxisBase::BinningCompatibility&
+);
 
 #endif // ROOT7_RAxis header guard

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -117,6 +117,10 @@ protected:
       return true;
    }
 
+   /// Placeholder bin width to be used in CompareBinBorders when there is no
+   /// bin or the width of that bin is irrelevant.
+   constexpr static const double kNoBinWidth = -1.;
+
    /// Compare two axis bin borders
    ///
    /// Given a source axis bin border position, a target axis bin border
@@ -127,15 +131,17 @@ protected:
    ///
    /// If there is no regular bin on one side of the target axis bin border, if
    /// it is an under/overflow bin, or if you do not care about the result on
-   /// that side, please leave the corresponding bin width to a negative value.
+   /// that side of the target bin border, please set the corresponding bin
+   /// width to kNoBinWidth.
    ///
    static int CompareBinBorders(double sourceBorder,
                                 double targetBorder,
-                                double leftTargetBinWidth = -1.,
-                                double rightTargetBinWidth = -1.) {
-      // Current tolerance policy when there is no bin on one side
-      if (leftTargetBinWidth < 0.) leftTargetBinWidth = 1.;
-      if (rightTargetBinWidth < 0.) rightTargetBinWidth = 1.;
+                                double leftTargetBinWidth,
+                                double rightTargetBinWidth) {
+      // Current tolerance policy when there is no bin width on one side is to
+      // treat the unknown bin width as a bin width of 1.
+      if (leftTargetBinWidth == kNoBinWidth) leftTargetBinWidth = 1.;
+      if (rightTargetBinWidth == kNoBinWidth) rightTargetBinWidth = 1.;
 
       // Perform an approximate bin border comparison
       const double sourceOffset = sourceBorder - targetBorder;

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -809,13 +809,13 @@ public:
       CompatKind Kind() const noexcept { return fKind; }
 
       /// Get the detailed result of a numerical axis comparison
-      NumericBinningCompatibility GetNumeric() {
+      NumericBinningCompatibility GetNumeric() const {
          CheckKind(CompatKind::kNumeric);
          return fNumeric;
       }
 
       /// Get the detailed result of a labeled axis comparison
-      LabeledBinningCompatibility GetLabeled() {
+      LabeledBinningCompatibility GetLabeled() const {
          CheckKind(CompatKind::kLabeled);
          return fLabeled;
       }

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -180,8 +180,6 @@ protected:
                return 1;
             case BinSide::kTo:
                return ComparePosToBinBorder(x, GetFirstBin(), BinSide::kFrom);
-            default:
-               throw std::runtime_error("No such bin side");
          }
       }
 
@@ -193,8 +191,6 @@ protected:
             case BinSide::kTo:
                // Everything is before the overflow bin's "right edge", +inf
                return -1;
-            default:
-               throw std::runtime_error("No such bin side");
          }
       }
 
@@ -214,9 +210,6 @@ protected:
             rightBinWidth =
                (bin < GetLastBin()) ? (GetBinTo(bin+1) - borderPos)
                                     : kNoBinWidth;
-            break;
-         default:
-            throw std::runtime_error("No such bin side");
       }
 
       // Perform an approximate bin border comparison

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -236,6 +236,16 @@ protected:
    virtual NumericBinningCmpResult
    CompareNumericalBinning(const RAxisBase& source) const;
 
+   /// Callback of `CompareNumericalBinning()` containing the actual bin border
+   /// comparison logic, to be invoked after simulating any required axis growth
+   /// scenarios, on the grown target axis.
+   ///
+   /// This method can be overriden for performance optimization purposes.
+   ///
+   virtual NumericBinningCmpResult
+   CompareNumericalBinningAfterGrowth(const RAxisBase& source,
+                                      bool growthOccured) const;
+
 public:
    /**
     \class const_iterator

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -171,7 +171,7 @@ protected:
    ///
    /// This is a higher-level alternative to CompareBinBorders().
    ///
-   int ComparePosToBinBorder(double x, int bin, BinSide side) {
+   int ComparePosToBinBorder(double x, int bin, BinSide side) const noexcept {
       // Handle underflow bin edge case
       if (bin == kUnderflowBin) {
          switch (side) {

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -532,6 +532,12 @@ public:
       // NOTE: This property does not affect the histogram merging
       //       implementation, but should be reported as a warning to its user.
       //
+      // NOTE: This does _not_ imply that the target bins are bigger, for a
+      //       counter-example this flag would be set in the example below:
+      //
+      //           Source axis bins:   |---|
+      //           Target axis bins: |---|---|
+      //
       bool MergingIsLossy() const {
          CheckKind(CmpKind::kNumeric);
          return fFlags & kMergingIsLossy;
@@ -647,8 +653,6 @@ public:
       /// specified in their documentation. They are what's queried by the
       /// boolean property accessors of this class.
       ///
-      // FIXME: Remove implementation notes after implementation
-      //
       enum Flags {
          // === NUMERIC-SPECIFIC FLAGS ===
          //
@@ -664,20 +668,9 @@ public:
          kFullBinBijection = 1 << 2,
 
          // Some bins from the source map to target bins that span extra range
-         //
-         // NOTE: This does _not_ imply that the target bin is bigger, for
-         //       example this flag should also be set in the scenario below:
-         //
-         //           Source axis bins:   |---|
-         //           Target axis bins: |---|---|
-         //
          kMergingIsLossy = 1 << 3,
 
          // Some regular bins from the source axis map to multiple target bins
-         //
-         // NOTE: Keep target under/overflow bins in mind while computing this
-         //       flag.
-         //
          kRegularBinAliasing = 1 << 4,
 
          // The source underflow bin must be empty to allow histogram merging

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -23,6 +23,7 @@
 #include <ostream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "ROOT/RAxisConfig.hxx"
@@ -777,37 +778,35 @@ public:
          *this = std::move(other);
       }
       BinningCompatibility& operator=(const BinningCompatibility& other) {
-         this->~BinningCompatibility();
          switch (other.fKind) {
             case CompatKind::kIncompatible:
-               new(this) BinningCompatibility();
+               rebuild();
                break;
 
             case CompatKind::kNumeric:
-               new(this) BinningCompatibility(other.fNumeric);
+               rebuild(other.fNumeric);
                break;
 
             case CompatKind::kLabeled:
-               new(this) BinningCompatibility(other.fLabeled);
+               rebuild(other.fLabeled);
                break;
-         };
+         }
          return *this;
       }
       BinningCompatibility& operator=(BinningCompatibility&& other) {
-         this->~BinningCompatibility();
          switch (other.fKind) {
             case CompatKind::kIncompatible:
-               new(this) BinningCompatibility();
+               rebuild();
                break;
 
             case CompatKind::kNumeric:
-               new(this) BinningCompatibility(std::move(other.fNumeric));
+               rebuild(std::move(other.fNumeric));
                break;
 
             case CompatKind::kLabeled:
-               new(this) BinningCompatibility(std::move(other.fLabeled));
+               rebuild(std::move(other.fLabeled));
                break;
-         };
+         }
          return *this;
       }
 
@@ -890,6 +889,14 @@ public:
          // Valid if fKind is CompatKind::kLabeled
          LabeledBinningCompatibility fLabeled;
       };
+
+      /// Replace with another instance of BinningCompatibility, constructed
+      /// using the provided arguments.
+      template <typename... Args>
+      void rebuild(Args&&... args) {
+         this->~BinningCompatibility();
+         new(this) BinningCompatibility(std::forward<Args>(args)...);
+      }
    };
 
    /// Compare the binning of this axis with that of another axis for the

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -220,7 +220,7 @@ public:
          )
       {}
 
-      NumericBinningCompatibility(const NumericBinningCompatibility&) = default;
+      // Check against another comparison result
       bool operator==(const NumericBinningCompatibility& other) const {
          return fFlags == other.fFlags;
       }
@@ -661,7 +661,7 @@ public:
          )
       {}
 
-      LabeledBinningCompatibility(const LabeledBinningCompatibility&) = default;
+      // Check against another comparison result
       bool operator==(const LabeledBinningCompatibility& other) const {
          return fFlags == other.fFlags;
       }
@@ -809,13 +809,13 @@ public:
       CompatKind Kind() const noexcept { return fKind; }
 
       /// Get the detailed result of a numerical axis comparison
-      NumericBinningCompatibility GetNumeric() const {
+      const NumericBinningCompatibility& GetNumeric() const {
          CheckKind(CompatKind::kNumeric);
          return fNumeric;
       }
 
       /// Get the detailed result of a labeled axis comparison
-      LabeledBinningCompatibility GetLabeled() const {
+      const LabeledBinningCompatibility& GetLabeled() const {
          CheckKind(CompatKind::kLabeled);
          return fLabeled;
       }

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -1341,7 +1341,7 @@ public:
 
       // Collect the set of source bin labels in the order where the user sees
       // them. Ignore uncommitted source labels: no bin = no data to be merged.
-      std::vector<std::string_view> sourceLabels = GetBinLabels();
+      std::vector<std::string_view> sourceLabels = source.GetBinLabels();
       sourceLabels.resize(numSourceBins);
 
       // Check how source _bins_ map into target bins and labels, simulating

--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -323,11 +323,87 @@ template <int DIMENSIONS, class PRECISION,
 void Add(RHist<DIMENSIONS, PRECISION, STAT_TO...> &to, const RHist<DIMENSIONS, PRECISION, STAT_FROM...> &from)
 {
    // Enforce "same axis configuration" policy.
+   //
+   // FIXME: To avoid code bloat, extract the per-axis comparison logic to a
+   //        separate cpp file, we can do this because axes are type-erased.
+   //
    auto& toImpl = *to.GetImpl();
    const auto& fromImpl = *from.GetImpl();
    for (int dim = 0; dim < DIMENSIONS; ++dim) {
-      if (!toImpl.GetAxis(dim).HasSameBinningAs(fromImpl.GetAxis(dim))) {
-         throw std::runtime_error("Attempted to add RHists with incompatible axis binning");
+      using CmpKind = RAxisBase::BinningCmpResult::CmpKind;
+      auto axisCmp = toImpl.GetAxis(dim).CompareBinning(fromImpl.GetAxis(dim));
+      switch (axisCmp.Kind()) {
+         case CmpKind::kIncompatible:
+            // Merging histograms with fully incompatible axis types will never
+            // be supported
+            throw std::runtime_error(
+               "Attempted to add RHists with incompatible axis types"
+            );
+         case CmpKind::kNumeric: {
+            auto numericAxisCmp = axisCmp.GetNumeric();
+            // FIXME: Support complicated merge scenarios where a source
+            //        histogram bin doesn't map into a target histogram bin with
+            //        the same global bin index
+            if (!numericAxisCmp.HasFullBinBijection()) {
+               throw std::runtime_error(
+                  "RHist::Add currently requires identical global "
+                  "binning of source and target histograms"
+               );
+            }
+            // TODO: Figure out how to report MergingIsLossy() info to the user
+            // FIXME: Handle bin aliasing more gracefully in histogram merging
+            //        by only bombing during bin data copy, if the aliasing bin
+            //        turns out to be non-empty? But this does lead the target
+            //        histogram data to be in a corrupted half-filled state if
+            //        the exception is caught... Or maybe we can do two passes
+            //        through the histogram, one to check for non-empty aliasing
+            //        bins and one to do the actual addition, but that's costly.
+            if (numericAxisCmp.HasRegularBinAliasing()) {
+               throw std::runtime_error(
+                  "RHist::Add currently does not support \"bin aliasing\" "
+                  "scenarios where a single source histogram bin maps into "
+                  "multiple target histogram bins"
+               );
+            }
+            // FIXME: Handle under/overflow emptiness constraint more gracefully
+            //        by only bombing if those bins are non-empty. See the
+            //        discussion of regular bin aliasing above for caveats.
+            if (numericAxisCmp.MergingNeedsEmptyUnderflow()
+                || numericAxisCmp.MergingNeedsEmptyOverflow()) {
+               throw std::runtime_error(
+                  "RHist::Add currently does not support checking for "
+                  "emptiness of source under/overflow bins"
+               );
+            }
+            // FIXME: Grow target axis (requires growth support)
+            if (numericAxisCmp.MergingNeedsTargetGrowth()) {
+               throw std::runtime_error(
+                  "RHist::Add currently does not support growing the target "
+                  "histogram's axes"
+               );
+            }
+            break;
+         }
+         case CmpKind::kLabeled: {
+            auto labeledAxisCmp = axisCmp.GetLabeled();
+            // FIXME: Support complicated merge scenarios where a source
+            //        histogram bin doesn't map into a target histogram bin with
+            //        the same global bin index
+            if (!labeledAxisCmp.HasSameBins()) {
+               throw std::runtime_error(
+                  "RHist::Add currently requires identical global "
+                  "binning of source and target histograms"
+               );
+            }
+            break;
+         }
+         default:
+            // If you encounter this error, the RHist::Add code needs updating
+            // to support new binning comparison types
+            throw std::runtime_error(
+               "BUG: The RHist::Add implementation got out of sync with the "
+               "RAxis codebase and must be updated to support new binning types"
+            );
       }
    }
 

--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -400,12 +400,12 @@ void Add(RHist<DIMENSIONS, PRECISION, STAT_TO...> &to, const RHist<DIMENSIONS, P
                throw std::runtime_error(
                   "RHist::Add currently requires the source and target "
                   "histogram axes to have their bin labels in the same order"
-               )
+               );
             }
             // FIXME: Support complicated merge scenarios where a source
             //        histogram bin doesn't map into a target histogram bin with
             //        the same global bin index
-            if (numericAxisCmp.TargetWillHaveExtraBins()) {
+            if (labeledAxisCmp.TargetWillHaveExtraBins()) {
                throw std::runtime_error(
                   "RHist::Add currently requires identical global "
                   "binning of source and target histograms"

--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -360,7 +360,7 @@ void Add(RHist<DIMENSIONS, PRECISION, STAT_TO...> &to, const RHist<DIMENSIONS, P
             //        bins and one to do the actual addition, but that's costly.
             if (numericAxisCmp.HasRegularBinAliasing()) {
                throw std::runtime_error(
-                  "RHist::Add currently does not support \"bin aliasing\" "
+                  "RHist::Add does not currently support \"bin aliasing\" "
                   "scenarios where a single source histogram bin maps into "
                   "multiple target histogram bins"
                );
@@ -371,14 +371,14 @@ void Add(RHist<DIMENSIONS, PRECISION, STAT_TO...> &to, const RHist<DIMENSIONS, P
             if (numericAxisCmp.MergingNeedsEmptyUnderflow()
                 || numericAxisCmp.MergingNeedsEmptyOverflow()) {
                throw std::runtime_error(
-                  "RHist::Add currently does not support checking for "
+                  "RHist::Add does not currently support checking for "
                   "emptiness of source under/overflow bins"
                );
             }
             // FIXME: Grow target axis (requires growth support)
             if (numericAxisCmp.MergingNeedsTargetGrowth()) {
                throw std::runtime_error(
-                  "RHist::Add currently does not support growing the target "
+                  "RHist::Add does not currently support growing the target "
                   "histogram's axes"
                );
             }
@@ -386,10 +386,26 @@ void Add(RHist<DIMENSIONS, PRECISION, STAT_TO...> &to, const RHist<DIMENSIONS, P
          }
          case CmpKind::kLabeled: {
             auto labeledAxisCmp = axisCmp.GetLabeled();
+            // FIXME: Grow target axis (requires growth support)
+            //        (we could already add support for adding source bin labels
+            //        to the target axis, but that's useless without growth)
+            if (labeledAxisCmp.TargetMustGrow()) {
+               throw std::runtime_error(
+                  "RHist::Add does not currently support growing the target "
+                  "histogram's axes"
+               );
+            }
+            // FIXME: Support out-of-order bin labels
+            if (labeledAxisCmp.LabelOrderDiffers()) {
+               throw std::runtime_error(
+                  "RHist::Add currently requires the source and target "
+                  "histogram axes to have their bin labels in the same order"
+               )
+            }
             // FIXME: Support complicated merge scenarios where a source
             //        histogram bin doesn't map into a target histogram bin with
             //        the same global bin index
-            if (!labeledAxisCmp.HasSameBins()) {
+            if (numericAxisCmp.TargetWillHaveExtraBins()) {
                throw std::runtime_error(
                   "RHist::Add currently requires identical global "
                   "binning of source and target histograms"

--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -330,16 +330,16 @@ void Add(RHist<DIMENSIONS, PRECISION, STAT_TO...> &to, const RHist<DIMENSIONS, P
    auto& toImpl = *to.GetImpl();
    const auto& fromImpl = *from.GetImpl();
    for (int dim = 0; dim < DIMENSIONS; ++dim) {
-      using CmpKind = RAxisBase::BinningCmpResult::CmpKind;
+      using CompatKind = RAxisBase::BinningCompatibility::CompatKind;
       auto axisCmp = toImpl.GetAxis(dim).CompareBinning(fromImpl.GetAxis(dim));
       switch (axisCmp.Kind()) {
-         case CmpKind::kIncompatible:
+         case CompatKind::kIncompatible:
             // Merging histograms with fully incompatible axis types will never
             // be supported
             throw std::runtime_error(
                "Attempted to add RHists with incompatible axis types"
             );
-         case CmpKind::kNumeric: {
+         case CompatKind::kNumeric: {
             auto numericAxisCmp = axisCmp.GetNumeric();
             // FIXME: Support complicated merge scenarios where a source
             //        histogram bin doesn't map into a target histogram bin with
@@ -384,7 +384,7 @@ void Add(RHist<DIMENSIONS, PRECISION, STAT_TO...> &to, const RHist<DIMENSIONS, P
             }
             break;
          }
-         case CmpKind::kLabeled: {
+         case CompatKind::kLabeled: {
             auto labeledAxisCmp = axisCmp.GetLabeled();
             // FIXME: Grow target axis (requires growth support)
             //        (we could already add support for adding source bin labels

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -130,20 +130,23 @@ ROOT::Experimental::RAxisBase::CheckFixedNumericBinningCompat(
          ++sourceBin;
       }
 
-      // If any source bin mapped into the target underflow bin like this, the
-      // source->target bin mapping isn't trivial and the merge is lossy as some
-      // source regular bins will map into the infinite target underflow bin.
+      // If any source bin mapped into the target underflow bin like this...
       if (sourceBin != source.GetFirstBin()) {
+         // Then those bins don't map into identically numbered target bin
          trivialRegularBinMapping = false;
+
+         // And they map into a larger bin, the infinitely large underflow bin
          mergingIsLossy = true;
       }
 
-      // If the selected source bin partially maps into the target underflow
-      // bin, then it covers both target underflow and regular/overflow range,
-      // and this source bin must be empty for a merge to be possible.
+      // If the selected bin partially maps into the target underflow bin...
       if (ComparePosToBinBorder(source.GetBinFrom(sourceBin),
                                 GetFirstBin(),
                                 BinSide::kFrom) < 0) {
+         // Then the first bin it maps to is the target underflow bin
+         trivialRegularBinMapping = false;
+
+         // And it maps into two bins, underflow and first regular or overflow
          regularBinAliasing = true;
       }
       // At this point, we have taken care of mappings from the first source
@@ -197,8 +200,8 @@ ROOT::Experimental::RAxisBase::CheckFixedNumericBinningCompat(
          const double sourceTo = source.GetBinTo(sourceBin);
 
          // Does the source->target bin mapping remain trivial so far?
-         if (targetBin == sourceBin) {
-            trivialRegularBinMapping = true;
+         if (targetBin != sourceBin) {
+            trivialRegularBinMapping = false;
          }
 
          // Does the first target bin cover nontrivial extra range on the left

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -277,6 +277,7 @@ ROOT::Experimental::RAxisBase::CheckFixedNumericBinningCompat(
       regularBinBijection && (source.CanGrow() == CanGrow());
 
    // Produce the final result of the numerical axis binning comparison
+   using Flags = NumericBinningCompatibility::Flags;
    return NumericBinningCompatibility(
       Flags(trivialRegularBinMapping * Flags::kTrivialRegularBinMapping
             + regularBinBijection * Flags::kRegularBinBijection
@@ -285,7 +286,7 @@ ROOT::Experimental::RAxisBase::CheckFixedNumericBinningCompat(
             + regularBinAliasing * Flags::kRegularBinAliasing
             + needEmptyUnderflow * Flags::kNeedEmptyUnderflow
             + needEmptyOverflow * Flags::kNeedEmptyOverflow
-            + targetMustGrow * Flags::kTargetMustGrow)
+            + growthOccured * Flags::kTargetMustGrow)
    );
 }
 

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -60,8 +60,10 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
       return BinningCmpResult();
    } else if (target_lbl_ptr) {
       const auto lbl_cmp = target_lbl_ptr->CompareBinLabels(*source_lbl_ptr);
-      return BinningCmpResult(lbl_cmp & RAxisLabels::kLabelsCmpSuperset,
-                              lbl_cmp & RAxisLabels::kLabelsCmpDisordered);
+      return BinningCmpResult(
+         LabeledBinningCmpResult(lbl_cmp & RAxisLabels::kLabelsCmpSuperset,
+                                 lbl_cmp & RAxisLabels::kLabelsCmpDisordered)
+      );
    }
    // If control reached this point, then we know that both the source and the
    // target axis use numerical bin borders
@@ -389,14 +391,16 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
       regularBinBijection && (source.CanGrow() == target.CanGrow());
 
    // Produce the final result of the numerical axis binning comparison
-   return BinningCmpResult(trivialRegularBinMapping,
-                           regularBinBijection,
-                           fullBinBijection,
-                           mergingIsLossy,
-                           regularBinAliasing,
-                           needEmptyUnderflow,
-                           needEmptyOverflow,
-                           targetMustGrow);
+   return BinningCmpResult(
+      NumericBinningCmpResult(trivialRegularBinMapping,
+                              regularBinBijection,
+                              fullBinBijection,
+                              mergingIsLossy,
+                              regularBinAliasing,
+                              needEmptyUnderflow,
+                              needEmptyOverflow,
+                              targetMustGrow)
+   );
 }
 
 int ROOT::Experimental::RAxisEquidistant::GetBinIndexForLowEdge(double x) const noexcept

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -215,9 +215,9 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
          ++sourceBin;
       }
 
-      // If any source bin does that, then the source->target bin mapping isn't
-      // trivial and the merge is lossy as some source regular bins will map
-      // into the infinite target underflow bin.
+      // If any source bin maps into the target underflow bin, then the
+      // source->target bin mapping isn't trivial and the merge is lossy as some
+      // source regular bins will map into the infinite target underflow bin.
       if (sourceBin > 1) {
          trivialRegularBinMapping = false;
          mergingIsLossy = true;
@@ -256,12 +256,7 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
          return;
       }
 
-      // Find the first target bin which a source bin maps into
-      //
-      // We know that there will be one such bin, as we have checked that there
-      // is at least one target bin and that the source bins are not all located
-      // in the target overflow range.
-      //
+      // Prepare to iterate over target axis bins
       int targetBin = 1;
       double targetFrom = target.GetBinFrom(1);
       double targetTo = target.GetBinTo(1);
@@ -274,11 +269,19 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
          targetTo = target.GetBinTo(targetBin);
          targetWidth = targetTo - targetFrom;
       };
+
+      // Find the first target bin which a source bin maps into
+      //
+      // We know that there will be one such bin, as we have checked that there
+      // is at least one target bin and that the source bins are not all located
+      // in the target overflow range.
+      //
       // NOTE: We can afford not to use the true next target bin width here,
       //       which simplifies the code quite a bit, because we do not care
       //       whether the comparison returns 0 or >= 0 on the right hand side
       //       of the targetTo bin border. We only care about it returning <0,
       //       which is fully determined by the left side tolerance.
+      //
       while (CompareBinBorders(sourceMin, targetTo, targetWidth, -1.) >= 0) {
          nextTargetBin();
       }
@@ -288,10 +291,10 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
       // Iterate over source bins, advancing the target bin index as needed,
       // until either axis has been fully covered
       //
-      // One loop invariant here is that anytime a loop iteration begins,
-      // sourceBin designates a source bin for which we haven't studied that
-      // target bin mappings, and targetBin designates the first bin which
-      // sourceBin maps into.
+      // The key loop invariant here is that anytime a loop iteration begins,
+      // sourceBin designates a source bin which we haven't studied (underflow
+      // bin mapping aside), and targetBin designates the first target axis bin
+      // which sourceBin maps into.
       //
       for (; sourceBin <= numSourceBins; ++sourceBin) {
          // Get the source bin's limits

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -21,6 +21,22 @@
 
 ROOT::Experimental::RAxisBase::~RAxisBase() {}
 
+std::ostream& operator<<(
+   std::ostream& s,
+   const ROOT::Experimental::RAxisBase::NumericBinningCompatibility& x
+) {
+   return s << "NumericBinningCompatibility { Flags("
+            << ' ' << (x.HasTrivialRegularBinMapping() ? "TRIVIAL_REG" : "trivial_reg")
+            << ' ' << (x.HasRegularBinBijection() ? "REG_BIJECTION" : "reg_bijection")
+            << ' ' << (x.HasFullBinBijection() ? "FULL_BIJECTION" : "full_bijection")
+            << ' ' << (x.MergingIsLossy() ? "LOSSY_MERGE" : "lossy_merge")
+            << ' ' << (x.HasRegularBinAliasing() ? "REG_ALIASING" : "reg_aliasing")
+            << ' ' << (x.MergingNeedsEmptyUnderflow() ? "NEED_EMPTY_UF" : "need_empty_uf")
+            << ' ' << (x.MergingNeedsEmptyOverflow() ? "NEED_EMPTY_OF" : "need_empty_of")
+            << ' ' << (x.MergingNeedsTargetGrowth() ? "NEED_GROWTH" : "need_growth")
+            << " ) }";
+}
+
 ROOT::Experimental::RAxisBase::NumericBinningCompatibility
 ROOT::Experimental::RAxisBase::CheckFixedNumericBinningCompat(
    const RAxisBase& source,
@@ -288,6 +304,43 @@ ROOT::Experimental::RAxisBase::CheckFixedNumericBinningCompat(
             + needEmptyOverflow * Flags::kNeedEmptyOverflow
             + growthOccured * Flags::kTargetMustGrow)
    );
+}
+
+std::ostream& operator<<(
+   std::ostream& s,
+   const ROOT::Experimental::RAxisBase::LabeledBinningCompatibility& x
+) {
+   s << "LabeledBinningCompatibility { Flags("
+     << ' ' << (x.TargetMustGrow() ? "MUST_GROW" : "must_grow")
+     << ' ' << (x.LabelOrderDiffers() ? "BAD_ORDER" : "bad_order")
+     << ' ' << (x.TargetWillHaveExtraBins() ? "EXTRA_BINS" : "extra_bins")
+     << " ), SourceOnlyLabels { ";
+   for (const auto& label: x.SourceOnlyLabels()) {
+      s << '"' << label << "\" ";
+   }
+   return s << "} }";
+}
+
+std::ostream& operator<<(
+   std::ostream& s,
+   const ROOT::Experimental::RAxisBase::BinningCompatibility& x
+) {
+   s << "BinningCompatibility { ";
+   using CompatKind = ROOT::Experimental::RAxisBase::BinningCompatibility::CompatKind;
+   switch (x.Kind()) {
+      case CompatKind::kIncompatible:
+         s << "Incompatible";
+         break;
+
+      case CompatKind::kNumeric:
+         s << x.GetNumeric();
+         break;
+
+      case CompatKind::kLabeled:
+         s << x.GetLabeled();
+         break;
+   };
+   return s << " }";
 }
 
 void ROOT::Experimental::RAxisBase::BinningCompatibility::CheckKind(CompatKind expectedKind) const {

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -33,7 +33,10 @@ bool ROOT::Experimental::RAxisBase::HasSameBinningAs(const RAxisBase& other) con
       return false;
    } else if (lbl_ptr) {
       auto lbl_cmp = lbl_ptr->CompareBinLabels(*other_lbl_ptr);
-      return (lbl_cmp == RAxisLabels::kLabelsCmpSame);
+      return (!lbl_cmp.SourceHasExtraLabels())
+         && (!lbl_cmp.LabelOrderDiffers())
+         // FIXME: RHistData merging limitation that should go away
+         && (lbl_ptr->GetNBinsNoOver() == other_lbl_ptr->GetNBinsNoOver());
    } else {
       return true;
    }
@@ -59,10 +62,8 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
    if (bool(target_lbl_ptr) != bool(source_lbl_ptr)) {
       return BinningCmpResult();
    } else if (target_lbl_ptr) {
-      const auto lbl_cmp = target_lbl_ptr->CompareBinLabels(*source_lbl_ptr);
       return BinningCmpResult(
-         LabeledBinningCmpResult(lbl_cmp & RAxisLabels::kLabelsCmpSuperset,
-                                 lbl_cmp & RAxisLabels::kLabelsCmpDisordered)
+         target_lbl_ptr->CompareBinLabels(*source_lbl_ptr)
       );
    }
    // If control reached this point, then we know that both the source and the

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -378,10 +378,6 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
          // ...and these source bins do not map into target bins with the same
          // indices, so the bin index mapping is nontrivial
          trivialRegularBinMapping = false;
-
-         // Any aliasing, including with the target overflow bin, was already
-         // detected by the source bin iteration code above
-         return;
       }
    }();
 

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -107,7 +107,7 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
 
    // Check if the source underflow and overflow bins must be empty
    const bool sourceHasUnderOver = !source.CanGrow();
-   const bool needEmptyUnderOver = (target.CanGrow() && sourceHasUnderOver);
+   const bool needEmptyUnderOver = sourceHasUnderOver && target.CanGrow();
    const double firstBinWidth = target.GetBinTo(1) - target.GetMinimum();
    const int minComparison = CompareBinBorders(source.GetMinimum(),
                                                target.GetMinimum(),
@@ -138,12 +138,15 @@ ROOT::Experimental::RAxisBase::CompareBinningWith(const RAxisBase& source) const
    //          * If >1 source bins, including the source underflow bin, map into
    //            the target underflow bin, then the merge is lossy
    //          * If we need to iterate, then the bin mapping isn't trivial
-   //       - Iterate over target bins until source axis minimum is covered
+   //       - Iterate over target bins until source bin is covered
    //          * If the source underflow bin maps into >1 target bin(s), then
    //            ... haven't we checked it already?
    //          * If we need to iterate, then the bin mapping isn't trivial
    //       - Jointly iterate over source/target until reaching the end of one
    //       - Final update to booleans depending on remaining bins on each side
+   //
+   //       This should be extracted into a lambda to permit early exit when
+   //       either the end of the source of the target axis is reached.
    //
    throw std::runtime_error("Not implemented yet!");
 

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -282,27 +282,6 @@ ROOT::Experimental::RAxisBase::CompareNumericalBinningAfterGrowth(
                                   growthOccured);
 }
 
-bool ROOT::Experimental::RAxisBase::HasSameBinningAs(const RAxisBase& other) const {
-   // Bin borders must match
-   if (!HasSameBinBordersAs(other))
-      return false;
-
-   // Bin labels must match
-   auto lbl_ptr = dynamic_cast<const RAxisLabels*>(this);
-   auto other_lbl_ptr = dynamic_cast<const RAxisLabels*>(&other);
-   if (bool(lbl_ptr) != bool(other_lbl_ptr)) {
-      return false;
-   } else if (lbl_ptr) {
-      auto lbl_cmp = lbl_ptr->CompareBinLabels(*other_lbl_ptr);
-      return (!lbl_cmp.SourceHasExtraLabels())
-         && (!lbl_cmp.LabelOrderDiffers())
-         // FIXME: RHistData merging limitation that should go away
-         && (lbl_ptr->GetNBinsNoOver() == other_lbl_ptr->GetNBinsNoOver());
-   } else {
-      return true;
-   }
-}
-
 void ROOT::Experimental::RAxisBase::BinningCmpResult::CheckKind(CmpKind expectedKind) const {
    if (fKind != expectedKind) {
       throw std::runtime_error("The queried property is invalid for this "
@@ -356,21 +335,6 @@ int ROOT::Experimental::RAxisEquidistant::GetBinIndexForLowEdge(double x) const 
       return RAxisBase::kInvalidBin;
 
    return binIdx;
-}
-
-bool ROOT::Experimental::RAxisEquidistant::HasSameBinBordersAs(const RAxisBase& other) const {
-   // This is an optimized override for the equidistant-equidistant case,
-   // fall back to the default implementation if we're not in that case.
-   auto other_eq_ptr = dynamic_cast<const RAxisEquidistant*>(&other);
-   if (!other_eq_ptr)
-      return RAxisBase::HasSameBinBordersAs(other);
-   const RAxisEquidistant& other_eq = *other_eq_ptr;
-
-   // Can directly compare equidistant/growable axis properties in this case
-   return fInvBinWidth == other_eq.fInvBinWidth &&
-          fLow == other_eq.fLow &&
-          fNBinsNoOver == other_eq.fNBinsNoOver &&
-          CanGrow() == other_eq.CanGrow();
 }
 
 ROOT::Experimental::RAxisBase::NumericBinningCmpResult
@@ -450,50 +414,3 @@ int ROOT::Experimental::RAxisIrregular::GetBinIndexForLowEdge(double x) const no
    // If not, report failure
    return RAxisBase::kInvalidBin;
 }
-
-bool ROOT::Experimental::RAxisIrregular::HasSameBinBordersAs(const RAxisBase& other) const {
-   // This is an optimized override for the irregular-irregular case,
-   // fall back to the default implementation if we're not in that case.
-   auto other_irr_ptr = dynamic_cast<const RAxisIrregular*>(&other);
-   if (!other_irr_ptr)
-      return RAxisBase::HasSameBinBordersAs(other);
-   const RAxisIrregular& other_irr = *other_irr_ptr;
-
-   // Only need to compare bin borders in this specialized case
-   return fBinBorders == other_irr.fBinBorders;
-}
-
-ROOT::Experimental::EAxisCompatibility ROOT::Experimental::CanMap(const RAxisEquidistant &target,
-                                                                  const RAxisEquidistant &source) noexcept
-{
-   // First, let's get the common "all parameters are equal" case out of the way
-   if (source.HasSameBinningAs(target))
-      return EAxisCompatibility::kIdentical;
-
-   // Do the source min/max boundaries correspond to target bin boundaries?
-   int idxTargetLow = target.GetBinIndexForLowEdge(source.GetMinimum());
-   int idxTargetHigh = target.GetBinIndexForLowEdge(source.GetMaximum());
-   if (idxTargetLow < 0 || idxTargetHigh < 0)
-      // If not, the source is incompatible with the target since the first or
-      // last source bin does not map into a target axis bin.
-      return EAxisCompatibility::kIncompatible;
-
-   // If so, and if the bin width is the same, then since we've eliminated the
-   // care where min/max/width are equal, source must be a subset of target.
-   if (source.GetInverseBinWidth() == target.GetInverseBinWidth())
-      return EAxisCompatibility::kContains;
-
-   // Now we are left with the case
-   //   source: 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6
-   //   target: ...0.0, 0.3, 0.6...
-   // The question is: is the ratio of the bin width identical to the ratio of
-   // the number of bin?
-   if (std::fabs(target.GetInverseBinWidth() * source.GetNBinsNoOver() -
-                 source.GetInverseBinWidth() * (idxTargetHigh - idxTargetLow)) > 1E-6 * target.GetInverseBinWidth())
-      return EAxisCompatibility::kIncompatible;
-
-   // source is a fine-grained version of target.
-   return EAxisCompatibility::kSampling;
-}
-
-// TODO: the other CanMap() overloads

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -21,7 +21,7 @@
 
 ROOT::Experimental::RAxisBase::~RAxisBase() {}
 
-virtual ROOT::Experimental::RAxisBase::NumericBinningCmpResult
+ROOT::Experimental::RAxisBase::NumericBinningCmpResult
 ROOT::Experimental::RAxisBase::CompareNumericalBinningAfterGrowth(
    const RAxisBase& source,
    bool growthOccured
@@ -194,7 +194,7 @@ ROOT::Experimental::RAxisBase::CompareNumericalBinningAfterGrowth(
          // axis in attempting to do so.
          bool endOfTargetAxis = false;
          const int firstTargetBin = targetBin;
-         while (ComparePosToBinBorders(sourceTo, targetBin, BinSide::kTo) >= 0) {
+         while (ComparePosToBinBorder(sourceTo, targetBin, BinSide::kTo) >= 0) {
             if (targetBin < GetNBinsNoOver()) {
                ++targetBin;
             } else {
@@ -210,7 +210,7 @@ ROOT::Experimental::RAxisBase::CompareNumericalBinningAfterGrowth(
 
          // Next, we need to tell which other bins the source bin maps into
          int lastBinCmpResult;
-         if (endOfTarget) {
+         if (endOfTargetAxis) {
             // If the end of the target axis was reached, then we know that
             // sourceBin maps into the current targetBin, because we didn't
             // manage to find a targetBin which even extends beyond the end of
@@ -250,7 +250,7 @@ ROOT::Experimental::RAxisBase::CompareNumericalBinningAfterGrowth(
          // loop, as we cannot maintain the loop invariant that at the beginning
          // of a loop iteration, `targetBin` must be the first bin which the
          // active `sourceBin` maps into.
-         if (endOfTarget) break;
+         if (endOfTargetAxis) break;
       }
 
       // Was the end of the target axis reached w/o covering all source bins?
@@ -381,19 +381,20 @@ ROOT::Experimental::RAxisGrow::CompareNumericalBinning(const RAxisBase& source) 
 
    // Prepare to simulate axis growth if need be
    RAxisGrow targetAfterGrowth;
-   const RAxisGrow* targetPtr = *this;
+   const RAxisGrow* targetPtr = this;
 
    // Check if axis growth is needed
    const bool growLeft =
       (ComparePosToBinBorder(sourceMin, GetFirstBin(), BinSide::kFrom) < 0);
    const bool growRight =
       (ComparePosToBinBorder(sourceMin, GetLastBin(), BinSide::kTo) < 0);
-   if (growLeft || growRight) {
+   const bool mustGrow = growLeft || growRight;
+   if (mustGrow) {
       // Simulate axis growth on the left-hand side
       const double leftGrowth =
          static_cast<double>(growLeft) * (GetMinimum() - sourceMin);
       int leftBins = std::floor(leftGrowth / GetBinWidth());
-      double leftBorder = GetMinimum() - leftBins*GetBinWidth()
+      double leftBorder = GetMinimum() - leftBins*GetBinWidth();
       if (CompareBinBorders(sourceMin,
                             leftBorder,
                             kNoBinWidth,
@@ -424,7 +425,7 @@ ROOT::Experimental::RAxisGrow::CompareNumericalBinning(const RAxisBase& source) 
    }
 
    // Call back binning comparison hook on the possibly grown axis
-   return targetPtr->CompareNumericalBinningAfterGrowth(source, targetMustGrow);
+   return targetPtr->CompareNumericalBinningAfterGrowth(source, mustGrow);
 }
 
 int ROOT::Experimental::RAxisIrregular::GetBinIndexForLowEdge(double x) const noexcept

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -22,7 +22,7 @@
 ROOT::Experimental::RAxisBase::~RAxisBase() {}
 
 ROOT::Experimental::RAxisBase::NumericBinningCompatibility
-ROOT::Experimental::RAxisBase::CheckFixedNumericalBinningCompat(
+ROOT::Experimental::RAxisBase::CheckFixedNumericBinningCompat(
    const RAxisBase& source,
    bool growthOccured
 ) const {
@@ -277,14 +277,16 @@ ROOT::Experimental::RAxisBase::CheckFixedNumericalBinningCompat(
       regularBinBijection && (source.CanGrow() == CanGrow());
 
    // Produce the final result of the numerical axis binning comparison
-   return NumericBinningCompatibility(trivialRegularBinMapping,
-                                      regularBinBijection,
-                                      fullBinBijection,
-                                      mergingIsLossy,
-                                      regularBinAliasing,
-                                      needEmptyUnderflow,
-                                      needEmptyOverflow,
-                                      growthOccured);
+   return NumericBinningCompatibility(
+      Flags(trivialRegularBinMapping * Flags::kTrivialRegularBinMapping
+            + regularBinBijection * Flags::kRegularBinBijection
+            + fullBinBijection * Flags::kFullBinBijection
+            + mergingIsLossy * Flags::kMergingIsLossy
+            + regularBinAliasing * Flags::kRegularBinAliasing
+            + needEmptyUnderflow * Flags::kNeedEmptyUnderflow
+            + needEmptyOverflow * Flags::kNeedEmptyOverflow
+            + targetMustGrow * Flags::kTargetMustGrow)
+   );
 }
 
 void ROOT::Experimental::RAxisBase::BinningCompatibility::CheckKind(CompatKind expectedKind) const {
@@ -314,7 +316,7 @@ ROOT::Experimental::RAxisBase::CheckBinningCompat(const RAxisBase& source) const
 
    // If control reached this point, then we know that both the source and the
    // target axis use numerical bin borders
-   return BinningCompatibility(CheckNumericalBinningCompat(source));
+   return BinningCompatibility(CheckNumericBinningCompat(source));
 }
 
 int ROOT::Experimental::RAxisEquidistant::GetBinIndexForLowEdge(double x) const noexcept
@@ -343,7 +345,7 @@ int ROOT::Experimental::RAxisEquidistant::GetBinIndexForLowEdge(double x) const 
 }
 
 ROOT::Experimental::RAxisBase::NumericBinningCompatibility
-ROOT::Experimental::RAxisGrow::CheckNumericalBinningCompat(
+ROOT::Experimental::RAxisGrow::CheckNumericBinningCompat(
    const RAxisBase& source
 ) const {
    // Convenience shorthands
@@ -396,7 +398,7 @@ ROOT::Experimental::RAxisGrow::CheckNumericalBinningCompat(
    }
 
    // Call back binning comparison hook on the possibly grown axis
-   return targetPtr->CheckFixedNumericalBinningCompat(source, mustGrow);
+   return targetPtr->CheckFixedNumericBinningCompat(source, mustGrow);
 }
 
 int ROOT::Experimental::RAxisIrregular::GetBinIndexForLowEdge(double x) const noexcept

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -21,7 +21,7 @@
 
 ROOT::Experimental::RAxisBase::~RAxisBase() {}
 
-ROOT::Experimental::RAxisBase::NumericBinningCmpResult
+ROOT::Experimental::RAxisBase::NumericBinningCompatibility
 ROOT::Experimental::RAxisBase::CompareNumericalBinningAfterGrowth(
    const RAxisBase& source,
    bool growthOccured
@@ -277,24 +277,24 @@ ROOT::Experimental::RAxisBase::CompareNumericalBinningAfterGrowth(
       regularBinBijection && (source.CanGrow() == CanGrow());
 
    // Produce the final result of the numerical axis binning comparison
-   return NumericBinningCmpResult(trivialRegularBinMapping,
-                                  regularBinBijection,
-                                  fullBinBijection,
-                                  mergingIsLossy,
-                                  regularBinAliasing,
-                                  needEmptyUnderflow,
-                                  needEmptyOverflow,
-                                  growthOccured);
+   return NumericBinningCompatibility(trivialRegularBinMapping,
+                                      regularBinBijection,
+                                      fullBinBijection,
+                                      mergingIsLossy,
+                                      regularBinAliasing,
+                                      needEmptyUnderflow,
+                                      needEmptyOverflow,
+                                      growthOccured);
 }
 
-void ROOT::Experimental::RAxisBase::BinningCmpResult::CheckKind(CmpKind expectedKind) const {
+void ROOT::Experimental::RAxisBase::BinningCompatibility::CheckKind(CompatKind expectedKind) const {
    if (fKind != expectedKind) {
       throw std::runtime_error("The queried property is invalid for this "
          "kind of axis binning comparison");
    }
 }
 
-ROOT::Experimental::RAxisBase::BinningCmpResult
+ROOT::Experimental::RAxisBase::BinningCompatibility
 ROOT::Experimental::RAxisBase::CompareBinning(const RAxisBase& source) const {
    // Handle labeled axis edge case
    //
@@ -305,16 +305,16 @@ ROOT::Experimental::RAxisBase::CompareBinning(const RAxisBase& source) const {
    const auto target_lbl_ptr = dynamic_cast<const RAxisLabels*>(this);
    const auto source_lbl_ptr = dynamic_cast<const RAxisLabels*>(&source);
    if (bool(target_lbl_ptr) != bool(source_lbl_ptr)) {
-      return BinningCmpResult();
+      return BinningCompatibility();
    } else if (target_lbl_ptr) {
-      return BinningCmpResult(
+      return BinningCompatibility(
          target_lbl_ptr->CompareBinLabels(*source_lbl_ptr)
       );
    }
 
    // If control reached this point, then we know that both the source and the
    // target axis use numerical bin borders
-   return BinningCmpResult(CompareNumericalBinning(source));
+   return BinningCompatibility(CompareNumericalBinning(source));
 }
 
 int ROOT::Experimental::RAxisEquidistant::GetBinIndexForLowEdge(double x) const noexcept
@@ -342,7 +342,7 @@ int ROOT::Experimental::RAxisEquidistant::GetBinIndexForLowEdge(double x) const 
    return binIdx;
 }
 
-ROOT::Experimental::RAxisBase::NumericBinningCmpResult
+ROOT::Experimental::RAxisBase::NumericBinningCompatibility
 ROOT::Experimental::RAxisGrow::CompareNumericalBinning(const RAxisBase& source) const {
    // Convenience shorthands
    const double sourceMin = source.GetMinimum();

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -417,7 +417,7 @@ ROOT::Experimental::RAxisGrow::CheckNumericBinningCompat(
    const bool growLeft =
       (ComparePosToBinBorder(sourceMin, GetFirstBin(), BinSide::kFrom) < 0);
    const bool growRight =
-      (ComparePosToBinBorder(sourceMin, GetLastBin(), BinSide::kTo) < 0);
+      (ComparePosToBinBorder(sourceMax, GetLastBin(), BinSide::kTo) > 0);
    const bool mustGrow = growLeft || growRight;
    if (mustGrow) {
       // Simulate axis growth on the left-hand side

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -22,7 +22,7 @@
 ROOT::Experimental::RAxisBase::~RAxisBase() {}
 
 ROOT::Experimental::RAxisBase::NumericBinningCompatibility
-ROOT::Experimental::RAxisBase::CompareNumericalBinningAfterGrowth(
+ROOT::Experimental::RAxisBase::CheckFixedNumericalBinningCompat(
    const RAxisBase& source,
    bool growthOccured
 ) const {
@@ -295,7 +295,7 @@ void ROOT::Experimental::RAxisBase::BinningCompatibility::CheckKind(CompatKind e
 }
 
 ROOT::Experimental::RAxisBase::BinningCompatibility
-ROOT::Experimental::RAxisBase::CompareBinning(const RAxisBase& source) const {
+ROOT::Experimental::RAxisBase::CheckBinningCompat(const RAxisBase& source) const {
    // Handle labeled axis edge case
    //
    // NOTE: This must be handled at the axis base class level, because C++ does
@@ -308,13 +308,13 @@ ROOT::Experimental::RAxisBase::CompareBinning(const RAxisBase& source) const {
       return BinningCompatibility();
    } else if (target_lbl_ptr) {
       return BinningCompatibility(
-         target_lbl_ptr->CompareBinLabels(*source_lbl_ptr)
+         target_lbl_ptr->CheckLabeledBinningCompat(*source_lbl_ptr)
       );
    }
 
    // If control reached this point, then we know that both the source and the
    // target axis use numerical bin borders
-   return BinningCompatibility(CompareNumericalBinning(source));
+   return BinningCompatibility(CheckNumericalBinningCompat(source));
 }
 
 int ROOT::Experimental::RAxisEquidistant::GetBinIndexForLowEdge(double x) const noexcept
@@ -343,7 +343,9 @@ int ROOT::Experimental::RAxisEquidistant::GetBinIndexForLowEdge(double x) const 
 }
 
 ROOT::Experimental::RAxisBase::NumericBinningCompatibility
-ROOT::Experimental::RAxisGrow::CompareNumericalBinning(const RAxisBase& source) const {
+ROOT::Experimental::RAxisGrow::CheckNumericalBinningCompat(
+   const RAxisBase& source
+) const {
    // Convenience shorthands
    const double sourceMin = source.GetMinimum();
    const double sourceMax = source.GetMaximum();
@@ -394,7 +396,7 @@ ROOT::Experimental::RAxisGrow::CompareNumericalBinning(const RAxisBase& source) 
    }
 
    // Call back binning comparison hook on the possibly grown axis
-   return targetPtr->CompareNumericalBinningAfterGrowth(source, mustGrow);
+   return targetPtr->CheckFixedNumericalBinningCompat(source, mustGrow);
 }
 
 int ROOT::Experimental::RAxisIrregular::GetBinIndexForLowEdge(double x) const noexcept

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -364,10 +364,10 @@ ROOT::Experimental::RAxisGrow::CompareNumericalBinning(const RAxisBase& source) 
          static_cast<double>(growLeft) * (GetMinimum() - sourceMin);
       int leftBins = std::floor(leftGrowth / GetBinWidth());
       double leftBorder = GetMinimum() - leftBins*GetBinWidth();
-      if (CompareBinBorders(sourceMin,
-                            leftBorder,
-                            kNoBinWidth,
-                            GetBinWidth()) < 0) {
+      if (ComparePosToBinBorder(sourceMin,
+                                leftBorder,
+                                kNoBinWidth,
+                                GetBinWidth()) < 0) {
          ++leftBins;
          leftBorder -= GetBinWidth();
       }
@@ -377,10 +377,10 @@ ROOT::Experimental::RAxisGrow::CompareNumericalBinning(const RAxisBase& source) 
          static_cast<double>(growRight) * (sourceMax - GetMaximum());
       int rightBins = std::floor(rightGrowth / GetBinWidth());
       double rightBorder = GetMaximum() + rightBins*GetBinWidth();
-      if (CompareBinBorders(sourceMax,
-                            rightBorder,
-                            GetBinWidth(),
-                            kNoBinWidth) > 0) {
+      if (ComparePosToBinBorder(sourceMax,
+                                rightBorder,
+                                GetBinWidth(),
+                                kNoBinWidth) > 0) {
          ++rightBins;
          rightBorder += GetBinWidth();
       }

--- a/hist/histv7/src/RAxis.cxx
+++ b/hist/histv7/src/RAxis.cxx
@@ -63,10 +63,15 @@ ROOT::Experimental::RAxisBase::CompareNumericalBinningAfterGrowth(
    bool mergingIsLossy =
       sourceHasUnderOver && ((minComparison < 0) || (maxComparison > 0));
 
-   // Now, time to look at regular bins.
+   // Now, time to look at regular bins
+   //
+   // The lambda is run immediately, and only once. Its purpose is to enable
+   // exiting the regular bin comparison logic early as soon as all source
+   // regular bins have been processed. You could call it the ultimate goto.
+   //
    bool trivialRegularBinMapping = true;
    bool regularBinAliasing = false;
-   [&] {
+   [&]{
       // Handle the edge case where the source axis has no regular bin
       if (source.GetNBinsNoOver() == 0) {
          return;

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -785,6 +785,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
     {
       SCOPED_TRACE("Source axis is irregular");
       testEqBinnedToNonGrowable(makeEquidistant, makeEqBinnedIrregular);
+
       // Extra scenarios enabled by irregular source axis binning
       const RAxisEquidistant target(6, 1.2, 4.2);
       {

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -720,17 +720,19 @@ TEST(AxisTest, NumericBinningCompatibility) {
                            + fixedSource * CompatFlags::kNeedEmptyOverflow);
       }
       {
-        SCOPED_TRACE("Source axis has larger bins");
+        SCOPED_TRACE("Source axis bins are larger by an integer factor");
         checkNumericCompat(target,
                            makeSource(2, 1.2, 3.2),
                            CompatFlags::kRegularBinAliasing);
       }
+      // FIXME: Explore non-integer factors too
       {
-        SCOPED_TRACE("Source axis has smaller bins");
+        SCOPED_TRACE("Source axis bins are smaller by an integer factor");
         checkNumericCompat(target,
                            makeSource(8, 1.2, 3.2),
                            CompatFlags::kMergingIsLossy);
       }
+      // FIXME: Explore non-integer factors too
       {
         SCOPED_TRACE("Source axis is shifted forward");
         checkNumericCompat(target,

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -931,7 +931,8 @@ TEST(AxisTest, NumericBinningCompatibility) {
       testEqBinnedToNonGrowable(makeEqBinnedIrregular, makeEqBinnedIrregular);
       testEqBinnedToIrregular(makeEqBinnedIrregular);
       // NOTE: There are Irr<-Irr specific scenarios, but I did not find one
-      //       which is _qualitatively_ different from the Irr<->EqBinned ones
+      //       which is _qualitatively_ different from the Irr<->EqBinned ones.
+      //       Please add some here as needed.
     }
   }
 

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -478,48 +478,48 @@ TEST(AxisTest, Labels) {
       using LabelsCompatibility = RAxisBase::LabeledBinningCompatibility;
       const int uncommittedTargetLabels =
         (expected_labels.size() - caxis.GetNBinsNoOver());
-      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(expected_labels)),
+      EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(expected_labels)),
                 LabelsCompatibility(false,
                                     uncommittedTargetLabels > 0,
                                     false,
                                     false));
       const std::vector<std::string_view> missing_last_label(
         expected_labels.cbegin(), expected_labels.cend() - 1);
-      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(missing_last_label)),
+      EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(missing_last_label)),
                 LabelsCompatibility(false,
                                     uncommittedTargetLabels > 1,
                                     false,
                                     uncommittedTargetLabels == 0));
       auto one_extra_label = expected_labels;
       one_extra_label.push_back("I AM ROOT");
-      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(one_extra_label)),
+      EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(one_extra_label)),
                 LabelsCompatibility(true,
                                     true,
                                     false,
                                     false));
       auto swapped_labels = expected_labels;
       std::swap(swapped_labels[0], swapped_labels[expected_labels.size()-1]);
-      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
+      EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(swapped_labels)),
                 LabelsCompatibility(false,
                                     uncommittedTargetLabels > 0,
                                     true,
                                     false));
       auto changed_one_label = expected_labels;
       changed_one_label[0] = "I AM ROOT";
-      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(changed_one_label)),
+      EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(changed_one_label)),
                 LabelsCompatibility(true,
                                     true,
                                     true,
                                     true));
       auto removed_first = expected_labels;
       removed_first.erase(removed_first.cbegin());
-      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(removed_first)),
+      EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(removed_first)),
                 LabelsCompatibility(false,
                                     uncommittedTargetLabels > 0,
                                     true,
                                     true));
       swapped_labels.push_back("I AM ROOT");
-      EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
+      EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(swapped_labels)),
                 LabelsCompatibility(true,
                                     true,
                                     true,

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -680,7 +680,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
 
   {
     SCOPED_TRACE("Target axis is equidistant");
-    const RAxisEquidistant targetEq(4, 1.2, 3.2);  // Bin width: 0.5
+    const RAxisEquidistant target(4, 1.2, 3.2);  // Bin width: 0.5
 
     // Deduplicated test for fixed-sized and growable equidistant sources
     auto testEqOrGrowSource = [&](const auto& makeSource)
@@ -688,7 +688,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
       bool fixedSource = !(makeSource(4, 1.2, 3.2).CanGrow());
       {
         SCOPED_TRACE("Source axis has the same binning");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            makeSource(4, 1.2, 3.2),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
@@ -696,44 +696,44 @@ TEST(AxisTest, NumericBinningCompatibility) {
       }
       {
         SCOPED_TRACE("Source axis has one more bin on the left");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            makeSource(5, 0.7, 3.2),
                            CompatFlags::kMergingIsLossy);
       }
       {
         SCOPED_TRACE("Source axis has one more bin on the right");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            makeSource(5, 1.2, 3.7),
                            CompatFlags::kMergingIsLossy);
       }
       {
         SCOPED_TRACE("Source axis has one less bin on the left");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            makeSource(3, 1.7, 3.2),
                            fixedSource * CompatFlags::kNeedEmptyUnderflow);
       }
       {
         SCOPED_TRACE("Source axis has one less bin on the right");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            makeSource(3, 1.2, 2.7),
                            CompatFlags::kTrivialRegularBinMapping
                            + fixedSource * CompatFlags::kNeedEmptyOverflow);
       }
       {
         SCOPED_TRACE("Source axis has larger bins");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            makeSource(2, 1.2, 3.2),
                            CompatFlags::kRegularBinAliasing);
       }
       {
         SCOPED_TRACE("Source axis has smaller bins");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            makeSource(8, 1.2, 3.2),
                            CompatFlags::kMergingIsLossy);
       }
       {
         SCOPED_TRACE("Source axis is shifted forward");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            makeSource(4, 1.3, 3.3),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
@@ -744,7 +744,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
       }
       {
         SCOPED_TRACE("Source axis is shifted backward");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            makeSource(4, 1.1, 3.1),
                            CompatFlags::kMergingIsLossy
                            + CompatFlags::kRegularBinAliasing
@@ -764,7 +764,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
       SCOPED_TRACE("Source axis is irregular");
      {
         SCOPED_TRACE("Source axis has the same binning");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
@@ -772,32 +772,32 @@ TEST(AxisTest, NumericBinningCompatibility) {
       }
       {
         SCOPED_TRACE("Source axis has one more bin on the left");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({0.42, 1.2, 1.7, 2.2, 2.7, 3.2}),
                            CompatFlags::kMergingIsLossy);
       }
       {
         SCOPED_TRACE("Source axis has one more bin on the right");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 4.9}),
                            CompatFlags::kMergingIsLossy);
       }
       {
         SCOPED_TRACE("Source axis has one less bin on the left");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.7, 2.2, 2.7, 3.2}),
                            CompatFlags::kNeedEmptyUnderflow);
       }
       {
         SCOPED_TRACE("Source axis has one less bin on the right");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.2, 1.7, 2.2, 2.7}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kNeedEmptyOverflow);
       }
       {
         SCOPED_TRACE("First source border is shifted forward");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.3, 1.7, 2.2, 2.7, 3.2}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
@@ -807,14 +807,14 @@ TEST(AxisTest, NumericBinningCompatibility) {
       }
       {
         SCOPED_TRACE("First source border is shifted backward");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.1, 1.7, 2.2, 2.7, 3.2}),
                            CompatFlags::kMergingIsLossy
                            + CompatFlags::kRegularBinAliasing);
       }
       {
         SCOPED_TRACE("Second source border is shifted forward");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.2, 1.8, 2.2, 2.7, 3.2}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
@@ -824,14 +824,14 @@ TEST(AxisTest, NumericBinningCompatibility) {
       }
       {
         SCOPED_TRACE("Second source border is shifted backward");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.2, 1.6, 2.2, 2.7, 3.2}),
                            CompatFlags::kMergingIsLossy
                            + CompatFlags::kRegularBinAliasing);
       }
       {
         SCOPED_TRACE("Last source border is shifted forward");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.3}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
@@ -841,7 +841,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
       }
       {
         SCOPED_TRACE("Last source border is shifted backward");
-        checkNumericCompat(targetEq,
+        checkNumericCompat(target,
                            RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.1}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -476,31 +476,33 @@ TEST(AxisTest, Labels) {
 
       using LabelsCmpResult = RAxisBase::LabeledBinningCmpResult;
 
+      const bool sameLabelsMeansSameBins =
+        (caxis.GetNBinsNoOver() == static_cast<int>(expected_labels.size()));
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(expected_labels)),
-                LabelsCmpResult(false, false));
+                LabelsCmpResult(false, false, sameLabelsMeansSameBins));
       const std::vector<std::string_view> missing_last_label(
         expected_labels.cbegin(), expected_labels.cend() - 1);
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(missing_last_label)),
-                LabelsCmpResult(false, false));
+                LabelsCmpResult(false, false, false));
       auto one_extra_label = expected_labels;
       one_extra_label.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(one_extra_label)),
-                LabelsCmpResult(true, false));
+                LabelsCmpResult(true, false, false));
       auto swapped_labels = expected_labels;
       std::swap(swapped_labels[0], swapped_labels[expected_labels.size()-1]);
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
-                LabelsCmpResult(false, true));
+                LabelsCmpResult(false, true, false));
       auto changed_one_label = expected_labels;
       changed_one_label[0] = "I AM ROOT";
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(changed_one_label)),
-                LabelsCmpResult(true, false));
+                LabelsCmpResult(true, false, false));
       auto removed_first = expected_labels;
       removed_first.erase(removed_first.cbegin());
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(removed_first)),
-                LabelsCmpResult(false, true));
+                LabelsCmpResult(false, true, false));
       swapped_labels.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
-                LabelsCmpResult(true, true));
+                LabelsCmpResult(true, true, false));
 
       RAxisConfig cfg(caxis);
       EXPECT_EQ(cfg.GetTitle(), title);

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -475,55 +475,55 @@ TEST(AxisTest, Labels) {
       }
 
       // Compare the RAxisLabels with various variations of itself
-      using LabelsCmpResult = RAxisBase::LabeledBinningCmpResult;
+      using LabelsCompatibility = RAxisBase::LabeledBinningCompatibility;
       const int uncommittedTargetLabels =
         (expected_labels.size() - caxis.GetNBinsNoOver());
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(expected_labels)),
-                LabelsCmpResult(false,
-                                uncommittedTargetLabels > 0,
-                                false,
-                                false));
+                LabelsCompatibility(false,
+                                    uncommittedTargetLabels > 0,
+                                    false,
+                                    false));
       const std::vector<std::string_view> missing_last_label(
         expected_labels.cbegin(), expected_labels.cend() - 1);
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(missing_last_label)),
-                LabelsCmpResult(false,
-                                uncommittedTargetLabels > 1,
-                                false,
-                                uncommittedTargetLabels == 0));
+                LabelsCompatibility(false,
+                                    uncommittedTargetLabels > 1,
+                                    false,
+                                    uncommittedTargetLabels == 0));
       auto one_extra_label = expected_labels;
       one_extra_label.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(one_extra_label)),
-                LabelsCmpResult(true,
-                                true,
-                                false,
-                                false));
+                LabelsCompatibility(true,
+                                    true,
+                                    false,
+                                    false));
       auto swapped_labels = expected_labels;
       std::swap(swapped_labels[0], swapped_labels[expected_labels.size()-1]);
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
-                LabelsCmpResult(false,
-                                uncommittedTargetLabels > 0,
-                                true,
-                                false));
+                LabelsCompatibility(false,
+                                    uncommittedTargetLabels > 0,
+                                    true,
+                                    false));
       auto changed_one_label = expected_labels;
       changed_one_label[0] = "I AM ROOT";
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(changed_one_label)),
-                LabelsCmpResult(true,
-                                true,
-                                true,
-                                true));
+                LabelsCompatibility(true,
+                                    true,
+                                    true,
+                                    true));
       auto removed_first = expected_labels;
       removed_first.erase(removed_first.cbegin());
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(removed_first)),
-                LabelsCmpResult(false,
-                                uncommittedTargetLabels > 0,
-                                true,
-                                true));
+                LabelsCompatibility(false,
+                                    uncommittedTargetLabels > 0,
+                                    true,
+                                    true));
       swapped_labels.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
-                LabelsCmpResult(true,
-                                true,
-                                true,
-                                false));
+                LabelsCompatibility(true,
+                                    true,
+                                    true,
+                                    false));
 
       RAxisConfig cfg(caxis);
       EXPECT_EQ(cfg.GetTitle(), title);

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -662,8 +662,8 @@ TEST(AxisTest, NumericBinningCompatibility) {
   using CompatFlags = NumericCompat::Flags;
 
   // Check numerix axis binning compatibility with minimal boilerplate
-  const auto checkNumericCompat = [](const auto& target,
-                                     const auto& source,
+  const auto checkNumericCompat = [](const RAxisBase& target,
+                                     const RAxisBase& source,
                                      int expectedCompatFlags) {
       const NumericCompat expected{CompatFlags(expectedCompatFlags)};
       EXPECT_EQ(target.CheckBinningCompat(source), BinningCompat(expected));

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -474,31 +474,33 @@ TEST(AxisTest, Labels) {
         EXPECT_EQ(caxis.GetBinLabels()[i], expected_labels[i]);
       }
 
+      using LabelsCmpResult = RAxisBase::LabeledBinningCmpResult;
+
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(expected_labels)),
-                RAxisLabels::kLabelsCmpSame);
+                LabelsCmpResult(false, false));
       const std::vector<std::string_view> missing_last_label(
         expected_labels.cbegin(), expected_labels.cend() - 1);
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(missing_last_label)),
-                RAxisLabels::kLabelsCmpSubset);
+                LabelsCmpResult(false, false));
       auto one_extra_label = expected_labels;
       one_extra_label.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(one_extra_label)),
-                RAxisLabels::kLabelsCmpSuperset);
+                LabelsCmpResult(true, false));
       auto swapped_labels = expected_labels;
       std::swap(swapped_labels[0], swapped_labels[expected_labels.size()-1]);
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
-                RAxisLabels::kLabelsCmpDisordered);
+                LabelsCmpResult(false, true));
       auto changed_one_label = expected_labels;
       changed_one_label[0] = "I AM ROOT";
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(changed_one_label)),
-                RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpSuperset);
+                LabelsCmpResult(true, false));
       auto removed_first = expected_labels;
       removed_first.erase(removed_first.cbegin());
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(removed_first)),
-                RAxisLabels::kLabelsCmpSubset | RAxisLabels::kLabelsCmpDisordered);
+                LabelsCmpResult(false, true));
       swapped_labels.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CompareBinLabels(RAxisLabels(swapped_labels)),
-                RAxisLabels::kLabelsCmpSuperset | RAxisLabels::kLabelsCmpDisordered);
+                LabelsCmpResult(true, true));
 
       RAxisConfig cfg(caxis);
       EXPECT_EQ(cfg.GetTitle(), title);

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -903,6 +903,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
     // to deduplicate it without sacrificing code quality yet...
     //
     const auto testEqBinnedToIrregular = [&](const auto& makeSource) {
+      testEqBinnedToEqBinned(makeEqBinnedIrregular, makeSource);
       const auto source = makeSource(6, 1.2, 4.2);
       const bool fixedSource = !source.CanGrow();
       {
@@ -975,17 +976,14 @@ TEST(AxisTest, NumericBinningCompatibility) {
 
     {
       SCOPED_TRACE("Source axis is equidistant");
-      testEqBinnedToNonGrowable(makeEqBinnedIrregular, makeEquidistant);
       testEqBinnedToIrregular(makeEquidistant);
     }
     {
       SCOPED_TRACE("Source axis is growable");
-      testEqBinnedToNonGrowable(makeEqBinnedIrregular, makeGrowable);
       testEqBinnedToIrregular(makeGrowable);
     }
     {
       SCOPED_TRACE("Source axis is irregular");
-      testEqBinnedToNonGrowable(makeEqBinnedIrregular, makeEqBinnedIrregular);
       testEqBinnedToIrregular(makeEqBinnedIrregular);
       // NOTE: There are Irr<->Irr specific scenarios, but I did not find one
       //       which is _qualitatively_ different from the Irr<->EqBinned ones.

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -680,16 +680,16 @@ TEST(AxisTest, NumericBinningCompatibility) {
 
   {
     SCOPED_TRACE("Target axis is equidistant");
-    const RAxisEquidistant target(4, 1.2, 3.2);  // Bin width: 0.5
+    const RAxisEquidistant target(6, 1.2, 4.2);  // Bin width: 0.5
 
     // Deduplicated test for fixed-sized and growable equidistant sources
     const auto testEqOrGrowSource = [&](const auto& makeSource)
     {
-      const bool fixedSource = !(makeSource(4, 1.2, 3.2).CanGrow());
+      const bool fixedSource = !(makeSource(6, 1.2, 4.2).CanGrow());
       {
         SCOPED_TRACE("Source axis has the same binning");
         checkNumericCompat(target,
-                           makeSource(4, 1.2, 3.2),
+                           makeSource(6, 1.2, 4.2),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
                            + fixedSource * CompatFlags::kFullBinBijection);
@@ -697,46 +697,58 @@ TEST(AxisTest, NumericBinningCompatibility) {
       {
         SCOPED_TRACE("Source axis has one more bin on the left");
         checkNumericCompat(target,
-                           makeSource(5, 0.7, 3.2),
+                           makeSource(7, 0.7, 4.2),
                            CompatFlags::kMergingIsLossy);
       }
       {
         SCOPED_TRACE("Source axis has one more bin on the right");
         checkNumericCompat(target,
-                           makeSource(5, 1.2, 3.7),
+                           makeSource(7, 1.2, 4.7),
                            CompatFlags::kMergingIsLossy);
       }
       {
         SCOPED_TRACE("Source axis has one less bin on the left");
         checkNumericCompat(target,
-                           makeSource(3, 1.7, 3.2),
+                           makeSource(5, 1.7, 4.2),
                            fixedSource * CompatFlags::kNeedEmptyUnderflow);
       }
       {
         SCOPED_TRACE("Source axis has one less bin on the right");
         checkNumericCompat(target,
-                           makeSource(3, 1.2, 2.7),
+                           makeSource(5, 1.2, 3.7),
                            CompatFlags::kTrivialRegularBinMapping
                            + fixedSource * CompatFlags::kNeedEmptyOverflow);
       }
       {
         SCOPED_TRACE("Source axis bins are larger by an integer factor");
         checkNumericCompat(target,
-                           makeSource(2, 1.2, 3.2),
+                           makeSource(3, 1.2, 4.2),
                            CompatFlags::kRegularBinAliasing);
       }
-      // FIXME: Explore non-integer factors too
+      {
+        SCOPED_TRACE("Source axis bins are larger by a non-integer factor");
+        checkNumericCompat(target,
+                           makeSource(4, 1.2, 4.2),
+                           CompatFlags::kMergingIsLossy
+                           + CompatFlags::kRegularBinAliasing);
+      }
       {
         SCOPED_TRACE("Source axis bins are smaller by an integer factor");
         checkNumericCompat(target,
-                           makeSource(8, 1.2, 3.2),
+                           makeSource(12, 1.2, 4.2),
                            CompatFlags::kMergingIsLossy);
       }
-      // FIXME: Explore non-integer factors too
+      {
+        SCOPED_TRACE("Source axis bins are smaller by a non-integer factor");
+        checkNumericCompat(target,
+                           makeSource(11, 1.2, 4.2),
+                           CompatFlags::kMergingIsLossy
+                           + CompatFlags::kRegularBinAliasing);
+      }
       {
         SCOPED_TRACE("Source axis is shifted forward");
         checkNumericCompat(target,
-                           makeSource(4, 1.3, 3.3),
+                           makeSource(6, 1.3, 4.3),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
                            + fixedSource * CompatFlags::kFullBinBijection
@@ -747,7 +759,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
       {
         SCOPED_TRACE("Source axis is shifted backward");
         checkNumericCompat(target,
-                           makeSource(4, 1.1, 3.1),
+                           makeSource(6, 1.1, 4.1),
                            CompatFlags::kMergingIsLossy
                            + CompatFlags::kRegularBinAliasing
                            + fixedSource * CompatFlags::kNeedEmptyOverflow);
@@ -767,7 +779,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
      {
         SCOPED_TRACE("Source axis has the same binning");
         checkNumericCompat(target,
-                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2}),
+                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
                            + CompatFlags::kFullBinBijection);
@@ -775,32 +787,32 @@ TEST(AxisTest, NumericBinningCompatibility) {
       {
         SCOPED_TRACE("Source axis has one more bin on the left");
         checkNumericCompat(target,
-                           RAxisIrregular({0.42, 1.2, 1.7, 2.2, 2.7, 3.2}),
+                           RAxisIrregular({0.4, 1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
                            CompatFlags::kMergingIsLossy);
       }
       {
         SCOPED_TRACE("Source axis has one more bin on the right");
         checkNumericCompat(target,
-                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 4.9}),
+                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2, 5.9}),
                            CompatFlags::kMergingIsLossy);
       }
       {
         SCOPED_TRACE("Source axis has one less bin on the left");
         checkNumericCompat(target,
-                           RAxisIrregular({1.7, 2.2, 2.7, 3.2}),
+                           RAxisIrregular({1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
                            CompatFlags::kNeedEmptyUnderflow);
       }
       {
         SCOPED_TRACE("Source axis has one less bin on the right");
         checkNumericCompat(target,
-                           RAxisIrregular({1.2, 1.7, 2.2, 2.7}),
+                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 3.7}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kNeedEmptyOverflow);
       }
       {
         SCOPED_TRACE("First source border is shifted forward");
         checkNumericCompat(target,
-                           RAxisIrregular({1.3, 1.7, 2.2, 2.7, 3.2}),
+                           RAxisIrregular({1.3, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
                            + CompatFlags::kFullBinBijection
@@ -810,14 +822,14 @@ TEST(AxisTest, NumericBinningCompatibility) {
       {
         SCOPED_TRACE("First source border is shifted backward");
         checkNumericCompat(target,
-                           RAxisIrregular({1.1, 1.7, 2.2, 2.7, 3.2}),
+                           RAxisIrregular({1.1, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
                            CompatFlags::kMergingIsLossy
                            + CompatFlags::kRegularBinAliasing);
       }
       {
         SCOPED_TRACE("Second source border is shifted forward");
         checkNumericCompat(target,
-                           RAxisIrregular({1.2, 1.8, 2.2, 2.7, 3.2}),
+                           RAxisIrregular({1.2, 1.8, 2.2, 2.7, 3.2, 3.7, 4.2}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
                            + CompatFlags::kFullBinBijection
@@ -827,14 +839,14 @@ TEST(AxisTest, NumericBinningCompatibility) {
       {
         SCOPED_TRACE("Second source border is shifted backward");
         checkNumericCompat(target,
-                           RAxisIrregular({1.2, 1.6, 2.2, 2.7, 3.2}),
+                           RAxisIrregular({1.2, 1.6, 2.2, 2.7, 3.2, 3.7, 4.2}),
                            CompatFlags::kMergingIsLossy
                            + CompatFlags::kRegularBinAliasing);
       }
       {
         SCOPED_TRACE("Last source border is shifted forward");
         checkNumericCompat(target,
-                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.3}),
+                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.3}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
                            + CompatFlags::kFullBinBijection
@@ -844,7 +856,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
       {
         SCOPED_TRACE("Last source border is shifted backward");
         checkNumericCompat(target,
-                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.1}),
+                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.1}),
                            CompatFlags::kTrivialRegularBinMapping
                            + CompatFlags::kRegularBinBijection
                            + CompatFlags::kFullBinBijection

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -662,19 +662,19 @@ TEST(AxisTest, NumericBinningCompatibility) {
   using CompatFlags = NumericCompat::Flags;
 
   // Check numerix axis binning compatibility with minimal boilerplate
-  auto checkNumericCompat = [](const auto& target,
-                               const auto& source,
-                               int expectedCompatFlags) {
+  const auto checkNumericCompat = [](const auto& target,
+                                     const auto& source,
+                                     int expectedCompatFlags) {
       const NumericCompat expected{CompatFlags(expectedCompatFlags)};
       EXPECT_EQ(target.CheckBinningCompat(source), BinningCompat(expected));
     };
 
   // Syntaxically lightweight alternative to templates for code which doesn't
   // care whether an equidistant axis is growable or not.
-  auto makeEquidistant = [](int numBins, float min, float max) {
+  const auto makeEquidistant = [](int numBins, float min, float max) {
     return RAxisEquidistant(numBins, min, max);
   };
-  auto makeGrowable = [](int numBins, float min, float max) {
+  const auto makeGrowable = [](int numBins, float min, float max) {
     return RAxisGrow(numBins, min, max);
   };
 
@@ -683,9 +683,9 @@ TEST(AxisTest, NumericBinningCompatibility) {
     const RAxisEquidistant target(4, 1.2, 3.2);  // Bin width: 0.5
 
     // Deduplicated test for fixed-sized and growable equidistant sources
-    auto testEqOrGrowSource = [&](const auto& makeSource)
+    const auto testEqOrGrowSource = [&](const auto& makeSource)
     {
-      bool fixedSource = !(makeSource(4, 1.2, 3.2).CanGrow());
+      const bool fixedSource = !(makeSource(4, 1.2, 3.2).CanGrow());
       {
         SCOPED_TRACE("Source axis has the same binning");
         checkNumericCompat(target,

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -458,7 +458,7 @@ TEST(AxisTest, Irregular) {
 
 // Test that an RAxisLabels has the expected properties
 //
-// This function was extracted from the Labels test to reduce nesting. It
+// This function was extracted from the Labels test to reduce lambda nesting. It
 // assumes that the input axis was constructed as RAxisLabels(expected_title,
 // labels), and received some number of operations that may have inserted new
 // labels from that point, ultimately leading to the expected_labels set.
@@ -800,6 +800,18 @@ TEST(AxisTest, NumericBinningCompatibility) {
       // Extra scenarios enabled by irregular source axis binning
       const RAxisEquidistant target(6, 1.2, 4.2);
       {
+        SCOPED_TRACE("Source axis has an extra inner bin border");
+        checkNumericCompat(target,
+                           RAxisIrregular({1.2, 1.4, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
+                           CompatFlags::kMergingIsLossy);
+      }
+      {
+        SCOPED_TRACE("Source axis has one less inner bin border");
+        checkNumericCompat(target,
+                           RAxisIrregular({1.2, 2.2, 2.7, 3.2, 3.7, 4.2}),
+                           CompatFlags::kRegularBinAliasing);
+      }
+      {
         SCOPED_TRACE("First source border is shifted forward");
         checkNumericCompat(target,
                            RAxisIrregular({1.3, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
@@ -872,6 +884,18 @@ TEST(AxisTest, NumericBinningCompatibility) {
         const auto source = makeSource(6, 1.2, 4.2);
         const bool fixedSource = !source.CanGrow();
         {
+          SCOPED_TRACE("Target axis has an extra inner bin border");
+          checkNumericCompat(RAxisIrregular({1.2, 1.4, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
+                             source,
+                             CompatFlags::kRegularBinAliasing);
+        }
+        {
+          SCOPED_TRACE("Target axis has one less inner bin border");
+          checkNumericCompat(RAxisIrregular({1.2, 2.2, 2.7, 3.2, 3.7, 4.2}),
+                             source,
+                             CompatFlags::kMergingIsLossy);
+        }
+        {
           SCOPED_TRACE("First target border is shifted forward");
           checkNumericCompat(RAxisIrregular({1.3, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
                              source,
@@ -941,7 +965,7 @@ TEST(AxisTest, NumericBinningCompatibility) {
       SCOPED_TRACE("Source axis is irregular");
       testEqBinnedToNonGrowable(makeEqBinnedIrregular, makeEqBinnedIrregular);
       testEqBinnedToIrregular(makeEqBinnedIrregular);
-      // NOTE: There are Irr<-Irr specific scenarios, but I did not find one
+      // NOTE: There are Irr<->Irr specific scenarios, but I did not find one
       //       which is _qualitatively_ different from the Irr<->EqBinned ones.
       //       Please add some here as needed.
     }

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -483,7 +483,8 @@ TEST(AxisTest, Labels) {
                 LabelsCompatibility(
                   CompatFlags(
                     (uncommittedTargetLabels > 0) * CompatFlags::kTargetMustGrow
-                  )
+                  ),
+                  std::vector<std::string_view>{}
                 ));
       const std::vector<std::string_view> missing_last_label(
         expected_labels.cbegin(), expected_labels.cend() - 1);
@@ -492,16 +493,15 @@ TEST(AxisTest, Labels) {
                   CompatFlags(
                     (uncommittedTargetLabels > 1) * CompatFlags::kTargetMustGrow
                     + (uncommittedTargetLabels == 0) * CompatFlags::kExtraTargetBins
-                  )
+                  ),
+                  std::vector<std::string_view>{}
                 ));
       auto one_extra_label = expected_labels;
       one_extra_label.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(one_extra_label)),
                 LabelsCompatibility(
-                  CompatFlags(
-                    CompatFlags::kSourceOnlyLabels
-                    + CompatFlags::kTargetMustGrow
-                  )
+                  CompatFlags(CompatFlags::kTargetMustGrow),
+                  std::vector<std::string_view>{"I AM ROOT"}
                 ));
       auto swapped_labels = expected_labels;
       std::swap(swapped_labels[0], swapped_labels[expected_labels.size()-1]);
@@ -510,18 +510,19 @@ TEST(AxisTest, Labels) {
                   CompatFlags(
                     (uncommittedTargetLabels > 0) * CompatFlags::kTargetMustGrow
                     + CompatFlags::kLabelOrderDiffers
-                  )
+                  ),
+                  std::vector<std::string_view>{}
                 ));
       auto changed_one_label = expected_labels;
       changed_one_label[0] = "I AM ROOT";
       EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(changed_one_label)),
                 LabelsCompatibility(
                   CompatFlags(
-                    CompatFlags::kSourceOnlyLabels
-                    + CompatFlags::kTargetMustGrow
+                    CompatFlags::kTargetMustGrow
                     + CompatFlags::kLabelOrderDiffers
                     + CompatFlags::kExtraTargetBins
-                  )
+                  ),
+                  std::vector<std::string_view>{"I AM ROOT"}
                 ));
       auto removed_first = expected_labels;
       removed_first.erase(removed_first.cbegin());
@@ -531,16 +532,17 @@ TEST(AxisTest, Labels) {
                     (uncommittedTargetLabels > 0) * CompatFlags::kTargetMustGrow
                     + CompatFlags::kLabelOrderDiffers
                     + CompatFlags::kExtraTargetBins
-                  )
+                  ),
+                  std::vector<std::string_view>{}
                 ));
       swapped_labels.push_back("I AM ROOT");
       EXPECT_EQ(caxis.CheckLabeledBinningCompat(RAxisLabels(swapped_labels)),
                 LabelsCompatibility(
                   CompatFlags(
-                    CompatFlags::kSourceOnlyLabels
-                    + CompatFlags::kTargetMustGrow
+                    CompatFlags::kTargetMustGrow
                     + CompatFlags::kLabelOrderDiffers
-                  )
+                  ),
+                  std::vector<std::string_view>{"I AM ROOT"}
                 ));
 
       RAxisConfig cfg(caxis);

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -929,7 +929,8 @@ TEST(AxisTest, NumericBinningCompatibility) {
       SCOPED_TRACE("Source axis is irregular");
       testEqBinnedToNonGrowable(makeEqBinnedIrregular, makeEqBinnedIrregular);
       testEqBinnedToIrregular(makeEqBinnedIrregular);
-      // FIXME: Tests which are specific to the irr<-irr scenario
+      // NOTE: There are Irr<-Irr specific scenarios, but I did not find one
+      //       which is _qualitatively_ different from the Irr<->EqBinned ones
     }
   }
 

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -1158,10 +1158,73 @@ TEST(AxisTest, NumericBinningCompatibility) {
       SCOPED_TRACE("Source axis is irregular");
       testEqBinnedToGrowable(makeEqBinnedIrregular);
       testIrregularToEqBinned(makeGrowable);
-      // TODO: Test adding a new bin of various widths on the left/right side,
-      //       and shifting the left/right bin borders outwards by various
-      //       amounts. For growable axes, 0.2 vs 1 vs 1.2 vs 2 makes a
-      //       difference.
+
+      // Outcomes which are specific to the Grow<-Irr scenario
+      const RAxisGrow target(6, 1.2, 4.2);
+      {
+        SCOPED_TRACE("Creating a left source border at -0.2 bins");
+        checkNumericCompat(target,
+                           RAxisIrregular({1.1, 1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
+                           CompatFlags::kTrivialRegularBinMapping
+                           + CompatFlags::kRegularBinBijection
+                           + CompatFlags::kMergingIsLossy
+                           + CompatFlags::kNeedEmptyUnderflow
+                           + CompatFlags::kNeedEmptyOverflow
+                           + CompatFlags::kTargetMustGrow);
+      }
+      {
+        SCOPED_TRACE("Creating a left source border at -1.2 bin");
+        checkNumericCompat(target,
+                           RAxisIrregular({0.6, 1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
+                           CompatFlags::kMergingIsLossy
+                           + CompatFlags::kRegularBinAliasing
+                           + CompatFlags::kNeedEmptyUnderflow
+                           + CompatFlags::kNeedEmptyOverflow
+                           + CompatFlags::kTargetMustGrow);
+      }
+      {
+        SCOPED_TRACE("Creating a right source border at +0.2 bins");
+        checkNumericCompat(target,
+                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2, 4.3}),
+                           CompatFlags::kTrivialRegularBinMapping
+                           + CompatFlags::kRegularBinBijection
+                           + CompatFlags::kMergingIsLossy
+                           + CompatFlags::kNeedEmptyUnderflow
+                           + CompatFlags::kNeedEmptyOverflow
+                           + CompatFlags::kTargetMustGrow);
+      }
+      {
+        SCOPED_TRACE("Creating a right source border at +1.2 bin");
+        checkNumericCompat(target,
+                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2, 4.8}),
+                           CompatFlags::kTrivialRegularBinMapping
+                           + CompatFlags::kMergingIsLossy
+                           + CompatFlags::kRegularBinAliasing
+                           + CompatFlags::kNeedEmptyUnderflow
+                           + CompatFlags::kNeedEmptyOverflow
+                           + CompatFlags::kTargetMustGrow);
+      }
+      {
+        SCOPED_TRACE("Shifting the left source border by -0.2 bins");
+        checkNumericCompat(target,
+                           RAxisIrregular({1.1, 1.7, 2.2, 2.7, 3.2, 3.7, 4.2}),
+                           CompatFlags::kMergingIsLossy
+                           + CompatFlags::kRegularBinAliasing
+                           + CompatFlags::kNeedEmptyUnderflow
+                           + CompatFlags::kNeedEmptyOverflow
+                           + CompatFlags::kTargetMustGrow);
+      }
+      {
+        SCOPED_TRACE("Shifting the right source border by +0.2 bins");
+        checkNumericCompat(target,
+                           RAxisIrregular({1.2, 1.7, 2.2, 2.7, 3.2, 3.7, 4.3}),
+                           CompatFlags::kTrivialRegularBinMapping
+                           + CompatFlags::kMergingIsLossy
+                           + CompatFlags::kRegularBinAliasing
+                           + CompatFlags::kNeedEmptyUnderflow
+                           + CompatFlags::kNeedEmptyOverflow
+                           + CompatFlags::kTargetMustGrow);
+      }
     }
   }
 }

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -456,143 +456,154 @@ TEST(AxisTest, Irregular) {
   }
 }
 
+// Test that an RAxisLabels has the expected properties
+//
+// This function was extracted from the Labels test to reduce nesting. It
+// assumes that the input axis was constructed as RAxisLabels(expected_title,
+// labels), and received some number of operations that may have inserted new
+// labels from that point, ultimately leading to the expected_labels set.
+//
+void check_labeled_axis(const RAxisLabels& axis,
+                        std::string_view expected_title,
+                        const std::vector<std::string_view>& expected_labels) {
+  // Notice that the RAxisBase configuration is _not_ updated when new
+  // labels are added. This is by design, according to the RAxisLabels docs.
+  // The configuration would be updated on Grow(), but we can't test Grow()
+  // right now since it isn't implemented yet...
+  test_axis_equidistant(axis,
+                        expected_title,
+                        true,
+                        labels.size(),
+                        0.0,
+                        static_cast<double>(labels.size()));
+
+  EXPECT_EQ(axis.GetBinLabels().size(), expected_labels.size());
+  for (size_t i = 0; i < expected_labels.size(); ++i) {
+    EXPECT_EQ(axis.GetBinLabels()[i], expected_labels[i]);
+  }
+
+  // Compare the RAxisLabels with various variations of itself
+  using BinningCompat = RAxisBase::BinningCompatibility;
+  using LabeledCompat = RAxisBase::LabeledBinningCompatibility;
+  using CompatFlags = LabeledCompat::Flags;
+  auto checkLabeledCompat =
+    [&axis](const auto& sourceLabels,
+            int expectedCompatFlags,
+            auto&& expectedExtraSourceLabels) {
+      const RAxisLabels source(sourceLabels);
+      const LabeledCompat expected(CompatFlags(expectedCompatFlags),
+                                   std::move(expectedExtraSourceLabels));
+      EXPECT_EQ(axis.CheckLabeledBinningCompat(source), expected);
+      EXPECT_EQ(axis.CheckBinningCompat(source), BinningCompat(expected));
+    };
+  const int uncommittedTargetLabels =
+    (expected_labels.size() - axis.GetNBinsNoOver());
+  {
+    SCOPED_TRACE("Compare with newly created axis, same labels");
+    checkLabeledCompat(
+      expected_labels,
+      (uncommittedTargetLabels > 0) * CompatFlags::kTargetMustGrow,
+      std::vector<std::string_view>{}
+    );
+  }
+  {
+    const std::vector<std::string_view> missing_last_label(
+      expected_labels.cbegin(), expected_labels.cend() - 1);
+    SCOPED_TRACE("Compare with newly created axis, missing last label");
+    checkLabeledCompat(
+      missing_last_label,
+      (uncommittedTargetLabels > 1) * CompatFlags::kTargetMustGrow
+      + (uncommittedTargetLabels == 0) * CompatFlags::kExtraTargetBins,
+      std::vector<std::string_view>{}
+    );
+  }
+  {
+    auto one_extra_label = expected_labels;
+    one_extra_label.push_back("I AM ROOT");
+    SCOPED_TRACE("Compare with newly created axis, one extra label");
+    checkLabeledCompat(
+      one_extra_label,
+      CompatFlags::kTargetMustGrow,
+      std::vector<std::string_view>{"I AM ROOT"}
+    );
+  }
+  auto swapped_labels = expected_labels;
+  std::swap(swapped_labels[0], swapped_labels[expected_labels.size()-1]);
+  {
+    SCOPED_TRACE("Compare with newly created axis, swapped label");
+    checkLabeledCompat(
+      swapped_labels,
+      (uncommittedTargetLabels > 0) * CompatFlags::kTargetMustGrow
+      + CompatFlags::kLabelOrderDiffers,
+      std::vector<std::string_view>{}
+    );
+  }
+  {
+    auto changed_one_label = expected_labels;
+    changed_one_label[0] = "I AM ROOT";
+    SCOPED_TRACE("Compare with newly created axis, changed one label");
+    checkLabeledCompat(
+      changed_one_label,
+      CompatFlags::kTargetMustGrow
+      + CompatFlags::kLabelOrderDiffers
+      + CompatFlags::kExtraTargetBins,
+      std::vector<std::string_view>{"I AM ROOT"}
+    );
+  }
+  {
+    auto missing_first_label = expected_labels;
+    missing_first_label.erase(missing_first_label.cbegin());
+    SCOPED_TRACE("Compare with newly created axis, missing first label");
+    checkLabeledCompat(
+      missing_first_label,
+      (uncommittedTargetLabels > 0) * CompatFlags::kTargetMustGrow
+      + CompatFlags::kLabelOrderDiffers
+      + CompatFlags::kExtraTargetBins,
+      std::vector<std::string_view>{}
+    );
+  }
+  swapped_labels.push_back("I AM ROOT");
+  {
+    SCOPED_TRACE("Compare with newly created axis, swapped label + one extra");
+    checkLabeledCompat(
+      swapped_labels,
+      CompatFlags::kTargetMustGrow
+      + CompatFlags::kLabelOrderDiffers,
+      std::vector<std::string_view>{"I AM ROOT"}
+    );
+  }
+
+  // RAxisLabels's labeled binning scheme is not considered compatible with
+  // any sort of numerical binning
+  EXPECT_EQ(axis.CheckBinningCompat(RAxisEquidistant(4, 0.1, 2.3)),
+            BinningCompat());
+  EXPECT_EQ(RAxisEquidistant(4, 0.1, 2.3).CheckBinningCompat(axis),
+            BinningCompat());
+  EXPECT_EQ(axis.CheckBinningCompat(RAxisIrregular({1.2, 3.5, 7.9})),
+            BinningCompat());
+  EXPECT_EQ(RAxisIrregular({1.2, 3.5, 7.9}).CheckBinningCompat(axis),
+            BinningCompat());
+  EXPECT_EQ(axis.CheckBinningCompat(RAxisGrow(4, 0.1, 2.3)),
+            BinningCompat());
+  EXPECT_EQ(RAxisGrow(4, 0.1, 2.3).CheckBinningCompat(axis),
+            BinningCompat());
+
+  RAxisConfig cfg(axis);
+  EXPECT_EQ(cfg.GetTitle(), expected_title);
+  EXPECT_EQ(cfg.GetNBinsNoOver(), static_cast<int>(expected_labels.size()));
+  EXPECT_EQ(cfg.GetKind(), RAxisConfig::kLabels);
+  EXPECT_EQ(cfg.GetBinBorders().size(), 0u);
+  EXPECT_EQ(cfg.GetBinLabels().size(), expected_labels.size());
+  for (size_t i = 0; i < expected_labels.size(); ++i) {
+    EXPECT_EQ(cfg.GetBinLabels()[i], expected_labels[i]);
+  }
+}
+
 TEST(AxisTest, Labels) {
   auto test = [](RAxisLabels& axis, std::string_view title) {
-    // Checks which only require a const RAxisLabels&, can also be used to
-    // assess state invariance after calling mutator methods which shouldn't
-    // have mutated anything _else_ than their intended target.
-    auto const_tests = [&title](const RAxisLabels& caxis,
-                                const auto& expected_labels) {
-      // Notice that the RAxisBase configuration is _not_ updated when new
-      // labels are added. This is by design, according to the RAxisLabels docs.
-      // The configuration would be updated on Grow(), but we can't test Grow()
-      // right now since it isn't implemented yet...
-      test_axis_equidistant(caxis, title, true, 5, 0.0, 5.0);
-
-      EXPECT_EQ(caxis.GetBinLabels().size(), expected_labels.size());
-      for (size_t i = 0; i < expected_labels.size(); ++i) {
-        EXPECT_EQ(caxis.GetBinLabels()[i], expected_labels[i]);
-      }
-
-      // Compare the RAxisLabels with various variations of itself
-      using BinningCompat = RAxisBase::BinningCompatibility;
-      using LabeledCompat = RAxisBase::LabeledBinningCompatibility;
-      using CompatFlags = LabeledCompat::Flags;
-      auto checkLabeledCompat =
-        [&caxis](const auto& sourceLabels,
-                 int expectedCompatFlags,
-                 auto&& expectedExtraSourceLabels) {
-          const RAxisLabels source(sourceLabels);
-          const LabeledCompat expected(CompatFlags(expectedCompatFlags),
-                                       std::move(expectedExtraSourceLabels));
-          EXPECT_EQ(caxis.CheckLabeledBinningCompat(source), expected);
-          EXPECT_EQ(caxis.CheckBinningCompat(source), BinningCompat(expected));
-        };
-      const int uncommittedTargetLabels =
-        (expected_labels.size() - caxis.GetNBinsNoOver());
-      {
-        SCOPED_TRACE("Compare with newly created axis, same labels");
-        checkLabeledCompat(
-          expected_labels,
-          (uncommittedTargetLabels > 0) * CompatFlags::kTargetMustGrow,
-          std::vector<std::string_view>{}
-        );
-      }
-      {
-        const std::vector<std::string_view> missing_last_label(
-          expected_labels.cbegin(), expected_labels.cend() - 1);
-        SCOPED_TRACE("Compare with newly created axis, missing last label");
-        checkLabeledCompat(
-          missing_last_label,
-          (uncommittedTargetLabels > 1) * CompatFlags::kTargetMustGrow
-          + (uncommittedTargetLabels == 0) * CompatFlags::kExtraTargetBins,
-          std::vector<std::string_view>{}
-        );
-      }
-      {
-        auto one_extra_label = expected_labels;
-        one_extra_label.push_back("I AM ROOT");
-        SCOPED_TRACE("Compare with newly created axis, one extra label");
-        checkLabeledCompat(
-          one_extra_label,
-          CompatFlags::kTargetMustGrow,
-          std::vector<std::string_view>{"I AM ROOT"}
-        );
-      }
-      auto swapped_labels = expected_labels;
-      std::swap(swapped_labels[0], swapped_labels[expected_labels.size()-1]);
-      {
-        SCOPED_TRACE("Compare with newly created axis, swapped label");
-        checkLabeledCompat(
-          swapped_labels,
-          (uncommittedTargetLabels > 0) * CompatFlags::kTargetMustGrow
-          + CompatFlags::kLabelOrderDiffers,
-          std::vector<std::string_view>{}
-        );
-      }
-      {
-        auto changed_one_label = expected_labels;
-        changed_one_label[0] = "I AM ROOT";
-        SCOPED_TRACE("Compare with newly created axis, changed one label");
-        checkLabeledCompat(
-          changed_one_label,
-          CompatFlags::kTargetMustGrow
-          + CompatFlags::kLabelOrderDiffers
-          + CompatFlags::kExtraTargetBins,
-          std::vector<std::string_view>{"I AM ROOT"}
-        );
-      }
-      {
-        auto missing_first_label = expected_labels;
-        missing_first_label.erase(missing_first_label.cbegin());
-        SCOPED_TRACE("Compare with newly created axis, missing first label");
-        checkLabeledCompat(
-          missing_first_label,
-          (uncommittedTargetLabels > 0) * CompatFlags::kTargetMustGrow
-          + CompatFlags::kLabelOrderDiffers
-          + CompatFlags::kExtraTargetBins,
-          std::vector<std::string_view>{}
-        );
-      }
-      swapped_labels.push_back("I AM ROOT");
-      {
-        SCOPED_TRACE("Compare with newly created axis, swapped label + one extra");
-        checkLabeledCompat(
-          swapped_labels,
-          CompatFlags::kTargetMustGrow
-          + CompatFlags::kLabelOrderDiffers,
-          std::vector<std::string_view>{"I AM ROOT"}
-        );
-      }
-
-      // RAxisLabels's labeled binning scheme is not considered compatible with
-      // any sort of numerical binning
-      EXPECT_EQ(caxis.CheckBinningCompat(RAxisEquidistant(4, 0.1, 2.3)),
-                BinningCompat());
-      EXPECT_EQ(RAxisEquidistant(4, 0.1, 2.3).CheckBinningCompat(caxis),
-                BinningCompat());
-      EXPECT_EQ(caxis.CheckBinningCompat(RAxisIrregular({1.2, 3.5, 7.9})),
-                BinningCompat());
-      EXPECT_EQ(RAxisIrregular({1.2, 3.5, 7.9}).CheckBinningCompat(caxis),
-                BinningCompat());
-      EXPECT_EQ(caxis.CheckBinningCompat(RAxisGrow(4, 0.1, 2.3)),
-                BinningCompat());
-      EXPECT_EQ(RAxisGrow(4, 0.1, 2.3).CheckBinningCompat(caxis),
-                BinningCompat());
-
-      RAxisConfig cfg(caxis);
-      EXPECT_EQ(cfg.GetTitle(), title);
-      EXPECT_EQ(cfg.GetNBinsNoOver(), static_cast<int>(expected_labels.size()));
-      EXPECT_EQ(cfg.GetKind(), RAxisConfig::kLabels);
-      EXPECT_EQ(cfg.GetBinBorders().size(), 0u);
-      EXPECT_EQ(cfg.GetBinLabels().size(), expected_labels.size());
-      for (size_t i = 0; i < expected_labels.size(); ++i) {
-        EXPECT_EQ(cfg.GetBinLabels()[i], expected_labels[i]);
-      }
-    };
     {
       SCOPED_TRACE("Original labels configuration");
-      const_tests(axis, labels);
+      check_labeled_axis(axis, title, labels);
     }
 
     // Bin queries aren't const in general, but should effectively be when
@@ -609,7 +620,7 @@ TEST(AxisTest, Labels) {
     EXPECT_EQ(axis.GetBinCenterByName("klmno"), 4.5);
     {
       SCOPED_TRACE("After querying existing labels");
-      const_tests(axis, labels);
+      check_labeled_axis(axis, title, labels);
     }
 
     // FIXME: Can't test RAxisGrow::Grow() as this method is not implemented.
@@ -622,23 +633,23 @@ TEST(AxisTest, Labels) {
     new_labels.push_back("pq");
     {
       SCOPED_TRACE("After querying a first new label");
-      const_tests(axis, new_labels);
+      check_labeled_axis(axis, title, new_labels);
     }
     EXPECT_EQ(axis.GetBinCenterByName("pq"), 5.5);
     {
       SCOPED_TRACE("After querying the first new label's center");
-      const_tests(axis, new_labels);
+      check_labeled_axis(axis, title, new_labels);
     }
     EXPECT_EQ(axis.GetBinCenterByName("rst"), 6.5);
     new_labels.push_back("rst");
     {
       SCOPED_TRACE("After querying a second new label's center");
-      const_tests(axis, new_labels);
+      check_labeled_axis(axis, title, new_labels);
     }
     EXPECT_EQ(axis.FindBinByName("rst"), 6);
     {
       SCOPED_TRACE("After querying the second new label again");
-      const_tests(axis, new_labels);
+      check_labeled_axis(axis, title, new_labels);
     }
   };
 

--- a/hist/histv7/test/axis.cxx
+++ b/hist/histv7/test/axis.cxx
@@ -561,59 +561,6 @@ TEST(AxisTest, Labels) {
   }
 }
 
-TEST(AxisTest, SameBinning) {
-  using EqAxis = RAxisEquidistant;
-  using GrowAxis = RAxisGrow;
-  using IrrAxis = RAxisIrregular;
-  using LabAxis = RAxisLabels;
-
-  auto test_eq = [](const RAxisBase& base, bool grow) {
-    EXPECT_EQ(base.HasSameBinningAs(EqAxis(4, 1.2, 3.4)), !grow);
-    EXPECT_EQ(base.HasSameBinningAs(EqAxis("RitleEq", 4, 1.2, 3.4)), !grow);
-    EXPECT_EQ(base.HasSameBinningAs(GrowAxis(4, 1.2, 3.4)), grow);
-    EXPECT_EQ(base.HasSameBinningAs(GrowAxis("RitleGrow", 4, 1.2, 3.4)), grow);
-    // NOTE: Whether an IrrAxis with the "same" bin boundaries is considered to
-    //       have the same binning is left unspecified for now.
-    EXPECT_FALSE(base.HasSameBinningAs(EqAxis(6, 1.2, 3.4)));
-    EXPECT_FALSE(base.HasSameBinningAs(EqAxis(4, 1.7, 3.4)));
-    EXPECT_FALSE(base.HasSameBinningAs(EqAxis(4, 1.2, 3.9)));
-    EXPECT_FALSE(base.HasSameBinningAs(IrrAxis({0.1, 2.3, 4.5, 6.7, 8.9})));
-    // FIXME: Workaround for RAxisLabels constructor ambiguity
-    const std::vector<std::string_view> four_labels({"a", "bc", "def", "g"});
-    EXPECT_FALSE(base.HasSameBinningAs(LabAxis(four_labels)));
-  };
-  {
-    SCOPED_TRACE("Equidistant axis");
-    test_eq(EqAxis(4, 1.2, 3.4), false);
-  }
-  {
-    SCOPED_TRACE("Growable axis");
-    test_eq(GrowAxis(4, 1.2, 3.4), true);
-  }
-
-  const IrrAxis irr({1.2, 3.4, 5.6});
-  const RAxisBase& ibase = irr;
-  EXPECT_TRUE(ibase.HasSameBinningAs(IrrAxis({1.2, 3.4, 5.6})));
-  EXPECT_TRUE(ibase.HasSameBinningAs(IrrAxis("RitleIrr", {1.2, 3.4, 5.6})));
-  // NOTE: Whether an EqAxis with the "same" bin boundaries is considered to
-  //       have the same binning is left unspecified for now.
-  EXPECT_FALSE(ibase.HasSameBinningAs(EqAxis(2, 1.2, 3.4)));
-  EXPECT_FALSE(ibase.HasSameBinningAs(GrowAxis(2, 1.2, 3.4)));
-  // FIXME: Workaround for RAxisLabels constructor ambiguity
-  const std::vector<std::string_view> two_labels({"abc", "d"});
-  EXPECT_FALSE(ibase.HasSameBinningAs(LabAxis(two_labels)));
-
-  // FIXME: Workaround for RAxisLabels constructor ambiguity
-  const std::vector<std::string_view> three_labels({"ab", "cde" "f"});
-  const LabAxis lab(three_labels);
-  const RAxisBase& lbase = lab;
-  EXPECT_TRUE(lbase.HasSameBinningAs(LabAxis(three_labels)));
-  EXPECT_TRUE(lbase.HasSameBinningAs(LabAxis("RitleLab", three_labels)));
-  EXPECT_FALSE(lbase.HasSameBinningAs(EqAxis(3, 0., 3.)));
-  EXPECT_FALSE(lbase.HasSameBinningAs(GrowAxis(3, 0., 3.)));
-  EXPECT_FALSE(lbase.HasSameBinningAs(IrrAxis({0., 1., 2., 3.})));
-}
-
 TEST(AxisTest, ReverseBinLimits) {
   {
     RAxisConfig cfg(10, 3.4, 1.2);


### PR DESCRIPTION
This is the current state of my experiment towards enabling finer-grained axis binning comparisons that "axis configuration is exactly the same" or "axis configuration is different".

Once finished, this should enable switching between several histogram merging logics, including...

- The current implementation, which is maximally fast but a bit too limited (it doesn't even allow the target histogram to grow to span the source histogram range if it is able to).
    * Note that said implementation did already gain some superpowers in the current state of this PR, such as ability to merge when axis bin borders are _slightly_ different.
- More permissive implementations, which trade speed for generality.

Here's what should IMO be added before this PR can be considered ready to merge:

- [x] Tests, lots of them. There's some very tricky code in there, even if it got clearer over time...
- [ ] Performance optimizations to reduce the impact of comparing axis binning, including...
    * [ ] Not comparing every axis bin border when the axes are equidistant
    * [ ] Reducing reliance on virtual function calls, especially in loops
    * [ ] Possibly early algorithm exit as soon as complete conclusions are reached (but this will only benefit worst-case scenarios where axis binnings are very different, so...)
- [ ] Demonstration of a more permissive histogram merging algorithm, to cross-check that the current binning comparison info adequately enables writing one as intended.