### PR TITLE
[PyROOT] Add workaround for frozen rootbrowse on MacOS

### DIFF
--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -16,6 +16,7 @@
 from contextlib import contextmanager
 import os
 import sys
+from time import sleep
 
 # Support both Python2 and Python3 at the same time
 if sys.version_info.major > 2 :
@@ -727,7 +728,13 @@ REPLACE_HELP = "replace object if already existing"
 
 def _openBrowser(rootFile=None):
     browser = ROOT.TBrowser()
-    _input("Press enter to exit.")
+    if ROOT.gSystem.InheritsFrom('TMacOSXSystem'):
+        print("Press ctrl+c to exit.")
+        while True:
+            ROOT.gSystem.ProcessEvents()
+            sleep(0.01)
+    else:
+        _input("Press enter to exit.")
 
 def rootBrowse(fileName=None):
     if fileName:

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -730,9 +730,12 @@ def _openBrowser(rootFile=None):
     browser = ROOT.TBrowser()
     if ROOT.gSystem.InheritsFrom('TMacOSXSystem'):
         print("Press ctrl+c to exit.")
-        while True:
-            ROOT.gSystem.ProcessEvents()
-            sleep(0.01)
+        try:
+            while True:
+                ROOT.gSystem.ProcessEvents()
+                sleep(0.01)
+        except (KeyboardInterrupt, SystemExit):
+            pass
     else:
         _input("Press enter to exit.")
 


### PR DESCRIPTION
Since MacOS blocks our second thread to update the GUI, rootbrowse will
run the event loop in the main thread if the underlying system is MacOS.

This is a hotfix for ROOT-10787, but a general fix to enable the GUI in
Python script mode is still missing.