### PR TITLE
[cmake] macOS: prefer user-provided Python install over Framework:

### DIFF
--- a/cmake/modules/SearchRootCoreDeps.cmake
+++ b/cmake/modules/SearchRootCoreDeps.cmake
@@ -65,6 +65,11 @@ If PYTHON_EXECUTABLE is NOT specified:
 
 message(STATUS "Looking for Python")
 
+# On macOS, prefer user-provided Pythons.
+set(Python_FIND_FRAMEWORK LAST)
+set(Python2_FIND_FRAMEWORK LAST)
+set(Python3_FIND_FRAMEWORK LAST)
+
 # CMake 3.14 is the minimum because in 3.12 and 3.13, despite find_package(PythonX) being present,
 # the Numpy-related variables are not set
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14)


### PR DESCRIPTION
The framework one depends on https://github.com/root-project/root/issues/6753
and https://gitlab.kitware.com/cmake/cmake/-/issues/21293
before we can potentially use it. And anyway if users install their own
Python we should be nice and use that, not Python coming with Xcode / cmd line tools.

Works around:
dlopen(/Users/sftnight/build/jenkins/night/LABEL/mac10beta/SPEC/cxx17/V/master/build/lib/libROOTTPython.so, 9): Library not loaded: @rpath/Python3.framework/Versions/3.8/Python3
  Referenced from: /Users/sftnight/build/jenkins/night/LABEL/mac10beta/SPEC/cxx17/V/master/build/lib/libROOTTPython.so
  Reason: image not found