### PR TITLE
[RF] Add more functional-style getValue interface to RooFit.

### DIFF
--- a/roofit/roofit/inc/RooGaussian.h
+++ b/roofit/roofit/inc/RooGaussian.h
@@ -47,6 +47,7 @@ protected:
 
   Double_t evaluate() const override;
   RooSpan<double> evaluateBatch(std::size_t begin, std::size_t batchSize) const override;
+  RooSpan<double> evaluateSpan(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const override;
 
 private:
 

--- a/roofit/roofit/src/RooBreitWigner.cxx
+++ b/roofit/roofit/src/RooBreitWigner.cxx
@@ -94,7 +94,7 @@ RooSpan<double> RooBreitWigner::evaluateBatch(std::size_t begin, std::size_t bat
   if (!batchX && !batchMean && !batchWidth) {
     return {};
   }
-  batchSize = findSize({ xData, meanData, widthData });
+  batchSize = findSmallestBatch({ xData, meanData, widthData });
   auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
 
   if (batchX && !batchMean && !batchWidth ) {

--- a/roofit/roofit/src/RooChiSquarePdf.cxx
+++ b/roofit/roofit/src/RooChiSquarePdf.cxx
@@ -111,7 +111,7 @@ RooSpan<double> RooChiSquarePdf::evaluateBatch(std::size_t begin, std::size_t ba
   if (!batch_x && !batch_ndof) {
     return {};
   }
-  batchSize = findSize({ _xData, _ndofData });
+  batchSize = findSmallestBatch({ _xData, _ndofData });
   auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
 
   if (batch_x && !batch_ndof ) {

--- a/roofit/roofit/src/RooExponential.cxx
+++ b/roofit/roofit/src/RooExponential.cxx
@@ -116,7 +116,7 @@ RooSpan<double> RooExponential::evaluateBatch(std::size_t begin, std::size_t bat
   if (!batchX && !batchC) {
     return {};
   }
-  batchSize = findSize({ xData, cData });
+  batchSize = BatchHelpers::findSmallestBatch({ xData, cData });
   auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
 
   if (batchX && !batchC ) {

--- a/roofit/roofit/src/RooGaussian.cxx
+++ b/roofit/roofit/src/RooGaussian.cxx
@@ -146,7 +146,7 @@ RooSpan<double> RooGaussian::evaluateSpan(BatchHelpers::RunContext& evalData, co
   auto meanData = mean->getValues(evalData, normSet);
   auto sigmaData = sigma->getValues(evalData, normSet);
 
-  std::size_t batchLength = BatchHelpers::findSize({xData, meanData, sigmaData});
+  std::size_t batchLength = BatchHelpers::findSmallestBatch({xData, meanData, sigmaData});
   auto output = evalData.makeBatch(this, batchLength);
 
   if (xData.size() >= 1 && meanData.size() == 1 && sigmaData.size() == 1) {

--- a/roofit/roofit/src/RooLandau.cxx
+++ b/roofit/roofit/src/RooLandau.cxx
@@ -185,7 +185,7 @@ RooSpan<double> RooLandau::evaluateBatch(std::size_t begin, std::size_t batchSiz
   if (!batchX && !batchMean && !batchSigma) {
     return {};
   }
-  batchSize = findSize({ xData, meanData, sigmaData });
+  batchSize = BatchHelpers::findSmallestBatch({ xData, meanData, sigmaData });
   auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
 
   if (batchX && !batchMean && !batchSigma ) {

--- a/roofit/roofit/src/RooLognormal.cxx
+++ b/roofit/roofit/src/RooLognormal.cxx
@@ -123,7 +123,7 @@ RooSpan<double> RooLognormal::evaluateBatch(std::size_t begin, std::size_t batch
   if (!batchX && !batchM0 && !batchK) {
     return {};
   }
-  batchSize = findSize({ xData, m0Data, kData });
+  batchSize = findSmallestBatch({ xData, m0Data, kData });
   auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
 
   if (batchX && !batchM0 && !batchK ) {

--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -122,7 +122,7 @@ RooSpan<double> RooPoisson::evaluateBatch(std::size_t begin, std::size_t batchSi
   if (!batchX && !batchMean) {
     return {};
   }
-  batchSize = findSize({ xData, meanData });
+  batchSize = findSmallestBatch({ xData, meanData });
   auto output = _batchData.makeWritableBatchUnInit(begin, batchSize);
 
   if (batchX && !batchMean ) {

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -227,6 +227,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     BatchHelpers.h
     RooVDTHeaders.h
     RooWrapperPdf.h
+    RunContext.h
     RooFitLegacy/RooCatTypeLegacy.h
     RooFitLegacy/RooCategorySharedProperties.h
     RooNaNPacker.h
@@ -440,6 +441,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/BatchData.cxx
     src/BatchHelpers.cxx
     src/RooWrapperPdf.cxx
+    src/RunContext.cxx
     src/RooFitLegacy/RooCatTypeLegacy.cxx
     src/RooFitLegacy/RooCategorySharedProperties.cxx
     src/RooFitLegacy/RooMultiCatIter.cxx

--- a/roofit/roofitcore/inc/BatchData.h
+++ b/roofit/roofitcore/inc/BatchData.h
@@ -25,6 +25,8 @@
 #include <string>
 
 class RooArgSet;
+class RooAbsReal;
+class RooArgProxy;
 
 namespace BatchHelpers {
 

--- a/roofit/roofitcore/inc/BatchHelpers.h
+++ b/roofit/roofitcore/inc/BatchHelpers.h
@@ -131,6 +131,25 @@ class BracketAdapterWithMask {
     const size_t _mask;
 };
 
+
+/// Helper class to access a batch-related part of RooAbsReal's interface, which should not leak to the outside world.
+class BatchInterfaceAccessor {
+  public:
+    static void clearBatchMemory(RooAbsReal& theReal) {
+      theReal.clearBatchMemory();
+    }
+
+    static void checkBatchComputation(const RooAbsReal& theReal, std::size_t evtNo,
+        const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) {
+      theReal.checkBatchComputation(evtNo, normSet, relAccuracy);
+    }
+
+    static void checkBatchComputation(const RooAbsReal& theReal, const BatchHelpers::RunContext& evalData, std::size_t evtNo,
+        const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) {
+      theReal.checkBatchComputation(evalData, evtNo, normSet, relAccuracy);
+    }
+};
+
 }
 
 #endif /* ROOFIT_ROOFITCORE_INC_BATCHHELPERS_H_ */

--- a/roofit/roofitcore/inc/BatchHelpers.h
+++ b/roofit/roofitcore/inc/BatchHelpers.h
@@ -44,7 +44,7 @@ struct EvaluateInfo {
   size_t size, nBatches;
 };
   
-size_t findSize(std::vector< RooSpan<const double> > parameters);
+size_t findSmallestBatch(std::vector< RooSpan<const double> > parameters);
 
 EvaluateInfo getInfo(std::vector<const RooRealProxy*> parameters, size_t begin, size_t batchSize);
 EvaluateInfo init(std::vector< RooRealProxy > parameters, 

--- a/roofit/roofitcore/inc/BatchHelpers.h
+++ b/roofit/roofitcore/inc/BatchHelpers.h
@@ -18,9 +18,9 @@
 #define ROOFIT_ROOFITCORE_INC_BATCHHELPERS_H_
 
 #include "RooRealProxy.h"
+#include "RooSpan.h"
 
 #include <vector>
-#include <RooSpan.h>
 
 class RooArgSet;
 
@@ -90,7 +90,7 @@ class BracketAdapterWithMask {
     _isBatch(!batch.empty()),
     _payload(payload),
     _pointer(batch.empty() ? &_payload : batch.data()),
-    _mask(batch.empty() ? 0 : ~static_cast<size_t>(0))
+    _mask(batch.size() > 1 ? ~static_cast<size_t>(0): 0)
     {
     }
     

--- a/roofit/roofitcore/inc/BatchHelpers.h
+++ b/roofit/roofitcore/inc/BatchHelpers.h
@@ -44,7 +44,7 @@ struct EvaluateInfo {
   size_t size, nBatches;
 };
   
-size_t findSmallestBatch(std::vector< RooSpan<const double> > parameters);
+size_t findSmallestBatch(const std::vector< RooSpan<const double> >& parameters);
 
 EvaluateInfo getInfo(std::vector<const RooRealProxy*> parameters, size_t begin, size_t batchSize);
 EvaluateInfo init(std::vector< RooRealProxy > parameters, 

--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -84,6 +84,7 @@
 #pragma link C++ class RooCmdArg+ ;
 #pragma link C++ class RooCmdConfig+ ;
 #pragma link C++ class RooConstVar+ ;
+#pragma read sourceClass="RooConstVar" targetClass="RooConstVar" version="[1]" source="Double_t _value" target="" code="{ newObj->changeVal(onfile._value); }"
 #pragma link C++ class RooConvCoefVar+ ;
 #pragma link C++ class RooConvGenContext+ ;
 #pragma link C++ class RooConvIntegrandBinding+ ;

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -21,6 +21,7 @@
 #include "RooArgSet.h"
 #include "RooArgList.h"
 #include "RooSpan.h"
+#include "RunContext.h"
 #include <map>
 #include <string>
 
@@ -98,6 +99,14 @@ public:
   virtual void weightError(Double_t& lo, Double_t& hi, ErrorType etype=Poisson) const ; 
   virtual const RooArgSet* get(Int_t index) const ;
 
+  /// Retrieve batches of data for each real-valued variable in this dataset.
+  /// \param[out]  evalData Store references to all data batches in this struct.
+  /// \param first Index of first event that ends up in the batch.
+  /// \param len   Number of events in each batch.
+  /// Needs to be overridden by derived classes. This implementation returns an empty RunContext.
+  virtual void getBatches(BatchHelpers::RunContext& evalData, std::size_t first = 0, std::size_t len = std::numeric_limits<std::size_t>::max()) const {
+    (void)evalData; (void)first; (void)len;
+  }
   ////////////////////////////////////////////////////////////////////////////////
   /// Return event weights of all events in range [first, first+len).
   /// If no contiguous structure of weights is stored, an empty batch can be returned.

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -54,7 +54,7 @@ public:
   virtual Bool_t isWeighted() const = 0 ;
 
   virtual std::vector<RooSpan<const double>> getBatch(std::size_t first, std::size_t len) const = 0;
-  virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const;
+  virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const = 0;
 
   // Change observable name
   virtual Bool_t changeObservableName(const char* from, const char* to) =0 ;

--- a/roofit/roofitcore/inc/RooAbsFunc.h
+++ b/roofit/roofitcore/inc/RooAbsFunc.h
@@ -17,7 +17,11 @@
 #define ROO_ABS_FUNC
 
 #include "Rtypes.h"
+#include "RooSpan.h"
+
 #include <list>
+#include <vector>
+
 class RooAbsRealLValue ;
 
 class RooAbsFunc {
@@ -36,6 +40,9 @@ public:
   }
 
   virtual Double_t operator()(const Double_t xvector[]) const = 0;
+  virtual RooSpan<const double> getValues(std::vector<RooSpan<const double>> /*coordinates*/) const {
+    throw std::logic_error("Not implemented.");
+  }
   virtual Double_t getMinLimit(UInt_t dimension) const = 0;
   virtual Double_t getMaxLimit(UInt_t dimension) const = 0;
 

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -36,6 +36,9 @@ class TList ;
 class RooLinkedList ;
 class RooNumGenConfig ;
 class RooRealIntegral ;
+namespace BatchHelpers {
+struct RunContext;
+}
 
 class RooAbsPdf : public RooAbsReal {
 public:
@@ -201,6 +204,7 @@ public:
 
   RooSpan<const double> getValBatch(std::size_t begin, std::size_t batchSize,
       const RooArgSet* normSet = nullptr) const final;
+  RooSpan<const double> getValues(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const;
   RooSpan<const double> getLogValBatch(std::size_t begin, std::size_t batchSize,
       const RooArgSet* normSet = nullptr) const;
 

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -46,6 +46,9 @@ class RooVectorDataStore ;
 namespace RooHelpers {
 class BatchInterfaceAccessor;
 }
+namespace BatchHelpers {
+struct RunContext;
+}
 struct TreeReadBuffer; /// A space to attach TBranches
 
 class TH1;
@@ -108,6 +111,7 @@ public:
   virtual Double_t getValV(const RooArgSet* normalisationSet = nullptr) const ;
 
   virtual RooSpan<const double> getValBatch(std::size_t begin, std::size_t maxSize, const RooArgSet* normSet = nullptr) const;
+  virtual RooSpan<const double> getValues(BatchHelpers::RunContext& evalData, const RooArgSet* normSet = nullptr) const;
 
   Double_t getPropagatedError(const RooFitResult &fr, const RooArgSet &nset = RooArgSet()) const;
 
@@ -406,6 +410,7 @@ protected:
   /// Evaluate this PDF / function / constant. Needs to be overridden by all derived classes.
   virtual Double_t evaluate() const = 0;
   virtual RooSpan<double> evaluateBatch(std::size_t begin, std::size_t maxSize) const;
+  virtual RooSpan<double> evaluateSpan(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const;
 
   //---------- Interface to access batch data ---------------------------
   //

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -43,10 +43,8 @@ class RooFitResult ;
 class RooAbsMoment ;
 class RooDerivative ;
 class RooVectorDataStore ;
-namespace RooHelpers {
-class BatchInterfaceAccessor;
-}
 namespace BatchHelpers {
+class BatchInterfaceAccessor;
 struct RunContext;
 }
 struct TreeReadBuffer; /// A space to attach TBranches
@@ -414,7 +412,7 @@ protected:
 
   //---------- Interface to access batch data ---------------------------
   //
-  friend class RooHelpers::BatchInterfaceAccessor;
+  friend class BatchHelpers::BatchInterfaceAccessor;
   void clearBatchMemory() {
     _batchData.clear();
     for (auto arg : _serverList) {
@@ -427,6 +425,7 @@ protected:
 
  private:
   void checkBatchComputation(std::size_t evtNo, const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) const;
+  void checkBatchComputation(const BatchHelpers::RunContext& evalData, std::size_t evtNo, const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) const;
 
   const BatchHelpers::BatchData& batchData() const {
     return _batchData;

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -108,6 +108,8 @@ public:
     std::vector<double> vec(first, last);
     return {RooSpan<const double>(vec)};
   }
+  virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const;
+
 
  protected:
 
@@ -117,6 +119,7 @@ public:
   RooCategory* _indexCat ;
   mutable RooAbsDataStore* _curStore ; //! Datastore associated with current event
   mutable Int_t _curIndex ; //! Index associated with current event
+  mutable std::unique_ptr<std::vector<double>> _weightBuffer; //! Buffer for weights in case a batch of values is requested.
   Bool_t _ownComps ; //! 
 
   ClassDef(RooCompositeDataStore,1) // Composite Data Storage class

--- a/roofit/roofitcore/inc/RooConstVar.h
+++ b/roofit/roofitcore/inc/RooConstVar.h
@@ -17,10 +17,11 @@
 #define ROO_CONST_VAR
 
 #include "RooAbsReal.h"
-#include "RooArgList.h"
-#include "RooListProxy.h"
 
 class RooArgSet ;
+namespace BatchHelpers {
+  struct RunContext;
+}
 
 class RooConstVar final : public RooAbsReal {
 public:
@@ -29,19 +30,28 @@ public:
   RooConstVar(const char *name, const char *title, Double_t value);
   RooConstVar(const RooConstVar& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooConstVar(*this,newname); }
-  virtual ~RooConstVar();
+  virtual ~RooConstVar() = default;
 
-  ////////////////////////////////////////////////////////////////////////////////
   /// Return (constant) value.
   virtual Double_t getValV(const RooArgSet*) const {
     return _value;
   }
 
+  RooSpan<const double> getValues(BatchHelpers::RunContext& evalData, const RooArgSet*) const;
+
   void writeToStream(std::ostream& os, Bool_t compact) const ;
 
+  /// Returns false, as the value of the constant doesn't depend on other objects.
   virtual Bool_t isDerived() const { 
-    // Does value or shape of this arg depend on any other arg?
-    return kFALSE ;
+    return false;
+  }
+
+  /// Change the value of this constant.
+  /// On purpose, this is not `setVal`, as this could be confused with the `setVal`
+  /// that is available for variables. Constants, however, should remain mostly constant.
+  /// This function is e.g. useful when reading the constant from a file.
+  void changeVal(double value) {
+    _value = value;
   }
 
 protected:
@@ -50,9 +60,7 @@ protected:
     return _value;
   }
 
-  Double_t _value{0.}; // Constant value of self
-
-  ClassDef(RooConstVar,1) // Constant RooAbsReal value object
+  ClassDef(RooConstVar,2) // Constant RooAbsReal value object
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooDataProjBinding.h
+++ b/roofit/roofitcore/inc/RooDataProjBinding.h
@@ -40,6 +40,7 @@ protected:
 
   RooSuperCategory* _superCat ;  // Supercategory constructed from _data's category variables
   Roo1DTable* _catTable ;        // Supercategory table generated from _data
+  mutable std::unique_ptr<std::vector<double>> _batchBuffer; //! Storage for handing out spans.
 
   ClassDef(RooDataProjBinding,0) // RealFunc/Dataset binding for data projection of a real function
 };

--- a/roofit/roofitcore/inc/RooDataProjBinding.h
+++ b/roofit/roofitcore/inc/RooDataProjBinding.h
@@ -29,6 +29,8 @@ public:
 
   virtual Double_t operator()(const Double_t xvector[]) const;
 
+  RooSpan<const double> getValues(std::vector<RooSpan<const double>> coordinates) const;
+
 protected:
 
   mutable Bool_t _first   ;  // Bit indicating if operator() has been called yet

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -108,6 +108,8 @@ public:
   virtual const RooArgSet* get(Int_t index) const override;
   virtual const RooArgSet* get() const override;
 
+  void getBatches(BatchHelpers::RunContext& evalData,
+      std::size_t first = 0, std::size_t len = std::numeric_limits<std::size_t>::max()) const override;
   virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const override;
 
   // Add one ore more rows of data

--- a/roofit/roofitcore/inc/RooFormula.h
+++ b/roofit/roofitcore/inc/RooFormula.h
@@ -20,10 +20,16 @@
 #include "RooArgList.h"
 #include "RooArgSet.h"
 #include "TFormula.h"
+#include "RooSpan.h"
+#include "BatchData.h"
 
 #include <memory>
 #include <vector>
 #include <string>
+
+namespace BatchHelpers {
+struct RunContext;
+}
 
 class RooFormula : public TNamed, public RooPrintable {
 public:
@@ -53,6 +59,7 @@ public:
   Bool_t ok() const { return _tFormula != nullptr; }
   /// Evalute all parameters/observables, and then evaluate formula.
   Double_t eval(const RooArgSet* nset=0) const;
+  RooSpan<double> evaluateSpan(const RooAbsReal* dataOwner, BatchHelpers::RunContext& inputData, const RooArgSet* nset = nullptr) const;
 
   /// DEBUG: Dump state information
   void dump() const;

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -70,6 +70,7 @@ public:
 
   // Function evaluation
   virtual Double_t evaluate() const ;
+  RooSpan<double> evaluateSpan(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const;
 
   protected:
   // Post-processing of server redirection

--- a/roofit/roofitcore/inc/RooGenericPdf.h
+++ b/roofit/roofitcore/inc/RooGenericPdf.h
@@ -49,6 +49,7 @@ protected:
   // Function evaluation
   RooListProxy _actualVars ; 
   virtual Double_t evaluate() const ;
+  RooSpan<double> evaluateSpan(BatchHelpers::RunContext& inputData, const RooArgSet* normSet) const;
 
   Bool_t setFormula(const char* formula) ;
 

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -89,102 +89,10 @@ class HijackMessageStream{
 std::vector<std::string> tokenise(const std::string &str, const std::string &delims, bool returnEmptyToken = true);
 
 
-
-class CachingError : public std::exception {
-  public:
-    CachingError(const std::string& newMessage) :
-      std::exception(),
-      _messages()
-    {
-      _messages.push_back(newMessage);
-    }
-
-    CachingError(CachingError&& previous, const std::string& newMessage) :
-    std::exception(),
-    _messages{std::move(previous._messages)}
-    {
-      _messages.push_back(newMessage);
-    }
-
-    const char* what() const noexcept override {
-      std::stringstream out;
-      out << "**Caching Error** in\n";
-
-      std::string indent;
-      for (auto it = _messages.rbegin(); it != _messages.rend(); ++it) {
-        std::string message = *it;
-        auto pos = message.find('\n', 0);
-        while (pos != std::string::npos) {
-          message.insert(pos+1, indent);
-          pos = (message.find('\n', pos+1));
-        }
-
-        out << indent << message << "\n";
-        indent += " ";
-      }
-
-      out << std::endl;
-
-      std::string* ret = new std::string(out.str()); //Make it survive this method
-
-      return ret->c_str();
-    }
-
-
-  private:
-    std::vector<std::string> _messages;
-};
-
-
-class FormatPdfTree {
-  public:
-    template <class T,
-    typename std::enable_if<std::is_base_of<RooAbsArg, T>::value>::type* = nullptr >
-    FormatPdfTree& operator<<(const T& arg) {
-      _stream << arg.ClassName() << "::" << arg.GetName() << " " << &arg << " ";
-      arg.printArgs(_stream);
-      return *this;
-    }
-
-    template <class T,
-    typename std::enable_if< ! std::is_base_of<RooAbsArg, T>::value>::type* = nullptr >
-    FormatPdfTree& operator<<(const T& arg) {
-      _stream << arg;
-      return *this;
-    }
-
-    operator std::string() const {
-      return _stream.str();
-    }
-
-    std::ostream& stream() {
-      return _stream;
-    }
-
-  private:
-    std::ostringstream _stream;
-};
-
-
 /// Check if the parameters have a range, and warn if the range extends below / above the set limits.
 void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_list<const RooAbsReal*> pars,
     double min = -std::numeric_limits<double>::max(), double max = std::numeric_limits<double>::max(),
     bool limitsInAllowedRange = false, std::string extraMessage = "");
-
-
-/// Helper class to access a batch-related part of RooAbsReal's interface, which should not leak to the outside world.
-class BatchInterfaceAccessor {
-  public:
-    static void clearBatchMemory(RooAbsReal& theReal) {
-      theReal.clearBatchMemory();
-    }
-
-    static void checkBatchComputation(const RooAbsReal& theReal, std::size_t evtNo,
-        const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) {
-      theReal.checkBatchComputation(evtNo, normSet, relAccuracy);
-    }
-};
-
 
 }
 

--- a/roofit/roofitcore/inc/RooRealAnalytic.h
+++ b/roofit/roofitcore/inc/RooRealAnalytic.h
@@ -24,12 +24,13 @@ public:
     RooRealBinding(func,vars,normSet,rangeName), _code(code) { }
   inline virtual ~RooRealAnalytic() { }
 
-  virtual Double_t operator()(const Double_t xvector[]) const;
+  virtual Double_t operator()(const Double_t xvector[]) const override;
+  RooSpan<const double> getValues(std::vector<RooSpan<const double>> coordinates) const override;
 
 protected:
   Int_t _code;
 
-  ClassDef(RooRealAnalytic,0) // Function binding to an analytical integral of a RooAbsReal
+  ClassDefOverride(RooRealAnalytic,0) // Function binding to an analytical integral of a RooAbsReal
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealAnalytic.h
+++ b/roofit/roofitcore/inc/RooRealAnalytic.h
@@ -30,6 +30,9 @@ public:
 protected:
   Int_t _code;
 
+private:
+  mutable std::unique_ptr<std::vector<double>> _batchBuffer; //! Buffer for handing out spans.
+
   ClassDefOverride(RooRealAnalytic,0) // Function binding to an analytical integral of a RooAbsReal
 };
 

--- a/roofit/roofitcore/inc/RooRealBinding.h
+++ b/roofit/roofitcore/inc/RooRealBinding.h
@@ -17,11 +17,14 @@
 #define ROO_REAL_BINDING
 
 #include "RooAbsFunc.h"
-#include <list>
+#include "RooSpan.h"
+#include <vector>
+#include <memory>
 
 class RooAbsRealLValue;
 class RooAbsReal;
 class RooArgSet;
+namespace BatchHelpers{ struct RunContext; }
 
 class RooRealBinding : public RooAbsFunc {
 public:
@@ -30,6 +33,7 @@ public:
   virtual ~RooRealBinding();
 
   virtual Double_t operator()(const Double_t xvector[]) const;
+  virtual RooSpan<const double> getValues(std::vector<RooSpan<const double>> coordinates) const;
   virtual Double_t getMinLimit(UInt_t dimension) const;
   virtual Double_t getMaxLimit(UInt_t dimension) const;
 
@@ -52,9 +56,10 @@ protected:
   mutable Double_t* _xsave ;
   const TNamed* _rangeName ; //!
   
-  mutable std::list<RooAbsReal*> _compList ; //!
-  mutable std::list<Double_t>    _compSave ; //!
+  mutable std::vector<RooAbsReal*> _compList ; //!
+  mutable std::vector<Double_t>    _compSave ; //!
   mutable Double_t _funcSave ; //!
+  mutable std::unique_ptr<BatchHelpers::RunContext> _evalData; /// Memory for batch evaluations
   
   ClassDef(RooRealBinding,0) // Function binding to RooAbsReal object
 };

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -17,6 +17,7 @@
 #define ROO_REAL_VAR
 
 #include "RooAbsRealLValue.h"
+#include "RunContext.h"
 
 #include "TString.h"
 
@@ -57,6 +58,20 @@ public:
   /// \return Span with event data. If not attached to a data store, empty batch. The batch will be shorter if data store ends.
   RooSpan<const double> getValBatch(std::size_t begin, std::size_t batchSize, const RooArgSet* = nullptr) const final {
     return _batchData.getBatch(begin, batchSize);
+  }
+  /// Get values of this variable.
+  /// Check if `inputData` has data registered for this instance. If not, return a batch of size one
+  /// with the current value of the variable.
+  RooSpan<const double> getValues(BatchHelpers::RunContext& inputData, const RooArgSet*) const final {
+    auto item = inputData.spans.find(this);
+    if (item != inputData.spans.end()) {
+      return item->second;
+    }
+
+    auto output = inputData.makeBatch(this, 1);
+    output[0] = _value;
+
+    return output;
   }
 
   virtual void setVal(Double_t value);

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -59,20 +59,7 @@ public:
   RooSpan<const double> getValBatch(std::size_t begin, std::size_t batchSize, const RooArgSet* = nullptr) const final {
     return _batchData.getBatch(begin, batchSize);
   }
-  /// Get values of this variable.
-  /// Check if `inputData` has data registered for this instance. If not, return a batch of size one
-  /// with the current value of the variable.
-  RooSpan<const double> getValues(BatchHelpers::RunContext& inputData, const RooArgSet*) const final {
-    auto item = inputData.spans.find(this);
-    if (item != inputData.spans.end()) {
-      return item->second;
-    }
-
-    auto output = inputData.makeBatch(this, 1);
-    output[0] = _value;
-
-    return output;
-  }
+  RooSpan<const double> getValues(BatchHelpers::RunContext& inputData, const RooArgSet*) const final;
 
   virtual void setVal(Double_t value);
   virtual void setVal(Double_t value, const char* rangeName);

--- a/roofit/roofitcore/inc/RooSpan.h
+++ b/roofit/roofitcore/inc/RooSpan.h
@@ -37,22 +37,16 @@ public:
   using value_type = typename std::remove_cv<T>::type;
 
   constexpr RooSpan() :
-  _auxStorage{},
   _span{} { }
 
   constexpr RooSpan(RooSpan&& other) :
-  _auxStorage{std::move(other._auxStorage)},
   _span{other._span.data(), other._span.size()}
   { }
 
   constexpr RooSpan(const RooSpan& other) :
-  _auxStorage{other._auxStorage},
   _span{other._span}
   { }
 
-  // Declare the const version as friend here, so one can
-  // construct RooSpan<const T> from RooSpan<const T> AND share the memory.
-  friend class RooSpan<const T>;
 
   /// Conversion constructor from <T> to <const T>
   /// If the input span owns some memory, the const-version of the
@@ -60,7 +54,6 @@ public:
   template<typename NON_CONST_T,
       typename = typename std::enable_if<std::is_same<const NON_CONST_T, T>::value>::type >
   constexpr RooSpan(const RooSpan<NON_CONST_T>& other) :
-  _auxStorage{other._auxStorage},
   _span{other.data(), other.size()}
   { }
 
@@ -68,7 +61,6 @@ public:
   /// Construct from a range. Data held by foreign object.
   template < class InputIterator>
   constexpr RooSpan(InputIterator beginIn, InputIterator endIn) :
-  _auxStorage{},
   _span{beginIn, endIn}
   { }
 
@@ -76,7 +68,6 @@ public:
   /// Construct from start and end pointers.
   constexpr RooSpan(typename std::span<T>::pointer beginIn,
       typename std::span<T>::pointer endIn) :
-    _auxStorage{},
     _span{beginIn, endIn}
   { }
 
@@ -84,29 +75,21 @@ public:
   /// Construct from start pointer and size.
   constexpr RooSpan(typename std::span<T>::pointer beginIn,
       typename std::span<T>::index_type sizeIn) :
-  _auxStorage{},
   _span{beginIn, sizeIn}
   { }
 
 
   constexpr RooSpan(const std::vector<typename std::remove_cv<T>::type>& vec) noexcept :
-  _auxStorage{},
   _span{vec}
   { }
 
   constexpr RooSpan(std::vector<typename std::remove_cv<T>::type>& vec) noexcept :
-  _auxStorage{},
   _span{vec}
   { }
 
 
-  /// Hand data over to this span. This will mean that the data will get
-  /// deleted when it goes out of scope. Try to avoid this because
-  /// unnecessary copies will be made.
-  constexpr RooSpan(std::vector<value_type>&& payload) :
-  _auxStorage{new std::vector<value_type>(std::forward<std::vector<value_type>>(payload))},
-  _span{_auxStorage->begin(), _auxStorage->end()}
-  { }
+  /// We cannot point to temporary data.
+  constexpr RooSpan(std::vector<value_type>&& payload) = delete;
 
 
   RooSpan<T>& operator=(const RooSpan<T>& other) = default;
@@ -124,10 +107,16 @@ public:
     return _span.data();
   }
 
+#ifdef NDEBUG
+  constexpr typename std::span<T>::reference operator[](typename std::span<T>::index_type i) const noexcept {
+    return _span[i];
+  }
+#else
   typename std::span<T>::reference operator[](typename std::span<T>::index_type i) const noexcept {
     assert(i < _span.size());
     return _span[i];
   }
+#endif
 
   constexpr typename std::span<T>::index_type size() const noexcept {
     return _span.size();
@@ -144,23 +133,19 @@ public:
 
   ///Test if the span overlaps with `other`.
   template <class Span_t>
-  bool overlaps(const Span_t& other) const {
+  constexpr bool overlaps(const Span_t& other) const {
     return insideSpan(other.begin()) || insideSpan(other.end()-1)
         || other.insideSpan(begin()) || other.insideSpan(end()-1);
   }
 
   ///Test if the given pointer/iterator is inside the span.
   template <typename ptr_t>
-  bool insideSpan(ptr_t ptr) const {
+  constexpr bool insideSpan(ptr_t ptr) const {
     return begin() <= ptr && ptr < end();
   }
 
 private:
 
-  /// If a class does not own a contiguous block of memory, which
-  /// could be used to create a span, the memory has to be kept alive
-  /// until all referring spans are destroyed.
-  std::shared_ptr<std::vector<value_type>> _auxStorage;
   std::span<T> _span;
 };
 

--- a/roofit/roofitcore/inc/RooSpan.h
+++ b/roofit/roofitcore/inc/RooSpan.h
@@ -50,14 +50,20 @@ public:
   _span{other._span}
   { }
 
+  // Declare the const version as friend here, so one can
+  // construct RooSpan<const T> from RooSpan<const T> AND share the memory.
+  friend class RooSpan<const T>;
 
   /// Conversion constructor from <T> to <const T>
+  /// If the input span owns some memory, the const-version of the
+  /// span will copy the shared_ptr.
   template<typename NON_CONST_T,
       typename = typename std::enable_if<std::is_same<const NON_CONST_T, T>::value>::type >
   constexpr RooSpan(const RooSpan<NON_CONST_T>& other) :
-  _auxStorage{},
+  _auxStorage{other._auxStorage},
   _span{other.data(), other.size()}
   { }
+
 
   /// Construct from a range. Data held by foreign object.
   template < class InputIterator>

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -76,6 +76,7 @@ public:
     std::vector<double> vec(first, last);
     return {RooSpan<const double>(vec)};
   }
+  virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const;
 
   // Change observable name
   virtual Bool_t changeObservableName(const char* from, const char* to) ;
@@ -166,6 +167,7 @@ public:
   const Double_t* _extWgtErrLoArray{nullptr};    //! External weight array - low error
   const Double_t* _extWgtErrHiArray{nullptr};    //! External weight array - high error
   const Double_t* _extSumW2Array{nullptr};       //! External sum of weights array
+  mutable std::unique_ptr<std::vector<double>> _weightBuffer; //! Buffer for weights in case a batch of values is requested.
 
   mutable Double_t  _curWgt ;      // Weight of current event
   mutable Double_t  _curWgtErrLo ; // Weight of current event

--- a/roofit/roofitcore/inc/RunContext.h
+++ b/roofit/roofitcore/inc/RunContext.h
@@ -1,0 +1,53 @@
+// Author: Stephan Hageboeck, CERN  Jul 2020
+
+/*****************************************************************************
+ * RooFit
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2020, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#ifndef ROOFIT_ROOFITCORE_INC_BATCHRUNCONTEXT_H_
+#define ROOFIT_ROOFITCORE_INC_BATCHRUNCONTEXT_H_
+
+#include "RooSpan.h"
+
+#include <unordered_map>
+#include <vector>
+
+class RooArgSet;
+class RooAbsReal;
+class RooArgProxy;
+
+namespace BatchHelpers {
+
+/// Data that has to be passed around when evaluating functions / PDFs.
+struct RunContext {
+  RooSpan<const double> getBatch(const RooArgProxy& proxy) const;
+  RooSpan<const double> getBatch(const RooAbsReal* owner) const;
+  /// Retrieve a batch of data corresponding to the element passed as `owner`.
+  RooSpan<const double> operator[](const RooAbsReal* owner) const { return getBatch(owner); }
+  RooSpan<double> getWritableBatch(const RooAbsReal* owner);
+  RooSpan<double> makeBatch(const RooAbsReal* owner, std::size_t size);
+
+  /// Clear all computation results without freeing memory.
+  void clear() { spans.clear(); rangeName = nullptr; }
+
+  /// Once an object has computed its value(s), the span pointing to the results is registered here.
+  std::unordered_map<const RooAbsReal*, RooSpan<const double>> spans;
+  /// Memory owned by this struct. It is associated to nodes in the computation graph using their pointers.
+  std::unordered_map<const RooAbsReal*, std::vector<double>> ownedMemory;
+  const char* rangeName{nullptr}; /// If evaluation should only occur in a range, the range name can be passed here.
+  std::vector<double> logProbabilities; /// Possibility to register log probabilities.
+};
+
+}
+
+#endif

--- a/roofit/roofitcore/src/BatchData.cxx
+++ b/roofit/roofitcore/src/BatchData.cxx
@@ -16,8 +16,12 @@
 
 #include "BatchData.h"
 
+#include "RooArgProxy.h"
+#include "RooAbsReal.h"
+
 #include <ostream>
 #include <iomanip>
+#include <vector>
 
 namespace BatchHelpers {
 
@@ -161,7 +165,6 @@ void BatchData::attachForeignStorage(const std::vector<double>& vec) {
   clear();
 
   _foreignData = &vec;
-  _ownedBatches.clear();
 }
 
 

--- a/roofit/roofitcore/src/BatchHelpers.cxx
+++ b/roofit/roofitcore/src/BatchHelpers.cxx
@@ -26,12 +26,12 @@ namespace BatchHelpers {
  * \param[in] parameters Vector of spans to read sizes from.
  * \return Smallest non-zero size found.
  */
-size_t findSize(std::vector< RooSpan<const double> > parameters) 
+size_t findSmallestBatch(std::vector< RooSpan<const double> > parameters) 
 {
   if (parameters.empty() || std::all_of(parameters.begin(), parameters.end(), [](const RooSpan<const double> span){ return span.size() == 0;})) {
     return 0;
   }
-  if (std::all_of(parameters.begin(), parameters.end(), [](const RooSpan<const double> span){ return span.size() == 1;})) {
+  if (std::all_of(parameters.begin(), parameters.end(), [](const RooSpan<const double> span){ return span.size() <= 1;})) {
     return 1;
   }
 

--- a/roofit/roofitcore/src/BatchHelpers.cxx
+++ b/roofit/roofitcore/src/BatchHelpers.cxx
@@ -26,7 +26,7 @@ namespace BatchHelpers {
  * \param[in] parameters Vector of spans to read sizes from.
  * \return Smallest non-zero size found.
  */
-size_t findSmallestBatch(std::vector< RooSpan<const double> > parameters) 
+size_t findSmallestBatch(const std::vector< RooSpan<const double> >& parameters)
 {
   if (parameters.empty() || std::all_of(parameters.begin(), parameters.end(), [](const RooSpan<const double> span){ return span.size() == 0;})) {
     return 0;

--- a/roofit/roofitcore/src/BatchHelpers.cxx
+++ b/roofit/roofitcore/src/BatchHelpers.cxx
@@ -19,18 +19,30 @@
 namespace BatchHelpers {
 
 /**
- * This function returns the minimum size of the non-zero-sized batches.
+ * This function returns the minimum size of the batches that have a size > 1.
+ * - If the size is zero, there is no data, so ignore this batch.
+ * - If the size is one, the first element is broadcast.
+ * - If the size is > 1, this is a data batch for which values should be computed.
  * \param[in] parameters Vector of spans to read sizes from.
  * \return Smallest non-zero size found.
  */
 size_t findSize(std::vector< RooSpan<const double> > parameters) 
 {
+  if (parameters.empty() || std::all_of(parameters.begin(), parameters.end(), [](const RooSpan<const double> span){ return span.size() == 0;})) {
+    return 0;
+  }
+  if (std::all_of(parameters.begin(), parameters.end(), [](const RooSpan<const double> span){ return span.size() == 1;})) {
+    return 1;
+  }
+
   size_t ret = std::numeric_limits<std::size_t>::max();
-  for (auto &param : parameters) 
-    if (param.size()> 0 && param.size()<ret) ret=param.size();
+  for (const auto& param : parameters)
+    if (param.size() > 1 && param.size()<ret)
+      ret = param.size();
     
   return ret;
 }
+
 
 /* This function returns the minimum size of the non-zero-sized batches
  * as well as the number of parameters that are batches, wrapped in a

--- a/roofit/roofitcore/src/RooAbsDataStore.cxx
+++ b/roofit/roofitcore/src/RooAbsDataStore.cxx
@@ -212,24 +212,3 @@ void RooAbsDataStore::printMultiline(ostream& os, Int_t /*content*/, Bool_t verb
   }
 }
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get the weights of the events in the range [first, first+size).
-/// This is a slow default implementation that will fill a vector with every
-/// event retrieved one by one (even if the weight is constant).
-/// Derived classes should return a span pointing to the original data.
-///
-/// If weights are not stored contiguously, an empty batch may be returned.
-RooSpan<const double> RooAbsDataStore::getWeightBatch(std::size_t first, std::size_t len) const {
-
-    std::vector<double> ret;
-    ret.reserve(len);
-
-    for (auto i = first; i < first+len; ++i) {
-      ret.push_back(weight(i));
-    }
-
-    return RooSpan<const double>(std::move(ret));
-}
-

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -401,6 +401,55 @@ RooSpan<const double> RooAbsPdf::getValBatch(std::size_t begin, std::size_t maxS
   return ret;
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute batch of values for given input data, and normalise by integrating over
+/// the observables in `nset`. Store result in `evalData`, and return a span pointing to
+/// it.
+///
+/// If `nset` is `nullptr`, unnormalised values
+/// are returned. All elements of `nset` must be lvalues.
+///
+/// \param[in/out]  evalData Object holding data that should be used in computations.
+/// Each array of data is identified by the pointer to the RooFit object that this data belongs to.
+/// The object that this function is called on will store its results here as well.
+/// \param[in] normSet   If not nullptr, normalise results by integrating over
+/// the variables in this set. The normalisation is only computed once, and applied
+/// to the full batch.
+/// \return RooSpan with probabilities. The memory of this span is owned by `evalData`.
+RooSpan<const double> RooAbsPdf::getValues(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const {
+  auto item = evalData.spans.find(this);
+  if (item != evalData.spans.end()) {
+    return item->second;
+  }
+
+  auto outputs = evaluateSpan(evalData, normSet);
+  assert(evalData.spans.count(this) > 0);
+
+  if (normSet != nullptr) {
+    if (normSet != _normSet || _norm == nullptr) {
+      syncNormalization(normSet);
+    }
+    // Evaluate denominator
+    const double normVal = _norm->getVal();
+
+    if (normVal < 0.
+        || (normVal == 0. && std::any_of(outputs.begin(), outputs.end(), [](double val){return val != 0;}))) {
+      logEvalError(Form("p.d.f normalization integral is zero or negative."
+          "\n\tInt(%s) = %f", GetName(), normVal));
+    }
+
+    if (normVal != 1. && normVal > 0.) {
+      const double invNorm = 1./normVal;
+      for (double& val : outputs) { //CHECK_VECTORISE
+        val *= invNorm;
+      }
+    }
+  }
+
+  return outputs;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Analytical integral with normalization (see RooAbsReal::analyticalIntegralWN() for further information)
 ///
@@ -1079,7 +1128,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
      // retrieve from cache
      const RooArgSet *constr =
         _myws->set(Form("CACHE_CONSTR_OF_PDF_%s_FOR_OBS_%s", GetName(), RooNameSet(*data.get()).content()));
-     coutI(Minimization) << "createNLL picked up cached consraints from workspace with " << constr->getSize()
+     coutI(Minimization) << "createNLL picked up cached constraints from workspace with " << constr->getSize()
                          << " entries" << endl;
      allConstraints.add(*constr);
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -5020,7 +5020,7 @@ RooSpan<double> RooAbsReal::evaluateSpan(BatchHelpers::RunContext& evalData, con
     }
   }
 
-  const auto dataSize = std::max<std::size_t>(1, BatchHelpers::findSize(leafValues));
+  const auto dataSize = std::max<std::size_t>(1, BatchHelpers::findSmallestBatch(leafValues));
   auto outputData = evalData.makeBatch(this, dataSize);
 
   {

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -85,6 +85,7 @@
 #include "RooHelpers.h"
 #include "BatchHelpers.h"
 #include "RunContext.h"
+#include "ValueChecking.h"
 
 #include "Compression.h"
 #include "Math/IFunction.h"
@@ -281,7 +282,7 @@ Double_t RooAbsReal::getValV(const RooArgSet* nset) const
   }
 
   if (isValueDirtyAndClear()) {
-    _value = traceEval(nset) ;
+    _value = traceEval(nullptr) ;
     //     clearValueDirty() ;
   }
   //   cout << "RooAbsReal::getValV(" << GetName() << ") writing _value = " << _value << endl ;
@@ -5051,11 +5052,6 @@ RooSpan<double> RooAbsReal::evaluateSpan(BatchHelpers::RunContext& evalData, con
 
 
 
-
-using RooHelpers::CachingError;
-using RooHelpers::FormatPdfTree;
-
-
 Double_t RooAbsReal::_DEBUG_getVal(const RooArgSet* normalisationSet) const {
 
   const bool tmpFast = _fast;
@@ -5155,3 +5151,74 @@ void RooAbsReal::checkBatchComputation(std::size_t evtNo, const RooArgSet* normS
   }
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Walk through expression tree headed by the `this` object, and check a batch computation.
+///
+/// Check if the results in `evalData` for event `evtNo` are identical to the current value of the nodes.
+/// If a difference is found, an exception is thrown, and propagates up the expression tree. The tree is formatted
+/// to see where the computation error happened.
+/// @param evalData Data with results of batch computation. This is checked against the current value of the expression tree.
+/// @param evtNo    Event from `evalData` to check for.
+/// @param normSet  Optional normalisation set that was used in computation.
+/// @param relAccuracy Accuracy required for passing the check.
+void RooAbsReal::checkBatchComputation(const BatchHelpers::RunContext& evalData, std::size_t evtNo, const RooArgSet* normSet, double relAccuracy) const {
+  for (const auto server : _serverList) {
+    try {
+      auto realServer = dynamic_cast<RooAbsReal*>(server);
+      if (realServer)
+        realServer->checkBatchComputation(evalData, evtNo, normSet, relAccuracy);
+    } catch (CachingError& error) {
+      throw CachingError(std::move(error),
+          FormatPdfTree() << *this);
+    }
+  }
+
+  const auto item = evalData.spans.find(this);
+  if (item == evalData.spans.end())
+    return;
+
+  auto batch = item->second;
+  const double value = getVal(normSet);
+  const double batchVal = batch.size() == 1 ? batch[0] : batch[evtNo];
+  const double relDiff = value != 0. ? (value - batchVal)/value : value - batchVal;
+
+  if (fabs(relDiff) > relAccuracy && fabs(value) > 1.E-300) {
+    FormatPdfTree formatter;
+    formatter << "--> (Batch computation wrong:)\n";
+    printStream(formatter.stream(), kName | kClassName | kArgs | kExtras | kAddress, kInline);
+    formatter << std::setprecision(17)
+    << "\n batch[" << std::setw(7) << evtNo-1 << "]=     " << (evtNo > 0 && evtNo - 1 < batch.size() ? std::to_string(batch[evtNo-1]) : "---")
+    << "\n batch[" << std::setw(7) << evtNo   << "]=     " << batchVal << " !!!"
+    << "\n expected ('value'): " << value
+    << "\n eval(unnorm.)     : " << evaluate()
+    << "\n delta         " <<                     " =     " << value - batchVal
+    << "\n rel delta     " <<                     " =     " << relDiff
+    << "\n _batch[" << std::setw(7) << evtNo+1 << "]=     " << (batch.size() > evtNo+1 ? std::to_string(batch[evtNo+1]) : "---");
+
+
+
+    formatter << "\nServers: ";
+    for (const auto server : _serverList) {
+      formatter << "\n - ";
+      server->printStream(formatter.stream(), kName | kClassName | kArgs | kExtras | kAddress | kValue, kInline);
+      formatter << std::setprecision(17);
+
+      auto serverAsReal = dynamic_cast<RooAbsReal*>(server);
+      if (serverAsReal) {
+        auto serverBatch = evalData.spans.count(serverAsReal) != 0 ? evalData.spans.find(serverAsReal)->second : RooSpan<const double>();
+        if (serverBatch.size() > evtNo) {
+          formatter << "\n   _batch[" << evtNo-1 << "]=" << (serverBatch.size() > evtNo-1 ? std::to_string(serverBatch[evtNo-1]) : "---")
+                    << "\n   _batch[" << evtNo << "]=" << serverBatch[evtNo]
+                    << "\n   _batch[" << evtNo+1 << "]=" << (serverBatch.size() > evtNo+1 ? std::to_string(serverBatch[evtNo+1]) : "---");
+        }
+        else {
+          formatter << std::setprecision(17)
+          << "\n   getVal()=" << serverAsReal->getVal(normSet);
+        }
+      }
+    }
+
+    throw CachingError(formatter);
+  }
+}

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -83,6 +83,8 @@
 #include "RooVectorDataStore.h"
 #include "RooCachedReal.h"
 #include "RooHelpers.h"
+#include "BatchHelpers.h"
+#include "RunContext.h"
 
 #include "Compression.h"
 #include "Math/IFunction.h"
@@ -102,6 +104,9 @@
 #include "TVector.h"
 #include "ROOT/RMakeUnique.hxx"
 #include "strlcpy.h"
+#ifndef NDEBUG
+#include <TSystem.h> // To print stack traces when caching errors are detected
+#endif
 
 #include <sstream>
 #include <iostream>
@@ -317,6 +322,35 @@ RooSpan<const double> RooAbsReal::getValBatch(std::size_t begin, std::size_t max
   return _batchData.getBatch(begin, maxSize);
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute batch of values for given input data, store result in `evalData`,
+/// and return a span pointing to it.
+///
+/// \param[in] evalData  Object holding spans of input data. Store our output here.
+/// \param[in] normSet   Pass this normSet on to objects that are serving values to
+/// the one where this function is called.
+RooSpan<const double> RooAbsReal::getValues(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const {
+  auto item = evalData.spans.find(this);
+  if (item != evalData.spans.end()) {
+    return item->second;
+  }
+
+  if (normSet && normSet != _lastNSet) {
+    // TODO Implement better:
+    // The proxies, i.e. child nodes in the computation graph, sometimes need to know
+    // what to normalise over. I hope that passing the normalisation set through all
+    // interfaces will do the trick, but cross-checks that the correct normalisation set
+    // is used should nevertheless be implemented.
+    const_cast<RooAbsReal*>(this)->setProxyNormSet(normSet);
+    // This member only seems to be in use in RooFormulaVar. Consider removing it:
+    _lastNSet = (RooArgSet*) normSet;
+  }
+
+  auto results = evaluateSpan(evalData, normSet ? normSet : _lastNSet);
+
+  return results;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -4897,7 +4931,6 @@ RooSpan<double> RooAbsReal::evaluateBatch(std::size_t begin, std::size_t maxSize
         << " If it is part of ROOT, consider requesting this on https://root.cern." << std::endl;
   }
 
-
   std::vector<std::tuple<RooRealVar*, RooSpan<const double>, double>> batchLeafs;
   for (auto leaf : allLeafs) {
     auto leafRRV = dynamic_cast<RooRealVar*>(leaf);
@@ -4945,9 +4978,79 @@ RooSpan<double> RooAbsReal::evaluateBatch(std::size_t begin, std::size_t maxSize
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Evaluate function for a batch of data points. If not overridden by
+/// derived classes, this will call the slow, single-valued evaluate() in a loop.
+/// \param[in/out]  evalData Object holding data that should be used in computations.
+/// If data of a specific object is needed, it is looked up in `evalData.spans[&object]`.
+/// If such a span exists, no computation will be triggered.
+/// When the `this` object is done computing its values, it registers the results under `evalData.spans[this]`.
+/// \param[in]  normSet  Optional normalisation set for computations in terms this one depends on.
+/// \return     Span pointing to the results. The memory is owned by `evalData`.
+RooSpan<double> RooAbsReal::evaluateSpan(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const {
+  if (RooMsgService::instance().isActive(this, RooFit::FastEvaluations, RooFit::INFO)) {
+    coutI(FastEvaluations) << "The class " << IsA()->GetName() << " does not implement the faster batch evaluation interface."
+        << " Consider requesting or implementing it to benefit from a speed up." << std::endl;
+  }
+
+  // Find leaves of the computation graph. Assign known data values to these.
+  RooArgSet allLeafs;
+  leafNodeServerList(&allLeafs);
+
+  std::vector<RooAbsRealLValue*> settableLeaves;
+  std::vector<RooSpan<const double>> leafValues;
+  std::vector<double> oldLeafValues;
+
+  for (auto item : allLeafs) {
+    if (!item->IsA()->InheritsFrom(RooAbsRealLValue::Class()))
+      continue;
+
+    auto leaf = static_cast<RooAbsRealLValue*>(item);
+
+    settableLeaves.push_back(leaf);
+    oldLeafValues.push_back(leaf->getVal());
+
+    auto knownLeaf = evalData.spans.find(leaf);
+    if (knownLeaf != evalData.spans.end()) {
+      // Data are already known
+      leafValues.push_back(knownLeaf->second);
+    } else {
+      auto result = leaf->getValues(evalData, normSet);
+      leafValues.push_back(result);
+    }
+  }
+
+  const auto dataSize = std::max<std::size_t>(1, BatchHelpers::findSize(leafValues));
+  auto outputData = evalData.makeBatch(this, dataSize);
+
+  {
+    // Side track all caching that RooFit might think is necessary.
+    // When used with batch computations, we depend on computation
+    // graphs actually evaluating correctly, instead of having
+    // pre-calculated values side-loaded into nodes event-per-event.
+    DisableCachingRAII disableCaching(inhibitDirty());
+
+    // For each event, assign values to the leaves, and run the single-value computation.
+    for (std::size_t i=0; i < outputData.size(); ++i) {
+      for (unsigned int j=0; j < settableLeaves.size(); ++j) {
+        if (leafValues[j].size() > i)
+          settableLeaves[j]->setVal(leafValues[j][i], evalData.rangeName);
+      }
+
+      outputData[i] = evaluate();
+    }
+  }
+
+  // Reset values
+  for (unsigned int j=0; j < settableLeaves.size(); ++j) {
+    settableLeaves[j]->setVal(oldLeafValues[j]);
+  }
+
+  return outputData;
+}
 
 
-#include "TSystem.h"
+
 
 using RooHelpers::CachingError;
 using RooHelpers::FormatPdfTree;
@@ -4970,7 +5073,9 @@ Double_t RooAbsReal::_DEBUG_getVal(const RooArgSet* normalisationSet) const {
   const double ret = (_fast && !_inhibitDirty) ? _value : fullEval;
 
   if (std::isfinite(ret) && ( ret != 0. ? (ret - fullEval)/ret : ret - fullEval) > 1.E-9) {
+#ifndef NDEBUG
     gSystem->StackTrace();
+#endif
     FormatPdfTree formatter;
     formatter << "--> (Scalar computation wrong here:)\n"
             << GetName() << " " << this << " _fast=" << tmpFast

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -511,3 +511,19 @@ void RooCompositeDataStore::dump()
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Get the weights of the events in the range [first, first+len).
+/// This implementation will fill a vector with every event retrieved one by one
+/// (even if the weight is constant). Then, it returns a span.
+RooSpan<const double> RooCompositeDataStore::getWeightBatch(std::size_t first, std::size_t len) const {
+  if (!_weightBuffer) {
+    _weightBuffer.reset(new std::vector<double>());
+    _weightBuffer->reserve(len);
+
+    for (std::size_t i = 0; i < static_cast<std::size_t>(numEntries()); ++i) {
+      _weightBuffer->push_back(weight(i));
+    }
+  }
+
+  return {_weightBuffer->data() + first, len};
+}

--- a/roofit/roofitcore/src/RooConstVar.cxx
+++ b/roofit/roofitcore/src/RooConstVar.cxx
@@ -22,26 +22,23 @@
 RooConstVar represent a constant real-valued object
 **/
 
-
-#include "RooFit.h"
-
-#include "Riostream.h"
 #include "RooConstVar.h"
+#include "BatchHelpers.h"
+#include "RunContext.h"
 
 using namespace std;
 
 ClassImp(RooConstVar);
-  ;
 
 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with value
-///_fast = kTRUE ;
-
 RooConstVar::RooConstVar(const char *name, const char *title, Double_t value) : 
-  RooAbsReal(name,title), _value(value)
-{  
+  RooAbsReal(name,title)
+{
+  _fast = true;
+  _value = value;
   setAttribute("Constant",kTRUE) ;
 }
 
@@ -49,22 +46,23 @@ RooConstVar::RooConstVar(const char *name, const char *title, Double_t value) :
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
-///_fast = kTRUE ;
-
 RooConstVar::RooConstVar(const RooConstVar& other, const char* name) : 
-  RooAbsReal(other, name), _value(other._value)
+  RooAbsReal(other, name)
 {
+  _fast = true;
 }
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Destructor
+/// Return batch with 1 constant element.
+RooSpan<const double> RooConstVar::getValues(BatchHelpers::RunContext& evalData, const RooArgSet*) const {
+  auto item = evalData.spans.find(this);
+  if (item == evalData.spans.end()) {
+    return evalData.spans[this] = {&_value, 1};
+  }
 
-RooConstVar::~RooConstVar() 
-{
+  return evalData.spans[this];
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Write object contents to stream

--- a/roofit/roofitcore/src/RooDataProjBinding.cxx
+++ b/roofit/roofitcore/src/RooDataProjBinding.cxx
@@ -165,8 +165,9 @@ Double_t RooDataProjBinding::operator()(const Double_t xvector[]) const
 RooSpan<const double> RooDataProjBinding::getValues(std::vector<RooSpan<const double>> coordinates) const {
   assert(isValid());
 
-  std::vector<double> results;
-  results.reserve(coordinates.front().size());
+  if (!_batchBuffer)
+    _batchBuffer.reset(new std::vector<double>());
+  _batchBuffer->resize(coordinates.front().size());
 
   std::unique_ptr<double[]> xVec( new double[coordinates.size()] );
 
@@ -175,8 +176,8 @@ RooSpan<const double> RooDataProjBinding::getValues(std::vector<RooSpan<const do
       xVec.get()[dim] = coordinates[dim][i];
     }
 
-    this->operator()(xVec.get());
+    (*_batchBuffer)[i] = this->operator()(xVec.get());
   }
 
-  return std::move(results);
+  return {*_batchBuffer};
 }

--- a/roofit/roofitcore/src/RooDataProjBinding.cxx
+++ b/roofit/roofitcore/src/RooDataProjBinding.cxx
@@ -158,3 +158,25 @@ Double_t RooDataProjBinding::operator()(const Double_t xvector[]) const
   if (wgtSum==0) return 0 ;
   return result / wgtSum ;
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Evaluate the function at the specified values of the dependents.
+RooSpan<const double> RooDataProjBinding::getValues(std::vector<RooSpan<const double>> coordinates) const {
+  assert(isValid());
+
+  std::vector<double> results;
+  results.reserve(coordinates.front().size());
+
+  std::unique_ptr<double[]> xVec( new double[coordinates.size()] );
+
+  for (std::size_t i=0; i < coordinates.front().size(); ++i) {
+    for (unsigned int dim=0; dim < coordinates.size(); ++dim) {
+      xVec.get()[dim] = coordinates[dim][i];
+    }
+
+    this->operator()(xVec.get());
+  }
+
+  return std::move(results);
+}

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -89,6 +89,7 @@ For the inverse conversion, see `RooAbsData::convertToVectorStore()`.
 #include "RooSentinel.h"
 #include "RooTrace.h"
 #include "RooHelpers.h"
+#include "BatchHelpers.h"
 
 #include "TTree.h"
 #include "TH2.h"
@@ -1007,10 +1008,26 @@ Double_t RooDataSet::weightSquared() const
 }
 
 
-
-// See base class.
+////////////////////////////////////////////////////////////////////////////////
+/// \see RooAbsData::getWeightBatch().
 RooSpan<const double> RooDataSet::getWeightBatch(std::size_t first, std::size_t len) const {
   return _dstore->getWeightBatch(first, len);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Retrieve batches of data for each real-valued variable in this dataset.
+/// \param[out] evalData Store references to all data batches in this struct's `spans`.
+/// The key to retrieve an item is the pointer of the variable that owns the data.
+/// \param first Index of first event that ends up in the batch.
+/// \param len   Number of events in each batch.
+void RooDataSet::getBatches(BatchHelpers::RunContext& evalData, std::size_t begin, std::size_t len) const {
+  std::vector<RooSpan<const double>> batches = store()->getBatch(begin, len);
+
+  for (unsigned int i=0; i < _varsNoWgt.size(); ++i) {
+    auto var = static_cast<RooRealVar*>(_varsNoWgt[i]);
+    evalData.spans[var] = batches[i];
+  }
 }
 
 

--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -386,7 +386,7 @@ RooSpan<double> RooFormula::evaluateSpan(const RooAbsReal* dataOwner, BatchHelpe
     inputSpans.push_back(std::move(batch));
   }
 
-  const auto nData = BatchHelpers::findSize(inputSpans);
+  const auto nData = BatchHelpers::findSmallestBatch(inputSpans);
   auto output = inputData.makeBatch(dataOwner, nData);
   std::vector<double> pars(_origList.size());
 

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -153,6 +153,24 @@ Double_t RooFormulaVar::evaluate() const
 
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Evaluate the formula for all entries of our servers found in `inputData`.
+RooSpan<double> RooFormulaVar::evaluateSpan(BatchHelpers::RunContext& inputData, const RooArgSet* normSet) const {
+  if (normSet != _lastNSet) {
+    // TODO: Remove dependence on _lastNSet
+    // See also comment in RooAbsReal::getValBatch().
+    std::cerr << "Formula " << GetName() << " " << GetTitle() << "\n\tBeing evaluated with normSet " << normSet << "\n";
+    normSet->Print("V");
+    std::cerr << "\tHowever, _lastNSet = " << _lastNSet << "\n";
+    if (_lastNSet) _lastNSet->Print("V");
+
+    throw std::logic_error("Got conflicting norm sets. This shouldn't happen.");
+  }
+
+  return formula().evaluateSpan(this, inputData, normSet);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Propagate server change information to embedded RooFormula object
 
 Bool_t RooFormulaVar::redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t /*isRecursive*/)

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -49,6 +49,7 @@ the names of the arguments are not hard coded.
 #include "RooStreamParser.h"
 #include "RooMsgService.h"
 #include "RooArgList.h"
+#include "RunContext.h"
 
 
 
@@ -126,6 +127,17 @@ Double_t RooGenericPdf::evaluate() const
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Evaluate this formula for values found in inputData.
+RooSpan<double> RooGenericPdf::evaluateSpan(BatchHelpers::RunContext& inputData, const RooArgSet* normSet) const {
+  if (normSet != nullptr && normSet != _normSet)
+    throw std::logic_error("Got conflicting normSets");
+
+  auto results = formula().evaluateSpan(this, inputData, _normSet);
+  inputData.spans[this] = results;
+
+  return results;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Change formula expression to given expression

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -39,8 +39,10 @@ In extended mode, a
 #include "RooRealSumPdf.h"
 #include "RooRealVar.h"
 #include "RooProdPdf.h"
-#include "RooHelpers.h"
 #include "RooNaNPacker.h"
+#ifdef ROOFIT_CHECK_CACHED_VALUES
+#include "BatchHelpers.h"
+#endif
 
 #include "TMath.h"
 #include "Math/Util.h"
@@ -455,7 +457,7 @@ std::tuple<double, double, double> RooNLLVar::computeBatched(std::size_t stepSiz
     assert(_dataClone->valid());
     pdfClone->getValV(_normSet);
     try {
-      RooHelpers::BatchInterfaceAccessor::checkBatchComputation(*pdfClone, evtNo, _normSet);
+      BatchHelpers::BatchInterfaceAccessor::checkBatchComputation(*pdfClone, evtNo, _normSet);
     } catch (std::exception& e) {
       std::cerr << "ERROR when checking batch computation for event " << evtNo << ":\n"
           << e.what() << std::endl;

--- a/roofit/roofitcore/src/RooRealAnalytic.cxx
+++ b/roofit/roofitcore/src/RooRealAnalytic.cxx
@@ -28,6 +28,7 @@ RooAbsReal object (specified by a code) to a set of dependent variables.
 
 #include "RooRealAnalytic.h"
 #include "RooAbsReal.h"
+#include "RooAbsRealLValue.h"
 
 #include <assert.h>
 
@@ -46,4 +47,29 @@ Double_t RooRealAnalytic::operator()(const Double_t xvector[]) const
   loadValues(xvector);  
   _ncall++ ;
   return _code ? _func->analyticalIntegralWN(_code,_nset,_rangeName?_rangeName->GetName():0):_func->getVal(_nset) ;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Evaluate the analytic integral of the function at the specified values of the dependents.
+RooSpan<const double> RooRealAnalytic::getValues(std::vector<RooSpan<const double>> coordinates) const {
+  assert(isValid());
+  _ncall += coordinates.front().size();
+
+  std::vector<double> results;
+  results.reserve(coordinates.front().size());
+
+  for (std::size_t i=0; i < coordinates.front().size(); ++i) {
+    for (unsigned int dim=0; dim < coordinates.size(); ++dim) {
+      _vars[dim]->setVal(coordinates[dim][i]);
+    }
+
+    if (_code == 0) {
+      results.push_back(_func->getVal(_nset));
+    } else {
+      results.push_back(_func->analyticalIntegralWN(_code,_nset,_rangeName?_rangeName->GetName():0));
+    }
+  }
+
+  return std::move(results);
 }

--- a/roofit/roofitcore/src/RooRealAnalytic.cxx
+++ b/roofit/roofitcore/src/RooRealAnalytic.cxx
@@ -56,8 +56,10 @@ RooSpan<const double> RooRealAnalytic::getValues(std::vector<RooSpan<const doubl
   assert(isValid());
   _ncall += coordinates.front().size();
 
-  std::vector<double> results;
-  results.reserve(coordinates.front().size());
+  if (!_batchBuffer)
+    _batchBuffer.reset(new std::vector<double>());
+  _batchBuffer->resize(coordinates.front().size());
+  RooSpan<double> results(*_batchBuffer);
 
   for (std::size_t i=0; i < coordinates.front().size(); ++i) {
     for (unsigned int dim=0; dim < coordinates.size(); ++dim) {
@@ -65,11 +67,12 @@ RooSpan<const double> RooRealAnalytic::getValues(std::vector<RooSpan<const doubl
     }
 
     if (_code == 0) {
-      results.push_back(_func->getVal(_nset));
+      results[i] = _func->getVal(_nset);
     } else {
-      results.push_back(_func->analyticalIntegralWN(_code,_nset,_rangeName?_rangeName->GetName():0));
+      results[i] = _func->analyticalIntegralWN(_code,_nset,_rangeName?_rangeName->GetName():0);
     }
   }
 
-  return std::move(results);
+  return results;
 }
+

--- a/roofit/roofitcore/src/RooRealBinding.cxx
+++ b/roofit/roofitcore/src/RooRealBinding.cxx
@@ -238,7 +238,7 @@ RooSpan<const double> RooRealBinding::getValues(std::vector<RooSpan<const double
   assert(coordinates.front().size() == results.size());
 
   if (_clipInvalid) {
-    RooSpan<double> resultsWritable(_evalData->ownedMemory[_func]);
+    RooSpan<double> resultsWritable(_evalData->getWritableBatch(_func));
     assert(results.data() == resultsWritable.data());
     assert(results.size() == resultsWritable.size());
 

--- a/roofit/roofitcore/src/RooRealBinding.cxx
+++ b/roofit/roofitcore/src/RooRealBinding.cxx
@@ -30,6 +30,8 @@ of its servers and present it as a simple array oriented interface.
 #include "RooAbsRealLValue.h"
 #include "RooNameReg.h"
 #include "RooMsgService.h"
+#include "BatchHelpers.h"
+#include "RunContext.h"
 
 #include <cassert>
 
@@ -122,11 +124,12 @@ void RooRealBinding::saveXVec() const
   _funcSave = _func->_value ;
 
   // Save components
-  list<RooAbsReal*>::iterator ci = _compList.begin() ;
-  list<Double_t>::iterator si = _compSave.begin() ;
-  while(ci!=_compList.end()) {
+  auto ci = _compList.begin() ;
+  auto si = _compSave.begin() ;
+  while(ci != _compList.end()) {
     *si = (*ci)->_value ;
-    ++si ; ++ci ;
+    ++si;
+    ++ci;
   }
   
   for (UInt_t i=0 ; i<getDimension() ; i++) {
@@ -146,11 +149,12 @@ void RooRealBinding::restoreXVec() const
   _func->_value = _funcSave ;
 
   // Restore components
-  list<RooAbsReal*>::iterator ci = _compList.begin() ;
-  list<Double_t>::iterator si = _compSave.begin() ;
-  while (ci!=_compList.end()) {
+  auto ci = _compList.begin() ;
+  auto si = _compSave.begin() ;
+  while (ci != _compList.end()) {
     (*ci)->_value = *si ;
-    ++ci ; ++si ;
+    ++ci;
+    ++si;
   }
 
   for (UInt_t i=0 ; i<getDimension() ; i++) {
@@ -188,8 +192,69 @@ Double_t RooRealBinding::operator()(const Double_t xvector[]) const
   assert(isValid());
   _ncall++ ;
   loadValues(xvector);
-  //cout << getName() << "(x=" << xvector[0] << ")=" << _func->getVal(_nset) << " (nset = " << (_nset? *_nset:RooArgSet()) << ")" << endl ;
   return _xvecValid ? _func->getVal(_nset) : 0. ;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Evaluate the bound object at all locations indicated by the data in `coordinates`.
+/// \param coordinates Vector of spans that contain the points where the function should be evaluated.
+/// The ordinal position in the vector corresponds to the ordinal position in the set of
+/// {observables, parameters} that were passed to the constructor.
+/// The spans can either have a size of `n`, in which case a batch of `n` results is returned, or they can have
+/// a size of 1. In the latter case, the value in the span is broadcast to all `n` events.
+/// \return Batch of function values for each coordinate given in the input spans. If a parameter is invalid, i.e.,
+/// out of its range, an empty span is returned. If an observable is invalid, the function value is 0.
+RooSpan<const double> RooRealBinding::getValues(std::vector<RooSpan<const double>> coordinates) const {
+  assert(isValid());
+  _ncall += coordinates.front().size();
+
+  bool parametersValid = true;
+
+  // Use _evalData to hold on to memory between integration calls
+  if (!_evalData) {
+    _evalData.reset(new BatchHelpers::RunContext());
+  } else {
+    _evalData->clear();
+  }
+  _evalData->rangeName = RooNameReg::instance().constStr(_rangeName);
+
+  for (unsigned int dim=0; dim < coordinates.size(); ++dim) {
+    const RooSpan<const double>& values = coordinates[dim];
+    RooAbsRealLValue& var = *_vars[dim];
+    _evalData->spans[&var] = values;
+    if (_clipInvalid && values.size() == 1) {
+      // The argument is a parameter of the function. Check it
+      // here, so we can do early stopping if it's invalid.
+      parametersValid &= var.isValidReal(values[0]);
+      assert(values.size() == 1);
+    }
+  }
+
+  if (!parametersValid)
+    return {};
+
+  auto results = _func->getValues(*_evalData, _nset);
+  assert(coordinates.front().size() == results.size());
+
+  if (_clipInvalid) {
+    RooSpan<double> resultsWritable(_evalData->ownedMemory[_func]);
+    assert(results.data() == resultsWritable.data());
+    assert(results.size() == resultsWritable.size());
+
+    // Run through all events, and check if the given coordinates are valid:
+    for (std::size_t coord=0; coord < coordinates.size(); ++coord) {
+      if (coordinates[coord].size() == 1)
+        continue; // We checked all parameters above
+
+      for (std::size_t evt=0; evt < coordinates[coord].size(); ++evt) {
+        if (!_vars[coord]->isValidReal(coordinates[coord][evt]))
+          resultsWritable[evt] = 0.;
+      }
+    }
+  }
+
+  return results;
 }
 
 

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -1384,3 +1384,25 @@ std::string RooTreeDataStore::makeTreeName() const {
   return std::string("RooTreeDataStore_") + GetName() + "_" + title;
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get the weights of the events in the range [first, first+len).
+/// This implementation will fill a vector with every event retrieved one by one
+/// (even if the weight is constant). Then, it returns a span.
+RooSpan<const double> RooTreeDataStore::getWeightBatch(std::size_t first, std::size_t len) const {
+
+  if (_extWgtArray) {
+    return {_extWgtArray + first, len};
+  }
+
+  if (!_weightBuffer) {
+    _weightBuffer.reset(new std::vector<double>());
+    _weightBuffer->reserve(len);
+
+    for (std::size_t i = 0; i < GetEntries(); ++i) {
+      _weightBuffer->push_back(weight(i));
+    }
+  }
+
+  return {_weightBuffer->data() + first, len};
+}

--- a/roofit/roofitcore/src/RunContext.cxx
+++ b/roofit/roofitcore/src/RunContext.cxx
@@ -1,0 +1,75 @@
+// Author: Stephan Hageboeck, CERN  Jul 2020
+
+/*****************************************************************************
+ * RooFit
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2020, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#include "RunContext.h"
+
+#include "RooArgProxy.h"
+#include "RooAbsReal.h"
+
+namespace BatchHelpers {
+
+/// Check if there is a span of data corresponding to the variable in this proxy.
+RooSpan<const double> RunContext::getBatch(const RooArgProxy& proxy) const {
+  return getBatch(static_cast<const RooAbsReal*>(proxy.absArg()));
+}
+
+
+/// Check if there is a span of data corresponding to the object passed as owner.
+RooSpan<const double> RunContext::getBatch(const RooAbsReal* owner) const {
+  const auto item = spans.find(owner);
+  if (item != spans.end())
+    return item->second;
+
+  return {};
+}
+
+
+/// Check if there is a writable span of data corresponding to the object passed as owner.
+/// The span can be used both for reading and writing.
+RooSpan<double> RunContext::getWritableBatch(const RooAbsReal* owner) {
+  auto item = ownedMemory.find(owner);
+  if (item != ownedMemory.end()) {
+    assert(spans.count(owner) > 0); // If we can write, the span must also be registered for reading
+    return RooSpan<double>(item->second);
+  }
+
+  return {};
+}
+
+
+/// Create a writable batch. If the RunContext already owns memory for the object
+/// `owner`, just resize the memory. If it doesn't exist yet, allocate it.
+/// \warning The memory will be uninitialised, so every entry **must** be overwritten.
+/// On first use, all values are initialised to `-inf` to help detect such errors.
+/// A read-only reference to the memory will be stored in `spans`.
+/// \param owner RooFit object whose value should be written into the memory.
+/// \param size Requested size of the span.
+/// \return A writeable RooSpan of the requested size, whose memory is owned by
+/// the RunContext.
+RooSpan<double> RunContext::makeBatch(const RooAbsReal* owner, std::size_t size) {
+  auto item = ownedMemory.find(owner);
+  if (item == ownedMemory.end() || item->second.size() != size) {
+    std::vector<double>& data = ownedMemory[owner];
+    data.resize(size, -std::numeric_limits<double>::infinity());
+    spans[owner] = RooSpan<const double>(data);
+    return {data};
+  }
+
+  spans[owner] = RooSpan<const double>(item->second);
+  return {item->second};
+}
+
+}

--- a/roofit/roofitcore/src/ValueChecking.h
+++ b/roofit/roofitcore/src/ValueChecking.h
@@ -1,0 +1,95 @@
+/*
+ * ValueChecking.h
+ *
+ *  Created on: 03.08.2020
+ *      Author: shageboeck
+ */
+
+#ifndef ROOFIT_ROOFITCORE_INC_VALUECHECKING_H_
+#define ROOFIT_ROOFITCORE_INC_VALUECHECKING_H_
+
+#include <TSystem.h>
+
+#include <exception>
+#include <vector>
+#include <string>
+#include <sstream>
+
+class CachingError : public std::exception {
+  public:
+    CachingError(const std::string& newMessage) :
+      std::exception(),
+      _messages()
+    {
+      _messages.push_back(newMessage);
+    }
+
+    CachingError(CachingError&& previous, const std::string& newMessage) :
+    std::exception(),
+    _messages{std::move(previous._messages)}
+    {
+      _messages.push_back(newMessage);
+    }
+
+    const char* what() const noexcept override {
+      std::stringstream out;
+      out << "**Computation/caching error** in\n";
+
+      std::string indent;
+      for (auto it = _messages.rbegin(); it != _messages.rend(); ++it) {
+        std::string message = *it;
+        auto pos = message.find('\n', 0);
+        while (pos != std::string::npos) {
+          message.insert(pos+1, indent);
+          pos = (message.find('\n', pos+1));
+        }
+
+        out << indent << message << "\n";
+        indent += " ";
+      }
+
+      out << std::endl;
+
+      std::string* ret = new std::string(out.str()); //Make it survive this method
+
+      return ret->c_str();
+    }
+
+
+  private:
+    std::vector<std::string> _messages;
+};
+
+
+class FormatPdfTree {
+  public:
+    template <class T,
+    typename std::enable_if<std::is_base_of<RooAbsArg, T>::value>::type* = nullptr >
+    FormatPdfTree& operator<<(const T& arg) {
+      _stream << arg.ClassName() << "::" << arg.GetName() << " " << &arg << " ";
+      arg.printArgs(_stream);
+      return *this;
+    }
+
+    template <class T,
+    typename std::enable_if< ! std::is_base_of<RooAbsArg, T>::value>::type* = nullptr >
+    FormatPdfTree& operator<<(const T& arg) {
+      _stream << arg;
+      return *this;
+    }
+
+    operator std::string() const {
+      return _stream.str();
+    }
+
+    std::ostream& stream() {
+      return _stream;
+    }
+
+  private:
+    std::ostringstream _stream;
+};
+
+
+
+#endif /* ROOFIT_ROOFITCORE_INC_VALUECHECKING_H_ */

--- a/roofit/roofitmore/src/RooHypatia2.cxx
+++ b/roofit/roofitmore/src/RooHypatia2.cxx
@@ -502,7 +502,7 @@ RooSpan<double> RooHypatia2::evaluateBatch(std::size_t begin, std::size_t batchS
   auto a2 = _a2.getValBatch(begin, batchSize);
   auto n2 = _n2.getValBatch(begin, batchSize);
 
-  batchSize = BatchHelpers::findSize({x, lambda, zeta, beta, sig, mu, a, n, a2, n2});
+  batchSize = BatchHelpers::findSmallestBatch({x, lambda, zeta, beta, sig, mu, a, n, a2, n2});
 
   auto output = _batchData.makeWritableBatchInit(begin, batchSize, 0.);
 


### PR DESCRIPTION
Add a new interface to RooFit, which uses a `RunContext` object to store data. This allows for passing data around between nodes of the computation graph without having to alter class members.
Some residual altering of class members remains, so the interface is not thread safe. It, however, solves the problem of not being able to compute an integral, the likelihoods of entries in a dataset + possibly some other set of x-values while another computation is running. This is the key to solving things like ROOT-3874 or faster integrators.

In this PR, the interface is never used. Uses + tests will come in later PRs, but I couldn't dump 30 commits in one PR.