### PR TITLE
[webgui] Better control over data transfer, latest JSROOT

### DIFF
--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -59,10 +59,12 @@ protected:
       const char *ui5theme = gEnv->GetValue("WebGui.openui5theme","");
       if (ui5theme && *ui5theme)
          more_args.append("openui5theme: \""s + ui5theme + "\","s);
+      int credits = gEnv->GetValue("WebGui.ConnCredits", 10);
+      if ((credits > 0) && (credits != 10))
+         more_args.append("credits: "s + std::to_string(credits) + ","s);
       auto user_args = fWindow.GetUserArgs();
       if (!user_args.empty())
-         more_args = "user_args: "s + user_args + ","s;
-
+         more_args.append("user_args: "s + user_args + ","s);
       if (!more_args.empty()) {
          std::string search = "JSROOT.connectWebWindow({"s;
          std::string replace = search + more_args;

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -368,6 +368,7 @@ std::string ROOT::Experimental::RWebWindowsManager::GetUrl(const ROOT::Experimen
 ///   WebGui.JsonComp: compression factor for JSON conversion, if not specified - each widget uses own default values
 ///   WebGui.ForceHttp: 0 - off (default), 1 - always create real http server to run web window
 ///   WebGui.Console: -1 - output only console.error(), 0 - add console.warn(), 1  - add console.log() output
+///   WebGui.ConnCredits: 10 - number of packets which can be send by server or client without acknowledge from receiving side
 ///   WebGui.openui5src:   alternative location for openui5 like https://openui5.hana.ondemand.com/
 ///   WebGui.openui5libs:  list of pre-loaded ui5 libs like sap.m, sap.ui.layout, sap.ui.unified
 ///   WebGui.openui5theme:  openui5 theme like sap_belize (default) or sap_fiori_3

--- a/js/scripts/JSRoot.base3d.js
+++ b/js/scripts/JSRoot.base3d.js
@@ -1345,7 +1345,8 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
       let line = this.GetObject(),
           main = this.frame_painter();
 
-      if (!main || !main.mode3d || !main.toplevel || !line) return;
+      if (!main || !main.mode3d || !main.toplevel || !line)
+         return null;
 
       let fN, fP, pnts = [];
 
@@ -1367,6 +1368,8 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
       let lines = jsrp.createLineSegments(pnts, create3DLineMaterial(this, line));
 
       main.toplevel.add(lines);
+
+      return true;
    }
 
    // ==============================================================================================

--- a/js/scripts/JSRoot.geobase.js
+++ b/js/scripts/JSRoot.geobase.js
@@ -2110,7 +2110,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
          source = createProjectionMatrix(source);
 
       let frustum = new THREE.Frustum();
-      frustum.setFromMatrix(source);
+      frustum.setFromProjectionMatrix(source);
 
       frustum.corners = new Float32Array([
           1,  1,  1,

--- a/js/scripts/JSRoot.geom.js
+++ b/js/scripts/JSRoot.geom.js
@@ -206,11 +206,12 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
             evnt.preventDefault();
             evnt.stopPropagation();
 
-            if (!jsrp.closeMenu())
-               jsrp.createMenu(this, evnt).then(menu => {
-                  menu.painter.FillContextMenu(menu);
-                  menu.show();
-               });
+            if (jsrp.closeMenu && jsrp.closeMenu()) return;
+
+            jsrp.createMenu(this, evnt).then(menu => {
+                menu.painter.FillContextMenu(menu);
+                menu.show();
+            });
          }
       });
 
@@ -547,13 +548,15 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
       return res;
    }
 
-   TGeoPainter.prototype.ActivateInBrowser = function(names, force) {
+   /** @summary Activate specified items in the browser */
+   TGeoPainter.prototype.activateInBrowser = function(names, force) {
       // if (this.GetItemName() === null) return;
 
       if (typeof names == 'string') names = [ names ];
 
       if (this._hpainter) {
          // show browser if it not visible
+
          this._hpainter.activateItems(names, force);
 
          // if highlight in the browser disabled, suppress in few seconds
@@ -620,42 +623,33 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
    TGeoPainter.prototype.FillContextMenu = function(menu) {
       menu.add("header: Draw options");
 
-      menu.addchk(this.ctrl.update_browser, "Browser update", function() {
+      menu.addchk(this.ctrl.update_browser, "Browser update", () => {
          this.ctrl.update_browser = !this.ctrl.update_browser;
-         if (!this.ctrl.update_browser) this.ActivateInBrowser([]);
+         if (!this.ctrl.update_browser) this.activateInBrowser([]);
       });
-      menu.addchk(this.ctrl.show_controls, "Show Controls", function() {
-         this.showControlOptions('toggle');
-      });
-      menu.addchk(this.ctrl._axis, "Show axes", function() {
-         this.setAxesDraw('toggle');
-      });
-      if (this.geo_manager)
-         menu.addchk(this.ctrl.showtop, "Show top volume", function() {
-            this.setShowTop(!this.ctrl.showtop);
-         });
+      menu.addchk(this.ctrl.show_controls, "Show Controls", () => this.showControlOptions('toggle'));
 
-      menu.addchk(this.ctrl.wireframe, "Wire frame", function() {
-         this.toggleWireFrame();
-      });
-      menu.addchk(this.ctrl.highlight, "Highlight volumes", function() {
+      menu.addchk(this.ctrl._axis, "Show axes", () => this.setAxesDraw('toggle'));
+
+      if (this.geo_manager)
+         menu.addchk(this.ctrl.showtop, "Show top volume", () => this.setShowTop(!this.ctrl.showtop));
+
+      menu.addchk(this.ctrl.wireframe, "Wire frame", () => this.toggleWireFrame());
+
+      menu.addchk(this.ctrl.highlight, "Highlight volumes", () => {
          this.ctrl.highlight = !this.ctrl.highlight;
       });
-      menu.addchk(this.ctrl.highlight_scene, "Highlight scene", function() {
+      menu.addchk(this.ctrl.highlight_scene, "Highlight scene", () => {
          this.ctrl.highlight_scene = !this.ctrl.highlight_scene;
       });
-      menu.add("Reset camera position", function() {
-         this.focusCamera();
-      });
+      menu.add("Reset camera position", () => this.focusCamera());
+
       if (!this._geom_viewer)
-         menu.add("Get camera position", function() {
-            alert("Position (as url): &opt=" + this.produceCameraUrl());
-         });
+         menu.add("Get camera position", () => alert("Position (as url): &opt=" + this.produceCameraUrl()));
+
       if (!this.ctrl.project)
-         menu.addchk(this.ctrl.rotate, "Autorotate", function() {
-            this.setAutoRotate(!this.ctrl.rotate);
-         });
-      menu.addchk(this.ctrl.select_in_view, "Select in view", function() {
+         menu.addchk(this.ctrl.rotate, "Autorotate", () => this.setAutoRotate(!this.ctrl.rotate));
+      menu.addchk(this.ctrl.select_in_view, "Select in view", () => {
          this.ctrl.select_in_view = !this.ctrl.select_in_view;
          if (this.ctrl.select_in_view) this.startDrawGeometry();
       });
@@ -1013,9 +1007,9 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
                } else
                   continue;
 
-               menu.add((many ? "sub:" : "header:") + hdr, itemname, function(arg) { this.ActivateInBrowser([arg], true); });
+               menu.add((many ? "sub:" : "header:") + hdr, itemname, arg => this.activateInBrowser([arg], true));
 
-               menu.add("Browse", itemname, function(arg) { this.ActivateInBrowser([arg], true); });
+               menu.add("Browse", itemname, arg => this.activateInBrowser([arg], true));
 
                if (this._hpainter)
                   menu.add("Inspect", itemname, function(arg) { this._hpainter.display(arg, "inspect"); });
@@ -1342,7 +1336,7 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
 
          if (painter.ctrl.update_browser) {
             if (painter.ctrl.highlight && tooltip) names = [ tooltip ];
-            painter.ActivateInBrowser(names);
+            painter.activateInBrowser(names);
          }
 
          if (!resolve || !resolve.obj) return tooltip;
@@ -3185,7 +3179,6 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
      * @desc Timeout used to avoid multiple rendering of the picture when several 3D drawings
      * superimposed with each other. If tmeout<=0, rendering performed immediately
      * Several special values are used:
-     *   -2222 - rendering performed only if there were previous calls, which causes timeout activation
      *   -1    - force recheck of rendering order based on camera position */
    TGeoPainter.prototype.Render3D = function(tmout, measure) {
 
@@ -3205,8 +3198,7 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
 
       if (this.render_tmout) {
          clearTimeout(this.render_tmout);
-      } else {
-         if (tmout === -2222) return; // special case to check if rendering timeout was active
+         delete this.render_tmout;
       }
 
       jsrp.beforeRender3D(this._renderer);
@@ -3226,8 +3218,6 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
       let tm2 = new Date();
 
       this.last_render_tm = tm2.getTime();
-
-      delete this.render_tmout;
 
       if ((this.first_render_tm === 0) && measure) {
          this.first_render_tm = tm2.getTime() - tm1.getTime();
@@ -4048,7 +4038,9 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
       // if (obj && obj._typename=='TGeoManager' && (obj.fNsegments > 3))
       //   geo.GradPerSegm = 360/obj.fNsegments;
 
-      painter.SetDivId(divid, 5);
+      painter.SetDivId(divid, -1);
+      painter.setAsMainPainter();
+      painter.addToPadPrimitives(); // will add to pad primitives if any
 
       painter.options = painter.decodeOptions(opt); // indicator of initialization
 

--- a/js/scripts/JSRoot.hierarchy.js
+++ b/js/scripts/JSRoot.hierarchy.js
@@ -670,7 +670,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       this.main().select(".jsroot_browser").select(".jsroot_browser_btns").remove();
    }
 
-   BrowserLayout.prototype.SetBrowserContent = function(guiCode) {
+   BrowserLayout.prototype.setBrowserContent = function(guiCode) {
       let main = d3.select("#" + this.gui_div + " .jsroot_browser");
       if (main.empty()) return;
 
@@ -1313,7 +1313,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
          if (!res.obj) return null;
 
-         let main_painter = JSROOT.get_main_painter(divid);
+         let main_painter = JSROOT.getMainPainter(divid);
 
          if (main_painter && (typeof main_painter.performDrop === 'function'))
             return main_painter.performDrop(res.obj, itemname, res.item, opt).then(p => drop_complete(p));
@@ -1565,7 +1565,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       if (typeof items == 'string') items = [ items ];
 
-      let active = [],  // array of elements to activate
+      let active = [], // array of elements to activate
           update = []; // array of elements to update
       this.forEachItem(item => { if (item._background) { active.push(item); delete item._background; } });
 
@@ -1633,7 +1633,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       if (force && this.brlayout) {
          if (!this.brlayout.browser_kind)
-           return this.createBrowser('float', true).then(find_next);
+           return this.createBrowser('float', true).then(() => find_next());
          if (!this.brlayout.browser_visible)
             this.brlayout.ToggleBrowserVisisbility();
       }
@@ -1954,7 +1954,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       }
 
       if (!itemname && item && ('_cached_draw_object' in this) && (req.length == 0)) {
-         // special handling for drawGUI when cashed
+         // special handling for online draw when cashed
          let obj = this._cached_draw_object;
          delete this._cached_draw_object;
          return Promise.resolve(obj);
@@ -2424,7 +2424,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if (title) document.title = title;
 
       let load = GetOption("load");
-      if (load) prereq += ";io;gpad;";
 
       if (expanditems.length==0 && (GetOption("expand")==="")) expanditems.push("");
 
@@ -2608,7 +2607,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          this.h = createStreamerInfoContent(obj)
       else
          this.h = createInspectorContent(obj);
-      return this.refreshHtml().then(() => { this.SetDivId(this.divid); });
+      return this.refreshHtml().then(() => { this.setTopPainter(); });
    }
 
    // ======================================================================================
@@ -2625,16 +2624,16 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    /** @summary Build gui without visisble hierarchy browser
      * @desc avoid loading of jquery part
      * @private */
-   JSROOT.buildNobrowserGUI = function() {
-      let myDiv = d3.select('#simpleGUI'),
-          online = false, drawing = false;
+   JSROOT.buildNobrowserGUI = function(gui_element, gui_kind) {
 
-      if (myDiv.empty()) {
+      let myDiv = (typeof gui_element == 'string') ? d3.select('#' + gui_element) : d3.select(gui_element);
+      if (myDiv.empty()) return alert('no div for simple nobrowser gui found');
+
+      let online = false, drawing = false;
+      if (gui_kind == 'online')
          online = true;
-         myDiv = d3.select('#onlineGUI');
-         if (myDiv.empty()) { myDiv = d3.select('#drawGUI'); drawing = true; }
-         if (myDiv.empty()) return alert('no div for simple nobrowser gui found');
-      }
+      else if (gui_kind == 'draw')
+         online = drawing = true;
 
       if (myDiv.attr("ignoreurl") === "true")
          JSROOT.settings.IgnoreUrlOptions = true;
@@ -2687,7 +2686,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       // painter.select_main().style('overflow','auto');
 
       return painter.refreshHtml().then(() => {
-         painter.SetDivId(divid);
+         painter.setTopPainter();
          return painter;
       });
    }
@@ -2736,7 +2735,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       painter.h = createInspectorContent(obj);
 
       return painter.refreshHtml().then(() => {
-         painter.SetDivId(divid);
+         painter.setTopPainter();
          return painter;
       });
    }
@@ -2756,7 +2755,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          super();
          this.frameid = frameid;
          if (frameid != "$batch$") {
-            this.SetDivId(frameid);
+            this.SetDivId(frameid); // base painter
             this.select_main().property('mdi', this);
          }
          this.cleanupFrame = JSROOT.cleanup; // use standard cleanup function by default

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -1274,75 +1274,69 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
    }
 
    let drawPave = (divid, pave, opt) => {
-      // one could force drawing of PaveText on specific sub-pad
-      let onpad;
-      if ((typeof opt == 'string') && (opt.indexOf("onpad:")==0)) {
-         onpad = opt.substr(6);
-         opt = "";
-      }
-
       let painter = new JSROOT.TPavePainter(pave);
 
-      painter.SetDivId(divid, 2, onpad);
+      return jsrp.ensureTCanvas(painter, divid, false).then(() => {
 
-      if ((pave.fName === "title") && (pave._typename === "TPaveText")) {
-         let tpainter = painter.FindPainterFor(null, "title");
-         if (tpainter && (tpainter !== painter)) {
-            tpainter.DeleteThis();
-         } else if ((opt == "postitle") || painter.IsDummyPos(pave)) {
-            let st = JSROOT.gStyle, fp = painter.frame_painter();
-            if (st && fp) {
-               let midx = st.fTitleX, y2 = st.fTitleY, w = st.fTitleW, h = st.fTitleH;
-               if (!h && fp) h = (y2-fp.fY2NDC)*0.7;
-               if (!w && fp) w = fp.fX2NDC - fp.fX1NDC;
-               if (!h || isNaN(h) || (h<0)) h = 0.06;
-               if (!w || isNaN(w) || (w<0)) w = 0.44;
-               pave.fX1NDC = midx - w/2;
-               pave.fY1NDC = y2 - h;
-               pave.fX2NDC = midx + w/2;
-               pave.fY2NDC = y2;
-               pave.fInit = 1;
+         if ((pave.fName === "title") && (pave._typename === "TPaveText")) {
+            let tpainter = painter.FindPainterFor(null, "title");
+            if (tpainter && (tpainter !== painter)) {
+               tpainter.DeleteThis();
+            } else if ((opt == "postitle") || painter.IsDummyPos(pave)) {
+               let st = JSROOT.gStyle, fp = painter.frame_painter();
+               if (st && fp) {
+                  let midx = st.fTitleX, y2 = st.fTitleY, w = st.fTitleW, h = st.fTitleH;
+                  if (!h && fp) h = (y2-fp.fY2NDC)*0.7;
+                  if (!w && fp) w = fp.fX2NDC - fp.fX1NDC;
+                  if (!h || isNaN(h) || (h<0)) h = 0.06;
+                  if (!w || isNaN(w) || (w<0)) w = 0.44;
+                  pave.fX1NDC = midx - w/2;
+                  pave.fY1NDC = y2 - h;
+                  pave.fX2NDC = midx + w/2;
+                  pave.fY2NDC = y2;
+                  pave.fInit = 1;
+               }
             }
+         } else if (pave._typename === "TPaletteAxis") {
+            pave.fBorderSize = 1;
+            pave.fShadowColor = 0;
+
+            // check some default values of TGaxis object, otherwise axis will not be drawn
+            if (pave.fAxis) {
+               if (!pave.fAxis.fChopt) pave.fAxis.fChopt = "+";
+               if (!pave.fAxis.fNdiv) pave.fAxis.fNdiv = 12;
+               if (!pave.fAxis.fLabelOffset) pave.fAxis.fLabelOffset = 0.005;
+            }
+
+            painter.z_handle = new JSROOT.TAxisPainter(pave.fAxis, true);
+            painter.z_handle.SetDivId(divid, -1);
+
+            painter.UseContextMenu = true;
          }
-      } else if (pave._typename === "TPaletteAxis") {
-         pave.fBorderSize = 1;
-         pave.fShadowColor = 0;
 
-         // check some default values of TGaxis object, otherwise axis will not be drawn
-         if (pave.fAxis) {
-            if (!pave.fAxis.fChopt) pave.fAxis.fChopt = "+";
-            if (!pave.fAxis.fNdiv) pave.fAxis.fNdiv = 12;
-            if (!pave.fAxis.fLabelOffset) pave.fAxis.fLabelOffset = 0.005;
+         switch (pave._typename) {
+            case "TPaveLabel":
+               painter.PaveDrawFunc = painter.DrawPaveLabel;
+               break;
+            case "TPaveStats":
+               painter.PaveDrawFunc = painter.DrawPaveStats;
+               painter.$secondary = true; // indicates that painter created from others
+               break;
+            case "TPaveText":
+            case "TPavesText":
+            case "TDiamond":
+               painter.PaveDrawFunc = painter.DrawPaveText;
+               break;
+            case "TLegend":
+               painter.PaveDrawFunc = painter.DrawPaveLegend;
+               break;
+            case "TPaletteAxis":
+               painter.PaveDrawFunc = painter.DrawPaletteAxis;
+               break;
          }
 
-         painter.z_handle = new JSROOT.TAxisPainter(pave.fAxis, true);
-         painter.z_handle.SetDivId(divid, -1);
-
-         painter.UseContextMenu = true;
-      }
-
-      switch (pave._typename) {
-         case "TPaveLabel":
-            painter.PaveDrawFunc = painter.DrawPaveLabel;
-            break;
-         case "TPaveStats":
-            painter.PaveDrawFunc = painter.DrawPaveStats;
-            painter.$secondary = true; // indicates that painter created from others
-            break;
-         case "TPaveText":
-         case "TPavesText":
-         case "TDiamond":
-            painter.PaveDrawFunc = painter.DrawPaveText;
-            break;
-         case "TLegend":
-            painter.PaveDrawFunc = painter.DrawPaveLegend;
-            break;
-         case "TPaletteAxis":
-            painter.PaveDrawFunc = painter.DrawPaletteAxis;
-            break;
-      }
-
-      return painter.DrawPave(opt);
+         return painter.DrawPave(opt);
+      });
    }
 
    /** @summary Produce and draw TLegend object for the specified divid
@@ -1352,7 +1346,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
      * @memberof JSROOT.Painter
      * @private */
    let produceLegend = (divid, opt) => {
-      let main_painter = JSROOT.get_main_painter(divid);
+      let main_painter = JSROOT.getMainPainter(divid);
       if (!main_painter) return;
 
       let pp = main_painter.pad_painter(),
@@ -2265,7 +2259,6 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       fp.SetAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, 0, 0);
       fp.CreateXY({ ndim: this.Dimension(),
                     check_pad_range: this.check_pad_range,
-                    create_canvas: this.create_canvas,
                     zoom_ymin: this.zoom_ymin,
                     zoom_ymax: this.zoom_ymax,
                     ymin_nz: this.ymin_nz,
@@ -2397,7 +2390,10 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          return statpainter.Enabled;
       }
 
-      JSROOT.draw(this.divid, stat, "onpad:" + this.pad_name);
+      let prev_name = this.CurrentPadName(this.pad_name);
+      JSROOT.draw(this.divid, stat).then(() => {
+         this.CurrentPadName(prev_name);
+      });
 
       return true;
    }
@@ -4306,26 +4302,28 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       // create painter and add it to canvas
       let painter = new TH1Painter(histo);
 
-      if (!painter.SetDivId(divid, 1)) return null;
+      return jsrp.ensureTCanvas(painter, divid).then(() => {
+         // tend to be main painter - if first
+         painter.setAsMainPainter();
 
-      // here we deciding how histogram will look like and how will be shown
-      painter.DecodeOptions(opt);
+         // here we deciding how histogram will look like and how will be shown
+         painter.DecodeOptions(opt);
 
-      painter.CheckPadRange(!painter.options.Mode3D);
+         painter.CheckPadRange(!painter.options.Mode3D);
 
-      painter.ScanContent();
+         painter.ScanContent();
 
-      painter.CreateStat(); // only when required
+         painter.CreateStat(); // only when required
 
-      return painter.callDrawFunc()
-            .then(() => painter.drawNextFunction(0))
-            .then(() => {
-               if (!painter.options.Mode3D && painter.options.AutoZoom)
-                  painter.AutoZoom();
-               painter.FillToolbar();
-               painter.DrawingReady();
-               return painter;
-            });
+         return painter.callDrawFunc();
+      }).then(() => painter.drawNextFunction(0)).then(() => {
+
+          if (!painter.options.Mode3D && painter.options.AutoZoom)
+             painter.AutoZoom();
+          painter.FillToolbar();
+
+          return painter;
+      });
    }
 
    // ========================================================================
@@ -6331,37 +6329,42 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       // create painter and add it to canvas
       let painter = new JSROOT.TH2Painter(histo);
 
-      if (!painter.SetDivId(divid, 1)) return null;
+      return jsrp.ensureTCanvas(painter, divid).then(() => {
 
-      // here we deciding how histogram will look like and how will be shown
-      painter.DecodeOptions(opt);
+         painter.setAsMainPainter();
 
-      if (painter.IsTH2Poly()) {
-         if (painter.options.Mode3D)
-            painter.options.Lego = 12; // lego always 12
-         else if (!painter.options.Color)
-            painter.options.Color = true; // default is color
-      }
+         // here we deciding how histogram will look like and how will be shown
+         painter.DecodeOptions(opt);
 
-      painter._show_empty_bins = false;
+         if (painter.IsTH2Poly()) {
+            if (painter.options.Mode3D)
+               painter.options.Lego = 12; // lego always 12
+            else if (!painter.options.Color)
+               painter.options.Color = true; // default is color
+         }
 
-      painter._can_move_colz = true;
+         painter._show_empty_bins = false;
 
-      // special case for root 3D drawings - pad range is wired
-      painter.CheckPadRange(!painter.options.Mode3D && (painter.options.Contour != 14));
+         painter._can_move_colz = true;
 
-      painter.ScanContent();
+         // special case for root 3D drawings - pad range is wired
+         painter.CheckPadRange(!painter.options.Mode3D && (painter.options.Contour != 14));
 
-      painter.CreateStat(); // only when required
+         painter.ScanContent();
 
-      return painter.callDrawFunc()
-                    .then(() => painter.drawNextFunction(0))
-                    .then(()=> {
-         if (!painter.Mode3D && painter.options.AutoZoom) painter.AutoZoom();
-            painter.FillToolbar();
+         painter.CreateStat(); // only when required
+
+         return painter.callDrawFunc();
+
+      }).then(() => painter.drawNextFunction(0)).then(()=> {
+
+         if (!painter.Mode3D && painter.options.AutoZoom)
+            painter.AutoZoom();
+
+         painter.FillToolbar();
          if (painter.options.Project && !painter.mode3d)
               painter.ToggleProjection(painter.options.Project);
-          painter.DrawingReady();
+
           return painter;
       });
    }
@@ -6797,15 +6800,15 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          return null; // drawing not needed
 
       let painter = new THStackPainter(stack, opt);
-      painter.SetDivId(divid, 2); // in list of primitives, but not main painter
-      painter.DecodeOptions(opt);
 
-     if (!painter.options.nostack)
-          painter.options.nostack = ! painter.BuildStack(stack);
+      return jsrp.ensureTCanvas(painter, divid, false).then(() => {
 
-      let promise = Promise.resolve(painter);
+         painter.DecodeOptions(opt);
 
-      if (!painter.options.same) {
+         if (!painter.options.nostack)
+             painter.options.nostack = ! painter.BuildStack(stack);
+
+         if (painter.options.same) return;
 
          if (!stack.fHistogram)
              stack.fHistogram = painter.CreateHistogram(stack);
@@ -6816,13 +6819,10 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          // if (mm && (!this.options.nostack || (hist.fMinimum==-1111 && hist.fMaximum==-1111))) hopt += ";minimum:" + mm.min + ";maximum:" + mm.max;
          if (mm) hopt += ";minimum:" + mm.min + ";maximum:" + mm.max;
 
-         promise = JSROOT.draw(divid, stack.fHistogram, hopt).then(subp => {
-             painter.firstpainter = subp;
-             return painter;
+         return JSROOT.draw(divid, stack.fHistogram, hopt).then(subp => {
+            painter.firstpainter = subp;
          });
-      }
-
-      return promise.then(() => painter.drawNextHisto(0));
+      }).then(() => painter.drawNextHisto(0));
    }
 
    // =================================================================================

--- a/js/scripts/JSRoot.interactive.js
+++ b/js/scripts/JSRoot.interactive.js
@@ -429,7 +429,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             .on("start", function(evnt) {
                if (detectRightButton(evnt.sourceEvent)) return;
 
-               jsrp.closeMenu(); // close menu
+               if (jsrp.closeMenu) jsrp.closeMenu(); // close menu
 
                pthis.SwitchTooltip(false); // disable tooltip
 
@@ -1355,7 +1355,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       },
 
       clearInteractiveElements: function() {
-         jsrp.closeMenu();
+         if (jsrp.closeMenu) jsrp.closeMenu();
          this.zoom_kind = 0;
          if (this.zoom_rect) { this.zoom_rect.remove(); delete this.zoom_rect; }
          delete this.zoom_curr;

--- a/js/scripts/JSRoot.jq2d.js
+++ b/js/scripts/JSRoot.jq2d.js
@@ -9,510 +9,17 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
 
    if (typeof jQuery === 'undefined') globalThis.jQuery = $;
 
-  /** @summary Produce exec string for WebCanas to set color value
-    * @desc Color can be id or string, but should belong to list of known colors
-    * For higher color numbers TColor::GetColor(r,g,b) will be invoked to ensure color is exists
-    * @private */
-   function getColorExec(col, method) {
-      let id = -1, arr = jsrp.root_colors;
-      if (typeof col == "string") {
-         if (!col || (col == "none")) id = 0; else
-            for (let k = 1; k < arr.length; ++k)
-               if (arr[k] == col) { id = k; break; }
-         if ((id < 0) && (col.indexOf("rgb") == 0)) id = 9999;
-      } else if (!isNaN(col) && arr[col]) {
-         id = col;
-         col = arr[id];
-      }
-
-      if (id < 0) return "";
-
-      if (id >= 50) {
-         // for higher color numbers ensure that such color exists
-         let c = d3.color(col);
-         id = "TColor::GetColor(" + c.r + "," + c.g + "," + c.b + ")";
-      }
-
-      return "exec:" + method + "(" + id + ")";
-   }
-
-   /**
-    * @summary Class for creating context menu
-    *
-    * @class
-    * @memberof JSROOT
-    * @private
-    * @desc Use {@link JSROOT.Painter.createMenu} to create instance of the menu
-    */
-
-   class JQueryMenu {
-      constructor(painter, menuname, show_event) {
-         this.painter = painter;
-         this.menuname = menuname;
-         this.element = null;
-         this.code = "";
-         this.cnt = 1;
-         this.funcs = {};
-         this.separ = false;
-         if (show_event && (typeof show_event == "object"))
-            if ((show_event.clientX !== undefined) && (show_event.clientY !== undefined))
-               this.show_evnt = { clientX: show_event.clientX, clientY: show_event.clientY };
-
-         this.remove_bind = this.remove.bind(this);
-      }
-
-      add(name, arg, func, title) {
-         if (name == "separator") { this.code += "<li>-</li>"; this.separ = true; return; }
-
-         if (name.indexOf("header:")==0) {
-            this.code += "<li class='ui-widget-header' style='padding:3px; padding-left:5px;'>"+name.substr(7)+"</li>";
-            return;
-         }
-
-         if (name=="endsub:") { this.code += "</ul></li>"; return; }
-
-         let item = "", close_tag = "</li>";
-         title = title ? " title='" + title + "'" : "";
-         if (name.indexOf("sub:")==0) { name = name.substr(4); close_tag = "<ul>"; }
-
-         if (typeof arg == 'function') { func = arg; arg = name; }
-
-         if (name.indexOf("chk:")==0) { item = "<span class='ui-icon ui-icon-check' style='margin:1px'></span>"; name = name.substr(4); } else
-         if (name.indexOf("unk:")==0) { item = "<span class='ui-icon ui-icon-blank' style='margin:1px'></span>"; name = name.substr(4); }
-
-         // special handling of first versions with menu support
-         if (($.ui.version.indexOf("1.10")==0) || ($.ui.version.indexOf("1.9")==0))
-            item = '<a href="#">' + item + name + '</a>';
-         else if ($.ui.version.indexOf("1.11")==0)
-            item += name;
-         else
-            item = "<div" + title + ">" + item + name + "</div>";
-
-         this.code += "<li cnt='" + this.cnt + ((arg !== undefined) ? "' arg='" + arg : "") + "'>" + item + close_tag;
-         if (typeof func == 'function') this.funcs[this.cnt] = func; // keep call-back function
-
-         this.cnt++;
-      }
-
-      addchk(flag, name, arg, func) {
-         let handler = func;
-         if (typeof arg == 'function') {
-            func = arg;
-            handler = res => func(arg=="1");
-            arg = flag ? "0" : "1";
-         }
-         return this.add((flag ? "chk:" : "unk:") + name, arg, handler);
-      }
-
-      size() { return this.cnt-1; }
-
-      addDrawMenu(top_name, opts, call_back) {
-         if (!opts) opts = [];
-         if (opts.length==0) opts.push("");
-
-         let without_sub = false;
-         if (top_name.indexOf("nosub:")==0) {
-            without_sub = true;
-            top_name = top_name.substr(6);
-         }
-
-         if (opts.length === 1) {
-            if (opts[0]==='inspect') top_name = top_name.replace("Draw", "Inspect");
-            return this.add(top_name, opts[0], call_back);
-         }
-
-         if (!without_sub) this.add("sub:" + top_name, opts[0], call_back);
-
-         for (let i=0;i<opts.length;++i) {
-            let name = opts[i];
-            if (name=="") name = '&lt;dflt&gt;';
-
-            let group = i+1;
-            if ((opts.length>5) && (name.length>0)) {
-               // check if there are similar options, which can be grouped once again
-               while ((group<opts.length) && (opts[group].indexOf(name)==0)) group++;
-            }
-
-            if (without_sub) name = top_name + " " + name;
-
-            if (group < i+2) {
-               this.add(name, opts[i], call_back);
-            } else {
-               this.add("sub:" + name, opts[i], call_back);
-               for (let k=i+1;k<group;++k)
-                  this.add(opts[k], opts[k], call_back);
-               this.add("endsub:");
-               i = group-1;
-            }
-         }
-         if (!without_sub) this.add("endsub:");
-      }
-
-      /** @summary Add color selection menu entries  */
-      AddColorMenu(name, value, set_func, fill_kind) {
-         if (value === undefined) return;
-         this.add("sub:" + name, function() {
-            // todo - use jqury dialog here
-            let useid = (typeof value !== 'string');
-            let col = prompt("Enter color " + (useid ? "(only id number)" : "(name or id)"), value);
-            if (col === null) return;
-            let id = parseInt(col);
-            if (!isNaN(id) && jsrp.getColor(id)) {
-               col = jsrp.getColor(id);
-            } else {
-               if (useid) return;
-            }
-            set_func(useid ? id : col);
-         });
-         let useid = (typeof value !== 'string');
-         for (let n = -1; n < 11; ++n) {
-            if ((n < 0) && useid) continue;
-            if ((n == 10) && (fill_kind !== 1)) continue;
-            let col = (n < 0) ? 'none' : jsrp.getColor(n);
-            if ((n == 0) && (fill_kind == 1)) col = 'none';
-            let svg = "<svg width='100' height='18' style='margin:0px;background-color:" + col + "'><text x='4' y='12' style='font-size:12px' fill='" + (n == 1 ? "white" : "black") + "'>" + col + "</text></svg>";
-            this.addchk((value == (useid ? n : col)), svg, (useid ? n : col), res => set_func(useid ? parseInt(res) : res));
-         }
-         this.add("endsub:");
-      }
-
-      /** @summary Add size selection menu entries */
-      SizeMenu(name, min, max, step, value, set_func) {
-         if (value === undefined) return;
-
-         this.add("sub:" + name, function() {
-            // todo - use jqury dialog here
-            let entry = value.toFixed(4);
-            if (step >= 0.1) entry = value.toFixed(2);
-            if (step >= 1) entry = value.toFixed(0);
-            let val = prompt("Enter value of " + name, entry);
-            if (!val) return;
-            val = parseFloat(val);
-            if (!isNaN(val)) set_func((step >= 1) ? Math.round(val) : val);
-         });
-         for (let val = min; val <= max; val += step) {
-            let entry = val.toFixed(2);
-            if (step >= 0.1) entry = val.toFixed(1);
-            if (step >= 1) entry = val.toFixed(0);
-            this.addchk((Math.abs(value - val) < step / 2), entry,
-                        val, res => set_func((step >= 1) ? parseInt(res) : parseFloat(res)));
-         }
-         this.add("endsub:");
-      }
-
-      /** @summary Add size selection menu entries */
-      SelectMenu(name, values, value, set_func) {
-         this.add("sub:" + name);
-         for (let n = 0; n < values.length; ++n)
-            this.addchk(values[n] == value, values[n], values[n], res => set_func(res));
-         this.add("endsub:");
-      }
-
-      /** @summary Add color selection menu entries  */
-      RColorMenu(name, value, set_func) {
-         // if (value === undefined) return;
-         let colors = ['black', 'white', 'red', 'green', 'blue', 'yellow', 'magenta', 'cyan'];
-
-         this.add("sub:" + name, () => {
-            // todo - use jqury dialog here
-            let col = prompt("Enter color name - empty string will reset color", value);
-            set_func(col);
-         });
-         let col = null, fillcol = 'black', coltxt = 'default', bkgr = '';
-         for (let n = -1; n < colors.length; ++n) {
-            if (n >= 0) {
-               coltxt = col = colors[n];
-               bkgr = "background-color:" + col;
-               fillcol = (col == 'white') ? 'black' : 'white';
-            }
-            let svg = `<svg width='100' height='18' style='margin:0px;${bkgr}'><text x='4' y='12' style='font-size:12px' fill='${fillcol}'>${coltxt}</text></svg>`;
-            this.addchk(value == col, svg, coltxt, res => set_func(res == 'default' ? null : res));
-         }
-         this.add("endsub:");
-      }
-
-
-      /** @summary Add items to change RAttrText */
-      RAttrTextItems(fontHandler, opts, set_func) {
-         if (!opts) opts = {};
-         this.RColorMenu("color", fontHandler.color, sel => set_func({ name: "color_name", value: sel }));
-         if (fontHandler.scaled)
-            this.SizeMenu("size", 0.01, 0.10, 0.01, fontHandler.size /fontHandler.scale, sz => set_func({ name: "size", value: sz }));
-         else
-            this.SizeMenu("size", 6, 20, 2, fontHandler.size, sz => set_func({ name: "size", value: sz }));
-
-         this.SelectMenu("family", ["Arial", "Times New Roman", "Courier New", "Symbol"], fontHandler.name, res => set_func( {name: "font_family", value: res }));
-
-         this.SelectMenu("style", ["normal", "italic", "oblique"], fontHandler.style || "normal", res => set_func( {name: "font_style", value: res == "normal" ? null : res }));
-
-         this.SelectMenu("weight", ["normal", "lighter", "bold", "bolder"], fontHandler.weight || "normal", res => set_func( {name: "font_weight", value: res == "normal" ? null : res }));
-
-         if (!opts.noalign)
-            this.add("align");
-         if (!opts.noangle)
-            this.add("angle");
-      }
-
-      /** @summary Fill context menu for text attributes
-       * @private */
-      AddTextAttributesMenu(painter, prefix) {
-         // for the moment, text attributes accessed directly from objects
-
-         let obj = painter.GetObject();
-         if (!obj || !('fTextColor' in obj)) return;
-
-         this.add("sub:" + (prefix ? prefix : "Text"));
-         this.AddColorMenu("color", obj.fTextColor,
-            arg => { obj.fTextColor = arg; painter.InteractiveRedraw(true, getColorExec(arg, "SetTextColor")); });
-
-         let align = [11, 12, 13, 21, 22, 23, 31, 32, 33];
-
-         this.add("sub:align");
-         for (let n = 0; n < align.length; ++n) {
-            this.addchk(align[n] == obj.fTextAlign,
-               align[n], align[n],
-               // align[n].toString() + "_h:" + hnames[Math.floor(align[n]/10) - 1] + "_v:" + vnames[align[n]%10-1], align[n],
-               function(arg) { this.GetObject().fTextAlign = parseInt(arg); this.InteractiveRedraw(true, "exec:SetTextAlign(" + arg + ")"); }.bind(painter));
-         }
-         this.add("endsub:");
-
-         this.add("sub:font");
-         for (let n = 1; n < 16; ++n) {
-            this.addchk(n == Math.floor(obj.fTextFont / 10), n, n,
-               function(arg) { this.GetObject().fTextFont = parseInt(arg) * 10 + 2; this.InteractiveRedraw(true, "exec:SetTextFont(" + this.GetObject().fTextFont + ")"); }.bind(painter));
-         }
-         this.add("endsub:");
-
-         this.add("endsub:");
-      }
-
-      /** @summary Fill context menu for graphical attributes in painter
-       * @private */
-      AddAttributesMenu(painter, preffix) {
-         // this method used to fill entries for different attributes of the object
-         // like TAttFill, TAttLine, ....
-         // all menu call-backs need to be rebind, while menu can be used from other painter
-
-         if (!preffix) preffix = "";
-
-         if (painter.lineatt && painter.lineatt.used) {
-            this.add("sub:" + preffix + "Line att");
-            this.SizeMenu("width", 1, 10, 1, painter.lineatt.width,
-               arg => { painter.lineatt.Change(undefined, arg); painter.InteractiveRedraw(true, "exec:SetLineWidth(" + arg + ")"); });
-            this.AddColorMenu("color", painter.lineatt.color,
-               arg => { painter.lineatt.Change(arg); painter.InteractiveRedraw(true, getColorExec(arg, "SetLineColor")); });
-            this.add("sub:style", function() {
-               let id = prompt("Enter line style id (1-solid)", 1);
-               if (id === null) return;
-               id = parseInt(id);
-               if (isNaN(id) || !jsrp.root_line_styles[id]) return;
-               this.lineatt.Change(undefined, undefined, id);
-               this.InteractiveRedraw(true, "exec:SetLineStyle(" + id + ")");
-            }.bind(painter));
-            for (let n = 1; n < 11; ++n) {
-               let dash = jsrp.root_line_styles[n],
-                   svg = "<svg width='100' height='18'><text x='1' y='12' style='font-size:12px'>" + n + "</text><line x1='30' y1='8' x2='100' y2='8' stroke='black' stroke-width='3' stroke-dasharray='" + dash + "'></line></svg>";
-
-               this.addchk((painter.lineatt.style == n), svg, n, function(arg) { this.lineatt.Change(undefined, undefined, parseInt(arg)); this.InteractiveRedraw(true, "exec:SetLineStyle(" + arg + ")"); }.bind(painter));
-            }
-            this.add("endsub:");
-            this.add("endsub:");
-
-            if (('excl_side' in painter.lineatt) && (painter.lineatt.excl_side !== 0)) {
-               this.add("sub:Exclusion");
-               this.add("sub:side");
-               for (let side = -1; side <= 1; ++side)
-                  this.addchk((painter.lineatt.excl_side == side), side, side, function(arg) {
-                     this.lineatt.ChangeExcl(parseInt(arg));
-                     this.InteractiveRedraw();
-                  }.bind(painter));
-               this.add("endsub:");
-
-               this.SizeMenu("width", 10, 100, 10, painter.lineatt.excl_width,
-                  arg => { painter.lineatt.ChangeExcl(undefined, arg); painter.InteractiveRedraw(); });
-
-               this.add("endsub:");
-            }
-         }
-
-         if (painter.fillatt && painter.fillatt.used) {
-            this.add("sub:" + preffix + "Fill att");
-            this.AddColorMenu("color", painter.fillatt.colorindx,
-               arg => { painter.fillatt.Change(arg, undefined, painter.svg_canvas()); painter.InteractiveRedraw(true, getColorExec(arg, "SetFillColor")); }, painter.fillatt.kind);
-            this.add("sub:style", function() {
-               let id = prompt("Enter fill style id (1001-solid, 3000..3010)", this.fillatt.pattern);
-               if (id === null) return;
-               id = parseInt(id);
-               if (isNaN(id)) return;
-               this.fillatt.Change(undefined, id, this.svg_canvas());
-               this.InteractiveRedraw(true, "exec:SetFillStyle(" + id + ")");
-            }.bind(painter));
-
-            let supported = [1, 1001, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3010, 3021, 3022];
-
-            for (let n = 0; n < supported.length; ++n) {
-               let sample = painter.createAttFill({ std: false, pattern: supported[n], color: painter.fillatt.colorindx || 1 }),
-                   svg = "<svg width='100' height='18'><text x='1' y='12' style='font-size:12px'>" + supported[n].toString() + "</text><rect x='40' y='0' width='60' height='18' stroke='none' fill='" + sample.fillcolor() + "'></rect></svg>";
-               this.addchk(painter.fillatt.pattern == supported[n], svg, supported[n], function(arg) {
-                  this.fillatt.Change(undefined, parseInt(arg), this.svg_canvas());
-                  this.InteractiveRedraw(true, "exec:SetFillStyle(" + arg + ")");
-               }.bind(painter));
-            }
-            this.add("endsub:");
-            this.add("endsub:");
-         }
-
-         if (painter.markeratt && painter.markeratt.used) {
-            this.add("sub:" + preffix + "Marker att");
-            this.AddColorMenu("color", painter.markeratt.color,
-               arg => { painter.markeratt.Change(arg); painter.InteractiveRedraw(true, getColorExec(arg, "SetMarkerColor"));});
-            this.SizeMenu("size", 0.5, 6, 0.5, painter.markeratt.size,
-               arg => { painter.markeratt.Change(undefined, undefined, arg); painter.InteractiveRedraw(true, "exec:SetMarkerSize(" + parseInt(arg) + ")"); });
-
-            this.add("sub:style");
-            let supported = [1, 2, 3, 4, 5, 6, 7, 8, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34];
-
-            for (let n = 0; n < supported.length; ++n) {
-
-               let clone = new JSROOT.TAttMarkerHandler({ style: supported[n], color: painter.markeratt.color, size: 1.7 }),
-                   svg = "<svg width='60' height='18'><text x='1' y='12' style='font-size:12px'>" + supported[n].toString() + "</text><path stroke='black' fill='" + (clone.fill ? "black" : "none") + "' d='" + clone.create(40, 8) + "'></path></svg>";
-
-               this.addchk(painter.markeratt.style == supported[n], svg, supported[n],
-                  function(arg) { this.markeratt.Change(undefined, parseInt(arg)); this.InteractiveRedraw(true, "exec:SetMarkerStyle(" + arg + ")"); }.bind(painter));
-            }
-            this.add("endsub:");
-            this.add("endsub:");
-         }
-      }
-
-      /** @summary Fill context menu for axis
-       * @private */
-      AddTAxisMenu(painter, faxis, kind) {
-         this.add("sub:Labels");
-         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kCenterLabels), "Center",
-               arg => { faxis.InvertBit(JSROOT.EAxisBits.kCenterLabels); painter.InteractiveRedraw("pad", `exec:CenterLabels(${arg})`, kind); });
-         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kLabelsVert), "Rotate",
-               arg => { faxis.InvertBit(JSROOT.EAxisBits.kLabelsVert); painter.InteractiveRedraw("pad", `exec:SetBit(TAxis::kLabelsVert,${arg})`, kind); });
-         this.AddColorMenu("Color", faxis.fLabelColor,
-               arg => { faxis.fLabelColor = arg; painter.InteractiveRedraw("pad", getColorExec(arg, "SetLabelColor"), kind); });
-         this.SizeMenu("Offset", 0, 0.1, 0.01, faxis.fLabelOffset,
-               arg => { faxis.fLabelOffset = arg; painter.InteractiveRedraw("pad", `exec:SetLabelOffset(${arg})`, kind); } );
-         this.SizeMenu("Size", 0.02, 0.11, 0.01, faxis.fLabelSize,
-               arg => { faxis.fLabelSize = arg; painter.InteractiveRedraw("pad", `exec:SetLabelSize(${arg})`, kind); } );
-         this.add("endsub:");
-         this.add("sub:Title");
-         this.add("SetTitle", () => {
-            let t = prompt("Enter axis title", faxis.fTitle);
-            if (t!==null) { faxis.fTitle = t; painter.InteractiveRedraw("pad", `exec:SetTitle("${t}")`, kind); }
-         });
-         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kCenterTitle), "Center",
-               arg => { faxis.InvertBit(JSROOT.EAxisBits.kCenterTitle); painter.InteractiveRedraw("pad", `exec:CenterTitle(${arg})`, kind); });
-         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kOppositeTitle), "Opposite",
-                () => { faxis.InvertBit(JSROOT.EAxisBits.kOppositeTitle); painter.RedrawPad(); });
-         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kRotateTitle), "Rotate",
-               arg => { faxis.InvertBit(JSROOT.EAxisBits.kRotateTitle); painter.InteractiveRedraw("pad", `exec:RotateTitle(${arg})`, kind); });
-         this.AddColorMenu("Color", faxis.fTitleColor,
-               arg => { faxis.fTitleColor = arg; painter.InteractiveRedraw("pad", getColorExec(arg, "SetTitleColor"), kind); });
-         this.SizeMenu("Offset", 0, 3, 0.2, faxis.fTitleOffset,
-                         arg => { faxis.fTitleOffset = arg; painter.InteractiveRedraw("pad", `exec:SetTitleOffset(${arg})`, kind); });
-         this.SizeMenu("Size", 0.02, 0.11, 0.01, faxis.fTitleSize,
-                         arg => { faxis.fTitleSize = arg; painter.InteractiveRedraw("pad", `exec:SetTitleSize(${arg})`, kind); });
-         this.add("endsub:");
-         this.add("sub:Ticks");
-         if (faxis._typename == "TGaxis") {
-            this.AddColorMenu("Color", faxis.fLineColor,
-                     arg => { faxis.fLineColor = arg; painter.InteractiveRedraw("pad"); });
-            this.SizeMenu("Size", -0.05, 0.055, 0.01, faxis.fTickSize,
-                     arg => { faxis.fTickSize = arg; painter.InteractiveRedraw("pad"); } );
-         } else {
-            this.AddColorMenu("Color", faxis.fAxisColor,
-                     arg => { faxis.fAxisColor = arg; painter.InteractiveRedraw("pad", getColorExec(arg, "SetAxisColor"), kind); });
-            this.SizeMenu("Size", -0.05, 0.055, 0.01, faxis.fTickLength,
-                     arg => { faxis.fTickLength = arg; painter.InteractiveRedraw("pad", `exec:SetTickLength(${arg})`, kind); });
-         }
-         this.add("endsub:");
-      }
-
-      remove() {
-         if (this.element!==null) {
-            this.element.remove();
-            if (this.close_callback) this.close_callback();
-            document.body.removeEventListener('click', this.remove_bind);
-         }
-         this.element = null;
-      }
-
-      show(event, close_callback) {
-         this.remove();
-
-         if (typeof close_callback == 'function') this.close_callback = close_callback;
-
-         if (!event && this.show_evnt) event = this.show_evnt;
-
-         document.body.addEventListener('click', this.remove_bind);
-
-         let oldmenu = document.getElementById(this.menuname);
-         if (oldmenu) oldmenu.parentNode.removeChild(oldmenu);
-
-         $(document.body).append('<ul class="jsroot_ctxmenu">' + this.code + '</ul>');
-
-         this.element = $('.jsroot_ctxmenu');
-
-         let pthis = this;
-
-         this.element
-            .attr('id', this.menuname)
-            .css('left', event.clientX + window.pageXOffset)
-            .css('top', event.clientY + window.pageYOffset)
-//            .css('font-size', '80%')
-            .css('position', 'absolute') // this overrides ui-menu-items class property
-            .menu({
-               items: "> :not(.ui-widget-header)",
-               select: function( event, ui ) {
-                  let arg = ui.item.attr('arg'),
-                      cnt = ui.item.attr('cnt'),
-                      func = cnt ? pthis.funcs[cnt] : null;
-                  pthis.remove();
-                  if (typeof func == 'function') {
-                     if (pthis.painter)
-                        func.bind(pthis.painter)(arg); // if 'painter' field set, returned as this to callback
-                     else
-                        func(arg);
-                  }
-              }
-            });
-
-         let newx = null, newy = null;
-
-         if (event.clientX + this.element.width() > $(window).width()) newx = $(window).width() - this.element.width() - 20;
-         if (event.clientY + this.element.height() > $(window).height()) newy = $(window).height() - this.element.height() - 20;
-
-         if (newx!==null) this.element.css('left', (newx>0 ? newx : 0) + window.pageXOffset);
-         if (newy!==null) this.element.css('top', (newy>0 ? newy : 0) + window.pageYOffset);
-      }
-
-   } // class JQueryMenu
-
-
-   jsrp.createMenu = function(painter, show_event) {
-      let menu = new JQueryMenu(painter, 'root_ctx_menu', show_event);
-
-      return Promise.resolve(menu);
-   }
-
-   // =================================================================================================
-
    let BrowserLayout = JSROOT.BrowserLayout;
 
    /// set browser title text
    /// Title also used for dragging of the float browser
-   BrowserLayout.prototype.SetBrowserTitle = function(title) {
+   BrowserLayout.prototype.setBrowserTitle = function(title) {
       let main = d3.select("#" + this.gui_div + " .jsroot_browser");
       if (!main.empty())
          main.select(".jsroot_browser_title").text(title);
    }
 
-   BrowserLayout.prototype.ToggleBrowserKind = function(kind) {
+   BrowserLayout.prototype.toggleBrowserKind = function(kind) {
 
       if (!this.gui_div) return;
 
@@ -707,7 +214,7 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
    BrowserLayout.prototype.Toggle = function(browser_kind) {
       if (this.browser_visible!=='changing') {
          if (browser_kind === this.browser_kind) this.ToggleBrowserVisisbility();
-                                            else this.ToggleBrowserKind(browser_kind);
+                                            else this.toggleBrowserKind(browser_kind);
       }
    }
 
@@ -1625,9 +1132,9 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
 
       guiCode += '<div id="' + this.gui_div+'_browser_hierarchy" class="jsroot_browser_hierarchy"></div>';
 
-      this.brlayout.SetBrowserContent(guiCode);
+      this.brlayout.setBrowserContent(guiCode);
 
-      this.brlayout.SetBrowserTitle(this.is_online ? 'ROOT online server' : 'Read a ROOT file');
+      this.brlayout.setBrowserTitle(this.is_online ? 'ROOT online server' : 'Read a ROOT file');
 
       let localfile_read_callback = null;
 
@@ -1701,7 +1208,7 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
          this.initializeBrowser();
       }
 
-      this.brlayout.ToggleBrowserKind(browser_kind || "fix");
+      this.brlayout.toggleBrowserKind(browser_kind || "fix");
 
       return Promise.resolve(true);
    }
@@ -1737,7 +1244,7 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
 
       if (this.is_online) {
          if (this.h && this.h._toptitle)
-            this.brlayout.SetBrowserTitle(this.h._toptitle);
+            this.brlayout.setBrowserTitle(this.h._toptitle);
          let painter = this;
          jmain.find(".gui_monitoring")
            .prop('checked', this.isMonitoring())
@@ -1764,20 +1271,18 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
    /** @summary Build main JSROOT GUI
      * @returns {Promise} when completed
      * @private  */
-   JSROOT.buildGUI = function() {
-      let myDiv = d3.select('#simpleGUI'), online = false;
+   JSROOT.buildGUI = function(gui_element, gui_kind) {
+      let myDiv = (typeof gui_element == 'string') ? d3.select('#' + gui_element) : d3.select(gui_element);
+      if (myDiv.empty()) return alert('no div for gui found');
 
-      if (myDiv.empty()) {
-         myDiv = d3.select('#onlineGUI');
-         if (myDiv.empty()) return alert('no div for gui found');
-         online = true;
-      }
+      let online = false;
+      if (gui_kind == "online") online = true;
 
       if (myDiv.attr("ignoreurl") === "true")
          JSROOT.settings.IgnoreUrlOptions = true;
 
-      if (JSROOT.decodeUrl().has("nobrowser") || (myDiv.attr("nobrowser") && myDiv.attr("nobrowser")!=="false"))
-         return JSROOT.buildNobrowserGUI();
+      if (JSROOT.decodeUrl().has("nobrowser") || (myDiv.attr("nobrowser") && myDiv.attr("nobrowser")!=="false") || (gui_kind == "draw") || (gui_kind == "nobrowser"))
+         return JSROOT.buildNobrowserGUI(gui_element, gui_kind);
 
       jsrp.readStyleFromURL();
 
@@ -2340,7 +1845,7 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
 
       player.Show = function(divid, args) {
 
-         this.SetDivId(divid, -1); // just to get access to main element
+         this.SetDivId(divid, -1);
 
          let main = $(this.select_main().node());
 
@@ -2358,8 +1863,9 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
                "<hr/>" +
                "<div id='" + this.drawid + "' style='width:100%'></div>");
 
-         // only when main html element created, one can set divid
-         this.SetDivId(divid);
+         // only when main html element created, one can painter
+         // ObjectPainter allow such usage of methods from BasePainter
+         this.setTopPainter();
 
          let p = this;
 

--- a/js/scripts/JSRoot.menu.js
+++ b/js/scripts/JSRoot.menu.js
@@ -1,0 +1,526 @@
+/// @file JSRoot.menu.js
+/// JSROOT menu implementation
+
+JSROOT.define(['d3', 'jquery', 'painter', 'jquery-ui'], (d3, $, jsrp) => {
+
+   "use strict";
+
+   JSROOT.loadScript('$$$style/jquery-ui');
+
+   if (typeof jQuery === 'undefined') globalThis.jQuery = $;
+
+  /** @summary Produce exec string for WebCanas to set color value
+    * @desc Color can be id or string, but should belong to list of known colors
+    * For higher color numbers TColor::GetColor(r,g,b) will be invoked to ensure color is exists
+    * @private */
+   function getColorExec(col, method) {
+      let id = -1, arr = jsrp.root_colors;
+      if (typeof col == "string") {
+         if (!col || (col == "none")) id = 0; else
+            for (let k = 1; k < arr.length; ++k)
+               if (arr[k] == col) { id = k; break; }
+         if ((id < 0) && (col.indexOf("rgb") == 0)) id = 9999;
+      } else if (!isNaN(col) && arr[col]) {
+         id = col;
+         col = arr[id];
+      }
+
+      if (id < 0) return "";
+
+      if (id >= 50) {
+         // for higher color numbers ensure that such color exists
+         let c = d3.color(col);
+         id = "TColor::GetColor(" + c.r + "," + c.g + "," + c.b + ")";
+      }
+
+      return "exec:" + method + "(" + id + ")";
+   }
+
+   /**
+    * @summary Class for creating context menu
+    *
+    * @class
+    * @memberof JSROOT.Painter
+    * @desc Use {@link JSROOT.Painter.createMenu} to create instance of the menu
+    * @private
+    */
+
+   class JQueryMenu {
+      constructor(painter, menuname, show_event) {
+         this.painter = painter;
+         this.menuname = menuname;
+         this.element = null;
+         this.code = "";
+         this.cnt = 1;
+         this.funcs = {};
+         this.separ = false;
+         if (show_event && (typeof show_event == "object"))
+            if ((show_event.clientX !== undefined) && (show_event.clientY !== undefined))
+               this.show_evnt = { clientX: show_event.clientX, clientY: show_event.clientY };
+
+         this.remove_bind = this.remove.bind(this);
+      }
+
+      add(name, arg, func, title) {
+         if (name == "separator") { this.code += "<li>-</li>"; this.separ = true; return; }
+
+         if (name.indexOf("header:")==0) {
+            this.code += "<li class='ui-widget-header' style='padding:3px; padding-left:5px;'>"+name.substr(7)+"</li>";
+            return;
+         }
+
+         if (name=="endsub:") { this.code += "</ul></li>"; return; }
+
+         let item = "", close_tag = "</li>";
+         title = title ? " title='" + title + "'" : "";
+         if (name.indexOf("sub:")==0) { name = name.substr(4); close_tag = "<ul>"; }
+
+         if (typeof arg == 'function') { func = arg; arg = name; }
+
+         if (name.indexOf("chk:")==0) { item = "<span class='ui-icon ui-icon-check' style='margin:1px'></span>"; name = name.substr(4); } else
+         if (name.indexOf("unk:")==0) { item = "<span class='ui-icon ui-icon-blank' style='margin:1px'></span>"; name = name.substr(4); }
+
+         // special handling of first versions with menu support
+         if (($.ui.version.indexOf("1.10")==0) || ($.ui.version.indexOf("1.9")==0))
+            item = '<a href="#">' + item + name + '</a>';
+         else if ($.ui.version.indexOf("1.11")==0)
+            item += name;
+         else
+            item = "<div" + title + ">" + item + name + "</div>";
+
+         this.code += "<li cnt='" + this.cnt + ((arg !== undefined) ? "' arg='" + arg : "") + "'>" + item + close_tag;
+         if (typeof func == 'function') this.funcs[this.cnt] = func; // keep call-back function
+
+         this.cnt++;
+      }
+
+      addchk(flag, name, arg, func) {
+         let handler = func;
+         if (typeof arg == 'function') {
+            func = arg;
+            handler = res => func(arg=="1");
+            arg = flag ? "0" : "1";
+         }
+         return this.add((flag ? "chk:" : "unk:") + name, arg, handler);
+      }
+
+      size() { return this.cnt-1; }
+
+      addDrawMenu(top_name, opts, call_back) {
+         if (!opts) opts = [];
+         if (opts.length==0) opts.push("");
+
+         let without_sub = false;
+         if (top_name.indexOf("nosub:")==0) {
+            without_sub = true;
+            top_name = top_name.substr(6);
+         }
+
+         if (opts.length === 1) {
+            if (opts[0]==='inspect') top_name = top_name.replace("Draw", "Inspect");
+            return this.add(top_name, opts[0], call_back);
+         }
+
+         if (!without_sub) this.add("sub:" + top_name, opts[0], call_back);
+
+         for (let i=0;i<opts.length;++i) {
+            let name = opts[i];
+            if (name=="") name = '&lt;dflt&gt;';
+
+            let group = i+1;
+            if ((opts.length>5) && (name.length>0)) {
+               // check if there are similar options, which can be grouped once again
+               while ((group<opts.length) && (opts[group].indexOf(name)==0)) group++;
+            }
+
+            if (without_sub) name = top_name + " " + name;
+
+            if (group < i+2) {
+               this.add(name, opts[i], call_back);
+            } else {
+               this.add("sub:" + name, opts[i], call_back);
+               for (let k=i+1;k<group;++k)
+                  this.add(opts[k], opts[k], call_back);
+               this.add("endsub:");
+               i = group-1;
+            }
+         }
+         if (!without_sub) this.add("endsub:");
+      }
+
+      /** @summary Add color selection menu entries  */
+      AddColorMenu(name, value, set_func, fill_kind) {
+         if (value === undefined) return;
+         this.add("sub:" + name, function() {
+            // todo - use jqury dialog here
+            let useid = (typeof value !== 'string');
+            let col = prompt("Enter color " + (useid ? "(only id number)" : "(name or id)"), value);
+            if (col === null) return;
+            let id = parseInt(col);
+            if (!isNaN(id) && jsrp.getColor(id)) {
+               col = jsrp.getColor(id);
+            } else {
+               if (useid) return;
+            }
+            set_func(useid ? id : col);
+         });
+         let useid = (typeof value !== 'string');
+         for (let n = -1; n < 11; ++n) {
+            if ((n < 0) && useid) continue;
+            if ((n == 10) && (fill_kind !== 1)) continue;
+            let col = (n < 0) ? 'none' : jsrp.getColor(n);
+            if ((n == 0) && (fill_kind == 1)) col = 'none';
+            let svg = "<svg width='100' height='18' style='margin:0px;background-color:" + col + "'><text x='4' y='12' style='font-size:12px' fill='" + (n == 1 ? "white" : "black") + "'>" + col + "</text></svg>";
+            this.addchk((value == (useid ? n : col)), svg, (useid ? n : col), res => set_func(useid ? parseInt(res) : res));
+         }
+         this.add("endsub:");
+      }
+
+      /** @summary Add size selection menu entries */
+      SizeMenu(name, min, max, step, value, set_func) {
+         if (value === undefined) return;
+
+         this.add("sub:" + name, function() {
+            // todo - use jqury dialog here
+            let entry = value.toFixed(4);
+            if (step >= 0.1) entry = value.toFixed(2);
+            if (step >= 1) entry = value.toFixed(0);
+            let val = prompt("Enter value of " + name, entry);
+            if (!val) return;
+            val = parseFloat(val);
+            if (!isNaN(val)) set_func((step >= 1) ? Math.round(val) : val);
+         });
+         for (let val = min; val <= max; val += step) {
+            let entry = val.toFixed(2);
+            if (step >= 0.1) entry = val.toFixed(1);
+            if (step >= 1) entry = val.toFixed(0);
+            this.addchk((Math.abs(value - val) < step / 2), entry,
+                        val, res => set_func((step >= 1) ? parseInt(res) : parseFloat(res)));
+         }
+         this.add("endsub:");
+      }
+
+      /** @summary Add size selection menu entries */
+      SelectMenu(name, values, value, set_func) {
+         this.add("sub:" + name);
+         for (let n = 0; n < values.length; ++n)
+            this.addchk(values[n] == value, values[n], values[n], res => set_func(res));
+         this.add("endsub:");
+      }
+
+      /** @summary Add color selection menu entries  */
+      RColorMenu(name, value, set_func) {
+         // if (value === undefined) return;
+         let colors = ['black', 'white', 'red', 'green', 'blue', 'yellow', 'magenta', 'cyan'];
+
+         this.add("sub:" + name, () => {
+            // todo - use jqury dialog here
+            let col = prompt("Enter color name - empty string will reset color", value);
+            set_func(col);
+         });
+         let col = null, fillcol = 'black', coltxt = 'default', bkgr = '';
+         for (let n = -1; n < colors.length; ++n) {
+            if (n >= 0) {
+               coltxt = col = colors[n];
+               bkgr = "background-color:" + col;
+               fillcol = (col == 'white') ? 'black' : 'white';
+            }
+            let svg = `<svg width='100' height='18' style='margin:0px;${bkgr}'><text x='4' y='12' style='font-size:12px' fill='${fillcol}'>${coltxt}</text></svg>`;
+            this.addchk(value == col, svg, coltxt, res => set_func(res == 'default' ? null : res));
+         }
+         this.add("endsub:");
+      }
+
+
+      /** @summary Add items to change RAttrText */
+      RAttrTextItems(fontHandler, opts, set_func) {
+         if (!opts) opts = {};
+         this.RColorMenu("color", fontHandler.color, sel => set_func({ name: "color_name", value: sel }));
+         if (fontHandler.scaled)
+            this.SizeMenu("size", 0.01, 0.10, 0.01, fontHandler.size /fontHandler.scale, sz => set_func({ name: "size", value: sz }));
+         else
+            this.SizeMenu("size", 6, 20, 2, fontHandler.size, sz => set_func({ name: "size", value: sz }));
+
+         this.SelectMenu("family", ["Arial", "Times New Roman", "Courier New", "Symbol"], fontHandler.name, res => set_func( {name: "font_family", value: res }));
+
+         this.SelectMenu("style", ["normal", "italic", "oblique"], fontHandler.style || "normal", res => set_func( {name: "font_style", value: res == "normal" ? null : res }));
+
+         this.SelectMenu("weight", ["normal", "lighter", "bold", "bolder"], fontHandler.weight || "normal", res => set_func( {name: "font_weight", value: res == "normal" ? null : res }));
+
+         if (!opts.noalign)
+            this.add("align");
+         if (!opts.noangle)
+            this.add("angle");
+      }
+
+      /** @summary Fill context menu for text attributes
+       * @private */
+      AddTextAttributesMenu(painter, prefix) {
+         // for the moment, text attributes accessed directly from objects
+
+         let obj = painter.GetObject();
+         if (!obj || !('fTextColor' in obj)) return;
+
+         this.add("sub:" + (prefix ? prefix : "Text"));
+         this.AddColorMenu("color", obj.fTextColor,
+            arg => { obj.fTextColor = arg; painter.InteractiveRedraw(true, getColorExec(arg, "SetTextColor")); });
+
+         let align = [11, 12, 13, 21, 22, 23, 31, 32, 33];
+
+         this.add("sub:align");
+         for (let n = 0; n < align.length; ++n) {
+            this.addchk(align[n] == obj.fTextAlign,
+               align[n], align[n],
+               // align[n].toString() + "_h:" + hnames[Math.floor(align[n]/10) - 1] + "_v:" + vnames[align[n]%10-1], align[n],
+               function(arg) { this.GetObject().fTextAlign = parseInt(arg); this.InteractiveRedraw(true, "exec:SetTextAlign(" + arg + ")"); }.bind(painter));
+         }
+         this.add("endsub:");
+
+         this.add("sub:font");
+         for (let n = 1; n < 16; ++n) {
+            this.addchk(n == Math.floor(obj.fTextFont / 10), n, n,
+               function(arg) { this.GetObject().fTextFont = parseInt(arg) * 10 + 2; this.InteractiveRedraw(true, "exec:SetTextFont(" + this.GetObject().fTextFont + ")"); }.bind(painter));
+         }
+         this.add("endsub:");
+
+         this.add("endsub:");
+      }
+
+      /** @summary Fill context menu for graphical attributes in painter
+       * @private */
+      AddAttributesMenu(painter, preffix) {
+         // this method used to fill entries for different attributes of the object
+         // like TAttFill, TAttLine, ....
+         // all menu call-backs need to be rebind, while menu can be used from other painter
+
+         if (!preffix) preffix = "";
+
+         if (painter.lineatt && painter.lineatt.used) {
+            this.add("sub:" + preffix + "Line att");
+            this.SizeMenu("width", 1, 10, 1, painter.lineatt.width,
+               arg => { painter.lineatt.Change(undefined, arg); painter.InteractiveRedraw(true, "exec:SetLineWidth(" + arg + ")"); });
+            this.AddColorMenu("color", painter.lineatt.color,
+               arg => { painter.lineatt.Change(arg); painter.InteractiveRedraw(true, getColorExec(arg, "SetLineColor")); });
+            this.add("sub:style", function() {
+               let id = prompt("Enter line style id (1-solid)", 1);
+               if (id === null) return;
+               id = parseInt(id);
+               if (isNaN(id) || !jsrp.root_line_styles[id]) return;
+               this.lineatt.Change(undefined, undefined, id);
+               this.InteractiveRedraw(true, "exec:SetLineStyle(" + id + ")");
+            }.bind(painter));
+            for (let n = 1; n < 11; ++n) {
+               let dash = jsrp.root_line_styles[n],
+                   svg = "<svg width='100' height='18'><text x='1' y='12' style='font-size:12px'>" + n + "</text><line x1='30' y1='8' x2='100' y2='8' stroke='black' stroke-width='3' stroke-dasharray='" + dash + "'></line></svg>";
+
+               this.addchk((painter.lineatt.style == n), svg, n, function(arg) { this.lineatt.Change(undefined, undefined, parseInt(arg)); this.InteractiveRedraw(true, "exec:SetLineStyle(" + arg + ")"); }.bind(painter));
+            }
+            this.add("endsub:");
+            this.add("endsub:");
+
+            if (('excl_side' in painter.lineatt) && (painter.lineatt.excl_side !== 0)) {
+               this.add("sub:Exclusion");
+               this.add("sub:side");
+               for (let side = -1; side <= 1; ++side)
+                  this.addchk((painter.lineatt.excl_side == side), side, side, function(arg) {
+                     this.lineatt.ChangeExcl(parseInt(arg));
+                     this.InteractiveRedraw();
+                  }.bind(painter));
+               this.add("endsub:");
+
+               this.SizeMenu("width", 10, 100, 10, painter.lineatt.excl_width,
+                  arg => { painter.lineatt.ChangeExcl(undefined, arg); painter.InteractiveRedraw(); });
+
+               this.add("endsub:");
+            }
+         }
+
+         if (painter.fillatt && painter.fillatt.used) {
+            this.add("sub:" + preffix + "Fill att");
+            this.AddColorMenu("color", painter.fillatt.colorindx,
+               arg => { painter.fillatt.Change(arg, undefined, painter.svg_canvas()); painter.InteractiveRedraw(true, getColorExec(arg, "SetFillColor")); }, painter.fillatt.kind);
+            this.add("sub:style", function() {
+               let id = prompt("Enter fill style id (1001-solid, 3000..3010)", this.fillatt.pattern);
+               if (id === null) return;
+               id = parseInt(id);
+               if (isNaN(id)) return;
+               this.fillatt.Change(undefined, id, this.svg_canvas());
+               this.InteractiveRedraw(true, "exec:SetFillStyle(" + id + ")");
+            }.bind(painter));
+
+            let supported = [1, 1001, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3010, 3021, 3022];
+
+            for (let n = 0; n < supported.length; ++n) {
+               let sample = painter.createAttFill({ std: false, pattern: supported[n], color: painter.fillatt.colorindx || 1 }),
+                   svg = "<svg width='100' height='18'><text x='1' y='12' style='font-size:12px'>" + supported[n].toString() + "</text><rect x='40' y='0' width='60' height='18' stroke='none' fill='" + sample.fillcolor() + "'></rect></svg>";
+               this.addchk(painter.fillatt.pattern == supported[n], svg, supported[n], function(arg) {
+                  this.fillatt.Change(undefined, parseInt(arg), this.svg_canvas());
+                  this.InteractiveRedraw(true, "exec:SetFillStyle(" + arg + ")");
+               }.bind(painter));
+            }
+            this.add("endsub:");
+            this.add("endsub:");
+         }
+
+         if (painter.markeratt && painter.markeratt.used) {
+            this.add("sub:" + preffix + "Marker att");
+            this.AddColorMenu("color", painter.markeratt.color,
+               arg => { painter.markeratt.Change(arg); painter.InteractiveRedraw(true, getColorExec(arg, "SetMarkerColor"));});
+            this.SizeMenu("size", 0.5, 6, 0.5, painter.markeratt.size,
+               arg => { painter.markeratt.Change(undefined, undefined, arg); painter.InteractiveRedraw(true, "exec:SetMarkerSize(" + parseInt(arg) + ")"); });
+
+            this.add("sub:style");
+            let supported = [1, 2, 3, 4, 5, 6, 7, 8, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34];
+
+            for (let n = 0; n < supported.length; ++n) {
+
+               let clone = new JSROOT.TAttMarkerHandler({ style: supported[n], color: painter.markeratt.color, size: 1.7 }),
+                   svg = "<svg width='60' height='18'><text x='1' y='12' style='font-size:12px'>" + supported[n].toString() + "</text><path stroke='black' fill='" + (clone.fill ? "black" : "none") + "' d='" + clone.create(40, 8) + "'></path></svg>";
+
+               this.addchk(painter.markeratt.style == supported[n], svg, supported[n],
+                  function(arg) { this.markeratt.Change(undefined, parseInt(arg)); this.InteractiveRedraw(true, "exec:SetMarkerStyle(" + arg + ")"); }.bind(painter));
+            }
+            this.add("endsub:");
+            this.add("endsub:");
+         }
+      }
+
+      /** @summary Fill context menu for axis
+       * @private */
+      AddTAxisMenu(painter, faxis, kind) {
+         this.add("sub:Labels");
+         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kCenterLabels), "Center",
+               arg => { faxis.InvertBit(JSROOT.EAxisBits.kCenterLabels); painter.InteractiveRedraw("pad", `exec:CenterLabels(${arg})`, kind); });
+         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kLabelsVert), "Rotate",
+               arg => { faxis.InvertBit(JSROOT.EAxisBits.kLabelsVert); painter.InteractiveRedraw("pad", `exec:SetBit(TAxis::kLabelsVert,${arg})`, kind); });
+         this.AddColorMenu("Color", faxis.fLabelColor,
+               arg => { faxis.fLabelColor = arg; painter.InteractiveRedraw("pad", getColorExec(arg, "SetLabelColor"), kind); });
+         this.SizeMenu("Offset", 0, 0.1, 0.01, faxis.fLabelOffset,
+               arg => { faxis.fLabelOffset = arg; painter.InteractiveRedraw("pad", `exec:SetLabelOffset(${arg})`, kind); } );
+         this.SizeMenu("Size", 0.02, 0.11, 0.01, faxis.fLabelSize,
+               arg => { faxis.fLabelSize = arg; painter.InteractiveRedraw("pad", `exec:SetLabelSize(${arg})`, kind); } );
+         this.add("endsub:");
+         this.add("sub:Title");
+         this.add("SetTitle", () => {
+            let t = prompt("Enter axis title", faxis.fTitle);
+            if (t!==null) { faxis.fTitle = t; painter.InteractiveRedraw("pad", `exec:SetTitle("${t}")`, kind); }
+         });
+         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kCenterTitle), "Center",
+               arg => { faxis.InvertBit(JSROOT.EAxisBits.kCenterTitle); painter.InteractiveRedraw("pad", `exec:CenterTitle(${arg})`, kind); });
+         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kOppositeTitle), "Opposite",
+                () => { faxis.InvertBit(JSROOT.EAxisBits.kOppositeTitle); painter.RedrawPad(); });
+         this.addchk(faxis.TestBit(JSROOT.EAxisBits.kRotateTitle), "Rotate",
+               arg => { faxis.InvertBit(JSROOT.EAxisBits.kRotateTitle); painter.InteractiveRedraw("pad", `exec:RotateTitle(${arg})`, kind); });
+         this.AddColorMenu("Color", faxis.fTitleColor,
+               arg => { faxis.fTitleColor = arg; painter.InteractiveRedraw("pad", getColorExec(arg, "SetTitleColor"), kind); });
+         this.SizeMenu("Offset", 0, 3, 0.2, faxis.fTitleOffset,
+                         arg => { faxis.fTitleOffset = arg; painter.InteractiveRedraw("pad", `exec:SetTitleOffset(${arg})`, kind); });
+         this.SizeMenu("Size", 0.02, 0.11, 0.01, faxis.fTitleSize,
+                         arg => { faxis.fTitleSize = arg; painter.InteractiveRedraw("pad", `exec:SetTitleSize(${arg})`, kind); });
+         this.add("endsub:");
+         this.add("sub:Ticks");
+         if (faxis._typename == "TGaxis") {
+            this.AddColorMenu("Color", faxis.fLineColor,
+                     arg => { faxis.fLineColor = arg; painter.InteractiveRedraw("pad"); });
+            this.SizeMenu("Size", -0.05, 0.055, 0.01, faxis.fTickSize,
+                     arg => { faxis.fTickSize = arg; painter.InteractiveRedraw("pad"); } );
+         } else {
+            this.AddColorMenu("Color", faxis.fAxisColor,
+                     arg => { faxis.fAxisColor = arg; painter.InteractiveRedraw("pad", getColorExec(arg, "SetAxisColor"), kind); });
+            this.SizeMenu("Size", -0.05, 0.055, 0.01, faxis.fTickLength,
+                     arg => { faxis.fTickLength = arg; painter.InteractiveRedraw("pad", `exec:SetTickLength(${arg})`, kind); });
+         }
+         this.add("endsub:");
+      }
+
+      remove() {
+         if (this.element!==null) {
+            this.element.remove();
+            if (this.close_callback) this.close_callback();
+            document.body.removeEventListener('click', this.remove_bind);
+         }
+         this.element = null;
+      }
+
+      show(event, close_callback) {
+         this.remove();
+
+         if (typeof close_callback == 'function') this.close_callback = close_callback;
+
+         if (!event && this.show_evnt) event = this.show_evnt;
+
+         document.body.addEventListener('click', this.remove_bind);
+
+         let oldmenu = document.getElementById(this.menuname);
+         if (oldmenu) oldmenu.parentNode.removeChild(oldmenu);
+
+         $(document.body).append('<ul class="jsroot_ctxmenu">' + this.code + '</ul>');
+
+         this.element = $('.jsroot_ctxmenu');
+
+         let pthis = this;
+
+         this.element
+            .attr('id', this.menuname)
+            .css('left', event.clientX + window.pageXOffset)
+            .css('top', event.clientY + window.pageYOffset)
+//            .css('font-size', '80%')
+            .css('position', 'absolute') // this overrides ui-menu-items class property
+            .menu({
+               items: "> :not(.ui-widget-header)",
+               select: function( event, ui ) {
+                  let arg = ui.item.attr('arg'),
+                      cnt = ui.item.attr('cnt'),
+                      func = cnt ? pthis.funcs[cnt] : null;
+                  pthis.remove();
+                  if (typeof func == 'function') {
+                     if (pthis.painter)
+                        func.bind(pthis.painter)(arg); // if 'painter' field set, returned as this to callback
+                     else
+                        func(arg);
+                  }
+              }
+            });
+
+         let newx = null, newy = null;
+
+         if (event.clientX + this.element.width() > $(window).width()) newx = $(window).width() - this.element.width() - 20;
+         if (event.clientY + this.element.height() > $(window).height()) newy = $(window).height() - this.element.height() - 20;
+
+         if (newx!==null) this.element.css('left', (newx>0 ? newx : 0) + window.pageXOffset);
+         if (newy!==null) this.element.css('top', (newy>0 ? newy : 0) + window.pageYOffset);
+      }
+
+   } // class JQueryMenu
+
+   /** @summary Create JSROOT menu
+     * @desc See {@link JSROOT.Painter.jQueryMenu} class for detailed list of methods
+     * @memberof JSROOT.Painter
+     * @example
+     * JSROOT.Painter.createMenu(painter, evnt).then(menu => {
+     *     menu.add("First", () => console.log("Click first"));
+     *     let flag = true;
+     *     menu.addchk(flag, "Checked", arg => console.log(`Now flag is ${arg}`));
+     *     menu.show();
+     * }); */
+   let createMenu = (painter, show_event) => {
+      let menu = new JQueryMenu(painter, 'root_ctx_menu', show_event);
+
+      return Promise.resolve(menu);
+   }
+
+   /** @summary Close previousely created and shown JSROOT menu
+     * @memberof JSROOT.Painter */
+   let closeMenu = function(menuname) {
+      let x = document.getElementById(menuname || 'root_ctx_menu');
+      if (x) { x.parentNode.removeChild(x); return true; }
+      return false;
+   }
+
+   jsrp.createMenu = createMenu;
+   jsrp.closeMenu = closeMenu;
+
+   if (JSROOT.nodejs) module.exports = jsrp;
+
+   return jsrp;
+});

--- a/js/scripts/JSRoot.tree.js
+++ b/js/scripts/JSRoot.tree.js
@@ -2882,7 +2882,6 @@ JSROOT.define(['io', 'math'], (jsrio, jsrmath) => {
          // redirect drawing to the player
          create_player = 1;
 
-         console.log('start drawing player itermediate', intermediate, divid);
          return JSROOT.require("jq2d").then(() => {
             JSROOT.createTreePlayer(painter);
             painter.configureTree(tree);

--- a/js/scripts/JSRoot.v7more.js
+++ b/js/scripts/JSRoot.v7more.js
@@ -173,11 +173,9 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
    function drawLegend(divid, legend, opt) {
       let painter = new JSROOT.v7.RPavePainter(legend, opt, "legend");
 
-      painter.SetDivId(divid);
-
       painter.DrawContent = drawLegendContent;
 
-      return painter.DrawPave();
+     return jsrp.ensureRCanvas(painter, divid, false).then(() => painter.DrawPave());
    }
 
    // =================================================================================
@@ -210,11 +208,9 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
    function drawPaveText(divid, pave, opt) {
       let painter = new JSROOT.v7.RPavePainter(pave, opt, "pavetext");
 
-      painter.SetDivId(divid);
-
       painter.DrawContent = drawPaveTextContent;
 
-      return painter.DrawPave();
+      return jsrp.ensureRCanvas(painter, divid, false).then(() => painter.DrawPave());
    }
 
 

--- a/ui5/eve7/controller/GeomViewer.controller.js
+++ b/ui5/eve7/controller/GeomViewer.controller.js
@@ -318,7 +318,7 @@ sap.ui.define(['sap/ui/core/Component',
             this.geo_painter.AddHighlightHandler(this);
          }
 
-         this.geo_painter.ActivateInBrowser = this.activateInTreeTable.bind(this);
+         this.geo_painter.activateInBrowser = this.activateInTreeTable.bind(this);
 
          this.geo_painter.assignClones(this.geo_clones);
       },

--- a/ui5/eve7/controller/Main.controller.js
+++ b/ui5/eve7/controller/Main.controller.js
@@ -34,6 +34,12 @@ sap.ui.define(['sap/ui/core/Component',
          t.setHtmlText("<strong style=\"color: red;\">Client Disconnected !</strong>");
       },
 
+      /** called when relative number of possible send operation below or over the threshold  */
+      onSendThresholdChanged: function(below, value) {
+         var t = this.byId("centerTitle");
+         t.$().css('color', below ? 'yellow' : '')
+      },
+
 
       UpdateCommandsButtons: function(cmds) {
          if (!cmds || this.commands) return;

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -60,12 +60,29 @@ sap.ui.define([], function() {
    }
 
    EveManager.prototype.OnWebsocketClosed = function() {
-      for (var i = 0; i < this.controllers.length; ++i) {
-         if (typeof this.controllers[i].onDisconnect !== "undefined") {
-            this.controllers[i].onDisconnect();
-         }
-      }
+      this.controllers.forEach(ctrl => {
+         if (typeof ctrl.onDisconnect === "function")
+             ctrl.onDisconnect();
+      });
    }
+
+   /** Checks if number of credits on the connection below threshold */
+   EveManager.prototype.CheckSendThreshold = function() {
+      if (!this.handle) return false;
+      let value = this.handle.getRelCanSend();
+      let below = (value <= 0.2);
+      if (this.credits_below_threshold === undefined)
+         this.credits_below_threshold = false;
+      if (this.credits_below_threshold === below)
+         return below;
+
+      this.credits_below_threshold = below;
+      this.controllers.forEach(ctrl => {
+         if (typeof ctrl.onSendThresholdChanged === "function")
+             ctrl.onSendThresholdChanged(below, value);
+      });
+   }
+
 
    EveManager.prototype.OnWebsocketOpened = function() {
       // console.log("opened!!!");

--- a/ui5/eve7/lib/EveScene.js
+++ b/ui5/eve7/lib/EveScene.js
@@ -316,6 +316,10 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       if (this.mgr.MatchSelection(this.mgr.global_highlight_id, obj3d.eve_el, indx))
          return true;
 
+      // when send queue below threshold, ignre highlight
+      if (this.mgr.CheckSendThreshold())
+         return true;
+
       let is_multi  = false;
       let is_secsel = indx !== undefined;
 
@@ -335,6 +339,10 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       // QQQQ This will have to change for multi client support.
       // Highlight will always be multi and we will have to track
       // which highlight is due to our connection.
+
+      // when send queue below threshold, ignre highlight
+      if (this.mgr.CheckSendThreshold())
+         return true;
 
       let is_multi  = false;
       let is_secsel = false;

--- a/ui5/eve7/lib/GeomDrawing.js
+++ b/ui5/eve7/lib/GeomDrawing.js
@@ -40,7 +40,7 @@ sap.ui.define(['sap/ui/core/Control',
          if (this.geom_painter) {
             // this should be moved to GeomPainter itself !!!
 
-            this.geom_painter.SetDivId(this.getDomRef(), 5);
+            this.geom_painter.SetDivId(this.getDomRef());
 
             var size = this.geom_painter.size_for_3d();
 
@@ -48,6 +48,7 @@ sap.ui.define(['sap/ui/core/Control',
 
             // set top painter only when first child exists
             this.geom_painter.accessTopPainter(true);
+            this.geom_painter.setAsMainPainter();
 
             this.geom_painter.Render3D();
          }

--- a/ui5/eve7/lib/GlViewerJSRoot.js
+++ b/ui5/eve7/lib/GlViewerJSRoot.js
@@ -167,7 +167,7 @@ sap.ui.define([
 
             if (painter.options.update_browser) {
                if (painter.options.highlight && tooltip) names = [ tooltip ];
-               painter.ActivateInBrowser(names);
+               painter.activateInBrowser(names);
             }
 
             if (!resolve || !resolve.obj) return tooltip;
@@ -203,7 +203,7 @@ sap.ui.define([
 
          var browseHandler = this.controller.invokeBrowseOf.bind(this.controller);
 
-         JSROOT.Painter.createMenu(this.geo_painter, function(menu) {
+         JSROOT.Painter.createMenu(this.geo_painter, evnt).then(menu => {
             var numitems = 0, cnt = 0;
             if (intersects)
                for (var n=0;n<intersects.length;++n)

--- a/ui5/eve7/lib/GlViewerThree.js
+++ b/ui5/eve7/lib/GlViewerThree.js
@@ -202,7 +202,6 @@ sap.ui.define([
                   // Was needed for "on press with timeout"
                   // glc.controls.resetMouseDown(event);
 
-                  JSROOT.Painter.createMenu(glc, glc.showContextMenu.bind(glc, event2));
                }
             }
 


### PR DESCRIPTION
RWebWindow uses credit-based data transport. 
Default number of credits was always 10 and can be too small.
Now this default value can be changed via "WebGui.ConnCredits" variable.

In WebEve checks amount of available credits to suppress highlight operations - main source of small packets send to server.
Let avoid situation when such small packets over-flood communication channel.

Latest JSROOT code with better organization how TCanvas and TFrame painters provided when required.
Previous implementation was not adequate, while cannot take into account that object may be drawn on TCanvas or on RCanvas. Now it clearly stated in the code.