### PR TITLE
Fix TPad::WaitPrimitive() when canvas is closing

### DIFF
--- a/graf2d/gpad/inc/TCanvas.h
+++ b/graf2d/gpad/inc/TCanvas.h
@@ -66,8 +66,8 @@ protected:
    static Bool_t fgIsFolder;       ///< Indicates if canvas can be browsed as a folder
 
 private:
-   TCanvas(const TCanvas &canvas);  // cannot copy canvas, use TObject::Clone()
-   TCanvas &operator=(const TCanvas &rhs);  // idem
+   TCanvas(const TCanvas &canvas) = delete;
+   TCanvas &operator=(const TCanvas &rhs) = delete;
    void     Build();
    void     CopyPixmaps();
    void     DrawEventStatus(Int_t event, Int_t x, Int_t y, TObject *selected);

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -129,8 +129,8 @@ protected:
    virtual void  SetBatch(Bool_t batch=kTRUE);
 
 private:
-   TPad(const TPad &pad);  // cannot copy pads, use TObject::Clone()
-   TPad &operator=(const TPad &rhs);  // idem
+   TPad(const TPad &pad) = delete;
+   TPad &operator=(const TPad &rhs) = delete;
 
    void CopyBackgroundPixmap(Int_t x, Int_t y);
    void CopyBackgroundPixmaps(TPad *start, TPad *stop, Int_t x, Int_t y);

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -6886,15 +6886,15 @@ void TPad::UseCurrentStyle()
 
 TObject *TPad::WaitPrimitive(const char *pname, const char *emode)
 {
-   if (!gPad) return 0;
+   if (!gPad) return nullptr;
 
    if (strlen(emode)) gROOT->SetEditorMode(emode);
    if (gROOT->GetEditorMode() == 0 && strlen(pname) > 2) gROOT->SetEditorMode(&pname[1]);
 
    if (!fPrimitives) fPrimitives = new TList;
    gSystem->ProcessEvents();
-   TObject *oldlast = gPad->GetListOfPrimitives()->Last();
-   TObject *obj = 0;
+   TObject *oldlast = gPad->GetListOfPrimitives() ? gPad->GetListOfPrimitives()->Last() : nullptr;
+   TObject *obj = nullptr;
    Bool_t testlast = kFALSE;
    Bool_t hasname = strlen(pname) > 0;
    if (!pname[0] && !emode[0]) testlast = kTRUE;
@@ -6921,7 +6921,7 @@ TObject *TPad::WaitPrimitive(const char *pname, const char *emode)
       gSystem->Sleep(10);
    }
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -1306,7 +1306,7 @@ void TPad::Draw(Option_t *option)
    // pad cannot be in itself and it can only be in one other pad at a time
    if (!fPrimitives) fPrimitives = new TList;
    if (gPad != this) {
-      if (fMother && fMother->TestBit(kNotDeleted)) 
+      if (fMother && fMother->TestBit(kNotDeleted))
             if (fMother->GetListOfPrimitives()) fMother->GetListOfPrimitives()->Remove(this);
       TPad *oldMother = fMother;
       fCanvas = gPad->GetCanvas();
@@ -6218,7 +6218,7 @@ void TPad::ShowGuidelines(TObject *object, const Int_t event, const char mode, c
    TPad *is_pad = dynamic_cast<TPad *>( object );
    TVirtualPad *padSave = 0;
    padSave = gPad;
-   if (is_pad) 
+   if (is_pad)
      if (is_pad->GetMother()) is_pad->GetMother()->cd();
 
    static TPad * tmpGuideLinePad;
@@ -6899,13 +6899,14 @@ TObject *TPad::WaitPrimitive(const char *pname, const char *emode)
    Bool_t hasname = strlen(pname) > 0;
    if (!pname[0] && !emode[0]) testlast = kTRUE;
    if (testlast) gROOT->SetEditorMode();
-   while (!gSystem->ProcessEvents() && gROOT->GetSelectedPad()) {
+   while (!gSystem->ProcessEvents() && gROOT->GetSelectedPad() && gPad) {
       if (gROOT->GetEditorMode() == 0) {
          if (hasname) {
             obj = FindObject(pname);
             if (obj) return obj;
          }
          if (testlast) {
+            if (!gPad->GetListOfPrimitives()) return nullptr;
             obj = gPad->GetListOfPrimitives()->Last();
             if (obj != oldlast) return obj;
             Int_t event = GetEvent();


### PR DESCRIPTION
In such case gPad can be set to nullptr and function fails
Solving https://root-forum.cern.ch/t/43560