### PR TITLE
Fix IncrementalExecutor error with TExecutor::GetPoolSize() on Windows

### DIFF
--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -46,6 +46,7 @@ if(imt)
     src/RTaskArena.cxx
     src/TImplicitMT.cxx
     src/TThreadExecutor.cxx
+    src/TExecutor.cxx
   )
 
   target_include_directories(Imt SYSTEM PRIVATE ${TBB_INCLUDE_DIRS})

--- a/core/imt/inc/ROOT/TExecutor.hxx
+++ b/core/imt/inc/ROOT/TExecutor.hxx
@@ -443,30 +443,6 @@ auto TExecutor::MapReduce(F func, const std::vector<T> &args, R redfunc, unsigne
    return Reduce(Map(func, args, redfunc, nChunks), redfunc);
 }
 
-//////////////////////////////////////////////////////////////////////////
-/// \brief Return the number of pooled workers.
-///
-/// \return The number of workers in the pool in the executor used as a backend.
-
-unsigned TExecutor::GetPoolSize() const
-{
-   unsigned poolSize{0u};
-   switch(fExecPolicy){
-      case ROOT::EExecutionPolicy::kSequential:
-         poolSize = fSequentialExecutor->GetPoolSize();
-         break;
-      case ROOT::EExecutionPolicy::kMultiThread:
-         poolSize = fThreadExecutor->GetPoolSize();
-         break;
-      case ROOT::EExecutionPolicy::kMultiProcess:
-         poolSize = fProcessExecutor->GetPoolSize();
-         break;
-      default:
-         break;
-   }
-   return poolSize;
-}
-
 } // namespace Internal
 } // namespace ROOT
 

--- a/core/imt/src/TExecutor.cxx
+++ b/core/imt/src/TExecutor.cxx
@@ -1,0 +1,42 @@
+// @(#)root/thread:$Id$
+// Author: Xavier Valls September 2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+#include "ROOT/TExecutor.hxx"
+
+namespace ROOT{
+
+namespace Internal{
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Return the number of pooled workers.
+///
+/// \return The number of workers in the pool in the executor used as a backend.
+
+unsigned TExecutor::GetPoolSize() const
+{
+   unsigned poolSize{0u};
+   switch(fExecPolicy){
+      case ROOT::EExecutionPolicy::kSequential:
+         poolSize = fSequentialExecutor->GetPoolSize();
+         break;
+      case ROOT::EExecutionPolicy::kMultiThread:
+         poolSize = fThreadExecutor->GetPoolSize();
+         break;
+      case ROOT::EExecutionPolicy::kMultiProcess:
+         poolSize = fProcessExecutor->GetPoolSize();
+         break;
+      default:
+         break;
+   }
+   return poolSize;
+}
+
+} // namespace Internal
+} // namespace ROOT


### PR DESCRIPTION
Moving the inline unsigned TExecutor::GetPoolSize() const method from the TExecutor.hxx header file to the (new) TExecutor.cxx source file fixes the following error on Windows:
```
IncrementalExecutor::executeFunction: symbol '?GetPoolSize@TThreadExecutor@ROOT@@QBEIXZ' unresolved while linking function '??__Eid@?$codecvt@DDU_Mbstatet@@@std@@2V0locale@2@A@YAXXZcling_module_0_'!
You are probably missing the definition of public: unsigned int __thiscall ROOT::TThreadExecutor::GetPoolSize(void)const
Maybe you need to load the corresponding shared library?
```