### PR TITLE
[cmake] Load ctest envvars for Python vetos

### DIFF
--- a/cmake/modules/CTestCustom.cmake
+++ b/cmake/modules/CTestCustom.cmake
@@ -34,3 +34,6 @@ include(${dir}/test/CTestCustom.cmake OPTIONAL)
 include(${dir}/roottest/CTestCustom.cmake OPTIONAL)
 include(${dir}/rootbench/CTestCustom.cmake OPTIONAL)
 include(${dir}/tutorials/CTestCustom.cmake OPTIONAL)
+
+#---Load custom environment variables for test configurations at runtime------
+include(${dir}/CTestEnvVars.cmake OPTIONAL)


### PR DESCRIPTION
Same as the backport for 6.18! Fixes the errors in the nightlies: http://cdash.cern.ch/viewTest.php?onlyfailed&buildid=21468

Coupled to https://github.com/root-project/roottest/pull/590