### PR TITLE
Backport TFormula version 13 and TF1 version 12 changes from master to 6.22

### DIFF
--- a/hist/hist/inc/LinkDef.h
+++ b/hist/hist/inc/LinkDef.h
@@ -340,6 +340,6 @@
   source="" target="fBinSumw2" \
   code="{ fBinSumw2.Reset(); }"
 
-
+#pragma read sourceClass="TF1" targetClass="TF1" version="[10]" source="TF1AbsComposition* fComposition_ptr" target="fComposition" code="{ fComposition.reset(onfile.fComposition_ptr); onfile.fComposition_ptr = nullptr; }"
 
 #endif

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -264,7 +264,6 @@ protected:
    std::unique_ptr<TFormula>   fFormula;        //Pointer to TFormula in case when user define formula 
    std::unique_ptr<TF1Parameters> fParams;   //Pointer to Function parameters object (exists only for not-formula functions)
    std::unique_ptr<TF1AbsComposition> fComposition; //! Pointer to composition (NSUM or CONV)
-   TF1AbsComposition *fComposition_ptr{nullptr};   // saved pointer (unique_ptr is transient)
 
    /// General constructor for TF1. Most of the other constructors delegate on it
    TF1(EFType functionType, const char *name, Double_t xmin, Double_t xmax, Int_t npar, Int_t ndim, EAddToList addToGlobList, TF1Parameters *params = nullptr, TF1FunctorPointer * functor = nullptr):
@@ -706,7 +705,7 @@ private:
    inline double EvalParVec(const Double_t *data, const Double_t *params);
 #endif
 
-   ClassDef(TF1, 11) // The Parametric 1-D function
+   ClassDef(TF1, 12) // The Parametric 1-D function
 };
 
 namespace ROOT {

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -263,7 +263,7 @@ protected:
    std::unique_ptr<TF1FunctorPointer>  fFunctor; //! Functor object to wrap any C++ callable object 
    std::unique_ptr<TFormula>   fFormula;        //Pointer to TFormula in case when user define formula 
    std::unique_ptr<TF1Parameters> fParams;   //Pointer to Function parameters object (exists only for not-formula functions)
-   std::unique_ptr<TF1AbsComposition> fComposition; //! Pointer to composition (NSUM or CONV)
+   std::unique_ptr<TF1AbsComposition> fComposition; // Pointer to composition (NSUM or CONV)
 
    /// General constructor for TF1. Most of the other constructors delegate on it
    TF1(EFType functionType, const char *name, Double_t xmin, Double_t xmax, Int_t npar, Int_t ndim, EAddToList addToGlobList, TF1Parameters *params = nullptr, TF1FunctorPointer * functor = nullptr):

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -93,7 +93,7 @@ private:
    Bool_t            fClingInitialized;  //!  transient to force re-initialization
    Bool_t            fAllParametersSetted;    // flag to control if all parameters are setted
    Bool_t            fLazyInitialization = kFALSE;  //! transient flag to control lazy initialization (needed for reading from files)
-   TMethodCall *fMethod; //! pointer to methodcall
+   std::unique_ptr<TMethodCall> fMethod; //! pointer to methodcall
    std::unique_ptr<TMethodCall> fGradMethod; //! pointer to a methodcall
    TString           fClingName;     //! unique name passed to Cling to define the function ( double clingName(double*x, double*p) )
    std::string       fSavedInputFormula;  //! unique name used to defined the function and used in the global map (need to be saved in case of lazy initialization)
@@ -251,6 +251,6 @@ public:
    void           SetVariables(const std::pair<TString,Double_t> *vars, const Int_t size);
    void SetVectorized(Bool_t vectorized);
 
-   ClassDef(TFormula,12)
+   ClassDef(TFormula,13)
 };
 #endif

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3577,8 +3577,6 @@ void TF1::Streamer(TBuffer &b)
             R__LOCKGUARD(gROOTMutex);
             gROOT->GetListOfFunctions()->Add(this);
          }
-         if (v >= 10 && v < 11)
-            fComposition = std::unique_ptr<TF1AbsComposition>(fComposition_ptr);
          return;
       } else {
          ROOT::v5::TF1Data fold;

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -392,7 +392,7 @@ TFormula::TFormula()
    fReadyToExecute = false;
    fClingInitialized = false;
    fAllParametersSetted = false;
-   fMethod = 0;
+
    fNdim = 0;
    fNpar = 0;
    fNumber = 0;
@@ -421,9 +421,6 @@ TFormula::~TFormula()
       gROOT->GetListOfFunctions()->Remove(this);
    }
 
-   if (fMethod) {
-      fMethod->Delete();
-   }
    int nLinParts = fLinearParts.size();
    if (nLinParts > 0) {
       for (int i = 0; i < nLinParts; ++i) delete fLinearParts[i];
@@ -437,11 +434,9 @@ TFormula::TFormula(const char *name, const char *formula, bool addToGlobList, bo
 {
    fReadyToExecute = false;
    fClingInitialized = false;
-   fMethod = 0;
    fNdim = 0;
    fNpar = 0;
    fNumber = 0;
-   fMethod = 0;
    fLambdaPtr = nullptr;
    fVectorized = vectorize;
 #ifndef R__HAS_VECCORE
@@ -526,7 +521,7 @@ TFormula::TFormula(const char *name, const char *formula, int ndim, int npar, bo
 
 ////////////////////////////////////////////////////////////////////////////////
 TFormula::TFormula(const TFormula &formula) :
-   TNamed(formula.GetName(),formula.GetTitle()), fMethod(nullptr)
+  TNamed(formula.GetName(),formula.GetTitle())
 {
    formula.Copy(*this);
 
@@ -701,18 +696,12 @@ void TFormula::Copy(TObject &obj) const
          fnew.fReadyToExecute = false;
       }
    }
-   else if (fMethod) {
-      if (fnew.fMethod) delete fnew.fMethod;
-      // use copy-constructor of TMethodCall
-      TMethodCall *m = new TMethodCall(*fMethod);
-      fnew.fMethod  = m;
-   }
-
-   if (fGradMethod) {
-      // use copy-constructor of TMethodCall
-      TMethodCall *m = new TMethodCall(*fGradMethod);
-      fnew.fGradMethod.reset(m);
-   }
+   // use copy-constructor of TMethodCall
+   // if c++-14 could use std::make_unique
+   TMethodCall *m = (fMethod) ? new TMethodCall(*fMethod) : nullptr;
+   fnew.fMethod.reset(m);
+   TMethodCall *gm = (fGradMethod) ? new TMethodCall(*fGradMethod) : nullptr;
+   fnew.fGradMethod.reset(gm);
 
    fnew.fFuncPtr = fFuncPtr;
    fnew.fGradGenerationInput = fGradGenerationInput;
@@ -733,8 +722,8 @@ void TFormula::Clear(Option_t * )
    fClingName = "";
 
 
-   if(fMethod) fMethod->Delete();
-   fMethod = nullptr;
+   fMethod.reset();
+   fGradMethod.reset();
 
    fClingVariables.clear();
    fClingParameters.clear();
@@ -793,10 +782,9 @@ prepareMethod(bool HasParameters, bool HasVariables, const char* FuncName,
    return Method;
 }
 
-static TInterpreter::CallFuncIFacePtr_t::Generic_t
-prepareFuncPtr(TMethodCall *Method) {
-   if (!Method) return nullptr;
-   CallFunc_t *callfunc = Method->GetCallFunc();
+static TInterpreter::CallFuncIFacePtr_t::Generic_t  prepareFuncPtr(TMethodCall *method) {
+  if (!method) return nullptr;
+  CallFunc_t *callfunc = method->GetCallFunc();
 
    if (!gCling->CallFunc_IsValid(callfunc)) {
       Error("prepareFuncPtr", "Callfunc retuned from Cling is not valid");
@@ -823,10 +811,9 @@ bool TFormula::PrepareEvalMethod()
    if (!fMethod) {
       Bool_t hasParameters = (fNpar > 0);
       Bool_t hasVariables = (fNdim > 0);
-      fMethod = prepareMethod(hasParameters, hasVariables, fClingName,
-                              fVectorized).release();
+      fMethod = prepareMethod(hasParameters, hasVariables, fClingName,fVectorized);
       if (!fMethod) return false; 
-      fFuncPtr = prepareFuncPtr(fMethod);
+      fFuncPtr = prepareFuncPtr(fMethod.get());
    }
    return fFuncPtr;
 }
@@ -3085,9 +3072,8 @@ void TFormula::SetVectorized(Bool_t vectorized)
       fClingName = "";
       fClingInput = fFormula;
 
-      if (fMethod)
-         fMethod->Delete();
-      fMethod = nullptr;
+      fMethod.reset();
+      // should I add fGradMethod.reset() ?
 
       FillVecFunctionsShurtCuts();   // to replace with the right vectorized signature (e.g. sin  -> vecCore::math::Sin)
       PreProcessFormula(fFormula);
@@ -3434,10 +3420,7 @@ void TFormula::ReInitializeEvalMethod() {
       fLazyInitialization = false;
       return;
    }
-   if (fMethod) {
-      fMethod->Delete();
-      fMethod = nullptr;
-   }
+   fMethod.reset();
    if (!fLazyInitialization)   Warning("ReInitializeEvalMethod", "Formula is NOT properly initialized - try calling again TFormula::PrepareEvalMethod");
    //else  Info("ReInitializeEvalMethod", "Compile now the formula expression using Cling");
 

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -406,9 +406,9 @@ void stress3()
    Float_t comp = f.GetCompressionFactor();
    Bool_t OK = kTRUE;
 #ifdef R__HAS_CLOUDFLARE_ZLIB
-   constexpr Long64_t lastgood = 52027;
+   constexpr Long64_t lastgood = 52290;
 #else
-   constexpr Long64_t lastgood = 51886;
+   constexpr Long64_t lastgood = 52116;
 #endif
    constexpr Long64_t tolerance = 150;
 #ifdef R__HAS_DEFAULT_LZ4


### PR DESCRIPTION
This is a request for backport of https://github.com/root-project/root/pull/7035
to 6-22 patches because of this ClassDef change:
`   ClassDef(TF1, 11) // The Parametric 1-D function` (previous was 10)
which we are checking in this test:
https://github.com/cms-sw/cmssw/blob/master/DQMServices/Components/test/testSchemaEvolution.cpp#L44
and should have one or the other version, and we better use this fix in 6-22 anyway.
