### PR TITLE
[ntuple] [WIP] NTuple field iterators

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -352,6 +352,9 @@ public:
    NTupleSize_t GetNEntries() const;
    NTupleSize_t GetNElements(DescriptorId_t columnId) const;
 
+   /// Returns the root field of this NTuple. The root field is the parent of all top-level
+   /// data fields.
+   DescriptorId_t GetRootFieldId() const;
    DescriptorId_t FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const;
    /// Searches for a top-level field
    DescriptorId_t FindFieldId(std::string_view fieldName) const;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -414,8 +414,9 @@ public:
    std::unique_ptr<RNTupleModel> GenerateModel() const;
    void PrintInfo(std::ostream &output) const;
 
+   enum class ENTupleMergeable { StructureMismatch, NamesMismatch, Mergeable };
    /// Check whether this NTuple can be merged with another NTuple.
-   bool IsMergeable(const RNTupleDescriptor &other) const;
+   ENTupleMergeable IsMergeable(const RNTupleDescriptor &other) const;
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -413,6 +413,9 @@ public:
    /// Re-create the C++ model from the stored meta-data
    std::unique_ptr<RNTupleModel> GenerateModel() const;
    void PrintInfo(std::ostream &output) const;
+
+   /// Check whether this NTuple can be merged with another NTuple.
+   bool IsMergeable(const RNTupleDescriptor &other) const;
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -317,7 +317,7 @@ public:
          using pointer = DescriptorId_t*;
          using reference = const DescriptorId_t&;
 
-         RIterator() = default;
+         RIterator() = delete;
          RIterator(const RFieldDescriptor& fieldDesc, DescriptorId_t index)
             : fFieldChildren(fieldDesc.GetLinkIds()), fIndex(index) {}
          ~RIterator() = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -369,7 +369,9 @@ public:
    /// Given kNBytesPostscript bytes, extract the header and footer lengths in bytes
    static void LocateMetadata(const void *postscript, std::uint32_t &szHeader, std::uint32_t &szFooter);
 
-   const RFieldDescriptor& GetFieldDescriptor(DescriptorId_t fieldId) const { return fFieldDescriptors.at(fieldId); }
+   const RFieldDescriptor& GetFieldDescriptor(DescriptorId_t fieldId) const {
+       return fFieldDescriptors.at(fieldId);
+   }
    const RColumnDescriptor& GetColumnDescriptor(DescriptorId_t columnId) const {
       return fColumnDescriptors.at(columnId);
    }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -484,6 +484,20 @@ bool ROOT::Experimental::RFieldDescriptor::operator==(const RFieldDescriptor &ot
           fLinkIds == other.fLinkIds;
 }
 
+ROOT::Experimental::RFieldDescriptor::EFieldMergeable
+ROOT::Experimental::RFieldDescriptor::IsMergeable(const RFieldDescriptor& other) const {
+   if (GetStructure() != other.GetStructure()) {
+      return EFieldMergeable::kStructureMismatch;
+   }
+   if (GetFieldName() != other.GetFieldName()) {
+      return EFieldMergeable::kNameMismatch;
+   }
+   if (GetLinkIds().size() != other.GetLinkIds().size()) {
+      return EFieldMergeable::kNChildrenMismatch;
+   }
+   return EFieldMergeable::kMatch;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -710,32 +724,9 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDes
    return model;
 }
 
-ROOT::Experimental::RNTupleDescriptor::ENTupleMergeable
+ROOT::Experimental::RFieldDescriptor::EFieldMergeable
 ROOT::Experimental::RNTupleDescriptor::IsMergeable(const RNTupleDescriptor &other) const {
-   struct MergeCriteria {
-      std::vector<std::string> names = std::vector<std::string>();
-      std::vector<ENTupleStructure> structures = std::vector<ENTupleStructure>();
-   };
-
-   auto getMergeCriteria = [=](const RNTupleDescriptor& ntuple) -> MergeCriteria {
-      MergeCriteria info;
-      for (auto& f: ntuple.GetTopLevelFields()) {
-         info.names.push_back(f.GetFieldName());
-         info.structures.push_back(f.GetStructure());
-      }
-      return info;
-   };
-
-   auto ntuple_info = getMergeCriteria(*this);
-   auto other_ntuple_info = getMergeCriteria(other);
-
-   if (ntuple_info.structures != other_ntuple_info.structures) {
-      return ENTupleMergeable::StructureMismatch;
-   }
-   if (ntuple_info.names != other_ntuple_info.names) {
-      return ENTupleMergeable::NamesMismatch;
-   }
-   return ENTupleMergeable::Mergeable;
+   return GetTopLevelFields().IsMergeable(other.GetTopLevelFields());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -645,6 +645,13 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleDescriptor::GetNElem
    return result;
 }
 
+
+ROOT::Experimental::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::GetRootFieldId() const
+{
+   return FindFieldId("", kInvalidDescriptorId);
+}
+
+
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const
 {
@@ -665,8 +672,7 @@ ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, D
 
 ROOT::Experimental::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName) const
 {
-   auto rootId = FindFieldId("", kInvalidDescriptorId);
-   return FindFieldId(fieldName, rootId);
+   return FindFieldId(fieldName, GetRootFieldId());
 }
 
 
@@ -697,8 +703,7 @@ ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t columnId, NT
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDescriptor::GenerateModel() const
 {
    auto model = std::make_unique<RNTupleModel>();
-   auto rootId = FindFieldId("", kInvalidDescriptorId);
-   const auto &rootDesc = GetFieldDescriptor(rootId);
+   const auto &rootDesc = GetFieldDescriptor(GetRootFieldId());
    for (const auto id : rootDesc.GetLinkIds()) {
       const auto &topDesc = GetFieldDescriptor(id);
       auto field = Detail::RFieldBase::Create(topDesc.GetFieldName(), topDesc.GetTypeName());

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -703,9 +703,7 @@ ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t columnId, NT
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDescriptor::GenerateModel() const
 {
    auto model = std::make_unique<RNTupleModel>();
-   const auto &rootDesc = GetFieldDescriptor(GetRootFieldId());
-   for (const auto id : rootDesc.GetLinkIds()) {
-      const auto &topDesc = GetFieldDescriptor(id);
+   for (const auto& topDesc : GetTopLevelFields()) {
       auto field = Detail::RFieldBase::Create(topDesc.GetFieldName(), topDesc.GetTypeName());
       model->AddField(std::unique_ptr<Detail::RFieldBase>(field));
    }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -721,10 +721,9 @@ ROOT::Experimental::RNTupleDescriptor::IsMergeable(const RNTupleDescriptor &othe
 
    auto getMergeCriteria = [=](const RNTupleDescriptor& ntuple) -> MergeCriteria {
       MergeCriteria info;
-      for (auto f: ntuple.GetTopLevelFields()) {
-         const auto& fd = ntuple.GetFieldDescriptor(f);
-         info.names.push_back(fd.GetFieldName());
-         info.structures.push_back(fd.GetStructure());
+      for (auto& f: ntuple.GetTopLevelFields()) {
+         info.names.push_back(f.GetFieldName());
+         info.structures.push_back(f.GetStructure());
       }
       return info;
    };
@@ -732,7 +731,6 @@ ROOT::Experimental::RNTupleDescriptor::IsMergeable(const RNTupleDescriptor &othe
    auto ntuple_info = getMergeCriteria(*this);
    auto other_ntuple_info = getMergeCriteria(other);
 
-   using ENTupleMergeable = RNTupleDescriptor::ENTupleMergeable;
    if (ntuple_info.structures != other_ntuple_info.structures) {
       return ENTupleMergeable::StructureMismatch;
    }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -712,7 +712,8 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDes
    return model;
 }
 
-bool ROOT::Experimental::RNTupleDescriptor::IsMergeable(const RNTupleDescriptor &other) const {
+ROOT::Experimental::RNTupleDescriptor::ENTupleMergeable
+ROOT::Experimental::RNTupleDescriptor::IsMergeable(const RNTupleDescriptor &other) const {
    struct MergeCriteria {
       std::vector<std::string> names = std::vector<std::string>();
       std::vector<ENTupleStructure> structures = std::vector<ENTupleStructure>();
@@ -731,8 +732,14 @@ bool ROOT::Experimental::RNTupleDescriptor::IsMergeable(const RNTupleDescriptor 
    auto ntuple_info = getMergeCriteria(*this);
    auto other_ntuple_info = getMergeCriteria(other);
 
-   return (ntuple_info.names == other_ntuple_info.names
-      && ntuple_info.structures == other_ntuple_info.structures);
+   using ENTupleMergeable = RNTupleDescriptor::ENTupleMergeable;
+   if (ntuple_info.structures != other_ntuple_info.structures) {
+      return ENTupleMergeable::StructureMismatch;
+   }
+   if (ntuple_info.names != other_ntuple_info.names) {
+      return ENTupleMergeable::NamesMismatch;
+   }
+   return ENTupleMergeable::Mergeable;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -712,6 +712,28 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDes
    return model;
 }
 
+bool ROOT::Experimental::RNTupleDescriptor::IsMergeable(const RNTupleDescriptor &other) const {
+   struct MergeCriteria {
+      std::vector<std::string> names = std::vector<std::string>();
+      std::vector<ENTupleStructure> structures = std::vector<ENTupleStructure>();
+   };
+
+   auto getMergeCriteria = [=](const RNTupleDescriptor& ntuple) -> MergeCriteria {
+      MergeCriteria info;
+      for (auto f: ntuple.GetTopLevelFields()) {
+         const auto& fd = ntuple.GetFieldDescriptor(f);
+         info.names.push_back(fd.GetFieldName());
+         info.structures.push_back(fd.GetStructure());
+      }
+      return info;
+   };
+
+   auto ntuple_info = getMergeCriteria(*this);
+   auto other_ntuple_info = getMergeCriteria(other);
+
+   return (ntuple_info.names == other_ntuple_info.names
+      && ntuple_info.structures == other_ntuple_info.structures);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 
 ROOT_ADD_GTEST(ntuple_basics ntuple_basics.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_descriptor ntuple_descriptor.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+ROOT_ADD_GTEST(ntuple_field_iterator ntuple_field_iterator.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_minifile ntuple_minifile.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_packing ntuple_packing.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -102,7 +102,7 @@ TEST(RNTuple, Descriptor)
    EXPECT_EQ(NTupleSize_t(1100), reference.GetNElements(3));
    EXPECT_EQ(NTupleSize_t(3300), reference.GetNElements(4));
 
-   EXPECT_EQ(DescriptorId_t(0), reference.FindFieldId("", ROOT::Experimental::kInvalidDescriptorId));
+   EXPECT_EQ(DescriptorId_t(0), reference.GetRootFieldId());
    EXPECT_EQ(DescriptorId_t(1), reference.FindFieldId("list", 0));
    EXPECT_EQ(DescriptorId_t(1), reference.FindFieldId("list"));
    EXPECT_EQ(DescriptorId_t(2), reference.FindFieldId("list", 1));

--- a/tree/ntuple/v7/test/ntuple_field_iterator.cxx
+++ b/tree/ntuple/v7/test/ntuple_field_iterator.cxx
@@ -34,4 +34,56 @@ TEST(RNTupleDescriptor, FieldIterator)
           printf("\tsecond level field id: %lu\n", child_field);
        }
     }
+
+    // todo(max) tests
+}
+
+TEST(RNTupleDescriptor, IsMergeable)
+{
+    FileRaii fileGuard("test_field_iterator1.root");
+    FileRaii fileGuard2("test_field_iterator2.root");
+
+    auto model = RNTupleModel::Create();
+    auto floats = model->MakeField<std::vector<float>>("jets");
+    auto bools = model->MakeField<std::vector<bool>>("bools");
+    auto ints = model->MakeField<std::int32_t>("ints");
+
+    auto model2 = std::unique_ptr<RNTupleModel>(model->Clone());
+    auto modelRead = std::unique_ptr<RNTupleModel>(model->Clone());
+    auto modelRead2 = std::unique_ptr<RNTupleModel>(model->Clone());
+
+    {
+        RNTupleWriter ntuple(std::move(model),
+            std::make_unique<RPageSinkFile>("ntuple1", fileGuard.GetPath(), RNTupleWriteOptions()));
+        ntuple.Fill();
+
+        RNTupleWriter ntuple2(std::move(model2),
+            std::make_unique<RPageSinkFile>("ntuple2", fileGuard2.GetPath(), RNTupleWriteOptions()));
+        ntuple2.Fill();
+    }
+
+    // mismatched model
+    auto different_model = RNTupleModel::Create();
+    auto different_model_read = std::unique_ptr<RNTupleModel>(different_model->Clone());
+    auto different_floats = different_model->MakeField<std::vector<float>>("jorts");
+    FileRaii fileGuard3("test_field_iterator3.root");
+    {
+        RNTupleWriter ntuple(std::move(different_model),
+            std::make_unique<RPageSinkFile>("ntuple3", fileGuard3.GetPath(), RNTupleWriteOptions()));
+        ntuple.Fill();
+    }
+
+    RNTupleReader ntuple(std::move(modelRead),
+      std::make_unique<RPageSourceFile>("ntuple1", fileGuard.GetPath(), RNTupleReadOptions()));
+
+    RNTupleReader ntuple_copy(std::move(modelRead2),
+      std::make_unique<RPageSourceFile>("ntuple2", fileGuard2.GetPath(), RNTupleReadOptions()));
+
+    RNTupleReader different_ntuple(std::move(different_model_read),
+      std::make_unique<RPageSourceFile>("ntuple3", fileGuard3.GetPath(), RNTupleReadOptions()));
+
+    // mergeable with itself
+    EXPECT_TRUE(ntuple.GetDescriptor().IsMergeable(ntuple_copy.GetDescriptor()));
+    // not mergeable with a ntuple with different top-level fields
+    EXPECT_FALSE(ntuple.GetDescriptor().IsMergeable(different_ntuple.GetDescriptor()));
 }

--- a/tree/ntuple/v7/test/ntuple_field_iterator.cxx
+++ b/tree/ntuple/v7/test/ntuple_field_iterator.cxx
@@ -1,6 +1,6 @@
 #include "ntuple_test.hxx"
 using RFieldDescriptorRange = ROOT::Experimental::RFieldDescriptorRange;
-using ENTupleMergeable = ROOT::Experimental::RNTupleDescriptor::ENTupleMergeable;
+using EFieldMergeable = ROOT::Experimental::RFieldDescriptor::EFieldMergeable;
 
 TEST(RNTupleDescriptor, FieldIterator)
 {
@@ -84,9 +84,12 @@ TEST(RNTupleDescriptor, IsMergeable)
       std::make_unique<RPageSourceFile>("ntuple3", fileGuard3.GetPath(), RNTupleReadOptions()));
 
     // mergeable with itself
-    EXPECT_TRUE(ENTupleMergeable::Mergeable
-       == ntuple.GetDescriptor().IsMergeable(ntuple_copy.GetDescriptor()));
+    EXPECT_TRUE(EFieldMergeable::kMatch
+            == ntuple.GetDescriptor().IsMergeable(ntuple_copy.GetDescriptor()));
     // not mergeable with a ntuple with different top-level fields
-    EXPECT_TRUE(ENTupleMergeable::StructureMismatch
+    EXPECT_FALSE(EFieldMergeable::kMatch
+       == ntuple.GetDescriptor().IsMergeable(different_ntuple.GetDescriptor()));
+    // 3 child fields vs 1 child field
+    EXPECT_TRUE(EFieldMergeable::kNChildrenMismatch
        == ntuple.GetDescriptor().IsMergeable(different_ntuple.GetDescriptor()));
 }

--- a/tree/ntuple/v7/test/ntuple_field_iterator.cxx
+++ b/tree/ntuple/v7/test/ntuple_field_iterator.cxx
@@ -1,0 +1,37 @@
+#include "ntuple_test.hxx"
+using RFieldDescriptorRange = ROOT::Experimental::RFieldDescriptorRange;
+
+TEST(RNTupleDescriptor, FieldIterator)
+{
+    auto model = RNTupleModel::Create();
+    auto floats = model->MakeField<std::vector<float>>("jets");
+    auto bools = model->MakeField<std::vector<bool>>("bools");
+    auto bool_vec_vec = model->MakeField<std::vector<std::vector<bool>>>("bool_vec_vec");
+    auto ints = model->MakeField<std::int32_t>("ints");
+
+    FileRaii fileGuard("test_field_iterator.root");
+    auto modelRead = std::unique_ptr<RNTupleModel>(model->Clone());
+    {
+        RNTupleWriter ntuple(std::move(model),
+           std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
+        ntuple.Fill();
+    }
+
+    RNTupleReader ntuple(std::move(modelRead),
+       std::make_unique<RPageSourceFile>("ntuple", fileGuard.GetPath(), RNTupleReadOptions()));
+
+    printf("-- printing top-level fields\n");
+    const auto& ntuple_desc = ntuple.GetDescriptor();
+    for (auto f: ntuple_desc.GetTopLevelFields()) {
+       printf("top level field id: %lu\n", f);
+       printf("\tname: %s\n", ntuple_desc.GetFieldDescriptor(f).GetFieldName().c_str());
+    }
+
+    printf("\n-- printing first two levels\n");
+    for (auto f: ntuple_desc.GetTopLevelFields()) {
+       printf("top level field id: %lu\n", f);
+       for (auto child_field: ntuple_desc.GetFieldRange(f)) {
+          printf("\tsecond level field id: %lu\n", child_field);
+       }
+    }
+}

--- a/tree/ntuple/v7/test/ntuple_field_iterator.cxx
+++ b/tree/ntuple/v7/test/ntuple_field_iterator.cxx
@@ -23,16 +23,16 @@ TEST(RNTupleDescriptor, FieldIterator)
 
     printf("-- printing top-level fields\n");
     const auto& ntuple_desc = ntuple.GetDescriptor();
-    for (auto f: ntuple_desc.GetTopLevelFields()) {
-       printf("top level field id: %lu\n", f);
-       printf("\tname: %s\n", ntuple_desc.GetFieldDescriptor(f).GetFieldName().c_str());
+    for (auto& f: ntuple_desc.GetTopLevelFields()) {
+       printf("top level field id: %lu\n", f.GetId());
+       printf("\tname: %s\n", f.GetFieldName().c_str());
     }
 
     printf("\n-- printing first two levels\n");
-    for (auto f: ntuple_desc.GetTopLevelFields()) {
-       printf("top level field id: %lu\n", f);
-       for (auto child_field: ntuple_desc.GetFieldRange(f)) {
-          printf("\tsecond level field id: %lu\n", child_field);
+    for (auto& f: ntuple_desc.GetTopLevelFields()) {
+       printf("top level field id: %lu\n", f.GetId());
+       for (auto& child_field: ntuple_desc.GetFieldRange(f)) {
+          printf("\tsecond level field id: %lu\n", child_field.GetId());
        }
     }
 

--- a/tree/ntuple/v7/test/ntuple_field_iterator.cxx
+++ b/tree/ntuple/v7/test/ntuple_field_iterator.cxx
@@ -1,5 +1,6 @@
 #include "ntuple_test.hxx"
 using RFieldDescriptorRange = ROOT::Experimental::RFieldDescriptorRange;
+using ENTupleMergeable = ROOT::Experimental::RNTupleDescriptor::ENTupleMergeable;
 
 TEST(RNTupleDescriptor, FieldIterator)
 {
@@ -83,7 +84,9 @@ TEST(RNTupleDescriptor, IsMergeable)
       std::make_unique<RPageSourceFile>("ntuple3", fileGuard3.GetPath(), RNTupleReadOptions()));
 
     // mergeable with itself
-    EXPECT_TRUE(ntuple.GetDescriptor().IsMergeable(ntuple_copy.GetDescriptor()));
+    EXPECT_TRUE(ENTupleMergeable::Mergeable
+       == ntuple.GetDescriptor().IsMergeable(ntuple_copy.GetDescriptor()));
     // not mergeable with a ntuple with different top-level fields
-    EXPECT_FALSE(ntuple.GetDescriptor().IsMergeable(different_ntuple.GetDescriptor()));
+    EXPECT_TRUE(ENTupleMergeable::StructureMismatch
+       == ntuple.GetDescriptor().IsMergeable(different_ntuple.GetDescriptor()));
 }


### PR DESCRIPTION
Implements an iterator over the field descriptors of an NTuple. This is a building block for comparing and merging two NTuples by only looking at their descriptors. 