### PR TITLE
Fix `rf204b_extendedLikelihood_rangedFit.C` error on Windows

### DIFF
--- a/tutorials/roofit/rf204b_extendedLikelihood_rangedFit.C
+++ b/tutorials/roofit/rf204b_extendedLikelihood_rangedFit.C
@@ -68,7 +68,7 @@ void rf204b_extendedLikelihood_rangedFit()
 
  // Build plain exponential model
  RooRealVar x("x", "x", 10, 100);
- RooRealVar alpha("alpha", "alpha", -0.04, -0.1, -0);
+ RooRealVar alpha("alpha", "alpha", -0.04, -0.1, -0.0);
  RooExponential model("model", "Exponential model", x, alpha);
 
  // Define side band regions and full range


### PR DESCRIPTION
Fix the following error on Windows:

In file included from input_line_10:1:
C:\Users\sftnight\git\master\tutorials\roofit\rf204b_extendedLikelihood_rangedFit.C:71:13: error: call to constructor of 'RooRealVar' is ambiguous
 RooRealVar alpha("alpha", "alpha", -0.04, -0.1, -0);
            ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/Users/sftnight/build/release\include\RooRealVar.h:41:3: note: candidate constructor
  RooRealVar(const char *name, const char *title, Double_t minValue,
  ^
C:/Users/sftnight/build/release\include\RooRealVar.h:43:3: note: candidate constructor
  RooRealVar(const char *name, const char *title, Double_t value,
  ^
CMake Error at C:/Users/sftnight/build/release/RootTestDriver.cmake:237 (message):
  error code: 1