### PR TITLE
[cling] Do not inject libCling first (ROOT-10499):

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -589,8 +589,9 @@ extern "C" const Decl* TCling__GetObjectDecl(TObject *obj) {
 extern "C" R__DLLEXPORT TInterpreter *CreateInterpreter(void* interpLibHandle,
                                                         const char* argv[])
 {
+   auto tcling = new TCling("C++", "cling C++ Interpreter", argv);
    cling::DynamicLibraryManager::ExposeHiddenSharedLibrarySymbols(interpLibHandle);
-   return new TCling("C++", "cling C++ Interpreter", argv);
+   return tcling;
 }
 
 extern "C" R__DLLEXPORT void DestroyInterpreter(TInterpreter *interp)

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -205,3 +205,10 @@ TEST_F(TClingTests, ClingLookupHelper) {
   gCling->GetFunction(cl, "RDataFrameTake<float>");
   gCling->GetFunction(cl, "RDataFrameTake<std::vector<float>>");
 }
+
+// Check that compiled and interpreted statics share the same address.
+TEST_F(TClingTests, ROOT10499) {
+   EXPECT_EQ((void*)&std::cout, (void*)gInterpreter->Calc("&std::cout"));
+   EXPECT_EQ((void*)&std::cerr, (void*)gInterpreter->Calc("&std::cerr"));
+   EXPECT_EQ((void*)&errno, (void*)gInterpreter->Calc("&errno"));
+}

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -46,32 +46,32 @@ struct CleanupRAII {
 TEST_F(TClingTests, GenerateDictionaryErrorHandling)
 {
    // Check error reporting and handling.
-   ROOT_EXPECT_ERROR(ASSERT_FALSE(gInterpreter->GenerateDictionary("", "")), "TInterpreter::TCling::GenerateDictionary",
+   ROOT_EXPECT_ERROR(EXPECT_FALSE(gInterpreter->GenerateDictionary("", "")), "TInterpreter::TCling::GenerateDictionary",
                      "Cannot generate dictionary without passing classes.");
-   ROOT_EXPECT_ERROR(ASSERT_FALSE(gInterpreter->GenerateDictionary(nullptr, nullptr)),
+   ROOT_EXPECT_ERROR(EXPECT_FALSE(gInterpreter->GenerateDictionary(nullptr, nullptr)),
                      "TInterpreter::TCling::GenerateDictionary", "Cannot generate dictionary without passing classes.");
 }
 
 TEST_F(TClingTests, GenerateDictionaryRegression)
 {
    // Make sure we do not crash or go in an infinite loop.
-   ASSERT_TRUE(gInterpreter->GenerateDictionary("std::set<int>"));
-   ASSERT_TRUE(gInterpreter->GenerateDictionary("std::set<int>", ""));
-   ASSERT_TRUE(gInterpreter->GenerateDictionary("std::set<int>", "set"));
+   EXPECT_TRUE(gInterpreter->GenerateDictionary("std::set<int>"));
+   EXPECT_TRUE(gInterpreter->GenerateDictionary("std::set<int>", ""));
+   EXPECT_TRUE(gInterpreter->GenerateDictionary("std::set<int>", "set"));
 
    // FIXME: This makes the linkdef parser go in an infinite loop.
-   //ASSERT_TRUE(gInterpreter->GenerateDictionary("std::vector<std::array<int, 5>>", ""));
+   //EXPECT_TRUE(gInterpreter->GenerateDictionary("std::vector<std::array<int, 5>>", ""));
 }
 
 TEST_F(TClingTests, GenerateDictionary)
 {
    auto cl = TClass::GetClass("vector<TNamed*>");
-   ASSERT_FALSE(cl && cl->IsLoaded());
+   EXPECT_FALSE(cl && cl->IsLoaded());
 
-   ASSERT_TRUE(gInterpreter->GenerateDictionary("std::vector<TNamed*>"));
+   EXPECT_TRUE(gInterpreter->GenerateDictionary("std::vector<TNamed*>"));
    cl = TClass::GetClass("vector<TNamed*>");
-   ASSERT_TRUE(cl != nullptr);
-   ASSERT_TRUE(cl->IsLoaded());
+   EXPECT_TRUE(cl != nullptr);
+   EXPECT_TRUE(cl->IsLoaded());
 }
 
 // Test ROOT-6967
@@ -79,7 +79,7 @@ TEST_F(TClingTests, GetEnumWithSameVariableName)
 {
    gInterpreter->ProcessLine("int en;enum en{kNone};");
    auto en = gInterpreter->GetEnum(nullptr, "en");
-   ASSERT_TRUE(en != nullptr);
+   EXPECT_TRUE(en != nullptr);
 }
 
 // Check if we can get the source code of function definitions.
@@ -88,7 +88,7 @@ TEST_F(TClingTests, MakeInterpreterValue)
    gInterpreter->Declare("void my_func_to_print() {}");
    std::unique_ptr<TInterpreterValue> v = gInterpreter->MakeInterpreterValue();
    gInterpreter->Evaluate("my_func_to_print", *v);
-   ASSERT_THAT(v->ToString(), testing::HasSubstr("void my_func_to_print"));
+   EXPECT_THAT(v->ToString(), testing::HasSubstr("void my_func_to_print"));
 }
 
 static std::string MakeLibNamePlatformIndependent(llvm::StringRef libName)
@@ -112,31 +112,31 @@ TEST_F(TClingTests, GetClassSharedLibs)
    };
 
    llvm::StringRef lib = GetLibs("TLorentzVector");
-   ASSERT_STREQ("Physics", MakeLibNamePlatformIndependent(lib).c_str());
+   EXPECT_STREQ("Physics", MakeLibNamePlatformIndependent(lib).c_str());
 
    // FIXME: This should return GenVector. The default args of the LorentzVector
    // are shadowed by Vector4Dfwd.h.
    lib = GetLibs("ROOT::Math::LorentzVector");
-   ASSERT_STREQ("", MakeLibNamePlatformIndependent(lib).c_str());
+   EXPECT_STREQ("", MakeLibNamePlatformIndependent(lib).c_str());
 
    lib = GetLibs("ROOT::Math::PxPyPzE4D<float>");
-   ASSERT_STREQ("GenVector", MakeLibNamePlatformIndependent(lib).c_str());
+   EXPECT_STREQ("GenVector", MakeLibNamePlatformIndependent(lib).c_str());
 
    // FIXME: We should probably resolve again to GenVector as it contains the
    // template pattern.
    lib = GetLibs("ROOT::Math::PxPyPzE4D<int>");
-   ASSERT_STREQ("", MakeLibNamePlatformIndependent(lib).c_str());
+   EXPECT_STREQ("", MakeLibNamePlatformIndependent(lib).c_str());
 
    lib = GetLibs("vector<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > >");
-   ASSERT_STREQ("GenVector", MakeLibNamePlatformIndependent(lib).c_str());
+   EXPECT_STREQ("GenVector", MakeLibNamePlatformIndependent(lib).c_str());
 
    lib = GetLibs("ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > ");
 #ifdef R__USE_CXXMODULES
-   ASSERT_STREQ("GenVector", MakeLibNamePlatformIndependent(lib).c_str());
+   EXPECT_STREQ("GenVector", MakeLibNamePlatformIndependent(lib).c_str());
 #else
    // FIXME: This is another bug in the non-modules functionality. Note the
    // trailing space...
-   ASSERT_STREQ("", MakeLibNamePlatformIndependent(lib).c_str());
+   EXPECT_STREQ("", MakeLibNamePlatformIndependent(lib).c_str());
 #endif
 
    // FIXME: Another bug in non-modules:
@@ -172,10 +172,10 @@ TEST_F(TClingTests, GetSharedLibDeps)
       = MakeDepLibsPlatformIndependent(GetLibDeps("libGenVector.so"));
 #ifdef R__MACOSX
    // It may depend on tbb
-   ASSERT_TRUE(llvm::StringRef(SeenDeps).startswith("GenVector"));
+   EXPECT_TRUE(llvm::StringRef(SeenDeps).startswith("GenVector"));
 #else
     // Depends only on libCore.so but libCore.so is loaded and thus missing.
-    ASSERT_STREQ("GenVector", SeenDeps.c_str());
+    EXPECT_STREQ("GenVector", SeenDeps.c_str());
 #endif
 
    SeenDeps = MakeDepLibsPlatformIndependent(GetLibDeps("libTreePlayer.so"));
@@ -184,12 +184,12 @@ TEST_F(TClingTests, GetSharedLibDeps)
    // Depending on the configuration we expect:
    // TreePlayer Gpad Graf Graf3d Hist [Imt] [MathCore] MultiProc Net Tree [tbb]..
    // FIXME: We should add a generic gtest regex matcher and use a regex here.
-   ASSERT_TRUE(SeenDepsRef.startswith("TreePlayer Gpad Graf Graf3d Hist"));
-   ASSERT_TRUE(SeenDepsRef.contains("MultiProc Net Tree"));
+   EXPECT_TRUE(SeenDepsRef.startswith("TreePlayer Gpad Graf Graf3d Hist"));
+   EXPECT_TRUE(SeenDepsRef.contains("MultiProc Net Tree"));
 
-   ROOT_EXPECT_ERROR(ASSERT_TRUE(nullptr == GetLibDeps("")), "TCling__GetSharedLibImmediateDepsSlow",
+   ROOT_EXPECT_ERROR(EXPECT_TRUE(nullptr == GetLibDeps("")), "TCling__GetSharedLibImmediateDepsSlow",
                      "Cannot find library ''");
-   ROOT_EXPECT_ERROR(ASSERT_TRUE(nullptr == GetLibDeps("   ")), "TCling__GetSharedLibImmediateDepsSlow",
+   ROOT_EXPECT_ERROR(EXPECT_TRUE(nullptr == GetLibDeps("   ")), "TCling__GetSharedLibImmediateDepsSlow",
                      "Cannot find library '   '");
 }
 #endif

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -282,22 +282,6 @@ IncrementalJIT::IncrementalJIT(IncrementalExecutor& exe,
   m_CompileLayer(m_ObjectLayer, llvm::orc::SimpleCompiler(*m_TM)),
   m_LazyEmitLayer(m_CompileLayer) {
 
-  // Force the JIT to query for symbols local to itself, i.e. if it resides in a
-  // shared library it will resolve symbols from there first. This is done to
-  // implement our proto symbol versioning protection. Namely, if some other
-  // library provides llvm symbols, we want out JIT to avoid looking at them.
-  //
-  // FIXME: In general, this approach causes numerous issues when cling is
-  // embedded and the framework needs to provide its own set of symbols which
-  // exist in llvm. Most notably if the framework links against different
-  // versions of linked against llvm libraries. For instance, if we want to provide
-  // a custom zlib in the framework the JIT will still resolve to llvm's version
-  // of libz causing hard-to-debug bugs. In order to work around such cases we
-  // need to swap the llvm system libraries, which can be tricky for two
-  // reasons: (a) llvm's cmake doesn't really support it; (b) only works if we
-  // build llvm from sources.
-  llvm::sys::DynamicLibrary::SearchOrder
-    = llvm::sys::DynamicLibrary::SO_LoadedFirst;
   // Enable JIT symbol resolution from the binary.
   llvm::sys::DynamicLibrary::LoadLibraryPermanently(0, 0);
 


### PR DESCRIPTION
Some platforms have problems (rightfully so!) in finding symbols
from libCling.so, which is dlopened with RTLD_LOCAL. libCling should
me made available to RuntimeDyld, but priority should be given to
the main binary, i.e. the "traditional" symbol resolution. This is
achieved by injecting libCling as a symbol source into the
DynLibManager *after* the initialization of cling::Interpreter.

This fixes e.g. ROOT-10499, by resolving to the process's `cout`,
not the "copy" in libCling.