### PR TITLE
[http] provide WS-only mode, use it for webgui

### DIFF
--- a/README/ReleaseNotes/v624/index.md
+++ b/README/ReleaseNotes/v624/index.md
@@ -121,8 +121,28 @@ For details, see the RooFit tutorial [rf612_recoverFromInvalidParameters.C](http
 
 ## Networking Libraries
 
+### Multithreaded support for FastCGI
+Now when THttpServer creates FastCGI engine, 10 worker threds used to process requests
+received via FastCGI channel. This significantly increase a performance, especially when
+several clients are connected.
+
+### Better security for THttpServer with webgui
+If THttpServer created for use with webgui widgets (RBrowser, RCanvas, REve), it only will
+provide access to the widgets via websocket connection - any other kind of requests like root.json
+or exe.json will be refused completely. Cobined with connection tokens and https protocol,
+this makes usage of webgui components in public networks more secure.
+
 
 ## GUI Libraries
+
+### RBrowser improvments
+- central factory methods to handle browsing, editing and drawing of different classes
+- simple possibility to extend RBrowser on user-defined classes
+- support of web-based geometry viewer
+- better support of TTree drawing
+- server-side handling of code editor and image viewer widgets
+- rbrowser content is fully recovered when web-browser is reloaded
+- load of widgets code only when really required (shorter startup time for RBrowser)
 
 
 ## Montecarlo Libraries

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -134,6 +134,13 @@ RWebWindowsManager::~RWebWindowsManager()
 ///
 ///      WebGui.HttpWSTmout: 10000
 ///
+/// By default, THttpServer created in restricted mode which only allows websocket handlers
+/// and processes only very few other related http requests. For security reasons such mode
+/// should be always enabled. Only if it is really necessary to process all other kinds
+/// of HTTP requests, one could specify 0 for following parameter (default 1):
+///
+///      WebGui.WSOnly: 1
+///
 /// Following parameter controls browser max-age caching parameter for files (default 3600)
 ///
 ///      WebGui.HttpMaxAge: 3600
@@ -180,6 +187,8 @@ bool RWebWindowsManager::CreateServer(bool with_http)
       if (gApplication)
          gApplication->Connect("Terminate(Int_t)", "THttpServer", fServer.get(), "SetTerminate()");
 
+      Int_t wsonly = gEnv->GetValue("WebGui.WSOnly", 1);
+      fServer->SetWSOnly(wsonly != 0);
 
       // this is location where all ROOT UI5 sources are collected
       // normally it is $ROOTSYS/ui5 or <prefix>/ui5 location

--- a/js/files/wslist.htm
+++ b/js/files/wslist.htm
@@ -1,0 +1,32 @@
+<!--  this file used to present list of WS handlers  -->
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <meta charset="UTF-8">
+      <title>List of WS handlers</title>
+   </head>
+
+   <body>
+      <div id="winlist">
+         loading list...
+      </div>
+
+      <script type='text/javascript'>
+         let lst = "$$$wslist$$$";
+
+         let elem = document.getElementById("winlist"), html = "";
+
+         if (lst && typeof lst == "object")
+            lst.forEach(entry => {
+               if (!entry.title) entry.title = "Window " + entry.name;
+               html += `<a href="${entry.name}/" title="${entry.title}">${entry.name}</a>`;
+            });
+
+         if (!html) html = "No widgets";
+
+         elem.innerHTML = html;
+
+      </script>
+   </body>
+
+</html>

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "29/01/2021";
+   JSROOT.version_date = "1/02/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}
@@ -1149,7 +1149,7 @@
       let xhr = JSROOT.nodejs ? new (require("xhr2"))() : new XMLHttpRequest();
 
       xhr.http_callback = (typeof user_accept_callback == 'function') ? user_accept_callback.bind(xhr) : function() {};
-      xhr.error_callback = (typeof user_reject_callback == 'function') ? user_reject_callback : function(err) { console.warn(err.message); this.http_callback(null); }.bind(xhr);
+      xhr.error_callback = (typeof user_reject_callback == 'function') ? user_reject_callback.bind(xhr) : function(err) { console.warn(err.message); this.http_callback(null); }.bind(xhr);
 
       if (!kind) kind = "buf";
 
@@ -1170,7 +1170,7 @@
             if (oEvent.lengthComputable && this.expected_size && (oEvent.loaded > this.expected_size)) {
                this.did_abort = true;
                this.abort();
-               this.error_callback(Error('Server sends more bytes ' + oEvent.loaded + ' than expected ' + this.expected_size + '. Abort I/O operation'));
+               this.error_callback(Error('Server sends more bytes ' + oEvent.loaded + ' than expected ' + this.expected_size + '. Abort I/O operation'), 598);
             }
          }.bind(xhr));
 
@@ -1183,7 +1183,7 @@
             if (!isNaN(len) && (len > this.expected_size) && !JSROOT.settings.HandleWrongHttpResponse) {
                this.did_abort = true;
                this.abort();
-               return this.error_callback(Error('Server response size ' + len + ' larger than expected ' + this.expected_size + '. Abort I/O operation'));
+               return this.error_callback(Error('Server response size ' + len + ' larger than expected ' + this.expected_size + '. Abort I/O operation'), 599);
             }
          }
 
@@ -1192,7 +1192,7 @@
          if ((this.status != 200) && (this.status != 206) && !browser.qt5 &&
              // in these special cases browsers not always set status
              !((this.status == 0) && ((url.indexOf("file://")==0) || (url.indexOf("blob:")==0)))) {
-               return this.error_callback(Error('Fail to load url ' + url));
+               return this.error_callback(Error('Fail to load url ' + url), this.status);
          }
 
          if (this.nodejs_checkzip && (this.getResponseHeader("content-encoding") == "gzip")) {

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -32,8 +32,8 @@ class THttpServer : public TNamed {
 
 protected:
    TList fEngines;                      ///<! engines which runs http server
-   THttpTimer *fTimer{nullptr};         ///<! timer used to access main thread
-   TRootSniffer *fSniffer{nullptr};     ///<! sniffer provides access to ROOT objects hierarchy
+   std::unique_ptr<THttpTimer> fTimer;   ///<! timer used to access main thread
+   std::unique_ptr<TRootSniffer> fSniffer; ///<! sniffer provides access to ROOT objects hierarchy
    Bool_t fTerminated{kFALSE};          ///<! termination flag, disables all requests processing
    Long_t fMainThrdId{0};               ///<! id of the thread for processing requests
    Bool_t fOwnThread{kFALSE};           ///<! true when specialized thread allocated for processing requests
@@ -67,8 +67,11 @@ protected:
 
    static Bool_t VerifyFilePath(const char *fname);
 
+   THttpServer(const THttpServer &) = delete;
+   THttpServer &operator=(const THttpServer &) = delete;
+
 public:
-   THttpServer(const char *engine = "civetweb:8080");
+   THttpServer(const char *engine = "http:8080");
    virtual ~THttpServer();
 
    Bool_t CreateEngine(const char *engine);
@@ -76,7 +79,7 @@ public:
    Bool_t IsAnyEngine() const { return fEngines.GetSize() > 0; }
 
    /** returns pointer on objects sniffer */
-   TRootSniffer *GetSniffer() const { return fSniffer; }
+   TRootSniffer *GetSniffer() const { return fSniffer.get(); }
 
    void SetSniffer(TRootSniffer *sniff);
 
@@ -151,7 +154,7 @@ public:
    /** Restrict access to specified object */
    void Restrict(const char *path, const char *options);
 
-   Bool_t RegisterCommand(const char *cmdname, const char *method, const char *icon = 0);
+   Bool_t RegisterCommand(const char *cmdname, const char *method, const char *icon = nullptr);
 
    Bool_t Hide(const char *fullname, Bool_t hide = kTRUE);
 
@@ -172,7 +175,7 @@ public:
    /** Reads content of file from the disk, use std::string in return value */
    static std::string ReadFileContent(const std::string &filename);
 
-   ClassDef(THttpServer, 0) // HTTP server for ROOT analysis
+   ClassDefOverride(THttpServer, 0) // HTTP server for ROOT analysis
 };
 
 #endif

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -38,6 +38,7 @@ protected:
    Long_t fMainThrdId{0};               ///<! id of the thread for processing requests
    Bool_t fOwnThread{kFALSE};           ///<! true when specialized thread allocated for processing requests
    std::thread fThrd;                   ///<! own thread
+   Bool_t fWSOnly{kFALSE};              ///<! when true, handle only websockets / longpoll engine
 
    TString fJSROOTSYS;       ///<! location of local JSROOT files
    TString fTopName{"ROOT"}; ///<! name of top folder, default - "ROOT"
@@ -85,7 +86,11 @@ public:
 
    Bool_t IsReadOnly() const;
 
-   void SetReadOnly(Bool_t readonly);
+   void SetReadOnly(Bool_t readonly = kTRUE);
+
+   Bool_t IsWSOnly() const;
+
+   void SetWSOnly(Bool_t on = kTRUE);
 
    /** set termination flag, no any further requests will be processed */
    void SetTerminate();

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -66,6 +66,8 @@ protected:
 
    void StopServerThread();
 
+   std::string BuildWSEntryPage();
+
    static Bool_t VerifyFilePath(const char *fname);
 
    THttpServer(const THttpServer &) = delete;

--- a/net/http/inc/TRootSniffer.h
+++ b/net/http/inc/TRootSniffer.h
@@ -242,7 +242,7 @@ public:
 
    Bool_t Produce(const std::string &path, const std::string &file, const std::string &options, std::string &res);
 
-   ClassDef(TRootSniffer, 0) // Sniffer of ROOT objects (basic version)
+   ClassDefOverride(TRootSniffer, 0) // Sniffer of ROOT objects (basic version)
 };
 
 #endif

--- a/net/http/src/TCivetweb.h
+++ b/net/http/src/TCivetweb.h
@@ -25,7 +25,7 @@ protected:
    Bool_t fOnlySecured{kFALSE}; ///<! if server should run only https protocol
    Int_t fMaxAge{3600};         ///<! max-age parameter
 
-   virtual void Terminate() { fTerminating = kTRUE; }
+   void Terminate() override { fTerminating = kTRUE; }
 
    Bool_t IsSecured() const { return fOnlySecured; }
 
@@ -33,7 +33,7 @@ public:
    TCivetweb(Bool_t only_secured = kFALSE);
    virtual ~TCivetweb();
 
-   virtual Bool_t Create(const char *args);
+   Bool_t Create(const char *args) override;
 
    const char *GetTopName() const { return fTopName.Data(); }
 

--- a/net/http/src/TFastCgi.h
+++ b/net/http/src/TFastCgi.h
@@ -25,13 +25,13 @@ protected:
    std::unique_ptr<std::thread> fThrd;  ///<! thread which takes requests, can be many later
    Bool_t fTerminating{kFALSE};     ///<! set when http server wants to terminate all engines
 
-   virtual void Terminate() { fTerminating = kTRUE; }
+   void Terminate() override { fTerminating = kTRUE; }
 
 public:
    TFastCgi();
    virtual ~TFastCgi();
 
-   virtual Bool_t Create(const char *args);
+   Bool_t Create(const char *args) override;
 
    Int_t GetSocket() const { return fSocket; }
 

--- a/net/httpsniff/inc/TRootSnifferFull.h
+++ b/net/httpsniff/inc/TRootSnifferFull.h
@@ -22,25 +22,25 @@ protected:
    TMemFile *fMemFile{nullptr}; ///<! file used to manage streamer infos
    TList *fSinfo{nullptr};      ///<! last produced streamer info
 
-   virtual void ScanObjectProperties(TRootSnifferScanRec &rec, TObject *obj);
+   void ScanObjectProperties(TRootSnifferScanRec &rec, TObject *obj) override;
 
-   virtual void ScanKeyProperties(TRootSnifferScanRec &rec, TKey *key, TObject *&obj, TClass *&obj_class);
+   void ScanKeyProperties(TRootSnifferScanRec &rec, TKey *key, TObject *&obj, TClass *&obj_class) override;
 
-   virtual void ScanObjectChilds(TRootSnifferScanRec &rec, TObject *obj);
+   void ScanObjectChilds(TRootSnifferScanRec &rec, TObject *obj) override;
 
    void CreateMemFile();
 
-   virtual Bool_t CanDrawClass(TClass *cl) { return IsDrawableClass(cl); }
+   Bool_t CanDrawClass(TClass *cl) override { return IsDrawableClass(cl); }
 
-   virtual Bool_t HasStreamerInfo() const { return kTRUE; }
+   Bool_t HasStreamerInfo() const override { return kTRUE; }
 
-   virtual Bool_t ProduceBinary(const std::string &path, const std::string &options, std::string &res);
+   Bool_t ProduceBinary(const std::string &path, const std::string &options, std::string &res) override;
 
-   virtual Bool_t ProduceImage(Int_t kind, const std::string &path, const std::string &options, std::string &res);
+   Bool_t ProduceImage(Int_t kind, const std::string &path, const std::string &options, std::string &res) override;
 
-   virtual Bool_t ProduceXml(const std::string &path, const std::string &options, std::string &res);
+   Bool_t ProduceXml(const std::string &path, const std::string &options, std::string &res) override;
 
-   virtual Bool_t ProduceExe(const std::string &path, const std::string &options, Int_t reskind, std::string &res);
+   Bool_t ProduceExe(const std::string &path, const std::string &options, Int_t reskind, std::string &res) override;
 
 public:
    TRootSnifferFull(const char *name, const char *objpath = "Objects");
@@ -48,16 +48,15 @@ public:
 
    static Bool_t IsDrawableClass(TClass *cl);
 
-   virtual Bool_t IsStreamerInfoItem(const char *itemname);
+   Bool_t IsStreamerInfoItem(const char *itemname) override;
 
-   virtual ULong_t GetStreamerInfoHash();
+   ULong_t GetStreamerInfoHash() override;
 
-   virtual ULong_t GetItemHash(const char *itemname);
+   ULong_t GetItemHash(const char *itemname) override;
 
-   virtual void *
-   FindInHierarchy(const char *path, TClass **cl = nullptr, TDataMember **member = nullptr, Int_t *chld = nullptr);
+   void *FindInHierarchy(const char *path, TClass **cl = nullptr, TDataMember **member = nullptr, Int_t *chld = nullptr) override;
 
-   ClassDef(TRootSnifferFull, 0) // Sniffer for many ROOT classes, including histograms, graphs, pads and tree
+   ClassDefOverride(TRootSnifferFull, 0) // Sniffer for many ROOT classes, including histograms, graphs, pads and tree
 };
 
 #endif

--- a/tutorials/webgui/webwindow/client.html
+++ b/tutorials/webgui/webwindow/client.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>RWebWindow test</title>
-    <script src="/jsrootsys/scripts/JSRoot.core.js" type="text/javascript"></script>
+    <script src="jsrootsys/scripts/JSRoot.core.js" type="text/javascript"></script>
   </head>
 
   <body>


### PR DESCRIPTION
In such mode only requests for websocket-handlers are allowed.
And if connection token is configured, such connection only
can be established by providing the token.

Increases security of THttpServer used for webgui widgets in public networks

Provide default THttpServer page for WS-only mode that one sees list of active widgets
