### PR TITLE
Fix crash when only part of the open canvases has been closed

### DIFF
--- a/graf2d/cocoa/src/CocoaPrivate.mm
+++ b/graf2d/cocoa/src/CocoaPrivate.mm
@@ -122,6 +122,7 @@ NSObject<X11Window> *CocoaPrivate::GetWindow(Window_t windowID)const
       } else {
          NSLog(@"This window not found among allocated/deleted drawables");
       }
+      return 0;
    }
 #endif
    assert(winIter != fDrawables.end() && "GetWindow, non-existing window requested");

--- a/graf2d/cocoa/src/TGCocoa.mm
+++ b/graf2d/cocoa/src/TGCocoa.mm
@@ -3441,6 +3441,8 @@ void TGCocoa::SetDoubleBufferON()
 
    NSObject<X11Window> * const window = fPimpl->GetWindow(fSelectedDrawable);
 
+   if (!window) return;
+
    assert(window.fIsPixmap == NO &&
           "SetDoubleBufferON, selected drawable is a pixmap, can not attach pixmap to pixmap");
 


### PR DESCRIPTION
Fix crash on teardown when only part of the open canvases has been closed.
This was reported here: https://sft.its.cern.ch/jira/browse/ROOT-10836