### PR TITLE
[DF] Fix branch type inference in some cases

### DIFF
--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -157,7 +157,10 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
 {
    // look for TLeaf either with GetLeaf(colName) or with GetLeaf(branchName, leafName) (splitting on last dot)
    auto leaf = t.GetLeaf(colName.c_str());
+   if (!leaf)
+      leaf = t.FindLeaf(colName.c_str()); // try harder
    if (!leaf) {
+      // try splitting branchname and leafname
       const auto dotPos = colName.find_last_of('.');
       const auto hasDot = dotPos != std::string::npos;
       if (hasDot) {
@@ -171,6 +174,8 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
 
    // we could not find a leaf named colName, so we look for a TBranchElement
    auto branch = t.GetBranch(colName.c_str());
+   if (!branch)
+      branch = t.FindBranch(colName.c_str()); // try harder
    if (branch) {
       static const TClassRef tbranchelement("TBranchElement");
       if (branch->InheritsFrom(tbranchelement)) {

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -101,8 +101,11 @@ static void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnName
 
       ExploreBranch(t, bNamesReg, bNames, subBranch, newPrefix, friendName);
 
-      if (t.GetBranch(fullName.c_str()) || t.FindBranch(fullName.c_str()))
-         UpdateList(bNamesReg, bNames, fullName, friendName);
+      auto branchDirectlyFromTree = t.GetBranch(fullName.c_str());
+      if (!branchDirectlyFromTree)
+         branchDirectlyFromTree = t.FindBranch(fullName.c_str()); // try harder
+      if (branchDirectlyFromTree)
+         UpdateList(bNamesReg, bNames, std::string(branchDirectlyFromTree->GetFullName()), friendName);
 
       if (t.GetBranch(subBranchName.c_str()))
          UpdateList(bNamesReg, bNames, subBranchName, friendName);


### PR DESCRIPTION
- try harder to find branches and leaves users requested when
  trying to figure out their type
- when building the list of valid column names, use the output of
  TBranch::GetFullName instead of the names (joined by dots) of
  the branches we traversed so far. With multiple nested
  TBranchElements, the traversal might be `a.b.c` while the name
  returned by TBranch::GetFullName (which is what TTree::GetBranch
  recognizes) might be simply `a.c` (see e.g. ROOT-9975).

These changes fix ROOT-9975, although in some corner cases they might
change which column names RDataFrame considers valid (any "reasonable"
user application that was working should keep working -- no tutorial,
test or integration benchmark we have was broken by these changes).

A test is at https://github.com/root-project/roottest/pull/632 .