### PR TITLE
In TBranchElement init offset avoid stripping part of the name.

### DIFF
--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -60,7 +60,7 @@ namespace {
           && (str.Data()[prefix.Length()] == '.' || (prefix[prefix.Length()-1]=='.')))
       {
          if (!str.Index(prefix))
-            str.Remove(0, strlen(prefix));
+            str.Remove(0, prefix.Length());
       }
    }
    struct R__PushCache {

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -53,12 +53,14 @@ ClassImp(TBranchElement);
 ////////////////////////////////////////////////////////////////////////////////
 
 namespace {
-   void RemovePrefix(TString& str, const char* prefix) {
+   void RemovePrefix(TString& str, const TString &prefix) {
       // -- Remove a prefix from a string.
-      if (str.Length() && prefix && strlen(prefix)) {
-         if (!str.Index(prefix)) {
+      // -- Require a '.' after the prefix.
+      if (prefix.Length() && prefix.Length() <= str.Length()
+          && (str.Data()[prefix.Length()] == '.' || (prefix[prefix.Length()-1]=='.')))
+      {
+         if (!str.Index(prefix))
             str.Remove(0, strlen(prefix));
-         }
       }
    }
    struct R__PushCache {


### PR DESCRIPTION
A prefix needs to be followed by a delimiter

This fixes ROOOT-5983.