### PR TITLE
Fix for Visual Studio 2019 v16.7.0

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4077,6 +4077,13 @@ int RootClingMain(int argc,
    for (const std::string &PPDefine : gOptPPDefines)
       clingArgs.push_back(std::string("-D") + PPDefine);
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1926)
+    // FIXME: Silly workaround for rootcling not being able to parse the STL
+    //        headers anymore after the update of Visual Studio v16.7.0
+    //        To be checked/removed after the upgrade of LLVM & Clang
+   clingArgs.push_back(std::string("-D__CUDACC__"));
+#endif
+
    for (const std::string &PPUndefine : gOptPPUndefines)
       clingArgs.push_back(std::string("-U") + PPUndefine);
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4078,9 +4078,9 @@ int RootClingMain(int argc,
       clingArgs.push_back(std::string("-D") + PPDefine);
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1926)
-    // FIXME: Silly workaround for rootcling not being able to parse the STL
-    //        headers anymore after the update of Visual Studio v16.7.0
-    //        To be checked/removed after the upgrade of LLVM & Clang
+   // FIXME: Silly workaround for rootcling not being able to parse the STL
+   //        headers anymore after the update of Visual Studio v16.7.0
+   //        To be checked/removed after the upgrade of LLVM & Clang
    clingArgs.push_back(std::string("-D__CUDACC__"));
 #endif
 

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -776,6 +776,12 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     PPOpts.addMacroDef("__CLING__GNUC_MINOR__=" ClingStringify(__GNUC_MINOR__));
 #elif defined(_MSC_VER)
     PPOpts.addMacroDef("__CLING__MSVC__=" ClingStringify(_MSC_VER));
+#if (_MSC_VER >= 1926)
+    // FIXME: Silly workaround for rootcling not being able to parse the STL
+    //        headers anymore after the update of Visual Studio v16.7.0
+    //        To be checked/removed after the upgrade of LLVM & Clang
+    PPOpts.addMacroDef("__CUDACC__");
+#endif
 #endif
 
 // https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -776,12 +776,6 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     PPOpts.addMacroDef("__CLING__GNUC_MINOR__=" ClingStringify(__GNUC_MINOR__));
 #elif defined(_MSC_VER)
     PPOpts.addMacroDef("__CLING__MSVC__=" ClingStringify(_MSC_VER));
-#if (_MSC_VER >= 1926)
-    // FIXME: Silly workaround for rootcling not being able to parse the STL
-    //        headers anymore after the update of Visual Studio v16.7.0
-    //        To be checked/removed after the upgrade of LLVM & Clang
-    PPOpts.addMacroDef("__CUDACC__");
-#endif
 #endif
 
 // https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html


### PR DESCRIPTION
Silly workaround for rootcling not being able to parse the STL headers anymore after the update of Visual Studio to the version 16.7.0:
```
  Generating G__Core.cxx, ../bin/libCore.rootmap
  In file included from input_line_5:1:
  In file included from C:/Users/sftnight/build/release/include\Rtypes.h:191:
  In file included from C:/Users/sftnight/build/release/include/TGenericClassInfo.h:21:
  In file included from C:/Users/sftnight/build/release/include/TSchemaHelper.h:17:
  In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.291  10\\include\string:11:
  In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.291  10\\include\xstring:14:
  In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.291  10\\include\xmemory:16:
  In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.291  10\\include\xutility:15:
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\utility(137,9): error G08EB1F86: expected member name or ';' after declaration specifiers [C:\Users\sftnight\build\release\core\G__Core.vcxproj]
          !_Is_implicitly_default_constructible<_Uty1>::value || !_Is_implicitly_default_constructible<_Uty2>::value)
          ^
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\utility(137,9): error GC66A3811: expected ')' [C:\Users\sftnight\build\release\core\G__Core.vcxproj]
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\utility:136:23: note: to match this '('
      constexpr explicit(
                        ^
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\utility(218,24): error G08EB1F86: expected member name or ';' after declaration specifiers [C:\Users\sftnight\build\release\core\G__Core.vcxproj]
      constexpr explicit(!is_convertible_v<const _Other1&, _Ty1> || !is_convertible_v<const _Other2&, _Ty2>)
      ~~~~~~~~~~~~~~~~~~ ^
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\utility(218,24): error GC66A3811: expected ')' [C:\Users\sftnight\build\release\core\G__Core.vcxproj]
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\utility:218:23: note: to match this '('
      constexpr explicit(!is_convertible_v<const _Other1&, _Ty1> || !is_convertible_v<const _Other2&, _Ty2>)
                        ^
  In file included from input_line_5:1:
  In file included from C:/Users/sftnight/build/release/include\Rtypes.h:191:
  In file included from C:/Users/sftnight/build/release/include/TGenericClassInfo.h:21:
  In file included from C:/Users/sftnight/build/release/include/TSchemaHelper.h:17:
  In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\string:11:
  In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\xstring:14:
  In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\xmemory:16:
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\xutility(63,31): error G959205E0: '_To' does not refer to a value [C:\Users\sftnight\build\release\core\G__Core.vcxproj]
      return __builtin_bit_cast(_To, _Val);
                                ^
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\\include\xutility:51:17: note: declared here
  template <class _To, class _From,
                  ^
CUSTOMBUILD : error : Error loading the default header files. [C:\Users\sftnight\build\release\core\G__Core.vcxproj]
```
To be checked/removed after the upgrade of LLVM & Clang