### PR TITLE
Adding a missing backtick in the documentation of a TH1 ctor

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -621,7 +621,7 @@ TH1::~TH1()
 ///
 /// \param[in] name name of histogram (avoid blanks)
 /// \param[in] title histogram title.
-///            If title is of the form `stringt;stringx;stringy;stringz`
+///            If title is of the form `stringt;stringx;stringy;stringz`,
 ///            the histogram title is set to `stringt`,
 ///            the x axis title to `stringy`, the y axis title to `stringy`, etc.
 /// \param[in] nbins number of bins

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -621,7 +621,7 @@ TH1::~TH1()
 ///
 /// \param[in] name name of histogram (avoid blanks)
 /// \param[in] title histogram title.
-///            If title is of the form stringt;stringx;stringy;stringz`
+///            If title is of the form `stringt;stringx;stringy;stringz`
 ///            the histogram title is set to `stringt`,
 ///            the x axis title to `stringy`, the y axis title to `stringy`, etc.
 /// \param[in] nbins number of bins


### PR DESCRIPTION
Adding a missing backtick in the documentation of a TH1 ctor