### PR TITLE
Clone also name in the reflected shape.

### DIFF
--- a/geom/geom/src/TGeoVolume.cxx
+++ b/geom/geom/src/TGeoVolume.cxx
@@ -1861,7 +1861,7 @@ TGeoVolume *TGeoVolume::MakeReflectedVolume(const char *newname) const
    // Reflect the shape (if any) and connect it.
    if (fShape) {
       TGeoShape *reflected_shape =
-         TGeoScaledShape::MakeScaledShape("", fShape, new TGeoScale(1.,1.,-1.));
+         TGeoScaledShape::MakeScaledShape(fShape->GetName(), fShape, new TGeoScale(1.,1.,-1.));
       vol->SetShape(reflected_shape);
    }
    // Reflect the daughters.


### PR DESCRIPTION
Completes the fix for copying old names in the TGeo reflection factory. Requested by CMS. 