### PR TITLE
Use multiple threads in FastCGI

### DIFF
--- a/cmake/modules/FindFastCGI.cmake
+++ b/cmake/modules/FindFastCGI.cmake
@@ -10,7 +10,7 @@
 #  FASTCGI_LIBRARY     - library when using FastCGI.
 #  FASTCGI_FOUND       - true if FASTCGI found.
 
-find_path(FASTCGI_INCLUDE_DIR NAME fcgiapp.h PATH_SUFFIXES include)
+find_path(FASTCGI_INCLUDE_DIR NAME fcgiapp.h PATH_SUFFIXES include/fastcgi include)
 
 if(NOT FASTCGI_LIBRARY)
    find_library(FASTCGI_LIBRARY NAMES fcgi PATHS PATH_SUFFIXES lib)

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -141,6 +141,7 @@ RWebWindowsManager::~RWebWindowsManager()
 /// One also can configure usage of FastCGI server for web windows:
 ///
 ///      WebGui.FastCgiPort: 4000
+///      WebGui.FastCgiThreads: 10
 ///
 /// To be able start web browser for such windows, one can provide real URL of the
 /// web server which will connect with that FastCGI instance:
@@ -206,6 +207,7 @@ bool RWebWindowsManager::CreateServer(bool with_http)
    int http_wstmout = gEnv->GetValue("WebGui.HttpWSTmout", 10000);
    int http_maxage = gEnv->GetValue("WebGui.HttpMaxAge", -1);
    int fcgi_port = gEnv->GetValue("WebGui.FastCgiPort", 0);
+   int fcgi_thrds = gEnv->GetValue("WebGui.FastCgiThreads", 10);
    const char *fcgi_serv = gEnv->GetValue("WebGui.FastCgiServer", "");
    fLaunchTmout = gEnv->GetValue("WebGui.LaunchTmout", 30.);
    const char *http_loopback = gEnv->GetValue("WebGui.HttpLoopback", "no");
@@ -249,7 +251,7 @@ bool RWebWindowsManager::CreateServer(bool with_http)
       TString engine, url;
 
       if (fcgi_port > 0) {
-         engine.Form("fastcgi:%d", fcgi_port);
+         engine.Form("fastcgi:%d?thrds=%d", fcgi_port, fcgi_thrds);
          if (!fServer->CreateEngine(engine)) return false;
          if (fcgi_serv && (strlen(fcgi_serv) > 0)) fAddr = fcgi_serv;
          if (http_port < 0) return true;

--- a/net/http/src/TFastCgi.h
+++ b/net/http/src/TFastCgi.h
@@ -37,8 +37,9 @@ public:
 
    Bool_t IsTerminating() const { return fTerminating; }
 
-   void ProcessRequest(void *req);
+   Bool_t IsDebugMode() const { return fDebugMode; }
 
+   const char *GetTopName() const { return fTopName.Length() > 0 ? fTopName.Data() : nullptr; }
 };
 
 #endif

--- a/net/http/src/TFastCgi.h
+++ b/net/http/src/TFastCgi.h
@@ -14,15 +14,16 @@
 
 #include "THttpEngine.h"
 
-class TThread;
+#include <thread>
+#include <memory>
 
 class TFastCgi : public THttpEngine {
 protected:
-   Int_t fSocket;       ///<! socket used by fastcgi
-   Bool_t fDebugMode;   ///<! debug mode, may required for fastcgi debugging in other servers
-   TString fTopName;    ///<! name of top item
-   TThread *fThrd;      ///<! thread which takes requests, can be many later
-   Bool_t fTerminating; ///<! set when http server wants to terminate all engines
+   Int_t fSocket{0};            ///<! socket used by fastcgi
+   Bool_t fDebugMode{kFALSE};   ///<! debug mode, may required for fastcgi debugging in other servers
+   TString fTopName;            ///<! name of top item
+   std::unique_ptr<std::thread> fThrd;  ///<! thread which takes requests, can be many later
+   Bool_t fTerminating{kFALSE};     ///<! set when http server wants to terminate all engines
 
    virtual void Terminate() { fTerminating = kTRUE; }
 
@@ -30,11 +31,14 @@ public:
    TFastCgi();
    virtual ~TFastCgi();
 
-   Int_t GetSocket() const { return fSocket; }
-
    virtual Bool_t Create(const char *args);
 
-   static void *run_func(void *);
+   Int_t GetSocket() const { return fSocket; }
+
+   Bool_t IsTerminating() const { return fTerminating; }
+
+   void ProcessRequest(void *req);
+
 };
 
 #endif


### PR DESCRIPTION
Improve performance of FastCGI by processing several requests in parallel.
Could be real alternative now to pure `civetweb` solution concerning performance