### PR TITLE
Add R__DLLEXPORT to export the static constexpr class members of RColor

### DIFF
--- a/core/foundation/inc/DllImport.h
+++ b/core/foundation/inc/DllImport.h
@@ -29,5 +29,12 @@
 # define R__EXTERN extern
 #endif
 
+#ifndef R__DLLEXPORT
+# ifdef _MSC_VER
+#  define R__DLLEXPORT __declspec(dllexport)
+# else
+#  define R__DLLEXPORT __attribute__ ((visibility ("default")))
+# endif
+#endif
 
 #endif

--- a/graf2d/gpadv7/inc/ROOT/RColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RColor.hxx
@@ -13,6 +13,7 @@
 #include <vector>
 #include <string>
 #include <array>
+#include <DllImport.h>
 
 namespace ROOT {
 namespace Experimental {
@@ -212,25 +213,25 @@ public:
       fName.clear();
    }
 
-   static constexpr RGB_t kBlack{{0, 0, 0}};
-   static constexpr RGB_t kGreen{{0, 0x80, 0}};
-   static constexpr RGB_t kLime{{0, 0xFF, 0}};
-   static constexpr RGB_t kAqua{{0, 0xFF, 0xFF}};
-   static constexpr RGB_t kPurple{{0x80, 0, 0x80}};
-   static constexpr RGB_t kGrey{{0x80, 0x80, 0x80}};
-   static constexpr RGB_t kFuchsia{{0xFF, 0, 0xFF}};
-   static constexpr RGB_t kNavy{{0, 0, 0x80}};
-   static constexpr RGB_t kBlue{{0, 0, 0xff}};
-   static constexpr RGB_t kTeal{{0, 0x80, 0x80}};
-   static constexpr RGB_t kOlive{{0x80, 0x80, 0}};
-   static constexpr RGB_t kSilver{{0xc0, 0xc0, 0xc0}};
-   static constexpr RGB_t kMaroon{{0x80, 0, 0}};
-   static constexpr RGB_t kRed{{0xff, 0, 0}};
-   static constexpr RGB_t kYellow{{0xff, 0xff, 0}};
-   static constexpr RGB_t kWhite{{0xff, 0xff, 0xff}};
-   static constexpr float kTransparent{0.};
-   static constexpr float kSemiTransparent{0.5};
-   static constexpr float kOpaque{1.};
+   R__DLLEXPORT static constexpr RGB_t kBlack{{0, 0, 0}};
+   R__DLLEXPORT static constexpr RGB_t kGreen{{0, 0x80, 0}};
+   R__DLLEXPORT static constexpr RGB_t kLime{{0, 0xFF, 0}};
+   R__DLLEXPORT static constexpr RGB_t kAqua{{0, 0xFF, 0xFF}};
+   R__DLLEXPORT static constexpr RGB_t kPurple{{0x80, 0, 0x80}};
+   R__DLLEXPORT static constexpr RGB_t kGrey{{0x80, 0x80, 0x80}};
+   R__DLLEXPORT static constexpr RGB_t kFuchsia{{0xFF, 0, 0xFF}};
+   R__DLLEXPORT static constexpr RGB_t kNavy{{0, 0, 0x80}};
+   R__DLLEXPORT static constexpr RGB_t kBlue{{0, 0, 0xff}};
+   R__DLLEXPORT static constexpr RGB_t kTeal{{0, 0x80, 0x80}};
+   R__DLLEXPORT static constexpr RGB_t kOlive{{0x80, 0x80, 0}};
+   R__DLLEXPORT static constexpr RGB_t kSilver{{0xc0, 0xc0, 0xc0}};
+   R__DLLEXPORT static constexpr RGB_t kMaroon{{0x80, 0, 0}};
+   R__DLLEXPORT static constexpr RGB_t kRed{{0xff, 0, 0}};
+   R__DLLEXPORT static constexpr RGB_t kYellow{{0xff, 0xff, 0}};
+   R__DLLEXPORT static constexpr RGB_t kWhite{{0xff, 0xff, 0xff}};
+   R__DLLEXPORT static constexpr float kTransparent{0.};
+   R__DLLEXPORT static constexpr float kSemiTransparent{0.5};
+   R__DLLEXPORT static constexpr float kOpaque{1.};
 
    friend bool operator==(const RColor &lhs, const RColor &rhs)
    {

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -264,9 +264,6 @@ if(root7)
                  v7/fitpanel.cxx
                  v7/fitpanel6.cxx
       )
-  if(MSVC AND NOT win_broken_tests)
-    list(APPEND root7_veto v7/box.cxx v7/draw*.cxx )
-  endif()
   if(NOT davix)
     list(APPEND root7_veto v7/ntuple/ntpl003_lhcbOpenData.C)
     list(APPEND root7_veto v7/ntuple/ntpl004_dimuon.C)


### PR DESCRIPTION

Fix the isssue with the static constexpr class members of RColor not being properly exported, even with `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`, and causing the following kind of error, for example when trying to execute the root7 box.cxx macro:
```
Processing box.cxx...
IncrementalExecutor::executeFunction: symbol '?kGreen@RColor@Experimental@ROOT@@2V?$array@E$02@std@@B' unresolved while linking [cling interface function]!
You are probably missing the definition of public: static class std::array<unsigned char,3> const ROOT::Experimental::RColor::kGreen
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol '?kRed@RColor@Experimental@ROOT@@2V?$array@E$02@std@@B' unresolved while linking [cling interface function]!
You are probably missing the definition of public: static class std::array<unsigned char,3> const ROOT::Experimental::RColor::kRed
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol '?kBlue@RColor@Experimental@ROOT@@2V?$array@E$02@std@@B' unresolved while linking [cling interface function]!
You are probably missing the definition of public: static class std::array<unsigned char,3> const ROOT::Experimental::RColor::kBlue
Maybe you need to load the corresponding shared library?
```