### PR TITLE
document TH1 unbinned stats calculations

### DIFF
--- a/documentation/users-guide/Histograms.md
+++ b/documentation/users-guide/Histograms.md
@@ -1528,6 +1528,8 @@ For a more detailed explanation, see "Input/Output".
 
 -   **`TH1`**`::GetMean(int axis)` - returns the mean value along axis.
 
+-   **`TH1`**`::GetStdDev(int axis)` - returns the sigma distribution along axis.
+
 -   **`TH1`**`::GetRMS(int axis)` - returns the Root Mean Square
     along axis.
 

--- a/documentation/users-guide/Histograms.md
+++ b/documentation/users-guide/Histograms.md
@@ -1566,6 +1566,72 @@ For a more detailed explanation, see "Input/Output".
 -   **`TH1`**`::Reset()` - resets the bin contents and errors of a
     histogram
 
+## Important note on returned statistics (`GetMean`, `GetStdDev`, etc.)
+
+
+By default, histogram statistics are computed at fill time using the
+unbinned data used to update the bin content. **This means the values
+returned by `GetMean`, `GetStdDev`, etc., are those of the dataset used
+to fill the histogram**, not those of the binned content of the histogram
+itself, **unless one of the axes has been zoomed**. (See the documentation
+on `TH1::GetStats()`.) This is useful if you want to keep track of the
+mean and standard deviation of the dataset you are visualizing with the histogram,
+but it can lead to some unintuitive results.
+
+For example, suppose you have a histogram
+with one bin between 0 and 100, then you fill it with a
+Gaussian dataset with mean 20 and standard deviation 2:
+``` {.cpp}
+TH1F * h = new TH1F("h", "h", 1, 0, 100);
+for(int i=0; i<10000; i++) h->Fill(gRandom->Gaus(20, 2));
+```
+Right now, `h->GetMean()` will return 20 and `h->GetStdDev()` will return 2;
+ROOT calculated these values as we filled `h`.
+Next, zoom in on the Gaussian:
+``` {.cpp}
+h->GetXaxis()->SetRangeUser(10, 30);
+```
+Now, `h->GetMean()` will return 50 and `h->GetStdDev()` will return 0.
+What happened? Well, `GetMean` and `GetStdDev` (and many other `TH1` functions)
+return the statistics for *bins in range*; this is because the histogram only
+stores the contents of its bins, not the coordinates of the values used to fill it.
+So even though `h` has only one bin and it's still included in the range, ROOT returns the
+binned statistics because `SetRangeUser` set the bit `TAxis::kAxisRange` to 1.
+*This remains true even if you zoom out:*
+``` {.cpp}
+h->GetXaxis()->SetRangeUser(0, 100);
+```
+still results in `GetMean` and `GetStdDev` returning 50 and 0, respectively,
+because, even though this is the original range of the histogram, *the X axis has
+still been assigned a range*. To mark the X axis as having no range, you can call
+``` {.cpp}
+h->GetXaxis()->SetRange();
+```
+without arguments or with arguments `(0, 0)`. This sets the bit `TAxis::kAxisRange` to 0,
+and ROOT again uses the statistics calculated at fill time: `GetMean` and `GetStdDev`
+now return 20 and 2, respectively.
+
+If you want ROOT to consistently return the statistics of the binned dataset stored
+in the histogram and not those of the dataset used to fill it, you can call
+`TH1::ResetStats`. This will delete the statistics originally calculated at fill
+time and replace them with those calculated from the bins; note that you cannot later
+retrieve the original statistics--they are lost. Continuing the example above,
+``` {.cpp}
+h->ResetStats();
+h->GetXaxis()->SetRange();
+```
+results in `GetMean` and `GetStdDev` returning 50 and 0, respectively.
+If you fill the histogram again, the statistics will be a mix of binned and
+unbinned:
+``` {.cpp}
+h->ResetStats();
+h->GetXaxis()->SetRange();
+for(int i=0; i<10000; i++) h->Fill(85);
+```
+results in `GetMean` and `GetStdDev` returning 67.5 and 17.5, respectively;
+you must call `TH1::ResetStats` again to get consistent binned statistics.
+
+
 ## Alphanumeric Bin Labels
 
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -518,6 +518,13 @@ When using the options 2 or 3 above, the labels are automatically
         TH1::GetEntries() returns the number of entries
         TH1::Reset() resets the bin contents and errors of an histogram
 ~~~
+ IMPORTANT NOTE: The returned values for GetMean and GetStdDev depend on how the
+ histogram statistics are calculated. By default, if no range has been set, the
+ returned values are the (unbinned) ones calculated at fill time. If a range has been
+ set, however, the values are calculated using the bins in range; THIS IS TRUE EVEN
+ IF THE RANGE INCLUDES ALL BINS--use TAxis::SetRange(0, 0) to unset the range.
+ To ensure that the returned values are always those of the binned data stored in the
+ histogram, call TH1::ResetStats. See TH1::GetStats.
 */
 
 TF1 *gF1=0;  //left for back compatibility (use TVirtualFitter::GetUserFunc instead)
@@ -856,6 +863,12 @@ Bool_t TH1::Add(TF1 *f1, Double_t c1, Option_t *option)
 /// is used , ie  this = this + c1*factor*h1
 /// Use the other TH1::Add function if you do not want this feature
 ///
+/// IMPORTANT NOTE3: You should be careful about the statistics of the
+/// returned histogram, whose statistics may be binned or unbinned,
+/// depending on whether c1 is negative, whether TAxis::kAxisRange is true,
+/// and whether TH1::ResetStats has been called on either this or h1.
+/// See TH1::GetStats.
+///
 /// The function return kFALSE if the Add operation failed
 
 Bool_t TH1::Add(const TH1 *h1, Double_t c1)
@@ -1013,6 +1026,12 @@ Bool_t TH1::Add(const TH1 *h1, Double_t c1)
 /// IMPORTANT NOTE: If you intend to use the errors of this histogram later
 /// you should call Sumw2 before making this operation.
 /// This is particularly important if you fit the histogram after TH1::Add
+///
+/// IMPORTANT NOTE2: You should be careful about the statistics of the
+/// returned histogram, whose statistics may be binned or unbinned,
+/// depending on whether c1 is negative, whether TAxis::kAxisRange is true,
+/// and whether TH1::ResetStats has been called on either this or h1.
+/// See TH1::GetStats.
 ///
 /// ANOTHER SPECIAL CASE : h1 = h2 and c2 < 0
 /// do a scaling   this = c1 * h1 / (bin Volume)
@@ -7058,6 +7077,15 @@ void TH1::UseCurrentStyle()
 /// call the static function TH1::StatOverflows(kTRUE) before filling
 /// the histogram.
 ///
+/// IMPORTANT NOTE: The returned value depends on how the histogram statistics
+/// are calculated. By default, if no range has been set, the returned mean is
+/// the (unbinned) one calculated at fill time. If a range has been set, however,
+/// the mean is calculated using the bins in range, as described above; THIS
+/// IS TRUE EVEN IF THE RANGE INCLUDES ALL BINS--use TAxis::SetRange(0, 0) to unset
+/// the range. To ensure that the returned mean (and all other statistics) is
+/// always that of the binned data stored in the histogram, call TH1::ResetStats.
+/// See TH1::GetStats.
+///
 /// Return mean value of this histogram along the X axis.
 ///
 /// Note that the mean value/StdDev is computed using the bins in the currently
@@ -7097,6 +7125,15 @@ Double_t TH1::GetMean(Int_t axis) const
 ///
 /// Also note, that although the definition of standard error doesn't include the
 /// assumption of normality, many uses of this feature implicitly assume it.
+///
+/// IMPORTANT NOTE: The returned value depends on how the histogram statistics
+/// are calculated. By default, if no range has been set, the returned value is
+/// the (unbinned) one calculated at fill time. If a range has been set, however,
+/// the value is calculated using the bins in range, as described above; THIS
+/// IS TRUE EVEN IF THE RANGE INCLUDES ALL BINS--use TAxis::SetRange(0, 0) to unset
+/// the range. To ensure that the returned value (and all other statistics) is
+/// always that of the binned data stored in the histogram, call TH1::ResetStats.
+/// See TH1::GetStats.
 
 Double_t TH1::GetMeanError(Int_t axis) const
 {
@@ -7120,6 +7157,15 @@ Double_t TH1::GetMeanError(Int_t axis) const
 /// To force the underflows and overflows in the computation, one must
 /// call the static function TH1::StatOverflows(kTRUE) before filling
 /// the histogram.
+///
+/// IMPORTANT NOTE: The returned value depends on how the histogram statistics
+/// are calculated. By default, if no range has been set, the returned standard
+/// deviation is the (unbinned) one calculated at fill time. If a range has been
+/// set, however, the standard deviation is calculated using the bins in range,
+/// as described above; THIS IS TRUE EVEN IF THE RANGE INCLUDES ALL BINS--use
+/// TAxis::SetRange(0, 0) to unset the range. To ensure that the returned standard
+/// deviation (and all other statistics) is always that of the binned data stored
+/// in the histogram, call TH1::ResetStats. See TH1::GetStats.
 
 Double_t TH1::GetStdDev(Int_t axis) const
 {
@@ -7159,6 +7205,15 @@ Double_t TH1::GetStdDev(Int_t axis) const
 /// original data distribution is Normal. The correct one would require
 /// the 4-th momentum value, which cannot be accurately estimated from an histogram since
 /// the x-information for all entries is not kept.
+///
+/// IMPORTANT NOTE: The returned value depends on how the histogram statistics
+/// are calculated. By default, if no range has been set, the returned value is
+/// the (unbinned) one calculated at fill time. If a range has been set, however,
+/// the value is calculated using the bins in range, as described above; THIS
+/// IS TRUE EVEN IF THE RANGE INCLUDES ALL BINS--use TAxis::SetRange(0, 0) to unset
+/// the range. To ensure that the returned value (and all other statistics) is
+/// always that of the binned data stored in the histogram, call TH1::ResetStats.
+/// See TH1::GetStats.
 
 Double_t TH1::GetStdDevError(Int_t axis) const
 {
@@ -7172,6 +7227,9 @@ Double_t TH1::GetStdDevError(Int_t axis) const
 ///
 ///Note, that since third and fourth moment are not calculated
 ///at the fill time, skewness and its standard error are computed bin by bin
+///
+/// IMPORTANT NOTE: The returned value depends on how the histogram statistics
+/// are calculated. See TH1::GetMean and TH1::GetStdDev.
 
 Double_t TH1::GetSkewness(Int_t axis) const
 {
@@ -7242,6 +7300,9 @@ Double_t TH1::GetSkewness(Int_t axis) const
 ////
 /// Note, that since third and fourth moment are not calculated
 /// at the fill time, kurtosis and its standard error are computed bin by bin
+///
+/// IMPORTANT NOTE: The returned value depends on how the histogram statistics
+/// are calculated. See TH1::GetMean and TH1::GetStdDev.
 
 Double_t TH1::GetKurtosis(Int_t axis) const
 {
@@ -7319,6 +7380,12 @@ Double_t TH1::GetKurtosis(Int_t axis) const
 /// If a sub-range is specified, the function recomputes these quantities
 /// from the bin contents in the current axis range.
 ///
+/// IMPORTANT NOTE: This means that the returned statistics are context-dependent.
+/// If TAxis::kAxisRange, the returned statistics are dependent on the binning;
+/// otherwise, they are a copy of the histogram statistics computed at fill time,
+/// which are unbinned by default (calling TH1::ResetStats forces them to use
+/// binned statistics). You can reset TAxis::kAxisRange using TAxis::SetRange(0, 0).
+///
 /// Note that the mean value/StdDev is computed using the bins in the currently
 /// defined range (see TAxis::SetRange). By default the range includes
 /// all bins from 1 to nbins included, excluding underflows and overflows.
@@ -7391,6 +7458,9 @@ void TH1::PutStats(Double_t *stats)
 ///
 /// The number of entries is set to the total bin content or (in case of weighted histogram)
 /// to number of effective entries
+///
+/// Note that, by default, before calling this function, statistics are those
+/// computed at fill time, which are unbinned. See TH1::GetStats.
 
 void TH1::ResetStats()
 {


### PR DESCRIPTION
Initially reported in the forum [here](https://root-forum.cern.ch/t/th1-stat-calculations-are-inconsistent/40152), this adds documentation explaining the behavior of `TH1::GetStats` so that a user can know when to expect binned vs. unbinned values.