### PR TITLE
[Backport to v6.16][cmake] Suppress warnings for builtin xrootd

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -901,7 +901,7 @@ if(builtin_xrootd)
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-               -DCMAKE_CXX_FLAGS=${__cxxflags}
+               -DCMAKE_CXX_FLAGS=${__cxxflags}\ -w
                -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
                -DENABLE_PYTHON=OFF


### PR DESCRIPTION
The builtin xrootd version 4.8.5 has the -Werror flag in release mode,
which causes build errors with future compilers such as happened with
gcc9. The -w flag suppresses all warnings even if -Werror is set
afterwards. Future xrootd releases (4.12 and later) have the -Werror
flag removed in release mode.