### PR TITLE
[RCanvas] add interactive moving of RCanvas elements

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
@@ -22,9 +22,10 @@ namespace ROOT {
 namespace Experimental {
 
 class RChangeAttrRequest : public RDrawableRequest {
-   std::vector<std::string> ids;    ///< array of ids
-   std::vector<std::string> names;  ///< array of attribute names
+   std::vector<std::string> ids;                           ///< array of ids
+   std::vector<std::string> names;                         ///< array of attribute names
    std::vector<std::unique_ptr<RAttrMap::Value_t>> values; ///< array of values
+   bool update{true};                                      ///< update canvas at the end
    bool fNeedUpdate{false};       ///<! is canvas update required
    RChangeAttrRequest(const RChangeAttrRequest &) = delete;
    RChangeAttrRequest& operator=(const RChangeAttrRequest &) = delete;

--- a/graf2d/gpadv7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/src/RCanvas.cxx
@@ -252,6 +252,10 @@ void ROOT::Experimental::RCanvas::ResolveSharedPtrs()
 
 std::unique_ptr<ROOT::Experimental::RDrawableReply> ROOT::Experimental::RChangeAttrRequest::Process()
 {
+   // suppress all changes coming from non-main connection
+   if (!GetContext().IsMainConn())
+      return nullptr;
+
    auto canv = const_cast<ROOT::Experimental::RCanvas *>(GetContext().GetCanvas());
    if (!canv) return nullptr;
 
@@ -277,7 +281,7 @@ std::unique_ptr<ROOT::Experimental::RDrawableReply> ROOT::Experimental::RChangeA
       }
    }
 
-   fNeedUpdate = (vers > 0);
+   fNeedUpdate = (vers > 0) && update;
 
    return nullptr; // no need for any reply
 }

--- a/js/changes.md
+++ b/js/changes.md
@@ -4,7 +4,16 @@
 1. Support RX and RY drawing option together with COL of TH2
 2. Add support of #overline, #underline, #strike into TLatex parsing (#196)
 3. Add support of TGeoTessellated shape
-4. Major changes in v7 drawing: RFrame, RPalette, RColor, ...
+4. Major changes in v7 drawing: RFrame, RPalette, RColor, RStatBox, ...
+5. Fix in reading std::map member-wise
+6. Better handling of context menu position
+
+
+## Changes in 5.8.1
+1. Fix - use Math.floor when search for bin label
+2. Fix - renable correct highlight of TGraphErrors
+3. Fix - adjust TH1/TH2/TAxis values to let stream them in ROOT
+4. Fix - adjust TH[1,2,3].Fill() method to update entries count
 
 
 ## Changes in 5.8.0

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 7/05/2020";
+   JSROOT.version = "dev 28/05/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootPainter.hist3d.js
+++ b/js/scripts/JSRootPainter.hist3d.js
@@ -3338,7 +3338,7 @@
                err[ierr+2] = fp.grz(graph.fZ[i] - graph.fEZ[i]);
                err[ierr+3] = x;
                err[ierr+4] = y;
-               err[ierr+5] = fp.grz(graph.fZ[i] + graph.fEZ[i]);;
+               err[ierr+5] = fp.grz(graph.fZ[i] + graph.fEZ[i]);
                ierr+=6;
             }
 

--- a/js/scripts/JSRootPainter.js
+++ b/js/scripts/JSRootPainter.js
@@ -3875,10 +3875,14 @@
          make("sw-resize", "M2," + (height-2) + "h15v5h-20v-20h5Z");
          make("se-resize", "M" + (width-2) + "," + (height-2) + "h-15v5h20v-20h-5Z");
 
-         make("w-resize", "M-3,18h5v" + Math.max(0, height - 2*18) + "h-5Z");
-         make("e-resize", "M" + (width+3) + ",18h-5v" + Math.max(0, height - 2*18) + "h5Z");
-         make("n-resize", "M18,-3v5h" + Math.max(0, width - 2*18) + "v-5Z");
-         make("s-resize", "M18," + (height+3) + "v-5h" + Math.max(0, width - 2*18) + "v5Z");
+         if (!callback.no_change_x) {
+            make("w-resize", "M-3,18h5v" + Math.max(0, height - 2*18) + "h-5Z");
+            make("e-resize", "M" + (width+3) + ",18h-5v" + Math.max(0, height - 2*18) + "h5Z");
+         }
+         if (!callback.no_change_y) {
+            make("n-resize", "M18,-3v5h" + Math.max(0, width - 2*18) + "v-5Z");
+            make("s-resize", "M18," + (height+3) + "v-5h" + Math.max(0, width - 2*18) + "v5Z");
+         }
       }
 
       function complete_drag() {
@@ -3981,8 +3985,10 @@
 
                var handle = drag_rect.property('drag_handle');
 
-               handle.acc_x1 += d3.event.dx;
-               handle.acc_y1 += d3.event.dy;
+               if (!callback.no_change_x)
+                  handle.acc_x1 += d3.event.dx;
+               if (!callback.no_change_y)
+                  handle.acc_y1 += d3.event.dy;
 
                drag_rect.attr("x", Math.min( Math.max(handle.acc_x1, 0), handle.pad_w))
                         .attr("y", Math.min( Math.max(handle.acc_y1, 0), handle.pad_h));
@@ -4042,6 +4048,9 @@
 
             var handle = drag_rect.property('drag_handle'),
                 dx = d3.event.dx, dy = d3.event.dy, elem = d3.select(this);
+
+            if (callback.no_change_x) dx = 0;
+            if (callback.no_change_y) dy = 0;
 
             if (elem.classed('js_nw_resize')) { handle.acc_x1 += dx; handle.acc_y1 += dy; }
             else if (elem.classed('js_ne_resize')) { handle.acc_x2 += dx; handle.acc_y1 += dy; }
@@ -5133,7 +5142,7 @@
                    w = Math.min(rect.width/curr.fsize, 0.5); // at maximum, 0.5 should be used
 
                node.append('svg:tspan').attr('dx', makeem(curr.dx-w)).attr('dy', makeem(curr.dy-0.2)).text(curr.accent);
-               curr.dy = 0.2;; // compensate hat
+               curr.dy = 0.2; // compensate hat
                curr.dx = Math.max(0.2, w-0.2); // extra horizontal gap
                curr.accent = false;
             } else {

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -1908,10 +1908,8 @@
    }
 
    TFramePainter.prototype.ProcessKeyPress = function(evnt) {
-      if (!JSROOT.key_handling) return;
-
       var main = this.select_main();
-      if (main.empty()) return;
+      if (!JSROOT.key_handling || main.empty()) return;
 
       var key = "";
       switch (evnt.keyCode) {


### PR DESCRIPTION
Following objects can be interactively moved now:
`RFrame`, `RHistStatBox`, `RFrameTitle`, RPaletteDrawable`
All position/size changes applied automatically to server side
Introduce moving constrains for `RFrameTitle` and `RPaletteDrawable` - 
they only can be moved/resize in one direction
Main part is in JavaScript code
Can be tested with `tutorials/v7/draw_rh2_colz.cxx` macro