### PR TITLE
Including headers for all libraries based on ROOT_STANDARD_LIBRARY_PACKAGE

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1242,6 +1242,16 @@ function(ROOT_STANDARD_LIBRARY_PACKAGE libname)
     endif()
   endif()
 
+  foreach (h ${ARG_HEADERS})
+    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/inc/${h}")
+      list(APPEND ARG_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/inc/${h}")
+    elseif (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/v7/inc/${h}")
+      list(APPEND ARG_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/v7/inc/${h}")
+    else()
+      message("Could not find directory of header file: ${h}")
+    endif()
+  endforeach()
+
   if (ARG_OBJECT_LIBRARY)
     ROOT_OBJECT_LIBRARY(${libname}Objs ${ARG_SOURCES}
                         $<$<BOOL:${ARG_NO_SOURCES}>:dummy.cxx>)


### PR DESCRIPTION
Partially solves: [ROOT-10915](https://its.cern.ch/jira/browse/ROOT-10915)

Reasoning from the ticket:
> It seems most header files are not added to the library targets that compose ROOT. This is most imminent to me when I create a Visual Studio project by CMake. Almost all header files are missing in the solution explorer.

> While this still allows to build ROOT, the IDE experience is severly limited. Automatic code refactoring and static analysis fails to a large degree, because the headers are not considered part of the project. E.g. the clang-tidy integration in Visual Studio cannot fix any header files.