### PR TITLE
[roofit] fix gcc10 warning with uninitialized variables

### DIFF
--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -714,7 +714,7 @@ Double_t RooTreeDataStore::weightError(RooAbsData::ErrorType etype) const
     // We have a weight array, use that info
 
     // Return symmetric error on current bin calculated either from Poisson statistics or from SumOfWeights
-    Double_t lo,hi ;
+    Double_t lo = 0, hi =0;
     weightError(lo,hi,etype) ;
     return (lo+hi)/2 ;
 
@@ -724,7 +724,7 @@ Double_t RooTreeDataStore::weightError(RooAbsData::ErrorType etype) const
     if (_wgtVar->hasAsymError()) {
       return ( _wgtVar->getAsymErrorHi() - _wgtVar->getAsymErrorLo() ) / 2 ;
     } else {
-      return _wgtVar->getError() ;    
+      return _wgtVar->getError() ;
     }
 
   } else {
@@ -757,9 +757,9 @@ void RooTreeDataStore::weightError(Double_t& lo, Double_t& hi, RooAbsData::Error
     case RooAbsData::Poisson:
       // Weight may be preset or precalculated    
       if (_curWgtErrLo>=0) {
-	lo = _curWgtErrLo ;
-	hi = _curWgtErrHi ;
-	return ;
+         lo = _curWgtErrLo ;
+         hi = _curWgtErrHi ;
+         return ;
       }
       
       // Otherwise Calculate poisson errors

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -569,7 +569,7 @@ Double_t RooVectorDataStore::weightError(RooAbsData::ErrorType etype) const
     // We have a weight array, use that info
 
     // Return symmetric error on current bin calculated either from Poisson statistics or from SumOfWeights
-    Double_t lo,hi ;
+    Double_t lo = 0, hi = 0 ;
     weightError(lo,hi,etype) ;
     return (lo+hi)/2 ;
 
@@ -579,7 +579,7 @@ Double_t RooVectorDataStore::weightError(RooAbsData::ErrorType etype) const
     if (_wgtVar->hasAsymError()) {
       return ( _wgtVar->getAsymErrorHi() - _wgtVar->getAsymErrorLo() ) / 2 ;
     } else if (_wgtVar->hasError(kFALSE)) {
-      return _wgtVar->getError() ;    
+      return _wgtVar->getError();
     } else {
       return 0 ;
     }
@@ -612,11 +612,11 @@ void RooVectorDataStore::weightError(Double_t& lo, Double_t& hi, RooAbsData::Err
       break ;
       
     case RooAbsData::Poisson:
-      // Weight may be preset or precalculated    
+      // Weight may be preset or precalculated
       if (_curWgtErrLo>=0) {
-	lo = _curWgtErrLo ;
-	hi = _curWgtErrHi ;
-	return ;
+         lo = _curWgtErrLo ;
+         hi = _curWgtErrHi ;
+         return ;
       }
       
       // Otherwise Calculate poisson errors


### PR DESCRIPTION
roofit/roofitcore/src/RooVectorDataStore.cxx: In member function
‘virtual Double_t RooVectorDataStore::weightError(RooAbsData::ErrorType)
const’:
roofit/roofitcore/src/RooVectorDataStore.cxx:574:15:
warning: ‘lo’ may be used uninitialized in this function
[-Wmaybe-uninitialized]
  574 |     return (lo+hi)/2 ;
      |            ~~~^~~~
roofit/roofitcore/src/RooVectorDataStore.cxx:574:15: warning: ‘hi’ may
be used uninitialized in this function [-Wmaybe-uninitialized]