### PR TITLE
[cling] External llvm does not have config.h

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -25,15 +25,10 @@
 #include <unordered_set>
 #include <vector>
 
-#include "llvm/Config/config.h" // Get configuration settings
-
-#if defined(HAVE_DLFCN_H) && defined(HAVE_DLOPEN)
+#ifdef LLVM_ON_UNIX
 #include <dlfcn.h>
-#endif
-
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
-#endif // HAVE_UNISTD_H
+#endif // LLVM_ON_UNIX
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>


### PR DESCRIPTION
This should fix the issue when cling is built against prebuilt llvm on setups
such as conda.

Should partially fix ROOT-10812