### PR TITLE
[README] Fix "Getting started with Root" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See more screenshots on our [gallery](https://root.cern/gallery).
 ## Download and Getting Started
 See [root.cern download page](https://root.cern/downloading-root) for the latest binary releases.
 
-[Getting started with ROOT.](https://root.cern/getting-started)
+[Getting started with ROOT.](https://root.cern/get_started)
 
 ## Building
 Clone the repo


### PR DESCRIPTION
The link **Getting started with Root** redirects to [this page](https://root.cern/getting-started) which is no longer accessible, it should redirect [here](https://root.cern/get_started).