### PR TITLE
[ntuple] move field name validity check from model to FieldBase

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RField
 
 #include <ROOT/RColumn.hxx>
+#include <ROOT/RError.hxx>
 #include <ROOT/RColumnElement.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldValue.hxx>
@@ -27,7 +28,6 @@
 #include <ROOT/TypeTraits.hxx>
 
 #include <TGenericClassInfo.h>
-#include <TError.h>
 
 #include <algorithm>
 #include <array>
@@ -159,6 +159,8 @@ public:
 
    /// Factory method to resurrect a field from the stored on-disk type information
    static RFieldBase *Create(const std::string &fieldName, const std::string &typeName);
+   /// Check whether a given string is a valid field name
+   static RResult<void> EnsureValidFieldName(std::string_view fieldName);
 
    /// Generates an object of the field type and allocates new initialized memory according to the type.
    RFieldValue GenerateValue();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -22,8 +22,6 @@
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RStringView.hxx>
 
-#include <TError.h>
-
 #include <memory>
 #include <unordered_set>
 #include <utility>
@@ -53,8 +51,8 @@ class RNTupleModel {
    /// Keeps track of which field names are taken.
    std::unordered_set<std::string> fFieldNames;
 
-   /// Checks that user-provided field names are valid. Throws an RException
-   /// for invalid names.
+   /// Checks that user-provided field names are valid in the context
+   /// of this NTuple model. Throws an RException for invalid names.
    void EnsureValidFieldName(std::string_view fieldName);
 
 public:

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -16,6 +16,7 @@
 #include <ROOT/RColumn.hxx>
 #include <ROOT/RColumnModel.hxx>
 #include <ROOT/REntry.hxx>
+#include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RFieldVisitor.hxx>
@@ -188,6 +189,17 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
    R__ERROR_HERE("NTuple") << "Field " << fieldName << " has unknown type " << normalizedType;
    R__ASSERT(false);
    return nullptr;
+}
+
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::Detail::RFieldBase::EnsureValidFieldName(std::string_view fieldName)
+{
+   if (fieldName == "") {
+      return R__FAIL("field name cannot be empty string \"\"");
+   } else if (fieldName.find(".") != std::string::npos) {
+      return R__FAIL("field name '" + std::string(fieldName) + "' cannot contain dot characters '.'");
+   }
+   return RResult<void>::Success();
 }
 
 void ROOT::Experimental::Detail::RFieldBase::AppendImpl(const ROOT::Experimental::Detail::RFieldValue& /*value*/) {

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -25,13 +25,13 @@
 
 void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fieldName)
 {
+   RResult<void> nameValid = Detail::RFieldBase::EnsureValidFieldName(fieldName);
+   if (!nameValid) {
+      nameValid.Throw();
+   }
    auto fieldNameStr = std::string(fieldName);
    if (fFieldNames.insert(fieldNameStr).second == false) {
-      throw RException(R__FAIL("field name '" + fieldNameStr + "' already exists"));
-   } else if (fieldNameStr == "") {
-      throw RException(R__FAIL("field name cannot be empty string \"\""));
-   } else if (fieldNameStr.find(".") != std::string::npos) {
-      throw RException(R__FAIL("field name '" + fieldNameStr + "' cannot contain dot characters '.'"));
+      throw RException(R__FAIL("field name '" + fieldNameStr + "' already exists in NTuple model"));
    }
 }
 


### PR DESCRIPTION
During the implementation of #5934, I realized the field name validity check could be used for more than `RNTupleModel`. 
This PR separates the field validity check `EnsureValidFieldName` in two: 
* a check for field names in general (no dots, no empty string), which will also be useful for `RNTupleDescriptorBuilder`
* a model-specific check (no duplicate names).