### PR TITLE
[cling] DynamicLookup: avoid printing internal expression representation for non-debug builds

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLookup.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLookup.cpp
@@ -734,9 +734,12 @@ namespace cling {
         cling::errs() << "Error while creating dynamic expression for:\n  ";
         SubTree->printPretty(cling::errs(), 0 /*PrinterHelper*/,
                              m_Context->getPrintingPolicy(), 2);
+        cling::errs() << "\n";
+#ifndef NDEBUG
         cling::errs() <<
-          "\nwith internal representation (look for <dependent type>):\n";
+          "with internal representation (look for <dependent type>):\n";
         SubTree->dump(cling::errs(), m_Sema->getSourceManager());
+#endif
         return SubTree;
       }
       m_Sema->ImpCastExprToType(UnOp,


### PR DESCRIPTION
As discussed in the associated JIRA ticket, this information is of no utility for the end user and will only be included in Debug builds.  For additional information, see [ROOT-7199](https://sft.its.cern.ch/jira/projects/ROOT/issues/ROOT-7199).

Fixes ROOT-7199.