### PR TITLE
Use find_package(BLAS) to satisfy MathMore's cblas dependencies introduced by GSL.

### DIFF
--- a/math/mathmore/CMakeLists.txt
+++ b/math/mathmore/CMakeLists.txt
@@ -84,7 +84,18 @@ SOURCES
     GSL
 )
 
+target_link_libraries(MathMore PRIVATE ${GSL_LIBRARY})
 target_include_directories(MathMore SYSTEM PRIVATE ${GSL_INCLUDE_DIR})
-target_link_libraries(MathMore PRIVATE ${GSL_LIBRARIES})
+find_package(BLAS QUIET)
+if (BLAS_FOUND)
+  if (TARGET BLAS::BLAS)
+    set(MATHMORE_BLAS BLAS::BLAS)
+  else()
+    set(MATHMORE_BLAS ${BLAS_LIBRARIES})
+  endif()
+else()
+  set(MATHMORE_BLAS ${GSL_CBLAS_LIBRARY})
+endif()
+target_link_libraries(MathMore PRIVATE ${MATHMORE_BLAS})
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/math/mathmore/test/CMakeLists.txt
+++ b/math/mathmore/test/CMakeLists.txt
@@ -50,7 +50,7 @@ add_definitions(-DHAVE_ROOTLIBS)
 #---Build and add all the defined test in the list---------------
 foreach(file ${TestMathMoreSource})
   get_filename_component(testname ${file} NAME_WE)
-  ROOT_EXECUTABLE(${testname} ${file} LIBRARIES ${GSL_LIBRARIES} ${Libraries})
+  ROOT_EXECUTABLE(${testname} ${file} LIBRARIES ${GSL_LIBRARY} ${MATHMORE_BLAS} ${Libraries})
   ROOT_ADD_TEST(mathmore-${testname} COMMAND ${testname} LABELS ${${testname}_LABELS})
 endforeach()
 


### PR DESCRIPTION
We use a conformant BLAS implementation to satisfy the cblas
dependencies of MathMore coming from GSL in preference to GSL's provided
libgslcblas.

GSL explicitly makes this possible by segregating its BLAS
implementation, and by not having an explicit link from libgsl.so to
libgslcblas.so.

Allowing a non-GSL BLAS enables:

1. the use of (much) more efficient implementations by mathmore / GSL
   functions;

2. consistency with other uses of BLAS within ROOT (e.g. TMVA).