### PR TITLE
Improve scalabity of TClass's object repository

### DIFF
--- a/core/cont/inc/TVirtualCollectionProxy.h
+++ b/core/cont/inc/TVirtualCollectionProxy.h
@@ -96,11 +96,11 @@ public:
    }
    virtual TClass::ObjectPtr NewObject() const {
       // Return a new container object
-      return fClass.GetClass()==0 ? TClass::ObjectPtr{nullptr, nullptr} : fClass->NewObject();
+      return fClass.GetClass()==0 ? TClass::ObjectPtr{} : fClass->NewObject();
    }
    virtual TClass::ObjectPtr NewObject(void *arena) const {
       // Execute the container constructor
-      return fClass.GetClass()==0 ? TClass::ObjectPtr{nullptr, nullptr} : fClass->NewObject(arena);
+      return fClass.GetClass()==0 ? TClass::ObjectPtr{} : fClass->NewObject(arena);
    }
 
    virtual void     *NewArray(Int_t nElements) const {
@@ -113,11 +113,11 @@ public:
    }
    virtual TClass::ObjectPtr NewObjectArray(Int_t nElements) const {
       // Return a new container object
-      return fClass.GetClass()==0 ? TClass::ObjectPtr{nullptr, nullptr}: fClass->NewObjectArray(nElements);
+      return fClass.GetClass()==0 ? TClass::ObjectPtr{} : fClass->NewObjectArray(nElements);
    }
    virtual TClass::ObjectPtr NewObjectArray(Int_t nElements, void *arena) const {
       // Execute the container constructor
-      return fClass.GetClass()==0 ? TClass::ObjectPtr{nullptr, nullptr} : fClass->NewObjectArray(nElements, arena);
+      return fClass.GetClass()==0 ? TClass::ObjectPtr{} : fClass->NewObjectArray(nElements, arena);
    }
 
    virtual void      Destructor(void *p, Bool_t dtorOnly = kFALSE) const {

--- a/core/cont/inc/TVirtualCollectionProxy.h
+++ b/core/cont/inc/TVirtualCollectionProxy.h
@@ -94,6 +94,14 @@ public:
       // Execute the container constructor
       return fClass.GetClass()==0 ? 0 : fClass->New(arena);
    }
+   virtual TClass::ObjectPtr NewObject() const {
+      // Return a new container object
+      return fClass.GetClass()==0 ? TClass::ObjectPtr{nullptr, nullptr} : fClass->NewObject();
+   }
+   virtual TClass::ObjectPtr NewObject(void *arena) const {
+      // Execute the container constructor
+      return fClass.GetClass()==0 ? TClass::ObjectPtr{nullptr, nullptr} : fClass->NewObject(arena);
+   }
 
    virtual void     *NewArray(Int_t nElements) const {
       // Return a new container object
@@ -102,6 +110,14 @@ public:
    virtual void     *NewArray(Int_t nElements, void *arena) const {
       // Execute the container constructor
       return fClass.GetClass()==0 ? 0 : fClass->NewArray(nElements, arena);
+   }
+   virtual TClass::ObjectPtr NewObjectArray(Int_t nElements) const {
+      // Return a new container object
+      return fClass.GetClass()==0 ? TClass::ObjectPtr{nullptr, nullptr}: fClass->NewObjectArray(nElements);
+   }
+   virtual TClass::ObjectPtr NewObjectArray(Int_t nElements, void *arena) const {
+      // Execute the container constructor
+      return fClass.GetClass()==0 ? TClass::ObjectPtr{nullptr, nullptr} : fClass->NewObjectArray(nElements, arena);
    }
 
    virtual void      Destructor(void *p, Bool_t dtorOnly = kFALSE) const {

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -318,6 +318,20 @@ private:
 
    TVirtualStreamerInfo     *GetStreamerInfoImpl(Int_t version, Bool_t silent) const;
 
+   struct ObjRepoValue {
+      ObjRepoValue(const TClass *what, Version_t version) : fClass(what),fVersion(version) {}
+      const TClass *fClass;
+      Version_t     fVersion;
+   };
+
+   mutable TVirtualMutex *fOVRMutex = nullptr;
+   typedef std::multimap<void*, ObjRepoValue> RepoCont_t;
+   mutable RepoCont_t fObjectVersionRepository;
+
+   void UnregisterAddressInRepository(const char *where, void *location, const TClass *what) const;
+   void MoveAddressInRepository(const char *where, void *oldadd, void *newadd, const TClass *what) const;
+   void RegisterAddressInRepository(const char *where, void *location, const TClass *what) const;
+
 private:
    TClass(const TClass& tc) = delete;
    TClass& operator=(const TClass&) = delete;

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -143,7 +143,7 @@ public:
       TVirtualStreamerInfo *fAllocator = nullptr;
 
    public:
-      ObjectPtr(void *ptr, TVirtualStreamerInfo *allocator = nullptr) : fPtr(ptr), fAllocator(allocator) {}
+      ObjectPtr(void *ptr = nullptr, TVirtualStreamerInfo *allocator = nullptr) : fPtr(ptr), fAllocator(allocator) {}
 
       void *GetPtr() const { return fPtr; }
 

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -318,14 +318,8 @@ private:
 
    TVirtualStreamerInfo     *GetStreamerInfoImpl(Int_t version, Bool_t silent) const;
 
-   struct ObjRepoValue {
-      ObjRepoValue(const TClass *what, Version_t version) : fClass(what),fVersion(version) {}
-      const TClass *fClass;
-      Version_t     fVersion;
-   };
-
    mutable TVirtualMutex *fOVRMutex = nullptr;
-   typedef std::multimap<void*, ObjRepoValue> RepoCont_t;
+   typedef std::multimap<void*, Version_t> RepoCont_t;
    mutable RepoCont_t fObjectVersionRepository;
 
    void UnregisterAddressInRepository(const char *where, void *location, const TClass *what) const;

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -132,6 +132,10 @@ public:
                         // in ROOT Meta w/o interpreter information
    };
 
+   // "Typed" pointer that recalls how TClass::New allocated the object.
+   // It is returned by TClass:NewObject and should be passed to TClass::DeleteArray or TClass::Destructor
+   // to delete the object.
+   // It is also used in TVirtualCollectionProxy for the same reasons.
    class ObjectPtr
    {
       void *fPtr = nullptr;
@@ -586,8 +590,7 @@ public:
    void               Store(TBuffer &b) const;
 
    // Pseudo-method apply to the 'obj'. In particular those are used to
-   // implement TObject like methods for non-TObject classes
-
+   // implement TObject like methods for non-TObject classes.
    Int_t              Browse(void *obj, TBrowser *b) const;
    void               DeleteArray(void *ary, Bool_t dtorOnly = kFALSE);
    void               DeleteArray(ObjectPtr ary, Bool_t dtorOnly = kFALSE);

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -132,6 +132,22 @@ public:
                         // in ROOT Meta w/o interpreter information
    };
 
+   class ObjectPtr
+   {
+      void *fPtr = nullptr;
+
+      TVirtualStreamerInfo *fAllocator = nullptr;
+
+   public:
+      ObjectPtr(void *ptr, TVirtualStreamerInfo *allocator = nullptr) : fPtr(ptr), fAllocator(allocator) {}
+
+      void *GetPtr() const { return fPtr; }
+
+      TVirtualStreamerInfo *GetAllocator() const { return fAllocator; }
+
+      operator bool() const { return fPtr != nullptr; }
+   };
+
 private:
 
 
@@ -506,6 +522,10 @@ public:
    void              *New(void *arena, ENewType defConstructor = kClassNew) const;
    void              *NewArray(Long_t nElements, ENewType defConstructor = kClassNew) const;
    void              *NewArray(Long_t nElements, void *arena, ENewType defConstructor = kClassNew) const;
+   ObjectPtr          NewObject(ENewType defConstructor = kClassNew, Bool_t quiet = kFALSE) const;
+   ObjectPtr          NewObject(void *arena, ENewType defConstructor = kClassNew) const;
+   ObjectPtr          NewObjectArray(Long_t nElements, ENewType defConstructor = kClassNew) const;
+   ObjectPtr          NewObjectArray(Long_t nElements, void *arena, ENewType defConstructor = kClassNew) const;
    virtual void       PostLoadCheck();
    Long_t             Property() const;
    Int_t              ReadBuffer(TBuffer &b, void *pointer, Int_t version, UInt_t start, UInt_t count);
@@ -570,7 +590,9 @@ public:
 
    Int_t              Browse(void *obj, TBrowser *b) const;
    void               DeleteArray(void *ary, Bool_t dtorOnly = kFALSE);
+   void               DeleteArray(ObjectPtr ary, Bool_t dtorOnly = kFALSE);
    void               Destructor(void *obj, Bool_t dtorOnly = kFALSE);
+   void               Destructor(ObjectPtr obj, Bool_t dtorOnly = kFALSE);
    void              *DynamicCast(const TClass *base, void *obj, Bool_t up = kTRUE);
    const void        *DynamicCast(const TClass *base, const void *obj, Bool_t up = kTRUE);
    Bool_t             IsFolder(void *obj) const;

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -136,13 +136,12 @@ public:
    // It is returned by TClass:NewObject and should be passed to TClass::DeleteArray or TClass::Destructor
    // to delete the object.
    // It is also used in TVirtualCollectionProxy for the same reasons.
-   class ObjectPtr
+   struct ObjectPtr
    {
       void *fPtr = nullptr;
 
       TVirtualStreamerInfo *fAllocator = nullptr;
 
-   public:
       ObjectPtr(void *ptr = nullptr, TVirtualStreamerInfo *allocator = nullptr) : fPtr(ptr), fAllocator(allocator) {}
 
       void *GetPtr() const { return fPtr; }

--- a/core/meta/inc/TVirtualArray.h
+++ b/core/meta/inc/TVirtualArray.h
@@ -21,21 +21,24 @@ Wrapper around an object and giving indirect access to its content
 even if the object is not of a class in the Cint/Reflex dictionary.
 */
 
+#include "TClass.h"
 #include "TClassRef.h"
 
 class TVirtualArray {
 public:
+   using ObjectPtr = TClass::ObjectPtr;
+
    TClassRef  fClass;
    UInt_t     fCapacity;
    UInt_t     fSize;
-   char      *fArray; ///<[fSize]
+   ObjectPtr  fArray; ///< fSize elements
 
-   TVirtualArray( TClass *cl, UInt_t size ) : fClass(cl), fCapacity(size), fSize(size), fArray( (char*)( cl ? cl->NewArray(size) : 0) ) {};
+   TVirtualArray( TClass *cl, UInt_t size ) : fClass(cl), fCapacity(size), fSize(size), fArray( ( cl ? cl->NewObjectArray(size) : ObjectPtr{nullptr, nullptr}) ) {};
    ~TVirtualArray() { if (fClass) fClass->DeleteArray( fArray ); }
 
    TClass *GetClass() { return fClass; }
    char *operator[](UInt_t ind) const { return GetObjectAt(ind); }
-   char *GetObjectAt(UInt_t ind) const { return fArray+fClass->Size()*ind; }
+   char *GetObjectAt(UInt_t ind) const { return ((char*)fArray.GetPtr())+fClass->Size()*ind; }
 
    void SetSize(UInt_t size) {
       // Set the used size of this array to 'size'.   If size is greater than the existing
@@ -43,7 +46,7 @@ public:
       fSize = size;
       if (fSize > fCapacity && fClass) {
          fClass->DeleteArray( fArray );
-         fArray = (char*)fClass->NewArray(fSize);
+         fArray = fClass->NewObjectArray(fSize);
          fCapacity = fSize;
       }
    }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -281,15 +281,15 @@ void TClass::RegisterAddressInRepository(const char * /*where*/, void *location,
 //    }
    {
       R__LOCKGUARD2(fOVRMutex);
-      fObjectVersionRepository.insert(RepoCont_t::value_type(location, RepoCont_t::mapped_type(what,version)));
+      fObjectVersionRepository.insert(RepoCont_t::value_type(location, version));
    }
 #if 0
    // This code could be used to prevent an address to be registered twice.
-   std::pair<RepoCont_t::iterator, Bool_t> tmp = fObjectVersionRepository.insert(RepoCont_t::value_type>(location, RepoCont_t::mapped_type(what,version)));
+   std::pair<RepoCont_t::iterator, Bool_t> tmp = fObjectVersionRepository.insert(RepoCont_t::value_type>(location, version));
    if (!tmp.second) {
       Warning(where, "Reregistering an object of class '%s' version %d at address %p", what->GetName(), version, p);
       fObjectVersionRepository.erase(tmp.first);
-      tmp = fObjectVersionRepository.insert(RepoCont_t::value_type>(location, RepoCont_t::mapped_type(what,version)));
+      tmp = fObjectVersionRepository.insert(RepoCont_t::value_type>(location, version));
       if (!tmp.second) {
          Warning(where, "Failed to reregister an object of class '%s' version %d at address %p", what->GetName(), version, location);
       }
@@ -305,7 +305,7 @@ void TClass::UnregisterAddressInRepository(const char * /*where*/, void *locatio
    RepoCont_t::iterator cur = fObjectVersionRepository.find(location);
    for (; cur != fObjectVersionRepository.end();) {
       RepoCont_t::iterator tmp = cur++;
-      if ((tmp->first == location) && (tmp->second.fVersion == what->GetClassVersion())) {
+      if ((tmp->first == location) && (tmp->second == what->GetClassVersion())) {
          // -- We still have an address, version match.
          // Info(where, "Unregistering address %p of class '%s' version %d", location, what->GetName(), what->GetClassVersion());
          fObjectVersionRepository.erase(tmp);
@@ -330,7 +330,7 @@ void TClass::MoveAddressInRepository(const char * /*where*/, void *oldadd, void 
       if (oldadd <= tmp->first && tmp->first < ( ((char*)oldadd) + objsize) ) {
          // The location is within the object, let's move it.
 
-         fObjectVersionRepository.insert(RepoCont_t::value_type(((char*)tmp->first)+delta, RepoCont_t::mapped_type(tmp->second.fClass,tmp->second.fVersion)));
+         fObjectVersionRepository.insert(RepoCont_t::value_type(((char*)tmp->first)+delta, tmp->second));
          fObjectVersionRepository.erase(tmp);
 
       } else {
@@ -5352,9 +5352,9 @@ void TClass::Destructor(void *obj, Bool_t dtorOnly)
          } else {
             //objVer = iter->second;
             for (; (iter != fObjectVersionRepository.end()) && (iter->first == p); ++iter) {
-               Version_t ver = iter->second.fVersion;
+               Version_t ver = iter->second;
                knownVersions.insert(ver);
-               if (ver == fClassVersion && this == iter->second.fClass) {
+               if (ver == fClassVersion) {
                   verFound = kTRUE;
                }
             }
@@ -5464,9 +5464,9 @@ void TClass::DeleteArray(void *ary, Bool_t dtorOnly)
             inRepo = kFALSE;
          } else {
             for (; (iter != fObjectVersionRepository.end()) && (iter->first == p); ++iter) {
-               Version_t ver = iter->second.fVersion;
+               Version_t ver = iter->second;
                knownVersions.insert(ver);
-               if (ver == fClassVersion && this == iter->second.fClass ) {
+               if (ver == fClassVersion) {
                   verFound = kTRUE;
                }
             }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5380,7 +5380,7 @@ void TClass::Destructor(void *obj, Bool_t dtorOnly)
             }
          }
       } else {
-         // The loaded class vers  ion is not the same as the version of the code
+         // The loaded class version is not the same as the version of the code
          // which was used to allocate this object.  The best we can do is use
          // the TVirtualStreamerInfo to try to free up some of the allocated memory.
          TVirtualStreamerInfo* si = (TVirtualStreamerInfo*) fStreamerInfo->At(objVer);

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1572,7 +1572,7 @@ void TClass::Init(const char *name, Version_t cversion,
    if (fClassInfo) {
       SetTitle(gCling->ClassInfo_Title(fClassInfo));
       if ( fDeclFileName == 0 || fDeclFileName[0] == '\0' ) {
-	fDeclFileName = kUndeterminedClassInfoName;
+         fDeclFileName = kUndeterminedClassInfoName;
          // Missing interface:
          // fDeclFileLine = gInterpreter->ClassInfo_FileLine( fClassInfo );
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -269,6 +269,24 @@ TClass::ENewType &TClass__GetCallingNew() {
    return fgCallingNew;
 }
 
+struct TClass__GetCallingNewRAII
+{
+   TClass::ENewType &fCurrentValue;
+   TClass::ENewType  fOldValue;
+
+   TClass__GetCallingNewRAII(TClass::ENewType newvalue) :
+      fCurrentValue(TClass__GetCallingNew()),
+      fOldValue(fCurrentValue)
+   {
+      fCurrentValue = newvalue;
+   }
+
+   ~TClass__GetCallingNewRAII()
+   {
+      fCurrentValue = fOldValue;
+   }
+};
+
 void TClass::RegisterAddressInRepository(const char * /*where*/, void *location, const TClass *what) const
 {
    // Register the object for special handling in the destructor.
@@ -4964,9 +4982,10 @@ TClass::ObjectPtr TClass::NewObject(ENewType defConstructor, Bool_t quiet) const
       // so there is a dictionary and it was generated
       // by rootcint, so there should be a default
       // constructor we can call through the wrapper.
-      TClass__GetCallingNew() = defConstructor;
-      p = fNew(0);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = fNew(0);
+      }
       if (!p && !quiet) {
          //Error("New", "cannot create object of class %s version %d", GetName(), fClassVersion);
          Error("New", "cannot create object of class %s", GetName());
@@ -4980,9 +4999,10 @@ TClass::ObjectPtr TClass::NewObject(ENewType defConstructor, Bool_t quiet) const
       // library is loaded and there will be a default
       // constructor we can call.
       // [This is very unlikely to work, but who knows!]
-      TClass__GetCallingNew() = defConstructor;
-      p = gCling->ClassInfo_New(GetClassInfo());
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = gCling->ClassInfo_New(GetClassInfo());
+      }
       if (!p && !quiet) {
          //Error("New", "cannot create object of class %s version %d", GetName(), fClassVersion);
          Error("New", "cannot create object of class %s", GetName());
@@ -4991,9 +5011,10 @@ TClass::ObjectPtr TClass::NewObject(ENewType defConstructor, Bool_t quiet) const
       // There is no dictionary at all, so this is an emulated
       // class; however we do have the services of a collection proxy,
       // so this is an emulated STL class.
-      TClass__GetCallingNew() = defConstructor;
-      p = fCollectionProxy->NewObject();
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = fCollectionProxy->NewObject();
+      }
       if (!p && !quiet) {
          //Error("New", "cannot create object of class %s version %d", GetName(), fClassVersion);
          Error("New", "cannot create object of class %s", GetName());
@@ -5023,9 +5044,10 @@ TClass::ObjectPtr TClass::NewObject(ENewType defConstructor, Bool_t quiet) const
          return 0;
       }
 
-      TClass__GetCallingNew() = defConstructor;
-      p = { sinfo->New(), sinfo};
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = { sinfo->New(), sinfo};
+      }
 
       // FIXME: Mistake?  See note above at the GetObjectStat() call.
       // Allow TObject's to be registered again.
@@ -5074,9 +5096,10 @@ TClass::ObjectPtr TClass::NewObject(void *arena, ENewType defConstructor) const
       // so there is a dictionary and it was generated
       // by rootcint, so there should be a default
       // constructor we can call through the wrapper.
-      TClass__GetCallingNew() = defConstructor;
-      p = fNew(arena);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = fNew(arena);
+      }
       if (!p) {
          Error("New with placement", "cannot create object of class %s version %d at address %p", GetName(), fClassVersion, arena);
       }
@@ -5089,9 +5112,10 @@ TClass::ObjectPtr TClass::NewObject(void *arena, ENewType defConstructor) const
       // library is loaded and there will be a default
       // constructor we can call.
       // [This is very unlikely to work, but who knows!]
-      TClass__GetCallingNew() = defConstructor;
-      p = gCling->ClassInfo_New(GetClassInfo(),arena);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = gCling->ClassInfo_New(GetClassInfo(),arena);
+      }
       if (!p) {
          Error("New with placement", "cannot create object of class %s version %d at address %p", GetName(), fClassVersion, arena);
       }
@@ -5099,9 +5123,10 @@ TClass::ObjectPtr TClass::NewObject(void *arena, ENewType defConstructor) const
       // There is no dictionary at all, so this is an emulated
       // class; however we do have the services of a collection proxy,
       // so this is an emulated STL class.
-      TClass__GetCallingNew() = defConstructor;
-      p = fCollectionProxy->NewObject(arena);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = fCollectionProxy->NewObject(arena);
+      }
    } else if (!HasInterpreterInfo() && !fCollectionProxy) {
       // There is no dictionary at all and we do not have
       // the services of a collection proxy available, so
@@ -5125,9 +5150,10 @@ TClass::ObjectPtr TClass::NewObject(void *arena, ENewType defConstructor) const
          return 0;
       }
 
-      TClass__GetCallingNew() = defConstructor;
-      p = { sinfo->New(arena), sinfo };
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = { sinfo->New(arena), sinfo };
+      }
 
       // ???BUG???
       // Allow TObject's to be registered again.
@@ -5173,9 +5199,10 @@ TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, ENewType defConstruct
       // so there is a dictionary and it was generated
       // by rootcint, so there should be a default
       // constructor we can call through the wrapper.
-      TClass__GetCallingNew() = defConstructor;
-      p = fNewArray(nElements, 0);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = fNewArray(nElements, 0);
+      }
       if (!p) {
          Error("NewArray", "cannot create object of class %s version %d", GetName(), fClassVersion);
       }
@@ -5188,9 +5215,10 @@ TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, ENewType defConstruct
       // library is loaded and there will be a default
       // constructor we can call.
       // [This is very unlikely to work, but who knows!]
-      TClass__GetCallingNew() = defConstructor;
-      p = gCling->ClassInfo_New(GetClassInfo(),nElements);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = gCling->ClassInfo_New(GetClassInfo(),nElements);
+      }
       if (!p) {
          Error("NewArray", "cannot create object of class %s version %d", GetName(), fClassVersion);
       }
@@ -5198,9 +5226,10 @@ TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, ENewType defConstruct
       // There is no dictionary at all, so this is an emulated
       // class; however we do have the services of a collection proxy,
       // so this is an emulated STL class.
-      TClass__GetCallingNew() = defConstructor;
-      p = fCollectionProxy->NewObjectArray(nElements);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = fCollectionProxy->NewObjectArray(nElements);
+      }
    } else if (!HasInterpreterInfo() && !fCollectionProxy) {
       // There is no dictionary at all and we do not have
       // the services of a collection proxy available, so
@@ -5224,9 +5253,10 @@ TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, ENewType defConstruct
          return 0;
       }
 
-      TClass__GetCallingNew() = defConstructor;
-      p = { sinfo->NewArray(nElements), sinfo };
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = { sinfo->NewArray(nElements), sinfo };
+      }
 
       // ???BUG???
       // Allow TObject's to be registered again.
@@ -5270,9 +5300,10 @@ TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, void *arena, ENewType
       // so there is a dictionary and it was generated
       // by rootcint, so there should be a default
       // constructor we can call through the wrapper.
-      TClass__GetCallingNew() = defConstructor;
-      p = fNewArray(nElements, arena);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = fNewArray(nElements, arena);
+      }
       if (!p) {
          Error("NewArray with placement", "cannot create object of class %s version %d at address %p", GetName(), fClassVersion, arena);
       }
@@ -5285,9 +5316,10 @@ TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, void *arena, ENewType
       // call, or the class is interpreted and we will call the default
       // constructor that way, or no default constructor is available and
       // we fail.
-      TClass__GetCallingNew() = defConstructor;
-      p = gCling->ClassInfo_New(GetClassInfo(),nElements, arena);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = gCling->ClassInfo_New(GetClassInfo(),nElements, arena);
+      }
       if (!p) {
          Error("NewArray with placement", "cannot create object of class %s version %d at address %p", GetName(), fClassVersion, arena);
       }
@@ -5295,9 +5327,10 @@ TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, void *arena, ENewType
       // There is no dictionary at all, so this is an emulated
       // class; however we do have the services of a collection proxy,
       // so this is an emulated STL class.
-      TClass__GetCallingNew() = defConstructor;
-      p = fCollectionProxy->NewObjectArray(nElements, arena);
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = fCollectionProxy->NewObjectArray(nElements, arena);
+      }
    } else if (!HasInterpreterInfo() && !fCollectionProxy) {
       // There is no dictionary at all and we do not have
       // the services of a collection proxy available, so
@@ -5321,9 +5354,10 @@ TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, void *arena, ENewType
          return 0;
       }
 
-      TClass__GetCallingNew() = defConstructor;
-      p = { sinfo->NewArray(nElements, arena), sinfo };
-      TClass__GetCallingNew() = kRealNew;
+      {
+         TClass__GetCallingNewRAII callingNew(defConstructor);
+         p = { sinfo->NewArray(nElements, arena), sinfo };
+      }
 
       // ???BUG???
       // Allow TObject's to be registered again.

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -4975,7 +4975,7 @@ void *TClass::New(ENewType defConstructor, Bool_t quiet) const
 
 TClass::ObjectPtr TClass::NewObject(ENewType defConstructor, Bool_t quiet) const
 {
-   ObjectPtr p{nullptr};
+   ObjectPtr p;
 
    if (fNew) {
       // We have the new operator wrapper function,
@@ -5089,7 +5089,7 @@ void *TClass::New(void *arena, ENewType defConstructor) const
 
 TClass::ObjectPtr TClass::NewObject(void *arena, ENewType defConstructor) const
 {
-   ObjectPtr p{nullptr};
+   ObjectPtr p;
 
    if (fNew) {
       // We have the new operator wrapper function,
@@ -5192,7 +5192,7 @@ void *TClass::NewArray(Long_t nElements, ENewType defConstructor) const
 
 TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, ENewType defConstructor) const
 {
-   ObjectPtr p{nullptr};
+   ObjectPtr p;
 
    if (fNewArray) {
       // We have the new operator wrapper function,
@@ -5293,7 +5293,7 @@ void *TClass::NewArray(Long_t nElements, void *arena, ENewType defConstructor) c
 
 TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, void *arena, ENewType defConstructor) const
 {
-   ObjectPtr p{nullptr};
+   ObjectPtr p;
 
    if (fNewArray) {
       // We have the new operator wrapper function,

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -4943,7 +4943,21 @@ const void *TClass::DynamicCast(const TClass *cl, const void *obj, Bool_t up)
 
 void *TClass::New(ENewType defConstructor, Bool_t quiet) const
 {
-   void* p = 0;
+   auto obj = NewObject(defConstructor, quiet);
+   if (obj.GetPtr() && obj.GetAllocator()) {
+      // Register the object for special handling in the destructor.
+      RegisterAddressInRepository("TClass::New", obj.GetPtr(), this);
+   }
+   return obj.GetPtr();
+}
+
+// See TClass:New
+// returns a TClass::ObjectPtr which remembers if the object was allocated
+// via a TStreamerInfo.
+
+TClass::ObjectPtr TClass::NewObject(ENewType defConstructor, Bool_t quiet) const
+{
+   ObjectPtr p{nullptr};
 
    if (fNew) {
       // We have the new operator wrapper function,
@@ -4978,7 +4992,7 @@ void *TClass::New(ENewType defConstructor, Bool_t quiet) const
       // class; however we do have the services of a collection proxy,
       // so this is an emulated STL class.
       TClass__GetCallingNew() = defConstructor;
-      p = fCollectionProxy->New();
+      p = fCollectionProxy->NewObject();
       TClass__GetCallingNew() = kRealNew;
       if (!p && !quiet) {
          //Error("New", "cannot create object of class %s version %d", GetName(), fClassVersion);
@@ -5010,7 +5024,7 @@ void *TClass::New(ENewType defConstructor, Bool_t quiet) const
       }
 
       TClass__GetCallingNew() = defConstructor;
-      p = sinfo->New();
+      p = { sinfo->New(), sinfo};
       TClass__GetCallingNew() = kRealNew;
 
       // FIXME: Mistake?  See note above at the GetObjectStat() call.
@@ -5019,12 +5033,11 @@ void *TClass::New(ENewType defConstructor, Bool_t quiet) const
          SetObjectStat(statsave);
       }
 
-      // Register the object for special handling in the destructor.
-      if (p) {
-         RegisterAddressInRepository("New",p,this);
-      } else {
+      if (!p) {
          Error("New", "Failed to construct class '%s' using streamer info", GetName());
       }
+
+      return p;
    } else {
       Fatal("New", "This cannot happen!");
    }
@@ -5039,7 +5052,22 @@ void *TClass::New(ENewType defConstructor, Bool_t quiet) const
 
 void *TClass::New(void *arena, ENewType defConstructor) const
 {
-   void* p = 0;
+   auto obj = NewObject(arena, defConstructor);
+   if (obj.GetPtr() && obj.GetAllocator()) {
+      // Register the object for special handling in the destructor.
+      RegisterAddressInRepository("TClass::New with placement", obj.GetPtr(), this);
+   }
+   return obj.GetPtr();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return a pointer to a newly allocated object of this class.
+/// The class must have a default constructor. For meaning of
+/// defConstructor, see TClass::IsCallingNew().
+
+TClass::ObjectPtr TClass::NewObject(void *arena, ENewType defConstructor) const
+{
+   ObjectPtr p{nullptr};
 
    if (fNew) {
       // We have the new operator wrapper function,
@@ -5072,7 +5100,7 @@ void *TClass::New(void *arena, ENewType defConstructor) const
       // class; however we do have the services of a collection proxy,
       // so this is an emulated STL class.
       TClass__GetCallingNew() = defConstructor;
-      p = fCollectionProxy->New(arena);
+      p = fCollectionProxy->NewObject(arena);
       TClass__GetCallingNew() = kRealNew;
    } else if (!HasInterpreterInfo() && !fCollectionProxy) {
       // There is no dictionary at all and we do not have
@@ -5098,7 +5126,7 @@ void *TClass::New(void *arena, ENewType defConstructor) const
       }
 
       TClass__GetCallingNew() = defConstructor;
-      p = sinfo->New(arena);
+      p = { sinfo->New(arena), sinfo };
       TClass__GetCallingNew() = kRealNew;
 
       // ???BUG???
@@ -5107,10 +5135,6 @@ void *TClass::New(void *arena, ENewType defConstructor) const
          SetObjectStat(statsave);
       }
 
-      // Register the object for special handling in the destructor.
-      if (p) {
-         RegisterAddressInRepository("TClass::New with placement",p,this);
-      }
    } else {
       Error("New with placement", "This cannot happen!");
    }
@@ -5126,7 +5150,23 @@ void *TClass::New(void *arena, ENewType defConstructor) const
 
 void *TClass::NewArray(Long_t nElements, ENewType defConstructor) const
 {
-   void* p = 0;
+   auto obj = NewObjectArray(nElements, defConstructor);
+   if (obj.GetPtr() && obj.GetAllocator()) {
+      // Register the object for special handling in the destructor.
+      RegisterAddressInRepository("TClass::NewArray", obj.GetPtr(), this);
+   }
+   return obj.GetPtr();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return a pointer to a newly allocated array of objects
+/// of this class.
+/// The class must have a default constructor. For meaning of
+/// defConstructor, see TClass::IsCallingNew().
+
+TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, ENewType defConstructor) const
+{
+   ObjectPtr p{nullptr};
 
    if (fNewArray) {
       // We have the new operator wrapper function,
@@ -5159,7 +5199,7 @@ void *TClass::NewArray(Long_t nElements, ENewType defConstructor) const
       // class; however we do have the services of a collection proxy,
       // so this is an emulated STL class.
       TClass__GetCallingNew() = defConstructor;
-      p = fCollectionProxy->NewArray(nElements);
+      p = fCollectionProxy->NewObjectArray(nElements);
       TClass__GetCallingNew() = kRealNew;
    } else if (!HasInterpreterInfo() && !fCollectionProxy) {
       // There is no dictionary at all and we do not have
@@ -5185,7 +5225,7 @@ void *TClass::NewArray(Long_t nElements, ENewType defConstructor) const
       }
 
       TClass__GetCallingNew() = defConstructor;
-      p = sinfo->NewArray(nElements);
+      p = { sinfo->NewArray(nElements), sinfo };
       TClass__GetCallingNew() = kRealNew;
 
       // ???BUG???
@@ -5194,10 +5234,6 @@ void *TClass::NewArray(Long_t nElements, ENewType defConstructor) const
          SetObjectStat(statsave);
       }
 
-      // Register the object for special handling in the destructor.
-      if (p) {
-         RegisterAddressInRepository("TClass::NewArray",p,this);
-      }
    } else {
       Error("NewArray", "This cannot happen!");
    }
@@ -5212,7 +5248,22 @@ void *TClass::NewArray(Long_t nElements, ENewType defConstructor) const
 
 void *TClass::NewArray(Long_t nElements, void *arena, ENewType defConstructor) const
 {
-   void* p = 0;
+   auto obj = NewObjectArray(nElements, arena, defConstructor);
+   if (obj.GetPtr() && obj.GetAllocator()) {
+      // Register the object for special handling in the destructor.
+      RegisterAddressInRepository("TClass::NewArray with placement", obj.GetPtr(), this);
+   }
+   return obj.GetPtr();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return a pointer to a newly allocated object of this class.
+/// The class must have a default constructor. For meaning of
+/// defConstructor, see TClass::IsCallingNew().
+
+TClass::ObjectPtr TClass::NewObjectArray(Long_t nElements, void *arena, ENewType defConstructor) const
+{
+   ObjectPtr p{nullptr};
 
    if (fNewArray) {
       // We have the new operator wrapper function,
@@ -5245,7 +5296,7 @@ void *TClass::NewArray(Long_t nElements, void *arena, ENewType defConstructor) c
       // class; however we do have the services of a collection proxy,
       // so this is an emulated STL class.
       TClass__GetCallingNew() = defConstructor;
-      p = fCollectionProxy->NewArray(nElements, arena);
+      p = fCollectionProxy->NewObjectArray(nElements, arena);
       TClass__GetCallingNew() = kRealNew;
    } else if (!HasInterpreterInfo() && !fCollectionProxy) {
       // There is no dictionary at all and we do not have
@@ -5271,7 +5322,7 @@ void *TClass::NewArray(Long_t nElements, void *arena, ENewType defConstructor) c
       }
 
       TClass__GetCallingNew() = defConstructor;
-      p = sinfo->NewArray(nElements, arena);
+      p = { sinfo->NewArray(nElements, arena), sinfo };
       TClass__GetCallingNew() = kRealNew;
 
       // ???BUG???
@@ -5285,10 +5336,7 @@ void *TClass::NewArray(Long_t nElements, void *arena, ENewType defConstructor) c
          // use the streamer info to destroy them.
       }
 
-      // Register the object for special handling in the destructor.
-      if (p) {
-         RegisterAddressInRepository("TClass::NewArray with placement",p,this);
-      }
+      return p;
    } else {
       Error("NewArray with placement", "This cannot happen!");
    }
@@ -5410,6 +5458,22 @@ void TClass::Destructor(void *obj, Bool_t dtorOnly)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Explicitly call destructor for object.
+
+void TClass::Destructor(TClass::ObjectPtr obj, Bool_t dtorOnly)
+{
+   // Do nothing if passed a null pointer.
+   if (obj.GetPtr() == 0)
+      return;
+
+   if (obj.GetAllocator()) {
+      obj.GetAllocator()->Destructor(obj.GetPtr(), dtorOnly);
+   } else {
+      Destructor(obj.GetPtr(), dtorOnly);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Explicitly call operator delete[] for an array.
 
 void TClass::DeleteArray(void *ary, Bool_t dtorOnly)
@@ -5464,6 +5528,7 @@ void TClass::DeleteArray(void *ary, Bool_t dtorOnly)
                objVer = iter->second;
                if (objVer == fClassVersion) {
                   currentVersion = kTRUE;
+                  break;
                }
             }
          }
@@ -5515,6 +5580,21 @@ void TClass::DeleteArray(void *ary, Bool_t dtorOnly)
       }
    } else {
       Error("DeleteArray", "This cannot happen! (class '%s')", GetName());
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Explicitly call operator delete[] for an array.
+
+void TClass::DeleteArray(TClass::ObjectPtr obj, Bool_t dtorOnly)
+{
+   // Do nothing if passed a null pointer.
+   if (obj.GetPtr() == 0) return;
+
+   if (obj.GetAllocator()) {
+      obj.GetAllocator()->DeleteArray(obj.GetPtr(), dtorOnly);
+   } else {
+      DeleteArray(obj.GetPtr(), dtorOnly);
    }
 }
 

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -64,11 +64,23 @@ public:
    // Virtual in-place constructor
    virtual void* New(void* memory)   const {  return new(memory) Cont_t; }
 
+   // Virtual constructor
+   virtual TClass::ObjectPtr NewObject()   const             {  return {new Cont_t, nullptr};         }
+
+   // Virtual in-place constructor
+   virtual TClass::ObjectPtr NewObject(void* memory)   const {  return {new(memory) Cont_t, nullptr}; }
+
    // Virtual array constructor
    virtual void* NewArray(Int_t nElements)   const             {  return new Cont_t[nElements];         }
 
    // Virtual in-place constructor
    virtual void* NewArray(Int_t nElements, void* memory)   const {  return new(memory) Cont_t[nElements]; }
+
+   // Virtual array constructor
+   virtual TClass::ObjectPtr NewObjectArray(Int_t nElements)   const             {  return {new Cont_t[nElements], nullptr};         }
+
+   // Virtual in-place constructor
+   virtual TClass::ObjectPtr NewObjectArray(Int_t nElements, void* memory)   const {  return {new(memory) Cont_t[nElements], nullptr}; }
 
    // Virtual destructor
    virtual void  Destructor(void* p, Bool_t dtorOnly = kFALSE) const;

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -106,7 +106,6 @@ private:
    Version_t         fOldVersion;        ///<! Version of the TStreamerInfo object read from the file
    Int_t             fNVirtualInfoLoc;   ///<! Number of virtual info location to update.
    ULong_t          *fVirtualInfoLoc;    ///<![fNVirtualInfoLoc] Location of the pointer to the TStreamerInfo inside the object (when emulated)
-   std::atomic<ULong_t> fLiveCount;      ///<! Number of outstanding pointer to this StreamerInfo.
    TStreamerInfoActions::TActionSequence *fReadObjectWise;        ///<! List of read action resulting from the compilation.
    TStreamerInfoActions::TActionSequence *fReadMemberWise;        ///<! List of read action resulting from the compilation for use in member wise streaming.
    TStreamerInfoActions::TActionSequence *fReadMemberWiseVecPtr;  ///<! List of read action resulting from the compilation for use in member wise streaming.

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -161,7 +161,6 @@ TStreamerInfo::TStreamerInfo()
    fOldVersion = Class()->GetClassVersion();
    fNVirtualInfoLoc = 0;
    fVirtualInfoLoc = 0;
-   fLiveCount = 0;
 
    fReadObjectWise = 0;
    fReadMemberWise = 0;
@@ -196,7 +195,6 @@ TStreamerInfo::TStreamerInfo(TClass *cl)
    fOldVersion = Class()->GetClassVersion();
    fNVirtualInfoLoc = 0;
    fVirtualInfoLoc = 0;
-   fLiveCount = 0;
 
    fReadObjectWise = 0;
    fReadMemberWise = 0;
@@ -4815,7 +4813,6 @@ void* TStreamerInfo::New(void *obj)
    for(int nbase = 0; nbase < fNVirtualInfoLoc; ++nbase) {
       *(TStreamerInfo**)(p + fVirtualInfoLoc[nbase]) = this;
    }
-   ++fLiveCount;
    return p;
 }
 
@@ -4996,7 +4993,6 @@ void TStreamerInfo::DestructorImpl(void* obj, Bool_t dtorOnly)
    if (!dtorOnly) {
       delete[] p;
    }
-   --fLiveCount;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/src/TStreamerInfoWriteBuffer.cxx
+++ b/io/io/src/TStreamerInfoWriteBuffer.cxx
@@ -513,7 +513,6 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
 
                   UInt_t pos = b.WriteVersionMemberWise(this->IsA(),kTRUE);
                   b.WriteVersion( vClass, kFALSE );
-                  TStreamerInfo *subinfo = (TStreamerInfo*)vClass->GetStreamerInfo();
                   DOLOOP {
                      char **contp = (char**)(arr[k]+ioffset);
                      for(int j=0;j<compinfo[i]->fLength;++j) {
@@ -521,7 +520,22 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
                         TVirtualCollectionProxy::TPushPop helper( proxy, cont );
                         Int_t nobjects = cont ? proxy->Size() : 0;
                         b << nobjects;
-                        subinfo->WriteBufferSTL(b,proxy,nobjects);
+                        if (nobjects) {
+                           auto actions = proxy->GetWriteMemberWiseActions();
+
+                           char startbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                           char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                           void *begin = &(startbuf[0]);
+                           void *end = &(endbuf[0]);
+                           proxy->GetFunctionCreateIterators()(cont, &begin, &end, proxy);
+                           // We can not get here with a split vector of pointer, so we can indeed assume
+                           // that actions->fConfiguration != null.
+                           b.ApplySequence(*actions, begin, end);
+                           if (begin != &(startbuf[0])) {
+                              // assert(end != endbuf);
+                              proxy->GetFunctionDeleteTwoIterators()(begin,end);
+                           }
+                        }
                      }
                   }
                   b.SetByteCount(pos,kTRUE);
@@ -559,7 +573,6 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
 
                   UInt_t pos = b.WriteVersionMemberWise(this->IsA(),kTRUE);
                   b.WriteVersion( vClass, kFALSE );
-                  TStreamerInfo *subinfo = (TStreamerInfo*)vClass->GetStreamerInfo();
                   DOLOOP {
                      char *obj = (char*)(arr[k]+ioffset);
                      Int_t n = compinfo[i]->fLength;
@@ -570,7 +583,22 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
                         TVirtualCollectionProxy::TPushPop helper( proxy, obj );
                         Int_t nobjects = proxy->Size();
                         b << nobjects;
-                        subinfo->WriteBufferSTL(b,proxy,nobjects);
+                        if (nobjects) {
+                           auto actions = proxy->GetWriteMemberWiseActions();
+
+                           char startbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                           char endbuf[TVirtualCollectionProxy::fgIteratorArenaSize];
+                           void *begin = &(startbuf[0]);
+                           void *end = &(endbuf[0]);
+                           proxy->GetFunctionCreateIterators()(obj, &begin, &end, proxy);
+                           // We can not get here with a split vector of pointer, so we can indeed assume
+                           // that actions->fConfiguration != null.
+                           b.ApplySequence(*actions, begin, end);
+                           if (begin != &(startbuf[0])) {
+                              // assert(end != endbuf);
+                              proxy->GetFunctionDeleteTwoIterators()(begin,end);
+                           }
+                        }
                      }
                   }
                   b.SetByteCount(pos,kTRUE);

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -5415,7 +5415,8 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
       if (fBranchOffset[i] != TStreamerInfo::kMissing && !(implied && abranch->TestBit(kAddressSet))) {
          abranch->SetAddressImpl(fObject + fBranchOffset[i], implied);
          abranch->SetBit(kAddressSet);
-         abranch->SetMakeClass(TestBit(kDecomposedObj));
+         if (TestBit(kDecomposedObj) != abranch->TestBit(kDecomposedObj))
+            abranch->SetMakeClass(TestBit(kDecomposedObj));
       } else {
          // When the member is missing, just leave the address alone
          // (since setting explicitly to 0 would trigger error/warning


### PR DESCRIPTION
Reached milestone in improving the thread scaling in Chris’ threaded-io benchmark.  As it stands, the runtime is 30% better in single thread (this is because the writing part of ROOT I/O is exercised by this example but it has not yet been as optimized as the reading part of the ROOT I/O library) and is 5.4 times better with 32 threads.  Previously the 32 threads case was running at only 20% of the theoretical maximum (i.e. assuming complete linearity), it now runs at 70% (“fun” fact before the improvement that gave most of the boost to the scalar performance, that number had reached 80%).
