### PR TITLE
fix regression in f8edeb9 not using correct string_view with CUDA

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -518,40 +518,38 @@ CHECK_CXX_SOURCE_COMPILES("#include <string_view>
 if(found_stdstringview)
   set(hasstdstringview define)
   if(cuda)
-    if(CMAKE_CUDA_STANDARD GREATER_EQUAL CMAKE_CXX_STANDARD)
-      # CUDA_NVCC_EXECUTABLE
-      if(DEFINED ENV{CUDA_NVCC_EXECUTABLE})
-        set(CUDA_NVCC_EXECUTABLE "$ENV{CUDA_NVCC_EXECUTABLE}" CACHE FILEPATH "The CUDA compiler")
-      else()
-        find_program(CUDA_NVCC_EXECUTABLE
-          NAMES nvcc nvcc.exe
-          PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
-            ENV CUDA_TOOKIT_ROOT
-            ENV CUDA_PATH
-            ENV CUDA_BIN_PATH
-          PATH_SUFFIXES bin bin64
-          DOC "The CUDA compiler"
-          NO_DEFAULT_PATH
-        )
-        find_program(CUDA_NVCC_EXECUTABLE
-          NAMES nvcc nvcc.exe
-          PATHS /opt/cuda/bin
-          PATH_SUFFIXES cuda/bin
-          DOC "The CUDA compiler"
-        )
-        # Search default search paths, after we search our own set of paths.
-        find_program(CUDA_NVCC_EXECUTABLE nvcc)
-      endif()
-      mark_as_advanced(CUDA_NVCC_EXECUTABLE)
-      if(CUDA_NVCC_EXECUTABLE)
-        execute_process(COMMAND "echo"
-          "-e" "#include <string_view>\nint main() { char arr[3] = {'B', 'a', 'r'}; std::string_view strv(arr, sizeof(arr)); return 0;}"
-          "|"
-          "${CUDA_NVCC_EXECUTABLE}" "-std=c++${CMAKE_CUDA_STANDARD}" "-o" "/dev/null" "-x" "c++" "-"
-          RESULT_VARIABLE nvcc_compiled_string_view)
-        if (nvcc_compiled_string_view EQUAL "0")
-          set(cudahasstdstringview define)
-        endif()
+    # CUDA_NVCC_EXECUTABLE
+    if(DEFINED ENV{CUDA_NVCC_EXECUTABLE})
+      set(CUDA_NVCC_EXECUTABLE "$ENV{CUDA_NVCC_EXECUTABLE}" CACHE FILEPATH "The CUDA compiler")
+    else()
+      find_program(CUDA_NVCC_EXECUTABLE
+        NAMES nvcc nvcc.exe
+        PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
+          ENV CUDA_TOOKIT_ROOT
+          ENV CUDA_PATH
+          ENV CUDA_BIN_PATH
+        PATH_SUFFIXES bin bin64
+        DOC "The CUDA compiler"
+        NO_DEFAULT_PATH
+      )
+      find_program(CUDA_NVCC_EXECUTABLE
+        NAMES nvcc nvcc.exe
+        PATHS /opt/cuda/bin
+        PATH_SUFFIXES cuda/bin
+        DOC "The CUDA compiler"
+      )
+      # Search default search paths, after we search our own set of paths.
+      find_program(CUDA_NVCC_EXECUTABLE nvcc)
+    endif()
+    mark_as_advanced(CUDA_NVCC_EXECUTABLE)
+    if(CUDA_NVCC_EXECUTABLE)
+      execute_process(COMMAND "echo"
+        "-e" "#include <string_view>\nint main() { char arr[3] = {'B', 'a', 'r'}; std::string_view strv(arr, sizeof(arr)); return 0;}"
+        "|"
+        "${CUDA_NVCC_EXECUTABLE}" "-std=c++${CMAKE_CUDA_STANDARD}" "-o" "/dev/null" "-x" "c++" "-"
+        RESULT_VARIABLE nvcc_compiled_string_view)
+      if (nvcc_compiled_string_view EQUAL "0")
+        set(cudahasstdstringview define)
       endif()
     endif()
   endif()

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -528,6 +528,7 @@ else()
   endif()
 endif()
 
+set(cudahasstdstringview undef)
 if(found_stdstringview)
   CHECK_CXX_SOURCE_COMPILES("#include <string_view>
      int main() { size_t pos; std::string_view str; std::stod(str,&pos); return 0;}" found_stod_stringview)

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -518,35 +518,11 @@ CHECK_CXX_SOURCE_COMPILES("#include <string_view>
 if(found_stdstringview)
   set(hasstdstringview define)
   if(cuda)
-    # CUDA_NVCC_EXECUTABLE
-    if(DEFINED ENV{CUDA_NVCC_EXECUTABLE})
-      set(CUDA_NVCC_EXECUTABLE "$ENV{CUDA_NVCC_EXECUTABLE}" CACHE FILEPATH "The CUDA compiler")
-    else()
-      find_program(CUDA_NVCC_EXECUTABLE
-        NAMES nvcc nvcc.exe
-        PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
-          ENV CUDA_TOOKIT_ROOT
-          ENV CUDA_PATH
-          ENV CUDA_BIN_PATH
-        PATH_SUFFIXES bin bin64
-        DOC "The CUDA compiler"
-        NO_DEFAULT_PATH
-      )
-      find_program(CUDA_NVCC_EXECUTABLE
-        NAMES nvcc nvcc.exe
-        PATHS /opt/cuda/bin
-        PATH_SUFFIXES cuda/bin
-        DOC "The CUDA compiler"
-      )
-      # Search default search paths, after we search our own set of paths.
-      find_program(CUDA_NVCC_EXECUTABLE nvcc)
-    endif()
-    mark_as_advanced(CUDA_NVCC_EXECUTABLE)
     if(CUDA_NVCC_EXECUTABLE)
-      execute_process(COMMAND "echo"
-        "-e" "#include <string_view>\nint main() { char arr[3] = {'B', 'a', 'r'}; std::string_view strv(arr, sizeof(arr)); return 0;}"
-        "|"
-        "${CUDA_NVCC_EXECUTABLE}" "-std=c++${CMAKE_CUDA_STANDARD}" "-o" "/dev/null" "-x" "c++" "-"
+      execute_process(
+        COMMAND "echo"
+          "-e" "#include <string_view>\nint main() { char arr[3] = {'B', 'a', 'r'}; std::string_view strv(arr, sizeof(arr)); return 0;}"
+        COMMAND "${CUDA_NVCC_EXECUTABLE}" "-std=c++${CMAKE_CUDA_STANDARD}" "-o" "/dev/null" "-x" "c++" "-"
         RESULT_VARIABLE nvcc_compiled_string_view)
       if (nvcc_compiled_string_view EQUAL "0")
         set(cudahasstdstringview define)

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -512,10 +512,49 @@ unset(found_stdexpstringview CACHE)
 unset(found_stod_stringview CACHE)
 
 set(hasstdexpstringview undef)
+set(cudahasstdstringview undef)
 CHECK_CXX_SOURCE_COMPILES("#include <string_view>
   int main() { char arr[3] = {'B', 'a', 'r'}; std::string_view strv(arr, sizeof(arr)); return 0;}" found_stdstringview)
 if(found_stdstringview)
   set(hasstdstringview define)
+  if(cuda)
+    if(CMAKE_CUDA_STANDARD GREATER_EQUAL CMAKE_CXX_STANDARD)
+      # CUDA_NVCC_EXECUTABLE
+      if(DEFINED ENV{CUDA_NVCC_EXECUTABLE})
+        set(CUDA_NVCC_EXECUTABLE "$ENV{CUDA_NVCC_EXECUTABLE}" CACHE FILEPATH "The CUDA compiler")
+      else()
+        find_program(CUDA_NVCC_EXECUTABLE
+          NAMES nvcc nvcc.exe
+          PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
+            ENV CUDA_TOOKIT_ROOT
+            ENV CUDA_PATH
+            ENV CUDA_BIN_PATH
+          PATH_SUFFIXES bin bin64
+          DOC "The CUDA compiler"
+          NO_DEFAULT_PATH
+        )
+        find_program(CUDA_NVCC_EXECUTABLE
+          NAMES nvcc nvcc.exe
+          PATHS /opt/cuda/bin
+          PATH_SUFFIXES cuda/bin
+          DOC "The CUDA compiler"
+        )
+        # Search default search paths, after we search our own set of paths.
+        find_program(CUDA_NVCC_EXECUTABLE nvcc)
+      endif()
+      mark_as_advanced(CUDA_NVCC_EXECUTABLE)
+      if(CUDA_NVCC_EXECUTABLE)
+        execute_process(COMMAND "echo"
+          "-e" "#include <string_view>\nint main() { char arr[3] = {'B', 'a', 'r'}; std::string_view strv(arr, sizeof(arr)); return 0;}"
+          "|"
+          "${CUDA_NVCC_EXECUTABLE}" "-std=c++${CMAKE_CUDA_STANDARD}" "-o" "/dev/null" "-x" "c++" "-"
+          RESULT_VARIABLE nvcc_compiled_string_view)
+        if (nvcc_compiled_string_view EQUAL "0")
+          set(cudahasstdstringview define)
+        endif()
+      endif()
+    endif()
+  endif()
 else()
   set(hasstdstringview undef)
 
@@ -528,13 +567,9 @@ else()
   endif()
 endif()
 
-set(cudahasstdstringview undef)
 if(found_stdstringview)
   CHECK_CXX_SOURCE_COMPILES("#include <string_view>
      int main() { size_t pos; std::string_view str; std::stod(str,&pos); return 0;}" found_stod_stringview)
-  if(CMAKE_CUDA_STANDARD GREATER_EQUAL CMAKE_CXX_STANDARD)
-    set(cudahasstdstringview define)
-  endif()
 elseif(found_stdexpstringview)
   CHECK_CXX_SOURCE_COMPILES("#include <experimental/string_view>
      int main() { size_t pos; std::experimental::string_view str; std::stod(str,&pos); return 0;}" found_stod_stringview)

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -531,6 +531,9 @@ endif()
 if(found_stdstringview)
   CHECK_CXX_SOURCE_COMPILES("#include <string_view>
      int main() { size_t pos; std::string_view str; std::stod(str,&pos); return 0;}" found_stod_stringview)
+  if(CMAKE_CUDA_STANDARD GREATER_EQUAL CMAKE_CXX_STANDARD)
+    set(cudahasstdstringview define)
+  endif()
 elseif(found_stdexpstringview)
   CHECK_CXX_SOURCE_COMPILES("#include <experimental/string_view>
      int main() { size_t pos; std::experimental::string_view str; std::stod(str,&pos); return 0;}" found_stod_stringview)

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -519,11 +519,17 @@ if(found_stdstringview)
   set(hasstdstringview define)
   if(cuda)
     if(CUDA_NVCC_EXECUTABLE)
+      if (WIN32)
+        set(PLATFORM_NULL_FILE "nul")
+      else()
+        set(PLATFORM_NULL_FILE "/dev/null")
+      endif()
       execute_process(
         COMMAND "echo"
           "-e" "#include <string_view>\nint main() { char arr[3] = {'B', 'a', 'r'}; std::string_view strv(arr, sizeof(arr)); return 0;}"
-        COMMAND "${CUDA_NVCC_EXECUTABLE}" "-std=c++${CMAKE_CUDA_STANDARD}" "-o" "/dev/null" "-x" "c++" "-"
+        COMMAND "${CUDA_NVCC_EXECUTABLE}" "-std=c++${CMAKE_CUDA_STANDARD}" "-o" "${PLATFORM_NULL_FILE}" "-x" "c++" "-"
         RESULT_VARIABLE nvcc_compiled_string_view)
+      unset(PLATFORM_NULL_FILE CACHE)
       if (nvcc_compiled_string_view EQUAL "0")
         set(cudahasstdstringview define)
       endif()

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1462,6 +1462,30 @@ if(cuda OR tmva-gpu)
     endif()
     enable_language(CUDA)
     set(cuda ON CACHE BOOL "Found Cuda for TMVA GPU" FORCE)
+    # CUDA_NVCC_EXECUTABLE
+    if(DEFINED ENV{CUDA_NVCC_EXECUTABLE})
+      set(CUDA_NVCC_EXECUTABLE "$ENV{CUDA_NVCC_EXECUTABLE}" CACHE FILEPATH "The CUDA compiler")
+    else()
+      find_program(CUDA_NVCC_EXECUTABLE
+        NAMES nvcc nvcc.exe
+        PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
+          ENV CUDA_TOOKIT_ROOT
+          ENV CUDA_PATH
+          ENV CUDA_BIN_PATH
+        PATH_SUFFIXES bin bin64
+        DOC "The CUDA compiler"
+        NO_DEFAULT_PATH
+      )
+      find_program(CUDA_NVCC_EXECUTABLE
+        NAMES nvcc nvcc.exe
+        PATHS /opt/cuda/bin
+        PATH_SUFFIXES cuda/bin
+        DOC "The CUDA compiler"
+      )
+      # Search default search paths, after we search our own set of paths.
+      find_program(CUDA_NVCC_EXECUTABLE nvcc)
+    endif()
+    mark_as_advanced(CUDA_NVCC_EXECUTABLE)
     ###
     ### look for package CuDNN
     if (cudnn)

--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -33,6 +33,7 @@
 #@usecxxmodules@ R__USE_CXXMODULES   /**/
 #@uselibc++@ R__USE_LIBCXX    /**/
 #@hasstdstringview@ R__HAS_STD_STRING_VIEW   /**/
+#@cudahasstdstringview@ R__CUDA_HAS_STD_STRING_VIEW   /**/
 #@hasstdexpstringview@ R__HAS_STD_EXPERIMENTAL_STRING_VIEW   /**/
 #@hasstodstringview@ R__HAS_STOD_STRING_VIEW /**/
 #@hasopplusequalstringview@ R__HAS_OP_EQUAL_PLUS_STRING_VIEW /**/

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda/CudaMatrix.h
@@ -20,10 +20,13 @@
 #define TMVA_DNN_ARCHITECTURES_CUDA_CUDAMATRIX
 
 // in case we compile C++ code with std-17 and cuda with lower standard
+// use experimental string_view, otherwise keep as is
 #include "RConfigure.h"
 #ifdef R__HAS_STD_STRING_VIEW
+#ifndef R__CUDA_HAS_STD_STRING_VIEW
 #undef R__HAS_STD_STRING_VIEW
 #define R__HAS_STD_EXPERIMENTAL_STRING_VIEW
+#endif
 #endif
 
 #include "cuda.h"

--- a/tmva/tmva/src/DNN/Architectures/Cuda.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cuda.cu
@@ -15,10 +15,13 @@
 /////////////////////////////////////////////////////////////////
 
 // in case we compile C++ code with std-17 and cuda with lower standard
+// use experimental string_view, otherwise keep as is
 #include "RConfigure.h"
 #ifdef R__HAS_STD_STRING_VIEW
+#ifndef R__CUDA_HAS_STD_STRING_VIEW
 #undef R__HAS_STD_STRING_VIEW
 #define R__HAS_STD_EXPERIMENTAL_STRING_VIEW
+#endif
 #endif
 
 #include "TMVA/DNN/Architectures/Cuda.h"

--- a/tmva/tmva/src/DNN/Architectures/Cudnn.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cudnn.cu
@@ -15,10 +15,13 @@
 ///////////////////////////////////////////////////////////////////
 
 // in case we compile C++ code with std-17 and cuda with lower standard
+// use experimental string_view, otherwise keep as is
 #include "RConfigure.h"
 #ifdef R__HAS_STD_STRING_VIEW
+#ifndef R__CUDA_HAS_STD_STRING_VIEW
 #undef R__HAS_STD_STRING_VIEW
 #define R__HAS_STD_EXPERIMENTAL_STRING_VIEW
+#endif
 #endif
 
 #include "TMVA/DNN/Architectures/TCudnn.h"


### PR DESCRIPTION
CUDA 11 now supports C++17, which has `std::string_view`. Make sure the configuration when using CUDA allows it.