### PR TITLE
Fix EST updating in clang::ASTReader

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTReader.h
@@ -505,8 +505,7 @@ private:
     FunctionProtoType::ExceptionSpecInfo m_ESI;
     PendingExceptionSpecUpdateInfo(FunctionDecl *FD,
                                   FunctionProtoType::ExceptionSpecInfo ESI)
-      : m_FD(FD), m_ESI(ESI), ShouldUpdateESI(true) { }
-    PendingExceptionSpecUpdateInfo(FunctionDecl *FD) : m_FD(FD) { }
+      : m_FD(FD), m_ESI(ESI) { }
   };
   /// \brief Exception specification updates that have been loaded but not yet
   /// propagated across the relevant redeclaration chain. The map key is the

--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
@@ -533,14 +533,6 @@ void CodeGenFunction::EmitEndEHSpec(const Decl *D) {
     return;
 
   ExceptionSpecificationType EST = Proto->getExceptionSpecType();
-
-  // Might need to deserialize
-  if (EST == EST_Uninstantiated || EST == EST_Unevaluated) {
-    FD = FD->getMostRecentDecl();
-    Proto = FD->getType()->getAs<FunctionProtoType>();
-    EST = Proto->getExceptionSpecType();
-  }
-
   if (isNoexceptExceptionSpec(EST)) {
     if (Proto->getNoexceptSpec(getContext()) == FunctionProtoType::NR_Nothrow) {
       EHStack.popTerminate();

--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
@@ -446,14 +446,6 @@ void CodeGenFunction::EmitStartEHSpec(const Decl *D) {
     return;
 
   ExceptionSpecificationType EST = Proto->getExceptionSpecType();
-
-  // Might need to deserialize
-  if (EST == EST_Uninstantiated) {
-    FD = FD->getMostRecentDecl();
-    Proto = FD->getType()->getAs<FunctionProtoType>();
-    EST = Proto->getExceptionSpecType();
-  }
-
   if (isNoexceptExceptionSpec(EST)) {
     if (Proto->getNoexceptSpec(getContext()) == FunctionProtoType::NR_Nothrow) {
       // noexcept functions are simple terminate scopes.

--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
@@ -446,6 +446,14 @@ void CodeGenFunction::EmitStartEHSpec(const Decl *D) {
     return;
 
   ExceptionSpecificationType EST = Proto->getExceptionSpecType();
+
+  // Might need to deserialize
+  if (EST == EST_Uninstantiated || EST == EST_Unevaluated) {
+    FD->getMostRecentDecl();
+    Proto = FD->getType()->getAs<FunctionProtoType>();
+    EST = Proto->getExceptionSpecType();
+  }
+
   if (isNoexceptExceptionSpec(EST)) {
     if (Proto->getNoexceptSpec(getContext()) == FunctionProtoType::NR_Nothrow) {
       // noexcept functions are simple terminate scopes.

--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CGException.cpp
@@ -448,7 +448,7 @@ void CodeGenFunction::EmitStartEHSpec(const Decl *D) {
   ExceptionSpecificationType EST = Proto->getExceptionSpecType();
 
   // Might need to deserialize
-  if (EST == EST_Uninstantiated || EST == EST_Unevaluated) {
+  if (EST == EST_Uninstantiated) {
     FD = FD->getMostRecentDecl();
     Proto = FD->getType()->getAs<FunctionProtoType>();
     EST = Proto->getExceptionSpecType();


### PR DESCRIPTION
When reading an evaluated EST, make sure we provide *that* to the
update object, instead of leaving the EST to be used for the
update uninitialized.

Remove the now unused (and due to two FuncDecls fairly ambiguous)
ctor from a FuncDecl. Instead, set ShouldUpdateESI explicitly in
the only case where it matters.

This fixes 30ecf72, and as that
points out, should become irrelevant once
llvm-mirror/clang@5d50602
is merged into ROOT.