### PR TITLE
Fixes and improvements for the TKDE class

### DIFF
--- a/hist/hist/inc/TKDE.h
+++ b/hist/hist/inc/TKDE.h
@@ -65,8 +65,8 @@ public:
       kForcedBinning
    };
 
-   
-   TKDE();                    // defaul constructor used only by I/O 
+
+   TKDE();                    // defaul constructor used only by I/O
 
    TKDE(UInt_t events, const Double_t* data, Double_t xMin = 0.0, Double_t xMax = 0.0, const Option_t* option =
                  "KernelType:Gaussian;Iteration:Adaptive;Mirror:noMirror;Binning:RelaxedBinning", Double_t rho = 1.0) {
@@ -154,7 +154,7 @@ private:
    TF1* fApproximateBias; //! Output Kernel Density Estimation approximate bias
    TGraphErrors* fGraph;  //! Graph with the errors
 
-   EKernelType fKernelType;    
+   EKernelType fKernelType;
    EIteration fIteration;
    EMirror fMirror;
    EBinning fBinning;
@@ -190,7 +190,7 @@ private:
    struct KernelIntegrand;
    friend struct KernelIntegrand;
 
-   void Instantiate(KernelFunction_Ptr kernfunc, UInt_t events, const Double_t* data, const Double_t* weight, 
+   void Instantiate(KernelFunction_Ptr kernfunc, UInt_t events, const Double_t* data, const Double_t* weight,
                     Double_t xMin, Double_t xMax, const Option_t* option, Double_t rho);
 
    inline Double_t GaussianKernel(Double_t x) const {

--- a/hist/hist/inc/TKDE.h
+++ b/hist/hist/inc/TKDE.h
@@ -34,6 +34,9 @@ Physics. Computer Physics Communications 136:198-207,2001" - e-Print Archive: he
 class TKDE : public TNamed  {
 public:
 
+   /// Types of Kernel functions
+   /// They can be set using the function SetKernelType()
+   // or as a string in the constructor
    enum EKernelType { // Kernel function type option
       kGaussian,
       kEpanechnikov,
@@ -43,12 +46,15 @@ public:
       kTotalKernels // Internal use only for member initialization
    };
 
-   enum EIteration { // KDE fitting option
+   /// Iteration types. They can be set using SetIteration()
+   enum EIteration {
       kAdaptive,
       kFixed
    };
 
-   enum EMirror { // Data "mirroring" option to address the probability "spill out" boundary effect
+   /// Data "mirroring" option to address the probability "spill out" boundary effect
+   /// They can be set using SetMirror()
+   enum EMirror {
       kNoMirror,
       kMirrorLeft,
       kMirrorRight,
@@ -60,29 +66,43 @@ public:
       kMirrorAsymBoth
    };
 
-   enum EBinning{ // Data binning option
+   /// Data binning option.
+   /// They can be set using SetBinning()
+   enum EBinning{
       kUnbinned,
       kRelaxedBinning, // The algorithm is allowed to use binning if the data is large enough
       kForcedBinning
    };
 
+   ///  default constructor used only by I/O
+   TKDE();
 
-   TKDE();                    // defaul constructor used only by I/O
-
+   /// Constructor for unweighted data
+   /// Varius option for TKDE can be passed in the option string as below.
+   /// Note that min and max will define the plotting range but will not restrict the data in the unbinned case
+   /// Instead when use binning, only the data in the range will be considered.
+   /// Note also, that when some data exists outside the range, one should not use the mirror option with unbinned.
+   /// Adaptive will be soon very slow especially for Nevents > 10000.
+   /// For this reason, by default for Nevents >=10000, the data are automatically binned  in
+   /// nbins=Min(10000,Nevents/10)
+   /// In case of ForceBinning option the default number of bins is 1000
    TKDE(UInt_t events, const Double_t* data, Double_t xMin = 0.0, Double_t xMax = 0.0, const Option_t* option =
                  "KernelType:Gaussian;Iteration:Adaptive;Mirror:noMirror;Binning:RelaxedBinning", Double_t rho = 1.0) {
       Instantiate( nullptr,  events, data, nullptr, xMin, xMax, option, rho);
    }
 
+   /// Constructor for weighted data
    TKDE(UInt_t events, const Double_t* data, const Double_t* dataWeight, Double_t xMin = 0.0, Double_t xMax = 0.0, const Option_t* option =
         "KernelType:Gaussian;Iteration:Adaptive;Mirror:noMirror;Binning:RelaxedBinning", Double_t rho = 1.0) {
       Instantiate( nullptr,  events, data, dataWeight, xMin, xMax, option, rho);
    }
 
+   /// Constructor for unwweighted data and a user defined kernel function
    template<class KernelFunction>
    TKDE(const Char_t* /*name*/, const KernelFunction& kernfunc, UInt_t events, const Double_t* data, Double_t xMin = 0.0, Double_t xMax = 0.0, const Option_t* option = "KernelType:UserDefined;Iteration:Adaptive;Mirror:noMirror;Binning:RelaxedBinning", Double_t rho = 1.0)  {
       Instantiate(new ROOT::Math::WrappedFunction<const KernelFunction&>(kernfunc), events, data, nullptr, xMin, xMax, option, rho);
    }
+   /// Constructor for weighted data and a user defined kernel function
    template<class KernelFunction>
    TKDE(const Char_t* /*name*/, const KernelFunction& kernfunc, UInt_t events, const Double_t* data, const Double_t * dataWeight, Double_t xMin = 0.0, Double_t xMax = 0.0, const Option_t* option = "KernelType:UserDefined;Iteration:Adaptive;Mirror:noMirror;Binning:RelaxedBinning", Double_t rho = 1.0)  {
       Instantiate(new ROOT::Math::WrappedFunction<const KernelFunction&>(kernfunc), events, data, dataWeight, xMin, xMax, option, rho);

--- a/hist/hist/inc/TKDE.h
+++ b/hist/hist/inc/TKDE.h
@@ -54,7 +54,7 @@ public:
       kMirrorRight,
       kMirrorBoth,
       kMirrorAsymLeft,
-      kMirrorAsymLeftRight,
+      kMirrorRightAsymLeft,
       kMirrorAsymRight,
       kMirrorLeftAsymRight,
       kMirrorAsymBoth

--- a/hist/hist/inc/TKDE.h
+++ b/hist/hist/inc/TKDE.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 class TGraphErrors;
 class TF1;
@@ -131,18 +132,33 @@ public:
    const Double_t * GetAdaptiveWeights() const;
 
 
+public:
+
+   class TKernel {
+      TKDE *fKDE;
+      UInt_t fNWeights;               // Number of kernel weights (bandwidth as vectorized for binning)
+      std::vector<Double_t> fWeights; // Kernel weights (bandwidth)
+   public:
+      TKernel(Double_t weight, TKDE *kde);
+      void ComputeAdaptiveWeights();
+      Double_t operator()(Double_t x) const;
+      Double_t GetWeight(Double_t x) const;
+      Double_t GetFixedWeight() const;
+      const std::vector<Double_t> &GetAdaptiveWeights() const;
+   };
+
+   friend class TKernel;
+
 private:
 
    TKDE(TKDE& kde);           // Disallowed copy constructor
    TKDE operator=(TKDE& kde); // Disallowed assign operator
 
+   // Kernel funciton pointer. It is managed by class for internal kernels or exernally for user defined kernels
    typedef ROOT::Math::IBaseFunctionOneDim* KernelFunction_Ptr;
-   KernelFunction_Ptr fKernelFunction;  //! pointer to kernel function
+   KernelFunction_Ptr fKernelFunction;  ///<! pointer to kernel function
 
-   class TKernel;
-   friend class TKernel;
-
-   TKernel* fKernel;             //! internal kernel class. Transient because it is recreated after reading from a file
+   std::unique_ptr<TKernel> fKernel;             ///<! internal kernel class. Transient because it is recreated after reading from a file
 
    std::vector<Double_t> fData;   // Data events
    std::vector<Double_t> fEvents; // Original data storage
@@ -253,7 +269,7 @@ private:
    TF1* GetPDFUpperConfidenceInterval(Double_t confidenceLevel = 0.95, UInt_t npx = 100, Double_t xMin = 1.0, Double_t xMax = 0.0);
    TF1* GetPDFLowerConfidenceInterval(Double_t confidenceLevel = 0.95, UInt_t npx = 100, Double_t xMin = 1.0, Double_t xMax = 0.0);
 
-   ClassDef(TKDE, 2) // One dimensional semi-parametric Kernel Density Estimation
+   ClassDef(TKDE, 3) // One dimensional semi-parametric Kernel Density Estimation
 
 };
 

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1565,6 +1565,11 @@ TF1 *TF1::GetCurrent()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return a pointer to the histogram used to visualise the function
+/// Note that this histogram is managed by the function and
+/// in same case it is automatically deleted when some TF1 functions are called
+///  such as TF1::SetParameters, TF1::SetNpx, TF1::SetRange
+/// It is then reccomended either to clone the return object or calling again teh GetHistogram
+/// function whenever is needed
 
 TH1 *TF1::GetHistogram() const
 {

--- a/hist/hist/src/TKDE.cxx
+++ b/hist/hist/src/TKDE.cxx
@@ -236,7 +236,7 @@ void TKDE::GetOptions(std::string optionType, std::string option) {
       } else if (option.compare("mirrorasymleft") == 0) {
          fMirror = kMirrorAsymLeft;
       } else if (option.compare("mirrorrightasymleft") == 0) {
-         fMirror = kMirrorAsymLeftRight;
+         fMirror = kMirrorRightAsymLeft;
       } else if (option.compare("mirrorasymright") == 0) {
          fMirror = kMirrorAsymRight;
       } else if (option.compare("mirrorleftasymright") == 0) {
@@ -431,8 +431,8 @@ void TKDE::SetUseBins() {
 void TKDE::SetMirror() {
    // Sets the mirroring
    fMirrorLeft   = fMirror == kMirrorLeft      || fMirror == kMirrorBoth          || fMirror == kMirrorLeftAsymRight;
-   fMirrorRight  = fMirror == kMirrorRight     || fMirror == kMirrorBoth          || fMirror == kMirrorAsymLeftRight;
-   fAsymLeft     = fMirror == kMirrorAsymLeft  || fMirror == kMirrorAsymLeftRight || fMirror == kMirrorAsymBoth;
+   fMirrorRight  = fMirror == kMirrorRight     || fMirror == kMirrorBoth          || fMirror == kMirrorRightAsymLeft;
+   fAsymLeft     = fMirror == kMirrorAsymLeft  || fMirror == kMirrorRightAsymLeft || fMirror == kMirrorAsymBoth;
    fAsymRight    = fMirror == kMirrorAsymRight || fMirror == kMirrorLeftAsymRight || fMirror == kMirrorAsymBoth;
    fUseMirroring = fMirrorLeft                 || fMirrorRight ;
 }

--- a/hist/hist/src/TKDE.cxx
+++ b/hist/hist/src/TKDE.cxx
@@ -19,8 +19,8 @@
  3. "Hardle W, Muller M, Sperlich S, Werwatz A, Nonparametric and Semiparametric Models. Springer."
  4. "Cranmer KS, Kernel Estimation in High-Energy
  Physics. Computer Physics Communications 136:198-207,2001" - e-Print Archive: hep ex/0011057.
- 
- The algorithm is briefly described in (4). A binned version is also implemented to address the 
+
+ The algorithm is briefly described in (4). A binned version is also implemented to address the
  performance issue due to its data size dependance.
  */
 
@@ -110,7 +110,7 @@ void TKDE::Instantiate(KernelFunction_Ptr kernfunc, UInt_t events, const Double_
    fGraph = 0;
    fNewData = false;
    fUseMirroring = false; fMirrorLeft = false; fMirrorRight = false;
-   fAsymLeft = false; fAsymRight = false; 
+   fAsymLeft = false; fAsymRight = false;
    fNBins = events < 10000 ? 100 : events / 10;
    fNEvents = events;
    fUseBinsNEvents = 10000;
@@ -361,9 +361,9 @@ void TKDE::SetNBins(UInt_t nbins) {
 
    SetUseBins();
    if (!fUseBins) {
-      if (fBinning == kUnbinned) 
+      if (fBinning == kUnbinned)
          Warning("SetNBins", "Bin type using SetBinning must be set for using a binned evaluation");
-      else 
+      else
          Warning("SetNBins", "Bin type using SetBinning or with SetUseBinsNEvents must be set for using a binned evaluation");
    }
 }
@@ -416,8 +416,9 @@ void TKDE::SetUseBins() {
          fUseBins = kFALSE;
    }
 
-   // set the binning
-   if (fUseBins &&  !fEvents.empty() ) {
+   // set the binning (if KDE already initialized)
+   if (fUseBins &&  fKernel && !fEvents.empty() ) {
+      fWeightSize = fNBins / (fXMax - fXMin);
       SetBinCentreData(fXMin, fXMax);
       SetBinCountData();
       SetKernel();
@@ -441,7 +442,7 @@ void TKDE::SetData(const Double_t* data, const Double_t* wgts) {
    }
    fEvents.assign(data, data + fNEvents);
    if (wgts) fEventWeights.assign(wgts, wgts + fNEvents);
-   
+
    if (fUseMinMaxFromData) {
       fXMin = *std::min_element(fEvents.begin(), fEvents.end());
       fXMax = *std::max_element(fEvents.begin(), fEvents.end());
@@ -461,7 +462,7 @@ void TKDE::SetData(const Double_t* data, const Double_t* wgts) {
    SetBinCountData();
 
 
-   ComputeDataStats(); 
+   ComputeDataStats();
    if (fUseMirroring) {
       SetMirroredEvents();
    }
@@ -485,7 +486,7 @@ void TKDE::ReInit() {
       Error("ReInit","TKDE does not contain any data !");
       return;
    }
-       
+
    SetKernelFunction(0);
 
    SetKernel();
@@ -506,7 +507,7 @@ void TKDE::InitFromNewData() {
       fXMin = *std::min_element(fEvents.begin(), fEvents.end());
       fXMax = *std::max_element(fEvents.begin(), fEvents.end());
    }
-   ComputeDataStats(); 
+   ComputeDataStats();
    //    if (fUseBins) {
    // } // bin usage is not supported in this case
    //
@@ -518,7 +519,7 @@ void TKDE::InitFromNewData() {
 }
 
 void TKDE::SetMirroredEvents() {
-   // Mirrors the data 
+   // Mirrors the data
    std::vector<Double_t> originalEvents = fEvents;
    std::vector<Double_t> originalWeights = fEventWeights;
   if (fMirrorLeft) {
@@ -533,7 +534,7 @@ void TKDE::SetMirroredEvents() {
    }
    if (!fEventWeights.empty() && (fMirrorLeft || fMirrorRight)) {
       // copy weights too
-      fEventWeights.insert(fEventWeights.end(), fEventWeights.begin(), fEventWeights.end() ); 
+      fEventWeights.insert(fEventWeights.end(), fEventWeights.begin(), fEventWeights.end() );
    }
 
    if(fUseBins) {
@@ -545,9 +546,9 @@ void TKDE::SetMirroredEvents() {
       fData = fEvents;
    }
    SetBinCountData();
-   
+
    fEvents = originalEvents;
-   fEventWeights = originalWeights; 
+   fEventWeights = originalWeights;
 }
 
 void TKDE::SetMean() {
@@ -600,10 +601,10 @@ void TKDE::SetKernelFunction(KernelFunction_Ptr kernfunc) {
       default:
          /// for user defined kernels
          fKernelFunction = kernfunc;
-         fKernelType = kUserDefined; 
+         fKernelType = kUserDefined;
    }
 
-   if (fKernelType == kUserDefined) { 
+   if (fKernelType == kUserDefined) {
       if (fKernelFunction) {
          CheckKernelValidity();
          SetUserCanonicalBandwidth();
@@ -614,7 +615,7 @@ void TKDE::SetKernelFunction(KernelFunction_Ptr kernfunc) {
          return;
       }
    }
-   assert(fKernelFunction); 
+   assert(fKernelFunction);
    SetKernelSigmas2();
    SetCanonicalBandwidths();
    SetKernel();
@@ -626,7 +627,7 @@ void TKDE::SetCanonicalBandwidths() {
    fCanonicalBandwidths[kEpanechnikov] = 1.7188; // Checked in Mathematica
    fCanonicalBandwidths[kBiweight] = 2.03617;    // Checked in Mathematica
    fCanonicalBandwidths[kCosineArch] = 1.7663;   // Checked in Mathematica
-   fCanonicalBandwidths[kUserDefined] = 1.0;     // To be Checked 
+   fCanonicalBandwidths[kUserDefined] = 1.0;     // To be Checked
 }
 
 void TKDE::SetKernelSigmas2() {
@@ -730,9 +731,9 @@ void TKDE::TKernel::ComputeAdaptiveWeights() {
    Double_t minWeight = weights[0] * 0.05;
    unsigned int n = fKDE->fData.size();
    assert( n == weights.size() );
-   bool useDataWeights = (fKDE->fBinCount.size() == n); 
+   bool useDataWeights = (fKDE->fBinCount.size() == n);
    Double_t f = 0.0;
-   for (unsigned int i = 0; i < n; ++i) { 
+   for (unsigned int i = 0; i < n; ++i) {
 //   for (; weight != weights.end(); ++weight, ++data, ++dataW) {
       if (useDataWeights && fKDE->fBinCount[i] <= 0) continue;  // skip negative or null weights
       f = (*fKDE->fKernel)(fKDE->fData[i]);
@@ -767,11 +768,11 @@ void TKDE::SetBinCentreData(Double_t xmin, Double_t xmax) {
 void TKDE::SetBinCountData() {
    // Returns the bins' count from the data for using with the binned option
    // or set the bin count to the weights in case of weighted data
-   if (fUseBins) { 
+   if (fUseBins) {
       fBinCount.resize(fNBins);
       fSumOfCounts = 0;
-      // case of weighted events 
-      if (!fEventWeights.empty() ) { 
+      // case of weighted events
+      if (!fEventWeights.empty() ) {
          for (UInt_t i = 0; i < fNEvents; ++i) {
             if (fEvents[i] >= fXMin && fEvents[i] < fXMax) {
                fBinCount[Index(fEvents[i])] += fEventWeights[i];
@@ -780,7 +781,7 @@ void TKDE::SetBinCountData() {
             }
          }
       }
-      // case of unweighted data 
+      // case of unweighted data
       else {
          for (UInt_t i = 0; i < fNEvents; ++i) {
             if (fEvents[i] >= fXMin && fEvents[i] < fXMax) {
@@ -793,12 +794,12 @@ void TKDE::SetBinCountData() {
    else if (!fEventWeights.empty() ) {
       fBinCount = fEventWeights;
       fSumOfCounts = 0;
-      for (UInt_t i = 0; i < fNEvents; ++i) 
+      for (UInt_t i = 0; i < fNEvents; ++i)
          fSumOfCounts += fEventWeights[i];
    }
    else {
       fSumOfCounts = fNEvents;
-      fBinCount.clear(); 
+      fBinCount.clear();
    }
 }
 
@@ -934,11 +935,11 @@ Double_t TKDE::TKernel::operator()(Double_t x) const {
    // The internal class's unary function: returns the kernel density estimate
    Double_t result(0.0);
    UInt_t n = fKDE->fData.size();
-   // case of bins or weighted data 
+   // case of bins or weighted data
    Bool_t useBins = (fKDE->fBinCount.size() == n);
    Double_t nSum = (useBins) ? fKDE->fSumOfCounts : fKDE->fNEvents;
    // double dmin = 1.E10;
-   // double xmin,bmin,wmin; 
+   // double xmin,bmin,wmin;
    for (UInt_t i = 0; i < n; ++i) {
       Double_t binCount = (useBins) ? fKDE->fBinCount[i] : 1.0;
       result += binCount / fWeights[i] * (*fKDE->fKernelFunction)((x - fKDE->fData[i]) / fWeights[i]);

--- a/hist/hist/test/test_tkde.cxx
+++ b/hist/hist/test/test_tkde.cxx
@@ -248,7 +248,25 @@ TEST(TKDE, tkde_hist_mirror)
    // check other mirrors types:
    t.useSetters = false;
    t.mirror = "mirrorLeft";
-   t.CompareWithHist("tkde_mirror_3");
+   t.CompareWithHist("tkde_mirrorL");
+   EXPECT_PRED1(TestKDE::IsPValid, t.pval);
+   t.mirror = "mirrorRight";
+   t.CompareWithHist("tkde_mirrorR");
+   EXPECT_PRED1(TestKDE::IsPValid, t.pval);
+   t.mirror = "mirrorAsymBoth";
+   t.CompareWithHist("tkde_mirrorAsym");
+   EXPECT_PRED1(TestKDE::IsPValid, t.pval);
+   t.mirror = "mirrorAsymLeft";
+   t.CompareWithHist("tkde_mirrorAL");
+   EXPECT_PRED1(TestKDE::IsPValid, t.pval);
+   t.mirror = "mirrorAsymRight";
+   t.CompareWithHist("tkde_mirrorAR");
+   EXPECT_PRED1(TestKDE::IsPValid, t.pval);
+   t.mirror = "mirrorRightAsymLeft";
+   t.CompareWithHist("tkde_mirrorRAL");
+   EXPECT_PRED1(TestKDE::IsPValid, t.pval);
+   t.mirror = "mirrorLeftAsymRight";
+   t.CompareWithHist("tkde_mirrorLAR");
    EXPECT_PRED1(TestKDE::IsPValid, t.pval);
 }
 

--- a/hist/hist/test/test_tkde.cxx
+++ b/hist/hist/test/test_tkde.cxx
@@ -4,48 +4,66 @@
 #include "TKDE.h"
 #include "TString.h"
 #include "TFile.h"
-#include "TRandom.h"
+#include "TRandom3.h"
 #include "TVirtualPad.h"
 #include "TF1.h"
 #include "TH1.h"
 
 struct  TestKDE  {
 
-   int n = 1000;
+   // using n < 10000 use a default nbins=100 for KDE
+   int n = 10000;
+   bool useSetters = false;
    bool binned = false;
    bool adaptive = false;
    bool makePlot = true;
-   bool debug = false; 
-   int nbins = 40;
+   bool debug = false;
+   int nbins = 100;
+   int seed = 1111;
+
+   std::vector<double> data;  // kde data
 
    std::vector<double> xtest;
+
    int nTestPoints = 21;
    double values1[21];
    double values2[21];
 
    double pval;
+   double pval2;
 
    TKDE * Create() {
-      std::vector<double> v; v.reserve(n);
-      for(int i=0;i<n;++i) v.push_back( (i < 0.2*n) ? gRandom->Gaus(10,1) : gRandom->Gaus(10,4) );
-      TString opt = "KernelType:Gaussian;Iteration:Fixed;Mirror:noMirror;Binning:Unbinned";
-      TKDE *kde = new TKDE(v.size(), &v[0], 0., 20., opt, 1);
-      if (adaptive) {
-         kde->SetIteration(TKDE::kAdaptive);
-      }
-      if (binned) {
-         kde->SetBinning(TKDE::kRelaxedBinning);
-         kde->SetUseBinsNEvents(100);
-         kde->SetNBins(20);
-      }
+      TRandom3 r(seed);
+      data.resize(n);
+      for(int i=0;i<n;++i) data[i] = (i < 0.2*n) ? r.Gaus(10,1) : r.Gaus(10,4);
+      const char *iterationType = (adaptive) ? "Adaptive" : "Fixed";
+      const char *binningType = (binned) ? "ForcedBinning" : "Unbinned";
+      TString opt;
+      if (useSetters)
+         opt = "KernelType:Gaussian;Iteration:Fixed;Mirror:noMirror;Binning:Unbinned";
+      else
+         opt = TString::Format("KernelType:Gaussian;Iteration:%s;Mirror:noMirror;Binning:%s",iterationType, binningType);
 
+      assert((int)data.size() == n);
+      TKDE *kde = new TKDE(n, data.data(), 0., 20., opt, 1);
+      if (useSetters) {
+         if (adaptive) {
+            kde->SetIteration(TKDE::kAdaptive);
+         }
+         if (binned) {
+            // use relaxed binned mode
+            kde->SetBinning(TKDE::kRelaxedBinning);
+            kde->SetUseBinsNEvents(100);
+            kde->SetNBins(nbins);  // when nbins=100 (using setters or not should give same results)
+         }
+      }
       xtest.resize(20);
       TAxis a(nTestPoints,-0.5,20.5);
       for (size_t i = 0; i < xtest.size(); ++i) {
          xtest[i] = a.GetBinCenter(i+1);
          values1[i] = (*kde)(xtest[i] );
       }
-      if (debug) { 
+      if (debug) {
          std::cout << "Before writing,  kde values :  ";
          for (size_t i = 0; i < xtest.size(); ++i) {
             std::cout << values1[i];
@@ -64,43 +82,54 @@ struct  TestKDE  {
 
    void CompareWithHist(TString name = "tkde") {
       auto kde = Create();
-      int nhistbins = n/20;
-      auto h1 = new TH1D("h1","h1",nhistbins,0.,20.);
-      for(int i=0;i<n;++i) h1->Fill( (i < 0.2*n) ? gRandom->Gaus(10,1) : gRandom->Gaus(10,4) );
+      int nhistbins = 100;
+      auto h1 = new TH1D("h1", "h1", nhistbins, 0., 20.);
+      for(int i=0;i<n;++i) h1->Fill( data[i] );
 
       h1->Sumw2();
       h1->Scale(1./h1->Integral(), "width");
-      
-      auto h2 = kde->GetFunction(nhistbins)->GetHistogram();
-      h2->Sumw2();
-      // set correct bin error
-      for (int i = 1; i <= h2->GetNbinsX()+1; ++i)
-         h2->SetBinError(i, sqrt( h2->GetBinContent(i)/( n * h2->GetBinWidth(i) ) ) );
+
+      auto fkde = kde->GetFunction(nhistbins);
 
       if (makePlot) {
          //auto c1 = new TCanvas();
          kde->Draw();
-         h1->SetLineColor(kBlue); 
+         h1->SetLineColor(kBlue);
          h1->Draw("SAME");
          TString fname = name + "_hist.pdf";
-         if (gPad) gPad->SaveAs(fname); 
+         if (gPad) gPad->SaveAs(fname);
       }
 
 
       // make chi2 test
-      double pvalChi  = h1->Chi2Test(h2,"WW P"); 
-      double pvalKS =  h1->KolmogorovTest(h2);
-      std::cout << "CompareWithHist:   Chi2 test = " << pvalChi << " KS test = " << pvalKS << std::endl;
-      pval = std::min(pvalKS, pvalChi);
+      //double pvalChi2  = h1->Chi2Test(h2,"WW P");
+      // note Chisquare called SetParameters and delete histogram returned from the function
+      double chi2 = h1->Chisquare(fkde);
+      double pvalChi2 = TMath::Prob(chi2, nhistbins);
+
+      auto h2 = fkde->GetHistogram();
+      h2->Sumw2();
+      // set correct bin error
+      for (int i = 1; i <= h2->GetNbinsX() + 1; ++i)
+         h2->SetBinError(i, sqrt(h2->GetBinContent(i) / (n * h2->GetBinWidth(i))));
+
+      // compute KS test
+      double pvalKS = h1->KolmogorovTest(h2);
+      std::cout << "CompareWithHist:   Chi2 test = " << chi2 << "/" << nhistbins << " pvalue = " << pvalChi2 <<
+                   "  KS test p value = " << pvalKS << std::endl;
+      pval = std::min(pvalKS, pvalChi2);
+      pval2 = std::max(pvalKS, pvalChi2);
 
       delete kde;
-      delete h1; 
+      delete h1;
    }
 
    static bool IsPValid(double pval) {
-      return (pval > 0.01);
+      return pval > 0.01;
    }
-
+   static bool IsPValid2(double pval1, double pval2){
+      return pval1 > 1.E-4 && pval2 > 0.05;
+   }
 
    void Write(TString name = "tkde") {
       TFile *f = new TFile("test_tkde.root", "RECREATE");
@@ -113,11 +142,11 @@ struct  TestKDE  {
 
    void Read(TString name = "tkde") {
       TFile *f = new TFile("test_tkde.root");
-      auto kde = (TKDE*) f->Get(name); 
+      auto kde = (TKDE*) f->Get(name);
       //kde->Dump();
       for (size_t i = 0; i < xtest.size(); ++i) values2[i] = (*kde)(xtest[i] );
 
-      if (debug) { 
+      if (debug) {
          std::cout << "After reading,  kde values : ";
          for (size_t i = 0; i < xtest.size(); ++i) {
             std::cout << values2[i];
@@ -126,40 +155,64 @@ struct  TestKDE  {
          }
       }
 
-      if (makePlot) { 
+      if (makePlot) {
          kde->Draw("SAME");
-         TString gfname = name + ".pdf"; 
+         TString gfname = name + ".pdf";
          gPad->SaveAs(gfname);
       }
       //f->Close();
       delete f;
    }
-   
+
 };
 
 /// Hstogram comparison tests
 /// In this test we compare the TKDE with an histogram
-/// filled with th same type of data. A GoF test (chi2 and KS) is applied to
+/// filled with the same type of data. A GoF test (chi2 and KS) is applied to
 /// check for compatibility
 TEST(TKDE, tkde_hist)
-{   
+{
    TestKDE t;
-   t.CompareWithHist(); 
+   t.CompareWithHist();
    EXPECT_PRED1(TestKDE::IsPValid, t.pval);
 }
 TEST(TKDE, tkde_hist_adaptive)
-{   
+{
    TestKDE t;
-   t.adaptive = true; 
-   t.CompareWithHist("tkde_adaptive"); 
+   // reduce n here since unbinned adaptive is slow
+   t.n = 2000;
+   t.adaptive = true;
+   t.CompareWithHist("tkde_adaptive");
+   EXPECT_PRED1(TestKDE::IsPValid, t.pval);
+   // test also default constructors + usage of setters functions
+   t.useSetters = true;
+   t.CompareWithHist("tkde_adaptive_2");
    EXPECT_PRED1(TestKDE::IsPValid, t.pval);
 }
 TEST(TKDE, tkde_hist_binned)
-{  
+{
    TestKDE t;
-   t.adaptive = true; 
-   t.binned = true; 
-   t.CompareWithHist("tkde_binned"); 
+   t.adaptive = false;
+   t.binned = true;
+   t.nbins = 3000;
+   // with binned not adaptive it is good for high statistics
+   t.CompareWithHist("tkde_binned");
+   EXPECT_PRED2(TestKDE::IsPValid2, t.pval, t.pval2);
+   t.useSetters = true;
+   t.CompareWithHist("tkde_binned_2");
+   EXPECT_PRED2(TestKDE::IsPValid2, t.pval, t.pval2);
+}
+TEST(TKDE, tkde_hist_adaptive_binned)
+{
+   TestKDE t;
+   t.nbins = t.n/10;
+   //t.nbins = 3000;
+   t.adaptive = true;
+   t.binned = true;
+   t.CompareWithHist("tkde_adaptive_binned");
+   EXPECT_PRED1(TestKDE::IsPValid, t.pval);
+   t.useSetters = true;
+   t.CompareWithHist("tkde_adaptive_binned_2");
    EXPECT_PRED1(TestKDE::IsPValid, t.pval);
 }
 
@@ -171,10 +224,10 @@ TEST(TKDE, tkde_io)
    t.Write();
    t.Read();
 
-   // double delta = 1.E-15; 
+   // double delta = 1.E-15;
    // EXPECT_NEAR(t.values1[0], t.values2[0], delta);
 
-   
+
    for (size_t i = 0; i < t.xtest.size(); ++i) {
       EXPECT_DOUBLE_EQ(t.values1[i], t.values2[i]);
    }
@@ -185,6 +238,7 @@ TEST(TKDE, tkde_io_adaptive)
    TString name = "tkde_adaptive";
    TestKDE t;
    t.adaptive = true;
+   t.n = 2000;
    t.Write(name);
    t.Read(name);
    double delta = 1.E-3;
@@ -197,7 +251,7 @@ TEST(TKDE, tkde_io_adaptive)
 TEST(TKDE, tkde_io_binned)
 {
    TestKDE t;
-   t.adaptive = true; 
+   t.adaptive = true;
    t.binned = true;
    TString name = "tkde_binned";
    t.Write(name);
@@ -208,4 +262,3 @@ TEST(TKDE, tkde_io_binned)
       //EXPECT_DOUBLE_EQ(t.values1[i], t.values2[i]);
    }
 }
-


### PR DESCRIPTION
Apply some bug fixes in the TKDE class.
 - Fix initialization for the automatic binning case
 - Fix setting the bins using the setter functions.
 - Fix mirroring for binned case (fix ROOT-8488)
 - Fix MirrorAsym case 
 - Fix computation of non-adaptive bandwidth for binned case
  
Add also some improvements in the class avoid some unneeded re-initialization and some small speedup in the kernel calculations.
Improve also the documentations