### PR TITLE
[http] disable auth domain check when domain not configured 6.22

### DIFF
--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -573,6 +573,9 @@ Bool_t TCivetweb::Create(const char *args)
       options[op++] = auth_file.Data();
       options[op++] = "authentication_domain";
       options[op++] = auth_domain.Data();
+   } else {
+      options[op++] = "enable_auth_domain_check";
+      options[op++] = "no";
    }
 
    if (log_file.Length() > 0) {


### PR DESCRIPTION
While it enabled by default, it makes problem when
http request includes full URL. Causes problem described in

https://root-forum.cern.ch/t/serving-files-with-thttpserver/42850