### PR TITLE
Implement fast running versions of RDF tutorials

### DIFF
--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
@@ -21,6 +21,10 @@
 /// 3. Reconstruct the Higgs boson from the remaining Z boson candidates and calculate
 ///    its invariant mass.
 ///
+/// The tutorial has the fast mode enabled by default, which reads the data from already skimmed
+/// datasets with a total size of only 51MB. If the fast mode is disabled, the tutorial runs over
+/// the full dataset with a size of 12GB.
+///
 /// \macro_image
 /// \macro_code
 /// \macro_output
@@ -37,6 +41,7 @@
 #include "TLegend.h"
 #include "Math/Vector4Dfwd.h"
 #include "TStyle.h"
+#include <string>
 
 using namespace ROOT::VecOps;
 using RNode = ROOT::RDF::RNode;
@@ -394,34 +399,35 @@ void plot(T sig, T bkg, T data, const std::string &x_label, const std::string &f
    c->SaveAs(filename.c_str());
 }
 
-void df103_NanoAODHiggsAnalysis()
+void df103_NanoAODHiggsAnalysis(const bool run_fast = true)
 {
    // Enable multi-threading
    ROOT::EnableImplicitMT();
 
+   // In fast mode, take samples from */cms_opendata_2012_nanoaod_skimmed/*, which has
+   // the preselections from the selection_* functions already applied.
+   std::string path = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod";
+   if (run_fast) path += "_skimmed";
+
    // Create dataframes for signal, background and data samples
 
    // Signal: Higgs -> 4 leptons
-   ROOT::RDataFrame df_sig_4l("Events",
-                              "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/SMHiggsToZZTo4L.root");
+   ROOT::RDataFrame df_sig_4l("Events", path + "/SMHiggsToZZTo4L.root");
 
    // Background: ZZ -> 4 leptons
    // Note that additional background processes from the original paper with minor contribution were left out for this
    // tutorial.
-   ROOT::RDataFrame df_bkg_4mu("Events",
-                               "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/ZZTo4mu.root");
-   ROOT::RDataFrame df_bkg_4el("Events",
-                               "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/ZZTo4e.root");
-   ROOT::RDataFrame df_bkg_2el2mu("Events",
-                                  "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/ZZTo2e2mu.root");
+   ROOT::RDataFrame df_bkg_4mu("Events", path + "/ZZTo4mu.root");
+   ROOT::RDataFrame df_bkg_4el("Events", path + "/ZZTo4e.root");
+   ROOT::RDataFrame df_bkg_2el2mu("Events", path + "/ZZTo2e2mu.root");
 
    // CMS data taken in 2012 (11.6 fb^-1 integrated luminosity)
    ROOT::RDataFrame df_data_doublemu(
-      "Events", {"root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
-                 "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012C_DoubleMuParked.root"});
+      "Events", {path + "/Run2012B_DoubleMuParked.root",
+                 path + "/Run2012C_DoubleMuParked.root"});
    ROOT::RDataFrame df_data_doubleel(
-      "Events", {"root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleElectron.root",
-                 "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012C_DoubleElectron.root"});
+      "Events", {path + "/Run2012B_DoubleElectron.root",
+                 path + "/Run2012C_DoubleElectron.root"});
 
    // Reconstruct Higgs to 4 muons
    auto df_sig_4mu_reco = reco_higgs_to_4mu(df_sig_4l);
@@ -500,5 +506,6 @@ void df103_NanoAODHiggsAnalysis()
 
 int main()
 {
-   df103_NanoAODHiggsAnalysis();
+   const auto run_fast = true;
+   df103_NanoAODHiggsAnalysis(run_fast);
 }

--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.C
@@ -406,28 +406,26 @@ void df103_NanoAODHiggsAnalysis(const bool run_fast = true)
 
    // In fast mode, take samples from */cms_opendata_2012_nanoaod_skimmed/*, which has
    // the preselections from the selection_* functions already applied.
-   std::string path = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod";
-   if (run_fast) path += "_skimmed";
+   std::string path = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/";
+   if (run_fast) path = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod_skimmed/";
 
    // Create dataframes for signal, background and data samples
 
    // Signal: Higgs -> 4 leptons
-   ROOT::RDataFrame df_sig_4l("Events", path + "/SMHiggsToZZTo4L.root");
+   ROOT::RDataFrame df_sig_4l("Events", path + "SMHiggsToZZTo4L.root");
 
    // Background: ZZ -> 4 leptons
    // Note that additional background processes from the original paper with minor contribution were left out for this
    // tutorial.
-   ROOT::RDataFrame df_bkg_4mu("Events", path + "/ZZTo4mu.root");
-   ROOT::RDataFrame df_bkg_4el("Events", path + "/ZZTo4e.root");
-   ROOT::RDataFrame df_bkg_2el2mu("Events", path + "/ZZTo2e2mu.root");
+   ROOT::RDataFrame df_bkg_4mu("Events", path + "ZZTo4mu.root");
+   ROOT::RDataFrame df_bkg_4el("Events", path + "ZZTo4e.root");
+   ROOT::RDataFrame df_bkg_2el2mu("Events", path + "ZZTo2e2mu.root");
 
    // CMS data taken in 2012 (11.6 fb^-1 integrated luminosity)
    ROOT::RDataFrame df_data_doublemu(
-      "Events", {path + "/Run2012B_DoubleMuParked.root",
-                 path + "/Run2012C_DoubleMuParked.root"});
+      "Events", {path + "Run2012B_DoubleMuParked.root", path + "Run2012C_DoubleMuParked.root"});
    ROOT::RDataFrame df_data_doubleel(
-      "Events", {path + "/Run2012B_DoubleElectron.root",
-                 path + "/Run2012C_DoubleElectron.root"});
+      "Events", {path + "Run2012B_DoubleElectron.root", path + "Run2012C_DoubleElectron.root"});
 
    // Reconstruct Higgs to 4 muons
    auto df_sig_4mu_reco = reco_higgs_to_4mu(df_sig_4l);
@@ -506,6 +504,5 @@ void df103_NanoAODHiggsAnalysis(const bool run_fast = true)
 
 int main()
 {
-   const auto run_fast = true;
-   df103_NanoAODHiggsAnalysis(run_fast);
+   df103_NanoAODHiggsAnalysis(/*fast=*/true);
 }

--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.py
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.py
@@ -253,25 +253,25 @@ def plot(sig, bkg, data, x_label, filename):
 def df103_NanoAODHiggsAnalysis(run_fast = True):
     # In fast mode, take samples from */cms_opendata_2012_nanoaod_skimmed/*, which has
     # the preselections from the selection_* functions already applied.
-    path = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod"
-    if run_fast: path += "_skimmed"
+    path = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/"
+    if run_fast: path = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod_skimmed/"
 
     # Create dataframes for signal, background and data samples
 
     # Signal: Higgs -> 4 leptons
-    df_sig_4l = ROOT.RDataFrame("Events", path + "/SMHiggsToZZTo4L.root")
+    df_sig_4l = ROOT.RDataFrame("Events", path + "SMHiggsToZZTo4L.root")
 
     # Background: ZZ -> 4 leptons
     # Note that additional background processes from the original paper
     # with minor contribution were left out for this
     # tutorial.
-    df_bkg_4mu = ROOT.RDataFrame("Events", path + "/ZZTo4mu.root")
-    df_bkg_4el = ROOT.RDataFrame("Events", path + "/ZZTo4e.root")
-    df_bkg_2el2mu = ROOT.RDataFrame("Events", path + "/ZZTo2e2mu.root")
+    df_bkg_4mu = ROOT.RDataFrame("Events", path + "ZZTo4mu.root")
+    df_bkg_4el = ROOT.RDataFrame("Events", path + "ZZTo4e.root")
+    df_bkg_2el2mu = ROOT.RDataFrame("Events", path + "ZZTo2e2mu.root")
 
     # CMS data taken in 2012 (11.6 fb^-1 integrated luminosity)
-    df_data_doublemu = ROOT.RDataFrame("Events", (path + f for f in ["/Run2012B_DoubleMuParked.root", "/Run2012B_DoubleMuParked.root"]))
-    df_data_doubleel = ROOT.RDataFrame("Events", (path + f for f in ["/Run2012B_DoubleElectron.root", "/Run2012B_DoubleElectron.root"]))
+    df_data_doublemu = ROOT.RDataFrame("Events", (path + f for f in ["Run2012B_DoubleMuParked.root", "Run2012B_DoubleMuParked.root"]))
+    df_data_doubleel = ROOT.RDataFrame("Events", (path + f for f in ["Run2012B_DoubleElectron.root", "Run2012B_DoubleElectron.root"]))
 
     # Number of bins for all histograms
     nbins = 36

--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.py
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.py
@@ -22,6 +22,10 @@
 ## in C++, have been moved to a header that is then declared to the ROOT C++ interpreter. The functions that instead
 ## create nodes of the computational graph (e.g. Filter, Define) remain inside the main Python script.
 ##
+## The tutorial has the fast mode enabled by default, which reads the data from already skimmed
+## datasets with a total size of only 51MB. If the fast mode is disabled, the tutorial runs over
+## the full dataset with a size of 12GB.
+##
 ## \macro_image
 ## \macro_code
 ## \macro_output
@@ -246,38 +250,28 @@ def plot(sig, bkg, data, x_label, filename):
     d.SaveAs(filename)
 
 
-def df103_NanoAODHiggsAnalysis():
+def df103_NanoAODHiggsAnalysis(run_fast = True):
+    # In fast mode, take samples from */cms_opendata_2012_nanoaod_skimmed/*, which has
+    # the preselections from the selection_* functions already applied.
+    path = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod"
+    if run_fast: path += "_skimmed"
+
     # Create dataframes for signal, background and data samples
 
     # Signal: Higgs -> 4 leptons
-    df_sig_4l = ROOT.RDataFrame("Events",
-                                "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/SMHiggsToZZTo4L.root")
+    df_sig_4l = ROOT.RDataFrame("Events", path + "/SMHiggsToZZTo4L.root")
 
     # Background: ZZ -> 4 leptons
     # Note that additional background processes from the original paper
     # with minor contribution were left out for this
     # tutorial.
-    df_bkg_4mu = ROOT.RDataFrame("Events",
-                                 "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/ZZTo4mu.root")
-
-    df_bkg_4el = ROOT.RDataFrame("Events",
-                                 "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/ZZTo4e.root")
-
-    df_bkg_2el2mu = ROOT.RDataFrame("Events",
-                                    "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/ZZTo2e2mu.root")
+    df_bkg_4mu = ROOT.RDataFrame("Events", path + "/ZZTo4mu.root")
+    df_bkg_4el = ROOT.RDataFrame("Events", path + "/ZZTo4e.root")
+    df_bkg_2el2mu = ROOT.RDataFrame("Events", path + "/ZZTo2e2mu.root")
 
     # CMS data taken in 2012 (11.6 fb^-1 integrated luminosity)
-    doublemu_files = ROOT.std.vector("string")(2)
-    doublemu_files[0] = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root"
-    doublemu_files[1] = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012C_DoubleMuParked.root"
-
-    df_data_doublemu = ROOT.RDataFrame("Events", doublemu_files)
-
-    doubleel_files = ROOT.std.vector("string")(2)
-    doubleel_files[0] = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleElectron.root"
-    doubleel_files[1] = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012C_DoubleElectron.root"
-
-    df_data_doubleel = ROOT.RDataFrame("Events", doubleel_files)
+    df_data_doublemu = ROOT.RDataFrame("Events", (path + f for f in ["/Run2012B_DoubleMuParked.root", "/Run2012B_DoubleMuParked.root"]))
+    df_data_doubleel = ROOT.RDataFrame("Events", (path + f for f in ["/Run2012B_DoubleElectron.root", "/Run2012B_DoubleElectron.root"]))
 
     # Number of bins for all histograms
     nbins = 36
@@ -395,4 +389,5 @@ def df103_NanoAODHiggsAnalysis():
 
 
 if __name__ == "__main__":
-    df103_NanoAODHiggsAnalysis()
+    run_fast = True
+    df103_NanoAODHiggsAnalysis(run_fast)


### PR DESCRIPTION
I've preskimmed the files for df103, which is now reduced from 12GB to 51MB. The fast mode is enabled by default for the tutorials, though we can still run the full version in the benchmarks. The difference is simply the postfix `_skimmed` in the filepath.