### PR TITLE
[DF] Reduce amount of templates used for column readers

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
@@ -56,9 +56,6 @@ public:
       return *static_cast<T *>(GetImpl(entry));
    }
 
-   /// Perform clean-up operations if needed. Called at the end of a processing task.
-   virtual void Reset() {}
-
 private:
    virtual void *GetImpl(Long64_t entry) = 0;
 };
@@ -101,15 +98,15 @@ public:
    {
    }
 
-   /// Delete the TTreeReaderValue object.
+   /// The dtor resets the TTreeReaderValue object.
    //
-   // Without this call, a race condition is present in which a TTreeReader
+   // Otherwise a race condition is present in which a TTreeReader
    // and its TTreeReader{Value,Array}s can be deleted concurrently:
    // - Thread #1) a task ends and pushes back processing slot
    // - Thread #2) a task starts and overwrites thread-local TTreeReaderValues
    // - Thread #1) first task deletes TTreeReader
    // See https://github.com/root-project/root/commit/26e8ace6e47de6794ac9ec770c3bbff9b7f2e945
-   void Reset() final { fTreeValue.reset(); }
+   ~RTreeColumnReader() { fTreeValue.reset(); }
 };
 
 /// RTreeColumnReader specialization for TTree values read via TTreeReaderArrays.
@@ -195,8 +192,8 @@ public:
    {
    }
 
-   /// Delete the TTreeReaderArray object.
-   void Reset() final { fTreeArray.reset(); }
+   /// See the other class template specializations for an explanation.
+   ~RTreeColumnReader() { fTreeArray.reset(); }
 };
 
 /// RTreeColumnReader specialization for arrays of boolean values read via TTreeReaderArrays.
@@ -236,8 +233,8 @@ public:
    {
    }
 
-   /// Delete the TTreeReaderArray object.
-   void Reset() final { fTreeArray.reset(); }
+   /// See the other class template specializations for an explanation.
+   ~RTreeColumnReader() { fTreeArray.reset(); }
 };
 
 /// Column reader type that deals with values read from RDataSources.

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
@@ -64,13 +64,12 @@ private:
 };
 
 /// Column reader for defined (aka custom) columns.
-template <typename T>
 class R__CLING_PTRCHECK(off) RDefineReader final : public RColumnReaderBase {
    /// Non-owning reference to the node responsible for the custom column. Needed when querying custom values.
    RDFDetail::RDefineBase &fDefine;
 
    /// Non-owning ptr to the value of a custom column.
-   T *fCustomValuePtr = nullptr;
+   void *fCustomValuePtr = nullptr;
 
    /// The slot this value belongs to.
    unsigned int fSlot = std::numeric_limits<unsigned int>::max();
@@ -82,10 +81,10 @@ class R__CLING_PTRCHECK(off) RDefineReader final : public RColumnReaderBase {
    }
 
 public:
-   RDefineReader(unsigned int slot, RDFDetail::RDefineBase &define)
-      : fDefine(define), fCustomValuePtr(static_cast<T *>(define.GetValuePtr(slot))), fSlot(slot)
+   RDefineReader(unsigned int slot, RDFDetail::RDefineBase &define, const std::type_info &tid)
+      : fDefine(define), fCustomValuePtr(define.GetValuePtr(slot)), fSlot(slot)
    {
-      CheckDefine(define, typeid(T));
+      CheckDefine(define, tid);
    }
 };
 
@@ -260,7 +259,7 @@ MakeColumnReader(unsigned int slot, RDFDetail::RDefineBase *define, TTreeReader 
    using Ret_t = std::unique_ptr<RColumnReaderBase>;
 
    if (define != nullptr)
-      return Ret_t(new RDefineReader<T>(slot, *define));
+      return Ret_t(new RDefineReader(slot, *define, typeid(T)));
 
    if (DSValuePtrsPtr != nullptr) {
       auto &DSValuePtrs = *DSValuePtrsPtr;

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
@@ -50,6 +50,8 @@ public:
    virtual ~RColumnReaderBase() = default;
 
    /// Return the column value for the given entry. Called at most once per entry.
+   /// \tparam T The column type
+   /// \param entry The entry number
    template <typename T>
    T &Get(Long64_t entry)
    {

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
@@ -252,8 +252,6 @@ public:
    RDSColumnReader(void * DSValuePtr) : fDSValuePtr(static_cast<T **>(DSValuePtr)) {}
 };
 
-using RDFValueTuple_t = std::vector<std::unique_ptr<RColumnReaderBase>>;
-
 template <typename T>
 std::unique_ptr<RColumnReaderBase>
 MakeColumnReader(unsigned int slot, RDFDetail::RDefineBase *define, TTreeReader *r,
@@ -297,8 +295,8 @@ struct RColumnReadersInfo {
 
 /// Initialize a tuple of column readers.
 template <typename... ColTypes>
-void InitColumnReaders(unsigned int slot, RDFValueTuple_t &valueTuple, TTreeReader *r, TypeList<ColTypes...>,
-                       const RColumnReadersInfo &colInfo)
+void InitColumnReaders(unsigned int slot, std::vector<std::unique_ptr<RColumnReaderBase>> &colReaders, TTreeReader *r,
+                       TypeList<ColTypes...>, const RColumnReadersInfo &colInfo)
 {
    // see RColumnReadersInfo for why we pass these arguments like this rather than directly as function arguments
    const auto &colNames = colInfo.fColNames;
@@ -314,7 +312,7 @@ void InitColumnReaders(unsigned int slot, RDFValueTuple_t &valueTuple, TTreeRead
    // Construct the column readers
    int i = 0;
    (void)expander{
-      (valueTuple.emplace_back(InitColumnReadersHelper<ColTypes>(
+      (colReaders.emplace_back(InitColumnReadersHelper<ColTypes>(
           slot, isDefine[i] ? customColMap.at(colNames[i]).get() : nullptr, DSValuePtrsMap, r, colNames[i])),
        ++i)...,
       0};

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -91,7 +91,7 @@ public:
          bookedBranch.second->InitSlot(r, slot);
       RDFInternal::RColumnReadersInfo info{RActionBase::GetColumnNames(), RActionBase::GetDefines(), fIsDefine.data(),
                                            fLoopManager->GetDSValuePtrs()};
-      RDFInternal::InitColumnReaders(slot, fValues[slot], r, ColumnTypes_t{}, info);
+      fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
       fHelper.InitTask(r, slot);
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -113,18 +113,10 @@ public:
 
    void FinalizeSlot(unsigned int slot) final
    {
-      ClearValueReaders(slot);
-      for (auto &column : GetDefines().GetColumns()) {
+      for (auto &column : GetDefines().GetColumns())
          column.second->ClearValueReaders(slot);
-      }
-      fHelper.CallFinalizeTask(slot);
-   }
-
-   void ClearValueReaders(unsigned int slot)
-   {
-      for (auto &v : fValues[slot])
-         v->Reset();
       fValues[slot].clear();
+      fHelper.CallFinalizeTask(slot);
    }
 
    void Finalize() final

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -114,7 +114,7 @@ public:
    void FinalizeSlot(unsigned int slot) final
    {
       for (auto &column : GetDefines().GetColumns())
-         column.second->ClearValueReaders(slot);
+         column.second->FinaliseSlot(slot);
       fValues[slot].clear();
       fHelper.CallFinalizeTask(slot);
    }

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -51,7 +51,8 @@ class RAction : public RActionBase {
    Helper fHelper;
    const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
    PrevDataFrame &fPrevData;
-   std::vector<RDFValueTuple_t> fValues;
+   /// Column readers per slot and per input column
+   std::vector<std::vector<std::unique_ptr<RColumnReaderBase>>> fValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -111,6 +111,7 @@ public:
 
    void TriggerChildrenCount() final { fPrevData.IncrChildrenCount(); }
 
+   /// Clean-up operations to be performed at the end of a task.
    void FinalizeSlot(unsigned int slot) final
    {
       for (auto &column : GetDefines().GetColumns())
@@ -119,6 +120,8 @@ public:
       fHelper.CallFinalizeTask(slot);
    }
 
+   /// Clean-up and finalize the action result (e.g. merging slot-local results).
+   /// It invokes the helper's Finalize method.
    void Finalize() final
    {
       fHelper.Finalize();

--- a/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
@@ -63,7 +63,6 @@ public:
    virtual void Initialize() = 0;
    virtual void InitSlot(TTreeReader *r, unsigned int slot) = 0;
    virtual void TriggerChildrenCount() = 0;
-   virtual void ClearValueReaders(unsigned int slot) = 0;
    virtual void FinalizeSlot(unsigned int) = 0;
    virtual void Finalize() = 0;
    /// This method is invoked to update a partial result during the event loop, right before passing the result to a

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -136,10 +136,8 @@ public:
    void ClearValueReaders(unsigned int slot) final
    {
       if (fIsInitialized[slot]) {
-         for (auto &v : fValues[slot])
-            v->Reset();
-         fIsInitialized[slot] = false;
          fValues[slot].clear();
+         fIsInitialized[slot] = false;
       }
    }
 };

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -120,8 +120,10 @@ public:
       }
    }
 
+   /// Return the (type-erased) address of the Define'd value for the given processing slot.
    void *GetValuePtr(unsigned int slot) final { return static_cast<void *>(&fLastResults[slot]); }
 
+   /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
    void Update(unsigned int slot, Long64_t entry) final
    {
       if (entry != fLastCheckedEntry[slot]) {
@@ -133,6 +135,7 @@ public:
 
    const std::type_info &GetTypeId() const { return typeid(ret_type); }
 
+   /// Clean-up operations to be performed at the end of a task.
    void FinaliseSlot(unsigned int slot) final
    {
       if (fIsInitialized[slot]) {

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -115,7 +115,7 @@ public:
       if (!fIsInitialized[slot]) {
          fIsInitialized[slot] = true;
          RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fDSValuePtrs};
-         RDFInternal::InitColumnReaders(slot, fValues[slot], r, ColumnTypes_t{}, info);
+         fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
          fLastCheckedEntry[slot] = -1;
       }
    }

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -61,7 +61,8 @@ class RDefine final : public RDefineBase {
    const ColumnNames_t fColumnNames;
    ValuesPerSlot_t fLastResults;
 
-   std::vector<RDFInternal::RDFValueTuple_t> fValues;
+   /// Column readers per slot and per input column
+   std::vector<std::vector<std::unique_ptr<RDFInternal::RColumnReaderBase>>> fValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -133,7 +133,7 @@ public:
 
    const std::type_info &GetTypeId() const { return typeid(ret_type); }
 
-   void ClearValueReaders(unsigned int slot) final
+   void FinaliseSlot(unsigned int slot) final
    {
       if (fIsInitialized[slot]) {
          fValues[slot].clear();

--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -54,11 +54,14 @@ public:
    RDefineBase &operator=(RDefineBase &&) = delete;
    virtual ~RDefineBase();
    virtual void InitSlot(TTreeReader *r, unsigned int slot) = 0;
+   /// Return the (type-erased) address of the Define'd value for the given processing slot.
    virtual void *GetValuePtr(unsigned int slot) = 0;
    virtual const std::type_info &GetTypeId() const = 0;
    std::string GetName() const;
    std::string GetTypeName() const;
+   /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
    virtual void Update(unsigned int slot, Long64_t entry) = 0;
+   /// Clean-up operations to be performed at the end of a task.
    virtual void FinaliseSlot(unsigned int slot) = 0;
    /// Return the unique identifier of this RDefineBase.
    unsigned int GetID() const { return fID; }

--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -59,7 +59,7 @@ public:
    std::string GetName() const;
    std::string GetTypeName() const;
    virtual void Update(unsigned int slot, Long64_t entry) = 0;
-   virtual void ClearValueReaders(unsigned int slot) = 0;
+   virtual void FinaliseSlot(unsigned int slot) = 0;
    /// Return the unique identifier of this RDefineBase.
    unsigned int GetID() const { return fID; }
 };

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -150,7 +150,7 @@ public:
       filters.push_back(name);
    }
 
-   virtual void ClearTask(unsigned int slot) final
+   virtual void FinaliseSlot(unsigned int slot) final
    {
       for (auto &column : fDefines.GetColumns())
          column.second->ClearValueReaders(slot);

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -56,7 +56,8 @@ class RFilter final : public RFilterBase {
    const ColumnNames_t fColumnNames;
    const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
    PrevDataFrame &fPrevData;
-   std::vector<RDFInternal::RDFValueTuple_t> fValues;
+   /// Column readers per slot and per input column
+   std::vector<std::vector<std::unique_ptr<RDFInternal::RColumnReaderBase>>> fValues;
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
 

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -153,7 +153,7 @@ public:
    virtual void FinaliseSlot(unsigned int slot) final
    {
       for (auto &column : fDefines.GetColumns())
-         column.second->ClearValueReaders(slot);
+         column.second->FinaliseSlot(slot);
 
       fValues[slot].clear();
    }

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -110,7 +110,7 @@ public:
       for (auto &bookedBranch : fDefines.GetColumns())
          bookedBranch.second->InitSlot(r, slot);
       RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fLoopManager->GetDSValuePtrs()};
-      RDFInternal::InitColumnReaders(slot, fValues[slot], r, ColumnTypes_t{}, info);
+      fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
    }
 
    // recursive chain of `Report`s

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -143,13 +143,6 @@ public:
       fPrevData.IncrChildrenCount();
    }
 
-   virtual void ClearValueReaders(unsigned int slot) final
-   {
-      for (auto &v : fValues[slot])
-         v->Reset();
-      fValues[slot].clear();
-   }
-
    void AddFilterName(std::vector<std::string> &filters)
    {
       fPrevData.AddFilterName(filters);
@@ -159,11 +152,10 @@ public:
 
    virtual void ClearTask(unsigned int slot) final
    {
-      for (auto &column : fDefines.GetColumns()) {
+      for (auto &column : fDefines.GetColumns())
          column.second->ClearValueReaders(slot);
-      }
 
-      ClearValueReaders(slot);
+      fValues[slot].clear();
    }
 
    std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph()

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -150,6 +150,7 @@ public:
       filters.push_back(name);
    }
 
+   /// Clean-up operations to be performed at the end of a task.
    virtual void FinaliseSlot(unsigned int slot) final
    {
       for (auto &column : fDefines.GetColumns())

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -63,7 +63,7 @@ public:
       std::fill(fAccepted.begin(), fAccepted.end(), 0);
       std::fill(fRejected.begin(), fRejected.end(), 0);
    }
-   virtual void ClearTask(unsigned int slot) = 0;
+   virtual void FinaliseSlot(unsigned int slot) = 0;
    virtual void InitNode();
    virtual void AddFilterName(std::vector<std::string> &filters) = 0;
 };

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -63,7 +63,6 @@ public:
       std::fill(fAccepted.begin(), fAccepted.end(), 0);
       std::fill(fRejected.begin(), fRejected.end(), 0);
    }
-   virtual void ClearValueReaders(unsigned int slot) = 0;
    virtual void ClearTask(unsigned int slot) = 0;
    virtual void InitNode();
    virtual void AddFilterName(std::vector<std::string> &filters) = 0;

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -63,6 +63,7 @@ public:
       std::fill(fAccepted.begin(), fAccepted.end(), 0);
       std::fill(fRejected.begin(), fRejected.end(), 0);
    }
+   /// Clean-up operations to be performed at the end of a task.
    virtual void FinaliseSlot(unsigned int slot) = 0;
    virtual void InitNode();
    virtual void AddFilterName(std::vector<std::string> &filters) = 0;

--- a/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
@@ -55,7 +55,6 @@ public:
    void *PartialUpdate(unsigned int slot) final;
    bool HasRun() const final;
    void SetHasRun() final;
-   void ClearValueReaders(unsigned int slot) final;
 
    std::shared_ptr<GraphDrawing::GraphNode> GetGraph();
 

--- a/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
@@ -44,7 +44,7 @@ public:
    void *GetValuePtr(unsigned int slot) final;
    const std::type_info &GetTypeId() const final;
    void Update(unsigned int slot, Long64_t entry) final;
-   void ClearValueReaders(unsigned int slot) final;
+   void FinaliseSlot(unsigned int slot) final;
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
@@ -57,7 +57,7 @@ public:
    void ResetReportCount() final;
    void InitNode() final;
    void AddFilterName(std::vector<std::string> &filters) final;
-   void ClearTask(unsigned int slot) final;
+   void FinaliseSlot(unsigned int slot) final;
    std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph();
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
@@ -55,7 +55,6 @@ public:
    void ResetChildrenCount() final;
    void TriggerChildrenCount() final;
    void ResetReportCount() final;
-   void ClearValueReaders(unsigned int slot) final;
    void InitNode() final;
    void AddFilterName(std::vector<std::string> &filters) final;
    void ClearTask(unsigned int slot) final;

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -78,12 +78,6 @@ void RJittedAction::SetHasRun()
    return fConcreteAction->SetHasRun();
 }
 
-void RJittedAction::ClearValueReaders(unsigned int slot)
-{
-   R__ASSERT(fConcreteAction != nullptr);
-   return fConcreteAction->ClearValueReaders(slot);
-}
-
 std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RJittedAction::GetGraph()
 {
    R__ASSERT(fConcreteAction != nullptr);

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -37,8 +37,8 @@ void RJittedDefine::Update(unsigned int slot, Long64_t entry)
    fConcreteDefine->Update(slot, entry);
 }
 
-void RJittedDefine::ClearValueReaders(unsigned int slot)
+void RJittedDefine::FinaliseSlot(unsigned int slot)
 {
    R__ASSERT(fConcreteDefine != nullptr);
-   fConcreteDefine->ClearValueReaders(slot);
+   fConcreteDefine->FinaliseSlot(slot);
 }

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -83,12 +83,6 @@ void RJittedFilter::ResetReportCount()
    fConcreteFilter->ResetReportCount();
 }
 
-void RJittedFilter::ClearValueReaders(unsigned int slot)
-{
-   R__ASSERT(fConcreteFilter != nullptr);
-   fConcreteFilter->ClearValueReaders(slot);
-}
-
 void RJittedFilter::ClearTask(unsigned int slot)
 {
    R__ASSERT(fConcreteFilter != nullptr);

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -83,10 +83,10 @@ void RJittedFilter::ResetReportCount()
    fConcreteFilter->ResetReportCount();
 }
 
-void RJittedFilter::ClearTask(unsigned int slot)
+void RJittedFilter::FinaliseSlot(unsigned int slot)
 {
    R__ASSERT(fConcreteFilter != nullptr);
-   fConcreteFilter->ClearTask(slot);
+   fConcreteFilter->FinaliseSlot(slot);
 }
 
 void RJittedFilter::InitNode()

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -464,9 +464,7 @@ void RLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
 
 /// Build TTreeReaderValues for all nodes
 /// This method loops over all filters, actions and other booked objects and
-/// calls their `InitColumnReaders` methods. It is called once per node per slot, before
-/// running the event loop. It also informs each node of the TTreeReader that
-/// a particular slot will be using.
+/// calls their `InitSlot` method, to get them ready for running a task.
 void RLoopManager::InitNodeSlots(TTreeReader *r, unsigned int slot)
 {
    for (auto &ptr : fBookedActions)

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -522,7 +522,7 @@ void RLoopManager::CleanUpTask(unsigned int slot)
    for (auto &ptr : fBookedActions)
       ptr->FinalizeSlot(slot);
    for (auto &ptr : fBookedFilters)
-      ptr->ClearTask(slot);
+      ptr->FinaliseSlot(slot);
 }
 
 /// Add RDF nodes that require just-in-time compilation to the computation graph.


### PR DESCRIPTION
`RColumnReaderBase` is now a non-template class, and only its `Get`
method is templated over the type of the value to retrieve.

This alternative design has two main advantages:
- it simplifies `RAction` greatly, removing the need for the special
  `RTypeErasedColumnReader` type: now all column readers are type erased
  in the sense that a `RColumnReaderBase*` does not contain the type of
  the column that will be read
- it makes it possible to pass `RColumnReaderBase` through interfaces
  that type-erase column types, which is important to better integrate
  RDF and RDataSource: in the future, `RDataSource` implementations will
  be able to return specialized column readers to RDF rather than raw
  pointers to the datasource values

There should be no visible difference in event loop runtimes: a virtual
call to `SomeColumnReader<T>::Get` has been substituted with a direct,
inlined call to `RColumnReaderBase::Get<T>` which in turn executes a
virtual call to `SomeColumnReader<T>::GetImpl`.

Compile times and jitting times should benefit from the reduced amount
of templates.