### PR TITLE
Fix ROOT-9240 by preventing TMapFile::WhichMapFile from initializing TROOT

### DIFF
--- a/io/io/src/TMapFile.cxx
+++ b/io/io/src/TMapFile.cxx
@@ -1233,9 +1233,12 @@ void TMapFile::operator delete(void *ptr)
 
 TMapFile *TMapFile::WhichMapFile(void *addr)
 {
-   if (!gROOT || !gROOT->GetListOfMappedFiles()) return 0;
+   // Don't use gROOT so that this routine does not trigger TROOT's initialization
+   // This is essentially since this routine is called via operator delete
+   // which is used during RegisterModule (i.e. during library loading).
+   if (!ROOT::Internal::gROOTLocal || !ROOT::Internal::gROOTLocal->GetListOfMappedFiles()) return 0;
 
-   TObjLink *lnk = ((TList *)gROOT->GetListOfMappedFiles())->LastLink();
+   TObjLink *lnk = ((TList *)ROOT::Internal::gROOTLocal->GetListOfMappedFiles())->LastLink();
    while (lnk) {
       TMapFile *mf = (TMapFile*)lnk->GetObject();
       if (!mf) return 0;

--- a/io/io/src/TMapFile.cxx
+++ b/io/io/src/TMapFile.cxx
@@ -1234,8 +1234,10 @@ void TMapFile::operator delete(void *ptr)
 TMapFile *TMapFile::WhichMapFile(void *addr)
 {
    // Don't use gROOT so that this routine does not trigger TROOT's initialization
-   // This is essentially since this routine is called via operator delete
-   // which is used during RegisterModule (i.e. during library loading).
+   // This is essential since this routine is called via operator delete
+   // which is used during RegisterModule (i.e. during library loading, including the initial
+   // start up).  Using gROOT leads to recursive call to RegisterModule and initiliaztion of
+   // the interpreter in the middle of the execution of RegisterModule (i.e. undefined behavior).
    if (!ROOT::Internal::gROOTLocal || !ROOT::Internal::gROOTLocal->GetListOfMappedFiles()) return 0;
 
    TObjLink *lnk = ((TList *)ROOT::Internal::gROOTLocal->GetListOfMappedFiles())->LastLink();


### PR DESCRIPTION


TMapFile::WhichMapFile is called via operator delete which is used during RegisterModule
and letting TMapFile::WhichMapFile trigger the initialization of the TROOT object means that
  a) RegisterModule will have nested called to RegisterModule
  b) The interpreter will be created in the middle of the execution of RegisterModule.

Both are potentially fatal (i.e. undefined behavior).