### PR TITLE
[PyROOT] Backport: Install missing header TPyDispatcher.h

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -20,6 +20,9 @@ if(dataframe)
         inc/RNumpyDS.hxx)
 endif()
 
+list(APPEND PYROOT_EXTRA_HEADERS
+     inc/TPyDispatcher.h)
+
 set(py_sources
   ROOT/__init__.py
   ROOT/_application.py


### PR DESCRIPTION
Backport of the TPyDispatcher.h fix in https://github.com/root-project/root/pull/6588