### PR TITLE
Add patches for gcc 9 and 10

### DIFF
--- a/cint/cint/lib/prec_stl/deque
+++ b/cint/cint/lib/prec_stl/deque
@@ -99,8 +99,10 @@ class deque {
 #else
     bool operator!=(const iterator& x) ;
 #endif
+#if (!defined(G__GNUC) || (defined(G__GNUC) && G__GNUC_VER>=3004 && G__GNUC_VER<10000))
     iterator operator+(long n);
     iterator operator-(long n);
+#endif
     iterator& operator+=(long n);
     iterator& operator-=(long n);
     T& operator[](long n) ;
@@ -148,8 +150,10 @@ class deque {
     reverse_iterator operator++(int a);
     reverse_iterator& operator--();
     reverse_iterator operator--(int a);
+#if (!defined(G__GNUC) || (defined(G__GNUC) && G__GNUC_VER>=3004 && G__GNUC_VER<10000))
     reverse_iterator operator+(long n);
     reverse_iterator operator-(long n);
+#endif
     reverse_iterator& operator+=(long n);
     reverse_iterator& operator-=(long n);
     T& operator[](long n) ;

--- a/cint/cint/lib/prec_stl/list
+++ b/cint/cint/lib/prec_stl/list
@@ -96,10 +96,10 @@ class list {
     iterator operator++(int a);
     iterator& operator--();
     iterator operator--(int a);
-#ifndef G__APPLE_LIBCXX
+#if !defined(G__APPLE_LIBCXX) && (!defined(G__GNUC) || (G__GNUC_VER>=3004 && G__GNUC_VER<9000))
     bool operator==(const iterator& x) ;
 #endif
-#if !defined(G__HPUX) && !defined(G__APPLE_LIBCXX)
+#if !defined(G__HPUX) && !defined(G__APPLE_LIBCXX) && (!defined(G__GNUC) || (G__GNUC_VER>=3004 && G__GNUC_VER<9000))
     bool operator!=(const iterator& x) ;
 #endif
 #if defined(G__VISUAL) && (G__MSC_VER>=1600)
@@ -107,7 +107,7 @@ class list {
 	void* _Ptr;
 #endif
   };
-#ifdef G__APPLE_LIBCXX
+#if defined(G__APPLE_LIBCXX) || (defined(G__GNUC) && !(G__GNUC_VER>=3004 && G__GNUC_VER<9000))
    friend bool operator==(const list::iterator& x,const list::iterator& y)const;
    friend bool operator!=(const list::iterator& x,const list::iterator& y)const;
 #endif

--- a/cint/cint/lib/prec_stl/map
+++ b/cint/cint/lib/prec_stl/map
@@ -115,7 +115,7 @@ class map {
     iterator operator++(int a);
     iterator& operator--();
     iterator operator--(int a);
-#if defined (G__VISUAL) || (defined(G__GNUC_VER) && G__GNUC_VER>=3004) || defined(G__INTEL_COMPILER)
+#if defined (G__VISUAL) || (defined(G__GNUC_VER) && G__GNUC_VER>=3004 && G__GNUC_VER<9000) || defined(G__INTEL_COMPILER)
 #if !defined(G__APPLE_LIBCXX)
     bool operator==(const iterator& x) ;
     bool operator!=(const iterator& x) ;
@@ -125,7 +125,7 @@ class map {
     bool operator==(const iterator& x) ;
 #endif
   };
-#if (defined(G__GNUC) && !defined(G__KCC) && !defined(G__INTEL_COMPILER)  && !(G__GNUC_VER>=3004)) || defined(G__APPLE_LIBCXX)
+#if (defined(G__GNUC) && !defined(G__KCC) && !defined(G__INTEL_COMPILER)  && !(G__GNUC_VER>=3004 && G__GNUC_VER<9000)) || defined(G__APPLE_LIBCXX)
   friend bool operator==(const map::iterator& x ,const map::iterator& y) const;
   friend bool operator!=(const map::iterator& x ,const map::iterator& y) const;
 #endif

--- a/cint/cint/lib/prec_stl/multimap
+++ b/cint/cint/lib/prec_stl/multimap
@@ -112,7 +112,7 @@ class multimap {
     iterator operator++(int a);
     iterator& operator--();
     iterator operator--(int a);
-#if defined (G__VISUAL) || (defined(G__GNUC) && G__GNUC_VER>=3004)
+#if defined (G__VISUAL) || (defined(G__GNUC) && G__GNUC_VER>=3004 && G__GNUC_VER<9000)
 #if !defined(G__APPLE_LIBCXX)
     bool operator==(const iterator& x) ;
     bool operator!=(const iterator& x) ;
@@ -122,7 +122,7 @@ class multimap {
     bool operator==(const iterator& x) ;
 #endif
   };
-#if (defined(G__GNUC) && !defined (G__KCC) && !defined(G__INTEL_COMPILER) && !(G__GNUC_VER>=3004)) || defined(G__APPLE_LIBCXX)
+#if (defined(G__GNUC) && !defined (G__KCC) && !defined(G__INTEL_COMPILER) && !(G__GNUC_VER>=3004 && G__GNUC_VER<9000)) || defined(G__APPLE_LIBCXX)
   friend bool operator==(const multimap::iterator& x ,const multimap::iterator& y) const;
   friend bool operator!=(const multimap::iterator& x ,const multimap::iterator& y) const;
 #endif

--- a/cint/cint/lib/prec_stl/multiset
+++ b/cint/cint/lib/prec_stl/multiset
@@ -105,7 +105,7 @@ class multiset {
     iterator operator++(int a);
     iterator& operator--();
     iterator operator--(int a);
-#if defined (G__VISUAL) || (defined(G__GNUC) && G__GNUC_VER>=3004)
+#if defined (G__VISUAL) || (defined(G__GNUC) && G__GNUC_VER>=3004 && G__GNUC_VER<9000)
 #if !defined(G__APPLE_LIBCXX)
     bool operator==(const iterator& x) ;
     bool operator!=(const iterator& x) ;
@@ -115,7 +115,7 @@ class multiset {
     bool operator==(const iterator& x) ;
 #endif
   };
-#if ((defined(G__GNUC) && !defined (G__KCC) && !defined(G__INTEL_COMPILER)) && !(G__GNUC_VER>=3004)) || defined(G__APPLE_LIBCXX)
+#if ((defined(G__GNUC) && !defined (G__KCC) && !defined(G__INTEL_COMPILER)) && !(G__GNUC_VER>=3004 && G__GNUC_VER<9000)) || defined(G__APPLE_LIBCXX)
   friend bool operator==(const multiset::iterator& x ,const multiset::iterator& y) const;
   friend bool operator!=(const multiset::iterator& x ,const multiset::iterator& y) const;
 #endif

--- a/cint/cint/lib/prec_stl/set
+++ b/cint/cint/lib/prec_stl/set
@@ -105,7 +105,7 @@ class set {
     iterator operator++(int a);
     iterator& operator--();
     iterator operator--(int a);
-#if defined (G__VISUAL) || (defined(G__GNUC) && G__GNUC_VER>=3004)
+#if defined (G__VISUAL) || (defined(G__GNUC) && G__GNUC_VER>=3004 && G__GNUC_VER<9000)
 #if !defined(G__APPLE_LIBCXX)
     bool operator==(const iterator& x) ;
     bool operator!=(const iterator& x) ;
@@ -115,7 +115,7 @@ class set {
     bool operator==(const iterator& x) ;
 #endif
   };
-#if (defined(G__GNUC) && !defined(G__KCC) && !defined(G__INTEL_COMPILER) && !(G__GNUC_VER>=3004)) || defined(G__APPLE_LIBCXX)
+#if (defined(G__GNUC) && !defined(G__KCC) && !defined(G__INTEL_COMPILER) && !(G__GNUC_VER>=3004 && G__GNUC_VER<9000)) || defined(G__APPLE_LIBCXX)
   friend bool operator==(const set::iterator& x ,const set::iterator& y) const;
   friend bool operator!=(const set::iterator& x ,const set::iterator& y) const;
 #endif


### PR DESCRIPTION
This includes to patches reported at the root forum for compilation of root 5 using gcc 9 and 10.

* gcc 9 patchset: https://root-forum.cern.ch/t/root-5-compilation-with-gcc-9/33981
* gcc 10 patchset: https://root-forum.cern.ch/t/root-5-compilation-with-gcc-10-2/43258/3

I know root 5 is now longer maintained, but if any of the admins could shortly have a glance and think about including these, I would be very thankful.