### PR TITLE
remove TPoolManager from imt/LinkDef

### DIFF
--- a/core/imt/inc/LinkDef.h
+++ b/core/imt/inc/LinkDef.h
@@ -7,7 +7,6 @@
 // Only for the autoload, autoparse. No IO of these classes is foreseen!
 // Exclude in case ROOT does not have IMT support
 #ifdef R__USE_IMT
-#pragma link C++ class ROOT::Internal::TPoolManager-;
 #pragma link C++ class ROOT::TThreadExecutor-;
 #pragma link C++ class ROOT::Experimental::TTaskGroup-;
 #endif


### PR DESCRIPTION
TPoolManager doesn't exist anymore and this was triggering a warning