### PR TITLE
v6.22: Fix #7016 Do no leak Conversion StreamerInfo for unversion classes.

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -7077,7 +7077,7 @@ TVirtualStreamerInfo *TClass::GetConversionStreamerInfo( const TClass* cl, Int_t
    info = (TVirtualStreamerInfo*)info->Clone();
 
    // When cloning the StreamerInfo we record (and thus restore)
-   // the absolute value of the version, let's keep the original.
+   // the absolute value of the version, let's restore the sign.
    if (version == -1)
       info->SetClassVersion(-1);
 
@@ -7183,7 +7183,7 @@ TVirtualStreamerInfo *TClass::FindConversionStreamerInfo( const TClass* cl, UInt
    info = (TVirtualStreamerInfo*)info->Clone();
 
    // When cloning the StreamerInfo we record (and thus restore)
-   // the absolute value of the version, let's keep the original.
+   // the absolute value of the version, let's restore the sign.
    if (version == -1)
       info->SetClassVersion(-1);
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -7047,7 +7047,7 @@ TVirtualStreamerInfo *TClass::GetConversionStreamerInfo( const TClass* cl, Int_t
          arr = it->second;
       }
 
-      if( arr && version > -1 && version < arr->GetSize() && arr->At( version ) )
+      if( arr && version >= -1 && version < arr->GetSize() && arr->At( version ) )
          return (TVirtualStreamerInfo*) arr->At( version );
    }
 
@@ -7076,6 +7076,11 @@ TVirtualStreamerInfo *TClass::GetConversionStreamerInfo( const TClass* cl, Int_t
 
    info = (TVirtualStreamerInfo*)info->Clone();
 
+   // When cloning the StreamerInfo we record (and thus restore)
+   // the absolute value of the version, let's keep the original.
+   if (version == -1)
+      info->SetClassVersion(-1);
+
    if( !info->BuildFor( this ) ) {
       delete info;
       return 0;
@@ -7098,6 +7103,11 @@ TVirtualStreamerInfo *TClass::GetConversionStreamerInfo( const TClass* cl, Int_t
          fConversionStreamerInfo = new std::map<std::string, TObjArray*>();
       }
       (*fConversionStreamerInfo)[cl->GetName()] = arr;
+   }
+   if (arr->At(info->GetClassVersion())) {
+      Error("GetConversionStreamerInfo", "Conversion StreamerInfo from %s to %s version %d has already been created",
+            this->GetName(), info->GetName(), info->GetClassVersion());
+      delete arr->At(info->GetClassVersion());
    }
    arr->AddAtAndExpand( info, info->GetClassVersion() );
    return info;
@@ -7169,7 +7179,14 @@ TVirtualStreamerInfo *TClass::FindConversionStreamerInfo( const TClass* cl, UInt
    // non artificial streamer elements and we should build it for current class
    /////////////////////////////////////////////////////////////////////////////
 
+   int version = info->GetClassVersion();
    info = (TVirtualStreamerInfo*)info->Clone();
+
+   // When cloning the StreamerInfo we record (and thus restore)
+   // the absolute value of the version, let's keep the original.
+   if (version == -1)
+      info->SetClassVersion(-1);
+
    if( !info->BuildFor( this ) ) {
       delete info;
       return 0;

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2155,7 +2155,7 @@ void TBranchElement::SetupInfo()
 
          TStreamerInfo* info;
          if( targetClass != cl )
-            info = (TStreamerInfo*)targetClass->GetConversionStreamerInfo( cl, fCheckSum );
+            info = (TStreamerInfo*)targetClass->FindConversionStreamerInfo( cl, fCheckSum );
          else {
             info = (TStreamerInfo*)cl->FindStreamerInfo( fCheckSum );
             if (info) {


### PR DESCRIPTION
The leak is related to the handling of conversion from unversioned class from MathCore
(namely from ```ROOT::Math::Cartesian3D<double>``` to ```ROOT::Math::Cartesian3D<Double32_t>``` and
```ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::GlobalCoordinateSystemTag>```
to ```ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::GlobalCoordinateSystemTag>```

In some circumstances (involving which StreamerInfo was recorded in an acceleration structure/cache), TClass was
not remembering that it already created the Conversion StreamerInfo from one to the other and recreating from each object read.

In the case of DUNE, the leak was triggered by running:
```
   Events->Draw("recob::Tracks_pandoraTrack__DecoderandReco.obj.fTraj.fMomenta.fCoordinates.fX");
```
or similar.