### PR TITLE
Fix Jira issue #ROOT-7968

### DIFF
--- a/tmva/tmva/inc/TMVA/MsgLogger.h
+++ b/tmva/tmva/inc/TMVA/MsgLogger.h
@@ -74,7 +74,7 @@ namespace TMVA {
       std::string GetPrintedSource()   const;
       std::string GetFormattedSource() const;
 
-      static UInt_t GetMaxSourceSize() { return static_cast<UInt_t>(fgMaxSourceSize); }
+      static UInt_t GetMaxSourceSize();
 
       // Needed for copying
       MsgLogger& operator= ( const MsgLogger& parent );

--- a/tmva/tmva/src/MsgLogger.cxx
+++ b/tmva/tmva/src/MsgLogger.cxx
@@ -166,6 +166,14 @@ std::string TMVA::MsgLogger::GetFormattedSource() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// returns the maximum source size
+
+UInt_t TMVA::MsgLogger::GetMaxSourceSize()
+{
+   return static_cast<UInt_t>(fgMaxSourceSize);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// the full logger prefix
 
 std::string TMVA::MsgLogger::GetPrintedSource() const


### PR DESCRIPTION
Outline the `TMVA::MsgLogger::GetMaxSourceSize()` method returning the `fgMaxSourceSize` static variable, in order to properly export it on Windows