### PR TITLE
[PyROOT][ROOT-10830] Add hash pythonization for std::string

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -841,6 +841,16 @@ PyObject* name##StringCompare(PyObject* self, PyObject* obj)                 \
 CPPYY_IMPL_STRING_PYTHONIZATION_CMP(std::string, Stl)
 CPPYY_IMPL_STRING_PYTHONIZATION_CMP(std::wstring, StlW)
 
+Py_hash_t StlStringHash(PyObject* self)
+{
+// std::string objects hash to the same values as Python strings to allow
+// matches in dictionaries etc.
+    PyObject* data = StlStringGetData(self);
+    Py_hash_t h = CPyCppyy_PyText_Type.tp_hash(data);
+    Py_DECREF(data);
+    return h;
+}
+
 
 //- STL iterator behavior ----------------------------------------------------
 PyObject* StlIterNext(PyObject* self)
@@ -1157,6 +1167,7 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
         Utility::AddToClass(pyclass, "__cmp__",  (PyCFunction)StlStringCompare, METH_O);
         Utility::AddToClass(pyclass, "__eq__",   (PyCFunction)StlStringIsEqual, METH_O);
         Utility::AddToClass(pyclass, "__ne__",   (PyCFunction)StlStringIsNotEqual, METH_O);
+        ((PyTypeObject*)pyclass)->tp_hash = (hashfunc)StlStringHash;
     }
 
     else if (name == "basic_string<wchar_t,char_traits<wchar_t>,allocator<wchar_t> >" || \


### PR DESCRIPTION
Fixes following reproducer in https://sft.its.cern.ch/jira/browse/ROOT-10830 :
```python
>>> v = cppyy.gbl.std.vector[cppyy.gbl.std.string]()
>>> v.push_back('a')
>>> v.push_back('b')
>>> v.push_back('c')
>>> set(v) == set('abc')
True
```

Hash std::string and str of the same char sequence to the same value. From:
https://bitbucket.org/wlav/cpycppyy/commits/66ad2fca300b4343ce17144b448725fd9e260e21