### PR TITLE
[RF] Improve debugging of batch computations & fix a move vs copy problem.

### DIFF
--- a/roofit/roofitcore/inc/RunContext.h
+++ b/roofit/roofitcore/inc/RunContext.h
@@ -30,6 +30,13 @@ namespace BatchHelpers {
 
 /// Data that has to be passed around when evaluating functions / PDFs.
 struct RunContext {
+  RunContext() { }
+  /// Deleted because copying the owned memory is expensive.
+  /// If needed, it can be implemented, though.
+  /// \warning Remember to relocate all spans in `spans` to new location
+  /// in `ownedMemory` after data have been copied!
+  RunContext(const RunContext&) = delete;
+  RunContext(RunContext&&) = default;
   RooSpan<const double> getBatch(const RooArgProxy& proxy) const;
   RooSpan<const double> getBatch(const RooAbsReal* owner) const;
   /// Retrieve a batch of data corresponding to the element passed as `owner`.

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -5211,7 +5211,7 @@ void RooAbsReal::checkBatchComputation(const BatchHelpers::RunContext& evalData,
     FormatPdfTree formatter;
     formatter << "--> (Batch computation wrong:)\n";
     printStream(formatter.stream(), kName | kClassName | kArgs | kExtras | kAddress, kInline);
-    formatter << std::setprecision(17)
+    formatter << "\n batch=" << batch.data() << " size=" << batch.size() << std::setprecision(17)
     << "\n batch[" << std::setw(7) << evtNo-1 << "]=     " << (evtNo > 0 && evtNo - 1 < batch.size() ? std::to_string(batch[evtNo-1]) : "---")
     << "\n batch[" << std::setw(7) << evtNo   << "]=     " << batchVal << " !!!"
     << "\n expected ('value'): " << value


### PR DESCRIPTION
It looks like the STL on the machine with the nightly failures was copying the `RunContext` struct. Bad idea, because this creates dangling pointers!
I `deleted` the copy constructor and only allow moves.
Please take care of the merging.