### PR TITLE
Implement rapidity-based DeltaR calculations in TLorentzVector

### DIFF
--- a/math/genvector/inc/Math/GenVector/VectorUtil.h
+++ b/math/genvector/inc/Math/GenVector/VectorUtil.h
@@ -83,17 +83,41 @@ namespace ROOT {
             return dphi*dphi + deta*deta;
          }
 
+	 /**
+	  Find square of the difference in true rapidity (y) and Phi betwen two generic vectors
+	  The only requirements on the Vector classes is that they implement the Phi() and Rapidity() method
+	  \param v1  Vector 1
+	  \param v2  Vector 2
+	  \return   Angle between the two vectors
+	  \f[ \Delta R2 = ( \Delta \phi )^2 + ( \Delta \y )^2  \f],
+	  */
+	 template <class Vector1, class Vector2>
+	 inline typename Vector1::Scalar DeltaR2RapidityPhi( const Vector1 & v1, const Vector2 & v2) {
+	    typename Vector1::Scalar dphi = DeltaPhi(v1,v2);
+	    typename Vector1::Scalar drap = v2.Rapidity() - v1.Rapidity();
+	    return dphi*dphi + drap*drap;
+	 }
+
          /**
           Find difference in pseudorapidity (Eta) and Phi betwen two generic vectors
           The only requirements on the Vector classes is that they implement the Phi() and Eta() method
+	  An option to use the rapidity instead of Eta is included, for use with massive vectors.
           \param v1  Vector 1
           \param v2  Vector 2
+          \param useRapidity use rapidity instead of pseudorapidity?
           \return   Angle between the two vectors
-          \f[ \Delta R = \sqrt{  ( \Delta \phi )^2 + ( \Delta \eta )^2 } \f]
+          \f[ \Delta R = \sqrt{  ( \Delta \phi )^2 + ( \Delta \eta )^2 } \f],
+          or
+          \f[ \Delta R2 = ( \Delta \phi )^2 + ( \Delta \y )^2  \f]
+          if useRapidity is true.
           */
          template <class Vector1, class Vector2>
-         inline typename Vector1::Scalar DeltaR( const Vector1 & v1, const Vector2 & v2) {
-            return std::sqrt( DeltaR2(v1,v2) );
+         inline typename Vector1::Scalar DeltaR( const Vector1 & v1, const Vector2 & v2, const bool useRapidity=false) {
+	    if(useRapidity==false){
+	       return std::sqrt( DeltaR2(v1,v2) );
+	    } else {
+	       return std::sqrt( DeltaR2RapidityPhi(v1,v2) );
+	    }
          }
 
 

--- a/math/genvector/inc/Math/GenVector/VectorUtil.h
+++ b/math/genvector/inc/Math/GenVector/VectorUtil.h
@@ -101,26 +101,28 @@ namespace ROOT {
          /**
           Find difference in pseudorapidity (Eta) and Phi betwen two generic vectors
           The only requirements on the Vector classes is that they implement the Phi() and Eta() method
-	  An option to use the rapidity instead of Eta is included, for use with massive vectors.
           \param v1  Vector 1
           \param v2  Vector 2
-          \param useRapidity use rapidity instead of pseudorapidity?
           \return   Angle between the two vectors
           \f[ \Delta R = \sqrt{  ( \Delta \phi )^2 + ( \Delta \eta )^2 } \f],
-          or
-          \f[ \Delta R2 = ( \Delta \phi )^2 + ( \Delta \y )^2  \f]
-          if useRapidity is true.
           */
          template <class Vector1, class Vector2>
-         inline typename Vector1::Scalar DeltaR( const Vector1 & v1, const Vector2 & v2, const bool useRapidity=false) {
-	    if(useRapidity==false){
+         inline typename Vector1::Scalar DeltaR( const Vector1 & v1, const Vector2 & v2 ) {
 	       return std::sqrt( DeltaR2(v1,v2) );
-	    } else {
-	       return std::sqrt( DeltaR2RapidityPhi(v1,v2) );
-	    }
          }
 
-
+	/**
+          Find difference in Rapidity (y) and Phi betwen two generic vectors
+          The only requirements on the Vector classes is that they implement the Phi() and Rapidity() method
+          \param v1  Vector 1
+          \param v2  Vector 2
+          \return   Angle between the two vectors
+          \f[ \Delta R = \sqrt{  ( \Delta \phi )^2 + ( \Delta y )^2 } \f],
+          */
+         template <class Vector1, class Vector2>
+         inline typename Vector1::Scalar DeltaRapidityPhi( const Vector1 & v1, const Vector2 & v2 ) {
+            return std::sqrt( DeltaR2RapidityPhi(v1,v2) );
+         }
 
          /**
           Find CosTheta Angle between two generic 3D vectors

--- a/math/genvector/inc/Math/GenVector/VectorUtil.h
+++ b/math/genvector/inc/Math/GenVector/VectorUtil.h
@@ -89,7 +89,7 @@ namespace ROOT {
 	  \param v1  Vector 1
 	  \param v2  Vector 2
 	  \return   Angle between the two vectors
-	  \f[ \Delta R2 = ( \Delta \phi )^2 + ( \Delta \y )^2  \f],
+	  \f[ \Delta R2 = ( \Delta \phi )^2 + ( \Delta \y )^2  \f]
 	  */
 	 template <class Vector1, class Vector2>
 	 inline typename Vector1::Scalar DeltaR2RapidityPhi( const Vector1 & v1, const Vector2 & v2) {
@@ -104,11 +104,11 @@ namespace ROOT {
           \param v1  Vector 1
           \param v2  Vector 2
           \return   Angle between the two vectors
-          \f[ \Delta R = \sqrt{  ( \Delta \phi )^2 + ( \Delta \eta )^2 } \f],
+          \f[ \Delta R = \sqrt{  ( \Delta \phi )^2 + ( \Delta \eta )^2 } \f]
           */
          template <class Vector1, class Vector2>
-         inline typename Vector1::Scalar DeltaR( const Vector1 & v1, const Vector2 & v2 ) {
-	       return std::sqrt( DeltaR2(v1,v2) );
+         inline typename Vector1::Scalar DeltaR( const Vector1 & v1, const Vector2 & v2) {
+            return std::sqrt( DeltaR2(v1,v2) );
          }
 
 	/**
@@ -120,7 +120,7 @@ namespace ROOT {
           \f[ \Delta R = \sqrt{  ( \Delta \phi )^2 + ( \Delta y )^2 } \f],
           */
          template <class Vector1, class Vector2>
-         inline typename Vector1::Scalar DeltaRapidityPhi( const Vector1 & v1, const Vector2 & v2 ) {
+         inline typename Vector1::Scalar DeltaRapidityPhi( const Vector1 & v1, const Vector2 & v2) {
             return std::sqrt( DeltaR2RapidityPhi(v1,v2) );
          }
 

--- a/math/physics/inc/TLorentzVector.h
+++ b/math/physics/inc/TLorentzVector.h
@@ -181,8 +181,9 @@ public:
    // Transverse energy w.r.t. given axis.
 
    inline Double_t DeltaPhi(const TLorentzVector &) const;
-   inline Double_t DeltaR(const TLorentzVector &) const;
+   inline Double_t DeltaR(const TLorentzVector &, Bool_t useRapidity=kFALSE) const;
    inline Double_t DrEtaPhi(const TLorentzVector &) const;
+   inline Double_t DrRapidityPhi(const TLorentzVector &) const;
    inline TVector2 EtaPhiVector();
 
    inline Double_t Angle(const TVector3 & v) const;
@@ -460,14 +461,25 @@ inline Double_t TLorentzVector::DeltaPhi(const TLorentzVector & v) const {
 inline Double_t TLorentzVector::Eta() const {
    return PseudoRapidity();
 }
-inline Double_t TLorentzVector::DeltaR(const TLorentzVector & v) const {
-   Double_t deta = Eta()-v.Eta();
-   Double_t dphi = TVector2::Phi_mpi_pi(Phi()-v.Phi());
-   return TMath::Sqrt( deta*deta+dphi*dphi );
+
+inline Double_t TLorentzVector::DeltaR(const TLorentzVector & v, const Bool_t useRapidity) const {
+  if(useRapidity){
+     Double_t drap = Rapidity()-v.Rapidity();
+     Double_t dphi = TVector2::Phi_mpi_pi(Phi()-v.Phi());
+     return TMath::Sqrt( drap*drap+dphi*dphi );
+  } else {
+    Double_t deta = Eta()-v.Eta();
+    Double_t dphi = TVector2::Phi_mpi_pi(Phi()-v.Phi());
+    return TMath::Sqrt( deta*deta+dphi*dphi );
+  }
 }
 
 inline Double_t TLorentzVector::DrEtaPhi(const TLorentzVector & v) const{
    return DeltaR(v);
+}
+
+inline Double_t TLorentzVector::DrRapidityPhi(const TLorentzVector & v) const{
+   return DeltaR(v, kTRUE);
 }
 
 inline TVector2 TLorentzVector::EtaPhiVector() {


### PR DESCRIPTION
Hello,

At the moment, the `ROOT::TLorentzVector` class uses a pseudorapidity-based calculation for the commonly-used DeltaR distance between vectors. For massive objects, such as jets, the rapidity should often be used instead. I have implemented a small switch within the `TLorentzVector::DeltaR` function to allow users to make this calculation with the vector's rapidity, instead of pseudorapidity. This has a default value of `kFALSE`, which means that the current behaviour will be the default one.

I have cross-checked this new functionality with the `fastjet::pseudojet::delta_R` implementation and an internal ATLAS one, which all give the same results when performing the rapidity-based calculation.

Please let me know if I have violated any contribution guidelines, and I will update this PR accordingly!

🍻 Matt 