### PR TITLE
Add missing header TEveVector.h in Eve module

### DIFF
--- a/graf3d/eve/CMakeLists.txt
+++ b/graf3d/eve/CMakeLists.txt
@@ -37,6 +37,7 @@ set(EVE_HEADERS1
   TEveTransEditor.h
   TEveTreeTools.h
   TEveUtil.h
+  TEveVector.h
   TEveViewer.h
   TEveViewerListEditor.h
   TEveVSD.h


### PR DESCRIPTION
This commit adds the missing TEveVector.h header in the Eve module which causes the Modules build on Windows to fail.

@vgvassilev 