### PR TITLE
[DF] Always pass arguments with the same type to std::min in Min

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -731,7 +731,7 @@ public:
    void Exec(unsigned int slot, const T &vs)
    {
       for (auto &&v : vs)
-         fMins[slot] = std::min(v, fMins[slot]);
+         fMins[slot] = std::min(static_cast<ResultType>(v), fMins[slot]);
    }
 
    void Initialize() { /* noop */}
@@ -775,7 +775,7 @@ public:
    void Exec(unsigned int slot, const T &vs)
    {
       for (auto &&v : vs)
-         fMaxs[slot] = std::max((ResultType)v, fMaxs[slot]);
+         fMaxs[slot] = std::max(static_cast<ResultType>(v), fMaxs[slot]);
    }
 
    void Initialize() { /* noop */}


### PR DESCRIPTION
When the Min or Max actions are jitted, their result type is always
double, independently of the column type. If the column type happens
to be of a different type, std::min won't compile because template
parameter type deduction is ambiguous.
We now always explicitly cast the arguments of std::min to the desired
result type to avoid the ambiguity.

This fixes #6435.