### PR TITLE
[webgui] let use with fastcgi, introduce token verification

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -127,6 +127,7 @@ private:
    ConnectionsList_t fConn;                         ///<! list of all accepted connections
    mutable std::mutex fConnMutex;                   ///<! mutex used to protect connection list
    unsigned fConnLimit{1};                          ///<! number of allowed active connections
+   std::string fConnToken;                          ///<! value of "token" URL parameter which should be provided for connecting window
    bool fNativeOnlyConn{false};                     ///<! only native connection are allowed, created by Show() method
    unsigned fMaxQueueLength{10};                    ///<! maximal number of queue entries
    WebWindowConnectCallback_t fConnCallback;        ///<! callback for connect event
@@ -189,6 +190,8 @@ private:
 
    void AssignCallbackThreadId();
 
+   std::string GetConnToken() const;
+
 public:
 
    RWebWindow();
@@ -222,15 +225,11 @@ public:
    /// returns configured window height (0 - default)
    unsigned GetHeight() const { return fHeight; }
 
-   /////////////////////////////////////////////////////////////////////////
-   /// Configure maximal number of allowed connections - 0 is unlimited
-   /// Will not affect already existing connections
-   /// Default is 1 - the only client is allowed
-   void SetConnLimit(unsigned lmt = 0) { fConnLimit = lmt; }
+   void SetConnLimit(unsigned lmt = 0);
 
-   /////////////////////////////////////////////////////////////////////////
-   /// returns configured connections limit (0 - default)
-   unsigned GetConnLimit() const { return fConnLimit; }
+   unsigned GetConnLimit() const;
+
+   void SetConnToken(const std::string &token = "");
 
    /////////////////////////////////////////////////////////////////////////
    /// configures maximal queue length of data which can be held by window

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -22,7 +22,10 @@
 #include "TROOT.h"
 #include <string>
 
-ROOT::Experimental::RLogChannel &ROOT::Experimental::WebGUILog() {
+using namespace ROOT::Experimental;
+
+RLogChannel &ROOT::Experimental::WebGUILog()
+{
    static RLogChannel sLog("ROOT.WebGUI");
    return sLog;
 }
@@ -37,7 +40,7 @@ ROOT::Experimental::RLogChannel &ROOT::Experimental::WebGUILog() {
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Default constructor - browser kind configured from gROOT->GetWebDisplay()
 
-ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs()
+RWebDisplayArgs::RWebDisplayArgs()
 {
    SetBrowserKind("");
 }
@@ -46,7 +49,7 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs()
 /// Constructor - browser kind specified as std::string
 /// See SetBrowserKind() method for description of allowed parameters
 
-ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(const std::string &browser)
+RWebDisplayArgs::RWebDisplayArgs(const std::string &browser)
 {
    SetBrowserKind(browser);
 }
@@ -55,7 +58,7 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(const std::string &browser)
 /// Constructor - browser kind specified as const char *
 /// See SetBrowserKind() method for description of allowed parameters
 
-ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(const char *browser)
+RWebDisplayArgs::RWebDisplayArgs(const char *browser)
 {
    SetBrowserKind(browser);
 }
@@ -63,7 +66,7 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(const char *browser)
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Constructor - specify window width and height
 
-ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(int width, int height, int x, int y, const std::string &browser)
+RWebDisplayArgs::RWebDisplayArgs(int width, int height, int x, int y, const std::string &browser)
 {
    SetSize(width, height);
    SetPos(x, y);
@@ -73,7 +76,7 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(int width, int height, int 
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Constructor - specify master window and channel (if reserved already)
 
-ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(std::shared_ptr<RWebWindow> master, int channel)
+RWebDisplayArgs::RWebDisplayArgs(std::shared_ptr<RWebWindow> master, int channel)
 {
    SetMasterWindow(master, channel);
 }
@@ -82,7 +85,7 @@ ROOT::Experimental::RWebDisplayArgs::RWebDisplayArgs(std::shared_ptr<RWebWindow>
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Destructor
 
-ROOT::Experimental::RWebDisplayArgs::~RWebDisplayArgs()
+RWebDisplayArgs::~RWebDisplayArgs()
 {
   // must be defined here to correctly call RWebWindow destructor
 }
@@ -90,7 +93,7 @@ ROOT::Experimental::RWebDisplayArgs::~RWebDisplayArgs()
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Set size of web browser window as string like "800x600"
 
-bool ROOT::Experimental::RWebDisplayArgs::SetSizeAsStr(const std::string &str)
+bool RWebDisplayArgs::SetSizeAsStr(const std::string &str)
 {
    auto separ = str.find("x");
    if ((separ == std::string::npos) || (separ == 0) || (separ == str.length()-1)) return false;
@@ -114,7 +117,7 @@ bool ROOT::Experimental::RWebDisplayArgs::SetSizeAsStr(const std::string &str)
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Set position of web browser window as string like "100,100"
 
-bool ROOT::Experimental::RWebDisplayArgs::SetPosAsStr(const std::string &str)
+bool RWebDisplayArgs::SetPosAsStr(const std::string &str)
 {
    auto separ = str.find(",");
    if ((separ == std::string::npos) || (separ == 0) || (separ == str.length()-1)) return false;
@@ -148,7 +151,7 @@ bool ROOT::Experimental::RWebDisplayArgs::SetPosAsStr(const std::string &str)
 ///    local - either cef or qt5
 ///   <prog> - any program name which will be started instead of default browser, like /usr/bin/opera
 
-ROOT::Experimental::RWebDisplayArgs &ROOT::Experimental::RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
+RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
 {
    std::string kind = _kind;
 
@@ -216,7 +219,7 @@ ROOT::Experimental::RWebDisplayArgs &ROOT::Experimental::RWebDisplayArgs::SetBro
 /////////////////////////////////////////////////////////////////////
 /// Returns configured browser name
 
-std::string ROOT::Experimental::RWebDisplayArgs::GetBrowserName() const
+std::string RWebDisplayArgs::GetBrowserName() const
 {
    switch (GetBrowserKind()) {
       case kChrome: return "chrome";
@@ -238,7 +241,7 @@ std::string ROOT::Experimental::RWebDisplayArgs::GetBrowserName() const
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Assign window and channel id where other window will be embed
 
-void ROOT::Experimental::RWebDisplayArgs::SetMasterWindow(std::shared_ptr<RWebWindow> master, int channel)
+void RWebDisplayArgs::SetMasterWindow(std::shared_ptr<RWebWindow> master, int channel)
 {
    SetBrowserKind(kEmbedded);
    fMaster = master;
@@ -249,7 +252,7 @@ void ROOT::Experimental::RWebDisplayArgs::SetMasterWindow(std::shared_ptr<RWebWi
 /// Append string to url options
 /// Add "&" as separator if any options already exists
 
-void ROOT::Experimental::RWebDisplayArgs::AppendUrlOpt(const std::string &opt)
+void RWebDisplayArgs::AppendUrlOpt(const std::string &opt)
 {
    if (opt.empty()) return;
 
@@ -263,7 +266,7 @@ void ROOT::Experimental::RWebDisplayArgs::AppendUrlOpt(const std::string &opt)
 /// Returns full url, which is combined from URL and extra URL options
 /// Takes into account "#" symbol in url - options are inserted before that symbol
 
-std::string ROOT::Experimental::RWebDisplayArgs::GetFullUrl() const
+std::string RWebDisplayArgs::GetFullUrl() const
 {
    std::string url = GetUrl(), urlopt = GetUrlOpt();
    if (url.empty() || urlopt.empty()) return url;
@@ -285,7 +288,7 @@ std::string ROOT::Experimental::RWebDisplayArgs::GetFullUrl() const
 /// Either just name of browser which can be used like "opera"
 /// or full execution string which must includes $url like "/usr/bin/opera $url"
 
-void ROOT::Experimental::RWebDisplayArgs::SetCustomExec(const std::string &exec)
+void RWebDisplayArgs::SetCustomExec(const std::string &exec)
 {
    SetBrowserKind(kCustom);
    fExec = exec;
@@ -294,7 +297,7 @@ void ROOT::Experimental::RWebDisplayArgs::SetCustomExec(const std::string &exec)
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// returns custom executable to start web browser
 
-std::string ROOT::Experimental::RWebDisplayArgs::GetCustomExec() const
+std::string RWebDisplayArgs::GetCustomExec() const
 {
    if (GetBrowserKind() != kCustom)
       return "";
@@ -313,7 +316,7 @@ std::string ROOT::Experimental::RWebDisplayArgs::GetCustomExec() const
 /// After RWebWindow is displayed created QWebEngineView can be found with the command:
 ///     auto view = qparent->findChild<QWebEngineView*>("RootWebView");
 
-std::string ROOT::Experimental::RWebDisplayArgs::GetQt5EmbedQualifier(const void *qparent, const std::string &urlopt)
+std::string RWebDisplayArgs::GetQt5EmbedQualifier(const void *qparent, const std::string &urlopt)
 {
    std::string where = "qt5";
    if (qparent) {

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -40,14 +40,15 @@
 #include <spawn.h>
 #endif
 
+using namespace ROOT::Experimental;
 using namespace std::string_literals;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Static holder of registered creators of web displays
 
-std::map<std::string, std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Creator>> &ROOT::Experimental::RWebDisplayHandle::GetMap()
+std::map<std::string, std::unique_ptr<RWebDisplayHandle::Creator>> &RWebDisplayHandle::GetMap()
 {
-   static std::map<std::string, std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Creator>> sMap;
+   static std::map<std::string, std::unique_ptr<RWebDisplayHandle::Creator>> sMap;
    return sMap;
 }
 
@@ -57,7 +58,7 @@ std::map<std::string, std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Cre
 /// \param name - creator name like ChromeCreator
 /// \param libname - shared library name where creator could be provided
 
-std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Creator> &ROOT::Experimental::RWebDisplayHandle::FindCreator(const std::string &name, const std::string &libname)
+std::unique_ptr<RWebDisplayHandle::Creator> &RWebDisplayHandle::FindCreator(const std::string &name, const std::string &libname)
 {
    auto &m = GetMap();
    auto search = m.find(name);
@@ -79,7 +80,7 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Creator> &ROOT::Experimen
    if (search != m.end())
       return search->second;
 
-   static std::unique_ptr<ROOT::Experimental::RWebDisplayHandle::Creator> dummy;
+   static std::unique_ptr<RWebDisplayHandle::Creator> dummy;
    return dummy;
 }
 
@@ -135,7 +136,7 @@ public:
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Class to handle starting of web-browsers like Chrome or Firefox
 
-ROOT::Experimental::RWebDisplayHandle::BrowserCreator::BrowserCreator(bool custom, const std::string &exec)
+RWebDisplayHandle::BrowserCreator::BrowserCreator(bool custom, const std::string &exec)
 {
    if (custom) return;
 
@@ -165,7 +166,7 @@ ROOT::Experimental::RWebDisplayHandle::BrowserCreator::BrowserCreator(bool custo
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Check if browser executable exists and can be used
 
-void ROOT::Experimental::RWebDisplayHandle::BrowserCreator::TestProg(const std::string &nexttry, bool check_std_paths)
+void RWebDisplayHandle::BrowserCreator::TestProg(const std::string &nexttry, bool check_std_paths)
 {
    if (nexttry.empty() || !fProg.empty())
       return;
@@ -199,8 +200,8 @@ void ROOT::Experimental::RWebDisplayHandle::BrowserCreator::TestProg(const std::
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Display given URL in web browser
 
-std::unique_ptr<ROOT::Experimental::RWebDisplayHandle>
-ROOT::Experimental::RWebDisplayHandle::BrowserCreator::Display(const RWebDisplayArgs &args)
+std::unique_ptr<RWebDisplayHandle>
+RWebDisplayHandle::BrowserCreator::Display(const RWebDisplayArgs &args)
 {
    std::string url = args.GetFullUrl();
    if (url.empty())
@@ -359,7 +360,7 @@ ROOT::Experimental::RWebDisplayHandle::BrowserCreator::Display(const RWebDisplay
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Constructor
 
-ROOT::Experimental::RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserCreator(true)
+RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserCreator(true)
 {
    TestProg(gEnv->GetValue("WebGui.Chrome", ""));
 
@@ -391,7 +392,7 @@ ROOT::Experimental::RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserC
 /// Replace $geometry placeholder with geometry settings
 /// Also RWebDisplayArgs::GetExtraArgs() are appended
 
-void ROOT::Experimental::RWebDisplayHandle::ChromeCreator::ProcessGeometry(std::string &exec, const RWebDisplayArgs &args)
+void RWebDisplayHandle::ChromeCreator::ProcessGeometry(std::string &exec, const RWebDisplayArgs &args)
 {
    std::string geometry;
    if ((args.GetWidth() > 0) && (args.GetHeight() > 0))
@@ -417,7 +418,7 @@ void ROOT::Experimental::RWebDisplayHandle::ChromeCreator::ProcessGeometry(std::
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Handle profile argument
 
-std::string ROOT::Experimental::RWebDisplayHandle::ChromeCreator::MakeProfile(std::string &exec, bool)
+std::string RWebDisplayHandle::ChromeCreator::MakeProfile(std::string &exec, bool)
 {
    std::string rmdir, profile_arg;
 
@@ -441,7 +442,7 @@ std::string ROOT::Experimental::RWebDisplayHandle::ChromeCreator::MakeProfile(st
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Constructor
 
-ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::FirefoxCreator() : BrowserCreator(true)
+RWebDisplayHandle::FirefoxCreator::FirefoxCreator() : BrowserCreator(true)
 {
    TestProg(gEnv->GetValue("WebGui.Firefox", ""));
 
@@ -469,7 +470,7 @@ ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::FirefoxCreator() : Browse
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Create Firefox profile to run independent browser window
 
-std::string ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::MakeProfile(std::string &exec, bool batch_mode)
+std::string RWebDisplayHandle::FirefoxCreator::MakeProfile(std::string &exec, bool batch_mode)
 {
    std::string rmdir, profile_arg;
 
@@ -509,7 +510,7 @@ std::string ROOT::Experimental::RWebDisplayHandle::FirefoxCreator::MakeProfile(s
 /// Returns RWebDisplayHandle, which holds information of running browser application
 /// Can be used fully independent from RWebWindow classes just to show any web page
 
-std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> ROOT::Experimental::RWebDisplayHandle::Display(const RWebDisplayArgs &args)
+std::unique_ptr<RWebDisplayHandle> RWebDisplayHandle::Display(const RWebDisplayArgs &args)
 {
    std::unique_ptr<RWebDisplayHandle> handle;
 
@@ -573,7 +574,7 @@ std::unique_ptr<ROOT::Experimental::RWebDisplayHandle> ROOT::Experimental::RWebD
 ///     auto handle = RWebDisplayHandle::Display(args);
 /// ~~~
 
-bool ROOT::Experimental::RWebDisplayHandle::DisplayUrl(const std::string &url)
+bool RWebDisplayHandle::DisplayUrl(const std::string &url)
 {
    RWebDisplayArgs args;
    args.SetUrl(url);
@@ -589,7 +590,7 @@ bool ROOT::Experimental::RWebDisplayHandle::DisplayUrl(const std::string &url)
 /// Produce image file using JSON data as source
 /// Invokes JSROOT drawing functionality in headless browser - Google Chrome
 
-bool ROOT::Experimental::RWebDisplayHandle::ProduceImage(const std::string &fname, const std::string &json, int width, int height)
+bool RWebDisplayHandle::ProduceImage(const std::string &fname, const std::string &json, int width, int height)
 {
    if (json.empty())
       return false;
@@ -763,7 +764,7 @@ try_again:
    // remove target image file - we use it as detection when chrome is ready
    gSystem->Unlink(tgtfilename.Data());
 
-   auto handle = ROOT::Experimental::RWebDisplayHandle::Display(args);
+   auto handle = RWebDisplayHandle::Display(args);
 
    if (!handle) {
       R__LOG_DEBUG(0, WebGUILog()) << "Cannot start " << args.GetBrowserName() << " to produce image " << fname;

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -30,13 +30,14 @@
 #include <algorithm>
 #include <fstream>
 
+using namespace ROOT::Experimental;
 using namespace std::string_literals;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Destructor for WebConn
 /// Notify special HTTP request which blocks headless browser from exit
 
-ROOT::Experimental::RWebWindow::WebConn::~WebConn()
+RWebWindow::WebConn::~WebConn()
 {
    if (fHold) {
       fHold->SetTextContent("console.log('execute holder script');  if (window) setTimeout (window.close, 1000); if (window) window.close();");
@@ -69,13 +70,13 @@ using RWebWindow::Send() method and call-back function assigned via RWebWindow::
 /// RWebWindow constructor
 /// Should be defined here because of std::unique_ptr<RWebWindowWSHandler>
 
-ROOT::Experimental::RWebWindow::RWebWindow() = default;
+RWebWindow::RWebWindow() = default;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// RWebWindow destructor
 /// Closes all connections and remove window from manager
 
-ROOT::Experimental::RWebWindow::~RWebWindow()
+RWebWindow::~RWebWindow()
 {
    if (fMaster)
       fMaster->RemoveEmbedWindow(fMasterConnId, fMasterChannel);
@@ -110,7 +111,7 @@ ROOT::Experimental::RWebWindow::~RWebWindow()
 /// It uses "file:rootui5sys/panel/panel.html" as default HTML page
 /// At the moment only FitPanel is existing
 
-void ROOT::Experimental::RWebWindow::SetPanelName(const std::string &name)
+void RWebWindow::SetPanelName(const std::string &name)
 {
    {
       std::lock_guard<std::mutex> grd(fConnMutex);
@@ -127,8 +128,8 @@ void ROOT::Experimental::RWebWindow::SetPanelName(const std::string &name)
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Assigns manager reference, window id and creates websocket handler, used for communication with the clients
 
-std::shared_ptr<ROOT::Experimental::RWebWindowWSHandler>
-ROOT::Experimental::RWebWindow::CreateWSHandler(std::shared_ptr<RWebWindowsManager> mgr, unsigned id, double tmout)
+std::shared_ptr<RWebWindowWSHandler>
+RWebWindow::CreateWSHandler(std::shared_ptr<RWebWindowsManager> mgr, unsigned id, double tmout)
 {
    fMgr = mgr;
    fId = id;
@@ -144,7 +145,7 @@ ROOT::Experimental::RWebWindow::CreateWSHandler(std::shared_ptr<RWebWindowsManag
 /// Return URL string to access web window
 /// If remote flag is specified, real HTTP server will be started automatically
 
-std::string ROOT::Experimental::RWebWindow::GetUrl(bool remote)
+std::string RWebWindow::GetUrl(bool remote)
 {
    return fMgr->GetUrl(*this, remote);
 }
@@ -152,7 +153,7 @@ std::string ROOT::Experimental::RWebWindow::GetUrl(bool remote)
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Return THttpServer instance serving requests to the window
 
-THttpServer *ROOT::Experimental::RWebWindow::GetServer()
+THttpServer *RWebWindow::GetServer()
 {
    return fMgr->GetServer();
 }
@@ -162,7 +163,7 @@ THttpServer *ROOT::Experimental::RWebWindow::GetServer()
 /// See ROOT::Experimental::RWebWindowsManager::Show() docu for more info
 /// returns (future) connection id (or 0 when fails)
 
-unsigned ROOT::Experimental::RWebWindow::Show(const RWebDisplayArgs &args)
+unsigned RWebWindow::Show(const RWebDisplayArgs &args)
 {
    return fMgr->ShowWindow(*this, false, args);
 }
@@ -173,7 +174,7 @@ unsigned ROOT::Experimental::RWebWindow::Show(const RWebDisplayArgs &args)
 /// See ROOT::Experimental::RWebWindowsManager::Show() docu for more info
 /// returns (future) connection id (or 0 when fails)
 
-unsigned ROOT::Experimental::RWebWindow::MakeBatch(bool create_new, const RWebDisplayArgs &args)
+unsigned RWebWindow::MakeBatch(bool create_new, const RWebDisplayArgs &args)
 {
    unsigned connid = 0;
    if (!create_new)
@@ -188,7 +189,7 @@ unsigned ROOT::Experimental::RWebWindow::MakeBatch(bool create_new, const RWebDi
 /// Connection to that job may not be initialized yet
 /// If connection does not exists, returns 0
 
-unsigned ROOT::Experimental::RWebWindow::FindBatch()
+unsigned RWebWindow::FindBatch()
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -211,7 +212,7 @@ unsigned ROOT::Experimental::RWebWindow::FindBatch()
 /// Batch jobs will be ignored here
 /// Returns 0 if connection not exists
 
-unsigned ROOT::Experimental::RWebWindow::GetDisplayConnection() const
+unsigned RWebWindow::GetDisplayConnection() const
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -232,7 +233,7 @@ unsigned ROOT::Experimental::RWebWindow::GetDisplayConnection() const
 /// Find connection with given websocket id
 /// Connection mutex should be locked before method calling
 
-std::shared_ptr<ROOT::Experimental::RWebWindow::WebConn> ROOT::Experimental::RWebWindow::FindOrCreateConnection(unsigned wsid, bool make_new, const char *query)
+std::shared_ptr<RWebWindow::WebConn> RWebWindow::FindOrCreateConnection(unsigned wsid, bool make_new, const char *query)
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -279,7 +280,7 @@ std::shared_ptr<ROOT::Experimental::RWebWindow::WebConn> ROOT::Experimental::RWe
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Remove connection with given websocket id
 
-std::shared_ptr<ROOT::Experimental::RWebWindow::WebConn> ROOT::Experimental::RWebWindow::RemoveConnection(unsigned wsid)
+std::shared_ptr<RWebWindow::WebConn> RWebWindow::RemoveConnection(unsigned wsid)
 {
 
    std::shared_ptr<WebConn> res;
@@ -308,7 +309,7 @@ std::shared_ptr<ROOT::Experimental::RWebWindow::WebConn> ROOT::Experimental::RWe
 /// Such requests should not be replied for the long time
 /// Be aware that function called directly from THttpServer thread, which is not same thread as window
 
-bool ROOT::Experimental::RWebWindow::ProcessBatchHolder(std::shared_ptr<THttpCallArg> &arg)
+bool RWebWindow::ProcessBatchHolder(std::shared_ptr<THttpCallArg> &arg)
 {
    std::string query = arg->GetQuery();
 
@@ -356,7 +357,7 @@ bool ROOT::Experimental::RWebWindow::ProcessBatchHolder(std::shared_ptr<THttpCal
 /// Provide data to user callback
 /// User callback must be executed in the window thread
 
-void ROOT::Experimental::RWebWindow::ProvideQueueEntry(unsigned connid, EQueueEntryKind kind, std::string &&arg)
+void RWebWindow::ProvideQueueEntry(unsigned connid, EQueueEntryKind kind, std::string &&arg)
 {
    {
       std::lock_guard<std::mutex> grd(fInputQueueMutex);
@@ -370,7 +371,7 @@ void ROOT::Experimental::RWebWindow::ProvideQueueEntry(unsigned connid, EQueueEn
 /// Invoke callbacks with existing data
 /// Must be called from appropriate thread
 
-void ROOT::Experimental::RWebWindow::InvokeCallbacks(bool force)
+void RWebWindow::InvokeCallbacks(bool force)
 {
    if (fCallbacksThrdIdSet && (fCallbacksThrdId != std::this_thread::get_id()) && !force)
       return;
@@ -414,7 +415,7 @@ void ROOT::Experimental::RWebWindow::InvokeCallbacks(bool force)
 /// Key is random number generated when starting new window
 /// When client is connected, key should be supplied to correctly identify it
 
-unsigned ROOT::Experimental::RWebWindow::AddDisplayHandle(bool batch_mode, const std::string &key, std::unique_ptr<RWebDisplayHandle> &handle)
+unsigned RWebWindow::AddDisplayHandle(bool batch_mode, const std::string &key, std::unique_ptr<RWebDisplayHandle> &handle)
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -432,7 +433,7 @@ unsigned ROOT::Experimental::RWebWindow::AddDisplayHandle(bool batch_mode, const
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Returns true if provided key value already exists (in processes map or in existing connections)
 
-bool ROOT::Experimental::RWebWindow::HasKey(const std::string &key) const
+bool RWebWindow::HasKey(const std::string &key) const
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -453,7 +454,7 @@ bool ROOT::Experimental::RWebWindow::HasKey(const std::string &key) const
 /// Check if started process(es) establish connection. After timeout such processed will be killed
 /// Method invoked from http server thread, therefore appropriate mutex must be used on all relevant data
 
-void ROOT::Experimental::RWebWindow::CheckPendingConnections()
+void RWebWindow::CheckPendingConnections()
 {
    if (!fMgr) return;
 
@@ -488,7 +489,7 @@ void ROOT::Experimental::RWebWindow::CheckPendingConnections()
 /// Check if there are connection which are inactive for longer time
 /// For instance, batch browser will be stopped if no activity for 30 sec is there
 
-void ROOT::Experimental::RWebWindow::CheckInactiveConnections()
+void RWebWindow::CheckInactiveConnections()
 {
    timestamp_t stamp = std::chrono::system_clock::now();
 
@@ -523,7 +524,7 @@ void ROOT::Experimental::RWebWindow::CheckInactiveConnections()
 /// Will not affect already existing connections
 /// Default is 1 - the only client is allowed
 
-void ROOT::Experimental::RWebWindow::SetConnLimit(unsigned lmt)
+void RWebWindow::SetConnLimit(unsigned lmt)
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -533,7 +534,7 @@ void ROOT::Experimental::RWebWindow::SetConnLimit(unsigned lmt)
 /////////////////////////////////////////////////////////////////////////
 /// returns configured connections limit (0 - default)
 
-unsigned ROOT::Experimental::RWebWindow::GetConnLimit() const
+unsigned RWebWindow::GetConnLimit() const
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -545,7 +546,7 @@ unsigned ROOT::Experimental::RWebWindow::GetConnLimit() const
 /// When specified, in URL of webpage such token should be provided as &token=value parameter,
 /// otherwise web window will refuse connection
 
-void ROOT::Experimental::RWebWindow::SetConnToken(const std::string &token)
+void RWebWindow::SetConnToken(const std::string &token)
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -555,7 +556,7 @@ void ROOT::Experimental::RWebWindow::SetConnToken(const std::string &token)
 /////////////////////////////////////////////////////////////////////////
 /// Returns configured connection token
 
-std::string ROOT::Experimental::RWebWindow::GetConnToken() const
+std::string RWebWindow::GetConnToken() const
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -566,7 +567,7 @@ std::string ROOT::Experimental::RWebWindow::GetConnToken() const
 /// Processing of websockets call-backs, invoked from RWebWindowWSHandler
 /// Method invoked from http server thread, therefore appropriate mutex must be used on all relevant data
 
-bool ROOT::Experimental::RWebWindow::ProcessWS(THttpCallArg &arg)
+bool RWebWindow::ProcessWS(THttpCallArg &arg)
 {
    if (arg.GetWSId() == 0)
       return true;
@@ -744,7 +745,7 @@ bool ROOT::Experimental::RWebWindow::ProcessWS(THttpCallArg &arg)
    return true;
 }
 
-void ROOT::Experimental::RWebWindow::CompleteWSSend(unsigned wsid)
+void RWebWindow::CompleteWSSend(unsigned wsid)
 {
    auto conn = FindConnection(wsid);
 
@@ -763,7 +764,7 @@ void ROOT::Experimental::RWebWindow::CompleteWSSend(unsigned wsid)
 /// Prepare text part of send data
 /// Should be called under locked connection mutex
 
-std::string ROOT::Experimental::RWebWindow::_MakeSendHeader(std::shared_ptr<WebConn> &conn, bool txt, const std::string &data, int chid)
+std::string RWebWindow::_MakeSendHeader(std::shared_ptr<WebConn> &conn, bool txt, const std::string &data, int chid)
 {
    std::string buf;
 
@@ -810,7 +811,7 @@ std::string ROOT::Experimental::RWebWindow::_MakeSendHeader(std::shared_ptr<WebC
 /// Checks if one should send data for specified connection
 /// Returns true when send operation was performed
 
-bool ROOT::Experimental::RWebWindow::CheckDataToSend(std::shared_ptr<WebConn> &conn)
+bool RWebWindow::CheckDataToSend(std::shared_ptr<WebConn> &conn)
 {
    std::string hdr, data;
 
@@ -858,7 +859,7 @@ bool ROOT::Experimental::RWebWindow::CheckDataToSend(std::shared_ptr<WebConn> &c
 /// Checks if new data can be send (internal use only)
 /// If necessary, provide credits to the client
 
-void ROOT::Experimental::RWebWindow::CheckDataToSend(bool only_once)
+void RWebWindow::CheckDataToSend(bool only_once)
 {
    // make copy of all connections to be independent later, only active connections are checked
    auto arr = GetConnections(0, true);
@@ -878,7 +879,7 @@ void ROOT::Experimental::RWebWindow::CheckDataToSend(bool only_once)
 ///////////////////////////////////////////////////////////////////////////////////
 /// Special method to process all internal activity when window runs in separate thread
 
-void ROOT::Experimental::RWebWindow::Sync()
+void RWebWindow::Sync()
 {
    InvokeCallbacks();
 
@@ -892,7 +893,7 @@ void ROOT::Experimental::RWebWindow::Sync()
 ///////////////////////////////////////////////////////////////////////////////////
 /// Returns window address which is used in URL
 
-std::string ROOT::Experimental::RWebWindow::GetAddr() const
+std::string RWebWindow::GetAddr() const
 {
     return fWSHandler->GetName();
 }
@@ -902,7 +903,7 @@ std::string ROOT::Experimental::RWebWindow::GetAddr() const
 /// Address can be required if one needs to access data from one window into another window
 /// Used for instance when inserting panel into canvas
 
-std::string ROOT::Experimental::RWebWindow::GetRelativeAddr(const std::shared_ptr<RWebWindow> &win) const
+std::string RWebWindow::GetRelativeAddr(const std::shared_ptr<RWebWindow> &win) const
 {
    if (fMgr != win->fMgr) {
       R__LOG_ERROR(WebGUILog()) << "Same web window manager should be used";
@@ -921,7 +922,7 @@ std::string ROOT::Experimental::RWebWindow::GetRelativeAddr(const std::shared_pt
 /// Default is empty value - no extra string in URL
 /// Version should be string like "1.2" or "ver1.subv2" and not contain any special symbols
 
-void ROOT::Experimental::RWebWindow::SetClientVersion(const std::string &vers)
+void RWebWindow::SetClientVersion(const std::string &vers)
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
    fClientVersion = vers;
@@ -930,7 +931,7 @@ void ROOT::Experimental::RWebWindow::SetClientVersion(const std::string &vers)
 /////////////////////////////////////////////////////////////////////////
 /// Returns current client version
 
-std::string ROOT::Experimental::RWebWindow::GetClientVersion() const
+std::string RWebWindow::GetClientVersion() const
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
    return fClientVersion;
@@ -941,7 +942,7 @@ std::string ROOT::Experimental::RWebWindow::GetClientVersion() const
 /// This JSON code injected into main HTML document into JSROOT.connectWebWindow()
 /// Must be called before RWebWindow::Show() method is called
 
-void ROOT::Experimental::RWebWindow::SetUserArgs(const std::string &args)
+void RWebWindow::SetUserArgs(const std::string &args)
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
    fUserArgs = args;
@@ -951,7 +952,7 @@ void ROOT::Experimental::RWebWindow::SetUserArgs(const std::string &args)
 /// Returns configured user arguments for web window
 /// See \ref SetUserArgs method for more details
 
-std::string ROOT::Experimental::RWebWindow::GetUserArgs() const
+std::string RWebWindow::GetUserArgs() const
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
    return fUserArgs;
@@ -960,7 +961,7 @@ std::string ROOT::Experimental::RWebWindow::GetUserArgs() const
 ///////////////////////////////////////////////////////////////////////////////////
 /// Returns current number of active clients connections
 
-int ROOT::Experimental::RWebWindow::NumConnections(bool with_pending) const
+int RWebWindow::NumConnections(bool with_pending) const
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
    auto sz = fConn.size();
@@ -977,7 +978,7 @@ int ROOT::Experimental::RWebWindow::NumConnections(bool with_pending) const
 /// If empty file name is provided, data recording will be disabled
 /// Recorded data can be used in JSROOT directly to test client code without running C++ server
 
-void ROOT::Experimental::RWebWindow::RecordData(const std::string &fname, const std::string &fprefix)
+void RWebWindow::RecordData(const std::string &fname, const std::string &fprefix)
 {
    fProtocolFileName = fname;
    fProtocolCnt = fProtocolFileName.empty() ? -1 : 0;
@@ -991,7 +992,7 @@ void ROOT::Experimental::RWebWindow::RecordData(const std::string &fname, const 
 /// Only active connections are returned - where clients confirms connection
 /// Total number of connections can be retrieved with NumConnections() method
 
-unsigned ROOT::Experimental::RWebWindow::GetConnectionId(int num) const
+unsigned RWebWindow::GetConnectionId(int num) const
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
    return ((num >= 0) && (num < (int)fConn.size()) && fConn[num]->fActive) ? fConn[num]->fConnId : 0;
@@ -1002,7 +1003,7 @@ unsigned ROOT::Experimental::RWebWindow::GetConnectionId(int num) const
 /// connid is connection (0 - any)
 /// if only_active==false, also inactive connections check or connections which should appear
 
-bool ROOT::Experimental::RWebWindow::HasConnection(unsigned connid, bool only_active) const
+bool RWebWindow::HasConnection(unsigned connid, bool only_active) const
 {
    std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -1027,7 +1028,7 @@ bool ROOT::Experimental::RWebWindow::HasConnection(unsigned connid, bool only_ac
 /// Normally leads to closing of all correspondent browser windows
 /// Some browsers (like firefox) do not allow by default to close window
 
-void ROOT::Experimental::RWebWindow::CloseConnections()
+void RWebWindow::CloseConnections()
 {
    SubmitData(0, true, "CLOSE", 0);
 }
@@ -1036,7 +1037,7 @@ void ROOT::Experimental::RWebWindow::CloseConnections()
 /// Close specified connection
 /// Connection id usually appears in the correspondent call-backs
 
-void ROOT::Experimental::RWebWindow::CloseConnection(unsigned connid)
+void RWebWindow::CloseConnection(unsigned connid)
 {
    if (connid)
       SubmitData(connid, true, "CLOSE", 0);
@@ -1045,7 +1046,7 @@ void ROOT::Experimental::RWebWindow::CloseConnection(unsigned connid)
 ///////////////////////////////////////////////////////////////////////////////////
 /// returns connection (or all active connections)
 
-ROOT::Experimental::RWebWindow::ConnectionsList_t ROOT::Experimental::RWebWindow::GetConnections(unsigned connid, bool only_active) const
+RWebWindow::ConnectionsList_t RWebWindow::GetConnections(unsigned connid, bool only_active) const
 {
    ConnectionsList_t arr;
 
@@ -1071,7 +1072,7 @@ ROOT::Experimental::RWebWindow::ConnectionsList_t ROOT::Experimental::RWebWindow
 /// if direct==true, checks if direct sending (without queuing) is possible
 /// if connid==0, all existing connections are checked
 
-bool ROOT::Experimental::RWebWindow::CanSend(unsigned connid, bool direct) const
+bool RWebWindow::CanSend(unsigned connid, bool direct) const
 {
    auto arr = GetConnections(connid, direct); // for direct sending connection has to be active
 
@@ -1096,7 +1097,7 @@ bool ROOT::Experimental::RWebWindow::CanSend(unsigned connid, bool direct) const
 /// if connid==0, maximal value for all connections is returned
 /// If wrong connection is specified, -1 is return
 
-int ROOT::Experimental::RWebWindow::GetSendQueueLength(unsigned connid) const
+int RWebWindow::GetSendQueueLength(unsigned connid) const
 {
    int maxq = -1;
 
@@ -1115,7 +1116,7 @@ int ROOT::Experimental::RWebWindow::GetSendQueueLength(unsigned connid) const
 /// Allows to specify channel. chid==1 is normal communication, chid==0 for internal with higher priority
 /// If connid==0, data will be send to all connections
 
-void ROOT::Experimental::RWebWindow::SubmitData(unsigned connid, bool txt, std::string &&data, int chid)
+void RWebWindow::SubmitData(unsigned connid, bool txt, std::string &&data, int chid)
 {
    if (fMaster)
       return fMaster->SubmitData(fMasterConnId, txt, std::move(data), fMasterChannel);
@@ -1170,7 +1171,7 @@ void ROOT::Experimental::RWebWindow::SubmitData(unsigned connid, bool txt, std::
 /// Sends data to specified connection
 /// If connid==0, data will be send to all connections
 
-void ROOT::Experimental::RWebWindow::Send(unsigned connid, const std::string &data)
+void RWebWindow::Send(unsigned connid, const std::string &data)
 {
    SubmitData(connid, true, std::string(data), 1);
 }
@@ -1179,7 +1180,7 @@ void ROOT::Experimental::RWebWindow::Send(unsigned connid, const std::string &da
 /// Send binary data to specified connection
 /// If connid==0, data will be sent to all connections
 
-void ROOT::Experimental::RWebWindow::SendBinary(unsigned connid, std::string &&data)
+void RWebWindow::SendBinary(unsigned connid, std::string &&data)
 {
    SubmitData(connid, false, std::move(data), 1);
 }
@@ -1188,7 +1189,7 @@ void ROOT::Experimental::RWebWindow::SendBinary(unsigned connid, std::string &&d
 /// Send binary data to specified connection
 /// If connid==0, data will be sent to all connections
 
-void ROOT::Experimental::RWebWindow::SendBinary(unsigned connid, const void *data, std::size_t len)
+void RWebWindow::SendBinary(unsigned connid, const void *data, std::size_t len)
 {
    std::string buf;
    buf.resize(len);
@@ -1199,7 +1200,7 @@ void ROOT::Experimental::RWebWindow::SendBinary(unsigned connid, const void *dat
 ///////////////////////////////////////////////////////////////////////////////////
 /// Assign thread id which has to be used for callbacks
 
-void ROOT::Experimental::RWebWindow::AssignCallbackThreadId()
+void RWebWindow::AssignCallbackThreadId()
 {
    fCallbacksThrdIdSet = true;
    fCallbacksThrdId = std::this_thread::get_id();
@@ -1232,7 +1233,7 @@ void ROOT::Experimental::RWebWindow::AssignCallbackThreadId()
 /// win->Show();
 /// ~~~
 
-void ROOT::Experimental::RWebWindow::SetDataCallBack(WebWindowDataCallback_t func)
+void RWebWindow::SetDataCallBack(WebWindowDataCallback_t func)
 {
    AssignCallbackThreadId();
    fDataCallback = func;
@@ -1241,7 +1242,7 @@ void ROOT::Experimental::RWebWindow::SetDataCallBack(WebWindowDataCallback_t fun
 /////////////////////////////////////////////////////////////////////////////////
 /// Set call-back function for new connection
 
-void ROOT::Experimental::RWebWindow::SetConnectCallBack(WebWindowConnectCallback_t func)
+void RWebWindow::SetConnectCallBack(WebWindowConnectCallback_t func)
 {
    AssignCallbackThreadId();
    fConnCallback = func;
@@ -1250,7 +1251,7 @@ void ROOT::Experimental::RWebWindow::SetConnectCallBack(WebWindowConnectCallback
 /////////////////////////////////////////////////////////////////////////////////
 /// Set call-back function for disconnecting
 
-void ROOT::Experimental::RWebWindow::SetDisconnectCallBack(WebWindowConnectCallback_t func)
+void RWebWindow::SetDisconnectCallBack(WebWindowConnectCallback_t func)
 {
    AssignCallbackThreadId();
    fDisconnCallback = func;
@@ -1259,7 +1260,7 @@ void ROOT::Experimental::RWebWindow::SetDisconnectCallBack(WebWindowConnectCallb
 /////////////////////////////////////////////////////////////////////////////////
 /// Set call-backs function for connect, data and disconnect events
 
-void ROOT::Experimental::RWebWindow::SetCallBacks(WebWindowConnectCallback_t conn, WebWindowDataCallback_t data, WebWindowConnectCallback_t disconn)
+void RWebWindow::SetCallBacks(WebWindowConnectCallback_t conn, WebWindowDataCallback_t data, WebWindowConnectCallback_t disconn)
 {
    AssignCallbackThreadId();
    fConnCallback = conn;
@@ -1275,7 +1276,7 @@ void ROOT::Experimental::RWebWindow::SetCallBacks(WebWindowConnectCallback_t con
 /// First non-zero value breaks loop and result is returned.
 /// Runs application mainloop and short sleeps in-between
 
-int ROOT::Experimental::RWebWindow::WaitFor(WebWindowWaitFunc_t check)
+int RWebWindow::WaitFor(WebWindowWaitFunc_t check)
 {
    return fMgr->WaitFor(*this, check);
 }
@@ -1289,7 +1290,7 @@ int ROOT::Experimental::RWebWindow::WaitFor(WebWindowWaitFunc_t check)
 /// Runs application mainloop and short sleeps in-between
 /// WebGui.OperationTmout rootrc parameter defines waiting time in seconds
 
-int ROOT::Experimental::RWebWindow::WaitForTimed(WebWindowWaitFunc_t check)
+int RWebWindow::WaitForTimed(WebWindowWaitFunc_t check)
 {
    return fMgr->WaitFor(*this, check, true, GetOperationTmout());
 }
@@ -1303,7 +1304,7 @@ int ROOT::Experimental::RWebWindow::WaitForTimed(WebWindowWaitFunc_t check)
 /// Runs application mainloop and short sleeps in-between
 /// duration (in seconds) defines waiting time
 
-int ROOT::Experimental::RWebWindow::WaitForTimed(WebWindowWaitFunc_t check, double duration)
+int RWebWindow::WaitForTimed(WebWindowWaitFunc_t check, double duration)
 {
    return fMgr->WaitFor(*this, check, true, duration);
 }
@@ -1313,7 +1314,7 @@ int ROOT::Experimental::RWebWindow::WaitForTimed(WebWindowWaitFunc_t check, doub
 /// Run window functionality for specified time
 /// If no action can be performed - just sleep specified time
 
-void ROOT::Experimental::RWebWindow::Run(double tm)
+void RWebWindow::Run(double tm)
 {
    if (!fCallbacksThrdIdSet || (fCallbacksThrdId != std::this_thread::get_id())) {
       R__LOG_WARNING(WebGUILog()) << "Change thread id where RWebWindow is executed";
@@ -1332,7 +1333,7 @@ void ROOT::Experimental::RWebWindow::Run(double tm)
 /////////////////////////////////////////////////////////////////////////////////
 /// Add embed window
 
-unsigned ROOT::Experimental::RWebWindow::AddEmbedWindow(std::shared_ptr<RWebWindow> window, int channel)
+unsigned RWebWindow::AddEmbedWindow(std::shared_ptr<RWebWindow> window, int channel)
 {
    if (channel < 2)
       return 0;
@@ -1353,7 +1354,7 @@ unsigned ROOT::Experimental::RWebWindow::AddEmbedWindow(std::shared_ptr<RWebWind
 /////////////////////////////////////////////////////////////////////////////////
 /// Remove RWebWindow associated with the channel
 
-void ROOT::Experimental::RWebWindow::RemoveEmbedWindow(unsigned connid, int channel)
+void RWebWindow::RemoveEmbedWindow(unsigned connid, int channel)
 {
    auto arr = GetConnections(connid);
 
@@ -1369,9 +1370,9 @@ void ROOT::Experimental::RWebWindow::RemoveEmbedWindow(unsigned connid, int chan
 /// Create new RWebWindow
 /// Using default RWebWindowsManager
 
-std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RWebWindow::Create()
+std::shared_ptr<RWebWindow> RWebWindow::Create()
 {
-   return ROOT::Experimental::RWebWindowsManager::Instance()->CreateWindow();
+   return RWebWindowsManager::Instance()->CreateWindow();
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -1379,7 +1380,7 @@ std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RWebWindow::
 /// Tries to correctly close THttpServer, associated with RWebWindowsManager
 /// After that exit from process
 
-void ROOT::Experimental::RWebWindow::TerminateROOT()
+void RWebWindow::TerminateROOT()
 {
 
    // workaround to release all connection-specific handles as soon as possible
@@ -1401,7 +1402,7 @@ void ROOT::Experimental::RWebWindow::TerminateROOT()
 /// Has to be used instead of RWebWindow::Show() when window potentially can be embed into other windows
 /// Soon RWebWindow::Show() method will be done protected
 
-unsigned ROOT::Experimental::RWebWindow::ShowWindow(std::shared_ptr<RWebWindow> window, const RWebDisplayArgs &args)
+unsigned RWebWindow::ShowWindow(std::shared_ptr<RWebWindow> window, const RWebDisplayArgs &args)
 {
    if (!window)
       return 0;

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -18,6 +18,7 @@
 
 #include "THttpWSHandler.h"
 #include "TEnv.h"
+#include "TUrl.h"
 
 #include <ROOT/RWebWindow.hxx>
 
@@ -40,6 +41,19 @@ protected:
 
    void VerifyDefaultPageContent(std::shared_ptr<THttpCallArg> &arg) override
    {
+      auto token = fWindow.GetConnToken();
+      if (!token.empty()) {
+         TUrl url;
+         url.SetOptions(arg->GetQuery());
+         // refuse connection which does not provide proper token
+         if (!url.HasOption("token") || (token != url.GetValueFromOptions("token"))) {
+            // refuce loading of default web page without token
+            arg->SetContent("refused");
+            arg->Set404();
+            return;
+         }
+      }
+
       auto version = fWindow.GetClientVersion();
       if (!version.empty()) {
          std::string search = "jsrootsys/scripts/JSRoot.core."s;

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -414,6 +414,9 @@ unsigned ROOT::Experimental::RWebWindowsManager::ShowWindow(RWebWindow &win, boo
    if (user_args.GetBrowserKind() == RWebDisplayArgs::kEmbedded)
       return 0;
 
+   // place here while involves conn mutex
+   auto token = win.GetConnToken();
+
    // we book manager mutex for a longer operation,
    std::lock_guard<std::recursive_mutex> grd(fMutex);
 
@@ -462,6 +465,8 @@ unsigned ROOT::Experimental::RWebWindowsManager::ShowWindow(RWebWindow &win, boo
 
    args.AppendUrlOpt(std::string("key=") + key);
    if (batch_mode) args.AppendUrlOpt("batch_mode");
+   if (!token.empty())
+      args.AppendUrlOpt(std::string("token=") + token);
 
    if (!normal_http)
       args.SetHttpServer(GetServer());

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -34,6 +34,7 @@
 #include <thread>
 #include <chrono>
 
+using namespace ROOT::Experimental;
 
 /** \class ROOT::Experimental::RWebWindowsManager
 \ingroup webdisplay
@@ -50,9 +51,9 @@ Method RWebWindowsManager::Show() used to show window in specified location.
 /// Returns default window manager
 /// Used to display all standard ROOT elements like TCanvas or TFitPanel
 
-std::shared_ptr<ROOT::Experimental::RWebWindowsManager> &ROOT::Experimental::RWebWindowsManager::Instance()
+std::shared_ptr<RWebWindowsManager> &RWebWindowsManager::Instance()
 {
-   static std::shared_ptr<RWebWindowsManager> sInstance = std::make_shared<ROOT::Experimental::RWebWindowsManager>();
+   static std::shared_ptr<RWebWindowsManager> sInstance = std::make_shared<RWebWindowsManager>();
    return sInstance;
 }
 
@@ -70,7 +71,7 @@ static std::thread::id gWebWinMainThrd = std::this_thread::get_id();
 /// Returns true when called from main process
 /// Main process recognized at the moment when library is loaded
 
-bool ROOT::Experimental::RWebWindowsManager::IsMainThrd()
+bool RWebWindowsManager::IsMainThrd()
 {
    return std::this_thread::get_id() == gWebWinMainThrd;
 }
@@ -79,13 +80,13 @@ bool ROOT::Experimental::RWebWindowsManager::IsMainThrd()
 /// window manager constructor
 /// Required here for correct usage of unique_ptr<THttpServer>
 
-ROOT::Experimental::RWebWindowsManager::RWebWindowsManager() = default;
+RWebWindowsManager::RWebWindowsManager() = default;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// window manager destructor
 /// Required here for correct usage of unique_ptr<THttpServer>
 
-ROOT::Experimental::RWebWindowsManager::~RWebWindowsManager()
+RWebWindowsManager::~RWebWindowsManager()
 {
    if (gApplication && fServer && !fServer->IsTerminated()) {
       gApplication->Disconnect("Terminate(Int_t)", fServer.get(), "SetTerminate()");
@@ -147,7 +148,7 @@ ROOT::Experimental::RWebWindowsManager::~RWebWindowsManager()
 ///      WebGui.FastCgiServer: https://your_apache_server.com/root_cgi_path
 ///
 
-bool ROOT::Experimental::RWebWindowsManager::CreateServer(bool with_http)
+bool RWebWindowsManager::CreateServer(bool with_http)
 {
    // explicitly protect server creation
    std::lock_guard<std::recursive_mutex> grd(fMutex);
@@ -292,7 +293,7 @@ bool ROOT::Experimental::RWebWindowsManager::CreateServer(bool with_http)
 /// Creates new window
 /// To show window, RWebWindow::Show() have to be called
 
-std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RWebWindowsManager::CreateWindow()
+std::shared_ptr<RWebWindow> RWebWindowsManager::CreateWindow()
 {
 
    // we book manager mutex for a longer operation, locked again in server creation
@@ -303,7 +304,7 @@ std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RWebWindowsM
       return nullptr;
    }
 
-   std::shared_ptr<ROOT::Experimental::RWebWindow> win = std::make_shared<ROOT::Experimental::RWebWindow>();
+   std::shared_ptr<RWebWindow> win = std::make_shared<RWebWindow>();
 
    if (!win) {
       R__LOG_ERROR(WebGUILog()) << "Fail to create RWebWindow instance";
@@ -334,7 +335,7 @@ std::shared_ptr<ROOT::Experimental::RWebWindow> ROOT::Experimental::RWebWindowsM
 /// Release all references to specified window
 /// Called from RWebWindow destructor
 
-void ROOT::Experimental::RWebWindowsManager::Unregister(ROOT::Experimental::RWebWindow &win)
+void RWebWindowsManager::Unregister(RWebWindow &win)
 {
    if (win.fWSHandler)
       fServer->UnregisterWS(win.fWSHandler);
@@ -343,7 +344,7 @@ void ROOT::Experimental::RWebWindowsManager::Unregister(ROOT::Experimental::RWeb
 //////////////////////////////////////////////////////////////////////////
 /// Provide URL address to access specified window from inside or from remote
 
-std::string ROOT::Experimental::RWebWindowsManager::GetUrl(const ROOT::Experimental::RWebWindow &win, bool remote)
+std::string RWebWindowsManager::GetUrl(const RWebWindow &win, bool remote)
 {
    if (!fServer) {
       R__LOG_ERROR(WebGUILog()) << "Server instance not exists when requesting window URL";
@@ -404,7 +405,7 @@ std::string ROOT::Experimental::RWebWindowsManager::GetUrl(const ROOT::Experimen
 ///
 ///   HTTP-server related parameters documented in RWebWindowsManager::CreateServer() method
 
-unsigned ROOT::Experimental::RWebWindowsManager::ShowWindow(RWebWindow &win, bool batch_mode, const RWebDisplayArgs &user_args)
+unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, bool batch_mode, const RWebDisplayArgs &user_args)
 {
    // silently ignore regular Show() calls in batch mode
    if (!batch_mode && gROOT->IsWebDisplayBatch())
@@ -491,7 +492,7 @@ unsigned ROOT::Experimental::RWebWindowsManager::ShowWindow(RWebWindow &win, boo
 /// First non-zero value breaks waiting loop and result is returned (or 0 if time is expired).
 /// If parameter timed is true, timelimit (in seconds) defines how long to wait
 
-int ROOT::Experimental::RWebWindowsManager::WaitFor(RWebWindow &win, WebWindowWaitFunc_t check, bool timed, double timelimit)
+int RWebWindowsManager::WaitFor(RWebWindow &win, WebWindowWaitFunc_t check, bool timed, double timelimit)
 {
    int res = 0;
    int cnt = 0;
@@ -526,7 +527,7 @@ int ROOT::Experimental::RWebWindowsManager::WaitFor(RWebWindow &win, WebWindowWa
 //////////////////////////////////////////////////////////////////////////
 /// Terminate http server and ROOT application
 
-void ROOT::Experimental::RWebWindowsManager::Terminate()
+void RWebWindowsManager::Terminate()
 {
    if (fServer)
       fServer->SetTerminate();

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -326,6 +326,10 @@ std::shared_ptr<RWebWindow> RWebWindowsManager::CreateWindow()
       win->RecordData(fname, prefix);
    }
 
+   const char *token = gEnv->GetValue("WebGui.ConnToken", "");
+   if (token && *token)
+      win->SetConnToken(token);
+
    fServer->RegisterWS(wshandler);
 
    return win;

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "22/01/2021";
+   JSROOT.version_date = "29/01/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}
@@ -1155,8 +1155,13 @@
 
       let method = "GET", async = true, p = kind.indexOf(";sync");
       if (p > 0) { kind = kind.substr(0,p); async = false; }
-      if (kind === "head") method = "HEAD"; else
-      if ((kind === "post") || (kind === "multi") || (kind === "posttext")) method = "POST";
+      switch (kind) {
+         case "head": method = "HEAD"; break;
+         case "posttext": method = "POST"; kind = "text"; break;
+         case "postbuf":  method = "POST"; kind = "buf"; break;
+         case "post":
+         case "multi":  method = "POST"; kind = buf; break;
+      }
 
       xhr.kind = kind;
 
@@ -1200,7 +1205,6 @@
 
          switch(this.kind) {
             case "xml": return this.http_callback(this.responseXML);
-            case "posttext":
             case "text": return this.http_callback(this.responseText);
             case "object": return this.http_callback(JSROOT.parse(this.responseText));
             case "multi": return this.http_callback(JSROOT.parseMulti(this.responseText));
@@ -1246,6 +1250,7 @@
      *    - "xml" - returns req.responseXML
      *    - "head" - returns request itself, uses "HEAD" request method
      *    - "post" - creates post request, submits req.send(post_data)
+     *    - "postbuf" - creates post request, expectes binary data as response
      * @param {string} url - URL for the request
      * @param {string} kind - kind of requested data
      * @param {string} [post_data] - data submitted with post kind of request

--- a/js/scripts/JSRoot.geobase.js
+++ b/js/scripts/JSRoot.geobase.js
@@ -10,10 +10,14 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
      * @alias JSROOT.GEO
      */
    let geo = {
-      GradPerSegm: 6,     // grad per segment in cylinder/spherical symmetry shapes
+      GradPerSegm: 6,      // grad per segment in cylinder/spherical symmetry shapes
       CompressComp: true,  // use faces compression in composite shapes
       CompLimit: 20        // maximal number of components in composite shape
    };
+
+   const kindGeo = 0,    // TGeoNode / TGeoShape
+         kindEve = 1,    // TEveShape / TEveGeoShapeExtract
+         kindShape = 2;  // special kind for single shape handling
 
    /** @summary TGeo-related bits
      * @private */
@@ -1655,7 +1659,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
 
       let matrix = null;
 
-      if (kind === 1) {
+      if (kind === kindEve) {
          // special handling for EVE nodes
 
          matrix = new THREE.Matrix4();
@@ -2287,7 +2291,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
       if (!this.origin || !this.nodes) return null;
       let obj = this.origin[indx], clone = this.nodes[indx];
       if (!obj || !clone) return null;
-      if (clone.kind === 0) {
+      if (clone.kind === kindGeo) {
          if (obj.fVolume) return obj.fVolume.fShape;
       } else {
          return obj.fShape;
@@ -2346,7 +2350,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
        if (sublevel>this.maxdepth) this.maxdepth = sublevel;
 
        let chlds = null;
-       if (kind===0)
+       if (kind === kindGeo)
           chlds = (obj.fVolume && obj.fVolume.fNodes) ? obj.fVolume.fNodes.arr : null;
        else
           chlds = obj.fElements ? obj.fElements.arr : null;
@@ -2377,7 +2381,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
 
           let chlds = null, shape = null;
 
-          if (kind===1) {
+          if (kind === kindEve) {
              shape = obj.fShape;
              if (obj.fElements) chlds = obj.fElements.arr;
           } else if (obj.fVolume) {
@@ -2390,10 +2394,11 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
              clone.matrix = matrix.elements; // take only matrix elements, matrix will be constructed in worker
              if (clone.matrix[0] === 1) {
                 let issimple = true;
-                for (let k=1;(k<clone.matrix.length) && issimple;++k)
+                for (let k = 1; (k < clone.matrix.length) && issimple; ++k)
                    issimple = (clone.matrix[k] === ((k===5) || (k===10) || (k===15) ? 1 : 0));
                 if (issimple) delete clone.matrix;
              }
+             if (clone.matrix && (kind == kindEve)) clone.abs_matrix = true;
           }
           if (shape) {
              clone.fDX = shape.fDX;
@@ -2439,7 +2444,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
       this.plain_shape = obj;
 
       let node = {
-            id: 0, sortid: 0, kind: 2,
+            id: 0, sortid: 0, kind: kindShape,
             name: "Shape",
             nfaces: obj.nfaces,
             fDX: 1, fDY: 1, fDZ: 1, vol: 1,
@@ -2474,7 +2479,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
          clone.vis = 0; // 1 - only with last level
          delete clone.nochlds;
 
-         if (clone.kind === 0) {
+         if (clone.kind === kindGeo) {
             if (obj.fVolume) {
                if (on_screen) {
                   // on screen bits used always, childs always checked
@@ -2813,7 +2818,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
       let clone = this.nodes[entry.nodeid];
       let visible = true;
 
-      if (clone.kind === 2) {
+      if (clone.kind === kindShape) {
          let prop = { name: clone.name, nname: clone.name, shape: null, material: null, chlds: null };
          let _opacity = entry.opacity || 1;
          prop.fillcolor = new THREE.Color( entry.color ? "rgb(" + entry.color + ")" : "blue" );
@@ -2833,7 +2838,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
 
       let node = this.origin[entry.nodeid];
 
-      if (clone.kind === 1) {
+      if (clone.kind === kindEve) {
          // special handling for EVE nodes
 
          let prop = { name: geo.getObjectName(node), nname: geo.getObjectName(node), shape: node.fShape, material: null, chlds: null };
@@ -2921,7 +2926,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
          let obj3d = undefined;
 
          if (three_prnt.children)
-            for (let i=0;i<three_prnt.children.length;++i) {
+            for (let i = 0; i < three_prnt.children.length; ++i) {
                if (three_prnt.children[i].nchld === nchld) {
                   obj3d = three_prnt.children[i];
                   break;
@@ -2938,8 +2943,10 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
 
          obj3d = new THREE.Object3D();
 
-         if (node.matrix) {
-            // console.log(stack.toString(), lvl, 'matrix ', node.matrix.toString());
+         if (node.abs_matrix) {
+            obj3d.absMatrix = new THREE.Matrix4();
+            obj3d.absMatrix.fromArray(node.matrix);
+         } else if (node.matrix) {
             obj3d.matrix.fromArray(node.matrix);
             obj3d.matrix.decompose( obj3d.position, obj3d.quaternion, obj3d.scale );
          }
@@ -2952,7 +2959,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
 
          // this is only for debugging - test inversion of whole geometry
          if ((lvl==0) && (typeof options == 'object') && options.scale) {
-            if ((options.scale.x<0) || (options.scale.y<0) || (options.scale.z<0)) {
+            if ((options.scale.x < 0) || (options.scale.y < 0) || (options.scale.z < 0)) {
                obj3d.scale.copy(options.scale);
                obj3d.updateMatrix();
             }
@@ -3776,15 +3783,22 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
 
          prop.material.side = opt.doubleside ? THREE.DoubleSide : THREE.FrontSide;
 
-         let mesh = null;
+         let mesh = null, matrix = obj3d.absMatrix || obj3d.matrixWorld;
 
-         if (obj3d.matrixWorld.determinant() > -0.9) {
+         if (matrix.determinant() > -0.9) {
             mesh = new THREE.Mesh(shape.geom, prop.material);
          } else {
             mesh = createFlippedMesh(shape, prop.material);
          }
 
          obj3d.add(mesh);
+
+         if (obj3d.absMatrix) {
+            mesh.matrix.copy(obj3d.absMatrix);
+            mesh.matrix.decompose( obj3d.position, obj3d.quaternion, obj3d.scale );
+            mesh.updateMatrixWorld();
+         }
+
          // specify rendering order, required for transparency handling
          //if (obj3d.$jsroot_depth !== undefined)
          //   mesh.renderOrder = clones.maxdepth - obj3d.$jsroot_depth;

--- a/js/scripts/JSRoot.geom.js
+++ b/js/scripts/JSRoot.geom.js
@@ -601,7 +601,7 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
 
                let m1 = mesh.matrixWorld, flip;
 
-               if (m1.equals(m2)) return true
+               if (m1.equals(m2)) return true;
                if ((m1.determinant()>0) && (m2.determinant()<-0.9)) {
                   flip = THREE.Vector3(1,1,-1);
                   m2 = m2.clone().scale(flip);
@@ -1085,17 +1085,14 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
                if (!this._geom_viewer)
                menu.add("Hide", n, function(indx) {
                   let resolve = menu.painter._clones.resolveStack(intersects[indx].object.stack);
-
-                  if (resolve.obj && (resolve.node.kind === 0) && resolve.obj.fVolume) {
+                  const kindGeo = 0, kindEve = 1;
+                  if (resolve.obj && (resolve.node.kind === kindGeo) && resolve.obj.fVolume) {
                      geo.SetBit(resolve.obj.fVolume, geo.BITS.kVisThis, false);
                      geo.updateBrowserIcons(resolve.obj.fVolume, this._hpainter);
-                  } else
-                  if (resolve.obj && (resolve.node.kind === 1)) {
+                  } else if (resolve.obj && (resolve.node.kind === kindEve)) {
                      resolve.obj.fRnrSelf = false;
                      geo.updateBrowserIcons(resolve.obj, this._hpainter);
                   }
-                  // intersects[arg].object.visible = false;
-                  // this.render3D();
 
                   this.testGeomChanges();// while many volumes may disappear, recheck all of them
                });
@@ -1721,21 +1718,28 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
          if (entry.stack[0]===1) entry.custom_color = "blue";
       }
 
-      let mesh,
-          prop = this._clones.getDrawEntryProperties(entry),
+      let mesh, prop = this._clones.getDrawEntryProperties(entry),
           obj3d = this._clones.createObject3D(entry.stack, toplevel, this.ctrl);
 
       prop.material.wireframe = this.ctrl.wireframe;
 
       prop.material.side = this.ctrl.bothSides ? THREE.DoubleSide : THREE.FrontSide;
 
-      if (obj3d.matrixWorld.determinant() > -0.9) {
+      let matrix = obj3d.absMatrix || obj3d.matrixWorld;
+
+      if (matrix.determinant() > -0.9) {
          mesh = new THREE.Mesh( shape.geom, prop.material );
       } else {
          mesh = geo.createFlippedMesh(shape, prop.material);
       }
 
       obj3d.add(mesh);
+
+      if (obj3d.absMatrix) {
+         mesh.matrix.copy(obj3d.absMatrix);
+         mesh.matrix.decompose( mesh.position, mesh.quaternion, mesh.scale );
+         mesh.updateMatrixWorld();
+      }
 
       // keep full stack of nodes
       mesh.stack = entry.stack;
@@ -1846,6 +1850,7 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
    }
 
 
+   /** @summary Create geometry projection */
    TGeoPainter.prototype.doProjection = function() {
       let toplevel = this.getProjectionSource();
 
@@ -1869,7 +1874,7 @@ JSROOT.define(['d3', 'three', 'geobase', 'painter', 'base3d'], (d3, THREE, geo, 
       toplevel.traverse(mesh => {
          if (!(mesh instanceof THREE.Mesh) || !mesh.stack) return;
 
-         let geom2 = geo.projectGeometry(mesh.geometry, mesh.parent.matrixWorld, this.ctrl.project, this.ctrl.projectPos, mesh._flippedMesh);
+         let geom2 = geo.projectGeometry(mesh.geometry, mesh.parent.absMatrix || mesh.parent.matrixWorld, this.ctrl.project, this.ctrl.projectPos, mesh._flippedMesh);
 
          if (!geom2) return;
 

--- a/js/scripts/JSRoot.hierarchy.js
+++ b/js/scripts/JSRoot.hierarchy.js
@@ -2329,7 +2329,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          delete this.disp;
       }
 
-      this.createDisplay();
+      return this.createDisplay();
    }
 
    /** @summary function updates object drawings for other painters

--- a/js/scripts/JSRoot.webwindow.js
+++ b/js/scripts/JSRoot.webwindow.js
@@ -487,7 +487,12 @@ JSROOT.define([], () => {
       this.close();
       if (!href && this.href) href = this.href;
 
-      let pthis = this, ntry = 0, args = (this.key ? ("key=" + this.key) : "");
+      let pthis = this, ntry = 0,
+          args = (this.key ? ("key=" + this.key) : "");
+      if (this.token) {
+         if (args) args += "&";
+         args += "token=" + this.token;
+      }
 
       function retry_open(first_time) {
 
@@ -704,6 +709,7 @@ JSROOT.define([], () => {
          }
 
          handle.key = d.get("key");
+         handle.token = d.get("token");
 
          if (arg.first_recv) {
             arg.receiver = {

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -159,8 +159,17 @@ public:
    /** mark reply as 404 error - page/request not exists or refused */
    void Set404() { SetContentType("_404_"); }
 
+   /** Return true if reply can be postponed by server  */
+   virtual Bool_t CanPostpone() const { return kTRUE; }
+
    /** mark as postponed - reply will not be send to client immediately */
-   void SetPostponed() { SetContentType("_postponed_"); }
+   void SetPostponed()
+   {
+      if (CanPostpone())
+         SetContentType("_postponed_");
+      else
+         Set404();
+   }
 
    /** indicate that http request should response with file content */
    void SetFile(const char *filename = nullptr)

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -38,7 +38,6 @@ protected:
    Long_t fMainThrdId{0};               ///<! id of the thread for processing requests
    Bool_t fOwnThread{kFALSE};           ///<! true when specialized thread allocated for processing requests
    std::thread fThrd;                   ///<! own thread
-   Bool_t fOldProcessSignature{kFALSE}; ///<! flag used to detect usage of old signature of Process() method
 
    TString fJSROOTSYS;       ///<! location of local JSROOT files
    TString fTopName{"ROOT"}; ///<! name of top folder, default - "ROOT"
@@ -63,8 +62,6 @@ protected:
    virtual void ProcessRequest(std::shared_ptr<THttpCallArg> arg);
 
    virtual void ProcessBatchHolder(std::shared_ptr<THttpCallArg> &arg);
-
-   virtual void ProcessRequest(THttpCallArg *arg);
 
    void StopServerThread();
 

--- a/net/http/src/TFastCgi.cxx
+++ b/net/http/src/TFastCgi.cxx
@@ -176,6 +176,16 @@ Bool_t TFastCgi::Create(const char *args)
 ////////////////////////////////////////////////////////////////////////////////
 
 class TFastCgiCallArg : public THttpCallArg {
+
+protected:
+
+   void CheckWSPageContent(THttpWSHandler *) override
+   {
+      std::string search = "JSROOT.connectWebWindow({";
+      std::string replace = search + "socket_kind:\"longpoll\",";
+      ReplaceAllinContent(search, replace, true);
+   }
+
 public:
    TFastCgiCallArg() = default;
 

--- a/net/http/src/TFastCgi.cxx
+++ b/net/http/src/TFastCgi.cxx
@@ -175,6 +175,16 @@ Bool_t TFastCgi::Create(const char *args)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TFastCgiCallArg : public THttpCallArg {
+public:
+   TFastCgiCallArg() = default;
+
+   /** All FastCGI requests should be immediately replied to get slot for next */
+   Bool_t CanPostpone() const override { return kFALSE; }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 void *TFastCgi::run_func(void *args)
 {
 #ifndef HTTP_WITHOUT_FASTCGI
@@ -202,7 +212,7 @@ void *TFastCgi::run_func(void *args)
       const char *inp_method = FCGX_GetParam("REQUEST_METHOD", request.envp);
       const char *inp_length = FCGX_GetParam("CONTENT_LENGTH", request.envp);
 
-      auto arg = std::make_shared<THttpCallArg>();
+      auto arg = std::make_shared<TFastCgiCallArg>();
       if (inp_path)
          arg->SetPathAndFileName(inp_path);
       if (inp_query)

--- a/net/http/src/THttpLongPollEngine.cxx
+++ b/net/http/src/THttpLongPollEngine.cxx
@@ -100,9 +100,17 @@ void THttpLongPollEngine::Send(const void *buf, int len)
 {
    std::shared_ptr<THttpCallArg> poll;
 
+   std::string sendbuf = MakeBuffer(buf, len);
+
    {
       std::lock_guard<std::mutex> grd(fMutex);
-      poll = std::move(fPoll);
+      if (fPoll) {
+         poll = std::move(fPoll);
+      } else if (fBufKind == kNoBuf)  {
+         fBufKind = kBinBuf;
+         std::swap(fBuf, sendbuf);
+         return;
+      }
    }
 
    if(!poll) {
@@ -110,9 +118,7 @@ void THttpLongPollEngine::Send(const void *buf, int len)
       return;
    }
 
-   std::string buf2 = MakeBuffer(buf, len);
-
-   poll->SetBinaryContent(std::move(buf2));
+   poll->SetBinaryContent(std::move(sendbuf));
    poll->NotifyCondition();
 }
 
@@ -123,9 +129,18 @@ void THttpLongPollEngine::SendHeader(const char *hdr, const void *buf, int len)
 {
    std::shared_ptr<THttpCallArg> poll;
 
+   std::string sendbuf = MakeBuffer(buf, len, hdr);
+
    {
       std::lock_guard<std::mutex> grd(fMutex);
-      poll = std::move(fPoll);
+      if (fPoll) {
+         poll = std::move(fPoll);
+      } else if (fBufKind == kNoBuf)  {
+         fBufKind = kBinBuf;
+         if (!fRaw && hdr) fBufHeader = hdr;
+         std::swap(fBuf, sendbuf);
+         return;
+      }
    }
 
    if(!poll) {
@@ -133,9 +148,7 @@ void THttpLongPollEngine::SendHeader(const char *hdr, const void *buf, int len)
       return;
    }
 
-   std::string buf2 = MakeBuffer(buf, len, hdr);
-
-   poll->SetBinaryContent(std::move(buf2));
+   poll->SetBinaryContent(std::move(sendbuf));
    if (!fRaw)
       poll->SetExtraHeader("LongpollHeader", hdr);
    poll->NotifyCondition();
@@ -149,18 +162,24 @@ void THttpLongPollEngine::SendCharStar(const char *buf)
 {
    std::shared_ptr<THttpCallArg> poll;
 
+   std::string sendbuf(fRaw ? "txt:" : "");
+   sendbuf.append(buf);
+
    {
       std::lock_guard<std::mutex> grd(fMutex);
-      poll = std::move(fPoll);
+      if (fPoll) {
+         poll = std::move(fPoll);
+      } else if (fBufKind == kNoBuf) {
+         fBufKind = fRaw ? kBinBuf : kTxtBuf;
+         std::swap(fBuf, sendbuf);
+         return;
+      }
    }
 
    if(!poll) {
       Error("SendCharStart", "Operation invoked before polling request obtained");
       return;
    }
-
-   std::string sendbuf(fRaw ? "txt:" : "");
-   sendbuf.append(buf);
 
    if (fRaw) poll->SetBinaryContent(std::move(sendbuf));
         else poll->SetTextContent(std::move(sendbuf));
@@ -177,25 +196,27 @@ Bool_t THttpLongPollEngine::PreProcess(std::shared_ptr<THttpCallArg> &arg)
    if (!strstr(arg->GetQuery(), "&dummy"))
       return kFALSE;
 
-   arg->SetPostponed(); // mark http request as pending, http server should wait for notification
-
    std::shared_ptr<THttpCallArg> poll;
 
-   {
+   // if request cannot be postponed just reply it
+   if (arg->CanPostpone()) {
       std::lock_guard<std::mutex> grd(fMutex);
-      poll = std::move(fPoll);
-      fPoll = arg;         // keep reference on polling request
+      if (fBufKind != kNoBuf) {
+         // there is data which can be send directly
+         poll = arg;
+      } else {
+         arg->SetPostponed(); // mark http request as pending, http server should wait for notification
+         poll = std::move(fPoll);
+         fPoll = arg;         // keep reference on polling request
+      }
+
+   } else {
+      poll = arg;
    }
 
-   if (arg == poll)
-      Fatal("PreProcess", "Submit same THttpCallArg object once again");
-
    if (poll) {
-      Error("PreProcess", "Get next dummy request when previous not completed");
-      // if there are pending request, reply it immediately
-      // normally should never happen
-      if (fRaw) poll->SetBinaryContent(std::string("txt:") + gLongPollNope);
-           else poll->SetTextContent(std::string(gLongPollNope));
+      // if there buffered data, it will be provided
+      PostProcess(poll);
       poll->NotifyCondition();         // inform http server that request is processed
    }
 
@@ -209,15 +230,37 @@ Bool_t THttpLongPollEngine::PreProcess(std::shared_ptr<THttpCallArg> &arg)
 
 void THttpLongPollEngine::PostProcess(std::shared_ptr<THttpCallArg> &arg)
 {
-   if (fRaw) arg->SetBinaryContent(std::string("txt:") + gLongPollNope);
-        else arg->SetTextContent(std::string(gLongPollNope));
+   EBufKind kind = kNoBuf;
+   std::string sendbuf, sendhdr;
+
+   {
+      std::lock_guard<std::mutex> grd(fMutex);
+      if (fBufKind != kNoBuf) {
+         kind = fBufKind;
+         fBufKind = kNoBuf;
+         std::swap(sendbuf, fBuf);
+         std::swap(sendhdr, fBufHeader);
+      }
+   }
+
+   if (kind == kTxtBuf) {
+      arg->SetTextContent(std::move(sendbuf));
+   } else if (kind == kBinBuf) {
+      arg->SetBinaryContent(std::move(sendbuf));
+      if (!sendhdr.empty())
+         arg->SetExtraHeader("LongpollHeader", sendhdr.c_str());
+   } else if (fRaw) {
+      arg->SetBinaryContent(std::string("txt:") + gLongPollNope);
+   } else {
+      arg->SetTextContent(std::string(gLongPollNope));
+   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
-/// Indicate that polling requests is there and can be immediately invoked
+/// Indicate that polling requests is there or buffer empty and can be immediately invoked
 
 Bool_t THttpLongPollEngine::CanSendDirectly()
 {
    std::lock_guard<std::mutex> grd(fMutex);
-   return fPoll ? kTRUE : kFALSE;
+   return fPoll || (fBufKind == kNoBuf) ? kTRUE : kFALSE;
 }

--- a/net/http/src/THttpLongPollEngine.cxx
+++ b/net/http/src/THttpLongPollEngine.cxx
@@ -188,10 +188,10 @@ Bool_t THttpLongPollEngine::PreProcess(std::shared_ptr<THttpCallArg> &arg)
    }
 
    if (arg == poll)
-      Fatal("PreviewData", "Submit same THttpCallArg object once again");
+      Fatal("PreProcess", "Submit same THttpCallArg object once again");
 
    if (poll) {
-      Error("PreviewData", "Get next dummy request when previous not completed");
+      Error("PreProcess", "Get next dummy request when previous not completed");
       // if there are pending request, reply it immediately
       // normally should never happen
       if (fRaw) poll->SetBinaryContent(std::string("txt:") + gLongPollNope);

--- a/net/http/src/THttpLongPollEngine.h
+++ b/net/http/src/THttpLongPollEngine.h
@@ -25,9 +25,14 @@ class THttpLongPollEngine : public THttpWSEngine {
 
 protected:
 
+   enum EBufKind { kNoBuf, kTxtBuf, kBinBuf };
+
    bool fRaw{false};                    ///!< if true, only content can be used for data transfer
    std::mutex fMutex;                   ///!< protect polling request to use it from different threads
    std::shared_ptr<THttpCallArg> fPoll; ///!< hold polling request, which can be immediately used for the next sending
+   EBufKind fBufKind{kNoBuf};           ///!< if buffered data available
+   std::string fBuf;                    ///!< buffered data
+   std::string fBufHeader;              ///!< buffered header
    static const std::string gLongPollNope;    ///!< default reply on the longpoll request
 
    std::string MakeBuffer(const void *buf, int len, const char *hdr = nullptr);

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -754,7 +754,7 @@ void THttpServer::ProcessRequest(std::shared_ptr<THttpCallArg> arg)
 
       if (arg->fContent.empty()) {
          arg->Set404();
-      } else {
+      } else if (!arg->Is404()) {
          // replace all references on JSROOT
          if (fJSROOT.Length() > 0) {
             std::string repl("=\"");

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -713,14 +713,6 @@ void THttpServer::ProcessRequest(std::shared_ptr<THttpCallArg> arg)
       return;
    }
 
-   // this is just to support old Process(THttpCallArg*), should be deprecated after 6.20
-   fOldProcessSignature = kTRUE;
-   ProcessRequest(arg.get());
-   if (fOldProcessSignature) {
-      Error("ProcessRequest", "Deprecated signature is used, please used std::shared_ptr<THttpCallArg>");
-      return;
-   }
-
    if (arg->fFileName.IsNull() || (arg->fFileName == "index.htm") || (arg->fFileName == "default.htm")) {
 
       if (arg->fFileName == "default.htm") {
@@ -962,14 +954,6 @@ void THttpServer::ProcessRequest(std::shared_ptr<THttpCallArg> arg)
    // potentially add cors header
    if (IsCors())
       arg->AddHeader("Access-Control-Allow-Origin", GetCors());
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// \deprecated  One should use signature with std::shared_ptr
-
-void THttpServer::ProcessRequest(THttpCallArg *)
-{
-   fOldProcessSignature = kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
1. Enable webgui usage via FastCGI. While FastCGI engine can process the only request a time, it is not allowed to hold user requests for a longer time. In such case LongPollEngine will be used differently - really polling many dummy requests waiting if server wants to submit some data
2. Introduce optional token for RWebWindow connection. If specified, correspondent "token" parameter **must** be provided in URL when open the window in the browser. Planed for usage in Eve7.
3. Update JSROOT, including fix in TEveGeomShapeExtract rendering