### PR TITLE
Fix the RNTuple.LargeFile test on 32bit Linux (i386 and armv7hf)

### DIFF
--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -13,6 +13,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include <ROOT/RConfig.hxx>
+
 #include "ROOT/RMiniFile.hxx"
 
 #include <ROOT/RRawFile.hxx>
@@ -1010,7 +1012,11 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::RFileSimple::Write(
    R__ASSERT(fFile);
    size_t retval;
    if ((offset >= 0) && (static_cast<std::uint64_t>(offset) != fFilePos)) {
+#ifdef R__SEEK64
+      retval = fseeko64(fFile, offset, SEEK_SET);
+#else
       retval = fseek(fFile, offset, SEEK_SET);
+#endif
       R__ASSERT(retval == 0);
       fFilePos = offset;
    }
@@ -1110,7 +1116,11 @@ ROOT::Experimental::Internal::RNTupleFileWriter *ROOT::Experimental::Internal::R
    if (idxDirSep != std::string::npos) {
       fileName.erase(0, idxDirSep + 1);
    }
+#ifdef R__SEEK64
+   FILE *fileStream = fopen64(std::string(path.data(), path.size()).c_str(), "wb");
+#else
    FILE *fileStream = fopen(std::string(path.data(), path.size()).c_str(), "wb");
+#endif
    R__ASSERT(fileStream);
 
    auto writer = new RNTupleFileWriter(ntupleName);
@@ -1330,7 +1340,11 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::WriteTFileSkeleton(int def
    fFileSimple.Write(&strEmpty, strEmpty.GetSize());
    fFileSimple.Write(&fileRoot, fileRoot.GetSize());
    fFileSimple.fFilePos = tail;
+#ifdef R__SEEK64
+   auto retval = fseeko64(fFileSimple.fFile, tail, SEEK_SET);
+#else
    auto retval = fseek(fFileSimple.fFile, tail, SEEK_SET);
+#endif
    R__ASSERT(retval == 0);
    fFileSimple.fFilePos = tail;
 }

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -1,3 +1,5 @@
+#include <ROOT/RConfig.hxx>
+
 #include "ntuple_test.hxx"
 
 TEST(RNTuple, RealWorld1)
@@ -122,10 +124,17 @@ TEST(RNTuple, LargeFile)
          ntuple->Fill();
       }
    }
+#ifdef R__SEEK64
+   FILE *file = fopen64(fileGuard.GetPath().c_str(), "rb");
+   ASSERT_TRUE(file != nullptr);
+   EXPECT_EQ(0, fseeko64(file, 0, SEEK_END));
+   EXPECT_GT(ftello64(file), 2048LL * 1024LL * 1024LL);
+#else
    FILE *file = fopen(fileGuard.GetPath().c_str(), "rb");
    ASSERT_TRUE(file != nullptr);
    EXPECT_EQ(0, fseek(file, 0, SEEK_END));
    EXPECT_GT(ftell(file), 2048LL * 1024LL * 1024LL);
+#endif
    fclose(file);
 
    auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath());


### PR DESCRIPTION
Before this change:

[ RUN      ] RNTuple.LargeFile
Warning in <ROOT [NTuple] Warning /builddir/build/BUILD/root-6.22.00/tree/ntuple/v7/src/RPageStorageFile.cxx:43 in ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view, std::string_view, const ROOT::Experimental::RNTupleWriteOptions&)>: The RNTuple file format will change. Do not store real data with this version of RNTuple!
Fatal: retval == nbytes violated at line 1007 of `/builddir/build/BUILD/root-6.22.00/tree/ntuple/v7/src/RMiniFile.cxx'
aborting
