### PR TITLE
[ntuple] Rename NTuple "root field" to "field zero"

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -30,9 +30,9 @@ namespace Experimental {
 ROOT::Experimental::RNTupleDS::RNTupleDS(std::unique_ptr<ROOT::Experimental::RNTupleReader> ntuple)
 {
    fReaders.emplace_back(std::move(ntuple));
-   auto rootField = fReaders[0]->GetModel()->GetRootField();
-   for (auto &f : *rootField) {
-      if (f.GetParent() != rootField)
+   auto fieldZero = fReaders[0]->GetModel()->GetFieldZero();
+   for (auto &f : *fieldZero) {
+      if (f.GetParent() != fieldZero)
          continue;
       fColumnNames.push_back(f.GetName());
       fColumnTypes.push_back(f.GetType());

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -248,9 +248,9 @@ public:
 
 
 /// The container field for an ntuple model, which itself has no physical representation
-class RFieldRoot : public Detail::RFieldBase {
+class RFieldZero : public Detail::RFieldBase {
 public:
-   RFieldRoot() : Detail::RFieldBase("", "", ENTupleStructure::kRecord, false /* isSimple */) { }
+   RFieldZero() : Detail::RFieldBase("", "", ENTupleStructure::kRecord, false /* isSimple */) { }
    RFieldBase* Clone(std::string_view newName);
 
    void GenerateColumnsImpl() final {}

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -44,7 +44,7 @@ by the RPrintSchemaVisitor class. The RFieldBase class and classes which inherit
 class RFieldVisitor {
 public:
    virtual void VisitField(const Detail::RFieldBase &field) = 0;
-   virtual void VisitRootField(const RFieldRoot &field) { VisitField(field); }
+   virtual void VisitFieldZero(const RFieldZero &field) { VisitField(field); }
    virtual void VisitArrayField(const RArrayField &field) { VisitField(field); }
    virtual void VisitBoolField(const RField<bool> &field) { VisitField(field); }
    virtual void VisitClassField(const RClassField &field) { VisitField(field); }
@@ -80,7 +80,7 @@ private:
 public:
    RPrepareVisitor() = default;
    void VisitField(const Detail::RFieldBase &field) final;
-   void VisitRootField(const RFieldRoot &field) final;
+   void VisitFieldZero(const RFieldZero &field) final;
 
    unsigned int GetDeepestLevel() const { return fDeepestLevel; }
    unsigned int GetNumFields() const { return fNumFields; }
@@ -121,7 +121,7 @@ public:
    }
    /// Prints summary of Field
    void VisitField(const Detail::RFieldBase &field) final;
-   void VisitRootField(const RFieldRoot &rootField) final;
+   void VisitFieldZero(const RFieldZero &fieldZero) final;
    void SetFrameSymbol(char s) { fFrameSymbol = s; }
    void SetWidth(int w) { fWidth = w; }
    void SetDeepestLevel(int d);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -352,6 +352,8 @@ public:
    NTupleSize_t GetNEntries() const;
    NTupleSize_t GetNElements(DescriptorId_t columnId) const;
 
+   /// Returns the logical parent of all top-level NTuple data fields.
+   DescriptorId_t GetFieldZeroId() const;
    DescriptorId_t FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const;
    /// Searches for a top-level field
    DescriptorId_t FindFieldId(std::string_view fieldName) const;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -46,7 +46,7 @@ A model needs to be frozen before it can be used to create a live ntuple.
 // clang-format on
 class RNTupleModel {
    /// Hierarchy of fields consisting of simple types and collections (sub trees)
-   std::unique_ptr<RFieldRoot> fRootField;
+   std::unique_ptr<RFieldZero> fFieldZero;
    /// Contains field values corresponding to the created top-level fields
    std::unique_ptr<REntry> fDefaultEntry;
 
@@ -64,7 +64,7 @@ public:
    std::shared_ptr<T> MakeField(std::string_view fieldName, ArgsT&&... args) {
       auto field = std::make_unique<RField<T>>(fieldName);
       auto ptr = fDefaultEntry->AddValue<T>(field.get(), std::forward<ArgsT>(args)...);
-      fRootField->Attach(std::move(field));
+      fFieldZero->Attach(std::move(field));
       return ptr;
    }
 
@@ -75,7 +75,7 @@ public:
    void AddField(std::string_view fieldName, T* fromWhere) {
       auto field = std::make_unique<RField<T>>(fieldName);
       fDefaultEntry->CaptureValue(field->CaptureValue(fromWhere));
-      fRootField->Attach(std::move(field));
+      fFieldZero->Attach(std::move(field));
    }
 
    template <typename T>
@@ -88,7 +88,7 @@ public:
       std::string_view fieldName,
       std::unique_ptr<RNTupleModel> collectionModel);
 
-   RFieldRoot *GetRootField() const { return fRootField.get(); }
+   RFieldZero* GetFieldZero() const { return fFieldZero.get(); }
    REntry* GetDefaultEntry() { return fDefaultEntry.get(); }
    std::unique_ptr<REntry> CreateEntry();
    RNTupleVersion GetVersion() const { return RNTupleVersion(); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -26,7 +26,7 @@ namespace Experimental {
 
 /**
  * The fields in the ntuple model tree can carry different structural information about the type system.
- * Leaf fields contain just data, collection fields resolve to offset columns, record root fields have no
+ * Leaf fields contain just data, collection fields resolve to offset columns, record fields have no
  * materialization on the primitive column layer.
  */
 enum ENTupleStructure {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -130,7 +130,7 @@ public:
 \brief An RNTupleView provides read-only access to a single field of the ntuple
 
 The view owns a field and its underlying columns in order to fill an ntuple value object with data. Data can be
-accessed by index. For top level fields, the index refers to the entry number. Fields that are part of
+accessed by index. For top-level fields, the index refers to the entry number. Fields that are part of
 nested collections have global index numbers that are derived from their parent indexes.
 
 Fields of simple types with a Map() method will use that and thus expose zero-copy access.

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -295,9 +295,9 @@ void ROOT::Experimental::Detail::RFieldBase::RSchemaIterator::Advance()
 //------------------------------------------------------------------------------
 
 
-ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RFieldRoot::Clone(std::string_view /*newName*/)
+ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RFieldZero::Clone(std::string_view /*newName*/)
 {
-   Detail::RFieldBase* result = new RFieldRoot();
+   Detail::RFieldBase* result = new RFieldZero();
    for (auto &f : fSubFields) {
       auto clone = f->Clone(f->GetName());
       result->Attach(std::unique_ptr<RFieldBase>(clone));
@@ -306,7 +306,7 @@ ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RFieldRoot::Clone(st
 }
 
 
-ROOT::Experimental::REntry* ROOT::Experimental::RFieldRoot::GenerateEntry()
+ROOT::Experimental::REntry* ROOT::Experimental::RFieldZero::GenerateEntry()
 {
    auto entry = new REntry();
    for (auto& f : fSubFields) {
@@ -315,9 +315,9 @@ ROOT::Experimental::REntry* ROOT::Experimental::RFieldRoot::GenerateEntry()
    return entry;
 }
 
-void ROOT::Experimental::RFieldRoot::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RFieldZero::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
-   visitor.VisitRootField(*this);
+   visitor.VisitFieldZero(*this);
 }
 
 
@@ -1007,8 +1007,8 @@ ROOT::Experimental::RCollectionField::RCollectionField(
    : RFieldBase(name, ":Collection:", ENTupleStructure::kCollection, true /* isSimple */)
    , fCollectionNTuple(collectionNTuple)
 {
-   for (unsigned i = 0; i < collectionModel->GetRootField()->fSubFields.size(); ++i) {
-      auto& subField = collectionModel->GetRootField()->fSubFields[i];
+   for (unsigned i = 0; i < collectionModel->GetFieldZero()->fSubFields.size(); ++i) {
+      auto& subField = collectionModel->GetFieldZero()->fSubFields[i];
       Attach(std::move(subField));
    }
 }

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -42,7 +42,7 @@ void ROOT::Experimental::RPrepareVisitor::VisitField(const Detail::RFieldBase &f
 }
 
 
-void ROOT::Experimental::RPrepareVisitor::VisitRootField(const RFieldRoot &field)
+void ROOT::Experimental::RPrepareVisitor::VisitFieldZero(const RFieldZero &field)
 {
    VisitField(field);
    fNumFields--;
@@ -93,10 +93,10 @@ void ROOT::Experimental::RPrintSchemaVisitor::VisitField(const Detail::RFieldBas
 }
 
 
-void ROOT::Experimental::RPrintSchemaVisitor::VisitRootField(const RFieldRoot &rootField)
+void ROOT::Experimental::RPrintSchemaVisitor::VisitFieldZero(const RFieldZero &fieldZero)
 {
    auto fieldNo = 1;
-   for (auto f : rootField.GetSubFields()) {
+   for (auto f : fieldZero.GetSubFields()) {
       RPrintSchemaVisitor visitor(*this);
       visitor.fFieldNo = fieldNo++;
       f->AcceptVisitor(visitor);

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -33,7 +33,7 @@
 
 void ROOT::Experimental::RNTupleReader::ConnectModel() {
    std::unordered_map<const Detail::RFieldBase *, DescriptorId_t> fieldPtr2Id;
-   fieldPtr2Id[fModel->GetFieldZero()] = fSource->GetDescriptor().FindFieldId("", kInvalidDescriptorId);
+   fieldPtr2Id[fModel->GetFieldZero()] = fSource->GetDescriptor().GetFieldZeroId();
    for (auto &field : *fModel->GetFieldZero()) {
       auto parentId = fieldPtr2Id[field.GetParent()];
       auto fieldId = fSource->GetDescriptor().FindFieldId(field.GetName(), parentId);

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -33,8 +33,8 @@
 
 void ROOT::Experimental::RNTupleReader::ConnectModel() {
    std::unordered_map<const Detail::RFieldBase *, DescriptorId_t> fieldPtr2Id;
-   fieldPtr2Id[fModel->GetRootField()] = fSource->GetDescriptor().FindFieldId("", kInvalidDescriptorId);
-   for (auto &field : *fModel->GetRootField()) {
+   fieldPtr2Id[fModel->GetFieldZero()] = fSource->GetDescriptor().FindFieldId("", kInvalidDescriptorId);
+   for (auto &field : *fModel->GetFieldZero()) {
       auto parentId = fieldPtr2Id[field.GetParent()];
       auto fieldId = fSource->GetDescriptor().FindFieldId(field.GetName(), parentId);
       R__ASSERT(fieldId != kInvalidDescriptorId);
@@ -112,7 +112,7 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       // FitString defined in RFieldVisitor.cxx
       output << frameSymbol << " N-Tuple : " << RNTupleFormatter::FitString(name, width-13) << frameSymbol << std::endl; // prints line with name of ntuple
       output << frameSymbol << " Entries : " << RNTupleFormatter::FitString(std::to_string(GetNEntries()), width - 13) << frameSymbol << std::endl;  // prints line with number of entries
-      GetModel()->GetRootField()->AcceptVisitor(prepVisitor);
+      GetModel()->GetFieldZero()->AcceptVisitor(prepVisitor);
 
       printVisitor.SetFrameSymbol(frameSymbol);
       printVisitor.SetWidth(width);
@@ -122,7 +122,7 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       for (int i = 0; i < width; ++i)
          output << frameSymbol;
       output << std::endl;
-      GetModel()->GetRootField()->AcceptVisitor(printVisitor);
+      GetModel()->GetFieldZero()->AcceptVisitor(printVisitor);
       for (int i = 0; i < width; ++i)
          output << frameSymbol;
       output << std::endl;
@@ -204,7 +204,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleWriter> ROOT::Experimental::RNTupleWr
 void ROOT::Experimental::RNTupleWriter::CommitCluster()
 {
    if (fNEntries == fLastCommitted) return;
-   for (auto& field : *fModel->GetRootField()) {
+   for (auto& field : *fModel->GetFieldZero()) {
       field.Flush();
       field.CommitCluster();
    }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -645,6 +645,7 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleDescriptor::GetNElem
    return result;
 }
 
+
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, DescriptorId_t parentId) const
 {
@@ -663,10 +664,17 @@ ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName, D
 }
 
 
-ROOT::Experimental::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName) const
+ROOT::Experimental::DescriptorId_t
+ROOT::Experimental::RNTupleDescriptor::GetFieldZeroId() const
 {
-   auto rootId = FindFieldId("", kInvalidDescriptorId);
-   return FindFieldId(fieldName, rootId);
+   return FindFieldId("", kInvalidDescriptorId);
+}
+
+
+ROOT::Experimental::DescriptorId_t
+ROOT::Experimental::RNTupleDescriptor::FindFieldId(std::string_view fieldName) const
+{
+   return FindFieldId(fieldName, GetFieldZeroId());
 }
 
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -25,16 +25,16 @@
 
 
 ROOT::Experimental::RNTupleModel::RNTupleModel()
-  : fRootField(std::make_unique<RFieldRoot>())
+  : fFieldZero(std::make_unique<RFieldZero>())
   , fDefaultEntry(std::make_unique<REntry>())
 {}
 
 ROOT::Experimental::RNTupleModel* ROOT::Experimental::RNTupleModel::Clone()
 {
    auto cloneModel = new RNTupleModel();
-   auto cloneRootField = static_cast<RFieldRoot*>(fRootField->Clone(""));
-   cloneModel->fRootField = std::unique_ptr<RFieldRoot>(cloneRootField);
-   cloneModel->fDefaultEntry = std::unique_ptr<REntry>(cloneRootField->GenerateEntry());
+   auto cloneFieldZero = static_cast<RFieldZero*>(fFieldZero->Clone(""));
+   cloneModel->fFieldZero = std::unique_ptr<RFieldZero>(cloneFieldZero);
+   cloneModel->fDefaultEntry = std::unique_ptr<REntry>(cloneFieldZero->GenerateEntry());
    return cloneModel;
 }
 
@@ -42,7 +42,7 @@ ROOT::Experimental::RNTupleModel* ROOT::Experimental::RNTupleModel::Clone()
 void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBase> field)
 {
    fDefaultEntry->AddValue(field->GenerateValue());
-   fRootField->Attach(std::move(field));
+   fFieldZero->Attach(std::move(field));
 }
 
 
@@ -52,15 +52,15 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTuple> ROOT::Experimental::RNTup
    auto collectionNTuple = std::make_shared<RCollectionNTuple>(std::move(collectionModel->fDefaultEntry));
    auto field = std::make_unique<RCollectionField>(fieldName, collectionNTuple, std::move(collectionModel));
    fDefaultEntry->CaptureValue(field->CaptureValue(collectionNTuple->GetOffsetPtr()));
-   fRootField->Attach(std::move(field));
+   fFieldZero->Attach(std::move(field));
    return collectionNTuple;
 }
 
 std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::CreateEntry()
 {
    auto entry = std::make_unique<REntry>();
-   for (auto& f : *fRootField) {
-      if (f.GetParent() != GetRootField())
+   for (auto& f : *fFieldZero) {
+      if (f.GetParent() != GetFieldZero())
          continue;
       entry->AddValue(f.GenerateValue());
    }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -115,11 +115,11 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
                                 model.GetVersion(), model.GetUuid());
 
    std::unordered_map<const RFieldBase *, DescriptorId_t> fieldPtr2Id; // necessary to find parent field ids
-   const auto &rootField = *model.GetRootField();
-   fDescriptorBuilder.AddField(fLastFieldId, rootField.GetFieldVersion(), rootField.GetTypeVersion(),
-      rootField.GetName(), rootField.GetType(), rootField.GetNRepetitions(), rootField.GetStructure());
-   fieldPtr2Id[&rootField] = fLastFieldId++;
-   for (auto& f : *model.GetRootField()) {
+   const auto &fieldZero = *model.GetFieldZero();
+   fDescriptorBuilder.AddField(fLastFieldId, fieldZero.GetFieldVersion(), fieldZero.GetTypeVersion(),
+      fieldZero.GetName(), fieldZero.GetType(), fieldZero.GetNRepetitions(), fieldZero.GetStructure());
+   fieldPtr2Id[&fieldZero] = fLastFieldId++;
+   for (auto& f : *model.GetFieldZero()) {
       fDescriptorBuilder.AddField(fLastFieldId, f.GetFieldVersion(), f.GetTypeVersion(), f.GetName(), f.GetType(),
                                   f.GetNRepetitions(), f.GetStructure());
       fDescriptorBuilder.AddFieldLink(fieldPtr2Id[f.GetParent()], fLastFieldId);

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -102,7 +102,7 @@ TEST(RNTuple, Descriptor)
    EXPECT_EQ(NTupleSize_t(1100), reference.GetNElements(3));
    EXPECT_EQ(NTupleSize_t(3300), reference.GetNElements(4));
 
-   EXPECT_EQ(DescriptorId_t(0), reference.FindFieldId("", ROOT::Experimental::kInvalidDescriptorId));
+   EXPECT_EQ(DescriptorId_t(0), reference.GetFieldZeroId());
    EXPECT_EQ(DescriptorId_t(1), reference.FindFieldId("list", 0));
    EXPECT_EQ(DescriptorId_t(1), reference.FindFieldId("list"));
    EXPECT_EQ(DescriptorId_t(2), reference.FindFieldId("list", 1));


### PR DESCRIPTION
See naming discussion here: https://github.com/root-project/root/pull/5768#discussion_r434156785
Also implemented convenience `GetFieldZeroId` function. 