### PR TITLE
v6.22 Fix Jira issue #ROOT-10925 Can not compile ROOT macro on Windows

### DIFF
--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -4294,6 +4294,8 @@ const char *TWinNTSystem::GetLibraries(const char *regexp, const char *options,
             if (!ntlibs.IsNull()) ntlibs.Append(" ");
             if ((s.Index("python") == kNPOS) && (s.Index("cppyy") == kNPOS) &&
                 (s.Index("vcruntime") == kNPOS) && (s.Index(".pyd") == kNPOS) &&
+                (s.Index("lzma") == kNPOS) && (s.Index("gdk-1.3") == kNPOS) &&
+                (s.Index("glib-1.3") == kNPOS) && (s.Index("iconv-1.3") == kNPOS) &&
                 (s.Index("msvcp") == kNPOS))
               ntlibs.Append(s);
          }


### PR DESCRIPTION
Filter out internal DLLs, not supposed to be linked when using ACLiC