### PR TITLE
[PyROOT][Docs] Parse documentation in pythonization .py files

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tarray.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tarray.py
@@ -8,6 +8,43 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
+r'''
+/**
+\class TArray
+\brief \parblock \endparblock
+\htmlonly
+<div class="pyrootbox">
+\endhtmlonly
+## PyROOT
+
+When used from Python, the subclasses of TArray (TArrayC, TArrayS, TArrayI, TArrayL, TArrayF and TArrayD) benefit from the following extra features:
+
+- Their size can be obtained with `len`, which is equivalent to TArray::GetSize():
+\code{.py}
+import ROOT
+
+a = ROOT.TArrayD(2)
+print(len(a)) # prints '2'
+\endcode
+
+- Their elements can be read and written with the `getitem` and `setitem` operators, respectively:
+\code{.py}
+a[0] = 0.2
+a[1] = 1.7
+print(a[0]) # prints '0.2'
+\endcode
+
+- They are iterable:
+\code{.py}
+for elem in a:
+    print(elem)
+\endcode
+\htmlonly
+</div>
+\endhtmlonly
+*/
+'''
+
 from ROOT import pythonization
 
 from ._generic import _add_getitem_checked

--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -293,7 +293,8 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # the files are not read by doxygen.
 
 EXTENSION_MAPPING      = h=C++ \
-                         icc=C++
+                         icc=C++ \
+                         pyzdoc=C++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -936,7 +937,8 @@ FILE_PATTERNS          = *.c \
                          *.ucf \
                          *.qsf \
                          *.as \
-                         *.js
+                         *.js \
+                         *.pyzdoc
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -16,11 +16,13 @@ export DOXYGEN_NOTEBOOK_PATH := $(DOXYGEN_OUTPUT_DIRECTORY)/notebooks
 export DOXYGEN_STRIP_PATH := $(shell cd $(PWD)/../..; pwd)
 export DOXYGEN_INCLUDE_PATH := $(shell find $(DOXYGEN_STRIP_PATH) -type d -name dictpch -prune -o -type d -name inc)
 
+PYZ_DIR = ../../bindings/pyroot/pythonizations/python/ROOT/pythonization
+
 define MkDir
 	+@[ -d $1 ] || mkdir -p $1
 endef
 
-all: filter folders mathjax images doxygen
+all: filter folders mathjax images pyzdoc doxygen
 
 filter:
 	`root-config --cxx` -o filter filter.cxx -std=c++11
@@ -33,7 +35,10 @@ images:
 	$(call MkDir,$(DOXYGEN_IMAGE_PATH))
 	cp images/* $(DOXYGEN_IMAGE_PATH)
 
-doxygen: filter
+pyzdoc:
+	$(PYTHON_EXECUTABLE) extract_docstrings.py $(PYZ_DIR)
+
+doxygen: filter pyzdoc
 	$(call MkDir,$(DOXYGEN_OUTPUT_DIRECTORY))
 	$(call MkDir,$(DOXYGEN_EXAMPLE_PATH))
 	$(call MkDir,$(DOXYGEN_NOTEBOOK_PATH))
@@ -44,5 +49,5 @@ doxygen: filter
 	rm -f $(DOXYGEN_NOTEBOOK_PATH)/*.root
 
 clean:
-	rm -r $(DOXYGEN_OUTPUT_DIRECTORY) filter htmlfooter.html dataset*
+	rm -r $(DOXYGEN_OUTPUT_DIRECTORY) filter htmlfooter.html dataset* $(PYZ_DIR)/*.pyzdoc
 

--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -22,7 +22,7 @@ define MkDir
 	+@[ -d $1 ] || mkdir -p $1
 endef
 
-all: filter folders mathjax images pyzdoc doxygen
+all: filter folders mathjax images doxygen
 
 filter:
 	`root-config --cxx` -o filter filter.cxx -std=c++11
@@ -50,4 +50,3 @@ doxygen: filter pyzdoc
 
 clean:
 	rm -r $(DOXYGEN_OUTPUT_DIRECTORY) filter htmlfooter.html dataset* $(PYZ_DIR)/*.pyzdoc
-

--- a/documentation/doxygen/ROOT.css
+++ b/documentation/doxygen/ROOT.css
@@ -17,3 +17,9 @@ div.contents {
   top:0;
   width:1px;
 }
+
+.pyrootbox {
+  border: 1px solid #879ecb;
+  background-color: #f9fafc;
+  padding: 15px;
+}

--- a/documentation/doxygen/extract_docstrings.py
+++ b/documentation/doxygen/extract_docstrings.py
@@ -1,0 +1,44 @@
+#-------------------------------------------------------------------------------
+#  Author: Enric Tejedor <enric.tejedor.saavedra@cern.ch> CERN
+#-------------------------------------------------------------------------------
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+# Code that extracts the docstrings from pythonization files and stores them
+# in .pyzdoc files, so that doxygen can process them later to merge the
+# documentation they contain with that of C++ files
+
+import ast
+import sys
+from os import path, walk
+
+if len(sys.argv) < 2:
+    print("Please provide the directory where documented .py files are.")
+    exit(1)
+
+pyz_dir = sys.argv[1]
+
+(_, _, filenames) = next(walk(pyz_dir))
+
+# Iterate over pythonization files
+for pyz_file in filenames:
+    if not pyz_file.endswith('.py'):
+        continue
+
+    pyz_file_path = pyz_dir + path.sep + pyz_file
+    with open(pyz_file_path) as fd:
+        file_contents = fd.read()
+
+    # Docs for pythonizations are provided as a module-level docstring
+    module = ast.parse(file_contents)
+    ds = ast.get_docstring(module)
+    if ds is not None:
+        with open(pyz_file_path + '.pyzdoc', 'w') as pyz_doc_file:
+            pyz_doc_file.write(ds)
+


### PR DESCRIPTION
[skip-ci]

This PR introduces the parsing of documentation to be included in the reference guide for PyROOT pythonizations of ROOT classes.

It makes the necessary settings to activate the parsing of C++-like docs in Python files and adds the first example of such docs: the pythonizations of `TArray` and its subclasses.

The PyROOT docs are enclosed in a box that is placed after the documentation of the C++ files. The style of that box has been defined to match the style of the docs page (background and border):

![image](https://user-images.githubusercontent.com/8089558/88268039-0d815680-ccd2-11ea-9223-b2c8cccf6be2.png)
