### PR TITLE
Introduce Optimize() drawing method for RH1/RH2/RH3 classes

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
@@ -84,11 +84,11 @@ public:
 };
 
 
-/** \class RDrawableDisplayItem
+/** \class RIndirectDisplayItem
 \ingroup GpadROOT7
-\brief Generic display item for RDrawable, just reference drawable itself
+\brief Extract (reference) only basic attributes from drawable, but not drawable itself
 \author Sergey Linev <s.linev@gsi.de>
-\date 2017-05-31
+\date 2020-04-02
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 

--- a/graf2d/gpadv7/inc/ROOT/RDrawableRequest.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawableRequest.hxx
@@ -80,7 +80,7 @@ public:
 
 /** \class RDrawableExecRequest
 \ingroup GpadROOT7
-\brief Base class for requests which can be submitted from the clients
+\brief Request execution of method of referenced drawable, no reply
 \author Sergey Linev <s.linev@gsi.de>
 \date 2020-04-14
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
@@ -88,13 +88,9 @@ public:
 
 class RDrawableExecRequest : public RDrawableRequest {
    std::string exec; ///< that to execute
-
 public:
-
    std::unique_ptr<RDrawableReply> Process() override;
-
 };
-
 
 } // namespace Experimental
 } // namespace ROOT

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -45,6 +45,19 @@ public:
    class RUserRanges {
       std::vector<double> values;  ///< min/max values for all dimensions
       std::vector<bool> flags;     ///< flag if values available
+
+      void UpdateDim(unsigned ndim, const RUserRanges &src)
+      {
+         if (src.IsUnzoom(ndim)) {
+            ClearMinMax(ndim);
+         } else {
+            if (src.HasMin(ndim))
+               AssignMin(ndim, src.GetMin(ndim));
+            if (src.HasMax(ndim))
+               AssignMax(ndim, src.GetMax(ndim));
+         }
+      }
+
    public:
       // Default constructor - for I/O
       RUserRanges() = default;
@@ -78,26 +91,31 @@ public:
       double GetMin(unsigned ndim) const { return (ndim*2 < values.size()) ? values[ndim*2] : 0.; }
 
       // Assign minimum for specified dimension
-      void AssignMin(unsigned ndim, double value, bool force = false)
+      void AssignMin(unsigned ndim, double value)
       {
-         if (!HasMin(ndim) || force) {
-            Extend(ndim+1);
-            values[ndim*2] = value;
-            flags[ndim*2] = true;
-         }
+          Extend(ndim+1);
+          values[ndim*2] = value;
+          flags[ndim*2] = true;
       }
 
       bool HasMax(unsigned ndim) const { return (ndim*2+1 < flags.size()) && flags[ndim*2+1]; }
       double GetMax(unsigned ndim) const { return (ndim*2+1 < values.size()) ? values[ndim*2+1] : 0.; }
 
       // Assign maximum for specified dimension
-      void AssignMax(unsigned ndim, double value, bool force = false)
+      void AssignMax(unsigned ndim, double value)
       {
-         if (!HasMax(ndim) || force) {
-            Extend(ndim+1);
-            values[ndim*2+1] = value;
-            flags[ndim*2+1] = true;
-         }
+          Extend(ndim+1);
+          values[ndim*2+1] = value;
+          flags[ndim*2+1] = true;
+      }
+
+      void ClearMinMax(unsigned ndim)
+      {
+         if (ndim*2+1 < flags.size())
+            flags[ndim*2] = flags[ndim*2+1] = false;
+
+         if (ndim*2+1 < values.size())
+            values[ndim*2] = values[ndim*2+1] = 0.;
       }
 
       /** Returns true if axis configured as unzoomed, can be specified from client */
@@ -115,6 +133,14 @@ public:
             if (fl) return true;
          return false;
       }
+
+      void Update(const RUserRanges &src)
+      {
+         UpdateDim(0, src);
+         UpdateDim(1, src);
+         UpdateDim(2, src);
+      }
+
    };
 
 private:

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -31,8 +31,7 @@ namespace Experimental {
 /** \class RFrame
 \ingroup GpadROOT7
 \brief Holds an area where drawing on user coordinate-system can be performed.
-\author Axel Naumann <axel@cern.ch>
-\author Sergey Linev <s.linev@gsi.de>
+\authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
 \date 2017-09-26
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */

--- a/graf2d/gpadv7/src/RFrame.cxx
+++ b/graf2d/gpadv7/src/RFrame.cxx
@@ -39,10 +39,10 @@ void RFrame::GetAxisRanges(unsigned ndim, const RAttrAxis &axis, RUserRanges &ra
       ranges.AssignMax(ndim, axis.GetMax());
 
    if (axis.HasZoomMin())
-      ranges.AssignMin(ndim, axis.GetZoomMin(), true);
+      ranges.AssignMin(ndim, axis.GetZoomMin());
 
    if (axis.HasZoomMax())
-      ranges.AssignMax(ndim, axis.GetZoomMax(), true);
+      ranges.AssignMax(ndim, axis.GetZoomMax());
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -94,13 +94,19 @@ void RFrame::PopulateMenu(RMenuItems &items)
 
 void RFrame::SetClientRanges(unsigned connid, const RUserRanges &ranges, bool ismainconn)
 {
-   fClientRanges[connid] = ranges;
-
    if (ismainconn) {
       AssignZoomRange(0, AttrX(), ranges);
       AssignZoomRange(1, AttrY(), ranges);
       AssignZoomRange(2, AttrZ(), ranges);
    }
+
+   if (fClientRanges.find(connid) == fClientRanges.end()) {
+      RUserRanges ranges0;
+      GetClientRanges(connid, ranges0);
+      fClientRanges[connid] = ranges0;
+   }
+
+   fClientRanges[connid].Update(ranges);
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/hist/histdrawv7/CMakeLists.txt
+++ b/hist/histdrawv7/CMakeLists.txt
@@ -10,9 +10,11 @@
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTHistDraw
   HEADERS
+    ROOT/RHistDisplayItem.hxx
     ROOT/RHistDrawable.hxx
     ROOT/RHistStatBox.hxx
   SOURCES
+    src/RHistDisplayItem.cxx
     src/RHistDrawable.cxx
     src/RHistStatBox.cxx
   DICTIONARY_OPTIONS

--- a/hist/histdrawv7/inc/LinkDef.h
+++ b/hist/histdrawv7/inc/LinkDef.h
@@ -23,6 +23,8 @@
 #pragma link C++ class ROOT::Experimental::Internal::RIOShared<ROOT::Experimental::Detail::RHistImplPrecisionAgnosticBase<3>>+;
 
 #pragma link C++ class ROOT::Experimental::RHistDrawableBase+;
+#pragma link C++ class ROOT::Experimental::RHistDrawableBase::RRequest+;
+#pragma link C++ class ROOT::Experimental::RHistDrawableBase::RReply+;
 #pragma link C++ class ROOT::Experimental::RHistDrawable<1>+;
 #pragma link C++ class ROOT::Experimental::RHistDrawable<2>+;
 #pragma link C++ class ROOT::Experimental::RHistDrawable<3>+;
@@ -30,8 +32,6 @@
 #pragma link C++ class ROOT::Experimental::RHist2Drawable+;
 #pragma link C++ class ROOT::Experimental::RHist3Drawable+;
 
-#pragma link C++ class ROOT::Experimental::RHist2Drawable::RRequest+;
-#pragma link C++ class ROOT::Experimental::RHist2Drawable::RReply+;
 
 #pragma link C++ class ROOT::Experimental::RHistDisplayItem+;
 

--- a/hist/histdrawv7/inc/LinkDef.h
+++ b/hist/histdrawv7/inc/LinkDef.h
@@ -22,12 +22,16 @@
 #pragma link C++ class ROOT::Experimental::Internal::RIOShared<ROOT::Experimental::Detail::RHistImplPrecisionAgnosticBase<2>>+;
 #pragma link C++ class ROOT::Experimental::Internal::RIOShared<ROOT::Experimental::Detail::RHistImplPrecisionAgnosticBase<3>>+;
 
+#pragma link C++ class ROOT::Experimental::RHistDrawableBase+;
 #pragma link C++ class ROOT::Experimental::RHistDrawable<1>+;
 #pragma link C++ class ROOT::Experimental::RHistDrawable<2>+;
 #pragma link C++ class ROOT::Experimental::RHistDrawable<3>+;
 #pragma link C++ class ROOT::Experimental::RHist1Drawable+;
 #pragma link C++ class ROOT::Experimental::RHist2Drawable+;
 #pragma link C++ class ROOT::Experimental::RHist3Drawable+;
+
+#pragma link C++ class ROOT::Experimental::RHist2Drawable::RRequest+;
+#pragma link C++ class ROOT::Experimental::RHist2Drawable::RReply+;
 
 #pragma link C++ class ROOT::Experimental::RHistDisplayItem+;
 

--- a/hist/histdrawv7/inc/LinkDef.h
+++ b/hist/histdrawv7/inc/LinkDef.h
@@ -29,6 +29,8 @@
 #pragma link C++ class ROOT::Experimental::RHist2Drawable+;
 #pragma link C++ class ROOT::Experimental::RHist3Drawable+;
 
+#pragma link C++ class ROOT::Experimental::RHistDisplayItem+;
+
 #pragma link C++ class ROOT::Experimental::RDisplayHistStat+;
 
 #pragma link C++ class ROOT::Experimental::RHistStatBoxBase+;

--- a/hist/histdrawv7/inc/ROOT/RHistDisplayItem.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDisplayItem.hxx
@@ -26,9 +26,12 @@ namespace Experimental {
 class RAxisBase;
 
 class RHistDisplayItem : public RIndirectDisplayItem {
-   std::vector<const RAxisBase *> fAxes;   ///< histogram axes, temporary pointer
+   std::vector<const RAxisBase *> fAxes;   ///< histogram axes, only temporary pointers
    std::vector<int> fIndicies;             ///< [left,right,step] for each axes
    std::vector<double> fBinContent;        ///< extracted bins values
+   double fContMin{0.};                    ///< minimum content value
+   double fContMinPos{0.};                 ///< minimum positive value
+   double fContMax{0.};                    ///< maximum content value
 
 public:
    RHistDisplayItem() = default;
@@ -44,6 +47,13 @@ public:
    }
 
    auto &GetBinContent() { return fBinContent; }
+
+   void SetContentMinMax(double min, double minpos, double max)
+   {
+      fContMin = min;
+      fContMinPos = minpos;
+      fContMax = max;
+   }
 };
 
 } // namespace Experimental

--- a/hist/histdrawv7/inc/ROOT/RHistDisplayItem.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDisplayItem.hxx
@@ -1,0 +1,52 @@
+/// \file ROOT/RHistDisplayItem.h
+/// \ingroup HistDraw ROOT7
+/// \author Sergey Linev <s.linev@gsi.de>
+/// \date 2020-06-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RHistDisplayItem
+#define ROOT7_RHistDisplayItem
+
+#include <ROOT/RDisplayItem.hxx>
+
+#include <vector>
+
+namespace ROOT {
+namespace Experimental {
+
+class RAxisBase;
+
+class RHistDisplayItem : public RIndirectDisplayItem {
+   std::vector<const RAxisBase *> fAxes;   ///< histogram axes, temporary pointer
+   std::vector<int> fIndicies;             ///< [left,right,step] for each axes
+   std::vector<double> fBinContent;        ///< extracted bins values
+
+public:
+   RHistDisplayItem() = default;
+
+   RHistDisplayItem(const RDrawable &dr);
+
+   void AddAxis(const RAxisBase *axis, int left = -1, int right = -1, int step = 1)
+   {
+      fAxes.emplace_back(axis);
+      fIndicies.emplace_back(left);
+      fIndicies.emplace_back(right);
+      fIndicies.emplace_back(step);
+   }
+
+   auto &GetBinContent() { return fBinContent; }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -157,9 +157,7 @@ public:
    RHist1Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<1>(hist) {}
 
    RHist1Drawable &Bar() { SetDrawKind("bar", 0); fBarOffset.Clear(); fBarWidth.Clear(); return *this; }
-   RHist1Drawable &Bar(double offset, double width) { SetDrawKind("bar", 0); fBarOffset = offset; fBarWidth = width; return *this; }
-   RHist1Drawable &Bar3D() { SetDrawKind("bar", 1); fBarOffset.Clear(); fBarWidth.Clear(); return *this; }
-   RHist1Drawable &Bar3D(double offset, double width) { SetDrawKind("bar", 1); fBarOffset = offset; fBarWidth = width; return *this; }
+   RHist1Drawable &Bar(double offset, double width, bool mode3d = false) { SetDrawKind("bar", mode3d ? 1 : 0); fBarOffset = offset; fBarWidth = width; return *this; }
    RHist1Drawable &Error(int kind = 0) { SetDrawKind("err", kind); return *this; }
    RHist1Drawable &Marker() { SetDrawKind("p"); return *this; }
    RHist1Drawable &Star() { AttrMarker().SetStyle(3); return Marker(); }

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -41,7 +41,7 @@ class RHistDrawableBase : public RDrawable {
    RAttrFill                fAttrFill{this, "fill_"};     ///<! hist fill attributes
    RAttrText                fAttrText{this, "text_"};     ///<! hist text attributes
    RAttrMarker              fMarkerAttr{this, "marker_"}; ///<! hist marker attributes
-   RAttrValue<bool>         fOptimize{this, "optimize", true};  ///<! optimize drawing
+   RAttrValue<bool>         fOptimize{this, "optimize", false}; ///<! optimize drawing
 
 protected:
 
@@ -180,7 +180,7 @@ protected:
 
    std::unique_ptr<RDisplayItem> CreateHistDisplay(const RDisplayContext &) override;
 
-   bool Is3D() const final { return (GetDrawKind() == "lego") || (GetDrawKind() == "surf"); }
+   bool Is3D() const final { return (GetDrawKind() == "lego") || (GetDrawKind() == "surf") || (GetDrawKind() == "err"); }
 
 public:
    RHist2Drawable() = default;

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -189,6 +189,7 @@ public:
    RHist2Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<2>(hist) {}
 
    RHist2Drawable &Color() { SetDrawKind("col"); return *this; }
+   RHist2Drawable &Box(int kind = 0) { SetDrawKind("box", kind); return *this; }
    RHist2Drawable &Lego(int kind = 0) { SetDrawKind("lego", kind); return *this; }
    RHist2Drawable &Surf(int kind = 0) { SetDrawKind("surf", kind); return *this; }
    RHist2Drawable &Error() { SetDrawKind("err"); return *this; }

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -36,8 +36,6 @@ public:
    using HistImpl_t = Detail::RHistImplPrecisionAgnosticBase<DIMENSIONS>;
 
 private:
-   Internal::RIOShared<HistImpl_t> fHistImpl;             ///< I/O capable reference on histogram
-
    RAttrValue<std::string>  fKind{this, "kind", ""};      ///<! hist draw kind
    RAttrValue<int>          fSub{this, "sub", -1};        ///<! hist draw sub kind
    RAttrLine                fAttrLine{this, "line_"};     ///<! hist line attributes
@@ -46,6 +44,8 @@ private:
    RAttrMarker              fMarkerAttr{this, "marker_"}; ///<! hist marker attributes
 
 protected:
+
+   Internal::RIOShared<HistImpl_t> fHistImpl;             ///< I/O capable reference on histogram
 
    void CollectShared(Internal::RIOSharedVector_t &vect) override { vect.emplace_back(&fHistImpl); }
 
@@ -126,7 +126,12 @@ public:
 
 
 class RHist2Drawable final : public RHistDrawable<2> {
-   RAttrValue<bool> fText{this, "text", false};           ///<! draw text
+   RAttrValue<bool> fText{this, "text", false};               ///<! draw text
+   RAttrValue<bool> fOptimize{this, "optimize", false};       ///<! optimize drawing
+
+protected:
+
+   std::unique_ptr<RDisplayItem> Display(const RDisplayContext &) override;
 
 public:
    RHist2Drawable() = default;
@@ -142,6 +147,9 @@ public:
    RHist2Drawable &Scatter() { SetDrawKind("scat"); return *this; }
    RHist2Drawable &Arrow() { SetDrawKind("arr"); return *this; }
    RHist2Drawable &Text(bool on = true) { fText = on; return *this; }
+
+   RHist2Drawable &Optimize(bool on = true) { fOptimize = on; return *this; }
+
 };
 
 

--- a/hist/histdrawv7/src/RHistDisplayItem.cxx
+++ b/hist/histdrawv7/src/RHistDisplayItem.cxx
@@ -1,0 +1,23 @@
+/// \file RHistDisplayItem.cxx
+/// \ingroup Hist ROOT7
+/// \author Sergey Linev <s.linev@gsi.de>
+/// \date 2020-06-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RHistDisplayItem.hxx"
+
+using namespace ROOT::Experimental;
+
+RHistDisplayItem::RHistDisplayItem(const RDrawable &dr) : RIndirectDisplayItem(dr)
+{
+}
+

--- a/hist/histdrawv7/src/RHistDrawable.cxx
+++ b/hist/histdrawv7/src/RHistDrawable.cxx
@@ -49,6 +49,7 @@ std::unique_ptr<RDisplayItem> RHist1Drawable::CreateHistDisplay(const RDisplayCo
       }
 
       if (i1 >= i2) {
+         // fatal, fallback to full content
          i1 = 0; i2 = nbinsx;
       }
 
@@ -81,7 +82,6 @@ std::unique_ptr<RDisplayItem> RHist1Drawable::CreateHistDisplay(const RDisplayCo
          bins.resize((i2 - i1) / stepi * (produce_minmax ? 2 : 1));
       } else {
          bins.resize(i2 - i1);
-         stepi = 1;
       }
 
       double min{0}, minpos{0}, max{0};
@@ -165,8 +165,9 @@ std::unique_ptr<RDisplayItem> RHist2Drawable::CreateHistDisplay(const RDisplayCo
       }
 
       if ((i1 >= i2) || (j1 >= j2)) {
-         printf("FATAL, fallback to full content\n");
-         i1 = 0; i2 = nbinsx; j1 = 0; j2 = nbinsy;
+         // FATAL, fallback to full content
+         i1 = 0; i2 = nbinsx;
+         j1 = 0; j2 = nbinsy;
       }
 
       // make approx 200 bins visible in each direction
@@ -243,10 +244,137 @@ std::unique_ptr<RDisplayItem> RHist2Drawable::CreateHistDisplay(const RDisplayCo
 }
 
 
-std::unique_ptr<RDisplayItem> RHist3Drawable::CreateHistDisplay(const RDisplayContext & /*ctxt*/)
+std::unique_ptr<RDisplayItem> RHist3Drawable::CreateHistDisplay(const RDisplayContext &ctxt)
 {
    auto item = std::make_unique<RHistDisplayItem>(*this);
 
-   return item;
+   auto frame = ctxt.GetPad()->GetFrame();
+   RFrame::RUserRanges ranges;
+   if (frame) frame->GetClientRanges(ctxt.GetConnId(), ranges);
 
+   auto himpl = fHistImpl.get();
+
+   if (himpl) {
+
+      int nbinsx = himpl->GetAxis(0).GetNBinsNoOver();
+      int nbinsy = himpl->GetAxis(1).GetNBinsNoOver();
+      int nbinsz = himpl->GetAxis(2).GetNBinsNoOver();
+
+      int i1 = 0, i2 = nbinsx, stepi = 1,
+          j1 = 0, j2 = nbinsy, stepj = 1,
+          k1 = 0, k2 = nbinsz, stepk = 1;
+
+      if (ranges.HasMin(0) && ranges.HasMax(0) && (ranges.GetMin(0) != ranges.GetMax(0))) {
+         i1 = himpl->GetAxis(0).FindBin(ranges.GetMin(0));
+         i2 = himpl->GetAxis(0).FindBin(ranges.GetMax(0));
+         if (i1 <= 1) i1 = 0; else i1--; // include extra left bin
+         if ((i2 <= 0) || (i2 >= nbinsx)) i2 = nbinsx; else i2++; // include extra right bin
+      }
+
+      if (ranges.HasMin(1) && ranges.HasMax(1) && (ranges.GetMin(1) != ranges.GetMax(1))) {
+         j1 = himpl->GetAxis(1).FindBin(ranges.GetMin(1));
+         j2 = himpl->GetAxis(1).FindBin(ranges.GetMax(1));
+         if (j1 <= 1) j1 = 0; else j1--; // include extra left bin
+         if ((j2 <= 0) || (j2 >= nbinsy)) j2 = nbinsy; else j2++; // include extra right bin
+      }
+
+      if (ranges.HasMin(2) && ranges.HasMax(2) && (ranges.GetMin(2) != ranges.GetMax(2))) {
+         k1 = himpl->GetAxis(2).FindBin(ranges.GetMin(2));
+         k2 = himpl->GetAxis(2).FindBin(ranges.GetMax(2));
+         if (k1 <= 1) k1 = 0; else k1--; // include extra left bin
+         if ((k2 <= 0) || (k2 >= nbinsz)) k2 = nbinsz; else k2++; // include extra right bin
+      }
+
+      if ((i1 >= i2) || (j1 >= j2) || (k1 >= k2)) {
+         // FATAL, fallback to full content
+         i1 = 0; i2 = nbinsx;
+         j1 = 0; j2 = nbinsy;
+         k1 = 0; k2 = nbinsz;
+      }
+
+      // make approx 25 bins visible in each direction
+      static const int NumVisibleBins = 25;
+
+      bool needrebin = false;
+
+      if (i2 - i1 > NumVisibleBins) {
+         stepi = (i2 - i1) / NumVisibleBins;
+         if (stepi < 2) stepi = 2;
+         i1 = (i1 / stepi) * stepi;
+         if (i2 % stepi > 0) i2 = (i2/stepi + 1) * stepi;
+         needrebin = true;
+      }
+
+      if (j2 - j1 > NumVisibleBins) {
+         stepj = (j2 - j1) / NumVisibleBins;
+         if (stepj < 2) stepj = 2;
+         j1 = (j1 / stepj) * stepj;
+         if (j2 % stepj > 0) j2 = (j2/stepj + 1) * stepj;
+         needrebin = true;
+      }
+
+      if (k2 - k1 > NumVisibleBins) {
+         stepk = (k2 - k1) / NumVisibleBins;
+         if (stepk < 2) stepk = 2;
+         k1 = (k1 / stepk) * stepk;
+         if (k2 % stepk > 0) k2 = (k2/stepk + 1) * stepk;
+         needrebin = true;
+      }
+
+      // be aware, right indicies i2 or j2 can be larger then axes index range.
+      // In this case axis rebin is special
+
+      auto &bins = item->GetBinContent();
+      bins.resize((i2 - i1) / stepi * (j2 - j1) / stepj * (k2 - k1) / stepk);
+
+      double min{0}, minpos{0}, max{0};
+
+      min = max = himpl->GetBinContentAsDouble(1);
+      if (max > 0) minpos = max;
+
+      /// found histogram min/max values
+      for (int k = 0; k < nbinsz; ++k)
+         for (int j = 0; j < nbinsy; ++j)
+            for (int i = 0; i < nbinsx; ++i) {
+               double val = himpl->GetBinContentAsDouble(k*nbinsx*nbinsy + j*nbinsx + i + 1);
+               if (val < min) min = val; else
+               if (val > max) max = val;
+               if ((val > 0.) && (val < minpos)) minpos = val;
+               if (!needrebin && (i>=i1) && (i<i2) && (j>=j1) && (j<j2) && (k>=k1) && (k<k2)) {
+                  int indx = (k-k1)*(j2-j1)*(i2-i1) + (j-j1)*(i2-i1) + (i-i1);
+                  bins[indx] = val;
+               }
+            }
+
+      // provide simple rebin with average values
+      // TODO: provide methods in histogram classes
+      if (needrebin)
+         for (int k = k1; k < k2; k += stepk) {
+            int kr = std::min(k+stepk, nbinsz);
+            for (int j = j1; j < j2; j += stepj) {
+               int jr = std::min(j+stepj, nbinsy);
+               for (int i = i1; i < i2; i += stepi) {
+                  double sum = 0.;
+                  int ir = std::min(i+stepi, nbinsx);
+                  int cnt = 0;
+                  for(int kk = k; kk < kr; ++kk)
+                     for(int jj = j; jj < jr; ++jj)
+                        for(int ii = i; ii < ir; ++ii) {
+                           sum += himpl->GetBinContentAsDouble(kk*nbinsx*nbinsy + jj*nbinsx + ii + 1);
+                           cnt++;
+                        }
+
+                  int indx = (k-k1)/stepk * (j2-j1)/stepj * (i2-i1)/stepi + (j-j1)/stepj * (i2-i1)/stepi + (i-i1)/stepi;
+                  bins[indx] = sum/cnt;
+               }
+            }
+         }
+
+      item->SetContentMinMax(min, minpos, max);
+      item->AddAxis(&himpl->GetAxis(0), i1, i2, stepi);
+      item->AddAxis(&himpl->GetAxis(1), j1, j2, stepj);
+      item->AddAxis(&himpl->GetAxis(2), k1, k2, stepk);
+   }
+
+   return item;
 }

--- a/hist/histdrawv7/src/RHistDrawable.cxx
+++ b/hist/histdrawv7/src/RHistDrawable.cxx
@@ -20,6 +20,8 @@
 #include "ROOT/RPadBase.hxx"
 #include "ROOT/RAxis.hxx"
 
+#include <algorithm> // for std::min
+
 using namespace ROOT::Experimental;
 
 std::unique_ptr<RDisplayItem> RHist2Drawable::CreateHistDisplay(const RDisplayContext &ctxt)
@@ -40,7 +42,7 @@ std::unique_ptr<RDisplayItem> RHist2Drawable::CreateHistDisplay(const RDisplayCo
       int nbinsx = himpl->GetAxis(0).GetNBinsNoOver();
       int nbinsy = himpl->GetAxis(1).GetNBinsNoOver();
 
-      int i1 = 0, i2 = nbinsx, j1 = 0, j2 = nbinsy;
+      int i1 = 0, i2 = nbinsx, j1 = 0, j2 = nbinsy, stepi = 1, stepj = 1;
 
       if (ranges.HasMin(0) && ranges.HasMax(0) && (ranges.GetMin(0) != ranges.GetMax(0))) {
          i1 = himpl->GetAxis(0).FindBin(ranges.GetMin(0));
@@ -56,41 +58,81 @@ std::unique_ptr<RDisplayItem> RHist2Drawable::CreateHistDisplay(const RDisplayCo
          if ((j2 <= 0) || (j2 >= nbinsy)) j2 = nbinsy; else j2++; // include extra right bin
       }
 
-      printf("Get indicies %d %d %d %d\n", i1, i2, j1, j2);
-
       if ((i1>=i2) || (j1>=j2)) {
          printf("FATAL, fallback to full content\n");
          i1 = 0; i2 = nbinsx; j1 = 0; j2 = nbinsy;
       }
 
+      // make approx 200 bins visible in each direction
+      static const int NumVisibleBins = 200;
+
+      bool needrebin = false;
+
+      if (i2 - i1 > NumVisibleBins) {
+         stepi = (i2 - i1) / NumVisibleBins;
+         if (stepi < 2) stepi = 2;
+         i1 = (i1 / stepi) * stepi;
+         if (i2 % stepi > 0) i2 = (i2/stepi + 1) * stepi;
+         needrebin = true;
+      }
+
+      if (j2 - j1 > NumVisibleBins) {
+         stepj = (j2 - j1) / NumVisibleBins;
+         if (stepj < 2) stepj = 2;
+         j1 = (j1 / stepj) * stepj;
+         if (j2 % stepj > 0) j2 = (j2/stepj + 1) * stepj;
+         needrebin = true;
+      }
+
+      printf("Get indicies X: %d %d %d Y: %d %d %d\n", i1, i2, stepi, j1, j2, stepj);
+
+      // be aware, right indicies i2 or j2 can be larger then axes index range.
+      // In this case axis rebin is special
+
       auto &bins = item->GetBinContent();
-      bins.resize((i2 - i1) * (j2 - j1));
+      bins.resize((i2 - i1) / stepi * (j2 - j1) / stepj);
 
       double min{0}, minpos{0}, max{0};
 
       min = max = himpl->GetBinContentAsDouble(1);
       if (max > 0) minpos = max;
-      int previndx = -1;
 
+      /// found histogram min/max values
       for (int j = 0; j < nbinsy; ++j)
          for (int i = 0; i < nbinsx; ++i) {
             double val = himpl->GetBinContentAsDouble(j*nbinsx + i + 1);
             if (val < min) min = val; else
             if (val > max) max = val;
             if ((val > 0.) && (val < minpos)) minpos = val;
-            if ((i>=i1) && (i<i2) && (j>=j1) && (j<j2)) {
+            if (!needrebin && (i>=i1) && (i<i2) && (j>=j1) && (j<j2)) {
                int indx = (j-j1)*(i2-i1) + (i-i1);
-               if ((indx != previndx+1) || (indx < 0) || (indx >= (int) bins.size()))
-                  printf("Index mismatch %d prev %d max %d\n", indx, previndx, (int) bins.size());
-               else
-                  bins[indx] = val;
-               previndx = indx;
+               bins[indx] = val;
+            }
+         }
+
+      // provide simple rebin with average values
+      // TODO: provide methods in histogram classes
+      if (needrebin)
+         for (int j = j1; j < j2; j += stepj) {
+            int jr = std::min(j+stepj, nbinsy);
+            for (int i = i1; i < i2; i += stepi) {
+               double sum = 0.;
+               int ir = std::min(i+stepi, nbinsx);
+               int cnt = 0;
+               for(int jj = j; jj < jr; ++jj)
+                  for(int ii = i; ii < ir; ++ii) {
+                     sum += himpl->GetBinContentAsDouble(jj*nbinsx + ii + 1);
+                     cnt++;
+                  }
+
+               int indx = (j-j1)/stepj * (i2-i1)/stepi + (i-i1)/stepi;
+               bins[indx] = sum/cnt;
             }
          }
 
       item->SetContentMinMax(min, minpos, max);
-      item->AddAxis(&himpl->GetAxis(0), i1, i2);
-      item->AddAxis(&himpl->GetAxis(1), j1, j2);
+      item->AddAxis(&himpl->GetAxis(0), i1, i2, stepi);
+      item->AddAxis(&himpl->GetAxis(1), j1, j2, stepj);
    }
 
    return item;

--- a/hist/histdrawv7/src/RHistDrawable.cxx
+++ b/hist/histdrawv7/src/RHistDrawable.cxx
@@ -16,16 +16,22 @@
 #include "ROOT/RHistDrawable.hxx"
 
 #include "ROOT/RHistDisplayItem.hxx"
+#include "ROOT/RFrame.hxx"
+#include "ROOT/RPadBase.hxx"
 #include "ROOT/RAxis.hxx"
 
 using namespace ROOT::Experimental;
 
-std::unique_ptr<RDisplayItem> RHist2Drawable::Display(const RDisplayContext &ctxt)
+std::unique_ptr<RDisplayItem> RHist2Drawable::CreateHistDisplay(const RDisplayContext &ctxt)
 {
-   if (!fOptimize)
-      return RHistDrawable<2>::Display(ctxt);
-
    auto item = std::make_unique<RHistDisplayItem>(*this);
+
+   auto frame = ctxt.GetPad()->GetFrame();
+   RFrame::RUserRanges ranges;
+   if (frame) frame->GetClientRanges(ctxt.GetConnId(), ranges);
+
+   printf("Frame X min %5.3f max %5.3f\n", ranges.GetMin(0), ranges.GetMax(0));
+   printf("Frame Y min %5.3f max %5.3f\n", ranges.GetMin(1), ranges.GetMax(1));
 
    auto himpl = fHistImpl.get();
 
@@ -34,17 +40,57 @@ std::unique_ptr<RDisplayItem> RHist2Drawable::Display(const RDisplayContext &ctx
       int nbinsx = himpl->GetAxis(0).GetNBinsNoOver();
       int nbinsy = himpl->GetAxis(1).GetNBinsNoOver();
 
-      auto &bins = item->GetBinContent();
-      bins.resize(nbinsy*nbinsx);
-      bins[0] = 0; // bin[0] does not used in RHist, Why?
+      int i1 = 0, i2 = nbinsx, j1 = 0, j2 = nbinsy;
 
-      for (int ny = 0; ny < nbinsy; ++ny)
-         for (int nx = 0; nx < nbinsx; ++nx) {
-            bins[ny*nbinsx + nx] = himpl->GetBinContentAsDouble(ny*nbinsx + nx + 1);
+      if (ranges.HasMin(0) && ranges.HasMax(0) && (ranges.GetMin(0) != ranges.GetMax(0))) {
+         i1 = himpl->GetAxis(0).FindBin(ranges.GetMin(0));
+         i2 = himpl->GetAxis(0).FindBin(ranges.GetMax(0));
+         if (i1 <= 1) i1 = 0; else i1--; // include extra left bin
+         if ((i2 <= 0) || (i2 >= nbinsx)) i2 = nbinsx; else i2++; // include extra right bin
+      }
+
+      if (ranges.HasMin(1) && ranges.HasMax(1) && (ranges.GetMin(1) != ranges.GetMax(1))) {
+         j1 = himpl->GetAxis(1).FindBin(ranges.GetMin(1));
+         j2 = himpl->GetAxis(1).FindBin(ranges.GetMax(1));
+         if (j1 <= 1) j1 = 0; else j1--; // include extra left bin
+         if ((j2 <= 0) || (j2 >= nbinsy)) j2 = nbinsy; else j2++; // include extra right bin
+      }
+
+      printf("Get indicies %d %d %d %d\n", i1, i2, j1, j2);
+
+      if ((i1>=i2) || (j1>=j2)) {
+         printf("FATAL, fallback to full content\n");
+         i1 = 0; i2 = nbinsx; j1 = 0; j2 = nbinsy;
+      }
+
+      auto &bins = item->GetBinContent();
+      bins.resize((i2 - i1) * (j2 - j1));
+
+      double min{0}, minpos{0}, max{0};
+
+      min = max = himpl->GetBinContentAsDouble(1);
+      if (max > 0) minpos = max;
+      int previndx = -1;
+
+      for (int j = 0; j < nbinsy; ++j)
+         for (int i = 0; i < nbinsx; ++i) {
+            double val = himpl->GetBinContentAsDouble(j*nbinsx + i + 1);
+            if (val < min) min = val; else
+            if (val > max) max = val;
+            if ((val > 0.) && (val < minpos)) minpos = val;
+            if ((i>=i1) && (i<i2) && (j>=j1) && (j<j2)) {
+               int indx = (j-j1)*(i2-i1) + (i-i1);
+               if ((indx != previndx+1) || (indx < 0) || (indx >= (int) bins.size()))
+                  printf("Index mismatch %d prev %d max %d\n", indx, previndx, (int) bins.size());
+               else
+                  bins[indx] = val;
+               previndx = indx;
+            }
          }
 
-      item->AddAxis(&himpl->GetAxis(0), 0, nbinsx);
-      item->AddAxis(&himpl->GetAxis(1), 0, nbinsy);
+      item->SetContentMinMax(min, minpos, max);
+      item->AddAxis(&himpl->GetAxis(0), i1, i2);
+      item->AddAxis(&himpl->GetAxis(1), j1, j2);
    }
 
    return item;

--- a/hist/histdrawv7/src/RHistDrawable.cxx
+++ b/hist/histdrawv7/src/RHistDrawable.cxx
@@ -118,9 +118,6 @@ std::unique_ptr<RDisplayItem> RHist2Drawable::CreateHistDisplay(const RDisplayCo
    RFrame::RUserRanges ranges;
    if (frame) frame->GetClientRanges(ctxt.GetConnId(), ranges);
 
-   printf("Frame X min %5.3f max %5.3f\n", ranges.GetMin(0), ranges.GetMax(0));
-   printf("Frame Y min %5.3f max %5.3f\n", ranges.GetMin(1), ranges.GetMax(1));
-
    auto himpl = fHistImpl.get();
 
    if (himpl) {
@@ -169,8 +166,6 @@ std::unique_ptr<RDisplayItem> RHist2Drawable::CreateHistDisplay(const RDisplayCo
          if (j2 % stepj > 0) j2 = (j2/stepj + 1) * stepj;
          needrebin = true;
       }
-
-      printf("Get indicies X: %d %d %d Y: %d %d %d\n", i1, i2, stepi, j1, j2, stepj);
 
       // be aware, right indicies i2 or j2 can be larger then axes index range.
       // In this case axis rebin is special

--- a/hist/histdrawv7/src/RHistDrawable.cxx
+++ b/hist/histdrawv7/src/RHistDrawable.cxx
@@ -15,3 +15,37 @@
 
 #include "ROOT/RHistDrawable.hxx"
 
+#include "ROOT/RHistDisplayItem.hxx"
+#include "ROOT/RAxis.hxx"
+
+using namespace ROOT::Experimental;
+
+std::unique_ptr<RDisplayItem> RHist2Drawable::Display(const RDisplayContext &ctxt)
+{
+   if (!fOptimize)
+      return RHistDrawable<2>::Display(ctxt);
+
+   auto item = std::make_unique<RHistDisplayItem>(*this);
+
+   auto himpl = fHistImpl.get();
+
+   if (himpl) {
+
+      int nbinsx = himpl->GetAxis(0).GetNBinsNoOver();
+      int nbinsy = himpl->GetAxis(1).GetNBinsNoOver();
+
+      auto &bins = item->GetBinContent();
+      bins.resize(nbinsy*nbinsx);
+      bins[0] = 0; // bin[0] does not used in RHist, Why?
+
+      for (int ny = 0; ny < nbinsy; ++ny)
+         for (int nx = 0; nx < nbinsx; ++nx) {
+            bins[ny*nbinsx + nx] = himpl->GetBinContentAsDouble(ny*nbinsx + nx + 1);
+         }
+
+      item->AddAxis(&himpl->GetAxis(0), 0, nbinsx);
+      item->AddAxis(&himpl->GetAxis(1), 0, nbinsy);
+   }
+
+   return item;
+}

--- a/hist/histdrawv7/test/io.cxx
+++ b/hist/histdrawv7/test/io.cxx
@@ -4,9 +4,8 @@
 #include "ROOT/RHistDrawable.hxx"
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/RColor.hxx"
-#include "ROOT/RFile.hxx"
 
-#include "TFile.h"
+#include "TMemFile.h"
 
 using namespace ROOT::Experimental;
 
@@ -14,14 +13,43 @@ using namespace ROOT::Experimental;
 TEST(IOTest, OneD)
 {
    RAxisConfig xaxis{10, 0., 1.};
-   RH1D h(xaxis);
-   auto file = RFile::Recreate("IOTestOneD.root");
-   file->Write("h", h);
+   RH1D h1(xaxis);
+
+   TMemFile file("testrh1.root","RECREATE","Testing I/O of RH1D");
+
+   file.WriteObject(&h1, "h1");
+
+   auto readh1 = file.Get<RH1D>("h1");
+
+   ASSERT_NE(readh1, nullptr);
+
+   delete readh1;
 }
+
+// Test storing of 2D histogram
+TEST(IOTest, TwoD)
+{
+   RAxisConfig xaxis{10, 0., 1.};
+   RAxisConfig yaxis{10, 0., 1.};
+   RH2D h2(xaxis, yaxis);
+
+   TMemFile file("testrh2.root","RECREATE","Testing I/O of RH2D");
+
+   file.WriteObject(&h2, "h2");
+
+   auto readh2 = file.Get<RH2D>("h2");
+
+   ASSERT_NE(readh2, nullptr);
+
+   delete readh2;
+}
+
 
 // Test storing RCanvas with two RHistDrawable, referencing same histo
 TEST(IOTest, OneDOpts)
 {
+   TMemFile file("test_canvas_rh1.root","RECREATE","Testing RCanvas I/O with RH1D");
+
    {
       RAxisConfig xaxis{10, 0., 1.};
       auto h = std::make_shared<RH1D>(xaxis);
@@ -43,14 +71,10 @@ TEST(IOTest, OneDOpts)
       EXPECT_NE(pr2->GetHist().get(), nullptr);
       EXPECT_EQ(pr1->GetHist().get(), pr2->GetHist().get());
 
-      auto file = RFile::Recreate("IOTestOneDOpts.root");
-      file->Write("canv", canv);
-      file->Close();
+      file.WriteObject(&canv, "canv");
    }
 
-   auto file2 = TFile::Open("IOTestOneDOpts.root");
-   ASSERT_NE(file2, nullptr);
-   auto canv2 = file2->Get<ROOT::Experimental::RCanvas>("canv");
+   auto canv2 = file.Get<ROOT::Experimental::RCanvas>("canv");
    ASSERT_NE(canv2, nullptr);
 
    EXPECT_EQ(canv2->NumPrimitives(), 3u);
@@ -69,5 +93,4 @@ TEST(IOTest, OneDOpts)
    EXPECT_EQ(dr1->GetHist(), dr2->GetHist());
 
    delete canv2;
-   delete file2;
 }

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 2/07/2020";
+   JSROOT.version = "dev 3/07/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 1/07/2020";
+   JSROOT.version = "dev 2/07/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 25/06/2020";
+   JSROOT.version = "dev 26/06/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 30/06/2020";
+   JSROOT.version = "dev 1/07/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 26/06/2020";
+   JSROOT.version = "dev 29/06/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 29/06/2020";
+   JSROOT.version = "dev 30/06/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;

--- a/js/scripts/JSRootPainter.v6.js
+++ b/js/scripts/JSRootPainter.v6.js
@@ -2093,8 +2093,7 @@
       } else {
          switch (kind) {
             case 1:
-               var fp = this.frame_painter();
-               if (fp) fp.ProcessFrameClick(pnt);
+               this.ProcessFrameClick(pnt);
                break;
             case 2:
                var pp = this.pad_painter();
@@ -2502,7 +2501,7 @@
 
          var diff = now.getTime() - this.last_touch.getTime();
 
-         if ((diff > 500) && (diff<2000) && !this.frame_painter().IsTooltipShown()) {
+         if ((diff > 500) && (diff < 2000) && !this.IsTooltipShown()) {
             this.ShowContextMenu('main', { clientX: this.zoom_curr[0], clientY: this.zoom_curr[1] });
             this.last_touch = new Date(0);
          } else {

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -1789,9 +1789,9 @@
          unzoom_z = (zmin === zmax) && (zmin === 0);
       }
 
-      var changed = false, fp = this, changes = {};
-
-      var req = {
+      var changed = false, fp = this, changes = {},
+          r_x = "", r_y = "", r_z = "",
+         req = {
          _typename: "ROOT::Experimental::RFrame::RUserRanges",
          values: [0, 0, 0, 0, 0, 0],
          flags: [false, false, false, false, false, false]
@@ -1803,7 +1803,7 @@
             if (zoom_x && obj.CanZoomIn("x", xmin, xmax)) {
                fp.zoom_xmin = xmin;
                fp.zoom_xmax = xmax;
-               changed = true;
+               changed = true; r_x = "0";
                zoom_x = false;
                fp.v7AttrChange(changes, "x_zoommin", xmin);
                fp.v7AttrChange(changes, "x_zoommax", xmax);
@@ -1813,7 +1813,7 @@
             if (zoom_y && obj.CanZoomIn("y", ymin, ymax)) {
                fp.zoom_ymin = ymin;
                fp.zoom_ymax = ymax;
-               changed = true;
+               changed = true; r_y = "1";
                zoom_y = false;
                fp.v7AttrChange(changes, "y_zoommin", ymin);
                fp.v7AttrChange(changes, "y_zoommax", ymax);
@@ -1823,7 +1823,7 @@
             if (zoom_z && obj.CanZoomIn("z", zmin, zmax)) {
                fp.zoom_zmin = zmin;
                fp.zoom_zmax = zmax;
-               changed = true;
+               changed = true; r_z = "2";
                zoom_z = false;
                fp.v7AttrChange(changes, "z_zoommin", zmin);
                fp.v7AttrChange(changes, "z_zoommax", zmax);
@@ -1835,21 +1835,21 @@
       // and process unzoom, if any
       if (unzoom_x || unzoom_y || unzoom_z) {
          if (unzoom_x) {
-            if (this.zoom_xmin !== this.zoom_xmax) changed = true;
+            if (this.zoom_xmin !== this.zoom_xmax) { changed = true; r_x = "0"; }
             this.zoom_xmin = this.zoom_xmax = 0;
             fp.v7AttrChange(changes, "x_zoommin", null);
             fp.v7AttrChange(changes, "x_zoommax", null);
             req.values[0] = req.values[1] = -1;
          }
          if (unzoom_y) {
-            if (this.zoom_ymin !== this.zoom_ymax) changed = true;
+            if (this.zoom_ymin !== this.zoom_ymax) { changed = true; r_y = "1"; }
             this.zoom_ymin = this.zoom_ymax = 0;
             fp.v7AttrChange(changes, "y_zoommin", null);
             fp.v7AttrChange(changes, "y_zoommax", null);
             req.values[2] = req.values[3] = -1;
          }
          if (unzoom_z) {
-            if (this.zoom_zmin !== this.zoom_zmax) changed = true;
+            if (this.zoom_zmin !== this.zoom_zmax) { changed = true; r_z = "2"; }
             this.zoom_zmin = this.zoom_zmax = 0;
             fp.v7AttrChange(changes, "z_zoommin", null);
             fp.v7AttrChange(changes, "z_zoommax", null);
@@ -1857,15 +1857,13 @@
          }
       }
 
-      if (this.v7CommMode() == JSROOT.v7.CommMode.kNormal) {
-         console.log('Send zoom ', req);
+      if (this.v7CommMode() == JSROOT.v7.CommMode.kNormal)
          this.v7SubmitRequest("zoom", { _typename: "ROOT::Experimental::RFrame::RZoomRequest", ranges: req });
-      }
 
       // this.v7SendAttrChanges(changes);
 
       if (changed)
-         this.InteractiveRedraw("pad", "zoom");
+         this.InteractiveRedraw("pad", "zoom" + r_x + r_y + r_z);
 
       return changed;
    }

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -1858,6 +1858,7 @@
       }
 
       if (this.v7CommMode() == JSROOT.v7.CommMode.kNormal) {
+         console.log('Send zoom ', req);
          this.v7SubmitRequest("zoom", { _typename: "ROOT::Experimental::RFrame::RZoomRequest", ranges: req });
       }
 

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -134,11 +134,12 @@
    JSROOT.TObjectPainter.prototype.createv7AttFill = function(prefix) {
       if (!prefix || (typeof prefix != "string")) prefix = "fill_";
 
-      var fill_color = this.v7EvalColor(prefix + "color", "white");
+      var fill_color = this.v7EvalColor(prefix + "color", ""),
+          fill_style = this.v7EvalAttr(prefix + "style", 1001);
 
-      this.createAttFill({ pattern: 1001, color: 0 });
+      this.createAttFill({ pattern: fill_style, color: 0 });
 
-      this.fillatt.SetSolidColor(fill_color);
+      this.fillatt.SetSolidColor(fill_color || "none");
    }
 
    /** Create this.lineatt object based on v7 line attributes */

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -2038,8 +2038,7 @@
       } else {
          switch (kind) {
             case 1:
-               var fp = this.frame_painter();
-               if (fp) fp.ProcessFrameClick(pnt);
+               this.ProcessFrameClick(pnt);
                break;
             case 2:
                var pp = this.pad_painter();
@@ -2187,7 +2186,7 @@
 
          var diff = now.getTime() - this.last_touch.getTime();
 
-         if ((diff > 500) && (diff<2000) && !this.frame_painter().IsTooltipShown()) {
+         if ((diff > 500) && (diff<2000) && !this.IsTooltipShown()) {
             this.ShowContextMenu('main', { clientX: this.zoom_curr[0], clientY: this.zoom_curr[1] });
             this.last_touch = new Date(0);
          } else {

--- a/js/scripts/JSRootPainter.v7.js
+++ b/js/scripts/JSRootPainter.v7.js
@@ -5243,6 +5243,7 @@
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RHist1Drawable", icon: "img_histo1d", prereq: "v7hist", func: "JSROOT.v7.drawHist1", opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RHist2Drawable", icon: "img_histo2d", prereq: "v7hist", func: "JSROOT.v7.drawHist2", opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RHist3Drawable", icon: "img_histo3d", prereq: "v7hist3d", func: "JSROOT.v7.drawHist3", opt: "" });
+   JSROOT.addDrawFunc({ name: "ROOT::Experimental::RHistDisplayItem", icon: "img_histo1d", prereq: "v7hist", func: "JSROOT.v7.drawHistDisplayItem", opt: "" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RText", icon: "img_text", prereq: "v7more", func: "JSROOT.v7.drawText", opt: "", direct: true, csstype: "text" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RFrameTitle", icon: "img_text", func: drawFrameTitle, opt: "", direct: true, csstype: "title" });
    JSROOT.addDrawFunc({ name: "ROOT::Experimental::RPaletteDrawable", icon: "img_text", func: drawPalette, opt: "" });

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -199,7 +199,6 @@
    }
 
    RHistPainter.prototype.Cleanup = function() {
-
       // clear all 3D buffers
       this.Clear3DScene();
 
@@ -412,9 +411,16 @@
 
       method = method.bind(this);
 
-      if (this.IsDisplayItem() && (reason == "zoom") && (this.v7CommMode() == JSROOT.v7.CommMode.kNormal)) {
+      var is_axes_zoomed = false;
+      if (reason && (typeof reason == "string") && (reason.indexOf("zoom") == 0)) {
+         if (reason.indexOf("0") > 0) is_axes_zoomed = true;
+         if ((this.Dimension() > 1) && (reason.indexOf("1") > 0)) is_axes_zoomed = true;
+         if ((this.Dimension() > 2) && (reason.indexOf("2") > 0)) is_axes_zoomed = true;
+      }
 
-         var handle = this.PrepareColorDraw({ only_indexes: true });
+      if (this.IsDisplayItem() && is_axes_zoomed && (this.v7CommMode() == JSROOT.v7.CommMode.kNormal)) {
+
+         var handle = this.PrepareDraw({ only_indexes: true });
 
          // submit request if histogram data not enough for display
          if (handle.incomplete) {
@@ -735,7 +741,8 @@
       this.InteractiveRedraw("pad", "drawopt");
    }
 
-   RHistPainter.prototype.PrepareColorDraw = function(args) {
+   /** Calculate histogram inidicies and axes values for each visible bin */
+   RHistPainter.prototype.PrepareDraw = function(args) {
 
       if (!args) args = { rounding: true, extra: 0, middle: 0 };
 
@@ -1211,7 +1218,7 @@
 
       this.CheckHistDrawAttributes();
 
-      var handle = this.PrepareColorDraw({ extra: 1, only_indexes: true });
+      var handle = this.PrepareDraw({ extra: 1, only_indexes: true });
 
       if (this.options.Bar)
          return this.DrawBars(handle, width, height);
@@ -1815,7 +1822,6 @@
    }
 
    RH1Painter.prototype.Draw2D = function(call_back, reason) {
-
       this.Clear3DScene();
       this.mode3d = false;
 
@@ -2254,7 +2260,7 @@
 
    RH2Painter.prototype.DrawBinsColor = function(w,h) {
       var histo = this.GetHisto(),
-          handle = this.PrepareColorDraw(),
+          handle = this.PrepareDraw(),
           colPaths = [], currx = [], curry = [],
           colindx, cmd1, cmd2, i, j, binz, di = handle.stepi, dj = handle.stepj;
 
@@ -2516,7 +2522,7 @@
    }
 
    RH2Painter.prototype.DrawBinsContour = function(frame_w,frame_h) {
-      var handle = this.PrepareColorDraw({ rounding: false, extra: 100, original: this.options.Proj != 0 }),
+      var handle = this.PrepareDraw({ rounding: false, extra: 100, original: this.options.Proj != 0 }),
           main = this.frame_painter(),
           palette = main.GetPalette(),
           levels = palette.GetContour(),
@@ -2746,7 +2752,7 @@
       var histo = this.GetHisto(),
           i,j,binz,colindx,binw,binh,lbl,posx,posy,sizex,sizey;
 
-      if (handle===null) handle = this.PrepareColorDraw({ rounding: false });
+      if (handle===null) handle = this.PrepareDraw({ rounding: false });
 
       var text_col = this.v7EvalColor("text_color", "black"),
           text_angle = -1*this.v7EvalAttr("text_angle", 0),
@@ -2801,7 +2807,7 @@
       var histo = this.GetHisto(), cmd = "",
           i,j,binz,colindx,binw,binh,lbl, loop, dn = 1e-30, dx, dy, xc,yc,
           dxn,dyn,x1,x2,y1,y2, anr,si,co,
-          handle = this.PrepareColorDraw({ rounding: false }),
+          handle = this.PrepareDraw({ rounding: false }),
           scale_x = (handle.grx[handle.i2] - handle.grx[handle.i1])/(handle.i2 - handle.i1 + 1-0.03)/2,
           scale_y = (handle.gry[handle.j2] - handle.gry[handle.j1])/(handle.j2 - handle.j1 + 1-0.03)/2,
           di = handle.stepi, dj = handle.stepj;
@@ -2867,7 +2873,7 @@
    RH2Painter.prototype.DrawBinsBox = function(w,h) {
 
       var histo = this.GetHisto(),
-          handle = this.PrepareColorDraw({ rounding: false }),
+          handle = this.PrepareDraw({ rounding: false }),
           main = this.frame_painter();
 
       if (main.maxbin === main.minbin) {
@@ -2981,7 +2987,7 @@
 
    RH2Painter.prototype.DrawCandle = function(w,h) {
       var histo = this.GetHisto(), yaxis = this.GetAxis("y"),
-          handle = this.PrepareColorDraw(),
+          handle = this.PrepareDraw(),
           pmain = this.frame_painter(), // used for axis values conversions
           i, j, y, sum0, sum1, sum2, cont, center, counter, integral, w, pnt,
           bars = "", markers = "", posy;
@@ -3091,7 +3097,7 @@
    RH2Painter.prototype.DrawBinsScatter = function(w,h) {
       var histo = this.GetHisto(),
           fp = this.frame_painter(),
-          handle = this.PrepareColorDraw({ rounding: true, pixel_density: true, scatter_plot: true }),
+          handle = this.PrepareDraw({ rounding: true, pixel_density: true, scatter_plot: true }),
           colPaths = [], currx = [], curry = [], cell_w = [], cell_h = [],
           colindx, cmd1, cmd2, i, j, binz, cw, ch, factor = 1.,
           scale = this.options.ScatCoef * ((this.gmaxbin) > 2000 ? 2000. / this.gmaxbin : 1.),
@@ -3941,7 +3947,8 @@
    }
 
    RHistStatsPainter.prototype.Redraw = function(reason) {
-      if ((reason == "zoom") && (this.v7CommMode() == JSROOT.v7.CommMode.kNormal)) {
+      if (reason && (typeof reason == "string") && (reason.indexOf("zoom") == 0) &&
+          (this.v7CommMode() == JSROOT.v7.CommMode.kNormal)) {
          var req = {
             _typename: "ROOT::Experimental::RHistStatBoxBase::RRequest",
             mask: this.GetObject().fShowMask // lines to show in stat box

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -1068,12 +1068,11 @@
       return true;
    }
 
-   RH1Painter.prototype.DrawBars = function(width, height) {
+   RH1Painter.prototype.DrawBars = function(handle, width, height) {
 
       this.CreateG(true);
 
-      var left = this.GetSelectIndex("x", "left", -1),
-          right = this.GetSelectIndex("x", "right", 1),
+      var left = handle.i1, right = handle.i2, di = handle.stepi,
           pmain = this.frame_painter(),
           pthis = this,
           histo = this.GetHisto(), xaxis = this.GetAxis("x"),
@@ -1085,9 +1084,9 @@
          if (this.options.BaseLine >= pmain.scale_ymin)
             gry2 = Math.round(pmain.gry(this.options.BaseLine));
 
-      for (i = left; i < right; ++i) {
+      for (i = left; i < right; i += di) {
          x1 = xaxis.GetBinCoord(i);
-         x2 = xaxis.GetBinCoord(i+1);
+         x2 = xaxis.GetBinCoord(i+di);
 
          if (pmain.logx && (x2 <= 0)) continue;
 
@@ -1140,17 +1139,16 @@
                .style("fill", d3.rgb(this.fillatt.color).darker(0.5).toString());
    }
 
-   RH1Painter.prototype.DrawFilledErrors = function(width, height) {
+   RH1Painter.prototype.DrawFilledErrors = function(handle, width, height) {
       this.CreateG(true);
 
-      var left = this.GetSelectIndex("x", "left", -1),
-          right = this.GetSelectIndex("x", "right", 1),
+      var left = handle.i1, right = handle.i2, di = handle.stepi,
           pmain = this.frame_painter(),
           histo = this.GetHisto(), xaxis = this.GetAxis("x"),
           i, x, grx, y, yerr, gry1, gry2,
           bins1 = [], bins2 = [];
 
-      for (i = left; i < right; ++i) {
+      for (i = left; i < right; i += di) {
          x = xaxis.GetBinCoord(i+0.5);
          if (pmain.logx && (x <= 0)) continue;
          grx = Math.round(pmain.grx(x));
@@ -1189,20 +1187,21 @@
 
       this.CheckHistDrawAttributes();
 
+      var handle = this.PrepareColorDraw({ extra: 1, only_indexes: true });
+
       if (this.options.Bar)
-         return this.DrawBars(width, height);
+         return this.DrawBars(handle, width, height);
 
       if ((this.options.ErrorKind === 3) || (this.options.ErrorKind === 4))
-         return this.DrawFilledErrors(width, height);
+         return this.DrawFilledErrors(handle, width, height);
 
-      return this.DrawHistBins(width, height);
+      return this.DrawHistBins(handle, width, height);
    }
 
-   RH1Painter.prototype.DrawHistBins = function(width, height) {
+   RH1Painter.prototype.DrawHistBins = function(handle, width, height) {
       this.CreateG(true);
 
       var options = this.options,
-          handle = this.PrepareColorDraw({ extra: 1, only_indexes: true }),
           left = handle.i1,
           right = handle.i2,
           di = handle.stepi,
@@ -1225,7 +1224,7 @@
 
       if (options.ErrorKind === 2) {
          if (this.fillatt.empty()) show_markers = true;
-                               else path_fill = "";
+                              else path_fill = "";
       } else if (options.Error) {
          path_err = "";
       }
@@ -1796,15 +1795,11 @@
       this.Clear3DScene();
       this.mode3d = false;
 
-      console.log('Calling histogram Draw2D');
-
       if (!this.DrawAxes())
          return JSROOT.CallBack(call_back);
 
       this.DrawingBins(call_back, reason, function() {
          // called when bins received from server, must be reentrant
-         console.log('Calling DrawBins');
-
          this.DrawBins();
          this.UpdateStatWebCanvas();
          this.AddInteractive();

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -107,7 +107,37 @@
          histo = obj;
 
          if (!histo.getBinContent || force) {
-            if (histo.fAxes.length == 2) {
+            if (histo.fAxes.length == 3) {
+               this.ProvideAxisMethods(histo.fAxes[0]);
+               this.ProvideAxisMethods(histo.fAxes[1]);
+               this.ProvideAxisMethods(histo.fAxes[2]);
+
+               histo.nx = histo.fIndicies[1] - histo.fIndicies[0];
+               histo.dx = histo.fIndicies[0] + 1;
+               histo.stepx = histo.fIndicies[2];
+
+               histo.ny = histo.fIndicies[4] - histo.fIndicies[3];
+               histo.dy = histo.fIndicies[3] + 1;
+               histo.stepy = histo.fIndicies[5];
+
+               histo.nz = histo.fIndicies[7] - histo.fIndicies[6];
+               histo.dz = histo.fIndicies[6] + 1;
+               histo.stepz = histo.fIndicies[8];
+
+               // this is index in original histogram
+               histo.getBin = function(x, y, z) { return (x-1) + this.fAxes[0].GetNumBins()*(y-1) + this.fAxes[0].GetNumBins()*this.fAxes[1].GetNumBins()*(z-1); }
+
+               // this is index in current available data
+               if ((histo.stepx > 1) || (histo.stepy > 1) || (histo.stepz > 1))
+                  histo.getBin0 = function(x, y, z) { return Math.floor((x-this.dx)/this.stepx) + this.nx/this.stepx*Math.floor((y-this.dy)/this.stepy) + this.nx/this.stepx*this.ny/this.stepy*Math.floor((z-this.dz)/this.stepz); }
+               else
+                  histo.getBin0 = function(x, y, z) { return (x-this.dx) + this.nx*(y-this.dy) + this.nx*this.ny*(z-dz); }
+
+               histo.getBinContent = function(x, y, z) { return this.fBinContent[this.getBin0(x, y, z)]; }
+               histo.getBinError = function(x, y, z) { return Math.sqrt(Math.abs(this.getBinContent(x, y, z))); }
+
+
+            } else if (histo.fAxes.length == 2) {
                this.ProvideAxisMethods(histo.fAxes[0]);
                this.ProvideAxisMethods(histo.fAxes[1]);
 
@@ -118,10 +148,6 @@
                histo.ny = histo.fIndicies[4] - histo.fIndicies[3];
                histo.dy = histo.fIndicies[3] + 1;
                histo.stepy = histo.fIndicies[5];
-
-               // does display item covers full range?
-               // histo._full_range = (histo.dx == 1) && (histo.nx >= histo.fAxes[0].GetNumBins()) &&
-               //                     (histo.dy == 1) && (histo.ny >= histo.fAxes[1].GetNumBins());
 
                // this is index in original histogram
                histo.getBin = function(x, y) { return (x-1) + this.fAxes[0].GetNumBins()*(y-1); }
@@ -139,9 +165,6 @@
                histo.nx = histo.fIndicies[1] - histo.fIndicies[0];
                histo.dx = histo.fIndicies[0] + 1;
                histo.stepx = histo.fIndicies[2];
-
-               // does display item covers full range?
-               // histo._full_range = (histo.dx == 1) && (histo.nx >= histo.fAxes[0].GetNumBins());
 
                histo.getBin = function(x) { return x-1; }
                if (histo.stepx > 1)
@@ -717,6 +740,7 @@
       if (!args) args = { rounding: true, extra: 0, middle: 0 };
 
       if (args.extra === undefined) args.extra = 0;
+      if (args.right_extra === undefined) args.right_extra = args.extra;
       if (args.middle === undefined) args.middle = 0;
 
       var histo = this.GetHisto(), xaxis = this.GetAxis("x"), yaxis = this.GetAxis("y"),
@@ -725,11 +749,11 @@
           i, j, x, y, binz, binarea,
           res = {
              i1: this.GetSelectIndex("x", "left", 0 - args.extra),
-             i2: this.GetSelectIndex("x", "right", 1 + args.extra),
+             i2: this.GetSelectIndex("x", "right", 1 + args.right_extra),
              j1: (hdim < 2) ? 0 : this.GetSelectIndex("y", "left", 0 - args.extra),
-             j2: (hdim < 2) ? 1 : this.GetSelectIndex("y", "right", 1 + args.extra),
+             j2: (hdim < 2) ? 1 : this.GetSelectIndex("y", "right", 1 + args.right_extra),
              k1: (hdim < 3) ? 0 : this.GetSelectIndex("z", "left", 0 - args.extra),
-             k2: (hdim < 3) ? 1 : this.GetSelectIndex("z", "right", 1 + args.extra),
+             k2: (hdim < 3) ? 1 : this.GetSelectIndex("z", "right", 1 + args.right_extra),
              stepi: 1, stepj: 1, stepk: 1,
              min: 0, max: 0, sumz: 0, xbar1: 0, xbar2: 1, ybar1: 0, ybar2: 1
           };
@@ -3677,14 +3701,67 @@
       return painter;
    }
 
+   // =================================================================================
+
+
+   // place basic declaration here to be able use it with RHistDisplayItem
+   function RH3Painter(histo) {
+      JSROOT.v7.RHistPainter.call(this, histo);
+
+      this.mode3d = true;
+   }
+
+   RH3Painter.prototype = Object.create(RHistPainter.prototype);
+
+   RH3Painter.prototype.Dimension = function() {
+      return 3;
+   }
+
+   function drawHist3(divid, histo, opt) {
+      // create painter and add it to canvas
+      var painter = new RH3Painter(histo);
+
+      painter.PrepareFrame(divid, true); // create if necessary frame in 3d mode
+
+      painter.options = { Box: 0, Scatter: false, Sphere: 0, Color: false, minimum: -1111, maximum: -1111 };
+
+      var kind = painter.v7EvalAttr("kind", ""),
+          sub = painter.v7EvalAttr("sub", 0),
+          o = painter.options;
+
+      switch(kind) {
+         case "box": o.Box = 10 + sub; break;
+         case "sphere": o.Sphere = 10 + sub; break;
+         case "col": o.Color = true; break;
+         case "scat": o.Scatter = true;  break;
+         default: o.Box = 10;
+      }
+
+      JSROOT.AssertPrerequisites('v7hist3d', function() {
+         painter.ScanContent();
+         painter.Redraw();
+         painter.DrawingReady();
+      }.bind(this));
+
+      return painter;
+   }
+
+   // =================================================================================
+
    function drawHistDisplayItem(divid, obj, opt) {
-      if (!obj || (obj.fAxes.length < 2))
+      if (!obj)
+         return null;
+
+      if (obj.fAxes.length == 1)
          return drawHist1(divid, obj, opt);
 
       if (obj.fAxes.length == 2)
          return drawHist2(divid, obj, opt);
 
-      return null; // support of RH3 object
+      if (obj.fAxes.length == 3)
+         return drawHist3(divid, obj, opt);
+
+      return null;
    }
 
    // =============================================================
@@ -3889,9 +3966,12 @@
    JSROOT.v7.RHistPainter = RHistPainter;
    JSROOT.v7.RH1Painter = RH1Painter;
    JSROOT.v7.RH2Painter = RH2Painter;
+   JSROOT.v7.RH3Painter = RH3Painter;
 
    JSROOT.v7.drawHist1 = drawHist1;
    JSROOT.v7.drawHist2 = drawHist2;
+   JSROOT.v7.drawHist3 = drawHist3;
+
    JSROOT.v7.drawHistDisplayItem = drawHistDisplayItem;
    JSROOT.v7.drawHistStats = drawHistStats;
 

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -2790,9 +2790,10 @@
           absmin = Math.max(0, main.minbin),
           i, j, binz, absz, res = "", cross = "", btn1 = "", btn2 = "",
           colindx, zdiff, dgrx, dgry, xx, yy, ww, hh, cmd1, cmd2,
-          xyfactor = 1, uselogz = false, logmin = 0, logmax = 1;
+          xyfactor = 1, uselogz = false, logmin = 0, logmax = 1,
+          di = handle.stepi, dj = handle.stepj;
 
-      if (this.root_pad().fLogz && (absmax>0)) {
+      if (main.logz && (absmax>0)) {
          uselogz = true;
          logmax = Math.log(absmax);
          if (absmin>0) logmin = Math.log(absmin); else
@@ -2805,8 +2806,8 @@
       }
 
       // now start build
-      for (i = handle.i1; i < handle.i2; ++i) {
-         for (j = handle.j1; j < handle.j2; ++j) {
+      for (i = handle.i1; i < handle.i2; i += di) {
+         for (j = handle.j1; j < handle.j2; j += dj) {
             binz = histo.getBinContent(i + 1, j + 1);
             absz = Math.abs(binz);
             if ((absz === 0) || (absz < absmin)) continue;
@@ -2817,14 +2818,14 @@
             // avoid oversized bins
             if (zdiff < 0) zdiff = 0;
 
-            ww = handle.grx[i+1] - handle.grx[i];
-            hh = handle.gry[j] - handle.gry[j+1];
+            ww = handle.grx[i+di] - handle.grx[i];
+            hh = handle.gry[j] - handle.gry[j+dj];
 
             dgrx = zdiff * ww;
             dgry = zdiff * hh;
 
             xx = Math.round(handle.grx[i] + dgrx);
-            yy = Math.round(handle.gry[j+1] + dgry);
+            yy = Math.round(handle.gry[j+dj] + dgry);
 
             ww = Math.max(Math.round(ww - 2*dgrx), 1);
             hh = Math.max(Math.round(hh - 2*dgry), 1);
@@ -2846,6 +2847,8 @@
             }
          }
       }
+
+      console.log('LINE COLOR', this.lineatt.color, "FILL COLOR", this.fillatt.color);
 
       if (res.length > 0) {
          var elem = this.draw_g.append("svg:path")
@@ -3615,6 +3618,7 @@
       switch(kind) {
          case "lego": o.Lego = sub > 0 ? 10+sub : 12; o.Mode3D = true; break;
          case "surf": o.Surf = sub > 0 ? 10+sub : 1; o.Mode3D = true; break;
+         case "box": o.Box = true; o.BoxStyle = 10 + sub; break;
          case "err": o.Error = true; o.Mode3D = true; break;
          case "cont": o.Contour = sub > 0 ? 10+sub : 1; break;
          case "arr": o.Arrow = true; break;

--- a/js/scripts/JSRootPainter.v7hist.js
+++ b/js/scripts/JSRootPainter.v7hist.js
@@ -58,10 +58,10 @@
       return obj && obj.fAxes ? true : false;
    }
 
-   RHistPainter.prototype.GetHisto = function() {
+   RHistPainter.prototype.GetHisto = function(force) {
       var obj = this.GetObject(), histo = this.GetHImpl(obj);
 
-      if (histo && !histo.getBinContent) {
+      if (histo && (!histo.getBinContent || force)) {
          if (histo.fAxes._2) {
             this.ProvideAxisMethods(histo.fAxes._0);
             this.ProvideAxisMethods(histo.fAxes._1);
@@ -103,22 +103,27 @@
 
          histo = obj;
 
-         if (!histo.getBinContent) {
+         if (!histo.getBinContent || force) {
             if (histo.fAxes.length == 2) {
                this.ProvideAxisMethods(histo.fAxes[0]);
                this.ProvideAxisMethods(histo.fAxes[1]);
 
                histo.nx = histo.fIndicies[1] - histo.fIndicies[0];
                histo.dx = histo.fIndicies[0] + 1;
+               histo.stepx = histo.fIndicies[2];
 
                histo.ny = histo.fIndicies[4] - histo.fIndicies[3];
                histo.dy = histo.fIndicies[3] + 1;
+               histo.stepy = histo.fIndicies[5];
 
                // this is index in original histogram
                histo.getBin = function(x, y) { return (x-1) + this.fAxes[0].GetNumBins()*(y-1); }
 
                // this is index in current available data
-               histo.getBin0 = function(x, y) { return (x-this.dx) + this.nx*(y-this.dy); }
+               if ((histo.stepx > 1) || (histo.stepy > 1))
+                  histo.getBin0 = function(x, y) { return Math.floor((x-this.dx)/this.stepx) + this.nx/this.stepx*Math.floor((y-this.dy)/this.stepy); }
+               else
+                  histo.getBin0 = function(x, y) { return (x-this.dx) + this.nx*(y-this.dy); }
 
                histo.getBinContent = function(x, y) { return this.fBinContent[this.getBin0(x, y)]; }
                histo.getBinError = function(x, y) { return Math.sqrt(Math.abs(this.getBinContent(x, y))); }
@@ -126,10 +131,14 @@
                this.ProvideAxisMethods(histo.fAxes[0]);
                histo.nx = histo.fIndicies[1] - histo.fIndicies[0];
                histo.dx = histo.fIndicies[0] + 1;
+               histo.stepx = histo.fIndicies[2];
                histo.getBin = function(x) { return x-1; }
-               histo.getBin0 = function(x) { return x-this.dx; }
-               histo.getBinContent = function(x) { return this.fBinContent[x-this.dx]; }
-               histo.getBinError = function(x) { return Math.sqrt(Math.abs(this.fBinContent[x-this.dx])); }
+               if (histo.stepx > 1)
+                  histo.getBin0 = function(x) { return Math.floor((x-this.dx)/this.stepx); }
+               else
+                  histo.getBin0 = function(x) { return x-this.dx; }
+               histo.getBinContent = function(x) { return this.fBinContent[this.getBin0(x)]; }
+               histo.getBinError = function(x) { return Math.sqrt(Math.abs(this.getBinContent(x))); }
             }
          }
       }
@@ -639,20 +648,30 @@
              i2: this.GetSelectIndex("x", "right", 1 + args.extra),
              j1: (hdim===1) ? 0 : this.GetSelectIndex("y", "left", 0 - args.extra),
              j2: (hdim===1) ? 1 : this.GetSelectIndex("y", "right", 1 + args.extra),
+             stepi: 1, stepj: 1,
              min: 0, max: 0, sumz: 0, xbar1: 0, xbar2: 1, ybar1: 0, ybar2: 1
           };
 
       if (this.IsDisplayItem() && histo.fIndicies) {
-         if (res.i1 < histo.fIndicies[0]) res.i1 = histo.fIndicies[0];
-         if (res.i2 > histo.fIndicies[1]) res.i2 = histo.fIndicies[1];
+         if (res.i1 < histo.fIndicies[0]) { res.i1 = histo.fIndicies[0]; res.incomplete = true; }
+         if (res.i2 > histo.fIndicies[1]) { res.i2 = histo.fIndicies[1]; res.incomplete = true; }
+         res.stepi = histo.fIndicies[2];
+         if (res.stepi > 1) res.incomplete = true;
          if ((hdim > 1) && (histo.fIndicies.length > 4)) {
-            if (res.j1 < histo.fIndicies[3]) res.j1 = histo.fIndicies[3];
-            if (res.j2 > histo.fIndicies[4]) res.j2 = histo.fIndicies[4];
+            if (res.j1 < histo.fIndicies[3]) { res.j1 = histo.fIndicies[3]; res.incomplete = true; }
+            if (res.j2 > histo.fIndicies[4]) { res.j2 = histo.fIndicies[4]; res.incomplete = true; }
+            res.stepj = histo.fIndicies[5];
+            if (res.stepj > 1) res.incomplete = true;
          }
       }
 
-      res.grx = new Array(res.i2+1); // no need for Float32Array, plain Array is 10% faster
-      res.gry = new Array(res.j2+1);
+      if (args.only_indexes) return res;
+
+      // no need for Float32Array, plain Array is 10% faster
+      // reserve more places to avoid complex boundary checks
+
+      res.grx = new Array(res.i2+res.stepi+1);
+      res.gry = new Array(res.j2+res.stepj+1);
 
       if (args.original) {
          res.original = true;
@@ -681,6 +700,10 @@
          if ((res.i1 < res.i2-2) && (res.grx[res.i2-1] == res.grx[res.i2])) res.i2--;
       }
 
+      // copy last valid value to higher indicies
+      while (i < res.i2 + res.stepi + 1)
+         res.grx[i++] = res.grx[res.i2];
+
       if (hdim===1) {
          res.gry[0] = pmain.gry(0);
          res.gry[1] = pmain.gry(1);
@@ -703,18 +726,21 @@
          if ((res.j1 < res.j2-2) && (res.gry[res.j2-1] == res.gry[res.j2])) res.j2--;
       }
 
-      //  find min/max values in selected range
+      // copy last valid value to higher indicies
+      while ((hdim > 1) && (j < res.j2 + res.stepj + 1))
+         res.gry[j++] = res.gry[res.j2];
 
+      //  find min/max values in selected range
       binz = histo.getBinContent(res.i1 + 1, res.j1 + 1);
       this.maxbin = this.minbin = this.minposbin = null;
 
-      for (i = res.i1; i < res.i2; ++i) {
-         for (j = res.j1; j < res.j2; ++j) {
+      for (i = res.i1; i < res.i2; i += res.stepi) {
+         for (j = res.j1; j < res.j2; j += res.stepj) {
             binz = histo.getBinContent(i + 1, j + 1);
             if (isNaN(binz)) continue;
             res.sumz += binz;
             if (args.pixel_density) {
-               binarea = (res.grx[i+1]-res.grx[i])*(res.gry[j]-res.gry[j+1]);
+               binarea = (res.grx[i+res.stepi]-res.grx[i])*(res.gry[j]-res.gry[j+res.stepj]);
                if (binarea <= 0) continue;
                res.max = Math.max(res.max, binz);
                if ((binz>0) && ((binz<res.min) || (res.min===0))) res.min = binz;
@@ -2107,11 +2133,11 @@
       var histo = this.GetHisto(),
           handle = this.PrepareColorDraw(),
           colPaths = [], currx = [], curry = [],
-          colindx, cmd1, cmd2, i, j, binz;
+          colindx, cmd1, cmd2, i, j, binz, di = handle.stepi, dj = handle.stepj;
 
       // now start build
-      for (i = handle.i1; i < handle.i2; ++i) {
-         for (j = handle.j1; j < handle.j2; ++j) {
+      for (i = handle.i1; i < handle.i2; i += di) {
+         for (j = handle.j1; j < handle.j2; j += dj) {
             binz = histo.getBinContent(i + 1, j + 1);
             colindx = handle.palette.getContourIndex(binz);
             if (binz===0) {
@@ -2120,20 +2146,20 @@
             }
             if (colindx === null) continue;
 
-            cmd1 = "M"+handle.grx[i]+","+handle.gry[j+1];
+            cmd1 = "M"+handle.grx[i]+","+handle.gry[j+dj];
             if (colPaths[colindx] === undefined) {
                colPaths[colindx] = cmd1;
             } else{
-               cmd2 = "m" + (handle.grx[i]-currx[colindx]) + "," + (handle.gry[j+1]-curry[colindx]);
+               cmd2 = "m" + (handle.grx[i]-currx[colindx]) + "," + (handle.gry[j+dj]-curry[colindx]);
                colPaths[colindx] += (cmd2.length < cmd1.length) ? cmd2 : cmd1;
             }
 
             currx[colindx] = handle.grx[i];
-            curry[colindx] = handle.gry[j+1];
+            curry[colindx] = handle.gry[j+dj];
 
-            colPaths[colindx] += "v" + (handle.gry[j] - handle.gry[j+1]) +
-                                 "h" + (handle.grx[i+1] - handle.grx[i]) +
-                                 "v" + (handle.gry[j+1] - handle.gry[j]) + "z";
+            colPaths[colindx] += "v" + (handle.gry[j] - handle.gry[j+dj]) +
+                                 "h" + (handle.grx[i+di] - handle.grx[i]) +
+                                 "v" + (handle.gry[j+dj] - handle.gry[j]) + "z";
          }
       }
 
@@ -3437,8 +3463,31 @@
       return (obj.FindBin(max,0.5) - obj.FindBin(min,0) > 1);
    }
 
-   RH2Painter.prototype.UpdateDisplayItem = function(reply) {
-      console.log('GET REPLY!!!');
+   RH2Painter.prototype.UpdateDisplayItem = function(src) {
+      var obj = this.GetObject();
+      if (!obj || !src) return false;
+
+      obj.fAxes = src.fAxes;
+      obj.fIndicies = src.fIndicies;
+      obj.fBinContent = src.fBinContent;
+      obj.fContMin = src.fContMin;
+      obj.fContMinPos = src.fContMinPos;
+      obj.fContMax = src.fContMax;
+
+      this.GetHisto(true);
+
+      return true;
+   }
+
+   RH2Painter.prototype.ProcessItemReply = function(reply) {
+      if (!this.IsDisplayItem()) {
+         console.error('Get item when display normal histogram');
+         return;
+      }
+
+      this.UpdateDisplayItem(reply.item);
+
+      this.DrawBins();
    }
 
    RH2Painter.prototype.Draw2D = function(call_back, reason) {
@@ -3451,11 +3500,13 @@
 
 
       if (this.IsDisplayItem() && (reason == "zoom") && (this.v7CommMode() == JSROOT.v7.CommMode.kNormal)) {
-         var req = {
-            _typename: "ROOT::Experimental::RHist2Drawable::RRequest"
-         };
 
-         this.v7SubmitRequest("hist", req, this.UpdateDisplayItem.bind(this));
+         var handle = this.PrepareColorDraw({ only_indexes: true }),
+             req = { _typename: "ROOT::Experimental::RHist2Drawable::RRequest" };
+
+         // submit request if histogram data not enough for display
+         if (handle.incomplete)
+            this.v7SubmitRequest("hist", req, this.ProcessItemReply.bind(this));
       }
 
       if (this.DrawAxes())

--- a/js/scripts/JSRootPainter.v7hist3d.js
+++ b/js/scripts/JSRootPainter.v7hist3d.js
@@ -506,7 +506,7 @@
       if (main.logx) {
          if (xmax <= 0) xmax = 1.;
          if ((xmin <= 0) && this.xaxis)
-            for (var i=0;i<this.xaxis.fNbins;++i) {
+            for (var i=0;i<this.xaxis.GetNumBins();++i) {
                xmin = Math.max(xmin, this.xaxis.GetBinLowEdge(i+1));
                if (xmin>0) break;
             }
@@ -530,7 +530,7 @@
       if (main.logy && !opts.use_y_for_z) {
          if (ymax <= 0) ymax = 1.;
          if ((ymin <= 0) && this.yaxis)
-            for (var i=0;i<this.yaxis.fNbins;++i) {
+            for (var i=0;i<this.yaxis.GetNumBins();++i) {
                ymin = Math.max(ymin, this.yaxis.GetBinLowEdge(i+1));
                if (ymin>0) break;
             }
@@ -1470,39 +1470,35 @@
           histo = this.GetHisto();
 
       if (reason == "resize")  {
-
          if (is_main && main.Resize3D()) main.Render3D();
-
-      } else {
-
-         this.DeleteAtt();
-
-         this.ScanContent(true); // may be required for axis drawings
-
-         if (is_main) {
-            main.Create3DScene();
-            main.SetAxesRanges(this.xmin, this.xmax, this.ymin, this.ymax, 0, 0);
-            main.Set3DOptions(this.options);
-            main.DrawXYZ(main.toplevel, { use_y_for_z: true, zmult: 1.1, zoom: JSROOT.gStyle.Zooming, ndim: 1 });
-         }
-
-         if (main.mode3d) {
-            this.DrawLego();
-            this.UpdatePaletteDraw();
-            main.Render3D();
-            this.UpdateStatWebCanvas();
-            main.AddKeysHandler();
-         }
+         return JSROOT.CallBack(call_back);
       }
+
+      this.DeleteAtt();
+
+      this.ScanContent(true); // may be required for axis drawings
 
       if (is_main) {
-         // (re)draw palette by resize while canvas may change dimension
-         // this.DrawColorPalette(this.options.Zscale && ((this.options.Lego===12) || (this.options.Lego===14)));
-
-         // this.DrawTitle();
+         main.Create3DScene();
+         main.SetAxesRanges(this.xmin, this.xmax, this.ymin, this.ymax, 0, 0);
+         main.Set3DOptions(this.options);
+         main.DrawXYZ(main.toplevel, { use_y_for_z: true, zmult: 1.1, zoom: JSROOT.gStyle.Zooming, ndim: 1 });
       }
 
-      JSROOT.CallBack(call_back);
+      if (!main.mode3d)
+         return JSROOT.CallBack(call_back);
+
+      this.DrawingBins(call_back, reason, function() {
+         // called when bins received from server, must be reentrant
+         var main = this.frame_painter();
+
+         this.DrawLego();
+         this.UpdatePaletteDraw();
+         main.Render3D();
+         this.UpdateStatWebCanvas();
+         main.AddKeysHandler();
+      });
+
    }
 
    // ==========================================================================================
@@ -1635,8 +1631,19 @@
           handle = this.PrepareColorDraw({rounding: false, use3d: true, extra: 1, middle: 0.5 }),
           i, j, x1, y1, x2, y2, z11, z12, z21, z22,
           di = handle.stepi, dj = handle.stepj,
+          numstepi = handle.i2 - handle.i1, numstepj = handle.j2 - handle.j1,
           axis_zmin = main.grz.domain()[0],
           axis_zmax = main.grz.domain()[1];
+
+      if (di > 1) {
+         numstepi = Math.round(numstepi/di);
+         if (numstepi * di < (handle.i2 - handle.i1)) numstepi++;
+      }
+
+      if (dj > 1) {
+         numstepj = Math.round(numstepj/dj);
+         if (numstepj * dj < (handle.j2 - handle.j1)) numstepj++;
+      }
 
       // first adjust ranges
 
@@ -1739,7 +1746,7 @@
       }
 
       function RememberVertex(indx, ii,jj) {
-         var bin = ((ii-handle.i1)/di * (handle.j2-handle.j1)/dj + (jj-handle.j1)/dj)*8;
+         var bin = ((ii-handle.i1)/di * numstepj + (jj-handle.j1)/dj)*8;
 
          if (normindx[bin]>=0)
             return console.error('More than 8 vertexes for the bin');
@@ -1752,7 +1759,7 @@
       function RecalculateNormals(arr) {
          for (var ii=handle.i1; ii<handle.i2; ii += di) {
             for (var jj=handle.j1; jj<handle.j2; jj += dj) {
-               var bin = ((ii-handle.i1)/di * (handle.j2-handle.j1)/dj + (jj-handle.j1)/dj) * 8;
+               var bin = ((ii-handle.i1)/di * numstepj + (jj-handle.j1)/dj) * 8;
 
                if (normindx[bin] === -1) continue; // nothing there
 
@@ -1872,7 +1879,7 @@
 
       if (donormals) {
          // for each bin maximal 8 points reserved
-         normindx = new Int32Array((handle.i2-handle.i1)/di*(handle.j2-handle.j1)/dj*8);
+         normindx = new Int32Array(numstepi * numstepj * 8);
          for (var n=0;n<normindx.length;++n) normindx[n] = -1;
       }
 

--- a/js/scripts/JSRootPainter.v7hist3d.js
+++ b/js/scripts/JSRootPainter.v7hist3d.js
@@ -1074,7 +1074,7 @@
           main = this.frame_painter(),
           axis_zmin = main.grz.domain()[0],
           axis_zmax = main.grz.domain()[1],
-          handle = this.PrepareColorDraw({ rounding: false, use3d: true, extra: 1 }),
+          handle = this.PrepareDraw({ rounding: false, use3d: true, extra: 1 }),
           i1 = handle.i1, i2 = handle.i2, j1 = handle.j1, j2 = handle.j2, di = handle.stepi, dj = handle.stepj,
           i, j, x1, x2, y1, y2, binz1, binz2, reduced, nobottom, notop,
           pthis = this,
@@ -1595,7 +1595,7 @@
    JSROOT.v7.RH2Painter.prototype.DrawContour3D = function(realz) {
       // for contour plots one requires handle with full range
       var main = this.frame_painter(),
-          handle = this.PrepareColorDraw({rounding: false, use3d: true, extra: 100, middle: 0.0 }),
+          handle = this.PrepareDraw({rounding: false, use3d: true, extra: 100, middle: 0.0 }),
           histo = this.GetHisto(), // get levels
           palette = main.GetPalette(),
           layerz = 2*main.size_z3d, pnts = [];
@@ -1628,7 +1628,7 @@
    JSROOT.v7.RH2Painter.prototype.DrawSurf = function() {
       var histo = this.GetHisto(),
           main = this.frame_painter(),
-          handle = this.PrepareColorDraw({rounding: false, use3d: true, extra: 1, middle: 0.5 }),
+          handle = this.PrepareDraw({rounding: false, use3d: true, extra: 1, middle: 0.5 }),
           i, j, x1, y1, x2, y2, z11, z12, z21, z22,
           di = handle.stepi, dj = handle.stepj,
           numstepi = handle.i2 - handle.i1, numstepj = handle.j2 - handle.j1,
@@ -1981,7 +1981,7 @@
 
       if (this.options.Surf === 13) {
 
-         handle = this.PrepareColorDraw({rounding: false, use3d: true, extra: 100, middle: 0.0 });
+         handle = this.PrepareDraw({rounding: false, use3d: true, extra: 100, middle: 0.0 });
 
          // get levels
          var levels = this.GetContour(), // init contour
@@ -2052,7 +2052,7 @@
       var pthis = this,
           main = this.frame_painter(),
           histo = this.GetHisto(),
-          handle = this.PrepareColorDraw({ rounding: false, use3d: true, extra: 1 }),
+          handle = this.PrepareDraw({ rounding: false, use3d: true, extra: 1 }),
           zmin = main.grz.domain()[0],
           zmax = main.grz.domain()[1],
           i, j, binz, binerr, x1, y1, x2, y2, z1, z2,
@@ -2649,7 +2649,7 @@
 
       if (!this.draw_content) return;
 
-      var handle = this.PrepareColorDraw({ only_indexes: true, extra: -0.5, right_extra: -1 });
+      var handle = this.PrepareDraw({ only_indexes: true, extra: -0.5, right_extra: -1 });
 
       if (this.options.Scatter)
          if (this.Draw3DScatter(handle)) return;

--- a/js/scripts/JSRootPainter.v7hist3d.js
+++ b/js/scripts/JSRootPainter.v7hist3d.js
@@ -1278,7 +1278,7 @@
                 histo = p.GetHisto(),
                 tip = p.Get3DToolTip( this.face_to_bins_index[intersect.faceIndex] );
 
-            tip.x1 = Math.max(-main.size_xy3d,  handle.grx[tip.ix-1] + handle.xbar1*(handle.grx[tip.ix]-handle.grx[tip.ix-1]));
+            tip.x1 = Math.max(-main.size_xy3d, handle.grx[tip.ix-1] + handle.xbar1*(handle.grx[tip.ix]-handle.grx[tip.ix-1]));
             tip.x2 = Math.min(main.size_xy3d, handle.grx[tip.ix-1] + handle.xbar2*(handle.grx[tip.ix]-handle.grx[tip.ix-1]));
 
             tip.y1 = Math.max(-main.size_xy3d, handle.gry[tip.iy-1] + handle.ybar1*(handle.gry[tip.iy] - handle.gry[tip.iy-1]));

--- a/js/scripts/JSRootPainter.v7hist3d.js
+++ b/js/scripts/JSRootPainter.v7hist3d.js
@@ -2050,7 +2050,7 @@
           handle = this.PrepareColorDraw({ rounding: false, use3d: true, extra: 1 }),
           zmin = main.grz.domain()[0],
           zmax = main.grz.domain()[1],
-          i, j, bin, binz, binerr, x1, y1, x2, y2, z1, z2,
+          i, j, binz, binerr, x1, y1, x2, y2, z1, z2,
           nsegments = 0, lpos = null, binindx = null, lindx = 0;
 
        function check_skip_min() {
@@ -2073,9 +2073,8 @@
                 // just count number of segments
                 if (loop===0) { nsegments+=3; continue; }
 
-                bin = histo.getBin(i+1,j+1);
-                binerr = histo.getBinError(bin);
-                binindx[lindx/18] = bin;
+                binerr = histo.getBinError(i+1,j+1);
+                binindx[lindx/18] = histo.getBin(i+1,j+1);
 
                 y1 = handle.gry[j];
                 y2 = handle.gry[j+1];

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -67,9 +67,9 @@ void draw_rh1()
    subpads[0][1]->Draw(pHist2)->Marker().AttrMarker().SetColor(col2).SetStyle(30).SetSize(1.5);
 
    // text and marker draw options
-   subpads[1][1]->Draw<RFrameTitle>("Bar() and Bar3D() draw options");
+   subpads[1][1]->Draw<RFrameTitle>("Bar() draw options");
    subpads[1][1]->Draw(pHist1)->Bar(0,0.5).AttrFill().SetColor(col1);
-   subpads[1][1]->Draw(pHist2)->Bar3D(0.5,0.5).AttrFill().SetColor(col2);
+   subpads[1][1]->Draw(pHist2)->Bar(0.5,0.5,true).AttrFill().SetColor(col2);
 
    // line draw option
    subpads[0][2]->Draw<RFrameTitle>("Line() draw option");

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -24,6 +24,7 @@
 #include "ROOT/RHistStatBox.hxx"
 #include "ROOT/RFrame.hxx"
 #include "TMath.h"
+#include "TString.h"
 
 
 // macro must be here while cling is not capable to load
@@ -34,7 +35,7 @@ using namespace ROOT::Experimental;
 
 void draw_rh1_large()
 {
-   const int nbins = 500000;
+   const int nbins = 5000000;
 
    // Create the histogram.
    RAxisConfig xaxis("x", nbins, 0., nbins);
@@ -51,7 +52,7 @@ void draw_rh1_large()
    frame->SetGridX(true).SetGridY(true);
    frame->AttrX().SetZoomMinMax(nbins*0.2, nbins*0.8);
 
-   canvas->Draw<RFrameTitle>(Form("Large RH1D histogram with %d bins",nbins));
+   canvas->Draw<RFrameTitle>(TString::Format("Large RH1D histogram with %d bins",nbins).Data());
 
    auto draw = canvas->Draw(pHist);
 

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -1,0 +1,72 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// This macro generates really large RH1D histogram, fills it with predefined pattern and
+/// draw it in a RCanvas, using Optmize() drawing mode
+///
+/// \macro_code
+///
+/// \date 2020-07-02
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \author Sergey Linev <s.linev@gsi.de>
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RHistDrawable.hxx"
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RFrameTitle.hxx"
+#include "ROOT/RHistStatBox.hxx"
+#include "ROOT/RFrame.hxx"
+#include "TMath.h"
+
+
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
+R__LOAD_LIBRARY(libROOTHistDraw)
+
+using namespace ROOT::Experimental;
+
+void draw_rh1_large()
+{
+   const int nbins = 500000;
+
+   // Create the histogram.
+   RAxisConfig xaxis("x", nbins, 0., nbins);
+   auto pHist = std::make_shared<RH1D>(xaxis);
+
+   for(int i=0;i<nbins;++i)
+      pHist->Fill(1.*i, 1000.*TMath::Sin(100.*i/nbins));
+
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create("Canvas Title");
+
+   auto frame = canvas->GetOrCreateFrame();
+
+   frame->SetGridX(true).SetGridY(true);
+   frame->AttrX().SetZoomMinMax(nbins*0.2, nbins*0.8);
+
+   canvas->Draw<RFrameTitle>(Form("Large RH1D histogram with %d bins",nbins));
+
+   auto draw = canvas->Draw(pHist);
+
+   draw->AttrLine().SetColor(RColor::kLime);
+   draw->AttrFill().SetColor(RColor::kLime);
+   // draw->Line(); // configure line draw option
+   // draw->Bar(); // configure bar draw option
+   // draw->Error(1); // configure error drawing
+   draw->Hist();  // configure hist draw option, default
+
+   draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients
+
+   auto stat = canvas->Draw<RHist1StatBox>(pHist, "hist");
+   stat->AttrFill().SetColor(RColor::kBlue);
+
+   canvas->SetSize(1000, 700);
+   canvas->Show();
+}

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -41,7 +41,7 @@ void draw_rh1_large()
    auto pHist = std::make_shared<RH1D>(xaxis);
 
    for(int i=0;i<nbins;++i)
-      pHist->Fill(1.*i, 1000.*TMath::Sin(100.*i/nbins));
+      pHist->Fill(1.*i, 1000.*(2+TMath::Sin(100.*i/nbins)));
 
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
@@ -56,10 +56,10 @@ void draw_rh1_large()
    auto draw = canvas->Draw(pHist);
 
    draw->AttrLine().SetColor(RColor::kLime);
-   draw->AttrFill().SetColor(RColor::kLime);
+   // draw->AttrFill().SetColor(RColor::kLime);
    // draw->Line(); // configure line draw option
    // draw->Bar(); // configure bar draw option
-   // draw->Error(1); // configure error drawing
+   // draw->Error(3); // configure error drawing
    draw->Hist();  // configure hist draw option, default
 
    draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -32,7 +32,7 @@ using namespace ROOT::Experimental;
 
 void draw_rh2_large()
 {
-   const int nbins = 1000;
+   const int nbins = 100;
 
    // Create the histogram.
    RAxisConfig xaxis("x", nbins, 0., nbins);
@@ -52,8 +52,8 @@ void draw_rh2_large()
    // frame->Margins().SetRight(0.2_normal);
 
    frame->SetGridX(false).SetGridY(false);
-   // frame->AttrX().SetZoomMinMax(2.,8.);
-   // frame->AttrY().SetZoomMinMax(2.,8.);
+   frame->AttrX().SetZoomMinMax(nbins*0.2, nbins*0.8);
+   frame->AttrY().SetZoomMinMax(nbins*0.2, nbins*0.8);
 
    canvas->Draw<RFrameTitle>(Form("Large RH2D histogram with %d x %d bins",nbins,nbins));
 

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -1,0 +1,78 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// This macro generates really large RH2D histogram, fills it with predefined pattern and
+/// draw it in a RCanvas, using Optmize() drawing mode
+///
+/// \macro_code
+///
+/// \date 2020-06-26
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \author Sergey Linev <s.linev@gsi.de>
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RHistDrawable.hxx"
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RFrameTitle.hxx"
+#include "ROOT/RHistStatBox.hxx"
+#include "ROOT/RFrame.hxx"
+
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
+R__LOAD_LIBRARY(libROOTHistDraw)
+
+using namespace ROOT::Experimental;
+
+void draw_rh2_large()
+{
+   const int nbins = 1000;
+
+   // Create the histogram.
+   RAxisConfig xaxis("x", nbins, 0., nbins);
+   RAxisConfig yaxis("y", nbins, 0., nbins);
+   auto pHist = std::make_shared<RH2D>(xaxis, yaxis);
+
+   for(int i=0;i<nbins;++i)
+      for(int j=0;j<nbins;++j)
+         pHist->Fill({1.*i,1.*j}, i+j);
+
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create("Canvas Title");
+
+   auto frame = canvas->GetOrCreateFrame();
+
+   // should we made special style for frame with palette?
+   // frame->Margins().SetRight(0.2_normal);
+
+   frame->SetGridX(false).SetGridY(false);
+   // frame->AttrX().SetZoomMinMax(2.,8.);
+   // frame->AttrY().SetZoomMinMax(2.,8.);
+
+   canvas->Draw<RFrameTitle>(Form("Large RH2D histogram with %d x %d bins",nbins,nbins));
+
+   auto draw = canvas->Draw(pHist);
+
+   // draw->AttrLine().SetColor(RColor::kLime);
+   // draw->Surf(2); // configure surf4 draw option
+   // draw->Lego(2); // configure lego2 draw option
+   // draw->Contour(); // configure cont draw option
+   // draw->Scatter(); // configure color draw option (default)
+   // draw->Arrow(); // configure arrow draw option
+   // draw->Color(); // configure color draw option (default)
+   // draw->Text(true); // configure text drawing (can be enabled with most 2d options)
+
+   draw->Optimize(); // enable draw optimization, reduced data set will be send to clients
+
+   auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist2");
+   stat->AttrFill().SetColor(RColor::kRed);
+
+   canvas->SetSize(1000, 700);
+   canvas->Show();
+}

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -32,7 +32,7 @@ using namespace ROOT::Experimental;
 
 void draw_rh2_large()
 {
-   const int nbins = 1000;
+   const int nbins = 50;
 
    // Create the histogram.
    RAxisConfig xaxis("x", nbins, 0., nbins);
@@ -59,19 +59,21 @@ void draw_rh2_large()
 
    auto draw = canvas->Draw(pHist);
 
-   // draw->AttrLine().SetColor(RColor::kLime);
-   // draw->Surf(2); // configure surf4 draw option
-   // draw->Lego(2); // configure lego2 draw option
+   draw->AttrLine().SetColor(RColor::kLime);
    // draw->Contour(); // configure cont draw option
    // draw->Scatter(); // configure color draw option (default)
    // draw->Arrow(); // configure arrow draw option
-   // draw->Color(); // configure color draw option (default)
+   draw->Color(); // configure color draw option (default)
    // draw->Text(true); // configure text drawing (can be enabled with most 2d options)
+   // draw->Box(1); // configure box1 draw option
+   // draw->Surf(2); // configure surf4 draw option, 3d
+   // draw->Lego(2); // configure lego2 draw option, 3d
+   // draw->Error(); // configure error drawing, 3d
 
-   draw->Optimize(); // enable draw optimization, reduced data set will be send to clients
+   draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients
 
-   auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist2");
-   stat->AttrFill().SetColor(RColor::kRed);
+   auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
+   stat->AttrFill().SetColor(RColor::kBlue);
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -32,7 +32,7 @@ using namespace ROOT::Experimental;
 
 void draw_rh2_large()
 {
-   const int nbins = 100;
+   const int nbins = 1000;
 
    // Create the histogram.
    RAxisConfig xaxis("x", nbins, 0., nbins);

--- a/tutorials/v7/draw_rh3_large.cxx
+++ b/tutorials/v7/draw_rh3_large.cxx
@@ -31,18 +31,20 @@ R__LOAD_LIBRARY(libROOTHistDraw)
 
 using namespace ROOT::Experimental;
 
-void draw_rh2_large()
+void draw_rh3_large()
 {
-   const int nbins = 2000;
+   const int nbins = 200;
 
    // Create the histogram.
    RAxisConfig xaxis("x", nbins, 0., nbins);
    RAxisConfig yaxis("y", nbins, 0., nbins);
-   auto pHist = std::make_shared<RH2D>(xaxis, yaxis);
+   RAxisConfig zaxis("z", nbins, 0., nbins);
+   auto pHist = std::make_shared<RH3D>(xaxis, yaxis, zaxis);
 
    for(int i=0;i<nbins;++i)
       for(int j=0;j<nbins;++j)
-         pHist->Fill({1.*i,1.*j}, i+j);
+         for(int k=0;k<nbins;++k)
+            pHist->Fill({1.*i,1.*j,1.*k}, i+j+k);
 
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
@@ -52,29 +54,24 @@ void draw_rh2_large()
    // should we made special style for frame with palette?
    // frame->Margins().SetRight(0.2_normal);
 
-   frame->SetGridX(false).SetGridY(false);
-   frame->AttrX().SetZoomMinMax(nbins*0.2, nbins*0.8);
-   frame->AttrY().SetZoomMinMax(nbins*0.2, nbins*0.8);
+   frame->AttrX().SetZoomMinMax(nbins*0.1, nbins*0.9);
+   frame->AttrY().SetZoomMinMax(nbins*0.1, nbins*0.9);
+   frame->AttrZ().SetZoomMinMax(nbins*0.1, nbins*0.9);
 
-   canvas->Draw<RFrameTitle>(TString::Format("Large RH2D histogram with %d x %d bins",nbins,nbins).Data());
+   canvas->Draw<RFrameTitle>(TString::Format("Large RH3D histogram with %d x %d x %d bins",nbins,nbins,nbins).Data());
 
    auto draw = canvas->Draw(pHist);
 
    draw->AttrLine().SetColor(RColor::kLime);
-   // draw->Contour(); // configure cont draw option
-   // draw->Scatter(); // configure scatter draw option
-   // draw->Arrow(); // configure arrow draw option
-   draw->Color(); // configure color draw option (default)
-   // draw->Text(true); // configure text drawing (can be enabled with most 2d options)
-   // draw->Box(1); // configure box1 draw option
-   // draw->Surf(2); // configure surf4 draw option, 3d
-   // draw->Lego(2); // configure lego2 draw option, 3d
-   // draw->Error(); // configure error drawing, 3d
+   // draw->Box(); // configure box draw option (default)
+   // draw->Sphere(); // configure sphere draw option
+   draw->Scatter(); // configure scatter draw option
+   // draw->Color(); // configure color draw option
 
    draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients
 
-   auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
-   stat->AttrFill().SetColor(RColor::kBlue);
+   //auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
+   //stat->AttrFill().SetColor(RColor::kBlue);
 
    canvas->SetSize(1000, 700);
    canvas->Show();


### PR DESCRIPTION
When histogram object too large (more than 10^6 bins), its JSON representation can be huge.
At the same time graphics cannot display so much individual bins.
Therefore introduce `Optimize()` mode, when histogram can be rebinned before sending to the client
Allows to efficiently display histogram with arbitrary number of bins - the only limitation is memory and
efficiency of rebin algorithm (which is straight forward).

For all drawing options of `RH1`, `RH2`, `RH3` optimized drawing mode is supported now.
For the moment default value is off - mean one should explicitly enable it when drawing histogram.

Provide tutorial macros: `draw_rh1_large.cxx`, `draw_rh2_large.cxx`, `draw_rh3_large.cxx`
Ensure that they runs in compiled mode.