### PR TITLE
[RF] Continue new batch interface

### DIFF
--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -104,9 +104,9 @@ public:
   /// \param first Index of first event that ends up in the batch.
   /// \param len   Number of events in each batch.
   /// Needs to be overridden by derived classes. This implementation returns an empty RunContext.
-  virtual void getBatches(BatchHelpers::RunContext& evalData, std::size_t first = 0, std::size_t len = std::numeric_limits<std::size_t>::max()) const {
-    (void)evalData; (void)first; (void)len;
-  }
+  virtual void getBatches(BatchHelpers::RunContext& evalData,
+      std::size_t first = 0, std::size_t len = std::numeric_limits<std::size_t>::max()) const = 0;
+
   ////////////////////////////////////////////////////////////////////////////////
   /// Return event weights of all events in range [first, first+len).
   /// If no contiguous structure of weights is stored, an empty batch can be returned.

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -27,6 +27,9 @@ class RooAbsArg ;
 class RooArgList ;
 class TIterator ;
 class TTree ;
+namespace BatchHelpers {
+struct RunContext;
+}
 
 class RooAbsDataStore : public TNamed, public RooPrintable {
 public:
@@ -53,7 +56,8 @@ public:
   virtual Double_t weight(Int_t index) const = 0 ;
   virtual Bool_t isWeighted() const = 0 ;
 
-  virtual std::vector<RooSpan<const double>> getBatch(std::size_t first, std::size_t len) const = 0;
+  /// Retrieve batches for all observables in this data store.
+  virtual BatchHelpers::RunContext getBatches(std::size_t first, std::size_t len) const = 0;
   virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const = 0;
 
   // Change observable name

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -207,6 +207,7 @@ public:
   RooSpan<const double> getValues(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const;
   RooSpan<const double> getLogValBatch(std::size_t begin, std::size_t batchSize,
       const RooArgSet* normSet = nullptr) const;
+  RooSpan<const double> getLogProbabilities(BatchHelpers::RunContext& evalData, const RooArgSet* normSet = nullptr) const;
 
   /// \copydoc getNorm(const RooArgSet*) const
   Double_t getNorm(const RooArgSet& nset) const { 

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -132,6 +132,7 @@ protected:
 
   Double_t evaluate() const;
   virtual RooSpan<double> evaluateBatch(std::size_t begin, std::size_t batchSize) const;
+  RooSpan<double> evaluateSpan(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const;
 
 
   mutable RooAICRegistry _codeReg ;  //! Registry of component analytical integration codes

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -100,13 +100,12 @@ public:
 
   virtual void forceCacheUpdate() ;
   
-  virtual std::vector<RooSpan<const double>> getBatch(std::size_t first, std::size_t last) const {
+  virtual BatchHelpers::RunContext getBatches(std::size_t first, std::size_t len) const {
     //TODO
     std::cerr << "This functionality is not yet implemented for composite data stores." << std::endl;
-    throw std::logic_error("RooCompositeDataStore doesn't have batch access yet.");
-
-    std::vector<double> vec(first, last);
-    return {RooSpan<const double>(vec)};
+    throw std::logic_error("getBatches() not implemented for RooCompositeDataStore.");
+    (void)first; (void)len;
+    return {};
   }
   virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const;
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -90,13 +90,8 @@ public:
   }
   virtual Bool_t isNonPoissonWeighted() const ;
 
-  virtual RooSpan<const double> getWeightBatch(std::size_t, std::size_t) const {
-    //TODO
-    std::cerr << "Retrieving weights in batches not yet implemented for RooDataHist." << std::endl;
-    assert(false);
-
-    return {};
-  }
+  virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const;
+  void getBatches(BatchHelpers::RunContext& evalData, std::size_t begin, std::size_t len) const;
 
   Double_t sum(Bool_t correctForBinSize, Bool_t inverseCorr=kFALSE) const ;
   Double_t sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, Bool_t correctForBinSize, Bool_t inverseCorr=kFALSE) ;

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -23,12 +23,15 @@
 #include <utility>
 
 class RooRealSumPdf ;
+namespace BatchHelpers {
+struct RunContext;
+}
 
 class RooNLLVar : public RooAbsOptTestStatistic {
 public:
 
   // Constructors, assignment etc
-  RooNLLVar() { _first = kTRUE ; }
+  RooNLLVar();
   RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbsData& data,
 	    const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
 	    const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
@@ -75,15 +78,16 @@ private:
   std::tuple<double, double, double> computeScalar(
         std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const;
 
-  Bool_t _extended ;
+  Bool_t _extended{false};
   bool _batchEvaluations{false};
-  Bool_t _weightSq ; // Apply weights squared?
-  mutable Bool_t _first ; //!
-  Double_t _offsetSaveW2; //!
-  Double_t _offsetCarrySaveW2; //!
+  Bool_t _weightSq{false}; // Apply weights squared?
+  mutable Bool_t _first{true}; //!
+  Double_t _offsetSaveW2{false}; //!
+  Double_t _offsetCarrySaveW2{false}; //!
 
   mutable std::vector<Double_t> _binw ; //!
-  mutable RooRealSumPdf* _binnedPdf ; //!
+  mutable RooRealSumPdf* _binnedPdf{nullptr}; //!
+  mutable std::unique_ptr<BatchHelpers::RunContext> _evalData; //! Struct to store function evaluation workspaces.
    
   ClassDef(RooNLLVar,3) // Function representing (extended) -log(L) of p.d.f and dataset
 };

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -27,6 +27,10 @@
 #include <list>
 #include <string>
 
+namespace BatchHelpers {
+struct RunContext;
+}
+
 typedef RooArgList* pRooArgList ;
 typedef RooLinkedList* pRooLinkedList ;
 
@@ -100,6 +104,7 @@ private:
 
   Double_t evaluate() const ;
   virtual RooSpan<double> evaluateBatch(std::size_t begin, std::size_t size) const;
+  virtual RooSpan<double> evaluateSpan(BatchHelpers::RunContext& evalData, const RooArgSet* normSet) const;
 
   RooAbsReal* makeCondPdfRatioCorr(RooAbsReal& term, const RooArgSet& termNset, const RooArgSet& termImpSet, const char* normRange, const char* refRange) const ;
 

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -68,13 +68,12 @@ public:
   virtual Double_t weight(Int_t index) const ;
   virtual Bool_t isWeighted() const { return (_wgtVar!=0||_extWgtArray!=0) ; }
 
-  virtual std::vector<RooSpan<const double>> getBatch(std::size_t first, std::size_t last) const {
+  virtual BatchHelpers::RunContext getBatches(std::size_t first, std::size_t len) const {
     //TODO
     std::cerr << "This functionality is not yet implemented for tree data stores." << std::endl;
-    assert(false);
-
-    std::vector<double> vec(first, last);
-    return {RooSpan<const double>(vec)};
+    throw std::logic_error("getBatches() not implemented in RooTreeDataStore.");
+    (void)first; (void)len;
+    return {};
   }
   virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const;
 

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -76,7 +76,7 @@ public:
   virtual Double_t weight(Int_t index) const override;
   virtual Bool_t isWeighted() const override { return (_wgtVar!=0||_extWgtArray!=0) ; }
 
-  virtual std::vector<RooSpan<const double>> getBatch(std::size_t first, std::size_t last) const override;
+  BatchHelpers::RunContext getBatches(std::size_t first, std::size_t len) const override;
   virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const override;
 
   // Change observable name

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1018,17 +1018,16 @@ RooSpan<const double> RooDataSet::getWeightBatch(std::size_t first, std::size_t 
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Retrieve batches of data for each real-valued variable in this dataset.
+/// Write information to retrieve data columns into `evalData.spans`.
+/// All spans belonging to variables of this dataset are overwritten. Spans to other
+/// variables remain intact.
 /// \param[out] evalData Store references to all data batches in this struct's `spans`.
 /// The key to retrieve an item is the pointer of the variable that owns the data.
 /// \param first Index of first event that ends up in the batch.
 /// \param len   Number of events in each batch.
 void RooDataSet::getBatches(BatchHelpers::RunContext& evalData, std::size_t begin, std::size_t len) const {
-  std::vector<RooSpan<const double>> batches = store()->getBatch(begin, len);
-
-  for (unsigned int i=0; i < _varsNoWgt.size(); ++i) {
-    auto var = static_cast<RooRealVar*>(_varsNoWgt[i]);
-    evalData.spans[var] = batches[i];
+  for (auto&& batch : store()->getBatches(begin, len).spans) {
+    evalData.spans[batch.first] = std::move(batch.second);
   }
 }
 

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -40,6 +40,8 @@ In extended mode, a
 #include "RooRealVar.h"
 #include "RooProdPdf.h"
 #include "RooNaNPacker.h"
+#include "RunContext.h"
+
 #ifdef ROOFIT_CHECK_CACHED_VALUES
 #include "BatchHelpers.h"
 #endif
@@ -53,6 +55,8 @@ ClassImp(RooNLLVar)
 
 RooArgSet RooNLLVar::_emptySet ;
 
+RooNLLVar::RooNLLVar()
+{ }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct likelihood from given p.d.f and (binned or unbinned dataset)
@@ -452,6 +456,13 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Compute probabilites of all data events. Use faster batch interface.
+/// \param[in] stepSize Stride when moving through the dataset.
+///   \note For batch computations, the step size **must** be one.
+/// \param[in] firstEvent  First event to be processed.
+/// \param[in] lastEvent   First event not to be processed.
+/// \return Tuple with (Kahan sum of probabilities, carry of kahan sum, sum of weights)
 std::tuple<double, double, double> RooNLLVar::computeBatched(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const
 {
   if (stepSize != 1) {
@@ -460,10 +471,37 @@ std::tuple<double, double, double> RooNLLVar::computeBatched(std::size_t stepSiz
 
   auto pdfClone = static_cast<const RooAbsPdf*>(_funcClone);
 
-  auto results = pdfClone->getLogValBatch(firstEvent, lastEvent-firstEvent, _normSet);
+#ifdef ROOFIT_NEW_BATCH_INTERFACE
+  // Create a RunContext that will own the memory where computation results are stored.
+  // Holding on to this struct in between function calls will make sure that the memory
+  // is only allocated once.
+  if (!_evalData) {
+    _evalData.reset(new BatchHelpers::RunContext);
+  }
+  _evalData->clear();
+  _dataClone->getBatches(*_evalData, firstEvent, lastEvent-firstEvent);
 
+  auto results = pdfClone->getLogProbabilities(*_evalData, _normSet);
+#else
+  auto results = pdfClone->getLogValBatch(firstEvent, lastEvent-firstEvent, _normSet);
+#endif
 
 #ifdef ROOFIT_CHECK_CACHED_VALUES
+
+#ifdef ROOFIT_NEW_BATCH_INTERFACE
+  for (std::size_t evtNo = firstEvent; evtNo < lastEvent; evtNo += (lastEvent-firstEvent)/100) {
+    _dataClone->get(evtNo);
+    assert(_dataClone->valid());
+    pdfClone->getValV(_normSet);
+    try {
+      BatchHelpers::BatchInterfaceAccessor::checkBatchComputation(*pdfClone, *_evalData, evtNo, _normSet);
+    } catch (std::exception& e) {
+      std::cerr << "ERROR when checking batch computation for event " << evtNo << ":\n"
+          << e.what() << std::endl;
+    }
+  }
+
+#else
   for (std::size_t evtNo = firstEvent; evtNo < lastEvent; ++evtNo) {
     _dataClone->get(evtNo);
     assert(_dataClone->valid());
@@ -475,6 +513,8 @@ std::tuple<double, double, double> RooNLLVar::computeBatched(std::size_t stepSiz
           << e.what() << std::endl;
     }
   }
+#endif
+
 #endif
 
 

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -494,13 +494,12 @@ std::tuple<double, double, double> RooNLLVar::computeBatched(std::size_t stepSiz
     assert(_dataClone->valid());
     pdfClone->getValV(_normSet);
     try {
-      BatchHelpers::BatchInterfaceAccessor::checkBatchComputation(*pdfClone, *_evalData, evtNo, _normSet);
+      BatchHelpers::BatchInterfaceAccessor::checkBatchComputation(*pdfClone, *_evalData, evtNo-firstEvent, _normSet);
     } catch (std::exception& e) {
       std::cerr << "ERROR when checking batch computation for event " << evtNo << ":\n"
           << e.what() << std::endl;
     }
   }
-
 #else
   for (std::size_t evtNo = firstEvent; evtNo < lastEvent; ++evtNo) {
     _dataClone->get(evtNo);


### PR DESCRIPTION
Add more functionality to new batch interface, notably
- The direct retrieval of spans from datasets / data histograms.
- Code that uses the new interface in RooNLLVar for testing. For the moment protected by an `#ifdef ROOFIT_NEW_BATCH_INTEFACE`.
- An implementation of a batch computation for the RooProdPdf.

@phsft-bot build with flags -DCMAKE_CXX_FLAGS=-DROOFIT_NEW_BATCH_INTERFACE