### PR TITLE
[RF] Fix ROOT-10987.

### DIFF
--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -642,29 +642,13 @@ void RooAbsOptTestStatistic::optimizeConstantTerms(Bool_t activate, Bool_t apply
 
     _funcClone->findConstantNodes(*_dataClone->get(),_cachedNodes) ;
 
-//     cout << "ROATS::oCT(" << GetName() << ") funcClone structure dump BEFORE cacheArgs" << endl ;
-//     _funcClone->Print("t") ;
-
-
     // Cache constant nodes with dataset - also cache entries corresponding to zero-weights in data when using BinnedLikelihood
     _dataClone->cacheArgs(this,_cachedNodes,_normSet,!_funcClone->getAttribute("BinnedLikelihood")) ;  
-
-//     cout << "ROATS::oCT(" << GetName() << ") funcClone structure dump AFTER cacheArgs" << endl ;
-//     _funcClone->Print("t") ;
-
 
     // Put all cached nodes in AClean value caching mode so that their evaluate() is never called
     for (auto cacheArg : _cachedNodes) {
       cacheArg->setOperMode(RooAbsArg::AClean) ;
     }
-
-
-//     cout << "_cachedNodes = " << endl ;
-//     RooFIter i = _cachedNodes.fwdIterator() ;
-//     RooAbsArg* aa ;
-//     while ((aa=i.next())) {
-//       cout << aa->IsA()->GetName() << "::" << aa->GetName() << (aa->getAttribute("ConstantExpressionCached")?" CEC":"   ") << (aa->getAttribute("CacheAndTrack")?" CAT":"   ") << endl ;
-//     }
 
     RooArgSet* constNodes = (RooArgSet*) _cachedNodes.selectByAttrib("ConstantExpressionCached",kTRUE) ;
     RooArgSet actualTrackNodes(_cachedNodes) ;
@@ -675,11 +659,6 @@ void RooAbsOptTestStatistic::optimizeConstantTerms(Bool_t activate, Bool_t apply
       } else {
         coutI(Minimization) << " A total of " << constNodes->getSize() << " expressions have been identified as constant and will be precalculated and cached." << endl ;
       }
-//       RooFIter i = constNodes->fwdIterator() ;
-//       RooAbsArg* cnode ;
-//       while((cnode=i.next())) {
-// 	cout << cnode->IsA()->GetName() << "::" << cnode->GetName() << endl ;
-//       }      
     }
     if (actualTrackNodes.getSize()>0) {
       if (actualTrackNodes.getSize()<20) {


### PR DESCRIPTION
Fix a long-standing problem in RooFit's faster batch computations.

[ROOT-10987] When a PDF doesn't implement the faster batch interface,
RooFit's old, single-value computations have to be used as a fallback.
If RooFit, however, tries to precalculate those values, the nodes of
the computation graph will always yield the same wrong value, since
they are switched to "always clean".
This happens e.g. when a node of the graph doesn't depend on parameters,
but only on observables.

To fix this, the global static that inihibits "always clean" has to be
set while the computation is running.

**NB**:
The test for this exists since ages, but was marked `WILLFAIL`. I will switching it back to normal in a roottest PR (to come).
Automatic checkout of the corresponding roottest branch will run the test in normal mode already in this build.