### PR TITLE
Test error/warning/info messages in RDF tests

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1202,6 +1202,10 @@ void UpdateBoolArray(BoolArrayMap &, T&, const std::string &, TTree &) {}
 // RVec<bool> overload, update boolArrays if needed
 inline void UpdateBoolArray(BoolArrayMap &boolArrays, RVec<bool> &v, const std::string &outName, TTree &t)
 {
+   // in case the RVec<bool> does not correspond to a bool C-array
+   if (boolArrays.find(outName) == boolArrays.end())
+      return;
+
    if (v.size() > boolArrays[outName].Size()) {
       boolArrays[outName] = BoolArray(v); // resize and copy
       t.SetBranchAddress(outName.c_str(), boolArrays[outName].Data());

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -291,7 +291,7 @@ void RLoopManager::RunEmptySourceMT()
       } catch (...) {
          CleanUpTask(slot);
          // Error might throw in experiment frameworks like CMSSW
-         std::cerr << "RDataFrame::Run: event was loop interrupted\n";
+         std::cerr << "RDataFrame::Run: event loop was interrupted\n";
          throw;
       }
       CleanUpTask(slot);
@@ -314,7 +314,7 @@ void RLoopManager::RunEmptySource()
       }
    } catch (...) {
       CleanUpTask(0u);
-      std::cerr << "RDataFrame::Run: event was loop interrupted\n";
+      std::cerr << "RDataFrame::Run: event loop was interrupted\n";
       throw;
    }
    CleanUpTask(0u);
@@ -344,7 +344,7 @@ void RLoopManager::RunTreeProcessorMT()
          }
       } catch (...) {
          CleanUpTask(slot);
-         std::cerr << "RDataFrame::Run: event was loop interrupted\n";
+         std::cerr << "RDataFrame::Run: event loop was interrupted\n";
          throw;
       }
       CleanUpTask(slot);
@@ -370,7 +370,7 @@ void RLoopManager::RunTreeReader()
       }
    } catch (...) {
       CleanUpTask(0u);
-      std::cerr << "RDataFrame::Run: event was loop interrupted\n";
+      std::cerr << "RDataFrame::Run: event loop was interrupted\n";
       throw;
    }
    if (r.GetEntryStatus() != TTreeReader::kEntryNotFound && fNStopsReceived < fNChildren) {
@@ -401,7 +401,7 @@ void RLoopManager::RunDataSource()
          }
       } catch (...) {
          CleanUpTask(0u);
-         std::cerr << "RDataFrame::Run: event was loop interrupted\n";
+         std::cerr << "RDataFrame::Run: event loop was interrupted\n";
          throw;
       }
       CleanUpTask(0u);
@@ -433,7 +433,7 @@ void RLoopManager::RunDataSourceMT()
          }
       } catch (...) {
          CleanUpTask(slot);
-         std::cerr << "RDataFrame::Run: event was loop interrupted\n";
+         std::cerr << "RDataFrame::Run: event loop was interrupted\n";
          throw;
       }
       CleanUpTask(slot);

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -1,5 +1,6 @@
 /****** Run RDataFrame tests both with and without IMT enabled *******/
 #include <gtest/gtest.h>
+#include <ROOTUnitTestSupport.h>
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/TSeq.hxx>
 #include <TChain.h>
@@ -836,7 +837,7 @@ TEST_P(RDFSimpleTests, NonExistingFile)
    ROOT::RDataFrame r("myTree", "nonexistingfile.root");
 
    // We try to use the tree for jitting: an exception is thrown
-   EXPECT_ANY_THROW(r.Filter("inventedVar > 0"));
+   ROOT_EXPECT_ERROR(EXPECT_ANY_THROW(r.Filter("inventedVar > 0")), "TFile::TFile", "file nonexistingfile.root does not exist");
 }
 
 // ROOT-10549: check we throw if a file is unreadable
@@ -847,9 +848,11 @@ TEST_P(RDFSimpleTests, NonExistingFileInChain)
 
    ROOT::RDataFrame df("t", {filename, "doesnotexist.root"});
 
+   const auto errmsg ="file doesnotexist.root does not exist";
+
    bool exceptionCaught = false;
    try {
-      df.Count().GetValue();
+      ROOT_EXPECT_ERROR(df.Count().GetValue(), "TFile::TFile", errmsg);
    } catch (const std::runtime_error &e) {
       const std::string expected_msg =
          ROOT::IsImplicitMTEnabled()

--- a/tree/dataframe/test/datasource_sqlite.cxx
+++ b/tree/dataframe/test/datasource_sqlite.cxx
@@ -1,3 +1,4 @@
+#include <ROOTUnitTestSupport.h>
 #include <ROOT/RConfig.hxx>
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RMakeUnique.hxx>
@@ -125,7 +126,9 @@ TEST(RSqliteDS, ColumnReaders)
 {
    RSqliteDS rds(fileName0, query0);
    const auto nSlots = 2U;
-   rds.SetNSlots(nSlots);
+   ROOT_EXPECT_WARNING(rds.SetNSlots(nSlots), "SetNSlots",
+                       "Currently the SQlite data source faces performance degradation in multi-threaded mode. "
+                       "Consider turning off IMT.");
    auto vals = rds.GetColumnReaders<Long64_t>("fint");
    rds.Initialise();
    auto ranges = rds.GetEntryRanges();


### PR DESCRIPTION
Remaining printouts cannot easily be tested/checked, see also [this discussion](https://github.com/root-project/root/pull/5591#issuecomment-641453675).

#### dataframe_simple

* `RLoopManager::Run prints to stderr rather than using Warning/Error, because it does so from a catch clause, and Warning/Error could be made throw exceptions by experiments frameworks, and we don't want to `std::terminate`. There is no `ROOT_EXPECT_*` macro for stderr printouts that do not come from `Warning`, `Error` or `Info`.

#### datasource_sqlite

A constructor that warns is invoked by a factory function. Obviously, switching from

```c++
auto rdf = MakeSqliteDataFrame(fileName0, query0);
```
to 

```c++
ROOT_EXPECT_WARNING(auto rdf = MakeSqliteDataFrame(fileName0, query0), ..., ...);
```
makes it impossible to use `rdf` after this line. To make things worse, `rdf` is not default-constructible, so I cannot do

```c++
RDFType rdf;
ROOT_EXPECT_WARNING(rdf = MakeSqliteDataFrame(....), ...., ...);
```

...so I don't know how to catch that warning.