### PR TITLE
Fix a memory leak in TF1::Copy

### DIFF
--- a/hist/hist/inc/LinkDef.h
+++ b/hist/hist/inc/LinkDef.h
@@ -38,6 +38,7 @@
 #pragma link C++ class TF1AbsComposition + ;
 #pragma link C++ class TF1Convolution + ;
 #pragma link C++ class TF1NormSum + ;
+#pragma link C++ class TF1::TF1FunctorPointer + ;
 #pragma link C++ class std::vector < std::unique_ptr < TF1 >> +;
 #pragma link C++ class std::vector < std::unique_ptr < TF1AbsComposition >> +;
 #pragma link C++ class TF2-;

--- a/hist/hist/inc/LinkDef.h
+++ b/hist/hist/inc/LinkDef.h
@@ -38,7 +38,6 @@
 #pragma link C++ class TF1AbsComposition + ;
 #pragma link C++ class TF1Convolution + ;
 #pragma link C++ class TF1NormSum + ;
-#pragma link C++ class TF1::TF1FunctorPointer + ;
 #pragma link C++ class std::vector < std::unique_ptr < TF1 >> +;
 #pragma link C++ class std::vector < std::unique_ptr < TF1AbsComposition >> +;
 #pragma link C++ class TF2-;

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -223,13 +223,13 @@ public:
       kNo
    };
 
-protected:
 
    struct TF1FunctorPointer {
       virtual  ~TF1FunctorPointer() {}
       virtual  TF1FunctorPointer * Clone() const = 0;
    };
 
+protected:
 
    enum EFType {
       kFormula = 0,      // formula functions which can be stored,
@@ -268,7 +268,7 @@ protected:
    std::unique_ptr<TFormula>   fFormula;        //Pointer to TFormula in case when user define formula
    std::unique_ptr<TF1Parameters> fParams;   //Pointer to Function parameters object (exists only for not-formula functions)
    std::unique_ptr<TF1AbsComposition> fComposition; //Pointer to composition (NSUM or CONV)
-   //TF1AbsComposition *fComposition_ptr{nullptr};   // saved pointer (unique_ptr is transient)
+   TF1AbsComposition *fComposition_ptr{nullptr};   //saved pointer (unique_ptr is transient)
 
    /// General constructor for TF1. Most of the other constructors delegate on it
    TF1(EFType functionType, const char *name, Double_t xmin, Double_t xmax, Int_t npar, Int_t ndim, EAddToList addToGlobList, TF1Parameters *params = nullptr, TF1FunctorPointer * functor = nullptr):

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -798,7 +798,7 @@ inline T TF1::EvalParTempl(const T *data, const Double_t *params)
    assert(fType == EFType::kTemplScalar || fType == EFType::kTemplVec);
    if (!params) params = (Double_t *)fParams->GetParameters();
    if (fFunctor)
-      return ((TF1FunctorPointerImpl<T> *)fFunctor)->fImpl(data, params);
+      return ((TF1FunctorPointerImpl<T> *)fFunctor.get())->fImpl(data, params);
 
    // this should throw an error
    // we nned to implement a vectorized GetSave(x)
@@ -818,7 +818,7 @@ inline double TF1::EvalParVec(const Double_t *data, const Double_t *params)
    }
 
    if (fFunctor) {
-      res = ((TF1FunctorPointerImpl<ROOT::Double_v> *) fFunctor)->fImpl(d.data(), params);
+      res = ((TF1FunctorPointerImpl<ROOT::Double_v> *) fFunctor.get())->fImpl(d.data(), params);
    } else {
       //    res = GetSave(x);
       return TMath::SignalingNaN();

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 #include "TFormula.h"
+#include "TMethodCall.h"
 #include "TAttLine.h"
 #include "TAttFill.h"
 #include "TAttMarker.h"
@@ -38,7 +39,6 @@
 class TF1;
 class TH1;
 class TAxis;
-class TMethodCall;
 class TRandom;
 
 namespace ROOT {
@@ -261,22 +261,24 @@ protected:
    std::vector<Double_t>    fGamma;      //!Array gamma.
    TObject     *fParent{nullptr};     //!Parent object hooking this function (if one)
    TH1         *fHistogram{nullptr};  //!Pointer to histogram used for visualisation
-   TMethodCall *fMethodCall{nullptr}; //!Pointer to MethodCall in case of interpreted function
+   std::unique_ptr<TMethodCall> fMethodCall; //!Pointer to MethodCall in case of interpreted function
    Bool_t      fNormalized{false};    //Normalization option (false by default)
    Double_t    fNormIntegral{};        //Integral of the function before being normalized
-   TF1FunctorPointer  *fFunctor{nullptr}; //! Functor object to wrap any C++ callable object
-   TFormula    *fFormula{nullptr};        //Pointer to TFormula in case when user define formula
-   TF1Parameters *fParams{nullptr};   //Pointer to Function parameters object (exists only for not-formula functions)
-   std::unique_ptr<TF1AbsComposition> fComposition; //! Pointer to composition (NSUM or CONV)
-   TF1AbsComposition *fComposition_ptr{nullptr};   // saved pointer (unique_ptr is transient)
+   std::unique_ptr<TF1FunctorPointer>  fFunctor; //! Functor object to wrap any C++ callable object
+   std::unique_ptr<TFormula>   fFormula;        //Pointer to TFormula in case when user define formula
+   std::unique_ptr<TF1Parameters> fParams;   //Pointer to Function parameters object (exists only for not-formula functions)
+   std::unique_ptr<TF1AbsComposition> fComposition; //Pointer to composition (NSUM or CONV)
+   //TF1AbsComposition *fComposition_ptr{nullptr};   // saved pointer (unique_ptr is transient)
 
    /// General constructor for TF1. Most of the other constructors delegate on it
    TF1(EFType functionType, const char *name, Double_t xmin, Double_t xmax, Int_t npar, Int_t ndim, EAddToList addToGlobList, TF1Parameters *params = nullptr, TF1FunctorPointer * functor = nullptr):
       TNamed(name, name), TAttLine(), TAttFill(), TAttMarker(), fXmin(xmin), fXmax(xmax), fNpar(npar), fNdim(ndim),
-      fType(functionType), fParErrors(npar), fParMin(npar), fParMax(npar), fFunctor(functor), fParams(params)
+      fType(functionType), fParErrors(npar), fParMin(npar), fParMax(npar)
    {
+      fParams.reset(params);
+      fFunctor.reset(functor);
       DoInitialize(addToGlobList);
-   };
+   }
 
 private:
    // NSUM parsing helper functions
@@ -451,11 +453,11 @@ public:
    }
    virtual TFormula *GetFormula()
    {
-      return fFormula;
+      return fFormula.get();
    }
    virtual const TFormula *GetFormula() const
    {
-      return fFormula;
+      return fFormula.get();
    }
    virtual TString  GetExpFormula(Option_t *option = "") const
    {
@@ -492,7 +494,7 @@ public:
    }
    TMethodCall    *GetMethodCall() const
    {
-      return fMethodCall;
+      return fMethodCall.get();
    }
    virtual Int_t    GetNumber() const
    {
@@ -710,7 +712,7 @@ private:
    inline double EvalParVec(const Double_t *data, const Double_t *params);
 #endif
 
-   ClassDef(TF1, 10) // The Parametric 1-D function
+   ClassDef(TF1, 11) // The Parametric 1-D function
 };
 
 namespace ROOT {
@@ -721,8 +723,8 @@ namespace ROOT {
       {
          using Fnc_t = typename ROOT::Internal::GetFunctorType<decltype(ROOT::Internal::GetTheRightOp(&Func::operator()))>::type;
          f->fType = std::is_same<Fnc_t, double>::value? TF1::EFType::kTemplScalar : TF1::EFType::kTemplVec;
-         f->fFunctor = new TF1::TF1FunctorPointerImpl<Fnc_t>(ROOT::Math::ParamFunctorTempl<Fnc_t>(func));
-         f->fParams = new TF1Parameters(f->fNpar);
+         f->fFunctor.reset(new TF1::TF1FunctorPointerImpl<Fnc_t>(ROOT::Math::ParamFunctorTempl<Fnc_t>(func)));
+         f->fParams.reset(new TF1Parameters(f->fNpar));
       }
 
       template<class Func>
@@ -730,8 +732,8 @@ namespace ROOT {
       {
          using Fnc_t = typename ROOT::Internal::GetFunctorType<decltype(ROOT::Internal::GetTheRightOp(&Func::operator()))>::type;
          f->fType = std::is_same<Fnc_t, double>::value? TF1::EFType::kTemplScalar : TF1::EFType::kTemplVec;
-         f->fFunctor = new TF1::TF1FunctorPointerImpl<Fnc_t>(ROOT::Math::ParamFunctorTempl<Fnc_t>(func));
-         f->fParams = new TF1Parameters(f->fNpar);
+         f->fFunctor.reset(new TF1::TF1FunctorPointerImpl<Fnc_t>(ROOT::Math::ParamFunctorTempl<Fnc_t>(func)));
+         f->fParams.reset(new TF1Parameters(f->fNpar));
       }
 
       /// TF1 building from a string
@@ -741,7 +743,7 @@ namespace ROOT {
          static void Build(TF1 *f, const char *formula)
          {
             f->fType = TF1::EFType::kFormula;
-            f->fFormula = new TFormula("tf1lambda", formula, f->fNdim, f->fNpar, false);
+            f->fFormula.reset(new TFormula("tf1lambda", formula, f->fNdim, f->fNpar, false));
             TString formulaExpression(formula);
             Ssiz_t first = formulaExpression.Index("return") + 7;
             Ssiz_t last  = formulaExpression.Last(';');
@@ -839,14 +841,14 @@ void TF1::SetFunction(Func f)
 {
    // set function from a generic C++ callable object
    fType = EFType::kPtrScalarFreeFcn;
-   fFunctor = new TF1::TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctor(f));
+   fFunctor.reset(new TF1::TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctor(f)));
 }
 template <class PtrObj, typename MemFn>
 void TF1::SetFunction(PtrObj &p, MemFn memFn)
 {
    // set from a pointer to a member function
    fType = EFType::kPtrScalarFreeFcn;
-   fFunctor = new TF1::TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctor(p, memFn));
+   fFunctor.reset(new TF1::TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctor(p, memFn)));
 }
 
 template <class T>

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -96,7 +96,7 @@ private:
    std::atomic<Bool_t>  fClingInitialized;  //!  transient to force re-initialization
    Bool_t            fAllParametersSetted;    // flag to control if all parameters are setted
    Bool_t            fLazyInitialization = kFALSE;  //! transient flag to control lazy initialization (needed for reading from files)
-   TMethodCall *fMethod; //! pointer to methodcall
+   std::unique_ptr<TMethodCall> fMethod; //! pointer to methodcall
    std::unique_ptr<TMethodCall> fGradMethod; //! pointer to a methodcall
    TString           fClingName;     //! unique name passed to Cling to define the function ( double clingName(double*x, double*p) )
    std::string       fSavedInputFormula;  //! unique name used to defined the function and used in the global map (need to be saved in case of lazy initialization)
@@ -259,6 +259,6 @@ public:
    void           SetVariables(const std::pair<TString,Double_t> *vars, const Int_t size);
    void SetVectorized(Bool_t vectorized);
 
-   ClassDef(TFormula,12)
+   ClassDef(TFormula,13)
 };
 #endif

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3603,10 +3603,6 @@ void TF1::Streamer(TBuffer &b)
          saved = 1;
          Save(fXmin, fXmax, 0, 0, 0, 0);
       }
-      // if (fType == EFType::kCompositionFcn)
-      //    fComposition_ptr = fComposition.get();
-      // else
-      //    fComposition_ptr = nullptr;
       b.WriteClassBuffer(TF1::Class(), this);
 
       // clear vector contents

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -90,7 +90,7 @@ public:
             fFormula->SetParameters(from.GetParameters());
       } else {
          // case of a function pointers
-         fParams = new TF1Parameters(fNpar);
+         fParams.reset(new TF1Parameters(fNpar));
          fName = from.GetName();
          fTitle = from.GetTitle();
          // need to set parameter values
@@ -570,7 +570,7 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       fType = EFType::kCompositionFcn;
       fComposition = std::unique_ptr<TF1AbsComposition>(conv);
 
-      fParams = new TF1Parameters(fNpar); // default to zeros (TF1Convolution has no GetParameters())
+      fParams = std::unique_ptr<TF1Parameters>(new TF1Parameters(fNpar)); // default to zeros (TF1Convolution has no GetParameters())
       // set parameter names
       for (int i = 0; i < fNpar; i++)
          this->SetParName(i, conv->GetParName(i));
@@ -640,7 +640,7 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       fType = EFType::kCompositionFcn;
       fComposition = std::unique_ptr<TF1AbsComposition>(normSum);
 
-      fParams = new TF1Parameters(fNpar);
+      fParams = std::unique_ptr<TF1Parameters>(new TF1Parameters(fNpar));
       fParams->SetParameters(&(normSum->GetParameters())[0]); // inherit default parameters from normSum
 
       // Parameter names
@@ -654,7 +654,7 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       }
 
    } else { // regular TFormula
-      fFormula = new TFormula(name, formula, false, vectorize);
+      fFormula = std::unique_ptr<TFormula>(new TFormula(name, formula, false, vectorize));
       fNpar = fFormula->GetNpar();
       // TFormula can have dimension zero, but since this is a TF1 minimal dim is 1
       fNdim = fFormula->GetNdim() == 0 ? 1 : fFormula->GetNdim();
@@ -724,7 +724,7 @@ TF1::TF1(const char *name, Double_t xmin, Double_t xmax, Int_t npar, Int_t ndim,
       return;
    }
 
-   fMethodCall = new TMethodCall();
+   fMethodCall = std::unique_ptr<TMethodCall>(new TMethodCall());
    fMethodCall->InitWithPrototype(fName, "Double_t*,Double_t*");
 
    if (! fMethodCall->IsValid()) {
@@ -942,7 +942,6 @@ TF1 &TF1::operator=(const TF1 &rhs)
 TF1::~TF1()
 {
    if (fHistogram) delete fHistogram;
-   if (fMethodCall) delete fMethodCall;
 
    // this was before in TFormula destructor
    {
@@ -952,9 +951,6 @@ TF1::~TF1()
 
    if (fParent) fParent->RecursiveRemove(this);
 
-   if (fFormula) delete fFormula;
-   if (fParams) delete fParams;
-   if (fFunctor) delete fFunctor;
 }
 
 
@@ -998,7 +994,6 @@ void TF1::Browse(TBrowser *b)
 void TF1::Copy(TObject &obj) const
 {
    delete((TF1 &)obj).fHistogram;
-   delete((TF1 &)obj).fMethodCall;
 
    TNamed::Copy((TF1 &)obj);
    TAttLine::Copy((TF1 &)obj);
@@ -1029,36 +1024,25 @@ void TF1::Copy(TObject &obj) const
 
    if (fFormula) assert(fFormula->GetNpar() == fNpar);
 
-   if (fMethodCall) {
-      // use copy-constructor of TMethodCall
-      if (((TF1 &)obj).fMethodCall) delete((TF1 &)obj).fMethodCall;
-      TMethodCall *m = new TMethodCall(*fMethodCall);
-//       m->InitWithPrototype(fMethodCall->GetMethodName(),fMethodCall->GetProto());
-      ((TF1 &)obj).fMethodCall  = m;
-   }
-   if (fFormula) {
-      TFormula *formulaToCopy = ((TF1 &)obj).fFormula;
-      if (formulaToCopy) delete formulaToCopy;
-      formulaToCopy = new TFormula();
-      fFormula->Copy(*formulaToCopy);
-      ((TF1 &)obj).fFormula =  formulaToCopy;
-   }
-   if (fParams) {
-      TF1Parameters *paramsToCopy = ((TF1 &)obj).fParams;
-      if (paramsToCopy) *paramsToCopy = *fParams;
-      else ((TF1 &)obj).fParams = new TF1Parameters(*fParams);
-   }
-   if (fFunctor) {
-      // use clone of TF1FunctorPointer
-      if (((TF1 &)obj).fFunctor) delete((TF1 &)obj).fFunctor;
-      ((TF1 &)obj).fFunctor  = fFunctor->Clone();
-   }
+   // use copy-constructor of TMethodCall
+   TMethodCall *m = (fMethodCall) ? new TMethodCall(*fMethodCall) : nullptr;
+   ((TF1 &)obj).fMethodCall.reset(m);
 
+   TFormula *formulaToCopy = (fFormula) ? new TFormula(*fFormula) : nullptr;
+   ((TF1 &)obj).fFormula.reset(formulaToCopy);
+
+   TF1Parameters *paramsToCopy = (fParams) ? new TF1Parameters(*fParams) : nullptr;
+   ((TF1 &)obj).fParams.reset(paramsToCopy);
+
+   TF1FunctorPointer *functorToCopy = (fFunctor) ? fFunctor->Clone() : nullptr;
+   ((TF1 &)obj).fFunctor.reset(functorToCopy);
+
+   TF1AbsComposition *comp = nullptr;
    if (fComposition) {
-      TF1AbsComposition *comp = (TF1AbsComposition *)fComposition->IsA()->New();
+      comp = (TF1AbsComposition *)fComposition->IsA()->New();
       fComposition->Copy(*comp);
-      ((TF1 &)obj).fComposition = std::unique_ptr<TF1AbsComposition>(comp);
    }
+   ((TF1 &)obj).fComposition.reset(comp);
 }
 
 
@@ -1492,8 +1476,8 @@ Double_t TF1::EvalPar(const Double_t *x, const Double_t *params)
    if (fType == EFType::kPtrScalarFreeFcn || fType == EFType::kTemplScalar)  {
       if (fFunctor) {
          assert(fParams);
-         if (params) result = ((TF1FunctorPointerImpl<Double_t> *)fFunctor)->fImpl((Double_t *)x, (Double_t *)params);
-         else        result = ((TF1FunctorPointerImpl<Double_t> *)fFunctor)->fImpl((Double_t *)x, (Double_t *)fParams->GetParameters());
+         if (params) result = ((TF1FunctorPointerImpl<Double_t> *)fFunctor.get())->fImpl((Double_t *)x, (Double_t *)params);
+         else        result = ((TF1FunctorPointerImpl<Double_t> *)fFunctor.get())->fImpl((Double_t *)x, (Double_t *)fParams->GetParameters());
 
       } else          result = GetSave(x);
 
@@ -3600,7 +3584,7 @@ void TF1::Streamer(TBuffer &b)
             gROOT->GetListOfFunctions()->Add(this);
          }
          if (v >= 10)
-            fComposition = std::unique_ptr<TF1AbsComposition>(fComposition_ptr);
+            //fComposition = std::unique_ptr<TF1AbsComposition>(fComposition_ptr);
          return;
       } else {
          ROOT::v5::TF1Data fold;
@@ -3619,10 +3603,10 @@ void TF1::Streamer(TBuffer &b)
          saved = 1;
          Save(fXmin, fXmax, 0, 0, 0, 0);
       }
-      if (fType == EFType::kCompositionFcn)
-         fComposition_ptr = fComposition.get();
-      else
-         fComposition_ptr = nullptr;
+      // if (fType == EFType::kCompositionFcn)
+      //    fComposition_ptr = fComposition.get();
+      // else
+      //    fComposition_ptr = nullptr;
       b.WriteClassBuffer(TF1::Class(), this);
 
       // clear vector contents

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3583,8 +3583,8 @@ void TF1::Streamer(TBuffer &b)
             R__LOCKGUARD(gROOTMutex);
             gROOT->GetListOfFunctions()->Add(this);
          }
-         if (v >= 10)
-            //fComposition = std::unique_ptr<TF1AbsComposition>(fComposition_ptr);
+         if (v >= 10 && v < 11)
+            fComposition = std::unique_ptr<TF1AbsComposition>(fComposition_ptr);
          return;
       } else {
          ROOT::v5::TF1Data fold;

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -697,6 +697,7 @@ void TFormula::Copy(TObject &obj) const
    }
 
    // use copy-constructor of TMethodCall
+   // if c++-14 could use std::make_unique
    TMethodCall *m = (fMethod) ? new TMethodCall(*fMethod) : nullptr;
    fnew.fMethod.reset(m);
    TMethodCall *gm = (fGradMethod) ? new TMethodCall(*fGradMethod) : nullptr;


### PR DESCRIPTION
Fixes some leaks in TF1::Copy by using unique_ptr as data members 

Do a similar fix also in TFormula