### PR TITLE
[Fix][graf2d] Fix drawing performance of marker styles 6 and 7

### DIFF
--- a/graf2d/cocoa/src/TGQuartz.mm
+++ b/graf2d/cocoa/src/TGQuartz.mm
@@ -366,11 +366,19 @@ void TGQuartz::DrawPolyMarker(Int_t n, TPoint *xy)
    if (drawable.fScaleFactor > 1.)
       CGContextScaleCTM(ctx, 1. / drawable.fScaleFactor, 1. / drawable.fScaleFactor);
 
-   CGContextSetLineJoin(ctx, kCGLineJoinRound);
-   CGContextSetLineCap(ctx, kCGLineCapRound);
+   Style_t markerstyle = TAttMarker::GetMarkerStyleBase(GetMarkerStyle());
+
+   // The fast pixel markers need to be treated separately
+   if (markerstyle == 1 || markerstyle == 6 || markerstyle == 7) {
+       CGContextSetLineJoin(ctx, kCGLineJoinMiter);
+       CGContextSetLineCap(ctx, kCGLineCapButt);
+   } else {
+       CGContextSetLineJoin(ctx, kCGLineJoinRound);
+       CGContextSetLineCap(ctx, kCGLineCapRound);
+   }
 
    Float_t MarkerSizeReduced = GetMarkerSize() - TMath::Floor(TAttMarker::GetMarkerLineWidth(GetMarkerStyle())/2.)/4.;
-   Quartz::DrawPolyMarker(ctx, n, &fConvertedPoints[0], MarkerSizeReduced * drawable.fScaleFactor, TAttMarker::GetMarkerStyleBase(GetMarkerStyle()));
+   Quartz::DrawPolyMarker(ctx, n, &fConvertedPoints[0], MarkerSizeReduced * drawable.fScaleFactor, markerstyle);
 
    CGContextSetLineJoin(ctx, kCGLineJoinMiter);
    CGContextSetLineCap(ctx, kCGLineCapButt);

--- a/graf2d/win32gdk/src/TGWin32.cxx
+++ b/graf2d/win32gdk/src/TGWin32.cxx
@@ -3403,17 +3403,23 @@ void TGWin32::SetMarkerStyle(Style_t markerstyle)
 
 void TGWin32::UpdateMarkerStyle()
 {
-   gMarkerLineWidth = TMath::Max(1, Int_t(TAttMarker::GetMarkerLineWidth(fMarkerStyle)));
-   gdk_gc_set_line_attributes(gGCmark, gMarkerLineWidth,
-			      (GdkLineStyle)gMarkerLineStyle,
-			      (GdkCapStyle) gMarkerCapStyle,
-			      (GdkJoinStyle) gMarkerJoinStyle);
+   Style_t markerstyle = TAttMarker::GetMarkerStyleBase(fMarkerStyle);
+   gMarkerLineWidth = TAttMarker::GetMarkerLineWidth(fMarkerStyle);
+
+   // The fast pixel markers need to be treated separately
+   if (markerstyle == 1 || markerstyle == 6 || markerstyle == 7) {
+       gdk_gc_set_line_attributes(gGCmark, 0, GDK_LINE_SOLID, GDK_CAP_BUTT, GDK_JOIN_MITER);
+   } else {
+       gdk_gc_set_line_attributes(gGCmark, gMarkerLineWidth,
+                                  (GdkLineStyle) gMarkerLineStyle,
+                                  (GdkCapStyle)  gMarkerCapStyle,
+                                  (GdkJoinStyle) gMarkerJoinStyle);
+   }
 
    static GdkPoint shape[30];
 
-   Float_t MarkerSizeReduced = fMarkerSize - TMath::Floor(TAttMarker::GetMarkerLineWidth(fMarkerStyle)/2.)/4.;
+   Float_t MarkerSizeReduced = fMarkerSize - TMath::Floor(gMarkerLineWidth/2.)/4.;
    Int_t im = Int_t(4 * MarkerSizeReduced + 0.5);
-   Style_t markerstyle = TAttMarker::GetMarkerStyleBase(fMarkerStyle);
 
    if (markerstyle == 2) {
       // + shaped marker

--- a/graf2d/x11/src/TGX11.cxx
+++ b/graf2d/x11/src/TGX11.cxx
@@ -2437,12 +2437,19 @@ void TGX11::SetMarkerStyle(Style_t markerstyle)
    if (fMarkerStyle == markerstyle) return;
    static RXPoint shape[30];
    fMarkerStyle = TMath::Abs(markerstyle);
-   gMarkerLineWidth = TMath::Max(1, Int_t(TAttMarker::GetMarkerLineWidth(fMarkerStyle)));
-   XSetLineAttributes((Display*)fDisplay, *gGCmark, gMarkerLineWidth,
-                      gMarkerLineStyle, gMarkerCapStyle, gMarkerJoinStyle);
-   Float_t MarkerSizeReduced = fMarkerSize - TMath::Floor(TAttMarker::GetMarkerLineWidth(fMarkerStyle)/2.)/4.;
-   Int_t im = Int_t(4*MarkerSizeReduced + 0.5);
    markerstyle = TAttMarker::GetMarkerStyleBase(fMarkerStyle);
+   gMarkerLineWidth = TAttMarker::GetMarkerLineWidth(fMarkerStyle);
+
+   // The fast pixel markers need to be treated separately
+   if (markerstyle == 1 || markerstyle == 6 || markerstyle == 7) {
+       XSetLineAttributes((Display*)fDisplay, *gGCmark, 0, LineSolid, CapButt, JoinMiter);
+   } else {
+       XSetLineAttributes((Display*)fDisplay, *gGCmark, gMarkerLineWidth,
+                          gMarkerLineStyle, gMarkerCapStyle, gMarkerJoinStyle);
+   }
+
+   Float_t MarkerSizeReduced = fMarkerSize - TMath::Floor(gMarkerLineWidth/2.)/4.;
+   Int_t im = Int_t(4*MarkerSizeReduced + 0.5);
    if (markerstyle == 2) {
       // + shaped marker
       shape[0].x = -im;  shape[0].y = 0;


### PR DESCRIPTION
Hello,

after I installed the most recent ROOT release 6.22.00, I noticed that the drawing performance of the marker styles 6 and 7 became significantly worse. Unfortunately, I got to admit this is due to the additions of my PR  #4772.
The implementation of the marker line width required to use different line joins and line caps than default to look nice, but are a little bit slower. In usual cases you won't notice this, but when you draw 100.000+ points, it becomes significant.

I wrote this patch to fix this problem and make the markers 6 and 7, which are meant to be used for huge amounts of points, fast again. I confirmed that the fix works in an X11 environment. It would be good if someone can approve it also on Windows and MacOS.

Since this is a fix, it should also become part of the v6-22-00-patches branch, how ever I don't know exactly how to do this. Do I need to open a second PR for this?

All the best,
Simon