### PR TITLE
Revert "[To be reverted] Disable df026 because it requires pandas."

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -520,7 +520,6 @@ if(ROOT_pyroot_FOUND)
              sql/sqlfilldb.py       # same as the C++ case
              sql/sqlselect.py       # same as the C++ case
              launcher.py            # Not a tutorial
-             dataframe/df026_AsNumpyArrays.py    # Needs pandas. Should be activated once pandas on the build nodes.
              )
 
   if(pyroot_legacy)


### PR DESCRIPTION
PR to check the status of the build nodes wrt to pandas.

Related to the ticket https://sft.its.cern.ch/jira/browse/ROOT-10921