### PR TITLE
whitelist libMultiProc as library loaded importing ROOT

### DIFF
--- a/bindings/pyroot/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot/pythonizations/test/import_load_libs.py
@@ -35,6 +35,7 @@ class ImportLoadLibs(unittest.TestCase):
             'libNet',
             'libImt',
             'libMathCore',
+            'libMultiProc',
             'libssl',
             'libcrypt.*', # by libssl
             'libtbb',


### PR DESCRIPTION
Now Imt depends on MultiProc (https://github.com/root-project/root/pull/7040), so MultiProc gets loaded when importing ROOT in python and needs to be whitelisted