### PR TITLE
[http] always redirect browser to the same JSROOT location

### DIFF
--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "1/02/2021";
+   JSROOT.version_date = "2/02/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.hierarchy.js
+++ b/js/scripts/JSRoot.hierarchy.js
@@ -2100,19 +2100,15 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if (handle && ('execute' in handle))
          menu.add("Execute", () => this.executeCommand(itemname, menu.tree_node));
 
-      let drawurl = onlineprop.server + onlineprop.itemname + "/draw.htm", separ = "?";
-      if (this.isMonitoring()) {
-         drawurl += separ + "monitoring=" + this.getMonitoringInterval();
-         separ = "&";
-      }
-
       if (sett.opts && (node._can_draw !== false))
-         menu.addDrawMenu("Draw in new window", sett.opts, function(arg) { window.open(drawurl+separ+"opt=" +arg); });
+         menu.addDrawMenu("Draw in new window", sett.opts,
+                           arg => window.open(onlineprop.server + "?nobrowser&item=" + onlineprop.itemname +
+                                              (this.isMonitoring() ? "&monitoring=" + this.getMonitoringInterval() : "") +
+                                              (arg ? "&opt=" + arg : "")));
 
       if (sett.opts && (sett.opts.length > 0) && root_type && (node._can_draw !== false))
-         menu.addDrawMenu("Draw as png", sett.opts, function(arg) {
-            window.open(onlineprop.server + onlineprop.itemname + "/root.png?w=400&h=300&opt=" + arg);
-         });
+         menu.addDrawMenu("Draw as png", sett.opts,
+                           arg => window.open(onlineprop.server + onlineprop.itemname + "/root.png?w=600&h=400" + (arg ? "&opt=" + arg : "")));
 
       if ('_player' in node)
          menu.add("Player", () => this.player(itemname));

--- a/js/scripts/JSRoot.interactive.js
+++ b/js/scripts/JSRoot.interactive.js
@@ -1502,7 +1502,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             break;
          case 'disable':
          case 'leavebtn':
-            if (!state) btn.property('timout_handler', setTimeout(() => toggleButtonsVisibility(handler, 'timeout'), 500));
+            if (!state) btn.property('timout_handler', setTimeout(() => toggleButtonsVisibility(handler, 'timeout'), 1200));
             return;
       }
 

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -68,6 +68,8 @@ protected:
 
    std::string BuildWSEntryPage();
 
+   void ReplaceJSROOTLinks(std::shared_ptr<THttpCallArg> &arg);
+
    static Bool_t VerifyFilePath(const char *fname);
 
    THttpServer(const THttpServer &) = delete;


### PR DESCRIPTION
While many widgets will access JSROOT, try to always access JSROOT version from top server location
One cannot simply use src="/jsrootsys/scripts/JSRoot.core.js" while it does not work with FastCGI.
Therefore one have to use relative paths like "../../jsrootsys/scripts/JSRoot.core.js".
More efficiently will use browser cache