### PR TITLE
How to access RNTuple in a BulkIO style

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -57,7 +57,9 @@ private:
    /// The number of elements written resp. available in the column
    NTupleSize_t fNElements;
    /// The currently mapped page for reading
-   RPage fCurrentPage;
+public:
+   RPage fCurrentPage;   // necessary for extracting field data in bulk
+private:
    /// The column id is used to find matching pages with content when reading
    ColumnId_t fColumnIdSource;
    /// Used to pack and unpack pages on writing/reading

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -95,7 +95,9 @@ protected:
    /// Points into fColumns.  All fields that have columns have a distinct main column. For simple fields
    /// (float, int, ...), the principal column corresponds to the field type. For collection fields expect std::array,
    /// the main column is the offset field.  Class fields have no column of their own.
-   RColumn* fPrincipalColumn;
+public:
+   RColumn* fPrincipalColumn;   // necessary for extracting field data in bulk
+protected:
    /// The columns are connected either to a sink or to a source (not to both); they are owned by the field.
    std::vector<std::unique_ptr<RColumn>> fColumns;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -172,7 +172,9 @@ private:
    std::unique_ptr<Detail::RPageSink> fSink;
    /// Needs to be destructed before fSink
    std::unique_ptr<RNTupleModel> fModel;
-   NTupleSize_t fClusterSizeEntries;
+public:
+   NTupleSize_t fClusterSizeEntries;  // public so that I can configure it (differently for each data sample)
+private:
    NTupleSize_t fLastCommitted;
    NTupleSize_t fNEntries;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -145,7 +145,9 @@ class RNTupleView {
 
 private:
    /// fFieldId has fParent always set to null; views access nested fields without looking at the parent
-   FieldT fField;
+public:
+   FieldT fField;   // necessary for extracting field data in bulk
+private:
    /// Used as a Read() destination for fields that are not mappable
    Detail::RFieldValue fValue;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -53,7 +53,7 @@ The written file can be either in ROOT format or in RNTuple bare format.
 // clang-format on
 class RPageSinkFile : public RPageSink {
 public:
-   static constexpr std::size_t kDefaultElementsPerPage = 10000;
+   static constexpr std::size_t kDefaultElementsPerPage = 64*1024*1024 / 4;  // larger than cluster (same as in TTree test)
 
 private:
    RNTupleMetrics fMetrics;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -53,7 +53,8 @@ The written file can be either in ROOT format or in RNTuple bare format.
 // clang-format on
 class RPageSinkFile : public RPageSink {
 public:
-   static constexpr std::size_t kDefaultElementsPerPage = 64*1024*1024 / 4;  // larger than cluster (same as in TTree test)
+   // static constexpr std::size_t kDefaultElementsPerPage = 64*1024*1024 / 4;  // larger than cluster (same as in TTree test)
+   static constexpr std::size_t kDefaultElementsPerPage = 2097152;  // safe to compress
 
 private:
    RNTupleMetrics fMetrics;


### PR DESCRIPTION
_This PR is not intended to be merged into ROOT! That's why it's a draft!_

The purpose of this PR is to show which private members I had to make public to access RNTuple in a BulkIO style.

Two of these changes were just to parameterize the cluster and page sizes:

   * `fClusterSizeEntries` was made public so that I could set it and make it apples-to-apples with the other formats.
   * `kDefaultElementsPerPage = 2097152` is large, but 8× less than the maximum size that can be compressed. The maximum is `0xffffff` because the header provides 3 bytes to specify the uncompressed size, so that uncompressed size can't exceed that. The number I chose here is `2**21`, which is 8× below that limit, to allow for 8-byte integers and floating point numbers. What's probably missing here is the logic for splitting the data to be compressed into a series of blocks with this maximum size. (TTree and normal serialized objects do that.)

The rest of the changes are just turning private/protected members into public ones so that they can be read directly in a BulkIO style. Here's how that's done: suppose you're filling a buffer named `array` using a `view` of type `V` returned by `GetViewCollection` or `GetView<T>`. We know the `length` of elements to read, so the function is

```c++
template <typename V, typename T>
void read_from_rntuple_view(T* buffer, V& view, int64_t& offset, int64_t length) {
  int64_t current = 0;
  while (current < length) {
    T* data = (T*)view.fField.Map(offset + current);
    int32_t num = view.fField.fPrincipalColumn->fCurrentPage.GetNElements();
    int32_t skipped = (offset + current) - view.fField.fPrincipalColumn->fCurrentPage.GetGlobalRangeFirst();
    int32_t remaining = num - skipped;
    if (current + remaining > length) {
      remaining = length - current;
    }
    if (remaining > 0) {
      std::memcpy(&buffer[current], data, remaining*sizeof(T));
    }
    current += remaining;
  }
  offset += current;
}
```

Here's a sample usage:

```c++
auto ntuple = RNTupleReader::Open(std::move(model), "rntuple", filename);
auto view3 = ntuple->GetViewCollection("field");
auto view2 = view3.GetViewCollection("std::vector<std::vector<float>>");
auto view1 = view2.GetViewCollection("std::vector<float>");
auto view0 = view1.GetView<float>("float");

int64_t offset3 = 0;
int64_t offset2 = 0;
int64_t offset1 = 0;
int64_t offset0 = 0;

for (int64_t entry = 0;  entry < num_entries_in_file;  entry += num_entries_in_cluster) {
  int64_t length = num_entries_in_cluster;
  if (entry + length > num_entries_in_file) {
    length = num_entries_in_file - entry;   // trim for last cluster
  }

  int32_t* buffer_offset3 = allocate_output_offsets<int32_t>(length + 1);
  buffer_offsets3[0] = 0; // Awkward Array and Arrow offsets are a "fencepost" around the items they contain.
                          // For RNTuple input, which has no "dead space" before the first entry,
                          // they always start at zero. As a "fencepost," buffer_offsets.size() == length + 1.
  read_from_rntuple_view(&buffer_offsets3[1], view3, offset3, length);

  length = buffer_offsets3[length];   // now "length" is the length of the second level
  int32_t* buffer_offsets2 = allocate_output_offsets<int32_t>(length + 1);
  buffer_offsets2[0] = 0;
  read_from_rntuple_view(&buffer_offsets2[1], view2, offset2, length);

  length = buffer_offsets2[length];
  int32_t* buffer_offsets1 = allocate_output_offsets<int32_t>(length + 1);
  buffer_offsets1[0] = 0;
  read_from_rntuple_view(&buffer_offsets1[1], view1, offset1, length);

  length = buffer_offsets1[length];
  float* buffer_content = allocate_output_content<float>(length);   // content is different from offsets
  read_from_rntuple_view(buffer_content, view0, offset0, length);

  return somehow_pack_together(buffer_offset3, buffer_offset2, buffer_offset1, buffer_content);
}
```