### PR TITLE
Optimize roofit includes

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
@@ -7,7 +7,7 @@
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
- 
+
 #ifndef HISTFACTORY_CHANNEL_H
 #define HISTFACTORY_CHANNEL_H
 
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <vector>
 
 class TFile;
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/ConfigParser.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ConfigParser.h
@@ -22,6 +22,7 @@
 
 #include <cstdlib>
 #include <string>
+#include <vector>
 
 namespace RooStats{
    namespace HistFactory {

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistFactoryModelUtils.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistFactoryModelUtils.h
@@ -7,6 +7,10 @@
 #include "RooDataSet.h"
 #include "RooStats/HistFactory/ParamHistFunc.h"
 
+#include <vector>
+#include <map>
+#include <string>
+
 namespace RooStats {
 namespace HistFactory {
   ///\ingroup HistFactory

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistFactoryNavigation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistFactoryNavigation.h
@@ -2,6 +2,8 @@
 #define INCLUDE_HISTFACTORYNAVIGATION_H
 
 #include <map>
+#include <vector>
+#include <string>
 
 #include "TH1.h"
 #include "THStack.h"
@@ -13,11 +15,10 @@
 
 namespace RooStats {
   class ModelConfig;
-  namespace HistFactory { 
+  namespace HistFactory {
 
     class HistFactoryNavigation {
 
-  
     public:
 
       /// Initialze based on an already-created HistFactory Model

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistFactorySimultaneous.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistFactorySimultaneous.h
@@ -16,8 +16,10 @@
 #ifndef HISTFACTORY_SIMULTANEOUS
 #define HISTFACTORY_SIMULTANEOUS
 
-//#include "THashList.h"
 #include "RooSimultaneous.h"
+
+#include <string>
+#include <map>
 
 namespace RooStats{
 namespace HistFactory{

--- a/roofit/histfactory/inc/RooStats/HistFactory/LinInterpVar.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/LinInterpVar.h
@@ -14,6 +14,7 @@
 #include "RooAbsPdf.h"
 #include "RooRealProxy.h"
 #include "RooListProxy.h"
+#include <vector>
 
 class RooRealVar;
 class RooArgList ;

--- a/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
@@ -15,10 +15,10 @@
 #include <map>
 #include <fstream>
 #include <iostream>
+#include <vector>
 
-#include "TObject.h"
+#include "TNamed.h"
 #include "TFile.h"
-
 
 #include "PreprocessFunction.h"
 #include "RooStats/HistFactory/Channel.h"
@@ -156,13 +156,13 @@ private:
   std::map< std::string, double > fUniformSyst;
   std::map< std::string, double > fLogNormSyst;
   std::map< std::string, double > fNoSyst;
-  
+
   std::string GetDirPath( TDirectory* dir );
 
   ClassDef(RooStats::HistFactory::Measurement, 3);
 
 };
- 
+
 } // namespace HistFactory
 } // namespace RooStats
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -13,6 +13,10 @@
 #define ROO_PARAMHISTFUNC
 
 #include <map>
+#include <vector>
+#include <list>
+#include <string>
+
 #include "RooAbsReal.h"
 #include "RooRealProxy.h"
 #include "RooListProxy.h"

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -21,9 +21,11 @@
 #include "RooListProxy.h"
 
 #include "RooObjCacheManager.h"
+#include <vector>
+#include <list>
 
 class RooRealVar;
-class RooArgList ;
+class RooArgList;
 
 class PiecewiseInterpolation : public RooAbsReal {
 public:

--- a/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
@@ -17,6 +17,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 class RooMinuit ;
 

--- a/roofit/histfactory/src/Helper.h
+++ b/roofit/histfactory/src/Helper.h
@@ -13,7 +13,7 @@
 
 #include <string>
 #include <vector>
-
+#include <map>
 #include "TFile.h"
 
 #include "RooStats/HistFactory/EstimateSummary.h"

--- a/roofit/roofit/inc/RooBernstein.h
+++ b/roofit/roofit/inc/RooBernstein.h
@@ -18,9 +18,10 @@
 #include "RooRealVar.h"
 #include "RooListProxy.h"
 #include "RooAbsRealLValue.h"
+#include <string>
 
 class RooRealVar;
-class RooArgList ;
+class RooArgList;
 
 class RooBernstein : public RooAbsPdf {
 public:

--- a/roofit/roofit/inc/RooChi2MCSModule.h
+++ b/roofit/roofit/inc/RooChi2MCSModule.h
@@ -18,7 +18,6 @@
 #define ROO_CHI2_MCS_MODULE
 
 #include "RooAbsMCStudyModule.h"
-#include <string>
 
 class RooChi2MCSModule : public RooAbsMCStudyModule {
 public:

--- a/roofit/roofit/inc/RooFunctor1DBinding.h
+++ b/roofit/roofit/inc/RooFunctor1DBinding.h
@@ -13,14 +13,12 @@
 #ifndef ROOFUNCTOR1DBINDING
 #define ROOFUNCTOR1DBINDING
 
-#include "TString.h"
 #include "RooAbsReal.h"
 #include "RooArgList.h"
 #include "RooListProxy.h"
 #include "RooAbsPdf.h"
 #include "RooRealProxy.h"
 #include "RooMsgService.h"
-#include <string>
 #include "Math/IFunction.h"
 
 

--- a/roofit/roofit/inc/RooFunctorBinding.h
+++ b/roofit/roofit/inc/RooFunctorBinding.h
@@ -13,14 +13,12 @@
 #ifndef ROOFUNCTORBINDING
 #define ROOFUNCTORBINDING
 
-#include "TString.h"
 #include "RooAbsReal.h"
 #include "RooArgList.h"
 #include "RooListProxy.h"
 #include "RooAbsPdf.h"
 #include "RooRealProxy.h"
 #include "RooMsgService.h"
-#include <string>
 #include "Math/IFunction.h"
 
 namespace RooFit {

--- a/roofit/roofit/inc/RooIntegralMorph.h
+++ b/roofit/roofit/inc/RooIntegralMorph.h
@@ -17,9 +17,11 @@
 #include "RooCategoryProxy.h"
 #include "RooAbsReal.h"
 #include "RooAbsCategory.h"
-class RooBrentRootFinder ;
+#include <vector>
 
-class TH1D ;
+class RooBrentRootFinder;
+
+class TH1D;
 
 class RooIntegralMorph : public RooAbsCachedPdf {
 public:

--- a/roofit/roofit/inc/RooMomentMorph.h
+++ b/roofit/roofit/inc/RooMomentMorph.h
@@ -19,8 +19,6 @@
 #include "TMatrixD.h"
 #include "TVectorD.h"
 
-#include <string>
-
 class RooChangeTracker;
 
 class RooMomentMorph : public RooAbsPdf {

--- a/roofit/roofit/inc/RooMomentMorphFunc.h
+++ b/roofit/roofit/inc/RooMomentMorphFunc.h
@@ -19,8 +19,8 @@
 #include "TMatrixD.h"
 #include "TVectorD.h"
 
-#include <vector>
-#include <string>
+#include <list>
+
 class RooChangeTracker;
 
 class RooMomentMorphFunc : public RooAbsReal {

--- a/roofit/roofit/inc/RooMultiBinomial.h
+++ b/roofit/roofit/inc/RooMultiBinomial.h
@@ -17,15 +17,14 @@
 
 #include "RooAbsReal.h"
 #include "RooListProxy.h"
-#include "TString.h" 
 
-class RooArgList ;
+class RooArgList;
 
 
 class RooMultiBinomial : public RooAbsReal {
  public:
   // Constructors, assignment etc
-  inline RooMultiBinomial() { 
+  inline RooMultiBinomial() {
   }
 
   RooMultiBinomial(const char *name, const char *title, const RooArgList& effFuncList, const RooArgList& catList, Bool_t ignoreNonVisible);

--- a/roofit/roofit/inc/RooParamHistFunc.h
+++ b/roofit/roofit/inc/RooParamHistFunc.h
@@ -15,6 +15,7 @@
 #include "RooListProxy.h"
 #include "RooSetProxy.h"
 #include "RooDataHist.h"
+#include <list>
 
 class RooParamHistFunc : public RooAbsReal {
 public:

--- a/roofit/roofitcore/inc/BatchData.h
+++ b/roofit/roofitcore/inc/BatchData.h
@@ -20,7 +20,9 @@
 #include "RooSpan.h"
 #include <map>
 #include <tuple>
-#include <assert.h>
+#include <cassert>
+#include <vector>
+#include <string>
 
 class RooArgSet;
 

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -28,7 +28,7 @@
 #include <set>
 #include <deque>
 #include <stack>
-
+#include <string>
 #include <iostream>
 
 #ifndef R__LESS_INCLUDES

--- a/roofit/roofitcore/inc/RooAbsCategory.h
+++ b/roofit/roofitcore/inc/RooAbsCategory.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <map>
 #include <functional>
+#include <vector>
 
 #ifdef R__LESS_INCLUDES
 class RooCatType;

--- a/roofit/roofitcore/inc/RooAbsCategoryLValue.h
+++ b/roofit/roofitcore/inc/RooAbsCategoryLValue.h
@@ -18,6 +18,9 @@
 
 #include "RooAbsCategory.h"
 #include "RooAbsLValue.h"
+#include <list>
+#include <string>
+#include <utility>
 
 class RooAbsCategoryLValue : public RooAbsCategory, public RooAbsLValue {
 public:

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -23,6 +23,7 @@
 #include "RooLinkedListIter.h"
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 class RooCmdArg;
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -21,6 +21,8 @@
 #include "RooArgSet.h"
 #include "RooArgList.h"
 #include "RooSpan.h"
+#include <map>
+#include <string>
 
 class RooAbsArg;
 class RooAbsReal ;

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -17,11 +17,11 @@
 #define ROO_ABS_DATA_STORE
 
 #include "Rtypes.h"
-#include "RooArgSet.h" 
+#include "RooArgSet.h"
 #include "RooAbsData.h"
 #include "TNamed.h"
 #include <list>
-
+#include <vector>
 
 class RooAbsArg ;
 class RooArgList ;

--- a/roofit/roofitcore/inc/RooAbsProxy.h
+++ b/roofit/roofitcore/inc/RooAbsProxy.h
@@ -16,7 +16,6 @@
 #ifndef ROO_ABS_PROXY
 #define ROO_ABS_PROXY
 
-#include "TObject.h"
 #include "RooAbsArg.h"
 
 #ifdef _WIN32

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -24,6 +24,7 @@
 #include "RooGlobalFunc.h"
 #include "RooSpan.h"
 #include "BatchData.h"
+#include <map>
 
 class RooArgList ;
 class RooDataSet ;

--- a/roofit/roofitcore/inc/RooAbsRealLValue.h
+++ b/roofit/roofitcore/inc/RooAbsRealLValue.h
@@ -17,7 +17,8 @@
 #define ROO_ABS_REAL_LVALUE
 
 #include <cmath>
-#include <float.h>
+#include <cfloat>
+#include <utility>
 #include "TString.h"
 
 #include "RooAbsReal.h"

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -21,6 +21,7 @@
 #include "RooRealProxy.h"
 #include "TStopwatch.h"
 #include <string>
+#include <vector>
 
 class RooArgSet ;
 class RooAbsData ;

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -25,6 +25,9 @@
 #include "RooCacheManager.h"
 #include "RooObjCacheManager.h"
 #include "RooNameReg.h"
+#include <vector>
+#include <list>
+#include <utility>
 
 class RooAddPdf : public RooAbsPdf {
 public:

--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -19,6 +19,7 @@
 #include "RooAbsReal.h"
 #include "RooListProxy.h"
 #include "RooObjCacheManager.h"
+#include <list>
 
 class RooRealVar;
 class RooArgList ;

--- a/roofit/roofitcore/inc/RooBinIntegrator.h
+++ b/roofit/roofitcore/inc/RooBinIntegrator.h
@@ -19,6 +19,7 @@
 #include "RooAbsIntegrator.h"
 #include "RooNumIntConfig.h"
 #include <vector>
+#include <list>
 
 class RooBinIntegrator : public RooAbsIntegrator {
 public:

--- a/roofit/roofitcore/inc/RooCategory.h
+++ b/roofit/roofitcore/inc/RooCategory.h
@@ -18,6 +18,10 @@
 
 #include "RooAbsCategoryLValue.h"
 
+#include <vector>
+#include <map>
+#include <string>
+
 class RooCategorySharedProperties;
 
 class RooCategory final : public RooAbsCategoryLValue {

--- a/roofit/roofitcore/inc/RooClassFactory.h
+++ b/roofit/roofitcore/inc/RooClassFactory.h
@@ -22,8 +22,11 @@
 #include "RooPrintable.h"
 #include "RooFactoryWSTool.h"
 
-class RooAbsReal ;
-class RooAbsPdf ;
+#include <vector>
+#include <string>
+
+class RooAbsReal;
+class RooAbsPdf;
 
 class RooClassFactory : public TNamed, public RooPrintable {
 

--- a/roofit/roofitcore/inc/RooCmdArg.h
+++ b/roofit/roofitcore/inc/RooCmdArg.h
@@ -18,10 +18,9 @@
 #define ROO_CMD_ARG
 
 #include "TNamed.h"
-#include "TString.h"
 #include "RooLinkedList.h"
-
 #include <string>
+
 class RooAbsData ;
 class RooArgSet ;
 

--- a/roofit/roofitcore/inc/RooCmdConfig.h
+++ b/roofit/roofitcore/inc/RooCmdConfig.h
@@ -22,7 +22,7 @@
 #include "TList.h"
 #include "RooCmdArg.h"
 #include "RooArgSet.h"
-
+#include <string>
 
 class RooCmdConfig : public TObject {
 public:

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -16,9 +16,12 @@
 #ifndef ROO_COMPOSITE_DATA_STORE
 #define ROO_COMPOSITE_DATA_STORE
 
-#include "RooAbsDataStore.h" 
+#include "RooAbsDataStore.h"
+
 #include <map>
 #include <string>
+#include <vector>
+#include <list>
 
 class RooAbsArg ;
 class RooArgList ;

--- a/roofit/roofitcore/inc/RooCustomizer.h
+++ b/roofit/roofitcore/inc/RooCustomizer.h
@@ -17,14 +17,17 @@
 #ifndef ROO_PDF_CUSTOMIZER
 #define ROO_PDF_CUSTOMIZER
 
-#include "Rtypes.h"
 #include "TList.h"
 #include "TNamed.h"
 #include "TString.h"
 #include "RooArgSet.h"
 #include "RooPrintable.h"
 #include "RooFactoryWSTool.h"
-class RooAbsCategoryLValue ; 
+
+#include <vector>
+#include <string>
+
+class RooAbsCategoryLValue ;
 class RooAbsCategory ;
 class RooAbsArg ;
 class RooAbsPdf ;

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -25,7 +25,6 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <utility>
 
 class TObject ;
 class RooAbsArg;

--- a/roofit/roofitcore/inc/RooErrorHandler.h
+++ b/roofit/roofitcore/inc/RooErrorHandler.h
@@ -17,7 +17,8 @@
 #define ROO_ERROR_HANDLER
 
 #include <signal.h>
-#include "Rtypes.h"
+#include <cstdlib>
+#include "RtypesCore.h"
 
 class RooErrorHandler
 {

--- a/roofit/roofitcore/inc/RooErrorVar.h
+++ b/roofit/roofitcore/inc/RooErrorVar.h
@@ -19,12 +19,16 @@
 #include "RooAbsReal.h"
 #include "RooRealVar.h"
 #include "RooRealProxy.h"
-class RooVectorDataStore ;
+
+#include <list>
+#include <string>
+
+class RooVectorDataStore;
 
 class RooErrorVar : public RooAbsRealLValue {
 public:
   // Constructors, assignment etc.
-  inline RooErrorVar() { 
+  inline RooErrorVar() {
     // Default constructor
   }
   RooErrorVar(const char *name, const char *title, const RooRealVar& input) ;

--- a/roofit/roofitcore/inc/RooFFTConvPdf.h
+++ b/roofit/roofitcore/inc/RooFFTConvPdf.h
@@ -107,7 +107,7 @@ protected:
   virtual PdfCacheElem* createCache(const RooArgSet* nset) const ;
   virtual TString histNameSuffix() const ;
 
-  // mutable std::map<const RooHistPdf*,CacheAuxInfo*> _cacheAuxInfo ; //! Auxilary Cache information (do not persist)
+  // mutable std:: map<const RooHistPdf*,CacheAuxInfo*> _cacheAuxInfo ; //! Auxilary Cache information (do not persist)
   Double_t _bufFrac ; // Sampling buffer size as fraction of domain size 
   BufStrat _bufStrat ; // Strategy to fill the buffer
 

--- a/roofit/roofitcore/inc/RooFactoryWSTool.h
+++ b/roofit/roofitcore/inc/RooFactoryWSTool.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 #include <stack>
+#include <map>
 
 class RooAbsReal ;
 class RooAbsRealLValue ;

--- a/roofit/roofitcore/inc/RooFitResult.h
+++ b/roofit/roofitcore/inc/RooFitResult.h
@@ -28,7 +28,7 @@
 
 #include <vector>
 #include <string>
-
+#include <utility>
 
 class RooArgSet ;
 class RooAbsPdf ;

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -23,6 +23,7 @@
 #include "RooTrace.h"
 
 #include <memory>
+#include <list>
 
 class RooArgSet ;
 

--- a/roofit/roofitcore/inc/RooGenFitStudy.h
+++ b/roofit/roofitcore/inc/RooGenFitStudy.h
@@ -30,7 +30,7 @@ class RooAbsGenContext ;
 #include "RooArgSet.h"
 #include "RooLinkedList.h"
 #include "RooAbsPdf.h"
-
+#include <string>
 
 class RooGenFitStudy : public RooAbsStudy {
 public:

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -22,6 +22,8 @@
 #include "RooAbsReal.h"
 
 #include <sstream>
+#include <vector>
+#include <string>
 
 namespace RooHelpers {
 

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -21,6 +21,7 @@
 #include "RooSetProxy.h"
 #include "RooAICRegistry.h"
 #include "RooTrace.h"
+#include <list>
 
 class RooRealVar;
 class RooAbsReal;
@@ -28,7 +29,7 @@ class RooDataHist ;
 
 class RooHistFunc : public RooAbsReal {
 public:
-  RooHistFunc() ; 
+  RooHistFunc() ;
   RooHistFunc(const char *name, const char *title, const RooArgSet& vars, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistFunc(const char *name, const char *title, const RooArgList& funcObs, const RooArgList& histObs, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistFunc(const RooHistFunc& other, const char* name=0);

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -20,6 +20,7 @@
 #include "RooRealProxy.h"
 #include "RooSetProxy.h"
 #include "RooAICRegistry.h"
+#include <list>
 
 class RooRealVar;
 class RooAbsReal;
@@ -27,7 +28,7 @@ class RooDataHist ;
 
 class RooHistPdf : public RooAbsPdf {
 public:
-  RooHistPdf() ; 
+  RooHistPdf() ;
   RooHistPdf(const char *name, const char *title, const RooArgSet& vars, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistPdf(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistPdf(const RooHistPdf& other, const char* name=0);

--- a/roofit/roofitcore/inc/RooLinearVar.h
+++ b/roofit/roofitcore/inc/RooLinearVar.h
@@ -17,8 +17,9 @@
 #define ROO_LINEAR_VAR
 
 #include <cmath>
-#include <float.h>
-#include "TString.h"
+#include <cfloat>
+#include <string>
+#include <list>
 #include "RooAbsRealLValue.h"
 #include "RooRealProxy.h"
 #include "RooFormula.h"

--- a/roofit/roofitcore/inc/RooLinkedList.h
+++ b/roofit/roofitcore/inc/RooLinkedList.h
@@ -18,7 +18,7 @@
 
 #include <vector>
 
-#include "TNamed.h"
+#include "TObject.h"
 #include "RooLinkedListElem.h"
 #include "RooHashTable.h"
 

--- a/roofit/roofitcore/inc/RooListProxy.h
+++ b/roofit/roofitcore/inc/RooListProxy.h
@@ -16,7 +16,6 @@
 #ifndef ROO_LIST_PROXY
 #define ROO_LIST_PROXY
 
-#include "TObject.h"
 #include "RooAbsProxy.h"
 #include "RooLinkedListIter.h"
 #include "RooAbsArg.h"

--- a/roofit/roofitcore/inc/RooMath.h
+++ b/roofit/roofitcore/inc/RooMath.h
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <complex>
 
-#include "Rtypes.h"
 #include "TMath.h"
 
 typedef Double_t* pDouble_t;

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -21,8 +21,10 @@
 #include "TObject.h"
 #include "TStopwatch.h"
 #include <fstream>
+#include <vector>
+#include <string>
+#include <utility>
 #include "TMatrixDSymfwd.h"
-
 
 #include "Fit/Fitter.h"
 #include "RooMinimizerFcn.h"

--- a/roofit/roofitcore/inc/RooMinimizerFcn.h
+++ b/roofit/roofitcore/inc/RooMinimizerFcn.h
@@ -27,6 +27,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <vector>
 
 class RooMinimizer;
 

--- a/roofit/roofitcore/inc/RooMinuit.h
+++ b/roofit/roofitcore/inc/RooMinuit.h
@@ -22,6 +22,7 @@
 #include "TMatrixDSymfwd.h"
 #include <vector>
 #include <string>
+#include <utility>
 
 class RooAbsReal ;
 class RooFitResult ;

--- a/roofit/roofitcore/inc/RooMultiCategory.h
+++ b/roofit/roofitcore/inc/RooMultiCategory.h
@@ -16,13 +16,14 @@
 #ifndef ROO_MULTI_CATEGORY
 #define ROO_MULTI_CATEGORY
 
-class TObject ;
+class TObject;
 #include "RooAbsCategoryLValue.h"
 #include "RooArgSet.h"
 #include "RooSetProxy.h"
+#include <string>
 
 class RooSuperCategory;
- 
+
 
 class RooMultiCategory : public RooAbsCategory {
 public:

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -20,6 +20,7 @@
 #include "RooCmdArg.h"
 #include "RooAbsPdf.h"
 #include <vector>
+#include <utility>
 
 class RooRealSumPdf ;
 

--- a/roofit/roofitcore/inc/RooNameReg.h
+++ b/roofit/roofitcore/inc/RooNameReg.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <string>
 
 class RooNameReg : public TNamed {
 public:

--- a/roofit/roofitcore/inc/RooNameSet.h
+++ b/roofit/roofitcore/inc/RooNameSet.h
@@ -16,10 +16,10 @@
 #ifndef ROO_NAME_SET
 #define ROO_NAME_SET
 
-#include "TString.h"
 #include "TObject.h"
 #include "RooPrintable.h"
-class RooArgSet ;
+
+class RooArgSet;
 
 class RooNameSet : public TObject, public RooPrintable {
 public:

--- a/roofit/roofitcore/inc/RooNormSetCache.h
+++ b/roofit/roofitcore/inc/RooNormSetCache.h
@@ -16,7 +16,6 @@
 #ifndef ROO_NORMSET_CACHE
 #define ROO_NORMSET_CACHE
 
-#include <utility>
 #include <vector>
 #include <map>
 

--- a/roofit/roofitcore/inc/RooNumRunningInt.h
+++ b/roofit/roofitcore/inc/RooNumRunningInt.h
@@ -15,7 +15,7 @@
 #include "RooAbsCachedReal.h"
 #include "RooRealProxy.h"
 #include "RooAbsReal.h"
-
+#include <string>
 
 class RooNumRunningInt : public RooAbsCachedReal {
 public:

--- a/roofit/roofitcore/inc/RooProdGenContext.h
+++ b/roofit/roofitcore/inc/RooProdGenContext.h
@@ -18,6 +18,7 @@
 
 #include "RooAbsGenContext.h"
 #include "RooArgSet.h"
+#include <list>
 
 class RooProdPdf;
 class RooDataSet;

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -24,6 +24,8 @@
 #include "RooObjCacheManager.h"
 #include "RooCmdArg.h"
 #include <vector>
+#include <list>
+#include <string>
 
 typedef RooArgList* pRooArgList ;
 typedef RooLinkedList* pRooLinkedList ;

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -21,7 +21,7 @@
 #include "RooCacheManager.h"
 #include "RooObjCacheManager.h"
 
-#include <utility>
+#include <list>
 
 class RooRealVar;
 class RooArgList;

--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -22,6 +22,7 @@
 #include "RooRealProxy.h"
 #include "RooSetProxy.h"
 #include "RooListProxy.h"
+#include <list>
 
 class RooArgSet ;
 class TH1F ;

--- a/roofit/roofitcore/inc/RooRealSumFunc.h
+++ b/roofit/roofitcore/inc/RooRealSumFunc.h
@@ -20,6 +20,7 @@
 #include "RooListProxy.h"
 #include "RooAICRegistry.h"
 #include "RooObjCacheManager.h"
+#include <list>
 
 class RooRealSumFunc : public RooAbsReal {
 public:

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -20,6 +20,7 @@
 #include "RooListProxy.h"
 #include "RooAICRegistry.h"
 #include "RooObjCacheManager.h"
+#include <list>
 
 class RooRealSumPdf : public RooAbsPdf {
 public:

--- a/roofit/roofitcore/inc/RooRealVarSharedProperties.h
+++ b/roofit/roofitcore/inc/RooRealVarSharedProperties.h
@@ -16,7 +16,6 @@
 #ifndef ROO_REAL_VAR_SHARED_PROPERTY
 #define ROO_REAL_VAR_SHARED_PROPERTY
 
-#include "TObject.h"
 #include "RooSharedProperties.h"
 #include "RooLinkedList.h"
 

--- a/roofit/roofitcore/inc/RooSTLRefCountList.h
+++ b/roofit/roofitcore/inc/RooSTLRefCountList.h
@@ -15,11 +15,13 @@
 
 #ifndef ROOFIT_ROOFITCORE_INC_ROOSTLREFCOUNTLIST_H_
 #define ROOFIT_ROOFITCORE_INC_ROOSTLREFCOUNTLIST_H_
+
 #include "Rtypes.h"
 
 #include <vector>
+#include <string>
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 
 
 /**

--- a/roofit/roofitcore/inc/RooScaledFunc.h
+++ b/roofit/roofitcore/inc/RooScaledFunc.h
@@ -17,6 +17,7 @@
 #define ROO_SCALED_FUNC
 
 #include "RooAbsFunc.h"
+#include <list>
 
 class RooScaledFunc : public RooAbsFunc {
 public:

--- a/roofit/roofitcore/inc/RooSentinel.h
+++ b/roofit/roofitcore/inc/RooSentinel.h
@@ -16,7 +16,7 @@
 #ifndef ROO_SENTINEL
 #define ROO_SENTINEL
 
-#include "Rtypes.h"
+#include "RtypesCore.h"
 
 class RooSentinel {
 public:

--- a/roofit/roofitcore/inc/RooSetProxy.h
+++ b/roofit/roofitcore/inc/RooSetProxy.h
@@ -16,7 +16,6 @@
 #ifndef ROO_SET_PROXY
 #define ROO_SET_PROXY
 
-#include "TObject.h"
 #include "RooAbsProxy.h"
 #include "RooAbsArg.h"
 #include "RooArgSet.h"

--- a/roofit/roofitcore/inc/RooSimWSTool.h
+++ b/roofit/roofitcore/inc/RooSimWSTool.h
@@ -24,13 +24,14 @@
 #include <list>
 #include <map>
 #include <string>
+#include <vector>
 
-class RooAbsCategoryLValue ; 
-class RooAbsCategory ;
-class RooAbsArg ;
-class RooAbsPdf ;
-class RooCatType ;
-class RooSimultaneous ;
+class RooAbsCategoryLValue;
+class RooAbsCategory;
+class RooAbsArg;
+class RooAbsPdf;
+class RooCatType;
+class RooSimultaneous;
 
 
 class RooSimWSTool : public TNamed, public RooPrintable {

--- a/roofit/roofitcore/inc/RooSpan.h
+++ b/roofit/roofitcore/inc/RooSpan.h
@@ -18,6 +18,7 @@
 #define ROOFIT_ROOFITCORE_INC_ROOSPAN_H_
 
 #include "ROOT/RSpan.hxx"
+#include <vector>
 
 ////////////////////////////////////////////////////////////////////////////
 /// A simple container to hold a batch of data values.

--- a/roofit/roofitcore/inc/RooTemplateProxy.h
+++ b/roofit/roofitcore/inc/RooTemplateProxy.h
@@ -21,6 +21,7 @@
 #include "RooAbsRealLValue.h"
 #include "RooAbsCategory.h"
 #include "RooMsgService.h"
+#include <string>
 
 /**
 \class RooTemplateProxy

--- a/roofit/roofitcore/inc/RooTrace.h
+++ b/roofit/roofitcore/inc/RooTrace.h
@@ -18,9 +18,10 @@
 
 #include "RooLinkedList.h"
 #include <map>
+#include <string>
 
 #define TRACE_CREATE
-#define TRACE_DESTROY 
+#define TRACE_DESTROY
 
 class RooTrace {
 public:

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -16,8 +16,10 @@
 #ifndef ROO_TREE_DATA_STORE
 #define ROO_TREE_DATA_STORE
 
-#include "RooAbsDataStore.h" 
-#include "TString.h"
+#include "RooAbsDataStore.h"
+#include <vector>
+#include <list>
+#include <string>
 
 class RooAbsArg ;
 class RooArgList ;

--- a/roofit/roofitcore/inc/RooUnitTest.h
+++ b/roofit/roofitcore/inc/RooUnitTest.h
@@ -24,6 +24,7 @@
 #include "TH1.h"
 #include <list>
 #include <string>
+#include <utility>
 
 /*
  * The tolerance for the curve test is put to 0.4 instead of 0.2 to take into

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -18,10 +18,8 @@
 
 #include <list>
 #include <vector>
-#include <string>
 #include <algorithm>
-#include "RooAbsDataStore.h" 
-#include "TString.h"
+#include "RooAbsDataStore.h"
 #include "RooAbsCategory.h"
 #include "RooAbsReal.h"
 #include "RooChangeTracker.h"

--- a/roofit/roofitcore/inc/RooWrapperPdf.h
+++ b/roofit/roofitcore/inc/RooWrapperPdf.h
@@ -19,6 +19,7 @@
 #include "RooAbsReal.h"
 #include "RooRealProxy.h"
 #include "RooAbsPdf.h"
+#include <list>
 
 class RooWrapperPdf final : public RooAbsPdf {
 public:

--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -26,6 +26,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <set>
 
 template <class RooSet_t, std::size_t POOLSIZE>
 class MemPoolForRooSets {

--- a/roofit/roofitcore/src/RooFitLegacy/RooAbsCategoryLegacyIterator.h
+++ b/roofit/roofitcore/src/RooFitLegacy/RooAbsCategoryLegacyIterator.h
@@ -20,6 +20,8 @@
 #include "TIterator.h"
 #include "RooAbsCategory.h"
 #include <map>
+#include <vector>
+#include <string>
 
 #include "RooFitLegacy/RooCatTypeLegacy.h"
 

--- a/roofit/roostats/inc/RooStats/HybridResult.h
+++ b/roofit/roostats/inc/RooStats/HybridResult.h
@@ -18,6 +18,8 @@
 
 #include "RooStats/HypoTestResult.h"
 
+#include <vector>
+
 namespace RooStats {
 
    class HybridPlot;

--- a/roofit/roostats/inc/RooStats/HypoTestCalculator.h
+++ b/roofit/roostats/inc/RooStats/HypoTestCalculator.h
@@ -11,13 +11,7 @@
 #ifndef ROOSTATS_HypoTestCalculator
 #define ROOSTATS_HypoTestCalculator
 
-//#include "TNamed.h"
-
 #include "Rtypes.h"
-
-
-
-//
 
 // class RooAbsPdf;
 class RooAbsData;

--- a/roofit/roostats/inc/RooStats/HypoTestInverter.h
+++ b/roofit/roostats/inc/RooStats/HypoTestInverter.h
@@ -21,7 +21,7 @@ class RooRealVar;
 class TGraphErrors;
 
 #include <memory>
-
+#include <string>
 
 namespace RooStats {
 

--- a/roofit/roostats/inc/RooStats/HypoTestInverterResult.h
+++ b/roofit/roostats/inc/RooStats/HypoTestInverterResult.h
@@ -11,11 +11,11 @@
 #ifndef ROOSTATS_HypoTestInverterResult
 #define ROOSTATS_HypoTestInverterResult
 
-
-
 #include "RooStats/SimpleInterval.h"
 
 #include "RooStats/HypoTestResult.h"
+
+#include <vector>
 
 class RooRealVar;
 

--- a/roofit/roostats/inc/RooStats/IntervalCalculator.h
+++ b/roofit/roostats/inc/RooStats/IntervalCalculator.h
@@ -11,11 +11,7 @@
 #ifndef ROOSTATS_IntervalCalculator
 #define ROOSTATS_IntervalCalculator
 
-
-
 #include "Rtypes.h"
-
-//#include "TNamed.h"
 
 class RooAbsData;
 class RooWorkspace;

--- a/roofit/roostats/inc/RooStats/LikelihoodInterval.h
+++ b/roofit/roostats/inc/RooStats/LikelihoodInterval.h
@@ -21,6 +21,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 
 namespace ROOT {
    namespace Math {

--- a/roofit/roostats/inc/RooStats/MCMCCalculator.h
+++ b/roofit/roostats/inc/RooStats/MCMCCalculator.h
@@ -14,7 +14,7 @@
 
 #include "Rtypes.h"
 
-#include "TObject.h"
+#include "TNamed.h"
 #include "RooAbsPdf.h"
 #include "RooAbsData.h"
 #include "RooArgSet.h"

--- a/roofit/roostats/inc/RooStats/MCMCInterval.h
+++ b/roofit/roostats/inc/RooStats/MCMCInterval.h
@@ -19,6 +19,8 @@
 #include "RooArgList.h"
 #include "RooStats/MarkovChain.h"
 
+#include <vector>
+
 class RooNDKeysPdf;
 class RooProduct;
 

--- a/roofit/roostats/inc/RooStats/NeymanConstruction.h
+++ b/roofit/roostats/inc/RooStats/NeymanConstruction.h
@@ -25,6 +25,8 @@
 #include "RooAbsPdf.h"
 #include "RooArgSet.h"
 
+#include <map>
+
 class RooAbsData;
 
 namespace RooStats {

--- a/roofit/roostats/inc/RooStats/NumberCountingUtils.h
+++ b/roofit/roostats/inc/RooStats/NumberCountingUtils.h
@@ -77,7 +77,7 @@ END_HTML
 */
 //
 
-#include "Rtypes.h"
+#include "RtypesCore.h"
 
 
 namespace RooStats{

--- a/roofit/roostats/inc/RooStats/SamplingDistPlot.h
+++ b/roofit/roostats/inc/RooStats/SamplingDistPlot.h
@@ -20,6 +20,7 @@
 #include "TH1F.h"
 #include "TF1.h"
 #include "TLegend.h"
+#include <vector>
 
 #include "RooStats/SamplingDistribution.h"
 

--- a/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
@@ -13,6 +13,7 @@
 #define ROOSTATS_ToyMCImportanceSampler
 
 #include "RooStats/ToyMCSampler.h"
+#include <vector>
 
 namespace RooStats {
 

--- a/roofit/roostats/inc/RooStats/ToyMCSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCSampler.h
@@ -17,6 +17,8 @@
 #include "Rtypes.h"
 
 #include <vector>
+#include <list>
+#include <string>
 #include <sstream>
 
 #include "RooStats/TestStatSampler.h"


### PR DESCRIPTION
Provide standard includes like `<vector>` or `<map>` when correspondent class is used.
In rare cases remove such standard includes if they are not used
Remove/replace unused includes like TObject.h, TNamed.h, TString.h