### PR TITLE
[ntuple] Parallel page decompression

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -63,6 +63,7 @@ SOURCES
 LINKDEF
   LinkDef.h
 DEPENDENCIES
+  Imt
   RIO
   ROOTVecOps
 )

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -106,6 +106,7 @@ public:
    void Read(const NTupleSize_t globalIndex, RColumnElementBase *element) {
       if (!fCurrentPage.Contains(globalIndex)) {
          MapPage(globalIndex);
+         R__ASSERT(fCurrentPage.Contains(globalIndex));
       }
       void *src = static_cast<unsigned char *>(fCurrentPage.GetBuffer()) +
                   (globalIndex - fCurrentPage.GetGlobalRangeFirst()) * element->GetSize();

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -63,6 +63,15 @@ enum class ENTupleShowFormat {
 };
 
 
+class RNTupleImtTaskScheduler : public Detail::RPageStorage::RTaskScheduler {
+private:
+   std::unique_ptr<TTaskGroup> fTaskGroup;
+public:
+   void Reset() final;
+   void AddTask(const std::function<void(void)> &taskFunc) final;
+   void Wait() final;
+};
+
 // clang-format off
 /**
 \class ROOT::Experimental::RNTupleReader
@@ -86,7 +95,7 @@ private:
    std::unique_ptr<RNTupleReader> fDisplayReader;
    Detail::RNTupleMetrics fMetrics;
    /// Set as the page source's scheduler for parallel page decompression if IMT is on
-   std::unique_ptr<TTaskGroup> fUnzipTasks;
+   RNTupleImtTaskScheduler fUnzipTasks;
 
    void ConnectModel(const RNTupleModel &model);
    RNTupleReader *GetDisplayReader();

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -37,6 +37,7 @@ namespace Experimental {
 
 class REntry;
 class RNTupleModel;
+class TTaskGroup;
 
 namespace Detail {
 class RPageSink;
@@ -84,9 +85,12 @@ private:
    /// is a clone of the original reader.
    std::unique_ptr<RNTupleReader> fDisplayReader;
    Detail::RNTupleMetrics fMetrics;
+   /// Set as the page source's scheduler for parallel page decompression if IMT is on
+   std::unique_ptr<TTaskGroup> fUnzipTasks;
 
    void ConnectModel(const RNTupleModel &model);
    RNTupleReader *GetDisplayReader();
+   void InitPageSource();
 
 public:
    // Browse through the entries

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -74,7 +74,7 @@ public:
    {}
    ~RPage() = default;
 
-   ColumnId_t GetColumnId() { return fColumnId; }
+   ColumnId_t GetColumnId() const { return fColumnId; }
    /// The total space available in the page
    ClusterSize_t::ValueType GetCapacity() const { return fCapacity; }
    /// The space taken by column elements in the buffer

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -21,6 +21,7 @@
 #include <ROOT/RNTupleUtil.hxx>
 
 #include <cstddef>
+#include <mutex>
 #include <vector>
 
 namespace ROOT {
@@ -53,6 +54,7 @@ private:
    std::vector<RPage> fPages;
    std::vector<std::int32_t> fReferences;
    std::vector<RPageDeleter> fDeleters;
+   std::mutex fLock;
 
 public:
    RPagePool() = default;

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -51,7 +51,7 @@ private:
    ///   - searching by page
    ///   - searching by tree index
    std::vector<RPage> fPages;
-   std::vector<std::uint32_t> fReferences;
+   std::vector<std::int32_t> fReferences;
    std::vector<RPageDeleter> fDeleters;
 
 public:
@@ -63,6 +63,8 @@ public:
    /// Adds a new page to the pool together with the function to free its space. Upon registration,
    /// the page pool takes ownership of the page's memory. The new page has its reference counter set to 1.
    void RegisterPage(const RPage &page, const RPageDeleter &deleter);
+   /// Like RegisterPage() but the reference counter is initialized to 0
+   void PreloadPage(const RPage &page, const RPageDeleter &deleter);
    /// Tries to find the page corresponding to column and index in the cache. If the page is found, its reference
    /// counter is increased
    RPage GetPage(ColumnId_t columnId, NTupleSize_t globalIndex);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -223,6 +223,8 @@ public:
    /// LoadCluster() is typically called from the I/O thread of a cluster pool, i.e. the method runs
    /// concurrently to other methods of the page source.
    virtual std::unique_ptr<RCluster> LoadCluster(DescriptorId_t clusterId, const ColumnSet_t &columns) = 0;
+
+   virtual void UnzipCluster(RCluster * /*cluster*/) {}
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -165,7 +165,7 @@ private:
 
 protected:
    RNTupleDescriptor AttachImpl() final;
-   void UnzipClusterImpl(RCluster *cluster, TaskScheduleFunc_t taskScheduleFunc) final;
+   void UnzipClusterImpl(RCluster *cluster) final;
 
 public:
    RPageSourceFile(std::string_view ntupleName, std::string_view path, const RNTupleReadOptions &options);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -165,6 +165,7 @@ private:
 
 protected:
    RNTupleDescriptor AttachImpl() final;
+   void UnzipClusterImpl(RCluster *cluster, TaskScheduleFunc_t taskScheduleFunc) final;
 
 public:
    RPageSourceFile(std::string_view ntupleName, std::string_view path, const RNTupleReadOptions &options);
@@ -183,7 +184,6 @@ public:
    void ReleasePage(RPage &page) final;
 
    std::unique_ptr<RCluster> LoadCluster(DescriptorId_t clusterId, const ColumnSet_t &columns) final;
-   void UnzipCluster(RCluster *cluster) final;
 
    RNTupleMetrics &GetMetrics() final { return fMetrics; }
 };

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -16,10 +16,10 @@
 #ifndef ROOT7_RPageStorageFile
 #define ROOT7_RPageStorageFile
 
-#include <ROOT/RPageStorage.hxx>
 #include <ROOT/RMiniFile.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleZip.hxx>
+#include <ROOT/RPageStorage.hxx>
 #include <ROOT/RStringView.hxx>
 
 #include <array>
@@ -39,7 +39,6 @@ class RRawFile;
 namespace Experimental {
 namespace Detail {
 
-class RCluster;
 class RClusterPool;
 class RPageAllocatorHeap;
 class RPagePool;
@@ -127,14 +126,14 @@ private:
       RNTupleAtomicCounter &fNRead;
       RNTupleAtomicCounter &fSzReadPayload ;
       RNTupleAtomicCounter &fSzReadOverhead;
-      RNTuplePlainCounter  &fSzUnzip;
+      RNTupleAtomicCounter &fSzUnzip;
       RNTupleAtomicCounter &fNClusterLoaded;
-      RNTuplePlainCounter  &fNPageLoaded;
-      RNTuplePlainCounter  &fNPagePopulated;
+      RNTupleAtomicCounter &fNPageLoaded;
+      RNTupleAtomicCounter &fNPagePopulated;
       RNTupleAtomicCounter &fTimeWallRead;
-      RNTuplePlainCounter  &fTimeWallUnzip;
+      RNTupleAtomicCounter &fTimeWallUnzip;
       RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuRead;
-      RNTupleTickCounter<RNTuplePlainCounter>  &fTimeCpuUnzip;
+      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuUnzip;
       RNTupleCalcPerf &fBandwidthReadUncompressed;
       RNTupleCalcPerf &fBandwidthReadCompressed;
       RNTupleCalcPerf &fBandwidthUnzip;
@@ -163,6 +162,10 @@ private:
    RPageSourceFile(std::string_view ntupleName, const RNTupleReadOptions &options);
    RPage PopulatePageFromCluster(ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor,
                                  ClusterSize_t::ValueType clusterIndex);
+   //RPage UnwrapPage(DescriptorId_t clusterId,
+   //                 const ROnDiskPage::Key &key,
+   //                 const ROnDiskPage &onDiskPage,
+   //                 const RColumnElement &element);
 
 protected:
    RNTupleDescriptor AttachImpl() final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -161,11 +161,7 @@ private:
 
    RPageSourceFile(std::string_view ntupleName, const RNTupleReadOptions &options);
    RPage PopulatePageFromCluster(ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor,
-                                 ClusterSize_t::ValueType clusterIndex);
-   //RPage UnwrapPage(DescriptorId_t clusterId,
-   //                 const ROnDiskPage::Key &key,
-   //                 const ROnDiskPage &onDiskPage,
-   //                 const RColumnElement &element);
+                                 ClusterSize_t::ValueType idxInCluster);
 
 protected:
    RNTupleDescriptor AttachImpl() final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -184,6 +184,7 @@ public:
    void ReleasePage(RPage &page) final;
 
    std::unique_ptr<RCluster> LoadCluster(DescriptorId_t clusterId, const ColumnSet_t &columns) final;
+   void UnzipCluster(RCluster *cluster) final;
 
    RNTupleMetrics &GetMetrics() final { return fMetrics; }
 };

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -99,6 +99,8 @@ void ROOT::Experimental::Detail::RClusterPool::ExecUnzipClusters()
          if (!item.fCluster)
             return;
 
+         fPageSource.UnzipCluster(item.fCluster.get());
+
          item.fPromise.set_value(std::move(item.fCluster));
       }
    } // while (true)

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -50,7 +50,7 @@ bool ROOT::Experimental::Detail::RClusterPool::RInFlightCluster::operator <(cons
 ROOT::Experimental::Detail::RClusterPool::RClusterPool(RPageSource &pageSource, unsigned int size)
    : fPageSource(pageSource)
    , fPool(size)
-   , fThreadIo(&RClusterPool::ExecLoadClusters, this)
+   , fThreadIo(&RClusterPool::ExecReadClusters, this)
    , fThreadUnzip(&RClusterPool::ExecUnzipClusters, this)
 {
    R__ASSERT(size > 0);
@@ -68,8 +68,8 @@ ROOT::Experimental::Detail::RClusterPool::~RClusterPool()
    {
       // Controlled shutdown of the I/O thread
       std::unique_lock<std::mutex> lock(fLockWorkQueue);
-      fWorkQueue.emplace(RWorkItem());
-      fCvHasWork.notify_one();
+      fReadQueue.emplace(RReadItem());
+      fCvHasReadWork.notify_one();
    }
    fThreadIo.join();
 
@@ -101,25 +101,26 @@ void ROOT::Experimental::Detail::RClusterPool::ExecUnzipClusters()
 
          fPageSource.UnzipCluster(item.fCluster.get());
 
+         // Afterwards the GetCluster() method in the main thread can pick-up the cluster
          item.fPromise.set_value(std::move(item.fCluster));
       }
    } // while (true)
 }
 
-void ROOT::Experimental::Detail::RClusterPool::ExecLoadClusters()
+void ROOT::Experimental::Detail::RClusterPool::ExecReadClusters()
 {
    while (true) {
-      std::vector<RWorkItem> workItems;
+      std::vector<RReadItem> readItems;
       {
          std::unique_lock<std::mutex> lock(fLockWorkQueue);
-         fCvHasWork.wait(lock, [&]{ return !fWorkQueue.empty(); });
-         while (!fWorkQueue.empty()) {
-            workItems.emplace_back(std::move(fWorkQueue.front()));
-            fWorkQueue.pop();
+         fCvHasReadWork.wait(lock, [&]{ return !fReadQueue.empty(); });
+         while (!fReadQueue.empty()) {
+            readItems.emplace_back(std::move(fReadQueue.front()));
+            fReadQueue.pop();
          }
       }
 
-      for (auto &item : workItems) {
+      for (auto &item : readItems) {
          if (item.fClusterId == kInvalidDescriptorId)
             return;
 
@@ -142,6 +143,7 @@ void ROOT::Experimental::Detail::RClusterPool::ExecLoadClusters()
             cluster.reset();
             item.fPromise.set_value(std::move(cluster));
          } else {
+            // Hand-over the loaded cluster pages to the unzip thread
             std::unique_lock<std::mutex> lock(fLockUnzipQueue);
             fUnzipQueue.emplace(RUnzipItem{std::move(cluster), std::move(item.fPromise)});
             fCvHasUnzipWork.notify_one();
@@ -308,20 +310,20 @@ ROOT::Experimental::Detail::RClusterPool::GetCluster(
       for (const auto &kv : provide) {
          R__ASSERT(!kv.second.empty());
 
-         RWorkItem workItem;
-         workItem.fClusterId = kv.first;
-         workItem.fColumns = kv.second;
+         RReadItem readItem;
+         readItem.fClusterId = kv.first;
+         readItem.fColumns = kv.second;
 
          RInFlightCluster inFlightCluster;
          inFlightCluster.fClusterId = kv.first;
          inFlightCluster.fColumns = kv.second;
-         inFlightCluster.fFuture = workItem.fPromise.get_future();
+         inFlightCluster.fFuture = readItem.fPromise.get_future();
          fInFlightClusters.emplace_back(std::move(inFlightCluster));
 
-         fWorkQueue.emplace(std::move(workItem));
+         fReadQueue.emplace(std::move(readItem));
       }
-      if (fWorkQueue.size() > 0)
-         fCvHasWork.notify_one();
+      if (fReadQueue.size() > 0)
+         fCvHasReadWork.notify_one();
    } // work queue lock guard
 
    return WaitFor(clusterId, columns);

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -21,6 +21,7 @@
 #include <bitset>
 #include <cstdint>
 #include <memory>
+#include <utility>
 
 std::unique_ptr<ROOT::Experimental::Detail::RColumnElementBase>
 ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType type) {
@@ -45,7 +46,7 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType type) {
       R__ASSERT(false);
    }
    // never here
-   return std::make_unique<RColumnElementBase>();
+   return nullptr;
 }
 
 std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(EColumnType type) {

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -82,7 +82,12 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
 
 ROOT::Experimental::RNTupleReader::~RNTupleReader()
 {
-   fSource->SetTaskScheduleFunc(Detail::RPageSource::TaskScheduleFunc_t());
+#ifdef R__USE_IMT
+   if (fUnzipTasks) {
+      fUnzipTasks->Wait();
+      fSource->SetTaskScheduleFunc(Detail::RPageSource::TaskScheduleFunc_t());
+   }
+#endif
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::Open(

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -13,24 +13,28 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/RNTuple.hxx"
+#include <ROOT/RNTuple.hxx>
 
-#include "ROOT/RFieldVisitor.hxx"
-#include "ROOT/RNTupleModel.hxx"
-#include "ROOT/RPageStorage.hxx"
+#include <ROOT/RFieldVisitor.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RPageStorage.hxx>
 #include "ROOT/RPageStorageFile.hxx"
+#ifdef R__USE_IMT
+#include <ROOT/TTaskGroup.hxx>
+#endif
+
+#include <TError.h>
+#include <TROOT.h> // for IsImplicitMTEnabled()
 
 #include <algorithm>
 #include <exception>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
-
-#include <TError.h>
-#include <TFile.h> // for RNTupleWriter::Append
 
 
 void ROOT::Experimental::RNTupleReader::ConnectModel(const RNTupleModel &model) {
@@ -45,6 +49,18 @@ void ROOT::Experimental::RNTupleReader::ConnectModel(const RNTupleModel &model) 
    }
 }
 
+void ROOT::Experimental::RNTupleReader::InitPageSource()
+{
+#ifdef R__USE_IMT
+   if (IsImplicitMTEnabled()) {
+      fUnzipTasks = std::make_unique<TTaskGroup>();
+      fSource->SetTaskScheduleFunc([this](const std::function<void()> &task) { fUnzipTasks->Run(task); });
+   }
+#endif
+   fSource->Attach();
+   fMetrics.ObserveMetrics(fSource->GetMetrics());
+}
+
 ROOT::Experimental::RNTupleReader::RNTupleReader(
    std::unique_ptr<ROOT::Experimental::RNTupleModel> model,
    std::unique_ptr<ROOT::Experimental::Detail::RPageSource> source)
@@ -52,9 +68,8 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(
    , fModel(std::move(model))
    , fMetrics("RNTupleReader")
 {
-   fSource->Attach();
+   InitPageSource();
    ConnectModel(*fModel);
-   fMetrics.ObserveMetrics(fSource->GetMetrics());
 }
 
 ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> source)
@@ -62,12 +77,12 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
    , fModel(nullptr)
    , fMetrics("RNTupleReader")
 {
-   fSource->Attach();
-   fMetrics.ObserveMetrics(fSource->GetMetrics());
+   InitPageSource();
 }
 
 ROOT::Experimental::RNTupleReader::~RNTupleReader()
 {
+   fSource->SetTaskScheduleFunc(Detail::RPageSource::TaskScheduleFunc_t());
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::Open(

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -115,8 +115,7 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
    for (const auto &column : fColumnDescriptors) {
       // We generate the default memory representation for the given column type in order
       // to report the size _in memory_ of column elements
-      auto elementSize = Detail::RColumnElementBase::Generate(
-         column.second.GetModel().GetType())->GetSize();
+      auto elementSize = Detail::RColumnElementBase::Generate(column.second.GetModel().GetType())->GetSize();
 
       ColumnInfo info;
       info.fColumnId = column.second.GetId();

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -27,6 +27,13 @@ void ROOT::Experimental::Detail::RPagePool::RegisterPage(const RPage &page, cons
    fDeleters.emplace_back(deleter);
 }
 
+void ROOT::Experimental::Detail::RPagePool::PreloadPage(const RPage &page, const RPageDeleter &deleter)
+{
+   fPages.emplace_back(page);
+   fReferences.emplace_back(0);
+   fDeleters.emplace_back(deleter);
+}
+
 void ROOT::Experimental::Detail::RPagePool::ReturnPage(const RPage& page)
 {
    if (page.IsNull()) return;
@@ -54,7 +61,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage
 {
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
-      if (fReferences[i] == 0) continue;
+      if (fReferences[i] < 0) continue;
       if (fPages[i].GetColumnId() != columnId) continue;
       if (!fPages[i].Contains(globalIndex)) continue;
       fReferences[i]++;
@@ -68,7 +75,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage
 {
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
-      if (fReferences[i] == 0) continue;
+      if (fReferences[i] < 0) continue;
       if (fPages[i].GetColumnId() != columnId) continue;
       if (!fPages[i].Contains(clusterIndex)) continue;
       fReferences[i]++;

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -22,6 +22,7 @@
 
 void ROOT::Experimental::Detail::RPagePool::RegisterPage(const RPage &page, const RPageDeleter &deleter)
 {
+   std::lock_guard<std::mutex> lockGuard(fLock);
    fPages.emplace_back(page);
    fReferences.emplace_back(1);
    fDeleters.emplace_back(deleter);
@@ -29,6 +30,7 @@ void ROOT::Experimental::Detail::RPagePool::RegisterPage(const RPage &page, cons
 
 void ROOT::Experimental::Detail::RPagePool::PreloadPage(const RPage &page, const RPageDeleter &deleter)
 {
+   std::lock_guard<std::mutex> lockGuard(fLock);
    fPages.emplace_back(page);
    fReferences.emplace_back(0);
    fDeleters.emplace_back(deleter);
@@ -37,6 +39,7 @@ void ROOT::Experimental::Detail::RPagePool::PreloadPage(const RPage &page, const
 void ROOT::Experimental::Detail::RPagePool::ReturnPage(const RPage& page)
 {
    if (page.IsNull()) return;
+   std::lock_guard<std::mutex> lockGuard(fLock);
 
    unsigned int N = fPages.size();
    for (unsigned i = 0; i < N; ++i) {
@@ -59,6 +62,7 @@ void ROOT::Experimental::Detail::RPagePool::ReturnPage(const RPage& page)
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
    ColumnId_t columnId, NTupleSize_t globalIndex)
 {
+   std::lock_guard<std::mutex> lockGuard(fLock);
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
       if (fReferences[i] < 0) continue;
@@ -73,6 +77,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
    ColumnId_t columnId, const RClusterIndex &clusterIndex)
 {
+   std::lock_guard<std::mutex> lockGuard(fLock);
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
       if (fReferences[i] < 0) continue;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -95,6 +95,12 @@ ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSource::GetColum
    return columnHandle.fId;
 }
 
+void ROOT::Experimental::Detail::RPageSource::UnzipCluster(RCluster *cluster)
+{
+   if (fTaskScheduleFunc)
+      UnzipClusterImpl(cluster, fTaskScheduleFunc);
+}
+
 
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -97,8 +97,8 @@ ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSource::GetColum
 
 void ROOT::Experimental::Detail::RPageSource::UnzipCluster(RCluster *cluster)
 {
-   if (fTaskScheduleFunc)
-      UnzipClusterImpl(cluster, fTaskScheduleFunc);
+   if (fTaskScheduler)
+      UnzipClusterImpl(cluster);
 }
 
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -598,7 +598,6 @@ private:
    static constexpr int kNumThreads = 12;
    std::mutex fLock;
    std::condition_variable fCvHasWork;
-   std::condition_variable fCvIsDone;
    std::queue<std::unique_ptr<RTask>> fWaitingTasks;
    int fNumRunning = 0;
    std::vector<std::thread> fThreads;
@@ -626,22 +625,11 @@ public:
          fThreads.emplace_back(std::thread(&RTaskScheduler::ExecTaskRunner, this));
       }
    }
-
-   void WaitFor() {
-      std::unique_lock<std::mutex> lock(fLock);
-      fCvIsDone.wait(lock, [&]{ return (fNumRunning == 0) && fWaitingTasks.empty(); });
-   }
 };
 
 class RTask {
-private:
-   RTaskScheduler &fScheduler;
-   RTask *fAndThen = nullptr;
 public:
-   explicit RTask(RTaskScheduler &scheduler) : fScheduler(scheduler) {}
    virtual void Run() = 0;
-   void SetAndThen(RTask *andThen) { fAndThen = andThen; }
-   RTask *GetAndThen() { return fAndThen; }
 };
 
 
@@ -656,21 +644,9 @@ void RTaskScheduler::ExecTaskRunner()
          fWaitingTasks.pop();
          if (!task)
             return;
-         fNumRunning++;
       }
 
       task->Run();
-
-      {
-         std::unique_lock<std::mutex> lock(fLock);
-         fNumRunning--;
-         if (task->GetAndThen()) {
-            fWaitingTasks.emplace(std::unique_ptr<RTask>(task->GetAndThen()));
-            fCvHasWork.notify_one();
-         }
-         if ((fNumRunning == 0) && fWaitingTasks.empty())
-            fCvIsDone.notify_one();
-      }
    }
 }
 
@@ -678,9 +654,6 @@ void RTaskScheduler::ExecTaskRunner()
 class RUnzipTask : public RTask {
 public:
    std::function<void()> fRunFunc;
-
-   RUnzipTask(RTaskScheduler &scheduler) : RTask(scheduler) {}
-
    void Run() final { fRunFunc(); }
 };
 
@@ -692,6 +665,10 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipCluster(RCluster *cluster
 {
    RTaskScheduler scheduler;
    scheduler.Run();
+
+   std::mutex fLockIsDone;
+   std::condition_variable fCvIsDone;
+   std::atomic<size_t> nTasks{cluster->GetNOnDiskPages()};
 
    const auto clusterId = cluster->GetId();
    const auto &clusterDescriptor = fDescriptor.GetClusterDescriptor(clusterId);
@@ -713,9 +690,10 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipCluster(RCluster *cluster
          R__ASSERT(onDiskPage);
          R__ASSERT(onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage);
 
-         auto unzipTask = std::make_unique<RUnzipTask>(scheduler);
+         auto unzipTask = std::make_unique<RUnzipTask>();
          unzipTask->fRunFunc =
             [this, columnId, clusterId, firstInPage, onDiskPage,
+             &fLockIsDone, &fCvIsDone, &nTasks,
              element = allElements.back().get(),
              nElements = pi.fNElements,
              indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex
@@ -748,6 +726,11 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipCluster(RCluster *cluster
                   {
                      RPageAllocatorFile::DeletePage(page);
                   }, nullptr));
+
+               if (--nTasks == 0) {
+                  std::lock_guard<std::mutex> lockGuard(fLockIsDone);
+                  fCvIsDone.notify_one();
+               }
             };
 
          scheduler.ScheduleTask(std::move(unzipTask));
@@ -757,6 +740,7 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipCluster(RCluster *cluster
       } // for all pages in column
    } // for all columns in cluster
 
-   scheduler.WaitFor();
    fCounters->fNPagePopulated.Add(cluster->GetNOnDiskPages());
+   std::unique_lock<std::mutex> lock(fLockIsDone);
+   fCvIsDone.wait(lock, [&]{ return nTasks == 0; });
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -575,3 +575,8 @@ ROOT::Experimental::Detail::RPageSourceFile::LoadCluster(DescriptorId_t clusterI
       cluster->SetColumnAvailable(colId);
    return cluster;
 }
+
+void ROOT::Experimental::Detail::RPageSourceFile::UnzipCluster(RCluster *cluster)
+{
+
+}

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -338,7 +338,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
 
 
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::PopulatePageFromCluster(
-   ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor, ClusterSize_t::ValueType clusterIndex)
+   ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor, ClusterSize_t::ValueType idxInCluster)
 {
    const auto columnId = columnHandle.fId;
    const auto clusterId = clusterDescriptor.GetId();
@@ -346,18 +346,18 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
 
    // TODO(jblomer): binary search
    RClusterDescriptor::RPageRange::RPageInfo pageInfo;
-   decltype(clusterIndex) firstInPage = 0;
+   decltype(idxInCluster) firstInPage = 0;
    NTupleSize_t pageNo = 0;
    for (const auto &pi : pageRange.fPageInfos) {
-      if (firstInPage + pi.fNElements > clusterIndex) {
+      if (firstInPage + pi.fNElements > idxInCluster) {
          pageInfo = pi;
          break;
       }
       firstInPage += pi.fNElements;
       ++pageNo;
    }
-   R__ASSERT(firstInPage <= clusterIndex);
-   R__ASSERT((firstInPage + pageInfo.fNElements) > clusterIndex);
+   R__ASSERT(firstInPage <= idxInCluster);
+   R__ASSERT((firstInPage + pageInfo.fNElements) > idxInCluster);
 
    const auto element = columnHandle.fColumn->GetElement();
    const auto elementSize = element->GetSize();
@@ -376,7 +376,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
          fCurrentCluster = fClusterPool->GetCluster(clusterId, fActiveColumns);
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
-      auto cachedPage = fPagePool->GetPage(columnId, RClusterIndex(clusterId, clusterIndex));
+      auto cachedPage = fPagePool->GetPage(columnId, RClusterIndex(clusterId, idxInCluster));
       if (!cachedPage.IsNull())
          return cachedPage;
 
@@ -435,7 +435,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
    ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex)
 {
    const auto clusterId = clusterIndex.GetClusterId();
-   const auto index = clusterIndex.GetIndex();
+   const auto idxInCluster = clusterIndex.GetIndex();
    const auto columnId = columnHandle.fId;
    auto cachedPage = fPagePool->GetPage(columnId, clusterIndex);
    if (!cachedPage.IsNull())
@@ -443,7 +443,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
 
    R__ASSERT(clusterId != kInvalidDescriptorId);
    const auto &clusterDescriptor = fDescriptor.GetClusterDescriptor(clusterId);
-   return PopulatePageFromCluster(columnHandle, clusterDescriptor, index);
+   return PopulatePageFromCluster(columnHandle, clusterDescriptor, idxInCluster);
 }
 
 void ROOT::Experimental::Detail::RPageSourceFile::ReleasePage(RPage &page)

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -375,6 +375,11 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
       if (!fCurrentCluster || (fCurrentCluster->GetId() != clusterId) || !fCurrentCluster->ContainsColumn(columnId))
          fCurrentCluster = fClusterPool->GetCluster(clusterId, fActiveColumns);
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
+
+      auto cachedPage = fPagePool->GetPage(columnId, clusterIndex);
+      if (!cachedPage.IsNull())
+         return cachedPage;
+
       ROnDiskPage::Key key(columnId, pageNo);
       //printf("POPULATE cluster %ld column %ld page %ld\n", clusterId, columnId, pageNo);
       auto onDiskPage = fCurrentCluster->GetOnDiskPage(key);

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -591,6 +591,7 @@ ROOT::Experimental::Detail::RPageSourceFile::LoadCluster(DescriptorId_t clusterI
 
 void ROOT::Experimental::Detail::RPageSourceFile::UnzipClusterImpl(RCluster *cluster)
 {
+   RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
    fTaskScheduler->Reset();
 
    const auto clusterId = cluster->GetId();
@@ -624,7 +625,6 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipClusterImpl(RCluster *clu
 
                auto pageBufferPacked = new unsigned char[bytesPacked];
                if (onDiskPage->GetSize() != bytesPacked) {
-                  RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
                   fDecompressor(onDiskPage->GetAddress(), onDiskPage->GetSize(), bytesPacked, pageBufferPacked);
                   fCounters->fSzUnzip.Add(bytesPacked);
                } else {

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -661,7 +661,8 @@ public:
 } // anonymous namespace
 
 
-void ROOT::Experimental::Detail::RPageSourceFile::UnzipCluster(RCluster *cluster)
+void ROOT::Experimental::Detail::RPageSourceFile::UnzipClusterImpl(
+   RCluster *cluster, TaskScheduleFunc_t /* taskScheduleFunc */)
 {
    RTaskScheduler scheduler;
    scheduler.Run();

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -376,7 +376,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
          fCurrentCluster = fClusterPool->GetCluster(clusterId, fActiveColumns);
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
-      auto cachedPage = fPagePool->GetPage(columnId, clusterIndex);
+      auto cachedPage = fPagePool->GetPage(columnId, RClusterIndex(clusterId, clusterIndex));
       if (!cachedPage.IsNull())
          return cachedPage;
 
@@ -694,18 +694,13 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipCluster(RCluster *cluster
    scheduler.Run();
 
    const auto clusterId = cluster->GetId();
-   //printf("UNZIP cluster %ld\n", clusterId);
    const auto &clusterDescriptor = fDescriptor.GetClusterDescriptor(clusterId);
 
    std::vector<std::unique_ptr<RColumnElementBase>> allElements;
 
-
    const auto &columnsInCluster = cluster->GetAvailColumns();
    for (const auto columnId : columnsInCluster) {
       const auto &columnDesc = fDescriptor.GetColumnDescriptor(columnId);
-
-      //const auto &fieldDesc = fDescriptor.GetFieldDescriptor(columnDesc.GetFieldId());
-      //printf("   UNZIP cluster %ld column %ld %s\n", clusterId, columnId, fieldDesc.GetFieldName().c_str());
 
       allElements.emplace_back(RColumnElementBase::Generate(columnDesc.GetModel().GetType()));
 
@@ -713,7 +708,6 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipCluster(RCluster *cluster
       std::uint64_t pageNo = 0;
       std::uint64_t firstInPage = 0;
       for (const auto &pi : pageRange.fPageInfos) {
-         //printf("      UNZIP cluster %ld column %ld page %ld\n", clusterId, columnId, pageNo);
          ROnDiskPage::Key key(columnId, pageNo);
          auto onDiskPage = cluster->GetOnDiskPage(key);
          R__ASSERT(onDiskPage);
@@ -757,7 +751,6 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipCluster(RCluster *cluster
             };
 
          scheduler.ScheduleTask(std::move(unzipTask));
-         //unzipTask->Run();
 
          firstInPage += pi.fNElements;
          pageNo++;

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -2,8 +2,11 @@
 
 #include "ntuple_test.hxx"
 
+#include "TROOT.h"
+
 TEST(RNTuple, RealWorld1)
 {
+   ROOT::EnableImplicitMT();
    FileRaii fileGuard("test_ntuple_realworld1.root");
 
    // See https://github.com/olifre/root-io-bench/blob/master/benchmark.cpp
@@ -71,6 +74,7 @@ TEST(RNTuple, RealWorld1)
 // Stress test the asynchronous cluster pool by a deliberately unfavourable read pattern
 TEST(RNTuple, RandomAccess)
 {
+   ROOT::EnableImplicitMT();
    FileRaii fileGuard("test_ntuple_random_access.root");
 
    auto modelWrite = RNTupleModel::Create();
@@ -106,6 +110,7 @@ TEST(RNTuple, RandomAccess)
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
 TEST(RNTuple, LargeFile)
 {
+   ROOT::EnableImplicitMT();
    FileRaii fileGuard("test_large_file.root");
 
    auto modelWrite = RNTupleModel::Create();


### PR DESCRIPTION
The cluster pool now not only schedules loading of the compressed pages but also their prompt decompression. All the pages that have been loaded are now pushed into a follow-up pipeline step for decompression and pushing into the page pool.  This is done with multiple threads.  Compared to unwrapping pages on demand, we might now decompress pages from which we never read (because they get completely skipped by the analysis).  The RNTuple benchmarks suggest, however, that this happens quite rarely (<1%).