### PR TITLE
[RF][ROOT-7720] Try to fix caching Bug in ProductPdf.

### DIFF
--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -180,21 +180,14 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
   RooArgSet anaIntSet, numIntSet ;
 
   // First determine subset of observables in intSet that are factorizable
-  TIterator* compIter = compSet.createIterator() ;
-  TIterator* intIter = intSet.createIterator() ;
-  RooAbsPdf* pdf ;
-  RooAbsArg* arg ;
-  while((arg=(RooAbsArg*)intIter->Next())) {
-    Int_t count(0) ;
-    compIter->Reset() ;
-    while((pdf=(RooAbsPdf*)compIter->Next())) {
-      if (pdf->dependsOn(*arg)) count++ ;
-    }
+  for (const auto arg : intSet) {
+    auto count = std::count_if(compSet.begin(), compSet.end(), [arg](const RooAbsArg* pdfAsArg){
+      auto pdf = static_cast<const RooAbsPdf*>(pdfAsArg);
+      return (pdf->dependsOn(*arg));
+    });
 
-    if (count==0) {
-    } else if (count==1) {
+    if (count==1) {
       anaIntSet.add(*arg) ;
-    } else {
     }    
   }
 
@@ -202,27 +195,28 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
   RooArgSet prodSet ;
   numIntSet.add(intSet) ;
   
-  compIter->Reset() ;
-  while((pdf=(RooAbsPdf*)compIter->Next())) {
+  for (const auto pdfAsArg : compSet) {
+    auto pdf = static_cast<const RooAbsPdf*>(pdfAsArg);
+
     if (doFactorize && pdf->dependsOn(anaIntSet)) {
       RooArgSet anaSet ;
       Int_t code = pdf->getAnalyticalIntegralWN(anaIntSet,anaSet,0,isetRangeName) ;
       if (code!=0) {
-	// Analytical integral, create integral object
-	RooAbsReal* pai = pdf->createIntegral(anaSet,isetRangeName) ;
-	pai->setOperMode(_operMode) ;
-	
-	// Add to integral to product
-	prodSet.add(*pai) ;
-	
-	// Remove analytically integratable observables from numeric integration list
-	numIntSet.remove(anaSet) ;
-	
-	// Declare ownership of integral
-	saveSet.addOwned(*pai) ;
+        // Analytical integral, create integral object
+        RooAbsReal* pai = pdf->createIntegral(anaSet,isetRangeName) ;
+        pai->setOperMode(_operMode) ;
+
+        // Add to integral to product
+        prodSet.add(*pai) ;
+
+        // Remove analytically integratable observables from numeric integration list
+        numIntSet.remove(anaSet) ;
+
+        // Declare ownership of integral
+        saveSet.addOwned(*pai) ;
       } else {
-	// Analytic integration of factorizable observable not possible, add straight pdf to product
-	prodSet.add(*pdf) ;
+        // Analytic integration of factorizable observable not possible, add straight pdf to product
+        prodSet.add(*pdf) ;
       }      
     } else {
       // Non-factorizable observables, add straight pdf to product
@@ -243,8 +237,8 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
   prod->setExpensiveObjectCache(expensiveObjectCache()) ;
   prod->setOperMode(_operMode) ;
 
-  // Declare owndership of product
-  saveSet.addOwned(*prod) ;
+  // Declare ownership of product
+  saveSet.addOwned(*prod);
 
   // Create integral performing remaining numeric integration over (partial) analytic product
   RooAbsReal* ret = prod->createIntegral(numIntSet,isetRangeName) ;
@@ -252,9 +246,6 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
 //   ret->Print("v") ;
   ret->setOperMode(_operMode) ;
   saveSet.addOwned(*ret) ;
-
-  delete compIter ;
-  delete intIter ;
 
   // Caller owners returned master integral object
   return ret ;

--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -167,10 +167,12 @@ RooGenProdProj::~RooGenProdProj()
 /// \param[in] name Name of integral to be created.
 /// \param[in] compSet All components of the product.
 /// \param[in] intSet Observables to be integrated.
-/// \param[in] isetRangeName Integral range.
 /// \param[out] saveSet All component objects needed to represent the product integral are added as owned members to saveSet.
-/// The caller should take ownership of this set.
-/// \return A RooAbsReal object representing the requested integral.
+/// \note The set owns new components that are created for the integral.
+/// \param[in] isetRangeName Integral range.
+/// \param[in] doFactorize
+///
+/// \return A RooAbsReal object representing the requested integral. The object is owned by `saveSet`.
 ///
 /// The integration is factorized into components as much as possible and done analytically as far as possible.
 RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& compSet, const RooArgSet& intSet, 
@@ -223,8 +225,6 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
     }
   }
 
-  //cout << "RooGenProdProj::makeIntegral(" << GetName() << ") prodset = " << prodSet << endl ;
-
   // Create product of (partial) analytical integrals
   TString prodName ;
   if (isetRangeName) {
@@ -253,8 +253,6 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
 
   // Create integral performing remaining numeric integration over (partial) analytic product
   RooAbsReal* ret = prod->createIntegral(numIntSet,isetRangeName) ;
-//   cout << "verbose print of integral object" << endl ;
-//   ret->Print("v") ;
   ret->setOperMode(_operMode) ;
   saveSet.addOwned(*ret) ;
 

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -29,3 +29,4 @@ if(NOT MSVC OR win_broken_tests)
     LIBRARIES RooFitCore
     COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_1.root ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_2.root)
 endif()
+ROOT_ADD_GTEST(testRooProductPdf testRooProductPdf.cxx LIBRARIES RooFitCore)

--- a/roofit/roofitcore/test/testRooProductPdf.cxx
+++ b/roofit/roofitcore/test/testRooProductPdf.cxx
@@ -1,0 +1,52 @@
+// Tests for the RooProdPdf
+// Authors: Stephan Hageboeck, CERN  02/2019
+
+#include "RooProdPdf.h"
+#include "RooRealVar.h"
+#include "RooGenericPdf.h"
+#include "RooDataSet.h"
+
+#include "gtest/gtest.h"
+
+class TestProdPdf : public ::testing::Test {
+protected:
+  TestProdPdf() :
+  Test()
+  {
+    datap.reset(prod.generate(RooArgSet(x), 1000));
+    a.setConstant(true);
+  }
+
+  ~TestProdPdf() {
+
+  }
+
+  constexpr static double bTruth = -0.5;
+
+  RooRealVar x{"x", "x", 2., 0., 5.};
+  RooRealVar a{"a", "a", -0.2, -5., 0.};
+  RooRealVar b{"b", "b", bTruth, -5., 0.};
+
+  RooGenericPdf c1{"c1", "exp(x*a)", RooArgSet(x,a)};
+  RooGenericPdf c2{"c2", "exp(x*b)", RooArgSet(x,b)};
+  RooProdPdf prod{"mypdf", "mypdf", RooArgList(c1,c2)};
+  std::unique_ptr<RooDataSet> datap{nullptr};
+};
+
+TEST_F(TestProdPdf, CachingOpt2) {
+  prod.fitTo(*datap, RooFit::Optimize(2), RooFit::PrintLevel(-1));
+  EXPECT_LT(fabs(b.getVal() - bTruth), b.getError()*1.1) << "b=" << b.getVal()
+          << " +- " << b.getError() << " doesn't match truth value with O2.";
+}
+
+TEST_F(TestProdPdf, CachingOpt1) {
+  prod.fitTo(*datap, RooFit::Optimize(1), RooFit::PrintLevel(-1));
+  EXPECT_LT(fabs(b.getVal() - bTruth), b.getError()*1.1) << "b=" << b.getVal()
+        << " +- " << b.getError() << " doesn't match truth value with O1.";
+}
+
+TEST_F(TestProdPdf, CachingOpt0) {
+  prod.fitTo(*datap, RooFit::Optimize(0), RooFit::PrintLevel(-1));
+  EXPECT_LT(fabs(b.getVal() - bTruth), b.getError()*1.1) << "b=" << b.getVal()
+        << " +- " << b.getError() << " doesn't match truth value with O0.";
+}


### PR DESCRIPTION
I believe this is what happens:
- In a ProductPdf, the values of the different components are precomputed & cached if `Optimize(2)` is activated. This caches PDF values **with** normalisation.
- If the ProductPdf is integrated, those PDF values are not re-evaluated, the pre-cached values are used. That means that already normalised PDF values are used to compute the integrals, and then the PDFs are divided by the now wrong integrals.
- The fix is to clone the terms that are multiplied for computing the integrals. This side-tracks the pre-cached values when integrals are computed.