### PR TITLE
Optimize TPrincipal::AddRow function

### DIFF
--- a/hist/hist/src/TPrincipal.cxx
+++ b/hist/hist/src/TPrincipal.cxx
@@ -420,17 +420,23 @@ void TPrincipal::AddRow(const Double_t *p)
    }
    else {
 
-      Double_t cor = 1 - 1./Double_t(fNumberOfDataPoints);
+      Double_t invnp = 1. / Double_t(fNumberOfDataPoints);
+      Double_t invnpM1 = 1. /(Double_t(fNumberOfDataPoints - 1));
+      Double_t cor = 1. - invnp;
+      // use directly vector array for faster element access
+      Double_t * meanValues = fMeanValues.GetMatrixArray();
+      Double_t * covMatrix =  fCovarianceMatrix.GetMatrixArray();
       for (i = 0; i < fNumberOfVariables; i++) {
 
-         fMeanValues(i) *= cor;
-         fMeanValues(i) += p[i] / Double_t(fNumberOfDataPoints);
-         Double_t t1 = (p[i] - fMeanValues(i)) / (fNumberOfDataPoints - 1);
+         meanValues[i] *= cor;
+         meanValues[i] += p[i] * invnp;
+         Double_t t1 = (p[i] - meanValues[i]) * invnpM1;
 
          // Setting Matrix (lower triangle) elements
          for (j = 0; j < i + 1; j++) {
-            fCovarianceMatrix(i,j) *= cor;
-            fCovarianceMatrix(i,j) += t1 * (p[j] - fMeanValues(j));
+            Int_t index = i * fNumberOfVariables + j;
+            covMatrix[index] *= cor;
+            covMatrix[index] += t1 * (p[j] - meanValues[j]);
          }
       }
    }
@@ -446,7 +452,7 @@ void TPrincipal::AddRow(const Double_t *p)
 
    for (i = 0; i < fNumberOfVariables; i++) {
       j = (fNumberOfDataPoints-1) * fNumberOfVariables + i;
-      fUserData(j) = p[i];
+      fUserData.GetMatrixArray()[j] = p[i];
    }
 
 }

--- a/hist/hist/src/TPrincipal.cxx
+++ b/hist/hist/src/TPrincipal.cxx
@@ -420,9 +420,9 @@ void TPrincipal::AddRow(const Double_t *p)
    }
    else {
 
-      Double_t invnp = 1. / Double_t(fNumberOfDataPoints);
-      Double_t invnpM1 = 1. /(Double_t(fNumberOfDataPoints - 1));
-      Double_t cor = 1. - invnp;
+      const Double_t invnp = 1. / Double_t(fNumberOfDataPoints);
+      const Double_t invnpM1 = 1. /(Double_t(fNumberOfDataPoints - 1));
+      const Double_t cor = 1. - invnp;
       // use directly vector array for faster element access
       Double_t * meanValues = fMeanValues.GetMatrixArray();
       Double_t * covMatrix =  fCovarianceMatrix.GetMatrixArray();
@@ -430,11 +430,11 @@ void TPrincipal::AddRow(const Double_t *p)
 
          meanValues[i] *= cor;
          meanValues[i] += p[i] * invnp;
-         Double_t t1 = (p[i] - meanValues[i]) * invnpM1;
+         const Double_t t1 = (p[i] - meanValues[i]) * invnpM1;
 
          // Setting Matrix (lower triangle) elements
          for (j = 0; j < i + 1; j++) {
-            Int_t index = i * fNumberOfVariables + j;
+            const Int_t index = i * fNumberOfVariables + j;
             covMatrix[index] *= cor;
             covMatrix[index] += t1 * (p[j] - meanValues[j]);
          }


### PR DESCRIPTION
Optimize TPrincipal::AddRow function since it is reported that is causing a significative time in CMS reconstruction. 

Move divisions outside loop and use directly access to internal TVector and TMatrix elements.
In case data are not stored in the class the gain in the loop that is adding the row has been measured to be a factor of 10 for a data of 100 dimension and 100000 points