### PR TITLE
Set cling optimization level to 3 and turn off pointer checks

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1573,6 +1573,10 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
    fClingCallbacks->SetAutoParsingSuspended(fIsAutoParsingSuspended);
    fInterpreter->setCallbacks(std::move(clingCallbacks));
 
+   // force optlevel 3
+   fInterpreter->getCI()->getCodeGenOpts().OptimizationLevel = 3;
+   fInterpreter->setDefaultOptLevel(3);
+
    if (!fromRootCling) {
       cling::DynamicLibraryManager& DLM = *fInterpreter->getDynamicLibraryManager();
       // Make sure cling looks into ROOT's libdir, even if not part of LD_LIBRARY_PATH

--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -158,6 +158,9 @@ void BackendPasses::CreatePasses(llvm::Module& M, int OptLevel)
     // Inlining = CGOpts.NoInlining;
   }
 
+  // force normal inlining (as above says: NoInlining is kills)
+  const_cast<CodeGenOptions&>(m_CGOpts).setInlining(CodeGenOptions::NormalInlining);
+
   llvm::PassManagerBuilder PMBuilder;
   PMBuilder.OptLevel = OptLevel;
   PMBuilder.SizeLevel = m_CGOpts.OptimizeSize;

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1589,7 +1589,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     // FIXME: We have a bug when we switch to -O2, for some cases it takes
     // several minutes to optimize, while the same code compiled by clang -O2
     // takes only a few seconds.
-    CGOpts.OptimizationLevel = 0;
+    CGOpts.OptimizationLevel = 3;
     // Taken from a -O2 run of clang:
     CGOpts.DiscardValueNames = 1;
     CGOpts.OmitLeafFramePointer = 1;

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -918,7 +918,7 @@ namespace cling {
     std::vector<ASTTPtr_t> ASTTransformers;
     ASTTransformers.emplace_back(new AutoSynthesizer(TheSema));
     ASTTransformers.emplace_back(new EvaluateTSynthesizer(TheSema));
-    if (hasCodeGenerator() && !m_Interpreter->getOptions().NoRuntime) {
+    if (0 && hasCodeGenerator() && !m_Interpreter->getOptions().NoRuntime) {
       // Don't protect against crashes if we cannot run anything.
       // cling might also be in a PCH-generation mode; don't inject our Sema
       // pointer into the PCH.


### PR DESCRIPTION
Our use case requires optimization level 3 and disabled pointer checks. Therefore Fons asked me to send this PR.
Please see the following discussion:
https://root-forum.cern.ch/t/jit-performance-issue/38555

Commit based on
https://bitbucket.org/wlav/cppyy-backend/src/master/cling/patches/optlevel2_forced.diff