### PR TITLE
[DF][Doc] Add ROOT::RDF::RunGraphs doc

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -861,7 +861,20 @@ A complex analysis may require multiple `RDatFrame` objects to compute all desir
 event loops of each `RDataFrame` graph can be parallelized but run sequentially one after another. In the case of many threads
 you may encounter the problem that you run out of data to serve all available resources. To improve this scenario, the helper
 `ROOT::RDF::RunGraphs` allows you to process multiple `RDataFrame` graphs concurrently, which may improve the resource usage.
+~~~{.cpp}
+ROOT::EnableImplicitMT();
+ROOT::RDataFrame df1("tree1", "f1.root");
+ROOT::RDataFrame df2("tree2", "f2.root");
+auto histo1 = df1.Histo1D("x");
+auto histo2 = df2.Histo1D("y");
 
+// just accessing result pointers, the event loops of separate RDataFrames run one after the other
+histo1->Draw(); // runs first multi-thread event loop
+histo2->Draw(); // runs second multi-thread event loop
+
+// with ROOT::RDF::RunGraphs, event loops for separate computation graphs can run concurrently
+ROOT::RDF::RunGraphs({histo1, histo2});
+~~~
 <a name="reference"></a>
 */
 // clang-format on

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -54,7 +54,7 @@ You can directly see RDataFrame in action through its [code examples](https://ro
 - [More features](#more-features)
 - [Transformations](#transformations) -- manipulating data
 - [Actions](#actions) -- getting results
-- [Parallel execution](#parallel-execution) -- how to use it and common pitfalls
+- [Performance tips and parallel execution](#parallel-execution) -- how to use it and common pitfalls
 - [Class reference](#reference) -- most methods are implemented in the [RInterface](https://root.cern/doc/master/classROOT_1_1RDF_1_1RInterface.html) base class
 
 ## <a name="cheatsheet"></a>Cheat sheet
@@ -818,7 +818,7 @@ Actions can be **instant** or **lazy**. Instant actions are executed as soon as 
 executed whenever the object they return is accessed for the first time. As a rule of thumb, actions with a return value
 are lazy, the others are instant.
 
-##  <a name="parallel-execution"></a>Parallel execution
+##  <a name="parallel-execution"></a>Performance tips and parallel execution
 As pointed out before in this document, `RDataFrame` can transparently perform multi-threaded event loops to speed up
 the execution of its actions. Users have to call `ROOT::EnableImplicitMT()` *before* constructing the `RDataFrame`
 object to indicate that it should take advantage of a pool of worker threads. **Each worker thread processes a distinct
@@ -855,6 +855,12 @@ Note that the same slot might be associated to different threads over the course
 will never receive the same slot at the same time.
 This extra parameter might facilitate writing safe parallel code by having each thread write/modify a different
 *processing slot*, e.g. a different element of a list. See [here](#generic-actions) for an example usage of `ForeachSlot`.
+
+### Parallel execution of multiple `RDataFrame` event loops
+A complex analysis may require multiple `RDatFrame` objects to compute all desired results. This poses the challenge that the
+event loops of each `RDataFrame` graph can be parallelized but run sequentially one after another. In the case of many threads
+you may encounter the problem that you run out of data to serve all available resources. To improve this scenario, the helper
+`ROOT::RDF::RunGraphs` allows you to process multiple `RDataFrame` graphs concurrently, which may improve the resource usage.
 
 <a name="reference"></a>
 */

--- a/tutorials/dataframe/df104_HiggsToTwoPhotons.py
+++ b/tutorials/dataframe/df104_HiggsToTwoPhotons.py
@@ -207,7 +207,8 @@ text.DrawLatex(0.18, 0.84, "ATLAS")
 text.SetTextFont(42)
 text.DrawLatex(0.18 + 0.13, 0.84, "Open Data")
 text.SetTextSize(0.04)
-text.DrawLatex(0.18, 0.78, "#sqrt{s} = 13 TeV, 10 fb^{-1}");
+text.DrawLatex(0.18, 0.78, "#sqrt{s} = 13 TeV, 10 fb^{-1}")
 
 # Save the plot
-c.SaveAs("HiggsToTwoPhotons.pdf");
+c.SaveAs("df104_HiggsToTwoPhotons.png")
+print("Saved figure to df104_HiggsToTwoPhotons.png")

--- a/tutorials/dataframe/df104_HiggsToTwoPhotons.py
+++ b/tutorials/dataframe/df104_HiggsToTwoPhotons.py
@@ -79,6 +79,13 @@ for p in processes:
             "m_yy", "weight")
 
 # Run the event loop
+
+# RunGraphs allows to run the event loops of the separate RDataFrame graphs
+# concurrently. This results in an improved usage of the available resources
+# if each separate RDataFrame can not utilize all available resources, e.g.,
+# because not enough data is available.
+ROOT.RDF.RunGraphs([hists[s] for s in ["ggH", "VBF", "data"]])
+
 ggh = hists["ggH"].GetValue()
 vbf = hists["VBF"].GetValue()
 data = hists["data"].GetValue()

--- a/tutorials/dataframe/df105_WBosonAnalysis.py
+++ b/tutorials/dataframe/df105_WBosonAnalysis.py
@@ -125,6 +125,12 @@ for s in samples:
 
 # Run the event loop and merge histograms of the respective processes
 
+# RunGraphs allows to run the event loops of the separate RDataFrame graphs
+# concurrently. This results in an improved usage of the available resources
+# if each separate RDataFrame can not utilize all available resources, e.g.,
+# because not enough data is available.
+ROOT.RDF.RunGraphs([histos[s] for s in samples])
+
 def merge_histos(label):
     h = None
     for i, d in enumerate(files[label]):

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.py
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.py
@@ -113,6 +113,12 @@ for s in samples:
 
 # Run the event loop and merge histograms of the respective processes
 
+# RunGraphs allows to run the event loops of the separate RDataFrame graphs
+# concurrently. This results in an improved usage of the available resources
+# if each separate RDataFrame can not utilize all available resources, e.g.,
+# because not enough data is available.
+ROOT.RDF.RunGraphs([histos[s] for s in samples])
+
 def merge_histos(label):
     h = None
     for i, d in enumerate(files[label]):

--- a/tutorials/dataframe/df107_SingleTopAnalysis.py
+++ b/tutorials/dataframe/df107_SingleTopAnalysis.py
@@ -163,6 +163,12 @@ for s in samples:
 
 # Run the event loop and merge histograms of the respective processes
 
+# RunGraphs allows to run the event loops of the separate RDataFrame graphs
+# concurrently. This results in an improved usage of the available resources
+# if each separate RDataFrame can not utilize all available resources, e.g.,
+# because not enough data is available.
+ROOT.RDF.RunGraphs([histos[s] for s in samples])
+
 def merge_histos(label):
     h = None
     for i, d in enumerate(files[label]):


### PR DESCRIPTION
@eguiraud Where would you put `ROOT::RDF::RunGraphs` on the main `RDataFrame` doxygen page (https://root.cern/doc/master/classROOT_1_1RDataFrame.html#python)?

Fixes https://github.com/root-project/root/issues/6422