### PR TITLE
WIP: Add (symmetric) double-sided Crystal Ball shape to RooFit

### DIFF
--- a/roofit/roofit/CMakeLists.txt
+++ b/roofit/roofit/CMakeLists.txt
@@ -25,6 +25,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
     RooBukinPdf.h
     RooCBShape.h
     RooDSCBShape.h
+    RooSDSCBShape.h
     RooCFunction1Binding.h
     RooCFunction2Binding.h
     RooCFunction3Binding.h
@@ -85,6 +86,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
     src/RooBukinPdf.cxx
     src/RooCBShape.cxx
     src/RooDSCBShape.cxx
+    src/RooSDSCBShape.cxx
     src/RooCFunction1Binding.cxx
     src/RooCFunction2Binding.cxx
     src/RooCFunction3Binding.cxx

--- a/roofit/roofit/CMakeLists.txt
+++ b/roofit/roofit/CMakeLists.txt
@@ -24,6 +24,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
     RooBreitWigner.h
     RooBukinPdf.h
     RooCBShape.h
+    RooDSCBShape.h
     RooCFunction1Binding.h
     RooCFunction2Binding.h
     RooCFunction3Binding.h
@@ -83,6 +84,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
     src/RooBreitWigner.cxx
     src/RooBukinPdf.cxx
     src/RooCBShape.cxx
+    src/RooDSCBShape.cxx
     src/RooCFunction1Binding.cxx
     src/RooCFunction2Binding.cxx
     src/RooCFunction3Binding.cxx

--- a/roofit/roofit/inc/LinkDef1.h
+++ b/roofit/roofit/inc/LinkDef1.h
@@ -14,6 +14,7 @@
 #pragma link C++ class RooBukinPdf+ ;
 #pragma link C++ class RooCBShape+ ;
 #pragma link C++ class RooDSCBShape+ ;
+#pragma link C++ class RooSDSCBShape+ ;
 #pragma link C++ class RooChebychev+ ;
 #pragma link C++ class RooDecay+ ;
 #pragma link C++ class RooDstD0BG+ ;

--- a/roofit/roofit/inc/LinkDef1.h
+++ b/roofit/roofit/inc/LinkDef1.h
@@ -13,6 +13,7 @@
 #pragma link C++ class RooBreitWigner+ ;
 #pragma link C++ class RooBukinPdf+ ;
 #pragma link C++ class RooCBShape+ ;
+#pragma link C++ class RooDSCBShape+ ;
 #pragma link C++ class RooChebychev+ ;
 #pragma link C++ class RooDecay+ ;
 #pragma link C++ class RooDstD0BG+ ;

--- a/roofit/roofit/inc/RooDSCBShape.h
+++ b/roofit/roofit/inc/RooDSCBShape.h
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * Package: RooFitModels                                                     *
+ *    File: $Id: RooDSCBShape.h$                                             *
+ * Authors:                                                                  *
+ *    T. Skwarnicki modify RooCBShape to Asymmetrical Double-Sided CB        *
+ *    Michael Wilkinson add to RooFit source                                 *
+ *****************************************************************************/
+#ifndef ROO_DSCB_SHAPE
+#define ROO_DSCB_SHAPE
+
+#include "RooAbsPdf.h"
+#include "RooRealProxy.h"
+
+class RooRealVar;
+
+class RooDSCBShape : public RooAbsPdf {
+public:
+  RooDSCBShape() {} ;
+  RooDSCBShape(const char *name, const char *title, RooAbsReal& _m,
+	     RooAbsReal& _m0, RooAbsReal& _sigma,
+	     RooAbsReal& _alphaL, RooAbsReal& _nL,
+	     RooAbsReal& _alphaR, RooAbsReal& _nR);
+
+  RooDSCBShape(const RooDSCBShape& other, const char* name = 0);
+  virtual TObject* clone(const char* newname) const { return new RooDSCBShape(*this,newname); }
+
+  inline virtual ~RooDSCBShape() { }
+
+  virtual Int_t getAnalyticalIntegral( RooArgSet& allVars,  RooArgSet& analVars, const char* rangeName=0 ) const;
+  virtual Double_t analyticalIntegral( Int_t code, const char* rangeName=0 ) const;
+
+  // Optimized accept/reject generator support
+  virtual Int_t getMaxVal(const RooArgSet& vars) const ;
+  virtual Double_t maxVal(Int_t code) const ;
+
+protected:
+
+  Double_t ApproxErf(Double_t arg) const ;
+
+  RooRealProxy m;
+  RooRealProxy m0;
+  RooRealProxy sigma;
+  RooRealProxy alphaL;
+  RooRealProxy nL;
+  RooRealProxy alphaR;
+  RooRealProxy nR;
+
+  Double_t evaluate() const;
+
+private:
+
+  ClassDef(RooDSCBShape,1) // Asymmetrical Double-Sided Crystal Ball lineshape PDF
+};
+
+#endif

--- a/roofit/roofit/inc/RooSDSCBShape.h
+++ b/roofit/roofit/inc/RooSDSCBShape.h
@@ -1,0 +1,53 @@
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * Package: RooFitModels                                                     *
+ *    File: $Id: RooSDSCBShape.h$                                            *
+ * Authors:                                                                  *
+ *    T. Skwarnicki modify RooCBShape to Symmetrical Double-Sided CB         *
+ *    Michael Wilkinson add to RooFit source                                 *
+ *****************************************************************************/
+#ifndef ROO_SDSCB_SHAPE
+#define ROO_SDSCB_SHAPE
+
+#include "RooAbsPdf.h"
+#include "RooRealProxy.h"
+
+class RooRealVar;
+
+class RooSDSCBShape : public RooAbsPdf {
+public:
+  RooSDSCBShape() {} ;
+  RooSDSCBShape(const char *name, const char *title, RooAbsReal& _m,
+	     RooAbsReal& _m0, RooAbsReal& _sigma,
+	     RooAbsReal& _alpha, RooAbsReal& _n);
+
+  RooSDSCBShape(const RooSDSCBShape& other, const char* name = 0);
+  virtual TObject* clone(const char* newname) const { return new RooSDSCBShape(*this,newname); }
+
+  inline virtual ~RooSDSCBShape() { }
+
+  virtual Int_t getAnalyticalIntegral( RooArgSet& allVars,  RooArgSet& analVars, const char* rangeName=0 ) const;
+  virtual Double_t analyticalIntegral( Int_t code, const char* rangeName=0 ) const;
+
+  // Optimized accept/reject generator support
+  virtual Int_t getMaxVal(const RooArgSet& vars) const ;
+  virtual Double_t maxVal(Int_t code) const ;
+
+protected:
+
+  Double_t ApproxErf(Double_t arg) const ;
+
+  RooRealProxy m;
+  RooRealProxy m0;
+  RooRealProxy sigma;
+  RooRealProxy alpha;
+  RooRealProxy n;
+
+  Double_t evaluate() const;
+
+private:
+
+  ClassDef(RooSDSCBShape,1) // Symmetrical Double-Sided Crystal Ball lineshape PDF
+};
+
+#endif

--- a/roofit/roofit/src/RooDSCBShape.cxx
+++ b/roofit/roofit/src/RooDSCBShape.cxx
@@ -1,0 +1,256 @@
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * Package: RooFitModels                                                     *
+ * @(#)root/roofit:$Id$
+ * Authors:                                                                  *
+ *    T. Skwarnicki modify RooCBShape to Asymmetrical Double-Sided CB                     *
+ *    Michael Wilkinson add to RooFit source                                 *
+ *****************************************************************************/
+
+/** \class RooCBShape
+    \ingroup Roofit
+
+PDF implementing the Asymmetrical Double-Sided Crystall Ball line shape.
+**/
+
+#include "RooDSCBShape.h"
+#include "RooFit.h"
+
+#include "RooAbsReal.h"
+#include "RooRealVar.h"
+#include "RooMath.h"
+
+#include "TMath.h"
+
+#include "Riostream.h"
+#include "Riostream.h"
+#include <math.h>
+
+using namespace std;
+
+ClassImp(RooDSCBShape);
+
+////////////////////////////////////////////////////////////////////////////////
+
+Double_t RooDSCBShape::ApproxErf(Double_t arg) const
+{
+  static const double erflim = 5.0;
+  if( arg > erflim )
+    return 1.0;
+  if( arg < -erflim )
+    return -1.0;
+
+  return RooMath::erf(arg);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+RooDSCBShape::RooDSCBShape(const char *name, const char *title,
+		       RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _sigma,
+		       RooAbsReal& _alphaL, RooAbsReal& _nL,
+                       RooAbsReal& _alphaR, RooAbsReal& _nR) :
+  RooAbsPdf(name, title),
+  m("m", "Dependent", this, _m),
+  m0("m0", "M0", this, _m0),
+  sigma("sigma", "Sigma", this, _sigma),
+  alphaL("alphaL", "Left Alpha", this, _alphaL),
+  nL("nL", "Left Order", this, _nL),
+  alphaR("alphaR", "Right Alpha", this, _alphaR),
+  nR("nR", "Right Order", this, _nR)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+RooDSCBShape::RooDSCBShape(const RooDSCBShape& other, const char* name) :
+  RooAbsPdf(other, name), m("m", this, other.m), m0("m0", this, other.m0),
+  sigma("sigma", this, other.sigma), alphaL("alphaL", this, other.alphaL),
+  nL("nL", this, other.nL), alphaR("alphaR", this, other.alphaR),
+  nR("nR", this, other.nR)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Double_t RooDSCBShape::evaluate() const {
+
+  Double_t t = (Double_t)( (m-m0)/sigma );
+  Double_t absAlphaL = fabs( (Double_t)alphaL);
+  Double_t absAlphaR = fabs( (Double_t)alphaR);
+
+
+  if (t < -alphaL) {
+    Double_t a =  TMath::Power(nL/absAlphaL,nL)*exp(-0.5*absAlphaL*absAlphaL);
+    Double_t b= nL/absAlphaL - absAlphaL;
+
+    return a/TMath::Power(b - t, nL);
+  }
+  else if(t<=alphaR){
+    return exp(-0.5*t*t);
+  }
+  else {
+    Double_t a =  TMath::Power(nR/absAlphaR,nR)*exp(-0.5*absAlphaR*absAlphaR);
+    Double_t b= nR/absAlphaR - absAlphaR;
+
+    return a/TMath::Power(b + t, nR);
+  }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Int_t RooDSCBShape::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* /*rangeName*/) const
+{
+  if( matchArgs(allVars,analVars,m) )
+    return 1 ;
+
+  return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Double_t RooDSCBShape::analyticalIntegral(Int_t code, const char* rangeName) const
+{
+  static const double sqrtPiOver2 = 1.2533141373;
+  static const double sqrt2 = 1.4142135624;
+
+  R__ASSERT(code==1);
+  double result = 0.0;
+  bool useLogL = false;
+  bool useLogR = false;
+
+  if( fabs(nL-1.0) < 1.0e-05 )
+    useLogL = true;
+  if( fabs(nR-1.0) < 1.0e-05 )
+    useLogR = true;
+
+  double sig = fabs((Double_t)sigma);
+
+  double tmin = (m.min(rangeName)-m0)/sig;
+  double tmax = (m.max(rangeName)-m0)/sig;
+
+  double absAlphaL = fabs((Double_t)alphaL);
+  double absAlphaR = fabs((Double_t)alphaR);
+
+  if( ( tmin >= -absAlphaL ) && ( tmax <= absAlphaR ) ) {
+    result += sig*sqrtPiOver2*(   ApproxErf(tmax/sqrt2)
+                                - ApproxErf(tmin/sqrt2) );
+  }
+  else if( tmax <= -absAlphaL ) {
+    double a = TMath::Power(nL/absAlphaL,nL)*exp(-0.5*absAlphaL*absAlphaL);
+    double b = nL/absAlphaL - absAlphaL;
+
+    if(useLogL) {
+      result += a*sig*( log(b-tmin) - log(b-tmax) );
+    }
+    else {
+      result += a*sig/(1.0-nL)*(   1.0/(TMath::Power(b-tmin,nL-1.0))
+                                - 1.0/(TMath::Power(b-tmax,nL-1.0)) );
+    }
+  }
+  else if( tmin >= absAlphaR ) {
+    double a = TMath::Power(nR/absAlphaR,nR)*exp(-0.5*absAlphaR*absAlphaR);
+    double b = nR/absAlphaR - absAlphaR;
+
+    if(useLogR) {
+      result += a*sig*( log(b+tmax) - log(b+tmin) );
+    }
+    else {
+      result += a*sig/(1.0-nR)*(   1.0/(TMath::Power(b+tmax,nR-1.0))
+                                - 1.0/(TMath::Power(b+tmin,nR-1.0)) );
+    }
+  }
+  else if( ( tmin < -absAlphaL ) && ( tmax <= absAlphaR ) ) {
+    double a = TMath::Power(nL/absAlphaL,nL)*exp(-0.5*absAlphaL*absAlphaL);
+    double b = nL/absAlphaL - absAlphaL;
+
+    double term1 = 0.0;
+    if(useLogL) {
+      term1 = a*sig*(  log(b-tmin) - log(nL/absAlphaL));
+    }
+    else {
+      term1 = a*sig/(1.0-nL)*(   1.0/(TMath::Power(b-tmin,nL-1.0))
+                              - 1.0/(TMath::Power(nL/absAlphaL,nL-1.0)) );
+    }
+
+    double term2 = sig*sqrtPiOver2*(   ApproxErf(tmax/sqrt2)
+                                     - ApproxErf(-absAlphaL/sqrt2) );
+
+    result += term1 + term2;
+  }
+  else if( ( tmin < -absAlphaL ) && ( tmax > absAlphaR ) ) {
+    double aL = TMath::Power(nL/absAlphaL,nL)*exp(-0.5*absAlphaL*absAlphaL);
+    double aR = TMath::Power(nR/absAlphaR,nR)*exp(-0.5*absAlphaR*absAlphaR);
+    double bL = nL/absAlphaL - absAlphaL;
+    double bR = nR/absAlphaR - absAlphaR;
+
+    double term1 = 0.0;
+    if(useLogL) {
+      term1 = aL*sig*(  log(bL-tmin) - log(nL/absAlphaL));
+    }
+    else {
+      term1 = aL*sig/(1.0-nL)*(   1.0/(TMath::Power(bL-tmin,nL-1.0))
+                              - 1.0/(TMath::Power(nL/absAlphaL,nL-1.0)) );
+    }
+    double term2 = sig*sqrtPiOver2*(   ApproxErf( absAlphaR/sqrt2)
+                                     - ApproxErf(-absAlphaL/sqrt2) );
+
+    double term3 = 0.0;
+    if(useLogR) {
+      term3 = aR*sig*(  log(bR+tmax) - log(nR/absAlphaR));
+    }
+    else {
+      term3 = aR*sig/(1.0-nR)*(   1.0/(TMath::Power(bR+tmax,nR-1.0))
+                              - 1.0/(TMath::Power(nR/absAlphaR,nR-1.0)) );
+    }
+    result += term1 + term2 + term3;
+  }
+  else if( ( tmin >= -absAlphaL ) && ( tmax > absAlphaR ) ) {
+    double a = TMath::Power(nR/absAlphaR,nR)*exp(-0.5*absAlphaR*absAlphaR);
+    double b = nR/absAlphaR - absAlphaR;
+
+    double term1 = 0.0;
+    if(useLogR) {
+      term1 = a*sig*(  log(b+tmax) - log(nR/absAlphaR));
+    }
+    else {
+      term1 = a*sig/(1.0-nR)*(   1.0/(TMath::Power(b+tmax,nR-1.0))
+                              - 1.0/(TMath::Power(nR/absAlphaR,nR-1.0)) );
+    }
+
+    double term2 = sig*sqrtPiOver2*(   ApproxErf(absAlphaR/sqrt2)
+                                     - ApproxErf(tmin/sqrt2) );
+
+
+    result += term1 + term2;
+  }
+  else {
+    std::cout << " This should never happen! Error in RooDSCBShape logic " << std::endl;
+    assert(0);
+  }
+
+  return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Advertise that we know the maximum of self for given (m0,alpha,n,sigma)
+
+Int_t RooDSCBShape::getMaxVal(const RooArgSet& vars) const
+{
+  RooArgSet dummy ;
+
+  if (matchArgs(vars,dummy,m)) {
+    return 1 ;
+  }
+  return 0 ;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Double_t RooDSCBShape::maxVal(Int_t code) const
+{
+  R__ASSERT(code==1) ;
+
+  // The maximum value for given (m0,alpha,n,sigma)
+  return 1.0 ;
+}

--- a/roofit/roofit/src/RooSDSCBShape.cxx
+++ b/roofit/roofit/src/RooSDSCBShape.cxx
@@ -1,0 +1,246 @@
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * Package: RooFitModels                                                     *
+ * @(#)root/roofit:$Id$
+ * Authors:                                                                  *
+ *    T. Skwarnicki modify RooCBShape to Symmetrical Double-Sided CB         *
+ *    Michael Wilkinson add to RooFit source                                 *
+ *****************************************************************************/
+
+/** \class RooCBShape
+    \ingroup Roofit
+
+PDF implementing the Symmetrical Double-Sided Crystall Ball line shape.
+**/
+
+#include "RooSDSCBShape.h"
+#include "RooFit.h"
+
+#include "RooAbsReal.h"
+#include "RooRealVar.h"
+#include "RooMath.h"
+
+#include "TMath.h"
+
+#include "Riostream.h"
+#include "Riostream.h"
+#include <math.h>
+
+using namespace std;
+
+ClassImp(RooSDSCBShape);
+
+////////////////////////////////////////////////////////////////////////////////
+
+Double_t RooSDSCBShape::ApproxErf(Double_t arg) const
+{
+  static const double erflim = 5.0;
+  if( arg > erflim )
+    return 1.0;
+  if( arg < -erflim )
+    return -1.0;
+
+  return RooMath::erf(arg);
+}
+
+
+static const char rcsid[] =
+"$Id: RooSDSCBShape.C 1246 2013-04-02 02:51:06Z tskwarni $";
+
+////////////////////////////////////////////////////////////////////////////////
+
+RooSDSCBShape::RooSDSCBShape(const char *name, const char *title,
+		       RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _sigma,
+		       RooAbsReal& _alpha, RooAbsReal& _n) :
+  RooAbsPdf(name, title),
+  m("m", "Dependent", this, _m),
+  m0("m0", "M0", this, _m0),
+  sigma("sigma", "Sigma", this, _sigma),
+  alpha("alpha", "Alpha", this, _alpha),
+  n("n", "Order", this, _n)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+RooSDSCBShape::RooSDSCBShape(const RooSDSCBShape& other, const char* name) :
+  RooAbsPdf(other, name), m("m", this, other.m), m0("m0", this, other.m0),
+  sigma("sigma", this, other.sigma), alpha("alpha", this, other.alpha),
+  n("n", this, other.n)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Double_t RooSDSCBShape::evaluate() const {
+
+  Double_t t = fabs( (Double_t)( (m-m0)/sigma ) );
+  Double_t absAlpha = fabs( (Double_t)alpha);
+
+  if (t < absAlpha) {
+    return exp(-0.5*t*t);
+  }
+  else {
+    Double_t a =  TMath::Power(n/absAlpha,n)*exp(-0.5*absAlpha*absAlpha);
+    Double_t b= n/absAlpha - absAlpha;
+
+    return a/TMath::Power(b + t, n);
+  }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Int_t RooSDSCBShape::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* /*rangeName*/) const
+{
+  if( matchArgs(allVars,analVars,m) )
+    return 1 ;
+
+  return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Double_t RooSDSCBShape::analyticalIntegral(Int_t code, const char* rangeName) const
+{
+  static const double sqrtPiOver2 = 1.2533141373;
+  static const double sqrt2 = 1.4142135624;
+
+  assert(code==1);
+  double result = 0.0;
+  bool useLog = false;
+
+  if( fabs(n-1.0) < 1.0e-05 )
+    useLog = true;
+
+  double sig = fabs((Double_t)sigma);
+
+  double tmin = (m.min(rangeName)-m0)/sig;
+  double tmax = (m.max(rangeName)-m0)/sig;
+
+  double absAlpha = fabs((Double_t)alpha);
+
+  if( ( tmin >= -absAlpha ) && ( tmax <= absAlpha ) ) {
+    result += sig*sqrtPiOver2*(   ApproxErf(tmax/sqrt2)
+                                - ApproxErf(tmin/sqrt2) );
+  }
+  else if( tmax <= -absAlpha ) {
+    double a = TMath::Power(n/absAlpha,n)*exp(-0.5*absAlpha*absAlpha);
+    double b = n/absAlpha - absAlpha;
+
+    if(useLog) {
+      result += a*sig*( log(b-tmin) - log(b-tmax) );
+    }
+    else {
+      result += a*sig/(1.0-n)*(   1.0/(TMath::Power(b-tmin,n-1.0))
+                                - 1.0/(TMath::Power(b-tmax,n-1.0)) );
+    }
+  }
+  else if( tmin >= absAlpha ) {
+    double a = TMath::Power(n/absAlpha,n)*exp(-0.5*absAlpha*absAlpha);
+    double b = n/absAlpha - absAlpha;
+
+    if(useLog) {
+      result += a*sig*( log(b+tmax) - log(b+tmin) );
+    }
+    else {
+      result += a*sig/(1.0-n)*(   1.0/(TMath::Power(b+tmax,n-1.0))
+                                - 1.0/(TMath::Power(b+tmin,n-1.0)) );
+    }
+  }
+  else if( ( tmin < -absAlpha ) && ( tmax <= absAlpha ) ) {
+    double a = TMath::Power(n/absAlpha,n)*exp(-0.5*absAlpha*absAlpha);
+    double b = n/absAlpha - absAlpha;
+
+    double term1 = 0.0;
+    if(useLog) {
+      term1 = a*sig*(  log(b-tmin) - log(n/absAlpha));
+    }
+    else {
+      term1 = a*sig/(1.0-n)*(   1.0/(TMath::Power(b-tmin,n-1.0))
+                              - 1.0/(TMath::Power(n/absAlpha,n-1.0)) );
+    }
+
+    double term2 = sig*sqrtPiOver2*(   ApproxErf(tmax/sqrt2)
+                                     - ApproxErf(-absAlpha/sqrt2) );
+
+
+    result += term1 + term2;
+  }
+  else if( ( tmin < -absAlpha ) && ( tmax > absAlpha ) ) {
+    double a = TMath::Power(n/absAlpha,n)*exp(-0.5*absAlpha*absAlpha);
+    double b = n/absAlpha - absAlpha;
+
+    double term1 = 0.0;
+    if(useLog) {
+      term1 = a*sig*(  log(b-tmin) - log(n/absAlpha));
+    }
+    else {
+      term1 = a*sig/(1.0-n)*(   1.0/(TMath::Power(b-tmin,n-1.0))
+                              - 1.0/(TMath::Power(n/absAlpha,n-1.0)) );
+    }
+
+    double term2 = sig*sqrtPiOver2*(   ApproxErf( absAlpha/sqrt2)
+                                     - ApproxErf(-absAlpha/sqrt2) );
+
+
+    double term3 = 0.0;
+    if(useLog) {
+      term3 = a*sig*(  log(b+tmax) - log(n/absAlpha));
+    }
+    else {
+      term3 = a*sig/(1.0-n)*(   1.0/(TMath::Power(b+tmax,n-1.0))
+                              - 1.0/(TMath::Power(n/absAlpha,n-1.0)) );
+    }
+
+    result += term1 + term2 + term3;
+  }
+  else if( ( tmin >= -absAlpha ) && ( tmax > absAlpha ) ) {
+    double a = TMath::Power(n/absAlpha,n)*exp(-0.5*absAlpha*absAlpha);
+    double b = n/absAlpha - absAlpha;
+
+    double term1 = 0.0;
+    if(useLog) {
+      term1 = a*sig*(  log(b+tmax) - log(n/absAlpha));
+    }
+    else {
+      term1 = a*sig/(1.0-n)*(   1.0/(TMath::Power(b+tmax,n-1.0))
+                              - 1.0/(TMath::Power(n/absAlpha,n-1.0)) );
+    }
+
+    double term2 = sig*sqrtPiOver2*(   ApproxErf(-tmin/sqrt2)
+                                     - ApproxErf(-absAlpha/sqrt2) );
+
+
+    result += term1 + term2;
+  }
+  else {
+    std::cout << " This should never happen! Error in RooSDCCBShape logic " << std::endl;
+    assert(0);
+  }
+
+  return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Advertise that we know the maximum of self for given (m0,alpha,n,sigma)
+
+Int_t RooSDSCBShape::getMaxVal(const RooArgSet& vars) const
+{
+  RooArgSet dummy ;
+
+  if (matchArgs(vars,dummy,m)) {
+    return 1 ;
+  }
+  return 0 ;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Double_t RooSDSCBShape::maxVal(Int_t code) const
+{
+  R__ASSERT(code==1) ;
+
+  // The maximum value for given (m0,alpha,n,sigma)
+  return 1.0 ;
+}


### PR DESCRIPTION
`RooCBShape` is commonly used in HEP analyses. This adds its slightly less common extrapolations `RooDSCBShape` and `RooSDSCBShape`.