### PR TITLE
[v7] RAxisBase() is noexcept only if std::string() is.

### DIFF
--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -54,7 +54,7 @@ protected:
    ///\}
 
    /// Default construct a RAxisBase (for use by derived classes for I/O)
-   RAxisBase() noexcept = default;
+   RAxisBase() noexcept(noexcept(std::string())) = default;
 
    /// Virtual destructor needed in this inheritance-based design
    virtual ~RAxisBase();


### PR DESCRIPTION
The standard does not require that std::string's default constructor
be noexcept until C++17. For C++14, all reasonably new STL
implementations do add the noexcept specifier anyway, but e.g. STLs
coming with very old gcc versions might not.

Fixes #6731 .