### PR TITLE
[cmake] rootcling needs include/RConfigure.h (ROOT-10776):

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -601,12 +601,14 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   #---what rootcling command to use--------------------------
   if(ARG_STAGE1)
     set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" $<TARGET_FILE:rootcling_stage1>)
+    set(ROOTCINTDEP rconfigure)
     set(pcm_name)
   else()
     if(CMAKE_PROJECT_NAME STREQUAL ROOT)
       set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
                   "ROOTIGNOREPREFIX=1" $<TARGET_FILE:rootcling> -rootbuild)
-      set(ROOTCINTDEP rootcling)
+      # Modules need RConfigure.h copied into include/.
+      set(ROOTCINTDEP rootcling rconfigure)
     elseif(TARGET ROOT::rootcling)
       set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}" $<TARGET_FILE:ROOT::rootcling>)
     else()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -31,6 +31,8 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/include/RConfigure.h
     ${CMAKE_BINARY_DIR}/ginclude/RConfigure.h
 )
 
+add_custom_target(rconfigure ALL DEPENDS ${CMAKE_BINARY_DIR}/include/RConfigure.h)
+
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/ginclude/RGitCommit.h
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different


### PR DESCRIPTION
rootcling uses modules, and those have a modulemap entry for include/RConfigure.h.
Make sure that it actually gets copied before the first run of rootcling.