### PR TITLE
Eve-7 add missing EveElemControl for eve geo shape and projected polygons

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveScene.hxx
+++ b/graf3d/eve7/inc/ROOT/REveScene.hxx
@@ -118,8 +118,7 @@ public:
    void AddSubscriber(std::unique_ptr<REveClient> &&sub);
    void RemoveSubscriber(unsigned int);
 
-   void AddCommand(const std::string &name, const std::string &icon, const REveElement *element, const std::string &action)
-   { fCommands.emplace_back(name, icon, element, action); }
+   void AddCommand(const std::string &name, const std::string &icon, const REveElement *element, const std::string &action);
 };
 
 /******************************************************************************/

--- a/graf3d/eve7/src/REveScene.cxx
+++ b/graf3d/eve7/src/REveScene.cxx
@@ -78,6 +78,20 @@ void REveScene::RemoveSubscriber(unsigned id)
    fSubscribers.erase(std::remove_if(fSubscribers.begin(), fSubscribers.end(), pred), fSubscribers.end());
 }
 
+// Add Button in client gui with this command
+void REveScene::AddCommand(const std::string &name, const std::string &icon, const REveElement *element, const std::string &action)
+{
+   static const REveException eh("REveScene::AddCommand ");
+   if (element->GetElementId() && element->IsA())
+   {
+      fCommands.emplace_back(name, icon, element, action);
+   }
+   else
+   {
+      throw eh + "Element id and dictionary has to be defined";
+   }
+}
+
 void REveScene::BeginAcceptingChanges()
 {
    if (fAcceptingChanges) return;

--- a/ui5/eve7/lib/EveElements.js
+++ b/ui5/eve7/lib/EveElements.js
@@ -1035,6 +1035,8 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       else
          body.computeVertexNormals();
 
+      body.get_ctrl = function() { return new EveElemControl(this); }
+
       // XXXX Fix this. It seems we could have flat shading with usage of simple shaders.
       // XXXX Also, we could do edge detect on the server for outlines.
       // XXXX a) 3d objects - angle between triangles >= 85 degrees (or something);
@@ -1061,6 +1063,8 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       var mesh = new THREE.Mesh(geom, material);
 
       egs_ro.add(mesh);
+
+      egs_ro.get_ctrl = function() { return new EveElemControl(this); }
 
       return egs_ro;
    }
@@ -1118,8 +1122,9 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
             console.error("Unexpected primitive type " + rnr_data.idxBuff[ib_pos]);
             break;
          }
-
       }
+
+      psp_ro.get_ctrl =  function() { return new EveElemControl(this); }
 
       return psp_ro;
    }
@@ -1192,6 +1197,8 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          }
 
       }
+
+      psp_ro.get_ctrl =  function() { return new EveElemControl(this); }
 
       return psp_ro;
    }
@@ -1318,7 +1325,6 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
    EveElements.prototype.makeStraightLineSet = function(el, rnr_data)
     {
-        console.log("MAKE STRA ...");
       var obj3d = new THREE.Object3D();
 
       var mainColor = jsrp.getColor(el.fMainColor);


### PR DESCRIPTION

Commit e3c0412 enables highlight of eve shapes and projected polygons
Commit 85cc148 requested by Sophie Middleton.