### PR TITLE
[rbrowser] geometry viewer, modular RBrowser widgets

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveGeomViewer.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeomViewer.hxx
@@ -35,6 +35,7 @@ protected:
    std::string fSelectedVolume;              ///<! name of selected volume
    REveGeomDescription fDesc;                ///<! geometry description, send to the client as first message
    bool fShowHierarchy{true};                ///<! if hierarchy visible by default
+   std::string fTitle;                       ///<! title of geometry viewer
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to show geometry
 
@@ -48,6 +49,11 @@ public:
 
    REveGeomViewer(TGeoManager *mgr = nullptr, const std::string &volname = "");
    virtual ~REveGeomViewer();
+
+   void SetTitle(const std::string &title) { fTitle = title; }
+   const std::string &GetTitle() const { return fTitle; }
+
+   std::string GetWindowAddr() const;
 
    void SetGeometry(TGeoManager *mgr, const std::string &volname = "");
 

--- a/graf3d/eve7/src/REveGeomData.cxx
+++ b/graf3d/eve7/src/REveGeomData.cxx
@@ -74,6 +74,9 @@ public:
          return true;
       }
 
+      if (fNodeId >= (int) fDesc.fDesc.size())
+         return false;
+
       auto &node = fDesc.fDesc[fNodeId];
       if (node.chlds.size() == 0) return false;
       fStackParents.emplace_back(fParentId);
@@ -449,6 +452,8 @@ void ROOT::Experimental::REveGeomDescription::ProduceIdShifts()
 
 int ROOT::Experimental::REveGeomDescription::ScanNodes(bool only_visible, int maxlvl, REveGeomScanFunc_t func)
 {
+   if (fDesc.empty()) return 0;
+
    std::vector<int> stack;
    stack.reserve(25); // reserve enough space for most use-cases
    int counter{0};

--- a/graf3d/eve7/src/REveGeomViewer.cxx
+++ b/graf3d/eve7/src/REveGeomViewer.cxx
@@ -97,6 +97,15 @@ void ROOT::Experimental::REveGeomViewer::Show(const RWebDisplayArgs &args, bool 
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
+/// Return URL address of web window used for geometry viewer
+
+std::string ROOT::Experimental::REveGeomViewer::GetWindowAddr() const
+{
+   if (!fWebWindow) return "";
+   return fWebWindow->GetAddr();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
 /// Update geometry drawings in all web displays
 
 void ROOT::Experimental::REveGeomViewer::Update()

--- a/graf3d/eve7/src/REveUtil.cxx
+++ b/graf3d/eve7/src/REveUtil.cxx
@@ -26,8 +26,6 @@
 #include "TROOT.h"
 #include "TInterpreter.h"
 
-#include "TGMimeTypes.h"
-
 #include <list>
 #include <algorithm>
 #include <string>

--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -86,6 +86,8 @@ public:
 
    static std::shared_ptr<RElement> GetSubElement(std::shared_ptr<RElement> &elem, const RElementPath_t &path);
 
+   static RElementPath_t ParsePath(const std::string &str);
+
    static int ComparePaths(const RElementPath_t &path1, const RElementPath_t &path2);
 
    static std::string GetPathAsString(const RElementPath_t &path);

--- a/gui/browsable/inc/ROOT/Browsable/RSysFile.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RSysFile.hxx
@@ -55,7 +55,7 @@ public:
 
    static std::string GetFileIcon(const std::string &fname);
 
-   static std::string ProvideTopEntries(std::shared_ptr<RGroup> &comp, const std::string &workdir = "");
+   static RElementPath_t ProvideTopEntries(std::shared_ptr<RGroup> &comp, const std::string &workdir = "");
 
 };
 

--- a/gui/browsable/src/RElement.cxx
+++ b/gui/browsable/src/RElement.cxx
@@ -96,6 +96,35 @@ std::string RElement::GetContent(const std::string &kind)
 }
 
 /////////////////////////////////////////////////////////////////////
+/// Parse string path to produce RElementPath_t
+/// One should avoid to use string pathes as much as possible
+
+RElementPath_t RElement::ParsePath(const std::string &strpath)
+{
+   RElementPath_t arr;
+   if (strpath.empty())
+      return arr;
+
+   std::string slash = "/";
+
+   std::string::size_type previous = 0;
+   if (strpath[0] == slash[0]) previous++;
+
+   auto current = strpath.find(slash, previous);
+   while (current != std::string::npos) {
+      if (current > previous)
+         arr.emplace_back(strpath.substr(previous, current - previous));
+      previous = current + 1;
+      current = strpath.find(slash, previous);
+   }
+
+   if (previous < strpath.length())
+      arr.emplace_back(strpath.substr(previous));
+
+   return arr;
+}
+
+/////////////////////////////////////////////////////////////////////
 /// Compare two paths,
 /// Returns number of elements matches in both paths
 

--- a/gui/browsable/src/RSysFile.cxx
+++ b/gui/browsable/src/RSysFile.cxx
@@ -414,8 +414,6 @@ std::string RSysFile::GetFileIcon(const std::string &fname)
 }
 
 
-
-
 /////////////////////////////////////////////////////////////////////////////////
 /// Create file element
 
@@ -480,6 +478,8 @@ bool RSysFile::MatchName(const std::string &name) const
 
 RElement::EActionKind RSysFile::GetDefaultAction() const
 {
+   if (R_ISDIR(fStat.fMode)) return kActBrowse;
+
    auto icon = GetFileIcon(GetName());
    if (icon == "sap-icon://document-text"s) return kActEdit;
    if (icon == "sap-icon://picture"s) return kActImage;
@@ -539,7 +539,7 @@ std::string RSysFile::GetContent(const std::string &kind)
 /// Provide top entries for file system
 /// On windows it is list of existing drivers, on Linux it is "Files system" and "Home"
 
-std::string RSysFile::ProvideTopEntries(std::shared_ptr<RGroup> &comp, const std::string &workdir)
+RElementPath_t RSysFile::ProvideTopEntries(std::shared_ptr<RGroup> &comp, const std::string &workdir)
 {
    std::string seldir = workdir;
 
@@ -568,8 +568,8 @@ std::string RSysFile::ProvideTopEntries(std::shared_ptr<RGroup> &comp, const std
       std::string homedir = gSystem->UnixPathName(gSystem->HomeDirectory());
 
       if (!homedir.empty())
-         comp->Add(std::make_shared<Browsable::RWrapper>("Home",std::make_unique<RSysFile>(homedir)));
+         comp->Add(std::make_shared<Browsable::RWrapper>("Home", std::make_unique<RSysFile>(homedir)));
    }
 
-   return seldir;
+   return RElement::ParsePath(seldir);
 }

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -198,6 +198,7 @@ public:
 
       std::string clname = fKey->GetClassName();
       if (clname.empty()) return kActNone;
+      if (clname == "TGeoManager") return kActGeom;
       if (RProvider::CanDraw6(clname)) return kActDraw6;
       if (RProvider::CanDraw7(clname)) return kActDraw7;
       if (RProvider::CanHaveChilds(clname)) return kActBrowse;
@@ -219,7 +220,7 @@ public:
          case kActImage:
          case kActDraw6: return RProvider::CanDraw6(clname); // if can draw in TCanvas, can produce image
          case kActDraw7: return RProvider::CanDraw7(clname);
-         case kActGeom: return false;  // TODO
+         case kActGeom: return (clname == "TGeoManager");
          default: return false;
       }
 

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -180,6 +180,7 @@ RElement::EActionKind TObjectElement::GetDefaultAction() const
 {
    auto cl = GetClass();
    if (!cl) return kActNone;
+   if ("TGeoManager"s == cl->GetName()) return kActGeom;
    if (RProvider::CanDraw6(cl)) return kActDraw6;
    if (RProvider::CanDraw7(cl)) return kActDraw7;
    if (RProvider::CanHaveChilds(cl)) return kActBrowse;
@@ -197,7 +198,7 @@ bool TObjectElement::IsCapable(RElement::EActionKind action) const
       case kActImage:
       case kActDraw6: return RProvider::CanDraw6(cl); // if can draw in TCanvas, can produce image
       case kActDraw7: return RProvider::CanDraw7(cl);
-      case kActGeom: return false;  // TODO
+      case kActGeom: return ("TGeoManager"s == cl->GetName());
       default: return false;
    }
 

--- a/gui/browserv7/CMakeLists.txt
+++ b/gui/browserv7/CMakeLists.txt
@@ -51,8 +51,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowserv7
     ROOTBrowserWidgets
   DEPENDENCIES
     ROOTBrowsable
-    WebGui6
-    ROOTGpadv7
+    ROOTWebDisplay
 )
 
 

--- a/gui/browserv7/CMakeLists.txt
+++ b/gui/browserv7/CMakeLists.txt
@@ -14,12 +14,21 @@ ROOT_LINKER_LIBRARY(ROOTBrowserWidgets
      ROOTBrowsable
 )
 
+ROOT_LINKER_LIBRARY(ROOTBrowserTCanvasWidget
+     src/RBrowserTCanvasWidget.cxx
+  DEPENDENCIES
+     ROOTBrowserWidgets
+     Gpad
+     WebGui6
+)
+
 ROOT_LINKER_LIBRARY(ROOTBrowserGeomWidget
      src/RBrowserGeomWidget.cxx
   DEPENDENCIES
      ROOTBrowserWidgets
      ROOTEve
 )
+
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowserv7
   HEADERS

--- a/gui/browserv7/CMakeLists.txt
+++ b/gui/browserv7/CMakeLists.txt
@@ -8,6 +8,19 @@
 # CMakeLists.txt file for building ROOT gui/browserv7
 ############################################################################
 
+ROOT_LINKER_LIBRARY(ROOTBrowserWidgets
+     src/RBrowserWidget.cxx
+  DEPENDENCIES
+     ROOTBrowsable
+)
+
+ROOT_LINKER_LIBRARY(ROOTBrowserGeomWidget
+     src/RBrowserGeomWidget.cxx
+  DEPENDENCIES
+     ROOTBrowserWidgets
+     ROOTEve
+)
+
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowserv7
   HEADERS
     ROOT/RBrowser.hxx
@@ -19,8 +32,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowserv7
     src/RBrowser.cxx
     src/RBrowserData.cxx
     src/RFileDialog.cxx
+  LIBRARIES
+    ROOTBrowserWidgets
   DEPENDENCIES
     ROOTBrowsable
     WebGui6
     ROOTGpadv7
 )
+
+

--- a/gui/browserv7/CMakeLists.txt
+++ b/gui/browserv7/CMakeLists.txt
@@ -22,13 +22,19 @@ ROOT_LINKER_LIBRARY(ROOTBrowserTCanvasWidget
      WebGui6
 )
 
+ROOT_LINKER_LIBRARY(ROOTBrowserRCanvasWidget
+     src/RBrowserRCanvasWidget.cxx
+  DEPENDENCIES
+     ROOTBrowserWidgets
+     ROOTGpadv7
+)
+
 ROOT_LINKER_LIBRARY(ROOTBrowserGeomWidget
      src/RBrowserGeomWidget.cxx
   DEPENDENCIES
      ROOTBrowserWidgets
      ROOTEve
 )
-
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowserv7
   HEADERS

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -34,26 +34,13 @@ class RBrowser {
 
 protected:
 
-   struct BrowserPage {
-      bool fIsEditor{true};   ///<! either editor or image viewer
-      std::string fName;
-      std::string fTitle;
-      std::string fFileName;
-      std::string fContent;
-      bool fFirstSend{false};  ///<! if editor content was send at least one
-      std::string fItemPath;   ///<! item path in the browser
-      BrowserPage(bool is_edit) : fIsEditor(is_edit) {}
-      std::string GetKind() const { return fIsEditor ? "edit" : "image"; }
-   };
-
    std::string fTitle;  ///<! title
    unsigned fConnId{0}; ///<! default connection id
 
    bool fUseRCanvas{false};             ///<!  which canvas should be used
-   std::string fActiveTab;              ///<! name of active widget
+   std::string fActiveWidgetName;        ///<! name of active widget
    std::vector<std::shared_ptr<RBrowserWidget>> fWidgets; ///<!  all browser widgets
-   std::vector<std::unique_ptr<BrowserPage>> fPages;      ///<! list of text editors
-   int fPagesCnt{0};                                     ///<! counter for created editors
+   int fWidgetCnt{0};                                     ///<! counter for created widgets
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
@@ -61,18 +48,12 @@ protected:
 
    std::shared_ptr<RBrowserWidget> AddWidget(const std::string &kind);
    std::shared_ptr<RBrowserWidget> FindWidget(const std::string &name) const;
-   std::shared_ptr<RBrowserWidget> GetActiveWidget() const { return FindWidget(fActiveTab); }
-
-   BrowserPage *AddPage(bool is_editor);
-   BrowserPage *GetPage(const std::string &name) const;
-   BrowserPage *GetActivePage() const { return GetPage(fActiveTab); }
-   BrowserPage *FindPageFor(const std::string &item_path, bool is_editor = true);
+   std::shared_ptr<RBrowserWidget> GetActiveWidget() const { return FindWidget(fActiveWidgetName); }
 
    void CloseTab(const std::string &name);
 
    std::string ProcessBrowserRequest(const std::string &msg);
    std::string ProcessDblClick(const std::string &path, const std::string &drawingOptions, const std::string &);
-   std::string ProcessNewTab(const std::string &msg);
    std::string NewWidgetMsg(std::shared_ptr<RBrowserWidget> &widget);
    long ProcessRunMacro(const std::string &file_path);
    void ProcessSaveFile(const std::string &fname, const std::string &content);
@@ -83,8 +64,6 @@ protected:
 
    void SendInitMsg(unsigned connid);
    void ProcessMsg(unsigned connid, const std::string &arg);
-
-   std::string SendPageContent(BrowserPage *editor);
 
 public:
    RBrowser(bool use_rcanvas = true);

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -23,14 +23,9 @@
 #include <vector>
 #include <memory>
 
-class TString;
-class TCanvas;
-class TFile;
-
 namespace ROOT {
 namespace Experimental {
 
-class RCanvas;
 class RBrowserWidget;
 
 /** Web-based ROOT file browser */
@@ -55,9 +50,7 @@ protected:
    unsigned fConnId{0}; ///<! default connection id
 
    bool fUseRCanvas{false};             ///<!  which canvas should be used
-   std::vector<std::unique_ptr<TCanvas>> fCanvases;  ///<! canvases created by browser, should be closed at the end
-   std::string fActiveTab;            ///<! name of active for tab (RCanvas, TCanvas or BrowserPage)
-   std::vector<std::shared_ptr<ROOT::Experimental::RCanvas>> fRCanvases; ///<!  ROOT7 canvases
+   std::string fActiveTab;              ///<! name of active widget
    std::vector<std::shared_ptr<RBrowserWidget>> fWidgets; ///<!  all browser widgets
    std::vector<std::unique_ptr<BrowserPage>> fPages;      ///<! list of text editors
    int fPagesCnt{0};                                     ///<! counter for created editors
@@ -65,14 +58,6 @@ protected:
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
    RBrowserData  fBrowsable;                   ///<! central browsing element
-
-   TCanvas *AddCanvas();
-   TCanvas *GetActiveCanvas() const;
-   std::string GetCanvasUrl(TCanvas *);
-
-   std::shared_ptr<RCanvas> AddRCanvas();
-   std::shared_ptr<RCanvas> GetActiveRCanvas() const;
-   std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &);
 
    std::shared_ptr<RBrowserWidget> AddWidget(const std::string &kind);
    std::shared_ptr<RBrowserWidget> FindWidget(const std::string &name) const;

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -75,7 +75,8 @@ protected:
    std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &);
 
    std::shared_ptr<RBrowserWidget> AddWidget(const std::string &kind);
-   std::shared_ptr<RBrowserWidget> GetActiveWidget() const;
+   std::shared_ptr<RBrowserWidget> FindWidget(const std::string &name) const;
+   std::shared_ptr<RBrowserWidget> GetActiveWidget() const { return FindWidget(fActiveTab); }
 
    BrowserPage *AddPage(bool is_editor);
    BrowserPage *GetPage(const std::string &name) const;

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -7,7 +7,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -31,6 +31,7 @@ namespace ROOT {
 namespace Experimental {
 
 class RCanvas;
+class RBrowserWidget;
 
 /** Web-based ROOT file browser */
 
@@ -57,8 +58,9 @@ protected:
    std::vector<std::unique_ptr<TCanvas>> fCanvases;  ///<! canvases created by browser, should be closed at the end
    std::string fActiveTab;            ///<! name of active for tab (RCanvas, TCanvas or BrowserPage)
    std::vector<std::shared_ptr<ROOT::Experimental::RCanvas>> fRCanvases; ///<!  ROOT7 canvases
-   std::vector<std::unique_ptr<BrowserPage>> fPages;   ///<! list of text editors
-   int fPagesCnt{0};                                  ///<! counter for created editors
+   std::vector<std::shared_ptr<RBrowserWidget>> fWidgets; ///<!  all browser widgets
+   std::vector<std::unique_ptr<BrowserPage>> fPages;      ///<! list of text editors
+   int fPagesCnt{0};                                     ///<! counter for created editors
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
@@ -66,11 +68,14 @@ protected:
 
    TCanvas *AddCanvas();
    TCanvas *GetActiveCanvas() const;
-   std::string GetCanvasUrl(TCanvas *canv);
+   std::string GetCanvasUrl(TCanvas *);
 
    std::shared_ptr<RCanvas> AddRCanvas();
    std::shared_ptr<RCanvas> GetActiveRCanvas() const;
-   std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &canv);
+   std::string GetRCanvasUrl(std::shared_ptr<RCanvas> &);
+
+   std::shared_ptr<RBrowserWidget> AddWidget(const std::string &kind);
+   std::shared_ptr<RBrowserWidget> GetActiveWidget() const;
 
    BrowserPage *AddPage(bool is_editor);
    BrowserPage *GetPage(const std::string &name) const;

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -88,6 +88,7 @@ protected:
    std::string ProcessBrowserRequest(const std::string &msg);
    std::string ProcessDblClick(const std::string &path, const std::string &drawingOptions, const std::string &);
    std::string ProcessNewTab(const std::string &msg);
+   std::string NewWidgetMsg(std::shared_ptr<RBrowserWidget> &widget);
    long ProcessRunMacro(const std::string &file_path);
    void ProcessSaveFile(const std::string &fname, const std::string &content);
    std::string GetCurrentWorkingDirectory();

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -51,13 +51,9 @@ class RBrowserData {
    std::string fLastSortMethod;                          ///<! last sort method
    bool fLastSortReverse{false};                         ///<! last request reverse order
 
-   Browsable::RElementPath_t DecomposePath(const std::string &path, bool relative_to_work_element);
-
    void ResetLastRequest();
 
    bool ProcessBrowserRequest(const RBrowserRequest &request, RBrowserReply &reply);
-
-   std::shared_ptr<Browsable::RElement> GetSubElement(const Browsable::RElementPath_t &path);
 
 public:
    RBrowserData() = default;
@@ -68,7 +64,6 @@ public:
 
    void SetTopElement(std::shared_ptr<Browsable::RElement> elem);
 
-   void SetWorkingDirectory(const std::string &strpath);
    void SetWorkingPath(const Browsable::RElementPath_t &path);
 
    const Browsable::RElementPath_t &GetWorkingPath() const { return fWorkingPath; }
@@ -77,6 +72,11 @@ public:
 
    std::shared_ptr<Browsable::RElement> GetElement(const std::string &str);
    std::shared_ptr<Browsable::RElement> GetElementFromTop(const Browsable::RElementPath_t &path);
+
+   Browsable::RElementPath_t DecomposePath(const std::string &path, bool relative_to_work_element);
+   std::shared_ptr<Browsable::RElement> GetSubElement(const Browsable::RElementPath_t &path);
+
+
 };
 
 

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -51,7 +51,7 @@ class RBrowserData {
    std::string fLastSortMethod;                          ///<! last sort method
    bool fLastSortReverse{false};                         ///<! last request reverse order
 
-   void ResetLastRequest();
+   void ResetLastRequestData(bool with_element);
 
    bool ProcessBrowserRequest(const RBrowserRequest &request, RBrowserReply &reply);
 

--- a/gui/browserv7/inc/ROOT/RBrowserRequest.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserRequest.hxx
@@ -25,13 +25,14 @@ namespace Experimental {
 /** Request send from client to get content of path element */
 class RBrowserRequest {
 public:
-   std::string path; ///< requested path
-   int first{0};     ///< first child to request
-   int number{0};    ///< number of childs to request, 0 - all childs
-   std::string sort; ///< kind of sorting
-   bool reverse;     ///< reverse item order
-   bool hidden;      ///< show hidden files
-   std::string regex; ///< applied regex
+   std::string path;      ///< requested path
+   int first{0};          ///< first child to request
+   int number{0};         ///< number of childs to request, 0 - all childs
+   std::string sort;      ///< kind of sorting
+   bool reverse{false};   ///< reverse item order
+   bool hidden{false};    ///< show hidden files
+   bool reload{false};    ///< force items reload
+   std::string regex;     ///< applied regex
 };
 
 } // namespace Experimental

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -98,7 +98,7 @@ RBrowser::RBrowser(bool use_rcanvas)
    // add first canvas by default
 
    if (GetUseRCanvas())
-      AddRCanvas();
+      AddWidget("rcanvas");
    else
       AddWidget("tcanvas");
 
@@ -223,6 +223,7 @@ std::string RBrowser::ProcessDblClick(const std::string &item_path, const std::s
       }
    }
 
+   /*
    auto rcanv = GetActiveRCanvas();
    if (rcanv && elem->IsCapable(Browsable::RElement::kActDraw7)) {
 
@@ -237,7 +238,7 @@ std::string RBrowser::ProcessDblClick(const std::string &item_path, const std::s
       }
    }
 
-/*   auto canv = GetActiveCanvas();
+   auto canv = GetActiveCanvas();
    if (canv && elem->IsCapable(Browsable::RElement::kActDraw6)) {
 
       auto obj = elem->GetObject();
@@ -257,10 +258,12 @@ std::string RBrowser::ProcessDblClick(const std::string &item_path, const std::s
    auto dflt_action = elem->GetDefaultAction();
 
    std::string widget_kind;
-   if (dflt_action == Browsable::RElement::kActGeom)
-      widget_kind = "geom";
-   else if (dflt_action == Browsable::RElement::kActDraw6)
-      widget_kind = "tcanvas";
+   switch(dflt_action) {
+      case Browsable::RElement::kActGeom: widget_kind = "geom"; break;
+      case Browsable::RElement::kActDraw6: widget_kind = "tcanvas"; break;
+      case Browsable::RElement::kActDraw7: widget_kind = "rcanvas"; break;
+      default: widget_kind.clear();
+   }
 
    if (!widget_kind.empty()) {
       auto new_widget = AddWidget(widget_kind);
@@ -533,15 +536,15 @@ void RBrowser::CloseTab(const std::string &name)
    if (iter0 != fWidgets.end())
       fWidgets.erase(iter0);
 
-   auto iter1 = std::find_if(fCanvases.begin(), fCanvases.end(), [name](std::unique_ptr<TCanvas> &canv) { return name == canv->GetName(); });
-   if (iter1 != fCanvases.end())
-      fCanvases.erase(iter1);
+//   auto iter1 = std::find_if(fCanvases.begin(), fCanvases.end(), [name](std::unique_ptr<TCanvas> &canv) { return name == canv->GetName(); });
+//   if (iter1 != fCanvases.end())
+//      fCanvases.erase(iter1);
 
-   auto iter2 = std::find_if(fRCanvases.begin(), fRCanvases.end(), [name](const std::shared_ptr<RCanvas> &canv) { return name == canv->GetTitle(); });
-   if (iter2 != fRCanvases.end()) {
-      (*iter2)->Remove();
-      fRCanvases.erase(iter2);
-   }
+//   auto iter2 = std::find_if(fRCanvases.begin(), fRCanvases.end(), [name](const std::shared_ptr<RCanvas> &canv) { return name == canv->GetTitle(); });
+//   if (iter2 != fRCanvases.end()) {
+//      (*iter2)->Remove();
+//      fRCanvases.erase(iter2);
+//   }
 
    auto iter3 = std::find_if(fPages.begin(), fPages.end(), [name](std::unique_ptr<BrowserPage> &page) { return name == page->fName; });
    if (iter3 != fPages.end())
@@ -611,12 +614,12 @@ void RBrowser::SendInitMsg(unsigned connid)
 //      reply.emplace_back(arr);
 //   }
 
-   for (auto &canv : fRCanvases) {
-      auto url = GetRCanvasUrl(canv);
-      std::string name = canv->GetTitle();
-      std::vector<std::string> arr = { "root7", url, name };
-      reply.emplace_back(arr);
-   }
+//   for (auto &canv : fRCanvases) {
+//      auto url = GetRCanvasUrl(canv);
+//      std::string name = canv->GetTitle();
+//      std::vector<std::string> arr = { "root7", url, name };
+//      reply.emplace_back(arr);
+//   }
 
    for (auto &widget : fWidgets) {
       reply.emplace_back(std::vector<std::string>({ widget->GetKind(), widget->GetUrl(), widget->GetName(), widget->GetTitle() }));
@@ -663,15 +666,15 @@ std::string RBrowser::ProcessNewTab(const std::string &kind)
 {
    std::vector<std::string> reply;
 
-   if (kind == "NEWRCANVAS") {
-      auto canv = AddRCanvas();
-      auto url = GetRCanvasUrl(canv);
-      reply = {"root7"s, url, canv->GetTitle()};
+//   if (kind == "NEWRCANVAS") {
+//      auto canv = AddRCanvas();
+//      auto url = GetRCanvasUrl(canv);
+//      reply = {"root7"s, url, canv->GetTitle()};
 //   } else if (kind == "NEWTCANVAS") {
 //      auto canv = AddCanvas();
 //      auto url = GetCanvasUrl(canv);
 //      reply = {"root6"s, url, std::string(canv->GetName())};
-   } else if ((kind == "NEWEDITOR") || (kind == "NEWVIEWER")) {
+   if ((kind == "NEWEDITOR") || (kind == "NEWVIEWER")) {
       auto edit = AddPage(kind == "NEWEDITOR");
       reply = {edit->GetKind(), edit->fName, edit->fTitle};
    } else {

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -100,7 +100,7 @@ RBrowser::RBrowser(bool use_rcanvas)
    if (GetUseRCanvas())
       AddRCanvas();
    else
-      AddCanvas();
+      AddWidget("tcanvas");
 
    // AddWidget("geom");  // add geometry viewer at the beginning
 
@@ -237,7 +237,7 @@ std::string RBrowser::ProcessDblClick(const std::string &item_path, const std::s
       }
    }
 
-   auto canv = GetActiveCanvas();
+/*   auto canv = GetActiveCanvas();
    if (canv && elem->IsCapable(Browsable::RElement::kActDraw6)) {
 
       auto obj = elem->GetObject();
@@ -248,7 +248,7 @@ std::string RBrowser::ProcessDblClick(const std::string &item_path, const std::s
          // return "SELECT_TAB:"s + canv->GetName();
       }
    }
-
+*/
 
    auto widget = GetActiveWidget();
    if (widget && widget->DrawElement(elem, drawingOptions))
@@ -256,13 +256,19 @@ std::string RBrowser::ProcessDblClick(const std::string &item_path, const std::s
 
    auto dflt_action = elem->GetDefaultAction();
 
-   if (dflt_action == Browsable::RElement::kActGeom) {
-      auto gwidget = AddWidget("geom");
-      if (gwidget) {
-         // draw geometry calls Update(), but it is not a problem
-         // while connection is not yet established by the client
-         gwidget->DrawElement(elem, drawingOptions);
-         return NewWidgetMsg(gwidget);
+   std::string widget_kind;
+   if (dflt_action == Browsable::RElement::kActGeom)
+      widget_kind = "geom";
+   else if (dflt_action == Browsable::RElement::kActDraw6)
+      widget_kind = "tcanvas";
+
+   if (!widget_kind.empty()) {
+      auto new_widget = AddWidget(widget_kind);
+      if (new_widget) {
+         // draw object before client side is created - should not be a problem
+         // after widget add in browser, connection will be established and data provided
+         new_widget->DrawElement(elem, drawingOptions);
+         return NewWidgetMsg(new_widget);
       }
    }
 
@@ -598,12 +604,12 @@ void RBrowser::SendInitMsg(unsigned connid)
 
    reply.emplace_back(fBrowsable.GetWorkingPath()); // first element is current path
 
-   for (auto &canv : fCanvases) {
-      auto url = GetCanvasUrl(canv.get());
-      std::string name = canv->GetName();
-      std::vector<std::string> arr = { "root6", url, name };
-      reply.emplace_back(arr);
-   }
+//   for (auto &canv : fCanvases) {
+//      auto url = GetCanvasUrl(canv.get());
+//      std::string name = canv->GetName();
+//      std::vector<std::string> arr = { "root6", url, name };
+//      reply.emplace_back(arr);
+//   }
 
    for (auto &canv : fRCanvases) {
       auto url = GetRCanvasUrl(canv);
@@ -661,10 +667,10 @@ std::string RBrowser::ProcessNewTab(const std::string &kind)
       auto canv = AddRCanvas();
       auto url = GetRCanvasUrl(canv);
       reply = {"root7"s, url, canv->GetTitle()};
-   } else if (kind == "NEWTCANVAS") {
-      auto canv = AddCanvas();
-      auto url = GetCanvasUrl(canv);
-      reply = {"root6"s, url, std::string(canv->GetName())};
+//   } else if (kind == "NEWTCANVAS") {
+//      auto canv = AddCanvas();
+//      auto url = GetCanvasUrl(canv);
+//      reply = {"root6"s, url, std::string(canv->GetName())};
    } else if ((kind == "NEWEDITOR") || (kind == "NEWVIEWER")) {
       auto edit = AddPage(kind == "NEWEDITOR");
       reply = {edit->GetKind(), edit->fName, edit->fTitle};

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -33,17 +33,7 @@ void RBrowserData::SetTopElement(std::shared_ptr<Browsable::RElement> elem)
 {
    fTopElement = elem;
 
-   SetWorkingDirectory("");
-}
-
-/////////////////////////////////////////////////////////////////////
-/// set working directory relative to top element
-
-void RBrowserData::SetWorkingDirectory(const std::string &strpath)
-{
-   auto path = DecomposePath(strpath, false);
-
-   SetWorkingPath(path);
+   SetWorkingPath({});
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -82,22 +72,8 @@ Browsable::RElementPath_t RBrowserData::DecomposePath(const std::string &strpath
    if (strpath.empty())
       return arr;
 
-   std::string slash = "/";
-
-   std::string::size_type previous = 0;
-   if (strpath[0] == slash[0]) previous++;
-
-   auto current = strpath.find(slash, previous);
-   while (current != std::string::npos) {
-      if (current > previous)
-         arr.emplace_back(strpath.substr(previous, current - previous));
-      previous = current + 1;
-      current = strpath.find(slash, previous);
-   }
-
-   if (previous < strpath.length())
-      arr.emplace_back(strpath.substr(previous));
-
+   auto arr2 = Browsable::RElement::ParsePath(strpath);
+   arr.insert(arr.end(), arr2.begin(), arr2.end());
    return arr;
 }
 

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -43,20 +43,22 @@ void RBrowserData::SetWorkingPath(const Browsable::RElementPath_t &path)
 {
    fWorkingPath = path;
 
-   ResetLastRequest();
+   ResetLastRequestData(true);
 }
 
 /////////////////////////////////////////////////////////////////////
 /// Reset all data correspondent to last request
 
-void RBrowserData::ResetLastRequest()
+void RBrowserData::ResetLastRequestData(bool with_element)
 {
    fLastAllChilds = false;
    fLastSortedItems.clear();
    fLastSortMethod.clear();
    fLastItems.clear();
-   fLastPath.clear();
-   fLastElement.reset();
+   if (with_element) {
+      fLastPath.clear();
+      fLastElement.reset();
+   }
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -92,11 +94,14 @@ bool RBrowserData::ProcessBrowserRequest(const RBrowserRequest &request, RBrowse
       auto elem = GetSubElement(path);
       if (!elem) return false;
 
-      ResetLastRequest();
+      ResetLastRequestData(true);
 
       fLastPath = path;
       fLastElement = std::move(elem);
-}
+   } else if (request.reload) {
+      // only reload items from element, not need to reset element itself
+      ResetLastRequestData(false);
+   }
 
    // when request childs, always try to make elements
    if (fLastItems.empty()) {

--- a/gui/browserv7/src/RBrowserGeomWidget.cxx
+++ b/gui/browserv7/src/RBrowserGeomWidget.cxx
@@ -79,9 +79,8 @@ public:
 
    bool DrawElement(std::shared_ptr<Browsable::RElement> &elem, const std::string &) override
    {
-      // TODO: implement kActGeom capability
-      // if (!elem->IsCapable(Browsable::RElement::kActGeom))
-      //   return false;
+      if (!elem->IsCapable(Browsable::RElement::kActGeom))
+         return false;
 
       fObject = elem->GetObject();
       if (!fObject)

--- a/gui/browserv7/src/RBrowserGeomWidget.cxx
+++ b/gui/browserv7/src/RBrowserGeomWidget.cxx
@@ -32,7 +32,7 @@ class RBrowserGeomWidget : public RBrowserWidget {
 
    std::unique_ptr<Browsable::RHolder> fObject; // geometry object
 
-   /** Create dummy geometry - when nothiing else is there */
+   /** Create dummy geometry - when nothing else is there */
    TGeoManager *MakeDummy()
    {
       auto prev = gGeoManager;

--- a/gui/browserv7/src/RBrowserGeomWidget.cxx
+++ b/gui/browserv7/src/RBrowserGeomWidget.cxx
@@ -98,11 +98,6 @@ public:
       return true;
    }
 
-   std::string ReplyAfterDraw() override
-   {
-      return ""s;
-   }
-
 };
 
 // ======================================================================

--- a/gui/browserv7/src/RBrowserGeomWidget.cxx
+++ b/gui/browserv7/src/RBrowserGeomWidget.cxx
@@ -1,0 +1,63 @@
+/// \file RBrowserGeomWidget.cxx
+/// \ingroup rbrowser
+/// \author Sergey Linev <S.Linev@gsi.de>
+/// \date 2021-01-22
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "RBrowserWidget.hxx"
+
+#include <ROOT/REveGeomViewer.hxx>
+
+using namespace ROOT::Experimental;
+
+using namespace std::string_literals;
+
+
+class RBrowserGeomWidget : public RBrowserWidget {
+   REveGeomViewer fViewer;
+
+public:
+
+   RBrowserGeomWidget(const std::string &name) : RBrowserWidget(name), fViewer()
+   {
+      fViewer.SetTitle(name);
+      fViewer.SetShowHierarchy(false);
+   }
+
+   virtual ~RBrowserGeomWidget() = default;
+
+   std::string GetKind() const override { return "geom"s; }
+
+   void Show(const std::string &arg) override
+   {
+      fViewer.Show(arg);
+   }
+
+   std::string GetUrl() override
+   {
+      return "../"s + fViewer.GetWindowAddr() + "/"s;
+   }
+
+};
+
+// ======================================================================
+
+class RBrowserGeomProvider : public RBrowserWidgetProvider {
+protected:
+   std::shared_ptr<RBrowserWidget> Create(const std::string &name) final
+   {
+      return std::make_shared<RBrowserGeomWidget>(name);
+   }
+public:
+   RBrowserGeomProvider() : RBrowserWidgetProvider("geom") {}
+   ~RBrowserGeomProvider() = default;
+} sRBrowserGeomProvider;

--- a/gui/browserv7/src/RBrowserRCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserRCanvasWidget.cxx
@@ -69,11 +69,6 @@ public:
       return false;
    }
 
-   std::string ReplyAfterDraw() override
-   {
-      return ""s;
-   }
-
 };
 
 // ======================================================================

--- a/gui/browserv7/src/RBrowserRCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserRCanvasWidget.cxx
@@ -1,0 +1,90 @@
+/// \file RBrowserRCanvasWidget.cxx
+/// \ingroup rbrowser
+/// \author Sergey Linev <S.Linev@gsi.de>
+/// \date 2021-01-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "RBrowserWidget.hxx"
+
+#include <ROOT/Browsable/RProvider.hxx>
+
+#include <ROOT/RCanvas.hxx>
+
+using namespace ROOT::Experimental;
+
+using namespace std::string_literals;
+
+
+class RBrowserRCanvasWidget : public RBrowserWidget {
+
+   std::shared_ptr<RCanvas> fCanvas; ///<! drawn canvas
+
+public:
+
+   RBrowserRCanvasWidget(const std::string &name) : RBrowserWidget(name)
+   {
+      fCanvas = RCanvas::Create(name);
+   }
+
+   virtual ~RBrowserRCanvasWidget() = default;
+
+   std::string GetKind() const override { return "rcanvas"s; }
+
+   void Show(const std::string &arg) override
+   {
+      fCanvas->Show(arg);
+   }
+
+   std::string GetUrl() override
+   {
+      return "../"s + fCanvas->GetWindowAddr() + "/"s;
+   }
+
+   bool DrawElement(std::shared_ptr<Browsable::RElement> &elem, const std::string &opt) override
+   {
+      if (!elem->IsCapable(Browsable::RElement::kActDraw7))
+         return false;
+
+      auto obj = elem->GetObject();
+      if (!obj)
+         return false;
+
+      std::shared_ptr<RPadBase> subpad = fCanvas;
+
+      if (obj && Browsable::RProvider::Draw7(subpad, obj, opt)) {
+         fCanvas->Modified();
+         fCanvas->Update(true);
+         return true;
+      }
+
+      return false;
+   }
+
+   std::string ReplyAfterDraw() override
+   {
+      return ""s;
+   }
+
+};
+
+// ======================================================================
+
+class RBrowserRCanvasProvider : public RBrowserWidgetProvider {
+protected:
+   std::shared_ptr<RBrowserWidget> Create(const std::string &name) final
+   {
+      return std::make_shared<RBrowserRCanvasWidget>(name);
+   }
+public:
+   RBrowserRCanvasProvider() : RBrowserWidgetProvider("rcanvas") {}
+   ~RBrowserRCanvasProvider() = default;
+} sRBrowserRCanvasProvider;

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -15,6 +15,8 @@
 
 #include "RBrowserWidget.hxx"
 
+#include <ROOT/Browsable/RProvider.hxx>
+
 #include "TCanvas.h"
 #include "TWebCanvas.h"
 
@@ -70,32 +72,13 @@ public:
          return false;
 
       fObject = elem->GetObject();
-      if (!fObject)
-         return false;
 
-      // first take object without ownership
-      auto tobj = fObject->get_object<TObject>();
-      if (!tobj) {
-         // and now with ownership
-         auto utobj = fObject->get_unique<TObject>();
-         if (!utobj)
-            return false;
-         tobj = utobj.release();
-         tobj->SetBit(TObject::kMustCleanup); // TCanvas should care about cleanup
+      if (fObject && Browsable::RProvider::Draw6(fCanvas.get(), fObject, opt)) {
+         fCanvas->ForceUpdate();
+         return true;
       }
 
-      fCanvas->GetListOfPrimitives()->Clear();
-
-      fCanvas->GetListOfPrimitives()->Add(tobj, opt.c_str());
-
-      fCanvas->ForceUpdate(); // force update async - do not wait for confirmation
-
-      return true;
-   }
-
-   std::string ReplyAfterDraw() override
-   {
-      return ""s;
+      return false;
    }
 
 };
@@ -112,3 +95,4 @@ public:
    RBrowserTCanvasProvider() : RBrowserWidgetProvider("tcanvas") {}
    ~RBrowserTCanvasProvider() = default;
 } sRBrowserTCanvasProvider;
+

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -1,0 +1,114 @@
+/// \file RBrowserTCanvasWidget.cxx
+/// \ingroup rbrowser
+/// \author Sergey Linev <S.Linev@gsi.de>
+/// \date 2021-01-22
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "RBrowserWidget.hxx"
+
+#include "TCanvas.h"
+#include "TWebCanvas.h"
+
+using namespace ROOT::Experimental;
+
+using namespace std::string_literals;
+
+
+class RBrowserTCanvasWidget : public RBrowserWidget {
+
+   std::unique_ptr<TCanvas> fCanvas; ///<! drawn canvas
+   TWebCanvas *fWebCanvas{nullptr};  ///<! web implementation, owned by TCanvas
+
+   std::unique_ptr<Browsable::RHolder> fObject; // TObject drawing in the TCanvas
+
+public:
+
+   RBrowserTCanvasWidget(const std::string &name) : RBrowserWidget(name)
+   {
+      fCanvas = std::make_unique<TCanvas>(kFALSE);
+      fCanvas->SetName(name.c_str());
+      fCanvas->SetTitle(name.c_str());
+      fCanvas->ResetBit(TCanvas::kShowEditor);
+      fCanvas->ResetBit(TCanvas::kShowToolBar);
+      fCanvas->SetCanvas(fCanvas.get());
+      fCanvas->SetBatch(kTRUE); // mark canvas as batch
+      fCanvas->SetEditable(kTRUE); // ensure fPrimitives are created
+
+      // create implementation
+      fWebCanvas = new TWebCanvas(fCanvas.get(), "title", 0, 0, 800, 600);
+
+      // assign implementation
+      fCanvas->SetCanvasImp(fWebCanvas);
+   }
+
+   virtual ~RBrowserTCanvasWidget() = default;
+
+   std::string GetKind() const override { return "tcanvas"s; }
+
+   void Show(const std::string &arg) override
+   {
+      fWebCanvas->ShowWebWindow(arg);
+   }
+
+   std::string GetUrl() override
+   {
+      return "../"s + fWebCanvas->GetWebWindow()->GetAddr() + "/"s;
+   }
+
+   bool DrawElement(std::shared_ptr<Browsable::RElement> &elem, const std::string &opt) override
+   {
+      if (!elem->IsCapable(Browsable::RElement::kActDraw6))
+         return false;
+
+      fObject = elem->GetObject();
+      if (!fObject)
+         return false;
+
+      // first take object without ownership
+      auto tobj = fObject->get_object<TObject>();
+      if (!tobj) {
+         // and now with ownership
+         auto utobj = fObject->get_unique<TObject>();
+         if (!utobj)
+            return false;
+         tobj = utobj.release();
+         tobj->SetBit(TObject::kMustCleanup); // TCanvas should care about cleanup
+      }
+
+      fCanvas->GetListOfPrimitives()->Clear();
+
+      fCanvas->GetListOfPrimitives()->Add(tobj, opt.c_str());
+
+      fCanvas->ForceUpdate(); // force update async - do not wait for confirmation
+
+      return true;
+   }
+
+   std::string ReplyAfterDraw() override
+   {
+      return ""s;
+   }
+
+};
+
+// ======================================================================
+
+class RBrowserTCanvasProvider : public RBrowserWidgetProvider {
+protected:
+   std::shared_ptr<RBrowserWidget> Create(const std::string &name) final
+   {
+      return std::make_shared<RBrowserTCanvasWidget>(name);
+   }
+public:
+   RBrowserTCanvasProvider() : RBrowserWidgetProvider("tcanvas") {}
+   ~RBrowserTCanvasProvider() = default;
+} sRBrowserTCanvasProvider;

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -1,7 +1,7 @@
 /// \file RBrowserTCanvasWidget.cxx
 /// \ingroup rbrowser
 /// \author Sergey Linev <S.Linev@gsi.de>
-/// \date 2021-01-22
+/// \date 2021-01-25
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 

--- a/gui/browserv7/src/RBrowserWidget.cxx
+++ b/gui/browserv7/src/RBrowserWidget.cxx
@@ -55,6 +55,8 @@ std::shared_ptr<RBrowserWidget> RBrowserWidgetProvider::CreateWidget(const std::
       // try to load necessary libraries
       if (kind == "geom")
          gSystem->Load("libROOTBrowserGeomWidget");
+      else if (kind == "tcanvas")
+         gSystem->Load("libROOTBrowserTCanvasWidget");
       iter = map.find(kind);
       if (iter == map.end())
          return nullptr;

--- a/gui/browserv7/src/RBrowserWidget.cxx
+++ b/gui/browserv7/src/RBrowserWidget.cxx
@@ -1,0 +1,63 @@
+/// \file RBrowserWidget.cxx
+/// \ingroup rbrowser
+/// \author Sergey Linev <S.Linev@gsi.de>
+/// \date 2021-01-22
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "RBrowserWidget.hxx"
+
+#include <algorithm>
+
+#include "TSystem.h"
+
+
+using namespace std::string_literals;
+using namespace ROOT::Experimental;
+
+RBrowserWidgetProvider::RBrowserWidgetProvider(const std::string &kind)
+{
+   GetMap().emplace(kind, this);
+}
+
+RBrowserWidgetProvider::~RBrowserWidgetProvider()
+{
+   auto &map = GetMap();
+   auto iter = std::find_if(map.begin(), map.end(),
+         [this](const ProvidersMap_t::value_type &pair) { return this == pair.second; });
+
+   if (iter != map.end())
+      map.erase(iter);
+}
+
+RBrowserWidgetProvider::ProvidersMap_t& RBrowserWidgetProvider::GetMap()
+{
+   static RBrowserWidgetProvider::ProvidersMap_t mMap;
+   return mMap;
+}
+
+///////////////////////////////////////////////////////////////
+/// Create specified widget
+
+std::shared_ptr<RBrowserWidget> RBrowserWidgetProvider::CreateWidget(const std::string &kind, const std::string &name)
+{
+   auto &map = GetMap();
+   auto iter = map.find(kind);
+   if (iter == map.end()) {
+      // try to load necessary libraries
+      if (kind == "geom")
+         gSystem->Load("libROOTBrowserGeomWidget");
+      iter = map.find(kind);
+      if (iter == map.end())
+         return nullptr;
+   }
+   return iter->second->Create(name);
+}

--- a/gui/browserv7/src/RBrowserWidget.cxx
+++ b/gui/browserv7/src/RBrowserWidget.cxx
@@ -57,6 +57,8 @@ std::shared_ptr<RBrowserWidget> RBrowserWidgetProvider::CreateWidget(const std::
          gSystem->Load("libROOTBrowserGeomWidget");
       else if (kind == "tcanvas")
          gSystem->Load("libROOTBrowserTCanvasWidget");
+      else if (kind == "rcanvas")
+         gSystem->Load("libROOTBrowserRCanvasWidget");
       iter = map.find(kind);
       if (iter == map.end())
          return nullptr;

--- a/gui/browserv7/src/RBrowserWidget.hxx
+++ b/gui/browserv7/src/RBrowserWidget.hxx
@@ -20,6 +20,8 @@
 #include <map>
 #include <string>
 
+#include <ROOT/Browsable/RElement.hxx>
+
 namespace ROOT {
 namespace Experimental {
 
@@ -29,6 +31,7 @@ namespace Experimental {
 class RBrowserWidget {
 
    std::string fName;
+
 public:
 
    explicit RBrowserWidget(const std::string &name) : fName(name) {};
@@ -40,6 +43,9 @@ public:
    virtual std::string GetKind() const = 0;
    virtual std::string GetUrl() = 0;
    virtual std::string GetTitle() { return ""; }
+
+   virtual bool DrawElement(std::shared_ptr<Browsable::RElement> &, const std::string &) { return false; }
+   virtual std::string ReplyAfterDraw() { return ""; }
 };
 
 class RBrowserWidgetProvider {

--- a/gui/browserv7/src/RBrowserWidget.hxx
+++ b/gui/browserv7/src/RBrowserWidget.hxx
@@ -39,13 +39,15 @@ public:
 
    virtual void Show(const std::string &) = 0;
 
+   virtual void ResetConn() {}
+
    const std::string &GetName() const { return fName; }
    virtual std::string GetKind() const = 0;
    virtual std::string GetUrl() = 0;
    virtual std::string GetTitle() { return ""; }
 
    virtual bool DrawElement(std::shared_ptr<Browsable::RElement> &, const std::string &) { return false; }
-   virtual std::string ReplyAfterDraw() { return ""; }
+   virtual std::string SendWidgetContent() { return ""; }
 };
 
 class RBrowserWidgetProvider {

--- a/gui/browserv7/src/RBrowserWidget.hxx
+++ b/gui/browserv7/src/RBrowserWidget.hxx
@@ -1,0 +1,65 @@
+/// \file RBrowserWidget.hxx
+/// \ingroup rbrowser
+/// \author Sergey Linev <S.Linev@gsi.de>
+/// \date 2021-01-22
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RBrowserWidget
+#define ROOT7_RBrowserWidget
+
+#include <memory>
+#include <map>
+#include <string>
+
+namespace ROOT {
+namespace Experimental {
+
+/** Abstract Web-based widget, which can be used in the RBrowser
+  * Used to embed canvas, geometry viewer and potentially any other widgets */
+
+class RBrowserWidget {
+
+   std::string fName;
+public:
+
+   explicit RBrowserWidget(const std::string &name) : fName(name) {};
+   virtual ~RBrowserWidget() = default;
+
+   virtual void Show(const std::string &) = 0;
+
+   const std::string &GetName() const { return fName; }
+   virtual std::string GetKind() const = 0;
+   virtual std::string GetUrl() = 0;
+   virtual std::string GetTitle() { return ""; }
+};
+
+class RBrowserWidgetProvider {
+protected:
+   using ProvidersMap_t = std::map<std::string, RBrowserWidgetProvider*>;
+
+   virtual std::shared_ptr<RBrowserWidget> Create(const std::string &) = 0;
+
+   static ProvidersMap_t& GetMap();
+
+public:
+
+   explicit RBrowserWidgetProvider(const std::string &kind);
+   virtual ~RBrowserWidgetProvider();
+
+   static std::shared_ptr<RBrowserWidget> CreateWidget(const std::string &kind, const std::string &name);
+};
+
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/gui/browserv7/src/RBrowserWidget.hxx
+++ b/gui/browserv7/src/RBrowserWidget.hxx
@@ -30,7 +30,9 @@ namespace Experimental {
 
 class RBrowserWidget {
 
-   std::string fName;
+   std::string fName;   ///<!  widget name
+
+   Browsable::RElementPath_t  fPath;  ///<! path of drawn element
 
 public:
 
@@ -40,6 +42,9 @@ public:
    virtual void Show(const std::string &) = 0;
 
    virtual void ResetConn() {}
+
+   void SetPath(const Browsable::RElementPath_t &path) { fPath = path; }
+   const Browsable::RElementPath_t &GetPath() const { return fPath; }
 
    const std::string &GetName() const { return fName; }
    virtual std::string GetKind() const = 0;

--- a/gui/browserv7/src/RFileDialog.cxx
+++ b/gui/browserv7/src/RFileDialog.cxx
@@ -69,9 +69,9 @@ RFileDialog::RFileDialog(EDialogTypes kind, const std::string &title, const std:
    }
 
    auto comp = std::make_shared<Browsable::RGroup>("top", "Top file dialog element");
-   workdir = Browsable::RSysFile::ProvideTopEntries(comp, workdir);
+   auto workpath = Browsable::RSysFile::ProvideTopEntries(comp, workdir);
    fBrowsable.SetTopElement(comp);
-   fBrowsable.SetWorkingDirectory(workdir);
+   fBrowsable.SetWorkingPath(workpath);
 
    fWebWindow = RWebWindow::Create();
 

--- a/gui/browserv7/src/RFileDialog.cxx
+++ b/gui/browserv7/src/RFileDialog.cxx
@@ -229,8 +229,6 @@ std::string RFileDialog::GetRegexp(const std::string &fname) const
 
 void RFileDialog::SendInitMsg(unsigned connid)
 {
-   printf("Sending dialog init msg\n");
-
    auto filter = GetSelectedFilter();
    RBrowserRequest req;
    req.sort = "alphabetical";
@@ -248,7 +246,7 @@ void RFileDialog::SendInitMsg(unsigned connid)
                                    "\"filter\" : "s + jfilter.Data() + ","s +
                                    "\"filters\" : "s + jfilters.Data() + ","s +
                                    "\"fname\" : "s + jfname.Data() + ","s +
-                                   "\"brepl\" : "s + fBrowsable.ProcessRequest(req) + "   }"s);
+                                   "\"brepl\" : "s + fBrowsable.ProcessRequest(req) + " }"s);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -263,7 +261,7 @@ void RFileDialog::SendChPathMsg(unsigned connid)
    auto jpath = TBufferJSON::ToJSON(&fBrowsable.GetWorkingPath());
 
    fWebWindow->Send(connid, "CHMSG:{\"path\" : "s + jpath.Data() +
-                                 ", \"brepl\" : "s + fBrowsable.ProcessRequest(req) + "   }"s);
+                                 ", \"brepl\" : "s + fBrowsable.ProcessRequest(req) + " }"s);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -271,12 +269,6 @@ void RFileDialog::SendChPathMsg(unsigned connid)
 
 void RFileDialog::ProcessMsg(unsigned connid, const std::string &arg)
 {
-   size_t len = arg.find("\n");
-   if (len != std::string::npos)
-      printf("Recv %s\n", arg.substr(0, len).c_str());
-   else
-      printf("Recv %s\n", arg.c_str());
-
    if (arg.compare(0, 7, "CHPATH:") == 0) {
       auto path = TBufferJSON::FromJSON<Browsable::RElementPath_t>(arg.substr(7));
       if (path) fBrowsable.SetWorkingPath(*path);

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -101,11 +101,11 @@
    /** @summary JSROOT version id
      * @desc For the JSROOT release the string in format "major.minor.patch" like "6.0.0"
      * For the ROOT release string is "ROOT major.minor.patch" like "ROOT 6.24.00" */
-   JSROOT.version_id = "6.0.0";
+   JSROOT.version_id = "dev";
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "14/01/2021";
+   JSROOT.version_date = "22/01/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.geom.js
+++ b/js/scripts/JSRoot.geom.js
@@ -1993,7 +1993,6 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
                            new THREE.Plane(new THREE.Vector3(0, this.ctrl._yup ? -1 : 1, 0), 0),
                            new THREE.Plane(new THREE.Vector3(0, 0, this.ctrl._yup ? 1 : -1), 0) ];
 
-
       // Light - add default point light, adjust later
 
       let light = new THREE.PointLight(0xefefef, 1);
@@ -3150,7 +3149,7 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
                this.render3D(-1);
                this._last_render_meshes = this.ctrl.info.num_meshes;
             }
-            if (res !== 2) setTimeout(this.continueDraw.bind(this), (res === 1) ? 100 : 1);
+            if (res !== 2) setTimeout(() => this.continueDraw(), (res === 1) ? 100 : 1);
 
             return;
          }
@@ -3158,7 +3157,7 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
 
       let take_time = now - this._startm;
 
-      if (this._first_drawing)
+      if (this._first_drawing || this._full_redrawing)
          console.log(`Create tm = ${take_time} meshes ${this.ctrl.info.num_meshes} faces ${this.ctrl.info.num_faces}`);
 
       if (take_time > 300) {
@@ -3699,6 +3698,7 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
       }
 
       if (this._full_redrawing) {
+         this.adjustCameraPosition(true);
          this._full_redrawing = false;
          full_redraw = true;
          this.changedDepthMethod("norender");
@@ -4024,6 +4024,7 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
       delete this._extraObjects;
       delete this._clipCfg;
 
+      // only remove all childs from top level object
       jsrp.disposeThreejsObject(this._toplevel, true);
 
       this._full_redrawing = true;

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -3938,12 +3938,12 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
    /** @summary Use provided connection for the web canvas
      * @private */
-   TCanvasPainter.prototype.useWebsocket = function(handle, href) {
+   TCanvasPainter.prototype.useWebsocket = function(handle) {
       this.closeWebsocket();
 
       this._websocket = handle;
       this._websocket.setReceiver(this);
-      this._websocket.connect(href);
+      this._websocket.connect();
    }
 
    /** @summary Hanler for websocket open event

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -3967,13 +3967,12 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
    /** @summary Use provided connection for the web canvas
      * @private */
-   RCanvasPainter.prototype.useWebsocket = function(handle, href) {
+   RCanvasPainter.prototype.useWebsocket = function(handle) {
       this.closeWebsocket();
 
       this._websocket = handle;
-      console.log('Use websocket', this._websocket.key);
       this._websocket.setReceiver(this);
-      this._websocket.connect(href);
+      this._websocket.connect();
    }
 
    /** @summary Hanler for websocket open event

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -615,7 +615,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          else if (txt.indexOf("Root 6") >= 0)
             msg = "NEWWIDGET:tcanvas";
          else if (txt.indexOf("Root 7") >= 0)
-            msg = "NEWRCANVAS";
+            msg = "NEWWIDGET:rcanvas";
 
          if (this.isConnected && msg)
             this.websocket.send(msg);
@@ -1019,10 +1019,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             this.createImageViewer(par1, par2);
          } else if (kind == "geom") {
             this.createGeomViewer(par1, par2, par3);
-         } else if (kind == "tcanvas") {
-            this.createCanvas("root6", par1, par2);
          } else
-            this.createCanvas(kind, par1, par2);
+            this.createCanvas(kind, par1, par2, par3);
       },
 
       createGeomViewer: function(url, name, title) {
@@ -1048,7 +1046,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       },
 
       createCanvas: function(kind, url, name) {
-         if (!url || !name || (kind != "root6" && kind != "root7")) return;
+         if (!url || !name || (kind != "tcanvas" && kind != "rcanvas")) return;
 
          let oTabContainer = this.byId("tabContainer");
          let item = new TabContainerItem({
@@ -1061,16 +1059,16 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          oTabContainer.addItem(item);
 
          // Change the selected tabs, only if it is new one, not the basic one
-         if(name !== "rcanv1") {
-            oTabContainer.setSelectedItem(item);
-         }
+         //if(name !== "rcanv1") {
+         //   oTabContainer.setSelectedItem(item);
+         // }
 
          let conn = new JSROOT.WebWindowHandle(this.websocket.kind);
          conn.setHRef(this.websocket.getHRef(url)); // argument for connect, makes relative path
 
          let painter = null;
 
-         if (kind == "root7") {
+         if (kind == "rcanvas") {
             painter = new JSROOT.v7.RCanvasPainter(null, null);
          } else {
             painter = new JSROOT.TCanvasPainter(null, null);

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -414,12 +414,14 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       },
 
       /** @summary Search TabContainerItem by key value */
-      findTab: function(name) {
-         let oTabContainer = this.byId("tabContainer");
-         let items = oTabContainer.getItems();
+      findTab: function(name, set_active) {
+         let oTabContainer = this.byId("tabContainer"),
+             items = oTabContainer.getItems();
          for(let i = 0; i< items.length; i++)
-            if (items[i].getKey() === name)
+            if (items[i].getKey() === name) {
+               if (set_active) oTabContainer.setSelectedItem(items[i]);
                return items[i];
+            }
       },
 
       /** @summary Retuns current selected tab, instance of TabContainerItem */
@@ -854,9 +856,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             let arr = JSON.parse(msg);
             let tab = this.findTab(arr[0]);
 
-            console.log('Get edtior code', arr[0], arr[3].length, msg);
             if (tab) {
-               console.log('Get edtior title', arr[1]);
                this.setEditorFileKind(tab, arr[1]);
                tab.getModel().setProperty("/title", arr[1]);
                tab.getModel().setProperty("/filename", arr[2]);
@@ -882,18 +882,15 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          case "NEWWIDGET": {  // widget created by server, need to establish connection
             let arr = JSON.parse(msg);
             this.createElement(arr[0], arr[1], arr[2], arr[3]);
-            const tabItem = this.findTab(arr[2]);
-            console.log('Select tab item', arr[2], !!tabItem);
-            if (tabItem) this.byId("tabContainer").setSelectedItem(tabItem);
+            this.findTab(arr[2], true); // set active
             break;
          }
          case "WORKPATH":
             this.updateBReadcrumbs(JSON.parse(msg));
             this.doReload();
             break;
-         case "SELECT_TAB":
-           let tab = this.findTab(msg);
-           if (tab) this.byId("tabContainer").setSelectedItem(tab);
+         case "SELECT_WIDGET":
+           this.findTab(msg, true); // set active
            break;
          case "BREPL":   // browser reply
             if (this.model) {
@@ -1002,8 +999,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          for (var k=1; k<arr.length; ++k) {
             let kind = arr[k][0];
             if (kind == "active") {
-               const tabItem = this.findTab(arr[k][1]);
-               if (tabItem) this.byId("tabContainer").setSelectedItem(tabItem);
+               this.findTab(arr[k][1], true); // set active
             } else if (kind == "history") {
                arr[k].shift();
                this.updateRootHist(arr[k]);

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -608,8 +608,10 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
          if (txt.indexOf("editor") >= 0)
             msg = "NEWEDITOR";
-         else if (txt.indexOf("viewer") >= 0)
+         else if (txt.indexOf("Image") >= 0)
             msg = "NEWVIEWER";
+         else if (txt.indexOf("Geometry") >= 0)
+            msg = "NEWWIDGET:geom";
          else if (txt.indexOf("Root 6") >= 0)
             msg = "NEWTCANVAS";
          else if (txt.indexOf("Root 7") >= 0)
@@ -878,7 +880,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          }
          case "NEWTAB": {  // canvas created by server, need to establish connection
             let arr = JSON.parse(msg);
-            this.createElement(arr[0], arr[1], arr[2]);
+            this.createElement(arr[0], arr[1], arr[2], arr[3]);
             break;
          }
          case "WORKPATH":
@@ -1033,15 +1035,13 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          oTabContainer.addItem(item);
          oTabContainer.setSelectedItem(item);
 
-         console.log('Try to connect geom viewer at url', this.websocket.getHRef(url));
-
          JSROOT.connectWebWindow({
             kind: this.websocket.kind,
             href: this.websocket.getHRef(url),
             user_args: { nobrowser: true }
          }).then(handle => XMLView.create({
             viewName: "rootui5.eve7.view.GeomViewer",
-            viewData: { conn_handle: handle }
+            viewData: { conn_handle: handle, embeded: true }
          })).then(oView => item.addContent(oView));
       },
 

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -377,6 +377,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
                oModel.setProperty("/title", title);
                oModel.setProperty("/filename", fname);
                this.syncEditor(tab, "SAVE");
+               this.doReload(true); // while new file appears, one should reload items on server
             },
             onCancel: function() { },
             onFailure: function() { }
@@ -573,8 +574,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          }
 
          if (changed) {
-            console.log('Settings changes - reload MODEL!!!');
-            this.doReload(true);
+            this.doReload();
          }
       },
 
@@ -652,8 +652,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             if (i>0) path.push(oLinks[i].getText());
             if (oLinks[i].getId() === sId ) break;
          }
+         // after CHPATH will be replied, client also start reload
          this.websocket.send('CHPATH:' + JSON.stringify(path));
-         this.doReload(true);
       },
 
       /* =========================================== */
@@ -883,7 +883,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          }
          case "WORKPATH":
             this.updateBReadcrumbs(JSON.parse(msg));
-            this.doReload(true);
+            this.doReload();
             break;
          case "SELECT_TAB":
            let tab = this.findTab(msg);
@@ -947,22 +947,22 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       },
 
       /** @summary Reload (refresh) file tree browser */
-      onRealoadPress: function (oEvent) {
-         this.doReload(true);
+      onRealoadPress: function() {
+         this.doReload(true); // force also update of items on server
       },
 
-      doReload: function(force) {
+      doReload: function(force_reload) {
          if (this.standalone) {
             this.showTextInBrowser();
             this.paintFoundNodes(null);
             this.model.setFullModel(this.fullModel);
          } else {
-            this.model.reloadMainModel(force);
+            this.model.reloadMainModel(true, force_reload);
          }
       },
 
       /** @summary Quit ROOT session */
-      onQuitRootPress: function(oEvent) {
+      onQuitRootPress: function() {
          this.websocket.send("QUIT_ROOT");
       },
 

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -802,31 +802,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
          if (!fullpath) return;
 
-         // do not use row._bHasChildren while it is not documented member of m.Row object
-         if (!prop.isLeaf) {
-            if (!prop.fullpath.endsWith(".root/")) {
-
-               let oBreadcrumbs = this.getView().byId("breadcrumbs");
-               let links = oBreadcrumbs.getLinks();
-               let currentText = oBreadcrumbs.getCurrentLocationText();
-
-               let path = "";
-               if ((currentText == "/") || (links.length < 1)) {
-                  path = prop.fullpath;
-               } else {
-                  path = "/";
-                  for (let i = 1; i < links.length; i++)
-                     path += links[i].getText() + "/";
-                  path += currentText + prop.fullpath;
-               }
-
-               // TODO: use plain array also here to avoid any possible confusion
-               this.websocket.send('CHDIR:' + path);
-               return this.doReload(true);
-            }
-         }
-
-         let className = this.getBaseClass(prop ? prop.className : ""),
+         let className = this.getBaseClass(prop.className),
              drawingOptions = className ? this.drawingOptions[className] : "";
 
          return this.sendDblClick(fullpath, drawingOptions || "");
@@ -907,6 +883,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          }
          case "WORKPATH":
             this.updateBReadcrumbs(JSON.parse(msg));
+            this.doReload(true);
             break;
          case "SELECT_TAB":
            let tab = this.findTab(msg);

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -744,14 +744,11 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
       onFullScreen: function() {
          let splitApp = this.getView().byId("SplitAppBrowser");
-         let btn = this.getView().byId('expandMaster');
          if (uiDevice.orientation.landscape) {
             if(splitApp.getMode() === "ShowHideMode") {
                splitApp.setMode("HideMode");
-               btn.setVisible(false);
             } else {
                splitApp.setMode("ShowHideMode");
-               btn.setVisible(true);
             }
          } else {
             if(splitApp.isMasterShown()) {
@@ -765,7 +762,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       handleChangeOrientation: function(is_landscape) {
          let btn = this.getView().byId('expandMaster');
          btn.setVisible(is_landscape);
-         btn.setIcon("sap-icon://full-screen");
+         btn.setIcon("sap-icon://open-command-field");
          this.getView().byId('masterPage').getParent().removeStyleClass('masterExpanded');
       },
 
@@ -774,7 +771,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          master.toggleStyleClass('masterExpanded');
          let expanded = master.hasStyleClass('masterExpanded');
          const btn = this.getView().byId('expandMaster');
-         btn.setIcon(expanded ? "sap-icon://exit-full-screen" : "sap-icon://full-screen");
+         btn.setIcon(expanded ? "sap-icon://close-command-field" : "sap-icon://open-command-field");
       },
 
       /* ========================================== */

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -613,7 +613,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          else if (txt.indexOf("Geometry") >= 0)
             msg = "NEWWIDGET:geom";
          else if (txt.indexOf("Root 6") >= 0)
-            msg = "NEWTCANVAS";
+            msg = "NEWWIDGET:tcanvas";
          else if (txt.indexOf("Root 7") >= 0)
             msg = "NEWRCANVAS";
 
@@ -1019,6 +1019,8 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             this.createImageViewer(par1, par2);
          } else if (kind == "geom") {
             this.createGeomViewer(par1, par2, par3);
+         } else if (kind == "tcanvas") {
+            this.createCanvas("root6", par1, par2);
          } else
             this.createCanvas(kind, par1, par2);
       },

--- a/ui5/browser/controller/FileDialog.controller.js
+++ b/ui5/browser/controller/FileDialog.controller.js
@@ -46,6 +46,8 @@ sap.ui.define(['rootui5/panel/Controller',
                                       // fileExtList: [{ id: "AllFiles", text: "All files (*.*)" }, { id: "png", text: "png files (*.png)"}, { id: "cxx", text: "CXX files (*.cxx)"}] });
          this.getView().setModel(this.oModel);
 
+         this.own_window = true;
+
          Fragment.load({
             name: "rootui5.browser.view.filedialog",
             controller: this,
@@ -62,7 +64,6 @@ sap.ui.define(['rootui5/panel/Controller',
             }
          });
 
-         this.own_window = true;
       },
 
       /** @summary Set path to the Breadcrumb element */
@@ -164,6 +165,9 @@ sap.ui.define(['rootui5/panel/Controller',
             this.oModel.setProperty("/canEditName", (this.kind == "SaveAs") || (this.kind == "NewFile"));
          }
 
+         if (this.own_window && document)
+             document.title = cfg.title || this.kind + " dialog";
+
          this.updateBReadcrumbs(cfg.path);
 
          this.oModel.setProperty("/fileName", cfg.fname);
@@ -193,7 +197,7 @@ sap.ui.define(['rootui5/panel/Controller',
          this.oModel.setProperty("/filesList", cfg.brepl.nodes);
       },
 
-      /** Close file dialog */
+      /** @summary Close file dialog */
       closeFileDialog: function(fname) {
          // add more logic when FileDialog embed into main window
          if (this.did_close) return;
@@ -228,13 +232,10 @@ sap.ui.define(['rootui5/panel/Controller',
          this.closeFileDialog();
       },
 
-      /** Entry point for all data from server */
+      /** @summary Entry point for all data from server */
       onWebsocketMsg: function(handle, msg) {
-
          if (typeof msg != "string")
             return console.error("Browser do not uses binary messages len = " + mgs.byteLength);
-
-         console.log('GET DLG MGS: ', msg.substr(0,50));
 
          let mhdr = msg.split(":")[0];
          msg = msg.substr(mhdr.length+1);
@@ -289,7 +290,7 @@ sap.ui.define(['rootui5/panel/Controller',
          oWarnDlg.open();
       },
 
-      /** method used to complete dialog */
+      /** @summary method used to complete dialog */
       _completeDialog: function(funcname, arg) {
          if (!this.dialog_args)
             return;
@@ -302,8 +303,8 @@ sap.ui.define(['rootui5/panel/Controller',
          delete this.dialog_args;
       },
 
-      /** @brief Start SaveAs dialog @private */
-
+      /** @summary Start SaveAs dialog
+        * @private */
       _initDialog: async function(kind, args) {
 
          if (!args || typeof args != "object")

--- a/ui5/browser/controller/FileDialog.controller.js
+++ b/ui5/browser/controller/FileDialog.controller.js
@@ -12,7 +12,7 @@ sap.ui.define(['rootui5/panel/Controller',
 
    /** FileDialog controller */
 
-   var FileDialog = GuiPanelController.extend("rootui5.browser.controller.FileDialog", {
+   let FileDialog = GuiPanelController.extend("rootui5.browser.controller.FileDialog", {
 
       //function called from GuiPanelController
       onPanelInit : function() {
@@ -50,7 +50,7 @@ sap.ui.define(['rootui5/panel/Controller',
             name: "rootui5.browser.view.filedialog",
             controller: this,
             id: "FileDialogFragment"
-         }).then(function (oFragment) {
+         }).then(oFragment => {
             this.fragment = oFragment;
             this.getView().addDependent(this.fragment);
             this.getView().byId("dialogPage").addContent(this.fragment);
@@ -60,17 +60,16 @@ sap.ui.define(['rootui5/panel/Controller',
                this.processInitMsg(this._init_msg);
                delete this._init_msg;
             }
-
-         }.bind(this));
+         });
 
          this.own_window = true;
       },
 
-      /** Set path to the Breadcrumb element */
+      /** @summary Set path to the Breadcrumb element */
       updateBReadcrumbs: function(split) {
          this._currentPath = split;
 
-         var oBreadcrumbs = sap.ui.core.Fragment.byId("FileDialogFragment", "breadcrumbs");
+         let oBreadcrumbs = sap.ui.core.Fragment.byId("FileDialogFragment", "breadcrumbs");
          if (!oBreadcrumbs)
             return;
 
@@ -88,13 +87,13 @@ sap.ui.define(['rootui5/panel/Controller',
          }
       },
 
-      /** Returns coded in Breadcrumb path
-       * If selectedId specified, return path up to that element id */
+      /** @summary Returns coded in Breadcrumb path
+       * @desc If selectedId specified, return path up to that element id */
       getBreadcrumbPath: function(selectedId) {
-         var oBreadcrumbs = sap.ui.core.Fragment.byId("FileDialogFragment", "breadcrumbs");
+         let oBreadcrumbs = sap.ui.core.Fragment.byId("FileDialogFragment", "breadcrumbs");
          if (selectedId && oBreadcrumbs) {
-            var oLinks = oBreadcrumbs.getLinks(), path = [];
-            for (var i = 0; i < oLinks.length; i++) {
+            let oLinks = oBreadcrumbs.getLinks(), path = [];
+            for (let i = 0; i < oLinks.length; i++) {
                if (i>0) path.push(oLinks[i].getText());
                if (oLinks[i].getId() === selectedId) return path;
             }
@@ -105,32 +104,43 @@ sap.ui.define(['rootui5/panel/Controller',
 
       // returns full file name as array
       getFullFileName: function() {
-         var path = this.getBreadcrumbPath();
+         let path = this.getBreadcrumbPath();
          path.push(this.oModel.getProperty("/fileName"));
          return path;
       },
 
       /** Handler for Breadcrumbs press event */
       onBreadcrumbsPress: function(oEvent) {
-         var path = this.getBreadcrumbPath(oEvent.getSource().sId);
+         let path = this.getBreadcrumbPath(oEvent.getSource().sId);
          if (this.kind == "OpenFile")
             this.oModel.setProperty("/fileName", "");
          this.websocket.send("CHPATH:" + JSON.stringify(path));
       },
 
-      /** Handler for List item press event */
+      /** @summary Handler for List item press event */
       onItemPress: function(event) {
-         var item = event.getParameters().listItem;
+         let item = event.getParameters().listItem;
          if (!item) return;
 
-         var ctxt = item.getBindingContext(),
+         let tm = new Date().getTime();
+
+         if (this._last_item === item) {
+            let diff = tm - this._last_tm;
+            if ((diff < 300) && (this.kind == "OpenFile"))
+               return this.onOkPress();
+         }
+
+         this._last_item = item;
+         this._last_tm = tm;
+
+         let ctxt = item.getBindingContext(),
              prop = ctxt ? ctxt.getProperty(ctxt.getPath()) : null;
 
          if (prop && (prop.icon == "sap-icon://folder-blank")) {
             if (this.kind == "OpenFile")
                this.oModel.setProperty("/fileName", "");
 
-            var path = this.getBreadcrumbPath();
+            let path = this.getBreadcrumbPath();
             path.push(item.getTitle());
             return this.websocket.send("CHPATH:" + JSON.stringify(path));
          }
@@ -138,14 +148,14 @@ sap.ui.define(['rootui5/panel/Controller',
          this.oModel.setProperty("/fileName", item.getTitle());
       },
 
-      /** When selected file extenstion changed */
+      /** @summary When selected file extenstion changed */
       onFileExtChanged: function() {
-         var extName = this.oModel.getProperty("/fileExt");
+         let extName = this.oModel.getProperty("/fileExt");
          this.websocket.send("CHEXT:" + extName);
       },
 
       processInitMsg: function(msg) {
-         var cfg = JSON.parse(msg);
+         let cfg = JSON.parse(msg);
 
          if (!this.dialog) {
             // when not an embedded dialog, update configuration from server
@@ -159,10 +169,10 @@ sap.ui.define(['rootui5/panel/Controller',
          this.oModel.setProperty("/fileName", cfg.fname);
 
          if (cfg.filters && cfg.filters.length) {
-            var arr = [];
-            for (var k=0;k<cfg.filters.length;++k) {
-               var fname = cfg.filters[k];
-               var p = fname.indexOf("(");
+            let arr = [];
+            for (let k = 0; k < cfg.filters.length; ++k) {
+               let fname = cfg.filters[k];
+               let p = fname.indexOf("(");
                if (p>0) fname = fname.substr(0,p);
                arr.push({id: fname.trim(), text: cfg.filters[k]});
             }
@@ -178,7 +188,7 @@ sap.ui.define(['rootui5/panel/Controller',
       },
 
       processChangePathMsg: function(msg) {
-         var cfg = JSON.parse(msg);
+         let cfg = JSON.parse(msg);
          this.updateBReadcrumbs(cfg.path);
          this.oModel.setProperty("/filesList", cfg.brepl.nodes);
       },
@@ -226,7 +236,7 @@ sap.ui.define(['rootui5/panel/Controller',
 
          console.log('GET DLG MGS: ', msg.substr(0,50));
 
-         var mhdr = msg.split(":")[0];
+         let mhdr = msg.split(":")[0];
          msg = msg.substr(mhdr.length+1);
 
          switch (mhdr) {
@@ -256,28 +266,24 @@ sap.ui.define(['rootui5/panel/Controller',
 
       /** Shown when warning message about overwritten file should appear */
       showWarningDialog: function() {
-         var oWarnDlg = new Dialog({
+         let oWarnDlg = new Dialog({
             title: "Warning",
             type: "Message",
             state: "Warning",
             content: new Text({ text: "File already exists. Overwrite? "}),
             beginButton: new Button({
                text: 'Cancel',
-               press: function() {
-                  oWarnDlg.close();
-               }
+               press: ()  => oWarnDlg.close()
             }),
             endButton: new Button({
                text: 'Ok',
                type: ButtonType.Emphasized,
-               press: function() {
+               press: () => {
                   oWarnDlg.close();
                   this.websocket.send("DLG_CONFIRM_SELECT");
-               }.bind(this)
+               }
             }),
-            afterClose: function() {
-               oWarnDlg.destroy();
-            }
+            afterClose: () => oWarnDlg.destroy()
          });
 
          oWarnDlg.open();
@@ -307,8 +313,8 @@ sap.ui.define(['rootui5/panel/Controller',
          if (!args.websocket)
             return this._completeDialog("onFailure");
 
-         var fname = args.filename || "";
-         var p = Math.max(fname.lastIndexOf("/"), fname.lastIndexOf("\\"));
+         let fname = args.filename || "";
+         let p = Math.max(fname.lastIndexOf("/"), fname.lastIndexOf("\\"));
          if (p>0) fname = fname.substr(p+1);
 
          this.kind = kind;
@@ -326,13 +332,11 @@ sap.ui.define(['rootui5/panel/Controller',
          // assign ourself as receiver of all
          this.websocket.setReceiver(this);
 
-         await Fragment.load({
+         this.fragment = await Fragment.load({
             name: "rootui5.browser.view.filedialog",
             controller: this,
             id: "FileDialogFragment"
-         }).then(function (oFragment) {
-            this.fragment = oFragment;
-         }.bind(this));
+         });
 
          this.fragment.setModel(this.oModel);
 
@@ -345,12 +349,12 @@ sap.ui.define(['rootui5/panel/Controller',
             content: this.fragment,
             beginButton: new Button({
                text: 'Cancel',
-               press: this.onCancelPress.bind(this)
+               press: () => this.onCancelPress()
             }),
             endButton: new Button({
                text: 'Ok',
                enabled: "{= ${/fileName} !== '' }",
-               press: this.onOkPress.bind(this)
+               press: () => this.onOkPress()
             })
          });
 
@@ -366,7 +370,7 @@ sap.ui.define(['rootui5/panel/Controller',
             delete this._init_msg;
          }
 
-         var server_args = [ this.kind, args.filename || "", this.websocket.getChannelId().toString() ];
+         let server_args = [ this.kind, args.filename || "", this.websocket.getChannelId().toString() ];
 
          // add at the end filter and filter array
          if (args.filter || args.filters) {
@@ -379,9 +383,10 @@ sap.ui.define(['rootui5/panel/Controller',
          return this;
       },
 
-      /** Press Ok button id Dialog, send selected file name and wait if confirmation required */
+      /** @summary Press Ok button id Dialog,
+        * @desc send selected file name and wait if confirmation required */
       onOkPress: function() {
-         var fullname = this.getFullFileName();
+         let fullname = this.getFullFileName();
 
          if (this.websocket)
             this.websocket.send("DLGSELECT:" + JSON.stringify(fullname));
@@ -416,22 +421,22 @@ sap.ui.define(['rootui5/panel/Controller',
     * args.onFailure - handler when any failure appears, dialog will be closed afterwards
     */
    FileDialog.SaveAs = function(args) {
-      var controller = new FileDialog();
+      let controller = new FileDialog();
 
       return controller._initDialog("SaveAs", args);
-   };
+   }
 
    FileDialog.NewFile = function(args) {
-      var controller = new FileDialog();
+      let controller = new FileDialog();
 
       return controller._initDialog("NewFile", args);
-   };
+   }
 
    FileDialog.OpenFile = function(args) {
-      var controller = new FileDialog();
+      let controller = new FileDialog();
 
       return controller._initDialog("OpenFile", args);
-   };
+   }
 
 
    return FileDialog;

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -9,33 +9,12 @@
   <Page showSubHeader="false" showHeader="false" showFooter="false">
     <content>
       <tnt:ToolHeader asyncMode="true" height="40px" >
-        <Button id="burgerMenu" icon="sap-icon://menu2" type="Transparent" tooltip="Hide/show browser" press="onFullScreen">
-          <layoutData>
-            <OverflowToolbarLayoutData priority="NeverOverflow" />
-          </layoutData>
-        </Button>
-        <Button id="expandMaster" icon="sap-icon://full-screen" type="Transparent" tooltip="Expand/shrink browser" press="onExpandMaster">
-          <layoutData>
-            <OverflowToolbarLayoutData priority="NeverOverflow" />
-          </layoutData>
-        </Button>
-        <Image height="35px" src="rootui5sys/browser/logo.png" />
+        <Button id="burgerMenu" icon="sap-icon://menu2" type="Transparent" tooltip="Hide/show browser" press="onFullScreen"/>
+        <Image height="35px" src="rootui5sys/browser/logo.png"/>
         <Text text="ROOT 7" wrapping="false" />
-        <ToolbarSpacer>
-          <layoutData>
-            <OverflowToolbarLayoutData priority="NeverOverflow" minWidth="16px" />
-          </layoutData>
-        </ToolbarSpacer>
-        <Button icon="sap-icon://settings" type="Transparent" tooltip="Settings" press="onSettingPress">
-          <layoutData>
-            <OverflowToolbarLayoutData priority="NeverOverflow" />
-          </layoutData>
-        </Button>
-        <Button icon="sap-icon://log" type="Transparent" tooltip="Logoff" press="onQuitRootPress">
-          <layoutData>
-            <OverflowToolbarLayoutData priority="NeverOverflow" />
-          </layoutData>
-        </Button>
+        <ToolbarSpacer/>
+        <Button icon="sap-icon://settings" type="Transparent" tooltip="Settings" press="onSettingPress"/>
+        <Button icon="sap-icon://log" type="Transparent" tooltip="Logoff" press="onQuitRootPress"/>
       </tnt:ToolHeader>
 
       <ScrollContainer height="calc(100% - 40px)">
@@ -46,7 +25,8 @@
               <customHeader>
                 <Toolbar width="100%">
                   <SearchField placeholder="Filter" liveChange="onSearch" />
-                  <Button icon="sap-icon://synchronize" press="onRealoadPress" tooltip="Refresh"/>
+                  <Button icon="sap-icon://synchronize" press="onRealoadPress" tooltip="Refresh browser content"/>
+                  <Button id="expandMaster" icon="sap-icon://open-command-field" tooltip="Expand/shrink" press="onExpandMaster"/>
                 </Toolbar>
               </customHeader>
               <content>

--- a/ui5/browser/view/tabsmenu.fragment.xml
+++ b/ui5/browser/view/tabsmenu.fragment.xml
@@ -1,8 +1,9 @@
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core">
   <ActionSheet title="Tabs selection" showCancelButton="true" placement="Left">
-    <Button text="Code editor"   id="NewTabCE" icon="sap-icon://write-new-document"     press="handleNewTab"  />
-    <Button text="Root 6 canvas" id="NewTabR6" icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
-    <Button text="Root 7 canvas" id="NewTabR7" icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
-    <Button text="Image viewer"  id="NewTabIV" icon="sap-icon://background"             press="handleNewTab" />
+    <Button text="Root 6 canvas"   icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
+    <Button text="Root 7 canvas"   icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
+    <Button text="Geometry viewer" icon="sap-icon://overview-chart"         press="handleNewTab" />
+    <Button text="Code editor"     icon="sap-icon://write-new-document"     press="handleNewTab"  />
+    <Button text="Image viewer"    icon="sap-icon://background"             press="handleNewTab" />
   </ActionSheet>
 </core:FragmentDefinition>

--- a/ui5/canv/controller/CanvasPanel.controller.js
+++ b/ui5/canv/controller/CanvasPanel.controller.js
@@ -89,7 +89,7 @@ sap.ui.define([
             }
 
             if (this.canvas_painter && this.canvas_painter._window_handle) {
-               this.canvas_painter.useWebsocket(this.canvas_painter._window_handle, this.canvas_painter._window_handle_href);
+               this.canvas_painter.useWebsocket(this.canvas_painter._window_handle);
                delete this.canvas_painter._window_handle;
             }
          }

--- a/ui5/eve7/controller/GeomViewer.controller.js
+++ b/ui5/eve7/controller/GeomViewer.controller.js
@@ -77,6 +77,7 @@ sap.ui.define(['sap/ui/core/Component',
          let viewData = this.getView().getViewData();
 
          this.websocket = viewData.conn_handle;
+         this._embeded = viewData.embeded;
 
          // this is code for the Components.js
          // this.websocket = Component.getOwnerComponentFor(this.getView()).getComponentData().conn_handle;
@@ -305,7 +306,7 @@ sap.ui.define(['sap/ui/core/Component',
          if (this.geo_painter) {
             this.geo_painter.clearDrawings();
          } else {
-            var geomDrawing = this.byId("geomDrawing");
+            let geomDrawing = this.byId("geomDrawing");
             this.geo_painter = JSROOT.Painter.createGeoPainter(geomDrawing.getDomRef(), null, drawopt);
             this.geo_painter.setMouseTmout(0);
             // this.geo_painter.setDepthMethod("dflt");
@@ -442,6 +443,7 @@ sap.ui.define(['sap/ui/core/Component',
        * if not all scripts are loaded, messages are quied and processed later */
 
       checkDrawMsg: function(kind, msg) {
+         console.log('Get message kind ', kind);
          if (kind) {
             if (!msg)
                return console.error("No message is provided for " + kind);
@@ -451,6 +453,7 @@ sap.ui.define(['sap/ui/core/Component',
             this.queue.push(msg);
          }
 
+
          if (!this.creator ||            // complete JSROOT/EVE7 TGeo functionality is loaded
             !this.queue.length ||        // drawing messages are created
             !this.renderingDone) return; // UI5 rendering is performed
@@ -458,6 +461,8 @@ sap.ui.define(['sap/ui/core/Component',
          // only from here we can start to analyze messages and create TGeo painter, clones objects and so on
 
          msg = this.queue.shift();
+
+         console.log('Process message kind ', msg.kind);
 
          switch (msg.kind) {
             case "draw":
@@ -477,6 +482,8 @@ sap.ui.define(['sap/ui/core/Component',
                   this.geo_painter.ctrl.show_config = true;
                   this.geom_model.refresh();
                }
+
+               console.log('start drawing');
 
                this.geo_painter.prepareObjectDraw(msg.visibles, "__geom_viewer_selection__");
 
@@ -517,7 +524,7 @@ sap.ui.define(['sap/ui/core/Component',
          // when connection closed, close panel as well
          console.log('CLOSE WINDOW WHEN CONNECTION CLOSED');
 
-         if (window) window.close();
+         if (window && !this._embeded) window.close();
 
          this.isConnected = false;
       },

--- a/ui5/eve7/controller/GeomViewer.controller.js
+++ b/ui5/eve7/controller/GeomViewer.controller.js
@@ -74,13 +74,15 @@ sap.ui.define(['sap/ui/core/Component',
    return Controller.extend("rootui5.geom.controller.GeomViewer", {
       onInit: function () {
 
-         this.websocket = this.getView().getViewData().conn_handle;
+         let viewData = this.getView().getViewData();
+
+         this.websocket = viewData.conn_handle;
 
          // this is code for the Components.js
          // this.websocket = Component.getOwnerComponentFor(this.getView()).getComponentData().conn_handle;
 
          this.websocket.setReceiver(this);
-         this.websocket.connect();
+         this.websocket.connect(viewData.conn_href);
 
          this.queue = []; // received draw messages
 

--- a/ui5/eve7/controller/GeomViewer.controller.js
+++ b/ui5/eve7/controller/GeomViewer.controller.js
@@ -1026,7 +1026,6 @@ sap.ui.define(['sap/ui/core/Component',
 
             if (this.model) {
                this.model.clearFullModel();
-               console.log('Calling reload model');
                this.model.reloadMainModel(force);
             }
          }

--- a/ui5/eve7/geom.html
+++ b/ui5/eve7/geom.html
@@ -55,7 +55,6 @@
         }).then(handle => {
             sap.ui.require(["sap/ui/core/mvc/XMLView"], XMLView => {
                 XMLView.create({
-                   id: "TopEveId",
                    viewName: "rootui5.eve7.view.GeomViewer",
                    viewData: { conn_handle: handle }
                 }).then(oView => oView.placeAt("GeomDiv"));


### PR DESCRIPTION
1. Support web-based geometry viewer. When clicking TGeoManager from the file, new tab with geometry viewer will be shown
2. Make RBrowserWidget class - entity to handle different views in modular way
   - RCanvas
   - TCanvas
   - Geometry viewer
   - Code editor
   - Image viewer
3. Functionality of each RBrowserWidget loaded only when required. When RBrowser started neither TCanvas nor RCanvas is loaded. Only when any object is clicked, small internal plugin is loaded and canvas is instantiated. Same with geometry viewer.
4. Small JSROOT optimization for generic embeding of web widgets
5. Always handle mouse double-click on server side. Only `RBrowsable` class can provide necessary information that is the best way to handle double-click. It either display object in current editor/viewer/canvas or will start new widget. 