### PR TITLE
[boost] Do not include all headers as submodules as some are disjoint sets

### DIFF
--- a/interpreter/cling/include/cling/boost.modulemap
+++ b/interpreter/cling/include/cling/boost.modulemap
@@ -6370,6 +6370,12 @@ In file included from /home/teemperor/llvm/boost-compile/inc-cms/boost/spirit/ho
 
 module boost_iostreams {
   export *
+  // FIXME: Brings boost_random which is currently broken.
+  exclude header "iostreams/filter/test.hpp"
+  // error: unknown template name 'stream_base'
+  exclude header "iostreams/detail/broken_overload_resolution/stream.hpp"
+  // error: redefinition of 'stream_buffer'
+  exclude header "iostreams/detail/broken_overload_resolution/stream_buffer.hpp"
   umbrella "iostreams"
   module * { export * }
 }

--- a/interpreter/cling/include/cling/boost.modulemap
+++ b/interpreter/cling/include/cling/boost.modulemap
@@ -82,11 +82,7 @@ module boost_accumulators [system] {
 }
 module boost_align {
   export *
-  module align_aligned_storage { export * header "aligned_storage.hpp" }
   module align_align { export * header "align.hpp" }
-
-  umbrella "align"
-  module * { export * }
 }
 module boost_any { export * module "any" { header "any.hpp" export * } }
 module boost_array { export * module "array" { header "array.hpp" export * } }
@@ -4977,8 +4973,6 @@ module boost_ptr_container {
 module boost_python {
   export *
   module python_python { export * header "python.hpp" }
-  umbrella "python"
-  module * { export * }
 }
 module boost_qvm {
   export *


### PR DESCRIPTION
boost_align and boost_python have umbrella header design, however we cannot use that specifier because then it warns about all the rest of boost not being part of the particular module.

This patch just adds align.hpp and python.hpp in the module. This may lead to some duplicates which we will hunt down and fix if needed. The patch should fix cmssw.

cc: @davidlange6 