### PR TITLE
[RF] Properly close polygons when drawing PDFs as surfaces.

### DIFF
--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -378,7 +378,7 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
   if (wmode==Extended) {
     // Add two points to make curve jump from 0 to yval at the left end of the plotting range.
     // This ensures that filled polygons are drawn properly.
-    addPoint(xlo-dx*1.00000001,0) ;
+    addPoint(xlo-dx*1.001, 0);
     addPoint(xlo-dx,yval[0]) ;
   } else if (wmode==Straight) {
     addPoint(xlo,0) ;
@@ -408,7 +408,7 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
 
   if (wmode==Extended) {
     addPoint(xhi+dx,yval[minPoints-1]) ;
-    addPoint(xhi+dx,0) ;
+    addPoint(xhi+dx*1.001, 0);
   } else if (wmode==Straight) {
     addPoint(xhi,0) ;
   }


### PR DESCRIPTION
[ROOT-10931] Due to an unstable sorting algorithm, polygons sometimes
won't close, since the order of the outermost points is not preserved.
By moving those points by 1/1000 of the distance between points, they
now always close.