### PR TITLE
Update builtin VecCore to 0.7.0 for ROOT 6.22

### DIFF
--- a/README/ReleaseNotes/v622/index.md
+++ b/README/ReleaseNotes/v622/index.md
@@ -945,3 +945,9 @@ ROOT will implement a workaround for this in an upcoming release.
 ## HEAD of the v6-22-00-patches branch
 
 These changes will be part of a future 6.22/06.
+
+### Build, Configuration and Testing Infrastructure
+
+The following builtins have been updated:
+
+- VecCore 0.7.0

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1354,7 +1354,7 @@ elseif(veccore)
 endif()
 
 if(builtin_veccore)
-  set(VecCore_VERSION "0.6.0")
+  set(VecCore_VERSION "0.7.0")
   set(VecCore_PROJECT "VecCore-${VecCore_VERSION}")
   set(VecCore_SRC_URI "${lcgpackages}/${VecCore_PROJECT}.tar.gz")
   set(VecCore_DESTDIR "${CMAKE_BINARY_DIR}/externals")
@@ -1362,7 +1362,7 @@ if(builtin_veccore)
 
   ExternalProject_Add(VECCORE
     URL     ${VecCore_SRC_URI}
-    URL_HASH SHA256=db404d745906efec2a76175995e847af9174df5a8da1e5ccdb241c773d7c8df9
+    URL_HASH SHA256=61d9fc4be815c5c98088c2796763d3ed82ba4bad5a69b7892c1c2e7e1e53d311
     BUILD_IN_SOURCE 0
     LOG_DOWNLOAD 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
     CMAKE_ARGS -G ${CMAKE_GENERATOR}


### PR DESCRIPTION
Backport of #7064.