### PR TITLE
[cmake] Fix ROOT/RLogger.hxx not found:

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -198,6 +198,7 @@ set(BASE_SOURCES
 if(CMAKE_CXX_STANDARD GREATER 11)
   list(APPEND BASE_HEADERS ROOT/RLogger.hxx)
   list(APPEND BASE_SOURCES v7/src/RLogger.cxx)
+  set(BASE_V7_INC ${CMAKE_SOURCE_DIR}/core/base/v7/inc)
   # TLogger.hxx may be used without root7 flag, but is placed in v7/inc/,
   # so we need to tell ROOT_INSTALL_HEADERS() where to find it
   set(BASE_HEADER_DIRS inc/ v7/inc/)
@@ -220,6 +221,7 @@ set(Core_dict_headers ${BASE_HEADERS} PARENT_SCOPE)
 ROOT_OBJECT_LIBRARY(Base ${BASE_SOURCES})
 
 target_include_directories(Base PRIVATE
+   ${BASE_V7_INC}
    ${PCRE_INCLUDE_DIR}
    res
    ${CMAKE_SOURCE_DIR}/core/foundation/res


### PR DESCRIPTION
When building without root7 but with C++14, RLogger is used.
Make it available to the include directories.