### PR TITLE
[RF] Re-expose RooFormulaVar::formula().

### DIFF
--- a/roofit/roofitcore/inc/RooFormula.h
+++ b/roofit/roofitcore/inc/RooFormula.h
@@ -50,7 +50,7 @@ public:
     return _origList.at(index);
   }
 
-  Bool_t ok() { return _tFormula != nullptr; }
+  Bool_t ok() const { return _tFormula != nullptr; }
   /// Evalute all parameters/observables, and then evaluate formula.
   Double_t eval(const RooArgSet* nset=0) const;
 

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -38,12 +38,12 @@ public:
 
   inline Bool_t ok() const { return formula().ok() ; }
 
+  /// Return pointer to parameter with given name.
   inline RooAbsArg* getParameter(const char* name) const { 
-    // Return pointer to parameter with given name
     return _actualVars.find(name) ; 
   }
+  /// Return pointer to parameter at given index.
   inline RooAbsArg* getParameter(Int_t index) const { 
-    // Return pointer to parameter at given index
     return _actualVars.at(index) ; 
   }
 

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -36,7 +36,7 @@ public:
   RooFormulaVar(const RooFormulaVar& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooFormulaVar(*this,newname); }
 
-  inline Bool_t ok() const { return formula().ok() ; }
+  inline Bool_t ok() const { return getFormula().ok() ; }
 
   /// Return pointer to parameter with given name.
   inline RooAbsArg* getParameter(const char* name) const { 
@@ -56,7 +56,12 @@ public:
   void printMetaArgs(std::ostream& os) const ;
 
   // Debugging
-  void dumpFormula() { formula().dump() ; }
+  /// Dump the formula to stdout.
+  void dumpFormula() { getFormula().dump() ; }
+  /// Get reference to the internal formula object.
+  const RooFormula& formula() const {
+    return getFormula();
+  }
 
   virtual Double_t defaultErrorLevel() const ;
 
@@ -73,7 +78,7 @@ public:
   virtual Bool_t isValidReal(Double_t /*value*/, Bool_t /*printError*/) const {return true;}
 
   private:
-  RooFormula& formula() const;
+  RooFormula& getFormula() const;
 
   RooListProxy _actualVars ;     // Actual parameters used by formula engine
   std::unique_ptr<RooFormula> _formula{nullptr}; //! Formula engine

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -128,7 +128,8 @@ RooFormulaVar::RooFormulaVar(const RooFormulaVar& other, const char* name) :
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return reference to internal RooFormula object.
-RooFormula& RooFormulaVar::formula() const
+/// If it doesn't exist, create it on the fly.
+RooFormula& RooFormulaVar::getFormula() const
 {
   if (!_formula) {
     // After being read from file, the formula object might not exist, yet:
@@ -147,7 +148,7 @@ RooFormula& RooFormulaVar::formula() const
 
 Double_t RooFormulaVar::evaluate() const
 {
-  return formula().eval(_lastNSet);
+  return getFormula().eval(_lastNSet);
 }
 
 
@@ -156,9 +157,9 @@ Double_t RooFormulaVar::evaluate() const
 
 Bool_t RooFormulaVar::redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t /*isRecursive*/)
 {
-  bool success = formula().changeDependents(newServerList,mustReplaceAll,nameChange);
+  bool success = getFormula().changeDependents(newServerList,mustReplaceAll,nameChange);
 
-  _formExpr = formula().GetTitle();
+  _formExpr = getFormula().GetTitle();
   return success;
 }
 
@@ -173,7 +174,7 @@ void RooFormulaVar::printMultiline(ostream& os, Int_t contents, Bool_t verbose, 
   if(verbose) {
     indent.Append("  ");
     os << indent;
-    formula().printMultiline(os,contents,verbose,indent);
+    getFormula().printMultiline(os,contents,verbose,indent);
   }
 }
 


### PR DESCRIPTION
In old versions of RooFormula, one could mutate the internal formula
object from the outside. This was unsafe. Therefore, the visibility of
formula() was reduced.
It can, however, be beneficial to have at least read access. Therefore,
a const overload of the function was provided to give users access.