### PR TITLE
[ntuple] add unit test for projection of inner collection

### DIFF
--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -59,6 +59,7 @@ template <class T>
 using RField = ROOT::Experimental::RField<T>;
 using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
 using RFieldDescriptor = ROOT::Experimental::RFieldDescriptor;
+using RFieldFuse = ROOT::Experimental::Detail::RFieldFuse;
 using RFieldMerger = ROOT::Experimental::RFieldMerger;
 using RFieldValue = ROOT::Experimental::Detail::RFieldValue;
 using RMiniFileReader = ROOT::Experimental::Internal::RMiniFileReader;

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -72,6 +72,8 @@ TEST(RNTuple, InsideCollection)
    EXPECT_EQ(1U, aVec->size());
    EXPECT_EQ(42.0, (*aVec)[0]);
    field->DestroyValue(value);
+   
+   // TODO: test reading of "klassVec.v1"
 }
 
 


### PR DESCRIPTION
Demonstrates how to access inner fields of a complex collection. In this case, we store an `std::vector<CustomStruct>` and we read `CustomStruct.a` as an `std::vector<float>`. This capability is necessary for efficient collection access in RNTupleDS.