### PR TITLE
[DF] Improve reading collections with RNTuple DS

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -35,14 +35,18 @@ class RNTupleDescriptor;
 namespace Detail {
 class RFieldBase;
 class RFieldValue;
+class RNTupleColumnReader;
 class RPageSource;
-
 } // namespace Detail
 
 class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// Clones of the first source, one for each slot
    std::vector<std::unique_ptr<ROOT::Experimental::Detail::RPageSource>> fSources;
 
+   /// We prepare a column reader prototype for every column. If a column reader is actually requested
+   /// in GetColumnReaders(), we move a clone of the prototype into the hands of RDataFrame.
+   /// Only the clone connects to the backing page store and acquires I/O resources.
+   std::vector<std::unique_ptr<Detail::RNTupleColumnReader>> fColumnReaderPrototypes;
    std::vector<std::string> fColumnNames;
    std::vector<std::string> fColumnTypes;
    std::vector<size_t> fActiveColumns;
@@ -50,11 +54,11 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    unsigned fNSlots = 0;
    bool fHasSeenAllRanges = false;
 
-   void AddFields(const RNTupleDescriptor &desc, DescriptorId_t parentId);
+   void AddRecord(const RNTupleDescriptor &desc, DescriptorId_t parentId);
 
 public:
    explicit RNTupleDS(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);
-   ~RNTupleDS() = default;
+   ~RNTupleDS();
    void SetNSlots(unsigned int nSlots) final;
    const std::vector<std::string> &GetColumnNames() const final { return fColumnNames; }
    bool HasColumn(std::string_view colName) const final;

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -54,7 +54,8 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    unsigned fNSlots = 0;
    bool fHasSeenAllRanges = false;
 
-   void AddRecord(const RNTupleDescriptor &desc, DescriptorId_t parentId);
+   void AddCollection(const RNTupleDescriptor &desc, DescriptorId_t collectionId);
+   void AddRecord(const RNTupleDescriptor &desc, DescriptorId_t recordId);
 
 public:
    explicit RNTupleDS(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -54,6 +54,14 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    unsigned fNSlots = 0;
    bool fHasSeenAllRanges = false;
 
+   /// Provides the RDF column "colName" given the field identified by fieldID. For records and collections,
+   /// AddProjection recurses into the sub fields. The skeinIDs is the list of field IDs of the outer collections
+   /// of fieldId. For instance, if fieldId refers to an `std::vector<Jet>`, with
+   /// struct Jet {
+   ///    float pt;
+   ///    float eta;
+   /// };
+   /// AddProject will recurse into Jet.pt and Jet.eta and provide the two inner fields as std::vector<float> each.
    void AddProjection(const RNTupleDescriptor &desc,
                       std::string_view colName,
                       DescriptorId_t fieldId,

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -54,8 +54,10 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    unsigned fNSlots = 0;
    bool fHasSeenAllRanges = false;
 
-   void AddCollection(const RNTupleDescriptor &desc, DescriptorId_t collectionId);
-   void AddRecord(const RNTupleDescriptor &desc, DescriptorId_t recordId);
+   void AddProjection(const RNTupleDescriptor &desc,
+                      std::string_view colName,
+                      DescriptorId_t fieldId,
+                      std::vector<DescriptorId_t> skeinIDs);
 
 public:
    explicit RNTupleDS(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -55,17 +55,17 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    bool fHasSeenAllRanges = false;
 
    /// Provides the RDF column "colName" given the field identified by fieldID. For records and collections,
-   /// AddProjection recurses into the sub fields. The skeinIDs is the list of field IDs of the outer collections
+   /// AddField recurses into the sub fields. The skeinIDs is the list of field IDs of the outer collections
    /// of fieldId. For instance, if fieldId refers to an `std::vector<Jet>`, with
    /// struct Jet {
    ///    float pt;
    ///    float eta;
    /// };
    /// AddProject will recurse into Jet.pt and Jet.eta and provide the two inner fields as std::vector<float> each.
-   void AddProjection(const RNTupleDescriptor &desc,
-                      std::string_view colName,
-                      DescriptorId_t fieldId,
-                      std::vector<DescriptorId_t> skeinIDs);
+   void AddField(const RNTupleDescriptor &desc,
+                 std::string_view colName,
+                 DescriptorId_t fieldId,
+                 std::vector<DescriptorId_t> skeinIDs);
 
 public:
    explicit RNTupleDS(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -35,9 +35,12 @@ class RNTupleDescriptor;
 namespace Detail {
 class RFieldBase;
 class RFieldValue;
-class RNTupleColumnReader;
 class RPageSource;
 } // namespace Detail
+
+namespace Internal {
+class RNTupleColumnReader;
+}
 
 class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// Clones of the first source, one for each slot
@@ -46,7 +49,7 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// We prepare a column reader prototype for every column. If a column reader is actually requested
    /// in GetColumnReaders(), we move a clone of the prototype into the hands of RDataFrame.
    /// Only the clone connects to the backing page store and acquires I/O resources.
-   std::vector<std::unique_ptr<Detail::RNTupleColumnReader>> fColumnReaderPrototypes;
+   std::vector<std::unique_ptr<ROOT::Experimental::Internal::RNTupleColumnReader>> fColumnReaderPrototypes;
    std::vector<std::string> fColumnNames;
    std::vector<std::string> fColumnTypes;
    std::vector<size_t> fActiveColumns;

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -61,7 +61,7 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    ///    float pt;
    ///    float eta;
    /// };
-   /// AddProject will recurse into Jet.pt and Jet.eta and provide the two inner fields as std::vector<float> each.
+   /// AddField will recurse into Jet.pt and Jet.eta and provide the two inner fields as std::vector<float> each.
    void AddField(const RNTupleDescriptor &desc,
                  std::string_view colName,
                  DescriptorId_t fieldId,

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -147,15 +147,15 @@ public:
 };
 
 /// Provides a particular field of the RNTuple as RDF column
-class RNTupleProjectionColumnReader : public RNTupleColumnReader {
+class RNTupleNormalColumnReader : public RNTupleColumnReader {
 public:
-   RNTupleProjectionColumnReader(std::unique_ptr<RFieldBase> f, const std::vector<DescriptorId_t> &skeinIDs)
+   RNTupleNormalColumnReader(std::unique_ptr<RFieldBase> f, const std::vector<DescriptorId_t> &skeinIDs)
       : RNTupleColumnReader(std::move(f), skeinIDs)
    {
    }
 
    std::unique_ptr<RNTupleColumnReader> Clone() const final {
-      return std::make_unique<RNTupleProjectionColumnReader>(fField->Clone(fField->GetName()), fSkeinIDs);
+      return std::make_unique<RNTupleNormalColumnReader>(fField->Clone(fField->GetName()), fSkeinIDs);
    }
 
    void Connect(RPageSource &source) final {
@@ -226,7 +226,7 @@ void RNTupleDS::AddField(
    skeinIDs.emplace_back(fieldId);
    fColumnNames.emplace_back(colName);
    fColumnTypes.emplace_back(valueField->GetType());
-   auto valColReader = std::make_unique<Detail::RNTupleProjectionColumnReader>(std::move(valueField), skeinIDs);
+   auto valColReader = std::make_unique<Detail::RNTupleNormalColumnReader>(std::move(valueField), skeinIDs);
    fColumnReaderPrototypes.emplace_back(std::move(valColReader));
 }
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -34,6 +34,9 @@ namespace ROOT {
 namespace Experimental {
 namespace Detail {
 
+/// An artifical field that transforms an RNTuple column that contains the offset of collections into
+/// collection sizes. It is used to provide the "number of" RDF columns for collections, e.g.
+/// `#jets` for a collection named `jets`.
 class RRDFCardinalityField : public ROOT::Experimental::Detail::RFieldBase {
 public:
    ROOT::Experimental::RField<ClusterSize_t> fOffsetField;
@@ -51,6 +54,8 @@ public:
       return std::make_unique<RRDFCardinalityField>();
    }
 
+   /// Being virtual, the field doesn't have any columns of its own but it uses, indirectly, the columns
+   /// of fOffsetField when reading
    void GenerateColumnsImpl() final { }
 
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final
@@ -63,6 +68,7 @@ public:
    }
    size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
 
+   /// Get the number of elements of the collection identified by globalIndex
    void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex,
                        ROOT::Experimental::Detail::RFieldValue *value) final
    {
@@ -70,6 +76,7 @@ public:
       fOffsetField.GetCollectionInfo(globalIndex, &collectionStart, value->Get<ClusterSize_t>());
    }
 
+   /// Get the number of elements of the collection identified by clusterIndex
    void ReadInClusterImpl(const ROOT::Experimental::RClusterIndex &clusterIndex,
                           ROOT::Experimental::Detail::RFieldValue *value) final
    {
@@ -79,15 +86,16 @@ public:
 };
 
 
+/// Every RDF column is represented by exactly one RNTuple field
 class RNTupleColumnReader : public ROOT::Detail::RDF::RColumnReaderBase {
 protected:
    using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
    using RFieldValue = ROOT::Experimental::Detail::RFieldValue;
    using RPageSource = ROOT::Experimental::Detail::RPageSource;
 
-   std::unique_ptr<RFieldBase> fField;
-   std::vector<DescriptorId_t> fSkeinIDs;
-   RFieldValue fValue;
+   std::unique_ptr<RFieldBase> fField; ///< The field backing the RDF column
+   std::vector<DescriptorId_t> fSkeinIDs; ///< For inner collections, the field IDs of the outer collections
+   RFieldValue fValue; ///< The memory location used to read from fField
    Long64_t fLastEntry; ///< Last entry number that was read
 
 public:
@@ -97,7 +105,10 @@ public:
    }
    virtual ~RNTupleColumnReader() { fField->DestroyValue(fValue); }
 
+   /// Column readers are created as prtotypes and then cloned for every slot
    virtual std::unique_ptr<RNTupleColumnReader> Clone() const = 0;
+   /// The RNTuple columns of fField and the outer collection fields given by fSkeinIDs are connected
+   /// to the RNTuple page source only on demand.
    virtual void Connect(RPageSource &source) = 0;
 
    void *GetImpl(Long64_t entry) final
@@ -110,7 +121,7 @@ public:
    }
 };
 
-
+/// Provides the size of a collection as an RDF column
 class RNTupleCardinalityColumnReader : public RNTupleColumnReader {
 public:
    RNTupleCardinalityColumnReader(std::unique_ptr<RFieldBase> f, const std::vector<DescriptorId_t> &skeinIDs)
@@ -133,7 +144,7 @@ public:
    }
 };
 
-
+/// Provides a particular field of the RNTuple as RDF column
 class RNTupleProjectionColumnReader : public RNTupleColumnReader {
 public:
    RNTupleProjectionColumnReader(std::unique_ptr<RFieldBase> f, const std::vector<DescriptorId_t> &skeinIDs)
@@ -167,24 +178,31 @@ void RNTupleDS::AddProjection(
 {
    const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
    if (fieldDesc.GetStructure() == ENTupleStructure::kCollection) {
+      // Inner fields of collections are provided as projected collections of only that inner field
       skeinIDs.emplace_back(fieldId);
       // There should only be one sub field but it's easiest to access via the sub field range
       for (const auto& f : desc.GetFieldRange(fieldDesc.GetId())) {
          AddProjection(desc, colName, f.GetId(), skeinIDs);
       }
+      // Note that at the end of the recursion, we handled the inner collections as well as the
+      // collection as whole (e.g. we have RDF columns std::vector<jet.pt>, std::vector<float> jet.eta)
+      // _and_ std::vector<Jet> jet. So we are done.
       return;
    } else if (fieldDesc.GetStructure() == ENTupleStructure::kRecord) {
+      // Inner fields of records are provided as individual RDF columns
       for (const auto& f : desc.GetFieldRange(fieldDesc.GetId())) {
          auto innerName = colName.empty() ? f.GetFieldName() : (std::string(colName) + "." + f.GetFieldName());
          AddProjection(desc, innerName, f.GetId(), skeinIDs);
       }
    }
 
+   // The class of fieldId might not be loaded in which case only the inner fields are made available
    auto fieldOrException = Detail::RFieldBase::Create("", fieldDesc.GetTypeName());
    if (!fieldOrException)
       return;
    auto valueField = fieldOrException.Unwrap();
    std::unique_ptr<Detail::RFieldBase> cardinalityField;
+   // Collections get the additional "number of" RDF column (e.g. `#jets`)
    if (!skeinIDs.empty())
       cardinalityField = std::make_unique<Detail::RRDFCardinalityField>();
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -180,12 +180,10 @@ void RNTupleDS::AddProjection(
       }
    }
 
-   // TODO(jblomer): return RResult from RFieldBase::Create and skip/warn if type is unknown
-   if (fieldDesc.GetTypeName().empty())
+   auto fieldOrException = Detail::RFieldBase::Create("", fieldDesc.GetTypeName());
+   if (!fieldOrException)
       return;
-
-   std::unique_ptr<Detail::RFieldBase> valueField;
-   valueField = Detail::RFieldBase::Create("", fieldDesc.GetTypeName());
+   auto valueField = fieldOrException.Unwrap();
    std::unique_ptr<Detail::RFieldBase> cardinalityField;
    if (!skeinIDs.empty())
       cardinalityField = std::make_unique<Detail::RRDFCardinalityField>();

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -138,6 +138,7 @@ public:
       auto f = fField.get();
       for (unsigned i = 0; i < fSkeinIDs.size() - 1; ++i) {
          Detail::RFieldFuse::Connect(fSkeinIDs[i], source, *f);
+         // The skein IDs refer to collection fields, so we know that they have exactly one sub field
          f = f->GetSubFields()[0];
       }
       auto cardinalityField = dynamic_cast<RRDFCardinalityField *>(f);

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -173,7 +173,7 @@ public:
 RNTupleDS::~RNTupleDS() = default;
 
 
-void RNTupleDS::AddProjection(
+void RNTupleDS::AddField(
    const RNTupleDescriptor &desc, std::string_view colName, DescriptorId_t fieldId,
    std::vector<DescriptorId_t> skeinIDs)
 {
@@ -183,7 +183,7 @@ void RNTupleDS::AddProjection(
       skeinIDs.emplace_back(fieldId);
       // There should only be one sub field but it's easiest to access via the sub field range
       for (const auto& f : desc.GetFieldRange(fieldDesc.GetId())) {
-         AddProjection(desc, colName, f.GetId(), skeinIDs);
+         AddField(desc, colName, f.GetId(), skeinIDs);
       }
       // Note that at the end of the recursion, we handled the inner collections as well as the
       // collection as whole (e.g. we have RDF columns std::vector<jet.pt>, std::vector<float> jet.eta)
@@ -193,7 +193,7 @@ void RNTupleDS::AddProjection(
       // Inner fields of records are provided as individual RDF columns
       for (const auto& f : desc.GetFieldRange(fieldDesc.GetId())) {
          auto innerName = colName.empty() ? f.GetFieldName() : (std::string(colName) + "." + f.GetFieldName());
-         AddProjection(desc, innerName, f.GetId(), skeinIDs);
+         AddField(desc, innerName, f.GetId(), skeinIDs);
       }
    }
 
@@ -236,7 +236,7 @@ RNTupleDS::RNTupleDS(std::unique_ptr<Detail::RPageSource> pageSource)
    const auto &descriptor = pageSource->GetDescriptor();
    fSources.emplace_back(std::move(pageSource));
 
-   AddProjection(descriptor, "", descriptor.GetFieldZeroId(), std::vector<DescriptorId_t>());
+   AddField(descriptor, "", descriptor.GetFieldZeroId(), std::vector<DescriptorId_t>());
 }
 
 RDF::RDataSource::Record_t RNTupleDS::GetColumnReadersImpl(std::string_view /* name */, const std::type_info & /* ti */)

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -94,7 +94,8 @@ protected:
    using RPageSource = ROOT::Experimental::Detail::RPageSource;
 
    std::unique_ptr<RFieldBase> fField; ///< The field backing the RDF column
-   std::vector<DescriptorId_t> fSkeinIDs; ///< For inner collections, the field IDs of the outer collections
+   /// For inner collections, the field IDs of the outer collections, from outermost to innermost. Empty otherwise.
+   std::vector<DescriptorId_t> fSkeinIDs;
    RFieldValue fValue; ///< The memory location used to read from fField
    Long64_t fLastEntry; ///< Last entry number that was read
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -34,7 +34,7 @@ namespace ROOT {
 namespace Experimental {
 namespace Detail {
 
-/// An artifical field that transforms an RNTuple column that contains the offset of collections into
+/// An artificial field that transforms an RNTuple column that contains the offset of collections into
 /// collection sizes. It is used to provide the "number of" RDF columns for collections, e.g.
 /// `#jets` for a collection named `jets`.
 class RRDFCardinalityField : public ROOT::Experimental::Detail::RFieldBase {

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -36,12 +36,12 @@ namespace Detail {
 
 class RRDFCardinalityField : public ROOT::Experimental::Detail::RFieldBase {
 public:
-   ROOT::Experimental::RField<ClusterSize_t> fIndexField;
+   ROOT::Experimental::RField<ClusterSize_t> fOffsetField;
 
    static std::string TypeName() { return "ROOT::Experimental::ClusterSize_t::ValueType"; }
    explicit RRDFCardinalityField(std::string_view name)
      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, false /* isSimple */)
-     , fIndexField(name)
+     , fOffsetField(name)
    {
    }
    RRDFCardinalityField(RRDFCardinalityField&& other) = default;
@@ -67,7 +67,7 @@ public:
                        ROOT::Experimental::Detail::RFieldValue *value) final
    {
       RClusterIndex collectionStart;
-      fIndexField.GetCollectionInfo(globalIndex, &collectionStart, value->Get<ClusterSize_t>());
+      fOffsetField.GetCollectionInfo(globalIndex, &collectionStart, value->Get<ClusterSize_t>());
    }
 };
 
@@ -134,7 +134,7 @@ public:
 
    void Connect(RPageSource &source) final {
       auto cardinalityField = dynamic_cast<RRDFCardinalityField *>(fField.get());
-      Detail::RFieldFuse::Connect(fFieldId, source, cardinalityField->fIndexField);
+      Detail::RFieldFuse::Connect(fFieldId, source, cardinalityField->fOffsetField);
    }
 };
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -37,6 +37,10 @@ namespace Detail {
 /// An artificial field that transforms an RNTuple column that contains the offset of collections into
 /// collection sizes. It is used to provide the "number of" RDF columns for collections, e.g.
 /// `#jets` for a collection named `jets`.
+///
+/// This field owns the collection offset field but instead of exposing the collection offsets it exposes
+/// the collection sizes (offset(N+1) - offset(N)).  For the time being, we offer this functionality only in RDataFrame.
+/// TODO(jblomer): consider providing a general set of useful virtual fields as part of RNTuple.
 class RRDFCardinalityField : public ROOT::Experimental::Detail::RFieldBase {
 public:
    ROOT::Experimental::RField<ClusterSize_t> fOffsetField;

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -258,6 +258,7 @@ RDF::RDataSource::Record_t RNTupleDS::GetColumnReadersImpl(std::string_view /* n
 std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase>
 RNTupleDS::GetColumnReaders(unsigned int slot, std::string_view name, const std::type_info & /*tid*/)
 {
+   // at this point we can assume that `name` will be found in fColumnNames, RDF is in charge validation
    // TODO(jblomer): check incoming type
    const auto index = std::distance(fColumnNames.begin(), std::find(fColumnNames.begin(), fColumnNames.end(), name));
    auto clone = fColumnReaderPrototypes[index]->Clone();

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -42,6 +42,11 @@ namespace Detail {
 /// the collection sizes (offset(N+1) - offset(N)).  For the time being, we offer this functionality only in RDataFrame.
 /// TODO(jblomer): consider providing a general set of useful virtual fields as part of RNTuple.
 class RRDFCardinalityField : public ROOT::Experimental::Detail::RFieldBase {
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view /* newName */) const final {
+      return std::make_unique<RRDFCardinalityField>();
+   }
+
 public:
    static std::string TypeName() { return "ROOT::Experimental::ClusterSize_t::ValueType"; }
    RRDFCardinalityField()
@@ -51,9 +56,6 @@ public:
    RRDFCardinalityField(RRDFCardinalityField&& other) = default;
    RRDFCardinalityField& operator =(RRDFCardinalityField&& other) = default;
    ~RRDFCardinalityField() = default;
-   std::unique_ptr<Detail::RFieldBase> Clone(std::string_view /* newName */) const final {
-      return std::make_unique<RRDFCardinalityField>();
-   }
 
    void GenerateColumnsImpl() final
    {
@@ -111,9 +113,7 @@ public:
    /// Column readers are created as prototype and then cloned for every slot
    std::unique_ptr<RNTupleColumnReader> Clone()
    {
-      auto cloneField = fField->Clone(fField->GetName());
-      cloneField->SetOnDiskId(fField->GetOnDiskId());
-      return std::make_unique<RNTupleColumnReader>(std::move(cloneField));
+      return std::make_unique<RNTupleColumnReader>(fField->Clone(fField->GetName()));
    }
 
    /// Connect the field and its subfields to the page source

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -219,7 +219,7 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
    }
 
    if (cardinalityField) {
-      fColumnNames.emplace_back(std::string("__rdf_sizeof_") + std::string(colName));
+      fColumnNames.emplace_back("__rdf_sizeof_" + std::string(colName));
       fColumnTypes.emplace_back(cardinalityField->GetType());
       auto cardColReader = std::make_unique<Detail::RNTupleColumnReader>(std::move(cardinalityField));
       fColumnReaderPrototypes.emplace_back(std::move(cardColReader));

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -32,7 +32,7 @@
 
 namespace ROOT {
 namespace Experimental {
-namespace Detail {
+namespace Internal {
 
 /// An artificial field that transforms an RNTuple column that contains the offset of collections into
 /// collection sizes. It is used to provide the "number of" RDF columns for collections, e.g.
@@ -43,14 +43,15 @@ namespace Detail {
 /// TODO(jblomer): consider providing a general set of useful virtual fields as part of RNTuple.
 class RRDFCardinalityField : public ROOT::Experimental::Detail::RFieldBase {
 protected:
-   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view /* newName */) const final
+   std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> CloneImpl(std::string_view /* newName */) const final
    {
       return std::make_unique<RRDFCardinalityField>();
    }
 
 public:
    static std::string TypeName() { return "ROOT::Experimental::ClusterSize_t::ValueType"; }
-   RRDFCardinalityField() : Detail::RFieldBase("", TypeName(), ENTupleStructure::kLeaf, false /* isSimple */) {}
+   RRDFCardinalityField()
+      : ROOT::Experimental::Detail::RFieldBase("", TypeName(), ENTupleStructure::kLeaf, false /* isSimple */) {}
    RRDFCardinalityField(RRDFCardinalityField &&other) = default;
    RRDFCardinalityField &operator=(RRDFCardinalityField &&other) = default;
    ~RRDFCardinalityField() = default;
@@ -58,18 +59,18 @@ public:
    void GenerateColumnsImpl() final
    {
       RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
-      fColumns.emplace_back(
-         std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
+      fColumns.emplace_back(std::unique_ptr<ROOT::Experimental::Detail::RColumn>(
+         ROOT::Experimental::Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
       fPrincipalColumn = fColumns[0].get();
    }
 
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final
    {
-      return Detail::RFieldValue(this, static_cast<ClusterSize_t *>(where));
+      return ROOT::Experimental::Detail::RFieldValue(this, static_cast<ClusterSize_t *>(where));
    }
-   Detail::RFieldValue CaptureValue(void *where) final
+   ROOT::Experimental::Detail::RFieldValue CaptureValue(void *where) final
    {
-      return Detail::RFieldValue(true /* captureFlag */, this, where);
+      return ROOT::Experimental::Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
 
@@ -131,7 +132,7 @@ public:
    }
 };
 
-} // namespace Detail
+} // namespace Internal
 
 RNTupleDS::~RNTupleDS() = default;
 
@@ -203,7 +204,7 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
    std::unique_ptr<Detail::RFieldBase> cardinalityField;
    // Collections get the additional "number of" RDF column (e.g. "__rdf_sizeof_tracks")
    if (!skeinIDs.empty()) {
-      cardinalityField = std::make_unique<Detail::RRDFCardinalityField>();
+      cardinalityField = std::make_unique<ROOT::Experimental::Internal::RRDFCardinalityField>();
       cardinalityField->SetOnDiskId(skeinIDs.back());
    }
 
@@ -221,14 +222,15 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
    if (cardinalityField) {
       fColumnNames.emplace_back("__rdf_sizeof_" + std::string(colName));
       fColumnTypes.emplace_back(cardinalityField->GetType());
-      auto cardColReader = std::make_unique<Detail::RNTupleColumnReader>(std::move(cardinalityField));
+      auto cardColReader = std::make_unique<ROOT::Experimental::Internal::RNTupleColumnReader>(
+         std::move(cardinalityField));
       fColumnReaderPrototypes.emplace_back(std::move(cardColReader));
    }
 
    skeinIDs.emplace_back(fieldId);
    fColumnNames.emplace_back(colName);
    fColumnTypes.emplace_back(valueField->GetType());
-   auto valColReader = std::make_unique<Detail::RNTupleColumnReader>(std::move(valueField));
+   auto valColReader = std::make_unique<ROOT::Experimental::Internal::RNTupleColumnReader>(std::move(valueField));
    fColumnReaderPrototypes.emplace_back(std::move(valColReader));
 }
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -43,29 +43,27 @@ namespace Detail {
 /// TODO(jblomer): consider providing a general set of useful virtual fields as part of RNTuple.
 class RRDFCardinalityField : public ROOT::Experimental::Detail::RFieldBase {
 protected:
-   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view /* newName */) const final {
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view /* newName */) const final
+   {
       return std::make_unique<RRDFCardinalityField>();
    }
 
 public:
    static std::string TypeName() { return "ROOT::Experimental::ClusterSize_t::ValueType"; }
-   RRDFCardinalityField()
-     : Detail::RFieldBase("", TypeName(), ENTupleStructure::kLeaf, false /* isSimple */)
-   {
-   }
-   RRDFCardinalityField(RRDFCardinalityField&& other) = default;
-   RRDFCardinalityField& operator =(RRDFCardinalityField&& other) = default;
+   RRDFCardinalityField() : Detail::RFieldBase("", TypeName(), ENTupleStructure::kLeaf, false /* isSimple */) {}
+   RRDFCardinalityField(RRDFCardinalityField &&other) = default;
+   RRDFCardinalityField &operator=(RRDFCardinalityField &&other) = default;
    ~RRDFCardinalityField() = default;
 
    void GenerateColumnsImpl() final
    {
       RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
-      fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-         Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
+      fColumns.emplace_back(
+         std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
       fPrincipalColumn = fColumns[0].get();
    }
 
-   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final
    {
       return Detail::RFieldValue(this, static_cast<ClusterSize_t *>(where));
    }
@@ -76,8 +74,8 @@ public:
    size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
 
    /// Get the number of elements of the collection identified by globalIndex
-   void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex,
-                       ROOT::Experimental::Detail::RFieldValue *value) final
+   void
+   ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, ROOT::Experimental::Detail::RFieldValue *value) final
    {
       RClusterIndex collectionStart;
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, value->Get<ClusterSize_t>());
@@ -92,7 +90,6 @@ public:
    }
 };
 
-
 /// Every RDF column is represented by exactly one RNTuple field
 class RNTupleColumnReader : public ROOT::Detail::RDF::RColumnReaderBase {
    using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
@@ -100,8 +97,8 @@ class RNTupleColumnReader : public ROOT::Detail::RDF::RColumnReaderBase {
    using RPageSource = ROOT::Experimental::Detail::RPageSource;
 
    std::unique_ptr<RFieldBase> fField; ///< The field backing the RDF column
-   RFieldValue fValue; ///< The memory location used to read from fField
-   Long64_t fLastEntry; ///< Last entry number that was read
+   RFieldValue fValue;                 ///< The memory location used to read from fField
+   Long64_t fLastEntry;                ///< Last entry number that was read
 
 public:
    RNTupleColumnReader(std::unique_ptr<RFieldBase> f)
@@ -136,13 +133,10 @@ public:
 
 } // namespace Detail
 
-
 RNTupleDS::~RNTupleDS() = default;
 
-
-void RNTupleDS::AddField(
-   const RNTupleDescriptor &desc, std::string_view colName, DescriptorId_t fieldId,
-   std::vector<DescriptorId_t> skeinIDs)
+void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName, DescriptorId_t fieldId,
+                         std::vector<DescriptorId_t> skeinIDs)
 {
    // As an example for the mapping of RNTuple fields to RDF columns, let's consider an RNTuple
    // using the following types and with a top-level field named "event" of type Event:
@@ -185,7 +179,7 @@ void RNTupleDS::AddField(
       // skeinIDs would already contain the fieldID of "event.tracks"
       skeinIDs.emplace_back(fieldId);
       // There should only be one sub field but it's easiest to access via the sub field range
-      for (const auto& f : desc.GetFieldRange(fieldDesc.GetId())) {
+      for (const auto &f : desc.GetFieldRange(fieldDesc.GetId())) {
          AddField(desc, colName, f.GetId(), skeinIDs);
       }
       // Note that at the end of the recursion, we handled the inner sub collections as well as the
@@ -193,7 +187,7 @@ void RNTupleDS::AddField(
       return;
    } else if (fieldDesc.GetStructure() == ENTupleStructure::kRecord) {
       // Inner fields of records are provided as individual RDF columns, e.g. "event.id"
-      for (const auto& f : desc.GetFieldRange(fieldDesc.GetId())) {
+      for (const auto &f : desc.GetFieldRange(fieldDesc.GetId())) {
          auto innerName = colName.empty() ? f.GetFieldName() : (std::string(colName) + "." + f.GetFieldName());
          AddField(desc, innerName, f.GetId(), skeinIDs);
       }
@@ -227,8 +221,7 @@ void RNTupleDS::AddField(
    if (cardinalityField) {
       fColumnNames.emplace_back(std::string("__rdf_sizeof_") + std::string(colName));
       fColumnTypes.emplace_back(cardinalityField->GetType());
-      auto cardColReader =
-         std::make_unique<Detail::RNTupleColumnReader>(std::move(cardinalityField));
+      auto cardColReader = std::make_unique<Detail::RNTupleColumnReader>(std::move(cardinalityField));
       fColumnReaderPrototypes.emplace_back(std::move(cardColReader));
    }
 
@@ -238,7 +231,6 @@ void RNTupleDS::AddField(
    auto valColReader = std::make_unique<Detail::RNTupleColumnReader>(std::move(valueField));
    fColumnReaderPrototypes.emplace_back(std::move(valColReader));
 }
-
 
 RNTupleDS::RNTupleDS(std::unique_ptr<Detail::RPageSource> pageSource)
 {
@@ -275,7 +267,8 @@ std::vector<std::pair<ULong64_t, ULong64_t>> RNTupleDS::GetEntryRanges()
 {
    // TODO(jblomer): use cluster boundaries for the entry ranges
    std::vector<std::pair<ULong64_t, ULong64_t>> ranges;
-   if (fHasSeenAllRanges) return ranges;
+   if (fHasSeenAllRanges)
+      return ranges;
 
    auto nEntries = fSources[0]->GetNEntries();
    const auto chunkSize = nEntries / fNSlots;
@@ -293,32 +286,23 @@ std::vector<std::pair<ULong64_t, ULong64_t>> RNTupleDS::GetEntryRanges()
    return ranges;
 }
 
-
 std::string RNTupleDS::GetTypeName(std::string_view colName) const
 {
-   const auto index = std::distance(
-      fColumnNames.begin(), std::find(fColumnNames.begin(), fColumnNames.end(), colName));
+   const auto index = std::distance(fColumnNames.begin(), std::find(fColumnNames.begin(), fColumnNames.end(), colName));
    return fColumnTypes[index];
 }
 
-
 bool RNTupleDS::HasColumn(std::string_view colName) const
 {
-   return std::find(fColumnNames.begin(), fColumnNames.end(), colName) !=
-          fColumnNames.end();
+   return std::find(fColumnNames.begin(), fColumnNames.end(), colName) != fColumnNames.end();
 }
-
 
 void RNTupleDS::Initialise()
 {
    fHasSeenAllRanges = false;
 }
 
-
-void RNTupleDS::Finalise()
-{
-}
-
+void RNTupleDS::Finalise() {}
 
 void RNTupleDS::SetNSlots(unsigned int nSlots)
 {
@@ -332,9 +316,8 @@ void RNTupleDS::SetNSlots(unsigned int nSlots)
       fSources[i]->Attach();
    }
 }
-} // ns Experimental
-} // ns ROOT
-
+} // namespace Experimental
+} // namespace ROOT
 
 ROOT::RDataFrame ROOT::Experimental::MakeNTupleDataFrame(std::string_view ntupleName, std::string_view fileName)
 {

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -47,7 +47,7 @@ TEST_F(RNTupleDSTest, ColTypeNames)
    RNTupleDS tds(std::move(fPageSource));
 
    auto colNames = tds.GetColumnNames();
-   ASSERT_EQ(colNames.size(), 5);
+   ASSERT_EQ(7, colNames.size());
 
    EXPECT_TRUE(tds.HasColumn("pt"));
    EXPECT_TRUE(tds.HasColumn("energy"));
@@ -55,6 +55,7 @@ TEST_F(RNTupleDSTest, ColTypeNames)
 
    EXPECT_STREQ("std::string", tds.GetTypeName("tag").c_str());
    EXPECT_STREQ("float", tds.GetTypeName("energy").c_str());
+   EXPECT_STREQ("ROOT::Experimental::ClusterSize_t::ValueType", tds.GetTypeName("#jets").c_str());
 }
 
 
@@ -64,6 +65,7 @@ void ReadTest(const std::string &name, const std::string &fname) {
    auto count = df.Count();
    auto sumpt = df.Sum<float>("pt");
    auto tag = df.Take<std::string>("tag");
+   auto njets = df.Take<std::string>("#jets");
    auto sumjets = df.Sum<std::vector<float>>("jets");
    auto sumvec = [](float red, const std::vector<std::vector<float>> &nnlo) {
       auto sum = 0.f;
@@ -78,6 +80,8 @@ void ReadTest(const std::string &name, const std::string &fname) {
    EXPECT_DOUBLE_EQ(sumpt.GetValue(), 42.f);
    EXPECT_EQ(tag.GetValue().size(), 1ull);
    EXPECT_EQ(tag.GetValue()[0], "xyz");
+   EXPECT_EQ(1ull, njets.GetValue().size());
+   //EXPECT_EQ(2u, njets.GetValue()[0]);
    EXPECT_EQ(sumjets.GetValue(), 3.f);
    EXPECT_EQ(sumnnlo.GetValue(), 16.f);
 }

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -51,6 +51,7 @@ TEST_F(RNTupleDSTest, ColTypeNames)
 
    EXPECT_TRUE(tds.HasColumn("pt"));
    EXPECT_TRUE(tds.HasColumn("energy"));
+   EXPECT_TRUE(tds.HasColumn("#nnlo"));
    EXPECT_FALSE(tds.HasColumn("Address"));
 
    EXPECT_STREQ("std::string", tds.GetTypeName("tag").c_str());
@@ -65,8 +66,9 @@ void ReadTest(const std::string &name, const std::string &fname) {
    auto count = df.Count();
    auto sumpt = df.Sum<float>("pt");
    auto tag = df.Take<std::string>("tag");
-   auto njets = df.Take<std::string>("#jets");
+   auto njets = df.Take<ROOT::Experimental::ClusterSize_t::ValueType>("#jets");
    auto sumjets = df.Sum<std::vector<float>>("jets");
+   auto sumnnlosize = df.Sum<std::vector<ROOT::Experimental::ClusterSize_t::ValueType>>("#nnlo");
    auto sumvec = [](float red, const std::vector<std::vector<float>> &nnlo) {
       auto sum = 0.f;
       for (auto &v : nnlo)
@@ -76,14 +78,15 @@ void ReadTest(const std::string &name, const std::string &fname) {
    };
    auto sumnnlo = df.Aggregate(sumvec, std::plus<float>{}, "nnlo", 0.f);
 
-   EXPECT_EQ(count.GetValue(), 1ull);
-   EXPECT_DOUBLE_EQ(sumpt.GetValue(), 42.f);
-   EXPECT_EQ(tag.GetValue().size(), 1ull);
-   EXPECT_EQ(tag.GetValue()[0], "xyz");
+   EXPECT_EQ(1ull, count.GetValue());
+   EXPECT_DOUBLE_EQ(42.f, sumpt.GetValue());
+   EXPECT_EQ(1ull, tag.GetValue().size());
+   EXPECT_EQ(std::string("xyz"), tag.GetValue()[0]);
    EXPECT_EQ(1ull, njets.GetValue().size());
-   //EXPECT_EQ(2u, njets.GetValue()[0]);
-   EXPECT_EQ(sumjets.GetValue(), 3.f);
-   EXPECT_EQ(sumnnlo.GetValue(), 16.f);
+   EXPECT_EQ(2u, njets.GetValue()[0]);
+   EXPECT_EQ(3.f, sumjets.GetValue());
+   EXPECT_EQ(16.f, sumnnlo.GetValue());
+   EXPECT_EQ(5u, sumnnlosize.GetValue());
 }
 
 TEST_F(RNTupleDSTest, Read)

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -60,6 +60,16 @@ TEST_F(RNTupleDSTest, ColTypeNames)
 }
 
 
+TEST_F(RNTupleDSTest, CardinalityColumn)
+{
+   auto df = ROOT::Experimental::MakeNTupleDataFrame(fNtplName, fFileName);
+
+   // Check that the special column #<collection> works with jitting
+   auto max_njets = df.Define("njets", "@jets.size").Max("njets");
+   EXPECT_EQ(2, *max_njets);
+}
+
+
 void ReadTest(const std::string &name, const std::string &fname) {
    auto df = ROOT::Experimental::MakeNTupleDataFrame(name, fname);
 

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -51,12 +51,12 @@ TEST_F(RNTupleDSTest, ColTypeNames)
 
    EXPECT_TRUE(tds.HasColumn("pt"));
    EXPECT_TRUE(tds.HasColumn("energy"));
-   EXPECT_TRUE(tds.HasColumn("#nnlo"));
+   EXPECT_TRUE(tds.HasColumn("__rdf_sizeof_nnlo"));
    EXPECT_FALSE(tds.HasColumn("Address"));
 
    EXPECT_STREQ("std::string", tds.GetTypeName("tag").c_str());
    EXPECT_STREQ("float", tds.GetTypeName("energy").c_str());
-   EXPECT_STREQ("ROOT::Experimental::ClusterSize_t::ValueType", tds.GetTypeName("#jets").c_str());
+   EXPECT_STREQ("ROOT::Experimental::ClusterSize_t::ValueType", tds.GetTypeName("__rdf_sizeof_jets").c_str());
 }
 
 
@@ -65,7 +65,7 @@ TEST_F(RNTupleDSTest, CardinalityColumn)
    auto df = ROOT::Experimental::MakeNTupleDataFrame(fNtplName, fFileName);
 
    // Check that the special column #<collection> works with jitting
-   auto max_njets = df.Define("njets", "@jets.size").Max("njets");
+   auto max_njets = df.Define("njets", "__rdf_sizeof_jets").Max("njets");
    EXPECT_EQ(2, *max_njets);
 }
 
@@ -76,9 +76,9 @@ void ReadTest(const std::string &name, const std::string &fname) {
    auto count = df.Count();
    auto sumpt = df.Sum<float>("pt");
    auto tag = df.Take<std::string>("tag");
-   auto njets = df.Take<ROOT::Experimental::ClusterSize_t::ValueType>("#jets");
+   auto njets = df.Take<ROOT::Experimental::ClusterSize_t::ValueType>("__rdf_sizeof_jets");
    auto sumjets = df.Sum<std::vector<float>>("jets");
-   auto sumnnlosize = df.Sum<std::vector<ROOT::Experimental::ClusterSize_t::ValueType>>("#nnlo");
+   auto sumnnlosize = df.Sum<std::vector<ROOT::Experimental::ClusterSize_t::ValueType>>("__rdf_sizeof_nnlo");
    auto sumvec = [](float red, const std::vector<std::vector<float>> &nnlo) {
       auto sum = 0.f;
       for (auto &v : nnlo)

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -155,7 +155,8 @@ public:
    RFieldBase& operator =(RFieldBase&&) = default;
    virtual ~RFieldBase();
 
-   ///// Copies the field and its sub fields using a possibly new name and a new, unconnected set of columns
+   /// Copies the field and its sub fields using a possibly new name and a new, unconnected set of columns
+   /// Note that the clone does _not_ carry over the original field's on-disk ID (since it is unconnected)
    virtual std::unique_ptr<RFieldBase> Clone(std::string_view newName) const = 0;
 
    /// Factory method to resurrect a field from the stored on-disk type information

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -222,8 +222,8 @@ public:
    ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }
    NTupleSize_t GetNElements() const { return fPrincipalColumn->GetNElements(); }
-   const RFieldBase *GetParent() const { return fParent; }
-   std::vector<const RFieldBase *> GetSubFields() const;
+   RFieldBase *GetParent() const { return fParent; }
+   std::vector<RFieldBase *> GetSubFields() const;
    bool IsSimple() const { return fIsSimple; }
 
    DescriptorId_t GetOnDiskId() const { return fOnDiskId; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -43,12 +43,12 @@ void PrintRNTuple(const RNTuple& ntuple, std::ostream& output);
  * materialization on the primitive column layer.
  */
 enum ENTupleStructure {
-   kInvalid,
    kLeaf,
    kCollection,
    kRecord,
    kVariant,
    kReference, // unimplemented so far
+   kInvalid,
 };
 
 /// Integer type long enough to hold the maximum number of entries in a column

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -213,6 +213,14 @@ ROOT::Experimental::Detail::RFieldBase::EnsureValidFieldName(std::string_view fi
    return RResult<void>::Success();
 }
 
+std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
+ROOT::Experimental::Detail::RFieldBase::Clone(std::string_view newName) const
+{
+   auto clone = CloneImpl(newName);
+   clone->fOnDiskId = fOnDiskId;
+   return clone;
+}
+
 void ROOT::Experimental::Detail::RFieldBase::AppendImpl(const ROOT::Experimental::Detail::RFieldValue& /*value*/) {
    R__ASSERT(false);
 }
@@ -327,7 +335,7 @@ void ROOT::Experimental::Detail::RFieldBase::RSchemaIterator::Advance()
 
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
-ROOT::Experimental::RFieldZero::Clone(std::string_view /*newName*/) const
+ROOT::Experimental::RFieldZero::CloneImpl(std::string_view /*newName*/) const
 {
    auto result = std::make_unique<RFieldZero>();
    for (auto &f : fSubFields)
@@ -546,7 +554,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
-ROOT::Experimental::RClassField::Clone(std::string_view newName) const
+ROOT::Experimental::RClassField::CloneImpl(std::string_view newName) const
 {
    return std::make_unique<RClassField>(newName, GetType());
 }
@@ -655,7 +663,7 @@ std::size_t ROOT::Experimental::RRecordField::GetItemPadding(std::size_t baseOff
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
-ROOT::Experimental::RRecordField::Clone(std::string_view newName) const
+ROOT::Experimental::RRecordField::CloneImpl(std::string_view newName) const
 {
    std::vector<std::unique_ptr<Detail::RFieldBase>> cloneItems;
    for (auto &item : fSubFields)
@@ -752,7 +760,7 @@ ROOT::Experimental::RVectorField::RVectorField(
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
-ROOT::Experimental::RVectorField::Clone(std::string_view newName) const
+ROOT::Experimental::RVectorField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
    return std::make_unique<RVectorField>(newName, std::move(newItemField));
@@ -937,7 +945,7 @@ ROOT::Experimental::RArrayField::RArrayField(
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
-ROOT::Experimental::RArrayField::Clone(std::string_view newName) const
+ROOT::Experimental::RArrayField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
    return std::make_unique<RArrayField>(newName, std::move(newItemField), fArrayLength);
@@ -1047,7 +1055,7 @@ ROOT::Experimental::RVariantField::RVariantField(
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
-ROOT::Experimental::RVariantField::Clone(std::string_view newName) const
+ROOT::Experimental::RVariantField::CloneImpl(std::string_view newName) const
 {
    auto nFields = fSubFields.size();
    std::vector<Detail::RFieldBase *> itemFields;
@@ -1168,7 +1176,7 @@ void ROOT::Experimental::RCollectionField::GenerateColumnsImpl()
 
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
-ROOT::Experimental::RCollectionField::Clone(std::string_view newName) const
+ROOT::Experimental::RCollectionField::CloneImpl(std::string_view newName) const
 {
    auto result = std::make_unique<RCollectionField>(newName, fCollectionNTuple, RNTupleModel::Create());
    for (auto& f : fSubFields) {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -251,10 +251,9 @@ void ROOT::Experimental::Detail::RFieldBase::Attach(
 }
 
 
-std::vector<const ROOT::Experimental::Detail::RFieldBase *>
-ROOT::Experimental::Detail::RFieldBase::GetSubFields() const
+std::vector<ROOT::Experimental::Detail::RFieldBase *> ROOT::Experimental::Detail::RFieldBase::GetSubFields() const
 {
-   std::vector<const RFieldBase *> result;
+   std::vector<RFieldBase *> result;
    for (const auto &f : fSubFields) {
       result.emplace_back(f.get());
    }

--- a/tree/ntuple/v7/test/ntuple_rdf.cxx
+++ b/tree/ntuple/v7/test/ntuple_rdf.cxx
@@ -26,4 +26,7 @@ TEST(RNTuple, RDF)
    ROOT::EnableImplicitMT();
    auto rdf = ROOT::Experimental::MakeNTupleDataFrame("myNTuple", fileGuard.GetPath());
    EXPECT_EQ(42.0, *rdf.Min("pt"));
+   auto s = rdf.Take<std::string>("klass.s");
+   EXPECT_EQ(1ull, s.GetValue().size());
+   EXPECT_EQ(std::string("abc"), s.GetValue()[0]);
 }

--- a/tree/ntuple/v7/test/ntuple_rdf.cxx
+++ b/tree/ntuple/v7/test/ntuple_rdf.cxx
@@ -17,6 +17,9 @@ TEST(RNTuple, RDF)
    wrNnlo->push_back(std::vector<float>{1.0, 2.0, 4.0, 8.0});
    auto wrKlass = modelWrite->MakeField<CustomStruct>("klass");
    wrKlass->s = "abc";
+   wrKlass->v1.push_back(100.);
+   wrKlass->v1.push_back(200.);
+   wrKlass->v1.push_back(300.);
 
    {
       auto ntuple = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
@@ -29,4 +32,6 @@ TEST(RNTuple, RDF)
    auto s = rdf.Take<std::string>("klass.s");
    EXPECT_EQ(1ull, s.GetValue().size());
    EXPECT_EQ(std::string("abc"), s.GetValue()[0]);
+   EXPECT_EQ(2U, *rdf.Min("__rdf_sizeof_jets"));
+   EXPECT_EQ(3U, *rdf.Min("__rdf_sizeof_klass.v1"));
 }


### PR DESCRIPTION
Adds the following columns to an RDF created from an RNTuple:

Inner collections
----------------------
The inner fields of collection of a record is projected to collections of the inner fields.  E.g. a for a field `jet` of type vector of

    struct Jet {
      float pt;
      float eta;
    };

the RDF exposes `std::vector<float> jet.pt` and `std::vector<float> jet.eta` in addition to `std::vector<Jet> jet`

Cardinality columns
--------------------------
For every collection `x`, an additional cardinality column `#x` is exposed that contains the number of elements of the collection.  Note that for inner collections, the cardinality columns is itself a collection. For instance, for a column `std::vector<std::vector<float>>` the cardinality column is of type `std::vector<std::uint32_t>`.
