### PR TITLE
[RF] Properly close polygons when drawing PDFs as surfaces.

### DIFF
--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -377,8 +377,9 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
 
   if (wmode==Extended) {
     // Add two points to make curve jump from 0 to yval at the left end of the plotting range.
-    // This ensures that filled polygons are drawn properly.
-    addPoint(xlo-dx*1.00000001,0) ;
+    // This ensures that filled polygons are drawn properly. The first point needs to be to the
+    // left of the second. Since points are sorted later, its x coordinate is shifted by 1/1000 dx.
+    addPoint(xlo-dx*1.001, 0);
     addPoint(xlo-dx,yval[0]) ;
   } else if (wmode==Straight) {
     addPoint(xlo,0) ;
@@ -407,8 +408,10 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
   addPoint(xhi,yval[minPoints-1]) ;
 
   if (wmode==Extended) {
+    // Add two points to close polygon. The order matters. Since they are sorted in x later, the second
+    // point is shifted by 1/1000 * dx.
     addPoint(xhi+dx,yval[minPoints-1]) ;
-    addPoint(xhi+dx,0) ;
+    addPoint(xhi+dx*1.001, 0);
   } else if (wmode==Straight) {
     addPoint(xhi,0) ;
   }


### PR DESCRIPTION
[ROOT-10931] Due to an unstable sorting algorithm, polygons sometimes
won't close, since the order of the outermost points is not preserved.
By moving those points by 1/1000 of the distance between points, they
now always close.