### PR TITLE
Veto roostats tutorial TestNonCentral.C when mathmore is not present.

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -155,7 +155,8 @@ if(NOT ROOT_mathmore_FOUND)
       math/Legendre.C
       math/mathmoreIntegration.C
       math/tStudent.C
-      math/normalDist.C)
+      math/normalDist.C
+      roostats/TestNonCentral.C )
 endif()
 
 if(NOT ROOT_fftw3_FOUND)


### PR DESCRIPTION
This Fixes ROOT-10818