### PR TITLE
[PyROOT][ROOT-11027] Revert activation of batch mode made by cppyy

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -26,6 +26,9 @@ environ['CPPYY_API_PATH'] = 'none'
 environ['CPPYY_NO_ROOT_FILTER'] = '1'
 
 import cppyy
+if not 'ROOTSYS' in environ:
+    # Revert setting made by cppyy
+    cppyy.gbl.gROOT.SetBatch(False)
 
 # import libROOTPythonizations with Python version number
 import sys, importlib


### PR DESCRIPTION
Right after importing cppyy, set batch mode to false to
neutralize the setting to true made by cppyy (in case ROOTSYS
is not defined).

Disabling the batch mode at this point is ok, since the user
settings done via command line (-b) or programmatically are
processed later. This means the setting we do here does not
overwrite a possible user setting.

More information about the issue fixed by this commit here:
https://sft.its.cern.ch/jira/browse/ROOT-11027