### PR TITLE
[ntuple] Implement RFieldDescriptor range

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <chrono>
 #include <memory>
+#include <numeric>
 #include <ostream>
 #include <vector>
 #include <string>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -403,12 +403,12 @@ public:
       return GetFieldRange(GetFieldDescriptor(fieldId), comparator);
    }
    RFieldDescriptorRange GetTopLevelFields() const {
-      return GetFieldRange(GetFieldDescriptor(0));
+      return GetFieldRange(GetFieldZeroId());
    }
    RFieldDescriptorRange GetTopLevelFields(
       const std::function<bool(DescriptorId_t, DescriptorId_t)>& comparator) const
    {
-      return GetFieldRange(GetFieldDescriptor(0), comparator);
+      return GetFieldRange(GetFieldZeroId(), comparator);
    }
 
    std::string GetName() const { return fName; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -330,6 +330,7 @@ public:
             );
          }
          bool operator!=(const iterator& rh) const { return fIndex != rh.fIndex; }
+         bool operator==(const iterator& rh) const { return fIndex == rh.fIndex; }
       };
       /// An iterator over a field's children.
       RFieldDescriptorRange(const RNTupleDescriptor& ntuple, const RFieldDescriptor& field)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -32,7 +32,6 @@
 namespace ROOT {
 namespace Experimental {
 
-class RFieldDescriptorRange;
 class RNTupleDescriptorBuilder;
 class RNTupleModel;
 
@@ -303,14 +302,26 @@ private:
    std::unordered_map<DescriptorId_t, RClusterDescriptor> fClusterDescriptors;
 
 public:
+   // clang-format off
+   /**
+   \class ROOT::Experimental::RNTupleDescriptor::RFieldDescriptorRange
+   \ingroup NTuple
+   \brief Used to loop over a field's child fields
+   */
+   // clang-format on
    class RFieldDescriptorRange {
    private:
+      /// The associated NTuple for this range.
       const RNTupleDescriptor& fNTuple;
+      /// The descriptor ids of the child fields. These may be sorted using
+      /// a comparison function.
       std::vector<DescriptorId_t> fFieldChildren = {};
    public:
       class RIterator {
       private:
+         /// The enclosing range's NTuple.
          const RNTupleDescriptor& fNTuple;
+         /// The enclosing range's descriptor id list.
          const std::vector<DescriptorId_t>& fFieldChildren;
          std::size_t fIndex = 0;
       public:
@@ -332,10 +343,9 @@ public:
          bool operator!=(const iterator& rh) const { return fIndex != rh.fIndex; }
          bool operator==(const iterator& rh) const { return fIndex == rh.fIndex; }
       };
-      /// An iterator over a field's children.
       RFieldDescriptorRange(const RNTupleDescriptor& ntuple, const RFieldDescriptor& field)
          : fNTuple(ntuple), fFieldChildren(field.GetLinkIds()) {}
-      /// An iterator over a field's children sorted by a given comparison function.
+      /// Sort the range using an arbitrary comparison function.
       RFieldDescriptorRange(const RNTupleDescriptor& ntuple, const RFieldDescriptor& field,
          const std::function<bool(DescriptorId_t, DescriptorId_t)>& comparator)
          : fNTuple(ntuple), fFieldChildren(field.GetLinkIds())

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -376,15 +376,18 @@ public:
    /// Given kNBytesPostscript bytes, extract the header and footer lengths in bytes
    static void LocateMetadata(const void *postscript, std::uint32_t &szHeader, std::uint32_t &szFooter);
 
-   const RFieldDescriptor& GetFieldDescriptor(DescriptorId_t fieldId) const { return fFieldDescriptors.at(fieldId); }
+   const RFieldDescriptor& GetFieldDescriptor(DescriptorId_t fieldId) const {
+      return fFieldDescriptors.at(fieldId);
+   }
    const RColumnDescriptor& GetColumnDescriptor(DescriptorId_t columnId) const {
       return fColumnDescriptors.at(columnId);
    }
    const RClusterDescriptor& GetClusterDescriptor(DescriptorId_t clusterId) const {
       return fClusterDescriptors.at(clusterId);
    }
+
    RFieldDescriptorRange GetFieldRange(const RFieldDescriptor& fieldDesc) const {
-       return RFieldDescriptorRange(*this, fieldDesc);
+      return RFieldDescriptorRange(*this, fieldDesc);
    }
    RFieldDescriptorRange GetFieldRange(const RFieldDescriptor& fieldDesc,
       const std::function<bool(DescriptorId_t, DescriptorId_t)>& comparator) const
@@ -392,7 +395,7 @@ public:
       return RFieldDescriptorRange(*this, fieldDesc, comparator);
    }
    RFieldDescriptorRange GetFieldRange(DescriptorId_t fieldId) const {
-       return GetFieldRange(GetFieldDescriptor(fieldId));
+      return GetFieldRange(GetFieldDescriptor(fieldId));
    }
    RFieldDescriptorRange GetFieldRange(DescriptorId_t fieldId,
       const std::function<bool(DescriptorId_t, DescriptorId_t)>& comparator) const
@@ -400,7 +403,7 @@ public:
       return GetFieldRange(GetFieldDescriptor(fieldId), comparator);
    }
    RFieldDescriptorRange GetTopLevelFields() const {
-       return GetFieldRange(GetFieldDescriptor(0));
+      return GetFieldRange(GetFieldDescriptor(0));
    }
    RFieldDescriptorRange GetTopLevelFields(
       const std::function<bool(DescriptorId_t, DescriptorId_t)>& comparator) const

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -697,10 +697,7 @@ ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t columnId, NT
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDescriptor::GenerateModel() const
 {
    auto model = std::make_unique<RNTupleModel>();
-   auto rootId = FindFieldId("", kInvalidDescriptorId);
-   const auto &rootDesc = GetFieldDescriptor(rootId);
-   for (const auto id : rootDesc.GetLinkIds()) {
-      const auto &topDesc = GetFieldDescriptor(id);
+   for (const auto &topDesc : GetTopLevelFields()) {
       auto field = Detail::RFieldBase::Create(topDesc.GetFieldName(), topDesc.GetTypeName());
       model->AddField(std::unique_ptr<Detail::RFieldBase>(field));
    }

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -133,28 +133,25 @@ TEST(RFieldDescriptorRange, IterateOverFieldNames)
    auto ints = model->MakeField<std::int32_t>("ints");
 
    FileRaii fileGuard("test_field_iterator.root");
-   auto modelRead = std::unique_ptr<RNTupleModel>(model->Clone());
    {
-       RNTupleWriter ntuple(std::move(model),
-          std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-       ntuple.Fill();
+      RNTupleWriter ntuple(std::move(model),
+         std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
+      ntuple.Fill();
    }
 
-   RNTupleReader ntuple(std::move(modelRead),
-      std::make_unique<RPageSourceFile>("ntuple", fileGuard.GetPath(), RNTupleReadOptions()));
-
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    // iterate over top-level fields
    std::vector<std::string> names{};
-   for (auto& f: ntuple.GetDescriptor().GetTopLevelFields()) {
+   for (auto& f: ntuple->GetDescriptor().GetTopLevelFields()) {
       names.push_back(f.GetFieldName());
    }
-   EXPECT_EQ(names.size(), 4);
+   ASSERT_EQ(names.size(), 4);
    EXPECT_EQ(names[0], std::string("jets"));
    EXPECT_EQ(names[1], std::string("bools"));
    EXPECT_EQ(names[2], std::string("bool_vec_vec"));
    EXPECT_EQ(names[3], std::string("ints"));
 
-   const auto& ntuple_desc = ntuple.GetDescriptor();
+   const auto& ntuple_desc = ntuple->GetDescriptor();
    auto top_level_fields = ntuple_desc.GetTopLevelFields();
 
    // iterate over child field ranges
@@ -168,7 +165,7 @@ TEST(RFieldDescriptorRange, IterateOverFieldNames)
       auto float_child_range = ntuple_desc.GetFieldRange(child_field);
       EXPECT_EQ(float_child_range.begin(), float_child_range.end());
    }
-   EXPECT_EQ(child_names.size(), 1);
+   ASSERT_EQ(child_names.size(), 1);
    EXPECT_EQ(child_names[0], std::string("float"));
 
    // check if canonical iterator methods work
@@ -181,7 +178,7 @@ TEST(RFieldDescriptorRange, IterateOverFieldNames)
    for (auto& child_field: ntuple_desc.GetFieldRange(bool_vec_vec_desc)) {
       child_names.push_back(child_field.GetFieldName());
    }
-   EXPECT_EQ(child_names.size(), 1);
+   ASSERT_EQ(child_names.size(), 1);
    EXPECT_EQ(child_names[0], std::string("std::vector<bool>"));
 }
 
@@ -194,17 +191,14 @@ TEST(RFieldDescriptorRange, SortByLambda)
    auto ints = model->MakeField<std::int32_t>("ints");
 
    FileRaii fileGuard("test_field_iterator.root");
-   auto modelRead = std::unique_ptr<RNTupleModel>(model->Clone());
    {
-       RNTupleWriter ntuple(std::move(model),
-          std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
-       ntuple.Fill();
+      RNTupleWriter ntuple(std::move(model),
+         std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions()));
+      ntuple.Fill();
    }
 
-   RNTupleReader ntuple(std::move(modelRead),
-      std::make_unique<RPageSourceFile>("ntuple", fileGuard.GetPath(), RNTupleReadOptions()));
-
-   const auto& ntuple_desc = ntuple.GetDescriptor();
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   const auto& ntuple_desc = ntuple->GetDescriptor();
    auto alpha_order = [&](auto lhs, auto rhs) {
       return ntuple_desc.GetFieldDescriptor(lhs).GetFieldName()
          < ntuple_desc.GetFieldDescriptor(rhs).GetFieldName();
@@ -214,7 +208,7 @@ TEST(RFieldDescriptorRange, SortByLambda)
    for (auto& f: ntuple_desc.GetTopLevelFields(alpha_order)) {
       sorted_names.push_back(f.GetFieldName());
    }
-   EXPECT_EQ(sorted_names.size(), 4);
+   ASSERT_EQ(sorted_names.size(), 4);
    EXPECT_EQ(sorted_names[0], std::string("bool_vec_vec"));
    EXPECT_EQ(sorted_names[1], std::string("bools"));
    EXPECT_EQ(sorted_names[2], std::string("ints"));
@@ -227,7 +221,7 @@ TEST(RFieldDescriptorRange, SortByLambda)
    {
       sorted_names.push_back(f.GetFieldName());
    }
-   EXPECT_EQ(sorted_names.size(), 4);
+   ASSERT_EQ(sorted_names.size(), 4);
    EXPECT_EQ(sorted_names[0], std::string("jets"));
    EXPECT_EQ(sorted_names[1], std::string("ints"));
    EXPECT_EQ(sorted_names[2], std::string("bools"));
@@ -243,7 +237,7 @@ TEST(RFieldDescriptorRange, SortByLambda)
       sorted_by_typename.push_back(f.GetFieldName());
    }
    // int32_t, vector<bool>, vector<float>, vector<vector<bool>
-   EXPECT_EQ(sorted_by_typename.size(), 4);
+   ASSERT_EQ(sorted_by_typename.size(), 4);
    EXPECT_EQ(sorted_by_typename[0], std::string("ints"));
    EXPECT_EQ(sorted_by_typename[1], std::string("bools"));
    EXPECT_EQ(sorted_by_typename[2], std::string("jets"));

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -166,7 +166,7 @@ TEST(RFieldDescriptorRange, IterateOverFieldNames)
       child_names.push_back(child_field.GetFieldName());
       // check the empty range
       auto float_child_range = ntuple_desc.GetFieldRange(child_field);
-      EXPECT_FALSE(float_child_range.begin() != float_child_range.end());
+      EXPECT_EQ(float_child_range.begin(), float_child_range.end());
    }
    EXPECT_EQ(child_names.size(), 1);
    EXPECT_EQ(child_names[0], std::string("float"));

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -208,7 +208,12 @@ TEST(RFieldDescriptorRange, SortByFieldNames)
       std::make_unique<RPageSourceFile>("ntuple", fileGuard.GetPath(), RNTupleReadOptions()));
 
    std::vector<std::string> sorted_names{};
-   for (auto& f: ntuple.GetDescriptor().GetTopLevelFields().SortByNames()) {
+   const auto& ntuple_desc = ntuple.GetDescriptor();
+   for (auto& f: ntuple_desc.GetTopLevelFields(
+      [&](DescriptorId_t lhs, DescriptorId_t rhs) -> bool {
+         return ntuple_desc.GetFieldDescriptor(lhs).GetFieldName()
+            < ntuple_desc.GetFieldDescriptor(rhs).GetFieldName();}))
+   {
       sorted_names.push_back(f.GetFieldName());
    }
 


### PR DESCRIPTION
This PR implements an iterator over an `NTuple's` field descriptors (i.e. field metadata). It is a building block for the upcoming NTuple merger algorithm by allowing comparison between two `NTuples`. This PR is a slimmed down version of PR #5768. 

**Edit**: Users can optionally sort the NTuple iterator range, (e.g. field names by alphabetical order) with arbitrary comparison functions (see e05a85b). 

<details>
<summary>Notes on previous sort approach</summary>
<br>
We wanted to be able to iterate over `FieldDescriptors` in alphabetical order by name, this is implemented in a3a3da6 using a layer of indirection, namely a vector of offsets `RFieldDescriptorRange::fOffsets`. 
I decided on making this an optional adapter method `SortByNames` instead of the default ordering, because it turns out iterating over `FieldDescriptors` is used elsewhere in the code (see improvements in API client code in 222a412)

</details>