### PR TITLE
Enable using Automatic differentiation  for computing Parameter Gradient in TF1

### DIFF
--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -209,6 +209,11 @@ public:
 
    void GradientPar(const Double_t *x, Double_t *result);
 
+   // query if TFormula provides gradient computation using AD (CLAD)
+   bool HasGeneratedGradient() const {
+      return fGradMethod != nullptr;
+   }
+
    // template <class T>
    // T Eval(T x, T y = 0, T z = 0, T t = 0) const;
    template <class T>

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -2448,6 +2448,10 @@ Double_t TF1::GradientPar(Int_t ipar, const Double_t *x, Double_t eps)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute the gradient wrt parameters
+/// If the TF1 object is based on a formula expression (TFormula)
+/// and TFormula::GenerateGradientPar() has been successfully called
+/// automatic differentiation using CLAD is used instead of the default
+/// numerical differentiation
 ///
 /// \param x  point, were the gradient is computed
 /// \param grad  used to return the computed gradient, assumed to be of at least fNpar size
@@ -2462,7 +2466,10 @@ Double_t TF1::GradientPar(Int_t ipar, const Double_t *x, Double_t eps)
 
 void TF1::GradientPar(const Double_t *x, Double_t *grad, Double_t eps)
 {
-   GradientParTempl<Double_t>(x, grad, eps);
+   if (fFormula && fFormula->HasGeneratedGradient())
+      fFormula->GradientPar(x,grad);
+   else
+      GradientParTempl<Double_t>(x, grad, eps);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Enable using TFormula::GradientPar for TFormula based TF1's. This allows to use AD when fitting in ROOT. It is enough to add option `G` when fitting histograms of graphs. 

Add a method `TFormula::HasGeneratedGradient()` which returns true  when `TFormula::GenerateGradientPar()` is called successfully.  This allows to check in TF1 if AD can be used in  the computation of the parametric gradient for TF1

