### PR TITLE
Actually 'inherit' compression setting even if TTree is no attached.

### DIFF
--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -1211,7 +1211,11 @@ Int_t TBasket::WriteBuffer()
    fHeaderOnly = kTRUE;
    fCycle = fBranch->GetWriteBasket();
    Int_t cxlevel = fBranch->GetCompressionLevel();
+   if (cxlevel == ROOT::RCompressionSetting::ELevel::kInherit)
+      cxlevel = file->GetCompressionLevel();
    ROOT::RCompressionSetting::EAlgorithm::EValues cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(fBranch->GetCompressionAlgorithm());
+   if (cxAlgorithm == ROOT::RCompressionSetting::EAlgorithm::kInherit)
+      cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(file->GetCompressionAlgorithm());
    if (cxlevel > 0) {
       Int_t nbuffers = 1 + (fObjlen - 1) / kMAXZIPBUF;
       Int_t buflen = fKeylen + fObjlen + 9 * nbuffers + 28; //add 28 bytes in case object is placed in a deleted gap


### PR DESCRIPTION
When writing an in-memory TTree to a file without first attaching it, we still need to take cues from the file
for the compression setting if the user has not specified any.

This fixes issue #6350

Fixes #6350