### PR TITLE
Fix bad regex

### DIFF
--- a/proof/proof/src/TProofMgr.cxx
+++ b/proof/proof/src/TProofMgr.cxx
@@ -820,7 +820,7 @@ TFileCollection *TProofMgr::UploadFiles(TList *src,
    if (dest && strlen(dest) > 0) {
       TString dst(dest), dt;
       Ssiz_t from = 0;
-      TRegexp re("<d+[0-9]>");
+      TRegexp re("<d[0-9]+>");
       while (dst.Tokenize(dt, from, "/")) {
          if (dt.Contains(re)) {
             TParameter<Int_t> *pi = new TParameter<Int_t>(dt, -1);


### PR DESCRIPTION
It should find a "d" followed by one or more digits, not one or more "d"s followed by one digit.