### PR TITLE
[TreeProcMT] Fix reading of different trees in the same file (v6.22)

### DIFF
--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -340,7 +340,10 @@ TTreeView::GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::st
 {
    const bool hasEntryList = entryList.GetN() > 0;
    const bool usingLocalEntries = friendInfo.fFriendNames.empty() && !hasEntryList;
-   if (fChain == nullptr || (usingLocalEntries && fileNames[0] != fChain->GetListOfFiles()->At(0)->GetTitle())) {
+   const bool needNewChain =
+      fChain == nullptr || (usingLocalEntries && (fileNames[0] != fChain->GetListOfFiles()->At(0)->GetTitle() ||
+                                                  treeNames[0] != fChain->GetListOfFiles()->At(0)->GetName()));
+   if (needNewChain) {
       MakeChain(treeNames, fileNames, friendInfo, nEntries, friendEntries);
       if (hasEntryList) {
          fEntryList.reset(new TEntryList(entryList));


### PR DESCRIPTION
Backport of #7149, fixes #7143.