### PR TITLE
[PyROOT] Add ISO8859-1 to list of known modules at import time

### DIFF
--- a/bindings/pyroot/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot/pythonizations/test/import_load_libs.py
@@ -60,6 +60,7 @@ class ImportLoadLibs(unittest.TestCase):
             'binascii',
             'libbz2',
             'libexpat',
+            'ISO8859-1',
             # System libraries and others
             'libnss_.*',
             'ld.*',


### PR DESCRIPTION
The module ISO8859-1 is used for text encoding, appeared first on
fedora32.