### PR TITLE
[v7, exceptions] Add R__FORWARD_ERROR macro

### DIFF
--- a/core/base/v7/inc/ROOT/RError.hxx
+++ b/core/base/v7/inc/ROOT/RError.hxx
@@ -214,10 +214,10 @@ public:
    ~RResult() = default;
 
    /// Used by R__FORWARD_RESULT in order to keep track of the stack trace in case of errors
-   static RResult &Forward(RResult &result, RError::RLocation &&sourceLocation) {
-      if (result.fError)
-         result.fError->AddFrame(std::move(sourceLocation));
-      return result;
+   RResult &Forward(RError::RLocation &&sourceLocation) {
+      if (fError)
+         fError->AddFrame(std::move(sourceLocation));
+      return *this;
    }
 
    /// If the operation was successful, returns a const reference to the inner type.
@@ -261,10 +261,10 @@ public:
    ~RResult() = default;
 
    /// Used by R__FORWARD_RESULT in order to keep track of the stack trace in case of errors
-   static RResult &Forward(RResult &result, RError::RLocation &&sourceLocation) {
-      if (result.fError)
-         result.fError->AddFrame(std::move(sourceLocation));
-      return result;
+   RResult &Forward(RError::RLocation &&sourceLocation) {
+      if (fError)
+         fError->AddFrame(std::move(sourceLocation));
+      return *this;
    }
 
    /// Short-hand method to throw an exception in the case of errors. Does nothing for
@@ -280,7 +280,7 @@ public:
 /// Short-hand to return an RResult<T> in an error state; the RError is implicitly converted into RResult<T>
 #define R__FAIL(msg) ROOT::Experimental::RError(msg, {R__LOG_PRETTY_FUNCTION, __FILE__, __LINE__})
 /// Short-hand to return an RResult<T> value from a subroutine to the calling stack frame
-#define R__FORWARD_RESULT(res) std::move(res.Forward(res, {R__LOG_PRETTY_FUNCTION, __FILE__, __LINE__}))
+#define R__FORWARD_RESULT(res) std::move(res.Forward({R__LOG_PRETTY_FUNCTION, __FILE__, __LINE__}))
 } // namespace Experimental
 } // namespace ROOT
 


### PR DESCRIPTION
For call chains where an inner function returns an `RResult` of a different template than the outer `RResult` return type, we cannot use `R__FORWARD_RESULT`.  Instead we need to test the inner type for an error state and can, in case of an error, use `return R__FORWARD_ERROR`.  Discussed in #5934.

The PR also comes with a minor simplification for `RResult<T>::Forward()`.