### PR TITLE
[io] combine merge handling cases for TObjects

### DIFF
--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -611,7 +611,6 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
             } else if (cl->IsTObject()) {
                if (alreadyseen) continue;
 
-               bool mergeableTObject = true;
                // try synthesizing the Merge method call according to the TObject
                TList listH;
                TString listHargs;
@@ -621,10 +620,10 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                } else if (cl->GetMethodWithPrototype("Merge", "TCollection*")) {
                   listHargs.Form("((TCollection*)0x%lx)", (ULong_t)&listH);
                } else {
-                  // do nothing and pass unmergeable objects through to the output file
-                  mergeableTObject = false;
+                  // pass unmergeable objects through to the output file
+                  canBeMerged = kFALSE;
                }
-               if (mergeableTObject) {
+               if (canBeMerged) {
                   // Loop over all source files and merge same-name object
                   TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
                   if (nextsource == 0) {

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -609,8 +609,6 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                   }
                }
             } else if (cl->IsTObject()) {
-               if (alreadyseen) continue;
-
                // try synthesizing the Merge method call according to the TObject
                TList listH;
                TString listHargs;
@@ -624,6 +622,10 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                   canBeMerged = kFALSE;
                }
                if (canBeMerged) {
+                  if (alreadyseen) {
+                     // skip already seen mergeable objects, don't skip unmergeable objects
+                     continue;
+                  }
                   // Loop over all source files and merge same-name object
                   TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
                   if (nextsource == 0) {

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -608,7 +608,10 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                      inputs.Delete();
                   }
                }
-            } else if (cl->IsTObject()) {
+            } else if (cl->IsTObject()
+                  && (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*")
+                      || cl->GetMethodWithPrototype("Merge", "TCollection*"))) {
+
                if (alreadyseen) continue;
 
                // synthesize a method call according to the TObject
@@ -617,15 +620,9 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                if (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*")) {
                   listHargs.Form("(TCollection*)0x%lx,(TFileMergeInfo*)0x%lx",
                                   (ULong_t)&listH, (ULong_t)&info);
-               } else if (cl->GetMethodWithPrototype("Merge", "TCollection*")) {
-                  listHargs.Form("((TCollection*)0x%lx)", (ULong_t)&listH);
                } else {
-                  // skip any unhandled TObjects
-                  Info("MergeRecursive", "skipping TObject without Merge method with type (%s), name: %s title: %s",
-                        key->GetClassName(), key->GetName(), key->GetTitle());
-                  continue;
+                  listHargs.Form("((TCollection*)0x%lx)", (ULong_t)&listH);
                }
-
                // Loop over all source files and merge same-name object
                TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
                if (nextsource == 0) {

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -608,71 +608,74 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                      inputs.Delete();
                   }
                }
-            } else if (cl->IsTObject()
-                  && (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*")
-                      || cl->GetMethodWithPrototype("Merge", "TCollection*"))) {
-
+            } else if (cl->IsTObject()) {
                if (alreadyseen) continue;
 
-               // synthesize a method call according to the TObject
+               bool mergeableTObject = true;
+               // try synthesizing the Merge method call according to the TObject
                TList listH;
                TString listHargs;
                if (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*")) {
                   listHargs.Form("(TCollection*)0x%lx,(TFileMergeInfo*)0x%lx",
                                   (ULong_t)&listH, (ULong_t)&info);
-               } else {
+               } else if (cl->GetMethodWithPrototype("Merge", "TCollection*")) {
                   listHargs.Form("((TCollection*)0x%lx)", (ULong_t)&listH);
-               }
-               // Loop over all source files and merge same-name object
-               TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
-               if (nextsource == 0) {
-                  // There is only one file in the list
-                  Int_t error = 0;
-                  obj->Execute("Merge", listHargs.Data(), &error);
-                  info.fIsFirst = kFALSE;
-                  if (error) {
-                     Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
-                           obj->GetName(), key->GetName());
-                  }
                } else {
-                  while (nextsource) {
-                     // make sure we are at the correct directory level by cd'ing to path
-                     TDirectory *ndir = nextsource->GetDirectory(path);
-                     if (ndir) {
-                        ndir->cd();
-                        TKey *key2 = (TKey*)ndir->GetListOfKeys()->FindObject(key->GetName());
-                        if (key2) {
-                           TObject *hobj = key2->ReadObj();
-                           if (!hobj) {
-                              Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
-                                   key->GetName(), key->GetTitle(), nextsource->GetName());
-                              nextsource = (TFile*)sourcelist->After(nextsource);
-                              continue;
-                           }
-                           // Set ownership for collections
-                           if (hobj->InheritsFrom(TCollection::Class())) {
-                              ((TCollection*)hobj)->SetOwner();
-                           }
-                           hobj->ResetBit(kMustCleanup);
-                           listH.Add(hobj);
-                           Int_t error = 0;
-                           obj->Execute("Merge", listHargs.Data(), &error);
-                           info.fIsFirst = kFALSE;
-                           if (error) {
-                              Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
-                                    obj->GetName(), nextsource->GetName());
-                           }
-                           listH.Delete();
-                        }
-                     }
-                     nextsource = (TFile*)sourcelist->After( nextsource );
-                  }
-                  // Merge the list, if still to be done
-                  if (info.fIsFirst) {
+                  // do nothing and pass unmergeable objects through to the output file
+                  mergeableTObject = false;
+               }
+               if (mergeableTObject) {
+                  // Loop over all source files and merge same-name object
+                  TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
+                  if (nextsource == 0) {
+                     // There is only one file in the list
                      Int_t error = 0;
                      obj->Execute("Merge", listHargs.Data(), &error);
                      info.fIsFirst = kFALSE;
-                     listH.Delete();
+                     if (error) {
+                        Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
+                              obj->GetName(), key->GetName());
+                     }
+                  } else {
+                     while (nextsource) {
+                        // make sure we are at the correct directory level by cd'ing to path
+                        TDirectory *ndir = nextsource->GetDirectory(path);
+                        if (ndir) {
+                           ndir->cd();
+                           TKey *key2 = (TKey*)ndir->GetListOfKeys()->FindObject(key->GetName());
+                           if (key2) {
+                              TObject *hobj = key2->ReadObj();
+                              if (!hobj) {
+                                 Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
+                                      key->GetName(), key->GetTitle(), nextsource->GetName());
+                                 nextsource = (TFile*)sourcelist->After(nextsource);
+                                 continue;
+                              }
+                              // Set ownership for collections
+                              if (hobj->InheritsFrom(TCollection::Class())) {
+                                 ((TCollection*)hobj)->SetOwner();
+                              }
+                              hobj->ResetBit(kMustCleanup);
+                              listH.Add(hobj);
+                              Int_t error = 0;
+                              obj->Execute("Merge", listHargs.Data(), &error);
+                              info.fIsFirst = kFALSE;
+                              if (error) {
+                                 Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
+                                       obj->GetName(), nextsource->GetName());
+                              }
+                              listH.Delete();
+                           }
+                        }
+                        nextsource = (TFile*)sourcelist->After( nextsource );
+                     }
+                     // Merge the list, if still to be done
+                     if (info.fIsFirst) {
+                        Int_t error = 0;
+                        obj->Execute("Merge", listHargs.Data(), &error);
+                        info.fIsFirst = kFALSE;
+                        listH.Delete();
+                     }
                   }
                }
             } else {

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -608,16 +608,23 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                      inputs.Delete();
                   }
                }
-            } else if (cl->IsTObject() &&
-                       cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*") ) {
-               // Object implements Merge(TCollection*,TFileMergeInfo*) and has a reflex dictionary ...
-
-               // Check if already treated
+            } else if (cl->IsTObject()) {
                if (alreadyseen) continue;
 
+               // synthesize a method call according to the TObject
                TList listH;
                TString listHargs;
-               listHargs.Form("(TCollection*)0x%lx,(TFileMergeInfo*)0x%lx", (ULong_t)&listH,(ULong_t)&info);
+               if (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*")) {
+                  listHargs.Form("(TCollection*)0x%lx,(TFileMergeInfo*)0x%lx",
+                                  (ULong_t)&listH, (ULong_t)&info);
+               } else if (cl->GetMethodWithPrototype("Merge", "TCollection*")) {
+                  listHargs.Form("((TCollection*)0x%lx)", (ULong_t)&listH);
+               } else {
+                  // skip any unhandled TObjects
+                  Info("MergeRecursive", "skipping TObject without Merge method with type (%s), name: %s title: %s",
+                        key->GetClassName(), key->GetName(), key->GetTitle());
+                  continue;
+               }
 
                // Loop over all source files and merge same-name object
                TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
@@ -635,74 +642,6 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                      // make sure we are at the correct directory level by cd'ing to path
                      TDirectory *ndir = nextsource->GetDirectory(path);
                      if (ndir) {
-                        // For consistency (and persformance), we reset the MustCleanup be also for those
-                        // 'key' retrieved indirectly.
-                        //ndir->ResetBit(kMustCleanup);
-                        ndir->cd();
-                        TKey *key2 = (TKey*)ndir->GetListOfKeys()->FindObject(key->GetName());
-                        if (key2) {
-                           TObject *hobj = key2->ReadObj();
-                           if (!hobj) {
-                              Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
-                                   key->GetName(), key->GetTitle(), nextsource->GetName());
-                              nextsource = (TFile*)sourcelist->After(nextsource);
-                              continue;
-                           }
-                           // Set ownership for collections
-                           if (hobj->InheritsFrom(TCollection::Class())) {
-                              ((TCollection*)hobj)->SetOwner();
-                           }
-                           hobj->ResetBit(kMustCleanup);
-                           listH.Add(hobj);
-                           Int_t error = 0;
-                           obj->Execute("Merge", listHargs.Data(), &error);
-                           info.fIsFirst = kFALSE;
-                           if (error) {
-                              Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
-                                    obj->GetName(), nextsource->GetName());
-                           }
-                           listH.Delete();
-                        }
-                     }
-                     nextsource = (TFile*)sourcelist->After( nextsource );
-                  }
-                  // Merge the list, if still to be done
-                  if (info.fIsFirst) {
-                     Int_t error = 0;
-                     obj->Execute("Merge", listHargs.Data(), &error);
-                     info.fIsFirst = kFALSE;
-                     listH.Delete();
-                  }
-               }
-            } else if (cl->IsTObject() &&
-                       cl->GetMethodWithPrototype("Merge", "TCollection*") ) {
-               // Object implements Merge(TCollection*) and has a reflex dictionary ...
-
-               // Check if already treated
-               if (alreadyseen) continue;
-
-               TList listH;
-               TString listHargs;
-               listHargs.Form("((TCollection*)0x%lx)", (ULong_t)&listH);
-
-               // Loop over all source files and merge same-name object
-               TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
-               if (nextsource == 0) {
-                  // There is only one file in the list
-                  Int_t error = 0;
-                  obj->Execute("Merge", listHargs.Data(), &error);
-                  if (error) {
-                     Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
-                           obj->GetName(), key->GetName());
-                  }
-               } else {
-                  while (nextsource) {
-                     // make sure we are at the correct directory level by cd'ing to path
-                     TDirectory *ndir = nextsource->GetDirectory(path);
-                     if (ndir) {
-                        // For consistency (and persformance), we reset the MustCleanup be also for those
-                        // 'key' retrieved indirectly.
-                        //ndir->ResetBit(kMustCleanup);
                         ndir->cd();
                         TKey *key2 = (TKey*)ndir->GetListOfKeys()->FindObject(key->GetName());
                         if (key2) {


### PR DESCRIPTION
Combines the two cases in `TFileMerger::MergeRecursive` when a `TObject` declares a `Merge` method.

The method can either be:
1. `SomeClass::Merge(TCollection* inputs, TFileMergeInfo* info)` or
2. `SomeClass::Merge(TCollection* inputs)`

These cases were combined because they are nearly identical, and only differ in what arguments are passed to the
`TObject::Execute` call using `listHargs`. Concretely, the call is:

`obj->Execute("Merge", listHargs.Data(), &error);`

For option 1, `listHargs` has the parameter types `TCollection*` and
`TFileMerge*` info.
For option 2, `listHargs` only holds `TCollection*`