### PR TITLE
[http] provide MIME type when downloading file, support woff

### DIFF
--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -336,12 +336,16 @@ static int begin_request_handler(struct mg_connection *conn, void *)
       if( hFile != INVALID_HANDLE_VALUE) {
          auto dwRet = GetFinalPathNameByHandle( hFile, Path, BUFSIZE, VOLUME_NAME_DOS );
          // produced file name may include \\? symbols, which are indicating long file name
-         if(dwRet < BUFSIZE) 
+         if(dwRet < BUFSIZE)
             filename = Path;
          CloseHandle(hFile);
       }
 #endif
-      mg_send_file(conn, filename.Data());
+      const char *mime_type = THttpServer::GetMimeType(filename.Data());
+      if (mime_type)
+         mg_send_mime_file(conn, filename.Data(), mime_type);
+      else
+         mg_send_file(conn, filename.Data());
    } else {
 
       Bool_t dozip = kFALSE;

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -1250,6 +1250,8 @@ const char *THttpServer::GetMimeType(const char *path)
                              {".avi", 4, "video/x-msvideo"},
                              {".bmp", 4, "image/bmp"},
                              {".ttf", 4, "application/x-font-ttf"},
+                             {".woff", 5, "font/woff"},
+                             {".woff2", 6, "font/woff2"},
                              {NULL, 0, NULL}};
 
    int path_len = strlen(path);


### PR DESCRIPTION
When civetweb function used to provide file, mg_send_mime_file will
be used now. It set content type based on extension, recognized by
THttpServer.

Add support of woff/woff2 extensions, which font file used in openui5