### PR TITLE
[DF] Add support for Snapshots of TBranchObjects

### DIFF
--- a/README/ReleaseNotes/v624/index.md
+++ b/README/ReleaseNotes/v624/index.md
@@ -54,6 +54,7 @@ The following people have contributed to this new version:
 ## RDataFrame
 
 - With [ROOT-10023](https://sft.its.cern.ch/jira/browse/ROOT-10023) fixed, RDataFrame can now read and write certain branches containing unsplit objects, i.e. TBranchObjects. More information is available at [ROOT-10022](https://sft.its.cern.ch/jira/browse/ROOT-10022).
+- Snapshot now respects the basket size and split level of the original branch when copying branches to a new TTree.
 
 
 ## Histogram Libraries

--- a/README/ReleaseNotes/v624/index.md
+++ b/README/ReleaseNotes/v624/index.md
@@ -51,6 +51,11 @@ The following people have contributed to this new version:
 ## TTree Libraries
 
 
+## RDataFrame
+
+- With [ROOT-10023](https://sft.its.cern.ch/jira/browse/ROOT-10023) fixed, RDataFrame can now read and write certain branches containing unsplit objects, i.e. TBranchObjects. More information is available at [ROOT-10022](https://sft.its.cern.ch/jira/browse/ROOT-10022).
+
+
 ## Histogram Libraries
 
 

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1141,7 +1141,8 @@ void SetBranchesHelper(BoolArrayMap &, TTree *inputTree, TTree &outputTree, cons
       const auto bufSize = inputBranch->GetBasketSize();
       const auto splitLevel = inputBranch->GetSplitLevel();
 
-      if (std::string_view(inputBranch->ClassName()) == "TBranchObject") {
+      static TClassRef tbo_cl("TBranchObject");
+      if (inputBranch->IsA() == tbo_cl) {
          // Need to pass a pointer to pointer
          outputTree.Branch(name.c_str(), (T **)inputBranch->GetAddress(), bufSize, splitLevel);
       } else {

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1138,7 +1138,15 @@ void SetBranchesHelper(BoolArrayMap &, TTree *inputTree, TTree &outputTree, cons
       // In particular, by keeping splitlevel equal to 0 if this was the case for `inputBranch`, we avoid
       // writing garbage when unsplit objects cannot be written as split objects (e.g. in case of a polymorphic
       // TObject branch, see https://bit.ly/2EjLMId ).
-      outputTree.Branch(name.c_str(), address, inputBranch->GetBasketSize(), inputBranch->GetSplitLevel());
+      const auto bufSize = inputBranch->GetBasketSize();
+      const auto splitLevel = inputBranch->GetSplitLevel();
+
+      if (std::string_view(inputBranch->ClassName()) == "TBranchObject") {
+         // Need to pass a pointer to pointer
+         outputTree.Branch(name.c_str(), (T **)inputBranch->GetAddress(), bufSize, splitLevel);
+      } else {
+         outputTree.Branch(name.c_str(), address, bufSize, splitLevel);
+      }
    } else {
       outputTree.Branch(name.c_str(), address);
    }


### PR DESCRIPTION
Recent commits have introduced the ability to read TBranchObjects into TTreeReader and RDF.
Writing of TBranchObjects, however, was still not working correctly.

This PR fixes the writing part of ROOT-10022 and adds the corresponding tests.

@pcanal can you think of other cases we should be testing? Should we also propagate the value of `TBranch::GetMakeClass` from input branch to output branch? Do `TBranchElements` require similar special-casing (it doesn't seem so from our tests)?

EDIT: I also ran these tests through valgrind, all is well