### PR TITLE
[RF] Fix std::regex failures on Mac10.15.

### DIFF
--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -204,7 +204,8 @@ std::string RooFormula::processFormula(std::string formula) const {
     const auto& var = _origList[i];
     std::string regex = "\\b";
     regex += var.GetName();
-    regex += "\\b(?!\\[)"; //Negative lookahead. If the variable is called `x`, this might otherwise replace `x[0]`.
+    regex = std::regex_replace(regex, std::regex("([\\[\\]])"), "\\$1"); // The name might contain [ or ].
+    regex += "\\b(?!\\[)"; // Veto '[' as next character. If the variable is called `x`, this might otherwise replace `x[0]`.
     std::regex findParameterRegex(regex);
 
     std::stringstream replacement;


### PR DESCRIPTION
Due to a change on Mac, [ and ] in the names of RooFit objects had to be
replaced by \\[ and \\] to be used in regexes.

This will fix the failures in the nightlies that suddenly popped up.