### PR TITLE
[io] io_uring ReadV implementation

### DIFF
--- a/bindings/pyroot/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot/pythonizations/test/import_load_libs.py
@@ -38,6 +38,7 @@ class ImportLoadLibs(unittest.TestCase):
             'libssl',
             'libcrypt.*', # by libssl
             'libtbb',
+            'liburing', # by libRIO if uring option is enabled
             # On centos7 libssl links against kerberos pulling in all dependencies below, removed with libssl1.1.0
             'libgssapi_krb5',
             'libkrb5',

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -12,7 +12,6 @@
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
-#include <vector>
 
 #include <liburing.h>
 #include <liburing/io_uring.h>

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -57,7 +57,7 @@ public:
       return available;
    }
 
-   struct io_uring *raw() {
+   struct io_uring *GetRawRing() {
       return &fRing;
    }
 };

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -40,7 +40,7 @@ private:
 public:
    // Create an io_uring instance. The ring selects an appropriate queue depth. which can be queried
    // afterwards using GetQueueDepth(). The depth is typically 1024 or lower. Throws an exception if
-   // the ring could be not be initialized.
+   // ring setup fails.
    RIoUring() {
       std::uint32_t queueDepth = 1024;
       int ret;
@@ -63,8 +63,7 @@ public:
    }
 
    // Create a io_uring instance that can hold at least `entriesHint` submission entries. The actual
-   // queue depth is rounded up to the next power of 2. Throws an exception if the ring couldn't
-   // be initialized.
+   // queue depth is rounded up to the next power of 2. Throws an exception if ring setup fails.
    RIoUring(std::uint32_t entriesHint) {
       struct io_uring_params params = {}; /* zero initialize param struct, no flags */
       int ret = io_uring_queue_init_params(entriesHint, &fRing, &params);

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -55,8 +55,11 @@ public:
             throw std::runtime_error("Error initializing io_uring: " + std::string(std::strerror(-ret)));
          }
          // try again with a smaller queue for ENOMEM
-         // -- if it gets to 0, queue_init will fail with an invalid argument error
          queueDepth /= 2;
+         if (queueDepth == 0) {
+            throw std::runtime_error("Fatal Error: failed to allocate memory for the smallest possible "
+               "io_uring instance. 'memlock' memory has been exhausted for this user");
+         }
       }
    }
 

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -73,7 +73,7 @@ public:
       std::uint64_t fOffset = 0;
       /// The number of desired bytes
       std::size_t fSize = 0;
-      /// The number of actually read bytes, set by ReadV()
+      /// The number of actually read bytes, set by the RIoUring instance
       std::size_t fOutBytes = 0;
       /// The file descriptor
       int fFileDes = -1;
@@ -81,7 +81,6 @@ public:
 
    /// Submit a number of read events and wait for completion.
    void SubmitReadsAndWait(RReadEvent* readEvents, unsigned int nReads) {
-
       unsigned int batch = 0;
       unsigned int batchSize = fSize;
       unsigned int readPos = 0;

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -11,9 +11,12 @@
 
 #include <cstring>
 #include <stdexcept>
+#include <vector>
 
 #include <liburing.h>
 #include <liburing/io_uring.h>
+
+#include <ROOT/RRawFile.hxx>
 
 #include "TError.h"
 
@@ -23,6 +26,7 @@ namespace Internal {
 class RIoUring {
 private:
    struct io_uring fRing;
+   size_t fSize;
 
    static bool CheckIsAvailable() {
       try {
@@ -36,8 +40,8 @@ private:
    }
 
 public:
-   explicit RIoUring(size_t size) {
-      int ret = io_uring_queue_init(size, &fRing, 0 /* no flags */);
+   explicit RIoUring(size_t size) : fSize(size) {
+      int ret = io_uring_queue_init(fSize, &fRing, 0 /* no flags */);
       if (ret) {
          throw std::runtime_error("Error initializing io_uring: " + std::string(std::strerror(-ret)));
       }
@@ -45,6 +49,7 @@ public:
 
    RIoUring(const RIoUring&) = delete;
    RIoUring& operator=(const RIoUring&) = delete;
+
 
    ~RIoUring() {
       // todo(max) try submitting any pending events before exiting
@@ -57,8 +62,89 @@ public:
       return available;
    }
 
+   /// Access the raw io_uring instance.
    struct io_uring *GetRawRing() {
       return &fRing;
+   }
+
+   /// Basic read event composed of RIOVec IO data and a target file descriptor.
+   struct RReadEvent {
+      RRawFile::RIOVec* fIoVec = nullptr;
+      int fFileDes = -1;
+   };
+
+   /// Submit a number of read events and wait for completion.
+   void SubmitReadsAndWait(std::vector<RReadEvent>& readEvents) {
+      auto numEvents = readEvents.size();
+      if (numEvents > fSize) {
+         throw std::runtime_error("too many read events (" + std::to_string(numEvents) + ") for "
+            + "ring with size (" + std::to_string(fSize) + "). event batching is not implemented yet");
+      }
+
+      // todo(max) think about registering fFileDes to avoid repeated kernel fd mappings
+      // ```
+      // io_uring_register_files(p_ring, &fFileDes, 1);
+      // -- then fd parameter in prep_read is the offset into the array of fixed files
+      // -- (i.e. 0, because we only have one file)
+      // io_uring_prep_read(sqe, 0, ioVec[i].fBuffer, ioVec[i].fSize, ioVec[i].fOffset);
+      // -- and the sqe flags have to be adjusted
+      // sqe->flags |= IOSQE_FIXED_FILE;
+      // ```
+      // files are unregistered when the queue is destroyed
+
+      // prep reads
+      struct io_uring_sqe *sqe;
+      for (std::size_t i = 0; i < numEvents; ++i) {
+         sqe = io_uring_get_sqe(&fRing);
+         if (!sqe) {
+            throw std::runtime_error("get SQE failed for read request '" +
+               std::to_string(i) + "', error: " + std::string(strerror(errno)));
+         }
+         if (readEvents[i].fFileDes == -1) {
+            throw std::runtime_error("bad fd (-1) for read request '" + std::to_string(i) + "'");
+         }
+         if (readEvents[i].fIoVec == nullptr) {
+            throw std::runtime_error("null RIOVec* for read request '" + std::to_string(i) + "'");
+         }
+         io_uring_prep_read(sqe,
+            readEvents[i].fFileDes,
+            readEvents[i].fIoVec->fBuffer,
+            readEvents[i].fIoVec->fSize,
+            readEvents[i].fIoVec->fOffset
+         );
+         sqe->user_data = i;
+      }
+
+      // todo(max) fix for batched sqe submissions where ret may not equal nReq
+      // todo(max) check for any difference between submit vs. submit and wait for large nReq
+      int submitted = io_uring_submit_and_wait(&fRing, numEvents);
+      if (submitted <= 0) {
+         throw std::runtime_error("ring submit failed, error: " + std::string(strerror(errno)));
+      }
+      if (submitted != static_cast<int>(numEvents)) {
+         throw std::runtime_error("ring submitted " + std::to_string(submitted) +
+            " events but requested " + std::to_string(numEvents));
+      }
+      // reap reads
+      struct io_uring_cqe *cqe;
+      int ret;
+      for (int i = 0; i < submitted; ++i) {
+         ret = io_uring_wait_cqe(&fRing, &cqe);
+         if (ret < 0) {
+            throw std::runtime_error("wait cqe failed, error: " + std::string(std::strerror(-ret)));
+         }
+         auto index = reinterpret_cast<std::size_t>(io_uring_cqe_get_data(cqe));
+         if (index >= numEvents) {
+            throw std::runtime_error("bad cqe user data: " + std::to_string(index));
+         }
+         if (cqe->res < 0) {
+            throw std::runtime_error("read failed for ReadEvent[" + std::to_string(index) + "], "
+               "error: " + std::string(std::strerror(-cqe->res)));
+         }
+         readEvents[index].fIoVec->fOutBytes = static_cast<std::size_t>(cqe->res);
+         io_uring_cqe_seen(&fRing, cqe);
+      }
+      return;
    }
 };
 

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -64,7 +64,7 @@ public:
 
    // Create a io_uring instance that can hold at least `entriesHint` submission entries. The actual
    // queue depth is rounded up to the next power of 2. Throws an exception if ring setup fails.
-   RIoUring(std::uint32_t entriesHint) {
+   explicit RIoUring(std::uint32_t entriesHint) {
       struct io_uring_params params = {}; /* zero initialize param struct, no flags */
       int ret = io_uring_queue_init_params(entriesHint, &fRing, &params);
       if (ret != 0) {

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -86,17 +86,6 @@ public:
             + "ring with size (" + std::to_string(fSize) + "). event batching is not implemented yet");
       }
 
-      // todo(max) think about registering fFileDes to avoid repeated kernel fd mappings
-      // ```
-      // io_uring_register_files(p_ring, &fFileDes, 1);
-      // -- then fd parameter in prep_read is the offset into the array of fixed files
-      // -- (i.e. 0, because we only have one file)
-      // io_uring_prep_read(sqe, 0, ioVec[i].fBuffer, ioVec[i].fSize, ioVec[i].fOffset);
-      // -- and the sqe flags have to be adjusted
-      // sqe->flags |= IOSQE_FIXED_FILE;
-      // ```
-      // files are unregistered when the queue is destroyed
-
       // prep reads
       struct io_uring_sqe *sqe;
       for (std::size_t i = 0; i < nReads; ++i) {

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -56,6 +56,10 @@ public:
       static const bool available = RIoUring::CheckIsAvailable();
       return available;
    }
+
+   struct io_uring *raw() {
+      return &fRing;
+   }
 };
 
 } // namespace Internal

--- a/io/io/inc/ROOT/RRawFileUnix.hxx
+++ b/io/io/inc/ROOT/RRawFileUnix.hxx
@@ -45,6 +45,7 @@ public:
    ~RRawFileUnix();
    std::unique_ptr<RRawFile> Clone() const final;
    int GetFeatures() const final;
+   int GetFd() const { return fFileDes; }
 };
 
 } // namespace Internal

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -115,7 +115,7 @@ void ROOT::Internal::RRawFileUnix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
 #ifdef R__HAS_URING
    if (RIoUring::IsAvailable()) {
-      RIoUring ring(nReq);
+      RIoUring ring(128);
       std::vector<RIoUring::RReadEvent> reads;
       reads.reserve(nReq);
       for (std::size_t i = 0; i < nReq; ++i) {

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -24,6 +24,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <fcntl.h>
 #include <sys/mman.h>

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -116,7 +116,7 @@ void ROOT::Internal::RRawFileUnix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 #ifdef R__HAS_URING
    if (RIoUring::IsAvailable()) {
       RIoUring ring(nReq);
-      struct io_uring *p_ring = ring.raw();
+      struct io_uring *p_ring = ring.GetRawRing();
 
       // todo(max) try registering fFileDes to avoid repeated kernel fd mappings
       // ```

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -120,11 +120,16 @@ void ROOT::Internal::RRawFileUnix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
       reads.reserve(nReq);
       for (std::size_t i = 0; i < nReq; ++i) {
          RIoUring::RReadEvent ev;
-         ev.fIoVec = &ioVec[i];
+         ev.fBuffer = ioVec[i].fBuffer;
+         ev.fOffset = ioVec[i].fOffset;
+         ev.fSize = ioVec[i].fSize;
          ev.fFileDes = fFileDes;
          reads.push_back(ev);
       }
-      ring.SubmitReadsAndWait(reads);
+      ring.SubmitReadsAndWait(reads.data(), nReq);
+      for (std::size_t i = 0; i < nReq; ++i) {
+         ioVec[i].fOutBytes = reads.at(i).fOutBytes;
+      }
       return;
    }
    Warning("RRawFileUnix",

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -115,7 +115,7 @@ void ROOT::Internal::RRawFileUnix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
 #ifdef R__HAS_URING
    if (RIoUring::IsAvailable()) {
-      RIoUring ring(128);
+      RIoUring ring;
       std::vector<RIoUring::RReadEvent> reads;
       reads.reserve(nReq);
       for (std::size_t i = 0; i < nReq; ++i) {

--- a/io/io/test/RIoUring.cxx
+++ b/io/io/test/RIoUring.cxx
@@ -40,10 +40,7 @@ TEST(RRawFileUnix, ReadV)
    auto nReq = 128;
 
    auto iovecs = make_iovecs(nReq);
-   // auto t1 = std::chrono::high_resolution_clock::now();
    f->ReadV(iovecs.data(), nReq);
-   // auto t2 = std::chrono::high_resolution_clock::now();
-   // std::cout << std::chrono::duration_cast<std::chrono::microseconds>( t2 - t1 ).count() << " microseconds\n";
    for (auto iovec: iovecs) {
       for (std::size_t i = 0; i < iovec.fOutBytes; ++i) {
          EXPECT_EQ('a', ((unsigned char*)iovec.fBuffer)[i]);

--- a/io/io/test/RIoUring.cxx
+++ b/io/io/test/RIoUring.cxx
@@ -41,7 +41,7 @@ TEST(RRawFileUnix, ReadV)
    FileRaii fileGuard(file, std::string(filesize, 'a')); // ~2MB
    auto f = RRawFileUnix::Create(file);
 
-   auto nReq = 2048; // demo submission batching, uring size is usually around 1024
+   auto nReq = 2000; // demo submission batching, uring size is usually around 1024
 
    auto iovecs = make_iovecs(nReq, filesize);
    f->ReadV(iovecs.data(), nReq);
@@ -99,10 +99,12 @@ TEST(RawUring, FileRegistration)
    // files are opened lazily, force file open via GetSize
    auto size = f.GetSize();
 
-   unsigned int nReads = 128;
+   unsigned int nReads = 100;
    auto iovecs = make_iovecs(nReads, size);
 
    RIoUring ring(nReads);
+   EXPECT_EQ(ring.GetQueueDepth(), 128); // queue depth rounds up to next power of 2
+
    auto r = ring.GetRawRing();
    auto fd = f.GetFd();
    io_uring_register_files(r, &fd, 1);

--- a/io/io/test/RIoUring.cxx
+++ b/io/io/test/RIoUring.cxx
@@ -4,7 +4,24 @@
 #include "ROOT/RRawFileUnix.hxx"
 
 using RIoUring = ROOT::Internal::RIoUring;
+using RIOVec = RRawFile::RIOVec;
 using RRawFileUnix = ROOT::Internal::RRawFileUnix;
+
+namespace {
+
+std::vector<RIOVec> make_iovecs(int n, unsigned int fileSize) {
+   std::vector<RIOVec> iovecs;
+   for (int i = 0; i < n; ++i) {
+      RIOVec io;
+      io.fBuffer = malloc(4096 * 9);
+      io.fOffset = std::rand() % fileSize;
+      io.fSize = 4096 * 8;
+      iovecs.push_back(io);
+   }
+   return iovecs;
+}
+
+} // anonymous namespace
 
 TEST(RIoUring, Basics)
 {
@@ -19,28 +36,16 @@ TEST(RIoUring, IsAvailable)
 
 TEST(RRawFileUnix, ReadV)
 {
-   using RIOVec = RRawFile::RIOVec;
    auto file = "test_uring_readv";
    auto filesize = 2 << 20;
    FileRaii fileGuard(file, std::string(filesize, 'a')); // ~2MB
    auto f = RRawFileUnix::Create(file);
 
-   auto make_iovecs = [&](int num) -> std::vector<RIOVec> {
-      std::vector<RIOVec> iovecs;
-      for (int i = 0; i < num; ++i) {
-         RIOVec io;
-         io.fBuffer = malloc(4096 * 9);
-         io.fOffset = std::rand() % filesize;
-         io.fSize = 4096 * 8;
-         iovecs.push_back(io);
-      }
-      return iovecs;
-   };
-
    auto nReq = 128;
 
-   auto iovecs = make_iovecs(nReq);
+   auto iovecs = make_iovecs(nReq, filesize);
    f->ReadV(iovecs.data(), nReq);
+
    for (auto iovec: iovecs) {
       for (std::size_t i = 0; i < iovec.fOutBytes; ++i) {
          EXPECT_EQ('a', ((unsigned char*)iovec.fBuffer)[i]);
@@ -83,4 +88,66 @@ TEST(RawUring, NopRoundTrip)
 
    io_uring_cqe_seen(&ring, cqe);
    io_uring_queue_exit(&ring);
+}
+
+TEST(RawUring, FileRegistration)
+{
+   auto file = "test_uring_readv";
+   auto filesize = 2 << 20;
+   FileRaii fileGuard(file, std::string(filesize, 'a')); // ~2MB
+   RRawFileUnix f(file, RRawFile::ROptions());
+   // files are opened lazily, force file open via GetSize
+   auto size = f.GetSize();
+
+   unsigned int nReads = 128;
+   auto iovecs = make_iovecs(nReads, size);
+
+   RIoUring ring(nReads);
+   auto r = ring.GetRawRing();
+   auto fd = f.GetFd();
+   io_uring_register_files(r, &fd, 1);
+   auto fixed_file = 0; // 1st entry in fixed file array => offset 0
+   {
+      struct io_uring_sqe *sqe;
+      for (std::size_t i = 0; i < nReads; ++i) {
+         sqe = io_uring_get_sqe(r);
+         io_uring_prep_read(sqe,
+            fixed_file,
+            iovecs[i].fBuffer,
+            iovecs[i].fSize,
+            iovecs[i].fOffset
+         );
+         sqe->flags |= IOSQE_FIXED_FILE;
+         sqe->user_data = i;
+      }
+      int submitted = io_uring_submit_and_wait(r, nReads);
+      if (submitted <= 0) {
+         throw std::runtime_error("ring submit failed, error: " + std::string(strerror(errno)));
+      }
+      // reap reads
+      struct io_uring_cqe *cqe;
+      int ret;
+      for (int i = 0; i < submitted; ++i) {
+         ret = io_uring_wait_cqe(r, &cqe);
+         if (ret < 0) {
+            throw std::runtime_error("wait cqe failed, error: " + std::string(std::strerror(-ret)));
+         }
+         auto index = reinterpret_cast<std::size_t>(io_uring_cqe_get_data(cqe));
+         if (index >= nReads) {
+            throw std::runtime_error("bad cqe user data: " + std::to_string(index));
+         }
+         if (cqe->res < 0) {
+            throw std::runtime_error("read failed for ReadEvent[" + std::to_string(index) + "], "
+               "error: " + std::string(std::strerror(-cqe->res)));
+         }
+         iovecs[index].fOutBytes = static_cast<std::size_t>(cqe->res);
+         io_uring_cqe_seen(r, cqe);
+      }
+   }
+   for (auto iovec: iovecs) {
+      for (std::size_t i = 0; i < iovec.fOutBytes; ++i) {
+         EXPECT_EQ('a', ((unsigned char*)iovec.fBuffer)[i]);
+      }
+      free(iovec.fBuffer);
+   }
 }

--- a/io/io/test/RIoUring.cxx
+++ b/io/io/test/RIoUring.cxx
@@ -41,7 +41,7 @@ TEST(RRawFileUnix, ReadV)
    FileRaii fileGuard(file, std::string(filesize, 'a')); // ~2MB
    auto f = RRawFileUnix::Create(file);
 
-   auto nReq = 1000; // demo submission batching, uring size is around ~128
+   auto nReq = 2048; // demo submission batching, uring size is usually around 1024
 
    auto iovecs = make_iovecs(nReq, filesize);
    f->ReadV(iovecs.data(), nReq);

--- a/io/io/test/RIoUring.cxx
+++ b/io/io/test/RIoUring.cxx
@@ -37,7 +37,7 @@ TEST(RRawFileUnix, ReadV)
       return iovecs;
    };
 
-   auto nReq = 2000;
+   auto nReq = 128;
 
    auto iovecs = make_iovecs(nReq);
    // auto t1 = std::chrono::high_resolution_clock::now();

--- a/io/io/test/RIoUring.cxx
+++ b/io/io/test/RIoUring.cxx
@@ -41,7 +41,7 @@ TEST(RRawFileUnix, ReadV)
    FileRaii fileGuard(file, std::string(filesize, 'a')); // ~2MB
    auto f = RRawFileUnix::Create(file);
 
-   auto nReq = 128;
+   auto nReq = 1000; // demo submission batching, uring size is around ~128
 
    auto iovecs = make_iovecs(nReq, filesize);
    f->ReadV(iovecs.data(), nReq);

--- a/io/io/test/RIoUring.cxx
+++ b/io/io/test/RIoUring.cxx
@@ -23,17 +23,6 @@ std::vector<RIOVec> make_iovecs(int n, unsigned int fileSize) {
 
 } // anonymous namespace
 
-TEST(RIoUring, Basics)
-{
-   // successfully construct a ring with queue depth 4
-   RIoUring ring(4);
-}
-
-TEST(RIoUring, IsAvailable)
-{
-   ASSERT_TRUE(RIoUring::IsAvailable());
-}
-
 TEST(RRawFileUnix, ReadV)
 {
    auto file = "test_uring_readv";

--- a/io/io/test/RRawFile.cxx
+++ b/io/io/test/RRawFile.cxx
@@ -1,42 +1,6 @@
-#include "RConfigure.h"
-#include "ROOT/RRawFile.hxx"
-#include "ROOT/RMakeUnique.hxx"
-
-#include <algorithm>
-#include <cstdio>
-#include <cstring>
-#include <fstream>
-#include <memory>
-#include <stdexcept>
-#include <string>
-#include <utility>
-
-#include "gtest/gtest.h"
-
-using RRawFile = ROOT::Internal::RRawFile;
+#include "io_test.hxx"
 
 namespace {
-
-/**
- * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
- * goes out of scope.
- */
-class FileRaii {
-private:
-   std::string fPath;
-public:
-   FileRaii(const std::string &path, const std::string &content) : fPath(path)
-   {
-      std::ofstream ostrm(path, std::ios::binary | std::ios::out | std::ios::trunc);
-      ostrm << content;
-   }
-   FileRaii(const FileRaii&) = delete;
-   FileRaii& operator=(const FileRaii&) = delete;
-   ~FileRaii() {
-      std::remove(fPath.c_str());
-   }
-};
-
 
 /**
  * A minimal RRawFile implementation that serves data from a string. It keeps a counter of the number of read calls

--- a/io/io/test/io_test.hxx
+++ b/io/io/test/io_test.hxx
@@ -3,7 +3,6 @@
 #include "ROOT/RMakeUnique.hxx"
 
 #include <algorithm>
-#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/io/io/test/io_test.hxx
+++ b/io/io/test/io_test.hxx
@@ -1,0 +1,42 @@
+#include "RConfigure.h"
+#include "ROOT/RRawFile.hxx"
+#include "ROOT/RMakeUnique.hxx"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "gtest/gtest.h"
+
+using RRawFile = ROOT::Internal::RRawFile;
+
+namespace {
+
+/**
+ * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
+ * goes out of scope.
+ */
+class FileRaii {
+private:
+   std::string fPath;
+public:
+   FileRaii(const std::string &path, const std::string &content) : fPath(path)
+   {
+      std::ofstream ostrm(path, std::ios::binary | std::ios::out | std::ios::trunc);
+      ostrm << content;
+   }
+   FileRaii(const FileRaii&) = delete;
+   FileRaii& operator=(const FileRaii&) = delete;
+   ~FileRaii() {
+      std::remove(fPath.c_str());
+   }
+};
+
+} // anonymous namespace


### PR DESCRIPTION
Implements a basic `RRawFileUnix::ReadV` implementation using the `io_uring` async backend.  
Note: `ReadV` performs many disjoint reads on one file, not scatter IO using `readv`

Basic means: 
* simple error-handling  
* no interrupt considerations
* ~~no submission queue event batching (large `nReq` may exhaust memory resources)~~ implemented in 8c8a841 

The idea is to benchmark whether io_uring allows us to take advantage of modern IO devices, e.g. SSD queue depth etc. 

I also factored out a common test header `io_test.hxx` from `test/RRawFile.cxx` for use in `test/RIoUring.cxx`