### PR TITLE
Create symlink to libJupyROOTX_Y.so when using CMAKE_INSTALL_PYTHONDIR

### DIFF
--- a/bindings/jupyroot/CMakeLists.txt
+++ b/bindings/jupyroot/CMakeLists.txt
@@ -75,6 +75,12 @@ foreach(val RANGE ${how_many_pythons})
                              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
                              ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 
+  if (NOT CMAKE_INSTALL_LIBDIR STREQUAL CMAKE_INSTALL_PYTHONDIR)
+    # add a symlink to ${libname} in CMAKE_INSTALL_PYTHONDIR
+    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink\
+            ${CMAKE_INSTALL_FULL_LIBDIR}/lib${libname}.so\
+            ${CMAKE_INSTALL_FULL_PYTHONDIR}/lib${libname}.so)")
+  endif()
 endforeach()
 
 # Install Python sources and bytecode

--- a/bindings/jupyroot/CMakeLists.txt
+++ b/bindings/jupyroot/CMakeLists.txt
@@ -75,7 +75,7 @@ foreach(val RANGE ${how_many_pythons})
                              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
                              ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 
-  if (NOT CMAKE_INSTALL_LIBDIR STREQUAL CMAKE_INSTALL_PYTHONDIR)
+  if (NOT MSVC AND NOT CMAKE_INSTALL_LIBDIR STREQUAL CMAKE_INSTALL_PYTHONDIR)
     # add a symlink to ${libname} in CMAKE_INSTALL_PYTHONDIR
     install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink\
             ${CMAKE_INSTALL_FULL_LIBDIR}/lib${libname}.so\


### PR DESCRIPTION
Fixes importing `JupyROOT` when `CMAKE_INSTALL_PYTHONDIR` is set to the standard site-packages directory. Fixes the failure seen in this build of the conda nightly:

https://lcgapp-services.cern.ch/root-jenkins/view/conda/job/conda-nightlies/99/console

The builds after 100 include this patch and work as expected. (The new failure in [`roottest_python_JupyROOT_ROOT_kernel_notebook`](https://lcgapp-services.cern.ch/root-jenkins/view/conda/job/conda-nightlies/101/testReport/projectroot.python/JupyROOT/roottest_python_JupyROOT_ROOT_kernel_notebook/) is a bug in `metakernel` that is fixed by https://github.com/Calysto/metakernel/pull/214.)