### PR TITLE
[NFC] v6-22: Try to prevent anti-virus false positive detection on Wi…

### DIFF
--- a/main/src/hadd.cxx
+++ b/main/src/hadd.cxx
@@ -408,6 +408,10 @@ int main( int argc, char **argv )
 
    std::vector<std::string> partialFiles;
 
+#ifndef R__WIN32
+   // this is commented out only to try to prevent false positive detection
+   // from several anti-virus engines on Windows, and multiproc is not
+   // supported on Windows anyway
    if (multiproc) {
       auto uuid = TUUID();
       auto partialTail = uuid.AsString();
@@ -417,6 +421,7 @@ int main( int argc, char **argv )
          partialFiles.emplace_back(buffer.str());
       }
    }
+#endif
 
    auto mergeFiles = [&](TFileMerger &merger) {
       if (reoptimize) {


### PR DESCRIPTION
…ndows

Comment out part of the code to try to prevent false positive detection from several anti-virus engines on Windows (and multiproc is not supported on Windows anyway)