### PR TITLE
[bug] [Core] Prevent null pointer dereference in TQObject.

### DIFF
--- a/core/base/src/TQObject.cxx
+++ b/core/base/src/TQObject.cxx
@@ -473,6 +473,7 @@ void TQObject::CollectClassSignalLists(TList& list, TClass* cls)
 
 void TQObject::HighPriority(const char *signal_name, const char *slot_name)
 {
+   if (!fListOfSignals) return;
    TQConnectionList *clist = (TQConnectionList*)
       fListOfSignals->FindObject(signal_name);
 
@@ -499,6 +500,7 @@ void TQObject::HighPriority(const char *signal_name, const char *slot_name)
 
 void TQObject::LowPriority(const char *signal_name, const char *slot_name)
 {
+   if (!fListOfSignals) return;
    TQConnectionList *clist = (TQConnectionList*)
       fListOfSignals->FindObject(signal_name);
 


### PR DESCRIPTION
Prevent null pointer dereference in TQObject.
Please note that ``if (!fListOfSignals)`` checks already exist in other functions of this class.

Tag @bellenot 