### PR TITLE
[RF] Make integrator replaceable from outside for bin sampling.

### DIFF
--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -92,7 +92,7 @@ public:
   std::list<double>* binBoundaries(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override;
   std::list<double>* plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const override;
 
-  ROOT::Math::IntegratorOneDim& integrator() const;
+  std::unique_ptr<ROOT::Math::IntegratorOneDim>& integrator() const;
 
 
 protected:

--- a/roofit/roofitcore/src/RooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/src/RooBinSamplingPdf.cxx
@@ -252,11 +252,11 @@ std::list<double>* RooBinSamplingPdf::plotSamplingHint(RooAbsRealLValue& obs, Do
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return reference to the integrator that's used to sample the bins.
-/// This can be used to alter the integration method or sampling accuracy.
+/// Return reference to a unique_ptr holding the integrator that's used to sample the bins.
+/// This can be used to change options such as sampling accuracy or to entirely exchange the integrator.
 /// \see ROOT::Math::IntegratorOneDim::SetOptions to alter integration options.
 /// \note When integration options are altered, these changes are not saved to files.
-ROOT::Math::IntegratorOneDim& RooBinSamplingPdf::integrator() const {
+std::unique_ptr<ROOT::Math::IntegratorOneDim>& RooBinSamplingPdf::integrator() const {
   if (!_integrator) {
     _integrator.reset(new ROOT::Math::IntegratorOneDim(*this,
         ROOT::Math::IntegrationOneDim::kADAPTIVE, // GSL Integrator. Will really get it only if MathMore enabled.
@@ -266,7 +266,7 @@ ROOT::Math::IntegratorOneDim& RooBinSamplingPdf::integrator() const {
         ));
   }
 
-  return *_integrator;
+  return _integrator;
 }
 
 
@@ -284,6 +284,6 @@ double RooBinSamplingPdf::integrate(const RooArgSet* normSet, double low, double
   // Need to set this because operator() only takes one argument.
   _normSetForIntegrator = normSet;
 
-  return integrator().Integral(low, high);
+  return integrator()->Integral(low, high);
 }
 


### PR DESCRIPTION
In writing a paper I noticed that although I promised that users can exchange the integrator of RooBinSamplingPdf,
they cannot. They can only alter options of the existing integrator.