### PR TITLE
[DF] Test and workaround for the TLeaf-side part of ROOT-10942

### DIFF
--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -157,6 +157,19 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
          const auto branchName = colName.substr(0, dotPos);
          const auto leafName = colName.substr(dotPos + 1);
          leaf = t.GetLeaf(branchName.c_str(), leafName.c_str());
+
+         // FIXME GetLeaf("a.b") and GetLeaf("a", "b") might fail while GetBranch("a.b") might work, even if a leaf
+         // called "a.b" exists. If that's the case, however, we don't want branch->GetCurrentClass()->GetName() as the
+         // type, because GetCurrentClass() returns the type of the top-level branch.
+         // So as a last resort, let's check if we manage to get to the leaf from the TBranch.
+         // To be revised once the TLeaf part of ROOT-10942 is fixed (see the ticket for more context).
+         auto branch = t.GetBranch(colName.c_str());
+         if (branch) {
+            auto leaves = branch->GetListOfLeaves();
+            if (leaves->GetEntries() == 1 && branch->GetListOfBranches()->GetEntries() == 0 &&
+                static_cast<TLeaf *>(leaves->At(0))->GetFullName() == colName)
+               return GetLeafTypeName(static_cast<TLeaf *>(leaves->At(0)), colName);
+         }
       }
    }
    if (leaf)

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -425,11 +425,11 @@ TEST(RDataFrameInterface, TypeUnknownToInterpreter)
 }
 
 // ROOT-10942
-TEST(RDataFrameInterface, GetColumnNamesWithSimpleStruct)
+TEST(RDataFrameInterface, ColumnWithSimpleStruct)
 {
    gInterpreter->Declare("struct S { int a; int b; };");
    S c;
-   c.a = 1;
+   c.a = 42;
    c.b = 2;
    TTree t("t", "t");
    t.Branch("c", &c);
@@ -438,4 +438,8 @@ TEST(RDataFrameInterface, GetColumnNamesWithSimpleStruct)
    ROOT::RDataFrame df(t);
    const std::vector<std::string> expected({ "c.a", "a", "c.b", "b", "c" });
    EXPECT_EQ(df.GetColumnNames(), expected);
+   for (const std::string &col : {"c.a", "a"}) {
+      EXPECT_DOUBLE_EQ(df.Mean<int>(col).GetValue(), 42.); // compiled
+      EXPECT_DOUBLE_EQ(df.Mean(col).GetValue(), 42.); // jitted
+   }
 }


### PR DESCRIPTION
This should bring RDF back to a fully working state (for all cases we test) after the change in valid column names discussed in ROOT-10942 .