### PR TITLE
Fix errors due to unresolved GetPoolSize

### DIFF
--- a/core/base/inc/ROOT/TExecutorCRTP.hxx
+++ b/core/base/inc/ROOT/TExecutorCRTP.hxx
@@ -145,12 +145,6 @@ public:
    template<class T> T* Reduce(const std::vector<T*> &mergeObjs);
    template<class T, class R> auto Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
 
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Return the number of pooled workers.
-   ///
-   /// \return The number of workers in the pool.
-   unsigned GetPoolSize() const = delete; // must be implemented in derived class
-
 private:
 
    SubC &Derived()

--- a/core/imt/inc/ROOT/TExecutor.hxx
+++ b/core/imt/inc/ROOT/TExecutor.hxx
@@ -448,7 +448,7 @@ auto TExecutor::MapReduce(F func, const std::vector<T> &args, R redfunc, unsigne
 ///
 /// \return The number of workers in the pool in the executor used as a backend.
 
-unsigned TExecutor::GetPoolSize() const
+inline unsigned TExecutor::GetPoolSize() const
 {
    unsigned poolSize{0u};
    switch(fExecPolicy){


### PR DESCRIPTION
The definition of `TExecutor::GetPoolSize()` causes errors in builds with `runtime_cxxmodules=OFF`:
```
IncrementalExecutor::executeFunction: symbol '_ZNK4ROOT15TThreadExecutor11GetPoolSizeEv' unresolved while linking symbol 'atexit'!
You are probably missing the definition of ROOT::TThreadExecutor::GetPoolSize() const
Maybe you need to load the corresponding shared library?
atexit not defined
```