### PR TITLE
[PyROOT] Add deprecation warning for TTree.AsMatrix

### DIFF
--- a/README/ReleaseNotes/v624/index.md
+++ b/README/ReleaseNotes/v624/index.md
@@ -111,3 +111,7 @@ The following people have contributed to this new version:
 ## Build, Configuration and Testing Infrastructure
 
 - a new cmake variable, `CMAKE_INSTALL_PYTHONDIR`, has been added: it allows customization of the installation directory of ROOT's python modules
+
+## PyROOT
+
+- Deprecate `TTree.AsMatrix` in this release and mark for removal in v6.26. Please use instead `RDataFrame.AsNumpy`.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_ttree.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_ttree.py
@@ -65,6 +65,9 @@ def _TTreeAsMatrix(self, columns=None, exclude=None, dtype="double", return_labe
         array(, labels): Numpy array(, labels of columns)
     """
 
+    import warnings
+    warnings.warn("TTree.AsMatrix is deprecated since v6.24 and will be removed in v6.26. Please use instead RDataFrame.AsNumpy.", FutureWarning)
+
     # Import numpy lazily
     try:
         import numpy as np


### PR DESCRIPTION
Print a warning in v6.24 and mark for removal in v6.26. The feature is
replaced by RDataFrame.AsNumpy.