### PR TITLE
[RF] Add recovery from invalid parameters for BatchMode

### DIFF
--- a/roofit/roofitcore/inc/RooNaNPacker.h
+++ b/roofit/roofitcore/inc/RooNaNPacker.h
@@ -86,6 +86,11 @@ struct RooNaNPacker {
     return isNaNWithPayload(_payload) ? unpackNaN(_payload) : 0.;
   }
 
+  /// Retrieve a NaN with the current float payload packed into the mantissa.
+  double getNaNWithPayload() const {
+    return _payload;
+  }
+
   /// Test if this struct has a float packed into its mantissa.
   bool isNaNWithPayload() const {
     return isNaNWithPayload(_payload);


### PR DESCRIPTION
I had this lying around in an older branch. Could be interesting to add for 6.24, since it makes the new functionality more consistent. Otherwise, the recovery would only work in single-value mode.

So far, the recovery from invalid parameters only worked in scalar mode.
Here, RooAbsPdf and RooNLLVar are augmented with the NaN packer trick
also in batch mode.
This allows for propagating information about evaluation errors to the
minimiser.