### PR TITLE
Explicitly pass ParamFunction.h as it is included by Polynomial.h

### DIFF
--- a/math/mathmore/CMakeLists.txt
+++ b/math/mathmore/CMakeLists.txt
@@ -32,6 +32,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(MathMore
     Math/MCParameters.h
     Math/PdfFuncMathMore.h
     Math/Polynomial.h
+    Math/ParamFunction.h
     Math/QuasiRandom.h
     Math/RootFinderAlgorithms.h
     Math/SpecFuncMathMore.h


### PR DESCRIPTION
This fixes a cmssw llvm9 plus modules issue:

error: 'ROOT::Math::ParamFunction' has different definitions in different modules; first difference is defined here found method 'SetParameters' with body

cc: @davidlange6 