### PR TITLE
Remove the CACHE & FORCE when setting the CMAKE_CXX_FLAGS_<CONFIG> on…

### DIFF
--- a/cmake/modules/SetUpWindows.cmake
+++ b/cmake/modules/SetUpWindows.cmake
@@ -50,12 +50,12 @@ elseif(MSVC)
   endif()
 
   #---Select compiler flags----------------------------------------------------------------
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -Z7"          CACHE STRING "Flags for release build with debug info" FORCE)
-  set(CMAKE_CXX_FLAGS_RELEASE        "-O2"              CACHE STRING "Flags for release build" FORCE)
-  set(CMAKE_CXX_FLAGS_DEBUG          "-Od -Z7"          CACHE STRING "Flags for a debug build" FORCE)
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -Z7"          CACHE STRING "Flags for release build with debug info" FORCE)
-  set(CMAKE_C_FLAGS_RELEASE          "-O2"              CACHE STRING "Flags for release build" FORCE)
-  set(CMAKE_C_FLAGS_DEBUG            "-Od -Z7"          CACHE STRING "Flags for a debug build" FORCE)
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -Z7")
+  set(CMAKE_CXX_FLAGS_RELEASE        "-O2")
+  set(CMAKE_CXX_FLAGS_DEBUG          "-Od -Z7")
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -Z7")
+  set(CMAKE_C_FLAGS_RELEASE          "-O2")
+  set(CMAKE_C_FLAGS_DEBUG            "-Od -Z7")
 
   #---Set Linker flags----------------------------------------------------------------------
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -ignore:4049,4206,4217,4221 -incremental:no")


### PR DESCRIPTION
… Windows

This was breaking the Windows build with the following error:
```
[2020-10-08T10:19:28.238Z] axis.obj : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT '??$?8DU?$char_traits@D@std@@@__ROOT@experimental@std@@YA_NV?$basic_string_view@DU?$char_traits@D@std@@@012@0@Z' [C:\build\workspace\root-pullrequests-build\build\hist\histv7\test\histhistv7testUnit.vcxproj]
```
On Windows (well, multi-configuration generators) we need to change those flags in different places, hence we must not have `CACHE` and `FORCE`.