### PR TITLE
[RF] Consider rangeName for integration in RooParamHistFunc

### DIFF
--- a/roofit/roofit/src/RooParamHistFunc.cxx
+++ b/roofit/roofit/src/RooParamHistFunc.cxx
@@ -24,8 +24,10 @@
 #include "RooAbsReal.h"
 #include "RooAbsCategory.h"
 #include "RooRealVar.h"
+#include "RooHelpers.h"
 #include <math.h>
 #include "TMath.h"
+
 
 using namespace std ;
 
@@ -244,18 +246,27 @@ Int_t RooParamHistFunc::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& a
 /// Implement analytical integrations by doing appropriate weighting from  component integrals
 /// functions to integrators of components
 
-Double_t RooParamHistFunc::analyticalIntegralWN(Int_t code, const RooArgSet* /*normSet2*/,const char* /*rangeName*/) const
+Double_t RooParamHistFunc::analyticalIntegralWN(Int_t code, const RooArgSet* /*normSet2*/,const char* rangeName) const
 {
+  // Supports only the scenario of integration over all dependents
   R__ASSERT(code==1) ;
 
-  Double_t ret(0) ;
-  Int_t i(0) ;
-  for (const auto param : _p) {
-    auto p = static_cast<const RooAbsReal*>(param);
-    Double_t bin = p->getVal() ;
-    if (_relParam) bin *= getNominal(i++) ;
-    ret += bin ;
+  // The logic for summing over the histogram is borrowed from RooHistPdf with some differences:
+  //
+  //  - a lambda function is used to inject the parameters for bin scaling into the RooDataHist::sum method
+  //
+  //  - for simplicity, there is no check for the possibility of full-range integration with another overload of
+  //    RooDataHist::sum
+  std::map<const RooAbsArg*, std::pair<Double_t, Double_t> > ranges;
+  for (const auto obs : _x) {
+    ranges[obs] = RooHelpers::getRangeOrBinningInterval(obs, rangeName);
   }
+
+  auto getBinScale = [&](int iBin){ return static_cast<const RooAbsReal&>(_p[iBin]).getVal(); };
+
+  auto integrationSet = _dh.get();
+  RooArgSet sliceSet{};
+  Double_t ret = const_cast<RooDataHist&>(_dh).sum(*integrationSet, sliceSet, kFALSE, kTRUE, ranges, getBinScale);
 
   // WVE fix this!!! Assume uniform binning for now!
   Double_t binV(1) ;

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <functional>
 
 class TObject ;
 class RooAbsArg;
@@ -95,7 +96,12 @@ public:
 
   Double_t sum(Bool_t correctForBinSize, Bool_t inverseCorr=kFALSE) const ;
   Double_t sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, Bool_t correctForBinSize, Bool_t inverseCorr=kFALSE) ;
-  Double_t sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, Bool_t correctForBinSize, Bool_t inverseCorr, const std::map<const RooAbsArg*, std::pair<Double_t, Double_t> >& ranges);
+  Double_t sum(const RooArgSet& sumSet,
+               const RooArgSet& sliceSet,
+               Bool_t correctForBinSize,
+               Bool_t inverseCorr,
+               const std::map<const RooAbsArg*, std::pair<Double_t, Double_t> >& ranges,
+               std::function<double(int)> getBinScale = [](int){ return 1.0; } );
 
   virtual Double_t weight() const { 
     // Return weight of current bin

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -24,6 +24,8 @@
 #include <sstream>
 #include <vector>
 #include <string>
+#include <utility>
+
 
 namespace RooHelpers {
 
@@ -111,6 +113,8 @@ struct DisableCachingRAII {
   bool _oldState;
 };
 
+
+std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const char* rangeName);
 
 
 }

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -1553,7 +1553,8 @@ Double_t RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, Bo
 
 Double_t RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet,
 	Bool_t correctForBinSize, Bool_t inverseBinCor,
-	const std::map<const RooAbsArg*, std::pair<Double_t, Double_t> >& ranges)
+	const std::map<const RooAbsArg*, std::pair<Double_t, Double_t> >& ranges,
+    std::function<double(int)> getBinScale)
 {
   checkInit();
   checkBinBounds();
@@ -1624,7 +1625,7 @@ Double_t RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet,
     const Double_t corr = correctForBinSize ? (inverseBinCor ? 1. / _binv[ibin] : _binv[ibin] ) : 1.0;
     //cout << "adding bin[" << ibin << "] to sum wgt = " << _wgt[ibin] << " binv = " << theBinVolume << " _binv[" << ibin << "] " << _binv[ibin] << endl;
     // const Double_t y = _wgt[ibin] * corr * corrPartial - carry;
-    const Double_t y = get_wgt(ibin) * corr * corrPartial - carry;
+    const Double_t y = getBinScale(ibin)*(get_wgt(ibin) * corr * corrPartial) - carry;
     const Double_t t = total + y;
     carry = (t - total) - y;
     total = t;

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -144,4 +144,30 @@ void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_lis
   }
 }
 
+
+/// Get the lower and upper bound of parameter range if arg can be casted to RooAbsRealLValue.
+/// If no range with rangeName is defined for the argument, this will check if a binning of the
+/// same name exists and return the interval covered by the binning.
+/// Returns `{-infinity, infinity}` if agument can't be casted to RooAbsRealLValue* or if no
+/// range or binning with the requested name exists.
+/// \param[in] arg RooAbsArg for which to get the range.
+/// \param[in] rangeName The name of the range.
+std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const char* rangeName) {
+  auto rlv = dynamic_cast<RooAbsRealLValue const*>(arg);
+  if (rlv) {
+    const RooAbsBinning* binning = rlv->getBinningPtr(rangeName);
+    if (rangeName && rlv->hasRange(rangeName)) {
+      return {rlv->getMin(rangeName), rlv->getMax(rangeName)};
+    } else if (binning) {
+      if (!binning->isParameterized()) {
+        return {binning->lowBound(), binning->highBound()};
+      } else {
+        return {binning->lowBoundFunc()->getVal(), binning->highBoundFunc()->getVal()};
+      }
+    }
+  }
+  return {-std::numeric_limits<double>::infinity(), +std::numeric_limits<double>::infinity()};
+}
+
+
 }

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -35,6 +35,7 @@ discrete dimensions.
 #include "RooCategory.h"
 #include "RooWorkspace.h"
 #include "RooGlobalFunc.h"
+#include "RooHelpers.h"
 
 #include "TError.h"
 #include "TBuffer.h"
@@ -317,7 +318,6 @@ Int_t RooHistPdf::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Return integral identified by 'code'. The actual integration
 /// is deferred to RooDataHist::sum() which implements partial
@@ -342,22 +342,7 @@ Double_t RooHistPdf::analyticalIntegral(Int_t code, const char* rangeName) const
       intSet.add(*ha);
     }
     if (!(code & 1)) {
-      RooAbsRealLValue* rlv = dynamic_cast<RooAbsRealLValue*>(pa);
-      if (rlv) {
-        const RooAbsBinning* binning = rlv->getBinningPtr(rangeName);
-        if (rangeName && rlv->hasRange(rangeName)) {
-          ranges[ha] = std::make_pair(
-              rlv->getMin(rangeName), rlv->getMax(rangeName));
-        } else if (binning) {
-          if (!binning->isParameterized()) {
-            ranges[ha] = std::make_pair(
-                binning->lowBound(), binning->highBound());
-          } else {
-            ranges[ha] = std::make_pair(
-                binning->lowBoundFunc()->getVal(), binning->highBoundFunc()->getVal());
-          }
-        }
-      }
+      ranges[ha] = RooHelpers::getRangeOrBinningInterval(pa, rangeName);
     }
     // WVE must sync hist slice list values to pdf slice list
     // Transfer values from


### PR DESCRIPTION
The logic for summing over histogram bins in different ranges used in
RooHistPdf is also implemented in RooParamHistFunc. This means the
range is now considered when computing integrals of RooParamHistFunc.

RooParamHistFunc allows you to scale the counts in each bin with a
parameter. The interface of RooDataHist::sum was extended with a
function parameter to inject the logic of scaling the bin weight
depending on the bin index.

This commit partly fixes issue #7182. We still need to implement the
range feature in RooHistFunc.