### PR TITLE
Fix in complex_quartic  problem reported in issue #6900 and add test

### DIFF
--- a/math/mathmore/inc/Math/Polynomial.h
+++ b/math/mathmore/inc/Math/Polynomial.h
@@ -105,26 +105,29 @@ public:
 
 //   using ParamFunction::operator();
 
-
    /**
       Find the polynomial roots.
       For n <= 4, the roots are found analytically while for larger order an iterative numerical method is used
-      The numerical method used is from GSL (see <A HREF="http://www.gnu.org/software/gsl/manual/gsl-ref_6.html#SEC53" )
+      The numerical method used is from GSL (see <A HREF="https://www.gnu.org/software/gsl/doc/html/poly.html">documentation</A> )
+      For the case of n = 4 by default an analytical algorithm is used from an implementation by
+       Andrew W. Steiner and Andy Buckley which is a translation from the original Cenrlib routine
+       (< HREF="https://cds.cern.ch/record/2050876/files/c208.html">RRTEQ4</A> ).
+      Note that depending on the coefficients the result could be not very accurate if the discriminant of the resolvent cubic
+      equation is very small. In that case it might be more robust to use the numerical method, by calling directly FindNumRoots()
+
    */
    const std::vector<std::complex <double> > & FindRoots();
-
 
    /**
       Find the only the real polynomial roots.
       For n <= 4, the roots are found analytically while for larger order an iterative numerical method is used
-      The numerical method used is from GSL (see <A HREF="http://www.gnu.org/software/gsl/manual/gsl-ref_6.html#SEC53" )
+      The numerical method used is from GSL (see <A HREF="https://www.gnu.org/software/gsl/doc/html/poly.html">documentation</A> )
    */
    std::vector<double > FindRealRoots();
 
-
    /**
       Find the polynomial roots using always an iterative numerical methods
-      The numerical method used is from GSL (see <A HREF="http://www.gnu.org/software/gsl/manual/gsl-ref_6.html#SEC53" )
+      The numerical method used is from GSL (see <A HREF="https://www.gnu.org/software/gsl/doc/html/poly.html">documentation</A> )
    */
    const std::vector<std::complex <double> > & FindNumRoots();
 
@@ -138,7 +141,7 @@ public:
 
    /**
        Optimized method to evaluate at the same time the function value and derivative at a point x.
-       Implement the interface specified bby ROOT::Math::IGradientOneDim.
+       Implement the interface specified by ROOT::Math::IGradientOneDim.
        In the case of polynomial there is no advantage to compute both at the same time
    */
    void FdF (double x, double & f, double & df) const {

--- a/math/mathmore/src/complex_quartic.h
+++ b/math/mathmore/src/complex_quartic.h
@@ -151,9 +151,11 @@ gsl_poly_complex_solve_quartic (double a, double b, double c, double d,
         disc = R2 - Q3;
 
 //       more numerical problems with this calculation of disc
-//       double CR2 = 729 * rcub * rcub;
-//       double CQ3 = 2916 * qcub * qcub * qcub;
-//       disc = (CR2 - CQ3) / 2125764.0;
+//LM - use this since it fixes case reported in issue #6900 when disc is approx 0
+//      (needs to add additional test cases where disc is ~ 0)
+        double CR2 = 729 * rcub * rcub;
+        double CQ3 = 2916 * qcub * qcub * qcub;
+        disc = (CR2 - CQ3) / 2125764.0;
 
 
         if (0 == R && 0 == Q)
@@ -162,7 +164,7 @@ gsl_poly_complex_solve_quartic (double a, double b, double c, double d,
             u[1] = -rc / 3;
             u[2] = -rc / 3;
           }
-        else if (R2 == Q3)
+        else if (disc == 0)
           {
             double sqrtQ = sqrt (Q);
             if (R > 0)
@@ -398,4 +400,3 @@ gsl_poly_complex_solve_quartic (double a, double b, double c, double d,
 
   return 4;
 }
-

--- a/math/mathmore/test/CMakeLists.txt
+++ b/math/mathmore/test/CMakeLists.txt
@@ -55,3 +55,4 @@ foreach(file ${TestMathMoreSource})
 endforeach()
 
 ROOT_ADD_GTEST(stressMathMoreUnit testStress.cxx StatFunction.cxx LIBRARIES Core MathCore MathMore)
+ROOT_ADD_GTEST(testPolynomialRoots testPolynomialRoots LIBRARIES Core MathCore MathMore)

--- a/math/mathmore/test/testPolynomialRoots.cxx
+++ b/math/mathmore/test/testPolynomialRoots.cxx
@@ -1,0 +1,226 @@
+// test finding Roots of polynomials
+
+#include "gtest/gtest.h"
+
+#include "Math/Polynomial.h"
+#include <vector>
+#include <complex>
+
+using namespace ROOT::Math;
+using namespace std;
+
+class QuarticPolynomial : public ::testing::Test {
+
+protected:
+   enum EModeType { kAnalytical = 1, kNumerical = 2 };
+   vector<double> coeff;
+   vector<complex<double>> expectedResult;
+   double a, b, c, d, e = 0;
+   double tolerance = 0;
+   bool debug = false;
+   EModeType algoType;
+
+   void checkResult(vector<complex<double>> &result)
+   {
+      // sort first result
+      auto smallerComplex = [&](complex<double> c1, complex<double> c2) {
+         double diff = std::abs( c1.real()-c2.real() );
+         // in case of numerical roots difference can be small
+         //if (c1.real() != c2.real())
+         if (diff > std::max(tolerance, 4 * std::numeric_limits<double>::epsilon() ) )
+            return c1.real() < c2.real();
+         else
+            return c1.imag() < c2.imag();
+      };
+      std::sort(result.begin(), result.end(), smallerComplex);
+
+      ASSERT_EQ(result.size(), expectedResult.size());
+      ASSERT_EQ(result.size(), 4 );
+
+      // unrolll loop to have test printing component when failed
+      if (tolerance <= 0) {
+         // in this case check with 4 ulp
+         EXPECT_DOUBLE_EQ(result[0].real(), expectedResult[0].real());
+         EXPECT_DOUBLE_EQ(result[0].imag(), expectedResult[0].imag());
+
+         EXPECT_DOUBLE_EQ(result[1].real(), expectedResult[1].real());
+         EXPECT_DOUBLE_EQ(result[1].imag(), expectedResult[1].imag());
+
+         EXPECT_DOUBLE_EQ(result[2].real(), expectedResult[2].real());
+         EXPECT_DOUBLE_EQ(result[2].imag(), expectedResult[2].imag());
+
+         EXPECT_DOUBLE_EQ(result[3].real(), expectedResult[3].real());
+         EXPECT_DOUBLE_EQ(result[3].imag(), expectedResult[3].imag());
+      }
+      else {
+         // check within a given absolute tolerance
+         EXPECT_NEAR(result[0].real(), expectedResult[0].real(), tolerance);
+         EXPECT_NEAR(result[0].imag(), expectedResult[0].imag(), tolerance);
+
+         EXPECT_NEAR(result[1].real(), expectedResult[1].real(), tolerance);
+         EXPECT_NEAR(result[1].imag(), expectedResult[1].imag(), tolerance);
+
+         EXPECT_NEAR(result[2].real(), expectedResult[2].real(), tolerance);
+         EXPECT_NEAR(result[2].imag(), expectedResult[2].imag(), tolerance);
+
+         EXPECT_NEAR(result[3].real(), expectedResult[3].real(),tolerance);
+         EXPECT_NEAR(result[3].imag(), expectedResult[3].imag(),tolerance);
+      }
+   }
+
+   void print(const vector<complex<double>> &result)
+   {
+      std::string algoName = (algoType == kNumerical) ? "Numerical" : "Analytical";
+      std::cout << algoName << " solution for " << a << "*x^4 + " << b << "*x^3 + " << c << "*x^2 + " << d << "*x + " << e << " = 0"
+                << std::endl;
+      for (unsigned int i = 0; i < result.size(); i++)
+      {
+         std::cout << " root " << i << " : " << result[i] << std::endl;
+      }
+   }
+
+      void runTest(EModeType type, double tol = 0)
+   {
+      a = coeff[0];
+      b = coeff[1];
+      c = coeff[2];
+      d = coeff[3];
+      e = coeff[4];
+
+      tolerance = tol;
+      algoType = type;
+
+      Polynomial pol(a, b, c, d, e);
+
+      auto result = (type != kNumerical) ? pol.FindRoots() : pol.FindNumRoots();
+
+      checkResult(result);
+
+      if (debug)
+         print(result);
+   }
+};
+
+// test x^4 - 16 = 0
+TEST_F(QuarticPolynomial, FindRootsDirect_DegPol1)
+{
+   coeff = {1, 0, 0, 0, -16};
+
+   expectedResult = {complex<double>(-2, 0),
+                     complex<double>( 0,-2),
+                     complex<double>( 0, 2),
+                     complex<double>( 2, 0)};
+
+   runTest(kAnalytical);
+   runTest(kNumerical, 1.E-13);
+}
+
+// test (x+1)^4 = 0
+TEST_F(QuarticPolynomial, FindRootsDirect_DegPol2)
+{
+   coeff = {1, 4, 6, 4, 1};
+
+   expectedResult = {complex<double>(-1, 0),
+                     complex<double>(-1, 0),
+                     complex<double>(-1, 0),
+                     complex<double>(-1, 0)};
+
+   runTest(kAnalytical);
+   // bad tolerance for this test
+   debug = true;
+   // numerical method has a large error for this case
+   runTest(kNumerical, 1.E-3);
+}
+
+// test x4 + 5x^2 + 4 = 0
+//4 imaginary roots (x-i)(x+i)(x-2i)(x+2i)=0
+TEST_F(QuarticPolynomial, FindRootsDirect_4ImagRoots)
+{
+   coeff = {1, 0, 5, 0, 4};
+
+   expectedResult = {complex<double>(0, -2),
+                     complex<double>(0, -1),
+                     complex<double>(0, 1),
+                     complex<double>(0, 2)};
+
+   //debug = true;
+   runTest(kAnalytical, 0);
+   runTest(kNumerical, 1.E-12);
+}
+
+//
+// four full complex roots, (x-1-i)(x-1+i)(x-1-2i)(x-1+2i)=0")
+TEST_F(QuarticPolynomial, FindRootsDirect_4CompRoots)
+{
+   coeff = {1.0, -4.0, 11.0, -14.0, 10.0};
+
+   expectedResult = {complex<double>(1, -2),
+                     complex<double>(1, -1),
+                     complex<double>(1, 1),
+                     complex<double>(1, 2)};
+
+   runTest(kAnalytical, 0);
+   runTest(kNumerical, 1.E-12);
+}
+
+// four real roots (x+1)(x+2)(x+3)(x+4)=0
+TEST_F(QuarticPolynomial, FindRootsDirect_4RealRoots)
+{
+
+   coeff = {1.0, 10.0, 35.0, 50.0, 24.0};
+
+   expectedResult = {complex<double>(-4, 0),
+                     complex<double>(-3, 0),
+                     complex<double>(-2, 0),
+                     complex<double>(-1, 0)};
+
+   runTest(kAnalytical, 0);
+   runTest(kNumerical, 1.E-12);
+}
+
+// test   x^4-8x^3+12x^2+16x+4=0
+// 4 real roots where 2 are degeenrates
+
+TEST_F(QuarticPolynomial, FindRootsDirect_4RealDegRoots)
+{
+
+   coeff = {1.0, -8.0, 12.0, 16.0, 4.0};
+
+   expectedResult = {complex<double>(-0.44948974278317788, 0),
+                     complex<double>(-0.44948974278317788, 0),
+                     complex<double>(4.44948974278317788, 0),  // this is 4 - r0
+                     complex<double>(4.44948974278317788, 0)};
+
+   runTest(kAnalytical, 0);
+   debug = true;
+   runTest(kNumerical, 1.E-7);
+}
+
+// test 5x^4 + 4x^3 + 3x^2 + 2x + 1
+
+TEST_F(QuarticPolynomial, FindRootsDirect_54321)
+{
+   coeff = {5, 4, 3, 2, 1};
+
+   expectedResult = {complex<double>(-0.5378322749029899, -0.358284686345128),
+                     complex<double>(-0.5378322749029899, +0.358284686345128),
+                     complex<double>(+0.13783227490298988, -0.6781543891053364),
+                     complex<double>(+0.13783227490298988, +0.6781543891053364)};
+
+   runTest(kAnalytical);
+   runTest(kNumerical);
+}
+// special case reported in issue #6900 by S. Binet
+TEST_F(QuarticPolynomial, FindRootsNumeric_4RealDegRootsR0)
+{
+   coeff = {2.2206846808021337, 7.643281053997895, 8.831759446092846, 3.880673545129404, 0.5724551380144077};
+
+   expectedResult = {complex<double>(-1.3429253, 0.),
+                     complex<double>(-1.3427327, 0 ),
+                     complex<double>(-0.3781962, 0 ),
+                     complex<double>(-0.3780036, 0) };
+
+   debug = true;
+   runTest(kAnalytical, 1.E-6);
+   runTest(kNumerical, 1.E-4);
+}

--- a/math/mathmore/test/testPolynomialRoots.cxx
+++ b/math/mathmore/test/testPolynomialRoots.cxx
@@ -102,7 +102,7 @@ protected:
 };
 
 // test x^4 - 16 = 0
-TEST_F(QuarticPolynomial, FindRootsDirect_DegPol1)
+TEST_F(QuarticPolynomial, FindRoots_DegPol1)
 {
    coeff = {1, 0, 0, 0, -16};
 
@@ -116,7 +116,7 @@ TEST_F(QuarticPolynomial, FindRootsDirect_DegPol1)
 }
 
 // test (x+1)^4 = 0
-TEST_F(QuarticPolynomial, FindRootsDirect_DegPol2)
+TEST_F(QuarticPolynomial, FindRoots_DegPol2)
 {
    coeff = {1, 4, 6, 4, 1};
 
@@ -134,7 +134,7 @@ TEST_F(QuarticPolynomial, FindRootsDirect_DegPol2)
 
 // test x4 + 5x^2 + 4 = 0
 //4 imaginary roots (x-i)(x+i)(x-2i)(x+2i)=0
-TEST_F(QuarticPolynomial, FindRootsDirect_4ImagRoots)
+TEST_F(QuarticPolynomial, FindRoots_4ImagRoots)
 {
    coeff = {1, 0, 5, 0, 4};
 
@@ -150,7 +150,7 @@ TEST_F(QuarticPolynomial, FindRootsDirect_4ImagRoots)
 
 //
 // four full complex roots, (x-1-i)(x-1+i)(x-1-2i)(x-1+2i)=0")
-TEST_F(QuarticPolynomial, FindRootsDirect_4CompRoots)
+TEST_F(QuarticPolynomial, FindRoots_4CompRoots)
 {
    coeff = {1.0, -4.0, 11.0, -14.0, 10.0};
 
@@ -164,7 +164,7 @@ TEST_F(QuarticPolynomial, FindRootsDirect_4CompRoots)
 }
 
 // four real roots (x+1)(x+2)(x+3)(x+4)=0
-TEST_F(QuarticPolynomial, FindRootsDirect_4RealRoots)
+TEST_F(QuarticPolynomial, FindRoots_4RealRoots)
 {
 
    coeff = {1.0, 10.0, 35.0, 50.0, 24.0};
@@ -181,7 +181,7 @@ TEST_F(QuarticPolynomial, FindRootsDirect_4RealRoots)
 // test   x^4-8x^3+12x^2+16x+4=0
 // 4 real roots where 2 are degeenrates
 
-TEST_F(QuarticPolynomial, FindRootsDirect_4RealDegRoots)
+TEST_F(QuarticPolynomial, FindRoots_4RealDegRoots)
 {
 
    coeff = {1.0, -8.0, 12.0, 16.0, 4.0};
@@ -198,7 +198,7 @@ TEST_F(QuarticPolynomial, FindRootsDirect_4RealDegRoots)
 
 // test 5x^4 + 4x^3 + 3x^2 + 2x + 1
 
-TEST_F(QuarticPolynomial, FindRootsDirect_54321)
+TEST_F(QuarticPolynomial, FindRoots_54321)
 {
    coeff = {5, 4, 3, 2, 1};
 
@@ -208,10 +208,10 @@ TEST_F(QuarticPolynomial, FindRootsDirect_54321)
                      complex<double>(+0.13783227490298988, +0.6781543891053364)};
 
    runTest(kAnalytical);
-   runTest(kNumerical);
+   runTest(kNumerical, 1.E-13);
 }
 // special case reported in issue #6900 by S. Binet
-TEST_F(QuarticPolynomial, FindRootsNumeric_4RealDegRootsR0)
+TEST_F(QuarticPolynomial, FindRoots_4RealDegRootsR0)
 {
    coeff = {2.2206846808021337, 7.643281053997895, 8.831759446092846, 3.880673545129404, 0.5724551380144077};
 


### PR DESCRIPTION
Uncomment some different code that is used to compute the discriminat of the
resolvent cubic equation used to find the roots of a quartic equation. 
This different code seems to be better numerically. 

This fixes #6900

Add tests for quartic equations to validate code. 