### PR TITLE
[Tutorials] Run df10* tutorials serially in ctest.

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -436,6 +436,11 @@ set (long_running
      dataframe/df10[2-7]*
      multicore/mp103*)
 file(GLOB long_running RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${long_running})
+#--List multithreaded tutorials to run them serially
+set (multithreaded
+     dataframe/df10[2-7]*
+     multicore/mp103*)
+file(GLOB multithreaded RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${multithreaded})
 
 #---Loop over all tutorials and define the corresponding test---------
 
@@ -460,6 +465,9 @@ foreach(t ${tutorials})
   if(${t} IN_LIST long_running)
     list(APPEND labels longtest)
   endif()
+  if(${t} IN_LIST multithreaded)
+    list(APPEND labels multithreaded)
+  endif()
 
    # These tests on ARM64 need much more than 20 minutes - increase the timeout
    if(ROOT_ARCHITECTURE MATCHES arm64 OR ROOT_ARCHITECTURE MATCHES ppc64)
@@ -475,6 +483,13 @@ foreach(t ${tutorials})
                 DEPENDS tutorial-hsimple ${${tname}-depends}
                 ENVIRONMENT ${ROOT_environ}
                 TIMEOUT ${thisTestTimeout})
+
+  if(${t} IN_LIST multithreaded)
+    # Makes sure that this doesn't run in parallel with other multithreaded tutorials, and that cmake doesn't start too
+    # many other tests. That we use 4 processors is actually a lie, because IMT takes whatever it finds.
+    # However, even this poor indication of MT behaviour is a good hint for cmake to reduce congestion.
+    set_tests_properties(tutorial-${tname} PROPERTIES RESOURCE_LOCK multithreaded PROCESSORS 4)
+  endif()
 endforeach()
 
 #---Loop over all MPI tutorials and define the corresponding test---------
@@ -607,6 +622,9 @@ if(ROOT_pyroot_FOUND)
     if(${t} IN_LIST long_running)
       list(APPEND labels longtest)
     endif()
+    if(${t} IN_LIST multithreaded)
+      list(APPEND labels multithreaded)
+    endif()
 
     string(REPLACE ".py" "" tname ${t})
     string(REPLACE "/" "-" tname ${tname})
@@ -638,5 +656,12 @@ if(ROOT_pyroot_FOUND)
                 ENVIRONMENT ${ROOT_environ}
                 PYTHON_DEPS ${python_deps}
                 ${py_will_fail})
+
+    if(${t} IN_LIST multithreaded)
+      # Makes sure that this doesn't run in parallel with other multithreaded tutorials, and that cmake doesn't start too
+      # many other tests. That we use 4 processors is actually a lie, because IMT takes whatever it finds.
+      # However, even this poor indication of MT behaviour is a good hint for cmake to reduce congestion.
+      set_tests_properties(${tutorial_name} PROPERTIES RESOURCE_LOCK multithreaded PROCESSORS 4)
+    endif()
   endforeach()
 endif()


### PR DESCRIPTION
Since all df10* tutorials use IMT(hardware concurrency), it's
inefficient to run them in parallel. This regularly brings us into
timeouts in the nightlies.