### PR TITLE
Fix #6393

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -1684,19 +1684,8 @@ Cppyy::TCppMethod_t Cppyy::GetMethodTemplate(
 
     if (func) {
     // make sure we didn't match a non-templated overload
-        if (strstr(func->GetName(), "<"))
+        if (func->ExtraProperty() & kIsTemplateSpec)
             return (TCppMethod_t)new_CallWrapper(func);
-
-    // don't give in just yet, but rather get the full name through the symbol name,
-    // as eg. constructors do not receive their proper/full name from GetName()
-        int err;
-        char* truename = TClassEdit::DemangleName(func->GetMangledName(), err);
-        if (truename && err != -1) {
-            bool isTemplated = (bool)strstr(truename, "<");
-            free(truename);
-            if (isTemplated)
-                return (TCppMethod_t)new_CallWrapper(func);
-        }
 
     // disregard this non-templated method as it will be considered when appropriate
         return (TCppMethod_t)nullptr;

--- a/bindings/pyroot/cppyy/patches/clingwrapper-use-kIsTemplateSpec.patch
+++ b/bindings/pyroot/cppyy/patches/clingwrapper-use-kIsTemplateSpec.patch
@@ -1,0 +1,39 @@
+From 6220954941eda5612543f8f80a89dc46babb49da Mon Sep 17 00:00:00 2001
+From: Axel Naumann <Axel.Naumann@cern.ch>
+Date: Wed, 23 Sep 2020 11:02:59 +0200
+Subject: [PATCH] [cppyy-backend] Use new ExtraProperty to determine
+ templateness.
+
+---
+ .../cppyy-backend/clingwrapper/src/clingwrapper.cxx | 13 +------------
+ 1 file changed, 1 insertion(+), 12 deletions(-)
+
+diff --git a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+index ae52fbe635..e79013324e 100644
+--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
++++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+@@ -1684,20 +1684,9 @@ Cppyy::TCppMethod_t Cppyy::GetMethodTemplate(
+ 
+     if (func) {
+     // make sure we didn't match a non-templated overload
+-        if (strstr(func->GetName(), "<"))
++        if (func->ExtraProperty() & kIsTemplateSpec)
+             return (TCppMethod_t)new_CallWrapper(func);
+ 
+-    // don't give in just yet, but rather get the full name through the symbol name,
+-    // as eg. constructors do not receive their proper/full name from GetName()
+-        int err;
+-        char* truename = TClassEdit::DemangleName(func->GetMangledName(), err);
+-        if (truename && err != -1) {
+-            bool isTemplated = (bool)strstr(truename, "<");
+-            free(truename);
+-            if (isTemplated)
+-                return (TCppMethod_t)new_CallWrapper(func);
+-        }
+-
+     // disregard this non-templated method as it will be considered when appropriate
+         return (TCppMethod_t)nullptr;
+     }
+-- 
+2.25.1
+

--- a/core/meta/inc/TDictionary.h
+++ b/core/meta/inc/TDictionary.h
@@ -124,7 +124,8 @@ enum EFunctionProperty {
    kIsConversion  = 0x00000002,
    kIsDestructor  = 0x00000004,
    kIsOperator    = 0x00000008,
-   kIsInlined     = 0x00000010
+   kIsInlined     = 0x00000010,
+   kIsTemplateSpec= 0x00000020
 };
 
 enum EClassProperty {

--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -518,6 +518,8 @@ long TClingMethodInfo::ExtraProperty() const
       property |= kIsDestructor;
    if (fd->isInlined())
       property |= kIsInlined;
+   if (fd->getTemplatedKind() != clang::FunctionDecl::TK_NonTemplate)
+      property |= kIsTemplateSpec;
    return property;
 }
 

--- a/core/metacling/test/TClingMethodInfoTests.cxx
+++ b/core/metacling/test/TClingMethodInfoTests.cxx
@@ -384,6 +384,10 @@ struct TemplateFun {
    template <class T>
    int NonCtor(float, T);
 };
+class InheritTemplateFun: TemplateFun {
+public:
+    using TemplateFun::TemplateFun;
+};
 )CODE");
 
    TClass *clTemplateFun = TClass::GetClass("TemplateFun");
@@ -396,4 +400,20 @@ struct TemplateFun {
    TFunction *funNonCtor = clTemplateFun->GetMethodWithPrototype("NonCtor", "float, int");
    ASSERT_NE(funNonCtor, nullptr);
    EXPECT_EQ(funNonCtor->ExtraProperty() & kIsTemplateSpec, kIsTemplateSpec);
+
+
+   TClass *clInhTemplateFun = TClass::GetClass("InheritTemplateFun");
+   ASSERT_NE(clInhTemplateFun, nullptr);
+
+   // Fails because LookupHelper doesn't know how to instantiate function templates,
+   // even though at least the function template is made available to the derived
+   // class as per using decl. This is issue #6481.
+   //TFunction *funInhCtor = clInhTemplateFun->GetMethodWithPrototype("InheritTemplateFun", "int, int");
+   //ASSERT_NE(funInhCtor, nullptr);
+   //EXPECT_EQ(funInhCtor->ExtraProperty() & kIsTemplateSpec, kIsTemplateSpec);
+   //EXPECT_EQ(funInhCtor->Property() & kIsPrivate, kIsPrivate);
+
+   // Doesn't work either, as GetListOfFunctionTemplates() ignores using decls.
+   // Issue #6482
+   // clInhTemplateFun->GetListOfFunctionTemplates(true)->ls(); // FindObject("InheritTemplateFun")-
 }

--- a/core/metacling/test/TClingMethodInfoTests.cxx
+++ b/core/metacling/test/TClingMethodInfoTests.cxx
@@ -11,16 +11,16 @@
 
 TEST(TClingMethodInfo, Prototype)
 {
-  TClass *cl = TClass::GetClass("TObject");
-  ASSERT_NE(cl, nullptr);
-  TMethod *meth = (TMethod*)cl->GetListOfMethods()->FindObject("SysError");
-  ASSERT_NE(meth, nullptr);
-  EXPECT_STREQ(meth->GetPrototype(), "void TObject::SysError(const char* method, const char* msgfmt,...) const");
+   TClass *cl = TClass::GetClass("TObject");
+   ASSERT_NE(cl, nullptr);
+   TMethod *meth = (TMethod *)cl->GetListOfMethods()->FindObject("SysError");
+   ASSERT_NE(meth, nullptr);
+   EXPECT_STREQ(meth->GetPrototype(), "void TObject::SysError(const char* method, const char* msgfmt,...) const");
 }
 
 TEST(TClingMethodInfo, ROOT10789)
 {
-  gInterpreter->Declare(R"CODE(
+   gInterpreter->Declare(R"CODE(
 namespace ROOT10789 {
 
 struct EmptyStruct {
@@ -153,64 +153,61 @@ template <class T>
 inline BUG6359::BUG6359(int ,T) {}
 )CODE");
 
-  struct FuncInfo_t{
-    const char* fName;
-    int fNOverloads;
-    long fPropertyToTest;
-  };
+   struct FuncInfo_t {
+      const char *fName;
+      int fNOverloads;
+      long fPropertyToTest;
+   };
 
-  auto checkClass = [](const char* className, int nMethods, std::vector<FuncInfo_t> funcInfos)
-    {
+   auto checkClass = [](const char *className, int nMethods, std::vector<FuncInfo_t> funcInfos) {
       TClass *cl = TClass::GetClass(className);
       ASSERT_NE(cl, nullptr);
-      TListOfFunctions *methods = (TListOfFunctions *) cl->GetListOfMethods();
-      EXPECT_EQ(methods->GetSize(), nMethods)
-        << "for scope " << className << (methods->ls(), "") << '\n';
-      for (auto &&funcInfo: funcInfos) {
-        TList *overloads = methods->GetListForObject(funcInfo.fName);
-        ASSERT_NE(overloads, nullptr);
-        EXPECT_EQ(overloads->GetSize(), funcInfo.fNOverloads)
-          << "for " << className << "::" << funcInfo.fName << (overloads->ls(), "") << '\n';
-        for (auto meth: TRangeDynCast<TMethod>(overloads))
-          EXPECT_EQ(meth->Property() & funcInfo.fPropertyToTest, funcInfo.fPropertyToTest) << "for method " << meth->GetPrototype()
-            << " in class " << className;
+      TListOfFunctions *methods = (TListOfFunctions *)cl->GetListOfMethods();
+      EXPECT_EQ(methods->GetSize(), nMethods) << "for scope " << className << (methods->ls(), "") << '\n';
+      for (auto &&funcInfo : funcInfos) {
+         TList *overloads = methods->GetListForObject(funcInfo.fName);
+         ASSERT_NE(overloads, nullptr);
+         EXPECT_EQ(overloads->GetSize(), funcInfo.fNOverloads)
+            << "for " << className << "::" << funcInfo.fName << (overloads->ls(), "") << '\n';
+         for (auto meth : TRangeDynCast<TMethod>(overloads))
+            EXPECT_EQ(meth->Property() & funcInfo.fPropertyToTest, funcInfo.fPropertyToTest)
+               << "for method " << meth->GetPrototype() << " in class " << className;
       }
-    };
+   };
 
-  checkClass("ROOT10789::EmptyStruct", 6,
-    {{"EmptyStruct", 3, kIsPublic}, {"~EmptyStruct", 1, kIsPublic}});
+   checkClass("ROOT10789::EmptyStruct", 6, {{"EmptyStruct", 3, kIsPublic}, {"~EmptyStruct", 1, kIsPublic}});
 
-  checkClass("ROOT10789::Base", 11,
-    {{"func", 1, kIsPublic}, {"protectedFunc", 2, kIsProtected}, {"Base", 3, kIsPublic}});
+   checkClass("ROOT10789::Base", 11,
+              {{"func", 1, kIsPublic}, {"protectedFunc", 2, kIsProtected}, {"Base", 3, kIsPublic}});
 
-  checkClass("ROOT10789::Derived", 12,
-    {{"publicFunc", 2, kIsPrivate}, {"protectedFunc", 2, kIsPublic}, {"publicFunc", 2, kIsPrivate},
-     {"Derived", 7 /*includes *all* ctors, even base-class-used*/, kIsPublic}});
+   checkClass("ROOT10789::Derived", 12,
+              {{"publicFunc", 2, kIsPrivate},
+               {"protectedFunc", 2, kIsPublic},
+               {"publicFunc", 2, kIsPrivate},
+               {"Derived", 7 /*includes *all* ctors, even base-class-used*/, kIsPublic}});
 
-  checkClass("ROOT10789::Rederived", 7,
-    {{"protectedFunc", 2, kIsPrivate}, {"Rederived", 3, kIsPublic}});
+   checkClass("ROOT10789::Rederived", 7, {{"protectedFunc", 2, kIsPrivate}, {"Rederived", 3, kIsPublic}});
 
-  checkClass("ROOT10789::BagOfThings", 6, {});
+   checkClass("ROOT10789::BagOfThings", 6, {});
 
-  checkClass("ROOT10789::EmptyNamespace", 0, {});
+   checkClass("ROOT10789::EmptyNamespace", 0, {});
 
-  checkClass("ROOT10789::SingleFuncNamespace", 1, {{"SingleFunc", 1, 0}});
+   checkClass("ROOT10789::SingleFuncNamespace", 1, {{"SingleFunc", 1, 0}});
 
-  checkClass("ROOT10789::SingleUsingDeclNamespace", 1, {{"SingleFunc", 1, 0}});
+   checkClass("ROOT10789::SingleUsingDeclNamespace", 1, {{"SingleFunc", 1, 0}});
 
-  checkClass("ROOT10789::WithInlineNamespace", 4,
-    {{"InlineNamespaceFunc", 1, 0}, {"InlineInlineNamespaceFunc", 1, 0}, {"InAnon", 2, 0}});
+   checkClass("ROOT10789::WithInlineNamespace", 4,
+              {{"InlineNamespaceFunc", 1, 0}, {"InlineInlineNamespaceFunc", 1, 0}, {"InAnon", 2, 0}});
 
-  checkClass("ROOT10789::Split", 4,
-    {{"One", 1, 0}, {"Two", 2, 0}, {"Three", 1, 0}});
+   checkClass("ROOT10789::Split", 4, {{"One", 1, 0}, {"Two", 2, 0}, {"Three", 1, 0}});
 
-  checkClass("BUG6359", 5,
-    {{"BUG6359", 2, 0}});
+   checkClass("BUG6359", 5, {{"BUG6359", 2, 0}});
 }
 
-TEST(TClingMethodInfo, DerivedCtorROOT11010) {
+TEST(TClingMethodInfo, DerivedCtorROOT11010)
+{
 
-  gInterpreter->Declare(R"CODE(
+   gInterpreter->Declare(R"CODE(
 int ROOT11010baseMemCtorCalled = 0;
 int ROOT11010baseMemDtorCalled = 0;
 int ROOT11010baseCtorCalled = 0;
@@ -257,119 +254,118 @@ namespace ROOT11010 {
 }
 )CODE");
 
-  auto GetInt = [](const char* name) {
-    auto *globals = gROOT->GetListOfGlobals();
-    std::string fullname("ROOT11010");
-    fullname += name;
-    return *(int*)((TGlobal*)globals->FindObject(fullname.c_str()))->GetAddress();
-  };
+   auto GetInt = [](const char *name) {
+      auto *globals = gROOT->GetListOfGlobals();
+      std::string fullname("ROOT11010");
+      fullname += name;
+      return *(int *)((TGlobal *)globals->FindObject(fullname.c_str()))->GetAddress();
+   };
 
-  {
-    // ROOT-10789 take 2:
-    TClassRef c("ROOT11010::Base");
-    ASSERT_TRUE(c) << "Cannot find TClass for ROOT11010::Base";
-    TFunction *f = (TFunction*)c->GetListOfMethods()->FindObject("Base");
-    ASSERT_TRUE(f) << "Cannot find constructor for ROOT11010::Base";
+   {
+      // ROOT-10789 take 2:
+      TClassRef c("ROOT11010::Base");
+      ASSERT_TRUE(c) << "Cannot find TClass for ROOT11010::Base";
+      TFunction *f = (TFunction *)c->GetListOfMethods()->FindObject("Base");
+      ASSERT_TRUE(f) << "Cannot find constructor for ROOT11010::Base";
 
-    CallFunc_t* callf = gInterpreter->CallFunc_Factory();
-    MethodInfo_t* meth = gInterpreter->MethodInfo_Factory(f->GetDeclId());
-    gInterpreter->CallFunc_SetFunc(callf, meth);
-    gInterpreter->MethodInfo_Delete(meth);
-    const TInterpreter::CallFuncIFacePtr_t &faceptr = gInterpreter->CallFunc_IFacePtr(callf);
-    gInterpreter->CallFunc_Delete(callf);   // does not touch IFacePtr
+      CallFunc_t *callf = gInterpreter->CallFunc_Factory();
+      MethodInfo_t *meth = gInterpreter->MethodInfo_Factory(f->GetDeclId());
+      gInterpreter->CallFunc_SetFunc(callf, meth);
+      gInterpreter->MethodInfo_Delete(meth);
+      const TInterpreter::CallFuncIFacePtr_t &faceptr = gInterpreter->CallFunc_IFacePtr(callf);
+      gInterpreter->CallFunc_Delete(callf); // does not touch IFacePtr
 
-    EXPECT_EQ(GetInt("baseMemCtorCalled"), 0);
-    EXPECT_EQ(GetInt("baseMemDtorCalled"), 0);
-    EXPECT_EQ(GetInt("baseCtorCalled"), 0);
-    EXPECT_EQ(GetInt("baseDtorCalled"), 0);
+      EXPECT_EQ(GetInt("baseMemCtorCalled"), 0);
+      EXPECT_EQ(GetInt("baseMemDtorCalled"), 0);
+      EXPECT_EQ(GetInt("baseCtorCalled"), 0);
+      EXPECT_EQ(GetInt("baseDtorCalled"), 0);
 
-    EXPECT_EQ(GetInt("derivMemCtorCalled"), 0);
-    EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
-    EXPECT_EQ(GetInt("derivDtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivMemCtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivDtorCalled"), 0);
 
-    void* argbuf[8];
-    void* objresult = nullptr;
-    std::string s("TheStringCtorArg");
-    argbuf[0] = &s;
-    faceptr.fGeneric(0, 1, argbuf, &objresult);
-    EXPECT_NE(objresult, nullptr);
+      void *argbuf[8];
+      void *objresult = nullptr;
+      std::string s("TheStringCtorArg");
+      argbuf[0] = &s;
+      faceptr.fGeneric(0, 1, argbuf, &objresult);
+      EXPECT_NE(objresult, nullptr);
 
-    EXPECT_EQ(GetInt("baseMemCtorCalled"), 1);
-    EXPECT_EQ(GetInt("baseMemDtorCalled"), 0);
-    EXPECT_EQ(GetInt("baseCtorCalled"), 1);
-    EXPECT_EQ(GetInt("baseDtorCalled"), 0);
+      EXPECT_EQ(GetInt("baseMemCtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseMemDtorCalled"), 0);
+      EXPECT_EQ(GetInt("baseCtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseDtorCalled"), 0);
 
-    EXPECT_EQ(GetInt("derivMemCtorCalled"), 0);
-    EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
-    EXPECT_EQ(GetInt("derivDtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivMemCtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivDtorCalled"), 0);
 
-    c->Destructor(objresult);
+      c->Destructor(objresult);
 
-    EXPECT_EQ(GetInt("baseMemCtorCalled"), 1);
-    EXPECT_EQ(GetInt("baseMemDtorCalled"), 1);
-    EXPECT_EQ(GetInt("baseCtorCalled"), 1);
-    EXPECT_EQ(GetInt("baseDtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseMemCtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseMemDtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseCtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseDtorCalled"), 1);
 
-    EXPECT_EQ(GetInt("derivMemCtorCalled"), 0);
-    EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
-    EXPECT_EQ(GetInt("derivDtorCalled"), 0);
-  }
+      EXPECT_EQ(GetInt("derivMemCtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivDtorCalled"), 0);
+   }
 
-  {
-    TClassRef c("ROOT11010::Derived");
-    ASSERT_TRUE(c) << "Cannot find TClass for ROOT11010::Derived";
-    TFunction *f = (TFunction*)c->GetListOfMethods()->FindObject("Derived");
-    ASSERT_TRUE(f) << "Cannot find constructor for ROOT11010::Derived";
+   {
+      TClassRef c("ROOT11010::Derived");
+      ASSERT_TRUE(c) << "Cannot find TClass for ROOT11010::Derived";
+      TFunction *f = (TFunction *)c->GetListOfMethods()->FindObject("Derived");
+      ASSERT_TRUE(f) << "Cannot find constructor for ROOT11010::Derived";
 
-    CallFunc_t* callf = gInterpreter->CallFunc_Factory();
-    MethodInfo_t* meth = gInterpreter->MethodInfo_Factory(f->GetDeclId());
-    gInterpreter->CallFunc_SetFunc(callf, meth);
-    gInterpreter->MethodInfo_Delete(meth);
+      CallFunc_t *callf = gInterpreter->CallFunc_Factory();
+      MethodInfo_t *meth = gInterpreter->MethodInfo_Factory(f->GetDeclId());
+      gInterpreter->CallFunc_SetFunc(callf, meth);
+      gInterpreter->MethodInfo_Delete(meth);
 // On Windows we get an assert, CodeGen-ing the callfunc for the construction:
 // CGClass.cpp:488's CallBaseDtor::Emit fails to cast CFG.CurCodeDecl (the callfunc
 // __cf2 function) into the expected destructor (i.e. CXXMethodDecl). I.e. something
 // is wrong in the exception emission stack.
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
 
-    const TInterpreter::CallFuncIFacePtr_t &faceptr = gInterpreter->CallFunc_IFacePtr(callf);
-    gInterpreter->CallFunc_Delete(callf);   // does not touch IFacePtr
+      const TInterpreter::CallFuncIFacePtr_t &faceptr = gInterpreter->CallFunc_IFacePtr(callf);
+      gInterpreter->CallFunc_Delete(callf); // does not touch IFacePtr
 
+      EXPECT_EQ(GetInt("baseMemCtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseMemDtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseCtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseDtorCalled"), 1);
 
-    EXPECT_EQ(GetInt("baseMemCtorCalled"), 1);
-    EXPECT_EQ(GetInt("baseMemDtorCalled"), 1);
-    EXPECT_EQ(GetInt("baseCtorCalled"), 1);
-    EXPECT_EQ(GetInt("baseDtorCalled"), 1);
+      EXPECT_EQ(GetInt("derivMemCtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivDtorCalled"), 0);
 
-    EXPECT_EQ(GetInt("derivMemCtorCalled"), 0);
-    EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
-    EXPECT_EQ(GetInt("derivDtorCalled"), 0);
+      void *argbuf[8];
+      void *objresult = nullptr;
+      std::string s("TheStringCtorArg");
+      argbuf[0] = &s;
+      faceptr.fGeneric(0, 1, argbuf, &objresult);
+      EXPECT_NE(objresult, nullptr);
 
-    void* argbuf[8];
-    void* objresult = nullptr;
-    std::string s("TheStringCtorArg");
-    argbuf[0] = &s;
-    faceptr.fGeneric(0, 1, argbuf, &objresult);
-    EXPECT_NE(objresult, nullptr);
+      EXPECT_EQ(GetInt("baseMemCtorCalled"), 2);
+      EXPECT_EQ(GetInt("baseMemDtorCalled"), 1);
+      EXPECT_EQ(GetInt("baseCtorCalled"), 2);
+      EXPECT_EQ(GetInt("baseDtorCalled"), 1);
 
-    EXPECT_EQ(GetInt("baseMemCtorCalled"), 2);
-    EXPECT_EQ(GetInt("baseMemDtorCalled"), 1);
-    EXPECT_EQ(GetInt("baseCtorCalled"), 2);
-    EXPECT_EQ(GetInt("baseDtorCalled"), 1);
+      EXPECT_EQ(GetInt("derivMemCtorCalled"), 1);
+      EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
+      EXPECT_EQ(GetInt("derivDtorCalled"), 0);
 
-    EXPECT_EQ(GetInt("derivMemCtorCalled"), 1);
-    EXPECT_EQ(GetInt("derivMemDtorCalled"), 0);
-    EXPECT_EQ(GetInt("derivDtorCalled"), 0);
+      c->Destructor(objresult);
 
-    c->Destructor(objresult);
+      EXPECT_EQ(GetInt("baseMemCtorCalled"), 2);
+      EXPECT_EQ(GetInt("baseMemDtorCalled"), 2);
+      EXPECT_EQ(GetInt("baseCtorCalled"), 2);
+      EXPECT_EQ(GetInt("baseDtorCalled"), 2);
 
-    EXPECT_EQ(GetInt("baseMemCtorCalled"), 2);
-    EXPECT_EQ(GetInt("baseMemDtorCalled"), 2);
-    EXPECT_EQ(GetInt("baseCtorCalled"), 2);
-    EXPECT_EQ(GetInt("baseDtorCalled"), 2);
-
-    EXPECT_EQ(GetInt("derivMemCtorCalled"), 1);
-    EXPECT_EQ(GetInt("derivMemDtorCalled"), 1);
-    EXPECT_EQ(GetInt("derivDtorCalled"), 1);
+      EXPECT_EQ(GetInt("derivMemCtorCalled"), 1);
+      EXPECT_EQ(GetInt("derivMemDtorCalled"), 1);
+      EXPECT_EQ(GetInt("derivDtorCalled"), 1);
 #endif
-  }
+   }
 }


### PR DESCRIPTION
Fix #6393 (at least incrementally) by avoiding the demangling step, and instead exposing the template-ness consistently.