### PR TITLE
Add a circular buffer to compute the mean value (fix issue #7164)

### DIFF
--- a/gui/gui/inc/TGSpeedo.h
+++ b/gui/gui/inc/TGSpeedo.h
@@ -61,6 +61,9 @@ protected:
    Bool_t           fThresholdActive;     // kTRUE if glowing threhsholds are active
    Bool_t           fPeakMark;            // kTRUE if peak mark is active
    Bool_t           fMeanMark;            // kTRUE if mean mark is active
+   Int_t            fBufferSize;          // circular bufffer size
+   Int_t            fBufferCount;         // circular bufffer count
+   std::vector<Float_t> fBuffer;          // circular bufffer for mean calculation
 
    virtual void     DoRedraw();
            void     DrawNeedle();
@@ -83,6 +86,7 @@ public:
    Float_t              GetScaleMin() const { return fScaleMin; }
    Float_t              GetScaleMax() const { return fScaleMax; }
    Bool_t               IsThresholdActive() { return fThresholdActive; }
+   Float_t              GetMean();
 
    void Build();
    void Glow(EGlowColor col = kGreen);
@@ -105,6 +109,7 @@ public:
    void DisableMeanMark() { fMeanMark = kFALSE; }
    void ResetPeakVal() { fPeakVal = fValue; fClient->NeedRedraw(this); }
    void SetMeanValue(Float_t mean) { fMeanVal = mean; fClient->NeedRedraw(this); }
+   void SetBufferSize(Int_t size);
 
    void OdoClicked() { Emit("OdoClicked()"); }   // *SIGNAL*
    void LedClicked() { Emit("LedClicked()"); }   // *SIGNAL*

--- a/gui/gui/inc/TGSpeedo.h
+++ b/gui/gui/inc/TGSpeedo.h
@@ -61,9 +61,9 @@ protected:
    Bool_t           fThresholdActive;     // kTRUE if glowing threhsholds are active
    Bool_t           fPeakMark;            // kTRUE if peak mark is active
    Bool_t           fMeanMark;            // kTRUE if mean mark is active
-   Int_t            fBufferSize;          // circular bufffer size
-   Int_t            fBufferCount;         // circular bufffer count
-   std::vector<Float_t> fBuffer;          // circular bufffer for mean calculation
+   Int_t            fBufferSize;          // circular buffer size
+   Int_t            fBufferCount;         // circular buffer count
+   std::vector<Float_t> fBuffer;          // circular buffer for mean calculation
 
    virtual void     DoRedraw();
            void     DrawNeedle();

--- a/gui/gui/src/TGSpeedo.cxx
+++ b/gui/gui/src/TGSpeedo.cxx
@@ -417,7 +417,7 @@ void TGSpeedo::SetScaleValue(Float_t val)
       else
          fBuffer[fBufferCount % fBufferSize] = fValue;
       ++fBufferCount;
-      if ((fBufferCount + 1) > fBuffer.size())
+      if ((fBufferCount + 1) > (Int_t)fBuffer.size())
          fBufferCount = 0;
    }
 

--- a/gui/gui/src/TGSpeedo.cxx
+++ b/gui/gui/src/TGSpeedo.cxx
@@ -419,7 +419,7 @@ void TGSpeedo::SetScaleValue(Float_t val)
       else
          fBuffer[fBufferCount % fBufferSize] = fValue;
       ++fBufferCount;
-      if ((fBufferCount + 1) > fBufferSize)
+      if (fBufferCount == fBufferSize)
          fBufferCount = 0;
    }
 

--- a/gui/gui/src/TGSpeedo.cxx
+++ b/gui/gui/src/TGSpeedo.cxx
@@ -73,8 +73,7 @@ TGSpeedo::TGSpeedo(const TGWindow *p, int id)
    if (!fImage || !fImage->IsValid())
       Error("TGSpeedo::Build", "%s not found", fPicName.Data());
    fBufferCount = 0;
-   fBufferSize = 10;
-   fBuffer.resize(fBufferSize, 0.0);
+   fBufferSize = 0;
    Build();
    AddInput(kButtonPressMask | kButtonReleaseMask);
 }
@@ -113,8 +112,7 @@ TGSpeedo::TGSpeedo(const TGWindow *p, Float_t smin, Float_t smax,
    if (!fImage || !fImage->IsValid())
       Error("TGSpeedo::Build", "%s not found", fPicName.Data());
    fBufferCount = 0;
-   fBufferSize = 10;
-   fBuffer.resize(fBufferSize, 0.0);
+   fBufferSize = 0;
    Build();
    AddInput(kButtonPressMask | kButtonReleaseMask);
 }
@@ -413,10 +411,12 @@ void TGSpeedo::SetScaleValue(Float_t val)
    if (fValue > fPeakVal)
       fPeakVal = fValue;
 
-   fBuffer[fBufferCount % fBufferSize] = fValue;
-   ++fBufferCount;
-   if (fBufferCount >= fBufferSize)
-      fBufferCount = 0;
+   if (fBufferSize > 0) {
+      fBuffer[fBufferCount % fBufferSize] = fValue;
+      ++fBufferCount;
+      if (fBufferCount >= fBufferSize)
+         fBufferCount = 0;
+   }
 
    fAngle = fAngleMin + (fValue / ((fScaleMax - fScaleMin) /
            (fAngleMax - fAngleMin)));
@@ -511,7 +511,9 @@ void TGSpeedo::DrawNeedle()
    Translate(80.0, angle, &xpk0, &ypk0);
    Translate(67.0, angle, &xpk1, &ypk1);
 
-   fMeanVal = GetMean();
+   if (fBufferSize > 0) {
+      fMeanVal = GetMean();
+   }
    // compute x/y position of the mean mark
    angle = fAngleMin + (fMeanVal / ((fScaleMax - fScaleMin) /
           (fAngleMax - fAngleMin)));

--- a/gui/gui/src/TGSpeedo.cxx
+++ b/gui/gui/src/TGSpeedo.cxx
@@ -236,7 +236,7 @@ Float_t TGSpeedo::GetMean()
 {
    if ((fBufferSize == 0) || (fBuffer.size() == 0))
       return fMeanVal;
-   return (Float_t) std::accumulate(fBuffer.begin(), fBuffer.end(), 0.0) / fBuffer.size();
+   return std::accumulate(fBuffer.begin(), fBuffer.end(), 0.0f) / fBuffer.size();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -317,9 +317,15 @@ Bool_t TGSpeedo::HandleButton(Event_t *event)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the circular buffer size (used for the automatic mean calculation).
+/// SetMeanValue is ignored if SetBufferSize is called with a greater-than-zero
+/// argument. The mean value is then automatically calculated by using the sum
+/// of values contained in the buffer divided by their count.
+/// To disable automatic mean calculation, simply call SetBufferSize with a zero
+/// argument
 
 void TGSpeedo::SetBufferSize(Int_t size)
 {
+   if (size < 0) size = 0;
    fBufferSize = size;
    fBuffer.clear();
    fBuffer.reserve(fBufferSize);

--- a/gui/gui/src/TGSpeedo.cxx
+++ b/gui/gui/src/TGSpeedo.cxx
@@ -417,7 +417,7 @@ void TGSpeedo::SetScaleValue(Float_t val)
       else
          fBuffer[fBufferCount % fBufferSize] = fValue;
       ++fBufferCount;
-      if (fBufferCount >= fBufferSize)
+      if ((fBufferCount + 1) > fBuffer.size())
          fBufferCount = 0;
    }
 

--- a/gui/gui/src/TGSpeedo.cxx
+++ b/gui/gui/src/TGSpeedo.cxx
@@ -234,7 +234,7 @@ TGDimension TGSpeedo::GetDefaultSize() const
 
 Float_t TGSpeedo::GetMean()
 {
-   return (Float_t) std::accumulate(fBuffer.begin(), fBuffer.end(), 0.0) / fBufferSize;
+   return (Float_t) std::accumulate(fBuffer.begin(), fBuffer.end(), 0.0) / fBuffer.size();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -319,9 +319,9 @@ Bool_t TGSpeedo::HandleButton(Event_t *event)
 void TGSpeedo::SetBufferSize(Int_t size)
 {
    fBufferSize = size;
-   if (fBufferCount > fBufferSize)
-      fBufferCount = fBufferSize;
-   fBuffer.resize(fBufferSize);
+   fBuffer.clear();
+   fBuffer.reserve(fBufferSize);
+   fBufferCount = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -412,7 +412,10 @@ void TGSpeedo::SetScaleValue(Float_t val)
       fPeakVal = fValue;
 
    if (fBufferSize > 0) {
-      fBuffer[fBufferCount % fBufferSize] = fValue;
+      if (fBufferCount < fBufferSize)
+         fBuffer.push_back(fValue);
+      else
+         fBuffer[fBufferCount % fBufferSize] = fValue;
       ++fBufferCount;
       if (fBufferCount >= fBufferSize)
          fBufferCount = 0;

--- a/gui/gui/src/TGSpeedo.cxx
+++ b/gui/gui/src/TGSpeedo.cxx
@@ -234,6 +234,8 @@ TGDimension TGSpeedo::GetDefaultSize() const
 
 Float_t TGSpeedo::GetMean()
 {
+   if ((fBufferSize == 0) || (fBuffer.size() == 0))
+      return fMeanVal;
    return (Float_t) std::accumulate(fBuffer.begin(), fBuffer.end(), 0.0) / fBuffer.size();
 }
 
@@ -412,12 +414,12 @@ void TGSpeedo::SetScaleValue(Float_t val)
       fPeakVal = fValue;
 
    if (fBufferSize > 0) {
-      if (fBufferCount < fBufferSize)
+      if ((Int_t)fBuffer.size() < (fBufferCount + 1))
          fBuffer.push_back(fValue);
       else
          fBuffer[fBufferCount % fBufferSize] = fValue;
       ++fBufferCount;
-      if ((fBufferCount + 1) > (Int_t)fBuffer.size())
+      if ((fBufferCount + 1) > fBufferSize)
          fBufferCount = 0;
    }
 
@@ -514,9 +516,8 @@ void TGSpeedo::DrawNeedle()
    Translate(80.0, angle, &xpk0, &ypk0);
    Translate(67.0, angle, &xpk1, &ypk1);
 
-   if (fBufferSize > 0) {
-      fMeanVal = GetMean();
-   }
+   fMeanVal = GetMean();
+
    // compute x/y position of the mean mark
    angle = fAngleMin + (fMeanVal / ((fScaleMax - fScaleMin) /
           (fAngleMax - fAngleMin)));


### PR DESCRIPTION
Add a very simple circular buffer allowing to automatically compute and display the mean of last N values when enabling the mean mark with `EnableMeanMark()`. The size of the buffer can be changed with `SetBufferSize()`. Thanks to @ferdymercury for the suggestion