### PR TITLE
Fix Jira issue #ROOT-8817 Rounding issue with float(entries-1) in TTreeViewer

### DIFF
--- a/gui/gui/inc/TGDoubleSlider.h
+++ b/gui/gui/inc/TGDoubleSlider.h
@@ -114,11 +114,23 @@ public:
 
    virtual void  SetScale(Int_t scale) { fScale = scale; }
    virtual void  SetRange(Float_t min, Float_t max) {
-      SetRangeD((Double_t) min, (Double_t) max);
+      SetRange((Double_t) min, (Double_t) max);
+   }
+   virtual void  SetRange(Long64_t min, Long64_t max) {
+      SetRange((Double_t) min, (Double_t) max);
+   }
+   virtual void  SetRange(Int_t min, Int_t max) {
+      SetRange((Double_t) min, (Double_t) max);
    }
 
    virtual void SetPosition(Float_t min, Float_t max) {
-      SetPositionD((Double_t) min, (Double_t) max);
+      SetPosition((Double_t) min, (Double_t) max);
+   }
+   virtual void SetPosition(Long64_t min, Long64_t max) {
+      SetPosition((Double_t) min, (Double_t) max);
+   }
+   virtual void SetPosition(Int_t min, Int_t max) {
+      SetPosition((Double_t) min, (Double_t) max);
    }
 
    virtual Float_t GetMinPosition() const {
@@ -127,6 +139,13 @@ public:
    virtual Float_t GetMaxPosition() const {
       return (Float_t) GetMaxPositionD();
    }
+   virtual Long64_t GetMinPositionL() const {
+      return (Long64_t)GetMinPositionD();
+   }
+   virtual Long64_t GetMaxPositionL() const {
+      return (Long64_t)GetMaxPositionD();
+   }
+
    virtual void GetPosition(Float_t &min, Float_t &max) const {
       if (fReversedScale) { min = (Float_t)(fVmin+fVmax-fSmax); max = (Float_t)(fVmin+fVmax-fSmin); }
       else { min = (Float_t)fSmin; max = (Float_t)fSmax; }
@@ -135,15 +154,23 @@ public:
       if (fReversedScale) { *min = (Float_t)(fVmin+fVmax-fSmax); *max = (Float_t)(fVmin+fVmax-fSmin); }
       else { *min = (Float_t)fSmin; *max = (Float_t)fSmax; }
    }
+   virtual void GetPosition(Long64_t &min, Long64_t &max) const {
+      if (fReversedScale) { min = (Long64_t)(fVmin+fVmax-fSmax); max = (Long64_t)(fVmin+fVmax-fSmin); }
+      else { min = (Long64_t)fSmin; max = (Long64_t)fSmax; }
+   }
+   virtual void GetPosition(Long64_t *min, Long64_t *max) const {
+      if (fReversedScale) { *min = (Long64_t)(fVmin+fVmax-fSmax); *max = (Long64_t)(fVmin+fVmax-fSmin); }
+      else { *min = (Long64_t)fSmin; *max = (Long64_t)fSmax; }
+   }
 
    // double precision methods
 
-   virtual void  SetRangeD(Double_t min, Double_t max) {
+   virtual void  SetRange(Double_t min, Double_t max) {
       fVmin = min; fVmax = max;
       FixBounds(fVmin, fVmax);
    }
 
-   virtual void SetPositionD(Double_t min, Double_t max) {
+   virtual void SetPosition(Double_t min, Double_t max) {
       if (fReversedScale) { fSmin = fVmin+fVmax-max; fSmax = fVmin+fVmax-min; }
       else { fSmin = min; fSmax = max; }
       fClient->NeedRedraw(this);
@@ -157,11 +184,11 @@ public:
       if (fReversedScale) return fVmin+fVmax-fSmin;
       else return fSmax;
    }
-   virtual void GetPositionD(Double_t &min, Double_t &max) const {
+   virtual void GetPosition(Double_t &min, Double_t &max) const {
       if (fReversedScale) { min = fVmin+fVmax-fSmax; max = fVmin+fVmax-fSmin; }
       else { min = fSmin; max = fSmax; }
    }
-   virtual void GetPositionD(Double_t *min, Double_t *max) const {
+   virtual void GetPosition(Double_t *min, Double_t *max) const {
       if (fReversedScale) { *min = fVmin+fVmax-fSmax; *max = fVmin+fVmax-fSmin; }
       else { *min = fSmin; *max = fSmax; }
    }

--- a/gui/gui/inc/TGDoubleSlider.h
+++ b/gui/gui/inc/TGDoubleSlider.h
@@ -76,17 +76,17 @@ private:
    TGDoubleSlider& operator=(const TGDoubleSlider&); // Not implemented
 
 protected:
-   Float_t       fPos;           // logical position between fVmin and fVmax
-   Float_t       fSmin;          // logical position of min value of Slider
-   Float_t       fSmax;          // logical position of max value of Slider
+   Double_t      fPos;           // logical position between fVmin and fVmax
+   Double_t      fSmin;          // logical position of min value of Slider
+   Double_t      fSmax;          // logical position of max value of Slider
    Int_t         fRelPos;        // slider position in pixel coordinates
-   Float_t       fVmin;          // logical lower limit of slider
-   Float_t       fVmax;          // logical upper limit of slider
+   Double_t      fVmin;          // logical lower limit of slider
+   Double_t      fVmax;          // logical upper limit of slider
    Int_t         fScale;         // tick mark scale
    Int_t         fScaleType;     // tick mark scale type (no, downright, both)
    Int_t         fPressPoint;    // mouse position at button press event
-   Float_t       fPressSmin;     // logical min position at button press event
-   Float_t       fPressSmax;     // logical max position at button press event
+   Double_t      fPressSmin;     // logical min position at button press event
+   Double_t      fPressSmax;     // logical max position at button press event
    Int_t         fMove;          // 1: move min value
                                  // 2: move max value
                                  // 3: move min and max value
@@ -97,7 +97,7 @@ protected:
 
    TString       GetSString() const; // returns scaling type as string
 
-   static void   FixBounds(Float_t &min, Float_t &max);
+   static void   FixBounds(Double_t &min, Double_t &max);
    void          ChangeCursor(Event_t *event);
 
 public:
@@ -114,29 +114,54 @@ public:
 
    virtual void  SetScale(Int_t scale) { fScale = scale; }
    virtual void  SetRange(Float_t min, Float_t max) {
+      SetRangeD((Double_t) min, (Double_t) max);
+   }
+
+   virtual void SetPosition(Float_t min, Float_t max) {
+      SetPositionD((Double_t) min, (Double_t) max);
+   }
+
+   virtual Float_t GetMinPosition() const {
+      return (Float_t) GetMinPositionD();
+   }
+   virtual Float_t GetMaxPosition() const {
+      return (Float_t) GetMaxPositionD();
+   }
+   virtual void GetPosition(Float_t &min, Float_t &max) const {
+      if (fReversedScale) { min = (Float_t)(fVmin+fVmax-fSmax); max = (Float_t)(fVmin+fVmax-fSmin); }
+      else { min = (Float_t)fSmin; max = (Float_t)fSmax; }
+   }
+   virtual void GetPosition(Float_t *min, Float_t *max) const {
+      if (fReversedScale) { *min = (Float_t)(fVmin+fVmax-fSmax); *max = (Float_t)(fVmin+fVmax-fSmin); }
+      else { *min = (Float_t)fSmin; *max = (Float_t)fSmax; }
+   }
+
+   // double precision methods
+
+   virtual void  SetRangeD(Double_t min, Double_t max) {
       fVmin = min; fVmax = max;
       FixBounds(fVmin, fVmax);
    }
 
-   virtual void SetPosition(Float_t min, Float_t max) {
+   virtual void SetPositionD(Double_t min, Double_t max) {
       if (fReversedScale) { fSmin = fVmin+fVmax-max; fSmax = fVmin+fVmax-min; }
       else { fSmin = min; fSmax = max; }
       fClient->NeedRedraw(this);
    }
 
-   virtual Float_t GetMinPosition() const {
+   virtual Double_t GetMinPositionD() const {
       if (fReversedScale) return fVmin+fVmax-fSmax;
       else return fSmin;
    }
-   virtual Float_t GetMaxPosition() const {
+   virtual Double_t GetMaxPositionD() const {
       if (fReversedScale) return fVmin+fVmax-fSmin;
       else return fSmax;
    }
-   virtual void GetPosition(Float_t &min, Float_t &max) const {
+   virtual void GetPositionD(Double_t &min, Double_t &max) const {
       if (fReversedScale) { min = fVmin+fVmax-fSmax; max = fVmin+fVmax-fSmin; }
       else { min = fSmin; max = fSmax; }
    }
-   virtual void GetPosition(Float_t *min, Float_t *max) const {
+   virtual void GetPositionD(Double_t *min, Double_t *max) const {
       if (fReversedScale) { *min = fVmin+fVmax-fSmax; *max = fVmin+fVmax-fSmin; }
       else { *min = fSmin; *max = fSmax; }
    }

--- a/gui/gui/inc/TGTripleSlider.h
+++ b/gui/gui/inc/TGTripleSlider.h
@@ -85,6 +85,9 @@ public:
    virtual Float_t   GetPointerPosition() const {
       return (Float_t) GetPointerPositionD();
    }
+   virtual Long64_t  GetPointerPositionL() const {
+      return (Long64_t) GetPointerPositionD();
+   }
    virtual Double_t  GetPointerPositionD() const {
       if (fReversedScale) return fVmin + fVmax - fSCz;
       else return fSCz;
@@ -93,8 +96,13 @@ public:
    virtual Bool_t    HandleConfigureNotify(Event_t* event);
    virtual Bool_t    HandleMotion(Event_t *event);
    virtual void      SetConstrained(Bool_t on = kTRUE);
-   virtual void      SetPointerPosition(Float_t pos);
-   virtual void      SetPointerPositionD(Double_t pos);
+   virtual void      SetPointerPosition(Double_t pos);
+   virtual void      SetPointerPosition(Float_t pos) {
+      SetPointerPosition((Double_t) pos);
+   }
+   virtual void      SetPointerPosition(Long64_t pos) {
+      SetPointerPosition((Double_t) pos);
+   }
    virtual void      SetRelative(Bool_t rel = kTRUE) { fRelative = rel; }
    virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
 
@@ -134,12 +142,20 @@ public:
       if (fReversedScale) return fVmin + fVmax - fSCz;
       else return fSCz;
    }
+   virtual Long64_t  GetPointerPositionL() const {
+      return (Long64_t) GetPointerPositionD();
+   }
    virtual Bool_t    HandleButton(Event_t *event);
    virtual Bool_t    HandleConfigureNotify(Event_t* event);
    virtual Bool_t    HandleMotion(Event_t *event);
    virtual void      SetConstrained(Bool_t on = kTRUE);
-   virtual void      SetPointerPosition(Float_t pos);
-   virtual void      SetPointerPositionD(Double_t pos);
+   virtual void      SetPointerPosition(Double_t pos);
+   virtual void      SetPointerPosition(Float_t pos) {
+      SetPointerPosition((Double_t) pos);
+   }
+   virtual void      SetPointerPosition(Long64_t pos) {
+      SetPointerPosition((Double_t) pos);
+   }
    virtual void      SetRelative(Bool_t rel = kTRUE) { fRelative = rel; }
    virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
 

--- a/gui/gui/inc/TGTripleSlider.h
+++ b/gui/gui/inc/TGTripleSlider.h
@@ -61,7 +61,7 @@ class TGTripleVSlider : public TGDoubleVSlider {
 
 protected:
    Int_t            fCz;           // vertical pointer position in pixel coordinates
-   Float_t          fSCz;          // vertical pointer position
+   Double_t         fSCz;          // vertical pointer position
    Bool_t           fConstrained;  // kTRUE if pointer is constrained to slider edges
    Bool_t           fRelative;     // kTRUE if pointer position is relative to slider
    const TGPicture *fPointerPic;   // picture to draw pointer
@@ -83,6 +83,9 @@ public:
    virtual void      PointerPositionChanged() { Emit("PointerPositionChanged()"); } //*SIGNAL*
    virtual void      DrawPointer();
    virtual Float_t   GetPointerPosition() const {
+      return (Float_t) GetPointerPositionD();
+   }
+   virtual Double_t  GetPointerPositionD() const {
       if (fReversedScale) return fVmin + fVmax - fSCz;
       else return fSCz;
    }
@@ -91,6 +94,7 @@ public:
    virtual Bool_t    HandleMotion(Event_t *event);
    virtual void      SetConstrained(Bool_t on = kTRUE);
    virtual void      SetPointerPosition(Float_t pos);
+   virtual void      SetPointerPositionD(Double_t pos);
    virtual void      SetRelative(Bool_t rel = kTRUE) { fRelative = rel; }
    virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
 
@@ -102,7 +106,7 @@ class TGTripleHSlider : public TGDoubleHSlider {
 
 protected:
    Int_t            fCz;           // horizontal pointer position in pixel coordinates
-   Float_t          fSCz;          // vertical pointer position
+   Double_t         fSCz;          // vertical pointer position
    Bool_t           fConstrained;  // kTRUE if pointer is constrained to slider edges
    Bool_t           fRelative;     // kTRUE if pointer position is relative to slider
    const TGPicture *fPointerPic;   // picture to draw pointer
@@ -124,6 +128,9 @@ public:
    virtual void      PointerPositionChanged() { Emit("PointerPositionChanged()"); } //*SIGNAL*
    virtual void      DrawPointer();
    virtual Float_t   GetPointerPosition() const {
+      return (Float_t) GetPointerPositionD();
+   }
+   virtual Double_t  GetPointerPositionD() const {
       if (fReversedScale) return fVmin + fVmax - fSCz;
       else return fSCz;
    }
@@ -132,6 +139,7 @@ public:
    virtual Bool_t    HandleMotion(Event_t *event);
    virtual void      SetConstrained(Bool_t on = kTRUE);
    virtual void      SetPointerPosition(Float_t pos);
+   virtual void      SetPointerPositionD(Double_t pos);
    virtual void      SetRelative(Bool_t rel = kTRUE) { fRelative = rel; }
    virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
 

--- a/gui/gui/src/TGDoubleSlider.cxx
+++ b/gui/gui/src/TGDoubleSlider.cxx
@@ -105,11 +105,11 @@ TGDoubleSlider::TGDoubleSlider(const TGWindow *p, UInt_t w, UInt_t h, UInt_t typ
 ////////////////////////////////////////////////////////////////////////////////
 /// Avoid boundaries to be equal.
 
-void TGDoubleSlider::FixBounds(Float_t &min, Float_t &max)
+void TGDoubleSlider::FixBounds(Double_t &min, Double_t &max)
 {
    if (min > max) min = max;
 
-   Float_t eps = 1e-6;
+   Double_t eps = 1e-6;
    if (max - min < eps) {
       if (max == 0)
          max += eps;
@@ -370,7 +370,7 @@ Bool_t TGDoubleVSlider::HandleMotion(Event_t *event)
    was = now;
 
    int       diff;
-   Float_t   oldMin, oldMax;
+   Double_t  oldMin, oldMax;
 
    diff    = event->fY - fPressPoint;
    oldMin  = fSmin;
@@ -388,7 +388,7 @@ Bool_t TGDoubleVSlider::HandleMotion(Event_t *event)
       if (fSmax < fSmin) fSmax = fSmin;
    } else if (fMove == 3) {
       // change of min and of max value
-      Float_t logicalDiff;
+      Double_t logicalDiff;
       logicalDiff = diff * (fVmax - fVmin) / (fHeight-16);
       if (fPressSmax + logicalDiff > fVmax)
          logicalDiff = fVmax - fPressSmax;
@@ -561,7 +561,7 @@ Bool_t TGDoubleHSlider::HandleMotion(Event_t *event)
    was = now;
 
    int     diff;
-   Float_t oldMin, oldMax;
+   Double_t oldMin, oldMax;
 
    diff    = event->fX - fPressPoint;
    oldMin  = fSmin;
@@ -579,7 +579,7 @@ Bool_t TGDoubleHSlider::HandleMotion(Event_t *event)
       if (fSmax < fSmin) fSmax = fSmin;
    } else if (fMove == 3) {
       // change of min and of max value
-      Float_t logicalDiff;
+      Double_t logicalDiff;
       logicalDiff = diff * (fVmax - fVmin) / (fWidth-16);
       if (fPressSmax + logicalDiff > fVmax)
          logicalDiff = fVmax - fPressSmax;

--- a/gui/gui/src/TGTripleSlider.cxx
+++ b/gui/gui/src/TGTripleSlider.cxx
@@ -333,15 +333,7 @@ void TGTripleVSlider::SetPointerPos(Int_t z, Int_t opt)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set pointer position in scaled (real) value
 
-void TGTripleVSlider::SetPointerPosition(Float_t pos)
-{
-   SetPointerPositionD((Double_t) pos);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set pointer position in scaled (real) value - double precision
-
-void TGTripleVSlider::SetPointerPositionD(Double_t pos)
+void TGTripleVSlider::SetPointerPosition(Double_t pos)
 {
    if (fReversedScale) {
       fSCz = fVmin + fVmax - pos;
@@ -614,15 +606,7 @@ void TGTripleHSlider::SetPointerPos(Int_t z, Int_t opt)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set pointer position in scaled (real) value
 
-void TGTripleHSlider::SetPointerPosition(Float_t pos)
-{
-   SetPointerPositionD((Double_t) pos);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set pointer position in scaled (real) value - double precision
-
-void TGTripleHSlider::SetPointerPositionD(Double_t pos)
+void TGTripleHSlider::SetPointerPosition(Double_t pos)
 {
    if (fReversedScale) {
       fSCz = fVmin + fVmax - pos;

--- a/gui/gui/src/TGTripleSlider.cxx
+++ b/gui/gui/src/TGTripleSlider.cxx
@@ -204,7 +204,7 @@ Bool_t TGTripleVSlider::HandleMotion(Event_t *event)
    was = now;
 
    int     diff;
-   Float_t oldMin, oldMax;
+   Double_t oldMin, oldMax;
 
    diff    = event->fY - fPressPoint;
    oldMin  = fSmin;
@@ -224,7 +224,7 @@ Bool_t TGTripleVSlider::HandleMotion(Event_t *event)
       if (fSmax < fSmin) fSmax = fSmin;
    } else if (fMove == 3) {
       // change of min and of max value
-      Float_t logicalDiff;
+      Double_t logicalDiff;
       logicalDiff = diff * (fVmax - fVmin) / (fHeight-16);
       if (fPressSmax + logicalDiff > fVmax)
          logicalDiff = fVmax - fPressSmax;
@@ -309,7 +309,7 @@ void TGTripleVSlider::SetPointerPos(Int_t z, Int_t opt)
       }
    }
    if (lcheck)
-      fSCz = fVmin + ((Float_t)(fCz-8) * (fVmax - fVmin) / (Float_t)(fHeight-16));
+      fSCz = fVmin + ((Double_t)(fCz-8) * (fVmax - fVmin) / (Double_t)(fHeight-16));
    if(fSCz < fVmin) fSCz = fVmin;
    if(fSCz > fVmax) fSCz = fVmax;
    if (fConstrained) {
@@ -335,13 +335,21 @@ void TGTripleVSlider::SetPointerPos(Int_t z, Int_t opt)
 
 void TGTripleVSlider::SetPointerPosition(Float_t pos)
 {
+   SetPointerPositionD((Double_t) pos);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set pointer position in scaled (real) value - double precision
+
+void TGTripleVSlider::SetPointerPositionD(Double_t pos)
+{
    if (fReversedScale) {
       fSCz = fVmin + fVmax - pos;
    }
    else {
       fSCz = pos;
    }
-   Float_t absPos = (fSCz - fVmin) * (fHeight-16) / (fVmax - fVmin);
+   Double_t absPos = (fSCz - fVmin) * (fHeight-16) / (fVmax - fVmin);
    SetPointerPos((int)(absPos+5.0), 0);
 }
 
@@ -477,7 +485,7 @@ Bool_t TGTripleHSlider::HandleMotion(Event_t *event)
    was = now;
 
    int     diff;
-   Float_t oldMin, oldMax;
+   Double_t oldMin, oldMax;
 
    diff    = event->fX - fPressPoint;
    oldMin  = fSmin;
@@ -497,7 +505,7 @@ Bool_t TGTripleHSlider::HandleMotion(Event_t *event)
       if (fSmax < fSmin) fSmax = fSmin;
    } else if (fMove == 3) {
       // change of min and of max value
-      Float_t logicalDiff;
+      Double_t logicalDiff;
       logicalDiff = diff * (fVmax - fVmin) / (fWidth-16);
       if (fPressSmax + logicalDiff > fVmax)
          logicalDiff = fVmax - fPressSmax;
@@ -582,7 +590,7 @@ void TGTripleHSlider::SetPointerPos(Int_t z, Int_t opt)
       }
    }
    if (lcheck)
-      fSCz = fVmin + ((Float_t)(fCz-8) * (fVmax - fVmin) / (Float_t)(fWidth-16));
+      fSCz = fVmin + ((Double_t)(fCz-8) * (fVmax - fVmin) / (Double_t)(fWidth-16));
    if(fSCz < fVmin) fSCz = fVmin;
    if(fSCz > fVmax) fSCz = fVmax;
    if (fConstrained) {
@@ -608,13 +616,21 @@ void TGTripleHSlider::SetPointerPos(Int_t z, Int_t opt)
 
 void TGTripleHSlider::SetPointerPosition(Float_t pos)
 {
+   SetPointerPositionD((Double_t) pos);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set pointer position in scaled (real) value - double precision
+
+void TGTripleHSlider::SetPointerPositionD(Double_t pos)
+{
    if (fReversedScale) {
       fSCz = fVmin + fVmax - pos;
    }
    else {
       fSCz = pos;
    }
-   Float_t absPos = (fSCz - fVmin) * (fWidth-16) / (fVmax - fVmin);
+   Double_t absPos = (fSCz - fVmin) * (fWidth-16) / (fVmax - fVmin);
    SetPointerPos((int)(absPos+5.0), 0);
 }
 

--- a/tree/treeviewer/src/TParallelCoordEditor.cxx
+++ b/tree/treeviewer/src/TParallelCoordEditor.cxx
@@ -652,7 +652,7 @@ void TParallelCoordEditor::DoFirstEntry()
    if (fAvoidSignal) return;
 
    fParallel->SetCurrentFirst((Long64_t)fFirstEntry->GetNumber());
-   fEntriesToDraw->SetPositionD((Long64_t)fFirstEntry->GetNumber(),(Long64_t)fFirstEntry->GetNumber()+fParallel->GetCurrentN());
+   fEntriesToDraw->SetPosition((Long64_t)fFirstEntry->GetNumber(),(Long64_t)fFirstEntry->GetNumber()+fParallel->GetCurrentN());
    Update();
 }
 
@@ -841,7 +841,7 @@ void TParallelCoordEditor::DoNentries()
    if (fAvoidSignal) return;
 
    fParallel->SetCurrentN((Long64_t)fNentries->GetNumber());
-   fEntriesToDraw->SetPositionD(fParallel->GetCurrentFirst(),fParallel->GetCurrentFirst()+fParallel->GetCurrentN());
+   fEntriesToDraw->SetPosition(fParallel->GetCurrentFirst(),fParallel->GetCurrentFirst()+fParallel->GetCurrentN());
    Update();
 }
 
@@ -986,7 +986,7 @@ void TParallelCoordEditor::SetModel(TObject* obj)
    CleanUpVariables();
 
    if (fInit) fEntriesToDraw->SetRange(0LL,fParallel->GetNentries());
-   fEntriesToDraw->SetPositionD(fParallel->GetCurrentFirst(), fParallel->GetCurrentFirst()+fParallel->GetCurrentN());
+   fEntriesToDraw->SetPosition(fParallel->GetCurrentFirst(), fParallel->GetCurrentFirst()+fParallel->GetCurrentN());
 
    fFirstEntry->SetNumber(fParallel->GetCurrentFirst());
    fNentries->SetNumber(fParallel->GetCurrentN());

--- a/tree/treeviewer/src/TParallelCoordEditor.cxx
+++ b/tree/treeviewer/src/TParallelCoordEditor.cxx
@@ -636,7 +636,7 @@ void TParallelCoordEditor::DoEntriesToDraw()
    if (fAvoidSignal) return;
 
    Long64_t nentries,firstentry;
-   firstentry = (Long64_t)fEntriesToDraw->GetMinPositionD();
+   firstentry = fEntriesToDraw->GetMinPositionL();
    nentries = (Long64_t)(fEntriesToDraw->GetMaxPositionD() - fEntriesToDraw->GetMinPositionD() + 1);
 
    fParallel->SetCurrentFirst(firstentry);
@@ -806,7 +806,7 @@ void TParallelCoordEditor::DoLiveEntriesToDraw()
    if (fAvoidSignal) return;
 
    Long64_t nentries,firstentry;
-   firstentry = (Long64_t)fEntriesToDraw->GetMinPositionD();
+   firstentry = fEntriesToDraw->GetMinPositionL();
    nentries = (Long64_t)(fEntriesToDraw->GetMaxPositionD() - fEntriesToDraw->GetMinPositionD() + 1);
 
    fFirstEntry->SetNumber(firstentry);
@@ -985,7 +985,7 @@ void TParallelCoordEditor::SetModel(TObject* obj)
    CleanUpSelections();
    CleanUpVariables();
 
-   if (fInit) fEntriesToDraw->SetRangeD(0,fParallel->GetNentries());
+   if (fInit) fEntriesToDraw->SetRange(0LL,fParallel->GetNentries());
    fEntriesToDraw->SetPositionD(fParallel->GetCurrentFirst(), fParallel->GetCurrentFirst()+fParallel->GetCurrentN());
 
    fFirstEntry->SetNumber(fParallel->GetCurrentFirst());

--- a/tree/treeviewer/src/TParallelCoordEditor.cxx
+++ b/tree/treeviewer/src/TParallelCoordEditor.cxx
@@ -636,8 +636,8 @@ void TParallelCoordEditor::DoEntriesToDraw()
    if (fAvoidSignal) return;
 
    Long64_t nentries,firstentry;
-   firstentry = (Long64_t)fEntriesToDraw->GetMinPosition();
-   nentries = (Long64_t)(fEntriesToDraw->GetMaxPosition() - fEntriesToDraw->GetMinPosition() + 1);
+   firstentry = (Long64_t)fEntriesToDraw->GetMinPositionD();
+   nentries = (Long64_t)(fEntriesToDraw->GetMaxPositionD() - fEntriesToDraw->GetMinPositionD() + 1);
 
    fParallel->SetCurrentFirst(firstentry);
    fParallel->SetCurrentN(nentries);
@@ -652,7 +652,7 @@ void TParallelCoordEditor::DoFirstEntry()
    if (fAvoidSignal) return;
 
    fParallel->SetCurrentFirst((Long64_t)fFirstEntry->GetNumber());
-   fEntriesToDraw->SetPosition((Long64_t)fFirstEntry->GetNumber(),(Long64_t)fFirstEntry->GetNumber()+fParallel->GetCurrentN());
+   fEntriesToDraw->SetPositionD((Long64_t)fFirstEntry->GetNumber(),(Long64_t)fFirstEntry->GetNumber()+fParallel->GetCurrentN());
    Update();
 }
 
@@ -806,8 +806,8 @@ void TParallelCoordEditor::DoLiveEntriesToDraw()
    if (fAvoidSignal) return;
 
    Long64_t nentries,firstentry;
-   firstentry = (Long64_t)fEntriesToDraw->GetMinPosition();
-   nentries = (Long64_t)(fEntriesToDraw->GetMaxPosition() - fEntriesToDraw->GetMinPosition() + 1);
+   firstentry = (Long64_t)fEntriesToDraw->GetMinPositionD();
+   nentries = (Long64_t)(fEntriesToDraw->GetMaxPositionD() - fEntriesToDraw->GetMinPositionD() + 1);
 
    fFirstEntry->SetNumber(firstentry);
    fNentries->SetNumber(nentries);
@@ -841,7 +841,7 @@ void TParallelCoordEditor::DoNentries()
    if (fAvoidSignal) return;
 
    fParallel->SetCurrentN((Long64_t)fNentries->GetNumber());
-   fEntriesToDraw->SetPosition(fParallel->GetCurrentFirst(),fParallel->GetCurrentFirst()+fParallel->GetCurrentN());
+   fEntriesToDraw->SetPositionD(fParallel->GetCurrentFirst(),fParallel->GetCurrentFirst()+fParallel->GetCurrentN());
    Update();
 }
 
@@ -985,8 +985,8 @@ void TParallelCoordEditor::SetModel(TObject* obj)
    CleanUpSelections();
    CleanUpVariables();
 
-   if (fInit) fEntriesToDraw->SetRange(0,fParallel->GetNentries());
-   fEntriesToDraw->SetPosition(fParallel->GetCurrentFirst(), fParallel->GetCurrentFirst()+fParallel->GetCurrentN());
+   if (fInit) fEntriesToDraw->SetRangeD(0,fParallel->GetNentries());
+   fEntriesToDraw->SetPositionD(fParallel->GetCurrentFirst(), fParallel->GetCurrentFirst()+fParallel->GetCurrentN());
 
    fFirstEntry->SetNumber(fParallel->GetCurrentFirst());
    fNentries->SetNumber(fParallel->GetCurrentN());

--- a/tree/treeviewer/src/TTreeViewer.cxx
+++ b/tree/treeviewer/src/TTreeViewer.cxx
@@ -1142,11 +1142,11 @@ void TTreeViewer::BuildInterface()
    // map the tree if it was supplied in the constructor
 
    if (!fTree) {
-      fSlider->SetRangeD(0,1000000);
-      fSlider->SetPositionD(0,1000000);
+      fSlider->SetRange(0LL,1000000LL);
+      fSlider->SetPosition(0LL,1000000LL);
    } else {
-      fSlider->SetRangeD(0,fTree->GetEntries()-1);
-      fSlider->SetPositionD(0,fTree->GetEntries()-1);
+      fSlider->SetRange(0LL,fTree->GetEntries()-1);
+      fSlider->SetPosition(0LL,fTree->GetEntries()-1);
    }
    PrintEntries();
    fProgressBar->SetPosition(0);
@@ -1452,7 +1452,7 @@ void TTreeViewer::ExecuteDraw()
    // get entries to be processed
    Long64_t nentries = (Long64_t)(fSlider->GetMaxPositionD() -
                             fSlider->GetMinPositionD() + 1);
-   Long64_t firstentry =(Long64_t) fSlider->GetMinPositionD();
+   Long64_t firstentry = fSlider->GetMinPositionL();
 //printf("firstentry=%lld, nentries=%lld\n",firstentry,nentries);
    // check if Scan is checked and if there is something in the box
    if (fScanMode) {
@@ -1619,7 +1619,7 @@ void TTreeViewer::ExecuteSpider()
    // get entries to be processed
    Long64_t nentries = (Long64_t)(fSlider->GetMaxPositionD() -
                             fSlider->GetMinPositionD() + 1);
-   Long64_t firstentry = (Long64_t) fSlider->GetMinPositionD();
+   Long64_t firstentry = fSlider->GetMinPositionL();
 
    // create the spider plot
 
@@ -1777,7 +1777,7 @@ Bool_t TTreeViewer::HandleTimer(TTimer *timer)
    if (fCounting) {
       Double_t first = fSlider->GetMinPositionD();
       Double_t last  = fSlider->GetMaxPositionD();
-      Double_t current = (Float_t)fTree->GetReadEntry();
+      Double_t current = (Double_t)fTree->GetReadEntry();
       Double_t percent = (current-first+1)/(last-first+1);
       fProgressBar->SetPosition(100.*percent);
       fProgressBar->ShowPosition();
@@ -2702,7 +2702,7 @@ void TTreeViewer::PrintEntries()
    if (!fTree) return;
    char * msg = new char[100];
    snprintf(msg,100, "First entry : %lld Last entry : %lld",
-           (Long64_t)fSlider->GetMinPositionD(), (Long64_t)fSlider->GetMaxPositionD());
+           fSlider->GetMinPositionL(), fSlider->GetMaxPositionL());
    Message(msg);
    delete[] msg;
 }
@@ -2836,8 +2836,8 @@ Bool_t TTreeViewer::SwitchTree(Int_t index)
    }
 
    fTree = tree;
-   fSlider->SetRangeD(0,fTree->GetEntries()-1);
-   fSlider->SetPositionD(0,fTree->GetEntries()-1);
+   fSlider->SetRange(0LL,fTree->GetEntries()-1);
+   fSlider->SetPosition(0LL,fTree->GetEntries()-1);
    command = "Current Tree : ";
    command += fTree->GetName();
    fLbl2->SetText(new TGString(command.c_str()));

--- a/tree/treeviewer/src/TTreeViewer.cxx
+++ b/tree/treeviewer/src/TTreeViewer.cxx
@@ -2917,7 +2917,7 @@ void TTreeViewer::DoRefresh()
    fTree->Refresh();
    Double_t min = fSlider->GetMinPositionD();
    Double_t max = (Double_t)fTree->GetEntries()-1;
-   fSlider->SetRangeD(min,max);
-   fSlider->SetPositionD(min,max);
+   fSlider->SetRange(min,max);
+   fSlider->SetPosition(min,max);
    ExecuteDraw();
 }

--- a/tree/treeviewer/src/TTreeViewer.cxx
+++ b/tree/treeviewer/src/TTreeViewer.cxx
@@ -1142,11 +1142,11 @@ void TTreeViewer::BuildInterface()
    // map the tree if it was supplied in the constructor
 
    if (!fTree) {
-      fSlider->SetRange(0,1000000);
-      fSlider->SetPosition(0,1000000);
+      fSlider->SetRangeD(0,1000000);
+      fSlider->SetPositionD(0,1000000);
    } else {
-      fSlider->SetRange(0,fTree->GetEntries()-1);
-      fSlider->SetPosition(0,fTree->GetEntries()-1);
+      fSlider->SetRangeD(0,fTree->GetEntries()-1);
+      fSlider->SetPositionD(0,fTree->GetEntries()-1);
    }
    PrintEntries();
    fProgressBar->SetPosition(0);
@@ -1450,9 +1450,9 @@ void TTreeViewer::ExecuteDraw()
    if (fEnableCut) cut = Cut();
 
    // get entries to be processed
-   Long64_t nentries = (Long64_t)(fSlider->GetMaxPosition() -
-                            fSlider->GetMinPosition() + 1);
-   Long64_t firstentry =(Long64_t) fSlider->GetMinPosition();
+   Long64_t nentries = (Long64_t)(fSlider->GetMaxPositionD() -
+                            fSlider->GetMinPositionD() + 1);
+   Long64_t firstentry =(Long64_t) fSlider->GetMinPositionD();
 //printf("firstentry=%lld, nentries=%lld\n",firstentry,nentries);
    // check if Scan is checked and if there is something in the box
    if (fScanMode) {
@@ -1617,9 +1617,9 @@ void TTreeViewer::ExecuteSpider()
    if (fEnableCut) cut = Cut();
 
    // get entries to be processed
-   Long64_t nentries = (Long64_t)(fSlider->GetMaxPosition() -
-                            fSlider->GetMinPosition() + 1);
-   Long64_t firstentry =(Long64_t) fSlider->GetMinPosition();
+   Long64_t nentries = (Long64_t)(fSlider->GetMaxPositionD() -
+                            fSlider->GetMinPositionD() + 1);
+   Long64_t firstentry = (Long64_t) fSlider->GetMinPositionD();
 
    // create the spider plot
 
@@ -1775,10 +1775,10 @@ void TTreeViewer::RemoveLastRecord()
 Bool_t TTreeViewer::HandleTimer(TTimer *timer)
 {
    if (fCounting) {
-      Float_t first = fSlider->GetMinPosition();
-      Float_t last  = fSlider->GetMaxPosition();
-      Float_t current = (Float_t)fTree->GetReadEntry();
-      Float_t percent = (current-first+1)/(last-first+1);
+      Double_t first = fSlider->GetMinPositionD();
+      Double_t last  = fSlider->GetMaxPositionD();
+      Double_t current = (Float_t)fTree->GetReadEntry();
+      Double_t percent = (current-first+1)/(last-first+1);
       fProgressBar->SetPosition(100.*percent);
       fProgressBar->ShowPosition();
    }
@@ -2702,7 +2702,7 @@ void TTreeViewer::PrintEntries()
    if (!fTree) return;
    char * msg = new char[100];
    snprintf(msg,100, "First entry : %lld Last entry : %lld",
-           (Long64_t)fSlider->GetMinPosition(), (Long64_t)fSlider->GetMaxPosition());
+           (Long64_t)fSlider->GetMinPositionD(), (Long64_t)fSlider->GetMaxPositionD());
    Message(msg);
    delete[] msg;
 }
@@ -2836,8 +2836,8 @@ Bool_t TTreeViewer::SwitchTree(Int_t index)
    }
 
    fTree = tree;
-   fSlider->SetRange(0,fTree->GetEntries()-1);
-   fSlider->SetPosition(0,fTree->GetEntries()-1);
+   fSlider->SetRangeD(0,fTree->GetEntries()-1);
+   fSlider->SetPositionD(0,fTree->GetEntries()-1);
    command = "Current Tree : ";
    command += fTree->GetName();
    fLbl2->SetText(new TGString(command.c_str()));
@@ -2915,9 +2915,9 @@ void TTreeViewer::UpdateRecord(const char *name)
 void TTreeViewer::DoRefresh()
 {
    fTree->Refresh();
-   Float_t min = fSlider->GetMinPosition();
-   Float_t max = (Float_t)fTree->GetEntries()-1;
-   fSlider->SetRange(min,max);
-   fSlider->SetPosition(min,max);
+   Double_t min = fSlider->GetMinPositionD();
+   Double_t max = (Double_t)fTree->GetEntries()-1;
+   fSlider->SetRangeD(min,max);
+   fSlider->SetPositionD(min,max);
    ExecuteDraw();
 }


### PR DESCRIPTION
`TGDoubleSlider`, `TGTripleSlider`: Replace `Float_t` by `Double_t` internally, and provide methods accordingly, keeping the backward compatible ones
`TTreeViewer`: Replace the `Float_t` methods by the `Double_t` ones, allowing to increase precision and range of the "entries" left-hand side double slider