### PR TITLE
Make GetEntriesSerialized actually work with destructive serialization

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1488,10 +1488,6 @@ Int_t TBranch::GetEntriesSerialized(Long64_t entry, TBuffer &user_buf, TBuffer *
    // TODO: eventually support multiple leaves.
    if (R__unlikely(fNleaves != 1)) { return -1; }
    TLeaf *leaf = static_cast<TLeaf*>(fLeaves.UncheckedAt(0));
-   if (R__unlikely(leaf->GetDeserializeType() == TLeaf::DeserializeType::kDestructive)) {
-      Error("GetEntriesSerialized", "Encountered a branch with destructive deserialization; failing.\n");
-      return -1;
-   }
 
    // Remember which entry we are reading.
    fReadEntry = entry;


### PR DESCRIPTION
TBulkRead::GetEntriesSerialized should simply work with destructive
serialization. Not sure why the check is there.