### PR TITLE
[DF] Do not call SetBranchAddress when not needed

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1127,6 +1127,10 @@ void UpdateBoolArray(BoolArrayMap &, T&, const std::string &, TTree &) {}
 // RVec<bool> overload, update boolArrays if needed
 inline void UpdateBoolArray(BoolArrayMap &boolArrays, RVec<bool> &v, const std::string &outName, TTree &t)
 {
+   // in case the RVec<bool> does not correspond to a bool C-array
+   if (boolArrays.find(outName) == boolArrays.end())
+      return;
+
    if (v.size() > boolArrays[outName].Size()) {
       boolArrays[outName] = BoolArray(v); // resize and copy
       t.SetBranchAddress(outName.c_str(), boolArrays[outName].Data());


### PR DESCRIPTION
This removes spurious warnings from dataframe_snapshot.cxx.
The problem (once again) was that map::operator[] creates entries
if not present.