### PR TITLE
[wincxxmodules] Simplify includes, Expose M_PI for Windows

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -166,6 +166,14 @@ if (libcxx AND NOT APPLE)
   target_compile_definitions(Core PRIVATE __CORRECT_ISO_CPP_WCHAR_H_PROTO)
 endif()
 
+if(MSVC)
+  # Definitions of MATH Macros (required in MathCore) like M_PI are only  
+  # exposed on Windows after defining the _USE_MATH_DEFINES macro. By   
+  # specifying it as a property for Core, we ensure that the macros are 
+  # properly exposed when using Modules on Windows.
+  target_compile_definitions(Core PRIVATE _USE_MATH_DEFINES)
+endif()
+
 #while basic libs do not depend on Core, we have to add includes directly
 
 target_include_directories(Core PUBLIC

--- a/math/vecops/CMakeLists.txt
+++ b/math/vecops/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 
 if(MSVC)
   target_compile_options(ROOTVecOps PRIVATE -O2 /fp:fast)
+  target_compile_definitions(ROOTVecOps PRIVATE _USE_MATH_DEFINES)
 else()
   target_compile_options(ROOTVecOps PRIVATE -O3 -ffast-math)
 endif()

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -36,14 +36,6 @@
 #include <vector>
 #include <utility>
 
-#define _USE_MATH_DEFINES // enable definition of M_PI
-#ifdef _WIN32
-// cmath does not expose M_PI on windows
-#include <math.h>
-#else
-#include <cmath>
-#endif
-
 #ifdef R__HAS_VDT
 #include <vdt/vdtMath.h>
 #endif

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -438,6 +438,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     ${installoptions}
 )
 
+if(MSVC)
+  target_compile_definitions(TMVA PRIVATE _USE_MATH_DEFINES)
+endif()
+
 if(vdt OR builtin_vdt)
   target_include_directories(TMVA PRIVATE ${VDT_INCLUDE_DIRS})
 endif()

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -122,4 +122,8 @@ if(root7)
   target_sources(ROOTDataFrame PRIVATE src/RNTupleDS.cxx)
 endif(root7)
 
+if(MSVC)
+  target_compile_definitions(ROOTDataFrame PRIVATE _USE_MATH_DEFINES)
+endif()
+
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -67,4 +67,8 @@ DEPENDENCIES
   ROOTVecOps
 )
 
+if(MSVC)
+  target_compile_definitions(ROOTNTuple PRIVATE _USE_MATH_DEFINES)
+endif()
+
 ROOT_ADD_TEST_SUBDIRECTORY(v7/test)


### PR DESCRIPTION
On Windows, the M_PI constants are hidden inside #define _USE_MATH_DEFINES
guard. If this macro is not defined at the start of the program, some
other header file might include math.h and the header is suppressed
forever.

Therefore, this commit moves #define _USE_MATH_DEFINES to the start of
the file and also custom defines M_PI as it is not exposed on building
Modules with Windows.

@vgvassilev 