### PR TITLE
[GH] Add action to register new issues for triaging

### DIFF
--- a/.github/workflows/registerIssuesForTriage.yml
+++ b/.github/workflows/registerIssuesForTriage.yml
@@ -1,0 +1,16 @@
+on:
+  issues:
+    types: opened
+
+jobs:
+  assign_issue_to_project:
+    runs-on: ubuntu-latest
+    name: Add new issues to the triage project
+    steps:
+    - name: Create new project card with issue
+      id: list
+      uses: qmacro/action-add-issue-to-project-column@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        project: 'Triage'
+        column: 'Needs triage'


### PR DESCRIPTION
[skip-ci]

When new issues are created, this action adds them to the the board
https://github.com/root-project/root/projects/2