### PR TITLE
Fix libary path of modules for Windows

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1417,7 +1417,11 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       // ROOT usually knows better where its libraries are. This way we can
       // discover modules without having to should thisroot.sh and should fix
       // gnuinstall.
+#ifdef R__WIN32
+      Paths.push_back(TROOT::GetBinDir().Data());
+#else
       Paths.push_back(TROOT::GetLibDir().Data());
+#endif
       GetEnvVarPath("CLING_PREBUILT_MODULE_PATH", Paths);
       //GetEnvVarPath("LD_LIBRARY_PATH", Paths);
       std::string EnvVarPath;

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -526,7 +526,7 @@ namespace {
   static SmallVector<StringRef, 4> getPathsFromEnv(const char* EnvVar) {
     if (!EnvVar) return {};
     SmallVector<StringRef, 4> Paths;
-    StringRef(EnvVar).split(Paths, ':', -1, false);
+    StringRef(EnvVar).split(Paths, llvm::sys::EnvPathSeparator, -1, false);
     return Paths;
   }
 


### PR DESCRIPTION
This commit fixes the library path of modules in Windows by adding the Bin directory in the list of paths. Previously, ROOT by default assumes that modules are present in the Lib directory which is not the case for Windows.

@vgvassilev @bellenot 