### PR TITLE
Fix typo in minuit2 omp cmake feature flag

### DIFF
--- a/math/minuit2/StandAlone.cmake
+++ b/math/minuit2/StandAlone.cmake
@@ -155,7 +155,7 @@ if(minuit2_standalone)
 endif()
 
 # Setup package info
-add_feature_info(minuit2_openmp minuit2_openmp "OpenMP (Thread safe FCNs only)")
+add_feature_info(minuit2_omp minuit2_omp "OpenMP (Thread safe FCNs only)")
 add_feature_info(minuit2_mpi minuit2_mpi "MPI (Thread safe FCNs only)")
 set_package_properties(OpenMP PROPERTIES
     URL "http://www.openmp.org"


### PR DESCRIPTION
See https://github.com/GooFit/Minuit2/issues/7. The feature should have the same flag as the OMP flag.