### PR TITLE
Tell clad where to find LLVM.

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -69,7 +69,9 @@ else()
                -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+               -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
                -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+               -DLLVM_DIR=${LLVM_DIR}
                -DClang_DIR=${Clang_DIR}
                -DCLANG_INCLUDE_DIRS=${CLANG_INCLUDE_DIRS}
                -DCLAD_BUILD_STATIC_ONLY=ON


### PR DESCRIPTION
This is needed to fix ROOT-10886 in conjunction with
https://github.com/vgvassilev/clad/pull/170.