### PR TITLE
[PyROOT][6467] Backport 622: For Python-C++ derived types, invoke constructor via the dispatcher

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
@@ -185,8 +185,7 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* dct)
 // sure the python object is properly carried, but they can only be generated
 // if the base class supports them
     if (has_default || !has_constructors)
-        code << "  " << derivedName << "() {}\n"
-             << "  " << derivedName << "(PyObject* pyobj) : m_self(pyobj) {}\n";
+        code << "  " << derivedName << "() {}\n";
     if (has_default || has_cctor || !has_constructors) {
         code << "  " << derivedName << "(const " << derivedName << "& other) : ";
         if (has_cctor)


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/6582