### PR TITLE
Update RootMacros.cmake

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -660,7 +660,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
       ${incdirs} $<TARGET_PROPERTY:${ARG_MODULE},INCLUDE_DIRECTORIES>)
   else()
     get_filename_component(dictionary_name ${dictionary} NAME)   
-    add_custom_target(${dictionary} DEPENDS ${dictionary}.cxx ${pcm_name} ${rootmap_name} ${cpp_module_file})
+    add_custom_target(${dictionary_name} DEPENDS ${dictionary}.cxx ${pcm_name} ${rootmap_name} ${cpp_module_file})
   endif()
 
   if(PROJECT_NAME STREQUAL "ROOT")

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -659,6 +659,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     target_include_directories(${dictionary} PRIVATE
       ${incdirs} $<TARGET_PROPERTY:${ARG_MODULE},INCLUDE_DIRECTORIES>)
   else()
+    get_filename_component(dictionary_name ${dictionary} NAME)   
     add_custom_target(${dictionary} DEPENDS ${dictionary}.cxx ${pcm_name} ${rootmap_name} ${cpp_module_file})
   endif()
 


### PR DESCRIPTION
Allow dictionary files to be created in subdirectories. This was working earlier and is broken now. As there is no way to define othe output directory, providing the dictionary with path is the only way to achieve that.