### PR TITLE
[DF] Allow casting RResultPtr<Derived> to RResultPtr<Base>

### DIFF
--- a/tree/dataframe/inc/ROOT/RResultPtr.hxx
+++ b/tree/dataframe/inc/ROOT/RResultPtr.hxx
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <functional>
+#include <type_traits> // std::is_constructible
 
 namespace ROOT {
 namespace Internal {
@@ -158,14 +159,15 @@ public:
    RResultPtr &operator=(const RResultPtr &) = default;
    RResultPtr &operator=(RResultPtr &&) = default;
    explicit operator bool() const { return bool(fObjPtr); }
-   template <typename TO, typename std::enable_if<std::is_convertible<T, TO>::value, int>::type = 0>
-   operator RResultPtr<TO>() const
+
+   /// Convert a RResultPtr<T2> to a RResultPtr<T>.
+   ///
+   /// Useful e.g. to store a number of RResultPtr<TH1D> and RResultPtr<TH2D> in a std::vector<RResultPtr<TH1>>.
+   /// The requirements on T2 and T are the same as for conversion between std::shared_ptr<T2> and std::shared_ptr<T>.
+   template <typename T2, typename std::enable_if<std::is_constructible<std::shared_ptr<T>, std::shared_ptr<T2>>::value,
+                                                  int>::type = 0>
+   RResultPtr(const RResultPtr<T2> &r) : fLoopManager(r.fLoopManager), fObjPtr(r.fObjPtr), fActionPtr(r.fActionPtr)
    {
-      RResultPtr<TO> rp;
-      rp.fLoopManager = fLoopManager;
-      rp.fObjPtr = fObjPtr;
-      rp.fActionPtr = fActionPtr;
-      return rp;
    }
 
    /// Get a const reference to the encapsulated object.

--- a/tree/dataframe/test/dataframe_resptr.cxx
+++ b/tree/dataframe/test/dataframe_resptr.cxx
@@ -91,6 +91,14 @@ TEST(RResultPtr, IsReady)
    EXPECT_TRUE(p.IsReady());
 }
 
+// ROOT-9785, ROOT-10321
+TEST(RResultPtr, CastToBase)
+{
+   auto ptr = ROOT::RDataFrame(42).Histo1D<ULong64_t>("rdfentry_");
+   auto basePtr = ROOT::RDF::RResultPtr<TH1>(ptr);
+   EXPECT_EQ(basePtr->GetEntries(), 42ll);
+}
+
 TEST(RResultHandle, Ctor)
 {
    ROOT::RDataFrame df(3);


### PR DESCRIPTION
...and add a test. This fixes ROOT-10321.

This is also the proper fix for ROOT-9785 (basically the same
issue/feature request), which was supposed to be fixed by
78fca0b but unfortunately that commit enabled the conversion
based on the wrong condition: `is_convertible<T, TO>` rather
than `is_convertible<T*, TO*>`.
In order to fully delegate the decision on convertibility to
`shared_ptr`, we now use `is_constructible<shared_ptr<TO>, shared_ptr<T>>`
as the condition instead.