### PR TITLE
Move the initialization of static constexpr variables from source to …

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RColor.hxx
@@ -243,6 +243,26 @@ public:
    }
 };
 
+constexpr RColor::RGB_t RColor::kBlack;
+constexpr RColor::RGB_t RColor::kGreen;
+constexpr RColor::RGB_t RColor::kLime;
+constexpr RColor::RGB_t RColor::kAqua;
+constexpr RColor::RGB_t RColor::kPurple;
+constexpr RColor::RGB_t RColor::kGrey;
+constexpr RColor::RGB_t RColor::kFuchsia;
+constexpr RColor::RGB_t RColor::kNavy;
+constexpr RColor::RGB_t RColor::kBlue;
+constexpr RColor::RGB_t RColor::kTeal;
+constexpr RColor::RGB_t RColor::kOlive;
+constexpr RColor::RGB_t RColor::kSilver;
+constexpr RColor::RGB_t RColor::kMaroon;
+constexpr RColor::RGB_t RColor::kRed;
+constexpr RColor::RGB_t RColor::kYellow;
+constexpr RColor::RGB_t RColor::kWhite;
+constexpr float RColor::kTransparent;
+constexpr float RColor::kSemiTransparent;
+constexpr float RColor::kOpaque;
+
 } // namespace Experimental
 } // namespace ROOT
 

--- a/graf2d/gpadv7/src/RColor.cxx
+++ b/graf2d/gpadv7/src/RColor.cxx
@@ -14,26 +14,6 @@ using namespace ROOT::Experimental;
 
 using namespace std::string_literals;
 
-constexpr RColor::RGB_t RColor::kBlack;
-constexpr RColor::RGB_t RColor::kGreen;
-constexpr RColor::RGB_t RColor::kLime;
-constexpr RColor::RGB_t RColor::kAqua;
-constexpr RColor::RGB_t RColor::kPurple;
-constexpr RColor::RGB_t RColor::kGrey;
-constexpr RColor::RGB_t RColor::kFuchsia;
-constexpr RColor::RGB_t RColor::kNavy;
-constexpr RColor::RGB_t RColor::kBlue;
-constexpr RColor::RGB_t RColor::kTeal;
-constexpr RColor::RGB_t RColor::kOlive;
-constexpr RColor::RGB_t RColor::kSilver;
-constexpr RColor::RGB_t RColor::kMaroon;
-constexpr RColor::RGB_t RColor::kRed;
-constexpr RColor::RGB_t RColor::kYellow;
-constexpr RColor::RGB_t RColor::kWhite;
-constexpr float RColor::kTransparent;
-constexpr float RColor::kSemiTransparent;
-constexpr float RColor::kOpaque;
-
 
 ///////////////////////////////////////////////////////////////////////////
 /// Converts string name of color in RGB value - when possible


### PR DESCRIPTION
…header

This fixes the following errors on Windows (with all macros using `RColor`):
```
C:\build\release\tutorials\v7>root -l box.cxx
root [0]
Processing box.cxx...
IncrementalExecutor::executeFunction: symbol '?kGreen@RColor@Experimental@ROOT@@2V?$array@E$02@std@@B' unresolved while linking [cling interface function]!
You are probably missing the definition of public: static class std::array<unsigned char,3> const ROOT::Experimental::RColor::kGreen
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol '?kRed@RColor@Experimental@ROOT@@2V?$array@E$02@std@@B' unresolved while linking [cling interface function]!
You are probably missing the definition of public: static class std::array<unsigned char,3> const ROOT::Experimental::RColor::kRed
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol '?kBlue@RColor@Experimental@ROOT@@2V?$array@E$02@std@@B' unresolved while linking [cling interface function]!
You are probably missing the definition of public: static class std::array<unsigned char,3> const ROOT::Experimental::RColor::kBlue
Maybe you need to load the corresponding shared library?
```