### PR TITLE
[bug][GUI]Protection against null pointer der. and  better error messages

### DIFF
--- a/gui/gui/src/TGButton.cxx
+++ b/gui/gui/src/TGButton.cxx
@@ -902,7 +902,7 @@ TGPictureButton::TGPictureButton(const TGWindow *p, const TGPicture *pic,
       Int_t id, GContext_t norm, UInt_t option) : TGButton(p, id, norm, option)
 {
    if (!pic) {
-      Error("TGPictureButton", "pixmap not found for button %d", id);
+      Error("TGPictureButton", "pixmap not found or the file format is not supported for button %d", id);
       fPic = fClient->GetPicture("mb_question_s.xpm");
    } else {
       fPic = pic;
@@ -931,7 +931,7 @@ TGPictureButton::TGPictureButton(const TGWindow *p, const TGPicture *pic,
    : TGButton(p, id, norm, option)
 {
    if (!pic) {
-      Error("TGPictureButton", "pixmap not found for button\n%s",
+      Error("TGPictureButton", "pixmap not found or the file format is not supported for button\n%s",
             cmd ? cmd : "");
       fPic = fClient->GetPicture("mb_question_s.xpm");
    } else {
@@ -959,7 +959,7 @@ TGPictureButton::TGPictureButton(const TGWindow *p, const char *pic,
    Int_t id, GContext_t norm, UInt_t option) : TGButton(p, id, norm, option)
 {
    if (!pic || !pic[0]) {
-      if (p) Error("TGPictureButton", "pixmap not found for button");
+      if (p) Error("TGPictureButton", "pixmap not found or the file format is not supported for button");
       fPic = fClient->GetPicture("mb_question_s.xpm");
    } else {
       fPic = fClient->GetPicture(pic);
@@ -993,7 +993,7 @@ TGPictureButton::~TGPictureButton()
 void TGPictureButton::SetPicture(const TGPicture *new_pic)
 {
    if (!new_pic) {
-      Error("SetPicture", "pixmap not found for button %d\n%s",
+      Error("SetPicture", "pixmap not found or the file format is not supported for button %d\n%s",
             fWidgetId, fCommand.Data());
       return;
    }
@@ -1143,13 +1143,13 @@ void TGCheckButton::Init()
    Resize();
 
    if (!fOn) {
-      Error("TGCheckButton", "checked_t.xpm not found");
+      Error("TGCheckButton", "checked_t.xpm not found or the file format is not supported.");
    } else if (!fOff) {
-      Error("TGCheckButton", "unchecked_t.xpm not found");
+      Error("TGCheckButton", "unchecked_t.xpm not found or the file format is not supported.");
    } else if (!fDisOn) {
-      Error("TGCheckButton", "checked_dis_t.xpm not found");
+      Error("TGCheckButton", "checked_dis_t.xpm not found or the file format is not supported.");
    } else if (!fDisOff) {
-      Error("TGCheckButton", "unchecked_dis_t.xpm not found");
+      Error("TGCheckButton", "unchecked_dis_t.xpm not found or the file format is not supported.");
    }
    int hotchar;
 
@@ -1507,7 +1507,7 @@ void TGRadioButton::Init()
    fDisOff = fClient->GetPicture("rbutton_dis_off.xpm");
 
    if (!fOn || !fOff || !fDisOn || !fDisOff)
-      Error("TGRadioButton", "rbutton_*.xpm not found");
+      Error("TGRadioButton", "rbutton_*.xpm not found or the file format is not supported.");
 
    Resize();
 
@@ -1552,8 +1552,8 @@ TGRadioButton::~TGRadioButton()
 
 TGDimension TGRadioButton::GetDefaultSize() const
 {
-   UInt_t w = !fTWidth ? fOff->GetWidth() : fTWidth + fOff->GetWidth() + 10;
-   UInt_t h = !fTHeight ? fOff->GetHeight() : fTHeight + 2;
+   UInt_t w = !fTWidth ? ( fOff?fOff->GetWidth():10) : fTWidth + fOff->GetWidth() + 10;
+   UInt_t h = !fTHeight ? ( fOff?fOff->GetHeight():2) : fTHeight + 2;
 
    w = GetOptions() & kFixedWidth ? fWidth : w;
    h = GetOptions() & kFixedHeight ? fHeight : h;
@@ -1936,7 +1936,7 @@ void TGTextButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 void TGPictureButton::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    if (!fPic) {
-      Error("SavePrimitive()", "pixmap not found for picture button %d ", fWidgetId);
+      Error("SavePrimitive()", "pixmap not found or the file format is not supported for picture button %d ", fWidgetId);
       return;
    }
 


### PR DESCRIPTION
In this PR:

 - Protection against null pointer dereference if fOff==nullptr.
 - Better error messages if the images cannot be loaded.  

Tag @couet 




Also, I've tried to compile ROOT version with  -Dgminimal=ON  but it turns out one needs also -Dasimage=ON to make it for ROOT possible to load the standard pixmaps. Would that make sense to include the support of these pixmaps into -Dgminimal ?





 

