### PR TITLE
[RF] Fix propagation of the operation mode in RooProdPdf

### DIFF
--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1565,7 +1565,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
       RooAbsPdf* pdf = (RooAbsPdf*) term->first() ;
 
       RooAbsReal* partInt = pdf->createIntegral(termISet,termNSet,isetRangeName) ;
-      //partInt->setOperMode(operMode()) ;
+      partInt->setOperMode(operMode()) ;
       partInt->setStringAttribute("PROD_TERM_TYPE","IIIa") ;
 
       isOwned=kTRUE ;
@@ -1590,7 +1590,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
       const std::string name = makeRGPPName("GENPROJ_",*term,termISet,termNSet,isetRangeName) ;
       RooAbsReal* partInt = new RooGenProdProj(name.c_str(),name.c_str(),*term,termISet,termNSet,isetRangeName) ;
       partInt->setStringAttribute("PROD_TERM_TYPE","IIIb") ;
-      //partInt->setOperMode(operMode()) ;
+      partInt->setOperMode(operMode()) ;
 
       //cout << "processProductTerm(" << GetName() << ") case IIIb func = " << partInt->GetName() << endl ;
 
@@ -1619,7 +1619,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
     partInt->setExpensiveObjectCache(expensiveObjectCache()) ;
 
     partInt->setStringAttribute("PROD_TERM_TYPE","IVa") ;
-    //partInt->setOperMode(operMode()) ;
+    partInt->setOperMode(operMode()) ;
 
     //cout << "processProductTerm(" << GetName() << ") case IVa func = " << partInt->GetName() << endl ;
 


### PR DESCRIPTION
Uncomment line setting operation mode of partInt components of RooPro…dPdf using current operation mode.

This seems to be needed in order to propagate to the cached intergal component s of the RooProdPdf is operation mode.
It fixes issue #7157 where RooProdPdf is used from a RooFFTConv. In this case
the RooFFTConv sets AlwaysDirty as operation mode its components, and then the ROoProdPdf needs to propage to its owned parts, otherwise during the FFT computation the RooProdPdf returns always its first evaluation.

To fix the example in #7157 it is sufficient to uncomment line RooProdPdf.cxx:1622, since it is case IVa in code. 
But a similar issue is present when using case IIIa and IIb. 