### PR TITLE
[DF] Use unique file names in tests (6.22)

### DIFF
--- a/tree/dataframe/test/dataframe_display.cxx
+++ b/tree/dataframe/test/dataframe_display.cxx
@@ -178,7 +178,7 @@ TEST(RDFDisplayTests, DisplayPrintString)
 TEST(RDFDisplayTests, CharArray)
 {
    {
-      TFile f("f.root", "recreate");
+      TFile f("chararray.root", "recreate");
       TTree t("t", "t");
       char str[4] = "asd";
       t.Branch("str", str, "str[4]/C");
@@ -189,7 +189,7 @@ TEST(RDFDisplayTests, CharArray)
       f.Write();
    }
 
-   const auto str = ROOT::RDataFrame("t", "f.root").Display()->AsString();
+   const auto str = ROOT::RDataFrame("t", "chararray.root").Display()->AsString();
    EXPECT_EQ(str, "str | \nasd | \nbar | \n    | \n");
 }
 

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -226,7 +226,7 @@ TEST(RDFHelpers, SaveGraphAfterEventLoop)
 
 TEST(RDFHelpers, SaveGraphRootFromTree)
 {
-   TFile f("f.root", "recreate");
+   TFile f("savegraphrootfromtree.root", "recreate");
    TTree t("t", "t");
    int a;
    t.Branch("a", &a);
@@ -239,7 +239,7 @@ TEST(RDFHelpers, SaveGraphRootFromTree)
       "digraph {\n\t2 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
       "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 2;\n}");
 
-   ROOT::RDataFrame df("t", "f.root");
+   ROOT::RDataFrame df("t", "savegraphrootfromtree.root");
    auto c = df.Count();
 
    auto strOut = SaveGraph(c);
@@ -249,7 +249,7 @@ TEST(RDFHelpers, SaveGraphRootFromTree)
 
 TEST(RDFHelpers, SaveGraphToFile)
 {
-   TFile f("f.root", "recreate");
+   TFile f("savegraphtofile.root", "recreate");
    TTree t("t", "t");
    int a;
    t.Branch("a", &a);
@@ -262,7 +262,7 @@ TEST(RDFHelpers, SaveGraphToFile)
       "digraph {\n\t2 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
       "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 2;\n}");
 
-   ROOT::RDataFrame df("t", "f.root");
+   ROOT::RDataFrame df("t", "savegraphtofile.root");
    auto c = df.Count();
 
    const auto outFileName = "savegraphout.root";


### PR DESCRIPTION
Otherwise tests run concurrently can write on each other's feet.