### PR TITLE
Outline the  RObjectDrawable class dtor in the cxx file

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
@@ -45,6 +45,8 @@ protected:
 public:
    RObjectDrawable() : RDrawable("tobject") {}
 
+   virtual ~RObjectDrawable();
+
    RObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : RDrawable("tobject"), fObj(obj), fOpts(opt) {}
 
 };

--- a/graf2d/gpadv7/src/RObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/RObjectDrawable.cxx
@@ -21,6 +21,8 @@
 
 using namespace ROOT::Experimental;
 
+RObjectDrawable::~RObjectDrawable() {}
+
 std::unique_ptr<RDisplayItem> RObjectDrawable::Display(const RDisplayContext &ctxt)
 {
    if (GetVersion() > ctxt.GetLastVersion())


### PR DESCRIPTION
It should fix broken cxxmodules combination: While building module 'ROOTGpadv7' imported from graf2d/primitivesv7/inc/ROOT/RBox.hxx:12:
In file included from <module-includes>:1:
In file included from include/ROOT/RCanvas.hxx:12:
In file included from include/ROOT/RPadBase.hxx:12:
include/ROOT/RDrawable.hxx:61:39: note: in instantiation of function template specialization 'std::__shared_ptr<TObject, __gnu_cxx::_S_atomic>::reset<TObject>' requested here