### PR TITLE
[clad] Bump clad version to v0.7.

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -32,11 +32,20 @@ if(MSVC)
     GIT_TAG v0.7
     UPDATE_COMMAND ""
     CMAKE_ARGS -G ${CMAKE_GENERATOR}
-               -DCLAD_BUILD_STATIC_ONLY=ON
                -DCMAKE_INSTALL_PREFIX=${clad_install_dir}/plugins
-               -DClang_DIR=${Clang_DIR}
                -DCLAD_PATH_TO_LLVM_BUILD=${LLVM_BINARY_DIR}
+
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+               -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+               -DLLVM_DIR=${LLVM_DIR}
+               -DClang_DIR=${Clang_DIR}
                -DCLANG_INCLUDE_DIRS=${CLANG_INCLUDE_DIRS}
+               -DCLAD_BUILD_STATIC_ONLY=ON
+
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${_clad_build_type}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build . --config ${_clad_build_type} --target install
     # Wrap download, configure and build steps in a script to log output

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -29,7 +29,7 @@ if(MSVC)
   ExternalProject_Add(
     clad
     GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-    GIT_TAG v0.6
+    GIT_TAG v0.7
     UPDATE_COMMAND ""
     CMAKE_ARGS -G ${CMAKE_GENERATOR}
                -DCLAD_BUILD_STATIC_ONLY=ON
@@ -61,7 +61,7 @@ else()
   ExternalProject_Add(
     clad
     GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-    GIT_TAG v0.6
+    GIT_TAG v0.7
     UPDATE_COMMAND ""
     CMAKE_ARGS -G ${CMAKE_GENERATOR}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -44,6 +44,7 @@ if(MSVC)
     LOG_CONFIGURE ON
     LOG_BUILD ON
     LOG_INSTALL ON
+    LOG_OUTPUT_ON_FAILURE ON
     # We need the target clangBasic to be built before building clad. However, we
     # support building prebuilt clang and adding clangBasic breaks this case.
     # Delegate the dependency resolution to the clingInterpreter target (which


### PR DESCRIPTION
The new release includes some improvements:
  * Implement hessian matrices via the clad::jacobian interface.

See more at: https://github.com/vgvassilev/clad/blob/v0.7/docs/ReleaseNotes.md

This patch should be the last part of the fix for ROOT-10886.