### PR TITLE
[eve7] minimal code formatting

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilderTemplate.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilderTemplate.hxx
@@ -1,6 +1,16 @@
+// @(#)root/eve7:$Id$
+// Authors: Matevz Tadel & Alja Mrak-Tadel: 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #ifndef ROOT7_REveDataProxySimpleBuilderTemplate
 #define ROOT7_REveDataProxySimpleBuilderTemplate
-
 
 #include <ROOT/REveDataSimpleProxyBuilder.hxx>
 
@@ -49,7 +59,7 @@ private:
    const REveDataSimpleProxyBuilderTemplate& operator=(const REveDataSimpleProxyBuilderTemplate&); // stop default
 };
 
-
 } // namespace Experimental
 } // namespace ROOT
+
 #endif

--- a/graf3d/eve7/inc/ROOT/REveScalableStraightLineSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REveScalableStraightLineSet.hxx
@@ -1,3 +1,14 @@
+// @(#)root/eve7:$Id$
+// Authors: Matevz Tadel & Alja Mrak-Tadel: 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #ifndef ROOT_REveScalableStraightLineSet
 #define ROOT_REveScalableStraightLineSet
 
@@ -28,4 +39,5 @@ public:
 
 } // namespace Experimental
 } // namespace ROOT
+
 #endif

--- a/graf3d/eve7/inc/ROOT/REveTableProxyBuilder.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTableProxyBuilder.hxx
@@ -1,3 +1,14 @@
+// @(#)root/eve7:$Id$
+// Authors: Matevz Tadel & Alja Mrak-Tadel: 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #ifndef ROOT7_REveTableProxyBuilder
 #define ROOT7_REveTableProxyBuilder
 
@@ -32,7 +43,8 @@ public:
    void SetCollection(REveDataCollection*) override;
    void ConfigChanged();
 };
-}
-}
+
+} // Experimental
+} // ROOT
 
 #endif

--- a/graf3d/eve7/src/REveCompound.cxx
+++ b/graf3d/eve7/src/REveCompound.cxx
@@ -14,7 +14,6 @@
 #include "TClass.h"
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveCompound
 \ingroup REve

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -24,9 +24,7 @@
 
 #include <sstream>
 
-
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 
 Color_t  REveDataCollection::fgDefaultColor  = kBlue;

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -17,9 +17,7 @@
 
 #include <cassert>
 
-
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 
 REveDataProxyBuilderBase::Product::Product(std::string iViewType, const REveViewContext* c) : m_viewType(iViewType), m_viewContext(c), m_elements(0)

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -4,11 +4,10 @@
 #include <ROOT/REveDataCollection.hxx>
 #include <ROOT/REveCompound.hxx>
 #include <ROOT/REveScene.hxx>
-#include <assert.h>
+#include <cassert>
 #include <TClass.h>
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 REveDataSimpleProxyBuilder::REveDataSimpleProxyBuilder()
 {

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -1,6 +1,16 @@
+// @(#)root/eve7:$Id$
+// Authors: Matevz Tadel & Alja Mrak-Tadel: 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include <ROOT/REveDataSimpleProxyBuilder.hxx>
 
-// user include files
 #include <ROOT/REveDataCollection.hxx>
 #include <ROOT/REveCompound.hxx>
 #include <ROOT/REveScene.hxx>

--- a/graf3d/eve7/src/REveDataTable.cxx
+++ b/graf3d/eve7/src/REveDataTable.cxx
@@ -1,3 +1,14 @@
+// @(#)root/eve7:$Id$
+// Authors: Matevz Tadel & Alja Mrak-Tadel: 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include <ROOT/REveDataTable.hxx>
 #include <ROOT/REveDataCollection.hxx>
 #include <TClass.h>

--- a/graf3d/eve7/src/REveEllipsoid.cxx
+++ b/graf3d/eve7/src/REveEllipsoid.cxx
@@ -1,3 +1,14 @@
+// @(#)root/eve7:$Id$
+// Authors: Matevz Tadel & Alja Mrak-Tadel: 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include <ROOT/REveEllipsoid.hxx>
 #include <ROOT/REveTrans.hxx>
 #include <ROOT/REveProjectionManager.hxx>

--- a/graf3d/eve7/src/REveGeoPolyShape.cxx
+++ b/graf3d/eve7/src/REveGeoPolyShape.cxx
@@ -28,15 +28,14 @@
 #include "TGeoMatrix.h"
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveGeoPolyShape
 \ingroup REve
 Description of REveGeoPolyShape
 */
 
-Bool_t REX::REveGeoPolyShape::fgAutoEnforceTriangles = kTRUE;
-Bool_t REX::REveGeoPolyShape::fgAutoCalculateNormals = kFALSE;
+Bool_t REveGeoPolyShape::fgAutoEnforceTriangles = kTRUE;
+Bool_t REveGeoPolyShape::fgAutoCalculateNormals = kFALSE;
 
 void   REveGeoPolyShape::SetAutoEnforceTriangles(Bool_t f) { fgAutoEnforceTriangles = f; }
 Bool_t REveGeoPolyShape::GetAutoEnforceTriangles()         { return fgAutoEnforceTriangles; }

--- a/graf3d/eve7/src/REveGeoShape.cxx
+++ b/graf3d/eve7/src/REveGeoShape.cxx
@@ -80,7 +80,7 @@ it gets forwarded to geo-manager and this tesselation detail is
 used when creating the buffer passed to GL.
 */
 
-TGeoManager *REX::REveGeoShape::fgGeoManager = init_geo_mangeur();
+TGeoManager *REveGeoShape::fgGeoManager = init_geo_mangeur();
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return static geo-manager that is used internally to make shapes

--- a/graf3d/eve7/src/REveGeoShapeExtract.cxx
+++ b/graf3d/eve7/src/REveGeoShapeExtract.cxx
@@ -17,7 +17,6 @@
 #include "TGeoShape.h"
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveGeoShapeExtract
 \ingroup REve

--- a/graf3d/eve7/src/REveJetCone.cxx
+++ b/graf3d/eve7/src/REveJetCone.cxx
@@ -19,9 +19,7 @@
 
 #include <cassert>
 
-
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveJetCone
 \ingroup REve

--- a/graf3d/eve7/src/REveLine.cxx
+++ b/graf3d/eve7/src/REveLine.cxx
@@ -16,7 +16,6 @@
 #include "TClass.h"
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveLine
 \ingroup REve

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -37,8 +37,7 @@
 #include "TClass.h"
 #include "THttpServer.h"
 
-#include "Riostream.h"
-
+#include <fstream>
 #include <sstream>
 #include <iostream>
 

--- a/graf3d/eve7/src/REvePointSet.cxx
+++ b/graf3d/eve7/src/REvePointSet.cxx
@@ -21,7 +21,6 @@
 
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REvePointSet
 \ingroup REve

--- a/graf3d/eve7/src/REvePolygonSetProjected.cxx
+++ b/graf3d/eve7/src/REvePolygonSetProjected.cxx
@@ -21,7 +21,6 @@
 #include <cassert>
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 namespace
 {

--- a/graf3d/eve7/src/REveProjections.cxx
+++ b/graf3d/eve7/src/REveProjections.cxx
@@ -18,7 +18,6 @@
 #include <limits>
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveProjection
 \ingroup REve
@@ -28,8 +27,8 @@ Enables to define an external center of distortion and a scale to
 fixate a bounding box of a projected point.
 */
 
-Float_t REX::REveProjection::fgEps    = 0.005f;
-Float_t REX::REveProjection::fgEpsSqr = 0.000025f;
+Float_t REveProjection::fgEps    = 0.005f;
+Float_t REveProjection::fgEpsSqr = 0.000025f;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.

--- a/graf3d/eve7/src/REveScalableStraightLineSet.cxx
+++ b/graf3d/eve7/src/REveScalableStraightLineSet.cxx
@@ -1,3 +1,14 @@
+// @(#)root/eve7:$Id$
+// Authors: Matevz Tadel & Alja Mrak-Tadel: 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include "ROOT/REveScalableStraightLineSet.hxx"
 #include "ROOT/REveChunkManager.hxx"
 

--- a/graf3d/eve7/src/REveScalableStraightLineSet.cxx
+++ b/graf3d/eve7/src/REveScalableStraightLineSet.cxx
@@ -8,7 +8,6 @@ to be scaled in accordance with an external object.
 */
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.

--- a/graf3d/eve7/src/REveSceneInfo.cxx
+++ b/graf3d/eve7/src/REveSceneInfo.cxx
@@ -13,7 +13,6 @@
 #include <ROOT/REveScene.hxx>
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveSceneInfo
 \ingroup REve

--- a/graf3d/eve7/src/REveSecondarySelectable.cxx
+++ b/graf3d/eve7/src/REveSecondarySelectable.cxx
@@ -13,7 +13,6 @@
 #include <ROOT/REveElement.hxx>
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveSecondarySelectable
 \ingroup REve

--- a/graf3d/eve7/src/REveShape.cxx
+++ b/graf3d/eve7/src/REveShape.cxx
@@ -10,8 +10,6 @@
  *************************************************************************/
 
 #include <ROOT/REveShape.hxx>
-#include "Riostream.h"
-
 
 using namespace ROOT::Experimental;
 

--- a/graf3d/eve7/src/REveShape.cxx
+++ b/graf3d/eve7/src/REveShape.cxx
@@ -14,7 +14,6 @@
 
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveShape
 \ingroup REve

--- a/graf3d/eve7/src/REveTableProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveTableProxyBuilder.cxx
@@ -1,3 +1,14 @@
+// @(#)root/eve7:$Id$
+// Authors: Matevz Tadel & Alja Mrak-Tadel: 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include "TClass.h"
 #include <ROOT/REveTableProxyBuilder.hxx>
 #include <ROOT/REveTableInfo.hxx>

--- a/graf3d/eve7/src/REveTrack.cxx
+++ b/graf3d/eve7/src/REveTrack.cxx
@@ -26,7 +26,6 @@
 
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveTrack
 \ingroup REve

--- a/graf3d/eve7/src/REveTrackProjected.cxx
+++ b/graf3d/eve7/src/REveTrackProjected.cxx
@@ -17,7 +17,6 @@
 
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveTrackProjected
 \ingroup REve

--- a/graf3d/eve7/src/REveTrackPropagator.cxx
+++ b/graf3d/eve7/src/REveTrackPropagator.cxx
@@ -16,7 +16,6 @@
 #include "TMath.h"
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveMagField
 \ingroup REve

--- a/graf3d/eve7/src/REveTrans.cxx
+++ b/graf3d/eve7/src/REveTrans.cxx
@@ -41,7 +41,6 @@
 #define F33 15
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveTrans
 \ingroup REve

--- a/graf3d/eve7/src/REveTrans.cxx
+++ b/graf3d/eve7/src/REveTrans.cxx
@@ -16,8 +16,6 @@
 #include "TClass.h"
 #include "TMath.h"
 
-#include "Riostream.h"
-
 #include <cctype>
 
 #define F00  0

--- a/graf3d/eve7/src/REveTreeTools.cxx
+++ b/graf3d/eve7/src/REveTreeTools.cxx
@@ -20,7 +20,6 @@
 #include "TTreeFormula.h"
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveSelectorToEventList
 \ingroup REve

--- a/graf3d/eve7/src/REveTypes.cxx
+++ b/graf3d/eve7/src/REveTypes.cxx
@@ -1,3 +1,14 @@
+// @(#)root/eve7:$Id$
+// Authors: Matevz Tadel & Alja Mrak-Tadel: 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include <ROOT/REveTypes.hxx>
 
 using namespace ROOT::Experimental;

--- a/graf3d/eve7/src/REveUtil.cxx
+++ b/graf3d/eve7/src/REveUtil.cxx
@@ -38,7 +38,7 @@ namespace REX = ROOT::Experimental;
 Standard utility functions for Eve.
 */
 
-TObjArray* REX::REveUtil::fgDefaultColors = nullptr;
+TObjArray *REveUtil::fgDefaultColors = nullptr;
 
 namespace
 {

--- a/graf3d/eve7/src/REveVSD.cxx
+++ b/graf3d/eve7/src/REveVSD.cxx
@@ -14,7 +14,6 @@
 #include "TTree.h"
 
 using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
 
 /** \class REveVSD
 \ingroup REve

--- a/graf3d/eve7/src/REveVSDStructs.cxx
+++ b/graf3d/eve7/src/REveVSDStructs.cxx
@@ -11,9 +11,6 @@
 
 #include <ROOT/REveVSDStructs.hxx>
 
-using namespace ROOT::Experimental;
-namespace REX = ROOT::Experimental;
-
 namespace ROOT {
 namespace Experimental {
 


### PR DESCRIPTION
* remove unused namespaces
* replace `Riostream.h` by required standard includes
* add copyright block where missing 
