### PR TITLE
Remove register keyword which is deprecated in c++17

### DIFF
--- a/math/mathcore/src/mixmax.icc
+++ b/math/mathcore/src/mixmax.icc
@@ -257,7 +257,7 @@ inline myuint fmodmulM61(myuint cum, myuint a, myuint b){
 
 inline myuint fmodmulM61(myuint cum, myuint s, myuint a)
 {
-    register myuint o,ph,pl,ah,al;
+    myuint o,ph,pl,ah,al;
     o=(s)*a;
     ph = ((s)>>32);
     pl = (s) & MASK32;


### PR DESCRIPTION
register is used in mixmax.icc for non intel x86 architecture (e.g. new Apple M1)
It is deprectaed and useless with new compiler versions (e.g. c++17)