### PR TITLE
[DF] Use std::array for column readers

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaders.hxx
@@ -307,8 +307,9 @@ MakeColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, cons
    const auto &customColMap = customCols.GetColumns();
 
    int i = -1;
-   std::array<std::unique_ptr<RColumnReaderBase>, sizeof...(ColTypes)> ret{(++i, MakeOneColumnReader<ColTypes>(
-      slot, isDefine[i] ? customColMap.at(colNames[i]).get() : nullptr, DSValuePtrsMap, r, colNames[i]))...};
+   std::array<std::unique_ptr<RColumnReaderBase>, sizeof...(ColTypes)> ret{
+      {{(++i, MakeOneColumnReader<ColTypes>(slot, isDefine[i] ? customColMap.at(colNames[i]).get() : nullptr,
+                                            DSValuePtrsMap, r, colNames[i]))}...}};
    return ret;
 
    (void)slot;     // avoid _bogus_ "unused variable" warnings for slot on gcc 4.9

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -17,6 +17,7 @@
 #include "ROOT/RDF/Utils.hxx" // ColumnNames_t, IsInternalColumn
 #include "ROOT/RDF/RLoopManager.hxx"
 
+#include <array>
 #include <cstddef> // std::size_t
 #include <memory>
 #include <string>
@@ -52,7 +53,7 @@ class RAction : public RActionBase {
    const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
    PrevDataFrame &fPrevData;
    /// Column readers per slot and per input column
-   std::vector<std::vector<std::unique_ptr<RColumnReaderBase>>> fValues;
+   std::vector<std::array<std::unique_ptr<RDFInternal::RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
@@ -116,7 +117,8 @@ public:
    {
       for (auto &column : GetDefines().GetColumns())
          column.second->FinaliseSlot(slot);
-      fValues[slot].clear();
+      for (auto &v : fValues[slot])
+         v.reset();
       fHelper.CallFinalizeTask(slot);
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -19,6 +19,7 @@
 #include "ROOT/TypeTraits.hxx"
 #include "RtypesCore.h"
 
+#include <array>
 #include <deque>
 #include <type_traits>
 #include <vector>
@@ -62,7 +63,7 @@ class RDefine final : public RDefineBase {
    ValuesPerSlot_t fLastResults;
 
    /// Column readers per slot and per input column
-   std::vector<std::vector<std::unique_ptr<RDFInternal::RColumnReaderBase>>> fValues;
+   std::vector<std::array<std::unique_ptr<RDFInternal::RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
@@ -139,7 +140,8 @@ public:
    void FinaliseSlot(unsigned int slot) final
    {
       if (fIsInitialized[slot]) {
-         fValues[slot].clear();
+         for (auto &v : fValues[slot])
+            v.reset();
          fIsInitialized[slot] = false;
       }
    }

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -57,7 +57,7 @@ class RFilter final : public RFilterBase {
    const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
    PrevDataFrame &fPrevData;
    /// Column readers per slot and per input column
-   std::vector<std::vector<std::unique_ptr<RDFInternal::RColumnReaderBase>>> fValues;
+   std::vector<std::array<std::unique_ptr<RDFInternal::RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
 
@@ -156,7 +156,8 @@ public:
       for (auto &column : fDefines.GetColumns())
          column.second->FinaliseSlot(slot);
 
-      fValues[slot].clear();
+      for (auto &v : fValues[slot])
+         v.reset();
    }
 
    std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph()


### PR DESCRIPTION
It makes recovery of column values slightly faster, which is visible in rootbench.