### PR TITLE
libatomic usage fix (for ARM builds), master branch (2020.10.11.)

### DIFF
--- a/io/io/CMakeLists.txt
+++ b/io/io/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -58,13 +58,13 @@ ROOT_LINKER_LIBRARY(RIO
   $<TARGET_OBJECTS:RootPcmObjs>
   LIBRARIES
     ${CMAKE_DL_LIBS}
-    ${ROOT_ATOMIC_LIBS}
   DEPENDENCIES
     Core
     Thread
 )
 
 target_include_directories(RIO PRIVATE ${CMAKE_SOURCE_DIR}/core/clib/res)
+target_link_libraries(RIO PUBLIC ${ROOT_ATOMIC_LIBS})
 
 if(root7)
   set(RIO_EXTRA_HEADERS ROOT/RFile.hxx)


### PR DESCRIPTION
Made the `RIO` library's dependence on `libatomic` public. Unfortunately the previous incantation was not transitive. The clients were not set up to link against libatomic themselves as well. And with [TFile.h](https://github.com/root-project/root/blob/master/io/io/inc/TFile.h#L129-L132) publicly exposing a dependence on `std::atomic`, and multiple classes implemented in the project that inherit from `TFile` (and are built into other libraries), this really is a must.

This ties to both #4561 (where I described ARM's explicit dependence on `libatomic` "in certain situations"), and also to #6432 (ROOT's CMake configuration could really do with a significant cleanup/rewrite).

Unfortunately such errors will keep coming back if we can not set up a centralised test for this. Any chance that that could be done?