### PR TITLE
Add THistRange class defining a generic histogram range and its iterator

### DIFF
--- a/hist/hist/CMakeLists.txt
+++ b/hist/hist/CMakeLists.txt
@@ -29,6 +29,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Hist
     TFitResultPtr.h
     TFormula.h
     TFractionFitter.h
+    THistRange.h
     TGraph2DErrors.h
     TGraph2D.h
     TGraphAsymmErrors.h
@@ -116,6 +117,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Hist
     TFormulaPrimitive_v5.cxx
     TFormula_v5.cxx
     TFractionFitter.cxx
+    THistRange.cxx
     TGraph2D.cxx
     TGraph2DErrors.cxx
     TGraphAsymmErrors.cxx

--- a/hist/hist/inc/LinkDef.h
+++ b/hist/hist/inc/LinkDef.h
@@ -67,6 +67,8 @@
 #pragma link C++ class TH2F-;
 #pragma link C++ class TH2Poly+;
 #pragma link C++ class TH2PolyBin+;
+#pragma link C++ class THistRange+;
+#pragma link C++ class TBinIterator+;
 #pragma link C++ class TProfile2Poly+;
 #pragma link C++ class TProfile2PolyBin+;
 #pragma link C++ class TH2S-;

--- a/hist/hist/inc/THistRange.h
+++ b/hist/hist/inc/THistRange.h
@@ -1,0 +1,158 @@
+// @(#)root/hist:$Id$
+// Author: Lorenzo MOneta 11/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2003, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_THistRange
+#define ROOT_THistRange
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// THistRange                                                           //
+//                                                                      //
+// Class defining a generic range of the histogram                      //
+// Used to iterated between bins                                        //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TError.h"  // for R__ASSERT
+
+class TH1;
+
+
+
+class TBinIterator {
+private:
+   int fBin;  // global bin number used to advanced
+   int fXbin; //  bin X number
+   int fYbin; // bin y number
+   int fZbin; // bin Z number
+
+   int fNx;   // total x size (nbins+2)
+   int fNy;   //  y size
+   int fNz;   // z size
+   int fXmin; // min x value
+   int fXmax; // max x value
+   int fYmin; // min y value
+   int fYmax; // max y value
+   int fZmin; // min z value
+   int fZmax; // max z value
+
+   int fDim; // histogram dimension
+
+   // compute global bin number given x,y,x bin numbers
+   void SetGlobalBin()
+   {
+      if (fDim == 1)
+         fBin = fXbin;
+      else if (fDim == 2)
+         fBin = fXbin + fNx * fYbin;
+      else
+         fBin = fXbin + fNx * (fYbin + fNy * fZbin);
+   }
+
+   // private default ctor (used by THistRange)
+   TBinIterator()
+      : fBin(0), fXbin(0), fYbin(0), fZbin(0), fNx(0), fNy(0), fNz(0), fXmin(0), fXmax(0), fYmin(0), fYmax(0), fZmin(0),
+        fZmax(0), fDim(0)
+   {
+   }
+
+public:
+   friend class THistRange;
+
+   // enum defining option range type:
+   enum ERangeType {
+      kHistRange, // use range provided by histogram
+      kAxisBins,  // use allbins within axis limits (no underflow/overflows)
+      kAllBins,   // use all bins including underflows/overflows
+      kUnOfBins   // collection of all underflow/overflow bins
+   };
+
+   TBinIterator(const TH1 *h, ERangeType type);
+   // TBinIterator(TBinIterator &rhs) = default;
+   // TBinIterator &operator=(const TBinIterator &) = default;
+
+   // implement end
+   static TBinIterator End()
+   {
+      TBinIterator end;
+      end.fBin = -1;
+      return end;
+   }
+
+   // keep inline to be faster
+   TBinIterator &operator++()
+   {
+      if (fXbin < fXmax)
+         fXbin++;
+      else if (fDim > 1) {
+         fXbin = fXmin;
+         if (fYbin < fYmax)
+            fYbin++;
+         else if (fDim > 2) {
+            fYbin = fYmin;
+            if (fZbin < fZmax)
+               fZbin++;
+            else {
+               fBin = -1;
+               return *this;
+            }
+         } else {
+            R__ASSERT(fDim == 2);
+            fBin = -1;
+            return *this;
+         }
+      } else {
+         R__ASSERT(fDim == 1);
+         fBin = -1;
+         return *this;
+      }
+      // fXbin can be incremented to zero only in case of TH2Poly
+      // where you can start from negative bin numbers
+      // In that case fXbin = 0 will be excluded
+      if (fXbin == 0) {
+         R__ASSERT(fXmin < 0 && fDim == 1);
+         fXbin = 1; // this happens in case of TH2Poly
+      }
+      SetGlobalBin();
+      return *this;
+   }
+
+   TBinIterator operator++(int)
+   {
+      TBinIterator tmp(*this);
+      operator++();
+      return tmp;
+   }
+
+   bool operator==(const TBinIterator &rhs) const { return fBin == rhs.fBin; }
+   bool operator!=(const TBinIterator &rhs) const { return fBin != rhs.fBin; }
+   int &operator*() { return fBin; }
+};
+
+class THistRange {
+
+public:
+   typedef TBinIterator iterator;
+   typedef TBinIterator::ERangeType RangeType;
+
+   iterator begin() { return fBegin; }
+
+   iterator end() { return fEnd; }
+
+   THistRange(const TH1 *h1, TBinIterator::ERangeType type = TBinIterator::kHistRange);
+
+protected:
+
+   TBinIterator fBegin;
+   TBinIterator fEnd;
+};
+
+
+#endif

--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -727,23 +727,27 @@ Double_t TH2Poly::Integral(Option_t* option) const
    TString opt = option;
    opt.ToLower();
 
+   Double_t w;
+   Double_t integral = 0.;
+
+   TIter next(fBins);
+   TObject *obj;
+   TH2PolyBin *bin;
    if ((opt.Contains("width")) || (opt.Contains("area"))) {
-      Double_t w;
-      Double_t integral = 0.;
-
-      TIter    next(fBins);
-      TObject *obj;
-      TH2PolyBin *bin;
-      while ((obj=next())) {
-         bin       = (TH2PolyBin*) obj;
-         w         = bin->GetArea();
-         integral += w*(bin->GetContent());
+      while ((obj = next())) {
+         bin = (TH2PolyBin *)obj;
+         w = bin->GetArea();
+         integral += w * (bin->GetContent());
       }
-
-      return integral;
    } else {
-      return fTsumw;
+      // need to recompute integral in case somebith called SetBinContent and
+      // cannot use fTsumw since it is not updated in that case
+      while ((obj = next())) {
+         bin = (TH2PolyBin *)obj;
+         integral += (bin->GetContent());
+      }
    }
+   return integral;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/THistRange.cxx
+++ b/hist/hist/src/THistRange.cxx
@@ -1,0 +1,92 @@
+// @(#)root/hist:$Id$
+// Author: Lorenzo MOneta 11/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2003, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "THistRange.h"
+
+#include "TH1.h"
+#include "TH2Poly.h"
+#include "TProfile2Poly.h"
+
+THistRange::THistRange(const TH1 *h1, RangeType type)
+{
+   fBegin = TBinIterator(h1, type);
+   fEnd = TBinIterator::End();
+}
+
+// implementation of TBinIterator class
+
+/// constructor of  TBInIterator taking as input an histogram pointer
+/// This constructors set iterator, the global bin,  to its first value (begin)
+TBinIterator::TBinIterator(const TH1 *h, ERangeType type)
+{
+   // deal with special cases (e.g. TH2Poly)
+   if (h->IsA() == TH2Poly::Class() || h->IsA() == TProfile2Poly::Class()) {
+      const TH2Poly *hpoly = static_cast<const TH2Poly *>(h);
+      R__ASSERT(hpoly);
+      if (type == TBinIterator::kAllBins) {
+         // this will loop on all bins (one should exclude 0)
+         fXmin = -9;
+         fXmax = hpoly->GetNumberOfBins();
+      } else if (type != TBinIterator::kUnOfBins) {
+         // overflow bins in TH2Poly are from -9 to -1
+         fXmin = -9;
+         fXmax = -1;
+      } else {
+         // standard bin loop
+         fXmin = 1;
+         fXmax = hpoly->GetNumberOfBins();
+      }
+
+      fYmin = 0;
+      fYmax = 0;
+      fZmin = 0;
+      fZmax = 0;
+      fDim = 1; // this case is equivalent to have one dimension
+   }
+   // general case for TH1,TH2, TH3 and prfile classes
+   else {
+
+      fNx = h->GetNbinsX() + 2;
+      fNy = h->GetNbinsY() + 2;
+      fNz = h->GetNbinsZ() + 2;
+      fDim = h->GetDimension();
+
+      if (type == TBinIterator::kHistRange) {
+         fXmin = h->GetXaxis()->GetFirst();
+         fXmax = h->GetXaxis()->GetLast();
+         fYmin = h->GetYaxis()->GetFirst();
+         fYmax = h->GetYaxis()->GetLast();
+         fZmin = h->GetZaxis()->GetFirst();
+         fZmax = h->GetZaxis()->GetLast();
+      } else if (type == TBinIterator::kAxisBins) {
+         fXmin = 1;
+         fXmax = h->GetNbinsX();
+         fYmin = 1;
+         fYmax = h->GetNbinsY();
+         fZmin = 1;
+         fZmax = h->GetNbinsZ();
+      } else if (type == TBinIterator::kAllBins || type == TBinIterator::kUnOfBins) {
+         fXmin = 0;
+         fXmax = h->GetNbinsX() + 1;
+         fYmin = 0;
+         fYmax = h->GetNbinsY() + 1;
+         fZmin = 0;
+         fZmax = h->GetNbinsZ() + 1;
+      }
+   }
+
+   // set bins to initial value
+   fXbin = fXmin;
+   fYbin = fYmin;
+   fZbin = fZmin;
+
+   SetGlobalBin();
+}

--- a/hist/hist/src/THistRange.cxx
+++ b/hist/hist/src/THistRange.cxx
@@ -37,7 +37,7 @@ TBinIterator::TBinIterator(const TH1 *h, ERangeType type)
          // this will loop on all bins (one should exclude 0)
          fXmin = -9;
          fXmax = hpoly->GetNumberOfBins();
-      } else if (type != TBinIterator::kUnOfBins) {
+      } else if (type == TBinIterator::kUnOfBins) {
          // overflow bins in TH2Poly are from -9 to -1
          fXmin = -9;
          fXmax = -1;

--- a/hist/hist/src/THistRange.cxx
+++ b/hist/hist/src/THistRange.cxx
@@ -26,6 +26,8 @@ THistRange::THistRange(const TH1 *h1, RangeType type)
 /// constructor of  TBInIterator taking as input an histogram pointer
 /// This constructors set iterator, the global bin,  to its first value (begin)
 TBinIterator::TBinIterator(const TH1 *h, ERangeType type)
+   : fNx(0), fNy(0), fNz(0),
+     fXmin(0), fXmax(0), fYmin(0), fYmax(0), fZmin(0), fZmax(0)
 {
    // deal with special cases (e.g. TH2Poly)
    if (h->IsA() == TH2Poly::Class() || h->IsA() == TProfile2Poly::Class()) {

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -15,6 +15,7 @@ ROOT_ADD_GTEST(testTH1FindFirstBinAbove test_TH1_FindFirstBinAbove.cxx LIBRARIES
 ROOT_ADD_GTEST(test_TEfficiency test_TEfficiency.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(TGraphMultiErrorsTests TGraphMultiErrorsTests.cxx LIBRARIES Hist RIO)
 ROOT_ADD_GTEST(test_TF123_Moments test_TF123_Moments.cxx LIBRARIES Hist)
+ROOT_ADD_GTEST(test_THBinIterator test_THBinIterator.cxx LIBRARIES Hist)
 
 if(fftw3)
   ROOT_ADD_GTEST(testTF1 test_tf1.cxx LIBRARIES Hist)

--- a/hist/hist/test/test_THBinIterator.cxx
+++ b/hist/hist/test/test_THBinIterator.cxx
@@ -1,0 +1,378 @@
+#include "gtest/gtest.h"
+
+// test iterating histogram bins and using the new THistRange and
+// THBinIterator classes
+
+#include "TH1.h"
+#include "TH2.h"
+#include "TH3.h"
+#include "TRandom.h"
+#include "THistRange.h"
+#include "TStopwatch.h"
+
+// global variables
+int printLevel = 0;
+bool fastMode = true;
+
+double testAxisIter(TH1 *h)
+{
+
+   TStopwatch w;
+   w.Start();
+
+
+   int xmin = h->GetXaxis()->GetFirst();
+   int xmax = h->GetXaxis()->GetLast();
+   int ymin = h->GetYaxis()->GetFirst();
+   int ymax = h->GetYaxis()->GetLast();
+   int zmin = h->GetZaxis()->GetFirst();
+   int zmax = h->GetZaxis()->GetLast();
+
+   double sum = 0;
+   for (int i = xmin; i <= xmax; ++i) {
+      for (int j = ymin; j <= ymax; ++j) {
+         for (int k = zmin; k <= zmax; ++k) {
+            sum += h->GetBinContent(i, j, k); // this is faster than GetBin
+            // int iglob = h->GetBin(i,j,k);
+            // sum += h->GetArray()[iglob];
+         }
+      }
+   }
+   w.Stop();
+   if (printLevel) {
+      w.Print();
+      std::cout << "Axis iteration: integral is : " << sum << std::endl;
+   }
+   return sum;
+}
+
+double testBinGlobalIter(TH1 *h)
+{
+
+   TStopwatch w;
+   w.Start();
+
+   //std::cout << "Use GetBinXYZ and global bin iteration " << std::endl;
+
+
+   int xmin = h->GetXaxis()->GetFirst();
+   int xmax = h->GetXaxis()->GetLast();
+   int ymin = h->GetYaxis()->GetFirst();
+   int ymax = h->GetYaxis()->GetLast();
+   int zmin = h->GetZaxis()->GetFirst();
+   int zmax = h->GetZaxis()->GetLast();
+
+   int n = h->GetNcells();
+
+   // look at case when one uses all in range bins
+   bool useAllInBins = false;
+   if (!h->GetXaxis()->TestBit(TAxis::kAxisRange) && !h->GetYaxis()->TestBit(TAxis::kAxisRange) &&
+       !h->GetZaxis()->TestBit(TAxis::kAxisRange))
+      useAllInBins = true;
+
+   if (h->GetDimension() < 3) {
+      zmin = 0;
+      zmax = 0;
+      if (h->GetDimension() < 2) {
+         ymin = 0;
+         ymax = 0;
+      }
+   }
+
+   double sum = 0;
+   if (!useAllInBins) {
+      int ix, iy, iz;
+      for (int i = 0; i < n; ++i) {
+         // use GetBinXYZ to get axis bin numbers
+         h->GetBinXYZ(i, ix, iy, iz);
+         if (ix >= xmin && ix <= xmax && iy >= ymin && iy <= ymax && iz >= zmin && iz <= zmax) {
+            sum += h->GetBinContent(i);
+         }
+      }
+   }
+   else {
+      // exclude only underflow/overflow
+      for (int i = 0; i < n; ++i) {
+         if (h->IsBinOverflow(i) || h->IsBinUnderflow(i))
+            continue;
+         sum += h->GetBinContent(i);
+      }
+   }
+   if (printLevel) {
+      w.Print();
+      std::cout << "GlobalBinIteration: integral is : " << sum << std::endl;
+   }
+   return sum;
+}
+
+double testTHBinIterator(TH1 * h) {
+
+   //std::cout << "Use new TBinIterator class " << std::endl;
+
+   TStopwatch w;
+   w.Start();
+
+   THistRange r(h);
+
+   double sum = 0;
+   for (auto it = r.begin(); it != r.end(); it++) {
+      int bin = *it;
+      sum += h->GetBinContent(bin);
+   }
+
+   if (printLevel) {
+      w.Print();
+      std::cout << "THBinIterator: integral is : " << sum << std::endl;
+   }
+   return sum;
+}
+
+// creation of histograms
+int nEvents = 1000000;
+TH1 *createTH1()
+{
+   int nbins = (fastMode) ? 1000000 : 100000000;
+   if (printLevel)
+      std::cout << "TH1 tests: create and fill a 1d histogram with " << std::pow(nbins,1) << " nbins" << std::endl;
+
+   auto h1 = new TH1D("h1", "h1", nbins, 0, 10);
+   const int n = nEvents;
+   for (int i = 0; i < n;  ++i) {
+      double x = gRandom->Gaus(5, 2);
+      h1->Fill(x);
+   }
+   return h1;
+}
+TH1 *createTH2()
+{
+   int nbins = (fastMode) ? 1000 : 10000;
+   if (printLevel)
+      std::cout << "TH2 tests: create and fill a 2d histogram with " << std::pow(nbins, 2) << " nbins" << std::endl;
+   auto h1 = new TH2D("h2", "h2", nbins, 0, 10, nbins, 0, 10);
+   const int n = nEvents;
+   for (int i = 0; i < n; ++i) {
+      double x = gRandom->Gaus(5, 2);
+      double y = gRandom->Gaus(1, 3);
+      h1->Fill(x, y);
+   }
+   return h1;
+}
+TH1 *createTH3()
+{
+   int nbins = (fastMode) ? 100 : 500;
+   if (printLevel)
+      std::cout << "TH3 tests : create and fill 3d histogram with " << std::pow(nbins, 3) << " nbins" << std::endl;
+   auto h1 = new TH3D("h3", "h3", nbins, 0, 10, nbins, 0, 10, nbins, 0, 10);
+   const int n = nEvents;
+   for (int i = 0; i < n; ++i) {
+      double x = gRandom->Gaus(5, 2);
+      double y = gRandom->Gaus(1, 3);
+      double z = gRandom->Gaus(0, 5);
+      h1->Fill(x, y, z);
+   }
+   return h1;
+}
+
+// test classes
+class THIterationTestBase : public ::testing::Test {
+protected:
+
+
+   static TH1 *h1;
+   static double refValue;
+   static void TearDownTestSuite() {
+      //GOOD:  this is called after running same test suite and not at
+      // end of main program.
+      if (printLevel) std::cout << "Delete histogram " << h1->GetName() << std::endl;
+      delete h1;
+   }
+};
+TH1 * THIterationTestBase::h1 = nullptr;
+double THIterationTestBase::refValue = 0;
+
+// TH1 test classes -
+class TestTH1DFull : public THIterationTestBase {
+protected:
+   static void SetUpTestSuite() {
+      h1 = createTH1();
+      refValue = h1->Integral();
+   }
+};
+class TestTH1DRange : public THIterationTestBase {
+protected:
+   static void SetUpTestSuite()
+   {
+      h1 = createTH1();
+      // test 60% of histogram
+      int xmin = 0.2 * h1->GetNbinsX();
+      int xmax = 0.8 * h1->GetNbinsX();
+      h1->GetXaxis()->SetRange(xmin, xmax);
+      refValue = h1->Integral(xmin,xmax);
+   }
+};
+// TH2 classes
+
+class TestTH2DFull : public THIterationTestBase {
+protected:
+   static void SetUpTestSuite()
+   {
+      h1 = createTH2();
+      refValue = h1->Integral();
+   }
+};
+
+class TestTH2DRange : public THIterationTestBase {
+protected:
+   static void SetUpTestSuite()
+   {
+      h1 = createTH2();
+      // test 60% of histogram
+      int xmin = 0.2 * h1->GetNbinsX();
+      int xmax = 0.8 * h1->GetNbinsX();
+      h1->GetXaxis()->SetRange(xmin, xmax);
+      int ymin = 0.2 * h1->GetNbinsY();
+      int ymax = 0.8 * h1->GetNbinsY();
+      h1->GetYaxis()->SetRange(ymin, ymax);
+      refValue = ((TH2* )h1)->Integral(xmin, xmax, ymin, ymax);
+   }
+};
+// TH3 classes
+class TestTH3DFull : public THIterationTestBase {
+protected:
+   static void SetUpTestSuite()
+   {
+      h1 = createTH3();
+      refValue = h1->Integral();
+   }
+};
+
+class TestTH3DRange : public THIterationTestBase {
+protected:
+   static void SetUpTestSuite()
+   {
+      h1 = createTH3();
+      // createTH3();
+      // test 60% of histogram
+      // test 60% of histogram
+      int xmin = 0.2 * h1->GetNbinsX();
+      int xmax = 0.8 * h1->GetNbinsX();
+      h1->GetXaxis()->SetRange(xmin, xmax);
+      int ymin = 0.2 * h1->GetNbinsY();
+      int ymax = 0.8 * h1->GetNbinsY();
+      h1->GetYaxis()->SetRange(ymin, ymax);
+      int zmin = 0.2 * h1->GetNbinsZ();
+      int zmax = 0.8 * h1->GetNbinsZ();
+      h1->GetZaxis()->SetRange(zmin, zmax);
+      refValue = ((TH3*) h1)->Integral(xmin, xmax, ymin, ymax,zmin,zmax);
+   }
+};
+
+// test with full range
+
+TEST_F(TestTH1DFull, AxisIteration)
+{
+   EXPECT_EQ(testAxisIter(h1), refValue);
+}
+TEST_F(TestTH1DFull, GlobalIteration)
+{
+   EXPECT_EQ(testBinGlobalIter(h1), refValue);
+}
+TEST_F(TestTH1DFull, BinIterator)
+{
+   EXPECT_EQ(testTHBinIterator(h1), refValue);
+}
+
+// test with restricted range
+TEST_F(TestTH1DRange, AxisIteration)
+{
+   EXPECT_EQ(testAxisIter(h1), refValue);
+}
+TEST_F(TestTH1DRange, GlobalIteration)
+{
+   EXPECT_EQ(testBinGlobalIter(h1), refValue);
+}
+TEST_F(TestTH1DRange, BinIterator)
+{
+   EXPECT_EQ(testTHBinIterator(h1), refValue);
+}
+
+// TH2D tests
+TEST_F(TestTH2DFull, AxisIteration)
+{
+   EXPECT_EQ(testAxisIter(h1), refValue);
+}
+TEST_F(TestTH2DFull, GlobalIteration)
+{
+   EXPECT_EQ(testBinGlobalIter(h1), refValue);
+}
+TEST_F(TestTH2DFull, BinIterator)
+{
+   EXPECT_EQ(testTHBinIterator(h1), refValue);
+}
+// 2D tests with restricted range
+TEST_F(TestTH2DRange, AxisIteration)
+{
+   EXPECT_EQ(testAxisIter(h1), refValue);
+}
+TEST_F(TestTH2DRange, GlobalIteration)
+{
+   EXPECT_EQ(testBinGlobalIter(h1), refValue);
+}
+TEST_F(TestTH2DRange, BinIterator)
+{
+   EXPECT_EQ(testTHBinIterator(h1), refValue);
+}
+
+// TH3D tests
+TEST_F(TestTH3DFull, AxisIteration)
+{
+   EXPECT_EQ(testAxisIter(h1), refValue);
+}
+TEST_F(TestTH3DFull, GlobalIteration)
+{
+   EXPECT_EQ(testBinGlobalIter(h1), refValue);
+}
+TEST_F(TestTH3DFull, BinIterator)
+{
+   EXPECT_EQ(testTHBinIterator(h1), refValue);
+}
+// 3D tests with restricted range
+TEST_F(TestTH3DRange, AxisIteration)
+{
+   EXPECT_EQ(testAxisIter(h1), refValue);
+}
+TEST_F(TestTH3DRange, GlobalIteration)
+{
+   EXPECT_EQ(testBinGlobalIter(h1), refValue);
+}
+TEST_F(TestTH3DRange, BinIterator)
+{
+   EXPECT_EQ(testTHBinIterator(h1), refValue);
+}
+
+int main(int argc, char **argv)
+{
+
+   // Disables elapsed time by default.
+   //::testing::GTEST_FLAG(print_time) = false;
+
+
+   // Parse command line arguments
+   for (Int_t i = 1; i < argc; i++) {
+      std::string arg = argv[i];
+      if (arg == "-v") {
+         std::cout << "---running in verbose mode" << std::endl;
+         printLevel = 1;
+      } else if (arg == "-b") {
+         std::cout << "---running in benchmark mode to measure time" << std::endl;
+         fastMode = false;
+      }
+   }
+
+
+   // This allows the user to override the flag on the command line.
+   ::testing::InitGoogleTest(&argc, argv);
+
+
+   return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The THistRange class define a generic bin range region which can be used to efficiently iterate over bins.
It is used to create a THBinIterator class which can used to iterate over bins
without using for loops over axis or simple global bin iterations.
Example for computing histogram integral in a given range: 

```
auto hist = new TH1D("h1","h1",100,-5,5);
hist->FillRandom("gaus");  
hist->GetXaxis()->SetRange(40,60); 
THistRange r(hist); 
double integral = 0; 
for (auto & bin : r) {   integral += hist->GetBinContent(bin);  }
std::cout << "integral " << integral << std::endl;
```


Add also a test program which measures the ieration time. When iterating over a multi-dimensional histogram (e.g. 3 d) the new iteration can be up to 10 times faster.