### PR TITLE
[DF] Fix calls to compiled Snapshot without columns, `Snapshot<>`

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -509,23 +509,33 @@ std::function<R(unsigned int, Args...)> AddSlotParameter(F &f, TypeList<Args...>
 }
 
 template <typename ColType, typename... Rest>
-struct RNeedJitting {
-   static constexpr bool value = RNeedJitting<Rest...>::value;
+struct RNeedJittingHelper {
+   static constexpr bool value = RNeedJittingHelper<Rest...>::value;
 };
 
 template <typename... Rest>
-struct RNeedJitting<RInferredType, Rest...> {
+struct RNeedJittingHelper<RInferredType, Rest...> {
    static constexpr bool value = true;
 };
 
 template <typename T>
-struct RNeedJitting<T> {
+struct RNeedJittingHelper<T> {
    static constexpr bool value = false;
 };
 
 template <>
-struct RNeedJitting<RInferredType> {
+struct RNeedJittingHelper<RInferredType> {
    static constexpr bool value = true;
+};
+
+template <typename ...ColTypes>
+struct RNeedJitting {
+   static constexpr bool value = RNeedJittingHelper<ColTypes...>::value;
+};
+
+template <>
+struct RNeedJitting<> {
+   static constexpr bool value = false;
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Recent changes in Snapshot broke the edge case of a compiled Snapshot
call with no selected columns, i.e. `Snapshot<>("tree", "f.root", {})`.
This commit adds support for this case in the CreateAction machinery
that Snapshot now makes use of, re-enabling this usecase.

We have a "test" for this usecase in rootbench.