### PR TITLE
Avoid null pointer dereference in TPad::SetCrosshair

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -6485,6 +6485,7 @@ Int_t TPad::GetCrosshair() const
 
 void TPad::SetCrosshair(Int_t crhair)
 {
+   if (!fCanvas) return;
    fCrosshair = crhair;
    fCrosshairPos = 0;
 


### PR DESCRIPTION
Avoid null pointer dereference in TPad::SetCrosshair

Tag @couet 