### PR TITLE
TGSpeedo: enable retrieval of odometer value

### DIFF
--- a/gui/gui/inc/TGSpeedo.h
+++ b/gui/gui/inc/TGSpeedo.h
@@ -82,6 +82,7 @@ public:
 
    const TGPicture     *GetPicture() const { return fBase; }
    TImage              *GetImage() const { return fImage; }
+   Int_t                GetOdoVal() const { return fCounter; }
    Float_t              GetPeakVal() const { return fPeakVal; }
    Float_t              GetScaleMin() const { return fScaleMin; }
    Float_t              GetScaleMax() const { return fScaleMax; }


### PR DESCRIPTION
In the same way that you can retrieve peak value. For logging purposes in parallel to the GUI.