### PR TITLE
[RNTupleDS] Use lazy RNTupleColumnReaders

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -16,9 +16,11 @@
 #include "RDefineReader.hxx"
 #include "RDSColumnReader.hxx"
 #include "RTreeColumnReader.hxx"
+
+#include <ROOT/RDataSource.hxx>
+#include <ROOT/TypeTraits.hxx>
 #include <TError.h> // R__ASSERT
 #include <TTreeReader.h>
-#include <ROOT/TypeTraits.hxx>
 
 #include <array>
 #include <map>
@@ -36,32 +38,39 @@ namespace RDFDetail = ROOT::Detail::RDF;
 
 template <typename T>
 std::unique_ptr<RDFDetail::RColumnReaderBase>
-MakeColumnReader(unsigned int slot, RDFDetail::RDefineBase *define, TTreeReader *r,
+MakeColumnReader(unsigned int slot, RDFDetail::RDefineBase *define, TTreeReader *r, ROOT::RDF::RDataSource *ds,
                  const std::vector<void *> *DSValuePtrsPtr, const std::string &colName)
 {
    using Ret_t = std::unique_ptr<RDFDetail::RColumnReaderBase>;
 
-   if (define != nullptr)
+   if (define != nullptr) // it's a Define'd column
       return Ret_t(new RDefineReader(slot, *define, typeid(T)));
 
    if (DSValuePtrsPtr != nullptr) {
+      // reading from a RDataSource with the old column reader interface
       auto &DSValuePtrs = *DSValuePtrsPtr;
       return Ret_t(new RDSColumnReader<T>(DSValuePtrs[slot]));
    }
 
+   if (ds != nullptr) {
+      // reading from a RDataSource with the new column reader interface
+      return ds->GetColumnReaders(slot, colName, typeid(T));
+   }
+
+   // reading from a TTree
    return Ret_t(new RTreeColumnReader<T>(*r, colName));
 }
 
 template <typename T>
 std::unique_ptr<RDFDetail::RColumnReaderBase>
-MakeOneColumnReader(unsigned int slot, RDFDetail::RDefineBase *define,
-                    const std::map<std::string, std::vector<void *>> &DSValuePtrsMap, TTreeReader *r,
-                    const std::string &colName)
+MakeColumnReadersHelper(unsigned int slot, RDFDetail::RDefineBase *define,
+                        const std::map<std::string, std::vector<void *>> &DSValuePtrsMap, TTreeReader *r,
+                        ROOT::RDF::RDataSource *ds, const std::string &colName)
 {
    const auto DSValuePtrsIt = DSValuePtrsMap.find(colName);
    const std::vector<void *> *DSValuePtrsPtr = DSValuePtrsIt != DSValuePtrsMap.end() ? &DSValuePtrsIt->second : nullptr;
-   R__ASSERT(define != nullptr || r != nullptr || DSValuePtrsPtr != nullptr);
-   return MakeColumnReader<T>(slot, define, r, DSValuePtrsPtr, colName);
+   R__ASSERT(define != nullptr || r != nullptr || DSValuePtrsPtr != nullptr || ds != nullptr);
+   return MakeColumnReader<T>(slot, define, r, ds, DSValuePtrsPtr, colName);
 }
 
 /// This type aggregates some of the arguments passed to InitColumnReaders.
@@ -73,6 +82,7 @@ struct RColumnReadersInfo {
    const RBookedDefines &fCustomCols;
    const bool *fIsDefine;
    const std::map<std::string, std::vector<void *>> &fDSValuePtrsMap;
+   ROOT::RDF::RDataSource *fDataSource;
 };
 
 /// Create a group of column readers, one per type in the parameter pack.
@@ -87,17 +97,20 @@ MakeColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, cons
    const auto &customCols = colInfo.fCustomCols;
    const bool *isDefine = colInfo.fIsDefine;
    const auto &DSValuePtrsMap = colInfo.fDSValuePtrsMap;
+   auto *ds = colInfo.fDataSource;
 
    const auto &customColMap = customCols.GetColumns();
 
    int i = -1;
    std::array<std::unique_ptr<RDFDetail::RColumnReaderBase>, sizeof...(ColTypes)> ret{
-      {{(++i, MakeOneColumnReader<ColTypes>(slot, isDefine[i] ? customColMap.at(colNames[i]).get() : nullptr,
-                                            DSValuePtrsMap, r, colNames[i]))}...}};
+      {{(++i, MakeColumnReadersHelper<ColTypes>(slot, isDefine[i] ? customColMap.at(colNames[i]).get() : nullptr,
+                                                DSValuePtrsMap, r, ds, colNames[i]))}...}};
    return ret;
 
-   (void)slot;     // avoid _bogus_ "unused variable" warnings for slot on gcc 4.9
-   (void)r;        // avoid "unused variable" warnings for r on gcc5.2
+   // avoid bogus "unused variable" warnings
+   (void)ds;
+   (void)slot;
+   (void)r;
 }
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -35,11 +35,11 @@ using namespace ROOT::TypeTraits;
 namespace RDFDetail = ROOT::Detail::RDF;
 
 template <typename T>
-std::unique_ptr<RColumnReaderBase>
+std::unique_ptr<RDFDetail::RColumnReaderBase>
 MakeColumnReader(unsigned int slot, RDFDetail::RDefineBase *define, TTreeReader *r,
                  const std::vector<void *> *DSValuePtrsPtr, const std::string &colName)
 {
-   using Ret_t = std::unique_ptr<RColumnReaderBase>;
+   using Ret_t = std::unique_ptr<RDFDetail::RColumnReaderBase>;
 
    if (define != nullptr)
       return Ret_t(new RDefineReader(slot, *define, typeid(T)));
@@ -53,9 +53,10 @@ MakeColumnReader(unsigned int slot, RDFDetail::RDefineBase *define, TTreeReader 
 }
 
 template <typename T>
-std::unique_ptr<RColumnReaderBase> MakeOneColumnReader(unsigned int slot, RDFDetail::RDefineBase *define,
-                                                       const std::map<std::string, std::vector<void *>> &DSValuePtrsMap,
-                                                       TTreeReader *r, const std::string &colName)
+std::unique_ptr<RDFDetail::RColumnReaderBase>
+MakeOneColumnReader(unsigned int slot, RDFDetail::RDefineBase *define,
+                    const std::map<std::string, std::vector<void *>> &DSValuePtrsMap, TTreeReader *r,
+                    const std::string &colName)
 {
    const auto DSValuePtrsIt = DSValuePtrsMap.find(colName);
    const std::vector<void *> *DSValuePtrsPtr = DSValuePtrsIt != DSValuePtrsMap.end() ? &DSValuePtrsIt->second : nullptr;
@@ -78,7 +79,7 @@ struct RColumnReadersInfo {
 /// colInfo.fColNames and colInfo.fIsDefine are expected to have size equal to the parameter pack, and elements ordered
 /// accordingly, i.e. fIsDefine[0] refers to fColNames[0] which is of type "ColTypes[0]".
 template <typename... ColTypes>
-std::array<std::unique_ptr<RColumnReaderBase>, sizeof...(ColTypes)>
+std::array<std::unique_ptr<RDFDetail::RColumnReaderBase>, sizeof...(ColTypes)>
 MakeColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, const RColumnReadersInfo &colInfo)
 {
    // see RColumnReadersInfo for why we pass these arguments like this rather than directly as function arguments
@@ -90,7 +91,7 @@ MakeColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, cons
    const auto &customColMap = customCols.GetColumns();
 
    int i = -1;
-   std::array<std::unique_ptr<RColumnReaderBase>, sizeof...(ColTypes)> ret{
+   std::array<std::unique_ptr<RDFDetail::RColumnReaderBase>, sizeof...(ColTypes)> ret{
       {{(++i, MakeOneColumnReader<ColTypes>(slot, isDefine[i] ? customColMap.at(colNames[i]).get() : nullptr,
                                             DSValuePtrsMap, r, colNames[i]))}...}};
    return ret;

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -307,8 +307,11 @@ void AddDSColumnsHelper(const std::string &colName, RLoopManager &lm, RDataSourc
       return;
 
    const auto valuePtrs = ds.GetColumnReaders<T>(colName);
-   std::vector<void*> typeErasedValuePtrs(valuePtrs.begin(), valuePtrs.end());
-   lm.AddDSValuePtrs(colName, std::move(typeErasedValuePtrs));
+   if (!valuePtrs.empty()) {
+      // we are using the old GetColumnReaders mechanism
+      std::vector<void*> typeErasedValuePtrs(valuePtrs.begin(), valuePtrs.end());
+      lm.AddDSValuePtrs(colName, std::move(typeErasedValuePtrs));
+   }
 }
 
 /// Take list of column names that must be defined, current map of custom columns, current list of defined column names,
@@ -396,7 +399,7 @@ void JitDefineHelper(F &&f, const ColumnNames_t &cols, std::string_view name, RL
    const auto dummyType = "jittedCol_t";
    // use unique_ptr<RDefineBase> instead of make_unique<NewCol_t> to reduce jit/compile-times
    jittedDefine->SetDefine(std::unique_ptr<RDefineBase>(
-      new NewCol_t(name, dummyType, std::forward<F>(f), cols, lm->GetNSlots(), *defines, lm->GetDSValuePtrs())));
+      new NewCol_t(name, dummyType, std::forward<F>(f), cols, lm->GetNSlots(), *defines, lm->GetDSValuePtrs(), ds)));
 
    // defines points to the columns structure in the heap, created before the jitted call so that the jitter can
    // share data after it has lazily compiled the code. Here the data has been used and the memory can be freed.

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -54,7 +54,7 @@ class RAction : public RActionBase {
    const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
    PrevDataFrame &fPrevData;
    /// Column readers per slot and per input column
-   std::vector<std::array<std::unique_ptr<RDFInternal::RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -92,7 +92,7 @@ public:
       for (auto &bookedBranch : GetDefines().GetColumns())
          bookedBranch.second->InitSlot(r, slot);
       RDFInternal::RColumnReadersInfo info{RActionBase::GetColumnNames(), RActionBase::GetDefines(), fIsDefine.data(),
-                                           fLoopManager->GetDSValuePtrs()};
+                                           fLoopManager->GetDSValuePtrs(), fLoopManager->GetDataSource()};
       fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
       fHelper.InitTask(r, slot);
    }

--- a/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
@@ -14,7 +14,7 @@
 #include <Rtypes.h>
 
 namespace ROOT {
-namespace Internal {
+namespace Detail {
 namespace RDF {
 
 /**
@@ -43,7 +43,7 @@ private:
 };
 
 } // namespace RDF
-} // namespace Internal
+} // namespace Detail
 } // namespace ROOT
 
 #endif

--- a/tree/dataframe/inc/ROOT/RDF/RDSColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDSColumnReader.hxx
@@ -20,7 +20,7 @@ namespace RDF {
 
 /// Column reader type that deals with values read from RDataSources.
 template <typename T>
-class R__CLING_PTRCHECK(off) RDSColumnReader final : public RColumnReaderBase {
+class R__CLING_PTRCHECK(off) RDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    T **fDSValuePtr = nullptr;
 
    void *GetImpl(Long64_t) final { return *fDSValuePtr; }

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -100,8 +100,8 @@ class RDefine final : public RDefineBase {
 public:
    RDefine(std::string_view name, std::string_view type, F expression, const ColumnNames_t &columns,
                  unsigned int nSlots, const RDFInternal::RBookedDefines &defines,
-                 const std::map<std::string, std::vector<void *>> &DSValuePtrs)
-      : RDefineBase(name, type, nSlots, defines, DSValuePtrs), fExpression(std::move(expression)),
+                 const std::map<std::string, std::vector<void *>> &DSValuePtrs, ROOT::RDF::RDataSource *ds)
+      : RDefineBase(name, type, nSlots, defines, DSValuePtrs, ds), fExpression(std::move(expression)),
         fColumnNames(columns), fLastResults(fNSlots), fValues(fNSlots), fIsDefine()
    {
       const auto nColumns = fColumnNames.size();
@@ -116,7 +116,7 @@ public:
    {
       if (!fIsInitialized[slot]) {
          fIsInitialized[slot] = true;
-         RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fDSValuePtrs};
+         RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fDSValuePtrs, fDataSource};
          fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
          fLastCheckedEntry[slot] = -1;
       }

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -64,7 +64,7 @@ class RDefine final : public RDefineBase {
    ValuesPerSlot_t fLastResults;
 
    /// Column readers per slot and per input column
-   std::vector<std::array<std::unique_ptr<RDFInternal::RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;

--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -23,6 +23,9 @@
 class TTreeReader;
 
 namespace ROOT {
+namespace RDF {
+class RDataSource;
+}
 namespace Detail {
 namespace RDF {
 
@@ -42,13 +45,14 @@ protected:
    RDFInternal::RBookedDefines fDefines;
    std::deque<bool> fIsInitialized; // because vector<bool> is not thread-safe
    const std::map<std::string, std::vector<void *>> &fDSValuePtrs; // reference to RLoopManager's data member
+   ROOT::RDF::RDataSource *fDataSource; ///< non-owning ptr to the RDataSource, if any. Used to retrieve column readers.
 
    static unsigned int GetNextID();
 
 public:
    RDefineBase(std::string_view name, std::string_view type, unsigned int nSlots,
-                     const RDFInternal::RBookedDefines &defines,
-                     const std::map<std::string, std::vector<void *>> &DSValuePtrs);
+               const RDFInternal::RBookedDefines &defines,
+               const std::map<std::string, std::vector<void *>> &DSValuePtrs, ROOT::RDF::RDataSource *ds);
 
    RDefineBase &operator=(const RDefineBase &) = delete;
    RDefineBase &operator=(RDefineBase &&) = delete;

--- a/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
@@ -27,7 +27,7 @@ namespace RDFDetail = ROOT::Detail::RDF;
 void CheckDefineType(RDFDetail::RDefineBase &define, const std::type_info &tid);
 
 /// Column reader for defined (aka custom) columns.
-class R__CLING_PTRCHECK(off) RDefineReader final : public RColumnReaderBase {
+class R__CLING_PTRCHECK(off) RDefineReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    /// Non-owning reference to the node responsible for the custom column. Needed when querying custom values.
    RDFDetail::RDefineBase &fDefine;
 

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -58,7 +58,7 @@ class RFilter final : public RFilterBase {
    const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
    PrevDataFrame &fPrevData;
    /// Column readers per slot and per input column
-   std::vector<std::array<std::unique_ptr<RDFInternal::RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
 

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -110,7 +110,8 @@ public:
    {
       for (auto &bookedBranch : fDefines.GetColumns())
          bookedBranch.second->InitSlot(r, slot);
-      RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fLoopManager->GetDSValuePtrs()};
+      RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
+                                           fLoopManager->GetDataSource()};
       fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2210,9 +2210,9 @@ private:
       using NewColEntry_t =
          RDFDetail::RDefine<decltype(entryColGen), RDFDetail::CustomColExtraArgs::SlotAndEntry>;
 
-      auto entryColumn =
-         std::make_shared<NewColEntry_t>(entryColName, entryColType, std::move(entryColGen), ColumnNames_t{},
-                                         fLoopManager->GetNSlots(), newCols, fLoopManager->GetDSValuePtrs());
+      auto entryColumn = std::make_shared<NewColEntry_t>(entryColName, entryColType, std::move(entryColGen),
+                                                         ColumnNames_t{}, fLoopManager->GetNSlots(), newCols,
+                                                         fLoopManager->GetDSValuePtrs(), fDataSource);
       newCols.AddName(entryColName);
       newCols.AddColumn(entryColumn, entryColName);
 
@@ -2222,9 +2222,9 @@ private:
       auto slotColGen = [](unsigned int slot) { return slot; };
       using NewColSlot_t = RDFDetail::RDefine<decltype(slotColGen), RDFDetail::CustomColExtraArgs::Slot>;
 
-      auto slotColumn =
-         std::make_shared<NewColSlot_t>(slotColName, slotColType, std::move(slotColGen), ColumnNames_t{},
-                                        fLoopManager->GetNSlots(), newCols, fLoopManager->GetDSValuePtrs());
+      auto slotColumn = std::make_shared<NewColSlot_t>(slotColName, slotColType, std::move(slotColGen), ColumnNames_t{},
+                                                       fLoopManager->GetNSlots(), newCols,
+                                                       fLoopManager->GetDSValuePtrs(), fDataSource);
       newCols.AddName(slotColName);
       newCols.AddColumn(slotColumn, slotColName);
 
@@ -2335,7 +2335,7 @@ private:
       using NewCol_t = RDFDetail::RDefine<F, DefineType>;
       auto newColumn =
          std::make_shared<NewCol_t>(name, retTypeName, std::forward<F>(expression), validColumnNames,
-                                    fLoopManager->GetNSlots(), fDefines, fLoopManager->GetDSValuePtrs());
+                                    fLoopManager->GetNSlots(), fDefines, fLoopManager->GetDSValuePtrs(), fDataSource);
 
       RDFInternal::RBookedDefines newCols(fDefines);
       newCols.AddName(name);

--- a/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
@@ -34,7 +34,7 @@ class RJittedDefine : public RDefineBase {
 public:
    RJittedDefine(std::string_view name, std::string_view type, unsigned int nSlots,
                        const std::map<std::string, std::vector<void *>> &DSValuePtrs)
-      : RDefineBase(name, type, nSlots, RDFInternal::RBookedDefines(), DSValuePtrs)
+      : RDefineBase(name, type, nSlots, RDFInternal::RBookedDefines(), DSValuePtrs, nullptr)
    {
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
@@ -28,7 +28,7 @@ namespace RDF {
 
 /// RTreeColumnReader specialization for TTree values read via TTreeReaderValues
 template <typename T>
-class R__CLING_PTRCHECK(off) RTreeColumnReader final : public RColumnReaderBase {
+class R__CLING_PTRCHECK(off) RTreeColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    std::unique_ptr<TTreeReaderValue<T>> fTreeValue;
 
    void *GetImpl(Long64_t) final { return fTreeValue->Get(); }
@@ -54,7 +54,7 @@ public:
 ///
 /// TTreeReaderArrays are used whenever the RDF column type is RVec<T>.
 template <typename T>
-class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<T>> final : public RColumnReaderBase {
+class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<T>> final : public ROOT::Detail::RDF::RColumnReaderBase {
    std::unique_ptr<TTreeReaderArray<T>> fTreeArray;
 
    /// Enumerator for the memory layout of the branch
@@ -141,7 +141,7 @@ public:
 ///
 /// TTreeReaderArray<bool> is used whenever the RDF column type is RVec<bool>.
 template <>
-class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<bool>> final : public RColumnReaderBase {
+class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<bool>> final : public ROOT::Detail::RDF::RColumnReaderBase {
 
    std::unique_ptr<TTreeReaderArray<bool>> fTreeArray;
 

--- a/tree/dataframe/inc/ROOT/RDataSource.hxx
+++ b/tree/dataframe/inc/ROOT/RDataSource.hxx
@@ -11,6 +11,7 @@
 #ifndef ROOT_RDATASOURCE
 #define ROOT_RDATASOURCE
 
+#include "RDF/RColumnReaderBase.hxx"
 #include "ROOT/RStringView.hxx"
 #include "RtypesCore.h" // ULong64_t
 #include "TString.h"
@@ -111,6 +112,9 @@ protected:
    virtual std::string AsString() { return "generic data source"; };
 
 public:
+   /// Tag type used to indicate that newer versions of RDataSource interfaces should be invoked
+   static struct RV2Interface{} V2;
+
    virtual ~RDataSource() = default;
 
    // clang-format off
@@ -151,6 +155,17 @@ public:
       std::transform(typeErasedVec.begin(), typeErasedVec.end(), typedVec.begin(),
                      [](void *p) { return static_cast<T **>(p); });
       return typedVec;
+   }
+
+   /// If the other GetColumnReaders overload returns an empty vector, this overload will be called instead.
+   /// \param[in] slot The data processing slot that needs to be considered
+   /// \param[in] name The name of the column for which a column reader needs to be returned
+   /// \param[in] tid A type_info
+   /// At least one of the two must return a non-empty/non-null value.
+   virtual std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase>
+   GetColumnReaders(unsigned int /*slot*/, std::string_view /*name*/, const std::type_info &)
+   {
+      return {};
    }
 
    // clang-format off

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -1,12 +1,13 @@
 /// \file RNTupleDS.hxx
 /// \ingroup NTuple ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch>
+/// \author Enrico Guiraud <enrico.guiraud@cern.ch>
 /// \date 2018-10-04
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -35,17 +36,12 @@ namespace Detail {
 class RFieldBase;
 class RFieldValue;
 class RPageSource;
-} // namespace Detail
 
+} // namespace Detail
 
 class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// Clones of the first source, one for each slot
    std::vector<std::unique_ptr<ROOT::Experimental::Detail::RPageSource>> fSources;
-
-   /// Fields and values for all active columns and all slots
-   std::vector<std::vector<std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>>> fFields;
-   std::vector<std::vector<Detail::RFieldValue>> fValues;
-   std::vector<std::vector<void *>> fValuePtrs;
 
    std::vector<std::string> fColumnNames;
    std::vector<std::string> fColumnTypes;
@@ -70,6 +66,9 @@ public:
 
    void Initialise() final;
    void Finalise() final;
+
+   std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase>
+   GetColumnReaders(unsigned int /*slot*/, std::string_view /*name*/, const std::type_info &) final;
 
 protected:
    Record_t GetColumnReadersImpl(std::string_view name, const std::type_info &) final;

--- a/tree/dataframe/src/RDefineBase.cxx
+++ b/tree/dataframe/src/RDefineBase.cxx
@@ -27,9 +27,9 @@ unsigned int RDefineBase::GetNextID()
 
 RDefineBase::RDefineBase(std::string_view name, std::string_view type, unsigned int nSlots,
                          const RDFInternal::RBookedDefines &defines,
-                         const std::map<std::string, std::vector<void *>> &DSValuePtrs)
+                         const std::map<std::string, std::vector<void *>> &DSValuePtrs, ROOT::RDF::RDataSource *ds)
    : fName(name), fType(type), fNSlots(nSlots), fLastCheckedEntry(fNSlots, -1), fDefines(defines),
-     fIsInitialized(nSlots, false), fDSValuePtrs(DSValuePtrs)
+     fIsInitialized(nSlots, false), fDSValuePtrs(DSValuePtrs), fDataSource(ds)
 {
 }
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -1,18 +1,20 @@
 /// \file RNTupleDS.cxx
 /// \ingroup NTuple ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch>
+/// \author Enrico Guiraud <enrico.guiraud@cern.ch>
 /// \date 2018-10-04
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#include <ROOT/RDF/RColumnReaderBase.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
@@ -30,6 +32,43 @@
 
 namespace ROOT {
 namespace Experimental {
+namespace Detail {
+class RNTupleColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
+   using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
+   using RFieldValue = ROOT::Experimental::Detail::RFieldValue;
+   using RPageSource = ROOT::Experimental::Detail::RPageSource;
+
+   std::unique_ptr<RFieldBase> fField;
+   RFieldValue fValue;
+   Long64_t fLastEntry; ///< Last entry number that was read
+
+   std::unique_ptr<RFieldBase> MakeField(const std::string &colName, RPageSource &source)
+   {
+      const auto &descriptor = source.GetDescriptor();
+      const auto fieldId = descriptor.FindFieldId(colName);
+      const auto &fieldDescriptor = descriptor.GetFieldDescriptor(fieldId);
+      const auto typeName = fieldDescriptor.GetTypeName();
+      auto fieldBasePtr = Detail::RFieldBase::Create(fieldDescriptor.GetFieldName(), typeName);
+      Detail::RFieldFuse::ConnectRecursively(fieldId, source, *fieldBasePtr);
+      return std::unique_ptr<RFieldBase>(fieldBasePtr);
+   }
+
+public:
+   RNTupleColumnReader(const std::string &colName, RPageSource &source)
+      : fField(MakeField(colName, source)), fValue(fField->GenerateValue()), fLastEntry(-1)
+   {
+   }
+
+   void *GetImpl(Long64_t entry) final
+   {
+      if (entry != fLastEntry) {
+         fField->Read(entry, &fValue);
+         fLastEntry = entry;
+      }
+      return fValue.GetRawPtr();
+   }
+};
+} // namespace Detail
 
 void ROOT::Experimental::RNTupleDS::AddFields(const RNTupleDescriptor &desc, DescriptorId_t parentId)
 {
@@ -53,39 +92,20 @@ ROOT::Experimental::RNTupleDS::RNTupleDS(std::unique_ptr<Detail::RPageSource> pa
    fSources.emplace_back(std::move(pageSource));
 }
 
-
-RDF::RDataSource::Record_t RNTupleDS::GetColumnReadersImpl(std::string_view name, const std::type_info& /* ti */)
+RDF::RDataSource::Record_t RNTupleDS::GetColumnReadersImpl(std::string_view /* name */, const std::type_info & /* ti */)
 {
-   const auto colIdx = std::distance(
-      fColumnNames.begin(), std::find(fColumnNames.begin(), fColumnNames.end(), name));
-   // TODO(jblomer): check expected type info like in, e.g., RRootDS.cxx
-
-   std::vector<void*> ptrs;
-   for (unsigned int slot = 0; slot < fNSlots; ++slot) {
-      if (!fValuePtrs[slot][colIdx]) {
-         const auto &descriptor = fSources[slot]->GetDescriptor();
-         auto colName = fColumnNames[colIdx];
-         auto typeName = fColumnTypes[colIdx];
-         auto fieldId = descriptor.FindFieldId(colName);
-         fFields[slot][colIdx] = std::unique_ptr<Detail::RFieldBase>(
-            Detail::RFieldBase::Create(descriptor.GetFieldDescriptor(fieldId).GetFieldName(), typeName));
-         Detail::RFieldFuse::ConnectRecursively(fieldId, *fSources[slot], *fFields[slot][colIdx]);
-         fValues[slot][colIdx] = fFields[slot][colIdx]->GenerateValue();
-         fValuePtrs[slot][colIdx] = fValues[slot][colIdx].GetRawPtr();
-         if (slot == 0)
-            fActiveColumns.emplace_back(colIdx);
-      }
-      ptrs.push_back(&fValuePtrs[slot][colIdx]);
-   }
-
-   return ptrs;
+   // This datasource uses the GetColumnReaders2 API instead (better name in the works)
+   return {};
 }
 
-bool RNTupleDS::SetEntry(unsigned int slot, ULong64_t entryIndex)
+std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase>
+RNTupleDS::GetColumnReaders(unsigned int slot, std::string_view name, const std::type_info & /*tid*/)
 {
-   for (auto colIdx : fActiveColumns) {
-      fFields[slot][colIdx]->Read(entryIndex, &fValues[slot][colIdx]);
-   }
+   return std::make_unique<ROOT::Experimental::Detail::RNTupleColumnReader>(std::string(name), *fSources[slot]);
+}
+
+bool RNTupleDS::SetEntry(unsigned int, ULong64_t)
+{
    return true;
 }
 
@@ -144,20 +164,10 @@ void RNTupleDS::SetNSlots(unsigned int nSlots)
    R__ASSERT(nSlots > 0);
    fNSlots = nSlots;
 
-   fFields.resize(fNSlots);
-   fValues.resize(fNSlots);
-   fValuePtrs.resize(fNSlots);
    for (unsigned int i = 1; i < fNSlots; ++i) {
       fSources.emplace_back(fSources[0]->Clone());
       R__ASSERT(i == (fSources.size() - 1));
       fSources[i]->Attach();
-   }
-
-   auto nColumns = fColumnNames.size();
-   for (unsigned int i = 0; i < fNSlots; ++i) {
-      fFields[i].resize(nColumns);
-      fValues[i].resize(nColumns);
-      fValuePtrs[i].resize(nColumns, nullptr);
    }
 }
 


### PR DESCRIPTION
This PR adds a new version of the `RDataSource::GetColumnReaders` method. This new version allows the implementation of per-datasource, lazy column readers that know how to communicate with the concrete associated datasource type.

As a consequence, datasource implementations are not required to load
values of all required columns when `RDataSource::SetEntry` is called, but
the loading can be delayed to the moment in which a value is actually
needed. In case of strict upstream `Filters`, this should result in
less work performed and therefore improved runtimes.

For the `lhcb` benchmark at https://github.com/jblomer/iotools, using the new lazy column readers for `RNTupleDS` results in a 40% runtime improvement. 