### PR TITLE
Increase timeout for PPC64

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -462,7 +462,7 @@ foreach(t ${tutorials})
   endif()
 
    # These tests on ARM64 need much more than 20 minutes - increase the timeout
-   if(ROOT_ARCHITECTURE MATCHES arm64)
+   if(ROOT_ARCHITECTURE MATCHES arm64 OR ROOT_ARCHITECTURE MATCHES ppc64)
      set(thisTestTimeout 2400) # 40m
    else()
      set(thisTestTimeout 1200) # 20m
@@ -489,7 +489,7 @@ foreach(t ${mpi_tutorials})
   string(REPLACE "/" "-" tname ${tname})
 
    # These tests on ARM64 need much more than 20 minutes - increase the timeout
-   if(ROOT_ARCHITECTURE MATCHES arm64)
+   if(ROOT_ARCHITECTURE MATCHES arm64 OR ROOT_ARCHITECTURE MATCHES ppc64)
      set(thisTestTimeout 2400) # 40m
    else()
      set(thisTestTimeout 1200) # 20m


### PR DESCRIPTION
With this change:

1036/1038 Test  #853: tutorial-tmva-TMVA_Higgs_Classification .............................   Passed  1248.66 sec
1037/1038 Test  #854: tutorial-tmva-TMVA_RNN_Classification ...............................   Passed  1252.92 sec
1038/1038 Test  #852: tutorial-tmva-TMVA_CNN_Classification ...............................   Passed  1273.47 sec

Instead of timing out at 1200 s.
