### PR TITLE
[TMVA] Provide some fixes for  TMVA MulticlassGui

### DIFF
--- a/tmva/tmvagui/src/efficienciesMulticlass.cxx
+++ b/tmva/tmvagui/src/efficienciesMulticlass.cxx
@@ -188,8 +188,11 @@ roccurvelist_t TMVA::getRocCurves(TDirectory *binDir, TString methodPrefix, TStr
             if (hname.Contains(graphNameRef) && hname.BeginsWith(methodPrefix) && !hname.Contains("Train")) {
 
                // Extract classname from plot name
-               UInt_t index = hname.Last('_');
-               TString classname = hname(index + 1, hname.Length() - (index + 1));
+               // classname is string after nameref
+               Int_t index = hname.Index(graphNameRef) + graphNameRef.Length();
+               TString classname = hname(index, hname.Length() - index);
+
+               //std::cout << "Found TGraph " << hname << " with classname " << classname << std::endl;
 
                rocCurves.push_back(std::make_tuple(methodTitle, classname, h));
             }
@@ -423,7 +426,7 @@ Int_t EfficiencyPlotWrapper::addGraph(TGraph *graph)
    }
 
    fCanvas->cd();
-   graph->DrawClone("");
+   graph->Draw("");
    fCanvas->Update();
 
    ++fNumMethods;
@@ -471,11 +474,14 @@ TCanvas *EfficiencyPlotWrapper::newEfficiencyCanvas(TString name, TString title,
    Double_t y1 = 0.0;
    Double_t y2 = 1.0;
 
-   TH2F *frame = new TH2F(Form("%s_%s", title.Data(), "frame"), title, 500, x1, x2, 500, y1, y2);
+   TH1F *frame = new TH1F(Form("%s_%s", title.Data(), "frame"), title, 500, x1, x2);
+   frame->SetMinimum(y1);
+   frame->SetMaximum(y2);
+
    frame->GetXaxis()->SetTitle(xtit);
    frame->GetYaxis()->SetTitle(ytit);
    TMVA::TMVAGlob::SetFrameStyle(frame, 1.0);
-   frame->DrawClone();
+   frame->Draw();
 
    return c;
 }

--- a/tmva/tmvagui/src/mvasMulticlass.cxx
+++ b/tmva/tmvagui/src/mvasMulticlass.cxx
@@ -125,9 +125,11 @@ void TMVA::mvasMulticlass(TString dataset, TString fin , HistType htype , Bool_t
             TString hFrameName(TString::Format("frame_class%d_",icls) + methodTitle);
             TObject *o = gROOT->FindObject(hFrameName);
             if(o) delete o;
-            TH2F* frame = new TH2F( hFrameName, ((TH1*)hists.First())->GetTitle(),
-                                    nb, xmin, xmax, nb, ymin, ymax );
-            frame->GetXaxis()->SetTitle( methodTitle + " response for "+classnames.at(icls));
+            TH1F* frame = new TH1F( hFrameName, ((TH1*)hists.First())->GetTitle(),
+                                    nb, xmin, xmax);
+            frame->SetMinimum(ymin);
+            frame->SetMaximum(ymax);
+            frame->GetXaxis()->SetTitle(methodTitle + " response for " + classnames.at(icls));
             frame->GetYaxis()->SetTitle("(1/N) dN^{ }/^{ }dx");
             TMVAGlob::SetFrameStyle( frame );
 
@@ -207,7 +209,7 @@ void TMVA::mvasMulticlass(TString dataset, TString fin , HistType htype , Bool_t
                }
 
                ymax = histmax*maxMult;
-               frame->GetYaxis()->SetLimits( 0, ymax );
+               frame->SetMaximum( ymax );
 
                // for better visibility, plot thinner lines
                TMVAGlob::SetMultiClassStyle( &othists );


### PR DESCRIPTION
This PR provides two fixes for the plots drawing in the multiclass GUI as reported in 
https://root-forum.cern.ch/t/some-bugs-in-tmva-multiclassgui/41114

- fix clicking of plots by using a TH1 for the frame instead of a TH2
- fix the display of ROC curve 1vs all and 1 vs 1 . The bug was due to  a wrong parsing of t he classname
