### PR TITLE
Fix TMVA  dependency on Cuda  

### DIFF
--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -47,10 +47,12 @@
 #include "TMVA/DNN/Architectures/Cpu.h"
 //#endif
 
+#if 0
 #ifdef R__HAS_TMVAGPU
 #include "TMVA/DNN/Architectures/Cuda.h"
 #ifdef R__HAS_CUDNN
 #include "TMVA/DNN/Architectures/TCudnn.h"
+#endif
 #endif
 #endif
 

--- a/tmva/tmva/inc/TMVA/MethodDNN.h
+++ b/tmva/tmva/inc/TMVA/MethodDNN.h
@@ -60,7 +60,7 @@
 #define DNNCPU
 #endif
 #ifdef R__HAS_TMVAGPU
-#define DNNCUDA
+//#define DNNCUDA
 #endif
 
 #ifdef DNNCPU

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -46,6 +46,13 @@
 #include "TMVA/DNN/Adadelta.h"
 #include "TMVA/Timer.h"
 
+#ifdef R__HAS_TMVAGPU
+#include "TMVA/DNN/Architectures/Cuda.h"
+#ifdef R__HAS_CUDNN
+#include "TMVA/DNN/Architectures/TCudnn.h"
+#endif
+#endif
+
 #include <chrono>
 
 REGISTER_METHOD(DL)

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -53,6 +53,13 @@ Deep Neural Network Implementation.
 #include "TMVA/NeuralNet.h"
 #include "TMVA/Monitoring.h"
 
+#ifdef R__HAS_TMVACPU
+#include "TMVA/DNN/Architectures/Cpu.h"
+#endif
+#ifdef R__HAS_TMVAGPU
+#include "TMVA/DNN/Architectures/Cuda.h"
+#endif
+
 #include <algorithm>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Now TMVA does not have anymore dependency on Cuda at the header file.
In principle one could have MethodDL depending on Cuda tensor, but this is not needed if single event evaluation is not done on GPU.
With this PR now the Cuda headers are included from TMVA source files 

This PR should avoid the problem of ROOT-10980 and  #6999 should not be anymore needed 