### PR TITLE
[wincxxmodules] Fix MathCore.pcm build on Windows

### DIFF
--- a/interpreter/cling/include/cling/libc_msvc.modulemap
+++ b/interpreter/cling/include/cling/libc_msvc.modulemap
@@ -19,6 +19,10 @@ module "libc" [system] [extern_c] [no_undeclared_includes] {
     export *
     header "fenv.h"
   }
+  module "float.h" {
+    export *
+    header "float.h"
+  }
   module "memory.h" {
     export *
     header "memory.h"

--- a/interpreter/cling/include/cling/std_msvc.modulemap
+++ b/interpreter/cling/include/cling/std_msvc.modulemap
@@ -176,10 +176,6 @@ module "std" [system] {
     export *
     header "execution"
   }
-  module "float.h" {
-    export *
-    header "float.h"
-  }
   module "filesystem" {
     requires cplusplus17, !header_existence
     export *


### PR DESCRIPTION
This commit fixes the error received on building MathCore.pcm on Windows.

```
  In file included from input_line_16:9:
  In file included from C:/root-build/include\Fit/FitConfig.h:23:
C:/root-build/include\TMath.h(782,13): error G30564CF7: use of undeclared identifier '_finite' [C:\root-build\math\math
core\G__MathCore.vcxproj]
     { return finite(x); }
              ^
  C:/root-build/include\TMath.h:571:22: note: expanded from macro 'finite'
  #      define finite _finite
                       ^
```

@vgvassilev @bellenot 