### PR TITLE
Avoid calling TTree::ChangeFile if file is TMemFile

### DIFF
--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -229,3 +229,58 @@ TEST(TBufferMerger, CheckTreeFillResults)
    RemoveFile("tbuffermerger_sequential.root");
    RemoveFile("tbuffermerger_parallel.root");
 }
+
+/**
+ * \test TBufferMerger, SetMaxTreeSize
+ * \brief Test to avoid issue #6523.
+ * 
+ * `TTree`'s default behaviour of changing the file it is attached to when reaching
+ * a size greater than `fgMaxTreeSize` doesn't fit in the design of TBufferMerger.
+ * The `TTree::Fill` method has been modified accordingly, avoiding this behaviour
+ * when the tree is attached to a TMemFile (thus also a TBufferMergerFile). This
+ * test tries to trigger the behaviour forcedly by calling `TTree::SetMaxTreeSize`
+ * but the TBufferMergerFile is never detached from the tree.
+ */
+TEST(TBufferMerger, SetMaxTreeSize)
+{
+   ROOT::EnableThreadSafety();
+
+   {
+      ROOT::Experimental::TBufferMerger merger{"tbuffermerger_setmaxtreesize.root"};
+
+      auto tbmfile = merger.GetFile(); // std::shared_ptr<TBufferMergerFile>
+
+      int nentries{20000};
+      int maxtreesize{1000};
+
+      TTree tree{"T", "SetMaxTreeSize(1000)"};
+      tree.SetMaxTreeSize(maxtreesize);
+
+      Fill(&tree, 0, nentries);
+
+      tbmfile->Write();
+   }
+
+   EXPECT_TRUE(FileExists("tbuffermerger_setmaxtreesize.root"));
+
+   {
+      TFile f{"tbuffermerger_setmaxtreesize.root"};
+      std::unique_ptr<TTree> t{f.Get<TTree>("T")};
+
+      EXPECT_EQ(t->GetEntries(), 20000);
+
+      int sum{0};
+      int n{0};
+      t->SetBranchAddress("n", &n);
+
+      for (auto i = 0; i < t->GetEntries(); i++) {
+         t->GetEntry(i);
+         sum += n;
+      }
+
+      // sum(range(20000)) == 199990000
+      EXPECT_EQ(sum, 199990000);
+   }
+
+   RemoveFile("tbuffermerger_setmaxtreesize.root");
+}

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -13,6 +13,7 @@
 #include "TInterpreter.h"
 #include "TROOT.h" // IsImplicitMTEnabled
 #include "TTreeReader.h"
+#include "TTree.h" // For MaxTreeSizeRAII. Revert when #6640 will be solved.
 
 #ifdef R__USE_IMT
 #include "ROOT/TThreadExecutor.hxx"
@@ -29,6 +30,7 @@
 #include <unordered_map>
 #include <vector>
 #include <set>
+#include <limits> // For MaxTreeSizeRAII. Revert when #6640 will be solved.
 
 using namespace ROOT::Detail::RDF;
 using namespace ROOT::Internal::RDF;
@@ -202,6 +204,25 @@ static void ThrowIfNSlotsChanged(unsigned int nSlots)
       throw std::runtime_error(msg);
    }
 }
+
+/**
+\struct MaxTreeSizeRAII
+\brief Scope-bound change of `TTree::fgMaxTreeSize`.
+
+This RAII object stores the current value result of `TTree::GetMaxTreeSize`,
+changes it to maximum at construction time and restores it back at destruction
+time. Needed for issue #6523 and should be reverted when #6640 will be solved.
+*/
+struct MaxTreeSizeRAII {
+   Long64_t fOldMaxTreeSize;
+
+   MaxTreeSizeRAII() : fOldMaxTreeSize(TTree::GetMaxTreeSize())
+   {
+      TTree::SetMaxTreeSize(std::numeric_limits<Long64_t>::max());
+   }
+
+   ~MaxTreeSizeRAII() { TTree::SetMaxTreeSize(fOldMaxTreeSize); }
+};
 
 } // anonymous namespace
 
@@ -553,6 +574,9 @@ void RLoopManager::EvalChildrenCounts()
 /// Also perform a few setup and clean-up operations (jit actions if necessary, clear booked actions after the loop...).
 void RLoopManager::Run()
 {
+   // Change value of TTree::GetMaxTreeSize only for this scope. Revert when #6640 will be solved.
+   MaxTreeSizeRAII ctxtmts;
+
    ThrowIfNSlotsChanged(GetNSlots());
 
    Jit();

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -6,6 +6,7 @@
 #include "TSystem.h"
 #include <TInterpreter.h>
 #include "TTree.h"
+#include "TChain.h"
 #include "gtest/gtest.h"
 #include <limits>
 #include <memory>
@@ -1034,6 +1035,74 @@ TEST(RDFSnapshotMore, ForbiddenOutputFilenameMT)
    // "SysError in <TFile::TFile>: file /definitely/not/a/valid/path/f.root can not be opened No such file or directory\nError in <TReentrantRWLock::WriteUnLock>: Write lock already released for 0x55f179989378\n"
    // but the address printed changes every time
    EXPECT_THROW(df.Snapshot("t", out_fname, {"rdfslot_"}), std::runtime_error);
+}
+
+/**
+ * Test against issue #6523 and #6640
+ * Try to force `TTree::ChangeFile` behaviour. Within RDataFrame, this should
+ * not happen and both sequential and multithreaded Snapshot should only create
+ * one file.
+ */
+TEST(RDFSnapshotMore, SetMaxTreeSizeMT)
+{
+   // Set TTree max size to a low number. Normally this would trigger the
+   // behaviour of TTree::ChangeFile, but not within RDataFrame.
+   auto old_maxtreesize{TTree::GetMaxTreeSize()};
+   TTree::SetMaxTreeSize(1000);
+
+   // Create TTree, fill it and Snapshot (should create one single file).
+   {
+      TTree t{"T", "SetMaxTreeSize(1000)"};
+      int x{};
+      auto nentries{20000};
+
+      t.Branch("x", &x, "x/I");
+
+      for (auto i = 0; i < nentries; i++) {
+         x = i;
+         t.Fill();
+      }
+
+      ROOT::RDataFrame df{t};
+      df.Snapshot<Int_t>("T", "rdfsnapshot_ttree_sequential_setmaxtreesize.root", {"x"});
+   }
+
+   // Create an RDF from the previously snapshotted file, then Snapshot again
+   // with IMT enabled.
+   {
+      ROOT::EnableImplicitMT();
+
+      ROOT::RDataFrame df{"T", "rdfsnapshot_ttree_sequential_setmaxtreesize.root"};
+      df.Snapshot<Int_t>("T", "rdfsnapshot_imt_setmaxtreesize.root", {"x"});
+
+      ROOT::DisableImplicitMT();
+   }
+
+   // Check the file for data integrity.
+   {
+      TFile f{"rdfsnapshot_imt_setmaxtreesize.root"};
+      std::unique_ptr<TTree> t{f.Get<TTree>("T")};
+
+      EXPECT_EQ(t->GetEntries(), 20000);
+
+      int sum{0};
+      int x{0};
+      t->SetBranchAddress("x", &x);
+
+      for (auto i = 0; i < t->GetEntries(); i++) {
+         t->GetEntry(i);
+         sum += x;
+      }
+
+      // sum(range(20000)) == 199990000
+      EXPECT_EQ(sum, 199990000);
+   }
+
+   gSystem->Unlink("rdfsnapshot_ttree_sequential_setmaxtreesize.root");
+   gSystem->Unlink("rdfsnapshot_imt_setmaxtreesize.root");
+
+   // Reset TTree max size to its old value
+   TTree::SetMaxTreeSize(old_maxtreesize);
 }
 
 #endif // R__USE_IMT

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -2679,27 +2679,26 @@ TStreamerInfo* TTree::BuildStreamerInfo(TClass* cl, void* pointer /* = 0 */, Boo
 /// If the current file contains other objects like TH1 and TTree,
 /// these objects are automatically moved to the new file.
 ///
-/// IMPORTANT NOTE:
-///
-/// Be careful when writing the final Tree header to the file!
-///
-/// Don't do:
+/// \warning Be careful when writing the final Tree header to the file!
+///      Don't do:
 /// ~~~ {.cpp}
 ///     TFile *file = new TFile("myfile.root","recreate");
 ///     TTree *T = new TTree("T","title");
-///     T->Fill(); //loop
+///     T->Fill(); // Loop
 ///     file->Write();
 ///     file->Close();
 /// ~~~
-/// but do the following:
+/// \warning but do the following:
 /// ~~~ {.cpp}
 ///     TFile *file = new TFile("myfile.root","recreate");
 ///     TTree *T = new TTree("T","title");
-///     T->Fill(); //loop
-///     file = T->GetCurrentFile(); //to get the pointer to the current file
+///     T->Fill(); // Loop
+///     file = T->GetCurrentFile(); // To get the pointer to the current file
 ///     file->Write();
 ///     file->Close();
 /// ~~~
+///
+/// \note This method is never called if the input file is a `TMemFile` or derivate.
 
 TFile* TTree::ChangeFile(TFile* file)
 {
@@ -4522,9 +4521,14 @@ void TTree::DropBuffers(Int_t)
 /// Note that the user can decide to call FlushBaskets and AutoSave in her event loop
 /// base on the number of events written instead of the number of bytes written.
 ///
-/// Note that calling FlushBaskets too often increases the IO time.
+/// \note Calling `TTree::FlushBaskets` too often increases the IO time. 
+/// 
+/// \note Calling `TTree::AutoSave` too often increases the IO time and also the
+///       file size.
 ///
-/// Note that calling AutoSave too often increases the IO time and also the file size.
+/// \note This method calls `TTree::ChangeFile` when the tree reaches a size
+///       greater than `TTree::fgMaxTreeSize`. This doesn't happen if the tree is
+///       attached to a `TMemFile` or derivate.
 
 Int_t TTree::Fill()
 {
@@ -4705,6 +4709,7 @@ Int_t TTree::Fill()
    if (fDirectory)
       if (TFile *file = fDirectory->GetFile())
          if (static_cast<TDirectory *>(file) == fDirectory && (file->GetEND() > fgMaxTreeSize))
+            // Changing file clashes with the design of TMemFile and derivates, see #6523.
             if (!(dynamic_cast<TMemFile *>(file)))
                ChangeFile(file);
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -392,6 +392,7 @@ End_Macro
 #include "TLeafS.h"
 #include "TList.h"
 #include "TMath.h"
+#include "TMemFile.h"
 #include "TROOT.h"
 #include "TRealData.h"
 #include "TRegexp.h"
@@ -4703,8 +4704,9 @@ Int_t TTree::Fill()
    // to the case where the tree is in the top level directory.
    if (fDirectory)
       if (TFile *file = fDirectory->GetFile())
-         if ((TDirectory *)file == fDirectory && (file->GetEND() > fgMaxTreeSize))
-            ChangeFile(file);
+         if (static_cast<TDirectory *>(file) == fDirectory && (file->GetEND() > fgMaxTreeSize))
+            if (!(dynamic_cast<TMemFile *>(file)))
+               ChangeFile(file);
 
    return nerror == 0 ? nbytes : -1;
 }


### PR DESCRIPTION
Fixes #6523 .

As per comments by Philippe and Guilherme, the behaviour triggered by `TTree::Fill` to change the associated TFile when reaching a size greater than `fgMaxTreeSize` doesn't fit within the scope of TBufferMerger. Avoid calling `TTree::ChangeFile` doesn't change anything from the user perspective and doesn't interfere with the I/O mechanism of TBufferMerger (and thus of the multithreaded RDF Snapshot as well). 

While fixing the above issue I found another one that may be related to this. Meanwhile the draft can be discussed.

TODO
- [x] Update docs in TTree::Fill, TTree::ChangeFile and TBufferMerger. Tell the users that TBufferMergerFile doesn't trigger this behaviour
- [x] Include the reproducer as test