### PR TITLE
Fix too aggressive -Werror replacements

### DIFF
--- a/builtins/davix/CMakeLists.txt
+++ b/builtins/davix/CMakeLists.txt
@@ -21,7 +21,7 @@ foreach(lib davix neon)
   list(APPEND DAVIX_LIBRARIES ${DAVIX_PREFIX}/lib/${libname})
 endforeach()
 
-string(REPLACE "-Werror" "" DAVIX_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+string(REPLACE "-Werror " "" DAVIX_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
 
 ExternalProject_Add(DAVIX
   URL ${DAVIX_URL}/davix-${DAVIX_VERSION}.tar.gz

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -9,7 +9,7 @@ include(ExternalProject)
 include(FindPackageHandleStandardArgs)
 
 set(lcgpackages http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources)
-string(REPLACE "-Werror" "" ROOT_EXTERNAL_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+string(REPLACE "-Werror " "" ROOT_EXTERNAL_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
 
 macro(find_package)
   if(NOT "${ARGV0}" IN_LIST ROOT_BUILTINS)

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -140,7 +140,7 @@ if(gcctoolchain)
 endif()
 
 # We will not fix llvm or clang.
-string(REPLACE "-Werror" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+string(REPLACE "-Werror " "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
 
 if(LLVM_SHARED_LINKER_FLAGS)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LLVM_SHARED_LINKER_FLAGS}")


### PR DESCRIPTION
The replacements removes the -Werror option for externals, which is intended.
However, it also replaces e.g. -Werror=format-security with =format-security, which results in compilation failures due to the unknown option =format-security.
