### PR TITLE
[ntuple, tutorials] Remove ifdef around R__LOAD_LIBRARY

### DIFF
--- a/tutorials/v7/ntuple/ntpl001_staff.C
+++ b/tutorials/v7/ntuple/ntpl001_staff.C
@@ -18,10 +18,7 @@
 // Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
 // triggering autoloading from the use of templated types would require an exhaustive enumeration
 // of "all" template instances in the LinkDef file.
-#include <RConfigure.h>
-#ifndef R__USE_CXXMODULES
 R__LOAD_LIBRARY(ROOTNTuple)
-#endif
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>

--- a/tutorials/v7/ntuple/ntpl002_vector.C
+++ b/tutorials/v7/ntuple/ntpl002_vector.C
@@ -16,10 +16,7 @@
 // Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
 // triggering autoloading from the use of templated types would require an exhaustive enumeration
 // of "all" template instances in the LinkDef file.
-#include <RConfigure.h>
-#ifndef R__USE_CXXMODULES
 R__LOAD_LIBRARY(ROOTNTuple)
-#endif
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -21,10 +21,7 @@
 // Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
 // triggering autoloading from the use of templated types would require an exhaustive enumeration
 // of "all" template instances in the LinkDef file.
-#include <RConfigure.h>
-#ifndef R__USE_CXXMODULES
 R__LOAD_LIBRARY(ROOTNTuple)
-#endif
 
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTuple.hxx>

--- a/tutorials/v7/ntuple/ntpl004_dimuon.C
+++ b/tutorials/v7/ntuple/ntpl004_dimuon.C
@@ -20,10 +20,7 @@
 // Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
 // triggering autoloading from the use of templated types would require an exhaustive enumeration
 // of "all" template instances in the LinkDef file.
-#include <RConfigure.h>
-#ifndef R__USE_CXXMODULES
 R__LOAD_LIBRARY(ROOTNTuple)
-#endif
 
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RNTuple.hxx>

--- a/tutorials/v7/ntuple/ntpl005_introspection.C
+++ b/tutorials/v7/ntuple/ntpl005_introspection.C
@@ -17,10 +17,7 @@
 // Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
 // triggering autoloading from the use of templated types would require an exhaustive enumeration
 // of "all" template instances in the LinkDef file.
-#include <RConfigure.h>
-#ifndef R__USE_CXXMODULES
 R__LOAD_LIBRARY(ROOTNTuple)
-#endif
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>


### PR DESCRIPTION
As discussed with @Axel-Naumann, in the interest of more concise RNTuple tutorials this PR removes the ifdef around `R__LOAD_LIBRARY`.  The library is simply always loaded.