### PR TITLE
[unix] No linked so does not mean failure on MacOS:

### DIFF
--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -523,8 +523,15 @@ static void DylibAdded(const struct mach_header *mh, intptr_t /* vmaddr_slide */
    // explicitly linked against the executable. Additional dylibs
    // come when they are explicitly linked against loaded so's, currently
    // we are not interested in these
-   if (lib.EndsWith("/libSystem.B.dylib"))
+   if (lib.EndsWith("/libSystem.B.dylib")) {
       gotFirstSo = kTRUE;
+      if (linkedDylibs.IsNull()) {
+         // TSystem::GetLibraries() assumes that an empty GetLinkedLibraries()
+         // means failure to extract the linked libraries. Signal "we did
+         // manage, but it's empty" by returning a single space.
+         linkedDylibs = ' ';
+      }
+   }
 
    // add all libs loaded before libSystem.B.dylib
    if (!gotFirstSo && (lib.EndsWith(".dylib") || lib.EndsWith(".so"))) {


### PR DESCRIPTION
An empty list of linked libraries was interpreted as failure to extract
the list of linked libraries; the default "-lCore -lRint..." was taken instead.
When running python, no libs show up as linked. That caused "-lRint" to be claimed
as linked, which was preventing gSystem.Load("libRint") within python, claiming
that it is already loaded (as it is linked).

Instead, if the library signaling the end of linked libraries is seen, and so far
no libraries have been found as linked, set the list-of-linked-libraries to " ",
i.e. not empty, triggering the "success" path in TSystem::GetLibraries(), and correctly
reporting the linked libraries.

This fixes JupyROOT-cppcompleter-doctest, JupyROOT-ROOT-kernel-notebook not finding
TTabCom::TTabCom() because loadling libRint was mistakenly a no-op.