### PR TITLE
[DF] Unify RAction implementation: no need for 3 different template classes 

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -73,20 +73,22 @@ GetValuePtrsPtr(const std::string &colName, const std::map<std::string, std::vec
 }
 
 /// This overload is specialized to act on RTypeErasedColumnValues instead of RColumnValues.
-template <std::size_t... S, typename... ColTypes>
+template <typename... ColTypes>
 void InitColumnReaders(unsigned int slot, std::vector<RTypeErasedColumnValue> &values, TTreeReader *r,
-                       const ColumnNames_t &bn, const RBookedCustomColumns &customCols, std::index_sequence<S...>,
-                       ROOT::TypeTraits::TypeList<ColTypes...>, const std::array<bool, sizeof...(S)> &isTmpColumn,
+                       const ColumnNames_t &bn, const RBookedCustomColumns &customCols,
+                       ROOT::TypeTraits::TypeList<ColTypes...>,
+                       const std::array<bool, sizeof...(ColTypes)> &isTmpColumn,
                        const std::map<std::string, std::vector<void *>> &DSValuePtrsMap)
 {
    const auto &customColMap = customCols.GetColumns();
 
    // Construct the column readers
    using expander = int[];
+   int i = 0;
    (void)expander{
-      (values.emplace_back(MakeColumnReader<ColTypes>(slot, isTmpColumn[S] ? customColMap.at(bn[S]).get() : nullptr, r,
-                                                      GetValuePtrsPtr(bn[S], DSValuePtrsMap), bn[S])),
-       0)...,
+      (values.emplace_back(MakeColumnReader<ColTypes>(slot, isTmpColumn[i] ? customColMap.at(bn[i]).get() : nullptr, r,
+                                                      GetValuePtrsPtr(bn[i], DSValuePtrsMap), bn[i])),
+       ++i)...,
       0};
 
    (void)slot; // avoid bogus 'unused parameter' warning
@@ -303,8 +305,7 @@ public:
    void InitColumnValues(TTreeReader *r, unsigned int slot)
    {
       InitColumnReaders(slot, fValues[slot], r, RActionBase::GetColumnNames(), RActionBase::GetCustomColumns(),
-                        typename ActionCRTP_t::TypeInd_t{}, ColumnTypes_t{}, ActionCRTP_t::fIsCustomColumn,
-                        ActionCRTP_t::fLoopManager->GetDSValuePtrs());
+                        ColumnTypes_t{}, ActionCRTP_t::fIsCustomColumn, ActionCRTP_t::fLoopManager->GetDSValuePtrs());
    }
 
    template <std::size_t... S>
@@ -346,8 +347,7 @@ public:
    void InitColumnValues(TTreeReader *r, unsigned int slot)
    {
       InitColumnReaders(slot, fValues[slot], r, RActionBase::GetColumnNames(), RActionBase::GetCustomColumns(),
-                        typename ActionCRTP_t::TypeInd_t{}, ColumnTypes_t{}, ActionCRTP_t::fIsCustomColumn,
-                        ActionCRTP_t::fLoopManager->GetDSValuePtrs());
+                        ColumnTypes_t{}, ActionCRTP_t::fIsCustomColumn, ActionCRTP_t::fLoopManager->GetDSValuePtrs());
    }
 
    template <std::size_t... S>

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -82,12 +82,12 @@ void InitColumnReaders(unsigned int slot, std::vector<RTypeErasedColumnValue> &v
 }
 
 /// This overload is specialized to act on RTypeErasedColumnValues instead of RColumnValues.
-template <std::size_t... S, typename... ColTypes>
-void ResetColumnReaders(std::vector<RTypeErasedColumnValue> &values, std::index_sequence<S...>,
-                        ROOT::TypeTraits::TypeList<ColTypes...>)
+template <typename... ColTypes>
+void ResetColumnReaders(std::vector<RTypeErasedColumnValue> &values, ROOT::TypeTraits::TypeList<ColTypes...>)
 {
    using expander = int[];
-   (void)expander{(values[S].Cast<ColTypes>()->Reset(), 0)...};
+   int i = 0;
+   (void)expander{(values[i].Cast<ColTypes>()->Reset(), ++i)...};
    values.clear();
 }
 
@@ -169,10 +169,7 @@ struct ActionImpl<Helper, ColumnTypes, true> {
       CallExec(slot, entry, helper, values, TypeInd_t{}, ColumnTypes{});
    }
 
-   static void ResetColumnReaders(Values_t &values)
-   {
-      RDFInternal::ResetColumnReaders(values, TypeInd_t{}, ColumnTypes{});
-   }
+   static void ResetColumnReaders(Values_t &values) { RDFInternal::ResetColumnReaders(values, ColumnTypes{}); }
 };
 
 // clang-format off


### PR DESCRIPTION
Before this commit, we had a generic RAction and two template
specializations for `RAction<SnapshotHelper>` and
`RAction<SnapshotHelperMT>`. Common logic between the three was kept
in the common base class `RActionCRTP<RAction<...>>`.

This is unnecessarily complex. Instead, we now have a single RAction
class and a helper ActionImpl type that contains the parts of the
logic that needs to differ for `RAction<SnapshotHelper>` and
`RAction<SnapshotHelperMT>`. A single specialization of ActionImpl is
used for both helpers to reduce code duplication.