### PR TITLE
Revert "Fix logic of handling dependencies when NO_CXXMODULE is specified"

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -562,15 +562,11 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   #---Get the library and module dependencies-----------------
   if(ARG_DEPENDENCIES)
     foreach(dep ${ARG_DEPENDENCIES})
-      set(dict "$<TARGET_NAME_IF_EXISTS:G__${dep}>")
-      set(dependent_pcm ${libprefix}${dep}_rdict.pcm})
-      if(runtime_cxxmodules)
-        #---Check for NO_CXXMODULE flag in a dependent module---
-        set(dependent_pcm "$<IF:$<BOOL:$<TARGET_PROPERTY:${dict},ARG_NO_MODULE>>,,-m ${dep}.pcm>")
-        set(newargs ${newargs} ${dependent_pcm})
-      else()
-        set(newargs ${newargs} -m ${dependent_pcm})
+      set(dependent_pcm ${libprefix}${dep}_rdict.pcm)
+      if (runtime_cxxmodules)
+        set(dependent_pcm ${dep}.pcm)
       endif()
+      set(newargs ${newargs} -m  ${dependent_pcm})
     endforeach()
   endif()
 
@@ -647,7 +643,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   # would not happen if we used target_sources() directly with the dictionary source.
   if(TARGET "${ARG_MODULE}" AND NOT "${ARG_MODULE}" STREQUAL "${dictionary}")
     add_library(${dictionary} OBJECT ${dictionary}.cxx)
-    set_target_properties(${dictionary} PROPERTIES POSITION_INDEPENDENT_CODE TRUE ARG_NO_MODULE ${ARG_NO_CXXMODULE})
+    set_target_properties(${dictionary} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
     target_sources(${ARG_MODULE} PRIVATE $<TARGET_OBJECTS:${dictionary}>)
 
     target_compile_options(${dictionary} PRIVATE


### PR DESCRIPTION
This reverts commit 276c4b2066219ac63f1175ddbbf9886816557580 as the former causes problems with earlier CMake versions.