### PR TITLE
Increase gDebug level needed for too frequent messages in TFoamVect.cxx

### DIFF
--- a/math/foam/src/TFoamVect.cxx
+++ b/math/foam/src/TFoamVect.cxx
@@ -48,7 +48,7 @@ TFoamVect::TFoamVect(Int_t n)
       }
       for (i=0; i<n; i++) *(fCoords+i)=0.0;
    }
-   if(gDebug) Info("TFoamVect", "USER CONSTRUCTOR TFoamVect(const Int_t)\n ");
+   if(gDebug>=3) Info("TFoamVect", "USER CONSTRUCTOR TFoamVect(const Int_t)\n ");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -75,7 +75,7 @@ TFoamVect::TFoamVect(const TFoamVect &Vect): TObject(Vect)
 
 TFoamVect::~TFoamVect()
 {
-   if(gDebug) Info("TFoamVect"," DESTRUCTOR TFoamVect~ \n");
+   if(gDebug>=3) Info("TFoamVect"," DESTRUCTOR TFoamVect~ \n");
    delete [] fCoords; //  free(fCoords)
    fCoords=0;
 }
@@ -96,7 +96,7 @@ TFoamVect& TFoamVect::operator =(const TFoamVect& Vect)
    fDim=Vect.fDim;
    for(i=0; i<fDim; i++)
       fCoords[i] = Vect.fCoords[i];
-   if(gDebug)  Info("TFoamVect", "SUBSITUTE operator =\n ");
+   if(gDebug>=3)  Info("TFoamVect", "SUBSITUTE operator =\n ");
    return *this;
 }
 


### PR DESCRIPTION
While debugging a fitting the console gets clogged by a lot of messages of calling constructors and destructors of TFoamVect. I set the debug level needed to 5 for the messages to appear, and leaving the more important ones (like errors) as they were, in debug level 1.