### PR TITLE
[PyROOT] Harden tests of refcounts by invoking GC manually

### DIFF
--- a/bindings/pyroot/pythonizations/test/numbadeclare.py
+++ b/bindings/pyroot/pythonizations/test/numbadeclare.py
@@ -3,6 +3,7 @@ import ROOT
 import sys
 import os
 import numpy as np
+import gc
 
 
 # Check whether these tests should be skipped
@@ -45,6 +46,7 @@ class NumbaDeclareSimple(unittest.TestCase):
         Test refcount of decorator
         """
         x = ROOT.Numba.Declare(["float"], "float")
+        gc.collect()
         self.assertEqual(sys.getrefcount(x), 2)
 
     @unittest.skipIf(skip, skip_reason)
@@ -58,6 +60,7 @@ class NumbaDeclareSimple(unittest.TestCase):
             return x
         fn0 = ROOT.Numba.Declare(["float"], "float")(f1)
         ref = nb.cfunc("float32(float32)", nopython=True)(f2)
+        gc.collect()
         if sys.version_info.major == 2:
             self.assertEqual(sys.getrefcount(f1), sys.getrefcount(f2) + 1)
         else:
@@ -84,6 +87,8 @@ class NumbaDeclareSimple(unittest.TestCase):
         @ROOT.Numba.Declare(["float"], "float")
         def fn1(x):
             return x
+
+        gc.collect()
 
         self.assertTrue(hasattr(fn1, "__cpp_wrapper__"))
         self.assertTrue(type(fn1.__cpp_wrapper__) == str)

--- a/bindings/pyroot/pythonizations/test/rvec_asrvec.py
+++ b/bindings/pyroot/pythonizations/test/rvec_asrvec.py
@@ -2,6 +2,7 @@ import unittest
 import ROOT
 import numpy as np
 import sys
+import gc
 
 
 def get_maximum_for_dtype(dtype):
@@ -105,9 +106,11 @@ class AsRVec(unittest.TestCase):
         """
         np_obj = np.array([1, 2])
         rvec = ROOT.VecOps.AsRVec(np_obj)
+        gc.collect()
         self.assertEqual(sys.getrefcount(rvec), 2)
         self.assertEqual(sys.getrefcount(np_obj), 3)
         del rvec
+        gc.collect()
         self.assertEqual(sys.getrefcount(np_obj), 2)
 
 


### PR DESCRIPTION
Axel has observed a flaky test on fedora30, which collects too late objects being already out of scope and the fails the test of the refcounts. I've put invokations of the GC now always before we test refcounts to prevent such failures.