### PR TITLE
[JupyROOT][6974] Fixes for IPython

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/__init__.py
+++ b/bindings/jupyroot/python/JupyROOT/__init__.py
@@ -21,5 +21,6 @@ except ImportError:
 _is_ipython = hasattr(builtins, '__IPYTHON__')
 
 if _is_ipython:
+    from IPython import get_ipython
     cppcompleter.load_ipython_extension(get_ipython())
     utils.iPythonize()

--- a/bindings/jupyroot/python/JupyROOT/__init__.py
+++ b/bindings/jupyroot/python/JupyROOT/__init__.py
@@ -13,6 +13,13 @@
 
 from JupyROOT.helpers import cppcompleter, utils
 
-if '__IPYTHON__' in __builtins__ and __IPYTHON__:
+# Check if we are in the IPython shell
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins # Py2
+_is_ipython = hasattr(builtins, '__IPYTHON__')
+
+if _is_ipython:
     cppcompleter.load_ipython_extension(get_ipython())
     utils.iPythonize()


### PR DESCRIPTION
Fixes #6974 and also updates the way in which we check if we are in IPython in `JupyROOT/__init__.py`, to sync it with `ROOT/__init__.py`.

