### PR TITLE
[DF] Early-quit event loop for RDataSource+Range 

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -708,7 +708,7 @@ public:
       using Range_t = RDFDetail::RRange<Proxied>;
       auto rangePtr = std::make_shared<Range_t>(begin, end, stride, fProxiedPtr);
       fLoopManager->Book(rangePtr.get());
-      RInterface<RDFDetail::RRange<Proxied>> tdf_r(std::move(rangePtr), *fLoopManager, fDefines, fDataSource);
+      RInterface<RDFDetail::RRange<Proxied>, DS_t> tdf_r(std::move(rangePtr), *fLoopManager, fDefines, fDataSource);
       return tdf_r;
    }
 

--- a/tree/dataframe/inc/ROOT/RTrivialDS.hxx
+++ b/tree/dataframe/inc/ROOT/RTrivialDS.hxx
@@ -34,7 +34,7 @@ protected:
 
 public:
    RTrivialDS(ULong64_t size, bool skipEvenEntries = false);
-   // This ctor produces a data-source that returns infinite entries
+   /// This ctor produces a data-source that returns infinite entries
    RTrivialDS();
    ~RTrivialDS();
    const std::vector<std::string> &GetColumnNames() const;

--- a/tree/dataframe/inc/ROOT/RTrivialDS.hxx
+++ b/tree/dataframe/inc/ROOT/RTrivialDS.hxx
@@ -34,6 +34,8 @@ protected:
 
 public:
    RTrivialDS(ULong64_t size, bool skipEvenEntries = false);
+   // This ctor produces a data-source that returns infinite entries
+   RTrivialDS();
    ~RTrivialDS();
    const std::vector<std::string> &GetColumnNames() const;
    bool HasColumn(std::string_view colName) const;
@@ -45,7 +47,10 @@ public:
    std::string GetLabel();
 };
 
+// Make a RDF wrapping a RTrivialDS with the specified amount of entries
 RInterface<RDFDetail::RLoopManager, RTrivialDS> MakeTrivialDataFrame(ULong64_t size, bool skipEvenEntries = false);
+// Make a RDF wrapping a RTrivialDS with infinite entries
+RInterface<RDFDetail::RLoopManager, RTrivialDS> MakeTrivialDataFrame();
 
 } // ns RDF
 

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -385,13 +385,13 @@ void RLoopManager::RunDataSource()
    R__ASSERT(fDataSource != nullptr);
    fDataSource->Initialise();
    auto ranges = fDataSource->GetEntryRanges();
-   while (!ranges.empty()) {
+   while (!ranges.empty() && fNStopsReceived < fNChildren) {
       InitNodeSlots(nullptr, 0u);
       fDataSource->InitSlot(0u, 0ull);
       try {
          for (const auto &range : ranges) {
             auto end = range.second;
-            for (auto entry = range.first; entry < end; ++entry) {
+            for (auto entry = range.first; entry < end && fNStopsReceived < fNChildren; ++entry) {
                if (fDataSource->SetEntry(0u, entry)) {
                   RunAndCheckFilters(0u, entry);
                }

--- a/tree/dataframe/src/RTrivialDS.cxx
+++ b/tree/dataframe/src/RTrivialDS.cxx
@@ -4,6 +4,8 @@
 #include <ROOT/RMakeUnique.hxx>
 #include <TError.h>
 
+#include <limits>
+
 namespace ROOT {
 
 namespace RDF {
@@ -23,6 +25,10 @@ std::vector<void *> RTrivialDS::GetColumnReadersImpl(std::string_view, const std
 }
 
 RTrivialDS::RTrivialDS(ULong64_t size, bool skipEvenEntries) : fSize(size), fSkipEvenEntries(skipEvenEntries)
+{
+}
+
+RTrivialDS::RTrivialDS() : fSize(std::numeric_limits<ULong64_t>::max()), fSkipEvenEntries(false)
 {
 }
 
@@ -47,7 +53,19 @@ std::string RTrivialDS::GetTypeName(std::string_view) const
 
 std::vector<std::pair<ULong64_t, ULong64_t>> RTrivialDS::GetEntryRanges()
 {
-   auto ranges(std::move(fEntryRanges)); // empty fEntryRanges
+   if (fSize == std::numeric_limits<ULong64_t>::max()) {
+      auto currentEntry = *std::max_element(fCounter.begin(), fCounter.end());
+      // infinite source, just make some ranges up
+      std::vector<std::pair<ULong64_t, ULong64_t>> ranges(fNSlots);
+      for (auto &range : ranges) {
+         range = std::make_pair(currentEntry, currentEntry + 10);
+         currentEntry += 10;
+      }
+      return ranges;
+   }
+
+   // empty fEntryRanges so we'll return an empty vector on subsequent calls
+   auto ranges = std::move(fEntryRanges);
    return ranges;
 }
 
@@ -71,6 +89,12 @@ void RTrivialDS::SetNSlots(unsigned int nSlots)
 
 void RTrivialDS::Initialise()
 {
+   if (fSize == std::numeric_limits<ULong64_t>::max()) {
+      // infinite source, nothing to do here
+      return;
+   }
+
+   // initialize fEntryRanges
    const auto chunkSize = fSize / fNSlots;
    auto start = 0UL;
    auto end = 0UL;
@@ -93,6 +117,12 @@ RInterface<RDFDetail::RLoopManager, RTrivialDS> MakeTrivialDataFrame(ULong64_t s
 {
    auto lm = std::make_unique<RDFDetail::RLoopManager>(std::make_unique<RTrivialDS>(size, skipEvenEntries),
                                                        RDFInternal::ColumnNames_t{});
+   return RInterface<RDFDetail::RLoopManager, RTrivialDS>(std::move(lm));
+}
+
+RInterface<RDFDetail::RLoopManager, RTrivialDS> MakeTrivialDataFrame()
+{
+   auto lm = std::make_unique<RDFDetail::RLoopManager>(std::make_unique<RTrivialDS>(), RDFInternal::ColumnNames_t{});
    return RInterface<RDFDetail::RLoopManager, RTrivialDS>(std::move(lm));
 }
 

--- a/tree/dataframe/test/datasource_trivial.cxx
+++ b/tree/dataframe/test/datasource_trivial.cxx
@@ -132,6 +132,15 @@ TEST(RTrivialDS, SkipEntries)
    EXPECT_EQ(*tdfAll.Count(), 20ULL);
 }
 
+// Test for issue #6455, "RDS does not early-quit event loops when all Ranges are exhausted"
+TEST(RTrivialDS, EarlyQuitWithRange)
+{
+   // this is a data-source that returns an infinite amount of entries
+   auto df = ROOT::RDF::MakeTrivialDataFrame();
+   // here we check that the event loop early-quits when the Range is exhausted
+   EXPECT_EQ(df.Range(10).Count().GetValue(), 10);
+}
+
 #ifdef R__B64
 
 TEST(RTrivialDS, FromARDFWithJitting)


### PR DESCRIPTION
RDataSource event loops did not check whether Ranges had been exhausted
and always looped until the end of the dataset in all cases.
Event processing was a no-op after Ranges had been exhausted so results
were correct but runtimes were longer than necessary.

This fixes #6455.