### PR TITLE
Add back line accidentally removed in commit 17bc17715524b4cc6b46324c428845e9ab945684

### DIFF
--- a/config/root-config.in
+++ b/config/root-config.in
@@ -438,7 +438,9 @@ Usage: root-config [--prefix[=DIR]] [--exec-prefix[=DIR]] [--version]\
  [--cflags] [--auxcflags] [--ldflags] [--new] [--nonew] [--libs] [--glibs]\
  [--evelibs] [--bindir] [--libdir] [--incdir] [--etcdir] [--tutdir] [--srcdir]\
  [--noauxcflags] [--noauxlibs] [--noldflags] [--has-<feature>] [--arch]\
-[--python-version] [--python2-version] [--python3-version] [--cc] [--cxx] [--f77] [--ld ] [--help]"
+ [--platform] [--config] [--features] [--ncpu] [--git-revision]\
+ [--python-version] [--python2-version] [--python3-version]\
+ [--cc] [--cxx] [--f77] [--ld ] [--help]"
 
 if test $# -eq 0; then
    echo "${usage}" 1>&2


### PR DESCRIPTION
When --python2-version and --python3-version were added the root-config --usage, some other option were accidentally deleted.