### PR TITLE
Move the workaround for latest VS2019 from rootcling_impl.cxx to CIFa…

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4077,13 +4077,6 @@ int RootClingMain(int argc,
    for (const std::string &PPDefine : gOptPPDefines)
       clingArgs.push_back(std::string("-D") + PPDefine);
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1926)
-   // FIXME: Silly workaround for rootcling not being able to parse the STL
-   //        headers anymore after the update of Visual Studio v16.7.0
-   //        To be checked/removed after the upgrade of LLVM & Clang
-   clingArgs.push_back(std::string("-D__CUDACC__"));
-#endif
-
    for (const std::string &PPUndefine : gOptPPUndefines)
       clingArgs.push_back(std::string("-U") + PPUndefine);
 

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -788,6 +788,12 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     PPOpts.addMacroDef("__CLING__GNUC_MINOR__=" ClingStringify(__GNUC_MINOR__));
 #elif defined(_MSC_VER)
     PPOpts.addMacroDef("__CLING__MSVC__=" ClingStringify(_MSC_VER));
+#if (_MSC_VER >= 1926)
+    // FIXME: Silly workaround for cling not being able to parse the STL
+    //        headers anymore after the update of Visual Studio v16.7.0
+    //        To be checked/removed after the upgrade of LLVM & Clang
+    PPOpts.addMacroDef("__CUDACC__");
+#endif
 #endif
 
 // https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html


### PR DESCRIPTION
…ctory.cpp

Following [this discussion on GitHub](https://github.com/root-project/cling/commit/df0e84968ab9fe7ea280b4ae78203675f68438f5#), move back the workaround for Visual Studio 2019 v16.7.0 from `rootcling_impl.cxx` to `CIFactory.cpp`