### PR TITLE
[rbrowser] let show RBrowser instead of TBrowser 

### DIFF
--- a/core/gui/inc/TBrowserImp.h
+++ b/core/gui/inc/TBrowserImp.h
@@ -2,7 +2,7 @@
 // Author: Fons Rademakers   15/11/95
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -29,20 +29,17 @@ class TGMainFrame;
 class TBrowserImp {
 
 protected:
-   TBrowser  *fBrowser;     //TBrowser associated with this implementation
-   Bool_t     fShowCycles;  //Show object cycle numbers in browser
+   TBrowser  *fBrowser{nullptr};     ///< TBrowser associated with this implementation
+   Bool_t     fShowCycles{kFALSE};   ///< Show object cycle numbers in browser
 
-   TBrowserImp(const TBrowserImp& br)
-     : fBrowser(br.fBrowser), fShowCycles(br.fShowCycles) { }
-   TBrowserImp& operator=(const TBrowserImp& br)
-     {if(this!=&br) {fBrowser=br.fBrowser; fShowCycles=br.fShowCycles;}
-     return *this;}
+   TBrowserImp(const TBrowserImp&) = delete;
+   TBrowserImp &operator=(const TBrowserImp& br) = delete;
 
 public:
-   TBrowserImp(TBrowser *b=nullptr) : fBrowser(b), fShowCycles(kFALSE) { }
+   TBrowserImp(TBrowser *b = nullptr);
    TBrowserImp(TBrowser *b, const char *title, UInt_t width, UInt_t height, Option_t *opt = "");
    TBrowserImp(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt = "");
-   virtual ~TBrowserImp() { }
+   virtual ~TBrowserImp() = default;
 
    virtual void      Add(TObject *, const char *, Int_t) { }
    virtual void      AddCheckBox(TObject *, Bool_t = kFALSE) { }
@@ -56,7 +53,7 @@ public:
    virtual void      RecursiveRemove(TObject *) { }
    virtual void      Refresh(Bool_t = kFALSE) { }
    virtual void      Show() { }
-   virtual void      SetDrawOption(Option_t *option="");
+   virtual void      SetDrawOption(Option_t * = "") { }
    virtual Option_t *GetDrawOption() const { return nullptr; }
 
    virtual Long_t    ExecPlugin(const char *, const char *, const char *, Int_t, Int_t) { return 0; }
@@ -64,17 +61,12 @@ public:
    virtual void      StartEmbedding(Int_t, Int_t) { }
    virtual void      StopEmbedding(const char *) { }
 
-   virtual TGMainFrame *GetMainFrame() const { return 0; }
+   virtual TGMainFrame *GetMainFrame() const { return nullptr; }
 
    virtual TBrowser *GetBrowser() const      { return fBrowser; }
    virtual void      SetBrowser(TBrowser *b) { fBrowser = b; }
 
    ClassDef(TBrowserImp,0)  //ABC describing browser implementation protocol
 };
-
-inline TBrowserImp::TBrowserImp(TBrowser *, const char *, UInt_t, UInt_t, Option_t *)
-   : fBrowser(0), fShowCycles(kFALSE) { }
-inline TBrowserImp::TBrowserImp(TBrowser *, const char *, Int_t, Int_t, UInt_t, UInt_t, Option_t *)
-   : fBrowser(0), fShowCycles(kFALSE) { }
 
 #endif

--- a/core/gui/src/TBrowserImp.cxx
+++ b/core/gui/src/TBrowserImp.cxx
@@ -2,7 +2,7 @@
 // Author: Fons Rademakers   15/11/95
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -19,4 +19,26 @@ ABC describing GUI independent browser implementation protocol.
 
 ClassImp(TBrowserImp);
 
-void TBrowserImp::SetDrawOption(Option_t * /*option*/) {}
+///////////////////////////////////////////////////////////////////
+/// Default constructor
+
+TBrowserImp::TBrowserImp(TBrowser *b) :
+   fBrowser(b), fShowCycles(kFALSE)
+{
+}
+
+///////////////////////////////////////////////////////////////////
+/// Constructor with browser width and height
+
+TBrowserImp::TBrowserImp(TBrowser *, const char *, UInt_t, UInt_t, Option_t *) :
+   fBrowser(nullptr), fShowCycles(kFALSE)
+{
+}
+
+///////////////////////////////////////////////////////////////////
+/// Constructor with browser x, y, width and height
+
+TBrowserImp::TBrowserImp(TBrowser *, const char *, Int_t, Int_t, UInt_t, UInt_t, Option_t *)
+   : fBrowser(nullptr), fShowCycles(kFALSE)
+{
+}

--- a/etc/plugins/TBrowserImp/P030_RWebBrowserImp.C
+++ b/etc/plugins/TBrowserImp/P030_RWebBrowserImp.C
@@ -1,0 +1,7 @@
+void P030_RWebBrowserImp()
+{
+   gPluginMgr->AddHandler("TBrowserImp", "ROOT::Experimental::RWebBrowserImp", "ROOT::Experimental::RWebBrowserImp",
+      "ROOTBrowserv7", "NewBrowser(TBrowser *, const char *, Int_t, Int_t, UInt_t, UInt_t)");
+   gPluginMgr->AddHandler("TBrowserImp", "ROOT::Experimental::RWebBrowserImp", "ROOT::Experimental::RWebBrowserImp",
+      "ROOTBrowserv7", "NewBrowser(TBrowser *, const char *, UInt_t, UInt_t)");
+}

--- a/gui/browserv7/CMakeLists.txt
+++ b/gui/browserv7/CMakeLists.txt
@@ -43,10 +43,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowserv7
     ROOT/RBrowserReply.hxx
     ROOT/RBrowserRequest.hxx
     ROOT/RFileDialog.hxx
+    ROOT/RWebBrowserImp.hxx
   SOURCES
     src/RBrowser.cxx
     src/RBrowserData.cxx
     src/RFileDialog.cxx
+    src//RWebBrowserImp.cxx
   LIBRARIES
     ROOTBrowserWidgets
   DEPENDENCIES

--- a/gui/browserv7/inc/LinkDef.h
+++ b/gui/browserv7/inc/LinkDef.h
@@ -20,4 +20,6 @@
 #pragma link C++ class ROOT::Experimental::RBrowser+;
 #pragma link C++ class ROOT::Experimental::RFileDialog+;
 
+#pragma link C++ class ROOT::Experimental::RWebBrowserImp+;
+
 #endif

--- a/gui/browserv7/inc/ROOT/RWebBrowserImp.hxx
+++ b/gui/browserv7/inc/ROOT/RWebBrowserImp.hxx
@@ -1,0 +1,47 @@
+// Author: Sergey Linev <S.Linev@gsi.de>
+// Date: 2021-02-11
+// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RWebBrowserImp
+#define ROOT7_RWebBrowserImp
+
+#include "TBrowserImp.h"
+
+#include "ROOT/RBrowser.hxx"
+
+namespace ROOT {
+namespace Experimental {
+
+class RWebBrowserImp : public TBrowserImp {
+
+   std::shared_ptr<RBrowser> fWebBrowser;  ///< actual browser used
+   Int_t fX{-1}, fY{-1}, fWidth{0}, fHeight{0}; ///< window coordinates
+
+public:
+   RWebBrowserImp(TBrowser *b = nullptr);
+   RWebBrowserImp(TBrowser *b, const char *title, UInt_t width, UInt_t height, Option_t *opt = "");
+   RWebBrowserImp(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt = "");
+   virtual ~RWebBrowserImp();
+
+   void      Iconify() final;
+   void      Refresh(Bool_t = kFALSE) final;
+   void      Show() final;
+
+   static TBrowserImp *NewBrowser(TBrowser *b = nullptr, const char *title = "ROOT Browser", UInt_t width = 800, UInt_t height = 500, Option_t *opt = "");
+   static TBrowserImp *NewBrowser(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt = "");
+
+   ClassDefOverride(RWebBrowserImp,0)  // browser implementation for RBrowser
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/gui/browserv7/src/RWebBrowserImp.cxx
+++ b/gui/browserv7/src/RWebBrowserImp.cxx
@@ -1,0 +1,90 @@
+// Author: Sergey Linev <S.Linev@gsi.de>
+// Date: 2021-02-11
+// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RWebBrowserImp.hxx>
+
+using namespace ROOT::Experimental;
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Default constructor
+
+RWebBrowserImp::RWebBrowserImp(TBrowser *b) : TBrowserImp(b)
+{
+   fWebBrowser = std::make_shared<RBrowser>();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Constructor with width and height parameters
+
+RWebBrowserImp::RWebBrowserImp(TBrowser *b, const char *title, UInt_t width, UInt_t height, Option_t *opt) : TBrowserImp(b,title, width, height, opt)
+{
+   fWidth = width;
+   fHeight = height;
+   fWebBrowser = std::make_shared<RBrowser>();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Constructor with x,y, width and height parameters
+
+RWebBrowserImp::RWebBrowserImp(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt) : TBrowserImp(b,title, x, y, width, height, opt)
+{
+   fX = x;
+   fY = y;
+   fWidth = width;
+   fHeight = height;
+   fWebBrowser = std::make_shared<RBrowser>();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Constructor with width and height parameters
+
+RWebBrowserImp::~RWebBrowserImp()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Iconify browser
+
+void RWebBrowserImp::Iconify()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Refresh browser
+
+void RWebBrowserImp::Refresh(Bool_t)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Show browser
+
+void RWebBrowserImp::Show()
+{
+   fWebBrowser->Show();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Factory method to create RWebBrowserImp via plugin
+
+TBrowserImp *RWebBrowserImp::NewBrowser(TBrowser *b, const char *title, UInt_t width, UInt_t height, Option_t *opt)
+{
+   return new RWebBrowserImp(b, title, width, height, opt);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Factory method to create RWebBrowserImp via plugin
+
+TBrowserImp *RWebBrowserImp::NewBrowser(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt)
+{
+   return new RWebBrowserImp(b, title, x, y, width, height, opt);
+}

--- a/gui/gui/inc/TRootBrowser.h
+++ b/gui/gui/inc/TRootBrowser.h
@@ -2,7 +2,7 @@
 // Author: Bertrand Bellenot   26/09/2007
 
 /*************************************************************************
- * Copyright (C) 1995-2007, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -34,9 +34,9 @@ class TGHSplitter;
 class TBrowserPlugin : public TNamed
 {
 public:
-   Int_t    fTab;             // Tab number
-   Int_t    fSubTab;          // Tab element number
-   TString  fCommand;         // Command to be executed
+   Int_t    fTab{0};             // Tab number
+   Int_t    fSubTab{0};          // Tab element number
+   TString  fCommand;            // Command to be executed
 
    TBrowserPlugin(const char *name, const char *cmd = "", Int_t tab = 1,
                   Int_t sub = -1) : TNamed(name, cmd), fTab(tab),
@@ -51,9 +51,8 @@ public:
 };
 
 class TRootBrowser : public TGMainFrame, public TBrowserImp {
-private:
-   TRootBrowser(const TRootBrowser&); // Not implemented
-   TRootBrowser& operator=(const TRootBrowser&); // Not implemented
+   TRootBrowser(const TRootBrowser&) = delete;
+   TRootBrowser& operator=(const TRootBrowser&) = delete;
 
 protected:
 
@@ -121,17 +120,17 @@ public:
       kLeft, kRight, kBottom
    };
 
-   TRootBrowser(TBrowser *b = 0, const char *name = "ROOT Browser", UInt_t width = 800, UInt_t height = 500, Option_t *opt="", Bool_t initshow=kTRUE);
-   TRootBrowser(TBrowser *b, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt="", Bool_t initshow=kTRUE);
+   TRootBrowser(TBrowser *b = nullptr, const char *name = "ROOT Browser", UInt_t width = 800, UInt_t height = 500, Option_t *opt = "", Bool_t initshow = kTRUE);
+   TRootBrowser(TBrowser *b, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt = "", Bool_t initshow = kTRUE);
    virtual ~TRootBrowser();
 
    void              InitPlugins(Option_t *opt="");
 
    void              CreateBrowser(const char *name);
    void              CloneBrowser();
-   virtual void      CloseWindow();
+   void              CloseWindow() override;
    virtual void      CloseTab(Int_t id);
-   virtual void      CloseTabs();
+   void              CloseTabs() override;
    void              DoTab(Int_t id);
    void              EventInfo(Int_t event, Int_t px, Int_t py, TObject *selected);
    TGFrame          *GetActFrame() const { return (TGFrame *)fEditFrame; }
@@ -148,40 +147,40 @@ public:
    void              RemoveTab(Int_t pos, Int_t subpos);
    void              SetActBrowser(TBrowserImp *b) { fActBrowser = b; }
    void              ShowMenu(TGCompositeFrame *menu);
-   virtual void      StartEmbedding(Int_t pos = kRight, Int_t subpos = -1);
-   virtual void      StopEmbedding(const char *name = 0) { StopEmbedding(name, 0); }
+   void              StartEmbedding(Int_t pos = kRight, Int_t subpos = -1) override;
+   void              StopEmbedding(const char *name = nullptr) override { StopEmbedding(name, 0); }
    void              StopEmbedding(const char *name, TGLayoutHints *layout);
    void              SwitchMenus(TGCompositeFrame *from);
 
-   virtual void      BrowseObj(TObject *obj);             //*SIGNAL*
-   virtual void      ExecuteDefaultAction(TObject *obj);  //*SIGNAL*
+   void              BrowseObj(TObject *obj) override;             //*SIGNAL*
+   void              ExecuteDefaultAction(TObject *obj) override;  //*SIGNAL*
    virtual void      DoubleClicked(TObject *obj);         //*SIGNAL*
    virtual void      Checked(TObject *obj, Bool_t check); //*SIGNAL*
 
-   virtual void      Add(TObject *obj, const char *name = 0, Int_t check = -1);
-   virtual void      RecursiveRemove(TObject *obj);
-   virtual void      Refresh(Bool_t force = kFALSE);
-   virtual void      Show() { MapRaised(); }
-   Option_t         *GetDrawOption() const;
-   TGMainFrame      *GetMainFrame() const { return (TGMainFrame *)this; }
+   void              Add(TObject *obj, const char *name = nullptr, Int_t check = -1) override;
+   void              RecursiveRemove(TObject *obj) override;
+   void              Refresh(Bool_t force = kFALSE) override;
+   void              Show() override { MapRaised(); }
+   Option_t         *GetDrawOption() const override;
+   TGMainFrame      *GetMainFrame() const override { return (TGMainFrame *)this; }
 
-   virtual Long_t    ExecPlugin(const char *name = 0, const char *fname = 0,
-                                const char *cmd = 0, Int_t pos = kRight,
-                                Int_t subpos = -1);
-   virtual void      SetStatusText(const char *txt, Int_t col);
-   virtual Bool_t    HandleKey(Event_t *event);
+   Long_t            ExecPlugin(const char *name = nullptr, const char *fname = nullptr,
+                                const char *cmd = nullptr, Int_t pos = kRight,
+                                Int_t subpos = -1) override;
+   void              SetStatusText(const char *txt, Int_t col) override;
+   Bool_t            HandleKey(Event_t *event) override;
 
    virtual void      ShowCloseTab(Bool_t show) { fShowCloseTab = show; }
    virtual Bool_t    IsCloseTabShown() const { return fShowCloseTab; }
    Bool_t            IsWebGUI();
 
    // overridden from TGMainFrame
-   virtual void      ReallyDelete();
+   void              ReallyDelete() override;
 
-   static TBrowserImp *NewBrowser(TBrowser *b = 0, const char *title = "ROOT Browser", UInt_t width = 800, UInt_t height = 500, Option_t *opt="");
-   static TBrowserImp *NewBrowser(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt="");
+   static TBrowserImp *NewBrowser(TBrowser *b = nullptr, const char *title = "ROOT Browser", UInt_t width = 800, UInt_t height = 500, Option_t *opt = "");
+   static TBrowserImp *NewBrowser(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt = "");
 
-   ClassDef(TRootBrowser, 0) // New ROOT Browser
+   ClassDefOverride(TRootBrowser, 0) // New ROOT Browser
 };
 
 #endif

--- a/gui/gui/inc/TRootBrowserLite.h
+++ b/gui/gui/inc/TRootBrowserLite.h
@@ -2,7 +2,7 @@
 // Author: Fons Rademakers   27/02/98
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -97,6 +97,9 @@ private:
    Bool_t  HistoryForward();
    void    ClearHistory();
 
+   TRootBrowserLite(const TRootBrowserLite&) = delete;
+   TRootBrowserLite& operator=(const TRootBrowserLite&) = delete;
+
 protected:
    TGPopupMenu         *fFileMenu;
    TGPopupMenu         *fViewMenu;
@@ -117,57 +120,57 @@ protected:
    TGTextEdit          *fTextEdit;          // contents of browsed text file
 
 public:
-   TRootBrowserLite(TBrowser *b = 0, const char *title = "ROOT Browser", UInt_t width = 800, UInt_t height = 500);
+   TRootBrowserLite(TBrowser *b = nullptr, const char *title = "ROOT Browser", UInt_t width = 800, UInt_t height = 500);
    TRootBrowserLite(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height);
    virtual ~TRootBrowserLite();
 
-   virtual void Add(TObject *obj, const char *name = 0, Int_t check = -1);
+   void         Add(TObject *obj, const char *name = nullptr, Int_t check = -1) override;
    virtual void AddToBox(TObject *obj, const char *name);
    virtual void AddToTree(TObject *obj, const char *name, Int_t check = -1);
 
-   virtual void AddCheckBox(TObject *obj, Bool_t check = kFALSE);
-   virtual void CheckObjectItem(TObject *obj, Bool_t check = kFALSE);
-   virtual void RemoveCheckBox(TObject *obj);
+   void         AddCheckBox(TObject *obj, Bool_t check = kFALSE) override;
+   void         CheckObjectItem(TObject *obj, Bool_t check = kFALSE) override;
+   void         RemoveCheckBox(TObject *obj) override;
 
-   virtual void BrowseObj(TObject *obj);             //*SIGNAL*
-   virtual void ExecuteDefaultAction(TObject *obj);  //*SIGNAL*
+   void         BrowseObj(TObject *obj) override;             //*SIGNAL*
+   void         ExecuteDefaultAction(TObject *obj) override;  //*SIGNAL*
    virtual void DoubleClicked(TObject *obj);         //*SIGNAL*
    virtual void Checked(TObject *obj, Bool_t check); //*SIGNAL*
-   virtual void CloseTabs() { }
-   virtual void Iconify() { }
-   virtual void RecursiveRemove(TObject *obj);
-   virtual void Refresh(Bool_t force = kFALSE);
+   void         CloseTabs() override { }
+   void         Iconify() override { }
+   void         RecursiveRemove(TObject *obj) override;
+   void         Refresh(Bool_t force = kFALSE) override;
    virtual void ResizeBrowser() { }
    virtual void ShowToolBar(Bool_t show = kTRUE);
    virtual void ShowStatusBar(Bool_t show = kTRUE);
-   virtual void Show() { MapRaised(); }
-   virtual void SetDefaults(const char *iconStyle = 0, const char *sortBy = 0);
-   virtual Bool_t HandleKey(Event_t *event);
-   virtual void SetStatusText(const char *txt, Int_t col);
+   void         Show() override { MapRaised(); }
+   virtual void SetDefaults(const char *iconStyle = nullptr, const char *sortBy = nullptr);
+   Bool_t       HandleKey(Event_t *event) override;
+   void         SetStatusText(const char *txt, Int_t col) override;
 
    TGListTree      *GetListTree()  const { return fLt; }
    TGFileContainer *GetIconBox()   const;
    TGStatusBar     *GetStatusBar() const { return fStatusBar; }
-   TGMenuBar       *GetMenuBar()   const { return  fMenuBar; }
+   TGMenuBar       *GetMenuBar()   const { return fMenuBar; }
    TGToolBar       *GetToolBar()   const { return fToolBar; }
-   void             SetDrawOption(Option_t *option="");
-   Option_t        *GetDrawOption() const;
+   void             SetDrawOption(Option_t *option = "") override;
+   Option_t        *GetDrawOption() const override;
    void             SetSortMode(Int_t new_mode);
-   TGMainFrame     *GetMainFrame() const { return (TGMainFrame *)this; }
+   TGMainFrame     *GetMainFrame() const override { return (TGMainFrame *)this; }
 
    // overridden from TGMainFrame
-   void     CloseWindow();
-   Bool_t   ProcessMessage(Long_t msg, Long_t parm1, Long_t parm2);
-   void     ReallyDelete();
+   void     CloseWindow() override;
+   Bool_t   ProcessMessage(Long_t msg, Long_t parm1, Long_t parm2) override;
+   void     ReallyDelete() override;
 
-   // auxilary (a la privae) methods
+   // auxilary (a la private) methods
    void     ExecMacro();
    void     InterruptMacro();
 
-   static TBrowserImp *NewBrowser(TBrowser *b = 0, const char *title = "ROOT Browser", UInt_t width = 800, UInt_t height = 500, Option_t *opt="");
+   static TBrowserImp *NewBrowser(TBrowser *b = nullptr, const char *title = "ROOT Browser", UInt_t width = 800, UInt_t height = 500, Option_t *opt="");
    static TBrowserImp *NewBrowser(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt="");
 
-   ClassDef(TRootBrowserLite,0)  //ROOT native GUI version of browser
+   ClassDefOverride(TRootBrowserLite,0)  //ROOT native GUI version of browser
 };
 
 #endif

--- a/gui/gui/src/TRootBrowser.cxx
+++ b/gui/gui/src/TRootBrowser.cxx
@@ -2,7 +2,7 @@
 // Author: Bertrand Bellenot   26/09/2007
 
 /*************************************************************************
- * Copyright (C) 1995-2007, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/gui/gui/src/TRootBrowserLite.cxx
+++ b/gui/gui/src/TRootBrowserLite.cxx
@@ -2,7 +2,7 @@
 // Author: Fons Rademakers   27/02/98
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *


### PR DESCRIPTION
Provide TBrowserImp, register it in plugins
To enable one should add following entry in rootrc file:

    Browser.Name: ROOT::Experimental::RWebBrowserImp

Modernize TBrowserImp sources