### PR TITLE
Use std::mutex for gErrorMutex

### DIFF
--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -26,11 +26,13 @@
 //////////////////////////////////////////////////////////////////////////
 
 
+#include <ROOT/RConfig.hxx>
 #include "RtypesCore.h"
 #include <cstdarg>
 
 
 class TVirtualMutex;
+extern TVirtualMutex *gErrorMutex R__DEPRECATED(6,26, "ROOT stopped exporting gErrorMutex.");
 
 const Int_t kUnset    =  -1;
 const Int_t kPrint    =   0;

--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -27,12 +27,13 @@
 
 
 #include <ROOT/RConfig.hxx>
+#include <DllImport.h> // for R__EXTERN
 #include "RtypesCore.h"
 #include <cstdarg>
 
 
 class TVirtualMutex;
-extern TVirtualMutex *gErrorMutex R__DEPRECATED(6,26, "ROOT stopped exporting gErrorMutex.");
+R__EXTERN TVirtualMutex *gErrorMutex R__DEPRECATED(6,26, "ROOT stopped exporting gErrorMutex.");
 
 const Int_t kUnset    =  -1;
 const Int_t kPrint    =   0;

--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -27,7 +27,7 @@
 
 
 #include "RtypesCore.h"
-#include <stdarg.h>
+#include <cstdarg>
 
 
 class TVirtualMutex;
@@ -40,8 +40,6 @@ const Int_t kError    =   3000;
 const Int_t kBreak    =   4000;
 const Int_t kSysError =   5000;
 const Int_t kFatal    =   6000;
-
-R__EXTERN TVirtualMutex *gErrorMutex;
 
 typedef void (*ErrorHandlerFunc_t)(int level, Bool_t abort, const char *location,
               const char *msg);

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -56,12 +56,8 @@ asm(".desc ___crashreporter_info__, 0x10");
 
 static ErrorHandlerFunc_t gErrorHandler = DefaultErrorHandler;
 
-
-/// Mutex for error and error format protection
-static std::mutex &GetErrorMutex()
-{
-   static std::mutex m;
-   return m;
+namespace {
+std::mutex gErrorPrintMutex;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -96,7 +92,7 @@ again:
    va_end(ap);
 
    // Serialize the actual printing.
-   std::lock_guard<std::mutex> guard(GetErrorMutex());
+   std::lock_guard<std::mutex> guard(gErrorPrintMutex);
 
    const char *toprint = buf; // Work around for older platform where we use TThreadTLSWrapper
    fprintf(stderr, "%s", toprint);
@@ -131,7 +127,7 @@ ErrorHandlerFunc_t GetErrorHandler()
 void DefaultErrorHandler(Int_t level, Bool_t abort_bool, const char *location, const char *msg)
 {
    if (gErrorIgnoreLevel == kUnset) {
-      std::lock_guard<std::mutex> guard(GetErrorMutex());
+      std::lock_guard<std::mutex> guard(gErrorPrintMutex);
 
       gErrorIgnoreLevel = 0;
       if (gEnv) {


### PR DESCRIPTION
In the course of reducing dependencies in `TError.[hxx|cxx]`, replace the `TVirtualMutex` type of `gErrorMutex` by `std::mutex`. Note the other changes

- `gErrorMutex` is not exported anymore (@Axel-Naumann this breaks backwards-compatibility _if_ anyone is actually using the symbol... what do you think?)
- `gErrorMutex` is not a pointer anymore but it is a global, though anonymous-namespaced, `std::mutex`; this means init-time construction of a non-PoD type, which might be a problem.  We get around taking the big ROOT lock for initializing the pointer though.
- Slight adjustments to the includes