### PR TITLE
Avoid auto-parsing for std::pair during I/O init.

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -834,7 +834,20 @@ void TClassEdit::GetNormalizedName(std::string &norm_name, std::string_view name
 
    // Remove the std:: and default template argument and insert the Long64_t and change basic_string to string.
    TClassEdit::TSplitType splitname(norm_name.c_str(),(TClassEdit::EModType)(TClassEdit::kLong64 | TClassEdit::kDropStd | TClassEdit::kDropStlDefault | TClassEdit::kKeepOuterConst));
-   splitname.ShortType(norm_name,TClassEdit::kDropStd | TClassEdit::kDropStlDefault | TClassEdit::kResolveTypedef | TClassEdit::kKeepOuterConst);
+   splitname.ShortType(norm_name, TClassEdit::kDropStd | TClassEdit::kDropStlDefault | TClassEdit::kResolveTypedef | TClassEdit::kKeepOuterConst);
+
+   if (splitname.fElements.empty() || splitname.fElements[0] == "std::pair" || splitname.fElements[0] == "pair") {
+      // We don't want to lookup the std::pair itself.
+      std::string first, second;
+      GetNormalizedName(first, splitname.fElements[1]);
+      GetNormalizedName(second, splitname.fElements[2]);
+      norm_name = "pair<" + first + "," + second;
+      if (!second.empty() && second.back() == '>')
+         norm_name += " >";
+      else
+         norm_name += ">";
+      return;
+   }
 
    // Depending on how the user typed their code, in particular typedef
    // declarations, we may end up with an explicit '::' being

--- a/io/io/src/TEmulatedCollectionProxy.cxx
+++ b/io/io/src/TEmulatedCollectionProxy.cxx
@@ -40,7 +40,7 @@ the class TEmulatedMapProxy.
 //
 
 static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const char *dmFull, Int_t offset);
-static TStreamerInfo *R__GenerateTClassForPair(const std::string &f, const std::string &s);
+TStreamerInfo *R__GenerateTClassForPair(const std::string &f, const std::string &s);
 
 TEmulatedCollectionProxy::TEmulatedCollectionProxy(const TEmulatedCollectionProxy& copy)
    : TGenCollectionProxy(copy)
@@ -670,7 +670,7 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const char
 }
 
 
-static TStreamerInfo *R__GenerateTClassForPair(const std::string &fname, const std::string &sname)
+TStreamerInfo *R__GenerateTClassForPair(const std::string &fname, const std::string &sname)
 {
    // Generate a TStreamerInfo for a std::pair<fname,sname>
    // This TStreamerInfo is then used as if it was read from a file to generate


### PR DESCRIPTION
Don't provoke auto-parsing during name normalization for the std::pair (but let it happen for its parameters if need be).

In TGenCollectionProxy Don't provoke autoparsing for an std::pair.

In TGenCollectionProxy handle the fact that we may now not find the std::pair.

Addresses (at least part of) ROOT-10932