### PR TITLE
[histv7] Simplify class structure:

### DIFF
--- a/hist/histv7/inc/ROOT/RAxisLayout.hxx
+++ b/hist/histv7/inc/ROOT/RAxisLayout.hxx
@@ -1,0 +1,62 @@
+/// \file ROOT/RAxisLayout.h
+/// \ingroup Hist ROOT7
+/// \author Axel Naumann <axel@cern.ch>
+/// \date 2020-07-06
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RAxisLayout
+#define ROOT7_RAxisLayout
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ROOT {
+namespace Experimental {
+namespace Internal {
+
+/**
+\class RAxisLayout
+Calculuates bin index from a set of axes and a coordinate tuple.
+*/
+template <class AxisTuple>
+class RAxisLayout {
+private:
+   ///\{
+   /// Internal types to translate tuple<AXES...> => tuple<AXES::Coord_t...>
+   template <class T>
+   struct CoordTuple;
+
+   template <class... Axes>
+   struct CoordTuple<std::tuple<Axes...>> {
+      using type = std::tuple<typename Axes::Coord_t...>;
+   };
+   ///\}
+
+public:
+   using AxisTuple_t = AxisTuple;
+   using CoordTuple_t = typename CoordTuple<AxisTuple>::type;
+
+private:
+   AxisTuple fAxes;
+
+public:
+   RAxisLayout(const AxisTuple &axes): fAxes(axes) {}
+
+   ssize_t GetBinIndex(const CoordTuple_t &x) const;
+};
+
+} // namespace Internal
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_RAxisLayout header guard

--- a/hist/histv7/inc/ROOT/RHistData.hxx
+++ b/hist/histv7/inc/ROOT/RHistData.hxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2015, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -24,56 +24,187 @@
 namespace ROOT {
 namespace Experimental {
 
-template <int DIMENSIONS, class PRECISION, template <int D_, class P_> class... STAT>
-class RHist;
+namespace Internal {
 
 /**
- \class RHistStatContent
- Basic histogram statistics, keeping track of the bin content and the total
- number of calls to Fill().
+ Empty implementation not keeping track of the Poisson uncertainty per bin.
  */
-template <int DIMENSIONS, class PRECISION>
-class RHistStatContent {
+template <int Dimensions, class WeightType, template <class EL> class Container, bool>
+class RHistStatUncertainty {
 public:
-   /// The type of a (possibly multi-dimensional) coordinate.
-   using CoordArray_t = Hist::CoordArray_t<DIMENSIONS>;
-   /// The type of the weight and the bin content.
-   using Weight_t = PRECISION;
+   RHistStatUncertainty() = default;
+   RHistStatUncertainty(size_t /*bin_size*/, size_t /*overflow_size*/) {}
+
+   WeightType GetBinArray(int binidx) const { return  0.; }
+   void Fill(int /*binidx*/, WeightType /*weight*/ = 1.) const {}
+
+   /// Merge with other `RHistStatUncertainty` data, assuming same bin configuration.
+   void Add(const RHistStatUncertainty& other) const {}
+};
+
+/**
+ \class RHistStatUncertainty
+ Histogram statistics to keep track of the Poisson uncertainty per bin.
+ */
+template <int Dimensions, class WeightType, template <class EL> class Container>
+class RHistStatUncertainty<Dimensions, WeightType, Container, true> {
+public:
    /// Type of the bin content array.
-   using Content_t = std::vector<PRECISION>;
-
-   /**
-    \class RConstBinStat
-    Const view on a RHistStatContent for a given bin.
-   */
-   class RConstBinStat {
-   public:
-      RConstBinStat(const RHistStatContent &stat, int index): fContent(stat.GetBinContent(index)) {}
-      PRECISION GetContent() const { return fContent; }
-
-   private:
-      PRECISION fContent; ///< The content of this bin.
-   };
-
-   /**
-    \class RBinStat
-    Modifying view on a RHistStatContent for a given bin.
-   */
-   class RBinStat {
-   public:
-      RBinStat(RHistStatContent &stat, int index): fContent(stat.GetBinContent(index)) {}
-      PRECISION &GetContent() const { return fContent; }
-
-   private:
-      PRECISION &fContent; ///< The content of this bin.
-   };
-
-   using ConstBinStat_t = RConstBinStat;
-   using BinStat_t = RBinStat;
+   using Content_t = Container<WeightType>;
 
 private:
+   /// Uncertainty of the content for each bin excluding under-/overflow.
+   Content_t fSumWeightsSquared; ///< Sum of squared weights.
+   /// Uncertainty of the under-/overflow content.
+   Content_t fOverflowSumWeightsSquared; ///< Sum of squared weights for under-/overflow.
+
+public:
+   RHistStatUncertainty() = default;
+   RHistStatUncertainty(size_t bin_size, size_t overflow_size): fSumWeightsSquared(bin_size), fOverflowSumWeightsSquared(overflow_size) {}
+
+   /// Get a reference to the bin corresponding to `binidx` of the correct bin
+   /// content array 
+   /// i.e. depending if `binidx` is a regular bin or an under- / overflow bin.
+   WeightType GetBinArray(int binidx) const
+   {
+      if (binidx < 0){
+         return fOverflowSumWeightsSquared[-binidx - 1];
+      } else {
+         return fSumWeightsSquared[binidx - 1];
+      }
+   }
+
+   /// Get a reference to the bin corresponding to `binidx` of the correct bin
+   /// content array (non-const)
+   /// i.e. depending if `binidx` is a regular bin or an under- / overflow bin.
+   WeightType& GetBinArray(int binidx)
+   {
+      if (binidx < 0){
+         return fOverflowSumWeightsSquared[-binidx - 1];
+      } else {
+         return fSumWeightsSquared[binidx - 1];
+      }
+   }
+
+   /// Add weight to the bin at `binidx`; the coordinate was `x`.
+   void Fill(int binidx, WeightType weight = 1.)
+   {
+      GetBinArray(binidx) += weight * weight;
+   }
+
+   /// Calculate a bin's (Poisson) uncertainty of the bin content as the
+   /// square-root of the bin's sum of squared weights.
+   double GetBinUncertaintyImpl(int binidx) const { return std::sqrt(GetBinArray(binidx)); }
+
+   /// Get a bin's sum of squared weights.
+   WeightType GetSumOfSquaredWeights(int binidx) const { return GetBinArray(binidx); }
+   /// Get a bin's sum of squared weights.
+   WeightType &GetSumOfSquaredWeights(int binidx) { return GetBinArray(binidx); }
+
+   /// Get the structure holding the sum of squares of weights.
+   const Content_t &GetSumOfSquaredWeights() const { return fSumWeightsSquared; }
+   /// Get the structure holding the sum of squares of weights (non-const).
+   Content_t &GetSumOfSquaredWeights() { return fSumWeightsSquared; }
+
+   /// Get the structure holding the under-/overflow sum of squares of weights.
+   const Content_t &GetOverflowSumOfSquaredWeights() const { return fOverflowSumWeightsSquared; }
+   /// Get the structure holding the under-/overflow sum of squares of weights (non-const).
+   Content_t &GetOverflowSumOfSquaredWeights() { return fOverflowSumWeightsSquared; }
+
+   /// Merge with other `RHistStatUncertainty` data, assuming same bin configuration.
+   void Add(const RHistStatUncertainty& other) {
+      assert(fSumWeightsSquared.size() == other.fSumWeightsSquared.size()
+               && "this and other have incompatible bin configuration!");
+      assert(fOverflowSumWeightsSquared.size() == other.fOverflowSumWeightsSquared.size()
+               && "this and other have incompatible bin configuration!");
+      for (size_t b = 0; b < fSumWeightsSquared.size(); ++b)
+         fSumWeightsSquared[b] += other.fSumWeightsSquared[b];
+      for (size_t b = 0; b < fOverflowSumWeightsSquared.size(); ++b)
+         fOverflowSumWeightsSquared[b] += other.fOverflowSumWeightsSquared[b];
+   }
+};
+
+/**
+ Empty implementation not keeping track of moments.
+ */
+template <int Dimensions, class WeightType, bool>
+class RHistDataMomentUncert {
+   RHistDataMomentUncert() = default;
+   RHistDataMomentUncert(size_t, size_t) {}
+
+   void FillMoment(const std::array<double, Dimensions> &/*x*/, WeightType /*weight*/ = 1.) const {}
+
+   void Add(const RHistDataMomentUncert& other) const {}
+};
+
+/** \class RHistDataMomentUncert
+  For now do as `RH1`: calculate first (xw) and second (x^2w) moment.
+*/
+template <int Dimensions, class WeightType>
+class RHistDataMomentUncert<Dimensions, WeightType, true> {
+public:
+   /// Type of the moments array.
+   using MomentArr_t = std::array<WeightType, Dimensions>;
+
+private:
+   MomentArr_t fMomentXW;
+   MomentArr_t fMomentX2W;
+   // FIXME: Add sum(w.x.y)-style stats.
+
+public:
+   RHistDataMomentUncert() = default;
+   RHistDataMomentUncert(size_t, size_t) {}
+
+   /// Add weight to the bin at binidx; the coordinate was x.
+   void FillMoment(const std::array<double, Dimensions> &x, WeightType weight = 1.)
+   {
+      for (int idim = 0; idim < Dimensions; ++idim) {
+         const WeightType xw = x[idim] * weight;
+         fMomentXW[idim] += xw;
+         fMomentX2W[idim] += x[idim] * xw;
+      }
+   }
+
+   // FIXME: Add a way to query the inner data
+
+   /// Merge with other RHistDataMomentUncert data, assuming same bin configuration.
+   void Add(const RHistDataMomentUncert& other) {
+      for (size_t d = 0; d < Dimensions; ++d) {
+         fMomentXW[d] += other.fMomentXW[d];
+         fMomentX2W[d] += other.fMomentX2W[d];
+      }
+   }
+};
+} // namespace Internal
+
+namespace Detail {
+
+/** \class RHistData
+  A `RHistImplBase`'s data, provides accessors to all its statistics.
+  */
+template <int Dimensions, class WeightType, int StatConfig, template <class EL> class Container>
+class RHistData:
+public Internal::RHistStatUncertainty<Dimensions, WeightType, Container,
+   (bool)(StatConfig & Hist::Stat::kUncertainty)>,
+Internal::RHistDataMomentUncert<Dimensions, WeightType,
+   (bool)(StatConfig & (Hist::Stat::k1stMoment | Hist::Stat::k2ndMoment))>
+{
+public:
+   /// Type of the bin content array.
+   using Content_t = Container<WeightType>;
+   using HistStatUncertainty_t = Internal::RHistStatUncertainty<Dimensions, WeightType, Container,
+      (bool)(StatConfig & (int)Hist::Stat::kUncertainty)>;
+   using HistDataMomentUncert_t = Internal::RHistDataMomentUncert<Dimensions, WeightType,
+      (bool)(StatConfig & ((int)Hist::Stat::k1stMoment | (int)Hist::Stat::k2ndMoment))>;
+private:
    /// Number of calls to Fill().
-   int64_t fEntries = 0;
+   ssize_t fEntries = 0;
+
+   /// Sum of weights.
+   WeightType fSumWeights = 0;
+
+   /// Sum of (weights^2).
+   WeightType fSumWeights2 = 0;
 
    /// Bin content.
    Content_t fBinContent;
@@ -82,13 +213,16 @@ private:
    Content_t fOverflowBinContent;
 
 public:
-   RHistStatContent() = default;
-   RHistStatContent(size_t bin_size, size_t overflow_size): fBinContent(bin_size), fOverflowBinContent(overflow_size) {}
+   RHistData() = default;
+   RHistData(size_t bin_size, size_t overflow_size):
+      HistStatUncertainty_t(bin_size, overflow_size),
+      HistDataMomentUncert_t(bin_size, overflow_size),
+    fBinContent(bin_size), fOverflowBinContent(overflow_size) {}
 
    /// Get a reference to the bin corresponding to `binidx` of the correct bin
    /// content array 
    /// i.e. depending if `binidx` is a regular bin or an under- / overflow bin.
-   Weight_t GetBinArray(int binidx) const
+   WeightType GetBinArray(int binidx) const
    {
       if (binidx < 0){
          return fOverflowBinContent[-binidx - 1];
@@ -100,7 +234,7 @@ public:
    /// Get a reference to the bin corresponding to `binidx` of the correct bin
    /// content array (non-const)
    /// i.e. depending if `binidx` is a regular bin or an under- / overflow bin.
-   Weight_t& GetBinArray(int binidx)
+   WeightType& GetBinArray(int binidx)
    {
       if (binidx < 0){
          return fOverflowBinContent[-binidx - 1];
@@ -110,7 +244,7 @@ public:
    }
 
    /// Add weight to the bin content at `binidx`.
-   void Fill(const CoordArray_t & /*x*/, int binidx, Weight_t weight = 1.)
+   void Fill(int binidx, WeightType weight = 1.)
    {
       GetBinArray(binidx) += weight;
       ++fEntries;
@@ -130,14 +264,14 @@ public:
    size_t sizeUnderOver() const noexcept { return fOverflowBinContent.size(); }
 
    /// Get the bin content for the given bin.
-   Weight_t operator[](int binidx) const { return GetBinArray(binidx); }
+   WeightType operator[](int binidx) const { return GetBinArray(binidx); }
    /// Get the bin content for the given bin (non-const).
-   Weight_t &operator[](int binidx) { return GetBinArray(binidx); }
+   WeightType &operator[](int binidx) { return GetBinArray(binidx); }
 
    /// Get the bin content for the given bin.
-   Weight_t GetBinContent(int binidx) const { return GetBinArray(binidx); }
+   WeightType GetBinContent(int binidx) const { return GetBinArray(binidx); }
    /// Get the bin content for the given bin (non-const).
-   Weight_t &GetBinContent(int binidx) { return GetBinArray(binidx); }
+   WeightType &GetBinContent(int binidx) { return GetBinArray(binidx); }
 
    /// Retrieve the content array.
    const Content_t &GetContentArray() const { return fBinContent; }
@@ -150,7 +284,7 @@ public:
    Content_t &GetOverflowContentArray() { return fOverflowBinContent; }
 
    /// Merge with other RHistStatContent, assuming same bin configuration.
-   void Add(const RHistStatContent& other) {
+   void Add(const RHistData& other) {
       assert(fBinContent.size() == other.fBinContent.size()
                && "this and other have incompatible bin configuration!");
       assert(fOverflowBinContent.size() == other.fOverflowBinContent.size()
@@ -160,452 +294,10 @@ public:
          fBinContent[b] += other.fBinContent[b];
       for (size_t b = 0; b < fOverflowBinContent.size(); ++b)
          fOverflowBinContent[b] += other.fOverflowBinContent[b];
-   }
-};
-
-/**
- \class RHistStatTotalSumOfWeights
- Keeps track of the histogram's total sum of weights.
- */
-template <int DIMENSIONS, class PRECISION>
-class RHistStatTotalSumOfWeights {
-public:
-   /// The type of a (possibly multi-dimensional) coordinate.
-   using CoordArray_t = Hist::CoordArray_t<DIMENSIONS>;
-   /// The type of the weight and the bin content.
-   using Weight_t = PRECISION;
-
-   /**
-    \class RBinStat
-    No-op; this class does not provide per-bin statistics.
-   */
-   class RBinStat {
-   public:
-      RBinStat(const RHistStatTotalSumOfWeights &, int) {}
-   };
-
-   using ConstBinStat_t = RBinStat;
-   using BinStat_t = RBinStat;
-
-private:
-   /// Sum of weights.
-   PRECISION fSumWeights = 0;
-
-public:
-   RHistStatTotalSumOfWeights() = default;
-   RHistStatTotalSumOfWeights(size_t, size_t) {}
-
-   /// Add weight to the bin content at binidx.
-   void Fill(const CoordArray_t & /*x*/, int, Weight_t weight = 1.) { fSumWeights += weight; }
-
-   /// Get the sum of weights.
-   Weight_t GetSumOfWeights() const { return fSumWeights; }
-
-   /// Merge with other RHistStatTotalSumOfWeights data, assuming same bin configuration.
-   void Add(const RHistStatTotalSumOfWeights& other) {
-      fSumWeights += other.fSumWeights;
-   }
-};
-
-/**
- \class RHistStatTotalSumOfSquaredWeights
- Keeps track of the histogram's total sum of squared weights.
- */
-template <int DIMENSIONS, class PRECISION>
-class RHistStatTotalSumOfSquaredWeights {
-public:
-   /// The type of a (possibly multi-dimensional) coordinate.
-   using CoordArray_t = Hist::CoordArray_t<DIMENSIONS>;
-   /// The type of the weight and the bin content.
-   using Weight_t = PRECISION;
-
-   /**
-    \class RBinStat
-    No-op; this class does not provide per-bin statistics.
-   */
-   class RBinStat {
-   public:
-      RBinStat(const RHistStatTotalSumOfSquaredWeights &, int) {}
-   };
-
-   using ConstBinStat_t = RBinStat;
-   using BinStat_t = RBinStat;
-
-private:
-   /// Sum of (weights^2).
-   PRECISION fSumWeights2 = 0;
-
-public:
-   RHistStatTotalSumOfSquaredWeights() = default;
-   RHistStatTotalSumOfSquaredWeights(size_t, size_t) {}
-
-   /// Add weight to the bin content at binidx.
-   void Fill(const CoordArray_t & /*x*/, int /*binidx*/, Weight_t weight = 1.) { fSumWeights2 += weight * weight; }
-
-   /// Get the sum of weights.
-   Weight_t GetSumOfSquaredWeights() const { return fSumWeights2; }
-
-   /// Merge with other RHistStatTotalSumOfSquaredWeights data, assuming same bin configuration.
-   void Add(const RHistStatTotalSumOfSquaredWeights& other) {
-      fSumWeights2 += other.fSumWeights2;
-   }
-};
-
-/**
- \class RHistStatUncertainty
- Histogram statistics to keep track of the Poisson uncertainty per bin.
- */
-template <int DIMENSIONS, class PRECISION>
-class RHistStatUncertainty {
-
-public:
-   /// The type of a (possibly multi-dimensional) coordinate.
-   using CoordArray_t = Hist::CoordArray_t<DIMENSIONS>;
-   /// The type of the weight and the bin content.
-   using Weight_t = PRECISION;
-   /// Type of the bin content array.
-   using Content_t = std::vector<PRECISION>;
-
-   /**
-    \class RConstBinStat
-    Const view on a `RHistStatUncertainty` for a given bin.
-   */
-   class RConstBinStat {
-   public:
-      RConstBinStat(const RHistStatUncertainty &stat, int index): fSumW2(stat.GetSumOfSquaredWeights(index)) {}
-      PRECISION GetSumW2() const { return fSumW2; }
-
-      double GetUncertaintyImpl() const { return std::sqrt(std::abs(fSumW2)); }
-
-   private:
-      PRECISION fSumW2; ///< The bin's sum of square of weights.
-   };
-
-   /**
-    \class RBinStat
-    Modifying view on a `RHistStatUncertainty` for a given bin.
-   */
-   class RBinStat {
-   public:
-      RBinStat(RHistStatUncertainty &stat, int index): fSumW2(stat.GetSumOfSquaredWeights(index)) {}
-      PRECISION &GetSumW2() const { return fSumW2; }
-      // Can never modify this. Set GetSumW2() instead.
-      double GetUncertaintyImpl() const { return std::sqrt(std::abs(fSumW2)); }
-
-   private:
-      PRECISION &fSumW2; ///< The bin's sum of square of weights.
-   };
-
-   using ConstBinStat_t = RConstBinStat;
-   using BinStat_t = RBinStat;
-
-private:
-   /// Uncertainty of the content for each bin excluding under-/overflow.
-   Content_t fSumWeightsSquared; ///< Sum of squared weights.
-   /// Uncertainty of the under-/overflow content.
-   Content_t fOverflowSumWeightsSquared; ///< Sum of squared weights for under-/overflow.
-
-public:
-   RHistStatUncertainty() = default;
-   RHistStatUncertainty(size_t bin_size, size_t overflow_size): fSumWeightsSquared(bin_size), fOverflowSumWeightsSquared(overflow_size) {}
-
-   /// Get a reference to the bin corresponding to `binidx` of the correct bin
-   /// content array 
-   /// i.e. depending if `binidx` is a regular bin or an under- / overflow bin.
-   Weight_t GetBinArray(int binidx) const
-   {
-      if (binidx < 0){
-         return fOverflowSumWeightsSquared[-binidx - 1];
-      } else {
-         return fSumWeightsSquared[binidx - 1];
-      }
+      HistStatUncertainty_t::Add(other);
+      HistDataMomentUncert_t::AdD(other);
    }
 
-   /// Get a reference to the bin corresponding to `binidx` of the correct bin
-   /// content array (non-const)
-   /// i.e. depending if `binidx` is a regular bin or an under- / overflow bin.
-   Weight_t& GetBinArray(int binidx)
-   {
-      if (binidx < 0){
-         return fOverflowSumWeightsSquared[-binidx - 1];
-      } else {
-         return fSumWeightsSquared[binidx - 1];
-      }
-   }
-
-   /// Add weight to the bin at `binidx`; the coordinate was `x`.
-   void Fill(const CoordArray_t & /*x*/, int binidx, Weight_t weight = 1.)
-   {
-      GetBinArray(binidx) += weight * weight;
-   }
-
-   /// Calculate a bin's (Poisson) uncertainty of the bin content as the
-   /// square-root of the bin's sum of squared weights.
-   double GetBinUncertaintyImpl(int binidx) const { return std::sqrt(GetBinArray(binidx)); }
-
-   /// Get a bin's sum of squared weights.
-   Weight_t GetSumOfSquaredWeights(int binidx) const { return GetBinArray(binidx); }
-   /// Get a bin's sum of squared weights.
-   Weight_t &GetSumOfSquaredWeights(int binidx) { return GetBinArray(binidx); }
-
-   /// Get the structure holding the sum of squares of weights.
-   const std::vector<double> &GetSumOfSquaredWeights() const { return fSumWeightsSquared; }
-   /// Get the structure holding the sum of squares of weights (non-const).
-   std::vector<double> &GetSumOfSquaredWeights() { return fSumWeightsSquared; }
-
-   /// Get the structure holding the under-/overflow sum of squares of weights.
-   const std::vector<double> &GetOverflowSumOfSquaredWeights() const { return fOverflowSumWeightsSquared; }
-   /// Get the structure holding the under-/overflow sum of squares of weights (non-const).
-   std::vector<double> &GetOverflowSumOfSquaredWeights() { return fOverflowSumWeightsSquared; }
-
-   /// Merge with other `RHistStatUncertainty` data, assuming same bin configuration.
-   void Add(const RHistStatUncertainty& other) {
-      assert(fSumWeightsSquared.size() == other.fSumWeightsSquared.size()
-               && "this and other have incompatible bin configuration!");
-      assert(fOverflowSumWeightsSquared.size() == other.fOverflowSumWeightsSquared.size()
-               && "this and other have incompatible bin configuration!");
-      for (size_t b = 0; b < fSumWeightsSquared.size(); ++b)
-         fSumWeightsSquared[b] += other.fSumWeightsSquared[b];
-      for (size_t b = 0; b < fOverflowSumWeightsSquared.size(); ++b)
-         fOverflowSumWeightsSquared[b] += other.fOverflowSumWeightsSquared[b];
-   }
-};
-
-/** \class RHistDataMomentUncert
-  For now do as `RH1`: calculate first (xw) and second (x^2w) moment.
-*/
-template <int DIMENSIONS, class PRECISION>
-class RHistDataMomentUncert {
-public:
-   /// The type of a (possibly multi-dimensional) coordinate.
-   using CoordArray_t = Hist::CoordArray_t<DIMENSIONS>;
-   /// The type of the weight and the bin content.
-   using Weight_t = PRECISION;
-   /// Type of the bin content array.
-   using Content_t = std::vector<PRECISION>;
-
-   /**
-    \class RBinStat
-    No-op; this class does not provide per-bin statistics.
-   */
-   class RBinStat {
-   public:
-      RBinStat(const RHistDataMomentUncert &, int) {}
-   };
-
-   using ConstBinStat_t = RBinStat;
-   using BinStat_t = RBinStat;
-
-private:
-   std::array<Weight_t, DIMENSIONS> fMomentXW;
-   std::array<Weight_t, DIMENSIONS> fMomentX2W;
-   // FIXME: Add sum(w.x.y)-style stats.
-
-public:
-   RHistDataMomentUncert() = default;
-   RHistDataMomentUncert(size_t, size_t) {}
-
-   /// Add weight to the bin at binidx; the coordinate was x.
-   void Fill(const CoordArray_t &x, int /*binidx*/, Weight_t weight = 1.)
-   {
-      for (int idim = 0; idim < DIMENSIONS; ++idim) {
-         const PRECISION xw = x[idim] * weight;
-         fMomentXW[idim] += xw;
-         fMomentX2W[idim] += x[idim] * xw;
-      }
-   }
-
-   // FIXME: Add a way to query the inner data
-
-   /// Merge with other RHistDataMomentUncert data, assuming same bin configuration.
-   void Add(const RHistDataMomentUncert& other) {
-      for (size_t d = 0; d < DIMENSIONS; ++d) {
-         fMomentXW[d] += other.fMomentXW[d];
-         fMomentX2W[d] += other.fMomentX2W[d];
-      }
-   }
-};
-
-/** \class RHistStatRuntime
-  Interface implementing a pure virtual functions `DoFill()`, `DoFillN()`.
-  */
-template <int DIMENSIONS, class PRECISION>
-class RHistStatRuntime {
-public:
-   /// The type of a (possibly multi-dimensional) coordinate.
-   using CoordArray_t = Hist::CoordArray_t<DIMENSIONS>;
-   /// The type of the weight and the bin content.
-   using Weight_t = PRECISION;
-   /// Type of the bin content array.
-   using Content_t = std::vector<PRECISION>;
-
-   /**
-    \class RBinStat
-    No-op; this class does not provide per-bin statistics.
-   */
-   class RBinStat {
-   public:
-      RBinStat(const RHistStatRuntime &, int) {}
-   };
-
-   using ConstBinStat_t = RBinStat;
-   using BinStat_t = RBinStat;
-
-   RHistStatRuntime() = default;
-   RHistStatRuntime(size_t, size_t) {}
-   virtual ~RHistStatRuntime() = default;
-
-   virtual void DoFill(const CoordArray_t &x, int binidx, Weight_t weightN) = 0;
-   void Fill(const CoordArray_t &x, int binidx, Weight_t weight = 1.) { DoFill(x, binidx, weight); }
-};
-
-namespace Detail {
-
-/** \class RHistBinStat
-  Const view on a bin's statistical data. Combines all STATs' BinStat_t views.
-  */
-template <class DATA, class... BASES>
-class RHistBinStat: public BASES... {
-private:
-   /// Check whether `double T::GetBinUncertaintyImpl(int)` can be called.
-   template <class T>
-   static auto HaveUncertainty(const T *This) -> decltype(This->GetUncertaintyImpl());
-   /// Fall-back case for check whether `double T::GetBinUncertaintyImpl(int)` can be called.
-   template <class T>
-   static char HaveUncertainty(...);
-
-public:
-   RHistBinStat(DATA &data, int index): BASES(data, index)... {}
-
-   /// Whether this provides storage for uncertainties, or whether uncertainties
-   /// are determined as poisson uncertainty of the content.
-   static constexpr bool HasBinUncertainty()
-   {
-      struct AllYourBaseAreBelongToUs: public BASES... {
-      };
-      return sizeof(HaveUncertainty<AllYourBaseAreBelongToUs>(nullptr)) == sizeof(double);
-   }
-   /// Calculate the bin content's uncertainty for the given bin, using base class information,
-   /// i.e. forwarding to a base's `GetUncertaintyImpl()`.
-   template <bool B = true, class = typename std::enable_if<B && HasBinUncertainty()>::type>
-   double GetUncertainty() const
-   {
-      return this->GetUncertaintyImpl();
-   }
-   /// Calculate the bin content's uncertainty for the given bin, using Poisson
-   /// statistics on the absolute bin content. Only available if no base provides
-   /// this functionality. Requires `GetContent()`.
-   template <bool B = true, class = typename std::enable_if<B && !HasBinUncertainty()>::type>
-   double GetUncertainty(...) const
-   {
-      auto content = this->GetContent();
-      return std::sqrt(std::fabs(content));
-   }
-};
-
-/** \class RHistData
-  A `RHistImplBase`'s data, provides accessors to all its statistics.
-  */
-template <int DIMENSIONS, class PRECISION, class STORAGE, template <int D_, class P_> class... STAT>
-class RHistData: public STAT<DIMENSIONS, PRECISION>... {
-private:
-   /// Check whether `double T::GetBinUncertaintyImpl(int)` can be called.
-   template <class T>
-   static auto HaveUncertainty(const T *This) -> decltype(This->GetBinUncertaintyImpl(12));
-   /// Fall-back case for check whether `double T::GetBinUncertaintyImpl(int)` can be called.
-   template <class T>
-   static char HaveUncertainty(...);
-
-public:
-   /// Matching `RHist`.
-   using Hist_t = RHist<DIMENSIONS, PRECISION, STAT...>;
-
-   /// The type of the weight and the bin content.
-   using Weight_t = PRECISION;
-
-   /// The type of a (possibly multi-dimensional) coordinate.
-   using CoordArray_t = Hist::CoordArray_t<DIMENSIONS>;
-
-   /// The type of a non-modifying view on a bin.
-   using ConstHistBinStat_t =
-      RHistBinStat<const RHistData, typename STAT<DIMENSIONS, PRECISION>::ConstBinStat_t...>;
-
-   /// The type of a modifying view on a bin.
-   using HistBinStat_t = RHistBinStat<RHistData, typename STAT<DIMENSIONS, PRECISION>::BinStat_t...>;
-
-   /// Number of dimensions of the coordinates.
-   static constexpr int GetNDim() noexcept { return DIMENSIONS; }
-
-   RHistData() = default;
-
-   /// Constructor providing the number of bins (incl under, overflow) to the
-   /// base classes.
-   RHistData(size_t bin_size, size_t overflow_size): STAT<DIMENSIONS, PRECISION>(bin_size, overflow_size)... {}
-
-   /// Fill weight at x to the bin content at binidx.
-   void Fill(const CoordArray_t &x, int binidx, Weight_t weight = 1.)
-   {
-      // Call `Fill()` on all base classes.
-      // This combines a couple of C++ spells:
-      // - "STAT": is a template parameter pack of template template arguments. It
-      //           has multiple (or one or no) elements; each is a template name
-      //           that needs to be instantiated before it can be used.
-      // - "...":  template parameter pack expansion; the expression is evaluated
-      //           for each `STAT`. The expression is
-      //           `(STAT<DIMENSIONS, PRECISION>::Fill(x, binidx, weight), 0)`.
-      // - "trigger_base_fill{}":
-      //           initialization, provides a context in which template parameter
-      //           pack expansion happens.
-      // - ", 0":  because `Fill()` returns void it cannot be used as initializer
-      //           expression. The trailing ", 0" gives it the type of the trailing
-      //           comma-separated expression - int.
-      using trigger_base_fill = int[];
-      (void)trigger_base_fill{(STAT<DIMENSIONS, PRECISION>::Fill(x, binidx, weight), 0)...};
-   }
-
-   /// Integrate other statistical data into the current data.
-   ///
-   /// The implementation assumes that the other statistics were recorded with
-   /// the same binning configuration, and that the statistics of `OtherData`
-   /// are a superset of those recorded by the active `RHistData` instance.
-   template <typename OtherData>
-   void Add(const OtherData &other)
-   {
-      // Call `Add()` on all base classes, using the same tricks as `Fill()`.
-      using trigger_base_add = int[];
-      (void)trigger_base_add{(STAT<DIMENSIONS, PRECISION>::Add(other), 0)...};
-   }
-
-   /// Whether this provides storage for uncertainties, or whether uncertainties
-   /// are determined as poisson uncertainty of the content.
-   static constexpr bool HasBinUncertainty()
-   {
-      struct AllYourBaseAreBelongToUs: public STAT<DIMENSIONS, PRECISION>... {
-      };
-      return sizeof(HaveUncertainty<AllYourBaseAreBelongToUs>(nullptr)) == sizeof(double);
-   }
-
-   /// Calculate the bin content's uncertainty for the given bin, using base class information,
-   /// i.e. forwarding to a base's `GetBinUncertaintyImpl(binidx)`.
-   template <bool B = true, class = typename std::enable_if<B && HasBinUncertainty()>::type>
-   double GetBinUncertainty(int binidx) const
-   {
-      return this->GetBinUncertaintyImpl(binidx);
-   }
-   /// Calculate the bin content's uncertainty for the given bin, using Poisson
-   /// statistics on the absolute bin content. Only available if no base provides
-   /// this functionality. Requires `GetContent()`.
-   template <bool B = true, class = typename std::enable_if<B && !HasBinUncertainty()>::type>
-   double GetBinUncertainty(int binidx, ...) const
-   {
-      auto content = this->GetBinContent(binidx);
-      return std::sqrt(std::fabs(content));
-   }
-
-   /// Get a view on the statistics values of a bin.
-   ConstHistBinStat_t GetView(int idx) const { return ConstHistBinStat_t(*this, idx); }
-   /// Get a (non-const) view on the statistics values of a bin.
-   HistBinStat_t GetView(int idx) { return HistBinStat_t(*this, idx); }
 };
 } // namespace Detail
 

--- a/hist/histv7/inc/ROOT/RHistUtils.hxx
+++ b/hist/histv7/inc/ROOT/RHistUtils.hxx
@@ -22,36 +22,16 @@ namespace ROOT {
 namespace Experimental {
 namespace Hist {
 
-template <int DIMENSIONS>
-struct RCoordArray: std::array<double, DIMENSIONS> {
-   using Base_t = std::array<double, DIMENSIONS>;
-
-   /// Default construction.
-   RCoordArray() = default;
-
-   /// Construction with one `double` per `DIMENSION`.
-   template<class...ELEMENTS, class = typename std::enable_if<sizeof...(ELEMENTS) + 1 == DIMENSIONS>::type>
-   RCoordArray(double x, ELEMENTS...el): Base_t{{x, el...}} {}
-
-   /// Fallback constructor, invoked if the one above fails because of the wrong number of
-   /// arguments / coordinates.
-   template<class T, class...ELEMENTS, class = typename std::enable_if<sizeof...(ELEMENTS) + 1 != DIMENSIONS>::type>
-   RCoordArray(T, ELEMENTS...) {
-      static_assert(sizeof...(ELEMENTS) + 1 == DIMENSIONS, "Number of coordinates does not match DIMENSIONS");
-   }
-
-   /// Construction from a C-style array.
-   RCoordArray(double (&arr)[DIMENSIONS]): Base_t(arr) {}
-
-   /// Copy-construction from a C++-style array.
-   /// (No need for a move-constructor, it isn't any better for doubles)
-   RCoordArray(const std::array<double, DIMENSIONS>& arr): Base_t(arr) {}
+namespace Stat {
+enum EStat { // not enum class - want int-casts!
+   kUncertainty = 1, ///< Poisson uncertainty per bin
+   kRuntime = 2, ///< Runtime statistics - but how to set them?
+   k1stMoment = 4, ///< 1st moment
+   k2ndMoment = 8, ///< 2nd moment
+   // k3rdMoment = 16, ///< 3rd moment
+   // k4thMoment = 32, ///< 4th moment
 };
-
-template <int DIMENSIONS>
-//using CoordArray_t = std::array<double, DIMENSIONS>;
-using CoordArray_t = RCoordArray<DIMENSIONS>;
-
+}
 
 } // namespace Hist
 } // namespace Experimental


### PR DESCRIPTION
Axis-type agnostic base; Fill happens through derived.
Gets rid of RHistImpl (soon).
Still needs some work, esp with C++14...
[skip-CI]