### PR TITLE
[TMVA] Fix using GUI functions TMVA::mva and TMVA::mvaeffs running in batch

### DIFF
--- a/tmva/tmva/inc/TMVA/Config.h
+++ b/tmva/tmva/inc/TMVA/Config.h
@@ -111,7 +111,9 @@ namespace TMVA {
          Int_t   fMaxNumOfAllowedVariablesForScatterPlots;
          Int_t   fNbinsMVAoutput;
          Int_t   fNbinsXOfROCCurve;
-         Bool_t  fUsePaperStyle;
+         Bool_t  fUsePaperStyle;   // set to get eps output
+         enum { kPNG = 0, kGIF = 1, kPDF = 2, kEPS = 3 };
+         Int_t fPlotFormat; // (0: png , 1: gif, 2: pdf, 3: eps)
 
       } fVariablePlotting; // Customisable plotting properties
 

--- a/tmva/tmva/src/Config.cxx
+++ b/tmva/tmva/src/Config.cxx
@@ -70,6 +70,7 @@ TMVA::Config::Config() :
    fVariablePlotting.fNbinsMVAoutput   = 40;
    fVariablePlotting.fNbinsXOfROCCurve = 100;
    fVariablePlotting.fUsePaperStyle = 0;
+   fVariablePlotting.fPlotFormat = VariablePlotting::kPNG;  // format for plotting (use when fUsePaperStyle ==0)
 
    // IO names
    fIONames.fWeightFileDirPrefix = "";

--- a/tmva/tmvagui/inc/TMVA/mvaeffs.h
+++ b/tmva/tmvagui/inc/TMVA/mvaeffs.h
@@ -16,7 +16,7 @@
 namespace TMVA{
 
    void mvaeffs(TString dataset, TString fin = "TMVA.root",
-                Float_t nSingal = 1000, Float_t nBackground = 1000,
+                Float_t nSignal = 1000, Float_t nBackground = 1000,
                 Bool_t useTMVAStyle = kTRUE, TString formula="S/sqrt(S+B)" );
 
    // this macro plots the signal and background efficiencies

--- a/tmva/tmvagui/inc/TMVA/mvaeffs.h
+++ b/tmva/tmvagui/inc/TMVA/mvaeffs.h
@@ -15,7 +15,8 @@
 
 namespace TMVA{
 
-   void mvaeffs(TString dataset, TString fin = "TMVA.root", 
+   void mvaeffs(TString dataset, TString fin = "TMVA.root",
+                Float_t nSingal = 1000, Float_t nBackground = 1000,
                 Bool_t useTMVAStyle = kTRUE, TString formula="S/sqrt(S+B)" );
 
    // this macro plots the signal and background efficiencies
@@ -54,7 +55,7 @@ namespace TMVA{
       TH1*     sigE;
       TH1*     bgdE;
       TH1*     purS;
-      TH1*     sSig;    
+      TH1*     sSig;
       TH1*     effpurS;
       TCanvas* canvas;
       TLatex*  line1;
@@ -63,25 +64,25 @@ namespace TMVA{
       Double_t maxSignificance;
       Double_t maxSignificanceErr;
 
-      void SetResultHists(); 
+      void SetResultHists();
 
       ClassDef(MethodInfo,0);
    };
 
-   class StatDialogMVAEffs {  
+   class StatDialogMVAEffs {
 
       RQ_OBJECT("StatDialogMVAEffs")
-      
+
          public:
 
       StatDialogMVAEffs(TString ds,const TGWindow* p, Float_t ns, Float_t nb);
       virtual ~StatDialogMVAEffs();
-   
+
       void SetFormula(const TString& f) { fFormula = f; }
       TString GetFormula();
       TString GetFormulaString() { return fFormula; }
       TString GetLatexFormula();
-   
+
       void ReadHistograms(TFile* file);
       void UpdateSignificanceHists();
       void DrawHistograms();
@@ -92,7 +93,7 @@ namespace TMVA{
 
       TGMainFrame *fMain;
       Float_t fNSignal;
-      Float_t fNBackground;  
+      Float_t fNBackground;
       TString fFormula;
       TString dataset;
       TList * fInfoList;

--- a/tmva/tmvagui/src/mvaeffs.cxx
+++ b/tmva/tmvagui/src/mvaeffs.cxx
@@ -147,6 +147,8 @@ TMVA::StatDialogMVAEffs::~StatDialogMVAEffs()
       fInfoList=0;
    }
 
+   // in case of batch mode fMain is a nullptr
+   if (fMain) {
 
    fSigInput->Disconnect();
    fBkgInput->Disconnect();
@@ -156,6 +158,7 @@ TMVA::StatDialogMVAEffs::~StatDialogMVAEffs()
    fMain->CloseWindow();
    fMain->Cleanup();
    fMain = 0;
+   }
 }
 
 TMVA::StatDialogMVAEffs::StatDialogMVAEffs(TString ds,const TGWindow* p, Float_t ns, Float_t nb) :
@@ -171,52 +174,55 @@ TMVA::StatDialogMVAEffs::StatDialogMVAEffs(TString ds,const TGWindow* p, Float_t
    fCloseButton(0),
    maxLenTitle(0)
 {
-   UInt_t totalWidth  = 500;
-   UInt_t totalHeight = 300;
+   // only in interactive mode
+   if (!gROOT->IsBatch()) {
+      UInt_t totalWidth = 500;
+      UInt_t totalHeight = 300;
 
-   // main frame
-   fMain = new TGMainFrame(p, totalWidth, totalHeight, kMainFrame | kVerticalFrame);
+      // main frame
+      fMain = new TGMainFrame(p, totalWidth, totalHeight, kMainFrame | kVerticalFrame);
 
-   TGLabel *sigLab = new TGLabel(fMain,"Signal events");
-   fMain->AddFrame(sigLab, new TGLayoutHints(kLHintsLeft | kLHintsTop,5,5,5,5));
+      TGLabel *sigLab = new TGLabel(fMain, "Signal events");
+      fMain->AddFrame(sigLab, new TGLayoutHints(kLHintsLeft | kLHintsTop, 5, 5, 5, 5));
 
-   fSigInput = new TGNumberEntry(fMain, (Double_t) fNSignal,5,-1,(TGNumberFormat::EStyle) 5);
-   fSigInput->SetLimits(TGNumberFormat::kNELLimitMin,0,1);
-   fMain->AddFrame(fSigInput, new TGLayoutHints(kLHintsLeft | kLHintsTop,5,5,5,5));
-   fSigInput->Resize(100,24);
+      fSigInput = new TGNumberEntry(fMain, (Double_t)fNSignal, 5, -1, (TGNumberFormat::EStyle)5);
+      fSigInput->SetLimits(TGNumberFormat::kNELLimitMin, 0, 1);
+      fMain->AddFrame(fSigInput, new TGLayoutHints(kLHintsLeft | kLHintsTop, 5, 5, 5, 5));
+      fSigInput->Resize(100, 24);
 
-   TGLabel *bkgLab = new TGLabel(fMain, "Background events");
-   fMain->AddFrame(bkgLab, new TGLayoutHints(kLHintsLeft | kLHintsTop,5,5,5,5));
+      TGLabel *bkgLab = new TGLabel(fMain, "Background events");
+      fMain->AddFrame(bkgLab, new TGLayoutHints(kLHintsLeft | kLHintsTop, 5, 5, 5, 5));
 
-   fBkgInput = new TGNumberEntry(fMain, (Double_t) fNBackground,5,-1,(TGNumberFormat::EStyle) 5);
-   fBkgInput->SetLimits(TGNumberFormat::kNELLimitMin,0,1);
-   fMain->AddFrame(fBkgInput, new TGLayoutHints(kLHintsLeft | kLHintsTop,5,5,5,5));
-   fBkgInput->Resize(100,24);
+      fBkgInput = new TGNumberEntry(fMain, (Double_t)fNBackground, 5, -1, (TGNumberFormat::EStyle)5);
+      fBkgInput->SetLimits(TGNumberFormat::kNELLimitMin, 0, 1);
+      fMain->AddFrame(fBkgInput, new TGLayoutHints(kLHintsLeft | kLHintsTop, 5, 5, 5, 5));
+      fBkgInput->Resize(100, 24);
 
-   fButtons = new TGHorizontalFrame(fMain, totalWidth,30);
+      fButtons = new TGHorizontalFrame(fMain, totalWidth, 30);
 
-   fCloseButton = new TGTextButton(fButtons,"&Close");
-   fButtons->AddFrame(fCloseButton, new TGLayoutHints(kLHintsLeft | kLHintsTop));
+      fCloseButton = new TGTextButton(fButtons, "&Close");
+      fButtons->AddFrame(fCloseButton, new TGLayoutHints(kLHintsLeft | kLHintsTop));
 
-   fDrawButton = new TGTextButton(fButtons,"&Draw");
-   fButtons->AddFrame(fDrawButton, new TGLayoutHints(kLHintsRight | kLHintsTop,15));
+      fDrawButton = new TGTextButton(fButtons, "&Draw");
+      fButtons->AddFrame(fDrawButton, new TGLayoutHints(kLHintsRight | kLHintsTop, 15));
 
-   fMain->AddFrame(fButtons,new TGLayoutHints(kLHintsLeft | kLHintsBottom,5,5,5,5));
+      fMain->AddFrame(fButtons, new TGLayoutHints(kLHintsLeft | kLHintsBottom, 5, 5, 5, 5));
 
-   fMain->SetWindowName("Significance");
-   fMain->SetWMPosition(0,0);
-   fMain->MapSubwindows();
-   fMain->Resize(fMain->GetDefaultSize());
-   fMain->MapWindow();
+      fMain->SetWindowName("Significance");
+      fMain->SetWMPosition(0, 0);
+      fMain->MapSubwindows();
+      fMain->Resize(fMain->GetDefaultSize());
+      fMain->MapWindow();
 
-   fSigInput->Connect("ValueSet(Long_t)","TMVA::StatDialogMVAEffs",this, "SetNSignal()");
-   fBkgInput->Connect("ValueSet(Long_t)","TMVA::StatDialogMVAEffs",this, "SetNBackground()");
+      fSigInput->Connect("ValueSet(Long_t)", "TMVA::StatDialogMVAEffs", this, "SetNSignal()");
+      fBkgInput->Connect("ValueSet(Long_t)", "TMVA::StatDialogMVAEffs", this, "SetNBackground()");
 
-//   fDrawButton->Connect("Clicked()","TGNumberEntry",fSigInput, "ValueSet(Long_t)");
-//   fDrawButton->Connect("Clicked()","TGNumberEntry",fBkgInput, "ValueSet(Long_t)");
-   fDrawButton->Connect("Clicked()", "TMVA::StatDialogMVAEffs", this, "Redraw()");
+      //   fDrawButton->Connect("Clicked()","TGNumberEntry",fSigInput, "ValueSet(Long_t)");
+      //   fDrawButton->Connect("Clicked()","TGNumberEntry",fBkgInput, "ValueSet(Long_t)");
+      fDrawButton->Connect("Clicked()", "TMVA::StatDialogMVAEffs", this, "Redraw()");
 
-   fCloseButton->Connect("Clicked()", "TMVA::StatDialogMVAEffs", this, "Close()");
+      fCloseButton->Connect("Clicked()", "TMVA::StatDialogMVAEffs", this, "Close()");
+   }
 }
 
 void TMVA::StatDialogMVAEffs::UpdateCanvases()
@@ -520,20 +526,22 @@ void TMVA::StatDialogMVAEffs::PrintResults( const MethodInfo* info )
    }
 }
 
-void TMVA::mvaeffs(TString dataset, TString fin ,
-                   Bool_t useTMVAStyle, TString formula )
+void TMVA::mvaeffs(TString dataset, TString fin, Float_t nsignal, Float_t nbackground, Bool_t useTMVAStyle,
+                   TString formula)
 {
    TMVAGlob::Initialize( useTMVAStyle );
 
-   TGClient * graphicsClient = TGClient::Instance();
-   if (graphicsClient == nullptr) {
-      // When including mvaeffs in a stand-alone macro, the graphics subsystem
-      // is not initialised and `TGClient::Instance` is a nullptr.
-      graphicsClient = new TGClient();
+   TGClient *graphicsClient = TGClient::Instance();
+   if (!gROOT->IsBatch()) {
+      if (graphicsClient == nullptr) {
+         // When including mvaeffs in a stand-alone macro, the graphics subsystem
+         // is not initialised and `TGClient::Instance` is a nullptr.
+         graphicsClient = new TGClient();
+      }
    }
 
    StatDialogMVAEffs* gGui = new StatDialogMVAEffs(dataset,
-      graphicsClient->GetRoot(), 1000, 1000);
+      (graphicsClient) ? graphicsClient->GetRoot() : nullptr, nsignal, nbackground);
 
 
    TFile* file = TMVAGlob::OpenFile( fin );
@@ -541,5 +549,5 @@ void TMVA::mvaeffs(TString dataset, TString fin ,
    gGui->SetFormula(formula);
    gGui->UpdateSignificanceHists();
    gGui->DrawHistograms();
-   gGui->RaiseDialog();
+   if (!gROOT->IsBatch()) gGui->RaiseDialog();
 }

--- a/tmva/tmvagui/src/mvaeffs.cxx
+++ b/tmva/tmvagui/src/mvaeffs.cxx
@@ -16,6 +16,8 @@
 #include "TMVA/mvaeffs.h"
 #include "TMVA/tmvaglob.h"
 #include "TROOT.h"
+#include "TError.h"
+#include "TApplication.h"
 
 #include <iomanip>
 #include <iostream>
@@ -175,7 +177,7 @@ TMVA::StatDialogMVAEffs::StatDialogMVAEffs(TString ds,const TGWindow* p, Float_t
    maxLenTitle(0)
 {
    // only in interactive mode
-   if (!gROOT->IsBatch()) {
+   if (p != nullptr) {
       UInt_t totalWidth = 500;
       UInt_t totalHeight = 300;
 
@@ -532,11 +534,14 @@ void TMVA::mvaeffs(TString dataset, TString fin, Float_t nsignal, Float_t nbackg
    TMVAGlob::Initialize( useTMVAStyle );
 
    TGClient *graphicsClient = TGClient::Instance();
-   if (!gROOT->IsBatch()) {
-      if (graphicsClient == nullptr) {
-         // When including mvaeffs in a stand-alone macro, the graphics subsystem
-         // is not initialised and `TGClient::Instance` is a nullptr.
-         graphicsClient = new TGClient();
+   if (graphicsClient == nullptr && !gROOT->IsBatch()) {
+      if (gApplication == nullptr)
+         // When using mvaeffs in a stand-alone macro, and batch mode is not set
+         Info("mvaeffs","GUI is not initialized, because TApplication is not started. Running as in batch mode");
+      else {
+         // gTAPPlication has started but `TGClient::Instance` is a nullptr. Should not happen
+         Error("mvaeffs", "TApplication is present but TGCLient instance is a nullptr");
+         return;
       }
    }
 

--- a/tmva/tmvagui/src/tmvaglob.cxx
+++ b/tmva/tmvagui/src/tmvaglob.cxx
@@ -5,7 +5,7 @@ using std::cout;
 using std::endl;
 
 // set the style
-void TMVA::TMVAGlob::SetSignalAndBackgroundStyle( TH1* sig, TH1* bkg, TH1* all ) 
+void TMVA::TMVAGlob::SetSignalAndBackgroundStyle( TH1* sig, TH1* bkg, TH1* all )
 {
    //signal
    // const Int_t FillColor__S = 38 + 150; // change of Color Scheme in ROOT-5.16.
@@ -28,7 +28,7 @@ void TMVA::TMVAGlob::SetSignalAndBackgroundStyle( TH1* sig, TH1* bkg, TH1* all )
       sig->SetFillStyle( FillStyle__S );
       sig->SetFillColor( FillColor__S );
    }
- 
+
    if (bkg != NULL) {
       bkg->SetLineColor( LineColor__B );
       bkg->SetLineWidth( LineWidth__B );
@@ -44,7 +44,7 @@ void TMVA::TMVAGlob::SetSignalAndBackgroundStyle( TH1* sig, TH1* bkg, TH1* all )
    }
 }
 
-void TMVA::TMVAGlob::SetMultiClassStyle( TObjArray* hists ) 
+void TMVA::TMVAGlob::SetMultiClassStyle( TObjArray* hists )
 {
    //signal
    // const Int_t FillColor__S = 38 + 150; // change of Color Scheme in ROOT-5.16.
@@ -94,19 +94,19 @@ void TMVA::TMVAGlob::SetFrameStyle( TH1* frame, Float_t scale )
 }
 
 void TMVA::TMVAGlob::SetTMVAStyle() {
-      
+
    TStyle *TMVAStyle = gROOT->GetStyle("TMVA");
    if(TMVAStyle!=0) {
       gROOT->SetStyle("TMVA");
       return;
    }
-         
+
    TMVAStyle = new TStyle(*gROOT->GetStyle("Plain")); // our style is based on Plain
    TMVAStyle->SetName("TMVA");
    TMVAStyle->SetTitle("TMVA style based on \"Plain\" with modifications defined in tmvaglob.C");
    gROOT->GetListOfStyles()->Add(TMVAStyle);
    gROOT->SetStyle("TMVA");
-         
+
    TMVAStyle->SetLineStyleString( 5, "[52 12]" );
    TMVAStyle->SetLineStyleString( 6, "[22 12]" );
    TMVAStyle->SetLineStyleString( 7, "[22 10 7 10]" );
@@ -219,31 +219,38 @@ void TMVA::TMVAGlob::imgconv( TCanvas* c, const TString & fname )
       // create directory if not existing
       TString f = fname;
       TString dir = f.Remove( f.Last( '/' ), f.Length() - f.Last( '/' ) );
-      gSystem->mkdir( dir );
+      // directory does not exists , try to make it
+      if (gSystem->AccessPathName(dir)) {
+         if (gSystem->mkdir(dir, kTRUE) != 0) {
+            Error("imgconv","Error creating plot directory: %s",dir.Data());
+         }
+      }
 
       TString pngName = fname + ".png";
       TString gifName = fname + ".gif";
       TString epsName = fname + ".eps";
+      TString pdfName = fname + ".pdf";
       c->cd();
 
       // create eps (other option: c->Print( epsName ))
       if (gConfig().fVariablePlotting.fUsePaperStyle) {
          c->Print(epsName);
-      } 
+      }
       else {
-         cout << "--- --------------------------------------------------------------------" << endl;
-         cout << "--- If you want to save the image as eps, gif or png, please comment out " << endl;
-         cout << "--- the corresponding lines (line no. 239-241) in tmvaglob.C" << endl;
-         cout << "--- --------------------------------------------------------------------" << endl;
-         c->Print(epsName);
-         c->Print(pngName);
-         // c->Print(gifName);
+         if (gConfig().fVariablePlotting.fPlotFormat == Config::VariablePlotting::kGIF)
+            c->Print(gifName);
+         else if (gConfig().fVariablePlotting.fPlotFormat == Config::VariablePlotting::kPDF)
+            c->Print(pdfName);
+         else if (gConfig().fVariablePlotting.fPlotFormat == Config::VariablePlotting::kEPS)
+            c->Print(epsName);
+         else
+            c->Print(pngName);
       }
    }
 }
 
-TImage * TMVA::TMVAGlob::findImage(const char * imageName) 
-{ 
+TImage * TMVA::TMVAGlob::findImage(const char * imageName)
+{
    // looks for the image in tutorialpath
    //TString tutorialPath = "$ROOTSYS/tutorials/tmva"; // look for the image in here
    TString tutorialPath = getenv ("ROOTSYS");
@@ -251,7 +258,7 @@ TImage * TMVA::TMVAGlob::findImage(const char * imageName)
    TImage *img(0);
    TString fullName = Form("%s/%s", tutorialPath.Data(), imageName);
    Bool_t fileFound = ! gSystem->AccessPathName(fullName);
-   
+
    if(fileFound) {
       img = TImage::Open(fullName);
    } else {
@@ -268,7 +275,7 @@ void TMVA::TMVAGlob::plot_logo( Float_t v_scale, Float_t skew )
       cout << "+++ Could not open image tmva_logo.gif" << endl;
       return;
    }
-      
+
    img->SetConstRatio(kFALSE);
    UInt_t h_ = img->GetHeight();
    UInt_t w_ = img->GetWidth();
@@ -280,8 +287,8 @@ void TMVA::TMVAGlob::plot_logo( Float_t v_scale, Float_t skew )
 
    Float_t d = 0.055;
    // absolute coordinates
-   Float_t x1R = 1 - gStyle->GetPadRightMargin(); 
-   Float_t y1B = 1 - gStyle->GetPadTopMargin()+.01; // we like the logo to sit a bit above the histo 
+   Float_t x1R = 1 - gStyle->GetPadRightMargin();
+   Float_t y1B = 1 - gStyle->GetPadTopMargin()+.01; // we like the logo to sit a bit above the histo
 
    Float_t x1L = x1R - d*r/skew;
    Float_t y1T = y1B + d*v_scale*skew;
@@ -303,9 +310,9 @@ void TMVA::TMVAGlob::plot_logo( Float_t v_scale, Float_t skew )
 
    p1->cd();
    img->Draw();
-} 
+}
 
-void TMVA::TMVAGlob::NormalizeHist( TH1* h ) 
+void TMVA::TMVAGlob::NormalizeHist( TH1* h )
 {
    if (h==0) return;
    if (h->GetSumw2N() == 0) h->Sumw2();
@@ -314,11 +321,11 @@ void TMVA::TMVAGlob::NormalizeHist( TH1* h )
       h->Scale( 1.0/h->GetSumOfWeights()/dx );
    }
 }
-void TMVA::TMVAGlob::NormalizeHists( TH1* sig, TH1* bkg ) 
+void TMVA::TMVAGlob::NormalizeHists( TH1* sig, TH1* bkg )
 {
    if (sig->GetSumw2N() == 0) sig->Sumw2();
    if (bkg && bkg->GetSumw2N() == 0) bkg->Sumw2();
-      
+
    if(sig->GetSumOfWeights()!=0) {
       Float_t dx = (sig->GetXaxis()->GetXmax() - sig->GetXaxis()->GetXmin())/sig->GetNbinsX();
       sig->Scale( 1.0/sig->GetSumOfWeights()/dx );
@@ -402,9 +409,9 @@ Int_t TMVA::TMVAGlob::GetNumberOfTargets( TDirectory *dir )
    TIter next(dir->GetListOfKeys());
    TKey* key    = 0;
    Int_t noTrgts = 0;
-      
+
    while ((key = (TKey*)next())) {
-      if (key->GetCycle() != 1) continue;        
+      if (key->GetCycle() != 1) continue;
       if (TString(key->GetName()).Contains("__Regression_target")) noTrgts++;
    }
    return noTrgts;
@@ -415,14 +422,14 @@ Int_t TMVA::TMVAGlob::GetNumberOfInputVariables( TDirectory *dir )
    TIter next(dir->GetListOfKeys());
    TKey* key    = 0;
    Int_t noVars = 0;
-         
+
    while ((key = (TKey*)next())) {
       if (key->GetCycle() != 1) continue;
-         
+
       // count number of variables (signal is sufficient), exclude target(s)
       if (TString(key->GetName()).Contains("__Signal") || (TString(key->GetName()).Contains("__Regression") && !(TString(key->GetName()).Contains("__Regression_target")))) noVars++;
    }
-      
+
    return noVars;
 }
 
@@ -431,7 +438,7 @@ std::vector<TString> TMVA::TMVAGlob::GetInputVariableNames(TDirectory *dir)
    TIter next(dir->GetListOfKeys());
    TKey* key = 0;
    std::vector<TString> names;
-      
+
    while ((key = (TKey*)next())) {
       if (key->GetCycle() != 1) continue;
       TClass *cl = gROOT->GetClass(key->GetClassName());
@@ -458,15 +465,15 @@ Int_t TMVA::TMVAGlob::GetNumberOfInputVariablesMultiClass( TDirectory *dir ){
    std::vector<TString> names(GetInputVariableNames(dir));
    return names.end() - names.begin();
 }
-   
+
 std::vector<TString> TMVA::TMVAGlob::GetClassNames(TDirectory *dir )
-{      
-      
+{
+
    TIter next(dir->GetListOfKeys());
    TKey* key = 0;
    //set<std::string> varnames;
    std::vector<TString> names;
-      
+
    while ((key = (TKey*)next())) {
       if (key->GetCycle() != 1) continue;
       TClass *cl = gROOT->GetClass(key->GetClassName());
@@ -521,7 +528,7 @@ TKey* TMVA::TMVAGlob::FindMethod( TString name, TDirectory *dir )
       mkey = (TKey*)mnext();
       if (mkey==0) {
          loop = kFALSE;
-      } 
+      }
       else {
          TString clname = mkey->GetClassName();
          TClass *cl = gROOT->GetClass(clname);
@@ -549,7 +556,7 @@ Bool_t TMVA::TMVAGlob::ExistMethodName( TString name, TDirectory *dir )
       mkey = (TKey*)mnext();
       if (mkey==0) {
          loop = kFALSE;
-      } 
+      }
       else {
          TString clname  = mkey->GetClassName();
          TString keyname = mkey->GetName();
@@ -569,7 +576,7 @@ Bool_t TMVA::TMVAGlob::ExistMethodName( TString name, TDirectory *dir )
                TClass *cl_ = gROOT->GetClass(clname_);
                if (cl_->InheritsFrom("TDirectory")) {
                   TString mname = mkey_->GetName(); // method name
-                  if (mname==name) { // target found!                  
+                  if (mname==name) { // target found!
                      return kTRUE;
                   }
                }
@@ -610,19 +617,19 @@ UInt_t TMVA::TMVAGlob::GetListOfJobs( TFile* file, TList& jobdirs)
    // get a list of all jobs in all method directories
    // based on ideas by Peter and Joerg found in macro deviations.C
    TIter next(file->GetListOfKeys());
-   TKey *key(0);   
+   TKey *key(0);
    while ((key = (TKey*)next())) {
-         
+
       if (TString(key->GetName()).BeginsWith("Method_")) {
          if (gROOT->GetClass(key->GetClassName())->InheritsFrom("TDirectory")) {
 
             TDirectory* mDir = (TDirectory*)key->ReadObj();
-               
+
             TIter keyIt(mDir->GetListOfKeys());
             TKey *jobkey;
             while ((jobkey = (TKey*)keyIt())) {
                if (!gROOT->GetClass(jobkey->GetClassName())->InheritsFrom("TDirectory")) continue;
-                  
+
                TDirectory *jobDir = (TDirectory *)jobkey->ReadObj();
                cout << "jobdir name  " << jobDir->GetName() << endl;
                jobdirs.Add(jobDir);
@@ -728,4 +735,3 @@ TDirectory *TMVA::TMVAGlob::GetCorrelationPlotsDir( TMVAGlob::TypeOfPlot type, T
    }
    return corrdir;
 }
-


### PR DESCRIPTION
This fixes #6479 when running ROOT in batch (with root -b), but still
a problem is present when running ROOT in a standalone application (see #6483).

- improve TMVA::mva fixing a problem in storing output plots.
   - Create the full path to the directory `dataset/plot`
   - Add option via TMVA::Config::VariablePlotting::fPlotFormat
 to specify plot output format

- in TMVA::mvaeffs do not create a GUI dialog to set number of signal and background events for efficiency plots when running in batch mode
- add option to pass events number in TMVA::mvaeffs function call

The last commit provide the fix for ROOT-9483 (https://sft.its.cern.ch/jira/browse/ROOT-9483)