### PR TITLE
[RF] Enable bin averaging by default in RooPlot::residHist/pullHist

### DIFF
--- a/README/ReleaseNotes/v624/index.md
+++ b/README/ReleaseNotes/v624/index.md
@@ -99,6 +99,10 @@ See the discussion at [ROOT-11014](https://sft.its.cern.ch/jira/browse/ROOT-1101
 When RooFit performs binned fits, it takes the probability density at the bin centre as a proxy for the probability in the bin. This can lead to a bias.
 To alleviate this, the new class [RooBinSamplingPdf](https://root.cern/doc/v624/classRooBinSamplingPdf.html) has been added to RooFit.
 
+### More accurate residual and pull distributions
+When making residual or pull distributions with `RooPlot::residHist` or `RooPlot::pullHist`, the histogram is now compared with the curve's average values within a given bin by default, ensuring that residual and pull distributions are valid for strongly curved distributions.
+The old default behaviour was to interpolate the curve at the bin centres, which can still be enabled by setting the `useAverage` parameter of `RooPlot::residHist` or `RooPlot::pullHist` to `false`.
+
 ### Improved recovery from invalid parameters
 When a function in RooFit is undefined (Poisson with negative mean, PDF with negative values, etc), RooFit can now pass information about the
 "badness" of the violation to the minimiser. The minimiser can use this to compute a gradient to find its way out of the undefined region.

--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -176,9 +176,9 @@ public:
   Double_t chiSquare(int nFitParam=0) const { return chiSquare(0,0,nFitParam) ; } 
   Double_t chiSquare(const char* pdfname, const char* histname, int nFitParam=0) const ;
 
-  RooHist* residHist(const char* histname=0, const char* pdfname=0,bool normalize=false, bool useAverage=kFALSE) const ;
+  RooHist* residHist(const char* histname=0, const char* pdfname=0,bool normalize=false, bool useAverage=true) const ;
   ///Uses residHist() and sets normalize=true
-  RooHist* pullHist(const char* histname=0, const char* pdfname=0, bool useAverage=false) const 
+  RooHist* pullHist(const char* histname=0, const char* pdfname=0, bool useAverage=true) const 
     { return residHist(histname,pdfname,true,useAverage); }
 
   void Browse(TBrowser *b) ;

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -1133,6 +1133,8 @@ Double_t RooPlot::chiSquare(const char* curvename, const char* histname, int nFi
 /// to curve 'curvename'. If normalize is true, the residuals are divided by the error
 /// of the histogram, effectively returning a pull histogram.
 /// The plotting range of the graph is adapted to the plotting range of the current plot.
+/// If `useAverage` is true, the histogram is compared with the curve's average values within a given bin.
+/// Otherwise, the curve is interpolated at the bin centres, which is not accurate for curved distributions.
 RooHist* RooPlot::residHist(const char* histname, const char* curvename, bool normalize, bool useAverage) const
 {
   // Find curve object

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -676,10 +676,12 @@ public:
     // -------------------------------------------------------
 
     // Construct a histogram with the residuals of the data w.r.t. the curve
-    RooHist* hresid = frame1->residHist() ;
+    // we set `useAverage` to false for this test because this was done for the reference histogram
+    RooHist* hresid = frame1->residHist(nullptr, nullptr, false, false) ;
 
     // Construct a histogram with the pulls of the data w.r.t the curve
-    RooHist* hpull = frame1->pullHist() ;
+    // we set `useAverage` to false for this test because this was done for the reference histogram
+    RooHist* hpull = frame1->pullHist(nullptr, nullptr, false) ;
 
     // Create a new frame to draw the residual distribution and add the distribution to the frame
     RooPlot* frame2 = x.frame(Title("Residual Distribution")) ;


### PR DESCRIPTION
When making residual or pull distributions with `RooPlot::residHist` or
`RooPlot::pullHist`, the histogram is now compared with the curve's
average values within a given bin by default, ensuring that residual and
pull distributions are valid for strongly curved distributions.

The old default behaviour was to interpolate the curve at the bin
centres, which can still be enabled by setting the useAverage
parameter of `RooPlot::residHist` or `RooPlot::pullHist` to `false`.

Addresses https://github.com/root-project/root/issues/7239.