### PR TITLE
[RF] Circumvent precalculated values for batch evaluations.

### DIFF
--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4875,12 +4875,11 @@ RooSpan<double> RooAbsReal::evaluateBatch(std::size_t begin, std::size_t maxSize
   leafNodeServerList(&allLeafs);
 
   if (RooMsgService::instance().isActive(this, RooFit::Optimization, RooFit::INFO)) {
-    coutI(Optimization) << "The class " << IsA()->GetName() << " does not have the faster batch evaluation interface."
-          << " Consider requesting this feature on ROOT's JIRA tracker." << std::endl;
+    coutI(Optimization) << "The class " << IsA()->GetName() << " could benefit from implementing the faster batch evaluation interface."
+        << " If it is part of ROOT, consider requesting this on https://root.cern." << std::endl;
   }
 
 
-  // TODO Make faster by using batch computation results also on intermediate nodes?
   std::vector<std::tuple<RooRealVar*, RooSpan<const double>, double>> batchLeafs;
   for (auto leaf : allLeafs) {
     auto leafRRV = dynamic_cast<RooRealVar*>(leaf);
@@ -4901,6 +4900,13 @@ RooSpan<double> RooAbsReal::evaluateBatch(std::size_t begin, std::size_t maxSize
 
   auto output = _batchData.makeWritableBatchUnInit(begin, maxSize);
 
+  // Side track all caching that RooFit might think is necessary.
+  // This yields wrong results when used with batch computations,
+  // since data are not loaded globally here, and the caches of
+  // objects are therefore not updated.
+  const bool oldInhibitState = inhibitDirty();
+  setDirtyInhibit(true);
+
   for (std::size_t i = 0; i < output.size(); ++i) {
     for (auto& tup : batchLeafs) {
       RooRealVar* leaf = std::get<0>(tup);
@@ -4911,6 +4917,8 @@ RooSpan<double> RooAbsReal::evaluateBatch(std::size_t begin, std::size_t maxSize
 
     output[i] = evaluate();
   }
+
+  setDirtyInhibit(oldInhibitState);
 
   // Reset values
   for (auto& tup : batchLeafs) {


### PR DESCRIPTION
[ROOT-10987] When a PDF doesn't implement the faster batch interface,
RooFit's old, single-value computations have to be used as a fallback.
If RooFit, however, tries to precalculate those values, the nodes of
the computation graph will always yield the same wrong value, since
they are switched to "always clean".
This happens e.g. when a node of the graph doesn't depend on parameters,
but only on observables.

To fix this, the global static that inihibits "always clean" has to be
set while the computation is running.

(cherry picked from commit 47da6c180b7edd69dcb309fe06197cc50ffc538f)