### PR TITLE
Fix division by zero

### DIFF
--- a/graf2d/graf/src/TArrow.cxx
+++ b/graf2d/graf/src/TArrow.cxx
@@ -173,13 +173,6 @@ void TArrow::Paint(Option_t *option)
 void TArrow::PaintArrow(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
                         Float_t arrowsize, Option_t *option)
 {
-
-   // Option and attributes
-   TString opt = option;
-   opt.ToLower();
-   TAttLine::Modify();
-   TAttFill::Modify();
-
    // Compute the gPad coordinates in TRUE normalized space (NDC)
    Int_t iw = gPad->GetWw();
    Int_t ih = gPad->GetWh();
@@ -189,6 +182,15 @@ void TArrow::PaintArrow(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
    Int_t iy1 = (Int_t)(ih*y1p);
    Int_t ix2 = (Int_t)(iw*x2p);
    Int_t iy2 = (Int_t)(ih*y2p);
+   if (ix1==ix2||iy1==iy2) return; 
+   
+   // Option and attributes
+   TString opt = option;
+   opt.ToLower();
+   TAttLine::Modify();
+   TAttFill::Modify();
+
+
    Double_t wndc  = TMath::Min(1.,(Double_t)iw/(Double_t)ih);
    Double_t hndc  = TMath::Min(1.,(Double_t)ih/(Double_t)iw);
    Double_t rh    = hndc/(Double_t)ih;


### PR DESCRIPTION
Prevent division over zero for floats and integers  in TArrow.

Tag @couet 

Please note that only one line was added.


Code to reproduce on Linux

```
#include <TCanvas.h>
#include <TArrow.h>
#include <iostream>
#include <fenv.h>


int main(int argc, char **argv) {
    feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
    TCanvas* C= new TCanvas("canvas","canvas",20,200);
    const int N=20;
    C->cd();
    C->Divide(N,1);
    C->cd(1);
    TArrow* a = new TArrow();
    a->PaintArrow(10, 10, 5, 5, 0.01);
    delete a;
    delete C;
    return 0;
}




````


