### PR TITLE
Fix possible typo in TKDE.cxx

### DIFF
--- a/hist/hist/src/TKDE.cxx
+++ b/hist/hist/src/TKDE.cxx
@@ -535,7 +535,7 @@ void TKDE::SetMirroredEvents() {
       SetBinCountData();
 
       // now mirror the bins
-      assert(fNBins = fData.size());
+      assert(fNBins == fData.size());
       if (fMirrorLeft) {
          fData.insert(fData.begin(), fNBins, 0.);
          fBinCount.insert(fBinCount.begin(), fNBins, 0.);


### PR DESCRIPTION
I get this error in one of my builds. Maybe a typo?
```
/home/vpadulan/Programs/rootproject/root/hist/hist/src/TKDE.cxx:538:21: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
```