### PR TITLE
[thstack] fix error in options decoding, fix gcc10 warnings

### DIFF
--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -799,16 +799,16 @@ void THStack::Paint(Option_t *choptin)
    }
 
    TString loption = opt;
-   char *nostack  = (char *)strstr(loption.Data(),"nostack");
-   char *nostackb = (char *)strstr(loption.Data(),"nostackb");
-   char *candle   = (char *)strstr(loption.Data(),"candle");
-   char *violin   = (char *)strstr(loption.Data(),"violin");
+   Bool_t nostack  = loption.Contains("nostack");
+   Bool_t nostackb = loption.Contains("nostackb");
+   Bool_t candle   = loption.Contains("candle");
+   Bool_t violin   = loption.Contains("violin");
 
    // do not delete the stack. Another pad may contain the same object
    // drawn in stack mode!
    //if (nostack && fStack) {fStack->Delete(); delete fStack; fStack = 0;}
 
-   if (!opt.Contains("nostack") && (!opt.Contains("candle")) && (!opt.Contains("violin"))) BuildStack();
+   if (!nostack && !candle && !violin) BuildStack();
 
    Double_t themax,themin;
    if (fMaximum == -1111) themax = GetMaximum(option);
@@ -831,7 +831,7 @@ void THStack::Paint(Option_t *choptin)
       TAxis *yaxis = h->GetYaxis();
       const TArrayD *xbins = xaxis->GetXbins();
       if (h->GetDimension() > 1) {
-         if (loption.Length()<=0) loption.Form("%s","lego1");
+         if (loption.IsNull()) loption = "lego1";
          const TArrayD *ybins = yaxis->GetXbins();
          if (xbins->fN != 0 && ybins->fN != 0) {
             fHistogram = new TH2F(GetName(),GetTitle(),
@@ -864,9 +864,12 @@ void THStack::Paint(Option_t *choptin)
       fHistogram->SetTitle(GetTitle());
    }
 
-   if (nostack)  {*nostack  = 0; strncat(nostack,nostack+7,7);}
-   if (nostackb) {*nostackb = 0; strncat(nostackb,nostackb+8,8);}
-   else fHistogram->GetPainter()->SetStack(fHists);
+   if (nostackb) {
+      loption.ReplaceAll("nostackb","");
+   } else {
+      if (nostack) loption.ReplaceAll("nostack","");
+      fHistogram->GetPainter()->SetStack(fHists);
+   }
 
    if (!fHistogram->TestBit(TH1::kIsZoomed)) {
       if (nostack && fMaximum != -1111) fHistogram->SetMaximum(fMaximum);


### PR DESCRIPTION
Old code was trying to manipulate TString::Data() directly and
has several caveats. Now just check if some special options are present

Following code which should suppress "nostack" or "nostackb" was wrong:
```
   if (nostack)  {*nostack  = 0; strncat(nostack,nostack+7,7);}
   if (nostackb) {*nostackb = 0; strncat(nostackb,nostackb+8,8);}
```
If lopion = "nostackb", then first operation was preformed, then second, making absolutely  unpredictable results.

Also length parameter was wrong - why copy only 7 characters when just want to remove "nostack" string and copying 8 characters when want to remove "nostackb" string?

Now just use boolean values and normal TString methods.
Also fixing warnings, which appears with gcc 10 like this:

https://cdash.cern.ch/viewBuildError.php?type=1&buildid=901702
