### PR TITLE
Fix BinData copy constructor

### DIFF
--- a/math/mathcore/src/BinData.cxx
+++ b/math/mathcore/src/BinData.cxx
@@ -104,7 +104,7 @@ namespace ROOT {
 
       fpTmpCoordErrorVector = new double [ fDim ];
 
-      ComputeSums(); 
+      ComputeSums();
     }
 
     /**
@@ -142,7 +142,7 @@ namespace ROOT {
       }
 
       fpTmpCoordErrorVector = new double [ fDim ];
-      ComputeSums(); 
+      ComputeSums();
     }
 
     /**
@@ -181,7 +181,7 @@ namespace ROOT {
       }
 
       fpTmpCoordErrorVector = new double [ fDim ];
-      ComputeSums(); 
+      ComputeSums();
     }
 
     /**
@@ -220,8 +220,11 @@ namespace ROOT {
     /**
       copy constructors
     */
-    BinData::BinData (const BinData & rhs) :
-      FitData()
+    BinData::BinData(const BinData &rhs)
+      : FitData(),
+      fDataPtr(nullptr),
+      fDataErrorPtr(nullptr), fDataErrorHighPtr(nullptr), fDataErrorLowPtr(nullptr),
+      fpTmpCoordErrorVector(nullptr), fpTmpBinEdgeVector(nullptr)
     {
       *this = rhs;
     }
@@ -267,44 +270,35 @@ namespace ROOT {
       }
       else
       {
+        // copy data vector and set correct pointer
         fData = rhs.fData;
-
         if ( !fData.empty() )
           fDataPtr = &fData.front();
 
+         // copy coordinate erro and set correct pointers
         fCoordErrors = rhs.fCoordErrors;
+        if (!fCoordErrors.empty()) {
+           assert(kCoordError == fErrorType || kAsymError == fErrorType);
+           fCoordErrorsPtr.resize(fDim);
+           for (unsigned int i = 0; i < fDim; i++) {
+              fCoordErrorsPtr[i] = fCoordErrors[i].empty() ? nullptr : &fCoordErrors[i].front();
+           }
+        }
+        // copy data error
         fDataError = rhs.fDataError;
+        if (!fDataError.empty()) {
+           assert(kValueError == fErrorType || kCoordError == fErrorType);
+           fDataErrorPtr = &fDataError.front();
+        }
+        // copy the asymmetric data error
         fDataErrorHigh = rhs.fDataErrorHigh;
         fDataErrorLow = rhs.fDataErrorLow;
-
-        if( ! fCoordErrors.empty() )
-        {
-          assert( kCoordError == fErrorType || kAsymError == fErrorType );
-          fCoordErrorsPtr.resize( fDim );
-
-          for ( unsigned int i=0; i<fDim; i++ )
-          {
-            fCoordErrorsPtr[i] = fCoordErrors[i].empty() ? nullptr : &fCoordErrors[i].front();
-          }
-        }
-
-        fDataError = rhs.fDataError;
-        fDataErrorHigh = rhs.fDataErrorHigh;
-        fDataErrorLow = rhs.fDataErrorLow;
-
-        assert( fDataErrorLow.empty() == fDataErrorHigh.empty() );
-        assert( fDataErrorLow.empty() != fDataError.empty() || kNoError == fErrorType );
-
-        if ( !fDataError.empty() )
-        {
-          assert( kValueError == fErrorType || kCoordError == fErrorType );
-          fDataErrorPtr = &fDataError.front();
-        }
-        else if ( !fDataErrorHigh.empty() && !fDataErrorLow.empty() )
-        {
-          assert( kAsymError == fErrorType );
-          fDataErrorHighPtr = &fDataErrorHigh.front();
-          fDataErrorLowPtr = &fDataErrorLow.front();
+        // both error low and high should be empty or not
+        assert( fDataErrorLow.empty() == fDataErrorHigh.empty()) ;
+        if (!fDataErrorHigh.empty() && !fDataErrorLow.empty()) {
+           assert(kAsymError == fErrorType);
+           fDataErrorHighPtr = &fDataErrorHigh.front();
+           fDataErrorLowPtr = &fDataErrorLow.front();
         }
       }
 
@@ -454,9 +448,9 @@ namespace ROOT {
       FitData::Add( x );
       fSumContent += y;
       if (y != 0 || ey != 1.0)  fSumError2 += ey*ey;
-      // set the weight flag checking if error^2 != y 
-      if (!fIsWeighted) 
-         if (y != 0 && std::abs( ey*ey/y - 1.0) > 1.E-12) fIsWeighted = true; 
+      // set the weight flag checking if error^2 != y
+      if (!fIsWeighted)
+         if (y != 0 && std::abs( ey*ey/y - 1.0) > 1.E-12) fIsWeighted = true;
     }
 
     /**
@@ -481,9 +475,9 @@ namespace ROOT {
       FitData::Add( x );
       fSumContent += y;
       if (y != 0 || ey != 1.0)  fSumError2 += ey*ey;
-       // set the weight flag checking if error^2 != y 
-      if (!fIsWeighted) 
-         if (y != 0 && std::abs( ey*ey/y - 1.0) > 1.E-12) fIsWeighted = true; 
+       // set the weight flag checking if error^2 != y
+      if (!fIsWeighted)
+         if (y != 0 && std::abs( ey*ey/y - 1.0) > 1.E-12) fIsWeighted = true;
     }
 
     /**
@@ -509,7 +503,7 @@ namespace ROOT {
       FitData::Add( x );
       fSumContent += y;
       if (y != 0 || eyl != 1.0 || eyh != 1.0)  fSumError2  += (eyl+eyh)*(eyl+eyh)/4;
-      
+
     }
 
     /**
@@ -550,7 +544,7 @@ namespace ROOT {
       FitData::Add( x );
       fSumContent += val;
       if (val != 0 || eval != 1.0) fSumError2  += eval*eval;
-      if (!fIsWeighted) 
+      if (!fIsWeighted)
          if (val != 0 && std::abs( eval*eval/val - 1.0) > 1.E-12) fIsWeighted = true;
     }
 
@@ -581,7 +575,7 @@ namespace ROOT {
       FitData::Add( x );
       fSumContent += val;
       if (val != 0 || eval != 1.0) fSumError2  += eval*eval;
-      if (!fIsWeighted) 
+      if (!fIsWeighted)
          if (val != 0 && std::abs( eval*eval/val - 1.0) > 1.E-12) fIsWeighted = true;
     }
 
@@ -828,7 +822,7 @@ namespace ROOT {
     void BinData::ComputeSums() {
        unsigned int n = Size();
        fSumContent = 0;
-       fSumError2 = 0; 
+       fSumError2 = 0;
        if (fErrorType != kAsymError) {
           for (unsigned int i = 0; i < n; ++i)  {
              double y = Value(i);
@@ -839,16 +833,16 @@ namespace ROOT {
        }
        else {
           for (unsigned int i = 0; i < n; ++i)  {
-             double y = Value(i); 
+             double y = Value(i);
              fSumContent += y;
              double elval,ehval = 0;
              GetAsymError(i,elval,ehval);
-             if (y != 0 || elval != 1.0 || ehval != 1.0) 
+             if (y != 0 || elval != 1.0 || ehval != 1.0)
                 fSumError2 += (elval+ehval)*(elval+ehval)/4;
           }
        }
        // set the weight flag
-       fIsWeighted =  (fSumContent != fSumError2); 
+       fIsWeighted =  (fSumContent != fSumError2);
     }
 
   } // end namespace Fit

--- a/math/mathcore/src/BinData.cxx
+++ b/math/mathcore/src/BinData.cxx
@@ -221,7 +221,7 @@ namespace ROOT {
       copy constructors
     */
     BinData::BinData(const BinData &rhs)
-      : FitData(),
+      : FitData(rhs),
       fDataPtr(nullptr),
       fDataErrorPtr(nullptr), fDataErrorHighPtr(nullptr), fDataErrorLowPtr(nullptr),
       fpTmpCoordErrorVector(nullptr), fpTmpBinEdgeVector(nullptr)

--- a/math/mathcore/src/FitData.cxx
+++ b/math/mathcore/src/FitData.cxx
@@ -209,6 +209,8 @@ namespace ROOT {
       }
 
       FitData::FitData(const FitData &rhs)
+         : fWrapped(false), fMaxPoints(0), fNPoints(0), fDim(0),
+           fpTmpCoordVector(nullptr)
       {
          *this = rhs;
       }

--- a/math/mathcore/test/CMakeLists.txt
+++ b/math/mathcore/test/CMakeLists.txt
@@ -75,11 +75,9 @@ ROOT_ADD_GTEST(stressMathCoreUnit stress/testSMatrix.cxx stress/testGenVector.cx
         stress/TestHelper.cxx
         LIBRARIES Core MathCore Hist RIO Tree GenVector)
 
-ROOT_ADD_GTEST(GradientUnit testGradient.cxx
-       LIBRARIES Core MathCore Hist RIO Tree GenVector)
+ROOT_ADD_GTEST(GradientUnit testGradient.cxx LIBRARIES Core MathCore Hist )
 
-ROOT_ADD_GTEST(GradientFittingUnit testGradientFitting.cxx
-  LIBRARIES Core MathCore Hist RIO Tree GenVector)
+ROOT_ADD_GTEST(GradientFittingUnit testGradientFitting.cxx LIBRARIES Core MathCore Hist)
 
 if(veccore AND vc)
   ROOT_ADD_GTEST(VectorizedTMathUnit testVectorizedTMath.cxx

--- a/math/mathcore/test/testGradient.cxx
+++ b/math/mathcore/test/testGradient.cxx
@@ -26,6 +26,8 @@
 #include <iostream>
 #include <string>
 
+int printLevel = 0;
+
 // Class to encapsulate the types that define how the gradient test is
 // performed; it also stores information strings about the types.
 //    DataType defines how to instantiate the gradient evaluation: Double_t,
@@ -292,13 +294,15 @@ struct GradientTestEvaluation {
          fFitter->Gradient(fModel->fParams, solution);
       end = std::chrono::system_clock::now();
 
-      // std::cout << "Gradient is : " << fFitter->NDim() << "  ";
-      //  for (unsigned int i = 0; i < fNumParams ; ++i)
-      //    std::cout << "  " << solution[i];
-      // std::cout << std::endl;
-
-
       std::chrono::duration<Double_t> timeElapsed = end - start;
+
+      if (printLevel > 0) {
+         std::cout << "Gradient is : " << fFitter->NDim() << "  ";
+         for (unsigned int i = 0; i < fNumParams; ++i)
+            std::cout << "  " << solution[i];
+         std::cout << std::endl;
+         std::cout << "elapsed time is " << timeElapsed.count() << std::endl;
+      }
 
       return timeElapsed.count() / fNumRepetitions;
 
@@ -446,7 +450,7 @@ typedef ::testing::Types<VectorialSerial1D, VectorialSerial2D> TestTypes;
 #  ifdef R__USE_IMT
 typedef ::testing::Types<ScalarMultithread1D, ScalarMultithread2D> TestTypes;
 #  else
-typedef ::testing::Types<> TestTypes;
+typedef ::testing::Types<ScalarSerial1D,ScalarSerial2D> TestTypes;
 #  endif
 #endif
 
@@ -506,3 +510,27 @@ TYPED_TEST(PoissonLikelihoodGradientTest, PoissonLikelihoodGradient)
    }
 }
 
+// add main() to avoid a linking error
+int main(int argc, char **argv)
+{
+
+   // Parse command line arguments
+   for (Int_t i = 1; i < argc; i++) {
+      std::string arg = argv[i];
+      if (arg == "-v") {
+         std::cout << "---running in verbose mode" << std::endl;
+         printLevel = 1;
+      } else if (arg == "-vv") {
+         std::cout << "---running in very verbose mode" << std::endl;
+         printLevel = 2;
+      } else if (arg == "-vvv") {
+         std::cout << "---running in very very verbose mode" << std::endl;
+         printLevel = 3;
+      }
+   }
+
+   // This allows the user to override the flag on the command line.
+   ::testing::InitGoogleTest(&argc, argv);
+
+   return RUN_ALL_TESTS();
+}

--- a/math/mathcore/test/testGradientFitting.cxx
+++ b/math/mathcore/test/testGradientFitting.cxx
@@ -289,8 +289,8 @@ INSTANTIATE_TYPED_TEST_SUITE_P(GradientFitting, GradientFittingTest, TestTypes);
 
 int main(int argc, char** argv) {
 
-// Disables elapsed time by default.
-  //::testing::GTEST_FLAG(print_time) = false;
+   // Disables elapsed time by default.
+   //::testing::GTEST_FLAG(print_time) = false;
 
    // Parse command line arguments
    for (Int_t i = 1 ;  i < argc ; i++) {


### PR DESCRIPTION
This PR fixes the copy constructor of the `ROOT::Fit::BinDtaa` class, 
solving the problem reported in 
https://root-forum.cern.ch/t/globalchi2-function-for-many-histograms-in-root-fitfcn/42016/10

In addition this PR fixes a small issue of one mathcore tests, which was reporting a linking error in case both IMT and VECCORE were not present