### PR TITLE
fixed code to load JupyROOT in python2

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -72,10 +72,11 @@ for _, module_name, _ in  pkgutil.walk_packages(pyz.__path__):
         module = importlib.import_module(pyz.__name__ + '.' + module_name)
 
 # Check if we are in the IPython shell
-try:
+if major == 3:
     import builtins
-except ImportError:
-    import __builtin__ as builtins # Py2
+else:
+    import __builtin__ as builtins  
+
 _is_ipython = hasattr(builtins, '__IPYTHON__')
 
 # Configure ROOT facade module


### PR DESCRIPTION
An small bug detected in LCG98 that only affect python2
JupyROOT is not loaded when you are importing ROOT in the notebook.

this code fix this problem.

Omar.