### PR TITLE
[http] disable auth domain check when domain not configured

### DIFF
--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -577,6 +577,9 @@ Bool_t TCivetweb::Create(const char *args)
       options[op++] = auth_file.Data();
       options[op++] = "authentication_domain";
       options[op++] = auth_domain.Data();
+   } else {
+      options[op++] = "enable_auth_domain_check";
+      options[op++] = "no";
    }
 
    if (log_file.Length() > 0) {


### PR DESCRIPTION
While auth domain check enabled by default, it makes problem when
http request includes full URL - as TWebFile does. Causes problem described in

https://root-forum.cern.ch/t/serving-files-with-thttpserver/42850

Let open http files server by `THttpServer` from other ROOT session