### PR TITLE
[cling] Explicitly resolve symbols also from injected libs:

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -281,6 +281,11 @@ IncrementalJIT::IncrementalJIT(IncrementalExecutor& exe,
                 m_NotifyObjectLoaded, NotifyFinalizedT(*this)),
   m_CompileLayer(m_ObjectLayer, llvm::orc::SimpleCompiler(*m_TM)),
   m_LazyEmitLayer(m_CompileLayer) {
+  // Libraries might get exposed through ExposeHiddenSharedLibrarySymbols(),
+  // make them available to the JIT, even though their symbols cannot be
+  // resolved through the process.
+  llvm::sys::DynamicLibrary::SearchOrder
+    = llvm::sys::DynamicLibrary::SO_LoadedLast;
 
   // Enable JIT symbol resolution from the binary.
   llvm::sys::DynamicLibrary::LoadLibraryPermanently(0, 0);


### PR DESCRIPTION
Some platforms respect RTLD_LOCAL: symbols from libraries loaded with
this flag cannot be resolved by dlsym through the process. They should
instead be exposed to the JIT by calling ExposeHiddenSharedLibrarySymbols().
But then the JIT needs to actually make use of these libraries from
symbol resolution. That is done by setting SearchOrder to SO_LoadedLast, as
nicely documented in that flag.

Fixes ROOT not finding libCling symbols on some platforms, e.g. CentOS7,
Ubuntu 16 and 18.