### PR TITLE
remove dependency on tbb interfaces from RTaskArena

### DIFF
--- a/core/imt/inc/ROOT/RTaskArena.hxx
+++ b/core/imt/inc/ROOT/RTaskArena.hxx
@@ -36,12 +36,11 @@
 
 /// tbb::task_arena is an alias of tbb::interface7::task_arena, which doesn't allow
 /// to forward declare tbb::task_arena without forward declaring tbb::interface7
-namespace tbb{
-namespace interface7{class task_arena;}
-using task_arena = interface7::task_arena;
-}
 
 namespace ROOT {
+
+class ROpaqueTaskArena;
+
 namespace Internal {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -65,11 +64,11 @@ class RTaskArenaWrapper {
 public:
    ~RTaskArenaWrapper(); // necessary to set size back to zero
    static unsigned TaskArenaSize(); // A static getter lets us check for RTaskArenaWrapper's existence
-   tbb::task_arena &Access();
+   ROOT::ROpaqueTaskArena &Access();
 private:
    RTaskArenaWrapper(unsigned maxConcurrency = 0);
    friend std::shared_ptr<ROOT::Internal::RTaskArenaWrapper> GetGlobalTaskArena(unsigned maxConcurrency);
-   std::unique_ptr<tbb::task_arena> fTBBArena;
+   std::unique_ptr<ROOT::ROpaqueTaskArena> fTBBArena;
    static unsigned fNWorkers;
 };
 

--- a/core/imt/src/ROpaqueTaskArena.hxx
+++ b/core/imt/src/ROpaqueTaskArena.hxx
@@ -1,0 +1,5 @@
+#include "tbb/task_arena.h"
+
+namespace ROOT {
+class ROpaqueTaskArena: public tbb::task_arena {};
+}

--- a/core/imt/src/RTaskArena.cxx
+++ b/core/imt/src/RTaskArena.cxx
@@ -1,4 +1,5 @@
 #include "ROOT/RTaskArena.hxx"
+#include "ROpaqueTaskArena.hxx"
 #include "TError.h"
 #include "TROOT.h"
 #include "TThread.h"
@@ -68,7 +69,7 @@ int LogicalCPUBandwithControl()
 /// * If no BC in place and maxConcurrency<1, defaults to the default tbb number of threads,
 /// which is CPU affinity aware
 ////////////////////////////////////////////////////////////////////////////////
-RTaskArenaWrapper::RTaskArenaWrapper(unsigned maxConcurrency) : fTBBArena(new tbb::task_arena{})
+RTaskArenaWrapper::RTaskArenaWrapper(unsigned maxConcurrency) : fTBBArena(new ROpaqueTaskArena{})
 {
    const unsigned tbbDefaultNumberThreads = fTBBArena->max_concurrency(); // not initialized, automatic state
    maxConcurrency = maxConcurrency > 0 ? std::min(maxConcurrency, tbbDefaultNumberThreads) : tbbDefaultNumberThreads;
@@ -100,7 +101,7 @@ unsigned RTaskArenaWrapper::TaskArenaSize()
 ////////////////////////////////////////////////////////////////////////////////
 /// Provides access to the wrapped tbb::task_arena.
 ////////////////////////////////////////////////////////////////////////////////
-tbb::task_arena &RTaskArenaWrapper::Access()
+ROOT::ROpaqueTaskArena &RTaskArenaWrapper::Access()
 {
    return *fTBBArena;
 }

--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -1,4 +1,5 @@
 #include "ROOT/TThreadExecutor.hxx"
+#include "ROpaqueTaskArena.hxx"
 #if !defined(_MSC_VER)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"

--- a/core/imt/test/testRTaskArena.cxx
+++ b/core/imt/test/testRTaskArena.cxx
@@ -1,6 +1,7 @@
 #include "TROOT.h"
 #include "ROOT/RTaskArena.hxx"
 #include "ROOT/TThreadExecutor.hxx"
+#include "../src/ROpaqueTaskArena.hxx"
 #include <fstream>
 #include <random>
 #include <thread>
@@ -8,7 +9,6 @@
 #include <condition_variable>
 #include <mutex>
 #include "gtest/gtest.h"
-#include "tbb/task_arena.h"
 
 #ifdef R__USE_IMT
 


### PR DESCRIPTION
Introduce yet another layer of abstraction in ROpaqueTaskArena,
a class inheriting from tbb::task_arena that will allow us to keep
tbb hidden from ROOT interfaces while solving the issue of having to
forward-declare tbb::task_arena in an interface-dependent way

Thanks @Axel-Naumann !