### PR TITLE
[ntuple] Fix race condition in ~RNTupleReader()

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -86,6 +86,10 @@ Individual fields can be read as well by instantiating a tree view.
 // clang-format on
 class RNTupleReader {
 private:
+   /// Set as the page source's scheduler for parallel page decompression if IMT is on
+   /// Needs to be destructed after the pages source is destructed (an thus be declared before)
+   RNTupleImtTaskScheduler fUnzipTasks;
+
    std::unique_ptr<Detail::RPageSource> fSource;
    /// Needs to be destructed before fSource
    std::unique_ptr<RNTupleModel> fModel;
@@ -94,8 +98,6 @@ private:
    /// is a clone of the original reader.
    std::unique_ptr<RNTupleReader> fDisplayReader;
    Detail::RNTupleMetrics fMetrics;
-   /// Set as the page source's scheduler for parallel page decompression if IMT is on
-   RNTupleImtTaskScheduler fUnzipTasks;
 
    void ConnectModel(const RNTupleModel &model);
    RNTupleReader *GetDisplayReader();

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -100,12 +100,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
    InitPageSource();
 }
 
-ROOT::Experimental::RNTupleReader::~RNTupleReader()
-{
-#ifdef R__USE_IMT
-   fSource->SetTaskScheduler(nullptr);
-#endif
-}
+ROOT::Experimental::RNTupleReader::~RNTupleReader() = default;
 
 std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::Open(
    std::unique_ptr<RNTupleModel> model,

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -311,9 +311,7 @@ ROOT::Experimental::Detail::RPageSourceFile::RPageSourceFile(std::string_view nt
 }
 
 
-ROOT::Experimental::Detail::RPageSourceFile::~RPageSourceFile()
-{
-}
+ROOT::Experimental::Detail::RPageSourceFile::~RPageSourceFile() = default;
 
 
 ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFile::AttachImpl()


### PR DESCRIPTION
The RNTupleReader should destruct its page source before it destructs
the task scheduler.  In particular it must never set the page source's
task scheduler to nullptr because the page source might still use the
task scheduler for decompression.

Fixes #7076