### PR TITLE
[DF] Jit and exec Cache together with the rest

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -641,8 +641,11 @@ public:
          cacheCall.seekp(-2, cacheCall.cur);                         // remove the last ",
       cacheCall << ">(*reinterpret_cast<std::vector<std::string>*>(" // vector<string> should be ColumnNames_t
                 << RDFInternal::PrettyPrintAddr(&columnList) << "));";
-      // jit cacheCall, return result
-      RDFInternal::InterpreterCalc(cacheCall.str(), "Cache");
+
+      // book the code to jit with the RLoopManager and trigger the event loop
+      fLoopManager->ToJitExec(cacheCall.str());
+      fLoopManager->Jit();
+
       return resRDF;
    }
 


### PR DESCRIPTION
Before this commit, a Cache call without template parameters would
trigger jitting and execution of the corresponding typed Cache call
on the spot, separately from the rest of RDF's jitting.

With these changes the code needed by Cache is merged with the rest of
the code booked for jitting. Jitting is then triggered on the spot,
because a jitted Cache call needs the jitted code to produce its return
value.

This resolves the Cache-related part of ROOT-9790, "Lazy jitting of
Cache and Snapshot".