### PR TITLE
Fix TMVA tests: #elif without expression and typo

### DIFF
--- a/tmva/tmva/test/Method/TestMethodDNNValidationSize.cxx
+++ b/tmva/tmva/test/Method/TestMethodDNNValidationSize.cxx
@@ -44,14 +44,14 @@ struct TestMethodDNNValidationSize {
    size_t GetProcessedValidationOption(TString options)
    {
 #ifdef DNNCPU
-      const TString defualtOptions = "!H:!V:Layout=RELU|50:Architecture=CPU:";
-#elif DNNCUDA
-      const TString defualtOptions = "!H:!V:Layout=RELU|50:Architecture=GPU:";
+      const TString defaultOptions = "!H:!V:Layout=RELU|50:Architecture=CPU:";
+#elif defined DNNCUDA
+      const TString defaultOptions = "!H:!V:Layout=RELU|50:Architecture=GPU:";
 #else
 #error "This should not happen. Can only compile with CPU or CUDA implementations."
 #endif
 
-      IMethod *m = fFactory->BookMethod(fDataLoader.get(), Types::kDNN, "DNN", defualtOptions + options);
+      IMethod *m = fFactory->BookMethod(fDataLoader.get(), Types::kDNN, "DNN", defaultOptions + options);
       MethodDNN *mdnn = dynamic_cast<MethodDNN *>(m);
 
       size_t numValidationSamples = mdnn->GetNumValidationSamples();


### PR DESCRIPTION
fixes the following:
```
/build/root/src/root-6.22.00-cuda/tmva/tmva/test/Method/TestMethodDNNValidationSize.cxx:48:14: error: #elif with no expression
   48 | #elif DNNCUDA
      |              ^
/build/root/src/root-6.22.00-cuda/tmva/tmva/test/Method/TestMethodDNNValidationSize.cxx:51:2: error: #error "This should not happen. Can only compile with CPU or CUDA implementations."
   51 | #error "This should not happen. Can only compile with CPU or CUDA implementations."
      |  ^~~~~
```
and
```
/build/root/src/root-6.22.00-cuda/tmva/tmva/test/Method/TestMethodDNNValidationSize.cxx: In member function ‘size_t TMVA::TestMethodDNNValidationSize::GetProcessedValidationOption(TString)’:
/build/root/src/root-6.22.00-cuda/tmva/tmva/test/Method/TestMethodDNNValidationSize.cxx:54:80: error: ‘defualtOptions’ was not declared in this scope
   54 |       IMethod *m = fFactory->BookMethod(fDataLoader.get(), Types::kDNN, "DNN", defualtOptions + options);
      |                                                                                ^~~~~~~~~~~~~~
```