### PR TITLE
[ntuple] avoid inheriting from std::iterator for all homebrew iterators (NFC)

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -112,18 +112,24 @@ protected:
 
 public:
    /// Iterates over the sub tree of fields in depth-first search order
-   class RSchemaIterator : public std::iterator<std::forward_iterator_tag, Detail::RFieldBase> {
+   class RSchemaIterator {
    private:
-      using iterator = RSchemaIterator;
       struct Position {
          Position() : fFieldPtr(nullptr), fIdxInParent(-1) { }
-         Position(pointer fieldPtr, int idxInParent) : fFieldPtr(fieldPtr), fIdxInParent(idxInParent) { }
-         pointer fFieldPtr;
+         Position(RFieldBase *fieldPtr, int idxInParent) : fFieldPtr(fieldPtr), fIdxInParent(idxInParent) { }
+         RFieldBase *fFieldPtr;
          int fIdxInParent;
       };
       /// The stack of nodes visited when walking down the tree of fields
       std::vector<Position> fStack;
    public:
+      using iterator = RSchemaIterator;
+      using iterator_category = std::forward_iterator_tag;
+      using value_type = RFieldBase;
+      using difference_type = std::ptrdiff_t;
+      using pointer = RFieldBase*;
+      using reference = RFieldBase&;
+
       RSchemaIterator() { fStack.emplace_back(Position()); }
       RSchemaIterator(pointer val, int idxInParent) { fStack.emplace_back(Position(val, idxInParent)); }
       ~RSchemaIterator() {}

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -81,11 +81,17 @@ private:
 
 public:
    // Browse through the entries
-   class RIterator : public std::iterator<std::forward_iterator_tag, NTupleSize_t> {
+   class RIterator {
    private:
-      using iterator = RIterator;
       NTupleSize_t fIndex = kInvalidNTupleIndex;
    public:
+      using iterator = RIterator;
+      using iterator_category = std::forward_iterator_tag;
+      using value_type = NTupleSize_t;
+      using difference_type = NTupleSize_t;
+      using pointer = NTupleSize_t*;
+      using reference = NTupleSize_t&;
+
       RIterator() = default;
       explicit RIterator(NTupleSize_t index) : fIndex(index) {}
       ~RIterator() = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -42,11 +42,17 @@ private:
    const NTupleSize_t fStart;
    const NTupleSize_t fEnd;
 public:
-   class RIterator : public std::iterator<std::forward_iterator_tag, NTupleSize_t> {
+   class RIterator {
    private:
-      using iterator = RIterator;
       NTupleSize_t fIndex = kInvalidNTupleIndex;
    public:
+      using iterator = RIterator;
+      using iterator_category = std::forward_iterator_tag;
+      using value_type = NTupleSize_t;
+      using difference_type = NTupleSize_t;
+      using pointer = NTupleSize_t*;
+      using reference = NTupleSize_t&;
+
       RIterator() = default;
       explicit RIterator(NTupleSize_t index) : fIndex(index) {}
       ~RIterator() = default;
@@ -78,11 +84,17 @@ private:
    const ClusterSize_t::ValueType fStart;
    const ClusterSize_t::ValueType fEnd;
 public:
-   class RIterator : public std::iterator<std::forward_iterator_tag, RClusterIndex> {
+   class RIterator {
    private:
-      using iterator = RIterator;
       RClusterIndex fIndex;
    public:
+      using iterator = RIterator;
+      using iterator_category = std::forward_iterator_tag;
+      using value_type = RClusterIndex;
+      using difference_type = RClusterIndex;
+      using pointer = RClusterIndex*;
+      using reference = RClusterIndex&;
+
       RIterator() = default;
       explicit RIterator(const RClusterIndex &index) : fIndex(index) {}
       ~RIterator() = default;


### PR DESCRIPTION
This is sadly more verbose, but I thought I'd bring all the other iterators in line with C++17 where inheriting from std::iterator is deprecated (https://en.cppreference.com/w/cpp/iterator/iterator). 
I mostly followed the guidelines here https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/