### PR TITLE
Fix Jira issue #ROOT-10969 Can not compile ROOT macro on Win10

### DIFF
--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -4256,6 +4256,7 @@ const char *TWinNTSystem::GetLibraries(const char *regexp, const char *options,
    TString libs(TSystem::GetLibraries(regexp, options, isRegexp));
    TString ntlibs;
    TString opt = options;
+   Bool_t in_program_files = kFALSE;
 
    if ( (opt.First('L')!=kNPOS) ) {
       TRegexp separator("[^ \\t\\s]+");
@@ -4275,6 +4276,17 @@ const char *TWinNTSystem::GetLibraries(const char *regexp, const char *options,
             s.ToLower();
             if ((s.Index("c:/windows/") != kNPOS) ||
                 (s.Index("python") != kNPOS)) {
+               start += end+1;
+               continue;
+            }
+            if (s.BeginsWith("c:/program")) {
+               in_program_files = kTRUE;
+               start += end+1;
+               continue;
+            }
+            if (in_program_files) {
+               if (s.EndsWith(".dll"))
+                  in_program_files = kFALSE;
                start += end+1;
                continue;
             }


### PR DESCRIPTION
Skip all DLL in `C:/Program Files...` the path containing spaces is not handled properly anyway, leading to this kind of error:
`LINK : fatal error LNK1181: cannot open input file 'c:\program.obj'`
And an even more fundamental reason is that the matching `.lib` files are usually not along side the DLLs in `C:\Program Files*`