### PR TITLE
[PyROOT][6376] Fix calculation of offset of dispatch pointer

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
@@ -206,6 +206,11 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* dct)
         }
     }
 
+// add an offset calculator for the dispatch ptr as needed
+    code << "public:\n"
+         << "static size_t _dispatchptr_offset() { return (size_t)&(("
+         << derivedName << "*)(0x0))->m_self; }";
+
 // finish class declaration
     code << "};\n}";
 


### PR DESCRIPTION
Fixes #6376. The previous way of calculating the offset was causing a corruption in a multi-inheritance case (described in #6376).

Adapted from:
https://bitbucket.org/wlav/cpycppyy/commits/7d9eb4a170ff9e3da9569232ba76ef59c9ee72fd
since CPPConstructor.cxx has changed since last update.