### PR TITLE
Correctly cleanup data in TTF (ROOT-10882)

### DIFF
--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -64,9 +64,9 @@ TTF helper class containing glyphs description.
 
    class TTGlyph {
    public:
-      UInt_t     fIndex; ///< glyph index in face
-      FT_Vector  fPos;   ///< position of glyph origin
-      FT_Glyph   fImage; ///< glyph image
+      UInt_t     fIndex{0};     ///< glyph index in face
+      FT_Vector  fPos;          ///< position of glyph origin
+      FT_Glyph   fImage{nullptr}; ///< glyph image
    };
 
 protected:

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -42,7 +42,7 @@ Int_t          TTF::fgSymbItaFontIdx = -1;
 Int_t          TTF::fgFontCount      = 0;
 Int_t          TTF::fgNumGlyphs      = 0;
 char          *TTF::fgFontName[kTTMaxFonts];
-FT_Matrix     *TTF::fgRotMatrix;
+FT_Matrix     *TTF::fgRotMatrix      = nullptr;
 FT_Library     TTF::fgLibrary;
 FT_BBox        TTF::fgCBox;
 FT_Face        TTF::fgFace[kTTMaxFonts];

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -212,7 +212,10 @@ void TTF::LayoutGlyphs()
       origin.y = 0;
 
       // clear existing image if there is one
-      if (glyph->fImage) FT_Done_Glyph(glyph->fImage);
+      if (glyph->fImage) {
+         FT_Done_Glyph(glyph->fImage);
+         glyph->fImage = nullptr;
+      }
 
       // load the glyph image (in its native format)
       if (FT_Load_Glyph(fgFace[fgCurFontIdx], glyph->fIndex, load_flags))


### PR DESCRIPTION
Created image may be cleaned up many times, causing ROOT crash
One also should initialize that pointer properly

Actually, created images should be cleaned up immediately after they were used,
but this requires more changes