### PR TITLE
[TAxis] print warning if trying to unzoom without gPad

### DIFF
--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -1125,7 +1125,7 @@ void TAxis::Streamer(TBuffer &R__b)
 void TAxis::UnZoom()
 {
    if (!gPad) {
-      Warning("TAxis::UnZoom","Cannot UnZoom if gPad does not exist.");
+      Warning("TAxis::UnZoom","Cannot UnZoom if gPad does not exist. Did you mean to draw the TAxis fist?");
       return;
    }
    gPad->SetView();

--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -1124,7 +1124,10 @@ void TAxis::Streamer(TBuffer &R__b)
 
 void TAxis::UnZoom()
 {
-   if (!gPad) return;
+   if (!gPad) {
+      Warning("TAxis::UnZoom","Cannot UnZoom if gPad does not exist.")
+      return;
+   }
    gPad->SetView();
 
    //unzoom object owning this axis

--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -1125,7 +1125,7 @@ void TAxis::Streamer(TBuffer &R__b)
 void TAxis::UnZoom()
 {
    if (!gPad) {
-      Warning("TAxis::UnZoom","Cannot UnZoom if gPad does not exist.")
+      Warning("TAxis::UnZoom","Cannot UnZoom if gPad does not exist.");
       return;
    }
    gPad->SetView();

--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -1125,7 +1125,7 @@ void TAxis::Streamer(TBuffer &R__b)
 void TAxis::UnZoom()
 {
    if (!gPad) {
-      Warning("TAxis::UnZoom","Cannot UnZoom if gPad does not exist. Did you mean to draw the TAxis fist?");
+      Warning("TAxis::UnZoom","Cannot UnZoom if gPad does not exist. Did you mean to draw the TAxis first?");
       return;
    }
    gPad->SetView();


### PR DESCRIPTION
Initially reported in the forum [here](https://root-forum.cern.ch/t/th1-stat-calculations-are-inconsistent/40152), this warns user that `UnZoom` does nothing if the axis hasn't been drawn.