### PR TITLE
Allow commands with only one character in TGCommandPlugin

### DIFF
--- a/gui/gui/src/TGCommandPlugin.cxx
+++ b/gui/gui/src/TGCommandPlugin.cxx
@@ -138,7 +138,7 @@ void TGCommandPlugin::CheckRemote(const char * /*str*/)
 void TGCommandPlugin::HandleCommand()
 {
    const char *string = fCommandBuf->GetString();
-   if (strlen(string) > 1) {
+   if (strlen(string) > 0) {
       // form temporary file path
       TString sPrompt = "root []";
       TString pathtmp = TString::Format("%s/command.%d.log",


### PR DESCRIPTION
For example, imagine you define a variable int x = 3;

Then, you could type 'x' and press ENTER so that the command line shows its value.