### PR TITLE
[DF] Consistetly use ColumnNames_t alias in RDF constructors

### DIFF
--- a/tree/dataframe/inc/ROOT/RDataFrame.hxx
+++ b/tree/dataframe/inc/ROOT/RDataFrame.hxx
@@ -43,8 +43,7 @@ class RDataFrame : public ROOT::RDF::RInterface<RDFDetail::RLoopManager> {
 public:
    using ColumnNames_t = RDFDetail::ColumnNames_t;
    RDataFrame(std::string_view treeName, std::string_view filenameglob, const ColumnNames_t &defaultBranches = {});
-   RDataFrame(std::string_view treename, const std::vector<std::string> &filenames,
-              const ColumnNames_t &defaultBranches = {});
+   RDataFrame(std::string_view treename, const ColumnNames_t &filenames, const ColumnNames_t &defaultBranches = {});
    RDataFrame(std::string_view treeName, ::TDirectory *dirPtr, const ColumnNames_t &defaultBranches = {});
    RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches = {});
    RDataFrame(ULong64_t numEntries);

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -946,8 +946,7 @@ RDataFrame::RDataFrame(std::string_view treeName, std::string_view filenameglob,
 /// The filename globbing supports the same type of expressions as TChain::Add().
 /// The default branches are looked at in case no branch is specified in the booking of actions or transformations.
 /// See RInterface for the documentation of the methods available.
-RDataFrame::RDataFrame(std::string_view treeName, const std::vector<std::string> &fileglobs,
-                       const ColumnNames_t &defaultBranches)
+RDataFrame::RDataFrame(std::string_view treeName, const ColumnNames_t &fileglobs, const ColumnNames_t &defaultBranches)
    : RInterface(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultBranches))
 {
    std::string treeNameInt(treeName);


### PR DESCRIPTION
While doing some unrelated work I stumbled on an incosistency. Since the fix was so simple, I decided to go for a pr.