### PR TITLE
[DF] Print info message if RDisplay::Print is omitting some columns

### DIFF
--- a/tree/dataframe/src/RDFDisplay.cxx
+++ b/tree/dataframe/src/RDFDisplay.cxx
@@ -198,6 +198,10 @@ void RDisplay::Print() const
    std::vector<bool> hasPrintedNext(fNColumns,
                                     false); // Keeps track if the collection as already been shortened, allowing to skip
                                             // all elements until the next printable element.
+
+   if (columnsToPrint < fNColumns)
+      Info("Print", "Only showing %lu columns out of %lu\n", columnsToPrint, fNColumns);
+
    auto nrRows = fTable.size();
    for (size_t rowIndex = 0; rowIndex < nrRows; ++rowIndex) {
       auto &row = fTable[rowIndex];


### PR DESCRIPTION
Addresses some of the feedback in https://sft.its.cern.ch/jira/browse/ROOT-10889 .