### PR TITLE
[PyROOT][6470] Fix virtual call issue in deep hierarchy

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
@@ -5,6 +5,7 @@
 #include "Executors.h"
 #include "MemoryRegulator.h"
 #include "ProxyWrappers.h"
+#include "PyStrings.h"
 
 #include "CPyCppyy/DispatchPtr.h"
 
@@ -83,10 +84,9 @@ PyObject* CPyCppyy::CPPConstructor::Call(
         address = (ptrdiff_t)((CPPInstance*)pyobj)->GetObject();
         if (address) {
             ((CPPInstance*)pyobj)->CppOwns();
-            PyObject* pyoff = PyObject_CallMethod(dispproxy, (char*)"_dispatchptr_offset", nullptr);
-            size_t disp_offset = PyLong_AsSsize_t(pyoff);
-            Py_DECREF(pyoff);
-            new ((void*)(address + disp_offset)) DispatchPtr{(PyObject*)self};
+            PyObject* res = PyObject_CallMethodObjArgs(
+            dispproxy, PyStrings::gDispInit, pyobj, (PyObject*)self, nullptr);
+            Py_XDECREF(res);
         }
         Py_DECREF(pyobj);
         Py_DECREF(dispproxy);

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
@@ -254,9 +254,10 @@ static PyObject* pt_new(PyTypeObject* subtype, PyObject* args, PyObject* kwds)
             Py_ssize_t sz = PyDict_Size(dct);
             if (0 < sz && !Cppyy::IsNamespace(result->fCppType)) {
                 result->fFlags |= CPPScope::kIsPython;
-                if (!InsertDispatcher(result, dct)) {
-                    if (!PyErr_Occurred())
-                         PyErr_Warn(PyExc_RuntimeWarning, (char*)"no python-side overrides supported");
+                std::ostringstream errmsg;
+                if (!InsertDispatcher(result, PyTuple_GET_ITEM(args, 1), dct, errmsg)) {
+                    PyErr_Format(PyExc_TypeError, "no python-side overrides supported (%s)", errmsg.str().c_str());
+                    return nullptr;
                 } else {
                 // the direct base can be useful for some templates, such as shared_ptrs,
                 // so make it accessible (the __cpp_cross__ data member also signals that

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.h
@@ -1,12 +1,15 @@
 #ifndef CPYCPPYY_DISPATCHER_H
 #define CPYCPPYY_DISPATCHER_H
 
+// Standard
+#include <sstream>
+
 namespace CPyCppyy {
 
 class CPPScope;
 
 // helper that inserts dispatchers for virtual methods
-bool InsertDispatcher(CPPScope* klass, PyObject* dct);
+bool InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct, std::ostringstream& err);
 
 } // namespace CPyCppyy
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.cxx
@@ -53,6 +53,7 @@ PyObject* CPyCppyy::PyStrings::gCppImag          = nullptr;
 PyObject* CPyCppyy::PyStrings::gThisModule       = nullptr;
 
 PyObject* CPyCppyy::PyStrings::gNoImplicit       = nullptr;
+PyObject* CPyCppyy::PyStrings::gDispInit         = nullptr;
 
 PyObject* CPyCppyy::PyStrings::gExPythonize      = nullptr;
 PyObject* CPyCppyy::PyStrings::gPythonize        = nullptr;
@@ -116,6 +117,7 @@ bool CPyCppyy::CreatePyStrings() {
     CPPYY_INITIALIZE_STRING(gThisModule,     cppyy);
 
     CPPYY_INITIALIZE_STRING(gNoImplicit,     __cppyy_no_implicit);
+    CPPYY_INITIALIZE_STRING(gDispInit,       _init_dispatchptr);
 
     CPPYY_INITIALIZE_STRING(gExPythonize,    __cppyy_explicit_pythonize__);
     CPPYY_INITIALIZE_STRING(gPythonize,      __cppyy_pythonize__);
@@ -175,6 +177,7 @@ PyObject* CPyCppyy::DestroyPyStrings() {
     Py_DECREF(PyStrings::gThisModule);  PyStrings::gThisModule  = nullptr;
 
     Py_DECREF(PyStrings::gNoImplicit);  PyStrings::gNoImplicit  = nullptr;
+    Py_DECREF(PyStrings::gDispInit);    PyStrings::gDispInit    = nullptr;
 
     Py_DECREF(PyStrings::gExPythonize); PyStrings::gExPythonize = nullptr;
     Py_DECREF(PyStrings::gPythonize);   PyStrings::gPythonize   = nullptr;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.h
@@ -56,6 +56,7 @@ namespace PyStrings {
     extern PyObject* gThisModule;
 
     extern PyObject* gNoImplicit;
+    extern PyObject* gDispInit;
 
     extern PyObject* gExPythonize;
     extern PyObject* gPythonize;


### PR DESCRIPTION
Fixes #6470 .

Fix how the inheritance hierarchy is constructed when there's more
than one level of cross-inheritance, for example C++ class ->
Py class 1 -> Py class 2. In the example, the C++ Dispatcher class
of Py class 2 should inherit from the Dispatcher class of Py class 1,
and not directly from the base C++ class. This was causing an
undesired behaviour in the resolution of some virtual calls, as
shown in the reproducer of 6470.

This PR is an adaptation of the code that is in upstream
cppyy, but it does not incorporate yet all the changes for
multiple cross-inheritance (i.e. a Python class that inherits
from more than one C++ class). Multiple cross-inheritance was
anyway not supported in old PyROOT, and its current implementation
in cppyy does not seem to support the inheritance from both a pure
Python class and a C++ class at the same time (even via the use
of cppyy.multi), and that case was supported in the old PyROOT.