### PR TITLE
A subset of further improvements to reduce lock contention

### DIFF
--- a/core/thread/inc/ROOT/TReentrantRWLock.hxx
+++ b/core/thread/inc/ROOT/TReentrantRWLock.hxx
@@ -88,7 +88,7 @@ struct UniqueLockRecurseCount {
 struct RecurseCounts {
    using Hint_t = TVirtualRWMutex::Hint_t;
    using ReaderColl_t = std::unordered_map<std::thread::id, size_t>;
-   size_t fWriteRecurse; ///<! Number of re-entry in the lock by the same thread.
+   size_t fWriteRecurse =  0; ///<! Number of re-entry in the lock by the same thread.
 
    std::thread::id fWriterThread; ///<! Holder of the write lock
    ReaderColl_t fReadersCount;    ///<! Set of reader thread ids


### PR DESCRIPTION
Further reduction in lock contention when using RDataFrame with a large number of threads and/or files, by migrating one hot spot in TBufferFile to use read-write locks instead of only write locks.

On a small test with 256 threads the reduced lock contention reduces wall time from 25 minutes to 19 seconds, and increases CPU usage from 400% to 4000%.

This PR also fixes an uninitialised variable potentially affecting the global read-write lock.