### PR TITLE
[io] Fix segfault in ReadObjectAny

### DIFF
--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -1021,7 +1021,7 @@ void *TKey::ReadObjectAny(const TClass* expectedClass)
    }
    TBufferFile bufferRef(TBuffer::kRead, fObjlen+fKeylen);
    if (!bufferRef.Buffer()) {
-      Error("ReadObj", "Cannot allocate buffer: fObjlen = %d", fObjlen);
+      Error("ReadObjectAny", "Cannot allocate buffer: fObjlen = %d", fObjlen);
       return 0;
    }
    if (GetFile()==0) return 0;
@@ -1116,7 +1116,7 @@ void *TKey::ReadObjectAny(const TClass* expectedClass)
    if (cl->IsTObject()) {
       auto tobjBaseOffset = cl->GetBaseClassOffset(TObject::Class());
       if (tobjBaseOffset == -1) {
-         Fatal("ReadObj","Incorrect detection of the inheritance from TObject for class %s.\n",
+         Fatal("ReadObjectAny","Incorrect detection of the inheritance from TObject for class %s.\n",
                fClassName.Data());
       }
       TObject *tobj = (TObject*)( ((char*)pobj) + tobjBaseOffset);

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -756,7 +756,8 @@ TObject *TKey::ReadObj()
    }
    if (!cl->IsTObject()) {
       // in principle user should call TKey::ReadObjectAny!
-      return (TObject*)ReadObjectAny(0);
+      Error("ReadObj", "class %s does not inherit from TObject, call ReadObjectAny instead", fClassName.Data());
+      return 0;
    }
 
    TBufferFile bufferRef(TBuffer::kRead, fObjlen+fKeylen);
@@ -1014,6 +1015,10 @@ TObject *TKey::ReadObjWithBuffer(char *bufferRead)
 
 void *TKey::ReadObjectAny(const TClass* expectedClass)
 {
+   if (!expectedClass) {
+      Error("ReadObjectAny", "input was null pointer");
+      return 0;
+   }
    TBufferFile bufferRef(TBuffer::kRead, fObjlen+fKeylen);
    if (!bufferRef.Buffer()) {
       Error("ReadObj", "Cannot allocate buffer: fObjlen = %d", fObjlen);


### PR DESCRIPTION
Fixes a segfault that surfaced during #6008 (trying to merge `RNTuple` objects). 

`RNTuple` doesn't inherit from `TObject`, so `ReadObj` ends up passing a null pointer to `ReadObjectAny`. 
We add a null check to `ReadObjectAny` and return `0` if `ReadObj` is called on classes that don't inherit from `TObject`. 

Before: 
```shell
../bin/hadd -f merged.root ntuple1.root ntuple2.root
hadd Target file: merged.root
hadd compression setting for all output: 1
hadd Source file 1: ntuple1.root
hadd Source file 2: ntuple2.root
hadd Sources and Target have different compression levels
hadd merging will be slower
hadd Target path: merged.root:/

 *** Break *** segmentation violation
```

After:
```shell
 ../bin/hadd -f merged.root ntuple1.root ntuple2.root
hadd Target file: merged.root
hadd compression setting for all output: 1
hadd Source file 1: ntuple1.root
hadd Source file 2: ntuple2.root
hadd Sources and Target have different compression levels
hadd merging will be slower
hadd Target path: merged.root:/
Error in <TKey::ReadObj>: class ROOT::Experimental::RNTuple does not derive from TObject, call ReadObjectAny instead
Info in <TFileMerger::MergeRecursive>: could not read object for key {ntuple, }
```