### PR TITLE
Avoid a double delete of histograms in TFractionFitter (ROOT-10752)

### DIFF
--- a/hist/hist/src/TFractionFitter.cxx
+++ b/hist/hist/src/TFractionFitter.cxx
@@ -211,6 +211,8 @@ fFitDone(kFALSE), fChisquare(0), fPlot(0)  {
       // Histogram containing template prediction
       TString s = Form("Prediction for MC sample %i",par);
       TH1* pred = (TH1*) ((TH1*)MCs->At(par))->Clone(s);
+      // TFractionFitter manages these histograms
+      pred->SetDirectory(0);
       pred->SetTitle(s);
       fAji.Add(pred);
    }
@@ -256,7 +258,7 @@ TFractionFitter::~TFractionFitter() {
    if (fFractionFitter) delete fFractionFitter;
    delete[] fIntegralMCs;
    delete[] fFractions;
-   if (fPlot) delete fPlot; 
+   if (fPlot) delete fPlot;
    fAji.Delete();
 }
 
@@ -613,8 +615,8 @@ void TFractionFitter::GetResult(Int_t parm, Double_t& value, Double_t& error) co
 /// uncertainties are taken into account).
 /// Note that the name of this histogram will simply be the same as that of the
 /// "data" histogram, prefixed with the string "Fraction fit to hist: ".
-/// Note also that the histogram is managed by the TFractionFitter class, so the returned pointer will be invalid if 
-/// the class is deleted 
+/// Note also that the histogram is managed by the TFractionFitter class, so the returned pointer will be invalid if
+/// the class is deleted
 
 TH1* TFractionFitter::GetPlot() {
    if (! fFitDone) {
@@ -692,6 +694,8 @@ void TFractionFitter::ComputeFCN(Double_t& f, const Double_t* xx, Int_t flag)
    if (flag == 3) {
       TString ts = "Fraction fit to hist: "; ts += fData->GetName();
       fPlot = (TH1*) fData->Clone(ts.Data());
+      // plot histogram is managed by TFractionFitter
+      fPlot->SetDirectory(0);
       fPlot->Reset();
    }
    // likelihood computation
@@ -951,8 +955,8 @@ void TFractionFitter::ComputeChisquareLambda()
 /// Return the adjusted MC template (Aji) for template (parm).
 /// Note that the (Aji) times fractions only sum to the total prediction
 /// of the fit if all weights are 1.
-/// Note also that the histogram is managed by the TFractionFitter class, so the returned pointer will be invalid if 
-/// the class is deleted 
+/// Note also that the histogram is managed by the TFractionFitter class, so the returned pointer will be invalid if
+/// the class is deleted
 
 TH1* TFractionFitter::GetMCPrediction(Int_t parm) const
 {


### PR DESCRIPTION
Call SetDirectory(0) for the internal histogram ( plot + MC prediction templates) managed by TFractionFitter. This avoids double-delete when deleting TFractionFitter and gDirectory and fixes ROOT-10752