### PR TITLE
[hadd] add option to specify which objects should (not) be merged

### DIFF
--- a/main/src/hadd-argparse.py
+++ b/main/src/hadd-argparse.py
@@ -23,6 +23,8 @@ The prefix can be optionally followed by B whose casing is ignored, eg. 1k, 1K, 
 	parser.add_argument("-dbg", help="Parallelize the execution in multiple processes in debug mode (Does not delete partial files stored inside working directory)")
 	parser.add_argument("-d", help="Carry out the partial multiprocess execution in the specified directory")
 	parser.add_argument("-n", help="Open at most 'maxopenedfiles' at once (use 0 to request to use the system maximum)")
+        parser.add_argument("-l", help="Comma-separated list of objects (not) to merge.")
+        parser.add_argument("-b", help="Use objects passed to -l as blacklist.")
 	parser.add_argument("-cachesize", help="Resize the prefetching cache use to speed up I/O operations(use 0 to disable)")
 	parser.add_argument("-experimental-io-features", help="Used with an argument provided, enables the corresponding experimental feature for output trees")
 	parser.add_argument("-f", help="Gives the ability to specify the compression level of the target file(by default 4) ")

--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -77,6 +77,7 @@
 #include "TKey.h"
 #include "TClass.h"
 #include "TSystem.h"
+#include "TStopwatch.h"
 #include "TUUID.h"
 #include "ROOT/StringConv.hxx"
 #include "snprintf.h"
@@ -116,6 +117,9 @@ int main( int argc, char **argv )
    Int_t maxopenedfiles = 0;
    Int_t verbosity = 99;
    TString cacheSize;
+   std::vector<std::string> AddObjectNamesList;
+   Bool_t blacklist = kFALSE;
+   TStopwatch clock;
    SysInfo_t s;
    gSystem->GetSysInfo(&s);
    auto nProcesses = s.fCpus;
@@ -143,7 +147,10 @@ int main( int argc, char **argv )
          debug = kTRUE;
          verbosity = kTRUE;
          ++ffirst;
-      } else if (strcmp(argv[a], "-d") == 0) {
+      } else if ( strcmp(argv[a],"-b") == 0 ) {
+         blacklist = kTRUE;
+         ++ffirst;
+      }  else if (strcmp(argv[a], "-d") == 0) {
          if (a + 1 != argc && argv[a + 1][0] != '-') {
             if (gSystem->AccessPathName(argv[a + 1])) {
                std::cerr << "Error: could not access the directory specified: " << argv[a + 1]
@@ -288,6 +295,18 @@ int main( int argc, char **argv )
             }
          }
          ++ffirst;
+      } else if (!strcmp(argv[a], "-l")) {
+         if (a+1 >= argc) {
+            std::cerr << "Error: no AddObjectNamesList items were specified after -l; ignoring\n";
+         } else {
+            std::stringstream ss;
+            ss.str(argv[++a]);
+            ++ffirst;
+            std::string item;
+            while (std::getline(ss, item, ','))
+              AddObjectNamesList.push_back(item);
+         }
+         ++ffirst;
       } else if ( argv[a][0] == '-' ) {
          bool farg = false;
          if (force && argv[a][1] == 'f') {
@@ -344,12 +363,15 @@ int main( int argc, char **argv )
    }
 
    if (verbosity > 1) {
+      clock.Start();
       std::cout << "hadd Target file: " << targetname << std::endl;
    }
 
    TFileMerger fileMerger(kFALSE, kFALSE);
    fileMerger.SetMsgPrefix("hadd");
    fileMerger.SetPrintLevel(verbosity - 1);
+   for(const auto& objn : AddObjectNamesList)
+     fileMerger.AddObjectNames(objn.data());
    if (maxopenedfiles > 0) {
       fileMerger.SetMaxOpenedFiles(maxopenedfiles);
    }
@@ -398,6 +420,12 @@ int main( int argc, char **argv )
    }
 
    auto filesToProcess = argc - ffirst;
+   for (auto i = argc - ffirst; i < argc; i++)
+      if (argv[i] && argv[i][0] == '@'){
+         auto inFile = std::ifstream(argv[i]+1);
+         filesToProcess = std::count(std::istreambuf_iterator<char>(inFile), std::istreambuf_iterator<char>(), '\n');
+      }
+
    auto step = (filesToProcess + nProcesses - 1) / nProcesses;
    if (multiproc && step < 3) {
       // At least 3 files per process
@@ -437,8 +465,12 @@ int main( int argc, char **argv )
       Bool_t status;
       if (append)
          status = merger.PartialMerge(TFileMerger::kIncremental | TFileMerger::kAll);
-      else
-         status = merger.Merge();
+      else {
+         Int_t merge_type = TFileMerger::kAll | TFileMerger::kRegular;
+         if (!AddObjectNamesList.empty())
+            blacklist ? merge_type |= TFileMerger::kSkipListed : merge_type |= TFileMerger::kOnlyListed;
+         status = merger.PartialMerge(merge_type);
+      }
       return status;
    };
 
@@ -515,6 +547,10 @@ int main( int argc, char **argv )
 #endif
 
    if (status) {
+      if (verbosity > 1) {
+         clock.Stop();
+         clock.Print();
+      }
       if (verbosity == 1) {
          std::cout << "hadd merged " << fileMerger.GetMergeList()->GetEntries() << " input files in " << targetname
                    << ".\n";


### PR DESCRIPTION
Hi all! This is my first PR, please be gentle 🙂 

The PR is meant to trigger a discussion on the feature described in the title, rather than being a request that it should go in as-is.

### Description 
Add `-l` and `-b` command line options for passing a list of objects to `TFileMerger::AddObjectNames` and setting  the `TFileMerger::kSkipListed` or `TFileMerger::kOnlyListed` flags.

### Purpose 
Allows to merge only certain objects from the list of input files.

### Use case 
Merging single directories/trees into separate root files. More concrete: when producing nTuples (on the WLCG) with common LHCb tools, one sometimes wants to run different selections on the same input stream and write out a tree for each of the selections. All these trees end up in the same root file.

### Shortcomings
- All directories will be copied in whitelist mode, but the non-whitelisted ones will be empty. I didn't look further into this, but it could be that this would have to be changed in `TFileMerger` rather than `hadd`.
- The code is not rigorously tested. If the feature should be added, I am available to do that.
- There is a `TStopwach` remnant from my tests. I wouldn't mind throwing it out again
- Lines 423-428 are also leftover when trying to run with a list of (xrootd) input files in multiprocess mode. This doesn't seem to work irrespective of the new feature. I will try to look into it further