### PR TITLE
We meant fIsAutoParsingSuspended instead of IsAutoLoadingEnabled()

### DIFF
--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -334,7 +334,8 @@ bool TClingCallbacks::LookupObject(const DeclContext* DC, DeclarationName Name) 
    if (fIsLoadingModule)
       return false;
 
-   if (!IsAutoLoadingEnabled() || fIsAutoLoadingRecursively) return false;
+   if (fIsAutoParsingSuspended || fIsAutoLoadingRecursively)
+      return false;
 
    if (findInGlobalModuleIndex(Name, /*loadFirstMatchOnly*/ false))
       return true;


### PR DESCRIPTION
There used to be just one way of resolving an unknown name (eg. MyClass) -- by using the TCling::AutoLoad interface. However, there are two ingredients to resolve a name -- make the name known to the cling and make its library known to the JIT. Historically, these were one function.

Later, we implemented performance optimization on top which divides the two steps in order to avoid excessive library loading. Now we have an auto parse step which is designed to avoid the heavy TCling::Autoload.

The particular callback calls tryAutoParseInternal which is controlled by fIsAutoParsingSuspended.