### PR TITLE
Allow only the system modulemaps to be overriden by already present ones

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -580,7 +580,9 @@ namespace {
                                     const std::string& Filename,
                                     const std::string& Location,
                                     std::string& overlay,
-                                    bool RegisterModuleMap = true) -> void {
+                                    bool RegisterModuleMap = true,
+                                    bool AllowModulemapOverride = false)
+       -> void {
 
       assert(llvm::sys::fs::exists(SystemDir) && "Must exist!");
 
@@ -589,7 +591,7 @@ namespace {
       llvm::sys::path::append(systemLoc, modulemapFilename);
       // Check if we need to mount a custom modulemap. We may have it, for
       // instance when we are on osx or using libc++.
-      if (llvm::sys::fs::exists(systemLoc.str())) {
+      if (AllowModulemapOverride &&llvm::sys::fs::exists(systemLoc.str())) {
         if (HSOpts.Verbose)
           cling::log() << "Loading '" << systemLoc.str() << "'\n";
 
@@ -661,9 +663,11 @@ namespace {
                             clingIncLoc.str(), MOverlay);
 #else
     maybeAppendOverlayEntry(cIncLoc.str(), "libc.modulemap", clingIncLoc.str(),
-                            MOverlay);
+                            MOverlay, /*RegisterModuleMap=*/ true,
+                            /*AllowModulemapOverride=*/true);
     maybeAppendOverlayEntry(stdIncLoc.str(), "std.modulemap", clingIncLoc.str(),
-                            MOverlay);
+                            MOverlay, /*RegisterModuleMap=*/ true,
+                            /*AllowModulemapOverride=*/true);
 #endif // LLVM_ON_WIN32
 
     if (!tinyxml2IncLoc.empty())


### PR DESCRIPTION
This patch is a workaround once again for the poor LCG design where we have all header files (and modulemaps) installed in the same folder.