### PR TITLE
fixed copy ctor; fUseGrad setting in MnApplication was lost before

### DIFF
--- a/math/minuit2/inc/Minuit2/MnMigrad.h
+++ b/math/minuit2/inc/Minuit2/MnMigrad.h
@@ -72,8 +72,6 @@ public:
    /// construct from FCNGradientBase + MnUserParameterState + MnStrategy
    MnMigrad(const FCNGradientBase& fcn, const MnUserParameterState& par, const MnStrategy& str) : MnApplication(fcn, MnUserParameterState(par), str), fMinimizer(VariableMetricMinimizer()) {}
 
-   MnMigrad(const MnMigrad& migr) : MnApplication(migr.Fcnbase(), migr.State(), migr.Strategy(), migr.NumOfCalls()), fMinimizer(migr.fMinimizer) {}
-
    ~MnMigrad() {}
 
    ModularFunctionMinimizer& Minimizer() {return fMinimizer;}

--- a/math/minuit2/inc/Minuit2/MnMigrad.h
+++ b/math/minuit2/inc/Minuit2/MnMigrad.h
@@ -74,6 +74,12 @@ public:
 
    ~MnMigrad() {}
 
+   /// Copy constructor, copy shares the reference to the same FCNBase in MnApplication
+   MnMigrad(const MnMigrad&) = default;
+
+   // Copy assignment deleted, since MnApplication has unassignable reference to FCNBase
+   MnMigrad& operator=(const MnMigrad&) = delete;
+
    ModularFunctionMinimizer& Minimizer() {return fMinimizer;}
    const ModularFunctionMinimizer& Minimizer() const {return fMinimizer;}
 

--- a/math/minuit2/inc/Minuit2/MnMigrad.h
+++ b/math/minuit2/inc/Minuit2/MnMigrad.h
@@ -81,10 +81,6 @@ private:
 
    VariableMetricMinimizer fMinimizer;
 
-private:
-
-   //forbidden assignment of migrad (const FCNBase& = )
-   MnMigrad& operator=(const MnMigrad&) {return *this;}
 };
 
   }  // namespace Minuit2


### PR DESCRIPTION
This patch removes a wrongly implemented copy constructor, which lost the fUseGrad setting (if it was `true` in the original, the copy had `false`), effectively replacing it with the default copy ctor, which is perfectly fine here.