### PR TITLE
[RF][ROOT-10845] Correct IsOnHeap() for RooFit objects.

### DIFF
--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -24,6 +24,8 @@
 #ifndef ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_
 #define ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_
 
+#include "TStorage.h"
+
 #include <vector>
 #include <algorithm>
 #include <set>
@@ -33,7 +35,7 @@ class MemPoolForRooSets {
 
   struct Arena {
     Arena()
-      : ownedMemory{static_cast<RooSet_t *>(::operator new(POOLSIZE * sizeof(RooSet_t)))},
+      : ownedMemory{static_cast<RooSet_t *>(TStorage::ObjectAlloc(POOLSIZE * sizeof(RooSet_t)))},
         memBegin{ownedMemory}, nextItem{ownedMemory},
         memEnd{memBegin + POOLSIZE}, refCount{0}
     {

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 ROOT_ADD_GTEST(testRooWrapperPdf testRooWrapperPdf.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testGenericPdf testGenericPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooAbsPdf testRooAbsPdf.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testRooAbsCollection testRooAbsCollection.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)
 ROOT_ADD_GTEST(testRooFormula testRooFormula.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testProxiesAndCategories testProxiesAndCategories.cxx

--- a/roofit/roofitcore/test/testRooAbsCollection.cxx
+++ b/roofit/roofitcore/test/testRooAbsCollection.cxx
@@ -1,0 +1,14 @@
+// Tests for the RooAbsCollection and derived classes
+// Authors: Stephan Hageboeck, CERN  05/2020
+#include "RooArgSet.h"
+
+#include "gtest/gtest.h"
+
+/// ROOT-10845 IsOnHeap() always returned false.
+TEST(RooArgSet, IsOnHeap) {
+  auto setp = new RooArgSet();
+  EXPECT_TRUE(setp->IsOnHeap());
+
+  RooArgSet setStack;
+  EXPECT_FALSE(setStack.IsOnHeap());
+}

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -181,3 +181,11 @@ TEST(RooDataSet, ReducingData) {
   }
 }
 
+/// ROOT-10845 IsOnHeap() always returned false.
+TEST(RooDataSet, IsOnHeap) {
+  auto setp = new RooDataSet();
+  EXPECT_TRUE(setp->IsOnHeap());
+
+  RooDataSet setStack;
+  EXPECT_FALSE(setStack.IsOnHeap());
+}


### PR DESCRIPTION
Since RooDataSet and RooArgSet use their own operator new, IsOnHeap was
returning false. Now, memory is allocated using TStorage, which
correctly sets the kIsOnHeap bit if necessary.