### PR TITLE
[JupyROOT] Make jupyter working without root --notebook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,8 +536,14 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
     DESTINATION ${CMAKE_INSTALL_CMAKEDIR})
 endif()
 
-#---Make sure the Jupyter ROOT C++ kernel runs with the same Python version as ROOT-----
-set(root_kernel_dir  notebook/kernels/root)
+#---Add configuration files for kernel and jupyter----------------------------------------------
+# Make sure the Jupyter ROOT C++ kernel runs with the same Python version as ROOT
+set(root_jupyter_dir notebook)
+set(root_jupyter_config jupyter_notebook_config.py)
+configure_file(etc/${root_jupyter_dir}/${root_jupyter_config}.in etc/${root_jupyter_dir}/${root_jupyter_config})
+install(FILES ${CMAKE_BINARY_DIR}/etc/${root_jupyter_dir}/${root_jupyter_config} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/${root_jupyter_dir})
+
+set(root_kernel_dir  ${root_jupyter_dir}/kernels/root)
 set(root_kernel_file kernel.json)
 configure_file(etc/${root_kernel_dir}/${root_kernel_file}.in etc/${root_kernel_dir}/${root_kernel_file})
 install(FILES ${CMAKE_BINARY_DIR}/etc/${root_kernel_dir}/${root_kernel_file} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/${root_kernel_dir})

--- a/config/thisroot.csh
+++ b/config/thisroot.csh
@@ -118,6 +118,13 @@ if ($?old_rootsys) then
                                  -e "s;^$old_rootsys/etc/notebook:;;g"   \
                                  -e "s;^$old_rootsys/etc/notebook${DOLLAR};;g"`
    endif
+   if ($?JUPYTER_CONFIG_DIR) then
+      setenv JUPYTER_CONFIG_DIR `set DOLLAR='$'; echo $JUPYTER_CONFIG_DIR | \
+                             sed -e "s;:$old_rootsys/etc/notebook:;:;g" \
+                                 -e "s;:$old_rootsys/etc/notebook${DOLLAR};;g"   \
+                                 -e "s;^$old_rootsys/etc/notebook:;;g"   \
+                                 -e "s;^$old_rootsys/etc/notebook${DOLLAR};;g"`
+   endif
 
 endif
 
@@ -181,6 +188,12 @@ if ($?JUPYTER_PATH) then
    setenv JUPYTER_PATH ${ROOTSYS}/etc/notebook:$JUPYTER_PATH
 else
    setenv JUPYTER_PATH ${ROOTSYS}/etc/notebook
+endif
+
+if ($?JUPYTER_CONFIG_DIR) then
+   setenv JUPYTER_CONFIG_DIR ${ROOTSYS}/etc/notebook:$JUPYTER_CONFIG_DIR
+else
+   setenv JUPYTER_CONFIG_DIR ${ROOTSYS}/etc/notebook
 endif
 
 # Prevent Cppyy from checking the PCH (and avoid warning)

--- a/config/thisroot.fish
+++ b/config/thisroot.fish
@@ -48,6 +48,7 @@ update_path PYTHONPATH "$old_rootsys" "/lib" @libdir@
 update_path MANPATH "$old_rootsys" "/man" @mandir@
 update_path CMAKE_PREFIX_PATH "$old_rootsys" "" $ROOTSYS
 update_path JUPYTER_PATH "$old_rootsys" "/etc/notebook" ROOTSYS/etc/notebook
+update_path JUPYTER_CONFIG_DIR "$old_rootsys" "/etc/notebook" ROOTSYS/etc/notebook
 
 # Prevent Cppyy from checking the PCH (and avoid warning)
 set -xg CLING_STANDARD_PCH none

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -64,6 +64,10 @@ clean_environment()
          drop_from_path "$JUPYTER_PATH" "${old_rootsys}/etc/notebook"
          JUPYTER_PATH=$newpath
       fi
+      if [ -n "${JUPYTER_CONFIG_DIR}" ]; then
+         drop_from_path "$JUPYTER_CONFIG_DIR" "${old_rootsys}/etc/notebook"
+         JUPYTER_CONFIG_DIR=$newpath
+      fi
    fi
    if [ -z "${MANPATH}" ]; then
       # Grab the default man path before setting the path to avoid duplicates
@@ -141,6 +145,12 @@ set_environment()
       JUPYTER_PATH=$ROOTSYS/etc/notebook; export JUPYTER_PATH       # Linux, ELF HP-UX
    else
       JUPYTER_PATH=$ROOTSYS/etc/notebook:$JUPYTER_PATH; export JUPYTER_PATH
+   fi
+
+   if [ -z "${JUPYTER_CONFIG_DIR}" ]; then
+      JUPYTER_CONFIG_DIR=$ROOTSYS/etc/notebook; export JUPYTER_CONFIG_DIR # Linux, ELF HP-UX
+   else
+      JUPYTER_CONFIG_DIR=$ROOTSYS/etc/notebook:$JUPYTER_CONFIG_DIR; export JUPYTER_CONFIG_DIR
    fi
 }
 

--- a/etc/notebook/jupyter_notebook_config.py
+++ b/etc/notebook/jupyter_notebook_config.py
@@ -1,3 +1,0 @@
-import os
-if 'ROOTSYS' in os.environ:
-    c.NotebookApp.extra_static_paths.append(os.path.join(os.environ['ROOTSYS'], 'js/'))

--- a/etc/notebook/jupyter_notebook_config.py
+++ b/etc/notebook/jupyter_notebook_config.py
@@ -1,0 +1,3 @@
+import os
+if 'ROOTSYS' in os.environ:
+    c.NotebookApp.extra_static_paths.append(os.path.join(os.environ['ROOTSYS'], 'js/'))

--- a/etc/notebook/jupyter_notebook_config.py.in
+++ b/etc/notebook/jupyter_notebook_config.py.in
@@ -1,0 +1,7 @@
+import os
+if 'ROOTSYS' in os.environ:
+    # Prefer using JSROOT from ROOTSYS if defined
+    c.NotebookApp.extra_static_paths.append(os.path.join(os.environ['ROOTSYS'], 'js/'))
+else:
+    # Fall back to CMAKE_INSTALL_PREFIX to find JSROOT
+    c.NotebookApp.extra_static_paths.append(os.path.join("@CMAKE_INSTALL_PREFIX@", 'js/'))

--- a/etc/notebook/jupyter_notebook_config.py.in
+++ b/etc/notebook/jupyter_notebook_config.py.in
@@ -3,5 +3,5 @@ if 'ROOTSYS' in os.environ:
     # Prefer using JSROOT from ROOTSYS if defined
     c.NotebookApp.extra_static_paths.append(os.path.join(os.environ['ROOTSYS'], 'js/'))
 else:
-    # Fall back to CMAKE_INSTALL_PREFIX to find JSROOT
-    c.NotebookApp.extra_static_paths.append(os.path.join("@CMAKE_INSTALL_PREFIX@", 'js/'))
+    # Fall back to CMAKE_INSTALL_PREFIX/CMAKE_INSTALL_JSROOTDIR, e.g., for a system installation
+    c.NotebookApp.extra_static_paths.append(os.path.join("@CMAKE_INSTALL_PREFIX@", "@CMAKE_INSTALL_JSROOTDIR@"))


### PR DESCRIPTION
Befor we switched JSROOT to the local instances of the JS libraries, we could use jupyter with all features right after sourcing `thisroot.*`. Due to the switch, the path to the JS libraries was broken, which is now fixed by this PR. This makes `root --notebook` redundant in this case.

Still to be added is the correct behaviour when ROOT is installed. I'll line out here how it should be done:

1. We should abandon the `.rootnb` folder in `HOME` and use the default `.jupyter` folder.
2. There, we have to add our config to the `jupyter_notebook_config.py` file, which is basically nothing else than `c.NotebookApp.extra_static_paths.append('/path/to/root/js')`.
3. I think we should just get rid of the custom css things, which would be made default if installed into `.jupyter`.
4. Install the ROOT kernel in `/usr/share/jupyter/kernels/root`, such as all other kernels.

I would go first with this PR, which only improves the current behaviour. Next I'll have a look into a proper installation of our jupyter related files, but I'll make another PR for that.

**Edit:** I've fixed the installation to a prefix. This just fixes the current issues but keeps the old installation/sourcing behaviour of jupyroot. We can refactor in another RP later!