### PR TITLE
[Tree] Add support for branches of type long and unsigned long

### DIFF
--- a/documentation/users-guide/Trees.md
+++ b/documentation/users-guide/Trees.md
@@ -585,6 +585,8 @@ The symbols used for the type are:
 -   `i`: a 32 bit unsigned integer
 -   `L`: a 64 bit signed integer
 -   `l`: a 64 bit unsigned integer
+-   `G`: a long signed integer, stored as 64 bit
+-   `g`: a long unsigned integer, stored as 64 bit
 -   `F`: a 32 bit floating point
 -   `D`: a 64 bit floating point
 -   `O`: [the letter 'o', not a zero] a boolean (Bool\_t)

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -252,10 +252,14 @@ char TypeName2ROOTTypeName(const std::string &b)
       return 'F';
    if (b == "Double_t" || b == "double")
       return 'D';
-   if (b == "Long64_t" || b == "long" || b == "long int")
+   if (b == "Long64_t" || b == "long long" || b == "long long int")
       return 'L';
-   if (b == "ULong64_t" || b == "unsigned long" || b == "unsigned long int")
+   if (b == "ULong64_t" || b == "unsigned long long" || b == "unsigned long long int")
       return 'l';
+   if (b == "Long_t" || b == "long" || b == "long int")
+      return 'G';
+   if (b == "ULong_t" || b == "unsigned long" || b == "unsigned long int")
+      return 'g';
    if (b == "Bool_t" || b == "bool")
       return 'O';
    return ' ';

--- a/tree/tree/CMakeLists.txt
+++ b/tree/tree/CMakeLists.txt
@@ -46,6 +46,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Tree
     TLeaf.h
     TLeafI.h
     TLeafL.h
+    TLeafG.h
     TLeafObject.h
     TLeafO.h
     TLeafS.h
@@ -98,6 +99,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Tree
     src/TLeafF16.cxx
     src/TLeafI.cxx
     src/TLeafL.cxx
+    src/TLeafG.cxx
     src/TLeafObject.cxx
     src/TLeafO.cxx
     src/TLeafS.cxx

--- a/tree/tree/inc/LinkDef.h
+++ b/tree/tree/inc/LinkDef.h
@@ -46,6 +46,7 @@
 #pragma link C++ class TLeafI+;
 #pragma link C++ class TLeafS+;
 #pragma link C++ class TLeafL+;
+#pragma link C++ class TLeafG+;
 #pragma link C++ class TLeafO+;
 #pragma link C++ class TNtuple-;
 #pragma link C++ class TNtupleD-;

--- a/tree/tree/inc/TLeafG.h
+++ b/tree/tree/inc/TLeafG.h
@@ -1,0 +1,68 @@
+// @(#)root/tree:$Id$
+// Author: Enrico Guiraud
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TLeafG
+#define ROOT_TLeafG
+
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TLeafG                                                               //
+//                                                                      //
+// A TLeaf for a long integer data type.                                //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+
+#include "TLeaf.h"
+
+class TLeafG : public TLeaf {
+
+protected:
+   Long_t     fMinimum;       ///<  Minimum value if leaf range is specified
+   Long_t     fMaximum;       ///<  Maximum value if leaf range is specified
+   Long_t    *fValue;         ///<! Pointer to data buffer
+   Long_t   **fPointer;       ///<! Address of pointer to data buffer
+
+public:
+   TLeafG();
+   TLeafG(TBranch *parent, const char *name, const char *type);
+   virtual ~TLeafG();
+
+   virtual void    Export(TClonesArray *list, Int_t n);
+   virtual void    FillBasket(TBuffer &b);
+   const char     *GetTypeName() const;
+   virtual Int_t   GetMaximum() const { return (Int_t)fMaximum; }
+   virtual Int_t   GetMinimum() const { return (Int_t)fMinimum; }
+   virtual Double_t     GetValue(Int_t i=0) const;
+   virtual Long64_t     GetValueLong64(Int_t i = 0) const ;
+   virtual LongDouble_t GetValueLongDouble(Int_t i = 0) const;
+   virtual void   *GetValuePointer() const { return fValue; }
+   virtual Bool_t  IncludeRange(TLeaf *);
+   virtual void    Import(TClonesArray *list, Int_t n);
+   virtual void    PrintValue(Int_t i=0) const;
+   virtual void    ReadBasket(TBuffer &b);
+   virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
+   virtual bool    ReadBasketFast(TBuffer&, Long64_t);
+   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) { return GetDeserializeType() == DeserializeType::kInPlace; }
+   virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
+   virtual void    SetAddress(void *add=0);
+   virtual void    SetMaximum(Long_t max) {fMaximum = max;}
+   virtual void    SetMinimum(Long_t min) {fMinimum = min;}
+
+   ClassDef(TLeafG,1);  //A TLeaf for a long integer data type.
+};
+
+// if leaf is a simple type, i must be set to 0
+// if leaf is an array, i is the array element number to be returned
+inline Long64_t TLeafG::GetValueLong64(Int_t i) const { return fValue[i]; }
+
+#endif

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -158,6 +158,8 @@ TBranch::TBranch()
 ///            - `d` : a 24 bit truncated floating point (`Double32_t`)
 ///            - `L` : a 64 bit signed integer (`Long64_t`)
 ///            - `l` : a 64 bit unsigned integer (`ULong64_t`)
+///            - `G` : a long signed integer, stored as 64 bit (`Long_t`)
+///            - `g` : a long unsigned integer, stored as 64 bit (`ULong_t`)
 ///            - `O` : [the letter `o`, not a zero] a boolean (`Bool_t`)
 ///
 ///         Arrays of values are supported with the following syntax:

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -32,6 +32,7 @@
 #include "TLeafF16.h"
 #include "TLeafI.h"
 #include "TLeafL.h"
+#include "TLeafG.h"
 #include "TLeafO.h"
 #include "TLeafObject.h"
 #include "TLeafS.h"
@@ -389,6 +390,11 @@ void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
             leaf = new TLeafD(this, leafname, leaftype);
          } else if (*leaftype == 'd') {
             leaf = new TLeafD32(this, leafname, leaftype);
+         } else if (*leaftype == 'G') {
+            leaf = new TLeafG(this, leafname, leaftype);
+         } else if (*leaftype == 'g') {
+            leaf = new TLeafG(this, leafname, leaftype);
+            leaf->SetUnsigned();
          }
          if (!leaf) {
             Error("TLeaf", "Illegal data type for %s/%s", name, leaflist);

--- a/tree/tree/src/TLeafG.cxx
+++ b/tree/tree/src/TLeafG.cxx
@@ -1,0 +1,272 @@
+// @(#)root/tree:$Id$
+// Author: Enrico Guiraud
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/** \class TLeafG
+\ingroup tree
+
+A TLeaf for a 64 bit Integer data type.
+*/
+
+#include "TLeafG.h"
+#include "TBranch.h"
+#include "TBuffer.h"
+#include "TClonesArray.h"
+#include <iostream>
+
+ClassImp(TLeafG);
+
+////////////////////////////////////////////////////////////////////////////////
+/// Default constructor for LeafL.
+
+TLeafG::TLeafG(): TLeaf()
+{
+   fLenType = sizeof(Long_t);
+   fMinimum = 0;
+   fMaximum = 0;
+   fValue   = 0;
+   fPointer = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Create a LeafL.
+
+TLeafG::TLeafG(TBranch *parent, const char *name, const char *type)
+   :TLeaf(parent, name,type)
+{
+   fLenType = sizeof(Long_t);
+   fMinimum = 0;
+   fMaximum = 0;
+   fValue   = 0;
+   fPointer = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Default destructor for a LeafL.
+
+TLeafG::~TLeafG()
+{
+   if (ResetAddress(0,kTRUE)) delete [] fValue;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Export element from local leaf buffer to ClonesArray.
+
+void TLeafG::Export(TClonesArray *list, Int_t n)
+{
+   Long_t *value = fValue;
+   for (Int_t i=0;i<n;i++) {
+      char *first = (char*)list->UncheckedAt(i);
+      Long_t *ii = (Long_t*)&first[fOffset];
+      for (Int_t j=0;j<fLen;j++) {
+         ii[j] = value[j];
+      }
+      value += fLen;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Pack leaf elements in Basket output buffer.
+
+void TLeafG::FillBasket(TBuffer &b)
+{
+   Int_t i;
+   Int_t len = GetLen();
+   if (fPointer) fValue = *fPointer;
+   if (IsRange()) {
+      if (fValue[0] > fMaximum) fMaximum = fValue[0];
+   }
+   if (IsUnsigned()) {
+      for (i=0;i<len;i++) b << (ULong_t)fValue[i];
+   } else {
+      b.WriteFastArray(fValue,len);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns name of leaf type.
+
+const char *TLeafG::GetTypeName() const
+{
+   if (fIsUnsigned) return "ULong_t";
+   return "Long_t";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns current value of leaf.
+/// - if leaf is a simple type, i must be set to 0
+/// - if leaf is an array, i is the array element number to be returned
+
+Double_t TLeafG::GetValue(Int_t i) const
+{
+   if (fIsUnsigned) return (Double_t)((ULong_t)fValue[i]);
+   return fValue[i];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns current value of leaf
+/// - if leaf is a simple type, i must be set to 0
+/// - if leaf is an array, i is the array element number to be returned
+
+LongDouble_t TLeafG::GetValueLongDouble(Int_t i) const
+{
+   if (fIsUnsigned) return (LongDouble_t)((ULong_t)fValue[i]);
+   return fValue[i];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Copy/set fMinimum and fMaximum to include/be wide than those of the parameter
+
+Bool_t TLeafG::IncludeRange(TLeaf *input)
+{
+    if (input) {
+        if (input->GetMaximum() > this->GetMaximum())
+            this->SetMaximum( input->GetMaximum() );
+        if (input->GetMinimum() < this->GetMinimum())
+            this->SetMinimum( input->GetMinimum() );
+        return kTRUE;
+    } else {
+        return kFALSE;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Import element from ClonesArray into local leaf buffer.
+
+void TLeafG::Import(TClonesArray *list, Int_t n)
+{
+   const Int_t kIntUndefined = -9999;
+   Int_t j = 0;
+   char *clone;
+   for (Int_t i=0;i<n;i++) {
+      clone = (char*)list->UncheckedAt(i);
+      if (clone) memcpy(&fValue[j],clone + fOffset, 8*fLen);
+      else       memcpy(&fValue[j],&kIntUndefined,  8*fLen);
+      j += fLen;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Prints leaf value.
+
+void TLeafG::PrintValue(Int_t l) const
+{
+   if (fIsUnsigned) {
+      ULong_t *uvalue = (ULong_t*)GetValuePointer();
+      printf("%lu",uvalue[l]);
+   } else {
+      Long_t *value = (Long_t*)GetValuePointer();
+      printf("%ld",value[l]);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Read leaf elements from Basket input buffer.
+
+void TLeafG::ReadBasket(TBuffer &b)
+{
+   if (!fLeafCount && fNdata == 1) {
+      b.ReadLong(fValue[0]);
+   } else {
+      if (fLeafCount) {
+         Long64_t entry = fBranch->GetReadEntry();
+         if (fLeafCount->GetBranch()->GetReadEntry() != entry) {
+            fLeafCount->GetBranch()->GetEntry(entry);
+         }
+         Int_t len = Int_t(fLeafCount->GetValue());
+         if (len > fLeafCount->GetMaximum()) {
+            printf("ERROR leaf:%s, len=%d and max=%d\n",GetName(),len,fLeafCount->GetMaximum());
+            len = fLeafCount->GetMaximum();
+         }
+         fNdata = len*fLen;
+         b.ReadFastArray(fValue,len*fLen);
+      } else {
+         b.ReadFastArray(fValue,fLen);
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Deserialize input by performing byteswap as needed.
+bool TLeafG::ReadBasketFast(TBuffer& input_buf, Long64_t N)
+{
+   if (R__unlikely(fLeafCount)) {return false;}
+   return input_buf.ByteSwapBuffer(fLen*N, kLong_t);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Read leaf elements from Basket input buffer and export buffer to
+/// TClonesArray objects.
+
+void TLeafG::ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n)
+{
+   if (n*fLen == 1) {
+      b >> fValue[0];
+   } else {
+      b.ReadFastArray(fValue,n*fLen);
+   }
+   Long_t *value = fValue;
+   for (Int_t i=0;i<n;i++) {
+      char *first = (char*)list->UncheckedAt(i);
+      Long_t *ii = (Long_t*)&first[fOffset];
+      for (Int_t j=0;j<fLen;j++) {
+         ii[j] = value[j];
+      }
+      value += fLen;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Read a long integer from std::istream s and store it into the branch buffer.
+
+void TLeafG::ReadValue(std::istream &s, Char_t /*delim = ' '*/)
+{
+#if defined(_MSC_VER) && (_MSC_VER<1300)
+   printf("Due to a bug in VC++6, the function TLeafG::ReadValue is dummy\n");
+#else
+   if (fIsUnsigned) {
+      ULong_t *uvalue = (ULong_t*)GetValuePointer();
+      for (Int_t i=0;i<fLen;i++) s >> uvalue[i];
+   } else {
+      Long_t *value = (Long_t*)GetValuePointer();
+      for (Int_t i=0;i<fLen;i++) s >> value[i];
+   }
+#endif
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set leaf buffer data address.
+
+void TLeafG::SetAddress(void *add)
+{
+   if (ResetAddress(add) && (add!=fValue)) {
+      delete [] fValue;
+   }
+   if (add) {
+      if (TestBit(kIndirectAddress)) {
+         fPointer = (Long_t**) add;
+         Int_t ncountmax = fLen;
+         if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
+         if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
+             ncountmax > fNdata || *fPointer == 0) {
+            if (*fPointer) delete [] *fPointer;
+            if (ncountmax > fNdata) fNdata = ncountmax;
+            *fPointer = new Long_t[fNdata];
+         }
+         fValue = *fPointer;
+      } else {
+         fValue = (Long_t*)add;
+      }
+   } else {
+      fValue = new Long_t[fNdata];
+      fValue[0] = 0;
+   }
+}
+

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -98,6 +98,8 @@ It is strongly recommended to persistify those as objects rather than lists of l
    - `d` : a 24 bit truncated floating point (`Double32_t`)
    - `L` : a 64 bit signed integer (`Long64_t`)
    - `l` : a 64 bit unsigned integer (`ULong64_t`)
+   - `G` : a long signed integer, stored as 64 bit (`Long_t`)
+   - `g` : a long unsigned integer, stored as 64 bit (`ULong_t`)
    - `O` : [the letter `o`, not a zero] a boolean (`Bool_t`)
 
   Examples:
@@ -1930,6 +1932,8 @@ Int_t TTree::Branch(const char* foldername, Int_t bufsize /* = 32000 */, Int_t s
 ///         - `d` : a 24 bit truncated floating point (`Double32_t`)
 ///         - `L` : a 64 bit signed integer (`Long64_t`)
 ///         - `l` : a 64 bit unsigned integer (`ULong64_t`)
+///         - `G` : a long signed integer, stored as 64 bit (`Long_t`)
+///         - `g` : a long unsigned integer, stored as 64 bit (`ULong_t`)
 ///         - `O` : [the letter `o`, not a zero] a boolean (`Bool_t`)
 ///
 ///      Arrays of values are supported with the following syntax:

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -464,8 +464,8 @@ static char DataTypeToChar(EDataType datatype)
    case kDouble32_t: return 'd';
    case kFloat_t:    return 'F';
    case kFloat16_t:  return 'f';
-   case kLong_t:     return 0; // unsupported
-   case kULong_t:    return 0; // unsupported?
+   case kLong_t:     return 'G';
+   case kULong_t:    return 'g';
    case kchar:       return 0; // unsupported
    case kLong64_t:   return 'L';
    case kULong64_t:  return 'l';

--- a/tree/treeplayer/test/array.cxx
+++ b/tree/treeplayer/test/array.cxx
@@ -237,3 +237,35 @@ TEST(TTreeReaderArray, ROOT10397)
    EXPECT_EQ(xr.GetSize(), 7);
    EXPECT_EQ(zr.GetSize(), 13 - 7);
 }
+
+TEST(TTreeReaderArray, LongIntArray)
+{
+   const auto fname = "TTreeReaderArrayLongIntArray.root";
+   {
+      TFile f(fname, "recreate");
+      long int G[3] = {std::numeric_limits<long int>::min(), 42, std::numeric_limits<long int>::max()};
+      int size = 2;
+      unsigned long int *g = new unsigned long int[size];
+      g[0] = 42;
+      g[1] = std::numeric_limits<unsigned long int>::max();
+      TTree t("t", "t");
+      t.Branch("G", G, "G[3]/G");
+      t.Branch("n", &size);
+      t.Branch("g", g, "g[n]/g");
+      t.Fill();
+      t.Write();
+   }
+
+   TFile f(fname);
+   TTreeReader r("t", &f);
+   TTreeReaderArray<long int> rG(r, "G");
+   TTreeReaderArray<unsigned long int> rg(r, "g");
+   EXPECT_TRUE(r.Next());
+   ASSERT_EQ(rG.GetSize(), 3);
+   EXPECT_EQ(rG[0], std::numeric_limits<long int>::min());
+   EXPECT_EQ(rG[1], 42);
+   ASSERT_EQ(rg.GetSize(), 2);
+   EXPECT_EQ(rg[0], 42);
+   EXPECT_EQ(rg[1], std::numeric_limits<unsigned long int>::max());
+   EXPECT_FALSE(r.Next());
+}

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -24,6 +24,8 @@ TEST(TTreeReaderLeafs, LeafListCaseA) {
    double Double = 9.;
    long long SLL = 10;
    unsigned long long ULL = 11;
+   long SL = 12;
+   unsigned long UL = 13;
    bool Bool = true;
 
    auto tree = std::make_unique<TTree>("T", "In-memory test tree");
@@ -38,6 +40,8 @@ TEST(TTreeReaderLeafs, LeafListCaseA) {
    tree->Branch("D", &Double, "D/D");
    tree->Branch("L", &SLL, "L/L");
    tree->Branch("l", &ULL, "l/l");
+   tree->Branch("G", &SL, "G/G");
+   tree->Branch("g", &UL, "g/g");
    tree->Branch("O", &Bool, "O/O");
 
    tree->Fill();
@@ -56,6 +60,8 @@ TEST(TTreeReaderLeafs, LeafListCaseA) {
    TTreeReaderValue<double> trDouble(TR, "D");
    TTreeReaderValue<signed long long> trSLL(TR, "L");
    TTreeReaderValue<unsigned long long> trULL(TR, "l");
+   TTreeReaderValue<signed long> trSL(TR, "G");
+   TTreeReaderValue<unsigned long> trUL(TR, "g");
    TTreeReaderValue<bool> trBool(TR, "O");
 
    TR.SetEntry(1);
@@ -71,6 +77,8 @@ TEST(TTreeReaderLeafs, LeafListCaseA) {
    EXPECT_DOUBLE_EQ(Double, *trDouble);
    EXPECT_EQ(SLL, *trSLL);
    EXPECT_EQ(ULL, *trULL);
+   EXPECT_EQ(SL, *trSL);
+   EXPECT_EQ(UL, *trUL);
    EXPECT_EQ(Bool, *trBool);
 }
 


### PR DESCRIPTION
The corresponding leaflist letters are 'G' and 'g'.
A new class TLeafG is added -- basically a copy of TLeafL with
[U]Long64_t changed to [U]Long_t.

This fixes ROOT-8885, "Cannot create a branch of long, unsigned long,
std::size_t types".

For review convenience, I attach the diffs betwen `TLeafL.{h,cxx}` and `TLeafG.{h,cxx}`:
- [TLeafLGh.diff](https://github.com/root-project/root/files/5355689/TLeafLGh.txt)
- [TLeafLGcxx.diff](https://github.com/root-project/root/files/5355684/TLeafLGcxx.txt)

@Axel-Naumann `TTreeReader` seems to deal with long integers just fine. Nothing to do there, right?

~~@pcanal where can I add tests?~~

- [x] add tests in tree/treeplayer/test/leafs.cxx
- [x] update `TypeName2ROOTTypeName` in `tree/dataframe/src/RDFUtils.cxx`
- [x] update doc of class TTree
- [x] update doc of `TBranch::TBranch(TTree *tree, const char *name, void *address, const char *leaflist, Int_t basketsize, Int_t compress)`
- [x] update doc of `TBranch* TTree::Branch(const char* name, void* address, const char* leaflist, Int_t bufsize /* = 32000 */)`
- [x] update user's guide: documentation/users-guide/Trees.md