### PR TITLE
[webgui] many RBrowser improvments

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1811,7 +1811,7 @@ if(webgui)
       ExternalProject_Add(
         OPENUI5
         URL ${CMAKE_SOURCE_DIR}/builtins/openui5/openui5.tar.gz
-        URL_HASH SHA256=0cde25387047163fe2ed5f32eb7224628be10c3b6afa07d0b2a42002543909c2
+        URL_HASH SHA256=f40910aae22afb80f0d1a0ff07577ff8073896dd4415e4c64a125b7c29b89b0e
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""

--- a/graf3d/eve7/src/REveGeomViewer.cxx
+++ b/graf3d/eve7/src/REveGeomViewer.cxx
@@ -36,9 +36,9 @@ ROOT::Experimental::REveGeomViewer::REveGeomViewer(TGeoManager *mgr, const std::
    fWebWindow->SetDefaultPage("file:rootui5sys/eve7/geom.html");
 
    // this is call-back, invoked when message received via websocket
-   fWebWindow->SetDataCallBack([this](unsigned connid, const std::string &arg) { this->WebWindowCallback(connid, arg); });
+   fWebWindow->SetDataCallBack([this](unsigned connid, const std::string &arg) { WebWindowCallback(connid, arg); });
    fWebWindow->SetGeometry(900, 700); // configure predefined window geometry
-   fWebWindow->SetConnLimit(1); // the only connection is allowed
+   fWebWindow->SetConnLimit(0); // allow any connections numbers at the same time
    fWebWindow->SetMaxQueueLength(30); // number of allowed entries in the window queue
 
    fDesc.SetPreferredOffline(gEnv->GetValue("WebGui.PreferredOffline",0) != 0);

--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -45,6 +45,17 @@ public:
 
    static EContentKind GetContentKind(const std::string &kind);
 
+   /** Possible actions on double-click */
+   enum EActionKind {
+      kActNone,    ///< do nothing
+      kActBrowse,  ///< just browse (expand) item
+      kActEdit,    ///< can provide data for text editor
+      kActImage,   ///< can be shown in image viewer, can provide image
+      kActDraw6,   ///< can be drawn inside ROOT6 canvas
+      kActDraw7,   ///< can be drawn inside ROOT7 canvas
+      kActGeom     ///< can be shown in geometry viewer
+   };
+
    virtual ~RElement() = default;
 
    /** Name of browsable, must be provided in derived classes */
@@ -66,6 +77,12 @@ public:
 
    /** Access object */
    virtual std::unique_ptr<RHolder> GetObject() { return nullptr; }
+
+   /** Get default action */
+   virtual EActionKind GetDefaultAction() const { return kActNone; }
+
+   /** Check if want to perform action */
+   virtual bool IsCapable(EActionKind action) const { return action == GetDefaultAction(); }
 
    static std::shared_ptr<RElement> GetSubElement(std::shared_ptr<RElement> &elem, const RElementPath_t &path);
 

--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -59,6 +59,8 @@ public:
    /** Create iterator for childs elements if any */
    virtual std::unique_ptr<RLevelIter> GetChildsIter();
 
+   virtual int GetNumChilds();
+
    /** Returns element content, depends from kind. Can be "text" or "image64" or "json" */
    virtual std::string GetContent(const std::string & = "text");
 

--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -66,6 +66,10 @@ public:
    virtual std::unique_ptr<RHolder> GetObject() { return nullptr; }
 
    static std::shared_ptr<RElement> GetSubElement(std::shared_ptr<RElement> &elem, const RElementPath_t &path);
+
+   static int ComparePaths(const RElementPath_t &path1, const RElementPath_t &path2);
+
+   static std::string GetPathAsString(const RElementPath_t &path);
 };
 
 } // namespace Browsable

--- a/gui/browsable/inc/ROOT/Browsable/RLevelIter.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RLevelIter.hxx
@@ -31,25 +31,18 @@ class RLevelIter {
 public:
    virtual ~RLevelIter() = default;
 
-   /** Shift to next element */
+   /** Shift to next entry */
    virtual bool Next() = 0;
 
-   /** Is there current element  */
-   virtual bool HasItem() const = 0;
+   /** Returns current entry name  */
+   virtual std::string GetItemName() const = 0;
 
-   /** Returns current element name  */
-   virtual std::string GetName() const = 0;
+   virtual int GetNumItemChilds() const;
 
-   /** If element may have childs: 0 - no, >0 - yes, -1 - maybe */
-   virtual int CanHaveChilds() const { return 0; }
-
-   /** Returns full information for current element */
+   /** Create RElement for current entry - may take much time to load object or open file */
    virtual std::shared_ptr<RElement> GetElement() = 0;
 
    virtual std::unique_ptr<RItem> CreateItem();
-
-   /** Reset iterator to the first element, returns false if not supported */
-   virtual bool Reset() { return false; }
 
    virtual bool Find(const std::string &name);
 

--- a/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
@@ -73,6 +73,7 @@ private:
    struct StructDraw7 { RProvider *provider{nullptr}; Draw7Func_t func; };
    struct StructClass {
       RProvider *provider{nullptr};
+      bool can_have_childs{false};
       std::string iconname, browselib, draw6lib, draw7lib;
       bool dummy() const { return !provider; }
    };

--- a/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
@@ -39,13 +39,23 @@ public:
 
    virtual ~RProvider();
 
-   static std::string GetClassIcon(const std::string &classname);
-   static std::string GetClassIcon(const TClass *cl);
+   class ClassArg {
+      friend class RProvider;
+      const TClass *cl{nullptr};
+      std::string name;
+      ClassArg() = delete;
+   public:
+      ClassArg(const TClass *_cl) : cl(_cl) {}
+      ClassArg(const std::string &_name) : name(_name) {}
+      ClassArg(const char *_name) : name(_name) {}
 
-   static bool CanHaveChilds(const std::string &classname);
-   static bool CanHaveChilds(const TClass *cl);
-   static bool CanDraw6(const TClass *cl);
-   static bool CanDraw7(const TClass *cl);
+      bool empty() const { return !cl && name.empty(); }
+   };
+
+   static std::string GetClassIcon(const ClassArg &);
+   static bool CanHaveChilds(const ClassArg &);
+   static bool CanDraw6(const ClassArg &);
+   static bool CanDraw7(const ClassArg &);
 
    static bool IsFileFormatSupported(const std::string &extension);
    static std::shared_ptr<RElement> OpenFile(const std::string &extension, const std::string &fullname);
@@ -95,8 +105,7 @@ private:
    static Draw6Map_t &GetDraw6Map();
    static Draw7Map_t &GetDraw7Map();
 
-   static const StructClass &GetClassEntry(const std::string &clname);
-   static const StructClass &GetClassEntry(const TClass *cl, bool check_parent = true);
+   static const StructClass &GetClassEntry(const ClassArg &);
 
    template<class Map_t>
    void CleanThis(Map_t &fmap)

--- a/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
@@ -50,6 +50,8 @@ public:
       ClassArg(const char *_name) : name(_name) {}
 
       bool empty() const { return !cl && name.empty(); }
+      const TClass *GetClass() const { return cl; }
+      const std::string &GetName() const { return name; }
    };
 
    static std::string GetClassIcon(const ClassArg &);

--- a/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
@@ -44,6 +44,8 @@ public:
 
    static bool CanHaveChilds(const std::string &classname);
    static bool CanHaveChilds(const TClass *cl);
+   static bool CanDraw6(const TClass *cl);
+   static bool CanDraw7(const TClass *cl);
 
    static bool IsFileFormatSupported(const std::string &extension);
    static std::shared_ptr<RElement> OpenFile(const std::string &extension, const std::string &fullname);

--- a/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
@@ -42,6 +42,9 @@ public:
    static std::string GetClassIcon(const std::string &classname);
    static std::string GetClassIcon(const TClass *cl);
 
+   static bool CanHaveChilds(const std::string &classname);
+   static bool CanHaveChilds(const TClass *cl);
+
    static bool IsFileFormatSupported(const std::string &extension);
    static std::shared_ptr<RElement> OpenFile(const std::string &extension, const std::string &fullname);
    static std::shared_ptr<RElement> Browse(std::unique_ptr<RHolder> &obj);

--- a/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
@@ -40,6 +40,7 @@ public:
    virtual ~RProvider();
 
    static std::string GetClassIcon(const std::string &classname);
+   static std::string GetClassIcon(const TClass *cl);
 
    static bool IsFileFormatSupported(const std::string &extension);
    static std::shared_ptr<RElement> OpenFile(const std::string &extension, const std::string &fullname);
@@ -58,23 +59,38 @@ protected:
    void RegisterBrowse(const TClass *cl, BrowseFunc_t func);
    void RegisterDraw6(const TClass *cl, Draw6Func_t func);
    void RegisterDraw7(const TClass *cl, Draw7Func_t func);
+   void RegisterClass(const std::string &clname,
+                      const std::string &iconname,
+                      const std::string &browselib = "",
+                      const std::string &draw6lib = "",
+                      const std::string &draw7lib = "");
 
 private:
 
-   struct StructBrowse { RProvider *provider{nullptr};  BrowseFunc_t func; };
-   struct StructFile { RProvider *provider{nullptr};  FileFunc_t func; };
-   struct StructDraw6 { RProvider *provider{nullptr};  Draw6Func_t func; };
-   struct StructDraw7 { RProvider *provider{nullptr};  Draw7Func_t func; };
+   struct StructBrowse { RProvider *provider{nullptr}; BrowseFunc_t func; };
+   struct StructFile { RProvider *provider{nullptr}; FileFunc_t func; };
+   struct StructDraw6 { RProvider *provider{nullptr}; Draw6Func_t func; };
+   struct StructDraw7 { RProvider *provider{nullptr}; Draw7Func_t func; };
+   struct StructClass {
+      RProvider *provider{nullptr};
+      std::string iconname, browselib, draw6lib, draw7lib;
+      bool dummy() const { return !provider; }
+   };
 
-   using BrowseMap_t = std::multimap<const TClass*, StructBrowse>;
+   using ClassMap_t = std::multimap<std::string, StructClass>;
    using FileMap_t = std::multimap<std::string, StructFile>;
+   using BrowseMap_t = std::multimap<const TClass*, StructBrowse>;
    using Draw6Map_t = std::multimap<const TClass*, StructDraw6>;
    using Draw7Map_t = std::multimap<const TClass*, StructDraw7>;
 
-   static BrowseMap_t &GetBrowseMap();
+   static ClassMap_t &GetClassMap();
    static FileMap_t &GetFileMap();
+   static BrowseMap_t &GetBrowseMap();
    static Draw6Map_t &GetDraw6Map();
    static Draw7Map_t &GetDraw7Map();
+
+   static const StructClass &GetClassEntry(const std::string &clname);
+   static const StructClass &GetClassEntry(const TClass *cl, bool check_parent = true);
 
    template<class Map_t>
    void CleanThis(Map_t &fmap)

--- a/gui/browsable/inc/ROOT/Browsable/RSysFile.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RSysFile.hxx
@@ -51,6 +51,8 @@ public:
 
    std::string GetContent(const std::string &kind) override;
 
+   EActionKind GetDefaultAction() const override;
+
    static std::string GetFileIcon(const std::string &fname);
 
    static std::string ProvideTopEntries(std::shared_ptr<RGroup> &comp, const std::string &workdir = "");

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -59,6 +59,11 @@ public:
    std::unique_ptr<RHolder> GetObject() override;
 
    const TClass *GetClass() const;
+
+   EActionKind GetDefaultAction() const override;
+
+   bool IsCapable(EActionKind) const override;
+
 };
 
 } // namespace Browsable

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -40,7 +40,7 @@ public:
 
    TObjectElement(std::unique_ptr<RHolder> &obj, const std::string &name = "");
 
-   virtual ~TObjectElement() = default;
+   virtual ~TObjectElement();
 
    /** Name of TObject */
    std::string GetName() const override;

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -58,7 +58,7 @@ public:
    /** Return copy of TObject holder - if possible */
    std::unique_ptr<RHolder> GetObject() override;
 
-   std::string ClassName() const;
+   const TClass *GetClass() const;
 };
 
 } // namespace Browsable

--- a/gui/browsable/src/RElement.cxx
+++ b/gui/browsable/src/RElement.cxx
@@ -30,6 +30,19 @@ std::unique_ptr<RLevelIter> RElement::GetChildsIter()
 }
 
 /////////////////////////////////////////////////////////////////////
+/// Returns number of childs
+/// By default creates iterator and iterates over all items
+
+int RElement::GetNumChilds()
+{
+   auto iter = GetChildsIter();
+   if (!iter) return 0;
+   int cnt = 0;
+   while (iter->Next()) cnt++;
+   return cnt;
+}
+
+/////////////////////////////////////////////////////////////////////
 /// Find item with specified name
 /// Default implementation, should work for all
 

--- a/gui/browsable/src/RElement.cxx
+++ b/gui/browsable/src/RElement.cxx
@@ -82,3 +82,33 @@ std::string RElement::GetContent(const std::string &kind)
    return ""s;
 }
 
+/////////////////////////////////////////////////////////////////////
+/// Compare two paths,
+/// Returns number of elements matches in both paths
+
+int RElement::ComparePaths(const RElementPath_t &path1, const RElementPath_t &path2)
+{
+   int sz = path1.size();
+   if (sz > (int) path2.size()) sz = path2.size();
+
+   for (int n = 0; n < sz; ++n)
+      if (path1[n] != path2[n])
+         return n;
+
+   return sz;
+}
+
+/////////////////////////////////////////////////////////////////////
+/// Converts element path back to string
+
+std::string RElement::GetPathAsString(const RElementPath_t &path)
+{
+   std::string res;
+   for (auto &elem : path) {
+      res.append("/");
+      res.append(elem);
+   }
+
+   return res;
+}
+

--- a/gui/browsable/src/RGroup.cxx
+++ b/gui/browsable/src/RGroup.cxx
@@ -24,28 +24,20 @@ public:
    virtual ~RGroupIter() = default;
 
    /** Shift to next element */
-   bool Next() override { fIndx++; return HasItem(); }
-
-   /** Is there current element  */
-   bool HasItem() const override { return (fIndx >= 0) &&  (fIndx < (int) fComp.GetChilds().size()); }
+   bool Next() override { return ++fIndx < (int) fComp.GetChilds().size(); }
 
    /** Returns current element name  */
-   std::string GetName() const override { return fComp.GetChilds()[fIndx]->GetName(); }
+   std::string GetItemName() const override { return fComp.GetChilds()[fIndx]->GetName(); }
 
-   /** If element may have childs: 0 - no, >0 - yes, -1 - maybe */
-   int CanHaveChilds() const override { return fComp.GetChilds().size(); }
+   /** Number of child elements in current element - not know, most probably there */
+   int GetNumItemChilds() const override { return -1; }
 
    /** Returns full information for current element */
    std::shared_ptr<RElement> GetElement() override { return fComp.GetChilds()[fIndx]; }
 
-   /** Reset iterator to the first element, returns false if not supported */
-   bool Reset() override { fIndx = -1; return true; }
-
    /** Find item with specified name, use item MatchName() functionality */
    bool Find(const std::string &name) override
    {
-      if (!Reset()) return false;
-
       while (Next()) {
          if (fComp.GetChilds()[fIndx]->MatchName(name))
             return true;

--- a/gui/browsable/src/RLevelIter.cxx
+++ b/gui/browsable/src/RLevelIter.cxx
@@ -13,16 +13,26 @@
 
 using namespace ROOT::Experimental::Browsable;
 
+
+/////////////////////////////////////////////////////////////////////
+/// Returns number of childs in current entry
+/// 0 if there is no childs
+/// >0 if there are really childs
+/// -1 if entry may have child elements
+
+int RLevelIter::GetNumItemChilds() const
+{
+   return 0;
+}
+
 /////////////////////////////////////////////////////////////////////
 /// Find item with specified name
 /// Default implementation, should work for all
 
 bool RLevelIter::Find(const std::string &name)
 {
-   if (!Reset()) return false;
-
    while (Next()) {
-      if (GetName() == name)
+      if (GetItemName() == name)
          return true;
    }
 
@@ -35,6 +45,8 @@ bool RLevelIter::Find(const std::string &name)
 
 std::unique_ptr<RItem> RLevelIter::CreateItem()
 {
-   return HasItem() ? std::make_unique<RItem>(GetName(), CanHaveChilds(), CanHaveChilds() > 0 ? "sap-icon://folder-blank" : "sap-icon://document") : nullptr;
+   auto nchilds = GetNumItemChilds();
+
+   return std::make_unique<RItem>(GetItemName(), nchilds, nchilds != 0 ? "sap-icon://folder-blank" : "sap-icon://document");
 }
 

--- a/gui/browsable/src/RProvider.cxx
+++ b/gui/browsable/src/RProvider.cxx
@@ -137,14 +137,18 @@ void RProvider::RegisterDraw7(const TClass *cl, Draw7Func_t func)
 // Register class with supported libs (if any)
 
 void RProvider::RegisterClass(const std::string &clname, const std::string &iconname,
-                             const std::string &browselib, const std::string &draw6lib, const std::string &draw7lib)
+                              const std::string &browselib, const std::string &draw6lib, const std::string &draw7lib)
 {
    auto &bmap = GetClassMap();
 
    if (!clname.empty() && (bmap.find(clname) != bmap.end()))
       R__LOG_ERROR(BrowsableLog()) << "Entry for class " << clname << " already exists";
 
-   bmap.emplace(clname, StructClass{this, iconname,browselib, draw6lib, draw7lib});
+   std::string blib = browselib;
+   bool can_have_childs = !browselib.empty();
+   if ((blib == "dflt") || (blib == "TObject")) blib = ""; // just use as indicator that browsing is possible
+
+   bmap.emplace(clname, StructClass{this, can_have_childs, iconname, blib, draw6lib, draw7lib});
 }
 
 //////////////////////////////////////////////////////////////////////////////////
@@ -380,4 +384,21 @@ std::string RProvider::GetClassIcon(const TClass *cl)
 
    return "sap-icon://electronic-medical-record"s;
 }
+
+
+
+// ==============================================================================================
+
+class RDefaultProvider : public RProvider {
+
+public:
+   RDefaultProvider()
+   {
+      // TODO: let read from rootrc or any other files
+      RegisterClass("ROOT::Experimental::RH1D", "sap-icon://vertical-bar-chart", "", "", "libROOTHistDrawProvider");
+      RegisterClass("ROOT::Experimental::RH2D", "sap-icon://pixelate", "", "", "libROOTHistDrawProvider");
+      RegisterClass("ROOT::Experimental::RH3D", "sap-icon://vertical-bar-chart", "", "", "libROOTHistDrawProvider");
+   }
+
+} newRDefaultProvider;
 

--- a/gui/browsable/src/RProvider.cxx
+++ b/gui/browsable/src/RProvider.cxx
@@ -161,7 +161,7 @@ const RProvider::StructClass &RProvider::GetClassEntry(const std::string &clname
       return iter->second;
 
    for (auto &elem : bmap)
-      if (elem.first.compare(0, clname.length(), clname) == 0)
+      if (clname.compare(0, elem.first.length(), elem.first) == 0)
          return elem.second;
 
    static StructClass dummy;

--- a/gui/browsable/src/RProvider.cxx
+++ b/gui/browsable/src/RProvider.cxx
@@ -224,7 +224,7 @@ std::shared_ptr<RElement> RProvider::OpenFile(const std::string &extension, cons
 // Template function to scan class entries, including parent object classes
 
 template<class Map_t, class Iterator_t>
-bool ScanProviderMap(Map_t &fmap, const TClass *cl, bool test_all, std::function<bool(Iterator_t &)> check_func)
+bool ScanProviderMap(Map_t &fmap, const TClass *cl, bool test_all = false, std::function<bool(Iterator_t &)> check_func = nullptr)
 {
    if (!cl)
       return false;
@@ -233,7 +233,7 @@ bool ScanProviderMap(Map_t &fmap, const TClass *cl, bool test_all, std::function
    while (testcl) {
       auto iter = fmap.find(testcl);
       if (iter != fmap.end())
-         if (check_func(iter))
+         if (!check_func || check_func(iter))
             return true;
 
       auto bases = testcl->GetListOfBases();
@@ -369,6 +369,29 @@ bool RProvider::CanHaveChilds(const TClass *cl)
 {
    return GetClassEntry(cl).can_have_childs;
 }
+
+bool RProvider::CanDraw6(const TClass *cl)
+{
+   if (ScanProviderMap<Draw6Map_t, Draw6Map_t::iterator>(GetDraw6Map(), cl))
+      return true;
+
+   if (!GetClassEntry(cl).draw6lib.empty())
+      return true;
+
+   return false;
+}
+
+bool RProvider::CanDraw7(const TClass *cl)
+{
+   if (ScanProviderMap<Draw7Map_t, Draw7Map_t::iterator>(GetDraw7Map(), cl))
+      return true;
+
+   if (!GetClassEntry(cl).draw7lib.empty())
+      return true;
+
+   return false;
+}
+
 
 // ==============================================================================================
 

--- a/gui/browsable/src/RProvider.cxx
+++ b/gui/browsable/src/RProvider.cxx
@@ -378,9 +378,9 @@ public:
    RDefaultProvider()
    {
       // TODO: let read from rootrc or any other files
-      RegisterClass("ROOT::Experimental::RH1D", "sap-icon://vertical-bar-chart", "", "", "libROOTHistDrawProvider");
+      RegisterClass("ROOT::Experimental::RH1D", "sap-icon://bar-chart", "", "", "libROOTHistDrawProvider");
       RegisterClass("ROOT::Experimental::RH2D", "sap-icon://pixelate", "", "", "libROOTHistDrawProvider");
-      RegisterClass("ROOT::Experimental::RH3D", "sap-icon://vertical-bar-chart", "", "", "libROOTHistDrawProvider");
+      RegisterClass("ROOT::Experimental::RH3D", "sap-icon://product", "", "", "libROOTHistDrawProvider");
    }
 
 } newRDefaultProvider;

--- a/gui/browsable/src/RSysFile.cxx
+++ b/gui/browsable/src/RSysFile.cxx
@@ -237,31 +237,27 @@ public:
 
    virtual ~RSysDirLevelIter() { CloseDir(); }
 
-   bool Reset() override { return OpenDir(); }
-
    bool Next() override { return NextDirEntry(); }
 
    bool Find(const std::string &name) override { return FindDirEntry(name); }
 
-   bool HasItem() const override { return !fItemName.empty(); }
+   std::string GetItemName() const override { return fItemName; }
 
-   std::string GetName() const override { return fItemName; }
-
-   /** Returns true if item can have childs and one should try to create iterator (optional) */
-   int CanHaveChilds() const override
+   /** Returns -1 if directory or file format supported */
+   int GetNumItemChilds() const override
    {
       if (R_ISDIR(fCurrentStat.fMode))
-         return 1;
+         return -1;
 
       if (RProvider::IsFileFormatSupported(GetFileExtension(fCurrentName)))
-         return 1;
+         return -1;
 
       return 0;
    }
 
    std::unique_ptr<RItem> CreateItem() override
    {
-      auto item = std::make_unique<RSysFileItem>(GetName(), CanHaveChilds());
+      auto item = std::make_unique<RSysFileItem>(GetItemName(), GetNumItemChilds());
 
       // this is construction of current item
       char tmp[256];
@@ -277,7 +273,7 @@ public:
       if (item->isdir)
          item->SetIcon("sap-icon://folder-blank"s);
       else
-         item->SetIcon(RSysFile::GetFileIcon(GetName()));
+         item->SetIcon(RSysFile::GetFileIcon(GetItemName()));
 
       // file size
       Long64_t _fsize = item->size, bsize = item->size;

--- a/gui/browsable/src/RSysFile.cxx
+++ b/gui/browsable/src/RSysFile.cxx
@@ -475,6 +475,19 @@ bool RSysFile::MatchName(const std::string &name) const
 }
 
 /////////////////////////////////////////////////////////////////////////////////
+/// Get default action for the file
+/// Either start text editor or image viewer or just do file browsing
+
+RElement::EActionKind RSysFile::GetDefaultAction() const
+{
+   auto icon = GetFileIcon(GetName());
+   if (icon == "sap-icon://document-text"s) return kActEdit;
+   if (icon == "sap-icon://picture"s) return kActImage;
+   if (icon == "sap-icon://org-chart"s) return kActBrowse;
+   return kActNone;
+}
+
+/////////////////////////////////////////////////////////////////////////////////
 /// Returns full file name - including fully qualified path
 
 std::string RSysFile::GetFullName() const

--- a/gui/browsable/src/TBranchBrowseProvider.cxx
+++ b/gui/browsable/src/TBranchBrowseProvider.cxx
@@ -14,6 +14,11 @@
 
 using namespace ROOT::Experimental::Browsable;
 
+
+////////////////////////////////////////////////////////////
+/// Representing TBranchElement in browsables
+/// Kept here only for a demo - default TObject-based API is enough for handling TBranchElement
+
 class TBrElement : public TObjectElement {
 
 public:
@@ -21,15 +26,18 @@ public:
 
    virtual ~TBrElement() = default;
 
+   int GetNumChilds() override
+   {
+      auto br = fObject->Get<TBranchElement>();
+      return br && br->IsFolder() ? TObjectElement::GetNumChilds() : 0;
+   }
+
    /** Create iterator for childs elements if any */
    std::unique_ptr<RLevelIter> GetChildsIter() override
    {
-      TBranchElement *br = const_cast<TBranchElement*> (fObject->Get<TBranchElement>()); // try to cast into TBranchElement
-      if (!br) return nullptr;
-
-      if (br->GetListOfBranches()->GetEntriesFast() > 0)
+      auto br = fObject->Get<TBranchElement>();
+      if (br && br->IsFolder())
          return TObjectElement::GetChildsIter();
-
       return nullptr;
    }
 };

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -190,6 +190,42 @@ public:
       return std::make_unique<RAnyObjectHolder>(obj_class, obj, true);
    }
 
+
+   EActionKind GetDefaultAction() const override
+   {
+      if (fElement)
+         return fElement->GetDefaultAction();
+
+      std::string clname = fKey->GetClassName();
+      if (clname.empty()) return kActNone;
+      if (RProvider::CanDraw6(clname)) return kActDraw6;
+      if (RProvider::CanDraw7(clname)) return kActDraw7;
+      if (RProvider::CanHaveChilds(clname)) return kActBrowse;
+      return kActNone;
+
+   }
+
+   bool IsCapable(EActionKind action) const override
+   {
+      if (fElement)
+         return fElement->IsCapable(action);
+
+      std::string clname = fKey->GetClassName();
+      if (clname.empty()) return false;
+
+      switch(action) {
+         case kActBrowse: return RProvider::CanHaveChilds(clname);
+         case kActEdit: return true;
+         case kActImage:
+         case kActDraw6: return RProvider::CanDraw6(clname); // if can draw in TCanvas, can produce image
+         case kActDraw7: return RProvider::CanDraw7(clname);
+         case kActGeom: return false;  // TODO
+         default: return false;
+      }
+
+      return false;
+   }
+
 };
 
 // ==============================================================================================

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -199,8 +199,6 @@ public:
       if (tobj) {
          bool owned_by_dir = (fDir->FindObject(tobj) == tobj) || (clname == "TGeoManager");
 
-         printf("owned_by_dir obj %p %s %d\n", tobj, clname.c_str(), owned_by_dir);
-
          return std::make_unique<TObjectHolder>(tobj, !owned_by_dir);
       }
 

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -79,26 +79,15 @@ public:
 
    int GetNumItemChilds() const override
    {
-      std::string clname = fKey->GetClassName();
-      // TODO: more advanced logic required here
-      return (clname.find("TDirectory") == 0) ||
-             (clname.find("TGeoManager") == 0) ||
-             (clname.find("TGeoNode") == 0) ||
-             (clname.find("TGeoVolume") == 0) ||
-             (clname.find("TTree") == 0) ||
-             (clname.find("TNtuple") == 0) ||
-             (clname.find("TBranchElement") == 0) ? -1 : 0;
+      return RProvider::CanHaveChilds(fKey->GetClassName()) ? -1 : 0;
    }
 
    /** Create element for the browser */
    std::unique_ptr<RItem> CreateItem() override
    {
       auto item = std::make_unique<TKeyItem>(GetItemName(), GetNumItemChilds());
-
       item->SetClassName(fKey->GetClassName());
-
       item->SetIcon(RProvider::GetClassIcon(fKey->GetClassName()));
-
       return item;
    }
 

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -70,18 +70,14 @@ public:
 
    virtual ~TDirectoryLevelIter() = default;
 
-   bool Reset() override { return CreateIter(); }
-
    bool Next() override { return NextDirEntry(); }
 
    // use default implementation for now
    // bool Find(const std::string &name) override { return FindDirEntry(name); }
 
-   bool HasItem() const override { return fKey && !fCurrentName.empty(); }
+   std::string GetItemName() const override { return fCurrentName; }
 
-   std::string GetName() const override { return fCurrentName; }
-
-   int CanHaveChilds() const override
+   int GetNumItemChilds() const override
    {
       std::string clname = fKey->GetClassName();
       // TODO: more advanced logic required here
@@ -91,13 +87,13 @@ public:
              (clname.find("TGeoVolume") == 0) ||
              (clname.find("TTree") == 0) ||
              (clname.find("TNtuple") == 0) ||
-             (clname.find("TBranchElement") == 0) ? 1 : 0;
+             (clname.find("TBranchElement") == 0) ? -1 : 0;
    }
 
    /** Create element for the browser */
    std::unique_ptr<RItem> CreateItem() override
    {
-      auto item = std::make_unique<TKeyItem>(GetName(), CanHaveChilds());
+      auto item = std::make_unique<TKeyItem>(GetItemName(), GetNumItemChilds());
 
       item->SetClassName(fKey->GetClassName());
 

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -310,10 +310,27 @@ std::unique_ptr<RLevelIter> TCollectionElement::GetChildsIter()
 class RTObjectProvider : public RProvider {
 
 public:
+   //////////////////////////////////////////////////////////////////////////////////
+   // Register TObject-based class with standard browsing/drawing libs
+
+   void RegisterTObject(const std::string &clname, const std::string &iconname, bool can_browse = false, bool can_draw = true)
+   {
+      RegisterClass(clname, iconname, can_browse ? "dflt"s : ""s,
+                                      can_draw ? "libROOTObjectDraw6Provider"s : ""s,
+                                      can_draw ? "libROOTObjectDraw7Provider"s : ""s);
+   }
+
    RTObjectProvider()
    {
-      RegisterClass("TTree", "sap-icon://tree");
-      RegisterClass("TNtuple", "sap-icon://tree");
+      RegisterTObject("TTree", "sap-icon://tree", true, false);
+      RegisterTObject("TNtuple", "sap-icon://tree", true, false);
+      RegisterClass("TBranchElement", "sap-icon://e-care", "libROOTBranchBrowseProvider", "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
+      RegisterClass("TLeaf", "sap-icon://e-care", ""s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
+
+      RegisterTObject("TDirectory", "sap-icon://folder-blank", true, false);
+      RegisterTObject("TH1", "sap-icon://vertical-bar-chart");
+      RegisterTObject("TH2", "sap-icon://pixelate");
+      RegisterTObject("TGraph", "sap-icon://line-chart");
 
       RegisterBrowse(TFolder::Class(), [](std::unique_ptr<RHolder> &object) -> std::shared_ptr<RElement> {
          return std::make_shared<TFolderElement>(object);

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -180,13 +180,9 @@ RElement::EActionKind TObjectElement::GetDefaultAction() const
 {
    auto cl = GetClass();
    if (!cl) return kActNone;
-
    if (RProvider::CanDraw6(cl)) return kActDraw6;
-
    if (RProvider::CanDraw7(cl)) return kActDraw7;
-
    if (RProvider::CanHaveChilds(cl)) return kActBrowse;
-
    return kActNone;
 }
 
@@ -205,7 +201,7 @@ bool TObjectElement::IsCapable(RElement::EActionKind action) const
       default: return false;
    }
 
-   return true;
+   return false;
 }
 
 
@@ -367,34 +363,35 @@ public:
    //////////////////////////////////////////////////////////////////////////////////
    // Register TObject-based class with standard browsing/drawing libs
 
-   void RegisterTObject(const std::string &clname, const std::string &iconname, bool can_browse = false, bool can_draw = true)
+   void RegisterTObject(const std::string &clname, const std::string &iconname, bool can_browse = false, int can_draw = 3)
    {
       RegisterClass(clname, iconname, can_browse ? "dflt"s : ""s,
-                                      can_draw ? "libROOTObjectDraw6Provider"s : ""s,
-                                      can_draw ? "libROOTObjectDraw7Provider"s : ""s);
+                                      can_draw & 1 ? "libROOTObjectDraw6Provider"s : ""s,
+                                      can_draw & 2 ? "libROOTObjectDraw7Provider"s : ""s);
    }
 
    RTObjectProvider()
    {
-      RegisterTObject("TTree", "sap-icon://tree", true, false);
-      RegisterTObject("TNtuple", "sap-icon://tree", true, false);
+      RegisterTObject("TTree", "sap-icon://tree", true, 0);
+      RegisterTObject("TNtuple", "sap-icon://tree", true, 0);
       RegisterClass("TBranchElement", "sap-icon://e-care", "libROOTBranchBrowseProvider", "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
       RegisterClass("TLeaf", "sap-icon://e-care", ""s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
 
-      RegisterTObject("TDirectory", "sap-icon://folder-blank", true, false);
+      RegisterTObject("TDirectory", "sap-icon://folder-blank", true, 0);
       RegisterTObject("TH1", "sap-icon://bar-chart");
       RegisterTObject("TH2", "sap-icon://pixelate");
       RegisterTObject("TH3", "sap-icon://product");
       RegisterTObject("TProfile", "sap-icon://vertical-bar-chart");
       RegisterTObject("TGraph", "sap-icon://line-chart");
+      RegisterTObject("TCanvas", "sap-icon://business-objects-experience", false, 1); // only can use TWebCanvas
 
       RegisterTObject("THStack", "sap-icon://multiple-bar-chart");
       RegisterTObject("TMultiGraph", "sap-icon://multiple-line-chart");
 
-      RegisterTObject("TCollection", "sap-icon://list", true, false);
-      RegisterTObject("TGeoManager", "sap-icon://overview-chart", true, false);
-      RegisterTObject("TGeoVolume", "sap-icon://product", true, false);
-      RegisterTObject("TGeoNode", "sap-icon://product", true, false);
+      RegisterTObject("TCollection", "sap-icon://list", true, 0);
+      RegisterTObject("TGeoManager", "sap-icon://overview-chart", true, 0);
+      RegisterTObject("TGeoVolume", "sap-icon://product", true, 0);
+      RegisterTObject("TGeoNode", "sap-icon://product", true, 0);
 
       RegisterBrowse(TFolder::Class(), [](std::unique_ptr<RHolder> &object) -> std::shared_ptr<RElement> {
          return std::make_shared<TFolderElement>(object);

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -317,6 +317,9 @@ class RTObjectProvider : public RProvider {
 public:
    RTObjectProvider()
    {
+      RegisterClass("TTree", "sap-icon://tree");
+      RegisterClass("TNtuple", "sap-icon://tree");
+
       RegisterBrowse(TFolder::Class(), [](std::unique_ptr<RHolder> &object) -> std::shared_ptr<RElement> {
          return std::make_shared<TFolderElement>(object);
       });

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -176,6 +176,39 @@ const TClass *TObjectElement::GetClass() const
 }
 
 
+RElement::EActionKind TObjectElement::GetDefaultAction() const
+{
+   auto cl = GetClass();
+   if (!cl) return kActNone;
+
+   if (RProvider::CanDraw6(cl)) return kActDraw6;
+
+   if (RProvider::CanDraw7(cl)) return kActDraw7;
+
+   if (RProvider::CanHaveChilds(cl)) return kActBrowse;
+
+   return kActNone;
+}
+
+bool TObjectElement::IsCapable(RElement::EActionKind action) const
+{
+   auto cl = GetClass();
+   if (!cl) return false;
+
+   switch(action) {
+      case kActBrowse: return RProvider::CanHaveChilds(cl);
+      case kActEdit: return true;
+      case kActImage:
+      case kActDraw6: return RProvider::CanDraw6(cl); // if can draw in TCanvas, can produce image
+      case kActDraw7: return RProvider::CanDraw7(cl);
+      case kActGeom: return false;  // TODO
+      default: return false;
+   }
+
+   return true;
+}
+
+
 // ==============================================================================================
 
 

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -349,12 +349,19 @@ public:
       RegisterClass("TLeaf", "sap-icon://e-care", ""s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
 
       RegisterTObject("TDirectory", "sap-icon://folder-blank", true, false);
-      RegisterTObject("TH1", "sap-icon://vertical-bar-chart");
+      RegisterTObject("TH1", "sap-icon://bar-chart");
       RegisterTObject("TH2", "sap-icon://pixelate");
+      RegisterTObject("TH3", "sap-icon://product");
       RegisterTObject("TProfile", "sap-icon://vertical-bar-chart");
       RegisterTObject("TGraph", "sap-icon://line-chart");
 
-      RegisterTObject("TGeoManager", "sap-icon://tree", true, false);
+      RegisterTObject("THStack", "sap-icon://multiple-bar-chart");
+      RegisterTObject("TMultiGraph", "sap-icon://multiple-line-chart");
+
+      RegisterTObject("TCollection", "sap-icon://list", true, false);
+      RegisterTObject("TGeoManager", "sap-icon://overview-chart", true, false);
+      RegisterTObject("TGeoVolume", "sap-icon://product", true, false);
+      RegisterTObject("TGeoNode", "sap-icon://product", true, false);
 
       RegisterBrowse(TFolder::Class(), [](std::unique_ptr<RHolder> &object) -> std::shared_ptr<RElement> {
          return std::make_shared<TFolderElement>(object);

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -68,17 +68,20 @@ protected:
    std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &canv);
 
    EditorPage *AddEditor();
+   EditorPage *GetActiveEditor() const;
 
    void CloseTab(const std::string &name);
 
    std::string ProcessBrowserRequest(const std::string &msg);
-   std::string ProcessDblClick(const std::string &path, const std::string &drawingOptions);
+   std::string ProcessDblClick(const std::string &path, const std::string &drawingOptions, const std::string &);
    long ProcessRunCommand(const std::string &file_path);
    void ProcessSaveFile(const std::string &file_path);
    std::string GetCurrentWorkingDirectory();
 
    void SendInitMsg(unsigned connid);
    void ProcessMsg(unsigned connid, const std::string &arg);
+
+   std::string SendEditorContent(EditorPage *editor);
 
 public:
    RBrowser(bool use_rcanvas = true);

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -22,7 +22,6 @@
 
 #include <vector>
 #include <memory>
-#include <stdint.h>
 
 class TString;
 class TCanvas;
@@ -39,13 +38,22 @@ class RBrowser {
 
 protected:
 
+   struct EditorPage {
+      std::string fName;
+      std::string fTitle;
+      std::string fFileName;
+      std::string fContent;
+   };
+
    std::string fTitle;  ///<! title
    unsigned fConnId{0}; ///<! default connection id
 
    bool fUseRCanvas{false};             ///<!  which canvas should be used
    std::vector<std::unique_ptr<TCanvas>> fCanvases;  ///<! canvases created by browser, should be closed at the end
-   std::string fActiveCanvas;            ///<! name of active for RBrowser canvas, not a gPad!
+   std::string fActiveTab;            ///<! name of active for tab (RCanvas, TCanvas or EditorPage)
    std::vector<std::shared_ptr<ROOT::Experimental::RCanvas>> fRCanvases; ///<!  ROOT7 canvases
+   std::vector<std::unique_ptr<EditorPage>> fEditors;   ///<! list of text editors
+   int fEditorsCnt{0};                                  ///<! counter for created editors
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
@@ -54,11 +62,14 @@ protected:
    TCanvas *AddCanvas();
    TCanvas *GetActiveCanvas() const;
    std::string GetCanvasUrl(TCanvas *canv);
-   void CloseCanvas(const std::string &name);
 
    std::shared_ptr<RCanvas> AddRCanvas();
    std::shared_ptr<RCanvas> GetActiveRCanvas() const;
    std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &canv);
+
+   EditorPage *AddEditor();
+
+   void CloseTab(const std::string &name);
 
    std::string ProcessBrowserRequest(const std::string &msg);
    std::string ProcessDblClick(const std::string &path, const std::string &drawingOptions);

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -72,14 +72,15 @@ protected:
    std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &canv);
 
    EditorPage *AddEditor(bool is_editor);
-   EditorPage *GetActiveEditor() const;
+   EditorPage *GetEditor(const std::string &name) const;
+   EditorPage *GetActiveEditor() const { return GetEditor(fActiveTab); }
 
    void CloseTab(const std::string &name);
 
    std::string ProcessBrowserRequest(const std::string &msg);
    std::string ProcessDblClick(const std::string &path, const std::string &drawingOptions, const std::string &);
-   long ProcessRunCommand(const std::string &file_path);
-   void ProcessSaveFile(const std::string &file_path);
+   long ProcessRunMacro(const std::string &file_path);
+   void ProcessSaveFile(const std::string &fname, const std::string &content);
    std::string GetCurrentWorkingDirectory();
 
    void SendInitMsg(unsigned connid);

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -43,6 +43,7 @@ protected:
       std::string fTitle;
       std::string fFileName;
       std::string fContent;
+      bool fFirstSend{false};    ///<! if editor content was send at least one
    };
 
    std::string fTitle;  ///<! title

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -86,6 +86,9 @@ protected:
    void ProcessSaveFile(const std::string &fname, const std::string &content);
    std::string GetCurrentWorkingDirectory();
 
+   std::vector<std::string> GetRootHistory();
+   std::vector<std::string> GetRootLogs();
+
    void SendInitMsg(unsigned connid);
    void ProcessMsg(unsigned connid, const std::string &arg);
 

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -44,7 +44,8 @@ protected:
       std::string fTitle;
       std::string fFileName;
       std::string fContent;
-      bool fFirstSend{false};    ///<! if editor content was send at least one
+      bool fFirstSend{false};  ///<! if editor content was send at least one
+      std::string fItemPath;   ///<! item path in the browser
       EditorPage(bool is_edit) : fIsEditor(is_edit) {}
       std::string GetKind() const { return fIsEditor ? "edit" : "image"; }
    };
@@ -74,11 +75,13 @@ protected:
    EditorPage *AddEditor(bool is_editor);
    EditorPage *GetEditor(const std::string &name) const;
    EditorPage *GetActiveEditor() const { return GetEditor(fActiveTab); }
+   EditorPage *FindEditorFor(const std::string &item_path, bool is_editor = true);
 
    void CloseTab(const std::string &name);
 
    std::string ProcessBrowserRequest(const std::string &msg);
    std::string ProcessDblClick(const std::string &path, const std::string &drawingOptions, const std::string &);
+   std::string ProcessNewTab(const std::string &msg);
    long ProcessRunMacro(const std::string &file_path);
    void ProcessSaveFile(const std::string &fname, const std::string &content);
    std::string GetCurrentWorkingDirectory();

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -39,11 +39,14 @@ class RBrowser {
 protected:
 
    struct EditorPage {
+      bool fIsEditor{true};   ///<! either editor or image viewer
       std::string fName;
       std::string fTitle;
       std::string fFileName;
       std::string fContent;
       bool fFirstSend{false};    ///<! if editor content was send at least one
+      EditorPage(bool is_edit) : fIsEditor(is_edit) {}
+      std::string GetKind() const { return fIsEditor ? "edit" : "image"; }
    };
 
    std::string fTitle;  ///<! title
@@ -68,7 +71,7 @@ protected:
    std::shared_ptr<RCanvas> GetActiveRCanvas() const;
    std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &canv);
 
-   EditorPage *AddEditor();
+   EditorPage *AddEditor(bool is_editor);
    EditorPage *GetActiveEditor() const;
 
    void CloseTab(const std::string &name);

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -38,7 +38,7 @@ class RBrowser {
 
 protected:
 
-   struct EditorPage {
+   struct BrowserPage {
       bool fIsEditor{true};   ///<! either editor or image viewer
       std::string fName;
       std::string fTitle;
@@ -46,7 +46,7 @@ protected:
       std::string fContent;
       bool fFirstSend{false};  ///<! if editor content was send at least one
       std::string fItemPath;   ///<! item path in the browser
-      EditorPage(bool is_edit) : fIsEditor(is_edit) {}
+      BrowserPage(bool is_edit) : fIsEditor(is_edit) {}
       std::string GetKind() const { return fIsEditor ? "edit" : "image"; }
    };
 
@@ -55,10 +55,10 @@ protected:
 
    bool fUseRCanvas{false};             ///<!  which canvas should be used
    std::vector<std::unique_ptr<TCanvas>> fCanvases;  ///<! canvases created by browser, should be closed at the end
-   std::string fActiveTab;            ///<! name of active for tab (RCanvas, TCanvas or EditorPage)
+   std::string fActiveTab;            ///<! name of active for tab (RCanvas, TCanvas or BrowserPage)
    std::vector<std::shared_ptr<ROOT::Experimental::RCanvas>> fRCanvases; ///<!  ROOT7 canvases
-   std::vector<std::unique_ptr<EditorPage>> fEditors;   ///<! list of text editors
-   int fEditorsCnt{0};                                  ///<! counter for created editors
+   std::vector<std::unique_ptr<BrowserPage>> fPages;   ///<! list of text editors
+   int fPagesCnt{0};                                  ///<! counter for created editors
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
@@ -72,10 +72,10 @@ protected:
    std::shared_ptr<RCanvas> GetActiveRCanvas() const;
    std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &canv);
 
-   EditorPage *AddEditor(bool is_editor);
-   EditorPage *GetEditor(const std::string &name) const;
-   EditorPage *GetActiveEditor() const { return GetEditor(fActiveTab); }
-   EditorPage *FindEditorFor(const std::string &item_path, bool is_editor = true);
+   BrowserPage *AddPage(bool is_editor);
+   BrowserPage *GetPage(const std::string &name) const;
+   BrowserPage *GetActivePage() const { return GetPage(fActiveTab); }
+   BrowserPage *FindPageFor(const std::string &item_path, bool is_editor = true);
 
    void CloseTab(const std::string &name);
 
@@ -89,7 +89,7 @@ protected:
    void SendInitMsg(unsigned connid);
    void ProcessMsg(unsigned connid, const std::string &arg);
 
-   std::string SendEditorContent(EditorPage *editor);
+   std::string SendPageContent(BrowserPage *editor);
 
 public:
    RBrowser(bool use_rcanvas = true);

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <map>
 
 namespace ROOT {
 namespace Experimental {
@@ -39,7 +40,8 @@ class RBrowserData {
    std::shared_ptr<Browsable::RElement> fTopElement;    ///<! top element
 
    Browsable::RElementPath_t  fWorkingPath;             ///<! path showed in Breadcrumb
-   std::shared_ptr<Browsable::RElement> fWorkElement;   ///<! main element used for working in browser dialog
+
+   std::map<Browsable::RElementPath_t, std::shared_ptr<Browsable::RElement>> fCache; ///<! already requested elements
 
    Browsable::RElementPath_t fLastPath;                  ///<! path to last used element
    std::shared_ptr<Browsable::RElement> fLastElement;    ///<! last element used in request
@@ -49,11 +51,13 @@ class RBrowserData {
    std::string fLastSortMethod;                          ///<! last sort method
    bool fLastSortReverse{false};                         ///<! last request reverse order
 
-   Browsable::RElementPath_t DecomposePath(const std::string &path);
+   Browsable::RElementPath_t DecomposePath(const std::string &path, bool relative_to_work_element);
 
    void ResetLastRequest();
 
    bool ProcessBrowserRequest(const RBrowserRequest &request, RBrowserReply &reply);
+
+   std::shared_ptr<Browsable::RElement> GetSubElement(const Browsable::RElementPath_t &path);
 
 public:
    RBrowserData() = default;

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -437,18 +437,18 @@ RBrowser::BrowserPage *RBrowser::GetPage(const std::string &name) const
 {
    if (name.empty()) return nullptr;
 
-   auto iter = std::find_if(fPages.begin(), fPages.end(), [this,name](const std::unique_ptr<BrowserPage> &page) { return name == page->fName; });
+   auto iter = std::find_if(fPages.begin(), fPages.end(), [name](const std::unique_ptr<BrowserPage> &page) { return name == page->fName; });
 
    return (iter != fPages.end()) ? iter->get() : nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-/// Find editor for specified item path
+/// Find editor/image viewer page for specified item path
 
 RBrowser::BrowserPage *RBrowser::FindPageFor(const std::string &item_path, bool is_editor)
 {
    auto iter = std::find_if(fPages.begin(), fPages.end(),
-            [this,item_path,is_editor](const std::unique_ptr<BrowserPage> &page) {
+            [item_path,is_editor](const std::unique_ptr<BrowserPage> &page) {
               return (item_path == page->fItemPath) && (is_editor == page->fIsEditor);
             });
 
@@ -522,10 +522,7 @@ std::vector<std::string> RBrowser::GetRootLogs()
    }
 
    return arr;
-
 }
-
-
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 /// Process client connect

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -680,7 +680,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       tabSelectItem: function(oEvent) {
          let item = oEvent.getParameter('item');
          if (item && item.getKey())
-            this.websocket.send("SELECT_TAB:" + item.getKey());
+            this.websocket.send("TAB_SELECTED:" + item.getKey());
       },
 
       /** @brief Close Tab event handler */
@@ -932,15 +932,9 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          case "WORKPATH":
             this.updateBReadcrumbs(JSON.parse(msg));
             break;
-         case "SELECT_TAB": // Selected the back selected canvas
-           let oTabContainer = this.byId("tabContainer");
-           let items = oTabContainer.getItems();
-           for(let i = 0; i< items.length; i++) {
-              if (items[i].getKey() === msg) {
-                 oTabContainer.setSelectedItem(items[i]);
-                 break;
-              }
-           }
+         case "SELECT_TAB":
+           let tab = this.findTab(msg);
+           if (tab) this.byId("tabContainer").setSelectedItem(item);
            break;
          case "BREPL":   // browser reply
             if (this.model) {

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -934,7 +934,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             break;
          case "SELECT_TAB":
            let tab = this.findTab(msg);
-           if (tab) this.byId("tabContainer").setSelectedItem(item);
+           if (tab) this.byId("tabContainer").setSelectedItem(tab);
            break;
          case "BREPL":   // browser reply
             if (this.model) {

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -87,7 +87,7 @@
           <detailPages>
             <l:Splitter orientation="Vertical">
               <Page title="Javascript ROOT Browser" showNavButton="false" showFooter="false" showSubHeader="false" showHeader="false">
-                <TabContainer id="myTabContainer" showAddNewButton="true" addNewButtonPress="addNewButtonPressHandler" itemSelect="tabSelectItem" itemClose="tabCloseHandler" />
+                <TabContainer id="tabContainer" showAddNewButton="true" addNewButtonPress="addNewButtonPressHandler" itemSelect="tabSelectItem" itemClose="tabCloseHandler" />
               </Page>
               <Page showNavButton="false" showFooter="false" showSubHeader="false" showHeader="false">
                 <layoutData><l:SplitterLayoutData size="20%" /></layoutData>

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -6,21 +6,15 @@
           xmlns:core="sap.ui.core"
           xmlns:l="sap.ui.layout"
           xmlns:tnt="sap.tnt">
-
   <Page showSubHeader="false" showHeader="false" showFooter="false">
     <content>
       <tnt:ToolHeader asyncMode="true" height="40px" >
-        <Button id="burgerMenu" icon="sap-icon://menu2" type="Transparent">
+        <Button id="burgerMenu" icon="sap-icon://menu2" type="Transparent" tooltip="Hide/show browser" press="onFullScreen">
           <layoutData>
             <OverflowToolbarLayoutData priority="NeverOverflow" />
           </layoutData>
         </Button>
-        <Button id="expandMaster" icon="sap-icon://full-screen" type="Transparent" press="onExpandMaster">
-          <layoutData>
-            <OverflowToolbarLayoutData priority="NeverOverflow" />
-          </layoutData>
-        </Button>
-        <Button id="shrinkMaster" icon="sap-icon://exit-full-screen" type="Transparent" press="onShrinkMaster" visible="false">
+        <Button id="expandMaster" icon="sap-icon://full-screen" type="Transparent" tooltip="Expand/shrink browser" press="onExpandMaster">
           <layoutData>
             <OverflowToolbarLayoutData priority="NeverOverflow" />
           </layoutData>
@@ -87,7 +81,7 @@
           <detailPages>
             <l:Splitter orientation="Vertical">
               <Page title="Javascript ROOT Browser" showNavButton="false" showFooter="false" showSubHeader="false" showHeader="false">
-                <TabContainer id="tabContainer" showAddNewButton="true" addNewButtonPress="addNewButtonPressHandler" itemSelect="tabSelectItem" itemClose="tabCloseHandler" />
+                <TabContainer id="tabContainer" showAddNewButton="true" addNewButtonPress="handlePressAddTab" itemSelect="tabSelectItem" itemClose="handleTabClose"/>
               </Page>
               <Page showNavButton="false" showFooter="false" showSubHeader="false" showHeader="false">
                 <layoutData><l:SplitterLayoutData size="20%" /></layoutData>

--- a/ui5/browser/view/tabsmenu.fragment.xml
+++ b/ui5/browser/view/tabsmenu.fragment.xml
@@ -1,8 +1,8 @@
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core">
   <ActionSheet title="Tabs selection" showCancelButton="true" placement="Left">
-    <Button text="Code Editor"   id="NewTabCE" icon="sap-icon://write-new-document"     press="newCodeEditor"  />
-    <Button text="Root 6 canvas" id="NewTabR6" icon="sap-icon://column-chart-dual-axis" press="newRootXCanvas" />
-    <Button text="Root 7 canvas" id="NewTabR7" icon="sap-icon://column-chart-dual-axis" press="newRootXCanvas" />
+    <Button text="Code editor"   id="NewTabCE" icon="sap-icon://write-new-document"     press="handleNewTab"  />
+    <Button text="Root 6 canvas" id="NewTabR6" icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
+    <Button text="Root 7 canvas" id="NewTabR7" icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
     <Button text="Image viewer"  id="NewTabIV" icon="sap-icon://background"             press="newImageViewer" />
   </ActionSheet>
 </core:FragmentDefinition>

--- a/ui5/browser/view/tabsmenu.fragment.xml
+++ b/ui5/browser/view/tabsmenu.fragment.xml
@@ -3,6 +3,6 @@
     <Button text="Code editor"   id="NewTabCE" icon="sap-icon://write-new-document"     press="handleNewTab"  />
     <Button text="Root 6 canvas" id="NewTabR6" icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
     <Button text="Root 7 canvas" id="NewTabR7" icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
-    <Button text="Image viewer"  id="NewTabIV" icon="sap-icon://background"             press="newImageViewer" />
+    <Button text="Image viewer"  id="NewTabIV" icon="sap-icon://background"             press="handleNewTab" />
   </ActionSheet>
 </core:FragmentDefinition>

--- a/ui5/eve7/controller/GeomViewer.controller.js
+++ b/ui5/eve7/controller/GeomViewer.controller.js
@@ -100,6 +100,7 @@ sap.ui.define(['sap/ui/core/Component',
             var app = this.byId("geomViewerApp");
             app.setMode(sap.m.SplitAppMode.HideMode);
             app.setInitialMaster(this.createId("geomControl"));
+            app.removeMasterPage(this.byId("geomHierarchy"));
             this.byId("geomControl").setShowNavButton(false);
          } else {
 
@@ -110,7 +111,7 @@ sap.ui.define(['sap/ui/core/Component',
 
             t.setModel(this.model);
 
-            var vis_selected_handler = this.visibilitySelected.bind(this);
+            // var vis_selected_handler = this.visibilitySelected.bind(this);
 
             this.model.assignTreeTable(t);
 


### PR DESCRIPTION
1. Introduce central class registry in `RBrowsable` classes. It is the place which describes how class can be handled. Let avoid hardcoded class names in many other places of RBrowser. Registry also includes icons.
2. Introduce internal `RBrowsable` objects cache. When any object read from the file, it preserved in the cache and provided again if same path is requested from browser. 
3. Define/handle `actions` for `Browsable::RElement` class. Actions are: draw, browse, edit, image, .... Action are handled with double click on the browser item. Now when image is clicked, it automatically displayed in the image viewer.
4. When object clicked with CodeEditor active - JSON will be shown for the object.
5. Handle `CodeEditor` and `ImageViewer` content on server side. When web browser is reloaded, all correspondent tabs are recreated properly
6. Update openui5 tarball - include missing CodeEditor snippets
7. Lots of layout and code improvements in the RBrowser client-side. 