### PR TITLE
[Cling][cpt] Fix Cling CI by removing svn dependence and dropping Python 2

### DIFF
--- a/interpreter/cling/.github/workflows/ci.yml
+++ b/interpreter/cling/.github/workflows/ci.yml
@@ -96,10 +96,10 @@ jobs:
         fi
         export CLING_BUILD_FLAGS="$CLING_BUILD_FLAGS -DCLANG_ENABLE_ARCMT=OFF -DCLANG_ENABLE_STATIC_ANALYZER=OFF -DLLVM_ENABLE_WARNINGS=OFF -DCLING_ENABLE_WARNINGS=ON"
         if [[ ${{ matrix.name }} == *"compile"* ]]; then
-          ./cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }}
+          python3 cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }}
         elif [[ ${{ matrix.name }} == *"fromtar"* ]]; then
-          ./cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }} --with-binary-llvm --with-llvm-tar
+          python3 cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }} --with-binary-llvm --with-llvm-tar
         else
-          ./cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }} --with-binary-llvm
+          python3 cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }} --with-binary-llvm
         fi
       working-directory: tools/packaging/

--- a/interpreter/cling/test/lit.cfg
+++ b/interpreter/cling/test/lit.cfg
@@ -321,15 +321,6 @@ if platform.system() not in ['Windows']:
 # require it.
 if not os.path.exists(os.path.join(config.test_exec_root, "..", "..", "clang", "test")):
   config.test_exec_root = os.path.join(config.test_exec_root, "..", "..")
-  llvm_revision = urlopen(
-      "https://raw.githubusercontent.com/root-project/cling/master/LastKnownGoodLLVMSVNRevision.txt"
-      ).readline().strip().decode('utf-8')
-  subprocess.Popen(['sudo svn export http://llvm.org/svn/llvm-project/llvm/branches/{0}/utils/lit utils/lit'.format(llvm_revision)],
-                                    cwd=config.llvm_src_root,
-                                    shell=True,
-                                    stdin=subprocess.PIPE,
-                                    stdout=None,
-                                    stderr=subprocess.STDOUT).communicate('yes'.encode('utf-8'))
 config.substitutions.append(('%testexecdir', config.test_exec_root))
 config.substitutions.append(('%llvmsrcdir', config.llvm_src_root))
 config.available_features.add('vanilla-cling')

--- a/interpreter/cling/tools/packaging/README.md
+++ b/interpreter/cling/tools/packaging/README.md
@@ -34,8 +34,8 @@ or
 cd tools/packaging/
 ./cpt.py -c
 ```
-Regardless of the platform and operating system, make sure your system has the
-latest and greatest version of Python 2 installed, v2.7 being the absolute minimum.
+Regardless of the platform and operating system, make sure to call the cpt script
+with Python 3.
 CPT uses some features and modules which are not a part of older versions of Python.
 The same holds true for the versions of GCC/Clang you have on your machine. Older
 compilers do not support c++11 features and thus you can expect a build error if you


### PR DESCRIPTION
LLVM has dropped it's svn instance, so cpt was unable to retrieve LLVM from svn (and Cling CI was failing).

Also, lit is not being installed as an independent package on MacOS when being installed using Python2's pip (used to work earlier). Therefore we decided to drop Python 2 (also Python 2 has reached end of life).

@Axel-Naumann This should also solve the sudo issue when running tests, that you mentioned to me around a year ago ;)

Linked issue - https://github.com/root-project/cling/issues/385