### PR TITLE
[RF] Fix an initial value in RooMomentMorphND.

### DIFF
--- a/roofit/roofit/src/RooMomentMorphND.cxx
+++ b/roofit/roofit/src/RooMomentMorphND.cxx
@@ -450,8 +450,7 @@ RooMomentMorphND::CacheElem *RooMomentMorphND::getCache(const RooArgSet * /*nset
 
    for (int i = 0; i < 3 * nPdf; ++i) {
       string fracName = Form("frac_%d", i);
-      double initval = 0.0;
-      RooRealVar *frac = new RooRealVar(fracName.c_str(), fracName.c_str(), initval); // to be set later
+      RooRealVar *frac = new RooRealVar(fracName.c_str(), fracName.c_str(), 1.); // to be set later
 
       fracl.add(*frac);
       if (i < nPdf)

--- a/roofit/roofit/src/RooMomentMorphND.cxx
+++ b/roofit/roofit/src/RooMomentMorphND.cxx
@@ -450,7 +450,7 @@ RooMomentMorphND::CacheElem *RooMomentMorphND::getCache(const RooArgSet * /*nset
 
    for (int i = 0; i < 3 * nPdf; ++i) {
       string fracName = Form("frac_%d", i);
-      RooRealVar *frac = new RooRealVar(fracName.c_str(), fracName.c_str(), 1.); // to be set later
+      RooRealVar *frac = new RooRealVar(fracName.c_str(), fracName.c_str(), /*value=*/1.); // to be set later
 
       fracl.add(*frac);
       if (i < nPdf)


### PR DESCRIPTION
RooMomentMorphND was initialising fractions to zero. That will lead to
an all-zero PDF, which triggers evaluation errors. Setting all fractions
to 1 avoids those warnings, and the correct values will be calculated
during the first fit step.