### PR TITLE
[Tree] Fix cases in which GetLeaf(branchname, leafname) ignores the branchname argument

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6021,7 +6021,7 @@ TLeaf* TTree::GetLeafImpl(const char* branchname, const char *leafname)
    }
    TIter nextl(GetListOfLeaves());
    while ((leaf = (TLeaf*)nextl())) {
-      if (strcmp(leaf->GetFullName(), leafname) && strcmp(leaf->GetName(), leafname))
+      if (strcmp(leaf->GetFullName(), leafname) != 0 && strcmp(leaf->GetName(), leafname) != 0)
          continue; // leafname does not match GetName() nor GetFullName(), this is not the right leaf
       if (branchname) {
          // check the branchname is also a match

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6067,7 +6067,7 @@ TLeaf* TTree::GetLeafImpl(const char* branchname, const char *leafname)
    while ((fe = (TFriendElement*)next())) {
       TTree *t = fe->GetTree();
       if (t) {
-         leaf = t->GetLeaf(leafname);
+         leaf = t->GetLeaf(branchname, leafname);
          if (leaf) return leaf;
       }
    }

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6024,8 +6024,10 @@ TLeaf* TTree::GetLeafImpl(const char* branchname, const char *leafname)
       if (strcmp(leaf->GetFullName(), leafname) && strcmp(leaf->GetName(), leafname))
          continue;
       if (branchname) {
-         UInt_t nbch = strlen(branchname);
          TBranch *br = leaf->GetBranch();
+         if (!strcmp(br->GetFullName(), branchname))
+            return leaf;
+         UInt_t nbch = strlen(branchname);
          const char* brname = br->GetName();
          TBranch *mother = br->GetMother();
          if (strncmp(brname,branchname,nbch)) {

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6022,9 +6022,11 @@ TLeaf* TTree::GetLeafImpl(const char* branchname, const char *leafname)
    TIter nextl(GetListOfLeaves());
    while ((leaf = (TLeaf*)nextl())) {
       if (strcmp(leaf->GetFullName(), leafname) && strcmp(leaf->GetName(), leafname))
-         continue;
+         continue; // leafname does not match GetName() nor GetFullName(), this is not the right leaf
       if (branchname) {
+         // check the branchname is also a match
          TBranch *br = leaf->GetBranch();
+         // if a quick comparison with the branch full name is a match, we are done
          if (!strcmp(br->GetFullName(), branchname))
             return leaf;
          UInt_t nbch = strlen(branchname);

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6021,9 +6021,7 @@ TLeaf* TTree::GetLeafImpl(const char* branchname, const char *leafname)
    }
    TIter nextl(GetListOfLeaves());
    while ((leaf = (TLeaf*)nextl())) {
-      if (!strcmp(leaf->GetFullName(),leafname))
-         return leaf;
-      if (strcmp(leaf->GetName(),leafname))
+      if (strcmp(leaf->GetFullName(), leafname) && strcmp(leaf->GetName(), leafname))
          continue;
       if (branchname) {
          UInt_t nbch = strlen(branchname);

--- a/tree/tree/test/TTreeRegressions.cxx
+++ b/tree/tree/test/TTreeRegressions.cxx
@@ -6,6 +6,8 @@
 
 #include "gtest/gtest.h"
 
+#include <vector>
+
 // ROOT-10702
 TEST(TTreeRegressions, CompositeTypeWithNameClash)
 {
@@ -96,15 +98,20 @@ TEST(TTreeRegressions, GetLeafAndFriends)
 {
    TTree t("t", "t");
    int x = 42;
+   std::vector<int> v(1, 42);
    t.Branch("x", &x);
+   t.Branch("vec", &v);
    t.Fill();
 
    TTree t2("t2", "t2");
    t2.Branch("x", &x);
+   t2.Branch("vec", &v);
    t2.Fill();
 
    EXPECT_EQ(t.GetLeaf("asdklj", "x"), nullptr);
+   EXPECT_EQ(t.GetLeaf("asdklj", "vec"), nullptr);
 
    t.AddFriend(&t2);
    EXPECT_EQ(t.GetLeaf("asdklj", "x"), nullptr);
+   EXPECT_EQ(t.GetLeaf("asdklj", "vec"), nullptr);
 }

--- a/tree/tree/test/TTreeRegressions.cxx
+++ b/tree/tree/test/TTreeRegressions.cxx
@@ -90,3 +90,21 @@ TEST(TTreeRegressions, ChangeFileWithTFileOnStack)
    gSystem->Unlink("ChangeFileWithTFileOnStack_1.root");
    gSystem->Unlink("ChangeFileWithTFileOnStack_2.root");
 }
+
+// Issue #6964
+TEST(TTreeRegressions, GetLeafAndFriends)
+{
+   TTree t("t", "t");
+   int x = 42;
+   t.Branch("x", &x);
+   t.Fill();
+
+   TTree t2("t2", "t2");
+   t2.Branch("x", &x);
+   t2.Fill();
+
+   EXPECT_EQ(t.GetLeaf("asdklj", "x"), nullptr);
+
+   t.AddFriend(&t2);
+   EXPECT_EQ(t.GetLeaf("asdklj", "x"), nullptr);
+}


### PR DESCRIPTION
This fixes and adds tests for #6964 and should also fix #6944 .