### PR TITLE
[xmlparser] print line where error is observed (ROOT-8142)

### DIFF
--- a/io/xmlparser/src/TSAXParser.cxx
+++ b/io/xmlparser/src/TSAXParser.cxx
@@ -171,7 +171,10 @@ void TSAXParser::OnWarning(const char *text)
 
 Int_t TSAXParser::OnError(const char *text)
 {
-   Emit("OnError(const char *)", text);
+   TString errmsg;
+   errmsg.Form("Source line: %d  %s", fContext->input->line, text);
+
+   Emit("OnError(const char *)", errmsg.Data());
    return -3;
 }
 
@@ -181,7 +184,10 @@ Int_t TSAXParser::OnError(const char *text)
 
 Int_t TSAXParser::OnFatalError(const char *text)
 {
-   Emit("OnFatalError(const char *)", text);
+   TString errmsg;
+   errmsg.Form("Source line: %d  %s", fContext->input->line, text);
+
+   Emit("OnFatalError(const char *)", errmsg.Data());
    return -4;
 }
 


### PR DESCRIPTION
Provides exact line number in the file
Default xmlparser output is misleading -  it just reports line number 0.