### PR TITLE
[roofit] do not apply -fno-math-errno flags for MSVC

### DIFF
--- a/hist/hist/src/TProfile3D.cxx
+++ b/hist/hist/src/TProfile3D.cxx
@@ -871,7 +871,7 @@ void TProfile3D::LabelsInflate(Option_t *ax)
 ///  - "u" draw labels up (end of label right adjusted)
 ///  - "d" draw labels down (start of label left adjusted)
 
-void TProfile3D::LabelsOption(Option_t */* option */, Option_t * /* ax */)
+void TProfile3D::LabelsOption(Option_t * /* option */, Option_t * /* ax */)
 {
    Error("LabelsOption","Labels option function is not implemented for a TProfile3D");
 }

--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -80,7 +80,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistFactory
 
 # For recent clang, this can facilitate auto-vectorisation.
 # In RooFit, the errno side effect is not needed, anyway:
-target_compile_options(HistFactory PUBLIC -fno-math-errno)
+if(NOT MSVC)
+  target_compile_options(HistFactory PUBLIC -fno-math-errno)
+endif()
 
 ROOT_EXECUTABLE(hist2workspace
   MakeModelAndMeasurements.cxx

--- a/roofit/roofit/CMakeLists.txt
+++ b/roofit/roofit/CMakeLists.txt
@@ -150,6 +150,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
 
 # For recent clang, this can facilitate auto-vectorisation.
 # In RooFit, the errno side effect is not needed, anyway:
-target_compile_options(RooFit PUBLIC -fno-math-errno)
+if(NOT MSVC)
+  target_compile_options(RooFit PUBLIC -fno-math-errno)
+endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -459,6 +459,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
 
 # For recent clang, this can facilitate auto-vectorisation.
 # In RooFit, the errno side effect is not needed, anyway:
-target_compile_options(RooFitCore PUBLIC -fno-math-errno)
+if(NOT MSVC)
+  target_compile_options(RooFitCore PUBLIC -fno-math-errno)
+endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/roofitmore/CMakeLists.txt
+++ b/roofit/roofitmore/CMakeLists.txt
@@ -54,7 +54,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitMore
 
 # For recent clang, this can facilitate auto-vectorisation.
 # In RooFit, the errno side effect is not needed, anyway:
-target_compile_options(RooFitMore PUBLIC -fno-math-errno)
-
+if(NOT MSVC)
+  target_compile_options(RooFitMore PUBLIC -fno-math-errno)
+endif()
 
 #ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
Avoid warnings in Windows compilation