### PR TITLE
Do not attempt to load_library the ROOT Pythonizations module

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -5,7 +5,7 @@ from functools import partial
 
 import libcppyy as cppyy_backend
 from cppyy import gbl as gbl_namespace
-from cppyy import cppdef, include, load_library
+from cppyy import cppdef, include
 from libROOTPythonizations import gROOT, CreateBufferFromAddress
 
 from ._application import PyROOTApplication
@@ -291,8 +291,6 @@ class ROOTFacade(types.ModuleType):
     @property
     def TPyDispatcher(self):
         include('ROOT/TPyDispatcher.h')
-        major, minor = sys.version_info[0:2]
-        load_library('libROOTPythonizations{}_{}'.format(major, minor))
         tpd = gbl_namespace.TPyDispatcher
         type(self).TPyDispatcher = tpd
         return tpd


### PR DESCRIPTION
It is not necessary here, since it is already loaded due to the
from libROOTPythonizations import ...
earlier in the file, and it fails when the python module is not in the
library path (it is in the python path only)

/usr/lib64/python3.9/site-packages/libROOTPythonizations3_9.cpython-39-x86_64-linux-gnu.so

https://bugzilla.redhat.com/show_bug.cgi?id=1900661