### PR TITLE
Eve-7:  Finalize multiple selection 

### DIFF
--- a/graf3d/eve7/src/REveSelection.cxx
+++ b/graf3d/eve7/src/REveSelection.cxx
@@ -510,12 +510,21 @@ void REveSelection::NewElementPicked(ElementId_t id, bool multi, bool secondary,
       {
          if (rec)
          {
-            if (secondary || rec->is_secondary()) // ??? should actually be && ???
+            assert(secondary == rec->is_secondary());
+            if (secondary || rec->is_secondary())
             {
-               // XXXX union or difference:
-               // - if all secondary_idcs are already in the record, toggle
-               //   - if final result is empty set, remove element from selection
-               // - otherwise union
+               std::set<int> dup;
+               for (auto &ns :  secondary_idcs)
+               {
+                  int nsi = ns;
+                  auto ir = rec->f_sec_idcs.insert(nsi);
+                  if (!ir.second)
+                     dup.insert(nsi);
+               }
+
+               // erase duplicates
+               for (auto &dit :  dup)
+                  rec->f_sec_idcs.erase(dit);
             }
             else
             {
@@ -525,6 +534,9 @@ void REveSelection::NewElementPicked(ElementId_t id, bool multi, bool secondary,
          else
          {
             AddNiece(el);
+            rec = find_record(el);
+            rec->f_is_sec   = true;
+            rec->f_sec_idcs = secondary_idcs;
          }
       }
       else

--- a/ui5/eve7/lib/EveScene.js
+++ b/ui5/eve7/lib/EveScene.js
@@ -274,7 +274,7 @@ sap.ui.define([
 
       // other change bits
       if (el.render_data) {
-         if ((el.changeBit & this.mgr.EChangeBits.kCBObjProp) || (el.changeBit & this.mgr.EChangeBits.kCBColorSelection))
+         if ((el.changeBit & this.mgr.EChangeBits.kCBObjProps) || (el.changeBit & this.mgr.EChangeBits.kCBColorSelection))
          {
             this.replaceElement(el);
          }
@@ -308,7 +308,8 @@ sap.ui.define([
 
    /** interactive handler */
    EveScene.prototype.processElementHighlighted = function(obj3d, indx, evnt)
-   {
+    {
+        return;
       if (this.mgr.MatchSelection(this.mgr.global_selection_id, obj3d.eve_el, indx))
          return true;
 


### PR DESCRIPTION
This change enables multiple selection in secondary selectable objects. The current examples are digit set an line sets. Use 'Ctrl' key to add selected elements.