### PR TITLE
[PyROOT][ROOT-10833] Use new API instead of deprecated one (6.22)

### DIFF
--- a/bindings/pyroot_legacy/ROOT.py
+++ b/bindings/pyroot_legacy/ROOT.py
@@ -720,7 +720,7 @@ class ModuleFacade( types.ModuleType ):
 
     # python side pythonizations (should live in their own file, if we get many)
       def set_size(self, buf):
-         buf.SetSize(self.GetN())
+         buf.reshape((self.GetN(),))
          return buf
 
     # TODO: add pythonization API to pypy-c


### PR DESCRIPTION
To prevent deprecation warning.