### PR TITLE
[IO] Deprecate TStreamerElement::ESTLtype in favor of ROOT::ESTLType

### DIFF
--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -90,22 +90,22 @@ namespace TClassEdit {
       kDropHash         = 1<<13 /* Drop the hash if applies to the collection */
    };
 
-   enum ESTLType {
-      kNotSTL            = ROOT::kNotSTL,
-      kVector            = ROOT::kSTLvector,
-      kList              = ROOT::kSTLlist,
-      kForwardlist       = ROOT::kSTLforwardlist,
-      kDeque             = ROOT::kSTLdeque,
-      kMap               = ROOT::kSTLmap,
-      kMultiMap          = ROOT::kSTLmultimap,
-      kSet               = ROOT::kSTLset,
-      kMultiSet          = ROOT::kSTLmultiset,
-      kUnorderedSet      = ROOT::kSTLunorderedset,
-      kUnorderedMultiSet = ROOT::kSTLunorderedmultiset,
-      kUnorderedMap      = ROOT::kSTLunorderedmap,
-      kUnorderedMultiMap = ROOT::kSTLunorderedmultimap,
-      kBitSet            = ROOT::kSTLbitset,
-      kEnd               = ROOT::kSTLend
+   enum R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") ESTLType {
+      kNotSTL            R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kNotSTL,
+      kVector            R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLvector,
+      kList              R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLlist,
+      kForwardlist       R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLforwardlist,
+      kDeque             R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLdeque,
+      kMap               R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLmap,
+      kMultiMap          R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLmultimap,
+      kSet               R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLset,
+      kMultiSet          R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLmultiset,
+      kUnorderedSet      R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedset,
+      kUnorderedMultiSet R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedmultiset,
+      kUnorderedMap      R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedmap,
+      kUnorderedMultiMap R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedmultimap,
+      kBitSet            R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLbitset,
+      kEnd               R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLend
    };
 
    enum class EComplexType : short {

--- a/core/meta/inc/TDictionary.h
+++ b/core/meta/inc/TDictionary.h
@@ -194,21 +194,21 @@ public:
    static TDictionary* GetDictionary(const std::type_info &typeinfo);
 
    // Type of STL container (returned by IsSTLContainer).
-   enum ESTLType {
-      kNone              = ROOT::kNotSTL,
-      kVector            = ROOT::kSTLvector,
-      kList              = ROOT::kSTLlist,
-      kForwardlist       = ROOT::kSTLforwardlist,
-      kDeque             = ROOT::kSTLdeque,
-      kMap               = ROOT::kSTLmap,
-      kMultimap          = ROOT::kSTLmultimap,
-      kSet               = ROOT::kSTLset,
-      kMultiset          = ROOT::kSTLmultiset,
-      kUnorderedSet      = ROOT::kSTLunorderedset,
-      kUnorderedMultiset = ROOT::kSTLunorderedmultiset,
-      kUnorderedMap      = ROOT::kSTLunorderedmap,
-      kUnorderedMultimap = ROOT::kSTLunorderedmultimap,
-      kBitset            = ROOT::kSTLbitset
+   enum R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") ESTLType {
+      kNone              R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kNotSTL,
+      kVector            R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLvector,
+      kList              R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLlist,
+      kForwardlist       R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLforwardlist,
+      kDeque             R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLdeque,
+      kMap               R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLmap,
+      kMultimap          R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLmultimap,
+      kSet               R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLset,
+      kMultiset          R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLmultiset,
+      kUnorderedSet      R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedset,
+      kUnorderedMultiset R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedmultiset,
+      kUnorderedMap      R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedmap,
+      kUnorderedMultimap R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedmultimap,
+      kBitset            R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLbitset
    };
 
    /// Kinds of members to include in lists.

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -54,22 +54,22 @@ protected:
 
 public:
 
-   enum ESTLtype {
-      kSTL                  = ROOT::kSTLany,
-      kSTLstring            = ROOT::kSTLstring,
-      kSTLvector            = ROOT::kSTLvector,
-      kSTLlist              = ROOT::kSTLlist,
-      kSTLforwardlist       = ROOT::kSTLforwardlist,
-      kSTLdeque             = ROOT::kSTLdeque,
-      kSTLmap               = ROOT::kSTLmap,
-      kSTLmultimap          = ROOT::kSTLmultimap,
-      kSTLset               = ROOT::kSTLset,
-      kSTLmultiset          = ROOT::kSTLmultiset,
-      kSTLunorderedset      = ROOT::kSTLunorderedset,
-      kSTLunorderedmultiset = ROOT::kSTLunorderedmultiset,
-      kSTLunorderedmap      = ROOT::kSTLunorderedmap,
-      kSTLunorderedmultimap = ROOT::kSTLunorderedmultimap,
-      kSTLbitset            = ROOT::kSTLbitset
+   enum R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") ESTLtype {
+      kSTL                  R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLany,
+      kSTLstring            R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLstring,
+      kSTLvector            R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLvector,
+      kSTLlist              R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLlist,
+      kSTLforwardlist       R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLforwardlist,
+      kSTLdeque             R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLdeque,
+      kSTLmap               R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLmap,
+      kSTLmultimap          R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLmultimap,
+      kSTLset               R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLset,
+      kSTLmultiset          R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLmultiset,
+      kSTLunorderedset      R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedset,
+      kSTLunorderedmultiset R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedmultiset,
+      kSTLunorderedmap      R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedmap,
+      kSTLunorderedmultimap R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLunorderedmultimap,
+      kSTLbitset            R__DEPRECATED(6, 34, "Please use ROOT::ESTLType instead.") = ROOT::kSTLbitset
    };
    // TStreamerElement status bits
    enum EStatusBits {

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -103,6 +103,7 @@ class Container {
 
 #include "Compression.h"
 
+#include "ESTLType.h"
 #include "TArrayI.h"
 #include "TError.h"
 #include "TBase64.h"
@@ -1225,19 +1226,19 @@ void TBufferJSON::JsonStartElement(const TStreamerElement *elem, const TClass *b
                elem_name = "fLineStyles";
          }
       break;
-   case TClassEdit::kVector: elem_name = "fVector"; break;
-   case TClassEdit::kList: elem_name = "fList"; break;
-   case TClassEdit::kForwardlist: elem_name = "fForwardlist"; break;
-   case TClassEdit::kDeque: elem_name = "fDeque"; break;
-   case TClassEdit::kMap: elem_name = "fMap"; break;
-   case TClassEdit::kMultiMap: elem_name = "fMultiMap"; break;
-   case TClassEdit::kSet: elem_name = "fSet"; break;
-   case TClassEdit::kMultiSet: elem_name = "fMultiSet"; break;
-   case TClassEdit::kUnorderedSet: elem_name = "fUnorderedSet"; break;
-   case TClassEdit::kUnorderedMultiSet: elem_name = "fUnorderedMultiSet"; break;
-   case TClassEdit::kUnorderedMap: elem_name = "fUnorderedMap"; break;
-   case TClassEdit::kUnorderedMultiMap: elem_name = "fUnorderedMultiMap"; break;
-   case TClassEdit::kBitSet: elem_name = "fBitSet"; break;
+   case ROOT::ESTLType::kSTLvector: elem_name = "fVector"; break;
+   case ROOT::ESTLType::kSTLlist: elem_name = "fList"; break;
+   case ROOT::ESTLType::kSTLforwardlist: elem_name = "fForwardlist"; break;
+   case ROOT::ESTLType::kSTLdeque: elem_name = "fDeque"; break;
+   case ROOT::ESTLType::kSTLmap: elem_name = "fMap"; break;
+   case ROOT::ESTLType::kSTLmultimap: elem_name = "fMultiMap"; break;
+   case ROOT::ESTLType::kSTLset: elem_name = "fSet"; break;
+   case ROOT::ESTLType::kSTLmultiset: elem_name = "fMultiSet"; break;
+   case ROOT::ESTLType::kSTLunorderedset: elem_name = "fUnorderedSet"; break;
+   case ROOT::ESTLType::kSTLunorderedmultiset: elem_name = "fUnorderedMultiSet"; break;
+   case ROOT::ESTLType::kSTLunorderedmap: elem_name = "fUnorderedMap"; break;
+   case ROOT::ESTLType::kSTLunorderedmultimap: elem_name = "fUnorderedMultiMap"; break;
+   case ROOT::ESTLType::kSTLbitset: elem_name = "fBitSet"; break;
    case json_TArray: elem_name = "fArray"; break;
    case json_TString:
    case json_stdstring: elem_name = "fString"; break;
@@ -1347,8 +1348,9 @@ void TBufferJSON::JsonWriteObject(const void *obj, const TClass *cl, Bool_t chec
    } else if ((special_kind <= 0) || (special_kind > json_TArray)) {
       // FIXME: later post processing should be active for all special classes, while they all keep output in the value
       JsonDisablePostprocessing();
-   } else if ((special_kind == TClassEdit::kMap) || (special_kind == TClassEdit::kMultiMap) ||
-              (special_kind == TClassEdit::kUnorderedMap) || (special_kind == TClassEdit::kUnorderedMultiMap)) {
+   } else if ((special_kind == ROOT::ESTLType::kSTLmap) || (special_kind == ROOT::ESTLType::kSTLmultimap) ||
+              (special_kind == ROOT::ESTLType::kSTLunorderedmap) ||
+              (special_kind == ROOT::ESTLType::kSTLunorderedmultimap)) {
 
       if ((fMapAsObject && (fStack.size()==1)) || (stack && stack->fElem && strstr(stack->fElem->GetTitle(), "JSON_object")))
          map_convert = 2; // mapped into normal object
@@ -1396,7 +1398,8 @@ void TBufferJSON::JsonWriteObject(const void *obj, const TClass *cl, Bool_t chec
 
    } else {
 
-      bool base64 = ((special_kind == TClassEdit::kVector) && stack && stack->fElem && strstr(stack->fElem->GetTitle(), "JSON_base64"));
+      bool base64 = ((special_kind == ROOT::ESTLType::kSTLvector) && stack && stack->fElem &&
+                     strstr(stack->fElem->GetTitle(), "JSON_base64"));
 
       // for array, string and STL collections different handling -
       // they not recognized at the end as objects in JSON
@@ -1836,8 +1839,8 @@ void *TBufferJSON::JsonReadObject(void *obj, const TClass *objClass, TClass **re
    }
 
    Int_t map_convert = 0;
-   if ((special_kind == TClassEdit::kMap) || (special_kind == TClassEdit::kMultiMap) ||
-       (special_kind == TClassEdit::kUnorderedMap) || (special_kind == TClassEdit::kUnorderedMultiMap)) {
+   if ((special_kind == ROOT::ESTLType::kSTLmap) || (special_kind == ROOT::ESTLType::kSTLmultimap) ||
+       (special_kind == ROOT::ESTLType::kSTLunorderedmap) || (special_kind == ROOT::ESTLType::kSTLunorderedmultimap)) {
       map_convert = json->is_object() ? 2 : 1; // check if map was written as array or as object
    }
 


### PR DESCRIPTION
I don't know if this is desirable or not, but I figured I would raise the issue. `TStreamerElement::ESTLtype` duplicates `ROOT::ESTLType` exactly, but with a lower-case `t` in `type`. It confused me when I found this out (and it turns out that I forgot to update `TStreamerElement::ESTLtype` when I updated `ROOT::ESTLType`).

I could not find any usage of `TStreamerElement::ESTLType` in ROOT, and ROOT compiles just fine without the enum, but just in case someone out there is using it, I'm proposing to deprecate it in 6.24 and remove it in 6.26.

Feel free to close this PR if you don't think this makes sense.

UPDATE:

after discussion with @pcanal we decided that deprecation/removal is the right thing to do, and I extended the patch to `TDictionary` and `TClassEdit`. `TBufferJSON` had some usage of `TClassEdit::ESTLType` which has now been substituted with `ROOT::ESTLType`.

UPDATE 2:

Since gcc 5 (the system compiler on Ubuntu 16) [does not support deprecation of enumerators](https://godbolt.org/z/1TEo5M), I'm proposing to disable `R__DEPRECATED` for that gcc version (it was already disabled for gcc 5.1 and 5.2 due to a different issue).