### PR TITLE
[cxxmodules] Use forward declarations instead on including the header.

### DIFF
--- a/sql/sqlite/CMakeLists.txt
+++ b/sql/sqlite/CMakeLists.txt
@@ -8,10 +8,6 @@
 # CMakeLists.txt file for building ROOT sql/pgsql package
 ############################################################################
 
-if(runtime_cxxmodules AND APPLE)
-  list(APPEND extra_dictionary_opts "-mByproduct" "SQLite3")
-endif()
-
 ROOT_STANDARD_LIBRARY_PACKAGE(RSQLite
   HEADERS
     TSQLiteResult.h
@@ -27,8 +23,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RSQLite
     Core
     Net
     RIO
-  DICTIONARY_OPTIONS
-    ${extra_dictionary_opts}
 )
 
 target_include_directories(RSQLite PUBLIC ${SQLITE_INCLUDE_DIR})

--- a/sql/sqlite/inc/TSQLiteResult.h
+++ b/sql/sqlite/inc/TSQLiteResult.h
@@ -14,7 +14,7 @@
 
 #include "TSQLResult.h"
 
-#include <sqlite3.h>
+class sqlite3_stmt;
 
 class TSQLiteResult : public TSQLResult {
 

--- a/sql/sqlite/inc/TSQLiteRow.h
+++ b/sql/sqlite/inc/TSQLiteRow.h
@@ -14,7 +14,7 @@
 
 #include "TSQLRow.h"
 
-#include <sqlite3.h>
+class sqlite3_stmt;
 
 class TSQLiteRow : public TSQLRow {
 

--- a/sql/sqlite/inc/TSQLiteServer.h
+++ b/sql/sqlite/inc/TSQLiteServer.h
@@ -14,7 +14,7 @@
 
 #include "TSQLServer.h"
 
-#include <sqlite3.h>
+class sqlite3;
 
 class TSQLiteServer : public TSQLServer {
 

--- a/sql/sqlite/inc/TSQLiteStatement.h
+++ b/sql/sqlite/inc/TSQLiteStatement.h
@@ -14,7 +14,8 @@
 
 #include "TSQLStatement.h"
 
-#include <sqlite3.h>
+class sqlite3;
+class sqlite3_stmt;
 
 struct SQLite3_Stmt_t {
    sqlite3      *fConn;

--- a/sql/sqlite/src/TSQLiteResult.cxx
+++ b/sql/sqlite/src/TSQLiteResult.cxx
@@ -12,6 +12,8 @@
 #include "TSQLiteResult.h"
 #include "TSQLiteRow.h"
 
+#include <sqlite3.h>
+
 ClassImp(TSQLiteResult);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sql/sqlite/src/TSQLiteServer.cxx
+++ b/sql/sqlite/src/TSQLiteServer.cxx
@@ -17,6 +17,8 @@
 #include "TSQLTableInfo.h"
 #include "TSQLRow.h"
 
+#include <sqlite3.h>
+
 ClassImp(TSQLiteServer);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sql/sqlite/src/TSQLiteStatement.cxx
+++ b/sql/sqlite/src/TSQLiteStatement.cxx
@@ -23,6 +23,8 @@
 #include "TDatime.h"
 #include "TTimeStamp.h"
 
+#include <sqlite3.h>
+
 #include <stdlib.h>
 
 ClassImp(TSQLiteStatement);


### PR DESCRIPTION
This allows the dictionary to be independent on the SQLite3 module on OSX which is built implicitly and needs control over its invalidation.