### PR TITLE
Fix for missing type attribute in triangular and quadrangular GDML tags.

### DIFF
--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -4212,6 +4212,7 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine *gdml, XMLNodePointer_t node
       tempattr.ToLower();
       if (tempattr == "triangular") {
          attr = gdml->GetFirstAttr(child);
+         bool relative = false;
 
          while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
@@ -4246,17 +4247,17 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine *gdml, XMLNodePointer_t node
             else if (tempattr == "type") {
                type = gdml->GetAttrValue(attr);
                type.ToLower();
-               bool relative = (type == "relative") ? true : false;
-               AddTriangularFacet(relative);
+               relative = (type == "relative") ? true : false;
             }
 
             attr = gdml->GetNextAttr(attr);
          }
-
+         AddTriangularFacet(relative);
       }
 
       else if (tempattr == "quadrangular") {
          attr = gdml->GetFirstAttr(child);
+         bool relative = false;
 
          while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
@@ -4300,12 +4301,12 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine *gdml, XMLNodePointer_t node
             else if (tempattr == "type") {
                type = gdml->GetAttrValue(attr);
                type.ToLower();
-               bool relative = (type == "relative") ? true : false;
-               AddQuadrangularFacet(relative);
+               relative = (type == "relative") ? true : false;
             }
 
             attr = gdml->GetNextAttr(attr);
          }
+         AddQuadrangularFacet(relative);
       }
       child = gdml->GetNext(child);
    }


### PR DESCRIPTION
This fixes the GDML parsing for the "triangular" and "quadrangular" GDML tags missing the type attribute, which defaults to "ABSOLUTE" now. This addresses the forum report: https://root-forum.cern.ch/t/reading-gdml-file-in-root-6-14/41408