### PR TITLE
[HIST] Several fixes in handling histogram and profiles with labels

### DIFF
--- a/hist/hist/inc/TAxis.h
+++ b/hist/hist/inc/TAxis.h
@@ -81,7 +81,7 @@ public:
 
    Bool_t     CanExtend() const { return (fBits2 & kCanExtend);  }
    Bool_t     CanBeAlphanumeric() { return !(fBits2 & kNotAlpha); }
-   Bool_t     IsAlphanumeric() { return fBits2 & kAlphanumeric; }
+   Bool_t     IsAlphanumeric() const { return fBits2 & kAlphanumeric; }
    void       SetAlphanumeric(Bool_t alphanumeric = kTRUE);
    void       SetCanExtend(Bool_t canExtend) { fBits2 = canExtend ? (fBits2 | kCanExtend) : (fBits2 & ~kCanExtend); }
    void       SetNoAlphanumeric(Bool_t noalpha = kTRUE) {
@@ -227,4 +227,3 @@ inline void TAxis::SetNoExponent(Bool_t noExponent)
 
 
 #endif
-

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -138,6 +138,7 @@ protected:
    static Bool_t    RecomputeAxisLimits(TAxis& destAxis, const TAxis& anAxis);
    static Bool_t    SameLimitsAndNBins(const TAxis& axis1, const TAxis& axis2);
    Bool_t   IsEmpty() const;
+   UInt_t GetAxisLabelStatus() const;
 
    inline static Double_t AutoP2GetPower2(Double_t x, Bool_t next = kTRUE);
    inline static Int_t AutoP2GetBins(Int_t n);

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -120,7 +120,6 @@ public:
    static Int_t FitOptionsMake(Option_t *option, Foption_t &Foption);
 
 private:
-   Int_t   AxisChoice(Option_t *axis) const;
    void    Build();
 
    TH1(const TH1&);
@@ -132,6 +131,8 @@ protected:
    TH1(const char *name,const char *title,Int_t nbinsx,Double_t xlow,Double_t xup);
    TH1(const char *name,const char *title,Int_t nbinsx,const Float_t *xbins);
    TH1(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins);
+
+   Int_t            AxisChoice(Option_t *axis) const;
    virtual Int_t    BufferFill(Double_t x, Double_t w);
    virtual Bool_t   FindNewAxisLimits(const TAxis* axis, const Double_t point, Double_t& newMin, Double_t &newMax);
    virtual void     SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *option = "");

--- a/hist/hist/inc/TProfile.h
+++ b/hist/hist/inc/TProfile.h
@@ -33,18 +33,19 @@ class TProfile : public TH1D {
 
 public:
    friend class TProfileHelper;
+   friend class TH1Merger;
 
 protected:
-    TArrayD     fBinEntries;      //number of entries per bin
-    EErrorType  fErrorMode;       //Option to compute errors
-    Double_t    fYmin;            //Lower limit in Y (if set)
-    Double_t    fYmax;            //Upper limit in Y (if set)
-    Bool_t      fScaling;         //!True when TProfile::Scale is called
-    Double_t    fTsumwy;          //Total Sum of weight*Y
-    Double_t    fTsumwy2;         //Total Sum of weight*Y*Y
-    TArrayD     fBinSumw2;        //Array of sum of squares of weights per bin
+   TArrayD fBinEntries;   // number of entries per bin
+   EErrorType fErrorMode; // Option to compute errors
+   Double_t fYmin;        // Lower limit in Y (if set)
+   Double_t fYmax;        // Upper limit in Y (if set)
+   Bool_t fScaling;       //! True when TProfile::Scale is called
+   Double_t fTsumwy;      // Total Sum of weight*Y
+   Double_t fTsumwy2;     // Total Sum of weight*Y*Y
+   TArrayD fBinSumw2;     // Array of sum of squares of weights per bin
 
-static Bool_t   fgApproximate;    //bin error approximation option
+   static Bool_t fgApproximate; // bin error approximation option
 
    virtual Int_t    BufferFill(Double_t, Double_t) {return -2;} //may not use
    virtual Int_t    BufferFill(Double_t x, Double_t y, Double_t w);
@@ -138,4 +139,3 @@ public:
 };
 
 #endif
-

--- a/hist/hist/inc/TProfile2D.h
+++ b/hist/hist/inc/TProfile2D.h
@@ -101,9 +101,9 @@ public:
    virtual Bool_t    Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
    virtual void      ExtendAxis(Double_t x, TAxis *axis);
    Int_t             Fill(Double_t x, Double_t y, Double_t z);
-   virtual Int_t     Fill(Double_t x, const char *namey, Double_t z);
-   virtual Int_t     Fill(const char *namex, Double_t y, Double_t z);
-   virtual Int_t     Fill(const char *namex, const char *namey, Double_t z);
+   virtual Int_t     Fill(Double_t x, const char *namey, Double_t z, Double_t w = 1.);
+   virtual Int_t     Fill(const char *namex, Double_t y, Double_t z, Double_t w = 1.);
+   virtual Int_t     Fill(const char *namex, const char *namey, Double_t z, Double_t w = 1.);
    virtual Int_t     Fill(Double_t x, Double_t y, Double_t z, Double_t w);
    virtual Double_t  GetBinContent(Int_t bin) const;
    virtual Double_t  GetBinContent(Int_t binx, Int_t biny) const {return GetBinContent(GetBin(binx,biny));}

--- a/hist/hist/inc/TProfile2D.h
+++ b/hist/hist/inc/TProfile2D.h
@@ -28,6 +28,7 @@ class TProfile2D : public TH2D {
 
 public:
    friend class TProfileHelper;
+   friend class TH1Merger;
 
 protected:
    TArrayD     fBinEntries;      //number of entries per bin

--- a/hist/hist/inc/TProfile3D.h
+++ b/hist/hist/inc/TProfile3D.h
@@ -123,6 +123,9 @@ public:
    virtual void      GetStats(Double_t *stats) const;
    virtual Double_t  GetTmin() const {return fTmin;}
    virtual Double_t  GetTmax() const {return fTmax;}
+   virtual void      LabelsDeflate(Option_t *axis="X");
+   virtual void      LabelsInflate(Option_t *axis="X");
+   virtual void      LabelsOption(Option_t *option="h", Option_t *axis="X");
    virtual Long64_t  Merge(TCollection *list);
    virtual Bool_t    Multiply(TF1 *h1, Double_t c1=1);
    virtual Bool_t    Multiply(const TH1 *h1);

--- a/hist/hist/inc/TProfile3D.h
+++ b/hist/hist/inc/TProfile3D.h
@@ -28,6 +28,7 @@ class TProfile3D : public TH3D {
 
 public:
    friend class TProfileHelper;
+   friend class TH1Merger;
 
 protected:
    TArrayD       fBinEntries;      //number of entries per bin

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -5346,9 +5346,20 @@ void TH1::LabelsOption(Option_t *option, Option_t *ax)
    }
 
    Double_t entries = fEntries;
-   Int_t n = TMath::Min(axis->GetNbins(), labels->GetSize());
+   // Code works only if first n bins have labels if we uncomment following line
+   // but we don't want to support this special case
+   // Int_t n = TMath::Min(axis->GetNbins(), labels->GetSize());
+
+   // support only cases where each bin has a labels (should be when axis is alphanumeric)
+   Int_t n = labels->GetSize();
+   if (n != axis->GetNbins()) {
+      Error("LabelsOption", "axis %s of Histogram %s has bins without labels. Sorting is not supported in this case",
+            axis->GetName(), GetName());
+      return;
+   }
    std::vector<Int_t> a(n);
    std::vector<Int_t> b(n);
+
 
    Int_t i, j, k;
    std::vector<Double_t> cont;

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3407,8 +3407,8 @@ Int_t TH1::Fill(const char *namex, Double_t w)
    Double_t z= w;
    fTsumw   += z;
    fTsumw2  += z*z;
-   // this make sense if the histogram is not expanding (no axis can be extended)
-   if (!CanExtendAllAxes()) {
+   // this make sense if the histogram is not expanding (the x axis cannot be extended)
+   if (!fXaxis.CanExtend() || !fXaxis.IsAlphanumeric()) {
       Double_t x = fXaxis.GetBinCenter(bin);
       fTsumwx  += z*x;
       fTsumwx2 += z*x*x;
@@ -6530,6 +6530,21 @@ UInt_t TH1::SetCanExtend(UInt_t extendBitMask)
    }
 
    return oldExtendBitMask;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// Internal function used in TH1::Fill to see which axis is full alphanumeric
+/// i.e. can be extended and is alphanumeric
+UInt_t TH1::GetAxisLabelStatus() const
+{
+   UInt_t bitMask = kNoAxis;
+   if (fXaxis.CanExtend() && fXaxis.IsAlphanumeric() ) bitMask |= kXaxis;
+   if (GetDimension() > 1 && fYaxis.CanExtend() && fYaxis.IsAlphanumeric())
+      bitMask |= kYaxis;
+   if (GetDimension() > 2 && fZaxis.CanExtend() && fZaxis.IsAlphanumeric())
+      bitMask |= kZaxis;
+
+   return bitMask;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -5353,9 +5353,9 @@ void TH1::LabelsOption(Option_t *option, Option_t *ax)
    // support only cases where each bin has a labels (should be when axis is alphanumeric)
    Int_t n = labels->GetSize();
    if (n != axis->GetNbins()) {
-      Error("LabelsOption", "axis %s of Histogram %s has bins without labels. Sorting is not supported in this case",
+      Warning("LabelsOption", "axis %s of Histogram %s has bins without labels. Sorting might not work correctly",
             axis->GetName(), GetName());
-      return;
+      //return;
    }
    std::vector<Int_t> a(n);
    std::vector<Int_t> b(n);
@@ -5394,8 +5394,8 @@ void TH1::LabelsOption(Option_t *option, Option_t *ax)
          for (i = 0; i < n; i++) {
             SetBinContent(i + 1, cont[b[a[i]] - 1]); // b[a[i]] returns bin number. .we need to subtract 1
             if (gDebug)
-               std::cout << "setting bin " << i + 1 << "value " << cont[b[a[i]] - 1] << " from bin " << b[a[i]]
-                         << "label " << labold->At(a[i])->GetName() << " a " << a[i] << std::endl;
+               Info("LabelsOption","setting bin %d value %f from bin %d label %s at pos %d ",
+                         i+1,cont[b[a[i]] - 1],b[a[i]],labold->At(a[i])->GetName(),a[i]);
             if (!errors.empty())
                SetBinError(i + 1, errors[b[a[i]] - 1]);
          }
@@ -7601,7 +7601,7 @@ void TH1::GetStats(Double_t *stats) const
    // in this case the statistics in x does not make any sense
    Bool_t labelHist =  ((const_cast<TAxis&>(fXaxis)).GetLabels() && fXaxis.CanExtend() );
    // fTsumw == 0 && fEntries > 0 is a special case when uses SetBinContent or calls ResetStats before
-   if ((fTsumw == 0 && fEntries > 0) || ( fXaxis.TestBit(TAxis::kAxisRange) && !labelHist) ) {
+   if ( (fTsumw == 0 && fEntries > 0) || fXaxis.TestBit(TAxis::kAxisRange) ) {
       for (bin=0;bin<4;bin++) stats[bin] = 0;
 
       Int_t firstBinX = fXaxis.GetFirst();

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -5461,9 +5461,11 @@ void TH1::LabelsOption(Option_t *option, Option_t *ax)
                else
                   obj = nullptr;
             }
-            if (!obj)
+            if (!obj) {
                // this should not really happen
                R__ASSERT("LabelsOption - No corresponding bin found when ordering labels");
+               return;
+            }
 
             labels->Add(obj);
             if (gDebug)
@@ -5545,8 +5547,10 @@ void TH1::LabelsOption(Option_t *option, Option_t *ax)
                else
                   obj = nullptr;
             }
-            if (!obj)
+            if (!obj) {
                R__ASSERT("LabelsOption - No corresponding bin found when ordering labels");
+               return;
+            }
             labels->Add(obj);
             if (gDebug)
                std::cout << " set label " << obj->GetName() << " to bin " << i + 1 << " from bin " << a[i] << "content "

--- a/hist/hist/src/TH1Merger.cxx
+++ b/hist/hist/src/TH1Merger.cxx
@@ -1025,6 +1025,19 @@ Bool_t TH1Merger::LabelMerge() {
       if (!fNoCheck && hist->GetEntries() > 0) CheckForDuplicateLabels(hist);
 
       // loop on bins of the histogram and do the merge
+      if (gDebug) {
+         // print bins original histogram
+         std::cout << "Bins of original histograms\n";
+         for (int ix = 1; ix <= fH0->GetXaxis()->GetNbins(); ++ix) {
+            for (int iy = 1; iy <= fH0->GetYaxis()->GetNbins(); ++iy) {
+               for (int iz = 1; iz <= fH0->GetZaxis()->GetNbins(); ++iz) {
+                  int i = fH0->GetBin(ix,iy,iz);
+                  std::cout << "bin" << ix << "," << iy << "," << iz
+                     << "  : " << fH0->RetrieveBinContent(i) /* << " , " << fH0->fBinEntries.fArray[i] */ << std::endl;
+               }
+            }
+         }
+      }
       for (Int_t ibin = 0; ibin < hist->fNcells; ibin++) {
 
          // if bin is empty we can skip it
@@ -1065,8 +1078,13 @@ Bool_t TH1Merger::LabelMerge() {
          // find corresponding case (in case bin is not overflow)
          // and see if for that axis we need to merge using labels or bin numbers
          if (ix == -1) {
-            if (mergeLabelsX)
+            if (mergeLabelsX) {
+               // std::cout << "find bin for label " << labelX << "  " << fH0->GetBinContent(1,1,1) << " nbins "
+               // << fH0->GetXaxis()->GetNbins() << std::endl;
                ix = fH0->fXaxis.FindBin(labelX);
+               // std::cout << "bin for label " << ix << "  " << fH0->GetBinContent(1,1,1) << " nbins "
+               // << fH0->GetXaxis()->GetNbins() << std::endl;
+            }
             else
                ix = FindFixBinNumber(binx, hist->fXaxis, fH0->fXaxis);
          }
@@ -1087,6 +1105,7 @@ Bool_t TH1Merger::LabelMerge() {
          if (gDebug)
             Info("TH1Merge::LabelMerge","Merge bin [%d,%d,%d] with label [%s,%s,%s] into bin [%d,%d,%d]",
                  binx,biny,binz,labelX,labelY,labelZ,ix,iy,iz);
+
 
          Int_t ib = fH0->GetBin(ix,iy,iz);
          if (ib < 0 || ib >= fH0->fNcells) {

--- a/hist/hist/src/TH1Merger.cxx
+++ b/hist/hist/src/TH1Merger.cxx
@@ -813,14 +813,7 @@ Bool_t TH1Merger::SameAxesMerge() {
          //Int_t nx = hist->GetXaxis()->GetNbins();
          // loop on bins of the histogram and do the merge
       for (Int_t ibin = 0; ibin < hist->fNcells; ibin++) {
-
-         Double_t cu = hist->RetrieveBinContent(ibin);
-         Double_t e1sq = TMath::Abs(cu);
-         if (fH0->fSumw2.fN) e1sq= hist->GetBinErrorSqUnchecked(ibin);
-
-         fH0->AddBinContent(ibin,cu);
-         if (fH0->fSumw2.fN) fH0->fSumw2.fArray[ibin] += e1sq;
-
+         MergeBin(hist, ibin, ibin);
       }
    }
    //copy merged stats
@@ -861,12 +854,8 @@ Bool_t TH1Merger::DifferentAxesMerge() {
       // loop on bins of the histogram and do the merge
       for (Int_t ibin = 0; ibin < hist->fNcells; ibin++) {
 
-         Double_t cu = hist->RetrieveBinContent(ibin);
-         Double_t e1sq = TMath::Abs(cu);
-         if (fH0->fSumw2.fN) e1sq= hist->GetBinErrorSqUnchecked(ibin);
-
          // if bin is empty we can skip it
-         if (cu == 0 && e1sq == 0) continue;
+         if (IsBinEmpty(hist,ibin)) continue;
 
          Int_t binx,biny,binz;
          hist->GetBinXYZ(ibin, binx, biny, binz);
@@ -912,8 +901,8 @@ Bool_t TH1Merger::DifferentAxesMerge() {
                   fH0->GetName(), ib,fH0->fNcells);
          }
 
-          fH0->AddBinContent(ib,cu);
-          if (fH0->fSumw2.fN) fH0->fSumw2.fArray[ib] += e1sq;
+         MergeBin(hist, ibin, ib);
+
       }
    }
    //copy merged stats
@@ -1038,12 +1027,8 @@ Bool_t TH1Merger::LabelMerge() {
       // loop on bins of the histogram and do the merge
       for (Int_t ibin = 0; ibin < hist->fNcells; ibin++) {
 
-         Double_t cu = hist->RetrieveBinContent(ibin);
-         Double_t e1sq = cu;
-         if (fH0->fSumw2.fN) e1sq= hist->GetBinErrorSqUnchecked(ibin);
-
          // if bin is empty we can skip it
-         if (cu == 0 && e1sq == 0) continue;
+         if (IsBinEmpty(hist,ibin)) continue;
 
          Int_t binx,biny,binz;
          hist->GetBinXYZ(ibin, binx, biny, binz);
@@ -1109,8 +1094,7 @@ Bool_t TH1Merger::LabelMerge() {
                   fH0->GetName(), ib,fH0->fNcells);
          }
 
-          fH0->AddBinContent(ib,cu);
-          if (fH0->fSumw2.fN) fH0->fSumw2.fArray[ib] += e1sq;
+         MergeBin(hist, ibin, ib);
       }
    }
    //copy merged stats
@@ -1118,4 +1102,52 @@ Bool_t TH1Merger::LabelMerge() {
    fH0->SetEntries(nentries);
 
    return kTRUE;
+}
+
+/// helper function for merging
+
+Bool_t TH1Merger::IsBinEmpty(const TH1 * hist, Int_t ibin) {
+   Double_t cu = hist->RetrieveBinContent(ibin);
+   Double_t e1sq = (hist->fSumw2.fN) ?  hist->GetBinErrorSqUnchecked(ibin) : cu;
+   return cu == 0 && e1sq == 0;
+}
+
+// merge input bin (ibin) of histograms hist ibin into current bin cbin of this histogram
+void TH1Merger::MergeBin(const TH1 *hist, Int_t ibin, Int_t cbin)
+{
+   if (!fIsProfileMerge) {
+      Double_t cu = hist->RetrieveBinContent(ibin);
+      fH0->AddBinContent(cbin, cu);
+      if (fH0->fSumw2.fN) {
+         Double_t e1sq = (hist->fSumw2.fN) ? hist->GetBinErrorSqUnchecked(ibin) : cu;
+         fH0->fSumw2.fArray[cbin] += e1sq;
+      }
+   } else {
+      if (fIsProfile1D)
+         MergeProfileBin(static_cast<const TProfile *> (hist), ibin, cbin);
+      else if (fIsProfile2D)
+         MergeProfileBin(static_cast<const TProfile2D *> (hist), ibin, cbin);
+      else if (fIsProfile3D)
+         MergeProfileBin(static_cast<const TProfile3D *> (hist), ibin, cbin);
+   }
+   return;
+}
+
+// merge profile input bin (ibin) of histograms hist ibin into current bin cbin of this histogram
+template<class TProfileType>
+void TH1Merger::MergeProfileBin(const TProfileType *h, Int_t hbin, Int_t pbin)
+{
+   TProfileType *p = static_cast<TProfileType *>(fH0);
+   p->fArray[pbin] += h->fArray[hbin];
+   p->fSumw2.fArray[pbin] += h->fSumw2.fArray[hbin];
+   p->fBinEntries.fArray[pbin] += h->fBinEntries.fArray[hbin];
+   if (p->fBinSumw2.fN) {
+      if (h->fBinSumw2.fN)
+         p->fBinSumw2.fArray[pbin] += h->fBinSumw2.fArray[hbin];
+      else
+         p->fBinSumw2.fArray[pbin] += h->fArray[hbin];
+   }
+   if (gDebug)
+      Info("TH1Merge::MergeProfileBin", "Merge bin %d of profile %s with content %f in bin %d - result is %f", hbin,
+           h->GetName(), h->fArray[hbin], pbin, p->fArray[pbin]);
 }

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -407,21 +407,26 @@ Int_t TH3::Fill(const char *namex, const char *namey, const char *namez, Double_
    if (binx == 0 || binx > fXaxis.GetNbins()) return -1;
    if (biny == 0 || biny > fYaxis.GetNbins()) return -1;
    if (binz == 0 || binz > fZaxis.GetNbins()) return -1;
-   Double_t x = fXaxis.GetBinCenter(binx);
-   Double_t y = fYaxis.GetBinCenter(biny);
-   Double_t z = fZaxis.GetBinCenter(binz);
+
    Double_t v = w;
    fTsumw   += v;
    fTsumw2  += v*v;
-   fTsumwx  += v*x;
-   fTsumwx2 += v*x*x;
-   fTsumwy  += v*y;
-   fTsumwy2 += v*y*y;
-   fTsumwxy += v*x*y;
-   fTsumwz  += v*z;
-   fTsumwz2 += v*z*z;
-   fTsumwxz += v*x*z;
-   fTsumwyz += v*y*z;
+   // skip computation of the statistics along axis that have labels (can be extended and are aphanumeric)
+   UInt_t labelBitMask = GetAxisLabelStatus();
+   if (labelBitMask != TH1::kAllAxes) {
+      Double_t x = (labelBitMask & TH1::kXaxis) ? 0 : fXaxis.GetBinCenter(binx);
+      Double_t y = (labelBitMask & TH1::kYaxis) ? 0 : fYaxis.GetBinCenter(biny);
+      Double_t z = (labelBitMask & TH1::kZaxis) ? 0 : fZaxis.GetBinCenter(binz);
+      fTsumwx += v * x;
+      fTsumwx2 += v * x * x;
+      fTsumwy += v * y;
+      fTsumwy2 += v * y * y;
+      fTsumwxy += v * x * y;
+      fTsumwz += v * z;
+      fTsumwz2 += v * z * z;
+      fTsumwxz += v * x * z;
+      fTsumwyz += v * y * z;
+   }
    return bin;
 }
 
@@ -452,20 +457,24 @@ Int_t TH3::Fill(const char *namex, Double_t y, const char *namez, Double_t w)
       if (!GetStatOverflowsBehaviour()) return -1;
    }
    if (binz == 0 || binz > fZaxis.GetNbins()) return -1;
-   Double_t x = fXaxis.GetBinCenter(binx);
-   Double_t z = fZaxis.GetBinCenter(binz);
    Double_t v = w;
    fTsumw   += v;
    fTsumw2  += v*v;
-   fTsumwx  += v*x;
-   fTsumwx2 += v*x*x;
    fTsumwy  += v*y;
    fTsumwy2 += v*y*y;
-   fTsumwxy += v*x*y;
-   fTsumwz  += v*z;
-   fTsumwz2 += v*z*z;
-   fTsumwxz += v*x*z;
-   fTsumwyz += v*y*z;
+   // skip computation of the statistics along axis that have labels (can be extended and are aphanumeric)
+   UInt_t labelBitMask = GetAxisLabelStatus();
+   if (labelBitMask != (TH1::kXaxis | TH1::kZaxis) ) {
+      Double_t x = (labelBitMask & TH1::kXaxis) ? 0 : fXaxis.GetBinCenter(binx);
+      Double_t z = (labelBitMask & TH1::kZaxis) ? 0 : fZaxis.GetBinCenter(binz);
+      fTsumwx += v * x;
+      fTsumwx2 += v * x * x;
+      fTsumwxy += v * x * y;
+      fTsumwz += v * z;
+      fTsumwz2 += v * z * z;
+      fTsumwxz += v * x * z;
+      fTsumwyz += v * y * z;
+   }
    return bin;
 }
 
@@ -496,20 +505,24 @@ Int_t TH3::Fill(const char *namex, const char *namey, Double_t z, Double_t w)
    if (binz == 0 || binz > fZaxis.GetNbins()) {
       if (!GetStatOverflowsBehaviour()) return -1;
    }
-   Double_t x = fXaxis.GetBinCenter(binx);
-   Double_t y = fYaxis.GetBinCenter(biny);
    Double_t v = w;
    fTsumw   += v;
    fTsumw2  += v*v;
-   fTsumwx  += v*x;
-   fTsumwx2 += v*x*x;
-   fTsumwy  += v*y;
-   fTsumwy2 += v*y*y;
-   fTsumwxy += v*x*y;
    fTsumwz  += v*z;
    fTsumwz2 += v*z*z;
-   fTsumwxz += v*x*z;
-   fTsumwyz += v*y*z;
+   // skip computation of the statistics along axis that have labels (can be extended and are aphanumeric)
+   UInt_t labelBitMask = GetAxisLabelStatus();
+   if (labelBitMask != (TH1::kXaxis | TH1::kYaxis)) {
+      Double_t x = (labelBitMask & TH1::kXaxis) ? 0 : fXaxis.GetBinCenter(binx);
+      Double_t y = (labelBitMask & TH1::kYaxis) ? 0 : fYaxis.GetBinCenter(biny);
+      fTsumwx += v * x;
+      fTsumwx2 += v * x * x;
+      fTsumwy += v * y;
+      fTsumwy2 += v * y * y;
+      fTsumwxy += v * x * y;
+      fTsumwxz += v * x * z;
+      fTsumwyz += v * y * z;
+   }
    return bin;
 }
 
@@ -540,20 +553,23 @@ Int_t TH3::Fill(Double_t x, const char *namey, const char *namez, Double_t w)
    }
    if (biny == 0 || biny > fYaxis.GetNbins()) return -1;
    if (binz == 0 || binz > fZaxis.GetNbins()) return -1;
-   Double_t y = fYaxis.GetBinCenter(biny);
-   Double_t z = fZaxis.GetBinCenter(binz);
+
+   // skip computation of the statistics along axis that have labels (can be extended and are aphanumeric)
+   UInt_t labelBitMask = GetAxisLabelStatus();
+   Double_t y = (labelBitMask & TH1::kYaxis) ? 0 : fYaxis.GetBinCenter(biny);
+   Double_t z = (labelBitMask & TH1::kZaxis) ? 0 : fZaxis.GetBinCenter(binz);
    Double_t v = w;
-   fTsumw   += v;
-   fTsumw2  += v*v;
-   fTsumwx  += v*x;
-   fTsumwx2 += v*x*x;
-   fTsumwy  += v*y;
-   fTsumwy2 += v*y*y;
-   fTsumwxy += v*x*y;
-   fTsumwz  += v*z;
-   fTsumwz2 += v*z*z;
-   fTsumwxz += v*x*z;
-   fTsumwyz += v*y*z;
+   fTsumw += v;
+   fTsumw2 += v * v;
+   fTsumwx += v * x;
+   fTsumwx2 += v * x * x;
+   fTsumwy += v * y;
+   fTsumwy2 += v * y * y;
+   fTsumwxy += v * x * y;
+   fTsumwz += v * z;
+   fTsumwz2 += v * z * z;
+   fTsumwxz += v * x * z;
+   fTsumwyz += v * y * z;
    return bin;
 }
 
@@ -592,7 +608,8 @@ Int_t TH3::Fill(const char * namex, Double_t y, Double_t z, Double_t w)
       if (!GetStatOverflowsBehaviour())
          return -1;
    }
-   Double_t x = fXaxis.GetBinCenter(binx);
+   UInt_t labelBitMask = GetAxisLabelStatus();
+   Double_t x = (labelBitMask & TH1::kXaxis) ? 0 : fXaxis.GetBinCenter(binx);
    Double_t v = w;
    fTsumw += v;
    fTsumw2 += v * v;
@@ -636,7 +653,8 @@ Int_t TH3::Fill(Double_t x, const char *namey, Double_t z, Double_t w)
    if (binz == 0 || binz > fZaxis.GetNbins()) {
       if (!GetStatOverflowsBehaviour()) return -1;
    }
-   Double_t y = fYaxis.GetBinCenter(biny);
+   UInt_t labelBitMask = GetAxisLabelStatus();
+   Double_t y = (labelBitMask & TH1::kYaxis) ? 0 : fYaxis.GetBinCenter(biny);
    Double_t v = w;
    fTsumw   += v;
    fTsumw2  += v*v;
@@ -681,7 +699,8 @@ Int_t TH3::Fill(Double_t x, Double_t y, const char *namez, Double_t w)
       if (!GetStatOverflowsBehaviour()) return -1;
    }
    if (binz == 0 || binz > fZaxis.GetNbins()) return -1;
-   Double_t z = fZaxis.GetBinCenter(binz);
+   UInt_t labelBitMask = GetAxisLabelStatus();
+   Double_t z = (labelBitMask & TH1::kZaxis) ? 0 : fZaxis.GetBinCenter(binz);
    Double_t v = w;
    fTsumw   += v;
    fTsumw2  += v*v;

--- a/hist/hist/src/TProfile.cxx
+++ b/hist/hist/src/TProfile.cxx
@@ -689,16 +689,17 @@ Int_t TProfile::Fill(const char *namex, Double_t y)
    if (bin == 0 || bin > fXaxis.GetNbins()) {
       if (!GetStatOverflowsBehaviour()) return -1;
    }
-   Double_t x = fXaxis.GetBinCenter(bin);
    fTsumw++;
    fTsumw2++;
-   fTsumwx  += x;
-   fTsumwx2 += x*x;
-   fTsumwy  += y;
-   fTsumwy2 += y*y;
+   fTsumwy += y;
+   fTsumwy2 += y * y;
+   if (!fXaxis.CanExtend() || !fXaxis.IsAlphanumeric()) {
+      Double_t x = fXaxis.GetBinCenter(bin);
+      fTsumwx += x;
+      fTsumwx2 += x * x;
+   }
    return bin;
 }
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill a Profile histogram with weights.
 
@@ -753,11 +754,13 @@ Int_t TProfile::Fill(const char *namex, Double_t y, Double_t w)
    if (bin == 0 || bin > fXaxis.GetNbins()) {
       if (!GetStatOverflowsBehaviour()) return -1;
    }
-   Double_t x = fXaxis.GetBinCenter(bin);
    fTsumw   += u;
    fTsumw2  += u*u;
-   fTsumwx  += u*x;
-   fTsumwx2 += u*x*x;
+   if (!fXaxis.CanExtend() || !fXaxis.IsAlphanumeric()) {
+      Double_t x = fXaxis.GetBinCenter(bin);
+      fTsumwx += u*x;
+      fTsumwx2 += u*x*x;
+   }
    fTsumwy  += u*y;
    fTsumwy2 += u*y*y;
    return bin;

--- a/hist/hist/src/TProfile.cxx
+++ b/hist/hist/src/TProfile.cxx
@@ -920,7 +920,11 @@ void TProfile::GetStats(Double_t *stats) const
 
    // Loop on bins
    Int_t bin, binx;
-   if (fTsumw == 0 || fXaxis.TestBit(TAxis::kAxisRange)) {
+   // identify the case of labels with extension of axis range
+   // in this case the statistics in x does not make any sense
+   Bool_t labelHist =  ((const_cast<TAxis&>(fXaxis)).GetLabels() && fXaxis.CanExtend() );
+
+   if ( (fTsumw == 0 /* && fEntries > 0 */) || fXaxis.TestBit(TAxis::kAxisRange) ) {
       for (bin=0;bin<6;bin++) stats[bin] = 0;
       if (!fBinEntries.fArray) return;
       Int_t firstBinX = fXaxis.GetFirst();
@@ -933,7 +937,7 @@ void TProfile::GetStats(Double_t *stats) const
       for (binx = firstBinX; binx <= lastBinX; binx++) {
          Double_t w   = fBinEntries.fArray[binx];
          Double_t w2  = (fBinSumw2.fN ? fBinSumw2.fArray[binx] : w);
-         Double_t x   = fXaxis.GetBinCenter(binx);
+         Double_t x   = (!labelHist) ? fXaxis.GetBinCenter(binx) : 0;
          stats[0] += w;
          stats[1] += w2;
          stats[2] += w*x;

--- a/hist/hist/src/TProfile2D.cxx
+++ b/hist/hist/src/TProfile2D.cxx
@@ -916,8 +916,12 @@ void TProfile2D::GetStats(Double_t *stats) const
 {
    if (fBuffer) ((TProfile2D*)this)->BufferEmpty();
 
+   // check for labels axis . In that case corresponsing statistics do not make sense and it is set to zero
+   Bool_t labelXaxis =  ((const_cast<TAxis&>(fXaxis)).GetLabels() && fXaxis.CanExtend() );
+   Bool_t labelYaxis =  ((const_cast<TAxis&>(fYaxis)).GetLabels() && fYaxis.CanExtend() );
+
    // Loop on bins
-   if (fTsumw == 0 || fXaxis.TestBit(TAxis::kAxisRange) || fYaxis.TestBit(TAxis::kAxisRange)) {
+   if ( (fTsumw == 0 /* && fEntries > 0 */) || fXaxis.TestBit(TAxis::kAxisRange) || fYaxis.TestBit(TAxis::kAxisRange)) {
       Int_t bin, binx, biny;
       Double_t w, w2;
       Double_t x,y;
@@ -939,12 +943,12 @@ void TProfile2D::GetStats(Double_t *stats) const
          }
       }
       for (biny = firstBinY; biny <= lastBinY; biny++) {
-         y = fYaxis.GetBinCenter(biny);
+         y = (!labelYaxis) ? fYaxis.GetBinCenter(biny) : 0;
          for (binx = firstBinX; binx <= lastBinX; binx++) {
             bin = GetBin(binx,biny);
             w         = fBinEntries.fArray[bin];
             w2        = (fBinSumw2.fN ? fBinSumw2.fArray[bin] : w );
-            x         = fXaxis.GetBinCenter(binx);
+            x         = (!labelXaxis) ? fXaxis.GetBinCenter(binx) : 0;
             stats[0] += w;
             stats[1] += w2;
             stats[2] += w*x;

--- a/hist/hist/src/TProfile3D.cxx
+++ b/hist/hist/src/TProfile3D.cxx
@@ -835,6 +835,41 @@ void TProfile3D::GetStats(Double_t *stats) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Reduce the number of bins for this axis to the number of bins having a label.
+
+void TProfile3D::LabelsDeflate(Option_t *ax)
+{
+   TProfileHelper::LabelsDeflate(this, ax);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Double the number of bins for axis.
+/// Refill histogram
+/// This function is called by TAxis::FindBin(const char *label)
+
+void TProfile3D::LabelsInflate(Option_t *ax)
+{
+   TProfileHelper::LabelsInflate(this, ax);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set option(s) to draw axis with labels.
+///
+/// option might have the following values:
+///
+///  - "a" sort by alphabetic order
+///  - ">" sort by decreasing values
+///  - "<" sort by increasing values
+///  - "h" draw labels horizontal
+///  - "v" draw labels vertical
+///  - "u" draw labels up (end of label right adjusted)
+///  - "d" draw labels down (start of label left adjusted)
+
+void TProfile3D::LabelsOption(Option_t */* option */, Option_t * /* ax */)
+{
+   Error("LabelsOption","Labels option function is not implemented for a TProfile3D");
+}
+////////////////////////////////////////////////////////////////////////////////
 /// Merge all histograms in the collection in this histogram.
 ///
 /// This function computes the min/max for the axes,
@@ -1073,7 +1108,7 @@ TProfile2D *TProfile3D::DoProjectProfile2D(const char* name, const char * title,
    // Since no axis range is considered when doing the projection TProfile3D->TH3D
    // the resulting histogram will have the same axis as the parent one
    // we need afterwards to set the range in the 3D histogram to considered it later
-   // when doing the projection in a Profile2D 
+   // when doing the projection in a Profile2D
    if (fXaxis.TestBit(TAxis::kAxisRange) ) {
       h3dW->GetXaxis()->SetRange(fXaxis.GetFirst(),fXaxis.GetLast());
       h3dN->GetXaxis()->SetRange(fXaxis.GetFirst(),fXaxis.GetLast());

--- a/hist/hist/src/TProfile3D.cxx
+++ b/hist/hist/src/TProfile3D.cxx
@@ -786,21 +786,27 @@ void TProfile3D::GetStats(Double_t *stats) const
    if (fBuffer) ((TProfile3D*)this)->BufferEmpty();
 
    // Loop on bins
-   if (fTsumw == 0 || fXaxis.TestBit(TAxis::kAxisRange) || fYaxis.TestBit(TAxis::kAxisRange)) {
+   if ( (fTsumw == 0 /* && fEntries > 0 */) || fXaxis.TestBit(TAxis::kAxisRange) || fYaxis.TestBit(TAxis::kAxisRange)) {
+
+      // check for labels axis . In that case corresponsing statistics do not make sense and it is set to zero
+      Bool_t labelXaxis = ((const_cast<TAxis &>(fXaxis)).GetLabels() && fXaxis.CanExtend());
+      Bool_t labelYaxis = ((const_cast<TAxis &>(fYaxis)).GetLabels() && fYaxis.CanExtend());
+      Bool_t labelZaxis = ((const_cast<TAxis &>(fZaxis)).GetLabels() && fZaxis.CanExtend());
+
       Int_t bin, binx, biny,binz;
       Double_t w, w2;
       Double_t x,y,z;
       for (bin=0;bin<kNstat;bin++) stats[bin] = 0;
       if (!fBinEntries.fArray) return;
       for (binz=fZaxis.GetFirst();binz<=fZaxis.GetLast();binz++) {
-         z = fZaxis.GetBinCenter(binz);
+         z = (!labelZaxis) ? fZaxis.GetBinCenter(binz) : 0;
          for (biny=fYaxis.GetFirst();biny<=fYaxis.GetLast();biny++) {
-            y = fYaxis.GetBinCenter(biny);
+            y = (!labelYaxis) ? fYaxis.GetBinCenter(biny) : 0;
             for (binx=fXaxis.GetFirst();binx<=fXaxis.GetLast();binx++) {
                bin = GetBin(binx,biny,binz);
                w         = fBinEntries.fArray[bin];
                w2        = (fBinSumw2.fN ? fBinSumw2.fArray[bin] : w );
-               x         = fXaxis.GetBinCenter(binx);
+               x         = (!labelXaxis) ? fXaxis.GetBinCenter(binx) : 0;
                stats[0]  += w;
                stats[1]  += w2;
                stats[2]  += w*x;

--- a/hist/hist/src/TProfileHelper.h
+++ b/hist/hist/src/TProfileHelper.h
@@ -735,7 +735,7 @@ Double_t TProfileHelper::GetBinError(T* p, Int_t bin)
    if (err2 != 0 && neff < 5) test = eprim2*sum/err2;
    //Int_t cellLimit = (p->GetDimension() == 3)?1000404:10404;
    if (p->fgApproximate && (test < 1.e-4 || eprim2 <= 0)) {
-      Double_t stats[TH1::kNstat];
+      Double_t stats[TH1::kNstat] = {0};
       p->GetStats(stats);
       Double_t ssum = stats[0];
       // for 1D profile

--- a/hist/hist/src/TProfileHelper.h
+++ b/hist/hist/src/TProfileHelper.h
@@ -25,6 +25,7 @@
 #include "TError.h"
 #include "THashList.h"
 #include "TMath.h"
+#include "TH1Merger.h"
 
 class TProfileHelper {
 
@@ -182,6 +183,14 @@ Long64_t TProfileHelper::Merge(T* p, TCollection *li) {
 
    TList inlist;
    inlist.AddAll(li);
+
+   // use TH1Merger class
+   TH1Merger merger(*p, *li, "");
+   Bool_t ret = merger();
+
+   return (ret) ? p->GetEntries() : -1;
+
+#ifdef OLD_PROFILE_MERGE
 
    TAxis newXAxis;
    TAxis newYAxis;
@@ -414,6 +423,7 @@ Long64_t TProfileHelper::Merge(T* p, TCollection *li) {
       delete hclone;
    }
    return (Long64_t)nentries;
+#endif
 }
 
 template <typename T>

--- a/test/stressHistogram.cxx
+++ b/test/stressHistogram.cxx
@@ -197,9 +197,9 @@ bool testAddProfile1()
    Double_t c1 = r.Rndm();
    Double_t c2 = r.Rndm();
 
-   TProfile* p1 = new TProfile("t1D1-p1", "p1-Title", numberOfBins, minRange, maxRange);
-   TProfile* p2 = new TProfile("t1D1-p2", "p2-Title", numberOfBins, minRange, maxRange);
-   TProfile* p3 = new TProfile("t1D1-p3", "p3=c1*p1+c2*p2", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("t1D1_p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p2 = new TProfile("t1D1_p2", "p2-Title", numberOfBins, minRange, maxRange);
+   TProfile* p3 = new TProfile("t1D1_p3", "p3=c1*p1+c2*p2", numberOfBins, minRange, maxRange);
 
    for ( Int_t e = 0; e < nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -215,13 +215,13 @@ bool testAddProfile1()
       p3->Fill(x, y,  c2);
    }
 
-   TProfile* p4 = new TProfile("t1D1-p4", "p4=c1*p1+p2*c2", numberOfBins, minRange, maxRange);
+   TProfile* p4 = new TProfile("t1D1_p4", "p4=c1*p1+p2*c2", numberOfBins, minRange, maxRange);
    p4->Add(p1, p2, c1, c2);
 
    bool ret = equals("Add1DProfile1", p3, p4, cmpOptStats, 1E-13);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -350,20 +350,20 @@ bool testAddVarProf1()
    Double_t c1 = r.Rndm();
    Double_t c2 = r.Rndm();
 
-   TProfile* p1 = new TProfile("t1D1-p1", "p1-Title", numberOfBins, v);
-   TProfile* p2 = new TProfile("t1D1-p2", "p2-Title", numberOfBins, v);
-   TProfile* p3 = new TProfile("t1D1-p3", "p3=c1*p1+c2*p2", numberOfBins, v);
+   TProfile* p1 = new TProfile("t1D1_p1", "p1-Title", numberOfBins, v);
+   TProfile* p2 = new TProfile("t1D1_p2", "p2-Title", numberOfBins, v);
+   TProfile* p3 = new TProfile("t1D1_p3", "p3=c1*p1+c2*p2", numberOfBins, v);
 
    FillProfiles(p1, p3, 1.0, c1);
    FillProfiles(p2, p3, 1.0, c2);
 
-   TProfile* p4 = new TProfile("t1D1-p4", "p4=c1*p1+p2*c2", numberOfBins, v);
+   TProfile* p4 = new TProfile("t1D1_p4", "p4=c1*p1+p2*c2", numberOfBins, v);
    p4->Add(p1, p2, c1, c2);
 
    bool ret = equals("AddVar1DProf1", p3, p4, cmpOptStats, 1E-13);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
 
    return ret;
 }
@@ -591,15 +591,15 @@ bool testAdd2DProfile1()
    Double_t c1 = r.Rndm();
    Double_t c2 = r.Rndm();
 
-   TProfile2D* p1 = new TProfile2D("t2D1-p1", "p1",
+   TProfile2D* p1 = new TProfile2D("t2D1_p1", "p1",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile2D* p2 = new TProfile2D("t2D1-p2", "p2",
+   TProfile2D* p2 = new TProfile2D("t2D1_p2", "p2",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile2D* p3 = new TProfile2D("t2D1-p3", "p3=c1*p1+c2*p2",
+   TProfile2D* p3 = new TProfile2D("t2D1_p3", "p3=c1*p1+c2*p2",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -619,14 +619,14 @@ bool testAdd2DProfile1()
       p3->Fill(x, y, z, c2);
    }
 
-   TProfile2D* p4 = new TProfile2D("t2D1-p4", "p4=c1*p1+c2*p2",
+   TProfile2D* p4 = new TProfile2D("t2D1_p4", "p4=c1*p1+c2*p2",
                        numberOfBins, minRange, maxRange,
                        numberOfBins + 2, minRange, maxRange);
    p4->Add(p1, p2, c1, c2);
    bool ret = equals("Add2DProfile1", p3, p4, cmpOptStats , 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -677,15 +677,15 @@ bool testAdd2DProfile2()
 
    Double_t c2 = r.Rndm();
 
-   TProfile2D* p1 = new TProfile2D("t2D2-p1", "p1",
+   TProfile2D* p1 = new TProfile2D("t2D2_p1", "p1",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile2D* p2 = new TProfile2D("t2D2-p2", "p2",
+   TProfile2D* p2 = new TProfile2D("t2D2_p2", "p2",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile2D* p3 = new TProfile2D("t2D2-p3", "p3=p1+c2*p2",
+   TProfile2D* p3 = new TProfile2D("t2D2_p3", "p3=p1+c2*p2",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -707,8 +707,8 @@ bool testAdd2DProfile2()
 
    p1->Add(p2, c2);
    bool ret = equals("Add2DProfile2", p3, p1, cmpOptStats, 1E-10);
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -771,17 +771,17 @@ bool testAdd3DProfile1()
    Double_t c1 = r.Rndm();
    Double_t c2 = r.Rndm();
 
-   TProfile3D* p1 = new TProfile3D("t3D1-p1", "p1",
+   TProfile3D* p1 = new TProfile3D("t3D1_p1", "p1",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile3D* p2 = new TProfile3D("t3D1-p2", "p2",
+   TProfile3D* p2 = new TProfile3D("t3D1_p2", "p2",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile3D* p3 = new TProfile3D("t3D1-p3", "p3=c1*p1+c2*p2",
+   TProfile3D* p3 = new TProfile3D("t3D1_p3", "p3=c1*p1+c2*p2",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -804,15 +804,15 @@ bool testAdd3DProfile1()
       p3->Fill(x, y, z, t,  c2);
    }
 
-   TProfile3D* p4 = new TProfile3D("t3D1-p4", "p4=c1*p1+c2*p2",
+   TProfile3D* p4 = new TProfile3D("t3D1_p4", "p4=c1*p1+c2*p2",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
    p4->Add(p1, p2, c1, c2);
    bool ret = equals("Add3DProfile1", p3, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -868,17 +868,17 @@ bool testAdd3DProfile2()
 
    Double_t c2 = r.Rndm();
 
-   TProfile3D* p1 = new TProfile3D("t3D2-p1", "p1",
+   TProfile3D* p1 = new TProfile3D("t3D2_p1", "p1",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile3D* p2 = new TProfile3D("t3D2-p2", "p2",
+   TProfile3D* p2 = new TProfile3D("t3D2_p2", "p2",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile3D* p3 = new TProfile3D("t3D2-p3", "p3=p1+c2*p2",
+   TProfile3D* p3 = new TProfile3D("t3D2_p3", "p3=p1+c2*p2",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -903,8 +903,8 @@ bool testAdd3DProfile2()
 
    p1->Add(p2, c2);
    bool ret = equals("Add3DProfile2", p3, p1, cmpOptStats, 1E-10);
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -1869,8 +1869,8 @@ bool testDivideProf1()
    Double_t c1 = 1;//r.Rndm();
    Double_t c2 = 1;//r.Rndm();
 
-   TProfile* p1 = new TProfile("d1D1-p1", "p1-Title", numberOfBins, minRange, maxRange);
-   TProfile* p2 = new TProfile("d1D1-p2", "p2-Title", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("d1D1_p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p2 = new TProfile("d1D1_p2", "p2-Title", numberOfBins, minRange, maxRange);
 
    p1->Sumw2();p2->Sumw2();
 
@@ -1888,7 +1888,7 @@ bool testDivideProf1()
    }
 
 
-   TProfile* p3 = new TProfile("d1D1-p3", "p3=(c1*p1)/(c2*p2)", numberOfBins, minRange, maxRange);
+   TProfile* p3 = new TProfile("d1D1_p3", "p3=(c1*p1)/(c2*p2)", numberOfBins, minRange, maxRange);
    p3->Divide(p1, p2, c1, c2);
 
    // There is no Multiply method to tests. And the errors are wrongly
@@ -2410,7 +2410,7 @@ bool testAssignProfile1D()
 {
    // Tests the operator=() method for 1D Profiles
 
-   TProfile* p1 = new TProfile("=1D-p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("=1D_p1", "p1-Title", numberOfBins, minRange, maxRange);
 
    for ( Int_t e = 0; e < nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -2418,11 +2418,11 @@ bool testAssignProfile1D()
       p1->Fill(x, y, 1.0);
    }
 
-   TProfile* p2 = new TProfile("=1D-p2", "p2-Title", numberOfBins, minRange, maxRange);
+   TProfile* p2 = new TProfile("=1D_p2", "p2-Title", numberOfBins, minRange, maxRange);
    *p2 = *p1;
 
    bool ret = equals("Assign Oper Prof '='  1D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2433,7 +2433,7 @@ bool testAssignProfileVar1D()
    Double_t v[numberOfBins+1];
    FillVariableRange(v);
 
-   TProfile* p1 = new TProfile("=1D-p1", "p1-Title", numberOfBins, v);
+   TProfile* p1 = new TProfile("=1D_p1", "p1-Title", numberOfBins, v);
 
    for ( Int_t e = 0; e < nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -2441,11 +2441,11 @@ bool testAssignProfileVar1D()
       p1->Fill(x, y, 1.0);
    }
 
-   TProfile* p2 = new TProfile("=1D-p2", "p2-Title", numberOfBins, v);
+   TProfile* p2 = new TProfile("=1D_p2", "p2-Title", numberOfBins, v);
    *p2 = *p1;
 
    bool ret = equals("Assign Oper VarP '='  1D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2496,7 +2496,7 @@ bool testCopyConstructorProfile1D()
 {
    // Tests the copy constructor for 1D Profiles
 
-   TProfile* p1 = new TProfile("cc1D-p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("cc1D_p1", "p1-Title", numberOfBins, minRange, maxRange);
 
    for ( Int_t e = 0; e < nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -2507,7 +2507,7 @@ bool testCopyConstructorProfile1D()
    TProfile* p2 = new TProfile(*p1);
 
    bool ret = equals("Copy Constructor Prof 1D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2518,7 +2518,7 @@ bool testCopyConstructorProfileVar1D()
    Double_t v[numberOfBins+1];
    FillVariableRange(v);
 
-   TProfile* p1 = new TProfile("cc1D-p1", "p1-Title", numberOfBins, v);
+   TProfile* p1 = new TProfile("cc1D_p1", "p1-Title", numberOfBins, v);
 
    for ( Int_t e = 0; e < nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -2529,7 +2529,7 @@ bool testCopyConstructorProfileVar1D()
    TProfile* p2 = new TProfile(*p1);
 
    bool ret = equals("Copy Constructor VarP 1D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2580,7 +2580,7 @@ bool testCloneProfile1D()
 {
    // Tests the clone method for 1D Profiles
 
-   TProfile* p1 = new TProfile("cl1D-p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("cl1D_p1", "p1-Title", numberOfBins, minRange, maxRange);
 
    for ( Int_t e = 0; e < nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -2591,7 +2591,7 @@ bool testCloneProfile1D()
    TProfile* p2 = static_cast<TProfile*> ( p1->Clone() );
 
    bool ret = equals("Clone Function Prof   1D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2602,7 +2602,7 @@ bool testCloneProfileVar1D()
    Double_t v[numberOfBins+1];
    FillVariableRange(v);
 
-   TProfile* p1 = new TProfile("cl1D-p1", "p1-Title", numberOfBins, v);
+   TProfile* p1 = new TProfile("cl1D_p1", "p1-Title", numberOfBins, v);
 
    for ( Int_t e = 0; e < nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -2613,7 +2613,7 @@ bool testCloneProfileVar1D()
    TProfile* p2 = static_cast<TProfile*> ( p1->Clone() );
 
    bool ret = equals("Clone Function VarP   1D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2647,7 +2647,7 @@ bool testAssignProfile2D()
 {
    // Tests the operator=() method for 2D Profiles
 
-   TProfile2D* p1 = new TProfile2D("=2D-p1", "p1-Title",
+   TProfile2D* p1 = new TProfile2D("=2D_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -2658,13 +2658,13 @@ bool testAssignProfile2D()
       p1->Fill(x, y, z, 1.0);
    }
 
-   TProfile2D* p2 = new TProfile2D("=2D-p2", "p2-Title",
+   TProfile2D* p2 = new TProfile2D("=2D_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
    *p2 = *p1;
 
    bool ret = equals("Assign Oper Prof '='  2D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2696,7 +2696,7 @@ bool testCopyConstructorProfile2D()
 {
    // Tests the copy constructor for 2D Profiles
 
-   TProfile2D* p1 = new TProfile2D("cc2D-p1", "p1-Title",
+   TProfile2D* p1 = new TProfile2D("cc2D_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -2710,7 +2710,7 @@ bool testCopyConstructorProfile2D()
    TProfile2D* p2 = new TProfile2D(*p1);
 
    bool ret = equals("Copy Constructor Prof 2D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2741,7 +2741,7 @@ bool testCloneProfile2D()
 {
    // Tests the clone method for 2D Profiles
 
-   TProfile2D* p1 = new TProfile2D("cl2D-p1", "p1-Title",
+   TProfile2D* p1 = new TProfile2D("cl2D_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -2755,7 +2755,7 @@ bool testCloneProfile2D()
    TProfile2D* p2 = static_cast<TProfile2D*> ( p1->Clone() );
 
    bool ret = equals("Clone Function Prof   2D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2792,7 +2792,7 @@ bool testAssignProfile3D()
 {
    // Tests the operator=() method for 3D Profiles
 
-   TProfile3D* p1 = new TProfile3D("=3D-p1", "p1-Title",
+   TProfile3D* p1 = new TProfile3D("=3D_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -2805,14 +2805,14 @@ bool testAssignProfile3D()
       p1->Fill(x, y, z, t, 1.0);
    }
 
-   TProfile3D* p2 = new TProfile3D("=3D-p2", "p2-Title",
+   TProfile3D* p2 = new TProfile3D("=3D_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
    *p2 = *p1;
 
    bool ret = equals("Assign Oper Prof '='  3D", p1, p2);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2845,7 +2845,7 @@ bool testCopyConstructorProfile3D()
 {
    // Tests the copy constructor for 3D Profiles
 
-   TProfile3D* p1 = new TProfile3D("cc3D-p1", "p1-Title",
+   TProfile3D* p1 = new TProfile3D("cc3D_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -2861,7 +2861,7 @@ bool testCopyConstructorProfile3D()
    TProfile3D* p2 = new TProfile3D(*p1);
 
    bool ret = equals("Copy Constructor Prof 3D", p1, p2/*, cmpOptStats*/);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -2894,7 +2894,7 @@ bool testCloneProfile3D()
 {
    // Tests the clone method for 3D Profiles
 
-   TProfile3D* p1 = new TProfile3D("cl3D-p1", "p1-Title",
+   TProfile3D* p1 = new TProfile3D("cl3D_p1", "p1-Title",
                        numberOfBins, minRange, maxRange,
                        numberOfBins + 1, minRange, maxRange,
                        numberOfBins + 2, minRange, maxRange);
@@ -2910,7 +2910,7 @@ bool testCloneProfile3D()
    TProfile3D* p2 = static_cast<TProfile3D*> ( p1->Clone() );
 
    bool ret = equals("Clone Function Prof   3D", p1, p2);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -3000,7 +3000,7 @@ bool testWriteReadProfile1D()
 {
    // Tests the write and read methods for 1D Profiles
 
-   TProfile* p1 = new TProfile("wr1D-p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("wr1D_p1", "p1-Title", numberOfBins, minRange, maxRange);
 
    for ( Int_t e = 0; e < nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -3013,10 +3013,10 @@ bool testWriteReadProfile1D()
    f.Close();
 
    TFile f2("tmpHist.root");
-   TProfile* p2 = static_cast<TProfile*> ( f2.Get("wr1D-p1") );
+   TProfile* p2 = static_cast<TProfile*> ( f2.Get("wr1D_p1") );
 
    bool ret = equals("Read/Write Prof 1D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -3027,7 +3027,7 @@ bool testWriteReadProfileVar1D()
    Double_t v[numberOfBins+1];
    FillVariableRange(v);
 
-   TProfile* p1 = new TProfile("wr1D-p1", "p1-Title", numberOfBins, v);
+   TProfile* p1 = new TProfile("wr1D_p1", "p1-Title", numberOfBins, v);
 
    for ( Int_t e = 0; e < nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -3040,10 +3040,10 @@ bool testWriteReadProfileVar1D()
    f.Close();
 
    TFile f2("tmpHist.root");
-   TProfile* p2 = static_cast<TProfile*> ( f2.Get("wr1D-p1") );
+   TProfile* p2 = static_cast<TProfile*> ( f2.Get("wr1D_p1") );
 
    bool ret = equals("Read/Write VarP 1D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -3079,7 +3079,7 @@ bool testWriteReadProfile2D()
 {
    // Tests the write and read methods for 2D Profiles
 
-   TProfile2D* p1 = new TProfile2D("wr2D-p1", "p1-Title",
+   TProfile2D* p1 = new TProfile2D("wr2D_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -3095,10 +3095,10 @@ bool testWriteReadProfile2D()
    f.Close();
 
    TFile f2("tmpHist.root");
-   TProfile2D* p2 = static_cast<TProfile2D*> ( f2.Get("wr2D-p1") );
+   TProfile2D* p2 = static_cast<TProfile2D*> ( f2.Get("wr2D_p1") );
 
    bool ret = equals("Read/Write Prof 2D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -3136,7 +3136,7 @@ bool testWriteReadProfile3D()
 {
    // Tests the write and read methods for 3D Profile
 
-   TProfile3D* p1 = new TProfile3D("wr3D-p1", "p1-Title",
+   TProfile3D* p1 = new TProfile3D("wr3D_p1", "p1-Title",
                                  numberOfBins, minRange, maxRange,
                                  numberOfBins + 1, minRange, maxRange,
                                  numberOfBins + 2, minRange, maxRange);
@@ -3154,14 +3154,14 @@ bool testWriteReadProfile3D()
    f.Close();
 
    TFile f2("tmpHist.root");
-   TProfile3D* p2 = static_cast<TProfile3D*> ( f2.Get("wr3D-p1") );
+   TProfile3D* p2 = static_cast<TProfile3D*> ( f2.Get("wr3D_p1") );
 
    // In this particular case the statistics are not checked. The
    // Chi2Test is not properly implemented for the TProfile3D
    // class. If the cmpOptStats flag is set, then there will be a
    // crash.
    bool ret = equals("Read/Write Prof 3D", p1, p2);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -3313,9 +3313,9 @@ bool testMergeProf1D()
    p1->Merge(list);
 
    bool ret = equals("Merge1DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -3342,9 +3342,9 @@ bool testMergeProfVar1D()
    p1->Merge(list);
 
    bool ret = equals("Merge1DVarP", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -3405,16 +3405,16 @@ bool testMergeProf2D()
 {
    // Tests the merge method for 2D Profiles
 
-   TProfile2D* p1 = new TProfile2D("merge2D-p1", "p1-Title",
+   TProfile2D* p1 = new TProfile2D("merge2D_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p2 = new TProfile2D("merge2D-p2", "p2-Title",
+   TProfile2D* p2 = new TProfile2D("merge2D_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p3 = new TProfile2D("merge2D-p3", "p3-Title",
+   TProfile2D* p3 = new TProfile2D("merge2D_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p4 = new TProfile2D("merge2D-p4", "p4-Title",
+   TProfile2D* p4 = new TProfile2D("merge2D_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -3449,9 +3449,9 @@ bool testMergeProf2D()
    p1->Merge(list);
 
    bool ret = equals("Merge2DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -3519,19 +3519,19 @@ bool testMergeProf3D()
 {
    // Tests the merge method for 3D Profiles
 
-   TProfile3D* p1 = new TProfile3D("merge3D-p1", "p1-Title",
+   TProfile3D* p1 = new TProfile3D("merge3D_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p2 = new TProfile3D("merge3D-p2", "p2-Title",
+   TProfile3D* p2 = new TProfile3D("merge3D_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p3 = new TProfile3D("merge3D-p3", "p3-Title",
+   TProfile3D* p3 = new TProfile3D("merge3D_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p4 = new TProfile3D("merge3D-p4", "p4-Title",
+   TProfile3D* p4 = new TProfile3D("merge3D_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -3570,9 +3570,9 @@ bool testMergeProf3D()
    p1->Merge(list);
 
    bool ret = equals("Merge3DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -3926,9 +3926,9 @@ bool testMergeProf1DLabelSame()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelSame1DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -3936,16 +3936,16 @@ bool testMergeProf2DLabelSame()
 {
    // Tests the merge with some equal labels method for 2D Profiles
 
-   TProfile2D* p1 = new TProfile2D("merge2DLabelSame-p1", "p1-Title",
+   TProfile2D* p1 = new TProfile2D("merge2DLabelSame_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p2 = new TProfile2D("merge2DLabelSame-p2", "p2-Title",
+   TProfile2D* p2 = new TProfile2D("merge2DLabelSame_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p3 = new TProfile2D("merge2DLabelSame-p3", "p3-Title",
+   TProfile2D* p3 = new TProfile2D("merge2DLabelSame_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p4 = new TProfile2D("merge2DLabelSame-p4", "p4-Title",
+   TProfile2D* p4 = new TProfile2D("merge2DLabelSame_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -3988,9 +3988,9 @@ bool testMergeProf2DLabelSame()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelSame2DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -3998,19 +3998,19 @@ bool testMergeProf3DLabelSame()
 {
    // Tests the merge with some equal labels method for 3D Profiles
 
-   TProfile3D* p1 = new TProfile3D("merge3DLabelSame-p1", "p1-Title",
+   TProfile3D* p1 = new TProfile3D("merge3DLabelSame_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p2 = new TProfile3D("merge3DLabelSame-p2", "p2-Title",
+   TProfile3D* p2 = new TProfile3D("merge3DLabelSame_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p3 = new TProfile3D("merge3DLabelSame-p3", "p3-Title",
+   TProfile3D* p3 = new TProfile3D("merge3DLabelSame_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p4 = new TProfile3D("merge3DLabelSame-p4", "p4-Title",
+   TProfile3D* p4 = new TProfile3D("merge3DLabelSame_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -4057,9 +4057,9 @@ bool testMergeProf3DLabelSame()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelSame3DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -4264,10 +4264,10 @@ bool testMergeProf1DLabelDiff()
 {
    // Tests the merge with some different labels method for 1D Profiles
 
-   TProfile* p1 = new TProfile("merge1DLabelDiff-p1", "p1-Title", numberOfBins, minRange, maxRange);
-   TProfile* p2 = new TProfile("merge1DLabelDiff-p2", "p2-Title", numberOfBins, minRange, maxRange);
-   TProfile* p3 = new TProfile("merge1DLabelDiff-p3", "p3-Title", numberOfBins, minRange, maxRange);
-   TProfile* p4 = new TProfile("merge1DLabelDiff-p4", "p4-Title", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("merge1DLabelDiff_p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p2 = new TProfile("merge1DLabelDiff_p2", "p2-Title", numberOfBins, minRange, maxRange);
+   TProfile* p3 = new TProfile("merge1DLabelDiff_p3", "p3-Title", numberOfBins, minRange, maxRange);
+   TProfile* p4 = new TProfile("merge1DLabelDiff_p4", "p4-Title", numberOfBins, minRange, maxRange);
 
    // It does not work properly! Look, the bins with the same labels
    // are different ones and still the tests passes! This is not
@@ -4305,9 +4305,9 @@ bool testMergeProf1DLabelDiff()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelDiff1DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+      if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -4315,16 +4315,16 @@ bool testMergeProf2DLabelDiff()
 {
    // Tests the merge with some different labels method for 2D Profiles
 
-   TProfile2D* p1 = new TProfile2D("merge2DLabelDiff-p1", "p1-Title",
+   TProfile2D* p1 = new TProfile2D("merge2DLabelDiff_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p2 = new TProfile2D("merge2DLabelDiff-p2", "p2-Title",
+   TProfile2D* p2 = new TProfile2D("merge2DLabelDiff_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p3 = new TProfile2D("merge2DLabelDiff-p3", "p3-Title",
+   TProfile2D* p3 = new TProfile2D("merge2DLabelDiff_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p4 = new TProfile2D("merge2DLabelDiff-p4", "p4-Title",
+   TProfile2D* p4 = new TProfile2D("merge2DLabelDiff_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -4367,9 +4367,9 @@ bool testMergeProf2DLabelDiff()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelDiff2DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -4377,19 +4377,19 @@ bool testMergeProf3DLabelDiff()
 {
    // Tests the merge with some different labels method for 3D Profiles
 
-   TProfile3D* p1 = new TProfile3D("merge3DLabelDiff-p1", "p1-Title",
+   TProfile3D* p1 = new TProfile3D("merge3DLabelDiff_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p2 = new TProfile3D("merge3DLabelDiff-p2", "p2-Title",
+   TProfile3D* p2 = new TProfile3D("merge3DLabelDiff_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p3 = new TProfile3D("merge3DLabelDiff-p3", "p3-Title",
+   TProfile3D* p3 = new TProfile3D("merge3DLabelDiff_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p4 = new TProfile3D("merge3DLabelDiff-p4", "p4-Title",
+   TProfile3D* p4 = new TProfile3D("merge3DLabelDiff_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -4436,9 +4436,9 @@ bool testMergeProf3DLabelDiff()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelDiff3DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -4630,10 +4630,10 @@ bool testMergeProf1DLabelAll()
 {
    // Tests the merge method with fully equally labelled 1D Profiles
 
-   TProfile* p1 = new TProfile("merge1DLabelAll-p1", "p1-Title", numberOfBins, minRange, maxRange);
-   TProfile* p2 = new TProfile("merge1DLabelAll-p2", "p2-Title", numberOfBins, minRange, maxRange);
-   TProfile* p3 = new TProfile("merge1DLabelAll-p3", "p3-Title", numberOfBins, minRange, maxRange);
-   TProfile* p4 = new TProfile("merge1DLabelAll-p4", "p4-Title", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("merge1DLabelAll_p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p2 = new TProfile("merge1DLabelAll_p2", "p2-Title", numberOfBins, minRange, maxRange);
+   TProfile* p3 = new TProfile("merge1DLabelAll_p3", "p3-Title", numberOfBins, minRange, maxRange);
+   TProfile* p4 = new TProfile("merge1DLabelAll_p4", "p4-Title", numberOfBins, minRange, maxRange);
 
    for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
@@ -4672,9 +4672,9 @@ bool testMergeProf1DLabelAll()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelAll1DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+      if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -4682,16 +4682,16 @@ bool testMergeProf2DLabelAll()
 {
    // Tests the merge method with fully equally labelled 2D Profiles
 
-   TProfile2D* p1 = new TProfile2D("merge2DLabelAll-p1", "p1-Title",
+   TProfile2D* p1 = new TProfile2D("merge2DLabelAll_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p2 = new TProfile2D("merge2DLabelAll-p2", "p2-Title",
+   TProfile2D* p2 = new TProfile2D("merge2DLabelAll_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p3 = new TProfile2D("merge2DLabelAll-p3", "p3-Title",
+   TProfile2D* p3 = new TProfile2D("merge2DLabelAll_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p4 = new TProfile2D("merge2DLabelAll-p4", "p4-Title",
+   TProfile2D* p4 = new TProfile2D("merge2DLabelAll_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -4735,9 +4735,9 @@ bool testMergeProf2DLabelAll()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelAll2DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -4745,19 +4745,19 @@ bool testMergeProf3DLabelAll()
 {
    // Tests the merge method with fully equally labelled 3D Profiles
 
-   TProfile3D* p1 = new TProfile3D("merge3DLabelAll-p1", "p1-Title",
+   TProfile3D* p1 = new TProfile3D("merge3DLabelAll_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p2 = new TProfile3D("merge3DLabelAll-p2", "p2-Title",
+   TProfile3D* p2 = new TProfile3D("merge3DLabelAll_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p3 = new TProfile3D("merge3DLabelAll-p3", "p3-Title",
+   TProfile3D* p3 = new TProfile3D("merge3DLabelAll_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p4 = new TProfile3D("merge3DLabelAll-p4", "p4-Title",
+   TProfile3D* p4 = new TProfile3D("merge3DLabelAll_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -4805,9 +4805,9 @@ bool testMergeProf3DLabelAll()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelAll3DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -5043,46 +5043,60 @@ bool testMergeProf1DLabelAllDiff()
 {
    // Tests the merge method with fully differently labelled 1D Profiles
 
-   TProfile* p1 = new TProfile("merge1DLabelAllDiff-p1", "p1-Title", numberOfBins, minRange, maxRange);
-   TProfile* p2 = new TProfile("merge1DLabelAllDiff-p2", "p2-Title", numberOfBins, minRange, maxRange);
-   TProfile* p3 = new TProfile("merge1DLabelAllDiff-p3", "p3-Title", numberOfBins, minRange, maxRange);
-   TProfile* p4 = new TProfile("merge1DLabelAllDiff-p4", "p4-Title", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("merge1DLabelAllDiff_p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p2 = new TProfile("merge1DLabelAllDiff_p2", "p2-Title", numberOfBins, minRange, maxRange);
+   TProfile* p3 = new TProfile("merge1DLabelAllDiff_p3", "p3-Title", numberOfBins, minRange, maxRange);
+   TProfile* p4 = new TProfile("merge1DLabelAllDiff_p4", "p4-Title", 2*numberOfBins, minRange, maxRange);
 
    for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t y = r.Gaus(10+x, 1);
       p1->Fill(x, y, 1.0);
       p4->Fill(x, y, 1.0);
    }
 
    for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t y = r.Gaus(20 + x, 2);
       p2->Fill(x, y, 1.0);
       p4->Fill(x, y, 1.0);
    }
 
    for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t y = r.Uniform(30 + x, 3);
       p3->Fill(x, y, 1.0);
       p4->Fill(x, y, 1.0);
    }
 
-   // It does not work properly! Look, the bins with the same labels
-   // are different ones and still the tests passes! This is not
-   // consistent with TH1::Merge()
-   for ( Int_t i = 1; i <= numberOfBins; ++ i) {
-      ostringstream name;
-      name << (char) ((int) 'a' + i - 1);
-      p1->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      name << 1;
-      p2->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      name << 2;
-      p3->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      name << 3;
-      p4->GetXaxis()->SetBinLabel(i, name.str().c_str());
+   /// set diff labels in p1 and p2 but in p3 same labels as p2
+   for (Int_t i = 1; i <= numberOfBins; ++i) {
+      char letter = (char)((int)'a' + i - 1);
+      ostringstream name1, name2;
+      name1 << letter << 1;
+      p1->GetXaxis()->SetBinLabel(i, name1.str().c_str());
+      name2 << letter << 2;
+      p2->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      // use for h3 same label as for h2 to test the merging
+      p3->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      // we set the bin labels also in h4
+      p4->GetXaxis()->SetBinLabel(i, name1.str().c_str());
+      p4->GetXaxis()->SetBinLabel(i + numberOfBins, name2.str().c_str());
    }
+   // // It does not work properly! Look, the bins with the same labels
+   // // are different ones and still the tests passes! This is not
+   // // consistent with TH1::Merge()
+   // for ( Int_t i = 1; i <= numberOfBins; ++ i) {
+   //    ostringstream name;
+   //    name << (char) ((int) 'a' + i - 1);
+   //    p1->GetXaxis()->SetBinLabel(i, name.str().c_str());
+   //    name << 1;
+   //    p2->GetXaxis()->SetBinLabel(i, name.str().c_str());
+   //    name << 2;
+   //    p3->GetXaxis()->SetBinLabel(i, name.str().c_str());
+   //    name << 2;
+   //    p4->GetXaxis()->SetBinLabel(i, name.str().c_str());
+   // }
 
    TList *list = new TList;
    list->Add(p2);
@@ -5091,9 +5105,9 @@ bool testMergeProf1DLabelAllDiff()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelAllDiff1DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -5101,16 +5115,16 @@ bool testMergeProf2DLabelAllDiff()
 {
    // Tests the merge method with fully differently labelled 2D Profiles
 
-   TProfile2D* p1 = new TProfile2D("merge2DLabelAllDiff-p1", "p1-Title",
+   TProfile2D* p1 = new TProfile2D("merge2DLabelAllDiff_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p2 = new TProfile2D("merge2DLabelAllDiff-p2", "p2-Title",
+   TProfile2D* p2 = new TProfile2D("merge2DLabelAllDiff_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p3 = new TProfile2D("merge2DLabelAllDiff-p3", "p3-Title",
+   TProfile2D* p3 = new TProfile2D("merge2DLabelAllDiff_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile2D* p4 = new TProfile2D("merge2DLabelAllDiff-p4", "p4-Title",
+   TProfile2D* p4 = new TProfile2D("merge2DLabelAllDiff_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
@@ -5164,9 +5178,9 @@ bool testMergeProf2DLabelAllDiff()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelAllDiff2DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -5174,19 +5188,19 @@ bool testMergeProf3DLabelAllDiff()
 {
    // Tests the merge method with fully differently labelled 3D Profiles
 
-   TProfile3D* p1 = new TProfile3D("merge3DLabelAllDiff-p1", "p1-Title",
+   TProfile3D* p1 = new TProfile3D("merge3DLabelAllDiff_p1", "p1-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p2 = new TProfile3D("merge3DLabelAllDiff-p2", "p2-Title",
+   TProfile3D* p2 = new TProfile3D("merge3DLabelAllDiff_p2", "p2-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p3 = new TProfile3D("merge3DLabelAllDiff-p3", "p3-Title",
+   TProfile3D* p3 = new TProfile3D("merge3DLabelAllDiff_p3", "p3-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
-   TProfile3D* p4 = new TProfile3D("merge3DLabelAllDiff-p4", "p4-Title",
+   TProfile3D* p4 = new TProfile3D("merge3DLabelAllDiff_p4", "p4-Title",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -5248,9 +5262,9 @@ bool testMergeProf3DLabelAllDiff()
    p1->Merge(list);
 
    bool ret = equals("MergeLabelAllDiff3DProf", p1, p4, cmpOptStats, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -5454,10 +5468,10 @@ bool testMergeProf1D_Diff(bool testEmpty = false)
 
    // Stats fail, for a reason I do not know :S
 
-   TProfile *p1 = new TProfile("merge1DDiff-p1","p1-Title",110,-110,0);
-   TProfile *p2 = new TProfile("merge1DDiff-p2","p2-Title",220,0,110);
-   TProfile *p3 = new TProfile("merge1DDiff-p3","p3-Title",330,-55,55);
-   TProfile *p4 = new TProfile("merge1DDiff-p4","p4-Title",220,-110,110);
+   TProfile *p1 = new TProfile("merge1DDiff_p1","p1-Title",110,-110,0);
+   TProfile *p2 = new TProfile("merge1DDiff_p2","p2-Title",220,0,110);
+   TProfile *p3 = new TProfile("merge1DDiff_p3","p3-Title",330,-55,55);
+   TProfile *p4 = new TProfile("merge1DDiff_p4","p4-Title",220,-110,110);
 
    if (!testEmpty) {
       for ( Int_t e = 0; e < nEvents; ++e ) {
@@ -5490,9 +5504,9 @@ bool testMergeProf1D_Diff(bool testEmpty = false)
 
    const char * testName = (!testEmpty) ? "MergeProf1D-Diff" : "MergeProf1D-DiffEmpty";
    bool ret = equals(testName, p1, p4, cmpOptNone , 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -5509,16 +5523,16 @@ bool testMergeProf2DDiff()
    // Tests the merge method with different binned 2D Profile
 
    // This tests fails! It should not!
-   TProfile2D *p1 = new TProfile2D("merge2DDiff-p1","p1-Title",
+   TProfile2D *p1 = new TProfile2D("merge2DDiff_p1","p1-Title",
                                    11,-110,0,
                                    11,-110,0);
-   TProfile2D *p2 = new TProfile2D("merge2DDiff-p2","p2-Title",
+   TProfile2D *p2 = new TProfile2D("merge2DDiff_p2","p2-Title",
                                    22,0,110,
                                    22,0,110);
-   TProfile2D *p3 = new TProfile2D("merge2DDiff-p3","p3-Title",
+   TProfile2D *p3 = new TProfile2D("merge2DDiff_p3","p3-Title",
                                    44,-55,55,
                                    44,-55,55);
-   TProfile2D *p4 = new TProfile2D("merge2DDiff-p4","p4-Title",
+   TProfile2D *p4 = new TProfile2D("merge2DDiff_p4","p4-Title",
                                    22,-110,110,
                                    22,-110,110);
 
@@ -5553,9 +5567,9 @@ bool testMergeProf2DDiff()
    p1->Merge(list);
 
    bool ret = equals("MergeDiff2DProf", p1, p4, cmpOptStats, 1E-8);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -5564,19 +5578,19 @@ bool testMergeProf3DDiff()
    // Tests the merge method with different binned 3D Profile
 
    // This tests fails! Segmentation Fault!!It should not!
-   TProfile3D *p1 = new TProfile3D("merge3DDiff-p1","p1-Title",
+   TProfile3D *p1 = new TProfile3D("merge3DDiff_p1","p1-Title",
                                    11,-110,0,
                                    11,-110,0,
                                    11,-110,0);
-   TProfile3D *p2 = new TProfile3D("merge3DDiff-p2","p2-Title",
+   TProfile3D *p2 = new TProfile3D("merge3DDiff_p2","p2-Title",
                                    22,0,110,
                                    22,0,110,
                                    22,0,110);
-   TProfile3D *p3 = new TProfile3D("merge3DDiff-p3","p3-Title",
+   TProfile3D *p3 = new TProfile3D("merge3DDiff_p3","p3-Title",
                                    44,-55,55,
                                    44,-55,55,
                                    44,-55,55);
-   TProfile3D *p4 = new TProfile3D("merge3DDiff-p4","p4-Title",
+   TProfile3D *p4 = new TProfile3D("merge3DDiff_p4","p4-Title",
                                    22,-110,110,
                                    22,-110,110,
                                    22,-110,110);
@@ -5617,9 +5631,9 @@ bool testMergeProf3DDiff()
    // exclude statistics in comparison since chi2 test will fail with low
    // bin statistics
    bool ret = equals("MergeDiff3DProf", p1, p4, cmpOptNone, 1E-10);
-   delete p1;
-   delete p2;
-   delete p3;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
+   if (cleanHistos) delete p3;
    return ret;
 }
 
@@ -6254,8 +6268,8 @@ bool testLabelsInflateProf1D()
    }
 
 
-   TProfile* p1 = new TProfile("tLI1D-p1", "p1-Title", numberOfBins, minRange, maxRange);
-   TProfile* p2 = new TProfile("tLI1D-p2", "p2-Title", numberOfFills, minRange, maxRangeInflate);
+   TProfile* p1 = new TProfile("tLI1D_p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p2 = new TProfile("tLI1D_p2", "p2-Title", numberOfFills, minRange, maxRangeInflate);
 
    p1->GetXaxis()->SetTimeDisplay(1);
 
@@ -6271,7 +6285,7 @@ bool testLabelsInflateProf1D()
    }
 
    bool ret = equals("LabelsInflateProf1D", p1, p2);
-   delete p1;
+   if (cleanHistos) delete p1;
    return ret;
 }
 
@@ -6461,8 +6475,8 @@ bool testInterpolation3D()
 
 bool testScale1DProf()
 {
-   TProfile* p1 = new TProfile("scD1-p1", "p1-Title", numberOfBins, minRange, maxRange);
-   TProfile* p2 = new TProfile("scD1-p2", "p2=c1*p1", numberOfBins, minRange, maxRange);
+   TProfile* p1 = new TProfile("scD1_p1", "p1-Title", numberOfBins, minRange, maxRange);
+   TProfile* p2 = new TProfile("scD1_p2", "p2=c1*p1", numberOfBins, minRange, maxRange);
 
    Double_t c1 = r.Rndm();
 
@@ -6476,17 +6490,17 @@ bool testScale1DProf()
    p1->Scale(c1);
 
    int status = equals("testScale Prof 1D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return status;
 }
 
 bool testScale2DProf()
 {
-   TProfile2D* p1 = new TProfile2D("scD2-p1", "p1",
+   TProfile2D* p1 = new TProfile2D("scD2_p1", "p1",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile2D* p2 = new TProfile2D("scD2-p2", "p2=c1*p1",
+   TProfile2D* p2 = new TProfile2D("scD2_p2", "p2=c1*p1",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
    Double_t c1 = r.Rndm();
@@ -6502,18 +6516,18 @@ bool testScale2DProf()
    p1->Scale(c1);
 
    int status = equals("testScale Prof 2D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return status;
 }
 
 bool testScale3DProf()
 {
-   TProfile3D* p1 = new TProfile3D("scD3-p1", "p1",
+   TProfile3D* p1 = new TProfile3D("scD3_p1", "p1",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
 
-   TProfile3D* p2 = new TProfile3D("scD3-p2", "p2=c1*p1",
+   TProfile3D* p2 = new TProfile3D("scD3_p2", "p2=c1*p1",
                                    numberOfBins, minRange, maxRange,
                                    numberOfBins + 1, minRange, maxRange,
                                    numberOfBins + 2, minRange, maxRange);
@@ -6531,7 +6545,7 @@ bool testScale3DProf()
    p1->Scale(c1);
 
    int status = equals("testScale Prof 3D", p1, p2, cmpOptStats);
-   delete p1;
+   if (cleanHistos) delete p1;
    return status;
 }
 
@@ -8023,7 +8037,7 @@ bool testRefReadProf1D()
    bool ret = 0;
    TProfile* p1 = 0;
    if ( refFileOption == refFileWrite ) {
-      p1 = new TProfile("rr1D-p1", "p1-Title", numberOfBins, minRange, maxRange);
+      p1 = new TProfile("rr1D_p1", "p1-Title", numberOfBins, minRange, maxRange);
 //      p1->Sumw2();
 
       for ( Int_t e = 0; e < nEvents; ++e ) {
@@ -8034,12 +8048,12 @@ bool testRefReadProf1D()
       p1->Write();
    } else {
       TH1::SetDefaultSumw2(false);
-      p1 = static_cast<TProfile*> ( refFile->Get("rr1D-p1") );
+      p1 = static_cast<TProfile*> ( refFile->Get("rr1D_p1") );
       if (!p1) {
-          Error("testRefReadProf1D","Error reading profile rr1D-p1 from file");
+          Error("testRefReadProf1D","Error reading profile rr1D_p1 from file");
           return kTRUE;  // true indicates a failure
       }
-      TProfile* p2 = new TProfile("rr1D-p2", "p2-Title", numberOfBins, minRange, maxRange);
+      TProfile* p2 = new TProfile("rr1D_p2", "p2-Title", numberOfBins, minRange, maxRange);
 //      p2->Sumw2();
 
       for ( Int_t e = 0; e < nEvents; ++e ) {
@@ -8104,7 +8118,7 @@ bool testRefReadProf2D()
    TProfile2D* p1 = 0;
    bool ret = 0;
    if ( refFileOption == refFileWrite ) {
-      p1 = new TProfile2D("rr2D-p1", "p1-Title",
+      p1 = new TProfile2D("rr2D_p1", "p1-Title",
                                       numberOfBins, minRange, maxRange,
                                       numberOfBins, minRange, maxRange);
 
@@ -8116,12 +8130,12 @@ bool testRefReadProf2D()
       }
       p1->Write();
    } else {
-      p1 = static_cast<TProfile2D*> ( refFile->Get("rr2D-p1") );
+      p1 = static_cast<TProfile2D*> ( refFile->Get("rr2D_p1") );
       if (!p1) {
-          Error("testRefReadProf2D","Error reading profile rr2D-p1 from file");
+          Error("testRefReadProf2D","Error reading profile rr2D_p1 from file");
           return kTRUE;  // true indicates a failure
       }
-      TProfile2D* p2 = new TProfile2D("rr2D-p2", "p2-Title",
+      TProfile2D* p2 = new TProfile2D("rr2D_p2", "p2-Title",
                                       numberOfBins, minRange, maxRange,
                                       numberOfBins, minRange, maxRange);
 
@@ -8190,7 +8204,7 @@ bool testRefReadProf3D()
    TProfile3D* p1 = 0;
    bool ret = 0;
    if ( refFileOption == refFileWrite ) {
-      p1 = new TProfile3D("rr3D-p1", "p1-Title",
+      p1 = new TProfile3D("rr3D_p1", "p1-Title",
                           numberOfBins, minRange, maxRange,
                           numberOfBins, minRange, maxRange,
                           numberOfBins, minRange, maxRange);
@@ -8204,12 +8218,12 @@ bool testRefReadProf3D()
       }
       p1->Write();
    } else {
-      p1 = static_cast<TProfile3D*> ( refFile->Get("rr3D-p1") );
+      p1 = static_cast<TProfile3D*> ( refFile->Get("rr3D_p1") );
       if (!p1) {
-          Error("testRefReadProf3D","Error reading profile rr3D-p1 from file");
+          Error("testRefReadProf3D","Error reading profile rr3D_p1 from file");
           return kTRUE;  // true indicates a failure
       }
-      TProfile3D* p2 = new TProfile3D("rr3D-p2", "p2-Title",
+      TProfile3D* p2 = new TProfile3D("rr3D_p2", "p2-Title",
                           numberOfBins, minRange, maxRange,
                           numberOfBins, minRange, maxRange,
                           numberOfBins, minRange, maxRange);
@@ -8321,8 +8335,8 @@ bool testIntegerRebinProfile()
    TProfile* p2 = static_cast<TProfile*>( p1->Rebin(rebin, "testIntegerRebin") );
 
    bool ret = equals("TestIntegerRebinProf", p2, p3, cmpOptStats );
-   delete p1;
-   delete p2;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
    return ret;
 }
 
@@ -8370,8 +8384,8 @@ bool testIntegerRebinNoNameProfile()
    TProfile* p2 = dynamic_cast<TProfile*>( p1->Clone() );
    p2->Rebin(rebin);
    bool ret = equals("TestIntRebNoNamProf", p2, p3, cmpOptStats);
-   delete p1;
-   delete p2;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
    return ret;
 }
 
@@ -8468,8 +8482,8 @@ bool testArrayRebinProfile()
    delete [] rebinArray;
 
    bool ret = equals("TestArrayRebinProf", p2, p3, cmpOptStats );
-   delete p1;
-   delete p2;
+   if (cleanHistos) delete p1;
+   if (cleanHistos) delete p2;
    return ret;
 }
 
@@ -9522,7 +9536,7 @@ public:
       delete n3;
 
       // profiles
-      delete p3;
+      if (cleanHistos) delete p3;
 
       delete p2XY;
       delete p2XZ;

--- a/test/stressHistogram.cxx
+++ b/test/stressHistogram.cxx
@@ -5031,69 +5031,71 @@ bool testMerge3DLabelAllDiff()
    // All label sizes are less than number of bins, therefore axis cannot be extended
    // and merge is done then numerically and not in label mode
 
+   // use smaller numberOfBins to have all labels filled in h4
+   int nBins = numberOfBins/2;
+
    TH3D* h1 = new TH3D("merge3DLabelAllDiff_h1", "h1-Title",
-                       numberOfBins, minRange, maxRange,
-                       numberOfBins + 1, minRange, maxRange,
-                       numberOfBins + 2, minRange, maxRange);
+                       nBins, minRange, maxRange,
+                       nBins + 1, minRange, maxRange,
+                       nBins + 2, minRange, maxRange);
    TH3D* h2 = new TH3D("merge3DLabelAllDiff_h2", "h2-Title",
-                       numberOfBins, minRange, maxRange,
-                       numberOfBins + 1, minRange, maxRange,
-                       numberOfBins + 2, minRange, maxRange);
+                       nBins, minRange, maxRange,
+                       nBins + 1, minRange, maxRange,
+                       nBins + 2, minRange, maxRange);
    TH3D* h3 = new TH3D("merge3DLabelAllDiff_h3", "h3-Title",
-                       numberOfBins, minRange, maxRange,
-                       numberOfBins + 1, minRange, maxRange,
-                       numberOfBins + 2, minRange, maxRange);
+                       nBins, minRange, maxRange,
+                       nBins + 1, minRange, maxRange,
+                       nBins + 2, minRange, maxRange);
    TH3D* h4 = new TH3D("merge3DLabelAllDiff_h4", "h4-Title",
-                       numberOfBins, minRange, maxRange,
-                       numberOfBins + 1, minRange, maxRange,
-                       numberOfBins + 2, minRange, maxRange);
+                       nBins, minRange, maxRange,
+                       nBins + 1, minRange, maxRange,
+                       nBins + 2, minRange, maxRange);
+
+
+   // the y axis will have the last bin without a label since it contains nBins+1
+   for ( Int_t i = 1; i <= nBins; ++ i) {
+      char letter = (char) ((int) 'a' + i - 1);
+      ostringstream name1, name2;
+      name1 << letter << 1;
+      h1->GetXaxis()->SetBinLabel(i, name1.str().c_str());
+      h1->GetYaxis()->SetBinLabel(i, name1.str().c_str());
+      name2 << letter << 2;
+      h2->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      h2->GetYaxis()->SetBinLabel(i, name2.str().c_str());
+      // use for h3 same label as for h2 to test the merging
+      h3->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      h3->GetYaxis()->SetBinLabel(i, name2.str().c_str());
+       // we do not set the bin labels in h4 xaxis
+      h4->GetYaxis()->SetBinLabel(i, name2.str().c_str());
+   }
+
+   for ( Int_t e = 0; e < nEvents ; ++e ) {
+      TString label = h1->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
+      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      h1->Fill(label, y, z, 1.0);
+      h4->Fill(label, y, z, 1.0);
+   }
+
+   for ( Int_t e = 0; e < nEvents ; ++e ) {
+      TString label = h2->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
+      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      h2->Fill(label, y, z, 1.0);
+      h4->Fill(label, y, z, 1.0);
+   }
 
    for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
+      TString label = h3->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
       Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
       Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
       Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      h1->Fill(x, y, z, 1.0);
-      h4->Fill(x, y, z, 1.0);
+      h3->Fill(label, y, z, 1.0);
+      h4->Fill(label, y, z, 1.0);
    }
 
-   for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
-      Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      h2->Fill(x, y, z, 1.0);
-      h4->Fill(x, y, z, 1.0);
-   }
-
-   for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
-      Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      h3->Fill(x, y, z, 1.0);
-      h4->Fill(x, y, z, 1.0);
-   }
-
-   //NB do not set labels for all bins
-   //this will make merge for all axis numeric
-   // i.e. using bin centers and ignoring labels
-   for ( Int_t i = 1; i < numberOfBins; ++ i) {
-      ostringstream name;
-      name << (char) ((int) 'a' + i - 1);
-      h1->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      h1->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      h1->GetZaxis()->SetBinLabel(i, name.str().c_str());
-      name << 1;
-      h2->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      h2->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      h2->GetZaxis()->SetBinLabel(i, name.str().c_str());
-      name << 2;
-      h3->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      h3->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      h3->GetZaxis()->SetBinLabel(i, name.str().c_str());
-      name << 3;
-      h4->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      h4->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      h4->GetZaxis()->SetBinLabel(i, name.str().c_str());
-   }
+   // for debugging save a copy of h1
+   if (!cleanHistos) h1->Clone("merge3DLabelAllDiff_h0");
 
    TList *list = new TList;
    list->Add(h2);
@@ -5101,7 +5103,133 @@ bool testMerge3DLabelAllDiff()
 
    h1->Merge(list);
 
+   // labels are ordered differently. Use alphabetic for comparing histograms
+   h1->LabelsOption("a","x");
+   h4->LabelsOption("a","x");
+
    bool ret = equals("MergeLabelAllDiff3D", h1, h4, cmpOptStats, 1E-10);
+   if (cleanHistos) delete h1;
+   if (cleanHistos) delete h2;
+   if (cleanHistos) delete h3;
+   return ret;
+}
+
+bool testMerge3DLabelAllDiffWeight()
+{
+   // Tests the merge method with fully differently labelled 3D weighted
+   // histograms
+   // This tests use first axis numerically and then set labels
+   // and it is different than wiorkflow in previous one
+   // It is the same as in TProfile3D test case, where we do not have support for filling with labels
+
+   // use less bins
+   int nBins = 2;//numberOfBins/2;
+
+   TH3D* h1 = new TH3D("merge3DLabelAllDiff_h1", "h1-Title",
+                                   nBins, minRange, maxRange,
+                                    1, minRange, maxRange,
+                                   1 , minRange, maxRange);
+   TH3D* h2 = new TH3D("merge3DLabelAllDiff_h2", "h2-Title",
+                                   nBins, minRange, maxRange,
+                                    1, minRange, maxRange,
+                                   1 , minRange, maxRange);
+   TH3D* h3 = new TH3D("merge3DLabelAllDiff_h3", "h3-Title",
+                                   nBins, minRange, maxRange,
+                                    1, minRange, maxRange,
+                                   1, minRange, maxRange);
+   TH3D* h4 = new TH3D("merge3DLabelAllDiff_h4", "h4-Title",
+                                   2*nBins, minRange, 2*maxRange-minRange,
+                                    1, minRange, maxRange,
+                                   1 , minRange, maxRange);
+
+
+
+   // the x axis will be full labels while the y axis will be numeric
+   // avoid underflow-overflow in x
+   // should the merge not use labels if underflow-overflows are presents ?
+   // when merging with labels underflow/overflow are ignored and
+   //NB when axis are extended underflow/overflow are set to zero
+
+   // profile3d has not yet filling with labels implemented.
+   // test filling with x but be careful in filling reference histogram h4
+
+   for ( Int_t e = 0; e < nEvents; ++e ) {
+      // avoid underflow/overflows in label axis
+      Double_t x = r.Uniform(minRange, maxRange);
+      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t t = r.Gaus(10+x+y+z, 1);
+      h1->Fill(x, y, z, t);
+      h4->Fill(x, y, z, t);
+   }
+
+   for ( Int_t e = 0; e < nEvents; ++e ) {
+      //TString label = h2->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
+      Double_t x = r.Uniform(minRange, maxRange);
+      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t t = r.Gaus(20+x+y+z, 1);
+      h2->Fill(x, y, z, t);
+      Double_t x4 = x + maxRange - minRange;
+      h4->Fill(x4, y, z, t);
+   }
+
+   for ( Int_t e = 0; e < nEvents; ++e ) {
+      //TString label = h3->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
+      Double_t x = r.Uniform(minRange, maxRange);
+      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t t = r.Gaus(30+y+z, 1);
+      h3->Fill(x, y, z, t);
+      Double_t x4 = x + maxRange - minRange;
+      h4->Fill(x4, y, z, t);
+   }
+
+   // the y axis will have the last bin without a label since it contains nBins+1
+   // need to sert bin labels after filling otherwise Fill will not work correctly
+   // on alphanumeric axis
+   bool orderLabelList = true;
+   for ( Int_t i = 1; i <= nBins; ++ i) {
+      char letter = (char) ((int) 'a' + i - 1);
+      ostringstream name1, name2;
+      name1 << letter << 1;
+      TString ylabel = letter;
+      h1->GetXaxis()->SetBinLabel(i, name1.str().c_str());
+      //h1->GetYaxis()->SetBinLabel(i, ylabel);
+      name2 << letter << 2;
+      h2->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      //h2->GetYaxis()->SetBinLabel(i, ylabel);
+      // use for h3 same label as for h2 to test the merging
+      h3->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      //h3->GetYaxis()->SetBinLabel(i, ylabel);
+
+      std::cout << "setting bin label in h4 " << i+nBins << " : " << name2.str() << std::endl;
+      h4->GetXaxis()->SetBinLabel(i, name1.str().c_str());
+      if (!orderLabelList) h4->GetXaxis()->SetBinLabel(i+nBins, name2.str().c_str());
+      // we set however label in p4 y axis
+      //p4->GetYaxis()->SetBinLabel(i, ylabel);
+   }
+   // fill later for h4 to keep same order in label list
+   if (orderLabelList) {
+      for ( Int_t i = 1; i <= nBins; ++ i) {
+        h4->GetXaxis()->SetBinLabel(i+nBins, h3->GetXaxis()->GetBinLabel(i));
+      }
+   }
+
+   // for debugging save a copy of h1
+   if (!cleanHistos) h1->Clone("merge3DLabelAllDiff_h0");
+
+   TList *list = new TList;
+   list->Add(h2);
+   list->Add(h3);
+
+   h1->Merge(list);
+
+   // need to reset statistics
+   h1->ResetStats();
+   h4->ResetStats();
+
+   bool ret = equals("MergeLabelAllDiff3DWeight", h1, h4, cmpOptStats, 1E-10);
    if (cleanHistos) delete h1;
    if (cleanHistos) delete h2;
    if (cleanHistos) delete h3;
@@ -5183,60 +5311,77 @@ bool testMergeProf2DLabelAllDiff()
 {
    // Tests the merge method with fully differently labelled 2D Profiles
 
+   // use less bins
+   int nBins = numberOfBins/2;
+
    TProfile2D* p1 = new TProfile2D("merge2DLabelAllDiff_p1", "p1-Title",
-                                   numberOfBins, minRange, maxRange,
-                                   numberOfBins + 2, minRange, maxRange);
+                                   nBins, minRange, maxRange,
+                                   nBins + 2, minRange, maxRange);
    TProfile2D* p2 = new TProfile2D("merge2DLabelAllDiff_p2", "p2-Title",
-                                   numberOfBins, minRange, maxRange,
-                                   numberOfBins + 2, minRange, maxRange);
+                                   nBins, minRange, maxRange,
+                                   nBins + 2, minRange, maxRange);
    TProfile2D* p3 = new TProfile2D("merge2DLabelAllDiff_p3", "p3-Title",
-                                   numberOfBins, minRange, maxRange,
-                                   numberOfBins + 2, minRange, maxRange);
+                                   nBins, minRange, maxRange,
+                                   nBins + 2, minRange, maxRange);
    TProfile2D* p4 = new TProfile2D("merge2DLabelAllDiff_p4", "p4-Title",
-                                   numberOfBins, minRange, maxRange,
-                                   numberOfBins + 2, minRange, maxRange);
+                                   2*nBins, minRange, maxRange,
+                                   nBins + 2, minRange, maxRange);
 
-   for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
-      Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      p1->Fill(x, y, z, 1.0);
-      p4->Fill(x, y, z, 1.0);
+
+   // the y axis will have the last bin without a label since it contains nBins+1
+   for ( Int_t i = 1; i <= nBins; ++ i) {
+      char letter = (char) ((int) 'a' + i - 1);
+      ostringstream name1, name2;
+      name1 << letter << 1;
+      TString ylabel = letter;
+      p1->GetXaxis()->SetBinLabel(i, name1.str().c_str());
+      p1->GetYaxis()->SetBinLabel(i, ylabel);
+      name2 << letter << 2;
+      p2->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      p2->GetYaxis()->SetBinLabel(i, ylabel);
+      // use for h3 same label as for h2 to test the merging
+      p3->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      p3->GetYaxis()->SetBinLabel(i, ylabel);
+       // we do not set the bin labels in p4 X. We let p4 getting its labels at fill time
+      // std::cout << "setting bin label in p4" << i+nBins << " : " << name2.str() << std::endl;
+      p4->GetXaxis()->SetBinLabel(i, name1.str().c_str());
+
+      // // we set however label in p4 y axis
+      p4->GetYaxis()->SetBinLabel(i, ylabel);
    }
+   for ( Int_t i = 1; i <= nBins; ++ i) {
+         p4->GetXaxis()->SetBinLabel(i+nBins, p3->GetXaxis()->GetBinLabel(i));
+    }
 
-   for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
-      Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+
+
+   // the x axis will be full labels while the y axis will be numeric
+   // avoid underflow-overflow in x
+   // should the merge not use labels if underflow-overflows are presents ?
+   // when merging with labels underflow/overflow are ignored and
+   //NB when axis are extended underflow/overflow are set to zero
+
+   for ( Int_t e = 0; e < nEvents; ++e ) {
+      //Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      TString label = p1->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
       Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      p2->Fill(x, y, z, 1.0);
-      p4->Fill(x, y, z, 1.0);
+      Double_t z = r.Gaus(10+y, 1);
+      p1->Fill(label, y, z, 1.0);
+      p4->Fill(label, y, z, 1.0);
    }
-
-   for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
-      Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+   for ( Int_t e = 0; e < nEvents; ++e ) {
+      TString label = p2->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
       Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      p3->Fill(x, y, z, 1.0);
-      p4->Fill(x, y, z, 1.0);
+      Double_t z = r.Gaus(20+y, 1);
+      p2->Fill(label, y, z, 1.0);
+      p4->Fill(label, y, z, 1.0);
    }
-
-   // It does not work properly! Look, the bins with the same labels
-   // are different ones and still the tests passes! This is not
-   // consistent with TH1::Merge()
-   for ( Int_t i = 1; i <= numberOfBins; ++ i) {
-      ostringstream name;
-      name << (char) ((int) 'a' + i - 1);
-      p1->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      p1->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      name << 1;
-      p2->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      p2->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      name << 2;
-      p3->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      p3->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      name << 3;
-      p4->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      p4->GetYaxis()->SetBinLabel(i, name.str().c_str());
+   for ( Int_t e = 0; e < nEvents; ++e ) {
+      TString label = p3->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
+      Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t z = r.Gaus(30+y, 1);
+      p3->Fill(label, y, z, 1.0);
+      p4->Fill(label, y, z, 1.0);
    }
 
    TList *list = new TList;
@@ -5245,7 +5390,23 @@ bool testMergeProf2DLabelAllDiff()
 
    p1->Merge(list);
 
+   // need to re-order labels since in p4 labels are in different order
+   p1->LabelsOption("a","x");
+   p4->LabelsOption("a","x");
+
+   // for (int ix = 0; ix <= p1->GetXaxis()->GetNbins()+1; ++ix) {
+   //    for (int iy = 0; iy <= p1->GetYaxis()->GetNbins()+1; ++iy) {
+   //             int i = p1->GetBin(ix,iy);
+   //               std::cout << " bin " << ix << "," << iy << " : " << p1->GetBinSumw2()->fArray[i] << "  "
+   //                      << p4->GetBinSumw2()->fArray[i] << "  " << std::endl;
+   //    }
+   // }
+
    bool ret = equals("MergeLabelAllDiff2DProf", p1, p4, cmpOptStats, 1E-10);
+
+   // std::cout << p1->GetBinSumw2()->fArray[i] << "  "
+   //   << p4->GetBinSumw2()->fArray[i] << "  " << std::endl;
+
    if (cleanHistos) delete p1;
    if (cleanHistos) delete p2;
    if (cleanHistos) delete p3;
@@ -5255,79 +5416,136 @@ bool testMergeProf2DLabelAllDiff()
 bool testMergeProf3DLabelAllDiff()
 {
    // Tests the merge method with fully differently labelled 3D Profiles
+// use less bins
+   int nBins = numberOfBins/2;
+   int nBinsX = nBins;
+   int nBinsY = nBinsX;
+   int nBinsZ = nBinsX;
+
+   bool orderLabelList = true;
 
    TProfile3D* p1 = new TProfile3D("merge3DLabelAllDiff_p1", "p1-Title",
-                                   numberOfBins, minRange, maxRange,
-                                   numberOfBins + 1, minRange, maxRange,
-                                   numberOfBins + 2, minRange, maxRange);
+                                   nBinsX, minRange, maxRange,
+                                   nBinsY, minRange, maxRange,
+                                   nBinsZ, minRange, maxRange);
    TProfile3D* p2 = new TProfile3D("merge3DLabelAllDiff_p2", "p2-Title",
-                                   numberOfBins, minRange, maxRange,
-                                   numberOfBins + 1, minRange, maxRange,
-                                   numberOfBins + 2, minRange, maxRange);
+                                   nBinsX, minRange, maxRange,
+                                   nBinsY, minRange, maxRange,
+                                    nBinsZ, minRange, maxRange);
    TProfile3D* p3 = new TProfile3D("merge3DLabelAllDiff_p3", "p3-Title",
-                                   numberOfBins, minRange, maxRange,
-                                   numberOfBins + 1, minRange, maxRange,
-                                   numberOfBins + 2, minRange, maxRange);
+                                   nBinsX, minRange, maxRange,
+                                   nBinsY, minRange, maxRange,
+                                   nBinsZ, minRange, maxRange);
    TProfile3D* p4 = new TProfile3D("merge3DLabelAllDiff_p4", "p4-Title",
-                                   numberOfBins, minRange, maxRange,
-                                   numberOfBins + 1, minRange, maxRange,
-                                   numberOfBins + 2, minRange, maxRange);
+                                   2*nBinsX, minRange, 2*maxRange-minRange,
+                                    nBinsY, minRange, maxRange,
+                                    nBinsZ, minRange, maxRange);
 
-   for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
-      Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+
+
+   // the x axis will be full labels while the y axis will be numeric
+   // avoid underflow-overflow in x
+   // should the merge not use labels if underflow-overflows are presents ?
+   // when merging with labels underflow/overflow are ignored and
+   //NB when axis are extended underflow/overflow are set to zero
+
+   // profile3d has not yet filling with labels implemented.
+   // test filling with x but be careful in filling reference histogram p4
+
+   int imerge = 3;
+   for ( Int_t e = 0; e < 10*nEvents; ++e ) {
+      Double_t x = r.Uniform(minRange, maxRange);
       Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
       Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t t = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t t = r.Gaus(10+x+y+z, 1);
       p1->Fill(x, y, z, t, 1.0);
       p4->Fill(x, y, z, t, 1.0);
    }
 
-   for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
-      Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+if (imerge > 1) {
+   for ( Int_t e = 0; e < 100*nEvents; ++e ) {
+      //TString label = p2->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
+      Double_t x = r.Uniform(minRange, maxRange);
       Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
       Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t t = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t t = r.Gaus(20+x+y+z, 1);
       p2->Fill(x, y, z, t, 1.0);
-      p4->Fill(x, y, z, t, 1.0);
+      Double_t x4 = x + maxRange - minRange;
+      p4->Fill(x4, y, z, t, 1.0);
    }
+}
 
-   for ( Int_t e = 0; e < nEvents * nEvents; ++e ) {
-      Double_t x = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+if (imerge > 2) {
+   for ( Int_t e = 0; e < 10*nEvents; ++e ) {
+      //TString label = p3->GetXaxis()->GetLabels()->At(r.Integer(nBins))->GetName();
+      Double_t x = r.Uniform(minRange, maxRange);
       Double_t y = r.Uniform(0.9 * minRange, 1.1 * maxRange);
       Double_t z = r.Uniform(0.9 * minRange, 1.1 * maxRange);
-      Double_t t = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t t = r.Gaus(30+y+z, 1);
       p3->Fill(x, y, z, t, 1.0);
-      p4->Fill(x, y, z, t, 1.0);
+      Double_t x4 = x + maxRange - minRange;
+      p4->Fill(x4, y, z, t, 1.0);
+   }
+}
+
+   // the y axis will have the last bin without a label since it contains nBins+1
+   // need to sert bin labels after filling otherwise Fill will not work correctly
+   // on alphanumeric axis
+   for ( Int_t i = 1; i <= nBins; ++ i) {
+      char letter = (char) ((int) 'a' + i - 1);
+      ostringstream name1, name2;
+      name1 << letter << 1;
+      TString ylabel = letter;
+      p1->GetXaxis()->SetBinLabel(i, name1.str().c_str());
+      //p1->GetYaxis()->SetBinLabel(i, ylabel);
+      name2 << letter << 2;
+      p2->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      //p2->GetYaxis()->SetBinLabel(i, ylabel);
+      // use for h3 same label as for h2 to test the merging
+      p3->GetXaxis()->SetBinLabel(i, name2.str().c_str());
+      //p3->GetYaxis()->SetBinLabel(i, ylabel);
+
+      //std::cout << "setting bin label in h4 " << i+nBins << " : " << name2.str() << std::endl;
+      p4->GetXaxis()->SetBinLabel(i, name1.str().c_str());
+      if (!orderLabelList) p4->GetXaxis()->SetBinLabel(i+nBins, name2.str().c_str());
+   }
+   // fill later for h4 to keep same order in label list
+   if (orderLabelList) {
+      for ( Int_t i = 1; i <= nBins; ++ i) {
+        p4->GetXaxis()->SetBinLabel(i+nBins, p3->GetXaxis()->GetBinLabel(i));
+      }
    }
 
-   // It does not work properly! Look, the bins with the same labels
-   // are different ones and still the tests passes! This is not
-   // consistent with TH1::Merge()
-   for ( Int_t i = 1; i <= numberOfBins; ++ i) {
-      ostringstream name;
-      name << (char) ((int) 'a' + i - 1);
-      p1->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      p1->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      p1->GetZaxis()->SetBinLabel(i, name.str().c_str());
-      name << 1;
-      p2->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      p2->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      p2->GetZaxis()->SetBinLabel(i, name.str().c_str());
-      name << 2;
-      p3->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      p3->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      p3->GetZaxis()->SetBinLabel(i, name.str().c_str());
-      name << 3;
-      p4->GetXaxis()->SetBinLabel(i, name.str().c_str());
-      p4->GetYaxis()->SetBinLabel(i, name.str().c_str());
-      p4->GetZaxis()->SetBinLabel(i, name.str().c_str());
-   }
+   // for debugging save a copy of p1
+   //if (!cleanHistos)
+   auto * p0 = (TProfile3D*) p1->Clone("merge3DLabelAllDiff_p0");
+   p1->Reset();
 
    TList *list = new TList;
-   list->Add(p2);
-   list->Add(p3);
-
+   std::cout << p0->fArray[13] << std::endl;
+   list->Add(p0);
    p1->Merge(list);
+   std::cout << p1->fArray[13] << std::endl;
+
+   list->Clear();
+   if (imerge > 1){
+
+   list->Add(p2);
+   p1->Merge(list);
+   std::cout << p1->fArray[17] << std::endl;
+   }
+   else {
+      //p4->LabelsDeflate();
+   }
+   if (imerge > 2) {
+   list->Clear();
+   list->Add(p3);
+   p1->Merge(list);
+   std::cout << p1->fArray[17] << std::endl;
+   }
+
+   p1->ResetStats();
+   p4->ResetStats();
 
    bool ret = equals("MergeLabelAllDiff3DProf", p1, p4, cmpOptStats, 1E-10);
    if (cleanHistos) delete p1;
@@ -6064,12 +6282,15 @@ bool testLabel2DX()
       h1->GetXaxis()->SetBinLabel(i+1, vLabels[i].c_str());
    }
 
+   // remove bins without labels
+
+   h2->LabelsDeflate();
+
    // test ordering label in content descending order
    h2->LabelsOption(">", "x");
    // test ordering label alphabetically
    h2->LabelsOption("a","x");
 
-   h2->LabelsDeflate();
 
    bool status = equals("testLabel2DX", h1, h2, cmpOptStats, 1E-10);
    if (cleanHistos) delete h1;
@@ -6261,7 +6482,7 @@ bool testLabel3DY()
 
 bool testLabel3DZ()
 {
-   // Tests labelling a 1D Histogram, test ordering of labels (TH1::LabelsOption)
+   // Tests labelling a 3D Histogram, test ordering of labels (TH1::LabelsOption)
    // build histogram with extra  labels to test also TH1::LabelsDeflate
 
    TH3D *h1 = new TH3D("lD3_h1", "h1-Title", numberOfBins, minRange, maxRange, numberOfBins, minRange, maxRange,
@@ -6317,6 +6538,239 @@ bool testLabel3DZ()
    h1->SetEntries(nentries);
 
    bool status = equals("testLabel3DZ", h1, h2, cmpOptStats, 1E-13);
+   if (cleanHistos)
+      delete h1;
+   return status;
+}
+
+bool testLabelProf1D()
+{
+   // Tests labelling a 1D Profile, test ordering of labels (TH1::LabelsOption)
+   // build histogram with extra  labels to test also TH1::LabelsDeflate
+
+   // test also case of labels not ordered (bug present in LabelsOptions before Sep2020)
+   bool shuffleLabels = false;
+
+   TProfile *p1 = new TProfile("lD1_p1", "p1-Title", 2 * numberOfBins, minRange, maxRange);
+   int extraBins = 20;
+   TProfile *p2 = new TProfile("lD1_p2", "p2-Title", 2 * numberOfBins + extraBins, minRange,
+                       maxRange + extraBins * p1->GetXaxis()->GetBinWidth(1));
+
+   // set labels
+   Int_t n = p1->GetNbinsX(); // number of labels must be equal to number of bins of refeerence histogram
+   std::vector<std::string> vLabels(n);
+   std::vector<int> bins(n);
+   for (Int_t i = 0; i < n; ++i) {
+      Int_t bin = i + 1;
+      ostringstream label;
+      char letter = (char)((int)'a' + i);
+      label << letter;
+      vLabels[i] = label.str();
+      bins[i] = bin;
+   }
+   // set bin label in random order in bins to test ordering when labels are filled randomly
+   //std::shuffle(bins.begin(), bins.end(), std::default_random_engine{});
+   for (size_t i = 0; i < bins.size(); ++i) {
+      p2->GetXaxis()->SetBinLabel(bins[i], vLabels[i].c_str());
+   }
+   // sort labels in alphabetic order
+   std::sort(vLabels.begin(), vLabels.end());
+
+   for (Int_t e = 0; e < nEvents; ++e) {
+      Double_t value = r.Uniform(minRange, maxRange);
+      Double_t y = r.Gaus(10.+value, 2.);
+      Int_t bin = p1->GetXaxis()->FindBin(value);
+      p1->Fill(p1->GetXaxis()->GetBinCenter(bin), y, 1.0);
+
+
+      p2->Fill(vLabels[bin - 1].c_str(), y, 1.0);
+   }
+
+   // test ordering label in content ascending order
+   p2->LabelsOption("<", "x");
+   // test ordering label alphabetically
+   p1->LabelsOption("<", "x");
+   //p2->LabelsOption("a");
+   p2->LabelsDeflate();
+
+   bool status = equals("testLabelProf1D", p1, p2, cmpOptStats, 1E-13);
+   if (cleanHistos)
+      delete p1;
+   return status;
+}
+
+bool testLabelProf1D_2()
+{
+   // Tests labelling a 1D Profile,  test only ordering of labels with content
+
+   // test case when profile have weights (issue #)
+   bool shuffleLabels = false;
+
+   // add test with weights
+   bool defsumw2 = TProfile::GetDefaultSumw2();
+   if (!defsumw2) TProfile::SetDefaultSumw2(true);
+
+   TProfile *p1 = new TProfile("lD1_p1", "p1-Title", 2 * numberOfBins, minRange, maxRange);
+   int extraBins = 20;
+   TProfile *p2 = new TProfile("lD1_p2", "p2-Title", 2 * numberOfBins + extraBins, minRange,
+                               maxRange + extraBins * p1->GetXaxis()->GetBinWidth(1));
+
+   // set labels
+   Int_t n = p1->GetNbinsX(); // number of labels must be equal to number of bins of refeerence histogram
+   std::vector<std::string> vLabels(n);
+   std::vector<int> bins(n);
+   for (Int_t i = 0; i < n; ++i) {
+      Int_t bin = i + 1;
+      ostringstream label;
+      char letter = (char)((int)'a' + i);
+      label << letter;
+      vLabels[i] = label.str();
+      bins[i] = bin;
+   }
+   // set bin label in random order in bins to test ordering when labels are filled randomly
+   // std::shuffle(bins.begin(), bins.end(), std::default_random_engine{});
+   for (size_t i = 0; i < bins.size(); ++i) {
+      p2->GetXaxis()->SetBinLabel(bins[i], vLabels[i].c_str());
+   }
+   // sort labels in alphabetic order
+   std::sort(vLabels.begin(), vLabels.end());
+
+   for (Int_t e = 0; e < nEvents; ++e) {
+      Double_t value = r.Uniform(minRange, maxRange);
+      Double_t y = r.Gaus(10. + value, 2.);
+      Int_t bin = p1->GetXaxis()->FindBin(value);
+      p1->Fill(p1->GetXaxis()->GetBinCenter(bin), y, 1.0);
+
+      p2->Fill(vLabels[bin - 1].c_str(), y, 1.0);
+   }
+
+   // test ordering label in content ascending order
+   p2->LabelsOption(">", "x");
+   // test ordering label alphabetically
+   p1->LabelsOption(">", "x");
+   // p2->LabelsOption("a");
+   p2->LabelsDeflate();
+
+   bool status = equals("testLabelProf1D", p1, p2, cmpOptStats, 1E-13);
+   if (cleanHistos) delete p1;
+   if (!defsumw2) TProfile::SetDefaultSumw2(false);
+
+   return status;
+}
+
+bool testLabelProf2DX()
+{
+   // Tests labelling a 2D Histogram with labels in the X axis (TH1::LabelsOption)
+   // build histogram with extra  labels to test also TH1::LabelsDeflate
+
+   TProfile2D *h1 = new TProfile2D("lD2_h1", "h1-Title", 2 * numberOfBins, minRange, maxRange, numberOfBins, minRange, maxRange);
+   TProfile2D *h2 = new TProfile2D("lD2_h2", "h2-Title", 2 * numberOfBins , minRange,
+                       maxRange, numberOfBins, minRange, maxRange);
+   // TProfile2D *h2 = new TProfile2D("lD2_h2", "h2-Title", 2 * numberOfBins + 20, minRange,
+   //                                 maxRange + 20 * h1->GetXaxis()->GetBinWidth(1), numberOfBins, minRange, maxRange);
+
+   // set labels
+   std::vector<std::string> vLabels(h1->GetNbinsX());
+   std::vector<int> bins(h1->GetNbinsX());
+   for (Int_t i = 0; i < h1->GetNbinsX(); ++i) {
+      Int_t bin = i + 1;
+      ostringstream label;
+      char letter = (char)((int)'a' + i);
+      label << letter;
+      vLabels[i] = label.str();
+      bins[i] = bin;
+   }
+   // set bin label in random order in bins to test ordering when labels are filled randomly
+   std::shuffle(bins.begin(), bins.end(), std::default_random_engine{});
+   for (size_t i = 0; i < bins.size(); ++i) {
+      h2->GetXaxis()->SetBinLabel(bins[i], vLabels[i].c_str());
+   }
+   // sort labels in alphabetic order
+   std::sort(vLabels.begin(), vLabels.end());
+
+   // fill h1 with numbers and h2 using labels
+   // since labels are ordered alphabetically
+   // for filling bin i-th of h1 same bin i-th will be filled of h2
+   for (Int_t e = 0; e < nEvents * nEvents; ++e) {
+      Double_t xvalue = r.Uniform(minRange, maxRange);
+      Double_t yvalue = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t zvalue = r.Gaus(xvalue + yvalue, 3);
+      Int_t binx = h1->GetXaxis()->FindBin(xvalue);
+      Int_t biny = h1->GetYaxis()->FindBin(yvalue);
+      h1->Fill(h1->GetXaxis()->GetBinCenter(binx), h1->GetYaxis()->GetBinCenter(biny), zvalue, 1.0);
+
+      h2->Fill(vLabels[binx - 1].c_str(), h1->GetYaxis()->GetBinCenter(biny), zvalue, 1.0);
+   }
+   // labels in h1 are set in alphabetic order
+   // by setting labels in h1 we make its axis extendable
+   for (size_t i = 0; i < vLabels.size(); ++i) {
+      h1->GetXaxis()->SetBinLabel(i + 1, vLabels[i].c_str());
+   }
+
+   //h2->LabelsDeflate();
+
+   // test ordering label in content descending order
+   h2->LabelsOption(">", "x");
+   // test ordering label alphabetically
+   h2->LabelsOption("a", "x");
+
+
+   bool status = equals("testLabel2DX", h1, h2, cmpOptStats, 1E-10);
+   if (cleanHistos)
+      delete h1;
+   return status;
+}
+
+bool testLabelProf2DY()
+{
+   // Tests labelling a 2D Histogram and  test ordering of labels in Y axis (TH1::LabelsOption)
+   // build histogram with extra  labels to test also TH1::LabelsDeflate
+
+   TProfile2D *h1 = new TProfile2D("lD2_h1", "h1-Title", numberOfBins, minRange, maxRange, 2 * numberOfBins, minRange, maxRange);
+   // build histo with extra  labels to tets the deflate option
+   TProfile2D *h2 = new TProfile2D("lD2_h2", "h2-Title", numberOfBins, minRange, maxRange, 2 * numberOfBins + 20, minRange,
+                       maxRange + 20 * h1->GetYaxis()->GetBinWidth(1));
+
+   // set labels (size must be equal to reference histogram (h1) nbins)
+   std::vector<std::string> vLabels(h1->GetNbinsY());
+   std::vector<int> bins(h1->GetNbinsY());
+   for (Int_t i = 0; i < h1->GetNbinsY(); ++i) {
+      Int_t bin = i + 1;
+      ostringstream label;
+      char letter = (char)((int)'a' + i);
+      label << letter;
+      vLabels[i] = label.str();
+      bins[i] = bin;
+   }
+   // try  shuffling the labels to test random label order in list
+   std::shuffle(bins.begin(), bins.end(), std::default_random_engine{});
+   for (size_t i = 0; i < bins.size(); ++i) {
+      h2->GetYaxis()->SetBinLabel(bins[i], vLabels[i].c_str());
+   }
+   // sort labels in alphabetic order
+   std::sort(vLabels.begin(), vLabels.end());
+
+   for (Int_t e = 0; e < nEvents; ++e) {
+      Double_t xvalue = r.Uniform(0.9 * minRange, 1.1 * maxRange);
+      Double_t yvalue = r.Uniform(minRange, maxRange);
+      Double_t zvalue = r.Gaus(xvalue + yvalue, 3);
+      Int_t binx = h1->GetXaxis()->FindBin(xvalue);
+      Int_t biny = h1->GetYaxis()->FindBin(yvalue);
+      h1->Fill(h1->GetXaxis()->GetBinCenter(binx), h1->GetYaxis()->GetBinCenter(biny), zvalue, 1.0);
+
+      h2->Fill(h1->GetXaxis()->GetBinCenter(binx), vLabels[biny - 1].c_str(), zvalue, 1.0);
+   }
+
+   h2->LabelsDeflate("Y");
+   // test ordering label in content ascending order
+   h2->LabelsOption("<", "y");
+   // then order labels alphabetically
+   h2->LabelsOption("a", "y");
+
+   // note in this test label axis (y) is not extendable because labels are matching the bins
+   // and we can test also the Mean and RMS
+
+   bool status = equals("testLabelProf2DY", h1, h2, cmpOptStats, 1E-13);
    if (cleanHistos)
       delete h1;
    return status;
@@ -10362,7 +10816,7 @@ int stressHistogram(int testNumber = 0)
       if (cleanHistos) delete htp2;
    }
 
-   // Test 3
+   // Test 5
    // Range Tests
    const unsigned int numberOfRange = 3;
    pointer2Test rangeTestPointer[numberOfRange] = { testTH2toTH1,
@@ -10373,7 +10827,7 @@ int stressHistogram(int testNumber = 0)
                                         "Projection with Range for Histograms and Profiles................",
                                         rangeTestPointer };
 
-  // Test 4
+  // Test 6
    const unsigned int numberOfRebin = 11;
    pointer2Test rebinTestPointer[numberOfRebin] = { testIntegerRebin,       testIntegerRebinProfile,
                                                     testIntegerRebinNoName, testIntegerRebinNoNameProfile,
@@ -10384,7 +10838,7 @@ int stressHistogram(int testNumber = 0)
                                         "Histogram Rebinning..............................................",
                                         rebinTestPointer };
 
-   // Test 5
+   // Test 7
    // Add Tests
    const unsigned int numberOfAdds = 22;
    pointer2Test addTestPointer[numberOfAdds] = { testAdd1,    testAddProfile1,
@@ -10406,7 +10860,7 @@ int stressHistogram(int testNumber = 0)
                                       "Add tests for 1D, 2D and 3D Histograms and Profiles..............",
                                       addTestPointer };
 
-   // Test 6
+   // Test 8
    // Multiply Tests
    const unsigned int numberOfMultiply = 20;
    pointer2Test multiplyTestPointer[numberOfMultiply] = { testMul1,      testMul2,
@@ -10427,7 +10881,7 @@ int stressHistogram(int testNumber = 0)
                                            "Multiply tests for 1D, 2D and 3D Histograms......................",
                                            multiplyTestPointer };
 
-   // Test 7
+   // Test 9
    // Divide Tests
    const unsigned int numberOfDivide = 12;
    pointer2Test divideTestPointer[numberOfDivide] = { testDivide1,     testDivide2,
@@ -10448,7 +10902,7 @@ int stressHistogram(int testNumber = 0)
    // The division methods for the profiles have to be changed to
    // calculate the errors correctly.
 
-   // Test 8
+   // Test 10
    // Copy Tests
    const unsigned int numberOfCopy = 26;
    pointer2Test copyTestPointer[numberOfCopy] = { testAssign1D,             testAssignProfile1D,
@@ -10469,7 +10923,7 @@ int stressHistogram(int testNumber = 0)
                                        "Copy tests for 1D, 2D and 3D Histograms and Profiles.............",
                                        copyTestPointer };
 
-   // Test 9
+   // Test 11
    // WriteRead Tests
    const unsigned int numberOfReadwrite = 10;
    pointer2Test readwriteTestPointer[numberOfReadwrite] = { testWriteRead1D,      testWriteReadProfile1D,
@@ -10482,8 +10936,8 @@ int stressHistogram(int testNumber = 0)
                                             "Read/Write tests for 1D, 2D and 3D Histograms and Profiles.......",
                                             readwriteTestPointer };
 
-   // Test 10
-   // Merge Tests
+   // Test 12
+   // Merge Tests same axis
    std::vector<pointer2Test> mergeSameTestPointer = { testMerge1D,                 testMerge1DMixedWeights,
                                                       testMergeVar1D,
                                                       testMergeProf1D,             testMergeProfVar1D,
@@ -10492,7 +10946,8 @@ int stressHistogram(int testNumber = 0)
                                                       testMergeHn<THnD>,           testMergeHn<THnSparseD>
    };
 
-
+   // Test 13
+   // Merge Tests with labels
    std::vector<pointer2Test> mergeLabelTestPointer = {  testMerge1DLabelSame,        testMergeProf1DLabelSame,
                                                         testMerge2DLabelSame,        testMergeProf2DLabelSame,
                                                         testMerge3DLabelSame,        testMergeProf3DLabelSame,
@@ -10505,15 +10960,20 @@ int stressHistogram(int testNumber = 0)
                                                         testMerge1DLabelAllDiffOld,
                                                         testMerge1DLabelAllDiff,     testMergeProf1DLabelAllDiff,
                                                         testMerge2DLabelAllDiff,     testMergeProf2DLabelAllDiff,
-                                                        testMerge3DLabelAllDiff,     testMergeProf3DLabelAllDiff,
+                                                        testMerge3DLabelAllDiff,     testMerge3DLabelAllDiffWeight,
+                                                        testMergeProf3DLabelAllDiff,
                                                         testMerge1DLabelSameStatsBug
    };
+   // Test 14
+   // Merge Tests with differen axes
    std::vector<pointer2Test> mergeDiffTestPointer = {   testMerge1DDiff,             testMergeProf1DDiff,
                                                         testMerge2DDiff,             testMergeProf2DDiff,
                                                         testMerge3DDiff,             testMergeProf3DDiff,
                                                         testMerge1DDiffEmpty,        testMerge2DDiffEmpty,
                                                         testMerge3DDiffEmpty,        testMergeProf1DDiffEmpty
    };
+   // Test 15
+   // Merge Tests with extendable axes
    std::vector<pointer2Test> mergeExtTestPointer =  {   testMerge1DExtend,           testMerge2DExtendAll,
                                                         testMerge2DExtendX,          testMerge2DExtendY,
                                                         testMerge3DExtendAll,
@@ -10538,7 +10998,7 @@ int stressHistogram(int testNumber = 0)
    struct TTestSuite mergeExtTestSuite = { numberOfMergeExt,
                                         "Merge tests for Histograms and Profiles with extendable axes ....",
                                            mergeExtTestPointer.data() };
-   // Test 11
+   // Test 16
    // Label Tests
    const unsigned int numberOfLabel = 5;
    pointer2Test labelTestPointer[numberOfLabel] = { testLabel1D, testLabel2DX, testLabel2DY, testLabel3DX,
@@ -10548,7 +11008,7 @@ int stressHistogram(int testNumber = 0)
                                         "Label tests for 1D and 2D Histograms ............................",
                                         labelTestPointer };
 
-   // Test 12
+   // Test 17
    // Interpolation Tests
    const unsigned int numberOfInterpolation = 4;
    pointer2Test interpolationTestPointer[numberOfInterpolation] = { testInterpolation1D,
@@ -10560,7 +11020,7 @@ int stressHistogram(int testNumber = 0)
                                                 "Interpolation tests for Histograms...............................",
                                                 interpolationTestPointer };
 
-   // Test 13
+   // Test 18
    // Scale Tests
    const unsigned int numberOfScale = 3;
    pointer2Test scaleTestPointer[numberOfScale] = { testScale1DProf,
@@ -10571,7 +11031,7 @@ int stressHistogram(int testNumber = 0)
                                         "Scale tests for Profiles.........................................",
                                         scaleTestPointer };
 
-   // Test 14
+   // Test 19
    // Integral Tests
    const unsigned int numberOfIntegral = 3;
    pointer2Test integralTestPointer[numberOfIntegral] = { testH1Integral,
@@ -10582,6 +11042,8 @@ int stressHistogram(int testNumber = 0)
                                            "Integral tests for Histograms....................................",
                                            integralTestPointer };
 
+   // Test 20
+   // Histogram buffer Tests
    const unsigned int numberOfBufferTest = 4;
    pointer2Test bufferTestPointer[numberOfBufferTest] = { testH1Buffer,
                                                           testH1BufferWeights,
@@ -10592,17 +11054,20 @@ int stressHistogram(int testNumber = 0)
                                            "Buffer tests for Histograms......................................",
                                            bufferTestPointer };
 
+   // Test 21
+   // Histogram extend axis  Tests
    const unsigned int numberOfExtendTest = 4;
    pointer2Test extendTestPointer[numberOfExtendTest] = { testH1Extend,
                                                           testH2Extend,
                                                           testProfileExtend,
                                                           testProfile2Extend
    };
+
    struct TTestSuite extendTestSuite = { numberOfExtendTest,
                                            "Extend axis tests for Histograms.................................",
                                            extendTestPointer };
 
-   // Test 15
+   // Test 22
    // TH1-THn[Sparse] Conversions Tests
    const unsigned int numberOfConversions = 3;
    pointer2Test conversionsTestPointer[numberOfConversions] = { testConversion1D,
@@ -10613,7 +11078,7 @@ int stressHistogram(int testNumber = 0)
                                               "TH1-THn[Sparse] Conversion tests.................................",
                                               conversionsTestPointer };
 
-   // Test 16
+   // Test 23
    // FillData Tests
    const unsigned int numberOfFillData = 12;
    pointer2Test fillDataTestPointer[numberOfFillData] = { testSparseData1DFull,  testSparseData1DSparse,
@@ -10672,8 +11137,8 @@ int stressHistogram(int testNumber = 0)
    }
    GlobalStatus += status;
 
-   // Test 17
-   // Reference Tests
+   // Test 24
+   // Reference Tests: compare with a reference old file
    const unsigned int numberOfRefRead = 7;
    pointer2Test refReadTestPointer[numberOfRefRead] = { testRefRead1D,  testRefReadProf1D,
                                                         testRefRead2D,  testRefReadProf2D,
@@ -10684,7 +11149,6 @@ int stressHistogram(int testNumber = 0)
                                           "Reference File Read for Histograms and Profiles..................",
                                           refReadTestPointer };
 
-   // test24 - compare with a reference old file
    testCounter++;
    if (runAll || testNumber == testCounter) {
       if (refFileOption == refFileWrite) {
@@ -10699,11 +11163,15 @@ int stressHistogram(int testNumber = 0)
 
       if (refFile != 0) {
          r.SetSeed(8652);
+         // reference file was created with statoverflow = true
+         TH1::StatOverflows(true);
          if (defaultEqualOptions == cmpOptDebug) {
             std::cout << "content of file " << refFile->GetName() << std::endl;
             refFile->ls();
          }
          status = 0;
+         // when running this test order is important for random number. Need to keep same order as
+         // in reference file
          for (unsigned int j = 0; j < refReadTestSuite.nTests; ++j) {
             status += refReadTestSuite.tests[j]();
          }
@@ -11118,8 +11586,15 @@ int compareStatistics( TH1* h1, TH1* h2, bool debug, double ERRORLIMIT)
    std::string option = "WW OF UF";
    const char * opt = option.c_str();
 
+   // for profiles in 2D and 3D avoid problems with bins with zero error
+   TProfile2D::Approximate(true);
+   TProfile3D::Approximate(true);
+
    double chi_12 = h1->Chi2Test(h2, opt);
    double chi_21 = h2->Chi2Test(h1, opt);
+
+   TProfile2D::Approximate(false);
+   TProfile3D::Approximate(false);
 
    differents += (bool) equals(chi_12, 1, ERRORLIMIT);
    differents += (bool) equals(chi_21, 1, ERRORLIMIT);

--- a/test/stressHistogram.cxx
+++ b/test/stressHistogram.cxx
@@ -4127,6 +4127,9 @@ bool testMerge1DLabelDiff()
    h1->Merge(list);
 
    // need to order the histo to compare them
+   h1->LabelsDeflate();
+   h4->LabelsDeflate();
+
    h1->LabelsOption("a");
    h4->LabelsOption("a");
 
@@ -6290,6 +6293,9 @@ bool testLabel1D()
    // test ordering label alphabetically
    h2->LabelsOption("a");
 
+   // reset stats so h2 will have a fake mean,stddev
+   h1->ResetStats();
+   h2->ResetStats();
 
    bool status = equals("testLabel1D", h1, h2, cmpOptStats, 1E-13);
    if (cleanHistos) delete h1;
@@ -6336,11 +6342,6 @@ bool testLabel2DX()
 
       h2->Fill( vLabels[binx-1].c_str(), h1->GetYaxis()->GetBinCenter(biny), 1.0);
    }
-   // labels in h1 are set in alphabetic order
-   // by setting labels in h1 we make its axis extendable
-   for (size_t i = 0; i < vLabels.size(); ++i ) {
-      h1->GetXaxis()->SetBinLabel(i+1, vLabels[i].c_str());
-   }
 
    // remove bins without labels
 
@@ -6351,6 +6352,9 @@ bool testLabel2DX()
    // test ordering label alphabetically
    h2->LabelsOption("a","x");
 
+   // reset stats so h2 will have a fake mean,stddev
+   h1->ResetStats();
+   h2->ResetStats();
 
    bool status = equals("testLabel2DX", h1, h2, cmpOptStats, 1E-10);
    if (cleanHistos) delete h1;
@@ -6394,6 +6398,8 @@ bool testLabel2DY()
       h2->Fill(  h1->GetXaxis()->GetBinCenter(binx), vLabels[biny-1].c_str(), 1.0);
    }
 
+   // axis of h2 is not extended, make it to have 0 statistics
+   h2->GetYaxis()->SetCanExtend(true);
    h2->LabelsDeflate("Y");
    // test ordering label in content ascending order
    h2->LabelsOption("<", "y");
@@ -6402,6 +6408,14 @@ bool testLabel2DY()
 
    // note in this test label axis (y) is not extendable because labels are matching the bins
    // and we can test also the Mean and RMS
+   // reset stats so h2 will have a fake mean,stddev
+
+   // by setting labels in h1 we make its axis extendable and we get zero statistics in Y
+   for (size_t i = 0; i < vLabels.size(); ++i) {
+      h1->GetYaxis()->SetBinLabel(i + 1, vLabels[i].c_str());
+   }
+   h1->ResetStats();
+   h2->ResetStats();
 
    bool status = equals("testLabel2DY", h1, h2, cmpOptStats, 1E-13);
    if (cleanHistos) delete h1;
@@ -6450,6 +6464,8 @@ bool testLabel3DX()
       h2->Fill( vLabels[binx-1].c_str(), yvalue, zvalue, 1.0);
    }
 
+   // axis of h2 is not extended, make it to have 0 statistics
+   h2->GetXaxis()->SetCanExtend(true);
    h2->LabelsDeflate("X");
 
    // test ordering label in content descending order
@@ -6459,10 +6475,12 @@ bool testLabel3DX()
 
    // reset statistics  in ref histogram to have consistent mean and std-dev
    // since h2 has its statistics reset
-   // fix problem of entries
-   Double_t nentries = h1->GetEntries();
+   // and fix problem of entries
+   for (size_t i = 0; i < bins.size(); ++i) {
+      h1->GetXaxis()->SetBinLabel(i+1, vLabels[i].c_str());
+   }
    h1->ResetStats();
-   h1->SetEntries(nentries);
+   h2->ResetStats();
 
    bool status = equals("testLabel3DX", h1, h2, cmpOptStats, 1E-13);
    if (cleanHistos) delete h1;
@@ -6502,8 +6520,10 @@ bool testLabel3DY()
    for (Int_t i = 0; i < h2->GetNbinsX() && i < (Int_t) bins.size(); ++i) {
       h2->GetXaxis()->SetBinLabel(i+1, vLabels[i].c_str());
    }
-   // make axis not extendable otehrwise statistics in X will be set to zero
+   // make axis not extendable otherwise statistics in X will be set to zero
    h2->GetXaxis()->SetCanExtend(kFALSE);
+   // but make y axis extendable
+   h2->GetYaxis()->SetCanExtend(kTRUE);
 
    // fill h1 with numbers and h2 using labels
    // since labels are ordered alphabetically
@@ -6519,20 +6539,22 @@ bool testLabel3DY()
       h2->Fill(vLabels[binx - 1].c_str(), vLabels[biny - 1].c_str(), zvalue, 1.0);
    }
 
-
-
+   h2->LabelsDeflate("Y");
    // test ordering label in content descending order
    h2->LabelsOption("<", "y");
    // test ordering label alphabetically
    h2->LabelsOption("a", "y");
-   h2->LabelsDeflate("Y");
+
 
    // reset statistics  in ref histogram to have consistent mean and std-dev
    // since h2 has its statistics reset
-   // fix problem of entries
-   Double_t nentries = h1->GetEntries();
+   // and fix problem of entries
+   for (size_t i = 0; i < bins.size(); ++i) {
+      h1->GetYaxis()->SetBinLabel(i+1, vLabels[i].c_str());
+   }
+
    h1->ResetStats();
-   h1->SetEntries(nentries);
+   h2->ResetStats();
 
    bool status = equals("testLabel3DY", h1, h2, cmpOptStats, 1E-13);
    if (cleanHistos)
@@ -6583,6 +6605,7 @@ bool testLabel3DZ()
       h2->Fill(xvalue, yvalue, vLabels[binz - 1].c_str(), 1.0);
    }
 
+   h2->GetZaxis()->SetCanExtend(kTRUE);
    h2->LabelsDeflate("Z");
 
    // test ordering label in content descending order
@@ -6592,10 +6615,12 @@ bool testLabel3DZ()
 
    // reset statistics  in ref histogram to have consistent mean and std-dev
    // since h2 has its statistics reset
-   // fix problem of entries
-   Double_t nentries = h1->GetEntries();
+   // and fix problem of entries
+   for (size_t i = 0; i < bins.size(); ++i) {
+      h1->GetZaxis()->SetBinLabel(i+1, vLabels[i].c_str());
+   }
    h1->ResetStats();
-   h1->SetEntries(nentries);
+   h2->ResetStats();
 
    bool status = equals("testLabel3DZ", h1, h2, cmpOptStats, 1E-13);
    if (cleanHistos)
@@ -6646,12 +6671,18 @@ bool testLabelProf1D()
       p2->Fill(vLabels[bin - 1].c_str(), y, 1.0);
    }
 
+   // set also labels in p1
+   for (size_t i = 0; i < bins.size(); ++i) {
+      p1->GetXaxis()->SetBinLabel(i+1, vLabels[i].c_str());
+   }
+
    // test ordering label in content ascending order
-   p2->LabelsOption("<", "x");
-   // test ordering label alphabetically
-   p1->LabelsOption("<", "x");
-   //p2->LabelsOption("a");
    p2->LabelsDeflate();
+   p2->LabelsOption(">", "x");
+   // test ordering label alphabetically
+   p1->LabelsOption(">", "x");
+   //p2->LabelsOption("a");
+
 
    bool status = equals("testLabelProf1D", p1, p2, cmpOptStats, 1E-13);
    if (cleanHistos)
@@ -6704,14 +6735,20 @@ bool testLabelProf1D_2()
       p2->Fill(vLabels[bin - 1].c_str(), y, 1.0);
    }
 
-   // test ordering label in content ascending order
-   p2->LabelsOption(">", "x");
-   // test ordering label alphabetically
-   p1->LabelsOption(">", "x");
-   // p2->LabelsOption("a");
-   p2->LabelsDeflate();
+   // set also labels in p1
+   for (size_t i = 0; i < bins.size(); ++i) {
+      p1->GetXaxis()->SetBinLabel(i + 1, vLabels[i].c_str());
+   }
 
-   bool status = equals("testLabelProf1D", p1, p2, cmpOptStats, 1E-13);
+   p2->LabelsDeflate();
+   // test ordering label in content ascending order
+   p2->LabelsOption("<", "x");
+   // test ordering label alphabetically
+   p1->LabelsOption("<", "x");
+   // p2->LabelsOption("a");
+
+
+   bool status = equals("testLabelProf1D_2", p1, p2, cmpOptStats, 1E-13);
    if (cleanHistos) delete p1;
    if (!defsumw2) TProfile::SetDefaultSumw2(false);
 
@@ -6766,6 +6803,7 @@ bool testLabelProf2DX()
    for (size_t i = 0; i < vLabels.size(); ++i) {
       h1->GetXaxis()->SetBinLabel(i + 1, vLabels[i].c_str());
    }
+   h1->ResetStats();
 
    //h2->LabelsDeflate();
 
@@ -6774,8 +6812,9 @@ bool testLabelProf2DX()
    // test ordering label alphabetically
    h2->LabelsOption("a", "x");
 
+   h2->ResetStats();
 
-   bool status = equals("testLabel2DX", h1, h2, cmpOptStats, 1E-10);
+   bool status = equals("testLabelProf2DX", h1, h2, cmpOptStats, 1E-10);
    if (cleanHistos)
       delete h1;
    return status;
@@ -6783,6 +6822,11 @@ bool testLabelProf2DX()
 
 bool testLabelProf2DY()
 {
+   bool precSumw2 = TProfile2D::GetDefaultSumw2();
+   TProfile2D::SetDefaultSumw2(true);
+   if (defaultEqualOptions == cmpOptDebug)
+      Info("testLabelProf2DY", "Set default sum2 from %d", precSumw2);
+
    // Tests labelling a 2D Histogram and  test ordering of labels in Y axis (TH1::LabelsOption)
    // build histogram with extra  labels to test also TH1::LabelsDeflate
 
@@ -6823,9 +6867,20 @@ bool testLabelProf2DY()
 
    h2->LabelsDeflate("Y");
    // test ordering label in content ascending order
-   h2->LabelsOption("<", "y");
+   //h2->LabelsOption("<", "y");
+
+   h2->Clone("h0");
+
    // then order labels alphabetically
    h2->LabelsOption("a", "y");
+   h2->GetYaxis()->SetCanExtend(true); // y axis was not exteded because had more bins . FOrce it
+   h2->ResetStats();
+
+   // by setting labels in h1 we make its axis extendable
+   for (size_t i = 0; i < vLabels.size(); ++i) {
+      h1->GetYaxis()->SetBinLabel(i + 1, vLabels[i].c_str());
+   }
+   h1->ResetStats();
 
    // note in this test label axis (y) is not extendable because labels are matching the bins
    // and we can test also the Mean and RMS
@@ -6833,6 +6888,7 @@ bool testLabelProf2DY()
    bool status = equals("testLabelProf2DY", h1, h2, cmpOptStats, 1E-13);
    if (cleanHistos)
       delete h1;
+   TProfile2D::SetDefaultSumw2(precSumw2);
    return status;
 }
 
@@ -11082,10 +11138,12 @@ int stressHistogram(int testNumber = 0)
                                            mergeExtTestPointer.data() };
    // Test 16
    // Label Tests
-   const unsigned int numberOfLabel = 5;
-   pointer2Test labelTestPointer[numberOfLabel] = { testLabel1D, testLabel2DX, testLabel2DY, testLabel3DX,
-                                                    testLabelsInflateProf1D
-   };
+   const unsigned int numberOfLabel = 11;
+   pointer2Test labelTestPointer[numberOfLabel] = {testLabel1D,  testLabel2DX, testLabel2DY,
+                                                   testLabel3DX, testLabel3DY, testLabel3DZ,
+                                                   testLabelProf1D, testLabelProf1D_2,
+                                                   testLabelProf2DX, testLabelProf2DY,
+                                                   testLabelsInflateProf1D};
    struct TTestSuite labelTestSuite = { numberOfLabel,
                                         "Label tests for 1D and 2D Histograms ............................",
                                         labelTestPointer };


### PR DESCRIPTION
This PR provides several fixes for histogram and profile having labels. n particular: 
 - fix ROOT-7894 by using now for TProfile::Merge the same logic as TH1::Merge. (impelmentation based on TH1Merger class)
- fix #6403  for TProfile::LabelsOption when there are weights
- fix also another bug for handling of underflow/overflow in TProfile::ExtendAxis 

Add several new tests for these case in stressHistogram 