### PR TITLE
Interpreter lock states

### DIFF
--- a/core/base/inc/TVirtualRWMutex.h
+++ b/core/base/inc/TVirtualRWMutex.h
@@ -52,6 +52,18 @@ public:
       virtual ~State(); // implemented in TVirtualMutex.cxx
    };
 
+   struct StateAndRecurseCount {
+      /// State of gCoreMutex when the first interpreter-related function was invoked.
+      std::unique_ptr<ROOT::TVirtualRWMutex::State> fState;
+
+      /// Interpreter-related functions will push the "entry" lock state to *this.
+      /// Recursive calls will do that, too - but we must only forget about the lock
+      /// state once this recursion count went to 0.
+      Int_t fRecurseCount = 0;
+
+      operator bool() const { return (bool)fState; }
+   };
+
    /// \class StateDelta
    /// State as returned by `GetStateDelta()` that can be passed to
    /// `Restore()`

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -9385,12 +9385,12 @@ void TCling::ApplyToInterpreterMutex(void *delta)
          R__ASSERT(fInitialMutex.fRecurseCount == 0 && "Inconsistent state of fInitialMutex!  Another thread within Interpreter critical section.");
          std::swap(fInitialMutex, typedDelta->fInitialState);
       } else {
-         // This case happens whenever, EnableThreadSafety is first called from
+         // This case happens when EnableThreadSafety is first called from
          // the interpreter function we just handled.
-         // Since thread safetely was not enabled at the time we rewinded, there was
+         // Since thread safety was not enabled at the time we rewound, there was
          // no lock taken and even-though we should be locking the rest of this
          // interpreter handling/modifying code (since there might be threads in
-         // flight), we can't because there would be any lock guard to release the
+         // flight), we can't because there would not be any lock guard to release the
          // locks
          if (fInitialMutex || fInitialMutex.fRecurseCount !=0)
             Error("ApplyToInterpreterMutex",

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -165,7 +165,14 @@ private: // Data Members
       operator bool() const { return (bool)fState; }
    };
 
-   std::vector<MutexStateAndRecurseCount> fInitialMutex{1};
+   struct MutexStateAndRecurseCountDelta {
+      using StateDelta = ROOT::TVirtualRWMutex::StateDelta;
+
+      MutexStateAndRecurseCount   fInitialState;
+      std::unique_ptr<StateDelta> fDelta;
+   };
+
+   MutexStateAndRecurseCount fInitialMutex;
 
    DeclId_t GetDeclId(const llvm::GlobalValue *gv) const;
 

--- a/core/thread/src/TReentrantRWLock.cxx
+++ b/core/thread/src/TReentrantRWLock.cxx
@@ -327,7 +327,7 @@ TReentrantRWLock<MutexT, RecurseCountsT>::Rewind(const State &earlierState) {
       // but that's weird, that does not account to other change in fReaders during between
       // the snapshot and the rewind ... humm unless the lock held is a WriteLock
       // (the actual use case) in which case there is no other thread that can update fReaders
-      // and we also assume that the "user code" is balance and release all read locks it takes.
+      // and we also assume that the "user code" is balanced and release all read locks it takes.
       fReaders = typedState.fReadersCount + 1;
       // Release this thread's reader lock(s)
       ReadUnLock(hint);

--- a/core/thread/test/CMakeLists.txt
+++ b/core/thread/test/CMakeLists.txt
@@ -8,4 +8,4 @@ ROOT_ADD_UNITTEST_DIR(Core Thread Hist)
 
 ROOT_ADD_GTEST(testTThreadedObject testTThreadedObject.cxx LIBRARIES Hist)
 
-ROOT_ADD_GTEST(testInterpreterLock testInterpreterLock.cxx LIBRARIES Imt)
+ROOT_ADD_GTEST(testInterpreterLock testInterpreterLock.cxx LIBRARIES Imt REPEATS 100)

--- a/core/thread/test/CMakeLists.txt
+++ b/core/thread/test/CMakeLists.txt
@@ -7,3 +7,5 @@
 ROOT_ADD_UNITTEST_DIR(Core Thread Hist)
 
 ROOT_ADD_GTEST(testTThreadedObject testTThreadedObject.cxx LIBRARIES Hist)
+
+ROOT_ADD_GTEST(testInterpreterLock testInterpreterLock.cxx LIBRARIES Imt)

--- a/core/thread/test/testInterpreterLock.cxx
+++ b/core/thread/test/testInterpreterLock.cxx
@@ -1,0 +1,154 @@
+#include "ROOT/TThreadExecutor.hxx"
+#include "TVirtualRWMutex.h"
+#include "TInterpreter.h"
+#include "TROOT.h"
+#include <iostream>
+#include <string>
+#include <vector>
+#include <thread>
+
+#include "gtest/gtest.h"
+
+static auto gDeclarator =  gInterpreter->Declare("int f(int n) { int x = 0; for (auto i = 0u; i < n; ++i) ++x; return x; }");
+
+constexpr bool gDebugOrder = false;
+
+TEST(InterpreterLock, ConcurrentCalc)
+{
+   ASSERT_TRUE(gDeclarator);
+   bool flag = true;
+   auto func = [&](int) {
+      gInterpreter->Calc("f(10)");
+      R__LOCKGUARD(gROOTMutex);
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : start" << std::endl;
+
+      EXPECT_TRUE(flag) << "Broken flag update on thread " << std::this_thread::get_id();
+      flag = false;
+      gInterpreter->Calc("f(100000)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : end" << std::endl;
+      flag = true;
+   };
+   ROOT::TThreadExecutor pool(32);
+   std::vector<int> id;
+   for (auto i = 0u; i < 16; i++) id.push_back(i);
+   pool.Foreach(func, id);
+}
+
+
+TEST(InterpreterLock, ReadLocks)
+{
+   ASSERT_TRUE(gDeclarator);
+   auto func = [&](int) {
+      R__READ_LOCKGUARD(ROOT::gCoreMutex);
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : start" << std::endl;
+      R__READ_LOCKGUARD(ROOT::gCoreMutex);
+      gInterpreter->Calc("f(10)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : middle" << std::endl;
+
+      R__LOCKGUARD(gROOTMutex);
+      gInterpreter->Calc("f(100000)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : end" << std::endl;
+
+   };
+   ROOT::TThreadExecutor pool;
+   std::vector<int> id;
+   for (auto i = 0u; i < 16; i++) id.push_back(i);
+   pool.Foreach(func, id);
+}
+
+TEST(InterpreterLock, BalancedUserReadLock)
+{
+   ASSERT_TRUE(gDeclarator);
+   auto func = [&](int) {
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : start" << std::endl;
+      gInterpreter->Calc("R__READ_LOCKGUARD(ROOT::gCoreMutex); f(10)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : middle" << std::endl;
+
+      R__LOCKGUARD(gROOTMutex);
+      gInterpreter->Calc("R__READ_LOCKGUARD(ROOT::gCoreMutex); f(100000)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : end" << std::endl;
+
+   };
+   ROOT::TThreadExecutor pool;
+   std::vector<int> id;
+   for (auto i = 0u; i < 16; i++) id.push_back(i);
+   pool.Foreach(func, id);
+}
+
+TEST(InterpreterLock, BalancedUserWriteLock)
+{
+   ASSERT_TRUE(gDeclarator);
+   auto func = [&](int) {
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : start" << std::endl;
+      gInterpreter->Calc("R__WRITE_LOCKGUARD(ROOT::gCoreMutex); f(10)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : middle" << std::endl;
+
+      R__LOCKGUARD(gROOTMutex);
+      gInterpreter->Calc("R__WRITE_LOCKGUARD(ROOT::gCoreMutex); f(100000)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : end" << std::endl;
+
+   };
+   ROOT::TThreadExecutor pool;
+   std::vector<int> id;
+   for (auto i = 0u; i < 16; i++) id.push_back(i);
+   pool.Foreach(func, id);
+}
+
+TEST(InterpreterLock, UnBalancedUserReadLock)
+{
+   ASSERT_TRUE(gDeclarator);
+   auto func = [&](int) {
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : start" << std::endl;
+      gInterpreter->Calc("ROOT::gCoreMutex->ReadLock(); f(10)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : middle" << std::endl;
+
+      {
+            R__LOCKGUARD(gROOTMutex);
+            gInterpreter->Calc("R__READ_LOCKGUARD(ROOT::gCoreMutex); f(100000)");
+            if (gDebugOrder)
+               std::cerr << std::this_thread::get_id() << " : end" << std::endl;
+      }
+
+      ROOT::gCoreMutex->ReadUnLock(nullptr);
+   };
+   ROOT::TThreadExecutor pool;
+   std::vector<int> id;
+   for (auto i = 0u; i < 16; i++) id.push_back(i);
+   pool.Foreach(func, id);
+}
+
+TEST(InterpreterLock, UnBalancedUserWriteLock)
+{
+   ASSERT_TRUE(gDeclarator);
+   auto func = [&](int) {
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : start" << std::endl;
+      gInterpreter->Calc("ROOT::gCoreMutex->ReadLock(); f(10)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : middle" << std::endl;
+
+      gInterpreter->Calc("ROOT::gCoreMutex->WriteLock(); f(100000)");
+      if (gDebugOrder)
+         std::cerr << std::this_thread::get_id() << " : end" << std::endl;
+
+      ROOT::gCoreMutex->WriteUnLock(nullptr);
+      ROOT::gCoreMutex->ReadUnLock(nullptr);
+   };
+   ROOT::TThreadExecutor pool;
+   std::vector<int> id;
+   for (auto i = 0u; i < 16; i++) id.push_back(i);
+   pool.Foreach(func, id);
+}

--- a/core/thread/test/testInterpreterLock.cxx
+++ b/core/thread/test/testInterpreterLock.cxx
@@ -12,7 +12,9 @@
 
 #include "gtest/gtest.h"
 
-static bool gDeclarator = (ROOT::EnableThreadSafety(), gInterpreter->Declare("int f(int n) { int x = 0; for (auto i = 0u; i < n; ++i) ++x; return x; }"));
+static bool gDeclarator =
+   (ROOT::EnableThreadSafety(),
+    gInterpreter->Declare("int f(int n) { int x = 0; for (auto i = 0u; i < n; ++i) ++x; return x; }"));
 
 constexpr bool gDebugOrder = false;
 constexpr unsigned int nThreads = 16;
@@ -37,19 +39,17 @@ TEST(InterpreterLock, ConcurrentCalc)
 #ifdef R__USE_IMT
    ROOT::TThreadExecutor pool(32);
    std::vector<int> id;
-   for (auto i = 0u; i < nThreads; i++) id.push_back(i);
+   for (auto i = 0u; i < nThreads; i++)
+      id.push_back(i);
    pool.Foreach(func, id);
 #else
    std::vector<std::thread> threads;
-   for (unsigned int i=0; i < nThreads; ++i) {
-      threads.emplace_back([&,i]{
-         func(i);
-      });
+   for (unsigned int i = 0; i < nThreads; ++i) {
+      threads.emplace_back([&, i] { func(i); });
    }
-   std::for_each(threads.begin(), threads.end(), [](std::thread& thr){thr.join();});
+   std::for_each(threads.begin(), threads.end(), [](std::thread &thr) { thr.join(); });
 #endif
 }
-
 
 TEST(InterpreterLock, ReadLocks)
 {
@@ -67,21 +67,19 @@ TEST(InterpreterLock, ReadLocks)
       gInterpreter->Calc("f(100000)");
       if (gDebugOrder)
          std::cerr << std::this_thread::get_id() << " : end" << std::endl;
-
    };
 #ifdef R__USE_IMT
    ROOT::TThreadExecutor pool(32);
    std::vector<int> id;
-   for (auto i = 0u; i < nThreads; i++) id.push_back(i);
+   for (auto i = 0u; i < nThreads; i++)
+      id.push_back(i);
    pool.Foreach(func, id);
 #else
    std::vector<std::thread> threads;
-   for (unsigned int i=0; i < nThreads; ++i) {
-      threads.emplace_back([&,i]{
-         func(i);
-      });
+   for (unsigned int i = 0; i < nThreads; ++i) {
+      threads.emplace_back([&, i] { func(i); });
    }
-   std::for_each(threads.begin(), threads.end(), [](std::thread& thr){thr.join();});
+   std::for_each(threads.begin(), threads.end(), [](std::thread &thr) { thr.join(); });
 #endif
 }
 
@@ -99,21 +97,19 @@ TEST(InterpreterLock, BalancedUserReadLock)
       gInterpreter->Calc("R__READ_LOCKGUARD(ROOT::gCoreMutex); f(100000)");
       if (gDebugOrder)
          std::cerr << std::this_thread::get_id() << " : end" << std::endl;
-
    };
 #ifdef R__USE_IMT
    ROOT::TThreadExecutor pool(32);
    std::vector<int> id;
-   for (auto i = 0u; i < nThreads; i++) id.push_back(i);
+   for (auto i = 0u; i < nThreads; i++)
+      id.push_back(i);
    pool.Foreach(func, id);
 #else
    std::vector<std::thread> threads;
-   for (unsigned int i=0; i < nThreads; ++i) {
-      threads.emplace_back([&,i]{
-         func(i);
-      });
+   for (unsigned int i = 0; i < nThreads; ++i) {
+      threads.emplace_back([&, i] { func(i); });
    }
-   std::for_each(threads.begin(), threads.end(), [](std::thread& thr){thr.join();});
+   std::for_each(threads.begin(), threads.end(), [](std::thread &thr) { thr.join(); });
 #endif
 }
 
@@ -131,21 +127,19 @@ TEST(InterpreterLock, BalancedUserWriteLock)
       gInterpreter->Calc("R__WRITE_LOCKGUARD(ROOT::gCoreMutex); f(100000)");
       if (gDebugOrder)
          std::cerr << std::this_thread::get_id() << " : end" << std::endl;
-
    };
 #ifdef R__USE_IMT
    ROOT::TThreadExecutor pool(32);
    std::vector<int> id;
-   for (auto i = 0u; i < nThreads; i++) id.push_back(i);
+   for (auto i = 0u; i < nThreads; i++)
+      id.push_back(i);
    pool.Foreach(func, id);
 #else
    std::vector<std::thread> threads;
-   for (unsigned int i=0; i < nThreads; ++i) {
-      threads.emplace_back([&,i]{
-         func(i);
-      });
+   for (unsigned int i = 0; i < nThreads; ++i) {
+      threads.emplace_back([&, i] { func(i); });
    }
-   std::for_each(threads.begin(), threads.end(), [](std::thread& thr){thr.join();});
+   std::for_each(threads.begin(), threads.end(), [](std::thread &thr) { thr.join(); });
 #endif
 }
 
@@ -160,10 +154,10 @@ TEST(InterpreterLock, UnBalancedUserReadLock)
          std::cerr << std::this_thread::get_id() << " : middle" << std::endl;
 
       {
-            R__LOCKGUARD(gROOTMutex);
-            gInterpreter->Calc("R__READ_LOCKGUARD(ROOT::gCoreMutex); f(100000)");
-            if (gDebugOrder)
-               std::cerr << std::this_thread::get_id() << " : end" << std::endl;
+         R__LOCKGUARD(gROOTMutex);
+         gInterpreter->Calc("R__READ_LOCKGUARD(ROOT::gCoreMutex); f(100000)");
+         if (gDebugOrder)
+            std::cerr << std::this_thread::get_id() << " : end" << std::endl;
       }
 
       ROOT::gCoreMutex->ReadUnLock(nullptr);
@@ -171,16 +165,15 @@ TEST(InterpreterLock, UnBalancedUserReadLock)
 #ifdef R__USE_IMT
    ROOT::TThreadExecutor pool(32);
    std::vector<int> id;
-   for (auto i = 0u; i < nThreads; i++) id.push_back(i);
+   for (auto i = 0u; i < nThreads; i++)
+      id.push_back(i);
    pool.Foreach(func, id);
 #else
    std::vector<std::thread> threads;
-   for (unsigned int i=0; i < nThreads; ++i) {
-      threads.emplace_back([&,i]{
-         func(i);
-      });
+   for (unsigned int i = 0; i < nThreads; ++i) {
+      threads.emplace_back([&, i] { func(i); });
    }
-   std::for_each(threads.begin(), threads.end(), [](std::thread& thr){thr.join();});
+   std::for_each(threads.begin(), threads.end(), [](std::thread &thr) { thr.join(); });
 #endif
 }
 
@@ -204,15 +197,14 @@ TEST(InterpreterLock, UnBalancedUserWriteLock)
 #ifdef R__USE_IMT
    ROOT::TThreadExecutor pool(32);
    std::vector<int> id;
-   for (auto i = 0u; i < nThreads; i++) id.push_back(i);
+   for (auto i = 0u; i < nThreads; i++)
+      id.push_back(i);
    pool.Foreach(func, id);
 #else
    std::vector<std::thread> threads;
-   for (unsigned int i=0; i < nThreads; ++i) {
-      threads.emplace_back([&,i]{
-         func(i);
-      });
+   for (unsigned int i = 0; i < nThreads; ++i) {
+      threads.emplace_back([&, i] { func(i); });
    }
-   std::for_each(threads.begin(), threads.end(), [](std::thread& thr){thr.join();});
+   std::for_each(threads.begin(), threads.end(), [](std::thread &thr) { thr.join(); });
 #endif
 }


### PR DESCRIPTION
Avoid global stack for TCling's mutex states.

This solves race condition and ordering issues for the content of TCling::fInitialMutex.

Rather than relying on a global stack of state, leverage the fact that the code that temporarily
suspend the interpreter lock during user-code execution is already keeping/stashing away some
information.  Extend that code to stash all the necessary information (was 'only' the delta
and is now the delta + initial state + recurse count.