### PR TITLE
[DF] Fix out of bounds access in AddDSColumns

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2028,11 +2028,10 @@ public:
    {
       RDFInternal::CheckAggregate<R, MergeFun>(ArgTypesNoDecay());
       const auto columns = columnName.empty() ? ColumnNames_t() : ColumnNames_t({std::string(columnName)});
-      constexpr auto nColumns = ArgTypes::list_size;
 
       const auto validColumnNames = GetValidatedColumnNames(1, columns);
 
-      auto newColumns = CheckAndFillDSColumns(validColumnNames, std::make_index_sequence<nColumns>(), ArgTypes());
+      auto newColumns = CheckAndFillDSColumns(validColumnNames, std::make_index_sequence<1>(), TTraits::TypeList<T>());
 
       auto accObjPtr = std::make_shared<U>(aggIdentity);
       using Helper_t = RDFInternal::AggregateHelper<AccFun, MergeFun, R, T, U>;


### PR DESCRIPTION
The Aggregate method was calling CheckAndFillDSColumns with an index sequence
of length 2 rather than 1 (the aggregator lambda does take 2 arguments,
but only the second corresponds to an RDF column). This resulted in
a harmless out of bounds access in a vector<bool>: two bits were checked
rather than one, but because of bit-packing the capacity of a vector<bool>
is always a multiple of 8 so this never resulted in access to invalid
memory (and because of zero-initialization, the out-of-bounds values always
happened to read to the harmless, "correct" value, `false`).