### PR TITLE
[RF] Consistently use ROOT::Math::KahanSum everywhere in RooNLLVar

### DIFF
--- a/math/mathcore/inc/Math/Util.h
+++ b/math/mathcore/inc/Math/Util.h
@@ -129,6 +129,15 @@ namespace ROOT {
          std::fill(std::begin(fCarry), std::end(fCarry), 0.);
        }
 
+       /// Constructor to create a KahanSum from another KahanSum with a different number of accumulators
+       template <unsigned int M>
+       KahanSum(KahanSum<T,M> const& other) {
+         fSum[0] = other.Sum();
+         fCarry[0] = other.Carry();
+         std::fill(std::begin(fSum)+1, std::end(fSum), 0.);
+         std::fill(std::begin(fCarry)+1, std::end(fCarry), 0.);
+       }
+
        /// Single-element accumulation. Will not vectorise.
        void Add(T x) {
           auto y = x - fCarry[0];
@@ -235,6 +244,18 @@ namespace ROOT {
        KahanSum& operator+=(const KahanSum<U>& arg) {
          Add(arg.Sum());
          fCarry[0] += arg.Carry();
+         return *this;
+       }
+
+       /// Subtract other KahanSum. Does not vectorise.
+       ///
+       /// This is only meaningfull when both the sum and carry of each operand are of similar order of magnitude.
+       KahanSum<T, N>& operator-=(KahanSum<T, N> const& other) {
+         fSum[0]   -= other.Sum();
+         fCarry[0] -= other.Carry();
+         // add zero such that if the summed carry is large enough to be partly represented in the sum,
+         // it will happen
+         Add(T{});
          return *this;
        }
 

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -20,6 +20,8 @@
 #include "RooSetProxy.h"
 #include "RooRealProxy.h"
 #include "TStopwatch.h"
+#include "Math/Util.h"
+
 #include <string>
 #include <vector>
 
@@ -61,8 +63,8 @@ public:
 
   void enableOffsetting(Bool_t flag) ;
   Bool_t isOffsetting() const { return _doOffset ; }
-  virtual Double_t offset() const { return _offset ; }
-  virtual Double_t offsetCarry() const { return _offsetCarry; }
+  virtual Double_t offset() const { return _offset.Sum() ; }
+  virtual Double_t offsetCarry() const { return _offset.Carry(); }
 
 protected:
 
@@ -142,8 +144,7 @@ protected:
 
   RooFit::MPSplit        _mpinterl ; // Use interleaving strategy rather than N-wise split for partioning of dataset for multiprocessor-split
   Bool_t         _doOffset ; // Apply interval value offset to control numeric precision?
-  mutable Double_t _offset ; //! Offset
-  mutable Double_t _offsetCarry; //! avoids loss of precision
+  mutable ROOT::Math::KahanSum<double> _offset{0.0} ; //! Offset as KahanSum to avoid loss of precision
   mutable Double_t _evalCarry; //! carry of Kahan sum in evaluatePartition
 
   ClassDef(RooAbsTestStatistic,2) // Abstract base class for real-valued test statistics

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -64,6 +64,8 @@ public:
     _batchEvaluations = on;
   }
 
+  using ComputeBatchedResult = std::pair<ROOT::Math::KahanSum<double>, double>;
+
 protected:
 
   virtual Bool_t processEmptyDataSets() const { return _extended ; }
@@ -72,18 +74,14 @@ protected:
   static RooArgSet _emptySet ; // Supports named argument constructor
 
 private:
-  std::tuple<double, double, double> computeBatched(
-      std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const;
-
-  std::tuple<double, double, double> computeScalar(
-        std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const;
+  ComputeBatchedResult computeBatched(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const;
+  ComputeBatchedResult computeScalar(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const;
 
   Bool_t _extended{false};
   bool _batchEvaluations{false};
   Bool_t _weightSq{false}; // Apply weights squared?
   mutable Bool_t _first{true}; //!
-  Double_t _offsetSaveW2{false}; //!
-  Double_t _offsetCarrySaveW2{false}; //!
+  ROOT::Math::KahanSum<double> _offsetSaveW2{0.0}; //!
 
   mutable std::vector<Double_t> _binw ; //!
   mutable RooRealSumPdf* _binnedPdf{nullptr}; //!

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -64,7 +64,7 @@ public:
     _batchEvaluations = on;
   }
 
-  using ComputeBatchedResult = std::pair<ROOT::Math::KahanSum<double>, double>;
+  using ComputeResult = std::pair<ROOT::Math::KahanSum<double>, double>;
 
 protected:
 
@@ -74,8 +74,8 @@ protected:
   static RooArgSet _emptySet ; // Supports named argument constructor
 
 private:
-  ComputeBatchedResult computeBatched(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const;
-  ComputeBatchedResult computeScalar(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const;
+  ComputeResult computeBatched(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const;
+  ComputeResult computeScalar(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const;
 
   Bool_t _extended{false};
   bool _batchEvaluations{false};

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -66,8 +66,8 @@ RooAbsTestStatistic::RooAbsTestStatistic() :
   _func(0), _data(0), _projDeps(0), _splitRange(0), _simCount(0),
   _verbose(kFALSE), _init(kFALSE), _gofOpMode(Slave), _nEvents(0), _setNum(0),
   _numSets(0), _extSet(0), _nGof(0), _gofArray(0), _nCPU(1), _mpfeArray(0),
-  _mpinterl(RooFit::BulkPartition), _doOffset(kFALSE), _offset(0),
-  _offsetCarry(0), _evalCarry(0)
+  _mpinterl(RooFit::BulkPartition), _doOffset(kFALSE),
+  _evalCarry(0)
 {
 }
 
@@ -117,8 +117,6 @@ RooAbsTestStatistic::RooAbsTestStatistic(const char *name, const char *title, Ro
   _mpfeArray(0),
   _mpinterl(interleave),
   _doOffset(kFALSE),
-  _offset(0),
-  _offsetCarry(0),
   _evalCarry(0)
 {
   // Register all parameters as servers
@@ -177,7 +175,6 @@ RooAbsTestStatistic::RooAbsTestStatistic(const RooAbsTestStatistic& other, const
   _mpinterl(other._mpinterl),
   _doOffset(other._doOffset),
   _offset(other._offset),
-  _offsetCarry(other._offsetCarry),
   _evalCarry(other._evalCarry)
 {
   // Our parameters are those of original
@@ -693,7 +690,6 @@ void RooAbsTestStatistic::enableOffsetting(Bool_t flag)
     // Clear offset if feature is disabled to that it is recalculated next time it is enabled
     if (!_doOffset) {
       _offset = 0 ;
-      _offsetCarry = 0;
     }
     setValueDirty() ;
     break ;

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -102,10 +102,7 @@ RooNLLVar::RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbs
   _batchEvaluations = pc.getInt("BatchMode");
   _weightSq = kFALSE ;
   _first = kTRUE ;
-  _offset = 0.;
-  _offsetCarry = 0.;
   _offsetSaveW2 = 0.;
-  _offsetCarrySaveW2 = 0.;
 
   _binnedPdf = 0 ;
 }
@@ -124,7 +121,7 @@ RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbs
       integrateBinsPrecision),
   _extended(extended),
   _weightSq(kFALSE),
-  _first(kTRUE), _offsetSaveW2(0.), _offsetCarrySaveW2(0.)
+  _first(kTRUE)
 {
   // If binned likelihood flag is set, pdf is a RooRealSumPdf representing a yield vector
   // for a binned likelihood calculation
@@ -171,7 +168,7 @@ RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbs
       integrateBinsPrecision),
   _extended(extended),
   _weightSq(kFALSE),
-  _first(kTRUE), _offsetSaveW2(0.), _offsetCarrySaveW2(0.)
+  _first(kTRUE)
 {
   // If binned likelihood flag is set, pdf is a RooRealSumPdf representing a yield vector
   // for a binned likelihood calculation
@@ -211,8 +208,8 @@ RooNLLVar::RooNLLVar(const RooNLLVar& other, const char* name) :
   _extended(other._extended),
   _batchEvaluations(other._batchEvaluations),
   _weightSq(other._weightSq),
-  _first(kTRUE), _offsetSaveW2(other._offsetSaveW2),
-  _offsetCarrySaveW2(other._offsetCarrySaveW2),
+  _first(kTRUE),
+  _offsetSaveW2(other._offsetSaveW2),
   _binw(other._binw) {
   _binnedPdf = other._binnedPdf ? (RooRealSumPdf*)_funcClone : 0 ;
 }
@@ -253,7 +250,6 @@ void RooNLLVar::applyWeightSquared(Bool_t flag)
     if (flag != _weightSq) {
       _weightSq = flag;
       std::swap(_offset, _offsetSaveW2);
-      std::swap(_offsetCarry, _offsetCarrySaveW2);
     }
     setValueDirty();
   } else if ( _gofOpMode==MPMaster) {
@@ -282,7 +278,8 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
   // prevent loss of precision - this is a factor four more expensive than
   // straight addition, but since evaluating the PDF is usually much more
   // expensive than that, we tolerate the additional cost...
-  double result(0), carry(0), sumWeight(0);
+  ROOT::Math::KahanSum<double> result{0.0};
+  double sumWeight{0.0};
 
   RooAbsPdf* pdfClone = (RooAbsPdf*) _funcClone ;
 
@@ -294,7 +291,7 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
 
   // If pdf is marked as binned - do a binned likelihood calculation here (sum of log-Poisson for each bin)
   if (_binnedPdf) {
-    double sumWeightCarry = 0.;
+    ROOT::Math::KahanSum<double> sumWeightKahanSum{0.0};
     for (auto i=firstEvent ; i<lastEvent ; i+=stepSize) {
 
       _dataClone->get(i) ;
@@ -321,33 +318,23 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
 
       } else {
 
-        Double_t term = -1*(-mu + N*log(mu) - TMath::LnGamma(N+1)) ;
+        result += -1*(-mu + N*log(mu) - TMath::LnGamma(N+1));
+        sumWeightKahanSum += eventWeight;
 
-        // TODO replace by Math::KahanSum
-        // Kahan summation of sumWeight
-        Double_t y = eventWeight - sumWeightCarry;
-        Double_t t = sumWeight + y;
-        sumWeightCarry = (t - sumWeight) - y;
-        sumWeight = t;
-
-        // Kahan summation of result
-        y = term - carry;
-        t = result + y;
-        carry = (t - result) - y;
-        result = t;
       }
     }
 
+    sumWeight = sumWeightKahanSum.Sum();
 
   } else { //unbinned PDF
 
     if (_batchEvaluations) {
-      std::tie(result, carry, sumWeight) = computeBatched(stepSize, firstEvent, lastEvent);
+      std::tie(result, sumWeight) = computeBatched(stepSize, firstEvent, lastEvent);
 #ifdef ROOFIT_CHECK_CACHED_VALUES
 
-      double resultScalar, carryScalar, sumWeightScalar;
-      std::tie(resultScalar, carryScalar, sumWeightScalar) =
-          computeScalar(stepSize, firstEvent, lastEvent);
+      ROOT::Math::KahanSum<double> resultScalar, sumWeightScalar;
+      std::tie(resultScalar, sumWeightScalar) = computeScalar(stepSize, firstEvent, lastEvent);
+      double carryScalar = resultScalar.Carry();
 
       constexpr bool alwaysPrint = false;
 
@@ -368,7 +355,7 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
 
 #endif
     } else { //scalar mode
-      std::tie(result, carry, sumWeight) = computeScalar(stepSize, firstEvent, lastEvent);
+      std::tie(result, sumWeight) = computeScalar(stepSize, firstEvent, lastEvent);
     }
 
     // include the extended maximum likelihood term, if requested
@@ -407,18 +394,11 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
         Double_t expectedW2 = expected * sumW2 / _dataClone->sumEntries() ;
         Double_t extra= expectedW2 - sumW2*log(expected );
 
-        // Double_t y = pdfClone->extendedTerm(sumW2, _dataClone->get()) - carry;
+        // Double_t extra = pdfClone->extendedTerm(sumW2, _dataClone->get());
 
-        Double_t y = extra - carry ;
-
-        Double_t t = result + y;
-        carry = (t - result) - y;
-        result = t;
+        result += extra;
       } else {
-        Double_t y = pdfClone->extendedTerm(_dataClone->sumEntries(), _dataClone->get()) - carry;
-        Double_t t = result + y;
-        carry = (t - result) - y;
-        result = t;
+        result += pdfClone->extendedTerm(_dataClone->sumEntries(), _dataClone->get());
       }
     }
   } //unbinned PDF
@@ -427,10 +407,7 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
   // If part of simultaneous PDF normalize probability over
   // number of simultaneous PDFs: -sum(log(p/n)) = -sum(log(p)) + N*log(n)
   if (_simCount>1) {
-    Double_t y = sumWeight*log(1.0*_simCount) - carry;
-    Double_t t = result + y;
-    carry = (t - result) - y;
-    result = t;
+    result += sumWeight * log(1.0*_simCount);
   }
 
 
@@ -448,19 +425,14 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
     if (_offset==0 && result !=0 ) {
       coutI(Minimization) << "RooNLLVar::evaluatePartition(" << GetName() << ") first = "<< firstEvent << " last = " << lastEvent << " Likelihood offset now set to " << result << std::endl ;
       _offset = result ;
-      _offsetCarry = carry;
     }
 
     // Subtract offset
-    Double_t y = -_offset - (carry + _offsetCarry);
-    Double_t t = result + y;
-    carry = (t - result) - y;
-    result = t;
+    result -= _offset;
   }
 
-
-  _evalCarry = carry;
-  return result ;
+  _evalCarry = result.Carry();
+  return result.Sum() ;
 }
 
 
@@ -471,7 +443,7 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
 /// \param[in] firstEvent  First event to be processed.
 /// \param[in] lastEvent   First event not to be processed.
 /// \return Tuple with (Kahan sum of probabilities, carry of kahan sum, sum of weights)
-std::tuple<double, double, double> RooNLLVar::computeBatched(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const
+RooNLLVar::ComputeBatchedResult RooNLLVar::computeBatched(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const
 {
   const auto nEvents = lastEvent - firstEvent;
 
@@ -565,17 +537,17 @@ std::tuple<double, double, double> RooNLLVar::computeBatched(std::size_t stepSiz
 
     // Some events with evaluation errors. Return "badness" of errors.
     if (nanPacker.getPayload() > 0.) {
-      return std::tuple<double, double, double>{nanPacker.getNaNWithPayload(), 0., sumOfWeights};
+      return {{nanPacker.getNaNWithPayload()}, sumOfWeights};
     } else {
-      return std::tuple<double, double, double>{kahanSanitised.Sum(), kahanSanitised.Carry(), sumOfWeights};
+      return {kahanSanitised, sumOfWeights};
     }
   }
 
-  return std::tuple<double, double, double>{kahanProb.Sum(), kahanProb.Carry(), sumOfWeights};
+  return {kahanProb, sumOfWeights};
 }
 
 
-std::tuple<double, double, double> RooNLLVar::computeScalar(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const {
+RooNLLVar::ComputeBatchedResult RooNLLVar::computeScalar(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const {
   auto pdfClone = static_cast<const RooAbsPdf*>(_funcClone);
 
   ROOT::Math::KahanSum<double> kahanWeight;
@@ -600,8 +572,8 @@ std::tuple<double, double, double> RooNLLVar::computeScalar(std::size_t stepSize
 
   if (packedNaN.getPayload() != 0.) {
     // Some events with evaluation errors. Return "badness" of errors.
-    return std::tuple<double, double, double>{packedNaN.getNaNWithPayload(), 0., kahanWeight.Sum()};
+    return {{packedNaN.getNaNWithPayload()}, kahanWeight.Sum()};
   }
 
-  return std::tuple<double, double, double>{kahanProb.Sum(), kahanProb.Carry(), kahanWeight.Sum()};
+  return {kahanProb, kahanWeight.Sum()};
 }

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -362,15 +362,27 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
     if(_extended && _setNum==_extSet) {
       if (_weightSq) {
 
-        // TODO Batch this up
+
         // Calculate sum of weights-squared here for extended term
-        Double_t sumW2(0), sumW2carry(0);
-        for (decltype(_dataClone->numEntries()) i = 0; i < _dataClone->numEntries() ; i++) {
-          _dataClone->get(i);
-          Double_t y = _dataClone->weightSquared() - sumW2carry;
-          Double_t t = sumW2 + y;
-          sumW2carry = (t - sumW2) - y;
-          sumW2 = t;
+        Double_t sumW2;
+        if (_batchEvaluations) {
+          const RooSpan<const double> eventWeights = _dataClone->getWeightBatch(0, _nEvents);
+          if (eventWeights.empty()) {
+            sumW2 = (lastEvent - firstEvent) * _dataClone->weightSquared();
+          } else {
+            ROOT::Math::KahanSum<double, 4u> kahanWeight;
+            for (std::size_t i = 0; i < eventWeights.size(); ++i) {
+              kahanWeight.AddIndexed(eventWeights[i] * eventWeights[i], i);
+            }
+            sumW2 = kahanWeight.Sum();
+          }
+        } else { // scalar mode
+          ROOT::Math::KahanSum<double> sumW2KahanSum;
+          for (decltype(_dataClone->numEntries()) i = 0; i < _dataClone->numEntries() ; i++) {
+            _dataClone->get(i);
+            sumW2KahanSum += _dataClone->weightSquared();
+          }
+          sumW2 = sumW2KahanSum.Sum();
         }
 
         Double_t expected= pdfClone->expectedEvents(_dataClone->get());
@@ -443,7 +455,7 @@ Double_t RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEv
 /// \param[in] firstEvent  First event to be processed.
 /// \param[in] lastEvent   First event not to be processed.
 /// \return Tuple with (Kahan sum of probabilities, carry of kahan sum, sum of weights)
-RooNLLVar::ComputeBatchedResult RooNLLVar::computeBatched(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const
+RooNLLVar::ComputeResult RooNLLVar::computeBatched(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const
 {
   const auto nEvents = lastEvent - firstEvent;
 
@@ -547,7 +559,7 @@ RooNLLVar::ComputeBatchedResult RooNLLVar::computeBatched(std::size_t stepSize, 
 }
 
 
-RooNLLVar::ComputeBatchedResult RooNLLVar::computeScalar(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const {
+RooNLLVar::ComputeResult RooNLLVar::computeScalar(std::size_t stepSize, std::size_t firstEvent, std::size_t lastEvent) const {
   auto pdfClone = static_cast<const RooAbsPdf*>(_funcClone);
 
   ROOT::Math::KahanSum<double> kahanWeight;


### PR DESCRIPTION
This PR is addressing one of the `TODO`s left by @hageboeck in the RooFit code:

https://github.com/root-project/root/blob/master/roofit/roofitcore/src/RooNLLVar.cxx#L326

I hope this goes in the good direction. I still have to see how I can cover all the changes with tests, so this is a draft PR for now.

The most controversial part is probably the `_offset` subtraction: https://github.com/root-project/root/blob/master/roofit/roofitcore/src/RooNLLVar.cxx#L454.

It originally looked like this:

```C++
Double_t y = -_offset - (carry + _offsetCarry);
Double_t t = result + y;
carry = (t - result) - y;
result = t;
```

I'm not sure if that works. By definition, `_offset` is in the same order of magnitude as `result`, so the `carry + _offsetCarry` is lost when adding it with `_offset`, no? I think to subtract KahanSums of the same order of magnitude, one should better add the sums and carries individually and then make a dummy addition such that the carry can "spill over" into the sum if it got large enough after addition:

```C++
KahanSum<T, N>& operator-=(KahanSum<T, N> const& other) {
    fSum[0]   -= other.Sum();
    fCarry[0] -= other.Carry();
    // add zero such that if the summed carry is large enough to be partly represented in the sum, it will happen
    Add(T{});
    return *this;
}
```

@lmoneta