### PR TITLE
No need to check pandoc version anymore

### DIFF
--- a/documentation/HttpServer/Makefile
+++ b/documentation/HttpServer/Makefile
@@ -1,12 +1,6 @@
 MDFILES=titlepage.md HttpServer.md
 
-# define the pandoc options according to the pandoc version.
-PANDOC_VERSION=$(shell pandoc -v | grep "pandoc "  | sed -e "s/pandoc //")
-ifeq ($(PANDOC_VERSION),2.2)
 OPTIONS=-s -f markdown+smart --toc --toc-depth=2 --top-level-division=chapter --number-sections
-else
-OPTIONS=-s -S -f markdown --toc --toc-depth=2 --chapters --number-sections
-endif
 
 OPTIONSHTML=-H css/github.css --mathjax
 OPTIONSEPUB=--mathml --epub-cover-image=figures/cover.png

--- a/documentation/JSROOT/Makefile
+++ b/documentation/JSROOT/Makefile
@@ -1,12 +1,6 @@
 MDFILES=titlepage.md JSROOT.md
 
-# define the pandoc options according to the pandoc version.
-PANDOC_VERSION=$(shell pandoc -v | grep "pandoc "  | sed -e "s/pandoc //")
-ifeq ($(PANDOC_VERSION),2.2)
 OPTIONS=-s -f markdown+smart --toc --toc-depth=2 --top-level-division=chapter --number-sections
-else
-OPTIONS=-s -S -f markdown --toc --toc-depth=2 --chapters --number-sections
-endif
 
 OPTIONSHTML=-H css/github.css --mathjax
 OPTIONSEPUB=--mathml --epub-cover-image=figures/cover.png

--- a/documentation/minuit2/Makefile
+++ b/documentation/minuit2/Makefile
@@ -1,12 +1,6 @@
 MDFILES=titlepage.md Minuit2.md
 
-# define the pandoc options according to the pandoc version.
-PANDOC_VERSION=$(shell pandoc -v | grep "pandoc "  | sed -e "s/pandoc //")
-ifeq ($(PANDOC_VERSION),2.2)
 OPTIONS=-s -f markdown+smart --toc --toc-depth=2 --top-level-division=chapter --number-sections
-else
-OPTIONS=-s -S -f markdown --toc --toc-depth=2 --chapters --number-sections
-endif
 
 OPTIONSHTML=-H css/github.css --mathjax
 OPTIONSEPUB=--mathml --epub-cover-image=figures/cover.png

--- a/documentation/primer/Makefile
+++ b/documentation/primer/Makefile
@@ -8,13 +8,7 @@ MDFILESMOD=abstract_preprocessed.md Introduction_preprocessed.md ROOT_as_calcula
 	   functions_and_parameter_estimation_preprocessed.md filio_preprocessed.md root_in_python_preprocessed.md \
 	   concludingRemarks_preprocessed.md references_preprocessed.md
 
-# define the pandoc options according to the pandoc version.
-PANDOC_VERSION=$(shell pandoc -v | grep "pandoc "  | sed -e "s/pandoc //")
-ifeq ($(PANDOC_VERSION),2.2)
 OPTIONS=-s -f markdown+smart --toc --toc-depth=2 --top-level-division=chapter --number-sections --bibliography=bibliography.bib
-else
-OPTIONS=-s -S -f markdown --toc --chapters --number-sections --bibliography=bibliography.bib
-endif
 
 OPTIONSHTML=-H css/github.css --mathjax
 OPTIONSEPUB=--mathml --epub-cover-image=figures/Cover.png

--- a/documentation/spectrum/Makefile
+++ b/documentation/spectrum/Makefile
@@ -1,12 +1,6 @@
 MDFILES=titlepage.md Spectrum.md
 
-# define the pandoc options according to the pandoc version.
-PANDOC_VERSION=$(shell pandoc -v | grep "pandoc "  | sed -e "s/pandoc //")
-ifeq ($(PANDOC_VERSION),2.2)
 OPTIONS=-s -f markdown+smart --toc --toc-depth=2 --top-level-division=chapter --number-sections
-else
-OPTIONS=-s -S -f markdown --toc --toc-depth=2 --chapters --number-sections
-endif
 
 OPTIONSHTML=-H css/github.css --mathjax
 OPTIONSEPUB=--mathml --epub-cover-image=figures/cover.png

--- a/documentation/users-guide/Makefile
+++ b/documentation/users-guide/Makefile
@@ -14,13 +14,7 @@ PDFFILES=$(addprefix $(OUTDIR)/,$(MDFILES:.md=.pdf))
 LATEXA4PREFIX=ROOTUsersGuideA4
 LATEXLETTERPREFIX=ROOTUsersGuideLetter
 
-# define the pandoc options according to the pandoc version.
-PANDOC_VERSION=$(shell pandoc -v | grep "pandoc "  | sed -e "s/pandoc //")
-ifeq ($(PANDOC_VERSION),2.2)
 OPTIONS=-s -f markdown+smart --toc --toc-depth=2 --top-level-division=chapter --number-sections
-else
-OPTIONS=-s -S -f markdown --toc --toc-depth=2 --chapters --number-sections
-endif
 
 OPTIONSHTML=-H css/github.css --mathjax
 OPTIONSEPUB=--mathml


### PR DESCRIPTION
panda 2.2 used to be the more recent version and a special check was needed in case a version older that 2.2 was used.
Some options were backward incompatible between version older that 2.2 and version 2.2.

Now on the jenkins machine used to build the guides, the pandoc version is 2.5 so we do not need to check on pandoc version anymore. And  the way the test was done produced a wrong set of options for versions above 2.2.