### PR TITLE
[DF] Delay call to TTree::AddClone until first processed entry

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1277,12 +1277,8 @@ public:
 
    void InitTask(TTreeReader *r, unsigned int /* slot */)
    {
-      if (!r) // empty source, nothing to do
-         return;
-      fInputTree = r->GetTree();
-      // AddClone guarantees that if the input file changes the branches of the output tree are updated with the new
-      // addresses of the branch values
-      fInputTree->AddClone(fOutputTree.get());
+      if (r)
+         fInputTree = r->GetTree();
    }
 
    void Exec(unsigned int /* slot */, ColTypes &... values)
@@ -1292,6 +1288,10 @@ public:
          UpdateCArraysPtrs(values..., ind_t{});
       } else {
          SetBranches(values..., ind_t{});
+         // AddClone guarantees that if the input file changes the branches of the output tree are updated with the new
+         // addresses of the branch values
+         if (fInputTree != nullptr)
+            fInputTree->AddClone(fOutputTree.get());
          fIsFirstEvent = false;
       }
       UpdateBoolArrays(values..., ind_t{});


### PR DESCRIPTION
In rare cases, when processing a TChain and producing a Snapshot,
no entry in the first input TTree passes all Filters, so we never
have the chance to create the branches of the output TTree.
As a consequence, when switching from the first file to the next,
TTree::CopyAddresses fails to find the corresponding branches in
the output tree (which was added as its clone via TTree::AddClone),
and prints a warning (that can be safely ignored).

We now instead add the output tree of a Snapshot as a clone of the
input tree more lazily, only when we first process an entry (if ever).
This removes the aforementioned warning, reported at #6848.