### PR TITLE
[DF] In Display, match regex against all branches, not just top level

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -79,9 +79,8 @@ HeadNode_t CreateSnapshotRDF(const ColumnNames_t &validCols,
 
 std::string DemangleTypeIdName(const std::type_info &typeInfo);
 
-ColumnNames_t ConvertRegexToColumns(const RDFInternal::RBookedDefines &defines, TTree *tree,
-                                    ROOT::RDF::RDataSource *dataSource, std::string_view columnNameRegexp,
-                                    std::string_view callerName);
+ColumnNames_t
+ConvertRegexToColumns(const ColumnNames_t &colNames, std::string_view columnNameRegexp, std::string_view callerName);
 
 /// An helper object that sets and resets gErrorIgnoreLevel via RAII.
 class RIgnoreErrorLevelRAII {

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -67,6 +67,8 @@ using namespace ROOT::RDF;
 namespace TTraits = ROOT::TypeTraits;
 namespace RDFInternal = ROOT::Internal::RDF;
 
+ColumnNames_t GetTopLevelBranchNames(TTree &t);
+
 using HeadNode_t = ::ROOT::RDF::RResultPtr<RInterface<RLoopManager, void>>;
 HeadNode_t CreateSnapshotRDF(const ColumnNames_t &validCols,
                             std::string_view treeName,

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -532,11 +532,16 @@ public:
                                                  std::string_view columnNameRegexp = "",
                                                  const RSnapshotOptions &options = RSnapshotOptions())
    {
-      auto selectedColumns = RDFInternal::ConvertRegexToColumns(fDefines,
-                                                                fLoopManager->GetTree(),
-                                                                fDataSource,
-                                                                columnNameRegexp,
-                                                                "Snapshot");
+      const auto definedColumns = fDefines.GetNames();
+      auto *tree = fLoopManager->GetTree();
+      const auto treeBranchNames = tree != nullptr ? RDFInternal::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
+      const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
+      ColumnNames_t columnNames;
+      columnNames.reserve(definedColumns.size() + treeBranchNames.size() + dsColumns.size());
+      columnNames.insert(columnNames.end(), definedColumns.begin(), definedColumns.end());
+      columnNames.insert(columnNames.end(), treeBranchNames.begin(), treeBranchNames.end());
+      columnNames.insert(columnNames.end(), dsColumns.begin(), dsColumns.end());
+      const auto selectedColumns = RDFInternal::ConvertRegexToColumns(columnNames, columnNameRegexp, "Snapshot");
       return Snapshot(treename, filename, selectedColumns, options);
    }
    // clang-format on
@@ -650,9 +655,16 @@ public:
    /// is empty, all columns are selected. See the previous overloads for more information.
    RInterface<RLoopManager> Cache(std::string_view columnNameRegexp = "")
    {
-
-      auto selectedColumns = RDFInternal::ConvertRegexToColumns(fDefines, fLoopManager->GetTree(), fDataSource,
-                                                                columnNameRegexp, "Cache");
+      const auto definedColumns = fDefines.GetNames();
+      auto *tree = fLoopManager->GetTree();
+      const auto treeBranchNames = tree != nullptr ? RDFInternal::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
+      const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
+      ColumnNames_t columnNames;
+      columnNames.reserve(definedColumns.size() + treeBranchNames.size() + dsColumns.size());
+      columnNames.insert(columnNames.end(), definedColumns.begin(), definedColumns.end());
+      columnNames.insert(columnNames.end(), treeBranchNames.begin(), treeBranchNames.end());
+      columnNames.insert(columnNames.end(), dsColumns.begin(), dsColumns.end());
+      const auto selectedColumns = RDFInternal::ConvertRegexToColumns(columnNames, columnNameRegexp, "Cache");
       return Cache(selectedColumns);
    }
 
@@ -2180,8 +2192,15 @@ public:
    /// See the previous overloads for further details.
    RResultPtr<RDisplay> Display(std::string_view columnNameRegexp = "", const int &nRows = 5)
    {
-      auto selectedColumns = RDFInternal::ConvertRegexToColumns(fDefines, fLoopManager->GetTree(), fDataSource,
-                                                                columnNameRegexp, "Display");
+      const auto definedColumns = GetDefinedColumnNames();
+      const auto treeBranchNames = RDFInternal::GetTopLevelBranchNames(*fLoopManager->GetTree());
+      const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
+      ColumnNames_t columnNames;
+      columnNames.reserve(definedColumns.size() + treeBranchNames.size() + dsColumns.size());
+      columnNames.insert(columnNames.end(), definedColumns.begin(), definedColumns.end());
+      columnNames.insert(columnNames.end(), treeBranchNames.begin(), treeBranchNames.end());
+      columnNames.insert(columnNames.end(), dsColumns.begin(), dsColumns.end());
+      const auto selectedColumns = RDFInternal::ConvertRegexToColumns(columnNames, columnNameRegexp, "Display");
       return Display(selectedColumns, nRows);
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2192,14 +2192,7 @@ public:
    /// See the previous overloads for further details.
    RResultPtr<RDisplay> Display(std::string_view columnNameRegexp = "", const int &nRows = 5)
    {
-      const auto definedColumns = GetDefinedColumnNames();
-      const auto treeBranchNames = RDFInternal::GetTopLevelBranchNames(*fLoopManager->GetTree());
-      const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
-      ColumnNames_t columnNames;
-      columnNames.reserve(definedColumns.size() + treeBranchNames.size() + dsColumns.size());
-      columnNames.insert(columnNames.end(), definedColumns.begin(), definedColumns.end());
-      columnNames.insert(columnNames.end(), treeBranchNames.begin(), treeBranchNames.end());
-      columnNames.insert(columnNames.end(), dsColumns.begin(), dsColumns.end());
+      const auto columnNames = GetColumnNames();
       const auto selectedColumns = RDFInternal::ConvertRegexToColumns(columnNames, columnNameRegexp, "Display");
       return Display(selectedColumns, nRows);
    }

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -367,7 +367,6 @@ ConvertRegexToColumns(const ColumnNames_t &colNames, std::string_view columnName
       theRegex = theRegex + "$";
 
    ColumnNames_t selectedColumns;
-   selectedColumns.reserve(32);
 
    // Since we support gcc48 and it does not provide in its stl std::regex,
    // we need to use TPRegexp

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -283,17 +283,6 @@ static void GetTopLevelBranchNamesImpl(TTree &t, std::set<std::string> &bNamesRe
    }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-/// Get all the top-level branches names, including the ones of the friend trees
-static ColumnNames_t GetTopLevelBranchNames(TTree &t)
-{
-   std::set<std::string> bNamesSet;
-   ColumnNames_t bNames;
-   std::set<TTree *> analysedTrees;
-   GetTopLevelBranchNamesImpl(t, bNamesSet, bNames, analysedTrees);
-   return bNames;
-}
-
 static bool IsValidCppVarName(const std::string &var)
 {
    if (var.empty())
@@ -321,6 +310,17 @@ static bool IsValidCppVarName(const std::string &var)
 namespace ROOT {
 namespace Internal {
 namespace RDF {
+
+///////////////////////////////////////////////////////////////////////////////
+/// Get all the top-level branches names, including the ones of the friend trees
+ColumnNames_t GetTopLevelBranchNames(TTree &t)
+{
+   std::set<std::string> bNamesSet;
+   ColumnNames_t bNames;
+   std::set<TTree *> analysedTrees;
+   GetTopLevelBranchNamesImpl(t, bNamesSet, bNames, analysedTrees);
+   return bNames;
+}
 
 // The set here is used as a registry, the real list, which keeps the order, is
 // the one in the vector

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -353,9 +353,8 @@ std::string DemangleTypeIdName(const std::type_info &typeInfo)
    return tname;
 }
 
-ColumnNames_t ConvertRegexToColumns(const RDFInternal::RBookedDefines &defines, TTree *tree,
-                                    ROOT::RDF::RDataSource *dataSource, std::string_view columnNameRegexp,
-                                    std::string_view callerName)
+ColumnNames_t
+ConvertRegexToColumns(const ColumnNames_t &colNames, std::string_view columnNameRegexp, std::string_view callerName)
 {
    const auto theRegexSize = columnNameRegexp.size();
    std::string theRegex(columnNameRegexp);
@@ -373,28 +372,9 @@ ColumnNames_t ConvertRegexToColumns(const RDFInternal::RBookedDefines &defines, 
    // Since we support gcc48 and it does not provide in its stl std::regex,
    // we need to use TPRegexp
    TPRegexp regexp(theRegex);
-   for (auto &&colName : defines.GetNames()) {
+   for (auto &&colName : colNames) {
       if ((isEmptyRegex || 0 != regexp.Match(colName.c_str())) && !RDFInternal::IsInternalColumn(colName)) {
          selectedColumns.emplace_back(colName);
-      }
-   }
-
-   if (tree) {
-      auto branchNames = GetTopLevelBranchNames(*tree);
-      for (auto &branchName : branchNames) {
-         if (isEmptyRegex || 0 != regexp.Match(branchName.c_str())) {
-            selectedColumns.emplace_back(branchName);
-         }
-      }
-   }
-
-   if (dataSource) {
-      auto &dsColNames = dataSource->GetColumnNames();
-      for (auto &dsColName : dsColNames) {
-         if ((isEmptyRegex || 0 != regexp.Match(dsColName.c_str())) &&
-               !RDFInternal::IsInternalColumn(dsColName)) {
-            selectedColumns.emplace_back(dsColName);
-         }
       }
    }
 

--- a/tree/dataframe/test/dataframe_display.cxx
+++ b/tree/dataframe/test/dataframe_display.cxx
@@ -1,6 +1,9 @@
 /****** Run RDataFrame tests both with and without IMT enabled *******/
 #include <gtest/gtest.h>
 #include <ROOT/RDataFrame.hxx>
+#include <TTree.h>
+
+#include <utility> // std::pair
 
 using namespace ROOT;
 using namespace ROOT::RDF;
@@ -211,4 +214,18 @@ TEST(RDFDisplayTests, UniquePtr)
    const auto expected =
       "uptr                       | \nstd::unique_ptr -> nullptr | \n                           | \n";
    EXPECT_EQ(r->AsString(), expected);
+}
+
+
+// GitHub issue #6371
+TEST(RDFDisplayTests, SubBranch)
+{
+   auto p = std::make_pair(42, 84);
+   TTree t("t", "t");
+   t.Branch("p", &p, "a/I:b/I");
+   t.Fill();
+   ROOT::RDataFrame df(t);
+   const auto res = df.Display()->AsString();
+   const auto expected = "p.a | p.b | \n42  | 84  | \n    |     | \n";
+   EXPECT_EQ(res, expected);
 }


### PR DESCRIPTION
This fixes #6371, "Display doesn't work with non-top-level TTree branches".