### PR TITLE
Optimize gui includes

### DIFF
--- a/gui/cefdisplay/inc/simple_app.h
+++ b/gui/cefdisplay/inc/simple_app.h
@@ -24,6 +24,7 @@
 
 #include "gui_handler.h"
 #include "osr_handler.h"
+#include <string>
 
 class THttpServer;
 

--- a/gui/fitpanel/inc/TFitEditor.h
+++ b/gui/fitpanel/inc/TFitEditor.h
@@ -27,11 +27,8 @@
 #include "Math/MinimizerOptions.h"
 #include "Fit/DataRange.h"
 
-
-
 #include <vector>
 #include <map>
-#include <utility>
 
 //--- Object types
 enum EObjectType {

--- a/gui/fitpanel/src/CommonDefs.h
+++ b/gui/fitpanel/src/CommonDefs.h
@@ -1,3 +1,6 @@
+#include <vector>
+#include <map>
+
 typedef std::multimap<TObject*, TF1*>::iterator fPrevFitIter;
 typedef std::vector<TF1*>::iterator             fSystemFuncIter;
 

--- a/gui/ged/inc/HelpSMText.h
+++ b/gui/ged/inc/HelpSMText.h
@@ -12,7 +12,7 @@
 #ifndef ROOT_HelpSMText
 #define ROOT_HelpSMText
 
-#include "Rtypes.h"
+#include "RtypesCore.h"
 
 R__EXTERN const char gHelpSMTopLevel[];
 R__EXTERN const char gHelpSMGeneral[];

--- a/gui/gui/inc/HelpText.h
+++ b/gui/gui/inc/HelpText.h
@@ -12,7 +12,7 @@
 #ifndef ROOT_HelpText
 #define ROOT_HelpText
 
-#include "Rtypes.h"
+#include "RtypesCore.h"
 
 R__EXTERN const char gHelpAbout[];
 R__EXTERN const char gHelpBrowser[];

--- a/gui/gui/inc/TGDimension.h
+++ b/gui/gui/inc/TGDimension.h
@@ -22,7 +22,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "TObject.h"
+#include "RtypesCore.h"
 
 class TGDimension {
 public:

--- a/gui/gui/inc/TGFileBrowser.h
+++ b/gui/gui/inc/TGFileBrowser.h
@@ -18,6 +18,7 @@
 
 #include <list>
 #include <map>
+#include <string>
 
 class TGCanvas;
 class TGListTree;

--- a/gui/gui/inc/TGShapedFrame.h
+++ b/gui/gui/inc/TGShapedFrame.h
@@ -14,8 +14,6 @@
 
 #include "TGFrame.h"
 
-#include "TString.h"
-
 #include "TImage.h"
 
 #include "TGPicture.h"
@@ -23,8 +21,8 @@
 class TGShapedFrame : public TGCompositeFrame {
 
 private:
-   TGShapedFrame(const TGShapedFrame&); // Not implemented
-   TGShapedFrame& operator=(const TGShapedFrame&); // Not implemented
+   TGShapedFrame(const TGShapedFrame&) = delete;
+   TGShapedFrame& operator=(const TGShapedFrame&) = delete;
 
 protected:
    const TGPicture      *fBgnd;     // picture used as background/shape

--- a/gui/gui/inc/WidgetMessageTypes.h
+++ b/gui/gui/inc/WidgetMessageTypes.h
@@ -26,7 +26,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "Rtypes.h"
+#include "RtypesCore.h"
 
 
 enum EWidgetMessageTypes {

--- a/gui/gui/src/TGDimension.cxx
+++ b/gui/gui/src/TGDimension.cxx
@@ -33,12 +33,6 @@
 #include "TGDimension.h"
 #include "TMathBase.h"
 
-ClassImp(TGDimension);
-ClassImp(TGPosition);
-ClassImp(TGLongPosition);
-ClassImp(TGInsets);
-ClassImp(TGRectangle);
-
 void TGRectangle::Merge(const TGRectangle &r)
 {
    // Merge parameters

--- a/gui/recorder/inc/TRecorder.h
+++ b/gui/recorder/inc/TRecorder.h
@@ -118,7 +118,6 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "Riostream.h"
 #include "TApplication.h"
 #include "TError.h"
 #include "TTimer.h"
@@ -127,7 +126,8 @@
 #include "TCanvas.h"
 #include "THashList.h"
 
-#include <time.h>
+#include <ctime>
+#include <iostream>
 
 class TMutex;
 class TTree;

--- a/gui/recorder/src/TRecorder.cxx
+++ b/gui/recorder/src/TRecorder.cxx
@@ -136,6 +136,7 @@
 #include "KeySymbols.h"
 #include "TVirtualX.h"
 
+#include <iomanip>
 
 // Names of ROOT GUI events. Used for listing event logs.
 const char *kRecEventNames[] = {

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -16,6 +16,7 @@
 #include "TWebPainting.h"
 
 #include <memory>
+#include <string>
 
 class TWebPS : public TVirtualPS {
 

--- a/gui/webgui6/inc/TWebPadPainter.h
+++ b/gui/webgui6/inc/TWebPadPainter.h
@@ -17,6 +17,7 @@
 #include "TAttFill.h"
 #include "TAttText.h"
 #include "TAttMarker.h"
+#include <string>
 
 #include "TWebPainting.h"
 


### PR DESCRIPTION
Provide standard includes like `<string>` where correspondent standard class is used
Remove `TString.h` where not used
Use `RtypesCore.h` instead `Rtypes.h` or `TObject.h` where feasible 