### PR TITLE
[IO] Use collection proxies for I/O of RVecs

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -2012,6 +2012,7 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
          case ROOT::kSTLvector:
          case ROOT::kSTLlist:
          case ROOT::kSTLdeque:
+         case ROOT::kROOTRVec:
             methodTCP="Pushback";
             break;
          case ROOT::kSTLforwardlist:

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -4475,7 +4475,13 @@ ROOT::ESTLType ROOT::TMetaUtils::IsSTLCont(const clang::RecordDecl &cl)
    //                           For example: vector<deque<int>> has answer -1
 
    if (!IsStdClass(cl)) {
-      return ROOT::kNotSTL;
+      auto *nsDecl = llvm::dyn_cast<clang::NamespaceDecl>(cl.getDeclContext());
+      if (cl.getName() != "RVec" || nsDecl == nullptr || nsDecl->getName() != "VecOps")
+         return ROOT::kNotSTL;
+
+      auto *parentNsDecl = llvm::dyn_cast<clang::NamespaceDecl>(cl.getDeclContext()->getParent());
+      if (parentNsDecl == nullptr || parentNsDecl->getName() != "ROOT")
+         return ROOT::kNotSTL;
    }
 
    return STLKind(cl.getName());
@@ -4826,7 +4832,7 @@ ROOT::ESTLType ROOT::TMetaUtils::STLKind(const llvm::StringRef type)
 {
    static const char *stls[] =                  //container names
       {"any","vector","list", "deque","map","multimap","set","multiset","bitset",
-         "forward_list","unordered_set","unordered_multiset","unordered_map","unordered_multimap",0};
+         "forward_list","unordered_set","unordered_multiset","unordered_map","unordered_multimap", "RVec", 0};
    static const ROOT::ESTLType values[] =
       {ROOT::kNotSTL, ROOT::kSTLvector,
        ROOT::kSTLlist, ROOT::kSTLdeque,
@@ -4836,6 +4842,7 @@ ROOT::ESTLType ROOT::TMetaUtils::STLKind(const llvm::StringRef type)
        ROOT::kSTLforwardlist,
        ROOT::kSTLunorderedset, ROOT::kSTLunorderedmultiset,
        ROOT::kSTLunorderedmap, ROOT::kSTLunorderedmultimap,
+       ROOT::kROOTRVec,
        ROOT::kNotSTL
       };
    //              kind of stl container

--- a/core/cont/inc/TCollectionProxyInfo.h
+++ b/core/cont/inc/TCollectionProxyInfo.h
@@ -39,6 +39,10 @@
 class TVirtualCollectionProxy;
 
 namespace ROOT {
+namespace VecOps {
+template <typename T>
+class RVec;
+}
 
 namespace Internal {
 template <typename T> class TStdBitsetHelper {
@@ -747,6 +751,10 @@ namespace Detail {
          return {};
       }
    };
+
+   // TODO this can/should go away when we move to new RVec
+   template <>
+   struct TCollectionProxyInfo::Type<ROOT::VecOps::RVec<bool>> : TCollectionProxyInfo::Type<std::vector<Bool_t>> {};
 
    template <typename Bitset_t> struct TCollectionProxyInfo::Type<Internal::TStdBitsetHelper<Bitset_t> > : public TCollectionProxyInfo::Address<const Bool_t &>
    {

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2688,6 +2688,16 @@ int GenerateFullDict(std::ostream &dictStream,
             // Register the collections
             // coverity[fun_call_w_exception] - that's just fine.
             Internal::RStl::Instance().GenerateTClassFor(selClass.GetNormalizedName(), CRD, interp, normCtxt);
+         } else if (CRD->getName() == "RVec") {
+            static const clang::DeclContext *vecOpsDC = nullptr;
+            if (!vecOpsDC)
+               vecOpsDC = llvm::dyn_cast<clang::DeclContext>(
+                  interp.getLookupHelper().findScope("ROOT::VecOps", cling::LookupHelper::NoDiagnostics));
+            if (vecOpsDC && vecOpsDC->Equals(CRD->getDeclContext())) {
+               // Register the collections
+               // coverity[fun_call_w_exception] - that's just fine.
+               Internal::RStl::Instance().GenerateTClassFor(selClass.GetNormalizedName(), CRD, interp, normCtxt);
+            }
          } else {
             if (!gOptIgnoreExistingDict) {
                ROOT::TMetaUtils::WriteClassInit(dictStream, selClass, CRD, interp, normCtxt, ctorTypes,

--- a/core/foundation/inc/ESTLType.h
+++ b/core/foundation/inc/ESTLType.h
@@ -43,9 +43,10 @@ namespace ROOT {
       kSTLunorderedmultiset = 11,
       kSTLunorderedmap      = 12,
       kSTLunorderedmultimap = 13,
-      kSTLend               = 14,
+      kROOTRVec             = 14, /* ROOT type with STL container interface */
+      kSTLend               = 15,
       kSTLany               = 300 /* TVirtualStreamerInfo::kSTL */,
-      kSTLstring            = 365 /* TVirtualStreamerInfo::kSTLstring */
+      kSTLstring            = 365 /* TVirtualStreamerInfo::kSTLstring */,
    };
 
 }

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -547,6 +547,8 @@ ROOT::ESTLType TClassEdit::STLKind(std::string_view type)
             return values[k];
       }
    }
+   if (type.compare(offset, len, "ROOT::VecOps::RVec") == 0)
+      return ROOT::kROOTRVec;
    return ROOT::kNotSTL;
 }
 

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -1043,6 +1043,7 @@ void* TGenCollectionProxy::At(UInt_t idx)
    if ( fEnv && fEnv->fObject ) {
       switch (fSTL_type) {
       case ROOT::kSTLvector:
+      case ROOT::kROOTRVec:  // TODO will be unnecessary with RVec 2.0
          if ((*fValue).fKind == kBool_t) {
             auto vec = (std::vector<bool> *)(fEnv->fObject);
             fEnv->fLastValueVecBool = (*vec)[idx];
@@ -1207,6 +1208,7 @@ void* TGenCollectionProxy::Allocate(UInt_t n, Bool_t /* forceDelete */ )
          case ROOT::kSTLlist:
          case ROOT::kSTLforwardlist:
          case ROOT::kSTLdeque:
+         case ROOT::kROOTRVec:
             if( (fProperties & kNeedDelete) ) {
                Clear("force");
             }
@@ -1598,6 +1600,7 @@ TVirtualCollectionProxy::CreateIterators_t TGenCollectionProxy::GetFunctionCreat
 //   else
 //      fprintf(stderr,"a generic iterator\n");
 
+   // TODO could we do better than SlowCreateIterators for RVec?
    if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
       return fFunctionCreateIterators = TGenCollectionProxy__VectorCreateIterators;
    else if ( (fProperties & kIsAssociative) && read)
@@ -1624,6 +1627,7 @@ TVirtualCollectionProxy::CopyIterator_t TGenCollectionProxy::GetFunctionCopyIter
 
    if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
 
+   // TODO can we do better than the default for RVec?
    if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
       return fFunctionCopyIterator = TGenCollectionProxy__VectorCopyIterator;
    else if ( (fProperties & kIsAssociative) && read)
@@ -1651,6 +1655,7 @@ TVirtualCollectionProxy::Next_t TGenCollectionProxy::GetFunctionNext(Bool_t read
 
    if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
 
+   // TODO can we do better than the default for RVec?
    if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
       return fFunctionNextIterator = TGenCollectionProxy__VectorNext;
    else if ( (fProperties & kIsAssociative) && read)
@@ -1676,6 +1681,7 @@ TVirtualCollectionProxy::DeleteIterator_t TGenCollectionProxy::GetFunctionDelete
 
    if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
 
+   // TODO can we do better than the default for RVec?
    if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
       return fFunctionDeleteIterator = TGenCollectionProxy__VectorDeleteSingleIterators;
    else if ( (fProperties & kIsAssociative) && read)
@@ -1701,6 +1707,7 @@ TVirtualCollectionProxy::DeleteTwoIterators_t TGenCollectionProxy::GetFunctionDe
 
    if ( !fValue.load(std::memory_order_relaxed) ) InitializeEx(kFALSE);
 
+   // TODO could RVec use something faster than SlowCopyIterator?
    if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
       return fFunctionDeleteTwoIterators = TGenCollectionProxy__VectorDeleteTwoIterators;
    else if ( (fProperties & kIsAssociative) && read)

--- a/io/io/src/TGenCollectionStreamer.cxx
+++ b/io/io/src/TGenCollectionStreamer.cxx
@@ -218,6 +218,7 @@ void TGenCollectionStreamer::ReadPrimitives(int nElements, TBuffer &b, const TCl
    StreamHelper* itmstore = 0;
    StreamHelper* itmconv = 0;
    fEnv->fSize = nElements;
+   // TODO could RVec use something faster the default?
    switch (fSTL_type)  {
       case ROOT::kSTLvector:
          if (fVal->fKind != kBool_t)  {
@@ -405,6 +406,7 @@ void TGenCollectionStreamer::ReadObjects(int nElements, TBuffer &b, const TClass
       case ROOT::kSTLlist:
       case ROOT::kSTLforwardlist:
       case ROOT::kSTLdeque:
+      case ROOT::kROOTRVec: // TODO could we do something faster?
 #define DOLOOP(x) {int idx=0; while(idx<nElements) {StreamHelper* i=(StreamHelper*)TGenCollectionProxy::At(idx); { x ;} ++idx;} break;}
          fResize(fEnv->fObject,fEnv->fSize);
          fEnv->fIdx = 0;
@@ -517,6 +519,7 @@ void TGenCollectionStreamer::ReadPairFromMap(int nElements, TBuffer &b)
       case ROOT::kSTLlist:
       case ROOT::kSTLforwardlist:
       case ROOT::kSTLdeque:
+      case ROOT::kROOTRVec: // TODO could we do something faster?
 #define DOLOOP(x) {int idx=0; while(idx<nElements) {StreamHelper* i=(StreamHelper*)TGenCollectionProxy::At(idx); { x ;} ++idx;} break;}
          fResize(fEnv->fObject,fEnv->fSize);
          fEnv->fIdx = 0;
@@ -1001,6 +1004,7 @@ void TGenCollectionStreamer::WriteObjects(int nElements, TBuffer &b)
       case ROOT::kSTLset:
       case ROOT::kSTLunorderedset:
       case ROOT::kSTLunorderedmultiset:
+      case ROOT::kROOTRVec: // TODO could we do something faster?
 #define DOLOOP(x) {int idx=0; while(idx<nElements) {StreamHelper* i=(StreamHelper*)TGenCollectionProxy::At(idx); { x ;} ++idx;} break;}
          switch (fVal->fCase) {
             case kIsClass:
@@ -1298,6 +1302,7 @@ void TGenCollectionStreamer::ReadBufferDefault(TBuffer &b, void *obj, const TCla
             break;
       }
    }
+   // TODO Could we do something better for RVec?
    (this->*fReadBufferFunc)(b,obj,onFileClass);
 }
 
@@ -1350,6 +1355,7 @@ void TGenCollectionStreamer::ReadBufferGeneric(TBuffer &b, void *obj, const TCla
          case ROOT::kSTLset:
          case ROOT::kSTLunorderedset:
          case ROOT::kSTLunorderedmultiset:
+         case ROOT::kROOTRVec: // TODO could we do something faster?
             if (obj) {
                if (fProperties & kNeedDelete)   {
                   TGenCollectionProxy::Clear("force");
@@ -1405,6 +1411,7 @@ void TGenCollectionStreamer::Streamer(TBuffer &b)
             case ROOT::kSTLset:
             case ROOT::kSTLunorderedset:
             case ROOT::kSTLunorderedmultiset:
+            case ROOT::kROOTRVec: // TODO could we do something faster?
                switch (fVal->fCase) {
                   case kIsFundamental:  // Only handle primitives this way
                   case kIsEnum:
@@ -1439,6 +1446,7 @@ void TGenCollectionStreamer::Streamer(TBuffer &b)
             case ROOT::kSTLset:
             case ROOT::kSTLunorderedset:
             case ROOT::kSTLunorderedmultiset:
+            case ROOT::kROOTRVec: // TODO could we do something faster?
                switch (fVal->fCase) {
                   case kIsFundamental:  // Only handle primitives this way
                   case kIsEnum:
@@ -1484,6 +1492,7 @@ void TGenCollectionStreamer::StreamerAsMap(TBuffer &b)
             case ROOT::kSTLmultiset:
             case ROOT::kSTLset:
             case ROOT::kSTLunorderedset:
+            case ROOT::kROOTRVec: // TODO could we do something faster?
             case ROOT::kSTLunorderedmultiset:{
                   ReadPairFromMap(nElements, b);
                   break;

--- a/io/io/src/TMakeProject.cxx
+++ b/io/io/src/TMakeProject.cxx
@@ -511,6 +511,9 @@ UInt_t TMakeProject::GenerateIncludeForTemplate(FILE *fp, const char *clname, ch
                      case ROOT::kSTLbitset:
                         what = "bitset";
                         break;
+                     case ROOT::kROOTRVec:
+                        what = "ROOT/RVec.hxx";
+                        break;
                      default:
                         what = "undetermined_stl_container";
                         break;

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -1685,6 +1685,8 @@ namespace TStreamerInfoActions
                  || proxy.GetCollectionType() == ROOT::kSTLunorderedmap || proxy.GetCollectionType() == ROOT::kSTLunorderedmultimap
                  || proxy.GetCollectionType() == ROOT::kSTLbitset) {
          return kAssociativeLooper;
+      } else if (proxy.GetCollectionType() == ROOT::kROOTRVec && proxy.GetType() == EDataType::kBool_t) {
+         return kVectorLooper;
       } else {
          return kGenericLooper;
       }

--- a/io/xml/src/TXMLPlayer.cxx
+++ b/io/xml/src/TXMLPlayer.cxx
@@ -978,6 +978,7 @@ Bool_t TXMLPlayer::ProduceSTLstreamer(std::ostream &fs, TClass *cl, TStreamerSTL
       case ROOT::kSTLunorderedmultiset: narg = 1; break;
       case ROOT::kSTLunorderedmap: narg = 2; break;
       case ROOT::kSTLunorderedmultimap: narg = 2; break;
+      case ROOT::kROOTRVec: narg = 1; break;
 
       default: return false;
       }

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -506,6 +506,7 @@ TEST(VecOps, inputOutput)
    const ROOT::VecOps::RVec<Long64_t>::Impl_t llref {1ULL, 2ULL, 3ULL};
    const ROOT::VecOps::RVec<Short_t>::Impl_t sref {1, 2, 3};
    const ROOT::VecOps::RVec<Char_t>::Impl_t cref {1, 2, 3};
+   const ROOT::VecOps::RVec<bool>::Impl_t bref {true, false, true};
 
    {
       auto d = dref;
@@ -520,6 +521,7 @@ TEST(VecOps, inputOutput)
       auto ll = llref;
       auto s = sref;
       auto c = cref;
+      auto b = bref;
       TFile file(filename, "RECREATE");
       TTree t(treename, treename);
       t.Branch("d", &d);
@@ -534,6 +536,7 @@ TEST(VecOps, inputOutput)
       t.Branch("ll", &ll);
       t.Branch("s", &s);
       t.Branch("c", &c);
+      t.Branch("b", &b);
       t.Fill();
       t.Write();
    }
@@ -550,6 +553,7 @@ TEST(VecOps, inputOutput)
    auto ll = new ROOT::VecOps::RVec<Long64_t>::Impl_t();
    auto s = new ROOT::VecOps::RVec<Short_t>::Impl_t();
    auto c = new ROOT::VecOps::RVec<Char_t>::Impl_t();
+   auto b = new ROOT::VecOps::RVec<bool>::Impl_t();
 
    TFile file(filename);
    TTree *tp;
@@ -568,6 +572,7 @@ TEST(VecOps, inputOutput)
    t.SetBranchAddress("ll", &ll);
    t.SetBranchAddress("s", &s);
    t.SetBranchAddress("c", &c);
+   t.SetBranchAddress("b", &b);
 
    t.GetEntry(0);
    CheckEq(*d, dref);
@@ -580,6 +585,7 @@ TEST(VecOps, inputOutput)
    CheckEq(*f, fref);
    CheckEq(*d, dref);
    CheckEq(*f, fref);
+   CheckEq(*b, bref);
 
    gSystem->Unlink(filename);
 

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -489,9 +489,9 @@ void CheckEq(const T0 &v, const T0 &ref)
    }
 }
 
-TEST(VecOps, inputOutput)
+TEST(VecOps, inputOutputImpl)
 {
-   auto filename = "vecops_inputoutput.root";
+   auto filename = "vecops_inputoutput_impl.root";
    auto treename = "t";
 
    const ROOT::VecOps::RVec<double>::Impl_t dref {1., 2., 3.};
@@ -554,6 +554,109 @@ TEST(VecOps, inputOutput)
    auto s = new ROOT::VecOps::RVec<Short_t>::Impl_t();
    auto c = new ROOT::VecOps::RVec<Char_t>::Impl_t();
    auto b = new ROOT::VecOps::RVec<bool>::Impl_t();
+
+   TFile file(filename);
+   TTree *tp;
+   file.GetObject(treename, tp);
+   auto &t = *tp;
+
+   t.SetBranchAddress("d", &d);
+   t.SetBranchAddress("f", &f);
+   t.SetBranchAddress("ui", &ui);
+   t.SetBranchAddress("ul", &ul);
+   t.SetBranchAddress("ull", &ull);
+   t.SetBranchAddress("us", &us);
+   t.SetBranchAddress("uc", &uc);
+   t.SetBranchAddress("i", &i);
+   t.SetBranchAddress("l", &l);
+   t.SetBranchAddress("ll", &ll);
+   t.SetBranchAddress("s", &s);
+   t.SetBranchAddress("c", &c);
+   t.SetBranchAddress("b", &b);
+
+   t.GetEntry(0);
+   CheckEq(*d, dref);
+   CheckEq(*f, fref);
+   CheckEq(*d, dref);
+   CheckEq(*f, fref);
+   CheckEq(*d, dref);
+   CheckEq(*f, fref);
+   CheckEq(*d, dref);
+   CheckEq(*f, fref);
+   CheckEq(*d, dref);
+   CheckEq(*f, fref);
+   CheckEq(*b, bref);
+
+   gSystem->Unlink(filename);
+
+}
+
+
+TEST(VecOps, inputOutput)
+{
+   auto filename = "vecops_inputoutput.root";
+   auto treename = "t";
+
+   const ROOT::VecOps::RVec<double> dref {1., 2., 3.};
+   const ROOT::VecOps::RVec<float> fref {1.f, 2.f, 3.f};
+   const ROOT::VecOps::RVec<UInt_t> uiref {1, 2, 3};
+   const ROOT::VecOps::RVec<ULong_t> ulref {1UL, 2UL, 3UL};
+   const ROOT::VecOps::RVec<ULong64_t> ullref {1ULL, 2ULL, 3ULL};
+   const ROOT::VecOps::RVec<UShort_t> usref {1, 2, 3};
+   const ROOT::VecOps::RVec<UChar_t> ucref {1, 2, 3};
+   const ROOT::VecOps::RVec<Int_t> iref {1, 2, 3};;
+   const ROOT::VecOps::RVec<Long_t> lref {1UL, 2UL, 3UL};;
+   const ROOT::VecOps::RVec<Long64_t> llref {1ULL, 2ULL, 3ULL};
+   const ROOT::VecOps::RVec<Short_t> sref {1, 2, 3};
+   const ROOT::VecOps::RVec<Char_t> cref {1, 2, 3};
+   const ROOT::VecOps::RVec<bool> bref {true, false, true};
+
+   {
+      auto d = dref;
+      auto f = fref;
+      auto ui = uiref;
+      auto ul = ulref;
+      auto ull = ullref;
+      auto us = usref;
+      auto uc = ucref;
+      auto i = iref;
+      auto l = lref;
+      auto ll = llref;
+      auto s = sref;
+      auto c = cref;
+      auto b = bref;
+      TFile file(filename, "RECREATE");
+      TTree t(treename, treename);
+      t.Branch("d", &d);
+      t.Branch("f", &f);
+      t.Branch("ui", &ui);
+      t.Branch("ul", &ul);
+      t.Branch("ull", &ull);
+      t.Branch("us", &us);
+      t.Branch("uc", &uc);
+      t.Branch("i", &i);
+      t.Branch("l", &l);
+      t.Branch("ll", &ll);
+      t.Branch("s", &s);
+      t.Branch("c", &c);
+      t.Branch("b", &b);
+      t.Fill();
+      t.Write();
+   }
+
+   auto d = new ROOT::VecOps::RVec<double>();
+   auto f = new ROOT::VecOps::RVec<float>;
+   auto ui = new ROOT::VecOps::RVec<UInt_t>();
+   auto ul = new ROOT::VecOps::RVec<ULong_t>();
+   auto ull = new ROOT::VecOps::RVec<ULong64_t>();
+   auto us = new ROOT::VecOps::RVec<UShort_t>();
+   auto uc = new ROOT::VecOps::RVec<UChar_t>();
+   auto i = new ROOT::VecOps::RVec<Int_t>();
+   auto l = new ROOT::VecOps::RVec<Long_t>();
+   auto ll = new ROOT::VecOps::RVec<Long64_t>();
+   auto s = new ROOT::VecOps::RVec<Short_t>();
+   auto c = new ROOT::VecOps::RVec<Char_t>();
+   auto b = new ROOT::VecOps::RVec<bool>();
 
    TFile file(filename);
    TTree *tp;

--- a/tree/treeplayer/src/TTreeGeneratorBase.cxx
+++ b/tree/treeplayer/src/TTreeGeneratorBase.cxx
@@ -79,6 +79,8 @@ namespace Internal {
             case  ROOT::kSTLunorderedmap:      what = "unordered_map"; break;
             case -ROOT::kSTLunorderedmultimap: // same as positive
             case  ROOT::kSTLunorderedmultimap: what = "unordered_multimap"; break;
+            case -ROOT::kROOTRVec:             // same as positive
+            case  ROOT::kROOTRVec:             what = "ROOT/RVec.hxx"; break;
          }
          if (what[0]) {
             directive = "#include <";


### PR DESCRIPTION
Before this commit, RVec<T> objects were written to file as a normal
object with a single data member of type `std::vector<T, RAdoptAllocator<T>>`.
However, we want to:
- make use of the more generic "collection proxy" I/O mechanism that
  reads/writes STL-like collections in a generic way making use of their
  begin()/end()/size() API. This makes it possible to implicitly convert
  RVec to any other collection at the I/O level, and it also makes it possible to...
- evolve RVec internals to implement a small-buffer optimization and
  remove the `std::vector<T, RAdoptAllocator<T>>` data member without
  breaking I/O

The most important changes performed:
- added ROOT::ESSTLType::kROOTRVec
- added special case for RVec in dictionary generation:
  - RVecs are setup to use CollectionProxy
  - RVecs are treated as an STL container (even if not in namespace std)
- added special treatment of RVec<bool> (reusing the VectorLooper
  specialized for std::vector<bool>)

Philippe, Axel: what tests would you like to see?