### PR TITLE
[net] Fixes a memory leak in TSocket::SendProcessIDs (ROOT-6892)

### DIFF
--- a/net/net/src/TSocket.cxx
+++ b/net/net/src/TSocket.cxx
@@ -696,6 +696,7 @@ void TSocket::SendProcessIDs(const TMessage &mess)
          //if not add it to the fUUIDs list
          if (!fUUIDs) {
             fUUIDs = new TList();
+            fUUIDs->SetOwner(kTRUE);
          } else {
             if (fUUIDs->FindObject(pid->GetTitle()))
                continue;


### PR DESCRIPTION
Fixes a small memory leak in `TSocket::SendProcessIDs`.  Fixes ROOT-6892 JIRA ticket.

Please, see https://sft.its.cern.ch/jira/projects/ROOT/issues/ROOT-6892 for more information.