### PR TITLE
[cling] added missing include in cling/test/CodeUnloading/DeclShadowing.C

### DIFF
--- a/interpreter/cling/test/CodeUnloading/DeclShadowing.C
+++ b/interpreter/cling/test/CodeUnloading/DeclShadowing.C
@@ -9,6 +9,8 @@
 // RUN: cat %s | %cling 2>&1 | FileCheck %s
 #include <type_traits>
 #include <cstdlib>
+#include <string>
+
 cling::runtime::gClingOpts->AllowRedefinition = 1;
 
 // ==== Test UsingDirectiveDecl/UsingDecl


### PR DESCRIPTION
Added missing `#include <string>` that was causing the CodeUnloading/DeclShadowing.C test to fail.