### PR TITLE
[json] adjust char* JSON format depending on content

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3305,7 +3305,7 @@ void TBufferJSON::WriteFastArray(const Char_t *c, Int_t n)
    Bool_t has_zero = false;
    for (int i=0;i<n;++i)
       if (!c[i])
-         has_zero = true;
+         has_zero = true; // might be terminal '\0'
       else if (has_zero || !isprint(c[i]))
          need_blob = true;
 

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3295,7 +3295,7 @@ void TBufferJSON::WriteFastArray(const Bool_t *b, Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Char_t to buffer
 ///
-/// Normally written as JSON string, but if string includes 0 in the middle
+/// Normally written as JSON string, but if string includes \0 in the middle
 /// or some special characters, uses regular array. From array size 1000 it
 /// will be automatically converted into base64 coding
 

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3306,7 +3306,7 @@ void TBufferJSON::WriteFastArray(const Char_t *c, Int_t n)
    for (int i=0;i<n;++i)
       if (!c[i])
          has_zero = true;
-      else if (has_zero || (c[i] < 10))
+      else if (has_zero || !isprint(c[i]))
          need_blob = true;
 
    if (need_blob && (n >= 1000) && (!Stack()->fElem || (Stack()->fElem->GetArrayDim() < 2)))

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3303,11 +3303,14 @@ void TBufferJSON::WriteFastArray(const Char_t *c, Int_t n)
 {
    Bool_t need_blob = false;
    Bool_t has_zero = false;
-   for (int i=0;i<n;++i)
-      if (!c[i])
+   for (int i=0;i<n;++i) {
+      if (!c[i]) {
          has_zero = true; // might be terminal '\0'
-      else if (has_zero || !isprint(c[i]))
+      } else if (has_zero || !isprint(c[i])) {
          need_blob = true;
+         break;
+      }
+   }
 
    if (need_blob && (n >= 1000) && (!Stack()->fElem || (Stack()->fElem->GetArrayDim() < 2)))
       Stack()->fBase64 = true;

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3301,7 +3301,8 @@ void TBufferJSON::WriteFastArray(const Bool_t *b, Int_t n)
 
 void TBufferJSON::WriteFastArray(const Char_t *c, Int_t n)
 {
-   Bool_t need_blob = false, has_zero = false;
+   Bool_t need_blob = false;
+   Bool_t has_zero = false;
    for (int i=0;i<n;++i)
       if (!c[i])
          has_zero = true;

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -1892,10 +1892,10 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
 
       if (objClass && (jsonClass != objClass)) {
          if (obj || (jsonClass->GetBaseClassOffset(objClass) != 0)) {
-            if (jsonClass->GetBaseClassOffset(objClass) < 0) 
+            if (jsonClass->GetBaseClassOffset(objClass) < 0)
                Error("JsonReadObject", "Not possible to read %s and casting to %s pointer as the two classes are unrelated",
                      jsonClass->GetName(), objClass->GetName());
-            else 
+            else
                Error("JsonReadObject", "Reading %s and casting to %s pointer is currently not supported",
                      jsonClass->GetName(), objClass->GetName());
             if (process_stl)
@@ -2762,10 +2762,10 @@ R__ALWAYS_INLINE void TBufferJSON::JsonReadFastArray(T *arr, Int_t arrsize, bool
          nlohmann::json *elem = &(json->at(indx[0]));
          for (int k = 1; k < lastdim; ++k)
             elem = &((*elem)[indx[k]]);
-         arr[cnt] = asstring ? elem->get<std::string>()[indx[lastdim]] : (*elem)[indx[lastdim]].get<T>();
+         arr[cnt] = (asstring && elem->is_string()) ? elem->get<std::string>()[indx[lastdim]] : (*elem)[indx[lastdim]].get<T>();
          indexes->NextSeparator();
       }
-   } else if (asstring) {
+   } else if (asstring && json->is_string()) {
       std::string str = json->get<std::string>();
       for (int cnt = 0; cnt < arrsize; ++cnt)
          arr[cnt] = (cnt < (int)str.length()) ? str[cnt] : 0;
@@ -3294,10 +3294,24 @@ void TBufferJSON::WriteFastArray(const Bool_t *b, Int_t n)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Write array of Char_t to buffer
+///
+/// Normally written as JSON string, but if string includes 0 in the middle
+/// or some special characters, uses regular array. From array size 1000 it
+/// will be automatically converted into base64 coding
 
 void TBufferJSON::WriteFastArray(const Char_t *c, Int_t n)
 {
-   JsonWriteFastArray(c, n, "Int8", &TBufferJSON::JsonWriteConstChar);
+   Bool_t need_blob = false, has_zero = false;
+   for (int i=0;i<n;++i)
+      if (!c[i])
+         has_zero = true;
+      else if (has_zero || (c[i] < 10))
+         need_blob = true;
+
+   if (need_blob && (n >= 1000) && (!Stack()->fElem || (Stack()->fElem->GetArrayDim() < 2)))
+      Stack()->fBase64 = true;
+
+   JsonWriteFastArray(c, n, "Int8", need_blob ? &TBufferJSON::JsonWriteArrayCompress<Char_t> : &TBufferJSON::JsonWriteConstChar);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Before char* was always converted to JSON string, which was not correct.
Some special symbols can not be represented correctly by string
Also #0 symbol used as string terminator. Therefore if such special
usecase appears, JSON array is used. If there are more than 1000
elements - base64 coding automatically applied. 
Requied to correctly stream TASImage data