### PR TITLE
Allows to configure CUDA sm level for Cling CUDA tests

### DIFF
--- a/interpreter/cling/test/CUDADeviceCode/CUDADefineArg.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDADefineArg.C
@@ -9,7 +9,7 @@
 
 // The Test checks whether a define argument (-DTEST=3) is passed to the PTX
 // compiler. If it works, it should not throw an error.
-// RUN: cat %s | %cling -DTEST=3 -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -DTEST=3 -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 #include <iostream>

--- a/interpreter/cling/test/CUDADeviceCode/CUDAHostPrefix.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDAHostPrefix.C
@@ -9,7 +9,7 @@
 
 // The Test checks if a function with __host__ and __device__ prefix available
 // on host and device side.
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 .rawInput 1

--- a/interpreter/cling/test/CUDADeviceCode/CUDAInclude.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDAInclude.C
@@ -9,7 +9,7 @@
 
 // The test checks whether setting a new include path at runtime also works for
 // the PTX compiler.
-// RUN: cat %s | %cling -DTEST_PATH="\"%/p/\"" -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -DTEST_PATH="\"%/p/\"" -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 #include <iostream>

--- a/interpreter/cling/test/CUDADeviceCode/CUDAKernelArgument.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDAKernelArgument.C
@@ -9,7 +9,7 @@
 
 // The Test checks if a CUDA kernel works with a arguments and built-in
 // functions.
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 // Test, if a simple kernel with arguments works.

--- a/interpreter/cling/test/CUDADeviceCode/CUDAKernelTemplateComplex.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDAKernelTemplateComplex.C
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 
 // The Test checks if templated CUDA kernel in some special cases works.
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 // Check if templated CUDA kernel works, without explicit template type declaration.

--- a/interpreter/cling/test/CUDADeviceCode/CUDAKernelTemplateSimple.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDAKernelTemplateSimple.C
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 
 // The Test checks if templated CUDA kernel works.
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 // Check if template device side resoultion works.

--- a/interpreter/cling/test/CUDADeviceCode/CUDARegression.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDARegression.C
@@ -9,7 +9,7 @@
 
 // The test checks if the interface functions process(), declare() and parse()
 // of cling::Interpreter also work in the cuda mode.
-// RUN: cat %s | %cling -DTEST_PATH="\"%/p/\"" -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -DTEST_PATH="\"%/p/\"" -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 #include "cling/Interpreter/Interpreter.h"

--- a/interpreter/cling/test/CUDADeviceCode/CUDASharedMemory.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDASharedMemory.C
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 
 // The Test checks if runtime shared memory works.
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 const unsigned int numberOfThreads = 4;

--- a/interpreter/cling/test/CUDADeviceCode/CUDASimpleKernel.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDASimpleKernel.C
@@ -9,7 +9,7 @@
 
 // The Test checks if a CUDA compatible device is available and checks, if simple
 // __global__ and __device__ kernels are running.
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 // Check if cuda driver is available

--- a/interpreter/cling/test/CUDADeviceCode/CUDAStreams.C
+++ b/interpreter/cling/test/CUDADeviceCode/CUDAStreams.C
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 
 // The Test checks if cuda streams works.
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 const unsigned int numberOfThreads = 4;

--- a/interpreter/cling/test/CodeGeneration/CUDACtorDtor.C
+++ b/interpreter/cling/test/CodeGeneration/CUDACtorDtor.C
@@ -9,7 +9,7 @@
 // The Test checks, if the symbols __cuda_module_ctor and __cuda_module_dtor are
 // unique for every module. Attention, for a working test case, a cuda
 // fatbinary is necessary.
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
 // REQUIRES: cuda-runtime
 
 #include "cling/Interpreter/Interpreter.h"

--- a/interpreter/cling/test/Driver/CUDAMode.C
+++ b/interpreter/cling/test/Driver/CUDAMode.C
@@ -9,8 +9,8 @@
 
 // The Test starts the cling with the arg -xcuda and checks if the cuda mode
 // is enabled.
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -Xclang -verify 2>&1 | FileCheck %s
-// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath -fsyntax-only -Xclang -verify 2>&1
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -Xclang -verify 2>&1 | FileCheck %s
+// RUN: cat %s | %cling -x cuda --cuda-path=%cudapath %cudasmlevel -fsyntax-only -Xclang -verify 2>&1
 // REQUIRES: cuda-runtime
 
 

--- a/interpreter/cling/test/lit.cfg
+++ b/interpreter/cling/test/lit.cfg
@@ -344,6 +344,12 @@ if libcudart_path is not None:
   # https://developer.nvidia.com/blog/cuda-pro-tip-control-gpu-visibility-cuda_visible_devices/
   if 'CUDA_VISIBLE_DEVICES' in os.environ:
       config.environment['CUDA_VISIBLE_DEVICES'] = os.environ['CUDA_VISIBLE_DEVICES']
+  # set the CUDA sm level for the tests (e.g. "export CLING_TEST_CUDA_SM_LEVEL=35")
+  # if no sm level is set, the default of cling will be used
+  if 'CLING_TEST_CUDA_SM_LEVEL' in os.environ:
+      config.substitutions.append(('%cudasmlevel', '--cuda-gpu-arch=sm_' + os.environ['CLING_TEST_CUDA_SM_LEVEL']))
+  else:
+      config.substitutions.append(('%cudasmlevel', ""))
 
 # Loadable module
 # FIXME: This should be supplied by Makefile or autoconf.


### PR DESCRIPTION
- the CUDA sm level can be set via CLING_TEST_CUDA_SM_LEVEL environment variable (e.g. "35"), before running the tests
- this necessary, because the minimum sm level depends on the use CUDA SDK
- for example, CUDA 8.0 supports sm level 2.0, which is not support from CUDA 10.1 anymore  