### PR TITLE
[TCling] Backport 620: Exclude deleted functions from iteration.

### DIFF
--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -406,14 +406,17 @@ int TClingMethodInfo::InternalNext()
          // enable_if'ed functions.
          fTemplateSpec = GetOrInstantiateFuncTemplateWithDefaults(templateDecl, fInterp->getSema(),
                                                                   fInterp->getLookupHelper());
+         if (fTemplateSpec && fTemplateSpec->isDeleted())
+            fTemplateSpec = nullptr;
          if (fTemplateSpec)
             return 1;
       }
 
       // Return if this decl is a function or method.
-      if (llvm::isa<clang::FunctionDecl>(*fIter)) {
-         // Iterator is now valid.
-         return 1;
+      if (auto *FD = llvm::dyn_cast<clang::FunctionDecl>(*fIter)) {
+         if (!FD->isDeleted())
+            // Iterator is now valid.
+            return 1;
       }
 
       // Collect internal `__cling_N5xxx' inline namespaces; they will be traversed later


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/6173