### PR TITLE
[RF] Fix root-project/root#6408.

### DIFF
--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1838,13 +1838,11 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
       if (file.peek() == '#') {
         if(debug) oocxcoutD(data.get(),DataHandling) << "skipping comment on line " << line << endl;
       } else {
-
         // Read single line
         Bool_t readError = variables.readFromStream(file,kTRUE,verbose) ;
         data->_vars = variables ;
 
-        // Stop at end of file or on read error
-        if(file.eof()) break ;
+        // Stop on read error
         if(!file.good()) {
           oocoutE(data.get(), DataHandling) << "RooDataSet::read(static): read error at line " << line << endl ;
           break;
@@ -1852,10 +1850,16 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
 
         if (readError) {
           outOfRange++ ;
-          continue ;
+        } else {
+          blindCat->setIndex(haveBlindString) ;
+          data->fill(); // store this event
         }
-        blindCat->setIndex(haveBlindString) ;
-        data->fill(); // store this event
+      }
+
+      // Skip all white space (including empty lines).
+      while (isspace(file.peek())) {
+        char dummy;
+        file >> std::noskipws >> dummy >> std::skipws;
       }
     }
 

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -455,7 +455,10 @@ void RooTreeDataStore::createTree(const char* name, const char* title)
 void RooTreeDataStore::loadValues(const TTree *t, const RooFormulaVar* select, const char* /*rangeName*/, Int_t /*nStart*/, Int_t /*nStop*/) 
 {
   // Make our local copy of the tree, so we can safely loop through it.
-  std::unique_ptr<TTree> tClone( static_cast<TTree*>(t->Clone()) );
+  // We need a custom deleter, because if we don't deregister the Tree from the directory
+  // of the original, it tears it down at destruction time!
+  auto deleter = [](TTree* tree){tree->SetDirectory(nullptr); delete tree;};
+  std::unique_ptr<TTree, decltype(deleter)> tClone(static_cast<TTree*>(t->Clone()), deleter);
   tClone->SetDirectory(t->GetDirectory());
 
   // Clone list of variables  

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -15,6 +15,7 @@
 #include <TH1F.h>
 #include <TCut.h>
 #include <TSystem.h>
+#include <ROOT/RMakeUnique.hxx>
 
 #include <TRandom3.h>
 #include <TH1F.h>
@@ -212,4 +213,30 @@ TEST(RooDataSet, ReadCategory) {
   }
 
   gSystem->Unlink(filename);
+}
+
+/// root-project/root#6408: Importing from tree deletes the TFile with the original
+TEST(RooDataSet, CrashAfterImportFromTree) {
+  TTree* tree = new TTree("tree", "tree");
+  double var = 1;
+  tree->Branch("var", &var, "var/D");
+  var = 1;
+  tree->Fill();
+  var = 2;
+  tree->Fill();
+
+  auto roovar = std::make_unique<RooRealVar>("var", "var", 0, 10);
+  auto output_file = std::make_unique<TFile>("test.root", "RECREATE", "output_file");
+
+  ASSERT_TRUE(output_file->IsOpen());
+  auto data_set = std::make_unique<RooDataSet>("data_set", "data_set", tree, RooArgSet(*roovar));
+
+  // Would crash, since the TFile would be deleted by importing:
+  ASSERT_TRUE(output_file->IsOpen());
+
+  EXPECT_EQ(data_set->sumEntries(), 2.);
+  EXPECT_EQ(data_set->numEntries(), 2);
+  EXPECT_EQ(static_cast<RooRealVar*>(data_set->get(0)->find("var"))->getVal(), 1.);
+  EXPECT_EQ(static_cast<RooRealVar*>(data_set->get(1)->find("var"))->getVal(), 2.);
+
 }


### PR DESCRIPTION
Fix root-project/root#6408

Here, RooFit is bitten by a dangerous `FIXME` that wasn't fixed, see this:

https://github.com/root-project/root/blob/ee4e822e3413938b740850db68ab2221fd19744d/tree/tree/src/TBranch.cxx#L477-L499

What happens is that RooFit imports stuff from a Tree. To not disturb that tree, @pcanal suggested to clone it, and loop through it:
```c++
  std::unique_ptr<TTree> tClone(static_cast<TTree*>(t->Clone()));
  tClone->SetDirectory(t->GetDirectory());
```
For reasons I don't remember, I was instructed to set the directory of the clone to the original directory of the tree.

That now leads to a crash, because the cloned Tree closes the input file! I could work around the crash by instead using this:
```c++
  auto deleter = [](TTree* tree){tree->SetDirectory(nullptr); delete tree;};
  std::unique_ptr<TTree, decltype(deleter)> tClone(static_cast<TTree*>(t->Clone()), deleter);
  tClone->SetDirectory(t->GetDirectory());
```

But the `FIXME` might need a fix, though.