### PR TITLE
[v7, exceptions] Enable RResult to work with move-only types

### DIFF
--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -206,7 +206,9 @@ public:
       return result;
    }
 
-   const T &Get() {
+   /// If the operation was successful, returns the inner value and consumes the RResult.
+   /// If there was an error, Get() instead throws an exception.
+   T Get() {
       if (R__unlikely(fError)) {
          // Get() can be wrapped in a try-catch block, so throwing the exception here is akin to checking the error.
          // Setting fIsChecked to true also avoids a spurious warning in the RResult destructor
@@ -215,7 +217,7 @@ public:
          fError->AppendToMessage(" (unchecked RResult access!)");
          throw RException(*fError);
       }
-      return fValue;
+      return std::move(fValue);
    }
 
    explicit operator bool() { return Check(); }

--- a/core/base/v7/test/base_exception.cxx
+++ b/core/base/v7/test/base_exception.cxx
@@ -3,9 +3,12 @@
 
 #include <ROOT/RError.hxx>
 
+#include <memory>
 #include <stdexcept>
 
 using RException = ROOT::Experimental::RException;
+template<typename T>
+using RResult = ROOT::Experimental::RResult<T>;
 
 namespace {
 
@@ -73,7 +76,7 @@ TEST(Exception, ForwardResult)
 {
    auto res = TestChain(true);
    ASSERT_TRUE(static_cast<bool>(res));
-   EXPECT_EQ(42, res.Get());
+   EXPECT_EQ(42, res.Inspect());
 }
 
 
@@ -114,13 +117,35 @@ TEST(Exception, Syscall)
       // In production code, we would expect error handling code other than throw
       EXPECT_THROW(fd.Throw(), RException);
    }
-   EXPECT_EQ(42, fd.Get());
+   EXPECT_EQ(42, fd.Inspect());
 
-   EXPECT_THROW(TestSyscall(false).Get(), RException);
+   EXPECT_THROW(TestSyscall(false).Inspect(), RException);
 }
 
 TEST(Exception, ComplexReturnType)
 {
    auto res = TestComplex();
    EXPECT_EQ(1, ComplexReturnType::gNCopies);
+}
+
+TEST(Exception, MoveOnlyReturnType)
+{
+   auto TestMoveOnly = []() -> RResult<std::unique_ptr<int>> {
+      return std::make_unique<int>(1);
+   };
+   auto res = TestMoveOnly();
+
+   // Using Inspect to make a copy won't compile
+   // auto copy_inner = res.Inspect();
+
+   // This will compile, but we only have read-only access
+   const auto& copy_inner = res.Inspect();
+   EXPECT_EQ(1, *copy_inner);
+
+   // Instead, Unwrap is required to get ownership of the move-only type
+   auto move_inner = res.Unwrap();
+   EXPECT_EQ(1, *move_inner);
+   move_inner.reset();
+   move_inner = std::make_unique<int>(2);
+   EXPECT_EQ(2, *move_inner);
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -243,11 +243,7 @@ ROOT::Experimental::Detail::RPageSourceFile::~RPageSourceFile()
 ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFile::AttachImpl()
 {
    RNTupleDescriptorBuilder descBuilder;
-   auto ntplRes = fReader.GetNTuple(fNTupleName);
-   if (!ntplRes) {
-      ntplRes.Throw();
-   }
-   const auto ntpl = ntplRes.Get();
+   auto ntpl = fReader.GetNTuple(fNTupleName).Unwrap();
 
    auto buffer = std::unique_ptr<unsigned char[]>(new unsigned char[ntpl.fLenHeader]);
    auto zipBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[ntpl.fNBytesHeader]);

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -16,7 +16,7 @@ TEST(MiniFile, Raw)
 
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
-   auto ntuple = reader.GetNTuple("MyNTuple").Get();
+   auto ntuple = reader.GetNTuple("MyNTuple").Inspect();
    EXPECT_EQ(offHeader, ntuple.fSeekHeader);
    EXPECT_EQ(offFooter, ntuple.fSeekFooter);
 
@@ -46,7 +46,7 @@ TEST(MiniFile, Stream)
 
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
-   auto ntuple = reader.GetNTuple("MyNTuple").Get();
+   auto ntuple = reader.GetNTuple("MyNTuple").Inspect();
    EXPECT_EQ(offHeader, ntuple.fSeekHeader);
    EXPECT_EQ(offFooter, ntuple.fSeekFooter);
 
@@ -82,7 +82,7 @@ TEST(MiniFile, Proper)
 
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
-   auto ntuple = reader.GetNTuple("MyNTuple").Get();
+   auto ntuple = reader.GetNTuple("MyNTuple").Inspect();
    EXPECT_EQ(offHeader, ntuple.fSeekHeader);
    EXPECT_EQ(offFooter, ntuple.fSeekFooter);
 
@@ -122,10 +122,10 @@ TEST(MiniFile, Multi)
 
    auto rawFile = RRawFile::Create(fileGuard.GetPath());
    RMiniFileReader reader(rawFile.get());
-   auto ntuple1 = reader.GetNTuple("FirstNTuple").Get();
+   auto ntuple1 = reader.GetNTuple("FirstNTuple").Inspect();
    EXPECT_EQ(offHeader1, ntuple1.fSeekHeader);
    EXPECT_EQ(offFooter1, ntuple1.fSeekFooter);
-   auto ntuple2 = reader.GetNTuple("SecondNTuple").Get();
+   auto ntuple2 = reader.GetNTuple("SecondNTuple").Inspect();
    EXPECT_EQ(offHeader2, ntuple2.fSeekHeader);
    EXPECT_EQ(offFooter2, ntuple2.fSeekFooter);
 
@@ -166,7 +166,7 @@ TEST(MiniFile, Failures)
    RMiniFileReader reader(rawFile.get());
    RNTuple ntuple;
    try {
-      ntuple = reader.GetNTuple("No such RNTuple").Get();
+      ntuple = reader.GetNTuple("No such RNTuple").Inspect();
       FAIL() << "bad RNTuple names should throw";
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("no RNTuple named 'No such RNTuple' in file '" + fileGuard.GetPath()));


### PR DESCRIPTION
Spun off from [discussion](https://github.com/root-project/root/pull/5934/commits/6f3ec9372b011536fc314eef0835508a07d2513b#r448782416) on #5934, this PR lets us wrap move-only types in `RResult`.

We add a new method `Unwrap()` to obtain the inner type by value. The caller takes ownership of the inner type, and for move-only types the `RResult` is left in an unspecified state. I decided against adding safeguards against double-moves for now because it would result in false-positive messages for types without move specializations (e.g. `return std::move(42)`). Instead, we should make clear through documentation and examples that `Unwrap()` consumes the `RResult`. 

The existing const-ref access method `Get()` has been renamed `Inspect()` following Mozilla's `RResult`-like type [here](https://searchfox.org/mozilla-central/source/mfbt/Result.h#90-91). `Get()` has caused some confusion in code review and we've been looking for alternative names. 

Example: 
```cpp
auto TestMoveOnly = []() -> RResult<std::unique_ptr<int>> {
    return std::make_unique<int>(1);
};
auto res = TestMoveOnly();

// Using Inspect to make a copy won't compile
// auto copy_inner = res.Inspect();

// This will compile, but we only have read-only access
const auto& copy_inner = res.Inspect();
EXPECT_EQ(1, *copy_inner);

// Instead, Unwrap is required to get ownership of the move-only type
auto move_inner = res.Unwrap();
EXPECT_EQ(1, *move_inner);
move_inner.reset();
move_inner = std::make_unique<int>(2);
EXPECT_EQ(2, *move_inner);
```