### PR TITLE
[IMT] Remove duplicate unit test.

### DIFF
--- a/core/imt/test/CMakeLists.txt
+++ b/core/imt/test/CMakeLists.txt
@@ -4,6 +4,4 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-ROOT_ADD_UNITTEST_DIR(Imt Thread ${TBB_LIBRARIES})
-
 ROOT_ADD_GTEST(testImt testRTaskArena.cxx testTFuture.cxx testTTaskGroup.cxx LIBRARIES Imt ${TBB_LIBRARIES})


### PR DESCRIPTION
The IMT tests were both registered with ROOT_ADD_GTEST and
ROOT_ADD_UNITTEST_DIR. The latter was removed.