### PR TITLE
Fix or disable last failing tests on Windows

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -975,7 +975,13 @@ TROOT::~TROOT()
       SafeDelete(fCleanups);
 #endif
 
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+      // usedToIdentifyRootClingByDlSym is available when TROOT is part of rootcling.
+      if (dlsym(RTLD_DEFAULT, "usedToIdentifyRootClingByDlSym")) {
+         // deleting the interpreter makes things crash at exit in some cases
+         delete fInterpreter;
+      }
+#else
       // deleting the interpreter makes things crash at exit in some cases
       delete fInterpreter;
 #endif

--- a/core/meta/test/CMakeLists.txt
+++ b/core/meta/test/CMakeLists.txt
@@ -6,7 +6,9 @@
 
 ROOT_ADD_GTEST(testStatusBitsChecker testStatusBitsChecker.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testHashRecursiveRemove testHashRecursiveRemove.cxx LIBRARIES Core)
-ROOT_ADD_GTEST(testTClass testTClass.cxx LIBRARIES Core)
+if(NOT MSVC OR win_broken_tests)
+  ROOT_ADD_GTEST(testTClass testTClass.cxx LIBRARIES Core)
+endif()
 ROOT_ADD_GTEST(testTEnum testTEnum.cxx LIBRARIES Core)
 configure_file(stlDictCheck.h . COPYONLY)
 configure_file(stlDictCheckAux.h . COPYONLY)

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -63,6 +63,7 @@ TEST_F(TClingTests, GenerateDictionaryRegression)
    //EXPECT_TRUE(gInterpreter->GenerateDictionary("std::vector<std::array<int, 5>>", ""));
 }
 
+#if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
 TEST_F(TClingTests, GenerateDictionary)
 {
    auto cl = TClass::GetClass("vector<TNamed*>");
@@ -73,6 +74,7 @@ TEST_F(TClingTests, GenerateDictionary)
    EXPECT_TRUE(cl != nullptr);
    EXPECT_TRUE(cl->IsLoaded());
 }
+#endif
 
 // Test ROOT-6967
 TEST_F(TClingTests, GetEnumWithSameVariableName)
@@ -210,5 +212,8 @@ TEST_F(TClingTests, ClingLookupHelper) {
 TEST_F(TClingTests, ROOT10499) {
    EXPECT_EQ((void*)&std::cout, (void*)gInterpreter->Calc("&std::cout"));
    EXPECT_EQ((void*)&std::cerr, (void*)gInterpreter->Calc("&std::cerr"));
+#if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
+   // strangely enough, this works on the command prompt, but not in this test...
    EXPECT_EQ((void*)&errno, (void*)gInterpreter->Calc("&errno"));
+#endif
 }

--- a/core/rint/test/TTabComTests.cxx
+++ b/core/rint/test/TTabComTests.cxx
@@ -92,8 +92,14 @@ TEST(TTabComTests, CompleteTProfile)
 
 TEST(TTabComTests, CompleteTObj)
 {
+#ifdef _MSC_VER
+   std::string expected = "TObjArray TObjArrayIter TObjLink TObjOptLink TObjString"
+      " TObject TObject::EDeprecatedStatusBits TObject::EStatusBits TObjectRefSpy"
+      " TObjectSpy TObjectTable";
+#else
    std::string expected = "TObjArray TObjArrayIter TObjLink TObjOptLink TObjString"
       " TObject TObjectRefSpy TObjectSpy TObjectTable";
+#endif
    // FIXME: See ROOT-10989
    ASSERT_STREQ(expected.c_str(), GetCompletions("TObj",
                                                  /*ignore=*/{"TObjectHolder",

--- a/test/stressTMVA.cxx
+++ b/test/stressTMVA.cxx
@@ -2505,6 +2505,7 @@ void RegressionUnitTestWithDeviation::run()
    outputFile->Close();
    delete dataloader; 
    delete factory;
+   delete input;
 
    // reader tests
 

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -84,6 +84,7 @@ if (NOT dataframe)
     list(APPEND dataframe_veto tmva/tmva*.C)
 elseif(MSVC AND NOT win_broken_tests)
     list(APPEND dataframe_veto dataframe/*.py)
+    list(APPEND dataframe_veto tmva/tmva003_RReader.C)
 endif()
 
 if(NOT sqlite)


### PR DESCRIPTION
Improve the workaround for the deletion of fInterpreter in the TROOT destructor, which is needed in rootcling for c++ modules, and fix (or disable) the last failing tests