### PR TITLE
[webgui] Provide RAttrBase::CollectDefaults method

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -56,14 +56,7 @@ class RAttrAxis : public RAttrBase {
    RAttrValue<std::string> fTitlePos{this, "title_position", "right"};    ///<! axis title position - left, right, center
    RAttrValue<RPadLength>  fTitleOffset{this, "title_offset", {}};        ///<! axis title offset - relative to predefined position
 
-   R__ATTR_CLASS(RAttrAxis, "axis_", AddDefaults(fMin).AddDefaults(fMax)
-                                    .AddDefaults(fZoomMin).AddDefaults(fZoomMax)
-                                    .AddDefaults(fLog).AddDefaults(fReverse)
-                                    .AddDefaults(fTimeDisplay).AddDefaults(fTimeOffset).AddDefaults(fTimeFormat)
-                                    .AddDefaults(fAttrLine).AddDefaults(fEndingStyle).AddDefaults(fEndingSize)
-                                    .AddDefaults(fTicksSide).AddDefaults(fTicksSize).AddDefaults(fTicksColor)
-                                    .AddDefaults(fLabelsAttr).AddDefaults(fLabelsOffset).AddDefaults(fLabelsCenter)
-                                    .AddDefaults(fTitleAttr).AddDefaults(fTitle).AddDefaults(fTitlePos).AddDefaults(fTitleOffset));
+   R__ATTR_CLASS(RAttrAxis, "axis_");
 
    // min range, graphics will not show value less then this
    RAttrAxis &SetMin(double min) { fMin = min; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -39,24 +39,24 @@ class RAttrAxis : public RAttrBase {
    RAttrValue<double>      fTimeOffset{this, "time_offset", 0};           ///<! time offset to display
    RAttrValue<std::string> fTimeFormat{this, "time_format", ""};          ///<! time format
 
-   RAttrLine               fAttrLine{this, "line_"};                      ///<! line attributes
+   RAttrLine               fAttrLine{this, "line"};                       ///<! line attributes
    RAttrValue<std::string> fEndingStyle{this, "ending_style", ""};        ///<! axis ending style - none, arrow, circle
    RAttrValue<RPadLength>  fEndingSize{this, "ending_size", 0.02_normal}; ///<! axis ending size
 
    RAttrValue<std::string> fTicksSide{this, "ticks_side", "normal"};      ///<! ticks position - normal, invert, both
    RAttrValue<RPadLength>  fTicksSize{this, "ticks_size", 0.02_normal};   ///<! ticks size
-   RAttrColor              fTicksColor{this, "ticks_color_"};             ///<! ticks color
+   RAttrColor              fTicksColor{this, "ticks_color"};              ///<! ticks color
 
-   RAttrText               fLabelsAttr{this, "labels_"};                  ///<! text attributes for labels
+   RAttrText               fLabelsAttr{this, "labels"};                   ///<! text attributes for labels
    RAttrValue<RPadLength>  fLabelsOffset{this, "labels_offset", {}};      ///<! axis labels offset - relative to predefined position
    RAttrValue<bool>        fLabelsCenter{this, "labels_center", false};   ///<! center labels
 
-   RAttrText               fTitleAttr{this, "title_"};                    ///<! axis title text attributes
+   RAttrText               fTitleAttr{this, "title"};                     ///<! axis title text attributes
    RAttrValue<std::string> fTitle{this, "title", ""};                     ///<! axis title
    RAttrValue<std::string> fTitlePos{this, "title_position", "right"};    ///<! axis title position - left, right, center
    RAttrValue<RPadLength>  fTitleOffset{this, "title_offset", {}};        ///<! axis title offset - relative to predefined position
 
-   R__ATTR_CLASS(RAttrAxis, "axis_");
+   R__ATTR_CLASS(RAttrAxis, "axis");
 
    // min range, graphics will not show value less then this
    RAttrAxis &SetMin(double min) { fMin = min; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
@@ -188,7 +188,7 @@ public:
 } // namespace Experimental
 } // namespace ROOT
 
-#define R__ATTR_CLASS(ClassName,dflt_prefix,dflt_values) \
+#define R__ATTR_CLASS(ClassName,dflt_prefix) \
 protected: \
 const RAttrMap &GetDefaults() const override \
 { \

--- a/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
@@ -192,7 +192,7 @@ public:
 protected: \
 const RAttrMap &GetDefaults() const override \
 { \
-   static auto dflts = RAttrMap().dflt_values; \
+   static auto dflts = CollectDefaults(); \
    return dflts; \
 } \
 public: \

--- a/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
@@ -174,6 +174,8 @@ protected:
 
    virtual RAttrMap CollectDefaults() const;
 
+   virtual bool IsValue() const { return false; }
+
 public:
    RAttrBase() = default;
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBase.hxx
@@ -172,6 +172,8 @@ protected:
       return Eval<T>(name);
    }
 
+   virtual RAttrMap CollectDefaults() const;
+
 public:
    RAttrBase() = default;
 
@@ -179,6 +181,7 @@ public:
 
    friend bool operator==(const RAttrBase& lhs, const RAttrBase& rhs) { return lhs.IsSame(rhs) && rhs.IsSame(lhs); }
    friend bool operator!=(const RAttrBase& lhs, const RAttrBase& rhs) { return !lhs.IsSame(rhs) || !rhs.IsSame(lhs); }
+
 };
 
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrBox.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBox.hxx
@@ -26,10 +26,10 @@ namespace Experimental {
 
 class RAttrBox : public RAttrBase {
 
-   RAttrLine    fAttrBorder{this, "border_"};   ///<! box line attributes
-   RAttrFill    fAttrFill{this, "fill_"};       ///<! box fill attributes
+   RAttrLine    fAttrBorder{this, "border"};    ///<! box line attributes
+   RAttrFill    fAttrFill{this, "fill"};        ///<! box fill attributes
 
-   R__ATTR_CLASS(RAttrBox, "box_");
+   R__ATTR_CLASS(RAttrBox, "box");
 
    const RAttrLine &GetAttrBorder() const { return fAttrBorder; }
    RAttrBox &SetAttrBorder(const RAttrLine &border) { fAttrBorder = border; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrBox.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBox.hxx
@@ -29,7 +29,7 @@ class RAttrBox : public RAttrBase {
    RAttrLine    fAttrBorder{this, "border_"};   ///<! box line attributes
    RAttrFill    fAttrFill{this, "fill_"};       ///<! box fill attributes
 
-   R__ATTR_CLASS(RAttrBox, "box_", AddDefaults(fAttrBorder).AddDefaults(fAttrFill));
+   R__ATTR_CLASS(RAttrBox, "box_");
 
    const RAttrLine &GetAttrBorder() const { return fAttrBorder; }
    RAttrBox &SetAttrBorder(const RAttrLine &border) { fAttrBorder = border; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
@@ -37,6 +37,8 @@ class RAttrColor : public RAttrBase {
 
 protected:
 
+   RAttrMap CollectDefaults() const override { return RAttrMap().AddString("rgb", "").AddString("a", "").AddString("name", "").AddBool("auto", false); }
+
    /** Set color as plain SVG name like "white" or "lightblue". Clears RGB component before */
    void SetName(const std::string &_name) { SetValue("name", _name); }
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
@@ -32,7 +32,7 @@ welcome!
 
 class RAttrColor : public RAttrBase {
 
-   R__ATTR_CLASS(RAttrColor, "color_");
+   R__ATTR_CLASS(RAttrColor, "color");
 
 protected:
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrColor.hxx
@@ -32,11 +32,11 @@ welcome!
 
 class RAttrColor : public RAttrBase {
 
-   R__ATTR_CLASS(RAttrColor, "color_",
-                 AddString("rgb", "").AddString("a", "").AddString("name", "").AddBool("auto", false));
+   R__ATTR_CLASS(RAttrColor, "color_");
 
 protected:
 
+   /** Provide possible attributes names and values */
    RAttrMap CollectDefaults() const override { return RAttrMap().AddString("rgb", "").AddString("a", "").AddString("name", "").AddBool("auto", false); }
 
    /** Set color as plain SVG name like "white" or "lightblue". Clears RGB component before */

--- a/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
@@ -29,7 +29,7 @@ class RAttrFill : public RAttrBase {
    RAttrColor       fColor{this, "color_"};    ///<! fill color
    RAttrValue<int>  fStyle{this, "style", 1};  ///<! fill style
 
-   R__ATTR_CLASS(RAttrFill, "fill_", AddDefaults(fColor).AddDefaults(fStyle));
+   R__ATTR_CLASS(RAttrFill, "fill_");
 
    ///The fill style
    RAttrFill &SetStyle(int style) { fStyle = style; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
@@ -26,10 +26,10 @@ namespace Experimental {
 
 class RAttrFill : public RAttrBase {
 
-   RAttrColor       fColor{this, "color_"};    ///<! fill color
+   RAttrColor       fColor{this, "color"};     ///<! fill color
    RAttrValue<int>  fStyle{this, "style", 1};  ///<! fill style
 
-   R__ATTR_CLASS(RAttrFill, "fill_");
+   R__ATTR_CLASS(RAttrFill, "fill");
 
    ///The fill style
    RAttrFill &SetStyle(int style) { fStyle = style; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
@@ -26,11 +26,11 @@ namespace Experimental {
 
 class RAttrLine : public RAttrBase {
 
-   RAttrColor          fColor{this, "color_"};     ///<! line color
+   RAttrColor          fColor{this, "color"};      ///<! line color
    RAttrValue<double>  fWidth{this, "width", 1.};  ///<! line width
    RAttrValue<int>     fStyle{this, "style", 1};   ///<! line style
 
-   R__ATTR_CLASS(RAttrLine, "line_");
+   R__ATTR_CLASS(RAttrLine, "line");
 
    ///The width of the line.
    RAttrLine &SetWidth(double width) { fWidth = width; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
@@ -30,7 +30,7 @@ class RAttrLine : public RAttrBase {
    RAttrValue<double>  fWidth{this, "width", 1.};  ///<! line width
    RAttrValue<int>     fStyle{this, "style", 1};   ///<! line style
 
-   R__ATTR_CLASS(RAttrLine, "line_", AddDefaults(fColor).AddDefaults(fWidth).AddDefaults(fStyle));
+   R__ATTR_CLASS(RAttrLine, "line_");
 
    ///The width of the line.
    RAttrLine &SetWidth(double width) { fWidth = width; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
@@ -31,7 +31,7 @@ class RAttrMargins : public RAttrBase {
    RAttrValue<RPadLength>   fTop{this, "top", 0._normal};
    RAttrValue<RPadLength>   fBottom{this, "bottom", 0._normal};
 
-   R__ATTR_CLASS(RAttrMargins, "margin_");
+   R__ATTR_CLASS(RAttrMargins, "margin");
 
 public:
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
@@ -31,7 +31,7 @@ class RAttrMargins : public RAttrBase {
    RAttrValue<RPadLength>   fTop{this, "top", 0._normal};
    RAttrValue<RPadLength>   fBottom{this, "bottom", 0._normal};
 
-   R__ATTR_CLASS(RAttrMargins, "margin_", AddDefaults(fLeft).AddDefaults(fRight).AddDefaults(fTop).AddDefaults(fBottom));
+   R__ATTR_CLASS(RAttrMargins, "margin_");
 
 public:
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
@@ -30,7 +30,7 @@ class RAttrMarker : public RAttrBase {
    RAttrValue<double>   fSize{this, "size", 1.};    ///<! marker size
    RAttrValue<int>      fStyle{this, "style", 1};   ///<! marker style
 
-   R__ATTR_CLASS(RAttrMarker, "marker_", AddDefaults(fColor).AddDefaults(fSize).AddDefaults(fStyle));
+   R__ATTR_CLASS(RAttrMarker, "marker_");
 
    RAttrMarker &SetColor(const RColor &color) { fColor = color; return *this; }
    RColor GetColor() const { return fColor.GetColor(); }

--- a/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
@@ -26,11 +26,11 @@ namespace Experimental {
 
 class RAttrMarker : public RAttrBase {
 
-   RAttrColor           fColor{this, "color_"};     ///<! marker color
+   RAttrColor           fColor{this, "color"};      ///<! marker color
    RAttrValue<double>   fSize{this, "size", 1.};    ///<! marker size
    RAttrValue<int>      fStyle{this, "style", 1};   ///<! marker style
 
-   R__ATTR_CLASS(RAttrMarker, "marker_");
+   R__ATTR_CLASS(RAttrMarker, "marker");
 
    RAttrMarker &SetColor(const RColor &color) { fColor = color; return *this; }
    RColor GetColor() const { return fColor.GetColor(); }

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -26,13 +26,13 @@ namespace Experimental {
 
 class RAttrText : public RAttrBase {
 
-   RAttrColor           fColor{this, "color_"};       ///<! text color
+   RAttrColor           fColor{this, "color"};        ///<! text color
    RAttrValue<double>   fSize{this, "size", 12.};     ///<! text size
    RAttrValue<double>   fAngle{this, "angle", 0.};    ///<! text angle
    RAttrValue<int>      fAlign{this, "align", 22};    ///<! text align
    RAttrValue<int>      fFont{this, "font", 41};      ///<! text font
 
-   R__ATTR_CLASS(RAttrText, "text_");
+   R__ATTR_CLASS(RAttrText, "text");
 
    ///The text size
    RAttrText &SetSize(double sz) { fSize = sz; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -32,7 +32,7 @@ class RAttrText : public RAttrBase {
    RAttrValue<int>      fAlign{this, "align", 22};    ///<! text align
    RAttrValue<int>      fFont{this, "font", 41};      ///<! text font
 
-   R__ATTR_CLASS(RAttrText, "text_", AddDefaults(fColor).AddDefaults(fSize).AddDefaults(fAngle).AddDefaults(fAlign).AddDefaults(fFont));
+   R__ATTR_CLASS(RAttrText, "text_");
 
    ///The text size
    RAttrText &SetSize(double sz) { fSize = sz; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
@@ -31,6 +31,8 @@ protected:
 
    const RAttrMap &GetDefaults() const override { return fDefaults; }
 
+   bool IsValue() const override { return true; }
+
 public:
 
    RAttrValue() = default;

--- a/graf2d/gpadv7/inc/ROOT/RAxisDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAxisDrawable.hxx
@@ -34,7 +34,7 @@ class RAxisDrawable : public RDrawable {
    RPadPos fPos;                          ///< axis start point
    bool fVertical{false};                 ///< is vertical axis
    RPadLength fLength;                    ///< axis length
-   RAttrAxis fAttrAxis{this, "axis_"};    ///<! axis attributes
+   RAttrAxis fAttrAxis{this, "axis"};     ///<! axis attributes
 
 public:
 

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -145,12 +145,12 @@ public:
 
 private:
 
-   RAttrMargins                     fMargins{this, "margin_"};        ///<!
-   RAttrLine                        fAttrBorder{this, "border_"};     ///<!
-   RAttrFill                        fAttrFill{this, "fill_"};         ///<!
-   RAttrAxis                        fAttrX{this, "x_"};               ///<!
-   RAttrAxis                        fAttrY{this, "y_"};               ///<!
-   RAttrAxis                        fAttrZ{this, "z_"};               ///<!
+   RAttrMargins                     fMargins{this, "margin"};         ///<!
+   RAttrLine                        fAttrBorder{this, "border"};      ///<!
+   RAttrFill                        fAttrFill{this, "fill"};          ///<!
+   RAttrAxis                        fAttrX{this, "x"};                ///<!
+   RAttrAxis                        fAttrY{this, "y"};                ///<!
+   RAttrAxis                        fAttrZ{this, "z"};                ///<!
    RAttrValue<bool>                 fGridX{this, "gridx", false};     ///<!
    RAttrValue<bool>                 fGridY{this, "gridy", false};     ///<!
    std::map<unsigned, RUserRanges>  fClientRanges;                    ///<! individual client ranges

--- a/graf2d/gpadv7/inc/ROOT/RPad.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPad.hxx
@@ -30,7 +30,7 @@ class RPad: public RPadBase {
    RPadPos fPos;                           ///< pad position
    RPadExtent fSize;                       ///< pad size
 
-   RAttrLine fAttrLine{this, "border_"};   ///<! border attributes
+   RAttrLine fAttrLine{this, "border"};    ///<! border attributes
 
 protected:
 

--- a/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
@@ -33,7 +33,7 @@ namespace Experimental {
 class RPaletteDrawable final : public RDrawable {
 
    RPalette                fPalette;                              ///<  color palette to draw
-   RAttrAxis               fAttrAxis{this, "axis_"};              ///<! axis attributes
+   RAttrAxis               fAttrAxis{this, "axis"};               ///<! axis attributes
    RAttrValue<bool>        fVisible{this, "visible", true};       ///<! visibility flag
    RAttrValue<RPadLength>  fMargin{this, "margin", 0.02_normal};  ///<! margin
    RAttrValue<RPadLength>  fSize{this, "size", 0.05_normal};      ///<! margin

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -30,9 +30,9 @@ namespace Experimental {
 
 class RPave : public RDrawable {
 
-   RAttrText                fAttrText{this, "text_"};        ///<! text attributes
-   RAttrLine                fAttrBorder{this, "border_"};    ///<! border attributes
-   RAttrFill                fAttrFill{this, "fill_"};        ///<! line attributes
+   RAttrText               fAttrText{this, "text"};          ///<! text attributes
+   RAttrLine               fAttrBorder{this, "border"};      ///<! border attributes
+   RAttrFill               fAttrFill{this, "fill"};          ///<! line attributes
    RAttrValue<RPadLength>  fCornerX{this, "cornerx", 0.02};  ///<! X corner
    RAttrValue<RPadLength>  fCornerY{this, "cornery", 0.02};  ///<! Y corner
    RAttrValue<RPadLength>  fWidth{this, "width", 0.4};       ///<! pave width

--- a/graf2d/gpadv7/src/RAttrBase.cxx
+++ b/graf2d/gpadv7/src/RAttrBase.cxx
@@ -202,12 +202,7 @@ ROOT::Experimental::RAttrMap ROOT::Experimental::RAttrBase::CollectDefaults() co
    auto thisClass = TClass::GetClass(info);
    auto baseClass = TClass::GetClass<ROOT::Experimental::RAttrBase>();
    if (thisClass && baseClass) {
-
-      TIter iter(thisClass->GetListOfDataMembers());
-      TObject *member = nullptr;
-      while ((member = iter()) != nullptr) {
-         TDataMember *data_member = dynamic_cast<TDataMember *> (member);
-
+      for (auto data_member: TRangeDynCast<TDataMember>(thisClass->GetListOfDataMembers())) {
          if (data_member && data_member->GetClass() && data_member->GetClass()->InheritsFrom(baseClass) &&
              (data_member->GetClass()->GetBaseClassOffset(baseClass) == 0)) {
                res.AddDefaults(*((const RAttrBase *)((char*) this + data_member->GetOffset())));

--- a/graf2d/gpadv7/src/RAttrBase.cxx
+++ b/graf2d/gpadv7/src/RAttrBase.cxx
@@ -97,6 +97,7 @@ void ROOT::Experimental::RAttrBase::AssignDrawable(RDrawable *drawable, const st
    fDrawable = drawable;
    fOwnAttr.reset();
    fPrefix = prefix;
+   if (!IsValue() && !fPrefix.empty()) fPrefix.append("_"); // naming convention
    fParent = nullptr;
 }
 
@@ -108,6 +109,7 @@ void ROOT::Experimental::RAttrBase::AssignParent(RAttrBase *parent, const std::s
    fDrawable = nullptr;
    fOwnAttr.reset();
    fPrefix = prefix;
+   if (!IsValue() && !fPrefix.empty()) fPrefix.append("_"); // naming convention
    fParent = parent;
 }
 

--- a/graf2d/gpadv7/test/attribute.cxx
+++ b/graf2d/gpadv7/test/attribute.cxx
@@ -10,6 +10,9 @@ class CustomAttrs : public RAttrBase {
    RAttrBox fAttrBox{this, "box_"};
    RAttrText fAttrText{this, "text_"};
 
+protected:
+   RAttrMap CollectDefaults() const override { return RAttrMap().AddDefaults(fAttrBox).AddDefaults(fAttrText); }
+
    R__ATTR_CLASS(CustomAttrs, "custom_", AddDefaults(fAttrBox).AddDefaults(fAttrText));
 
    const RAttrBox &GetAttrBox() const { return fAttrBox; }
@@ -87,23 +90,19 @@ TEST(OptsTest, AttribDiffer) {
    CustomAttrs attrs2;
    CustomAttrs attrs3;
 
-   auto &al1 = attrs1.AttrBox().AttrBorder();
-   auto &al2 = attrs2.AttrBox().AttrBorder();
-   auto &al3 = attrs3.AttrBox().AttrBorder();
+   attrs1.AttrBox().AttrBorder().SetWidth(7.);
+   EXPECT_NE(attrs1, attrs2);
+   EXPECT_NE(attrs2, attrs1);
+   EXPECT_NE(attrs1, attrs3);
+   EXPECT_EQ(attrs2, attrs3);
+   EXPECT_EQ(attrs3, attrs2);
 
-   al1.SetWidth(7.);
-   EXPECT_NE(al1, al2);
-   EXPECT_NE(al2, al1);
-   EXPECT_NE(al1, al3);
-   EXPECT_EQ(al2, al3);
-   EXPECT_EQ(al3, al2);
-
-   al2.SetColor(RColor::kRed);
-   EXPECT_NE(al1, al2);
-   EXPECT_NE(al2, al1);
-   EXPECT_NE(al1, al3);
-   EXPECT_NE(al2, al3);
-   EXPECT_NE(al3, al2);
+   attrs2.AttrBox().AttrBorder().SetColor(RColor::kRed);
+   EXPECT_NE(attrs1, attrs2);
+   EXPECT_NE(attrs2, attrs1);
+   EXPECT_NE(attrs1, attrs3);
+   EXPECT_NE(attrs2, attrs3);
+   EXPECT_NE(attrs3, attrs2);
 }
 
 

--- a/graf2d/gpadv7/test/attribute.cxx
+++ b/graf2d/gpadv7/test/attribute.cxx
@@ -13,7 +13,7 @@ class CustomAttrs : public RAttrBase {
 protected:
    RAttrMap CollectDefaults() const override { return RAttrMap().AddDefaults(fAttrBox).AddDefaults(fAttrText); }
 
-   R__ATTR_CLASS(CustomAttrs, "custom_", AddDefaults(fAttrBox).AddDefaults(fAttrText));
+   R__ATTR_CLASS(CustomAttrs, "custom_");
 
    const RAttrBox &GetAttrBox() const { return fAttrBox; }
    CustomAttrs &SetAttrBox(const RAttrBox &box) { fAttrBox = box; return *this; }

--- a/graf2d/gpadv7/test/attribute.cxx
+++ b/graf2d/gpadv7/test/attribute.cxx
@@ -7,13 +7,13 @@
 using namespace ROOT::Experimental;
 
 class CustomAttrs : public RAttrBase {
-   RAttrBox fAttrBox{this, "box_"};
-   RAttrText fAttrText{this, "text_"};
+   RAttrBox fAttrBox{this, "box"};
+   RAttrText fAttrText{this, "text"};
 
 protected:
    RAttrMap CollectDefaults() const override { return RAttrMap().AddDefaults(fAttrBox).AddDefaults(fAttrText); }
 
-   R__ATTR_CLASS(CustomAttrs, "custom_");
+   R__ATTR_CLASS(CustomAttrs, "custom");
 
    const RAttrBox &GetAttrBox() const { return fAttrBox; }
    CustomAttrs &SetAttrBox(const RAttrBox &box) { fAttrBox = box; return *this; }

--- a/graf2d/gpadv7/test/rstyle.cxx
+++ b/graf2d/gpadv7/test/rstyle.cxx
@@ -15,9 +15,9 @@
 using namespace ROOT::Experimental;
 
 class CustomDrawable : public RDrawable {
-   RAttrLine  fAttrLine{this, "line_"};    ///<! line attributes
-   RAttrBox   fAttrBox{this, "box_"};      ///<! box attributes
-   RAttrText  fAttrText{this, "text_"};    ///<! text attributes
+   RAttrLine  fAttrLine{this, "line"};    ///<! line attributes
+   RAttrBox   fAttrBox{this, "box"};      ///<! box attributes
+   RAttrText  fAttrText{this, "text"};    ///<! text attributes
 
 public:
    CustomDrawable() : RDrawable("custom") {}

--- a/graf2d/primitivesv7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RBox.hxx
@@ -29,8 +29,8 @@ namespace Experimental {
 
 class RBox : public RDrawable {
 
-   RPadPos fP1, fP2;                    ///< box corners coordinates
-   RAttrBox fAttrBox{this, "box_"};     ///<! box attributes
+   RPadPos  fP1, fP2;                  ///< box corners coordinates
+   RAttrBox fAttrBox{this, "box"};     ///<! box attributes
 
 protected:
 

--- a/graf2d/primitivesv7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RBox.hxx
@@ -29,11 +29,10 @@ namespace Experimental {
 
 class RBox : public RDrawable {
 
-   RPadPos  fP1, fP2;                  ///< box corners coordinates
-   RAttrBox fAttrBox{this, "box"};     ///<! box attributes
+   RPadPos fP1, fP2;               ///< box corners coordinates
+   RAttrBox fAttrBox{this, "box"}; ///<! box attributes
 
 protected:
-
    // constructor for derived classes
    RBox(const std::string &subtype) : RDrawable(subtype) {}
 
@@ -46,14 +45,27 @@ public:
       fP2 = p2;
    }
 
-   RBox &SetP1(const RPadPos& p1) { fP1 = p1; return *this; }
-   RBox &SetP2(const RPadPos& p2) { fP2 = p2; return *this; }
+   RBox &SetP1(const RPadPos &p1)
+   {
+      fP1 = p1;
+      return *this;
+   }
 
-   const RPadPos& GetP1() const { return fP1; }
-   const RPadPos& GetP2() const { return fP2; }
+   RBox &SetP2(const RPadPos &p2)
+   {
+      fP2 = p2;
+      return *this;
+   }
+
+   const RPadPos &GetP1() const { return fP1; }
+   const RPadPos &GetP2() const { return fP2; }
 
    const RAttrBox &GetAttrBox() const { return fAttrBox; }
-   RBox &SetAttrBox(RAttrBox &box) { fAttrBox = box; return *this; }
+   RBox &SetAttrBox(RAttrBox &box)
+   {
+      fAttrBox = box;
+      return *this;
+   }
    RAttrBox &AttrBox() { return fAttrBox; }
 };
 

--- a/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
@@ -24,38 +24,52 @@ namespace Experimental {
 \brief A title for the RFrame.
 \author Sergey Linev <s.linev@gsi.de>
 \date 2020-02-26
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
 */
-
 
 class RFrameTitle final : public RDrawable {
 
-   std::string              fText;                                  ///< title to display
-   RAttrText                fAttrText{this, "text"};                ///<! title text attributes
-   RAttrValue<RPadLength>   fMargin{this, "margin", 0.02_normal};   ///<! title margin
-   RAttrValue<RPadLength>   fHeight{this, "height", 0.05_normal};   ///<! title height
+   std::string fText;                                           ///< title to display
+   RAttrText fAttrText{this, "text"};                           ///<! title text attributes
+   RAttrValue<RPadLength> fMargin{this, "margin", 0.02_normal}; ///<! title margin
+   RAttrValue<RPadLength> fHeight{this, "height", 0.05_normal}; ///<! title height
 
 protected:
-
    bool IsFrameRequired() const final { return true; }
 
 public:
-
    RFrameTitle() : RDrawable("title") {}
 
    RFrameTitle(const std::string &txt) : RFrameTitle() { fText = txt; }
 
-   RFrameTitle &SetText(const std::string &t) { fText = t; return *this; }
+   RFrameTitle &SetText(const std::string &t)
+   {
+      fText = t;
+      return *this;
+   }
    const std::string &GetText() const { return fText; }
 
-   RFrameTitle &SetMargin(const RPadLength &pos) { fMargin = pos; return *this; }
+   RFrameTitle &SetMargin(const RPadLength &pos)
+   {
+      fMargin = pos;
+      return *this;
+   }
    RPadLength GetMargin() const { return fMargin; }
 
-   RFrameTitle &SetHeight(const RPadLength &pos) { fHeight = pos; return *this; }
+   RFrameTitle &SetHeight(const RPadLength &pos)
+   {
+      fHeight = pos;
+      return *this;
+   }
    RPadLength GetHeight() const { return fHeight; }
 
    const RAttrText &GetAttrText() const { return fAttrText; }
-   RFrameTitle &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
+   RFrameTitle &SetAttrText(const RAttrText &attr)
+   {
+      fAttrText = attr;
+      return *this;
+   }
    RAttrText &AttrText() { return fAttrText; }
 };
 

--- a/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
@@ -31,7 +31,7 @@ namespace Experimental {
 class RFrameTitle final : public RDrawable {
 
    std::string              fText;                                  ///< title to display
-   RAttrText                fAttrText{this, "text_"};               ///<! title text attributes
+   RAttrText                fAttrText{this, "text"};                ///<! title text attributes
    RAttrValue<RPadLength>   fMargin{this, "margin", 0.02_normal};   ///<! title margin
    RAttrValue<RPadLength>   fHeight{this, "height", 0.05_normal};   ///<! title height
 

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -33,26 +33,26 @@ namespace Experimental {
 class RLegend : public RPave {
 
 public:
-
    /** \class REntry
    \ingroup GrafROOT7
    \brief An entry in RLegend, references RDrawable and its attributes
    \author Sergey Linev <S.Linev@gsi.de>
    \date 2019-10-09
-   \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+   \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+   is welcome!
    */
 
    class REntry {
 
       friend class RLegend;
 
-      std::string fLabel;    ///< label shown for the entry
+      std::string fLabel; ///< label shown for the entry
 
-      bool fLine{true}, fFill{false}, fMarker{false};  ///< enable line, fill, marker showing
+      bool fLine{true}, fFill{false}, fMarker{false}; ///< enable line, fill, marker showing
 
-      Internal::RIOShared<RDrawable> fDrawable;  ///< reference to RDrawable
+      Internal::RIOShared<RDrawable> fDrawable; ///< reference to RDrawable
 
-      std::string fDrawableId;        ///< drawable id, used only when display item
+      std::string fDrawableId; ///< drawable id, used only when display item
 
       bool IsCustomDrawable() const { return fDrawableId == "custom"; }
 
@@ -68,7 +68,6 @@ public:
       }
 
    public:
-
       REntry() = default;
 
       /** Create entry without reference to existing drawable object, can assign attributes */
@@ -85,10 +84,18 @@ public:
          fLabel = lbl;
       }
 
-      REntry &SetLabel(const std::string &lbl) { fLabel = lbl; return *this; }
+      REntry &SetLabel(const std::string &lbl)
+      {
+         fLabel = lbl;
+         return *this;
+      }
       const std::string &GetLabel() const { return fLabel; }
 
-      REntry &SetLine(bool on = true) { fLine = on; return *this; }
+      REntry &SetLine(bool on = true)
+      {
+         fLine = on;
+         return *this;
+      }
       bool GetLine() const { return fLine; }
 
       REntry &SetAttrLine(const RAttrLine &attr)
@@ -107,7 +114,11 @@ public:
          return {};
       }
 
-      REntry &SetFill(bool on = true) { fFill = on; return *this; }
+      REntry &SetFill(bool on = true)
+      {
+         fFill = on;
+         return *this;
+      }
       bool GetFill() const { return fFill; }
 
       REntry &SetAttrFill(const RAttrFill &attr)
@@ -126,7 +137,11 @@ public:
          return {};
       }
 
-      REntry &SetMarker(bool on = true) { fMarker = on; return *this; }
+      REntry &SetMarker(bool on = true)
+      {
+         fMarker = on;
+         return *this;
+      }
       bool GetMarker() const { return fMarker; }
 
       REntry &SetAttrMarker(const RAttrMarker &attr)
@@ -144,17 +159,14 @@ public:
             return RAttrMarker(const_cast<RDrawable *>(fDrawable.get()));
          return {};
       }
-
    };
 
 private:
-
-   std::string fTitle;           ///< legend title
+   std::string fTitle; ///< legend title
 
    std::vector<REntry> fEntries; ///< list of entries which should be displayed
 
 protected:
-
    void CollectShared(Internal::RIOSharedVector_t &vect) override
    {
       for (auto &entry : fEntries) {
@@ -190,15 +202,15 @@ protected:
    }
 
 public:
-
    RLegend() : RPave("legend") {}
 
-   RLegend(const std::string &title) : RLegend()
-   {
-      SetTitle(title);
-   }
+   RLegend(const std::string &title) : RLegend() { SetTitle(title); }
 
-   RLegend &SetTitle(const std::string &title) { fTitle = title; return *this; }
+   RLegend &SetTitle(const std::string &title)
+   {
+      fTitle = title;
+      return *this;
+   }
    const std::string &GetTitle() const { return fTitle; }
 
    REntry &AddEntry(const std::string &lbl)
@@ -216,7 +228,6 @@ public:
    auto NumEntries() const { return fEntries.size(); }
 
    auto &GetEntry(int n) { return fEntries[n]; }
-
 };
 
 } // namespace Experimental

--- a/graf2d/primitivesv7/inc/ROOT/RLine.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLine.hxx
@@ -26,9 +26,9 @@ namespace Experimental {
 
 class RLine : public RDrawable {
 
-   RPadPos fP1;                            ///< line begin
-   RPadPos fP2;                            ///< line end
-   RAttrLine  fAttrLine{this, "line_"};    ///<! line attributes
+   RPadPos    fP1;                        ///< line begin
+   RPadPos    fP2;                        ///< line end
+   RAttrLine  fAttrLine{this, "line"};    ///<! line attributes
 
 public:
 

--- a/graf2d/primitivesv7/inc/ROOT/RLine.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLine.hxx
@@ -26,24 +26,39 @@ namespace Experimental {
 
 class RLine : public RDrawable {
 
-   RPadPos    fP1;                        ///< line begin
-   RPadPos    fP2;                        ///< line end
-   RAttrLine  fAttrLine{this, "line"};    ///<! line attributes
+   RPadPos fP1, fP2;                  ///< line begin/end
+   RAttrLine fAttrLine{this, "line"}; ///<! line attributes
 
 public:
-
    RLine() : RDrawable("line") {}
 
-   RLine(const RPadPos& p1, const RPadPos& p2) : RLine() { fP1 = p1; fP2 = p2; }
+   RLine(const RPadPos &p1, const RPadPos &p2) : RLine()
+   {
+      fP1 = p1;
+      fP2 = p2;
+   }
 
-   RLine &SetP1(const RPadPos& p1) { fP1 = p1; return *this; }
-   RLine &SetP2(const RPadPos& p2) { fP2 = p2; return *this; }
+   RLine &SetP1(const RPadPos &p1)
+   {
+      fP1 = p1;
+      return *this;
+   }
 
-   const RPadPos& GetP1() const { return fP1; }
-   const RPadPos& GetP2() const { return fP2; }
+   RLine &SetP2(const RPadPos &p2)
+   {
+      fP2 = p2;
+      return *this;
+   }
+
+   const RPadPos &GetP1() const { return fP1; }
+   const RPadPos &GetP2() const { return fP2; }
 
    const RAttrLine &GetAttrLine() const { return fAttrLine; }
-   RLine &SetAttrLine(const RAttrLine &attr) { fAttrLine = attr; return *this; }
+   RLine &SetAttrLine(const RAttrLine &attr)
+   {
+      fAttrLine = attr;
+      return *this;
+   }
    RAttrLine &AttrLine() { return fAttrLine; }
 };
 

--- a/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
@@ -28,22 +28,28 @@ namespace Experimental {
 
 class RMarker : public RDrawable {
 
-   RPadPos fP;                               ///< position
-   RAttrMarker fMarkerAttr{this, "marker"};  ///<! marker attributes
+   RPadPos fP;                              ///< position
+   RAttrMarker fMarkerAttr{this, "marker"}; ///<! marker attributes
 
 public:
-
    RMarker() : RDrawable("marker") {}
 
-   RMarker(const RPadPos& p) : RMarker() { fP = p; }
+   RMarker(const RPadPos &p) : RMarker() { fP = p; }
 
-   RMarker &SetP(const RPadPos& p) { fP = p; return *this; }
-   const RPadPos& GetP() const { return fP; }
+   RMarker &SetP(const RPadPos &p)
+   {
+      fP = p;
+      return *this;
+   }
+   const RPadPos &GetP() const { return fP; }
 
    const RAttrMarker &GetAttrMarker() const { return fMarkerAttr; }
-   RMarker &SetAttrMarker(const RAttrMarker &attr) { fMarkerAttr = attr; return *this; }
+   RMarker &SetAttrMarker(const RAttrMarker &attr)
+   {
+      fMarkerAttr = attr;
+      return *this;
+   }
    RAttrMarker &AttrMarker() { return fMarkerAttr; }
-
 };
 
 } // namespace Experimental

--- a/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
@@ -28,8 +28,8 @@ namespace Experimental {
 
 class RMarker : public RDrawable {
 
-   RPadPos fP;                                ///< position
-   RAttrMarker fMarkerAttr{this, "marker_"};  ///<! marker attributes
+   RPadPos fP;                               ///< position
+   RAttrMarker fMarkerAttr{this, "marker"};  ///<! marker attributes
 
 public:
 

--- a/graf2d/primitivesv7/inc/ROOT/RPaveText.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RPaveText.hxx
@@ -19,7 +19,8 @@ namespace Experimental {
 \brief A RPave with text content
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2020-06-19
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
 */
 
 class RPaveText : public RPave {
@@ -27,7 +28,6 @@ class RPaveText : public RPave {
    std::vector<std::string> fText; ///< list of text entries
 
 public:
-
    RPaveText() : RPave("pavetext") {}
 
    void AddLine(const std::string &txt) { fText.emplace_back(txt); }
@@ -37,7 +37,6 @@ public:
    const std::string &GetLine(int n) const { return fText[n]; }
 
    void ClearLines() { fText.clear(); }
-
 };
 
 } // namespace Experimental

--- a/graf2d/primitivesv7/inc/ROOT/RText.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RText.hxx
@@ -28,9 +28,9 @@ namespace Experimental {
 
 class RText : public RDrawable {
 
-   std::string fText;                      ///< text to display
-   RPadPos fPos;                           ///< position
-   RAttrText  fAttrText{this, "text_"};    ///<! text attributes
+   std::string   fText;                     ///< text to display
+   RPadPos       fPos;                      ///< position
+   RAttrText     fAttrText{this, "text"};   ///<! text attributes
 
 public:
 

--- a/graf2d/primitivesv7/inc/ROOT/RText.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RText.hxx
@@ -23,34 +23,49 @@ namespace Experimental {
 \brief A text.
 \author Olivier Couet <Olivier.Couet@cern.ch>
 \date 2017-10-16
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
 */
 
 class RText : public RDrawable {
 
-   std::string   fText;                     ///< text to display
-   RPadPos       fPos;                      ///< position
-   RAttrText     fAttrText{this, "text"};   ///<! text attributes
+   std::string fText;                 ///< text to display
+   RPadPos fPos;                      ///< position
+   RAttrText fAttrText{this, "text"}; ///<! text attributes
 
 public:
-
    RText() : RDrawable("text") {}
 
    RText(const std::string &txt) : RText() { fText = txt; }
 
-   RText(const RPadPos& p, const std::string &txt) : RText() { fText = txt; fPos = p; }
+   RText(const RPadPos &p, const std::string &txt) : RText()
+   {
+      fText = txt;
+      fPos = p;
+   }
 
-   RText &SetText(const std::string &t) { fText = t; return *this; }
+   RText &SetText(const std::string &t)
+   {
+      fText = t;
+      return *this;
+   }
    const std::string &GetText() const { return fText; }
 
-   RText &SetPos(const RPadPos& p) { fPos = p; return *this; }
+   RText &SetPos(const RPadPos &p)
+   {
+      fPos = p;
+      return *this;
+   }
    const RPadPos &GetPos() const { return fPos; }
 
    const RAttrText &GetAttrText() const { return fAttrText; }
-   RText &SetAttrText(const RAttrText &attr) { fAttrText = attr; return *this; }
+   RText &SetAttrText(const RAttrText &attr)
+   {
+      fAttrText = attr;
+      return *this;
+   }
    RAttrText &AttrText() { return fAttrText; }
 };
-
 
 } // namespace Experimental
 } // namespace ROOT

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -35,12 +35,12 @@ namespace ROOT {
 namespace Experimental {
 
 class RHistDrawableBase : public RDrawable {
-   RAttrValue<std::string>  fKind{this, "kind", ""};      ///<! hist draw kind
-   RAttrValue<int>          fSub{this, "sub", -1};        ///<! hist draw sub kind
-   RAttrLine                fAttrLine{this, "line_"};     ///<! hist line attributes
-   RAttrFill                fAttrFill{this, "fill_"};     ///<! hist fill attributes
-   RAttrText                fAttrText{this, "text_"};     ///<! hist text attributes
-   RAttrMarker              fMarkerAttr{this, "marker_"}; ///<! hist marker attributes
+   RAttrValue<std::string>  fKind{this, "kind", ""};        ///<! hist draw kind
+   RAttrValue<int>          fSub{this, "sub", -1};          ///<! hist draw sub kind
+   RAttrLine                fAttrLine{this, "line"};        ///<! hist line attributes
+   RAttrFill                fAttrFill{this, "fill"};        ///<! hist fill attributes
+   RAttrText                fAttrText{this, "text"};        ///<! hist text attributes
+   RAttrMarker              fMarkerAttr{this, "marker"};    ///<! hist marker attributes
    RAttrValue<bool>         fOptimize{this, "optimize", false}; ///<! optimize drawing
 
 protected:


### PR DESCRIPTION
Let scan any derived from `RAttrBase` class for all members, which are RAttr classes and collect all default values for them.
Before was necessary to do this by hand in `R__ATTR_CLASS` macro.
Also enforce naming convention that names of members of RAttrLine should ends with underscore symbol.