### PR TITLE
tutorials/gui/games.C not working properly

### DIFF
--- a/tutorials/gui/games.C
+++ b/tutorials/gui/games.C
@@ -49,6 +49,12 @@ void games()
       return;
    }
    gROOT->ProcessLine("#define __RUN_GAMES__ 1");
+   
+   //Add this for CLING not to complain
+   gROOT->ProcessLine("#include \"Hello.h\"");
+   gROOT->ProcessLine("#include \"Aclock.h\"");
+   gROOT->ProcessLine("#include \"Tetris.h\"");
+   
    gROOT->ProcessLine("#include \"games.C\"");
    gROOT->ProcessLine("rungames()");
    gROOT->ProcessLine("#undef __RUN_GAMES__");


### PR DESCRIPTION
this fixes a compilation issue on ROOT6

I run it without at compiling, as:
`root -l games.C`