### PR TITLE
[cmake] help users get rid of "pyroot_experimental is a deprecated":

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1611,7 +1611,8 @@ endif()
 
 #---Check for deprecated PyROOT experimental ---------------------------------------------
 if(pyroot_experimental)
-  message(WARNING "pyroot_experimental is a deprecated flag from 6.22.00. To build the new PyROOT, just configure with -Dpyroot=ON.")
+  message(WARNING "pyroot_experimental is a deprecated flag from 6.22.00."
+                  "To build the new PyROOT, just configure with -Dpyroot=ON -Dpyroot_experimental=OFF.")
 endif()
 
 #---Check for MPI---------------------------------------------------------------------


### PR DESCRIPTION
Just specifying -Dpyroot=ON does not prevent pyroot_experimental from being set.
And the "deprecated" warning will be issues as long as pyroot_experimental is set.
So tell people to set it to OFF, which will get rid of the warning.