### PR TITLE
Add missing includes in RootShower test v6.22

### DIFF
--- a/test/RootShower/RSAbout.cxx
+++ b/test/RootShower/RSAbout.cxx
@@ -9,6 +9,7 @@
 
 #include <TSystem.h>
 #include <TROOT.h>
+#include <TVirtualX.h>
 #include <TRootHelpDialog.h>
 
 #include "RSAbout.h"

--- a/test/RootShower/RSMsgBox.cxx
+++ b/test/RootShower/RSMsgBox.cxx
@@ -8,6 +8,7 @@
  *************************************************************************/
 
 #include <TSystem.h>
+#include <TVirtualX.h>
 #include <TRootHelpDialog.h>
 
 #include "RSMsgBox.h"

--- a/test/RootShower/RootShower.cxx
+++ b/test/RootShower/RootShower.cxx
@@ -20,6 +20,7 @@
 
 #include <TFile.h>
 #include <TTree.h>
+#include <TBranch.h>
 #include <TFrame.h>
 #include <TH1.h>
 #include <TF1.h>

--- a/test/RootShower/SettingsDlg.cxx
+++ b/test/RootShower/SettingsDlg.cxx
@@ -9,6 +9,7 @@
 
 #include <stdlib.h>
 #include <TGLabel.h>
+#include <TVirtualX.h>
 #include <TRootHelpDialog.h>
 #include <TGMsgBox.h>
 


### PR DESCRIPTION
`TVirtualX.h` was removed from central includes like `TCanvas.h`
`TBranch.h` may be not provided with `TTree.h` if ROOT compiled with `dev` mode