### PR TITLE
Minuit2 remove unnecessary assert

### DIFF
--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -75,7 +75,7 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
    FunctionMinimum min(seed, fcn.Up());
 
    if (seed.Parameters().Vec().size() == 0) {
-      print.Error("No free parameters.");
+      print.Warn("No free parameters.");
       return min;
    }
 

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -218,7 +218,6 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
    MnAlgebraicVector prevStep(initialState.Gradient().Vec().size());
 
    MinimumState s0 = result.back();
-   assert(s0.IsValid());
 
    do {
 

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -143,6 +143,11 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
 
          AddResult(result, st);
 
+         if (!st.IsValid()) {
+           print.Warn("Invalid Hessian - exit the minimization");
+           break;
+         }
+
          // check new edm
          edm = st.Edm();
 

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -229,8 +229,6 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
    MnAlgebraicVector prevStep(initialState.Gradient().Vec().size());
 
    MinimumState s0 = result.back();
-   if (!s0.IsValid())
-     print.Warn("Initial state invalid, this should not happen");
 
    do {
 

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -69,14 +69,20 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
    // at exit of this function the BuilderPrintLevelConf object is destructed and automatically the
    // previous level will be restored
 
-   if (seed.Parameters().Vec().size() == 0) {
-      return FunctionMinimum(seed, fcn.Up());
-   }
-
    //   double edm = Estimator().Estimate(seed.Gradient(), seed.Error());
    double edm = seed.State().Edm();
 
    FunctionMinimum min(seed, fcn.Up());
+
+   if (seed.Parameters().Vec().size() == 0) {
+      print.Error("No free parameters.");
+      return min;
+   }
+
+   if (!seed.IsValid()) {
+     print.Error("Minimum seed invalid.");
+     return min;
+   }
 
    if (edm < 0.) {
       print.Error("Initial matrix not pos.def.");

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -218,6 +218,8 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
    MnAlgebraicVector prevStep(initialState.Gradient().Vec().size());
 
    MinimumState s0 = result.back();
+   if (!s0.IsValid())
+     print.Warn("Initial state invalid, this should not happen");
 
    do {
 


### PR DESCRIPTION
This patch removes an unnecessary assert, which is probably a left-over from early debugging.

Asserts are a way to document certain runtime assumptions that the code makes. They should be only used if the code cannot run correctly if the condition is not fulfilled. This assert here does not serve that purpose. Starting the minimization iteration with an invalid initial state is fine as far as the algorithm is concerned, because it does not make use of that property.

Edit: This is not a cosmetic change, because this assert triggers an abort in one of the iminuit tests if the code is compiled in debug mode, while the test runs fine in release mode.