### PR TITLE
[DF] Always pass arguments with the same type to std::min in Min

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -772,7 +772,7 @@ public:
    void Exec(unsigned int slot, const T &vs)
    {
       for (auto &&v : vs)
-         fMins[slot] = std::min(v, fMins[slot]);
+         fMins[slot] = std::min(static_cast<ResultType>(v), fMins[slot]);
    }
 
    void Initialize() { /* noop */}
@@ -822,7 +822,7 @@ public:
    void Exec(unsigned int slot, const T &vs)
    {
       for (auto &&v : vs)
-         fMaxs[slot] = std::max((ResultType)v, fMaxs[slot]);
+         fMaxs[slot] = std::max(static_cast<ResultType>(v), fMaxs[slot]);
    }
 
    void Initialize() { /* noop */}

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -448,3 +448,56 @@ TEST(RDataFrameInterface, ColumnWithSimpleStruct)
       EXPECT_DOUBLE_EQ(df.Mean(col).GetValue(), 42.); // jitted
    }
 }
+
+// Issue #6435
+TEST(RDataFrameInterface, MinMaxSumMeanStdDevOfScalar)
+{
+   auto df = ROOT::RDataFrame(4).Range(1, 0).Define("x", [](ULong64_t e) { return int(e); }, {"rdfentry_"});
+   auto max = df.Max<int>("x");
+   auto jit_max = df.Max("x");
+   auto min = df.Min<int>("x");
+   auto jit_min = df.Min("x");
+   auto sum = df.Sum<int>("x");
+   auto jit_sum = df.Sum("x");
+   auto mean = df.Mean<int>("x");
+   auto jit_mean = df.Mean("x");
+   auto stddev = df.StdDev<int>("x");
+   auto jit_stddev = df.StdDev("x");
+
+   EXPECT_EQ(*max, 3);
+   EXPECT_DOUBLE_EQ(*jit_max, 3.f);
+   EXPECT_EQ(*min, 1);
+   EXPECT_DOUBLE_EQ(*jit_min, 1.f);
+   EXPECT_EQ(*sum, 6);
+   EXPECT_DOUBLE_EQ(*jit_sum, 6.f);
+   EXPECT_DOUBLE_EQ(*mean, 2);
+   EXPECT_DOUBLE_EQ(*jit_mean, 2);
+   EXPECT_DOUBLE_EQ(*stddev, 1.f);
+   EXPECT_DOUBLE_EQ(*jit_stddev, 1.f);
+}
+
+TEST(RDataFrameInterface, MinMaxSumMeanStdDevOfRVec)
+{
+   auto df = ROOT::RDataFrame(1).Define("x", [] { return ROOT::RVec<int>{1,2,3}; });
+   auto max = df.Max<ROOT::RVec<int>>("x");
+   auto jit_max = df.Max("x");
+   auto min = df.Min<ROOT::RVec<int>>("x");
+   auto jit_min = df.Min("x");
+   auto sum = df.Sum<ROOT::RVec<int>>("x");
+   auto jit_sum = df.Sum("x");
+   auto mean = df.Mean<ROOT::RVec<int>>("x");
+   auto jit_mean = df.Mean("x");
+   auto stddev = df.StdDev<ROOT::RVec<int>>("x");
+   auto jit_stddev = df.StdDev("x");
+
+   EXPECT_EQ(*max, 3);
+   EXPECT_DOUBLE_EQ(*jit_max, 3.f);
+   EXPECT_EQ(*min, 1);
+   EXPECT_DOUBLE_EQ(*jit_min, 1.f);
+   EXPECT_EQ(*sum, 6);
+   EXPECT_DOUBLE_EQ(*jit_sum, 6.f);
+   EXPECT_DOUBLE_EQ(*mean, 2);
+   EXPECT_DOUBLE_EQ(*jit_mean, 2);
+   EXPECT_DOUBLE_EQ(*stddev, 1.f);
+   EXPECT_DOUBLE_EQ(*jit_stddev, 1.f);
+}


### PR DESCRIPTION
When the Min or Max actions are jitted, their result type is always
double, independently of the column type. If the column type happens
to be of a different type, std::min won't compile because template
parameter type deduction is ambiguous.
We now always explicitly cast the arguments of std::min to the desired
result type to avoid the ambiguity.
