### PR TITLE
Fix wrong (inverted) logic in `REveVector.hxx` (was already fixed in `TEveVector.h`)

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveVector.hxx
+++ b/graf3d/eve7/inc/ROOT/REveVector.hxx
@@ -42,13 +42,13 @@ public:
 #ifdef R__WIN32
    const TT *Arr() const
    {
-      if (offsetof(REveVectorT, fZ) == offsetof(REveVectorT, fX) + 2 * sizeof(TT))
+      if (offsetof(REveVectorT, fZ) != offsetof(REveVectorT, fX) + 2 * sizeof(TT))
          Error("REveVectorT", "Subsequent members cannot be accessed as array!");
       return &fX;
    }
    TT *Arr()
    {
-      if (offsetof(REveVectorT, fZ) == offsetof(REveVectorT, fX) + 2 * sizeof(TT))
+      if (offsetof(REveVectorT, fZ) != offsetof(REveVectorT, fX) + 2 * sizeof(TT))
          Error("REveVectorT", "Subsequent members cannot be accessed as array!");
       return &fX;
    }


### PR DESCRIPTION
This `#ifdef R__WIN32` block can be completely removed when moving to a newer version of Visual Studio, but  since moving to the latest version of Visual Studio introduces new issues, let's keep this code for now.