### PR TITLE
[ntuple, io] pass paths, names of ntuples for merging to RNTuple side

### DIFF
--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -19,10 +19,55 @@
 #include <ROOT/RNTupleMerger.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
+#include <iostream>
+
+namespace {
+
+// legacy bridge interface type
+using RNTupleList = std::vector<std::pair<
+   std::string,  // path
+   std::string   // ntuple name
+>>;
+
+} // anonymous namespace
+
+// legacy bridge interface to hadd via TFileMerger
 Long64_t ROOT::Experimental::RNTuple::Merge(TCollection* inputs, TFileMergeInfo* mergeInfo) {
    if (inputs == nullptr || mergeInfo == nullptr) {
       return -1;
    }
+   std::string& output_file = *(static_cast<std::string*>(static_cast<void*>(mergeInfo)));
+   if (output_file.empty()) {
+      return -1;
+   }
+   std::cout << "RNTuple merger output file is " << output_file << "\n";
+
+   RNTupleList& ntuples = *(static_cast<RNTupleList*>(static_cast<void*>(inputs)));
+   if (ntuples.size() == 0) {
+      std::cout << "got empty list of RNTuples to merge\n";
+      return -1;
+   }
+   for (const auto& ntpl: ntuples) {
+      std::cout << "merging ntuple from file '" << ntpl.first << " named '" << ntpl.second << "'\n";
+   }
+   // todo(max)
+   // 1. open the RNTuple page sources with the ntuple names and paths
+   // std::vector<std::unique_ptr<RPageSource>> merge_inputs;
+   // for (const auto& ntpl: ntuples) {
+   //    merge_inputs.emplace_back(RPageSource::Create(ntpl.second, ntpl.first));
+   // }
+   //
+   // 2. open the output file as a page sink
+   // - use the first ntuple name as the output ntuple name (?)
+   // - can we assume they're all the same?
+   // std::unique_ptr<RPageSink> merge_output = RPageSink::Create(ntuples.front().second, output_file);
+   //
+   // 3. call the merge function on the page sources and write it to the page sink
+   // auto res = MergeRNTuples(merge_inputs, merge_output);
+   // if (!res) {
+   //    return -1;
+   // }
+   std::cout << "RNTuple merging is unimplemented\n";
    return -1;
 }
 


### PR DESCRIPTION
We construct a vector of string pairs and pass it through to the
RNTuple::Merge function for merging. This implements a "legacy bridge"
between hadd/TFileMerger and the new RNTuple library.

We adhere to the Merge(TCollection*, TFileMergeInfo*) interface without
using either class in the implementation by carefully casting the
RNTuple information vector and output file string pointers.

An example of this technique is shown here, which passes UBSan, ASan,
and strict aliasing checks on gcc 10 and clang 10: https://godbolt.org/z/7ff3e8

For demonstration, the `hadd` output for merging two `ntuple` files looks like: 
```shell
$ ./bin/hadd -f dir/merged.root ntuple1.root ntuple2.root
hadd Target file: dir/merged.root
hadd compression setting for all output: 1
hadd Source file 1: ntuple1.root
hadd Source file 2: ntuple2.root
hadd Sources and Target have different compression levels
hadd merging will be slower
hadd Target path: dir/merged.root:/
Warning in <TFileMerger::MergeRecursive>: merging RNTuples is experimental

# note: TFileMerger debug output begins 
examining ntuple1.root:/
        got key for type ROOT::Experimental::RNTuple with name ntuple
examining ntuple2.root:/
        got key for type ROOT::Experimental::RNTuple with name ntuple
got ntuple from file 'ntuple1.root:/' named 'ntuple'
got ntuple from file 'ntuple2.root:/' named 'ntuple'

# note: RNTuple::Merge debug output begins
RNTuple merger output file is dir/merged.root:/
merging ntuple from file 'ntuple1.root:/ named 'ntuple'
merging ntuple from file 'ntuple2.root:/ named 'ntuple'
RNTuple merging is unimplemented

# control is passed back to TFileMerger::MergeRecursive
Error in <TFileMerger::MergeRecursive>: error merging RNTuples
Error in <TFileMerger::Merge>: error during merge of your ROOT files
```

