### PR TITLE
[Tutorials] Remove GetXaxis()->SetTitle() from tutorials.

### DIFF
--- a/tutorials/dataframe/df101_h1Analysis.C
+++ b/tutorials/dataframe/df101_h1Analysis.C
@@ -59,7 +59,6 @@ void FitAndPlotHdmd(TH1 &hdmd)
    // create the canvas for the h1analysis fit
    gStyle->SetOptFit();
    auto c1 = new TCanvas("c1", "h1analysis analysis", 10, 10, 800, 600);
-   hdmd.GetXaxis()->SetTitle("m_{K#pi#pi} - m_{K#pi}[GeV/c^{2}]");
    hdmd.GetXaxis()->SetTitleOffset(1.4);
 
    // fit histogram hdmd with function f5 using the loglikelihood option
@@ -109,7 +108,8 @@ void df101_h1Analysis()
 
    ROOT::RDataFrame dataFrame(chain);
    auto selected = Select(dataFrame);
-   auto hdmdARP = selected.Histo1D({"hdmd", "Dm_d", 40, 0.13, 0.17}, "dm_d");
+   // Note: The title syntax is "<Title>;<Label x axis>;<Label y axis>"
+   auto hdmdARP = selected.Histo1D({"hdmd", "Dm_d;m_{K#pi#pi} - m_{K#pi}[GeV/c^{2}]", 40, 0.13, 0.17}, "dm_d");
    auto selectedAddedBranch = selected.Define("h2_y", "rpd0_t / 0.029979f * 1.8646f / ptd0_d");
    auto h2ARP = selectedAddedBranch.Histo2D({"h2", "ptD0 vs Dm_d", 30, 0.135, 0.165, 30, -3, 6}, "dm_d", "h2_y");
 

--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -46,8 +46,8 @@ void df102_NanoAODDimuonAnalysis()
    // Compute invariant mass of the dimuon system
    auto df_mass = df_os.Define("Dimuon_mass", InvariantMass<float>, {"Muon_pt", "Muon_eta", "Muon_phi", "Muon_mass"});
 
-   // Make histogram of dimuon mass spectrum
-   auto h = df_mass.Histo1D({"Dimuon_mass", "Dimuon_mass", 30000, 0.25, 300}, "Dimuon_mass");
+   // Make histogram of dimuon mass spectrum. Note how we can set title and axis labels in one go
+   auto h = df_mass.Histo1D({"Dimuon_mass", "Dimuon mass;m_{#mu#mu} (GeV);N_{Events}", 30000, 0.25, 300}, "Dimuon_mass");
 
    // Request cut-flow report
    auto report = df_mass.Report();
@@ -57,9 +57,8 @@ void df102_NanoAODDimuonAnalysis()
    auto c = new TCanvas("c", "", 800, 700);
    c->SetLogx(); c->SetLogy();
 
-   h->SetTitle("");
-   h->GetXaxis()->SetTitle("m_{#mu#mu} (GeV)"); h->GetXaxis()->SetTitleSize(0.04);
-   h->GetYaxis()->SetTitle("N_{Events}"); h->GetYaxis()->SetTitleSize(0.04);
+   h->GetXaxis()->SetTitleSize(0.04);
+   h->GetYaxis()->SetTitleSize(0.04);
    h->DrawClone();
 
    TLatex label; label.SetNDC(true);

--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.py
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.py
@@ -36,8 +36,8 @@ df_os = df_2mu.Filter("Muon_charge[0] != Muon_charge[1]", "Muons with opposite c
 # Compute invariant mass of the dimuon system
 df_mass = df_os.Define("Dimuon_mass", "InvariantMass(Muon_pt, Muon_eta, Muon_phi, Muon_mass)")
 
-# Make histogram of dimuon mass spectrum
-h = df_mass.Histo1D(("Dimuon_mass", "Dimuon_mass", 30000, 0.25, 300), "Dimuon_mass")
+# Make histogram of dimuon mass spectrum. Note how we can set titles and axis labels in one go.
+h = df_mass.Histo1D(("Dimuon_mass", "Dimuon mass;m_{#mu#mu} (GeV);N_{Events}", 30000, 0.25, 300), "Dimuon_mass")
 
 # Request cut-flow report
 report = df_mass.Report()
@@ -48,8 +48,8 @@ c = ROOT.TCanvas("c", "", 800, 700)
 c.SetLogx(); c.SetLogy()
 
 h.SetTitle("")
-h.GetXaxis().SetTitle("m_{#mu#mu} (GeV)"); h.GetXaxis().SetTitleSize(0.04)
-h.GetYaxis().SetTitle("N_{Events}"); h.GetYaxis().SetTitleSize(0.04)
+h.GetXaxis().SetTitleSize(0.04)
+h.GetYaxis().SetTitleSize(0.04)
 h.Draw()
 
 label = ROOT.TLatex(); label.SetNDC(True)


### PR DESCRIPTION
In looking through the tutorials, I noticed that some are explicitly
setting axis labels. This is unnecessary, since it can be done
in the constructor.
This makes the plotting code less cluttered, and goes more a long the
principles of using RAII.