### PR TITLE
[gmi] Do not load all modules for a given identifier.

### DIFF
--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -328,6 +328,8 @@ bool TClingCallbacks::findInGlobalModuleIndex(DeclarationName Name, bool loadFir
             if (gDebug > 2)
                llvm::errs() << "Module '" << ModuleName << "' already loaded"
                             << " for '" << Name.getAsString() << "'\n";
+            if (loadFirstMatchOnly)
+               break;
             continue;
          }
 
@@ -359,7 +361,7 @@ bool TClingCallbacks::LookupObject(const DeclContext* DC, DeclarationName Name) 
    if (fIsAutoParsingSuspended || fIsAutoLoadingRecursively)
       return false;
 
-   if (findInGlobalModuleIndex(Name, /*loadFirstMatchOnly*/ false))
+   if (findInGlobalModuleIndex(Name, /*loadFirstMatchOnly*/ true))
       return true;
 
    if (Name.getNameKind() != DeclarationName::Identifier)


### PR DESCRIPTION
This should reduce the amount of modules we load for namespace lookups at the cost of being more fragile.

Improves the memory of hsimple.c from 145864 to 118696 and skips loading of 15 redundant modules.