### PR TITLE
v6-22: In TStreamerInfo::GenerateInfoForPair use a non-zero size enums.

### DIFF
--- a/core/dictgen/src/BaseSelectionRule.cxx
+++ b/core/dictgen/src/BaseSelectionRule.cxx
@@ -203,7 +203,6 @@ BaseSelectionRule::EMatchType BaseSelectionRule::Match(const clang::NamedDecl *d
     *   isLinkdef - if the selection rules were generating from a linkdef.h file
     */
 
-
    const std::string& name_value = fName;
    const std::string& pattern_value = fPattern;
 

--- a/core/meta/inc/TEnum.h
+++ b/core/meta/inc/TEnum.h
@@ -60,7 +60,13 @@ public:
    const TSeqCollection *GetConstants() const { return &fConstantList; }
    const TEnumConstant  *GetConstant(const char *name) const { return (TEnumConstant *)fConstantList.FindObject(name); }
    DeclId_t              GetDeclId() const;
-   EDataType             GetUnderlyingType() const;
+
+   /// Get the unterlying integer type of the enum:
+   ///     enum E { kOne }; //  ==> int
+   ///     enum F: long; //  ==> long
+   /// Returns kNumDataTypes if the enum is unknown / invalid.
+   EDataType             GetUnderlyingType() const { return fUnderlyingType; };
+
    Bool_t                IsValid();
    Long_t                Property() const;
    void                  SetClass(TClass *cl) { fClass = cl; }

--- a/core/meta/inc/TEnum.h
+++ b/core/meta/inc/TEnum.h
@@ -37,6 +37,7 @@ private:
    ClassInfo_t *fInfo;          //!interpreter information, owned by TEnum
    TClass      *fClass;         //!owning class
    std::string  fQualName;      // fully qualified type name
+   EDataType    fUnderlyingType;// Type (size) used to store the enum in memory
 
    enum EBits {
      kBitIsScopedEnum = BIT(14) ///< The enum is an enum class.
@@ -50,7 +51,7 @@ public:
                        kALoadAndInterpLookup = 3
                       };
 
-   TEnum(): fInfo(nullptr), fClass(nullptr) {}
+   TEnum(): fInfo(nullptr), fClass(nullptr), fUnderlyingType(kInt_t) {}
    TEnum(const char *name, DeclId_t declid, TClass *cls);
    virtual ~TEnum();
 

--- a/core/meta/inc/TEnum.h
+++ b/core/meta/inc/TEnum.h
@@ -33,11 +33,11 @@ class TEnumConstant;
 class TEnum : public TDictionary {
 
 private:
-   THashList    fConstantList;  //list of constants the enum type
-   ClassInfo_t *fInfo;          //!interpreter information, owned by TEnum
-   TClass      *fClass;         //!owning class
-   std::string  fQualName;      // fully qualified type name
-   EDataType    fUnderlyingType;// Type (size) used to store the enum in memory
+   THashList    fConstantList;            // List of constants the enum type
+   ClassInfo_t *fInfo  = nullptr;         //!Interpreter information, owned by TEnum
+   TClass      *fClass = nullptr;         //!Owning class
+   std::string  fQualName;                // Fully qualified type name
+   EDataType    fUnderlyingType = kInt_t; // Type (size) used to store the enum in memory
 
    enum EBits {
      kBitIsScopedEnum = BIT(14) ///< The enum is an enum class.
@@ -51,7 +51,7 @@ public:
                        kALoadAndInterpLookup = 3
                       };
 
-   TEnum(): fInfo(nullptr), fClass(nullptr), fUnderlyingType(kInt_t) {}
+   TEnum() = default;
    TEnum(const char *name, DeclId_t declid, TClass *cls);
    virtual ~TEnum();
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3140,6 +3140,8 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent)
          // to get the part to add or drop the default arguments as requested by the user)
          std::string alternative;
          gInterpreter->GetInterpreterTypeName(normalizedName.c_str(), alternative, kTRUE);
+         if (alternative.empty())
+            return nullptr;
          const char *altname = alternative.c_str();
          if (strncmp(altname, "std::", 5) == 0) {
             // For namespace (for example std::__1), GetInterpreterTypeName does

--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -439,6 +439,6 @@ void TDataType::AddBuiltins(TCollection* types)
 
 TDataType* TDataType::GetDataType(EDataType type)
 {
-   if (type == kOther_t) return 0;
+   if (type == kOther_t || type >= kNumDataTypes) return 0;
    return fgBuiltins[(int)type];
 }

--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -99,17 +99,6 @@ Long_t TEnum::Property() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Get the unterlying integer type of the enum:
-///     enum E { kOne }; //  ==> int
-///     enum F: long; //  ==> long
-/// Returns kNumDataTypes if the enum is unknown / invalid.
-
-EDataType TEnum::GetUnderlyingType() const
-{
-   return fUnderlyingType;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 
 TDictionary::DeclId_t TEnum::GetDeclId() const
 {

--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -36,7 +36,7 @@ ClassImp(TEnum);
 /// in TROOT::GetListOfGlobals).
 
 TEnum::TEnum(const char *name, DeclId_t declid, TClass *cls)
-   : fInfo(nullptr), fClass(cls), fUnderlyingType(kInt_t)
+   : fClass(cls)
 {
    SetName(name);
    if (cls) {

--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -36,7 +36,7 @@ ClassImp(TEnum);
 /// in TROOT::GetListOfGlobals).
 
 TEnum::TEnum(const char *name, DeclId_t declid, TClass *cls)
-   : fInfo(nullptr), fClass(cls)
+   : fInfo(nullptr), fClass(cls), fUnderlyingType(kInt_t)
 {
    SetName(name);
    if (cls) {
@@ -106,9 +106,7 @@ Long_t TEnum::Property() const
 
 EDataType TEnum::GetUnderlyingType() const
 {
-   if (fInfo)
-      return gInterpreter->ClassInfo_GetUnderlyingType(fInfo);
-   return kNumDataTypes;
+   return fUnderlyingType;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -134,8 +132,10 @@ void TEnum::Update(DeclId_t id)
 
    fInfo = gInterpreter->ClassInfo_Factory(id);
 
-   if (fInfo)
+   if (fInfo) {
       SetBit(kBitIsScopedEnum, gInterpreter->ClassInfo_IsScopedEnum(fInfo));
+      fUnderlyingType = gInterpreter->ClassInfo_GetUnderlyingType(fInfo);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5588,15 +5588,18 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
       }
       TClass *clm = TClass::GetClass(dmType);
       if (!clm) {
-         if (TEnum::GetEnum(dmType, TEnum::kNone)) {
-            Int_t dtype = kInt_t;
-            return new TStreamerBasicType(dmName,dmTitle,offset,dtype,dmFull.c_str());
+         auto enumdesc = TEnum::GetEnum(dmType, TEnum::kNone);
+         if (enumdesc) {
+            auto dtype = enumdesc->GetUnderlyingType();
+            auto el = new TStreamerBasicType(dmName, dmTitle, offset, dtype, dmFull.c_str());
+            auto datatype = TDataType::GetDataType(dtype);
+            if (datatype)
+               el->SetSize(datatype->Size());
+            else
+               el->SetSize(sizeof(int)); // Default size of enums.
+            return el;
          }
          return nullptr;
-         // either we have an Emulated enum or a really unknown class!
-         // let's just claim its an enum :(
-         //Int_t dtype = kInt_t;
-         //return new TStreamerBasicType(dmName,dmTitle,offset,dtype,dmFull.c_str());
       }
       // a pointer to a class
       if ( dmIsPtr ) {


### PR DESCRIPTION
This fix #6726

As reported by CMSSW tests (for example: cms-sw/cmsdist#6314 (comment)) where the data appear odd/corrupted, there is an issue in TStreamerInfo::GenerateInfoForPair (which is almost always used for std::pair in the tip of v6.22 and master).

The problem is when calculating the offset of the second data member, TStreamerInfo::GenerateInfoForPair uses (unwittingly, of course :) ), the value zero for the size of the enums.