### PR TITLE
Improvements in TMVA MethodCategory

### DIFF
--- a/tmva/tmva/inc/TMVA/DataSetInfo.h
+++ b/tmva/tmva/inc/TMVA/DataSetInfo.h
@@ -77,8 +77,8 @@ namespace TMVA {
       // ---
       // the variable data
       // ---
-      VariableInfo&     AddVariable( const TString& expression, const TString& title = "", const TString& unit = "", 
-                                     Double_t min = 0, Double_t max = 0, char varType='F', 
+      VariableInfo&     AddVariable( const TString& expression, const TString& title = "", const TString& unit = "",
+                                     Double_t min = 0, Double_t max = 0, char varType='F',
                                      Bool_t normalized = kTRUE, void* external = 0 );
       VariableInfo&     AddVariable( const VariableInfo& varInfo );
 
@@ -87,11 +87,11 @@ namespace TMVA {
                              Double_t min = 0, Double_t max = 0, char type = 'F', Bool_t normalized = kTRUE,
                              void *external = 0 );
 
-      VariableInfo&     AddTarget  ( const TString& expression, const TString& title, const TString& unit, 
+      VariableInfo&     AddTarget  ( const TString& expression, const TString& title, const TString& unit,
                                      Double_t min, Double_t max, Bool_t normalized = kTRUE, void* external = 0 );
       VariableInfo&     AddTarget  ( const VariableInfo& varInfo );
 
-      VariableInfo&     AddSpectator ( const TString& expression, const TString& title, const TString& unit, 
+      VariableInfo&     AddSpectator ( const TString& expression, const TString& title, const TString& unit,
                                        Double_t min, Double_t max, char type = 'F', Bool_t normalized = kTRUE, void* external = 0 );
       VariableInfo&     AddSpectator ( const VariableInfo& varInfo );
 
@@ -105,7 +105,7 @@ namespace TMVA {
       VariableInfo&                    GetVariableInfo( Int_t i ) { return fVariables.at(i); }
       const VariableInfo&              GetVariableInfo( Int_t i ) const { return fVariables.at(i); }
 
-      Int_t GetVarArraySize(const TString &expression) const { 
+      Int_t GetVarArraySize(const TString &expression) const {
          auto element = fVarArrays.find(expression);
          return (element != fVarArrays.end()) ? element->second : -1;
        }
@@ -198,7 +198,8 @@ namespace TMVA {
       void                       SetDataSetManager( DataSetManager* dsm ) { fDataSetManager = dsm; } // DSMTEST
       friend class DataSetManager;  // DSMTEST (datasetmanager test)
 
-   DataSetInfo( const DataSetInfo& ) : TObject() {}
+      DataSetInfo(const DataSetInfo &) = delete;
+      DataSetInfo & operator= (const DataSetInfo &) = delete;
 
       void PrintCorrelationMatrix( TTree* theTree );
 
@@ -227,19 +228,19 @@ namespace TMVA {
       Double_t                   fTestingSumBackgrWeights ;
 
 
-      
+
       TDirectory*                fOwnRootDir;        // ROOT output dir
       Bool_t                     fVerbose;           // Verbosity
 
       UInt_t                     fSignalClass;       // index of the class with the name signal
 
       std::vector<Float_t>*      fTargetsForMulticlass;//-> all targets 0 except the one with index==classNumber
-      
+
       mutable MsgLogger*         fLogger;            //! message logger
       MsgLogger& Log() const { return *fLogger; }
 
    public:
-       
+
        ClassDef(DataSetInfo,1);
    };
 }

--- a/tmva/tmva/inc/TMVA/MethodBase.h
+++ b/tmva/tmva/inc/TMVA/MethodBase.h
@@ -206,7 +206,8 @@ namespace TMVA {
 
       // signal/background classification response for all current set of data
       virtual std::vector<Double_t> GetMvaValues(Long64_t firstEvt = 0, Long64_t lastEvt = -1, Bool_t logProgress = false);
-
+      // same as above but using a provided data set (used by MethodCategory)
+      virtual std::vector<Double_t> GetDataMvaValues(DataSet *data = nullptr, Long64_t firstEvt = 0, Long64_t lastEvt = -1, Bool_t logProgress = false);
 
    public:
       // regression response
@@ -405,10 +406,9 @@ namespace TMVA {
 
       // returns reference to data set
       // NOTE: this DataSet is the "original" dataset, i.e. the one seen by ALL Classifiers WITHOUT transformation
-      DataSet* Data() const { return DataInfo().GetDataSet(); }
+      DataSet* Data() const { return (fTmpData) ? fTmpData : DataInfo().GetDataSet(); }
       DataSetInfo&     DataInfo() const { return fDataSetInfo; }
 
-      mutable const Event*   fTmpEvent; //! temporary event when testing on a different DataSet than the own one
 
       // event reference and update
       // NOTE: these Event accessors make sure that you get the events transformed according to the
@@ -442,10 +442,12 @@ namespace TMVA {
       void                  DisableWriting(Bool_t setter){ fModelPersistence = setter?kFALSE:kTRUE; }//DEPRECATED
 
     protected:
-      // helper variables for JsMVA
-      IPythonInteractive *fInteractive = nullptr;
-      bool fExitFromTraining = false;
-      UInt_t fIPyMaxIter = 0, fIPyCurrentIter = 0;
+      mutable const Event *fTmpEvent; //! temporary event when testing on a different DataSet than the own one
+      DataSet *fTmpData =  nullptr; //! temporary dataset used when evaluating on a different data (used by MethodCategory::GetMvaValues)
+       // helper variables for JsMVA
+       IPythonInteractive *fInteractive = nullptr;
+       bool fExitFromTraining = false;
+       UInt_t fIPyMaxIter = 0, fIPyCurrentIter = 0;
 
     public:
 

--- a/tmva/tmva/inc/TMVA/MethodCategory.h
+++ b/tmva/tmva/inc/TMVA/MethodCategory.h
@@ -98,8 +98,12 @@ namespace TMVA {
 
       virtual void MakeClass( const TString& = TString("") ) const {};
 
-   private :
+   protected :
 
+      // signal/background classification response for all current set of data
+      virtual std::vector<Double_t> GetMvaValues(Long64_t firstEvt = 0, Long64_t lastEvt = -1, Bool_t logProgress = false);
+
+   private:
       // initializing mostly monitoring tools of the category process
       void Init();
 

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -1332,18 +1332,21 @@ TMVA::DataSetFactory::MixEvents( DataSetInfo& dsi,
             eventVectorTesting.erase( std::remove( eventVectorTesting.begin(), eventVectorTesting.end(), (void*)NULL ), eventVectorTesting.end() );
          }
       }
-      else { // erase at end
+      else { // erase at end if size larger than requested
          if( eventVectorTraining.size() < UInt_t(requestedTraining) )
             Log() << kWARNING << Form("Dataset[%s] : ",dsi.GetName())<< "DataSetFactory/requested number of training samples larger than size of eventVectorTraining.\n"
                   << "There is probably an issue. Please contact the TMVA developers." << Endl;
-         std::for_each( eventVectorTraining.begin()+requestedTraining, eventVectorTraining.end(), DeleteFunctor<Event>() );
-         eventVectorTraining.erase(eventVectorTraining.begin()+requestedTraining,eventVectorTraining.end());
-
+         else if (eventVectorTraining.size() >  UInt_t(requestedTraining)) {
+            std::for_each( eventVectorTraining.begin()+requestedTraining, eventVectorTraining.end(), DeleteFunctor<Event>() );
+            eventVectorTraining.erase(eventVectorTraining.begin()+requestedTraining,eventVectorTraining.end());
+         }
          if( eventVectorTesting.size() < UInt_t(requestedTesting) )
             Log() << kWARNING << Form("Dataset[%s] : ",dsi.GetName())<< "DataSetFactory/requested number of testing samples larger than size of eventVectorTesting.\n"
                   << "There is probably an issue. Please contact the TMVA developers." << Endl;
-         std::for_each( eventVectorTesting.begin()+requestedTesting, eventVectorTesting.end(), DeleteFunctor<Event>() );
-         eventVectorTesting.erase(eventVectorTesting.begin()+requestedTesting,eventVectorTesting.end());
+         else if ( eventVectorTesting.size() > UInt_t(requestedTesting) ) {
+            std::for_each( eventVectorTesting.begin()+requestedTesting, eventVectorTesting.end(), DeleteFunctor<Event>() );
+            eventVectorTesting.erase(eventVectorTesting.begin()+requestedTesting,eventVectorTesting.end());
+         }
       }
    }
 

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -480,7 +480,9 @@ TH2* TMVA::DataSetInfo::CreateCorrelationMatrixHist( const TMatrixD* m,
 TMVA::DataSet* TMVA::DataSetInfo::GetDataSet() const
 {
    if (fDataSet==0 || fNeedsRebuilding) {
-      if(fDataSet!=0) ClearDataSet();
+      if (fNeedsRebuilding) Log() << kINFO << "Rebuilding Dataset " << fName << Endl;
+      if (fDataSet != 0)
+         ClearDataSet();
       //      fDataSet = DataSetManager::Instance().CreateDataSet(GetName()); //DSMTEST replaced by following lines
       if( !fDataSetManager )
          Log() << kFATAL << Form("Dataset[%s] : ",fName.Data()) << "DataSetManager has not been set in DataSetInfo (GetDataSet() )." << Endl;

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -934,6 +934,17 @@ std::vector<Double_t> TMVA::MethodBase::GetMvaValues(Long64_t firstEvt, Long64_t
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// get all the MVA values for the events of the given Data type
+// (this is used by Method Category and it does not need to be re-implmented by derived classes )
+std::vector<Double_t> TMVA::MethodBase::GetDataMvaValues(DataSet * data, Long64_t firstEvt, Long64_t lastEvt, Bool_t logProgress)
+{
+   fTmpData = data;
+   auto result = GetMvaValues(firstEvt, lastEvt, logProgress);
+   fTmpData = nullptr;
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// prepare tree branch with the method's discriminating variable
 
 void TMVA::MethodBase::AddClassifierOutputProb( Types::ETreeType type )

--- a/tmva/tmva/src/MethodCategory.cxx
+++ b/tmva/tmva/src/MethodCategory.cxx
@@ -293,6 +293,10 @@ TMVA::DataSetInfo& TMVA::MethodCategory::CreateCategoryDSI(const TCut& theCut,
    dsi->SetRootDir(oldDSI.GetRootDir());
    TString norm(oldDSI.GetNormalization().Data());
    dsi->SetNormalization(norm);
+   // need to add split options to normalize with cut efficiency
+   TString splitOpt = dsi->GetSplitOptions();
+   splitOpt += ":ScaleWithPreselEff";
+   dsi->SetSplitOptions(splitOpt);
 
    DataSetInfo& dsiReference= (*dsi);
 
@@ -624,7 +628,84 @@ Double_t TMVA::MethodCategory::GetMvaValue( Double_t* err, Double_t* errUpper )
    Double_t mvaValue = dynamic_cast<MethodBase*>(fMethods[methodToUse])->GetMvaValue(ev,err,errUpper);
    ev->SetVariableArrangement(0);
 
+   std::cout << "Event  is for method " << methodToUse << " spectator is " << ev->GetSpectator(0) << "  "
+             << fVarMaps[0][0] << " classID " << DataInfo().IsSignal(ev) << " value " <<  mvaValue
+             << " type " << Data()->GetCurrentType() << std::endl;
+
    return mvaValue;
+}
+
+///////////////////////////////////////////////////////////////
+/// returns the mva values of the right sub-classifier
+///
+std::vector<Double_t>
+TMVA::MethodCategory::GetMvaValues(Long64_t firstEvt, Long64_t lastEvt, Bool_t logProgress)
+{
+
+   std::vector<Double_t> result;
+
+   Info("GetMVaValues", "Evaluate MethodCategory for %d events type %d on the dataset %s", int(lastEvt - firstEvt),
+        (int)Data()->GetCurrentType(), DataInfo().GetName());
+
+   if (fMethods.empty())
+      return result;
+
+   auto data = Data();
+
+   // it is faster to evaluate all categories
+   std::vector<std::vector<Double_t>> mvaValues(fMethods.size());
+   for (UInt_t i = 0; i < fMethods.size(); ++i) {
+      // need to set variable map
+      for (UInt_t iev = firstEvt; iev < lastEvt; ++iev) {
+          data->SetCurrentEvent(iev);
+          const Event *ev = GetEvent(data->GetEvent());
+          ev->SetVariableArrangement(&fVarMaps[i]);
+      }
+      // need to set correct data in the different method
+      mvaValues[i] = dynamic_cast<MethodBase *>(fMethods[i])->GetDataMvaValues(data,firstEvt, lastEvt, logProgress);
+   }
+
+   // now loop on all events
+   result.resize(lastEvt - firstEvt);
+
+   for (UInt_t iev = firstEvt; iev < lastEvt; ++iev)
+   {
+      //std::cout << "Loop on event " << iev << " of " << DataInfo().GetName() << std::endl;
+      data->SetCurrentEvent(iev);
+      UInt_t methodToUse = 0;
+      const Event *ev = GetEvent(data->GetEvent());
+
+      // determine which sub-classifier to use for this event
+      Int_t suitableCutsN = 0;
+
+      for (UInt_t i = 0; i < fMethods.size(); ++i) {
+         if (PassesCut(ev, i)) {
+            ++suitableCutsN;
+            methodToUse = i;
+         }
+      }
+
+      if (suitableCutsN == 0) {
+         Log() << kWARNING << "Event does not lie within the cut of any sub-classifier." << Endl;
+         result[iev] = 0;
+      }
+
+      if (suitableCutsN > 1) {
+         Log() << kFATAL << "The defined categories are not disjoint." << Endl;
+         return result;
+      }
+
+
+      result[iev - firstEvt] = mvaValues[methodToUse][iev - firstEvt];
+
+      // std::cout << "Event " << iev << " is for method " << methodToUse << " spectator is " << ev->GetSpectator(0)
+      //           << "  " << fVarMaps[0][0] << " classID " << DataInfo().IsSignal(ev) << " value "
+      //           << result[iev - firstEvt] << " type " << data->GetCurrentType() << std::endl;
+
+      // reset variable map which was set it before
+      ev->SetVariableArrangement(nullptr);
+   }
+   return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -664,7 +745,7 @@ const std::vector<Float_t> &TMVA::MethodCategory::GetMulticlassValues()
    }
    // get mva value from the suitable sub-classifier
    ev->SetVariableArrangement(&fVarMaps[methodToUse]);
-   auto & result =  meth->GetMulticlassValues();
+   auto &result = meth->GetMulticlassValues();
    ev->SetVariableArrangement(nullptr);
    return result;
 }


### PR DESCRIPTION
This PR provides some improvements in using MethodCategory. 
As shown in the example code reported in the forum at https://root-forum.cern.ch/t/addspectator-variable-crashes-with-segmentation-violation-in-multi-class-kpykeras-tmva/42210
code example is [here](https://root-forum.cern.ch/uploads/short-url/y1NFPmCeTPh3YhDgKbucP3zpHyo.py)

Evaluation of MethodCategory is very small when using pymva. This PR provides the correct fixes by adding MethodCategory::GetMvaValues which evaluate on a batch of values and the needed fixes.  