### PR TITLE
[RF][ROOT-10810] Fix pickling of RooTreeDataStore.

### DIFF
--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -1352,13 +1352,12 @@ void RooTreeDataStore::Streamer(TBuffer &R__b)
   } else {
 
     TTree* tmpTree = _tree;
-    if (_tree) {
+    auto parent = dynamic_cast<TDirectory*>(R__b.GetParent());
+    if (_tree && parent) {
       // Large trees cannot be written because of the 1Gb I/O limitation.
       // Here, we take the tree away from our instance, write it, and continue
       // to write the rest of the class normally
       auto tmpDir = _tree->GetDirectory();
-      TFile* parent = dynamic_cast<TFile*>(R__b.GetParent());
-      assert(parent);
 
       _tree->SetDirectory(parent);
       _tree->FlushBaskets(false);


### PR DESCRIPTION
[ROOT-10810] When RooTreeDataStore is streamed without a TFile (happens
when pickling), a memory-resident tree in RooTreeDataStore fails to
pickle.
It had to be taken out of ROOT's streamer facilities, since it often
exceeds the 1 Gb size limit for streaming operations.

Test in [roottest/#530](https://github.com/root-project/roottest/pull/530)