### PR TITLE
handle NaN EDM better

### DIFF
--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -357,6 +357,13 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn& fcn, const GradientC
 
       edm = Estimator().Estimate(g, s0.Error());
 
+      if (isnan(edm)) {
+#ifdef WARNINGMSG
+        MN_INFO_MSG("VariableMetricBuilder: edm is NaN : exit iterations ");
+#endif
+        AddResult(result, s0);
+        return FunctionMinimum(seed, result, fcn.Up());
+      }
 
       if(edm < 0.) {
 #ifdef WARNINGMSG

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -30,7 +30,7 @@
 // #if defined(DEBUG) || defined(WARNINGMSG)
 // #endif
 
-
+#include <cmath>
 
 namespace ROOT {
 
@@ -357,7 +357,7 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn& fcn, const GradientC
 
       edm = Estimator().Estimate(g, s0.Error());
 
-      if (isnan(edm)) {
+      if (std::isnan(edm)) {
 #ifdef WARNINGMSG
         MN_INFO_MSG("VariableMetricBuilder: edm is NaN : exit iterations ");
 #endif


### PR DESCRIPTION
When the EDM value in Migrad is NaN, it nevertheless reports convergence, because failure to converge is detected with the condition (edm > edmval) which fails (wrongly) if edm is NaN.

The added code aborts the minimization at the earliest point if edm is NaN.