### PR TITLE
[ntuple] advertise RNTuple implements hadd MergeFile interface

### DIFF
--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -588,9 +588,9 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                               hobj->ResetBit(kMustCleanup);
                               inputs.Add(hobj);
                            } else {
-                             Info("MergeRecursive", "non-inheriting merge for key: %s in file %s",
-			        key->GetName(), nextsource->GetName());
-			   }
+                              Fatal("MergeRecursive", "Merging objects that don't inherit from TObject is unimplemented (key: %s in file %s)",
+                                    key->GetName(), nextsource->GetName());
+                           }
                            if (!oneGo) {
                               ROOT::MergeFunc_t func = cl->GetMerge();
                               Long64_t result = func(obj, &inputs, &info);

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -605,24 +605,19 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                         ndir->cd();
                         TKey *key2 = (TKey*)ndir->GetListOfKeys()->FindObject(key->GetName());
                         if (key2) {
-                           if (cl->IsTObject()) {
-                              TObject *hobj = key2->ReadObj();
-                              if (!hobj) {
-                                 Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
-                                      key->GetName(), key->GetTitle(), nextsource->GetName());
-                                 nextsource = (TFile*)sourcelist->After(nextsource);
-                                 continue;
-                              }
-                              // Set ownership for collections
-                              if (hobj->InheritsFrom(TCollection::Class())) {
-                                 ((TCollection*)hobj)->SetOwner();
-                              }
-                              hobj->ResetBit(kMustCleanup);
-                              inputs.Add(hobj);
-                           } else {
-                              Fatal("MergeRecursive", "Merging objects that don't inherit from TObject is unimplemented (key: %s in file %s)",
-                                    key->GetName(), nextsource->GetName());
+                           TObject *hobj = key2->ReadObj();
+                           if (!hobj) {
+                              Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
+                                   key->GetName(), key->GetTitle(), nextsource->GetName());
+                              nextsource = (TFile*)sourcelist->After(nextsource);
+                              continue;
                            }
+                           // Set ownership for collections
+                           if (hobj->InheritsFrom(TCollection::Class())) {
+                              ((TCollection*)hobj)->SetOwner();
+                           }
+                           hobj->ResetBit(kMustCleanup);
+                           inputs.Add(hobj);
                            if (!oneGo) {
                               ROOT::MergeFunc_t func = cl->GetMerge();
                               Long64_t result = func(obj, &inputs, &info);

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -371,6 +371,22 @@ Bool_t TFileMerger::Merge(Bool_t)
    return PartialMerge(kAll | kRegular);
 }
 
+namespace {
+
+/// Merge a list of RNTuples
+Long64_t MergeRNTuples(TClass* rntupleHandle, const TString& /* target */, const TList& /* sources */) {
+   if (!rntupleHandle) {
+      return Long64_t(-1);
+   }
+   // todo(max) implement rntuple merger
+   // [ ] build complete list of sources (some sources may actually be a directory with RNTuples inside)
+   // [ ] merge them
+   ROOT::MergeFunc_t func = rntupleHandle->GetMerge();
+   return func(static_cast<void*>(rntupleHandle), nullptr, nullptr);
+}
+
+} // anonymous namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Merge all objects in a directory
 ///
@@ -547,8 +563,23 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                status = MergeRecursive(newdir, sourcelist, type);
                if (onlyListed) type |= kOnlyListed;
                if (!status) return status;
-            } else if (cl->GetMerge()) {
-
+            } else if (!cl->IsTObject() && cl->GetMerge()) {
+               // merge objects that don't derive from TObject
+               if (std::string(key->GetClassName()) == "ROOT::Experimental::RNTuple") {
+                  Warning("MergeRecursive", "merging RNTuples is experimental");
+                  // todo(max): check if this works when a TDirectory is passed as the first
+                  // input argument
+                  Long64_t mergeResult = MergeRNTuples(cl, *path, *sourcelist);
+                  if (mergeResult < 0) {
+                     Error("MergeRecursive", "error merging RNTuples");
+                     return kFALSE;
+                  }
+                  return kTRUE;
+               }
+               TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
+               Fatal("MergeRecursive", "Merging objects that don't inherit from TObject is unimplemented (key: %s in file %s)",
+                      key->GetName(), nextsource->GetName());
+            } else if (cl->IsTObject() && cl->GetMerge()) {
                // Check if already treated
                if (alreadyseen) continue;
 

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -577,8 +577,9 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                   return kTRUE;
                }
                TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
-               Fatal("MergeRecursive", "Merging objects that don't inherit from TObject is unimplemented (key: %s in file %s)",
-                      key->GetName(), nextsource->GetName());
+               Error("MergeRecursive", "Merging objects that don't inherit from TObject is unimplemented (key: %s of type %s in file %s)",
+                      key->GetName(), key->GetClassName(), nextsource->GetName());
+               canBeMerged = kFALSE;
             } else if (cl->IsTObject() && cl->GetMerge()) {
                // Check if already treated
                if (alreadyseen) continue;

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -88,8 +88,6 @@ struct RNTuple {
    // RNTuple implements the hadd MergeFile interface
    /// Merge this NTuple with the input list entries
    Long64_t Merge(TCollection *input, TFileMergeInfo *mergeInfo);
-   /// Reset any state after merging
-   void ResetAfterMerge(TFileMergeInfo* /* mergeInfo */) {};
 };
 
 namespace Internal {

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -25,7 +25,9 @@
 #include <memory>
 #include <string>
 
+class TCollection;
 class TFile;
+class TFileMergeInfo;
 
 namespace ROOT {
 
@@ -82,6 +84,12 @@ struct RNTuple {
          fLenFooter == other.fLenFooter &&
          fReserved == other.fReserved;
    }
+
+   // RNTuple implements the hadd MergeFile interface
+   /// Merge this NTuple with the input list entries
+   Long64_t Merge(TCollection *input, TFileMergeInfo *mergeInfo);
+   /// Reset any state after merging
+   void ResetAfterMerge(TFileMergeInfo* /* mergeInfo */) {};
 };
 
 namespace Internal {

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -22,6 +22,7 @@
 
 #include <TError.h>
 #include <TFile.h>
+#include <TFileMergeInfo.h>
 #include <TKey.h>
 
 #include <algorithm>
@@ -1009,6 +1010,14 @@ void ROOT::Experimental::Internal::RMiniFileReader::ReadBuffer(void *buffer, siz
 {
    auto nread = fRawFile->ReadAt(buffer, nbytes, offset);
    R__ASSERT(nread == nbytes);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+Long64_t ROOT::Experimental::RNTuple::Merge(TCollection* /* input */, TFileMergeInfo* /* mergeInfo */) {
+   return -1;
 }
 
 

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -22,7 +22,6 @@
 
 #include <TError.h>
 #include <TFile.h>
-#include <TFileMergeInfo.h>
 #include <TKey.h>
 
 #include <algorithm>
@@ -1010,14 +1009,6 @@ void ROOT::Experimental::Internal::RMiniFileReader::ReadBuffer(void *buffer, siz
 {
    auto nread = fRawFile->ReadAt(buffer, nbytes, offset);
    R__ASSERT(nread == nbytes);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-
-Long64_t ROOT::Experimental::RNTuple::Merge(TCollection* /* input */, TFileMergeInfo* /* mergeInfo */) {
-   return -1;
 }
 
 

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -14,9 +14,21 @@
  *************************************************************************/
 
 #include <ROOT/RError.hxx>
+#include <ROOT/RMiniFile.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleMerger.hxx>
 #include <ROOT/RNTupleUtil.hxx>
+
+Long64_t ROOT::Experimental::RNTuple::Merge(TCollection* inputs, TFileMergeInfo* mergeInfo) {
+   if (inputs == nullptr || mergeInfo == nullptr) {
+      return -1;
+   }
+   return -1;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
 
 ROOT::Experimental::RResult<ROOT::Experimental::RFieldMerger>
 ROOT::Experimental::RFieldMerger::Merge(const ROOT::Experimental::RFieldDescriptor &lhs,


### PR DESCRIPTION
Declares a new method `RNTuple::Merge` to conform to the `hadd` merger interface, namely: 
https://github.com/root-project/root/blob/331efa4c00fefc38980eaaf7b41b8e95fcd1a23b/io/doc/v530/index.html#L43-L53

I originally thought about to adding this method `RNTupleReader`, but think this is the right choice since it's the `RNTuple` blob that's stored on disk, and we have to parse it into a `RNTupleReader` to do any useful work. 

Actually running it segfaults, and I'm not sure whether I've made a mistake in linking or elsewhere. 
~~**Edit:** segfault fixed by #6016~~
**Edit**: I believe the segfault is fixed by 12fef499c109da4c2454d9cca2e60e88a883aa1c, where I avoid assuming that mergeable objects are derived from `TObject`. 