### PR TITLE
[DF] Split ColumnReaders.hxx in one header per class

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -43,7 +43,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RSnapshotOptions.hxx
     ROOT/RTrivialDS.hxx
     ROOT/RDF/ActionHelpers.hxx
-    ROOT/RDF/ColumnReaders.hxx
+    ROOT/RDF/ColumnReaderUtils.hxx
     ROOT/RDF/GraphNode.hxx
     ROOT/RDF/GraphUtils.hxx
     ROOT/RDF/HistoModels.hxx
@@ -53,6 +53,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RBookedDefines.hxx
     ROOT/RDF/RDefineBase.hxx
     ROOT/RDF/RDefine.hxx
+    ROOT/RDF/RDefineReader.hxx
+    ROOT/RDF/RDSColumnReader.hxx
+    ROOT/RDF/RColumnReaderBase.hxx
     ROOT/RDF/RCutFlowReport.hxx
     ROOT/RDF/RDisplay.hxx
     ROOT/RDF/RFilterBase.hxx
@@ -68,6 +71,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RRangeBase.hxx
     ROOT/RDF/RRange.hxx
     ROOT/RDF/RSlotStack.hxx
+    ROOT/RDF/RTreeColumnReader.hxx
     ROOT/RDF/Utils.hxx
     ROOT/RDF/PyROOTHelpers.hxx
     ${RDATAFRAME_EXTRA_HEADERS}
@@ -77,9 +81,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RDefineBase.cxx
     src/RCutFlowReport.cxx
     src/RDataFrame.cxx
+    src/RDefineReader.cxx
     src/RDFActionHelpers.cxx
     src/RDFBookedDefines.cxx
-    src/RDFColumnReaders.cxx
     src/RDFDisplay.cxx
     src/RDFGraphUtils.cxx
     src/RDFHistoModels.cxx

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -1,0 +1,106 @@
+// Author: Enrico Guiraud CERN 09/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_COLUMNREADERUTILS
+#define ROOT_RDF_COLUMNREADERUTILS
+
+#include "RColumnReaderBase.hxx"
+#include "RDefineBase.hxx"
+#include "RDefineReader.hxx"
+#include "RDSColumnReader.hxx"
+#include "RTreeColumnReader.hxx"
+#include <TError.h> // R__ASSERT
+#include <TTreeReader.h>
+#include <ROOT/TypeTraits.hxx>
+
+#include <array>
+#include <map>
+#include <memory>
+#include <string>
+#include <typeinfo> // for typeid
+#include <vector>
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+using namespace ROOT::TypeTraits;
+namespace RDFDetail = ROOT::Detail::RDF;
+
+template <typename T>
+std::unique_ptr<RColumnReaderBase>
+MakeColumnReader(unsigned int slot, RDFDetail::RDefineBase *define, TTreeReader *r,
+                 const std::vector<void *> *DSValuePtrsPtr, const std::string &colName)
+{
+   using Ret_t = std::unique_ptr<RColumnReaderBase>;
+
+   if (define != nullptr)
+      return Ret_t(new RDefineReader(slot, *define, typeid(T)));
+
+   if (DSValuePtrsPtr != nullptr) {
+      auto &DSValuePtrs = *DSValuePtrsPtr;
+      return Ret_t(new RDSColumnReader<T>(DSValuePtrs[slot]));
+   }
+
+   return Ret_t(new RTreeColumnReader<T>(*r, colName));
+}
+
+template <typename T>
+std::unique_ptr<RColumnReaderBase> MakeOneColumnReader(unsigned int slot, RDFDetail::RDefineBase *define,
+                                                       const std::map<std::string, std::vector<void *>> &DSValuePtrsMap,
+                                                       TTreeReader *r, const std::string &colName)
+{
+   const auto DSValuePtrsIt = DSValuePtrsMap.find(colName);
+   const std::vector<void *> *DSValuePtrsPtr = DSValuePtrsIt != DSValuePtrsMap.end() ? &DSValuePtrsIt->second : nullptr;
+   R__ASSERT(define != nullptr || r != nullptr || DSValuePtrsPtr != nullptr);
+   return MakeColumnReader<T>(slot, define, r, DSValuePtrsPtr, colName);
+}
+
+/// This type aggregates some of the arguments passed to InitColumnReaders.
+/// We need to pass a single RColumnReadersInfo object rather than each argument separately because with too many
+/// arguments passed, gcc 7.5.0 and cling disagree on the ABI, which leads to the last function argument being read
+/// incorrectly from a compiled InitColumnReaders symbols when invoked from a jitted symbol.
+struct RColumnReadersInfo {
+   const std::vector<std::string> &fColNames;
+   const RBookedDefines &fCustomCols;
+   const bool *fIsDefine;
+   const std::map<std::string, std::vector<void *>> &fDSValuePtrsMap;
+};
+
+/// Create a group of column readers, one per type in the parameter pack.
+/// colInfo.fColNames and colInfo.fIsDefine are expected to have size equal to the parameter pack, and elements ordered
+/// accordingly, i.e. fIsDefine[0] refers to fColNames[0] which is of type "ColTypes[0]".
+template <typename... ColTypes>
+std::array<std::unique_ptr<RColumnReaderBase>, sizeof...(ColTypes)>
+MakeColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, const RColumnReadersInfo &colInfo)
+{
+   // see RColumnReadersInfo for why we pass these arguments like this rather than directly as function arguments
+   const auto &colNames = colInfo.fColNames;
+   const auto &customCols = colInfo.fCustomCols;
+   const bool *isDefine = colInfo.fIsDefine;
+   const auto &DSValuePtrsMap = colInfo.fDSValuePtrsMap;
+
+   const auto &customColMap = customCols.GetColumns();
+
+   int i = -1;
+   std::array<std::unique_ptr<RColumnReaderBase>, sizeof...(ColTypes)> ret{
+      {{(++i, MakeOneColumnReader<ColTypes>(slot, isDefine[i] ? customColMap.at(colNames[i]).get() : nullptr,
+                                            DSValuePtrsMap, r, colNames[i]))}...}};
+   return ret;
+
+   (void)slot;     // avoid _bogus_ "unused variable" warnings for slot on gcc 4.9
+   (void)r;        // avoid "unused variable" warnings for r on gcc5.2
+}
+
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT
+
+#endif // ROOT_RDF_COLUMNREADERS

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -11,9 +11,10 @@
 #ifndef ROOT_RACTION
 #define ROOT_RACTION
 
-#include "ROOT/RDF/ColumnReaders.hxx"
+#include "ROOT/RDF/ColumnReaderUtils.hxx"
 #include "ROOT/RDF/GraphNode.hxx"
 #include "ROOT/RDF/RActionBase.hxx"
+#include "ROOT/RDF/RColumnReaderBase.hxx"
 #include "ROOT/RDF/Utils.hxx" // ColumnNames_t, IsInternalColumn
 #include "ROOT/RDF/RLoopManager.hxx"
 

--- a/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
@@ -1,0 +1,49 @@
+// Author: Enrico Guiraud CERN 09/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_INTERNAL_RDF_RCOLUMNREADERBASE
+#define ROOT_INTERNAL_RDF_RCOLUMNREADERBASE
+
+#include <Rtypes.h>
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+/**
+\class ROOT::Internal::RDF::RColumnReaderBase
+\ingroup dataframe
+\brief Pure virtual base class for all column reader types
+
+This pure virtual class provides a common base class for the different column reader types, e.g. RTreeColumnReader and
+RDSColumnReader.
+**/
+class RColumnReaderBase {
+public:
+   virtual ~RColumnReaderBase() = default;
+
+   /// Return the column value for the given entry. Called at most once per entry.
+   /// \tparam T The column type
+   /// \param entry The entry number
+   template <typename T>
+   T &Get(Long64_t entry)
+   {
+      return *static_cast<T *>(GetImpl(entry));
+   }
+
+private:
+   virtual void *GetImpl(Long64_t entry) = 0;
+};
+
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT
+
+#endif

--- a/tree/dataframe/inc/ROOT/RDF/RDSColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDSColumnReader.hxx
@@ -1,0 +1,36 @@
+// Author: Enrico Guiraud CERN 09/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RDSCOLUMNREADER
+#define ROOT_RDF_RDSCOLUMNREADER
+
+#include "RColumnReaderBase.hxx"
+#include <Rtypes.h>  // Long64_t, R__CLING_PTRCHECK
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+/// Column reader type that deals with values read from RDataSources.
+template <typename T>
+class R__CLING_PTRCHECK(off) RDSColumnReader final : public RColumnReaderBase {
+   T **fDSValuePtr = nullptr;
+
+   void *GetImpl(Long64_t) final { return *fDSValuePtr; }
+
+public:
+   RDSColumnReader(void *DSValuePtr) : fDSValuePtr(static_cast<T **>(DSValuePtr)) {}
+};
+
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT
+
+#endif

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -11,7 +11,8 @@
 #ifndef ROOT_RCUSTOMCOLUMN
 #define ROOT_RCUSTOMCOLUMN
 
-#include "ROOT/RDF/ColumnReaders.hxx"
+#include "ROOT/RDF/ColumnReaderUtils.hxx"
+#include "ROOT/RDF/RColumnReaderBase.hxx"
 #include "ROOT/RDF/RDefineBase.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RIntegerSequence.hxx"

--- a/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
@@ -1,0 +1,58 @@
+// Author: Enrico Guiraud CERN 09/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RDEFINEREADER
+#define ROOT_RDF_RDEFINEREADER
+
+#include "RColumnReaderBase.hxx"
+#include "RDefineBase.hxx"
+#include <Rtypes.h>  // Long64_t, R__CLING_PTRCHECK
+
+#include <limits>
+#include <type_traits>
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+namespace RDFDetail = ROOT::Detail::RDF;
+
+void CheckDefineType(RDFDetail::RDefineBase &define, const std::type_info &tid);
+
+/// Column reader for defined (aka custom) columns.
+class R__CLING_PTRCHECK(off) RDefineReader final : public RColumnReaderBase {
+   /// Non-owning reference to the node responsible for the custom column. Needed when querying custom values.
+   RDFDetail::RDefineBase &fDefine;
+
+   /// Non-owning ptr to the value of a custom column.
+   void *fCustomValuePtr = nullptr;
+
+   /// The slot this value belongs to.
+   unsigned int fSlot = std::numeric_limits<unsigned int>::max();
+
+   void *GetImpl(Long64_t entry) final
+   {
+      fDefine.Update(fSlot, entry);
+      return fCustomValuePtr;
+   }
+
+public:
+   RDefineReader(unsigned int slot, RDFDetail::RDefineBase &define, const std::type_info &tid)
+      : fDefine(define), fCustomValuePtr(define.GetValuePtr(slot)), fSlot(slot)
+   {
+      CheckDefineType(define, tid);
+   }
+};
+
+}
+}
+}
+
+#endif

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -11,7 +11,8 @@
 #ifndef ROOT_RFILTER
 #define ROOT_RFILTER
 
-#include "ROOT/RDF/ColumnReaders.hxx"
+#include "ROOT/RDF/ColumnReaderUtils.hxx"
+#include "ROOT/RDF/RColumnReaderBase.hxx"
 #include "ROOT/RDF/RCutFlowReport.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RDF/RFilterBase.hxx"

--- a/tree/dataframe/src/RDefineReader.cxx
+++ b/tree/dataframe/src/RDefineReader.cxx
@@ -8,7 +8,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RDF/ColumnReaders.hxx>
+#include <ROOT/RDF/RDefineReader.hxx>
 #include <ROOT/RDF/RDefineBase.hxx>
 #include <ROOT/RDF/Utils.hxx> // TypeID2TypeName
 #include <TClass.h>
@@ -17,7 +17,7 @@
 #include <string>
 #include <typeinfo>
 
-void ROOT::Internal::RDF::CheckDefine(RDefineBase &define, const std::type_info &tid)
+void ROOT::Internal::RDF::CheckDefineType(RDefineBase &define, const std::type_info &tid)
 {
    const auto &colTId = define.GetTypeId();
 


### PR DESCRIPTION
Besides being more in line with our coding conventions, we will need
the split to avoid circular includes between ColumnReaders.hxx and
RDataSource.hxx when we implement lazy RDS column readers.

This PR is NFC, at least in spirit, but let's see what the bot says anyway.