### PR TITLE
[TTree] Avoid deletion of TFile on the stack

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -2789,7 +2789,7 @@ TFile* TTree::ChangeFile(TFile* file)
       if (newfile) newfile->Append(obj);
       file->Remove(obj);
    }
-   file->Delete();
+   file->TObject::Delete();
    file = 0;
    delete[] fname;
    fname = 0;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -2789,7 +2789,7 @@ TFile* TTree::ChangeFile(TFile* file)
       if (newfile) newfile->Append(obj);
       file->Remove(obj);
    }
-   delete file;
+   file->Delete();
    file = 0;
    delete[] fname;
    fname = 0;


### PR DESCRIPTION
TObject::Delete checks the IsOnHeap() bit, while `delete obj` does not.

This fixes #6527 , at least for the provided reproducer.