### PR TITLE
Fix #7016 Do no leak Conversion StreamerInfo for unversion classes.

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -7091,7 +7091,7 @@ TVirtualStreamerInfo *TClass::GetConversionStreamerInfo( const TClass* cl, Int_t
    info = (TVirtualStreamerInfo*)info->Clone();
 
    // When cloning the StreamerInfo we record (and thus restore)
-   // the absolute value of the version, let's keep the original.
+   // the absolute value of the version, let's restore the sign.
    if (version == -1)
       info->SetClassVersion(-1);
 
@@ -7197,7 +7197,7 @@ TVirtualStreamerInfo *TClass::FindConversionStreamerInfo( const TClass* cl, UInt
    info = (TVirtualStreamerInfo*)info->Clone();
 
    // When cloning the StreamerInfo we record (and thus restore)
-   // the absolute value of the version, let's keep the original.
+   // the absolute value of the version, let's restore the sign.
    if (version == -1)
       info->SetClassVersion(-1);
 

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2155,7 +2155,7 @@ void TBranchElement::SetupInfo()
 
          TStreamerInfo* info;
          if( targetClass != cl )
-            info = (TStreamerInfo*)targetClass->GetConversionStreamerInfo( cl, fCheckSum );
+            info = (TStreamerInfo*)targetClass->FindConversionStreamerInfo( cl, fCheckSum );
          else {
             info = (TStreamerInfo*)cl->FindStreamerInfo( fCheckSum );
             if (info) {


### PR DESCRIPTION
The leak is related to the handling of conversion from unversioned class from MathCore
(namely from ```ROOT::Math::Cartesian3D<double>``` to ```ROOT::Math::Cartesian3D<Double32_t>``` and
```ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::GlobalCoordinateSystemTag>```
to ```ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag>```

In some circumstances (involving which StreamerInfo was recorded in an acceleration structure/cache), TClass was
not remembering that it already created the Conversion StreamerInfo from one to the other and recreating from each object read.

In the case of DUNE, the leak was triggered by running:
```
   Events->Draw("recob::Tracks_pandoraTrack__DecoderandReco.obj.fTraj.fMomenta.fCoordinates.fX");
```
or similar.