### PR TITLE
Fixes #6939 gDirectory in one thread pointed to TFile deleted in another thread.

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -249,15 +249,31 @@ namespace Internal {
       TDirectoryAtomicAdapter(std::atomic<TDirectory*> &value) : fValue(value) {}
 
       template <typename T>
-      explicit operator T*() {
+      explicit operator T*() const {
          return (T*)fValue.load();
       }
 
-      operator TDirectory*() {
+      operator TDirectory*() const {
          return fValue.load();
       }
 
-      operator bool() { return fValue.load() != nullptr; }
+      operator bool() const { return fValue.load() != nullptr; }
+
+      bool operator==(const TDirectory *other) const {
+         return fValue.load() == other;
+      }
+
+      bool operator!=(const TDirectory *other) const {
+         return fValue.load() != other;
+      }
+
+      bool operator==(TDirectory *other) const {
+         return fValue.load() == other;
+      }
+
+      bool operator!=(TDirectory *other) const {
+         return fValue.load() != other;
+      }
 
       TDirectory *operator=(TDirectory *newvalue) {
          if (newvalue) {
@@ -267,7 +283,7 @@ namespace Internal {
          return newvalue;
       }
 
-      TDirectory *operator->() { return fValue.load(); }
+      TDirectory *operator->() const { return fValue.load(); }
    };
 } // Internal
 } // ROOT


### PR DESCRIPTION
gDirectory is now backed by an atomic thread local pointer so that the thread deleting a TFile can update other thread's gDirectory.
TDirectory now has a `std::vector<std::atomic<TDirectory*>*>` to keep track of the gDirectory's thread local pointing to the TDirectory.
TDirectory::TContext was already thread safe.
gDirectory is a macro that now actualy 'return' a TDirectoryAtomicAdapter which provides an adaption from std::atomic<TDirectory*> to the
outstanding usage (i.e. behave somewhat like a TDirectory*).
TDirectory::CurrentDirectory now returns a reference to a `std::atomic<TDirectory*>`

Note: due to the actual (but intended to be unnoticeable) change in the type of gDirectory, there is no plan to backport this PR.