### PR TITLE
[v6-22-00] fix memory leak in rooproduct

### DIFF
--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -148,6 +148,8 @@ RooProduct::ProdMap* RooProduct::groupProductTerms(const RooArgSet& allVars) con
   }
   if (indep->getSize()!=0) {
     map->push_back( std::make_pair(new RooArgSet(),indep) );
+  } else {
+     delete indep;
   }
 
   // Map observables -> functions ; start with individual observables


### PR DESCRIPTION
This is the backport of the little bug fix PR https://github.com/root-project/root/pull/7137 to v6-22-00.