### PR TITLE
Avoid null pointer dereference in TPad::DrawClassObject

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -1330,6 +1330,7 @@ void TPad::Draw(Option_t *option)
 
 void TPad::DrawClassObject(const TObject *classobj, Option_t *option)
 {
+   if (!classobj) return;
    char dname[256];
    const Int_t kMAXLEVELS = 10;
    TClass *clevel[kMAXLEVELS], *cl, *cll;


### PR DESCRIPTION
Avoid null pointer dereference in TPad::DrawClassObject

Tag @couet 