### PR TITLE
[cmake] Fix builds of clad with external LLVM

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LLVM_TOOL_LLVM_AR_BUILD OFF CACHE BOOL "")
 set(CLANG_TOOL_CLANG_OFFLOAD_BUNDLER_BUILD OFF CACHE BOOL "")
 set(LLVM_FORCE_USE_OLD_TOOLCHAIN ON CACHE BOOL "")
 
+# will be set again in case NOT builtin_llvm
 set(LLVM_DIR "${CMAKE_BINARY_DIR}/interpreter/llvm/src")
 if (clad)
   set(CLING_BUILD_PLUGINS ON)
@@ -405,6 +406,8 @@ Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
   set( CLANG_BUILT_STANDALONE 1 )
   set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")
 
+  # must be set before add_subdirectory(cling): it can change the value of LLVM_BINARY_DIR
+  set(LLVM_DIR "${LLVM_BINARY_DIR}")
   if (builtin_clang)
     # For builtin LLVM this is set in interpreter/llvm/src/CMakeLists.txt
     set(Clang_DIR ${LLVM_BINARY_DIR}/tools/clang/)

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -405,15 +405,15 @@ Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
   set( CLANG_BUILT_STANDALONE 1 )
   set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")
 
+  if (builtin_clang)
+    # For builtin LLVM this is set in interpreter/llvm/src/CMakeLists.txt
+    set(Clang_DIR ${LLVM_BINARY_DIR}/tools/clang/)
+    add_subdirectory(llvm/src/tools/clang EXCLUDE_FROM_ALL)
+  else()
+    set(Clang_DIR ${LLVM_BINARY_DIR}/lib/cmake/clang/)
+    add_subdirectory(cling)
+  endif()
 
-if (builtin_clang)
-  # For builtin LLVM this is set in interpreter/llvm/src/CMakeLists.txt
-  set(Clang_DIR ${LLVM_BINARY_DIR}/tools/clang/)
-  add_subdirectory(llvm/src/tools/clang EXCLUDE_FROM_ALL)
-else()
-  set(Clang_DIR ${LLVM_BINARY_DIR}/lib/cmake/clang/)
-  add_subdirectory(cling)
-endif()
 endif(builtin_llvm)
 
 #---Export the include directories------------------------------------------------------------------


### PR DESCRIPTION
LLVM_DIR cannot be "${CMAKE_BINARY_DIR}/interpreter/llvm/src" in case
of external LLVM, set it to ${LLVM_BINARY_DIR} instead.

This is a fairly urgent fix: our nightly conda builds are broken because of this issue.