### PR TITLE
[ntuple] Improve RFieldBase::Clone signature

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -154,7 +154,7 @@ public:
    virtual ~RFieldBase();
 
    ///// Copies the field and its sub fields using a possibly new name and a new, unconnected set of columns
-   virtual RFieldBase *Clone(std::string_view newName) const = 0;
+   virtual std::unique_ptr<RFieldBase> Clone(std::string_view newName) const = 0;
 
    /// Factory method to resurrect a field from the stored on-disk type information
    static RFieldBase *Create(const std::string &fieldName, const std::string &typeName);
@@ -260,7 +260,7 @@ public:
 class RFieldZero : public Detail::RFieldBase {
 public:
    RFieldZero() : Detail::RFieldBase("", "", ENTupleStructure::kRecord, false /* isSimple */) { }
-   RFieldBase* Clone(std::string_view newName) const;
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const;
 
    void GenerateColumnsImpl() final {}
    using Detail::RFieldBase::GenerateValue;
@@ -289,7 +289,7 @@ public:
    RClassField(RClassField&& other) = default;
    RClassField& operator =(RClassField&& other) = default;
    ~RClassField() = default;
-   RFieldBase* Clone(std::string_view newName) const final;
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
    using Detail::RFieldBase::GenerateValue;
@@ -317,7 +317,7 @@ public:
    RVectorField(RVectorField&& other) = default;
    RVectorField& operator =(RVectorField&& other) = default;
    ~RVectorField() = default;
-   RFieldBase* Clone(std::string_view newName) const final;
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
    using Detail::RFieldBase::GenerateValue;
@@ -354,7 +354,7 @@ public:
    RArrayField(RArrayField &&other) = default;
    RArrayField& operator =(RArrayField &&other) = default;
    ~RArrayField() = default;
-   RFieldBase *Clone(std::string_view newName) const final;
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
    using Detail::RFieldBase::GenerateValue;
@@ -393,7 +393,7 @@ public:
    RVariantField(RVariantField &&other) = default;
    RVariantField& operator =(RVariantField &&other) = default;
    ~RVariantField() = default;
-   RFieldBase *Clone(std::string_view newName) const final;
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
    using Detail::RFieldBase::GenerateValue;
@@ -441,7 +441,7 @@ public:
    RCollectionField(RCollectionField&& other) = default;
    RCollectionField& operator =(RCollectionField&& other) = default;
    ~RCollectionField() = default;
-   RFieldBase* Clone(std::string_view newName) const final;
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
 
@@ -472,7 +472,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    void GenerateColumnsImpl() final;
 
@@ -518,7 +520,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase *Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    void GenerateColumnsImpl() final;
 
@@ -555,7 +559,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    void GenerateColumnsImpl() final;
 
@@ -593,7 +599,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    void GenerateColumnsImpl() final;
 
@@ -630,7 +638,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    void GenerateColumnsImpl() final;
 
@@ -667,7 +677,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    void GenerateColumnsImpl() final;
 
@@ -704,7 +716,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    void GenerateColumnsImpl() final;
 
@@ -741,7 +755,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    void GenerateColumnsImpl() final;
 
@@ -788,7 +804,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    void GenerateColumnsImpl() final;
 
@@ -930,7 +948,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField(newName));
+   }
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
@@ -1010,9 +1030,9 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final {
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
       auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
-      return new RField<ROOT::VecOps::RVec<ItemT>>(newName, std::unique_ptr<Detail::RFieldBase>(newItemField));
+      return std::unique_ptr<RFieldBase>(new RField<ROOT::VecOps::RVec<ItemT>>(newName, std::move(newItemField)));
    }
 
    void GenerateColumnsImpl() final {
@@ -1097,8 +1117,8 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) const final {
-      return new RField<ROOT::VecOps::RVec<bool>>(newName);
+   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view newName) const final {
+      return std::unique_ptr<Detail::RFieldBase>(new RField<ROOT::VecOps::RVec<bool>>(newName));
    }
 
    void GenerateColumnsImpl() final {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -154,7 +154,7 @@ public:
    virtual ~RFieldBase();
 
    ///// Copies the field and its sub fields using a possibly new name and a new, unconnected set of columns
-   virtual RFieldBase *Clone(std::string_view newName) = 0;
+   virtual RFieldBase *Clone(std::string_view newName) const = 0;
 
    /// Factory method to resurrect a field from the stored on-disk type information
    static RFieldBase *Create(const std::string &fieldName, const std::string &typeName);
@@ -260,7 +260,7 @@ public:
 class RFieldZero : public Detail::RFieldBase {
 public:
    RFieldZero() : Detail::RFieldBase("", "", ENTupleStructure::kRecord, false /* isSimple */) { }
-   RFieldBase* Clone(std::string_view newName);
+   RFieldBase* Clone(std::string_view newName) const;
 
    void GenerateColumnsImpl() final {}
    using Detail::RFieldBase::GenerateValue;
@@ -289,7 +289,7 @@ public:
    RClassField(RClassField&& other) = default;
    RClassField& operator =(RClassField&& other) = default;
    ~RClassField() = default;
-   RFieldBase* Clone(std::string_view newName) final;
+   RFieldBase* Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
    using Detail::RFieldBase::GenerateValue;
@@ -317,7 +317,7 @@ public:
    RVectorField(RVectorField&& other) = default;
    RVectorField& operator =(RVectorField&& other) = default;
    ~RVectorField() = default;
-   RFieldBase* Clone(std::string_view newName) final;
+   RFieldBase* Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
    using Detail::RFieldBase::GenerateValue;
@@ -354,7 +354,7 @@ public:
    RArrayField(RArrayField &&other) = default;
    RArrayField& operator =(RArrayField &&other) = default;
    ~RArrayField() = default;
-   RFieldBase *Clone(std::string_view newName) final;
+   RFieldBase *Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
    using Detail::RFieldBase::GenerateValue;
@@ -393,7 +393,7 @@ public:
    RVariantField(RVariantField &&other) = default;
    RVariantField& operator =(RVariantField &&other) = default;
    ~RVariantField() = default;
-   RFieldBase *Clone(std::string_view newName) final;
+   RFieldBase *Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
    using Detail::RFieldBase::GenerateValue;
@@ -441,7 +441,7 @@ public:
    RCollectionField(RCollectionField&& other) = default;
    RCollectionField& operator =(RCollectionField&& other) = default;
    ~RCollectionField() = default;
-   RFieldBase* Clone(std::string_view newName) final;
+   RFieldBase* Clone(std::string_view newName) const final;
 
    void GenerateColumnsImpl() final;
 
@@ -472,7 +472,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
 
    void GenerateColumnsImpl() final;
 
@@ -518,7 +518,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase *Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase *Clone(std::string_view newName) const final { return new RField(newName); }
 
    void GenerateColumnsImpl() final;
 
@@ -555,7 +555,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
 
    void GenerateColumnsImpl() final;
 
@@ -593,7 +593,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
 
    void GenerateColumnsImpl() final;
 
@@ -630,7 +630,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
 
    void GenerateColumnsImpl() final;
 
@@ -667,7 +667,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
 
    void GenerateColumnsImpl() final;
 
@@ -704,7 +704,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
 
    void GenerateColumnsImpl() final;
 
@@ -741,7 +741,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
 
    void GenerateColumnsImpl() final;
 
@@ -788,7 +788,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
 
    void GenerateColumnsImpl() final;
 
@@ -930,7 +930,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final { return new RField(newName); }
+   RFieldBase* Clone(std::string_view newName) const final { return new RField(newName); }
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
@@ -1010,7 +1010,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final {
+   RFieldBase* Clone(std::string_view newName) const final {
       auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
       return new RField<ROOT::VecOps::RVec<ItemT>>(newName, std::unique_ptr<Detail::RFieldBase>(newItemField));
    }
@@ -1097,7 +1097,7 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() = default;
-   RFieldBase* Clone(std::string_view newName) final {
+   RFieldBase* Clone(std::string_view newName) const final {
       return new RField<ROOT::VecOps::RVec<bool>>(newName);
    }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -322,7 +322,7 @@ void ROOT::Experimental::Detail::RFieldBase::RSchemaIterator::Advance()
 //------------------------------------------------------------------------------
 
 
-ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RFieldZero::Clone(std::string_view /*newName*/)
+ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RFieldZero::Clone(std::string_view /*newName*/) const
 {
    Detail::RFieldBase* result = new RFieldZero();
    for (auto &f : fSubFields) {
@@ -542,7 +542,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
    }
 }
 
-ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RClassField::Clone(std::string_view newName)
+ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RClassField::Clone(std::string_view newName) const
 {
    return new RClassField(newName, GetType());
 }
@@ -638,7 +638,7 @@ ROOT::Experimental::RVectorField::RVectorField(
    Attach(std::move(itemField));
 }
 
-ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RVectorField::Clone(std::string_view newName)
+ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RVectorField::Clone(std::string_view newName) const
 {
    auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
    return new RVectorField(newName, std::unique_ptr<Detail::RFieldBase>(newItemField));
@@ -822,7 +822,7 @@ ROOT::Experimental::RArrayField::RArrayField(
    Attach(std::move(itemField));
 }
 
-ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RArrayField::Clone(std::string_view newName)
+ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RArrayField::Clone(std::string_view newName) const
 {
    auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
    return new RArrayField(newName, std::unique_ptr<Detail::RFieldBase>(newItemField), fArrayLength);
@@ -931,7 +931,7 @@ ROOT::Experimental::RVariantField::RVariantField(
    fTagOffset = (fMaxItemSize < fMaxAlignment) ? fMaxAlignment : fMaxItemSize;
 }
 
-ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RVariantField::Clone(std::string_view newName)
+ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RVariantField::Clone(std::string_view newName) const
 {
    auto nFields = fSubFields.size();
    std::vector<Detail::RFieldBase *> itemFields;
@@ -1050,7 +1050,7 @@ void ROOT::Experimental::RCollectionField::GenerateColumnsImpl()
 }
 
 
-ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RCollectionField::Clone(std::string_view /*newName*/)
+ROOT::Experimental::Detail::RFieldBase* ROOT::Experimental::RCollectionField::Clone(std::string_view /*newName*/) const
 {
    // TODO(jblomer)
    return nullptr;

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -43,9 +43,9 @@ ROOT::Experimental::RNTupleModel::RNTupleModel()
 ROOT::Experimental::RNTupleModel* ROOT::Experimental::RNTupleModel::Clone()
 {
    auto cloneModel = new RNTupleModel();
-   auto cloneFieldZero = static_cast<RFieldZero*>(fFieldZero->Clone(""));
-   cloneModel->fFieldZero = std::unique_ptr<RFieldZero>(cloneFieldZero);
-   cloneModel->fDefaultEntry = std::unique_ptr<REntry>(cloneFieldZero->GenerateEntry());
+   auto cloneFieldZero = fFieldZero->Clone("");
+   cloneModel->fFieldZero = std::unique_ptr<RFieldZero>(static_cast<RFieldZero *>(cloneFieldZero.release()));
+   cloneModel->fDefaultEntry = std::unique_ptr<REntry>(cloneModel->fFieldZero->GenerateEntry());
    return cloneModel;
 }
 


### PR DESCRIPTION
- Make it `const`
- Return a unique pointer instead of a raw pointer