### PR TITLE
Fix rint testing when Browsable::TObjectElement compiled

### DIFF
--- a/core/rint/test/TTabComTests.cxx
+++ b/core/rint/test/TTabComTests.cxx
@@ -103,5 +103,5 @@ TEST(TTabComTests, CompleteTObj)
    // FIXME: See ROOT-10989
    ASSERT_STREQ(expected.c_str(), GetCompletions("TObj",
                                                  /*ignore=*/{"TObjectDisplayItem", "TObjectDrawable", "TObjectHolder",
-                                                             "TObjectItem"}).c_str());
+                                                             "TObjectItem", "TObjectElement"}).c_str());
 }


### PR DESCRIPTION
In principle, it should not appear in "TObj" completion at all,
but just let ignore it for the moment