### PR TITLE
[PyROOT] Sanitize input arguments to AsNumpy

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rdataframe.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rdataframe.py
@@ -49,6 +49,12 @@ def RDataFrameAsNumpy(df, columns=None, exclude=None):
     Returns:
         dict: Dict with column names as keys and 1D numpy arrays with content as values
     """
+    # Sanitize input arguments
+    if isinstance(columns, str):
+        raise TypeError("The columns argument requires a list of strings")
+    if isinstance(exclude, str):
+        raise TypeError("The exclude argument requires a list of strings")
+
     # Import numpy and numpy.array derived class lazily
     try:
         import numpy


### PR DESCRIPTION
AsNumpy('foo') would iterate over the characters of 'foo'. Notify the
user that we expects AsNumpy(['foo']) in the case a plain string is
passed.