### PR TITLE
Tree:Fix ROOT-10829. Avoid using deleted object.

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -7845,27 +7845,27 @@ Long64_t TTree::ReadStream(std::istream& inputStream, const char *branchDescript
 void TTree::RecursiveRemove(TObject *obj)
 {
    if (obj == fEventList) {
-      fEventList = 0;
+      fEventList = nullptr;
    }
    if (obj == fEntryList) {
-      fEntryList = 0;
+      fEntryList = nullptr;
    }
    if (fUserInfo) {
       fUserInfo->RecursiveRemove(obj);
    }
    if (fPlayer == obj) {
-      fPlayer = 0;
+      fPlayer = nullptr;
    }
    if (fTreeIndex == obj) {
-      fTreeIndex = 0;
+      fTreeIndex = nullptr;
    }
    if (fAliases == obj) {
-      fAliases = 0;
+      fAliases = nullptr;
    } else if (fAliases) {
       fAliases->RecursiveRemove(obj);
    }
    if (fFriends == obj) {
-      fFriends = 0;
+      fFriends = nullptr;
    } else if (fFriends) {
       fFriends->RecursiveRemove(obj);
    }

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -7859,10 +7859,14 @@ void TTree::RecursiveRemove(TObject *obj)
    if (fTreeIndex == obj) {
       fTreeIndex = 0;
    }
-   if (fAliases) {
+   if (fAliases == obj) {
+      fAliases = 0;
+   } else if (fAliases) {
       fAliases->RecursiveRemove(obj);
    }
-   if (fFriends) {
+   if (fFriends == obj) {
+      fFriends = 0;
+   } else if (fFriends) {
       fFriends->RecursiveRemove(obj);
    }
 }


### PR DESCRIPTION
When deleting a TTree, we delete the list of friends and aliases.  Their deletion is broadcasted
through RecursiveRemove which eventually reached back to the original TTree.
And if TTree::RecursiveRemove then tries to call RecursiveRemove on those deleted list ... then
disaster follows ... in the form of:

```
pure virtual method called
terminate called without an active exception
Aborted (core dumped)
```