### PR TITLE
[ntuple] add debug output for low-level RNTuple structs

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -54,6 +54,7 @@ SOURCES
   v7/src/RNTupleMerger.cxx
   v7/src/RNTupleMetrics.cxx
   v7/src/RNTupleModel.cxx
+  v7/src/RNTupleUtil.cxx
   v7/src/RPage.cxx
   v7/src/RPageAllocator.cxx
   v7/src/RPagePool.cxx

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -82,6 +82,21 @@ struct RNTuple {
          fLenFooter == other.fLenFooter &&
          fReserved == other.fReserved;
    }
+
+   friend std::ostream& operator<<(std::ostream& os, const RNTuple& ntpl) {
+      os << "RNTuple {\n";
+      os << "    fVersion: " << ntpl.fVersion << ",\n";
+      os << "    fSize: " << ntpl.fSize << ",\n";
+      os << "    fSeekHeader: " << ntpl.fSeekHeader << ",\n";
+      os << "    fNBytesHeader: " << ntpl.fNBytesHeader << ",\n";
+      os << "    fLenHeader: " << ntpl.fLenHeader << ",\n";
+      os << "    fSeekFooter: " << ntpl.fSeekFooter << ",\n";
+      os << "    fNBytesFooter: " << ntpl.fNBytesFooter << ",\n";
+      os << "    fLenFooter: " << ntpl.fLenFooter << ",\n";
+      os << "    fReserved: " << ntpl.fReserved << ",\n";
+      os << "}";
+      return os;
+   }
 };
 
 namespace Internal {

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -82,21 +82,6 @@ struct RNTuple {
          fLenFooter == other.fLenFooter &&
          fReserved == other.fReserved;
    }
-
-   friend std::ostream& operator<<(std::ostream& os, const RNTuple& ntpl) {
-      os << "RNTuple {\n";
-      os << "    fVersion: " << ntpl.fVersion << ",\n";
-      os << "    fSize: " << ntpl.fSize << ",\n";
-      os << "    fSeekHeader: " << ntpl.fSeekHeader << ",\n";
-      os << "    fNBytesHeader: " << ntpl.fNBytesHeader << ",\n";
-      os << "    fLenHeader: " << ntpl.fLenHeader << ",\n";
-      os << "    fSeekFooter: " << ntpl.fSeekFooter << ",\n";
-      os << "    fNBytesFooter: " << ntpl.fNBytesFooter << ",\n";
-      os << "    fLenFooter: " << ntpl.fLenFooter << ",\n";
-      os << "    fReserved: " << ntpl.fReserved << ",\n";
-      os << "}";
-      return os;
-   }
 };
 
 namespace Internal {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -23,6 +23,13 @@
 namespace ROOT {
 namespace Experimental {
 
+struct RNTuple;
+
+namespace Internal {
+
+void PrintRNTuple(const RNTuple& ntuple, std::ostream& output);
+
+} // namespace Internal
 
 /**
  * The fields in the ntuple model tree can carry different structural information about the type system.

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -842,6 +842,24 @@ struct RTFNTuple {
       ntuple.fReserved     = fReserved;
       return ntuple;
    }
+
+   friend std::ostream& operator<<(std::ostream& os, const RTFNTuple& ntpl) {
+      os << "RTFNTuple {\n";
+      os << "    fByteCount: " << ntpl.fByteCount << ",\n";
+      os << "    fVersionClass: " << ntpl.fVersionClass << ",\n";
+      os << "    fChecksum: " << ntpl.fChecksum << ",\n";
+      os << "    fVersionInternal: " << ntpl.fVersionInternal << ",\n";
+      os << "    fSize: " << ntpl.fSize << ",\n";
+      os << "    fSeekHeader: " << ntpl.fSeekHeader << ",\n";
+      os << "    fNBytesHeader: " << ntpl.fNBytesHeader << ",\n";
+      os << "    fLenHeader: " << ntpl.fLenHeader << ",\n";
+      os << "    fSeekFooter: " << ntpl.fSeekFooter << ",\n";
+      os << "    fNBytesFooter: " << ntpl.fNBytesFooter << ",\n";
+      os << "    fLenFooter: " << ntpl.fLenFooter << ",\n";
+      os << "    fReserved: " << ntpl.fReserved << ",\n";
+      os << "}";
+      return os;
+   }
 };
 
 /// The bare file global header

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -842,23 +842,21 @@ struct RTFNTuple {
       ntuple.fReserved     = fReserved;
       return ntuple;
    }
-
-   friend std::ostream& operator<<(std::ostream& os, const RTFNTuple& ntpl) {
-      os << "RTFNTuple {\n";
-      os << "    fByteCount: " << ntpl.fByteCount << ",\n";
-      os << "    fVersionClass: " << ntpl.fVersionClass << ",\n";
-      os << "    fChecksum: " << ntpl.fChecksum << ",\n";
-      os << "    fVersionInternal: " << ntpl.fVersionInternal << ",\n";
-      os << "    fSize: " << ntpl.fSize << ",\n";
-      os << "    fSeekHeader: " << ntpl.fSeekHeader << ",\n";
-      os << "    fNBytesHeader: " << ntpl.fNBytesHeader << ",\n";
-      os << "    fLenHeader: " << ntpl.fLenHeader << ",\n";
-      os << "    fSeekFooter: " << ntpl.fSeekFooter << ",\n";
-      os << "    fNBytesFooter: " << ntpl.fNBytesFooter << ",\n";
-      os << "    fLenFooter: " << ntpl.fLenFooter << ",\n";
-      os << "    fReserved: " << ntpl.fReserved << ",\n";
-      os << "}";
-      return os;
+   void Print(std::ostream& output) {
+      output << "RTFNTuple {\n";
+      output << "    fByteCount: " << fByteCount << ",\n";
+      output << "    fVersionClass: " << fVersionClass << ",\n";
+      output << "    fChecksum: " << fChecksum << ",\n";
+      output << "    fVersionInternal: " << fVersionInternal << ",\n";
+      output << "    fSize: " << fSize << ",\n";
+      output << "    fSeekHeader: " << fSeekHeader << ",\n";
+      output << "    fNBytesHeader: " << fNBytesHeader << ",\n";
+      output << "    fLenHeader: " << fLenHeader << ",\n";
+      output << "    fSeekFooter: " << fSeekFooter << ",\n";
+      output << "    fNBytesFooter: " << fNBytesFooter << ",\n";
+      output << "    fLenFooter: " << fLenFooter << ",\n";
+      output << "    fReserved: " << fReserved << ",\n";
+      output << "}";
    }
 };
 

--- a/tree/ntuple/v7/src/RNTupleUtil.cxx
+++ b/tree/ntuple/v7/src/RNTupleUtil.cxx
@@ -1,0 +1,41 @@
+/// \file RNTupleUtil.cxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch> & Max Orok <maxwellorok@gmail.com>
+/// \date 2020-07-14
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RMiniFile.hxx"
+#include "ROOT/RNTupleUtil.hxx"
+
+#include <iostream>
+
+namespace ROOT {
+namespace Experimental {
+namespace Internal {
+
+void PrintRNTuple(const RNTuple& ntuple, std::ostream& output) {
+   output << "RNTuple {\n";
+   output << "    fVersion: " << ntuple.fVersion << ",\n";
+   output << "    fSize: " << ntuple.fSize << ",\n";
+   output << "    fSeekHeader: " << ntuple.fSeekHeader << ",\n";
+   output << "    fNBytesHeader: " << ntuple.fNBytesHeader << ",\n";
+   output << "    fLenHeader: " << ntuple.fLenHeader << ",\n";
+   output << "    fSeekFooter: " << ntuple.fSeekFooter << ",\n";
+   output << "    fNBytesFooter: " << ntuple.fNBytesFooter << ",\n";
+   output << "    fLenFooter: " << ntuple.fLenFooter << ",\n";
+   output << "    fReserved: " << ntuple.fReserved << ",\n";
+   output << "}";
+}
+
+} // namespace Internal
+} // namespace Experimental
+} // namespace ROOT


### PR DESCRIPTION
Lets us quickly check `NTuple` and `RTFNTuple` values during development.

Example output with dummy values: 
```cpp
RNTuple ntpl;
ntpl.fVersion = 1;                                                                      
ntpl.fSeekHeader = 100;                                                                               
std::cout << ntpl << "\n";                                                                        
```
```text
RNTuple {
    fVersion: 1,
    fSize: 48,
    fSeekHeader: 100,
    fNBytesHeader: 0,
    fLenHeader: 0,
    fSeekFooter: 0,
    fNBytesFooter: 0,
    fLenFooter: 0,
    fReserved: 0,
}
```

RTFNTuple is a little weird because of it's representation, maybe I could tweak it to be more readable? 
```cpp
RTFNTuple ntpl;
std::cout << ntpl; 
```
```text
RTFNTuple {
    fByteCount: 1073741878,
    fVersionClass: 0,
    fChecksum: 1700499286,
    fVersionInternal: 0,
    fSize: 48,
    fSeekHeader: 0,
    fNBytesHeader: 0,
    fLenHeader: 0,
    fSeekFooter: 0,
    fNBytesFooter: 0,
    fLenFooter: 0,
    fReserved: 0,
}
```
