### PR TITLE
Fix CoreBaseTests failure on Windows

### DIFF
--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -9,7 +9,7 @@
 # onepcm targets to be built.
 
 if(NOT MSVC)
-  set(dllib dl)
+  set(extralibs Cling dl)
 endif()
 
 ROOT_ADD_GTEST(CoreBaseTests
@@ -17,6 +17,6 @@ ROOT_ADD_GTEST(CoreBaseTests
   TQObjectTests.cxx
   TExceptionHandlerTests.cxx
   TStringTest.cxx
-  LIBRARIES Core Cling RIO ${dllib})
+  LIBRARIES Core Cling RIO ${extralibs})
 
 ROOT_ADD_GTEST(CoreErrorTests TErrorTests.cxx LIBRARIES Core)

--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -17,6 +17,6 @@ ROOT_ADD_GTEST(CoreBaseTests
   TQObjectTests.cxx
   TExceptionHandlerTests.cxx
   TStringTest.cxx
-  LIBRARIES Core Cling RIO ${extralibs})
+  LIBRARIES Core RIO ${extralibs})
 
 ROOT_ADD_GTEST(CoreErrorTests TErrorTests.cxx LIBRARIES Core)

--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -7,6 +7,10 @@
 # FIXME: The tests in core should require only libCore. OTOH, TQObjectTests uses the interpreter to register the class.
 # This means that if we run make CoreBaseTests the executable wouldn't be runnable because it requires libCling and
 # onepcm targets to be built.
+# N.B. We don't link with libCling on Windows, since linking with libCling leads to the following error:
+#   MSVCRT.lib(tncleanup.obj) : error LNK2005: "struct __type_info_node __type_info_root_node"
+#   (?__type_info_root_node@@3U__type_info_node@@A) already defined in libCling.lib(libCling.dll)
+#   [C:\build\workspace\root-pullrequests-build\build\core\base\test\CoreBaseTests.vcxproj]
 
 if(NOT MSVC)
   set(extralibs Cling dl)


### PR DESCRIPTION
Thsi fixes the following error:
```
MSVCRT.lib(tncleanup.obj) : error LNK2005: "struct __type_info_node __type_info_root_node" (?__type_info_root_node@@3U__type_info_node@@A) already defined in libCling.lib(libCling.dll) [C:\build\workspace\root-pullrequests-build\build\core\base\test\CoreBaseTests.vcxproj]
```