### PR TITLE
[foundation] Work around spurious GCC 4.8 warning:

### DIFF
--- a/core/foundation/inc/ROOT/RLogger.hxx
+++ b/core/foundation/inc/ROOT/RLogger.hxx
@@ -342,7 +342,7 @@ inline ELogLevel RLogChannel::GetEffectiveVerbosity(const RLogManager &mgr) cons
  to prevent "ambiguous else" in invocations such as `if (something) R__LOG_DEBUG()...`.
  */
 #define R__LOG_TO_CHANNEL(SEVERITY, CHANNEL)                                                                        \
-   (SEVERITY < ROOT::Experimental::ELogLevel::kInfo ||                                                              \
+   (SEVERITY < ROOT::Experimental::ELogLevel::kInfo + 0 ||                                                          \
     ROOT::Experimental::Internal::GetChannelOrManager(CHANNEL).GetEffectiveVerbosity(                               \
        ROOT::Experimental::RLogManager::Get()) >= SEVERITY) &&                                                      \
       ROOT::Experimental::Detail::RLogBuilder(SEVERITY, ROOT::Experimental::Internal::GetChannelOrManager(CHANNEL), \

--- a/core/foundation/inc/ROOT/RLogger.hxx
+++ b/core/foundation/inc/ROOT/RLogger.hxx
@@ -342,9 +342,9 @@ inline ELogLevel RLogChannel::GetEffectiveVerbosity(const RLogManager &mgr) cons
  to prevent "ambiguous else" in invocations such as `if (something) R__LOG_DEBUG()...`.
  */
 #define R__LOG_TO_CHANNEL(SEVERITY, CHANNEL)                                                                        \
-   (SEVERITY < ROOT::Experimental::ELogLevel::kInfo + 0 ||                                                          \
-    ROOT::Experimental::Internal::GetChannelOrManager(CHANNEL).GetEffectiveVerbosity(                               \
-       ROOT::Experimental::RLogManager::Get()) >= SEVERITY) &&                                                      \
+   ((SEVERITY < ROOT::Experimental::ELogLevel::kInfo + 0) ||                                                        \
+     ROOT::Experimental::Internal::GetChannelOrManager(CHANNEL).GetEffectiveVerbosity(                              \
+        ROOT::Experimental::RLogManager::Get()) >= SEVERITY) &&                                                     \
       ROOT::Experimental::Detail::RLogBuilder(SEVERITY, ROOT::Experimental::Internal::GetChannelOrManager(CHANNEL), \
                                               __FILE__, __LINE__, R__LOG_PRETTY_FUNCTION)
 


### PR DESCRIPTION
warning: value computed is not used [-Wunused-value]
when comparing two constexpr values.