### PR TITLE
[cmake] Complain if ninja too new an CMake too old:

### DIFF
--- a/cmake/modules/SetUpMacOS.cmake
+++ b/cmake/modules/SetUpMacOS.cmake
@@ -7,6 +7,26 @@
 set(ROOT_ARCHITECTURE macosx)
 set(ROOT_PLATFORM macosx)
 
+# https://gitlab.kitware.com/cmake/cmake/issues/19222
+if(CMAKE_VERSION VERSION_LESS 3.14.4)
+  if(CMAKE_GENERATOR STREQUAL "Ninja")
+    find_program(NINJAPROG ninja DOC "looking for Ninja to be used")
+    if (NINJAPROG)
+      execute_process(COMMAND ${NINJAPROG} --version
+        OUTPUT_VARIABLE NINJAVERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE NINJAVERSIONRES)
+      if(${NINJAVERSIONRES} EQ 0)
+        if(${NINJAVERSION} VERSION_GREATER 1.8.2)
+          message(FATAL_ERROR "You have hit https://gitlab.kitware.com/cmake/cmake/issues/19222\n"
+            "Your build will be indeterministic, i.e. unreliable for incremental builds."
+            "To fix this, please install CMake >= 3.14.4!")
+        endif()
+      endif()
+    endif()
+  endif()
+endif()
+
 if (CMAKE_SYSTEM_NAME MATCHES Darwin)
   EXECUTE_PROCESS(COMMAND sw_vers "-productVersion"
                   COMMAND cut -d . -f 1-2


### PR DESCRIPTION
Apple has switched to high-resolution timing for APFS, giving mu second resolution.
Ninja supports that since 1.9.0. BUT the binutils by Apple just write out zeros,
causing wrong time stamps and causing re-build events.

CMake has worked around that by touching the library generated by Apple binutils,
to update its timestamp. That means:
On Apple (assuming Apple filesystem), with a recent Ninja, CMake has to be >= 3.14.4.

This will be toned down to a WARNING message later - but for now, until we find the
CI nodes suffering from this, keep it as a FATAL_ERROR.