### PR TITLE
[DF] Fix inclusion of certain arrow headers in new arrow versions (6.20)

### DIFF
--- a/tree/dataframe/test/datasource_arrow.cxx
+++ b/tree/dataframe/test/datasource_arrow.cxx
@@ -11,7 +11,7 @@
 #include <arrow/memory_pool.h>
 #include <arrow/record_batch.h>
 #include <arrow/table.h>
-#include <arrow/compute/test_util.h>
+#include <arrow/testing/gtest_util.h>
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
arrow/compute/test_util.h has been removed from recent versions,
but arrow/testing/gtest_util.h contains what we need and is present
both in v0.15 and v0.17.