### PR TITLE
gSystem->GetHomeDirectory() should prefer $HOME on Unix systems

### DIFF
--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -3936,12 +3936,12 @@ const char *TUnixSystem::UnixHomedirectory(const char *name, char *path, char *m
       if (mydir[0])
          return mydir;
       pw = getpwuid(getuid());
-      if (pw && pw->pw_dir) {
-         strncpy(mydir, pw->pw_dir, kMAXPATHLEN-1);
+      if (gSystem->Getenv("HOME")) {
+         strncpy(mydir, gSystem->Getenv("HOME"), kMAXPATHLEN-1);
          mydir[kMAXPATHLEN-1] = '\0';
          return mydir;
-      } else if (gSystem->Getenv("HOME")) {
-         strncpy(mydir, gSystem->Getenv("HOME"), kMAXPATHLEN-1);
+      } else if (pw && pw->pw_dir) {
+         strncpy(mydir, pw->pw_dir, kMAXPATHLEN-1);
          mydir[kMAXPATHLEN-1] = '\0';
          return mydir;
       }


### PR DESCRIPTION
Currently, `gSystem->GetHomeDirectory()` will prefer to use the value from `etc/passwd` on Linux systems. In the Snap packaging, this causes issues due to the sandboxing permissions and is currently worked around by using LD_PRELOAD to hijack `getpwuid()` and force it to respect $HOME.

From what I see, every other instance in the ROOT repository already prefers the $HOME variable, apart from this one instance here. I wouldn't expect most users to notice this patch, but I would expect users who might have a need to change this value to assume simply changing $HOME is sufficient and expect this behaviour, which can be done without any real complexities; rather than changing /etc/passwd which is a much more involved task and relies upon legacy knowledge of Unix systems.