### PR TITLE
[TTreeReader] Quit event loop when main tree entries are over

### DIFF
--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -612,7 +612,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
       }
    }
 
-   if (fEndEntry >= 0 && entry >= fEndEntry) {
+   if ((fEndEntry >= 0 && entry >= fEndEntry) || (fEntry >= fTree->GetEntriesFast())) {
       fEntryStatus = kEntryBeyondEnd;
       return fEntryStatus;
    }


### PR DESCRIPTION
Before this commit, when using TTreeReader to loop over a dataset with
a friend TTree with more entries than the main TTree, TTreeReader would
run the event loop until the last entry _of the friend_, beyond the end
of the main TTree.

This is inconsistent with the behavior of e.g. TTree::Draw, as well as
the behavior of TTreeReader itself when fTree is a TChain rather than a
TTree.
This issue is described in more detail at
https://github.com/root-project/root/issues/6518.

With this patch, we quit the event loop as soon as the entries of the
main tree are over.

This fixes #6518.