### PR TITLE
Remove obsolete compatibility layers from TError

### DIFF
--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -72,8 +72,7 @@ void MinimalErrorHandler(int level, Bool_t abort, const char *location, const ch
 typedef void (*ErrorHandlerFunc_t)(int level, Bool_t abort, const char *location,
               const char *msg);
 
-extern "C" void ErrorHandler(int level, const char *location, const char *fmt,
-                             std::va_list va);
+extern "C" void ErrorHandler(int level, const char *location, const char *fmt, std::va_list va);
 
 extern void DefaultErrorHandler(int level, Bool_t abort, const char *location,
                                 const char *msg);

--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -73,7 +73,7 @@ typedef void (*ErrorHandlerFunc_t)(int level, Bool_t abort, const char *location
               const char *msg);
 
 extern "C" void ErrorHandler(int level, const char *location, const char *fmt,
-                             va_list va);
+                             std::va_list va);
 
 extern void DefaultErrorHandler(int level, Bool_t abort, const char *location,
                                 const char *msg);

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -111,7 +111,7 @@ ErrorHandlerFunc_t GetErrorHandler()
 void ErrorHandler(Int_t level, const char *location, const char *fmt, std::va_list ap)
 {
    thread_local Int_t buf_size(256);
-   thread_local char* buf_storage(0);
+   thread_local char *buf_storage(nullptr);
 
    char small_buf[256];
    char *buf = buf_storage ? buf_storage : small_buf;
@@ -130,7 +130,7 @@ again:
 
    Int_t n = vsnprintf(buf, buf_size, fmt, ap);
    if (n >= buf_size) {
-      buf_size = n+1;
+      buf_size = n + 1;
       if (buf != &(small_buf[0])) delete [] buf;
       buf = 0;
       va_end(ap);

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -22,7 +22,6 @@ to be replaced by the proper DefaultErrorHandler()
 
 #include "Varargs.h"
 #include "TError.h"
-#include "ThreadLocalStorage.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -111,8 +110,8 @@ ErrorHandlerFunc_t GetErrorHandler()
 
 void ErrorHandler(Int_t level, const char *location, const char *fmt, va_list ap)
 {
-   TTHREAD_TLS(Int_t) buf_size(256);
-   TTHREAD_TLS(char*) buf_storage(0);
+   thread_local Int_t buf_size(256);
+   thread_local char* buf_storage(0);
 
    char small_buf[256];
    char *buf = buf_storage ? buf_storage : small_buf;

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -20,7 +20,6 @@ errorhandler function. Initially the MinimalErrorHandler, which is supposed
 to be replaced by the proper DefaultErrorHandler()
 */
 
-#include "snprintf.h"
 #include "Varargs.h"
 #include "TError.h"
 #include "ThreadLocalStorage.h"
@@ -131,13 +130,8 @@ again:
       fmt = "no error message provided";
 
    Int_t n = vsnprintf(buf, buf_size, fmt, ap);
-   // old vsnprintf's return -1 if string is truncated new ones return
-   // total number of characters that would have been written
-   if (n == -1 || n >= buf_size) {
-      if (n == -1)
-         buf_size *= 2;
-      else
-         buf_size = n+1;
+   if (n >= buf_size) {
+      buf_size = n+1;
       if (buf != &(small_buf[0])) delete [] buf;
       buf = 0;
       va_end(ap);

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -20,9 +20,9 @@ errorhandler function. Initially the MinimalErrorHandler, which is supposed
 to be replaced by the proper DefaultErrorHandler()
 */
 
-#include "Varargs.h"
 #include "TError.h"
 
+#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <cerrno>
@@ -108,7 +108,7 @@ ErrorHandlerFunc_t GetErrorHandler()
 ////////////////////////////////////////////////////////////////////////////////
 /// General error handler function. It calls the user set error handler.
 
-void ErrorHandler(Int_t level, const char *location, const char *fmt, va_list ap)
+void ErrorHandler(Int_t level, const char *location, const char *fmt, std::va_list ap)
 {
    thread_local Int_t buf_size(256);
    thread_local char* buf_storage(0);
@@ -117,8 +117,8 @@ void ErrorHandler(Int_t level, const char *location, const char *fmt, va_list ap
    char *buf = buf_storage ? buf_storage : small_buf;
 
    int vc = 0;
-   va_list sap;
-   R__VA_COPY(sap, ap);
+   std::va_list sap;
+   va_copy(sap, ap);
 
 again:
    if (!buf) {
@@ -134,7 +134,7 @@ again:
       if (buf != &(small_buf[0])) delete [] buf;
       buf = 0;
       va_end(ap);
-      R__VA_COPY(ap, sap);
+      va_copy(ap, sap);
       vc = 1;
       goto again;
    }
@@ -189,55 +189,55 @@ void Obsolete(const char *function, const char *asOfVers, const char *removedFro
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function in case an error occurred.
 
-void Error(const char *location, const char *va_(fmt), ...)
+void Error(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kError, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kError, location, fmt, ap);
    va_end(ap);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function in case a system (OS or GUI) related error occurred.
 
-void SysError(const char *location, const char *va_(fmt), ...)
+void SysError(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap, va_(fmt));
-   ErrorHandler(kSysError, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kSysError, location, fmt, ap);
    va_end(ap);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function in case an error occurred.
 
-void Break(const char *location, const char *va_(fmt), ...)
+void Break(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kBreak, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kBreak, location, fmt, ap);
    va_end(ap);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function for informational messages.
 
-void Info(const char *location, const char *va_(fmt), ...)
+void Info(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kInfo, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kInfo, location, fmt, ap);
    va_end(ap);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function in warning situations.
 
-void Warning(const char *location, const char *va_(fmt), ...)
+void Warning(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kWarning, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kWarning, location, fmt, ap);
    va_end(ap);
 }
 
@@ -247,10 +247,10 @@ void Warning(const char *location, const char *va_(fmt), ...)
 // Fatal() *might* not abort the program (if gAbortLevel > kFatal) - but for all
 // reasonable settings it *will* abort. So let's be reasonable wrt Coverity:
 // coverity[+kill]
-void Fatal(const char *location, const char *va_(fmt), ...)
+void Fatal(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kFatal, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kFatal, location, fmt, ap);
    va_end(ap);
 }

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -116,31 +116,26 @@ void ErrorHandler(Int_t level, const char *location, const char *fmt, std::va_li
    char small_buf[256];
    char *buf = buf_storage ? buf_storage : small_buf;
 
-   int vc = 0;
-   std::va_list sap;
-   va_copy(sap, ap);
-
-again:
-   if (!buf) {
-      buf_storage = buf = new char[buf_size];
-   }
+   std::va_list ap_copy;
+   va_copy(ap_copy, ap);
 
    if (!fmt)
       fmt = "no error message provided";
 
-   Int_t n = vsnprintf(buf, buf_size, fmt, ap);
+   Int_t n = vsnprintf(buf, buf_size, fmt, ap_copy);
    if (n >= buf_size) {
+      va_end(ap_copy);
+
       buf_size = n + 1;
-      if (buf != &(small_buf[0])) delete [] buf;
-      buf = 0;
-      va_end(ap);
-      va_copy(ap, sap);
-      vc = 1;
-      goto again;
+      if (buf != &(small_buf[0]))
+         delete[] buf;
+      buf = new char[buf_size];
+
+      // Try again with a sufficiently large buffer
+      va_copy(ap_copy, ap);
+      vsnprintf(buf, buf_size, fmt, ap_copy);
    }
-   va_end(sap);
-   if (vc)
-      va_end(ap);
+   va_end(ap_copy);
 
    std::string bp = buf;
    if (level >= kSysError && level < kFatal) {

--- a/core/base/test/TErrorTests.cxx
+++ b/core/base/test/TErrorTests.cxx
@@ -41,3 +41,13 @@ TEST(TError, Basics) {
    SysError("location", "message");
    EXPECT_STREQ("message (errno: 42)", gTestLastMsg.c_str());
 }
+
+
+TEST(TError, LongMessage) {
+   SetErrorHandler(TestErrorHandler);
+   std::string longMessage(10000, 'X');
+   EXPECT_EQ(10000U, longMessage.length());
+
+   Info("location", longMessage.c_str());
+   EXPECT_EQ(longMessage, gTestLastMsg);
+}

--- a/core/base/test/TErrorTests.cxx
+++ b/core/base/test/TErrorTests.cxx
@@ -48,6 +48,6 @@ TEST(TError, LongMessage) {
    std::string longMessage(10000, 'X');
    EXPECT_EQ(10000U, longMessage.length());
 
-   Info("location", longMessage.c_str());
+   Info("location", "%s", longMessage.c_str());
    EXPECT_EQ(longMessage, gTestLastMsg);
 }


### PR DESCRIPTION
Replaces a few infrastructure bits that have ROOT internal compatibility layers with C++ standard facilities.  Namely:

- `[v]snprintf`
- thread local storage
- varargs