### PR TITLE
Revert "Remove deprecated symbol gErrorMutex"

### DIFF
--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -30,12 +30,16 @@
 //////////////////////////////////////////////////////////////////////////
 
 
+#include <ROOT/RConfig.hxx> // for R__DEPRECATED
 #include <DllImport.h> // for R__EXTERN
 #include "RtypesCore.h"
 
 #include <cstdarg>
 #include <functional>
 
+
+class TVirtualMutex;
+R__EXTERN TVirtualMutex *gErrorMutex R__DEPRECATED(6,26, "ROOT stopped exporting gErrorMutex.");
 
 const Int_t kUnset    =  -1;
 const Int_t kPrint    =   0;

--- a/core/foundation/src/TError.cxx
+++ b/core/foundation/src/TError.cxx
@@ -28,6 +28,9 @@ to be replaced by the proper DefaultErrorHandler()
 #include <cerrno>
 #include <string>
 
+// Deprecated
+TVirtualMutex *gErrorMutex = nullptr;
+
 Int_t  gErrorIgnoreLevel     = kUnset;
 Int_t  gErrorAbortLevel      = kSysError+1;
 Bool_t gPrintViaErrorHandler = kFALSE;


### PR DESCRIPTION
It's deprecated in 6.26, we need to keep it around until then.

This reverts commit 4d18ee14a6b91b1f01acbb3ef303f8a694f1bad1.

@jblomer am I missing something?