### PR TITLE
Remove duplicated semicolon in TVirtualPaveStats

### DIFF
--- a/hist/hist/inc/TVirtualPaveStats.h
+++ b/hist/hist/inc/TVirtualPaveStats.h
@@ -30,7 +30,7 @@ class TVirtualPaveStats {
 public:
    virtual ~TVirtualPaveStats() = default;
 
-   virtual TObject *GetParent() const = 0;;
+   virtual TObject *GetParent() const = 0;
    virtual void SetParent(TObject *) = 0;
 
    ClassDef(TVirtualPaveStats, 0)  //Abstract interface for TPaveStats


### PR DESCRIPTION
This double semicolon causes compilation with pedantic gcc settings in newer version to stop with an error