### PR TITLE
[cling] On Mac, try first without leading underscore:

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6954,23 +6954,23 @@ static std::string GetSharedLibImmediateDepsSlow(std::string lib,
             continue;
 
          if (BinObjFile->isELF()) {
-          // Skip the symbols which are part of the C/C++ runtime and have a
-          // fixed library version. See binutils ld VERSION. Those reside in
-          // 'system' libraries, which we avoid in FindLibraryForSymbol.
-          if (SymName.contains("@@GLIBCXX") || SymName.contains("@@CXXABI") ||
-              SymName.contains("@@GLIBC") || SymName.contains("@@GCC"))
-            continue;
+            // Skip the symbols which are part of the C/C++ runtime and have a
+            // fixed library version. See binutils ld VERSION. Those reside in
+            // 'system' libraries, which we avoid in FindLibraryForSymbol.
+            if (SymName.contains("@@GLIBCXX") || SymName.contains("@@CXXABI") ||
+               SymName.contains("@@GLIBC") || SymName.contains("@@GCC"))
+               continue;
 
-          // Those are 'weak undefined' symbols produced by gcc. We can
-          // ignore them.
-          // FIXME: It is unclear whether we can ignore all weak undefined
-          // symbols:
-          // http://lists.llvm.org/pipermail/llvm-dev/2017-October/118177.html
-          if (SymName == "_Jv_RegisterClasses" ||
-              SymName == "_ITM_deregisterTMCloneTable" ||
-              SymName == "_ITM_registerTMCloneTable")
-            continue;
-      }
+            // Those are 'weak undefined' symbols produced by gcc. We can
+            // ignore them.
+            // FIXME: It is unclear whether we can ignore all weak undefined
+            // symbols:
+            // http://lists.llvm.org/pipermail/llvm-dev/2017-October/118177.html
+            if (SymName == "_Jv_RegisterClasses" ||
+               SymName == "_ITM_deregisterTMCloneTable" ||
+               SymName == "_ITM_registerTMCloneTable")
+               continue;
+         }
 
 // FIXME: this might really depend on MachO library format instead of R__MACOSX.
 #ifdef R__MACOSX

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6972,6 +6972,15 @@ static std::string GetSharedLibImmediateDepsSlow(std::string lib,
             continue;
       }
 
+// FIXME: this might really depend on MachO library format instead of R__MACOSX.
+#ifdef R__MACOSX
+         // MacOS symbols sometimes have an extra "_", see
+         // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlsym.3.html
+         if (skipLoadedLibs && SymName[0] == '_'
+             && llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(SymName.drop_front()))
+            continue;
+#endif
+
          // If we can find the address of the symbol, we have loaded it. Skip.
          if (skipLoadedLibs && llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(SymName))
             continue;


### PR DESCRIPTION
Fixes unnecessary loading of (wrong) cppyy library because a symbol named "_PyExc_SyntaxError" cannot be found by dlsym.