### PR TITLE
Install headers with COMPONENT headers

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -120,4 +120,6 @@ foreach(val RANGE ${how_many_pythons})
 endforeach()
 
 file(COPY ${headers} DESTINATION ${CMAKE_BINARY_DIR}/include/CPyCppyy)
-install(FILES ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/CPyCppyy)
+install(FILES ${headers}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/CPyCppyy
+        COMPONENT headers)

--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -159,6 +159,8 @@ install(DIRECTORY ${localruntimedir}/ROOT
         COMPONENT libraries)
 
 # Install headers required by pythonizations
-install(FILES ${PYROOT_EXTRA_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ROOT)
+install(FILES ${PYROOT_EXTRA_HEADERS}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ROOT
+        COMPONENT headers)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
The headers in the new PyROOT are not installed with COMPONENT headers.