### PR TITLE
[dyld] Fix memory leaks when resolving symbols.

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
@@ -97,6 +97,9 @@ namespace cling {
   public:
     DynamicLibraryManager(const InvocationOptions& Opts);
     ~DynamicLibraryManager();
+    DynamicLibraryManager(const DynamicLibraryManager&) = delete;
+    DynamicLibraryManager& operator=(const DynamicLibraryManager&) = delete;
+
     InterpreterCallbacks* getCallbacks() { return m_Callbacks; }
     const InterpreterCallbacks* getCallbacks() const { return m_Callbacks; }
     void setCallbacks(InterpreterCallbacks* C) { m_Callbacks = C; }

--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -298,10 +298,6 @@ std::string GetExecutablePath() {
 }
 
 namespace cling {
-  DynamicLibraryManager::~DynamicLibraryManager() {
-    delete m_Dyld;
-  }
-
   class Dyld {
     struct BasePathHashFunction {
       size_t operator()(const BasePath& item) const {
@@ -867,6 +863,11 @@ namespace cling {
     */
 
     return ""; // Search found no match.
+  }
+
+  DynamicLibraryManager::~DynamicLibraryManager() {
+    static_assert(sizeof(Dyld) > 0, "Incomplete type");
+    delete m_Dyld;
   }
 
   void DynamicLibraryManager::initializeDyld(


### PR DESCRIPTION
This was seen in an experimental branch of cmssw.