### PR TITLE
[Tutorials] Veto df103_NanoAODHiggsAnalysis on Mac 10.13

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -89,6 +89,10 @@ if(NOT sqlite)
     list(APPEND dataframe_veto dataframe/*SQlite*)
 endif()
 
+if(MACOSX_VERSION VERSION_EQUAL 10.13)
+   list(APPEND dataframe_veto dataframe/df103_NanoAODHiggsAnalysis.*)
+endif()
+
 if(NOT ROOT_mlp_FOUND)
    set(mlp_veto legacy/mlp/*.C)
 endif()


### PR DESCRIPTION
Because of these errors (see e.g. https://bit.ly/31y2jSa):

```
Plugin dlopen(libXrdSecgsi-4.so, 256): image not found sec.protocol libXrdSecgsi-4.so
Secsss: 0x30 cryptography load failed; Protocol not supported
```