### PR TITLE
[PyROOT] Respect existing __str__ method in pretty printing

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_generic.py
@@ -41,8 +41,15 @@ def pythonizegeneric(klass, name):
     # name: string containing the name of the class
 
     # Add pretty printing via setting the __str__ special function
+
+    # Exclude classes which have the method __str__ already defined in C++
+    m = getattr(klass, '__str__', None)
+    has_cpp_str = True if m is not None and type(m).__name__ == 'CPPOverload' else False
+
+    # Exclude std::string with its own pythonization from cppyy
     exclude = [ 'std::string' ]
-    if name not in exclude:
+
+    if name not in exclude and not has_cpp_str:
         AddPrettyPrintingPyz(klass)
 
     return True

--- a/bindings/pyroot/pythonizations/test/pretty_printing.py
+++ b/bindings/pyroot/pythonizations/test/pretty_printing.py
@@ -65,6 +65,25 @@ class PrettyPrinting(unittest.TestCase):
         self.assertIn("TTree object at", s)
         self.assertEqual(s, r)
 
+    def test_user_class_with_str(self):
+        # ROOT-10967: Respect existing __str__ method defined in C++
+        ROOT.gInterpreter.Declare('struct MyClassWithStr { std::string __str__() { return "foo"; } };')
+        x = ROOT.MyClassWithStr()
+        self._print(x)
+        s = x.__str__()
+        r = x.__repr__()
+        self.assertIn("MyClassWithStr object at", r)
+        self.assertEqual(s, "foo")
+
+        # Test inherited class
+        ROOT.gInterpreter.Declare('struct MyClassWithStr2 : public MyClassWithStr { };')
+        x2 = ROOT.MyClassWithStr2()
+        self._print(x2)
+        s2 = x2.__str__()
+        r2 = x2.__repr__()
+        self.assertIn("MyClassWithStr2 object at", r2)
+        self.assertEqual(s2, "foo")
+
 
     # TNamed and TObject are not pythonized because these object are touched
     # by PyROOT before any pythonizations are added. Following, the classes


### PR DESCRIPTION
If the method `__str__` is already defined on the C++ side, don't inject
the cling based pretty printing.

Related to ROOT-10967

@etejedor You see any performance implications with the check added below? Do we trigger lookups with the `dir(...)`? Just to be sure :)