### PR TITLE
[io] Force async buffered read SQE submission

### DIFF
--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -144,6 +144,7 @@ public:
                readEvents[i].fSize,
                readEvents[i].fOffset
             );
+            sqe->flags |= IOSQE_ASYNC; // maximize read event throughput
             sqe->user_data = i;
          }
 


### PR DESCRIPTION
Check if there's any perf benefit to enabling the `IOSQE_ASYNC` flag for our buffered read use case.
(cc @Axel-Naumann, @jblomer)