### PR TITLE
[TBufferMerger] ResetBit(kMustCleanup) is not needed anymore

### DIFF
--- a/io/io/test/TBufferMerger.cxx
+++ b/io/io/test/TBufferMerger.cxx
@@ -84,12 +84,6 @@ TEST(TBufferMerger, SequentialTreeFill)
       auto myfile = merger.GetFile();
       auto mytree = new TTree("mytree", "mytree");
 
-      // The resetting of the kCleanup bit below is necessary to avoid leaving
-      // the management of this object to ROOT, which leads to a race condition
-      // that may cause a crash once all threads are finished and the final
-      // merge is happening
-      mytree->ResetBit(kMustCleanup);
-
       Fill(mytree, 0, nevents);
       myfile->Write();
    }
@@ -111,12 +105,6 @@ TEST(TBufferMerger, ParallelTreeFill)
          threads.emplace_back([=, &merger]() {
             auto myfile = merger.GetFile();
             auto mytree = new TTree("mytree", "mytree");
-
-            // The resetting of the kCleanup bit below is necessary to avoid leaving
-            // the management of this object to ROOT, which leads to a race condition
-            // that may cause a crash once all threads are finished and the final
-            // merge is happening
-            mytree->ResetBit(kMustCleanup);
 
             Fill(mytree, i * nevents, nevents);
             myfile->Write();
@@ -148,12 +136,6 @@ TEST(TBufferMerger, AutoSave)
          threads.emplace_back([=, &merger]() {
             auto myfile = merger.GetFile();
             auto mytree = new TTree("mytree", "mytree");
-
-            // The resetting of the kCleanup bit below is necessary to avoid leaving
-            // the management of this object to ROOT, which leads to a race condition
-            // that may cause a crash once all threads are finished and the final
-            // merge is happening
-            mytree->ResetBit(kMustCleanup);
 
             Fill(mytree, i * events_per_thread, events_per_thread);
             myfile->Write();

--- a/tutorials/multicore/mt103_fillNtupleFromMultipleThreads.C
+++ b/tutorials/multicore/mt103_fillNtupleFromMultipleThreads.C
@@ -39,12 +39,6 @@ void mt103_fillNtupleFromMultipleThreads()
       auto f = merger.GetFile();
       TNtuple ntrand("ntrand", "Random Numbers", "r");
 
-      // The resetting of the kCleanup bit below is necessary to avoid leaving
-      // the management of this object to ROOT, which leads to a race condition
-      // that may cause a crash once all threads are finished and the final
-      // merge is happening
-      ntrand.ResetBit(kMustCleanup);
-
       TRandom rnd(seed);
       for (auto i : ROOT::TSeqI(nEntries))
          ntrand.Fill(rnd.Gaus());


### PR DESCRIPTION
The list of cleanups should be thread-safe now (and if it's not, we want to know!).

I executed the test and the tutorial in a loop for a while (on a machine with 8 logical cores) and could not see any crash.