### PR TITLE
[cling] Support GCC10 type name:

### DIFF
--- a/interpreter/cling/test/Prompt/ValuePrinter/TuplesAndPairs.C
+++ b/interpreter/cling/test/Prompt/ValuePrinter/TuplesAndPairs.C
@@ -14,7 +14,7 @@
 #include <tuple>
 
 std::make_pair("s",10)
-//CHECK: (std::pair<{{.+char.+\[2\].*,.*int.*}}>) { "s", 10 }
+//CHECK: (std::pair<{{.+char.+.*,.*int.*}}>) { "s", 10 }
 
 std::make_pair(4L,'c')
 //CHECK: (std::pair<{{.*long.*,.*char.*}}>) { 4, 'c' }


### PR DESCRIPTION
(std::pair<std::__strip_reference_wrapper<const char *>::__type, std::__strip_reference_wrapper<int>::__type>) { "s", 10 }
i.e. the array size is not part of the type.