### PR TITLE
v6.22: Fix 6767 missing TStreamerInfo update during TClass reload.

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -309,6 +309,8 @@ private:
    // if no entries have been made.)
    static THashTable* fgClassTypedefHash;
 
+   TVirtualStreamerInfo     *GetStreamerInfoImpl(Int_t version, Bool_t silent) const;
+
 private:
    TClass(const TClass& tc) = delete;
    TClass& operator=(const TClass&) = delete;
@@ -348,7 +350,7 @@ public:
    void               AdoptSchemaRules( ROOT::Detail::TSchemaRuleSet *rules );
    virtual void       Browse(TBrowser *b);
    void               BuildRealData(void *pointer=0, Bool_t isTransient = kFALSE);
-   void               BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl);
+   void               BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl, Bool_t isTransient = kFALSE);
    void               CalculateStreamerOffset() const;
    Bool_t             CallShowMembers(const void* obj, TMemberInspector &insp, Bool_t isTransient = kFALSE) const;
    Bool_t             CanSplit() const;
@@ -360,7 +362,7 @@ public:
    void               Dump() const { TDictionary::Dump(); }
    void               Dump(const void *obj, Bool_t noAddr = kFALSE) const;
    char              *EscapeChars(const char *text) const;
-   TVirtualStreamerInfo     *FindStreamerInfo(UInt_t checksum) const;
+   TVirtualStreamerInfo     *FindStreamerInfo(UInt_t checksum, Bool_t isTransient = kFALSE) const;
    TVirtualStreamerInfo     *GetConversionStreamerInfo( const char* onfile_classname, Int_t version ) const;
    TVirtualStreamerInfo     *FindConversionStreamerInfo( const char* onfile_classname, UInt_t checksum ) const;
    TVirtualStreamerInfo     *GetConversionStreamerInfo( const TClass* onfile_cl, Int_t version ) const;
@@ -451,7 +453,7 @@ public:
    ClassStreamerFunc_t GetStreamerFunc() const;
    ClassConvStreamerFunc_t GetConvStreamerFunc() const;
    const TObjArray          *GetStreamerInfos() const { return fStreamerInfo; }
-   TVirtualStreamerInfo     *GetStreamerInfo(Int_t version=0) const;
+   TVirtualStreamerInfo     *GetStreamerInfo(Int_t version=0, Bool_t isTransient = kFALSE) const;
    TVirtualStreamerInfo     *GetStreamerInfoAbstractEmulated(Int_t version=0) const;
    TVirtualStreamerInfo     *FindStreamerInfoAbstractEmulated(UInt_t checksum) const;
    const std::type_info     *GetTypeInfo() const { return fTypeInfo; };

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -164,12 +164,12 @@ protected:
    TVirtualStreamerInfo *fStreamerInfo; //!Pointer to the current StreamerInfo for the baset class.
    TString               fErrorMsg;     //!Error message in case of checksum/version mismatch.
 
-   void InitStreaming();
+   void InitStreaming(Bool_t isTransient);
 
 public:
 
    TStreamerBase();
-   TStreamerBase(const char *name, const char *title, Int_t offset);
+   TStreamerBase(const char *name, const char *title, Int_t offset, Bool_t isTransient = kFALSE);
    virtual         ~TStreamerBase();
    Int_t            GetBaseVersion() {return fBaseVersion;}
    UInt_t           GetBaseCheckSum() {return fBaseCheckSum;}
@@ -181,10 +181,11 @@ public:
    Int_t            GetSize() const;
    TVirtualStreamerInfo *GetBaseStreamerInfo () const { return fStreamerInfo; }
    virtual void     Init(TVirtualStreamerInfo *obj=0);
+   void             Init(Bool_t isTransient = kFALSE);
    Bool_t           IsBase() const;
    virtual void     ls(Option_t *option="") const;
    Int_t            ReadBuffer (TBuffer &b, char *pointer);
-   void             SetNewBaseClass( TClass* cl ) { fNewBaseClass = cl; InitStreaming(); }
+   void             SetNewBaseClass( TClass* cl ) { fNewBaseClass = cl; InitStreaming(kFALSE); }
    void             SetBaseVersion(Int_t v) {fBaseVersion = v;}
    void             SetBaseCheckSum(UInt_t cs) {fBaseCheckSum = cs;}
    void             SetErrorMessage(const char *msg) { fErrorMsg = msg; }

--- a/core/meta/inc/TVirtualStreamerInfo.h
+++ b/core/meta/inc/TVirtualStreamerInfo.h
@@ -126,7 +126,7 @@ public:
    TVirtualStreamerInfo();
    TVirtualStreamerInfo(TClass * /*cl*/);
    virtual            ~TVirtualStreamerInfo();
-   virtual void        Build() = 0;
+   virtual void        Build(Bool_t isTransient = kFALSE) = 0;
    virtual void        BuildCheck(TFile *file = 0, Bool_t load = kTRUE) = 0;
    virtual void        BuildEmulated(TFile *file) = 0;
    virtual void        BuildOld() = 0;

--- a/core/meta/inc/TVirtualStreamerInfo.h
+++ b/core/meta/inc/TVirtualStreamerInfo.h
@@ -185,8 +185,8 @@ public:
    // provokes the creation of the corresponding TClass.  This relies on the dictionary for
    // std::pair<const int, int> to already exist (or the interpreter information being available)
    // as it is used as a template.
-   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &pairclassname) = 0;
-   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &firstname, const std::string &secondname) = 0;
+   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &pairclassname, bool silent) = 0;
+   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &firstname, const std::string &secondname, bool silent) = 0;
 
    virtual TVirtualCollectionProxy *GenEmulatedProxy(const char* class_name, Bool_t silent) = 0;
    virtual TClassStreamer *GenEmulatedClassStreamer(const char* class_name, Bool_t silent) = 0;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3087,7 +3087,7 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent)
    if (cl) return cl;
 
    if (ispair) {
-      auto pairinfo = TVirtualStreamerInfo::Factory()->GenerateInfoForPair(normalizedName);
+      auto pairinfo = TVirtualStreamerInfo::Factory()->GenerateInfoForPair(normalizedName, silent);
       return pairinfo ? pairinfo->GetClass() : nullptr;
 
    } else if (TClassEdit::IsSTLCont( normalizedName.c_str() )) {

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -2011,7 +2011,7 @@ void TClass::BuildRealData(void* pointer, Bool_t isTransient)
    if (!HasInterpreterInfo() || TClassEdit::IsSTLCont(GetName(), 0) || TClassEdit::IsSTLBitset(GetName())) {
       // We are an emulated class or an STL container.
       fRealData = new TList;
-      BuildEmulatedRealData("", 0, this);
+      BuildEmulatedRealData("", 0, this, isTransient);
       return;
    }
 
@@ -2070,7 +2070,7 @@ void TClass::BuildRealData(void* pointer, Bool_t isTransient)
 ////////////////////////////////////////////////////////////////////////////////
 /// Build the list of real data for an emulated class
 
-void TClass::BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl)
+void TClass::BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl, Bool_t isTransient)
 {
    R__LOCKGUARD(gInterpreterMutex);
 
@@ -2078,7 +2078,7 @@ void TClass::BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl)
    if (Property() & kIsAbstract) {
       info = GetStreamerInfoAbstractEmulated();
    } else {
-      info = GetStreamerInfo();
+      info = GetStreamerInfoImpl(fClassVersion, isTransient);
    }
    if (!info) {
       // This class is abstract, but we don't yet have a SteamerInfo for it ...
@@ -2107,7 +2107,7 @@ void TClass::BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl)
          cl->GetListOfRealData()->Add(rd);
          // Now we a dot
          rdname.Form("%s%s.",name,element->GetFullName());
-         if (cle) cle->BuildEmulatedRealData(rdname,offset+eoffset,cl);
+         if (cle) cle->BuildEmulatedRealData(rdname,offset+eoffset,cl, isTransient);
       } else {
          //others
          TString rdname; rdname.Form("%s%s",name,element->GetFullName());
@@ -2129,7 +2129,7 @@ void TClass::BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl)
          //base class
          Long_t eoffset = element->GetOffset();
          TClass *cle    = element->GetClassPointer();
-         if (cle) cle->BuildEmulatedRealData(name,offset+eoffset,cl);
+         if (cle) cle->BuildEmulatedRealData(name,offset+eoffset,cl, isTransient);
       }
    }
 }
@@ -4546,7 +4546,7 @@ Int_t TClass::GetNmethods()
 ///           with TStreamer::Optimize()!
 ///
 
-TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
+TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */, Bool_t isTransient /* = false */) const
 {
    TVirtualStreamerInfo *sinfo = fLastReadInfo;
 
@@ -4576,6 +4576,13 @@ TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
 
    R__LOCKGUARD(gInterpreterMutex);
 
+   return GetStreamerInfoImpl(version, isTransient);
+};
+
+// Implementation of/for TStreamerInfo::GetStreamerInfo.
+// This routine assumes the global lock has been taken.
+TVirtualStreamerInfo* TClass::GetStreamerInfoImpl(Int_t version, Bool_t silent) const
+{
    // Warning: version may be -1 for an emulated class, or -2 if the
    //          user requested the emulated streamerInfo for an abstract
    //          base class, even though we have a dictionary for it.
@@ -4586,7 +4593,7 @@ TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
       version = fClassVersion;
    }
 
-   sinfo = (TVirtualStreamerInfo *)fStreamerInfo->At(version);
+   TVirtualStreamerInfo *sinfo = (TVirtualStreamerInfo *)fStreamerInfo->At(version);
 
    if (!sinfo && (version != fClassVersion)) {
       // When the requested version does not exist we return
@@ -4609,7 +4616,7 @@ TVirtualStreamerInfo* TClass::GetStreamerInfo(Int_t version /* = 0 */) const
       if (HasDataMemberInfo() || fCollectionProxy) {
          // If we do not have a StreamerInfo for this version and we do not
          // have dictionary information nor a proxy, there is nothing to build!
-         sinfo->Build();
+         sinfo->Build(silent);
       }
    } else {
       if (!sinfo->IsCompiled()) {
@@ -6848,15 +6855,17 @@ void TClass::SetDirectoryAutoAdd(ROOT::DirAutoAdd_t autoAddFunc)
 ////////////////////////////////////////////////////////////////////////////////
 /// Find the TVirtualStreamerInfo in the StreamerInfos corresponding to checksum
 
-TVirtualStreamerInfo *TClass::FindStreamerInfo(UInt_t checksum) const
+TVirtualStreamerInfo *TClass::FindStreamerInfo(UInt_t checksum, Bool_t isTransient) const
 {
    TVirtualStreamerInfo *guess = fLastReadInfo;
    if (guess && guess->GetCheckSum() == checksum) {
       return guess;
    } else {
-      if (fCheckSum == checksum) return GetStreamerInfo();
+      if (fCheckSum == checksum)
+         return GetStreamerInfo(0, isTransient);
 
       R__LOCKGUARD(gInterpreterMutex);
+
       Int_t ninfos = fStreamerInfo->GetEntriesFast()-1;
       for (Int_t i=-1;i<ninfos;++i) {
          // TClass::fStreamerInfos has a lower bound not equal to 0,

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -4093,7 +4093,6 @@ void TClass::ReplaceWith(TClass *newcl) const
    TIter nextClass(gROOT->GetListOfClasses());
    TClass *acl;
    TVirtualStreamerInfo *info;
-   TList tobedeleted;
 
    // Since we are in the process of replacing a TClass by a TClass
    // coming from a dictionary, there is no point in loading any
@@ -4109,10 +4108,6 @@ void TClass::ReplaceWith(TClass *newcl) const
       }
    }
 
-   TIter delIter( &tobedeleted );
-   while ((acl = (TClass*)delIter())) {
-      delete acl;
-   }
    gInterpreter->UnRegisterTClassUpdate(this);
 }
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3088,7 +3088,9 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent)
 
    if (ispair) {
       auto pairinfo = TVirtualStreamerInfo::Factory()->GenerateInfoForPair(normalizedName, silent);
-      return pairinfo ? pairinfo->GetClass() : nullptr;
+      //return pairinfo ? pairinfo->GetClass() : nullptr;
+      if (pairinfo)
+         return pairinfo->GetClass();
 
    } else if (TClassEdit::IsSTLCont( normalizedName.c_str() )) {
 

--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -346,6 +346,9 @@ void TDataType::SetType(const char *name)
    } else if (!strcmp("signed char", name)) {
       fType = kChar_t; // kDataTypeAliasSignedChar_t;
       fSize = sizeof(Char_t);
+   } else if (!strcmp("void", name)) {
+      fType = kVoid_t;
+      fSize = 0;
    }
 
    if (!strcmp("Float16_t", fName.Data())) {

--- a/core/meta/src/TProtoClass.cxx
+++ b/core/meta/src/TProtoClass.cxx
@@ -96,6 +96,8 @@ TProtoClass::TProtoClass(TClass* cl):
       // - foreach base: base class's data members.
       for (auto realDataObj: *cl->GetListOfRealData()) {
          TRealData *rd = (TRealData*)realDataObj;
+         if (!rd->GetDataMember())
+            continue;
          TProtoRealData protoRealData(rd);
 
          if (TClass* clRD = rd->GetDataMember()->GetClass())
@@ -396,6 +398,7 @@ TProtoClass::TProtoRealData::TProtoRealData(const TRealData* rd):
    fStatusFlag(0)
 {
    TDataMember * dm = rd->GetDataMember();
+   assert(rd->GetDataMember());
    TClass * cl = dm->GetClass();
    assert(cl != NULL);
    fDMIndex = DataMemberIndex(cl,dm->GetName());

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -630,7 +630,7 @@ TStreamerBase::TStreamerBase() :
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TStreamerBase::TStreamerBase(const char *name, const char *title, Int_t offset)
+TStreamerBase::TStreamerBase(const char *name, const char *title, Int_t offset, Bool_t isTransient)
    : TStreamerElement(name,title,offset,TVirtualStreamerInfo::kBase,"BASE"),
      // Abuse TStreamerElement data member that is not used by TStreamerBase
      fBaseCheckSum( *( (UInt_t*)&(fMaxIndex[1]) ) ),
@@ -654,7 +654,7 @@ TStreamerBase::TStreamerBase(const char *name, const char *title, Int_t offset)
       fBaseVersion = 0;
    }
    fNewBaseClass = 0;
-   Init();
+   Init(isTransient);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -689,16 +689,21 @@ Int_t TStreamerBase::GetSize() const
 
 void TStreamerBase::Init(TVirtualStreamerInfo *)
 {
+   Init(kFALSE);
+}
+
+void TStreamerBase::Init(Bool_t isTransient)
+{
    fBaseClass = TClass::GetClass(GetName());
    if (!fBaseClass) return;
 
-   InitStreaming();
+   InitStreaming(isTransient);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Setup the fStreamerFunc and fStreamerinfo
 
-void TStreamerBase::InitStreaming()
+void TStreamerBase::InitStreaming(Bool_t isTransient)
 {
    if (fNewBaseClass) {
       fStreamerFunc = fNewBaseClass->GetStreamerFunc();
@@ -712,9 +717,9 @@ void TStreamerBase::InitStreaming()
       fStreamerFunc = fBaseClass->GetStreamerFunc();
       fConvStreamerFunc = fBaseClass->GetConvStreamerFunc();
       if (fBaseVersion >= 0 || fBaseCheckSum == 0) {
-         fStreamerInfo = fBaseClass->GetStreamerInfo(fBaseVersion);
+         fStreamerInfo = fBaseClass->GetStreamerInfo(fBaseVersion, isTransient);
       } else {
-         fStreamerInfo = fBaseClass->FindStreamerInfo(fBaseCheckSum);
+         fStreamerInfo = fBaseClass->FindStreamerInfo(fBaseCheckSum, isTransient);
       }
    } else {
       fStreamerFunc = 0;
@@ -843,14 +848,14 @@ void TStreamerBase::Update(const TClass *oldClass, TClass *newClass)
 
    if (fBaseClass == oldClass) {
       fBaseClass = newClass;
-      InitStreaming();
+      InitStreaming(kFALSE);
    } else if (fBaseClass == nullptr) {
       if (fName == newClass->GetName()) {
          fBaseClass = newClass;
-         InitStreaming();
+         InitStreaming(kFALSE);
       } else if (TClassTable::GetDict(fName)) {
          fBaseClass = TClass::GetClass(fName);
-         InitStreaming();
+         InitStreaming(kFALSE);
       }
    }
 }

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -265,7 +265,7 @@ public:
    Int_t               ReadBufferClones(TBuffer &b, TClonesArray *clones, Int_t nc, Int_t first, Int_t eoffset);
    Int_t               ReadBufferSTL(TBuffer &b, TVirtualCollectionProxy *cont, Int_t nc, Int_t eoffset, Bool_t v7 = kTRUE );
    void                SetCheckSum(UInt_t checksum) {fCheckSum = checksum;}
-   void                SetClass(TClass *cl) {fClass = cl;}
+   void                SetClass(TClass *cl);
    void                SetClassVersion(Int_t vers) {fClassVersion=vers;}
    void                SetOnFileClassVersion(Int_t vers) {fOnFileClassVersion=vers;}
    void                TagFile(TFile *fFile);

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -190,7 +190,7 @@ public:
    TStreamerInfo();
    TStreamerInfo(TClass *cl);
    virtual            ~TStreamerInfo();
-   void                Build();
+   void                Build(Bool_t isTransient = kFALSE);
    void                BuildCheck(TFile *file = 0, Bool_t load = kTRUE);
    void                BuildEmulated(TFile *file);
    void                BuildOld();

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -283,8 +283,8 @@ public:
    // provokes the creation of the corresponding TClass.  This relies on the dictionary for
    // std::pair<const int, int> to already exist (or the interpreter information being available)
    // as it is used as a template.
-   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &pairclassname);
-   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &firstname, const std::string &secondname);
+   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &pairclassname, bool silent);
+   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &firstname, const std::string &secondname, bool silent);
 
    virtual TVirtualCollectionProxy *GenEmulatedProxy(const char* class_name, Bool_t silent);
    virtual TClassStreamer *GenEmulatedClassStreamer(const char* class_name, Bool_t silent);

--- a/io/io/src/TEmulatedCollectionProxy.cxx
+++ b/io/io/src/TEmulatedCollectionProxy.cxx
@@ -113,7 +113,7 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
    if (fClass) return this;
 
 
-   TClass *cl = TClass::GetClass(fName.c_str());
+   TClass *cl = TClass::GetClass(fName.c_str(), kTRUE, silent);
    fEnv = 0;
    fKey = 0;
    if ( cl )  {
@@ -181,7 +181,7 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
                   GenerateTemporaryTEnum keyEnum(fKey->fCase, inside[1]);
                   GenerateTemporaryTEnum valueEnum(fVal->fCase, inside[2]);
 
-                  if (0==TClass::GetClass(nam.c_str())) {
+                  if (0==TClass::GetClass(nam.c_str(), kTRUE, silent)) {
                      // We need to emulate the pair
                      TVirtualStreamerInfo::Factory()->GenerateInfoForPair(inside[1],inside[2], silent);
                   }

--- a/io/io/src/TEmulatedCollectionProxy.cxx
+++ b/io/io/src/TEmulatedCollectionProxy.cxx
@@ -40,8 +40,6 @@ the class TEmulatedMapProxy.
 // a dictionary (See end of file for implementation
 //
 
-TStreamerInfo *R__GenerateTClassForPair(const std::string &f, const std::string &s);
-
 TEmulatedCollectionProxy::TEmulatedCollectionProxy(const TEmulatedCollectionProxy& copy)
    : TGenCollectionProxy(copy)
 {
@@ -185,7 +183,7 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
 
                   if (0==TClass::GetClass(nam.c_str())) {
                      // We need to emulate the pair
-                     R__GenerateTClassForPair(inside[1],inside[2]);
+                     TVirtualStreamerInfo::Factory()->GenerateInfoForPair(inside[1],inside[2], silent);
                   }
                }
                fValue = new Value(nam,silent);
@@ -643,9 +641,4 @@ void TEmulatedCollectionProxy::Streamer(TBuffer &b)
          WriteItems(nElements, b);
       }
    }
-}
-
-TStreamerInfo *R__GenerateTClassForPair(const std::string &fname, const std::string &sname)
-{
-   return (TStreamerInfo*)TVirtualStreamerInfo::Factory()->GenerateInfoForPair(fname, sname);
 }

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -27,9 +27,6 @@
 
 #define MESSAGE(which,text)
 
-// See TEmulatedCollectionProxy.cxx
-extern TStreamerInfo *R__GenerateTClassForPair(const std::string &f, const std::string &s);
-
 /**
 \class TGenVectorProxy
 \ingroup IO
@@ -470,7 +467,7 @@ TGenCollectionProxy::Value::Value(const std::string& inside_type, Bool_t silent)
                if ( prop&kIsFundamental ) {
                   fundType = gROOT->GetType( intype.c_str() );
                   if (fundType==0) {
-                     if (intype != "long double") {
+                     if (intype != "long double" && !silent) {
                         Error("TGenCollectionProxy","Unknown fundamental type %s",intype.c_str());
                      }
                      fSize = sizeof(int);
@@ -886,7 +883,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
                   TInterpreter::SuspendAutoParsing autoParseRaii(gCling);
                   if (0==TClass::GetClass(nam.c_str())) {
                      // We need to emulate the pair
-                     R__GenerateTClassForPair(inside[1],inside[2]);
+                     TVirtualStreamerInfo::Factory()->GenerateInfoForPair(inside[1],inside[2], silent);
                   }
                }
                newfValue = R__CreateValue(nam, silent);

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -453,18 +453,20 @@ TGenCollectionProxy::Value::Value(const std::string& inside_type, Bool_t silent)
                if ( prop&kIsStruct ) {
                   prop |= kIsClass;
                }
-               // Since we already searched GetClass earlier, this should
-               // never be true.
-               R__ASSERT(! (prop&kIsClass) && "Impossible code path" );
-//               if ( prop&kIsClass ) {
-//                  fType = TClass::GetClass(intype.c_str(),kTRUE,silent);
-//                  R__ASSERT(fType);
-//                  fCtor   = fType->GetNew();
-//                  fDtor   = fType->GetDestructor();
-//                  fDelete = fType->GetDelete();
-//               }
-//               else
-               if ( prop&kIsFundamental ) {
+
+               if ( prop&kIsClass ) {
+                  // We can get here in the case where the value if forward declared or
+                  // is an std::pair that can not be (yet) emulated (eg. "std::pair<int,void*>")
+                  fSize = std::string::npos;
+                  if (!silent)
+                     Error("TGenCollectionProxy", "Could not retrieve the TClass for %s", intype.c_str());
+//                fType = TClass::GetClass(intype.c_str(),kTRUE,silent);
+//                R__ASSERT(fType);
+//                fCtor   = fType->GetNew();
+//                fDtor   = fType->GetDestructor();
+//                fDelete = fType->GetDelete();
+               }
+               else if ( prop&kIsFundamental ) {
                   fundType = gROOT->GetType( intype.c_str() );
                   if (fundType==0) {
                      if (intype != "long double" && !silent) {

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5554,7 +5554,7 @@ TStreamerInfo::GenExplicitClassStreamer( const ::ROOT::TCollectionProxyInfo &inf
 //
 // Utility functions
 //
-static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std::string &dmFull, Int_t offset)
+static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std::string &dmFull, Int_t offset, bool silent)
 {
    // Create a TStreamerElement for the type 'dmFull' and whose data member name is 'dmName'.
 
@@ -5569,8 +5569,9 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
       dtype = dt->GetType();
       dsize = dt->Size();
       if (dmIsPtr && dtype != kCharStar) {
-         Error("Pair Emulation Building","%s is not yet supported in pair emulation",
-               dmFull.c_str());
+         if (!silent)
+            Error("Pair Emulation Building","%s is not yet supported in pair emulation",
+                  dmFull.c_str());
          return 0;
       } else {
          TStreamerElement *el = new TStreamerBasicType(dmName,dmTitle,offset,dtype,dmFull.c_str());
@@ -5625,7 +5626,7 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
 // provoke the creation of the corresponding TClass.  This relies on the dictionary for
 // std::pair<const int, int> to already exist (or the interpreter information being available)
 // as it is used as a template.
-TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firstname, const std::string &secondname)
+TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firstname, const std::string &secondname, bool silent)
 {
    // Generate a TStreamerInfo for a std::pair<fname,sname>
    // This TStreamerInfo is then used as if it was read from a file to generate
@@ -5637,7 +5638,7 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
    i->SetName(pname.c_str());
    i->SetClass(nullptr);
    i->GetElements()->Delete();
-   TStreamerElement *fel = R__CreateEmulatedElement("first", firstname, 0);
+   TStreamerElement *fel = R__CreateEmulatedElement("first", firstname, 0, silent);
    Int_t size = 0;
    if (fel) {
       i->GetElements()->Add( fel );
@@ -5650,7 +5651,7 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
       delete i;
       return 0;
    }
-   TStreamerElement *second = R__CreateEmulatedElement("second", secondname, size);
+   TStreamerElement *second = R__CreateEmulatedElement("second", secondname, size, silent);
    if (second) {
       i->GetElements()->Add( second );
    } else {
@@ -5666,11 +5667,12 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
    return i;
 }
 
-TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &pairclassname)
+TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &pairclassname, bool silent)
 {
    const static int pairlen = strlen("pair<");
    if (pairclassname.compare(0, pairlen, "pair<") != 0) {
-      Error("GenerateInfoForPair", "The class name passed is not a pair: %s", pairclassname.c_str());
+      if (!silent)
+         Error("GenerateInfoForPair", "The class name passed is not a pair: %s", pairclassname.c_str());
       return nullptr;
    }
 
@@ -5678,9 +5680,10 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &pair
    int nested = 0;
    int num = TClassEdit::GetSplit(pairclassname.c_str(), inside, nested);
    if (num != 4) {
-      Error("GenerateInfoForPair", "Could not find the pair arguments in %s", pairclassname.c_str());
+      if (!silent)
+         Error("GenerateInfoForPair", "Could not find the pair arguments in %s", pairclassname.c_str());
       return nullptr;
    }
 
-   return GenerateInfoForPair(inside[1], inside[2]);
+   return GenerateInfoForPair(inside[1], inside[2], silent);
 }

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5135,6 +5135,18 @@ void TStreamerInfo::PrintValueSTL(const char *name, TVirtualCollectionProxy *con
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Replace the TClass this streamerInfo is pointing to (belongs to)
+
+void TStreamerInfo::SetClass(TClass *newcl)
+{
+   if (newcl) {
+      // This is mostly (but not only) for the artificial "This" streamerElement for an stl collection.
+      Update(fClass, newcl);
+   }
+   fClass = newcl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Stream an object of class TStreamerInfo.
 
 void TStreamerInfo::Streamer(TBuffer &R__b)

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5624,6 +5624,8 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
          }
          return nullptr;
       }
+      if (clm->GetState() <= TClass::kForwardDeclared)
+         return nullptr;
       // a pointer to a class
       if ( dmIsPtr ) {
          if (clm->IsTObject()) {

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -255,7 +255,7 @@ namespace {
 ///
 /// A list of TStreamerElement derived classes is built by scanning
 /// one by one the list of data members of the analyzed class.
-void TStreamerInfo::Build()
+void TStreamerInfo::Build(Bool_t isTransient)
 {
    // Did another thread already do the work?
    if (fIsCompiled) return;
@@ -292,7 +292,7 @@ void TStreamerInfo::Build()
 
    TStreamerElement::Class()->IgnoreTObjectStreamer();
 
-   fClass->BuildRealData();
+   fClass->BuildRealData(nullptr, isTransient);
 
    fCheckSum = fClass->GetCheckSum();
 
@@ -323,8 +323,9 @@ void TStreamerInfo::Build()
             continue;
          }
          if (offset == kNeedObjectForVirtualBaseClass) {
-            Error("Build()", "Cannot stream virtual base %s of class %s",
-                  base->GetName(), fClass->GetName());
+            if (!isTransient)
+               Error("Build()", "Cannot stream virtual base %s of class %s",
+                     base->GetName(), fClass->GetName());
             continue;
          }
          const char* bname  = base->GetName();
@@ -338,13 +339,14 @@ void TStreamerInfo::Build()
             else       element = new TStreamerSTL(bname, btitle, offset, bname, 0, kFALSE);
             if (fClass->IsLoaded() && ((TStreamerSTL*)element)->GetSTLtype() != ROOT::kSTLvector) {
                if (!element->GetClassPointer()->IsLoaded()) {
-                  Error("Build","The class \"%s\" is compiled and its base class \"%s\" is a collection and we do not have a dictionary for it, we will not be able to read or write this base class.",GetName(),bname);
+                  if (!isTransient)
+                     Error("Build","The class \"%s\" is compiled and its base class \"%s\" is a collection and we do not have a dictionary for it, we will not be able to read or write this base class.",GetName(),bname);
                   delete element;
                   continue;
                }
             }
          } else {
-            element = new TStreamerBase(bname, btitle, offset);
+            element = new TStreamerBase(bname, btitle, offset, isTransient);
             TClass* clm = element->GetClassPointer();
             if (!clm) {
                // We have no information about the class yet, except that since it
@@ -368,7 +370,7 @@ void TStreamerInfo::Build()
                   // element from being inserted into the compiled info.
                   element->SetType(-1);
                }
-               if (!clm->IsLoaded() && !(isCollection || isString)) {
+               if (!isTransient && !clm->IsLoaded() && !(isCollection || isString)) {
                   // Don't complain about the base classes of collections nor of
                   // std::string.
                   Warning("Build", "%s: base class %s has no streamer or dictionary it will not be saved", GetName(), clm->GetName());
@@ -456,14 +458,16 @@ void TStreamerInfo::Build()
             const char* counterName = dm->GetArrayIndex();
             TRealData* rdCounter = (TRealData*) fClass->GetListOfRealData()->FindObject(counterName);
             if (!rdCounter || rdCounter->TestBit(TRealData::kTransient)) {
-               Error("Build", "%s, discarding: %s %s, illegal %s\n", GetName(), dmFull, dmName, dmTitle);
+               if (!isTransient)
+                  Error("Build", "%s, discarding: %s %s, illegal %s\n", GetName(), dmFull, dmName, dmTitle);
                continue;
             }
             dmCounter = rdCounter->GetDataMember();
             TDataType* dtCounter = dmCounter->GetDataType();
             Bool_t isInteger = dtCounter && ((dtCounter->GetType() == 3) || (dtCounter->GetType() == 13));
             if (!dtCounter || !isInteger) {
-               Error("Build", "%s, discarding: %s %s, illegal [%s] (must be Int_t)\n", GetName(), dmFull, dmName, counterName);
+               if (!isTransient)
+                  Error("Build", "%s, discarding: %s %s, illegal [%s] (must be Int_t)\n", GetName(), dmFull, dmName, counterName);
                continue;
             }
             TStreamerBasicType* bt = TStreamerInfo::GetElementCounter(counterName, dmCounter->GetClass());
@@ -471,7 +475,8 @@ void TStreamerInfo::Build()
                if (dmCounter->GetClass()->Property() & kIsAbstract) {
                   continue;
                }
-               Error("Build", "%s, discarding: %s %s, illegal [%s] must be placed before \n", GetName(), dmFull, dmName, counterName);
+               if (!isTransient)
+                  Error("Build", "%s, discarding: %s %s, illegal [%s] must be placed before \n", GetName(), dmFull, dmName, counterName);
                continue;
             }
          }
@@ -486,7 +491,8 @@ void TStreamerInfo::Build()
             dsize = sizeof(char*);
          }
          if (dtype == kOther_t || dtype == kNoType_t) {
-            Error("Build", "%s, unknown type: %s %s", GetName(), dmFull, dmName);
+            if (!isTransient)
+               Error("Build", "%s, unknown type: %s %s", GetName(), dmFull, dmName);
             continue;
          } else if (dmIsPtr && (dtype != kCharStar)) {
             if (dmCounter) {
@@ -496,7 +502,8 @@ void TStreamerInfo::Build()
                if ((fName == "TString") || (fName == "TClass")) {
                   continue;
                }
-               Error("Build", "%s, discarding: %s %s, no [dimension]\n", GetName(), dmFull, dmName);
+               if (!isTransient)
+                  Error("Build", "%s, discarding: %s %s, no [dimension]\n", GetName(), dmFull, dmName);
                continue;
             }
          } else {
@@ -521,7 +528,8 @@ void TStreamerInfo::Build()
             if (((TStreamerSTL*)element)->GetSTLtype() != ROOT::kSTLvector || hasCustomAlloc) {
                auto printErrorMsg = [&](const char* category)
                   {
-                     Error("Build","The class \"%s\" is %s and for its data member \"%s\" we do not have a dictionary for the collection \"%s\". Because of this, we will not be able to read or write this data member.",GetName(), category, dmName, dmType);
+                     if (!isTransient)
+                        Error("Build","The class \"%s\" is %s and for its data member \"%s\" we do not have a dictionary for the collection \"%s\". Because of this, we will not be able to read or write this data member.",GetName(), category, dmName, dmType);
                   };
                if (fClass->IsLoaded()) {
                   if (!element->GetClassPointer()->IsLoaded()) {
@@ -540,7 +548,8 @@ void TStreamerInfo::Build()
          } else {
             TClass* clm = TClass::GetClass(dmType);
             if (!clm) {
-               Error("Build", "%s, unknown type: %s %s\n", GetName(), dmFull, dmName);
+               if (!isTransient)
+                  Error("Build", "%s, unknown type: %s %s\n", GetName(), dmFull, dmName);
                continue;
             }
             if (isStdArray) {
@@ -557,7 +566,7 @@ void TStreamerInfo::Build()
                      element = new TStreamerObjectPointer(dmName, dmTitle, offset, dmFull);
                   } else {
                      element = new TStreamerObjectAnyPointer(dmName, dmTitle, offset, dmFull);
-                     if (!streamer && !clm->GetStreamer() && !clm->IsLoaded()) {
+                     if (!isTransient && !streamer && !clm->GetStreamer() && !clm->IsLoaded()) {
                         Error("Build", "%s: %s has no streamer or dictionary, data member %s will not be saved", GetName(), dmFull, dmName);
                      }
                   }
@@ -568,7 +577,7 @@ void TStreamerInfo::Build()
                element = new TStreamerString(dmName, dmTitle, offset);
             } else {
                element = new TStreamerObjectAny(dmName, dmTitle, offset, dmFull);
-               if (!streamer && !clm->GetStreamer() && !clm->IsLoaded()) {
+               if (!isTransient && !streamer && !clm->GetStreamer() && !clm->IsLoaded()) {
                   Warning("Build", "%s: %s has no streamer or dictionary, data member \"%s\" will not be saved", GetName(), dmFull, dmName);
                }
             }
@@ -645,7 +654,8 @@ void TStreamerInfo::Build()
    if (needAllocClass) {
       TStreamerInfo *infoalloc  = (TStreamerInfo *)Clone(TString::Format("%s@@%d",GetName(),GetClassVersion()));
       if (!infoalloc) {
-         Error("Build","Could you create a TStreamerInfo for %s\n",TString::Format("%s@@%d",GetName(),GetClassVersion()).Data());
+         if (!isTransient)
+            Error("Build","Could you create a TStreamerInfo for %s\n",TString::Format("%s@@%d",GetName(),GetClassVersion()).Data());
       } else {
          // Tell clone we should rerun BuildOld
          infoalloc->SetBit(kBuildOldUsed,false);


### PR DESCRIPTION
Under some circumstances TStreamerInfo::BuildOld crashes in TStreamerInfo::AddReadAction.

See original report: cms-sw/cmsdist#6314 (comment)

With the recent updates to switch more std::pair's TClass to be auto-generated from the typename (as opposed to generated from interpreter information), more STL's collection TClass have their StreamerInfo build earlier.

In the case above, a file is being fast cloned and thus the StreamerInfo to the new file. In particular there is this sequence of operation.

    Get TClass for pair(type1, vector<type2>>
    ** At this point the dictionary for vector<type2> is not loaded.
    ** The TClass for the pair is generated nonetheless
    *** This requires the building of the StreamerInfo for the TClass for vector<type2>, let's call it c1 but (intentionaly because it is not needed yet) does not trigger the loading of the dictionary the vector<type2>
    Some other operation requires the loading of the library that contains the dictionary for vector<type2>
    ** SInce c1 exists, it is replaced by the dictionary generated TClass for vector<type2>, let's call it c2
    ** Part of this replacement is to transfer c1's StreamerInfo into c2 (after 'reseting` it's state)
    Then the StreamerInfos are copied form the input file to the output
    ** This includes "building" and "compiling" the StreamerInfo
    *** This crasesd when calling AddReadAction

An STL collection's TClass (like c1 and c2)'s StreamerInfo contains an artificial StreamerElement (for infrastructures purposes) that points back to its owner.

So when the StreamerInfo is created it has internally a pointer to c1

The deficiency is that whenc1 is replaced by c2 and then deleted, the StreamerInfo was not updated and thus the later building of the StreamerInfo was using a stale pointer to c1

