### PR TITLE
Build libcppyy and libROOTPythonizations with undefined symbols

### DIFF
--- a/bindings/pyroot_experimental/CMakeLists.txt
+++ b/bindings/pyroot_experimental/CMakeLists.txt
@@ -4,5 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
+set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+
 add_subdirectory(cppyy)
 add_subdirectory(pythonizations)

--- a/bindings/pyroot_experimental/cppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CMakeLists.txt
@@ -4,8 +4,6 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
-
 add_subdirectory(cppyy-backend)
 add_subdirectory(CPyCppyy)
 add_subdirectory(cppyy)

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
@@ -50,7 +50,6 @@ foreach(val RANGE ${how_many_pythons})
   list(GET python_include_dirs ${val} python_include_dir)
   list(GET python_under_version_strings ${val} python_under_version_string)
   list(GET python_version_strings ${val} python_version_string)
-  list(GET python_libraries ${val} python_library)
 
   set(libname cppyy${python_under_version_string})
 
@@ -93,7 +92,11 @@ foreach(val RANGE ${how_many_pythons})
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   )
 
-  target_link_libraries(${libname} cppyy_backend${python_under_version_string} ${python_library})
+  if(APPLE)
+    target_link_libraries(${libname} PUBLIC -Wl,-bind_at_load -Wl,-undefined -Wl,dynamic_lookup cppyy_backend${python_under_version_string})
+  elseif(NOT MSVC)
+    target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all cppyy_backend${python_under_version_string})
+  endif()
 
   set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS ${libname})
 

--- a/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/CPyCppyy/CMakeLists.txt
@@ -54,6 +54,11 @@ foreach(val RANGE ${how_many_pythons})
   set(libname cppyy${python_under_version_string})
 
   add_library(${libname} SHARED ${headers} ${sources})
+  if(APPLE)
+    target_link_libraries(${libname} PUBLIC -Wl,-bind_at_load -Wl,-undefined -Wl,dynamic_lookup cppyy_backend${python_under_version_string})
+  elseif(NOT MSVC)
+    target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all cppyy_backend${python_under_version_string})
+  endif()
 
   if(NOT MSVC)
     target_compile_options(${libname} PRIVATE
@@ -91,12 +96,6 @@ foreach(val RANGE ${how_many_pythons})
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   )
-
-  if(APPLE)
-    target_link_libraries(${libname} PUBLIC -Wl,-bind_at_load -Wl,-undefined -Wl,dynamic_lookup cppyy_backend${python_under_version_string})
-  elseif(NOT MSVC)
-    target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all cppyy_backend${python_under_version_string})
-  endif()
 
   set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS ${libname})
 

--- a/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
+++ b/bindings/pyroot_experimental/cppyy/cppyy-backend/CMakeLists.txt
@@ -28,7 +28,6 @@ foreach(val RANGE ${how_many_pythons})
   set(libname cppyy_backend${python_under_version_string})
 
   add_library(${libname} SHARED clingwrapper/src/clingwrapper.cxx)
-
   target_link_libraries(${libname} Core ${CMAKE_DL_LIBS})
 
   # cppyy uses ROOT headers from binary directory

--- a/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
@@ -92,7 +92,14 @@ foreach(val RANGE ${how_many_pythons})
 
   set(libname ROOTPythonizations${python_under_version_string})
 
-  ROOT_LINKER_LIBRARY(${libname} ${cpp_sources} DEPENDENCIES Core Tree cppyy${python_under_version_string} CMAKENOEXPORT)
+  add_library(${libname} SHARED ${cpp_sources})
+  # Set the suffix to '.so' and the prefix to 'lib'
+  set_target_properties(${libname} PROPERTIES  ${ROOT_LIBRARY_PROPERTIES})
+  if(APPLE)
+    target_link_libraries(${libname} PUBLIC -Wl,-bind_at_load -Wl,-undefined -Wl,dynamic_lookup Core Tree cppyy${python_under_version_string})
+  elseif(NOT MSVC)
+    target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all Core Tree cppyy${python_under_version_string})
+  endif()
 
   target_include_directories(${libname} PRIVATE ${python_include_dir})
 
@@ -116,6 +123,11 @@ foreach(val RANGE ${how_many_pythons})
     install(CODE "execute_process(COMMAND ${python_executable} -O -m py_compile ${localruntimedir}/${py_source})")
   endforeach()
 
+  # Install library
+  install(TARGETS ${libname} EXPORT ${CMAKE_PROJECT_NAME}Exports
+                             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries
+                             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
+                             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 endforeach()
 
 # Install Python sources and bytecode

--- a/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot_experimental/pythonizations/CMakeLists.txt
@@ -93,8 +93,6 @@ foreach(val RANGE ${how_many_pythons})
   set(libname ROOTPythonizations${python_under_version_string})
 
   add_library(${libname} SHARED ${cpp_sources})
-  # Set the suffix to '.so' and the prefix to 'lib'
-  set_target_properties(${libname} PROPERTIES  ${ROOT_LIBRARY_PROPERTIES})
   if(APPLE)
     target_link_libraries(${libname} PUBLIC -Wl,-bind_at_load -Wl,-undefined -Wl,dynamic_lookup Core Tree cppyy${python_under_version_string})
   elseif(NOT MSVC)

--- a/bindings/tpython/CMakeLists.txt
+++ b/bindings/tpython/CMakeLists.txt
@@ -23,7 +23,11 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTPython
   DEPENDENCIES
     Core
   LIBRARIES
-  cppyy${PYTHON_UNDER_VERSION_STRING_Development_Main}
+    cppyy${PYTHON_UNDER_VERSION_STRING_Development_Main}
+    # We link libTPython against Python libraries to compensate for the fact that libcppyy
+    # is built with unresolved symbols. If we didn't do this, invoking TPython from C++
+    # would not work.
+    ${PYTHON_LIBRARIES_Development_Main}
 )
 
 # Disables warnings originating from deprecated register keyword in Python


### PR DESCRIPTION
Alternative to #5643 which does not use ROOT_LIBRARY_PROPERTIES