### PR TITLE
[geom] fix pcon/pgon TBuffer3D filling (ROOT-11015)

### DIFF
--- a/geom/geom/src/TGeoPcon.cxx
+++ b/geom/geom/src/TGeoPcon.cxx
@@ -1087,7 +1087,7 @@ void TGeoPcon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
 
    // outside, number of polygons: (nz-1)*(n-1)
    for (Int_t k = 0; k < (nz - 1); k++) {
-      indx1 = k*n;
+      indx1 = k*(n-1);
       indx2 = nz*(n-1) + n*2 + k*n;
       for (j = 0; j < n-1; j++) {
          buff.fPols[indx++] = c;

--- a/geom/geom/src/TGeoPgon.cxx
+++ b/geom/geom/src/TGeoPgon.cxx
@@ -1695,7 +1695,7 @@ void TGeoPgon::SetSegsAndPolsNoInside(TBuffer3D &buff) const
 
    // outside, number of polygons: (nz-1)*(n-1)
    for (Int_t k = 0; k < (nz - 1); k++) {
-      indx1 = k*n;
+      indx1 = k*(n-1);
       indx2 = nz*(n-1) + n*2 + k*n;
       for (j = 0; j < n-1; j++) {
          buff.fPols[indx++] = c;


### PR DESCRIPTION
Special algorithm is used now to produce pcon/pgon shape polygons
without inner surface (rmin==0). Where was mistake, which causes problem
when more than 2 z layers was specified.