### PR TITLE
[ntuple] start using RResult for fallible NTuple IO functions

### DIFF
--- a/io/io/inc/ROOT/RRawFile.hxx
+++ b/io/io/inc/ROOT/RRawFile.hxx
@@ -160,6 +160,8 @@ public:
    void Seek(std::uint64_t offset);
    /// Returns the size of the file
    std::uint64_t GetSize();
+   /// Returns the url of the file
+   std::string GetUrl() const;
 
    /// Opens the file if necessary and calls ReadVImpl
    void ReadV(RIOVec *ioVec, unsigned int nReq);

--- a/io/io/src/RRawFile.cxx
+++ b/io/io/src/RRawFile.cxx
@@ -129,6 +129,10 @@ std::uint64_t ROOT::Internal::RRawFile::GetSize()
    return fFileSize;
 }
 
+std::string ROOT::Internal::RRawFile::GetUrl() const {
+   return fUrl;
+}
+
 std::string ROOT::Internal::RRawFile::GetTransport(std::string_view url)
 {
    auto idx = url.find(kTransportSeparator);

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -16,6 +16,7 @@
 #ifndef ROOT7_RMiniFile
 #define ROOT7_RMiniFile
 
+#include <ROOT/RError.hxx>
 #include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RStringView.hxx>
 
@@ -105,16 +106,16 @@ private:
    /// Indicates whether the file is a TFile container or an RNTuple bare file
    bool fIsBare = false;
    /// Used when the file container turns out to be a bare file
-   RNTuple GetNTupleBare(std::string_view ntupleName);
+   RResult<RNTuple> GetNTupleBare(std::string_view ntupleName);
    /// Used when the file turns out to be a TFile container
-   RNTuple GetNTupleProper(std::string_view ntupleName);
+   RResult<RNTuple> GetNTupleProper(std::string_view ntupleName);
 
 public:
    RMiniFileReader() = default;
    /// Uses the given raw file to read byte ranges
    explicit RMiniFileReader(ROOT::Internal::RRawFile *rawFile);
    /// Extracts header and footer location for the RNTuple identified by ntupleName
-   RNTuple GetNTuple(std::string_view ntupleName);
+   RResult<RNTuple> GetNTuple(std::string_view ntupleName);
    /// Reads a given byte range from the file into the provided memory buffer
    void ReadBuffer(void *buffer, size_t nbytes, std::uint64_t offset);
 };

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -953,7 +953,7 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleProper(std::string_view 
       offset = offsetNextKey;
    }
    if (!found) {
-      return R__FAIL("no NTuple named '" + std::string(ntupleName)
+      return R__FAIL("no RNTuple named '" + std::string(ntupleName)
          + "' in file '" + fRawFile->GetUrl() + "'");
    }
 
@@ -975,8 +975,8 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleBare(std::string_view nt
    ReadBuffer(&name, name.GetSize(), offset);
    std::string_view foundName(name.fData, name.fLName);
    if (foundName != ntupleName) {
-      return R__FAIL("expected NTuple named '" + std::string(ntupleName)
-         + "' but instead found NTuple named '" + std::string(foundName)
+      return R__FAIL("expected RNTuple named '" + std::string(ntupleName)
+         + "' but instead found '" + std::string(foundName)
          + "' in file '" + fRawFile->GetUrl() + "'");
    }
    offset += name.GetSize();

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -224,7 +224,11 @@ ROOT::Experimental::Detail::RPageSourceFile::~RPageSourceFile()
 ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFile::AttachImpl()
 {
    RNTupleDescriptorBuilder descBuilder;
-   const auto fNTuple = fReader.GetNTuple(fNTupleName);
+   auto ntplRes = fReader.GetNTuple(fNTupleName);
+   if (!ntplRes) {
+      ntplRes.Throw();
+   }
+   const auto fNTuple = ntplRes.Get();
 
    auto buffer = std::unique_ptr<unsigned char[]>(new unsigned char[fNTuple.fLenHeader]);
    auto zipBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[fNTuple.fNBytesHeader]);

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -228,18 +228,18 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
    if (!ntplRes) {
       ntplRes.Throw();
    }
-   const auto fNTuple = ntplRes.Get();
+   const auto ntpl = ntplRes.Get();
 
-   auto buffer = std::unique_ptr<unsigned char[]>(new unsigned char[fNTuple.fLenHeader]);
-   auto zipBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[fNTuple.fNBytesHeader]);
-   fReader.ReadBuffer(zipBuffer.get(), fNTuple.fNBytesHeader, fNTuple.fSeekHeader);
-   fDecompressor(zipBuffer.get(), fNTuple.fNBytesHeader, fNTuple.fLenHeader, buffer.get());
+   auto buffer = std::unique_ptr<unsigned char[]>(new unsigned char[ntpl.fLenHeader]);
+   auto zipBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[ntpl.fNBytesHeader]);
+   fReader.ReadBuffer(zipBuffer.get(), ntpl.fNBytesHeader, ntpl.fSeekHeader);
+   fDecompressor(zipBuffer.get(), ntpl.fNBytesHeader, ntpl.fLenHeader, buffer.get());
    descBuilder.SetFromHeader(buffer.get());
 
-   buffer = std::unique_ptr<unsigned char[]>(new unsigned char[fNTuple.fLenFooter]);
-   zipBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[fNTuple.fNBytesFooter]);
-   fReader.ReadBuffer(zipBuffer.get(), fNTuple.fNBytesFooter, fNTuple.fSeekFooter);
-   fDecompressor(zipBuffer.get(), fNTuple.fNBytesFooter, fNTuple.fLenFooter, buffer.get());
+   buffer = std::unique_ptr<unsigned char[]>(new unsigned char[ntpl.fLenFooter]);
+   zipBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[ntpl.fNBytesFooter]);
+   fReader.ReadBuffer(zipBuffer.get(), ntpl.fNBytesFooter, ntpl.fSeekFooter);
+   fDecompressor(zipBuffer.get(), ntpl.fNBytesFooter, ntpl.fLenFooter, buffer.get());
    descBuilder.AddClustersFromFooter(buffer.get());
 
    return descBuilder.MoveDescriptor();

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -16,7 +16,7 @@ TEST(MiniFile, Raw)
 
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
-   auto ntuple = reader.GetNTuple("MyNTuple");
+   auto ntuple = reader.GetNTuple("MyNTuple").Get();
    EXPECT_EQ(offHeader, ntuple.fSeekHeader);
    EXPECT_EQ(offFooter, ntuple.fSeekFooter);
 
@@ -46,7 +46,7 @@ TEST(MiniFile, Stream)
 
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
-   auto ntuple = reader.GetNTuple("MyNTuple");
+   auto ntuple = reader.GetNTuple("MyNTuple").Get();
    EXPECT_EQ(offHeader, ntuple.fSeekHeader);
    EXPECT_EQ(offFooter, ntuple.fSeekFooter);
 
@@ -82,7 +82,7 @@ TEST(MiniFile, Proper)
 
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
-   auto ntuple = reader.GetNTuple("MyNTuple");
+   auto ntuple = reader.GetNTuple("MyNTuple").Get();
    EXPECT_EQ(offHeader, ntuple.fSeekHeader);
    EXPECT_EQ(offFooter, ntuple.fSeekFooter);
 
@@ -122,10 +122,10 @@ TEST(MiniFile, Multi)
 
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
-   auto ntuple1 = reader.GetNTuple("FirstNTuple");
+   auto ntuple1 = reader.GetNTuple("FirstNTuple").Get();
    EXPECT_EQ(offHeader1, ntuple1.fSeekHeader);
    EXPECT_EQ(offFooter1, ntuple1.fSeekFooter);
-   auto ntuple2 = reader.GetNTuple("SecondNTuple");
+   auto ntuple2 = reader.GetNTuple("SecondNTuple").Get();
    EXPECT_EQ(offHeader2, ntuple2.fSeekHeader);
    EXPECT_EQ(offFooter2, ntuple2.fSeekFooter);
 
@@ -164,5 +164,11 @@ TEST(MiniFile, Failures)
 
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
-   EXPECT_DEATH(reader.GetNTuple("No such NTiple"), ".*");
+   RNTuple ntuple;
+   try {
+      ntuple = reader.GetNTuple("No such NTuple").Get();
+      FAIL() << "bad ntuple names should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("no NTuple named 'No such NTuple' in file '" + fileGuard.GetPath()));
+   }
 }

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -166,9 +166,9 @@ TEST(MiniFile, Failures)
    RMiniFileReader reader(rawFile.get());
    RNTuple ntuple;
    try {
-      ntuple = reader.GetNTuple("No such NTuple").Get();
-      FAIL() << "bad ntuple names should throw";
+      ntuple = reader.GetNTuple("No such RNTuple").Get();
+      FAIL() << "bad RNTuple names should throw";
    } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("no NTuple named 'No such NTuple' in file '" + fileGuard.GetPath()));
+      EXPECT_THAT(err.what(), testing::HasSubstr("no RNTuple named 'No such RNTuple' in file '" + fileGuard.GetPath()));
    }
 }


### PR DESCRIPTION
This PR starts replacing `R__ASSERT` checks in fallible functions (e.g. IO) with the new `RResult` error sum type introduced in https://github.com/root-project/root/pull/4683. 

I started with `RMiniFileReader::GetNTuple` because it's an expected error case that an `NTuple` of a certain name doesn't exist in the given file (I've certainly done it a few times). 