### PR TITLE
Resolve oustanding roottest issues (with full testing)

### DIFF
--- a/hist/hist/inc/LinkDef.h
+++ b/hist/hist/inc/LinkDef.h
@@ -342,6 +342,6 @@
   source="" target="fBinSumw2" \
   code="{ fBinSumw2.Reset(); }"
 
-
+#pragma read sourceClass="TF1" targetClass="TF1" version="[10]" source="TF1AbsComposition* fComposition_ptr" target="fComposition" code="{ fComposition.reset(onfile.fComposition_ptr); onfile.fComposition_ptr = nullptr; }"
 
 #endif

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -268,7 +268,6 @@ protected:
    std::unique_ptr<TFormula>   fFormula;        //Pointer to TFormula in case when user define formula
    std::unique_ptr<TF1Parameters> fParams;   //Pointer to Function parameters object (exists only for not-formula functions)
    std::unique_ptr<TF1AbsComposition> fComposition; //Pointer to composition (NSUM or CONV)
-   TF1AbsComposition *fComposition_ptr{nullptr};   //saved pointer (unique_ptr is transient)
 
    /// General constructor for TF1. Most of the other constructors delegate on it
    TF1(EFType functionType, const char *name, Double_t xmin, Double_t xmax, Int_t npar, Int_t ndim, EAddToList addToGlobList, TF1Parameters *params = nullptr, TF1FunctorPointer * functor = nullptr):
@@ -712,7 +711,7 @@ private:
    inline double EvalParVec(const Double_t *data, const Double_t *params);
 #endif
 
-   ClassDef(TF1, 11) // The Parametric 1-D function
+   ClassDef(TF1, 12) // The Parametric 1-D function
 };
 
 namespace ROOT {

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3588,8 +3588,6 @@ void TF1::Streamer(TBuffer &b)
             R__LOCKGUARD(gROOTMutex);
             gROOT->GetListOfFunctions()->Add(this);
          }
-         if (v >= 10 && v < 11)
-            fComposition = std::unique_ptr<TF1AbsComposition>(fComposition_ptr);
          return;
       } else {
          ROOT::v5::TF1Data fold;

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -406,9 +406,9 @@ void stress3()
    Float_t comp = f.GetCompressionFactor();
    Bool_t OK = kTRUE;
 #ifdef R__HAS_CLOUDFLARE_ZLIB
-   constexpr Long64_t lastgood = 52027;
+   constexpr Long64_t lastgood = 52290;
 #else
-   constexpr Long64_t lastgood = 51886;
+   constexpr Long64_t lastgood = 52116;
 #endif
    constexpr Long64_t tolerance = 150;
 #ifdef R__HAS_DEFAULT_LZ4


### PR DESCRIPTION
a. Fix the test/stress failure when using the built-in zlib
b. disable new test that uses RDataFrame when it is not available.

Tweak TF1 backward compatibility mechanism (switch from using stale data member to using an I/O rule). 