### PR TITLE
Create html file from README.md in build dir

### DIFF
--- a/cmake/modules/CPackREADME.cmake
+++ b/cmake/modules/CPackREADME.cmake
@@ -1,0 +1,24 @@
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.
+# All rights reserved.
+#
+# For the licensing terms see $ROOTSYS/LICENSE.
+# For the list of contributors see $ROOTSYS/README/CREDITS.
+
+#---------------------------------------------------------------------------------------------------
+#  CPackREADME.cmake
+#   - Pre-packaging script to convert README.md to html
+#---------------------------------------------------------------------------------------------------
+
+#----------------------------------------------------------------------------------------------------
+# Apple productbuild cannot handle .md files as CPACK_PACKAGE_DESCRIPTION_FILE;
+# convert to HTML instead.
+#
+if (APPLE)
+  find_program(CONVERTER textutil)
+  if (NOT CONVERTER)
+    message(FATAL_ERROR "textutil executable not found")
+  endif()
+  execute_process(COMMAND ${CONVERTER} -convert html README.md -output "${CMAKE_BINARY_DIR}/README.html")
+  set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_BINARY_DIR}/README.html")
+  set(CPACK_RESOURCE_FILE_README "${CMAKE_BINARY_DIR}/README.html")
+endif()

--- a/cmake/modules/RootCPack.cmake
+++ b/cmake/modules/RootCPack.cmake
@@ -127,6 +127,14 @@ else()
 endif()
 
 #----------------------------------------------------------------------------------------------------
+# Execute pre packaging script
+#
+# We want to defer markdown to html conversion; CPACK_INSTALL_SCRIPTS allows this
+# but only takes a .cmake file as argument
+#
+set(CPACK_INSTALL_SCRIPTS ${CMAKE_SOURCE_DIR}/cmake/modules/CPackREADME.cmake)
+
+#----------------------------------------------------------------------------------------------------
 # Finally, generate the CPack per-generator options file and include the
 # base CPack configuration.
 #


### PR DESCRIPTION
because CPack is unable to package markdown files on macOS

@vgvassilev 