### PR TITLE
[PyROOT][DF] Improve RDataFrame.AsNumpy performance

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rdataframe.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rdataframe.py
@@ -76,7 +76,7 @@ def RDataFrameAsNumpy(df, columns=None, exclude=None):
     for column in columns:
         cpp_reference = result_ptrs[column].GetValue()
         if hasattr(cpp_reference, "__array_interface__"):
-            tmp = numpy.array(cpp_reference) # This adopts the memory of the C++ object.
+            tmp = numpy.asarray(cpp_reference) # This adopts the memory of the C++ object.
             py_arrays[column] = ndarray(tmp, result_ptrs[column])
         else:
             tmp = numpy.empty(len(cpp_reference), dtype=numpy.object)

--- a/bindings/pyroot/pythonizations/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_asnumpy.py
@@ -286,6 +286,28 @@ class RDataFrameAsNumpy(unittest.TestCase):
             arr2 = pickle.load(f)
         self.assertTrue(all(arr == arr2))
 
+    def test_memory_adoption_fundamental_types(self):
+        """
+        Testing the adoption of the memory from the C++ side for fundamental types
+        """
+        df = ROOT.ROOT.RDataFrame(1).Define("x", "1.0")
+        npy = df.AsNumpy(["x"])
+        pyarr = npy["x"]
+        cpparr = pyarr.result_ptr.GetValue()
+        pyarr[0] = 42
+        self.assertTrue(cpparr[0] == pyarr[0])
+
+    def test_memory_adoption_complex_types(self):
+        """
+        Testing the adoption of the memory from the C++ side for complex types
+        """
+        df = ROOT.ROOT.RDataFrame(1).Define("x", "std::vector<float>({1, 2, 3})")
+        npy = df.AsNumpy(["x"])
+        pyarr = npy["x"]
+        cpparr = pyarr.result_ptr.GetValue()
+        pyarr[0][0] = 42
+        self.assertTrue(cpparr[0][0] == pyarr[0][0])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/pyroot/pythonizations/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_asnumpy.py
@@ -280,8 +280,10 @@ class RDataFrameAsNumpy(unittest.TestCase):
         npy = df.AsNumpy(["x"])
         arr = npy["x"]
 
-        pickle.dump(arr, open("rdataframe_asnumpy.pickle", "wb"))
-        arr2 = pickle.load(open("rdataframe_asnumpy.pickle", "rb"))
+        with open("rdataframe_asnumpy.pickle", "wb") as f:
+            pickle.dump(arr, f)
+        with open("rdataframe_asnumpy.pickle", "rb") as f:
+            arr2 = pickle.load(f)
         self.assertTrue(all(arr == arr2))
 
 


### PR DESCRIPTION
* Fixes a warning in newer python version (first commit)
* Adds a test that we actually adopt memory from C++ objects and fixes the broken adoption from `numpy.array`

We should merge first the respective benchmarks in rootbench. The PR is ongoing here: https://github.com/root-project/rootbench/pull/195