### PR TITLE
Reset function sections before JITting

### DIFF
--- a/interpreter/cling/test/Prompt/Exceptions.C
+++ b/interpreter/cling/test/Prompt/Exceptions.C
@@ -1,0 +1,20 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling 2>&1 | FileCheck %s
+extern "C" int printf(const char*,...);
+
+struct TheStruct {
+  char m_Storage[100];
+};
+
+// CHECK: About to throw "ABC"
+printf("About to throw \"ABC\"\n");
+TheStruct getStructButThrows() { throw "ABC!"; }
+// CHECK: Exception occurred. Recovering...
+getStructButThrows()

--- a/interpreter/cling/test/Prompt/Exceptions.cpp
+++ b/interpreter/cling/test/Prompt/Exceptions.cpp
@@ -1,6 +1,0 @@
-struct TheStruct {
-  char m_Storage[100];
-};
-
-TheStruct getStructButThrows() { throw "ABC!"; }
-getStructButThrows()

--- a/interpreter/cling/test/Recursion/Exceptions.C
+++ b/interpreter/cling/test/Recursion/Exceptions.C
@@ -9,20 +9,25 @@
 // RUN: cat %s | %cling 2>&1 | FileCheck %s
 extern "C" int printf(const char*,...);
 
-struct TheStruct {
-  char m_Storage[100];
-};
+// When interpreting code, raised exceptions can be catched by the call site.
 
-// CHECK: About to throw "ABC"
-printf("About to throw \"ABC\"\n");
-TheStruct getStructButThrows() { throw "ABC!"; }
-// CHECK: Exception occurred. Recovering...
-getStructButThrows()
+#include "cling/Interpreter/Interpreter.h"
+
+try {
+  gCling->process("throw 1;");
+} catch (...) {
+  // CHECK: Caught exception from throw statement
+  printf("Caught exception from throw statement\n");
+}
 
 struct ThrowInConstructor {
   ThrowInConstructor() { throw 1; }
 };
-// CHECK: About to throw in constructor
-printf("About to throw in constructor\n");
-// CHECK: Exception occurred. Recovering...
-ThrowInConstructor t;
+try {
+  gCling->process("ThrowInConstructor t;");
+} catch (...) {
+  // CHECK: Caught exception from constructor
+  printf("Caught exception from constructor\n");
+}
+
+.q


### PR DESCRIPTION
This makes all functions end up in the same text section, which is important for `TCling` on macOS to catch exceptions from constructors: Stack unwinding requires information about program addresses to find out which objects to destroy and what code should be called to handle the exception. These addresses are relocated against a single `__text` section when loading the produced MachO binary, which breaks if the call sites of global constructors end up in a separate init section.

Fixes ROOT-10703 and ROOT-10962