### PR TITLE
Remove ROOT clib bits from TError

### DIFF
--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -73,7 +73,7 @@ typedef void (*ErrorHandlerFunc_t)(int level, Bool_t abort, const char *location
               const char *msg);
 
 extern "C" void ErrorHandler(int level, const char *location, const char *fmt,
-                             va_list va);
+                             std::va_list va);
 
 extern void DefaultErrorHandler(int level, Bool_t abort, const char *location,
                                 const char *msg);

--- a/core/base/inc/TError.h
+++ b/core/base/inc/TError.h
@@ -72,11 +72,9 @@ void MinimalErrorHandler(int level, Bool_t abort, const char *location, const ch
 typedef void (*ErrorHandlerFunc_t)(int level, Bool_t abort, const char *location,
               const char *msg);
 
-extern "C" void ErrorHandler(int level, const char *location, const char *fmt,
-                             std::va_list va);
+extern "C" void ErrorHandler(int level, const char *location, const char *fmt, std::va_list va);
 
-extern void DefaultErrorHandler(int level, Bool_t abort, const char *location,
-                                const char *msg);
+extern void DefaultErrorHandler(int level, Bool_t abort, const char *location, const char *msg);
 
 extern ErrorHandlerFunc_t SetErrorHandler(ErrorHandlerFunc_t newhandler);
 extern ErrorHandlerFunc_t GetErrorHandler();

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -113,7 +113,7 @@ ErrorHandlerFunc_t GetErrorHandler()
 void ErrorHandler(Int_t level, const char *location, const char *fmt, std::va_list ap)
 {
    TTHREAD_TLS(Int_t) buf_size(256);
-   TTHREAD_TLS(char*) buf_storage(0);
+   TTHREAD_TLS(char*) buf_storage(nullptr);
 
    char small_buf[256];
    char *buf = buf_storage ? buf_storage : small_buf;
@@ -137,7 +137,7 @@ again:
       if (n == -1)
          buf_size *= 2;
       else
-         buf_size = n+1;
+         buf_size = n + 1;
       if (buf != &(small_buf[0])) delete [] buf;
       buf = 0;
       va_end(ap);

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -20,7 +20,6 @@ errorhandler function. Initially the MinimalErrorHandler, which is supposed
 to be replaced by the proper DefaultErrorHandler()
 */
 
-#include "snprintf.h"
 #include "TError.h"
 #include "ThreadLocalStorage.h"
 
@@ -131,13 +130,8 @@ again:
       fmt = "no error message provided";
 
    Int_t n = vsnprintf(buf, buf_size, fmt, ap);
-   // old vsnprintf's return -1 if string is truncated new ones return
-   // total number of characters that would have been written
-   if (n == -1 || n >= buf_size) {
-      if (n == -1)
-         buf_size *= 2;
-      else
-         buf_size = n + 1;
+   if (n >= buf_size) {
+      buf_size = n + 1;
       if (buf != &(small_buf[0])) delete [] buf;
       buf = 0;
       va_end(ap);

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -21,10 +21,10 @@ to be replaced by the proper DefaultErrorHandler()
 */
 
 #include "snprintf.h"
-#include "Varargs.h"
 #include "TError.h"
 #include "ThreadLocalStorage.h"
 
+#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <cerrno>
@@ -110,7 +110,7 @@ ErrorHandlerFunc_t GetErrorHandler()
 ////////////////////////////////////////////////////////////////////////////////
 /// General error handler function. It calls the user set error handler.
 
-void ErrorHandler(Int_t level, const char *location, const char *fmt, va_list ap)
+void ErrorHandler(Int_t level, const char *location, const char *fmt, std::va_list ap)
 {
    TTHREAD_TLS(Int_t) buf_size(256);
    TTHREAD_TLS(char*) buf_storage(0);
@@ -119,8 +119,8 @@ void ErrorHandler(Int_t level, const char *location, const char *fmt, va_list ap
    char *buf = buf_storage ? buf_storage : small_buf;
 
    int vc = 0;
-   va_list sap;
-   R__VA_COPY(sap, ap);
+   std::va_list sap;
+   va_copy(sap, ap);
 
 again:
    if (!buf) {
@@ -141,7 +141,7 @@ again:
       if (buf != &(small_buf[0])) delete [] buf;
       buf = 0;
       va_end(ap);
-      R__VA_COPY(ap, sap);
+      va_copy(ap, sap);
       vc = 1;
       goto again;
    }
@@ -196,55 +196,55 @@ void Obsolete(const char *function, const char *asOfVers, const char *removedFro
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function in case an error occurred.
 
-void Error(const char *location, const char *va_(fmt), ...)
+void Error(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kError, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kError, location, fmt, ap);
    va_end(ap);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function in case a system (OS or GUI) related error occurred.
 
-void SysError(const char *location, const char *va_(fmt), ...)
+void SysError(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap, va_(fmt));
-   ErrorHandler(kSysError, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kSysError, location, fmt, ap);
    va_end(ap);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function in case an error occurred.
 
-void Break(const char *location, const char *va_(fmt), ...)
+void Break(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kBreak, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kBreak, location, fmt, ap);
    va_end(ap);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function for informational messages.
 
-void Info(const char *location, const char *va_(fmt), ...)
+void Info(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kInfo, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kInfo, location, fmt, ap);
    va_end(ap);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Use this function in warning situations.
 
-void Warning(const char *location, const char *va_(fmt), ...)
+void Warning(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kWarning, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kWarning, location, fmt, ap);
    va_end(ap);
 }
 
@@ -254,10 +254,10 @@ void Warning(const char *location, const char *va_(fmt), ...)
 // Fatal() *might* not abort the program (if gAbortLevel > kFatal) - but for all
 // reasonable settings it *will* abort. So let's be reasonable wrt Coverity:
 // coverity[+kill]
-void Fatal(const char *location, const char *va_(fmt), ...)
+void Fatal(const char *location, const char *fmt, ...)
 {
-   va_list ap;
-   va_start(ap,va_(fmt));
-   ErrorHandler(kFatal, location, va_(fmt), ap);
+   std::va_list ap;
+   va_start(ap, fmt);
+   ErrorHandler(kFatal, location, fmt, ap);
    va_end(ap);
 }

--- a/core/base/src/TError.cxx
+++ b/core/base/src/TError.cxx
@@ -130,7 +130,7 @@ void ErrorHandler(Int_t level, const char *location, const char *fmt, std::va_li
       buf_size = n + 1;
       if (buf != &(small_buf[0]))
          delete[] buf;
-      buf = new char[buf_size];
+      buf_storage = buf = new char[buf_size];
 
       // Try again with a sufficiently large buffer
       va_copy(ap_copy, ap);

--- a/core/base/test/TErrorTests.cxx
+++ b/core/base/test/TErrorTests.cxx
@@ -50,4 +50,8 @@ TEST(TError, LongMessage) {
 
    Info("location", "%s", longMessage.c_str());
    EXPECT_EQ(longMessage, gTestLastMsg);
+
+   // Again, should reuse the now enlarged, thread-local heap-allocated buffer
+   Info("location", "%s", longMessage.c_str());
+   EXPECT_EQ(longMessage, gTestLastMsg);
 }

--- a/core/base/test/TErrorTests.cxx
+++ b/core/base/test/TErrorTests.cxx
@@ -41,3 +41,13 @@ TEST(TError, Basics) {
    SysError("location", "message");
    EXPECT_STREQ("message (errno: 42)", gTestLastMsg.c_str());
 }
+
+
+TEST(TError, LongMessage) {
+   SetErrorHandler(TestErrorHandler);
+   std::string longMessage(10000, 'X');
+   EXPECT_EQ(10000U, longMessage.length());
+
+   Info("location", "%s", longMessage.c_str());
+   EXPECT_EQ(longMessage, gTestLastMsg);
+}


### PR DESCRIPTION
Second attempt at #5922, this time somewhat smaller patch without changing the TLS definition.