### PR TITLE
In TClass::GetListOfBaseClasses, correct conditional.

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3572,7 +3572,7 @@ TList *TClass::GetListOfBases()
             }
          }
          // We test again on fCanLoadClassInfo has another thread may have executed it.
-         if (!fHasRootPcmInfo && !fCanLoadClassInfo) {
+         if (!fHasRootPcmInfo && fCanLoadClassInfo) {
             LoadClassInfo();
          }
       }


### PR DESCRIPTION
It looks like without ROOT pcm but with a ClassInfo/Decl available but not loaded then the base class would not be properly setup.