### PR TITLE
Use Numerical gradient as input to the seed generator when using external gradients in Minuit2

### DIFF
--- a/math/minuit2/src/ModularFunctionMinimizer.cxx
+++ b/math/minuit2/src/ModularFunctionMinimizer.cxx
@@ -154,7 +154,9 @@ FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNGradientBase &fcn, c
    if (maxfcn == 0)
       maxfcn = 200 + 100 * npar + 5 * npar * npar;
 
-   MinimumSeed mnseeds = SeedGenerator()(mfcn, gc, st, strategy);
+   // use numerical gradient to compute initial derivatives for SeedGenerator
+   Numerical2PGradientCalculator numgc(mfcn, st.Trafo(), strategy);
+   MinimumSeed mnseeds = SeedGenerator()(mfcn, numgc, st, strategy);
 
    return Minimize(mfcn, gc, mnseeds, strategy, maxfcn, toler);
 }


### PR DESCRIPTION
With external gradient one does not provide often correct step sizes and therefore the initial state computed with the SeedGenerator could be  really off and many more iterations will be afterwards required.
It is much more convenient to use once the numerical gradient to compute the correct step sizes and then the initial approximate Hessian. In particular by using the numerical gradient one has also for free the second derivatives (the diagonal part of the Hessian) which can be used. 

A long term solution would be to provide also as input the second derivatives in Minuit2