### PR TITLE
[io] TDirectoryFile is now explicit about cycle meaning.

### DIFF
--- a/io/io/inc/TKey.h
+++ b/io/io/inc/TKey.h
@@ -92,6 +92,7 @@ protected:
    virtual void        IncrementPidOffset(UShort_t offset);
            Bool_t      IsFolder() const;
    virtual void        Keep();
+   virtual void        ls(Bool_t current) const;
    virtual void        ls(Option_t *option="") const;
    virtual void        Print(Option_t *option="") const;
    virtual Int_t       Read(TObject *obj);

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1164,13 +1164,23 @@ void TDirectoryFile::ls(Option_t *option) const
       }
    }
 
-   if (diskobj) {
-      TKey *key;
-      TIter next(GetListOfKeys());
-      while ((key = (TKey *) next())) {
+   if (diskobj && fKeys) {
+      //*-* Loop on all the keys
+      TObjLink *lnk = fKeys->FirstLink();
+      while (lnk) {
+         TKey *key = (TKey*)lnk->GetObject();
          TString s = key->GetName();
          if (s.Index(re) == kNPOS) continue;
-         key->ls();                 //*-* Loop on all the keys
+         bool first = (lnk->Prev() == nullptr) || (s != lnk->Prev()->GetObject()->GetName());
+         bool hasbackup = (lnk->Next() != nullptr) && (s == lnk->Next()->GetObject()->GetName());
+         if (first)
+            if (hasbackup)
+               key->ls(true);
+            else
+               key->ls();
+         else
+            key->ls(false);
+         lnk = lnk->Next();
       }
    }
    TROOT::DecreaseDirLevel();

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -689,6 +689,18 @@ void TKey::Keep()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// List Key contents.
+/// Add indicator of whether it is the current item or a backup copy.
+
+void TKey::ls(Bool_t current) const
+{
+   TROOT::IndentLevel();
+   std::cout <<"KEY: "<<fClassName<<"\t"<<GetName()<<";"<<GetCycle()<<"\t"<<GetTitle();
+   std::cout << (current ? " [current cycle]" : " [backup cycle]");
+   std::cout <<std::endl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// List Key contents.
 
 void TKey::ls(Option_t *) const
 {


### PR DESCRIPTION
The new layout add "[current cycle]" or "[backup cycle]" at the end of the line:

TFile**         tutorials/hsimple.root  Demo ROOT file with histograms
 TFile*         tutorials/hsimple.root  Demo ROOT file with histograms
  KEY: TH1F     hpx;2   This is the px distribution [current cycle]
  KEY: TH1F     hpx;1   This is the px distribution [backup cycle]
  KEY: TH2F     hpxpy;1 py vs px
  KEY: TProfile hprof;1 Profile of pz versus px
  KEY: TNtuple  ntuple;1        Demo ntuple