### PR TITLE
[RF] Fix pickling of RooTreeDataStore.

### DIFF
--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -1373,13 +1373,12 @@ void RooTreeDataStore::Streamer(TBuffer &R__b)
   } else {
 
     TTree* tmpTree = _tree;
-    if (_tree) {
+    auto parent = dynamic_cast<TDirectory*>(R__b.GetParent());
+    if (_tree && parent) {
       // Large trees cannot be written because of the 1Gb I/O limitation.
       // Here, we take the tree away from our instance, write it, and continue
       // to write the rest of the class normally
       auto tmpDir = _tree->GetDirectory();
-      TFile* parent = dynamic_cast<TFile*>(R__b.GetParent());
-      assert(parent);
 
       _tree->SetDirectory(parent);
       _tree->FlushBaskets(false);


### PR DESCRIPTION
[ROOT-10810] When RooTreeDataStore is streamed without a TFile (happens
when pickling), there's no parent directory. It was assumed, however,
that such a parent always exists.
Here, this assumption is removed, and the default streaming behaviour
is restored if the parent is not a TDirectory.

(cherry picked from commit ff14b62014507f7bd944ef57ca52f4cad486a17f)