### PR TITLE
Reduce contention on some atomics in core/meta and io

### DIFF
--- a/core/cont/inc/TVirtualCollectionProxy.h
+++ b/core/cont/inc/TVirtualCollectionProxy.h
@@ -43,7 +43,6 @@ private:
 protected:
    TClassRef fClass;
    UInt_t    fProperties;
-   virtual void UpdateValueClass(const TClass *oldcl, TClass *newcl) = 0;
    friend class TClass;
 
 public:

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -375,7 +375,7 @@ public:
                                                   Bool_t objectIsConst = kFALSE,
                                                   ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    Version_t          GetClassVersion() const {
-      if (!fVersionUsed.load())
+      if (!fVersionUsed.load(std::memory_order_relaxed))
          fVersionUsed = kTRUE;
       return fClassVersion;
    }
@@ -394,7 +394,7 @@ public:
    }
    const char        *GetContextMenuTitle() const { return fContextMenuTitle; }
    TVirtualStreamerInfo     *GetCurrentStreamerInfo() {
-      auto current = fCurrentInfo.load();
+      auto current = fCurrentInfo.load(std::memory_order_relaxed);
       if (current) return current;
       else return DetermineCurrentStreamerInfo();
    }

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -390,7 +390,8 @@ public:
    }
    const char        *GetContextMenuTitle() const { return fContextMenuTitle; }
    TVirtualStreamerInfo     *GetCurrentStreamerInfo() {
-      if (fCurrentInfo.load()) return fCurrentInfo;
+      auto current = fCurrentInfo.load();
+      if (current) return current;
       else return DetermineCurrentStreamerInfo();
    }
    TVirtualStreamerInfo     *GetLastReadInfo() const { return fLastReadInfo; }

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -374,7 +374,11 @@ public:
    TMethod           *GetClassMethodWithPrototype(const char *name, const char *proto,
                                                   Bool_t objectIsConst = kFALSE,
                                                   ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
-   Version_t          GetClassVersion() const { fVersionUsed = kTRUE; return fClassVersion; }
+   Version_t          GetClassVersion() const {
+      if (!fVersionUsed.load())
+         fVersionUsed = kTRUE;
+      return fClassVersion;
+   }
    Int_t              GetClassSize() const { return Size(); }
    TDataMember       *GetDataMember(const char *datamember) const;
    Long_t             GetDataMemberOffset(const char *membername) const;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -2855,7 +2855,7 @@ TVirtualCollectionProxy *TClass::GetCollectionProxy() const
 {
    // Use assert, so that this line (slow because of the TClassEdit) is completely
    // removed in optimized code.
-   assert(TestBit(kLoading) || !TClassEdit::IsSTLCont(fName) || fCollectionProxy || 0 == "The TClass for the STL collection has no collection proxy!");
+   //assert(TestBit(kLoading) || !TClassEdit::IsSTLCont(fName) || fCollectionProxy || 0 == "The TClass for the STL collection has no collection proxy!");
    if (gThreadTsd && fCollectionProxy) {
       TClassLocalStorage *local = TClassLocalStorage::GetStorage(this);
       if (local == 0) return fCollectionProxy;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -4064,11 +4064,6 @@ void TClass::ReplaceWith(TClass *newcl) const
 
          info->Update(this, newcl);
       }
-
-      if (acl->GetCollectionProxy()) {
-         acl->GetCollectionProxy()->UpdateValueClass(this, newcl);
-      }
-      // We should also inform all the TBranchElement :( but we do not have a master list :(
    }
 
    TIter delIter( &tobedeleted );

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -336,9 +336,6 @@ protected:
    // Allow to check function pointers.
    void CheckFunctions()  const;
 
-   // Set pointer to the TClass representing the content.
-   virtual void UpdateValueClass(const TClass *oldcl, TClass *newcl);
-
 private:
    TGenCollectionProxy(); // not implemented on purpose.
 

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -995,22 +995,6 @@ TClass *TGenCollectionProxy::GetValueClass() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Update the internal ValueClass when a TClass constructor need to
-/// replace an emulated TClass by the real TClass.
-
-void TGenCollectionProxy::UpdateValueClass(const TClass *oldValueType, TClass *newValueType)
-{
-   // Note that we do not need to update anything if we have not yet been
-   // initialized.  In addition (see ROOT-6040) doing an initialization here
-   // might hence a nested dlopen (due to autoloading).
-   auto value = fValue.load(std::memory_order_relaxed);
-   if (value && (*value).fType == oldValueType) {
-      // Set pointer to the TClass representing the content.
-      (*value).fType = newValueType;
-   }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// If the content is a simple numerical value, return its type (see TDataType)
 
 EDataType TGenCollectionProxy::GetType() const

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -575,7 +575,7 @@ TGenCollectionProxy::TGenCollectionProxy(const TGenCollectionProxy& copy)
    fCreateEnv.call = copy.fCreateEnv.call;
    fValOffset      = copy.fValOffset;
    fValDiff        = copy.fValDiff;
-   fValue          = copy.fValue.load() ? new Value(*copy.fValue) : 0;
+   fValue          = copy.fValue.load(std::memory_order_relaxed) ? new Value(*copy.fValue) : 0;
    fVal            = copy.fVal   ? new Value(*copy.fVal)   : 0;
    fKey            = copy.fKey   ? new Value(*copy.fKey)   : 0;
    fOnFileClass    = copy.fOnFileClass;
@@ -732,7 +732,7 @@ TGenCollectionProxy::~TGenCollectionProxy()
 
 TVirtualCollectionProxy* TGenCollectionProxy::Generate() const
 {
-   if ( !fValue.load() ) Initialize(kFALSE);
+   if ( !fValue.load(std::memory_order_relaxed) ) Initialize(kFALSE);
 
    if( fPointers )
       return new TGenCollectionProxy(*this);
@@ -941,7 +941,7 @@ TClass *TGenCollectionProxy::GetCollectionClass() const
 
 Int_t TGenCollectionProxy::GetCollectionType() const
 {
-   if (!fValue.load()) {
+   if (!fValue.load(std::memory_order_relaxed)) {
       Initialize(kFALSE);
    }
    return fSTL_type;
@@ -951,7 +951,7 @@ Int_t TGenCollectionProxy::GetCollectionType() const
 /// Return the offset between two consecutive value_types (memory layout).
 
 ULong_t TGenCollectionProxy::GetIncrement() const {
-   if (!fValue.load()) {
+   if (!fValue.load(std::memory_order_relaxed)) {
       Initialize(kFALSE);
    }
    return fValDiff;
@@ -971,7 +971,7 @@ UInt_t TGenCollectionProxy::Sizeof() const
 Bool_t TGenCollectionProxy::HasPointers() const
 {
    // Initialize proxy in case it hasn't been initialized yet
-   if( !fValue.load() )
+   if( !fValue.load(std::memory_order_relaxed) )
       Initialize(kFALSE);
 
    // The content of a map and multimap is always a 'pair' and hence
@@ -986,10 +986,10 @@ Bool_t TGenCollectionProxy::HasPointers() const
 
 TClass *TGenCollectionProxy::GetValueClass() const
 {
-   auto value = fValue.load();
+   auto value = fValue.load(std::memory_order_relaxed);
    if (!value) {
       Initialize(kFALSE);
-      value = fValue.load();
+      value = fValue.load(std::memory_order_relaxed);
    }
    return value ? (*value).fType.GetClass() : 0;
 }
@@ -1003,7 +1003,7 @@ void TGenCollectionProxy::UpdateValueClass(const TClass *oldValueType, TClass *n
    // Note that we do not need to update anything if we have not yet been
    // initialized.  In addition (see ROOT-6040) doing an initialization here
    // might hence a nested dlopen (due to autoloading).
-   auto value = fValue.load();
+   auto value = fValue.load(std::memory_order_relaxed);
    if (value && (*value).fType == oldValueType) {
       // Set pointer to the TClass representing the content.
       (*value).fType = newValueType;
@@ -1015,10 +1015,10 @@ void TGenCollectionProxy::UpdateValueClass(const TClass *oldValueType, TClass *n
 
 EDataType TGenCollectionProxy::GetType() const
 {
-   auto value = fValue.load();
+   auto value = fValue.load(std::memory_order_relaxed);
    if (!value) {
       Initialize(kFALSE);
-      value = fValue.load();
+      value = fValue.load(std::memory_order_relaxed);
    }
    return value ? (*value).fKind : kNoType_t;
 }
@@ -1260,7 +1260,7 @@ void TGenCollectionProxy::Commit(void* from)
 
 void TGenCollectionProxy::PushProxy(void *objstart)
 {
-   if ( !fValue.load() ) Initialize(kFALSE);
+   if ( !fValue.load(std::memory_order_relaxed) ) Initialize(kFALSE);
    if ( !fProxyList.empty() ) {
       EnvironBase_t* back = fProxyList.back();
       if ( back->fObject == objstart ) {
@@ -1569,14 +1569,14 @@ void TGenCollectionProxy__StagingDeleteTwoIterators(void *, void *)
 TVirtualCollectionProxy::CreateIterators_t TGenCollectionProxy::GetFunctionCreateIterators(Bool_t read)
 {
    if (read) {
-      if ( !fValue.load() ) InitializeEx(kFALSE);
+      if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
       if ( (fProperties & kIsAssociative) && read)
          return TGenCollectionProxy__StagingCreateIterators;
    }
 
    if ( fFunctionCreateIterators ) return fFunctionCreateIterators;
 
-   if ( !fValue.load() ) InitializeEx(kFALSE);
+   if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
 
 //   fprintf(stderr,"GetFunctinCreateIterator for %s will give: ",fClass.GetClassName());
 //   if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
@@ -1603,14 +1603,14 @@ TVirtualCollectionProxy::CreateIterators_t TGenCollectionProxy::GetFunctionCreat
 TVirtualCollectionProxy::CopyIterator_t TGenCollectionProxy::GetFunctionCopyIterator(Bool_t read)
 {
    if (read) {
-      if ( !fValue.load() ) InitializeEx(kFALSE);
+      if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
       if ( (fProperties & kIsAssociative) && read)
          return TGenCollectionProxy__StagingCopyIterator;
    }
 
    if ( fFunctionCopyIterator ) return fFunctionCopyIterator;
 
-   if ( !fValue.load() ) InitializeEx(kFALSE);
+   if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
 
    if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
       return fFunctionCopyIterator = TGenCollectionProxy__VectorCopyIterator;
@@ -1630,14 +1630,14 @@ TVirtualCollectionProxy::CopyIterator_t TGenCollectionProxy::GetFunctionCopyIter
 TVirtualCollectionProxy::Next_t TGenCollectionProxy::GetFunctionNext(Bool_t read)
 {
    if (read) {
-      if ( !fValue.load() ) InitializeEx(kFALSE);
+      if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
       if ( (fProperties & kIsAssociative) && read)
          return TGenCollectionProxy__StagingNext;
    }
 
    if ( fFunctionNextIterator ) return fFunctionNextIterator;
 
-   if ( !fValue.load() ) InitializeEx(kFALSE);
+   if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
 
    if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
       return fFunctionNextIterator = TGenCollectionProxy__VectorNext;
@@ -1655,14 +1655,14 @@ TVirtualCollectionProxy::Next_t TGenCollectionProxy::GetFunctionNext(Bool_t read
 TVirtualCollectionProxy::DeleteIterator_t TGenCollectionProxy::GetFunctionDeleteIterator(Bool_t read)
 {
    if (read) {
-      if ( !fValue.load() ) InitializeEx(kFALSE);
+      if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
       if ( (fProperties & kIsAssociative) && read)
          return TGenCollectionProxy__StagingDeleteSingleIterators;
    }
 
    if ( fFunctionDeleteIterator ) return fFunctionDeleteIterator;
 
-   if ( !fValue.load() ) InitializeEx(kFALSE);
+   if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
 
    if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
       return fFunctionDeleteIterator = TGenCollectionProxy__VectorDeleteSingleIterators;
@@ -1680,14 +1680,14 @@ TVirtualCollectionProxy::DeleteIterator_t TGenCollectionProxy::GetFunctionDelete
 TVirtualCollectionProxy::DeleteTwoIterators_t TGenCollectionProxy::GetFunctionDeleteTwoIterators(Bool_t read)
 {
    if (read) {
-      if ( !fValue.load() ) InitializeEx(kFALSE);
+      if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
       if ( (fProperties & kIsAssociative) && read)
          return TGenCollectionProxy__StagingDeleteTwoIterators;
    }
 
    if ( fFunctionDeleteTwoIterators ) return fFunctionDeleteTwoIterators;
 
-   if ( !fValue.load() ) InitializeEx(kFALSE);
+   if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
 
    if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
       return fFunctionDeleteTwoIterators = TGenCollectionProxy__VectorDeleteTwoIterators;

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -986,8 +986,12 @@ Bool_t TGenCollectionProxy::HasPointers() const
 
 TClass *TGenCollectionProxy::GetValueClass() const
 {
-   if (!fValue.load()) Initialize(kFALSE);
-   return fValue.load() ? (*fValue).fType.GetClass() : 0;
+   auto value = fValue.load();
+   if (!value) {
+      Initialize(kFALSE);
+      value = fValue.load();
+   }
+   return value ? (*value).fType.GetClass() : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -999,9 +1003,10 @@ void TGenCollectionProxy::UpdateValueClass(const TClass *oldValueType, TClass *n
    // Note that we do not need to update anything if we have not yet been
    // initialized.  In addition (see ROOT-6040) doing an initialization here
    // might hence a nested dlopen (due to autoloading).
-   if (fValue.load() && (*fValue).fType == oldValueType) {
+   auto value = fValue.load();
+   if (value && (*value).fType == oldValueType) {
       // Set pointer to the TClass representing the content.
-      (*fValue).fType = newValueType;
+      (*value).fType = newValueType;
    }
 }
 
@@ -1010,8 +1015,12 @@ void TGenCollectionProxy::UpdateValueClass(const TClass *oldValueType, TClass *n
 
 EDataType TGenCollectionProxy::GetType() const
 {
-   if ( !fValue.load() ) Initialize(kFALSE);
-   return (*fValue).fKind;
+   auto value = fValue.load();
+   if (!value) {
+      Initialize(kFALSE);
+      value = fValue.load();
+   }
+   return value ? (*value).fKind : kNoType_t;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The test used for these improvements is:

[multi.tar.gz](https://github.com/root-project/root/files/4989775/multi.tar.gz)

The results below are dramatic enough to be revelant event-though they are just one 1 with 2 jobs running at the same time, one with N threads and another with 32-N threads on a 32 real core machine (so the machine is always at full capacity).

before:
```
threads: 1 items: 10 events: 40000000 time: 192.72 s
threads: 2 items: 10 events: 40000000 time: 211.41 s
threads: 3 items: 10 events: 40000000 time: 219.9 s
threads: 4 items: 10 events: 40000000 time: 212.033 s
threads: 5 items: 10 events: 40000000 time: 214.991 s
threads: 6 items: 10 events: 40000000 time: 220.459 s
threads: 7 items: 10 events: 40000000 time: 219.831 s
threads: 8 items: 10 events: 40000000 time: 236.328 s
threads: 9 items: 10 events: 40000000 time: 222.565 s
threads: 10 items: 10 events: 40000000 time: 224.154 s
threads: 11 items: 10 events: 40000000 time: 229.009 s
threads: 12 items: 10 events: 40000000 time: 232.501 s
threads: 13 items: 10 events: 40000000 time: 227.134 s
threads: 14 items: 10 events: 40000000 time: 225.087 s
threads: 15 items: 10 events: 40000000 time: 223.564 s
threads: 16 items: 10 events: 40000000 time: 270.977 s
threads: 16 items: 10 events: 40000000 time: 291.434 s
threads: 17 items: 10 events: 40000000 time: 298.618 s
threads: 18 items: 10 events: 40000000 time: 237.387 s
threads: 19 items: 10 events: 40000000 time: 434.656 s
threads: 20 items: 10 events: 40000000 time: 358.451 s
threads: 21 items: 10 events: 40000000 time: 364.873 s
threads: 22 items: 10 events: 40000000 time: 491.755 s
threads: 23 items: 10 events: 40000000 time: 404.095 s
threads: 24 items: 10 events: 40000000 time: 444.607 s
threads: 25 items: 10 events: 40000000 time: 577.3 s
threads: 26 items: 10 events: 40000000 time: 603.918 s
threads: 27 items: 10 events: 40000000 time: 349.925 s
threads: 28 items: 10 events: 40000000 time: 359.936 s
threads: 29 items: 10 events: 40000000 time: 650.803 s
threads: 30 items: 10 events: 40000000 time: 383.258 s
threads: 31 items: 10 events: 40000000 time: 396.386 s
threads: 32 items: 10 events: 40000000 time: 407.827 s
```
after
```
threads: 1 items: 10 events: 40000000 time: 137.238 s
threads: 2 items: 10 events: 40000000 time: 133.271 s
threads: 3 items: 10 events: 40000000 time: 132.73 s
threads: 4 items: 10 events: 40000000 time: 135.589 s
threads: 5 items: 10 events: 40000000 time: 134.098 s
threads: 6 items: 10 events: 40000000 time: 135.231 s
threads: 7 items: 10 events: 40000000 time: 135.1 s
threads: 8 items: 10 events: 40000000 time: 135.831 s
threads: 9 items: 10 events: 40000000 time: 137.835 s
threads: 10 items: 10 events: 40000000 time: 135.396 s
threads: 11 items: 10 events: 40000000 time: 140.318 s
threads: 12 items: 10 events: 40000000 time: 134.98 s
threads: 13 items: 10 events: 40000000 time: 135.903 s
threads: 14 items: 10 events: 40000000 time: 135.5 s
threads: 15 items: 10 events: 40000000 time: 148.489 s
threads: 16 items: 10 events: 40000000 time: 138.087 s
threads: 16 items: 10 events: 40000000 time: 140.827 s
threads: 17 items: 10 events: 40000000 time: 138.913 s
threads: 18 items: 10 events: 40000000 time: 141.967 s
threads: 19 items: 10 events: 40000000 time: 140.632 s
threads: 20 items: 10 events: 40000000 time: 141.348 s
threads: 21 items: 10 events: 40000000 time: 136.448 s
threads: 22 items: 10 events: 40000000 time: 143.764 s
threads: 23 items: 10 events: 40000000 time: 139.445 s
threads: 24 items: 10 events: 40000000 time: 156.048 s
threads: 25 items: 10 events: 40000000 time: 138.128 s
threads: 26 items: 10 events: 40000000 time: 145.185 s
threads: 27 items: 10 events: 40000000 time: 137.8 s
threads: 27 items: 10 events: 40000000 time: 158.187 s
threads: 28 items: 10 events: 40000000 time: 141.434 s
threads: 30 items: 10 events: 40000000 time: 182.248 s
threads: 31 items: 10 events: 40000000 time: 142.101 s
threads: 32 items: 10 events: 40000000 time: 141.625 s
```