### PR TITLE
[PyROOT][7179] Reduce range of mapping __getitem__ to __call__

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
@@ -197,8 +197,11 @@ static int BuildScopeProxyDict(Cppyy::TCppScope_t scope, PyObject* pyclass)
                     qual_return.find("const", 0, 5) == std::string::npos) {
                 if (isCall && !potGetItem) potGetItem = method;
                 setupSetItem = true;     // will add methods as overloads
-            } else if (isCall) {
-            // not a non-const by-ref return, thus better __getitem__ candidate
+            } else if (isCall && 1 < Cppyy::GetMethodNumArgs(method)) {
+            // not a non-const by-ref return, thus better __getitem__ candidate; the
+            // requirement for multiple arguments is that there is otherwise no benefit
+            // over the use of normal __getitem__ (this allows multi-indexing argumenst,
+            // which is clean in Python, but not allowed in C++)
                 potGetItem = method;
             }
         }


### PR DESCRIPTION
Prevents mapping of `__getitem__` to `__call__` when the call operator returns by value and accepts one argument. Still, the mapping happens in other cases such as the one shown in #7179 .

More info here:
https://bitbucket.org/wlav/cppyy/issues/262

From:
https://bitbucket.org/wlav/cpycppyy/commits/ab434fbb7134550fda8dc0f4d03c587fcebb0549