### PR TITLE
Add possibility to pass an external generator when generating random numbers in TF1,2,3 and TH1,2,3 classes

### DIFF
--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -310,7 +310,7 @@ protected:
    void DoInitialize(EAddToList addToGlobList);
 
    void IntegrateForNormalization();
-   // tabulate the comulative function integral at  fNpx points. Used by GetRandom
+   // tabulate the cumulative function integral at  fNpx points. Used by GetRandom
    Bool_t ComputeCdfTable(Option_t * opt);
 
    virtual Double_t GetMinMaxNDim(Double_t *x , Bool_t findmax, Double_t epsilon = 0, Int_t maxiter = 0) const;

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -39,6 +39,7 @@ class TF1;
 class TH1;
 class TAxis;
 class TMethodCall;
+class TRandom;
 
 namespace ROOT {
    namespace Fit {
@@ -309,6 +310,8 @@ protected:
    void DoInitialize(EAddToList addToGlobList);
 
    void IntegrateForNormalization();
+   // tabulate the comulative function integral at  fNpx points. Used by GetRandom
+   Bool_t ComputeCdfTable(Option_t * opt);
 
    virtual Double_t GetMinMaxNDim(Double_t *x , Bool_t findmax, Double_t epsilon = 0, Int_t maxiter = 0) const;
    virtual void GetRange(Double_t *xmin, Double_t *xmax) const;
@@ -538,8 +541,8 @@ public:
    virtual void     GetParLimits(Int_t ipar, Double_t &parmin, Double_t &parmax) const;
    virtual Double_t GetProb() const;
    virtual Int_t    GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum);
-   virtual Double_t GetRandom();
-   virtual Double_t GetRandom(Double_t xmin, Double_t xmax);
+   virtual Double_t GetRandom(TRandom * rng = nullptr, Option_t * opt = nullptr);
+   virtual Double_t GetRandom(Double_t xmin, Double_t xmax, TRandom * rng = nullptr, Option_t * opt = nullptr);
    virtual void     GetRange(Double_t &xmin, Double_t &xmax) const;
    virtual void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const;
    virtual void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &zmin, Double_t &xmax, Double_t &ymax, Double_t &zmax) const;

--- a/hist/hist/inc/TF2.h
+++ b/hist/hist/inc/TF2.h
@@ -44,7 +44,7 @@ public:
 
    // constructor using a functor
 
-   TF2(const char *name, ROOT::Math::ParamFunctor f, Double_t xmin = 0, Double_t xmax = 1, Double_t ymin = 0, Double_t ymax = 1, Int_t npar = 0, Int_t ndim = 2);  
+   TF2(const char *name, ROOT::Math::ParamFunctor f, Double_t xmin = 0, Double_t xmax = 1, Double_t ymin = 0, Double_t ymax = 1, Int_t npar = 0, Int_t ndim = 2);
 
 
    // Template constructors from a pointer to any C++ class of type PtrObj with a specific member function of type
@@ -54,33 +54,33 @@ public:
       TF1(name,p,memFn,xmin,xmax,npar,ndim),
    fYmin(ymin), fYmax(ymax), fNpy(30), fContour(0)
    {
-      fNpx = 30; 
+      fNpx = 30;
    }
-   /// backward compatible ctor 
+   /// backward compatible ctor
    template <class PtrObj, typename MemFn>
    TF2(const char *name, const  PtrObj& p, MemFn memFn, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Int_t npar, const char * , const char *) :
       TF1(name,p,memFn,xmin,xmax,npar,2),
    fYmin(ymin), fYmax(ymax), fNpy(30), fContour(0)
    {
-      fNpx = 30; 
+      fNpx = 30;
    }
-   
-   // Template constructors from any  C++ callable object,  defining  the operator() (double * , double *) 
-   // and returning a double.    
-   template <typename Func> 
-   TF2(const char *name, Func f, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Int_t npar,Int_t ndim = 2) : 
+
+   // Template constructors from any  C++ callable object,  defining  the operator() (double * , double *)
+   // and returning a double.
+   template <typename Func>
+   TF2(const char *name, Func f, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Int_t npar,Int_t ndim = 2) :
       TF1(name,f,xmin,xmax,npar,ndim),
    fYmin(ymin), fYmax(ymax), fNpy(30), fContour(0)
    {
-      fNpx = 30; 
+      fNpx = 30;
    }
-   /// backward compatible ctor 
-   template <typename Func> 
-   TF2(const char *name, Func f, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Int_t npar,const char *) : 
+   /// backward compatible ctor
+   template <typename Func>
+   TF2(const char *name, Func f, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Int_t npar,const char *) :
       TF1(name,f,xmin,xmax,npar,2),
    fYmin(ymin), fYmax(ymax), fNpy(30), fContour(0)
    {
-      fNpx = 30; 
+      fNpx = 30;
    }
 
 
@@ -99,9 +99,9 @@ public:
    virtual Double_t GetContourLevel(Int_t level) const;
           Int_t     GetNpy() const {return fNpy;}
    virtual char    *GetObjectInfo(Int_t px, Int_t py) const;
-       Double_t     GetRandom();
-       Double_t     GetRandom(Double_t xmin, Double_t xmax);
-   virtual void     GetRandom2(Double_t &xrandom, Double_t &yrandom);
+   Double_t GetRandom(TRandom * rng = nullptr, Option_t * opt = nullptr);
+   Double_t GetRandom(Double_t xmin, Double_t xmax, TRandom * rng = nullptr, Option_t * opt = nullptr);
+   virtual void     GetRandom2(Double_t &xrandom, Double_t &yrandom, TRandom * rng = nullptr);
    using TF1::GetRange;
    virtual void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const;
    virtual void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &zmin, Double_t &xmax, Double_t &ymax, Double_t &zmax) const;

--- a/hist/hist/inc/TF3.h
+++ b/hist/hist/inc/TF3.h
@@ -92,7 +92,7 @@ public:
    virtual Double_t GetMinimumXYZ(Double_t &x, Double_t &y, Double_t &z);
    virtual Double_t GetMaximumXYZ(Double_t &x, Double_t &y, Double_t &z);
           Int_t     GetNpz() const {return fNpz;}
-   virtual void     GetRandom3(Double_t &xrandom, Double_t &yrandom, Double_t &zrandom);
+   virtual void     GetRandom3(Double_t &xrandom, Double_t &yrandom, Double_t &zrandom, TRandom * rng = nullptr);
    using TF1::GetRange;
    virtual void     GetRange(Double_t &xmin, Double_t &xmax) const;
    virtual void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const ;

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -52,6 +52,7 @@ class TList;
 class TCollection;
 class TVirtualFFT;
 class TVirtualHistPainter;
+class TRandom;
 
 
 class TH1 : public TNamed, public TAttLine, public TAttFill, public TAttMarker {
@@ -218,8 +219,8 @@ public:
    virtual Int_t    Fill(const char *name, Double_t w);
    virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride=1);
    virtual void     FillN(Int_t, const Double_t *, const Double_t *, const Double_t *, Int_t) {;}
-   virtual void     FillRandom(const char *fname, Int_t ntimes=5000);
-   virtual void     FillRandom(TH1 *h, Int_t ntimes=5000);
+   virtual void     FillRandom(const char *fname, Int_t ntimes=5000, TRandom * rng = nullptr);
+   virtual void     FillRandom(TH1 *h, Int_t ntimes=5000, TRandom * rng = nullptr);
    virtual Int_t    FindBin(Double_t x, Double_t y=0, Double_t z=0);
    virtual Int_t    FindFixBin(Double_t x, Double_t y=0, Double_t z=0) const;
    virtual Int_t    FindFirstBinAbove(Double_t threshold=0, Int_t axis=1, Int_t firstBin=1, Int_t lastBin=-1) const;
@@ -301,7 +302,7 @@ public:
    TVirtualHistPainter *GetPainter(Option_t *option="");
 
    virtual Int_t    GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum=0);
-   virtual Double_t GetRandom() const;
+   virtual Double_t GetRandom(TRandom * rng = nullptr) const;
    virtual void     GetStats(Double_t *stats) const;
    virtual Double_t GetStdDev(Int_t axis=1) const;
    virtual Double_t GetStdDevError(Int_t axis=1) const;

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -79,8 +79,8 @@ public:
    virtual Int_t    Fill(const char *namex, const char *namey, Double_t w);
    virtual void     FillN(Int_t, const Double_t *, const Double_t *, Int_t) {;} //MayNotUse
    virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double_t *w, Int_t stride=1);
-   virtual void     FillRandom(const char *fname, Int_t ntimes=5000);
-   virtual void     FillRandom(TH1 *h, Int_t ntimes=5000);
+   virtual void     FillRandom(const char *fname, Int_t ntimes=5000, TRandom * rng = nullptr);
+   virtual void     FillRandom(TH1 *h, Int_t ntimes=5000, TRandom * rng = nullptr);
    virtual void     FitSlicesX(TF1 *f1=0,Int_t firstybin=0, Int_t lastybin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = 0);
    virtual void     FitSlicesY(TF1 *f1=0,Int_t firstxbin=0, Int_t lastxbin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = 0);
    virtual Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz = 0) const;
@@ -94,7 +94,7 @@ public:
    virtual Double_t GetBinErrorUp(Int_t binx, Int_t biny) { return TH1::GetBinErrorUp( GetBin(binx, biny) ); }
    virtual Double_t GetCorrelationFactor(Int_t axis1=1,Int_t axis2=2) const;
    virtual Double_t GetCovariance(Int_t axis1=1,Int_t axis2=2) const;
-   virtual void     GetRandom2(Double_t &x, Double_t &y);
+   virtual void     GetRandom2(Double_t &x, Double_t &y, TRandom * rng = nullptr);
    virtual void     GetStats(Double_t *stats) const;
    virtual Double_t Integral(Option_t *option="") const;
    //virtual Double_t Integral(Int_t, Int_t, Option_t * ="") const {return 0;}

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -87,8 +87,8 @@ public:
    virtual Int_t    Fill(Double_t x, const char *namey, Double_t z, Double_t w);
    virtual Int_t    Fill(Double_t x, Double_t y, const char *namez, Double_t w);
 
-   virtual void     FillRandom(const char *fname, Int_t ntimes=5000);
-   virtual void     FillRandom(TH1 *h, Int_t ntimes=5000);
+   virtual void     FillRandom(const char *fname, Int_t ntimes=5000, TRandom * rng = nullptr);
+   virtual void     FillRandom(TH1 *h, Int_t ntimes=5000, TRandom * rng = nullptr);
    virtual void     FitSlicesZ(TF1 *f1=0,Int_t binminx=1, Int_t binmaxx=0,Int_t binminy=1, Int_t binmaxy=0,
                                         Int_t cut=0 ,Option_t *option="QNR"); // *MENU*
    virtual Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz) const;
@@ -102,7 +102,7 @@ public:
    virtual Double_t GetBinWithContent3(Double_t c, Int_t &binx, Int_t &biny, Int_t &binz, Int_t firstx=0, Int_t lastx=0,Int_t firsty=0, Int_t lasty=0, Int_t firstz=0, Int_t lastz=0, Double_t maxdiff=0) const;
    virtual Double_t GetCorrelationFactor(Int_t axis1=1,Int_t axis2=2) const;
    virtual Double_t GetCovariance(Int_t axis1=1,Int_t axis2=2) const;
-   virtual void     GetRandom3(Double_t &x, Double_t &y, Double_t &z);
+   virtual void     GetRandom3(Double_t &x, Double_t &y, Double_t &, TRandom * rng = nullptr);
    virtual void     GetStats(Double_t *stats) const;
    virtual Double_t Integral(Option_t *option="") const;
    virtual Double_t Integral(Int_t binx1, Int_t binx2, Int_t biny1, Int_t biny2, Int_t binz1, Int_t binz2, Option_t *option="") const;

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -2075,9 +2075,8 @@ Int_t TF1::GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum)
 }
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// Compute the cumulative function at fNpx points between fXmin and fXmax
-///  Option controls if doin automatically or force using a log scale (option ="log")
-///  or linear (option = "lin")
+///  Compute the cumulative function at fNpx points between fXmin and fXmax.
+///  Option can be used to force a log scale (option = "log"), linear (option = "lin") or automatic if empty.
 Bool_t TF1::ComputeCdfTable(Option_t * option) {
 
    fIntegral.resize(fNpx + 1);
@@ -2159,13 +2158,14 @@ Bool_t TF1::ComputeCdfTable(Option_t * option) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return a random number following this function shape
+/// Return a random number following this function shape.
 ///
-/// @param rng  Ranodm numjber generator. By default (or when passing a nullptr) the global gRandom is used
+/// @param rng  Random number generator. By default (or when passing a nullptr) the global gRandom is used
 /// @param option Option string which controls the binning used to compute the integral. Default mode is automatic depending of
 ///               xmax, xmin and Npx (function points).
-///               Possible values are: "LOG" to force usage of log scale for tabulating the integral
-///                                    "LIN" to force usage of linear scale when tabulating the integral
+///               Possible values are:
+///               -  "LOG" to force usage of log scale for tabulating the integral
+///               -  "LIN" to force usage of linear scale when tabulating the integral
 ///
 /// The distribution contained in the function fname (TF1) is integrated
 /// over the channel contents.
@@ -2230,10 +2230,10 @@ Double_t TF1::GetRandom(TRandom * rng, Option_t * option)
 ///   The parabolic approximation is very good as soon as the number
 ///   of bins is greater than 50.
 ///
-///  @param  xmin    : minimum value for  generated random numbers
-///  @param  xmax    : maximum value for  generated random numbers
-///  @param  rng     : (optional) random number generator pointer
-///  @param  option  : (optional) : `LOG` or `LIN` force usage of Log or Linear fo computing Cdf table
+///  @param  xmin    minimum value for  generated random numbers
+///  @param  xmax    maximum value for  generated random numbers
+///  @param  rng     (optional) random number generator pointer
+///  @param  option  (optional) : `LOG` or `LIN` to force the usage of a log or linear scale for computing the cumulative integral table
 ///
 ///  IMPORTANT NOTE
 ///

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -491,7 +491,7 @@ char *TF2::GetObjectInfo(Int_t px, Int_t py) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return a random number following this function shape
 
-Double_t TF2::GetRandom()
+Double_t TF2::GetRandom(TRandom *, Option_t *)
 {
    Error("GetRandom","cannot be called for TF2/3, use GetRandom2/3 instead");
    return 0;  // not yet implemented
@@ -501,7 +501,7 @@ Double_t TF2::GetRandom()
 /// Return a random number following this function shape
 
 
-Double_t TF2::GetRandom(Double_t, Double_t)
+Double_t TF2::GetRandom(Double_t, Double_t, TRandom *, Option_t *)
 {
    Error("GetRandom","cannot be called for TF2/3, use GetRandom2/3 instead");
    return 0;  // not yet implemented
@@ -526,7 +526,7 @@ Double_t TF2::GetRandom(Double_t, Double_t)
 ///  points (SetNpx, SetNpy) such that the peak is correctly tabulated
 ///  at several points.
 
-void TF2::GetRandom2(Double_t &xrandom, Double_t &yrandom)
+void TF2::GetRandom2(Double_t &xrandom, Double_t &yrandom, TRandom * rng)
 {
    //  Check if integral array must be build
    Int_t i,j,cell;
@@ -561,12 +561,13 @@ void TF2::GetRandom2(Double_t &xrandom, Double_t &yrandom)
 
 // return random numbers
    Double_t r,ddx,ddy,dxint;
-   r     = gRandom->Rndm();
+   if (!rng) rng = gRandom;
+   r     = rng->Rndm();
    cell  = TMath::BinarySearch(ncells,fIntegral.data(),r);
    dxint = fIntegral[cell+1] - fIntegral[cell];
    if (dxint > 0) ddx = dx*(r - fIntegral[cell])/dxint;
    else           ddx = 0;
-   ddy = dy*gRandom->Rndm();
+   ddy = dy*rng->Rndm();
    j   = cell/fNpx;
    i   = cell%fNpx;
    xrandom = fXmin +dx*i +ddx;
@@ -1043,4 +1044,3 @@ Double_t TF2::CentralMoment2(Double_t nx, Double_t ax, Double_t bx, Double_t ny,
    TF2 fnc("TF2_ExpValHelper",Form("%s*pow(x-%f,%f)*pow(y-%f,%f)",GetName(),xbar,nx,ybar,ny));
    return fnc.Integral(ax,bx,ay,by,epsilon)/norm;
 }
-

--- a/hist/hist/src/TF3.cxx
+++ b/hist/hist/src/TF3.cxx
@@ -321,7 +321,7 @@ Double_t TF3::GetMaximumXYZ(Double_t &x, Double_t &y, Double_t &z)
 ///  points (SetNpx, SetNpy, SetNpz) such that the peak is correctly tabulated
 ///  at several points.
 
-void TF3::GetRandom3(Double_t &xrandom, Double_t &yrandom, Double_t &zrandom)
+void TF3::GetRandom3(Double_t &xrandom, Double_t &yrandom, Double_t &zrandom, TRandom * rng)
 {
    //  Check if integral array must be build
    Int_t i,j,k,cell;
@@ -366,14 +366,15 @@ void TF3::GetRandom3(Double_t &xrandom, Double_t &yrandom, Double_t &zrandom)
 
 // return random numbers
    Double_t r;
-   r    = gRandom->Rndm();
+   if (!rng) rng = gRandom;
+   r    = rng->Rndm();
    cell = TMath::BinarySearch(ncells,fIntegral.data(),r);
    k    = cell/(fNpx*fNpy);
    j    = (cell -k*fNpx*fNpy)/fNpx;
    i    = cell -fNpx*(j +fNpy*k);
-   xrandom = fXmin +dx*i +dx*gRandom->Rndm();
-   yrandom = fYmin +dy*j +dy*gRandom->Rndm();
-   zrandom = fZmin +dz*k +dz*gRandom->Rndm();
+   xrandom = fXmin +dx*i +dx*rng->Rndm();
+   yrandom = fYmin +dy*j +dy*rng->Rndm();
+   zrandom = fZmin +dz*k +dz*rng->Rndm();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3431,6 +3431,11 @@ void TH1::DoFillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stri
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram following distribution in function fname.
 ///
+///  @param fname  : Function name used for filling the historam
+///  @param ntimes : number of times the histogram is filled
+///  @param rng    : (optional) Random number generator used to sample
+///
+///
 /// The distribution contained in the function fname (TF1) is integrated
 /// over the channel contents for the bin range of this histogram.
 /// It is normalized to 1.
@@ -3443,7 +3448,7 @@ void TH1::DoFillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stri
 ///
 /// One can also call TF1::GetRandom to get a random variate from a function.
 
-void TH1::FillRandom(const char *fname, Int_t ntimes)
+void TH1::FillRandom(const char *fname, Int_t ntimes, TRandom * rng)
 {
    Int_t bin, binx, ibin, loop;
    Double_t r1, x;
@@ -3483,7 +3488,7 @@ void TH1::FillRandom(const char *fname, Int_t ntimes)
 
    //   --------------Start main loop ntimes
    for (loop=0;loop<ntimes;loop++) {
-      r1 = gRandom->Rndm();
+      r1 = (rng) ? rng->Rndm() : gRandom->Rndm();
       ibin = TMath::BinarySearch(nbinsx,&integral[0],r1);
       //binx = 1 + ibin;
       //x    = xAxis->GetBinCenter(binx); //this is not OK when SetBuffer is used
@@ -3496,6 +3501,10 @@ void TH1::FillRandom(const char *fname, Int_t ntimes)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram following distribution in histogram h.
+///
+///  @param h      : Histogram  pointer used for smpling random number
+///  @param ntimes : number of times the histogram is filled
+///  @param rng    : (optional) Random number generator used for sampling
 ///
 /// The distribution contained in the histogram h (TH1) is integrated
 /// over the channel contents for the bin range of this histogram.
@@ -3510,7 +3519,7 @@ void TH1::FillRandom(const char *fname, Int_t ntimes)
 /// in this case we simply use a poisson distribution where
 /// the mean value per bin = bincontent/integral.
 
-void TH1::FillRandom(TH1 *h, Int_t ntimes)
+void TH1::FillRandom(TH1 *h, Int_t ntimes, TRandom * rng)
 {
    if (!h) { Error("FillRandom", "Null histogram"); return; }
    if (fDimension != h->GetDimension()) {
@@ -3534,7 +3543,7 @@ void TH1::FillRandom(TH1 *h, Int_t ntimes)
          Double_t sumgen = 0;
          for (Int_t bin=first;bin<=last;bin++) {
             Double_t mean = h->RetrieveBinContent(bin)*ntimes/sumw;
-            Double_t cont = (Double_t)gRandom->Poisson(mean);
+            Double_t cont = (rng) ? rng->Poisson(mean) : gRandom->Poisson(mean);
             sumgen += cont;
             AddBinContent(bin,cont);
             if (fSumw2.fN) fSumw2.fArray[bin] += cont;
@@ -3556,7 +3565,7 @@ void TH1::FillRandom(TH1 *h, Int_t ntimes)
             // remove extra entries
             i =  Int_t(sumgen+0.5);
             while( i > ntimes) {
-               Double_t x = h->GetRandom();
+               Double_t x = h->GetRandom(rng);
                Int_t ibin = fXaxis.FindBin(x);
                Double_t y = RetrieveBinContent(ibin);
                // skip in case bin is empty
@@ -4849,12 +4858,14 @@ void TH1::GetBinXYZ(Int_t binglobal, Int_t &binx, Int_t &biny, Int_t &binz) cons
 /// This function checks if the bins integral exists. If not, the integral
 /// is evaluated, normalized to one.
 ///
+/// @param rng (optional) Random number generator pointer used (default is gRandom)
+///
 /// The integral is automatically recomputed if the number of entries
 /// is not the same then when the integral was computed.
 /// NB Only valid for 1-d histograms. Use GetRandom2 or 3 otherwise.
 /// If the histogram has a bin with negative content a NaN is returned
 
-Double_t TH1::GetRandom() const
+Double_t TH1::GetRandom(TRandom * rng) const
 {
    if (fDimension > 1) {
       Error("GetRandom","Function only valid for 1-d histograms");
@@ -4873,7 +4884,7 @@ Double_t TH1::GetRandom() const
    // return a NaN in case some bins have negative content
    if (integral == TMath::QuietNaN() ) return TMath::QuietNaN();
 
-   Double_t r1 = gRandom->Rndm();
+   Double_t r1 = (rng) ? rng->Rndm() : gRandom->Rndm();
    Int_t ibin = TMath::BinarySearch(nbinsx,fIntegral,r1);
    Double_t x = GetBinLowEdge(ibin+1);
    if (r1 > fIntegral[ibin]) x +=

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -1078,12 +1078,12 @@ Double_t TH2::GetCovariance(Int_t axis1, Int_t axis2) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return 2 random numbers along axis x and y distributed according
-/// the cell-contents of a 2-dim histogram
+/// to the cell-contents of this 2-dim histogram
 /// return a NaN if the histogram has a bin with negative content
 ///
-/// @param x  reference to random generated x value
-/// @param y  reference to random generated x value
-/// @param rng (optional) Random number generator pointer used (default is gRandom)
+/// @param[out] x  reference to random generated x value
+/// @param[out] y  reference to random generated x value
+/// @param[in] rng (optional) Random number generator pointer used (default is gRandom)
 
 void TH2::GetRandom2(Double_t &x, Double_t &y, TRandom * rng)
 {

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -585,6 +585,10 @@ void TH2::FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram following distribution in function fname.
 ///
+///  @param fname  : Function name used for filling the historam
+///  @param ntimes : number of times the histogram is filled
+///  @param rng    : (optional) Random number generator used to sample
+///
 ///   The distribution contained in the function fname (TF2) is integrated
 ///   over the channel contents.
 ///   It is normalized to 1.
@@ -596,7 +600,7 @@ void TH2::FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double
 ///
 ///  One can also call TF2::GetRandom2 to get a random variate from a function.
 
-void TH2::FillRandom(const char *fname, Int_t ntimes)
+void TH2::FillRandom(const char *fname, Int_t ntimes, TRandom * rng)
 {
    Int_t bin, binx, biny, ibin, loop;
    Double_t r1, x, y;
@@ -646,7 +650,7 @@ void TH2::FillRandom(const char *fname, Int_t ntimes)
 
    // Start main loop ntimes
    for (loop=0;loop<ntimes;loop++) {
-      r1 = gRandom->Rndm();
+      r1 = (rng) ? rng->Rndm() : gRandom->Rndm();
       ibin = TMath::BinarySearch(nbins,&integral[0],r1);
       biny = ibin/nbinsx;
       binx = 1 + ibin - nbinsx*biny;
@@ -662,6 +666,10 @@ void TH2::FillRandom(const char *fname, Int_t ntimes)
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram following distribution in histogram h.
 ///
+///  @param h      : Histogram  pointer used for smpling random number
+///  @param ntimes : number of times the histogram is filled
+///  @param rng    : (optional) Random number generator used for sampling
+///
 ///   The distribution contained in the histogram h (TH2) is integrated
 ///   over the channel contents.
 ///   It is normalized to 1.
@@ -671,7 +679,7 @@ void TH2::FillRandom(const char *fname, Int_t ntimes)
 ///     - Fill histogram channel
 ///   ntimes random numbers are generated
 
-void TH2::FillRandom(TH1 *h, Int_t ntimes)
+void TH2::FillRandom(TH1 *h, Int_t ntimes, TRandom * rng)
 {
    if (!h) { Error("FillRandom", "Null histogram"); return; }
    if (fDimension != h->GetDimension()) {
@@ -684,7 +692,7 @@ void TH2::FillRandom(TH1 *h, Int_t ntimes)
    Double_t x,y;
    TH2 *h2 = (TH2*)h;
    for (loop=0;loop<ntimes;loop++) {
-      h2->GetRandom2(x,y);
+      h2->GetRandom2(x,y,rng);
       Fill(x,y);
    }
 }
@@ -717,7 +725,7 @@ void TH2::DoFitSlices(bool onX,
    if (lastbin < 0 || lastbin > nbins + 1) lastbin = nbins + 1;
    if (lastbin < firstbin) {firstbin = 0; lastbin = nbins + 1;}
 
-   
+
    TString opt = option;
    TString proj_opt = "e";
    Int_t i1 = opt.Index("[");
@@ -761,11 +769,11 @@ void TH2::DoFitSlices(bool onX,
    const TArrayD *bins = outerAxis.GetXbins();
    // outer axis boudaries used for creating reported histograms are different
    // than the limits used in the projection loop (firstbin,lastbin)
-   Int_t firstOutBin = outerAxis.TestBit(TAxis::kAxisRange) ? std::max(firstbin,1) : 1; 
+   Int_t firstOutBin = outerAxis.TestBit(TAxis::kAxisRange) ? std::max(firstbin,1) : 1;
    Int_t lastOutBin = outerAxis.TestBit(TAxis::kAxisRange) ?  std::min(lastbin,outerAxis.GetNbins() ) : outerAxis.GetNbins();
    Int_t nOutBins = lastOutBin-firstOutBin+1;
    // merge bins if use nstep > 1 and fixed bins
-   if (bins->fN == 0) nOutBins /= nstep;  
+   if (bins->fN == 0) nOutBins /= nstep;
    for (ipar=0;ipar<npar;ipar++) {
       snprintf(name,2000,"%s_%d",GetName(),ipar);
       snprintf(title,2000,"Fitted value of par[%d]=%s",ipar,f1->GetParName(ipar));
@@ -831,7 +839,7 @@ void TH2::DoFitSlices(bool onX,
       }
       // don't need to delete hp. If histogram has the same name it is re-used in TH2::Projection
    }
-   delete hp; 
+   delete hp;
    delete [] parsave;
    delete [] name;
    delete [] title;
@@ -1072,8 +1080,12 @@ Double_t TH2::GetCovariance(Int_t axis1, Int_t axis2) const
 /// Return 2 random numbers along axis x and y distributed according
 /// the cell-contents of a 2-dim histogram
 /// return a NaN if the histogram has a bin with negative content
+///
+/// @param x  reference to random generated x value
+/// @param y  reference to random generated x value
+/// @param rng (optional) Random number generator pointer used (default is gRandom)
 
-void TH2::GetRandom2(Double_t &x, Double_t &y)
+void TH2::GetRandom2(Double_t &x, Double_t &y, TRandom * rng)
 {
    Int_t nbinsx = GetNbinsX();
    Int_t nbinsy = GetNbinsY();
@@ -1090,14 +1102,15 @@ void TH2::GetRandom2(Double_t &x, Double_t &y)
    // case histogram has negative bins
    if (integral == TMath::QuietNaN() ) { x = TMath::QuietNaN(); y = TMath::QuietNaN(); return;}
 
-   Double_t r1 = gRandom->Rndm();
+   if (!rng) rng = gRandom;
+   Double_t r1 = rng->Rndm();
    Int_t ibin = TMath::BinarySearch(nbins,fIntegral,(Double_t) r1);
    Int_t biny = ibin/nbinsx;
    Int_t binx = ibin - nbinsx*biny;
    x = fXaxis.GetBinLowEdge(binx+1);
    if (r1 > fIntegral[ibin]) x +=
       fXaxis.GetBinWidth(binx+1)*(r1-fIntegral[ibin])/(fIntegral[ibin+1] - fIntegral[ibin]);
-   y = fYaxis.GetBinLowEdge(biny+1) + fYaxis.GetBinWidth(biny+1)*gRandom->Rndm();
+   y = fYaxis.GetBinLowEdge(biny+1) + fYaxis.GetBinWidth(biny+1)*rng->Rndm();
 }
 
 

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -1091,11 +1091,11 @@ Double_t TH3::GetCovariance(Int_t axis1, Int_t axis2) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return 3 random numbers along axis x , y and z distributed according
-/// the cell-contents of a 3-dim histogram
-/// @param x  reference to random generated x value
-/// @param y  reference to random generated y value
-/// @param z  reference to random generated z value
-/// @param rng (optional) Random number generator pointer used (default is gRandom)
+/// to the cell-contents of this 3-dim histogram
+/// @param[out] x  reference to random generated x value
+/// @param[out] y  reference to random generated y value
+/// @param[out] z  reference to random generated z value
+/// @param[in] rng (optional) Random number generator pointer used (default is gRandom)
 
 void TH3::GetRandom3(Double_t &x, Double_t &y, Double_t &z, TRandom * rng)
 {

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -651,6 +651,10 @@ Int_t TH3::Fill(Double_t x, Double_t y, const char *namez, Double_t w)
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram following distribution in function fname.
 ///
+///  @param fname  : Function name used for filling the historam
+///  @param ntimes : number of times the histogram is filled
+///  @param rng    : (optional) Random number generator used to sample
+///
 ///   The distribution contained in the function fname (TF1) is integrated
 ///   over the channel contents.
 ///   It is normalized to 1.
@@ -666,7 +670,7 @@ Int_t TH3::Fill(Double_t x, Double_t y, const char *namez, Double_t w)
 ///
 ///  One can also call TF1::GetRandom to get a random variate from a function.
 
-void TH3::FillRandom(const char *fname, Int_t ntimes)
+void TH3::FillRandom(const char *fname, Int_t ntimes, TRandom * rng)
 {
    Int_t bin, binx, biny, binz, ibin, loop;
    Double_t r1, x, y,z, xv[3];
@@ -729,7 +733,7 @@ void TH3::FillRandom(const char *fname, Int_t ntimes)
    if (fDimension < 2) nbinsy = -1;
    if (fDimension < 3) nbinsz = -1;
    for (loop=0;loop<ntimes;loop++) {
-      r1 = gRandom->Rndm();
+      r1 = (rng) ? rng->Rndm() : gRandom->Rndm();
       ibin = TMath::BinarySearch(nbins,&integral[0],r1);
       binz = ibin/nxy;
       biny = (ibin - nxy*binz)/nbinsx;
@@ -748,6 +752,10 @@ void TH3::FillRandom(const char *fname, Int_t ntimes)
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram following distribution in histogram h.
 ///
+///  @param h      : Histogram  pointer used for smpling random number
+///  @param ntimes : number of times the histogram is filled
+///  @param rng    : (optional) Random number generator used for sampling
+///
 ///   The distribution contained in the histogram h (TH3) is integrated
 ///   over the channel contents.
 ///   It is normalized to 1.
@@ -757,7 +765,7 @@ void TH3::FillRandom(const char *fname, Int_t ntimes)
 ///     - Fill histogram channel
 ///   ntimes random numbers are generated
 
-void TH3::FillRandom(TH1 *h, Int_t ntimes)
+void TH3::FillRandom(TH1 *h, Int_t ntimes, TRandom * rng)
 {
    if (!h) { Error("FillRandom", "Null histogram"); return; }
    if (fDimension != h->GetDimension()) {
@@ -770,7 +778,7 @@ void TH3::FillRandom(TH1 *h, Int_t ntimes)
    Int_t loop;
    Double_t x,y,z;
    for (loop=0;loop<ntimes;loop++) {
-      h3->GetRandom3(x,y,z);
+      h3->GetRandom3(x,y,z,rng);
       Fill(x,y,z);
    }
 }
@@ -1084,8 +1092,12 @@ Double_t TH3::GetCovariance(Int_t axis1, Int_t axis2) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return 3 random numbers along axis x , y and z distributed according
 /// the cell-contents of a 3-dim histogram
+/// @param x  reference to random generated x value
+/// @param y  reference to random generated y value
+/// @param z  reference to random generated z value
+/// @param rng (optional) Random number generator pointer used (default is gRandom)
 
-void TH3::GetRandom3(Double_t &x, Double_t &y, Double_t &z)
+void TH3::GetRandom3(Double_t &x, Double_t &y, Double_t &z, TRandom * rng)
 {
    Int_t nbinsx = GetNbinsX();
    Int_t nbinsy = GetNbinsY();
@@ -1104,7 +1116,8 @@ void TH3::GetRandom3(Double_t &x, Double_t &y, Double_t &z)
    // case histogram has negative bins
    if (integral == TMath::QuietNaN() ) { x = TMath::QuietNaN(); y = TMath::QuietNaN(); z = TMath::QuietNaN(); return;}
 
-   Double_t r1 = gRandom->Rndm();
+   if (!rng) rng = gRandom;
+   Double_t r1 = rng->Rndm();
    Int_t ibin = TMath::BinarySearch(nbins,fIntegral,(Double_t) r1);
    Int_t binz = ibin/nxy;
    Int_t biny = (ibin - nxy*binz)/nbinsx;
@@ -1112,8 +1125,8 @@ void TH3::GetRandom3(Double_t &x, Double_t &y, Double_t &z)
    x = fXaxis.GetBinLowEdge(binx+1);
    if (r1 > fIntegral[ibin]) x +=
       fXaxis.GetBinWidth(binx+1)*(r1-fIntegral[ibin])/(fIntegral[ibin+1] - fIntegral[ibin]);
-   y = fYaxis.GetBinLowEdge(biny+1) + fYaxis.GetBinWidth(biny+1)*gRandom->Rndm();
-   z = fZaxis.GetBinLowEdge(binz+1) + fZaxis.GetBinWidth(binz+1)*gRandom->Rndm();
+   y = fYaxis.GetBinLowEdge(biny+1) + fYaxis.GetBinWidth(biny+1)*rng->Rndm();
+   z = fZaxis.GetBinLowEdge(binz+1) + fZaxis.GetBinWidth(binz+1)*rng->Rndm();
 }
 
 


### PR DESCRIPTION

Improve also TF1::GetRandom to control log(linear) scale when computing the tabulated CDF
used for generating the random numbers. This fixes ROOT-9583