### PR TITLE
[DF] Fix inadvertent permanent change in gErrorIgnoreLevel

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -82,7 +82,7 @@ private:
 
 public:
    RIgnoreErrorLevelRAII(int errorIgnoreLevel) { gErrorIgnoreLevel = errorIgnoreLevel; }
-   RIgnoreErrorLevelRAII() { gErrorIgnoreLevel = fCurIgnoreErrorLevel; }
+   ~RIgnoreErrorLevelRAII() { gErrorIgnoreLevel = fCurIgnoreErrorLevel; }
 };
 
 /****** BuildAction overloads *******/

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -853,6 +853,11 @@ TEST_P(RDFSimpleTests, NonExistingFileInChain)
    const auto errmsg = "file %s/doesnotexist.root does not exist";
    TString expecteddiag;
    expecteddiag.Form(errmsg, gSystem->pwd());
+   // in the single-thread case the error happens when TTreeReader is calling LoadTree the first time
+   // otherwise we notice the file does not exist beforehand, e.g. in TTreeProcessorMT
+   if (!ROOT::IsImplicitMTEnabled())
+      expecteddiag += "\nWarning in <TTreeReader::SetEntryBase()>: There was an issue opening the last file associated "
+                      "to the TChain being processed.";
 
    bool exceptionCaught = false;
    try {


### PR DESCRIPTION
A typo in a RAII destructor prevented gErrorIgnoreLevel from being
reset to its previous value.