### PR TITLE
[ntuple] Add RFieldMerger class 

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -131,6 +131,8 @@ public:
    RColumnDescriptor &operator =(RColumnDescriptor &&other) = default;
 
    bool operator==(const RColumnDescriptor &other) const;
+   /// Get a copy of the descriptor
+   RColumnDescriptor Clone() const;
 
    DescriptorId_t GetId() const { return fColumnId; }
    RNTupleVersion GetVersion() const { return fVersion; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMerger.hxx
@@ -20,6 +20,10 @@
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
+#include <map>
+#include <memory>
+#include <vector>
+
 namespace ROOT {
 namespace Experimental {
 
@@ -28,14 +32,83 @@ namespace Experimental {
 \class ROOT::Experimental::RFieldMerger
 \ingroup NTuple
 \brief Two-way merge between NTuple fields
+
+Provides a mapping of field IDs and column IDs between structurally equivalent field trees.
+The merger is initialized with a reference field and its sub fields. It can then merge (map) multiple
+input fields. Successful merges return an input ID that can be subsequently used to map IDs of the
+input field to the reference field and vice versa. The reference field has input ID 0.
+
+In order to merge successfully, the input field must have at least the same type and subfields than
+the reference field. The input field can have additional sub fields, which are ignored.
+
+Normally, the constuctor and the Merge() method are called with zero fields, which would merge
+complete NTuple schemas. But it can be called with fields deeper in a hierarchy, too.
 */
 // clang-format on
 class RFieldMerger {
-private:
-   /// The merged field descriptor
-   RFieldDescriptor fMergedField = RFieldDescriptor();
 public:
-   static RResult<RFieldMerger> Merge(const RFieldDescriptor &lhs, const RFieldDescriptor &rhs);
+   /// In order to inpect a field, its subfields and the corresponding columns, both a field id and an RNTuple
+   /// descriptor are required
+   struct RFieldHandle {
+      const RNTupleDescriptor &desc;
+      DescriptorId_t fid = kInvalidDescriptorId;
+   };
+
+private:
+   /// Helper class to map descriptor IDs in both directions, from the reference to an input and vice versa.
+   struct RBiMap {
+      std::unordered_map<int, int> fInput2Reference;
+      std::unordered_map<int, int> fReference2Input;
+
+      void Insert(int input, int reference)
+      {
+         fInput2Reference[input] = reference;
+         fReference2Input[reference] = input;
+      }
+   };
+
+   /// The field ID of the top-most reference field
+   DescriptorId_t fReferenceId;
+
+   /// A clone of the initial field passed in the constructor and all its sub fields.
+   std::unordered_map<DescriptorId_t, RFieldDescriptor> fReferenceFields;
+   /// Maps from parent field ID to sub field IDs in the reference field tree
+   std::unordered_map<DescriptorId_t, std::vector<DescriptorId_t>> fSubFieldLinks;
+   /// Maps field ID to its column IDs in the reference field tree. The order of the columns is preserved,
+   /// so that the vector index is identical to the column index (RColumnDescriptor::fIndex).
+   std::unordered_map<DescriptorId_t, std::vector<DescriptorId_t>> fColumnLinks;
+
+   /// Bi-directional mapping between input field IDs and reference field IDs.
+   /// The input ID is used as an index.
+   std::vector<RBiMap> fFieldIdMaps;
+   /// Bi-directional mapping between input column IDs and reference column IDs.
+   /// The input ID is used as an index.
+   std::vector<RBiMap> fColumnIdMaps;
+
+   void MakeReference(const RFieldHandle &referenceHandle);
+
+   RResult<void> MergeImpl(DescriptorId_t referenceId, const RFieldHandle &inputHandle);
+
+public:
+   explicit RFieldMerger(const RFieldHandle &referenceHandle);
+
+   /// Returns a unique input ID on success, i.e. if the input field in the input handle is structurally
+   /// equivalent to the reference field.
+   RResult<int> Merge(const RFieldHandle &inputHandle);
+
+   DescriptorId_t GetReferenceFieldId(DescriptorId_t fieldId, int inputId) const {
+      return fFieldIdMaps[inputId].fInput2Reference.at(fieldId);
+   }
+   DescriptorId_t GetReferenceColumnId(DescriptorId_t columnId, int inputId) const {
+      return fColumnIdMaps[inputId].fInput2Reference.at(columnId);
+   }
+
+   DescriptorId_t GetInputFieldId(DescriptorId_t fieldId, int inputId) const {
+      return fFieldIdMaps[inputId].fReference2Input.at(fieldId);
+   }
+   DescriptorId_t GetInputColumnId(DescriptorId_t columnId, int inputId) const {
+      return fColumnIdMaps[inputId].fReference2Input.at(columnId);
+   }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -138,6 +138,9 @@ public:
    bool operator ==(const RNTupleVersion &other) const {
       return fVersionUse == other.fVersionUse && fVersionMin == other.fVersionMin && fFlags == other.fFlags;
    }
+   bool operator !=(const RNTupleVersion &other) const {
+      return !(*this == other);
+   }
 
    std::uint32_t GetVersionUse() const { return fVersionUse; }
    std::uint32_t GetVersionMin() const { return fVersionMin; }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -73,6 +73,8 @@ private:
 protected:
    void CreateImpl(const RNTupleModel &model) final;
    RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
+   RClusterDescriptor::RLocator CommitSealedPageImpl(DescriptorId_t columnId,
+                                                     const RPageStorage::RSealedPage &sealedPage) final;
    RClusterDescriptor::RLocator CommitClusterImpl(NTupleSize_t nEntries) final;
    void CommitDatasetImpl() final;
 
@@ -182,6 +184,8 @@ public:
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
    RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
    void ReleasePage(RPage &page) final;
+
+   RPageStorage::RSealedPage ReadSealedPage(DescriptorId_t columnId, const RClusterIndex &clusterIndex) final;
 
    std::unique_ptr<RCluster> LoadCluster(DescriptorId_t clusterId, const ColumnSet_t &columns) final;
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -514,6 +514,17 @@ bool ROOT::Experimental::RColumnDescriptor::operator==(const RColumnDescriptor &
           fIndex == other.fIndex;
 }
 
+ROOT::Experimental::RColumnDescriptor
+ROOT::Experimental::RColumnDescriptor::Clone() const {
+   RColumnDescriptor clone;
+   clone.fColumnId = fColumnId;
+   clone.fVersion  = fVersion;
+   clone.fModel    = fModel;
+   clone.fFieldId  = fFieldId;
+   clone.fIndex    = fIndex;
+   return clone;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -19,6 +19,8 @@
 #include <ROOT/RNTupleMerger.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
+#include <TError.h>
+
 Long64_t ROOT::Experimental::RNTuple::Merge(TCollection* inputs, TFileMergeInfo* mergeInfo) {
    if (inputs == nullptr || mergeInfo == nullptr) {
       return -1;
@@ -30,10 +32,98 @@ Long64_t ROOT::Experimental::RNTuple::Merge(TCollection* inputs, TFileMergeInfo*
 ////////////////////////////////////////////////////////////////////////////////
 
 
-ROOT::Experimental::RResult<ROOT::Experimental::RFieldMerger>
-ROOT::Experimental::RFieldMerger::Merge(const ROOT::Experimental::RFieldDescriptor &lhs,
-   const ROOT::Experimental::RFieldDescriptor &rhs)
+void ROOT::Experimental::RFieldMerger::MakeReference(const RFieldHandle &referenceHandle)
 {
-   return R__FAIL("couldn't merge field " + lhs.GetFieldName() + " with field "
-      + rhs.GetFieldName() + " (unimplemented!)");
+   fReferenceFields[referenceHandle.fid] = referenceHandle.desc.GetFieldDescriptor(referenceHandle.fid).Clone();
+   fFieldIdMaps[0].Insert(referenceHandle.fid, referenceHandle.fid);
+   fSubFieldLinks[referenceHandle.fid] = std::vector<DescriptorId_t>();
+   fColumnLinks[referenceHandle.fid] = std::vector<DescriptorId_t>();
+
+   // Register columns connected to the field
+   unsigned int columnIdx = 0;
+   while (true) {
+      auto columnId = referenceHandle.desc.FindColumnId(referenceHandle.fid, columnIdx);
+      if (columnId == kInvalidDescriptorId)
+         break;
+
+      fColumnIdMaps[0].Insert(columnId, columnId);
+      fColumnLinks[referenceHandle.fid].emplace_back(columnId);
+
+      columnIdx++;
+   };
+
+   // Recurse into the sub fields
+   for (const auto &f : referenceHandle.desc.GetFieldRange(referenceHandle.fid)) {
+      MakeReference({referenceHandle.desc, f.GetId()});
+      fSubFieldLinks[referenceHandle.fid].emplace_back(f.GetId());
+   }
+}
+
+
+ROOT::Experimental::RFieldMerger::RFieldMerger(const RFieldHandle &referenceHandle)
+   : fReferenceId(referenceHandle.fid)
+{
+   fFieldIdMaps.emplace_back(RBiMap());
+   fColumnIdMaps.emplace_back(RBiMap());
+   MakeReference(referenceHandle);
+}
+
+
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::RFieldMerger::MergeImpl(DescriptorId_t referenceId, const RFieldHandle &inputHandle)
+{
+   const RFieldDescriptor &lhs = fReferenceFields.at(referenceId);
+   const RFieldDescriptor &rhs = inputHandle.desc.GetFieldDescriptor(inputHandle.fid);
+   auto qualifiedName = inputHandle.desc.GetQualifiedFieldName(inputHandle.fid);
+
+   // TODO(jblomer): compare _normalized_ type name
+   if (lhs.GetTypeName() != rhs.GetTypeName())
+      return R__FAIL("field merge error: type mismatch for " + qualifiedName);
+   if (lhs.GetFieldVersion() != rhs.GetFieldVersion())
+      return R__FAIL("field merge error: field version mismatch for " + qualifiedName);
+   if (lhs.GetTypeVersion() != rhs.GetTypeVersion())
+      return R__FAIL("field merge error: type version mismatch for " + qualifiedName);
+   if (lhs.GetNRepetitions() != rhs.GetNRepetitions())
+      return R__FAIL("field merge error: fixed-size array mismatch for " + qualifiedName);
+   R__ASSERT(lhs.GetStructure() == rhs.GetStructure());
+
+   // Map the field and column IDs between input and reference
+   fFieldIdMaps.rbegin()->Insert(inputHandle.fid, referenceId);
+   const auto &referenceColumnIds = fColumnLinks.at(referenceId);
+   for (size_t i = 0; i < referenceColumnIds.size(); ++i) {
+      auto inputColumnId = inputHandle.desc.FindColumnId(inputHandle.fid, i);
+      R__ASSERT(inputColumnId != kInvalidDescriptorId);
+      fColumnIdMaps.rbegin()->Insert(inputColumnId, referenceColumnIds[i]);
+   }
+
+   // Recurse into the sub fields in the reference field tree
+   for (auto subId : fSubFieldLinks.at(referenceId)) {
+      const auto &subField = fReferenceFields.at(subId);
+      auto matchingInput = inputHandle.desc.FindFieldId(subField.GetFieldName(), inputHandle.fid);
+      if (matchingInput == kInvalidDescriptorId)
+         return R__FAIL("field merge error: missing field " + qualifiedName + "." + subField.GetFieldName());
+
+      auto success = MergeImpl(subId, {inputHandle.desc, matchingInput});
+      if (!success)
+         return R__FORWARD_ERROR(success);
+   }
+
+   return RResult<void>::Success();
+}
+
+
+ROOT::Experimental::RResult<int> ROOT::Experimental::RFieldMerger::Merge(const RFieldHandle &inputHandle)
+{
+   int inputId = fFieldIdMaps.size();
+   fFieldIdMaps.emplace_back(RBiMap());
+   fColumnIdMaps.emplace_back(RBiMap());
+
+   auto result = MergeImpl(fReferenceId, inputHandle);
+   if (!result) {
+      fFieldIdMaps.pop_back();
+      fColumnIdMaps.pop_back();
+      return R__FORWARD_ERROR(result);
+   }
+
+   return inputId;
 }

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -40,17 +40,10 @@ void ROOT::Experimental::RFieldMerger::MakeReference(const RFieldHandle &referen
    fColumnLinks[referenceHandle.fid] = std::vector<DescriptorId_t>();
 
    // Register columns connected to the field
-   unsigned int columnIdx = 0;
-   while (true) {
-      auto columnId = referenceHandle.desc.FindColumnId(referenceHandle.fid, columnIdx);
-      if (columnId == kInvalidDescriptorId)
-         break;
-
-      fColumnIdMaps[0].Insert(columnId, columnId);
-      fColumnLinks[referenceHandle.fid].emplace_back(columnId);
-
-      columnIdx++;
-   };
+   for (const auto &c : referenceHandle.desc.GetColumnRange(referenceHandle.fid)) {
+      fColumnIdMaps[0].Insert(c.GetId(), c.GetId());
+      fColumnLinks[referenceHandle.fid].emplace_back(c.GetId());
+   }
 
    // Recurse into the sub fields
    for (const auto &f : referenceHandle.desc.GetFieldRange(referenceHandle.fid)) {

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -168,14 +168,25 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
 
 void ROOT::Experimental::Detail::RPageSink::CommitPage(ColumnHandle_t columnHandle, const RPage &page)
 {
-   auto locator = CommitPageImpl(columnHandle, page);
+   fOpenColumnRanges.at(columnHandle.fId).fNElements += page.GetNElements();
 
-   auto columnId = columnHandle.fId;
-   fOpenColumnRanges[columnId].fNElements += page.GetNElements();
    RClusterDescriptor::RPageRange::RPageInfo pageInfo;
    pageInfo.fNElements = page.GetNElements();
-   pageInfo.fLocator = locator;
-   fOpenPageRanges[columnId].fPageInfos.emplace_back(pageInfo);
+   pageInfo.fLocator = CommitPageImpl(columnHandle, page);
+   fOpenPageRanges.at(columnHandle.fId).fPageInfos.emplace_back(pageInfo);
+}
+
+
+void ROOT::Experimental::Detail::RPageSink::CommitSealedPage(
+   ROOT::Experimental::DescriptorId_t columnId,
+   const ROOT::Experimental::Detail::RPageStorage::RSealedPage &sealedPage)
+{
+   fOpenColumnRanges.at(columnId).fNElements += sealedPage.fNElements;
+
+   RClusterDescriptor::RPageRange::RPageInfo pageInfo;
+   pageInfo.fNElements = sealedPage.fNElements;
+   pageInfo.fLocator = CommitSealedPageImpl(columnId, sealedPage);
+   fOpenPageRanges.at(columnId).fPageInfos.emplace_back(pageInfo);
 }
 
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -138,11 +138,8 @@ ROOT::Experimental::RClusterDescriptor::RLocator
 ROOT::Experimental::Detail::RPageSinkFile::CommitSealedPageImpl(
    DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage)
 {
-   const auto bitsOnStorage = Detail::RColumnElementBase::Generate(
-      fDescriptorBuilder.GetDescriptor()
-      .GetColumnDescriptor(columnId)
-      .GetModel()
-      .GetType()).GetBitsOnStorage();
+   const auto bitsOnStorage = RColumnElementBase::GetBitsOnStorage(
+      fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(columnId).GetModel().GetType());
 
    const auto bytesPacked = (bitsOnStorage * sealedPage.fNElements + 7) / 8;
    const auto offsetData = fWriter->WriteBlob(sealedPage.fBuffer.get(), sealedPage.fSize, bytesPacked);

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -69,6 +69,11 @@ public:
    RPage PopulatePage(ColumnHandle_t, ROOT::Experimental::NTupleSize_t) final { return RPage(); }
    RPage PopulatePage(ColumnHandle_t, const ROOT::Experimental::RClusterIndex &) final { return RPage(); }
    void ReleasePage(RPage &) final {}
+   RPageStorage::RSealedPage ReadSealedPage(
+      ROOT::Experimental::DescriptorId_t, const ROOT::Experimental::RClusterIndex &) final
+   {
+      return RPageStorage::RSealedPage();
+   }
    std::unique_ptr<RCluster> LoadCluster(
       ROOT::Experimental::DescriptorId_t clusterId,
       const ROOT::Experimental::Detail::RPageSource::ColumnSet_t &columns) final

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -67,8 +67,156 @@ TEST(RPageStorage, ReadSealedPages)
 }
 
 
-TEST(RFieldMerger, Merge)
+TEST(RFieldMerger, FieldMergeEmpty)
 {
-   auto mergeResult = RFieldMerger::Merge(RFieldDescriptor(), RFieldDescriptor());
-   EXPECT_FALSE(mergeResult);
+   auto model = RNTupleModel::Create();
+   RPageSinkNull sinkNull;
+   sinkNull.Create(*model);
+
+   const auto &desc = sinkNull.GetDescriptor();
+   RFieldMerger merger({desc, desc.GetFieldZeroId()});
+   EXPECT_EQ(desc.GetFieldZeroId(), merger.GetReferenceFieldId(desc.GetFieldZeroId(), 0));
+   EXPECT_EQ(desc.GetFieldZeroId(), merger.GetInputFieldId(desc.GetFieldZeroId(), 0));
+
+   auto result = merger.Merge({desc, desc.GetFieldZeroId()});
+   EXPECT_EQ(1, result.Inspect());
+   EXPECT_EQ(desc.GetFieldZeroId(), merger.GetReferenceFieldId(desc.GetFieldZeroId(), 1));
+   EXPECT_EQ(desc.GetFieldZeroId(), merger.GetInputFieldId(desc.GetFieldZeroId(), 1));
+}
+
+
+TEST(RFieldMerger, FieldMergeSame)
+{
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("pt");
+   model->MakeField<std::string>("tag");
+   model->MakeField<std::vector<std::string>>("vec");
+   RPageSinkNull sinkNull;
+   sinkNull.Create(*model);
+   // Needs to be destructed before the sink
+   model = nullptr;
+
+   const auto &desc = sinkNull.GetDescriptor();
+   RFieldMerger merger({desc, desc.GetFieldZeroId()});
+   auto result = merger.Merge({desc, desc.GetFieldZeroId()});
+   EXPECT_EQ(1, result.Inspect());
+
+   // Check that both string column ids are present
+   auto tagId = desc.FindFieldId("tag");
+   auto tagColIdx0 = desc.FindColumnId(tagId, 0);
+   auto tagColIdx1 = desc.FindColumnId(tagId, 1);
+   EXPECT_EQ(tagColIdx0, merger.GetReferenceColumnId(tagColIdx0, 1));
+   EXPECT_EQ(tagColIdx1, merger.GetReferenceColumnId(tagColIdx1, 1));
+
+   // Check that sub fields are present
+   auto vecId = desc.FindFieldId("vec");
+   DescriptorId_t vecSubId = ROOT::Experimental::kInvalidDescriptorId;
+   for (const auto &f : desc.GetFieldRange(vecId))
+      vecSubId = f.GetId();
+   ASSERT_NE(vecSubId, ROOT::Experimental::kInvalidDescriptorId);
+   ASSERT_EQ(vecId, desc.GetFieldDescriptor(vecSubId).GetParentId());
+   EXPECT_EQ(vecSubId, merger.GetInputFieldId(vecSubId, 0));
+   EXPECT_EQ(vecSubId, merger.GetInputFieldId(vecSubId, 1));
+}
+
+
+TEST(RFieldMerger, FieldMergeReorder)
+{
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("pt");
+   model->MakeField<std::string>("tag");
+   model->MakeField<std::vector<std::string>>("vec");
+   RPageSinkNull sinkRef;
+   sinkRef.Create(*model);
+
+   // Same model but different order of fields
+   model = RNTupleModel::Create();
+   model->MakeField<std::vector<std::string>>("vec");
+   model->MakeField<std::string>("tag");
+   model->MakeField<float>("pt");
+   RPageSinkNull sinkInput1;
+   sinkInput1.Create(*model);
+   model = nullptr;
+
+   const auto &descRef = sinkRef.GetDescriptor();
+   RFieldMerger merger({descRef, descRef.GetFieldZeroId()});
+
+   const auto &descInput1 = sinkInput1.GetDescriptor();
+   auto result = merger.Merge({descInput1, descInput1.GetFieldZeroId()});
+   ASSERT_EQ(1, result.Inspect());
+
+   auto ptRefId = descRef.FindFieldId("pt");
+   auto ptInput1Id = descInput1.FindFieldId("pt");
+   EXPECT_NE(ptRefId, ptInput1Id);
+   EXPECT_EQ(ptRefId, merger.GetReferenceFieldId(ptInput1Id, 1));
+   EXPECT_EQ(ptInput1Id, merger.GetInputFieldId(ptRefId, 1));
+}
+
+
+TEST(RFieldMerger, FieldMergeSlice)
+{
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("pt");
+   RPageSinkNull sinkRef;
+   sinkRef.Create(*model);
+
+   // 2nd model has one more field which gets ignored during the merge
+   model = RNTupleModel::Create();
+   model->MakeField<std::string>("tag");
+   model->MakeField<float>("pt");
+   RPageSinkNull sinkInput1;
+   sinkInput1.Create(*model);
+   model = nullptr;
+
+   const auto &descRef = sinkRef.GetDescriptor();
+   RFieldMerger merger({descRef, descRef.GetFieldZeroId()});
+
+   const auto &descInput1 = sinkInput1.GetDescriptor();
+   auto result = merger.Merge({descInput1, descInput1.GetFieldZeroId()});
+   ASSERT_EQ(1, result.Inspect());
+
+   auto ptRefId = descRef.FindFieldId("pt");
+   auto ptInput1Id = descInput1.FindFieldId("pt");
+   EXPECT_EQ(ptRefId, merger.GetReferenceFieldId(ptInput1Id, 1));
+   EXPECT_EQ(ptInput1Id, merger.GetInputFieldId(ptRefId, 1));
+}
+
+
+TEST(RFieldMerger, FieldMergeErrors)
+{
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("pt");
+   RPageSinkNull sinkRef;
+   sinkRef.Create(*model);
+
+   const auto &descRef = sinkRef.GetDescriptor();
+   RFieldMerger merger({descRef, descRef.GetFieldZeroId()});
+
+   // Failure 1: missing field
+   model = RNTupleModel::Create();
+   RPageSinkNull sinkInput1;
+   sinkInput1.Create(*model);
+   const auto &descInput1 = sinkInput1.GetDescriptor();
+   auto result1 = merger.Merge({descInput1, descInput1.GetFieldZeroId()});
+   EXPECT_FALSE(result1);
+
+   // Failure 2: type mismatch
+   model = RNTupleModel::Create();
+   model->MakeField<int>("pt");
+   RPageSinkNull sinkInput2;
+   sinkInput2.Create(*model);
+   model = nullptr;
+   const auto &descInput2 = sinkInput2.GetDescriptor();
+   auto result2 = merger.Merge({descInput2, descInput2.GetFieldZeroId()});
+   EXPECT_FALSE(result2);
+
+   // Eventually: successfully merge after errors
+   model = RNTupleModel::Create();
+   model->MakeField<float>("pt");
+   RPageSinkNull sinkInput3;
+   sinkInput3.Create(*model);
+   model = nullptr;
+   const auto &descInput3 = sinkInput3.GetDescriptor();
+   auto result3 = merger.Merge({descInput3, descInput3.GetFieldZeroId()});
+   EXPECT_EQ(1, result3.Inspect());
 }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -24,12 +24,12 @@ TEST(RPageStorage, ReadSealedPages)
    // Create an ntuple at least 2 clusters, one with 1 entry and one with 100000 entries.
    // Hence the second cluster should have more than a single page per column.  We write uncompressed
    // pages so that we can meaningfully peek into the content of read sealed pages later on.
-   auto modelReferende = RNTupleModel::Create();
-   auto wrPt = modelReferende->MakeField<std::int32_t>("pt", 42);
+   auto model = RNTupleModel::Create();
+   auto wrPt = model->MakeField<std::int32_t>("pt", 42);
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
-      RNTupleWriter ntuple(std::move(modelReferende),
+      RNTupleWriter ntuple(std::move(model),
          std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
       ntuple.Fill();
       ntuple.CommitCluster();

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -43,6 +43,8 @@ TEST(RPageStorage, ReadSealedPages)
    source.Attach();
    const auto &descriptor = source.GetDescriptor();
    auto columnId = descriptor.FindColumnId(descriptor.FindFieldId("pt"), 0);
+
+   // Check first cluster consisting of a single entry
    RClusterIndex index(descriptor.FindClusterId(columnId, 0), 0);
    auto sealedPage = source.ReadSealedPage(columnId, index);
    ASSERT_EQ(1U, sealedPage.fNElements);

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -1,5 +1,70 @@
 #include "ntuple_test.hxx"
 
+namespace {
+
+// Reads an integer from a little-endian 4 byte buffer
+std::int32_t ReadRawInt(void *ptr)
+{
+   std::int32_t val = *reinterpret_cast<std::int32_t *>(ptr);
+#ifndef R__BYTESWAP
+   // on big endian system
+   auto x = (val & 0x0000FFFF) << 16 | (val & 0xFFFF0000) >> 16;
+   return (x & 0x00FF00FF) << 8 | (x & 0xFF00FF00) >> 8;
+#else
+   return val;
+#endif
+}
+
+} // anonymous namespace
+
+TEST(RPageStorage, ReadSealedPages)
+{
+   FileRaii fileGuard("test_ntuple_sealed_pages.root");
+
+   // Create an ntuple at least 2 clusters, one with 1 entry and one with 100000 entries.
+   // Hence the second cluster should have more than a single page per column.  We write uncompressed
+   // pages so that we can meaningfully peek into the content of read sealed pages later on.
+   auto modelReferende = RNTupleModel::Create();
+   auto wrPt = modelReferende->MakeField<std::int32_t>("pt", 42);
+   {
+      RNTupleWriteOptions options;
+      options.SetCompression(0);
+      RNTupleWriter ntuple(std::move(modelReferende),
+         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
+      ntuple.Fill();
+      ntuple.CommitCluster();
+      for (unsigned i = 0; i < 100000; ++i) {
+         *wrPt = i;
+         ntuple.Fill();
+      }
+   }
+
+   RPageSourceFile source("myNTuple", fileGuard.GetPath(), RNTupleReadOptions());
+   source.Attach();
+   const auto &descriptor = source.GetDescriptor();
+   auto columnId = descriptor.FindColumnId(descriptor.FindFieldId("pt"), 0);
+   RClusterIndex index(descriptor.FindClusterId(columnId, 0), 0);
+   auto sealedPage = source.ReadSealedPage(columnId, index);
+   ASSERT_EQ(1U, sealedPage.fNElements);
+   ASSERT_EQ(4U, sealedPage.fSize);
+   EXPECT_EQ(42, ReadRawInt(sealedPage.fBuffer.get()));
+
+   // Check second, big cluster
+   auto clusterId = descriptor.FindClusterId(columnId, 1);
+   ASSERT_NE(clusterId, index.GetClusterId());
+   const auto &clusterDesc = descriptor.GetClusterDescriptor(clusterId);
+   const auto &pageRange = clusterDesc.GetPageRange(columnId);
+   EXPECT_GT(pageRange.fPageInfos.size(), 1U);
+   std::uint32_t firstElementInPage = 0;
+   for (const auto &pi : pageRange.fPageInfos) {
+      sealedPage = source.ReadSealedPage(columnId, RClusterIndex(clusterId, firstElementInPage));
+      ASSERT_GE(sealedPage.fSize, 4U);
+      EXPECT_EQ(firstElementInPage, ReadRawInt(sealedPage.fBuffer.get()));
+      firstElementInPage += pi.fNElements;
+   }
+}
+
+
 TEST(RFieldMerger, Merge)
 {
    auto mergeResult = RFieldMerger::Merge(RFieldDescriptor(), RFieldDescriptor());

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -53,6 +53,7 @@ using ENTupleContainerFormat = ROOT::Experimental::ENTupleContainerFormat;
 using ENTupleStructure = ROOT::Experimental::ENTupleStructure;
 using NTupleSize_t = ROOT::Experimental::NTupleSize_t;
 using RColumnModel = ROOT::Experimental::RColumnModel;
+using RClusterIndex = ROOT::Experimental::RClusterIndex;
 using RDanglingFieldDescriptor = ROOT::Experimental::RDanglingFieldDescriptor;
 using RException = ROOT::Experimental::RException;
 template <class T>


### PR DESCRIPTION
The RField merger takes care of mapping between structurally equivalent RNTuple descriptors. It is supposed to be used as a lookup data structure when merging column data of RNTuples.

Based on #6763 

One of the building blocks for fast merged, as sketched in #6105