### PR TITLE
[RF] Improve plotting of RooBinSamplingPdf.

### DIFF
--- a/roofit/roofitcore/src/RooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/src/RooBinSamplingPdf.cxx
@@ -222,7 +222,7 @@ std::list<double>* RooBinSamplingPdf::binBoundaries(RooAbsRealLValue& obs, Doubl
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return a list of all bin centres, so the PDF is plotted correctly.
+/// Return a list of all bin edges, so the PDF is plotted as a step function.
 /// \param[in] obs Observable to generate the sampling hint for.
 /// \param[in] xlo Beginning of range to create sampling hint for.
 /// \param[in] xhi End of range to create sampling hint for.
@@ -234,19 +234,24 @@ std::list<double>* RooBinSamplingPdf::plotSamplingHint(RooAbsRealLValue& obs, Do
     return nullptr;
   }
 
-  auto binCentres = new std::list<double>;
+  auto binEdges = new std::list<double>;
   const auto& binning = obs.getBinning();
-  binCentres->push_back(xlo);
 
-  for (unsigned int bin=0; bin < static_cast<unsigned int>(binning.numBins()); ++bin) {
-    const double centre = binning.binCenter(bin);
+  for (unsigned int bin=0, numBins = static_cast<unsigned int>(binning.numBins()); bin < numBins; ++bin) {
+    const double low  = std::max(binning.binLow(bin), xlo);
+    const double high = std::min(binning.binHigh(bin), xhi);
+    const double width = high - low;
 
-    if (xlo <= centre && centre < xhi)
-      binCentres->push_back(centre);
+    // Check if this bin is in plotting range at all
+    if (low >= high)
+      continue;
+
+    // Move support points slightly inside the bin, so step function is plotted correctly.
+    binEdges->push_back(low  + 0.001 * width);
+    binEdges->push_back(high - 0.001 * width);
   }
-  binCentres->push_back(xhi);
 
-  return binCentres;
+  return binEdges;
 }
 
 

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -571,7 +571,7 @@ Double_t RooCurve::chiSquare(const RooHist& hist, Int_t nFitParam) const
   for (i=0 ; i<np ; i++) {   
 
     // Retrieve histogram contents
-    ((RooHist&)hist).GetPoint(i,x,y) ;
+    hist.GetPoint(i,x,y) ;
 
     // Check if point is in range of curve
     if (x<xstart || x>xstop) continue ;
@@ -618,8 +618,8 @@ Double_t RooCurve::average(Double_t xFirst, Double_t xLast) const
   Int_t ifirst = findPoint(xFirst,1e10) ;
   Int_t ilast  = findPoint(xLast,1e10) ;
   Double_t xFirstPt,yFirstPt,xLastPt,yLastPt ;
-  const_cast<RooCurve&>(*this).GetPoint(ifirst,xFirstPt,yFirstPt) ;
-  const_cast<RooCurve&>(*this).GetPoint(ilast,xLastPt,yLastPt) ;
+  GetPoint(ifirst,xFirstPt,yFirstPt) ;
+  GetPoint(ilast,xLastPt,yLastPt) ;
 
   Double_t tolerance=1e-3*(xLast-xFirst) ;
 


### PR DESCRIPTION
In order to plot the bin sampling PDF as a step function, two support
points instead of one is needed. This improves plots, pulls and the chi2
calculation of RooPlot.

(See chi2 value in title of pull plot)

| old | new |
| --- |  --- |
| ![toy1](https://user-images.githubusercontent.com/16205615/106265880-f3e43d00-6227-11eb-8cf0-b3a51ddf2c8b.png) | ![toy_new](https://user-images.githubusercontent.com/16205615/106265508-702a5080-6227-11eb-9ef8-56129a19ed50.png) |
