### PR TITLE
Updates for DEB/RPM generation with CPack, and RPATH for regular tarballs.

### DIFF
--- a/cmake/modules/CMakeCPackOptions.cmake.in
+++ b/cmake/modules/CMakeCPackOptions.cmake.in
@@ -2,6 +2,35 @@
 # To pass variables to cpack from cmake, they must be configured
 # in this file.
 
+set(CPACK_PACKAGE_NAME "ROOT")
+set(CPACK_PACKAGE_VENDOR "CERN")
+set(CPACK_PACKAGE_DESCRIPTION "A modular scientific software toolkit")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://root.cern")
+set(CPACK_PACKAGE_CONTACT "ROOT Developers <root-dev@cern.ch>")
+
+if(CPACK_GENERATOR STREQUAL "DEB")
+  set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
+  set(CPACK_DEBIAN_PACKAGE_SECTION "science")
+  set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS TRUE)
+  set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS TRUE)
+  set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS_POLICY "=")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "g++")
+  set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "python3, python3-numpy")
+  set(CPACK_DEBIAN_PACKAGE_SUGGESTS "cmake, make, jupyter, python3-numba")
+endif()
+
+if(CPACK_GENERATOR STREQUAL "RPM")
+  set(CPACK_RPM_PACKAGE_AUTOREQ TRUE)
+  set(CPACK_RPM_PACKAGE_AUTOPROV TRUE)
+  set(CPACK_RPM_PACKAGE_REQUIRES "gcc-c++, python3")
+  set(CPACK_RPM_PACKAGE_REQUIRES_PRE "epel-release")
+  if (NOT gnuinstall)
+    set(CPACK_RPM_PACKAGE_RELOCATABLE TRUE)
+  else()
+    set(CPACK_RPM_PACKAGE_RELOCATABLE FALSE)
+  endif()
+endif()
+
 if(CPACK_GENERATOR MATCHES "NSIS")
   # There is a bug in NSI that does not handle full unix paths properly. Make
   # sure there is at least one set of four (4) backlasshes.

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -431,7 +431,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) # point to directories outside the b
 
 # Check whether to add RPATH to the installation (the build tree always has the RPATH enabled)
 if(rpath)
-  set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR}) # install LIBDIR
+  set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR} CACHE INTERNAL "") # install LIBDIR
   set(CMAKE_SKIP_INSTALL_RPATH FALSE)          # don't skip the full RPATH for the install tree
 elseif(APPLE)
   set(CMAKE_INSTALL_NAME_DIR "@rpath")


### PR DESCRIPTION
Please see commit messages for more information.

Note: For the regular binary releases, `-Drpath=ON -DCMAKE_INSTALL_RPATH='$ORIGIN/../lib'` should be added to our Jenkins jobs in order to use relative `RUNPATH` and not require setting `LD_LIBRARY_PATH` afterwards for using ROOT.
The only setup that will be really required later would be setting `PYTHONPATH` to the same as `root-config --libdir` before trying to `import ROOT` from Python.