### PR TITLE
Add multivariate random number generation

### DIFF
--- a/math/mathmore/inc/Math/GSLRndmEngines.h
+++ b/math/mathmore/inc/Math/GSLRndmEngines.h
@@ -210,6 +210,11 @@ namespace Math {
       void Gaussian2D(double sigmaX, double sigmaY, double rho, double &x, double &y) const;
 
       /**
+         Multivariate Gaussian distribution
+      */
+      void GaussianND(const int dim, double *pars, double *covmat, double *genpars) const;
+
+      /**
          Exponential distribution
       */
       double Exponential(double mu) const;

--- a/math/mathmore/src/GSLRndmEngines.cxx
+++ b/math/mathmore/src/GSLRndmEngines.cxx
@@ -35,9 +35,11 @@
 #include <ctime>
 #include <cassert>
 
+#include "gsl/gsl_linalg.h"
+#include "gsl/gsl_matrix.h"
 #include "gsl/gsl_rng.h"
 #include "gsl/gsl_randist.h"
-
+#include "gsl/gsl_vector.h"
 
 #include "Math/GSLRndmEngines.h"
 #include "GSLRngWrapper.h"
@@ -207,6 +209,27 @@ namespace Math {
       gsl_ran_bivariate_gaussian(  fRng->Rng(), sigmaX, sigmaY, rho, &x, &y);
    }
 
+   void GSLRandomEngine::GaussianND(const int dim, double *pars, double *covmat, double *genpars) const
+   {
+      // Gaussian Multivariate distribution
+      gsl_vector *mu = gsl_vector_alloc(dim);
+      for (int i = 0; i < 3; ++i) {
+         gsl_vector_set(mu, i, pars[i]);
+      }
+      gsl_matrix *L = gsl_matrix_alloc(dim, dim);
+      for (int i = 0; i < dim; ++i) {
+         for (int j = 0; j < dim; ++j) {
+            gsl_matrix_set(L, i, j, covmat[i * dim + j]);
+         }
+      }
+      gsl_linalg_cholesky_decomp(L);
+      gsl_vector *result = gsl_vector_alloc(dim);
+      gsl_ran_multivariate_gaussian(fRng->Rng(), mu, L, result);
+      for (int i = 0; i < dim; ++i) {
+         genpars[i] = gsl_vector_get(result, i);
+      }
+   }
+
    double GSLRandomEngine::Exponential(double mu)  const
    {
       // Exponential distribution
@@ -330,7 +353,7 @@ namespace Math {
    GSLRngMT::GSLRngMT() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_mt19937));
-      Initialize(); 
+      Initialize();
    }
 
 
@@ -338,35 +361,35 @@ namespace Math {
    GSLRngRanLux::GSLRngRanLux() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_ranlux) );
-      Initialize(); 
+      Initialize();
    }
 
    // second generation of Ranlux (single precision version - luxury 1)
    GSLRngRanLuxS1::GSLRngRanLuxS1() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_ranlxs1) );
-      Initialize(); 
+      Initialize();
    }
 
    // second generation of Ranlux (single precision version - luxury 2)
    GSLRngRanLuxS2::GSLRngRanLuxS2() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_ranlxs2) );
-      Initialize(); 
+      Initialize();
    }
 
    // double precision  version - luxury 1
    GSLRngRanLuxD1::GSLRngRanLuxD1() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_ranlxd1) );
-      Initialize(); 
+      Initialize();
    }
 
    // double precision  version - luxury 2
    GSLRngRanLuxD2::GSLRngRanLuxD2() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_ranlxd2) );
-      Initialize(); 
+      Initialize();
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -374,7 +397,7 @@ namespace Math {
    GSLRngTaus::GSLRngTaus() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_taus2) );
-      Initialize(); 
+      Initialize();
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -382,7 +405,7 @@ namespace Math {
    GSLRngGFSR4::GSLRngGFSR4() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_gfsr4) );
-      Initialize(); 
+      Initialize();
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -390,7 +413,7 @@ namespace Math {
    GSLRngCMRG::GSLRngCMRG() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_cmrg) );
-      Initialize(); 
+      Initialize();
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -398,7 +421,7 @@ namespace Math {
    GSLRngMRG::GSLRngMRG() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_mrg) );
-      Initialize(); 
+      Initialize();
    }
 
 
@@ -407,7 +430,7 @@ namespace Math {
    GSLRngRand::GSLRngRand() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_rand) );
-      Initialize(); 
+      Initialize();
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -415,7 +438,7 @@ namespace Math {
    GSLRngRanMar::GSLRngRanMar() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_ranmar) );
-      Initialize(); 
+      Initialize();
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -423,7 +446,7 @@ namespace Math {
    GSLRngMinStd::GSLRngMinStd() : GSLRandomEngine()
    {
       SetType(new GSLRngWrapper(gsl_rng_minstd) );
-      Initialize(); 
+      Initialize();
    }
 
 
@@ -433,8 +456,8 @@ namespace Math {
       SetType(new GSLRngWrapper(gsl_rng_mixmax) );
       Initialize(); // this creates the gsl_rng structure
       //  no real need to call CreateEngine since the underlined MIXMAX engine is created
-      // by calling GSLMixMaxWrapper::Seed(gsl_default_seed) that is called 
-      // when gsl_rng is allocated (in Initialize) 
+      // by calling GSLMixMaxWrapper::Seed(gsl_default_seed) that is called
+      // when gsl_rng is allocated (in Initialize)
       GSLMixMaxWrapper::CreateEngine(Engine()->Rng());
    }
    GSLRngMixMax::~GSLRngMixMax() {

--- a/math/mathmore/src/GSLRndmEngines.cxx
+++ b/math/mathmore/src/GSLRndmEngines.cxx
@@ -213,20 +213,18 @@ namespace Math {
    {
       // Gaussian Multivariate distribution
       gsl_vector *mu = gsl_vector_alloc(dim);
-      for (int i = 0; i < 3; ++i) {
-         gsl_vector_set(mu, i, pars[i]);
-      }
+      gsl_vector *genpars_vec = gsl_vector_alloc(dim);
       gsl_matrix *L = gsl_matrix_alloc(dim, dim);
       for (int i = 0; i < dim; ++i) {
+         gsl_vector_set(mu, i, pars[i]);
          for (int j = 0; j < dim; ++j) {
             gsl_matrix_set(L, i, j, covmat[i * dim + j]);
          }
       }
       gsl_linalg_cholesky_decomp(L);
-      gsl_vector *result = gsl_vector_alloc(dim);
-      gsl_ran_multivariate_gaussian(fRng->Rng(), mu, L, result);
+      gsl_ran_multivariate_gaussian(fRng->Rng(), mu, L, genpars_vec);
       for (int i = 0; i < dim; ++i) {
-         genpars[i] = gsl_vector_get(result, i);
+         genpars[i] = gsl_vector_get(genpars_vec, i);
       }
    }
 

--- a/tutorials/math/multivarGaus.C
+++ b/tutorials/math/multivarGaus.C
@@ -1,0 +1,56 @@
+/// \file
+/// \ingroup tutorial_math
+/// \notebook
+/// Tutorial illustrating the multivariate gaussian random number generation
+///
+/// \macro_image
+/// \macro_code
+///
+/// \author Jorge Lopez
+
+void multivarGaus() {
+  ROOT::Math::GSLRandomEngine rnd;
+  rnd.Initialize();
+
+  const int dim = 3;
+  double pars[dim] = {0, 0, 0.5};
+  double genpars[dim] = {0, 0, 0};
+  double cov[dim * dim] = {1.0, -0.2, 0.0, -0.2, 1.0, 0.5, 0.0, 0.5, 0.75};
+
+  TH1F* hX = new TH1F("hX", "hX;x;Counts", 100, -5, 5);
+  TH1F* hY = new TH1F("hY", "hY;y;Counts", 100, -5, 5);
+  TH1F* hZ = new TH1F("hZ", "hZ;z;Counts", 100, -5, 5);
+
+  TH2F* hXY = new TH2F("hXY", "hXY;x;y;Counts", 100, -5, 5, 100, -5, 5);
+  TH2F* hXZ = new TH2F("hXZ", "hXZ;x;z;Counts", 100, -5, 5, 100, -5, 5);
+  TH2F* hYZ = new TH2F("hYZ", "hYZ;y;z;Counts", 100, -5, 5, 100, -5, 5);
+
+  const int MAX = 10000;
+  for (int evnts = 0; evnts < MAX; ++evnts) {
+    rnd.GaussianND(dim, pars, cov, genpars);
+    auto x = genpars[0];
+    auto y = genpars[1];
+    auto z = genpars[2];
+    hX->Fill(x);
+    hY->Fill(y);
+    hZ->Fill(z);
+    hXY->Fill(x, y);
+    hXZ->Fill(x, z);
+    hYZ->Fill(y, z);
+  }
+
+  TCanvas* c = new TCanvas("c", "Multivariate gaussian random numbers");
+  c->Divide(3, 2);
+  c->cd(1);
+  hX->Draw();
+  c->cd(2);
+  hY->Draw();
+  c->cd(3);
+  hZ->Draw();
+  c->cd(4);
+  hXY->Draw("COL");
+  c->cd(5);
+  hXZ->Draw("COL");
+  c->cd(6);
+  hYZ->Draw("COL");
+}


### PR DESCRIPTION
Add multivariate gaussian random number generation with GSLRndmEngines. Example/use case in `/tutorials/math/multivarGaus.C`.

Related to [ROOT-767](https://sft.its.cern.ch/jira/browse/ROOT-767).