### PR TITLE
[v7, exceptions] add shorthand method for failed RResult<void>

### DIFF
--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -244,6 +244,13 @@ public:
       if (result.fError)
          result.fError->AddFrame(std::move(sourceLocation));
       return result;
+   }
+
+   /// Shorthand method to throw an exception in the case of errors. Does nothing for
+   /// functions that succeeded.
+   void ThrowOnError() {
+      if (!Check())
+         Throw();
    }
 
    explicit operator bool() { return Check(); }

--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -246,8 +246,8 @@ public:
       return result;
    }
 
-   /// Shorthand method to throw an exception in the case of errors. Does nothing for
-   /// functions that succeeded.
+   /// Short-hand method to throw an exception in the case of errors. Does nothing for
+   /// successful RResults.
    void ThrowOnError() {
       if (!Check())
          Throw();

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -111,12 +111,7 @@ TEST(Exception, VoidThrowOnError)
    // no throw on success
    TestSuccess().ThrowOnError();
    // throw on failure
-   try {
-      TestFailure().ThrowOnError();
-      FAIL() << "ThrowOnError must throw for error states";
-   } catch (const RException& err) {
-      // ThrowOnError() worked
-   }
+   EXPECT_THROW(TestFailure().ThrowOnError(), RException);
 }
 
 TEST(Exception, Syscall)

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -106,6 +106,18 @@ TEST(Exception, DoubleThrow)
    }
 }
 
+TEST(Exception, VoidThrowOnError)
+{
+   // no throw on success
+   TestSuccess().ThrowOnError();
+   // throw on failure
+   try {
+      TestFailure().ThrowOnError();
+      FAIL() << "ThrowOnError must throw for error states";
+   } catch (const RException& err) {
+      // ThrowOnError() worked
+   }
+}
 
 TEST(Exception, Syscall)
 {


### PR DESCRIPTION
Spun off from [discussion](https://github.com/root-project/root/pull/5967/files/f38dec8a28705a66fa234733be390f349941ce97#r448840263) on #5967:

For the new `RResult` error handling regime, fallible functions that don't return a value have the return type `RResult<void>`. 
Oftentimes, we only want to ensure the function succeeded before proceeding and throw an exception up the stack otherwise.

This PR adds a convenience method `ThrowOnError()` (analogous to `RResult<T>::Get()` for non-void `T`). 

`ThrowOnError` checks the error state of the `RResult<void>`, throwing if there's an error and doing nothing otherwise. 

Before:
```cpp
RResult<void> validRes = FallibleVoidFn();
if (!validRes) { 
    validRes.Throw(); 
}
```

After:
```cpp
FallibleVoidFn().ThrowOnError(); 
```