### PR TITLE
Fix for new version of cudnn version 8

### DIFF
--- a/tmva/tmva/src/DNN/Architectures/Cudnn/Propagate.cu
+++ b/tmva/tmva/src/DNN/Architectures/Cudnn/Propagate.cu
@@ -385,9 +385,9 @@ void TCudnn<AFloat>::InitializeConvWorkspace(TWorkspace * & workspace,
       LocalPerf();
       // these three type are absolutely equivalent
       // and one can access them as they wish to get info
-      cudnnConvolutionFwdAlgoPerf_t * m_fwd;
-      cudnnConvolutionBwdFilterAlgoPerf_t * m_bwdFilter;
-      cudnnConvolutionBwdDataAlgoPerf_t * m_bwdData;
+      cudnnConvolutionFwdAlgoPerf_t *m_fwd = nullptr;
+      cudnnConvolutionBwdFilterAlgoPerf_t *m_bwdFilter = nullptr;
+      cudnnConvolutionBwdDataAlgoPerf_t * m_bwdData = nullptr;
    };
 #else
    // More detailed alternative: cudnnFindConvolutionForwardAlgorithm (only option in newer cuDNN versions)

--- a/tutorials/tmva/TMVA_CNN_Classification.C
+++ b/tutorials/tmva/TMVA_CNN_Classification.C
@@ -422,13 +422,13 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
       // create python script which can be executed
       // crceate 2 conv2d layer + maxpool + dense
       TMacro m;
-      m.AddLine("import keras");
-      m.AddLine("from keras.models import Sequential");
-      m.AddLine("from keras.optimizers import Adam");
+      m.AddLine("import tensorflow");
+      m.AddLine("from tensorflow.keras.models import Sequential");
+      m.AddLine("from tensorflow.keras.optimizers import Adam");
       m.AddLine(
-         "from keras.layers import Input, Dense, Dropout, Flatten, Conv2D, MaxPooling2D, Reshape, BatchNormalization");
+         "from tensorflow.keras.layers import Input, Dense, Dropout, Flatten, Conv2D, MaxPooling2D, Reshape, BatchNormalization");
       m.AddLine("");
-      m.AddLine("model = keras.models.Sequential() ");
+      m.AddLine("model = Sequential() ");
       m.AddLine("model.add(Reshape((16, 16, 1), input_shape = (256, )))");
       m.AddLine("model.add(Conv2D(10, kernel_size = (3, 3), kernel_initializer = 'glorot_normal',activation = "
                 "'relu', padding = 'same'))");
@@ -452,10 +452,10 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1})
          Warning("TMVA_CNN_Classification", "Error creating Keras model file - skip using Keras");
       } else {
          // book PyKeras method only if Keras model could be created
-         Info("TMVA_CNN_Classification", "Booking Keras CNN model");
+         Info("TMVA_CNN_Classification", "Booking tf.Keras CNN model");
          factory.BookMethod(
             loader, TMVA::Types::kPyKeras, "PyKeras",
-            "H:!V:VarTransform=None:FilenameModel=model_cnn.h5:"
+            "H:!V:VarTransform=None:FilenameModel=model_cnn.h5:tf.keras:"
             "FilenameTrainedModel=trained_model_cnn.h5:NumEpochs=20:BatchSize=100:"
             "GpuOptions=allow_growth=True"); // needed for RTX NVidia card and to avoid TF allocates all GPU memory
       }

--- a/tutorials/tmva/TMVA_RNN_Classification.C
+++ b/tutorials/tmva/TMVA_RNN_Classification.C
@@ -403,13 +403,13 @@ the option string
             // create python script which can be executed
             // create 2 conv2d layer + maxpool + dense
             TMacro m;
-            m.AddLine("import keras");
-            m.AddLine("from keras.models import Sequential");
-            m.AddLine("from keras.optimizers import Adam");
-            m.AddLine("from keras.layers import Input, Dense, Dropout, Flatten, SimpleRNN, GRU, LSTM, Reshape, "
+            m.AddLine("import tensorflow");
+            m.AddLine("from tensorflow.keras.models import Sequential");
+            m.AddLine("from tensorflow.keras.optimizers import Adam");
+            m.AddLine("from tensorflow.keras.layers import Input, Dense, Dropout, Flatten, SimpleRNN, GRU, LSTM, Reshape, "
                       "BatchNormalization");
             m.AddLine("");
-            m.AddLine("model = keras.models.Sequential() ");
+            m.AddLine("model = Sequential() ");
             m.AddLine("model.add(Reshape((10, 30), input_shape = (10*30, )))");
             // add recurrent neural network depending on type / Use option to return the full output
             if (rnn_types[i] == "LSTM")
@@ -441,7 +441,7 @@ the option string
                Info("TMVA_RNN_Classification", "Booking Keras %s model", rnn_types[i].c_str());
                factory->BookMethod(dataloader, TMVA::Types::kPyKeras,
                                    TString::Format("PyKeras_%s", rnn_types[i].c_str()),
-                                   TString::Format("!H:!V:VarTransform=None:FilenameModel=%s:"
+                                   TString::Format("!H:!V:VarTransform=None:FilenameModel=%s:tf.keras:"
                                                    "FilenameTrainedModel=%s:GpuOptions=allow_growth=True:"
                                                    "NumEpochs=%d:BatchSize=%d",
                                                    modelName.Data(), trainedModelName.Data(), maxepochs, batchSize));


### PR DESCRIPTION
Apply a fix when using the CNN with the latest cudnn library (version 8) compatibile with Cuda11. 

Update also tutorials of tmva to make the keras models using tensorflow.keras that is now the reccomended way of using Keras