### PR TITLE
Introducing RPave class, imrpove RLegend

### DIFF
--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -39,6 +39,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RPadLength.hxx
     ROOT/RPadPos.hxx
     ROOT/RPadUserAxis.hxx
+    ROOT/RPave.hxx
     ROOT/RVirtualCanvasPainter.hxx
   SOURCES
     src/RCanvas.cxx

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -59,6 +59,7 @@
 #pragma link C++ class ROOT::Experimental::RFrame+;
 #pragma link C++ class ROOT::Experimental::RFrame::RUserRanges+;
 #pragma link C++ class ROOT::Experimental::RFrame::RZoomRequest+;
+#pragma link C++ class ROOT::Experimental::RPave+;
 #pragma link C++ class ROOT::Experimental::RPadLength+;
 #pragma link C++ class ROOT::Experimental::RPadLength::Pixel+;
 #pragma link C++ class ROOT::Experimental::RPadLength::Normal+;

--- a/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
@@ -25,7 +25,7 @@ namespace Experimental {
 
 class RAttrFill : public RAttrBase {
 
-   RAttrColor fColor{this, "color_"}; ///<! line color, will access container from line attributes
+   RAttrColor fColor{this, "color_"}; ///<! fill color, will access container from fill attributes
 
    R__ATTR_CLASS(RAttrFill, "fill_", AddInt("style", 1).AddDefaults(fColor));
 

--- a/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
@@ -77,6 +77,10 @@ public:
       fDrawable = &dr;
    }
 
+   const RDrawable *GetDrawable() const { return fDrawable; }
+
+   virtual ~RDrawableDisplayItem();
+
 };
 
 

--- a/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
@@ -18,6 +18,7 @@
 
 #include <vector>
 #include <string>
+#include <cmath>
 
 namespace ROOT {
 namespace Experimental {
@@ -225,7 +226,7 @@ public:
       if (HasNormal() || rhs.HasNormal())
          SetNormal(GetNormal() + rhs.GetNormal());
       return *this;
-   };
+   }
 
    /// Subtract a `RPadLength`.
    RPadLength &operator-=(const RPadLength &rhs)
@@ -237,7 +238,7 @@ public:
       if (HasNormal() || rhs.HasNormal())
          SetNormal(GetNormal() - rhs.GetNormal());
       return *this;
-   };
+   }
 
    /// Multiply a `RPadLength`.
    RPadLength &operator*=(double scale)
@@ -247,6 +248,19 @@ public:
       if (HasNormal()) SetNormal(scale*GetNormal());
       return *this;
    }
+
+   /// Compare a `RPadLength`.
+   bool operator==(const RPadLength &rhs) const
+   {
+      if ((HasUser() != rhs.HasUser()) ||
+          (HasUser() && std::fabs(GetUser() - rhs.GetUser()) > 1e-30)) return false;
+
+      if(std::fabs(GetPixel() - rhs.GetPixel()) > 1e-4) return false;
+
+      if (std::fabs(GetNormal() - rhs.GetNormal()) > 1e-6) return false;
+
+      return true;
+   };
 
    std::string AsString() const;
 

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -39,10 +39,6 @@ class RPave : public RDrawable {
    RAttrFill fAttrFill{this, "fill_"};       ///<! line attributes
    RPaveAttrs fAttr{this, ""};               ///<! pave direct attributes
 
-protected:
-
-   bool IsFrameRequired() const final { return true; }
-
 public:
 
    RPave(const std::string &csstype = "pave") : RDrawable(csstype) {}

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -1,0 +1,110 @@
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RPave
+#define ROOT7_RPave
+
+#include <ROOT/RDrawable.hxx>
+#include <ROOT/RAttrText.hxx>
+#include <ROOT/RAttrLine.hxx>
+#include <ROOT/RAttrFill.hxx>
+#include <ROOT/RPadPos.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+
+/** \class ROOT::Experimental::RPave
+\ingroup GrafROOT7
+\brief Base class for paves with text, statistic, legends, placed relative to RFrame position and adjustable height
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-06-18
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RPave : public RDrawable {
+
+   class RPaveAttrs : public RAttrBase {
+      friend class RPave;
+      R__ATTR_CLASS(RPaveAttrs, "", AddPadLength("cornerx",0.02).AddPadLength("cornery",0.02).AddPadLength("width",0.5).AddPadLength("height",0.2));
+   };
+
+   RAttrText fAttrText{this, "text_"};       ///<! text attributes
+   RAttrLine fAttrBorder{this, "border_"};   ///<! border attributes
+   RAttrFill fAttrFill{this, "fill_"};       ///<! line attributes
+   RPaveAttrs fAttr{this, ""};               ///<! pave direct attributes
+
+protected:
+
+   bool IsFrameRequired() const final { return true; }
+
+public:
+
+   RPave() : RDrawable("pave") {}
+
+   RPave &SetCornerX(const RPadLength &pos)
+   {
+      fAttr.SetValue("cornerx", pos);
+      return *this;
+   }
+
+   RPadLength GetCornerX() const
+   {
+      return fAttr.template GetValue<RPadLength>("cornerx");
+   }
+
+   RPave &SetCornerY(const RPadLength &pos)
+   {
+      fAttr.SetValue("cornery", pos);
+      return *this;
+   }
+
+   RPadLength GetCornerY() const
+   {
+      return fAttr.template GetValue<RPadLength>("cornery");
+   }
+
+   RPave &SetWidth(const RPadLength &width)
+   {
+      fAttr.SetValue("width", width);
+      return *this;
+   }
+
+   RPadLength GetWidth() const
+   {
+      return fAttr.template GetValue<RPadLength>("width");
+   }
+
+   RPave &SetHeight(const RPadLength &height)
+   {
+      fAttr.SetValue("height", height);
+      return *this;
+   }
+
+   RPadLength GetHeight() const
+   {
+      return fAttr.template GetValue<RPadLength>("height");
+   }
+
+   const RAttrText &GetAttrText() const { return fAttrText; }
+   RPave &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
+   RAttrText &AttrText() { return fAttrText; }
+
+   const RAttrLine &GetAttrBorder() const { return fAttrBorder; }
+   RPave &SetAttrBorder(const RAttrLine &border) { fAttrBorder = border; return *this; }
+   RAttrLine &AttrBorder() { return fAttrBorder; }
+
+   const RAttrFill &GetAttrFill() const { return fAttrFill; }
+   RPave &SetAttrFill(const RAttrFill &fill) { fAttrFill = fill; return *this; }
+   RAttrFill &AttrFill() { return fAttrFill; }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -45,7 +45,7 @@ protected:
 
 public:
 
-   RPave() : RDrawable("pave") {}
+   RPave(const std::string &csstype = "pave") : RDrawable(csstype) {}
 
    RPave &SetCornerX(const RPadLength &pos)
    {

--- a/graf2d/gpadv7/src/RDisplayItem.cxx
+++ b/graf2d/gpadv7/src/RDisplayItem.cxx
@@ -12,11 +12,13 @@
 
 #include "TString.h"
 
+using namespace ROOT::Experimental;
+
 ////////////////////////////////////////////////////////////////////////////
 /// Assign id using arbitrary pointer value
 /// Typically drawable pointer should be used here
 
-void ROOT::Experimental::RDisplayItem::SetObjectIDAsPtr(const void *ptr)
+void RDisplayItem::SetObjectIDAsPtr(const void *ptr)
 {
    SetObjectID(ObjectIDFromPtr(ptr));
 }
@@ -24,7 +26,7 @@ void ROOT::Experimental::RDisplayItem::SetObjectIDAsPtr(const void *ptr)
 ////////////////////////////////////////////////////////////////////////////
 /// Build full id, including prefix and object index
 
-void ROOT::Experimental::RDisplayItem::BuildFullId(const std::string &prefix)
+void RDisplayItem::BuildFullId(const std::string &prefix)
 {
    SetObjectID(prefix + std::to_string(GetIndex()) + "_" + GetObjectID());
 }
@@ -32,19 +34,30 @@ void ROOT::Experimental::RDisplayItem::BuildFullId(const std::string &prefix)
 ////////////////////////////////////////////////////////////////////////////
 /// Construct fillid using pointer value
 
-std::string ROOT::Experimental::RDisplayItem::ObjectIDFromPtr(const void *ptr)
+std::string RDisplayItem::ObjectIDFromPtr(const void *ptr)
 {
    auto hash = TString::Hash(&ptr, sizeof(ptr));
    return std::to_string(hash);
 }
 
 ///////////////////////////////////////////////////////////
+/// destructor
+
+RDrawableDisplayItem::~RDrawableDisplayItem()
+{
+   if (fDrawable)
+      fDrawable->OnDisplayItemDestroyed(this);
+}
+
+
+///////////////////////////////////////////////////////////
 /// Constructor
 
-ROOT::Experimental::RIndirectDisplayItem::RIndirectDisplayItem(const RDrawable &dr)
+RIndirectDisplayItem::RIndirectDisplayItem(const RDrawable &dr)
 {
    fAttr = &dr.fAttr;
    fCssClass = &dr.fCssClass;
    fId = &dr.fId;
 }
+
 

--- a/graf2d/gpadv7/test/rpave.cxx
+++ b/graf2d/gpadv7/test/rpave.cxx
@@ -1,0 +1,27 @@
+// @(#)root/graf2d:$Id$
+// Author: Sergey Linev <s.linev@gsi.de>, 2020-06-18
+
+
+#include "gtest/gtest.h"
+
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RPave.hxx"
+
+using namespace ROOT::Experimental;
+
+// Test RPave API
+TEST(Primitives, RPave)
+{
+   RCanvas canv;
+
+   auto frame = canv.GetOrCreateFrame();
+
+   auto pave = canv.Draw<RPave>();
+   pave->AttrFill().SetColor(RColor::kRed);
+
+   // when adding pave, RFrame is automatically created
+   EXPECT_EQ(canv.NumPrimitives(), 2u);
+
+   EXPECT_EQ(pave->AttrFill().GetColor(), RColor::kRed);
+}
+

--- a/graf2d/gpadv7/test/rpave.cxx
+++ b/graf2d/gpadv7/test/rpave.cxx
@@ -17,11 +17,25 @@ TEST(Primitives, RPave)
    auto frame = canv.GetOrCreateFrame();
 
    auto pave = canv.Draw<RPave>();
-   pave->AttrFill().SetColor(RColor::kRed);
+   pave->AttrBorder().SetColor(RColor::kRed).SetWidth(3);
+   pave->AttrFill().SetColor(RColor::kBlue).SetStyle(3003);
+   pave->SetCornerX(0.03_normal);
+   pave->SetWidth(0.4_normal);
+   pave->SetCornerY(-0.03_normal);
+   pave->SetHeight(0.2_normal);
 
    // when adding pave, RFrame is automatically created
    EXPECT_EQ(canv.NumPrimitives(), 2u);
 
-   EXPECT_EQ(pave->AttrFill().GetColor(), RColor::kRed);
+   EXPECT_EQ(pave->GetAttrBorder().GetColor(), RColor::kRed);
+   EXPECT_EQ(pave->GetAttrBorder().GetWidth(), 3);
+
+   EXPECT_EQ(pave->GetAttrFill().GetColor(), RColor::kBlue);
+   EXPECT_EQ(pave->GetAttrFill().GetStyle(), 3003);
+
+   EXPECT_EQ(pave->GetCornerX(), 0.03_normal);
+   EXPECT_EQ(pave->GetWidth(), 0.4_normal);
+   EXPECT_EQ(pave->GetCornerY(), -0.03_normal);
+   EXPECT_EQ(pave->GetHeight(), 0.2_normal);
 }
 

--- a/graf2d/primitivesv7/CMakeLists.txt
+++ b/graf2d/primitivesv7/CMakeLists.txt
@@ -12,11 +12,12 @@
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGraphicsPrimitives
   HEADERS
     ROOT/RBox.hxx
+    ROOT/RFrameTitle.hxx
     ROOT/RLegend.hxx
     ROOT/RLine.hxx
     ROOT/RMarker.hxx
+    ROOT/RPaveText.hxx
     ROOT/RText.hxx
-    ROOT/RFrameTitle.hxx
   SOURCES
     src/RBox.cxx
     src/RLegend.cxx

--- a/graf2d/primitivesv7/inc/LinkDef.h
+++ b/graf2d/primitivesv7/inc/LinkDef.h
@@ -16,8 +16,8 @@
 
 #pragma link C++ class ROOT::Experimental::RText+;
 #pragma link C++ class ROOT::Experimental::RFrameTitle+;
-#pragma link C++ class ROOT::Experimental::Internal::RLegendEntry+;
 #pragma link C++ class ROOT::Experimental::RLegend+;
+#pragma link C++ class ROOT::Experimental::RLegend::REntry+;
 #pragma link C++ class ROOT::Experimental::RLine+;
 #pragma link C++ class ROOT::Experimental::RBox+;
 #pragma link C++ class ROOT::Experimental::RMarker+;

--- a/graf2d/primitivesv7/inc/LinkDef.h
+++ b/graf2d/primitivesv7/inc/LinkDef.h
@@ -14,12 +14,13 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class ROOT::Experimental::RText+;
+#pragma link C++ class ROOT::Experimental::RBox+;
 #pragma link C++ class ROOT::Experimental::RFrameTitle+;
 #pragma link C++ class ROOT::Experimental::RLegend+;
 #pragma link C++ class ROOT::Experimental::RLegend::REntry+;
 #pragma link C++ class ROOT::Experimental::RLine+;
-#pragma link C++ class ROOT::Experimental::RBox+;
+#pragma link C++ class ROOT::Experimental::RPaveText+;
 #pragma link C++ class ROOT::Experimental::RMarker+;
+#pragma link C++ class ROOT::Experimental::RText+;
 
 #endif

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -17,6 +17,7 @@
 
 #include <initializer_list>
 #include <memory>
+#include <vector>
 
 namespace ROOT {
 namespace Experimental {

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -9,9 +9,7 @@
 #ifndef ROOT7_RLegend
 #define ROOT7_RLegend
 
-#include <ROOT/RBox.hxx>
-
-#include <ROOT/RAttrText.hxx>
+#include <ROOT/RPave.hxx>
 
 #include <initializer_list>
 #include <memory>
@@ -76,13 +74,11 @@ public:
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RLegend : public RBox {
+class RLegend : public RPave {
 
    std::string fTitle;                  ///< legend title
 
    std::vector<Internal::RLegendEntry> fEntries; ///< list of entries which should be displayed
-
-   RAttrText  fAttrTitle{this, "title_"};    ///<! title attributes
 
 protected:
 
@@ -97,21 +93,15 @@ protected:
 
 public:
 
-   RLegend() : RBox("legend") {}
+   RLegend() : RPave("legend") {}
 
-   RLegend(const RPadPos &p1, const RPadPos &p2, const std::string &title = "") : RLegend()
+   RLegend(const std::string &title) : RLegend()
    {
-      SetP1(p1);
-      SetP2(p2);
       SetTitle(title);
    }
 
    RLegend &SetTitle(const std::string &title) { fTitle = title; return *this; }
    const std::string &GetTitle() const { return fTitle; }
-
-   const RAttrText &GetAttrTitle() const { return fAttrTitle; }
-   RLegend &SetAttrTitle(const RAttrText &attr) { fAttrTitle = attr; return *this; }
-   RAttrText &AttrTitle() { return fAttrTitle; }
 
    Internal::RLegendEntry &AddEntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl = "")
    {
@@ -120,7 +110,6 @@ public:
    }
 
    auto NumEntries() const { return fEntries.size(); }
-
 
 };
 

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -18,57 +18,6 @@
 namespace ROOT {
 namespace Experimental {
 
-class RLegend;
-
-namespace Internal {
-
-/** \class RLegendEntry
-\ingroup GrafROOT7
-\brief An entry in RLegend, references RDrawable and its attributes
-\author Sergey Linev <S.Linev@gsi.de>
-\date 2019-10-09
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-*/
-
-
-class RLegendEntry {
-
-   friend class ROOT::Experimental::RLegend;
-
-   std::string fLabel;    ///< label shown for the entry
-
-   std::string fLine, fFill, fMarker;  ///< prefixes for line, fill, marker attributes
-
-   RIOShared<RDrawable> fDrawable;  ///< reference to RDrawable
-
-   std::string fDrawableId;        ///< drawable id, used only when display item
-
-public:
-
-   RLegendEntry() = default;
-
-   RLegendEntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl = "")
-   {
-      fDrawable = drawable;
-      fLabel = lbl;
-   }
-
-   RLegendEntry &SetLabel(const std::string &lbl) { fLabel = lbl; return *this; }
-   const std::string &GetLabel() const { return fLabel; }
-
-   RLegendEntry &SetLine(const std::string &lbl) { fLine = lbl; return *this; }
-   const std::string &GetLine() const { return fLine; }
-
-   RLegendEntry &SetFill(const std::string &lbl) { fFill = lbl; return *this; }
-   const std::string &GetFill() const { return fFill; }
-
-   RLegendEntry &SetMarker(const std::string &lbl) { fMarker = lbl; return *this; }
-   const std::string &GetMarker() const { return fMarker; }
-
-};
-
-}
-
 /** \class RLegend
 \ingroup GrafROOT7
 \brief A legend for several drawables
@@ -79,11 +28,56 @@ public:
 
 class RLegend : public RPave {
 
-   friend class RDisplayLegend;
+public:
+
+   /** \class REntry
+   \ingroup GrafROOT7
+   \brief An entry in RLegend, references RDrawable and its attributes
+   \author Sergey Linev <S.Linev@gsi.de>
+   \date 2019-10-09
+   \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+   */
+
+   class REntry {
+
+      friend class RLegend;
+
+      std::string fLabel;    ///< label shown for the entry
+
+      std::string fLine, fFill, fMarker;  ///< prefixes for line, fill, marker attributes
+
+      Internal::RIOShared<RDrawable> fDrawable;  ///< reference to RDrawable
+
+      std::string fDrawableId;        ///< drawable id, used only when display item
+
+   public:
+
+      REntry() = default;
+
+      REntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl = "")
+      {
+         fDrawable = drawable;
+         fLabel = lbl;
+      }
+
+      REntry &SetLabel(const std::string &lbl) { fLabel = lbl; return *this; }
+      const std::string &GetLabel() const { return fLabel; }
+
+      REntry &SetLine(const std::string &lbl) { fLine = lbl; return *this; }
+      const std::string &GetLine() const { return fLine; }
+
+      REntry &SetFill(const std::string &lbl) { fFill = lbl; return *this; }
+      const std::string &GetFill() const { return fFill; }
+
+      REntry &SetMarker(const std::string &lbl) { fMarker = lbl; return *this; }
+      const std::string &GetMarker() const { return fMarker; }
+   };
+
+private:
 
    std::string fTitle;                  ///< legend title
 
-   std::vector<Internal::RLegendEntry> fEntries; ///< list of entries which should be displayed
+   std::vector<REntry> fEntries; ///< list of entries which should be displayed
 
 protected:
 
@@ -111,7 +105,7 @@ protected:
    void OnDisplayItemDestroyed(RDisplayItem *) const override
    {
       for (auto &centry : fEntries) {
-         auto entry = const_cast<Internal::RLegendEntry *>(&centry);
+         auto entry = const_cast<REntry *>(&centry);
          entry->fDrawable.restore_io();
          entry->fDrawableId.clear();
       }
@@ -129,7 +123,7 @@ public:
    RLegend &SetTitle(const std::string &title) { fTitle = title; return *this; }
    const std::string &GetTitle() const { return fTitle; }
 
-   Internal::RLegendEntry &AddEntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl = "")
+   REntry &AddEntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl = "")
    {
       fEntries.emplace_back(drawable, lbl);
       return fEntries.back();

--- a/graf2d/primitivesv7/inc/ROOT/RPaveText.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RPaveText.hxx
@@ -1,0 +1,46 @@
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RPaveText
+#define ROOT7_RPaveText
+
+#include <ROOT/RPave.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+/** \class RPaveText
+\ingroup GrafROOT7
+\brief A RPave with text content
+\author Sergey Linev <S.Linev@gsi.de>
+\date 2020-06-19
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RPaveText : public RPave {
+
+   std::vector<std::string> fText; ///< list of text entries
+
+public:
+
+   RPaveText() : RPave("pavetext") {}
+
+   void AddLine(const std::string &txt) { fText.emplace_back(txt); }
+
+   auto NumLines() const { return fText.size(); }
+
+   const std::string &GetLine(int n) const { return fText[n]; }
+
+   void ClearLines() { fText.clear(); }
+
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -4,6 +4,7 @@
 #include "ROOT/RLine.hxx"
 #include "ROOT/RMarker.hxx"
 #include "ROOT/RText.hxx"
+#include "ROOT/RPaveText.hxx"
 #include "ROOT/RLegend.hxx"
 #include "ROOT/RCanvas.hxx"
 
@@ -118,10 +119,44 @@ TEST(Primitives, RLegend)
    legend->AddEntry(line2, "RLine 2");
    legend->AddEntry(line3, "RLine 3");
 
-   EXPECT_EQ(canv.NumPrimitives(), 4u);
+   EXPECT_EQ(canv.NumPrimitives(), 5u);
 
    EXPECT_EQ(legend->NumEntries(), 3u);
    EXPECT_EQ(legend->GetTitle(), "Legend title");
    EXPECT_EQ(legend->GetAttrFill().GetColor(), RColor::kWhite);
+}
+
+// Test RPaveText API
+TEST(Primitives, RPaveText)
+{
+   RCanvas canv;
+
+   auto text = canv.Draw<RPaveText>();
+
+   text->AttrText().SetColor(RColor::kBlack).SetSize(12).SetAlign(13).SetFont(42);
+   text->AttrBorder().SetColor(RColor::kRed).SetWidth(3);
+   text->AttrFill().SetColor(RColor::kBlue).SetStyle(3003);
+
+   text->AddLine("First line");
+   text->AddLine("Second line");
+   text->AddLine("Third line");
+
+   EXPECT_EQ(canv.NumPrimitives(), 2u);
+
+   EXPECT_EQ(text->NumLines(), 3u);
+   EXPECT_EQ(text->GetLine(0), "First line");
+   EXPECT_EQ(text->GetLine(1), "Second line");
+   EXPECT_EQ(text->GetLine(2), "Third line");
+
+   EXPECT_EQ(text->GetAttrText().GetColor(), RColor::kBlack);
+   EXPECT_DOUBLE_EQ(text->GetAttrText().GetSize(), 12);
+   EXPECT_EQ(text->GetAttrText().GetAlign(), 13);
+   EXPECT_EQ(text->GetAttrText().GetFont(), 42);
+
+   EXPECT_EQ(text->GetAttrBorder().GetColor(), RColor::kRed);
+   EXPECT_EQ(text->GetAttrBorder().GetWidth(), 3);
+
+   EXPECT_EQ(text->GetAttrFill().GetColor(), RColor::kBlue);
+   EXPECT_EQ(text->GetAttrFill().GetStyle(), 3003);
 }
 

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -119,7 +119,7 @@ TEST(Primitives, RLegend)
    legend->AddEntry(line2, "RLine 2");
    legend->AddEntry(line3, "RLine 3");
 
-   EXPECT_EQ(canv.NumPrimitives(), 5u);
+   EXPECT_EQ(canv.NumPrimitives(), 4u);
 
    EXPECT_EQ(legend->NumEntries(), 3u);
    EXPECT_EQ(legend->GetTitle(), "Legend title");
@@ -141,7 +141,7 @@ TEST(Primitives, RPaveText)
    text->AddLine("Second line");
    text->AddLine("Third line");
 
-   EXPECT_EQ(canv.NumPrimitives(), 2u);
+   EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(text->NumLines(), 3u);
    EXPECT_EQ(text->GetLine(0), "First line");

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -111,9 +111,9 @@ TEST(Primitives, RLegend)
    line2->AttrLine().SetColor(RColor::kGreen);
    line3->AttrLine().SetColor(RColor::kBlue);
 
-   auto legend = canv.Draw<RLegend>(RPadPos(0.5_normal, 0.6_normal), RPadPos(0.9_normal,0.9_normal), "Legend title");
-   legend->AttrBox().AttrFill().SetStyle(5).SetColor(RColor::kWhite);
-   legend->AttrBox().AttrBorder().SetWidth(2).SetColor(RColor::kRed);
+   auto legend = canv.Draw<RLegend>("Legend title");
+   legend->AttrFill().SetStyle(5).SetColor(RColor::kWhite);
+   legend->AttrBorder().SetWidth(2).SetColor(RColor::kRed);
    legend->AddEntry(line1, "RLine 1").SetLine("line_");
    legend->AddEntry(line2, "RLine 2").SetLine("line_");
    legend->AddEntry(line3, "RLine 3").SetLine("line_");
@@ -122,6 +122,6 @@ TEST(Primitives, RLegend)
 
    EXPECT_EQ(legend->NumEntries(), 3u);
    EXPECT_EQ(legend->GetTitle(), "Legend title");
-   EXPECT_EQ(legend->GetAttrBox().GetAttrFill().GetColor(), RColor::kWhite);
+   EXPECT_EQ(legend->GetAttrFill().GetColor(), RColor::kWhite);
 }
 

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -114,9 +114,9 @@ TEST(Primitives, RLegend)
    auto legend = canv.Draw<RLegend>("Legend title");
    legend->AttrFill().SetStyle(5).SetColor(RColor::kWhite);
    legend->AttrBorder().SetWidth(2).SetColor(RColor::kRed);
-   legend->AddEntry(line1, "RLine 1").SetLine("line_");
-   legend->AddEntry(line2, "RLine 2").SetLine("line_");
-   legend->AddEntry(line3, "RLine 3").SetLine("line_");
+   legend->AddEntry(line1, "RLine 1");
+   legend->AddEntry(line2, "RLine 2");
+   legend->AddEntry(line3, "RLine 3");
 
    EXPECT_EQ(canv.NumPrimitives(), 4u);
 

--- a/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
@@ -9,17 +9,13 @@
 #ifndef ROOT7_RHistStatBox
 #define ROOT7_RHistStatBox
 
-#include <ROOT/RDrawable.hxx>
+#include <ROOT/RPave.hxx>
 #include <ROOT/RDrawableRequest.hxx>
-#include <ROOT/RAttrText.hxx>
-#include <ROOT/RAttrLine.hxx>
-#include <ROOT/RAttrFill.hxx>
-#include <ROOT/RPadPos.hxx>
-#include "ROOT/RPadBase.hxx"
+#include <ROOT/RPadBase.hxx>
 #include <ROOT/RDisplayItem.hxx>
 #include <ROOT/RHist.hxx>
 #include <ROOT/RHistImpl.hxx>
-#include "ROOT/RFrame.hxx"
+#include <ROOT/RFrame.hxx>
 
 #include <memory>
 #include <string>
@@ -59,26 +55,14 @@ public:
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RHistStatBoxBase : public RDrawable {
-
-   class RHistStatBoxAttrs : public RAttrBase {
-      friend class RHistStatBoxBase;
-      R__ATTR_CLASS(RHistStatBoxAttrs, "", AddPadLength("cornerx",0.02).AddPadLength("cornery",0.02).AddPadLength("width",0.5).AddPadLength("height",0.2));
-   };
+class RHistStatBoxBase : public RPave {
 
    std::string fTitle;                       ///< stat box title
    unsigned fShowMask{0xff};                 ///< show stat box lines
 
-   RAttrText fAttrText{this, "text_"};       ///<! text attributes
-   RAttrLine fAttrBorder{this, "border_"};   ///<! border attributes
-   RAttrFill fAttrFill{this, "fill_"};       ///<! line attributes
-   RHistStatBoxAttrs fAttr{this, ""};        ///<! stat box direct attributes
-
 protected:
 
    enum EShowBits { kShowTitle = 0x1, kShowEntries = 0x2, kShowMean = 0x4, kShowDev = 0x8, kShowRange = 0x10 };
-
-   bool IsFrameRequired() const final { return true; }
 
    virtual void FillStatistic(unsigned, const RFrame::RUserRanges &, std::vector<std::string> &) const {}
 
@@ -97,7 +81,6 @@ public:
       // virtual destructor - required to pin vtable
       virtual ~RReply() = default;
    };
-
 
    class RRequest : public RDrawableRequest {
       unsigned mask{0xff};      // mask of items to show
@@ -128,66 +111,10 @@ public:
       }
    };
 
-   RHistStatBoxBase() : RDrawable("stats") {}
+   RHistStatBoxBase() : RPave("stats") {}
 
    void SetTitle(const std::string &title) { fTitle = title; }
    const std::string &GetTitle() const { return fTitle; }
-
-   RHistStatBoxBase &SetCornerX(const RPadLength &pos)
-   {
-      fAttr.SetValue("cornerx", pos);
-      return *this;
-   }
-
-   RPadLength GetCornerX() const
-   {
-      return fAttr.template GetValue<RPadLength>("cornerx");
-   }
-
-   RHistStatBoxBase &SetCornerY(const RPadLength &pos)
-   {
-      fAttr.SetValue("cornery", pos);
-      return *this;
-   }
-
-   RPadLength GetCornerY() const
-   {
-      return fAttr.template GetValue<RPadLength>("cornery");
-   }
-
-   RHistStatBoxBase &SetWidth(const RPadLength &width)
-   {
-      fAttr.SetValue("width", width);
-      return *this;
-   }
-
-   RPadLength GetWidth() const
-   {
-      return fAttr.template GetValue<RPadLength>("width");
-   }
-
-   RHistStatBoxBase &SetHeight(const RPadLength &height)
-   {
-      fAttr.SetValue("height", height);
-      return *this;
-   }
-
-   RPadLength GetHeight() const
-   {
-      return fAttr.template GetValue<RPadLength>("height");
-   }
-
-   const RAttrText &GetAttrText() const { return fAttrText; }
-   RHistStatBoxBase &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
-   RAttrText &AttrText() { return fAttrText; }
-
-   const RAttrLine &GetAttrBorder() const { return fAttrBorder; }
-   RHistStatBoxBase &SetAttrBorder(const RAttrLine &border) { fAttrBorder = border; return *this; }
-   RAttrLine &AttrBorder() { return fAttrBorder; }
-
-   const RAttrFill &GetAttrFill() const { return fAttrFill; }
-   RHistStatBoxBase &SetAttrFill(const RAttrFill &fill) { fAttrFill = fill; return *this; }
-   RAttrFill &AttrFill() { return fAttrFill; }
 };
 
 

--- a/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
@@ -28,14 +28,6 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RHistStatReply
-\ingroup GrafROOT7
-\brief Reply of stat box on RHistStatRequest, contains text lines to display
-\author Sergey Linev <s.linev@gsi.de>
-\date 2020-04-17
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-*/
-
 /** \class ROOT::Experimental::RDisplayHistStat
 \ingroup GrafROOT7
 \brief Object send to client for display of RHistStat, required to avoid sending histogram to the client

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 28/05/2020";
+   JSROOT.version = "dev 18/06/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 18/06/2020";
+   JSROOT.version = "dev 19/06/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -3539,17 +3539,27 @@
       }
    }
 
-   RPadPainter.prototype.FindSnap = function(snapid) {
+   /** Search painter with specified snapid, also sub-pads are checked */
+   RPadPainter.prototype.FindSnap = function(snapid, onlyid) {
 
-      if (this.snapid === snapid) return this;
+      function check(checkid) {
+         if (!checkid || (typeof checkid != 'string')) return false;
+         if (checkid == snapid) return true;
+         return onlyid && (checkid.length > snapid.length) &&
+                (checkid.indexOf(snapid) == (checkid.length - snapid.length));
+      }
+
+      if (check(this.snapid)) return this;
 
       if (!this.painters) return null;
 
       for (var k=0;k<this.painters.length;++k) {
          var sub = this.painters[k];
 
-         if (typeof sub.FindSnap === 'function') sub = sub.FindSnap(snapid);
-         else if (sub.snapid !== snapid) sub = null;
+         if (!onlyid && (typeof sub.FindSnap === 'function'))
+            sub = sub.FindSnap(snapid);
+         else if (!check(sub.snapid))
+            sub = null;
 
          if (sub) return sub;
       }

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -4687,14 +4687,16 @@
 
    // ======================================================================================
 
-
-
-   function RPavePainter(pave, opt) {
+   function RPavePainter(pave, opt, csstype) {
       JSROOT.TObjectPainter.call(this, pave, opt);
-      this.csstype = "pave";
+      this.csstype = csstype || "pave";
    }
 
    RPavePainter.prototype = Object.create(JSROOT.TObjectPainter.prototype);
+
+   RPavePainter.prototype.DrawContent = function() {
+      // do nothing, will be reimplemented in derived classes
+   }
 
    RPavePainter.prototype.DrawPave = function() {
 
@@ -4723,6 +4725,8 @@
 
       this.CreateG(false);
 
+      this.draw_g.classed("most_upper_primitives", true); // this primitive will remain on top of list
+
       if (!visible) return;
 
       if (fill_style == 0) fill_color = "none";
@@ -4749,6 +4753,8 @@
       this.pave_height = pave_height;
 
       // here should be fill and draw of text
+
+      this.DrawContent();
 
       if (JSROOT.BatchMode) return;
 
@@ -4783,7 +4789,7 @@
                  .attr("width", this.pave_width)
                  .attr("height", this.pave_height);
 
-      // here should be draw of context
+      this.DrawContent();
    }
 
    RPavePainter.prototype.Redraw = function(reason) {
@@ -4794,10 +4800,6 @@
       var painter = new RPavePainter(pave, opt);
 
       painter.SetDivId(divid);
-
-      painter.CreateG(false);
-
-      painter.draw_g.classed("most_upper_primitives", true); // this primitive will remain on top of list
 
       painter.DrawPave();
 
@@ -5206,7 +5208,7 @@
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RBox", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawBox", opt: "", direct: true, csstype: "box" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RMarker", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawMarker", opt: "", direct: true, csstype: "marker" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RPave", icon: "img_pavetext", func: drawPave, opt: "" });
-   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RLegend", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawLegend", opt: "", direct: true, csstype: "legend" });
+   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RLegend", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawLegend", opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RFrame", icon: "img_frame", func: "JSROOT.v7.drawFrame", opt: "" });
 
    JSROOT.v7.RAxisPainter = RAxisPainter;
@@ -5215,6 +5217,7 @@
    JSROOT.v7.RPadPainter = RPadPainter;
    JSROOT.v7.RCanvasPainter = RCanvasPainter;
    JSROOT.v7.TCanvasPainter = RCanvasPainter; // temporary, fix in ROOT soon
+   JSROOT.v7.RPavePainter = RPavePainter;
    JSROOT.v7.drawFrame = drawFrame;
    JSROOT.v7.drawPad = drawPad;
    JSROOT.v7.drawCanvas = drawCanvas;

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -152,6 +152,16 @@
       this.createAttLine({ color: line_color, width: line_width, style: line_style });
    }
 
+   JSROOT.TObjectPainter.prototype.createv7AttMarker = function(prefix) {
+      if (!prefix || (typeof prefix != "string")) prefix = "marker_";
+
+      var marker_color = this.v7EvalColor(prefix + "color", "black"),
+          marker_size = this.v7EvalAttr(prefix + "size", 1),
+          marker_style = this.v7EvalAttr(prefix + "style", 1);
+
+      this.createAttMarker({ color: marker_color, size: marker_size, style: marker_style });
+   }
+
    /** Create RChangeAttr, which can be applied on the server side */
    JSROOT.TObjectPainter.prototype.v7AttrChange = function(req,name,value,kind) {
       if (!this.snapid)

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -4720,19 +4720,30 @@
 
    RPavePainter.prototype.DrawPave = function() {
 
-      var framep = this.frame_painter();
+      //var framep = this.frame_painter();
 
       // frame painter must  be there
-      if (!framep)
-         return console.log('no frame painter - no palette');
+      //if (!framep)
+      //   return console.log('no frame painter - no RPave drawing');
 
-      var fx            = this.frame_x(),
-          fy            = this.frame_y(),
-          fw            = this.frame_width(),
-          fh            = this.frame_height(),
-          pw            = this.pad_width(),
-          ph            = this.pad_height(),
-          visible       = this.v7EvalAttr("visible", true),
+      var pw = this.pad_width(),
+          ph = this.pad_height(),
+          fx, fy, fw, fh;
+
+      if (this.frame_painter()) {
+         fx = this.frame_x();
+         fy = this.frame_y();
+         fw = this.frame_width();
+         fh = this.frame_height();
+      } else {
+         var st = JSROOT.gStyle;
+         fx = Math.round(st.fPadLeftMargin*pw);
+         fy = Math.round(st.fPadTopMargin*ph);
+         fw = Math.round((1-st.fPadLeftMargin-st.fPadRightMargin)*pw);
+         fh = Math.round((1-st.fPadTopMargin-st.fPadBottomMargin)*ph);
+      }
+
+      var visible       = this.v7EvalAttr("visible", true),
           pave_cornerx = this.v7EvalLength("cornerx", pw, 0.02),
           pave_cornery = this.v7EvalLength("cornery", ph, -0.02),
           pave_width   = this.v7EvalLength("width", pw, 0.3),
@@ -4791,12 +4802,22 @@
 
       var pave_x = parseInt(this.draw_g.attr("x")),
           pave_y = parseInt(this.draw_g.attr("y")),
-          fx     = this.frame_x(),
-          fy     = this.frame_y(),
-          fw     = this.frame_width(),
-          fh     = this.frame_height(),
           pw     = this.pad_width(),
-          ph     = this.pad_height();
+          ph     = this.pad_height(),
+          fx, fy, fw, fh;
+
+      if (this.frame_painter()) {
+         fx = this.frame_x();
+         fy = this.frame_y();
+         fw = this.frame_width();
+         fh = this.frame_height();
+      } else {
+         var st = JSROOT.gStyle;
+         fx = Math.round(st.fPadLeftMargin*pw);
+         fy = Math.round(st.fPadTopMargin*ph);
+         fw = Math.round((1-st.fPadLeftMargin-st.fPadRightMargin)*pw);
+         fh = Math.round((1-st.fPadTopMargin-st.fPadBottomMargin)*ph);
+      }
 
       var changes = {};
       this.v7AttrChange(changes, "cornerx", (pave_x + this.pave_width - fx - fw) / pw);

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -4758,8 +4758,8 @@
 
       if (JSROOT.BatchMode) return;
 
-      //if (JSROOT.gStyle.ContextMenu)
-      //   this.draw_g.on("contextmenu", this.ShowContextMenu.bind(this));
+      if (JSROOT.gStyle.ContextMenu && this.ShowContextMenu)
+         this.draw_g.on("contextmenu", this.ShowContextMenu.bind(this));
 
       this.AddDrag({ minwidth: 20, minheight: 20, redraw: this.SizeChanged.bind(this) });
    }

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -4734,7 +4734,7 @@
           ph            = this.pad_height(),
           visible       = this.v7EvalAttr("visible", true),
           pave_cornerx = this.v7EvalLength("cornerx", pw, 0.02),
-          pave_cornery = this.v7EvalLength("cornery", ph, 0.02),
+          pave_cornery = this.v7EvalLength("cornery", ph, -0.02),
           pave_width   = this.v7EvalLength("width", pw, 0.3),
           pave_height  = this.v7EvalLength("height", ph, 0.3),
           line_width    = this.v7EvalAttr("border_width", 1),
@@ -4752,7 +4752,7 @@
       if (fill_style == 0) fill_color = "none";
 
       var pave_x = Math.round(fx + fw + pave_cornerx - pave_width),
-          pave_y = Math.round(fy - pave_cornery);
+          pave_y = Math.round(fy + pave_cornery);
 
       // x,y,width,height attributes used for drag functionality
       this.draw_g.attr("transform", "translate(" + pave_x + "," + pave_y + ")")
@@ -4800,7 +4800,7 @@
 
       var changes = {};
       this.v7AttrChange(changes, "cornerx", (pave_x + this.pave_width - fx - fw) / pw);
-      this.v7AttrChange(changes, "cornery", (fy - pave_y) / ph);
+      this.v7AttrChange(changes, "cornery", (pave_y - fy) / ph);
       this.v7AttrChange(changes, "width", this.pave_width / pw);
       this.v7AttrChange(changes, "height", this.pave_height / ph);
       this.v7SendAttrChanges(changes, false); // do not invoke canvas update on the server
@@ -5229,6 +5229,7 @@
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RMarker", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawMarker", opt: "", direct: true, csstype: "marker" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RPave", icon: "img_pavetext", func: drawPave, opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RLegend", icon: "img_graph", prereq: "v7more", func: "JSROOT.v7.drawLegend", opt: "" });
+   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RPaveText", icon: "img_pavetext", prereq: "v7more", func: "JSROOT.v7.drawPaveText", opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RFrame", icon: "img_frame", func: "JSROOT.v7.drawFrame", opt: "" });
 
    JSROOT.v7.RAxisPainter = RAxisPainter;

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -3447,8 +3447,8 @@
    // =============================================================
 
 
-   function RHistStatsPainter(palette) {
-      JSROOT.TObjectPainter.call(this, palette);
+   function RHistStatsPainter(palette, opt) {
+      JSROOT.TObjectPainter.call(this, palette, opt);
       this.csstype = "stats";
    }
 

--- a/js/scripts/JSRootPainter.v7more.js
+++ b/js/scripts/JSRootPainter.v7more.js
@@ -136,7 +136,7 @@
       var legend     = this.GetObject(),
           text_size  = this.v7EvalAttr( "legend_text_size", 20),
           text_angle = -1 * this.v7EvalAttr( "legend_text_angle", 0),
-          text_align = this.v7EvalAttr( "legend_text_align", 22),
+          text_align = this.v7EvalAttr( "legend_text_align", 12),
           text_color = this.v7EvalColor( "legend_text_color", "black"),
           text_font  = this.v7EvalAttr( "legend_text_font", 41),
           width      = this.pave_width,
@@ -154,20 +154,36 @@
       this.StartTextDrawing(text_font, height/(nlines * 1.2));
 
       if (legend.fTitle) {
-         this.DrawText({ align: text_align, rotate: text_angle, color: text_color, latex: 1,
+         this.DrawText({ align: 22, rotate: text_angle, color: text_color, latex: 1,
                          width: width - 2*margin_x, height: stepy, x: margin_x, y: posy, text: legend.fTitle });
          posy += stepy;
       }
 
       for (var i=0; i<legend.fEntries.length; ++i) {
-         var entry = legend.fEntries[i];
+         var objp = null, entry = legend.fEntries[i];
 
          this.DrawText({ align: text_align, rotate: text_angle, color: text_color, latex: 1,
                          width: 0.75*width - 3*margin_x, height: stepy, x: 2*margin_x + width*0.25, y: posy, text: entry.fLabel });
 
-         var objp = pp.FindSnap(entry.fDrawableId, true);
+         if (entry.fDrawableId != "custom") {
+            objp = pp.FindSnap(entry.fDrawableId, true);
+         } else if (entry.fDrawable.fIO) {
+            objp = new JSROOT.TObjectPainter(entry.fDrawable.fIO);
+            if (entry.fLine) objp.createv7AttLine();
+            if (entry.fFill) objp.createv7AttFill();
+            if (entry.fMarker) objp.createv7AttMarker();
+         }
 
-         if (objp && objp.lineatt)
+         if (objp && entry.fFill && objp.fillatt)
+            this.draw_g
+              .append("svg:rect")
+              .attr("x", Math.round(margin_x))
+              .attr("y", Math.round(posy + stepy*0.1))
+              .attr("width", Math.round(width/4))
+              .attr("height", Math.round(stepy*0.8))
+              .call(objp.fillatt.func);
+
+         if (objp && entry.fLine && objp.lineatt)
             this.draw_g
               .append("svg:line")
               .attr("x1", Math.round(margin_x))
@@ -175,6 +191,11 @@
               .attr("x2", Math.round(margin_x + width/4))
               .attr("y2", Math.round(posy + stepy/2))
               .call(objp.lineatt.func);
+
+         if (objp && entry.fMarker && objp.markeratt)
+            this.draw_g.append("svg:path")
+                .attr("d", objp.markeratt.create(margin_x + width/8, posy + stepy/2))
+                .call(objp.markeratt.func);
 
          posy += stepy;
       }

--- a/js/scripts/JSRootPainter.v7more.js
+++ b/js/scripts/JSRootPainter.v7more.js
@@ -141,11 +141,12 @@
           text_font  = this.v7EvalAttr( "legend_text_font", 41),
           width      = this.pave_width,
           height     = this.pave_height,
-          nlines     = legend.fEntries.length;
+          nlines     = legend.fEntries.length,
+          pp         = this.pad_painter();
 
       if (legend.fTitle) nlines++;
 
-      if (!nlines) return;
+      if (!nlines || !pp) return;
 
       var arg = { align: text_align, rotate: text_angle, color: text_color, latex: 1 },
           stepy = height / nlines, posy = 0, margin_x = 0.02 * width;
@@ -164,9 +165,7 @@
          this.DrawText({ align: text_align, rotate: text_angle, color: text_color, latex: 1,
                          width: 0.75*width - 3*margin_x, height: stepy, x: 2*margin_x + width*0.25, y: posy, text: entry.fLabel });
 
-         var objp = this.FindPainterFor(entry.fDrawable.fIO);
-
-         console.log('Found painter ', i, !!objp);
+         var objp = pp.FindSnap(entry.fDrawableId, true);
 
          if (objp && objp.lineatt)
             this.draw_g

--- a/js/scripts/JSRootPainter.v7more.js
+++ b/js/scripts/JSRootPainter.v7more.js
@@ -215,16 +215,57 @@
       return painter.DrawingReady();
    }
 
+   // =================================================================================
 
+   function drawPaveTextContent() {
+      var pavetext   = this.GetObject(),
+          text_size  = this.v7EvalAttr( "pavetext_text_size", 20),
+          text_angle = -1 * this.v7EvalAttr( "pavetext_text_angle", 0),
+          text_align = this.v7EvalAttr( "pavetext_text_align", 12),
+          text_color = this.v7EvalColor( "pavetext_text_color", "black"),
+          text_font  = this.v7EvalAttr( "pavetext_text_font", 41),
+          width      = this.pave_width,
+          height     = this.pave_height,
+          nlines     = pavetext.fText.length;
+
+      if (!nlines) return;
+
+      var stepy = height / nlines, posy = 0, margin_x = 0.02 * width;
+
+      this.StartTextDrawing(text_font, height/(nlines * 1.2));
+
+      for (var i=0; i < pavetext.fText.length; ++i) {
+         var line = pavetext.fText[i];
+
+         this.DrawText({ align: text_align, rotate: text_angle, color: text_color, latex: 1,
+                         width: width - 2*margin_x, height: stepy, x: margin_x, y: posy, text: line });
+         posy += stepy;
+      }
+
+      this.FinishTextDrawing();
+   }
+
+   function drawPaveText(divid, pave, opt) {
+      var painter = new JSROOT.v7.RPavePainter(pave, opt, "pavetext");
+
+      painter.SetDivId(divid);
+
+      painter.DrawContent = drawPaveTextContent;
+
+      painter.DrawPave();
+
+      return painter.DrawingReady();
+   }
 
 
    // ================================================================================
 
-   JSROOT.v7.drawText   = drawText;
-   JSROOT.v7.drawLine   = drawLine;
-   JSROOT.v7.drawBox    = drawBox;
-   JSROOT.v7.drawMarker = drawMarker;
-   JSROOT.v7.drawLegend = drawLegend;
+   JSROOT.v7.drawText     = drawText;
+   JSROOT.v7.drawLine     = drawLine;
+   JSROOT.v7.drawBox      = drawBox;
+   JSROOT.v7.drawMarker   = drawMarker;
+   JSROOT.v7.drawLegend   = drawLegend;
+   JSROOT.v7.drawPaveText = drawPaveText;
 
    return JSROOT;
 

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -58,8 +58,13 @@ void draw_legend()
    auto legend = canvas->Draw<RLegend>("Legend title");
    legend->AttrFill().SetStyle(5).SetColor(RColor::kWhite);
    legend->AttrBorder().SetWidth(2).SetColor(RColor::kRed);
-   legend->AddEntry(draw1, "histo1").SetLine("line_");
-   legend->AddEntry(draw2, "histo2").SetLine("line_");
+   legend->AddEntry(draw1, "histo1");
+   legend->AddEntry(draw2, "histo2");
 
+   legend->AddEntry("test").SetAttrLine(RAttrLine().SetColor(RColor::kGreen).SetWidth(5))
+                           .SetAttrFill(RAttrFill().SetColor(RColor::kBlue).SetStyle(3004))
+                           .SetAttrMarker(RAttrMarker().SetColor(RColor::kRed).SetSize(3).SetStyle(28));
+
+   canvas->SetSize(1000, 700);
    canvas->Show();
 }

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -26,6 +26,7 @@
 // macro must be here while cling is not capable to load
 // library automatically for outlined function see ROOT-10336
 R__LOAD_LIBRARY(libROOTHistDraw)
+R__LOAD_LIBRARY(libROOTGraphicsPrimitives)
 
 using namespace ROOT::Experimental;
 

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -55,9 +55,9 @@ void draw_legend()
 
    canvas->AssignAutoColors();
 
-   auto legend = canvas->Draw<RLegend>(RPadPos(0.5_normal, 0.6_normal), RPadPos(0.9_normal,0.9_normal), "Legend title");
-   legend->AttrBox().AttrFill().SetStyle(5).SetColor(RColor::kWhite);
-   legend->AttrBox().AttrBorder().SetWidth(2).SetColor(RColor::kRed);
+   auto legend = canvas->Draw<RLegend>("Legend title");
+   legend->AttrFill().SetStyle(5).SetColor(RColor::kWhite);
+   legend->AttrBorder().SetWidth(2).SetColor(RColor::kRed);
    legend->AddEntry(draw1, "histo1").SetLine("line_");
    legend->AddEntry(draw2, "histo2").SetLine("line_");
 

--- a/tutorials/v7/draw_pave.cxx
+++ b/tutorials/v7/draw_pave.cxx
@@ -20,6 +20,7 @@
 
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/RPave.hxx"
+#include "ROOT/RPaveText.hxx"
 
 // macro must be here while cling is not capable to load
 // library automatically for outlined function see ROOT-10336
@@ -36,6 +37,16 @@ void draw_pave()
    auto pave = canvas->Draw<RPave>();
    pave->AttrFill().SetColor(RColor::kBlue);
    pave->AttrBorder().SetColor(RColor::kGreen).SetWidth(3);
+   pave->SetCornerY(-0.03_normal);
+   pave->SetHeight(0.2_normal);
+
+   auto text = canvas->Draw<RPaveText>();
+   text->AddLine("This is RTextPave");
+   text->AddLine("It can have several lines");
+   text->AddLine("It should be positioned below RPave");
+   text->AttrFill().SetColor(RColor::kYellow);
+   text->SetCornerY(0.25_normal);
+   text->SetHeight(0.3_normal);
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_pave.cxx
+++ b/tutorials/v7/draw_pave.cxx
@@ -1,0 +1,42 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// This macro generates a small V7 TH1D, fills it and draw it in a V7 canvas.
+/// The canvas is display in the web browser
+///
+/// \macro_code
+///
+/// \date 2015-03-22
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \author Axel Naumann <axel@cern.ch>
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RPave.hxx"
+
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
+R__LOAD_LIBRARY(ROOTGpadv7)
+
+using namespace ROOT::Experimental;
+
+void draw_pave()
+{
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create("Canvas Title");
+
+   // RFrame will be automatically created as well
+   auto pave = canvas->Draw<RPave>();
+   pave->AttrFill().SetColor(RColor::kBlue);
+   pave->AttrBorder().SetColor(RColor::kGreen).SetWidth(3);
+
+   canvas->SetSize(1000, 700);
+   canvas->Show();
+}


### PR DESCRIPTION
It is now base class for `RLegend`, `RPaveText`, `RHistStatsBox`.
Main functionality - consistent positioning relative to the `RFrame`. 
But also drawing without frame is possible - in that case just default frame position will be used.
Plus interactive moving of `RPave` around.

Improve `RLegend` class. Now it correctly drawn and can be interactively moved.
Also one can configure custom attributes disregard of other drawables.
Also special I/O mechanism is used to avoid large data transfer of RLegend::REntry - 
referenced drawable "masked out" before streaming.

Introduce `RPaveText` class

Update JSROOT code correspondingly. 
