### PR TITLE
Fix issue #6743 ROOT crashes if a TApplication is not present and tree->StartViewer() is called

### DIFF
--- a/core/gui/inc/TBrowser.h
+++ b/core/gui/inc/TBrowser.h
@@ -48,6 +48,8 @@ protected:
    TContextMenu  *fContextMenu;        //!Context menu pointer
    Bool_t         fNeedRefresh;        //True if the browser needs refresh
 
+   Bool_t         InitGraphics();
+
 public:
    enum EStatusBits {
       kNoHidden     = BIT(9)   // don't show '.' files and directories

--- a/core/gui/src/TBrowser.cxx
+++ b/core/gui/src/TBrowser.cxx
@@ -76,6 +76,26 @@ private:
 ClassImp(TBrowser);
 
 ////////////////////////////////////////////////////////////////////////////////
+// Make sure the application environment exists and the GUI libs are loaded
+
+Bool_t TBrowser::InitGraphics()
+{
+   // Make sure the application environment exists. It is need for graphics
+   // (colors are initialized in the TApplication ctor).
+   if (!gApplication)
+      TApplication::CreateApplication();
+   // make sure that the Gpad and GUI libs are loaded
+   TApplication::NeedGraphicsLibs();
+   if (gApplication)
+      gApplication->InitializeGraphics();
+   if (gROOT->IsBatch()) {
+      Warning("TBrowser", "The ROOT browser cannot run in batch mode");
+      return kFALSE;
+   }
+   return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Create a new browser with a name, title. Width and height are by
 /// default set to 640x400 and (optionally) adjusted by the screen factor
 /// (depending on Rint.Canvas.UseScreenFactor to be true or false, default
@@ -86,9 +106,8 @@ TBrowser::TBrowser(const char *name, const char *title, TBrowserImp *extimp,
    : TNamed(name, title), fLastSelectedObject(0), fImp(extimp), fTimer(0),
      fContextMenu(0), fNeedRefresh(kFALSE)
 {
-   // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   gApplication->InitializeGraphics();
+   if (!InitGraphics())
+      return;
    if (TClass::IsCallingNew() != TClass::kRealNew) {
       fImp = 0;
    } else {
@@ -108,9 +127,8 @@ TBrowser::TBrowser(const char *name, const char *title, UInt_t width,
    : TNamed(name, title), fLastSelectedObject(0), fImp(extimp), fTimer(0), fContextMenu(0),
      fNeedRefresh(kFALSE)
 {
-   // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   gApplication->InitializeGraphics();
+   if (!InitGraphics())
+      return;
    if (!fImp) fImp = gGuiFactory->CreateBrowserImp(this, title, width, height, opt);
    Create();
 }
@@ -123,9 +141,8 @@ TBrowser::TBrowser(const char *name, const char *title, Int_t x, Int_t y,
    : TNamed(name, title), fLastSelectedObject(0), fImp(extimp), fTimer(0), fContextMenu(0),
      fNeedRefresh(kFALSE)
 {
-   // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   gApplication->InitializeGraphics();
+   if (!InitGraphics())
+      return;
    fImp = gGuiFactory->CreateBrowserImp(this, title, x, y, width, height, opt);
    Create();
 }
@@ -137,9 +154,8 @@ TBrowser::TBrowser(const char *name, TObject *obj, const char *title, Option_t *
    : TNamed(name, title), fLastSelectedObject(0), fImp(0), fTimer(0), fContextMenu(0),
      fNeedRefresh(kFALSE)
 {
-   // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   gApplication->InitializeGraphics();
+   if (!InitGraphics())
+      return;
    Float_t cx = gStyle->GetScreenFactor();
    UInt_t w = UInt_t(cx*800);
    UInt_t h = UInt_t(cx*500);
@@ -156,9 +172,8 @@ TBrowser::TBrowser(const char *name, TObject *obj, const char *title,
    : TNamed(name, title), fLastSelectedObject(0), fTimer(0), fContextMenu(0),
      fNeedRefresh(kFALSE)
 {
-   // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   gApplication->InitializeGraphics();
+   if (!InitGraphics())
+      return;
    fImp = gGuiFactory->CreateBrowserImp(this, title, width, height, opt);
    Create(obj);
 }
@@ -172,9 +187,8 @@ TBrowser::TBrowser(const char *name, TObject *obj, const char *title,
    : TNamed(name, title), fLastSelectedObject(0), fTimer(0), fContextMenu(0),
      fNeedRefresh(kFALSE)
 {
-   // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   gApplication->InitializeGraphics();
+   if (!InitGraphics())
+      return;
    fImp = gGuiFactory->CreateBrowserImp(this, title, x, y, width, height, opt);
    Create(obj);
 }
@@ -187,9 +201,8 @@ TBrowser::TBrowser(const char *name, void *obj, TClass *cl,
    : TNamed(name, title), fLastSelectedObject(0), fTimer(0), fContextMenu(0),
      fNeedRefresh(kFALSE)
 {
-   // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   gApplication->InitializeGraphics();
+   if (!InitGraphics())
+      return;
    Float_t cx = gStyle->GetScreenFactor();
    UInt_t w = UInt_t(cx*800);
    UInt_t h = UInt_t(cx*500);
@@ -208,9 +221,8 @@ TBrowser::TBrowser(const char *name, void *obj, TClass *cl,
    : TNamed(name, title), fLastSelectedObject(0), fTimer(0), fContextMenu(0),
      fNeedRefresh(kFALSE)
 {
-   // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   gApplication->InitializeGraphics();
+   if (!InitGraphics())
+      return;
    fImp = gGuiFactory->CreateBrowserImp(this, title, width, height, opt);
    Create(new TBrowserObject(obj,cl,objname));
 }
@@ -225,9 +237,8 @@ TBrowser::TBrowser(const char *name,void *obj,  TClass *cl,
    : TNamed(name, title), fLastSelectedObject(0), fTimer(0), fContextMenu(0),
      fNeedRefresh(kFALSE)
 {
-   // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   gApplication->InitializeGraphics();
+   if (!InitGraphics())
+      return;
    fImp = gGuiFactory->CreateBrowserImp(this, title, x, y, width, height, opt);
    Create(new TBrowserObject(obj,cl,objname));
 }

--- a/gui/gui/src/TGWindow.cxx
+++ b/gui/gui/src/TGWindow.cxx
@@ -33,6 +33,7 @@
 #include "TVirtualX.h"
 #include "TApplication.h"
 #include "TError.h"
+#include "TSystem.h"
 
 ClassImp(TGWindow);
 ClassImp(TGUnknownWindowHandler);
@@ -57,7 +58,7 @@ TGWindow::TGWindow(const TGWindow *p, Int_t x, Int_t y, UInt_t w, UInt_t h,
       ::Error("TGWindow::TGWindow",
               "gClient and gApplication are nullptr!\n"
               "Please add a TApplication instance in the main() function of your application\n");
-      std::exit(EXIT_FAILURE);
+      gSystem->Exit(1);
    }
 
    if (!p && gClient) {

--- a/gui/gui/src/TGWindow.cxx
+++ b/gui/gui/src/TGWindow.cxx
@@ -31,6 +31,8 @@
 #include "TGWindow.h"
 #include <iostream>
 #include "TVirtualX.h"
+#include "TApplication.h"
+#include "TError.h"
 
 ClassImp(TGWindow);
 ClassImp(TGUnknownWindowHandler);
@@ -50,6 +52,13 @@ TGWindow::TGWindow(const TGWindow *p, Int_t x, Int_t y, UInt_t w, UInt_t h,
    fId = 0;
    fParent = 0;
    fNeedRedraw = kFALSE;
+
+   if (!p && !gClient && !gApplication) {
+      ::Error("TGWindow::TGWindow",
+              "gClient and gApplication are nullptr!\n"
+              "Please add a TApplication instance in the main() function of your application\n");
+      std::exit(EXIT_FAILURE);
+   }
 
    if (!p && gClient) {
       p = gClient->GetRoot();

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -24,6 +24,7 @@ extra libraries (Histogram, display, etc).
 #include <fstream>
 
 #include "TROOT.h"
+#include "TApplication.h"
 #include "TSystem.h"
 #include "TFile.h"
 #include "TEventList.h"
@@ -2947,8 +2948,14 @@ void TTreePlayer::SetEstimate(Long64_t n)
 
 void TTreePlayer::StartViewer(Int_t ww, Int_t wh)
 {
+   if (!gApplication)
+      TApplication::CreateApplication();
+   // make sure that the Gpad and GUI libs are loaded
+   TApplication::NeedGraphicsLibs();
+   if (gApplication)
+      gApplication->InitializeGraphics();
    if (gROOT->IsBatch()) {
-      Warning("StartViewer", "viewer cannot run in batch mode");
+      Warning("StartViewer", "The tree viewer cannot run in batch mode");
       return;
    }
 


### PR DESCRIPTION
Fixes #6743 ROOT crashes with no helpful error messages if a TApplication is not present and tree->StartViewer() is called. Now it prints the following warning:
```
Warning in <TTreePlayer::StartViewer>: The tree viewer cannot run in batch mode
```