### PR TITLE
replace MnRefCountedPointer with std::shared_ptr

### DIFF
--- a/math/minuit2/CMakeLists.txt
+++ b/math/minuit2/CMakeLists.txt
@@ -97,8 +97,6 @@ if(CMAKE_PROJECT_NAME STREQUAL ROOT)
       Minuit2/MnPlot.h
       Minuit2/MnPosDef.h
       Minuit2/MnPrint.h
-      Minuit2/MnRefCountedPointer.h
-      Minuit2/MnReferenceCounter.h
       Minuit2/MnScan.h
       Minuit2/MnSeedGenerator.h
       Minuit2/MnSimplex.h

--- a/math/minuit2/inc/Minuit2/BasicMinimumState.h
+++ b/math/minuit2/inc/Minuit2/BasicMinimumState.h
@@ -44,24 +44,6 @@ public:
    {
    }
 
-   ~BasicMinimumState() {}
-
-   BasicMinimumState(const BasicMinimumState &state)
-      : fParameters(state.fParameters), fError(state.fError), fGradient(state.fGradient), fEDM(state.fEDM),
-        fNFcn(state.fNFcn)
-   {
-   }
-
-   BasicMinimumState &operator=(const BasicMinimumState &state)
-   {
-      fParameters = state.fParameters;
-      fError = state.fError;
-      fGradient = state.fGradient;
-      fEDM = state.fEDM;
-      fNFcn = state.fNFcn;
-      return *this;
-   }
-
    void *operator new(size_t nbytes) { return StackAllocatorHolder::Get().Allocate(nbytes); }
 
    void operator delete(void *p, size_t /*nbytes */) { StackAllocatorHolder::Get().Deallocate(p); }

--- a/math/minuit2/inc/Minuit2/FunctionGradient.h
+++ b/math/minuit2/inc/Minuit2/FunctionGradient.h
@@ -10,8 +10,9 @@
 #ifndef ROOT_Minuit2_FunctionGradient
 #define ROOT_Minuit2_FunctionGradient
 
-#include "Minuit2/MnRefCountedPointer.h"
 #include "Minuit2/BasicFunctionGradient.h"
+
+#include <memory>
 
 namespace ROOT {
 
@@ -21,30 +22,20 @@ class FunctionGradient {
 
 private:
 public:
-   explicit FunctionGradient(unsigned int n)
-      : fData(MnRefCountedPointer<BasicFunctionGradient>(new BasicFunctionGradient(n)))
-   {
-   }
+   explicit FunctionGradient(unsigned int n) : fData(std::make_shared<BasicFunctionGradient>(n)) {}
 
-   explicit FunctionGradient(const MnAlgebraicVector &grd)
-      : fData(MnRefCountedPointer<BasicFunctionGradient>(new BasicFunctionGradient(grd)))
-   {
-   }
+   // HD: this deep-copies, inconsistent to assignment?
+   explicit FunctionGradient(const MnAlgebraicVector &grd) : fData(std::make_shared<BasicFunctionGradient>(grd)) {}
 
    FunctionGradient(const MnAlgebraicVector &grd, const MnAlgebraicVector &g2, const MnAlgebraicVector &gstep)
-      : fData(MnRefCountedPointer<BasicFunctionGradient>(new BasicFunctionGradient(grd, g2, gstep)))
+      : fData(std::make_shared<BasicFunctionGradient>(grd, g2, gstep))
    {
    }
-
-   ~FunctionGradient() {}
 
    FunctionGradient(const FunctionGradient &grad) : fData(grad.fData) {}
 
-   FunctionGradient &operator=(const FunctionGradient &grad)
-   {
-      fData = grad.fData;
-      return *this;
-   }
+   // HD: assignment shares the pointer
+   FunctionGradient &operator=(const FunctionGradient &grad) = default;
 
    const MnAlgebraicVector &Grad() const { return fData->Grad(); }
    const MnAlgebraicVector &Vec() const { return fData->Vec(); }
@@ -55,7 +46,7 @@ public:
    const MnAlgebraicVector &Gstep() const { return fData->Gstep(); }
 
 private:
-   MnRefCountedPointer<BasicFunctionGradient> fData;
+   std::shared_ptr<BasicFunctionGradient> fData;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/FunctionMinimum.h
+++ b/math/minuit2/inc/Minuit2/FunctionMinimum.h
@@ -13,6 +13,7 @@
 #include "Minuit2/BasicFunctionMinimum.h"
 
 #include <vector>
+#include <memory>
 
 #ifdef G__DICTIONARY
 typedef ROOT::Minuit2::MinimumState MinimumState;
@@ -32,54 +33,36 @@ namespace Minuit2 {
 class FunctionMinimum {
 
 public:
-   class MnReachedCallLimit {
-   };
-   class MnAboveMaxEdm {
-   };
+   using MnAboveMaxEdm = BasicFunctionMinimum::MnAboveMaxEdm;
+   using MnReachedCallLimit = BasicFunctionMinimum::MnReachedCallLimit;
 
 public:
    /// constructor from only MinimumSeed. Minimum is only from seed result not full minimization
-   FunctionMinimum(const MinimumSeed &seed, double up)
-      : fData(MnRefCountedPointer<BasicFunctionMinimum>(new BasicFunctionMinimum(seed, up)))
-   {
-   }
+   FunctionMinimum(const MinimumSeed &seed, double up) : fData(std::make_shared<BasicFunctionMinimum>(seed, up)) {}
 
    /// constructor at the end of a successfull minimization from seed and vector of states
    FunctionMinimum(const MinimumSeed &seed, const std::vector<MinimumState> &states, double up)
-      : fData(MnRefCountedPointer<BasicFunctionMinimum>(new BasicFunctionMinimum(seed, states, up)))
+      : fData(std::make_shared<BasicFunctionMinimum>(seed, states, up))
    {
    }
 
    /// constructor at the end of a failed minimization due to exceeding function call limit
    FunctionMinimum(const MinimumSeed &seed, const std::vector<MinimumState> &states, double up, MnReachedCallLimit)
-      : fData(MnRefCountedPointer<BasicFunctionMinimum>(
-           new BasicFunctionMinimum(seed, states, up, BasicFunctionMinimum::MnReachedCallLimit())))
+      : fData(std::make_shared<BasicFunctionMinimum>(seed, states, up, MnReachedCallLimit{}))
    {
    }
 
    /// constructor at the end of a failed minimization due to edm above maximum value
    FunctionMinimum(const MinimumSeed &seed, const std::vector<MinimumState> &states, double up, MnAboveMaxEdm)
-      : fData(MnRefCountedPointer<BasicFunctionMinimum>(
-           new BasicFunctionMinimum(seed, states, up, BasicFunctionMinimum::MnAboveMaxEdm())))
+      : fData(std::make_shared<BasicFunctionMinimum>(seed, states, up, MnAboveMaxEdm{}))
    {
    }
-
-   /// copy constructo
-   FunctionMinimum(const FunctionMinimum &min) : fData(min.fData) {}
-
-   FunctionMinimum &operator=(const FunctionMinimum &min)
-   {
-      fData = min.fData;
-      return *this;
-   }
-
-   ~FunctionMinimum() {}
 
    // add new state
    void Add(const MinimumState &state) { fData->Add(state); }
 
    // add new state
-   void Add(const MinimumState &state, MnAboveMaxEdm) { fData->Add(state, BasicFunctionMinimum::MnAboveMaxEdm()); }
+   void Add(const MinimumState &state, MnAboveMaxEdm) { fData->Add(state, MnAboveMaxEdm{}); }
 
    const MinimumSeed &Seed() const { return fData->Seed(); }
    const std::vector<ROOT::Minuit2::MinimumState> &States() const { return fData->States(); }
@@ -113,7 +96,7 @@ public:
    void SetErrorDef(double up) { return fData->SetErrorDef(up); }
 
 private:
-   MnRefCountedPointer<BasicFunctionMinimum> fData;
+   std::shared_ptr<BasicFunctionMinimum> fData;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/MinimumError.h
+++ b/math/minuit2/inc/Minuit2/MinimumError.h
@@ -10,8 +10,9 @@
 #ifndef ROOT_Minuit2_MinimumError
 #define ROOT_Minuit2_MinimumError
 
-#include "Minuit2/MnRefCountedPointer.h"
 #include "Minuit2/BasicMinimumError.h"
+
+#include <memory>
 
 namespace ROOT {
 
@@ -25,51 +26,34 @@ namespace Minuit2 {
 class MinimumError {
 
 public:
-   class MnNotPosDef {
-   };
-   class MnMadePosDef {
-   };
-   class MnHesseFailed {
-   };
-   class MnInvertFailed {
-   };
+   using MnHesseFailed = BasicMinimumError::MnHesseFailed;
+   using MnInvertFailed = BasicMinimumError::MnInvertFailed;
+   using MnMadePosDef = BasicMinimumError::MnMadePosDef;
+   using MnNotPosDef = BasicMinimumError::MnNotPosDef;
 
 public:
-   MinimumError(unsigned int n) : fData(MnRefCountedPointer<BasicMinimumError>(new BasicMinimumError(n))) {}
+   MinimumError(unsigned int n) : fData(std::make_shared<BasicMinimumError>(n)) {}
 
-   MinimumError(const MnAlgebraicSymMatrix &mat, double dcov)
-      : fData(MnRefCountedPointer<BasicMinimumError>(new BasicMinimumError(mat, dcov)))
-   {
-   }
+   MinimumError(const MnAlgebraicSymMatrix &mat, double dcov) : fData(std::make_shared<BasicMinimumError>(mat, dcov)) {}
 
    MinimumError(const MnAlgebraicSymMatrix &mat, MnHesseFailed)
-      : fData(MnRefCountedPointer<BasicMinimumError>(new BasicMinimumError(mat, BasicMinimumError::MnHesseFailed())))
+      : fData(std::make_shared<BasicMinimumError>(mat, MnHesseFailed{}))
    {
    }
 
    MinimumError(const MnAlgebraicSymMatrix &mat, MnMadePosDef)
-      : fData(MnRefCountedPointer<BasicMinimumError>(new BasicMinimumError(mat, BasicMinimumError::MnMadePosDef())))
+      : fData(std::make_shared<BasicMinimumError>(mat, MnMadePosDef{}))
    {
    }
 
    MinimumError(const MnAlgebraicSymMatrix &mat, MnInvertFailed)
-      : fData(MnRefCountedPointer<BasicMinimumError>(new BasicMinimumError(mat, BasicMinimumError::MnInvertFailed())))
+      : fData(std::make_shared<BasicMinimumError>(mat, MnInvertFailed{}))
    {
    }
 
    MinimumError(const MnAlgebraicSymMatrix &mat, MnNotPosDef)
-      : fData(MnRefCountedPointer<BasicMinimumError>(new BasicMinimumError(mat, BasicMinimumError::MnNotPosDef())))
+      : fData(std::make_shared<BasicMinimumError>(mat, MnNotPosDef{}))
    {
-   }
-
-   ~MinimumError() {}
-
-   MinimumError(const MinimumError &e) : fData(e.fData) {}
-
-   MinimumError &operator=(const MinimumError &err)
-   {
-      fData = err.fData;
-      return *this;
    }
 
    MnAlgebraicSymMatrix Matrix() const { return fData->Matrix(); }
@@ -88,7 +72,7 @@ public:
    bool IsAvailable() const { return fData->IsAvailable(); }
 
 private:
-   MnRefCountedPointer<BasicMinimumError> fData;
+   std::shared_ptr<BasicMinimumError> fData;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/MinimumParameters.h
+++ b/math/minuit2/inc/Minuit2/MinimumParameters.h
@@ -10,8 +10,9 @@
 #ifndef ROOT_Minuit2_MinimumParameters
 #define ROOT_Minuit2_MinimumParameters
 
-#include "Minuit2/MnRefCountedPointer.h"
 #include "Minuit2/BasicMinimumParameters.h"
+
+#include <memory>
 
 namespace ROOT {
 
@@ -20,31 +21,18 @@ namespace Minuit2 {
 class MinimumParameters {
 
 public:
-   MinimumParameters(unsigned int n, double fval = 0)
-      : fData(MnRefCountedPointer<BasicMinimumParameters>(new BasicMinimumParameters(n, fval)))
-   {
-   }
+   MinimumParameters(unsigned int n, double fval = 0) : fData(std::make_shared<BasicMinimumParameters>(n, fval)) {}
 
    /** takes the Parameter vector */
    MinimumParameters(const MnAlgebraicVector &avec, double fval)
-      : fData(MnRefCountedPointer<BasicMinimumParameters>(new BasicMinimumParameters(avec, fval)))
+      : fData(std::make_shared<BasicMinimumParameters>(avec, fval))
    {
    }
 
    /** takes the Parameter vector plus step size x1 - x0 = dirin */
    MinimumParameters(const MnAlgebraicVector &avec, const MnAlgebraicVector &dirin, double fval)
-      : fData(MnRefCountedPointer<BasicMinimumParameters>(new BasicMinimumParameters(avec, dirin, fval)))
+      : fData(std::make_shared<BasicMinimumParameters>(avec, dirin, fval))
    {
-   }
-
-   ~MinimumParameters() {}
-
-   MinimumParameters(const MinimumParameters &par) : fData(par.fData) {}
-
-   MinimumParameters &operator=(const MinimumParameters &par)
-   {
-      fData = par.fData;
-      return *this;
    }
 
    const MnAlgebraicVector &Vec() const { return fData->Vec(); }
@@ -54,7 +42,7 @@ public:
    bool HasStepSize() const { return fData->HasStepSize(); }
 
 private:
-   MnRefCountedPointer<BasicMinimumParameters> fData;
+   std::shared_ptr<BasicMinimumParameters> fData;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/MinimumSeed.h
+++ b/math/minuit2/inc/Minuit2/MinimumSeed.h
@@ -10,8 +10,9 @@
 #ifndef ROOT_Minuit2_MinimumSeed
 #define ROOT_Minuit2_MinimumSeed
 
-#include "Minuit2/MnRefCountedPointer.h"
 #include "Minuit2/BasicMinimumSeed.h"
+
+#include <memory>
 
 namespace ROOT {
 
@@ -31,18 +32,8 @@ class MinimumSeed {
 
 public:
    MinimumSeed(const MinimumState &st, const MnUserTransformation &trafo)
-      : fData(MnRefCountedPointer<BasicMinimumSeed>(new BasicMinimumSeed(st, trafo)))
+      : fData(std::make_shared<BasicMinimumSeed>(st, trafo))
    {
-   }
-
-   ~MinimumSeed() {}
-
-   MinimumSeed(const MinimumSeed &seed) : fData(seed.fData) {}
-
-   MinimumSeed &operator=(const MinimumSeed &seed)
-   {
-      fData = seed.fData;
-      return *this;
    }
 
    const MinimumState &State() const { return fData->State(); }
@@ -57,7 +48,7 @@ public:
    bool IsValid() const { return fData->IsValid(); }
 
 private:
-   MnRefCountedPointer<BasicMinimumSeed> fData;
+   std::shared_ptr<BasicMinimumSeed> fData;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/MinimumState.h
+++ b/math/minuit2/inc/Minuit2/MinimumState.h
@@ -10,8 +10,9 @@
 #ifndef ROOT_Minuit2_MinimumState
 #define ROOT_Minuit2_MinimumState
 
-#include "Minuit2/MnRefCountedPointer.h"
 #include "Minuit2/BasicMinimumState.h"
+
+#include <memory>
 
 namespace ROOT {
 
@@ -29,15 +30,12 @@ class MinimumState {
 
 public:
    /** invalid state */
-   MinimumState(unsigned int n) : fData(MnRefCountedPointer<BasicMinimumState>(new BasicMinimumState(n, 0., 0., 0.))) {}
+   MinimumState(unsigned int n) : fData(std::make_shared<BasicMinimumState>(n, 0., 0., 0.)) {}
    /** state without parameters and errors (only function value an, edm and nfcn) */
-   MinimumState(double fval, double edm, int nfcn)
-      : fData(MnRefCountedPointer<BasicMinimumState>(new BasicMinimumState(0, fval, edm, nfcn)))
-   {
-   }
+   MinimumState(double fval, double edm, int nfcn) : fData(std::make_shared<BasicMinimumState>(0, fval, edm, nfcn)) {}
    /** state with parameters only (from stepping methods like Simplex, Scan) */
    MinimumState(const MinimumParameters &states, double edm, int nfcn)
-      : fData(MnRefCountedPointer<BasicMinimumState>(new BasicMinimumState(states, edm, nfcn)))
+      : fData(std::make_shared<BasicMinimumState>(states, edm, nfcn))
    {
    }
 
@@ -45,18 +43,8 @@ public:
        such as Migrad) */
    MinimumState(const MinimumParameters &states, const MinimumError &err, const FunctionGradient &grad, double edm,
                 int nfcn)
-      : fData(MnRefCountedPointer<BasicMinimumState>(new BasicMinimumState(states, err, grad, edm, nfcn)))
+      : fData(std::make_shared<BasicMinimumState>(states, err, grad, edm, nfcn))
    {
-   }
-
-   ~MinimumState() {}
-
-   MinimumState(const MinimumState &state) : fData(state.fData) {}
-
-   MinimumState &operator=(const MinimumState &state)
-   {
-      fData = state.fData;
-      return *this;
    }
 
    const MinimumParameters &Parameters() const { return fData->Parameters(); }
@@ -75,7 +63,7 @@ public:
    bool HasCovariance() const { return fData->HasCovariance(); }
 
 private:
-   MnRefCountedPointer<BasicMinimumState> fData;
+   std::shared_ptr<BasicMinimumState> fData;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/src/CMakeLists.txt
+++ b/math/minuit2/src/CMakeLists.txt
@@ -86,8 +86,6 @@ set(MINUIT2_HEADERS
     MnPlot.h
     MnPosDef.h
     MnPrint.h
-    MnRefCountedPointer.h
-    MnReferenceCounter.h
     MnScan.h
     MnSeedGenerator.h
     MnSimplex.h


### PR DESCRIPTION
This replaces the homegrown MnRefCountedPointer with std::shared_ptr. Using standard components is better, of course, and clang's address sanitizer has reported issues with MnRefCountedPointer, another reason to do this.

I removed obsolete implementations of copy constructors, copy assignment operators and destructors from the affected classes, that just implemented the default behaviour.

The patch currently looks very complicated, because I used the new clang-formatted style, but will become much more easy to read when #6917 is accepted.