### PR TITLE
Set LC_RPATH while building builtin_xrootd

### DIFF
--- a/cmake/modules/XROOTDApplePostInstall.cmake
+++ b/cmake/modules/XROOTDApplePostInstall.cmake
@@ -8,22 +8,7 @@
 
 function(xrootd_libs_change_rpath build_libdir install_libdir)
 
-  set(XROOTD_ALL_LIBRARIES libXrdAppUtils.dylib libXrdBlacklistDecision-4.so
-                           libXrdBwm-4.so libXrdCksCalczcrc32-4.so
-                           libXrdCl.dylib libXrdClProxyPlugin-4.so
-                           libXrdClient.dylib libXrdCmsRedirectLocal-4.so
-                           libXrdCrypto.dylib libXrdCryptoLite.dylib
-                           libXrdFfs.dylib libXrdFileCache-4.so
-                           libXrdN2No2p-4.so libXrdOssSIgpfsT-4.so
-                           libXrdPosix.dylib libXrdPosixPreload.dylib
-                           libXrdPss-4.so libXrdSec-4.so libXrdSecProt-4.so
-                           libXrdSeckrb5-4.so libXrdSecpwd-4.so
-                           libXrdSecsss-4.so libXrdSecunix-4.so
-                           libXrdServer.dylib libXrdSsi-4.so
-                           libXrdSsiLib.dylib libXrdSsiLog-4.so
-                           libXrdSsiShMap.dylib libXrdThrottle-4.so
-                           libXrdUtils.dylib libXrdXml.dylib libXrdXrootd-4.so
-  )
+  file(GLOB XROOTD_ALL_LIBRARIES "${install_libdir}/libXrd*")
 
   find_program(INSTALL_NAME_TOOL install_name_tool)
 
@@ -31,13 +16,15 @@ function(xrootd_libs_change_rpath build_libdir install_libdir)
     message(STATUS "Found tool ${INSTALL_NAME_TOOL}")
     message(STATUS "Adjusting LC_RPATH variable of XRootD libraries in ${install_libdir}")
 
-    foreach(XRD_LIB_PATH IN LISTS XROOTD_ALL_LIBRARIES)
+    foreach(XRD_LIB_PATH ${XROOTD_ALL_LIBRARIES})
       execute_process(COMMAND ${INSTALL_NAME_TOOL} -rpath 
                               ${build_libdir} ${install_libdir} 
                               ${install_libdir}/${XRD_LIB_PATH}
                       ERROR_QUIET
       )
     endforeach()
+  else()
+    message(WARNING "install_name_tool was not found. LC_RPATH variable will not be modified.")
   endif()
 
 endfunction()

--- a/cmake/modules/XROOTDApplePostInstall.cmake
+++ b/cmake/modules/XROOTDApplePostInstall.cmake
@@ -2,14 +2,27 @@
 # libraries on macOS after installation. The function changes the value from
 # ${build_libdir} to ${install_libdir} with the `install_name_tool` executable.
 # On successive reiterations of the `cmake --install` command,
-# `install_name_tool` would error out since LC_RPATH would be already set to 
-# ${install_libdir}. Since that is what we want in the end, we redirect the
-# errors to /dev/null.
+# `install_name_tool` would error out since LC_RPATH would be already set to
+# ${install_libdir}. Since that is what we want in the end, we discard these
+# errors.
 
 function(xrootd_libs_change_rpath build_libdir install_libdir)
 
-  file(GLOB XROOTD_ALL_LIBRARIES
-    "${install_libdir}/libXrd*"
+  set(XROOTD_ALL_LIBRARIES libXrdAppUtils.dylib libXrdBlacklistDecision-4.so
+                           libXrdBwm-4.so libXrdCksCalczcrc32-4.so
+                           libXrdCl.dylib libXrdClProxyPlugin-4.so
+                           libXrdClient.dylib libXrdCmsRedirectLocal-4.so
+                           libXrdCrypto.dylib libXrdCryptoLite.dylib
+                           libXrdFfs.dylib libXrdFileCache-4.so
+                           libXrdN2No2p-4.so libXrdOssSIgpfsT-4.so
+                           libXrdPosix.dylib libXrdPosixPreload.dylib
+                           libXrdPss-4.so libXrdSec-4.so libXrdSecProt-4.so
+                           libXrdSeckrb5-4.so libXrdSecpwd-4.so
+                           libXrdSecsss-4.so libXrdSecunix-4.so
+                           libXrdServer.dylib libXrdSsi-4.so
+                           libXrdSsiLib.dylib libXrdSsiLog-4.so
+                           libXrdSsiShMap.dylib libXrdThrottle-4.so
+                           libXrdUtils.dylib libXrdXml.dylib libXrdXrootd-4.so
   )
 
   find_program(INSTALL_NAME_TOOL install_name_tool)
@@ -18,12 +31,13 @@ function(xrootd_libs_change_rpath build_libdir install_libdir)
     message(STATUS "Found tool ${INSTALL_NAME_TOOL}")
     message(STATUS "Adjusting LC_RPATH variable of XRootD libraries in ${install_libdir}")
 
-    foreach(XRD_LIB_PATH ${XROOTD_ALL_LIBRARIES})
-      execute_process(COMMAND 
-        bash -c "${INSTALL_NAME_TOOL} -rpath ${build_libdir} ${install_libdir} ${XRD_LIB_PATH} 2> /dev/null || true"
+    foreach(XRD_LIB_PATH IN LISTS XROOTD_ALL_LIBRARIES)
+      execute_process(COMMAND ${INSTALL_NAME_TOOL} -rpath 
+                              ${build_libdir} ${install_libdir} 
+                              ${install_libdir}/${XRD_LIB_PATH}
+                      ERROR_QUIET
       )
     endforeach()
-
   endif()
 
 endfunction()

--- a/cmake/modules/XROOTDApplePostInstall.cmake
+++ b/cmake/modules/XROOTDApplePostInstall.cmake
@@ -1,0 +1,29 @@
+# Post install routine needed to change the LC_RPATH variable of the XRootD
+# libraries on macOS after installation. The function changes the value from
+# ${build_libdir} to ${install_libdir} with the `install_name_tool` executable.
+# On successive reiterations of the `cmake --install` command,
+# `install_name_tool` would error out since LC_RPATH would be already set to 
+# ${install_libdir}. Since that is what we want in the end, we redirect the
+# errors to /dev/null.
+
+function(xrootd_libs_change_rpath build_libdir install_libdir)
+
+  file(GLOB XROOTD_ALL_LIBRARIES
+    "${install_libdir}/libXrd*"
+  )
+
+  find_program(INSTALL_NAME_TOOL install_name_tool)
+
+  if(INSTALL_NAME_TOOL)
+    message(STATUS "Found tool ${INSTALL_NAME_TOOL}")
+    message(STATUS "Adjusting LC_RPATH variable of XRootD libraries in ${install_libdir}")
+
+    foreach(XRD_LIB_PATH ${XROOTD_ALL_LIBRARIES})
+      execute_process(COMMAND 
+        bash -c "${INSTALL_NAME_TOOL} -rpath ${build_libdir} ${install_libdir} ${XRD_LIB_PATH} 2> /dev/null || true"
+      )
+    endforeach()
+
+  endif()
+
+endfunction()


### PR DESCRIPTION
The original issue is with some python tutorial failing on macOS nodes due to
```
<TNetXNGFile::Open>: [FATAL] Auth failed
```
Which in turn is due to a failure in loading some xrootd security libraries, among which
```
[Error  ][Utility           ] Unable to pre-load libXrdSecpwd.so: Plugin unable to load libXrdSecpwd-4.so; dlopen(libXrdSecpwd-4.so, 256): image not found
```

This happens because the library depends on other libraries (`libXrdCrypto`, `libXrdUtils`) and cannot find them since the `@rpath` palceholder is not substituted with the correct path to the libraries directory at runtime.
While this is true for the xrootd libraries in `build/lib`, it's not for the ones in `build/XROOTD-prefix/../src` which have the `LC_RPATH` variable set. The difference can be shown with `otool -l`
```
$ otool -l build/lib/libXrdSecpwd-4.so > libXrdSecpwd_buildlib.txt
$ otool -l build/XROOTD-prefix/src/XROOTD-build/src/libXrdSecpwd-4.so > libXrdSecpwd_xrootdprefixlib.txt
$ diff libXrdSecpwd_buildlib.txt libXrdSecpwd_xrootdprefixlib.txt
< build/lib/libXrdSecpwd-4.so:
---
> build/XROOTD-prefix/src/XROOTD-build/src/libXrdSecpwd-4.so:
307a308,311
>           cmd LC_RPATH
>       cmdsize 80
>          path /Users/sftnight/vpadulan/build/XROOTD-prefix/src/XROOTD-build/src (offset 12)
> Load command 14
312c316
< Load command 14
---
```

This `LC_RPATH` variable is set for our own libraries, e.g. `libHtml.so`
```
$ otool -l build/lib/libHtml.so
[...]
Load command 15
          cmd LC_RPATH
      cmdsize 80
         path /Users/sftnight/vpadulan/build/lib (offset 12)
```
But for some reason this information is lost after building `builtin_xrootd` (probably while installing the libraries from the prefix to the install directory).

A way to solve this is by manually adding the `CMAKE_INSTALL_RPATH` option to the `cmake` invokation of `builtin_xrootd` as is done in this PR. The result is:
```
$ otool -l build/lib/libXrdSecpwd-4.so
[...]
Load command 15
          cmd LC_RPATH
      cmdsize 80
         path /Users/sftnight/vpadulan/build/lib (offset 12)
```
This solves the initial problem with the python tutorial that now can run without errors
```
$time python build/tutorials/dataframe/df103_NanoAODHiggsAnalysis.py

real    0m20.308s
user    0m18.505s
sys    0m0.733s
```

There is still something to discuss: the libraries under `install/lib` still have `LC_RPATH` pointing to `build/lib`:
```
$ otool -l install/lib/libXrdSecpwd-4.so
[...]
Load command 15
          cmd LC_RPATH
      cmdsize 80
         path /Users/sftnight/vpadulan/build/lib (offset 12)
```

