### PR TITLE
Fix handling the asymptotic single poisson constraint in the AsymptoticCalculator (ROOT-10920)

### DIFF
--- a/roofit/roostats/inc/RooStats/HybridCalculator.h
+++ b/roofit/roostats/inc/RooStats/HybridCalculator.h
@@ -41,35 +41,35 @@ namespace RooStats {
       }
 
       ~HybridCalculator() {
-         if(fPriorNuisanceNullExternal == false) delete fPriorNuisanceNull;
-         if(fPriorNuisanceAltExternal == false) delete fPriorNuisanceAlt;
+         if(!fPriorNuisanceNullExternal) delete fPriorNuisanceNull;
+         if(!fPriorNuisanceAltExternal) delete fPriorNuisanceAlt;
       }
 
 
       /// Override the distribution used for marginalizing nuisance parameters that is inferred from ModelConfig
       virtual void ForcePriorNuisanceNull(RooAbsPdf& priorNuisance) {
-         if(fPriorNuisanceNullExternal == false) delete fPriorNuisanceNull;
-         fPriorNuisanceNull = &priorNuisance; fPriorNuisanceNullExternal = true;
+         if(!fPriorNuisanceNullExternal) delete fPriorNuisanceNull;
+         fPriorNuisanceNull = &priorNuisance; 
+         fPriorNuisanceNullExternal = true;
       }
       virtual void ForcePriorNuisanceAlt(RooAbsPdf& priorNuisance) {
-         if(fPriorNuisanceAltExternal == false) delete fPriorNuisanceAlt;
-         fPriorNuisanceAlt = &priorNuisance; fPriorNuisanceAltExternal = true;
+         if(!fPriorNuisanceAltExternal) delete fPriorNuisanceAlt;
+         fPriorNuisanceAlt = &priorNuisance; 
+         fPriorNuisanceAltExternal = true;
       }
 
       virtual void SetNullModel(const ModelConfig &nullModel) {
          fNullModel = &nullModel;
-         if(fPriorNuisanceNullExternal == false) {
-            delete fPriorNuisanceNull;
-            fPriorNuisanceNull = MakeNuisancePdf(nullModel, "PriorNuisanceNull");
-         }
+         if(!fPriorNuisanceNullExternal) delete fPriorNuisanceNull;
+         fPriorNuisanceNull = MakeNuisancePdf(nullModel, "PriorNuisanceNull");
+         fPriorNuisanceAltExternal = false;
       }
 
       virtual void SetAlternateModel(const ModelConfig &altModel) {
          fAltModel = &altModel;
-         if(fPriorNuisanceAltExternal == false) {
-            delete fPriorNuisanceAlt;
-            fPriorNuisanceAlt = MakeNuisancePdf(altModel, "PriorNuisanceAlt");
-         }
+         if(!fPriorNuisanceAltExternal) delete fPriorNuisanceAlt;
+         fPriorNuisanceAlt = MakeNuisancePdf(altModel, "PriorNuisanceAlt");
+         fPriorNuisanceAltExternal = false; 
       }
 
       /// set number of toys

--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -122,9 +122,7 @@ namespace RooStats {
       if(constraints.getSize() == 0) {
          oocoutW((TObject *)0, Eval) << "RooStatsUtils::MakeNuisancePdf - no constraints found on nuisance parameters in the input model" << endl;
          return 0;
-      } else if(constraints.getSize() == 1) {
-         return dynamic_cast<RooAbsPdf *>(constraints.first()->clone(name));
-      }
+      } 
       return new RooProdPdf(name,"", constraints);
    }
 


### PR DESCRIPTION
Avoid cloning the pdf when creating a NuisancePdf in RooStats::MakeNuisancePdf.
Without the cloning then the call in the AsymptoticCalculator to setNoRounding(true) is effective.
This fixes ROOT-10920

Also apply a small fix when setting an external nuisance pdf in the RooStats HybridCalculator 