### PR TITLE
Make task splitting in TTreeProcessorMT more sensible with many input files.

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -107,7 +107,10 @@ public:
    TTreeProcessorMT(TTree &tree, UInt_t nThreads = 0u);
 
    void Process(std::function<void(TTreeReader &)> func);
+
+   R__DEPRECATED(6, 26, "Please use SetTasksPerWorkerHint instead. This setting will be ignored.")
    static void SetMaxTasksPerFilePerWorker(unsigned int m);
+   R__DEPRECATED(6, 26, "Please use SetTasksPerWorkerHint and GetTasksPerWorkerHint instead. This setting is ignored.")
    static unsigned int GetMaxTasksPerFilePerWorker();
    static void SetTasksPerWorkerHint(unsigned int m);
    static unsigned int GetTasksPerWorkerHint();

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -97,6 +97,7 @@ private:
    Internal::FriendInfo GetFriendInfo(TTree &tree);
    std::vector<std::string> FindTreeNames();
    static unsigned int fgMaxTasksPerFilePerWorker;
+   static unsigned int fgTasksPerWorkerHint;
 
 public:
    TTreeProcessorMT(std::string_view filename, std::string_view treename = "", UInt_t nThreads = 0u);
@@ -108,6 +109,8 @@ public:
    void Process(std::function<void(TTreeReader &)> func);
    static void SetMaxTasksPerFilePerWorker(unsigned int m);
    static unsigned int GetMaxTasksPerFilePerWorker();
+   static void SetTasksPerWorkerHint(unsigned int m);
+   static unsigned int GetTasksPerWorkerHint();
 };
 
 } // End of namespace ROOT

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -171,18 +171,20 @@ MakeClusters(const std::vector<std::string> &treeNames, const std::vector<std::s
       entriesPerFile.emplace_back(entries);
    }
 
-   // Here we "fuse" together clusters if the number of clusters is too big with respect to
+   // Here we "fuse" clusters together if the number of clusters is too big with respect to
    // the number of slots, otherwise we can incur in an overhead which is big enough
    // to make parallelisation detrimental to performance.
    // For example, this is the case when, following a merging of many small files, a file
    // contains a tree with many entries and with clusters of just a few entries each.
    // Another problematic case is a high number of slots (e.g. 256) coupled with a high number
-   // of large files (e.g. 1000 files): the large amount of files might result in a large amount
+   // of files (e.g. 1000 files): the large amount of files might result in a large amount
    // of tasks, but the elevated concurrency level makes the little synchronization required by
    // task initialization very expensive. In this case it's better to simply process fewer, larger tasks.
+   // Cluster-merging can help reduce the number of tasks down to a minumum of one task per file.
+   //
    // The criterion according to which we fuse clusters together is to have around
-   // TTreeProcessorMT::GetTasksPerWorkerHint() clusters per file per slot.
-   // In particular, for each file we will cap the number of tasks to ceil(GetTasksPerWorkerHint() * nWorkers / nFiles).
+   // TTreeProcessorMT::GetTasksPerWorkerHint() clusters per slot.
+   // Concretely, for each file we will cap the number of tasks to ceil(GetTasksPerWorkerHint() * nWorkers / nFiles).
 
    std::vector<std::vector<EntryCluster>> eventRangesPerFile(clustersPerFile.size());
    auto clustersPerFileIt = clustersPerFile.begin();

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -172,15 +172,17 @@ MakeClusters(const std::vector<std::string> &treeNames, const std::vector<std::s
    }
 
    // Here we "fuse" together clusters if the number of clusters is too big with respect to
-   // the number of slots, otherwise we can incurr in an overhead which is big enough
+   // the number of slots, otherwise we can incur in an overhead which is big enough
    // to make parallelisation detrimental to performance.
    // For example, this is the case when, following a merging of many small files, a file
    // contains a tree with many entries and with clusters of just a few entries each.
-   // The criterion according to which we fuse clusters together is to have at most
-   // TTreeProcessorMT::GetMaxTasksPerFilePerWorker() clusters per file per slot.
-   // For example: given 2 files and 16 workers, at most
-   // 16 * 2 * TTreeProcessorMT::GetMaxTasksPerFilePerWorker() clusters will be created, at most
-   // 16 * TTreeProcessorMT::GetMaxTasksPerFilePerWorker() per file.
+   // Another problematic case is a high number of slots (e.g. 256) coupled with a high number
+   // of large files (e.g. 1000 files): the large amount of files might result in a large amount
+   // of tasks, but the elevated concurrency level makes the little synchronization required by
+   // task initialization very expensive. In this case it's better to simply process fewer, larger tasks.
+   // The criterion according to which we fuse clusters together is to have around
+   // TTreeProcessorMT::GetTasksPerWorkerHint() clusters per file per slot.
+   // In particular, for each file we will cap the number of tasks to ceil(GetTasksPerWorkerHint() * nWorkers / nFiles).
 
    std::vector<std::vector<EntryCluster>> eventRangesPerFile(clustersPerFile.size());
    auto clustersPerFileIt = clustersPerFile.begin();
@@ -629,30 +631,35 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
 }
 
 ////////////////////////////////////////////////////////////////////////
-/// \brief Sets the maximum number of tasks created per file, per worker.
-/// \return The maximum number of tasks created per file, per worker
+/// \brief This function is deprecated in favor of GetTasksPerWorkerHint().
 unsigned int TTreeProcessorMT::GetMaxTasksPerFilePerWorker()
 {
    return fgMaxTasksPerFilePerWorker;
 }
 
+////////////////////////////////////////////////////////////////////////
+/// \brief Retrieve the current value for the desired number of tasks per worker.
+/// \return The desired number of tasks to be created per worker. TTreeProcessorMT uses this value as an hint.
 unsigned int TTreeProcessorMT::GetTasksPerWorkerHint()
 {
    return fgTasksPerWorkerHint;
 }
 
 ////////////////////////////////////////////////////////////////////////
-/// \brief Sets the maximum number of tasks created per file, per worker.
-/// \param[in] maxTasksPerFile Name of the file containing the tree to process.
-///
-/// This allows to create a reasonable number of tasks even if any of the
-/// processed files features a bad clustering, for example with a lot of
-/// entries and just a few entries per cluster.
+/// \brief This function is deprecated in favor of SetTasksPerWorkerHint().
 void TTreeProcessorMT::SetMaxTasksPerFilePerWorker(unsigned int maxTasksPerFile)
 {
    fgMaxTasksPerFilePerWorker = maxTasksPerFile;
 }
 
+////////////////////////////////////////////////////////////////////////
+/// \brief Set the hint for the desired number of tasks created per worker.
+/// \param[in] tasksPerWorkerHint Desired number of tasks per worker.
+///
+/// This allows to create a reasonable number of tasks even if any of the
+/// processed files features a bad clustering, for example with a lot of
+/// entries and just a few entries per cluster, or to limit the number of
+/// tasks spawned when a very large number of files and workers is used.
 void TTreeProcessorMT::SetTasksPerWorkerHint(unsigned int tasksPerWorkerHint)
 {
    fgTasksPerWorkerHint = tasksPerWorkerHint;

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -572,8 +572,9 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    const std::vector<std::vector<std::string>> &friendFileNames = fFriendInfo.fFriendFileNames;
 
    // compute number of tasks per file
-   const unsigned int maxTasksPerFile = std::ceil(float(GetTasksPerWorkerHint()*fPool.GetPoolSize())/float(fFileNames.size()));
-   
+   const unsigned int maxTasksPerFile =
+      std::ceil(float(GetTasksPerWorkerHint() * fPool.GetPoolSize()) / float(fFileNames.size()));
+
    // If an entry list or friend trees are present, we need to generate clusters with global entry numbers,
    // so we do it here for all files.
    // Otherwise we can do it later, concurrently for each file, and clusters will contain local entry numbers.

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -129,7 +129,7 @@ using ClustersAndEntries = std::pair<std::vector<std::vector<EntryCluster>>, std
 ////////////////////////////////////////////////////////////////////////
 /// Return a vector of cluster boundaries for the given tree and files.
 static ClustersAndEntries
-MakeClusters(const std::vector<std::string> &treeNames, const std::vector<std::string> &fileNames)
+MakeClusters(const std::vector<std::string> &treeNames, const std::vector<std::string> &fileNames, const unsigned int maxTasksPerFile)
 {
    // Note that as a side-effect of opening all files that are going to be used in the
    // analysis once, all necessary streamers will be loaded into memory.
@@ -182,7 +182,6 @@ MakeClusters(const std::vector<std::string> &treeNames, const std::vector<std::s
    // 16 * 2 * TTreeProcessorMT::GetMaxTasksPerFilePerWorker() clusters will be created, at most
    // 16 * TTreeProcessorMT::GetMaxTasksPerFilePerWorker() per file.
 
-   const auto maxTasksPerFile = TTreeProcessorMT::GetMaxTasksPerFilePerWorker() * ROOT::GetThreadPoolSize();
    std::vector<std::vector<EntryCluster>> eventRangesPerFile(clustersPerFile.size());
    auto clustersPerFileIt = clustersPerFile.begin();
    auto eventRangesPerFileIt = eventRangesPerFile.begin();
@@ -285,6 +284,8 @@ static std::vector<std::string> GetTreeFullPaths(const TTree &tree)
 namespace ROOT {
 
 unsigned int TTreeProcessorMT::fgMaxTasksPerFilePerWorker = 24U;
+
+unsigned int TTreeProcessorMT::fgTasksPerWorkerHint = 24U;
 
 namespace Internal {
 
@@ -568,6 +569,9 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    const std::vector<Internal::NameAlias> &friendNames = fFriendInfo.fFriendNames;
    const std::vector<std::vector<std::string>> &friendFileNames = fFriendInfo.fFriendFileNames;
 
+   // compute number of tasks per file
+   const unsigned int maxTasksPerFile = std::ceil(float(GetTasksPerWorkerHint()*fPool.GetPoolSize())/float(fFileNames.size()));
+   
    // If an entry list or friend trees are present, we need to generate clusters with global entry numbers,
    // so we do it here for all files.
    // Otherwise we can do it later, concurrently for each file, and clusters will contain local entry numbers.
@@ -578,7 +582,7 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    const bool shouldRetrieveAllClusters = hasFriends || hasEntryList;
    ClustersAndEntries clusterAndEntries{};
    if (shouldRetrieveAllClusters) {
-      clusterAndEntries = MakeClusters(fTreeNames, fFileNames);
+      clusterAndEntries = MakeClusters(fTreeNames, fFileNames, maxTasksPerFile);
       if (hasEntryList)
          clusterAndEntries.first = ConvertToElistClusters(std::move(clusterAndEntries.first), fEntryList, fTreeNames,
                                                           fFileNames, clusterAndEntries.second);
@@ -600,7 +604,7 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
       const auto &theseTrees = shouldRetrieveAllClusters ? fTreeNames : std::vector<std::string>({fTreeNames[fileIdx]});
       // Evaluate clusters (with local entry numbers) and number of entries for this file, if needed
       const auto theseClustersAndEntries =
-         shouldRetrieveAllClusters ? ClustersAndEntries{} : MakeClusters(theseTrees, theseFiles);
+         shouldRetrieveAllClusters ? ClustersAndEntries{} : MakeClusters(theseTrees, theseFiles, maxTasksPerFile);
 
       // All clusters for the file to process, either with global or local entry numbers
       const auto &thisFileClusters = shouldRetrieveAllClusters ? clusters[fileIdx] : theseClustersAndEntries.first[0];
@@ -632,6 +636,11 @@ unsigned int TTreeProcessorMT::GetMaxTasksPerFilePerWorker()
    return fgMaxTasksPerFilePerWorker;
 }
 
+unsigned int TTreeProcessorMT::GetTasksPerWorkerHint()
+{
+   return fgTasksPerWorkerHint;
+}
+
 ////////////////////////////////////////////////////////////////////////
 /// \brief Sets the maximum number of tasks created per file, per worker.
 /// \param[in] maxTasksPerFile Name of the file containing the tree to process.
@@ -642,4 +651,9 @@ unsigned int TTreeProcessorMT::GetMaxTasksPerFilePerWorker()
 void TTreeProcessorMT::SetMaxTasksPerFilePerWorker(unsigned int maxTasksPerFile)
 {
    fgMaxTasksPerFilePerWorker = maxTasksPerFile;
+}
+
+void TTreeProcessorMT::SetTasksPerWorkerHint(unsigned int tasksPerWorkerHint)
+{
+   fgTasksPerWorkerHint = tasksPerWorkerHint;
 }


### PR DESCRIPTION
Previously if running with a large number of input files (few hundred or even a thousand+ could be typical for large datasets processed into flat trees with grid jobs) one could end up with a huge number of tasks (at minimum nThreads * nFiles).

This makes the splitting aware of the number of files, taken into account for both the default splitting and the function used for user configuration, which also changes name.