### PR TITLE
[cling] Use the dyld to show more meaningful message when a symbol is missing

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1605,7 +1605,8 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       cling::DynamicLibraryManager& DLM = *fInterpreter->getDynamicLibraryManager();
       // Make sure cling looks into ROOT's libdir, even if not part of LD_LIBRARY_PATH
       // e.g. because of an RPATH build.
-      DLM.addSearchPath(TROOT::GetLibDir().Data());
+      DLM.addSearchPath(TROOT::GetLibDir().Data(), /*isUser=*/true,
+                        /*prepend=*/true);
       auto ShouldPermanentlyIgnore = [](llvm::StringRef FileName) -> bool{
          llvm::StringRef stem = llvm::sys::path::stem(FileName);
          return stem.startswith("libNew") || stem.startswith("libcppyy_backend");

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1926,10 +1926,7 @@ bool TCling::RegisterPrebuiltModulePath(const std::string &FullPath,
       llvm::sys::path::append(ModuleMapFileName, ModuleMapName);
       const FileEntry *FE = FM.getFile(ModuleMapFileName, /*openFile*/ false,
                                        /*CacheFailure*/ false);
-
-      // FIXME: Calling IsLoaded is slow! Replace this with the appropriate
-      // call to the clang::ModuleMap class.
-      if (FE && !this->IsLoaded(FE->getName().data())) {
+      if (FE) {
          if (!HS.loadModuleMapFile(FE, /*IsSystem*/ false))
             return true;
          Error("RegisterPrebuiltModulePath", "Could not load modulemap in %s", ModuleMapFileName.c_str());

--- a/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
@@ -20,7 +20,6 @@
 namespace cling {
   class Dyld;
   class InterpreterCallbacks;
-  class InvocationOptions;
 
   ///\brief A helper class managing dynamic shared objects.
   ///
@@ -59,10 +58,6 @@ namespace cling {
     DyLibs m_DyLibs;
     llvm::StringSet<> m_LoadedLibraries;
 
-    ///\brief Contains the list of the current include paths.
-    ///
-    const InvocationOptions& m_Opts;
-
     ///\brief System's include path, get initialized at construction time.
     ///
     SearchPathInfos m_SearchPaths;
@@ -95,7 +90,7 @@ namespace cling {
     ///
     static std::string getSymbolLocation(void* func);
   public:
-    DynamicLibraryManager(const InvocationOptions& Opts);
+    DynamicLibraryManager();
     ~DynamicLibraryManager();
     DynamicLibraryManager(const DynamicLibraryManager&) = delete;
     DynamicLibraryManager& operator=(const DynamicLibraryManager&) = delete;
@@ -112,8 +107,10 @@ namespace cling {
        return m_SearchPaths;
     }
 
-    void addSearchPath(llvm::StringRef dir) {
-      m_SearchPaths.emplace_back(SearchPathInfo{dir, /*IsUser*/ true});
+    void addSearchPath(llvm::StringRef dir, bool isUser = true,
+                       bool prepend = false) {
+      auto pos = prepend ? m_SearchPaths.begin() : m_SearchPaths.end();
+      m_SearchPaths.insert(pos, SearchPathInfo{dir, isUser});
     }
 
     ///\brief Looks up a library taking into account the current include paths
@@ -163,6 +160,8 @@ namespace cling {
     ///
     std::string searchLibrariesForSymbol(const std::string& mangledName,
                                          bool searchSystem = true) const;
+
+    void dump(llvm::raw_ostream* S = nullptr) const;
 
     /// On a success returns to full path to a shared object that holds the
     /// symbol pointed by func.

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -201,10 +201,6 @@ namespace cling {
     ///
     std::unique_ptr<InterpreterCallbacks> m_Callbacks;
 
-    ///\brief Dynamic library manager object.
-    ///
-    std::unique_ptr<DynamicLibraryManager> m_DyLibManager;
-
     ///\brief Information about the last stored states through .storeState
     ///
     mutable std::vector<ClangInternalState*> m_StoredStates;
@@ -442,7 +438,13 @@ namespace cling {
     ///
     ///\param[in] S - stream to dump to or nullptr for default (cling::outs)
     ///
-    void DumpIncludePath(llvm::raw_ostream* S = nullptr);
+    void DumpIncludePath(llvm::raw_ostream* S = nullptr) const;
+
+    ///\brief Prints the current library paths and loaded libraries.
+    ///
+    ///\param[in] S - stream to dump to or nullptr for default (cling::outs)
+    ///
+    void DumpDynamicLibraryInfo(llvm::raw_ostream* S = nullptr) const;
 
     ///\brief Dump various internal data.
     ///
@@ -726,12 +728,8 @@ namespace cling {
     const InterpreterCallbacks* getCallbacks() const {return m_Callbacks.get();}
     InterpreterCallbacks* getCallbacks() { return m_Callbacks.get(); }
 
-    const DynamicLibraryManager* getDynamicLibraryManager() const {
-      return m_DyLibManager.get();
-    }
-    DynamicLibraryManager* getDynamicLibraryManager() {
-      return m_DyLibManager.get();
-    }
+    const DynamicLibraryManager* getDynamicLibraryManager() const;
+    DynamicLibraryManager* getDynamicLibraryManager();
 
     const Transaction* getFirstTransaction() const;
     const Transaction* getLastTransaction() const;

--- a/interpreter/cling/include/cling/MetaProcessor/MetaParser.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaParser.h
@@ -33,7 +33,7 @@ namespace cling {
   //                            HelpCommand | FileExCommand | FilesCommand |
   //                            ClassCommand | GCommand | StoreStateCommand |
   //                            CompareStateCommand | StatsCommand | undoCommand
-  //                 LCommand := 'L' FilePath
+  //                 LCommand := 'L' [FilePath]
   //                 TCommand := 'T' FilePath FilePath
   //                 >Command := '>' FilePath
   //                 qCommand := 'q'

--- a/interpreter/cling/include/cling/MetaProcessor/MetaSema.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaSema.h
@@ -59,7 +59,8 @@ namespace cling {
     const Interpreter& getInterpreter() const { return m_Interpreter; }
     bool isQuitRequested() const { return m_IsQuitRequested; }
 
-    ///\brief L command includes the given file or loads the given library.
+    ///\brief L command includes the given file or loads the given library. If
+    /// \c file is empty print the list of library paths.
     ///
     ///\param[in] file - The file/library to be loaded.
     ///\param[out] transaction - Transaction containing the loaded file.
@@ -139,7 +140,8 @@ namespace cling {
     ActionResult actOnUCommand(llvm::StringRef file);
 
     ///\brief Actions to be performed on add include path. It registers new
-    /// folder where header files can be searched.
+    /// folder where header files can be searched. If \c path is empty print the
+    /// list of include paths.
     ///
     ///\param[in] path - The path to add to header search.
     ///

--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -117,6 +117,17 @@ namespace {
 
 char UniqueCUDAStructorName::ID = 0;
 
+BackendPasses::BackendPasses(const clang::CodeGenOptions &CGOpts,
+                             const clang::TargetOptions & /*TOpts*/,
+                             const clang::LangOptions & /*LOpts*/,
+                             llvm::TargetMachine& TM):
+   m_TM(TM),
+   m_CGOpts(CGOpts) //,
+   //m_TOpts(TOpts),
+   //m_LOpts(LOpts)
+{}
+
+
 BackendPasses::~BackendPasses() {
   //delete m_PMBuilder->Inliner;
 }

--- a/interpreter/cling/lib/Interpreter/BackendPasses.h
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.h
@@ -52,13 +52,7 @@ namespace cling {
     BackendPasses(const clang::CodeGenOptions &CGOpts,
                   const clang::TargetOptions & /*TOpts*/,
                   const clang::LangOptions & /*LOpts*/,
-                  llvm::TargetMachine& TM):
-      m_TM(TM),
-      m_CGOpts(CGOpts) //,
-      //m_TOpts(TOpts),
-      //m_LOpts(LOpts)
-    {}
-
+                  llvm::TargetMachine& TM);
     ~BackendPasses();
 
     void runOnModule(llvm::Module& M, int OptLevel);

--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
@@ -276,8 +276,10 @@ namespace cling {
       (Magic == file_magic::elf_shared_object)
 #endif
 #elif defined(_WIN32)
-      (Magic == file_magic::pecoff_executable
-       || platform::IsDLL(libFullPath.str()))
+      // We should only include dll libraries without including executables,
+      // object code and others...
+      (Magic == file_magic::pecoff_executable &&
+       platform::IsDLL(libFullPath.str()))
 #else
 # error "Unsupported platform."
 #endif

--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -870,7 +870,9 @@ namespace cling {
 
   void DynamicLibraryManager::initializeDyld(
                  std::function<bool(llvm::StringRef)> shouldPermanentlyIgnore) {
-    assert(!m_Dyld && "Already initialized!");
+     //assert(!m_Dyld && "Already initialized!");
+    if (m_Dyld)
+      delete m_Dyld;
 
     std::string exeP = GetExecutablePath();
     auto ObjF =

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 #include "IncrementalExecutor.h"
+#include "BackendPasses.h"
 #include "IncrementalJIT.h"
 #include "Threading.h"
 
@@ -25,7 +26,6 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/Support/Host.h"

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
@@ -15,6 +15,7 @@
 #include "BackendPasses.h"
 #include "EnterUserCodeRAII.h"
 
+#include "cling/Interpreter/DynamicLibraryManager.h"
 #include "cling/Interpreter/InterpreterCallbacks.h"
 #include "cling/Interpreter/Transaction.h"
 #include "cling/Interpreter/Value.h"
@@ -44,6 +45,7 @@ namespace llvm {
 }
 
 namespace cling {
+  class DynamicLibraryManager;
   class IncrementalJIT;
   class Value;
 
@@ -142,6 +144,11 @@ namespace cling {
     ///\brief The list of llvm::Module-s to return the transaction
     /// after the JIT has emitted them.
     std::map<llvm::orc::VModuleKey, Transaction*> m_PendingModules;
+
+    /// Dynamic library manager object.
+    ///
+    DynamicLibraryManager m_DyLibManager;
+
   public:
     enum ExecutionResult {
       kExeSuccess,
@@ -158,9 +165,15 @@ namespace cling {
     void setExternalIncrementalExecutor(IncrementalExecutor *extIncrExec) {
       m_externalIncrementalExecutor = extIncrExec;
     }
-    void setCallbacks(InterpreterCallbacks* callbacks) {
-      m_Callbacks = callbacks;
+    void setCallbacks(InterpreterCallbacks* callbacks);
+
+    const DynamicLibraryManager& getDynamicLibraryManager() const {
+      return const_cast<IncrementalExecutor*>(this)->m_DyLibManager;
     }
+    DynamicLibraryManager& getDynamicLibraryManager() {
+      return m_DyLibManager;
+    }
+
     void installLazyFunctionCreator(LazyFunctionCreatorFunc_t fp);
 
     ///\brief Unload a set of JIT symbols.

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -19,7 +19,6 @@
 #include "DefinitionShadower.h"
 #include "DeviceKernelInliner.h"
 #include "DynamicLookup.h"
-#include "IncrementalExecutor.h"
 #include "NullDerefProtectionTransformer.h"
 #include "TransactionPool.h"
 #include "ValueExtractionSynthesizer.h"

--- a/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
@@ -133,21 +133,22 @@ namespace cling {
   // FilePath := AnyString
   // AnyString := .*^('\t' Comment)
   bool MetaParser::isLCommand(MetaSema::ActionResult& actionResult) {
-    bool result = false;
     if (getCurTok().is(tok::ident) && getCurTok().getIdent().equals("L")) {
       consumeAnyStringToken(tok::comment);
+      llvm::StringRef filePath;
       if (getCurTok().is(tok::raw_ident)) {
-        result = true;
-        actionResult = m_Actions.actOnLCommand(getCurTok().getIdent());
+        filePath = getCurTok().getIdent();
         consumeToken();
         if (getCurTok().is(tok::comment)) {
           consumeAnyStringToken(tok::eof);
           m_Actions.actOnComment(getCurTok().getIdent());
         }
       }
+      actionResult = m_Actions.actOnLCommand(filePath);
+      return true;
     }
     // TODO: Some fine grained diagnostics
-    return result;
+    return false;
   }
 
   // T := 'T' FilePath Comment

--- a/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
@@ -41,6 +41,11 @@ namespace cling {
 
   MetaSema::ActionResult MetaSema::actOnLCommand(llvm::StringRef file,
                                              Transaction** transaction /*= 0*/){
+    if (file.empty()) {
+      m_Interpreter.DumpDynamicLibraryInfo();
+      return AR_Success;
+    }
+
     ActionResult result = actOnUCommand(file);
     if (result != AR_Success)
       return result;

--- a/interpreter/cling/test/LibraryCall/library_path.C
+++ b/interpreter/cling/test/LibraryCall/library_path.C
@@ -1,0 +1,15 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// REQUIRES: shell
+// RUN: env -i LD_LIBRARY_PATH="../:./../" %cling ".L" | FileCheck %s
+
+// CHECK: ../
+// CHECK-NEXT: ./../
+// CHECK-NEXT: .
+// CHECK-NEXT: [system]


### PR DESCRIPTION
The dynamic library manager's dyld can search a symbol in the library path.
This patch uses that functionality to aid the 'unresolved while linking'
diagnostics.

Now we get:
```
cling -L lib/

****************** CLING ******************
* Type C++ code and press enter to run it *
*             Type .q to exit             *
*******************************************
[cling]$ extern int gErrorIgnoreLevel;
[cling]$ gErrorIgnoreLevel
IncrementalExecutor::executeFunction: symbol 'gErrorIgnoreLevel' unresolved while linking [cling interface function]!
Symbol found in '/.../lib/libCore.so'; did you mean to load it with .L /.../lib/libCore.so ?
[cling]$
```

We should merge it after #6385 to not disturb the upgrade process.