### PR TITLE
[cling] Fix next clang::CodeGen EH assert on MacOS:

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
@@ -533,6 +533,14 @@ void CodeGenFunction::EmitEndEHSpec(const Decl *D) {
     return;
 
   ExceptionSpecificationType EST = Proto->getExceptionSpecType();
+
+  // Might need to deserialize
+  if (EST == EST_Uninstantiated || EST == EST_Unevaluated) {
+    FD = FD->getMostRecentDecl();
+    Proto = FD->getType()->getAs<FunctionProtoType>();
+    EST = Proto->getExceptionSpecType();
+  }
+
   if (isNoexceptExceptionSpec(EST)) {
     if (Proto->getNoexceptSpec(getContext()) == FunctionProtoType::NR_Nothrow) {
       EHStack.popTerminate();


### PR DESCRIPTION
This extends "98ee7a19d0 [cling] Fix clang::CodeGen EH assert on MacOS:".
Just as for BeginEH, EndEH might not see the complete picture of an already
evaluated EST from a different Decl in the redecl chain. Teach it to look
at the most recent.

This assert hits when:
- a deserialized decl with unevaluated EST is emitted, but a later redecl has the EST evaluated;
- during the emission, CompleteRedeclChain() is not triggered, and the emitted decl does not get
an updated EST
In EmitEndEHSpec, the decl thus still has EST unevaluated, despite EmitBeginEHSpec having looked
at an evaluated EST from the most recent decl.

This fixes e.g. ./tree/dataframe/test/dataframe_ranges in ROOT on MacOS 10.15 with C++17.