### PR TITLE
Reduce TBasket high water mark use. Fix ROOT-10927.

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1793,6 +1793,7 @@ TBasket* TBranch::GetFreshBasket(TBuffer* user_buffer)
                fBaskets.AddAt(0,oldindex);
                fBaskets.SetLast(-1);
                fNBaskets = 0;
+               basket->Reset();
             } else {
                basket = fTree->CreateBasket(this);
             }


### PR DESCRIPTION
In commit 79f2e3b0e5, TBranch::GetFreshBasket was effectively switch from always reallocating
the TBuffer (i.e. minimal memory use but maximal number of memory allocation) to always keeping
the TBuffer (i.e. maximal memory use but minimal number of memory allocations).

This causes a problem in a use CMS use case where:
  - files were kept open
  - TTree were kept in memory
  - has (at least) one branch with one unusually large basket (257Mb)

This accumulated to increase the memory use from 1.8Gb to 2.9Gb.

For now (quick fix), we use TBasket::Reset (tuned for writing) also for reading.
(This leads to spurrious large reallocation in case of a consecutive series of
large baskets).