### PR TITLE
[DF] Introduce ROOT::RDF::RunGraphs

### DIFF
--- a/README/ReleaseNotes/v624/index.md
+++ b/README/ReleaseNotes/v624/index.md
@@ -71,6 +71,7 @@ See the discussion at [ROOT-11014](https://sft.its.cern.ch/jira/browse/ROOT-1101
 - With [ROOT-10023](https://sft.its.cern.ch/jira/browse/ROOT-10023) fixed, RDataFrame can now read and write certain branches containing unsplit objects, i.e. TBranchObjects. More information is available at [ROOT-10022](https://sft.its.cern.ch/jira/browse/ROOT-10022).
 - Snapshot now respects the basket size and split level of the original branch when copying branches to a new TTree.
 - For some `TTrees`, RDataFrame's `GetColumnNames` method returns multiple valid spellings for a given column. For example, leaf `"l"` under branch `"b"` might now be mentioned as `"l"` as well as `"b.l"`, while only one of the two spellings might have been recognized before.
+- Introduce `ROOT::RDF::RunGraphs`, which allows to compute the results of multiple RDataFrames concurrently while sharing the same thread pool. The computation may be more efficient than running the RDataFrames sequentially if an analysis consists of many RDataFrames, which don't have enough data to fully utilize the available resources.
 
 ## Histogram Libraries
 

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -39,6 +39,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDFHelpers.hxx
     ROOT/RLazyDS.hxx
     ROOT/RResultPtr.hxx
+    ROOT/RResultHandle.hxx
     ROOT/RRootDS.hxx
     ROOT/RSnapshotOptions.hxx
     ROOT/RTrivialDS.hxx
@@ -89,6 +90,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RDFHistoModels.cxx
     src/RDFInterfaceUtils.cxx
     src/RDFUtils.cxx
+    src/RDFHelpers.cxx
     src/RFilterBase.cxx
     src/RJittedAction.cxx
     src/RJittedDefine.cxx

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -14,6 +14,7 @@
 #define ROOT_RDF_HELPERS
 
 #include <ROOT/RDataFrame.hxx>
+#include <ROOT/RResultHandle.hxx>
 #include <ROOT/RDF/GraphUtils.hxx>
 #include <ROOT/RIntegerSequence.hxx>
 #include <ROOT/TypeTraits.hxx>
@@ -146,6 +147,29 @@ RNode AsRNode(NodeType node)
 {
    return node;
 }
+
+// clang-format off
+/// Trigger the event loop of multiple RDataFrames concurrently
+/// \param[in] handles A vector of RResultHandles
+///
+/// This function triggers the event loop of all computation graphs which relate to the
+/// given RResultHandles. The advantage compared to running the event loop implicitly by accessing the
+/// RResultPtr is that the event loops will run concurrently. Therefore, the overall
+/// computation of all results is generally more efficient.
+/// It should be noted that user-defined operations (e.g., Filters and Defines) of the different RDataFrame graphs are assumed to be safe to call concurrently.
+///
+/// ~~~{.cpp}
+/// ROOT::RDataFrame df1("tree1", "file1.root");
+/// auto r1 = df1.Histo1D("var1");
+///
+/// ROOT::RDataFrame df2("tree2", "file2.root");
+/// auto r2 = df2.Sum("var2");
+///
+/// // RResultPtr -> RResultHandle conversion is automatic
+/// ROOT::RDF::RunGraphs({r1, r2});
+/// ~~~
+// clang-format on
+void RunGraphs(std::vector<RResultHandle> handles);
 
 } // namespace RDF
 } // namespace ROOT

--- a/tree/dataframe/inc/ROOT/RResultHandle.hxx
+++ b/tree/dataframe/inc/ROOT/RResultHandle.hxx
@@ -1,0 +1,114 @@
+// Author: Stefan Wunsch, Enrico Guiraud CERN  09/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RRESULTHANDLE
+#define ROOT_RDF_RRESULTHANDLE
+
+#include "ROOT/RResultPtr.hxx"
+#include "ROOT/RDF/RLoopManager.hxx"
+#include "ROOT/RDF/RActionBase.hxx"
+#include "ROOT/RDF/Utils.hxx" // TypeID2TypeName
+
+#include <memory>
+#include <sstream>
+#include <typeinfo>
+#include <stdexcept> // std::runtime_error
+
+namespace ROOT {
+namespace RDF {
+
+class RResultHandle {
+   ROOT::Detail::RDF::RLoopManager* fLoopManager; //< Pointer to the loop manager
+   /// Owning pointer to the action that will produce this result.
+   /// Ownership is shared with RResultPtrs and RResultHandles that refer to the same result.
+   std::shared_ptr<ROOT::Internal::RDF::RActionBase> fActionPtr;
+   std::shared_ptr<void> fObjPtr; ///< Type erased shared pointer encapsulating the wrapped result
+   const std::type_info& fType; ///< Type of the wrapped result
+
+   // The ROOT::RDF::RunGraphs helper has to access the loop manager to check whether two RResultHandles belong to the same computation graph
+   friend void RunGraphs(std::vector<RResultHandle>);
+
+   /// Get the pointer to the encapsulated result.
+   /// Ownership is not transferred to the caller.
+   /// Triggers event loop and execution of all actions booked in the associated RLoopManager.
+   void* Get()
+   {
+      if (!fActionPtr->HasRun())
+         fLoopManager->Run();
+      return fObjPtr.get();
+   }
+
+   /// Compare given type to the type of the wrapped result and throw if the types don't match.
+   void CheckType(const std::type_info& type)
+   {
+      if (fType != type) {
+         std::stringstream ss;
+         ss << "Got the type " << ROOT::Internal::RDF::TypeID2TypeName(type)
+            << " but the RResultHandle refers to a result of type " << ROOT::Internal::RDF::TypeID2TypeName(fType)
+            << ".";
+         throw std::runtime_error(ss.str());
+      }
+   }
+
+public:
+   template <class T>
+   RResultHandle(const RResultPtr<T> &resultPtr) : fLoopManager(resultPtr.fLoopManager), fActionPtr(resultPtr.fActionPtr), fObjPtr(resultPtr.fObjPtr), fType(typeid(T)) {}
+
+   RResultHandle(const RResultHandle&) = default;
+   RResultHandle(RResultHandle&&) = default;
+
+   /// Get the pointer to the encapsulated object.
+   /// Triggers event loop and execution of all actions booked in the associated RLoopManager.
+   /// \tparam T Type of the action result
+   template <class T>
+   T* GetPtr()
+   {
+      CheckType(typeid(T));
+      return static_cast<T*>(Get());
+   }
+
+   /// Get a const reference to the encapsulated object.
+   /// Triggers event loop and execution of all actions booked in the associated RLoopManager.
+   /// \tparam T Type of the action result
+   template <class T>
+   const T& GetValue()
+   {
+      CheckType(typeid(T));
+      return *static_cast<T*>(Get());
+   }
+
+   /// Check whether the result has already been computed
+   ///
+   /// ~~~{.cpp}
+   /// std::vector<RResultHandle> results;
+   /// results.emplace_back(df.Mean<double>("var"));
+   /// res.IsReady(); // false, access will trigger event loop
+   /// std::cout << res.GetValue<double>() << std::endl; // triggers event loop
+   /// res.IsReady(); // true
+   /// ~~~
+   bool IsReady() const {
+      return fActionPtr->HasRun();
+   }
+
+   bool operator==(const RResultHandle &rhs) const
+   {
+      return fObjPtr == rhs.fObjPtr;
+   }
+
+   bool operator!=(const RResultHandle &rhs) const
+   {
+      return !(fObjPtr == rhs.fObjPtr);
+   }
+};
+
+} // namespace RDF
+} // namespace ROOT
+
+#endif // ROOT_RDF_RRESULTHANDLE

--- a/tree/dataframe/inc/ROOT/RResultPtr.hxx
+++ b/tree/dataframe/inc/ROOT/RResultPtr.hxx
@@ -299,6 +299,14 @@ public:
       fLoopManager->RegisterCallback(everyNEvents, std::move(c));
       return *this;
    }
+
+   // clang-format off
+   /// Check whether the result has already been computed
+   // clang-format on
+   bool IsReady()
+   {
+      return fActionPtr->HasRun();
+   }
 };
 
 template <typename T>

--- a/tree/dataframe/inc/ROOT/RResultPtr.hxx
+++ b/tree/dataframe/inc/ROOT/RResultPtr.hxx
@@ -103,6 +103,8 @@ class RResultPtr {
 
    friend class ROOT::Internal::RDF::GraphDrawing::GraphCreatorHelper;
 
+   friend class RResultHandle;
+
    /// \cond HIDDEN_SYMBOLS
    template <typename V, bool hasBeginEnd = TTraits::HasBeginAndEnd<V>::value>
    struct RIterationHelper {
@@ -302,8 +304,15 @@ public:
 
    // clang-format off
    /// Check whether the result has already been computed
+   ///
+   /// ~~~{.cpp}
+   /// auto res = df.Count();
+   /// res.IsReady(); // false, access will trigger event loop
+   /// std::cout << *res << std::endl; // triggers event loop
+   /// res.IsReady(); // true
+   /// ~~~
    // clang-format on
-   bool IsReady()
+   bool IsReady() const
    {
       return fActionPtr->HasRun();
    }

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -1,0 +1,59 @@
+// Author: Stefan Wunsch, Enrico Guiraud CERN  09/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RDFHelpers.hxx"
+#include "TROOT.h"      // IsImplicitMTEnabled
+#include "TError.h"     // Warning
+#include "RConfigure.h" // R__USE_IMT
+#ifdef R__USE_IMT
+#include "ROOT/TThreadExecutor.hxx"
+#endif // R__USE_IMT
+
+#include <set>
+
+using ROOT::RDF::RResultHandle;
+
+void ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
+{
+   if (handles.empty()) {
+      Warning("RunGraphs", "Got an empty list of handles");
+      return;
+   }
+
+   // Check that there are results which have not yet been run
+   unsigned int nNotRun = 0;
+   for (const auto &h : handles) {
+      if (!h.IsReady())
+         nNotRun++;
+   }
+   if (nNotRun < handles.size()) {
+      Warning("RunGraphs", "Got %lu handles from which %lu link to results which are already ready.", handles.size(),
+              handles.size() - nNotRun);
+      return;
+   }
+   if (nNotRun == 0)
+      return;
+
+   // Find the unique event loops
+   auto sameGraph = [](const RResultHandle &a, const RResultHandle &b) { return a.fLoopManager != b.fLoopManager; };
+   std::set<RResultHandle, decltype(sameGraph)> s(handles.begin(), handles.end(), sameGraph);
+   std::vector<RResultHandle> uniqueLoops(s.begin(), s.end());
+
+   // Trigger the unique event loops
+   auto run = [](RResultHandle &h) { h.fLoopManager->Run(); };
+#ifdef R__USE_IMT
+   if (ROOT::IsImplicitMTEnabled()) {
+      ROOT::TThreadExecutor{}.Foreach(run, uniqueLoops);
+      return;
+   }
+#endif // R__USE_IMT
+   for (auto &h : uniqueLoops)
+      run(h);
+}

--- a/tree/dataframe/test/dataframe_resptr.cxx
+++ b/tree/dataframe/test/dataframe_resptr.cxx
@@ -64,3 +64,13 @@ TEST(RResultPtr, ImplConv)
    EXPECT_TRUE(m != nullptr);
    EXPECT_TRUE(hasRun);
 }
+
+TEST(RResultPtr, IsReady)
+{
+   ROOT::RDataFrame d(1);
+   auto p = d.Define("x", "rdfentry_").Sum("x");
+   EXPECT_FALSE(p.IsReady());
+
+   p.GetValue();
+   EXPECT_TRUE(p.IsReady());
+}

--- a/tree/dataframe/test/dataframe_resptr.cxx
+++ b/tree/dataframe/test/dataframe_resptr.cxx
@@ -1,5 +1,12 @@
-#include <ROOT/RDataFrame.hxx>
+#include "ROOTUnitTestSupport.h"
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RResultHandle.hxx"
+
 #include "gtest/gtest.h"
+
+#include <vector>
+#include <cstddef>
+
 using namespace ROOT::RDF;
 
 class Dummy {
@@ -67,10 +74,133 @@ TEST(RResultPtr, ImplConv)
 
 TEST(RResultPtr, IsReady)
 {
-   ROOT::RDataFrame d(1);
-   auto p = d.Define("x", "rdfentry_").Sum("x");
+   ROOT::RDataFrame df(1);
+   auto p = df.Sum<ULong64_t>("rdfentry_");
    EXPECT_FALSE(p.IsReady());
 
    p.GetValue();
    EXPECT_TRUE(p.IsReady());
+}
+
+TEST(RResultHandle, Ctor)
+{
+   ROOT::RDataFrame df(3);
+   auto df2 = df.Define("x", [] { return 1.f; }, {});
+   auto r1 = df2.Histo1D<float>("x");
+   auto r2 = df2.Sum<float>("x");
+   auto r3 = df2.Count();
+
+   // Test constructors
+   RResultHandle h1(r1);
+   RResultHandle h2(r2);
+   RResultHandle h3(r3);
+}
+
+TEST(RResultHandle, StdVector)
+{
+   ROOT::RDataFrame df(3);
+   auto df2 = df.Define("x", [] { return 1.f; }, {});
+   auto r1 = df2.Histo1D<float>("x");
+   auto r2 = df2.Sum<float>("x");
+   auto r3 = df2.Count();
+
+   // Test push_back and emplace_back
+   std::vector<RResultHandle> v1;
+   v1.emplace_back(r1);
+   v1.push_back(r1);
+
+   // Test initializer list
+   std::vector<RResultHandle> v2 = {r1, r2, r3};
+}
+
+TEST(RResultHandle, TriggerRun)
+{
+   ROOT::RDataFrame df(3);
+   auto r1 = df.Sum<ULong64_t>("rdfentry_");
+   auto r2 = df.Count();
+
+   // Check that no event loops has run
+   EXPECT_EQ(df.GetNRuns(), 0u);
+
+   // Create handle and check that no event loop is triggered
+   RResultHandle h(r1);
+   EXPECT_EQ(df.GetNRuns(), 0u);
+
+   // Trigger event loop
+   h.GetValue<ULong64_t>();
+   EXPECT_EQ(df.GetNRuns(), 1u);
+
+   // Trigger event loop again via the RResultPtr and check that loop has not run
+   r1.GetPtr();
+   r1.GetValue();
+   EXPECT_EQ(df.GetNRuns(), 1u);
+
+   // Trigger event loop again via the second RResultPtr and check that loop has not run
+   r2.GetValue();
+   EXPECT_EQ(df.GetNRuns(), 1u);
+}
+
+TEST(RResultHandle, IsReady)
+{
+   ROOT::RDataFrame df(3);
+   auto r1 = df.Sum<ULong64_t>("rdfentry_");
+   auto r2 = df.Count();
+
+   RResultHandle h1(r1);
+   RResultHandle h2(r2);
+
+   // Event loop has not yet run
+   EXPECT_FALSE(h1.IsReady());
+   EXPECT_FALSE(h2.IsReady());
+
+   // Trigger loop and check that event loop is marked as run in both actions
+   h1.GetValue<ULong64_t>();
+   EXPECT_TRUE(h1.IsReady());
+   EXPECT_TRUE(h2.IsReady());
+}
+
+TEST(RResultHandle, GetPtrOrValue)
+{
+   ROOT::RDataFrame df(3);
+   auto df2 = df.Define("x", [] { return 1.f; }, {});
+   auto r1 = df2.Sum<float>("x");
+   auto r2 = df2.Count();
+
+   RResultHandle h1(r1);
+   RResultHandle h2(r2);
+
+   EXPECT_EQ(h1.GetPtr<float>(), r1.GetPtr());
+   EXPECT_EQ(h1.GetValue<float>(), r1.GetValue());
+
+   EXPECT_EQ(h2.GetPtr<ULong64_t>(), r2.GetPtr());
+   EXPECT_EQ(h2.GetValue<ULong64_t>(), r2.GetValue());
+}
+
+TEST(RResultHandle, Comparison)
+{
+   ROOT::RDataFrame df(3);
+   auto r1 = df.Sum<ULong64_t>("rdfentry_");
+   auto r2 = df.Count();
+
+   RResultHandle h1(r1);
+   RResultHandle h2(r2);
+   RResultHandle h3(r1);
+
+   EXPECT_FALSE(h1 == h2);
+   EXPECT_TRUE(h1 != h2);
+
+   EXPECT_TRUE(h1 == h1);
+   EXPECT_FALSE(h1 != h1);
+
+   EXPECT_TRUE(h1 == h3);
+   EXPECT_FALSE(h1 != h3);
+}
+
+TEST(RResultHandle, CheckType)
+{
+   ROOT::RDataFrame df(3);
+   auto r = df.Sum<ULong64_t>("rdfentry_");
+   RResultHandle h(r);
+   EXPECT_THROW(h.GetValue<float>(), std::runtime_error);
+   EXPECT_THROW(h.GetPtr<float>(), std::runtime_error);
 }


### PR DESCRIPTION
* The ROOT::RDF::RResultHandle is a type erased handle for a RResultPtr. The object can be used to store results of RDF actions in containers such as a std::vector<RResultHandle>.
* Added the ROOT::RDF::RunGraphs method