### PR TITLE
Provide include guards for public headers

### DIFF
--- a/core/lz4/inc/ZipLZ4.h
+++ b/core/lz4/inc/ZipLZ4.h
@@ -8,6 +8,9 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#ifndef ROOT_ZipLZ4
+#define ROOT_ZipLZ4
+
 // NOTE: the ROOT compression libraries aren't consistently written in C++; hence the
 // #ifdef's to avoid problems with C code.
 #ifdef __cplusplus
@@ -17,4 +20,6 @@ void R__zipLZ4(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, in
 void R__unzipLZ4(int *srcsize, unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/core/lzma/inc/ZipLZMA.h
+++ b/core/lzma/inc/ZipLZMA.h
@@ -9,6 +9,9 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#ifndef ROOT_ZipLZMA
+#define ROOT_ZipLZMA
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,4 +22,6 @@ void R__unzipLZMA(int *srcsize, unsigned char *src, int *tgtsize, unsigned char 
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/core/newdelete/inc/MemCheck.h
+++ b/core/newdelete/inc/MemCheck.h
@@ -54,6 +54,9 @@
 //
 //****************************************************************************//
 
+#ifndef ROOT_MemCheck
+#define ROOT_MemCheck
+
 #include "TROOT.h"
 
 
@@ -174,3 +177,5 @@ inline TStackInfo *TStackInfo::Next()
    //return (TStackInfo*)((char*)(&this[1])+fSize*sizeof(void*));
    return (TStackInfo*)((char*)(this)+fSize*sizeof(void*)+sizeof(TStackInfo));
 }
+
+#endif

--- a/core/zstd/inc/ZipZSTD.h
+++ b/core/zstd/inc/ZipZSTD.h
@@ -7,6 +7,9 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#ifndef ROOT_ZipZSTD
+#define ROOT_ZipZSTD
+
 // NOTE: the ROOT compression libraries aren't consistently written in C++; hence the
 // #ifdef's to avoid problems with C code.
 #ifdef __cplusplus
@@ -16,4 +19,6 @@ void R__zipZSTD(int cxlevel, int *srcsize, char *src, int *tgtsize, char *tgt, i
 void R__unzipZSTD(int *srcsize, unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/gui/ged/inc/HelpSMText.h
+++ b/gui/ged/inc/HelpSMText.h
@@ -9,6 +9,9 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#ifndef ROOT_HelpSMText
+#define ROOT_HelpSMText
+
 #include "Rtypes.h"
 
 R__EXTERN const char gHelpSMTopLevel[];
@@ -20,3 +23,5 @@ R__EXTERN const char gHelpSMAxis[];
 R__EXTERN const char gHelpSMTitle[];
 R__EXTERN const char gHelpSMStats[];
 R__EXTERN const char gHelpSMPSPDF[];
+
+#endif

--- a/gui/ged/inc/TAttTextEditor.h
+++ b/gui/ged/inc/TAttTextEditor.h
@@ -9,8 +9,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_TGedTextEditor
-#define ROOT_TGedTextEditor
+#ifndef ROOT_TAttTextEditor
+#define ROOT_TAttTextEditor
 
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //

--- a/gui/gui/inc/HelpText.h
+++ b/gui/gui/inc/HelpText.h
@@ -9,6 +9,9 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#ifndef ROOT_HelpText
+#define ROOT_HelpText
+
 #include "Rtypes.h"
 
 R__EXTERN const char gHelpAbout[];
@@ -23,3 +26,5 @@ R__EXTERN const char gHelpCanvas[];
 R__EXTERN const char gHelpObjects[];
 R__EXTERN const char gHelpTextEditor[];
 R__EXTERN const char gHelpRemote[];
+
+#endif

--- a/gui/gui/inc/TGDNDManager.h
+++ b/gui/gui/inc/TGDNDManager.h
@@ -9,8 +9,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_TDNDManager
-#define ROOT_TDNDManager
+#ifndef ROOT_TGDNDManager
+#define ROOT_TGDNDManager
 
 #include "TGFrame.h"
 
@@ -202,5 +202,5 @@ public:
 
 R__EXTERN TGDNDManager *gDNDManager; // global drag and drop manager
 
-#endif  // ROOT_TDNDManager
+#endif  // ROOT_TGDNDManager
 

--- a/gui/gui/inc/TGPasswdDialog.h
+++ b/gui/gui/inc/TGPasswdDialog.h
@@ -9,8 +9,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_TPasswdDialog
-#define ROOT_TPasswdDialog
+#ifndef ROOT_TGPasswdDialog
+#define ROOT_TGPasswdDialog
 
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There are several header files without typical guards:
```
#ifndef ROOT_Something
#define ROOT_Something
...
#endif 
```
Plus adjust defines names in GUI classes