### PR TITLE
RBrowser improvements

### DIFF
--- a/gui/browsable/CMakeLists.txt
+++ b/gui/browsable/CMakeLists.txt
@@ -23,6 +23,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowsable
     ROOT/Browsable/RUnique.hxx
     ROOT/Browsable/RWrapper.hxx
     ROOT/Browsable/TKeyItem.hxx
+    ROOT/Browsable/TObjectElement.hxx
     ROOT/Browsable/TObjectHolder.hxx
     ROOT/Browsable/TObjectItem.hxx
   SOURCES
@@ -68,6 +69,14 @@ ROOT_LINKER_LIBRARY(ROOTObjectDraw7Provider
      ROOTGpadv7
 )
 
+# provider for browsing of TBranchElement
+
+ROOT_LINKER_LIBRARY(ROOTBranchBrowseProvider
+     src/TBranchBrowseProvider.cxx
+  DEPENDENCIES
+     ROOTBrowsable
+     Tree
+)
 
 # provider for drawing of TLeaf on TCanvas
 

--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -39,6 +39,7 @@ public:
       kImage,     ///< "image64" - base64 for supported image formats (png/gif/gpeg)
       kPng,       ///< "png" - plain png binary code, returned inside std::string
       kJpeg,      ///< "jpg" or "jpeg" - plain jpg binary code, returned inside std::string
+      kJson,      ///< "json" representation of object, can be used in code editor
       kFileName   ///< "filename" - file name if applicable
    };
 
@@ -58,8 +59,8 @@ public:
    /** Create iterator for childs elements if any */
    virtual std::unique_ptr<RLevelIter> GetChildsIter();
 
-   /** Returns element content, depends from kind. Can be "text" or "image64" */
-   virtual std::string GetContent(const std::string & = "text") { return ""; }
+   /** Returns element content, depends from kind. Can be "text" or "image64" or "json" */
+   virtual std::string GetContent(const std::string & = "text");
 
    /** Access object */
    virtual std::unique_ptr<RHolder> GetObject() { return nullptr; }

--- a/gui/browsable/inc/ROOT/Browsable/RItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RItem.hxx
@@ -41,6 +41,7 @@ public:
    const std::string &GetName() const { return name; }
    const std::string &GetIcon() const { return icon; }
    virtual bool IsFolder() const { return false; }
+   virtual bool IsHidden() const { return false; }
 
    void SetChecked(bool on = true) { checked = on; }
    void SetExpanded(bool on = true) { expanded = on; }

--- a/gui/browsable/inc/ROOT/Browsable/RSysFileItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RSysFileItem.hxx
@@ -44,6 +44,13 @@ public:
 
    bool IsFolder() const override { return isdir; }
 
+   // return true for hidden files
+   bool IsHidden() const {
+      auto &n = GetName();
+      if ((n.length() == 0) || (n[0] != '.')) return false;
+      return (n != ".") && (n != "..");
+   }
+
    bool Compare(const RItem *b, const std::string &method) const override
    {
       if (IsFolder() != b->IsFolder())

--- a/gui/browsable/inc/ROOT/Browsable/RSysFileItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RSysFileItem.hxx
@@ -45,7 +45,7 @@ public:
    bool IsFolder() const override { return isdir; }
 
    // return true for hidden files
-   bool IsHidden() const {
+   bool IsHidden() const override {
       auto &n = GetName();
       if ((n.length() == 0) || (n[0] != '.')) return false;
       return (n != ".") && (n != "..");

--- a/gui/browsable/inc/ROOT/Browsable/TKeyItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TKeyItem.hxx
@@ -6,8 +6,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_Browsable_TDirectory
-#define ROOT7_Browsable_TDirectory
+#ifndef ROOT7_Browsable_TKeyItem
+#define ROOT7_Browsable_TKeyItem
 
 #include <ROOT/Browsable/RItem.hxx>
 

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -1,0 +1,68 @@
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_Browsable_TObjectElement
+#define ROOT7_Browsable_TObjectElement
+
+#include <ROOT/Browsable/RElement.hxx>
+
+class TObject;
+
+namespace ROOT {
+namespace Experimental {
+namespace Browsable {
+
+
+/** \class TObjectElement
+\ingroup rbrowser
+\brief Access to TObject basic properties for RBrowsable
+\author Sergey Linev <S.Linev@gsi.de>
+\date 2021-01-11
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+
+class TObjectElement : public RElement {
+protected:
+   std::unique_ptr<RHolder> fObject;
+   TObject *fObj{nullptr};
+   std::string fName;
+
+   bool IsSame(TObject *obj) const { return obj == fObj; }
+
+public:
+   TObjectElement(TObject *obj, const std::string &name = "");
+
+   TObjectElement(std::unique_ptr<RHolder> &obj, const std::string &name = "");
+
+   virtual ~TObjectElement() = default;
+
+   /** Name of TObject */
+   std::string GetName() const override;
+
+   void SetName(const std::string &name) { fName = name; }
+
+   /** Title of TObject */
+   std::string GetTitle() const override;
+
+   /** Create iterator for childs elements if any */
+   std::unique_ptr<RLevelIter> GetChildsIter() override;
+
+   /** Return copy of TObject holder - if possible */
+   std::unique_ptr<RHolder> GetObject() override;
+
+   std::string ClassName() const;
+
+};
+
+} // namespace Browsable
+} // namespace Experimental
+} // namespace ROOT
+
+
+#endif

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -59,7 +59,6 @@ public:
    std::unique_ptr<RHolder> GetObject() override;
 
    std::string ClassName() const;
-
 };
 
 } // namespace Browsable

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -35,8 +35,6 @@ protected:
 
    bool IsSame(TObject *obj) const { return obj == fObj; }
 
-   virtual int CanHaveSubSubChilds() const { return -1; }
-
 public:
    TObjectElement(TObject *obj, const std::string &name = "");
 
@@ -51,6 +49,8 @@ public:
 
    /** Title of TObject */
    std::string GetTitle() const override;
+
+   bool IsFolder();
 
    /** Create iterator for childs elements if any */
    std::unique_ptr<RLevelIter> GetChildsIter() override;

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -35,6 +35,8 @@ protected:
 
    bool IsSame(TObject *obj) const { return obj == fObj; }
 
+   virtual int CanHaveSubSubChilds() const { return -1; }
+
 public:
    TObjectElement(TObject *obj, const std::string &name = "");
 

--- a/gui/browsable/src/RElement.cxx
+++ b/gui/browsable/src/RElement.cxx
@@ -10,6 +10,7 @@
 
 #include <ROOT/Browsable/RLevelIter.hxx>
 #include <ROOT/RLogger.hxx>
+#include "TBufferJSON.h"
 
 using namespace ROOT::Experimental::Browsable;
 using namespace std::string_literals;
@@ -41,6 +42,7 @@ RElement::EContentKind RElement::GetContentKind(const std::string &kind)
    if ((lkind == "image") || (lkind == "image64")) return kImage;
    if (lkind == "png") return kPng;
    if ((lkind == "jpg") || (lkind == "jpeg")) return kJpeg;
+   if (lkind == "json") return kJson;
    if (lkind == "filename") return kFileName;
    return kNone;
 }
@@ -65,3 +67,18 @@ std::shared_ptr<RElement> RElement::GetSubElement(std::shared_ptr<RElement> &ele
 
    return curr;
 }
+
+/////////////////////////////////////////////////////////////////////
+/// Returns string content like text file content or json representation
+
+std::string RElement::GetContent(const std::string &kind)
+{
+   if (GetContentKind(kind) == kJson) {
+      auto obj = GetObject();
+      if (obj)
+         return TBufferJSON::ConvertToJSON(obj->GetObject(), obj->GetClass()).Data();
+   }
+
+   return ""s;
+}
+

--- a/gui/browsable/src/RProvider.cxx
+++ b/gui/browsable/src/RProvider.cxx
@@ -227,7 +227,7 @@ bool RProvider::Draw6(TVirtualPad *subpad, std::unique_ptr<RHolder> &object, con
    if (ScanProviderMap<Draw6Map_t, Draw6Map_t::iterator>(GetDraw6Map(), object->GetClass(), false, draw_func))
       return true;
 
-   if (object->GetClass()->InheritsFrom("TLeaf"))
+   if (object->GetClass()->InheritsFrom("TLeaf") || object->GetClass()->InheritsFrom("TBranchElement"))
       gSystem->Load("libROOTLeafDraw6Provider");
    else if (object->GetClass()->InheritsFrom(TObject::Class()))
       gSystem->Load("libROOTObjectDraw6Provider");
@@ -255,7 +255,7 @@ bool RProvider::Draw7(std::shared_ptr<ROOT::Experimental::RPadBase> &subpad, std
 
    // TODO: need factory methods for that
 
-   if (object->GetClass()->InheritsFrom("TLeaf"))
+   if (object->GetClass()->InheritsFrom("TLeaf") || object->GetClass()->InheritsFrom("TBranchElement"))
       gSystem->Load("libROOTLeafDraw7Provider");
    else if (object->GetClass()->InheritsFrom(TObject::Class()))
       gSystem->Load("libROOTObjectDraw7Provider");

--- a/gui/browsable/src/TBranchBrowseProvider.cxx
+++ b/gui/browsable/src/TBranchBrowseProvider.cxx
@@ -16,6 +16,9 @@ using namespace ROOT::Experimental::Browsable;
 
 class TBrElement : public TObjectElement {
 
+protected:
+   int CanHaveSubSubChilds() const override { return 0; }
+
 public:
    TBrElement(std::unique_ptr<RHolder> &br) : TObjectElement(br) {}
 

--- a/gui/browsable/src/TBranchBrowseProvider.cxx
+++ b/gui/browsable/src/TBranchBrowseProvider.cxx
@@ -1,0 +1,49 @@
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/Browsable/TObjectElement.hxx>
+#include <ROOT/Browsable/RProvider.hxx>
+#include <ROOT/Browsable/RLevelIter.hxx>
+
+#include "TBranchElement.h"
+
+using namespace ROOT::Experimental::Browsable;
+
+class TBrElement : public TObjectElement {
+
+public:
+   TBrElement(std::unique_ptr<RHolder> &br) : TObjectElement(br) {}
+
+   virtual ~TBrElement() = default;
+
+   /** Create iterator for childs elements if any */
+   std::unique_ptr<RLevelIter> GetChildsIter() override
+   {
+      TBranchElement *br = const_cast<TBranchElement*> (fObject->Get<TBranchElement>()); // try to cast into TBranchElement
+      if (!br) return nullptr;
+
+      if (br->GetListOfBranches()->GetEntriesFast() > 0)
+         return TObjectElement::GetChildsIter();
+
+      return nullptr;
+   }
+};
+
+// ==============================================================================================
+
+class TBranchBrowseProvider : public RProvider {
+
+public:
+   TBranchBrowseProvider()
+   {
+      RegisterBrowse(TBranchElement::Class(), [](std::unique_ptr<RHolder> &object) -> std::shared_ptr<RElement> {
+         return std::make_shared<TBrElement>(object);
+      });
+   }
+
+} newTBranchBrowseProvider;

--- a/gui/browsable/src/TBranchBrowseProvider.cxx
+++ b/gui/browsable/src/TBranchBrowseProvider.cxx
@@ -16,9 +16,6 @@ using namespace ROOT::Experimental::Browsable;
 
 class TBrElement : public TObjectElement {
 
-protected:
-   int CanHaveSubSubChilds() const override { return 0; }
-
 public:
    TBrElement(std::unique_ptr<RHolder> &br) : TObjectElement(br) {}
 

--- a/gui/browsable/src/TLeafDraw6Provider.cxx
+++ b/gui/browsable/src/TLeafDraw6Provider.cxx
@@ -30,6 +30,21 @@ public:
          return true;
       });
 
+      RegisterDraw6(TBranchElement::Class(), [](TVirtualPad *pad, std::unique_ptr<RHolder> &obj, const std::string &opt) -> bool {
+
+         auto hist = TLeafProvider::DrawBranchElement(obj);
+
+         if (!hist)
+            return false;
+
+         pad->GetListOfPrimitives()->Clear();
+
+         pad->GetListOfPrimitives()->Add(hist, opt.c_str());
+
+         return true;
+      });
+
+
    }
 
 } newTLeafDraw6Provider;

--- a/gui/browsable/src/TLeafDraw7Provider.cxx
+++ b/gui/browsable/src/TLeafDraw7Provider.cxx
@@ -38,6 +38,27 @@ public:
          return true;
       });
 
+      RegisterDraw7(TBranchElement::Class(), [](std::shared_ptr<ROOT::Experimental::RPadBase> &subpad, std::unique_ptr<RHolder> &obj, const std::string &opt) -> bool {
+
+         auto hist = TLeafProvider::DrawBranchElement(obj);
+
+         if (!hist)
+            return false;
+
+         if (subpad->NumPrimitives() > 0) {
+            subpad->Wipe();
+            subpad->GetCanvas()->Modified();
+            subpad->GetCanvas()->Update(true);
+         }
+
+         std::shared_ptr<TH1> shared;
+         shared.reset(hist);
+
+         subpad->Draw<ROOT::Experimental::TObjectDrawable>(shared, opt);
+
+         return true;
+      });
+
    }
 
 } newTLeafDraw7Provider;

--- a/gui/browsable/src/TLeafDraw7Provider.cxx
+++ b/gui/browsable/src/TLeafDraw7Provider.cxx
@@ -35,6 +35,9 @@ public:
 
          subpad->Draw<ROOT::Experimental::TObjectDrawable>(shared, opt);
 
+         subpad->GetCanvas()->Update(true);
+
+
          return true;
       });
 
@@ -55,6 +58,8 @@ public:
          shared.reset(hist);
 
          subpad->Draw<ROOT::Experimental::TObjectDrawable>(shared, opt);
+
+         subpad->GetCanvas()->Update(true);
 
          return true;
       });

--- a/gui/browsable/src/TObjectDraw7Provider.cxx
+++ b/gui/browsable/src/TObjectDraw7Provider.cxx
@@ -33,6 +33,7 @@ public:
          }
 
          subpad->Draw<ROOT::Experimental::TObjectDrawable>(tobj, opt);
+         subpad->GetCanvas()->Update(true);
          return true;
       });
 

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -19,6 +19,7 @@
 #include "TFolder.h"
 #include "TList.h"
 #include "TDirectory.h"
+#include "TBufferJSON.h"
 
 #include <sstream>
 
@@ -176,7 +177,6 @@ std::string TObjectElement::ClassName() const
 {
    return fObj ? fObj->ClassName() : "";
 }
-
 
 // ==============================================================================================
 

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -47,6 +47,7 @@ class RBrowserData {
    bool fLastAllChilds{false};                           ///<! if all chlds were extracted
    std::vector<const Browsable::RItem *> fLastSortedItems;   ///<! sorted child items, used in requests
    std::string fLastSortMethod;                          ///<! last sort method
+   bool fLastSortReverse{false};                         ///<! last request reverse order
 
    Browsable::RElementPath_t DecomposePath(const std::string &path);
 

--- a/gui/browserv7/inc/ROOT/RBrowserRequest.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserRequest.hxx
@@ -29,6 +29,7 @@ public:
    int first{0};     ///< first child to request
    int number{0};    ///< number of childs to request, 0 - all childs
    std::string sort; ///< kind of sorting
+   bool reverse;     ///< reverse item order
    bool hidden;      ///< show hidden files
    std::string regex; ///< applied regex
 };

--- a/gui/browserv7/inc/ROOT/RBrowserRequest.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserRequest.hxx
@@ -29,6 +29,7 @@ public:
    int first{0};     ///< first child to request
    int number{0};    ///< number of childs to request, 0 - all childs
    std::string sort; ///< kind of sorting
+   bool hidden;      ///< show hidden files
    std::string regex; ///< applied regex
 };
 

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -365,13 +365,20 @@ std::shared_ptr<RCanvas> RBrowser::GetActiveRCanvas() const
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 /// Close and delete specified canvas
+/// Check both list of TCanvas and list of RCanvas
 
 void RBrowser::CloseCanvas(const std::string &name)
 {
    auto iter = std::find_if(fCanvases.begin(), fCanvases.end(), [name](std::unique_ptr<TCanvas> &canv) { return name == canv->GetName(); });
-
-   if (iter != fCanvases.end())
+   if (iter != fCanvases.end()) {
       fCanvases.erase(iter);
+   } else {
+      auto iter2 = std::find_if(fRCanvases.begin(), fRCanvases.end(), [name](const std::shared_ptr<RCanvas> &canv) { return name == canv->GetTitle(); });
+      if (iter2 != fRCanvases.end()) {
+         (*iter2)->Remove();
+         fRCanvases.erase(iter2);
+      }
+   }
 
    if (fActiveCanvas == name)
       fActiveCanvas.clear();

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -185,16 +185,19 @@ std::string RBrowser::ProcessDblClick(const std::string &item_path, const std::s
 
    if (drawingOptions == "$$$editor$$$") {
       auto code = elem->GetContent("text");
-      if (code.empty())
-         return ""s;
+      if (!code.empty()) {
+         auto fname = elem->GetContent("filename");
+         if (fname.empty())
+            fname = elem->GetName();
+         std::vector<std::string> args = { fname, code };
 
-      auto fname = elem->GetContent("filename");
-      if (fname.empty())
-         fname = elem->GetName();
+         return "FREAD:"s + TBufferJSON::ToJSON(&args).Data();
+      }
+      auto json = elem->GetContent("json");
+      if (!json.empty())
+         return "JSON:"s + elem->GetName() + "$$$"s + json;
 
-      std::vector<std::string> args = { fname, code };
-
-      return "FREAD:"s + TBufferJSON::ToJSON(&args).Data();
+      return ""s;
    }
 
    if (drawingOptions == "$$$execute$$$") {

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -168,6 +168,10 @@ bool RBrowserData::ProcessBrowserRequest(const RBrowserRequest &request, RBrowse
    int id = 0;
    for (auto &item : fLastSortedItems) {
 
+      // check if element is hidden
+      if (!request.hidden && item->IsHidden())
+         continue;
+
       if (!request.regex.empty() && !item->IsFolder() && !std::regex_match(item->GetName(), expr))
          continue;
 

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -140,7 +140,9 @@ bool RBrowserData::ProcessBrowserRequest(const RBrowserRequest &request, RBrowse
    }
 
    // create sorted array
-   if ((fLastSortedItems.size() != fLastItems.size()) || (fLastSortMethod != request.sort)) {
+   if ((fLastSortedItems.size() != fLastItems.size()) ||
+       (fLastSortMethod != request.sort) ||
+       (fLastSortReverse != request.reverse)) {
       fLastSortedItems.resize(fLastItems.size(), nullptr);
       int id = 0;
       if (request.sort.empty()) {
@@ -160,7 +162,12 @@ bool RBrowserData::ProcessBrowserRequest(const RBrowserRequest &request, RBrowse
             std::sort(fLastSortedItems.begin(), fLastSortedItems.end(),
                       [request](const Browsable::RItem *a, const Browsable::RItem *b) { return a->Compare(b, request.sort); });
       }
+
+      if (request.reverse)
+         std::reverse(fLastSortedItems.begin(), fLastSortedItems.end());
+
       fLastSortMethod = request.sort;
+      fLastSortReverse = request.reverse;
    }
 
    const std::regex expr(request.regex);

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "6/01/2021"*/
-   JSROOT.version_date = "6/01/2021";
+   JSROOT.version_date = "11/01/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -934,6 +934,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    /** @summary Returns frame painter - object itself */
    TFramePainter.prototype.getFramePainter = function() { return this; }
 
+   /** @summary Returns true if it is ROOT6 frame
+     * @private */
+   TFramePainter.prototype.is_root6 = function() { return true; }
+
    /** @summary Returns frame or sub-objects, used in GED editor */
    TFramePainter.prototype.getObject = function(place) {
       if (place === "xaxis") return this.xaxis;
@@ -1538,6 +1542,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       delete this._click_handler;
       delete this._dblclick_handler;
       delete this.enabledKeys;
+
+      let pp = this.getPadPainter();
+      if (pp && (pp.frame_painter_ref === this))
+         delete pp.frame_painter_ref;
 
       JSROOT.ObjectPainter.prototype.cleanup.call(this);
    }
@@ -3106,6 +3114,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       }
 
       if (!isanyfound) {
+         // TODO: maybe just remove frame painter?
          let fp = this.getFramePainter();
          for (let k=0;k<this.painters.length;++k)
             if (fp !== this.painters[k])
@@ -3115,6 +3124,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          if (fp) {
             this.painters.push(fp);
             fp.cleanFrameDrawings();
+            fp.redraw();
          }
          if (this.removePadButtons) this.removePadButtons();
          this.addPadButtons(true);
@@ -3945,7 +3955,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    /** @summary Hanler for websocket close event
      * @private */
    TCanvasPainter.prototype.onWebsocketClosed = function(/*handle*/) {
-      jsrp.closeCurrentWindow();
+      if (!this.embed_canvas)
+         jsrp.closeCurrentWindow();
    }
 
    /** @summary Handle websocket messages

--- a/js/scripts/JSRoot.jq2d.js
+++ b/js/scripts/JSRoot.jq2d.js
@@ -11,8 +11,8 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
 
    let BrowserLayout = JSROOT.BrowserLayout;
 
-   /// set browser title text
-   /// Title also used for dragging of the float browser
+   /** @summary Set browser title text
+     * @desc Title also used for dragging of the float browser */
    BrowserLayout.prototype.setBrowserTitle = function(title) {
       let main = d3.select("#" + this.gui_div + " .jsroot_browser");
       if (!main.empty())
@@ -577,7 +577,7 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
    /** @summary Toggle open state of the item
      * @desc Used with "open all" / "close all" buttons in normal GUI
      * @param {boolean} isopen - if items should be expand or closed
-     * @returns {boolean} tru when any item was changed */
+     * @returns {boolean} true when any item was changed */
    HierarchyPainter.prototype.toggleOpenState = function(isopen, h) {
       let hitem = h || this.h;
 
@@ -2036,13 +2036,13 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
       return player;
    }
 
-   /** function used with THttpServer when tree is not yet loaded
+   /** @summary function used with THttpServer when tree is not yet loaded
      * @private */
    JSROOT.drawTreePlayerKey = function(hpainter, itemname) {
       return JSROOT.drawTreePlayer(hpainter, itemname, true);
    }
 
-   /** function used with THttpServer when tree is not yet loaded
+   /** @summary function used with THttpServer when tree is not yet loaded
      * @private */
    JSROOT.drawLeafPlayer = function(hpainter, itemname) {
       return JSROOT.drawTreePlayer(hpainter, itemname, false, true);

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -2408,10 +2408,10 @@ JSROOT.define(['d3'], (d3) => {
    ObjectPainter.prototype.startTextDrawing = function(font_face, font_size, draw_g, max_font_size) {
 
       if (!draw_g) draw_g = this.draw_g;
+      if (!draw_g || draw_g.empty()) return;
 
-      let font = (font_size === 'font') ? font_face : new FontHandler(font_face, font_size);
-
-      let pp = this.getPadPainter();
+      let font = (font_size === 'font') ? font_face : new FontHandler(font_face, font_size),
+          pp = this.getPadPainter();
 
       draw_g.call(font.func);
 
@@ -2421,7 +2421,7 @@ JSROOT.define(['d3'], (d3) => {
             .property('text_factor', 0.)
             .property('max_text_width', 0) // keep maximal text width, use it later
             .property('max_font_size', max_font_size)
-            .property("_fast_drawing", pp && pp._fast_drawing);
+            .property("_fast_drawing", pp ? pp._fast_drawing : false);
 
       if (draw_g.property("_fast_drawing"))
          draw_g.property("_font_too_small", (max_font_size && (max_font_size < 5)) || (font.size < 4));
@@ -2434,6 +2434,7 @@ JSROOT.define(['d3'], (d3) => {
      * @protected */
    ObjectPainter.prototype.scaleTextDrawing = function(factor, draw_g) {
       if (!draw_g) draw_g = this.draw_g;
+      if (!draw_g || draw_g.empty()) return;
       if (factor && (factor > draw_g.property('text_factor')))
          draw_g.property('text_factor', factor);
    }
@@ -2594,6 +2595,7 @@ JSROOT.define(['d3'], (d3) => {
       if (!arg.text) arg.text = "";
 
       arg.draw_g = arg.draw_g || this.draw_g;
+      if (!arg.draw_g || arg.draw_g.empty()) return;
 
       let font = arg.draw_g.property('text_font');
       arg.font = font; // use in latex conversion
@@ -2711,6 +2713,9 @@ JSROOT.define(['d3'], (d3) => {
      * @protected */
    ObjectPainter.prototype.finishTextDrawing = function(draw_g) {
       if (!draw_g) draw_g = this.draw_g;
+      if (!draw_g || draw_g.empty())
+         return Promise.resolve(false);
+
       draw_g.property('draw_text_completed', true); // mark that text drawing is completed
 
       return new Promise(resolveFunc => {

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -75,9 +75,82 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
         this.globalId = 1;
         this.nextElem = "";
-        this.DBLCLKRun = false;
 
-         this.websocket = this.getView().getViewData().conn_handle;
+        this._oSettingsModel = new JSONModel({
+            ShowHiddenFiles: false,
+            DBLCLKRun: false,
+            TH1: [
+               {name: "hist"},
+               {name: "P"},
+               {name: "P0"},
+               {name: "E"},
+               {name: "E1"},
+               {name: "E2"},
+               {name: "E3"},
+               {name: "E4"},
+               {name: "E1X0"},
+               {name: "L"},
+               {name: "LF2"},
+               {name: "B"},
+               {name: "B1"},
+               {name: "A"},
+               {name: "TEXT"},
+               {name: "LEGO"},
+               {name: "same"}
+            ],
+            TH2: [
+               {name: "COL"},
+               {name: "COLZ"},
+               {name: "COL0"},
+               {name: "COL1"},
+               {name: "COL0Z"},
+               {name: "COL1Z"},
+               {name: "COLA"},
+               {name: "BOX"},
+               {name: "BOX1"},
+               {name: "PROJ"},
+               {name: "PROJX1"},
+               {name: "PROJX2"},
+               {name: "PROJX3"},
+               {name: "PROJY1"},
+               {name: "PROJY2"},
+               {name: "PROJY3"},
+               {name: "SCAT"},
+               {name: "TEXT"},
+               {name: "TEXTE"},
+               {name: "TEXTE0"},
+               {name: "CONT"},
+               {name: "CONT1"},
+               {name: "CONT2"},
+               {name: "CONT3"},
+               {name: "CONT4"},
+               {name: "ARR"},
+               {name: "SURF"},
+               {name: "SURF1"},
+               {name: "SURF2"},
+               {name: "SURF4"},
+               {name: "SURF6"},
+               {name: "E"},
+               {name: "A"},
+               {name: "LEGO"},
+               {name: "LEGO0"},
+               {name: "LEGO1"},
+               {name: "LEGO2"},
+               {name: "LEGO3"},
+               {name: "LEGO4"},
+               {name: "same"}
+            ],
+            TProfile: [
+               {name: "E0"},
+               {name: "E1"},
+               {name: "E2"},
+               {name: "p"},
+               {name: "AH"},
+               {name: "hist"}
+            ]
+         });
+
+        this.websocket = this.getView().getViewData().conn_handle;
 
          // this is code for the Components.js
          // this.websocket = Component.getOwnerComponentFor(this.getView()).getComponentData().conn_handle;
@@ -355,7 +428,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          }
       },
 
-      /** @brief Extract the file name and extension
+      /** @summary Extract the file name and extension
        * @desc Used to set the editor's model properties and display the file name on the tab element  */
       setFileNameType: function (oEditor, fullname) {
          let oModel = oEditor.getModel();
@@ -440,7 +513,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          return true;
       },
 
-      /** @brief Handle the "Browse..." button press event */
+      /** @summary Handle the "Browse..." button press event */
       onChangeFile: function (oEvent) {
          let oEditor = this.getSelectedCodeEditor();
          if (!oEditor) return;
@@ -512,84 +585,14 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       /* ============================================= */
 
       _getSettingsMenu: async function () {
+
          if (!this._oSettingsMenu) {
             let fragment;
             await Fragment.load({name: "rootui5.browser.view.settingsmenu", controller: this}).then(function (oSettingsMenu) {
                fragment = oSettingsMenu;
             });
             if (fragment) {
-               let oModel = new JSONModel({
-                  "TH1": [
-                     {"name": "hist"},
-                     {"name": "P"},
-                     {"name": "P0"},
-                     {"name": "E"},
-                     {"name": "E1"},
-                     {"name": "E2"},
-                     {"name": "E3"},
-                     {"name": "E4"},
-                     {"name": "E1X0"},
-                     {"name": "L"},
-                     {"name": "LF2"},
-                     {"name": "B"},
-                     {"name": "B1"},
-                     {"name": "A"},
-                     {"name": "TEXT"},
-                     {"name": "LEGO"},
-                     {"name": "same"}
-                  ],
-                  "TH2": [
-                     {"name": "COL"},
-                     {"name": "COLZ"},
-                     {"name": "COL0"},
-                     {"name": "COL1"},
-                     {"name": "COL0Z"},
-                     {"name": "COL1Z"},
-                     {"name": "COLA"},
-                     {"name": "BOX"},
-                     {"name": "BOX1"},
-                     {"name": "PROJ"},
-                     {"name": "PROJX1"},
-                     {"name": "PROJX2"},
-                     {"name": "PROJX3"},
-                     {"name": "PROJY1"},
-                     {"name": "PROJY2"},
-                     {"name": "PROJY3"},
-                     {"name": "SCAT"},
-                     {"name": "TEXT"},
-                     {"name": "TEXTE"},
-                     {"name": "TEXTE0"},
-                     {"name": "CONT"},
-                     {"name": "CONT1"},
-                     {"name": "CONT2"},
-                     {"name": "CONT3"},
-                     {"name": "CONT4"},
-                     {"name": "ARR"},
-                     {"name": "SURF"},
-                     {"name": "SURF1"},
-                     {"name": "SURF2"},
-                     {"name": "SURF4"},
-                     {"name": "SURF6"},
-                     {"name": "E"},
-                     {"name": "A"},
-                     {"name": "LEGO"},
-                     {"name": "LEGO0"},
-                     {"name": "LEGO1"},
-                     {"name": "LEGO2"},
-                     {"name": "LEGO3"},
-                     {"name": "LEGO4"},
-                     {"name": "same"}
-                  ],
-                  "TProfile": [
-                     {"name": "E0"},
-                     {"name": "E1"},
-                     {"name": "E2"},
-                     {"name": "p"},
-                     {"name": "AH"},
-                     {"name": "hist"}
-                  ]
-               });
-               fragment.setModel(oModel);
+               fragment.setModel(this._oSettingsModel);
                this.getView().addDependent(fragment);
                this._oSettingsMenu = fragment;
             }
@@ -598,8 +601,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       },
 
       onSettingPress: async function () {
-         await this._getSettingsMenu();
-         this._oSettingsMenu.open();
+         let menu = await this._getSettingsMenu();
+         menu.open();
       },
 
       handleSettingsChange: function (oEvent) {
@@ -607,8 +610,15 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          this.drawingOptions[graphType] = oEvent.getSource().mProperties.value;
       },
 
-      settingsDBLCLKRun: function(oEvent) {
-         this.DBLCLKRun = oEvent.getSource().getSelected();
+      handleSeetingsConfirm: function() {
+         let was_hidden = this.model.isShowHidden(),
+             is_hidden = this._oSettingsModel.getProperty("/ShowHiddenFiles");
+
+         if (was_hidden != is_hidden) {
+            console.log('RELOAD MODEL!!!');
+            this.model.setShowHidden(is_hidden);
+            this.doReload(true);
+         }
       },
 
       /* ============================================= */
@@ -619,7 +629,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       /* =============== Tabs menu =============== */
       /* ========================================= */
 
-      /** @brief Add Tab event handler */
+      /** @summary Add Tab event handler */
       addNewButtonPressHandler: async function (oEvent) {
          //TODO: Change to some UI5 function (unknown for now)
          let oButton = oEvent.getSource().mAggregations._tabStrip.mAggregations.addButton;
@@ -831,7 +841,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       /* =============== ToolHeader =============== */
       /* ========================================== */
 
-      /** @brief Assign the "double click" event handler to each row */
+      /** @summary Assign the "double click" event handler to each row */
       assignRowHandlers: function () {
          var rows = this.byId("treeTable").getRows();
          for (var k = 0; k < rows.length; ++k) {
@@ -840,7 +850,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       },
 
       sendDblClick: function (fullpath, opt) {
-         if(this.DBLCLKRun) {
+         if(this._oSettingsModel.getProperty("/DBLCLKRun")) {
             if(opt !== '$$$editor$$$') {
                opt = '$$$execute$$$';
                console.log(fullpath);
@@ -849,7 +859,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          this.websocket.send('DBLCLK: ["' + fullpath + '","' + (opt || "") + '"]');
       },
 
-      /** @brief Double-click event handler */
+      /** @summary Double-click event handler */
       onRowDblClick: function (row) {
          let ctxt = row.getBindingContext(),
             prop = ctxt ? ctxt.getProperty(ctxt.getPath()) : null,
@@ -929,7 +939,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          this.isConnected = false;
       },
 
-     /** Entry point for all data from server */
+     /** @summary Entry point for all data from server */
      onWebsocketMsg: function(handle, msg, offset) {
 
          if (typeof msg != "string")
@@ -1009,13 +1019,13 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          }
       },
 
-      /** Get the ID of the currently selected tab of given tab container */
+      /** @summary Get the ID of the currently selected tab of given tab container */
       getSelectedtabFromtabContainer: function(divid) {
-         var  tabContainer = this.getView().byId('myTabContainer').getSelectedItem();
+         let tabContainer = this.getView().byId('myTabContainer').getSelectedItem();
          return tabContainer.slice(6, tabContainer.length);
       },
 
-      /** Show special message instead of nodes hierarchy */
+      /** @summary Show special message instead of nodes hierarchy */
       showTextInBrowser: function(text) {
          var br = this.byId("treeTable");
          br.collapseAll();
@@ -1046,7 +1056,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          // oSplitApp.getAggregation("_navMaster").$().css("width", "400px");
       },
 
-      /** Reload (refresh) file tree browser */
+      /** @summary Reload (refresh) file tree browser */
       onRealoadPress: function (oEvent) {
          this.doReload(true);
       },
@@ -1061,7 +1071,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          }
       },
 
-      /** Quit ROOT session */
+      /** @summary Quit ROOT session */
       onQuitRootPress: function(oEvent) {
          this.websocket.send("QUIT_ROOT");
       },
@@ -1070,7 +1080,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          this.changeItemsFilter(oEvt.getSource().getValue());
       },
 
-      /** Submit node search query to server, ignore in offline case */
+      /** @summary Submit node search query to server, ignore in offline case */
       changeItemsFilter: function(query, from_handler) {
 
          if (!from_handler) {

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -77,6 +77,13 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
         this.nextElem = "";
 
         this._oSettingsModel = new JSONModel({
+            SortMethods: [
+               { name: "name", value: "name" },
+               { name: "size", value: "size" },
+               { name: "none", value: "" }
+            ],
+            SortMethod: "name",
+            ReverseOrder: false,
             ShowHiddenFiles: false,
             DBLCLKRun: false,
             TH1: [
@@ -602,6 +609,11 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
       onSettingPress: async function () {
          let menu = await this._getSettingsMenu();
+
+         this._oSettingsModel.setProperty("/ShowHiddenFiles", this.model.isShowHidden());
+         this._oSettingsModel.setProperty("/SortMethod", this.model.getSortMethod());
+         this._oSettingsModel.setProperty("/ReverseOrder", this.model.isReverseOrder());
+
          menu.open();
       },
 
@@ -611,12 +623,28 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       },
 
       handleSeetingsConfirm: function() {
-         let was_hidden = this.model.isShowHidden(),
-             is_hidden = this._oSettingsModel.getProperty("/ShowHiddenFiles");
+         let hidden = this._oSettingsModel.getProperty("/ShowHiddenFiles"),
+             sort = this._oSettingsModel.getProperty("/SortMethod"),
+             reverse = this._oSettingsModel.getProperty("/ReverseOrder"),
+             changed = false;
 
-         if (was_hidden != is_hidden) {
-            console.log('RELOAD MODEL!!!');
-            this.model.setShowHidden(is_hidden);
+         if (hidden != this.model.isShowHidden()) {
+            changed = true;
+            this.model.setShowHidden(hiden);
+         }
+
+         if (reverse != this.model.isReverseOrder()) {
+            changed = true;
+            this.model.setReverseOrder(reverse);
+         }
+
+         if (sort != this.model.getSortMethod()) {
+            changed = true;
+            this.model.setSortMethod(sort);
+         }
+
+         if (changed) {
+            console.log('Settings changes - reload MODEL!!!');
             this.doReload(true);
          }
       },

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -765,15 +765,14 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             if (count <= 1) {
                MessageToast.show("Sorry, you cannot close the Code Editor", {duration: 1500});
             } else {
-               this.saveCheck(function ()  {oTabContainer.removeItem(oItemToClose);});
+               this.saveCheck(() => oTabContainer.removeItem(oItemToClose));
             }
          } else {
-            let pthis = this;
             MessageBox.confirm('Do you really want to close the "' + oItemToClose.getName() + '" tab?', {
-               onClose: function (oAction) {
+               onClose: oAction => {
                   if (oAction === MessageBox.Action.OK) {
                      if (oItemToClose.getName() === "ROOT Canvas")
-                        pthis.websocket.send("CLOSE_CANVAS:" + oItemToClose.getAdditionalText());
+                        this.websocket.send("CLOSE_CANVAS:" + oItemToClose.getAdditionalText());
 
                      oTabContainer.removeItem(oItemToClose);
 

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -979,19 +979,28 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          case "INMSG":
             this.processInitMsg(msg);
             break;
-         case "FREAD":  // text file read
-            var oEditor = this.getSelectedCodeEditor();
+         case "FREAD": { // text file read
+            let oEditor = this.getSelectedCodeEditor();
 
             if (oEditor) {
-               var arr = JSON.parse(msg);
-
+               let arr = JSON.parse(msg);
                this.setFileNameType(oEditor, arr[0]);
-
                oEditor.getModel().setProperty("/code", arr[1]);
-
                this.getElementFromCurrentTab("Save").setEnabled(true);
             }
             break;
+         }
+         case "JSON": { // json file read
+            let oEditor = this.getSelectedCodeEditor();
+            if (oEditor) {
+               let p = msg.indexOf("$$$"); // name and json separated by $$$
+               this.setFileNameType(oEditor, msg.substr(0, p) + ".json");
+               oEditor.getModel().setProperty("/code", msg.substr(p+3));
+               this.getElementFromCurrentTab("Save").setEnabled(true);
+            }
+            break;
+         }
+
          case "FIMG":  // image file read
             const oViewer = this.getSelectedImageViewer(true);
             if(oViewer) {
@@ -1140,8 +1149,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          console.log("Create canvas ", url, name);
          if (!url || !name) return;
 
-         var oTabContainer = this.byId("myTabContainer");
-         var oTabContainerItem = new TabContainerItem({
+         let oTabContainer = this.byId("myTabContainer");
+         let oTabContainerItem = new TabContainerItem({
             name: "ROOT Canvas",
             icon: "sap-icon://column-chart-dual-axis"
          });
@@ -1152,13 +1161,13 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
          // Change the selected tabs, only if it is new one, not the basic one
          if(name !== "rcanv1") {
-           oTabContainer.setSelectedItem(oTabContainerItem);
+            oTabContainer.setSelectedItem(oTabContainerItem);
          }
 
-         var conn = new JSROOT.WebWindowHandle(this.websocket.kind);
+         let conn = new JSROOT.WebWindowHandle(this.websocket.kind);
 
          // this is producing
-         var addr = this.websocket.href, relative_path = url;
+         let addr = this.websocket.href, relative_path = url;
          if (relative_path.indexOf("../")==0) {
             var ddd = addr.lastIndexOf("/",addr.length-2);
             addr = addr.substr(0,ddd) + relative_path.substr(2);
@@ -1174,7 +1183,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             painter = new JSROOT.TCanvasPainter(null, null);
          }
 
-         painter.online_canvas = true;
+         painter.online_canvas = true; // indicates that canvas gets data from running server
+         painter.embed_canvas = true;  // use to indicate that canvas ui should not close complete window when closing
          painter.use_openui = true;
          painter.batch_mode = false;
          painter._window_handle = conn;

--- a/ui5/browser/model/BrowserModel.js
+++ b/ui5/browser/model/BrowserModel.js
@@ -21,7 +21,8 @@ sap.ui.define([
 
             this.loadDataCounter = 0; // counter of number of nodes
 
-            this.sortOrder = "";
+            this.sortMethod = "name"; // "name", "size"
+            this.reverseOrder = false;
             this.itemsFilter = "";
             this.showHidden = false;
 
@@ -32,15 +33,23 @@ sap.ui.define([
            this.treeTable = t;
         },
 
+        /** @summary Set sort method */
+        setSortMethod: function(arg) { this.sortMethod = arg; },
+
+        /** @summary Get sort method */
+        getSortMethod: function() { return this.sortMethod; },
+
         /** @summary Set show hidden flag */
-        setShowHidden: function(flag) {
-           this.showHidden = flag;
-        },
+        setShowHidden: function(flag) { this.showHidden = flag; },
 
         /** @summary Is show hidden flag set */
-        isShowHidden: function() {
-           return this.showHidden;
-        },
+        isShowHidden: function() { return this.showHidden; },
+
+        /** @summary Set reverse order */
+        setReverseOrder: function(on) { this.reverseOrder = on; },
+
+        /** @summary Is reverse order */
+        isReverseOrder: function() { return this.reverseOrder; },
 
         /** @summary Set full model
           * @desc Method can be used when complete hierarchy is ready and can be used directly */
@@ -207,7 +216,8 @@ sap.ui.define([
               path: path,
               first: first || 0,
               number: number || this.threshold || 100,
-              sort: this.sortOrder || "",
+              sort: this.sortMethod || "",
+              reverse: this.reverseOrder || false,
               hidden: this.showHidden ? true : false,
               regex: this.itemsFilter ? "^(" + this.itemsFilter + ".*)$" : ""
            };
@@ -487,29 +497,6 @@ sap.ui.define([
 
               return true;
            }
-        },
-
-        // change sorting method, for now server supports default, "direct" and "reverse"
-        changeSortOrder: function(newValue) {
-           if (newValue === undefined)
-               newValue = this.getProperty("/sortOrder") || "";
-
-           if ((newValue !== "") && (newValue !=="direct") && (newValue !== "reverse")) {
-              console.error('WRONG sorting order ', newValue, 'use default');
-              newValue = "";
-           }
-
-           // ignore same value
-           if (newValue === this.sortOrder)
-              return;
-
-
-           this.sortOrder = newValue;
-
-           // now we should request values once again
-
-           this.submitRequest(this.h, "/");
-
         },
 
         changeItemsFilter: function(newValue) {

--- a/ui5/browser/model/BrowserModel.js
+++ b/ui5/browser/model/BrowserModel.js
@@ -23,6 +23,7 @@ sap.ui.define([
 
             this.sortOrder = "";
             this.itemsFilter = "";
+            this.showHidden = false;
 
             this.threshold = 100; // default threshold to prefetch items
         },
@@ -31,7 +32,18 @@ sap.ui.define([
            this.treeTable = t;
         },
 
-        /* Method can be used when complete hierarchy is ready and can be used directly */
+        /** @summary Set show hidden flag */
+        setShowHidden: function(flag) {
+           this.showHidden = flag;
+        },
+
+        /** @summary Is show hidden flag set */
+        isShowHidden: function() {
+           return this.showHidden;
+        },
+
+        /** @summary Set full model
+          * @desc Method can be used when complete hierarchy is ready and can be used directly */
         setFullModel: function(topnode) {
            this.fullModel = true;
            if (topnode.length) {
@@ -56,6 +68,7 @@ sap.ui.define([
               this.oBinding.checkUpdate(true);
         },
 
+        /** @summary Clear full model */
         clearFullModel: function() {
            if (!this.fullModel) return;
 
@@ -109,7 +122,8 @@ sap.ui.define([
            return curr;
         },
 
-        /** expand node by given path, when path not exists - try to send request */
+        /** @summary expand node by given path
+          * @desc When path not exists - try to send request */
         expandNodeByPath: function(path) {
            if (!path || (typeof path !== "string") || (path == "/")) return -1;
 
@@ -175,8 +189,8 @@ sap.ui.define([
 
         },
 
-        // submit next request to the server
-        // directly use web socket, later can be dedicated channel
+        /** @summary submit next request to the server
+          * @desc directly use web socket, later can be dedicated channel */
         submitRequest: function(elem, path, first, number) {
            if (first === "expanding") {
               first = 0;
@@ -184,17 +198,17 @@ sap.ui.define([
               delete this._expanding_path;
            }
 
-
            if (!this._websocket || elem._requested || this.fullModel) return;
            elem._requested = true;
 
            this.loadDataCounter++;
 
-           var request = {
+           let request = {
               path: path,
               first: first || 0,
               number: number || this.threshold || 100,
               sort: this.sortOrder || "",
+              hidden: this.showHidden ? true : false,
               regex: this.itemsFilter ? "^(" + this.itemsFilter + ".*)$" : ""
            };
            this._websocket.send("BRREQ:" + JSON.stringify(request));

--- a/ui5/browser/view/settingsmenu.fragment.xml
+++ b/ui5/browser/view/settingsmenu.fragment.xml
@@ -59,6 +59,13 @@
       <ViewSettingsCustomTab icon="sap-icon://action-settings" >
         <content>
           <VBox>
+            <HBox>
+               <Label text="Sorting" wrapping="true" />
+               <ComboBox items="{ path: '/SortMethods' }" selectedKey="{/SortMethod}">
+                   <core:Item text="{name}" key="{value}"/>
+               </ComboBox>
+            </HBox>
+            <CheckBox text="Reverse order" selected="{/ReverseOrder}" />
             <CheckBox text="Show hidden files" selected="{/ShowHiddenFiles}" />
             <CheckBox text="Double click to run macro" selected="{/DBLCLKRun}" />
           </VBox>

--- a/ui5/browser/view/settingsmenu.fragment.xml
+++ b/ui5/browser/view/settingsmenu.fragment.xml
@@ -1,5 +1,5 @@
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:l="sap.ui.layout" xmlns:f="sap.ui.layout.form">
-  <ViewSettingsDialog>
+  <ViewSettingsDialog confirm="handleSeetingsConfirm">
     <customTabs>
       <ViewSettingsCustomTab id="drawing-options" icon="sap-icon://signature" text="Drawing options" title="Drawing options" tooltip="Drawing options">
         <content>
@@ -59,7 +59,8 @@
       <ViewSettingsCustomTab icon="sap-icon://action-settings" >
         <content>
           <VBox>
-            <CheckBox text="Double click to run macro" select="settingsDBLCLKRun" />
+            <CheckBox text="Show hidden files" selected="{/ShowHiddenFiles}" />
+            <CheckBox text="Double click to run macro" selected="{/DBLCLKRun}" />
           </VBox>
         </content>
       </ViewSettingsCustomTab>


### PR DESCRIPTION
1. Do not show hidden files by default (can be changed via settings)
2. Sort items by names by default (can be changed via settings)
3. Let sort by name, by size or kept items unsorted
4. Items can be shown in reverse order (can be configure via settings)
5. Fix - do not open same file twice
6. Fix - let draw other object on same RCanvas/TCanvas (was broken due to jsroot v6 migration)
7. Fix - do not close RBrowser when embed RCanvas closed via menu command
8. Let browse and draw trees with `TBranchElement` branches (like example file from @eguiraud)
9. Show object JSON when double-click object with active code editor
10. Update JSROOT with correspondent RCanvas/TWebCanvas fixes, close to final 6.0.0 version