### PR TITLE
[RF] Fix linking issue of RooFitComputeLib.

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -472,8 +472,8 @@ foreach(incl ${fitcore_incl})
    target_include_directories(RooFitCore PUBLIC $<BUILD_INTERFACE:${incl}>)
 endforeach()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6)
-  # gcc 5 has a bug in that it fails to put its internal -lgcc into the right place when linking.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # gcc has a bug in that it fails to put its internal -lgcc into the right place when linking.
   # We need it to check cpu flags in src/InitUtils.cxx
   # Here, we add an explicit link instruction according to the workaround posted here:
   # https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899


### PR DESCRIPTION
In Fedora 29, with gcc, there is a problem with __builtin_cpu_supports() function. It causes an undefined symbol error during linking, unless you link against -lgcc explicitly. There was already code in the file to protect against this bug in some versions of gcc, but as the problems seems to exist under various gcc build configurations, I change the code to include the fix for every gcc version.

See also: https://github.com/root-project/root/issues/6855 