### PR TITLE
[PyROOT] Backport 6.22: Add TPyDispatcher for programming GUI callbacks in Python

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -77,6 +77,8 @@ set(cpp_sources
     src/PyzPythonHelpers.cxx
     src/CPPInstancePyz.cxx
     src/FacadeHelpers.cxx
+    src/TPyDispatcher.cxx
+    inc/TPyDispatcher.h
     ${PYROOT_EXTRA_SOURCE}
 )
 
@@ -104,7 +106,9 @@ foreach(val RANGE ${how_many_pythons})
     target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all Core Tree cppyy${python_under_version_string})
   endif()
 
-  target_include_directories(${libname} PRIVATE ${python_include_dir})
+  target_include_directories(${libname}
+     PRIVATE ${python_include_dir}
+     PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
 
   # Disables warnings caused by Py_RETURN_TRUE/Py_RETURN_FALSE
   if(NOT MSVC)

--- a/bindings/pyroot/pythonizations/inc/TPyDispatcher.h
+++ b/bindings/pyroot/pythonizations/inc/TPyDispatcher.h
@@ -1,0 +1,179 @@
+// Author: Enric Tejedor CERN  07/2020
+// Original PyROOT code by Wim Lavrijsen, LBL
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TPyDispatcher
+#define ROOT_TPyDispatcher
+
+//////////////////////////////////////////////////////////////////////////////
+//                                                                          //
+// TPyDispatcher                                                            //
+//                                                                          //
+// Dispatcher for C++ callbacks into Python code.                           //
+//                                                                          //
+//////////////////////////////////////////////////////////////////////////////
+
+// ROOT
+#include "TObject.h"
+
+class TDNDData;
+class TEveDigitSet;
+class TEveElement;
+class TEveTrack;
+class TEveWindow;
+class TGFrame;
+class TGListTreeItem;
+class TGMdiFrame;
+class TGLPhysicalShape;
+class TGShutterItem;
+class TGLVEntry;
+class TGLViewerBase;
+class TGVFileSplitter;
+class TList;
+class TObject;
+class TPad;
+class TProofProgressInfo;
+class TQCommand;
+class TSlave;
+class TSocket;
+class TVirtualPad;
+
+struct Event_t;
+
+// Python
+struct _object;
+typedef _object PyObject;
+
+class TPyDispatcher : public TObject {
+public:
+   TPyDispatcher(PyObject *callable);
+   TPyDispatcher(const TPyDispatcher &);
+   TPyDispatcher &operator=(const TPyDispatcher &);
+   ~TPyDispatcher();
+
+public:
+#ifndef __CINT__
+   PyObject *DispatchVA(const char *format = 0, ...);
+#else
+   PyObject *DispatchVA(const char *format, ...);
+#endif
+   PyObject *DispatchVA1(const char *clname, void *obj, const char *format, ...);
+
+   // pre-defined dispatches, same as per TQObject::Emit(); note that
+   // Emit() maps exclusively to this set, so several builtin types (e.g.
+   // Int_t, Bool_t, Float_t, etc.) have been omitted here
+   PyObject *Dispatch() { return DispatchVA(0); }
+   PyObject *Dispatch(const char *param) { return DispatchVA("s", param); }
+   PyObject *Dispatch(Double_t param) { return DispatchVA("d", param); }
+   PyObject *Dispatch(Long_t param) { return DispatchVA("l", param); }
+   PyObject *Dispatch(Long64_t param) { return DispatchVA("L", param); }
+
+   // further selection of pre-defined, existing dispatches
+   PyObject *Dispatch(Bool_t param) { return DispatchVA("i", param); }
+   PyObject *Dispatch(char *param) { return DispatchVA("s", param); }
+   PyObject *Dispatch(const char *text, Int_t len) { return DispatchVA("si", text, len); }
+   PyObject *Dispatch(Int_t param) { return DispatchVA("i", param); }
+   PyObject *Dispatch(Int_t x, Int_t y) { return DispatchVA("ii", x, y); }
+   PyObject *Dispatch(ULong_t param) { return DispatchVA("k", param); }
+   // ULong_t also for Handle_t (and Window_t, etc. ... )
+
+   PyObject *Dispatch(Event_t *event) { return DispatchVA1("Event_t", event, 0); }
+   PyObject *Dispatch(Event_t *event, ULong_t wid) { return DispatchVA1("Event_t", event, "k", wid); }
+   PyObject *Dispatch(TEveDigitSet *qs, Int_t idx) { return DispatchVA1("TEveDigitSet", qs, "i", idx); }
+   PyObject *Dispatch(TEveElement *el) { return DispatchVA1("TEveElement", el, 0); }
+   PyObject *Dispatch(TEveTrack *et) { return DispatchVA1("TEveTrack", et, 0); }
+   PyObject *Dispatch(TEveWindow *window) { return DispatchVA1("TEveWindow", window, 0); }
+   PyObject *Dispatch(TGFrame *frame) { return DispatchVA1("TGFrame", frame, 0); }
+   PyObject *Dispatch(TGFrame *frame, Int_t btn) { return DispatchVA1("TGFrame", frame, "i", btn); }
+   PyObject *Dispatch(TGFrame *frame, Int_t btn, Int_t x, Int_t y)
+   {
+      return DispatchVA1("TGFrame", frame, "iii", btn, x, y);
+   }
+   PyObject *Dispatch(TGFrame *frame, UInt_t keysym, UInt_t mask)
+   {
+      return DispatchVA1("TGFrame", frame, "II", keysym, mask);
+   }
+   PyObject *Dispatch(TGListTreeItem *entry) { return DispatchVA1("TGListTreeItem", entry, 0); }
+   PyObject *Dispatch(TGListTreeItem *entry, UInt_t mask) { return DispatchVA1("TGListTreeItem", entry, "I", mask); }
+   PyObject *Dispatch(TGListTreeItem *entry, UInt_t keysym, UInt_t mask)
+   {
+      return DispatchVA1("TGListTreeItem", entry, "II", keysym, mask);
+   }
+   PyObject *Dispatch(TGListTreeItem *entry, Int_t btn) { return DispatchVA1("TGListTreeItem", entry, "i", btn); }
+   PyObject *Dispatch(TGListTreeItem *entry, Int_t btn, Int_t x, Int_t y)
+   {
+      return DispatchVA1("TGListTreeItem", entry, "iii", btn, x, y);
+   }
+   PyObject *Dispatch(TGLVEntry *entry, Int_t btn) { return DispatchVA1("TGLVEntry", entry, "i", btn); }
+   PyObject *Dispatch(TGLVEntry *entry, Int_t btn, Int_t x, Int_t y)
+   {
+      return DispatchVA1("TGLVEntry", entry, "iii", btn, x, y);
+   }
+   PyObject *Dispatch(TGLViewerBase *viewer) { return DispatchVA1("TGLViewerBase", viewer, 0); }
+   PyObject *Dispatch(TGLPhysicalShape *shape) { return DispatchVA1("TGLPhysicalShape", shape, 0); }
+   PyObject *Dispatch(TGLPhysicalShape *shape, UInt_t u1, UInt_t u2)
+   {
+      return DispatchVA1("TGLPhysicalShape", shape, "II", u1, u2);
+   }
+   PyObject *Dispatch(TGMdiFrame *frame) { return DispatchVA1("TGMdiFrame", frame, 0); }
+   PyObject *Dispatch(TGShutterItem *item) { return DispatchVA1("TGShutterItem", item, 0); }
+   PyObject *Dispatch(TGVFileSplitter *frame) { return DispatchVA1("TGVFileSplitter", frame, 0); }
+   PyObject *Dispatch(TList *objs) { return DispatchVA1("TList", objs, 0); }
+   PyObject *Dispatch(TObject *obj) { return DispatchVA1("TObject", obj, 0); }
+   PyObject *Dispatch(TObject *obj, Bool_t check) { return DispatchVA1("TObject", obj, "i", check); }
+   PyObject *Dispatch(TObject *obj, UInt_t state) { return DispatchVA1("TObject", obj, "I", state); }
+   PyObject *Dispatch(TObject *obj, UInt_t button, UInt_t state)
+   {
+      return DispatchVA1("TObject", obj, "II", button, state);
+   }
+   PyObject *Dispatch(TSocket *sock) { return DispatchVA1("TSocket", sock, 0); }
+   PyObject *Dispatch(TVirtualPad *pad) { return DispatchVA1("TVirtualPad", pad, 0); }
+
+   PyObject *Dispatch(TPad *selpad, TObject *selected, Int_t event);
+   PyObject *Dispatch(Int_t event, Int_t x, Int_t y, TObject *selected);
+   PyObject *Dispatch(TVirtualPad *pad, TObject *obj, Int_t event);
+   PyObject *Dispatch(TGListTreeItem *item, TDNDData *data);
+   PyObject *Dispatch(const char *name, const TList *attr);
+
+   // for PROOF
+   PyObject *Dispatch(const char *msg, Bool_t all) { return DispatchVA("si", msg, all); }
+   PyObject *Dispatch(Long64_t total, Long64_t processed) { return DispatchVA("LL", total, processed); }
+   PyObject *Dispatch(Long64_t total, Long64_t processed, Long64_t bytesread, Float_t initTime, Float_t procTime,
+                      Float_t evtrti, Float_t mbrti)
+   {
+      return DispatchVA("LLLffff", total, processed, bytesread, initTime, procTime, evtrti, mbrti);
+   }
+   PyObject *Dispatch(Long64_t total, Long64_t processed, Long64_t bytesread, Float_t initTime, Float_t procTime,
+                      Float_t evtrti, Float_t mbrti, Int_t actw, Int_t tses, Float_t eses)
+   {
+      return DispatchVA("LLLffffiif", total, processed, bytesread, initTime, procTime, evtrti, mbrti, actw, tses, eses);
+   }
+   PyObject *Dispatch(const char *sel, Int_t sz, Long64_t fst, Long64_t ent)
+   {
+      return DispatchVA("siLL", sel, sz, fst, ent);
+   }
+   PyObject *Dispatch(const char *msg, Bool_t status, Int_t done, Int_t total)
+   {
+      return DispatchVA("siii", msg, status, done, total);
+   }
+
+   PyObject *Dispatch(TSlave *slave, Long64_t total, Long64_t processed)
+   {
+      return DispatchVA1("TSlave", slave, "LL", total, processed);
+   }
+   PyObject *Dispatch(TProofProgressInfo *pi) { return DispatchVA1("TProofProgressInfo", pi, 0); }
+   PyObject *Dispatch(TSlave *slave) { return DispatchVA("TSlave", slave, 0); }
+   PyObject *Dispatch(TSlave *slave, TProofProgressInfo *pi);
+
+private:
+   PyObject *fCallable; //! callable object to be dispatched
+};
+
+#endif

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -5,7 +5,7 @@ from functools import partial
 
 import libcppyy as cppyy_backend
 from cppyy import gbl as gbl_namespace
-from cppyy import cppdef
+from cppyy import cppdef, include, load_library
 from libROOTPythonizations import gROOT, CreateBufferFromAddress
 
 from ._application import PyROOTApplication
@@ -286,3 +286,13 @@ class ROOTFacade(types.ModuleType):
         ns.Declare = staticmethod(_NumbaDeclareDecorator)
         del type(self).Numba
         return ns
+
+    # Get TPyDispatcher for programming GUI callbacks
+    @property
+    def TPyDispatcher(self):
+        include('ROOT/TPyDispatcher.h')
+        major, minor = sys.version_info[0:2]
+        load_library('libROOTPythonizations{}_{}'.format(major, minor))
+        tpd = gbl_namespace.TPyDispatcher
+        type(self).TPyDispatcher = tpd
+        return tpd

--- a/bindings/pyroot/pythonizations/src/TPyDispatcher.cxx
+++ b/bindings/pyroot/pythonizations/src/TPyDispatcher.cxx
@@ -1,0 +1,285 @@
+// Author: Enric Tejedor CERN  07/2020
+// Original PyROOT code by Wim Lavrijsen, LBL
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+// Bindings
+#include "CPyCppyy.h"
+#include "TPyDispatcher.h"
+#include "ProxyWrappers.h"
+
+// ROOT
+#include "TClass.h"
+#include "TObject.h"
+
+// Standard
+#include <stdarg.h>
+
+//______________________________________________________________________________
+//                         Python callback dispatcher
+//                         ==========================
+//
+// The TPyDispatcher class acts as a functor that can be used for TFn's and GUIs
+// to install callbacks from CINT.
+
+//- constructors/destructor --------------------------------------------------
+TPyDispatcher::TPyDispatcher(PyObject *callable) : fCallable(0)
+{
+   // Construct a TPyDispatcher from a callable python object. Applies python
+   // object reference counting.
+   Py_XINCREF(callable);
+   fCallable = callable;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Copy constructor. Applies python object reference counting.
+
+TPyDispatcher::TPyDispatcher(const TPyDispatcher &other) : TObject(other)
+{
+   Py_XINCREF(other.fCallable);
+   fCallable = other.fCallable;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Assignment operator. Applies python object reference counting.
+
+TPyDispatcher &TPyDispatcher::operator=(const TPyDispatcher &other)
+{
+   if (this != &other) {
+      this->TObject::operator=(other);
+
+      Py_XDECREF(fCallable);
+      Py_XINCREF(other.fCallable);
+      fCallable = other.fCallable;
+   }
+
+   return *this;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Destructor. Reference counting for the held python object is in effect.
+
+TPyDispatcher::~TPyDispatcher()
+{
+   Py_XDECREF(fCallable);
+}
+
+//- public members -----------------------------------------------------------
+PyObject *TPyDispatcher::DispatchVA(const char *format, ...)
+{
+   // Dispatch the arguments to the held callable python object, using format to
+   // interpret the types of the arguments. Note that format is in python style,
+   // not in C printf style. See: https://docs.python.org/2/c-api/arg.html .
+   PyObject *args = 0;
+
+   if (format) {
+      va_list va;
+      va_start(va, format);
+
+      args = Py_VaBuildValue((char *)format, va);
+
+      va_end(va);
+
+      if (!args) {
+         PyErr_Print();
+         return 0;
+      }
+
+      if (!PyTuple_Check(args)) { // if only one arg ...
+         PyObject *t = PyTuple_New(1);
+         PyTuple_SET_ITEM(t, 0, args);
+         args = t;
+      }
+   }
+
+   PyObject *result = PyObject_CallObject(fCallable, args);
+   Py_XDECREF(args);
+
+   if (!result) {
+      PyErr_Print();
+      return 0;
+   }
+
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+PyObject *TPyDispatcher::DispatchVA1(const char *clname, void *obj, const char *format, ...)
+{
+   PyObject *pyobj = CPyCppyy::BindCppObject(obj, Cppyy::GetScope(clname), kFALSE /* isRef */);
+   if (!pyobj) {
+      PyErr_Print();
+      return 0;
+   }
+
+   PyObject *args = 0;
+
+   if (format) {
+      va_list va;
+      va_start(va, format);
+
+      args = Py_VaBuildValue((char *)format, va);
+
+      va_end(va);
+
+      if (!args) {
+         PyErr_Print();
+         return 0;
+      }
+
+      if (!PyTuple_Check(args)) { // if only one arg ...
+         PyObject *t = PyTuple_New(2);
+         PyTuple_SET_ITEM(t, 0, pyobj);
+         PyTuple_SET_ITEM(t, 1, args);
+         args = t;
+      } else {
+         PyObject *t = PyTuple_New(PyTuple_GET_SIZE(args) + 1);
+         PyTuple_SET_ITEM(t, 0, pyobj);
+         for (int i = 0; i < PyTuple_GET_SIZE(args); i++) {
+            PyObject *item = PyTuple_GET_ITEM(args, i);
+            Py_INCREF(item);
+            PyTuple_SET_ITEM(t, i + 1, item);
+         }
+         Py_DECREF(args);
+         args = t;
+      }
+   } else {
+      args = PyTuple_New(1);
+      PyTuple_SET_ITEM(args, 0, pyobj);
+   }
+
+   PyObject *result = PyObject_CallObject(fCallable, args);
+   Py_XDECREF(args);
+
+   if (!result) {
+      PyErr_Print();
+      return 0;
+   }
+
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+PyObject *TPyDispatcher::Dispatch(TPad *selpad, TObject *selected, Int_t event)
+{
+   PyObject *args = PyTuple_New(3);
+   PyTuple_SET_ITEM(args, 0, CPyCppyy::BindCppObject(selpad, Cppyy::GetScope("TPad")));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject(selected, Cppyy::GetScope("TObject")));
+   PyTuple_SET_ITEM(args, 2, PyInt_FromLong(event));
+
+   PyObject *result = PyObject_CallObject(fCallable, args);
+   Py_XDECREF(args);
+
+   if (!result) {
+      PyErr_Print();
+      return 0;
+   }
+
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+PyObject *TPyDispatcher::Dispatch(Int_t event, Int_t x, Int_t y, TObject *selected)
+{
+   PyObject *args = PyTuple_New(4);
+   PyTuple_SET_ITEM(args, 0, PyInt_FromLong(event));
+   PyTuple_SET_ITEM(args, 1, PyInt_FromLong(x));
+   PyTuple_SET_ITEM(args, 2, PyInt_FromLong(y));
+   PyTuple_SET_ITEM(args, 3, CPyCppyy::BindCppObject(selected, Cppyy::GetScope("TObject")));
+
+   PyObject *result = PyObject_CallObject(fCallable, args);
+   Py_XDECREF(args);
+
+   if (!result) {
+      PyErr_Print();
+      return 0;
+   }
+
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+PyObject *TPyDispatcher::Dispatch(TVirtualPad *pad, TObject *obj, Int_t event)
+{
+   PyObject *args = PyTuple_New(3);
+   PyTuple_SET_ITEM(args, 0, CPyCppyy::BindCppObject(pad, Cppyy::GetScope("TVirtualPad")));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject(obj, Cppyy::GetScope("TObject")));
+   PyTuple_SET_ITEM(args, 2, PyInt_FromLong(event));
+
+   PyObject *result = PyObject_CallObject(fCallable, args);
+   Py_XDECREF(args);
+
+   if (!result) {
+      PyErr_Print();
+      return 0;
+   }
+
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+PyObject *TPyDispatcher::Dispatch(TGListTreeItem *item, TDNDData *data)
+{
+   PyObject *args = PyTuple_New(2);
+   PyTuple_SET_ITEM(args, 0, CPyCppyy::BindCppObject(item, Cppyy::GetScope("TGListTreeItem")));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject(data, Cppyy::GetScope("TDNDData")));
+
+   PyObject *result = PyObject_CallObject(fCallable, args);
+   Py_XDECREF(args);
+
+   if (!result) {
+      PyErr_Print();
+      return 0;
+   }
+
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+PyObject *TPyDispatcher::Dispatch(const char *name, const TList *attr)
+{
+   PyObject *args = PyTuple_New(2);
+   PyTuple_SET_ITEM(args, 0, PyBytes_FromString(name));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject((void *)attr, Cppyy::GetScope("TList")));
+
+   PyObject *result = PyObject_CallObject(fCallable, args);
+   Py_XDECREF(args);
+
+   if (!result) {
+      PyErr_Print();
+      return 0;
+   }
+
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+PyObject *TPyDispatcher::Dispatch(TSlave *slave, TProofProgressInfo *pi)
+{
+   PyObject *args = PyTuple_New(2);
+   PyTuple_SET_ITEM(args, 0, CPyCppyy::BindCppObject(slave, Cppyy::GetScope("TSlave")));
+   PyTuple_SET_ITEM(args, 1, CPyCppyy::BindCppObject(pi, Cppyy::GetScope("TProofProgressInfo")));
+
+   PyObject *result = PyObject_CallObject(fCallable, args);
+   Py_XDECREF(args);
+
+   if (!result) {
+      PyErr_Print();
+      return 0;
+   }
+
+   return result;
+}


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/6055

Same as for the PR in master, if a better solution can be implemented using the automatic C++ wrappers of cppyy (work started by @vepadulano ), the changes in this PR will not be necessary anymore.
