### PR TITLE
Re-introduce math.h on Windows if needed

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -21,6 +21,7 @@
          #define _USE_MATH_DEFINES
       #endif
       #include <math.h>
+      #undef _USE_MATH_DEFINES
    #endif
    #define _VECOPS_USE_EXTERN_TEMPLATES false
 #else

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -16,6 +16,12 @@
 #define ROOT_RVEC
 
 #ifdef _WIN32
+   #ifndef M_PI
+      #ifndef _USE_MATH_DEFINES
+         #define _USE_MATH_DEFINES
+      #endif
+      #include <math.h>
+   #endif
    #define _VECOPS_USE_EXTERN_TEMPLATES false
 #else
    #define _VECOPS_USE_EXTERN_TEMPLATES true


### PR DESCRIPTION
After [those changes](https://github.com/root-project/root/commit/060e8d7afd8c47f61eee9f72004388b1a60d77f2), related to C++ modules on Windows, the following tests:

roottest-root-dataframe-writeFcc (Failed)
roottest-root-dataframe-test_readFcc (Failed)
roottest-root-dataframe-regression_snapshot (Failed)
roottest-root-dataframe-test_glob (Failed)
roottest-root-dataframe-test_reduce (Failed)
roottest-root-dataframe-ctors (Failed)

Are failing with the following errors:

```
1306: Processing C:/Users/sftnight/git/roottest/root/dataframe/test_ctors.C+...
1306: Info in <TWinNTSystem::ACLiC>: creating shared library C:/Users/sftnight/build/release/roottest/root/dataframe/test_ctors_C.dll
1306: In file included from input_line_9:9:
1306: In file included from C:/Users/sftnight/git/roottest/root/dataframe/test_ctors.C:4:
1306: In file included from C:/Users/sftnight/build/release/include\ROOT/RDataFrame.hxx:20:
1306: In file included from C:/Users/sftnight/build/release/include\ROOT/RDF/RInterface.hxx:15:
1306: In file included from C:/Users/sftnight/build/release/include\ROOT/RDF/ActionHelpers.hxx:25:
1306: C:/Users/sftnight/build/release/include\ROOT/RVec.hxx:1434:36: error: use of undeclared identifier 'M_PI'
1306: T DeltaPhi(T v1, T v2, const T c = M_PI)
1306:                                    ^
1306: C:/Users/sftnight/build/release/include\ROOT/RVec.hxx:1455:68: error: use of undeclared identifier 'M_PI'
1306: RVec<T> DeltaPhi(const RVec<T>& v1, const RVec<T>& v2, const T c = M_PI)
1306:                                                                    ^
1306: C:/Users/sftnight/build/release/include\ROOT/RVec.hxx:1473:55: error: use of undeclared identifier 'M_PI'
1306: RVec<T> DeltaPhi(const RVec<T>& v1, T v2, const T c = M_PI)
1306:                                                       ^
1306: C:/Users/sftnight/build/release/include\ROOT/RVec.hxx:1491:55: error: use of undeclared identifier 'M_PI'
1306: RVec<T> DeltaPhi(T v1, const RVec<T>& v2, const T c = M_PI)
1306:                                                       ^
1306: C:/Users/sftnight/build/release/include\ROOT/RVec.hxx:1510:113: error: use of undeclared identifier 'M_PI'
1306: RVec<T> DeltaR2(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, const RVec<T>& phi2, const T c = M_PI)
1306:                                                                                                                 ^
1306: C:/Users/sftnight/build/release/include\ROOT/RVec.hxx:1524:112: error: use of undeclared identifier 'M_PI'
1306: RVec<T> DeltaR(const RVec<T>& eta1, const RVec<T>& eta2, const RVec<T>& phi1, const RVec<T>& phi2, const T c = M_PI)
1306:                                                                                                                ^
1306: C:/Users/sftnight/build/release/include\ROOT/RVec.hxx:1537:54: error: use of undeclared identifier 'M_PI'
1306: T DeltaR(T eta1, T eta2, T phi1, T phi2, const T c = M_PI)
1306:                                                      ^
1306: Error in <ACLiC>: Executing 'C:\Users\sftnight\build\release\bin\rootcling -v0 "--lib-list-prefix=C:\Users\sftnight\build\release\roottest\root\dataframe\test_ctors_C_ACLiC_map" -f "C:\Users\sftnight\build\release\roottest\root\dataframe\test_ctors_C_ACLiC_dict.cxx"  -rml test_ctors_C -rmf "C:\Users\sftnight\build\release\roottest\root\dataframe\test_ctors_C.rootmap" -DR__ACLIC_ROOTMAP -I%ROOTSYS%\include -IC:/Users/sftnight/build/release/roottest/root/dataframe -D__ACLIC__  "C:/Users/sftnight/git/roottest/root/dataframe/test_ctors.C" "C:\Users\sftnight\build\release\roottest\root\dataframe\test_ctors_C_ACLiC_linkdef.h"' failed!
```

So let's re-introduce `#include <math.h>` and `_USE_MATH_DEFINES` on Windows if `M_PI` is not defined, trying not to break the C++ modules on Windows