### PR TITLE
TH3 alphanumeric labels fix

### DIFF
--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -1078,8 +1078,9 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
    if (!gStyle->GetStripDecimals())   optionDecimals = 1;
    if (fAxis) {
       if (fAxis->GetLabels()) {
-         optionM    = 1;
-         optionText = 1;
+         optionM     = 1;
+         optionText  = 1;
+         optionNoopt = 1;
          ndiv = fAxis->GetLast()-fAxis->GetFirst()+1;
       }
       TList *ml = fAxis->GetModifiedLabels();


### PR DESCRIPTION
When alpha numeric labels are present the number of avis division should not be optimized.
This fixes this issue: https://github.com/root-project/root/issues/6381