### PR TITLE
Backport in 6.22 of fix for ROOT-10920 in RooStats::AsymptoticCalculator 

### DIFF
--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -122,9 +122,7 @@ namespace RooStats {
       if(constraints.getSize() == 0) {
          oocoutW((TObject *)0, Eval) << "RooStatsUtils::MakeNuisancePdf - no constraints found on nuisance parameters in the input model" << endl;
          return 0;
-      } else if(constraints.getSize() == 1) {
-         return dynamic_cast<RooAbsPdf *>(constraints.first()->clone(name));
-      }
+      } 
       return new RooProdPdf(name,"", constraints);
    }
 


### PR DESCRIPTION
Avoid cloning the nuisance pdf single component. Make always a RooProdPdf of nuisances (constraints) also when there is a single term.

This avoid cloning the real pdf components and will fix the noRounding bug in the Poisson constraints happening in the AsymptoticCalculator (ROOT-10920)