### PR TITLE
fix memory leak in rooproduct

### DIFF
--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -148,6 +148,8 @@ RooProduct::ProdMap* RooProduct::groupProductTerms(const RooArgSet& allVars) con
   }
   if (indep->getSize()!=0) {
     map->push_back( std::make_pair(new RooArgSet(),indep) );
+  } else {
+     delete indep;
   }
 
   // Map observables -> functions ; start with individual observables


### PR DESCRIPTION
While investigating performance issues with performing many fits in a RooFit analysis workflow, I discovered this memory leak in my valgrind logs.

Getting this fix in as many release streams as possible would be good.