### PR TITLE
[Tree] Add regression test for the issue described in ROOT-10942

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6023,7 +6023,9 @@ TLeaf* TTree::GetLeafImpl(const char* branchname, const char *leafname)
             if (mother != br) {
                const char *mothername = mother->GetName();
                UInt_t motherlen = strlen(mothername);
-               if (nbch > motherlen && strncmp(mothername,branchname,motherlen)==0 && (mothername[motherlen-1]=='.' || branchname[motherlen]=='.')) {
+               if (!strcmp(mothername, branchname)) {
+                  return leaf;
+               } else if (nbch > motherlen && strncmp(mothername,branchname,motherlen)==0 && (mothername[motherlen-1]=='.' || branchname[motherlen]=='.')) {
                   // The left part of the requested name match the name of the mother, let's see if the right part match the name of the branch.
                   if (strncmp(brname,branchname+motherlen+1,nbch-motherlen-1)) {
                      // No it does not

--- a/tree/tree/test/TTreeRegressions.cxx
+++ b/tree/tree/test/TTreeRegressions.cxx
@@ -1,4 +1,5 @@
 #include "TMemFile.h"
+#include "TLeaf.h"
 #include "TTree.h"
 #include "TInterpreter.h"
 
@@ -41,4 +42,24 @@ TEST(TTreeRegressions, CompositeTypeWithNameClash)
    gInterpreter->ProcessLine(toJit2.c_str());
    t.GetEntry(0);
    EXPECT_EQ(ix, -1);
+}
+
+// ROOT-10942
+struct SimpleStruct {
+   double a;
+   double b;
+};
+
+TEST(TTreeRegressions, GetLeafByFullName)
+{
+   gInterpreter->Declare("struct SimpleStruct { double a; double b; };");
+   SimpleStruct c;
+   TTree t("t1", "t1");
+   t.Branch("c", &c);
+   t.Fill();
+
+   EXPECT_TRUE(t.GetLeaf("a") != nullptr);
+   EXPECT_TRUE(t.GetLeaf("c.a") != nullptr);
+   EXPECT_TRUE(t.GetLeaf("c", "a") != nullptr);
+   EXPECT_TRUE(t.GetLeaf(t.GetLeaf("a")->GetFullName()) != nullptr);
 }


### PR DESCRIPTION
i.e. t.GetLeaf(t.GetLeaf("a")->GetFullName()) == nullptr in some cases.