### PR TITLE
[ntuple] implement NTupleDescriptorBuilder validity check 

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -558,7 +558,7 @@ public:
                   const RNTupleVersion &version, const RNTupleUuid &uuid);
 
    void AddField(const RFieldDescriptor& fieldDesc);
-   void AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId);
+   RResult<void> AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId);
 
    void AddColumn(DescriptorId_t columnId, DescriptorId_t fieldId,
                   const RNTupleVersion &version, const RColumnModel &model, std::uint32_t index);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -547,7 +547,10 @@ private:
    RNTupleDescriptor fDescriptor;
 
 public:
-   bool IsValid() const { return true; /* TODO(jblomer) */}
+   /// Checks whether invariants hold:
+   /// * NTuple name is valid
+   /// * Fields have valid parent and child ids
+   RResult<void> EnsureValidDescriptor() const;
    const RNTupleDescriptor& GetDescriptor() const { return fDescriptor; }
    RNTupleDescriptor MoveDescriptor();
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -195,9 +195,9 @@ ROOT::Experimental::RResult<void>
 ROOT::Experimental::Detail::RFieldBase::EnsureValidFieldName(std::string_view fieldName)
 {
    if (fieldName == "") {
-      return R__FAIL("field name cannot be empty string \"\"");
+      return R__FAIL("name cannot be empty string \"\"");
    } else if (fieldName.find(".") != std::string::npos) {
-      return R__FAIL("field name '" + std::string(fieldName) + "' cannot contain dot characters '.'");
+      return R__FAIL("name '" + std::string(fieldName) + "' cannot contain dot characters '.'");
    }
    return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -765,6 +765,18 @@ ROOT::Experimental::RResult<void>
 ROOT::Experimental::RNTupleDescriptorBuilder::EnsureValidDescriptor() const {
    // Reuse field name validity check
    Detail::RFieldBase::EnsureValidFieldName(fDescriptor.GetName()).ThrowOnError();
+   // open-ended list of invariant checks
+   for (const auto& key_val: fDescriptor.fFieldDescriptors) {
+      const auto& id = key_val.first;
+      const auto& desc = key_val.second;
+      // parent not properly set
+      if (id != DescriptorId_t(0) && desc.GetParentId() == kInvalidDescriptorId) {
+         return R__FAIL("field with id '" + std::to_string(id) + "' has an invalid parent id");
+      }
+      if (desc.GetStructure() == ENTupleStructure::kLeaf && desc.GetLinkIds().size() != 0) {
+         return R__FAIL("leaf field '" + std::to_string(id) + "' cannot have child fields");
+      }
+   }
    return RResult<void>::Success();
 }
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -763,7 +763,9 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDes
 
 ROOT::Experimental::RResult<void>
 ROOT::Experimental::RNTupleDescriptorBuilder::EnsureValidDescriptor() const {
-   return R__FAIL("unimplemented!");
+   // Reuse field name validity check
+   Detail::RFieldBase::EnsureValidFieldName(fDescriptor.GetName()).ThrowOnError();
+   return RResult<void>::Success();
 }
 
 ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptorBuilder::MoveDescriptor()

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -764,7 +764,10 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDes
 ROOT::Experimental::RResult<void>
 ROOT::Experimental::RNTupleDescriptorBuilder::EnsureValidDescriptor() const {
    // Reuse field name validity check
-   Detail::RFieldBase::EnsureValidFieldName(fDescriptor.GetName()).ThrowOnError();
+   auto validName = Detail::RFieldBase::EnsureValidFieldName(fDescriptor.GetName());
+   if (!validName) {
+      return R__FORWARD_ERROR(validName);
+   }
    // open-ended list of invariant checks
    for (const auto& key_val: fDescriptor.fFieldDescriptors) {
       const auto& id = key_val.first;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -13,6 +13,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -759,6 +760,11 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDes
 
 ////////////////////////////////////////////////////////////////////////////////
 
+
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::RNTupleDescriptorBuilder::EnsureValidDescriptor() const {
+   return R__FAIL("unimplemented!");
+}
 
 ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::RNTupleDescriptorBuilder::MoveDescriptor()
 {

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -773,9 +773,6 @@ ROOT::Experimental::RNTupleDescriptorBuilder::EnsureValidDescriptor() const {
       if (id != DescriptorId_t(0) && desc.GetParentId() == kInvalidDescriptorId) {
          return R__FAIL("field with id '" + std::to_string(id) + "' has an invalid parent id");
       }
-      if (desc.GetStructure() == ENTupleStructure::kLeaf && desc.GetLinkIds().size() != 0) {
-         return R__FAIL("leaf field '" + std::to_string(id) + "' cannot have child fields");
-      }
    }
    return RResult<void>::Success();
 }
@@ -974,8 +971,14 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddFieldLink(DescriptorId_t fieldI
    if (linkId == DescriptorId_t(0)) {
       return R__FAIL("cannot make FieldZero a child field");
    }
+   if (fDescriptor.fFieldDescriptors.count(fieldId) == 0) {
+      return R__FAIL("field with id '" + std::to_string(fieldId) + "' doesn't exist in NTuple");
+   }
+   if (fDescriptor.fFieldDescriptors.count(linkId) == 0) {
+      return R__FAIL("child field with id '" + std::to_string(linkId) + "' doesn't exist in NTuple");
+   }
    // fail if field already has a valid parent
-   auto parentId = fDescriptor.fFieldDescriptors[linkId].fParentId;
+   auto parentId = fDescriptor.fFieldDescriptors.at(linkId).GetParentId();
    if (parentId != kInvalidDescriptorId) {
       return R__FAIL("field '" + std::to_string(linkId) + "' already has a parent ('" +
          std::to_string(parentId) + ")");
@@ -983,8 +986,8 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddFieldLink(DescriptorId_t fieldI
    if (fieldId == linkId) {
       return R__FAIL("cannot make field '" + std::to_string(fieldId) + "' a child of itself");
    }
-   fDescriptor.fFieldDescriptors[linkId].fParentId = fieldId;
-   fDescriptor.fFieldDescriptors[fieldId].fLinkIds.push_back(linkId);
+   fDescriptor.fFieldDescriptors.at(linkId).fParentId = fieldId;
+   fDescriptor.fFieldDescriptors.at(fieldId).fLinkIds.push_back(linkId);
    return RResult<void>::Success();
 }
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -230,13 +230,13 @@ TEST(RNTupleModel, EnforceValidFieldNames)
       auto field3 = model->MakeField<float>("", 42.0);
       FAIL() << "empty string as field name should throw";
    } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("field name cannot be empty string"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("name cannot be empty string"));
    }
    try {
       auto field3 = model->MakeField<float>("pt.pt", 42.0);
       FAIL() << "field name with periods should throw";
    } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("field name 'pt.pt' cannot contain dot characters '.'"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("name 'pt.pt' cannot contain dot characters '.'"));
    }
 
    // AddField

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -190,6 +190,8 @@ TEST(RDanglingFieldDescriptor, MakeDescriptorErrors)
 TEST(RNTupleDescriptorBuilder, CatchInvalidDescriptors)
 {
    RNTupleDescriptorBuilder descBuilder;
+
+   // empty string is not a valid NTuple name
    descBuilder.SetNTuple("", "", "", RNTupleVersion(1, 2, 3), ROOT::Experimental::RNTupleUuid());
    try {
       descBuilder.EnsureValidDescriptor();
@@ -198,6 +200,17 @@ TEST(RNTupleDescriptorBuilder, CatchInvalidDescriptors)
    }
    descBuilder.SetNTuple("something", "", "", RNTupleVersion(1, 2, 3), ROOT::Experimental::RNTupleUuid());
    descBuilder.EnsureValidDescriptor();
+
+   descBuilder.AddFieldLink(0, 1);
+   // leaf fields can't have children
+   descBuilder.AddField(1, RNTupleVersion(), RNTupleVersion(), "int", "int32_t",
+      0, ENTupleStructure::kLeaf);
+   descBuilder.AddFieldLink(1, 2);
+   try {
+      descBuilder.EnsureValidDescriptor();
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("leaf field '1' cannot have child fields"));
+   }
 }
 
 TEST(RFieldDescriptorRange, IterateOverFieldNames)

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -186,6 +186,12 @@ TEST(RDanglingFieldDescriptor, MakeDescriptorErrors)
       .MakeDescriptor();
    ASSERT_FALSE(fieldDescRes) << "unnamed field descriptors should throw";
    EXPECT_THAT(fieldDescRes.GetError()->GetReport(), testing::HasSubstr("field name cannot be empty string"));
+
+TEST(RNTupleDescriptorBuilder, CatchInvalidDescriptors)
+{
+   RNTupleDescriptorBuilder descBuilder;
+   descBuilder.SetNTuple("", "", "", RNTupleVersion(1, 2, 3), ROOT::Experimental::RNTupleUuid());
+   EXPECT_THROW(descBuilder.EnsureValidDescriptor(), RException);
 }
 
 TEST(RFieldDescriptorRange, IterateOverFieldNames)

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -191,7 +191,13 @@ TEST(RNTupleDescriptorBuilder, CatchInvalidDescriptors)
 {
    RNTupleDescriptorBuilder descBuilder;
    descBuilder.SetNTuple("", "", "", RNTupleVersion(1, 2, 3), ROOT::Experimental::RNTupleUuid());
-   EXPECT_THROW(descBuilder.EnsureValidDescriptor(), RException);
+   try {
+      descBuilder.EnsureValidDescriptor();
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("name cannot be empty string"));
+   }
+   descBuilder.SetNTuple("something", "", "", RNTupleVersion(1, 2, 3), ROOT::Experimental::RNTupleUuid());
+   descBuilder.EnsureValidDescriptor();
 }
 
 TEST(RFieldDescriptorRange, IterateOverFieldNames)


### PR DESCRIPTION
Add more error-checking to the `NTupleDescriptor` build process (sibling PR of #5934)
Intent after #5985 lands is to make `EnsureValidDescriptor` private, remove `GetDescriptor` and `MoveDescriptor` 
and expose a new method

`RNTupleDescriptorBuilder::MakeDescriptor() -> RResult<RNTupleDescriptor>` 

that we can call `Inspect` and `Unwrap` on. 

The actual `NTupleDescriptor` validity check is a bit sparse right now (I don't really know many `Column` or `Cluster` invariants).