### PR TITLE
[cmake] Append to include directories, do not overwrite them

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -462,7 +462,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
       # list(APPEND incdirs ${CMAKE_SOURCE_DIR})
       set(excludepaths ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
     elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/inc)
-      set(incdirs ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+      list(APPEND incdirs ${CMAKE_CURRENT_SOURCE_DIR}/inc)
     endif()
 
     foreach(dep ${ARG_DEPENDENCIES})


### PR DESCRIPTION
This fixes what was probably a typo in ROOT_GENERATE_DICTIONARY.

With this fix this CMakeLists is broken: https://github.com/root-project/rootbench/pull/161/files#diff-b605e888bcff10e766b8f07a585786ad , resulting in the following build error:

```
input_line_12:3:10: fatal error: 'inc/classes.h' file not found
#include "inc/classes.h"
         ^~~~~~~~~~~~~~~
Error: /home/eguiraud/ROOT/build_cxx17/bin/rootcling: compilation failure (/home/eguiraud/ROOT/build_rootbench/root/tree/dataframe/wmass/libSignalAnalysis81f7406343_dictUmbrella.h)
```