### PR TITLE
[DF] Disable cling nullptr checks in RDF internal logic

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -49,7 +49,7 @@ std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node,
  */
 // clang-format on
 template <typename Helper, typename PrevDataFrame, typename ColumnTypes_t = typename Helper::ColumnTypes_t>
-class RAction : public RActionBase {
+class R__CLING_PTRCHECK(off) RAction : public RActionBase {
    using TypeInd_t = std::make_index_sequence<ColumnTypes_t::list_size>;
 
    Helper fHelper;

--- a/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
@@ -25,7 +25,7 @@ namespace RDF {
 This pure virtual class provides a common base class for the different column reader types, e.g. RTreeColumnReader and
 RDSColumnReader.
 **/
-class RColumnReaderBase {
+class R__CLING_PTRCHECK(off) RColumnReaderBase {
 public:
    virtual ~RColumnReaderBase() = default;
 

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -42,7 +42,7 @@ struct SlotAndEntry{};
 // clang-format on
 
 template <typename F, typename ExtraArgsTag = CustomColExtraArgs::None>
-class RDefine final : public RDefineBase {
+class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    // shortcuts
    using NoneTag = CustomColExtraArgs::None;
    using SlotTag = CustomColExtraArgs::Slot;

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -50,7 +50,7 @@ using namespace ROOT::TypeTraits;
 namespace RDFGraphDrawing = ROOT::Internal::RDF::GraphDrawing;
 
 template <typename FilterF, typename PrevDataFrame>
-class RFilter final : public RFilterBase {
+class R__CLING_PTRCHECK(off) RFilter final : public RFilterBase {
    using ColumnTypes_t = typename CallableTraits<FilterF>::arg_types;
    using TypeInd_t = std::make_index_sequence<ColumnTypes_t::list_size>;
 


### PR DESCRIPTION
After changes to RDF's internal logic, some of the classes used
during the event loop were triggering unnecessary, slow cling nullptr
checks. This patch turns these checks off.

This resolves a performance regression in v6.23 w.r.t. v6.22 for RDF
macros run via the interpreter (`root dfMacro.C`).