### PR TITLE
[RF] Improve recovery from invalid function values

### DIFF
--- a/README/ReleaseNotes/v624/index.md
+++ b/README/ReleaseNotes/v624/index.md
@@ -90,6 +90,12 @@ See the discussion at [ROOT-11014](https://sft.its.cern.ch/jira/browse/ROOT-1101
 
 ## RooFit Libraries
 
+### Improved recovery from invalid parameters
+When a function in RooFit is undefined (Poisson with negative mean, PDF with negative values, etc), RooFit can now pass information about the
+"badness" of the violation to the minimiser. The minimiser can use this to compute a gradient to find its way out of the undefined region.
+This can drastically improve its ability to recover when unstable fit models are used, for example RooPolynomial.
+
+For details, see the RooFit tutorial [rf612_recoverFromInvalidParameters.C](https://root.cern/doc/v624/rf612__recoverFromInvalidParameters_8C.html).
 
 ## 2D Graphics Libraries
 

--- a/roofit/roofit/inc/RooPoisson.h
+++ b/roofit/roofit/inc/RooPoisson.h
@@ -30,7 +30,9 @@ public:
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
   void generateEvent(Int_t code) override;
   
+  /// Switch off/on rounding of `x` to the nearest integer.
   void setNoRounding(bool flag = kTRUE) {_noRounding = flag;}
+  /// Switch on or off protection against negative means.
   void protectNegativeMean(bool flag = kTRUE) {_protectNegative = flag;}
 
 protected:
@@ -38,7 +40,7 @@ protected:
   RooRealProxy x ;
   RooRealProxy mean ;
   Bool_t  _noRounding ;
-  Bool_t  _protectNegative ;
+  Bool_t  _protectNegative{true};
   
   Double_t evaluate() const override;
   RooSpan<double> evaluateBatch(std::size_t begin, std::size_t batchSize) const override;

--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -21,6 +21,7 @@ Poisson pdf
 #include "RooMath.h"
 #include "TMath.h"
 #include "Math/ProbFuncMathCore.h"
+#include "RooNaNPacker.h"
 
 #include "BatchHelpers.h"
 #include "RooVDTHeaders.h"
@@ -65,8 +66,11 @@ RooPoisson::RooPoisson(const char *name, const char *title,
 Double_t RooPoisson::evaluate() const
 {
   Double_t k = _noRounding ? x : floor(x);
-  if(_protectNegative && mean<0)
-    return 1e-3;
+  if(_protectNegative && mean<0) {
+    RooNaNPacker np;
+    np.setPayload(-mean);
+    return np._payload;
+  }
   return TMath::Poisson(k,mean) ;
 }
 

--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -43,8 +43,7 @@ RooPoisson::RooPoisson(const char *name, const char *title,
   RooAbsPdf(name,title),
   x("x","x",this,_x),
   mean("mean","mean",this,_mean),
-  _noRounding(noRounding),
-  _protectNegative(false)
+  _noRounding(noRounding)
 {
 }
 

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -229,6 +229,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooWrapperPdf.h
     RooFitLegacy/RooCatTypeLegacy.h
     RooFitLegacy/RooCategorySharedProperties.h
+    RooNaNPacker.h
   SOURCES
     src/BidirMMapPipe.cxx
     src/BidirMMapPipe.h

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -230,7 +230,7 @@ RooCmdArg CloneData(Bool_t flag) ;
 RooCmdArg Integrate(Bool_t flag) ;
 RooCmdArg Minimizer(const char* type, const char* alg=0) ;
 RooCmdArg Offset(Bool_t flag=kTRUE) ;
-
+RooCmdArg RecoverFromUndefinedRegions(double strength);
 /** @} */
 
 // RooAbsPdf::paramOn arguments

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -50,6 +50,8 @@ public:
   void setEps(Double_t eps) ;
   void optimizeConst(Int_t flag) ;
   void setEvalErrorWall(Bool_t flag) { fitterFcn()->SetEvalErrorWall(flag); }
+  /// \copydoc RooMinimizerFcn::SetRecoverFromNaNStrength()
+  void setRecoverFromNaNStrength(double strength) { fitterFcn()->SetRecoverFromNaNStrength(strength); }
   void setOffsetting(Bool_t flag) ;
   void setMaxIterations(Int_t n) ;
   void setMaxFunctionCalls(Int_t n) ;

--- a/roofit/roofitcore/inc/RooMinimizerFcn.h
+++ b/roofit/roofitcore/inc/RooMinimizerFcn.h
@@ -48,6 +48,12 @@ class RooMinimizerFcn : public ROOT::Math::IBaseFunctionMultiDim {
   RooArgList* GetInitConstParamList() { return _initConstParamList; }
 
   void SetEvalErrorWall(Bool_t flag) { _doEvalErrorWall = flag ; }
+  /// Try to recover from invalid function values. When invalid function values are encountered,
+  /// a penalty term is returned to the minimiser to make it back off. This sets the strength of this penalty.
+  /// \note A strength of zero is equivalent to a constant penalty (= the gradient vanishes, ROOT < 6.24).
+  /// Positive values lead to a gradient pointing away from the undefined regions. Use ~10 to force the minimiser
+  /// away from invalid function values.
+  void SetRecoverFromNaNStrength(double strength) { _recoverFromNaNStrength = strength; }
   void SetPrintEvalErrors(Int_t numEvalErrors) { _printEvalErrors = numEvalErrors ; }
   Bool_t SetLogFile(const char* inLogfile);
   std::ofstream* GetLogFile() { return _logfile; }
@@ -63,7 +69,8 @@ class RooMinimizerFcn : public ROOT::Math::IBaseFunctionMultiDim {
 
   Int_t evalCounter() const { return _evalCounter ; }
   void zeroEvalCount() { _evalCounter = 0 ; }
-
+  /// Return a possible offset that's applied to the function to separate invalid function values from valid ones.
+  double getOffset() const { return _funcOffset; }
 
  private:
   void SetPdfParamErr(Int_t index, Double_t value);
@@ -80,6 +87,8 @@ class RooMinimizerFcn : public ROOT::Math::IBaseFunctionMultiDim {
   const RooMinimizer *_context;
 
   mutable double _maxFCN;
+  mutable double _funcOffset{0.};
+  double _recoverFromNaNStrength{10.};
   mutable int _numBadNLL;
   mutable int _printEvalErrors;
   mutable int _evalCounter{0};
@@ -91,7 +100,7 @@ class RooMinimizerFcn : public ROOT::Math::IBaseFunctionMultiDim {
   RooArgList* _initConstParamList;
 
   std::ofstream *_logfile;
-  bool _doEvalErrorWall;
+  bool _doEvalErrorWall{true};
   bool _verbose;
 
 };

--- a/roofit/roofitcore/inc/RooNaNPacker.h
+++ b/roofit/roofitcore/inc/RooNaNPacker.h
@@ -1,0 +1,134 @@
+/*
+ * RooNaNPacker.h
+ *
+ *  Created on: 28.04.2020
+ *      Author: shageboeck
+ */
+
+#ifndef ROOFIT_ROOFITCORE_INC_ROONANPACKER_H_
+#define ROOFIT_ROOFITCORE_INC_ROONANPACKER_H_
+
+#include <TError.h>
+
+#include <limits>
+#include <cstdint>
+#include <cmath>
+#include <cassert>
+#include <numeric>
+#include <cstring>
+
+/// Little struct that can pack a float into the unused bits of the mantissa of a
+/// NaN double. This can be used to transport information about violation
+/// of function definition ranges, negative PDFs or other computation
+/// problems in RooFit.
+/// To separate NaNs that contain packed floats from regular NaNs, a tag is
+/// written into the upper bits of the mantissa. If this tag is found, a payload
+/// can be recovered. Otherwise, the NaN is assumed to originate from other sources
+/// than a RooFit class that wants to signal to the minimiser.
+struct RooNaNPacker {
+  double _payload;
+
+  // In double-valued NaNs, on can abuse the lowest 51 bit for payloads.
+  // We use this to pack a float into the lowest 32 bits, which leaves
+  // 19-bit to include a magic tag to tell NaNs with payload from ordinary
+  // NaNs:
+  static constexpr uint64_t magicTagMask = 0x3ffff00000000;
+  static constexpr uint64_t magicTag     = 0x321ab00000000;
+
+  constexpr RooNaNPacker() :
+    _payload(0.) { }
+
+  /// Create NaN with a packed floating point number.
+  explicit RooNaNPacker(float value) :
+    _payload(packFloatIntoNaN(value)) {  }
+
+  /// Pack float into mantissa of NaN.
+  void setPayload(float payload) {
+    _payload = packFloatIntoNaN(payload);
+
+    if (!std::isnan(_payload)) {
+      // Big-endian machine or other. Just return NaN.
+      warn();
+      _payload = std::numeric_limits<double>::quiet_NaN();
+    }
+  }
+
+  /// Accumulate a packed float from another NaN into `this`.
+  void accumulate(double val) {
+    *this += unpackNaN(val);
+  }
+
+  /// Unpack floats from NaNs, and sum the packed values.
+  template<class It_t>
+  static double accumulatePayloads(It_t begin, It_t end) {
+    double sum = std::accumulate(begin, end, 0.f, [](float acc, double val) {
+      return acc += unpackNaN(val);
+    });
+
+    return packFloatIntoNaN(sum);
+  }
+
+  /// Add to the packed float.
+  RooNaNPacker& operator+=(float val) {
+    setPayload(getPayload() + val);
+    return *this;
+  }
+
+  /// Multiply the packed float.
+  RooNaNPacker& operator*=(float val) {
+    setPayload(getPayload() * val);
+    return *this;
+  }
+
+  /// Retrieve packed float. Returns zero if number is not NaN
+  /// or if float wasn't packed by this class.
+  float getPayload() const {
+    return isNaNWithPayload(_payload) ? unpackNaN(_payload) : 0.;
+  }
+
+  /// Test if this struct has a float packed into its mantissa.
+  bool isNaNWithPayload() const {
+    return isNaNWithPayload(_payload);
+  }
+
+  /// Test if `val` has a float packed into its mantissa.
+  static bool isNaNWithPayload(double val) {
+    uint64_t tmp;
+    std::memcpy(&tmp, &val, sizeof(uint64_t));
+    return std::isnan(val) && (tmp & magicTagMask) == magicTag;
+  }
+
+  /// Pack float into mantissa of a NaN. Adds a tag to the
+  /// upper bits of the mantissa, so a "normal" NaN can be
+  /// differentiated from a NaN with a payload.
+  static double packFloatIntoNaN(float payload) {
+    double result = std::numeric_limits<double>::quiet_NaN();
+    uint64_t tmp;
+    std::memcpy(&tmp, &result, sizeof(uint64_t));
+    tmp |= magicTag;
+    std::memcpy(&tmp, &payload, sizeof(float));
+    std::memcpy(&result, &tmp, sizeof(uint64_t));
+    return result;
+  }
+
+  /// If `val` is NaN and a this NaN has been tagged as containing
+  /// a payload, unpack the float from the mantissa.
+  /// Return 0 otherwise.
+  static float unpackNaN(double val) {
+    float tmp;
+    std::memcpy(&tmp, &val, sizeof(float));
+    return isNaNWithPayload(val) ? tmp : 0.;
+  }
+
+  /// Warn that packing only works on little-endian machines.
+  static void warn() {
+    static bool haveWarned = false;
+    if (!haveWarned)
+      Warning("RooNaNPacker", "Fast recovery from undefined function values only implemented for little-endian machines."
+          " If necessary, request an extension of functionality on https://root.cern");
+    haveWarned = true;
+  }
+};
+
+
+#endif /* ROOFIT_ROOFITCORE_INC_ROONANPACKER_H_ */

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1218,6 +1218,8 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
 /// <tr><td> `EvalErrorWall(bool flag=true)`    <td>  When parameters are in disallowed regions (e.g. PDF is negative), return very high value to fitter
 ///                                                  to force it out of that region. This can, however, mean that the fitter gets lost in this region. If
 ///                                                  this happens, try switching it off.
+/// <tr><td> `RecoverFromUndefinedRegions(double strength)` <td> When PDF is invalid (e.g. parameter in undefined region), try to direct minimiser away from that region.
+///                                                              `strength` controls the magnitude of the penalty term. Leaving out this argument defaults to 10. Switch off with `strength = 0.`.
 /// <tr><td> `FitOptions(const char* optStr)`  <td>  \deprecated Steer fit with classic options string (for backward compatibility).
 ///                                                \attention Use of this option excludes use of any of the new style steering options.
 ///
@@ -1293,6 +1295,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
       "CloneData,GlobalObservables,GlobalObservablesTag,OffsetLikelihood,BatchMode");
 
   pc.defineDouble("prefit", "Prefit",0,0);
+  pc.defineDouble("RecoverFromUndefinedRegions", "RecoverFromUndefinedRegions",0,10.);
   pc.defineString("fitOpt","FitOptions",0,"") ;
   pc.defineInt("optConst","Optimize",0,2) ;
   pc.defineInt("verbose","Verbose",0,0) ;
@@ -1334,6 +1337,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
 
   // Decode command line arguments
   Double_t prefit = pc.getDouble("prefit");
+  const double recoverFromNaN = pc.getDouble("RecoverFromUndefinedRegions");
   const char* fitOpt = pc.getString("fitOpt",0,kTRUE) ;
   Int_t optConst = pc.getInt("optConst") ;
   Int_t verbose  = pc.getInt("verbose") ;
@@ -1452,6 +1456,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
     m.setMinimizerType(minType) ;
 
     m.setEvalErrorWall(doEEWall) ;
+    m.setRecoverFromNaNStrength(recoverFromNaN);
     if (doWarn==0) {
       // m.setNoWarn() ; WVE FIX THIS
     }

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -63,34 +63,24 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 
 */
 
-
-#include "RooFit.h"
-#include "RooMsgService.h"
-
-#include "TIterator.h"
-#include "TList.h"
 #include "RooAddPdf.h"
+
 #include "RooDataSet.h"
 #include "RooRealProxy.h"
-#include "RooPlot.h"
 #include "RooRealVar.h"
 #include "RooAddGenContext.h"
 #include "RooRealConstant.h"
-#include "RooNameReg.h"
 #include "RooRecursiveFraction.h"
 #include "RooGlobalFunc.h"
 #include "RooRealIntegral.h"
-#include "RooTrace.h"
 #include "RooNaNPacker.h"
 
-#include "Riostream.h"
 #include <algorithm>
-
+#include <sstream>
 
 using namespace std;
 
 ClassImp(RooAddPdf);
-;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -726,14 +716,15 @@ void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) cons
       if (coefDegen > 1.E-5) {
         myCoefCache[_coefList.getSize()] = RooNaNPacker::packFloatIntoNaN(100.f*coefDegen);
 
+        std::stringstream msg;
         if (_coefErrCount-->0) {
-          coutW(Eval) << "RooAddPdf::updateCoefCache(" << GetName()
-		            << " WARNING: sum of PDF coefficients not in range [0-1], value="
-		            << 1-lastCoef ;
+          msg << "RooAddPdf::updateCoefCache(" << GetName()
+              << " WARNING: sum of PDF coefficients not in range [0-1], value="
+		      << 1-lastCoef ;
           if (_coefErrCount==0) {
-            coutW(Eval) << " (no more will be printed)"  ;
+            msg << " (no more will be printed)"  ;
           }
-          coutW(Eval) << endl ;
+          coutW(Eval) << msg.str() << std::endl;
         }
       } 
     }

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -81,6 +81,7 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 #include "RooGlobalFunc.h"
 #include "RooRealIntegral.h"
 #include "RooTrace.h"
+#include "RooNaNPacker.h"
 
 #include "Riostream.h"
 #include <algorithm>
@@ -723,6 +724,8 @@ void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) cons
       // Treat coefficient degeneration
       const float coefDegen = lastCoef < 0. ? -lastCoef : (lastCoef > 1. ? lastCoef - 1. : 0.);
       if (coefDegen > 1.E-5) {
+        myCoefCache[_coefList.getSize()] = RooNaNPacker::packFloatIntoNaN(100.f*coefDegen);
+
         if (_coefErrCount-->0) {
           coutW(Eval) << "RooAddPdf::updateCoefCache(" << GetName()
 		            << " WARNING: sum of PDF coefficients not in range [0-1], value="

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -210,6 +210,9 @@ namespace RooFit {
   RooCmdArg Integrate(Bool_t flag)                       { return RooCmdArg("Integrate",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Minimizer(const char* type, const char* alg) { return RooCmdArg("Minimizer",0,0,0,0,type,alg,0,0) ; }
   RooCmdArg Offset(Bool_t flag)                          { return RooCmdArg("OffsetLikelihood",flag,0,0,0,0,0,0,0) ; }
+  /// When parameters are chosen such that a PDF is undefined, try to indicate to the minimiser how to leave this region.
+  /// \param strength Strength of hints for minimiser. Set to zero to switch off.
+  RooCmdArg RecoverFromUndefinedRegions(double strength) { return RooCmdArg("RecoverFromUndefinedRegions",0,0,strength,0,0,0,0,0) ; }
 
   
   // RooAbsPdf::paramOn arguments

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -663,10 +663,17 @@ RooFitResult* RooMinimizer::save(const char* userName, const char* userTitle)
   fitRes->setConstParList(saveConstList) ;
   fitRes->setInitParList(saveFloatInitList) ;
 
+  // The fitter often clones the function. We therefore have to ask it for its copy.
+  const auto fitFcn = dynamic_cast<const RooMinimizerFcn*>(_theFitter->GetFCN());
+  double removeOffset = 0.;
+  if (fitFcn) {
+    fitRes->setNumInvalidNLL(fitFcn->GetNumInvalidNLL());
+    removeOffset = - fitFcn->getOffset();
+  }
+
   fitRes->setStatus(_status) ;
   fitRes->setCovQual(_theFitter->GetMinimizer()->CovMatrixStatus()) ;
-  fitRes->setMinNLL(_theFitter->Result().MinFcnValue()) ;
-  fitRes->setNumInvalidNLL(_fcn->GetNumInvalidNLL()) ;
+  fitRes->setMinNLL(_theFitter->Result().MinFcnValue() + removeOffset);
   fitRes->setEDM(_theFitter->Result().Edm()) ;
   fitRes->setFinalParList(saveFloatFinalList) ;
   if (!_extV) {

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -50,6 +50,7 @@ to the fractions of the various functions. **This requires setting the last argu
 #include "RooRealProxy.h"
 #include "RooRealVar.h"
 #include "RooMsgService.h"
+#include "RooNaNPacker.h"
 
 #include <TError.h>
 
@@ -244,6 +245,8 @@ Double_t RooRealSumPdf::evaluate() const
             << sumCoeff << ". This means that the PDF is not properly normalised. If the PDF was meant to be extended, provide as many coefficients as functions." << endl ;
         _haveWarned = true;
       }
+      // Signal that we are in an undefined region:
+      value = RooNaNPacker::packFloatIntoNaN(100.f * (coefVal < 0. ? -coefVal : coefVal - 1.));
     }
 
     if (func->isSelectedComp()) {

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -30,3 +30,5 @@ if(NOT MSVC OR win_broken_tests)
     COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_1.root ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_2.root)
 endif()
 ROOT_ADD_GTEST(testRooProductPdf testRooProductPdf.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testNaNPacker testNaNPacker.cxx LIBRARIES RooFitCore)
+

--- a/roofit/roofitcore/test/testNaNPacker.cxx
+++ b/roofit/roofitcore/test/testNaNPacker.cxx
@@ -171,7 +171,12 @@ TEST(RooNaNPacker, FitParabola) {
     }
   }
 
-  EXPECT_LT(fitResult1->numInvalidNLL(), fitResult2->numInvalidNLL());
+  // This makes clang-tidy happy:
+  ASSERT_NE(fitResult1, nullptr);
+  ASSERT_NE(fitResult2, nullptr);
+  if (fitResult1 && fitResult2) { // makes clang-tidy happy
+    EXPECT_LT(fitResult1->numInvalidNLL(), fitResult2->numInvalidNLL());
+  }
 }
 
 /// Make coefficients of RooAddPdf sum to more than 1. Fitter should recover from this.
@@ -232,7 +237,12 @@ TEST(RooNaNPacker, FitAddPdf_DegenerateCoeff) {
     }
   }
 
-  EXPECT_LT(fitResult1->numInvalidNLL(), fitResult2->numInvalidNLL());
+  // This makes clang-tidy happy:
+  ASSERT_NE(fitResult1, nullptr);
+  ASSERT_NE(fitResult2, nullptr);
+  if (fitResult1 && fitResult2) { // makes clang-tidy happy
+    EXPECT_LT(fitResult1->numInvalidNLL(), fitResult2->numInvalidNLL());
+  }
 }
 
 /// Make coefficients of RooRealSumPdf sum to more than 1. Fitter should recover from this.
@@ -286,10 +296,12 @@ TEST(RooNaNPacker, Interface_RooAbsPdf_fitTo_RooRealSumPdf_DegenerateCoeff) {
     }
   }
 
-  if (verbose) {
-    fitResult1->Print();
-    fitResult2->Print();
+  // This makes clang-tidy happy:
+  ASSERT_NE(fitResult1, nullptr);
+  ASSERT_NE(fitResult2, nullptr);
+
+  if (fitResult1 && fitResult2) { // makes clang-tidy happy
+    EXPECT_LT(fitResult1->numInvalidNLL(), fitResult2->numInvalidNLL());
   }
-  EXPECT_LT(fitResult1->numInvalidNLL(), fitResult2->numInvalidNLL());
 }
 

--- a/roofit/roofitcore/test/testNaNPacker.cxx
+++ b/roofit/roofitcore/test/testNaNPacker.cxx
@@ -1,0 +1,149 @@
+// Tests for the RooNaNPacker
+// Authors: Stephan Hageboeck, CERN  04/2020
+#include "RooNaNPacker.h"
+#include "RooRealVar.h"
+#include "RooGenericPdf.h"
+#include "RooMinimizer.h"
+#include "RooFitResult.h"
+#include "RooDataSet.h"
+
+#include "gtest/gtest.h"
+
+#include <cmath>
+#include <bitset>
+#include <cstdint>
+
+void dumpFloats(double val) {
+  float tmp[2];
+  std::memcpy(tmp, &val, sizeof(double));
+
+  for (int i = 1; i >= 0; --i) {
+    unsigned long long ull = 0ull;
+    std::memcpy(&ull, &tmp[i], 4);
+    std::bitset<32> bits(ull);
+    std::cout << bits << " " << std::flush;
+  }
+  std::cout << std::endl;
+}
+
+TEST(RooNaNPacker, CanPackStuffIntoNaNs)
+{
+  static_assert((RooNaNPacker::magicTag & RooNaNPacker::magicTagMask) == RooNaNPacker::magicTag, "Bit mask wrong.");
+  constexpr bool dump = false;
+
+  // Create a NaN that has 1.337f as payload
+  RooNaNPacker rnp;
+  rnp.setPayload(1.337f);
+  EXPECT_TRUE(std::isnan(rnp._payload));
+  EXPECT_TRUE(rnp.isNaNWithPayload());
+  EXPECT_FLOAT_EQ(rnp.getPayload(), 1.337f);
+  if (dump) dumpFloats(rnp._payload);
+
+  // Create a normal double
+  rnp._payload = 1.337;
+  EXPECT_FALSE(std::isnan(rnp._payload));
+  EXPECT_FALSE(rnp.isNaNWithPayload());
+  EXPECT_DOUBLE_EQ(rnp._payload, 1.337);
+  EXPECT_FLOAT_EQ(rnp.getPayload(), 0.f);
+  if (dump) dumpFloats(rnp._payload);
+
+  // Create a normal double
+  rnp._payload = 4.;
+  EXPECT_FALSE(std::isnan(rnp._payload));
+  EXPECT_FALSE(rnp.isNaNWithPayload());
+  EXPECT_DOUBLE_EQ(rnp._payload, 4.);
+  EXPECT_FLOAT_EQ(rnp.getPayload(), 0.f);
+  if (dump) dumpFloats(rnp._payload);
+
+  // Create a simple payload
+  rnp.setPayload(0.);
+  EXPECT_TRUE(std::isnan(rnp._payload));
+  EXPECT_TRUE(rnp.isNaNWithPayload());
+  EXPECT_FLOAT_EQ(rnp.getPayload(), 0.f);
+  if (dump) dumpFloats(rnp._payload);
+
+  // Create a simple payload
+  rnp.setPayload(2.);
+  EXPECT_TRUE(std::isnan(rnp._payload));
+  EXPECT_TRUE(rnp.isNaNWithPayload());
+  EXPECT_FLOAT_EQ(rnp.getPayload(), 2.f);
+  if (dump) dumpFloats(rnp._payload);
+
+  // Create a simple payload
+  rnp.setPayload(4.);
+  EXPECT_TRUE(std::isnan(rnp._payload));
+  EXPECT_TRUE(rnp.isNaNWithPayload());
+  EXPECT_FLOAT_EQ(rnp.getPayload(), 4.f);
+  if (dump) dumpFloats(rnp._payload);
+
+  // Create a NaN that doesn't have the magic tag,
+  // so no information encoded
+  rnp._payload = std::numeric_limits<double>::quiet_NaN();
+  const float tmp = 1234.5f;
+  std::memcpy(&rnp._payload, &tmp, sizeof(float));
+  EXPECT_TRUE(std::isnan(rnp._payload));
+  EXPECT_FALSE(rnp.isNaNWithPayload());
+  EXPECT_FLOAT_EQ(rnp.getPayload(), 0.f);
+  if (dump) dumpFloats(rnp._payload);
+
+}
+
+
+TEST(RooNaNPacker, FitSimpleLinear) {
+  RooRealVar x("x", "x", -10, 10);
+  RooRealVar a1("a1", "a1", 12., -5., 15.);
+  RooGenericPdf pdf("pdf", "a1 + x", RooArgSet(x, a1));
+  std::unique_ptr<RooDataSet> data(pdf.generate(x, 1000));
+  std::unique_ptr<RooAbsReal> nll(pdf.createNLL(*data));
+
+  ASSERT_FALSE(std::isnan(pdf.getVal(RooArgSet(x))));
+  a1.setVal(-9.);
+  ASSERT_TRUE(std::isnan(pdf.getVal(RooArgSet(x))));
+
+  RooMinimizer minim(*nll);
+  minim.migrad();
+  minim.hesse();
+  auto fitResult = minim.save();
+
+  EXPECT_EQ(fitResult->status(), 0);
+  EXPECT_NEAR(a1.getVal(), 12., a1.getError());
+}
+
+
+
+TEST(RooNaNPacker, FitParabola) {
+  RooRealVar x("x", "x", -10, 10);
+  RooRealVar a1("a1", "a1", 12., -10., 15.);
+  RooRealVar a2("a2", "a2", 1.1, -5., 15.);
+  RooGenericPdf pdf("pdf", "a1 + x + a2 *x*x", RooArgSet(x, a1, a2));
+  std::unique_ptr<RooDataSet> data(pdf.generate(x, 10000));
+  auto nll = pdf.createNLL(*data);
+
+  RooArgSet params(a1, a2);
+  RooArgSet evilValues;
+  a1.setVal(-9.);
+  a2.setVal(-1.);
+  params.snapshot(evilValues);
+
+  params = evilValues;
+  auto fitResult1 = pdf.fitTo(*data, RooFit::Save());
+
+  params = evilValues;
+
+  auto fitResult2 = pdf.fitTo(*data, RooFit::Save());
+
+  fitResult1->Print();
+  fitResult2->Print();
+
+  for (auto fitResult : std::initializer_list<RooFitResult*>{fitResult1, fitResult2}) {
+    std::string config = (fitResult == fitResult1 ? "No error wall" : "Error wall");
+    const auto& a1Final = static_cast<RooRealVar&>(fitResult->floatParsFinal()[0]);
+    const auto& a2Final = static_cast<RooRealVar&>(fitResult->floatParsFinal()[1]);
+    EXPECT_EQ(fitResult->status(), 0) << config;
+    EXPECT_NEAR(a1Final.getVal(), 12., a1Final.getError()) << config;
+    EXPECT_NEAR(a2Final.getVal(),  0., a2Final.getError()) << config;
+  }
+
+  EXPECT_LT(fitResult1->numInvalidNLL(), fitResult2->numInvalidNLL());
+}
+

--- a/tutorials/roofit/rf612_recoverFromInvalidParameters.C
+++ b/tutorials/roofit/rf612_recoverFromInvalidParameters.C
@@ -1,0 +1,132 @@
+/// \file
+/// \ingroup tutorial_roofit
+/// \notebook -js
+/// Likelihood and minimization: Recover from regions where the function is not defined.
+///
+/// We demonstrate improved recovery from disallowed parameters. For this, we use a polynomial PDF of the form
+/// \f[
+///   \mathrm{Pol2} = \mathcal{N} \left( c + a_1 \cdot x + a_2 \cdot x^2 + 0.01 \cdot x^3 \right),
+/// \f]
+/// where \f$ \mathcal{N} \f$ is a normalisation factor. Unless the parameters are chosen carefully,
+/// this function can be negative, and hence, it cannot be used as a PDF. In this case, RooFit passes
+/// an error to the minimiser, which might try to recover.
+///
+/// Before ROOT 6.24, RooFit always passed the highest function value that was encountered during the minimisation
+/// to the minimiser. If a parameter is far in a disallowed region, the minimiser has to blindly test various
+/// values of the parameters. It might find the correct values by chance, but often be unable to recover from bad
+/// starting values. Here, we use a model with such bad values.
+///
+/// Starting with ROOT 6.24, the minimiser receives more information. For example, when a PDF is negative,
+/// the magnitude of the "undershoot" is passed to the minimiser. The minimiser can use this to compute a
+/// gradient, which will eventually lead it out of the disallowed region. The steepness of this gradient
+/// can be chosen using RooFit::RecoverFromUndefinedRegions(double). A value of zero is equivalent to RooFit
+/// before ROOT 6.24. Positive values activate the recovery. Values between 1. and 10. were found to be a
+/// good default. If no argument is passed, RooFit uses 10.
+///
+/// \macro_output
+/// \macro_code
+///
+/// \date 10/2020
+/// \author Stephan Hageboeck
+
+#include <RooRealVar.h>
+#include <RooPolynomial.h>
+#include <RooPlot.h>
+#include <RooDataSet.h>
+#include <RooGlobalFunc.h>
+#include <RooFitResult.h>
+#include <RooMsgService.h>
+
+#include <TCanvas.h>
+#include <TLegend.h>
+
+void rf612_recoverFromInvalidParameters() {
+
+  // Create a fit model:
+  // The polynomial is notoriously unstable, because it can quickly go negative.
+  // Since PDFs need to be positive, one often ends up with an unstable fit model.
+  RooRealVar x("x", "x", -15, 15);
+  RooRealVar a1("a1", "a1", -0.5, -10., 20.);
+  RooRealVar a2("a2", "a2", 0.2, -10., 20.);
+  RooRealVar a3("a3", "a3", 0.01);
+  RooPolynomial pdf("pol3", "c + a1 * x + a2 * x*x + 0.01 * x*x*x", x, RooArgSet(a1, a2, a3));
+
+  // Create toy data with all-positive coefficients:
+  std::unique_ptr<RooDataSet> data(pdf.generate(x, 10000));
+
+  // For plotting.
+  // We create pointers to the plotted objects. We want these objects to leak out of the function,
+  // so we can still see them after it returns.
+  TCanvas* c = new TCanvas();
+  RooPlot* frame = x.frame();
+  data->plotOn(frame, RooFit::Name("data"));
+
+  // Plotting a PDF with disallowed parameters doesn't work. We would get a lot of error messages.
+  // Therefore, we disable plotting messages in RooFit's message streams:
+  RooMsgService::instance().getStream(0).removeTopic(RooFit::Plotting);
+  RooMsgService::instance().getStream(1).removeTopic(RooFit::Plotting);
+
+
+  // RooFit before ROOT 6.24
+  // --------------------------------
+  // Before 6.24, RooFit wasn't able to recover from invalid parameters. The minimiser just errs around
+  // the starting values of the parameters without finding any improvement.
+
+  // Set up the parameters such that the PDF would come out negative. The PDF is now undefined.
+  a1.setVal(10.);
+  a2.setVal(-1.);
+
+  // Perform a fit:
+  RooFitResult* fitWithoutRecovery = pdf.fitTo(*data, RooFit::Save(),
+      RooFit::RecoverFromUndefinedRegions(0.), // This is how RooFit behaved prior to ROOT 6.24
+      RooFit::PrintEvalErrors(-1), // We are expecting a lot of evaluation errors. -1 switches off printing.
+      RooFit::PrintLevel(-1));
+
+  pdf.plotOn(frame, RooFit::LineColor(kRed), RooFit::Name("noRecovery"));
+
+
+
+  // RooFit since ROOT 6.24
+  // --------------------------------
+  // The minimiser gets information about the "badness" of the violation of the function definition. It uses this
+  // to find its way out of the disallowed parameter regions.
+  std::cout << "\n\n\n-------------- Starting second fit ---------------\n\n" << std::endl;
+
+  // Reset the parameters such that the PDF is again undefined.
+  a1.setVal(10.);
+  a2.setVal(-1.);
+
+  // Fit again, but pass recovery information to the minimiser:
+  RooFitResult* fitWithRecovery = pdf.fitTo(*data, RooFit::Save(),
+      RooFit::RecoverFromUndefinedRegions(1.), // The magnitude of the recovery information can be chosen here.
+                                                // Higher values mean more aggressive recovery.
+      RooFit::PrintEvalErrors(-1), // We are still expecting a few evaluation errors.
+      RooFit::PrintLevel(0));
+
+  pdf.plotOn(frame, RooFit::LineColor(kBlue), RooFit::Name("recovery"));
+
+
+
+  // Collect results and plot.
+  // --------------------------------
+  // We print the two fit results, and plot the fitted curves.
+  // The curve of the fit without recovery cannot be plotted, because the PDF is undefined if a2 < 0.
+  fitWithoutRecovery->Print();
+  std::cout << "Without recovery, the fitter encountered " << fitWithoutRecovery->numInvalidNLL()
+      << " invalid function values. The parameters are unchanged." << std::endl;
+
+  fitWithRecovery->Print();
+  std::cout << "With recovery, the fitter encountered " << fitWithRecovery->numInvalidNLL()
+      << " invalid function values, but the parameters are fitted." << std::endl;
+
+  TLegend* legend = new TLegend(0.5, 0.7, 0.9, 0.9);
+  legend->SetBorderSize(0);
+  legend->SetFillStyle(0);
+  legend->AddEntry(frame->findObject("data"), "Data", "P");
+  legend->AddEntry(frame->findObject("noRecovery"), "Without recovery (cannot be plotted)", "L");
+  legend->AddEntry(frame->findObject("recovery"), "With recovery", "L");
+  frame->Draw();
+  legend->Draw();
+  c->Draw();
+}
+


### PR DESCRIPTION
If the parameters of a function are outside of the definition range,
all kinds of errors might occur. PDFs might be negative, have negative
integrals, coefficients for the summation of PDFs might degenerate, ...

Previously, RooFit was just returning a high function value to Minuit.
This value was always the same, though.
Like this, Minuit cannot compute a gradient to get out of this region,
because all bad parameter points yield the same function value.

With this commit, RooFit can pack information about the "badness" of a
parameter point into the mantissa of a NaN, e.g. how much negative the
values of a PDF came out or how far the sum of PDF coefficients is from
1. This information is packed into NaN using "RooNaNPacker", and passed
through the computation graph. It is finally unpacked in RooMinimizerFcn
before being handed to the minimiser. This allows for the calculation of
gradients, enabling the fitter to recover from an invalid state more
easily.

When NaNs are being unpacked, they are presented to Minuit as maximum
function value + badness * penaltyStrength, so a gradient can be
computed that points away from the bad region. The maximum function
value comes from previous minimisation steps, the badness is the payload
of the packed NaN, and the strength can be set from the outside.

If the minimisation starts out in an undefined region, and the maximum
function value is not (yet) known, 0. + badness * strength is used.
Once a well-defined region is found, the valid function values are
offset such that they are all lower than 0. In this way, Minuit is
encouraged to step into the well-defined regions, and sees a rapidly
rising function when stepping out. When fit results are saved, though,
this offset is subtracted in order to recover "correct" NLL values.

Concretely:
- Add RooNaNPacker.
- Add a function to set the magnitude of the penalty term that's
supposed to drive the minimiser away from undefined regions.
- Add a function to RooMinimizerFcn that returns a possible artificial
offset. This helps to hide any offsetting from the outside world.
- When saving a fit result, remove any offset, and copy the number of
invalid function values into the fit result (was broken previously).