### PR TITLE
[wincxxmodules] Rename -fmodule-map-file flag to -moduleMapFile

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3598,7 +3598,7 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
       moduleMapFile << "}" << std::endl;
       moduleMapFile.close();
       gInterpreter->RegisterPrebuiltModulePath(build_loc.Data(), moduleMapName.Data());
-      rcling.Append(" \"-fmodule-map-file=" + moduleMapFullPath + "\" ");
+      rcling.Append(" \"-moduleMapFile=" + moduleMapFullPath + "\" ");
    }
 
    rcling.Append(" \"").Append(filename_fullpath).Append("\" ");


### PR DESCRIPTION
This commit renames the -fmodule-map-file flag used to specify the
modulemap file to -moduleMapFile as ROOT on Windows fails to recognize
the flag.

@vgvassilev 