### PR TITLE
Add code for full-functional TWebCanvas, provide qt5web tutorial

### DIFF
--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -20,6 +20,7 @@
 #include <ROOT/RWebWindow.hxx>
 
 #include "TROOT.h"
+#include <string>
 
 ROOT::Experimental::RLogChannel &ROOT::Experimental::WebGUILog() {
    static RLogChannel sLog("ROOT.WebGUI");
@@ -155,6 +156,9 @@ ROOT::Experimental::RWebDisplayArgs &ROOT::Experimental::RWebDisplayArgs::SetBro
    if (pos == 0) {
       SetUrlOpt(kind.substr(1));
       kind.clear();
+   } else if (pos != std::string::npos) {
+      SetUrlOpt(kind.substr(pos+1));
+      kind.resize(pos);
    }
 
    pos = kind.find("size:");
@@ -171,6 +175,12 @@ ROOT::Experimental::RWebDisplayArgs &ROOT::Experimental::RWebDisplayArgs::SetBro
       if (epos == std::string::npos) epos = kind.length();
       SetPosAsStr(kind.substr(pos+4, epos-pos-4));
       kind.erase(pos, epos-pos);
+   }
+
+   // very special handling of qt5 which can specify pointer as a string
+   if (kind.find("qt5:") == 0) {
+      SetDriverData((void *) std::stoul(kind.substr(4)));
+      kind.resize(3);
    }
 
    // remove all trailing spaces

--- a/gui/webgui6/CMakeLists.txt
+++ b/gui/webgui6/CMakeLists.txt
@@ -12,6 +12,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(WebGui6
   HEADERS
     TWebCanvas.h
     TWebGuiFactory.h
+    TWebMenuItem.h
+    TWebPadOptions.h
     TWebPadPainter.h
     TWebPainting.h
     TWebPS.h
@@ -19,12 +21,13 @@ ROOT_STANDARD_LIBRARY_PACKAGE(WebGui6
   SOURCES
     src/TWebCanvas.cxx
     src/TWebGuiFactory.cxx
+    src/TWebMenuItem.cxx
     src/TWebPadPainter.cxx
     src/TWebPainting.cxx
     src/TWebPS.cxx
     src/TWebSnapshot.cxx
   DEPENDENCIES
     Core
-    Gui 
+    Gui
     ROOTWebDisplay
 )

--- a/gui/webgui6/inc/LinkDef.h
+++ b/gui/webgui6/inc/LinkDef.h
@@ -14,13 +14,24 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class TWebGuiFactory+;
-#pragma link C++ class TWebCanvas+;
+#pragma link C++ class TWebMenuItem+;
+#pragma link C++ class TWebCheckedMenuItem+;
+#pragma link C++ class TWebMenuArgument+;
+#pragma link C++ class TWebArgsMenuItem+;
+#pragma link C++ class TWebMenuItems+;
+
+#pragma link C++ class TWebObjectOptions+;
+#pragma link C++ class TWebPadOptions+;
+#pragma link C++ class TWebPadClick+;
+
 #pragma link C++ class TWebPadPainter+;
 #pragma link C++ class TWebPS+;
 #pragma link C++ class TWebPainting+;
 #pragma link C++ class TWebSnapshot+;
 #pragma link C++ class TPadWebSnapshot+;
 #pragma link C++ class TCanvasWebSnapshot+;
+
+#pragma link C++ class TWebCanvas+;
+#pragma link C++ class TWebGuiFactory+;
 
 #endif

--- a/gui/webgui6/inc/TWebGuiFactory.h
+++ b/gui/webgui6/inc/TWebGuiFactory.h
@@ -1,7 +1,7 @@
 // Author: Sergey Linev, GSI   7/12/2016
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -17,7 +17,7 @@
 //                                                                      //
 // This class is a proxy-factory for web-base ROOT GUI components.      //
 // It overrides the member functions of the X11/win32gdk-based          //
-// TGuiFactory.                                                     //
+// TGuiFactory.                                                         //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 

--- a/gui/webgui6/inc/TWebMenuItem.h
+++ b/gui/webgui6/inc/TWebMenuItem.h
@@ -1,0 +1,144 @@
+// Author:  Sergey Linev, GSI  29/06/2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TWebMenuItem
+#define ROOT_TWebMenuItem
+
+#include "TString.h"
+#include "TClass.h"
+
+#include <string>
+#include <vector>
+#include <memory>
+
+class TClass;
+
+/** \class TWebMenuItem
+  Class contains info for producing menu item on the JS side.
+  */
+
+class TWebMenuItem {
+protected:
+   std::string fName;       //  name of the menu item
+   std::string fTitle;      //  title of menu item
+   std::string fExec;       // execute when item is activated
+   std::string fClassName;  // class name
+public:
+
+   TWebMenuItem(const std::string &name, const std::string &title) : fName(name), fTitle(title), fExec(), fClassName() {}
+   TWebMenuItem(const TWebMenuItem &rhs) : fName(rhs.fName), fTitle(rhs.fTitle), fExec(rhs.fExec), fClassName(rhs.fClassName) {}
+   virtual ~TWebMenuItem() = default;
+
+   /** Set execution string with all required arguments,
+    * which will be executed when menu item is selected  */
+   void SetExec(const std::string &exec) { fExec = exec; }
+
+   /** Set class name, to which method belons to  */
+   void SetClassName(const std::string &clname) { fClassName = clname; }
+
+   /** Returns menu item name */
+   const std::string &GetName() const { return fName; }
+
+   /** Returns execution string for the menu item */
+   const std::string &GetExec() const { return fExec; }
+};
+
+////////////////////////////////////////////////////////////////////////////
+
+class TWebCheckedMenuItem : public TWebMenuItem {
+protected:
+   bool fChecked{false}; ///<
+public:
+   /** Create checked menu item  */
+   TWebCheckedMenuItem(const std::string &name, const std::string &title, bool checked = false)
+      : TWebMenuItem(name, title), fChecked(checked)
+   {
+   }
+
+   /** virtual destructor need for vtable, used when vector of TMenuItem* is stored */
+   virtual ~TWebCheckedMenuItem() = default;
+
+   /** Set checked state for the item, default is none */
+   void SetChecked(bool on = true) { fChecked = on; }
+
+   bool IsChecked() const { return fChecked; }
+};
+
+////////////////////////////////////////////////////////////////////////////
+
+class TWebMenuArgument {
+protected:
+   std::string fName;     ///<  name of call argument
+   std::string fTitle;    ///<  title of call argument
+   std::string fTypeName; ///<  typename
+   std::string fDefault;  ///<  default value
+public:
+   TWebMenuArgument() = default;
+
+   TWebMenuArgument(const std::string &name, const std::string &title, const std::string &typname,
+                    const std::string &dflt = "")
+      : fName(name), fTitle(title), fTypeName(typname), fDefault(dflt)
+   {
+   }
+
+   void SetDefault(const std::string &dflt) { fDefault = dflt; }
+};
+
+////////////////////////////////////////////////////////////////////////////
+
+class TWebArgsMenuItem : public TWebMenuItem {
+protected:
+   std::vector<TWebMenuArgument> fArgs;
+
+public:
+
+   TWebArgsMenuItem(const std::string &name, const std::string &title) : TWebMenuItem(name, title) {}
+
+   /** virtual destructor need for vtable, used when vector of TMenuItem* is stored */
+   virtual ~TWebArgsMenuItem() = default;
+
+   std::vector<TWebMenuArgument> &GetArgs() { return fArgs; }
+
+};
+
+///////////////////////////////////////////////////////////////////////
+
+class TWebMenuItems {
+protected:
+   std::string fId;                                   ///< object identifier
+   std::vector<std::unique_ptr<TWebMenuItem>> fItems; ///< list of items in the menu
+public:
+   TWebMenuItems() = default;
+   TWebMenuItems(const std::string &snapid) : fId(snapid) {}
+
+   void Add(TWebMenuItem *item) { fItems.emplace_back(item); }
+
+   void AddMenuItem(const std::string &name, const std::string &title, const std::string &exec, TClass *cl = nullptr)
+   {
+      TWebMenuItem *item = new TWebMenuItem(name, title);
+      item->SetExec(exec);
+      if (cl) item->SetClassName(cl->GetName());
+      Add(item);
+   }
+
+   void AddChkMenuItem(const std::string &name, const std::string &title, bool checked, const std::string &toggle, TClass *cl = nullptr)
+   {
+      TWebCheckedMenuItem *item = new TWebCheckedMenuItem(name, title, checked);
+      item->SetExec(toggle);
+      if (cl) item->SetClassName(cl->GetName());
+      Add(item);
+   }
+
+   std::size_t Size() const { return fItems.size(); }
+
+   void PopulateObjectMenu(void *obj, TClass *cl);
+};
+
+#endif

--- a/gui/webgui6/inc/TWebPadOptions.h
+++ b/gui/webgui6/inc/TWebPadOptions.h
@@ -1,0 +1,53 @@
+// Author:  Sergey Linev, GSI  29/06/2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TWebPadOptions
+#define ROOT_TWebPadOptions
+
+#include <string>
+#include <vector>
+
+/// Class used to transport drawing options from the client
+class TWebObjectOptions {
+public:
+   std::string snapid;       ///< id of the object
+   std::string opt;          ///< drawing options
+   std::string fcust;        ///< custom string
+   std::vector<double> fopt; ///< custom float array
+};
+
+/// Class used to transport ranges from JSROOT canvas
+class TWebPadOptions {
+public:
+   std::string snapid;                        ///< id of pad
+   bool active{false};                        ///< if pad selected as active
+   int logx{0}, logy{0}, logz{0};             ///< pad log properties
+   int gridx{0}, gridy{0};                    ///< pad grid properties
+   int tickx{0}, ticky{0};                    ///< pad ticks properties
+   float mleft{0}, mright{0}, mtop{0}, mbottom{0}; ///< frame margins
+   bool ranges{false};                        ///< if true, pad has ranges
+   double px1{0}, py1{0}, px2{0}, py2{0};     ///< pad range
+   double ux1{0}, uy1{0}, ux2{0}, uy2{0};     ///< pad axis range
+   unsigned bits{0};                          ///< canvas status bits like tool editor
+   double zx1{0}, zx2{0}, zy1{0}, zy2{0}, zz1{0}, zz2{0}; ///< zooming ranges
+   std::vector<TWebObjectOptions> primitives; ///< drawing options for primitives
+};
+
+/// Class used to transport pad click events
+class TWebPadClick {
+public:
+   std::string padid;                         ///< id of pad
+   std::string objid;                         ///< id of clicked object, "null" when not defined
+   int x{-1};                                 ///< x coordinate of click event
+   int y{-1};                                 ///< y coordinate of click event
+   bool dbl{false};                           ///< when double-click was performed
+};
+
+#endif

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -965,7 +965,7 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
 
            while (!buf.empty()) {
               std::string sub = buf;
-              auto pos = buf.find(";;");
+              pos = buf.find(";;");
               if (pos == std::string::npos) {
                  sub = buf;
                  buf.clear();

--- a/gui/webgui6/src/TWebGuiFactory.cxx
+++ b/gui/webgui6/src/TWebGuiFactory.cxx
@@ -1,7 +1,7 @@
 // Author: Sergey Linev, GSI   7/12/2016
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -21,6 +21,7 @@
 #include "TRootGuiFactory.h"
 
 #include "TWebCanvas.h"
+#include "TEnv.h"
 
 #include <ROOT/RMakeUnique.hxx>
 
@@ -41,19 +42,22 @@ TApplicationImp *TWebGuiFactory::CreateApplicationImp(const char *classname, int
    return fGuiProxy->CreateApplicationImp(classname, argc, argv);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 
 TCanvasImp *TWebGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, UInt_t width, UInt_t height)
 {
-   return new TWebCanvas(c, title, 0, 0, width, height);
+   Bool_t readonly = gEnv->GetValue("WebGui.FullCanvas", (Int_t) 0) == 0;
+
+   return new TWebCanvas(c, title, 0, 0, width, height, readonly);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 TCanvasImp *TWebGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height)
 {
-   return new TWebCanvas(c, title, x, y, width, height);
+   Bool_t readonly = gEnv->GetValue("WebGui.FullCanvas", (Int_t) 0) == 0;
+
+   return new TWebCanvas(c, title, x, y, width, height, readonly);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/webgui6/src/TWebMenuItem.cxx
+++ b/gui/webgui6/src/TWebMenuItem.cxx
@@ -1,0 +1,121 @@
+// Author:  Sergey Linev, GSI  29/06/2017
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "TWebMenuItem.h"
+
+#include "TClass.h"
+#include "TList.h"
+#include "TMethod.h"
+#include "TMethodArg.h"
+#include "TMethodCall.h"
+
+void TWebMenuItems::PopulateObjectMenu(void *obj, TClass *cl)
+{
+   fItems.clear();
+
+   TList *lst = new TList;
+   cl->GetMenuItems(lst);
+
+   TIter iter(lst);
+   TMethod *m = nullptr;
+
+   Bool_t has_editor = kFALSE;
+
+   TClass *last_class = nullptr;
+
+   while ((m = (TMethod *)iter()) != nullptr) {
+
+      Bool_t is_editor = kFALSE;
+
+      if (strcmp(m->GetClass()->GetName(), "TH1") == 0) {
+         if (strcmp(m->GetName(), "SetHighlight") == 0) continue;
+         if (strcmp(m->GetName(), "DrawPanel") == 0) is_editor = kTRUE;
+      } else if (strcmp(m->GetClass()->GetName(), "TGraph") == 0) {
+         if (strcmp(m->GetName(), "SetHighlight") == 0) continue;
+         if (strcmp(m->GetName(), "DrawPanel") == 0) is_editor = kTRUE;
+      } else if (strcmp(m->GetClass()->GetName(), "TAttFill") == 0) {
+         if (strcmp(m->GetName(), "SetFillAttributes") == 0) is_editor = kTRUE;
+      } else if (strcmp(m->GetClass()->GetName(), "TAttLine") == 0) {
+         if (strcmp(m->GetName(), "SetLineAttributes") == 0) is_editor = kTRUE;
+      } else if (strcmp(m->GetClass()->GetName(), "TAttMarker") == 0) {
+         if (strcmp(m->GetName(), "SetMarkerAttributes") == 0) is_editor = kTRUE;
+      } else if (strcmp(m->GetClass()->GetName(), "TAttText") == 0) {
+         if (strcmp(m->GetName(), "SetTextAttributes") == 0) is_editor = kTRUE;
+      }
+
+      if (is_editor) {
+         if (!has_editor) {
+            AddMenuItem("Editor", "Attributes editor", "Show:Editor", last_class ? last_class : m->GetClass());
+            has_editor = kTRUE;
+         }
+         continue;
+      }
+
+      last_class = m->GetClass();
+
+      if (m->IsMenuItem() == kMenuToggle) {
+         TString getter;
+         if (m->Getter() && strlen(m->Getter()) > 0) {
+            getter = m->Getter();
+         } else if (strncmp(m->GetName(), "Set", 3) == 0) {
+            getter = TString(m->GetName())(3, strlen(m->GetName()) - 3);
+            if (cl->GetMethodAllAny(TString("Has") + getter))
+               getter = TString("Has") + getter;
+            else if (cl->GetMethodAllAny(TString("Get") + getter))
+               getter = TString("Get") + getter;
+            else if (cl->GetMethodAllAny(TString("Is") + getter))
+               getter = TString("Is") + getter;
+            else
+               getter = "";
+         }
+
+         if ((getter.Length() > 0) && cl->GetMethodAllAny(getter)) {
+            // execute getter method to get current state of toggle item
+
+            TMethodCall *call = new TMethodCall(cl, getter, "");
+
+            if (call->ReturnType() == TMethodCall::kLong) {
+               Long_t l(0);
+               call->Execute(obj, l);
+
+               AddChkMenuItem(m->GetName(), m->GetTitle(), l != 0, Form("%s(%s)", m->GetName(), (l != 0) ? "0" : "1"), m->GetClass());
+
+            } else {
+               // Error("CheckModifiedFlag", "Cannot get toggle value with getter %s", getter.Data());
+            }
+
+            delete call;
+         }
+      } else {
+         TList *args = m->GetListOfMethodArgs();
+
+         if (!args || (args->GetSize() == 0)) {
+            AddMenuItem(m->GetName(), m->GetTitle(), Form("%s()", m->GetName()), m->GetClass());
+         } else {
+            TWebArgsMenuItem *item = new TWebArgsMenuItem(m->GetName(), m->GetTitle());
+            item->SetExec(Form("%s()", m->GetName()));
+            if (m->GetClass()) item->SetClassName(m->GetClass()->GetName());
+
+            TIter args_iter(args);
+            TMethodArg *arg = nullptr;
+
+            while ((arg = dynamic_cast<TMethodArg *>(args_iter())) != nullptr) {
+               const char *dflt = arg->GetDefault();
+               if (!dflt) dflt = "";
+               item->GetArgs().emplace_back(arg->GetName(), arg->GetTitle(), arg->GetFullTypeName(), dflt);
+            }
+
+            Add(item);
+         }
+      }
+   }
+
+   delete lst;
+}

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "6/01/2021"*/
-   JSROOT.version_date = "11/01/2021";
+   JSROOT.version_date = "13/01/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/tutorials/webgui/qt5web/ExampleMain.cpp
+++ b/tutorials/webgui/qt5web/ExampleMain.cpp
@@ -1,3 +1,12 @@
+// Author: Sergey Linev, GSI  13/01/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
 
 #include <QTimer>
 #include <QApplication>
@@ -24,12 +33,11 @@ int main(int argc, char **argv)
    timer.setSingleShot(false);
    timer.start(20);
 
-   // create instance, which should be used everywhere
+   // top widget
    ExampleWidget* widget = new ExampleWidget();
 
    QObject::connect(&myapp, &QApplication::lastWindowClosed, &myapp, &QApplication::quit);
 
-   widget->ensurePolished();
    widget->show();
 
    int res = myapp.exec();

--- a/tutorials/webgui/qt5web/ExampleMain.cpp
+++ b/tutorials/webgui/qt5web/ExampleMain.cpp
@@ -1,0 +1,37 @@
+
+#include <QTimer>
+#include <QApplication>
+
+#include "TApplication.h"
+#include "TSystem.h"
+
+#include "ExampleWidget.h"
+
+int main(int argc, char **argv)
+{
+   argc = 1; // hide all additional parameters from ROOT and Qt
+   TApplication app("uno", &argc, argv); // ROOT application
+
+   char* argv2[3];
+   argv2[0] = argv[0];
+   argv2[1] = 0;
+
+   QApplication myapp(argc, argv2); // Qt application
+
+   // let run ROOT event loop
+   QTimer timer;
+   QObject::connect( &timer, &QTimer::timeout, []() { gSystem->ProcessEvents();  });
+   timer.setSingleShot(false);
+   timer.start(20);
+
+   // create instance, which should be used everywhere
+   ExampleWidget* widget = new ExampleWidget();
+
+   QObject::connect(&myapp, &QApplication::lastWindowClosed, &myapp, &QApplication::quit);
+
+   widget->ensurePolished();
+   widget->show();
+
+   int res = myapp.exec();
+   return res;
+}

--- a/tutorials/webgui/qt5web/ExampleWidget.cpp
+++ b/tutorials/webgui/qt5web/ExampleWidget.cpp
@@ -1,3 +1,13 @@
+// Author: Sergey Linev, GSI  13/01/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include "ExampleWidget.h"
 
 #include "TCanvas.h"
@@ -21,7 +31,7 @@ ExampleWidget::ExampleWidget(QWidget *parent, const char* name) :
 
    // create sample histogram
 
-   fHisto = new TH1F("h1","title", 100, -5, 5);
+   fHisto = new TH1F("gaus1","Example of TH1 drawing in TCanvas", 100, -5, 5);
    fHisto->FillRandom("gaus", 10000);
    fHisto->SetDirectory(nullptr);
 
@@ -29,7 +39,7 @@ ExampleWidget::ExampleWidget(QWidget *parent, const char* name) :
    fHisto->Draw();
 
    static constexpr int nth2points = 40;
-   fHisto2 = std::make_shared<TH2I>("gaus2", "Example of TH1", nth2points, -5, 5, nth2points, -5, 5);
+   fHisto2 = std::make_shared<TH2I>("gaus2", "Example of TH2 drawing in RCanvas", nth2points, -5, 5, nth2points, -5, 5);
    fHisto2->SetDirectory(nullptr);
    for (int n=0;n<nth2points;++n) {
       for (int k=0;k<nth2points;++k) {
@@ -39,7 +49,7 @@ ExampleWidget::ExampleWidget(QWidget *parent, const char* name) :
       }
    }
 
-   fxRCanvasWidget->getCanvas()->Draw<ROOT::Experimental::TObjectDrawable>(fHisto2, "colz");
+   fxRCanvasWidget->getCanvas()->Draw<ROOT::Experimental::TObjectDrawable>(fHisto2, "col");
 }
 
 ExampleWidget::~ExampleWidget()

--- a/tutorials/webgui/qt5web/ExampleWidget.cpp
+++ b/tutorials/webgui/qt5web/ExampleWidget.cpp
@@ -1,10 +1,12 @@
 #include "ExampleWidget.h"
 
 #include "TCanvas.h"
-#include "TClass.h"
 #include "TH1.h"
-#include "TROOT.h"
-#include "TWebCanvas.h"
+#include "TH2.h"
+#include "TMath.h"
+
+#include <ROOT/RCanvas.hxx>
+#include <ROOT/TObjectDrawable.hxx>
 
 #include <QMessageBox>
 
@@ -23,8 +25,21 @@ ExampleWidget::ExampleWidget(QWidget *parent, const char* name) :
    fHisto->FillRandom("gaus", 10000);
    fHisto->SetDirectory(nullptr);
 
-   gPad = fxCanvasWidget->getCanvas();
+   gPad = fxTCanvasWidget->getCanvas();
    fHisto->Draw();
+
+   static constexpr int nth2points = 40;
+   fHisto2 = std::make_shared<TH2I>("gaus2", "Example of TH1", nth2points, -5, 5, nth2points, -5, 5);
+   fHisto2->SetDirectory(nullptr);
+   for (int n=0;n<nth2points;++n) {
+      for (int k=0;k<nth2points;++k) {
+         double x = 10.*n/nth2points-5.;
+         double y = 10.*k/nth2points-5.;
+         fHisto2->SetBinContent(fHisto2->GetBin(n+1, k+1), (int) (1000*TMath::Gaus(x)*TMath::Gaus(y)));
+      }
+   }
+
+   fxRCanvasWidget->getCanvas()->Draw<ROOT::Experimental::TObjectDrawable>(fHisto2, "colz");
 }
 
 ExampleWidget::~ExampleWidget()

--- a/tutorials/webgui/qt5web/ExampleWidget.cpp
+++ b/tutorials/webgui/qt5web/ExampleWidget.cpp
@@ -1,0 +1,129 @@
+#include "ExampleWidget.h"
+
+#include "TCanvas.h"
+#include "TClass.h"
+#include "TH1.h"
+#include "TROOT.h"
+#include "TWebCanvas.h"
+
+#include <QMessageBox>
+
+ExampleWidget::ExampleWidget(QWidget *parent, const char* name) :
+   QWidget(parent)
+{
+   setupUi(this);
+
+   setAttribute(Qt::WA_DeleteOnClose);
+
+   setObjectName(name);
+
+   // create sample histogram
+
+   fHisto = new TH1F("h1","title", 100, -5, 5);
+   fHisto->FillRandom("gaus", 10000);
+   fHisto->SetDirectory(nullptr);
+
+   // configure TCanvas output
+
+   fCanvas = new TCanvas(kFALSE);
+   fCanvas->SetName("Canvas");
+   fCanvas->SetTitle("title");
+   fCanvas->ResetBit(TCanvas::kShowEditor);
+   fCanvas->SetCanvas(fCanvas);
+   fCanvas->SetBatch(kTRUE); // mark canvas as batch
+
+   TWebCanvas *web = new TWebCanvas(fCanvas, "title", 0, 0, 800, 600, kFALSE);
+
+   // web->AddCustomClass("CustomClass");
+   // web->SetCustomScripts("<custom JSROOT code to draw CustomClass>");
+
+   fCanvas->SetCanvasImp(web);
+
+   SetPrivateCanvasFields(fCanvas, true);
+
+   web->SetCanCreateObjects(kFALSE); // not yet create objects on server side
+
+   // web->SetUpdatedHandler([this]() { ProcessCanvasUpdated(); });
+   // web->SetActivePadChangedHandler([this](TPad *pad){ ProcessActivePadChanged(pad); });
+   // web->SetPadClickedHandler([this](TPad *pad, int x, int y) { ProcessPadClicked(pad, x, y); });
+   // web->SetPadDblClickedHandler([this](TPad *pad, int x, int y) { ProcessPadDblClicked(pad, x, y); });
+
+   ROOT::Experimental::RWebDisplayArgs args("qt5");
+   args.SetDriverData(this); // it is parent widget for created QWebEngineView element
+   args.SetUrlOpt("noopenui");
+   web->ShowWebWindow(args);
+
+   fView = findChild<QWebEngineView*>("RootWebView");
+   if (!fView) {
+      printf("FAIL TO FIND QWebEngineView - ROOT Qt5Web plugin does not work properly !!!!!\n");
+      exit(11);
+   }
+
+   canvasGridLayout->addWidget(fView);
+
+   // QObject::connect(fView, SIGNAL(drop(QDropEvent*)), this, SLOT(dropView(QDropEvent*)));
+
+   fCanvas->SetCanvasSize(fView->width(), fView->height());
+
+   gPad = fCanvas;
+   fHisto->Draw();
+
+//   fxQCanvas->setObjectName("example");
+//   fxQCanvas->getCanvas()->SetName("example");
+//   fxQCanvas->setEditorFrame(EditorFrame);
+//   fxQCanvas->buildEditorWindow();
+
+//   fxQCanvas->getCanvas()->cd();
+//   fHisto->Draw("colz");
+}
+
+ExampleWidget::~ExampleWidget()
+{
+   if (fCanvas) {
+      SetPrivateCanvasFields(fCanvas, false);
+      gROOT->GetListOfCanvases()->Remove(fCanvas);
+      fCanvas->Close();
+      delete fCanvas;
+      fCanvas = nullptr;
+   }
+}
+
+
+void ExampleWidget::SetPrivateCanvasFields(TCanvas *canv, bool on_init)
+{
+   Long_t offset = TCanvas::Class()->GetDataMemberOffset("fCanvasID");
+   if (offset > 0) {
+      Int_t *id = (Int_t *)((char*) canv + offset);
+      if (*id == canv->GetCanvasID()) *id = on_init ? 111222333 : -1;
+   } else {
+      printf("ERROR: Cannot modify fCanvasID data member\n");
+   }
+
+   offset = TCanvas::Class()->GetDataMemberOffset("fMother");
+   if (offset > 0) {
+      TPad **moth = (TPad **)((char*) canv + offset);
+      if (*moth == canv->GetMother()) *moth = on_init ? canv : nullptr;
+   } else {
+      printf("ERROR: Cannot set fMother data member in canvas\n");
+   }
+}
+
+
+
+void ExampleWidget::InfoButton_clicked()
+{
+   QMessageBox::information(this,"QtRoot standalone example","Demo how QRootCanvas can be inserted into the QWidget");
+}
+
+void ExampleWidget::resizeEvent(QResizeEvent * e)
+{
+   fCanvas->SetCanvasSize(fView->width(), fView->height());
+}
+
+void ExampleWidget::ExitButton_clicked()
+{
+   // when widget closed, application automatically exit
+   close();
+}
+
+

--- a/tutorials/webgui/qt5web/ExampleWidget.cpp
+++ b/tutorials/webgui/qt5web/ExampleWidget.cpp
@@ -23,101 +23,17 @@ ExampleWidget::ExampleWidget(QWidget *parent, const char* name) :
    fHisto->FillRandom("gaus", 10000);
    fHisto->SetDirectory(nullptr);
 
-   // configure TCanvas output
-
-   fCanvas = new TCanvas(kFALSE);
-   fCanvas->SetName("Canvas");
-   fCanvas->SetTitle("title");
-   fCanvas->ResetBit(TCanvas::kShowEditor);
-   fCanvas->SetCanvas(fCanvas);
-   fCanvas->SetBatch(kTRUE); // mark canvas as batch
-
-   TWebCanvas *web = new TWebCanvas(fCanvas, "title", 0, 0, 800, 600, kFALSE);
-
-   // web->AddCustomClass("CustomClass");
-   // web->SetCustomScripts("<custom JSROOT code to draw CustomClass>");
-
-   fCanvas->SetCanvasImp(web);
-
-   SetPrivateCanvasFields(fCanvas, true);
-
-   web->SetCanCreateObjects(kFALSE); // not yet create objects on server side
-
-   // web->SetUpdatedHandler([this]() { ProcessCanvasUpdated(); });
-   // web->SetActivePadChangedHandler([this](TPad *pad){ ProcessActivePadChanged(pad); });
-   // web->SetPadClickedHandler([this](TPad *pad, int x, int y) { ProcessPadClicked(pad, x, y); });
-   // web->SetPadDblClickedHandler([this](TPad *pad, int x, int y) { ProcessPadDblClicked(pad, x, y); });
-
-   ROOT::Experimental::RWebDisplayArgs args("qt5");
-   args.SetDriverData(this); // it is parent widget for created QWebEngineView element
-   args.SetUrlOpt("noopenui");
-   web->ShowWebWindow(args);
-
-   fView = findChild<QWebEngineView*>("RootWebView");
-   if (!fView) {
-      printf("FAIL TO FIND QWebEngineView - ROOT Qt5Web plugin does not work properly !!!!!\n");
-      exit(11);
-   }
-
-   canvasGridLayout->addWidget(fView);
-
-   // QObject::connect(fView, SIGNAL(drop(QDropEvent*)), this, SLOT(dropView(QDropEvent*)));
-
-   fCanvas->SetCanvasSize(fView->width(), fView->height());
-
-   gPad = fCanvas;
+   gPad = fxCanvasWidget->getCanvas();
    fHisto->Draw();
-
-//   fxQCanvas->setObjectName("example");
-//   fxQCanvas->getCanvas()->SetName("example");
-//   fxQCanvas->setEditorFrame(EditorFrame);
-//   fxQCanvas->buildEditorWindow();
-
-//   fxQCanvas->getCanvas()->cd();
-//   fHisto->Draw("colz");
 }
 
 ExampleWidget::~ExampleWidget()
 {
-   if (fCanvas) {
-      SetPrivateCanvasFields(fCanvas, false);
-      gROOT->GetListOfCanvases()->Remove(fCanvas);
-      fCanvas->Close();
-      delete fCanvas;
-      fCanvas = nullptr;
-   }
 }
-
-
-void ExampleWidget::SetPrivateCanvasFields(TCanvas *canv, bool on_init)
-{
-   Long_t offset = TCanvas::Class()->GetDataMemberOffset("fCanvasID");
-   if (offset > 0) {
-      Int_t *id = (Int_t *)((char*) canv + offset);
-      if (*id == canv->GetCanvasID()) *id = on_init ? 111222333 : -1;
-   } else {
-      printf("ERROR: Cannot modify fCanvasID data member\n");
-   }
-
-   offset = TCanvas::Class()->GetDataMemberOffset("fMother");
-   if (offset > 0) {
-      TPad **moth = (TPad **)((char*) canv + offset);
-      if (*moth == canv->GetMother()) *moth = on_init ? canv : nullptr;
-   } else {
-      printf("ERROR: Cannot set fMother data member in canvas\n");
-   }
-}
-
-
 
 void ExampleWidget::InfoButton_clicked()
 {
    QMessageBox::information(this,"QtRoot standalone example","Demo how QRootCanvas can be inserted into the QWidget");
-}
-
-void ExampleWidget::resizeEvent(QResizeEvent * e)
-{
-   fCanvas->SetCanvasSize(fView->width(), fView->height());
 }
 
 void ExampleWidget::ExitButton_clicked()
@@ -125,5 +41,3 @@ void ExampleWidget::ExitButton_clicked()
    // when widget closed, application automatically exit
    close();
 }
-
-

--- a/tutorials/webgui/qt5web/ExampleWidget.h
+++ b/tutorials/webgui/qt5web/ExampleWidget.h
@@ -4,7 +4,10 @@
 #include <QWidget>
 #include "ui_ExampleWidget.h"
 
+#include <memory>
+
 class TH1F;
+class TH2I;
 
 class ExampleWidget : public QWidget, public Ui::ExampleWidget
 {
@@ -12,7 +15,8 @@ class ExampleWidget : public QWidget, public Ui::ExampleWidget
 
    protected:
 
-      TH1F *fHisto{nullptr};
+      TH1F *fHisto{nullptr};  ///< histogram for display in TCanvas
+      std::shared_ptr<TH2I> fHisto2; ///< histogram for display in RCanvas
 
    public:
 

--- a/tutorials/webgui/qt5web/ExampleWidget.h
+++ b/tutorials/webgui/qt5web/ExampleWidget.h
@@ -2,29 +2,23 @@
 #define ExampleWidget_h
 
 #include <QWidget>
-#include <QWebEngineView>
 #include "ui_ExampleWidget.h"
 
 class TH1F;
-class TCanvas;
 
 class ExampleWidget : public QWidget, public Ui::ExampleWidget
 {
    Q_OBJECT
+
+   protected:
+
+      TH1F *fHisto{nullptr};
 
    public:
 
       ExampleWidget(QWidget *parent = 0, const char* name = 0);
 
       virtual ~ExampleWidget();
-
-   protected:
-      virtual void resizeEvent(QResizeEvent * e);
-      void SetPrivateCanvasFields(TCanvas *canv, bool on_init);
-
-      QWebEngineView *fView{nullptr};
-      TCanvas *fCanvas{nullptr};
-      TH1F *fHisto{nullptr};
 
    public slots:
 

--- a/tutorials/webgui/qt5web/ExampleWidget.h
+++ b/tutorials/webgui/qt5web/ExampleWidget.h
@@ -1,3 +1,13 @@
+// Author: Sergey Linev, GSI  13/01/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #ifndef ExampleWidget_h
 #define ExampleWidget_h
 
@@ -20,7 +30,7 @@ class ExampleWidget : public QWidget, public Ui::ExampleWidget
 
    public:
 
-      ExampleWidget(QWidget *parent = 0, const char* name = 0);
+      ExampleWidget(QWidget *parent = nullptr, const char* name = nullptr);
 
       virtual ~ExampleWidget();
 

--- a/tutorials/webgui/qt5web/ExampleWidget.h
+++ b/tutorials/webgui/qt5web/ExampleWidget.h
@@ -1,0 +1,36 @@
+#ifndef ExampleWidget_h
+#define ExampleWidget_h
+
+#include <QWidget>
+#include <QWebEngineView>
+#include "ui_ExampleWidget.h"
+
+class TH1F;
+class TCanvas;
+
+class ExampleWidget : public QWidget, public Ui::ExampleWidget
+{
+   Q_OBJECT
+
+   public:
+
+      ExampleWidget(QWidget *parent = 0, const char* name = 0);
+
+      virtual ~ExampleWidget();
+
+   protected:
+      virtual void resizeEvent(QResizeEvent * e);
+      void SetPrivateCanvasFields(TCanvas *canv, bool on_init);
+
+      QWebEngineView *fView{nullptr};
+      TCanvas *fCanvas{nullptr};
+      TH1F *fHisto{nullptr};
+
+   public slots:
+
+      void InfoButton_clicked();
+      void ExitButton_clicked();
+
+};
+
+#endif

--- a/tutorials/webgui/qt5web/ExampleWidget.ui
+++ b/tutorials/webgui/qt5web/ExampleWidget.ui
@@ -77,6 +77,24 @@
               <property name="spacing" >
                 <number>2</number>
               </property>
+              <item row="0" column="0" >
+                <widget class="TCanvasWidget" name="fxCanvasWidget" >
+                  <property name="sizePolicy" >
+                    <sizepolicy>
+                      <hsizetype>7</hsizetype>
+                      <vsizetype>7</vsizetype>
+                      <horstretch>0</horstretch>
+                      <verstretch>1</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="minimumSize" >
+                    <size>
+                      <width>100</width>
+                      <height>100</height>
+                    </size>
+                  </property>
+                </widget>
+              </item>
             </layout>
           </widget>
         </widget>
@@ -84,6 +102,9 @@
     </layout>
   </widget>
   <layoutdefault spacing="3" margin="3" />
+  <includes>
+    <include location="local">TCanvasWidget.h</include>
+  </includes>
   <connections>
     <connection>
       <sender>InfoBtn</sender>
@@ -98,5 +119,9 @@
       <slot>ExitButton_clicked()</slot>
     </connection>
   </connections>
-
+  <customwidgets>
+    <customwidget>
+      <class>TCanvasWidget</class>
+    </customwidget>
+  </customwidgets>
 </ui>

--- a/tutorials/webgui/qt5web/ExampleWidget.ui
+++ b/tutorials/webgui/qt5web/ExampleWidget.ui
@@ -66,11 +66,11 @@
               </item>
             </layout>
           </widget>
-          <widget class="QWidget" name="TCanvasTab">
+          <widget class="QWidget" name="RCanvasTab">
             <attribute name="title" >
-              <string>TCanvas</string>
+              <string>RCanvas</string>
             </attribute>
-            <layout class="QGridLayout" name="canvasGridLayout">
+            <layout class="QGridLayout" name="rcanvasGridLayout">
               <property name="margin" >
                 <number>2</number>
               </property>
@@ -78,7 +78,38 @@
                 <number>2</number>
               </property>
               <item row="0" column="0" >
-                <widget class="TCanvasWidget" name="fxCanvasWidget" >
+                <widget class="RCanvasWidget" name="fxRCanvasWidget" >
+                  <property name="sizePolicy" >
+                    <sizepolicy>
+                      <hsizetype>7</hsizetype>
+                      <vsizetype>7</vsizetype>
+                      <horstretch>0</horstretch>
+                      <verstretch>1</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="minimumSize" >
+                    <size>
+                      <width>100</width>
+                      <height>100</height>
+                    </size>
+                  </property>
+                </widget>
+              </item>
+            </layout>
+          </widget>
+          <widget class="QWidget" name="TCanvasTab">
+            <attribute name="title" >
+              <string>TCanvas</string>
+            </attribute>
+            <layout class="QGridLayout" name="tcanvasGridLayout">
+              <property name="margin" >
+                <number>2</number>
+              </property>
+              <property name="spacing" >
+                <number>2</number>
+              </property>
+              <item row="0" column="0" >
+                <widget class="TCanvasWidget" name="fxTCanvasWidget" >
                   <property name="sizePolicy" >
                     <sizepolicy>
                       <hsizetype>7</hsizetype>
@@ -103,6 +134,7 @@
   </widget>
   <layoutdefault spacing="3" margin="3" />
   <includes>
+    <include location="local">RCanvasWidget.h</include>
     <include location="local">TCanvasWidget.h</include>
   </includes>
   <connections>
@@ -120,6 +152,9 @@
     </connection>
   </connections>
   <customwidgets>
+    <customwidget>
+      <class>RCanvasWidget</class>
+    </customwidget>
     <customwidget>
       <class>TCanvasWidget</class>
     </customwidget>

--- a/tutorials/webgui/qt5web/ExampleWidget.ui
+++ b/tutorials/webgui/qt5web/ExampleWidget.ui
@@ -1,0 +1,102 @@
+<ui version="4.0" stdsetdef="1" >
+  <author>Sergey Linev</author>
+  <comment></comment>
+  <exportmacro></exportmacro>
+  <class>ExampleWidget</class>
+  <widget class="QWidget" name="ExampleWidget" >
+    <property name="geometry" >
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>682</width>
+        <height>559</height>
+      </rect>
+    </property>
+    <property name="windowTitle" >
+      <string>Qt5Web ROOT example</string>
+    </property>
+    <layout class="QGridLayout" >
+      <item row="0" column="0" >
+        <widget class="QLabel" name="textLabel1" >
+          <property name="text" >
+            <string>This is an example of using ROO5 qt5web components. &lt;br>It shows some default Qt5 widgets plus RCanvas and TCanvas with graphics inside</string>
+          </property>
+          <property name="wordWrap" >
+            <bool>false</bool>
+          </property>
+        </widget>
+      </item>
+      <item row="1" column="0" >
+        <widget class="QTabWidget" name="TabWidget" >
+          <widget class="QWidget" name="DefaultTab" >
+            <attribute name="title" >
+              <string>Default</string>
+            </attribute>
+            <layout class="QGridLayout" >
+              <item row="0" column="0" >
+                <widget class="QLabel" name="InfoLabel1" >
+                  <property name="text" >
+                    <string>This is just example of using standard Qt5 components</string>
+                  </property>
+                  <property name="alignment" >
+                    <set>Qt::AlignVCenter</set>
+                  </property>
+                  <property name="wordWrap" >
+                    <bool>true</bool>
+                  </property>
+                </widget>
+              </item>
+              <item row="1" column="0" >
+                <layout class="QHBoxLayout" >
+                  <item>
+                    <widget class="QPushButton" name="InfoBtn" >
+                      <property name="text" >
+                        <string>Info</string>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
+                    <widget class="QPushButton" name="ExitBtn" >
+                      <property name="text" >
+                        <string>Exit</string>
+                      </property>
+                    </widget>
+                  </item>
+                </layout>
+              </item>
+            </layout>
+          </widget>
+          <widget class="QWidget" name="TCanvasTab">
+            <attribute name="title" >
+              <string>TCanvas</string>
+            </attribute>
+            <layout class="QGridLayout" name="canvasGridLayout">
+              <property name="margin" >
+                <number>2</number>
+              </property>
+              <property name="spacing" >
+                <number>2</number>
+              </property>
+            </layout>
+          </widget>
+        </widget>
+      </item>
+    </layout>
+  </widget>
+  <layoutdefault spacing="3" margin="3" />
+  <connections>
+    <connection>
+      <sender>InfoBtn</sender>
+      <signal>clicked()</signal>
+      <receiver>ExampleWidget</receiver>
+      <slot>InfoButton_clicked()</slot>
+    </connection>
+    <connection>
+      <sender>ExitBtn</sender>
+      <signal>clicked()</signal>
+      <receiver>ExampleWidget</receiver>
+      <slot>ExitButton_clicked()</slot>
+    </connection>
+  </connections>
+
+</ui>

--- a/tutorials/webgui/qt5web/Makefile
+++ b/tutorials/webgui/qt5web/Makefile
@@ -1,0 +1,33 @@
+all: qt5web
+
+ROOTINCPATH := $(shell root-config --incdir)
+ROOTCFLAGS  := $(shell root-config --cflags)
+ROOTLIBS    := $(shell root-config --libs)
+ROOTGLIBS   := $(shell root-config --glibs)
+
+ifneq ($(findstring -std=c++11,$(ROOTCFLAGS)),)
+   QMAKEOPTFLAGS := "CONFIG+=c++11"
+endif
+ifneq ($(findstring -std=c++14,$(ROOTCFLAGS)),)
+    QMAKEOPTFLAGS := "CONFIG+=c++14"
+endif
+ifneq ($(findstring -std=c++17,$(ROOTCFLAGS)),)
+    QMAKEOPTFLAGS := "CONFIG+=c++17"
+endif
+
+HDRS = ExampleWidget.h 
+SRCS = ExampleWidget.cpp ExampleMain.cpp  
+UIS = ExampleWidget.ui
+
+Makefile.qt: qt5web.pro $(UIS)
+	@echo "Generating Makefile.qt"
+	qmake-qt5 qt5web.pro -o Makefile.qt $(QMAKEOPTFLAGS) "LIBS+=$(ROOTGLIBS) -lROOTWebDisplay -lWebGui6" "INCLUDEPATH+=$(ROOTINCPATH)" "DEPENDPATH+=$(ROOTINCPATH)" 
+
+qt5web: Makefile.qt $(HDRS) $(SRCS)
+	@echo "Compiling qt5web..."
+	$(MAKE) -f Makefile.qt
+
+clean:
+	@echo "Clean generated files"
+	rm -f Makefile.qt ui_ExampleWidget.h .qmake.stash qt5web
+	rm -rf .obj .moc 

--- a/tutorials/webgui/qt5web/Makefile
+++ b/tutorials/webgui/qt5web/Makefile
@@ -3,7 +3,6 @@ all: qt5web
 ROOTINCPATH := $(shell root-config --incdir)
 ROOTCFLAGS  := $(shell root-config --cflags)
 ROOTLIBS    := $(shell root-config --libs)
-ROOTGLIBS   := $(shell root-config --glibs)
 
 ifneq ($(findstring -std=c++11,$(ROOTCFLAGS)),)
    QMAKEOPTFLAGS := "CONFIG+=c++11"
@@ -21,7 +20,7 @@ UIS = ExampleWidget.ui
 
 Makefile.qt: qt5web.pro $(UIS)
 	@echo "Generating Makefile.qt"
-	qmake-qt5 qt5web.pro -o Makefile.qt $(QMAKEOPTFLAGS) "LIBS+=$(ROOTGLIBS) -lROOTWebDisplay -lWebGui6 -lROOTGpadv7" "INCLUDEPATH+=$(ROOTINCPATH)" "DEPENDPATH+=$(ROOTINCPATH)" 
+	qmake-qt5 qt5web.pro -o Makefile.qt $(QMAKEOPTFLAGS) "LIBS+=$(ROOTLIBS) -lROOTWebDisplay -lGpad -lWebGui6 -lROOTGpadv7" "INCLUDEPATH+=$(ROOTINCPATH)" "DEPENDPATH+=$(ROOTINCPATH)" 
 
 qt5web: Makefile.qt $(HDRS) $(SRCS)
 	@echo "Compiling qt5web..."

--- a/tutorials/webgui/qt5web/Makefile
+++ b/tutorials/webgui/qt5web/Makefile
@@ -15,8 +15,8 @@ ifneq ($(findstring -std=c++17,$(ROOTCFLAGS)),)
     QMAKEOPTFLAGS := "CONFIG+=c++17"
 endif
 
-HDRS = ExampleWidget.h 
-SRCS = ExampleWidget.cpp ExampleMain.cpp  
+HDRS = ExampleWidget.h TCanvasWidget.h
+SRCS = ExampleWidget.cpp TCanvasWidget.cpp ExampleMain.cpp  
 UIS = ExampleWidget.ui
 
 Makefile.qt: qt5web.pro $(UIS)

--- a/tutorials/webgui/qt5web/Makefile
+++ b/tutorials/webgui/qt5web/Makefile
@@ -15,13 +15,13 @@ ifneq ($(findstring -std=c++17,$(ROOTCFLAGS)),)
     QMAKEOPTFLAGS := "CONFIG+=c++17"
 endif
 
-HDRS = ExampleWidget.h TCanvasWidget.h
-SRCS = ExampleWidget.cpp TCanvasWidget.cpp ExampleMain.cpp  
+HDRS = ExampleWidget.h TCanvasWidget.h RCanvasWidget.h
+SRCS = ExampleWidget.cpp TCanvasWidget.cpp RCanvasWidget.cpp ExampleMain.cpp  
 UIS = ExampleWidget.ui
 
 Makefile.qt: qt5web.pro $(UIS)
 	@echo "Generating Makefile.qt"
-	qmake-qt5 qt5web.pro -o Makefile.qt $(QMAKEOPTFLAGS) "LIBS+=$(ROOTGLIBS) -lROOTWebDisplay -lWebGui6" "INCLUDEPATH+=$(ROOTINCPATH)" "DEPENDPATH+=$(ROOTINCPATH)" 
+	qmake-qt5 qt5web.pro -o Makefile.qt $(QMAKEOPTFLAGS) "LIBS+=$(ROOTGLIBS) -lROOTWebDisplay -lWebGui6 -lROOTGpadv7" "INCLUDEPATH+=$(ROOTINCPATH)" "DEPENDPATH+=$(ROOTINCPATH)" 
 
 qt5web: Makefile.qt $(HDRS) $(SRCS)
 	@echo "Compiling qt5web..."

--- a/tutorials/webgui/qt5web/RCanvasWidget.cpp
+++ b/tutorials/webgui/qt5web/RCanvasWidget.cpp
@@ -1,9 +1,18 @@
+// Author: Sergey Linev, GSI  13/01/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include "RCanvasWidget.h"
 
 #include <ROOT/RCanvas.hxx>
 
 #include <QGridLayout>
-
 
 RCanvasWidget::RCanvasWidget(QWidget *parent) : QWidget(parent)
 {

--- a/tutorials/webgui/qt5web/RCanvasWidget.cpp
+++ b/tutorials/webgui/qt5web/RCanvasWidget.cpp
@@ -1,0 +1,57 @@
+#include "RCanvasWidget.h"
+
+#include <ROOT/RCanvas.hxx>
+
+#include <QGridLayout>
+
+
+RCanvasWidget::RCanvasWidget(QWidget *parent) : QWidget(parent)
+{
+
+   setObjectName( "RCanvasWidget");
+
+   setSizeIncrement( QSize( 100, 100 ) );
+
+   setUpdatesEnabled( true );
+   setMouseTracking(true);
+
+   setFocusPolicy( Qt::TabFocus );
+   setCursor( Qt::CrossCursor );
+
+   setAcceptDrops(true);
+
+   QGridLayout *gridLayout = new QGridLayout(this);
+   gridLayout->setSpacing(10);
+   gridLayout->setMargin(1);
+
+   fCanvas = new ROOT::Experimental::RCanvas();
+
+   std::string arg = "qt5:";
+   arg += std::to_string((unsigned long) this);
+   arg += "?noopenui";
+
+   fCanvas->Show(arg);
+
+   fView = findChild<QWebEngineView*>("RootWebView");
+   if (!fView) {
+      printf("FAIL TO FIND QWebEngineView - ROOT Qt5Web plugin does not work properly !!!!!\n");
+      exit(11);
+   }
+
+   gridLayout->addWidget(fView);
+
+   fCanvas->SetSize({fView->width(), fView->height()});
+}
+
+RCanvasWidget::~RCanvasWidget()
+{
+   if (fCanvas) {
+      delete fCanvas;
+      fCanvas = nullptr;
+   }
+}
+
+void RCanvasWidget::resizeEvent(QResizeEvent *event)
+{
+   fCanvas->SetSize({fView->width(), fView->height()});
+}

--- a/tutorials/webgui/qt5web/RCanvasWidget.h
+++ b/tutorials/webgui/qt5web/RCanvasWidget.h
@@ -1,0 +1,33 @@
+#ifndef RCanvasWidget_H
+#define RCanvasWidget_H
+
+#include <QWidget>
+#include <QWebEngineView>
+
+namespace ROOT {
+namespace Experimental {
+class RCanvas;
+}
+}
+
+class RCanvasWidget : public QWidget {
+
+   Q_OBJECT
+
+public:
+   RCanvasWidget(QWidget *parent = nullptr);
+   virtual ~RCanvasWidget();
+
+   /// returns canvas shown in the widget
+   ROOT::Experimental::RCanvas *getCanvas() { return fCanvas; }
+
+protected:
+
+   void resizeEvent(QResizeEvent *event) override;
+
+   QWebEngineView *fView{nullptr};  ///< qt webwidget to show
+
+   ROOT::Experimental::RCanvas *fCanvas{nullptr};
+};
+
+#endif

--- a/tutorials/webgui/qt5web/RCanvasWidget.h
+++ b/tutorials/webgui/qt5web/RCanvasWidget.h
@@ -1,3 +1,13 @@
+// Author: Sergey Linev, GSI  13/01/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #ifndef RCanvasWidget_H
 #define RCanvasWidget_H
 

--- a/tutorials/webgui/qt5web/Readme.md
+++ b/tutorials/webgui/qt5web/Readme.md
@@ -1,0 +1,18 @@
+# qt5web example
+
+Demonstration how different ROOT web-based widgets can be embed into qt application
+To compile example, just call `make` in the directory.
+ROOT should be compiled with configured `-Dqt5web=ON`.
+As a result, `qt5web` application should be created.
+It includes `QTabWidget` with three tabs - standard Qt5 components for demo,
+TCanvas and RCanvas. Both show different histograms drawing.
+
+## How to include RCanvas into other Qt-based project
+
+Most easy way - just include `RCanvasWidget.h` and `RCanvasWidget.cpp` files
+in the project and let compile, linking with ROOT basic libraries `root-config --libs` plus `-lROOTWebDisplay -lROOTGpadv7`. `RCanvasWidget` is just `QWidget` which internally embed `RCanvas` drawing. See `ExampleWidget.ui` file how to embed such custom widget in normal qt ui file.
+
+To let ROOT work inside Qt5 event loop, one should instantiate `TApplication` object and
+regularly call `gSystem->ProcessEvents()` - see how it is done in `ExampleMain.cpp`.
+
+Author: Sergey Linev

--- a/tutorials/webgui/qt5web/TCanvasWidget.cpp
+++ b/tutorials/webgui/qt5web/TCanvasWidget.cpp
@@ -1,3 +1,13 @@
+// Author: Sergey Linev, GSI  13/01/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #include "TCanvasWidget.h"
 
 #include "TCanvas.h"
@@ -15,7 +25,6 @@
 #include <cstdio>
 
 #include "TWebCanvas.h"
-
 
 TCanvasWidget::TCanvasWidget(QWidget *parent) : QWidget(parent)
 {

--- a/tutorials/webgui/qt5web/TCanvasWidget.cpp
+++ b/tutorials/webgui/qt5web/TCanvasWidget.cpp
@@ -1,0 +1,143 @@
+#include "TCanvasWidget.h"
+
+#include "TCanvas.h"
+#include "TROOT.h"
+#include "TClass.h"
+#include "TEnv.h"
+#include "THttpServer.h"
+
+#include <QGridLayout>
+#include <QApplication>
+#include <QTimer>
+#include <QDropEvent>
+
+#include <cstdlib>
+#include <cstdio>
+
+#include "TWebCanvas.h"
+
+
+TCanvasWidget::TCanvasWidget(QWidget *parent) : QWidget(parent)
+{
+
+   setObjectName( "TCanvasWidget");
+
+   setSizeIncrement( QSize( 100, 100 ) );
+
+   setUpdatesEnabled( true );
+   setMouseTracking(true);
+
+   setFocusPolicy( Qt::TabFocus );
+   setCursor( Qt::CrossCursor );
+
+   setAcceptDrops(true);
+
+   QGridLayout *gridLayout = new QGridLayout(this);
+   gridLayout->setSpacing(10);
+   gridLayout->setMargin(1);
+
+   static int wincnt = 1;
+
+   fCanvas = new TCanvas(kFALSE);
+   fCanvas->SetName(Form("Canvas%d", wincnt++));
+   fCanvas->SetTitle("title");
+   fCanvas->ResetBit(TCanvas::kShowEditor);
+   fCanvas->SetCanvas(fCanvas);
+   fCanvas->SetBatch(kTRUE); // mark canvas as batch
+
+   gPad = fCanvas;
+
+   bool read_only = (gEnv->GetValue("WebGui.FullCanvas", (Int_t) 0) == 0);
+
+   TWebCanvas *web = new TWebCanvas(fCanvas, "title", 0, 0, 800, 600, read_only);
+
+   fCanvas->SetCanvasImp(web);
+
+   SetPrivateCanvasFields(true);
+
+   web->SetCanCreateObjects(kFALSE); // not yet create objects on server side
+
+   web->SetUpdatedHandler([=]() { emit CanvasUpdated(); });
+
+   web->SetActivePadChangedHandler([=](TPad *pad){ emit SelectedPadChanged(pad); });
+
+   web->SetPadClickedHandler([=](TPad *pad, int x, int y) { emit PadClicked(pad,x,y); });
+
+   web->SetPadDblClickedHandler([this](TPad *pad, int x, int y) { emit PadDblClicked(pad,x,y); });
+
+   ROOT::Experimental::RWebDisplayArgs args("qt5");
+   args.SetDriverData(this); // it is parent widget for created QWebEngineView element
+   args.SetUrlOpt("noopenui");
+
+   web->ShowWebWindow(args);
+
+   fView = findChild<QWebEngineView*>("RootWebView");
+   if (!fView) {
+      printf("FAIL TO FIND QWebEngineView - ROOT Qt5Web plugin does not work properly !!!!!\n");
+      exit(11);
+   }
+
+   gridLayout->addWidget(fView);
+
+   // QObject::connect(fView, SIGNAL(drop(QDropEvent*)), this, SLOT(dropView(QDropEvent*)));
+
+   fCanvas->SetCanvasSize(fView->width(), fView->height());
+}
+
+TCanvasWidget::~TCanvasWidget()
+{
+   if (fCanvas) {
+      SetPrivateCanvasFields(false);
+
+      gROOT->GetListOfCanvases()->Remove(fCanvas);
+
+      fCanvas->Close();
+      delete fCanvas;
+      fCanvas = nullptr;
+   }
+}
+
+void TCanvasWidget::SetPrivateCanvasFields(bool on_init)
+{
+   Long_t offset = TCanvas::Class()->GetDataMemberOffset("fCanvasID");
+   if (offset > 0) {
+      Int_t *id = (Int_t *)((char*) fCanvas + offset);
+      if (*id == fCanvas->GetCanvasID()) *id = on_init ? 111222333 : -1;
+   } else {
+      printf("ERROR: Cannot modify fCanvasID data member\n");
+   }
+
+   offset = TCanvas::Class()->GetDataMemberOffset("fMother");
+   if (offset > 0) {
+      TPad **moth = (TPad **)((char*) fCanvas + offset);
+      if (*moth == fCanvas->GetMother()) *moth = on_init ? fCanvas : nullptr;
+   } else {
+      printf("ERROR: Cannot set fMother data member in canvas\n");
+   }
+}
+
+void TCanvasWidget::resizeEvent(QResizeEvent *event)
+{
+   fCanvas->SetCanvasSize(fView->width(), fView->height());
+}
+
+void TCanvasWidget::activateEditor(TPad *pad, TObject *obj)
+{
+   TWebCanvas *cimp = dynamic_cast<TWebCanvas*> (fCanvas->GetCanvasImp());
+   if (cimp) {
+      cimp->ShowEditor(kTRUE);
+      cimp->ActivateInEditor(pad, obj);
+   }
+}
+
+void TCanvasWidget::setEditorVisible(bool flag)
+{
+   TCanvasImp *cimp = fCanvas->GetCanvasImp();
+   if (cimp) cimp->ShowEditor(flag);
+}
+
+void TCanvasWidget::activateStatusLine()
+{
+   TCanvasImp *cimp = fCanvas->GetCanvasImp();
+   if (cimp) cimp->ShowStatusBar(kTRUE);
+}

--- a/tutorials/webgui/qt5web/TCanvasWidget.h
+++ b/tutorials/webgui/qt5web/TCanvasWidget.h
@@ -1,3 +1,13 @@
+// Author: Sergey Linev, GSI  13/01/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 #ifndef TCanvasWidget_H
 #define TCanvasWidget_H
 
@@ -13,7 +23,7 @@ class TCanvasWidget : public QWidget {
    Q_OBJECT
 
 public:
-   TCanvasWidget(QWidget *parent = 0);
+   TCanvasWidget(QWidget *parent = nullptr);
    virtual ~TCanvasWidget();
 
    /// returns canvas shown in the widget

--- a/tutorials/webgui/qt5web/TCanvasWidget.h
+++ b/tutorials/webgui/qt5web/TCanvasWidget.h
@@ -1,0 +1,51 @@
+#ifndef TCanvasWidget_H
+#define TCanvasWidget_H
+
+#include <QWidget>
+#include <QWebEngineView>
+
+class TCanvas;
+class TPad;
+class TObject;
+
+class TCanvasWidget : public QWidget {
+
+   Q_OBJECT
+
+public:
+   TCanvasWidget(QWidget *parent = 0);
+   virtual ~TCanvasWidget();
+
+   /// returns canvas shown in the widget
+   TCanvas *getCanvas() { return fCanvas; }
+
+signals:
+
+   void CanvasUpdated();
+
+   void SelectedPadChanged(TPad*);
+
+   void PadClicked(TPad*,int,int);
+
+   void PadDblClicked(TPad*,int,int);
+
+public slots:
+
+   void activateEditor(TPad *pad = nullptr, TObject *obj = nullptr);
+
+   void activateStatusLine();
+
+   void setEditorVisible(bool flag = true);
+
+protected:
+
+   void resizeEvent(QResizeEvent *event) override;
+
+   void SetPrivateCanvasFields(bool on_init);
+
+   QWebEngineView *fView{nullptr};  ///< qt webwidget to show
+
+   TCanvas *fCanvas{nullptr};
+};
+
+#endif

--- a/tutorials/webgui/qt5web/qt5web.pro
+++ b/tutorials/webgui/qt5web/qt5web.pro
@@ -23,7 +23,9 @@ unix:QMAKE_CXXFLAGS += -fPIC
 
 FORMS += ExampleWidget.ui
 
-HEADERS += ExampleWidget.h
+HEADERS += ExampleWidget.h \
+           TCanvasWidget.h
 
 SOURCES += ExampleWidget.cpp \
+           TCanvasWidget.cpp \
            ExampleMain.cpp

--- a/tutorials/webgui/qt5web/qt5web.pro
+++ b/tutorials/webgui/qt5web/qt5web.pro
@@ -24,8 +24,10 @@ unix:QMAKE_CXXFLAGS += -fPIC
 FORMS += ExampleWidget.ui
 
 HEADERS += ExampleWidget.h \
-           TCanvasWidget.h
+           TCanvasWidget.h \
+           RCanvasWidget.h
 
 SOURCES += ExampleWidget.cpp \
            TCanvasWidget.cpp \
+           RCanvasWidget.cpp \
            ExampleMain.cpp

--- a/tutorials/webgui/qt5web/qt5web.pro
+++ b/tutorials/webgui/qt5web/qt5web.pro
@@ -1,0 +1,29 @@
+QT += network widgets webengine webenginewidgets
+
+TEMPLATE	= app
+LANGUAGE	= C++
+MOC_DIR     =.moc
+OBJECTS_DIR =.obj
+
+CONFIG	+= qt warn_off thread
+
+INCLUDEPATH += $$(ROOTSYS)/include
+DEPENDPATH  += $$(ROOTSYS)/include
+
+TARGET      = qt5web
+DESTDIR     = .
+PROJECTNAME = RootQt5Web
+
+win32:QMAKE_LFLAGS  += /nodefaultlib:msvcrt /verbose:lib msvcrt.lib
+
+win32:QMAKE_CXXFLAGS  += -MD
+
+# this is necessary to solve error with non-initialized gSystem
+unix:QMAKE_CXXFLAGS += -fPIC
+
+FORMS += ExampleWidget.ui
+
+HEADERS += ExampleWidget.h
+
+SOURCES += ExampleWidget.cpp \
+           ExampleMain.cpp

--- a/ui5/canv/canvas.html
+++ b/ui5/canv/canvas.html
@@ -27,13 +27,18 @@
 
    <script type='text/javascript'>
 
-      let batch_mode = JSROOT.decodeUrl().has("batch_mode"),
+      let url = JSROOT.decodeUrl(),
+          is_batch = url.has("batch_mode"),
+          is_ui5 = !url.has("noopenui") && !is_batch,
           _prereq = "v7";
 
-      if (batch_mode)
-        JSROOT.batch_mode = true;
-      else
-        _prereq += ";openui5";
+      if (is_batch)
+         JSROOT.batch_mode = true;
+
+      if (is_ui5)
+         _prereq += ";openui5";
+      else if (!is_batch)
+         _prereq += ";jq2d";
 
       JSROOT.connectWebWindow({
          prereq: _prereq,
@@ -41,14 +46,16 @@
          // openui5src: "https://openui5.hana.ondemand.com/1.82.2/",
       }).then(handle => {
          let painter = new JSROOT.v7.RCanvasPainter(null, null);
-         painter.batch_mode = batch_mode;
+         painter.online_canvas = true;
+         painter.use_openui = is_ui5;
+         painter.batch_mode = is_batch;
 
          if (window) {
             window.onbeforeunload = () => painter.closeWebsocket(true);
             if (JSROOT.browser.qt5) window.onqt5unload = window.onbeforeunload;
          }
 
-         if (!batch_mode) {
+         if (is_ui5) {
             painter.use_openui = true;
             painter._window_handle = handle;
 
@@ -71,8 +78,6 @@
             painter.setDom("CanvasDiv"); // just assign id, nothing else is happens
 
             painter.useWebsocket(handle); // when connection activated, ROOT must send new instance of the canvas
-
-            if (!batch_mode) JSROOT.Painter.registerForResize(painter);
          }
       });
 


### PR DESCRIPTION
1. Add several extra classes and code to implement full-functional `TWebCanvas`
    Functionality disabled by default - one has to set `WebGui.FullCanvas: 1` in rootrc file

2. Provide `qt5web` tutorial which shows how any ROOT web-based widget can be embed into Qt5-based application.
    As demo `RCanvas` and `TWebCanvas` are used. One probably can add more widgets like geometry viewer or `RBrowser`

3. Provide possibility to use RCanvas without openui5 case - useful exactly for such case when pure graphics should be embed.
    But even without ui5 for canvas itself one still can optionally use GED - 
    in this case ui5 only loaded on demand and used only for GED. 
