### PR TITLE
[RF] Accelerate finding of data in RooWorkspace.

### DIFF
--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -774,6 +774,10 @@ Bool_t RooWorkspace::import(RooAbsData& inData,
   }
 
   RooLinkedList& dataList = embedded ? _embeddedDataList : _dataList ;
+  if (dataList.GetSize() > 50 && dataList.getHashTableSize() == 0) {
+    // When the workspaces get larger, traversing the linked list becomes a bottleneck:
+    dataList.setHashTableSize(200);
+  }
 
   // Check that no dataset with target name already exists
   if (dsetName && dataList.FindObject(dsetName)) {


### PR DESCRIPTION
Switch on hash-assisted finding workspaces with 50 or more datasets.

Note on the arbitrary 200 elements:
The list will double its size of the initial 200 elements are not enough. 