### PR TITLE
Remove protections in TMath::Asin and TMath::ACos for input values outside the range

### DIFF
--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -648,15 +648,13 @@ inline Double_t TMath::TanH(Double_t x)
 
 ////////////////////////////////////////////////////////////////////////////////
 inline Double_t TMath::ASin(Double_t x)
-   { if (x < -1.) return -TMath::Pi()/2;
-     if (x >  1.) return  TMath::Pi()/2;
+   { 
      return asin(x);
    }
 
 ////////////////////////////////////////////////////////////////////////////////
 inline Double_t TMath::ACos(Double_t x)
-   { if (x < -1.) return TMath::Pi();
-     if (x >  1.) return 0;
+   { 
      return acos(x);
    }
 


### PR DESCRIPTION
Revert commit https://github.com/root-project/root/commit/0c1e5e6160fc816c3bbbe26e9b06aaf2c9a51f80

and remove the protections for entries outside range in TMath::ASin and TMath::ACos and let
std::asin and std::acos returning a NaN