### PR TITLE
Control the Minimizer when profiling nuisance parameters in the FrequentistCalculator

### DIFF
--- a/roofit/roofitcore/inc/RooProfileLL.h
+++ b/roofit/roofitcore/inc/RooProfileLL.h
@@ -35,7 +35,7 @@ public:
   void setAlwaysStartFromMin(Bool_t flag) { _startFromMin = flag ; }
   Bool_t alwaysStartFromMin() const { return _startFromMin ; }
 
-  MINIMIZER* minimizer() { return _minimizer ; }
+  MINIMIZER* minimizer() { if (!_minimizer) initializeMinimizer(); return _minimizer ; }
   RooAbsReal& nll() { return const_cast<RooAbsReal&>(_nll.arg()) ; }
   const RooArgSet& bestFitParams() const ;
   const RooArgSet& bestFitObs() const ;

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -100,6 +100,9 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
                                                         RooFit::ConditionalObservables(conditionalObs),
                                                         RooFit::Offset(config.useLikelihoodOffset));
       RooProfileLL* profile = dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance));
+      // set minimier options
+      profile->minimizer()->setMinimizerType(ROOT::Math::MinimizerOptions::DefaultMinimizerType().c_str());
+      profile->minimizer()->setPrintLevel(ROOT::Math::MinimizerOptions::DefaultPrintLevel()-1); 
       profile->getVal(); // this will do fit and set nuisance parameters to profiled values
 
       // Hack to extract a RooFitResult
@@ -210,6 +213,9 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
                                                        RooFit::Offset(config.useLikelihoodOffset));
 
       RooProfileLL* profile = dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance));
+      // set minimizer options
+      profile->minimizer()->setMinimizerType(ROOT::Math::MinimizerOptions::DefaultMinimizerType().c_str());
+      profile->minimizer()->setPrintLevel(ROOT::Math::MinimizerOptions::DefaultPrintLevel()-1); // use -1 to make more silent 
       profile->getVal(); // this will do fit and set nuisance parameters to profiled values
 
       // Hack to extract a RooFitResult

--- a/test/stressRooStats_tests.h
+++ b/test/stressRooStats_tests.h
@@ -1475,6 +1475,10 @@ public:
       return kTRUE;
    }
 
+   // larger value test tolerance especially when using toys (difference of <~ 0.1 observed between using Minuit or Minuit2)
+   //  (inherited default value is 1e-3)
+   Double_t vtol() { return (fCalculatorType == kAsymptotic) ? 0.01 : 0.1; } 
+
    Bool_t testCode() {
 
       // Create workspace and model
@@ -1629,8 +1633,9 @@ public:
       fConfidenceLevel(confidenceLevel)
    {};
 
-   Double_t vtol() { return 2e-2 ; } // set value test tolerance to 2e-2 (inherited default is 1e-3)
-
+   // larger value test tolerance especially when using toys (difference of <~ 0.1 observed between using Minuit or Minuit2)
+   //  (inherited default value is 1e-3)
+   Double_t vtol() { return (fCalculatorType == kAsymptotic) ? 0.02 : 0.1; } 
    // Basic checks for the parameters passed to the test
    // In case of invalid parameters, a warning is printed and the test is skipped
    Bool_t isTestAvailable() {


### PR DESCRIPTION
Fix using correct minimizer when computing the profiled nuisance parameters in the FrequentistCalculator

The Frequentist calculator needs to compute , before generating the toys, the profiled values of the nuisances for the nukll and alt case. RooProfileLL is used but the default (Minuit) minimizer was used.
Change now to use the static default value, which can be changed and also give possibility to control printlevel.
With this change we can now consistently use stressRooStats with Minuit2 minimizer

- Increase also tolerance of stressRooStats tests when using toys. This is needed in case a different minimizer is used