### PR TITLE
Optimize tree/io includes

### DIFF
--- a/io/io/inc/TBufferFile.h
+++ b/io/io/inc/TBufferFile.h
@@ -26,6 +26,7 @@
 #include "Bytes.h"
 
 #include <vector>
+#include <string>
 
 #ifdef R__OLDHPACC
 namespace std {

--- a/io/io/inc/TBufferText.h
+++ b/io/io/inc/TBufferText.h
@@ -13,7 +13,6 @@
 #define ROOT_TBufferText
 
 #include "TBufferIO.h"
-#include "TString.h"
 
 class TStreamerBase;
 class TExMap;

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -13,6 +13,8 @@
 
 #include "TGenCollectionProxy.h"
 
+#include <vector>
+
 class TEmulatedCollectionProxy : public TGenCollectionProxy  {
 
    // Friend declaration

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -22,6 +22,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include <atomic>
+#include <string>
 
 #include "Compression.h"
 #include "TDirectoryFile.h"

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -16,6 +16,7 @@
 #include "TList.h"
 #include "TString.h"
 #include "TStopwatch.h"
+#include <string>
 
 class TFile;
 class TDirectory;

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -20,7 +20,8 @@
 #include <atomic>
 #include <string>
 #include <map>
-#include <stdlib.h>
+#include <cstdlib>
+#include <vector>
 
 class TObjArray;
 class TCollectionProxyFactory;

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -13,6 +13,7 @@
 #define ROOT_TStreamerInfo
 
 #include <atomic>
+#include <vector>
 
 #include "TVirtualStreamerInfo.h"
 

--- a/io/io/inc/TVirtualCollectionIterators.h
+++ b/io/io/inc/TVirtualCollectionIterators.h
@@ -20,6 +20,7 @@ Small helper class to generically acquire and release iterators.
 
 #include "TVirtualCollectionProxy.h"
 #include "TError.h"
+#include <vector>
 
 class TVirtualCollectionIterators
 {

--- a/io/sql/inc/TBufferSQL2.h
+++ b/io/sql/inc/TBufferSQL2.h
@@ -6,6 +6,7 @@
 
 #include "TBufferText.h"
 #include "TString.h"
+#include <string>
 
 class TMap;
 class TExMap;

--- a/io/xml/inc/TXMLSetup.h
+++ b/io/xml/inc/TXMLSetup.h
@@ -12,7 +12,7 @@
 #ifndef ROOT_TXMLSetup
 #define ROOT_TXMLSetup
 
-#include "TObject.h"
+#include "Rtypes.h"
 #include "TString.h"
 
 #ifdef Bool

--- a/io/xmlparser/inc/TXMLDocument.h
+++ b/io/xmlparser/inc/TXMLDocument.h
@@ -14,9 +14,6 @@
 
 #include "TObject.h"
 
-#include "TString.h"
-
-
 struct _xmlDoc;
 class TXMLNode;
 
@@ -24,8 +21,8 @@ class TXMLNode;
 class TXMLDocument : public TObject {
 
 private:
-   TXMLDocument(const TXMLDocument&);            // Not implemented
-   TXMLDocument& operator=(const TXMLDocument&); // Not implemented
+   TXMLDocument(const TXMLDocument&) = delete;
+   TXMLDocument& operator=(const TXMLDocument&) = delete;
 
    _xmlDoc  *fXMLDoc;           // libxml xml doc
    TXMLNode *fRootNode;         // the root node

--- a/io/xmlparser/inc/TXMLNode.h
+++ b/io/xmlparser/inc/TXMLNode.h
@@ -14,16 +14,14 @@
 
 #include "TObject.h"
 
-#include "TString.h"
-
 class TList;
 struct _xmlNode;
 
 class TXMLNode : public TObject {
 
 private:
-   TXMLNode(const TXMLNode&);            // Not implemented
-   TXMLNode& operator=(const TXMLNode&); // Not implemented
+   TXMLNode(const TXMLNode&) = delete;
+   TXMLNode& operator=(const TXMLNode&) = delete;
 
    _xmlNode *fXMLNode;        ///< libxml node
 

--- a/io/xmlparser/inc/TXMLParser.h
+++ b/io/xmlparser/inc/TXMLParser.h
@@ -24,8 +24,8 @@ struct   _xmlParserCtxt;
 class TXMLParser : public TObject, public TQObject {
 
 private:
-   TXMLParser(const TXMLParser&);            // Not implemented
-   TXMLParser& operator=(const TXMLParser&); // Not implemented
+   TXMLParser(const TXMLParser&) = delete;
+   TXMLParser& operator=(const TXMLParser&) = delete;
 
 protected:
    _xmlParserCtxt     *fContext;          ///< Parse the xml file

--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -18,6 +18,7 @@
 #include <list>
 #include <map>
 #include <vector>
+#include <fstream>
 
 #include <TRegexp.h>
 

--- a/tree/tree/inc/TBranchSTL.h
+++ b/tree/tree/inc/TBranchSTL.h
@@ -13,7 +13,6 @@
 
 #include <map>
 #include <vector>
-#include <utility>
 
 class TTree;
 class TVirtualCollectionProxy;

--- a/tree/tree/inc/TBufferSQL.h
+++ b/tree/tree/inc/TBufferSQL.h
@@ -22,6 +22,9 @@
 
 #include "TBufferFile.h"
 
+#include <vector>
+#include <string>
+
 class TSQLRow;
 
 class TBufferSQL final : public TBufferFile {

--- a/tree/tree/inc/TIndArray.h
+++ b/tree/tree/inc/TIndArray.h
@@ -8,14 +8,14 @@
 #ifndef ROOT_TIndArray
 #define ROOT_TIndArray
 
-#include "Rtypes.h"
+#include "RtypesCore.h"
 
 
 class TIndArray
 {
    public:
       TIndArray():
-         fElems( 0 ), fCapacity( 0 ), fArr( 0 ) {};
+         fElems( 0 ), fCapacity( 0 ), fArr( nullptr ) {};
 
       virtual ~TIndArray()
       {

--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -43,6 +43,8 @@
 
 #include "TNamed.h"
 
+#include <vector>
+
 #ifdef R__LESS_INCLUDES
 class TBranch;
 #else

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -50,7 +50,8 @@ class TList;
 
 #include <array>
 #include <atomic>
-
+#include <vector>
+#include <utility>
 
 class TBuffer;
 class TBrowser;

--- a/tree/tree/inc/TreeUtils.h
+++ b/tree/tree/inc/TreeUtils.h
@@ -24,7 +24,7 @@
 
 #include <iosfwd>
 
-#include "Rtypes.h"
+#include "RtypesCore.h"
 
 namespace ROOT {
 namespace TreeUtils {

--- a/tree/tree/src/TBranchIMTHelper.h
+++ b/tree/tree/src/TBranchIMTHelper.h
@@ -12,7 +12,7 @@
 #ifndef ROOT_TBranchIMTHelper
 #define ROOT_TBranchIMTHelper
 
-#include "Rtypes.h"
+#include "RtypesCore.h"
 
 #ifdef R__USE_IMT
 #include "ROOT/TTaskGroup.hxx"

--- a/tree/tree/test/ElementStruct.h
+++ b/tree/tree/test/ElementStruct.h
@@ -1,6 +1,3 @@
-#include "Rtypes.h"
-#include "TObject.h"
-
 /**
  * The ElementStruct has no purpose except to provide
  * inputs to the test cases.

--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -18,12 +18,13 @@
 #include "TLeaf.h"
 #include "TClonesArray.h"
 #include "TString.h"
-#include "Riostream.h"
 #include "TError.h"
 #include "TVirtualCollectionProxy.h"
 #include "TNotifyLink.h"
 
 #include <algorithm>
+#include <string>
+#include <iostream>
 
 class TBranch;
 class TStreamerElement;

--- a/tree/treeplayer/inc/TBranchProxyDirector.h
+++ b/tree/treeplayer/inc/TBranchProxyDirector.h
@@ -12,7 +12,7 @@
 #ifndef ROOT_TBranchProxyDirector
 #define ROOT_TBranchProxyDirector
 
-#include "Rtypes.h"
+#include "RtypesCore.h"
 #include <vector>
 #include <list>
 #include <algorithm>
@@ -41,7 +41,7 @@ namespace Internal{
       std::list<Detail::TBranchProxy*> fDirected;
       std::vector<TFriendProxy*> fFriends;
 
-      TBranchProxyDirector(const TBranchProxyDirector &) : fTree(0), fEntry(-1) {;}
+      TBranchProxyDirector(const TBranchProxyDirector &) : fTree(nullptr), fEntry(-1) {;}
       TBranchProxyDirector& operator=(const TBranchProxyDirector&) {return *this;}
 
    public:

--- a/tree/treeplayer/inc/TChainIndex.h
+++ b/tree/treeplayer/inc/TChainIndex.h
@@ -31,6 +31,7 @@
 #include "TVirtualIndex.h"
 
 #include <vector>
+#include <utility>
 
 class TTreeFormula;
 class TTreeIndex;

--- a/tree/treeplayer/inc/TFormLeafInfoReference.h
+++ b/tree/treeplayer/inc/TFormLeafInfoReference.h
@@ -14,8 +14,6 @@
 
 #include "TFormLeafInfo.h"
 
-#include <string>
-
 // Forward declarations
 class TVirtualRefProxy;
 
@@ -77,4 +75,5 @@ public:
    // TFormLeafInfo overload: Update (and propagate) cached information
    virtual Bool_t   Update();
 };
+
 #endif /* ROOT_TFormLeafInfoReference */

--- a/tree/treeplayer/inc/TMPWorkerTree.h
+++ b/tree/treeplayer/inc/TMPWorkerTree.h
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <type_traits> //std::result_of
 #include <unistd.h> //pid_t
+#include <vector>
 
 class TMPWorkerTree : public TMPWorker {
    /// \cond

--- a/tree/treeplayer/inc/TRefProxy.h
+++ b/tree/treeplayer/inc/TRefProxy.h
@@ -16,8 +16,6 @@
 
 #include "TClassRef.h"
 
-#include <string>
-
 // Forward declarations
 class TFormLeafInfoReference;
 

--- a/tree/treeplayer/inc/TSelectorDraw.h
+++ b/tree/treeplayer/inc/TSelectorDraw.h
@@ -23,6 +23,8 @@
 
 #include "TSelector.h"
 
+#include <vector>
+
 class TTreeFormula;
 class TTreeFormulaManager;
 class TH1;

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -29,6 +29,7 @@
 #include <deque>
 #include <iterator>
 #include <unordered_map>
+#include <string>
 
 class TDictionary;
 class TDirectory;

--- a/tree/treeplayer/inc/TTreeReaderGenerator.h
+++ b/tree/treeplayer/inc/TTreeReaderGenerator.h
@@ -24,6 +24,7 @@
 #include "TTreeGeneratorBase.h"
 
 #include "TNamed.h"
+#include <vector>
 
 class TBranch;
 class TBranchElement;

--- a/tree/treeplayer/inc/TTreeReaderUtils.h
+++ b/tree/treeplayer/inc/TTreeReaderUtils.h
@@ -26,6 +26,8 @@
 #include "TBranchProxy.h"
 #include "TTreeReaderValue.h"
 
+#include <string>
+
 class TDictionary;
 class TTree;
 

--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -26,6 +26,8 @@
 #include "TBranchProxy.h"
 
 #include <type_traits>
+#include <vector>
+#include <string>
 
 class TBranch;
 class TBranchElement;

--- a/tree/treeviewer/inc/HelpTextTV.h
+++ b/tree/treeviewer/inc/HelpTextTV.h
@@ -12,7 +12,7 @@
 #ifndef ROOT_HelpTextTV
 #define ROOT_HelpTextTV
 
-#include <Rtypes.h>
+#include <RtypesCore.h>
 
 R__EXTERN const char gTVHelpAbout[];
 R__EXTERN const char gTVHelpStart[];


### PR DESCRIPTION
Provide standard includes where required
Replace `Rtypes.h` by `RtypesCore.h` where ClassDef not required
Remove `TString.h` where not used
Replace Riostream.h by necessary standard includes