### PR TITLE
[IO][NFC] Explicitly disable unused broken iterator::next implementation

### DIFF
--- a/core/cont/inc/TCollectionProxyInfo.h
+++ b/core/cont/inc/TCollectionProxyInfo.h
@@ -694,16 +694,9 @@ namespace Detail {
             new (dest_arena) iterator(*source);
             return dest_arena;
          }
-         static void* next(void *iter_loc, const void *end_loc) {
-            const iterator *end = (const iterator *)(end_loc);
-            iterator *iter = (iterator *)(iter_loc);
-            if (*iter != *end) {
-               ++(*iter);
-               //if (*iter != *end) {
-               //   return IteratorValue<Cont_t, Cont_t::value_type>::get(*iter);
-               //}
-            }
-            return 0;
+         static void* next(void *, const void *) {
+            R__ASSERT(false && "Intentionally not implemented, should use VectorLooper or similar for vector<bool>.");
+            return {};
          }
          static void destruct1(void *iter_ptr) {
             iterator *start = (iterator *)(iter_ptr);

--- a/core/cont/inc/TCollectionProxyInfo.h
+++ b/core/cont/inc/TCollectionProxyInfo.h
@@ -741,10 +741,10 @@ namespace Detail {
    // Need specialization for boolean references due to stupid STL std::vector<bool>
    template <class A> struct TCollectionProxyInfo::Address<std::vector<Bool_t, A>> {
       virtual ~Address() {}
-      static void* address(typename std::vector<Bool_t, A>::const_reference ref) {
-         (void) ref; // This is to prevent the unused variable warning.
-         R__ASSERT(0);
-         return 0;
+      static void* address(typename std::vector<Bool_t, A>::const_reference) {
+         R__ASSERT(false && "Intentionally not implemented, should use VectorLooper or other functions specialized for "
+                            "vector<bool> instead");
+         return {};
       }
    };
 


### PR DESCRIPTION
This is a specialization of iterator::next for vector<bool> that always returns a nullptr and should never be used.
IIUC, this code only exists to avoid compilation errors when compiling I/O code for `vector<bool>`.

With this patch we error out rather than silently returning a nullptr.