### PR TITLE
Revert "Fix NO_CXXMODULE handling logic for dependencies"

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -562,15 +562,11 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   #---Get the library and module dependencies-----------------
   if(ARG_DEPENDENCIES)
     foreach(dep ${ARG_DEPENDENCIES})
-      set(dict "G__${dep}")
-      set(dependent_pcm ${libprefix}${dep}_rdict.pcm})
-      if(runtime_cxxmodules)
-        #---Check for NO_CXXMODULE flag in a dependent module---
-        set(dependent_pcm "$<IF:$<BOOL:$<TARGET_PROPERTY:${dict},NO_MODULE>>,,-m ${dep}.pcm>")
-        set(newargs ${newargs} ${dependent_pcm})
-      else()
-        set(newargs ${newargs} -m ${dependent_pcm})
+      set(dependent_pcm ${libprefix}${dep}_rdict.pcm)
+      if (runtime_cxxmodules)
+        set(dependent_pcm ${dep}.pcm)
       endif()
+      set(newargs ${newargs} -m  ${dependent_pcm})
     endforeach()
   endif()
 
@@ -651,7 +647,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   # would not happen if we used target_sources() directly with the dictionary source.
   if(TARGET "${ARG_MODULE}" AND NOT "${ARG_MODULE}" STREQUAL "${dictionary}")
     add_library(${dictionary} OBJECT ${dictionary}.cxx)
-    set_target_properties(${dictionary} PROPERTIES POSITION_INDEPENDENT_CODE TRUE NO_MODULE ${ARG_NO_CXXMODULE})
+    set_target_properties(${dictionary} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
     target_sources(${ARG_MODULE} PRIVATE $<TARGET_OBJECTS:${dictionary}>)
 
     target_compile_options(${dictionary} PRIVATE


### PR DESCRIPTION
It broke C++17 build of ROOT with:
In module 'std' imported from input_line_1:1:
/usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../include/c++/10.1.0/bits/unique_ptr.h:207:12: error: 'std::__uniq_ptr_data<RooDataSet, std::default_delete<RooDataSet>, true, true>' has different definitions
      in different modules; defined here
    struct __uniq_ptr_data : __uniq_ptr_impl<_Tp, _Dp>
           ^
/usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../include/c++/10.1.0/bits/unique_ptr.h:207:12: note: definition in module 'std.condition_variable' is here
Error: /home/stefan/builds/root-dev/bin/rootcling: compilation failure (/home/stefan/builds/root-dev/lib/libRooStats03cff1ce95_dictUmbrella.h)
make[2]: *** [roofit/roostats/CMakeFiles/G__RooStats.dir/build.make:222: roofit/roostats/G__RooStats.cxx] Error 1