### PR TITLE
Remove gEnv and gSystem dependencies from TError

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -138,6 +138,7 @@ set(BASE_SOURCES
   src/TDirectory.cxx
   src/TEnv.cxx
   src/TError.cxx
+  src/TErrorDefaultHandler.cxx
   src/TException.cxx
   src/TExec.cxx
   src/TFileCollection.cxx

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -16,9 +16,10 @@ if(MSVC AND MSVC_VERSION GREATER_EQUAL 1925)
 endif()
 
 set(BASE_HEADERS
-  ROOT/StringConv.hxx
+  ROOT/TErrorDefaultHandler.hxx
   ROOT/TExecutor.hxx
   ROOT/TSequentialExecutor.hxx
+  ROOT/StringConv.hxx
   Buttons.h
   Bytes.h
   Byteswap.h

--- a/core/base/inc/ROOT/TErrorDefaultHandler.hxx
+++ b/core/base/inc/ROOT/TErrorDefaultHandler.hxx
@@ -1,0 +1,25 @@
+// @(#)root/thread:$Id$
+// Author: Jakob Blomer, June 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2006, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TErrorDefaultHandler
+#define ROOT_TErrorDefaultHandler
+
+namespace ROOT {
+namespace Internal {
+
+/// Destructs resources that are taken by using the default error handler.
+/// This function is called during the destruction of gROOT.
+void ReleaseDefaultErrorHandler();
+
+}
+}
+
+#endif

--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -28,6 +28,7 @@
 
 #include "RtypesCore.h"
 #include <stdarg.h>
+#include <functional>
 
 
 class TVirtualMutex;
@@ -42,6 +43,36 @@ const Int_t kSysError =   5000;
 const Int_t kFatal    =   6000;
 
 R__EXTERN TVirtualMutex *gErrorMutex;
+
+// TROOT sets the error ignore level handler, the system error message handler, and the error abort handler on
+// construction such that the "Root.ErrorIgnoreLevel" environment variable is used for the ignore level
+// and gSystem is used to generate a stack trace on abort.
+namespace ROOT {
+namespace Internal {
+
+/// If gErrorIgnoreLevel == kUnset, called in order to find the level as of
+/// which errors are handled in the default handler.  Calling this function is
+/// serialized.
+using ErrorIgnoreLevelHandlerFunc_t = std::function<Int_t ()>;
+/// Retrieves the error string associated with the last system error.
+using ErrorSystemMsgHandlerFunc_t = std::function<const char *()>;
+/// Called in order to terminate the application in the default handler.
+using ErrorAbortHandlerFunc_t = std::function<void ()>;
+
+ErrorIgnoreLevelHandlerFunc_t GetErrorIgnoreLevelHandler();
+/// Returns the previous handler for getting the ignore level
+ErrorIgnoreLevelHandlerFunc_t SetErrorIgnoreLevelHandler(ErrorIgnoreLevelHandlerFunc_t h);
+
+ErrorSystemMsgHandlerFunc_t GetErrorSystemMsgHandler();
+/// Returns the previous system error message handler
+ErrorSystemMsgHandlerFunc_t SetErrorSystemMsgHandler(ErrorSystemMsgHandlerFunc_t h);
+
+ErrorAbortHandlerFunc_t GetErrorAbortHandler();
+/// Returns the previous abort handler
+ErrorAbortHandlerFunc_t SetErrorAbortHandler(ErrorAbortHandlerFunc_t h);
+
+} // namespace Internal
+} // namespace ROOT
 
 typedef void (*ErrorHandlerFunc_t)(int level, Bool_t abort, const char *location,
               const char *msg);

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -40,14 +40,6 @@ Bool_t gPrintViaErrorHandler = kFALSE;
 const char *kAssertMsg = "%s violated at line %d of `%s'";
 const char *kCheckMsg  = "%s not true at line %d of `%s'";
 
-// Integrate with crash reporter.
-#ifdef __APPLE__
-extern "C" {
-static const char *__crashreporter_info__ = 0;
-asm(".desc ___crashreporter_info__, 0x10");
-}
-#endif
-
 static ErrorHandlerFunc_t gErrorHandler = ROOT::Internal::MinimalErrorHandler;
 
 

--- a/core/base/src/TErrorDefaultHandler.cxx
+++ b/core/base/src/TErrorDefaultHandler.cxx
@@ -1,0 +1,160 @@
+/// \file TErrorDefaultHandler.cxx
+/// \date 2020-06-14
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifdef WIN32
+#include <windows.h>
+#endif
+
+#include <TEnv.h>
+#include <TError.h>
+#include <ThreadLocalStorage.h>
+#include <TSystem.h>
+#include <Varargs.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cctype> // for tolower
+#include <cstring> // for strdup
+#include <mutex>
+
+
+/// Serializes error output, destructed when libCore is unloaded
+static std::mutex &GetErrorMutex() {
+   static std::mutex m;
+   return m;
+}
+
+
+/// Print debugging message to stderr and, on Windows, to the system debugger.
+static void DebugPrint(const char *fmt, ...)
+{
+   TTHREAD_TLS(Int_t) buf_size = 2048;
+   TTHREAD_TLS(char*) buf = 0;
+
+   va_list ap;
+   va_start(ap, fmt);
+
+again:
+   if (!buf)
+      buf = new char[buf_size];
+
+   Int_t n = vsnprintf(buf, buf_size, fmt, ap);
+   // old vsnprintf's return -1 if string is truncated new ones return
+   // total number of characters that would have been written
+   if (n == -1 || n >= buf_size) {
+      if (n == -1)
+         buf_size *= 2;
+      else
+         buf_size = n+1;
+      delete [] buf;
+      buf = 0;
+      va_end(ap);
+      va_start(ap, fmt);
+      goto again;
+   }
+   va_end(ap);
+
+   // Serialize the actual printing.
+   std::lock_guard<std::mutex> guard(GetErrorMutex());
+
+   const char *toprint = buf; // Work around for older platform where we use TThreadTLSWrapper
+   fprintf(stderr, "%s", toprint);
+
+#ifdef WIN32
+   ::OutputDebugString(buf);
+#endif
+}
+
+
+/// The default error handler function. It prints the message on stderr and
+/// if abort is set it aborts the application.  Replaces the minimal error handler
+/// of TError.h as part of the gROOT construction.  TError's minimal handler is put
+/// back in place during the gROOT destruction.
+void DefaultErrorHandler(Int_t level, Bool_t abort_bool, const char *location, const char *msg)
+{
+   if (gErrorIgnoreLevel == kUnset) {
+      std::lock_guard<std::mutex> guard(GetErrorMutex());
+
+      gErrorIgnoreLevel = 0;
+      if (gEnv) {
+         std::string slevel;
+         auto cstrlevel = gEnv->GetValue("Root.ErrorIgnoreLevel", "Print");
+         while (cstrlevel && *cstrlevel) {
+            slevel.push_back(tolower(*cstrlevel));
+            cstrlevel++;
+         }
+
+         if (slevel == "print")
+            gErrorIgnoreLevel = kPrint;
+         else if (slevel == "info")
+            gErrorIgnoreLevel = kInfo;
+         else if (slevel == "warning")
+            gErrorIgnoreLevel = kWarning;
+         else if (slevel == "error")
+            gErrorIgnoreLevel = kError;
+         else if (slevel == "break")
+            gErrorIgnoreLevel = kBreak;
+         else if (slevel == "syserror")
+            gErrorIgnoreLevel = kSysError;
+         else if (slevel == "fatal")
+            gErrorIgnoreLevel = kFatal;
+      }
+   }
+
+   if (level < gErrorIgnoreLevel)
+      return;
+
+   const char *type = 0;
+
+   if (level >= kInfo)
+      type = "Info";
+   if (level >= kWarning)
+      type = "Warning";
+   if (level >= kError)
+      type = "Error";
+   if (level >= kBreak)
+      type = "\n *** Break ***";
+   if (level >= kSysError)
+      type = "SysError";
+   if (level >= kFatal)
+      type = "Fatal";
+
+   std::string smsg;
+   if (level >= kPrint && level < kInfo)
+      smsg = msg;
+   else if (level >= kBreak && level < kSysError)
+      smsg = std::string(type) + " " + msg;
+   else if (!location || !location[0])
+      smsg = std::string(type) + ": " + msg;
+   else
+      smsg = std::string(type) + " in <" + location + ">: " + msg;
+
+   DebugPrint("%s\n", smsg.c_str());
+
+   fflush(stderr);
+   if (abort_bool) {
+
+#ifdef __APPLE__
+      if (__crashreporter_info__)
+         delete [] __crashreporter_info__;
+      __crashreporter_info__ = strdup(smsg.c_str());
+#endif
+
+      DebugPrint("aborting\n");
+      fflush(stderr);
+      if (gSystem) {
+         gSystem->StackTrace();
+         gSystem->Abort();
+      } else {
+         abort();
+      }
+   }
+}

--- a/core/base/src/TErrorDefaultHandler.cxx
+++ b/core/base/src/TErrorDefaultHandler.cxx
@@ -25,6 +25,14 @@
 #include <cstring> // for strdup
 #include <mutex>
 
+// Integrate with macOS crash reporter.
+#ifdef __APPLE__
+extern "C" {
+static const char *__crashreporter_info__ = 0;
+asm(".desc ___crashreporter_info__, 0x10");
+}
+#endif
+
 
 /// Serializes error output, destructed when libCore is unloaded
 static std::mutex &GetErrorMutex() {

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -938,6 +938,7 @@ TROOT::~TROOT()
 
       fMessageHandlers->Delete(); SafeDelete(fMessageHandlers);
 
+      ROOT::Internal::SetErrorIgnoreLevelHandler(ROOT::Internal::ErrorIgnoreLevelHandlerFunc_t());
 #ifdef R__COMPLETE_MEM_TERMINATION
       SafeDelete(fCanvases);
       SafeDelete(fTasks);
@@ -948,7 +949,6 @@ TROOT::~TROOT()
       fCleanups->Clear();
       delete fPluginManager; gPluginMgr = fPluginManager = 0;
       delete gClassTable;  gClassTable = 0;
-      ROOT::Internal::SetErrorIgnoreLevelHandler(ROOT::Internal::ErrorIgnoreLevelHandlerFunc_t());
       delete gEnv; gEnv = 0;
 
       if (fTypes) fTypes->Delete();

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -67,6 +67,7 @@ of a main program creating an interactive version is shown below:
 */
 
 #include <ROOT/RConfig.hxx>
+#include <ROOT/TErrorDefaultHandler.hxx>
 #include "RConfigure.h"
 #include "RConfigOptions.h"
 #include "RVersion.h"
@@ -942,6 +943,7 @@ TROOT::~TROOT()
       // Cleanup system class
       ROOT::Internal::SetErrorSystemMsgHandler(ROOT::Internal::ErrorSystemMsgHandlerFunc_t());
       SetErrorHandler(ROOT::Internal::MinimalErrorHandler);
+      ROOT::Internal::ReleaseDefaultErrorHandler();
       delete gSystem;
 
       // ROOT-6022:

--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -17,3 +17,5 @@ ROOT_ADD_GTEST(CoreBaseTests
   TQObjectTests.cxx
   TExceptionHandlerTests.cxx
   LIBRARIES Core Cling RIO ${dllib})
+
+ROOT_ADD_GTEST(CoreErrorTests TErrorTests.cxx LIBRARIES Core)

--- a/core/base/test/TErrorTests.cxx
+++ b/core/base/test/TErrorTests.cxx
@@ -34,6 +34,8 @@ TEST(TError, Basics) {
    EXPECT_STRNE("message", gTestLastMsg.c_str());
 
    ROOT::Internal::gROOTLocal->~TROOT();
+   // The TROOT destructor re-installed the minimal error handler
+   SetErrorHandler(TestErrorHandler);
 
    errno = 42;
    SysError("location", "message");

--- a/core/base/test/TErrorTests.cxx
+++ b/core/base/test/TErrorTests.cxx
@@ -1,0 +1,41 @@
+#include "gtest/gtest.h"
+
+#include "TError.h"
+#include "TROOT.h"
+
+#include <cerrno>
+#include <string>
+
+int gTestLastLevel = -1;
+bool gTestLastAbort = false;
+std::string gTestLastLocation;
+std::string gTestLastMsg;
+
+void TestErrorHandler(int level, Bool_t abort, const char *location, const char *msg)
+{
+   gTestLastLevel = level;
+   gTestLastAbort = abort;
+   gTestLastLocation = location;
+   gTestLastMsg = msg;
+}
+
+TEST(TError, Basics) {
+   ASSERT_TRUE(gROOT);
+   SetErrorHandler(TestErrorHandler);
+
+   Info("location", "message");
+   EXPECT_STREQ("location", gTestLastLocation.c_str());
+   EXPECT_STREQ("message", gTestLastMsg.c_str());
+   EXPECT_FALSE(gTestLastAbort);
+
+   errno = 42;
+   SysError("location", "message");
+   // We expect the explanation for errno 42
+   EXPECT_STRNE("message", gTestLastMsg.c_str());
+
+   ROOT::Internal::gROOTLocal->~TROOT();
+
+   errno = 42;
+   SysError("location", "message");
+   EXPECT_STREQ("message (errno: 42)", gTestLastMsg.c_str());
+}


### PR DESCRIPTION
In preparation of moving TError to foundation, this PR removes the direct use of gEnv and gSystem from TError.  The functionality is implemented by helper functions instead, which are registered and de-registered upon creation and destruction gEnv and gSystem.  The three tasks implemented by helpers are

- Read the ROOT environment in order to get the value of `Root.ErrorIgnoreLevel`
- Get the last system error message
- Abort the process