### PR TITLE
[Core] Revive TSeq tests

### DIFF
--- a/core/cont/test/CMakeLists.txt
+++ b/core/cont/test/CMakeLists.txt
@@ -7,3 +7,4 @@
 ROOT_ADD_UNITTEST_DIR(Core)
 
 ROOT_ADD_GTEST(testTypedIteration testTypedIteration.cxx LIBRARIES Core)
+ROOT_ADD_GTEST(TSeqTests TSeqTests.cxx LIBRARIES Core)


### PR DESCRIPTION
I guess these tests were not enabled by mistake?