### PR TITLE
[cling] Flag an error-Transaction as kRolledBack (ROOT-10798):

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -1519,8 +1519,11 @@ namespace cling {
     assert((T.getState() != Transaction::kRolledBack ||
             T.getState() != Transaction::kRolledBackWithErrors) &&
            "Transaction already rolled back.");
-    if (getOptions().ErrorOut)
+    if (getOptions().ErrorOut) {
+      // Tag the transaction as "won't need to be committed" (ROOT-10798).
+      T.setState(Transaction::kRolledBack);
       return;
+    }
 
     if (InterpreterCallbacks* callbacks = getCallbacks())
       callbacks->TransactionRollback(T);


### PR DESCRIPTION
Even for the ErrorOut case the Transaction should be flagged as beyond
kCompleted, to prevent it from being asserted on as "we have transaction
without errors that was not committed" in ~IncrementalParser().