### PR TITLE
[cmake] add find_dependency(nlohmann_json) when using external package

### DIFF
--- a/builtins/nlohmann/CMakeLists.txt
+++ b/builtins/nlohmann/CMakeLists.txt
@@ -3,6 +3,8 @@
 # file only used when ACLiC or ROOT macros will include REve headers,
 # it is not used for ROOT compilation
 
+set(nlohmann_json_VERSION "3.9.1" PARENT_SCOPE)
+
 add_custom_command(
      OUTPUT ${CMAKE_BINARY_DIR}/include/nlohmann/json.hpp
      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/builtins/nlohmann/json.hpp ${CMAKE_BINARY_DIR}/include/nlohmann/json.hpp

--- a/builtins/nlohmann/CMakeLists.txt
+++ b/builtins/nlohmann/CMakeLists.txt
@@ -3,7 +3,13 @@
 # file only used when ACLiC or ROOT macros will include REve headers,
 # it is not used for ROOT compilation
 
-set(nlohmann_json_VERSION "3.9.1" PARENT_SCOPE)
+# extract version from existing header file
+file(STRINGS "json.hpp" JSON_H REGEX "^#define NLOHMANN_JSON_VERSION_[A-Z]+[ ]+[0-9]+.*$")
+string(REGEX REPLACE ".+NLOHMANN_JSON_VERSION_MAJOR[ ]+([0-9]+).*$"   "\\1" JSON_VERSION_MAJOR "${JSON_H}")
+string(REGEX REPLACE ".+NLOHMANN_JSON_VERSION_MINOR[ ]+([0-9]+).*$"   "\\1" JSON_VERSION_MINOR "${JSON_H}")
+string(REGEX REPLACE ".+NLOHMANN_JSON_VERSION_PATCH[ ]+([0-9]+).*$" "\\1" JSON_VERSION_PATCH "${JSON_H}")
+set(nlohmann_json_VERSION "${JSON_VERSION_MAJOR}.${JSON_VERSION_MINOR}.${JSON_VERSION_PATCH}" PARENT_SCOPE)
+unset(JSON_H)
 
 add_custom_command(
      OUTPUT ${CMAKE_BINARY_DIR}/include/nlohmann/json.hpp

--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -85,6 +85,13 @@ foreach(_opt ${_root_enabled_options})
 endforeach()
 
 #----------------------------------------------------------------------------
+# Find external packages which were used in ROOT
+if (NOT ROOT_builtin_nlohmannjson_FOUND)
+  include(CMakeFindDependencyMacro)
+  find_dependency(nlohmann_json @nlohmann_json_VERSION@)
+endif()
+
+#----------------------------------------------------------------------------
 # Now set them to ROOT_LIBRARIES
 set(ROOT_LIBRARIES)
 if(MSVC)


### PR DESCRIPTION
Should solve issue #6784 

In such case one requires to have target `nlohmann_json::nlohmann_json` to get proper include paths
I did not found reasonable way to export such target from ROOT cmake file.