### PR TITLE
Avoid null pointer dereference in TPad::CopyBackgroundPixmaps

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -3840,6 +3840,7 @@ void TPad::PaintBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2, Option_t
 
 void TPad::CopyBackgroundPixmaps(TPad *start, TPad *stop, Int_t x, Int_t y)
 {
+   if (!start) return;
    TObject *obj;
    if (!fPrimitives) fPrimitives = new TList;
    TIter next(start->GetListOfPrimitives());


### PR DESCRIPTION
Avoid null pointer dereference in TPad::CopyBackgroundPixmaps

Tag @couet 