### PR TITLE
[clingutils] Add demangled name as alternate class name (ROOT-10804):

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -187,10 +187,13 @@ public:
 //______________________________________________________________________________
 class AnnotatedRecordDecl {
 private:
+   static std::string BuildDemangledTypeInfo(const clang::RecordDecl *rDecl,
+                                             const std::string &normalizedName);
    long fRuleIndex;
    const clang::RecordDecl* fDecl;
    std::string fRequestedName;
    std::string fNormalizedName;
+   std::string fDemangledTypeInfo;
    bool fRequestStreamerInfo;
    bool fRequestNoStreamer;
    bool fRequestNoInputOperator;
@@ -261,6 +264,7 @@ public:
 
    const char *GetRequestedName() const { return fRequestedName.c_str(); }
    const char *GetNormalizedName() const { return fNormalizedName.c_str(); }
+   const std::string &GetDemangledTypeInfo() const { return fDemangledTypeInfo; }
    bool HasClassVersion() const { return fRequestedVersionNumber >=0 ; }
    bool RequestStreamerInfo() const {
       // Equivalent to CINT's cl.RootFlag() & G__USEBYTECOUNT

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -35,6 +35,7 @@
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/Mangle.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
@@ -363,6 +364,62 @@ void TNormalizedCtxt::keepTypedef(const cling::LookupHelper &lh, const char* nam
    return fImpl->keepTypedef(lh, name, replace);
 }
 
+std::string AnnotatedRecordDecl::BuildDemangledTypeInfo(const clang::RecordDecl *rDecl,
+                                                        const std::string &normalizedName)
+{
+   // Types with strong typedefs must not be findable through demangled type names, or else
+   // the demangled name will resolve to both sinblings double / Double32_t.
+   if (normalizedName.find("Double32_t") != std::string::npos
+       || normalizedName.find("Float16_t") != std::string::npos)
+       return {};
+   std::unique_ptr<clang::MangleContext> mangleCtx(rDecl->getASTContext().createMangleContext());
+   std::string mangledName;
+   {
+      llvm::raw_string_ostream sstr(mangledName);
+      if (const clang::TypeDecl* TD = llvm::dyn_cast<clang::TypeDecl>(rDecl)) {
+         mangleCtx->mangleCXXRTTI(clang::QualType(TD->getTypeForDecl(), 0), sstr);
+      }
+   }
+   if (!mangledName.empty()) {
+      int errDemangle = 0;
+#ifdef WIN32
+      if (mangledName[0] == '\01')
+         mangledName.erase(0, 1);
+      char *demangledTIName = TClassEdit::DemangleName(mangledName.c_str(), errDemangle);
+      if (!errDemangle && demangledTIName) {
+         static const char typeinfoNameFor[] = " `RTTI Type Descriptor'";
+         if (strstr(demangledTIName, typeinfoNameFor)) {
+            std::string demangledName = demangledTIName;
+            demangledName.erase(demangledName.end() - strlen(typeinfoNameFor), demangledName.end());
+            if (demangledName.compare(0, 6, "class ") == 0)
+               demangledName.erase(0, 6);
+            else if (demangledName.compare(0, 7, "struct ") == 0)
+               demangledName.erase(0, 7);
+#else
+      char* demangledTIName = TClassEdit::DemangleName(mangledName.c_str(), errDemangle);
+      if (!errDemangle && demangledTIName) {
+         static const char typeinfoNameFor[] = "typeinfo for ";
+         if (!strncmp(demangledTIName, typeinfoNameFor, strlen(typeinfoNameFor))) {
+            std::string demangledName = demangledTIName + strlen(typeinfoNameFor);
+#endif
+            free(demangledTIName);
+            return demangledName;
+         } else {
+#ifdef WIN32
+            ROOT::TMetaUtils::Error("AnnotatedRecordDecl::BuildDemangledTypeInfo",
+                                    "Demangled typeinfo name '%s' does not contain `RTTI Type Descriptor'\n",
+                                    demangledTIName);
+#else
+            ROOT::TMetaUtils::Error("AnnotatedRecordDecl::BuildDemangledTypeInfo",
+                                    "Demangled typeinfo name '%s' does not start with 'typeinfo for'\n",
+                                    demangledTIName);
+#endif
+         } // if demangled type_info starts with "typeinfo for "
+      } // if demangling worked
+      free(demangledTIName);
+   } // if mangling worked
+   return {};
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -382,7 +439,7 @@ AnnotatedRecordDecl::AnnotatedRecordDecl(long index,
    fRequestNoInputOperator(rRequestNoInputOperator), fRequestOnlyTClass(rRequestOnlyTClass), fRequestedVersionNumber(rRequestedVersionNumber)
 {
    TMetaUtils::GetNormalizedName(fNormalizedName, decl->getASTContext().getTypeDeclType(decl), interpreter,normCtxt);
-
+   fDemangledTypeInfo = BuildDemangledTypeInfo(decl, fNormalizedName);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -412,8 +469,9 @@ AnnotatedRecordDecl::AnnotatedRecordDecl(long index,
       ROOT::TMetaUtils::Warning("AnnotatedRecordDecl",
                                 "Could not remove the requested template arguments.\n");
    }
-
+   fDemangledTypeInfo = BuildDemangledTypeInfo(decl, fNormalizedName);
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Normalize the requested type name.
 
@@ -436,8 +494,9 @@ AnnotatedRecordDecl::AnnotatedRecordDecl(long index,
    splitname1.ShortType(fRequestedName, 0);
 
    TMetaUtils::GetNormalizedName( fNormalizedName, clang::QualType(requestedType,0), interpreter, normCtxt);
-
+   fDemangledTypeInfo = BuildDemangledTypeInfo(decl, fNormalizedName);
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Normalize the requested name.
 
@@ -468,8 +527,7 @@ AnnotatedRecordDecl::AnnotatedRecordDecl(long index,
    } else {
       TMetaUtils::GetNormalizedName( fNormalizedName, decl->getASTContext().getTypeDeclType(decl),interpreter,normCtxt);
    }
-
-
+   fDemangledTypeInfo = BuildDemangledTypeInfo(decl, fNormalizedName);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1989,6 +2047,14 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
    if (cl.GetRequestedName()[0] && classname != cl.GetRequestedName()) {
       finalString << "\n" << "      ::ROOT::AddClassAlternate(\""
                   << classname << "\",\"" << cl.GetRequestedName() << "\");\n";
+   }
+
+   if (!cl.GetDemangledTypeInfo().empty()
+         && cl.GetDemangledTypeInfo() != classname
+         && cl.GetDemangledTypeInfo() != cl.GetRequestedName()) {
+      finalString << "\n" << "      ::ROOT::AddClassAlternate(\""
+                  << classname << "\",\"" << cl.GetDemangledTypeInfo() << "\");\n";
+
    }
 
    //---------------------------------------------------------------------------

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -70,7 +70,6 @@ const char *shortHelp =
 #include "cling/Interpreter/LookupHelper.h"
 #include "cling/Interpreter/Value.h"
 #include "clang/AST/CXXInheritance.h"
-#include "clang/AST/Mangle.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/MemoryBufferCache.h"
 #include "clang/Frontend/CompilerInstance.h"
@@ -2524,61 +2523,19 @@ int  ExtractClassesListAndDeclLines(RScanner &scan,
                classesListForRootmap.push_back(reqName);
             }
 
-            // Also register typeinfo::name(), unless we have pseudo-strong typedefs:
-            if (normalizedName.find("Double32_t") == std::string::npos
-                && normalizedName.find("Float16_t") == std::string::npos) {
-               std::unique_ptr<clang::MangleContext> mangleCtx(rDecl->getASTContext().createMangleContext());
-               std::string mangledName;
-               {
-                  llvm::raw_string_ostream sstr(mangledName);
-                  if (const clang::TypeDecl* TD = llvm::dyn_cast<clang::TypeDecl>(rDecl)) {
-                     mangleCtx->mangleCXXRTTI(clang::QualType(TD->getTypeForDecl(), 0), sstr);
-                  }
-               }
-               if (!mangledName.empty()) {
-                  int errDemangle = 0;
-#ifdef WIN32
-                  if (mangledName[0] == '\01')
-                     mangledName.erase(0, 1);
-                  char *demangledTIName = TClassEdit::DemangleName(mangledName.c_str(), errDemangle);
-                  if (!errDemangle && demangledTIName) {
-                     static const char typeinfoNameFor[] = " `RTTI Type Descriptor'";
-                     if (strstr(demangledTIName, typeinfoNameFor)) {
-                        std::string demangledName = demangledTIName;
-                        demangledName.erase(demangledName.end() - strlen(typeinfoNameFor), demangledName.end());
-                        if (demangledName.compare(0, 6, "class ") == 0)
-                           demangledName.erase(0, 6);
-                        else if (demangledName.compare(0, 7, "struct ") == 0)
-                           demangledName.erase(0, 7);
-#else
-                  char* demangledTIName = TClassEdit::DemangleName(mangledName.c_str(), errDemangle);
-                  if (!errDemangle && demangledTIName) {
-                     static const char typeinfoNameFor[] = "typeinfo for ";
-                     if (!strncmp(demangledTIName, typeinfoNameFor, strlen(typeinfoNameFor))) {
-                        std::string demangledName = demangledTIName + strlen(typeinfoNameFor);
-#endif
-                        // See the operations in TCling::AutoLoad(type_info)
-                        TClassEdit::TSplitType splitname( demangledName.c_str(), (TClassEdit::EModType)(TClassEdit::kLong64 | TClassEdit::kDropStd) );
-                        splitname.ShortType(demangledName, TClassEdit::kDropStlDefault | TClassEdit::kDropStd);
+            // Also register typeinfo::name(), unless we have pseudo-strong typedefs.
+            // GetDemangledTypeInfo() checks for Double32_t etc already and returns an empty string.
+            std::string demangledName = selClass.GetDemangledTypeInfo();
+            if (!demangledName.empty()) {
+               // See the operations in TCling::AutoLoad(type_info)
+               TClassEdit::TSplitType splitname( demangledName.c_str(), (TClassEdit::EModType)(TClassEdit::kLong64 | TClassEdit::kDropStd) );
+               splitname.ShortType(demangledName, TClassEdit::kDropStlDefault | TClassEdit::kDropStd);
 
-                        if (demangledName != normalizedName && (!reqName || demangledName != reqName)) {
-                           classesListForRootmap.push_back(demangledName);
-                        } // if demangledName != other name
-                     } else {
-#ifdef WIN32
-                        ROOT::TMetaUtils::Error("ExtractClassesListAndDeclLines",
-                                                "Demangled typeinfo name '%s' does not contain `RTTI Type Descriptor'\n",
-                                                demangledTIName);
-#else
-                        ROOT::TMetaUtils::Error("ExtractClassesListAndDeclLines",
-                                                "Demangled typeinfo name '%s' does not start with 'typeinfo for'\n",
-                                                demangledTIName);
-#endif
-                     } // if demangled type_info starts with "typeinfo for "
-                  } // if demangling worked
-                  free(demangledTIName);
-               } // if mangling worked
-            } // if no pseudo-strong typedef involved
+               if (demangledName != normalizedName && (!reqName || demangledName != reqName)) {
+                  // if demangledName != other name
+                  classesListForRootmap.push_back(demangledName);
+               }
+            }
          }
       }
    }


### PR DESCRIPTION
clang might need to find a definition, that "we" might have.
But we need to find it based on a type name from clang, from a fwd decl;
or (as in ROOT-10804) based on a typename-from-typeid operation.
So register that as an alias!

The normalized-name-as-known-to-ROOT and typeid-name can be different,
for instance for inline namespaces: stripped by ROOT, kept by typeid.

ROOT-10804 has a complex case where a lookup of a template argument failed
because it involves an inline namespace, and LHCb uses typeid demangling.
LHCb's case needed a nested name from a type (`LHCb::Event::v1::Track`)
that failed to load because `v1` is an inline namespace, thus failing
instantiation of `KeyedContainer<LHCb::Event::v1::Track,Containers::KeyedObjectManager<Containers::hashmap> >` and making it invalid.
The transaction unloading then fails to completely remove this instantiation
(an unrelated bug), such that the remainders of the invalid decl are picked
up by a subsequent template instantiation which then asserts because of the
incomplete (invalid) declaration.

We use the mangle/demangle trick from rootcling.
Now that multiple locations need it, just store it with the AnnotatedRecordDecl.
It will be needed for most classes; the overhead should be bearable.

(cherry picked from commit d9e819b82632cf02b3aaa251f5922b457b41624e)