### PR TITLE
Modernize core includes

### DIFF
--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -74,8 +74,8 @@ private:
    static Bool_t      fgGraphNeeded;    // True if graphics libs need to be initialized
    static Bool_t      fgGraphInit;      // True if graphics libs initialized
 
-   TApplication(const TApplication&);             // not implemented
-   TApplication& operator=(const TApplication&);  // not implemented
+   TApplication(const TApplication&) = delete;
+   TApplication& operator=(const TApplication&) = delete;
 
 protected:
    TApplication      *fAppRemote;      //Current remote application, if defined

--- a/core/base/inc/TBuffer.h
+++ b/core/base/inc/TBuffer.h
@@ -60,8 +60,8 @@ protected:
      fBufCur(0), fBufMax(0), fParent(0), fReAllocFunc(0), fCacheStack(0,(TVirtualArray*)0) {}
 
    // TBuffer objects cannot be copied or assigned
-   TBuffer(const TBuffer &);           // not implemented
-   void operator=(const TBuffer &);    // not implemented
+   TBuffer(const TBuffer &) = delete;
+   void operator=(const TBuffer &) = delete;
 
    Int_t Read(const char *name) { return TObject::Read(name); }
    Int_t Write(const char *name, Int_t opt, Int_t bufs)

--- a/core/base/inc/TEnv.h
+++ b/core/base/inc/TEnv.h
@@ -129,8 +129,8 @@ private:
    TString           fRcName;    // resource file base name
    Bool_t            fIgnoreDup; // ignore duplicates, don't issue warning
 
-   TEnv(const TEnv&);            // not implemented
-   TEnv& operator=(const TEnv&); // not implemented
+   TEnv(const TEnv&) = delete;
+   TEnv& operator=(const TEnv&) = delete;
 
    const char       *Getvalue(const char *name) const;
 
@@ -140,7 +140,7 @@ public:
 
    THashList          *GetTable() const { return fTable; }
    Bool_t              Defined(const char *name) const
-                                    { return Getvalue(name) != 0; }
+                                    { return Getvalue(name) != nullptr; }
 
    virtual const char *GetRcName() const { return fRcName; }
    virtual void        SetRcName(const char *name) { fRcName = name; }
@@ -151,7 +151,7 @@ public:
 
    virtual void        SetValue(const char *name, const char *value,
                                 EEnvLevel level = kEnvChange,
-                                const char *type = 0);
+                                const char *type = nullptr);
    virtual void        SetValue(const char *name, EEnvLevel level = kEnvChange);
    virtual void        SetValue(const char *name, Int_t value);
    virtual void        SetValue(const char *name, Double_t value);

--- a/core/base/inc/TFileCollection.h
+++ b/core/base/inc/TFileCollection.h
@@ -49,8 +49,8 @@ private:
    Long64_t    fNStagedFiles;       // number of staged files
    Long64_t    fNCorruptFiles;      // number of corrupt files
 
-   TFileCollection(const TFileCollection&);             // not implemented
-   TFileCollection& operator=(const TFileCollection&);  // not implemented
+   TFileCollection(const TFileCollection&) = delete;
+   TFileCollection& operator=(const TFileCollection&) = delete;
 
    void PrintDetailed(TString &showOnly) const;
    void FormatSize(Long64_t bytes, TString &um, Double_t &size) const;
@@ -59,8 +59,8 @@ public:
    enum EStatusBits {
       kRemoteCollection = BIT(15)   // the collection is not staged
    };
-   TFileCollection(const char *name = 0, const char *title = 0,
-                   const char *file = 0, Int_t nfiles = -1, Int_t firstfile = 1);
+   TFileCollection(const char *name = nullptr, const char *title = nullptr,
+                   const char *file = nullptr, Int_t nfiles = -1, Int_t firstfile = 1);
    virtual ~TFileCollection();
 
    Int_t           Add(TFileInfo *info);

--- a/core/base/inc/TFileInfo.h
+++ b/core/base/inc/TFileInfo.h
@@ -51,7 +51,7 @@ private:
 
    void             ParseInput(const char *in);
 
-   TFileInfo& operator=(const TFileInfo&);  // not implemented
+   TFileInfo& operator=(const TFileInfo&) = delete;
 
 public:
    enum EStatusBits {
@@ -115,7 +115,7 @@ private:
    Long64_t      fTotBytes;   // uncompressed size in bytes
    Long64_t      fZipBytes;   // compressed size in bytes
 
-   TFileInfoMeta& operator=(const TFileInfoMeta&);  // not implemented
+   TFileInfoMeta& operator=(const TFileInfoMeta &) = delete;
 
 public:
    enum EStatusBits { kExternal  = BIT(15) };

--- a/core/base/inc/TMemberInspector.h
+++ b/core/base/inc/TMemberInspector.h
@@ -40,8 +40,8 @@ private:
    TParentBuf* fParent; // current inspection "path"
    EObjectPointerState fObjectPointerState; // whether the address is valid or only an offset
 
-   TMemberInspector(const TMemberInspector&);            // Not implemented.
-   TMemberInspector &operator=(const TMemberInspector&); // Not implemented.
+   TMemberInspector(const TMemberInspector &) = delete;
+   TMemberInspector &operator=(const TMemberInspector &) = delete;
 
 public:
    TMemberInspector();

--- a/core/base/inc/TPRegexp.h
+++ b/core/base/inc/TPRegexp.h
@@ -97,7 +97,7 @@ public:
 class TPMERegexp : protected TPRegexp {
 
 private:
-   TPMERegexp& operator=(const TPMERegexp&);  // Not implemented
+   TPMERegexp& operator=(const TPMERegexp&) = delete;
 
 protected:
    Int_t    fNMaxMatches;         // maximum number of matches

--- a/core/base/inc/TPluginManager.h
+++ b/core/base/inc/TPluginManager.h
@@ -119,12 +119,12 @@ private:
 
    TPluginHandler() :
       fBase(), fRegexp(), fClass(), fPlugin(), fCtor(), fOrigin(),
-      fCallEnv(0), fMethod(0), fCanCall(0), fIsMacro(kTRUE), fIsGlobal(kTRUE) { }
+      fCallEnv(nullptr), fMethod(nullptr), fCanCall(0), fIsMacro(kTRUE), fIsGlobal(kTRUE) { }
    TPluginHandler(const char *base, const char *regexp,
                   const char *className, const char *pluginName,
                   const char *ctor, const char *origin);
-   TPluginHandler(const TPluginHandler&);            // not implemented
-   TPluginHandler& operator=(const TPluginHandler&); // not implemented
+   TPluginHandler(const TPluginHandler &) = delete;
+   TPluginHandler& operator=(const TPluginHandler &) = delete;
 
    ~TPluginHandler();
 
@@ -185,8 +185,8 @@ private:
    THashTable *fBasesLoaded;  //! table of base classes already checked or loaded
    Bool_t      fReadingDirs;  //! true if we are running LoadHandlersFromPluginDirs
 
-   TPluginManager(const TPluginManager& pm);              // not implemented
-   TPluginManager& operator=(const TPluginManager& pm);   // not implemented
+   TPluginManager(const TPluginManager &) = delete;
+   TPluginManager& operator=(const TPluginManager &) = delete;
    void   LoadHandlerMacros(const char *path);
 
 public:

--- a/core/base/inc/TQObject.h
+++ b/core/base/inc/TQObject.h
@@ -77,8 +77,8 @@ protected:
    static TString CompressName(const char *method_name);
 
 private:
-   TQObject(const TQObject& tqo);            // not implemented
-   TQObject& operator=(const TQObject& tqo); // not implemented
+   TQObject(const TQObject &) = delete;
+   TQObject& operator=(const TQObject &) = delete;
 
 public:
    TQObject();

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -103,8 +103,8 @@ private:
    static Bool_t   fgRootInit;            //Singleton initialization flag
    static Bool_t   fgMemCheck;            //Turn on memory leak checker
 
-   TROOT(const TROOT&);                   //Not implemented
-   TROOT& operator=(const TROOT&);        //Not implemented
+   TROOT(const TROOT&) = delete;
+   TROOT& operator=(const TROOT&) = delete;
 
 protected:
    typedef std::atomic<TListOfEnums*> AListOfEnums_t;

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -334,8 +334,8 @@ protected:
    static const char     *StripOffProto(const char *path, const char *proto);
 
 private:
-   TSystem(const TSystem&) = delete;              // not implemented
-   TSystem& operator=(const TSystem&) = delete;   // not implemented
+   TSystem(const TSystem&) = delete;
+   TSystem& operator=(const TSystem&) = delete;
    Bool_t ExpandFileName(const char *fname, char *xname, const int kBufSize);
 
 public:

--- a/core/base/inc/TTimer.h
+++ b/core/base/inc/TTimer.h
@@ -61,8 +61,8 @@ protected:
    TString   fCommand;     // interpreter command to be executed
 
 private:
-   TTimer(const TTimer&);            // not implemented
-   TTimer& operator=(const TTimer&); // not implemented
+   TTimer(const TTimer&) = delete;
+   TTimer& operator=(const TTimer&) = delete;
 
 public:
    TTimer(Long_t milliSec = 0, Bool_t mode = kTRUE);

--- a/core/base/inc/TVirtualMutex.h
+++ b/core/base/inc/TVirtualMutex.h
@@ -69,8 +69,8 @@ class TLockGuard {
 private:
    TVirtualMutex *fMutex;
 
-   TLockGuard(const TLockGuard&);             // not implemented
-   TLockGuard& operator=(const TLockGuard&);  // not implemented
+   TLockGuard(const TLockGuard&) = delete;
+   TLockGuard& operator=(const TLockGuard&) = delete;
 
 public:
    TLockGuard(TVirtualMutex *mutex)

--- a/core/base/inc/TVirtualPS.h
+++ b/core/base/inc/TVirtualPS.h
@@ -30,8 +30,8 @@
 class TVirtualPS : public TNamed, public TAttLine, public TAttFill, public TAttMarker, public TAttText {
 
 private:
-   TVirtualPS(const TVirtualPS&); // Not implemented
-   TVirtualPS& operator=(const TVirtualPS&); // Not implemented
+   TVirtualPS(const TVirtualPS&) = delete;
+   TVirtualPS& operator=(const TVirtualPS&) = delete;
 
 protected:
    Int_t        fNByte;           //Number of bytes written in the file (PDF)

--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -53,7 +53,7 @@ class TVirtualPad : public TObject, public TAttLine, public TAttFill,
 protected:
    Bool_t         fResizing;         //!true when resizing the pad
 
-   virtual void  *GetSender() { return this; }  //used to set gTQSender
+   void  *GetSender() override { return this; }  //used to set gTQSender
 
 public:
    TVirtualPad();
@@ -67,14 +67,14 @@ public:
    virtual void     AddExec(const char *name, const char *command) = 0;
    virtual TLegend *BuildLegend(Double_t x1=0.3, Double_t y1=0.21, Double_t x2=0.3, Double_t y2=0.21, const char *title="", Option_t *option = "") = 0;
    virtual TVirtualPad* cd(Int_t subpadnumber=0) = 0;
-   virtual void     Clear(Option_t *option="") = 0;
+           void     Clear(Option_t *option="") override = 0;
    virtual Int_t    Clip(Double_t *x, Double_t *y, Double_t xclipl, Double_t yclipb, Double_t xclipr, Double_t yclipt) = 0;
    virtual void     Close(Option_t *option="") = 0;
    virtual void     CopyPixmap() = 0;
    virtual void     CopyPixmaps() = 0;
    virtual void     DeleteExec(const char *name) = 0;
    virtual void     Divide(Int_t nx=1, Int_t ny=1, Float_t xmargin=0.01, Float_t ymargin=0.01, Int_t color=0) = 0;
-   virtual void     Draw(Option_t *option="") = 0;
+           void     Draw(Option_t *option="") override = 0;
    virtual void     DrawClassObject(const TObject *obj, Option_t *option="") = 0;
    virtual TH1F    *DrawFrame(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax, const char *title="") = 0;
    virtual void     ExecuteEventAxis(Int_t event, Int_t px, Int_t py, TAxis *axis) = 0;
@@ -132,8 +132,8 @@ public:
    virtual Int_t    GetLogy() const = 0;
    virtual Int_t    GetLogz() const = 0;
    virtual TVirtualPad  *GetMother() const = 0;
-   virtual const char *GetName() const = 0;
-   virtual const char *GetTitle() const = 0;
+           const char *GetName() const override = 0;
+           const char *GetTitle() const override = 0;
    virtual Int_t    GetPadPaint() const = 0;
    virtual Int_t    GetPixmapID() const = 0;
    virtual TObject *GetView3D() const = 0;
@@ -146,13 +146,13 @@ public:
    virtual Bool_t   IsModified() const = 0;
    virtual Bool_t   IsRetained() const = 0;
    virtual Bool_t   IsVertical() const = 0;
-   virtual void     ls(Option_t *option="") const = 0;
+           void     ls(Option_t *option="") const override = 0;
    virtual void     Modified(Bool_t flag=1) = 0;
    virtual Bool_t   OpaqueMoving() const = 0;
    virtual Bool_t   OpaqueResizing() const = 0;
    virtual Double_t PadtoX(Double_t x) const = 0;
    virtual Double_t PadtoY(Double_t y) const = 0;
-   virtual void     Paint(Option_t *option="") = 0;
+           void     Paint(Option_t *option="") override = 0;
    virtual void     PaintBorderPS(Double_t xl,Double_t yl,Double_t xt,Double_t yt,Int_t bmode,Int_t bsize,Int_t dark,Int_t light) = 0;
    virtual void     PaintBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2, Option_t *option="") = 0;
    virtual void     PaintFillArea(Int_t n, Float_t *x, Float_t *y, Option_t *option="") = 0;
@@ -176,16 +176,16 @@ public:
    virtual void     PaintTextNDC(Double_t u, Double_t v, const wchar_t *text) = 0;
    virtual Double_t PixeltoX(Int_t px) = 0;
    virtual Double_t PixeltoY(Int_t py) = 0;
-   virtual void     Pop() = 0;
-   virtual void     Print(const char *filename="") const = 0;
+           void     Pop() override = 0;
+           void     Print(const char *filename="") const override = 0;
    virtual void     Print(const char *filename, Option_t *option) = 0;
    virtual void     Range(Double_t x1, Double_t y1, Double_t x2, Double_t y2) = 0;
    virtual void     RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) = 0;
-   virtual void     RecursiveRemove(TObject *obj) = 0;
+           void     RecursiveRemove(TObject *obj) override = 0;
    virtual void     RedrawAxis(Option_t *option="") = 0;
    virtual void     ResetView3D(TObject *view=0) = 0;
    virtual void     ResizePad(Option_t *option="") = 0;
-   virtual void     SaveAs(const char *filename="",Option_t *option="") const = 0;
+           void     SaveAs(const char *filename="",Option_t *option="") const override = 0;
    virtual void     SetBatch(Bool_t batch=kTRUE) = 0;
    virtual void     SetBorderMode(Short_t bordermode) = 0;
    virtual void     SetBorderSize(Short_t bordersize) = 0;
@@ -264,7 +264,7 @@ public:
 
    static TVirtualPad *&Pad();
 
-   ClassDef(TVirtualPad,3)  //Abstract base class for Pads and Canvases
+   ClassDefOverride(TVirtualPad,3)  //Abstract base class for Pads and Canvases
 };
 
 //
@@ -278,8 +278,8 @@ public:
    ~TPickerStackGuard();
 
 private:
-   TPickerStackGuard(const TPickerStackGuard &rhs);
-   TPickerStackGuard &operator = (const TPickerStackGuard &rhs);
+   TPickerStackGuard(const TPickerStackGuard &rhs) = delete;
+   TPickerStackGuard &operator = (const TPickerStackGuard &rhs) = delete;
 };
 
 

--- a/core/base/inc/TVirtualX.h
+++ b/core/base/inc/TVirtualX.h
@@ -59,7 +59,7 @@ public:
    TVirtualX(const char *name, const char *title);
    virtual ~TVirtualX() { }
 
-   virtual Bool_t    Init(void *display=0);
+   virtual Bool_t    Init(void *display = nullptr);
    virtual void      ClearWindow();
    virtual void      ClosePixmap();
    virtual void      CloseWindow();

--- a/core/base/src/TVirtualPS.cxx
+++ b/core/base/src/TVirtualPS.cxx
@@ -32,13 +32,13 @@ ClassImp(TVirtualPS);
 
 TVirtualPS::TVirtualPS()
 {
-   fStream    = 0;
+   fStream    = nullptr;
    fNByte     = 0;
    fSizBuffer = kMaxBuffer;
    fBuffer    = new char[fSizBuffer+1];
    fLenBuffer = 0;
    fPrinted   = kFALSE;
-   fImplicitCREsc = 0;
+   fImplicitCREsc = nullptr;
 }
 
 
@@ -48,13 +48,13 @@ TVirtualPS::TVirtualPS()
 TVirtualPS::TVirtualPS(const char *name, Int_t)
           : TNamed(name,"Postscript interface")
 {
-   fStream    = 0;
+   fStream    = nullptr;
    fNByte     = 0;
    fSizBuffer = kMaxBuffer;
    fBuffer    = new char[fSizBuffer+1];
    fLenBuffer = 0;
    fPrinted   = kFALSE;
-   fImplicitCREsc = 0;
+   fImplicitCREsc = nullptr;
 }
 
 

--- a/core/base/src/TVirtualX.cxx
+++ b/core/base/src/TVirtualX.cxx
@@ -56,7 +56,7 @@ TVirtualX::TVirtualX(const char *name, const char *title) : TNamed(name, title),
 
 TVirtualX *&TVirtualX::Instance()
 {
-   static TVirtualX *instance = 0;
+   static TVirtualX *instance = nullptr;
    if (gPtr2VirtualX) instance = gPtr2VirtualX();
    return instance;
 }

--- a/core/cont/inc/TCollectionProxyInfo.h
+++ b/core/cont/inc/TCollectionProxyInfo.h
@@ -254,7 +254,7 @@ namespace Detail {
       PairHolder(const PairHolder& c) : first(c.first), second(c.second) {}
       virtual ~PairHolder() {}
    private:
-      PairHolder& operator=(const PairHolder&);  // not implemented
+      PairHolder& operator=(const PairHolder&) = delete;
    };
 
    template <class T> struct Address {

--- a/core/cont/inc/THashList.h
+++ b/core/cont/inc/THashList.h
@@ -37,8 +37,8 @@ protected:
    THashTable   *fTable;    //Hashtable used for quick lookup of objects
 
 private:
-   THashList(const THashList&);              // not implemented
-   THashList& operator=(const THashList&);   // not implemented
+   THashList(const THashList&) = delete;
+   THashList& operator=(const THashList&) = delete;
 
 public:
    THashList(Int_t capacity=TCollection::kInitHashTableCapacity, Int_t rehash=0);

--- a/core/cont/inc/THashTable.h
+++ b/core/cont/inc/THashTable.h
@@ -49,8 +49,8 @@ private:
 
    void        AddImpl(Int_t slot, TObject *object);
 
-   THashTable(const THashTable&);             // not implemented
-   THashTable& operator=(const THashTable&);  // not implemented
+   THashTable(const THashTable&) = delete;
+   THashTable& operator=(const THashTable&) = delete;
 
 public:
    THashTable(Int_t capacity = TCollection::kInitHashTableCapacity, Int_t rehash = 0);
@@ -119,7 +119,7 @@ private:
    TListIter        *fListCursor;  //current position in collision list
    Bool_t            fDirection;   //iteration direction
 
-   THashTableIter() : fTable(0), fCursor(0), fListCursor(0), fDirection(kIterForward) { }
+   THashTableIter() : fTable(nullptr), fCursor(0), fListCursor(nullptr), fDirection(kIterForward) { }
    Int_t             NextSlot();
 
 public:

--- a/core/cont/inc/TList.h
+++ b/core/cont/inc/TList.h
@@ -69,8 +69,8 @@ protected:
    void InsertAfter(const TObjLinkPtr_t &newlink, const TObjLinkPtr_t &prev);
 
 private:
-   TList(const TList&);             // not implemented
-   TList& operator=(const TList&);  // not implemented
+   TList(const TList&) = delete;
+   TList& operator=(const TList&) = delete;
 
 public:
    typedef TListIter Iterator_t;
@@ -208,7 +208,7 @@ protected:
    Bool_t         fDirection;    //iteration direction
    Bool_t         fStarted;      //iteration started
 
-   TListIter() : fList(0), fCurCursor(0), fCursor(0), fDirection(kIterForward),
+   TListIter() : fList(nullptr), fCurCursor(), fCursor(), fDirection(kIterForward),
                  fStarted(kFALSE) { }
 
 public:

--- a/core/cont/inc/TMap.h
+++ b/core/cont/inc/TMap.h
@@ -44,8 +44,8 @@ friend class  TMapIter;
 private:
    THashTable   *fTable;     //Hash table used to store TPair's
 
-   TMap(const TMap& map);             // not implemented
-   TMap& operator=(const TMap& map);  // not implemented
+   TMap(const TMap& map) = delete;
+   TMap& operator=(const TMap& map) = delete;
 
 protected:
    enum EStatusBits { kIsOwnerValue = BIT(15) };
@@ -105,7 +105,7 @@ private:
    TObject  *fKey;
    TObject  *fValue;
 
-   TPair& operator=(const TPair&); // Not implemented
+   TPair& operator=(const TPair&) = delete;
 
 public:
    TPair(TObject *key, TObject *value) : fKey(key), fValue(value) { }
@@ -151,7 +151,7 @@ private:
    THashTableIter   *fCursor;      //current position in map
    Bool_t            fDirection;   //iteration direction
 
-   TMapIter() : fMap(0), fCursor(0), fDirection(kIterForward) { }
+   TMapIter() : fMap(nullptr), fCursor(nullptr), fDirection(kIterForward) { }
 
 public:
    TMapIter(const TMap *map, Bool_t dir = kIterForward);

--- a/core/cont/inc/TObjectTable.h
+++ b/core/cont/inc/TObjectTable.h
@@ -45,8 +45,8 @@ private:
    void       FixCollisions(Int_t index);
 
 private:
-   TObjectTable(const TObjectTable&);             // not implemented
-   TObjectTable& operator=(const TObjectTable&);  // not implemented
+   TObjectTable(const TObjectTable&) = delete;
+   TObjectTable& operator=(const TObjectTable&) = delete;
 
 public:
    TObjectTable(Int_t tableSize = 100);

--- a/core/cont/inc/TOrdCollection.h
+++ b/core/cont/inc/TOrdCollection.h
@@ -47,8 +47,8 @@ private:
    Bool_t     LowWaterMark() const;
    void       SetCapacity(Int_t newCapacity);
 
-   TOrdCollection(const TOrdCollection&); // Not implemented
-   TOrdCollection& operator=(const TOrdCollection&); // Not implemented
+   TOrdCollection(const TOrdCollection&) = delete;
+   TOrdCollection& operator=(const TOrdCollection&) = delete;
 
 public:
    enum { kDefaultCapacity = 1, kMinExpand = 8, kShrinkFactor = 2 };
@@ -104,7 +104,7 @@ private:
    Int_t                  fCursor;    //next position in collection
    Bool_t                 fDirection; //iteration direction
 
-   TOrdCollectionIter() : fCol(0), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
+   TOrdCollectionIter() : fCol(nullptr), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
 
 public:
    TOrdCollectionIter(const TOrdCollection *col, Bool_t dir = kIterForward);

--- a/core/cont/inc/TVirtualCollectionProxy.h
+++ b/core/cont/inc/TVirtualCollectionProxy.h
@@ -37,8 +37,8 @@ namespace TStreamerInfoActions {
 
 class TVirtualCollectionProxy {
 private:
-   TVirtualCollectionProxy(const TVirtualCollectionProxy&); // Not implemented
-   TVirtualCollectionProxy& operator=(const TVirtualCollectionProxy&); // Not implemented
+   TVirtualCollectionProxy(const TVirtualCollectionProxy&) = delete;
+   TVirtualCollectionProxy& operator=(const TVirtualCollectionProxy&) = delete;
 
 protected:
    TClassRef fClass;
@@ -64,8 +64,8 @@ public:
          void *objectstart) : fProxy(proxy) { fProxy->PushProxy(objectstart); }
       inline ~TPushPop() { fProxy->PopProxy(); }
    private:
-      TPushPop(const TPushPop&); // Not implemented
-      TPushPop& operator=(const TPushPop&); // Not implemented
+      TPushPop(const TPushPop&) = delete;
+      TPushPop& operator=(const TPushPop&) = delete;
    };
 
    TVirtualCollectionProxy() : fClass(), fProperties(0) {};

--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -148,8 +148,8 @@ namespace TClassEdit {
       bool IsTemplate();
 
    private:
-      TSplitType(const TSplitType&); // intentionally not implemented
-      TSplitType &operator=(const TSplitType &); // intentionally not implemented
+      TSplitType(const TSplitType&) = delete;
+      TSplitType &operator=(const TSplitType &) = delete;
    };
 
    void        Init(TClassEdit::TInterpreterLookupHelper *helper);

--- a/core/meta/inc/TBaseClass.h
+++ b/core/meta/inc/TBaseClass.h
@@ -42,8 +42,8 @@ class TBaseClass : public TDictionary {
 #endif
 
 private:
-   TBaseClass(const TBaseClass &);          // Not implemented
-   TBaseClass&operator=(const TBaseClass&); // Not implemented
+   TBaseClass(const TBaseClass &) = delete;
+   TBaseClass&operator=(const TBaseClass &) = delete;
 
 private:
    BaseClassInfo_t    *fInfo;      //!pointer to CINT base class info
@@ -54,7 +54,7 @@ private:
    Int_t               fSTLType;   // cache of IsSTLContainer()
 
 public:
-   TBaseClass(BaseClassInfo_t *info = 0, TClass *cl = 0);
+   TBaseClass(BaseClassInfo_t *info = nullptr, TClass *cl = nullptr);
    virtual     ~TBaseClass();
    virtual void   Browse(TBrowser *b);
    const char    *GetTitle() const;

--- a/core/meta/inc/TGenericClassInfo.h
+++ b/core/meta/inc/TGenericClassInfo.h
@@ -141,8 +141,8 @@ namespace ROOT {
       //   protected:
    private:
       void CreateRuleSet( std::vector<ROOT::Internal::TSchemaHelper>& vect, Bool_t ProcessReadRules );
-      TGenericClassInfo(const TGenericClassInfo&); // Not implemented
-      TGenericClassInfo& operator=(const TGenericClassInfo&); // Not implemented
+      TGenericClassInfo(const TGenericClassInfo &) = delete;
+      TGenericClassInfo& operator=(const TGenericClassInfo &) = delete;
 
    private:
       TGenericClassInfo();

--- a/core/meta/inc/TListOfFunctionTemplates.h
+++ b/core/meta/inc/TListOfFunctionTemplates.h
@@ -44,8 +44,8 @@ private:
    THashTable fOverloads; // TLists of overloads.
    ULong64_t  fLastLoadMarker; // Represent interpreter state when we last did a full load.
 
-   TListOfFunctionTemplates(const TListOfFunctionTemplates&);              // not implemented
-   TListOfFunctionTemplates& operator=(const TListOfFunctionTemplates&);   // not implemented
+   TListOfFunctionTemplates(const TListOfFunctionTemplates&) = delete;
+   TListOfFunctionTemplates& operator=(const TListOfFunctionTemplates&) = delete;
    TList     *GetListForObjectNonConst(const char* name);
 
    void       MapObject(TObject *obj);

--- a/core/meta/inc/TListOfFunctions.h
+++ b/core/meta/inc/TListOfFunctions.h
@@ -42,8 +42,8 @@ private:
    THashTable fOverloads; // TLists of overloads.
    ULong64_t  fLastLoadMarker; // Represent interpreter state when we last did a full load.
 
-   TListOfFunctions(const TListOfFunctions&);              // not implemented
-   TListOfFunctions& operator=(const TListOfFunctions&);   // not implemented
+   TListOfFunctions(const TListOfFunctions&) = delete;
+   TListOfFunctions& operator=(const TListOfFunctions&) = delete;
    TList     *GetListForObjectNonConst(const char* name);
 
    void       MapObject(TObject *obj);

--- a/core/meta/inc/TMethodArg.h
+++ b/core/meta/inc/TMethodArg.h
@@ -38,15 +38,15 @@ class TMethodArg : public TDictionary {
 friend class TMethod;
 
 private:
-   TMethodArg(const TMethodArg&);    // Not implemented
-   TMethodArg& operator=(const TMethodArg&);    // Not implemented
+   TMethodArg(const TMethodArg&) = delete;
+   TMethodArg& operator=(const TMethodArg&) = delete;
 
    MethodArgInfo_t   *fInfo;         //pointer to CINT method argument info
    TFunction         *fMethod;       //pointer to the method or global function
    TDataMember       *fDataMember;   //TDataMember pointed by this arg,to get values and options from.
 
 public:
-   TMethodArg(MethodArgInfo_t *info = 0, TFunction *method = 0);
+   TMethodArg(MethodArgInfo_t *info = nullptr, TFunction *method = nullptr);
    virtual       ~TMethodArg();
    const char    *GetDefault() const;
    TFunction     *GetMethod() const { return fMethod; }

--- a/core/meta/inc/TSchemaHelper.h
+++ b/core/meta/inc/TSchemaHelper.h
@@ -22,7 +22,7 @@ namespace Internal {
    {
       TSchemaHelper(): fTarget(), fSourceClass(),
        fSource(), fCode(), fVersion(), fChecksum(),
-       fInclude(), fEmbed(true), fFunctionPtr( 0 ),
+       fInclude(), fEmbed(true), fFunctionPtr(nullptr),
        fAttributes() {}
       std::string fTarget;
       std::string fSourceClass;

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -33,8 +33,8 @@ class TVirtualStreamerInfo;
 class TStreamerElement : public TNamed {
 
 private:
-   TStreamerElement(const TStreamerElement &);          // Not implemented
-   TStreamerElement&operator=(const TStreamerElement&); // Not implemented
+   TStreamerElement(const TStreamerElement &) = delete;
+   TStreamerElement&operator=(const TStreamerElement&) = delete;
 
 protected:
    Int_t            fType;            //element type
@@ -151,8 +151,8 @@ public:
 class TStreamerBase : public TStreamerElement {
 
 private:
-   TStreamerBase(const TStreamerBase &);          // Not implemented
-   TStreamerBase&operator=(const TStreamerBase&); // Not implemented
+   TStreamerBase(const TStreamerBase &) = delete;
+   TStreamerBase&operator=(const TStreamerBase&) = delete;
 
 protected:
    Int_t             fBaseVersion;    //version number of the base class (used during memberwise streaming)
@@ -199,8 +199,8 @@ public:
 class TStreamerBasicPointer : public TStreamerElement {
 
 private:
-   TStreamerBasicPointer(const TStreamerBasicPointer &);          // Not implemented
-   TStreamerBasicPointer&operator=(const TStreamerBasicPointer&); // Not implemented
+   TStreamerBasicPointer(const TStreamerBasicPointer &) = delete;
+   TStreamerBasicPointer&operator=(const TStreamerBasicPointer&) = delete;
 
 protected:
    Int_t               fCountVersion;   //version number of the class with the counter
@@ -214,7 +214,7 @@ public:
    TStreamerBasicPointer(const char *name, const char *title, Int_t offset, Int_t dtype,
                          const char *countName, const char *countClass, Int_t version, const char *typeName);
    virtual       ~TStreamerBasicPointer();
-   TClass        *GetClassPointer() const { return 0; }
+   TClass        *GetClassPointer() const { return nullptr; }
    const char    *GetCountClass()   const {return fCountClass.Data();}
    const char    *GetCountName()    const {return fCountName.Data();}
    Int_t          GetCountVersion() const {return fCountVersion;}
@@ -236,8 +236,8 @@ public:
 class TStreamerLoop : public TStreamerElement {
 
 private:
-   TStreamerLoop(const TStreamerLoop&);          // Not implemented
-   TStreamerLoop&operator=(const TStreamerLoop&); // Not implemented
+   TStreamerLoop(const TStreamerLoop&) = delete;
+   TStreamerLoop&operator=(const TStreamerLoop&) = delete;
 
 protected:
    Int_t               fCountVersion;   //version number of the class with the counter
@@ -256,7 +256,7 @@ public:
    const char    *GetInclude() const;
    ULong_t        GetMethod() const;
    Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj=0);
+   virtual void   Init(TVirtualStreamerInfo *obj = nullptr);
    virtual Bool_t IsaPointer() const                {return kTRUE;         }
    virtual Bool_t HasCounter() const                {return fCounter!=0;   }
    void           SetCountClass(const char *clname) {fCountClass = clname; }
@@ -270,8 +270,8 @@ public:
 class TStreamerBasicType : public TStreamerElement {
 
 private:
-   TStreamerBasicType(const TStreamerBasicType&);          // Not implemented
-   TStreamerBasicType&operator=(const TStreamerBasicType&); // Not implemented
+   TStreamerBasicType(const TStreamerBasicType&) = delete;
+   TStreamerBasicType&operator=(const TStreamerBasicType&) = delete;
 
 protected:
    Int_t             fCounter;     //!value of data member when referenced by an array
@@ -281,7 +281,7 @@ public:
    TStreamerBasicType();
    TStreamerBasicType(const char *name, const char *title, Int_t offset, Int_t dtype, const char *typeName);
    virtual       ~TStreamerBasicType();
-   TClass        *GetClassPointer() const { return 0; }
+   TClass        *GetClassPointer() const { return nullptr; }
    Int_t          GetCounter() const {return fCounter;}
    ULong_t        GetMethod() const;
    Int_t          GetSize() const;
@@ -294,8 +294,8 @@ public:
 class TStreamerObject : public TStreamerElement {
 
 private:
-   TStreamerObject(const TStreamerObject&);          // Not implemented
-   TStreamerObject&operator=(const TStreamerObject&); // Not implemented
+   TStreamerObject(const TStreamerObject&) = delete;
+   TStreamerObject&operator=(const TStreamerObject&) = delete;
 
 public:
 
@@ -304,7 +304,7 @@ public:
    virtual       ~TStreamerObject();
    const char    *GetInclude() const;
    Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj=0);
+   virtual void   Init(TVirtualStreamerInfo *obj = nullptr);
 
    ClassDef(TStreamerObject,2)  //Streamer element of type object
 };
@@ -313,8 +313,8 @@ public:
 class TStreamerObjectAny : public TStreamerElement {
 
 private:
-   TStreamerObjectAny(const TStreamerObjectAny&);          // Not implemented
-   TStreamerObjectAny&operator=(const TStreamerObjectAny&); // Not implemented
+   TStreamerObjectAny(const TStreamerObjectAny&) = delete;
+   TStreamerObjectAny&operator=(const TStreamerObjectAny&) = delete;
 
 public:
 
@@ -332,8 +332,8 @@ public:
 class TStreamerObjectPointer : public TStreamerElement {
 
 private:
-   TStreamerObjectPointer(const TStreamerObjectPointer&);          // Not implemented
-   TStreamerObjectPointer&operator=(const TStreamerObjectPointer&); // Not implemented
+   TStreamerObjectPointer(const TStreamerObjectPointer&) = delete;
+   TStreamerObjectPointer&operator=(const TStreamerObjectPointer&) = delete;
 
 public:
 
@@ -342,7 +342,7 @@ public:
    virtual       ~TStreamerObjectPointer();
    const char    *GetInclude() const;
    Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj=0);
+   virtual void   Init(TVirtualStreamerInfo *obj = nullptr);
    virtual Bool_t IsaPointer() const {return kTRUE;}
    virtual void   SetArrayDim(Int_t dim);
 
@@ -353,8 +353,8 @@ public:
 class TStreamerObjectAnyPointer : public TStreamerElement {
 
 private:
-   TStreamerObjectAnyPointer(const TStreamerObjectAnyPointer&);          // Not implemented
-   TStreamerObjectAnyPointer&operator=(const TStreamerObjectAnyPointer&); // Not implemented
+   TStreamerObjectAnyPointer(const TStreamerObjectAnyPointer&) = delete;
+   TStreamerObjectAnyPointer&operator=(const TStreamerObjectAnyPointer&) = delete;
 
 public:
 
@@ -363,7 +363,7 @@ public:
    virtual       ~TStreamerObjectAnyPointer();
    const char    *GetInclude() const;
    Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj=0);
+   virtual void   Init(TVirtualStreamerInfo *obj = nullptr);
    virtual Bool_t IsaPointer() const {return kTRUE;}
    virtual void   SetArrayDim(Int_t dim);
 
@@ -374,8 +374,8 @@ public:
 class TStreamerString : public TStreamerElement {
 
 private:
-   TStreamerString(const TStreamerString&);          // Not implemented
-   TStreamerString&operator=(const TStreamerString&); // Not implemented
+   TStreamerString(const TStreamerString&) = delete;
+   TStreamerString&operator=(const TStreamerString&) = delete;
 
 public:
 
@@ -392,8 +392,8 @@ public:
 class TStreamerSTL : public TStreamerElement {
 
 private:
-   TStreamerSTL(const TStreamerSTL&);          // Not implemented
-   TStreamerSTL&operator=(const TStreamerSTL&); // Not implemented
+   TStreamerSTL(const TStreamerSTL&) = delete;
+   TStreamerSTL&operator=(const TStreamerSTL&) = delete;
 
 protected:
    Int_t       fSTLtype;       //type of STL vector
@@ -426,8 +426,8 @@ public:
 class TStreamerSTLstring : public TStreamerSTL {
 
 private:
-   TStreamerSTLstring(const TStreamerSTLstring&);          // Not implemented
-   TStreamerSTLstring&operator=(const TStreamerSTLstring&); // Not implemented
+   TStreamerSTLstring(const TStreamerSTLstring&) = delete;
+   TStreamerSTLstring&operator=(const TStreamerSTLstring&) = delete;
 
 public:
 
@@ -449,8 +449,8 @@ class TBuffer;
 //________________________________________________________________________
 class TStreamerArtificial : public TStreamerElement {
 private:
-   TStreamerArtificial(const TStreamerArtificial&);          // Not implemented
-   TStreamerArtificial&operator=(const TStreamerArtificial&); // Not implemented
+   TStreamerArtificial(const TStreamerArtificial&) = delete;
+   TStreamerArtificial&operator=(const TStreamerArtificial&) = delete;
 
 protected:
    ROOT::TSchemaRule::ReadFuncPtr_t     fReadFunc;    //!

--- a/core/meta/inc/TVirtualObject.h
+++ b/core/meta/inc/TVirtualObject.h
@@ -26,14 +26,14 @@ even if the object is not of a class in the Cint/Reflex dictionary.
 class TVirtualObject {
 private:
 
-   TVirtualObject(const TVirtualObject&) = delete;             // not implemented
-   TVirtualObject &operator=(const TVirtualObject&) = delete;  // not implemented
+   TVirtualObject(const TVirtualObject&) = delete;
+   TVirtualObject &operator=(const TVirtualObject&) = delete;
 
 public:
    TClassRef  fClass;
    void      *fObject;
 
-   TVirtualObject(TClass *cl) : fClass(cl), fObject(cl ? cl->New() : 0) { }
+   TVirtualObject(TClass *cl) : fClass(cl), fObject(cl ? cl->New() : nullptr) { }
    ~TVirtualObject() { if (fClass) fClass->Destructor(fObject); }
 
 

--- a/core/meta/src/TViewPubDataMembers.h
+++ b/core/meta/src/TViewPubDataMembers.h
@@ -31,11 +31,11 @@ protected:
    TList   fClasses; // list of the all the (base) classes for which we list methods.
 
 private:
-   TViewPubDataMembers(const TViewPubDataMembers&);              // not implemented
-   TViewPubDataMembers& operator=(const TViewPubDataMembers&);   // not implemented
+   TViewPubDataMembers(const TViewPubDataMembers&) = delete;
+   TViewPubDataMembers& operator=(const TViewPubDataMembers&) = delete;
 
 public:
-   TViewPubDataMembers(TClass *cl = 0);
+   TViewPubDataMembers(TClass *cl = nullptr);
    virtual    ~TViewPubDataMembers();
 
    TObject   *FindObject(const char *name) const;

--- a/core/meta/src/TViewPubFunctions.h
+++ b/core/meta/src/TViewPubFunctions.h
@@ -31,11 +31,11 @@ protected:
    TList   fClasses; // list of the all the (base) classes for which we list methods.
 
 private:
-   TViewPubFunctions(const TViewPubFunctions&);              // not implemented
-   TViewPubFunctions& operator=(const TViewPubFunctions&);   // not implemented
+   TViewPubFunctions(const TViewPubFunctions&) = delete;
+   TViewPubFunctions& operator=(const TViewPubFunctions&) = delete;
 
 public:
-   TViewPubFunctions(TClass *cl = 0);
+   TViewPubFunctions(TClass *cl = nullptr);
    virtual    ~TViewPubFunctions();
 
    TObject   *FindObject(const char *name) const;

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -609,10 +609,10 @@ private: // Private Utility Functions and Classes
    };
 
    TCling();
-   TCling(const TCling&); // NOT IMPLEMENTED
-   TCling& operator=(const TCling&); // NOT IMPLEMENTED
+   TCling(const TCling&) = delete;
+   TCling& operator=(const TCling&) = delete;
 
-   void Execute(TMethod*, TObjArray*, int* /*error*/ = 0)
+   void Execute(TMethod*, TObjArray*, int* /*error*/ = nullptr)
    {
    }
 

--- a/core/rint/inc/TRint.h
+++ b/core/rint/inc/TRint.h
@@ -39,12 +39,12 @@ private:
    Int_t         fCaughtSignal;       // TRint just caught a signal
    TFileHandler *fInputHandler;       // terminal input handler
 
-   TRint(const TRint&);               // not implemented
-   TRint& operator=(const TRint&);    // not implemented
+   TRint(const TRint&) = delete;
+   TRint& operator=(const TRint&) = delete;
 
    void    ExecLogon();
-   Long_t  ProcessRemote(const char *line, Int_t *error = 0);
-   Long_t  ProcessLineNr(const char* filestem, const char *line, Int_t *error = 0);
+   Long_t  ProcessRemote(const char *line, Int_t *error = nullptr);
+   Long_t  ProcessLineNr(const char* filestem, const char *line, Int_t *error = nullptr);
 
 public:
    TRint(const char *appClassName, int *argc, char **argv,

--- a/core/rint/inc/TTabCom.h
+++ b/core/rint/inc/TTabCom.h
@@ -187,12 +187,12 @@ public: // enums
    };
 
 private: // member functions
-   TTabCom(const TTabCom &);           //private and not implemented
-   TTabCom& operator=(const TTabCom&); //private and not implemented
+   TTabCom(const TTabCom &) = delete;
+   TTabCom& operator=(const TTabCom&) = delete;
 
    Int_t      Complete(const TRegexp& re, const TSeqCollection* pListOfCandidates,
                        const char appendage[], std::ostream& out, TString::ECaseCompare cmp = TString::kExact);
-   void       CopyMatch( char dest[], const char localName[], const char appendage[]=0, const char fullName[]=0 ) const;
+   void       CopyMatch( char dest[], const char localName[], const char appendage[] = nullptr, const char fullName[] = nullptr) const;
    EContext_t DetermineContext() const;
    TString    DeterminePath( const TString& fileName, const char defaultPath[] ) const;
    TString    ExtendPath( const char originalPath[], TString newBase ) const;

--- a/core/textinput/src/textinput/TerminalConfigUnix.h
+++ b/core/textinput/src/textinput/TerminalConfigUnix.h
@@ -36,8 +36,8 @@ typedef void (*sig_t)(int);
 
 class TerminalConfigUnix {
 private:
-   TerminalConfigUnix(const TerminalConfigUnix&); // not implemented
-   TerminalConfigUnix& operator=(const TerminalConfigUnix&); // not implemented
+   TerminalConfigUnix(const TerminalConfigUnix&) = delete;
+   TerminalConfigUnix& operator=(const TerminalConfigUnix&) = delete;
 public:
   ~TerminalConfigUnix();
 

--- a/core/textinput/src/textinput/TextInputContext.h
+++ b/core/textinput/src/textinput/TextInputContext.h
@@ -34,8 +34,8 @@ namespace textinput {
   // Context for textinput library. Collection of internal objects.
   class TextInputContext {
   private:
-     TextInputContext(const TextInputContext&); // not implemented
-     TextInputContext& operator=(const TextInputContext&); // not implemented
+     TextInputContext(const TextInputContext&) = delete;
+     TextInputContext& operator=(const TextInputContext&) = delete;
   public:
     TextInputContext(TextInput* ti, const char* histFile);
     ~TextInputContext();

--- a/core/thread/inc/TCondition.h
+++ b/core/thread/inc/TCondition.h
@@ -38,11 +38,11 @@ private:
    TMutex         *fMutex;         // mutex used around Wait() and TimedWait()
    Bool_t          fPrivateMutex;  // is fMutex our private mutex
 
-   TCondition(const TCondition&);             // not implemented
-   TCondition& operator=(const TCondition&);  // not implemented
+   TCondition(const TCondition&) = delete;
+   TCondition& operator=(const TCondition&) = delete;
 
 public:
-   TCondition(TMutex *m = 0);
+   TCondition(TMutex *m = nullptr);
    virtual ~TCondition();
 
    TMutex *GetMutex() const;

--- a/core/thread/inc/TMutex.h
+++ b/core/thread/inc/TMutex.h
@@ -35,8 +35,8 @@ friend class TThread;
 private:
    TMutexImp  *fMutexImp;   // pointer to mutex implementation
 
-   TMutex(const TMutex&);              // not implemented
-   TMutex& operator=(const TMutex&);   // not implemented
+   TMutex(const TMutex&) = delete;
+   TMutex& operator=(const TMutex&) = delete;
 
 public:
    TMutex(Bool_t recursive = kFALSE);

--- a/core/thread/inc/TRWLock.h
+++ b/core/thread/inc/TRWLock.h
@@ -36,8 +36,8 @@ private:
    TMutex       fMutex;     // rwlock mutex
    TCondition   fLockFree;  // rwlock condition variable
 
-   TRWLock(const TRWLock &);           // not implemented
-   TRWLock& operator=(const TRWLock&); // not implemented
+   TRWLock(const TRWLock &) = delete;
+   TRWLock& operator=(const TRWLock&) = delete;
 
 public:
    TRWLock();

--- a/core/thread/inc/TSemaphore.h
+++ b/core/thread/inc/TSemaphore.h
@@ -34,8 +34,8 @@ private:
    Int_t                   fValue;   // semaphore value
    UInt_t                  fWakeups; // wakeups
 
-   TSemaphore(const TSemaphore &s) = delete;             // not implemented
-   TSemaphore& operator=(const TSemaphore &s) = delete;  // not implemented
+   TSemaphore(const TSemaphore &s) = delete;
+   TSemaphore& operator=(const TSemaphore &s) = delete;
 
 public:
    TSemaphore(Int_t initial = 1);

--- a/core/thread/inc/TThread.h
+++ b/core/thread/inc/TThread.h
@@ -100,7 +100,7 @@ private:
 
    // Private Member functions
    void           Constructor();
-   void           SetComment(const char *txt = 0)
+   void           SetComment(const char *txt = nullptr)
                      { fComment[0] = 0; if (txt) { strncpy(fComment, txt, 99); fComment[99] = 0; } }
    void           DoError(Int_t level, const char *location, const char *fmt, va_list va) const;
    void           ErrorHandler(int level, const char *location, const char *fmt, va_list ap) const;
@@ -110,19 +110,19 @@ private:
    static void    AfterCancel(TThread *th);
    static void    **GetTls(Int_t k);
 
-   TThread(const TThread&);            // not implemented
-   TThread& operator=(const TThread&); // not implemented
+   TThread(const TThread&) = delete;
+   TThread& operator=(const TThread&) = delete;
 
 public:
-   TThread(VoidRtnFunc_t fn, void *arg = 0, EPriority pri = kNormalPriority);
-   TThread(VoidFunc_t fn, void *arg = 0, EPriority pri = kNormalPriority);
-   TThread(const char *thname, VoidRtnFunc_t fn, void *arg = 0, EPriority pri = kNormalPriority);
-   TThread(const char *thname, VoidFunc_t fn, void *arg = 0, EPriority pri = kNormalPriority);
+   TThread(VoidRtnFunc_t fn, void *arg = nullptr, EPriority pri = kNormalPriority);
+   TThread(VoidFunc_t fn, void *arg = nullptr, EPriority pri = kNormalPriority);
+   TThread(const char *thname, VoidRtnFunc_t fn, void *arg = nullptr, EPriority pri = kNormalPriority);
+   TThread(const char *thname, VoidFunc_t fn, void *arg = nullptr, EPriority pri = kNormalPriority);
    TThread(Long_t id = 0);
    virtual ~TThread();
 
    Int_t            Kill();
-   Int_t            Run(void *arg = 0);
+   Int_t            Run(void *arg = nullptr);
    void             SetPriority(EPriority pri);
    void             Delete(Option_t *option="") { TObject::Delete(option); }
    EPriority        GetPriority() const { return fPriority; }
@@ -134,10 +134,10 @@ public:
    static void      Initialize();
    static Bool_t    IsInitialized();
 
-   Long_t           Join(void **ret = 0);
-   static Long_t    Join(Long_t id, void **ret = 0);
+   Long_t           Join(void **ret = nullptr);
+   static Long_t    Join(Long_t id, void **ret = nullptr);
 
-   static Int_t     Exit(void *ret = 0);
+   static Int_t     Exit(void *ret = nullptr);
    static Int_t     Exists();
    static TThread  *GetThread(Long_t id);
    static TThread  *GetThread(const char *name);
@@ -165,7 +165,7 @@ public:
    static Int_t     CancelPoint();
    static Int_t     Kill(Long_t id);
    static Int_t     Kill(const char *name);
-   static Int_t     CleanUpPush(void *free, void *arg = 0);
+   static Int_t     CleanUpPush(void *free, void *arg = nullptr);
    static Int_t     CleanUpPop(Int_t exe = 0);
    static Int_t     CleanUp();
 


### PR DESCRIPTION
Declare non-implemented methods as  `= delete`, use `nullptr`, in few places use `ClassDefOverride`