### PR TITLE
[JupyROOT] 6.22: Rescue lost JavaScript code injected by JupyROOT

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -48,20 +48,56 @@ _jsCode = """
 <div id="{jsDivId}"
      style="width: {jsCanvasWidth}px; height: {jsCanvasHeight}px">
 </div>
-<script src="/static/components/requirejs/require.js" type="text/javascript" charset="utf-8"></script>
 <script>
- requirejs.config({{
-     paths: {{
-       'JSRootCore' : '{jsROOTSourceDir}scripts/JSRootCore',
-     }}
-   }});
- require(['JSRootCore'],
-     function(Core) {{
-       var obj = Core.JSONR_unref({jsonContent});
-       Core.key_handling = false;
-       Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
-     }}
- );
+if (typeof require !== 'undefined') {{
+
+    // All requirements met (we are in jupyter notebooks or we loaded requirejs before).
+    display_{jsDivId}();
+
+}} else {{
+
+    // We are in jupyterlab, we need to insert requirejs and configure it.
+    // Jupyterlab might be installed in a different base_url so we need to know it.
+    try {{
+        var base_url = JSON.parse(document.getElementById('jupyter-config-data').innerHTML).baseUrl;
+    }} catch(_) {{
+        var base_url = '/';
+    }}
+
+    // Try loading a local version of requirejs and fallback to cdn if not possible.
+    requirejs_load(base_url + 'static/components/requirejs/require.js', requirejs_success(base_url), function(){{
+        requirejs_load('https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.min.js', requirejs_success(base_url), function(){{
+            document.getElementById("{jsDivId}").innerHTML = "Failed to load requireJs";
+        }});
+    }});
+}}
+
+function requirejs_load(src, on_load, on_error) {{
+    var script = document.createElement('script');
+    script.src = src;
+    script.onload = on_load;
+    script.onerror = on_error;
+    document.head.appendChild(script);
+}}
+
+function requirejs_success(base_url) {{
+    return function() {{
+        require.config({{
+            baseUrl: base_url + 'static/'
+        }});
+        display_{jsDivId}();
+    }}
+}}
+
+function display_{jsDivId}() {{
+    require(['scripts/JSRootCore'],
+        function(Core) {{
+            var obj = Core.JSONR_unref({jsonContent});
+            Core.key_handling = false;
+            Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
+        }}
+    );
+}}
 </script>
 """
 


### PR DESCRIPTION
This modification was done in the old (legacy) JupyROOT (now in `bindings/pyroot_legacy/JupyROOT`), but not in the new one that was separated from the new PyROOT (now in `bindings/jupyroot`). Master is fine, this is just missing in 6.22.

This fixes the display of JSROOT graphics in SWAN.