### PR TITLE
fix iminuit tests run with gradient

### DIFF
--- a/math/minuit2/src/ModularFunctionMinimizer.cxx
+++ b/math/minuit2/src/ModularFunctionMinimizer.cxx
@@ -154,9 +154,7 @@ FunctionMinimum ModularFunctionMinimizer::Minimize(const FCNGradientBase &fcn, c
    if (maxfcn == 0)
       maxfcn = 200 + 100 * npar + 5 * npar * npar;
 
-   // use numerical gradient to compute initial derivatives for SeedGenerator
-   Numerical2PGradientCalculator numgc(mfcn, st.Trafo(), strategy);
-   MinimumSeed mnseeds = SeedGenerator()(mfcn, numgc, st, strategy);
+   MinimumSeed mnseeds = SeedGenerator()(mfcn, gc, st, strategy);
 
    return Minimize(mfcn, gc, mnseeds, strategy, maxfcn, toler);
 }


### PR DESCRIPTION
This reverts ae9f8ae62553f9150fdee1f8739be6996d539694

While the patch makes sense to me, it breaks a lot of iminuit's tests. I cannot say why, but the results are very far off in some cases. I can provide a log of the failing tests as proof if needed.