### PR TITLE
[MetaCling][ROOT-10872] Apply cppyy patch

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -494,9 +494,23 @@ void TClingCallFunc::make_narg_call(const std::string &return_type, const unsign
          callbuf << "*(" << type_name.c_str() << "**)args["
                  << i << "]";
       } else {
-         // pointer falls back to non-pointer case; the argument preserves
-         // the "pointerness" (i.e. doesn't reference the value).
-         callbuf << "*(" << type_name.c_str() << "*)args[" << i << "]";
+         // By-value construction; this may either copy or move, but there is no
+         // information here in terms of intent. Thus, simply assume that the intent
+         // is to move if there is no viable copy constructor (ie. if the code would
+         // otherwise fail to even compile).
+
+         // There does not appear to be a simple way of determining whether a viable
+         // copy constructor exists, so check for the most common case: the trivial
+         // one, but not uniquely available, while there is a move constructor.
+         CXXRecordDecl* rtdecl = QT->getAsCXXRecordDecl();
+         if (rtdecl && (rtdecl->hasTrivialCopyConstructor() && !rtdecl->hasSimpleCopyConstructor()) \
+               && rtdecl->hasMoveConstructor()) {
+            // move construction as needed for classes (note that this is implicit)
+            callbuf << "std::move(*(" << type_name.c_str() << "*)args[" << i << "])";
+         } else {
+            // otherwise, and for builtins, use copy construction of temporary*/
+            callbuf << "*(" << type_name.c_str() << "*)args[" << i << "]";
+         }
       }
    }
    callbuf << ")";

--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -482,6 +482,10 @@ long TClingMethodInfo::Property() const
    long property = 0L;
    property |= kIsCompiled;
    const clang::FunctionDecl *fd = GetMethodDecl();
+
+   if (fd->isDeleted())
+      return 0L;
+
    if (fd->isConstexpr())
       property |= kIsConstexpr;
    switch (fd->getAccess()) {
@@ -545,6 +549,8 @@ long TClingMethodInfo::ExtraProperty() const
    }
    long property = 0;
    const clang::FunctionDecl *fd = GetMethodDecl();
+   if (fd->isDeleted())
+      return 0L;
    if (fd->isOverloadedOperator())
       property |= kIsOperator;
    if (llvm::isa<clang::CXXConversionDecl>(fd))


### PR DESCRIPTION
This fix corresponds to a cppyy patch for MetaCling:

https://bitbucket.org/wlav/cppyy-backend/src/dfb9f7a46d7b703325179deea193bb1eb823728e/cling/patches/nodeleted.diff

Drops properties of deleted methods and chooses move in wrapper generator if no copy available.