### PR TITLE
Small Minuit2 Improvements: Avoid a duplicate state in FunctionMinimum 

### DIFF
--- a/math/minuit2/inc/Minuit2/BasicFunctionMinimum.h
+++ b/math/minuit2/inc/Minuit2/BasicFunctionMinimum.h
@@ -39,7 +39,7 @@ public:
    };
 
 public:
-   /// constructor from only MinimumSeed. Minimum is only from seed result not the full minimization
+   /// Constructor from only MinimumSeed. Minimum is only from seed result not the full minimization
    BasicFunctionMinimum(const MinimumSeed &seed, double up)
       : fSeed(seed), fStates(std::vector<MinimumState>(1, MinimumState(seed.Parameters(), seed.Error(), seed.Gradient(),
                                                                        seed.Parameters().Fval(), seed.NFcn()))),
@@ -47,28 +47,28 @@ public:
    {
    }
 
-   /// constructor at the end of a successfull minimization from seed and vector of states
+   /// Constructor at the end of a successfull minimization from seed and vector of states
    BasicFunctionMinimum(const MinimumSeed &seed, const std::vector<MinimumState> &states, double up)
       : fSeed(seed), fStates(states), fErrorDef(up), fAboveMaxEdm(false), fReachedCallLimit(false),
         fUserState(MnUserParameterState())
    {
    }
 
-   /// constructor at the end of a failed minimization due to exceeding function call limit
+   /// Constructor at the end of a failed minimization due to exceeding function call limit
    BasicFunctionMinimum(const MinimumSeed &seed, const std::vector<MinimumState> &states, double up, MnReachedCallLimit)
       : fSeed(seed), fStates(states), fErrorDef(up), fAboveMaxEdm(false), fReachedCallLimit(true),
         fUserState(MnUserParameterState())
    {
    }
 
-   /// constructor at the end of a failed minimization due to edm above maximum value
+   /// Constructor at the end of a failed minimization due to edm above maximum value
    BasicFunctionMinimum(const MinimumSeed &seed, const std::vector<MinimumState> &states, double up, MnAboveMaxEdm)
       : fSeed(seed), fStates(states), fErrorDef(up), fAboveMaxEdm(true), fReachedCallLimit(false),
         fUserState(MnUserParameterState())
    {
    }
 
-   /// copy constructor
+   /// Copy constructor
    BasicFunctionMinimum(const BasicFunctionMinimum &min)
       : fSeed(min.fSeed), fStates(min.fStates), fErrorDef(min.fErrorDef), fAboveMaxEdm(min.fAboveMaxEdm),
         fReachedCallLimit(min.fReachedCallLimit), fUserState(min.fUserState)

--- a/math/minuit2/inc/Minuit2/BasicMinimumState.h
+++ b/math/minuit2/inc/Minuit2/BasicMinimumState.h
@@ -25,19 +25,24 @@ namespace Minuit2 {
 class BasicMinimumState {
 
 public:
-   // constructor without parameter values but with function value, edm and nfcn
+   /// constructor without parameter values but with function value, edm and nfcn
+   /// This constructor will result in a state that is flagged as not valid
    BasicMinimumState(unsigned int n, double fval, double edm, int nfcn)
       : fParameters(MinimumParameters(n, fval)), fError(MinimumError(n)), fGradient(FunctionGradient(n)), fEDM(edm),
         fNFcn(nfcn)
    {
    }
 
+   /// COnstructor with parameters values, errors and gradient
    BasicMinimumState(const MinimumParameters &states, const MinimumError &err, const FunctionGradient &grad, double edm,
                      int nfcn)
       : fParameters(states), fError(err), fGradient(grad), fEDM(edm), fNFcn(nfcn)
    {
    }
 
+   /// Constuctor with only parameter values, edm + nfcn
+   /// The resulting state will have not error (HasCovariance() returns false)
+   /// but it will be a valid state, since it contains parameter values
    BasicMinimumState(const MinimumParameters &states, double edm, int nfcn)
       : fParameters(states), fError(MinimumError(states.Vec().size())),
         fGradient(FunctionGradient(states.Vec().size())), fEDM(edm), fNFcn(nfcn)

--- a/math/minuit2/inc/Minuit2/BasicMinimumState.h
+++ b/math/minuit2/inc/Minuit2/BasicMinimumState.h
@@ -25,7 +25,7 @@ namespace Minuit2 {
 class BasicMinimumState {
 
 public:
-   /// constructor without parameter values but with function value, edm and nfcn
+   /// Constructor without parameter values, but with function value, edm and nfcn.
    /// This constructor will result in a state that is flagged as not valid
    BasicMinimumState(unsigned int n, double fval, double edm, int nfcn)
       : fParameters(MinimumParameters(n, fval)), fError(MinimumError(n)), fGradient(FunctionGradient(n)), fEDM(edm),
@@ -33,16 +33,17 @@ public:
    {
    }
 
-   /// COnstructor with parameters values, errors and gradient
+   /// Constructor with parameters values, errors and gradient
    BasicMinimumState(const MinimumParameters &states, const MinimumError &err, const FunctionGradient &grad, double edm,
                      int nfcn)
       : fParameters(states), fError(err), fGradient(grad), fEDM(edm), fNFcn(nfcn)
    {
    }
 
-   /// Constuctor with only parameter values, edm + nfcn
-   /// The resulting state will have not error (HasCovariance() returns false)
-   /// but it will be a valid state, since it contains parameter values
+   /// Constuctor with only parameter values, edm and nfcn, but without errors (covariance).
+   /// The resulting state it will be considered valid, since it contains the parameter values,
+   /// although it will has not the error matrix (MinimumError) with
+   /// HasCovariance() returning false.
    BasicMinimumState(const MinimumParameters &states, double edm, int nfcn)
       : fParameters(states), fError(MinimumError(states.Vec().size())),
         fGradient(FunctionGradient(states.Vec().size())), fEDM(edm), fNFcn(nfcn)

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -106,12 +106,12 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
    int maxfcn_eff = maxfcn;
    int ipass = 0;
    bool iterate = false;
-   bool runHessian = false;
+   bool hessianComputed = false;
 
    do {
 
       iterate = false;
-      runHessian = false;
+      hessianComputed = false;
 
       print.Debug(ipass > 0 ? "Continue" : "Start", "iterating...");
 
@@ -141,7 +141,7 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
 
          MinimumState st = MnHesse(strategy)(fcn, min.State(), min.Seed().Trafo(), maxfcn);
 
-         runHessian = true;
+         hessianComputed = true;
 
          print.Info("After Hessian");
 
@@ -194,7 +194,7 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
       if (min.IsAboveMaxEdm()) {
          print.Info("Edm has been re-computed after Hesse; Edm", edm, "is now within tolerance");
       }
-      if (runHessian) min.Add(result.back());
+      if (hessianComputed) min.Add(result.back());
    }
 
    print.Debug("Minimum found", min);


### PR DESCRIPTION
Apply some small improvements in Minuit2. 
When using strategy 0 (i.e. when Hesse is not computed at the end of the minimization), the same state is added 2 times in the FunctionMinimum class.

This is now fixed by adding a flag runHessian in the VariableMetric code.

Add another improvement: do not compute Hessian during the iteration.When not using debug mode the Hessian, which requires a matrix inversion, was computed for each iteration. This is now fixed by avoid its computation, that is not needed by the algorithm. 