### PR TITLE
[RF] Remove excessive const-ness in object proxies.

### DIFF
--- a/roofit/roofitcore/inc/RooResolutionModel.h
+++ b/roofit/roofitcore/inc/RooResolutionModel.h
@@ -40,9 +40,7 @@ public:
   Double_t getValV(const RooArgSet* nset=0) const ;
   virtual RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const ;
   /// Return the convolution variable of the resolution model.
-  const RooAbsRealLValue& convVar() const {return *x;}
-  /// Return the convolution variable of the resolution model.
-  RooAbsRealLValue& convVar() {return *x;}
+  RooAbsRealLValue& convVar() const {return *x;}
   const RooRealVar& basisConvVar() const ;
 
   inline Bool_t isBasisSupported(const char* name) const { return basisCode(name)?kTRUE:kFALSE ; }

--- a/roofit/roofitcore/inc/RooTemplateProxy.h
+++ b/roofit/roofitcore/inc/RooTemplateProxy.h
@@ -205,20 +205,12 @@ public:
  
 
   /// Return reference to the proxied object.
-  const T& operator*() const {
-    return static_cast<T&>(*_arg);
-  }
-  /// Return reference to the proxied object.
-  T& operator*() {
+  T& operator*() const {
     return static_cast<T&>(*_arg);
   }
 
   /// Member access operator to proxied object.
-  const T* operator->() const {
-    return static_cast<const T*>(_arg);
-  }
-  /// Member access operator to proxied object.
-  T* operator->() {
+  T* operator->() const {
     return static_cast<T*>(_arg);
   }
 


### PR DESCRIPTION
RooFit proxies act similar to a smart pointer. It was, however, not
possible to mutate the pointed-to object if the owning proxy was const.
That's counter-intuitive.

A proxy to a const object can still be achieved by choosing the template
parameter const, e.g.
```
    RooTemplateProxy<const RooAbsPdf>
```