### PR TITLE
Further improvements to reduce lock contention

### DIFF
--- a/core/thread/inc/ROOT/TReentrantRWLock.hxx
+++ b/core/thread/inc/ROOT/TReentrantRWLock.hxx
@@ -88,7 +88,7 @@ struct UniqueLockRecurseCount {
 struct RecurseCounts {
    using Hint_t = TVirtualRWMutex::Hint_t;
    using ReaderColl_t = std::unordered_map<std::thread::id, size_t>;
-   size_t fWriteRecurse; ///<! Number of re-entry in the lock by the same thread.
+   size_t fWriteRecurse = 0; ///<! Number of re-entry in the lock by the same thread.
 
    std::thread::id fWriterThread; ///<! Holder of the write lock
    ReaderColl_t fReadersCount;    ///<! Set of reader thread ids
@@ -149,7 +149,7 @@ struct RecurseCounts {
 struct RecurseCountsShared {
    using Hint_t = TVirtualRWMutex::Hint_t;
    using ReaderColl_t = std::unordered_map<std::thread::id, size_t>;
-   size_t fWriteRecurse; ///<! Number of re-entry in the lock by the same thread.
+   size_t fWriteRecurse = 0; ///<! Number of re-entry in the lock by the same thread.
 
    std::thread::id fWriterThread; ///<! Holder of the write lock
    ReaderColl_t fReadersCount;    ///<! Set of reader thread ids

--- a/core/thread/src/TRWMutexImp.cxx
+++ b/core/thread/src/TRWMutexImp.cxx
@@ -21,6 +21,9 @@
 #include "TRWMutexImp.h"
 #include "ROOT/TSpinMutex.hxx"
 #include "TMutex.h"
+#if __cplusplus >= 201402L
+#include <shared_mutex>
+#endif
 
 namespace ROOT {
 
@@ -113,5 +116,11 @@ template class TRWMutexImp<ROOT::TSpinMutex>;
 template class TRWMutexImp<std::mutex>;
 template class TRWMutexImp<TMutex, ROOT::Internal::UniqueLockRecurseCount>;
 template class TRWMutexImp<ROOT::TSpinMutex, ROOT::Internal::UniqueLockRecurseCount>;
+#if __cplusplus >= 201402L
+template class TRWMutexImp<std::shared_timed_mutex, ROOT::Internal::RecurseCountsShared>;
+#endif
+#if __cplusplus >= 201703L
+template class TRWMutexImp<std::shared_mutex, ROOT::Internal::RecurseCountsShared>;
+#endif
 
 } // End of namespace ROOT

--- a/core/thread/src/TReentrantRWLock.cxx
+++ b/core/thread/src/TReentrantRWLock.cxx
@@ -36,6 +36,9 @@ thus preventing starvation.
 #include "TMutex.h"
 #include "TError.h"
 #include <assert.h>
+#if __cplusplus >= 201402L
+#include <shared_mutex>
+#endif
 
 using namespace ROOT;
 
@@ -413,4 +416,11 @@ template class TReentrantRWLock<std::mutex, ROOT::Internal::RecurseCounts>;
 template class TReentrantRWLock<ROOT::TSpinMutex, ROOT::Internal::UniqueLockRecurseCount>;
 template class TReentrantRWLock<TMutex, ROOT::Internal::UniqueLockRecurseCount>;
 template class TReentrantRWLock<std::mutex, ROOT::Internal::UniqueLockRecurseCount>;
+
+#if __cplusplus >= 201402L
+template class TReentrantRWLock<std::shared_timed_mutex, ROOT::Internal::RecurseCountsShared>;
+#endif
+#if __cplusplus >= 201703L
+template class TReentrantRWLock<std::shared_mutex, ROOT::Internal::RecurseCountsShared>;
+#endif
 }

--- a/core/thread/test/testRWLock.cxx
+++ b/core/thread/test/testRWLock.cxx
@@ -586,7 +586,7 @@ TEST(RWLock, concurrentResetRestoreSpin)
 
 TEST(RWLock, concurrentResetRestoreStd)
 {
-   concurrentResetRestore(gRWMutexSpin, 2, gRepetition / 10000);
+   concurrentResetRestore(gRWMutexStd, 2, gRepetition / 10000);
 }
 
 TEST(RWLock, LargeconcurrentResetRestore)

--- a/core/thread/test/testRWLock.cxx
+++ b/core/thread/test/testRWLock.cxx
@@ -719,6 +719,35 @@ TEST(RWLock, VeryLargeconcurrentReadsAndWritesSpin)
    concurrentReadsAndWrites(gRWMutexSpin,10,200,gRepetition / 100000);
 }
 
+TEST(RWLock, VeryLargeconcurrentReads)
+{
+   concurrentReadsAndWrites(gRWMutex, 0, 200, gRepetition / 10000);
+}
+
+TEST(RWLock, VeryLargeconcurrentReadsStd)
+{
+   concurrentReadsAndWrites(gRWMutexStd, 0, 200, gRepetition / 10000);
+}
+
+#if __cplusplus >= 201402L
+TEST(RWLock, VeryLargeconcurrentReadsStd14)
+{
+   concurrentReadsAndWrites(gRWMutexStd14, 0, 200, gRepetition / 10000);
+}
+#endif
+
+#if __cplusplus >= 201703L
+TEST(RWLock, VeryLargeconcurrentReadsStd17)
+{
+   concurrentReadsAndWrites(gRWMutexStd17, 0, 200, gRepetition / 10000);
+}
+#endif
+
+TEST(RWLock, VeryLargeconcurrentReadsSpin)
+{
+   concurrentReadsAndWrites(gRWMutexSpin,0,200,gRepetition / 100000);
+}
+
 TEST(RWLock, concurrentReadsAndWritesTL)
 {
    concurrentReadsAndWrites(gRWMutexTL, 1, 2, gRepetition / 10000);
@@ -732,4 +761,9 @@ TEST(RWLock, LargeconcurrentReadsAndWritesTL)
 TEST(RWLock, VeryLargeconcurrentReadsAndWritesTL)
 {
    concurrentReadsAndWrites(gRWMutexTL, 10, 200, gRepetition / 10000);
+}
+
+TEST(RWLock, VeryLargeconcurrentReadsTL)
+{
+   concurrentReadsAndWrites(gRWMutexTL, 0, 200, gRepetition / 10000);
 }

--- a/core/thread/test/testRWLock.cxx
+++ b/core/thread/test/testRWLock.cxx
@@ -254,6 +254,12 @@ auto gMutex = new TMutex(kTRUE);
 auto gRWMutex = new TRWMutexImp<TMutex>();
 auto gRWMutexSpin = new TRWMutexImp<ROOT::TSpinMutex>();
 auto gRWMutexStd = new TRWMutexImp<std::mutex>();
+#if __cplusplus >= 201402L
+auto gRWMutexStd14 = new TRWMutexImp<std::shared_timed_mutex, ROOT::Internal::RecurseCountsShared>();
+#endif
+#if __cplusplus >= 201703L
+auto gRWMutexStd17 = new TRWMutexImp<std::shared_mutex, ROOT::Internal::RecurseCountsShared>();
+#endif
 auto gReentrantRWMutex = new ROOT::TReentrantRWLock<TMutex>();
 auto gReentrantRWMutexSM = new ROOT::TReentrantRWLock<ROOT::TSpinMutex>();
 auto gReentrantRWMutexStd = new ROOT::TReentrantRWLock<std::mutex>();
@@ -589,6 +595,20 @@ TEST(RWLock, concurrentResetRestoreStd)
    concurrentResetRestore(gRWMutexStd, 2, gRepetition / 10000);
 }
 
+#if __cplusplus >= 201402L
+TEST(RWLock, concurrentResetRestoreStd14)
+{
+   concurrentResetRestore(gRWMutexStd14, 2, gRepetition / 10000);
+}
+#endif
+
+#if __cplusplus >= 201703L
+TEST(RWLock, concurrentResetRestoreStd17)
+{
+   concurrentResetRestore(gRWMutexStd17, 2, gRepetition / 10000);
+}
+#endif
+
 TEST(RWLock, LargeconcurrentResetRestore)
 {
    concurrentResetRestore(gRWMutex, 20, gRepetition / 40000);
@@ -627,6 +647,20 @@ TEST(RWLock, concurrentReadsAndWritesStd)
    concurrentReadsAndWrites(gRWMutexStd, 1, 2, gRepetition / 10000);
 }
 
+#if __cplusplus >= 201402L
+TEST(RWLock, concurrentReadsAndWritesStd14)
+{
+   concurrentReadsAndWrites(gRWMutexStd14, 1, 2, gRepetition / 10000);
+}
+#endif
+
+#if __cplusplus >= 201703L
+TEST(RWLock, concurrentReadsAndWritesStd17)
+{
+   concurrentReadsAndWrites(gRWMutexStd17, 1, 2, gRepetition / 10000);
+}
+#endif
+
 TEST(RWLock, LargeconcurrentReadsAndWrites)
 {
    concurrentReadsAndWrites(gRWMutex, 10, 20, gRepetition / 10000);
@@ -634,12 +668,55 @@ TEST(RWLock, LargeconcurrentReadsAndWrites)
 
 TEST(RWLock, LargeconcurrentReadsAndWritesStd)
 {
-   concurrentReadsAndWrites(gRWMutex, 10, 20, gRepetition / 10000);
+   concurrentReadsAndWrites(gRWMutexStd, 10, 20, gRepetition / 10000);
 }
+
+#if __cplusplus >= 201402L
+TEST(RWLock, LargeconcurrentReadsAndWritesStd14)
+{
+   concurrentReadsAndWrites(gRWMutexStd14, 10, 20, gRepetition / 10000);
+}
+#endif
+
+#if __cplusplus >= 201703L
+TEST(RWLock, LargeconcurrentReadsAndWritesStd17)
+{
+   concurrentReadsAndWrites(gRWMutexStd17, 10, 20, gRepetition / 10000);
+}
+#endif
 
 TEST(RWLock, LargeconcurrentReadsAndWritesSpin)
 {
    concurrentReadsAndWrites(gRWMutexSpin,10,20,gRepetition / 100000);
+}
+
+TEST(RWLock, VeryLargeconcurrentReadsAndWrites)
+{
+   concurrentReadsAndWrites(gRWMutex, 10, 200, gRepetition / 10000);
+}
+
+TEST(RWLock, VeryLargeconcurrentReadsAndWritesStd)
+{
+   concurrentReadsAndWrites(gRWMutexStd, 10, 200, gRepetition / 10000);
+}
+
+#if __cplusplus >= 201402L
+TEST(RWLock, VeryLargeconcurrentReadsAndWritesStd14)
+{
+   concurrentReadsAndWrites(gRWMutexStd14, 10, 200, gRepetition / 10000);
+}
+#endif
+
+#if __cplusplus >= 201703L
+TEST(RWLock, VeryLargeconcurrentReadsAndWritesStd17)
+{
+   concurrentReadsAndWrites(gRWMutexStd17, 10, 200, gRepetition / 10000);
+}
+#endif
+
+TEST(RWLock, VeryLargeconcurrentReadsAndWritesSpin)
+{
+   concurrentReadsAndWrites(gRWMutexSpin,10,200,gRepetition / 100000);
 }
 
 TEST(RWLock, concurrentReadsAndWritesTL)
@@ -650,4 +727,9 @@ TEST(RWLock, concurrentReadsAndWritesTL)
 TEST(RWLock, LargeconcurrentReadsAndWritesTL)
 {
    concurrentReadsAndWrites(gRWMutexTL, 10, 20, gRepetition / 10000);
+}
+
+TEST(RWLock, VeryLargeconcurrentReadsAndWritesTL)
+{
+   concurrentReadsAndWrites(gRWMutexTL, 10, 200, gRepetition / 10000);
 }

--- a/core/thread/test/testRWLock.cxx
+++ b/core/thread/test/testRWLock.cxx
@@ -13,6 +13,9 @@
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#if __cplusplus >= 201402L
+#include <shared_mutex>
+#endif
 
 using namespace ROOT;
 
@@ -254,6 +257,12 @@ auto gRWMutexStd = new TRWMutexImp<std::mutex>();
 auto gReentrantRWMutex = new ROOT::TReentrantRWLock<TMutex>();
 auto gReentrantRWMutexSM = new ROOT::TReentrantRWLock<ROOT::TSpinMutex>();
 auto gReentrantRWMutexStd = new ROOT::TReentrantRWLock<std::mutex>();
+#if __cplusplus >= 201402L
+auto gReentrantRWMutexStd14 = new ROOT::TReentrantRWLock<std::shared_timed_mutex, ROOT::Internal::RecurseCountsShared>();
+#endif
+#if __cplusplus >= 201703L
+auto gReentrantRWMutexStd17 = new ROOT::TReentrantRWLock<std::shared_mutex, ROOT::Internal::RecurseCountsShared>();
+#endif
 auto gSpinMutex = new ROOT::TSpinMutex();
 
 // Intentionally ignore the Fatal error due to the shread thread-local storage.
@@ -328,6 +337,30 @@ TEST(RWLock, WriteStdDirectUnLock)
    testWriteUnLock(gReentrantRWMutexStd, gRepetition, gWriteHint);
 }
 
+#if __cplusplus >= 201402L
+TEST(RWLock, WriteStdD14irectLock)
+{
+   gWriteHint = testWriteLock(gReentrantRWMutexStd14, gRepetition);
+}
+
+TEST(RWLock, WriteStd14DirectUnLock)
+{
+   testWriteUnLock(gReentrantRWMutexStd14, gRepetition, gWriteHint);
+}
+#endif
+
+#if __cplusplus >= 201703L
+TEST(RWLock, WriteStd17DirectLock)
+{
+   gWriteHint = testWriteLock(gReentrantRWMutexStd17, gRepetition);
+}
+
+TEST(RWLock, WriteStd17DirectUnLock)
+{
+   testWriteUnLock(gReentrantRWMutexStd17, gRepetition, gWriteHint);
+}
+#endif
+
 TEST(RWLock, WriteSpinDirectLock)
 {
    gWriteHint = testWriteLock(gReentrantRWMutexSM, gRepetition);
@@ -357,6 +390,30 @@ TEST(RWLock, ReadUnLockStdDirect)
 {
    testReadUnLock(gReentrantRWMutexStd, gRepetition, gReadHint);
 }
+
+#if __cplusplus >= 201402L
+TEST(RWLock, ReadLockStd14Direct)
+{
+   gReadHint = testReadLock(gReentrantRWMutexStd14, gRepetition);
+}
+
+TEST(RWLock, ReadUnLockStd14Direct)
+{
+   testReadUnLock(gReentrantRWMutexStd14, gRepetition, gReadHint);
+}
+#endif
+
+#if __cplusplus >= 201703L
+TEST(RWLock, ReadLockStd17Direct)
+{
+   gReadHint = testReadLock(gReentrantRWMutexStd17, gRepetition);
+}
+
+TEST(RWLock, ReadUnLockStd17Direct)
+{
+   testReadUnLock(gReentrantRWMutexStd17, gRepetition, gReadHint);
+}
+#endif
 
 TEST(RWLock, ReadLockSpinDirect)
 {
@@ -443,6 +500,20 @@ TEST(RWLock, ReentrantStd)
    Reentrant(*gReentrantRWMutexStd);
 }
 
+#if __cplusplus >= 201402L
+TEST(RWLock, ReentrantStd14)
+{
+   Reentrant(*gReentrantRWMutexStd14);
+}
+#endif
+
+#if __cplusplus >= 201703L
+TEST(RWLock, ReentrantStd17)
+{
+   Reentrant(*gReentrantRWMutexStd17);
+}
+#endif
+
 TEST(RWLock, ReentrantSpin)
 {
    Reentrant(*gReentrantRWMutexSM);
@@ -467,6 +538,20 @@ TEST(RWLock, ResetRestoreStd)
 {
    ResetRestore(*gReentrantRWMutexStd);
 }
+
+#if __cplusplus >= 201402L
+TEST(RWLock, ResetRestoreStd14)
+{
+   ResetRestore(*gReentrantRWMutexStd14);
+}
+#endif
+
+#if __cplusplus >= 201703L
+TEST(RWLock, ResetRestoreStd17)
+{
+   ResetRestore(*gReentrantRWMutexStd17);
+}
+#endif
 
 TEST(RWLock, ResetRestoreSpin)
 {


### PR DESCRIPTION
Further reduction in lock contention when using RDataFrame with a large number of threads and/or files, by improving the global read write lock and migrating one hot spot in TBufferFile to use it.