### PR TITLE
Provide more draw options for RH1/RH2 classes

### DIFF
--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -27,6 +27,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RAttrMarker.hxx
     ROOT/RAttrMargins.hxx
     ROOT/RAttrText.hxx
+    ROOT/RAttrValue.hxx
     ROOT/RPalette.hxx
     ROOT/RPaletteDrawable.hxx
     ROOT/RDrawable.hxx

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -14,15 +14,6 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class ROOT::Experimental::RAttrMap+;
-#pragma link C++ class ROOT::Experimental::RAttrMap::Value_t+;
-#pragma link C++ class ROOT::Experimental::RAttrMap::NoValue_t+;
-#pragma link C++ class ROOT::Experimental::RAttrMap::BoolValue_t+;
-#pragma link C++ class ROOT::Experimental::RAttrMap::IntValue_t+;
-#pragma link C++ class ROOT::Experimental::RAttrMap::DoubleValue_t+;
-#pragma link C++ class ROOT::Experimental::RAttrMap::StringValue_t+;
-#pragma link C++ class ROOT::Experimental::RAttrBase+;
-
 #pragma link C++ class ROOT::Experimental::RStyle+;
 #pragma link C++ class ROOT::Experimental::RStyle::Block_t+;
 
@@ -75,6 +66,20 @@
 #pragma link C++ class ROOT::Experimental::RCanvasDisplayItem+;
 
 #pragma read sourceClass="ROOT::Experimental::RCanvas" targetClass="ROOT::Experimental::RCanvas" source="" target="" code="{ newObj->ResolveSharedPtrs() ; }"
+
+#pragma link C++ class ROOT::Experimental::RAttrMap+;
+#pragma link C++ class ROOT::Experimental::RAttrMap::Value_t+;
+#pragma link C++ class ROOT::Experimental::RAttrMap::NoValue_t+;
+#pragma link C++ class ROOT::Experimental::RAttrMap::BoolValue_t+;
+#pragma link C++ class ROOT::Experimental::RAttrMap::IntValue_t+;
+#pragma link C++ class ROOT::Experimental::RAttrMap::DoubleValue_t+;
+#pragma link C++ class ROOT::Experimental::RAttrMap::StringValue_t+;
+#pragma link C++ class ROOT::Experimental::RAttrBase+;
+#pragma link C++ class ROOT::Experimental::RAttrValue<bool>+;
+#pragma link C++ class ROOT::Experimental::RAttrValue<int>+;
+#pragma link C++ class ROOT::Experimental::RAttrValue<double>+;
+#pragma link C++ class ROOT::Experimental::RAttrValue<std::string>+;
+#pragma link C++ class ROOT::Experimental::RAttrValue<ROOT::Experimental::RPadLength>+;
 
 #pragma link C++ class ROOT::Experimental::RColor+;
 #pragma link C++ class ROOT::Experimental::RAttrColor+;

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -12,6 +12,7 @@
 #include <ROOT/RAttrBase.hxx>
 #include <ROOT/RAttrLine.hxx>
 #include <ROOT/RAttrText.hxx>
+#include <ROOT/RAttrValue.hxx>
 
 namespace ROOT {
 namespace Experimental {
@@ -26,13 +27,19 @@ namespace Experimental {
 
 class RAttrAxis : public RAttrBase {
 
-   RAttrLine fAttrLine{this, "line_"};   ///<!  axis line attributes
-   RAttrText fAttrText{this, "text_"};   ///<!  axis text attributes
+   RAttrLine fAttrLine{this, "line_"};               ///<! line attributes
+   RAttrText fAttrText{this, "text_"};               ///<! text attributes
+   RAttrValue<double> fMin{this, "min", 0.};         ///<! axis min
+   RAttrValue<double> fMax{this, "max", 1.};         ///<! axis max
+   RAttrValue<double> fZoomMin{this, "zoommin", 0.}; ///<! axis zoom min
+   RAttrValue<double> fZoomMax{this, "zoommax", 0.}; ///<! axis zoom max
+   RAttrValue<bool> fLog{this, "log", false};        ///<! log scale
+   RAttrValue<bool> fInvert{this, "invert", false};  ///<! invert scale
 
    R__ATTR_CLASS(RAttrAxis, "axis_", AddDefaults(fAttrLine).AddDefaults(fAttrText)
-                                   .AddDouble("min", 0.).AddDouble("max", 1.)
-                                   .AddDouble("zoommin", 0.).AddDouble("zoommax", 0.)
-                                   .AddBool("log", false).AddBool("invert", false));
+                                    .AddDefaults(fMin).AddDefaults(fMax)
+                                    .AddDefaults(fZoomMin).AddDefaults(fZoomMax)
+                                    .AddDefaults(fLog).AddDefaults(fInvert));
 
    const RAttrLine &GetAttrLine() const { return fAttrLine; }
    RAttrAxis &SetAttrLine(const RAttrLine &line) { fAttrLine = line; return *this; }
@@ -43,32 +50,31 @@ class RAttrAxis : public RAttrBase {
    RAttrText &AttrText() { return fAttrText; }
 
    // min range, graphics will not show value less then this
-   RAttrAxis &SetMin(double min) { SetValue("min", min); return *this; }
-   RAttrAxis &SetMax(double max) { SetValue("max", max); return *this; }
-   double GetMin() const { return GetValue<double>("min"); }
-   double GetMax() const { return GetValue<double>("max"); }
-   bool HasMin() const { return HasValue<double>("min"); }
-   bool HasMax() const { return HasValue<double>("max"); }
+   RAttrAxis &SetMin(double min) { fMin = min; return *this; }
+   RAttrAxis &SetMax(double max) { fMax = max; return *this; }
+   double GetMin() const { return fMin; }
+   double GetMax() const { return fMax; }
+   bool HasMin() const { return fMin.Has(); }
+   bool HasMax() const { return fMax.Has(); }
 
    RAttrAxis &SetMinMax(double min, double max) { SetMin(min); SetMax(max); return *this; }
-   void ClearMinMax() { ClearValue("min"); ClearValue("max"); }
+   void ClearMinMax() { fMin.Clear(); fMax.Clear(); }
 
-   RAttrAxis &SetZoomMin(double min) { SetValue("zoommin", min); return *this; }
-   RAttrAxis &SetZoomMax(double max) { SetValue("zoommax", max); return *this; }
-   double GetZoomMin() const { return GetValue<double>("zoommin"); }
-   double GetZoomMax() const { return GetValue<double>("zoommax"); }
-   bool HasZoomMin() const { return HasValue<double>("zoommin"); }
-   bool HasZoomMax() const { return HasValue<double>("zoommax"); }
+   RAttrAxis &SetZoomMin(double min) { fZoomMin = min; return *this; }
+   RAttrAxis &SetZoomMax(double max) { fZoomMax = max; return *this; }
+   double GetZoomMin() const { return fZoomMin; }
+   double GetZoomMax() const { return fZoomMax; }
+   bool HasZoomMin() const { return fZoomMin.Has(); }
+   bool HasZoomMax() const { return fZoomMax.Has(); }
 
    RAttrAxis &SetZoomMinMax(double min, double max) { SetZoomMin(min); SetZoomMax(max); return *this; }
-   void ClearZoomMinMax() { ClearValue("zoommin"); ClearValue("zoommax"); }
+   void ClearZoomMinMax() { fZoomMin.Clear(); fZoomMax.Clear(); }
 
-   RAttrAxis &SetLog(bool on = true) { SetValue("log", on); return *this; }
-   bool GetLog() const { return GetValue<bool>("log"); }
+   RAttrAxis &SetLog(bool on = true) { fLog = on; return *this; }
+   bool GetLog() const { return fLog; }
 
-   RAttrAxis &SetInvert(bool on = true) { SetValue("invert", on); return *this; }
-   bool GetInvert() const { return GetValue<bool>("invert"); }
-
+   RAttrAxis &SetInvert(bool on = true) { fInvert = on; return *this; }
+   bool GetInvert() const { return fInvert; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -27,14 +27,14 @@ namespace Experimental {
 
 class RAttrAxis : public RAttrBase {
 
-   RAttrLine fAttrLine{this, "line_"};               ///<! line attributes
-   RAttrText fAttrText{this, "text_"};               ///<! text attributes
-   RAttrValue<double> fMin{this, "min", 0.};         ///<! axis min
-   RAttrValue<double> fMax{this, "max", 1.};         ///<! axis max
-   RAttrValue<double> fZoomMin{this, "zoommin", 0.}; ///<! axis zoom min
-   RAttrValue<double> fZoomMax{this, "zoommax", 0.}; ///<! axis zoom max
-   RAttrValue<bool> fLog{this, "log", false};        ///<! log scale
-   RAttrValue<bool> fInvert{this, "invert", false};  ///<! invert scale
+   RAttrLine            fAttrLine{this, "line_"};        ///<! line attributes
+   RAttrText            fAttrText{this, "text_"};        ///<! text attributes
+   RAttrValue<double>   fMin{this, "min", 0.};           ///<! axis min
+   RAttrValue<double>   fMax{this, "max", 1.};           ///<! axis max
+   RAttrValue<double>   fZoomMin{this, "zoommin", 0.};   ///<! axis zoom min
+   RAttrValue<double>   fZoomMax{this, "zoommax", 0.};   ///<! axis zoom max
+   RAttrValue<bool>     fLog{this, "log", false};        ///<! log scale
+   RAttrValue<bool>     fInvert{this, "invert", false};  ///<! invert scale
 
    R__ATTR_CLASS(RAttrAxis, "axis_", AddDefaults(fAttrLine).AddDefaults(fAttrText)
                                     .AddDefaults(fMin).AddDefaults(fMax)

--- a/graf2d/gpadv7/inc/ROOT/RAttrBox.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBox.hxx
@@ -26,8 +26,8 @@ namespace Experimental {
 
 class RAttrBox : public RAttrBase {
 
-   RAttrLine fAttrBorder{this, "border_"};   ///<!
-   RAttrFill fAttrFill{this, "fill_"};       ///<!
+   RAttrLine    fAttrBorder{this, "border_"};   ///<! box line attributes
+   RAttrFill    fAttrFill{this, "fill_"};       ///<! box fill attributes
 
    R__ATTR_CLASS(RAttrBox, "box_", AddDefaults(fAttrBorder).AddDefaults(fAttrFill));
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
@@ -88,7 +88,6 @@ public:
       }
 
       return *this;
-
    }
 
    /** Extract RColor for given attribute */

--- a/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
@@ -11,6 +11,7 @@
 
 #include <ROOT/RAttrBase.hxx>
 #include <ROOT/RAttrColor.hxx>
+#include <ROOT/RAttrValue.hxx>
 
 namespace ROOT {
 namespace Experimental {
@@ -25,13 +26,14 @@ namespace Experimental {
 
 class RAttrFill : public RAttrBase {
 
-   RAttrColor fColor{this, "color_"}; ///<! fill color, will access container from fill attributes
+   RAttrColor       fColor{this, "color_"};    ///<! fill color
+   RAttrValue<int>  fStyle{this, "style", 1};  ///<! fill style
 
-   R__ATTR_CLASS(RAttrFill, "fill_", AddInt("style", 1).AddDefaults(fColor));
+   R__ATTR_CLASS(RAttrFill, "fill_", AddDefaults(fColor).AddDefaults(fStyle));
 
    ///The fill style
-   RAttrFill &SetStyle(int style) { SetValue("style", style); return *this; }
-   int GetStyle() const { return GetValue<int>("style"); }
+   RAttrFill &SetStyle(int style) { fStyle = style; return *this; }
+   int GetStyle() const { return fStyle; }
 
    ///The fill color
    RAttrFill &SetColor(const RColor &color) { fColor = color; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
@@ -11,6 +11,7 @@
 
 #include <ROOT/RAttrBase.hxx>
 #include <ROOT/RAttrColor.hxx>
+#include <ROOT/RAttrValue.hxx>
 
 namespace ROOT {
 namespace Experimental {
@@ -25,22 +26,19 @@ namespace Experimental {
 
 class RAttrLine : public RAttrBase {
 
-   RAttrColor fColor{this, "color_"}; ///<! line color, will access container from line attributes
+   RAttrColor          fColor{this, "color_"};     ///<! line color
+   RAttrValue<double>  fWidth{this, "width", 1.};  ///<! line width
+   RAttrValue<int>     fStyle{this, "style", 1};   ///<! line style
 
-   R__ATTR_CLASS(RAttrLine, "line_", AddDouble("width", 1.).AddInt("style", 1).AddDefaults(fColor));
-
-   // keep it here, it is minimal set of methods which should be reimplemented
-   // using RAttrBase::RAttrBase;
-   // RAttrLine(const RAttrLine &src) : RAttrLine() { src.CopyTo(*this); }
-   // RAttrLine &operator=(const RAttrLine &src) { Clear(); src.CopyTo(*this); return *this; }
+   R__ATTR_CLASS(RAttrLine, "line_", AddDefaults(fColor).AddDefaults(fWidth).AddDefaults(fStyle));
 
    ///The width of the line.
-   RAttrLine &SetWidth(double width) { SetValue("width", width); return *this; }
-   double GetWidth() const { return GetValue<double>("width"); }
+   RAttrLine &SetWidth(double width) { fWidth = width; return *this; }
+   double GetWidth() const { return fWidth; }
 
    ///The style of the line.
-   RAttrLine &SetStyle(int style) { SetValue("style", style); return *this; }
-   int GetStyle() const { return GetValue<int>("style"); }
+   RAttrLine &SetStyle(int style) { fStyle = style; return *this; }
+   int GetStyle() const { return fStyle; }
 
    ///The color of the line.
    RAttrLine &SetColor(const RColor &color) { fColor = color; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
@@ -153,7 +153,6 @@ public:
       return *this;
    }
    RAttrMap &AddDefaults(const RAttrBase &vis);
-   RAttrMap &AddNothing() { return *this; }
 
    RAttrMap &AddValue(const std::string &name, bool value) { return AddBool(name, value); }
    RAttrMap &AddValue(const std::string &name, int value) { return AddInt(name, value); }

--- a/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
@@ -147,6 +147,12 @@ public:
    RAttrMap &AddPadLength(const std::string &name, const RPadLength &value) { m[name] = std::make_unique<StringValue_t>(value.AsString()); return *this; }
    RAttrMap &AddDefaults(const RAttrBase &vis);
 
+   RAttrMap &AddValue(const std::string &name, bool value) { return AddBool(name, value); }
+   RAttrMap &AddValue(const std::string &name, int value) { return AddInt(name, value); }
+   RAttrMap &AddValue(const std::string &name, double value) { return AddDouble(name, value); }
+   RAttrMap &AddValue(const std::string &name, const std::string &value) { return AddString(name, value); }
+   RAttrMap &AddValue(const std::string &name, const RPadLength &value) { return AddPadLength(name, value); }
+
    RAttrMap(const RAttrMap &src)
    {
       for (const auto &pair : src.m)

--- a/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMap.hxx
@@ -144,8 +144,16 @@ public:
    RAttrMap &AddInt(const std::string &name, int value) { m[name] = std::make_unique<IntValue_t>(value); return *this; }
    RAttrMap &AddDouble(const std::string &name, double value) { m[name] = std::make_unique<DoubleValue_t>(value); return *this; }
    RAttrMap &AddString(const std::string &name, const std::string &value) { m[name] = std::make_unique<StringValue_t>(value); return *this; }
-   RAttrMap &AddPadLength(const std::string &name, const RPadLength &value) { m[name] = std::make_unique<StringValue_t>(value.AsString()); return *this; }
+   RAttrMap &AddPadLength(const std::string &name, const RPadLength &value)
+   {
+      if (value.Empty())
+         Clear(name);
+      else
+         m[name] = std::make_unique<StringValue_t>(value.AsString());
+      return *this;
+   }
    RAttrMap &AddDefaults(const RAttrBase &vis);
+   RAttrMap &AddNothing() { return *this; }
 
    RAttrMap &AddValue(const std::string &name, bool value) { return AddBool(name, value); }
    RAttrMap &AddValue(const std::string &name, int value) { return AddInt(name, value); }

--- a/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
@@ -10,6 +10,7 @@
 #define ROOT7_RAttrMargins
 
 #include <ROOT/RAttrBase.hxx>
+#include <ROOT/RAttrValue.hxx>
 #include <ROOT/RPadLength.hxx>
 
 namespace ROOT {
@@ -24,45 +25,27 @@ namespace Experimental {
 */
 
 class RAttrMargins : public RAttrBase {
-
-   R__ATTR_CLASS(RAttrMargins, "margin_", AddString("left","").AddString("right","").AddString("top","").AddString("bottom",""));
-
-   RAttrMargins &SetLeft(const RPadLength &pos) { return SetMargin("left", pos); }
-   RPadLength GetLeft() const { return GetMargin("left"); }
-
-   RAttrMargins &SetRight(const RPadLength &pos) { return SetMargin("right", pos); }
-   RPadLength GetRight() const { return GetMargin("right"); }
-
-   RAttrMargins &SetTop(const RPadLength &pos) { return SetMargin("top", pos); }
-   RPadLength GetTop() const { return GetMargin("top"); }
-
-   RAttrMargins &SetBottom(const RPadLength &pos) { return SetMargin("bottom", pos); }
-   RPadLength GetBottom() const { return GetMargin("bottom"); }
+   R__ATTR_CLASS(RAttrMargins, "margin_", AddNothing());
 
 protected:
+   RAttrValue<RPadLength> fLeft{this, "left", 0._normal};
+   RAttrValue<RPadLength> fRight{this, "right", 0._normal};
+   RAttrValue<RPadLength> fTop{this, "top", 0._normal};
+   RAttrValue<RPadLength> fBottom{this, "bottom", 0._normal};
 
-   RAttrMargins &SetMargin(const std::string &name, const RPadLength &pos)
-   {
-      if (pos.Empty())
-         ClearValue(name);
-      else
-         SetValue(name, pos.AsString());
+public:
 
-      return *this;
-   }
+   RAttrMargins &SetLeft(const RPadLength &len) { fLeft = len; return *this; }
+   RPadLength GetLeft() const { return fLeft; }
 
-   RPadLength GetMargin(const std::string &name) const
-   {
-      RPadLength res;
+   RAttrMargins &SetRight(const RPadLength &len) { fRight = len; return *this; }
+   RPadLength GetRight() const { return fRight; }
 
-      auto value = GetValue<std::string>(name);
+   RAttrMargins &SetTop(const RPadLength &len) { fTop = len; return *this; }
+   RPadLength GetTop() const { return fTop; }
 
-      if (!value.empty())
-         res.ParseString(value);
-
-      return res;
-   }
-
+   RAttrMargins &SetBottom(const RPadLength &len) { fBottom = len; return *this; }
+   RPadLength GetBottom() const { return fBottom; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
@@ -25,13 +25,13 @@ namespace Experimental {
 */
 
 class RAttrMargins : public RAttrBase {
-   R__ATTR_CLASS(RAttrMargins, "margin_", AddNothing());
 
-protected:
-   RAttrValue<RPadLength> fLeft{this, "left", 0._normal};
-   RAttrValue<RPadLength> fRight{this, "right", 0._normal};
-   RAttrValue<RPadLength> fTop{this, "top", 0._normal};
-   RAttrValue<RPadLength> fBottom{this, "bottom", 0._normal};
+   RAttrValue<RPadLength>   fLeft{this, "left", 0._normal};
+   RAttrValue<RPadLength>   fRight{this, "right", 0._normal};
+   RAttrValue<RPadLength>   fTop{this, "top", 0._normal};
+   RAttrValue<RPadLength>   fBottom{this, "bottom", 0._normal};
+
+   R__ATTR_CLASS(RAttrMargins, "margin_", AddDefaults(fLeft).AddDefaults(fRight).AddDefaults(fTop).AddDefaults(fBottom));
 
 public:
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
@@ -11,13 +11,14 @@
 
 #include <ROOT/RAttrBase.hxx>
 #include <ROOT/RAttrColor.hxx>
+#include <ROOT/RAttrValue.hxx>
 
 namespace ROOT {
 namespace Experimental {
 
 /** \class RAttrMarker
 \ingroup GpadROOT7
-\author Axel Naumann <axel@cern.ch>
+\authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
 \date 2018-10-12
 \brief A marker attributes.
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
@@ -25,21 +26,24 @@ namespace Experimental {
 
 class RAttrMarker : public RAttrBase {
 
-   RAttrColor fColor{this, "color_"}; ///<! marker color, will access container from line attributes
+   RAttrColor           fColor{this, "color_"};     ///<! marker color
+   RAttrValue<double>   fSize{this, "size", 1.};    ///<! marker size
+   RAttrValue<int>      fStyle{this, "style", 1};   ///<! marker style
 
-   R__ATTR_CLASS(RAttrMarker, "marker_", AddDouble("size", 1.).AddInt("style", 1).AddDefaults(fColor));
+   R__ATTR_CLASS(RAttrMarker, "marker_", AddDefaults(fColor).AddDefaults(fSize).AddDefaults(fStyle));
 
    RAttrMarker &SetColor(const RColor &color) { fColor = color; return *this; }
    RColor GetColor() const { return fColor.GetColor(); }
    RAttrColor &AttrColor() { return fColor; }
 
    /// The size of the marker.
-   RAttrMarker &SetSize(float size) { SetValue("size", size); return *this; }
-   float GetSize() const { return GetValue<double>("size"); }
+   RAttrMarker &SetSize(double size) { fSize = size; return *this; }
+   double GetSize() const { return fSize; }
 
    /// The style of the marker.
-   RAttrMarker &SetStyle(int style) { SetValue("style", style); return *this; }
-   int GetStyle() const { return GetValue<int>("style"); }
+   RAttrMarker &SetStyle(int style) { fStyle = style; return *this; }
+   int GetStyle() const { return fStyle; }
+
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -13,41 +13,42 @@
 #include <ROOT/RAttrValue.hxx>
 #include <ROOT/RAttrColor.hxx>
 
-#include <string>
-
 namespace ROOT {
 namespace Experimental {
 
 /** \class RAttrText
 \ingroup GpadROOT7
 \brief A text.attributes.
-\author Axel Naumann <axel@cern.ch>
+\authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
 \date 2018-10-12
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-
 class RAttrText : public RAttrBase {
 
-   RAttrColor fColor{this, "color_"}; ///<! text color, will access container from text attributes
+   RAttrColor           fColor{this, "color_"};       ///<! text color
+   RAttrValue<double>   fSize{this, "size", 12.};     ///<! text size
+   RAttrValue<double>   fAngle{this, "angle", 0.};    ///<! text angle
+   RAttrValue<int>      fAlign{this, "align", 22};    ///<! text align
+   RAttrValue<int>      fFont{this, "font", 41};      ///<! text font
 
-   R__ATTR_CLASS(RAttrText, "text_", AddDouble("size", 12.).AddDouble("angle", 0.).AddInt("align", 22).AddInt("font", 41).AddDefaults(fColor));
+   R__ATTR_CLASS(RAttrText, "text_", AddDefaults(fColor).AddDefaults(fSize).AddDefaults(fAngle).AddDefaults(fAlign).AddDefaults(fFont));
 
    ///The text size
-   RAttrText &SetSize(double width) { SetValue("size", width); return *this; }
-   double GetSize() const { return GetValue<double>("size"); }
+   RAttrText &SetSize(double sz) { fSize = sz; return *this; }
+   double GetSize() const { return fSize; }
 
    ///The text angle
-   RAttrText &SetAngle(double angle) { SetValue("angle", angle); return *this; }
-   double GetAngle() const { return GetValue<double>("angle"); }
+   RAttrText &SetAngle(double angle) { fAngle = angle; return *this; }
+   double GetAngle() const { return fAngle; }
 
    ///The text alignment
-   RAttrText &SetAlign(int align) { SetValue("align", align); return *this; }
-   int GetAlign() const { return GetValue<int>("align"); }
+   RAttrText &SetAlign(int align) { fAlign = align; return *this; }
+   int GetAlign() const { return fAlign; }
 
    ///The text font
-   RAttrText &SetFont(int font) { SetValue("font", font); return *this; }
-   int GetFont() const { return GetValue<int>("font"); }
+   RAttrText &SetFont(int font) { fFont = font; return *this; }
+   int GetFont() const { return fFont; }
 
    ///The color of the text.
    RAttrText &SetColor(const RColor &color) { fColor = color; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -10,6 +10,7 @@
 #define ROOT7_RAttrText
 
 #include <ROOT/RAttrBase.hxx>
+#include <ROOT/RAttrValue.hxx>
 #include <ROOT/RAttrColor.hxx>
 
 #include <string>

--- a/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
@@ -49,6 +49,7 @@ public:
    void Set(const T &v) { SetValue("", v); }
    T Get() const { return GetValue<T>(""); }
    void Clear() { ClearValue(""); }
+   bool Has() const { return HasValue<T>(""); }
 
    RAttrValue &operator=(const T &v) { Set(v); return *this; }
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
@@ -26,6 +26,7 @@ namespace Experimental {
 template<typename T>
 class RAttrValue : public RAttrBase {
 protected:
+
    RAttrMap  fDefaults;    ///<!    map with default values
 
    const RAttrMap &GetDefaults() const override { return fDefaults; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
@@ -1,0 +1,61 @@
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RAttrValue
+#define ROOT7_RAttrValue
+
+#include <ROOT/RAttrBase.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+/** \class RAttrValue
+\ingroup GpadROOT7
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-06-24
+\brief Template class to access single value from drawable or other attributes
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+
+template<typename T>
+class RAttrValue : public RAttrBase {
+protected:
+   RAttrMap  fDefaults;    ///<!    map with default values
+
+   const RAttrMap &GetDefaults() const override { return fDefaults; }
+
+public:
+
+   RAttrValue() = default;
+
+   RAttrValue(RDrawable *drawable, const std::string &name, const T &dflt = T())
+   {
+      fDefaults.AddValue("", dflt);
+      AssignDrawable(drawable, name);
+   }
+
+   RAttrValue(RAttrBase *parent, const std::string &name, const T &dflt = T())
+   {
+      fDefaults.AddValue("", dflt);
+      AssignParent(parent, name);
+   }
+
+   void Set(const T &v) { SetValue("", v); }
+   T Get() const { return GetValue<T>(""); }
+   void Clear() { ClearValue(""); }
+
+   RAttrValue &operator=(const T &v) { Set(v); return *this; }
+
+   operator T() const { return Get(); }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_RAttrValue

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -120,15 +120,15 @@ public:
 
 private:
 
-   RAttrMargins fMargins{this, "margin_"};     ///<!
-   RAttrLine fAttrBorder{this, "border_"};     ///<!
-   RAttrFill fAttrFill{this, "fill_"};         ///<!
-   RAttrAxis fAttrX{this, "x_"};               ///<!
-   RAttrAxis fAttrY{this, "y_"};               ///<!
-   RAttrAxis fAttrZ{this, "z_"};               ///<!
-   RAttrValue<bool> fGridX{this, "gridx", false}; ///<!
-   RAttrValue<bool> fGridY{this, "gridy", false}; ///<!
-   std::map<unsigned, RUserRanges> fClientRanges; ///<! individual client ranges
+   RAttrMargins                     fMargins{this, "margin_"};        ///<!
+   RAttrLine                        fAttrBorder{this, "border_"};     ///<!
+   RAttrFill                        fAttrFill{this, "fill_"};         ///<!
+   RAttrAxis                        fAttrX{this, "x_"};               ///<!
+   RAttrAxis                        fAttrY{this, "y_"};               ///<!
+   RAttrAxis                        fAttrZ{this, "z_"};               ///<!
+   RAttrValue<bool>                 fGridX{this, "gridx", false};     ///<!
+   RAttrValue<bool>                 fGridY{this, "gridy", false};     ///<!
+   std::map<unsigned, RUserRanges>  fClientRanges;                    ///<! individual client ranges
 
    /// Mapping of user coordinates to normal coordinates, one entry per dimension.
    std::vector<std::unique_ptr<RPadUserAxisBase>> fUserCoord;

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -16,7 +16,7 @@
 #include "ROOT/RAttrFill.hxx"
 #include "ROOT/RAttrMargins.hxx"
 #include "ROOT/RAttrAxis.hxx"
-
+#include "ROOT/RAttrValue.hxx"
 #include "ROOT/RPadUserAxis.hxx"
 
 #include <memory>
@@ -120,18 +120,14 @@ public:
 
 private:
 
-   class RFrameAttrs : public RAttrBase {
-      friend class RFrame;
-      R__ATTR_CLASS(RFrameAttrs, "", AddBool("gridx", false).AddBool("gridy",false));
-   };
-
    RAttrMargins fMargins{this, "margin_"};     ///<!
    RAttrLine fAttrBorder{this, "border_"};     ///<!
    RAttrFill fAttrFill{this, "fill_"};         ///<!
    RAttrAxis fAttrX{this, "x_"};               ///<!
    RAttrAxis fAttrY{this, "y_"};               ///<!
    RAttrAxis fAttrZ{this, "z_"};               ///<!
-   RFrameAttrs fAttr{this,""};                 ///<! own frame attributes
+   RAttrValue<bool> fGridX{this, "gridx", false}; ///<!
+   RAttrValue<bool> fGridY{this, "gridy", false}; ///<!
    std::map<unsigned, RUserRanges> fClientRanges; ///<! individual client ranges
 
    /// Mapping of user coordinates to normal coordinates, one entry per dimension.
@@ -199,11 +195,11 @@ public:
    RFrame &SetAttrZ(const RAttrAxis &axis) { fAttrZ = axis; return *this; }
    RAttrAxis &AttrZ() { return fAttrZ; }
 
-   RFrame &SetGridX(bool on = true) { fAttr.SetValue("gridx", on); return *this; }
-   bool GetGridX() const { return fAttr.GetValue<bool>("gridx"); }
+   RFrame &SetGridX(bool on = true) { fGridX = on; return *this; }
+   bool GetGridX() const { return fGridX; }
 
-   RFrame &SetGridY(bool on = true) { fAttr.SetValue("gridy", on); return *this; }
-   bool GetGridY() const { return fAttr.GetValue<bool>("gridy"); }
+   RFrame &SetGridY(bool on = true) { fGridY = on; return *this; }
+   bool GetGridY() const { return fGridY; }
 
    void GetClientRanges(unsigned connid, RUserRanges &ranges);
 

--- a/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
@@ -11,6 +11,7 @@
 
 #include <ROOT/RDrawable.hxx>
 #include <ROOT/RAttrAxis.hxx>
+#include <ROOT/RAttrValue.hxx>
 #include <ROOT/RPadPos.hxx>
 #include <ROOT/RPalette.hxx>
 
@@ -31,14 +32,11 @@ namespace Experimental {
 
 class RPaletteDrawable final : public RDrawable {
 
-   class ROwnAttrs : public RAttrBase {
-      friend class RPaletteDrawable;
-      R__ATTR_CLASS(ROwnAttrs, "", AddBool("visible", true).AddPadLength("margin",0.02).AddPadLength("size",0.05));
-   };
-
    RPalette   fPalette;                     ///  color palette to draw
    RAttrAxis  fAttrAxis{this, "axis_"};     ///<! axis attributes
-   ROwnAttrs  fAttr{this,""};               ///<! own attributes
+   RAttrValue<bool> fVisible{this, "visible", true}; ///<! visibility flag
+   RAttrValue<RPadLength> fMargin{this, "margin", 0.02_normal}; ///<! margin
+   RAttrValue<RPadLength> fSize{this, "size", 0.05_normal}; ///<! margin
 
 protected:
 
@@ -52,30 +50,14 @@ public:
    RPaletteDrawable(const RPalette &palette, bool visible) : RPaletteDrawable() { fPalette = palette; SetVisible(visible); }
    const RPalette &GetPalette() const { return fPalette; }
 
-   RPaletteDrawable &SetVisible(bool on = true) { fAttr.SetValue("visible", on); return *this; }
-   bool GetVisible() const { return fAttr.GetValue<bool>("visible"); }
+   RPaletteDrawable &SetVisible(bool on = true) { fVisible = on; return *this; }
+   bool GetVisible() const { return fVisible; }
 
-   RPaletteDrawable &SetMargin(const RPadLength &pos)
-   {
-      fAttr.SetValue("margin", pos);
-      return *this;
-   }
+   RPaletteDrawable &SetMargin(const RPadLength &pos) { fMargin = pos; return *this; }
+   RPadLength GetMargin() const { return fMargin; }
 
-   RPadLength GetMargin() const
-   {
-      return fAttr.GetValue<RPadLength>("margin");
-   }
-
-   RPaletteDrawable &SetSize(const RPadLength &sz)
-   {
-      fAttr.SetValue("size", sz);
-      return *this;
-   }
-
-   RPadLength GetSize() const
-   {
-      return fAttr.GetValue<RPadLength>("size");
-   }
+   RPaletteDrawable &SetSize(const RPadLength &sz) { fSize = sz; return *this; }
+   RPadLength GetSize() const { return fSize; }
 
    const RAttrAxis &GetAttrAxis() const { return fAttrAxis; }
    RPaletteDrawable &SetAttrAxis(const RAttrAxis &attr) { fAttrAxis = attr; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
@@ -32,11 +32,11 @@ namespace Experimental {
 
 class RPaletteDrawable final : public RDrawable {
 
-   RPalette   fPalette;                     ///  color palette to draw
-   RAttrAxis  fAttrAxis{this, "axis_"};     ///<! axis attributes
-   RAttrValue<bool> fVisible{this, "visible", true}; ///<! visibility flag
-   RAttrValue<RPadLength> fMargin{this, "margin", 0.02_normal}; ///<! margin
-   RAttrValue<RPadLength> fSize{this, "size", 0.05_normal}; ///<! margin
+   RPalette                fPalette;                              ///<  color palette to draw
+   RAttrAxis               fAttrAxis{this, "axis_"};              ///<! axis attributes
+   RAttrValue<bool>        fVisible{this, "visible", true};       ///<! visibility flag
+   RAttrValue<RPadLength>  fMargin{this, "margin", 0.02_normal};  ///<! margin
+   RAttrValue<RPadLength>  fSize{this, "size", 0.05_normal};      ///<! margin
 
 protected:
 

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -30,13 +30,13 @@ namespace Experimental {
 
 class RPave : public RDrawable {
 
-   RAttrText fAttrText{this, "text_"};       ///<! text attributes
-   RAttrLine fAttrBorder{this, "border_"};   ///<! border attributes
-   RAttrFill fAttrFill{this, "fill_"};       ///<! line attributes
-   RAttrValue<RPadLength> fCornerX{this, "cornerx", 0.02}; ///<! X corner
-   RAttrValue<RPadLength> fCornerY{this, "cornery", 0.02}; ///<! Y corner
-   RAttrValue<RPadLength> fWidth{this, "width", 0.4}; ///<! pave width
-   RAttrValue<RPadLength> fHeight{this, "height", 0.2}; ///<! pave height
+   RAttrText                fAttrText{this, "text_"};        ///<! text attributes
+   RAttrLine                fAttrBorder{this, "border_"};    ///<! border attributes
+   RAttrFill                fAttrFill{this, "fill_"};        ///<! line attributes
+   RAttrValue<RPadLength>  fCornerX{this, "cornerx", 0.02};  ///<! X corner
+   RAttrValue<RPadLength>  fCornerY{this, "cornery", 0.02};  ///<! Y corner
+   RAttrValue<RPadLength>  fWidth{this, "width", 0.4};       ///<! pave width
+   RAttrValue<RPadLength>  fHeight{this, "height", 0.2};     ///<! pave height
 
 public:
 

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -13,6 +13,7 @@
 #include <ROOT/RAttrText.hxx>
 #include <ROOT/RAttrLine.hxx>
 #include <ROOT/RAttrFill.hxx>
+#include <ROOT/RAttrValue.hxx>
 #include <ROOT/RPadPos.hxx>
 
 namespace ROOT {
@@ -29,63 +30,29 @@ namespace Experimental {
 
 class RPave : public RDrawable {
 
-   class RPaveAttrs : public RAttrBase {
-      friend class RPave;
-      R__ATTR_CLASS(RPaveAttrs, "", AddPadLength("cornerx",0.02).AddPadLength("cornery",0.02).AddPadLength("width",0.5).AddPadLength("height",0.2));
-   };
-
    RAttrText fAttrText{this, "text_"};       ///<! text attributes
    RAttrLine fAttrBorder{this, "border_"};   ///<! border attributes
    RAttrFill fAttrFill{this, "fill_"};       ///<! line attributes
-   RPaveAttrs fAttr{this, ""};               ///<! pave direct attributes
+   RAttrValue<RPadLength> fCornerX{this, "cornerx", 0.02}; ///<! X corner
+   RAttrValue<RPadLength> fCornerY{this, "cornery", 0.02}; ///<! Y corner
+   RAttrValue<RPadLength> fWidth{this, "width", 0.4}; ///<! pave width
+   RAttrValue<RPadLength> fHeight{this, "height", 0.2}; ///<! pave height
 
 public:
 
    RPave(const std::string &csstype = "pave") : RDrawable(csstype) {}
 
-   RPave &SetCornerX(const RPadLength &pos)
-   {
-      fAttr.SetValue("cornerx", pos);
-      return *this;
-   }
+   RPave &SetCornerX(const RPadLength &pos) { fCornerX = pos; return *this; }
+   RPadLength GetCornerX() const { return fCornerX; }
 
-   RPadLength GetCornerX() const
-   {
-      return fAttr.template GetValue<RPadLength>("cornerx");
-   }
+   RPave &SetCornerY(const RPadLength &pos) { fCornerY = pos; return *this; }
+   RPadLength GetCornerY() const { return fCornerY; }
 
-   RPave &SetCornerY(const RPadLength &pos)
-   {
-      fAttr.SetValue("cornery", pos);
-      return *this;
-   }
+   RPave &SetWidth(const RPadLength &width) { fWidth = width; return *this; }
+   RPadLength GetWidth() const { return fWidth; }
 
-   RPadLength GetCornerY() const
-   {
-      return fAttr.template GetValue<RPadLength>("cornery");
-   }
-
-   RPave &SetWidth(const RPadLength &width)
-   {
-      fAttr.SetValue("width", width);
-      return *this;
-   }
-
-   RPadLength GetWidth() const
-   {
-      return fAttr.template GetValue<RPadLength>("width");
-   }
-
-   RPave &SetHeight(const RPadLength &height)
-   {
-      fAttr.SetValue("height", height);
-      return *this;
-   }
-
-   RPadLength GetHeight() const
-   {
-      return fAttr.template GetValue<RPadLength>("height");
-   }
+   RPave &SetHeight(const RPadLength &height) { fHeight = height; return *this; }
+   RPadLength GetHeight() const { return fHeight; }
 
    const RAttrText &GetAttrText() const { return fAttrText; }
    RPave &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }

--- a/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
@@ -30,10 +30,10 @@ namespace Experimental {
 
 class RFrameTitle final : public RDrawable {
 
-   std::string fText;                    ///< title to display
-   RAttrText  fAttrText{this, "text_"};  ///<! text attributes
-   RAttrValue<RPadLength> fMargin{this, "margin", 0.02_normal}; ///<! title margin
-   RAttrValue<RPadLength> fHeight{this, "height", 0.05_normal}; ///<! title height
+   std::string              fText;                                  ///< title to display
+   RAttrText                fAttrText{this, "text_"};               ///<! title text attributes
+   RAttrValue<RPadLength>   fMargin{this, "margin", 0.02_normal};   ///<! title margin
+   RAttrValue<RPadLength>   fHeight{this, "height", 0.05_normal};   ///<! title height
 
 protected:
 

--- a/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
@@ -11,6 +11,7 @@
 
 #include <ROOT/RDrawable.hxx>
 #include <ROOT/RAttrText.hxx>
+#include <ROOT/RAttrValue.hxx>
 #include <ROOT/RPadPos.hxx>
 
 #include <string>
@@ -29,14 +30,10 @@ namespace Experimental {
 
 class RFrameTitle final : public RDrawable {
 
-   class RTitleAttrs : public RAttrBase {
-      friend class RFrameTitle;
-      R__ATTR_CLASS(RTitleAttrs, "", AddString("margin","0.02").AddString("height","0.05"));
-   };
-
    std::string fText;                    ///< title to display
    RAttrText  fAttrText{this, "text_"};  ///<! text attributes
-   RTitleAttrs fAttr{this,""};           ///<! title direct attributes
+   RAttrValue<RPadLength> fMargin{this, "margin", 0.02_normal}; ///<! title margin
+   RAttrValue<RPadLength> fHeight{this, "height", 0.05_normal}; ///<! title height
 
 protected:
 
@@ -51,44 +48,11 @@ public:
    RFrameTitle &SetText(const std::string &t) { fText = t; return *this; }
    const std::string &GetText() const { return fText; }
 
-   RFrameTitle &SetMargin(const RPadLength &pos)
-   {
-      if (pos.Empty())
-         fAttr.ClearValue("margin");
-      else
-         fAttr.SetValue("margin", pos.AsString());
+   RFrameTitle &SetMargin(const RPadLength &pos) { fMargin = pos; return *this; }
+   RPadLength GetMargin() const { return fMargin; }
 
-      return *this;
-   }
-
-   RPadLength GetMargin() const
-   {
-      RPadLength res;
-      auto value = fAttr.GetValue<std::string>("margin");
-      if (!value.empty())
-         res.ParseString(value);
-      return res;
-   }
-
-   RFrameTitle &SetHeight(const RPadLength &pos)
-   {
-      if (pos.Empty())
-         fAttr.ClearValue("height");
-      else
-         fAttr.SetValue("height", pos.AsString());
-
-      return *this;
-   }
-
-   RPadLength GetHeight() const
-   {
-      RPadLength res;
-      auto value = fAttr.GetValue<std::string>("height");
-      if (!value.empty())
-         res.ParseString(value);
-      return res;
-   }
-
+   RFrameTitle &SetHeight(const RPadLength &pos) { fHeight = pos; return *this; }
+   RPadLength GetHeight() const { return fHeight; }
 
    const RAttrText &GetAttrText() const { return fAttrText; }
    RFrameTitle &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -116,6 +116,7 @@ public:
    RHist2Drawable &Error() { fAttr.SetValue("kind", std::string("err")); fAttr.ClearValue("sub"); return *this; }
    RHist2Drawable &Contour(int kind = 0) { fAttr.SetValue("kind", std::string("cont")); fAttr.SetValue("sub", kind); return *this; }
    RHist2Drawable &Scatter() { fAttr.SetValue("kind", std::string("scat")); fAttr.ClearValue("sub"); return *this; }
+   RHist2Drawable &Arrow() { fAttr.SetValue("kind", std::string("arr")); fAttr.ClearValue("sub"); return *this; }
    RHist2Drawable &Text(bool on = true) { fAttr.SetValue("text", on); return *this; }
 
    const RAttrLine &GetAttrLine() const { return fAttrLine; }

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -146,8 +146,6 @@ public:
 
 
 class RHist3Drawable final : public RHistDrawable<3> {
-   RAttrColor fColor{this, "color_"};     ///<! bin color, used which box option
-
 public:
    RHist3Drawable() = default;
 
@@ -158,11 +156,6 @@ public:
    RHist3Drawable &Box(int kind = 0) { SetDrawKind("box", kind); return *this; }
    RHist3Drawable &Sphere(int kind = 0) { SetDrawKind("sphere", kind); return *this; }
    RHist3Drawable &Scatter() { SetDrawKind("scat"); return *this; }
-
-   /// The color when box option is used
-   RHist3Drawable &SetColor(const RColor &color) { fColor = color; return *this; }
-   RColor GetColor() const { return fColor.GetColor(); }
-   RAttrColor &AttrColor() { return fColor; }
 };
 
 

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -20,22 +20,14 @@
 #include <ROOT/RAttrLine.hxx>
 #include <ROOT/RAttrText.hxx>
 #include <ROOT/RAttrMarker.hxx>
+#include <ROOT/RAttrFill.hxx>
 #include <ROOT/RHist.hxx>
 #include <ROOT/RHistImpl.hxx>
-#include <ROOT/RMenuItems.hxx>
 
 #include <memory>
 
 namespace ROOT {
 namespace Experimental {
-
-template <int DIMENSIONS, class PRECISION, template <int D_, class P_> class... STAT>
-class RHist;
-
-namespace Detail {
-template <int DIMENSIONS>
-class RHistImplPrecisionAgnosticBase;
-}
 
 template <int DIMENSIONS>
 class RHistDrawable : public RDrawable {
@@ -52,6 +44,7 @@ private:
 
    RHistAttrs  fAttr{this, ""};           ///<! hist direct attributes
    RAttrLine   fAttrLine{this, "line_"};  ///<! hist line attributes
+   RAttrFill   fAttrFill{this, "fill_"};  ///<! hist fill attributes
    RAttrText   fAttrText{this, "text_"};  ///<! hist text attributes
    RAttrMarker fMarkerAttr{this, "marker_"}; ///<! hist marker attributes
 
@@ -92,6 +85,10 @@ public:
    const RAttrLine &GetAttrLine() const { return fAttrLine; }
    RHistDrawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
    RAttrLine &AttrLine() { return fAttrLine; }
+
+   const RAttrFill &GetAttrFill() const { return fAttrFill; }
+   RHistDrawable &SetAttrFill(const RAttrFill &fill) { fAttrFill = fill; return *this; }
+   RAttrFill &AttrFill() { return fAttrFill; }
 
    const RAttrText &GetAttrText() const { return fAttrText; }
    RHistDrawable &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -109,7 +109,8 @@ public:
    template <class HIST>
    RHist1Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<1>(hist) {}
 
-   RHist1Drawable &Bar(int kind = 0) { SetDrawKind("bar", kind); return *this; }
+   RHist1Drawable &Bar() { SetDrawKind("bar", 0); return *this; }
+   RHist1Drawable &Bar3D() { SetDrawKind("bar", 1); return *this; }
    RHist1Drawable &Error(int kind = 0) { SetDrawKind("err", kind); return *this; }
    RHist1Drawable &Marker() { SetDrawKind("p"); return *this; }
    RHist1Drawable &Star() { AttrMarker().SetStyle(3); return Marker(); }

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -21,6 +21,7 @@
 #include <ROOT/RAttrText.hxx>
 #include <ROOT/RAttrMarker.hxx>
 #include <ROOT/RAttrFill.hxx>
+#include <ROOT/RAttrValue.hxx>
 #include <ROOT/RHist.hxx>
 #include <ROOT/RHistImpl.hxx>
 
@@ -37,12 +38,8 @@ public:
 private:
    Internal::RIOShared<HistImpl_t> fHistImpl;  ///< I/O capable reference on histogram
 
-   class RHistAttrs final : public RAttrBase {
-      friend class RHistDrawable;
-      R__ATTR_CLASS(RHistAttrs, "", AddString("kind","").AddInt("sub",0).AddBool("text", false));
-   };
-
-   RHistAttrs  fAttr{this, ""};           ///<! hist direct attributes
+   RAttrValue<std::string> fKind{this, "kind", ""};  ///<! hist draw kind
+   RAttrValue<int>  fSub{this, "sub", -1};     ///<! hist draw sub kind
    RAttrLine   fAttrLine{this, "line_"};  ///<! hist line attributes
    RAttrFill   fAttrFill{this, "fill_"};  ///<! hist fill attributes
    RAttrText   fAttrText{this, "text_"};  ///<! hist text attributes
@@ -61,14 +58,12 @@ protected:
 
    void SetDrawKind(const std::string &kind, int sub = -1)
    {
-      fAttr.SetValue("kind", kind);
-      if (sub>=0)
-         fAttr.SetValue("sub", sub);
+      fKind = kind;
+      if (sub >= 0)
+         fSub = sub;
       else
-         fAttr.ClearValue("sub");
+         fSub.Clear();
    }
-
-   void SetDrawText(bool on) { fAttr.SetValue("text", on); }
 
 public:
    RHistDrawable() : RDrawable("hist") {}
@@ -103,24 +98,34 @@ public:
 
 
 class RHist1Drawable final : public RHistDrawable<1> {
+   RAttrValue<double> fBarOffset{this, "bar_offset", 0.}; ///<!  bar offset
+   RAttrValue<double> fBarWidth{this, "bar_width", 1.};   ///<!  bar width
+   RAttrValue<bool> fText{this, "text", false};           ///<! draw text
+
 public:
    RHist1Drawable() = default;
 
    template <class HIST>
    RHist1Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<1>(hist) {}
 
-   RHist1Drawable &Bar() { SetDrawKind("bar", 0); return *this; }
-   RHist1Drawable &Bar3D() { SetDrawKind("bar", 1); return *this; }
+   RHist1Drawable &Bar() { SetDrawKind("bar", 0); fBarOffset.Clear(); fBarWidth.Clear(); return *this; }
+   RHist1Drawable &Bar(double offset, double width) { SetDrawKind("bar", 0); fBarOffset = offset; fBarWidth = width; return *this; }
+   RHist1Drawable &Bar3D() { SetDrawKind("bar", 1); fBarOffset.Clear(); fBarWidth.Clear(); return *this; }
+   RHist1Drawable &Bar3D(double offset, double width) { SetDrawKind("bar", 1); fBarOffset = offset; fBarWidth = width; return *this; }
    RHist1Drawable &Error(int kind = 0) { SetDrawKind("err", kind); return *this; }
    RHist1Drawable &Marker() { SetDrawKind("p"); return *this; }
    RHist1Drawable &Star() { AttrMarker().SetStyle(3); return Marker(); }
    RHist1Drawable &Hist() { SetDrawKind("hist"); return *this; }
    RHist1Drawable &Lego(int kind = 0) { SetDrawKind("lego", kind); return *this; }
-   RHist1Drawable &Text(bool on = true) { SetDrawText(on); return *this; }
+   RHist1Drawable &Text(bool on = true) { fText = on; return *this; }
+
+   double GetBarOffset() const { return fBarOffset; }
+   double GetBarWidth() const { return fBarWidth; }
 };
 
 
 class RHist2Drawable final : public RHistDrawable<2> {
+   RAttrValue<bool> fText{this, "text", false};           ///<! draw text
 
 public:
    RHist2Drawable() = default;
@@ -135,7 +140,7 @@ public:
    RHist2Drawable &Contour(int kind = 0) { SetDrawKind("cont", kind); return *this; }
    RHist2Drawable &Scatter() { SetDrawKind("scat"); return *this; }
    RHist2Drawable &Arrow() { SetDrawKind("arr"); return *this; }
-   RHist2Drawable &Text(bool on = true) { SetDrawText(on); return *this; }
+   RHist2Drawable &Text(bool on = true) { fText = on; return *this; }
 };
 
 

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -36,14 +36,14 @@ public:
    using HistImpl_t = Detail::RHistImplPrecisionAgnosticBase<DIMENSIONS>;
 
 private:
-   Internal::RIOShared<HistImpl_t> fHistImpl;  ///< I/O capable reference on histogram
+   Internal::RIOShared<HistImpl_t> fHistImpl;             ///< I/O capable reference on histogram
 
-   RAttrValue<std::string> fKind{this, "kind", ""};  ///<! hist draw kind
-   RAttrValue<int>  fSub{this, "sub", -1};     ///<! hist draw sub kind
-   RAttrLine   fAttrLine{this, "line_"};  ///<! hist line attributes
-   RAttrFill   fAttrFill{this, "fill_"};  ///<! hist fill attributes
-   RAttrText   fAttrText{this, "text_"};  ///<! hist text attributes
-   RAttrMarker fMarkerAttr{this, "marker_"}; ///<! hist marker attributes
+   RAttrValue<std::string>  fKind{this, "kind", ""};      ///<! hist draw kind
+   RAttrValue<int>          fSub{this, "sub", -1};        ///<! hist draw sub kind
+   RAttrLine                fAttrLine{this, "line_"};     ///<! hist line attributes
+   RAttrFill                fAttrFill{this, "fill_"};     ///<! hist fill attributes
+   RAttrText                fAttrText{this, "text_"};     ///<! hist text attributes
+   RAttrMarker              fMarkerAttr{this, "marker_"}; ///<! hist marker attributes
 
 protected:
 

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -19,6 +19,7 @@
 #include <ROOT/RDrawable.hxx>
 #include <ROOT/RAttrLine.hxx>
 #include <ROOT/RAttrText.hxx>
+#include <ROOT/RAttrMarker.hxx>
 #include <ROOT/RHist.hxx>
 #include <ROOT/RHistImpl.hxx>
 #include <ROOT/RMenuItems.hxx>
@@ -44,6 +45,16 @@ public:
 private:
    Internal::RIOShared<HistImpl_t> fHistImpl;  ///< I/O capable reference on histogram
 
+   class RHistAttrs final : public RAttrBase {
+      friend class RHistDrawable;
+      R__ATTR_CLASS(RHistAttrs, "", AddString("kind","").AddInt("sub",0).AddBool("text", false));
+   };
+
+   RHistAttrs  fAttr{this, ""};           ///<! hist direct attributes
+   RAttrLine   fAttrLine{this, "line_"};  ///<! hist line attributes
+   RAttrText   fAttrText{this, "text_"};  ///<! hist text attributes
+   RAttrMarker fMarkerAttr{this, "marker_"}; ///<! hist marker attributes
+
 protected:
 
    void CollectShared(Internal::RIOSharedVector_t &vect) override { vect.emplace_back(&fHistImpl); }
@@ -55,8 +66,19 @@ protected:
       // populate menu
    }
 
+   void SetDrawKind(const std::string &kind, int sub = -1)
+   {
+      fAttr.SetValue("kind", kind);
+      if (sub>=0)
+         fAttr.SetValue("sub", sub);
+      else
+         fAttr.ClearValue("sub");
+   }
+
+   void SetDrawText(bool on) { fAttr.SetValue("text", on); }
+
 public:
-   RHistDrawable();
+   RHistDrawable() : RDrawable("hist") {}
    virtual ~RHistDrawable() = default;
 
    template <class HIST>
@@ -67,42 +89,38 @@ public:
 
    std::shared_ptr<HistImpl_t> GetHist() const { return fHistImpl.get_shared(); }
 
-//   template <class HIST>
-//   RHistDrawable(std::unique_ptr<HIST> &&hist)
-//      : fHistImpl(std::unique_ptr<HistImpl_t>(std::move(*hist).TakeImpl())), fOpts(opts)
-//   {}
+   const RAttrLine &GetAttrLine() const { return fAttrLine; }
+   RHistDrawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
+   RAttrLine &AttrLine() { return fAttrLine; }
 
+   const RAttrText &GetAttrText() const { return fAttrText; }
+   RHistDrawable &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
+   RAttrText &AttrText() { return fAttrText; }
+
+   const RAttrMarker &GetAttrMarker() const { return fMarkerAttr; }
+   RHistDrawable &SetAttrMarker(const RAttrMarker &attr) { fMarkerAttr = attr; return *this; }
+   RAttrMarker &AttrMarker() { return fMarkerAttr; }
 };
 
-template <int DIMENSIONS> inline RHistDrawable<DIMENSIONS>::RHistDrawable() : RDrawable("hist") {}
+// template <int DIMENSIONS> inline RHistDrawable<DIMENSIONS>::RHistDrawable() : RDrawable("hist") {}
 
 
 class RHist1Drawable final : public RHistDrawable<1> {
-private:
-
-   RAttrLine  fAttrLine{this, "line_"};        ///<! line attributes
-
 public:
    RHist1Drawable() = default;
 
    template <class HIST>
    RHist1Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<1>(hist) {}
 
-   const RAttrLine &GetAttrLine() const { return fAttrLine; }
-   RHist1Drawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
-   RAttrLine &AttrLine() { return fAttrLine; }
+   RHist1Drawable &Bar(int kind = 0) { SetDrawKind("bar", kind); return *this; }
+   RHist1Drawable &Error(int kind = 0) { SetDrawKind("err", kind); return *this; }
+   RHist1Drawable &Hist() { SetDrawKind("hist"); return *this; }
+   RHist1Drawable &Lego(int kind = 0) { SetDrawKind("lego", kind); return *this; }
+   RHist1Drawable &Text(bool on = true) { SetDrawText(on); return *this; }
 };
 
 
 class RHist2Drawable final : public RHistDrawable<2> {
-   class RHist2Attrs final : public RAttrBase {
-      friend class RHist2Drawable;
-      R__ATTR_CLASS(RHist2Attrs, "", AddString("kind","").AddInt("sub",0).AddBool("text", false));
-   };
-
-   RHist2Attrs fAttr{this, ""};           ///<! hist2 direct attributes
-   RAttrLine   fAttrLine{this, "line_"};  ///<! line attributes, used for error or some lego plots
-   RAttrText   fAttrText{this, "text_"};  ///<! text attributes, used with Text drawing
 
 public:
    RHist2Drawable() = default;
@@ -110,35 +128,19 @@ public:
    template <class HIST>
    RHist2Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<2>(hist) {}
 
-   RHist2Drawable &Color() { fAttr.SetValue("kind", std::string("col")); fAttr.ClearValue("sub"); return *this; }
-   RHist2Drawable &Lego(int kind = 0) { fAttr.SetValue("kind", std::string("lego")); fAttr.SetValue("sub", kind); return *this; }
-   RHist2Drawable &Surf(int kind = 0) { fAttr.SetValue("kind", std::string("surf")); fAttr.SetValue("sub", kind); return *this; }
-   RHist2Drawable &Error() { fAttr.SetValue("kind", std::string("err")); fAttr.ClearValue("sub"); return *this; }
-   RHist2Drawable &Contour(int kind = 0) { fAttr.SetValue("kind", std::string("cont")); fAttr.SetValue("sub", kind); return *this; }
-   RHist2Drawable &Scatter() { fAttr.SetValue("kind", std::string("scat")); fAttr.ClearValue("sub"); return *this; }
-   RHist2Drawable &Arrow() { fAttr.SetValue("kind", std::string("arr")); fAttr.ClearValue("sub"); return *this; }
-   RHist2Drawable &Text(bool on = true) { fAttr.SetValue("text", on); return *this; }
-
-   const RAttrLine &GetAttrLine() const { return fAttrLine; }
-   RHist2Drawable &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
-   RAttrLine &AttrLine() { return fAttrLine; }
-
-   const RAttrText &GetAttrText() const { return fAttrText; }
-   RHist2Drawable &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
-   RAttrText &AttrText() { return fAttrText; }
-
+   RHist2Drawable &Color() { SetDrawKind("col"); return *this; }
+   RHist2Drawable &Lego(int kind = 0) { SetDrawKind("lego", kind); return *this; }
+   RHist2Drawable &Surf(int kind = 0) { SetDrawKind("surf", kind); return *this; }
+   RHist2Drawable &Error() { SetDrawKind("err"); return *this; }
+   RHist2Drawable &Contour(int kind = 0) { SetDrawKind("cont", kind); return *this; }
+   RHist2Drawable &Scatter() { SetDrawKind("scat"); return *this; }
+   RHist2Drawable &Arrow() { SetDrawKind("arr"); return *this; }
+   RHist2Drawable &Text(bool on = true) { SetDrawText(on); return *this; }
 };
 
 
 class RHist3Drawable final : public RHistDrawable<3> {
-   class RHist3Attrs final : public RAttrBase {
-      friend class RHist3Drawable;
-      R__ATTR_CLASS(RHist3Attrs, "", AddString("kind","").AddInt("sub",0));
-   };
-
-   RHist3Attrs fAttr{this, ""};           ///<! hist2 direct attributes
    RAttrColor fColor{this, "color_"};     ///<! bin color, used which box option
-   RAttrColor fLineColor{this, "line_color_"};     ///<! bin color, used which box option
 
 public:
    RHist3Drawable() = default;
@@ -146,23 +148,16 @@ public:
    template <class HIST>
    RHist3Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<3>(hist) {}
 
-   RHist3Drawable &Color() { fAttr.SetValue("kind", std::string("col")); fAttr.ClearValue("sub"); return *this; }
-   RHist3Drawable &Box(int kind = 0) { fAttr.SetValue("kind", std::string("box")); fAttr.SetValue("sub", kind); return *this; }
-   RHist3Drawable &Sphere(int kind = 0) { fAttr.SetValue("kind", std::string("sphere")); fAttr.SetValue("sub", kind); return *this; }
-   RHist3Drawable &Scatter() { fAttr.SetValue("kind", std::string("scat")); fAttr.ClearValue("sub"); return *this; }
+   RHist3Drawable &Color() { SetDrawKind("col"); return *this; }
+   RHist3Drawable &Box(int kind = 0) { SetDrawKind("box", kind); return *this; }
+   RHist3Drawable &Sphere(int kind = 0) { SetDrawKind("sphere", kind); return *this; }
+   RHist3Drawable &Scatter() { SetDrawKind("scat"); return *this; }
 
    /// The color when box option is used
    RHist3Drawable &SetColor(const RColor &color) { fColor = color; return *this; }
    RColor GetColor() const { return fColor.GetColor(); }
    RAttrColor &AttrColor() { return fColor; }
-
-   /// The line color when box option is used
-   RHist3Drawable &SetLineColor(const RColor &color) { fLineColor = color; return *this; }
-   RColor GetLineColor() const { return fLineColor.GetColor(); }
-   RAttrColor &AttrLineColor() { return fLineColor; }
 };
-
-
 
 
 inline auto GetDrawable(const std::shared_ptr<RH1D> &histimpl)

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -116,6 +116,7 @@ public:
    RHist1Drawable &Marker() { SetDrawKind("p"); return *this; }
    RHist1Drawable &Star() { AttrMarker().SetStyle(3); return Marker(); }
    RHist1Drawable &Hist() { SetDrawKind("hist"); return *this; }
+   RHist1Drawable &Line() { SetDrawKind("l"); return *this; }
    RHist1Drawable &Lego(int kind = 0) { SetDrawKind("lego", kind); return *this; }
    RHist1Drawable &Text(bool on = true) { fText = on; return *this; }
 

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -111,6 +111,8 @@ public:
 
    RHist1Drawable &Bar(int kind = 0) { SetDrawKind("bar", kind); return *this; }
    RHist1Drawable &Error(int kind = 0) { SetDrawKind("err", kind); return *this; }
+   RHist1Drawable &Marker() { SetDrawKind("p"); return *this; }
+   RHist1Drawable &Star() { AttrMarker().SetStyle(3); return Marker(); }
    RHist1Drawable &Hist() { SetDrawKind("hist"); return *this; }
    RHist1Drawable &Lego(int kind = 0) { SetDrawKind("lego", kind); return *this; }
    RHist1Drawable &Text(bool on = true) { SetDrawText(on); return *this; }

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 23/06/2020";
+   JSROOT.version = "dev 24/06/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 24/06/2020";
+   JSROOT.version = "dev 25/06/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootPainter.hist.js
+++ b/js/scripts/JSRootPainter.hist.js
@@ -1666,7 +1666,7 @@
       if (d.check('E', true)) {
          this.Error = true;
          if (hdim == 1) {
-            this.Zero = false; // do not draw empty bins with erros
+            this.Zero = false; // do not draw empty bins with errors
             this.Hist = false;
             if (!isNaN(parseInt(d.part[0]))) this.ErrorKind = parseInt(d.part[0]);
             if ((this.ErrorKind === 3) || (this.ErrorKind === 4)) this.need_fillcol = true;

--- a/js/scripts/JSRootPainter.hist3d.js
+++ b/js/scripts/JSRootPainter.hist3d.js
@@ -2723,7 +2723,7 @@
          for (j = j1; j < j2; ++j) {
             for (k = k1; k < k2; ++k) {
                bin_content = histo.getBinContent(i+1, j+1, k+1);
-               if ((bin_content===0) || (bin_content < this.gminbin)) continue;
+               if (!this.options.GLColor && ((bin_content===0) || (bin_content < this.gminbin))) continue;
                wei = use_scale ? Math.pow(Math.abs(bin_content*use_scale), 0.3333) : 1;
                if (wei < 1e-3) continue; // do not draw empty or very small bins
 
@@ -2793,7 +2793,7 @@
             biny = histo.fYaxis.GetBinCenter(j+1); gry = main.gry(biny);
             for (k = k1; k < k2; ++k) {
                bin_content = histo.getBinContent(i+1, j+1, k+1);
-               if ((bin_content===0) || (bin_content < this.gminbin)) continue;
+               if (!this.options.GLColor && ((bin_content===0) || (bin_content < this.gminbin))) continue;
 
                wei = use_scale ? Math.pow(Math.abs(bin_content*use_scale), 0.3333) : 1;
                if (wei < 1e-3) continue; // do not show very small bins

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -1594,8 +1594,6 @@
       var pp = this.pad_painter();
       if (pp) pp.frame_painter_ref = this; // keep direct reference to the frame painter
 
-      if (this.mode3d) return; // no need to create any elements in 3d mode
-
       // first update all attributes from objects
       this.UpdateAttributes();
 
@@ -1605,12 +1603,24 @@
           w = Math.round(width * (this.fX2NDC - this.fX1NDC)),
           tm = Math.round(height * (1 - this.fY2NDC)),
           h = Math.round(height * (this.fY2NDC - this.fY1NDC)),
-          rotate = false, fixpos = false;
+          rotate = false, fixpos = false, trans = "translate(" + lm + "," + tm + ")";
 
       if (pp && pp.options) {
          if (pp.options.RotateFrame) rotate = true;
          if (pp.options.FixFrame) fixpos = true;
       }
+
+      if (rotate) {
+         trans += " rotate(-90) " + "translate(" + -h + ",0)";
+         var d = w; w = h; h = d;
+      }
+
+      this._frame_x = lm;
+      this._frame_y = tm;
+      this._frame_width = w;
+      this._frame_height = h;
+
+      if (this.mode3d) return; // no need to create any elements in 3d mode
 
       // this is svg:g object - container for every other items belonging to frame
       this.draw_g = this.svg_layer("primitives_layer").select(".root_frame");
@@ -1644,17 +1654,6 @@
       }
 
       this.axes_drawn = false;
-
-      var trans = "translate(" + lm + "," + tm + ")";
-      if (rotate) {
-         trans += " rotate(-90) " + "translate(" + -h + ",0)";
-         var d = w; w = h; h = d;
-      }
-
-      this._frame_x = lm;
-      this._frame_y = tm;
-      this._frame_width = w;
-      this._frame_height = h;
 
       this.draw_g.attr("transform", trans);
 

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -4865,7 +4865,7 @@
           title_margin = this.v7EvalLength("margin", ph, 0.02),
           title_width  = fw,
           title_height = this.v7EvalLength("height", ph, 0.05),
-          text_size    = this.v7EvalAttr("text_size", 16),
+          text_size    = this.v7EvalAttr("text_size", 24),
           text_angle   = -1 * this.v7EvalAttr("text_angle", 0),
           text_align   = this.v7EvalAttr("text_align", 22),
           text_color   = this.v7EvalColor("text_color", "black"),

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -4865,7 +4865,7 @@
           title_margin = this.v7EvalLength("margin", ph, 0.02),
           title_width  = fw,
           title_height = this.v7EvalLength("height", ph, 0.05),
-          text_size    = this.v7EvalAttr("text_size", 24),
+          text_size    = this.v7EvalAttr("text_size", 20),
           text_angle   = -1 * this.v7EvalAttr("text_angle", 0),
           text_align   = this.v7EvalAttr("text_align", 22),
           text_color   = this.v7EvalColor("text_color", "black"),

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -1536,8 +1536,6 @@
       var pp = this.pad_painter();
       if (pp) pp.frame_painter_ref = this;
 
-      if (this.mode3d) return;
-
       // first update all attributes from objects
       this.UpdateAttributes();
 
@@ -1547,12 +1545,26 @@
           w = Math.round(width * (this.fX2NDC - this.fX1NDC)),
           tm = Math.round(height * (1 - this.fY2NDC)),
           h = Math.round(height * (this.fY2NDC - this.fY1NDC)),
-          rotate = false, fixpos = false;
+          rotate = false, fixpos = false,
+          trans = "translate(" + lm + "," + tm + ")";
 
       if (pp && pp.options) {
          if (pp.options.RotateFrame) rotate = true;
          if (pp.options.FixFrame) fixpos = true;
       }
+
+      if (rotate) {
+         trans += " rotate(-90) " + "translate(" + -h + ",0)";
+         var d = w; w = h; h = d;
+      }
+
+      // update values here to let access even when frame is not really updated
+      this._frame_x = lm;
+      this._frame_y = tm;
+      this._frame_width = w;
+      this._frame_height = h;
+
+      if (this.mode3d) return; // no need for real draw in mode3d
 
       // this is svg:g object - container for every other items belonging to frame
       this.draw_g = this.svg_layer("primitives_layer").select(".root_frame");
@@ -1595,17 +1607,6 @@
       }
 
       this.axes_drawn = false;
-
-      var trans = "translate(" + lm + "," + tm + ")";
-      if (rotate) {
-         trans += " rotate(-90) " + "translate(" + -h + ",0)";
-         var d = w; w = h; h = d;
-      }
-
-      this._frame_x = lm;
-      this._frame_y = tm;
-      this._frame_width = w;
-      this._frame_height = h;
 
       this.draw_g.attr("transform", trans);
 

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -1647,6 +1647,7 @@
       switch(kind) {
          case "bar": o.Bar = true; o.BarStyle = sub; break;
          case "err": o.Error = true; o.ErrorKind = sub; break;
+         case "p": o.Mark = true; break;
          case "lego": o.Lego = sub > 0 ? 10+sub : 12; o.Mode3D = true; break;
          default: o.Hist = true;
       }

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -1614,7 +1614,7 @@
 
    RH1Painter.prototype.Draw3D = function(call_back, reason) {
       this.mode3d = true;
-      JSROOT.AssertPrerequisites('hist3d', function() {
+      JSROOT.AssertPrerequisites('v7hist3d', function() {
          this.Draw3D(call_back, reason);
       }.bind(this));
    }
@@ -1648,6 +1648,7 @@
          case "bar": o.Bar = true; o.BarStyle = sub; break;
          case "err": o.Error = true; o.ErrorKind = sub; break;
          case "p": o.Mark = true; break;
+         case "l": o.Line = true; break;
          case "lego": o.Lego = sub > 0 ? 10+sub : 12; o.Mode3D = true; break;
          default: o.Hist = true;
       }

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -908,8 +908,8 @@
          gry1 = Math.round(pmain.gry(y));
 
          w = grx2 - grx1;
-         grx1 += Math.round(this.options.fBarOffset/1000*w);
-         w = Math.round(this.options.fBarWidth/1000*w);
+         grx1 += Math.round(this.options.BarOffset*w);
+         w = Math.round(this.options.BarWidth*w);
 
          if (pmain.swap_xy)
             bars += "M"+gry2+","+grx1 + "h"+(gry1-gry2) + "v"+w + "h"+(gry2-gry1) + "z";
@@ -1368,8 +1368,8 @@
 
       if (this.options.Bar) {
          var w = grx2 - grx1;
-         grx1 += Math.round(this.options.fBarOffset/1000*w);
-         grx2 = grx1 + Math.round(this.options.fBarWidth/1000*w);
+         grx1 += Math.round(this.options.BarOffset*w);
+         grx2 = grx1 + Math.round(this.options.BarWidth*w);
       }
 
       if (grx1 > grx2) { var d = grx1; grx1 = grx2; grx2 = d; }
@@ -1634,13 +1634,15 @@
                           Zero: false, Mark: false,
                           Line: false, Fill: false, Lego: 0, Surf: 0,
                           Text: false, TextAngle: 0, TextKind: "", AutoColor: 0,
-                          fBarOffset: 0, fBarWidth: 1000, BaseLine: false, Mode3D: false };
+                          BarOffset: 0., BarWidth: 1., BaseLine: false, Mode3D: false };
 
       var kind = painter.v7EvalAttr("kind", "hist"),
           sub = painter.v7EvalAttr("sub", 0),
           o = painter.options;
 
       o.Text = painter.v7EvalAttr("text", false);
+      o.BarOffset = painter.v7EvalAttr("bar_offset", 0.);
+      o.BarWidth = painter.v7EvalAttr("bar_width", 1.);
 
       switch(kind) {
          case "bar": o.Bar = true; o.BarStyle = sub; break;
@@ -2528,7 +2530,7 @@
           profile2d = (this.options.TextKind == "E") &&
                       this.MatchObjectType('TProfile2D') && (typeof histo.getBinEntries=='function');
 
-      if (this.options.fBarOffset!==0) text_offset = this.options.fBarOffset*1e-3;
+      if (this.options.BarOffset) text_offset = this.options.BarOffset;
 
       this.StartTextDrawing(42, text_size, text_g, text_size);
 
@@ -2802,8 +2804,8 @@
 
          w = handle.grx[i+1] - handle.grx[i];
          w *= 0.66;
-         center = (handle.grx[i+1] + handle.grx[i]) / 2 + this.options.fBarOffset/1000*w;
-         if (this.options.fBarWidth >0) w = w * this.options.fBarWidth / 1000;
+         center = (handle.grx[i+1] + handle.grx[i]) / 2 + this.options.BarOffset*w;
+         if (this.options.BarWidth > 0) w = w * this.options.BarWidth;
 
          pnt.x1 = Math.round(center - w/2);
          pnt.x2 = Math.round(center + w/2);
@@ -3416,7 +3418,7 @@
                           Text: true, TextAngle: 0, TextKind: "",
                           BaseLine: false, Mode3D: false, AutoColor: 0,
                           Color: false, Scat: false, ScatCoef: 1, Candle: "", Box: false, BoxStyle: 0, Arrow: false, Contour: 0, Proj: 0,
-                          minimum: -1111, maximum: -1111 };
+                          BarOffset: 0., BarWidth: 1., minimum: -1111, maximum: -1111 };
 
       var kind = painter.v7EvalAttr("kind", "col"),
           sub = painter.v7EvalAttr("sub", 0),

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -887,10 +887,8 @@
           pthis = this,
           histo = this.GetHisto(), xaxis = this.GetAxis("x"),
           i, x1, x2, grx1, grx2, y, gry1, gry2, w,
-          bars = "", barsl = "", barsr = "",
-          side = (this.options.BarStyle > 10) ? this.options.BarStyle % 10 : 0;
+          bars = "", barsl = "", barsr = "";
 
-      if (side>4) side = 4;
       gry2 = pmain.swap_xy ? 0 : height;
       if ((this.options.BaseLine !== false) && !isNaN(this.options.BaseLine))
          if (this.options.BaseLine >= pmain.scale_ymin)
@@ -918,9 +916,9 @@
          else
             bars += "M"+grx1+","+gry1 + "h"+w + "v"+(gry2-gry1) + "h"+(-w)+ "z";
 
-         if (side > 0) {
+         if (this.options.BarStyle > 0) {
             grx2 = grx1 + w;
-            w = Math.round(w * side / 10);
+            w = Math.round(w / 10);
             if (pmain.swap_xy) {
                barsl += "M"+gry2+","+grx1 + "h"+(gry1-gry2) + "v" + w + "h"+(gry2-gry1) + "z";
                barsr += "M"+gry2+","+grx2 + "h"+(gry1-gry2) + "v" + (-w) + "h"+(gry2-gry1) + "z";
@@ -1631,7 +1629,7 @@
 
       if (!painter.PrepareFrame(divid)) return null;
 
-      painter.options = { Hist: false, Bar: false,
+      painter.options = { Hist: false, Bar: false, BarStyle: 0,
                           Error: false, ErrorKind: -1, errorX: JSROOT.gStyle.fErrorX,
                           Zero: false, Mark: false,
                           Line: false, Fill: false, Lego: 0, Surf: 0,
@@ -3413,10 +3411,10 @@
 
       if (!painter.PrepareFrame(divid)) return null;
 
-      painter.options = { Hist: false, Bar: false, Error: false, Zero: false, Mark: false,
+      painter.options = { Hist: false, Error: false, Zero: false, Mark: false,
                           Line: false, Fill: false, Lego: 0, Surf: 0,
                           Text: true, TextAngle: 0, TextKind: "",
-                          fBarOffset: 0, fBarWidth: 1000, BaseLine: false, Mode3D: false, AutoColor: 0,
+                          BaseLine: false, Mode3D: false, AutoColor: 0,
                           Color: false, Scat: false, ScatCoef: 1, Candle: "", Box: false, BoxStyle: 0, Arrow: false, Contour: 0, Proj: 0,
                           minimum: -1111, maximum: -1111 };
 

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -148,13 +148,8 @@
    }
 
    RHistPainter.prototype.CheckHistDrawAttributes = function() {
-
-      this.createAttFill( { pattern: 0, color: 0 });
-
-      var lcol = this.v7EvalColor( "line_color", "black"),
-          lwidth = this.v7EvalAttr( "line_width", 1);
-
-      this.createAttLine({ color: lcol || 'black', width : parseInt(lwidth) || 1 });
+      this.createv7AttFill();
+      this.createv7AttLine();
    }
 
    RHistPainter.prototype.UpdateObject = function(obj, opt) {
@@ -1636,7 +1631,9 @@
 
       if (!painter.PrepareFrame(divid)) return null;
 
-      painter.options = { Hist: false, Bar: false, Error: false, ErrorKind: -1, errorX: 0, Zero: false, Mark: false,
+      painter.options = { Hist: false, Bar: false,
+                          Error: false, ErrorKind: -1, errorX: JSROOT.gStyle.fErrorX,
+                          Zero: false, Mark: false,
                           Line: false, Fill: false, Lego: 0, Surf: 0,
                           Text: false, TextAngle: 0, TextKind: "", AutoColor: 0,
                           fBarOffset: 0, fBarWidth: 1000, BaseLine: false, Mode3D: false };
@@ -1649,7 +1646,7 @@
 
       switch(kind) {
          case "bar": o.Bar = true; o.BarStyle = sub; break;
-         case "err": o.Error = true; o.ErrorKind = sub > 0 ? sub : 1; break;
+         case "err": o.Error = true; o.ErrorKind = sub; break;
          case "lego": o.Lego = sub > 0 ? 10+sub : 12; o.Mode3D = true; break;
          default: o.Hist = true;
       }
@@ -3415,7 +3412,7 @@
 
       if (!painter.PrepareFrame(divid)) return null;
 
-      painter.options = { Hist: false, Bar: false, Error: false, errorX: 0, Zero: false, Mark: false,
+      painter.options = { Hist: false, Bar: false, Error: false, Zero: false, Mark: false,
                           Line: false, Fill: false, Lego: 0, Surf: 0,
                           Text: true, TextAngle: 0, TextKind: "",
                           fBarOffset: 0, fBarWidth: 1000, BaseLine: false, Mode3D: false, AutoColor: 0,

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -3421,7 +3421,7 @@
                           Color: false, Scat: false, ScatCoef: 1, Candle: "", Box: false, BoxStyle: 0, Arrow: false, Contour: 0, Proj: 0,
                           BarOffset: 0., BarWidth: 1., minimum: -1111, maximum: -1111 };
 
-      var kind = painter.v7EvalAttr("kind", "col"),
+      var kind = painter.v7EvalAttr("kind", ""),
           sub = painter.v7EvalAttr("sub", 0),
           o = painter.options;
 
@@ -3434,7 +3434,8 @@
          case "cont": o.Contour = sub > 0 ? 10+sub : 1; break;
          case "arr": o.Arrow = true; break;
          case "scat": o.Scat = true; break;
-         default: o.Color = true;
+         case "col": o.Color = true; break;
+         default: if (!o.Text) o.Color = true;
       }
 
       // here we deciding how histogram will look like and how will be shown

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -2586,8 +2586,8 @@
           i,j,binz,colindx,binw,binh,lbl, loop, dn = 1e-30, dx, dy, xc,yc,
           dxn,dyn,x1,x2,y1,y2, anr,si,co,
           handle = this.PrepareColorDraw({ rounding: false }),
-          scale_x  = (handle.grx[handle.i2] - handle.grx[handle.i1])/(handle.i2 - handle.i1 + 1-0.03)/2,
-          scale_y  = (handle.gry[handle.j2] - handle.gry[handle.j1])/(handle.j2 - handle.j1 + 1-0.03)/2;
+          scale_x = (handle.grx[handle.i2] - handle.grx[handle.i1])/(handle.i2 - handle.i1 + 1-0.03)/2,
+          scale_y = (handle.gry[handle.j2] - handle.gry[handle.j1])/(handle.j2 - handle.j1 + 1-0.03)/2;
 
       for (var loop=0;loop<2;++loop)
          for (i = handle.i1; i < handle.i2; ++i)
@@ -3443,6 +3443,7 @@
          case "surf": o.Surf = sub > 0 ? 10+sub : 1; o.Mode3D = true; break;
          case "err": o.Error = true; o.Mode3D = true; break;
          case "cont": o.Contour = sub > 0 ? 10+sub : 1; break;
+         case "arr": o.Arrow = true; break;
          case "scat": o.Scat = true; break;
          default: o.Color = true;
       }

--- a/js/scripts/JSRootPainter.v7hist3d.js
+++ b/js/scripts/JSRootPainter.v7hist3d.js
@@ -2599,7 +2599,7 @@
          }
       }
 
-      var color = this.v7EvalColor("color", "red");
+      var color = this.v7EvalColor("fill_color", "red");
       var mesh = pnts.CreatePoints(color);
       main.toplevel.add(mesh);
 
@@ -2642,7 +2642,7 @@
       if (this.options.Scatter)
          if (this.Draw3DScatter()) return;
 
-      var fillcolor = this.v7EvalColor("color", "red"),
+      var fillcolor = this.v7EvalColor("fill_color", "red"),
           main = this.frame_painter(),
           buffer_size = 0, use_lambert = false,
           use_helper = false, use_colors = false, use_opacity = 1, use_scale = true,
@@ -2747,7 +2747,7 @@
          for (j = j1; j < j2; ++j) {
             for (k = k1; k < k2; ++k) {
                bin_content = histo.getBinContent(i+1, j+1, k+1);
-               if ((bin_content===0) || (bin_content < this.gminbin)) continue;
+               if (!this.options.Color && ((bin_content===0) || (bin_content < this.gminbin))) continue;
                wei = use_scale ? Math.pow(Math.abs(bin_content*use_scale), 0.3333) : 1;
                if (wei < 1e-3) continue; // do not draw empty or very small bins
 
@@ -2820,7 +2820,7 @@
             biny = yaxis.GetBinCenter(j+1); gry = main.gry(biny);
             for (k = k1; k < k2; ++k) {
                bin_content = histo.getBinContent(i+1, j+1, k+1);
-               if ((bin_content===0) || (bin_content < this.gminbin)) continue;
+               if (!this.options.Color && ((bin_content===0) || (bin_content < this.gminbin))) continue;
 
                wei = use_scale ? Math.pow(Math.abs(bin_content*use_scale), 0.3333) : 1;
                if (wei < 1e-3) continue; // do not show very small bins
@@ -3081,7 +3081,7 @@
 
       painter.options = { Box: 0, Scatter: false, Sphere: 0, Color: false, minimum: -1111, maximum: -1111 };
 
-      var kind = painter.v7EvalAttr("kind", "col"),
+      var kind = painter.v7EvalAttr("kind", ""),
           sub = painter.v7EvalAttr("sub", 0),
           o = painter.options;
 

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -1,14 +1,14 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// This macro generates a small V7 TH1D, fills it and draw it in a V7 canvas.
+/// This macro generates two RH1D, fills them and draw with different options in RCanvas.
 /// The canvas is display in the web browser
 ///
 /// \macro_code
 ///
 /// \date 2015-03-22
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-/// \author Axel Naumann <axel@cern.ch>
+/// \authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
@@ -18,6 +18,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include "ROOT/RHist.hxx"
 #include "ROOT/RHistDrawable.hxx"
 #include "ROOT/RFrameTitle.hxx"
 #include "ROOT/RCanvas.hxx"
@@ -42,7 +43,7 @@ void draw_rh1()
    }
 
    // Create a canvas to be displayed.
-   auto canvas = RCanvas::Create("Canvas Title");
+   auto canvas = RCanvas::Create("RH1 drawing options");
 
    // histograms colors
    auto col1 = RColor::kRed, col2 = RColor::kBlue;

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -51,25 +51,24 @@ void draw_rh1()
    auto subpads = canvas->Divide(2,3);
 
    // default draw option
-   subpads[0][0]->Draw<RFrameTitle>("Default \"hist\" draw options");
+   subpads[0][0]->Draw<RFrameTitle>("Default RH1 drawing");
    subpads[0][0]->Draw(pHist1)->AttrLine().SetColor(col1).SetWidth(2);
    subpads[0][0]->Draw(pHist2)->AttrLine().SetColor(col2).SetWidth(4);
 
    // errors draw options
-   subpads[1][0]->Draw<RFrameTitle>("Errors draw options");
+   subpads[1][0]->Draw<RFrameTitle>("Error() draw options");
    subpads[1][0]->Draw(pHist1)->Error(1).AttrLine().SetColor(col1);
    subpads[1][0]->Draw(pHist2)->Error(4).AttrFill().SetColor(col2).SetStyle(3003);
 
    // text and marker draw options
-   subpads[0][1]->Draw<RFrameTitle>("Text and marker draw options");
+   subpads[0][1]->Draw<RFrameTitle>("Text() and Marker() draw options");
    subpads[0][1]->Draw(pHist1)->Text(true).AttrText().SetColor(col1);
    subpads[0][1]->Draw(pHist2)->Marker().AttrMarker().SetColor(col2).SetStyle(30).SetSize(1.5);
 
    // text and marker draw options
-   subpads[1][1]->Draw<RFrameTitle>("Bar draw options");
-   subpads[1][1]->Draw(pHist1)->Bar().AttrFill().SetColor(col1);
-   subpads[1][1]->Draw(pHist2)->Bar3D().AttrFill().SetColor(col2);
-
+   subpads[1][1]->Draw<RFrameTitle>("Bar() and Bar3D() draw options");
+   subpads[1][1]->Draw(pHist1)->Bar(0,0.5).AttrFill().SetColor(col1);
+   subpads[1][1]->Draw(pHist2)->Bar3D(0.5,0.5).AttrFill().SetColor(col2);
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -65,6 +65,11 @@ void draw_rh1()
    subpads[0][1]->Draw(pHist1)->Text(true).AttrText().SetColor(col1);
    subpads[0][1]->Draw(pHist2)->Marker().AttrMarker().SetColor(col2).SetStyle(30).SetSize(1.5);
 
+   // text and marker draw options
+   subpads[1][1]->Draw<RFrameTitle>("Bar draw options");
+   subpads[1][1]->Draw(pHist1)->Bar().AttrFill().SetColor(col1);
+   subpads[1][1]->Draw(pHist2)->Bar3D().AttrFill().SetColor(col2);
+
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -60,6 +60,12 @@ void draw_rh1()
    subpads[1][0]->Draw(pHist1)->Error(1).AttrLine().SetColor(col1);
    subpads[1][0]->Draw(pHist2)->Error(4).AttrFill().SetColor(col2).SetStyle(3003);
 
+   // text and marker draw options
+   subpads[0][1]->Draw<RFrameTitle>("Text and marker draw options");
+   subpads[0][1]->Draw(pHist1)->Text(true).AttrText().SetColor(col1);
+   subpads[0][1]->Draw(pHist2)->Marker().AttrMarker().SetColor(col2).SetStyle(30).SetSize(1.5);
+
+
    canvas->SetSize(1000, 700);
    canvas->Show();
 }

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -19,6 +19,7 @@
  *************************************************************************/
 
 #include "ROOT/RHistDrawable.hxx"
+#include "ROOT/RFrameTitle.hxx"
 #include "ROOT/RCanvas.hxx"
 #include "TRandom.h"
 
@@ -42,6 +43,9 @@ void draw_rh1()
 
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
+
+   canvas->Draw<RFrameTitle>("Default \"hist\" draw option");
+
    auto draw1 = canvas->Draw(pHist);
    draw1->AttrLine().SetColor(RColor::kRed).SetWidth(2);
 

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -33,24 +33,32 @@ void draw_rh1()
 {
    // Create the histogram.
    RAxisConfig xaxis(25, 0., 10.);
-   auto pHist = std::make_shared<RH1D>(xaxis);
+   auto pHist1 = std::make_shared<RH1D>(xaxis);
    auto pHist2 = std::make_shared<RH1D>(xaxis);
 
    for (int n=0;n<1000;n++) {
-      pHist->Fill(gRandom->Gaus(3,0.8));
+      pHist1->Fill(gRandom->Gaus(3,0.8));
       pHist2->Fill(gRandom->Gaus(7,1.2));
    }
 
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
 
-   canvas->Draw<RFrameTitle>("Default \"hist\" draw option");
+   // histograms colors
+   auto col1 = RColor::kRed, col2 = RColor::kBlue;
 
-   auto draw1 = canvas->Draw(pHist);
-   draw1->AttrLine().SetColor(RColor::kRed).SetWidth(2);
+   // Divide canvas on 2x3 sub-pads to show different draw options
+   auto subpads = canvas->Divide(2,3);
 
-   auto draw2 = canvas->Draw(pHist2);
-   draw2->AttrLine().SetColor(RColor::kBlue).SetWidth(4);
+   // default draw option
+   subpads[0][0]->Draw<RFrameTitle>("Default \"hist\" draw options");
+   subpads[0][0]->Draw(pHist1)->AttrLine().SetColor(col1).SetWidth(2);
+   subpads[0][0]->Draw(pHist2)->AttrLine().SetColor(col2).SetWidth(4);
+
+   // errors draw options
+   subpads[1][0]->Draw<RFrameTitle>("Errors draw options");
+   subpads[1][0]->Draw(pHist1)->Error(1).AttrLine().SetColor(col1);
+   subpads[1][0]->Draw(pHist2)->Error(4).AttrFill().SetColor(col2).SetStyle(3003);
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -70,6 +70,15 @@ void draw_rh1()
    subpads[1][1]->Draw(pHist1)->Bar(0,0.5).AttrFill().SetColor(col1);
    subpads[1][1]->Draw(pHist2)->Bar3D(0.5,0.5).AttrFill().SetColor(col2);
 
+   // line draw option
+   subpads[0][2]->Draw<RFrameTitle>("Line() draw option");
+   subpads[0][2]->Draw(pHist1)->Line().AttrLine().SetColor(col1);
+   subpads[0][2]->Draw(pHist2)->Line().AttrLine().SetColor(col2);
+
+   // lego draw option
+   subpads[1][2]->Draw<RFrameTitle>("Lego() draw option");
+   subpads[1][2]->Draw(pHist1)->Lego().AttrFill().SetColor(col1);
+
    canvas->SetSize(1000, 700);
    canvas->Show();
 }

--- a/tutorials/v7/draw_rh2.cxx
+++ b/tutorials/v7/draw_rh2.cxx
@@ -1,0 +1,74 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// This macro generates RH2D and draw it with different options in RCanvas
+///
+/// \macro_code
+///
+/// \date 2020-06-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \author Sergey Linev <s.linev@gsi.de>
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RHist.hxx"
+#include "ROOT/RHistDrawable.hxx"
+#include "ROOT/RFrameTitle.hxx"
+#include "ROOT/RCanvas.hxx"
+#include "TRandom.h"
+
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
+R__LOAD_LIBRARY(libROOTHistDraw)
+
+using namespace ROOT::Experimental;
+
+void draw_rh2()
+{
+   // Create the histogram.
+   RAxisConfig xaxis("x", 20, 0., 10.);
+   RAxisConfig yaxis("y", 20, 0., 10.);
+   auto pHist = std::make_shared<RH2D>(xaxis, yaxis);
+
+   for (int n=0;n<10000;n++)
+      pHist->Fill({gRandom->Gaus(5.,2.), gRandom->Gaus(5.,2.)});
+
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create("RH2 drawing options");
+
+   // Divide canvas on 2x3 sub-pads to show different draw options
+   auto subpads = canvas->Divide(2,3);
+
+   // default draw option
+   subpads[0][0]->Draw<RFrameTitle>("Color() draw option (default)");
+   subpads[0][0]->Draw(pHist);
+
+   // contour draw options
+   subpads[1][0]->Draw<RFrameTitle>("Contour() draw option");
+   subpads[1][0]->Draw(pHist)->Contour();
+
+   // text draw options
+   subpads[0][1]->Draw<RFrameTitle>("Text() draw option");
+   subpads[0][1]->Draw(pHist)->Text(true).AttrText().SetColor(RColor::kBlue);
+
+   // arrow draw options
+   subpads[1][1]->Draw<RFrameTitle>("Arrow() draw option");
+   subpads[1][1]->Draw(pHist)->Arrow().AttrLine().SetColor(RColor::kRed);
+
+   // lego draw options
+   subpads[0][2]->Draw<RFrameTitle>("Lego() draw option");
+   subpads[0][2]->Draw(pHist)->Lego(2);
+
+   // surf draw option
+   subpads[1][2]->Draw<RFrameTitle>("Surf() draw option");
+   subpads[1][2]->Draw(pHist)->Surf(2);
+
+   canvas->SetSize(1000, 700);
+   canvas->Show();
+}

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -56,7 +56,7 @@ void draw_rh2_colz()
 
    frame->AttrY().SetZoomMinMax(2.,8.);
 
-   canvas->Draw<RFrameTitle>("2D histogram with color palette");
+   canvas->Draw<RFrameTitle>("2D histogram with color palette")->SetMargin(0.01_normal).SetHeight(0.09_normal);
 
    canvas->Draw<RPaletteDrawable>(RPalette::GetPalette(), true);
 

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -66,6 +66,7 @@ void draw_rh2_colz()
    // draw->Lego(2); // configure lego2 draw option
    // draw->Contour(); // configure cont draw option
    // draw->Scatter(); // configure color draw option (default)
+   // draw->Arrow(); // configure arrow draw option
    draw->Color(); // configure color draw option (default)
    draw->Text(true); // configure text drawing (can be enabled with most 2d options)
 

--- a/tutorials/v7/draw_rh3.cxx
+++ b/tutorials/v7/draw_rh3.cxx
@@ -47,7 +47,7 @@ void draw_rh3()
 
    auto draw = canvas->Draw(pHist);
    draw->SetColor(RColor::kBlue); // use color in some draw options
-   draw->SetLineColor(RColor::kRed);
+   draw->AttrLine().SetColor(RColor::kRed);
    draw->Scatter(); // scatter plot
    draw->Sphere(1); // draw spheres 0 - default, 1 - with colors
    draw->Color(); // draw colored boxes

--- a/tutorials/v7/draw_rh3.cxx
+++ b/tutorials/v7/draw_rh3.cxx
@@ -1,12 +1,12 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// This macro generates a small V7 TH2D, fills it with random values and
-/// draw it in a V7 canvas, using configured web browser
+/// This macro generates a small RH3D, fills it with random values and
+/// draw it in RCanvas, using configured web browser
 ///
 /// \macro_code
 ///
-/// \date 2020-03-04
+/// \date 2020-06-18
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 /// \author Sergey Linev <s.linev@gsi.de>
 
@@ -18,6 +18,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include "ROOT/RHist.hxx"
 #include "ROOT/RHistDrawable.hxx"
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/RFrameTitle.hxx"
@@ -41,17 +42,26 @@ void draw_rh3()
       pHist->Fill({gRandom->Gaus(0.,2.), gRandom->Gaus(0.,2.), gRandom->Gaus(0.,2.)});
 
    // Create a canvas to be displayed.
-   auto canvas = RCanvas::Create("Canvas Title");
+   auto canvas = RCanvas::Create("RH3D drawing options");
 
-   canvas->Draw<RFrameTitle>("3D histogram drawing");
+   // Divide canvas on 2x2 sub-pads to show different draw options
+   auto subpads = canvas->Divide(2,2);
 
-   auto draw = canvas->Draw(pHist);
-   draw->SetColor(RColor::kBlue); // use color in some draw options
-   draw->AttrLine().SetColor(RColor::kRed);
-   draw->Scatter(); // scatter plot
-   draw->Sphere(1); // draw spheres 0 - default, 1 - with colors
-   draw->Color(); // draw colored boxes
-   draw->Box(0); // draw boxes 0 - default, 1 - with colors, 2 - without lines
+   // default draw option
+   subpads[0][0]->Draw<RFrameTitle>("Box(0) default draw option");
+   subpads[0][0]->Draw(pHist)->Box(0).AttrFill().SetColor(RColor::kBlue);
+
+   // sphere draw options
+   subpads[1][0]->Draw<RFrameTitle>("Sphere(1) draw option");
+   subpads[1][0]->Draw(pHist)->Sphere(1);
+
+   // text draw options
+   subpads[0][1]->Draw<RFrameTitle>("Color() draw option");
+   subpads[0][1]->Draw(pHist)->Color();
+
+   // arrow draw options
+   subpads[1][1]->Draw<RFrameTitle>("Scatter() draw option");
+   subpads[1][1]->Draw(pHist)->Scatter().AttrFill().SetColor(RColor::kBlack);
 
    canvas->SetSize(1000, 700);
    canvas->Show();


### PR DESCRIPTION
Improve class design around `RAttrBase` classes. 
Introduce `RAttrValue<typename T>` template class to access single value from attributes.
Use it in all attributes classes and existing drawable classes. 
Let specify in single place type, string name and default value for each attribute.

Add following draw options for `RH1`:
   * `Error()`
   * `Text()`
   * `Marker()`
   * `Bar()`
   * `Line()`
   * `Lego()`

Add `Arrow()` draw option for `RH2`

Fix problem with 3D drawings - objects which position related to frame (which is not visible in 3D) now positioned and moved correctly after pad resize

Provide draw options overview macros: `draw_rh1.cxx` (see attached image), `draw_rh2.cxx`, `draw_rh3.cxx`

![draw_rh1](https://user-images.githubusercontent.com/4936580/85689202-b7b98e80-b6d2-11ea-82fe-2a3b33fa0b37.png)
