### PR TITLE
[jupyterlab] do not use require.js with JSROOT

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -73,7 +73,8 @@ if (typeof require !== 'undefined') {{
 
     // Try loading a local version of requirejs and fallback to cdn if not possible.
     script_load(base_url + 'static/scripts/JSRootCore.js', script_success, function(){{
-        script_load('https://root.cern/js/notebook/scripts/JSRootCore.min.js', script_success, function(){{
+        console.error('Fail to load JSROOT locally, please check your jupyter_notebook_config.py file')
+        script_load('https://root.cern/js/5.8.1/scripts/JSRootCore.min.js', script_success, function(){{
             document.getElementById("{jsDivId}").innerHTML = "Failed to load JSROOT";
         }});
     }});

--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -39,23 +39,31 @@ console.log("JupyROOT - %%cpp magic configured");
 
 _jsNotDrawableClassesPatterns = ["TEve*","TF3","TPolyLine3D"]
 
-
 _jsCanvasWidth = 800
 _jsCanvasHeight = 600
-
 _jsCode = """
+
 <div id="{jsDivId}"
      style="width: {jsCanvasWidth}px; height: {jsCanvasHeight}px">
 </div>
 <script>
 if (typeof require !== 'undefined') {{
 
-    // All requirements met (we are in jupyter notebooks or we loaded requirejs before).
-    display_{jsDivId}();
+    // We are in jupyter notebooks, use require.js which should be configured already
+    require(['scripts/JSRootCore'],
+        function(Core) {{
+           display_{jsDivId}(Core);
+        }}
+    );
+
+}} else if (typeof JSROOT !== 'undefined') {{
+
+   // JSROOT already loaded, just use it
+   display_{jsDivId}(JSROOT);
 
 }} else {{
 
-    // We are in jupyterlab, we need to insert requirejs and configure it.
+    // We are in jupyterlab without require.js, directly loading jsroot
     // Jupyterlab might be installed in a different base_url so we need to know it.
     try {{
         var base_url = JSON.parse(document.getElementById('jupyter-config-data').innerHTML).baseUrl;
@@ -64,14 +72,14 @@ if (typeof require !== 'undefined') {{
     }}
 
     // Try loading a local version of requirejs and fallback to cdn if not possible.
-    requirejs_load(base_url + 'static/components/requirejs/require.js', requirejs_success(base_url), function(){{
-        requirejs_load('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.min.js', requirejs_success(base_url), function(){{
-            document.getElementById("{jsDivId}").innerHTML = "Failed to load requireJs";
+    script_load(base_url + 'static/scripts/JSRootCore.js', script_success, function(){{
+        script_load('https://root.cern/js/notebook/scripts/JSRootCore.min.js', script_success, function(){{
+            document.getElementById("{jsDivId}").innerHTML = "Failed to load JSROOT";
         }});
     }});
 }}
 
-function requirejs_load(src, on_load, on_error) {{
+function script_load(src, on_load, on_error) {{
     var script = document.createElement('script');
     script.src = src;
     script.onload = on_load;
@@ -79,23 +87,14 @@ function requirejs_load(src, on_load, on_error) {{
     document.head.appendChild(script);
 }}
 
-function requirejs_success(base_url) {{
-    return function() {{
-        require.config({{
-            baseUrl: base_url + 'static/'
-        }});
-        display_{jsDivId}();
-    }}
+function script_success() {{
+   display_{jsDivId}(JSROOT);
 }}
 
-function display_{jsDivId}() {{
-    require(['scripts/JSRootCore'],
-        function(Core) {{
-            var obj = Core.JSONR_unref({jsonContent});
-            Core.key_handling = false;
-            Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
-        }}
-    );
+function display_{jsDivId}(Core) {{
+   var obj = Core.JSONR_unref({jsonContent});
+   Core.key_handling = false;
+   Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
 }}
 </script>
 """
@@ -295,7 +294,7 @@ def produceCanvasJson(canvas):
    cnt = 0
    for n in range(colors.GetLast()+1):
       if colors.At(n): cnt = cnt+1
-        
+
    # add all colors if there are more than 598 colors defined
    if cnt < 599 or prim.FindObject(colors):
       colors = None
@@ -311,14 +310,14 @@ def produceCanvasJson(canvas):
       prim.Add(palette)
 
    ROOT.TColor.DefinedColors()
-    
+
    canvas_json = ROOT.TBufferJSON.ConvertToJSON(canvas, 3)
 
    # Cleanup primitives after conversion
    if style is not None: prim.Remove(style)
    if colors is not None: prim.Remove(colors)
    if palette is not None: prim.Remove(palette)
-     
+
    return canvas_json
 
 transformers = []


### PR DESCRIPTION
require.js was used in jupyter notebook by default, therefore was used
also for JSROOT. In jupyter lab one can load JSROOT direcrtly. 
If JSROOT fails to load from static location, default
https://root.cern/js/notebook/ version will be used