### PR TITLE
Fix PyROOT installation on Windows

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -5,7 +5,9 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 if(pyroot)
-  if (NOT CMAKE_INSTALL_LIBDIR STREQUAL CMAKE_INSTALL_PYTHONDIR AND (how_many_pythons GREATER 1 OR MSVC))
+  if ((MSVC AND NOT CMAKE_INSTALL_BINDIR STREQUAL CMAKE_INSTALL_PYTHONDIR) OR
+      (NOT CMAKE_INSTALL_LIBDIR STREQUAL CMAKE_INSTALL_PYTHONDIR AND (how_many_pythons GREATER 1)))
+    message(STATUS "CMAKE_INSTALL_BINDIR = ${CMAKE_INSTALL_BINDIR}; CMAKE_INSTALL_PYTHONDIR = ${CMAKE_INSTALL_PYTHONDIR} ")
     message(FATAL_ERROR "Using a custom CMAKE_INSTALL_PYTHONDIR is not supported for multi-python builds or on Windows. Please check your build configuration.")
   endif()
 

--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -111,7 +111,7 @@ foreach(val RANGE ${how_many_pythons})
                              RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries
                              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
                              ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
-  if (NOT CMAKE_INSTALL_LIBDIR STREQUAL CMAKE_INSTALL_PYTHONDIR)
+  if (NOT MSVC AND NOT CMAKE_INSTALL_LIBDIR STREQUAL CMAKE_INSTALL_PYTHONDIR)
     # add a symlink to ${libname} in CMAKE_INSTALL_PYTHONDIR
     install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink\
             ${CMAKE_INSTALL_FULL_LIBDIR}/lib${libname}.so\

--- a/bindings/pyroot/cppyy/cppyy-backend/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/cppyy-backend/CMakeLists.txt
@@ -45,7 +45,7 @@ foreach(val RANGE ${how_many_pythons})
                              RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries
                              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
                              ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
-  if (NOT CMAKE_INSTALL_LIBDIR STREQUAL CMAKE_INSTALL_PYTHONDIR)
+  if (NOT MSVC AND NOT CMAKE_INSTALL_LIBDIR STREQUAL CMAKE_INSTALL_PYTHONDIR)
     # add a symlink to ${libname} in CMAKE_INSTALL_PYTHONDIR
     install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink\
             ${CMAKE_INSTALL_FULL_LIBDIR}/lib${libname}.so\

--- a/cmake/modules/RootInstallDirs.cmake
+++ b/cmake/modules/RootInstallDirs.cmake
@@ -58,7 +58,11 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
 endif()
 
 if(NOT DEFINED CMAKE_INSTALL_PYTHONDIR)
-  set(CMAKE_INSTALL_PYTHONDIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "python libraries and modules (same as LIBDIR)")
+  if(MSVC)
+    set(CMAKE_INSTALL_PYTHONDIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH "python libraries and modules (same as BINDIR)")
+  else()
+    set(CMAKE_INSTALL_PYTHONDIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "python libraries and modules (same as LIBDIR)")
+  endif()
 endif()
 
 if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)


### PR DESCRIPTION
The `.dll` and `.pyd` files must go into the `%ROOTSYS%\bin` directory on Windows