### PR TITLE
[TreeProcMT] Fix reading of different trees in the same file

### DIFF
--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -338,7 +338,10 @@ TTreeView::GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::st
 {
    const bool hasEntryList = entryList.GetN() > 0;
    const bool usingLocalEntries = friendInfo.fFriendNames.empty() && !hasEntryList;
-   if (fChain == nullptr || (usingLocalEntries && fileNames[0] != fChain->GetListOfFiles()->At(0)->GetTitle())) {
+   const bool needNewChain =
+      fChain == nullptr || (usingLocalEntries && (fileNames[0] != fChain->GetListOfFiles()->At(0)->GetTitle() ||
+                                                  treeNames[0] != fChain->GetListOfFiles()->At(0)->GetName()));
+   if (needNewChain) {
       MakeChain(treeNames, fileNames, friendInfo, nEntries, friendEntries);
       if (hasEntryList) {
          fEntryList.reset(new TEntryList(entryList));


### PR DESCRIPTION
The previous logic assumed that different samples would belong to
files with different names.
This could potentially result in wrong data being silently read in
case subsequent samples had same or fewer entries than the first
sample processed by a given thread.

This fixes #7143 .

@phi-mah please let me know if this looks reasonable/if this fixes your usecase.