### PR TITLE
[Core] Attempt to make TThreadExecutor usable even if (build option) IMT=OFF

### DIFF
--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -11,6 +11,7 @@
 ROOT_LINKER_LIBRARY(Imt
     src/base.cxx
     src/TTaskGroup.cxx
+    src/TThreadExecutor.cxx
   BUILTINS
     TBB
 )
@@ -51,6 +52,18 @@ if(imt)
   set_target_properties(Imt PROPERTIES COMPILE_FLAGS "${TBB_CXXFLAGS}")
 
   ROOT_ADD_TEST_SUBDIRECTORY(test)
+else()
+  ROOT_GENERATE_DICTIONARY(G__Imt STAGE1
+    ROOT/TThreadExecutor.hxx
+    LINKDEF
+      LinkDef.h
+    MODULE
+      Imt
+    DEPENDENCIES
+      Core
+      Thread
+  )
+
 endif()
 
 ROOT_INSTALL_HEADERS()

--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -50,8 +50,6 @@ if(imt)
   target_include_directories(Imt SYSTEM PRIVATE ${TBB_INCLUDE_DIRS})
   target_link_libraries(Imt PRIVATE ${TBB_LIBRARIES})
   set_target_properties(Imt PROPERTIES COMPILE_FLAGS "${TBB_CXXFLAGS}")
-
-  ROOT_ADD_TEST_SUBDIRECTORY(test)
 else()
   ROOT_GENERATE_DICTIONARY(G__Imt STAGE1
     ROOT/TThreadExecutor.hxx
@@ -65,5 +63,7 @@ else()
   )
 
 endif()
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)
 
 ROOT_INSTALL_HEADERS()

--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -14,16 +14,15 @@
 
 #include "RConfigure.h"
 
-// exclude in case ROOT does not have IMT support
 #ifndef R__USE_IMT
-// No need to error out for dictionaries.
-# if !defined(__ROOTCLING__) && !defined(G__DICTIONARY)
-#  error "Cannot use ROOT::TThreadExecutor without defining R__USE_IMT."
-# endif
+namespace ROOT { namespace Internal {
+   class RTaskArenaWrapper;
+} }
 #else
+#include "RTaskArena.hxx"
+#endif
 
 #include "ROOT/TExecutor.hxx"
-#include "RTaskArena.hxx"
 #include "TError.h"
 #include <functional>
 #include <memory>
@@ -447,5 +446,4 @@ namespace ROOT {
 
 } // namespace ROOT
 
-#endif   // R__USE_IMT
 #endif

--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -3,7 +3,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
 #endif
+#ifdef R__USE_IMT
 #include "tbb/tbb.h"
+#endif
 #if !defined(_MSC_VER)
 #pragma GCC diagnostic pop
 #endif
@@ -100,8 +102,66 @@ and transformations guarantee that each entry is processed from the beginning to
 the end without being interrupted by the processing of outer tasks.
 */
 
+// Run everything serially in case ROOT does not have IMT support
+#ifndef R__USE_IMT
+
+namespace {
+
+/// A helper function to implement the TThreadExecutor::ParallelReduce methods
+template<typename T>
+static T ParallelReduceHelper(const std::vector<T> &objs, const std::function<T(T a, T b)> &redfunc)
+{
+  return std::accumulate(objs.begin(), objs.end(), 0., redfunc);
+}
+
+}
+
 namespace ROOT {
-namespace Internal {
+
+//////////////////////////////////////////////////////////////////////////
+/// Class constructor.
+/// If the scheduler is active (e.g. because another TThreadExecutor is in flight, or ROOT::EnableImplicitMT() was
+/// called), work with the current pool of threads.
+/// If not, initialize the pool of threads, spawning nThreads. nThreads' default value, 0, initializes the
+/// pool with as many logical threads as are available in the system (see NLogicalCores in RTaskArenaWrapper.cxx).
+///
+/// At construction time, TThreadExecutor automatically enables ROOT's thread-safety locks as per calling
+/// ROOT::EnableThreadSafety().
+TThreadExecutor::TThreadExecutor(UInt_t /*nThreads*/)
+{
+
+}
+
+void TThreadExecutor::ParallelFor(unsigned int start, unsigned int end, unsigned step,
+                                  const std::function<void(unsigned int i)> &f)
+{
+   for (auto i = start; i < end; i += step) {
+      f(i);
+   }
+}
+
+double TThreadExecutor::ParallelReduce(const std::vector<double> &objs,
+                                       const std::function<double(double a, double b)> &redfunc)
+{
+   return ParallelReduceHelper<double>(objs, redfunc);
+}
+
+float TThreadExecutor::ParallelReduce(const std::vector<float> &objs,
+                                      const std::function<float(float a, float b)> &redfunc)
+{
+   return ParallelReduceHelper<float>(objs, redfunc);
+}
+
+unsigned TThreadExecutor::GetPoolSize()
+{
+   return 0;
+}
+
+} // namespace ROOT
+
+#else
+
+namespace {
 
 /// A helper function to implement the TThreadExecutor::ParallelReduce methods
 template<typename T>
@@ -121,7 +181,9 @@ static T ParallelReduceHelper(const std::vector<T> &objs, const std::function<T(
 
 }
 
-} // End NS Internal
+}
+
+namespace ROOT {
 
 //////////////////////////////////////////////////////////////////////////
 /// Class constructor.
@@ -150,13 +212,13 @@ void TThreadExecutor::ParallelFor(unsigned int start, unsigned int end, unsigned
 double TThreadExecutor::ParallelReduce(const std::vector<double> &objs,
                                        const std::function<double(double a, double b)> &redfunc)
 {
-   return fTaskArenaW->Access().execute([&] { return ROOT::Internal::ParallelReduceHelper<double>(objs, redfunc); });
+   return fTaskArenaW->Access().execute([&] { return ParallelReduceHelper<double>(objs, redfunc); });
 }
 
 float TThreadExecutor::ParallelReduce(const std::vector<float> &objs,
                                       const std::function<float(float a, float b)> &redfunc)
 {
-   return fTaskArenaW->Access().execute([&] { return ROOT::Internal::ParallelReduceHelper<float>(objs, redfunc); });
+   return fTaskArenaW->Access().execute([&] { return ParallelReduceHelper<float>(objs, redfunc); });
 }
 
 unsigned TThreadExecutor::GetPoolSize()
@@ -165,3 +227,5 @@ unsigned TThreadExecutor::GetPoolSize()
 }
 
 } // namespace ROOT
+
+#endif

--- a/core/imt/test/testRTaskArena.cxx
+++ b/core/imt/test/testRTaskArena.cxx
@@ -1,5 +1,4 @@
 #include "TROOT.h"
-#include "ROOT/RTaskArena.hxx"
 #include "ROOT/TThreadExecutor.hxx"
 #include <fstream>
 #include <random>
@@ -8,9 +7,10 @@
 #include <condition_variable>
 #include <mutex>
 #include "gtest/gtest.h"
-#include "tbb/task_arena.h"
 
 #ifdef R__USE_IMT
+#include "ROOT/RTaskArena.hxx"
+#include "tbb/task_arena.h"
 
 const unsigned maxConcurrency = ROOT::Internal::LogicalCPUBandwithControl();
 std::mt19937 randGenerator(0);                                      // seed the generator
@@ -200,6 +200,7 @@ TEST(RTaskArena, ThreadSafety) {
    }));
 }
 
+#endif //IMT
 
 // Have many threads create TThreadExecutor instances in parallel, which
 // each increment atomic counters in parallel.
@@ -233,4 +234,3 @@ TEST(TThreadExecutor, ThreadSafety) {
    EXPECT_TRUE(std::equal(counters.begin(), counters.end(), target.begin()));
 }
 
-#endif

--- a/core/imt/test/testTFuture.cxx
+++ b/core/imt/test/testTFuture.cxx
@@ -1,11 +1,11 @@
 #include "TROOT.h"
-#include "ROOT/TFuture.hxx"
 
 #include <future>
 
 #include "gtest/gtest.h"
 
 #ifdef R__USE_IMT
+#include "ROOT/TFuture.hxx"
 
 using namespace ROOT::Experimental;
 


### PR DESCRIPTION
It would be amazing if one could code against TThreadExecutor even if IMT is off. Otherwise, one would have to `ifdef` the hell out of all code where IMT should be used.
To make TTEx usable for e.g. RooFit, I `ifdef`ed a bit in the TThreadExecutor implementation:
- I replaced `parallel_for` by `for`, and `parallel_reduce` by `std::accumulate`.
- I enabled the tests in `core/imt` irrespective of whether IMT is available.
- Things that just cannot work in those tests were anyway protected by `ifdef`, but I had to move some `#include`s around.
- `TThreadExecutor::ForEach` works, but I wonder if we need more tests that run *both* with and without IMT.