### PR TITLE
Provide 3D draw options for RH2 and RH3 classes

### DIFF
--- a/hist/histdrawv7/inc/LinkDef.h
+++ b/hist/histdrawv7/inc/LinkDef.h
@@ -27,6 +27,7 @@
 #pragma link C++ class ROOT::Experimental::RHistDrawable<3>+;
 #pragma link C++ class ROOT::Experimental::RHist1Drawable+;
 #pragma link C++ class ROOT::Experimental::RHist2Drawable+;
+#pragma link C++ class ROOT::Experimental::RHist3Drawable+;
 
 #pragma link C++ class ROOT::Experimental::RDisplayHistStat+;
 

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -78,6 +78,7 @@ template <int DIMENSIONS> inline RHistDrawable<DIMENSIONS>::RHistDrawable() : RD
 
 class RHist1Drawable final : public RHistDrawable<1> {
 private:
+
    RAttrLine  fAttrLine{this, "line_"};        ///<! line attributes
 
 public:
@@ -87,15 +88,19 @@ public:
    RHist1Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<1>(hist) {}
 
    const RAttrLine &GetAttrLine() const { return fAttrLine; }
-   RHistDrawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
+   RHist1Drawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
    RAttrLine &AttrLine() { return fAttrLine; }
 };
 
 
 class RHist2Drawable final : public RHistDrawable<2> {
-   enum EDrawKind { kColor = 1, kLego = 2 };
+   class RHist2Attrs final : public RAttrBase {
+      friend class RHist2Drawable;
+      R__ATTR_CLASS(RHist2Attrs, "", AddString("kind","").AddInt("sub",0).AddBool("text", false));
+   };
 
-   int fDrawKind{kColor};        ///< histogram drawing kind
+   RHist2Attrs fAttr{this, ""};           ///<! hist2 direct attributes
+   RAttrLine   fAttrLine{this, "line_"};  ///<! line attributes, used for error or some lego plots
 
 public:
    RHist2Drawable() = default;
@@ -103,8 +108,16 @@ public:
    template <class HIST>
    RHist2Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<2>(hist) {}
 
-   RHist2Drawable &Color() { fDrawKind = kColor; return *this; }
-   RHist2Drawable &Lego() { fDrawKind = kLego; return *this; }
+   RHist2Drawable &Color() { fAttr.SetValue("kind", std::string("col")); fAttr.ClearValue("sub"); return *this; }
+   RHist2Drawable &Lego(int kind = 0) { fAttr.SetValue("kind", std::string("lego")); fAttr.SetValue("sub", kind); return *this; }
+   RHist2Drawable &Surf(int kind = 0) { fAttr.SetValue("kind", std::string("surf")); fAttr.SetValue("sub", kind); return *this; }
+   RHist2Drawable &Error() { fAttr.SetValue("kind", std::string("err")); fAttr.ClearValue("sub"); return *this; }
+   RHist2Drawable &Contour(int kind = 0) { fAttr.SetValue("kind", std::string("cont")); fAttr.SetValue("sub", kind); return *this; }
+   RHist2Drawable &Text(bool on = true) { fAttr.SetValue("text", on); return *this; }
+
+   const RAttrLine &GetAttrLine() const { return fAttrLine; }
+   RHist2Drawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
+   RAttrLine &AttrLine() { return fAttrLine; }
 };
 
 

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -18,6 +18,7 @@
 
 #include <ROOT/RDrawable.hxx>
 #include <ROOT/RAttrLine.hxx>
+#include <ROOT/RAttrText.hxx>
 #include <ROOT/RHist.hxx>
 #include <ROOT/RHistImpl.hxx>
 #include <ROOT/RMenuItems.hxx>
@@ -101,6 +102,7 @@ class RHist2Drawable final : public RHistDrawable<2> {
 
    RHist2Attrs fAttr{this, ""};           ///<! hist2 direct attributes
    RAttrLine   fAttrLine{this, "line_"};  ///<! line attributes, used for error or some lego plots
+   RAttrText   fAttrText{this, "text_"};  ///<! text attributes, used with Text drawing
 
 public:
    RHist2Drawable() = default;
@@ -119,6 +121,11 @@ public:
    const RAttrLine &GetAttrLine() const { return fAttrLine; }
    RHist2Drawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
    RAttrLine &AttrLine() { return fAttrLine; }
+
+   const RAttrText &GetAttrText() const { return fAttrText; }
+   RHist2Drawable &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
+   RAttrText &AttrText() { return fAttrText; }
+
 };
 
 

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -113,6 +113,7 @@ public:
    RHist2Drawable &Surf(int kind = 0) { fAttr.SetValue("kind", std::string("surf")); fAttr.SetValue("sub", kind); return *this; }
    RHist2Drawable &Error() { fAttr.SetValue("kind", std::string("err")); fAttr.ClearValue("sub"); return *this; }
    RHist2Drawable &Contour(int kind = 0) { fAttr.SetValue("kind", std::string("cont")); fAttr.SetValue("sub", kind); return *this; }
+   RHist2Drawable &Scatter() { fAttr.SetValue("kind", std::string("scat")); fAttr.ClearValue("sub"); return *this; }
    RHist2Drawable &Text(bool on = true) { fAttr.SetValue("text", on); return *this; }
 
    const RAttrLine &GetAttrLine() const { return fAttrLine; }
@@ -122,11 +123,35 @@ public:
 
 
 class RHist3Drawable final : public RHistDrawable<3> {
+   class RHist3Attrs final : public RAttrBase {
+      friend class RHist3Drawable;
+      R__ATTR_CLASS(RHist3Attrs, "", AddString("kind","").AddInt("sub",0));
+   };
+
+   RHist3Attrs fAttr{this, ""};           ///<! hist2 direct attributes
+   RAttrColor fColor{this, "color_"};     ///<! bin color, used which box option
+   RAttrColor fLineColor{this, "line_color_"};     ///<! bin color, used which box option
+
 public:
    RHist3Drawable() = default;
 
    template <class HIST>
    RHist3Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<3>(hist) {}
+
+   RHist3Drawable &Color() { fAttr.SetValue("kind", std::string("col")); fAttr.ClearValue("sub"); return *this; }
+   RHist3Drawable &Box(int kind = 0) { fAttr.SetValue("kind", std::string("box")); fAttr.SetValue("sub", kind); return *this; }
+   RHist3Drawable &Sphere(int kind = 0) { fAttr.SetValue("kind", std::string("sphere")); fAttr.SetValue("sub", kind); return *this; }
+   RHist3Drawable &Scatter() { fAttr.SetValue("kind", std::string("scat")); fAttr.ClearValue("sub"); return *this; }
+
+   /// The color when box option is used
+   RHist3Drawable &SetColor(const RColor &color) { fColor = color; return *this; }
+   RColor GetColor() const { return fColor.GetColor(); }
+   RAttrColor &AttrColor() { return fColor; }
+
+   /// The line color when box option is used
+   RHist3Drawable &SetLineColor(const RColor &color) { fLineColor = color; return *this; }
+   RColor GetLineColor() const { return fLineColor.GetColor(); }
+   RAttrColor &AttrLineColor() { return fLineColor; }
 };
 
 

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -93,12 +93,29 @@ public:
 
 
 class RHist2Drawable final : public RHistDrawable<2> {
+   enum EDrawKind { kColor = 1, kLego = 2 };
+
+   int fDrawKind{kColor};        ///< histogram drawing kind
+
 public:
    RHist2Drawable() = default;
 
    template <class HIST>
    RHist2Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<2>(hist) {}
+
+   RHist2Drawable &Color() { fDrawKind = kColor; return *this; }
+   RHist2Drawable &Lego() { fDrawKind = kLego; return *this; }
 };
+
+
+class RHist3Drawable final : public RHistDrawable<3> {
+public:
+   RHist3Drawable() = default;
+
+   template <class HIST>
+   RHist3Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<3>(hist) {}
+};
+
 
 
 
@@ -129,37 +146,37 @@ inline auto GetDrawable(const std::shared_ptr<RH2D> &histimpl)
 
 inline auto GetDrawable(const std::shared_ptr<RH2I> &histimpl)
 {
-   return std::make_shared<RHistDrawable<2>>(histimpl);
+   return std::make_shared<RHist2Drawable>(histimpl);
 }
 
 inline auto GetDrawable(const std::shared_ptr<RH2C> &histimpl)
 {
-   return std::make_shared<RHistDrawable<2>>(histimpl);
+   return std::make_shared<RHist2Drawable>(histimpl);
 }
 
 inline auto GetDrawable(const std::shared_ptr<RH2F> &histimpl)
 {
-   return std::make_shared<RHistDrawable<2>>(histimpl);
+   return std::make_shared<RHist2Drawable>(histimpl);
 }
 
 inline auto GetDrawable(const std::shared_ptr<RH3D> &histimpl)
 {
-   return std::make_shared<RHistDrawable<3>>(histimpl);
+   return std::make_shared<RHist3Drawable>(histimpl);
 }
 
 inline auto GetDrawable(const std::shared_ptr<RH3I> &histimpl)
 {
-   return std::make_shared<RHistDrawable<3>>(histimpl);
+   return std::make_shared<RHist3Drawable>(histimpl);
 }
 
 inline auto GetDrawable(const std::shared_ptr<RH3C> &histimpl)
 {
-   return std::make_shared<RHistDrawable<3>>(histimpl);
+   return std::make_shared<RHist3Drawable>(histimpl);
 }
 
 inline auto GetDrawable(const std::shared_ptr<RH3F> &histimpl)
 {
-   return std::make_shared<RHistDrawable<3>>(histimpl);
+   return std::make_shared<RHist3Drawable>(histimpl);
 }
 
 } // namespace Experimental

--- a/hist/histv7/inc/LinkDef.h
+++ b/hist/histv7/inc/LinkDef.h
@@ -18,10 +18,13 @@
 #pragma link C++ class ROOT::Experimental::RH1D+;
 #pragma link C++ class ROOT::Experimental::RH2F+;
 #pragma link C++ class ROOT::Experimental::RH2D+;
+#pragma link C++ class ROOT::Experimental::RH3F+;
+#pragma link C++ class ROOT::Experimental::RH3D+;
 // #pragma link C++ class ROOT::Experimental::Detail::RHistImpl<ROOT::Experimental::Detail::RHistData<1,double,vector<double>,ROOT::Experimental::RHistStatContent,ROOT::Experimental::RHistStatUncertainty>,ROOT::Experimental::RAxisEquidistant>+;
 // #pragma link C++ class ROOT::Experimental::Detail::RHistImpl<ROOT::Experimental::Detail::RHistData<2,double,vector<double>, ROOT::Experimental::RHistStatContent, ROOT::Experimental::RHistStatUncertainty>, ROOT::Experimental::RAxisEquidistant, ROOT::Experimental::RAxisIrregular>+;
 #pragma link C++ class ROOT::Experimental::Detail::RHistImplBase<ROOT::Experimental::Detail::RHistData<1,double,vector<double>,ROOT::Experimental::RHistStatContent,ROOT::Experimental::RHistStatUncertainty>>+;
 #pragma link C++ class ROOT::Experimental::Detail::RHistImplBase<ROOT::Experimental::Detail::RHistData<2,double,vector<double>,ROOT::Experimental::RHistStatContent,ROOT::Experimental::RHistStatUncertainty>>+;
+#pragma link C++ class ROOT::Experimental::Detail::RHistImplBase<ROOT::Experimental::Detail::RHistData<3,double,vector<double>,ROOT::Experimental::RHistStatContent,ROOT::Experimental::RHistStatUncertainty>>+;
 #pragma link C++ class ROOT::Experimental::Detail::RHistImplPrecisionAgnosticBase<1>+;
 #pragma link C++ class ROOT::Experimental::Detail::RHistImplPrecisionAgnosticBase<2>+;
 #pragma link C++ class ROOT::Experimental::Detail::RHistImplPrecisionAgnosticBase<3>+;
@@ -33,6 +36,7 @@
 #pragma link C++ class ROOT::Experimental::RHistStatUncertainty<3,double>+;
 #pragma link C++ class ROOT::Experimental::Detail::RHistData<1,double,vector<double>,ROOT::Experimental::RHistStatContent,ROOT::Experimental::RHistStatUncertainty>+;
 #pragma link C++ class ROOT::Experimental::Detail::RHistData<2,double,vector<double>,ROOT::Experimental::RHistStatContent,ROOT::Experimental::RHistStatUncertainty>+;
+#pragma link C++ class ROOT::Experimental::Detail::RHistData<3,double,vector<double>,ROOT::Experimental::RHistStatContent,ROOT::Experimental::RHistStatUncertainty>+;
 #pragma link C++ class ROOT::Experimental::RAxisBase+;
 #pragma link C++ class ROOT::Experimental::RAxisEquidistant+;
 #pragma link C++ class ROOT::Experimental::RAxisIrregular+;
@@ -42,5 +46,12 @@
 #pragma link C++ class tuple<ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisEquidistant>+;
 #pragma link C++ class tuple<ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisEquidistant>+;
 #pragma link C++ class tuple<ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisIrregular>+;
-
+#pragma link C++ class tuple<ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisEquidistant>+;
+#pragma link C++ class tuple<ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisIrregular>+;
+#pragma link C++ class tuple<ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisEquidistant>+;
+#pragma link C++ class tuple<ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisIrregular>+;
+#pragma link C++ class tuple<ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisEquidistant>+;
+#pragma link C++ class tuple<ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisIrregular>+;
+#pragma link C++ class tuple<ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisEquidistant>+;
+#pragma link C++ class tuple<ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisIrregular>+;
 #endif

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 22/06/2020";
+   JSROOT.version = "dev 23/06/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 19/06/2020";
+   JSROOT.version = "dev 22/06/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
@@ -1090,11 +1090,12 @@
     *    - 'tree'   TTree support
     *    - '2d'     basic 2d graphic (TCanvas/TPad/TFrame)
     *    - '3d'     basic 3d graphic (three.js)
-    *    - 'hist'   histograms 2d graphic
-    *    - 'hist3d' histograms 3d graphic
+    *    - 'hist'   histograms 2d drawing (SVG)
+    *    - 'hist3d' histograms 3d drawing (WebGL)
     *    - 'more2d' extra 2d graphic (TGraph, TF1)
     *    - 'v7'     ROOT v7 graphics
-    *    - 'v7hist' ROOT v7 histograms
+    *    - 'v7hist' ROOT v7 histograms 2d drawing (SVG)
+    *    - 'v7hist3d' v7 histograms 3d drawing (WebGL)
     *    - 'v7more' ROOT v7 special classes
     *    - 'math'   some methods from TMath class
     *    - 'jq'     jQuery and jQuery-ui
@@ -1199,11 +1200,6 @@
 
       if (kind.indexOf('jq;')>=0) need_jquery = true;
 
-      if (((kind.indexOf('hist;')>=0) || (kind.indexOf('hist3d;')>=0)) && (jsroot.sources.indexOf("hist")<0)) {
-         mainfiles += '$$$scripts/JSRootPainter.hist' + ext + ".js;";
-         modules.push('JSRootPainter.hist');
-      }
-
       if ((kind.indexOf('v6;')>=0) && (jsroot.sources.indexOf("v6")<0)) {
          mainfiles += '$$$scripts/JSRootPainter.v6' + ext + ".js;";
          modules.push('JSRootPainter.v6');
@@ -1214,9 +1210,14 @@
          modules.push('JSRootPainter.v7');
       }
 
-      if ((kind.indexOf('v7hist;')>=0) && (jsroot.sources.indexOf("v7hist")<0)) {
-         mainfiles += '$$$scripts/JSRootPainter.v7hist' + ext + ".js;";
-         modules.push('JSRootPainter.v7hist');
+      if ((kind.indexOf('v7hist;')>=0) || (kind.indexOf('v7hist3d;')>=0)) {
+         if(jsroot.sources.indexOf("v7hist") < 0) {
+            mainfiles += '$$$scripts/JSRootPainter.v7hist' + ext + ".js;";
+            modules.push('JSRootPainter.v7hist');
+         }
+      } else if (((kind.indexOf('hist;')>=0) || (kind.indexOf('hist3d;')>=0)) && (jsroot.sources.indexOf("hist")<0)) {
+         mainfiles += '$$$scripts/JSRootPainter.hist' + ext + ".js;";
+         modules.push('JSRootPainter.hist');
       }
 
       if ((kind.indexOf('v7more;')>=0) && (jsroot.sources.indexOf("v7more")<0)) {
@@ -1254,7 +1255,12 @@
          modules.push('JSRoot3DPainter');
       }
 
-      if ((kind.indexOf('hist3d;')>=0) && (jsroot.sources.indexOf("hist3d")<0)) {
+      if (kind.indexOf('v7hist3d;')>=0) {
+         if ((jsroot.sources.indexOf("v7hist3d")<0)) {
+            mainfiles += '$$$scripts/JSRootPainter.v7hist3d' + ext + ".js;";
+            modules.push('JSRootPainter.v7hist3d');
+         }
+      } else if ((kind.indexOf('hist3d;')>=0) && (jsroot.sources.indexOf("hist3d")<0)) {
          mainfiles += '$$$scripts/JSRootPainter.hist3d' + ext + ".js;";
          modules.push('JSRootPainter.hist3d');
       }

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -1084,7 +1084,7 @@
 
    /** @summary Load JSROOT functionality.
     *
-    * @desc As first argument, required components should be specifed:
+    * @desc As first argument, required components should be specified:
     *
     *    - 'io'     TFile functionality
     *    - 'tree'   TTree support
@@ -1106,7 +1106,7 @@
     *    - 'simple'  for basic user interface
     *    - 'load:<path/script.js>' list of user-specific scripts at the end of kind string
     *
-    * One could combine several compopnents, separating them by semicolon.
+    * One could combine several components, separating them by semicolon.
     * Depending of available components, either require.js or plain script loading will be used
     *
     * @param {string} kind - modules to load
@@ -1192,7 +1192,7 @@
             mainfiles += '$$$scripts/JSRootPainter' + ext + ".js;";
             extrafiles += '$$$style/JSRootPainter' + ext + '.css;';
          }
-         if ((jsroot.sources.indexOf("v6") < 0) && (kind.indexOf('v7;') < 0)) {
+         if ((jsroot.sources.indexOf("v6") < 0) && (kind.indexOf('v7') < 0)) {
             mainfiles += '$$$scripts/JSRootPainter.v6' + ext + ".js;";
             modules.push('JSRootPainter.v6');
          }

--- a/js/scripts/JSRootPainter.hist.js
+++ b/js/scripts/JSRootPainter.hist.js
@@ -6540,7 +6540,7 @@
 
          // if there is auto colors assignment, try to provide it
          if (this.options._pfc || this.options._plc || this.options._pmc) {
-            if (!this.pallette && JSROOT.Painter.GetColorPalette)
+            if (!this.palette && JSROOT.Painter.GetColorPalette)
                this.palette = JSROOT.Painter.GetColorPalette();
             if (this.palette) {
                var color = this.palette.calcColor(rindx, nhists+1);

--- a/js/scripts/JSRootPainter.hist3d.js
+++ b/js/scripts/JSRootPainter.hist3d.js
@@ -2118,7 +2118,7 @@
           tip.x1 = Math.max(-main.size_xy3d, main.grx(histo.fXaxis.GetBinLowEdge(tip.ix)));
           tip.x2 = Math.min(main.size_xy3d, main.grx(histo.fXaxis.GetBinLowEdge(tip.ix+1)));
           tip.y1 = Math.max(-main.size_xy3d, main.gry(histo.fYaxis.GetBinLowEdge(tip.iy)));
-          tip.y2 = Math.min(main.size_xy3d, main.gry(histo.fXaxis.GetBinLowEdge(tip.iy+1)));
+          tip.y2 = Math.min(main.size_xy3d, main.gry(histo.fYaxis.GetBinLowEdge(tip.iy+1)));
 
           tip.z1 = main.grz(tip.value-tip.error < this.zmin ? this.zmin : tip.value-tip.error);
           tip.z2 = main.grz(tip.value+tip.error > this.zmax ? this.zmax : tip.value+tip.error);

--- a/js/scripts/JSRootPainter.hist3d.js
+++ b/js/scripts/JSRootPainter.hist3d.js
@@ -28,7 +28,7 @@
    if (typeof JSROOT.THistPainter === 'undefined')
       throw new Error('JSROOT.THistPainter is not defined', 'JSRootPainter.hist3d.js');
 
-   JSROOT.TFramePainter.prototype.SetCameraPosition = function(pad, first_time) {
+   JSROOT.TFramePainter.prototype.SetCameraPosition = function(first_time, pad) {
       var max3d = Math.max(0.75*this.size_xy3d, this.size_z3d);
 
       if (first_time)
@@ -108,7 +108,7 @@
 
          this.Resize3D(); // set actual sizes
 
-         this.SetCameraPosition(this.root_pad(), false);
+         this.SetCameraPosition(false, this.root_pad());
 
          return;
       }
@@ -142,7 +142,7 @@
       this.camera.up = new THREE.Vector3(0,0,1);
       this.scene.add( this.camera );
 
-      this.SetCameraPosition(this.root_pad(), true);
+      this.SetCameraPosition(true, this.root_pad());
 
       var res = JSROOT.Painter.Create3DRenderer(this.scene_width, this.scene_height, this.usesvg, (sz.can3d == 4));
 
@@ -1299,7 +1299,7 @@
 
          mesh.tooltip = function(intersect) {
             if (isNaN(intersect.faceIndex)) {
-               console.error('faceIndex not provided, check three.js version', THREE.REVISION, 'expected r97');
+               console.error('faceIndex not provided, check three.js version', THREE.REVISION, 'expected r102');
                return null;
             }
 
@@ -2104,7 +2104,7 @@
 
        line.tooltip = function(intersect) {
           if (isNaN(intersect.index)) {
-             console.error('segment index not provided, check three.js version', THREE.REVISION, 'expected r97');
+             console.error('segment index not provided, check three.js version', THREE.REVISION, 'expected r102');
              return null;
           }
 
@@ -2589,7 +2589,7 @@
 
       mesh.tooltip = function(intersect) {
          if (isNaN(intersect.index)) {
-            console.error('intersect.index not provided, check three.js version', THREE.REVISION, 'expected r97');
+            console.error('intersect.index not provided, check three.js version', THREE.REVISION, 'expected r102');
             return null;
          }
 
@@ -2884,7 +2884,7 @@
 
          combined_bins.tooltip = function(intersect) {
             if (isNaN(intersect.faceIndex)) {
-               console.error('intersect.faceIndex not provided, check three.js version', THREE.REVISION, 'expected r97');
+               console.error('intersect.faceIndex not provided, check three.js version', THREE.REVISION, 'expected r102');
                return null;
             }
             var indx = Math.floor(intersect.faceIndex / this.bins_faces);
@@ -3153,7 +3153,7 @@
 
    TGraph2DPainter.prototype.Graph2DTooltip = function(intersect) {
       if (isNaN(intersect.index)) {
-         console.error('intersect.index not provided, check three.js version', THREE.REVISION, 'expected r97');
+         console.error('intersect.index not provided, check three.js version', THREE.REVISION, 'expected r102');
          return null;
       }
 
@@ -3509,7 +3509,7 @@
 
             mesh.tooltip = function(intersect) {
                if (isNaN(intersect.index)) {
-                  console.error('intersect.index not provided, check three.js version', THREE.REVISION, 'expected r97');
+                  console.error('intersect.index not provided, check three.js version', THREE.REVISION, 'expected r102');
                   return null;
                }
                var indx = Math.floor(intersect.index / this.nvertex);

--- a/js/scripts/JSRootPainter.more.js
+++ b/js/scripts/JSRootPainter.more.js
@@ -3309,7 +3309,7 @@
 
       // if there is auto colors assignment, try to provide it
       if (this._pfc || this._plc || this._pmc) {
-         if (!this.pallette && JSROOT.Painter.GetColorPalette)
+         if (!this.palette && JSROOT.Painter.GetColorPalette)
             this.palette = JSROOT.Painter.GetColorPalette();
          if (this.palette) {
             var color = this.palette.calcColor(indx, graphs.arr.length+1);

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -5241,6 +5241,7 @@
 
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RHist1Drawable", icon: "img_histo1d", prereq: "v7hist", func: "JSROOT.v7.drawHist1", opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RHist2Drawable", icon: "img_histo2d", prereq: "v7hist", func: "JSROOT.v7.drawHist2", opt: "" });
+   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RHist3Drawable", icon: "img_histo3d", prereq: "v7hist3d", func: "JSROOT.v7.drawHist3", opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RText", icon: "img_text", prereq: "v7more", func: "JSROOT.v7.drawText", opt: "", direct: true, csstype: "text" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RFrameTitle", icon: "img_text", func: drawFrameTitle, opt: "", direct: true, csstype: "title" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RPaletteDrawable", icon: "img_text", func: drawPalette, opt: "" });

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -23,7 +23,7 @@
 
    JSROOT.v7 = {}; // placeholder for v7-relevant code
 
-   /** Evalue attributes using fAttr storage and configured RStyle */
+   /** Evaluate attributes using fAttr storage and configured RStyle */
    JSROOT.TObjectPainter.prototype.v7EvalAttr = function(name, dflt) {
       var obj = this.GetObject();
       if (!obj) return dflt;
@@ -120,7 +120,7 @@
       return Math.round(norm*sizepx + px);
    }
 
-   /** Evalue RColor using attribute storage and configured RStyle */
+   /** Evaluate RColor using attribute storage and configured RStyle */
    JSROOT.TObjectPainter.prototype.v7EvalColor = function(name, dflt) {
       var rgb = this.v7EvalAttr(name + "_rgb", "");
 

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -4933,7 +4933,7 @@
             return l;
          }
 
-         // last color in pallette starts from level cntr[r-1]
+         // last color in palette starts from level cntr[r-1]
          return Math.floor((zc-cntr[0]) / (cntr[r-1] - cntr[0]) * (r-1));
       },
 

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -3378,7 +3378,7 @@
 
    RH2Painter.prototype.Draw3D = function(call_back, reason) {
       this.mode3d = true;
-      JSROOT.AssertPrerequisites('hist3d', function() {
+      JSROOT.AssertPrerequisites('v7hist3d', function() {
          this.Draw3D(call_back, reason);
       }.bind(this));
    }
@@ -3387,9 +3387,9 @@
 
       var main = this.frame_painter();
 
-      if (this.options.Mode3D !== main.mode3d) {
-         this.options.Mode3D = main.mode3d;
-      }
+      //if (this.options.Mode3D !== main.mode3d) {
+      //   this.options.Mode3D = main.mode3d;
+      //}
 
       var funcname = this.options.Mode3D ? "Draw3D" : "Draw2D";
 
@@ -3410,20 +3410,25 @@
                           Line: false, Fill: false, Lego: 0, Surf: 0,
                           Text: true, TextAngle: 0, TextKind: "",
                           fBarOffset: 0, fBarWidth: 1000, BaseLine: false, Mode3D: false, AutoColor: 0,
-                          Color: false, Scat: false, ScatCoef: 1, Candle: "", Box: false, BoxStyle: 0, Arrow: false, Contour: 0, Proj: 0 };
+                          Color: false, Scat: false, ScatCoef: 1, Candle: "", Box: false, BoxStyle: 0, Arrow: false, Contour: 0, Proj: 0,
+                          minimum: -1111, maximum: -1111 };
 
-      // FIXME: options are changed now in ROOT7 part, need to adjust here;
-      //if (obj.fOpts.fStyle.fIdx == 1) painter.options.Box = true;
-      //                           else painter.options.Color = true;
-      painter.options.Color = true;
+      var EDrawKind = { kColor: 1, kLego: 2 };
+
+      if (obj.fDrawKind == EDrawKind.kLego) {
+         painter.options.Lego = 12; // force for the moment
+         painter.options.Mode3D = true; // enable 3D
+      } else {
+         painter.options.Color = true;
+      }
 
       // here we deciding how histogram will look like and how will be shown
-      painter.DecodeOptions(opt);
+      // painter.DecodeOptions(opt);
 
-      if (painter.IsTH2Poly()) {
-         if (painter.options.Mode3D) painter.options.Lego = 12; // lego always 12
-         else if (!painter.options.Color) painter.options.Color = true; // default is color
-      }
+      //if (painter.IsTH2Poly()) {
+      //   if (painter.options.Mode3D) painter.options.Lego = 12; // lego always 12
+      //   else if (!painter.options.Color) painter.options.Color = true; // default is color
+      //}
 
       painter._show_empty_bins = false;
 

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -1059,7 +1059,7 @@
 
       if (show_markers) {
          // draw markers also when e2 option was specified
-         this.createAttMarker({ attr: histo, style: this.options.MarkStyle });
+         this.createv7AttMarker();
          if (this.markeratt.size > 0) {
             // simply use relative move from point, can optimize in the future
             path_marker = "";
@@ -1070,12 +1070,9 @@
       }
 
       if (show_text) {
-         text_col = this.get_color(histo.fMarkerColor);
-         text_angle = -1*options.TextAngle;
-         text_size = 20;
-
-         if ((options.fMarkerSize!==1) && text_angle)
-            text_size = 0.02 * height * options.fMarkerSize;
+         text_col = this.v7EvalColor("text_color", "black");
+         text_angle = -1*this.v7EvalAttr("text_angle", 0);
+         text_size = this.v7EvalAttr("text_size", 20);
 
          if (!text_angle && !options.TextKind) {
              var space = width / (right - left + 1);
@@ -1659,7 +1656,7 @@
       painter.options = { Hist: true, Bar: false, Error: false, ErrorKind: -1, errorX: 0, Zero: false, Mark: false,
                           Line: false, Fill: false, Lego: 0, Surf: 0,
                           Text: false, TextAngle: 0, TextKind: "", AutoColor: 0,
-                          fBarOffset: 0, fBarWidth: 1000, fMarkerSize: 1, BaseLine: false, Mode3D: false };
+                          fBarOffset: 0, fBarWidth: 1000, BaseLine: false, Mode3D: false };
 
       // here we deciding how histogram will look like and how will be shown
       // painter.DecodeOptions(opt);
@@ -2500,13 +2497,10 @@
          }
 
       if (textbins.length > 0) {
-         var text_col = this.get_color(histo.fMarkerColor),
-             text_angle = -1*this.options.TextAngle,
-             text_g = this.draw_g.append("svg:g").attr("class","th2poly_text"),
-             text_size = 12;
-
-         if ((histo.fMarkerSize!==1) && text_angle)
-             text_size = Math.round(0.02*h*histo.fMarkerSize);
+         var text_col = this.v7EvalColor("text_color", "black"),
+             text_angle = -1*this.v7EvalAttr("text_angle", 0),
+             text_size = this.v7EvalAttr("text_size", 12),
+             text_g = this.draw_g.append("svg:g").attr("class","th2poly_text");
 
          this.StartTextDrawing(42, text_size, text_g, text_size);
 
@@ -2539,15 +2533,13 @@
 
       if (handle===null) handle = this.PrepareColorDraw({ rounding: false });
 
-      var text_col = this.get_color(histo.fMarkerColor),
-          text_angle = -1*this.options.TextAngle,
+      var text_col = this.v7EvalColor("text_color", "black"),
+          text_angle = -1*this.v7EvalAttr("text_angle", 0),
+          text_size = this.v7EvalAttr("text_size", 20),
+          text_offset = 0,
           text_g = this.draw_g.append("svg:g").attr("class","th2_text"),
-          text_size = 20, text_offset = 0,
           profile2d = (this.options.TextKind == "E") &&
                       this.MatchObjectType('TProfile2D') && (typeof histo.getBinEntries=='function');
-
-      if ((histo.fMarkerSize!==1) && text_angle)
-         text_size = Math.round(0.02*h*histo.fMarkerSize);
 
       if (this.options.fBarOffset!==0) text_offset = this.options.fBarOffset*1e-3;
 
@@ -2567,7 +2559,7 @@
             lbl = (binz === Math.round(binz)) ? binz.toString() :
                       JSROOT.FFormat(binz, JSROOT.gStyle.fPaintTextFormat);
 
-            if (text_angle /*|| (histo.fMarkerSize!==1)*/) {
+            if (text_angle) {
                posx = Math.round(handle.grx[i] + binw*0.5);
                posy = Math.round(handle.gry[j+1] + binh*(0.5 + text_offset));
                sizex = 0;
@@ -2775,8 +2767,7 @@
           bars = "", markers = "", posy;
 
       // create attribute only when necessary
-      if (histo.fMarkerColor === 1) histo.fMarkerColor = histo.fLineColor;
-      this.createAttMarker({ attr: histo, style: 5 });
+      this.createv7AttMarker();
 
       // reset absolution position for markers
       this.markeratt.reset_pos();
@@ -2890,7 +2881,7 @@
       if (scale*handle.sumz < 1e5) {
          // one can use direct drawing of scatter plot without any patterns
 
-         this.createAttMarker({ attr: histo });
+         this.createv7AttMarker();
 
          this.markeratt.reset_pos();
 
@@ -2902,9 +2893,9 @@
                binz = histo.getBinContent(i + 1, j + 1);
 
                npix = Math.round(scale*binz);
-               if (npix<=0) continue;
+               if (npix <= 0) continue;
 
-               for (k=0;k<npix;++k)
+               for (k = 0; k < npix; ++k)
                   path += this.markeratt.create(
                             Math.round(handle.grx[i] + cw * JSROOT.random()),
                             Math.round(handle.gry[j+1] + ch * JSROOT.random()));
@@ -2961,7 +2952,7 @@
       if (defs.empty() && (colPaths.length>0))
          defs = layer.insert("svg:defs",":first-child");
 
-      this.createAttMarker({ attr: histo });
+      this.createv7AttMarker();
 
       var cntr = handle.palette.GetCountour();
 
@@ -3452,6 +3443,7 @@
          case "surf": o.Surf = sub > 0 ? 10+sub : 1; o.Mode3D = true; break;
          case "err": o.Error = true; o.Mode3D = true; break;
          case "cont": o.Contour = sub > 0 ? 10+sub : 1; break;
+         case "scat": o.Scat = true; break;
          default: o.Color = true;
       }
 

--- a/js/scripts/JSRootPainter.v7hist3d.js
+++ b/js/scripts/JSRootPainter.v7hist3d.js
@@ -2133,10 +2133,10 @@
               main = p.frame_painter(),
               tip = p.Get3DToolTip(this.intersect_index[pos]);
 
-          tip.x1 = Math.max(-main.size_xy3d, main.grx(histo.fXaxis.GetBinLowEdge(tip.ix)));
-          tip.x2 = Math.min(main.size_xy3d, main.grx(histo.fXaxis.GetBinLowEdge(tip.ix+1)));
-          tip.y1 = Math.max(-main.size_xy3d, main.gry(histo.fYaxis.GetBinLowEdge(tip.iy)));
-          tip.y2 = Math.min(main.size_xy3d, main.gry(histo.fXaxis.GetBinLowEdge(tip.iy+1)));
+          tip.x1 = Math.max(-main.size_xy3d, main.grx(p.GetAxis("x").GetBinLowEdge(tip.ix)));
+          tip.x2 = Math.min(main.size_xy3d, main.grx(p.GetAxis("x").GetBinLowEdge(tip.ix+1)));
+          tip.y1 = Math.max(-main.size_xy3d, main.gry(p.GetAxis("y").GetBinLowEdge(tip.iy)));
+          tip.y2 = Math.min(main.size_xy3d, main.gry(p.GetAxis("y").GetBinLowEdge(tip.iy+1)));
 
           tip.z1 = main.grz(tip.value-tip.error < this.zmin ? this.zmin : tip.value-tip.error);
           tip.z2 = main.grz(tip.value+tip.error > this.zmax ? this.zmax : tip.value+tip.error);
@@ -2355,25 +2355,21 @@
 
    RH3Painter.prototype = Object.create(JSROOT.v7.RHistPainter.prototype);
 
+   RH3Painter.prototype.Dimension = function() {
+      return 3;
+   }
+
    RH3Painter.prototype.ScanContent = function(when_axis_changed) {
 
       // no need to rescan histogram while result does not depend from axis selection
       if (when_axis_changed && this.nbinsx && this.nbinsy && this.nbinsz) return;
 
-      var histo = this.GetObject();
+      var histo = this.GetHisto();
+      if (!histo) return;
 
-      this.nbinsx = histo.fXaxis.fNbins;
-      this.nbinsy = histo.fYaxis.fNbins;
-      this.nbinsz = histo.fZaxis.fNbins;
-
-      this.xmin = histo.fXaxis.fXmin;
-      this.xmax = histo.fXaxis.fXmax;
-
-      this.ymin = histo.fYaxis.fXmin;
-      this.ymax = histo.fYaxis.fXmax;
-
-      this.zmin = histo.fZaxis.fXmin;
-      this.zmax = histo.fZaxis.fXmax;
+      this.nbinsx = this.GetAxis("x").GetNumBins();
+      this.nbinsy = this.GetAxis("y").GetNumBins();
+      this.nbinsz = this.GetAxis("z").GetNumBins();
 
       // global min/max, used at the moment in 3D drawing
 
@@ -2393,7 +2389,10 @@
    }
 
    RH3Painter.prototype.CountStat = function() {
-      var histo = this.GetHisto(), xaxis = histo.fXaxis, yaxis = histo.fYaxis, zaxis = histo.fZaxis,
+      var histo = this.GetHisto(),
+          xaxis = this.GetAxis("x"),
+          yaxis = this.GetAxis("y"),
+          zaxis = this.GetAxis("z"),
           stat_sum0 = 0, stat_sumx1 = 0, stat_sumy1 = 0,
           stat_sumz1 = 0, stat_sumx2 = 0, stat_sumy2 = 0, stat_sumz2 = 0,
           i1 = this.GetSelectIndex("x", "left"),
@@ -2509,24 +2508,25 @@
    }
 
    RH3Painter.prototype.GetBinTips = function (ix, iy, iz) {
-      var lines = [], pmain = this.frame_painter(), histo = this.GetHisto();
+      var lines = [], pmain = this.frame_painter(), histo = this.GetHisto(),
+          xaxis = this.GetAxis("x"), yaxis = this.GetAxis("y"), zaxis = this.GetAxis("z");
 
       lines.push(this.GetTipName());
 
       if (pmain.x_kind == 'labels')
-         lines.push("x = " + pmain.AxisAsText("x", histo.fXaxis.GetBinLowEdge(ix+1)) + "  xbin=" + (ix+1));
+         lines.push("x = " + pmain.AxisAsText("x", xaxis.GetBinLowEdge(ix+1)) + "  xbin=" + (ix+1));
       else
-         lines.push("x = [" + pmain.AxisAsText("x", histo.fXaxis.GetBinLowEdge(ix+1)) + ", " + pmain.AxisAsText("x", histo.fXaxis.GetBinLowEdge(ix+2)) + ")   xbin=" + (ix+1));
+         lines.push("x = [" + pmain.AxisAsText("x", xaxis.GetBinLowEdge(ix+1)) + ", " + pmain.AxisAsText("x", xaxis.GetBinLowEdge(ix+2)) + ")   xbin=" + (ix+1));
 
       if (pmain.y_kind == 'labels')
-         lines.push("y = " + pmain.AxisAsText("y", histo.fYaxis.GetBinLowEdge(iy+1))  + "  ybin=" + (iy+1));
+         lines.push("y = " + pmain.AxisAsText("y", yaxis.GetBinLowEdge(iy+1))  + "  ybin=" + (iy+1));
       else
-         lines.push("y = [" + pmain.AxisAsText("y", histo.fYaxis.GetBinLowEdge(iy+1)) + ", " + pmain.AxisAsText("y", histo.fYaxis.GetBinLowEdge(iy+2)) + ")  ybin=" + (iy+1));
+         lines.push("y = [" + pmain.AxisAsText("y", yaxis.GetBinLowEdge(iy+1)) + ", " + pmain.AxisAsText("y", yaxis.GetBinLowEdge(iy+2)) + ")  ybin=" + (iy+1));
 
       if (pmain.z_kind == 'labels')
-         lines.push("z = " + pmain.AxisAsText("z", histo.fZaxis.GetBinLowEdge(iz+1))  + "  zbin=" + (iz+1));
+         lines.push("z = " + pmain.AxisAsText("z", zaxis.GetBinLowEdge(iz+1))  + "  zbin=" + (iz+1));
       else
-         lines.push("z = [" + pmain.AxisAsText("z", histo.fZaxis.GetBinLowEdge(iz+1)) + ", " + pmain.AxisAsText("z", histo.fZaxis.GetBinLowEdge(iz+2)) + ")  zbin=" + (iz+1));
+         lines.push("z = [" + pmain.AxisAsText("z", zaxis.GetBinLowEdge(iz+1)) + ", " + pmain.AxisAsText("z", zaxis.GetBinLowEdge(iz+2)) + ")  zbin=" + (iz+1));
 
       var binz = histo.getBinContent(ix+1, iy+1, iz+1);
       if (binz === Math.round(binz))
@@ -2541,7 +2541,7 @@
       // try to draw 3D histogram as scatter plot
       // if too many points, box will be displayed
 
-      var histo = this.GetObject(),
+      var histo = this.GetHisto(),
           main = this.frame_painter(),
           i1 = this.GetSelectIndex("x", "left", 0.5),
           i2 = this.GetSelectIndex("x", "right", 0),
@@ -2575,7 +2575,8 @@
       JSROOT.seed(sumz);
 
       var pnts = new JSROOT.Painter.PointsCreator(numpixels, main.webgl, main.size_xy3d/200),
-          bins = new Int32Array(numpixels), nbin = 0;
+          bins = new Int32Array(numpixels), nbin = 0,
+          xaxis = this.GetAxis("x"), yaxis = this.GetAxis("y"), zaxis = this.GetAxis("z");
 
       for (i = i1; i < i2; ++i) {
          for (j = j1; j < j2; ++j) {
@@ -2585,9 +2586,9 @@
                var num = Math.round(bin_content*coef);
 
                for (var n=0;n<num;++n) {
-                  var binx = histo.fXaxis.GetBinCoord(i+JSROOT.random()),
-                      biny = histo.fYaxis.GetBinCoord(j+JSROOT.random()),
-                      binz = histo.fZaxis.GetBinCoord(k+JSROOT.random());
+                  var binx = xaxis.GetBinCoord(i+JSROOT.random()),
+                      biny = yaxis.GetBinCoord(j+JSROOT.random()),
+                      binz = zaxis.GetBinCoord(k+JSROOT.random());
 
                   // remember bin index for tooltip
                   bins[nbin++] = histo.getBin(i+1, j+1, k+1);
@@ -2598,12 +2599,13 @@
          }
       }
 
-      var mesh = pnts.CreatePoints(this.get_color(histo.fMarkerColor));
+      var color = this.v7EvalColor("color", "red");
+      var mesh = pnts.CreatePoints(color);
       main.toplevel.add(mesh);
 
       mesh.bins = bins;
       mesh.painter = this;
-      mesh.tip_color = (histo.fMarkerColor===3) ? 0xFF0000 : 0x00FF00;
+      mesh.tip_color = 0x00FF00;
 
       mesh.tooltip = function(intersect) {
          if (isNaN(intersect.index)) {
@@ -2614,16 +2616,16 @@
          var indx = Math.floor(intersect.index / this.nvertex);
          if ((indx<0) || (indx >= this.bins.length)) return null;
 
-         var p = this.painter, histo = p.GetHisto(),
+         var p = this.painter,
              main = p.frame_painter(),
              tip = p.Get3DToolTip(this.bins[indx]);
 
-         tip.x1 = main.grx(histo.fXaxis.GetBinLowEdge(tip.ix));
-         tip.x2 = main.grx(histo.fXaxis.GetBinLowEdge(tip.ix+1));
-         tip.y1 = main.gry(histo.fYaxis.GetBinLowEdge(tip.iy));
-         tip.y2 = main.gry(histo.fYaxis.GetBinLowEdge(tip.iy+1));
-         tip.z1 = main.grz(histo.fZaxis.GetBinLowEdge(tip.iz));
-         tip.z2 = main.grz(histo.fZaxis.GetBinLowEdge(tip.iz+1));
+         tip.x1 = main.grx(p.GetAxis("x").GetBinLowEdge(tip.ix));
+         tip.x2 = main.grx(p.GetAxis("x").GetBinLowEdge(tip.ix+1));
+         tip.y1 = main.gry(p.GetAxis("y").GetBinLowEdge(tip.iy));
+         tip.y2 = main.gry(p.GetAxis("y").GetBinLowEdge(tip.iy+1));
+         tip.z1 = main.grz(p.GetAxis("z").GetBinLowEdge(tip.iz));
+         tip.z2 = main.grz(p.GetAxis("z").GetBinLowEdge(tip.iz+1));
          tip.color = this.tip_color;
          tip.opacity = 0.3;
 
@@ -2637,25 +2639,22 @@
 
       if (!this.draw_content) return;
 
-      if (!this.options.Box && !this.options.GLBox && !this.options.GLColor && !this.options.Lego)
+      if (this.options.Scatter)
          if (this.Draw3DScatter()) return;
 
-      var rootcolor = 5/*this.GetObject().fFillColor*/,
-          fillcolor = this.get_color(rootcolor),
+      var fillcolor = this.v7EvalColor("color", "red"),
           main = this.frame_painter(),
           buffer_size = 0, use_lambert = false,
           use_helper = false, use_colors = false, use_opacity = 1, use_scale = true,
           single_bin_verts, single_bin_norms,
-          box_option = this.options.Box ? this.options.BoxStyle : 0,
           tipscale = 0.5;
 
-      if (!box_option && this.options.Lego) box_option = (this.options.Lego===1) ? 10 : this.options.Lego;
+      if (this.options.Sphere) {
 
-      if ((this.options.GLBox === 11) || (this.options.GLBox === 12)) {
-
+         // drawing spheres
          tipscale = 0.4;
          use_lambert = true;
-         if (this.options.GLBox === 12) use_colors = true;
+         if (this.options.Sphere === 11) use_colors = true;
 
          var geom = JSROOT.Painter.TestWebGL() ? new THREE.SphereGeometry(0.5, 16, 12) : new THREE.SphereGeometry(0.5, 8, 6);
          geom.applyMatrix( new THREE.Matrix4().makeRotationX( Math.PI / 2 ) );
@@ -2712,9 +2711,9 @@
          }
          use_helper = true;
 
-         if (box_option===12) { use_colors = true; } else
-         if (box_option===13) { use_colors = true; use_helper = false; }  else
-         if (this.options.GLColor) { use_colors = true; use_opacity = 0.5; use_scale = false; use_helper = false; use_lambert = true; }
+         if (this.options.Box == 11) { use_colors = true; } else
+         if (this.options.Box == 12) { use_colors = true; use_helper = false; }  else
+         if (this.options.Color) { use_colors = true; use_opacity = 0.5; use_scale = false; use_helper = false; use_lambert = true; }
       }
 
       if (use_scale)
@@ -2727,13 +2726,20 @@
           j2 = this.GetSelectIndex("y", "right", 0),
           k1 = this.GetSelectIndex("z", "left", 0.5),
           k2 = this.GetSelectIndex("z", "right", 0),
-          name = this.GetTipName("<br/>");
+          name = this.GetTipName("<br/>"),
+          palette = null;
+
+      if (use_colors) {
+         palette = main.GetPalette();
+         this.CreateContour(main, palette);
+      }
 
       if ((i2<=i1) || (j2<=j1) || (k2<=k1)) return;
 
-      var scalex = (main.grx(histo.fXaxis.GetBinLowEdge(i2+1)) - main.grx(histo.fXaxis.GetBinLowEdge(i1+1))) / (i2-i1),
-          scaley = (main.gry(histo.fYaxis.GetBinLowEdge(j2+1)) - main.gry(histo.fYaxis.GetBinLowEdge(j1+1))) / (j2-j1),
-          scalez = (main.grz(histo.fZaxis.GetBinLowEdge(k2+1)) - main.grz(histo.fZaxis.GetBinLowEdge(k1+1))) / (k2-k1);
+      var xaxis = this.GetAxis("x"), yaxis = this.GetAxis("y"), zaxis = this.GetAxis("z"),
+          scalex = (main.grx(xaxis.GetBinLowEdge(i2+1)) - main.grx(xaxis.GetBinLowEdge(i1+1))) / (i2-i1),
+          scaley = (main.gry(yaxis.GetBinLowEdge(j2+1)) - main.gry(yaxis.GetBinLowEdge(j1+1))) / (j2-j1),
+          scalez = (main.grz(zaxis.GetBinLowEdge(k2+1)) - main.grz(zaxis.GetBinLowEdge(k1+1))) / (k2-k1);
 
       var nbins = 0, i, j, k, wei, bin_content, cols_size = [], num_colors = 0, cols_sequence = [];
 
@@ -2749,8 +2755,8 @@
 
                if (!use_colors) continue;
 
-               var colindx = this.getContourColor(bin_content, true);
-               if (colindx !== null) {
+               var colindx = palette.getContourIndex(bin_content);
+               if (colindx >= 0) {
                   if (cols_size[colindx] === undefined) {
                      cols_size[colindx] = 0;
                      cols_sequence[colindx] = num_colors++;
@@ -2803,12 +2809,15 @@
             helper_positions[nseq] = new Float32Array(nbins * JSROOT.Painter.Box3D.Segments.length * 3);
       }
 
-      var binx, grx, biny, gry, binz, grz;
+      var binx, grx, biny, gry, binz, grz,
+          xaxis = this.GetAxis("x"),
+          yaxis = this.GetAxis("y"),
+          zaxis = this.GetAxis("z");
 
       for (i = i1; i < i2; ++i) {
-         binx = histo.fXaxis.GetBinCenter(i+1); grx = main.grx(binx);
+         binx = xaxis.GetBinCenter(i+1); grx = main.grx(binx);
          for (j = j1; j < j2; ++j) {
-            biny = histo.fYaxis.GetBinCenter(j+1); gry = main.gry(biny);
+            biny = yaxis.GetBinCenter(j+1); gry = main.gry(biny);
             for (k = k1; k < k2; ++k) {
                bin_content = histo.getBinContent(i+1, j+1, k+1);
                if ((bin_content===0) || (bin_content < this.gminbin)) continue;
@@ -2818,14 +2827,14 @@
 
                var nseq = 0;
                if (use_colors) {
-                  var colindx = this.getContourColor(bin_content, true);
-                  if (colindx === null) continue;
+                  var colindx = palette.getContourIndex(bin_content);
+                  if (colindx < 0) continue;
                   nseq = cols_sequence[colindx];
                }
 
                nbins = cols_nbins[nseq];
 
-               binz = histo.fZaxis.GetBinCenter(k+1); grz = main.grz(binz);
+               binz = zaxis.GetBinCenter(k+1); grz = main.grz(binz);
 
                // remember bin index for tooltip
                bin_tooltips[nseq][nbins] = histo.getBin(i+1, j+1, k+1);
@@ -2883,7 +2892,7 @@
          all_bins_buffgeom.addAttribute('position', new THREE.BufferAttribute( bin_verts[nseq], 3 ) );
          all_bins_buffgeom.addAttribute('normal', new THREE.BufferAttribute( bin_norms[nseq], 3 ) );
 
-         if (use_colors) fillcolor = this.fPalette.getColor(ncol);
+         if (use_colors) fillcolor = palette.getColor(ncol);
 
          var material = use_lambert ? new THREE.MeshLambertMaterial({ color: fillcolor, opacity: use_opacity, transparent: (use_opacity<1) })
                                     : new THREE.MeshBasicMaterial({ color: fillcolor, opacity: use_opacity });
@@ -2897,7 +2906,7 @@
          combined_bins.scalex = tipscale*scalex;
          combined_bins.scaley = tipscale*scaley;
          combined_bins.scalez = tipscale*scalez;
-         combined_bins.tip_color = (rootcolor===3) ? 0xFF0000 : 0x00FF00;
+         combined_bins.tip_color = 0x00FF00;
          combined_bins.use_scale = use_scale;
 
          combined_bins.tooltip = function(intersect) {
@@ -2912,9 +2921,9 @@
                 histo = p.GetHisto(),
                 main = p.frame_painter(),
                 tip = p.Get3DToolTip(this.bins[indx]),
-                grx = main.grx(histo.fXaxis.GetBinCoord(tip.ix-0.5)),
-                gry = main.gry(histo.fYaxis.GetBinCoord(tip.iy-0.5)),
-                grz = main.grz(histo.fZaxis.GetBinCoord(tip.iz-0.5)),
+                grx = main.grx(p.GetAxis("x").GetBinCoord(tip.ix-0.5)),
+                gry = main.gry(p.GetAxis("y").GetBinCoord(tip.iy-0.5)),
+                grz = main.grz(p.GetAxis("z").GetBinCoord(tip.iz-0.5)),
                 wei = this.use_scale ? Math.pow(Math.abs(tip.value*this.use_scale), 0.3333) : 1;
 
             tip.x1 = grx - this.scalex*wei; tip.x2 = grx + this.scalex*wei;
@@ -2943,6 +2952,9 @@
             main.toplevel.add(lines);
          }
       }
+
+      if (use_colors)
+         this.UpdatePaletteDraw();
    }
 
    RH3Painter.prototype.Redraw = function(reason) {
@@ -2993,7 +3005,7 @@
           j2 = this.GetSelectIndex("y", "right"),
           k1 = this.GetSelectIndex("z", "left"),
           k2 = this.GetSelectIndex("z", "right"),
-          i,j,k, histo = this.GetObject();
+          i,j,k, histo = this.GetHisto();
 
       if ((i1 === i2) || (j1 === j2) || (k1 === k2)) return;
 
@@ -3027,20 +3039,20 @@
       if ((kleft === kright-1) && (kleft > k1+1) && (kright < k2-1)) { kleft--; kright++; }
 
       if ((ileft > i1 || iright < i2) && (ileft < iright - 1)) {
-         xmin = histo.fXaxis.GetBinLowEdge(ileft+1);
-         xmax = histo.fXaxis.GetBinLowEdge(iright+1);
+         xmin = this.GetAxis("x").GetBinLowEdge(ileft+1);
+         xmax = this.GetAxis("x").GetBinLowEdge(iright+1);
          isany = true;
       }
 
       if ((jleft > j1 || jright < j2) && (jleft < jright - 1)) {
-         ymin = histo.fYaxis.GetBinLowEdge(jleft+1);
-         ymax = histo.fYaxis.GetBinLowEdge(jright+1);
+         ymin = this.GetAxis("y").GetBinLowEdge(jleft+1);
+         ymax = this.GetAxis("y").GetBinLowEdge(jright+1);
          isany = true;
       }
 
       if ((kleft > k1 || kright < k2) && (kleft < kright - 1)) {
-         zmin = histo.fZaxis.GetBinLowEdge(kleft+1);
-         zmax = histo.fZaxis.GetBinLowEdge(kright+1);
+         zmin = this.GetAxis("z").GetBinLowEdge(kleft+1);
+         zmax = this.GetAxis("z").GetBinLowEdge(kright+1);
          isany = true;
       }
 
@@ -3061,24 +3073,31 @@
       });
    }
 
-   JSROOT.Painter.drawHistogram3D = function(divid, histo, opt) {
+   JSROOT.v7.drawHist3 = function(divid, histo, opt) {
       // create painter and add it to canvas
       var painter = new RH3Painter(histo);
 
-      painter.SetDivId(divid, 4);
+      painter.PrepareFrame(divid, true); // create if necessary frame in 3d mode
 
-      painter.DecodeOptions(opt);
+      painter.options = { Box: 0, Scatter: false, Sphere: 0, Color: false, minimum: -1111, maximum: -1111 };
 
-      painter.CheckPadRange();
+      var kind = painter.v7EvalAttr("kind", "col"),
+          sub = painter.v7EvalAttr("sub", 0),
+          o = painter.options;
+
+      switch(kind) {
+         case "box": o.Box = 10 + sub; break;
+         case "sphere": o.Sphere = 10 + sub; break;
+         case "col": o.Color = true; break;
+         case "scat": o.Scatter = true;  break;
+         default: o.Box = 10;
+      }
 
       painter.ScanContent();
 
       painter.Redraw();
 
-      var stats = painter.CreateStat(); // only when required
-      if (stats) JSROOT.draw(painter.divid, stats, "");
-
-      painter.FillToolbar();
+      // painter.FillToolbar();
 
       return painter.DrawingReady();
    }

--- a/js/scripts/JSRootPainter.v7hist3d.js
+++ b/js/scripts/JSRootPainter.v7hist3d.js
@@ -3,32 +3,32 @@
 
 (function( factory ) {
    if ( typeof define === "function" && define.amd ) {
-      define( [ 'JSRootCore', 'd3', 'JSRootPainter.hist', 'threejs', 'threejs_all'], factory );
+      define( [ 'JSRootCore', 'd3', 'JSRootPainter.v7hist', 'threejs', 'threejs_all'], factory );
    } else if (typeof exports === 'object' && typeof module !== 'undefined') {
       var jsroot = require("./JSRootCore.js");
-      factory(jsroot, require("d3"), require("./JSRootPainter.hist.js"), require("three"), require("./three.extra.min.js"),
+      factory(jsroot, require("d3"), require("./JSRootPainter.v7hist.js"), require("three"), require("./three.extra.min.js"),
               jsroot.nodejs || (typeof document=='undefined') ? jsroot.nodejs_document : document);
    } else {
       if (typeof JSROOT == 'undefined')
-         throw new Error('JSROOT is not defined', 'JSRootPainter.hist3d.js');
+         throw new Error('JSROOT is not defined', 'JSRootPainter.v7hist3d.js');
       if (typeof d3 != 'object')
-         throw new Error('This extension requires d3.js', 'JSRootPainter.hist3d.js');
+         throw new Error('This extension requires d3.js', 'JSRootPainter.v7hist3d.js');
       if (typeof THREE == 'undefined')
-         throw new Error('THREE is not defined', 'JSRootPainter.hist3d.js');
+         throw new Error('THREE is not defined', 'JSRootPainter.v7hist3d.js');
       factory(JSROOT, d3, JSROOT, THREE, THREE);
    }
 } (function(JSROOT, d3, __DUMMY__, THREE, THREE_MORE, document) {
 
    "use strict";
 
-   JSROOT.sources.push("hist3d");
+   JSROOT.sources.push("v7hist3d");
 
    if ((typeof document=='undefined') && (typeof window=='object')) document = window.document;
 
-   if (typeof JSROOT.THistPainter === 'undefined')
-      throw new Error('JSROOT.THistPainter is not defined', 'JSRootPainter.hist3d.js');
+   if (typeof JSROOT.v7.RHistPainter === 'undefined')
+      throw new Error('JSROOT.v7.RHistPainter is not defined', 'JSRootPainter.v7hist3d.js');
 
-   JSROOT.TFramePainter.prototype.SetCameraPosition = function(pad, first_time) {
+   JSROOT.v7.RFramePainter.prototype.SetCameraPosition = function(pad, first_time) {
       var max3d = Math.max(0.75*this.size_xy3d, this.size_z3d);
 
       if (first_time)
@@ -54,7 +54,7 @@
    }
 
    /** @summary Create all necessary components for 3D drawings @private */
-   JSROOT.TFramePainter.prototype.Create3DScene = function(arg) {
+   JSROOT.v7.RFramePainter.prototype.Create3DScene = function(arg) {
 
       if ((arg!==undefined) && (arg<0)) {
 
@@ -120,6 +120,8 @@
 
       this.size_z3d = 100;
       this.size_xy3d = (sz.height > 10) && (sz.width > 10) ? Math.round(sz.width/sz.height*this.size_z3d) : this.size_z3d;
+
+      console.log('size_xy3d', this.size_xy3d);
 
       // three.js 3D drawing
       this.scene = new THREE.Scene();
@@ -227,7 +229,7 @@
    /** @brief Set frame activity flag
     * @private */
 
-   JSROOT.TFramePainter.prototype.SetActive = function(on) {
+   JSROOT.v7.RFramePainter.prototype.SetActive = function(on) {
       if (this.control)
          this.control.enableKeys = on && JSROOT.key_handling;
    }
@@ -242,7 +244,7 @@
      *  -2222 - rendering performed only if there were previous calls, which causes timeout activation
      * @private */
 
-   JSROOT.TFramePainter.prototype.Render3D = function(tmout) {
+   JSROOT.v7.RFramePainter.prototype.Render3D = function(tmout) {
 
       if (tmout === -1111) {
          // special handling for direct SVG renderer
@@ -306,7 +308,7 @@
       this.render_tmout = setTimeout(this.Render3D.bind(this,0), tmout);
    }
 
-   JSROOT.TFramePainter.prototype.Resize3D = function() {
+   JSROOT.v7.RFramePainter.prototype.Resize3D = function() {
 
       var sz = this.size_for_3d(this.access_3d_kind());
 
@@ -330,7 +332,7 @@
       return true;
    }
 
-   JSROOT.TFramePainter.prototype.BinHighlight3D = function(tip, selfmesh) {
+   JSROOT.v7.RFramePainter.prototype.BinHighlight3D = function(tip, selfmesh) {
 
       var changed = false, tooltip_mesh = null, changed_self = true,
           want_remove = !tip || (tip.x1===undefined) || !this.enable_highlight;
@@ -418,7 +420,7 @@
                                    grx: (tip.x1+tip.x2)/2, gry: (tip.y1+tip.y2)/2, grz: (tip.z1+tip.z2)/2 });
    }
 
-   JSROOT.TFramePainter.prototype.TestAxisVisibility = function(camera, toplevel, fb, bb) {
+   JSROOT.v7.RFramePainter.prototype.TestAxisVisibility = function(camera, toplevel, fb, bb) {
       var top;
       if (toplevel && toplevel.children)
          for (var n=0;n<toplevel.children.length;++n) {
@@ -473,11 +475,11 @@
       }
    }
 
-   JSROOT.TFramePainter.prototype.Set3DOptions = function(hopt) {
+   JSROOT.v7.RFramePainter.prototype.Set3DOptions = function(hopt) {
       this.opt3d = hopt;
    }
 
-   JSROOT.TFramePainter.prototype.DrawXYZ = function(toplevel, opts) {
+   JSROOT.v7.RFramePainter.prototype.DrawXYZ = function(toplevel, opts) {
       if (!opts) opts = {};
 
       var grminx = -this.size_xy3d, grmaxx = this.size_xy3d,
@@ -587,7 +589,7 @@
 
       this.grz.domain([ zmin, zmax ]).range([ grminz, grmaxz ]);
 
-      this.SetRootPadRange(pad, true); // set some coordinates typical for 3D projections in ROOT
+      // this.SetRootPadRange(pad, true); // set some coordinates typical for 3D projections in ROOT
 
       this.z_handle = new JSROOT.TAxisPainter(this.zaxis);
       this.z_handle.SetAxisConfig("zaxis", this.z_kind, this.grz, this.zmin, this.zmax, zmin, zmax);
@@ -1076,12 +1078,12 @@
       }
    }
 
-   /** Draw histograms in 3D mode @private */
-   JSROOT.THistPainter.prototype.Draw3DBins = function() {
+   /** Draw 1D/2D histograms in 3D mode @private */
+   JSROOT.v7.RHistPainter.prototype.Draw3DBins = function() {
 
       if (!this.draw_content) return;
 
-      if (this.IsTH2Poly() && this.DrawPolyLego)
+/*      if (this.IsTH2Poly() && this.DrawPolyLego)
          return this.DrawPolyLego();
 
       if ((this.Dimension()==2) && this.options.Contour && this.DrawContour3D)
@@ -1092,8 +1094,9 @@
 
       if ((this.Dimension()==2) && this.options.Error && this.DrawError)
          return this.DrawError();
+*/
 
-      // Perform TH1/TH2 lego plot with BufferGeometry
+      // Perform RH1/RH2 lego plot with BufferGeometry
 
       var vertices = JSROOT.Painter.Box3D.Vertices,
           indicies = JSROOT.Painter.Box3D.Indexes,
@@ -1150,8 +1153,11 @@
 
       if ((this.options.Lego === 12) || (this.options.Lego === 14)) {
          // drawing colors levels, axis can not exceed palette
-         levels = this.CreateContour(histo.fContour ? histo.fContour.length : 20, main.lego_zmin, main.lego_zmax);
-         palette = this.GetPalette();
+
+         palette = main.GetPalette();
+         this.CreateContour(main, palette);
+         levels = palette.GetContour();
+         // levels = this.CreateContour(histo.fContour ? histo.fContour.length : 20, main.lego_zmin, main.lego_zmax);
          //axis_zmin = levels[0];
          //axis_zmax = levels[levels.length-1];
       }
@@ -1162,14 +1168,14 @@
              z1 = 0, z2 = 0, numvertices = 0, num2vertices = 0;
 
          // artificially extend last level of color palette to maximal visible value
-         if (palette && (nlevel==levels.length-2) && zmax < axis_zmax) zmax = axis_zmax;
+         if (palette && (nlevel==levels.length-2) && (zmax < axis_zmax)) zmax = axis_zmax;
 
          var grzmin = main.grz(zmin), grzmax = main.grz(zmax);
 
          // now calculate size of buffer geometry for boxes
 
-         for (i=i1;i<i2;++i)
-            for (j=j1;j<j2;++j) {
+         for (i = i1; i < i2; ++i)
+            for (j = j1; j < j2; ++j) {
 
                if (!GetBinContent(i,j,nlevel)) continue;
 
@@ -1200,10 +1206,10 @@
             face_to_bins_indx2 = use16indx ? new Uint16Array(num2vertices/3) : new Uint32Array(num2vertices/3);
          }
 
-         for (i=i1;i<i2;++i) {
+         for (i=i1; i<i2; ++i) {
             x1 = handle.grx[i] + handle.xbar1*(handle.grx[i+1]-handle.grx[i]);
             x2 = handle.grx[i] + handle.xbar2*(handle.grx[i+1]-handle.grx[i]);
-            for (j=j1;j<j2;++j) {
+            for (j=j1; j<j2; ++j) {
 
                if (!GetBinContent(i,j,nlevel)) continue;
 
@@ -1272,11 +1278,10 @@
          geometry.addAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
          // geometry.computeVertexNormals();
 
-         var rootcolor = histo.fFillColor,
-             fcolor = this.get_color(rootcolor);
+         var rootcolor = 3, fcolor = this.get_color(rootcolor);
 
          if (palette) {
-            fcolor = palette.calcColor(nlevel, levels.length);
+            fcolor = palette.getColor(nlevel); // calcColor in v6
          } else {
             if ((this.options.Lego === 1) || (rootcolor < 2)) {
                rootcolor = 1;
@@ -1478,7 +1483,7 @@
          // use min/max values directly as graphical coordinates
          this.size_xy3d = this.size_z3d = 0;
 
-         this.DrawXYZ = JSROOT.TFramePainter.prototype.DrawXYZ; // just reuse axis drawing from frame painter
+         this.DrawXYZ = JSROOT.v7.RFramePainter.prototype.DrawXYZ; // just reuse axis drawing from frame painter
 
          this.DrawXYZ(main._toplevel);
 
@@ -1495,7 +1500,7 @@
    // ==========================================================================================
 
    /** @summary Draw 1-D histogram in 3D @private */
-   JSROOT.TH1Painter.prototype.Draw3D = function(call_back, reason) {
+   JSROOT.v7.RH1Painter.prototype.Draw3D = function(call_back, reason) {
 
       this.mode3d = true;
 
@@ -1515,7 +1520,7 @@
 
          if (is_main) {
             main.Create3DScene();
-            main.SetAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, 0, 0);
+            main.SetAxesRanges(this.xmin, this.xmax, this.ymin, this.ymax, 0, 0);
             main.Set3DOptions(this.options);
             main.DrawXYZ(main.toplevel, { use_y_for_z: true, zmult: 1.1, zoom: JSROOT.gStyle.Zooming, ndim: 1 });
          }
@@ -1530,9 +1535,9 @@
 
       if (is_main) {
          // (re)draw palette by resize while canvas may change dimension
-         this.DrawColorPalette(this.options.Zscale && ((this.options.Lego===12) || (this.options.Lego===14)));
+         // this.DrawColorPalette(this.options.Zscale && ((this.options.Lego===12) || (this.options.Lego===14)));
 
-         this.DrawTitle();
+         // this.DrawTitle();
       }
 
       JSROOT.CallBack(call_back);
@@ -1540,7 +1545,7 @@
 
    // ==========================================================================================
 
-   JSROOT.TH2Painter.prototype.Draw3D = function(call_back, reason) {
+   JSROOT.v7.RH2Painter.prototype.Draw3D = function(call_back, reason) {
 
       this.mode3d = true;
 
@@ -1556,19 +1561,17 @@
 
          var pad = this.root_pad(), zmult = 1.1;
 
-         this.zmin = pad.fLogz ? this.gminposbin * 0.3 : this.gminbin;
+         this.zmin = (pad && pad.fLogz) ? this.gminposbin * 0.3 : this.gminbin;
          this.zmax = this.gmaxbin;
-
          if (this.options.minimum !== -1111) this.zmin = this.options.minimum;
          if (this.options.maximum !== -1111) { this.zmax = this.options.maximum; zmult = 1; }
-
-         if (pad.fLogz && (this.zmin<=0)) this.zmin = this.zmax * 1e-5;
+         if (pad && pad.fLogz && (this.zmin<=0)) this.zmin = this.zmax * 1e-5;
 
          this.DeleteAtt();
 
          if (is_main) {
             main.Create3DScene();
-            main.SetAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, this.zmin, this.zmax);
+            main.SetAxesRanges(this.xmin, this.xmax, this.ymin, this.ymax, this.zmin, this.zmax);
             main.Set3DOptions(this.options);
             main.DrawXYZ(main.toplevel, { zmult: zmult, zoom: JSROOT.gStyle.Zooming, ndim: 2 });
          }
@@ -1584,16 +1587,15 @@
       if (is_main) {
 
          //  (re)draw palette by resize while canvas may change dimension
-         this.DrawColorPalette(this.options.Zscale && ((this.options.Lego===12) || (this.options.Lego===14) ||
-                               (this.options.Surf===11) || (this.options.Surf===12)));
-
-         this.DrawTitle();
+         //this.DrawColorPalette(this.options.Zscale && ((this.options.Lego===12) || (this.options.Lego===14) ||
+         //                      (this.options.Surf===11) || (this.options.Surf===12)));
+         // this.DrawTitle();
       }
 
       JSROOT.CallBack(call_back);
    }
 
-   JSROOT.TH2Painter.prototype.DrawContour3D = function(realz) {
+   JSROOT.v7.RH2Painter.prototype.DrawContour3D = function(realz) {
       // for contour plots one requires handle with full range
       var main = this.frame_painter(),
           handle = this.PrepareColorDraw({rounding: false, use3d: true, extra: 100, middle: 0.0 }),
@@ -1623,7 +1625,7 @@
       main.toplevel.add(lines);
    }
 
-   JSROOT.TH2Painter.prototype.DrawSurf = function() {
+   JSROOT.v7.RH2Painter.prototype.DrawSurf = function() {
       var histo = this.GetHisto(),
           main = this.frame_painter(),
           handle = this.PrepareColorDraw({rounding: false, use3d: true, extra: 1, middle: 0.5 }),
@@ -2025,7 +2027,7 @@
       }
    }
 
-   JSROOT.TH2Painter.prototype.DrawError = function() {
+   JSROOT.v7.RH2Painter.prototype.DrawError = function() {
       var pthis = this,
           main = this.frame_painter(),
           histo = this.GetHisto(),
@@ -2131,7 +2133,7 @@
        main.toplevel.add(line);
    }
 
-   JSROOT.TH2Painter.prototype.DrawPolyLego = function() {
+   JSROOT.v7.RH2Painter.prototype.DrawPolyLego = function() {
       var histo = this.GetHisto(),
           pmain = this.frame_painter(),
           axis_zmin = pmain.grz.domain()[0],
@@ -2329,15 +2331,15 @@
 
    // ==============================================================================
 
-   function TH3Painter(histo) {
-      JSROOT.THistPainter.call(this, histo);
+   function RH3Painter(histo) {
+      JSROOT.v7.RHistPainter.call(this, histo);
 
       this.mode3d = true;
    }
 
-   TH3Painter.prototype = Object.create(JSROOT.THistPainter.prototype);
+   RH3Painter.prototype = Object.create(JSROOT.v7.RHistPainter.prototype);
 
-   TH3Painter.prototype.ScanContent = function(when_axis_changed) {
+   RH3Painter.prototype.ScanContent = function(when_axis_changed) {
 
       // no need to rescan histogram while result does not depend from axis selection
       if (when_axis_changed && this.nbinsx && this.nbinsy && this.nbinsz) return;
@@ -2374,7 +2376,7 @@
       this.CreateAxisFuncs(true, true);
    }
 
-   TH3Painter.prototype.CountStat = function() {
+   RH3Painter.prototype.CountStat = function() {
       var histo = this.GetHisto(), xaxis = histo.fXaxis, yaxis = histo.fYaxis, zaxis = histo.fZaxis,
           stat_sum0 = 0, stat_sumx1 = 0, stat_sumy1 = 0,
           stat_sumz1 = 0, stat_sumx2 = 0, stat_sumy2 = 0, stat_sumz2 = 0,
@@ -2445,7 +2447,7 @@
       return res;
    }
 
-   TH3Painter.prototype.FillStatistic = function(stat, dostat, dofit) {
+   RH3Painter.prototype.FillStatistic = function(stat, dostat, dofit) {
 
       // no need to refill statistic if histogram is dummy
       if (this.IgnoreStatsFill()) return false;
@@ -2490,7 +2492,7 @@
       return true;
    }
 
-   TH3Painter.prototype.GetBinTips = function (ix, iy, iz) {
+   RH3Painter.prototype.GetBinTips = function (ix, iy, iz) {
       var lines = [], pmain = this.frame_painter(), histo = this.GetHisto();
 
       lines.push(this.GetTipName());
@@ -2519,7 +2521,7 @@
       return lines;
    }
 
-   TH3Painter.prototype.Draw3DScatter = function() {
+   RH3Painter.prototype.Draw3DScatter = function() {
       // try to draw 3D histogram as scatter plot
       // if too many points, box will be displayed
 
@@ -2615,7 +2617,7 @@
       return true;
    }
 
-   TH3Painter.prototype.Draw3DBins = function() {
+   RH3Painter.prototype.Draw3DBins = function() {
 
       if (!this.draw_content) return;
 
@@ -2927,7 +2929,7 @@
       }
    }
 
-   TH3Painter.prototype.Redraw = function(reason) {
+   RH3Painter.prototype.Redraw = function(reason) {
 
       var main = this.frame_painter(), // who makes axis and 3D drawing
           histo = this.GetHisto();
@@ -2939,7 +2941,7 @@
       } else {
 
          main.Create3DScene();
-         main.SetAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, this.zmin, this.zmax);
+         main.SetAxesRanges(this.xmin, this.xmax, this.ymin, this.ymax, this.zmin, this.zmax);
          main.Set3DOptions(this.options);
          main.DrawXYZ(main.toplevel, { zoom: JSROOT.gStyle.Zooming, ndim: 3 });
          this.Draw3DBins();
@@ -2948,10 +2950,10 @@
          main.AddKeysHandler();
       }
 
-      this.DrawTitle();
+      // this.DrawTitle();
    }
 
-   TH3Painter.prototype.FillToolbar = function() {
+   RH3Painter.prototype.FillToolbar = function() {
       var pp = this.pad_painter();
       if (!pp) return;
 
@@ -2961,14 +2963,14 @@
       pp.ShowButtons();
    }
 
-   TH3Painter.prototype.CanZoomIn = function(axis,min,max) {
+   RH3Painter.prototype.CanZoomIn = function(axis,min,max) {
       // check if it makes sense to zoom inside specified axis range
       var obj = this.GetHisto();
       if (obj) obj = obj["f"+axis.toUpperCase()+"axis"];
       return !obj || (obj.FindBin(max,0.5) - obj.FindBin(min,0) > 1);
    }
 
-   TH3Painter.prototype.AutoZoom = function() {
+   RH3Painter.prototype.AutoZoom = function() {
       var i1 = this.GetSelectIndex("x", "left"),
           i2 = this.GetSelectIndex("x", "right"),
           j1 = this.GetSelectIndex("y", "left"),
@@ -3029,7 +3031,7 @@
       if (isany) this.frame_painter().Zoom(xmin, xmax, ymin, ymax, zmin, zmax);
    }
 
-   TH3Painter.prototype.FillHistContextMenu = function(menu) {
+   RH3Painter.prototype.FillHistContextMenu = function(menu) {
 
       var sett = JSROOT.getDrawSettings("ROOT." + this.GetObject()._typename, 'nosame');
 
@@ -3045,7 +3047,7 @@
 
    JSROOT.Painter.drawHistogram3D = function(divid, histo, opt) {
       // create painter and add it to canvas
-      var painter = new JSROOT.TH3Painter(histo);
+      var painter = new RH3Painter(histo);
 
       painter.SetDivId(divid, 4);
 
@@ -3065,499 +3067,7 @@
       return painter.DrawingReady();
    }
 
-   // ===========================================================================================
-
-   function TGraph2DPainter(graph) {
-      JSROOT.TObjectPainter.call(this, graph);
-   }
-
-   TGraph2DPainter.prototype = Object.create(JSROOT.TObjectPainter.prototype);
-
-   TGraph2DPainter.prototype.DecodeOptions = function(opt) {
-      var d = new JSROOT.DrawOptions(opt);
-
-      if (!this.options)
-         this.options = {};
-
-      var res = this.options;
-
-      res.Color = d.check("COL");
-      res.Line = d.check("LINE");
-      res.Error = d.check("ERR") && this.MatchObjectType("TGraph2DErrors");
-      res.Circles = d.check("P0");
-      res.Markers = d.check("P");
-
-      if (!res.Markers && !res.Error && !res.Circles && !res.Line) res.Markers = true;
-      if (!res.Markers) res.Color = false;
-
-      this.OptionsStore(opt);
-   }
-
-   TGraph2DPainter.prototype.CreateHistogram = function() {
-      var gr = this.GetObject(),
-          xmin = gr.fX[0], xmax = xmin,
-          ymin = gr.fY[0], ymax = ymin,
-          zmin = gr.fZ[0], zmax = zmin;
-
-      for (var p = 0; p < gr.fNpoints;++p) {
-
-         var x = gr.fX[p], y = gr.fY[p], z = gr.fZ[p],
-             errx = this.options.Error ? gr.fEX[p] : 0,
-             erry = this.options.Error ? gr.fEY[p] : 0,
-             errz = this.options.Error ? gr.fEZ[p] : 0;
-
-         xmin = Math.min(xmin, x-errx);
-         xmax = Math.max(xmax, x+errx);
-         ymin = Math.min(ymin, y-erry);
-         ymax = Math.max(ymax, y+erry);
-         zmin = Math.min(zmin, z-errz);
-         zmax = Math.max(zmax, z+errz);
-      }
-
-      if (xmin >= xmax) xmax = xmin+1;
-      if (ymin >= ymax) ymax = ymin+1;
-      if (zmin >= zmax) zmax = zmin+1;
-      var dx = (xmax-xmin)*0.02, dy = (ymax-ymin)*0.02, dz = (zmax-zmin)*0.02,
-          uxmin = xmin - dx, uxmax = xmax + dx,
-          uymin = ymin - dy, uymax = ymax + dy,
-          uzmin = zmin - dz, uzmax = zmax + dz;
-
-      if ((uxmin<0) && (xmin>=0)) uxmin = xmin*0.98;
-      if ((uxmax>0) && (xmax<=0)) uxmax = 0;
-
-      if ((uymin<0) && (ymin>=0)) uymin = ymin*0.98;
-      if ((uymax>0) && (ymax<=0)) uymax = 0;
-
-      if ((uzmin<0) && (zmin>=0)) uzmin = zmin*0.98;
-      if ((uzmax>0) && (zmax<=0)) uzmax = 0;
-
-      var graph = this.GetObject();
-
-      if (graph.fMinimum != -1111) uzmin = graph.fMinimum;
-      if (graph.fMaximum != -1111) uzmax = graph.fMaximum;
-
-      var histo = JSROOT.CreateHistogram("TH2I", 10, 10);
-      histo.fName = graph.fName + "_h";
-      histo.fTitle = graph.fTitle;
-      histo.fXaxis.fXmin = uxmin;
-      histo.fXaxis.fXmax = uxmax;
-      histo.fYaxis.fXmin = uymin;
-      histo.fYaxis.fXmax = uymax;
-      histo.fZaxis.fXmin = uzmin;
-      histo.fZaxis.fXmax = uzmax;
-      histo.fMinimum = uzmin;
-      histo.fMaximum = uzmax;
-      histo.fBits = histo.fBits | JSROOT.TH1StatusBits.kNoStats;
-      return histo;
-   }
-
-   TGraph2DPainter.prototype.Graph2DTooltip = function(intersect) {
-      if (isNaN(intersect.index)) {
-         console.error('intersect.index not provided, check three.js version', THREE.REVISION, 'expected r97');
-         return null;
-      }
-
-      var indx = Math.floor(intersect.index / this.nvertex);
-      if ((indx<0) || (indx >= this.index.length)) return null;
-
-      indx = this.index[indx];
-
-      var p = this.painter,
-          grx = p.grx(this.graph.fX[indx]),
-          gry = p.gry(this.graph.fY[indx]),
-          grz = p.grz(this.graph.fZ[indx]);
-
-      if (this.check_next && indx+1<this.graph.fX.length) {
-         function sqr(v) { return v*v; }
-         var d = intersect.point,
-             grx1 = p.grx(this.graph.fX[indx+1]),
-             gry1 = p.gry(this.graph.fY[indx+1]),
-             grz1 = p.grz(this.graph.fZ[indx+1]);
-         if (sqr(d.x-grx1)+sqr(d.y-gry1)+sqr(d.z-grz1) < sqr(d.x-grx)+sqr(d.y-gry)+sqr(d.z-grz)) {
-            grx = grx1; gry = gry1; grz = grz1; indx++;
-         }
-      }
-
-      return {
-         x1: grx - this.scale0,
-         x2: grx + this.scale0,
-         y1: gry - this.scale0,
-         y2: gry + this.scale0,
-         z1: grz - this.scale0,
-         z2: grz + this.scale0,
-         color: this.tip_color,
-         lines: [ this.tip_name,
-                  "pnt: " + indx,
-                  "x: " + p.AxisAsText("x", this.graph.fX[indx]),
-                  "y: " + p.AxisAsText("y", this.graph.fY[indx]),
-                  "z: " + p.AxisAsText("z", this.graph.fZ[indx])
-                ]
-      }
-   }
-
-   /** Called when new mesh with points is created. */
-   TGraph2DPainter.prototype.PointsCallback = function(args, mesh) {
-      // mesh.graph = args.graph;
-      // mesh.index = args.index;
-      // mesh.painter = args.painter;
-      // mesh.scale0 = args.scale0;
-      // mesh.tip_color = args.tip_color;
-
-      JSROOT.extend(mesh, args);
-
-      mesh.tip_name = this.GetTipName();
-      mesh.tooltip = this.Graph2DTooltip;
-
-      mesh.painter.toplevel.add(mesh);
-
-      this.points_callback_cnt--;
-
-      this.CheckCallbacks();
-   }
-
-   TGraph2DPainter.prototype.CheckCallbacks = function() {
-      if (this.points_callback_cnt > 0) return;
-
-      var fp = this.frame_painter();
-      if (fp) fp.Render3D(100);
-
-      if (!this._drawing_ready) {
-         this.DrawingReady();
-         this._drawing_ready = true;
-      }
-   }
-
-   TGraph2DPainter.prototype.Redraw = function() {
-
-      var main = this.main_painter(),
-          fp = this.frame_painter(),
-          graph = this.GetObject(),
-          step = 1;
-
-      if (!graph || !main || !fp || !fp.mode3d) return;
-
-      function CountSelected(zmin, zmax) {
-         var cnt = 0;
-         for (var i=0; i < graph.fNpoints; ++i) {
-            if ((graph.fX[i] < fp.scale_xmin) || (graph.fX[i] > fp.scale_xmax) ||
-                (graph.fY[i] < fp.scale_ymin) || (graph.fY[i] > fp.scale_ymax) ||
-                (graph.fZ[i] < zmin) || (graph.fZ[i] >= zmax)) continue;
-
-            ++cnt;
-         }
-         return cnt;
-      }
-
-      // try to define scale-down factor
-      if ((JSROOT.gStyle.OptimizeDraw > 0) && !fp.webgl) {
-         var numselected = CountSelected(fp.scale_zmin, fp.scale_zmax),
-             sizelimit = 50000;
-
-         if (numselected > sizelimit) {
-            step = Math.floor(numselected / sizelimit);
-            if (step <= 2) step = 2;
-         }
-      }
-
-      var markeratt = new JSROOT.TAttMarkerHandler(graph),
-          palette = null,
-          levels = [fp.scale_zmin, fp.scale_zmax],
-          scale = fp.size_xy3d / 100 * markeratt.GetFullSize();
-
-      if (this.options.Circles) scale = 0.06*fp.size_xy3d;
-
-      if (fp.usesvg) scale*=0.3;
-
-      if (this.options.Color) {
-         levels = main.GetContour();
-         palette = main.GetPalette();
-      }
-
-      // how many callbacks are expected
-      this.points_callback_cnt = levels.length-1;
-
-      for (var lvl=0;lvl<levels.length-1;++lvl) {
-
-         var lvl_zmin = Math.max(levels[lvl], fp.scale_zmin),
-             lvl_zmax = Math.min(levels[lvl+1], fp.scale_zmax);
-
-         if (lvl_zmin >= lvl_zmax) {
-            this.points_callback_cnt--;
-            continue;
-         }
-
-         var size = Math.floor(CountSelected(lvl_zmin, lvl_zmax) / step),
-             pnts = null, select = 0,
-             index = new Int32Array(size), icnt = 0,
-             err = null, line = null, ierr = 0, iline = 0;
-
-         if (this.options.Markers || this.options.Circles)
-            pnts = new JSROOT.Painter.PointsCreator(size, fp.webgl, scale/3);
-
-         if (this.options.Error)
-            err = new Float32Array(size*6*3);
-
-         if (this.options.Line)
-            line = new Float32Array((size-1)*6);
-
-         for (var i=0; i < graph.fNpoints; ++i) {
-            if ((graph.fX[i] < fp.scale_xmin) || (graph.fX[i] > fp.scale_xmax) ||
-                (graph.fY[i] < fp.scale_ymin) || (graph.fY[i] > fp.scale_ymax) ||
-                (graph.fZ[i] < lvl_zmin) || (graph.fZ[i] >= lvl_zmax)) continue;
-
-            if (step > 1) {
-               select = (select+1) % step;
-               if (select!==0) continue;
-            }
-
-            index[icnt++] = i; // remember point index for tooltip
-
-            var x = fp.grx(graph.fX[i]),
-                y = fp.gry(graph.fY[i]),
-                z = fp.grz(graph.fZ[i]);
-
-            if (pnts) pnts.AddPoint(x,y,z);
-
-            if (err) {
-               err[ierr]   = fp.grx(graph.fX[i] - graph.fEX[i]);
-               err[ierr+1] = y;
-               err[ierr+2] = z;
-               err[ierr+3] = fp.grx(graph.fX[i] + graph.fEX[i]);
-               err[ierr+4] = y;
-               err[ierr+5] = z;
-               ierr+=6;
-               err[ierr]   = x;
-               err[ierr+1] = fp.gry(graph.fY[i] - graph.fEY[i]);
-               err[ierr+2] = z;
-               err[ierr+3] = x;
-               err[ierr+4] = fp.gry(graph.fY[i] + graph.fEY[i]);
-               err[ierr+5] = z;
-               ierr+=6;
-               err[ierr]   = x;
-               err[ierr+1] = y;
-               err[ierr+2] = fp.grz(graph.fZ[i] - graph.fEZ[i]);
-               err[ierr+3] = x;
-               err[ierr+4] = y;
-               err[ierr+5] = fp.grz(graph.fZ[i] + graph.fEZ[i]);
-               ierr+=6;
-            }
-
-            if (line) {
-               if (iline>=6) {
-                  line[iline] = line[iline-3];
-                  line[iline+1] = line[iline-2];
-                  line[iline+2] = line[iline-1];
-                  iline+=3;
-               }
-               line[iline] = x;
-               line[iline+1] = y;
-               line[iline+2] = z;
-               iline+=3;
-            }
-         }
-
-         if (line && (iline>3) && (line.length == iline)) {
-            var lcolor = this.get_color(this.GetObject().fLineColor),
-                material = new THREE.LineBasicMaterial({ color: new THREE.Color(lcolor) });
-            if (!JSROOT.browser.isIE) material.linewidth = this.GetObject().fLineWidth;
-            var linemesh = JSROOT.Painter.createLineSegments(line, material);
-            fp.toplevel.add(linemesh);
-
-            linemesh.graph = graph;
-            linemesh.index = index;
-            linemesh.painter = fp;
-            linemesh.scale0 = 0.7*scale;
-            linemesh.tip_name = this.GetTipName();
-            linemesh.tip_color = (graph.fMarkerColor === 3) ? 0xFF0000 : 0x00FF00;
-            linemesh.nvertex = 2;
-            linemesh.check_next = true;
-
-            linemesh.tooltip = this.Graph2DTooltip;
-         }
-
-         if (err) {
-            var lcolor = this.get_color(this.GetObject().fLineColor),
-                material = new THREE.LineBasicMaterial({ color: new THREE.Color(lcolor) });
-            if (!JSROOT.browser.isIE) material.linewidth = this.GetObject().fLineWidth;
-            var errmesh = JSROOT.Painter.createLineSegments(err, material);
-            fp.toplevel.add(errmesh);
-
-            errmesh.graph = graph;
-            errmesh.index = index;
-            errmesh.painter = fp;
-            errmesh.scale0 = 0.7*scale;
-            errmesh.tip_name = this.GetTipName();
-            errmesh.tip_color = (graph.fMarkerColor === 3) ? 0xFF0000 : 0x00FF00;
-            errmesh.nvertex = 6;
-
-            errmesh.tooltip = this.Graph2DTooltip;
-         }
-
-         if (!pnts) {
-            this.points_callback_cnt--;
-         } else {
-
-            var fcolor = 'blue';
-
-            if (!this.options.Circles)
-               fcolor = palette ? palette.calcColor(lvl, levels.length) :
-                                  this.get_color(graph.fMarkerColor);
-
-            pnts.AssignCallback(this.PointsCallback.bind(this, {
-               graph: graph,
-               index: index,
-               painter: fp,
-               scale0: 0.3*scale,
-               tip_color: (graph.fMarkerColor === 3) ? 0xFF0000 : 0x00FF00
-            }));
-
-            pnts.CreatePoints({ color: fcolor, style: this.options.Circles ? 4 : graph.fMarkerStyle });
-         }
-      }
-
-      this.CheckCallbacks();
-   }
-
-   JSROOT.Painter.drawGraph2D = function(divid, gr, opt) {
-
-      var painter = new JSROOT.TGraph2DPainter(gr);
-
-      painter.SetDivId(divid, -1); // just to get access to existing elements
-
-      painter.DecodeOptions(opt);
-
-      if (painter.main_painter()) {
-         painter.SetDivId(divid);
-         painter.Redraw();
-         return painter;
-      }
-
-      if (!gr.fHistogram)
-         gr.fHistogram = painter.CreateHistogram();
-
-      JSROOT.draw(divid, gr.fHistogram, "lego;axis", function(hpainter) {
-         painter.ownhisto = true;
-         painter.SetDivId(divid);
-         painter.Redraw();
-      });
-
-      return painter;
-   }
-
-   // ===================================================================
-
-   JSROOT.Painter.drawPolyMarker3D = function(divid, poly, opt) {
-
-      var painter = new JSROOT.TObjectPainter(poly);
-
-      painter.SetDivId(divid);
-
-      painter.Redraw = function() {
-
-         var fp = this.frame_painter();
-
-         if (!fp || !fp.mode3d) {
-            if (!this._did_redraw) this.DrawingReady();
-            this._did_redraw = true;
-            return;
-         }
-
-         var step = 1, sizelimit = 50000, numselect = 0;
-
-         for (var i=0;i<poly.fP.length;i+=3) {
-            if ((poly.fP[i] < fp.scale_xmin) || (poly.fP[i] > fp.scale_xmax) ||
-                (poly.fP[i+1] < fp.scale_ymin) || (poly.fP[i+1] > fp.scale_ymax) ||
-                (poly.fP[i+2] < fp.scale_zmin) || (poly.fP[i+2] > fp.scale_zmax)) continue;
-            ++numselect;
-         }
-
-         if ((JSROOT.gStyle.OptimizeDraw > 0) && (numselect > sizelimit)) {
-            step = Math.floor(numselect/sizelimit);
-            if (step <= 2) step = 2;
-         }
-
-         var size = Math.floor(numselect/step),
-             pnts = new JSROOT.Painter.PointsCreator(size, fp.webgl, fp.size_xy3d/100),
-             index = new Int32Array(size),
-             select = 0, icnt = 0;
-
-         for (var i=0; i<poly.fP.length; i+=3) {
-
-            if ((poly.fP[i] < fp.scale_xmin) || (poly.fP[i] > fp.scale_xmax) ||
-                (poly.fP[i+1] < fp.scale_ymin) || (poly.fP[i+1] > fp.scale_ymax) ||
-                (poly.fP[i+2] < fp.scale_zmin) || (poly.fP[i+2] > fp.scale_zmax)) continue;
-
-            if (step > 1) {
-               select = (select+1) % step;
-               if (select!==0) continue;
-            }
-
-            index[icnt++] = i;
-
-            pnts.AddPoint(fp.grx(poly.fP[i]), fp.gry(poly.fP[i+1]), fp.grz(poly.fP[i+2]));
-         }
-
-         pnts.AssignCallback(function(mesh) {
-            fp.toplevel.add(mesh);
-
-            mesh.tip_color = (poly.fMarkerColor === 3) ? 0xFF0000 : 0x00FF00;
-            mesh.tip_name = poly.fName || "Poly3D";
-            mesh.poly = poly;
-            mesh.painter = fp;
-            mesh.scale0 = 0.7*pnts.scale;
-            mesh.index = index;
-
-            mesh.tooltip = function(intersect) {
-               if (isNaN(intersect.index)) {
-                  console.error('intersect.index not provided, check three.js version', THREE.REVISION, 'expected r97');
-                  return null;
-               }
-               var indx = Math.floor(intersect.index / this.nvertex);
-               if ((indx<0) || (indx >= this.index.length)) return null;
-
-               indx = this.index[indx];
-
-               var p = this.painter,
-                   grx = p.grx(this.poly.fP[indx]),
-                   gry = p.gry(this.poly.fP[indx+1]),
-                   grz = p.grz(this.poly.fP[indx+2]);
-
-               return  {
-                  x1: grx - this.scale0,
-                  x2: grx + this.scale0,
-                  y1: gry - this.scale0,
-                  y2: gry + this.scale0,
-                  z1: grz - this.scale0,
-                  z2: grz + this.scale0,
-                  color: this.tip_color,
-                  lines: [ this.tip_name,
-                           "pnt: " + indx/3,
-                           "x: " + p.AxisAsText("x", this.poly.fP[indx]),
-                           "y: " + p.AxisAsText("y", this.poly.fP[indx+1]),
-                           "z: " + p.AxisAsText("z", this.poly.fP[indx+2])
-                         ]
-               }
-
-            }
-
-            fp.Render3D(100); // set large timeout to be able draw other points
-
-            if (!painter._did_redraw) painter.DrawingReady();
-            painter._did_redraw = true;
-
-         });
-
-         pnts.CreatePoints({ color: this.get_color(poly.fMarkerColor),
-                             style: poly.fMarkerStyle });
-      }
-
-      painter.Redraw();
-
-      return painter;
-   }
-
-   JSROOT.TH3Painter = TH3Painter;
-   JSROOT.TGraph2DPainter = TGraph2DPainter;
+   JSROOT.v7.RH3Painter = RH3Painter;
 
    return JSROOT;
 }));

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -60,7 +60,13 @@ void draw_rh2_colz()
 
    canvas->Draw<RPaletteDrawable>(RPalette::GetPalette(), true);
 
-   canvas->Draw(pHist);
+   auto draw = canvas->Draw(pHist);
+   // draw->AttrLine().SetColor(RColor::kLime);
+   // draw->Surf(4); // configure surf4 draw option
+   // draw->Lego(2); // configure lego2 draw option
+   // draw->Contour(); // configure cont draw option
+   draw->Color(); // configure color draw option (default)
+   draw->Text(true); // configure text drawing (can be enabled with most 2d options)
 
    auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist2");
    stat->AttrFill().SetColor(RColor::kRed);

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -50,7 +50,7 @@ void draw_rh2_colz()
    // should we made special style for frame with palette?
    frame->Margins().SetRight(0.2_normal);
 
-   frame->SetGridX(true).SetGridY(false);
+   frame->SetGridX(false).SetGridY(false);
 
    frame->AttrX().SetZoomMinMax(2.,8.);
 
@@ -62,9 +62,10 @@ void draw_rh2_colz()
 
    auto draw = canvas->Draw(pHist);
    // draw->AttrLine().SetColor(RColor::kLime);
-   // draw->Surf(4); // configure surf4 draw option
+   // draw->Surf(2); // configure surf4 draw option
    // draw->Lego(2); // configure lego2 draw option
    // draw->Contour(); // configure cont draw option
+   // draw->Scatter(); // configure color draw option (default)
    draw->Color(); // configure color draw option (default)
    draw->Text(true); // configure text drawing (can be enabled with most 2d options)
 

--- a/tutorials/v7/draw_rh3.cxx
+++ b/tutorials/v7/draw_rh3.cxx
@@ -1,0 +1,58 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// This macro generates a small V7 TH2D, fills it with random values and
+/// draw it in a V7 canvas, using configured web browser
+///
+/// \macro_code
+///
+/// \date 2020-03-04
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \author Sergey Linev <s.linev@gsi.de>
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RHistDrawable.hxx"
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RFrameTitle.hxx"
+#include "TRandom.h"
+
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
+R__LOAD_LIBRARY(libROOTHistDraw)
+
+using namespace ROOT::Experimental;
+
+void draw_rh3()
+{
+   // Create the histogram.
+   RAxisConfig xaxis("x", 10, -5., 5.);
+   RAxisConfig yaxis("y", 10, -5., 5.);
+   RAxisConfig zaxis("z", 10, -5., 5.);
+   auto pHist = std::make_shared<RH3D>(xaxis, yaxis, zaxis);
+
+   for (int n=0;n<10000;n++)
+      pHist->Fill({gRandom->Gaus(0.,2.), gRandom->Gaus(0.,2.), gRandom->Gaus(0.,2.)});
+
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create("Canvas Title");
+
+   canvas->Draw<RFrameTitle>("3D histogram drawing");
+
+   auto draw = canvas->Draw(pHist);
+   draw->SetColor(RColor::kBlue); // use color in some draw options
+   draw->SetLineColor(RColor::kRed);
+   draw->Scatter(); // scatter plot
+   draw->Sphere(1); // draw spheres 0 - default, 1 - with colors
+   draw->Color(); // draw colored boxes
+   draw->Box(0); // draw boxes 0 - default, 1 - with colors, 2 - without lines
+
+   canvas->SetSize(1000, 700);
+   canvas->Show();
+}

--- a/ui5/canv/canvas.html
+++ b/ui5/canv/canvas.html
@@ -74,7 +74,7 @@
       }
       
       JSROOT.ConnectWebWindow({
-         prereq: "2d;v6;v7;",
+         prereq: "2d;v7;",
          prereq_logdiv: "CanvasDiv",
          // openui5src: "https://openui5.hana.ondemand.com/",
          callback: InitV7Canvas


### PR DESCRIPTION
Via `RHist2Drawable` methods one can configure options:
   * `Color()` (2d, default)
   * `Scatter()` (2d)
   * `Text()` (2d)
   * `Contour()` (2d and 3d)
   * `Surface()` (3d)
   * `Lego()` (3d)

With `RHist3Drawable` following draw options supported
   * `Box(0)`, `Box(1)`, `Box(2)`
   * `Sphere(0)`, `Sphere(1)`
   * `Color()`
   * `Scatter()`

Fix problem with I/O for `RH3` class - add missing entries in LinkDef.h

![Canvas](https://user-images.githubusercontent.com/4936580/85428560-aad75680-b57d-11ea-9a4f-b0544c5159c0.png)
