### PR TITLE
[PyROOT][ROOT-10870] Fixes/additions for CPPExcInstance

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
@@ -150,6 +150,77 @@ static PyObject* ep_richcompare(CPPExcInstance* self, PyObject* other, int op)
     return PyObject_RichCompare(self->fCppInstance, other, op);
 }
 
+//----------------------------------------------------------------------------
+static int ep_nonzero(CPPExcInstance* self)
+{
+   if (self->fCppInstance)
+      return PyObject_IsTrue(self->fCppInstance);
+
+   return 0;
+}
+
+//-----------------------------------------------------------------------------
+static PyNumberMethods ep_as_number = {
+    0,                             // nb_add
+    0,                             // nb_subtract
+    0,                             // nb_multiply
+#if PY_VERSION_HEX < 0x03000000
+    0,                             // nb_divide
+#endif
+    0,                             // nb_remainder
+    0,                             // nb_divmod
+    0,                             // nb_power
+    0,                             // nb_negative
+    0,                             // nb_positive
+    0,                             // nb_absolute
+    (inquiry)ep_nonzero,           // nb_bool (nb_nonzero in p2)
+    0,                             // nb_invert
+    0,                             // nb_lshift
+    0,                             // nb_rshift
+    0,                             // nb_and
+    0,                             // nb_xor
+    0,                             // nb_or
+#if PY_VERSION_HEX < 0x03000000
+    0,                             // nb_coerce
+#endif
+    0,                             // nb_int
+    0,                             // nb_long (nb_reserved in p3)
+    0,                             // nb_float
+#if PY_VERSION_HEX < 0x03000000
+    0,                             // nb_oct
+    0,                             // nb_hex
+#endif
+    0,                             // nb_inplace_add
+    0,                             // nb_inplace_subtract
+    0,                             // nb_inplace_multiply
+#if PY_VERSION_HEX < 0x03000000
+    0,                             // nb_inplace_divide
+#endif
+    0,                             // nb_inplace_remainder
+    0,                             // nb_inplace_power
+    0,                             // nb_inplace_lshift
+    0,                             // nb_inplace_rshift
+    0,                             // nb_inplace_and
+    0,                             // nb_inplace_xor
+    0                              // nb_inplace_or
+#if PY_VERSION_HEX >= 0x02020000
+    , 0                            // nb_floor_divide
+#if PY_VERSION_HEX < 0x03000000
+    , 0                            // nb_true_divide
+#else
+    , 0                            // nb_true_divide
+#endif
+    , 0                            // nb_inplace_floor_divide
+    , 0                            // nb_inplace_true_divide
+#endif
+#if PY_VERSION_HEX >= 0x02050000
+    , 0                            // nb_index
+#endif
+#if PY_VERSION_HEX >= 0x03050000
+    , 0                            // nb_matrix_multiply
+    , 0                            // nb_inplace_matrix_multiply
+#endif
+};
 
 //= CPyCppyy exception object proxy type ======================================
 PyTypeObject CPPExcInstance_Type = {
@@ -163,7 +234,7 @@ PyTypeObject CPPExcInstance_Type = {
     0,                             // tp_setattr
     0,                             // tp_compare
     (reprfunc)ep_repr,             // tp_repr
-    0,                             // tp_as_number
+    &ep_as_number,                 // tp_as_number
     0,                             // tp_as_sequence
     0,                             // tp_as_mapping
     0,                             // tp_hash

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
@@ -207,11 +207,13 @@ void CPyCppyy::op_dealloc_nofree(CPPInstance* pyobj) {
     if (pyobj->fFlags & CPPInstance::kIsRegulated)
         MemoryRegulator::UnregisterPyObject(pyobj, (PyObject*)Py_TYPE((PyObject*)pyobj));
 
-    if (pyobj->fFlags & CPPInstance::kIsValue) {
-        Cppyy::CallDestructor(klass, cppobj);
-        Cppyy::Deallocate(klass, cppobj);
-    } else if (pyobj->fFlags & CPPInstance::kIsOwner) {
-        if (cppobj) Cppyy::Destruct(klass, cppobj);
+    if (pyobj->fFlags & CPPInstance::kIsOwner) {
+       if (pyobj->fFlags & CPPInstance::kIsValue) {
+           Cppyy::CallDestructor(klass, cppobj);
+           Cppyy::Deallocate(klass, cppobj);
+       } else {
+           if (cppobj) Cppyy::Destruct(klass, cppobj);
+       }
     }
     cppobj = nullptr;
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx
@@ -581,7 +581,7 @@ PyObject* CPyCppyy::InstancePtrExecutor::Execute(
 
 //----------------------------------------------------------------------------
 CPyCppyy::InstanceExecutor::InstanceExecutor(Cppyy::TCppType_t klass) :
-    fClass(klass), fFlags(CPPInstance::kIsValue)
+    fClass(klass), fFlags(CPPInstance::kIsValue | CPPInstance::kIsOwner)
 {
     /* empty */
 }
@@ -604,8 +604,8 @@ PyObject* CPyCppyy::InstanceExecutor::Execute(
     if (!pyobj)
         return nullptr;
 
-// python ref counting will now control this object's life span
-    ((CPPInstance*)pyobj)->PythonOwns();
+// python ref counting will now control this object's life span; it will be
+// deleted b/c it is marked as a by-value object (unless C++ ownership is set)
     return pyobj;
 }
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
@@ -844,12 +844,11 @@ PyObject* CPyCppyy::BindCppObjectNoCast(Cppyy::TCppObject_t address,
     CPPInstance* pyobj =
         (CPPInstance*)((PyTypeObject*)pyclass)->tp_new((PyTypeObject*)pyclass, args, nullptr);
     Py_DECREF(args);
-    Py_DECREF(pyclass);
 
 // bind, register and return if successful
     if (pyobj != 0) { // fill proxy value?
         unsigned objflags =
-            (isRef ? CPPInstance::kIsReference : 0) | (isValue ? CPPInstance::kIsValue : 0);
+            (isRef ? CPPInstance::kIsReference : 0) | (isValue ? CPPInstance::kIsValue : 0) | (flags & CPPInstance::kIsOwner);
         pyobj->Set(address, (CPPInstance::EFlags)objflags);
 
         if (smart_type)
@@ -864,8 +863,12 @@ PyObject* CPyCppyy::BindCppObjectNoCast(Cppyy::TCppObject_t address,
     if (((CPPClass*)pyclass)->fFlags & CPPScope::kIsException) {
         PyObject* exc_obj = CPPExcInstance_Type.tp_new(&CPPExcInstance_Type, nullptr, nullptr);
         ((CPPExcInstance*)exc_obj)->fCppInstance = (PyObject*)pyobj;
+        Py_DECREF(pyclass);
         return exc_obj;
     }
+
+    Py_DECREF(pyclass);
+
     return (PyObject*)pyobj;
 }
 


### PR DESCRIPTION
This PR:
- Fixes a corruption issue of `CPPExcInstance` objects that resulted in a crash at teardown time during garbage collection.
- Adds a boolean operator to `CPPExcInstance` that forwards the call to the internal `CPPInstance`

The changes will be communicated to upstream cppyy.