### PR TITLE
Update thisroot.sh

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -162,8 +162,12 @@ if [ -n "${ROOTSYS}" ] ; then
    old_rootsys=${ROOTSYS}
 fi
 
+if [ "x${BASH_ARGV}" = "x" ]; then
+   SOURCE="$(readlink -f "$0")"
+else
+   SOURCE="$(readlink -f "${BASH_ARGV[0]}")"
+fi
 
-SOURCE=${BASH_ARGV[0]}
 if [ "x$SOURCE" = "x" ]; then
    SOURCE=${(%):-%N} # for zsh
 fi


### PR DESCRIPTION
The current version neglected that the user might want to call a symbolic link (for convenience) rather than the full path. The conditional is required to allow calls by either executing the link, or by sourcing the link.