### PR TITLE
[prompt] Do not segfault when root_hist has zero lines

### DIFF
--- a/core/textinput/src/textinput/History.h
+++ b/core/textinput/src/textinput/History.h
@@ -39,7 +39,7 @@ namespace textinput {
     // Indices are reverse! I.e. 0 is newest!
     const std::string& GetLine(size_t Idx) const {
       static const std::string sEmpty;
-      if (Idx == (size_t)-1 || fEntries.size() == 0)
+      if (Idx == (size_t)-1 || fEntries.empty())
          return sEmpty;
       return fEntries[fEntries.size() - 1 - Idx];
     }

--- a/core/textinput/src/textinput/History.h
+++ b/core/textinput/src/textinput/History.h
@@ -39,7 +39,8 @@ namespace textinput {
     // Indices are reverse! I.e. 0 is newest!
     const std::string& GetLine(size_t Idx) const {
       static const std::string sEmpty;
-      if (Idx == (size_t)-1) return sEmpty;
+      if (Idx == (size_t)-1 || fEntries.size() == 0)
+         return sEmpty;
       return fEntries[fEntries.size() - 1 - Idx];
     }
     size_t GetSize() const { return fEntries.size(); }


### PR DESCRIPTION
Pressing ctrl-r when no ~/.root_hist file is present or possibly
when it contains 0 lines used to cause a segfault. The culprit
if an out-of-bound access in History::GetLine, as the case in which
the history has zero entries was not taken into account.

With this patch, Histoy::GetLine returns an empty string instead.
This fixes ROOT-10917.