### PR TITLE
Fix  a bug in computation of Minos errors when a parameter is bounded

### DIFF
--- a/math/mathcore/inc/Math/Minimizer.h
+++ b/math/mathcore/inc/Math/Minimizer.h
@@ -341,7 +341,6 @@ public:
       minos error for variable i, return false if Minos failed or not supported
       and the lower and upper errors are returned in errLow and errUp
       An extra flag  specifies if only the lower (option=-1) or the upper (option=+1) error calculation is run
-      (This feature is not yet implemented)
    */
    virtual bool GetMinosError(unsigned int ivar , double & errLow, double & errUp, int option = 0) {
       MATH_ERROR_MSG("Minimizer::GetMinosError","Minos Error not implemented");
@@ -425,6 +424,9 @@ public:
 
    /// status code of minimizer
    int Status() const { return fStatus; }
+
+   /// status code of Minos (to be re-implemented by the minimizers supporting Minos)
+   virtual int MinosStatus() const { return -1; }
 
    /// return the statistical scale used for calculate the error
    /// is typically 1 for Chi2 and 0.5 for likelihood minimization

--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -193,6 +193,12 @@ public:
    /// minos error for variable i, return false if Minos failed
    virtual bool GetMinosError(unsigned int i, double & errLow, double & errUp, int = 0);
 
+   /// minos status code of last Minos run
+   /// minosstatus = -1   : Minos is not run
+   ///             =  0   : last MINOS run was succesfull
+   ///             >  0   : some problems 
+   virtual int MinosStatus() const { return fMinosStatus; }
+
    /**
       perform a full calculation of the Hessian matrix for error calculation
     */
@@ -268,6 +274,7 @@ private:
    bool fUsed;
    bool fMinosRun;
    unsigned int fDim;
+   int fMinosStatus = -1;         // Minos status code
    std::vector<double> fParams;   // vector of output values
    std::vector<double> fErrors;   // vector of output errors
    std::vector<double> fCovar;    // vector storing the covariance matrix

--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -194,9 +194,9 @@ public:
    virtual bool GetMinosError(unsigned int i, double & errLow, double & errUp, int = 0);
 
    /// minos status code of last Minos run
-   /// minosstatus = -1   : Minos is not run
-   ///             =  0   : last MINOS run was succesfull
-   ///             >  0   : some problems 
+   /// minos status = -1   : Minos is not run
+   ///              =  0   : last MINOS run was succesfull
+   ///              >  0   : some problems encountered when running MINOS
    virtual int MinosStatus() const { return fMinosStatus; }
 
    /**

--- a/math/minuit/src/TMinuit.cxx
+++ b/math/minuit/src/TMinuit.cxx
@@ -5556,7 +5556,9 @@ void TMinuit::mnmnot(Int_t ilax, Int_t ilax2, Double_t &val2pl, Double_t &val2mi
       fU[ilax-1] = TMath::Max(fU[ilax-1],fAlim[ilax-1]);
       delu = fU[ilax-1] - ut;
 //        stop if already at limit with negligible step size
-      if (TMath::Abs(delu) / (TMath::Abs(ut) + TMath::Abs(fU[ilax-1])) < fEpsmac) goto L440;
+//        add also a check if both numerator and denominarot are not zero (ROOT-10835)(LM)
+      if ( (delu == 0 && ut == 0) ||
+         (TMath::Abs(delu) / (TMath::Abs(ut) + TMath::Abs(fU[ilax-1])) < fEpsmac)) goto L440;
       fac = delu / fMNOTw[it-1];
       for (i = 1; i <= fNpar; ++i) {
          fX[i-1] = fXt[i-1] + fac*fMNOTxdev[i-1];

--- a/math/minuit/src/TMinuitMinimizer.cxx
+++ b/math/minuit/src/TMinuitMinimizer.cxx
@@ -804,7 +804,7 @@ bool TMinuitMinimizer::GetMinosError(unsigned int i, double & errLow, double & e
    }
 
 
-   // syntax of MINOS is MINOS [maxcalls] [parno]
+   // syntax of MINOS command is:  MINOS [maxcalls] [parno]
    // if parno = 0 all parameters are done
    arglist[0] = MaxFunctionCalls();
    arglist[1] = i+1;  // par number starts from 1 in TMInuit
@@ -815,7 +815,7 @@ bool TMinuitMinimizer::GetMinosError(unsigned int i, double & errLow, double & e
    // check also the status from fCstatu
    if (isValid && fMinuit->fCstatu != "SUCCESSFUL") {
       if (fMinuit->fCstatu == "FAILURE" ) {
-         // in this case MINOS failed on all parametera, so it is not valid !
+         // in this case MINOS failed on all parameters, so it is not valid !
          ierr = 5;
          isValid = false;
       }

--- a/math/minuit/src/TMinuitMinimizer.cxx
+++ b/math/minuit/src/TMinuitMinimizer.cxx
@@ -815,7 +815,7 @@ bool TMinuitMinimizer::GetMinosError(unsigned int i, double & errLow, double & e
    // check also the status from fCstatu
    if (isValid && fMinuit->fCstatu != "SUCCESSFUL") {
       if (fMinuit->fCstatu == "FAILURE" ) {
-         // in this case MINOS failed on all prameter, so it is not valid !
+         // in this case MINOS failed on all parametera, so it is not valid !
          ierr = 5;
          isValid = false;
       }
@@ -824,6 +824,7 @@ bool TMinuitMinimizer::GetMinosError(unsigned int i, double & errLow, double & e
    }
 
    fStatus += 10*ierr;
+   fMinosStatus = ierr; 
 
    fMinosRun = true;
 

--- a/math/minuit2/CMakeLists.txt
+++ b/math/minuit2/CMakeLists.txt
@@ -249,7 +249,7 @@ if(minuit2_mpi)
 endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL ROOT)
-  add_definitions(-DWARNINGMSG)
+  add_definitions(-DWARNINGMSG -DUSE_ROOT_ERROR)
   ROOT_ADD_TEST_SUBDIRECTORY(test)
 else()
   include(StandAlone.cmake)

--- a/math/minuit2/CMakeLists.txt
+++ b/math/minuit2/CMakeLists.txt
@@ -249,7 +249,7 @@ if(minuit2_mpi)
 endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL ROOT)
-  add_definitions(-DWARNINGMSG -DUSE_ROOT_ERROR)
+  add_definitions(-DWARNINGMSG)
   ROOT_ADD_TEST_SUBDIRECTORY(test)
 else()
   include(StandAlone.cmake)

--- a/math/minuit2/inc/Minuit2/MinosError.h
+++ b/math/minuit2/inc/Minuit2/MinosError.h
@@ -27,19 +27,19 @@ class MinosError {
 
 public:
 
-   MinosError() : fParameter(0), fMinValue(0.), fUpper(MnCross()), fLower(MnCross()) {}
+   MinosError() : fParameter(0), fMinParValue(0.), fUpper(MnCross()), fLower(MnCross()) {}
 
-   MinosError(unsigned int par, double min, const MnCross& low, const MnCross& up) : fParameter(par), fMinValue(min), fUpper(up), fLower(low) {}
+   MinosError(unsigned int par, double value, const MnCross& low, const MnCross& up) : fParameter(par), fMinParValue(value), fUpper(up), fLower(low) {}
 
    ~MinosError() {}
 
-   MinosError(const MinosError& err) : fParameter(err.fParameter), fMinValue(err.fMinValue), fUpper(err.fUpper),  fLower(err.fLower) {}
+   MinosError(const MinosError& err) : fParameter(err.fParameter), fMinParValue(err.fMinParValue), fUpper(err.fUpper),  fLower(err.fLower) {}
 
    MinosError& operator=(const MinosError& ) = default;
 
    MinosError& operator()(const MinosError& err) {
       fParameter = err.fParameter;
-      fMinValue = err.fMinValue;
+      fMinParValue = err.fMinParValue;
       fUpper = err.fUpper;
       fLower = err.fLower;
       return *this;
@@ -49,12 +49,20 @@ public:
       return std::pair<double,double>(Lower(), Upper());
    }
    double Lower() const {
-      if ( AtLowerLimit() ) return LowerState().Parameter( Parameter() ).LowerLimit() -  fMinValue;
-      return -1.*LowerState().Error(Parameter())*(1. + fLower.Value());
+      if (AtLowerLimit())
+         return LowerState().Parameter(Parameter()).LowerLimit() - fMinParValue;
+      if (LowerValid() )
+         return -1. * LowerState().Error(Parameter()) * (1. + fLower.Value());
+      // return Hessian Error in case is invalid
+      return - LowerState().Error(Parameter());
    }
    double Upper() const {
-      if ( AtUpperLimit() ) return UpperState().Parameter( Parameter() ).UpperLimit() -  fMinValue;
-      return UpperState().Error(Parameter())*(1. + fUpper.Value());
+      if (AtUpperLimit())
+         return UpperState().Parameter(Parameter()).UpperLimit() - fMinParValue;
+      if (UpperValid())
+         return UpperState().Error(Parameter()) * (1. + fUpper.Value());
+      // return Hessian Error in case is invalid
+      return  UpperState().Error(Parameter());
    }
    unsigned int Parameter() const {return fParameter;}
    const MnUserParameterState& LowerState() const {return fLower.State();}
@@ -69,12 +77,13 @@ public:
    bool LowerNewMin() const {return fLower.NewMinimum();}
    bool UpperNewMin() const {return fUpper.NewMinimum();}
    unsigned int NFcn() const {return fUpper.NFcn() + fLower.NFcn();}
-   double Min() const {return fMinValue;}
+   // return parameter value at the minimum
+   double Min() const {return fMinParValue;}
 
 private:
 
    unsigned int fParameter;
-   double fMinValue;
+   double fMinParValue;
    MnCross fUpper;
    MnCross fLower;
 };

--- a/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
+++ b/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
@@ -240,17 +240,17 @@ public:
       A minimizaiton must be performed befre, return false if no minimization has been done
       In case of Minos failed the status error is updated as following
       status += 10 * minosStatus. 
-      The Minos status of last Minos run can also be retrieved bby calling MinosStatus()
+      The Minos status of last Minos run can also be retrieved by calling MinosStatus()
    */
    virtual bool GetMinosError(unsigned int i, double & errLow, double & errUp, int = 0);
 
    /** 
       MINOS status code of last Minos run
-       status & 1 > 0  : invalid lower error
-       status & 2 > 0  : invalid upper error 
-       status & 4 > 0  : invalid because maximum number of function calls exceeded 
-       status & 8 > 0  : a new minimum has been found
-       status & 16 > 0 : error is truuncated because parameter is at lower/upper limit
+       `status & 1 > 0`  : invalid lower error
+       `status & 2 > 0`  : invalid upper error
+       `status & 4 > 0`  : invalid because maximum number of function calls exceeded
+       `status & 8 > 0`  : a new minimum has been found
+       `status & 16 > 0` : error is truncated because parameter is at lower/upper limit
    */
    virtual int MinosStatus() const { return fMinosStatus; }
 

--- a/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
+++ b/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
@@ -311,6 +311,7 @@ private:
 
    unsigned int fDim;       // dimension of the function to be minimized
    bool fUseFumili;
+   unsigned int fCountNewMinMinos = 0;  // count number of times a new minimum is found in minos
 
    ROOT::Minuit2::MnUserParameterState fState;
    // std::vector<ROOT::Minuit2::MinosError> fMinosErrors;

--- a/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
+++ b/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
@@ -159,7 +159,7 @@ public:
    virtual double Edm() const { return fState.Edm(); }
 
    /// return  pointer to X values at the minimum
-   virtual const double *  X() const;
+   virtual const double *  X() const { return  &fValues.front();}
 
    /// return pointer to gradient values at the minimum
    virtual const double *  MinGradient() const { return 0; } // not available in Minuit2
@@ -239,15 +239,20 @@ public:
       get the minos error for parameter i, return false if Minos failed
       A minimizaiton must be performed befre, return false if no minimization has been done
       In case of Minos failed the status error is updated as following
-      status += 10 * minosStatus where the minos status is:
-       status = 1    : maximum number of function calls exceeded when running for lower error
-       status = 2    : maximum number of function calls exceeded when running for upper error
-       status = 3    : new minimum found when running for lower error
-       status = 4    : new minimum found when running for upper error
-       status = 5    : any other failure
-
+      status += 10 * minosStatus. 
+      The Minos status of last Minos run can also be retrieved bby calling MinosStatus()
    */
    virtual bool GetMinosError(unsigned int i, double & errLow, double & errUp, int = 0);
+
+   /** 
+      MINOS status code of last Minos run
+       status & 1 > 0  : invalid lower error
+       status & 2 > 0  : invalid upper error 
+       status & 4 > 0  : invalid because maximum number of function calls exceeded 
+       status & 8 > 0  : a new minimum has been found
+       status & 16 > 0 : error is truuncated because parameter is at lower/upper limit
+   */
+   virtual int MinosStatus() const { return fMinosStatus; }
 
    /**
       scan a parameter i around the minimum. A minimization must have been done before,
@@ -307,11 +312,14 @@ protected:
    /// examine the minimum result
    bool ExamineMinimum(const ROOT::Minuit2::FunctionMinimum & min);
 
+   // internal function to compute Minos errors
+   int RunMinosError(unsigned int i, double & errLow, double & errUp, int runopt);
+
 private:
 
    unsigned int fDim;       // dimension of the function to be minimized
    bool fUseFumili;
-   unsigned int fCountNewMinMinos = 0;  // count number of times a new minimum is found in minos
+   int fMinosStatus = -1;  // Minos status code
 
    ROOT::Minuit2::MnUserParameterState fState;
    // std::vector<ROOT::Minuit2::MinosError> fMinosErrors;

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -605,6 +605,17 @@ bool  Minuit2Minimizer::ExamineMinimum(const ROOT::Minuit2::FunctionMinimum & mi
    }
 
    if (debugLevel >= 1) PrintResults();
+
+   // set the minimum values in the fValues vector
+   const std::vector<MinuitParameter> & paramsObj = fState.MinuitParameters();
+   if (paramsObj.size() == 0) return 0;
+   assert(fDim == paramsObj.size());
+   // re-size vector if it has changed after a new minimization
+   if (fValues.size() != fDim) fValues.resize(fDim);
+   for (unsigned int i = 0; i < fDim; ++i) {
+      fValues[i] = paramsObj[i].Value();
+   }
+
    return validMinimum;
 }
 
@@ -638,22 +649,6 @@ void Minuit2Minimizer::PrintResults() {
       std::cout << "Nfcn  = " << fState.NFcn() << std::endl;
    }
 }
-
-const double * Minuit2Minimizer::X() const {
-   // return values at minimum
-   const std::vector<MinuitParameter> & paramsObj = fState.MinuitParameters();
-   if (paramsObj.size() == 0) return 0;
-   assert(fDim == paramsObj.size());
-   // be careful for multiple calls of this function. I will redo an allocation here
-   // only when size of vectors has changed (e.g. after a new minimization)
-   if (fValues.size() != fDim) fValues.resize(fDim);
-   for (unsigned int i = 0; i < fDim; ++i) {
-      fValues[i] = paramsObj[i].Value();
-   }
-
-   return  &fValues.front();
-}
-
 
 const double * Minuit2Minimizer::Errors() const {
    // return error at minimum (set to zero for fixed and constant params)
@@ -776,8 +771,7 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
    // runopt is a flag which specifies if only lower or upper error needs to be run
    // if runopt = 0 both, = 1 only lower, + 2 only upper errors
    errLow = 0; errUp = 0;
-   bool runLower = runopt != 2;
-   bool runUpper = runopt != 1;
+   
 
    assert( fMinuitFCN );
 
@@ -786,9 +780,6 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
       return false;
    }
 
-   int debugLevel = PrintLevel();
-   // internal minuit messages
-   MnPrint::SetLevel( debugLevel );
 
    // to run minos I need function minimum class
    // redo minimization from current state
@@ -810,7 +801,51 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
    if (ErrorDef() != fMinimum->Up() )
       fMinimum->SetErrorDef(ErrorDef() );
 
+   int mstatus = RunMinosError(i,errLow, errUp, runopt);
+
+   // run again the Minimization in case of a new minimum
+   // bit 8 is set
+   if ((mstatus & 8) != 0) {
+     
+      MN_INFO_MSG2("Minuit2Minimizer::GetMinosError",
+                   "Found a new minimum: run again the Minimization  starting from the new  point ");
+      if (PrintLevel() > 1) {
+         std::cout << "New minimum point found by MINOS: " << std::endl;
+         std::cout << "FVAL  = " << fState.Fval() << std::endl;
+         for (auto & par : fState.MinuitParameters() ) {
+            std::cout << par.Name() << "\t  = " << par.Value() << std::endl;
+         }
+      }
+      // release parameter that was fixed in the returned state from Minos
+      ReleaseVariable(i);
+      bool ok = Minimize();
+      if (!ok)  return false;
+      // run again Minos from new Minimum (also lower error needs to be re-computed)
+      MN_INFO_MSG2("Minuit2Minimizer::GetMinosError", "Run now again Minos from the new found Minimum");
+      mstatus = RunMinosError(i, errLow, errUp, runopt);
+
+      // do not reset new minimum bit to flag for other parameters
+      mstatus |= 8; 
+   }
+
+   fStatus += 10*mstatus;
+   fMinosStatus = mstatus; 
+
+   bool isValid =  ((mstatus & 1) == 0) && ((mstatus & 2) == 0);    
+   return isValid;
+}
+
+
+int Minuit2Minimizer::RunMinosError(unsigned int i, double & errLow, double & errUp, int runopt) {
    // switch off Minuit2 printing
+
+   bool runLower = runopt != 2;
+   bool runUpper = runopt != 1;
+
+   int debugLevel = PrintLevel();
+   // internal minuit messages
+   MnPrint::SetLevel( debugLevel );
+
    int prev_level = (PrintLevel() <= 0 ) ?   TurnOffPrintInfoLevel() : -2;
 
    // set the precision if needed
@@ -832,24 +867,30 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
    // cut off too small tolerance (they are not needed)
    tol = std::max(tol, 0.01);
 
-   if (debugLevel >=1) {
-      // print the real number of maxfcn used (defined in MnMinos)
-      int maxfcn_used = maxfcn;
-      if (maxfcn_used == 0) {
-         int nvar = fState.VariableParameters();
-         maxfcn_used = 2*(nvar+1)*(200 + 100*nvar + 5*nvar*nvar);
-      }
-      // print an empty line above
-      std::cout << "******************************************************************************************************\n";
-      std::string txt = (runLower) ? "lower" : "upper";
-      if (runLower && runUpper) txt = "lower and upper";
-      std::cout << "Minuit2Minimizer::GetMinosError - Run MINOS " << txt << " error for parameter #" << i << " : " << par_name
-                << " using max-calls " << maxfcn_used << ", tolerance " << tol << std::endl;
+   
+   // get the real number of maxfcn used (defined in MnMinos) to be printed 
+   int maxfcn_used = maxfcn;
+   if (maxfcn_used == 0) {
+      int nvar = fState.VariableParameters();
+      maxfcn_used = 2*(nvar+1)*(200 + 100*nvar + 5*nvar*nvar);
    }
 
-   if (runLower)
+   if (runLower) {
+      if (debugLevel >=1) {
+         std::cout << "******************************************************************************************************\n";
+         std::cout << "Minuit2Minimizer::GetMinosError - Run MINOS LOWER error for parameter #" << i << " : " << par_name
+                << " using max-calls " << maxfcn_used << ", tolerance " << tol << std::endl;
+      }
       low = minos.Loval(i, maxfcn, tol);
-   if (runUpper) up  = minos.Upval(i,maxfcn,tol);
+   }
+   if (runUpper) {
+      if (debugLevel >=1) {
+         std::cout << "******************************************************************************************************\n";
+         std::cout << "Minuit2Minimizer::GetMinosError - Run MINOS UPPER error for parameter #" << i << " : " << par_name
+                << " using max-calls " << maxfcn_used << ", tolerance " << tol << std::endl;
+      }
+      up  = minos.Upval(i,maxfcn,tol);
+   }
 
    ROOT::Minuit2::MinosError me(i, fMinimum->UserState().Value(i),low, up);
 
@@ -919,7 +960,7 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
    if (lowerInvalid || upperInvalid ) {
       // set status accroding to bit
       // bit 1:  lower invalid Minos errors
-      // bit 2:  uper invalid Minos error
+      // bit 2:  upper invalid Minos error
       // bit 3:   invalid because max FCN
       // bit 4 : invalid because a new minimum has been found
       if (lowerInvalid) {
@@ -928,60 +969,34 @@ bool Minuit2Minimizer::GetMinosError(unsigned int i, double & errLow, double & e
          if (me.LowerNewMin() ) mstatus |= 8;
       }
       if(upperInvalid) {
-         mstatus |= 3;
+         mstatus |= 2;
          if (me.AtUpperMaxFcn() ) mstatus |= 4;
          if (me.UpperNewMin() ) mstatus |= 8;
       }
-      //std::cout << "Error running Minos for parameter " << i << std::endl;
-      fStatus += 10*mstatus;
    }
+   // case upper/lower limit
+   if (me.AtUpperLimit() || me.AtLowerLimit())
+      mstatus |= 16; 
+
+   
 
    if (runLower) errLow = me.Lower();
    if (runUpper) errUp = me.Upper();
 
-   // in case of new minimum update minimum state
-   int iflagNewMinimum = 0;
+   // in case of new minimum found update also the  minimum state
    if (  ( runLower && me.LowerNewMin()) && (runUpper && me.UpperNewMin() ) ) {
-      iflagNewMinimum = 3;
       // take state with lower function value
       fState = (low.State().Fval() < up.State().Fval()) ? low.State() : up.State();
    } else if ( runLower && me.LowerNewMin() ) {
-      iflagNewMinimum = 1;
       fState = low.State();
    } else if ( runUpper && me.UpperNewMin() ) {
-      iflagNewMinimum = 2;
       fState = up.State();
    }
 
+   return mstatus;
 
-   // run gain the Minimization
-   if (iflagNewMinimum > 0) {
-      if (fCountNewMinMinos > 10) {
-          MN_ERROR_MSG("Minuit2Minimizer::GetMinosErrors:  failed - a maximum number of searches for a new minimum has been done");
-          return false;
-      }
-      fCountNewMinMinos++;
-      MN_INFO_MSG2("Minuit2Minimizer::GetMinosError",
-                   "Found a new minimum: run again the Minimization  starting from the new  point ");
-      if (debugLevel > 1) {
-         std::cout << "New minimum point found by Minos : " << std::endl;
-         std::cout << "FVAL  = " << fState.Fval() << std::endl;
-         for (auto & par : fState.MinuitParameters() ) {
-            std::cout << par.Name() << "\t  = " << par.Value() << std::endl;
-         }
-      }
-      // release parameter that was fixed in the returned state from Minos
-      ReleaseVariable(i);
-      bool ok = Minimize();
-      if (!ok)  return false;
-      // run again Minos from new Minimum (also lower error needs to be re-computed)
-      MN_INFO_MSG2("Minuit2Minimizer::GetMinosError", "Run now again Minos from the new found Minimum");
-      GetMinosError(i, errLow, errUp, runopt);
-   }
-
-   bool isValid = (runLower && me.LowerValid() ) || (runUpper && me.UpperValid() );
-   return isValid;
 }
+
 
 bool Minuit2Minimizer::Scan(unsigned int ipar, unsigned int & nstep, double * x, double * y, double xmin, double xmax) {
    // scan a parameter (variable) around the minimum value

--- a/math/minuit2/src/MnFunctionCross.cxx
+++ b/math/minuit2/src/MnFunctionCross.cxx
@@ -59,11 +59,14 @@ MnCross MnFunctionCross::operator()(const std::vector<unsigned int>& par, const 
    std::vector<double> alsb(3, 0.), flsb(3, 0.);
 
    int printLevel = MnPrint::Level();
-
+#ifdef DEBUG
+   printLevel = 3;
+#endif
 
 #ifdef DEBUG
-   std::cout<<"MnFunctionCross for parameter  "<<par.front()<< "fmin = " << aminsv
-            << " contur value aim = (fmin + up) = " << aim << std::endl;
+   for (unsigned int i = 0; i < par.size(); ++i)
+         std::cout << "MnFunctionCross for parameter  " << par[i] << " value " << pmid[i] << " dir " << pdir[i]
+         << " function min = " << aminsv << " contur value aim = (fmin + up) = " << aim << std::endl;
 #endif
 
 
@@ -75,14 +78,23 @@ MnCross MnFunctionCross::operator()(const std::vector<unsigned int>& par, const 
       if(fState.Parameter(kex).HasLimits()) {
          double zmid = pmid[i];
          double zdir = pdir[i];
-         if(fabs(zdir) < fState.Precision().Eps()) continue;
          //       double zlim = 0.;
          if(zdir > 0. && fState.Parameter(kex).HasUpperLimit()) {
             double zlim = fState.Parameter(kex).UpperLimit();
+            if (fabs(zdir) < fState.Precision().Eps()) {
+               // we have a limit
+               if (abs(zlim-zmid) < fState.Precision().Eps() ) limset = true;
+               continue;
+            }
             aulim = std::min(aulim, (zlim-zmid)/zdir);
          }
          else if(zdir < 0. && fState.Parameter(kex).HasLowerLimit()) {
             double zlim = fState.Parameter(kex).LowerLimit();
+            if (fabs(zdir) < fState.Precision().Eps()) {
+               // we have a limit
+               if (abs(zlim-zmid) < fState.Precision().Eps() ) limset = true;
+               continue;
+            }
             aulim = std::min(aulim, (zlim-zmid)/zdir);
          }
       }
@@ -92,19 +104,30 @@ MnCross MnFunctionCross::operator()(const std::vector<unsigned int>& par, const 
    std::cout<<"Largest allowed aulim "<< aulim << std::endl;
 #endif
 
-   if(aulim  < aopt+tla) limset = true;
 
+   // case of a single parameter and we are at limit
+   if (limset && npar == 1) {
+      if (printLevel > 1)
+         std::cout << "MnFunctionCross: parameter is at limit " << pmid[0] << " delta "
+         << pdir[0] << std::endl;
+      return MnCross(fState, nfcn, MnCross::CrossParLimit());
+   }
+
+   if (aulim < aopt + tla)
+      limset = true;
 
    MnMigrad migrad(fFCN, fState, MnStrategy(std::max(0, int(fStrategy.Strategy()-1))));
 
-   for(unsigned int i = 0; i < npar; i++) {
-#ifdef DEBUG
-      std::cout << "MnFunctionCross: Set value for " << par[i] <<  " to " << pmid[i] << std::endl;
-#endif
+   if (printLevel > 2) {
+      std::cout << "MnFunctionCross: Run Migrad fixing parameters :";
+      if (npar > 1) std::cout << std::endl;
+   }
+   for (unsigned int i = 0; i < npar; i++) {
+
       migrad.SetValue(par[i], pmid[i]);
 
-      if (printLevel > 1) {
-         std::cout << "MnFunctionCross: parameter " << i << " set to " << pmid[i] << std::endl;
+      if (printLevel > 2) {
+         std::cout << "\t" << fState.Name(par[i]) << " #" << par[i] << "  to " << pmid[i] << std::endl;
       }
    }
    // find minimum with respect all the other parameters (n- npar) (npar are the fixed ones)
@@ -112,12 +135,20 @@ MnCross MnFunctionCross::operator()(const std::vector<unsigned int>& par, const 
    FunctionMinimum min0 = migrad(maxcalls, mgr_tlr);
    nfcn += min0.NFcn();
 
-#ifdef DEBUG
-   std::cout << "MnFunctionCross: after Migrad on n-1  minimum is " << min0 << std::endl;
-#endif
+   if (printLevel > 2) {
+      MnPrint::PrintState(std::cout, min0.State(), "MnFunctionCross: Result after Migrad");
+      std::cout << min0.UserState().Parameters() << std::endl;
+   }
 
-   if (min0.Fval() < fFval + tlf)  // case of new minimum found
+   // case a new minimum is found
+   if (min0.Fval() < fFval - tlf) {
+      // case of new minimum is found
+      if (printLevel > 1) {
+         std::cout << "MnFunctionCross: A new minimum is found when scanning parameter  " << par.front() << " new value = "
+         << min0.Fval() << " old value : " << fFval << std::endl;
+      }
       return MnCross(min0.UserState(), nfcn, MnCross::CrossNewMin());
+   }
    if(min0.HasReachedCallLimit())
       return MnCross(min0.UserState(), nfcn, MnCross::CrossFcnLimit());
    if(!min0.IsValid()) return MnCross(fState, nfcn);
@@ -142,26 +173,26 @@ MnCross MnFunctionCross::operator()(const std::vector<unsigned int>& par, const 
    std::cout << "MnFunctionCross: flsb[0] = " << flsb[0] << " aopt =  " << aopt  << std::endl;
 #endif
 
-   for(unsigned int i = 0; i < npar; i++) {
-#ifdef DEBUG
-      std::cout << "MnFunctionCross: Set new value for " << par[i] <<  " from " << pmid[i] << " to " << pmid[i] + (aopt)*pdir[i] << " aopt = " << aopt << std::endl;
-#endif
+   if (printLevel > 2) {
+      std::cout << "MnFunctionCross: Run Migrad again (#2) : ";
+      if (npar > 1) std::cout << std::endl;
+   }
+   for (unsigned int i = 0; i < npar; i++) {
       migrad.SetValue(par[i], pmid[i] + (aopt)*pdir[i]);
-
-      if (printLevel > 1) {
-         std::cout << "MnFunctionCross: parameter " << i << " set to " << pmid[i] + (aopt)*pdir[i] << std::endl;
+      if (printLevel > 2) {
+         std::cout << "\t - parameter " << i << " fixed to " << pmid[i] + (aopt)*pdir[i] << std::endl;
       }
-
    }
 
    FunctionMinimum min1 = migrad(maxcalls, mgr_tlr);
    nfcn += min1.NFcn();
 
-#ifdef DEBUG
-   std::cout << "MnFunctionCross: after Migrad on n-1  minimum is " << min1 << std::endl;
-#endif
+   if (printLevel > 2) {
+      MnPrint::PrintState(std::cout, min1.State(), "MnFunctionCross: Result after 2nd Migrad");
+      std::cout << min1.UserState().Parameters() << std::endl;
+   }
 
-   if (min1.Fval() < fFval + tlf) // case of new minimum found
+   if (min1.Fval() < fFval - tlf) // case of new minimum found
       return MnCross(min1.UserState(), nfcn, MnCross::CrossNewMin());
    if(min1.HasReachedCallLimit())
       return MnCross(min1.UserState(), nfcn, MnCross::CrossFcnLimit());
@@ -198,24 +229,25 @@ L300:
                aopt = aulim;
                limset = true;
             }
+            if (printLevel > 2) {
+               std::cout << "MnFunctionCross: Run Migrad again (iteration " << it << " ) :  ";
+               if (npar > 1) std::cout << std::endl;
+            }
             for(unsigned int i = 0; i < npar; i++) {
-#ifdef DEBUG
-      std::cout << "MnFunctionCross: Set new value for " << par[i] <<  " to " << pmid[i] + (aopt)*pdir[i] << " aopt = " << aopt << std::endl;
-#endif
                migrad.SetValue(par[i], pmid[i] + (aopt)*pdir[i]);
-               if (printLevel > 1) {
-                  std::cout << "MnFunctionCross: parameter " << i << " set to " << pmid[i] + (aopt)*pdir[i] << std::endl;
+               if (printLevel > 2) {
+                  std::cout << "\t - parameter " << i << " fixed to " << pmid[i] + (aopt)*pdir[i] << std::endl;
                }
-
             }
             min1 = migrad(maxcalls, mgr_tlr);
             nfcn += min1.NFcn();
 
-#ifdef DEBUG
-   std::cout << "MnFunctionCross: after Migrad on n-1  minimum is " << min1 << std::endl;
-   std::cout << "nfcn = " << nfcn << std::endl;
-#endif
-            if (min1.Fval() < fFval + tlf) // case of new minimum found
+            if (printLevel > 2) {
+               MnPrint::PrintState(std::cout, min1.State(), "MnFunctionCross: Result after Migrad");
+               std::cout << min1.UserState().Parameters() << std::endl;
+            }
+
+            if (min1.Fval() < fFval - tlf) // case of new minimum found
                return MnCross(min1.UserState(), nfcn, MnCross::CrossNewMin());
             if(min1.HasReachedCallLimit())
                return MnCross(min1.UserState(), nfcn, MnCross::CrossFcnLimit());
@@ -264,25 +296,25 @@ L460:
       limset = true;
    }
 
+   if (printLevel > 2) {
+      std::cout << "MnFunctionCross: Run Migrad again (#3) : ";
+      if (npar > 1) std::cout << std::endl;
+   }
    for(unsigned int i = 0; i < npar; i++) {
-#ifdef DEBUG
-      std::cout << "MnFunctionCross: Set new value for " << par[i] <<  " from " << pmid[i] << " to " << pmid[i] + (aopt)*pdir[i] << " aopt = " << aopt << std::endl;
-#endif
       migrad.SetValue(par[i], pmid[i] + (aopt)*pdir[i]);
-      if (printLevel > 1) {
-         std::cout << "MnFunctionCross: parameter " << i << " set to " << pmid[i] + (aopt)*pdir[i] << std::endl;
+      if (printLevel > 2) {
+         std::cout << "\t : parameter " << i << " fixed to " << pmid[i] + (aopt)*pdir[i] << std::endl;
       }
-
    }
    FunctionMinimum min2 = migrad(maxcalls, mgr_tlr);
    nfcn += min2.NFcn();
 
-#ifdef DEBUG
-   std::cout << "MnFunctionCross: after Migrad on n-1  minimum is " << min2 << std::endl;
-   std::cout << "nfcn = " << nfcn << std::endl;
-#endif
+   if (printLevel > 2) {
+      MnPrint::PrintState(std::cout, min2.State(), "MnFunctionCross: Result after Migrad (#3): ");
+      std::cout << min2.UserState().Parameters() << std::endl;
+   }
 
-   if (min2.Fval() < fFval + tlf) // case of new minimum found
+   if (min2.Fval() < fFval - tlf) // case of new minimum found
       return MnCross(min2.UserState(), nfcn, MnCross::CrossNewMin());
    if(min2.HasReachedCallLimit())
       return MnCross(min2.UserState(), nfcn, MnCross::CrossFcnLimit());
@@ -471,23 +503,25 @@ L500:
          }
 
          // evaluate at new point aopt
+         if (printLevel > 2) {
+            std::cout << "MnFunctionCross: Run Migrad again at new point (#iter = " << ipt << " ): ";
+            if (npar > 1) std::cout << std::endl;
+         }
          for(unsigned int i = 0; i < npar; i++) {
-#ifdef DEBUG
-      std::cout << "MnFunctionCross: Set new value for " << par[i] <<  " from " << pmid[i] << " to " << pmid[i] + (aopt)*pdir[i] << " aopt = " << aopt << std::endl;
-#endif
             migrad.SetValue(par[i], pmid[i] + (aopt)*pdir[i]);
-            if (printLevel > 1) {
-               std::cout << "MnFunctionCross: parameter " << i << " set to " << pmid[i] + (aopt)*pdir[i] << std::endl;
+            if (printLevel > 2) {
+               std::cout << "\t : parameter " << i << " fixed to " << pmid[i] + (aopt)*pdir[i] << std::endl;
             }
          }
          min2 = migrad(maxcalls, mgr_tlr);
          nfcn += min2.NFcn();
-#ifdef DEBUG
-   std::cout << "MnFunctionCross: after Migrad on n-1  minimum is " << min2 << std::endl;
-   std::cout << "nfcn = " << nfcn << std::endl;
-#endif
 
-         if (min2.Fval() < fFval + tlf) // case of new minimum found
+         if (printLevel > 2) {
+            MnPrint::PrintState(std::cout, min2.State(), "MnFunctionCross: Result after new Migrad : ");
+            std::cout << min2.UserState().Parameters() << std::endl;
+         }
+
+         if (min2.Fval() < fFval - tlf) // case of new minimum found
             return MnCross(min2.UserState(), nfcn, MnCross::CrossNewMin());
          if(min2.HasReachedCallLimit())
             return MnCross(min2.UserState(), nfcn, MnCross::CrossFcnLimit());

--- a/math/minuit2/src/MnFunctionCross.cxx
+++ b/math/minuit2/src/MnFunctionCross.cxx
@@ -83,7 +83,7 @@ MnCross MnFunctionCross::operator()(const std::vector<unsigned int>& par, const 
             double zlim = fState.Parameter(kex).UpperLimit();
             if (fabs(zdir) < fState.Precision().Eps()) {
                // we have a limit
-               if (abs(zlim-zmid) < fState.Precision().Eps() ) limset = true;
+               if (fabs(zlim-zmid) < fState.Precision().Eps() ) limset = true;
                continue;
             }
             aulim = std::min(aulim, (zlim-zmid)/zdir);
@@ -92,7 +92,7 @@ MnCross MnFunctionCross::operator()(const std::vector<unsigned int>& par, const 
             double zlim = fState.Parameter(kex).LowerLimit();
             if (fabs(zdir) < fState.Precision().Eps()) {
                // we have a limit
-               if (abs(zlim-zmid) < fState.Precision().Eps() ) limset = true;
+               if (fabs(zlim-zmid) < fState.Precision().Eps() ) limset = true;
                continue;
             }
             aulim = std::min(aulim, (zlim-zmid)/zdir);

--- a/math/minuit2/src/MnMinos.cxx
+++ b/math/minuit2/src/MnMinos.cxx
@@ -112,10 +112,10 @@ MnCross MnMinos::FindCrossValue(int direction, unsigned int par, unsigned int ma
    int printLevel = MnPrint::Level();
    if (printLevel > 2) {
       if (direction == 1)
-         std::cout << "\n--------- MnMinos --------- \n Determination of upper Minos error for parameter "
+         std::cout << "--------- MnMinos -------\nDetermination of upper Minos error for parameter "
                    << par << std::endl;
       else
-         std::cout << "\n--------- MnMinos --------- \n Determination of lower Minos error for parameter "
+         std::cout << "--------- MnMinos -------\nDetermination of lower Minos error for parameter "
                    << par << std::endl;
    }
 

--- a/math/minuit2/src/MnMinos.cxx
+++ b/math/minuit2/src/MnMinos.cxx
@@ -63,33 +63,26 @@ std::pair<double,double> MnMinos::operator()(unsigned int par, unsigned int maxc
 
 double MnMinos::Lower(unsigned int par, unsigned int maxcalls, double toler) const {
    // get lower error for parameter par
-   MnUserParameterState upar = fMinimum.UserState();
-   double err = fMinimum.UserState().Error(par);
 
    MnCross aopt = Loval(par, maxcalls,toler);
 
-   double lower = aopt.IsValid() ? -1.*err*(1.+ aopt.Value()) : (aopt.AtLimit() ? upar.Parameter(par).LowerLimit() : upar.Value(par));
+   MinosError mnerr(par, fMinimum.UserState().Value(par), aopt, MnCross());
 
-   return lower;
+   return mnerr.Lower();
 }
 
 double MnMinos::Upper(unsigned int par, unsigned int maxcalls, double toler) const {
    // upper error for parameter par
+
    MnCross aopt = Upval(par, maxcalls,toler);
 
-   MnUserParameterState upar = fMinimum.UserState();
-   double err = fMinimum.UserState().Error(par);
+   MinosError mnerr(par, fMinimum.UserState().Value(par), MnCross(), aopt);
 
-   double upper = aopt.IsValid() ? err*(1.+ aopt.Value()) : (aopt.AtLimit() ? upar.Parameter(par).UpperLimit() : upar.Value(par));
-
-   return upper;
+   return mnerr.Upper();
 }
 
 MinosError MnMinos::Minos(unsigned int par, unsigned int maxcalls, double toler) const {
    // do full minos error anlysis (lower + upper) for parameter par
-   assert(fMinimum.IsValid());
-   assert(!fMinimum.UserState().Parameter(par).IsFixed());
-   assert(!fMinimum.UserState().Parameter(par).IsConst());
 
    MnCross up = Upval(par, maxcalls,toler);
 #ifdef DEBUG
@@ -102,6 +95,8 @@ MinosError MnMinos::Minos(unsigned int par, unsigned int maxcalls, double toler)
    std::cout << "Function calls to find lower error " << lo.NFcn() << std::endl;
 #endif
 
+   std::cout << "return Minos error " << lo.Value() << "  , " << up.Value() << std::endl;
+
    return MinosError(par, fMinimum.UserState().Value(par), lo, up);
 }
 
@@ -113,18 +108,21 @@ MnCross MnMinos::FindCrossValue(int direction, unsigned int par, unsigned int ma
    // pass now tolerance used for Migrad minimizations
 
    assert(direction == 1 || direction == -1);
-#ifdef DEBUG
-   if (direction == 1)
-      std::cout << "\n--------- MnMinos --------- \n Determination of positive Minos error for parameter "
-                << par << std::endl;
-   else
-      std::cout << "\n--------- MnMinos --------- \n Determination of positive Minos error for parameter "
-                << par << std::endl;
-#endif
+
+   int printLevel = MnPrint::Level();
+   if (printLevel > 2) {
+      if (direction == 1)
+         std::cout << "\n--------- MnMinos --------- \n Determination of upper Minos error for parameter "
+                   << par << std::endl;
+      else
+         std::cout << "\n--------- MnMinos --------- \n Determination of lower Minos error for parameter "
+                   << par << std::endl;
+   }
 
    assert(fMinimum.IsValid());
    assert(!fMinimum.UserState().Parameter(par).IsFixed());
    assert(!fMinimum.UserState().Parameter(par).IsConst());
+
    if(maxcalls == 0) {
       unsigned int nvar = fMinimum.UserState().VariableParameters();
       maxcalls = 2*(nvar+1)*(200 + 100*nvar + 5*nvar*nvar);
@@ -135,6 +133,15 @@ MnCross MnMinos::FindCrossValue(int direction, unsigned int par, unsigned int ma
    MnUserParameterState upar = fMinimum.UserState();
    double err = direction * upar.Error(par);
    double val = upar.Value(par) +  err;
+   // check if we do not cross limits
+   if (direction == 1 && upar.Parameter(par).HasUpperLimit()) {
+      val = std::min(val, upar.Parameter(par).UpperLimit());
+   }
+   if (direction == -1 && upar.Parameter(par).HasLowerLimit()) {
+      val = std::max(val, upar.Parameter(par).LowerLimit());
+   }
+   // recompute err in case it was truncated for the limit
+   err = val-upar.Value(par);
    std::vector<double> xmid(1, val);
    std::vector<double> xdir(1, err);
 
@@ -147,6 +154,7 @@ MnCross MnMinos::FindCrossValue(int direction, unsigned int par, unsigned int ma
    //LM:  change to use err**2 (m(i,i) instead of err as in F77 version
    double xunit = sqrt(up/m(ind,ind));
    // LM (29/04/08) bug: change should be done in internal variables
+   // set the initial value for the other parmaeters that we are going to fit in MnCross
    for(unsigned int i = 0; i < m.Nrow(); i++) {
       if(i == ind) continue;
       double xdev = xunit*m(ind,i);
@@ -156,6 +164,14 @@ MnCross MnMinos::FindCrossValue(int direction, unsigned int par, unsigned int ma
       unsigned int ext = upar.ExtOfInt(i);
 
       double unew = upar.Int2ext(i, xnew);
+
+      // take into account limits
+      if (upar.Parameter(ext).HasUpperLimit()) {
+         unew = std::min(unew, upar.Parameter(ext).UpperLimit());
+      }
+      if (upar.Parameter(ext).HasLowerLimit()) {
+         unew = std::max(unew, upar.Parameter(ext).LowerLimit());
+      }
 
 #ifdef DEBUG
       std::cout << "Parameter " << ext << " is set from " << upar.Value(ext) << " to " <<  unew << std::endl;
@@ -167,7 +183,8 @@ MnCross MnMinos::FindCrossValue(int direction, unsigned int par, unsigned int ma
    upar.SetValue(par, val);
 
 #ifdef DEBUG
-   std::cout << "Parameter " << par << " is fixed and set from " << fMinimum.UserState().Value(par) << " to " << val << std::endl;
+   std::cout << "Parameter " << par << " is fixed and set from " << fMinimum.UserState().Value(par) << " to " << val
+   << " delta = " << err << std::endl;
 #endif
 
 
@@ -176,7 +193,7 @@ MnCross MnMinos::FindCrossValue(int direction, unsigned int par, unsigned int ma
 
 
 #ifdef DEBUG
-   std::cout<<"----- MnMinos: aopt found from MnFunctionCross = "<<aopt.Value()<<std::endl << std::endl;
+   std::cout<<"----- MnMinos: aopt value found from MnFunctionCross = "<<aopt.Value()<<std::endl << std::endl;
 #endif
 
 #ifdef WARNINGMSG
@@ -187,17 +204,22 @@ MnCross MnMinos::FindCrossValue(int direction, unsigned int par, unsigned int ma
       MN_INFO_VAL2("MnMinos new Minimum found while looking for Parameter ",par_name);
    if (direction ==1) {
       if(aopt.AtLimit())
-         MN_INFO_VAL2("MnMinos Parameter is at Upper limit.",par_name);
+         MN_INFO_VAL2("MnMinos: parameter is at Upper limit.",par_name);
       if(!aopt.IsValid())
-         MN_INFO_VAL2("MnMinos could not find Upper Value for Parameter ",par_name);
+         MN_INFO_VAL2("MnMinos: could not find Upper Value for Parameter ",par_name);
    }
    else {
       if(aopt.AtLimit())
-         MN_INFO_VAL2("MnMinos Parameter is at Lower limit.",par_name);
+         MN_INFO_VAL2("MnMinos: parameter is at Lower limit.",par_name);
       if(!aopt.IsValid())
-         MN_INFO_VAL2("MnMinos could not find Lower Value for Parameter ",par_name);
+         MN_INFO_VAL2("MnMinos: could not find Lower Value for Parameter ",par_name);
    }
 #endif
+
+   if (printLevel > 2) {
+      std::string scanType = (direction == 1) ? "up" : "low";
+      std::cout << " ------ end Minos scan for " << scanType << " interval for parameter " << upar.Name(par) << std::endl;
+   }
 
    return aopt;
 }
@@ -211,82 +233,6 @@ MnCross MnMinos::Loval(unsigned int par, unsigned int maxcalls, double toler) co
    // return crossing in the lower parameter direction
    return FindCrossValue(-1,par,maxcalls,toler);
 }
-
-// #ifdef DEBUG
-//    std::cout << "\n--------- MnMinos --------- \n Determination of negative Minos error for parameter "
-//              << par << std::endl;
-// #endif
-
-//    assert(fMinimum.IsValid());
-//    assert(!fMinimum.UserState().Parameter(par).IsFixed());
-//    assert(!fMinimum.UserState().Parameter(par).IsConst());
-//    if(maxcalls == 0) {
-//       unsigned int nvar = fMinimum.UserState().VariableParameters();
-//       maxcalls = 2*(nvar+1)*(200 + 100*nvar + 5*nvar*nvar);
-//    }
-//    std::vector<unsigned int> para(1, par);
-
-//    MnUserParameterState upar = fMinimum.UserState();
-//    double err = upar.Error(par);
-//    double val = upar.Value(par) - err;
-//    std::vector<double> xmid(1, val);
-//    std::vector<double> xdir(1, -err);
-
-//    double up = fFCN.Up();
-//    unsigned int ind = upar.IntOfExt(par);
-//    MnAlgebraicSymMatrix m = fMinimum.Error().Matrix();
-//    double xunit = sqrt(up/m(ind,ind));
-//    // get internal parameters
-//    const MnAlgebraicVector & xt = fMinimum.Parameters().Vec();
-
-//    for(unsigned int i = 0; i < m.Nrow(); i++) {
-//       if(i == ind) continue;
-//       double xdev = xunit*m(ind,i);
-
-//       double xnew = xt(i) - xdev;
-
-//       // transform to external values
-//       double unew = upar.Int2ext(i, xnew);
-
-//       unsigned int ext = upar.ExtOfInt(i);
-
-// #ifdef DEBUG
-//       std::cout << "Parameter " << ext << " is set from " << upar.Value(ext) << " to " <<  unew << std::endl;
-// #endif
-//       upar.SetValue(ext, unew);
-//    }
-
-//    upar.Fix(par);
-//    upar.SetValue(par, val);
-
-// #ifdef DEBUG
-//    std::cout << "Parameter " << par << " is fixed and set from " << fMinimum.UserState().Value(par) << " to " << val << std::endl;
-// #endif
-
-//    //   double edmmax = 0.5*0.1*fFCN.Up()*1.e-3;
-//    double toler = 0.01;
-//    MnFunctionCross cross(fFCN, upar, fMinimum.Fval(), fStrategy);
-
-//    MnCross aopt = cross(para, xmid, xdir, toler, maxcalls);
-
-// #ifdef DEBUG
-//    std::cout<<"----- MnMinos: aopt found from MnFunctionCross = "<<aopt.Value()<<std::endl << std::endl;
-// #endif
-
-// #ifdef WARNINGMSG
-//    if(aopt.AtLimit())
-//       MN_INFO_VAL2("MnMinos Parameter is at Lower limit.",par);
-//    if(aopt.AtMaxFcn())
-//       MN_INFO_VAL2("MnMinos maximum number of function calls exceeded for Parameter ",par);
-//    if(aopt.NewMinimum())
-//       MN_INFO_VAL2("MnMinos new Minimum found while looking for Parameter ",par);
-//    if(!aopt.IsValid())
-//       MN_INFO_VAL2("MnMinos could not find Lower Value for Parameter ",par);
-// #endif
-
-//    return aopt;
-
-// }
 
 
    }  // namespace Minuit2


### PR DESCRIPTION
Fix bug  ROOT-10854. WHen a parameter is bound don;t go in the regions outside the bounds. This avoids that  a new minimum is found. 
Add also a protection to avoid an infinite loop in the new minimum iterative search.

Add fix also for the related issue ROOT-10835.  In that case avoid 0/0 division in TMInuit when parameter is bounded and minimum is at 0 and bound is 0. 