### PR TITLE
[TEnv] Make signatures of method declaration and definition uniform

### DIFF
--- a/core/base/src/TEnv.cxx
+++ b/core/base/src/TEnv.cxx
@@ -781,7 +781,7 @@ void TEnv::SetValue(const char *name, Int_t value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set or create a double resource value.
 
-void TEnv::SetValue(const char *name, double value)
+void TEnv::SetValue(const char *name, Double_t value)
 {
    SetValue(name, Form("%g", value));
 }


### PR DESCRIPTION
The `double` overload of `TEnv::SetValue` used `Double_t` as argument
type in the header file and `double` in the source file.
Now we consistently use `Double_t`.
This fixes #6425.
