### PR TITLE
Fix compilation warning in FunctionGradient

### DIFF
--- a/math/minuit2/inc/Minuit2/FunctionGradient.h
+++ b/math/minuit2/inc/Minuit2/FunctionGradient.h
@@ -35,7 +35,7 @@ public:
    FunctionGradient(const FunctionGradient &grad) : fData(grad.fData) {}
 
    // HD: assignment shares the pointer
-   FunctionGradient &operator=(const FunctionGradient &grad) = default;
+   FunctionGradient &operator=(const FunctionGradient & /*grad*/) = default;
 
    const MnAlgebraicVector &Grad() const { return fData->Grad(); }
    const MnAlgebraicVector &Vec() const { return fData->Vec(); }


### PR DESCRIPTION
Fix a compilation warning added when migrating to use shared_ptr