### PR TITLE
In MakeProject properly handle ptr in template args.

### DIFF
--- a/io/io/src/TMakeProject.cxx
+++ b/io/io/src/TMakeProject.cxx
@@ -669,11 +669,11 @@ TString TMakeProject::UpdateAssociativeToVector(const char *name)
       Int_t stlkind =  TMath::Abs(TClassEdit::STLKind(inside[0]));
 
       for(unsigned int i = 1; i<narg; ++i) {
-         // Treat the trailing stars the same as nested loc.
          inside[i] = UpdateAssociativeToVector( inside[i].c_str() );
       }
       if (nestedLoc) narg = nestedLoc;
 
+      // Treat the trailing stars the same as nested loc (i.e. ends up, properly, tacking them up back at the end of the name)
       if (!inside[narg-1].empty() && inside[narg-1][0] == '*')
          narg = narg - 1;
 

--- a/io/io/src/TMakeProject.cxx
+++ b/io/io/src/TMakeProject.cxx
@@ -671,6 +671,7 @@ TString TMakeProject::UpdateAssociativeToVector(const char *name)
       for(unsigned int i = 1; i<narg; ++i) {
          inside[i] = UpdateAssociativeToVector( inside[i].c_str() );
       }
+
       if (nestedLoc) narg = nestedLoc;
 
       // Treat the trailing stars the same as nested loc (i.e. ends up, properly, tacking them up back at the end of the name)

--- a/io/io/src/TMakeProject.cxx
+++ b/io/io/src/TMakeProject.cxx
@@ -669,10 +669,14 @@ TString TMakeProject::UpdateAssociativeToVector(const char *name)
       Int_t stlkind =  TMath::Abs(TClassEdit::STLKind(inside[0]));
 
       for(unsigned int i = 1; i<narg; ++i) {
+         // Treat the trailing stars the same as nested loc.
          inside[i] = UpdateAssociativeToVector( inside[i].c_str() );
       }
-
       if (nestedLoc) narg = nestedLoc;
+
+      if (!inside[narg-1].empty() && inside[narg-1][0] == '*')
+         narg = narg - 1;
+
 
       // Remove default allocator if any.
       static const char* allocPrefix = "std::allocator<";


### PR DESCRIPTION
Without this std::map<int,std::vector<double>* > got corrupted into std::map<int,std::vector<double,*> >.

This fixes ROOT-10796