### PR TITLE
Compatibility with python 2.7 versions before 2.7.9

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
@@ -32,7 +32,7 @@ def _NumbaDeclareDecorator(input_types, return_type, name=None):
         import cffi
     except:
         raise Exception('Failed to import cffi')
-    import re
+    import re, sys
 
     # Normalize input types by stripping ROOT and VecOps namespaces from input types
     def normalize_typename(t):
@@ -195,7 +195,11 @@ def pywrapper({SIGNATURE}):
         if 'RVec' in return_type:
             glob['dtype_r'] = get_numba_type(get_inner_type(return_type))
 
-        exec(pywrappercode, glob, locals())
+        if sys.version_info[0] >= 3:
+            exec(pywrappercode, glob, locals()) in {}
+        else:
+            exec(pywrappercode) in glob, locals()
+
         if not 'pywrapper' in locals():
             raise Exception('Failed to create Python wrapper function:\n{}'.format(pywrappercode))
 


### PR DESCRIPTION
This is a workaround for https://bugs.python.org/issue21591 which
affect Python 2 versions before 2.7.9. This includes Python 2.7.5
which is the Python 2 version on RHEL/CentOS 7.

The packaging of root on EPEL 7 with the new pyroot implementaion fails with the followin error:
```
+ /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 1
Bytecompiling .py files below /builddir/build/BUILDROOT/root-6.22.00-1.el7.x86_64/usr/lib64/python2.7 using /usr/bin/python2.7
Compiling /builddir/build/BUILDROOT/root-6.22.00-1.el7.x86_64/usr/lib64/python2.7/site-packages/ROOT/_numbadeclare.py ...
SyntaxError: unqualified exec is not allowed in function 'inner' it is a nested function (_numbadeclare.py, line 198)
error: Bad exit status from /var/tmp/rpm-tmp.RNRIsm (%install)
```

### test1.py

This is a minimal reproducer of the existing code:
```python
def test():
    def inner():
        glob = dict(globals())
        glob['a'] = 123
        exec('print(a); b = 456', glob, locals())
        print(locals()['b'])
    return inner()
test()
```
This produces the expected output with Python 3:
```
$ python3 test1.py 
123
456
```
But when using Python 2 it reproduces the error from the root build:
```
$ python2 test1.py 
  File "test1.py", line 5
    exec('print(a); b = 456', glob, locals())
SyntaxError: unqualified exec is not allowed in function 'inner' it is a nested function
```

### test2.py 

If the Python 2 syntax is used for the exec command:
```python
def test():
    def inner():
        glob = dict(globals())
        glob['a'] = 123
        exec('print(a); b = 456') in glob, locals()
        print(locals()['b'])
    return inner()
test()
```
Then Python 3 fails as expected since this syntax is not valid Pathon 3:
```
$ python3 test2.py 
Traceback (most recent call last):
  File "test2.py", line 8, in <module>
    test()
  File "test2.py", line 7, in test
    return inner()
  File "test2.py", line 5, in inner
    exec('print(a); b = 456') in glob, locals()
  File "<string>", line 1, in <module>
NameError: name 'a' is not defined
```
However, despite both syntax versions are supposed to be valid Python 2, this version succeeds with Python 2 even though the previous version did not:
```
$ python2 test2.py 
123
456
```
That the first version fails with Python 2 is a Python 2 bug, the two versions are supposed to be equivalent in Python 2. See https://bugs.python.org/issue21591. This issue has been fixed in later Python 2 versions, but is still present in Python 2.7.5, which is the Python2 version in RHEL/CentOS 7.

### test3.py

OK, we have identified one version that works for Python 3 and one version that works for Python 2. Can we combine them with an if statement to get something that works for both versions:

```python
import sys
def test():
    def inner():
        glob = dict(globals())
        glob['a'] = 123
        if sys.version_info[0] >= 3:
            exec('print(a); b = 456', glob, locals())
        else:
            exec('print(a); b = 456') in glob, locals()
        print(locals()['b'])
    return inner()
test()
```
This works for Python 3:
```
$ python3 test3.py 
123
456
```
Sadly it fails for Python 2:
```
$ python2 test3.py 
  File "test3.py", line 7
    exec('print(a); b = 456', glob, locals())
SyntaxError: function 'inner' uses import * and bare exec, which are illegal because it is a nested function
```
Even though the Python 3 code path it not executed by Python 2, it must still be parsable by the Python 2 interpreter.

### test4.py

We now try to modify the Python 3 code path so that it is both valid Python 2 and valid Python 3, and still does the right thing when run as Python 3:
```python
import sys
def test():
    def inner():
        glob = dict(globals())
        glob['a'] = 123
        if sys.version_info[0] >= 3:
            exec('print(a); b = 456', glob, locals()) in {}
        else:
            exec('print(a); b = 456') in glob, locals()
        print(locals()['b'])
    return inner()
test()
```
This still works for Python 3. Checking whether the return value of the exec funtion (i.e. None) is a member of the empty set doesn't really change anything:
```
$ python3 test4.py 
123
456
```
However, the change results in that the Python 3 part no longer triggers a syntax error whe using Python 2:
```
$ python2 test4.py 
123
456
```
So we are happy now!

### test5.py 

Wait... If the new Python 3 code path no longer triggera an error for Python 2, can't we use that for Python 2 as well. That would be simpler:
```python
def test():
    def inner():
        glob = dict(globals())
        glob['a'] = 123
        exec('print(a); b = 456', glob, locals()) in {}
        print(locals()['b'])
    return inner()
test()
```
This obiously works for Python 3:
```
$ python3 test5.py 
123
456
```
But although it doesn't trigger a syntax error fpr Python 2, it does trigger a runtime error:
```
[ellert@bestlapp test]$ python2 test5.py 
Traceback (most recent call last):
  File "test5.py", line 8, in <module>
    test()
  File "test5.py", line 7, in test
    return inner()
  File "test5.py", line 5, in inner
    exec('print(a); b = 456', glob, locals()) in {}
TypeError: exec: arg 1 must be a string, file, or code object
```
So no, that is not possible.

The proposed change to the root code is based on the test4.py example.
