### PR TITLE
[DF] Early-quit event loop for RDataSource+Range (v6.22)

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -386,13 +386,13 @@ void RLoopManager::RunDataSource()
    R__ASSERT(fDataSource != nullptr);
    fDataSource->Initialise();
    auto ranges = fDataSource->GetEntryRanges();
-   while (!ranges.empty()) {
+   while (!ranges.empty() && fNStopsReceived < fNChildren) {
       InitNodeSlots(nullptr, 0u);
       fDataSource->InitSlot(0u, 0ull);
       try {
          for (const auto &range : ranges) {
             auto end = range.second;
-            for (auto entry = range.first; entry < end; ++entry) {
+            for (auto entry = range.first; entry < end && fNStopsReceived < fNChildren; ++entry) {
                if (fDataSource->SetEntry(0u, entry)) {
                   RunAndCheckFilters(0u, entry);
                }


### PR DESCRIPTION
RDataSource event loops did not check whether Ranges had been exhausted
and always looped until the end of the dataset in all cases.
Event processing was a no-op after Ranges had been exhausted so results
were correct but runtimes were longer than necessary.

This fixes #6455.