### PR TITLE
[nlohmann/json.hpp] fix warning with gcc 4.8

### DIFF
--- a/io/io/res/json.hpp
+++ b/io/io/res/json.hpp
@@ -4448,15 +4448,15 @@ class byte_container_with_subtype : public BinaryType
         : container_type(std::move(b))
     {}
 
-    byte_container_with_subtype(const container_type& b, std::uint8_t subtype) noexcept(noexcept(container_type(b)))
+    byte_container_with_subtype(const container_type& b, std::uint8_t subtype_) noexcept(noexcept(container_type(b)))
         : container_type(b)
-        , m_subtype(subtype)
+        , m_subtype(subtype_)
         , m_has_subtype(true)
     {}
 
-    byte_container_with_subtype(container_type&& b, std::uint8_t subtype) noexcept(noexcept(container_type(std::move(b))))
+    byte_container_with_subtype(container_type&& b, std::uint8_t subtype_) noexcept(noexcept(container_type(std::move(b))))
         : container_type(std::move(b))
-        , m_subtype(subtype)
+        , m_subtype(subtype_)
         , m_has_subtype(true)
     {}
 
@@ -4489,9 +4489,9 @@ class byte_container_with_subtype : public BinaryType
 
     @since version 3.8.0
     */
-    void set_subtype(std::uint8_t subtype) noexcept
+    void set_subtype(std::uint8_t subtype_) noexcept
     {
-        m_subtype = subtype;
+        m_subtype = subtype_;
         m_has_subtype = true;
     }
 


### PR DESCRIPTION
By chance internal data member is the same as "subtype" argument

Fixes warnings like:
```
In file included from /mnt/build/jenkins/night/LABEL/ROOT-centos7/SPEC/noimt/V/6-22/root/io/io/src/TBufferJSON.cxx:131:0:
/mnt/build/jenkins/night/LABEL/ROOT-centos7/SPEC/noimt/V/6-22/root/io/io/res/json.hpp: In constructor ‘nlohmann::byte_container_with_subtype<BinaryType>::byte_container_with_subtype(const container_type&, uint8_t)’:

/mnt/build/jenkins/night/LABEL/ROOT-centos7/SPEC/noimt/V/6-22/root/io/io/res/json.hpp:4452:9: warning: declaration of ‘subtype’ shadows a member of 'this' [-Wshadow]
         : container_type(b)
         ^
/mnt/build/jenkins/night/LABEL/ROOT-centos7/SPEC/noimt/V/6-22/root/io/io/res/json.hpp: In constructor ‘nlohmann::byte_container_with_subtype<BinaryType>::byte_container_with_subtype(nlohmann::byte_container_with_subtype<BinaryType>::container_type&&, uint8_t)’:

/mnt/build/jenkins/night/LABEL/ROOT-centos7/SPEC/noimt/V/6-22/root/io/io/res/json.hpp:4458:9: warning: declaration of ‘subtype’ shadows a member of 'this' [-Wshadow]
         : container_type(std::move(b))
         ^
/mnt/build/jenkins/night/LABEL/ROOT-centos7/SPEC/noimt/V/6-22/root/io/io/res/json.hpp: In member function ‘void nlohmann::byte_container_with_subtype<BinaryType>::set_subtype(uint8_t)’:

/mnt/build/jenkins/night/LABEL/ROOT-centos7/SPEC/noimt/V/6-22/root/io/io/res/json.hpp:4493:5: warning: declaration of ‘subtype’ shadows a member of 'this' [-Wshadow]
     {
     ^
```