### PR TITLE
[wincxxmodules] Remove Cling as a dependency of win32gdk

### DIFF
--- a/graf2d/win32gdk/CMakeLists.txt
+++ b/graf2d/win32gdk/CMakeLists.txt
@@ -114,7 +114,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Win32gdk
     Glu32.lib
     Opengl32.lib
   DEPENDENCIES
-    Cling
     Core
     Graf
   BUILTINS


### PR DESCRIPTION
This commit is necessary as Cling does not have a .pcm file which causes problems when we try to build with flag -Druntime_cxxmodules=On on Windows

@vgvassilev @bellenot 