### PR TITLE
[webgui] adoption of jsroot v6, improve usability with ROOT6 classes

### DIFF
--- a/core/rint/test/TTabComTests.cxx
+++ b/core/rint/test/TTabComTests.cxx
@@ -102,6 +102,6 @@ TEST(TTabComTests, CompleteTObj)
 #endif
    // FIXME: See ROOT-10989
    ASSERT_STREQ(expected.c_str(), GetCompletions("TObj",
-                                                 /*ignore=*/{"TObjectHolder",
+                                                 /*ignore=*/{"TObjectDisplayItem", "TObjectDrawable", "TObjectHolder",
                                                              "TObjectItem"}).c_str());
 }

--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -14,7 +14,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RCanvas.hxx
     ROOT/RFrame.hxx
     ROOT/RMenuItems.hxx
-    ROOT/RObjectDrawable.hxx
     ROOT/RColor.hxx
     ROOT/RDisplayItem.hxx
     ROOT/RAttrMap.hxx
@@ -42,11 +41,11 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RPadUserAxis.hxx
     ROOT/RPave.hxx
     ROOT/RVirtualCanvasPainter.hxx
+    ROOT/TObjectDrawable.hxx
   SOURCES
     src/RCanvas.cxx
     src/RFrame.cxx
     src/RMenuItems.cxx
-    src/RObjectDrawable.cxx
     src/RColor.cxx
     src/RDisplayItem.cxx
     src/RDrawable.cxx
@@ -62,6 +61,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     src/RPadPos.cxx
     src/RPadUserAxis.cxx
     src/RVirtualCanvasPainter.cxx
+    src/TObjectDrawable.cxx
   DICTIONARY_OPTIONS
     -writeEmptyRootPCM
   DEPENDENCIES

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -21,7 +21,7 @@
 #pragma link C++ class ROOT::Experimental::RDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RDrawableDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RIndirectDisplayItem+;
-#pragma link C++ class ROOT::Experimental::RObjectDisplayItem+;
+#pragma link C++ class ROOT::Experimental::TObjectDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RDrawableReply+;
 #pragma link C++ class ROOT::Experimental::RDrawableRequest+;
 #pragma link C++ class ROOT::Experimental::RDrawableExecRequest+;
@@ -38,7 +38,7 @@
 #pragma link C++ class ROOT::Experimental::Detail::RArgsMenuItem+;
 #pragma link C++ class ROOT::Experimental::RMenuItems+;
 #pragma link C++ class ROOT::Experimental::RDrawableMenuRequest+;
-#pragma link C++ class ROOT::Experimental::RObjectDrawable+;
+#pragma link C++ class ROOT::Experimental::TObjectDrawable+;
 #pragma link C++ class ROOT::Experimental::RPadUserAxisBase+;
 #pragma link C++ class ROOT::Experimental::RPadCartesianUserAxis+;
 #pragma link C++ class ROOT::Experimental::RPadExtent+;

--- a/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
@@ -118,13 +118,15 @@ public:
 class RObjectDisplayItem : public RDisplayItem {
 protected:
 
+   int fKind;                              ///< object kind
    const TObject *fObject{nullptr};        ///< ROOT6 object
    std::string fOption;                    ///< drawing options
 
 public:
 
-   RObjectDisplayItem(const TObject *obj, const std::string &opt)
+   RObjectDisplayItem(int kind, const TObject *obj, const std::string &opt)
    {
+      fKind = kind;
       fObject = obj;
       fOption = opt;
    }

--- a/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
@@ -118,18 +118,22 @@ public:
 class TObjectDisplayItem : public RDisplayItem {
 protected:
 
-   int fKind;                              ///< object kind
+   int fKind{0};                           ///< object kind
    const TObject *fObject{nullptr};        ///< ROOT6 object
    std::string fOption;                    ///< drawing options
+   bool fOwner{false};                     ///<! if object must be deleted
 
 public:
 
-   TObjectDisplayItem(int kind, const TObject *obj, const std::string &opt)
+   TObjectDisplayItem(int kind, const TObject *obj, const std::string &opt, bool owner = false)
    {
       fKind = kind;
       fObject = obj;
       fOption = opt;
+      fOwner = owner;
    }
+
+   virtual ~TObjectDisplayItem();
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDisplayItem.hxx
@@ -107,7 +107,7 @@ public:
 };
 
 
-/** \class RObjectDisplayItem
+/** \class TObjectDisplayItem
 \ingroup GpadROOT7
 \brief Display item for TObject with drawing options
 \author Sergey Linev <s.linev@gsi.de>
@@ -115,7 +115,7 @@ public:
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RObjectDisplayItem : public RDisplayItem {
+class TObjectDisplayItem : public RDisplayItem {
 protected:
 
    int fKind;                              ///< object kind
@@ -124,7 +124,7 @@ protected:
 
 public:
 
-   RObjectDisplayItem(int kind, const TObject *obj, const std::string &opt)
+   TObjectDisplayItem(int kind, const TObject *obj, const std::string &opt)
    {
       fKind = kind;
       fObject = obj;

--- a/graf2d/gpadv7/inc/ROOT/RMenuItems.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RMenuItems.hxx
@@ -15,7 +15,7 @@
 
 #include <ROOT/RDrawableRequest.hxx>
 
-class TClass;
+#include "TClass.h"
 
 namespace ROOT {
 namespace Experimental {
@@ -31,9 +31,10 @@ namespace Detail {
 
 class RMenuItem {
 protected:
-   std::string fName;  ///<  name of the menu item
-   std::string fTitle; ///<  title of menu item
-   std::string fExec;  ///< execute when item is activated
+   std::string fName;       ///< name of the menu item
+   std::string fTitle;      ///< title of menu item
+   std::string fExec;       ///< execute when item is activated
+   std::string fClassName;  ///< class to which belongs menu item
 public:
    /** Default constructor */
    RMenuItem() = default;
@@ -41,7 +42,7 @@ public:
    /** Create menu item with the name and title
     *  name used to display item in the object context menu,
     *  title shown as hint info for that item  */
-   RMenuItem(const std::string &name, const std::string &title) : fName(name), fTitle(title), fExec() {}
+   RMenuItem(const std::string &name, const std::string &title) : fName(name), fTitle(title) {}
 
    /** virtual destructor need for vtable, used when vector of RMenuItem* is stored */
    virtual ~RMenuItem() = default;
@@ -49,6 +50,9 @@ public:
    /** Set execution string with all required arguments,
     * which will be executed when menu item is selected  */
    void SetExec(const std::string &exec) { fExec = exec; }
+
+   /** Set class name for menu item, will be used to group items together */
+   void SetClassName(const std::string &clname) { fClassName = clname; }
 
    /** Returns menu item name */
    const std::string &GetName() const { return fName; }
@@ -173,17 +177,19 @@ public:
 
    void Add(std::unique_ptr<Detail::RMenuItem> &&item) { fItems.emplace_back(std::move(item)); }
 
-   void AddMenuItem(const std::string &name, const std::string &title, const std::string &exec)
+   void AddMenuItem(const std::string &name, const std::string &title, const std::string &exec, const TClass *cl = nullptr)
    {
       auto item = std::make_unique<Detail::RMenuItem>(name, title);
       item->SetExec(exec);
+      if (cl) item->SetClassName(cl->GetName());
       Add(std::move(item));
    }
 
-   void AddChkMenuItem(const std::string &name, const std::string &title, bool checked, const std::string &toggle)
+   void AddChkMenuItem(const std::string &name, const std::string &title, bool checked, const std::string &toggle, const TClass *cl = nullptr)
    {
       auto item = std::make_unique<Detail::RCheckedMenuItem>(name, title, checked);
       item->SetExec(toggle);
+      if (cl) item->SetClassName(cl->GetName());
       Add(std::move(item));
    }
 

--- a/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
@@ -27,10 +27,16 @@ class RPadBase;
 */
 
 class RObjectDrawable final : public RDrawable {
+private:
 
-   Internal::RIOShared<TObject> fObj; ///< The object to be painted
+   enum {
+      kNone = 0,     ///< empty container
+      kObject = 1,   ///< plain object
+   };
 
-   std::string fOpts;  ///< drawing options
+   int fKind{kNone};                   ///< object kind
+   Internal::RIOShared<TObject> fObj;  ///< The object to be painted
+   std::string fOpts;                  ///< drawing options
 
 protected:
 
@@ -43,12 +49,19 @@ protected:
    void Execute(const std::string &) final;
 
 public:
+   // special kinds, see TWebSnapshot enums
+   enum EKind {
+      kColors = 4,   ///< list of ROOT colors
+      kStyle = 5     ///< instance of TStyle object
+   };
+
    RObjectDrawable() : RDrawable("tobject") {}
 
    virtual ~RObjectDrawable();
 
-   RObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : RDrawable("tobject"), fObj(obj), fOpts(opt) {}
+   RObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt = "") : RDrawable("tobject"), fKind(kObject), fObj(obj), fOpts(opt) {}
 
+   RObjectDrawable(EKind kind) : RDrawable("tobject"), fKind(kind) {}
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RObjectDrawable.hxx
@@ -12,6 +12,7 @@
 #include <ROOT/RDrawable.hxx>
 
 class TObject;
+class TColor;
 
 namespace ROOT {
 namespace Experimental {
@@ -38,6 +39,8 @@ private:
    Internal::RIOShared<TObject> fObj;  ///< The object to be painted
    std::string fOpts;                  ///< drawing options
 
+   const char *GetColorCode(TColor *col);
+
 protected:
 
    void CollectShared(Internal::RIOSharedVector_t &vect) final { vect.emplace_back(&fObj); }
@@ -52,16 +55,17 @@ public:
    // special kinds, see TWebSnapshot enums
    enum EKind {
       kColors = 4,   ///< list of ROOT colors
-      kStyle = 5     ///< instance of TStyle object
+      kStyle = 5,    ///< instance of TStyle object
+      kPalette = 6   ///< list of colors from palette
    };
 
    RObjectDrawable() : RDrawable("tobject") {}
 
-   virtual ~RObjectDrawable();
+   virtual ~RObjectDrawable() = default;
 
    RObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt = "") : RDrawable("tobject"), fKind(kObject), fObj(obj), fOpts(opt) {}
 
-   RObjectDrawable(EKind kind) : RDrawable("tobject"), fKind(kind) {}
+   RObjectDrawable(EKind kind, const std::string &opt = "");
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -41,6 +41,8 @@ private:
 
    const char *GetColorCode(TColor *col);
 
+   std::unique_ptr<TObject> CreateSpecials(int kind);
+
 protected:
 
    void CollectShared(Internal::RIOSharedVector_t &vect) final { vect.emplace_back(&fObj); }
@@ -63,7 +65,7 @@ public:
 
    TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt = "") : RDrawable("tobject"), fKind(kObject), fObj(obj), fOpts(opt) {}
 
-   TObjectDrawable(EKind kind, const std::string &opt = "");
+   TObjectDrawable(EKind kind, bool persistent = false);
 
    virtual ~TObjectDrawable() = default;
 };

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -6,8 +6,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_RObjectDrawable
-#define ROOT7_RObjectDrawable
+#ifndef ROOT7_TObjectDrawable
+#define ROOT7_TObjectDrawable
 
 #include <ROOT/RDrawable.hxx>
 
@@ -19,7 +19,7 @@ namespace Experimental {
 
 class RPadBase;
 
-/** \class RObjectDrawable
+/** \class TObjectDrawable
 \ingroup GpadROOT7
 \brief Provides v7 drawing facilities for TObject types (TGraph etc).
 \author Sergey Linev
@@ -27,7 +27,7 @@ class RPadBase;
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RObjectDrawable final : public RDrawable {
+class TObjectDrawable final : public RDrawable {
 private:
 
    enum {
@@ -59,13 +59,13 @@ public:
       kPalette = 6   ///< list of colors from palette
    };
 
-   RObjectDrawable() : RDrawable("tobject") {}
+   TObjectDrawable() : RDrawable("tobject") {}
 
-   virtual ~RObjectDrawable() = default;
+   TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt = "") : RDrawable("tobject"), fKind(kObject), fObj(obj), fOpts(opt) {}
 
-   RObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt = "") : RDrawable("tobject"), fKind(kObject), fObj(obj), fOpts(opt) {}
+   TObjectDrawable(EKind kind, const std::string &opt = "");
 
-   RObjectDrawable(EKind kind, const std::string &opt = "");
+   virtual ~TObjectDrawable() = default;
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/src/RDisplayItem.cxx
+++ b/graf2d/gpadv7/src/RDisplayItem.cxx
@@ -11,6 +11,7 @@
 #include "ROOT/RDrawable.hxx"
 
 #include "TString.h"
+#include "TObject.h"
 
 using namespace ROOT::Experimental;
 
@@ -58,6 +59,14 @@ RIndirectDisplayItem::RIndirectDisplayItem(const RDrawable &dr)
    fAttr = &dr.fAttr;
    fCssClass = &dr.fCssClass;
    fId = &dr.fId;
+}
+
+
+///////////////////////////////////////////////////////////
+/// destructor
+TObjectDisplayItem::~TObjectDisplayItem()
+{
+   if (fOwner) delete fObject;
 }
 
 

--- a/graf2d/gpadv7/src/RDrawableRequest.cxx
+++ b/graf2d/gpadv7/src/RDrawableRequest.cxx
@@ -30,8 +30,26 @@ RDrawableRequest::~RDrawableRequest() = default;
 
 std::unique_ptr<RDrawableReply> RDrawableExecRequest::Process()
 {
-   if (!exec.empty() && GetContext().GetDrawable())
-      GetContext().GetDrawable()->Execute(exec);
+   if (!exec.empty() && GetContext().GetDrawable()) {
+      std::string buf = exec;
+
+      // many operations can be separated by ";;" string
+      // TODO: exclude potential mistake if such symbols appears inside quotes
+
+      while (!buf.empty()) {
+         std::string sub = buf;
+         auto pos = buf.find(";;");
+         if (pos == std::string::npos) {
+            sub = buf;
+            buf.clear();
+         } else {
+            sub = buf.substr(0,pos);
+            buf = buf.substr(pos+2);
+         }
+         if (!sub.empty())
+            GetContext().GetDrawable()->Execute(sub);
+      }
+   }
 
    if (GetContext().GetCanvas())
       GetContext().GetCanvas()->Modified();

--- a/graf2d/gpadv7/src/RMenuItems.cxx
+++ b/graf2d/gpadv7/src/RMenuItems.cxx
@@ -38,7 +38,41 @@ void RMenuItems::PopulateObjectMenu(void *obj, TClass *cl)
    TIter iter(&lst);
    TMethod *m = nullptr;
 
+   TClass *last_class = nullptr;
+   bool has_editor = false;
+
+   auto match = [](const TObject *v, const char *name) { return !strcmp(v->GetName(), name); };
+
    while ((m = (TMethod *)iter()) != nullptr) {
+
+      TClass *m_cl = m->GetClass();
+      bool is_editor = false;
+
+      if (match(m_cl, "TH1")) {
+         if (match(m, "SetHighlight")) continue;
+         if (match(m, "DrawPanel")) is_editor = true;
+      } else if (match(m_cl, "TGraph")) {
+         if (match(m, "SetHighlight")) continue;
+         if (match(m, "DrawPanel")) is_editor = true;
+      } else if (match(m_cl, "TAttFill")) {
+         if (match(m, "SetFillAttributes")) is_editor = true;
+      } else if (match(m_cl, "TAttLine")) {
+         if (match(m, "SetLineAttributes")) is_editor = true;
+      } else if (match(m_cl, "TAttMarker")) {
+         if (match(m, "SetMarkerAttributes")) is_editor = true;
+      } else if (match(m_cl, "TAttText")) {
+         if (match(m, "SetTextAttributes")) is_editor = true;
+      }
+
+      if (is_editor) {
+         if (!has_editor) {
+            AddMenuItem("Editor", "Attributes editor", "Show:Editor", last_class ? last_class : m_cl);
+            has_editor = true;
+         }
+         continue;
+      }
+
+      last_class = m_cl;
 
       if (m->IsMenuItem() == kMenuToggle) {
          TString getter;
@@ -65,7 +99,7 @@ void RMenuItems::PopulateObjectMenu(void *obj, TClass *cl)
                Long_t l(0);
                call->Execute(obj, l);
 
-               AddChkMenuItem(m->GetName(), m->GetTitle(), l != 0, Form("%s(%s)", m->GetName(), (l != 0) ? "0" : "1"));
+               AddChkMenuItem(m->GetName(), m->GetTitle(), l != 0, Form("%s(%s)", m->GetName(), (l != 0) ? "0" : "1"), m_cl);
 
             } else {
                // Error("CheckModifiedFlag", "Cannot get toggle value with getter %s", getter.Data());
@@ -75,10 +109,11 @@ void RMenuItems::PopulateObjectMenu(void *obj, TClass *cl)
          TList *args = m->GetListOfMethodArgs();
 
          if (!args || (args->GetSize() == 0)) {
-            AddMenuItem(m->GetName(), m->GetTitle(), Form("%s()", m->GetName()));
+            AddMenuItem(m->GetName(), m->GetTitle(), Form("%s()", m->GetName()), m_cl);
          } else {
             auto item = std::make_unique<Detail::RArgsMenuItem>(m->GetName(), m->GetTitle());
             item->SetExec(Form("%s()", m->GetName()));
+            item->SetClassName(m_cl->GetName());
 
             TIter args_iter(args);
             TMethodArg *arg = nullptr;

--- a/graf2d/gpadv7/src/RObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/RObjectDrawable.cxx
@@ -13,6 +13,7 @@
 #include <ROOT/RMenuItems.hxx>
 
 #include "TROOT.h"
+#include "TStyle.h"
 
 #include <exception>
 #include <sstream>
@@ -25,19 +26,26 @@ RObjectDrawable::~RObjectDrawable() {}
 
 std::unique_ptr<RDisplayItem> RObjectDrawable::Display(const RDisplayContext &ctxt)
 {
-   if (GetVersion() > ctxt.GetLastVersion())
-      return std::make_unique<RObjectDisplayItem>(fObj.get(), fOpts);
+   if (GetVersion() > ctxt.GetLastVersion()) {
+      if (fKind == kStyle)
+         return std::make_unique<RObjectDisplayItem>(fKind, gStyle, fOpts);
+      else
+         return std::make_unique<RObjectDisplayItem>(fKind, fObj.get(), fOpts);
+   }
    return nullptr;
 }
 
 void RObjectDrawable::PopulateMenu(RMenuItems &items)
 {
    // fill context menu items for the ROOT class
-   items.PopulateObjectMenu(fObj.get(), fObj.get()->IsA());
+   if (fKind == kObject)
+      items.PopulateObjectMenu(fObj.get(), fObj.get()->IsA());
 }
 
 void RObjectDrawable::Execute(const std::string &exec)
 {
+   if (fKind != kObject) return;
+
    TObject *obj = fObj.get();
 
    std::stringstream cmd;

--- a/graf2d/gpadv7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/TObjectDrawable.cxx
@@ -6,7 +6,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RObjectDrawable.hxx>
+#include <ROOT/TObjectDrawable.hxx>
 
 #include <ROOT/RDisplayItem.hxx>
 #include <ROOT/RLogger.hxx>
@@ -25,7 +25,7 @@
 
 using namespace ROOT::Experimental;
 
-RObjectDrawable::RObjectDrawable(EKind kind, const std::string &opt) : RDrawable("tobject"), fKind(kind), fOpts(opt)
+TObjectDrawable::TObjectDrawable(EKind kind, const std::string &opt) : RDrawable("tobject"), fKind(kind), fOpts(opt)
 {
    switch (fKind) {
       case kColors: {
@@ -69,7 +69,7 @@ RObjectDrawable::RObjectDrawable(EKind kind, const std::string &opt) : RDrawable
 ////////////////////////////////////////////////////////////////////
 /// Convert TColor to RGB string for using with SVG
 
-const char *RObjectDrawable::GetColorCode(TColor *col)
+const char *TObjectDrawable::GetColorCode(TColor *col)
 {
    static TString code;
 
@@ -82,22 +82,22 @@ const char *RObjectDrawable::GetColorCode(TColor *col)
 }
 
 
-std::unique_ptr<RDisplayItem> RObjectDrawable::Display(const RDisplayContext &ctxt)
+std::unique_ptr<RDisplayItem> TObjectDrawable::Display(const RDisplayContext &ctxt)
 {
    if (GetVersion() > ctxt.GetLastVersion())
-      return std::make_unique<RObjectDisplayItem>(fKind, fObj.get(), fOpts);
+      return std::make_unique<TObjectDisplayItem>(fKind, fObj.get(), fOpts);
 
    return nullptr;
 }
 
-void RObjectDrawable::PopulateMenu(RMenuItems &items)
+void TObjectDrawable::PopulateMenu(RMenuItems &items)
 {
    // fill context menu items for the ROOT class
    if (fKind == kObject)
       items.PopulateObjectMenu(fObj.get(), fObj.get()->IsA());
 }
 
-void RObjectDrawable::Execute(const std::string &exec)
+void TObjectDrawable::Execute(const std::string &exec)
 {
    if (fKind != kObject) return;
 
@@ -105,6 +105,6 @@ void RObjectDrawable::Execute(const std::string &exec)
 
    std::stringstream cmd;
    cmd << "((" << obj->ClassName() << "* ) " << std::hex << std::showbase << (size_t)obj << ")->" << exec << ";";
-   std::cout << "RObjectDrawable::Execute Obj " << obj->GetName() << "Cmd " << cmd.str() << std::endl;
+   std::cout << "TObjectDrawable::Execute Obj " << obj->GetName() << "Cmd " << cmd.str() << std::endl;
    gROOT->ProcessLine(cmd.str().c_str());
 }

--- a/graf2d/gpadv7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/TObjectDrawable.cxx
@@ -103,8 +103,20 @@ void TObjectDrawable::Execute(const std::string &exec)
 
    TObject *obj = fObj.get();
 
+   std::string sub, ex = exec;
+   if (ex.compare(0, 6, "xaxis#") == 0) {
+      ex.erase(0,6);
+      ex.insert(0, "GetXaxis()->");
+   } else if (ex.compare(0, 6, "yaxis#") == 0) {
+      ex.erase(0,6);
+      ex.insert(0, "GetYaxis()->");
+   } else if (ex.compare(0, 6, "zaxis#") == 0) {
+      ex.erase(0,6);
+      ex.insert(0, "GetZaxis()->");
+   }
+
    std::stringstream cmd;
-   cmd << "((" << obj->ClassName() << "* ) " << std::hex << std::showbase << (size_t)obj << ")->" << exec << ";";
+   cmd << "((" << obj->ClassName() << "* ) " << std::hex << std::showbase << (size_t)obj << ")->" << ex << ";";
    std::cout << "TObjectDrawable::Execute Obj " << obj->GetName() << "Cmd " << cmd.str() << std::endl;
    gROOT->ProcessLine(cmd.str().c_str());
 }

--- a/gui/browsable/src/TLeafDraw7Provider.cxx
+++ b/gui/browsable/src/TLeafDraw7Provider.cxx
@@ -9,7 +9,7 @@
 #include "TLeafProvider.hxx"
 
 #include <ROOT/RCanvas.hxx>
-#include <ROOT/RObjectDrawable.hxx>
+#include <ROOT/TObjectDrawable.hxx>
 
 /** Provider for drawing of ROOT7 classes */
 
@@ -33,7 +33,7 @@ public:
          std::shared_ptr<TH1> shared;
          shared.reset(hist);
 
-         subpad->Draw<ROOT::Experimental::RObjectDrawable>(shared, opt);
+         subpad->Draw<ROOT::Experimental::TObjectDrawable>(shared, opt);
 
          return true;
       });

--- a/gui/browsable/src/TObjectDraw7Provider.cxx
+++ b/gui/browsable/src/TObjectDraw7Provider.cxx
@@ -10,7 +10,7 @@
 
 #include "TObject.h"
 #include <ROOT/RCanvas.hxx>
-#include <ROOT/RObjectDrawable.hxx>
+#include <ROOT/TObjectDrawable.hxx>
 
 using namespace ROOT::Experimental::Browsable;
 
@@ -32,7 +32,7 @@ public:
             subpad->GetCanvas()->Update(true);
          }
 
-         subpad->Draw<ROOT::Experimental::RObjectDrawable>(tobj, opt);
+         subpad->Draw<ROOT::Experimental::TObjectDrawable>(tobj, opt);
          return true;
       });
 

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -24,7 +24,6 @@
 
 #include <ROOT/RLogger.hxx>
 #include <ROOT/RMakeUnique.hxx>
-#include <ROOT/RObjectDrawable.hxx>
 #include <ROOT/RFileDialog.hxx>
 #include <ROOT/RCanvas.hxx>
 

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -722,7 +722,7 @@ RCanvasPainter::FindPrimitive(const RCanvas &can, const std::string &id, const R
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Method called when GUI sends file to save on local disk
-/// File coded with base64 coding
+/// File data coded with base64 coding beside SVG format
 
 void RCanvasPainter::SaveCreatedFile(std::string &reply)
 {
@@ -735,13 +735,22 @@ void RCanvasPainter::SaveCreatedFile(std::string &reply)
    std::string fname(reply, 0, pos);
    reply.erase(0, pos + 1);
 
-   TString binary = TBase64::Decode(reply.c_str());
+   Bool_t isSvg = (fname.length() > 4) && ((fname.rfind(".svg") == fname.length()-4) || (fname.rfind(".SVG") == fname.length()-4));
+
+   int file_len = 0;
 
    std::ofstream ofs(fname, std::ios::binary);
-   ofs.write(binary.Data(), binary.Length());
+   if (isSvg) {
+      ofs << reply;
+      file_len = reply.length();
+   } else {
+      TString binary = TBase64::Decode(reply.c_str());
+      ofs.write(binary.Data(), binary.Length());
+      file_len = binary.Length();
+   }
    ofs.close();
 
-   R__INFO_HERE("CanvasPainter") << " Save file from GUI " << fname << " len " << binary.Length();
+   R__INFO_HERE("CanvasPainter") << " Save file from GUI " << fname << " len " << file_len;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/cefdisplay/src/gui_handler.cxx
+++ b/gui/cefdisplay/src/gui_handler.cxx
@@ -207,7 +207,7 @@ protected:
 
    void CheckWSPageContent(THttpWSHandler *) override
    {
-      std::string search = "JSROOT.ConnectWebWindow({";
+      std::string search = "JSROOT.connectWebWindow({";
       std::string replace = search + "platform:\"cef3\",socket_kind:\"longpoll\",";
 
       ReplaceAllinContent(search, replace, true);

--- a/gui/qt5webdisplay/rooturlschemehandler.cpp
+++ b/gui/qt5webdisplay/rooturlschemehandler.cpp
@@ -78,7 +78,7 @@ protected:
 
    void CheckWSPageContent(THttpWSHandler *) override
    {
-      std::string search = "JSROOT.ConnectWebWindow({";
+      std::string search = "JSROOT.connectWebWindow({";
       std::string replace = search + "platform:\"qt5\",socket_kind:\"rawlongpoll\",";
 
       ReplaceAllinContent(search, replace, true);

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -809,7 +809,7 @@ try_again:
          }
       } else {
 
-         auto p1 = dumpcont.find(";base64,");
+         auto p1 = dumpcont.rfind(";base64,");
          auto p2 = dumpcont.rfind("></div>");
 
          if ((p1 != std::string::npos) && (p2 != std::string::npos) && (p1 < p2)) {

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -885,7 +885,7 @@ std::string ROOT::Experimental::RWebWindow::GetClientVersion() const
 
 /////////////////////////////////////////////////////////////////////////
 /// Set arbitrary JSON code, which is accessible via conn.GetUserArgs() method
-/// This JSON code injected into main HTML document into JSROOT.ConnectWebWindow()
+/// This JSON code injected into main HTML document into JSROOT.connectWebWindow()
 /// Must be called before RWebWindow::Show() method is called
 
 void ROOT::Experimental::RWebWindow::SetUserArgs(const std::string &args)

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -64,7 +64,7 @@ protected:
          more_args = "user_args: "s + user_args + ","s;
 
       if (!more_args.empty()) {
-         std::string search = "JSROOT.ConnectWebWindow({"s;
+         std::string search = "JSROOT.connectWebWindow({"s;
          std::string replace = search + more_args;
          arg->ReplaceAllinContent(search, replace, true);
          arg->AddNoCacheHeader();

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -98,7 +98,7 @@ Bool_t TWebCanvas::IsJSSupportedClass(TObject *obj)
                             {"TGaxis", false},
                             {"TPave", true},
                             {"TArrow", false},
-//                            {"TBox", false},  // in principle, can be handled via TWebPainter
+                            {"TBox", false},  // in principle, can be handled via TWebPainter
                             {"TWbox", false}, // some extra calls which cannot be handled via TWebPainter
                             {"TLine", false}, // also can be handler via TWebPainter
                             {"TText", false},
@@ -110,6 +110,7 @@ Bool_t TWebCanvas::IsJSSupportedClass(TObject *obj)
                             {"TPolyLine3D", false},
                             {"TGraph2D", false},
                             {"TGraph2DErrors", false},
+                            {"TASImage", false},
                             {nullptr, false}};
 
    // fast check of class name

--- a/js/files/canv_batch.htm
+++ b/js/files/canv_batch.htm
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
    <meta charset="UTF-8">
-   <title></title>
+   <title>Batch production</title>
    <script src="$jsrootsys/scripts/JSRootCore.js" type="text/javascript"></script>
    <style>
      @media print {
@@ -25,15 +25,17 @@
 <script type='text/javascript'>
    JSROOT.BatchMode = true;
 
+   let kind = "$draw_kind";
+
    JSROOT.draw("drawing", main_object, "").then(painter => {
-      d3.select("#data").remove();
-      if ("$draw_kind" != "draw")
-         painter.ProduceImage(true, "$draw_kind", res => {
-            var elem = d3.select("#drawing").attr("style", null);
-            if ("$draw_kind" == "svg")
+	   d3.select("#data").remove();
+      if (kind != "draw")
+         painter.ProduceImage(true, kind).then(res => {
+            let elem = d3.select("#drawing").attr("style", null);
+            if (kind == "svg")
                elem.html(res);
             else
-               elem.append("img").attr("src", res);
+            	elem.html("").append("img").attr("src", res);
         });
    });
 </script>

--- a/js/scripts/JSRoot.base3d.js
+++ b/js/scripts/JSRoot.base3d.js
@@ -5,15 +5,13 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
 
    "use strict";
 
-   /** Creates renderer for the 3D drawings
-    *
+   /** @summary Creates renderer for the 3D drawings
+    * @memberOf JSROOT.Painter
     * @param {value} width - rendering width
     * @param {value} height - rendering height
-    * @param {value} render3d - render type, see JSROOT.constants.Render3D
+    * @param {value} render3d - render type, see {@link JSROOT.constants.Render3D}
     * @param {object} args - different arguments for creating 3D renderer
-    * @private
-    */
-
+    * @private */
    jsrp.Create3DRenderer = function(width, height, render3d, args) {
 
       let rc = JSROOT.constants.Render3D;
@@ -21,11 +19,6 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
       render3d = jsrp.GetRender3DKind(render3d);
 
       if (!args) args = { antialias: true, alpha: true };
-
-      // solves problem with toDataUrl in headless mode of chrome
-      // found https://stackoverflow.com/questions/48011613
-      if (JSROOT.BatchMode && JSROOT.browser.isChromeHeadless && (kind == rc.WebGLImage))
-         args.premultipliedAlpha = false;
 
       let need_workaround = false, renderer,
           doc = JSROOT.get_document();
@@ -64,13 +57,10 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
 
          need_workaround = true;
       } else {
+         // rendering with WebGL directly into svg image
          renderer = new THREE.WebGLRenderer(args);
-         if (JSROOT.BatchMode) {
-            need_workaround = true;
-         } else {
-            renderer.jsroot_dom = doc.createElementNS('http://www.w3.org/2000/svg', 'image');
-            d3.select(renderer.jsroot_dom).attr("width", width).attr("height", height);
-         }
+         renderer.jsroot_dom = doc.createElementNS('http://www.w3.org/2000/svg', 'image');
+         d3.select(renderer.jsroot_dom).attr("width", width).attr("height", height);
       }
 
       if (need_workaround) {
@@ -143,13 +133,8 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
          imageData.data.set( pixels );
          context.putImageData( imageData, 0, 0 );
 
-         let dataUrl = canvas.toDataURL("image/png");
-         let svg = '<image width="' + canvas.width + '" height="' + canvas.height + '" xlink:href="' + dataUrl + '"></image>';
-         JSROOT.svg_workaround[renderer.workaround_id] = svg;
-      } else if (JSROOT.BatchMode) {
-         // this is conversion of WebGL context into svg image
-         let dataUrl = renderer.domElement.toDataURL("image/png");
-         let svg = '<image width="' + canvas.width + '" height="' + canvas.height + '" xlink:href="' + dataUrl + '"></image>';
+         let dataUrl = canvas.toDataURL("image/png"),
+             svg = '<image width="' + canvas.width + '" height="' + canvas.height + '" xlink:href="' + dataUrl + '"></image>';
          JSROOT.svg_workaround[renderer.workaround_id] = svg;
       } else {
          let dataUrl = renderer.domElement.toDataURL("image/png");

--- a/js/scripts/JSRoot.base3d.js
+++ b/js/scripts/JSRoot.base3d.js
@@ -64,9 +64,9 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
       }
 
       if (need_workaround) {
-         if (!JSROOT.svg_workaround) JSROOT.svg_workaround = [];
-         renderer.workaround_id = JSROOT.svg_workaround.length;
-         JSROOT.svg_workaround[renderer.workaround_id] = "<svg></svg>"; // dummy, provided in AfterRender3D
+         if (!JSROOT._.svg_3ds) JSROOT._.svg_3ds = [];
+         renderer.workaround_id = JSROOT._.svg_3ds.length;
+         JSROOT._.svg_3ds[renderer.workaround_id] = "<svg></svg>"; // dummy, provided in AfterRender3D
 
          // replace DOM element in renderer
          renderer.jsroot_dom = doc.createElementNS('http://www.w3.org/2000/svg', 'path');
@@ -103,7 +103,7 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
       if (renderer.jsroot_render3d == rc.SVG) {
          // case of SVGRenderer
          if (JSROOT.BatchMode) {
-            JSROOT.svg_workaround[renderer.workaround_id] = renderer.makeOuterHTML();
+            JSROOT._.svg_3ds[renderer.workaround_id] = renderer.makeOuterHTML();
          } else {
             let parent = renderer.jsroot_dom.parentNode;
             if (parent) {
@@ -135,7 +135,7 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
 
          let dataUrl = canvas.toDataURL("image/png"),
              svg = '<image width="' + canvas.width + '" height="' + canvas.height + '" xlink:href="' + dataUrl + '"></image>';
-         JSROOT.svg_workaround[renderer.workaround_id] = svg;
+         JSROOT._.svg_3ds[renderer.workaround_id] = svg;
       } else {
          let dataUrl = renderer.domElement.toDataURL("image/png");
          d3.select(renderer.jsroot_dom).attr("xlink:href", dataUrl);
@@ -143,10 +143,10 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
    }
 
    jsrp.ProcessSVGWorkarounds = function(svg) {
-      if (!JSROOT.svg_workaround) return svg;
-      for (let k = 0;  k < JSROOT.svg_workaround.length; ++k)
-         svg = svg.replace('<path jsroot_svg_workaround="' + k + '"></path>', JSROOT.svg_workaround[k]);
-      JSROOT.svg_workaround = undefined;
+      if (!JSROOT._.svg_3ds) return svg;
+      for (let k = 0;  k < JSROOT._.svg_3ds.length; ++k)
+         svg = svg.replace('<path jsroot_svg_workaround="' + k + '"></path>', JSROOT._.svg_3ds[k]);
+      JSROOT._.svg_3ds = undefined;
       return svg;
    }
 

--- a/js/scripts/JSRoot.geom.js
+++ b/js/scripts/JSRoot.geom.js
@@ -3030,6 +3030,8 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
          // activate worker
          if (this.ctrl.use_worker > 0) this.startWorker();
 
+         jsrp.Assign3DHandler(this);
+
          let size = this.size_for_3d(this._webgl ? undefined : 3);
 
          this._fit_main_area = (size.can3d === -1);

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -3040,20 +3040,21 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       });
    }
 
-   TPadPainter.prototype.CreateImage = function(format, call_back) {
-      if (format=="pdf") {
-         // use https://github.com/MrRio/jsPDF in the future here
-         JSROOT.CallBack(call_back, btoa("dummy PDF file"));
-      } else if ((format=="png") || (format=="jpeg") || (format=="svg")) {
-         this.ProduceImage(true, format, function(res) {
-            if ((format=="svg") || !res)
-               return JSROOT.CallBack(call_back, res);
+   /** @summary Create image for the pad
+     * @returns {Promise} with image data, coded with btoa() function */
+   TPadPainter.prototype.CreateImage = function(format) {
+      // use https://github.com/MrRio/jsPDF in the future here
+      if (format=="pdf")
+         return Promise.resolve(btoa("dummy PDF file"));
+
+      if ((format=="png") || (format=="jpeg") || (format=="svg"))
+         return this.ProduceImage(true, format).then(res => {
+            if (!res || (format=="svg")) return res;
             let separ = res.indexOf("base64,");
-            JSROOT.CallBack(call_back, (separ>0) ? res.substr(separ+7) : "");
+            return (separ>0) ? res.substr(separ+7) : "";
          });
-      } else {
-         JSROOT.CallBack(call_back, "");
-      }
+
+      return Promise.resolve("");
    }
 
    /** Collects pad information for TWebCanvas, need to update different states */
@@ -3199,7 +3200,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          if (filename.length === 0) filename = this.iscan ? "canvas" : "pad";
          filename += "." + kind;
       }
-      this.ProduceImage(full_canvas, kind, function(imgdata) {
+      this.ProduceImage(full_canvas, kind).then(imgdata => {
          let a = document.createElement('a');
          a.download = filename;
          a.href = (kind != "svg") ? imgdata : "data:image/svg+xml;charset=utf-8,"+encodeURIComponent(imgdata);
@@ -3209,19 +3210,19 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       });
    }
 
-   TPadPainter.prototype.ProduceImage = function(full_canvas, file_format, call_back) {
+   /** @summary Prodce image for the pad
+     * @returns {Promise} with created image */
+   TPadPainter.prototype.ProduceImage = function(full_canvas, file_format) {
 
       let use_frame = (full_canvas === "frame");
 
       let elem = use_frame ? this.svg_frame() : (full_canvas ? this.svg_canvas() : this.svg_pad(this.this_pad_name));
 
-      if (elem.empty()) return JSROOT.CallBack(call_back);
+      if (elem.empty()) return Promise.resolve("");
 
       let painter = (full_canvas && !use_frame) ? this.canv_painter() : this;
 
       let items = []; // keep list of replaced elements, which should be moved back at the end
-
-//      document.body.style.cursor = 'wait';
 
       if (!use_frame) // do not make transformations for the frame
       painter.ForEachPainterInPad(pp => {
@@ -3243,16 +3244,16 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
          let can3d = main.access_3d_kind();
 
-         if ((can3d !== 1) && (can3d !== 2)) return;
+         if ((can3d !== JSROOT.constants.Embed3D.Overlay) && (can3d !== JSROOT.constants.Embed3D.Embed)) return;
 
-         let sz2 = main.size_for_3d(2); // get size and position of DOM element as it will be embed
+         let sz2 = main.size_for_3d(JSROOT.constants.Embed3D.Embed); // get size and position of DOM element as it will be embed
 
          let canvas = main.renderer.domElement;
          main.Render3D(0); // WebGL clears buffers, therefore we should render scene and convert immediately
          let dataUrl = canvas.toDataURL("image/png");
 
          // remove 3D drawings
-         if (can3d == 2) {
+         if (can3d === JSROOT.constants.Embed3D.Embed) {
             item.foreign = item.prnt.select("." + sz2.clname);
             item.foreign.remove();
          }
@@ -3263,9 +3264,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             item.frame_next = item.frame_node.nextSibling;
             svg_frame.remove();
          }
-
-         //var origin = main.apply_3d_size(sz3d, true);
-         //origin.remove();
 
          // add svg image
          item.img = item.prnt.insert("image",".primitives_layer")     // create image object
@@ -3286,7 +3284,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          return decodeURIComponent(data);
       }
 
-      function reconstruct(res) {
+      function reconstruct() {
          for (let k=0;k<items.length;++k) {
             let item = items[k];
 
@@ -3304,8 +3302,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             if (item.btns_node) // reinsert buttons
                item.btns_prnt.insertBefore(item.btns_node, item.btns_next);
          }
-
-         JSROOT.CallBack(call_back, res);
       }
 
       let width = elem.property('draw_width'), height = elem.property('draw_height');
@@ -3315,28 +3311,35 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                  elem.node().innerHTML +
                  '</svg>';
 
-      if (file_format == "svg")
-         return reconstruct(svg); // return SVG file as is
+      if (file_format == "svg") {
+         reconstruct();
+         return Promise.resolve(svg); // return SVG file as is
+      }
 
       let doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
 
       let image = new Image();
-      image.onload = function() {
-         let canvas = document.createElement('canvas');
-         canvas.width = image.width;
-         canvas.height = image.height;
-         let context = canvas.getContext('2d');
-         context.drawImage(image, 0, 0);
 
-         reconstruct(canvas.toDataURL('image/' + file_format));
-      }
+      return new Promise(resolveFunc => {
+         image.onload = function() {
+            let canvas = document.createElement('canvas');
+            canvas.width = image.width;
+            canvas.height = image.height;
+            let context = canvas.getContext('2d');
+            context.drawImage(image, 0, 0);
 
-      image.onerror = function(arg) {
-         console.log('IMAGE ERROR', arg);
-         reconstruct(null);
-      }
+            reconstruct();
+            resolveFunc(canvas.toDataURL('image/' + file_format));
+         }
 
-      image.src = 'data:image/svg+xml;base64,' + window.btoa(reEncode(doctype + svg));
+         image.onerror = function(arg) {
+            console.log('IMAGE ERROR', arg);
+            reconstruct();
+            resolveFunc(null);
+         }
+
+         image.src = 'data:image/svg+xml;base64,' + window.btoa(reEncode(doctype + svg));
+      });
    }
 
    TPadPainter.prototype.PadButtonClick = function(funcname, evnt) {
@@ -3694,12 +3697,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       JSROOT.progress(msg, 7000);
    }
 
-   /// function called when canvas menu item Save is called
+   /** @summary Function called when canvas menu item Save is called */
    TCanvasPainter.prototype.SaveCanvasAsFile = function(fname) {
       let pnt = fname.indexOf(".");
-      this.CreateImage(fname.substr(pnt+1), res => {
-         this.SendWebsocket("SAVE:" + fname + ":" + res);
-      })
+      this.CreateImage(fname.substr(pnt+1))
+          .then(res => this.SendWebsocket("SAVE:" + fname + ":" + res));
    }
 
    TCanvasPainter.prototype.SendSaveCommand = function(fname) {
@@ -3801,9 +3803,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
              cmd = msg.substr(p1+1),
              reply = "REPLY:" + cmdid + ":";
          if ((cmd == "SVG") || (cmd == "PNG") || (cmd == "JPEG")) {
-            this.CreateImage(cmd.toLowerCase(), function(res) {
-               handle.Send(reply + res);
-            });
+            this.CreateImage(cmd.toLowerCase())
+                .then(res => handle.Send(reply + res));
          } else {
             console.log('Unrecognized command ' + cmd);
             handle.Send(reply);

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -1597,7 +1597,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    }
 
    TFramePainter.prototype.Redraw = function(/* reason */) {
-
       let pp = this.pad_painter();
       if (pp) pp.frame_painter_ref = this; // keep direct reference to the frame painter
 
@@ -2015,6 +2014,12 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       jsrp.SelectActivePad({ pp: this, active: false });
 
       JSROOT.ObjectPainter.prototype.Cleanup.call(this);
+   }
+
+   /** @summary Returns frame painter inside the pad
+     * @private */
+   TPadPainter.prototype.frame_painter = function() {
+      return this.frame_painter_ref;
    }
 
    /** @summary Cleanup primitives from pad - selector lets define which painters to remove */
@@ -3098,7 +3103,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       if (!r) return false;
 
-      let main = this.frame_painter_ref,
+      let main = this.frame_painter(),
           p = this.svg_pad(this.this_pad_name);
 
       r.ranges = main && main.ranges_set ? true : false; // indicate that ranges are assigned
@@ -3168,11 +3173,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
           case "xaxis":
           case "yaxis":
           case "zaxis":
-             selp = this.frame_painter_ref;
+             selp = this.frame_painter();
              selkind = name[0];
              break;
           case "frame":
-             selp = this.frame_painter_ref;
+             selp = this.frame_painter();
              break;
           default: {
              let indx = parseInt(name);
@@ -3233,7 +3238,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             btns.remove();
          }
 
-         let main = pp.frame_painter_ref;
+         let main = pp.frame_painter();
          if (!main || (typeof main.Render3D !== 'function')) return;
 
          let can3d = main.access_3d_kind();
@@ -3456,7 +3461,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
    TPadPainter.prototype.DrawingReady = function(res_painter) {
 
-      let main = this.frame_painter_ref;
+      let main = this.frame_painter();
 
       if (main && main.mode3d && typeof main.Render3D == 'function') main.Render3D(-2222);
 
@@ -3645,7 +3650,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
          let canv = JSROOT.Create("TCanvas"),
              pad = this.root_pad(),
-             main = this.frame_painter_ref, drawopt;
+             main = this.frame_painter(), drawopt;
 
          if (kind == "X") {
             canv.fLeftMargin = pad.fLeftMargin;

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -2643,7 +2643,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    }
 
    TPadPainter.prototype.RedrawByResize = function() {
-      if (this.access_3d_kind() === 1) return true;
+      if (this.access_3d_kind() === JSROOT.constants.Embed3D.Overlay) return true;
 
       for (let i = 0; i < this.painters.length; ++i)
          if (typeof this.painters[i].RedrawByResize === 'function')
@@ -3244,11 +3244,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          let main = pp.frame_painter();
          if (!main || (typeof main.Render3D !== 'function')) return;
 
-         let can3d = main.access_3d_kind();
+         let can3d = pp.access_3d_kind();
 
          if ((can3d !== JSROOT.constants.Embed3D.Overlay) && (can3d !== JSROOT.constants.Embed3D.Embed)) return;
 
-         let sz2 = main.size_for_3d(JSROOT.constants.Embed3D.Embed); // get size and position of DOM element as it will be embed
+         let sz2 = pp.size_for_3d(JSROOT.constants.Embed3D.Embed); // get size and position of DOM element as it will be embed
 
          let canvas = main.renderer.domElement;
          main.Render3D(0); // WebGL clears buffers, therefore we should render scene and convert immediately

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -2811,9 +2811,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          if (snap.fKind === webSnapIds.kColors) {
 
             let ListOfColors = [], arr = snap.fSnapshot.fOper.split(";");
-            for (let n=0;n<arr.length;++n) {
+            for (let n = 0; n < arr.length; ++n) {
                let name = arr[n], p = name.indexOf(":");
-               if (p>0) {
+               if (p > 0) {
                   ListOfColors[parseInt(name.substr(0,p))] = "rgb(" + name.substr(p+1) + ")";
                } else {
                   p = name.indexOf("=");

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -2200,6 +2200,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          if (this._fixed_size) {
             render_to.style("overflow","auto");
             rect = { width: this.pad.fCw, height: this.pad.fCh };
+            if (!rect.width || !rect.height)
+               rect = this.get_visible_rect(render_to);
          } else {
             rect = this.check_main_resize(2, new_size, factor);
          }
@@ -3310,6 +3312,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       let svg = '<svg width="' + width + '" height="' + height + '" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">' +
                  elem.node().innerHTML +
                  '</svg>';
+
+      if (jsrp.ProcessSVGWorkarounds)
+         svg = jsrp.ProcessSVGWorkarounds(svg);
+
+      svg = jsrp.CompressSVG(svg);
 
       if (file_format == "svg") {
          reconstruct();

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -1436,7 +1436,9 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
               System: jsrp.Coord.kCARTESIAN,
               AutoColor: false, NoStat: false, ForceStat: false, PadStats: false, PadTitle: false, AutoZoom: false,
               HighRes: 0, Zero: true, Palette: 0, BaseLine: false,
-              Optimize: JSROOT.settings.OptimizeDraw, Mode3D: false,
+              Optimize: JSROOT.settings.OptimizeDraw,
+              Mode3D: false,
+              Render3D: JSROOT.constants.Render3D.Default,
               FrontBox: true, BackBox: true,
               _pmc: false, _plc: false, _pfc: false, need_fillcol: false,
               minimum: -1111, maximum: -1111, ymin: 0, ymax: 0 });

--- a/js/scripts/JSRoot.hist3d.js
+++ b/js/scripts/JSRoot.hist3d.js
@@ -36,16 +36,17 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
      * @private */
    JSROOT.TFramePainter.prototype.Create3DScene = function(arg, render3d) {
 
-      let pp = this.pad_painter();
-
-      if ((arg!==undefined) && (arg < 0)) {
+      if ((arg !== undefined) && (arg < 0)) {
 
          if (!this.mode3d) return;
+
+         if (!this.clear_3d_canvas)
+            return console.error('Strange, why mode3d is configured!!!!', this.mode3d);
 
          //if (typeof this.TestAxisVisibility === 'function')
          this.TestAxisVisibility(null, this.toplevel);
 
-         if (pp) pp.clear_3d_canvas();
+         this.clear_3d_canvas();
 
          jsrp.DisposeThreejsObject(this.scene);
          if (this.control) this.control.Cleanup();
@@ -96,7 +97,10 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
       }
 
       render3d = jsrp.GetRender3DKind(render3d);
-      let sz = pp.size_for_3d(undefined, render3d);
+
+      jsrp.Assign3DHandler(this);
+
+      let sz = this.size_for_3d(undefined, render3d);
 
       this.size_z3d = 100;
       this.size_xy3d = (sz.height > 10) && (sz.width > 10) ? Math.round(sz.width/sz.height*this.size_z3d) : this.size_z3d;
@@ -127,7 +131,7 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
       this.renderer = jsrp.Create3DRenderer(this.scene_width, this.scene_height, render3d);
 
       this.webgl = (render3d === JSROOT.constants.Render3D.WebGL);
-      pp.add_3d_canvas(sz, this.renderer.jsroot_dom, this.webgl);
+      this.add_3d_canvas(sz, this.renderer.jsroot_dom, this.webgl);
 
       this.first_render_tm = 0;
       this.enable_highlight = false;
@@ -288,10 +292,9 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
    /** @summary Check is 3D drawing need to be resized */
    JSROOT.TFramePainter.prototype.Resize3D = function() {
 
-      let pp = this.pad_painter(),
-          sz = pp.size_for_3d(pp.access_3d_kind());
+      let sz = this.size_for_3d(this.access_3d_kind());
 
-      pp.apply_3d_size(sz);
+      this.apply_3d_size(sz);
 
       if ((this.scene_width === sz.width) && (this.scene_height === sz.height)) return false;
 

--- a/js/scripts/JSRoot.hist3d.js
+++ b/js/scripts/JSRoot.hist3d.js
@@ -36,6 +36,8 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
      * @private */
    JSROOT.TFramePainter.prototype.Create3DScene = function(arg, render3d) {
 
+      let pp = this.pad_painter();
+
       if ((arg!==undefined) && (arg < 0)) {
 
          if (!this.mode3d) return;
@@ -43,7 +45,7 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
          //if (typeof this.TestAxisVisibility === 'function')
          this.TestAxisVisibility(null, this.toplevel);
 
-         this.clear_3d_canvas();
+         if (pp) pp.clear_3d_canvas();
 
          jsrp.DisposeThreejsObject(this.scene);
          if (this.control) this.control.Cleanup();
@@ -94,7 +96,7 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
       }
 
       render3d = jsrp.GetRender3DKind(render3d);
-      let sz = this.size_for_3d(undefined, render3d);
+      let sz = pp.size_for_3d(undefined, render3d);
 
       this.size_z3d = 100;
       this.size_xy3d = (sz.height > 10) && (sz.width > 10) ? Math.round(sz.width/sz.height*this.size_z3d) : this.size_z3d;
@@ -125,7 +127,7 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
       this.renderer = jsrp.Create3DRenderer(this.scene_width, this.scene_height, render3d);
 
       this.webgl = (render3d === JSROOT.constants.Render3D.WebGL);
-      this.add_3d_canvas(sz, this.renderer.jsroot_dom, this.webgl);
+      pp.add_3d_canvas(sz, this.renderer.jsroot_dom, this.webgl);
 
       this.first_render_tm = 0;
       this.enable_highlight = false;
@@ -286,9 +288,10 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
    /** @summary Check is 3D drawing need to be resized */
    JSROOT.TFramePainter.prototype.Resize3D = function() {
 
-      let sz = this.size_for_3d(this.access_3d_kind());
+      let pp = this.pad_painter(),
+          sz = pp.size_for_3d(pp.access_3d_kind());
 
-      this.apply_3d_size(sz);
+      pp.apply_3d_size(sz);
 
       if ((this.scene_width === sz.width) && (this.scene_height === sz.height)) return false;
 

--- a/js/scripts/JSRoot.hist3d.js
+++ b/js/scripts/JSRoot.hist3d.js
@@ -207,7 +207,6 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
 
    /** @summary Set frame activity flag
     * @private */
-
    JSROOT.TFramePainter.prototype.SetActive = function(on) {
       if (this.control)
          this.control.enableKeys = on && JSROOT.key_handling;
@@ -221,7 +220,6 @@ JSROOT.define(['d3', 'painter', 'base3d', 'hist'], (d3, jsrp, THREE) => {
      *   - -2222 rendering performed only if there were previous calls, which causes timeout activation
      * @param {number} tmout - specifies delay, after which actual rendering will be invoked
      * @private */
-
    JSROOT.TFramePainter.prototype.Render3D = function(tmout) {
 
       if (tmout === -1111) {

--- a/js/scripts/JSRoot.interactive.js
+++ b/js/scripts/JSRoot.interactive.js
@@ -484,8 +484,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                      let rrr = resize_se.node().getBoundingClientRect();
                      pthis.ShowContextMenu('main', { clientX: rrr.left, clientY: rrr.top });
                   } else if (callback.canselect && (spent <= 600)) {
-                     let cp = pthis.canv_painter();
-                     if (cp) cp.SelectObjectPainter(pthis);
+                     let pp = pthis.pad_painter();
+                     if (pp) pp.SelectObjectPainter(pthis);
                   }
                }
             });
@@ -596,8 +596,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                evnt.sourceEvent.stopPropagation();
                if (this.moveEnd)
                   this.moveEnd(not_changed);
-               let cp = this.canv_painter();
-               if (cp) cp.SelectObjectPainter(this);
+               let pp = this.pad_painter();
+               if (pp) pp.SelectObjectPainter(this);
             }.bind(painter));
 
          painter.draw_g
@@ -778,8 +778,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          return true; // just process any key press
       },
 
-      /** Function called when frame is clicked and object selection can be performed
-        * such event can be used to select */
+      /** @summary Function called when frame is clicked and object selection can be performed
+        * @desc such event can be used to select */
       ProcessFrameClick: function(pnt, dblckick) {
 
          let pp = this.pad_painter();
@@ -935,12 +935,12 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                   break;
                case 2: {
                   let pp = this.pad_painter();
-                  if (pp) pp.SelectObjectPainter(this.x_handle);
+                  if (pp) pp.SelectObjectPainter(this, null, "xaxis");
                   break;
                }
                case 3: {
                   let pp = this.pad_painter();
-                  if (pp) pp.SelectObjectPainter(this.y_handle);
+                  if (pp) pp.SelectObjectPainter(this, null, "yaxis");
                   break;
                }
             }

--- a/js/scripts/JSRoot.interactive.js
+++ b/js/scripts/JSRoot.interactive.js
@@ -184,7 +184,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             gapy = 10,  // y coordinate, taking into account all gaps
             gapminx = -1111, gapmaxx = -1111,
             minhinty = -frame_shift.y,
-            maxhinty = this.pad_height("") - frame_rect.y - frame_shift.y;
+            maxhinty = this.canv_painter().pad_height() - frame_rect.y - frame_shift.y;
 
          function FindPosInGap(y) {
             for (let n = 0; (n < hints.length) && (y < maxhinty); ++n) {
@@ -469,7 +469,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                   handle.acc_y1 += evnt.dy;
 
                drag_rect.attr("x", Math.min(Math.max(handle.acc_x1, 0), handle.pad_w))
-                  .attr("y", Math.min(Math.max(handle.acc_y1, 0), handle.pad_h));
+                        .attr("y", Math.min(Math.max(handle.acc_y1, 0), handle.pad_h));
 
             }).on("end", function(evnt) {
                if (!drag_rect) return;
@@ -484,7 +484,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                      let rrr = resize_se.node().getBoundingClientRect();
                      pthis.ShowContextMenu('main', { clientX: rrr.left, clientY: rrr.top });
                   } else if (callback.canselect && (spent <= 600)) {
-                     pthis.canv_painter().SelectObjectPainter(pthis);
+                     let cp = pthis.canv_painter();
+                     if (cp) cp.SelectObjectPainter(pthis);
                   }
                }
             });
@@ -1494,7 +1495,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       },
 
       ToggleButtonsVisibility: function(action) {
-         let group = this.svg_layer("btns_layer", this.this_pad_name),
+         let group = this.svg_layer("btns_layer"),
              btn = group.select("[name='Toggle']");
 
          if (btn.empty()) return;
@@ -1529,7 +1530,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       },
 
       FindButton: function(keyname) {
-         let group = this.svg_layer("btns_layer", this.this_pad_name), found_func = "";
+         let group = this.svg_layer("btns_layer"), found_func = "";
          if (!group.empty())
             group.selectAll("svg").each(function() {
                if (d3.select(this).attr("key") === keyname)
@@ -1540,7 +1541,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       },
 
       RemoveButtons: function() {
-         let group = this.svg_layer("btns_layer", this.this_pad_name);
+         let group = this.svg_layer("btns_layer");
          if (!group.empty()) {
             group.selectAll("*").remove();
             group.property("nextx", null);
@@ -1548,7 +1549,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       },
 
       ShowButtons: function() {
-         let group = this.svg_layer("btns_layer", this.this_pad_name);
+         let group = this.svg_layer("btns_layer");
          if (group.empty()) return;
 
          // clean all previous buttons
@@ -1600,7 +1601,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
          group.property("nextx", x);
 
-         this.AlignBtns(group, this.pad_width(this.this_pad_name), this.pad_height(this.this_pad_name));
+         this.AlignBtns(group, this.pad_width(), this.pad_height());
 
          if (group.property('vertical'))
             ctrl.attr("y", x);

--- a/js/scripts/JSRoot.jq2d.js
+++ b/js/scripts/JSRoot.jq2d.js
@@ -75,7 +75,7 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
          title = title ? " title='" + title + "'" : "";
          if (name.indexOf("sub:")==0) { name = name.substr(4); close_tag = "<ul>"; }
 
-         if (typeof arg == 'function') { func = arg; arg = name;  }
+         if (typeof arg == 'function') { func = arg; arg = name; }
 
          if (name.indexOf("chk:")==0) { item = "<span class='ui-icon ui-icon-check' style='margin:1px'></span>"; name = name.substr(4); } else
          if (name.indexOf("unk:")==0) { item = "<span class='ui-icon ui-icon-blank' style='margin:1px'></span>"; name = name.substr(4); }
@@ -95,7 +95,13 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
       }
 
       addchk(flag, name, arg, func) {
-         return this.add((flag ? "chk:" : "unk:") + name, arg, func);
+         let handler = func;
+         if (typeof arg == 'function') {
+            func = arg;
+            handler = res => func(arg=="1");  
+            arg = flag ? "0" : "1"; 
+         }
+         return this.add((flag ? "chk:" : "unk:") + name, arg, handler);
       }
 
       size() { return this.cnt-1; }
@@ -143,20 +149,20 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
       }
 
       /** @summary Add color selection menu entries  */
-      AddColorMenuEntry(name, value, set_func, fill_kind) {
+      AddColorMenu(name, value, set_func, fill_kind) {
          if (value === undefined) return;
          this.add("sub:" + name, function() {
             // todo - use jqury dialog here
             let useid = (typeof value !== 'string');
             let col = prompt("Enter color " + (useid ? "(only id number)" : "(name or id)"), value);
-            if (!col) return;
+            if (col === null) return;
             let id = parseInt(col);
             if (!isNaN(id) && jsrp.getColor(id)) {
                col = jsrp.getColor(id);
             } else {
                if (useid) return;
             }
-            set_func.bind(this)(useid ? id : col);
+            set_func(useid ? id : col);
          });
          let useid = (typeof value !== 'string');
          for (let n = -1; n < 11; ++n) {
@@ -165,7 +171,7 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
             let col = (n < 0) ? 'none' : jsrp.getColor(n);
             if ((n == 0) && (fill_kind == 1)) col = 'none';
             let svg = "<svg width='100' height='18' style='margin:0px;background-color:" + col + "'><text x='4' y='12' style='font-size:12px' fill='" + (n == 1 ? "white" : "black") + "'>" + col + "</text></svg>";
-            this.addchk((value == (useid ? n : col)), svg, (useid ? n : col), set_func);
+            this.addchk((value == (useid ? n : col)), svg, (useid ? n : col), res => set_func(useid ? parseInt(res) : res));
          }
          this.add("endsub:");
       }
@@ -182,13 +188,14 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
             let val = prompt("Enter value of " + name, entry);
             if (!val) return;
             val = parseFloat(val);
-            if (!isNaN(val)) set_func.bind(this)((step >= 1) ? Math.round(val) : val);
+            if (!isNaN(val)) set_func((step >= 1) ? Math.round(val) : val);
          });
          for (let val = min; val <= max; val += step) {
             let entry = val.toFixed(2);
             if (step >= 0.1) entry = val.toFixed(1);
             if (step >= 1) entry = val.toFixed(0);
-            this.addchk((Math.abs(value - val) < step / 2), entry, val, set_func);
+            this.addchk((Math.abs(value - val) < step / 2), entry, 
+                        val, res => set_func((step >= 1) ? parseInt(res) : parseFloat(res)));
          }
          this.add("endsub:");
       }
@@ -202,8 +209,8 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
          if (!obj || !('fTextColor' in obj)) return;
 
          this.add("sub:" + (prefix ? prefix : "Text"));
-         this.AddColorMenuEntry("color", obj.fTextColor,
-            function(arg) { this.GetObject().fTextColor = parseInt(arg); this.InteractiveRedraw(true, getColorExec(parseInt(arg), "SetTextColor")); }.bind(painter));
+         this.AddColorMenu("color", obj.fTextColor,
+            arg => { obj.fTextColor = arg; painter.InteractiveRedraw(true, getColorExec(arg, "SetTextColor")); });
 
          let align = [11, 12, 13, 21, 22, 23, 31, 32, 33];
 
@@ -238,12 +245,12 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
          if (painter.lineatt && painter.lineatt.used) {
             this.add("sub:" + preffix + "Line att");
             this.SizeMenu("width", 1, 10, 1, painter.lineatt.width,
-               function(arg) { this.lineatt.Change(undefined, parseInt(arg)); this.InteractiveRedraw(true, "exec:SetLineWidth(" + arg + ")"); }.bind(painter));
-            this.AddColorMenuEntry("color", painter.lineatt.color,
-               function(arg) { this.lineatt.Change(arg); this.InteractiveRedraw(true, getColorExec(arg, "SetLineColor")); }.bind(painter));
+               arg => { painter.lineatt.Change(undefined, arg); painter.InteractiveRedraw(true, "exec:SetLineWidth(" + arg + ")"); });
+            this.AddColorMenu("color", painter.lineatt.color,
+               arg => { painter.lineatt.Change(arg); painter.InteractiveRedraw(true, getColorExec(arg, "SetLineColor")); });
             this.add("sub:style", function() {
                let id = prompt("Enter line style id (1-solid)", 1);
-               if (!id) return;
+               if (id === null) return;
                id = parseInt(id);
                if (isNaN(id) || !jsrp.root_line_styles[id]) return;
                this.lineatt.Change(undefined, undefined, id);
@@ -269,7 +276,7 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
                this.add("endsub:");
 
                this.SizeMenu("width", 10, 100, 10, painter.lineatt.excl_width,
-                  function(arg) { this.lineatt.ChangeExcl(undefined, parseInt(arg)); this.InteractiveRedraw(); }.bind(painter));
+                  arg => { painter.lineatt.ChangeExcl(undefined, arg); painter.InteractiveRedraw(); });
 
                this.add("endsub:");
             }
@@ -277,11 +284,11 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
 
          if (painter.fillatt && painter.fillatt.used) {
             this.add("sub:" + preffix + "Fill att");
-            this.AddColorMenuEntry("color", painter.fillatt.colorindx,
-               function(arg) { this.fillatt.Change(parseInt(arg), undefined, this.svg_canvas()); this.InteractiveRedraw(true, getColorExec(parseInt(arg), "SetFillColor")); }.bind(painter), painter.fillatt.kind);
+            this.AddColorMenu("color", painter.fillatt.colorindx,
+               arg => { painter.fillatt.Change(arg, undefined, painter.svg_canvas()); painter.InteractiveRedraw(true, getColorExec(arg, "SetFillColor")); }, painter.fillatt.kind);
             this.add("sub:style", function() {
                let id = prompt("Enter fill style id (1001-solid, 3000..3010)", this.fillatt.pattern);
-               if (!id) return;
+               if (id === null) return;
                id = parseInt(id);
                if (isNaN(id)) return;
                this.fillatt.Change(undefined, id, this.svg_canvas());
@@ -304,10 +311,10 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
 
          if (painter.markeratt && painter.markeratt.used) {
             this.add("sub:" + preffix + "Marker att");
-            this.AddColorMenuEntry("color", painter.markeratt.color,
-               function(arg) { this.markeratt.Change(arg); this.InteractiveRedraw(true, getColorExec(arg, "SetMarkerColor")); }.bind(painter));
+            this.AddColorMenu("color", painter.markeratt.color,
+               arg => { painter.markeratt.Change(arg); painter.InteractiveRedraw(true, getColorExec(arg, "SetMarkerColor"));});
             this.SizeMenu("size", 0.5, 6, 0.5, painter.markeratt.size,
-               function(arg) { this.markeratt.Change(undefined, undefined, parseFloat(arg)); this.InteractiveRedraw(true, "exec:SetMarkerSize(" + parseInt(arg) + ")"); }.bind(painter));
+               arg => { painter.markeratt.Change(undefined, undefined, arg); painter.InteractiveRedraw(true, "exec:SetMarkerSize(" + parseInt(arg) + ")"); });
 
             this.add("sub:style");
             let supported = [1, 2, 3, 4, 5, 6, 7, 8, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34];
@@ -325,46 +332,48 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
          }
       }
 
+      /** @summary Fill context menu for axis
+       * @private */
       AddTAxisMenu(painter, faxis, kind) {
          this.add("sub:Labels");
          this.addchk(faxis.TestBit(JSROOT.EAxisBits.kCenterLabels), "Center",
-               function() { faxis.InvertBit(JSROOT.EAxisBits.kCenterLabels); this.RedrawPad(); });
+               arg => { faxis.InvertBit(JSROOT.EAxisBits.kCenterLabels); painter.InteractiveRedraw("pad", `exec:CenterLabels(${arg})`, kind); });
          this.addchk(faxis.TestBit(JSROOT.EAxisBits.kLabelsVert), "Rotate",
-               function() { faxis.InvertBit(JSROOT.EAxisBits.kLabelsVert); this.RedrawPad(); });
-         this.AddColorMenuEntry("Color", faxis.fLabelColor,
-               function(arg) { faxis.fLabelColor = parseInt(arg); this.InteractiveRedraw("pad", getColorExec(parseInt(arg), "SetLabelColor"), kind); }.bind(painter));
+               arg => { faxis.InvertBit(JSROOT.EAxisBits.kLabelsVert); painter.InteractiveRedraw("pad", `exec:SetBit(TAxis::kLabelsVert,${arg})`, kind); });
+         this.AddColorMenu("Color", faxis.fLabelColor,
+               arg => { faxis.fLabelColor = arg; painter.InteractiveRedraw("pad", getColorExec(arg, "SetLabelColor"), kind); });
          this.SizeMenu("Offset", 0, 0.1, 0.01, faxis.fLabelOffset,
-               function(arg) { faxis.fLabelOffset = parseFloat(arg); this.RedrawPad(); } );
+               arg => { faxis.fLabelOffset = arg; painter.InteractiveRedraw("pad", `exec:SetLabelOffset(${arg})`, kind); } );
          this.SizeMenu("Size", 0.02, 0.11, 0.01, faxis.fLabelSize,
-               function(arg) { faxis.fLabelSize = parseFloat(arg); this.RedrawPad(); } );
+               arg => { faxis.fLabelSize = arg; painter.InteractiveRedraw("pad", `exec:SetLabelSize(${arg})`, kind); } );
          this.add("endsub:");
          this.add("sub:Title");
-         this.add("SetTitle", function() {
+         this.add("SetTitle", () => {
             let t = prompt("Enter axis title", faxis.fTitle);
-            if (t) { faxis.fTitle = t; this.RedrawPad(); }
+            if (t!==null) { faxis.fTitle = t; painter.InteractiveRedraw("pad", `exec:SetTitle("${t}")`, kind); }
          });
          this.addchk(faxis.TestBit(JSROOT.EAxisBits.kCenterTitle), "Center",
-               function() { faxis.InvertBit(JSROOT.EAxisBits.kCenterTitle); this.RedrawPad(); });
+               arg => { faxis.InvertBit(JSROOT.EAxisBits.kCenterTitle); painter.InteractiveRedraw("pad", `exec:CenterTitle(${arg})`, kind); });
          this.addchk(faxis.TestBit(JSROOT.EAxisBits.kRotateTitle), "Rotate",
-               function() { faxis.InvertBit(JSROOT.EAxisBits.kRotateTitle); this.RedrawPad(); });
-         this.AddColorMenuEntry("Color", faxis.fTitleColor,
-               function(arg) { faxis.fTitleColor = parseInt(arg); this.InteractiveRedraw("pad", getColorExec(parseInt(arg), "SetTitleColor"), kind); }.bind(painter));
+               arg => { faxis.InvertBit(JSROOT.EAxisBits.kRotateTitle); painter.InteractiveRedraw("pad", `exec:RotateTitle(${arg})`, kind); });
+         this.AddColorMenu("Color", faxis.fTitleColor,
+               arg => { faxis.fTitleColor = arg; painter.InteractiveRedraw("pad", getColorExec(arg, "SetTitleColor"), kind); });
          this.SizeMenu("Offset", 0, 3, 0.2, faxis.fTitleOffset,
-                               function(arg) { faxis.fTitleOffset = parseFloat(arg); this.RedrawPad(); } );
+                         arg => { faxis.fTitleOffset = arg; painter.InteractiveRedraw("pad", `exec:SetTitleOffset(${arg})`, kind); });
          this.SizeMenu("Size", 0.02, 0.11, 0.01, faxis.fTitleSize,
-               function(arg) { faxis.fTitleSize = parseFloat(arg); this.RedrawPad(); } );
+                         arg => { faxis.fTitleSize = arg; painter.InteractiveRedraw("pad", `exec:SetTitleSize(${arg})`, kind); });
          this.add("endsub:");
          this.add("sub:Ticks");
          if (faxis._typename == "TGaxis") {
-            this.AddColorMenuEntry("Color", faxis.fLineColor,
-                     function(arg) { faxis.fLineColor = parseInt(arg); this.RedrawPad(); });
+            this.AddColorMenu("Color", faxis.fLineColor,
+                     arg => { faxis.fLineColor = arg; painter.InteractiveRedraw("pad"); });
             this.SizeMenu("Size", -0.05, 0.055, 0.01, faxis.fTickSize,
-                     function(arg) { faxis.fTickSize = parseFloat(arg); this.RedrawPad(); } );
+                     arg => { faxis.fTickSize = arg; painter.InteractiveRedraw("pad"); } );
          } else {
-            this.AddColorMenuEntry("Color", faxis.fAxisColor,
-                        function(arg) { faxis.fAxisColor = parseInt(arg); this.InteractiveRedraw("pad", getColorExec(parseInt(arg), "SetAxisColor"), kind); }.bind(painter));
+            this.AddColorMenu("Color", faxis.fAxisColor,
+                     arg => { faxis.fAxisColor = arg; painter.InteractiveRedraw("pad", getColorExec(arg, "SetAxisColor"), kind); });
             this.SizeMenu("Size", -0.05, 0.055, 0.01, faxis.fTickLength,
-                     function(arg) { faxis.fTickLength = parseFloat(arg); this.RedrawPad(); } );
+                     arg => { faxis.fTickLength = arg; painter.InteractiveRedraw("pad", `exec:SetTickLength(${arg})`, kind); });
          }
          this.add("endsub:");
       }

--- a/js/scripts/JSRoot.more.js
+++ b/js/scripts/JSRoot.more.js
@@ -2280,9 +2280,9 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
                                .attr("cy",0)
                                .style("fill", "none")
                                .style("pointer-events","visibleFill")
-                               .on('mouseenter', () => this.MouseEvent('enter'))
-                               .on('mousemove', () => this.MouseEvent('move'))
-                               .on('mouseleave', () => this.MouseEvent('leave'));
+                               .on('mouseenter', evnt => this.MouseEvent('enter', evnt))
+                               .on('mousemove', evnt => this.MouseEvent('move', evnt))
+                               .on('mouseleave', evnt => this.MouseEvent('leave', evnt));
 
          interactive.attr("rx", this.szx).attr("ry", this.szy);
 

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -2186,10 +2186,11 @@ JSROOT.define(['d3'], (d3) => {
    }
 
    /** @summary Returns frame painter in current pad
+    * @desc Pad has direct reference on frame if any
     * @private */
    ObjectPainter.prototype.frame_painter = function() {
       let pp = this.pad_painter();
-      return pp ? pp.frame_painter_ref : null;
+      return pp ? pp.frame_painter() : null;
    }
 
    /** @summary Returns property of the frame painter

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -1903,10 +1903,13 @@ JSROOT.define(['d3'], (d3) => {
 
       let cp = this.canv_painter();
       if (!cp) return null;
-      if (cp.custom_palette && !palettedid) return cp.custom_palette;
+      if (cp.custom_palette && !palettedid)
+         return cp.custom_palette;
 
-      if (force && jsrp.GetColorPalette)
+      if (force && jsrp.GetColorPalette) {
+         console.log('Create palette !!!!');
          cp.custom_palette = jsrp.GetColorPalette(palettedid);
+       }
 
       return cp.custom_palette;
    }

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -3804,11 +3804,11 @@ JSROOT.define(['d3'], (d3) => {
      * @private */
    jsrp.CompressSVG = function(svg) {
 
-      // let s = 'try class="abc cdf" second class="kkk aaa" third';
-      // s = s.replace(/ class=\"[a-z0-9 ]*\"/g, "");
-
       svg = svg.replace(/url\(\&quot\;\#(\w+)\&quot\;\)/g, "url(#$1)")        // decode all URL
                .replace(/ class=\"\w*\"/g, "")                                // remove all classes
+               .replace(/ pad=\"\w*\"/g, "")                                  // remove all pad ids
+               .replace(/ title=\"\"/g, "")                                   // remove all empty titles
+               .replace(/<g objname=\"\w*\" objtype=\"\w*\"/g, "<g")          // remove object ids
                .replace(/<g transform=\"translate\(\d+\,\d+\)\"><\/g>/g, "")  // remove all empty groups with transform
                .replace(/<g><\/g>/g, "");                                     // remove all empty groups
 
@@ -3847,11 +3847,11 @@ JSROOT.define(['d3'], (d3) => {
 
          main.style("width", args.width + "px").style("height", args.height + "px");
 
-         JSROOT.svg_workaround = undefined;
+         JSROOT._.svg_3ds = undefined;
 
          return JSROOT.draw(main.node(), args.object, args.option || "").then(() => {
 
-            let has_workarounds = jsrp.ProcessSVGWorkarounds && JSROOT.svg_workaround;
+            let has_workarounds = JSROOT._.svg_3ds && jsrp.ProcessSVGWorkarounds;
 
             main.select('svg')
                 .attr("xmlns", "http://www.w3.org/2000/svg")

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -1714,13 +1714,11 @@ JSROOT.define(['d3'], (d3) => {
    ObjectPainter.prototype.AssignObject = function(obj) { this.draw_object = ((obj !== undefined) && (typeof obj == 'object')) ? obj : null; }
 
    /** @summary Assign snapid to the painter
-   *
-   * @desc Identifier used to communicate with server side and identifies object on the server
-   * @private */
+    * @desc Identifier used to communicate with server side and identifies object on the server
+    * @private */
    ObjectPainter.prototype.AssignSnapId = function(id) { this.snapid = id; }
 
    /** @summary Generic method to cleanup painter.
-    *
     * @desc Remove object drawing and in case of main painter - also main HTML components */
    ObjectPainter.prototype.Cleanup = function() {
 
@@ -1762,10 +1760,8 @@ JSROOT.define(['d3'], (d3) => {
    ObjectPainter.prototype.GetClassName = function() { return (this.draw_object ? this.draw_object._typename : "") || ""; }
 
    /** @summary Checks if drawn object matches with provided typename
-    *
     * @param {string} arg - typename
-    * @param {string} arg._typename - if arg is object, use its typename
-    */
+    * @param {string} arg._typename - if arg is object, use its typename */
    ObjectPainter.prototype.MatchObjectType = function(arg) {
       if (!arg || !this.draw_object) return false;
       if (typeof arg === 'string') return (this.draw_object._typename === arg);
@@ -1773,8 +1769,7 @@ JSROOT.define(['d3'], (d3) => {
       return this.draw_object._typename.match(arg);
    }
 
-   /** @summary Changes item name.
-    *
+   /** @summary Change item name
     * @desc When available, used for svg:title proprty
     * @private */
    ObjectPainter.prototype.SetItemName = function(name, opt, hpainter) {
@@ -1925,7 +1920,6 @@ JSROOT.define(['d3'], (d3) => {
    }
 
    /** @summary Checks if draw elements were resized and drawing should be updated.
-    *
     * @desc Redirects to {@link JSROOT.TPadPainter.CheckCanvasResize}
     * @private */
    ObjectPainter.prototype.CheckResize = function(arg) {
@@ -2124,11 +2118,9 @@ JSROOT.define(['d3'], (d3) => {
    }
 
    /** @summary Return functor, which can convert x and y coordinates into pixels, used for drawing
-    *
-    * Produce functor can convert x and y value by calling func.x(x) and func.y(y)
-    *  @param {boolean} isndc - if NDC coordinates will be used
-    *  @private
-    */
+    * @desc Produce functor can convert x and y value by calling func.x(x) and func.y(y)
+    * @param {boolean} isndc - if NDC coordinates will be used
+    * @private */
    ObjectPainter.prototype.AxisToSvgFunc = function(isndc) {
       let func = { isndc: isndc }, use_frame = this.draw_g && this.draw_g.property('in_frame');
       if (use_frame) func.main = this.frame_painter();
@@ -2454,7 +2446,6 @@ JSROOT.define(['d3'], (d3) => {
    }
 
    /** @summary Returns main object painter on the pad.
-    *
     * @desc Normally this is first histogram drawn on the pad, which also draws all axes
     * @param {boolean} [not_store = undefined] - if true, prevent temporary store of main painter reference
     * @param {string} [pad_name = undefined] - when specified, returns main painter from specified pad */
@@ -2493,8 +2484,7 @@ JSROOT.define(['d3'], (d3) => {
     * @param {string|object} divid - id of div element or directly DOMElement
     * @param {number} [kind = 0] - kind of object drawn with painter
     * @param {string} [pad_name = undefined] - when specified, subpad name used for object drawin
-    * @private
-    */
+    * @private */
    ObjectPainter.prototype.SetDivId = function(divid, kind, pad_name) {
 
       if (divid !== undefined) {
@@ -2583,8 +2573,7 @@ JSROOT.define(['d3'], (d3) => {
     * See {@link JSROOT.TAttMarkerHandler} for more info.
     * Instance assigned as this.markeratt data member, recognized by GED editor
     * @param {object} args - either TAttMarker or see arguments of {@link JSROOT.TAttMarkerHandler}
-    * @returns created handler
-    */
+    * @returns created handler */
    ObjectPainter.prototype.createAttMarker = function(args) {
       if (!args || (typeof args !== 'object')) args = { std: true }; else
          if (args.fMarkerColor !== undefined && args.fMarkerStyle !== undefined && args.fMarkerSize !== undefined) args = { attr: args, std: false };
@@ -2608,8 +2597,7 @@ JSROOT.define(['d3'], (d3) => {
    * @desc Can be used to produce lines in painter.
    * See {@link JSROOT.TAttLineHandler} for more info.
    * Instance assigned as this.lineatt data member, recognized by GED editor
-   * @param {object} args - either TAttLine or see constructor arguments of {@link JSROOT.TAttLineHandler}
-   */
+   * @param {object} args - either TAttLine or see constructor arguments of {@link JSROOT.TAttLineHandler} */
    ObjectPainter.prototype.createAttLine = function(args) {
       if (!args || (typeof args !== 'object')) args = { std: true }; else
          if (args.fLineColor !== undefined && args.fLineStyle !== undefined && args.fLineWidth !== undefined) args = { attr: args, std: false };
@@ -2791,6 +2779,35 @@ JSROOT.define(['d3'], (d3) => {
 
       return menu.size() > 0;
    }
+
+   /** @summary Produce exec string for WebCanas to set color value
+    * @desc Color can be id or string, but should belong to list of known colors
+    * For higher color numbers TColor::GetColor(r,g,b) will be invoked to ensure color is exists
+    * @private */
+   ObjectPainter.prototype.GetColorExec = function(col, method) {
+      let id = -1, arr = jsrp.root_colors;
+      if (typeof col == "string") {
+         if (!col || (col == "none")) id = 0; else
+            for (let k = 1; k < arr.length; ++k)
+               if (arr[k] == col) { id = k; break; }
+         if ((id < 0) && (col.indexOf("rgb") == 0)) id = 9999;
+      } else if (!isNaN(col) && arr[col]) {
+         id = col;
+         col = arr[id];
+      }
+
+      if (id < 0) return "";
+
+      if (id >= 50) {
+         // for higher color numbers ensure that such color exists
+         let c = d3.color(col);
+         id = "TColor::GetColor(" + c.r + "," + c.g + "," + c.b + ")";
+      }
+
+      return "exec:" + method + "(" + id + ")";
+   }
+
+
 
    /** @summary returns function used to display object status
     * @private */

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -2441,12 +2441,12 @@ JSROOT.define(['d3'], (d3) => {
       }
 
       // inform GED that something changes
-      let pp = this.pad_painter();
-      if (pp && (typeof pp.InteractiveObjectRedraw == 'function'))
-         pp.InteractiveObjectRedraw(this);
+      let pp = this.pad_painter(), canp = this.canv_painter();
+       
+      if (canp && (typeof canp.PadEvent == 'function'))
+         canp.PadEvent("redraw", pp, this, null, subelem);
 
       // inform server that drawopt changes
-      let canp = this.canv_painter();
       if (canp && (typeof canp.ProcessChanges == 'function'))
          canp.ProcessChanges(info, this, subelem);
    }
@@ -2950,10 +2950,10 @@ JSROOT.define(['d3'], (d3) => {
 
    /** @summary Set active pad painter
     *
-    * @desc Should be used to handle key press events, which are global in the web browser
+    * @desc Normally be used to handle key press events, which are global in the web browser
     * @param {object} args - functions arguments
     * @param {object} args.pp - pad painter
-    * @param {boolean} [args.active = false] - is pad activated or not
+    * @param {boolean} [args.active] - is pad activated or not
     * @private */
    jsrp.SelectActivePad = function(args) {
       if (args.active) {

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -2306,6 +2306,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          if (this._fixed_size) {
             render_to.style("overflow","auto");
             rect = { width: this.pad.fWinSize[0], height: this.pad.fWinSize[1] };
+            if (!rect.width || !rect.height)
+               rect = this.get_visible_rect(render_to);
          } else {
             rect = this.check_main_resize(2, new_size, factor);
          }
@@ -2313,7 +2315,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       this.createAttFill({ pattern: 1001, color: 0 });
 
-      if ((rect.width<=lmt) || (rect.height<=lmt)) {
+      if ((rect.width <= lmt) || (rect.height <= lmt)) {
          svg.style("display", "none");
          console.warn("Hide canvas while geometry too small w=",rect.width," h=",rect.height);
          rect.width = 200; rect.height = 100; // just to complete drawing
@@ -3149,6 +3151,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       let svg = '<svg width="' + width + '" height="' + height + '" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">' +
                  elem.node().innerHTML +
                  '</svg>';
+
+      if (jsrp.ProcessSVGWorkarounds)
+         svg = jsrp.ProcessSVGWorkarounds(svg);
+
+      svg = jsrp.CompressSVG(svg);
 
       if (file_format == "svg") {
          reconstruct();

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -2179,10 +2179,14 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       JSROOT.ObjectPainter.prototype.Cleanup.call(this);
    }
 
-   /** @summary Cleanup primitives from pad - selector lets define which painters to remove
-    * @private
-    */
+   /** @summary Returns frame painter inside the pad
+    * @private */
+   RPadPainter.prototype.frame_painter = function() {
+      return this.frame_painter_ref;
+   }
 
+   /** @summary Cleanup primitives from pad - selector lets define which painters to remove
+    * @private */
    RPadPainter.prototype.CleanPrimitives = function(selector) {
       if (!selector || (typeof selector !== 'function')) return;
 
@@ -2841,12 +2845,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          // will be used in SetDivId to assign style to painter
          this.next_rstyle = lst[indx].fStyle || this.rstyle;
 
-         if (snap._typename === "ROOT::Experimental::RObjectDisplayItem")
+         if (snap._typename === "ROOT::Experimental::RObjectDisplayItem") {
             if (!this.frame_painter())
-               return JSROOT.draw(this.divid, { _typename: "TFrame", $dummy: true }, "").then(function() {
-                  draw_callback("workaround"); // call function with "workaround" as argument
-               });
-
+               return JSROOT.draw(this.divid, { _typename: "TFrame", $dummy: true }, "")
+                            .then(() => draw_callback("workaround")); // call function with "workaround" as argument
+         }
 
          // TODO - fDrawable is v7, fObject from v6, maybe use same data member?
          JSROOT.draw(this.divid, snap.fDrawable || snap.fObject || snap, snap.fOption || "").then(draw_callback);
@@ -3072,7 +3075,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             btns.remove();
          }
 
-         let main = pp.frame_painter_ref;
+         let main = pp.frame_painter();
          if (!main || (typeof main.Render3D !== 'function')) return;
 
          let can3d = main.access_3d_kind();

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -2849,6 +2849,15 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          this.next_rstyle = lst[indx].fStyle || this.rstyle;
 
          if (snap._typename === "ROOT::Experimental::RObjectDisplayItem") {
+
+            // identifier used in RObjectDrawable
+            let webSnapIds = { kNone: 0,  kObject: 1, kColors: 4, kStyle: 5 };
+
+            if (snap.fKind == webSnapIds.kStyle) {
+               JSROOT.extend(JSROOT.gStyle, snap.fObject);
+               continue;
+            }
+
             if (!this.frame_painter())
                return JSROOT.draw(this.divid, { _typename: "TFrame", $dummy: true }, "")
                             .then(() => draw_callback("workaround")); // call function with "workaround" as argument

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -2751,9 +2751,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       return true;
    }
 
+   /** @symmary function called when drawing next snapshot from the list
+     * @desc it is also used as callback for drawing of previous snap
+     * @private */
    RPadPainter.prototype.DrawNextSnap = function(lst, indx, call_back, objpainter) {
-      // function called when drawing next snapshot from the list
-      // it is also used as callback for drawing of previous snap
 
       if (indx===-1) {
          // flag used to prevent immediate pad redraw during first draw
@@ -2858,7 +2859,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       }
    }
 
-   /** Search painter with specified snapid, also sub-pads are checked */
+   /** @summary Search painter with specified snapid, also sub-pads are checked */
    RPadPainter.prototype.FindSnap = function(snapid, onlyid) {
 
       function check(checkid) {
@@ -2980,20 +2981,21 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       });
    }
 
-   RPadPainter.prototype.CreateImage = function(format, call_back) {
-      if (format=="pdf") {
-         // use https://github.com/MrRio/jsPDF in the future here
-         JSROOT.CallBack(call_back, btoa("dummy PDF file"));
-      } else if ((format=="png") || (format=="jpeg") || (format=="svg")) {
-         this.ProduceImage(true, format, function(res) {
-            if ((format=="svg") || !res)
-               return JSROOT.CallBack(call_back, res);
+   /** @summary Create image for the pad
+     * @returns {Promise} with image data, coded with btoa() function */
+   RPadPainter.prototype.CreateImage = function(format) {
+      // use https://github.com/MrRio/jsPDF in the future here
+      if (format=="pdf")
+         return Promise.resolve(btoa("dummy PDF file"));
+
+      if ((format=="png") || (format=="jpeg") || (format=="svg"))
+         return this.ProduceImage(true, format).then(res => {
+            if (!res || (format=="svg")) return res;
             let separ = res.indexOf("base64,");
-            JSROOT.CallBack(call_back, (separ>0) ? res.substr(separ+7) : "");
+            return (separ>0) ? res.substr(separ+7) : "";
          });
-      } else {
-         JSROOT.CallBack(call_back, "");
-      }
+
+      return Promise.resolve("");
    }
 
    RPadPainter.prototype.ItemContextMenu = function(name) {
@@ -3036,7 +3038,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          if (filename.length === 0) filename = this.iscan ? "canvas" : "pad";
          filename += "." + kind;
       }
-      this.ProduceImage(full_canvas, kind, function(imgdata) {
+      this.ProduceImage(full_canvas, kind).then(imgdata => {
          let a = document.createElement('a');
          a.download = filename;
          a.href = (kind != "svg") ? imgdata : "data:image/svg+xml;charset=utf-8,"+encodeURIComponent(imgdata);
@@ -3046,19 +3048,19 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       });
    }
 
-   RPadPainter.prototype.ProduceImage = function(full_canvas, file_format, call_back) {
+   /** @summary Prodce image for the pad
+     * @returns {Promise} with created image */
+   RPadPainter.prototype.ProduceImage = function(full_canvas, file_format) {
 
       let use_frame = (full_canvas === "frame");
 
       let elem = use_frame ? this.svg_frame() : (full_canvas ? this.svg_canvas() : this.svg_pad(this.this_pad_name));
 
-      if (elem.empty()) return JSROOT.CallBack(call_back);
+      if (elem.empty()) return Promise.resolve("");
 
       let painter = (full_canvas && !use_frame) ? this.canv_painter() : this;
 
       let items = []; // keep list of replaced elements, which should be moved back at the end
-
-//      document.body.style.cursor = 'wait';
 
       if (!use_frame) // do not make transformations for the frame
       painter.ForEachPainterInPad(pp => {
@@ -3080,9 +3082,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
          let can3d = main.access_3d_kind();
 
-         if ((can3d !== 1) && (can3d !== 2)) return;
+         if ((can3d !== JSROOT.constants.Embed3D.Overlay) && (can3d !== JSROOT.constants.Embed3D.Embed)) return;
 
-         let sz2 = main.size_for_3d(2); // get size and position of DOM element as it will be embed
+         let sz2 = main.size_for_3d(JSROOT.constants.Embed3D.Embed); // get size and position of DOM element as it will be embed
 
          let canvas = main.renderer.domElement;
          main.Render3D(0); // WebGL clears buffers, therefore we should render scene and convert immediately
@@ -3090,7 +3092,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
          // remove 3D drawings
 
-         if (can3d == 2) {
+         if (can3d === JSROOT.constants.Embed3D.Embed) {
             item.foreign = item.prnt.select("." + sz2.clname);
             item.foreign.remove();
          }
@@ -3101,9 +3103,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             item.frame_next = item.frame_node.nextSibling;
             svg_frame.remove();
          }
-
-         //var origin = main.apply_3d_size(sz3d, true);
-         //origin.remove();
 
          // add svg image
          item.img = item.prnt.insert("image",".primitives_layer")     // create image object
@@ -3124,7 +3123,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          return decodeURIComponent(data);
       }
 
-      function reconstruct(res) {
+      function reconstruct() {
          for (let k=0;k<items.length;++k) {
             let item = items[k];
 
@@ -3142,8 +3141,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             if (item.btns_node) // reinsert buttons
                item.btns_prnt.insertBefore(item.btns_node, item.btns_next);
          }
-
-         JSROOT.CallBack(call_back, res);
       }
 
       let width = elem.property('draw_width'), height = elem.property('draw_height');
@@ -3153,32 +3150,36 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                  elem.node().innerHTML +
                  '</svg>';
 
-      if (file_format == "svg")
-         return reconstruct(svg); // return SVG file as is
+      if (file_format == "svg") {
+         reconstruct();
+         return Promise.resolve(svg); // return SVG file as is
+      }
 
       let doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
 
       let image = new Image();
-      image.onload = function() {
-         // if (options.result==="image") return JSROOT.CallBack(call_back, image);
 
-         // console.log('GOT IMAGE', image.width, image.height);
+      return new Promise(resolveFunc => {
+         image.onload = function() {
+            let canvas = document.createElement('canvas');
+            canvas.width = image.width;
+            canvas.height = image.height;
+            let context = canvas.getContext('2d');
+            context.drawImage(image, 0, 0);
 
-         let canvas = document.createElement('canvas');
-         canvas.width = image.width;
-         canvas.height = image.height;
-         let context = canvas.getContext('2d');
-         context.drawImage(image, 0, 0);
+            reconstruct();
 
-         reconstruct(canvas.toDataURL('image/' + file_format));
-      }
+            resolveFunc(canvas.toDataURL('image/' + file_format));
+         }
 
-      image.onerror = function(arg) {
-         console.log('IMAGE ERROR', arg);
-         reconstruct(null);
-      }
+         image.onerror = function(arg) {
+            console.log('IMAGE ERROR', arg);
+            reconstruct();
+            resolveFunc(null);
+         }
 
-      image.src = 'data:image/svg+xml;base64,' + window.btoa(reEncode(doctype + svg));
+         image.src = 'data:image/svg+xml;base64,' + window.btoa(reEncode(doctype + svg));
+      });
    }
 
 
@@ -3543,12 +3544,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       JSROOT.progress(msg, 7000);
    }
 
-   /// function called when canvas menu item Save is called
+   /** @summary Function called when canvas menu item Save is called */
    RCanvasPainter.prototype.SaveCanvasAsFile = function(fname) {
       let pnt = fname.indexOf(".");
-      this.CreateImage(fname.substr(pnt+1), res => {
-         this.SendWebsocket("SAVE:" + fname + ":" + res);
-      })
+      this.CreateImage(fname.substr(pnt+1))
+          .then(res => this.SendWebsocket("SAVE:" + fname + ":" + res));
    }
 
    RCanvasPainter.prototype.SendSaveCommand = function(fname) {
@@ -3634,9 +3634,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
              cmd = msg.substr(p1+1),
              reply = "REPLY:" + cmdid + ":";
          if ((cmd == "SVG") || (cmd == "PNG") || (cmd == "JPEG")) {
-            this.CreateImage(cmd.toLowerCase(), function(res) {
-               handle.Send(reply + res);
-            });
+            this.CreateImage(cmd.toLowerCase())
+                .then(res => handle.Send(reply + res));
          } else if (cmd.indexOf("ADDPANEL:") == 0) {
             let relative_path = cmd.substr(9);
             if (!this.ShowUI5Panel) {

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -2851,10 +2851,32 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          if (snap._typename === "ROOT::Experimental::RObjectDisplayItem") {
 
             // identifier used in RObjectDrawable
-            let webSnapIds = { kNone: 0,  kObject: 1, kColors: 4, kStyle: 5 };
+            let webSnapIds = { kNone: 0,  kObject: 1, kColors: 4, kStyle: 5, kPalette: 6 };
 
             if (snap.fKind == webSnapIds.kStyle) {
                JSROOT.extend(JSROOT.gStyle, snap.fObject);
+               continue;
+            }
+
+            if (snap.fKind == webSnapIds.kColors) {
+               let ListOfColors = [], arr = snap.fObject.arr;
+               for (let n = 0; n < arr.length; ++n) {
+                  let name = arr[n].fString, p = name.indexOf("=");
+                  if (p > 0)
+                     ListOfColors[parseInt(name.substr(0,p))] =name.substr(p+1);
+               }
+
+               this.root_colors = ListOfColors;
+               // set global list of colors
+               // jsrp.adoptRootColors(ListOfColors);
+               continue;
+            }
+
+            if (snap.fKind == webSnapIds.kPalette) {
+               let arr = snap.fObject.arr, palette = [];
+               for (let n = 0; n < arr.length; ++n)
+                  palette[n] =  arr[n].fString;
+               this.custom_palette = new JSROOT.ColorPalette(palette);
                continue;
             }
 

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -2403,7 +2403,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          return true;
       }
 
-      let svg_parent = this.svg_pad(),
+      let svg_parent = this.svg_pad(this.pad_name),
           svg_can = this.svg_canvas(),
           width = svg_parent.property("draw_width"),
           height = svg_parent.property("draw_height"),
@@ -2706,7 +2706,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    }
 
    RPadPainter.prototype.RedrawByResize = function() {
-      if (this.access_3d_kind() === 1) return true;
+      if (this.access_3d_kind() === JSROOT.constants.Embed3D.Overlay) return true;
 
       for (let i = 0; i < this.painters.length; ++i)
          if (typeof this.painters[i].RedrawByResize === 'function')
@@ -2826,7 +2826,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
             let padpainter = new RPadPainter(subpad, false);
             padpainter.DecodeOptions("");
-            padpainter.SetDivId(this.divid); // pad painter will be registered in the canvas painters list
+            padpainter.SetDivId(this.divid); // pad painter will be registered in parent painters list
             padpainter.AssignSnapId(snap.fObjectID);
             padpainter.rstyle = snap.fStyle;
 
@@ -2838,7 +2838,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             // we select current pad, where all drawing is performed
             let prev_name = padpainter.CurrentPadName(padpainter.this_pad_name);
 
-            padpainter.DrawNextSnap(snap.fPrimitives, -1, function() {
+            padpainter.DrawNextSnap(snap.fPrimitives, -1, () => {
                padpainter.CurrentPadName(prev_name);
                draw_callback(padpainter);
             });
@@ -3113,11 +3113,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          let main = pp.frame_painter();
          if (!main || (typeof main.Render3D !== 'function')) return;
 
-         let can3d = main.access_3d_kind();
+         let can3d = pp.access_3d_kind();
 
          if ((can3d !== JSROOT.constants.Embed3D.Overlay) && (can3d !== JSROOT.constants.Embed3D.Embed)) return;
 
-         let sz2 = main.size_for_3d(JSROOT.constants.Embed3D.Embed); // get size and position of DOM element as it will be embed
+         let sz2 = pp.size_for_3d(JSROOT.constants.Embed3D.Embed); // get size and position of DOM element as it will be embed
 
          let canvas = main.renderer.domElement;
          main.Render3D(0); // WebGL clears buffers, therefore we should render scene and convert immediately
@@ -3794,12 +3794,18 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    }
 
    /** @summary Submit executable command for given painter */
-   RCanvasPainter.prototype.SubmitExec = function(painter, exec /*, snapid */) {
-      console.log('SubmitExec', exec, painter.snapid);
+   RCanvasPainter.prototype.SubmitExec = function(painter, exec, subelem) {
+      console.log('SubmitExec', exec, painter.snapid, subelem);
 
       // snapid is intentionally ignored - only painter.snapid has to be used
-
       if (!this._websocket) return;
+
+      if (subelem) {
+         if ((subelem == "xaxis") || (subelem == "yaxis") || (subelem == "zaxis"))
+            exec = subelem + "#" + exec;
+         else
+            return console.log(`not recoginzed subelem ${subelem} in SubmitExec`);
+       }
 
       this.SubmitDrawableRequest("", {
          _typename: "ROOT::Experimental::RDrawableExecRequest",
@@ -3893,7 +3899,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             break;
          default:
             if ((kind.substr(0,5) == "exec:") && painter && painter.snapid) {
-               this.SubmitExec(painter, kind.substr(5));
+               this.SubmitExec(painter, kind.substr(5), subelem);
             } else {
                console.log("UNPROCESSED CHANGES", kind);
             }

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -2848,7 +2848,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          // will be used in SetDivId to assign style to painter
          this.next_rstyle = lst[indx].fStyle || this.rstyle;
 
-         if (snap._typename === "ROOT::Experimental::RObjectDisplayItem") {
+         if (snap._typename === "ROOT::Experimental::TObjectDisplayItem") {
 
             // identifier used in RObjectDrawable
             let webSnapIds = { kNone: 0,  kObject: 1, kColors: 4, kStyle: 5, kPalette: 6 };

--- a/js/scripts/JSRoot.v7hist3d.js
+++ b/js/scripts/JSRoot.v7hist3d.js
@@ -18,16 +18,17 @@ JSROOT.define(['d3', 'base3d', 'painter', 'v7hist'], (d3, THREE, jsrp) => {
      * @private */
    JSROOT.v7.RFramePainter.prototype.Create3DScene = function(arg, render3d) {
 
-      let pp = this.pad_painter();
-
-      if ((arg!==undefined) && (arg<0)) {
+      if ((arg !== undefined) && (arg < 0)) {
 
          if (!this.mode3d) return;
+
+         if (!this.clear_3d_canvas)
+            return console.error('Strange, why mode3d is configured!!!!', this.mode3d);
 
          //if (typeof this.TestAxisVisibility === 'function')
          this.TestAxisVisibility(null, this.toplevel);
 
-         if (pp) pp.clear_3d_canvas();
+         this.clear_3d_canvas();
 
          jsrp.DisposeThreejsObject(this.scene);
          if (this.control) this.control.Cleanup();
@@ -77,8 +78,10 @@ JSROOT.define(['d3', 'base3d', 'painter', 'v7hist'], (d3, THREE, jsrp) => {
          return;
       }
 
+      jsrp.Assign3DHandler(this);
+
       render3d = jsrp.GetRender3DKind(render3d);
-      let sz = pp.size_for_3d(undefined, render3d);
+      let sz = this.size_for_3d(undefined, render3d);
 
       this.size_z3d = 100;
       this.size_xy3d = (sz.height > 10) && (sz.width > 10) ? Math.round(sz.width/sz.height*this.size_z3d) : this.size_z3d;
@@ -109,7 +112,7 @@ JSROOT.define(['d3', 'base3d', 'painter', 'v7hist'], (d3, THREE, jsrp) => {
       this.renderer = jsrp.Create3DRenderer(this.scene_width, this.scene_height, render3d);
 
       this.webgl = (render3d === JSROOT.constants.Render3D.WebGL);
-      pp.add_3d_canvas(sz, this.renderer.jsroot_dom, this.webgl);
+      this.add_3d_canvas(sz, this.renderer.jsroot_dom, this.webgl);
 
       this.first_render_tm = 0;
       this.enable_highlight = false;
@@ -264,10 +267,9 @@ JSROOT.define(['d3', 'base3d', 'painter', 'v7hist'], (d3, THREE, jsrp) => {
 
    JSROOT.v7.RFramePainter.prototype.Resize3D = function() {
 
-      let pp = this.pad_painter(),
-          sz = pp.size_for_3d(pp.access_3d_kind());
+      let sz = this.size_for_3d(this.access_3d_kind());
 
-      pp.apply_3d_size(sz);
+      this.apply_3d_size(sz);
 
       if ((this.scene_width === sz.width) && (this.scene_height === sz.height)) return false;
 

--- a/js/scripts/JSRoot.v7hist3d.js
+++ b/js/scripts/JSRoot.v7hist3d.js
@@ -18,6 +18,8 @@ JSROOT.define(['d3', 'base3d', 'painter', 'v7hist'], (d3, THREE, jsrp) => {
      * @private */
    JSROOT.v7.RFramePainter.prototype.Create3DScene = function(arg, render3d) {
 
+      let pp = this.pad_painter();
+
       if ((arg!==undefined) && (arg<0)) {
 
          if (!this.mode3d) return;
@@ -25,7 +27,7 @@ JSROOT.define(['d3', 'base3d', 'painter', 'v7hist'], (d3, THREE, jsrp) => {
          //if (typeof this.TestAxisVisibility === 'function')
          this.TestAxisVisibility(null, this.toplevel);
 
-         this.clear_3d_canvas();
+         if (pp) pp.clear_3d_canvas();
 
          jsrp.DisposeThreejsObject(this.scene);
          if (this.control) this.control.Cleanup();
@@ -76,7 +78,7 @@ JSROOT.define(['d3', 'base3d', 'painter', 'v7hist'], (d3, THREE, jsrp) => {
       }
 
       render3d = jsrp.GetRender3DKind(render3d);
-      let sz = this.size_for_3d(undefined, render3d);
+      let sz = pp.size_for_3d(undefined, render3d);
 
       this.size_z3d = 100;
       this.size_xy3d = (sz.height > 10) && (sz.width > 10) ? Math.round(sz.width/sz.height*this.size_z3d) : this.size_z3d;
@@ -107,7 +109,7 @@ JSROOT.define(['d3', 'base3d', 'painter', 'v7hist'], (d3, THREE, jsrp) => {
       this.renderer = jsrp.Create3DRenderer(this.scene_width, this.scene_height, render3d);
 
       this.webgl = (render3d === JSROOT.constants.Render3D.WebGL);
-      this.add_3d_canvas(sz, this.renderer.jsroot_dom, this.webgl);
+      pp.add_3d_canvas(sz, this.renderer.jsroot_dom, this.webgl);
 
       this.first_render_tm = 0;
       this.enable_highlight = false;
@@ -262,9 +264,10 @@ JSROOT.define(['d3', 'base3d', 'painter', 'v7hist'], (d3, THREE, jsrp) => {
 
    JSROOT.v7.RFramePainter.prototype.Resize3D = function() {
 
-      let sz = this.size_for_3d(this.access_3d_kind());
+      let pp = this.pad_painter(),
+          sz = pp.size_for_3d(pp.access_3d_kind());
 
-      this.apply_3d_size(sz);
+      pp.apply_3d_size(sz);
 
       if ((this.scene_width === sz.width) && (this.scene_height === sz.height)) return false;
 

--- a/js/scripts/JSRoot.webwindow.js
+++ b/js/scripts/JSRoot.webwindow.js
@@ -574,12 +574,13 @@ JSROOT.define([], () => {
     * @param {string} [arg.openui5libs] - list of openui5 libraries loaded, default is "sap.m, sap.ui.layout, sap.ui.unified"
     * @param {string} [arg.socket_kind] - kind of connection longpoll|websocket, detected automatically from URL
     * @param {object} arg.receiver - instance of receiver for websocket events, allows to initiate connection immediately
-    * @param {string} arg.first_recv - required prefix in the first message from TWebWindow, remain part of message will be returned as arg.first_msg
+    * @param {string} arg.first_recv - required prefix in the first message from TWebWindow, remain part of message will be returned in handle.first_msg
     * @param {string} [arg.prereq2] - second part of prerequcities, which is loaded parallel to connecting with WebWindow
     * @returns {Promise} ready-to-use WebWindowHandle instance
     */
 
    JSROOT.connectWebWindow = function(arg) {
+
       if (typeof arg == 'function') arg = { callback: arg }; else
          if (!arg || (typeof arg != 'object')) arg = {};
 
@@ -648,10 +649,9 @@ JSROOT.define([], () => {
                OnWebsocketOpened: () => { }, // dummy function when websocket connected
 
                OnWebsocketMsg: (handle, msg) => {
-                  // console.log('Get message ' + msg + ' handle ' + !!handle);
                   if (msg.indexOf(arg.first_recv) != 0)
                      return handle.Close();
-                  arg.first_msg = msg.substr(arg.first_recv.length);
+                  handle.first_msg = msg.substr(arg.first_recv.length);
 
                   if (!arg.prereq2) resolveFunc(handle);
                },
@@ -670,7 +670,7 @@ JSROOT.define([], () => {
          if (arg.prereq2) {
             JSROOT.require(arg.prereq2).then(() => {
                delete arg.prereq2; // indicate that func is loaded
-               if (!arg.first_recv || arg.first_msg) resolveFunc(handle);
+               if (!arg.first_recv || handle.first_msg) resolveFunc(handle);
             });
          } else if (!arg.first_recv) {
             resolveFunc(handle);

--- a/js/scripts/JSRoot.webwindow.js
+++ b/js/scripts/JSRoot.webwindow.js
@@ -576,7 +576,6 @@ JSROOT.define([], () => {
     * @param {object} arg.receiver - instance of receiver for websocket events, allows to initiate connection immediately
     * @param {string} arg.first_recv - required prefix in the first message from TWebWindow, remain part of message will be returned as arg.first_msg
     * @param {string} [arg.prereq2] - second part of prerequcities, which is loaded parallel to connecting with WebWindow
-    * @param {function} arg.callback - function which is called with WebWindowHandle or when establish connection and get first portion of data
     * @returns {Promise} ready-to-use WebWindowHandle instance
     */
 
@@ -677,11 +676,6 @@ JSROOT.define([], () => {
             resolveFunc(handle);
          }
       });
-
-      // if callback specified, old API is used, callback getting handler and arg again
-      // TODO: remove it once all RWebWindow implementations in ROOT adjusted
-      if (arg.callback)
-         return promise.then(h => arg.callback(h, arg));
 
       return promise;
    }

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year */
-   JSROOT.version_date = "26/10/2020";
+   JSROOT.version_date = "27/10/2020";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date} */

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -2243,7 +2243,8 @@
       return this;
    }
 
-   // FIXME: for backward compatibility, will be removed in v6.2
+   /// FIXME: for backward compatibility, will be removed in v6.2
+
    JSROOT.GetUrlOption = function(opt, url, dflt) {
       return JSROOT.decodeUrl(url).get(opt, dflt === undefined ? null : dflt);
    }
@@ -2261,6 +2262,8 @@
 
    JSROOT.JSONR_unref = JSROOT.parse;
    JSROOT.MakeSVG = JSROOT.makeSVG;
+
+   /// end of backward compatibility block
 
    JSROOT._ = _;
    JSROOT.browser = browser;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year */
-   JSROOT.version_date = "29/10/2020";
+   JSROOT.version_date = "30/10/2020";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date} */

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -100,12 +100,12 @@
 
    /** @summary JSROOT version id
      * @desc For the JSROOT release the string in format "major.minor.patch" like "6.0.0"
-     *       For the ROOT release is string is "ROOT major.minor.patch" like "ROOT 6.24.00" */
+     *       For the ROOT release string is "ROOT major.minor.patch" like "ROOT 6.24.00" */
    JSROOT.version_id = "pre6";
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year */
-   JSROOT.version_date = "27/10/2020";
+   JSROOT.version_date = "28/10/2020";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date} */

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year */
-   JSROOT.version_date = "28/10/2020";
+   JSROOT.version_date = "29/10/2020";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date} */

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -2168,16 +2168,14 @@
       if (arg.openui5src) JSROOT.openui5src = arg.openui5src;
       if (arg.openui5libs) JSROOT.openui5libs = arg.openui5libs;
       if (arg.openui5theme) JSROOT.openui5theme = arg.openui5theme;
+      if (!arg.ignoreUrl) {
+         let url = JSROOT.decodeUrl();
+         if (url.has('nogl')) JSROOT.settings.Render3D = JSROOT.constants.Render3D.SVG;
+         if (url.has('libs')) JSROOT._.use_full_libs = true;
+      }
 
       let prereq = "webwindow;";
-      // FIXME: remove for JSROOT v7 once ROOT code is adjusted
-      if (arg && arg.prereq)
-         if (arg.prereq == "openui5")
-            prereq += "painter;openui5"; // because of eve7 app, should be fixed there
-         else
-            prereq += arg.prereq.replace(/;v6;v7/g, ";gpad;v7gpad").replace(/2d;v7;/g, "v7gpad;").replace(/2d;v6;/g, "gpad;");
-
-      console.log('Loading', prereq)
+      if (arg && arg.prereq) prereq += arg.prereq;
 
       return JSROOT.require(prereq).then(() => {
          if (arg && arg.prereq_logdiv && document) {
@@ -2263,8 +2261,6 @@
 
    JSROOT.JSONR_unref = JSROOT.parse;
    JSROOT.MakeSVG = JSROOT.makeSVG;
-   JSROOT.ConnectWebWindow = JSROOT.connectWebWindow;
-
 
    JSROOT._ = _;
    JSROOT.browser = browser;

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year */
-   JSROOT.version_date = "30/10/2020";
+   JSROOT.version_date = "2/11/2020";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date} */

--- a/tutorials/geom/webdemo.html
+++ b/tutorials/geom/webdemo.html
@@ -87,7 +87,7 @@
      AddButton("AUTOROTATE ON/OFF","autorotate()","Toggle autorotation ON/OFF");
      AddButton("Quit","quit()","Quit ROOT seesion");
 
-     JSROOT.ConnectWebWindow({
+     JSROOT.connectWebWindow({
        receiver: {
           // method called when connection to server is established
           OnWebsocketOpened: function(handle) {

--- a/tutorials/geom/webhelp.html
+++ b/tutorials/geom/webhelp.html
@@ -19,7 +19,7 @@
 
      var conn_handle = null;
 
-     JSROOT.ConnectWebWindow({
+     JSROOT.connectWebWindow({
        receiver: {
           // method called when connection to server is established
           OnWebsocketOpened: function(handle) {

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -8,7 +8,7 @@
 ///
 /// \date 2015-03-22
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-/// \authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
+/// \authors Axel Naumann <axel@cern.ch>, Sergey Linev <s.linev@gsi.de>
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -1,12 +1,14 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
+/// This macro shows how ROOT objects like TH1, TH2, TGraph can be drawn in RCanvas.
+///
 /// \macro_code
 ///
 /// \date 2017-06-02
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
-/// \author Axel Naumann <axel@cern.ch>
+/// \authors Axel Naumann <axel@cern.ch>, Sergey Linev <s.linev@gsi.de>
 
 /*************************************************************************
  * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
@@ -18,11 +20,12 @@
 
 #include <ROOT/RObjectDrawable.hxx>
 #include <ROOT/RCanvas.hxx>
-#include <TGraph.h>
+#include "TH1.h"
+#include "TH2.h"
+#include "TGraph.h"
+#include "TMath.h"
 
 #include <iostream>
-
-// Show how to display v6 objects in a v7 RCanvas.
 
 void draw_v6()
 {
@@ -32,30 +35,56 @@ void draw_v6()
    double x[npoints] = { 0., 1., 2., 3., 4., 5., 6., 7., 8., 9. };
    double y[npoints] = { .1, .2, .3, .4, .3, .2, .1, .2, .3, .4 };
    auto gr = std::make_shared<TGraph>(npoints, x, y);
-   auto canvas = RCanvas::Create("v7 RCanvas showing a v6 TGraph");
-   canvas->Draw<RObjectDrawable>(gr, "AL");
 
-   // canvas->Show("opera");   // one could specify program name which should show canvas (like chromium or firefox)
-   // canvas->Show("/usr/bin/chromium --app=$url &"); // one could use $url parameter, which replaced with canvas URL
+   static constexpr int nth1points = 100;
+   auto th1 = std::make_shared<TH1I>("gaus", "Example of TH1", nth1points, -5, 5);
+   th1->SetDirectory(nullptr);
+   for (int n=0;n<nth1points;++n) {
+      double x = 10.*n/nth1points-5.;
+      th1->SetBinContent(n+1, (int) (1000*TMath::Gaus(x)));
+   }
+
+   static constexpr int nth2points = 40;
+   auto th2 = std::make_shared<TH2I>("gaus2", "Example of TH1", nth2points, -5, 5, nth2points, -5, 5);
+   th2->SetDirectory(nullptr);
+   for (int n=0;n<nth2points;++n) {
+      for (int k=0;k<nth2points;++k) {
+         double x = 10.*n/nth2points-5.;
+         double y = 10.*k/nth2points-5.;
+         th2->SetBinContent(th2->GetBin(n+1, k+1), (int) (1000*TMath::Gaus(x)*TMath::Gaus(y)));
+      }
+   }
+
+   auto canvas = RCanvas::Create("RCanvas showing a v6 objects");
+
+   // Divide canvas on 2x2 sub-pads to show different draw options
+   auto subpads = canvas->Divide(2,2);
+
+   subpads[0][0]->Draw<RObjectDrawable>(gr, "AL");
+
+   subpads[0][1]->Draw<RObjectDrawable>(th1, "");
+
+   subpads[1][0]->Draw<RObjectDrawable>(th2, "colz");
+
+   // show same object again, but with other draw options
+   subpads[1][1]->Draw<RObjectDrawable>(th2, "lego2");
 
    canvas->Show(); // new window in default browser should popup and async update will be triggered
 
-   // synchronous, wait until painting is finished
-   canvas->Update(false,
-                  [](bool res) { std::cout << "First Update done = " << (res ? "true" : "false") << std::endl; });
+   // synchronous, wait until drawing is really finished
+   canvas->Update(false, [](bool res) { std::cout << "First sync update done = " << (res ? "true" : "false") << std::endl; });
 
-   canvas->Modified(); // invalidate canvas and force repainting with next Update()
+   // invalidate canvas and force repainting with next Update()
+   canvas->Modified();
 
    // call Update again, should return immediately if canvas was not modified
-   canvas->Update(false,
-                  [](bool res) { std::cout << "Second Update done = " << (res ? "true" : "false") << std::endl; });
+   canvas->Update(true, [](bool res) { std::cout << "Second async update done = " << (res ? "true" : "false") << std::endl; });
 
-   // request to create PNG file in asynchronous mode and specify lambda function as callback
-   // when request processed by the client, callback invoked with result value
-   // canvas->SaveAs("draw.png", true,
-   //               [](bool res) { std::cout << "Producing PNG done res = " << (res ? "true" : "false") << std::endl; });
+   std::cout << "This message appear normally before second async update" << std::endl;
 
-   // this function executed in synchronous mode (async = false is default),
-   // previous file saving will be completed at this point as well
-   // canvas->SaveAs("draw.svg"); // synchronous
+   // request to create PNG file
+   // canvas->SaveAs("draw_v6.png");
+
+   // and then create SVG file
+   // canvas->SaveAs("draw_v6.svg");
 }

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -55,7 +55,13 @@ void draw_v6()
       }
    }
 
+   auto style = std::shared_ptr<TStyle>((TStyle *)gStyle->Clone());
+
    auto canvas = RCanvas::Create("RCanvas showing a v6 objects");
+
+   // place copy of gStyle object, will be applied on JSROOT side
+   // set on the canvas before any other object is drawn
+   canvas->Draw<RObjectDrawable>(RObjectDrawable::kStyle);
 
    // Divide canvas on 2x2 sub-pads to show different draw options
    auto subpads = canvas->Divide(2,2);

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -55,13 +55,17 @@ void draw_v6()
       }
    }
 
-   auto style = std::shared_ptr<TStyle>((TStyle *)gStyle->Clone());
+   gStyle->SetPalette(kRainBow);
 
    auto canvas = RCanvas::Create("RCanvas showing a v6 objects");
 
    // place copy of gStyle object, will be applied on JSROOT side
    // set on the canvas before any other object is drawn
    canvas->Draw<RObjectDrawable>(RObjectDrawable::kStyle);
+
+   // copy custom palette to canvas, will be used for col drawings
+   // style object does not include color settings
+   canvas->Draw<RObjectDrawable>(RObjectDrawable::kPalette);
 
    // Divide canvas on 2x2 sub-pads to show different draw options
    auto subpads = canvas->Divide(2,2);

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -65,6 +65,10 @@ void draw_v6()
    // set on the canvas before any other object is drawn
    canvas->Draw<TObjectDrawable>(TObjectDrawable::kStyle);
 
+   // copy all existing ROOT colors, required when colors was modified
+   // or when colors should be possible from client side
+   canvas->Draw<TObjectDrawable>(TObjectDrawable::kColors);
+
    // copy custom palette to canvas, will be used for col drawings
    // style object does not include color settings
    canvas->Draw<TObjectDrawable>(TObjectDrawable::kPalette);
@@ -95,8 +99,8 @@ void draw_v6()
    std::cout << "This message appear normally before second async update" << std::endl;
 
    // create SVG file
-   canvas->SaveAs("draw_v6.svg");
+   // canvas->SaveAs("draw_v6.svg");
 
    // create PNG file
-   canvas->SaveAs("draw_v6.png");
+   // canvas->SaveAs("draw_v6.png");
 }

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -18,12 +18,14 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <ROOT/RObjectDrawable.hxx>
+#include <ROOT/TObjectDrawable.hxx>
+#include <ROOT/RPad.hxx>
 #include <ROOT/RCanvas.hxx>
 #include "TH1.h"
 #include "TH2.h"
 #include "TGraph.h"
 #include "TMath.h"
+#include "TStyle.h"
 
 #include <iostream>
 
@@ -61,23 +63,23 @@ void draw_v6()
 
    // place copy of gStyle object, will be applied on JSROOT side
    // set on the canvas before any other object is drawn
-   canvas->Draw<RObjectDrawable>(RObjectDrawable::kStyle);
+   canvas->Draw<TObjectDrawable>(TObjectDrawable::kStyle);
 
    // copy custom palette to canvas, will be used for col drawings
    // style object does not include color settings
-   canvas->Draw<RObjectDrawable>(RObjectDrawable::kPalette);
+   canvas->Draw<TObjectDrawable>(TObjectDrawable::kPalette);
 
    // Divide canvas on 2x2 sub-pads to show different draw options
    auto subpads = canvas->Divide(2,2);
 
-   subpads[0][0]->Draw<RObjectDrawable>(gr, "AL");
+   subpads[0][0]->Draw<TObjectDrawable>(gr, "AL");
 
-   subpads[0][1]->Draw<RObjectDrawable>(th1, "");
+   subpads[0][1]->Draw<TObjectDrawable>(th1, "");
 
-   subpads[1][0]->Draw<RObjectDrawable>(th2, "colz");
+   subpads[1][0]->Draw<TObjectDrawable>(th2, "colz");
 
    // show same object again, but with other draw options
-   subpads[1][1]->Draw<RObjectDrawable>(th2, "lego2");
+   subpads[1][1]->Draw<TObjectDrawable>(th2, "lego2");
 
    canvas->Show(); // new window in default browser should popup and async update will be triggered
 

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -82,9 +82,9 @@ void draw_v6()
 
    std::cout << "This message appear normally before second async update" << std::endl;
 
-   // request to create PNG file
-   // canvas->SaveAs("draw_v6.png");
+   // create SVG file
+   canvas->SaveAs("draw_v6.svg");
 
-   // and then create SVG file
-   // canvas->SaveAs("draw_v6.svg");
+   // create PNG file
+   canvas->SaveAs("draw_v6.png");
 }

--- a/tutorials/webgui/webwindow/client.html
+++ b/tutorials/webgui/webwindow/client.html
@@ -9,9 +9,9 @@
   </head>
 
   <body>
-     <button onclick="SendMsg('get_text')">Text</button> 
-     <button onclick="SendMsg('get_binary')">Binary</button> 
-     <button onclick="SendMsg('halt')">Halt</button> 
+     <button onclick="SendMsg('get_text')">Text</button>
+     <button onclick="SendMsg('get_binary')">Binary</button>
+     <button onclick="SendMsg('halt')">Halt</button>
      <div id="main"></div>
   </body>
 
@@ -23,12 +23,12 @@
        if (conn_handle)
           conn_handle.Send(txt);
     }
-    
+
     function AddOutput(msg) {
        document.getElementById("main").innerHTML += msg + "<br>";
     }
 
-    JSROOT.ConnectWebWindow({
+    JSROOT.connectWebWindow({
        // prereq: "2d",  /* one could specify different JSROOT components like 2d or geom
        // prereq_logdiv: "main",  /* div id where loading of JSROOT scripts will be logged */
        // callback: function(handle) { AddOutput("init done"); },  /* if necessary, initial callback can be cacthed */
@@ -39,17 +39,17 @@
              conn_handle = handle;
              AddOutput("Connected");
           },
-      
+
           // method with new message from server
           OnWebsocketMsg: function(handle, msg, offset) {
              if (typeof msg != "string") {
                 var arr = new Float32Array(msg, offset);
                 AddOutput("bin: " + arr.toString());
-             } else { 
+             } else {
                 AddOutput("txt: " + msg);
              }
           },
-          
+
           // method called when connection is gone
           OnWebsocketClosed: function(handle) {
              conn_handle = null;

--- a/ui5/browser/browser.html
+++ b/ui5/browser/browser.html
@@ -2,11 +2,9 @@
 <html lang="en">
    <head>
       <meta charset="UTF-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <title>ROOT Browser</title>
+      <title>ROOT RBrowser</title>
       <script type="text/javascript" src="jsrootsys/scripts/JSRootCore.js"></script>
       <link rel="stylesheet" type="text/css" href="rootui5sys/browser/style.css">
-
    </head>
 
    <body>
@@ -16,27 +14,20 @@
 
       <script type='text/javascript'>
 
-        function InitUI(handle) {
-
-           sap.ui.require(["sap/ui/core/mvc/XMLView"], XMLView => {
-              XMLView.create({
-                 id: "TopBrowserId",
-                 viewName: "rootui5.browser.view.Browser",
-                 viewData: { conn_handle: handle }
-              }).then(oView => oView.placeAt("BrowserDiv"));
-           });
-
-        }
-
-        if (JSROOT.GetUrlOption('libs')!==null) JSROOT.use_full_libs = true;
-
-        JSROOT.ConnectWebWindow({
+        JSROOT.connectWebWindow({
            prereq: "openui5;v6;v7",  // load v6,v7 because of canvas painter
 //           openui5src: "jsroot",    // use JSROOT provided package, default
-//           openui5src: "https://openui5.hana.ondemand.com/1.70.0/",
+//           openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
            openui5libs: "sap.m, sap.ui.layout, sap.ui.unified, sap.ui.table, sap.ui.codeeditor, sap.tnt", // customize openui5 libs later
-           prereq_logdiv: "BrowserDiv",
-           callback: InitUI
+           prereq_logdiv: "BrowserDiv"
+        }).then(handle => {
+            sap.ui.require(["sap/ui/core/mvc/XMLView"], XMLView => {
+                XMLView.create({
+                   id: "TopBrowserId",
+                   viewName: "rootui5.browser.view.Browser",
+                   viewData: { conn_handle: handle }
+                }).then(oView => oView.placeAt("BrowserDiv"));
+            });
         });
 
       </script>

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -1147,10 +1147,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             viewName: "rootui5.canv.view.Canvas",
             viewData: { canvas_painter: painter },
             height: "100%"
-         }).then(function(oView) {
-            oTabContainerItem.addContent(oView);
-            // JSROOT.CallBack(call_back, true);
-         });
+         }).then(oView => oTabContainerItem.addContent(oView));
       },
 
    });

--- a/ui5/canv/canvas.html
+++ b/ui5/canv/canvas.html
@@ -1,4 +1,3 @@
-<!--  this file used for ROOT7 RCanvas display -->
 <!DOCTYPE html>
 <html lang="en">
    <head>
@@ -28,42 +27,43 @@
 
    <script type='text/javascript'>
 
+      let batch_mode = JSROOT.decodeUrl().has("batch_mode"),
+          _prereq = "v7";
+
+      if (batch_mode)
+        JSROOT.BatchMode = true;
+      else
+        _prereq += ";openui5";
+
       JSROOT.connectWebWindow({
-         prereq: "v7",
-         prereq_logdiv: "CanvasDiv",
+         prereq: _prereq,
+         prereq_logdiv: "CanvasDiv"
          // openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
       }).then(handle => {
          let painter = new JSROOT.v7.RCanvasPainter(null);
-         painter.use_openui = true;
-         painter.batch_mode = JSROOT.decodeUrl().has("batch_mode");
-         if (painter.batch_mode) JSROOT.BatchMode = true;
+         painter.batch_mode = batch_mode;
 
          if (window) {
             window.onbeforeunload = painter.WindowBeforeUnloadHanlder.bind(painter);
             if (JSROOT.browser.qt5) window.onqt5unload = window.onbeforeunload;
          }
 
-         if (painter.use_openui && !painter.batch_mode) {
-
-            painter._window_handle = handle;
+         if (!batch_mode) {
             painter.use_openui = true;
+            painter._window_handle = handle;
 
-            JSROOT.require('openui5').then(() => {
-
-               sap.ui.require(["sap/ui/core/ComponentContainer"], function(ComponentContainer) {
-                  new ComponentContainer({
-                     name: "rootui5.canv",
-                     manifest: true,
-                     async: true,
-                     settings: {
-                        componentData: {
-                           canvas_painter: painter
-                        }
-                     },
-                     height: "100%"
-                  }).placeAt("CanvasDiv")
-               });
-
+            sap.ui.require(["sap/ui/core/ComponentContainer"], ComponentContainer => {
+               new ComponentContainer({
+                  name: "rootui5.canv",
+                  manifest: true,
+                  async: true,
+                  settings: {
+                     componentData: {
+                        canvas_painter: painter
+                     }
+                  },
+                  height: "100%"
+               }).placeAt("CanvasDiv")
             });
 
          } else {
@@ -72,7 +72,7 @@
 
             painter.UseWebsocket(handle); // when connection activated, ROOT must send new instance of the canvas
 
-            if (!painter.batch_mode) JSROOT.RegisterForResize(painter);
+            if (!batch_mode) JSROOT.RegisterForResize(painter);
          }
       });
 

--- a/ui5/canv/canvas.html
+++ b/ui5/canv/canvas.html
@@ -1,10 +1,9 @@
-<!--  this file used for ROOT7 Canvas display -->
+<!--  this file used for ROOT7 RCanvas display -->
 <!DOCTYPE html>
 <html lang="en">
    <head>
       <meta charset="UTF-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <title>ROOT7 TCanvas</title>
+      <title>ROOT7 RCanvas</title>
       <script type="text/javascript" src="jsrootsys/scripts/JSRootCore.js"></script>
    </head>
 
@@ -29,11 +28,14 @@
 
    <script type='text/javascript'>
 
-      function InitV7Canvas(handle, args) {
-
-         var painter = new JSROOT.v7.RCanvasPainter(null);
+      JSROOT.connectWebWindow({
+         prereq: "v7",
+         prereq_logdiv: "CanvasDiv",
+         // openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
+      }).then(handle => {
+         let painter = new JSROOT.v7.RCanvasPainter(null);
          painter.use_openui = true;
-         painter.batch_mode = JSROOT.GetUrlOption("batch_mode") !== null;
+         painter.batch_mode = JSROOT.decodeUrl().has("batch_mode");
          if (painter.batch_mode) JSROOT.BatchMode = true;
 
          if (window) {
@@ -46,7 +48,7 @@
             painter._window_handle = handle;
             painter.use_openui = true;
 
-            return JSROOT.AssertPrerequisites('openui5', function() {
+            JSROOT.require('openui5').then(() => {
 
                sap.ui.require(["sap/ui/core/ComponentContainer"], function(ComponentContainer) {
                   new ComponentContainer({
@@ -64,20 +66,14 @@
 
             });
 
+         } else {
+
+            painter.SetDivId("CanvasDiv", -1); // just assign id, nothing else is happens
+
+            painter.UseWebsocket(handle); // when connection activated, ROOT must send new instance of the canvas
+
+            if (!painter.batch_mode) JSROOT.RegisterForResize(painter);
          }
-
-         painter.SetDivId("CanvasDiv", -1); // just assign id, nothing else is happens
-
-         painter.UseWebsocket(handle); // when connection activated, ROOT must send new instance of the canvas
-
-         if (!painter.batch_mode) JSROOT.RegisterForResize(painter);
-      }
-
-      JSROOT.ConnectWebWindow({
-         prereq: "2d;v7;",
-         prereq_logdiv: "CanvasDiv",
-         // openui5src: "https://openui5.hana.ondemand.com/",
-         callback: InitV7Canvas
       });
 
    </script>

--- a/ui5/canv/canvas6.html
+++ b/ui5/canv/canvas6.html
@@ -1,4 +1,3 @@
-<!--  this file used for ROOT6 Canvas display with TWebWindow -->
 <!DOCTYPE html>
 <html lang="en">
    <head>
@@ -28,45 +27,52 @@
 
    <script type='text/javascript'>
 
+      let url = JSROOT.decodeUrl(),
+          is_batch = url.has("batch_mode"),
+          is_ui5 = !url.has("noopenui") && !is_batch,
+          _prereq = 'v6';
+
+      if (is_batch) JSROOT.BatchMode = true;
+
+      if (is_ui5)
+         _prereq += ";openui5";
+      else if (!is_batch)
+         _prereq += ";jq2d";  // jq2d need for BrowserLayout
+
       JSROOT.connectWebWindow({
-         prereq: "v6",
+         prereq: _prereq,
          prereq_logdiv: "CanvasDiv",
          // openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
       }).then(handle => {
-         let painter = new JSROOT.TCanvasPainter(null),
-             url = JSROOT.decodeUrl();
+         let painter = new JSROOT.TCanvasPainter(null);
 
          painter.online_canvas = true;
-         painter.use_openui = !url.has("noopenui");
-         painter.batch_mode = url.has("batch_mode");
-         if (painter.batch_mode) JSROOT.BatchMode = true;
+         painter.use_openui = is_ui5;
+         painter.batch_mode = is_batch;
 
          if (window) {
             window.onbeforeunload = painter.WindowBeforeUnloadHanlder.bind(painter);
             if (JSROOT.browser.qt5) window.onqt5unload = window.onbeforeunload;
          }
 
-         if (painter.use_openui && !painter.batch_mode) {
+         if (is_ui5) {
 
             painter._window_handle = handle;
 
-            JSROOT.require('openui5').then(() => {
-
-               sap.ui.require(["sap/ui/core/ComponentContainer"], function(ComponentContainer) {
-                  new ComponentContainer({
-                     name: "rootui5.canv",
-                     manifest: true,
-                     async: true,
-                     settings: {
-                        componentData: {
-                           canvas_painter: painter
-                        }
-                     },
-                     height: "100%"
-                  }).placeAt("CanvasDiv")
-               });
-
+            sap.ui.require(["sap/ui/core/ComponentContainer"], function(ComponentContainer) {
+               new ComponentContainer({
+                  name: "rootui5.canv",
+                  manifest: true,
+                  async: true,
+                  settings: {
+                     componentData: {
+                        canvas_painter: painter
+                     }
+                  },
+                  height: "100%"
+               }).placeAt("CanvasDiv")
             });
+
          } else {
 
             painter.SetDivId("CanvasDiv", -1); // just assign id, nothing else happens

--- a/ui5/canv/canvas6.html
+++ b/ui5/canv/canvas6.html
@@ -3,11 +3,10 @@
 <html lang="en">
    <head>
       <meta charset="UTF-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <title>ROOT6 TCanvas</title>
       <script type="text/javascript" src="jsrootsys/scripts/JSRootCore.js"></script>
    </head>
-   
+
    <style>
       html { height: 100%; }
       body { min-height: 100%; margin: 0; overflow: hidden }
@@ -26,16 +25,20 @@
          loading scripts...
       </div>
    </body>
-   
+
    <script type='text/javascript'>
-   
-      function InitV6Canvas(handle, args) {
-         
-         var painter = new JSROOT.TCanvasPainter(null);
-         
+
+      JSROOT.connectWebWindow({
+         prereq: "v6",
+         prereq_logdiv: "CanvasDiv",
+         // openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
+      }).then(handle => {
+         let painter = new JSROOT.TCanvasPainter(null),
+             url = JSROOT.decodeUrl();
+
          painter.online_canvas = true;
-         painter.use_openui = (JSROOT.GetUrlOption("noopenui") === null); 
-         painter.batch_mode = JSROOT.GetUrlOption("batch_mode") !== null;
+         painter.use_openui = !url.has("noopenui");
+         painter.batch_mode = url.has("batch_mode");
          if (painter.batch_mode) JSROOT.BatchMode = true;
 
          if (window) {
@@ -46,9 +49,9 @@
          if (painter.use_openui && !painter.batch_mode) {
 
             painter._window_handle = handle;
-            
-            return JSROOT.AssertPrerequisites('openui5', function() {
-               
+
+            JSROOT.require('openui5').then(() => {
+
                sap.ui.require(["sap/ui/core/ComponentContainer"], function(ComponentContainer) {
                   new ComponentContainer({
                      name: "rootui5.canv",
@@ -62,20 +65,15 @@
                      height: "100%"
                   }).placeAt("CanvasDiv")
                });
-               
+
             });
+         } else {
+
+            painter.SetDivId("CanvasDiv", -1); // just assign id, nothing else happens
+
+            painter.UseWebsocket(handle); // when connection activated, ROOT must send new instance of the canvas
          }
 
-         painter.SetDivId("CanvasDiv", -1); // just assign id, nothing else happens
-
-         painter.UseWebsocket(handle); // when connection activated, ROOT must send new instance of the canvas
-      }
-      
-      JSROOT.ConnectWebWindow({
-         prereq: "jq2d;v6;",
-         prereq_logdiv: "CanvasDiv",
-         // openui5src: "https://openui5.hana.ondemand.com/",
-         callback: InitV6Canvas
       });
 
    </script>

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -84,17 +84,19 @@ sap.ui.define([
 
       },
 
+      /** @summary function used to activate GED in full canvas */
       openuiActivateGed: function(painter, kind, mode) {
-         // function used to activate GED in full canvas
-
-         this.showGeEditor(true);
 
          var canvp = this.getCanvasPainter();
 
-         canvp.SelectObjectPainter(painter);
+         return this.showGeEditor(true).then(() => {
+            canvp.SelectObjectPainter(painter);
 
-         if (typeof canvp.ProcessChanges == 'function')
-            canvp.ProcessChanges("sbits", canvp);
+            if (typeof canvp.ProcessChanges == 'function')
+               canvp.ProcessChanges("sbits", canvp);
+
+            return true;
+         });
       },
 
       getCanvasPainter : function(also_without_websocket) {
@@ -260,7 +262,7 @@ sap.ui.define([
       },
 
       showGeEditor : function(new_state) {
-         this.showLeftArea(new_state ? "Ged" : "");
+         return this.showLeftArea(new_state ? "Ged" : "");
       },
 
       cleanupIfGed: function() {
@@ -360,7 +362,7 @@ sap.ui.define([
             viewData: { masterPanel: this },
             layoutData: oLd,
             height: (panel_name == "Panel") ? "100%" : undefined
-         }).then(function(oView) {
+         }).then(oView => {
 
             // workaround, while CanvasPanel.onBeforeRendering called too late
             can_elem.getController().preserveCanvasContent();
@@ -536,10 +538,11 @@ sap.ui.define([
          switch(that) {
             case "Menu": this.setShowMenu(on); break;
             case "StatusBar": this.toggleShowStatus(on); break;
-            case "Editor": this.showGeEditor(on); break;
+            case "Editor": return this.showGeEditor(on);
             case "ToolBar": this.toggleToolBar(on); break;
             case "ToolTips": this.toggleToolTip(on); break;
          }
+         return Promise.resolve(true);
       }
    });
 

--- a/ui5/canv/controller/CanvasPanel.controller.js
+++ b/ui5/canv/controller/CanvasPanel.controller.js
@@ -7,7 +7,7 @@ sap.ui.define([
    return Controller.extend("rootui5.canv.controller.CanvasPanel", {
 
       preserveCanvasContent: function () {
-         // workaround, openui5 does not preserve
+         // workaround, openui5 does not preserve DOM elements when calling onBeforeRendering
          let dom = this.getView().getDomRef();
          if (this.canvas_painter && dom && dom.children.length && !this._mainChild) {
             this._mainChild = dom.children[0];
@@ -17,6 +17,7 @@ sap.ui.define([
 
       onBeforeRendering: function() {
          this.preserveCanvasContent();
+         this._has_after_rendering = false;
       },
 
       setPainter: function(painter) {
@@ -28,70 +29,75 @@ sap.ui.define([
       },
 
       onAfterRendering: function() {
-         let dom = this.getView().getDomRef(), check_resize = false;
-
-         if (dom && this._mainChild) {
-            dom.appendChild(this._mainChild)
-            delete this._mainChild;
-            check_resize = true;
-         }
-
-         if (dom && !dom.children.length) {
-             let d = document.createElement("div");
-             d.style = "position:relative;left:0;right:0;top:0;bottom:0;height:100%;width:100%";
-             dom.appendChild(d);
-          }
-
-         if (this.canvas_painter) {
-            this.canvas_painter.SetDivId(dom.lastChild, -1);
-            if (check_resize) this.canvas_painter.CheckCanvasResize();
-         }
-
-         if (this.canvas_painter && this.canvas_painter._window_handle) {
-            this.canvas_painter.UseWebsocket(this.canvas_painter._window_handle, this.canvas_painter._window_handle_href);
-            delete this.canvas_painter._window_handle;
-         }
+         // workaround for openui5 problem - called before actual dimension of HTML element is assigned
+         // using timeout and resize event to handle it correctly
+         this._has_after_rendering = true;
+         this.invokeResizeTimeout(10);
       },
 
-      onResize: function(/* event */) {
-         // use timeout
-         if (this.resize_tmout) clearTimeout(this.resize_tmout);
-         this.resize_tmout = setTimeout(this.onResizeTimeout.bind(this), 300); // minimal latency
+      hasValidSize: function() {
+         return (this.getView().$().width() > 0) && (this.getView().$().height() > 0);
       },
 
-      drawCanvas: function(can, opt, call_back) {
-         if (this.canvas_painter) {
-            this.canvas_painter.Cleanup();
-            delete this.canvas_painter;
-         }
+      invokeResizeTimeout: function(tmout) {
+        if (this.resize_tmout) {
+            clearTimeout(this.resize_tmout);
+            delete this.resize_tmout;
+        }
 
-         let dom = this.getView().getDomRef();
-
-         if (!dom)
-            return JSROOT.CallBack(call_back, null);
-
-         if (dom.children.length == 0) {
-             let d = document.createElement("div");
-             d.style= "position:relative;left:0;right:0;top:0;bottom:0;height:100%;width:100%";
-             dom.appendChild(d);
-          }
-
-         JSROOT.draw(dom.lastChild, can, opt).then(painter => {
-            this.canvas_painter = painter;
-            JSROOT.CallBack(call_back, painter);
-         });
+        if (this.hasValidSize() && this._has_after_rendering)
+           this.onResizeTimeout();
+        else
+           this.resize_tmout = setTimeout(this.onResizeTimeout.bind(this), tmout);
       },
 
+      /** @summary Handle openui5 resize glitch
+        * @desc onAfterRendering method does not provide valid dimension of the HTML element
+        * One should wait either resize event or timeout and check if valid size is there
+        * Only then normal rendering can be started
+        * Method also used to check resize events  */
       onResizeTimeout: function() {
          delete this.resize_tmout;
-         if (this.canvas_painter)
+
+         if (!this.hasValidSize())
+             return this.invokeResizeTimeout(5000); // very rare check if something changed
+
+         let check_resize = true;
+
+         if (this._has_after_rendering) {
+
+            this._has_after_rendering = false;
+            check_resize = false;
+
+            let dom = this.getView().getDomRef();
+
+            if (dom && this._mainChild) {
+               dom.appendChild(this._mainChild)
+               delete this._mainChild;
+               check_resize = true;
+            }
+
+            if (dom && !dom.children.length) {
+               let d = document.createElement("div");
+               d.style = "position:relative;left:0;right:0;top:0;bottom:0;height:100%;width:100%";
+               dom.appendChild(d);
+            }
+
+            if (this.canvas_painter)
+               this.canvas_painter.SetDivId(dom.lastChild, -1);
+
+            if (this.canvas_painter && this.canvas_painter._window_handle) {
+               this.canvas_painter.UseWebsocket(this.canvas_painter._window_handle, this.canvas_painter._window_handle_href);
+               delete this.canvas_painter._window_handle;
+            }
+         }
+
+         if (this.canvas_painter && check_resize)
             this.canvas_painter.CheckCanvasResize();
       },
 
       onInit: function() {
-         console.log("INIT CANVAS PANEL");
-
-         ResizeHandler.register(this.getView(), this.onResize.bind(this));
+         ResizeHandler.register(this.getView(), this.invokeResizeTimeout.bind(this, 200));
       },
 
       onExit: function() {

--- a/ui5/canv/controller/Ged.controller.js
+++ b/ui5/canv/controller/Ged.controller.js
@@ -91,12 +91,17 @@ sap.ui.define([
 
          if (obj) {
             if ((data._kind === "TAttLine") && (obj.fLineColor!==undefined) && (obj.fLineStyle!==undefined) && (obj.fLineWidth!==undefined)) {
-               if (item == "attline/width") exec = "exec:SetLineWidth(" + pars.value + ")";
-               else if (item == "attline/style") exec = "exec:SetLineStyle(" + pars.value + ")";
-               else if (item == "attline/color") exec = data._painter.GetColorExec(pars.value, "SetLineColor");
+               if (item == "attline/width")
+                  exec = "exec:SetLineWidth(" + pars.value + ")";
+               else if (item == "attline/style")
+                  exec = "exec:SetLineStyle(" + pars.value + ")";
+               else if (item == "attline/color")
+                  exec = data._painter.GetColorExec(pars.value, "SetLineColor");
             } else if ((data._kind === "TAttFill") && (obj.fFillColor!==undefined) && (obj.fFillStyle!==undefined))  {
-               if (item == "attfill/pattern") exec = "exec:SetFillStyle(" + pars.value + ")";
-               else if (item == "attfill/color") exec = data._painter.GetColorExec(pars.value, "SetFillColor");
+               if (item == "attfill/pattern")
+                  exec = "exec:SetFillStyle(" + pars.value + ")";
+               else if (item == "attfill/color")
+                  exec = data._painter.GetColorExec(pars.value, "SetFillColor");
             }
          }
 

--- a/ui5/canv/manifest.json
+++ b/ui5/canv/manifest.json
@@ -1,4 +1,5 @@
 {
+   "_version": "1.8.0",
     "sap.app": {
         "id": "rootui5.canv"
     },
@@ -10,6 +11,7 @@
             "id": "RootCanvas"
         },
         "dependencies": {
+            "minUI5Version": "1.30.0",
             "libs": {
                 "sap.ui.core": {},
                 "sap.ui.layout": {},

--- a/ui5/canv/view/Axis.fragment.xml
+++ b/ui5/canv/view/Axis.fragment.xml
@@ -1,0 +1,9 @@
+<core:FragmentDefinition
+       xmlns="sap.m"
+       xmlns:l="sap.ui.layout"
+       xmlns:jsroot="rootui5.canv.controller"
+       xmlns:core="sap.ui.core">
+   <VBox>
+      <jsroot:ColorButton text="axis" attrcolor="{/axiscolor}" tooltip="Axis color"/>
+   </VBox>
+</core:FragmentDefinition>

--- a/ui5/canv/view/Axis.fragment.xml
+++ b/ui5/canv/view/Axis.fragment.xml
@@ -5,7 +5,6 @@
        xmlns:core="sap.ui.core">
    <VBox>
       <Input
-         id="titleInput"
          type="Text"
          placeholder="Enter title ..."
          valueStateText="Edit axis title"

--- a/ui5/canv/view/Axis.fragment.xml
+++ b/ui5/canv/view/Axis.fragment.xml
@@ -4,6 +4,62 @@
        xmlns:jsroot="rootui5.canv.controller"
        xmlns:core="sap.ui.core">
    <VBox>
-      <jsroot:ColorButton text="axis" attrcolor="{/axiscolor}" tooltip="Axis color"/>
+      <Input
+         id="titleInput"
+         type="Text"
+         placeholder="Enter title ..."
+         valueStateText="Edit axis title"
+         valueLiveUpdate="true"
+         value="{
+            path : '/axis/fTitle',
+            type : 'sap.ui.model.type.String'
+       }"/>
+      <jsroot:ColorButton text="Axis" attrcolor="{/axiscolor}" tooltip="Axis color"/>
+      <HBox justifyContent="SpaceBetween" alignItems="Center">
+          <VBox class="sapUiSmallMarginEnd">
+             <Label text="Ticks:" wrapping="true"/>
+         </VBox>
+         <VBox>
+            <StepInput min="-1.000" max="1.000" step="0.001" value="{/axis/fTickLength}" editable="true" displayValuePrecision="3"/>
+         </VBox>
+      </HBox>
+      <jsroot:ColorButton text="Title" attrcolor="{/color_title}" tooltip="Title color"/>
+      <CheckBox text="Center title" selected="{/center_title}"/>
+      <CheckBox text="Rotate title" selected="{/rotate_title}"/>
+      <HBox justifyContent="SpaceBetween" alignItems="Center">
+          <VBox class="sapUiSmallMarginEnd">
+             <Label text="Offset:" wrapping="true"/>
+         </VBox>
+         <VBox>
+            <StepInput min="0.00" max="3.00" step="0.01" value="{/axis/fTitleOffset}" editable="true" displayValuePrecision="3"/>
+         </VBox>
+      </HBox>
+      <HBox justifyContent="SpaceBetween" alignItems="Center">
+          <VBox class="sapUiSmallMarginEnd">
+             <Label text="Size:" wrapping="true"/>
+         </VBox>
+         <VBox>
+            <StepInput min="0.01" max="0.50" step="0.01" value="{/axis/fTitleSize}" editable="true" displayValuePrecision="3"/>
+         </VBox>
+      </HBox>
+      <jsroot:ColorButton text="Labels" attrcolor="{/color_label}" tooltip="Labels color"/>
+      <CheckBox text="Center label" selected="{/center_label}"/>
+      <CheckBox text="Rotate label" selected="{/vert_label}"/>
+      <HBox justifyContent="SpaceBetween" alignItems="Center">
+          <VBox class="sapUiSmallMarginEnd">
+             <Label text="Offset:" wrapping="true"/>
+         </VBox>
+         <VBox>
+            <StepInput min="0.00" max="0.20" step="0.01" value="{/axis/fLabelOffset}" editable="true" displayValuePrecision="3"/>
+         </VBox>
+      </HBox>
+      <HBox justifyContent="SpaceBetween" alignItems="Center">
+          <VBox class="sapUiSmallMarginEnd">
+             <Label text="Size:" wrapping="true"/>
+         </VBox>
+         <VBox>
+            <StepInput min="0.00" max="0.50" step="0.01" value="{/axis/fLabelSize}" editable="true" displayValuePrecision="3"/>
+         </VBox>
+      </HBox>
    </VBox>
 </core:FragmentDefinition>

--- a/ui5/eve7/geom.html
+++ b/ui5/eve7/geom.html
@@ -2,7 +2,6 @@
 <html lang="en">
    <head>
       <meta charset="UTF-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <title>Geometry viewer</title>
       <script type="text/javascript" src="jsrootsys/scripts/JSRootCore.js"></script>
       <style>
@@ -46,45 +45,21 @@
 
       <script type='text/javascript'>
 
-        function InitUI(handle) {
-
-           sap.ui.require(["sap/ui/core/mvc/XMLView"], function(XMLView) {
-              XMLView.create({
-                 id: "TopEveId",
-                 viewName: "rootui5.eve7.view.GeomViewer",
-                 viewData: { conn_handle: handle }
-              }).then(function(oView) {
-                 oView.placeAt("GeomDiv");
-              });
-           });
-
-//           sap.ui.require(["sap/ui/core/ComponentContainer"], function(ComponentContainer) {
-//               new ComponentContainer({
-//                  name: "rootui5.geom",
-//                  manifest: true,
-//                  async: true,
-//                  settings: {
-//                     componentData: {
-//                        conn_handle: handle
-//                     }
-//                  },
-//                  height: "100%"
-//               }).placeAt("GeomDiv")
-//            });
-
-        }
-
-        if (JSROOT.GetUrlOption('nogl')!==null) JSROOT.gStyle.NoWebGL = true;
-        if (JSROOT.GetUrlOption('libs')!==null) JSROOT.use_full_libs = true;
-
-        JSROOT.ConnectWebWindow({
+        JSROOT.connectWebWindow({
            prereq: "openui5",
-//           openui5src: "jsroot",    // use ROOT provided package
-//           openui5src: "https://openui5.hana.ondemand.com/",   // latest official openui5 release
-//           openui5theme: "sap_fiori_3",                        // optional theme
-           openui5libs: "sap.m, sap.ui.layout, sap.ui.unified, sap.ui.table", // customize openui5 libs later
            prereq_logdiv: "GeomDiv",
-           callback: InitUI
+//           openui5src: "jsroot",    // use ROOT provided package
+//           openui5src: "https://openui5.hana.ondemand.com/1.82.2/",   // latest official openui5 release
+//           openui5theme: "sap_fiori_3",                        // optional theme
+           openui5libs: "sap.m, sap.ui.layout, sap.ui.unified, sap.ui.table" // customize openui5 libs later
+        }).then(handle => {
+            sap.ui.require(["sap/ui/core/mvc/XMLView"], XMLView => {
+                XMLView.create({
+                   id: "TopEveId",
+                   viewName: "rootui5.eve7.view.GeomViewer",
+                   viewData: { conn_handle: handle }
+                }).then(oView => oView.placeAt("GeomDiv"));
+             });
         });
 
       </script>

--- a/ui5/eve7/index.html
+++ b/ui5/eve7/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
    <head>
       <meta charset="UTF-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <title>Eve7</title>
       <script type="text/javascript" src="jsrootsys/scripts/JSRootCore.js"></script>
       <style>
@@ -27,39 +26,33 @@
 
       <script type='text/javascript'>
 
-        function InitUI(handle) {
-
-//           sap.ui.loader.config({ paths: { rootui5: "../rootui5/" } });
-
-           sap.ui.require(["sap/ui/core/ComponentContainer"], function(ComponentContainer) {
-              new ComponentContainer({
-                 name: "rootui5.eve7",
-                 manifest: true,
-                 async: true,
-                 settings: {
-                    componentData: {
-                       conn_handle: handle
-                    }
-                 },
-                 height: "100%"
-              }).placeAt("EveDiv")
-           });
-        }
-
-        if (JSROOT.GetUrlOption('nogl')!==null) JSROOT.gStyle.NoWebGL = true;
-        if (JSROOT.GetUrlOption('libs')!==null) JSROOT.use_full_libs = true;
-
-        JSROOT.ConnectWebWindow({
-//           socket_kind: "file",
-           prereq: "openui5",
-//           openui5src: "jsroot",    // use JSROOT provided package, experimental
-//           openui5src: "https://openui5.hana.ondemand.com/1.72.0/",
-           openui5libs: "sap.ui.core", // customize openui5 libs
+        JSROOT.connectWebWindow({
+           // socket_kind: "file",  // used for offline
+           prereq: "painter;openui5",
            prereq_logdiv: "EveDiv",
-           callback: InitUI
+//           openui5src: "jsroot",    // use JSROOT provided package, experimental
+//           openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
+           openui5libs: "sap.ui.core" // customize openui5 libs
+        }).then(handle => {
+//          sap.ui.loader.config({ paths: { rootui5: "../rootui5/" } });  // used for offline
+
+            sap.ui.require(["sap/ui/core/ComponentContainer"], ComponentContainer => {
+               new ComponentContainer({
+                  name: "rootui5.eve7",
+                  manifest: true,
+                  async: true,
+                  settings: {
+                     componentData: {
+                        conn_handle: handle
+                     }
+                  },
+                  height: "100%"
+               }).placeAt("EveDiv")
+            });
+
         });
 
-      </script>
+        </script>
 
    </body>
 

--- a/ui5/panel/panel.html
+++ b/ui5/panel/panel.html
@@ -28,21 +28,20 @@
 
    <script type='text/javascript'>
 
-      let connect_args = {
+      JSROOT.connectWebWindow({
          prereq_logdiv: "PanelDiv",
-    	   // openui5src: "jsroot",
-    	   // openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
-    	   // openui5libs: "sap.ui.core, sap.ui.layout, sap.m",
+         // openui5src: "jsroot",
+         // openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
+         // openui5libs: "sap.ui.core, sap.ui.layout, sap.m",
          first_recv: "SHOWPANEL:",
          prereq2: "openui5",
          callback: ShowOpenui5Panel
-      };
+      }).then(handle => {
 
-      JSROOT.connectWebWindow(connect_args).then(handle => {
+         if (!handle || !sap) return false;
 
-         let viewName = connect_args.first_msg;
-
-         if (!handle || !viewName || !sap) return false;
+         let viewName = handle.first_msg;
+         if (!viewName) return false;
 
          if ((viewName.indexOf("rootui5.") !== 0) && (viewName.indexOf("jsroot.") !== 0) && (viewName.indexOf("sap.") !== 0)) {
             let p = viewName.indexOf(".");

--- a/ui5/panel/panel.html
+++ b/ui5/panel/panel.html
@@ -3,7 +3,6 @@
 <html lang="en">
    <head>
       <meta charset="UTF-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <title>ROOT7 web panel</title>
       <script type="text/javascript" src="jsrootsys/scripts/JSRootCore.js"></script>
    </head>
@@ -29,47 +28,44 @@
 
    <script type='text/javascript'>
 
-      function ShowOpenui5Panel(panel_handle, arg) {
+      let connect_args = {
+         prereq_logdiv: "PanelDiv",
+    	   // openui5src: "jsroot",
+    	   // openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
+    	   // openui5libs: "sap.ui.core, sap.ui.layout, sap.m",
+         first_recv: "SHOWPANEL:",
+         prereq2: "openui5",
+         callback: ShowOpenui5Panel
+      };
 
-         if (!panel_handle || !arg.first_msg || !sap) return false;
+      JSROOT.connectWebWindow(connect_args).then(handle => {
 
-         var panelid = "TopPanelId";
+         let viewName = connect_args.first_msg;
 
-         var viewName = arg.first_msg;
+         if (!handle || !viewName || !sap) return false;
 
          if ((viewName.indexOf("rootui5.") !== 0) && (viewName.indexOf("jsroot.") !== 0) && (viewName.indexOf("sap.") !== 0)) {
-            var p = viewName.indexOf(".");
+            let p = viewName.indexOf(".");
             if ((p > 1) && (p < viewName.length - 1)) {
-               var tgtpath = "/currentdir/";
-               var pp = JSROOT.source_dir.indexOf("/jsrootsys/");
-               if (pp>0) tgtpath = JSROOT.source_dir.substr(0,pp) + "currentdir/";
-               var _paths = {};
+               let tgtpath = "/currentdir/";
+               let pp = JSROOT.source_dir.indexOf("/jsrootsys/");
+               if (pp > 0) tgtpath = JSROOT.source_dir.substr(0,pp) + "currentdir/";
+               let _paths = {};
                _paths[viewName.substr(0,p)] = tgtpath;
                console.log('Register module path', viewName.substr(0,p), ' as ', tgtpath);
                sap.ui.loader.config({ paths: _paths });
             }
          }
 
-         sap.ui.require(["sap/ui/core/mvc/XMLView"], function(XMLView) {
+         sap.ui.require(["sap/ui/core/mvc/XMLView"], XMLView => {
             XMLView.create({
-               id: panelid,
+               id: "TopPanelId",
                viewName: viewName,
-               viewData: { handle: panel_handle }
-            }).then(function(oView) {
-               oView.placeAt("PanelDiv");
-            });
+               viewData: { handle: handle }
+            }).then(oView => oView.placeAt("PanelDiv"));
 
          });
-      }
 
-      JSROOT.ConnectWebWindow({
-         prereq_logdiv: "PanelDiv",
-         // openui5src: "jsroot",
-         // openui5src: "https://openui5.hana.ondemand.com/",
-         // openui5libs: "sap.ui.core, sap.ui.layout, sap.m",
-         first_recv: "SHOWPANEL:",
-         prereq2: "openui5",
-         callback: ShowOpenui5Panel
       });
 
    </script>


### PR DESCRIPTION
1. Replace older JSROOT v5 calls by actual code like JSROOT.connectWebWindow
2. More use of Promises in ROOT openui5 widgets
3. Rename `RObjectDrawable` to `TObjectDrawable` to emphasize that `TObject` is placed into `RCanvas` 
4. Provide support of ROOT6 gStyle, palette and colors when drawing ROOT6 objects in `RCanvas`
5. Make GED working with ROOT6 objects inside RCanvas
6. Providing preliminary `TAxis` GED
7. Fix problem with SVG and PNG production after JSROOT upgrade
8. Fix openui5 resize glitch - redraw only when real HTML element size is implemented