### PR TITLE
[ntuple] Implement RNTupleWriter::Append(TFile &)

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -30,6 +30,8 @@
 #include <sstream>
 #include <utility>
 
+class TFile;
+
 namespace ROOT {
 namespace Experimental {
 
@@ -205,6 +207,10 @@ public:
                                                   std::string_view ntupleName,
                                                   std::string_view storage,
                                                   const RNTupleWriteOptions &options = RNTupleWriteOptions());
+   static std::unique_ptr<RNTupleWriter> Append(std::unique_ptr<RNTupleModel> model,
+                                                std::string_view ntupleName,
+                                                TFile &file,
+                                                const RNTupleWriteOptions &options = RNTupleWriteOptions());
    RNTupleWriter(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Detail::RPageSink> sink);
    RNTupleWriter(const RNTupleWriter&) = delete;
    RNTupleWriter& operator=(const RNTupleWriter&) = delete;

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -18,6 +18,7 @@
 #include "ROOT/RFieldVisitor.hxx"
 #include "ROOT/RNTupleModel.hxx"
 #include "ROOT/RPageStorage.hxx"
+#include "ROOT/RPageStorageFile.hxx"
 
 #include <algorithm>
 #include <exception>
@@ -29,6 +30,7 @@
 #include <utility>
 
 #include <TError.h>
+#include <TFile.h> // for RNTupleWriter::Append
 
 
 void ROOT::Experimental::RNTupleReader::ConnectModel(const RNTupleModel &model) {
@@ -232,6 +234,16 @@ std::unique_ptr<ROOT::Experimental::RNTupleWriter> ROOT::Experimental::RNTupleWr
    const RNTupleWriteOptions &options)
 {
    return std::make_unique<RNTupleWriter>(std::move(model), Detail::RPageSink::Create(ntupleName, storage, options));
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleWriter> ROOT::Experimental::RNTupleWriter::Append(
+   std::unique_ptr<RNTupleModel> model,
+   std::string_view ntupleName,
+   TFile &file,
+   const RNTupleWriteOptions &options)
+{
+   auto sink = std::make_unique<Detail::RPageSinkFile>(ntupleName, file, options);
+   return std::make_unique<RNTupleWriter>(std::move(model), std::move(sink));
 }
 
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -41,31 +41,31 @@ TEST(RNTuple, MultipleInFile)
    {
       auto model = RNTupleModel::Create();
       auto fieldPt = model->MakeField<float>("pt", 42.0);
-      RNTupleWriter ntuple(std::move(model), std::make_unique<RPageSinkFile>("first", *file, RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto ntuple = RNTupleWriter::Append(std::move(model), "first", *file);
+      ntuple->Fill();
    }
    {
       auto model = RNTupleModel::Create();
       auto fieldPt = model->MakeField<float>("E", 1.0);
-      RNTupleWriter ntuple(std::move(model), std::make_unique<RPageSinkFile>("second", *file, RNTupleWriteOptions()));
-      ntuple.Fill();
+      auto ntuple = RNTupleWriter::Append(std::move(model), "second", *file);
+      ntuple->Fill();
    }
    file->Close();
    delete file;
 
-   RNTupleReader ntupleFirst(std::make_unique<RPageSourceFile>("first", fileGuard.GetPath(), RNTupleReadOptions()));
-   auto viewPt = ntupleFirst.GetView<float>("pt");
+   auto ntupleFirst = RNTupleReader::Open("first", fileGuard.GetPath());
+   auto viewPt = ntupleFirst->GetView<float>("pt");
    int n = 0;
-   for (auto i : ntupleFirst.GetEntryRange()) {
+   for (auto i : ntupleFirst->GetEntryRange()) {
       EXPECT_EQ(42.0, viewPt(i));
       n++;
    }
    EXPECT_EQ(1, n);
 
-   RNTupleReader ntupleSecond(std::make_unique<RPageSourceFile>("second", fileGuard.GetPath(), RNTupleReadOptions()));
-   auto viewE = ntupleSecond.GetView<float>("E");
+   auto ntupleSecond = RNTupleReader::Open("second", fileGuard.GetPath());
+   auto viewE = ntupleSecond->GetView<float>("E");
    n = 0;
-   for (auto i : ntupleSecond.GetEntryRange()) {
+   for (auto i : ntupleSecond->GetEntryRange()) {
       EXPECT_EQ(1.0, viewE(i));
       n++;
    }


### PR DESCRIPTION
Simplify writing multiple `RNTuple`s in a single open `TFile`.