### PR TITLE
Fix circular includes Rtypes.h/TGenericClassInfo.h [ROOT-10820]

### DIFF
--- a/core/meta/inc/TGenericClassInfo.h
+++ b/core/meta/inc/TGenericClassInfo.h
@@ -9,10 +9,13 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#ifndef ROOT_Rtypes
+#include "Rtypes.h"
+#endif
+
 #ifndef ROOT_TGenericClassInfo
 #define ROOT_TGenericClassInfo
 
-#include "Rtypes.h"
 #include "TSchemaHelper.h"
 #include <vector>
 

--- a/core/meta/inc/TGenericClassInfo.h
+++ b/core/meta/inc/TGenericClassInfo.h
@@ -10,6 +10,8 @@
  *************************************************************************/
 
 #ifndef ROOT_Rtypes
+// Include Rtypes.h outside of the code guard to insure the intended
+// ordering of Rtypes.h and TGenericClassInfo.h
 #include "Rtypes.h"
 #endif
 


### PR DESCRIPTION
Move several class declarations into TGenericClassInfo.h,
include there only RtypesCore.h