### PR TITLE
Disable failing pyroot and dataframe (Python) tests on Windows

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -15,7 +15,9 @@ endif()
 ROOT_ADD_PYUNITTEST(pyroot_root_module root_module.py)
 
 # Test versions of Python dependencies
-ROOT_ADD_PYUNITTEST(pyroot_dependency_versions dependency_versions.py)
+if(NOT MSVC)
+    ROOT_ADD_PYUNITTEST(pyroot_dependency_versions dependency_versions.py)
+endif()
 
 # General pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -82,6 +82,8 @@ if (NOT dataframe)
     list(APPEND dataframe_veto graphs/timeSeriesFromCSV_TDF.C)
     # TMVA tutorials dependent on RDataFrame
     list(APPEND dataframe_veto tmva/tmva*.C)
+elseif(MSVC AND NOT win_broken_tests)
+    list(APPEND dataframe_veto dataframe/*.py)
 endif()
 
 if(NOT sqlite)


### PR DESCRIPTION
- dependency_versions.py: cannot run the root-config shell script on Windows
- the tutorial-dataframe-df0XX_*.py are failing on Windows, but this should be fixed (hopefully) once llvm and clang get updated