### PR TITLE
[JupyROOT] Support installation of JupyROOT lib on Python directories

### DIFF
--- a/bindings/jupyroot/CMakeLists.txt
+++ b/bindings/jupyroot/CMakeLists.txt
@@ -72,8 +72,8 @@ foreach(val RANGE ${how_many_pythons})
   # Install library
   install(TARGETS ${libname} EXPORT ${CMAKE_PROJECT_NAME}Exports
                              RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries
-                             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
-                             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
+                             LIBRARY DESTINATION ${CMAKE_INSTALL_PYTHONDIR} COMPONENT libraries
+                             ARCHIVE DESTINATION ${CMAKE_INSTALL_PYTHONDIR} COMPONENT libraries)
 
 endforeach()
 


### PR DESCRIPTION
This supersedes https://github.com/root-project/root/pull/6248 and should fix the case when JupyROOT is installed on Python directories. Uses the same solution implemented by @eguiraud for `libROOTPythonizations`:

https://github.com/root-project/root/blob/master/bindings/pyroot/pythonizations/CMakeLists.txt#L145-L146