### PR TITLE
[RF] Set math-no-errno for roofit libraries

### DIFF
--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -78,6 +78,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistFactory
     XMLParser
 )
 
+# For recent clang, this can facilitate auto-vectorisation.
+# In RooFit, the errno side effect is not needed, anyway:
+target_compile_options(HistFactory PUBLIC -fno-math-errno)
+
 ROOT_EXECUTABLE(hist2workspace
   MakeModelAndMeasurements.cxx
   hist2workspace.cxx

--- a/roofit/roofit/CMakeLists.txt
+++ b/roofit/roofit/CMakeLists.txt
@@ -148,4 +148,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
     MathCore
 )
 
+# For recent clang, this can facilitate auto-vectorisation.
+# In RooFit, the errno side effect is not needed, anyway:
+target_compile_options(RooFit PUBLIC -fno-math-errno)
+
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -457,4 +457,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     inc/LinkDef.h
 )
 
+# For recent clang, this can facilitate auto-vectorisation.
+# In RooFit, the errno side effect is not needed, anyway:
+target_compile_options(RooFitCore PUBLIC -fno-math-errno)
+
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/roofitmore/CMakeLists.txt
+++ b/roofit/roofitmore/CMakeLists.txt
@@ -52,5 +52,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitMore
     Foam
 )
 
+# For recent clang, this can facilitate auto-vectorisation.
+# In RooFit, the errno side effect is not needed, anyway:
+target_compile_options(RooFitMore PUBLIC -fno-math-errno)
+
 
 #ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
For clang, this facilitates auto vectorisation by disabling the side effects of `std::` math functions.

This was recommended by @hageboeck in this issue thread:
https://github.com/root-project/root/issues/7032#issuecomment-773951513

In particular, this will benefit the [computation of the log-likelihood](https://github.com/root-project/root/blob/master/roofit/roofitcore/src/RooAbsPdf.cxx#L736) if `vdt` is not used.

One can try this little example to see that it works:
```C++
// compile with:
// clang++ -march=native -o test test.cc -Rpass-analysis=loop-vectorize  -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -O3
// or with no-math-errno to disable the side effects of std:: math functions:
// clang++ -march=native -o test test.cc -Rpass-analysis=loop-vectorize  -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -O3 -fno-math-errno

#include <vector>
#include <iostream>
#include <cmath>

int main() {

    std::vector<double> vals(1000, 1.1);

    for(std::size_t i = 0; i < vals.size(); ++i) {
        vals[i] = std::log(vals[i]);
    }

    std::cout << vals[0] << std::endl;

    return 0;
}
```