### PR TITLE
[DF] Slightly improve compile-times of generated code

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -376,7 +376,8 @@ void JitFilterHelper(F &&f, const ColumnNames_t &cols, std::string_view name,
    // share data after it has lazily compiled the code. Here the data has been used and the memory can be freed.
    delete customColumns;
 
-   jittedFilter->SetFilter(std::make_unique<F_t>(std::forward<F>(f), cols, *prevNodeOnHeap, newColumns, name));
+   jittedFilter->SetFilter(
+      std::unique_ptr<RFilterBase>(new F_t(std::forward<F>(f), cols, *prevNodeOnHeap, newColumns, name)));
    delete prevNodeOnHeap;
    delete wkJittedFilter;
 }


### PR DESCRIPTION
make_unique<ConcreteFilterType> requires many different type
instantiations, but we actually always upcast to unique_ptr<FilterBase>,
so let's just instantiate _that_.

This saves a few seconds of compile times in artificial benchmarks.