### PR TITLE
[RF] Improve interface of RooArgSet/RooArgList

### DIFF
--- a/roofit/roofit/src/RooMathCoreReg.cxx
+++ b/roofit/roofit/src/RooMathCoreReg.cxx
@@ -24,7 +24,11 @@
 #include "Math/SpecFuncMathCore.h"
 #include "Math/DistFuncMathCore.h"
 
-static RooMathCoreReg dummy ;
+namespace {
+
+RooMathCoreReg dummy ;
+
+}
 
 RooMathCoreReg::RooMathCoreReg()
 {

--- a/roofit/roofit/src/RooTMathReg.cxx
+++ b/roofit/roofit/src/RooTMathReg.cxx
@@ -23,7 +23,11 @@
 #include "RooCFunction4Binding.h"
 #include "TMath.h"
 
-static RooTMathReg dummy ;
+namespace {
+
+RooTMathReg dummy ;
+
+}
 
 RooTMathReg::RooTMathReg()
 {

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -16,6 +16,7 @@
 #ifndef ROO_ABS_COLLECTION
 #define ROO_ABS_COLLECTION
 
+#include "TObject.h"
 #include "TString.h"
 #include "RooAbsArg.h"
 #include "RooPrintable.h"

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -41,6 +41,21 @@ public:
     (void)dummy;
   };
 
+  /// Construct from iterators.
+  /// \tparam Iterator_t An iterator pointing to RooFit objects or references thereof.
+  /// \param beginIt Iterator to first element to add.
+  /// \param end Iterator to end of range to be added.
+  /// \param name Optional name of the collection.
+  template<typename Iterator_t,
+      typename value_type = typename std::iterator_traits<Iterator_t>::value_type,
+      typename = std::enable_if<std::is_convertible<const value_type*, const RooAbsArg*>::value> >
+  RooArgList(Iterator_t beginIt, Iterator_t endIt, const char* name="") :
+  RooArgList(name) {
+    for (auto it = beginIt; it != endIt; ++it) {
+      add(*it);
+    }
+  }
+
   virtual ~RooArgList();
   // Create a copy of an existing list. New variables cannot be added
   // to a copied list. The variables in the copied list are independent

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -26,39 +26,20 @@ public:
   RooArgList(const RooArgSet& set) ;
   explicit RooArgList(const TCollection& tcoll, const char* name="") ;
   explicit RooArgList(const char *name);
-  RooArgList(const RooAbsArg& var1, 
-	     const char *name="");
-  RooArgList(const RooAbsArg& var1, const RooAbsArg& var2, 
-	     const char *name="");
-  RooArgList(const RooAbsArg& var1, const RooAbsArg& var2,
-	     const RooAbsArg& var3, 
-	     const char *name="");
-  RooArgList(const RooAbsArg& var1, const RooAbsArg& var2,
-	     const RooAbsArg& var3, const RooAbsArg& var4, 
-	     const char *name="");
-  RooArgList(const RooAbsArg& var1, const RooAbsArg& var2,
-	     const RooAbsArg& var3, const RooAbsArg& var4, 
-	     const RooAbsArg& var5, 
-	     const char *name="");
-  RooArgList(const RooAbsArg& var1, const RooAbsArg& var2,
-	     const RooAbsArg& var3, const RooAbsArg& var4, 
-	     const RooAbsArg& var5, const RooAbsArg& var6, 
-	     const char *name="");
-  RooArgList(const RooAbsArg& var1, const RooAbsArg& var2,
-	     const RooAbsArg& var3, const RooAbsArg& var4, 
-	     const RooAbsArg& var5, const RooAbsArg& var6, 
-	     const RooAbsArg& var7, 
-	     const char *name="");
-  RooArgList(const RooAbsArg& var1, const RooAbsArg& var2,
-	     const RooAbsArg& var3, const RooAbsArg& var4, 
-	     const RooAbsArg& var5, const RooAbsArg& var6, 
-	     const RooAbsArg& var7, const RooAbsArg& var8, 
-	     const char *name="");
-  RooArgList(const RooAbsArg& var1, const RooAbsArg& var2,
-	     const RooAbsArg& var3, const RooAbsArg& var4, 
-	     const RooAbsArg& var5, const RooAbsArg& var6, 
-	     const RooAbsArg& var7, const RooAbsArg& var8, 
-	     const RooAbsArg& var9, const char *name="");
+  /// Construct a (non-owning) RooArgList from one or more
+  /// RooFit objects.
+  /// \param arg A RooFit object to be put in the set.
+  /// \param varsOrName Arbitrary number of
+  ///   - RooFit objects deriving from RooAbsArg.
+  ///   - A c-string to name the set.
+  template<typename... Arg_t>
+  RooArgList(const RooAbsArg& arg, const Arg_t&... argsOrName)
+  /*NB: Making this a delegating constructor led to linker errors with MSVC*/ {
+    processArg(arg);
+    // Expand parameter pack in C++ 11 way:
+    int dummy[] = { 0, (processArg(argsOrName), 0) ... };
+    (void)dummy;
+  };
 
   virtual ~RooArgList();
   // Create a copy of an existing list. New variables cannot be added
@@ -85,7 +66,9 @@ public:
 
   RooAbsArg& operator[](Int_t idx) const ; 
 
-protected:
+private:
+  void processArg(const RooAbsArg& arg) { add(arg); }
+  void processArg(const char* name) { _name = name; }
 
   ClassDef(RooArgList,1) // Ordered list of RooAbsArg objects
 };

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -78,19 +78,19 @@ public:
   explicit RooArgSet(const TCollection& tcoll, const char* name="") ;
   explicit RooArgSet(const char *name);
 
-  ~RooArgSet();
-  TObject* clone(const char* newname) const { return new RooArgSet(*this,newname); }
-  TObject* create(const char* newname) const { return new RooArgSet(newname); }
+  ~RooArgSet() override;
+  TObject* clone(const char* newname) const override { return new RooArgSet(*this,newname); }
+  TObject* create(const char* newname) const override { return new RooArgSet(newname); }
   RooArgSet& operator=(const RooArgSet& other) { RooAbsCollection::operator=(other) ; return *this ;}
 
   using RooAbsCollection::add;
-  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE);
+  Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) override;
 
   using RooAbsCollection::addOwned;
-  virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE);
+  Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE) override;
 
   using RooAbsCollection::addClone;
-  virtual RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE);
+  RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) override;
 
   using RooAbsCollection::operator[];
   RooAbsArg& operator[](const char* name) const;
@@ -148,7 +148,7 @@ private:
   static MemPool* memPool();
 #endif
   
-  ClassDef(RooArgSet,1) // Set of RooAbsArg objects
+  ClassDefOverride(RooArgSet,1) // Set of RooAbsArg objects
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -94,7 +94,8 @@ public:
   RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) override;
 
   using RooAbsCollection::operator[];
-  RooAbsArg& operator[](const char* name) const;
+  RooAbsArg& operator[](const TString& str) const;
+
 
   /// Shortcut for readFromStream(std::istream&, Bool_t, const char*, const char*, Bool_t), setting
   /// `flagReadAtt` and `section` to 0.

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -53,6 +53,21 @@ public:
     (void)dummy;
   };
 
+  /// Construct from iterators.
+  /// \tparam Iterator_t An iterator pointing to RooFit objects or references thereof.
+  /// \param beginIt Iterator to first element to add.
+  /// \param end Iterator to end of range to be added.
+  /// \param name Optional name of the collection.
+  template<typename Iterator_t,
+      typename value_type = typename std::iterator_traits<Iterator_t>::value_type,
+      typename = std::enable_if<std::is_convertible<const value_type*, const RooAbsArg*>::value> >
+  RooArgSet(Iterator_t beginIt, Iterator_t endIt, const char* name="") :
+  RooArgSet(name) {
+    for (auto it = beginIt; it != endIt; ++it) {
+      add(*it);
+    }
+  }
+
   RooArgSet(const RooArgSet& other, const char *name="");
 
   RooArgSet(const RooArgSet& set1, const RooArgSet& set2,

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -83,22 +83,14 @@ public:
   TObject* create(const char* newname) const { return new RooArgSet(newname); }
   RooArgSet& operator=(const RooArgSet& other) { RooAbsCollection::operator=(other) ; return *this ;}
 
-  virtual Bool_t add(const RooAbsCollection& col, Bool_t silent=kFALSE) {
-    // Add all elements in list to collection
-    return RooAbsCollection::add(col, silent);
-  }
-  virtual Bool_t addOwned(const RooAbsCollection& col, Bool_t silent=kFALSE) {
-    // Add all elements in list as owned components to collection
-    return RooAbsCollection::addOwned(col, silent);
-  }
-  virtual void addClone(const RooAbsCollection& col, Bool_t silent=kFALSE) {
-    // Add owned clone of all elements of list to collection
-    RooAbsCollection::addClone(col, silent);
-  }
+  using RooAbsCollection::add;
+  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE);
 
-  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) ;
+  using RooAbsCollection::addOwned;
   virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE);
-  virtual RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) ;
+
+  using RooAbsCollection::addClone;
+  virtual RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE);
 
   using RooAbsCollection::operator[];
   RooAbsArg& operator[](const char* name) const;

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -36,53 +36,36 @@ public:
  
   // Constructors, assignment etc.
   RooArgSet();
+
+  /// Construct a (non-owning) RooArgSet from one or more
+  /// RooFit objects. The set will not own its contents.
+  /// \tparam Ts Parameter pack of objects that derive from RooAbsArg or RooFit collections; or a name.
+  /// \param arg A RooFit object.
+  /// \param moreArgsOrName Arbitrary number of
+  /// - Further RooFit objects that derive from RooAbsArg
+  /// - RooFit collections of such objects
+  /// - A name for the set. Given multiple names, the last-given name prevails.
+  template<typename... Ts>
+  RooArgSet(const RooAbsArg& arg, const Ts&... moreArgsOrName) {
+    add(arg);
+    // Expand parameter pack in C++ 11 way:
+    int dummy[] = { 0, (processArg(moreArgsOrName), 0) ... };
+    (void)dummy;
+  };
+
+  RooArgSet(const RooArgSet& other, const char *name="");
+
+  RooArgSet(const RooArgSet& set1, const RooArgSet& set2,
+            const char *name="");
+
   RooArgSet(const RooArgList& list) ;
-  RooArgSet(const RooArgList& list, const RooAbsArg* var1) ;
+  RooArgSet(const RooAbsCollection& collection, const RooAbsArg* var1);
   explicit RooArgSet(const TCollection& tcoll, const char* name="") ;
   explicit RooArgSet(const char *name);
-  RooArgSet(const RooArgSet& set1, const RooArgSet& set2,
-	    const char *name="");
-  RooArgSet(const RooAbsArg& var1, 
-	    const char *name="");
-  RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2, 
-	    const char *name="");
-  RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2,
-	    const RooAbsArg& var3, 
-	    const char *name="");
-  RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2,
-	    const RooAbsArg& var3, const RooAbsArg& var4, 
-	    const char *name="");
-  RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2,
-	    const RooAbsArg& var3, const RooAbsArg& var4, 
-	    const RooAbsArg& var5, 
-	    const char *name="");
-  RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2,
-	    const RooAbsArg& var3, const RooAbsArg& var4, 
-	    const RooAbsArg& var5, const RooAbsArg& var6, 
-	    const char *name="");
-  RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2,
-            const RooAbsArg& var3, const RooAbsArg& var4, 
-	    const RooAbsArg& var5, const RooAbsArg& var6, 
-	    const RooAbsArg& var7, 
-	    const char *name="");
-  RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2,
-            const RooAbsArg& var3, const RooAbsArg& var4, 
-	    const RooAbsArg& var5, const RooAbsArg& var6, 
-	    const RooAbsArg& var7, const RooAbsArg& var8, 
-	    const char *name="");
-  RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2,
-            const RooAbsArg& var3, const RooAbsArg& var4, 
-	    const RooAbsArg& var5, const RooAbsArg& var6, 
-	    const RooAbsArg& var7, const RooAbsArg& var8, 
-	    const RooAbsArg& var9, const char *name="");
 
-  virtual ~RooArgSet();
-  // Create a copy of an existing list. New variables cannot be added
-  // to a copied list. The variables in the copied list are independent
-  // of the original variables.
-  RooArgSet(const RooArgSet& other, const char *name="");
-  virtual TObject* clone(const char* newname) const { return new RooArgSet(*this,newname); }
-  virtual TObject* create(const char* newname) const { return new RooArgSet(newname); }
+  ~RooArgSet();
+  TObject* clone(const char* newname) const { return new RooArgSet(*this,newname); }
+  TObject* create(const char* newname) const { return new RooArgSet(newname); }
   RooArgSet& operator=(const RooArgSet& other) { RooAbsCollection::operator=(other) ; return *this ;}
 
   virtual Bool_t add(const RooAbsCollection& col, Bool_t silent=kFALSE) {
@@ -141,8 +124,13 @@ public:
   }
 
 protected:
-
   Bool_t checkForDup(const RooAbsArg& arg, Bool_t silent) const ;
+
+private:
+  void processArg(const RooAbsArg& var) { add(var); }
+  void processArg(const RooArgSet& set) { add(set); if (_name.Length() == 0) _name = set.GetName(); }
+  void processArg(const RooArgList& list);
+  void processArg(const char* name) { _name = name; }
 
 #ifdef USEMEMPOOLFORARGSET
 private:

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -17,6 +17,7 @@
 #define ROO_ARG_SET
 
 #include "RooAbsCollection.h"
+#include "RooAbsArg.h"
 
 class RooArgList ;
 

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -342,10 +342,10 @@ RooCmdArg MultiArg(const RooCmdArg& arg1, const RooCmdArg& arg2,
  
 RooConstVar& RooConst(Double_t val) ; 
 
+// End group CmdArgs:
 /**
  * @}
  */
-
 }
 
 namespace RooFitShortHand {

--- a/roofit/roofitcore/inc/RooListProxy.h
+++ b/roofit/roofitcore/inc/RooListProxy.h
@@ -34,14 +34,15 @@ public:
   virtual const char* name() const { return GetName() ; }
 
   // List content management (modified for server hooks)
-  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) ;
-  virtual Bool_t add(const RooAbsCollection& list, Bool_t silent=kFALSE) { return RooAbsCollection::add(list,silent) ; }
+  using RooAbsCollection::add;
+  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE);
   virtual Bool_t add(const RooAbsArg& var, Bool_t valueServer, Bool_t shapeServer, Bool_t silent) ;
-  virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE);
-  virtual Bool_t addOwned(const RooAbsCollection& list, Bool_t silent=kFALSE) { return RooAbsCollection::addOwned(list,silent) ; }
   virtual Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) ;
   virtual Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;
   virtual void removeAll() ;
+
+  using RooAbsCollection::addOwned;
+  virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE);
 
   RooListProxy& operator=(const RooArgList& other) ;
 

--- a/roofit/roofitcore/inc/RooListProxy.h
+++ b/roofit/roofitcore/inc/RooListProxy.h
@@ -31,22 +31,22 @@ public:
   RooListProxy(const char* name, RooAbsArg* owner, const RooListProxy& other) ;
   virtual ~RooListProxy() ;
 
-  virtual const char* name() const { return GetName() ; }
+  virtual const char* name() const override { return GetName() ; }
 
   // List content management (modified for server hooks)
   using RooAbsCollection::add;
-  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE);
+  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) override;
   virtual Bool_t add(const RooAbsArg& var, Bool_t valueServer, Bool_t shapeServer, Bool_t silent) ;
-  virtual Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) ;
-  virtual Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;
-  virtual void removeAll() ;
 
   using RooAbsCollection::addOwned;
-  virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE);
+  virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE) override;
+  virtual Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) override;
+  virtual Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) override;
+  virtual void removeAll() override;
 
   RooListProxy& operator=(const RooArgList& other) ;
 
-  virtual void print(std::ostream& os, Bool_t addContents=kFALSE) const ;
+  virtual void print(std::ostream& os, Bool_t addContents=kFALSE) const override;
   
 protected:
     
@@ -54,9 +54,9 @@ protected:
   Bool_t _defValueServer ;  // Propagate value dirty flags?
   Bool_t _defShapeServer ;  // Propagate shape dirty flags?
 
-  virtual Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) ;
+  virtual Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) override;
 
-  ClassDef(RooListProxy,1) // Proxy class for a RooArgList
+  ClassDefOverride(RooListProxy,1) // Proxy class for a RooArgList
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooSetProxy.h
+++ b/roofit/roofitcore/inc/RooSetProxy.h
@@ -42,15 +42,17 @@ public:
   virtual const char* name() const { return GetName() ; }
 
   // List content management (modified for server hooks)
-  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) ;
-  virtual Bool_t add(const RooAbsCollection& list, Bool_t silent=kFALSE) { return RooAbsCollection::add(list,silent) ; }
+  using RooAbsCollection::add;
+  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE);
   virtual Bool_t add(const RooAbsArg& var, Bool_t valueServer, Bool_t shapeServer, Bool_t silent) ;
-  virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE);
-  virtual Bool_t addOwned(const RooAbsCollection& list, Bool_t silent=kFALSE) { return RooAbsCollection::addOwned(list,silent) ; }
-  virtual RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) ;
-  virtual void   addClone(const RooAbsCollection& list, Bool_t silent=kFALSE) { RooAbsCollection::addClone(list,silent) ; }
   virtual Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) ;
   virtual Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;
+
+  using RooAbsCollection::addOwned;
+  virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE) override;
+
+  using RooAbsCollection::addClone;
+  virtual RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) override;
   Bool_t remove(const RooAbsCollection& list, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;
   virtual void removeAll() ;
 

--- a/roofit/roofitcore/inc/RooSetProxy.h
+++ b/roofit/roofitcore/inc/RooSetProxy.h
@@ -39,24 +39,25 @@ public:
   RooSetProxy(const char* name, RooAbsArg* owner, const RooSetProxy& other) ;
   virtual ~RooSetProxy() ;
 
-  virtual const char* name() const { return GetName() ; }
+  virtual const char* name() const override { return GetName() ; }
 
   // List content management (modified for server hooks)
   using RooAbsCollection::add;
-  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE);
+  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) override;
   virtual Bool_t add(const RooAbsArg& var, Bool_t valueServer, Bool_t shapeServer, Bool_t silent) ;
-  virtual Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) ;
-  virtual Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;
 
   using RooAbsCollection::addOwned;
   virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE) override;
 
   using RooAbsCollection::addClone;
   virtual RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) override;
-  Bool_t remove(const RooAbsCollection& list, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;
-  virtual void removeAll() ;
 
-  virtual void print(std::ostream& os, Bool_t addContents=kFALSE) const ;
+  virtual Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) override;
+  virtual Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) override;
+  Bool_t remove(const RooAbsCollection& list, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;
+  virtual void removeAll() override;
+
+  virtual void print(std::ostream& os, Bool_t addContents=kFALSE) const override;
 
   RooSetProxy& operator=(const RooArgSet& other) ;
   
@@ -66,9 +67,9 @@ protected:
   Bool_t _defValueServer ;
   Bool_t _defShapeServer ;
 
-  virtual Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) ;
+  virtual Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) override;
 
-  ClassDef(RooSetProxy,1) // Proxy class for a RooArgSet
+  ClassDefOverride(RooSetProxy,1) // Proxy class for a RooArgSet
 };
 
 #endif

--- a/roofit/roofitcore/src/RooArgList.cxx
+++ b/roofit/roofitcore/src/RooArgList.cxx
@@ -38,13 +38,10 @@
 ///
 ///
 
-#include "Riostream.h"
-#include <iomanip>
-#include "TClass.h"
 #include "RooArgList.h"
+
 #include "RooErrorHandler.h"
 #include "RooStreamParser.h"
-#include "RooFormula.h"
 #include "RooAbsRealLValue.h"
 #include "RooAbsCategoryLValue.h"
 #include "RooTrace.h"
@@ -87,139 +84,6 @@ RooArgList::RooArgList(const char *name) :
 {
   TRACE_CREATE
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for list containing 1 initial object
-
-RooArgList::RooArgList(const RooAbsArg& var1,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 2 initial objects
-
-RooArgList::RooArgList(const RooAbsArg& var1, const RooAbsArg& var2,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 3 initial objects
-
-RooArgList::RooArgList(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 4 initial objects
-
-RooArgList::RooArgList(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 5 initial objects
-
-RooArgList::RooArgList(const RooAbsArg& var1,
-		     const RooAbsArg& var2, const RooAbsArg& var3,
-		     const RooAbsArg& var4, const RooAbsArg& var5,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 6 initial objects
-
-RooArgList::RooArgList(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4, 
-		     const RooAbsArg& var5, const RooAbsArg& var6,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5); add(var6);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 7 initial objects
-
-RooArgList::RooArgList(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4, 
-		     const RooAbsArg& var5, const RooAbsArg& var6, 
-		     const RooAbsArg& var7,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5); add(var6); add(var7) ;
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 8 initial objects
-
-RooArgList::RooArgList(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4, 
-		     const RooAbsArg& var5, const RooAbsArg& var6, 
-		     const RooAbsArg& var7, const RooAbsArg& var8,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5); add(var6); add(var7) ;add(var8) ;
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 9 initial objects
-
-RooArgList::RooArgList(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4, 
-		     const RooAbsArg& var5, const RooAbsArg& var6, 
-		     const RooAbsArg& var7, const RooAbsArg& var8,
-		     const RooAbsArg& var9, const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5); add(var6); add(var7); add(var8); add(var9);
-  TRACE_CREATE
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooArgList.cxx
+++ b/roofit/roofitcore/src/RooArgList.cxx
@@ -40,17 +40,17 @@
 
 #include "RooArgList.h"
 
-#include "RooErrorHandler.h"
 #include "RooStreamParser.h"
 #include "RooAbsRealLValue.h"
 #include "RooAbsCategoryLValue.h"
 #include "RooTrace.h"
 #include "RooMsgService.h"
 
+#include <stdexcept>
+
 using namespace std;
 
 ClassImp(RooArgList);
-  ;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -134,19 +134,22 @@ RooArgList::~RooArgList()
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Array operator. Element in slot 'idx' must already exist, otherwise
-/// code will abort. 
+/// Array operator. Element in slot `idx` must exist.
+/// \throws std::invalid_argument if `idx` is out of range.
 ///
-/// When used as lvalue in assignment operations, the element contained in
-/// the list will not be changed, only the value of the existing element!
-
+/// When used as
+/// ```
+///  myArgList[4] = x;
+/// ```
+/// note that the element contained in the list will not be
+/// replaced! Instead, `operator=` of the existing element is called.
 RooAbsArg& RooArgList::operator[](Int_t idx) const 
 {     
   RooAbsArg* arg = at(idx) ;
   if (!arg) {
     coutE(InputArguments) << "RooArgList::operator[](" << GetName() << ") ERROR: index " 
 			  << idx << " out of range (0," << getSize() << ")" << endl ;
-    RooErrorHandler::softAbort() ;
+    throw std::invalid_argument(std::string("Index ") + to_string(idx) + " is out of range.");
   }
   return *arg ; 
 }

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -150,12 +150,10 @@ RooArgSet::RooArgSet() :
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor from a RooArgList. If the list contains multiple
 /// objects with the same name, only the first is store in the set.
 /// Warning messages will be printed for dropped items.
-
 RooArgSet::RooArgSet(const RooArgList& list) :
   RooAbsCollection(list.GetName())
 {
@@ -164,27 +162,27 @@ RooArgSet::RooArgSet(const RooArgList& list) :
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor from a RooArgList. If the list contains multiple
-/// objects with the same name, only the first is store in the set.
+/// Constructor from a RooArgSet / RooArgList and a pointer to another RooFit object.
+///
+/// \param[in] collection Collection of RooFit objects to be added. If a list contains multiple
+/// objects with the same name, only the first is stored in the set.
 /// Warning messages will be printed for dropped items.
-
-RooArgSet::RooArgSet(const RooArgList& list, const RooAbsArg* var1) :
-  RooAbsCollection(list.GetName())
+/// \param[in] var1 Further object to be added. If it is already in `collection`,
+/// nothing happens, and the warning message is suppressed.
+RooArgSet::RooArgSet(const RooAbsCollection& collection, const RooAbsArg* var1) :
+  RooAbsCollection(collection.GetName())
 {
-  if (var1 && !list.contains(*var1)) {
+  if (var1 && !collection.contains(*var1)) {
     add(*var1,kTRUE) ;
   }
-  add(list,kTRUE) ; // verbose to catch duplicate errors
+  add(collection,kTRUE) ; // verbose to catch duplicate errors
   TRACE_CREATE
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Empty set constructor
-
+/// Empty set constructor.
 RooArgSet::RooArgSet(const char *name) :
   RooAbsCollection(name)
 {
@@ -192,151 +190,15 @@ RooArgSet::RooArgSet(const char *name) :
 }
 
 
-
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Construct a set from two existing sets
-
+/// Construct a set from two existing sets. The new set will not own its
+/// contents.
 RooArgSet::RooArgSet(const RooArgSet& set1, const RooArgSet& set2, const char *name) : RooAbsCollection(name)
 {
   add(set1) ;
   add(set2) ;
-  TRACE_CREATE    
-}
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 1 initial object
-
-RooArgSet::RooArgSet(const RooAbsArg& var1,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1);
   TRACE_CREATE
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 2 initial objects
-
-RooArgSet::RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 3 initial objects
-
-RooArgSet::RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 4 initial objects
-
-RooArgSet::RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 5 initial objects
-
-RooArgSet::RooArgSet(const RooAbsArg& var1,
-		     const RooAbsArg& var2, const RooAbsArg& var3,
-		     const RooAbsArg& var4, const RooAbsArg& var5,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 6 initial objects
-
-RooArgSet::RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4, 
-		     const RooAbsArg& var5, const RooAbsArg& var6,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5); add(var6);
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 7 initial objects
-
-RooArgSet::RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4, 
-		     const RooAbsArg& var5, const RooAbsArg& var6, 
-		     const RooAbsArg& var7,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5); add(var6); add(var7) ;
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 8 initial objects
-
-RooArgSet::RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4, 
-		     const RooAbsArg& var5, const RooAbsArg& var6, 
-		     const RooAbsArg& var7, const RooAbsArg& var8,
-		     const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5); add(var6); add(var7) ;add(var8) ;
-  TRACE_CREATE
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor for set containing 9 initial objects
-
-RooArgSet::RooArgSet(const RooAbsArg& var1, const RooAbsArg& var2, 
-		     const RooAbsArg& var3, const RooAbsArg& var4, 
-		     const RooAbsArg& var5, const RooAbsArg& var6, 
-		     const RooAbsArg& var7, const RooAbsArg& var8,
-		     const RooAbsArg& var9, const char *name) :
-  RooAbsCollection(name)
-{
-  add(var1); add(var2); add(var3); add(var4); add(var5); add(var6); add(var7); add(var8); add(var9);
-  TRACE_CREATE
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -362,18 +224,15 @@ RooArgSet::RooArgSet(const TCollection& tcoll, const char* name) :
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor. Note that a copy of a set is always non-owning,
-/// even the source set is owning. To create an owning copy of
-/// a set (owning or not), use the snaphot() method.
-
-RooArgSet::RooArgSet(const RooArgSet& other, const char *name) 
+/// even if the source set owns its contents. To create an owning copy of
+/// a set (owning or not), use the snapshot() method.
+RooArgSet::RooArgSet(const RooArgSet& other, const char *name)
   : RooAbsCollection(other,name)
 {
   TRACE_CREATE
 }
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -385,6 +244,13 @@ RooArgSet::~RooArgSet()
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Add contents of a RooArgList to the set.
+void RooArgSet::processArg(const RooArgList& list) {
+  add(list);
+  if (_name.Length() == 0)
+    _name = list.GetName();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Add element to non-owning set. The operation will fail if

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -42,7 +42,6 @@
 #include "RooArgSet.h"
 
 #include "TClass.h"
-#include "RooErrorHandler.h"
 #include "RooStreamParser.h"
 #include "RooFormula.h"
 #include "RooAbsRealLValue.h"
@@ -294,19 +293,21 @@ RooAbsArg* RooArgSet::addClone(const RooAbsArg& var, Bool_t silent)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Array operator. Named element must exist in set, otherwise
-/// code will abort. 
+/// Get reference to an element using its name. Named element must exist in set.
+/// \throws invalid_argument if an element with the given name is not in the set.
 ///
-/// When used as lvalue in assignment operations, the element contained in
-/// the list will not be changed, only the value of the existing element!
-
-RooAbsArg& RooArgSet::operator[](const char* name) const 
+/// Note that since most RooFit objects use an assignment operator that copies
+/// values, an expression like
+/// ```
+/// mySet["x"] = y;
+/// ```
+/// will not replace the element "x", it just assigns the values of y.
+RooAbsArg& RooArgSet::operator[](const TString& name) const
 {     
   RooAbsArg* arg = find(name) ;
   if (!arg) {
-    const std::string theName(name ? name : "");
-    coutE(InputArguments) << "RooArgSet::operator[](" << GetName() << ") ERROR: no element named '" << theName << "' in set" << endl ;
-    throw std::invalid_argument(std::string("No element named '") + theName + "' in set " + GetName());
+    coutE(InputArguments) << "RooArgSet::operator[](" << GetName() << ") ERROR: no element named " << name << " in set" << endl ;
+    throw std::invalid_argument((TString("No element named '") + name + "' in set " + GetName()).Data());
   }
   return *arg ; 
 }

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -58,6 +58,7 @@
 #include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <stdexcept>
 
 using namespace std ;
 
@@ -303,8 +304,9 @@ RooAbsArg& RooArgSet::operator[](const char* name) const
 {     
   RooAbsArg* arg = find(name) ;
   if (!arg) {
-    coutE(InputArguments) << "RooArgSet::operator[](" << GetName() << ") ERROR: no element named " << name << " in set" << endl ;
-    RooErrorHandler::softAbort() ;
+    const std::string theName(name ? name : "");
+    coutE(InputArguments) << "RooArgSet::operator[](" << GetName() << ") ERROR: no element named '" << theName << "' in set" << endl ;
+    throw std::invalid_argument(std::string("No element named '") + theName + "' in set " + GetName());
   }
   return *arg ; 
 }

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -45,9 +45,11 @@ using namespace std;
 
 ClassImp(RooClassFactory);
 
+namespace {
+
 static Int_t init();
 
-static Int_t dummy = init();
+Int_t dummy = init();
 
 static Int_t init()
 {
@@ -58,7 +60,7 @@ static Int_t init()
   return 0 ;
 }
 
-
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -178,10 +178,11 @@ using namespace std;
 ClassImp(RooCustomizer); 
 ;
 
+namespace {
 
 static Int_t init();
 
-static Int_t dummy = init() ;
+Int_t dummy = init() ;
 
 static Int_t init()
 {
@@ -191,6 +192,7 @@ static Int_t init()
   return 0 ;
 }
 
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with a prototype and masterCat index category.

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -74,9 +74,11 @@ ClassImp(RooFactoryWSTool);
 RooFactoryWSTool* RooFactoryWSTool::_of = 0 ;
 map<string,RooFactoryWSTool::IFace*>* RooFactoryWSTool::_hooks=0 ;
 
+namespace {
+
 static Int_t init();
 
-static Int_t dummy = init() ;
+Int_t dummy = init() ;
 
 static Int_t init()
 {
@@ -117,6 +119,7 @@ static Int_t init()
   return 0 ;
 }
 
+}
 
 #ifndef _WIN32
 #include <strings.h>

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -28,6 +28,7 @@
 #include "RooFitResult.h"
 #include "RooAbsPdf.h"
 #include "RooFormulaVar.h"
+#include "RooHelpers.h"
 #include "TH1.h"
 
 using namespace std;
@@ -300,7 +301,7 @@ namespace RooFit {
   RooCmdArg ClassName(const char* name)     { return RooCmdArg("ClassName",0,0,0,0,name,0,0,0) ; }
   RooCmdArg BaseClassName(const char* name) { return RooCmdArg("BaseClassName",0,0,0,0,name,0,0,0) ; }
   RooCmdArg TagName(const char* name)     { return RooCmdArg("LabelName",0,0,0,0,name,0,0,0) ; }
-   RooCmdArg OutputStream(ostream& os)    { return RooCmdArg("OutputStream",0,0,0,0,0,0,reinterpret_cast<TObject*>(&os),0) ; }
+  RooCmdArg OutputStream(ostream& os)    { return RooCmdArg("OutputStream",0,0,0,0,0,0,new RooHelpers::WrapIntoTObject<ostream>(os),0) ; }
   RooCmdArg Prefix(Bool_t flag)          { return RooCmdArg("Prefix",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Color(Color_t color)         { return RooCmdArg("Color",color,0,0,0,0,0,0,0) ; }
 

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -81,8 +81,7 @@ std::vector<std::string> tokenise(const std::string &str, const std::string &del
 /// \param[in] level Minimum level to hijack. Higher levels also get captured.
 /// \param[in] topics Topics to hijack. Use `|` to combine different topics, and cast to `RooFit::MsgTopic` if necessary.
 /// \param[in] objectName Only hijack messages from an object with the given name. Defaults to any object.
-HijackMessageStream::HijackMessageStream(RooFit::MsgLevel level, RooFit::MsgTopic topics, const char* objectName) :
-  std::ostringstream()
+HijackMessageStream::HijackMessageStream(RooFit::MsgLevel level, RooFit::MsgTopic topics, const char* objectName)
 {
   auto& msg = RooMsgService::instance();
   _oldKillBelow = msg.globalKillBelow();
@@ -95,7 +94,7 @@ HijackMessageStream::HijackMessageStream(RooFit::MsgLevel level, RooFit::MsgTopi
 
   _thisStream = msg.addStream(level,
       RooFit::Topic(topics),
-      RooFit::OutputStream(*this),
+      RooFit::OutputStream(_str),
       objectName ? RooFit::ObjectName(objectName) : RooCmdArg());
 }
 

--- a/roofit/roofitcore/src/RooMsgService.cxx
+++ b/roofit/roofitcore/src/RooMsgService.cxx
@@ -48,18 +48,17 @@ RooFit messages can be evaluated or suppressed.
 **/
 
 
-#include <sys/types.h>
-
-#include "RooFit.h"
-#include "RooAbsArg.h"
-#include "TClass.h"
-
 #include "RooMsgService.h"
+
+#include <sys/types.h>
+#include "RooAbsArg.h"
 #include "RooCmdArg.h"
 #include "RooCmdConfig.h"
 #include "RooGlobalFunc.h"
 #include "RooWorkspace.h"
+#include "RooHelpers.h"
 
+#include "TClass.h"
 #include "TSystem.h"
 
 #include <fstream>
@@ -233,7 +232,13 @@ Int_t RooMsgService::addStream(RooFit::MsgLevel level, const RooCmdArg& arg1, co
   const char* outFile = pc.getString("outFile") ;
   Bool_t prefix = pc.getInt("prefix") ;
   Color_t color = static_cast<Color_t>(pc.getInt("color")) ;
-  ostream* os = reinterpret_cast<ostream*>(pc.getObject("outStream")) ;
+  auto wrapper = static_cast<RooHelpers::WrapIntoTObject<ostream>*>(pc.getObject("outStream"));
+  ostream* os = nullptr;
+  if (wrapper) {
+    os = wrapper->_payload;
+    delete wrapper;
+    wrapper = nullptr;
+  }
 
   // Create new stream object
   StreamConfig newStream ;

--- a/roofit/roofitcore/src/RooSimWSTool.cxx
+++ b/roofit/roofitcore/src/RooSimWSTool.cxx
@@ -126,10 +126,11 @@ ClassImp(RooSimWSTool::ObjSplitRule);
 
 using namespace std ;
 
+namespace {
 
 static Int_t init();
 
-static Int_t dummy = init() ;
+Int_t dummy = init() ;
 
 static Int_t init()
 {
@@ -140,6 +141,7 @@ static Int_t init()
   return 0 ;
 }
 
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor of SimWSTool on given workspace. All input is taken from the workspace

--- a/roofit/roofitcore/test/testRooAbsCollection.cxx
+++ b/roofit/roofitcore/test/testRooAbsCollection.cxx
@@ -52,7 +52,7 @@ TEST(RooArgSet, SubscriptOperator) {
   RooRealVar y("y", "y", 0.);
   RooArgSet theSet(x, y);
 
-  EXPECT_EQ(theSet[static_cast<std::size_t>(0u)], &x);
+  EXPECT_EQ(theSet[0], &x);
   EXPECT_EQ(theSet[1], &y);
 
   const RooAbsArg& xRef = theSet["x"];

--- a/roofit/roofitcore/test/testRooAbsCollection.cxx
+++ b/roofit/roofitcore/test/testRooAbsCollection.cxx
@@ -64,3 +64,13 @@ TEST(RooArgSet, SubscriptOperator) {
   RooHelpers::HijackMessageStream hijack(RooFit::ERROR, RooFit::InputArguments);
   EXPECT_THROW(theSet[nullptr], std::invalid_argument);
 }
+
+TEST(RooArgSet, FromVector) {
+  std::vector<RooRealVar> vars;
+  vars.emplace_back("x", "x", 0.);
+  vars.emplace_back("y", "y", 0.);
+
+  RooArgSet theSet(vars.begin(), vars.end(), "Hallo");
+  EXPECT_EQ(theSet.size(), 2);
+  EXPECT_STREQ(theSet.GetName(), "Hallo");
+}

--- a/roofit/roofitcore/test/testRooAbsCollection.cxx
+++ b/roofit/roofitcore/test/testRooAbsCollection.cxx
@@ -1,6 +1,8 @@
 // Tests for the RooAbsCollection and derived classes
 // Authors: Stephan Hageboeck, CERN  05/2020
 #include "RooArgSet.h"
+#include "RooRealVar.h"
+#include "RooHelpers.h"
 
 #include "gtest/gtest.h"
 
@@ -11,4 +13,54 @@ TEST(RooArgSet, IsOnHeap) {
 
   RooArgSet setStack;
   EXPECT_FALSE(setStack.IsOnHeap());
+}
+
+TEST(RooArgSet_List, VariadicTemplateConstructor) {
+  RooRealVar x("x", "x", 0.);
+  RooRealVar y("y", "y", 0.);
+  RooRealVar z("z", "z", 0.);
+
+  RooArgSet theSet(x, "Hallo");
+  EXPECT_EQ(theSet.size(), 1);
+  EXPECT_STREQ(theSet.GetName(), "Hallo");
+
+  RooArgSet theSet2(x, y, "Hallo2");
+  EXPECT_EQ(theSet2.size(), 2);
+  EXPECT_STREQ(theSet2.GetName(), "Hallo2");
+
+  RooArgSet theSet3(x, y, z, "Hallo3");
+  EXPECT_EQ(theSet3.size(), 3);
+  EXPECT_STREQ(theSet3.GetName(), "Hallo3");
+
+
+  RooArgList theList(x, "Hallo");
+  EXPECT_EQ(theList.size(), 1);
+  EXPECT_STREQ(theList.GetName(), "Hallo");
+
+  RooArgList theList2(x, y, "Hallo2");
+  EXPECT_EQ(theList2.size(), 2);
+  EXPECT_STREQ(theList2.GetName(), "Hallo2");
+
+  RooArgList theList3(x, y, z, "Hallo3");
+  EXPECT_EQ(theList3.size(), 3);
+  EXPECT_STREQ(theList3.GetName(), "Hallo3");
+
+}
+
+TEST(RooArgSet, SubscriptOperator) {
+  RooRealVar x("x", "x", 0.);
+  RooRealVar y("y", "y", 0.);
+  RooArgSet theSet(x, y);
+
+  EXPECT_EQ(theSet[static_cast<std::size_t>(0u)], &x);
+  EXPECT_EQ(theSet[1], &y);
+
+  const RooAbsArg& xRef = theSet["x"];
+  const RooAbsArg& yRef = theSet["y"];
+  EXPECT_EQ(&xRef, static_cast<RooAbsArg*>(&x));
+  EXPECT_EQ(&yRef, static_cast<RooAbsArg*>(&y));
+
+  // Silence error to come next:
+  RooHelpers::HijackMessageStream hijack(RooFit::ERROR, RooFit::InputArguments);
+  EXPECT_THROW(theSet[nullptr], std::invalid_argument);
 }

--- a/roofit/roofitcore/test/testWorkspace.cxx
+++ b/roofit/roofitcore/test/testWorkspace.cxx
@@ -151,7 +151,7 @@ TEST_F(TestRooWorkspaceWithGaussian, ImportFromFile)
   EXPECT_TRUE(w.import("bogus:abc"));
   EXPECT_FALSE(hijack.str().empty());
 
-  hijack.str("");
+  hijack.stream().str("");
   ASSERT_TRUE(hijack.str().empty());
   EXPECT_TRUE(w.import( (spec.str()+"bogus").c_str()));
   EXPECT_FALSE(hijack.str().empty());

--- a/roofit/roofitmore/src/RooMathMoreReg.cxx
+++ b/roofit/roofitmore/src/RooMathMoreReg.cxx
@@ -24,7 +24,11 @@
 #include "Math/SpecFuncMathMore.h"
 #include "Math/DistFuncMathMore.h"
 
-static RooMathMoreReg dummy ;
+namespace {
+
+RooMathMoreReg dummy ;
+
+}
 
 RooMathMoreReg::RooMathMoreReg()
 {


### PR DESCRIPTION
This is the non-draft version of #6323 

- An interface that had a lot of manually-crafted constructor overloads is replaced by a variadic template. (Previously, you could e.g. construct with N objects, but not with N+1, because the overload didn't exist.
- An ambiguity for `operator[]` is solved.
- A constructor overload from iterators is added.
- A broken cast is solved, because windows was throwing RTTI exceptions.