### PR TITLE
[cmake] Add NDEBUG to CMAKE_CXX_FLAGS_${BUILD_TYPE}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,8 @@ include(CheckIntrinsics)
 
 #---Enable asserts------------------------------------------------------------------------------
 if(NOT asserts)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNDEBUG")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNDEBUG")
+  set(CMAKE_CXX_FLAGS_${BUILD_TYPE} "${CMAKE_CXX_FLAGS_${BUILD_TYPE}} -DNDEBUG")
+  set(CMAKE_C_FLAGS_${BUILD_TYPE} "${CMAKE_C_FLAGS_${BUILD_TYPE}} -DNDEBUG")
 endif()
 
 #---Enable CCache ------------------------------------------------------------------------------


### PR DESCRIPTION
Otherwise roottest will pick up in the standalone mode the NDEBUG
flag twice and fail due to a redefinition. This failure shows up
in the conda builds.