### PR TITLE
Update ROCCurve.cxx

### DIFF
--- a/tmva/tmva/src/ROCCurve.cxx
+++ b/tmva/tmva/src/ROCCurve.cxx
@@ -265,8 +265,8 @@ Double_t TMVA::ROCCurve::GetROCIntegral(const UInt_t num_points)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Returns a new TGraph containing the ROC curve. Specificity is on the x-axis,
-/// sensitivity on the y-axis.
+/// Returns a new TGraph containing the ROC curve. Sensitivity is on the x-axis,
+/// specificity on the y-axis.
 ///
 /// @param num_points Granularity of the resulting curve. The curve will be subdivided
 ///                     into num_points - 1 regions where the performance of the


### PR DESCRIPTION
docu incorrect for this function. sensitivity is on x, specificity is on y. only changed documentation to match.
relevant forum thread: https://root-forum.cern.ch/t/how-are-sensitivity-and-specificity-computed-in-tmva-roccurve/42806/4