### PR TITLE
Add RPageSinkFile metrics and access them through RNTupleWriter

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -211,6 +211,7 @@ private:
    std::unique_ptr<Detail::RPageSink> fSink;
    /// Needs to be destructed before fSink
    std::unique_ptr<RNTupleModel> fModel;
+   Detail::RNTupleMetrics fMetrics;
    NTupleSize_t fClusterSizeEntries;
    NTupleSize_t fLastCommitted;
    NTupleSize_t fNEntries;
@@ -243,6 +244,9 @@ public:
    }
    /// Ensure that the data from the so far seen Fill calls has been written to storage
    void CommitCluster();
+
+   void EnableMetrics() { fMetrics.Enable(); }
+   const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -68,6 +68,7 @@ private:
    std::uint64_t fClusterMaxOffset = 0;
    /// Helper for zipping keys and header / footer; comprises a 16MB zip buffer
    RNTupleCompressor fCompressor;
+   RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
 
 protected:
    void CreateImpl(const RNTupleModel &model) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -58,6 +58,11 @@ public:
    static constexpr std::size_t kDefaultElementsPerPage = 10000;
 
 private:
+   /// I/O performance counters that get registered in fMetrics
+   struct RCounters {
+      RNTupleAtomicCounter &fNPageCommitted;
+   };
+   std::unique_ptr<RCounters> fCounters;
    RNTupleMetrics fMetrics;
    std::unique_ptr<RPageAllocatorHeap> fPageAllocator;
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -251,11 +251,13 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
    std::unique_ptr<ROOT::Experimental::Detail::RPageSink> sink)
    : fSink(std::move(sink))
    , fModel(std::move(model))
+   , fMetrics("RNTupleWriter")
    , fClusterSizeEntries(kDefaultClusterSizeEntries)
    , fLastCommitted(0)
    , fNEntries(0)
 {
    fSink->Create(*fModel.get());
+   fMetrics.ObserveMetrics(fSink->GetMetrics());
 }
 
 ROOT::Experimental::RNTupleWriter::~RNTupleWriter()

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -50,6 +50,9 @@ ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntuple
 {
    R__LOG_WARNING(NTupleLog()) << "The RNTuple file format will change. " <<
       "Do not store real data with this version of RNTuple!";
+   fCounters = std::unique_ptr<RCounters>(new RCounters{
+      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("nPageCommitted", "", "number of pages committed to storage")
+   });
 }
 
 
@@ -133,6 +136,7 @@ ROOT::Experimental::Detail::RPageSinkFile::CommitPageImpl(ColumnHandle_t columnH
    RClusterDescriptor::RLocator result;
    result.fPosition = offsetData;
    result.fBytesOnStorage = zippedBytes;
+   fCounters->fNPageCommitted.Inc();
    return result;
 }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -45,7 +45,7 @@
 ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntupleName,
    const RNTupleWriteOptions &options)
    : RPageSink(ntupleName, options)
-   , fMetrics("RPageSinkRoot")
+   , fMetrics("RPageSinkFile")
    , fPageAllocator(std::make_unique<RPageAllocatorHeap>())
 {
    R__LOG_WARNING(NTupleLog()) << "The RNTuple file format will change. " <<

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -42,7 +42,7 @@
 #include <thread>
 #include <queue>
 
-ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, std::string_view path,
+ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntupleName,
    const RNTupleWriteOptions &options)
    : RPageSink(ntupleName, options)
    , fMetrics("RPageSinkRoot")
@@ -50,7 +50,13 @@ ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntuple
 {
    R__LOG_WARNING(NTupleLog()) << "The RNTuple file format will change. " <<
       "Do not store real data with this version of RNTuple!";
+}
 
+
+ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, std::string_view path,
+   const RNTupleWriteOptions &options)
+   : RPageSinkFile(ntupleName, options)
+{
    fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(Internal::RNTupleFileWriter::Recreate(
       ntupleName, path, options.GetCompression(), options.GetContainerFormat()));
 }
@@ -58,25 +64,16 @@ ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntuple
 
 ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, TFile &file,
    const RNTupleWriteOptions &options)
-   : RPageSink(ntupleName, options)
-   , fMetrics("RPageSinkRoot")
-   , fPageAllocator(std::make_unique<RPageAllocatorHeap>())
+   : RPageSinkFile(ntupleName, options)
 {
-   R__LOG_WARNING(NTupleLog()) << "The RNTuple file format will change. " <<
-      "Do not store real data with this version of RNTuple!";
-
    fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(Internal::RNTupleFileWriter::Append(ntupleName, file));
 }
 
 
 ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntupleName, std::string_view path,
    const RNTupleWriteOptions &options, std::unique_ptr<TFile> &file)
-   : RPageSink(ntupleName, options)
-   , fMetrics("RPageSinkRoot")
-   , fPageAllocator(std::make_unique<RPageAllocatorHeap>())
+   : RPageSinkFile(ntupleName, options)
 {
-   R__LOG_WARNING(NTupleLog()) << "The RNTuple file format will change. " <<
-      "Do not store real data with this version of RNTuple!";
    fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(
       Internal::RNTupleFileWriter::Recreate(ntupleName, path, file));
 }

--- a/tree/ntuple/v7/test/ntuple_metrics.cxx
+++ b/tree/ntuple/v7/test/ntuple_metrics.cxx
@@ -106,7 +106,7 @@ TEST(Metrics, RNTupleWriter)
    *float_field = 10.0;
    ntuple->Fill();
    ntuple->CommitCluster();
-   auto* page_counter = ntuple->GetMetrics().GetCounter("RNTupleWriter.RPageSinkRoot.nPageCommitted");
+   auto* page_counter = ntuple->GetMetrics().GetCounter("RNTupleWriter.RPageSinkFile.nPageCommitted");
    ASSERT_FALSE(page_counter == nullptr);
    // one page for the int field, one for the float field
    EXPECT_EQ(page_counter->GetValueAsInt(), 2);

--- a/tree/ntuple/v7/test/ntuple_metrics.cxx
+++ b/tree/ntuple/v7/test/ntuple_metrics.cxx
@@ -89,3 +89,25 @@ TEST(Metrics, Timer)
    }
    EXPECT_GT(ctrWallTime.GetValue(), 0U);
 }
+
+TEST(Metrics, RNTupleWriter)
+{
+   std::string rootFileName{"test_ntuple_writer_metrics.root"};
+   FileRaii fileGuard(rootFileName);
+
+   auto model = RNTupleModel::Create();
+   auto int_field = model->MakeField<int>("ints");
+   auto float_field = model->MakeField<float>("floats");
+   auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", rootFileName);
+   EXPECT_FALSE(ntuple->GetMetrics().IsEnabled());
+   ntuple->EnableMetrics();
+   EXPECT_TRUE(ntuple->GetMetrics().IsEnabled());
+   *int_field = 0;
+   *float_field = 10.0;
+   ntuple->Fill();
+   ntuple->CommitCluster();
+   auto* page_counter = ntuple->GetMetrics().GetCounter("RNTupleWriter.RPageSinkRoot.nPageCommitted");
+   ASSERT_FALSE(page_counter == nullptr);
+   // one page for the int field, one for the float field
+   EXPECT_EQ(page_counter->GetValueAsInt(), 2);
+}

--- a/tree/ntuple/v7/test/ntuple_metrics.cxx
+++ b/tree/ntuple/v7/test/ntuple_metrics.cxx
@@ -109,5 +109,5 @@ TEST(Metrics, RNTupleWriter)
    auto* page_counter = ntuple->GetMetrics().GetCounter("RNTupleWriter.RPageSinkFile.nPageCommitted");
    ASSERT_FALSE(page_counter == nullptr);
    // one page for the int field, one for the float field
-   EXPECT_EQ(page_counter->GetValueAsInt(), 2);
+   EXPECT_EQ(2, page_counter->GetValueAsInt());
 }


### PR DESCRIPTION
This PR adds a simple metric (`nPagesCommitted`) to `RPageSinkFile` which is newly accessible through `RNTupleWriter`. The implementation mirrors `RNTupleReader`. I refactored the `RPageSinkFile` constructors to delegate metrics initialization to a new private constructor as in `RNTupleReader`. There are definitely many other metrics to be added.