### PR TITLE
[webgui] improve CEF/QWebEngine components

### DIFF
--- a/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
+++ b/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
@@ -49,7 +49,7 @@ public:
 
    void CloseBrowser();
 
-   bool WaitForContent(int tmout_sec);
+   bool WaitForContent(int tmout_sec, const std::string &extra_args);
 
    static void AddCreator();
 

--- a/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
+++ b/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
@@ -38,8 +38,6 @@ protected:
 
    CefRefPtr<CefBrowser> fBrowser; ///< associated browser
 
-   std::string fContent;  ///< dump content of batch htmnl page
-
 public:
    RCefWebDisplayHandle(const std::string &url) : ROOT::Experimental::RWebDisplayHandle(url) {}
 
@@ -50,10 +48,6 @@ public:
    void SetBrowser(CefRefPtr<CefBrowser> br) { if (IsValid()) fBrowser = br; }
 
    bool WaitForContent(int tmout_sec);
-
-   void SetContent(const std::string &cont) { if (IsValid()) fContent = cont; }
-
-   std::string GetDumpContent() const override { return fContent; }
 
    static void AddCreator();
 

--- a/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
+++ b/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
@@ -47,6 +47,8 @@ public:
 
    void SetBrowser(CefRefPtr<CefBrowser> br) { if (IsValid()) fBrowser = br; }
 
+   void CloseBrowser();
+
    bool WaitForContent(int tmout_sec);
 
    static void AddCreator();

--- a/gui/cefdisplay/inc/gui_handler.h
+++ b/gui/cefdisplay/inc/gui_handler.h
@@ -19,6 +19,7 @@
 #include "include/cef_client.h"
 #include "include/wrapper/cef_resource_manager.h"
 #include <list>
+#include <vector>
 
 class THttpServer;
 
@@ -29,17 +30,18 @@ class GuiHandler : public CefClient,
                    public CefRequestHandler,
                    public CefResourceRequestHandler {
 protected:
-   THttpServer *fServer{nullptr};
-   bool fUseViews{false};
-   int fConsole{0};
-   // List of existing browser windows. Only accessed on the CEF UI thread.
-   typedef std::list<CefRefPtr<CefBrowser>> BrowserList;
-   BrowserList browser_list_;
+
+   bool fUseViews{false};   ///<! if view framework is used, required for true headless mode
+   int fConsole{0};         ///<! console parameter, assigned via WebGui.Console rootrc parameter
+   typedef std::list<CefRefPtr<CefBrowser>> BrowserList; ///<! List of existing browser windows. Only accessed on the CEF UI thread.
+   BrowserList fBrowserList;
+
+   std::vector<THttpServer *> fServers;
 
    bool is_closing_;
 
 public:
-   explicit GuiHandler(THttpServer *serv = nullptr, bool use_views = false);
+   explicit GuiHandler(bool use_views = false);
 
    // Provide access to the single global instance of this object.
    // static BaseHandler *GetInstance();
@@ -72,6 +74,7 @@ public:
 
    bool IsClosing() const { return is_closing_; }
 
+   // CefRequestHandler methods:
    virtual CefRefPtr<CefResourceRequestHandler> GetResourceRequestHandler(
          CefRefPtr<CefBrowser> browser,
          CefRefPtr<CefFrame> frame,
@@ -81,6 +84,7 @@ public:
          const CefString& request_initiator,
          bool& disable_default_handling) OVERRIDE { return this; }
 
+   // CefResourceRequestHandler methods:
    virtual cef_return_value_t OnBeforeResourceLoad(
          CefRefPtr<CefBrowser> browser,
          CefRefPtr<CefFrame> frame,
@@ -93,6 +97,8 @@ public:
          CefRefPtr<CefRequest> request) OVERRIDE;
 
    std::string AddBatchPage(const std::string &cont);
+
+   std::string MakePageUrl(THttpServer *serv, const std::string &addr);
 
    static bool PlatformInit();
 

--- a/gui/cefdisplay/inc/simple_app.h
+++ b/gui/cefdisplay/inc/simple_app.h
@@ -36,6 +36,7 @@ protected:
    bool fUseViewes{false};  ///<! is views framework used
    std::string fCefMain;    ///<! extra executable used for additional processes
    std::string fFirstUrl;   ///<! first URL to open
+   std::string fFirstContent; ///<! first page content open
    CefRect fFirstRect;      ///<! original width
    bool fFirstHeadless{false}; ///<! is first window is headless
    RCefWebDisplayHandle *fNextHandle{nullptr}; ///< next handle where browser will be created
@@ -45,7 +46,9 @@ protected:
    static THttpServer *gHttpServer;
 
 public:
-   SimpleApp(bool use_viewes, const std::string &cef_main, const std::string &url = "", int width = 0, int height = 0, bool headless = false);
+   SimpleApp(bool use_viewes, const std::string &cef_main,
+             const std::string &url = "", const std::string &cont = "",
+             int width = 0, int height = 0, bool headless = false);
 
    void SetNextHandle(RCefWebDisplayHandle *handle);
 
@@ -63,12 +66,11 @@ public:
 
    virtual void OnBeforeChildProcessLaunch(CefRefPtr<CefCommandLine> command_line) OVERRIDE;
 
-   void StartWindow(const std::string &url, CefRect &rect);
+   void StartWindow(const std::string &url, const std::string &cont, CefRect &rect);
 
    // CefRenderProcessHandler methods
    // virtual void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
    //                              CefRefPtr<CefV8Context> context) OVERRIDE;
-
 
    static THttpServer *GetHttpServer();
    static void SetHttpServer(THttpServer *serv);

--- a/gui/cefdisplay/inc/simple_app.h
+++ b/gui/cefdisplay/inc/simple_app.h
@@ -40,6 +40,7 @@ class SimpleApp : public CefApp,
 protected:
    bool fUseViewes{false};  ///<! is views framework used
    std::string fCefMain;    ///<! extra executable used for additional processes
+   THttpServer *fFirstServer; ///<! first server
    std::string fFirstUrl;   ///<! first URL to open
    std::string fFirstContent; ///<! first page content open
    CefRect fFirstRect;      ///<! original width
@@ -48,11 +49,9 @@ protected:
 
    CefRefPtr<GuiHandler> fGuiHandler; ///<! normal handler
 
-   static THttpServer *gHttpServer;
-
 public:
    SimpleApp(bool use_viewes, const std::string &cef_main,
-             const std::string &url = "", const std::string &cont = "",
+             THttpServer *serv = nullptr, const std::string &url = "", const std::string &cont = "",
              int width = 0, int height = 0, bool headless = false);
 
    void SetNextHandle(RCefWebDisplayHandle *handle);
@@ -87,14 +86,11 @@ public:
 #endif
 
 
-   void StartWindow(const std::string &url, const std::string &cont, CefRect &rect);
+   void StartWindow(THttpServer *serv, const std::string &url, const std::string &cont, CefRect &rect);
 
    // CefRenderProcessHandler methods
    // virtual void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
    //                              CefRefPtr<CefV8Context> context) OVERRIDE;
-
-   static THttpServer *GetHttpServer();
-   static void SetHttpServer(THttpServer *serv);
 
 private:
    // Include the default reference counting implementation.

--- a/gui/cefdisplay/inc/simple_app.h
+++ b/gui/cefdisplay/inc/simple_app.h
@@ -31,7 +31,12 @@ class THttpServer;
 class RCefWebDisplayHandle;
 
 // Implement application-level callbacks for the browser process.
-class SimpleApp : public CefApp, public CefBrowserProcessHandler /*, public CefRenderProcessHandler */ {
+class SimpleApp : public CefApp,
+#if defined(OS_LINUX)
+                  public CefPrintHandler,
+#endif
+                  /*, public CefRenderProcessHandler */
+                  public CefBrowserProcessHandler {
 protected:
    bool fUseViewes{false};  ///<! is views framework used
    std::string fCefMain;    ///<! extra executable used for additional processes
@@ -54,6 +59,11 @@ public:
 
    // CefApp methods:
    virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() OVERRIDE { return this; }
+
+#if defined(OS_LINUX)
+   // only on Linux special print handler is required to return PDF size
+   virtual CefRefPtr<CefPrintHandler> GetPrintHandler() OVERRIDE { return this; }
+#endif
    // virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() OVERRIDE { return this; }
 
    virtual void OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar) OVERRIDE;
@@ -65,6 +75,17 @@ public:
    OnBeforeCommandLineProcessing(const CefString &process_type, CefRefPtr<CefCommandLine> command_line) OVERRIDE;
 
    virtual void OnBeforeChildProcessLaunch(CefRefPtr<CefCommandLine> command_line) OVERRIDE;
+
+#if defined(OS_LINUX)
+   // CefPrintHandler methods
+   virtual CefSize GetPdfPaperSize(int device_units_per_inch) OVERRIDE { return CefSize(device_units_per_inch*8.25, device_units_per_inch*11.75); }
+   virtual bool OnPrintDialog( CefRefPtr< CefBrowser > browser, bool has_selection, CefRefPtr< CefPrintDialogCallback > callback ) OVERRIDE { return false; }
+   virtual bool OnPrintJob( CefRefPtr< CefBrowser > browser, const CefString& document_name, const CefString& pdf_file_path, CefRefPtr< CefPrintJobCallback > callback ) OVERRIDE { return false; }
+   virtual void OnPrintReset( CefRefPtr< CefBrowser > browser ) OVERRIDE {}
+   virtual void OnPrintSettings( CefRefPtr< CefBrowser > browser, CefRefPtr< CefPrintSettings > settings, bool get_defaults ) OVERRIDE {}
+   virtual void OnPrintStart( CefRefPtr< CefBrowser > browser ) OVERRIDE {}
+#endif
+
 
    void StartWindow(const std::string &url, const std::string &cont, CefRect &rect);
 

--- a/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
+++ b/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
@@ -89,17 +89,12 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> RCefWebDisplayHandle::Cef
    auto handle = std::make_unique<RCefWebDisplayHandle>(args.GetFullUrl());
 
    if (fCefApp) {
-      if (SimpleApp::GetHttpServer() != args.GetHttpServer()) {
-         R__ERROR_HERE("CEF") << "CEF do not allows to use different THttpServer instances";
-         return nullptr;
-      }
-
       fCefApp->SetNextHandle(handle.get());
 
       CefRect rect((args.GetX() > 0) ? args.GetX() : 0, (args.GetY() > 0) ? args.GetY() : 0,
             (args.GetWidth() > 0) ? args.GetWidth() : 800, (args.GetHeight() > 0) ? args.GetHeight() : 600);
 
-      fCefApp->StartWindow(args.GetFullUrl(), args.GetPageContent(), rect);
+      fCefApp->StartWindow(args.GetHttpServer(), args.GetFullUrl(), args.GetPageContent(), rect);
 
       if (args.IsHeadless())
          handle->WaitForContent(30, args.GetExtraArgs()); // 30 seconds
@@ -173,12 +168,10 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> RCefWebDisplayHandle::Cef
 
    // settings.remote_debugging_port = 7890;
 
-   SimpleApp::SetHttpServer(args.GetHttpServer());
-
    // SimpleApp implements application-level callbacks for the browser process.
    // It will create the first browser instance in OnContextInitialized() after
    // CEF has initialized.
-   fCefApp = new SimpleApp(use_views, cef_main.Data(), args.GetFullUrl(), args.GetPageContent(), args.GetWidth(), args.GetHeight(), args.IsHeadless());
+   fCefApp = new SimpleApp(use_views, cef_main.Data(), args.GetHttpServer(), args.GetFullUrl(), args.GetPageContent(), args.GetWidth(), args.GetHeight(), args.IsHeadless());
 
    fCefApp->SetNextHandle(handle.get());
 
@@ -201,7 +194,6 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> RCefWebDisplayHandle::Cef
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// Destructor
 /// Closes browser window if any
-
 
 RCefWebDisplayHandle::~RCefWebDisplayHandle()
 {

--- a/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
+++ b/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
@@ -54,7 +54,7 @@ public:
 
    virtual ~FrameSourceVisitor() = default;
 
-   void Visit( const CefString& str ) override
+   void Visit(const CefString &str) override
    {
       if (fHandle && fHandle->IsValid())
          fHandle->SetContent(str.ToString());
@@ -85,8 +85,9 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> RCefWebDisplayHandle::Cef
 
       fCefApp->StartWindow(args.GetFullUrl(), args.GetPageContent(), rect);
 
-      if (args.IsHeadless())
+      if (args.IsHeadless()) {
          handle->WaitForContent(30); // 30 seconds
+      }
 
       return handle;
    }
@@ -182,18 +183,31 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> RCefWebDisplayHandle::Cef
    return handle;
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/// Destructor
+/// Closes browser window if any
+
 
 RCefWebDisplayHandle::~RCefWebDisplayHandle()
 {
    fValid = kInvalid;
 
+   CloseBrowser();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/// Closes associated browser window
+
+
+void RCefWebDisplayHandle::CloseBrowser()
+{
    if (fBrowser) {
       auto host = fBrowser->GetHost();
       if (host) host->CloseBrowser(true);
       fBrowser = nullptr;
    }
-
 }
+
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -223,6 +237,11 @@ bool RCefWebDisplayHandle::WaitForContent(int tmout_sec)
 
       gSystem->Sleep(10); // only 10 ms sleep
    }
+
+   CloseBrowser();
+
+   // call it once here to complete browser window closing, timer is not installed in batch mode
+   CefDoMessageLoopWork();
 
    return !GetContent().empty();
 }

--- a/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
+++ b/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
@@ -56,7 +56,8 @@ public:
 
    void Visit( const CefString& str ) override
    {
-      if (fHandle) fHandle->SetContent(str.ToString());
+      if (fHandle && fHandle->IsValid())
+         fHandle->SetContent(str.ToString());
    }
 
 private:
@@ -64,8 +65,6 @@ private:
    IMPLEMENT_REFCOUNTING(FrameSourceVisitor);
    DISALLOW_COPY_AND_ASSIGN(FrameSourceVisitor);
 };
-
-
 
 
 std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> RCefWebDisplayHandle::CefCreator::Display(const ROOT::Experimental::RWebDisplayArgs &args)
@@ -201,7 +200,7 @@ bool RCefWebDisplayHandle::WaitForContent(int tmout_sec)
 
    bool did_try = false;
 
-   while ((--expired > 0) && fContent.empty()) {
+   while ((--expired > 0) && GetContent().empty()) {
 
       if (gSystem->ProcessEvents()) break; // interrupted, has to return
 
@@ -220,7 +219,7 @@ bool RCefWebDisplayHandle::WaitForContent(int tmout_sec)
       gSystem->Sleep(10); // only 10 ms sleep
    }
 
-   return !fContent.empty();
+   return !GetContent().empty();
 }
 
 

--- a/gui/cefdisplay/src/simple_app.cxx
+++ b/gui/cefdisplay/src/simple_app.cxx
@@ -368,8 +368,8 @@ void SimpleApp::OnBeforeCommandLineProcessing(const CefString &process_type, Cef
 {
    std::string name = process_type.ToString();
    std::string prog = command_line->GetProgram().ToString();
-   command_line->AppendSwitch("allow-file-access-from-files");
-   command_line->AppendSwitch("disable-web-security");
+   // command_line->AppendSwitch("allow-file-access-from-files");
+   // command_line->AppendSwitch("disable-web-security");
 
    // printf("OnBeforeCommandLineProcessing %s %s\n", name.c_str(), prog.c_str());
 //   if (fBatch) {
@@ -384,8 +384,8 @@ void SimpleApp::OnBeforeChildProcessLaunch(CefRefPtr<CefCommandLine> command_lin
    std::string newprog = fCefMain;
    command_line->SetProgram(newprog);
 
-   command_line->AppendSwitch("allow-file-access-from-files");
-   command_line->AppendSwitch("disable-web-security");
+   // command_line->AppendSwitch("allow-file-access-from-files");
+   // command_line->AppendSwitch("disable-web-security");
 
    // printf("OnBeforeChildProcessLaunch %s LastBatch %s\n", command_line->GetProgram().ToString().c_str(), fLastBatch ? "true" : "false");
 

--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -159,7 +159,11 @@ protected:
                load_finished = true; is_error = !is_ok;
             });
 
-            view->load(QUrl(fullurl));
+            const std::string &page_content = args.GetPageContent();
+            if (page_content.empty())
+               view->load(QUrl(fullurl));
+            else
+               view->setHtml(QString::fromUtf8(page_content.data(), page_content.size()), QUrl("file:///batch_page.html"));
 
             // loop here until content is configured
             while ((--expired > 0) && !get_content && !is_error) {

--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -64,7 +64,6 @@ class RQt5WebDisplayHandle : public RWebDisplayHandle {
 protected:
 
    RootWebView *fView{nullptr};  ///< pointer on widget, need to release when handle is destroyed
-   std::string fDumpContent;     ///< dump content which used in headless mode
 
    class Qt5Creator : public Creator {
       int fCounter{0}; ///< counter used to number handlers
@@ -182,7 +181,7 @@ protected:
             }
 
             if(get_content)
-               handle->SetGetDumpContent(content);
+               handle->SetContent(content);
          }
 
          return handle;
@@ -198,9 +197,6 @@ public:
       // now view can be safely destroyed
       if (fView) delete fView;
    }
-
-   void SetGetDumpContent(const std::string &cont) { fDumpContent = cont; }
-   std::string GetDumpContent() const override { return fDumpContent; }
 
    static void AddCreator()
    {

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -47,6 +47,7 @@ protected:
    EBrowserKind fKind{kNative};   ///<! id of web browser used for display
    std::string fUrl;              ///<! URL to display
    std::string fExtraArgs;        ///<! extra arguments which will be append to exec string
+   std::string fPageContent;      ///<! HTML page content
    std::string fRedirectOutput;   ///<! filename where browser output should be redirected
    bool fHeadless{false};         ///<! is browser runs in headless mode
    bool fStandalone{true};        ///<! indicates if browser should run isolated from other browser instances
@@ -93,16 +94,21 @@ public:
       return (GetBrowserKind() == kLocal) || (GetBrowserKind() == kCEF) || (GetBrowserKind() == kQt5);
    }
 
-   /// returns true if browser supports headless mode
+   /// returns true if browser supports headless (batch) mode, used for image production
    bool IsSupportHeadless() const
    {
-      return (GetBrowserKind() == kNative) || (GetBrowserKind() == kFirefox) || (GetBrowserKind() == kChrome);
+      return (GetBrowserKind() == kNative) || (GetBrowserKind() == kChrome) || (GetBrowserKind() == kCEF) || (GetBrowserKind() == kQt5);
    }
 
    /// set window url
    RWebDisplayArgs &SetUrl(const std::string &url) { fUrl = url; return *this; }
    /// returns window url
    const std::string &GetUrl() const { return fUrl; }
+
+   /// set window url
+   RWebDisplayArgs &SetPageContent(const std::string &cont) { fPageContent = cont; return *this; }
+   /// returns window url
+   const std::string &GetPageContent() const { return fPageContent; }
 
    /// Set standalone mode for running browser, default on
    /// When disabled, normal browser window (or just tab) will be started

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -102,7 +102,7 @@ public:
    /// set window url
    RWebDisplayArgs &SetUrl(const std::string &url) { fUrl = url; return *this; }
    /// returns window url
-   std::string GetUrl() const { return fUrl; }
+   const std::string &GetUrl() const { return fUrl; }
 
    /// Set standalone mode for running browser, default on
    /// When disabled, normal browser window (or just tab) will be started
@@ -113,7 +113,7 @@ public:
    /// set window url options
    RWebDisplayArgs &SetUrlOpt(const std::string &opt) { fUrlOpt = opt; return *this; }
    /// returns window url options
-   std::string GetUrlOpt() const { return fUrlOpt; }
+   const std::string &GetUrlOpt() const { return fUrlOpt; }
 
    /// append extra url options, add "&" as separator if required
    void AppendUrlOpt(const std::string &opt);

--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -27,6 +27,10 @@ namespace Experimental {
 
 class RWebDisplayHandle {
 
+   std::string fUrl; ///!< URL used to launch display
+
+   std::string fContent; ///!< page content
+
 protected:
    class Creator {
    public:
@@ -72,8 +76,6 @@ protected:
       std::string MakeProfile(std::string &exec, bool batch) override;
    };
 
-   std::string fUrl; ///!< URL used to launch display
-
    static std::map<std::string, std::unique_ptr<Creator>> &GetMap();
 
    static std::unique_ptr<Creator> &FindCreator(const std::string &name, const std::string &libname = "");
@@ -85,9 +87,10 @@ public:
    // required virtual destructor for correct cleanup at the end
    virtual ~RWebDisplayHandle() = default;
 
-   std::string GetUrl() const { return fUrl; }
+   const std::string &GetUrl() const { return fUrl; }
 
-   virtual std::string GetDumpContent() const { return ""; }
+   void SetContent(const std::string &cont) { fContent = cont; }
+   const std::string &GetContent() const { return fContent; }
 
    static std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args);
 

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -661,6 +661,19 @@ bool ROOT::Experimental::RWebDisplayHandle::ProduceImage(const std::string &fnam
    if ((args.GetBrowserKind() != RWebDisplayArgs::kCEF) && (args.GetBrowserKind() != RWebDisplayArgs::kQt5))
       args.SetBrowserKind(RWebDisplayArgs::kChrome);
 
+   // check capability of configured web display
+   if (draw_kind == "draw") {
+      if (EndsWith(".pdf") && (args.GetBrowserKind() == RWebDisplayArgs::kCEF)) {
+         R__ERROR_HERE("CanvasPainter") << "CEF do not support saving into PDF file";
+         return false;
+      }
+
+      if (EndsWith("shot.png") && (args.GetBrowserKind() != RWebDisplayArgs::kChrome)) {
+         // there is no direct screenshot in CEF or Qt5, therefore using normal PNG output
+         draw_kind = "png";
+      }
+   }
+
    TString dump_name;
    if ((draw_kind != "draw") && (args.GetBrowserKind() == RWebDisplayArgs::kChrome)) {
       dump_name = "canvasdump";

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -98,12 +98,14 @@ class RWebBrowserHandle : public RWebDisplayHandle {
    typedef pid_t browser_process_id;
 #endif
    std::string fTmpDir;         ///< temporary directory to delete at the end
-   std::string fDumpContent;    ///< dump content, used with headless mode
    bool fHasPid{false};
    browser_process_id fPid;
 
 public:
-   RWebBrowserHandle(const std::string &url, const std::string &tmpdir, const std::string &dump) : RWebDisplayHandle(url), fTmpDir(tmpdir), fDumpContent(dump)  {}
+   RWebBrowserHandle(const std::string &url, const std::string &tmpdir, const std::string &dump) : RWebDisplayHandle(url), fTmpDir(tmpdir)
+   {
+      SetContent(dump);
+   }
 
    RWebBrowserHandle(const std::string &url, const std::string &tmpdir, browser_process_id pid)
       : RWebDisplayHandle(url), fTmpDir(tmpdir), fHasPid(true), fPid(pid)
@@ -124,8 +126,6 @@ public:
       if (!fTmpDir.empty())
          gSystem->Exec((rmdir + fTmpDir).c_str());
    }
-
-   std::string GetDumpContent() const override { return fDumpContent; }
 
 };
 
@@ -503,7 +503,6 @@ std::string ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::MakeProfile(s
    return rmdir;
 }
 
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// Create web display
 /// \param args - defines where and how to display web window
@@ -763,7 +762,7 @@ try_again:
 
    if (draw_kind != "draw") {
 
-      auto dumpcont = handle->GetDumpContent();
+      auto dumpcont = handle->GetContent();
 
       if ((dumpcont.length() > 20) && (dumpcont.length() < 60) && !chrome_tmp_workaround && (args.GetBrowserKind() == RWebDisplayArgs::kChrome)) {
          // chrome creates dummy html file with mostly no content

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -681,7 +681,7 @@ bool ROOT::Experimental::RWebDisplayHandle::ProduceImage(const std::string &fnam
 
 try_again:
 
-   if (args.GetBrowserKind() == RWebDisplayArgs::kCEF) {
+   if ((args.GetBrowserKind() == RWebDisplayArgs::kCEF) || (args.GetBrowserKind() == RWebDisplayArgs::kQt5)) {
       args.SetUrl(""s);
       args.SetPageContent(filecont);
 

--- a/js/changes.md
+++ b/js/changes.md
@@ -7,6 +7,7 @@
 4. Major changes in v7 drawing: RFrame, RPalette, RColor, RStatBox, ...
 5. Fix in reading std::map member-wise
 6. Better handling of context menu position
+7. Support TASImage class - both PNG and binary content, including palette
 
 
 ## Changes in 5.8.1

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -95,7 +95,7 @@
 
    "use strict";
 
-   JSROOT.version = "dev 18/08/2020";
+   JSROOT.version = "dev 26/08/2020";
 
    JSROOT.source_dir = "";
    JSROOT.source_min = false;
@@ -1987,7 +1987,11 @@
          }
          m.GetParName = function(n) {
             if (this.fParams && this.fParams.fParNames) return this.fParams.fParNames[n];
-            if (this.fFormula && this.fFormula.fParams) return this.fFormula.fParams[n].first;
+            if (this.fFormula && this.fFormula.fParams) {
+               for (var k=0;k<this.fFormula.fParams.length;++k)
+                  if(this.fFormula.fParams[k].second == n)
+                     return this.fFormula.fParams[k].first;
+            }
             if (this.fNames && this.fNames[n]) return this.fNames[n];
             return "p"+n;
          }

--- a/js/style/JSRootPainter.css
+++ b/js/style/JSRootPainter.css
@@ -484,7 +484,7 @@
   --------------------------------------------------*/
 
 #jsroot_progressbox {
-    position: absolute;
+    position: fixed;
     min-width: 100px;
     height: auto;
     overflow: visible;
@@ -562,7 +562,7 @@
 
 /* stylesheet for enlarged canvas */
 #jsroot_enlarge_div {
-     position: absolute;
+     position: fixed;
      margin: 0px;
      border: 0px;
      padding: 0px;


### PR DESCRIPTION
1. Let run batch job without creating temporary HTML files. File content preserved in memory and just loaded directly into browser.
    - in CEF one need special resource handler
    - in QWebEngine HTML code can be directly loaded into browser
2. Support PDF file creation in CEF and QWebEngine
3. Simplify custom http handling in CEF, no need to use custom scheme handler singleton. Now many THttpServer instances can be used with CEF.
4. Update JSROOT with latest fixes