### PR TITLE
Implement RANLUX++ generator

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -73,6 +73,7 @@ set(HEADERS
   Math/QuantFuncMathCore.h
   Math/Random.h
   Math/RandomFunctions.h
+  Math/RanluxppEngine.h
   Math/RichardsonDerivator.h
   Math/RootFinder.h
   Math/SpecFuncMathCore.h
@@ -160,6 +161,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(MathCore
     src/ProbFuncMathCore.cxx
     src/QuantFuncMathCore.cxx
     src/RandomFunctions.cxx
+    src/RanluxppEngineImpl.cxx
     src/RichardsonDerivator.cxx
     src/RootFinder.cxx
     src/SparseData.cxx

--- a/math/mathcore/inc/LinkDef2.h
+++ b/math/mathcore/inc/LinkDef2.h
@@ -58,6 +58,7 @@
 #pragma link C++ class TRandomGen<ROOT::Math::MixMaxEngine<256,4>>+;
 #pragma link C++ class TRandomGen<ROOT::Math::MixMaxEngine<17,0>>+;
 #pragma link C++ class TRandomGen<ROOT::Math::MixMaxEngine<17,1>>+;
+#pragma link C++ class TRandomGen<ROOT::Math::RanluxppEngine2048>+;
 #pragma link C++ class TRandomGen<ROOT::Math::StdEngine<std::mt19937_64>>+;
 #pragma link C++ class TRandomGen<ROOT::Math::StdEngine<std::ranlux48>>+;
 

--- a/math/mathcore/inc/Math/RanluxppEngine.h
+++ b/math/mathcore/inc/Math/RanluxppEngine.h
@@ -1,0 +1,61 @@
+// @(#)root/mathcore:$Id$
+// Author: Jonas Hahnfeld 11/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_Math_RanluxppEngine
+#define ROOT_Math_RanluxppEngine
+
+#include "Math/TRandomEngine.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace ROOT {
+namespace Math {
+
+template <int w, int p>
+class RanluxppEngineImpl;
+
+template <int p>
+class RanluxppEngine final : public TRandomEngine {
+
+private:
+   std::unique_ptr<RanluxppEngineImpl<52, p>> fImpl;
+
+public:
+   RanluxppEngine(uint64_t seed = 314159265);
+   virtual ~RanluxppEngine();
+
+   /// Generate a double-precision random number with 52 bits of randomness
+   double Rndm() override;
+   /// Generate a double-precision random number (non-virtual method)
+   double operator()();
+   /// Generate a random integer value with 52 bits
+   uint64_t IntRndm();
+
+   /// Initialize and seed the state of the generator
+   void SetSeed(uint64_t seed);
+   /// Skip `n` random numbers without generating them
+   void Skip(uint64_t n);
+
+   /// Get name of the generator
+   static const char *Name() { return "RANLUX++"; }
+};
+
+using RanluxppEngine24 = RanluxppEngine<24>;
+using RanluxppEngine2048 = RanluxppEngine<2048>;
+
+extern template class RanluxppEngine<24>;
+extern template class RanluxppEngine<2048>;
+
+} // end namespace Math
+} // end namespace ROOT
+
+#endif /* ROOT_Math_RanluxppEngine */

--- a/math/mathcore/inc/TRandomGen.h
+++ b/math/mathcore/inc/TRandomGen.h
@@ -76,6 +76,7 @@ public:
 // some useful typedef
 #include "Math/StdEngine.h"
 #include "Math/MixMaxEngine.h"
+#include "Math/RanluxppEngine.h"
 
 // not working wight now for this classes
 //#define  DEFINE_TEMPL_INSTANCE
@@ -86,6 +87,8 @@ extern template class TRandomGen<ROOT::Math::MixMaxEngine<256,2>>;
 extern template class TRandomGen<ROOT::Math::MixMaxEngine<256,4>>;
 extern template class TRandomGen<ROOT::Math::MixMaxEngine<17,0>>;
 extern template class TRandomGen<ROOT::Math::MixMaxEngine<17,1>>;
+
+extern template class TRandomGen<ROOT::Math::RanluxppEngine2048>;
 
 extern template class  TRandomGen<ROOT::Math::StdEngine<std::mt19937_64> >;
 extern template class  TRandomGen<ROOT::Math::StdEngine<std::ranlux48> >;
@@ -125,6 +128,9 @@ typedef TRandomGen<ROOT::Math::MixMaxEngine<17,0>> TRandomMixMax17;
   
  */
 typedef TRandomGen<ROOT::Math::MixMaxEngine<256,2>> TRandomMixMax256;
+
+typedef TRandomGen<ROOT::Math::RanluxppEngine2048> TRandomRanluxpp;
+
 /**
   @ingroup Random
   Generator based on a the Mersenne-Twister generator with 64 bits, 

--- a/math/mathcore/src/RanluxppEngineImpl.cxx
+++ b/math/mathcore/src/RanluxppEngineImpl.cxx
@@ -1,0 +1,208 @@
+// @(#)root/mathcore:$Id$
+// Author: Jonas Hahnfeld 11/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/** \class ROOT::Math::RanluxppEngine
+Implementation of the RANLUX++ generator
+
+RANLUX++ is an LCG equivalent of RANLUX using 576 bit numbers.
+
+Described in
+A. Sibidanov, *A revision of the subtract-with-borrow random numbergenerators*,
+*Computer Physics Communications*, 221(2017), 299-303,
+preprint https://arxiv.org/pdf/1705.03123.pdf
+
+The code is loosely based on the Assembly implementation by A. Sibidanov
+available at https://github.com/sibidanov/ranluxpp/.
+*/
+
+#include "Math/RanluxppEngine.h"
+
+#include "mulmod.h"
+
+#include <cassert>
+#include <cstdint>
+
+namespace {
+
+// Variable templates are a feature of C++14, use the older technique of having
+// a static member in a template class.
+
+template <int p>
+struct RanluxppData;
+
+template <>
+struct RanluxppData<24> {
+   static const uint64_t kA[9];
+};
+const uint64_t RanluxppData<24>::kA[] = {
+   0x0000000000000000, 0x0000000000000000, 0x0000000000010000, 0xfffe000000000000, 0xffffffffffffffff,
+   0xffffffffffffffff, 0xffffffffffffffff, 0xfffffffeffffffff, 0xffffffffffffffff,
+};
+
+template <>
+struct RanluxppData<2048> {
+   static const uint64_t kA[9];
+};
+const uint64_t RanluxppData<2048>::kA[] = {
+   0xed7faa90747aaad9, 0x4cec2c78af55c101, 0xe64dcb31c48228ec, 0x6d8a15a13bee7cb0, 0x20b2ca60cb78c509,
+   0x256c3d3c662ea36c, 0xff74e54107684ed2, 0x492edfcc0cc8e753, 0xb48c187cf5b22097,
+};
+
+} // end anonymous namespace
+
+namespace ROOT {
+namespace Math {
+
+template <int w, int p>
+class RanluxppEngineImpl {
+
+private:
+   uint64_t fState[9]; ///< State of the generator
+   int fPosition = 0;  ///< Current position in bits
+
+   static constexpr const uint64_t *kA = RanluxppData<p>::kA;
+   static constexpr int kMaxPos = 9 * 64;
+
+   /// Produce next block of random bits
+   void Advance()
+   {
+      mulmod(kA, fState);
+      fPosition = 0;
+   }
+
+public:
+   /// Return the next random bits, generate a new block if necessary
+   uint64_t NextRandomBits()
+   {
+      if (fPosition + w > kMaxPos) {
+         Advance();
+      }
+
+      int idx = fPosition / 64;
+      int offset = fPosition % 64;
+      int numBits = 64 - offset;
+
+      uint64_t bits = fState[idx] >> offset;
+      if (numBits < w) {
+         bits |= fState[idx + 1] << numBits;
+      }
+      bits &= ((uint64_t(1) << w) - 1);
+
+      fPosition += w;
+      assert(fPosition <= kMaxPos && "position out of range!");
+
+      return bits;
+   }
+
+   /// Initialize and seed the state of the generator
+   void SetSeed(uint64_t s)
+   {
+      fState[0] = 1;
+      for (int i = 1; i < 9; i++) {
+         fState[i] = 0;
+      }
+
+      uint64_t a_seed[9];
+      // Skip 2 ** 96 states.
+      powermod(kA, a_seed, uint64_t(1) << 48);
+      powermod(a_seed, a_seed, uint64_t(1) << 48);
+      // Skip another s states.
+      powermod(a_seed, a_seed, s);
+      mulmod(a_seed, fState);
+
+      fPosition = 0;
+   }
+
+   /// Skip `n` random numbers without generating them
+   void Skip(uint64_t n)
+   {
+      int left = (kMaxPos - fPosition) / w;
+      assert(left >= 0 && "position was out of range!");
+      if (n < (uint64_t)left) {
+         // Just skip the next few entries in the currently available bits.
+         fPosition += n * w;
+         assert(fPosition <= kMaxPos && "position out of range!");
+         return;
+      }
+
+      n -= left;
+      // Need to advance and possibly skip over blocks.
+      int nPerState = kMaxPos / w;
+      int skip = (n / nPerState);
+
+      uint64_t a_skip[9];
+      powermod(kA, a_skip, skip + 1);
+      mulmod(a_skip, fState);
+
+      // Potentially skip numbers in the freshly generated block.
+      int remaining = n - skip * nPerState;
+      assert(remaining >= 0 && "should not end up at a negative position!");
+      fPosition = remaining * w;
+      assert(fPosition <= kMaxPos && "position out of range!");
+   }
+};
+
+template <int p>
+RanluxppEngine<p>::RanluxppEngine(uint64_t seed) : fImpl(new RanluxppEngineImpl<52, p>)
+{
+   fImpl->SetSeed(seed);
+}
+
+template <int p>
+RanluxppEngine<p>::~RanluxppEngine() = default;
+
+template <int p>
+double RanluxppEngine<p>::Rndm()
+{
+   return (*this)();
+}
+
+template <int p>
+double RanluxppEngine<p>::operator()()
+{
+   // Get 52 bits of randomness.
+   uint64_t bits = fImpl->NextRandomBits();
+
+   // Construct the double in [1, 2), using the random bits as mantissa.
+   static constexpr uint64_t exp = 0x3ff0000000000000;
+   union {
+      double dRandom;
+      uint64_t iRandom;
+   };
+   iRandom = exp | bits;
+
+   // Shift to the right interval of [0, 1).
+   return dRandom - 1;
+}
+
+template <int p>
+uint64_t RanluxppEngine<p>::IntRndm()
+{
+   return fImpl->NextRandomBits();
+}
+
+template <int p>
+void RanluxppEngine<p>::SetSeed(uint64_t seed)
+{
+   fImpl->SetSeed(seed);
+}
+
+template <int p>
+void RanluxppEngine<p>::Skip(uint64_t n)
+{
+   fImpl->Skip(n);
+}
+
+template class RanluxppEngine<24>;
+template class RanluxppEngine<2048>;
+
+} // end namespace Math
+} // end namespace ROOT

--- a/math/mathcore/src/TRandomGen.cxx
+++ b/math/mathcore/src/TRandomGen.cxx
@@ -3,6 +3,7 @@
 
 #include "TRandomGen.h"
 #include "Math/MixMaxEngine.h"
+#include "Math/RanluxppEngine.h"
 #include "Math/StdEngine.h"
 
 // define the instance
@@ -11,6 +12,8 @@ class TRandomGen<ROOT::Math::MixMaxEngine<256,2>>;
 class TRandomGen<ROOT::Math::MixMaxEngine<256,4>>; 
 class TRandomGen<ROOT::Math::MixMaxEngine<17,0>>;
 class TRandomGen<ROOT::Math::MixMaxEngine<17,1>>;
+
+class TRandomGen<ROOT::Math::RanluxppEngine2048>;
 
 class  TRandomGen<ROOT::Math::StdEngine<std::mt19937_64> >;
 class  TRandomGen<ROOT::Math::StdEngine<std::ranlux48> >;

--- a/math/mathcore/src/mulmod.h
+++ b/math/mathcore/src/mulmod.h
@@ -1,0 +1,347 @@
+// @(#)root/mathcore:$Id$
+// Author: Jonas Hahnfeld 11/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <cstdint>
+
+/// Multiply two 576 bit numbers, stored as 9 numbers of 64 bits each
+///
+/// \param[in] in1 first factor as 9 numbers of 64 bits each
+/// \param[in] in2 second factor as 9 numbers of 64 bits each
+/// \param[out] out result with 18 numbers of 64 bits each
+void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
+{
+   uint64_t next = 0;
+   unsigned nextCarry = 0;
+   for (int i = 0; i < 18; i++) {
+      uint64_t current = next;
+      unsigned carry = nextCarry;
+
+      next = 0;
+      nextCarry = 0;
+
+      for (int j = 0; j < 9 && j <= i; j++) {
+         int k = i - j;
+         if (k >= 9)
+            continue;
+
+         uint64_t upper1 = in1[j] >> 32;
+         uint64_t lower1 = static_cast<uint32_t>(in1[j]);
+
+         uint64_t upper2 = in2[k] >> 32;
+         uint64_t lower2 = static_cast<uint32_t>(in2[k]);
+
+         // Multiply 32-bit parts.
+         uint64_t upper = upper1 * upper2;
+         uint64_t middle1 = upper1 * lower2;
+         uint64_t middle2 = lower1 * upper2;
+         uint64_t middle = middle1 + middle2;
+         if (middle < middle1) {
+            // This can never overflow because the maximum value of upper is
+            // (2 ** 32 - 1) ** 2 = 2 ** 64 - 2 * 2 ** 32 + 1. When now adding
+            // another 2 ** 32, the result 2 ** 64 - 2 ** 32 + 1 is still smaller
+            // than the maximum 2 ** 64 - 1 that can be stored in a uint64_t.
+            upper += uint64_t(1) << 32;
+         }
+         uint64_t lower = lower1 * lower2;
+
+         uint64_t middle_upper = middle >> 32;
+         uint64_t middle_lower = middle << 32;
+
+         // Add to current, remember carry.
+         current += lower;
+         if (current < lower)
+            carry++;
+         current += middle_lower;
+         if (current < middle_lower)
+            carry++;
+
+         // Add to next, remember nextCarry.
+         next += middle_upper;
+         if (next < middle_upper)
+            nextCarry++;
+         next += upper;
+         if (next < upper)
+            nextCarry++;
+      }
+
+      next += carry;
+      if (next < carry)
+         nextCarry++;
+
+      out[i] = current;
+   }
+}
+
+/// Compute a value congruent to mul modulo m less than 2 ** 576
+///
+/// \param[in] mul product from multiply9x9 with 18 numbers of 64 bits each
+/// \param[out] out result with 9 numbers of 64 bits each
+///
+/// \f$ m = 2^{576} - 2^{240} + 1 \f$
+///
+/// Note that this function does *not* return the smallest value congruent to
+/// the modulus, it only guarantees a value smaller than \f$ 2^{576} \$!
+void mod_m(const uint64_t *mul, uint64_t *out)
+{
+   uint64_t r[9] = {0};
+
+   // r = t0 - t1 (24 * 24 = 576 bits)
+   unsigned carry = 0;
+   for (int i = 0; i < 9; i++) {
+      uint64_t t0_i = mul[i];
+
+      uint64_t r_ic = t0_i - carry;
+      if (r_ic > t0_i) {
+         carry = 1;
+      } else {
+         carry = 0;
+      }
+
+      uint64_t t1_i = mul[i + 9];
+      uint64_t r_i = r_ic - t1_i;
+      if (r_i > r_ic)
+         carry++;
+      r[i] = r_i;
+   }
+   int64_t c = -((int64_t)carry);
+
+   // r -= t2 (only 240 bits, so need to extend)
+   carry = 0;
+   for (int i = 0; i < 9; i++) {
+      uint64_t r_i = r[i];
+
+      uint64_t r_ic = r_i - carry;
+      if (r_ic > r_i) {
+         carry = 1;
+      } else {
+         carry = 0;
+      }
+
+      uint64_t t2_bits = 0;
+      if (i < 4) {
+         t2_bits += mul[i + 14] >> 16;
+         if (i < 3) {
+            t2_bits += mul[i + 15] << 48;
+         }
+      }
+      r_i = r_ic - t2_bits;
+      if (r_i > r_ic)
+         carry++;
+      r[i] = r_i;
+   }
+   c -= carry;
+
+   // r += (t3 + t2) * 2 ** 240; copy to output array.
+   carry = 0;
+   out[0] = r[0];
+   out[1] = r[1];
+   out[2] = r[2];
+   {
+      uint64_t r_3 = r[3];
+      // 16 upper bits
+      uint64_t t2_bits = (mul[14] >> 16) << 48;
+      uint64_t t3_bits = (mul[9] << 48);
+
+      r_3 += t2_bits;
+      if (r_3 < t2_bits)
+         carry++;
+      r_3 += t3_bits;
+      if (r_3 < t3_bits)
+         carry++;
+
+      out[3] = r_3;
+   }
+   for (int i = 0; i < 3; i++) {
+      uint64_t r_i = r[i + 4];
+      r_i += carry;
+      if (r_i < carry) {
+         carry = 1;
+      } else {
+         carry = 0;
+      }
+
+      uint64_t t2_bits = (mul[14 + i] >> 32) + (mul[15 + i] << 32);
+      uint64_t t3_bits = (mul[9 + i] >> 16) + (mul[10 + i] << 48);
+
+      r_i += t2_bits;
+      if (r_i < t2_bits)
+         carry++;
+      r_i += t3_bits;
+      if (r_i < t3_bits)
+         carry++;
+
+      out[i + 4] = r_i;
+   }
+   {
+      uint64_t r_7 = r[7];
+      r_7 += carry;
+      if (r_7 < carry) {
+         carry = 1;
+      } else {
+         carry = 0;
+      }
+
+      uint64_t t2_bits = (mul[17] >> 32);
+      uint64_t t3_bits = (mul[12] >> 16) + (mul[13] << 48);
+
+      r_7 += t2_bits;
+      if (r_7 < t2_bits)
+         carry++;
+      r_7 += t3_bits;
+      if (r_7 < t3_bits)
+         carry++;
+
+      out[7] = r_7;
+   }
+   {
+      uint64_t r_8 = r[8];
+      r_8 += carry;
+      if (r_8 < carry) {
+         carry = 1;
+      } else {
+         carry = 0;
+      }
+
+      uint64_t t3_bits = (mul[13] >> 16) + (mul[14] << 48);
+
+      r_8 += t3_bits;
+      if (r_8 < t3_bits)
+         carry++;
+
+      out[8] = r_8;
+   }
+   c += carry;
+
+   // c = floor(r / 2 ** 576) has been computed along the way via the carry
+   // flags. Now to update r = r - c * m, it suffices to know c * (-2 ** 240 + 1)
+   // because the 2 ** 576 will cancel out. Also note that c may be zero, but
+   // the operation is still performed to avoid branching.
+
+   // c * (-2 ** 240 + 1) in 576 bits looks as follows, depending on c:
+   //  - if c = 0, the number is zero.
+   //  - if c = 1: bits 576 to 240 are set,
+   //              bits 239 to 1 are zero, and
+   //              the last one is set
+   //  - if c = -1, which corresponds to all bits set (signed int64_t):
+   //              bits 576 to 240 are zero and the rest is set.
+   // Note that all bits except the last are exactly complimentary (unless c = 0)
+   // and the last byte is conveniently represented by c already.
+   // Now construct the three bit patterns from c, their names correspond to the
+   // assembly implementation by Alexei Sibidanov.
+
+   // c = 0 -> t0 = 0; c = 1 -> t0 = 0; c = -1 -> all bits set (sign extension)
+   // (The assembly implementation shifts by 63, which gives the same result.)
+   int64_t t0 = c >> 1;
+
+   // c = 0 -> t2 = 0; c = 1 -> upper 16 bits set; c = -1 -> lower 48 bits set
+   int64_t t2 = t0 - (c << 48);
+
+   // c = 0 -> t1 = 0; c = 1 -> all bits set; c = -1 -> t1 = 0
+   // (The assembly implementation shifts by 63, which gives the same result.)
+   int64_t t1 = t2 >> 48;
+
+   carry = 0;
+   {
+      uint64_t r_0 = out[0];
+
+      uint64_t out_0 = r_0 - c;
+      if (out_0 > r_0)
+         carry++;
+      out[0] = out_0;
+   }
+   for (int i = 1; i < 3; i++) {
+      uint64_t r_i = out[i];
+
+      uint64_t r_ic = r_i - carry;
+      if (r_ic > r_i) {
+         carry = 1;
+      } else {
+         carry = 0;
+      }
+
+      uint64_t out_i = r_ic - t0;
+      if (out_i > r_ic)
+         carry++;
+      out[i] = out_i;
+   }
+   {
+      uint64_t r_3 = out[3];
+
+      uint64_t r_3c = r_3 - carry;
+      if (r_3c > r_3) {
+         carry = 1;
+      } else {
+         carry = 0;
+      }
+
+      uint64_t out_3 = r_3c - t2;
+      if (out_3 > r_3c)
+         carry++;
+      out[3] = out_3;
+   }
+   for (int i = 4; i < 9; i++) {
+      uint64_t r_i = out[i];
+
+      uint64_t r_ic = r_i - carry;
+      if (r_ic > r_i) {
+         carry = 1;
+      } else {
+         carry = 0;
+      }
+
+      uint64_t out_i = r_ic - t1;
+      if (out_i > r_ic)
+         carry++;
+      out[i] = out_i;
+   }
+}
+
+/// Combine multiply9x9 and mod_m with internal temporary storage
+///
+/// \param[in] in1 first factor with 9 numbers of 64 bits each
+/// \param[inout] inout second factor and also the output of the same size
+void mulmod(const uint64_t *in1, uint64_t *inout)
+{
+   uint64_t mul[2 * 9] = {0};
+   multiply9x9(in1, inout, mul);
+   mod_m(mul, inout);
+}
+
+/// Compute base to the n modulo m
+///
+/// \param[in] base with 9 numbers of 64 bits each
+/// \param[out] res output with 9 numbers of 64 bits each
+/// \param[in] n exponent
+///
+/// The arguments base and res may point to the same location.
+void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
+{
+   uint64_t fac[9] = {0};
+   fac[0] = base[0];
+   res[0] = 1;
+   for (int i = 1; i < 9; i++) {
+      fac[i] = base[i];
+      res[i] = 0;
+   }
+
+   uint64_t mul[18] = {0};
+   while (n) {
+      if (n & 1) {
+         multiply9x9(res, fac, mul);
+         mod_m(mul, res);
+      }
+      n >>= 1;
+      if (!n)
+         break;
+      multiply9x9(fac, fac, mul);
+      mod_m(mul, fac);
+   }
+}

--- a/math/mathcore/test/CMakeLists.txt
+++ b/math/mathcore/test/CMakeLists.txt
@@ -81,6 +81,11 @@ ROOT_ADD_GTEST(GradientUnit testGradient.cxx
 ROOT_ADD_GTEST(GradientFittingUnit testGradientFitting.cxx
   LIBRARIES Core MathCore Hist RIO Tree GenVector)
 
+ROOT_ADD_GTEST(MulmodUnit mulmod.cxx)
+
+ROOT_ADD_GTEST(RanluxppEngineTests RanluxppEngine.cxx
+        LIBRARIES Core MathCore)
+
 if(veccore AND vc)
   ROOT_ADD_GTEST(VectorizedTMathUnit testVectorizedTMath.cxx
         LIBRARIES Core MathCore)

--- a/math/mathcore/test/RanluxppEngine.cxx
+++ b/math/mathcore/test/RanluxppEngine.cxx
@@ -1,0 +1,42 @@
+// @(#)root/mathcore:$Id$
+// Author: Jonas Hahnfeld 11/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "Math/RanluxppEngine.h"
+
+#include "gtest/gtest.h"
+
+using namespace ROOT::Math;
+
+TEST(RanluxppEngine, random2048)
+{
+   RanluxppEngine2048 rng(314159265);
+   // Match the assembly implementation in skipping the first 11 numbers.
+   rng.Skip(11);
+
+   // Values extracted from the assembly implementation.
+   EXPECT_EQ(rng.IntRndm(), 1357063655714534);
+   EXPECT_DOUBLE_EQ(rng.Rndm(), 0.500504017418743);
+
+   // Skip ahead in block.
+   rng.Skip(2);
+   EXPECT_EQ(rng.IntRndm(), 160414309741165);
+   EXPECT_DOUBLE_EQ(rng.Rndm(), 0.9422050833832005);
+
+   // Skip ahead to start of next block.
+   rng.Skip(5);
+   EXPECT_EQ(rng.IntRndm(), 911953872946889);
+   EXPECT_DOUBLE_EQ(rng.Rndm(), 0.7498142796273863);
+
+   // Skip ahead across blocks.
+   rng.Skip(42);
+   EXPECT_EQ(rng.IntRndm(), 4265826975858336);
+   EXPECT_DOUBLE_EQ(rng.Rndm(), 0.472544363223621);
+}

--- a/math/mathcore/test/mulmod.cxx
+++ b/math/mathcore/test/mulmod.cxx
@@ -1,0 +1,272 @@
+// @(#)root/mathcore:$Id$
+// Author: Jonas Hahnfeld 11/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "../src/mulmod.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdint>
+
+TEST(multiply9x9, simple)
+{
+   uint64_t a[9] = {2, 0, 0, 0, 0, 0, 0, 0, 0};
+   uint64_t b[9] = {3, 0, 0, 0, 0, 0, 0, 0, 0};
+   uint64_t mul[18];
+
+   multiply9x9(a, b, mul);
+
+   EXPECT_EQ(mul[0], 6);
+   for (int i = 1; i < 18; i++) {
+      EXPECT_EQ(mul[i], 0);
+   }
+}
+
+TEST(multiply9x9, full)
+{
+   uint64_t a[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+   uint64_t b[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+   uint64_t mul[18];
+
+   multiply9x9(a, b, mul);
+
+   EXPECT_EQ(mul[0], 1);
+   EXPECT_EQ(mul[1], 4);
+   EXPECT_EQ(mul[2], 10);
+   EXPECT_EQ(mul[3], 20);
+   EXPECT_EQ(mul[4], 35);
+   EXPECT_EQ(mul[5], 56);
+   EXPECT_EQ(mul[6], 84);
+   EXPECT_EQ(mul[7], 120);
+   EXPECT_EQ(mul[8], 165);
+   EXPECT_EQ(mul[9], 200);
+   EXPECT_EQ(mul[10], 224);
+   EXPECT_EQ(mul[11], 236);
+   EXPECT_EQ(mul[12], 235);
+   EXPECT_EQ(mul[13], 220);
+   EXPECT_EQ(mul[14], 190);
+   EXPECT_EQ(mul[15], 144);
+   EXPECT_EQ(mul[16], 81);
+   EXPECT_EQ(mul[17], 0);
+}
+
+TEST(multiply9x9, max)
+{
+   uint64_t max = UINT64_MAX;
+   uint64_t a[9] = {max, max, max, max, max, max, max, max, max};
+   uint64_t b[9] = {max, max, max, max, max, max, max, max, max};
+   uint64_t mul[18];
+
+   multiply9x9(a, b, mul);
+
+   // Expected result verified using the assembly implementation of ranluxppp
+   // and the following Python program:
+   //     >>> a = b = (1 << 576) - 1
+   //     >>> mul = a * b
+   //     >>> while mul > 0:
+   //     ...     print(hex(mul & 0xffffffffffffffff))
+   //     ...     mul = mul >> 64
+   //     ...
+   EXPECT_EQ(mul[0], 1);
+   for (int i = 1; i < 9; i++) {
+      EXPECT_EQ(mul[i], 0);
+   }
+   EXPECT_EQ(mul[9], 0xfffffffffffffffe);
+   for (int i = 10; i < 18; i++) {
+      EXPECT_EQ(mul[i], 0xffffffffffffffff);
+   }
+}
+
+// The modulus m = 2 ** 576 - 2 ** 240 + 1.
+
+TEST(mod_m, nop)
+{
+   // mul = 2 ** 512 < m
+   uint64_t mul[18] = {0};
+   mul[8] = 1;
+   uint64_t mod[9];
+
+   mod_m(mul, mod);
+
+   for (int i = 0; i < 8; i++) {
+      EXPECT_EQ(mod[i], 0);
+   }
+   EXPECT_EQ(mod[8], 1);
+}
+
+TEST(mod_m, modulus)
+{
+   // mul = m = 2 ** 576 - 2 ** 240 + 1
+   uint64_t mul[18] = {0};
+   mul[0] = 1;
+   mul[3] = 0xffff000000000000;
+   for (int i = 4; i < 9; i++) {
+      mul[i] = 0xffffffffffffffff;
+   }
+   uint64_t mod[9];
+
+   mod_m(mul, mod);
+
+   // mod_m does not provide the smallest value, but just a value smaller than
+   // 2 ** 576 that is congruent to mul; in this case, mul itself.
+   for (int i = 0; i < 9; i++) {
+      EXPECT_EQ(mod[i], mul[i]);
+   }
+}
+
+TEST(mod_m, simple)
+{
+   // mul = 2 ** 576
+   uint64_t mul[18] = {0};
+   mul[9] = 1;
+   uint64_t mod[9];
+
+   mod_m(mul, mod);
+
+   // The result is mod = mul - m = 2 ** 240 - 1, all first 240 bits set.
+   for (int i = 0; i < 3; i++) {
+      EXPECT_EQ(mod[i], 0xffffffffffffffff);
+   }
+   EXPECT_EQ(mod[3], 0x0000ffffffffffff);
+   for (int i = 4; i < 9; i++) {
+      EXPECT_EQ(mod[i], 0);
+   }
+}
+
+TEST(mod_m, pattern)
+{
+   uint64_t pattern1 = 0xdeafdeafdeafdeaf;
+   uint64_t pattern2 = 0xf00df00df00df00d;
+   uint64_t mul[18] = {
+      pattern1, pattern2, pattern1, pattern2, pattern1, pattern1, pattern2, pattern2, pattern2,
+      pattern1, pattern2, pattern1, pattern2, pattern2, pattern1, pattern1, pattern2, pattern1,
+   };
+   uint64_t mod[9];
+
+   mod_m(mul, mod);
+
+   // Expected result verified using the assembly implementation of ranluxppp
+   // and the following Python program:
+   //     >>> pattern1 = 0xdeafdeafdeafdeaf
+   //     >>> pattern2 = 0xf00df00df00df00d
+   //     >>> mul = 0
+   //     >>> for p in [
+   //     ...     pattern1, pattern2, pattern1, pattern2,
+   //     ...     pattern1, pattern1, pattern2, pattern2,
+   //     ...     pattern2, pattern1, pattern2, pattern1,
+   //     ...     pattern2, pattern2, pattern1, pattern1
+   //     ... ]:
+   //     ...     mul = (mul << 64) + p
+   //     ...
+   //     >>> m = (1 << 576) - (1 << 240) + 1
+   //     >>> mod = mul % m
+   //     >>> print(hex(mod))
+   EXPECT_EQ(mod[8], 0xf00e016c016c016b);
+   EXPECT_EQ(mod[7], 0xf00df00ecebdcebd);
+   EXPECT_EQ(mod[6], 0xe01bcebde01be01b);
+   EXPECT_EQ(mod[5], 0xcebde01bcebdcebd);
+   EXPECT_EQ(mod[4], 0xbd5fac01ac01ac01);
+   EXPECT_EQ(mod[3], 0xbd5d215021502150);
+   EXPECT_EQ(mod[2], 0x21500ff20ff20ff2);
+   EXPECT_EQ(mod[1], 0x0ff2215021502150);
+   EXPECT_EQ(mod[0], 0x2150215021502151);
+}
+
+TEST(mod_m, r_min)
+{
+   uint64_t mul[18] = {0};
+   mul[14] = 0xffffffffffff0000;
+   for (int i = 15; i < 18; i++) {
+      mul[i] = UINT64_MAX;
+   }
+   uint64_t mod[9];
+
+   mod_m(mul, mod);
+
+   // Expected result produced by the assembly implementation.
+   EXPECT_EQ(mod[0], 2);
+   EXPECT_EQ(mod[1], 0);
+   EXPECT_EQ(mod[2], 0);
+   EXPECT_EQ(mod[3], 0xfffd000000000000);
+   EXPECT_EQ(mod[4], 0xffffffffffffffff);
+   EXPECT_EQ(mod[5], 0xffff);
+   EXPECT_EQ(mod[6], 0);
+   EXPECT_EQ(mod[7], 0x0000000100000000);
+   EXPECT_EQ(mod[8], 0);
+}
+
+TEST(mod_m, r_max)
+{
+   uint64_t mul[18] = {0};
+   for (int i = 0; i < 14; i++) {
+      mul[i] = UINT64_MAX;
+   }
+   mul[14] = 0xffff;
+   uint64_t mod[9];
+
+   mod_m(mul, mod);
+
+   // Expected result produced by the assembly implementation.
+   for (int i = 0; i < 5; i++) {
+      EXPECT_EQ(mod[i], 0xffffffffffffffff);
+   }
+   EXPECT_EQ(mod[5], 0xfffffffffffeffff);
+   for (int i = 6; i < 9; i++) {
+      EXPECT_EQ(mod[i], 0xffffffffffffffff);
+   }
+}
+
+TEST(powermod, simple)
+{
+   uint64_t base[9] = {0};
+   base[0] = 2;
+   uint64_t res[9];
+
+   powermod(base, res, 15);
+
+   EXPECT_EQ(res[0], 1 << 15);
+   for (int i = 1; i < 9; i++) {
+      EXPECT_EQ(res[i], 0);
+   }
+}
+
+TEST(powermod, mod)
+{
+   uint64_t base[9] = {0};
+   base[0] = 2;
+   uint64_t res[9];
+
+   powermod(base, res, 576);
+
+   // The same result as mod_m::simple above:
+   // mod = 2 ** 576 - m = 2 ** 240 - 1, all first 240 bits set.
+   for (int i = 0; i < 3; i++) {
+      EXPECT_EQ(res[i], 0xffffffffffffffff);
+   }
+   EXPECT_EQ(res[3], 0x0000ffffffffffff);
+   for (int i = 4; i < 9; i++) {
+      EXPECT_EQ(res[i], 0);
+   }
+}
+
+TEST(powermod, alias)
+{
+   uint64_t a[9] = {0};
+   a[0] = 2;
+
+   // Can pass in the same pointer for base and res, the values should be
+   // copied before writing the output.
+   powermod(a, a, 15);
+
+   EXPECT_EQ(a[0], 1 << 15);
+   for (int i = 1; i < 9; i++) {
+      EXPECT_EQ(a[i], 0);
+   }
+}


### PR DESCRIPTION
RANLUX++ is an LCG equivalent of RANLUX using 576 bit numbers.

Described in
A. Sibidanov, *A revision of the subtract-with-borrow random numbergenerators*,
*Computer Physics Communications*, 221(2017), 299-303,
preprint https://arxiv.org/pdf/1705.03123.pdf

The code is loosely based on the Assembly implementation by A. Sibidanov
available at https://github.com/sibidanov/ranluxpp/.