### PR TITLE
[ntuple] check for valid NTuple top-level field names (ROOT-10856)

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -25,6 +25,7 @@
 #include <TError.h>
 
 #include <memory>
+#include <unordered_set>
 #include <utility>
 
 namespace ROOT {
@@ -49,6 +50,10 @@ class RNTupleModel {
    std::unique_ptr<RFieldRoot> fRootField;
    /// Contains field values corresponding to the created top-level fields
    std::unique_ptr<REntry> fDefaultEntry;
+   /// Keeps track of which field names are taken.
+   std::unordered_set<std::string> fFieldNames;
+
+   void EnsureUniqueFieldName(const std::string& fieldName);
 
 public:
    RNTupleModel();
@@ -62,6 +67,7 @@ public:
    /// Creates a new field and a corresponding tree value that is managed by a shared pointer.
    template <typename T, typename... ArgsT>
    std::shared_ptr<T> MakeField(std::string_view fieldName, ArgsT&&... args) {
+      EnsureUniqueFieldName(std::string(fieldName));
       auto field = std::make_unique<RField<T>>(fieldName);
       auto ptr = fDefaultEntry->AddValue<T>(field.get(), std::forward<ArgsT>(args)...);
       fRootField->Attach(std::move(field));
@@ -73,6 +79,7 @@ public:
 
    template <typename T>
    void AddField(std::string_view fieldName, T* fromWhere) {
+      EnsureUniqueFieldName(std::string(fieldName));
       auto field = std::make_unique<RField<T>>(fieldName);
       fDefaultEntry->CaptureValue(field->CaptureValue(fromWhere));
       fRootField->Attach(std::move(field));

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -53,7 +53,7 @@ class RNTupleModel {
    /// Keeps track of which field names are taken.
    std::unordered_set<std::string> fFieldNames;
 
-   void EnsureUniqueFieldName(const std::string& fieldName);
+   void EnsureUniqueFieldName(std::string_view fieldName);
 
 public:
    RNTupleModel();
@@ -67,7 +67,7 @@ public:
    /// Creates a new field and a corresponding tree value that is managed by a shared pointer.
    template <typename T, typename... ArgsT>
    std::shared_ptr<T> MakeField(std::string_view fieldName, ArgsT&&... args) {
-      EnsureUniqueFieldName(std::string(fieldName));
+      EnsureUniqueFieldName(fieldName);
       auto field = std::make_unique<RField<T>>(fieldName);
       auto ptr = fDefaultEntry->AddValue<T>(field.get(), std::forward<ArgsT>(args)...);
       fRootField->Attach(std::move(field));
@@ -79,7 +79,7 @@ public:
 
    template <typename T>
    void AddField(std::string_view fieldName, T* fromWhere) {
-      EnsureUniqueFieldName(std::string(fieldName));
+      EnsureUniqueFieldName(fieldName);
       auto field = std::make_unique<RField<T>>(fieldName);
       fDefaultEntry->CaptureValue(field->CaptureValue(fromWhere));
       fRootField->Attach(std::move(field));

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -53,7 +53,9 @@ class RNTupleModel {
    /// Keeps track of which field names are taken.
    std::unordered_set<std::string> fFieldNames;
 
-   void EnsureUniqueFieldName(std::string_view fieldName);
+   /// Checks that user-provided field names are valid. Throws an RException
+   /// for invalid names.
+   void EnsureValidFieldName(std::string_view fieldName);
 
 public:
    RNTupleModel();
@@ -67,7 +69,7 @@ public:
    /// Creates a new field and a corresponding tree value that is managed by a shared pointer.
    template <typename T, typename... ArgsT>
    std::shared_ptr<T> MakeField(std::string_view fieldName, ArgsT&&... args) {
-      EnsureUniqueFieldName(fieldName);
+      EnsureValidFieldName(fieldName);
       auto field = std::make_unique<RField<T>>(fieldName);
       auto ptr = fDefaultEntry->AddValue<T>(field.get(), std::forward<ArgsT>(args)...);
       fRootField->Attach(std::move(field));
@@ -79,7 +81,7 @@ public:
 
    template <typename T>
    void AddField(std::string_view fieldName, T* fromWhere) {
-      EnsureUniqueFieldName(fieldName);
+      EnsureValidFieldName(fieldName);
       auto field = std::make_unique<RField<T>>(fieldName);
       fDefaultEntry->CaptureValue(field->CaptureValue(fromWhere));
       fRootField->Attach(std::move(field));

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -30,6 +30,8 @@ void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fie
       throw RException(R__FAIL("field name '" + fieldNameStr + "' already exists"));
    } else if (fieldNameStr == "") {
       throw RException(R__FAIL("field name cannot be empty string \"\""));
+   } else if (fieldNameStr.find(".") != std::string::npos) {
+      throw RException(R__FAIL("field name '" + fieldNameStr + "' cannot contain periods '.'"));
    }
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -13,14 +13,12 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTuple.hxx>
 
-#include <TError.h>
-
 #include <cstdlib>
-#include <exception>
 #include <memory>
 #include <utility>
 
@@ -28,7 +26,7 @@
 void ROOT::Experimental::RNTupleModel::EnsureUniqueFieldName(const std::string& fieldName)
 {
    if (fFieldNames.insert(fieldName).second == false) {
-      throw std::runtime_error("RNTupleModel::MakeField: field name '" + fieldName + "' already exists");
+      throw RException(R__FAIL("field name '" + fieldName + "' already exists"));
    }
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -31,7 +31,7 @@ void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fie
    } else if (fieldNameStr == "") {
       throw RException(R__FAIL("field name cannot be empty string \"\""));
    } else if (fieldNameStr.find(".") != std::string::npos) {
-      throw RException(R__FAIL("field name '" + fieldNameStr + "' cannot contain periods '.'"));
+      throw RException(R__FAIL("field name '" + fieldNameStr + "' cannot contain dot characters '.'"));
    }
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -23,10 +23,11 @@
 #include <utility>
 
 
-void ROOT::Experimental::RNTupleModel::EnsureUniqueFieldName(const std::string& fieldName)
+void ROOT::Experimental::RNTupleModel::EnsureUniqueFieldName(std::string_view fieldName)
 {
-   if (fFieldNames.insert(fieldName).second == false) {
-      throw RException(R__FAIL("field name '" + fieldName + "' already exists"));
+   auto fieldNameStr = std::string(fieldName);
+   if (fFieldNames.insert(fieldNameStr).second == false) {
+      throw RException(R__FAIL("field name '" + fieldNameStr + "' already exists"));
    }
 }
 
@@ -56,7 +57,7 @@ void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBa
 std::shared_ptr<ROOT::Experimental::RCollectionNTuple> ROOT::Experimental::RNTupleModel::MakeCollection(
    std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)
 {
-   EnsureUniqueFieldName(std::string(fieldName));
+   EnsureUniqueFieldName(fieldName);
    auto collectionNTuple = std::make_shared<RCollectionNTuple>(std::move(collectionModel->fDefaultEntry));
    auto field = std::make_unique<RCollectionField>(fieldName, collectionNTuple, std::move(collectionModel));
    fDefaultEntry->CaptureValue(field->CaptureValue(collectionNTuple->GetOffsetPtr()));

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -23,11 +23,13 @@
 #include <utility>
 
 
-void ROOT::Experimental::RNTupleModel::EnsureUniqueFieldName(std::string_view fieldName)
+void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fieldName)
 {
    auto fieldNameStr = std::string(fieldName);
    if (fFieldNames.insert(fieldNameStr).second == false) {
       throw RException(R__FAIL("field name '" + fieldNameStr + "' already exists"));
+   } else if (fieldNameStr == "") {
+      throw RException(R__FAIL("field name cannot be empty string \"\""));
    }
 }
 
@@ -48,7 +50,7 @@ ROOT::Experimental::RNTupleModel* ROOT::Experimental::RNTupleModel::Clone()
 
 void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBase> field)
 {
-   EnsureUniqueFieldName(field->GetName());
+   EnsureValidFieldName(field->GetName());
    fDefaultEntry->AddValue(field->GenerateValue());
    fRootField->Attach(std::move(field));
 }
@@ -57,7 +59,7 @@ void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBa
 std::shared_ptr<ROOT::Experimental::RCollectionNTuple> ROOT::Experimental::RNTupleModel::MakeCollection(
    std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)
 {
-   EnsureUniqueFieldName(fieldName);
+   EnsureValidFieldName(fieldName);
    auto collectionNTuple = std::make_shared<RCollectionNTuple>(std::move(collectionModel->fDefaultEntry));
    auto field = std::make_unique<RCollectionField>(fieldName, collectionNTuple, std::move(collectionModel));
    fDefaultEntry->CaptureValue(field->CaptureValue(collectionNTuple->GetOffsetPtr()));

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -20,9 +20,17 @@
 #include <TError.h>
 
 #include <cstdlib>
+#include <exception>
 #include <memory>
 #include <utility>
 
+
+void ROOT::Experimental::RNTupleModel::EnsureUniqueFieldName(const std::string& fieldName)
+{
+   if (fFieldNames.insert(fieldName).second == false) {
+      throw std::runtime_error("RNTupleModel::MakeField: field name '" + fieldName + "' already exists");
+   }
+}
 
 ROOT::Experimental::RNTupleModel::RNTupleModel()
   : fRootField(std::make_unique<RFieldRoot>())
@@ -41,6 +49,7 @@ ROOT::Experimental::RNTupleModel* ROOT::Experimental::RNTupleModel::Clone()
 
 void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBase> field)
 {
+   EnsureUniqueFieldName(field->GetName());
    fDefaultEntry->AddValue(field->GenerateValue());
    fRootField->Attach(std::move(field));
 }
@@ -49,6 +58,7 @@ void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBa
 std::shared_ptr<ROOT::Experimental::RCollectionNTuple> ROOT::Experimental::RNTupleModel::MakeCollection(
    std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)
 {
+   EnsureUniqueFieldName(std::string(fieldName));
    auto collectionNTuple = std::make_shared<RCollectionNTuple>(std::move(collectionModel->fDefaultEntry));
    auto field = std::make_unique<RCollectionField>(fieldName, collectionNTuple, std::move(collectionModel));
    fDefaultEntry->CaptureValue(field->CaptureValue(collectionNTuple->GetOffsetPtr()));

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -212,7 +212,8 @@ TEST(RNTuple, Clusters)
    EXPECT_EQ(24.0, (*rdFourVec)[1]);
 }
 
-TEST(RNTupleModel, EnforceUniqueFieldNames)
+
+TEST(RNTupleModel, EnforceValidFieldNames)
 {
    auto model = RNTupleModel::Create();
    auto field = model->MakeField<float>("pt", 42.0);
@@ -222,8 +223,11 @@ TEST(RNTupleModel, EnforceUniqueFieldNames)
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
    }
-   auto field2 = model->MakeField<float>("pt2", 42.0);
 
-   // corner case -- doesn't apply to NTuple's FieldZero
-   auto field3 = model->MakeField<float>("", 42.0);
+   try {
+      auto field3 = model->MakeField<float>("", 42.0);
+      FAIL() << "empty string as field name should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field name cannot be empty string"));
+   }
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -216,26 +216,41 @@ TEST(RNTuple, Clusters)
 TEST(RNTupleModel, EnforceValidFieldNames)
 {
    auto model = RNTupleModel::Create();
+
    auto field = model->MakeField<float>("pt", 42.0);
 
+   // MakeField
    try {
       auto field2 = model->MakeField<float>("pt", 42.0);
       FAIL() << "repeated field names should throw";
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
    }
-
    try {
       auto field3 = model->MakeField<float>("", 42.0);
       FAIL() << "empty string as field name should throw";
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("field name cannot be empty string"));
    }
-
    try {
       auto field3 = model->MakeField<float>("pt.pt", 42.0);
       FAIL() << "field name with periods should throw";
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt.pt' cannot contain periods '.'"));
+   }
+
+   // AddField
+   try {
+      model->AddField(std::make_unique<RField<float>>(RField<float>("pt")));
+      FAIL() << "repeated field names should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
+   }
+   try {
+      float num = 10.0;
+      model->AddField("pt", &num);
+      FAIL() << "repeated field names should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
    }
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -211,3 +211,19 @@ TEST(RNTuple, Clusters)
    EXPECT_EQ(42.0, (*rdNnlo)[0][0]);
    EXPECT_EQ(24.0, (*rdFourVec)[1]);
 }
+
+TEST(RNTupleModel, EnforceUniqueFieldNames)
+{
+   auto model = RNTupleModel::Create();
+   auto field = model->MakeField<float>("pt", 42.0);
+   try {
+      auto field2 = model->MakeField<float>("pt", 42.0);
+      FAIL() << "repeated field names should throw";
+   } catch (const std::runtime_error& err) {
+     EXPECT_STREQ(err.what(), "RNTupleModel::MakeField: field name 'pt' already exists");
+   }
+   auto field2 = model->MakeField<float>("pt2", 42.0);
+
+   // corner case -- doesn't apply to NTuple's FieldZero
+   auto field3 = model->MakeField<float>("", 42.0);
+}

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -217,6 +217,7 @@ TEST(RNTupleModel, EnforceValidFieldNames)
 {
    auto model = RNTupleModel::Create();
    auto field = model->MakeField<float>("pt", 42.0);
+
    try {
       auto field2 = model->MakeField<float>("pt", 42.0);
       FAIL() << "repeated field names should throw";
@@ -229,5 +230,12 @@ TEST(RNTupleModel, EnforceValidFieldNames)
       FAIL() << "empty string as field name should throw";
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("field name cannot be empty string"));
+   }
+
+   try {
+      auto field3 = model->MakeField<float>("pt.pt", 42.0);
+      FAIL() << "field name with periods should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt.pt' cannot contain periods '.'"));
    }
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -236,7 +236,7 @@ TEST(RNTupleModel, EnforceValidFieldNames)
       auto field3 = model->MakeField<float>("pt.pt", 42.0);
       FAIL() << "field name with periods should throw";
    } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt.pt' cannot contain periods '.'"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt.pt' cannot contain dot characters '.'"));
    }
 
    // AddField

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -219,8 +219,8 @@ TEST(RNTupleModel, EnforceUniqueFieldNames)
    try {
       auto field2 = model->MakeField<float>("pt", 42.0);
       FAIL() << "repeated field names should throw";
-   } catch (const std::runtime_error& err) {
-     EXPECT_STREQ(err.what(), "RNTupleModel::MakeField: field name 'pt' already exists");
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
    }
    auto field2 = model->MakeField<float>("pt2", 42.0);
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -253,4 +253,18 @@ TEST(RNTupleModel, EnforceValidFieldNames)
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
    }
+
+   // MakeCollection
+   try {
+      auto otherModel = RNTupleModel::Create();
+      auto collection = model->MakeCollection("pt", std::move(otherModel));
+      FAIL() << "repeated field names should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt' already exists"));
+   }
+
+   // subfield names don't throw because full name differs (otherModel.pt)
+   auto otherModel = RNTupleModel::Create();
+   auto otherField = otherModel->MakeField<float>("pt", 42.0);
+   auto collection = model->MakeCollection("otherModel", std::move(otherModel));
 }

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -3,6 +3,7 @@
 
 #include <ROOT/RColumnModel.hxx>
 #include <ROOT/RDataFrame.hxx>
+#include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RFieldVisitor.hxx>
@@ -26,6 +27,7 @@
 #include <TFile.h>
 #include <TRandom3.h>
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #include "CustomStruct.hxx"
@@ -50,6 +52,7 @@ using ENTupleContainerFormat = ROOT::Experimental::ENTupleContainerFormat;
 using ENTupleStructure = ROOT::Experimental::ENTupleStructure;
 using NTupleSize_t = ROOT::Experimental::NTupleSize_t;
 using RColumnModel = ROOT::Experimental::RColumnModel;
+using RException = ROOT::Experimental::RException;
 template <class T>
 using RField = ROOT::Experimental::RField<T>;
 using RFieldBase = ROOT::Experimental::Detail::RFieldBase;


### PR DESCRIPTION
Fixes ROOT-10856 by keeping track of field names and throwing an exception if there's a name conflict. 

Edit: expanded PR scope to ensure field names are valid as well as unique (e.g. no empty string).  

~~**todo**~~ **done:** add unit test per method to ensure technique works:
- [x] `std::shared_ptr<T> MakeField(std::string_view fieldName, ArgsT&&... args)`
- [x] `void AddField(std::string_view fieldName, T* fromWhere)`
- [x] `void AddField(std::unique_ptr<Detail::RFieldBase> field)`
- [x] `std::shared_ptr<RCollectionNTuple> MakeCollection(std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)`

