### PR TITLE
[DF] Add all spellings of a branch name to valid column names 

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -97,12 +97,11 @@ static void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnName
 
       ExploreBranch(t, bNamesReg, bNames, subBranch, newPrefix, friendName);
 
-      if (t.GetBranch(fullName.c_str()) || t.FindBranch(fullName.c_str())) {
+      if (t.GetBranch(fullName.c_str()) || t.FindBranch(fullName.c_str()))
          UpdateList(bNamesReg, bNames, fullName, friendName);
 
-      } else if (t.GetBranch(subBranchName.c_str())) {
+      if (t.GetBranch(subBranchName.c_str()))
          UpdateList(bNamesReg, bNames, subBranchName, friendName);
-      }
    }
 }
 

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -423,3 +423,19 @@ TEST(RDataFrameInterface, TypeUnknownToInterpreter)
       df.Filter("res; return true;"),
       ss.str().c_str());
 }
+
+// ROOT-10942
+TEST(RDataFrameInterface, GetColumnNamesWithSimpleStruct)
+{
+   gInterpreter->Declare("struct S { int a; int b; };");
+   S c;
+   c.a = 1;
+   c.b = 2;
+   TTree t("t", "t");
+   t.Branch("c", &c);
+   t.Fill();
+
+   ROOT::RDataFrame df(t);
+   const std::vector<std::string> expected({ "c.a", "a", "c.b", "b", "c" });
+   EXPECT_EQ(df.GetColumnNames(), expected);
+}


### PR DESCRIPTION
Before this patch, in cases in which t.GetBranch("a.b") and
t.GetBranch("b") both returned a valid address, RDataFrame was adding
only "a.b" to the list of valid TTree columns.
With this patch, both "a.b" and "b" are recognized as valid column names.

We need this change in behavior to avoid a _worse_ change in behavior,
described in detail in ROOT-10942: since ROOT-10702 was fixed,
TTree::GetBranch became more powerful and started returning non-null
addresses for branch names with form "a.b" while it was returning a
nullptr until v6.20/06. With RDataFrame's previous logic, this in turn
meant that valid code that was using "a" as a column broke as RDataFrame
was now adding the "a.b" spelling to the list of valid columns instead.

This fixes the RDF-related part of ROOT-10942: "a" is recognized as a
valid spelling again, and "a.b" is kept as a new valid spelling.