### PR TITLE
Several new test failures on ppc64le with 6.22.06 due to:

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3274,6 +3274,8 @@ static int callback_for_dl_iterate_phdr(struct dl_phdr_info *info, size_t size, 
       // Skip \0, "", and kernel pseudo-libs linux-vdso.so.1 or linux-gate.so.1
       if (info->dlpi_name && info->dlpi_name[0]
           && strncmp(info->dlpi_name, "linux-vdso.so", 13)
+          && strncmp(info->dlpi_name, "linux-vdso32.so", 15)
+          && strncmp(info->dlpi_name, "linux-vdso64.so", 15)
           && strncmp(info->dlpi_name, "linux-gate.so", 13))
          newLibs->emplace_back(info->dlpi_name);
       sKnownLoadedLibBaseAddrs.insert(info->dlpi_addr);


### PR DESCRIPTION
g++: error: linux-vdso64.so.1: No such file or directory

The list of names filtered out by TCling is incomplete.
The vdso(7) man page gives the following list:

       user ABI   vDSO name
       ─────────────────────────────
       aarch64    linux-vdso.so.1
       arm        linux-vdso.so.1
       ia64       linux-gate.so.1
       mips       linux-vdso.so.1
       ppc/32     linux-vdso32.so.1
       ppc/64     linux-vdso64.so.1
       riscv      linux-vdso.so.1
       s390       linux-vdso32.so.1
       s390x      linux-vdso64.so.1
       sh         linux-gate.so.1
       i386       linux-gate.so.1
       x86-64     linux-vdso.so.1
       x86/x32    linux-vdso.so.1