### PR TITLE
[PyROOT][CMake] pyroot and pyroot_legacy interplay

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1571,7 +1571,7 @@ endif()
 
 #---Check for deprecated PyROOT experimental ---------------------------------------------
 if(pyroot_experimental)
-  message(FATAL_ERROR "pyroot_experimental is now called pyroot! Please reconfigure with -Dpyroot=ON")
+  message(WARNING "pyroot_experimental is a deprecated flag from 6.22.00. To build the new PyROOT, just configure with -Dpyroot=ON.")
 endif()
 
 #---Check for MPI---------------------------------------------------------------------

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1556,6 +1556,10 @@ endif()
 
 #---Check for PyROOT legacy---------------------------------------------------------------
 if(pyroot_legacy)
+  if(NOT pyroot)
+    message(FATAL_ERROR "pyroot_legacy is ON but pyroot is OFF. Please reconfigure with -Dpyroot=ON")
+  endif()
+
   if(fail-on-missing AND (NOT PYTHONLIBS_FOUND AND NOT Python2_Interpreter_Development_FOUND AND NOT Python3_Interpreter_Development_FOUND))
     message(FATAL_ERROR "PyROOT: Python development package not found and pyroot legacy component required"
                         " (python executable: ${PYTHON_EXECUTABLE})")


### PR DESCRIPTION
As pointed out by @bellenot , we need to cover the case in which the specified flags are (wrongly) `-Dpyroot=OFF` and `-Dpyroot_legacy=ON`.

The proposed solution in this PR shows a fatal error message saying "please reconfigure with pyroot=ON too". Alternatively, we could automatically enable `pyroot` if `pyroot_legacy` has been set to ON. To be discussed with the reviewers.

This assumes:
1. `-Dpyroot=ON` means "build me PyROOT".
2. `-Dpyroot_legacy=ON` means "from the PyROOTs you have, build me the old one!"

So (1) activates PyROOT and (2) selects which PyROOT to build.

Please shout if you have a different point of view.