### PR TITLE
[cling] New interface to export Cling run-time configuration bits.

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -134,6 +134,7 @@ foreach(file ${custom_modulemaps}
         Interpreter/Exception.h
         Interpreter/RuntimePrintValue.h
         Interpreter/RuntimeUniverse.h
+        Interpreter/RuntimeOptions.h
         Interpreter/Value.h)
   get_filename_component(path ${file} PATH)
   set(dest_file ${file})

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1593,7 +1593,7 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
    }
 
    // Enable ClinG's DefinitionShadower for ROOT.
-   fInterpreter->allowRedefinition();
+   fInterpreter->getRuntimeOptions().AllowRedefinition = 1;
 
    // Attach cling callbacks last; they might need TROOT::fInterpreter
    // and should thus not be triggered during the equivalent of

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -11,6 +11,7 @@
 #define CLING_INTERPRETER_H
 
 #include "cling/Interpreter/InvocationOptions.h"
+#include "cling/Interpreter/RuntimeOptions.h"
 
 #include "llvm/ADT/StringRef.h"
 
@@ -188,9 +189,9 @@ namespace cling {
     ///
     bool m_RawInputEnabled;
 
-    ///\brief Whether to allow decl redefinition, i.e. enable the DefinitionShadower.
-    ///
-    bool m_RedefinitionAllowed;
+    ///\brief Configuration bits that can be changed at runtime. This allows the
+    /// user to enable/disable specific interpreter extensions.
+    cling::runtime::RuntimeOptions m_RuntimeOptions;
 
     ///\brief Flag toggling the optimization level to be used.
     ///
@@ -360,6 +361,9 @@ namespace cling {
 
     const InvocationOptions& getOptions() const { return m_Opts; }
     InvocationOptions& getOptions() { return m_Opts; }
+
+    const cling::runtime::RuntimeOptions& getRuntimeOptions() const { return m_RuntimeOptions; }
+    cling::runtime::RuntimeOptions& getRuntimeOptions() { return m_RuntimeOptions; }
 
     const llvm::LLVMContext* getLLVMContext() const {
       return m_LLVMContext.get();
@@ -680,9 +684,6 @@ namespace cling {
 
     bool isRawInputEnabled() const { return m_RawInputEnabled; }
     void enableRawInput(bool raw = true) { m_RawInputEnabled = raw; }
-
-    bool isRedefinitionAllowed() const { return m_RedefinitionAllowed; }
-    void allowRedefinition(bool b = true) { m_RedefinitionAllowed = b; }
 
     int getDefaultOptLevel() const { return m_OptLevel; }
     void setDefaultOptLevel(int optLevel) { m_OptLevel = optLevel; }

--- a/interpreter/cling/include/cling/Interpreter/RuntimeOptions.h
+++ b/interpreter/cling/include/cling/Interpreter/RuntimeOptions.h
@@ -1,0 +1,27 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:  Javier Lopez-Gomez <j.lopez@cern.ch>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+#ifndef CLING_RUNTIME_OPTIONS_H
+#define CLING_RUNTIME_OPTIONS_H
+
+namespace cling {
+  namespace runtime {
+    /// \brief Interpreter configuration bits that can be changed at run-time
+    /// by the user, e.g. to enable/disable extensions.
+    struct RuntimeOptions {
+      RuntimeOptions() : AllowRedefinition(0) {}
+
+      /// \brief Allow the user to redefine entities (requests enabling the
+      /// `DefinitionShadower` AST transformer).
+      bool AllowRedefinition : 1;
+    };
+
+  } // end namespace runtime
+} // end namespace cling
+
+#endif // CLING_RUNTIME_OPTIONS_H

--- a/interpreter/cling/include/cling/Interpreter/RuntimeUniverse.h
+++ b/interpreter/cling/include/cling/Interpreter/RuntimeUniverse.h
@@ -23,6 +23,7 @@
 
 #ifdef __cplusplus
 
+#include <cling/Interpreter/RuntimeOptions.h>
 #include <new>
 
 namespace cling {
@@ -37,6 +38,9 @@ namespace cling {
     /// interprets itself. This is particularly important for implementing
     /// the dynamic scopes and the runtime bindings
     extern Interpreter* gCling;
+
+    /// \brief Configuration bits for the parent interpreter.
+    extern RuntimeOptions* gClingOpts;
 
     namespace internal {
       /// \brief Some of clang's routines rely on valid source locations and

--- a/interpreter/cling/include/cling/module.modulemap
+++ b/interpreter/cling/include/cling/module.modulemap
@@ -6,6 +6,7 @@ module Cling_Interpreter {
 
   // Only included at runtime.
   exclude header "Interpreter/RuntimeUniverse.h"
+  exclude header "Interpreter/RuntimeOptions.h"
   exclude header "Interpreter/DynamicLookupRuntimeUniverse.h"
   exclude header "Interpreter/RuntimePrintValue.h"
 

--- a/interpreter/cling/include/cling/module.modulemap.build
+++ b/interpreter/cling/include/cling/module.modulemap.build
@@ -1,6 +1,7 @@
 // Only included at runtime.
 module Cling_Runtime {
   module "RuntimeUniverse.h" { header "Interpreter/RuntimeUniverse.h" export * }
+  module "RuntimeOptions.h" { header "Interpreter/RuntimeOptions.h" export * }
   module "DynamicLookupRuntimeUniverse.h" { header "Interpreter/DynamicLookupRuntimeUniverse.h" export * }
   module "RuntimePrintValue.h" { header "Interpreter/RuntimePrintValue.h" export * }
   export *

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -207,7 +207,7 @@ namespace cling {
     m_UniqueCounter(parentInterp ? parentInterp->m_UniqueCounter + 1 : 0),
     m_PrintDebug(false), m_DynamicLookupDeclared(false),
     m_DynamicLookupEnabled(false), m_RawInputEnabled(false),
-    m_RedefinitionAllowed(false),
+    m_RuntimeOptions{},
     m_OptLevel(parentInterp ? parentInterp->m_OptLevel : -1) {
 
     if (handleSimpleOptions(m_Opts))
@@ -442,7 +442,8 @@ namespace cling {
         Strm << "#include \"cling/Interpreter/RuntimeUniverse.h\"\n";
         if (EmitDefinitions)
           Strm << "namespace cling { class Interpreter; namespace runtime { "
-                  "Interpreter* gCling=(Interpreter*)" << ThisP << ";}}\n";
+                  "Interpreter* gCling=(Interpreter*)" << ThisP << ";\n"
+                  "RuntimeOptions* gClingOpts=(RuntimeOptions*)" << &this->m_RuntimeOptions << ";}}\n";
       } else {
         Strm << "#include \"cling/Interpreter/CValuePrinter.h\"\n"
              << "void* gCling";
@@ -806,7 +807,7 @@ namespace cling {
       wrapPoint = utils::getWrapPoint(wrapReadySource, getCI()->getLangOpts());
 
     CompilationOptions CO = makeDefaultCompilationOpts();
-    CO.EnableShadowing = m_RedefinitionAllowed && !isRawInputEnabled();
+    CO.EnableShadowing = m_RuntimeOptions.AllowRedefinition && !isRawInputEnabled();
 
     if (isRawInputEnabled() || wrapPoint == std::string::npos) {
       CO.DeclarationExtraction = 0;

--- a/interpreter/cling/test/CodeUnloading/DeclShadowing.C
+++ b/interpreter/cling/test/CodeUnloading/DeclShadowing.C
@@ -9,8 +9,7 @@
 // RUN: cat %s | %cling 2>&1 | FileCheck %s
 #include <type_traits>
 #include <cstdlib>
-#include "cling/Interpreter/Interpreter.h"
-cling::runtime::gCling->allowRedefinition();
+cling::runtime::gClingOpts->AllowRedefinition = 1;
 
 // ==== Test UsingDirectiveDecl/UsingDecl
 // These should not be nested into a `__cling_N5xxx' namespace (but placed at


### PR DESCRIPTION
This PR allows the user to enable/disable specific interpreter capabilities without requiring to `#include` the heavier weight `Interpreter.h` (that also has dependencies on llvm).

The only feature covered at the moment is definition shadowing.  This allows for enabling/disabling it via:
```
cling::runtime::gClingOpts->AllowRedefinition = 1;  // or 0
```

Closes cling issue [#360](https://github.com/root-project/cling/issues/360).