### PR TITLE
[http] Fix special handling of rest_url argument in exe.json

### DIFF
--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -553,9 +553,11 @@ Bool_t TRootSnifferFull::ProduceExe(const std::string &path, const std::string &
          // very special case - function requires list of options after method=argument
 
          const char *pos = strstr(options.c_str(), "method=");
-         if (!pos || (strlen(pos) < strlen(method_name) + 8))
+         if (!pos || (strlen(pos) < strlen(method_name) + 7))
             return debug != nullptr;
-         call_args.Form("\"%s\"", pos + strlen(method_name) + 8);
+         const char *rest_url = pos + strlen(method_name) + 7;
+         if (*rest_url == '&') ++rest_url;
+         call_args.Form("\"%s\"", rest_url);
          break;
       }
 


### PR DESCRIPTION
If exe.json?method=MethodName was requested without any
extra arguments, such request was ignored.
But one can call obj->MethodName(""); in this case.
Now fixed