### PR TITLE
Add a warning message when the RooAddPdf normalization set is not defined (ROOT-10814)

### DIFF
--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -18,13 +18,13 @@
 /** \class RooAddPdf
     \ingroup Roofitcore
 
-RooAddPdf is an efficient implementation of a sum of PDFs of the form 
+RooAddPdf is an efficient implementation of a sum of PDFs of the form
 
 \f[
  \sum_{i=1}^{n} c_i \cdot \mathrm{PDF}_i
 \f]
 
-or 
+or
 \f[
  c_1\cdot\mathrm{PDF}_1 + c_2\cdot\mathrm{PDF}_2 \; + \; ... \; + \; \left( 1-\sum_{i=1}^{n-1}c_i \right) \cdot \mathrm{PDF}_n
 \f]
@@ -51,7 +51,7 @@ In this form the sum of the coefficients is always less than 1.0
 for all possible values of the individual coefficients between 0 and 1.
 \note Don't pass the \f$ n^\mathrm{th} \f$ coefficient. It is always 1, since the normalisation condition removes one degree of freedom.
 
-RooAddPdf relies on each component PDF to be normalized and will perform 
+RooAddPdf relies on each component PDF to be normalized and will perform
 no normalization other than calculating the proper last coefficient \f$ c_n \f$, if requested.
 An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ is independent of each \f$ c_i \f$.
 
@@ -98,16 +98,16 @@ RooAddPdf::RooAddPdf() :
   _recursive(false)
 {
   _coefErrCount = _errorCount ;
-  TRACE_CREATE 
+  TRACE_CREATE
 }
 
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Dummy constructor 
+/// Dummy constructor
 
 RooAddPdf::RooAddPdf(const char *name, const char *title) :
-  RooAbsPdf(name,title), 
+  RooAbsPdf(name,title),
   _refCoefNorm("!refCoefNorm","Reference coefficient normalization set",this,kFALSE,kFALSE),
   _refCoefRangeName(0),
   _projectCoefs(kFALSE),
@@ -121,7 +121,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title) :
   _recursive(kFALSE)
 {
   _coefErrCount = _errorCount ;
-  TRACE_CREATE 
+  TRACE_CREATE
 }
 
 
@@ -130,7 +130,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title) :
 /// Constructor with two PDFs and one coefficient
 
 RooAddPdf::RooAddPdf(const char *name, const char *title,
-		     RooAbsPdf& pdf1, RooAbsPdf& pdf2, RooAbsReal& coef1) : 
+		     RooAbsPdf& pdf1, RooAbsPdf& pdf2, RooAbsReal& coef1) :
   RooAbsPdf(name,title),
   _refCoefNorm("!refCoefNorm","Reference coefficient normalization set",this,kFALSE,kFALSE),
   _refCoefRangeName(0),
@@ -143,13 +143,13 @@ RooAddPdf::RooAddPdf(const char *name, const char *title,
   _allExtendable(kFALSE),
   _recursive(kFALSE)
 {
-  _pdfList.add(pdf1) ;  
+  _pdfList.add(pdf1) ;
   _pdfList.add(pdf2) ;
   _coefList.add(coef1) ;
 
   _coefCache.resize(_pdfList.size());
   _coefErrCount = _errorCount ;
-  TRACE_CREATE 
+  TRACE_CREATE
 }
 
 
@@ -177,7 +177,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
   _haveLastCoef(kFALSE),
   _allExtendable(kFALSE),
   _recursive(recursiveFractions)
-{ 
+{
   if (inPdfList.getSize()>inCoefList.getSize()+1 || inPdfList.getSize()<inCoefList.getSize()) {
     std::stringstream errorMsg;
     errorMsg << "RooAddPdf::RooAddPdf(" << GetName()
@@ -193,7 +193,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
     coutE(InputArguments) << errorMsg.str();
     throw std::invalid_argument(errorMsg.str());
   }
- 
+
   // Constructor with N PDFs and N or N-1 coefs
   RooArgList partinCoefList ;
 
@@ -226,7 +226,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
     // Process recursive fraction mode separately
     if (recursiveFractions) {
       partinCoefList.add(*coef) ;
-      if (first) {	
+      if (first) {
 
         // The first fraction is the first plain fraction
         first = kFALSE ;
@@ -242,7 +242,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
       }
 
     } else {
-      _coefList.add(*coef) ;    
+      _coefList.add(*coef) ;
     }
   }
 
@@ -253,7 +253,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
       coutE(InputArguments) << "RooAddPdf::RooAddPdf(" << GetName() << ") last argument " << inPdfList.at(inCoefList.size())->GetName() << " is not of type RooAbsPdf." << endl ;
       throw std::invalid_argument("Last argument for RooAddPdf is not a PDF.");
     }
-    _pdfList.add(*pdf) ;  
+    _pdfList.add(*pdf) ;
 
     // Process recursive fractions mode. Above, we verified that we don't have a last coefficient
     if (recursiveFractions) {
@@ -262,7 +262,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
       partinCoefList.add(RooFit::RooConst(1)) ;
       RooAbsReal* rfrac = new RooRecursiveFraction(Form("%s_recursive_fraction_%s",GetName(),pdf->GetName()),"Recursive Fraction",partinCoefList) ;
       addOwnedComponents(*rfrac) ;
-      _coefList.add(*rfrac) ;      	
+      _coefList.add(*rfrac) ;
 
       // In recursive mode we always have Ncoef=Npdf, since we added it just above
       _haveLastCoef=kTRUE ;
@@ -276,7 +276,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
   _coefCache.resize(_pdfList.size());
   _coefErrCount = _errorCount ;
 
-  TRACE_CREATE 
+  TRACE_CREATE
 }
 
 
@@ -284,8 +284,8 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
 ////////////////////////////////////////////////////////////////////////////////
 /// Generic constructor from list of extended PDFs. There are no coefficients as the expected
 /// number of events from each components determine the relative weight of the PDFs.
-/// 
-/// All PDFs must inherit from RooAbsPdf. 
+///
+/// All PDFs must inherit from RooAbsPdf.
 
 RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPdfList) :
   RooAbsPdf(name,title),
@@ -298,8 +298,8 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
   _haveLastCoef(kFALSE),
   _allExtendable(kTRUE),
   _recursive(kFALSE)
-{ 
-  // Constructor with N PDFs 
+{
+  // Constructor with N PDFs
   for (const auto pdfArg : inPdfList) {
     auto pdf = dynamic_cast<const RooAbsPdf*>(pdfArg);
 
@@ -311,12 +311,12 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
       coutE(InputArguments) << "RooAddPdf::RooAddPdf(" << GetName() << ") pdf " << pdf->GetName() << " is not extendable, ignored" << endl ;
       continue ;
     }
-    _pdfList.add(*pdf) ;    
+    _pdfList.add(*pdf) ;
   }
 
   _coefCache.resize(_pdfList.size());
   _coefErrCount = _errorCount ;
-  TRACE_CREATE 
+  TRACE_CREATE
 }
 
 
@@ -340,7 +340,7 @@ RooAddPdf::RooAddPdf(const RooAddPdf& other, const char* name) :
 {
   _coefCache.resize(_pdfList.size());
   _coefErrCount = _errorCount ;
-  TRACE_CREATE 
+  TRACE_CREATE
 }
 
 
@@ -365,13 +365,13 @@ RooAddPdf::~RooAddPdf()
 /// from the reference normalization set to the contextual normalization
 /// set by ratios of integrals.
 
-void RooAddPdf::fixCoefNormalization(const RooArgSet& refCoefNorm) 
+void RooAddPdf::fixCoefNormalization(const RooArgSet& refCoefNorm)
 {
   if (refCoefNorm.getSize()==0) {
     _projectCoefs = kFALSE ;
     return ;
   }
-  _projectCoefs = kTRUE ;  
+  _projectCoefs = kTRUE ;
 
   _refCoefNorm.removeAll() ;
   _refCoefNorm.add(refCoefNorm) ;
@@ -414,13 +414,13 @@ void RooAddPdf::fixCoefRange(const char* rangeName)
 RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooArgSet* iset, const char* rangeName) const
 {
 
-  // Check if cache already exists 
+  // Check if cache already exists
   CacheElem* cache = (CacheElem*) _projCacheMgr.getObj(nset,iset,0,rangeName) ;
   if (cache) {
     return cache ;
   }
 
-  //Create new cache 
+  //Create new cache
   cache = new CacheElem ;
 
   // *** PART 1 : Create supplemental normalization list ***
@@ -429,7 +429,7 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
   RooArgSet *fullDepList = getObservables(nset) ;
   if (iset) {
     fullDepList->remove(*iset,kTRUE,kTRUE) ;
-  }    
+  }
 
   // Fill with dummy unit RRVs for now
   for (int i = 0; i < _pdfList.getSize(); ++i) {
@@ -443,7 +443,7 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
     RooArgSet* pdfDeps = pdf->getObservables(nset) ;
     if (pdfDeps) {
       supNSet.remove(*pdfDeps,kTRUE,kTRUE) ;
-      delete pdfDeps ; 
+      delete pdfDeps ;
     }
 
     // Remove coef dependents
@@ -452,7 +452,7 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
       supNSet.remove(*coefDeps,kTRUE,kTRUE) ;
       delete coefDeps ;
     }
-    
+
     RooAbsReal* snorm ;
     TString name(GetName()) ;
     name.Append("_") ;
@@ -470,7 +470,7 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
   }
 
   delete fullDepList ;
-    
+
   if (_verboseEval>1) {
     cxcoutD(Caching) << "RooAddPdf::syncSuppNormList(" << GetName() << ") synching supplemental normalization list for norm" << (nset?*nset:RooArgSet()) << endl ;
     if dologD(Caching) {
@@ -501,7 +501,7 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
 
   if (nset2->getSize()==0 && _refCoefNorm.getSize()!=0) {
     //cout << "WVE: evaluating RooAddPdf without normalization, but have reference normalization for coefficient definition" << endl ;
-    
+
     nset2->add(_refCoefNorm) ;
     if (_refCoefRangeName) {
       rangeName = RooNameReg::str(_refCoefRangeName) ;
@@ -509,14 +509,14 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
   }
 
 
-  // Check if requested transformation is not identity 
+  // Check if requested transformation is not identity
   if (!nset2->equals(_refCoefNorm) || _refCoefRangeName !=0 || rangeName !=0 || _normRange.Length()>0) {
-   
+
     cxcoutD(Caching) << "ALEX:     RooAddPdf::syncCoefProjList(" << GetName() << ") projecting coefficients from "
-		   << *nset2 << (rangeName?":":"") << (rangeName?rangeName:"") 
+		   << *nset2 << (rangeName?":":"") << (rangeName?rangeName:"")
 		   << " to "  << ((_refCoefNorm.getSize()>0)?_refCoefNorm:*nset2) << (_refCoefRangeName?":":"") << (_refCoefRangeName?RooNameReg::str(_refCoefRangeName):"") << endl ;
-    
-    // Recalculate projection integrals of PDFs 
+
+    // Recalculate projection integrals of PDFs
     for (auto arg : _pdfList) {
       auto thePdf = static_cast<const RooAbsPdf*>(arg);
 
@@ -561,13 +561,13 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
       // Calculate reference range adjusted projection integral
       RooAbsReal* rangeProj1 ;
 
-   //    cout << "ALEX >>>> RooAddPdf(" << GetName() << ")::getPC _refCoefRangeName WVE = " 	   
+   //    cout << "ALEX >>>> RooAddPdf(" << GetName() << ")::getPC _refCoefRangeName WVE = "
 // 	   <<(_refCoefRangeName?":":"") << (_refCoefRangeName?RooNameReg::str(_refCoefRangeName):"")
-// 	   <<" _refCoefRangeName AK = "  << (_refCoefRangeName?_refCoefRangeName->GetName():"")  	   
+// 	   <<" _refCoefRangeName AK = "  << (_refCoefRangeName?_refCoefRangeName->GetName():"")
 // 	   << " && _refCoefNorm" << _refCoefNorm << " with size = _refCoefNorm.getSize() " << _refCoefNorm.getSize() << endl ;
 
-      // Check if _refCoefRangeName is identical to default range for all observables, 
-      // If so, substitute by unit integral 
+      // Check if _refCoefRangeName is identical to default range for all observables,
+      // If so, substitute by unit integral
 
       // ----------
       RooArgSet* tmpObs = thePdf->getObservables(_refCoefNorm) ;
@@ -588,11 +588,11 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
       // -------------
 
       if (_refCoefRangeName && _refCoefNorm.getSize()>0 && !allIdent) {
-	
+
 
 	RooArgSet* tmp = thePdf->getObservables(_refCoefNorm) ;
 	rangeProj1 = thePdf->createIntegral(*tmp,*tmp,RooNameReg::str(_refCoefRangeName)) ;
-	
+
 	//rangeProj1->setOperMode(operMode()) ;
 
 	delete tmp ;
@@ -607,11 +607,11 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
       }
       cxcoutD(Caching) << " RooAddPdf::syncCoefProjList(" << GetName() << ") R1 = " << rangeProj1->GetName() << endl ;
       cache->_refRangeProjList.addOwned(*rangeProj1) ;
-      
+
 
       // Calculate range adjusted projection integral
       RooAbsReal* rangeProj2 ;
-      cxcoutD(Caching) << "RooAddPdf::syncCoefProjList(" << GetName() << ") rangename = " << (rangeName?rangeName:"<null>") 
+      cxcoutD(Caching) << "RooAddPdf::syncCoefProjList(" << GetName() << ") rangename = " << (rangeName?rangeName:"<null>")
 		       << " nset = " << (nset?*nset:RooArgSet()) << endl ;
       if (rangeName && _refCoefNorm.getSize()>0) {
 
@@ -636,7 +636,7 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
       cxcoutD(Caching) << " RooAddPdf::syncCoefProjList(" << GetName() << ") R2 = " << rangeProj2->GetName() << endl ;
       cache->_rangeProjList.addOwned(*rangeProj2) ;
 
-    }               
+    }
 
   }
 
@@ -654,7 +654,7 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
 /// multiply the various range and dimensional corrections needed in the
 /// current use context.
 
-void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) const 
+void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) const
 {
   // Since this function updates the cache, it obviously needs write access:
   auto& myCoefCache = const_cast<std::vector<double>&>(_coefCache);
@@ -678,7 +678,7 @@ void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) cons
     } else {
       for (int j=0; j < _pdfList.getSize(); j++) {
         myCoefCache[j] /= coefSum ;
-      }			            
+      }
     }
 
   } else {
@@ -691,7 +691,7 @@ void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) cons
         auto coef = static_cast<RooAbsReal*>(coefArg);
         myCoefCache[i] = coef->getVal(nset) ;
         coefSum += myCoefCache[i++];
-      }		
+      }
       if (coefSum==0.) {
         coutW(Eval) << "RooAddPdf::updateCoefCache(" << GetName() << ") WARNING: sum of coefficients is zero 0" << endl ;
       } else {
@@ -709,7 +709,7 @@ void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) cons
         auto coef = static_cast<RooAbsReal*>(coefArg);
         myCoefCache[i] = coef->getVal(nset) ;
         lastCoef -= myCoefCache[i++];
-      }			
+      }
       myCoefCache[_coefList.getSize()] = lastCoef ;
 
       // Treat coefficient degeneration
@@ -727,7 +727,7 @@ void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) cons
           }
           coutW(Eval) << msg.str() << std::endl;
         }
-      } 
+      }
     }
   }
 
@@ -736,7 +736,7 @@ void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) cons
   if ((!_projectCoefs && _normRange.Length()==0) || cache._projList.getSize()==0) {
     return ;
   }
-   
+
   // Adjust coefficients for given projection
   Double_t coefSum(0) ;
   {
@@ -771,7 +771,7 @@ void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) cons
   for (int i=0; i < _pdfList.getSize(); i++) {
     myCoefCache[i] /= coefSum ;
   }
-  
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -802,8 +802,12 @@ Double_t RooAddPdf::evaluate() const
   auto normAndCache = getNormAndCache();
   const RooArgSet* nset = normAndCache.first;
   CacheElem* cache = normAndCache.second;
+  // check that nset is not a null pointer
+  // in this case interpretation of coefficient is arbitrary
+  if (!nset)
+     oocoutW(this, Eval) << "Evaluating RooAddPdf without a defined normalization set. This can lead to ambiguos coefficients definition and incorrect results."
+     << " Use RooAddPdf::fixCoefNormalization(nset) to provide a normalization set for defining uniquely RooAddPdf coefficients!" << std::endl;
 
-  
   // Do running sum of coef/pdf pairs, calculate lastCoef.
   Double_t value(0);
 
@@ -813,7 +817,7 @@ Double_t RooAddPdf::evaluate() const
     if (cache->_needSupNorm) {
       snormVal = ((RooAbsReal*)cache->_suppNormList.at(i))->getVal();
     }
-    
+
     Double_t pdfVal = pdf.getVal(nset);
     if (pdf.isSelectedComp()) {
       value += pdfVal*_coefCache[i]/snormVal;
@@ -874,10 +878,10 @@ void RooAddPdf::resetErrorCounters(Int_t resetValue)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if PDF is valid for given normalization set.
-/// Coeffient and PDF must be non-overlapping, but pdf-coefficient 
+/// Coeffient and PDF must be non-overlapping, but pdf-coefficient
 /// pairs may overlap each other
 
-Bool_t RooAddPdf::checkObservables(const RooArgSet* nset) const 
+Bool_t RooAddPdf::checkObservables(const RooArgSet* nset) const
 {
   Bool_t ret(kFALSE) ;
 
@@ -885,12 +889,12 @@ Bool_t RooAddPdf::checkObservables(const RooArgSet* nset) const
     auto pdf  = static_cast<const RooAbsPdf *>(_pdfList.at(i));
     auto coef = static_cast<const RooAbsReal*>(_coefList.at(i));
     if (pdf->observableOverlaps(nset,*coef)) {
-      coutE(InputArguments) << "RooAddPdf::checkObservables(" << GetName() << "): ERROR: coefficient " << coef->GetName() 
+      coutE(InputArguments) << "RooAddPdf::checkObservables(" << GetName() << "): ERROR: coefficient " << coef->GetName()
 			    << " and PDF " << pdf->GetName() << " have one or more dependents in common" << endl ;
       ret = kTRUE ;
     }
   }
-  
+
   return ret ;
 }
 
@@ -905,8 +909,8 @@ Bool_t RooAddPdf::checkObservables(const RooArgSet* nset) const
 /// analytically integrating the common set, and combines the components individual integration
 /// codes into a single integration code valid for RooAddPdf.
 
-Int_t RooAddPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, 
-					 const RooArgSet* normSet, const char* rangeName) const 
+Int_t RooAddPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars,
+					 const RooArgSet* normSet, const char* rangeName) const
 {
 
   RooArgSet* allDepVars = getObservables(allVars) ;
@@ -925,7 +929,7 @@ Int_t RooAddPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars
     for (const auto arg : allVars) {
       if (!subAnalVars.find(arg->GetName()) && pdf->dependsOn(*arg)) {
         allAnalVars.remove(*arg,kTRUE,kTRUE) ;
-      }	
+      }
     }
     n++ ;
   }
@@ -946,14 +950,14 @@ Int_t RooAddPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars
     RooArgSet* allAnalVars2 = pdf->getObservables(allAnalVars) ;
     subCode[n] = pdf->getAnalyticalIntegralWN(*allAnalVars2,subAnalVars,normSet,rangeName) ;
     if (subCode[n]==0 && allAnalVars2->getSize()>0) {
-      coutE(InputArguments) << "RooAddPdf::getAnalyticalIntegral(" << GetName() << ") WARNING: component PDF " << pdf->GetName() 
+      coutE(InputArguments) << "RooAddPdf::getAnalyticalIntegral(" << GetName() << ") WARNING: component PDF " << pdf->GetName()
 			    << "   advertises inconsistent set of integrals (e.g. (X,Y) but not X or Y individually."
 			    << "   Distributed analytical integration disabled. Please fix PDF" << endl ;
       allOK = kFALSE ;
     }
-    delete allAnalVars2 ; 
+    delete allAnalVars2 ;
     n++ ;
-  }  
+  }
   if (!allOK) {
     return 0 ;
   }
@@ -973,7 +977,7 @@ Int_t RooAddPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars
 ////////////////////////////////////////////////////////////////////////////////
 /// Return analytical integral defined by given scenario code
 
-Double_t RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName) const 
+Double_t RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName) const
 {
   // WVE needs adaptation to handle new rangeName feature
   if (code==0) {
@@ -985,7 +989,7 @@ Double_t RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, c
   const std::vector<Int_t>& subCode = _codeReg.retrieve(code-1,intSet) ;
   if (subCode.empty()) {
     coutE(InputArguments) << "RooAddPdf::analyticalIntegral(" << GetName() << "): ERROR unrecognized integration code, " << code << endl ;
-    assert(0) ;    
+    assert(0) ;
   }
 
   cxcoutD(Caching) << "RooAddPdf::aiWN(" << GetName() << ") calling getProjCache with nset = " << (normSet?*normSet:RooArgSet()) << endl ;
@@ -998,7 +1002,7 @@ Double_t RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, c
   CacheElem* cache = getProjCache(normSet,intSet,0) ; // WVE rangename here?
   updateCoefficients(*cache,normSet) ;
 
-  // Calculate the current value of this object  
+  // Calculate the current value of this object
   Double_t value(0) ;
 
   // Do running sum of coef/pdf pairs, calculate lastCoef.
@@ -1011,7 +1015,7 @@ Double_t RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, c
 
     if (_coefCache[i]) {
       snormVal = snormSet ? ((RooAbsReal*) cache->_suppNormList.at(i))->getVal() : 1.0 ;
-      
+
       // WVE swap this?
       Double_t val = pdf->analyticalIntegralWN(subCode[i],normSet,rangeName) ;
       if (pdf->isSelectedComp()) {
@@ -1030,8 +1034,8 @@ Double_t RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, c
 /// or the sum of the components extended terms, multiplied with the fraction that
 /// is in the current range w.r.t the reference range
 
-Double_t RooAddPdf::expectedEvents(const RooArgSet* nset) const 
-{  
+Double_t RooAddPdf::expectedEvents(const RooArgSet* nset) const
+{
   Double_t expectedTotal(0.0);
 
   cxcoutD(Caching) << "RooAddPdf::expectedEvents(" << GetName() << ") calling getProjCache with nset = " << (nset?*nset:RooArgSet()) << endl ;
@@ -1045,13 +1049,13 @@ Double_t RooAddPdf::expectedEvents(const RooArgSet* nset) const
     RooFIter iter3 = _pdfList.fwdIterator() ;
 
     if (_allExtendable) {
-      
+
       RooAbsPdf* pdf ;
-      while ((pdf=(RooAbsPdf*)iter3.next())) {      
+      while ((pdf=(RooAbsPdf*)iter3.next())) {
 	RooAbsReal* r1 = (RooAbsReal*)iter1.next() ;
 	RooAbsReal* r2 = (RooAbsReal*)iter2.next() ;
-	expectedTotal += (r2->getVal()/r1->getVal()) * pdf->expectedEvents(nset) ; 
-      }    
+	expectedTotal += (r2->getVal()/r1->getVal()) * pdf->expectedEvents(nset) ;
+      }
 
     } else {
 
@@ -1061,7 +1065,7 @@ Double_t RooAddPdf::expectedEvents(const RooArgSet* nset) const
 	Double_t ncomp = coef->getVal(nset) ;
 	RooAbsReal* r1 = (RooAbsReal*)iter1.next() ;
 	RooAbsReal* r2 = (RooAbsReal*)iter2.next() ;
-	expectedTotal += (r2->getVal()/r1->getVal()) * ncomp ; 
+	expectedTotal += (r2->getVal()/r1->getVal()) * ncomp ;
       }
 
     }
@@ -1075,7 +1079,7 @@ Double_t RooAddPdf::expectedEvents(const RooArgSet* nset) const
       RooFIter iter = _pdfList.fwdIterator() ;
       RooAbsPdf* pdf ;
       while((pdf=(RooAbsPdf*)iter.next())) {
-	expectedTotal += pdf->expectedEvents(nset) ; 
+	expectedTotal += pdf->expectedEvents(nset) ;
       }
 
     } else {
@@ -1084,13 +1088,13 @@ Double_t RooAddPdf::expectedEvents(const RooArgSet* nset) const
       RooAbsReal* coef ;
       while((coef=(RooAbsReal*)citer.next())) {
 	Double_t ncomp = coef->getVal(nset) ;
-	expectedTotal += ncomp ;      
+	expectedTotal += ncomp ;
       }
 
     }
 
   }
-  return expectedTotal ;  
+  return expectedTotal ;
 }
 
 
@@ -1099,7 +1103,7 @@ Double_t RooAddPdf::expectedEvents(const RooArgSet* nset) const
 /// Interface function used by test statistics to freeze choice of observables
 /// for interpretation of fraction coefficients
 
-void RooAddPdf::selectNormalization(const RooArgSet* depSet, Bool_t force) 
+void RooAddPdf::selectNormalization(const RooArgSet* depSet, Bool_t force)
 {
 
   if (!force && _refCoefNorm.getSize()!=0) {
@@ -1122,7 +1126,7 @@ void RooAddPdf::selectNormalization(const RooArgSet* depSet, Bool_t force)
 /// Interface function used by test statistics to freeze choice of range
 /// for interpretation of fraction coefficients
 
-void RooAddPdf::selectNormalizationRange(const char* rangeName, Bool_t force) 
+void RooAddPdf::selectNormalizationRange(const char* rangeName, Bool_t force)
 {
   if (!force && _refCoefRangeName) {
     return ;
@@ -1137,8 +1141,8 @@ void RooAddPdf::selectNormalizationRange(const char* rangeName, Bool_t force)
 /// Return specialized context to efficiently generate toy events from RooAddPdfs
 /// return RooAbsPdf::genContext(vars,prototype,auxProto,verbose) ; // WVE DEBUG
 
-RooAbsGenContext* RooAddPdf::genContext(const RooArgSet &vars, const RooDataSet *prototype, 
-					const RooArgSet* auxProto, Bool_t verbose) const 
+RooAbsGenContext* RooAddPdf::genContext(const RooArgSet &vars, const RooDataSet *prototype,
+					const RooArgSet* auxProto, Bool_t verbose) const
 {
   return new RooAddGenContext(*this,vars,prototype,auxProto,verbose) ;
 }
@@ -1148,7 +1152,7 @@ RooAbsGenContext* RooAddPdf::genContext(const RooArgSet &vars, const RooDataSet 
 ////////////////////////////////////////////////////////////////////////////////
 /// List all RooAbsArg derived contents in this cache element
 
-RooArgList RooAddPdf::CacheElem::containedArgs(Action) 
+RooArgList RooAddPdf::CacheElem::containedArgs(Action)
 {
   RooArgList allNodes;
   allNodes.add(_projList) ;
@@ -1164,7 +1168,7 @@ RooArgList RooAddPdf::CacheElem::containedArgs(Action)
 ////////////////////////////////////////////////////////////////////////////////
 /// Loop over components for plot sampling hints and merge them if there are multiple
 
-std::list<Double_t>* RooAddPdf::plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const 
+std::list<Double_t>* RooAddPdf::plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const
 {
   list<Double_t>* sumHint = 0 ;
   Bool_t needClean(kFALSE) ;
@@ -1193,7 +1197,7 @@ std::list<Double_t>* RooAddPdf::plotSamplingHint(RooAbsRealLValue& obs, Double_t
 	delete sumHint ;
 	sumHint = newSumHint ;
 	needClean = kTRUE ;
-	
+
       }
     }
   }
@@ -1209,11 +1213,11 @@ std::list<Double_t>* RooAddPdf::plotSamplingHint(RooAbsRealLValue& obs, Double_t
 ////////////////////////////////////////////////////////////////////////////////
 /// Loop over components for plot sampling hints and merge them if there are multiple
 
-std::list<Double_t>* RooAddPdf::binBoundaries(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const 
+std::list<Double_t>* RooAddPdf::binBoundaries(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const
 {
   list<Double_t>* sumBinB = 0 ;
   Bool_t needClean(kFALSE) ;
-  
+
   // Loop over components pdf
   for (auto arg : _pdfList) {
     auto pdf = static_cast<const RooAbsPdf *>(arg);
@@ -1227,7 +1231,7 @@ std::list<Double_t>* RooAddPdf::binBoundaries(RooAbsRealLValue& obs, Double_t xl
 	sumBinB = pdfBinB ;
 
       } else {
-	
+
 	list<Double_t>* newSumBinB = new list<Double_t>(sumBinB->size()+pdfBinB->size()) ;
 
 	// Merge hints into temporary array
@@ -1237,13 +1241,13 @@ std::list<Double_t>* RooAddPdf::binBoundaries(RooAbsRealLValue& obs, Double_t xl
 	delete sumBinB ;
 	delete pdfBinB ;
 	sumBinB = newSumBinB ;
-	needClean = kTRUE ;	
+	needClean = kTRUE ;
       }
     }
   }
 
   // Remove consecutive duplicates
-  if (needClean) {    
+  if (needClean) {
     list<Double_t>::iterator new_end = unique(sumBinB->begin(),sumBinB->end()) ;
     sumBinB->erase(new_end,sumBinB->end()) ;
   }
@@ -1254,7 +1258,7 @@ std::list<Double_t>* RooAddPdf::binBoundaries(RooAbsRealLValue& obs, Double_t xl
 
 ////////////////////////////////////////////////////////////////////////////////
 /// If all components that depend on obs are binned, so is their sum.
-Bool_t RooAddPdf::isBinnedDistribution(const RooArgSet& obs) const 
+Bool_t RooAddPdf::isBinnedDistribution(const RooArgSet& obs) const
 {
   for (const auto arg : _pdfList) {
     auto pdf = static_cast<const RooAbsPdf*>(arg);
@@ -1262,24 +1266,24 @@ Bool_t RooAddPdf::isBinnedDistribution(const RooArgSet& obs) const
       return kFALSE ;
     }
   }
-  
-  return kTRUE  ;  
+
+  return kTRUE  ;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Label OK'ed components of a RooAddPdf with cache-and-track
 
-void RooAddPdf::setCacheAndTrackHints(RooArgSet& trackNodes) 
+void RooAddPdf::setCacheAndTrackHints(RooArgSet& trackNodes)
 {
   RooFIter aiter = pdfList().fwdIterator() ;
   RooAbsArg* aarg ;
   while ((aarg=aiter.next())) {
     if (aarg->canNodeBeCached()==Always) {
       trackNodes.add(*aarg) ;
-      //cout << "tracking node RooAddPdf component " << aarg->IsA()->GetName() << "::" << aarg->GetName() << endl ;	      
-    } 
-  }  
+      //cout << "tracking node RooAddPdf component " << aarg->IsA()->GetName() << "::" << aarg->GetName() << endl ;
+    }
+  }
 }
 
 
@@ -1288,10 +1292,10 @@ void RooAddPdf::setCacheAndTrackHints(RooArgSet& trackNodes)
 /// Customized printing of arguments of a RooAddPdf to more intuitively reflect the contents of the
 /// product operator construction
 
-void RooAddPdf::printMetaArgs(ostream& os) const 
+void RooAddPdf::printMetaArgs(ostream& os) const
 {
   Bool_t first(kTRUE) ;
-    
+
   if (_coefList.getSize() != 0) {
     for (int i = 0; i < _pdfList.getSize(); ++i ) {
       const RooAbsArg * coef = _coefList.at(i);
@@ -1309,16 +1313,16 @@ void RooAddPdf::printMetaArgs(ostream& os) const
       }
     }
   } else {
-    
+
     for (const auto pdf : _pdfList) {
       if (!first) {
         os << " + " ;
       } else {
         first = kFALSE ;
       }
-      os << pdf->GetName() ; 
-    }  
+      os << pdf->GetName() ;
+    }
   }
 
-  os << " " ;    
+  os << " " ;
 }


### PR DESCRIPTION
A RooAddPdf needs to have always a normalization set defined when evaluating. 
If this set is not defined it evaluates the component pdf without a normalization. This can cause an ambiguous definition of the coefficients and therefore a different shape of the pdf given the same coefficient values. 
See problem reported in ROOT-10814

This PR just add a warning message to warn users to not evaluate the pdf without having provided first a normalization set.  

This  simple code shows the problem: 
https://cernbox.cern.ch/index.php/s/iosEw6qHq51SLbi
