### PR TITLE
Fix compilation warings in mathtext

### DIFF
--- a/graf2d/mathtext/inc/mathrender.h
+++ b/graf2d/mathtext/inc/mathrender.h
@@ -60,6 +60,12 @@ namespace mathtext {
          _x[0] = x0;
          _x[1] = y0;
       }
+      inline point_t& operator=(const point_t &point)
+      {
+         _x[0] = point._x[0];
+         _x[1] = point._x[1];
+         return *this;
+      }
       inline const float *x(void) const
       {
          return _x;


### PR DESCRIPTION
Provide assign operator for the point_t class which have copy constructor
Fixes compilation error when trying to compile with cxxmodules=ON, 