### PR TITLE
[Hist][Docs] Revise TH1 documentation.

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -176,10 +176,10 @@ Histograms may also be created by:
  Axis titles can be specified in the title argument of the constructor.
  They must be separated by ";":
 ~~~ {.cpp}
-        TH1F* h=new TH1F("h", "Histogram title;X Axis;Y Axis;Z Axis", 100, 0, 1);
+        TH1F* h=new TH1F("h", "Histogram title;X Axis;Y Axis", 100, 0, 1);
 ~~~
  The histogram title and the axis titles can be any TLatex string, and
- are persist if a histogram is written to a file.
+ are persisted if a histogram is written to a file.
 
  Any title can be omitted:
 ~~~ {.cpp}


### PR DESCRIPTION
After being notified that beginners were unable to label the axes of a
histogram, I revised the TH1 documentation a bit, such that the words
"axis labels" can now be found on the doxygen page.
Some lvl4 headers were converted in lvl2, so there is a bit more
structure, and a simple table of contents was added. Unfortunately,
doxygen doesn't support an automatic table of contents in class
documentation.