### PR TITLE
[RS] Skip NaNs and infinities in HypoTestInverter.

### DIFF
--- a/roofit/roostats/src/HypoTestInverterPlot.cxx
+++ b/roofit/roostats/src/HypoTestInverterPlot.cxx
@@ -116,7 +116,7 @@ TGraphErrors* HypoTestInverterPlot::MakePlot(Option_t * opt)
          CLErr = fResults->CLsError(index[i]);
       }
 
-      if (CLVal < 0.) {
+      if (CLVal < 0. || !std::isfinite(CLVal)) {
          Warning("HypoTestInverterPlot::MakePlot", "Got a confidence level of %f at x=%f (failed fit?). Skipping this point.", CLVal, fResults->GetXValue(index[i]));
          continue;
       }

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -673,12 +673,6 @@ double HypoTestInverterResult::GetGraphX(const TGraph & graph, double y0, bool l
    }
    double limit =  brf.Root();
 
-   // auto grfunc = [&](double * x, double *) {
-   //    return (fInterpolOption == kSpline) ? graph.Eval(*x, nullptr, "S") - y0 : graph.Eval(*x) - y0;
-   // };
-   // TF1 tgrfunc("tgrfunc",grfunc,xmin,xmax,0);
-   // double limit = tgrfunc.GetX(0,xmin,xmax);
-
 #ifdef DO_DEBUG
    if (lowSearch) std::cout << "lower limit search : ";
    else std::cout << "Upper limit search :  ";


### PR DESCRIPTION
If a fit fails, it might produce non-finite confidence levels. This can
be a problem for the hypothesis test inversion.
Here, all non-finite numbers are skipped, in the hope that this can
stabilise a limit calculation in cases where the failed fits are
irrelevant for finding the 95% CL.