### PR TITLE
[TreeReader] Add support for TBranchObjects  (6.22)

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -3120,7 +3120,7 @@ void TBranch::SetFirstEntry(Long64_t entry)
 
 void TBranch::SetupAddresses()
 {
-   // Nothing to do for regular branch, the TLeaf already did it.
+   SetAddress(nullptr); // in some cases, this triggers setting of the address
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -17,6 +17,7 @@ of the autoloading of branches as well as all the generic setup routine.
 #include "TBranchProxy.h"
 #include "TLeaf.h"
 #include "TBranchElement.h"
+#include "TBranchObject.h"
 #include "TStreamerElement.h"
 #include "TStreamerInfo.h"
 
@@ -307,7 +308,7 @@ Bool_t ROOT::Detail::TBranchProxy::Setup()
       }
 
       if (!fWhere) {
-         fBranch->SetAddress(0);
+         fBranch->SetupAddresses();
          fWhere = (double*)fBranch->GetAddress();
       }
 
@@ -400,11 +401,14 @@ Bool_t ROOT::Detail::TBranchProxy::Setup()
             fWhere = ((unsigned char*)be->GetObject()) + fOffset;
 
          }
+      } else if (fBranch->IsA() == TBranchObject::Class()) {
+         fIsaPointer = true; // this holds for all cases we test
+         fClassName = fBranch->GetClassName();
+         fClass = TClass::GetClass(fClassName);
       } else {
          fClassName = fBranch->GetClassName();
          fClass = TClass::GetClass(fClassName);
       }
-
 
       /*
         fClassName = fBranch->GetClassName(); // What about TClonesArray?

--- a/tree/treeplayer/test/branchobject.cxx
+++ b/tree/treeplayer/test/branchobject.cxx
@@ -1,0 +1,40 @@
+#include <TFile.h>
+#include <TTree.h>
+#include <TTreeReader.h>
+#include <TTreeReaderValue.h>
+#include <TH1D.h>
+
+#include "gtest/gtest.h"
+
+// ROOT-10023
+TEST(TTreeReaderBasic, BranchObject)
+{
+   TTree t("t", "t");
+   TObject *o = nullptr;
+   t.Branch("o", &o, 32000, 0); // must be unsplit to generate a TBranchObject
+
+   // Fill branch with different concrete types
+   TNamed name("name", "title");
+   TList list;
+   list.Add(&name);
+   o = &list;
+   t.Fill();
+   TH1D h("h", "h", 100, 0, 100);
+   h.Fill(42);
+   o = &h;
+   t.Fill();
+   o = nullptr;
+
+   TTreeReader r(&t);
+   TTreeReaderValue<TObject> rv(r, "o");
+   EXPECT_TRUE(r.Next());
+   EXPECT_STREQ(rv->ClassName(), "TList");
+   auto *asList = static_cast<TList *>(rv.Get());
+   EXPECT_EQ(asList->GetEntries(), 1);
+   EXPECT_STREQ(asList->At(0)->GetTitle(), "title");
+   EXPECT_STREQ(asList->At(0)->GetName(), "name");
+
+   EXPECT_TRUE(r.Next());
+   EXPECT_STREQ(rv->ClassName(), "TH1D");
+   EXPECT_DOUBLE_EQ(static_cast<TH1D *>(rv.Get())->GetMean(), 42.);
+}


### PR DESCRIPTION
To this end, two changes were introduced:
* TBranchProxy::Setup now uses the more generic fBranch->SetupAddresses()
  instead of fBranch->SetupAddress(nullptr) to trigger the setting
  of TBranch::fAddress: TBranchObject::SetupAddresses does the right
  thing, but TBranchObject::SetupAddress(nullptr) does not
* if the branch is a TBranchObject, we set TBranchProxy::fIsaPointer to
  true, as TBranchObject::GetAddress() returns a pointer to pointer to
  the actual object

This fixes ROOT-10022, ROOT-10023 and ROOT-9731.