### PR TITLE
Comply with TVirtualMCStack::PopNextTrack logic

### DIFF
--- a/montecarlo/vmc/src/TMCManagerStack.cxx
+++ b/montecarlo/vmc/src/TMCManagerStack.cxx
@@ -68,6 +68,7 @@ TParticle *TMCManagerStack::PopNextTrack(Int_t &itrack)
    }
    itrack = mcStack->top();
    mcStack->pop();
+   SetCurrentTrack(itrack);
    return fParticles->operator[](itrack);
 }
 


### PR DESCRIPTION
Don't rely on the engine to set the current track after popping from
TMCManagerStack but do it implicitly.