### PR TITLE
Buffer merger improve

### DIFF
--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -87,16 +87,22 @@ public:
       kSingleKey     = BIT(0),        ///< write collection with single key
       kOverwrite     = BIT(1),        ///< overwrite existing object with same name
       kWriteDelete   = BIT(2),        ///< write object, then delete previous key with same name
+   };
 
-      ///< Used to request that the class specific implementation of `TObject::Write` 
+protected:
+   enum DeprectatedWriteOpions {
+      ///< Used to request that the class specific implementation of `TObject::Write`
       ///< just prepare the objects to be ready to be written but do not actually write
       ///< them into the TBuffer. This is just for example by TBufferMerger to request
       ///< that the TTree inside the file calls `TTree::FlushBaskets` (outside of the merging lock)
       ///< and TBufferMerger will later ask for the write (inside the merging lock).
       ///< To take advantage of this feature the class needs to overload `TObject::Write`
       ///< and use this enum value accordingly.  (See `TTree::Write` and `TObject::Write`)
-      kOnlyPrepStep  = BIT(3)         
+      ///< Do not use, this feature will be migrate to the Merge function (See TClass and TTree::Merge)
+      kOnlyPrepStep  = BIT(3)
    };
+
+public:
 
    TObject();
    TObject(const TObject &object);

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -86,7 +86,16 @@ public:
    enum {
       kSingleKey     = BIT(0),        ///< write collection with single key
       kOverwrite     = BIT(1),        ///< overwrite existing object with same name
-      kWriteDelete   = BIT(2)         ///< write object, then delete previous key with same name
+      kWriteDelete   = BIT(2),        ///< write object, then delete previous key with same name
+
+      ///< Used to request that the class specific implementation of `TObject::Write` 
+      ///< just prepare the objects to be ready to be written but do not actually write
+      ///< them into the TBuffer. This is just for example by TBufferMerger to request
+      ///< that the TTree inside the file calls `TTree::FlushBaskets` (outside of the merging lock)
+      ///< and TBufferMerger will later ask for the write (inside the merging lock).
+      ///< To take advantage of this feature the class needs to overload `TObject::Write`
+      ///< and use this enum value accordingly.  (See `TTree::Write` and `TObject::Write`)
+      kOnlyPrepStep  = BIT(3)         
    };
 
    TObject();

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1058,7 +1058,10 @@ TColor::TColor(Float_t r, Float_t g, Float_t b, Float_t a): TNamed("","")
 TColor::~TColor()
 {
    gROOT->GetListOfColors()->Remove(this);
-   if (gROOT->GetListOfColors()->GetEntries() == 0) {fgPalette.Set(0); fgPalette=0;}
+   if (gROOT->GetListOfColors()->IsEmpty()) {
+      fgPalette.Set(0);
+      fgPalette=0;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -773,6 +773,9 @@ void TObject::UseCurrentStyle()
 
 Int_t TObject::Write(const char *name, Int_t option, Int_t bufsize) const
 {
+   if (R__unlikely(option & kOnlyPrepStep))
+      return 0;
+
    TString opt = "";
    if (option & kSingleKey)   opt += "SingleKey";
    if (option & kOverwrite)   opt += "OverWrite";

--- a/core/base/src/TUrl.cxx
+++ b/core/base/src/TUrl.cxx
@@ -631,14 +631,14 @@ void TUrl::ParseOptions() const
       return;
 
    TObjArray *objOptions = urloptions.Tokenize("&");
-   for (Int_t n = 0; n < objOptions->GetEntries(); n++) {
+   for (Int_t n = 0; n < objOptions->GetEntriesFast(); n++) {
       TString loption = ((TObjString *) objOptions->At(n))->GetName();
       TObjArray *objTags = loption.Tokenize("=");
       if (!fOptionsMap) {
          fOptionsMap = new TMap;
          fOptionsMap->SetOwnerKeyValue();
       }
-      if (objTags->GetEntries() == 2) {
+      if (objTags->GetEntriesFast() == 2) {
          TString key = ((TObjString *) objTags->At(0))->GetName();
          TString value = ((TObjString *) objTags->At(1))->GetName();
          fOptionsMap->Add(new TObjString(key), new TObjString(value));

--- a/core/meta/inc/TIsAProxy.h
+++ b/core/meta/inc/TIsAProxy.h
@@ -28,14 +28,22 @@ class TIsAProxy  : public TVirtualIsAProxy {
 private:
    template <typename T> using Atomic_t = std::atomic<T>;
 
+   // On testing with the data from the 250202_181_RECO.root and doing "just" serializing
+   // the value 8 was the sweet spot of performance.  With more slots, too much time is
+   // spent scanning the array of "last" seen and with less slots then the
+   // serialization induced by and/or the cost of executed `++fSubTypesReaders is slow
+   // down (noticeably) the streaming of branches with polymorphic containers.
+   static constexpr UInt_t fgMaxLastSlot = 8;
+
    const std::type_info     *fType;        //Actual typeid of the proxy
    Atomic_t<TClass*>         fClass;       //Actual TClass
-   Atomic_t<void*>           fLast;        //points into fSubTypes map for last used values
    Char_t                    fSubTypes[72];//map of known sub-types
    mutable Atomic_t<UInt_t>  fSubTypesReaders; //number of readers of fSubTypes
    Atomic_t<Bool_t>          fSubTypesWriteLockTaken; //True if there is a writer
    Bool_t                    fVirtual;     //Flag if class is virtual
    Atomic_t<Bool_t>          fInit;        //Initialization flag
+   Atomic_t<void*>           fLasts[fgMaxLastSlot]; // points into fSubTypes map for last used values
+   Atomic_t<UChar_t>         fNextLastSlot;// Next slot in fLasts to use for update (ring buffer)
 
    void* FindSubType(const std::type_info*) const;
    void* CacheSubType(const std::type_info*, TClass*);

--- a/core/meta/inc/TIsAProxy.h
+++ b/core/meta/inc/TIsAProxy.h
@@ -37,13 +37,13 @@ private:
 
    const std::type_info     *fType;        //Actual typeid of the proxy
    TClass                   *fClass;       //Actual TClass
-   Char_t                    fSubTypes[72];//map of known sub-types
-   mutable Atomic_t<UInt_t>  fSubTypesReaders; //number of readers of fSubTypes
+   Atomic_t<void*>           fLasts[fgMaxLastSlot];   // points into fSubTypes map for last used values
+   Char_t                    fSubTypes[72];           //map of known sub-types
+   mutable Atomic_t<UInt_t>  fSubTypesReaders;        //number of readers of fSubTypes
    Atomic_t<Bool_t>          fSubTypesWriteLockTaken; //True if there is a writer
-   Bool_t                    fVirtual;     //Flag if class is virtual
-   Atomic_t<Bool_t>          fInit;        //Initialization flag
-   Atomic_t<void*>           fLasts[fgMaxLastSlot]; // points into fSubTypes map for last used values
-   Atomic_t<UChar_t>         fNextLastSlot;// Next slot in fLasts to use for update (ring buffer)
+   Atomic_t<UChar_t>         fNextLastSlot; // Next slot in fLasts to use for update (ring buffer)
+   Atomic_t<Bool_t>          fInit;         //Initialization flag
+   Bool_t                    fVirtual;      //Flag if class is virtual
 
    void* FindSubType(const std::type_info*) const;
    void* CacheSubType(const std::type_info*, TClass*);

--- a/core/meta/inc/TIsAProxy.h
+++ b/core/meta/inc/TIsAProxy.h
@@ -36,7 +36,7 @@ private:
    static constexpr UInt_t fgMaxLastSlot = 8;
 
    const std::type_info     *fType;        //Actual typeid of the proxy
-   Atomic_t<TClass*>         fClass;       //Actual TClass
+   TClass                   *fClass;       //Actual TClass
    Char_t                    fSubTypes[72];//map of known sub-types
    mutable Atomic_t<UInt_t>  fSubTypesReaders; //number of readers of fSubTypes
    Atomic_t<Bool_t>          fSubTypesWriteLockTaken; //True if there is a writer

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6295,7 +6295,7 @@ void TClass::SetUnloaded()
       (*fEnums).Unload();
    }
 
-   if (fState <= kForwardDeclared && fStreamerInfo->GetEntries() != 0) {
+   if (fState <= kForwardDeclared && !fStreamerInfo->IsEmpty()) {
       fState = kEmulated;
    }
 

--- a/core/meta/src/TIsAProxy.cxx
+++ b/core/meta/src/TIsAProxy.cxx
@@ -118,10 +118,13 @@ TClass* TIsAProxy::operator()(const void *obj)
 
    // Check if type is already in sub-class cache
    auto last = ToPair(FindSubType(typ));
-   if ( last == nullptr || last->second == nullptr )  {
+   if ( last == nullptr )  {
       // Last resort: lookup root class
       auto cls = TClass::GetClass(*typ);
-      last = ToPair(CacheSubType(typ,cls));
+      if (cls)
+         last = ToPair(CacheSubType(typ,cls));
+      else
+         return nullptr; // Don't record failed searches (a library might be loaded between now and the next search).
    }
 
    UChar_t next = fNextLastSlot++;
@@ -132,7 +135,7 @@ TClass* TIsAProxy::operator()(const void *obj)
    }
    fLasts[next].store(last);
 
-   return last == nullptr ? nullptr: last->second;
+   return last == nullptr ? nullptr : last->second;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TIsAProxy.cxx
+++ b/core/meta/src/TIsAProxy.cxx
@@ -48,7 +48,7 @@ namespace {
 TIsAProxy::TIsAProxy(const std::type_info& typ)
    : fType(&typ), fClass(nullptr),
      fSubTypesReaders(0), fSubTypesWriteLockTaken(kFALSE),
-     fVirtual(kFALSE), fInit(kFALSE)
+     fInit(kFALSE), fVirtual(kFALSE)
 {
    static_assert(sizeof(ClassMap_t)<=sizeof(fSubTypes), "ClassMap size is to large for array");
 

--- a/core/meta/src/TIsAProxy.cxx
+++ b/core/meta/src/TIsAProxy.cxx
@@ -39,19 +39,22 @@ namespace {
    {
       return (ClassMap_t::value_type*)p;
    }
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Standard initializing constructor
 
 TIsAProxy::TIsAProxy(const std::type_info& typ)
-   : fType(&typ), fClass(nullptr), fLast(nullptr),
+   : fType(&typ), fClass(nullptr),
      fSubTypesReaders(0), fSubTypesWriteLockTaken(kFALSE),
      fVirtual(kFALSE), fInit(kFALSE)
 {
    static_assert(sizeof(ClassMap_t)<=sizeof(fSubTypes), "ClassMap size is to large for array");
 
    ::new(fSubTypes) ClassMap_t();
+   for(auto& slot : fLasts)
+      slot = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -72,7 +75,8 @@ void TIsAProxy::SetClass(TClass *cl)
 {
    GetMap(fSubTypes)->clear();
    fClass = cl;
-   fLast = nullptr;
+   for(auto& slot : fLasts)
+      slot = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -106,20 +110,30 @@ TClass* TIsAProxy::operator()(const void *obj)
    if ( typ == fType )  {
      return fClass.load();
    }
-   auto last = ToPair(fLast.load());
-   if ( last && typ == last->first )  {
-      return last->second;
+   for(auto& slot : fLasts) {
+      auto last = ToPair(slot);
+      if ( last && typ == last->first )  {
+         return last->second;
+      }
    }
+
    // Check if type is already in sub-class cache
-   last = ToPair(FindSubType(typ));
+   auto last = ToPair(FindSubType(typ));
    if ( last == nullptr || last->second == nullptr )  {
       // Last resort: lookup root class
       auto cls = TClass::GetClass(*typ);
       last = ToPair(CacheSubType(typ,cls));
    }
-   fLast.store(last);
 
-   return last == nullptr? nullptr: last->second;
+   UChar_t next = fNextLastSlot++;
+   if (next >= fgMaxLastSlot) {
+      UChar_t expected_value = next + 1;
+      next = next % fgMaxLastSlot;
+      fNextLastSlot.compare_exchange_strong(expected_value, next + 1);
+   }
+   fLasts[next].store(last);
+
+   return last == nullptr ? nullptr: last->second;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TIsAProxy.cxx
+++ b/core/meta/src/TIsAProxy.cxx
@@ -135,7 +135,7 @@ TClass* TIsAProxy::operator()(const void *obj)
    }
    fLasts[next].store(last);
 
-   return last == nullptr ? nullptr : last->second;
+   return last ? last->second : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TSchemaRuleSet.cxx
+++ b/core/meta/src/TSchemaRuleSet.cxx
@@ -113,7 +113,7 @@ Bool_t TSchemaRuleSet::AddRule( TSchemaRule* rule, EConsistencyCheck checkConsis
    bool streamerInfosTest;
    {
      R__LOCKGUARD(gInterpreterMutex);
-     streamerInfosTest = (fClass->GetStreamerInfos()==0 || fClass->GetStreamerInfos()->GetEntries()==0);
+     streamerInfosTest = (fClass->GetStreamerInfos()==0 || fClass->GetStreamerInfos()->IsEmpty());
    }
    if( rule->GetTarget()  && !(fClass->TestBit(TClass::kIsEmulation) && streamerInfosTest) ) {
       TObjArrayIter titer( rule->GetTarget() );
@@ -495,7 +495,7 @@ Bool_t TSchemaRuleSet::TMatches::HasRuleWithSource( const TString& name, Bool_t 
       if( rule->HasSource( name ) ) {
          if (needingAlloc) {
             const TObjArray *targets = rule->GetTarget();
-            if (targets && (targets->GetEntries() > 1 || targets->GetEntries()==0) ) {
+            if (targets && (targets->GetEntriesFast() > 1 || targets->IsEmpty()) ) {
                return kTRUE;
             }
             if (targets && name != targets->UncheckedAt(0)->GetName() ) {
@@ -525,11 +525,11 @@ Bool_t TSchemaRuleSet::TMatches::HasRuleWithTarget( const TString& name, Bool_t 
       if( rule->HasTarget( name ) ) {
          if (willset) {
             const TObjArray *targets = rule->GetTarget();
-            if (targets && (targets->GetEntries() > 1 || targets->GetEntries()==0) ) {
+            if (targets && (targets->GetEntriesFast() > 1 || targets->IsEmpty()) ) {
                return kTRUE;
             }
             const TObjArray *sources = rule->GetSource();
-            if (sources && (sources->GetEntries() > 1 || sources->GetEntries()==0) ) {
+            if (sources && (sources->GetEntriesFast() > 1 || sources->IsEmpty()) ) {
                return kTRUE;
             }
             if (sources && name != sources->UncheckedAt(0)->GetName() ) {

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6291,7 +6291,7 @@ UInt_t TCling::AutoParseImplRecurse(const char *cls, bool topLevel)
          clang::DeclContext* previousScopeAsContext = fInterpreter->getCI()->getASTContext().getTranslationUnitDecl();
          if (TClassEdit::IsStdClass(cls + offset))
             previousScopeAsContext = fInterpreter->getSema().getStdNamespace();
-         auto nTokens = tokens->GetEntries();
+         auto nTokens = tokens->GetEntriesFast();
          for (Int_t tk = 0; tk < nTokens; ++tk) {
             auto scopeObj = tokens->UncheckedAt(tk);
             auto scopeName = ((TObjString*) scopeObj)->String().Data();

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -135,6 +135,7 @@ void TClingClassInfo::AddBaseOffsetValue(const clang::Decl* decl, ptrdiff_t offs
    // determined by the parameter decl.
 
    OffsetPtrFunc_t executableFunc = 0;
+   std::unique_lock<std::mutex> lock(fOffsetCacheMutex);
    fOffsetCache[decl] = std::make_pair(offset, executableFunc);
 }
 
@@ -611,7 +612,7 @@ ptrdiff_t TClingClassInfo::GetBaseOffset(TClingClassInfo* base, void* address, b
 {
 
    {
-      R__READ_LOCKGUARD(ROOT::gCoreMutex);
+      std::unique_lock<std::mutex> lock(fOffsetCacheMutex);
 
       // Check for the offset in the cache.
       auto iter = fOffsetCache.find(base->GetDecl());

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -34,6 +34,7 @@
 #include <vector>
 #include <string>
 #include <utility>
+#include <mutex>
 
 #include "llvm/ADT/DenseMap.h"
 
@@ -69,6 +70,8 @@ private:
    std::vector<clang::DeclContext::decl_iterator> fIterStack; // Recursion stack for traversing nested scopes.
    std::string           fTitle; // The meta info for the class.
    std::string           fDeclFileName; // Name of the file where the underlying entity is declared.
+
+   std::mutex fOffsetCacheMutex;
    llvm::DenseMap<const clang::Decl*, std::pair<ptrdiff_t, OffsetPtrFunc_t> > fOffsetCache; // Functions already generated for offsets.
 
    explicit TClingClassInfo() = delete;
@@ -82,11 +85,21 @@ public: // Types
 
 public:
 
+   TClingClassInfo(const TClingClassInfo &rhs) : // Copy all but the mutex
+      TClingDeclInfo(rhs),
+      fInterp(rhs.fInterp), fFirstTime(rhs.fFirstTime), fDescend(rhs.fDescend),
+      fIterAll(rhs.fIterAll), fIsIter(rhs.fIsIter), fIter(rhs.fIter),
+      fType(rhs.fType), fIterStack(rhs.fIterStack), fTitle(rhs.fTitle),
+      fDeclFileName(rhs.fDeclFileName), fOffsetCache(rhs.fOffsetCache)
+   {}
    explicit TClingClassInfo(cling::Interpreter *, Bool_t all = kTRUE);
    explicit TClingClassInfo(cling::Interpreter *, const char *classname, bool intantiateTemplate = kTRUE);
    explicit TClingClassInfo(cling::Interpreter *, const clang::Type &);
    explicit TClingClassInfo(cling::Interpreter *, const clang::Decl *);
-   void                 AddBaseOffsetFunction(const clang::Decl* decl, OffsetPtrFunc_t func) { fOffsetCache[decl] = std::make_pair(0L, func); }
+   void                 AddBaseOffsetFunction(const clang::Decl* decl, OffsetPtrFunc_t func) {
+      std::unique_lock<std::mutex> lock(fOffsetCacheMutex);
+      fOffsetCache[decl] = std::make_pair(0L, func);
+   }
    void                 AddBaseOffsetValue(const clang::Decl* decl, ptrdiff_t offset);
    long                 ClassProperty() const;
    void                 Delete(void *arena, const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -99,7 +99,7 @@ public:
     */
    void SetMergeOptions(const TString& options);
 
-   /** Indicates that the file will not contain any TTree objects
+   /** Indicates that any TTree objects in the file should be skipped
     * and thus that steps that are specific to TTree can be skipped */
    void SetNotrees(Bool_t notrees=kFALSE)
    {

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -71,7 +71,10 @@ public:
    size_t GetQueueSize() const;
 
    /** Returns the number of bytes currently buffered (i.e. in the queue). */
-   size_t GetBuffered() const;
+   size_t GetBuffered() const
+   {
+      return fBuffered;
+   }
 
    /** Returns the current value of the auto save setting in bytes (default = 0). */
    size_t GetAutoSave() const;

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -110,6 +110,30 @@ public:
       return fMerger.GetNotrees();
    }
 
+   /** Indicates that the temporary keys (corresponding to the object held by the directories
+    *  of the TMemFile) should be compressed or not.   Those object are stored in the TMemFile
+    * (and thus possibly compressed) when a thread push its data forward (by calling
+    * TBufferMergerFile::Write) and the queue is being processed by another.
+    * Once the TMemFile is picked (by any thread to be merged), *after* taking the
+    * TBufferMerger::fMergeMutex, those object are read back (and thus possibly uncompressed)
+    * and then used by merging.
+    * In order word, the compression of those objects/keys is only usefull to reduce the size
+    * in memory (of the TMemFile) and does not affect (at all) the compression factor of the end
+    * result.
+    */
+   void SetCompressTemporaryKeys(Bool_t request_compression = true)
+   {
+      fCompressTemporaryKeys = request_compression;
+   }
+
+   /** Returns whether to compressed the TKey in the TMemFile for the object held by
+    * the TDirectories.  See TBufferMerger::SetCompressTemporaryKeys for more details.
+    */
+   Bool_t GetCompressTemporaryKeys() const
+   {
+      return fCompressTemporaryKeys;
+   }
+
    friend class TBufferMergerFile;
 
 private:
@@ -130,6 +154,7 @@ private:
    void Push(TBufferFile *buffer);
    bool TryMerge(TBufferMergerFile *memfile);
 
+   bool fCompressTemporaryKeys{false};                           //< Enable compression of the TKeys in the TMemFile (save memory at the expense of time, end result is unchanged)
    size_t fAutoSave{0};                                          //< AutoSave only every fAutoSave bytes
    std::atomic<size_t> fBuffered{0};                             //< Number of bytes currently buffered
    TFileMerger fMerger{false, false};                            //< TFileMerger used to merge all buffers

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -96,6 +96,20 @@ public:
     */
    void SetMergeOptions(const TString& options);
 
+   /** Indicates that the file will not contain any TTree objects
+    * and thus that steps that are specific to TTree can be skipped */
+   void SetNotrees(Bool_t notrees=kFALSE)
+   {
+      fMerger.SetNotrees(notrees);
+   }
+
+   /** Returns whether the the file has been marked as not containing any TTree objects
+    * and thus that steps that are specific to TTree can be skipped */
+   Bool_t GetNotrees() const
+   {
+      return fMerger.GetNotrees();
+   }
+
    friend class TBufferMergerFile;
 
 private:

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -114,7 +114,7 @@ private:
    size_t fBuffered{0};                                          //< Number of bytes currently buffered
    TFileMerger fMerger{false, false};                            //< TFileMerger used to merge all buffers
    std::mutex fMergeMutex;                                       //< Mutex used to lock fMerger
-   std::mutex fQueueMutex;                                       //< Mutex used to lock fQueue
+   mutable std::mutex fQueueMutex;                               //< Mutex used to lock fQueue
    std::queue<TBufferFile *> fQueue;                             //< Queue to which data is pushed and merged
    std::vector<std::weak_ptr<TBufferMergerFile>> fAttachedFiles; //< Attached files
 };

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -70,6 +70,9 @@ public:
    /** Returns the number of buffers currently in the queue. */
    size_t GetQueueSize() const;
 
+   /** Returns the number of bytes currently buffered (i.e. in the queue). */
+   size_t GetBuffered() const;
+
    /** Returns the current value of the auto save setting in bytes (default = 0). */
    size_t GetAutoSave() const;
 

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -117,7 +117,7 @@ private:
    bool TryMerge(TBufferMergerFile *memfile);
 
    size_t fAutoSave{0};                                          //< AutoSave only every fAutoSave bytes
-   size_t fBuffered{0};                                          //< Number of bytes currently buffered
+   std::atomic<size_t> fBuffered{0};                             //< Number of bytes currently buffered
    TFileMerger fMerger{false, false};                            //< TFileMerger used to merge all buffers
    std::mutex fMergeMutex;                                       //< Mutex used to lock fMerger
    mutable std::mutex fQueueMutex;                               //< Mutex used to lock fQueue

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -110,8 +110,11 @@ private:
 
    void Init(std::unique_ptr<TFile>);
 
+   void MergeImpl();
+
    void Merge();
    void Push(TBufferFile *buffer);
+   bool TryMerge(TBufferMergerFile *memfile);
 
    size_t fAutoSave{0};                                          //< AutoSave only every fAutoSave bytes
    size_t fBuffered{0};                                          //< Number of bytes currently buffered

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -64,13 +64,14 @@ public:
       kIncremental  = BIT(1),        ///< Merge the input file with the content of the output file (if already exising).
       kResetable    = BIT(2),        ///< Only the objects with a MergeAfterReset member function.
       kNonResetable = BIT(3),        ///< Only the objects without a MergeAfterReset member function.
+      kDelayWrite   = BIT(4),        ///< Delay the TFile write (to reduce the number of write when reusing the file)
 
       kAll            = BIT(2)|BIT(3),      ///< Merge all type of objects (default)
       kAllIncremental = kIncremental | kAll, ///< Merge incrementally all type of objects.
 
-      kOnlyListed     = BIT(4),        ///< Only the objects specified in fObjectNames list
-      kSkipListed     = BIT(5),        ///< Skip objects specified in fObjectNames list
-      kKeepCompression= BIT(6)         ///< Keep compression level unchanged for each input files
+      kOnlyListed     = BIT(5),        ///< Only the objects specified in fObjectNames list
+      kSkipListed     = BIT(6),        ///< Skip objects specified in fObjectNames list
+      kKeepCompression= BIT(7)         ///< Keep compression level unchanged for each input files
    };
 
    TFileMerger(Bool_t isLocal = kTRUE, Bool_t histoOneGo = kTRUE);

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -120,6 +120,7 @@ public:
    virtual Bool_t Merge(Bool_t = kTRUE);
    virtual Bool_t PartialMerge(Int_t type = kAll | kIncremental);
    virtual void   SetFastMethod(Bool_t fast=kTRUE)  {fFastMethod = fast;}
+           Bool_t GetNotrees() const { return fNoTrees; }
    virtual void   SetNotrees(Bool_t notrees=kFALSE) {fNoTrees = notrees;}
    virtual void        RecursiveRemove(TObject *obj);
 

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -20,6 +20,8 @@
 
 class TFile;
 class TDirectory;
+class THashList;
+class TKey;
 
 namespace ROOT {
 class TIOFeatures;
@@ -57,6 +59,11 @@ protected:
    virtual Bool_t AddFile(TFile *source, Bool_t own, Bool_t cpProgress);
    virtual Bool_t MergeRecursive(TDirectory *target, TList *sourcelist, Int_t type = kRegular | kAll);
 
+   virtual Bool_t MergeOne(TDirectory *target, TList *sourcelist, Int_t type,
+                TFileMergeInfo &info, TString &oldkeyname, THashList &allNames, Bool_t &status, Bool_t &onlyListed,
+                const TString &path,
+                TDirectory *current_sourcedir, TFile *current_file,
+                TKey *key, TObject *obj);
 public:
    /// Type of the partial merge
    enum EPartialMergeType {

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -217,7 +217,7 @@ public:
    TStreamerInfoActions::TActionSequence *GetWriteObjectWiseActions() { return fWriteObjectWise; }
    TStreamerInfoActions::TActionSequence *GetWriteTextActions() { return fWriteText; }
    Int_t               GetNdata()   const {return fNdata;}
-   Int_t               GetNelement() const { return fElements->GetEntries(); }
+   Int_t               GetNelement() const { return fElements->GetEntriesFast(); }
    Int_t               GetNumber()  const {return fNumber;}
    Int_t               GetLength(Int_t id) const {return fComp[id].fLength;}
    ULong_t             GetMethod(Int_t id) const {return fComp[id].fMethod;}

--- a/io/io/src/TArchiveFile.cxx
+++ b/io/io/src/TArchiveFile.cxx
@@ -159,7 +159,7 @@ Bool_t TArchiveFile::ParseUrl(const char *url, TString &archive, TString &member
    // FIXME: hard coded for "zip" archive format
    TString urloptions = u.GetOptions();
    TObjArray *objOptions = urloptions.Tokenize("&");
-   for (Int_t n = 0; n < objOptions->GetEntries(); n++) {
+   for (Int_t n = 0; n < objOptions->GetEntriesFast(); n++) {
 
       TString loption = ((TObjString*)objOptions->At(n))->GetName();
       TObjArray *objTags = loption.Tokenize("=");

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -66,6 +66,12 @@ size_t TBufferMerger::GetQueueSize() const
    return fQueue.size();
 }
 
+size_t TBufferMerger::GetBuffered() const
+{
+   std::lock_guard<std::mutex> lock(fQueueMutex);
+   return fBuffered;
+}
+
 void TBufferMerger::Push(TBufferFile *buffer)
 {
    {

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -49,6 +49,10 @@ TBufferMerger::~TBufferMerger()
 
    if (!fQueue.empty())
       Merge();
+
+   TFile *out = fMerger.GetOutputFile();
+   if (out)
+      out->Write("",TObject::kOverwrite);
 }
 
 std::shared_ptr<TBufferMergerFile> TBufferMerger::GetFile()
@@ -121,7 +125,7 @@ void TBufferMerger::Merge()
          queue.pop();
       }
 
-      fMerger.PartialMerge();
+      fMerger.PartialMerge(TFileMerger::kAll | TFileMerger::kIncremental | TFileMerger::kDelayWrite);
       fMerger.Reset();
       fMergeMutex.unlock();
    }

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -50,8 +50,7 @@ TBufferMerger::~TBufferMerger()
    if (!fQueue.empty())
       Merge();
 
-   TFile *out = fMerger.GetOutputFile();
-   if (out)
+   if (TFile *out = fMerger.GetOutputFile())
       out->Write("",TObject::kOverwrite);
 }
 
@@ -132,18 +131,14 @@ void TBufferMerger::MergeImpl()
 
 bool TBufferMerger::TryMerge(ROOT::Experimental::TBufferMergerFile *memfile)
 {
-   if (fMergeMutex.try_lock())
-   {
+   if (fMergeMutex.try_lock()) {
       memfile->WriteStreamerInfo();
       fMerger.AddFile(memfile);
       MergeImpl();
       fMergeMutex.unlock();
       return true;
    } else
-   {
       return false;
-   }
-
 }
 
 } // namespace Experimental

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -70,11 +70,6 @@ size_t TBufferMerger::GetQueueSize() const
    return fQueue.size();
 }
 
-size_t TBufferMerger::GetBuffered() const
-{
-   return fBuffered;
-}
-
 void TBufferMerger::Push(TBufferFile *buffer)
 {
    {

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -131,7 +131,7 @@ void TBufferMerger::MergeImpl()
       queue.pop();
    }
 
-   fMerger.PartialMerge(TFileMerger::kAll | TFileMerger::kIncremental | TFileMerger::kDelayWrite);
+   fMerger.PartialMerge(TFileMerger::kAll | TFileMerger::kIncremental | TFileMerger::kDelayWrite | TFileMerger::kKeepCompression);
    fMerger.Reset();
 }
 

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -50,6 +50,9 @@ TBufferMerger::~TBufferMerger()
    if (!fQueue.empty())
       Merge();
 
+   // Since we support purely incremental merging, Merge does not write the target objects
+   // that are attached to the file (TTree and histograms) and thus we need to write them
+   // now.
    if (TFile *out = fMerger.GetOutputFile())
       out->Write("",TObject::kOverwrite);
 }

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -72,7 +72,6 @@ size_t TBufferMerger::GetQueueSize() const
 
 size_t TBufferMerger::GetBuffered() const
 {
-   std::lock_guard<std::mutex> lock(fQueueMutex);
    return fBuffered;
 }
 

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -62,6 +62,7 @@ std::shared_ptr<TBufferMergerFile> TBufferMerger::GetFile()
 
 size_t TBufferMerger::GetQueueSize() const
 {
+   std::lock_guard<std::mutex> lock(fQueueMutex);
    return fQueue.size();
 }
 

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -29,6 +29,10 @@ TBufferMergerFile::~TBufferMergerFile()
 
 Int_t TBufferMergerFile::Write(const char *name, Int_t opt, Int_t bufsize)
 {
+   // Make sure the compression of the basket is done in the unlocked thread and
+   // not in the locked section.
+   TMemFile::Write(name, opt | TObject::kOnlyPrepStep, bufsize);
+
    // Instead of Writing the TTree, doing a memcpy, Pushing to the queue
    // then Reading and then deleting, let's see if we can just merge using
    // the live TTree.

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -42,7 +42,11 @@ Int_t TBufferMergerFile::Write(const char *name, Int_t opt, Int_t bufsize)
       return 0;
    }
 
+   auto oldCompLevel = GetCompressionLevel();
+   if (!fMerger.GetCompressTemporaryKeys())
+      SetCompressionLevel(0);
    Int_t nbytes = TMemFile::Write(name, opt, bufsize);
+   SetCompressionLevel(oldCompLevel);
 
    if (nbytes) {
       TBufferFile *buffer = new TBufferFile(TBuffer::kWrite, GetSize());

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -29,6 +29,14 @@ TBufferMergerFile::~TBufferMergerFile()
 
 Int_t TBufferMergerFile::Write(const char *name, Int_t opt, Int_t bufsize)
 {
+   // Instead of Writing the TTree, doing a memcpy, Pushing to the queue
+   // then Reading and then deleting, let's see if we can just merge using
+   // the live TTree.
+   if (fMerger.TryMerge(this)) {
+      ResetAfterMerge(0);
+      return 0;
+   }
+
    Int_t nbytes = TMemFile::Write(name, opt, bufsize);
 
    if (nbytes) {

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -31,7 +31,8 @@ Int_t TBufferMergerFile::Write(const char *name, Int_t opt, Int_t bufsize)
 {
    // Make sure the compression of the basket is done in the unlocked thread and
    // not in the locked section.
-   TMemFile::Write(name, opt | TObject::kOnlyPrepStep, bufsize);
+   if (!fMerger.GetNotrees())
+      TMemFile::Write(name, opt | TObject::kOnlyPrepStep, bufsize);
 
    // Instead of Writing the TTree, doing a memcpy, Pushing to the queue
    // then Reading and then deleting, let's see if we can just merge using

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1796,7 +1796,8 @@ Int_t TDirectoryFile::Write(const char *, Int_t opt, Int_t bufsize)
    while ((obj=next())) {
       nbytes += obj->Write(0,opt,bufsize);
    }
-   SaveSelf(kTRUE);   // force save itself
+   if (R__likely(!(opt & kOnlyPrepStep)))
+      SaveSelf(kTRUE);   // force save itself
 
    return nbytes;
 }

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -473,7 +473,8 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
       if (!obj && key) {
          obj = key->ReadObj();
          ownobj = kTRUE;
-      } else if (obj && info.fIsFirst && current_sourcedir != target) {
+      } else if (obj && info.fIsFirst && current_sourcedir != target
+                 && !cl->InheritsFrom( TDirectory::Class() )) {
          R__ASSERT(cl->IsTObject());
          TDirectory::TContext ctxt(current_sourcedir);
          obj = obj->Clone();
@@ -708,7 +709,7 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
       // and we are in incremental mode (because it will be reused
       // and has not been written to disk (for performance reason).
       // coverity[var_deref_model] the IsA()->InheritsFrom guarantees that the dynamic_cast will succeed.
-      if (!(type & kIncremental) || dirobj->GetFile() != target) {
+      if (ownobj && (!(type & kIncremental) || dirobj->GetFile() != target)) {
          dirobj->ResetBit(kMustCleanup);
          delete dirobj;
       }

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -388,6 +388,373 @@ Long64_t MergeRNTuples(TClass* rntupleHandle, const TString& /* target */, const
 
 } // anonymous namespace
 
+Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, TFileMergeInfo &info,
+                             TString &oldkeyname, THashList &allNames, Bool_t &status, Bool_t &onlyListed,
+                             const TString &path, TDirectory *current_sourcedir, TFile *current_file, TKey *key,
+                             TObject *obj)
+{
+   const char *keyname = obj ? obj->GetName() : key->GetName();
+   const char *keyclassname = obj ? obj->IsA()->GetName() : key->GetClassName();
+   const char *keytitle = obj ? obj->GetTitle() : key->GetTitle();
+
+   // Keep only the highest cycle number for each key for mergeable objects. They are stored
+   // in the (hash) list consecutively and in decreasing order of cycles, so we can continue
+   // until the name changes. We flag the case here and we act consequently later.
+   Bool_t alreadyseen = (oldkeyname == keyname) ? kTRUE : kFALSE;
+   Bool_t ownobj = kFALSE;
+
+   // Read in but do not copy directly the processIds.
+   if (strcmp(keyclassname, "TProcessID") == 0 && key) {
+      key->ReadObj();
+      return kTRUE;
+   }
+
+   // If we have already seen this object [name], we already processed
+   // the whole list of files for this objects and we can just skip it
+   // and any related cycles.
+   if (allNames.FindObject(keyname)) {
+      oldkeyname = keyname;
+      return kTRUE;
+   }
+
+   TClass *cl = TClass::GetClass(keyclassname);
+   if (!cl) {
+      Info("MergeRecursive", "cannot indentify object type (%s), name: %s title: %s",
+            keyclassname, keyname, keytitle);
+      return kTRUE;
+   }
+   // For mergeable objects we add the names in a local hashlist handling them
+   // again (see above)
+   if (cl->GetMerge() || cl->InheritsFrom(TDirectory::Class()) ||
+      (cl->IsTObject() && !cl->IsLoaded() &&
+         /* If it has a dictionary and GetMerge() is nullptr then we already know the answer
+            to the next question is 'no, if we were to ask we would useless trigger
+            auto-parsing */
+         (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*") ||
+         cl->GetMethodWithPrototype("Merge", "TCollection*"))))
+      allNames.Add(new TObjString(keyname));
+
+   if (fNoTrees && cl->InheritsFrom(R__TTree_Class)) {
+      // Skip the TTree objects and any related cycles.
+      oldkeyname = keyname;
+      return kTRUE;
+   }
+   // Check if only the listed objects are to be merged
+   if (type & kOnlyListed) {
+      onlyListed = kFALSE;
+      oldkeyname = keyname;
+      oldkeyname += " ";
+      onlyListed = fObjectNames.Contains(oldkeyname);
+      oldkeyname = keyname;
+      if ((!onlyListed) && (!cl->InheritsFrom(TDirectory::Class()))) return kTRUE;
+   }
+
+   if (!(type&kResetable && type&kNonResetable)) {
+      // If neither or both are requested at the same time, we merger both types.
+      if (!(type&kResetable)) {
+         if (cl->GetResetAfterMerge()) {
+            // Skip the object with a reset after merge routine (TTree and other incrementally mergeable objects)
+            oldkeyname = keyname;
+            return kTRUE;
+         }
+      }
+      if (!(type&kNonResetable)) {
+         if (!cl->GetResetAfterMerge()) {
+            // Skip the object without a reset after merge routine (Histograms and other non incrementally mergeable objects)
+            oldkeyname = keyname;
+            return kTRUE;
+         }
+      }
+   }
+   // read object from first source file
+   if (type & kIncremental) {
+      if (!obj)
+         obj = current_sourcedir->GetList()->FindObject(keyname);
+      if (!obj && key) {
+         obj = key->ReadObj();
+         ownobj = kTRUE;
+      } else if (obj && info.fIsFirst && current_sourcedir != target) {
+         R__ASSERT(cl->IsTObject());
+         TDirectory::TContext ctxt(current_sourcedir);
+         obj = obj->Clone();
+         ownobj = kTRUE;
+      }
+   } else if (key) {
+      obj = key->ReadObj();
+      ownobj = kTRUE;
+   }
+   if (!obj) {
+      Info("MergeRecursive", "could not read object for key {%s, %s}",
+            keyname, keytitle);
+      return kTRUE;
+   }
+   Bool_t canBeFound = (type & kIncremental) && (current_sourcedir->GetList()->FindObject(keyname) != nullptr);
+
+   // if (cl->IsTObject())
+   //    obj->ResetBit(kMustCleanup);
+   if (cl->IsTObject() && cl != obj->IsA()) {
+      Error("MergeRecursive", "TKey and object retrieve disagree on type (%s vs %s).  Continuing with %s.",
+            keyclassname, obj->IsA()->GetName(), obj->IsA()->GetName());
+      cl = obj->IsA();
+   }
+   Bool_t canBeMerged = kTRUE;
+
+   if ( cl->InheritsFrom( TDirectory::Class() ) ) {
+      // it's a subdirectory
+
+      target->cd();
+      TDirectory *newdir;
+
+      // For incremental or already seen we may have already a directory created
+      if (type & kIncremental || alreadyseen) {
+         newdir = target->GetDirectory(obj->GetName());
+         if (!newdir) {
+            newdir = target->mkdir( obj->GetName(), obj->GetTitle() );
+            // newdir->ResetBit(kMustCleanup);
+         }
+      } else {
+         newdir = target->mkdir( obj->GetName(), obj->GetTitle() );
+         // newdir->ResetBit(kMustCleanup);
+      }
+
+      // newdir is now the starting point of another round of merging
+      // newdir still knows its depth within the target file via
+      // GetPath(), so we can still figure out where we are in the recursion
+
+      // If this folder is a onlyListed object, merge everything inside.
+      if (onlyListed) type &= ~kOnlyListed;
+      status = MergeRecursive(newdir, sourcelist, type);
+      if (onlyListed) type |= kOnlyListed;
+      if (!status) return kFALSE;
+   } else if (!cl->IsTObject() && cl->GetMerge()) {
+      // merge objects that don't derive from TObject
+      if (std::string(keyclassname) == "ROOT::Experimental::RNTuple") {
+         Warning("MergeRecursive", "merging RNTuples is experimental");
+         // todo(max): check if this works when a TDirectory is passed as the first
+         // input argument
+         Long64_t mergeResult = MergeRNTuples(cl, *path, *sourcelist);
+         if (mergeResult < 0) {
+            Error("MergeRecursive", "error merging RNTuples");
+            return kFALSE;
+         }
+      } else {
+         TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
+         Error("MergeRecursive", "Merging objects that don't inherit from TObject is unimplemented (key: %s of type %s in file %s)",
+                  keyname, keyclassname, nextsource->GetName());
+         canBeMerged = kFALSE;
+      }
+   } else if (cl->IsTObject() && cl->GetMerge()) {
+      // Check if already treated
+      if (alreadyseen) return kTRUE;
+
+      TList inputs;
+      TList todelete;
+      Bool_t oneGo = fHistoOneGo && cl->InheritsFrom(R__TH1_Class);
+
+      // Loop over all source files and merge same-name object
+      TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
+      if (nextsource == 0) {
+         // There is only one file in the list
+         ROOT::MergeFunc_t func = cl->GetMerge();
+         func(obj, &inputs, &info);
+         info.fIsFirst = kFALSE;
+      } else {
+         do {
+            // make sure we are at the correct directory level by cd'ing to path
+            TDirectory *ndir = nextsource->GetDirectory(path);
+            if (ndir) {
+               // For consistency (and persformance), we reset the MustCleanup be also for those
+               // 'key' retrieved indirectly.
+               // ndir->ResetBit(kMustCleanup);
+               ndir->cd();
+               TObject *hobj = ndir->GetList()->FindObject(keyname);
+               if (!hobj) {
+                  TKey *key2 = (TKey*)ndir->GetListOfKeys()->FindObject(keyname);
+                  if (key2) {
+                     hobj = key2->ReadObj();
+                     if (!hobj) {
+                        Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
+                           keyname, keytitle, nextsource->GetName());
+                              nextsource = (TFile*)sourcelist->After(nextsource);
+                              return kTRUE;
+                     }
+                     todelete.Add(hobj);
+                  }
+               }
+               if (hobj) {
+                  // Set ownership for collections
+                  if (hobj->InheritsFrom(TCollection::Class())) {
+                     ((TCollection*)hobj)->SetOwner();
+                  }
+                  hobj->ResetBit(kMustCleanup);
+                  inputs.Add(hobj);
+                  if (!oneGo) {
+                     ROOT::MergeFunc_t func = cl->GetMerge();
+                     Long64_t result = func(obj, &inputs, &info);
+                     info.fIsFirst = kFALSE;
+                     if (result < 0) {
+                        Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
+                              keyname, nextsource->GetName());
+                     }
+                     inputs.Clear();
+                     todelete.Delete();
+                  }
+               }
+            }
+            nextsource = (TFile*)sourcelist->After( nextsource );
+         } while (nextsource);
+         // Merge the list, if still to be done
+         if (oneGo || info.fIsFirst) {
+            ROOT::MergeFunc_t func = cl->GetMerge();
+            func(obj, &inputs, &info);
+            info.fIsFirst = kFALSE;
+            inputs.Clear();
+            todelete.Delete();
+         }
+      }
+   } else if (cl->IsTObject()) {
+      // try synthesizing the Merge method call according to the TObject
+      TList listH;
+      TString listHargs;
+      if (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*")) {
+         listHargs.Form("(TCollection*)0x%lx,(TFileMergeInfo*)0x%lx",
+                           (ULong_t)&listH, (ULong_t)&info);
+      } else if (cl->GetMethodWithPrototype("Merge", "TCollection*")) {
+         listHargs.Form("((TCollection*)0x%lx)", (ULong_t)&listH);
+      } else {
+         // pass unmergeable objects through to the output file
+         canBeMerged = kFALSE;
+      }
+      if (canBeMerged) {
+         if (alreadyseen) {
+            // skip already seen mergeable objects, don't skip unmergeable objects
+            return kTRUE;
+         }
+         // Loop over all source files and merge same-name object
+         TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
+         if (nextsource == 0) {
+            // There is only one file in the list
+            Int_t error = 0;
+            obj->Execute("Merge", listHargs.Data(), &error);
+            info.fIsFirst = kFALSE;
+            if (error) {
+               Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
+                     obj->GetName(), keyname);
+            }
+         } else {
+            while (nextsource) {
+               // make sure we are at the correct directory level by cd'ing to path
+               TDirectory *ndir = nextsource->GetDirectory(path);
+               if (ndir) {
+                  ndir->cd();
+                  TKey *key2 = (TKey*)ndir->GetListOfKeys()->FindObject(keyname);
+                  if (key2) {
+                     TObject *hobj = key2->ReadObj();
+                     if (!hobj) {
+                        Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
+                              keyname, keytitle, nextsource->GetName());
+                        nextsource = (TFile*)sourcelist->After(nextsource);
+                        return kTRUE;
+                     }
+                     // Set ownership for collections
+                     if (hobj->InheritsFrom(TCollection::Class())) {
+                        ((TCollection*)hobj)->SetOwner();
+                     }
+                     hobj->ResetBit(kMustCleanup);
+                     listH.Add(hobj);
+                     Int_t error = 0;
+                     obj->Execute("Merge", listHargs.Data(), &error);
+                     info.fIsFirst = kFALSE;
+                     if (error) {
+                        Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
+                              obj->GetName(), nextsource->GetName());
+                     }
+                     listH.Delete();
+                  }
+               }
+               nextsource = (TFile*)sourcelist->After( nextsource );
+            }
+            // Merge the list, if still to be done
+            if (info.fIsFirst) {
+               Int_t error = 0;
+               obj->Execute("Merge", listHargs.Data(), &error);
+               info.fIsFirst = kFALSE;
+               listH.Delete();
+            }
+         }
+      }
+   } else {
+      // Object is of no type that we can merge
+      canBeMerged = kFALSE;
+   }
+
+   // now write the merged histogram (which is "in" obj) to the target file
+   // note that this will just store obj in the current directory level,
+   // which is not persistent until the complete directory itself is stored
+   // by "target->SaveSelf()" below
+   target->cd();
+
+   oldkeyname = keyname;
+   //!!if the object is a tree, it is stored in globChain...
+   if (cl->InheritsFrom(TDirectory::Class())) {
+      // printf("cas d'une directory\n");
+
+      auto dirobj = dynamic_cast<TDirectory *>(obj);
+      TString dirpath(dirobj->GetPath());
+      // coverity[unchecked_value] 'target' is from a file so GetPath always returns path starting with filename:
+      dirpath.Remove(0, std::strlen(dirobj->GetFile()->GetPath()));
+
+      // Do not delete the directory if it is part of the output
+      // and we are in incremental mode (because it will be reuse
+      // and has not been written to disk (for performance reason).
+      // coverity[var_deref_model] the IsA()->InheritsFrom guarantees that the dynamic_cast will succeed.
+      if (!(type & kIncremental) || dirobj->GetFile() != target) {
+         dirobj->ResetBit(kMustCleanup);
+         delete dirobj;
+      }
+      // Let's also delete the directory from the other source (thanks to the 'allNames'
+      // mechanism above we will not process the directories when tranversing the next
+      // files).
+      TFile *nextsource = current_file ? (TFile *)sourcelist->After(current_file) : (TFile *)sourcelist->First();
+      while (nextsource) {
+         TDirectory *ndir = nextsource->GetDirectory(dirpath);
+         // For consistency (and persformance), we reset the MustCleanup be also for those
+         // 'key' retrieved indirectly.
+         if (ndir) {
+            ndir->ResetBit(kMustCleanup);
+            delete ndir;
+         }
+         nextsource = (TFile *)sourcelist->After(nextsource);
+      }
+   } else if (cl->InheritsFrom(TCollection::Class())) {
+      // Don't overwrite, if the object were not merged.
+      if (obj->Write(oldkeyname, canBeMerged ? TObject::kSingleKey | TObject::kOverwrite : TObject::kSingleKey) <=
+            0) {
+         status = kFALSE;
+      }
+      ((TCollection *)obj)->SetOwner();
+      delete obj;
+   } else if (!canBeFound) { // Don't write the partial result for TTree and TH1
+      // Don't overwrite, if the object were not merged.
+      // NOTE: this is probably wrong for emulated objects.
+      if (cl->IsTObject()) {
+         if (obj->Write(oldkeyname, canBeMerged ? TObject::kOverwrite : 0) <= 0) {
+            status = kFALSE;
+         }
+         obj->ResetBit(kMustCleanup);
+      } else {
+         if (target->WriteObjectAny((void *)obj, cl, oldkeyname, canBeMerged ? "OverWrite" : "") <= 0) {
+            status = kFALSE;
+         }
+      }
+      if (ownobj)
+         cl->Destructor(obj); // just in case the class is not loaded.
+   }
+   info.Reset();
+
+   return kTRUE;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Merge all objects in a directory
 ///
@@ -440,374 +807,31 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
       // When current_sourcedir != 0 and current_file == 0 we are going over the target
       // for an incremental merge.
       if (current_sourcedir && (current_file == 0 || current_sourcedir != target)) {
+         TString oldkeyname;
+
+         // Loop over live objects
+         TIter nextobj( current_sourcedir->GetList() );
+         TObject *obj;
+         while ( (obj = (TKey*)nextobj())) {
+            auto result = MergeOne(target, sourcelist, type,
+                                   info, oldkeyname, allNames, status, onlyListed, path,
+                                   current_sourcedir, current_file,
+                                   nullptr, obj);
+            if (!result)
+               return kFALSE; // Stop completely in case of error.
+         } // while ( (obj = (TKey*)nextobj()))
 
          // loop over all keys in this directory
          TIter nextkey( current_sourcedir->GetListOfKeys() );
          TKey *key;
-         TString oldkeyname;
 
          while ( (key = (TKey*)nextkey())) {
-
-            // Keep only the highest cycle number for each key for mergeable objects. They are stored
-            // in the (hash) list consecutively and in decreasing order of cycles, so we can continue
-            // until the name changes. We flag the case here and we act consequently later.
-            Bool_t alreadyseen = (oldkeyname == key->GetName()) ? kTRUE : kFALSE;
-
-            // Read in but do not copy directly the processIds.
-            if (strcmp(key->GetClassName(),"TProcessID") == 0) { key->ReadObj(); continue;}
-
-            // If we have already seen this object [name], we already processed
-            // the whole list of files for this objects and we can just skip it
-            // and any related cycles.
-            if (allNames.FindObject(key->GetName())) {
-               oldkeyname = key->GetName();
-               continue;
-            }
-
-            TClass *cl = TClass::GetClass(key->GetClassName());
-            if (!cl) {
-               Info("MergeRecursive", "cannot indentify object type (%s), name: %s title: %s",
-                    key->GetClassName(), key->GetName(), key->GetTitle());
-               continue;
-            }
-            // For mergeable objects we add the names in a local hashlist handling them
-            // again (see above)
-            if (cl->GetMerge() || cl->InheritsFrom(TDirectory::Class()) ||
-               (cl->IsTObject() && !cl->IsLoaded() &&
-                 /* If it has a dictionary and GetMerge() is nullptr then we already know the answer
-                    to the next question is 'no, if we were to ask we would useless trigger
-                    auto-parsing */
-                 (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*") ||
-                  cl->GetMethodWithPrototype("Merge", "TCollection*"))))
-               allNames.Add(new TObjString(key->GetName()));
-
-            if (fNoTrees && cl->InheritsFrom(R__TTree_Class)) {
-               // Skip the TTree objects and any related cycles.
-               oldkeyname = key->GetName();
-               continue;
-            }
-            // Check if only the listed objects are to be merged
-            if (type & kOnlyListed) {
-               onlyListed = kFALSE;
-               oldkeyname = key->GetName();
-               oldkeyname += " ";
-               onlyListed = fObjectNames.Contains(oldkeyname);
-               oldkeyname = key->GetName();
-               if ((!onlyListed) && (!cl->InheritsFrom(TDirectory::Class()))) continue;
-            }
-
-            if (!(type&kResetable && type&kNonResetable)) {
-               // If neither or both are requested at the same time, we merger both types.
-               if (!(type&kResetable)) {
-                  if (cl->GetResetAfterMerge()) {
-                     // Skip the object with a reset after merge routine (TTree and other incrementally mergeable objects)
-                     oldkeyname = key->GetName();
-                     continue;
-                  }
-               }
-               if (!(type&kNonResetable)) {
-                  if (!cl->GetResetAfterMerge()) {
-                     // Skip the object without a reset after merge routine (Histograms and other non incrementally mergeable objects)
-                     oldkeyname = key->GetName();
-                     continue;
-                  }
-               }
-            }
-            // read object from first source file
-            TObject *obj;
-            if (type & kIncremental) {
-               obj = current_sourcedir->GetList()->FindObject(key->GetName());
-               if (!obj) {
-                  obj = key->ReadObj();
-               } else if (info.fIsFirst && current_sourcedir != target) {
-                  R__ASSERT(cl->IsTObject());
-                  obj = obj->Clone();
-               }
-            } else {
-               obj = key->ReadObj();
-            }
-            if (!obj) {
-               Info("MergeRecursive", "could not read object for key {%s, %s}",
-                    key->GetName(), key->GetTitle());
-               continue;
-            }
-            Bool_t canBeFound = (type & kIncremental) && (current_sourcedir->GetList()->FindObject(key->GetName()) != nullptr);
-            Bool_t needWriteAnyWay = kFALSE;
-            if (canBeFound) {
-               // For now the code require a key (that might be ignored see search through current_sourcedir->GetList())
-               // in the output file in order for it to be even considered.
-               needWriteAnyWay = target->GetListOfKeys()->FindObject(key->GetName()) == nullptr;
-            }
-            // if (cl->IsTObject())
-            //    obj->ResetBit(kMustCleanup);
-            if (cl->IsTObject() && cl != obj->IsA()) {
-               Error("MergeRecursive", "TKey and object retrieve disagree on type (%s vs %s).  Continuing with %s.",
-                    key->GetClassName(), obj->IsA()->GetName(), obj->IsA()->GetName());
-               cl = obj->IsA();
-            }
-            Bool_t canBeMerged = kTRUE;
-
-            if ( cl->InheritsFrom( TDirectory::Class() ) ) {
-               // it's a subdirectory
-
-               target->cd();
-               TDirectory *newdir;
-
-               // For incremental or already seen we may have already a directory created
-               if (type & kIncremental || alreadyseen) {
-                  newdir = target->GetDirectory(obj->GetName());
-                  if (!newdir) {
-                     newdir = target->mkdir( obj->GetName(), obj->GetTitle() );
-                     // newdir->ResetBit(kMustCleanup);
-                  }
-               } else {
-                  newdir = target->mkdir( obj->GetName(), obj->GetTitle() );
-                  // newdir->ResetBit(kMustCleanup);
-               }
-
-               // newdir is now the starting point of another round of merging
-               // newdir still knows its depth within the target file via
-               // GetPath(), so we can still figure out where we are in the recursion
-
-               // If this folder is a onlyListed object, merge everything inside.
-               if (onlyListed) type &= ~kOnlyListed;
-               status = MergeRecursive(newdir, sourcelist, type);
-               if (onlyListed) type |= kOnlyListed;
-               if (!status) return status;
-            } else if (!cl->IsTObject() && cl->GetMerge()) {
-               // merge objects that don't derive from TObject
-               if (std::string(key->GetClassName()) == "ROOT::Experimental::RNTuple") {
-                  Warning("MergeRecursive", "merging RNTuples is experimental");
-                  // todo(max): check if this works when a TDirectory is passed as the first
-                  // input argument
-                  Long64_t mergeResult = MergeRNTuples(cl, *path, *sourcelist);
-                  if (mergeResult < 0) {
-                     Error("MergeRecursive", "error merging RNTuples");
-                     return kFALSE;
-                  }
-               } else {
-                  TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
-                  Error("MergeRecursive", "Merging objects that don't inherit from TObject is unimplemented (key: %s of type %s in file %s)",
-                        key->GetName(), key->GetClassName(), nextsource->GetName());
-                  canBeMerged = kFALSE;
-               }
-            } else if (cl->IsTObject() && cl->GetMerge()) {
-               // Check if already treated
-               if (alreadyseen) continue;
-
-               TList inputs;
-               TList todelete;
-               Bool_t oneGo = fHistoOneGo && cl->InheritsFrom(R__TH1_Class);
-
-               // Loop over all source files and merge same-name object
-               TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
-               if (nextsource == 0) {
-                  // There is only one file in the list
-                  ROOT::MergeFunc_t func = cl->GetMerge();
-                  func(obj, &inputs, &info);
-                  info.fIsFirst = kFALSE;
-               } else {
-                  do {
-                     // make sure we are at the correct directory level by cd'ing to path
-                     TDirectory *ndir = nextsource->GetDirectory(path);
-                     if (ndir) {
-                        // For consistency (and persformance), we reset the MustCleanup be also for those
-                        // 'key' retrieved indirectly.
-                        // ndir->ResetBit(kMustCleanup);
-                        ndir->cd();
-                        TObject *hobj = ndir->GetList()->FindObject(key->GetName());
-                        if (!hobj) {
-                           TKey *key2 = (TKey*)ndir->GetListOfKeys()->FindObject(key->GetName());
-                           if (key2) {
-                              hobj = key2->ReadObj();
-                              if (!hobj) {
-                                 Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
-                                    key->GetName(), key->GetTitle(), nextsource->GetName());
-                                 nextsource = (TFile*)sourcelist->After(nextsource);
-                                 continue;
-                              }
-                              todelete.Add(hobj);
-                           }
-                        }
-                        if (hobj) {
-                           // Set ownership for collections
-                           if (hobj->InheritsFrom(TCollection::Class())) {
-                              ((TCollection*)hobj)->SetOwner();
-                           }
-                           hobj->ResetBit(kMustCleanup);
-                           inputs.Add(hobj);
-                           if (!oneGo) {
-                              ROOT::MergeFunc_t func = cl->GetMerge();
-                              Long64_t result = func(obj, &inputs, &info);
-                              info.fIsFirst = kFALSE;
-                              if (result < 0) {
-                                 Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
-                                       key->GetName(), nextsource->GetName());
-                              }
-                              inputs.Clear();
-                              todelete.Delete();
-                           }
-                        }
-                     }
-                     nextsource = (TFile*)sourcelist->After( nextsource );
-                  } while (nextsource);
-                  // Merge the list, if still to be done
-                  if (oneGo || info.fIsFirst) {
-                     ROOT::MergeFunc_t func = cl->GetMerge();
-                     func(obj, &inputs, &info);
-                     info.fIsFirst = kFALSE;
-                     inputs.Clear();
-                     todelete.Delete();
-                  }
-               }
-            } else if (cl->IsTObject()) {
-               // try synthesizing the Merge method call according to the TObject
-               TList listH;
-               TString listHargs;
-               if (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*")) {
-                  listHargs.Form("(TCollection*)0x%lx,(TFileMergeInfo*)0x%lx",
-                                  (ULong_t)&listH, (ULong_t)&info);
-               } else if (cl->GetMethodWithPrototype("Merge", "TCollection*")) {
-                  listHargs.Form("((TCollection*)0x%lx)", (ULong_t)&listH);
-               } else {
-                  // pass unmergeable objects through to the output file
-                  canBeMerged = kFALSE;
-               }
-               if (canBeMerged) {
-                  if (alreadyseen) {
-                     // skip already seen mergeable objects, don't skip unmergeable objects
-                     continue;
-                  }
-                  // Loop over all source files and merge same-name object
-                  TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
-                  if (nextsource == 0) {
-                     // There is only one file in the list
-                     Int_t error = 0;
-                     obj->Execute("Merge", listHargs.Data(), &error);
-                     info.fIsFirst = kFALSE;
-                     if (error) {
-                        Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
-                              obj->GetName(), key->GetName());
-                     }
-                  } else {
-                     while (nextsource) {
-                        // make sure we are at the correct directory level by cd'ing to path
-                        TDirectory *ndir = nextsource->GetDirectory(path);
-                        if (ndir) {
-                           ndir->cd();
-                           TKey *key2 = (TKey*)ndir->GetListOfKeys()->FindObject(key->GetName());
-                           if (key2) {
-                              TObject *hobj = key2->ReadObj();
-                              if (!hobj) {
-                                 Info("MergeRecursive", "could not read object for key {%s, %s}; skipping file %s",
-                                      key->GetName(), key->GetTitle(), nextsource->GetName());
-                                 nextsource = (TFile*)sourcelist->After(nextsource);
-                                 continue;
-                              }
-                              // Set ownership for collections
-                              if (hobj->InheritsFrom(TCollection::Class())) {
-                                 ((TCollection*)hobj)->SetOwner();
-                              }
-                              hobj->ResetBit(kMustCleanup);
-                              listH.Add(hobj);
-                              Int_t error = 0;
-                              obj->Execute("Merge", listHargs.Data(), &error);
-                              info.fIsFirst = kFALSE;
-                              if (error) {
-                                 Error("MergeRecursive", "calling Merge() on '%s' with the corresponding object in '%s'",
-                                       obj->GetName(), nextsource->GetName());
-                              }
-                              listH.Delete();
-                           }
-                        }
-                        nextsource = (TFile*)sourcelist->After( nextsource );
-                     }
-                     // Merge the list, if still to be done
-                     if (info.fIsFirst) {
-                        Int_t error = 0;
-                        obj->Execute("Merge", listHargs.Data(), &error);
-                        info.fIsFirst = kFALSE;
-                        listH.Delete();
-                     }
-                  }
-               }
-            } else {
-               // Object is of no type that we can merge
-               canBeMerged = kFALSE;
-            }
-
-            // now write the merged histogram (which is "in" obj) to the target file
-            // note that this will just store obj in the current directory level,
-            // which is not persistent until the complete directory itself is stored
-            // by "target->SaveSelf()" below
-            target->cd();
-
-            oldkeyname = key->GetName();
-            //!!if the object is a tree, it is stored in globChain...
-            if(cl->InheritsFrom( TDirectory::Class() )) {
-               //printf("cas d'une directory\n");
-
-               auto dirobj = dynamic_cast<TDirectory*>(obj);
-               TString dirpath(dirobj->GetPath());
-               // coverity[unchecked_value] 'target' is from a file so GetPath always returns path starting with filename:
-               dirpath.Remove(0, std::strlen(dirobj->GetFile()->GetPath()));
-
-               // Do not delete the directory if it is part of the output
-               // and we are in incremental mode (because it will be reuse
-               // and has not been written to disk (for performance reason).
-               // coverity[var_deref_model] the IsA()->InheritsFrom guarantees that the dynamic_cast will succeed.
-               if (!(type&kIncremental) || dirobj->GetFile() != target) {
-                  dirobj->ResetBit(kMustCleanup);
-                  delete dirobj;
-               }
-               // Let's also delete the directory from the other source (thanks to the 'allNames'
-               // mechanism above we will not process the directories when tranversing the next
-               // files).
-               TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
-               while (nextsource) {
-                  TDirectory *ndir = nextsource->GetDirectory(dirpath);
-                  // For consistency (and persformance), we reset the MustCleanup be also for those
-                  // 'key' retrieved indirectly.
-                  if (ndir) {
-                     ndir->ResetBit(kMustCleanup);
-                     delete ndir;
-                  }
-                  nextsource = (TFile*)sourcelist->After( nextsource );
-               }
-            } else if (cl->InheritsFrom( TCollection::Class() )) {
-               // Don't overwrite, if the object were not merged.
-               if ( obj->Write( oldkeyname, canBeMerged ? TObject::kSingleKey | TObject::kOverwrite : TObject::kSingleKey) <= 0 ) {
-                  status = kFALSE;
-               }
-               ((TCollection*)obj)->SetOwner();
-               delete obj;
-            } else if (!canBeFound) { // Don't write the partial result for TTree and TH1
-               // Don't overwrite, if the object were not merged.
-               // NOTE: this is probably wrong for emulated objects.
-               if (cl->IsTObject()) {
-                  if ( obj->Write( oldkeyname, canBeMerged ? TObject::kOverwrite : 0) <= 0) {
-                     status = kFALSE;
-                  }
-                  obj->ResetBit(kMustCleanup);
-               } else {
-                  if ( target->WriteObjectAny( (void*)obj, cl, oldkeyname, canBeMerged ? "OverWrite" : "" ) <= 0) {
-                     status = kFALSE;
-                  }
-               }
-               cl->Destructor(obj); // just in case the class is not loaded.
-            } else if (needWriteAnyWay) {
-               if (cl->IsTObject()) {
-                  if ( obj->Write( oldkeyname, canBeMerged ? TObject::kOverwrite : 0) <= 0) {
-                     status = kFALSE;
-                  }
-                  obj->ResetBit(kMustCleanup);
-               } else {
-                  if ( target->WriteObjectAny( (void*)obj, cl, oldkeyname, canBeMerged ? "OverWrite" : "" ) <= 0) {
-                     status = kFALSE;
-                  }
-               }
-            }
-            info.Reset();
+            auto result = MergeOne(target, sourcelist, type,
+                                   info, oldkeyname, allNames, status, onlyListed, path,
+                                   current_sourcedir, current_file,
+                                   key, nullptr);
+            if (!result)
+               return kFALSE; // Stop completely in case of error.
          } // while ( ( TKey *key = (TKey*)nextkey() ) )
       }
       current_file = current_file ? (TFile*)sourcelist->After(current_file) : (TFile*)sourcelist->First();

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -574,12 +574,12 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
                      Error("MergeRecursive", "error merging RNTuples");
                      return kFALSE;
                   }
-                  return kTRUE;
+               } else {
+                  TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
+                  Error("MergeRecursive", "Merging objects that don't inherit from TObject is unimplemented (key: %s of type %s in file %s)",
+                        key->GetName(), key->GetClassName(), nextsource->GetName());
+                  canBeMerged = kFALSE;
                }
-               TFile *nextsource = current_file ? (TFile*)sourcelist->After( current_file ) : (TFile*)sourcelist->First();
-               Error("MergeRecursive", "Merging objects that don't inherit from TObject is unimplemented (key: %s of type %s in file %s)",
-                      key->GetName(), key->GetClassName(), nextsource->GetName());
-               canBeMerged = kFALSE;
             } else if (cl->IsTObject() && cl->GetMerge()) {
                // Check if already treated
                if (alreadyseen) continue;

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -956,9 +956,18 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
    } else {
       // Close or write is required so the file is complete.
       if (in_type & kIncremental) {
+         // In the case of 'kDelayWrite' the caller want to avoid having to
+         // write the output objects once for every input file and instead
+         // write it only once at the end of the process.
          if (!(in_type & kDelayWrite))
             fOutputFile->Write("",TObject::kOverwrite);
       } else {
+         // If in_type is not incremental but type is incremental we are now in
+         // the case where the user "explicitly" request a non-incremental merge
+         // but we still have internally an incremental merge. Because the user
+         // did not request the incremental merge they also probably do not to a
+         // final Write of the file and thus not doing the write here would lead
+         // to data loss ...
          if (type & kIncremental)
             fOutputFile->Write("",TObject::kOverwrite);
          gROOT->GetListOfFiles()->Remove(fOutputFile);

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -705,7 +705,7 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
       dirpath.Remove(0, std::strlen(dirobj->GetFile()->GetPath()));
 
       // Do not delete the directory if it is part of the output
-      // and we are in incremental mode (because it will be reuse
+      // and we are in incremental mode (because it will be reused
       // and has not been written to disk (for performance reason).
       // coverity[var_deref_model] the IsA()->InheritsFrom guarantees that the dynamic_cast will succeed.
       if (!(type & kIncremental) || dirobj->GetFile() != target) {
@@ -718,7 +718,7 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
       TFile *nextsource = current_file ? (TFile *)sourcelist->After(current_file) : (TFile *)sourcelist->First();
       while (nextsource) {
          TDirectory *ndir = nextsource->GetDirectory(dirpath);
-         // For consistency (and persformance), we reset the MustCleanup be also for those
+         // For consistency (and performance), we reset the MustCleanup be also for those
          // 'key' retrieved indirectly.
          if (ndir) {
             ndir->ResetBit(kMustCleanup);

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -738,7 +738,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
 
       // Case of a custom collection (the user provided a CollectionProxy
       // for a class that is not an STL collection).
-      if (GetElements()->GetEntries() == 1) {
+      if (GetElements()->GetEntriesFast() == 1) {
          TObject *element = GetElements()->UncheckedAt(0);
          Bool_t isstl = element && strcmp("This",element->GetName())==0;
          if (isstl) {
@@ -799,7 +799,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
       const TObjArray *array = fClass->GetStreamerInfos();
       TStreamerInfo* info = 0;
 
-      if (fClass->TestBit(TClass::kIsEmulation) && array->GetEntries()==0) {
+      if (fClass->TestBit(TClass::kIsEmulation) && array->IsEmpty()) {
          // We have an emulated class that has no TStreamerInfo, this
          // means it was created to insert a (default) rule.  Consequently
          // the error message about the missing dictionary was not printed.
@@ -810,7 +810,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
 
       // Case of a custom collection (the user provided a CollectionProxy
       // for a class that is not an STL collection).
-      if (GetElements()->GetEntries() == 1) {
+      if (GetElements()->GetEntriesFast() == 1) {
          TObject *element = GetElements()->UncheckedAt(0);
          Bool_t isstl = element && strcmp("This",element->GetName())==0;
          if (isstl && !fClass->GetCollectionProxy()) {
@@ -1264,7 +1264,7 @@ void TStreamerInfo::BuildEmulated(TFile *file)
    fClassVersion = -1;
    fCheckSum = 2001;
    TObjArray *elements = GetElements();
-   Int_t ndata = elements ? elements->GetEntries() : 0;
+   Int_t ndata = elements ? elements->GetEntriesFast() : 0;
    for (Int_t i=0;i < ndata;i++) {
       TStreamerElement *element = (TStreamerElement*)elements->UncheckedAt(i);
       if (!element) break;
@@ -1583,14 +1583,14 @@ namespace {
             return nullptr;
          }
          TVirtualStreamerInfo *info = current->GetValueClass()->GetStreamerInfo();
-         if (info->GetElements()->GetEntries() != 2) {
+         if (info->GetElements()->GetEntriesFast() != 2) {
             return oldClass;
          }
          TStreamerElement *f = (TStreamerElement*) info->GetElements()->At(0);
          TStreamerElement *s = (TStreamerElement*) info->GetElements()->At(1);
 
          info = old->GetValueClass()->GetStreamerInfo();
-         assert(info->GetElements()->GetEntries() == 2);
+         assert(info->GetElements()->GetEntriesFast() == 2);
          TStreamerElement *of = (TStreamerElement*) info->GetElements()->At(0);
          TStreamerElement *os = (TStreamerElement*) info->GetElements()->At(1);
 
@@ -1755,7 +1755,7 @@ void TStreamerInfo::BuildOld()
 
    int nBaze = 0;
 
-   if ((fElements->GetEntries() == 1) && !strcmp(fElements->At(0)->GetName(), "This")) {
+   if ((fElements->GetEntriesFast() == 1) && !strcmp(fElements->At(0)->GetName(), "This")) {
       if (fClass->GetCollectionProxy())  {
          element = (TStreamerElement*)next();
          element->SetNewType( element->GetType() );
@@ -2782,7 +2782,7 @@ TObject *TStreamerInfo::Clone(const char *newname) const
    TStreamerInfo *newinfo = (TStreamerInfo*)TNamed::Clone(newname);
    if (newname && newname[0] && fName != newname) {
       TObjArray *newelems = newinfo->GetElements();
-      Int_t ndata = newelems->GetEntries();
+      Int_t ndata = newelems->GetEntriesFast();
       for(Int_t i = 0; i < ndata; ++i) {
          TObject *element = newelems->UncheckedAt(i);
          if (element->IsA() == TStreamerLoop::Class()) {
@@ -3163,7 +3163,7 @@ void TStreamerInfo::ForceWriteInfo(TFile* file, Bool_t force)
    if (fClass==0) {
       // Build or BuildCheck has not been called yet.
       // Let's use another means of checking.
-      if (fElements && fElements->GetEntries()==1 && strcmp("This",fElements->UncheckedAt(0)->GetName())==0) {
+      if (fElements && fElements->GetEntriesFast()==1 && strcmp("This",fElements->UncheckedAt(0)->GetName())==0) {
          // We are an STL collection.
          return;
       }
@@ -3593,7 +3593,7 @@ void TStreamerInfo::GenerateDeclaration(FILE *fp, FILE *sfp, const TList *subCla
       return;
    }
 
-   Bool_t needGenericTemplate = fElements==0 || fElements->GetEntries() == 0;
+   Bool_t needGenericTemplate = fElements==0 || fElements->IsEmpty();
    Bool_t isTemplate = kFALSE;
    const char *clname = GetName();
    TString template_protoname;
@@ -3959,7 +3959,7 @@ Int_t TStreamerInfo::GenerateHeaderFile(const char *dirname, const TList *subCla
          }
       }
    }
-   Bool_t needGenericTemplate = isTemplate && (fElements==0 || fElements->GetEntries()==0);
+   Bool_t needGenericTemplate = isTemplate && (fElements==0 || fElements->IsEmpty());
 
    if (gDebug) printf("generating code for class %s\n",GetName());
 
@@ -4526,7 +4526,7 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
          newel->SetReadRawFunc( rule->GetReadRawFunctionPointer() );
          toAdd.push_back(newel);
       } else {
-         toAdd.reserve(rule->GetTarget()->GetEntries());
+         toAdd.reserve(rule->GetTarget()->GetEntriesFast());
          TObjString * objstr = (TObjString*)(rule->GetTarget()->At(0));
          if (objstr) {
             TString newName = objstr->String();
@@ -4544,7 +4544,7 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
                // This would be a completely new member (so it would need to be cached)
                // TOBEDONE
             }
-            for(Int_t other = 1; other < rule->GetTarget()->GetEntries(); ++other) {
+            for(Int_t other = 1; other < rule->GetTarget()->GetEntriesFast(); ++other) {
                objstr = (TObjString*)(rule->GetTarget()->At(other));
                if (objstr) {
                   newName = objstr->String();

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -3003,7 +3003,7 @@ void TStreamerInfo::Compile()
    assert(fComp == 0 && fCompFull == 0 && fCompOpt == 0);
 
 
-   Int_t ndata = fElements->GetEntries();
+   Int_t ndata = fElements->GetEntriesFast();
 
 
    if (fReadObjectWise) fReadObjectWise->fActions.clear();
@@ -3894,7 +3894,7 @@ TStreamerInfoActions::TActionSequence *TStreamerInfoActions::TActionSequence::Cr
 
    TStreamerInfo *sinfo = static_cast<TStreamerInfo*>(info);
 
-   UInt_t ndata = info->GetElements()->GetEntries();
+   UInt_t ndata = info->GetElements()->GetEntriesFast();
    TStreamerInfoActions::TActionSequence *sequence = new TStreamerInfoActions::TActionSequence(info,ndata);
    if (IsDefaultVector(proxy))
    {
@@ -4009,7 +4009,7 @@ TStreamerInfoActions::TActionSequence *TStreamerInfoActions::TActionSequence::Cr
          return new TStreamerInfoActions::TActionSequence(0,0);
       }
 
-      UInt_t ndata = info->GetElements()->GetEntries();
+      UInt_t ndata = info->GetElements()->GetEntriesFast();
       TStreamerInfo *sinfo = static_cast<TStreamerInfo*>(info);
       TStreamerInfoActions::TActionSequence *sequence = new TStreamerInfoActions::TActionSequence(info,ndata);
 

--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -117,6 +117,7 @@ public:
            Long64_t *GetTreeOffset() const { return fTreeOffset; }
            Int_t     GetTreeOffsetLen() const { return fTreeOffsetLen; }
    virtual Double_t  GetWeight() const;
+   virtual Bool_t    InPlaceClone(TDirectory *newdirectory, const char *options = "");
    virtual Int_t     LoadBaskets(Long64_t maxmemory);
    virtual Long64_t  LoadTree(Long64_t entry);
            void      Lookup(Bool_t force = kFALSE);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -418,7 +418,7 @@ public:
    virtual TFile          *ChangeFile(TFile* file);
    virtual TTree          *CloneTree(Long64_t nentries = -1, Option_t* option = "");
    virtual void            CopyAddresses(TTree*,Bool_t undo = kFALSE);
-   virtual Long64_t        CopyEntries(TTree* tree, Long64_t nentries = -1, Option_t *option = "");
+   virtual Long64_t        CopyEntries(TTree* tree, Long64_t nentries = -1, Option_t *option = "", Bool_t needCopyAddresses = false);
    virtual TTree          *CopyTree(const char* selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
    virtual TBasket        *CreateBasket(TBranch*);
    virtual void            DirectoryAutoAdd(TDirectory *);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -540,6 +540,7 @@ public:
    virtual Long64_t        GetZipBytes() const { return fZipBytes; }
    virtual void            IncrementTotalBuffers(Int_t nbytes) { fTotalBuffers += nbytes; }
    Bool_t                  IsFolder() const { return kTRUE; }
+   virtual Bool_t          InPlaceClone(TDirectory *newdirectory, const char *options = "");
    virtual Int_t           LoadBaskets(Long64_t maxmemory = 2000000000);
    virtual Long64_t        LoadTree(Long64_t entry);
    virtual Long64_t        LoadTreeFriend(Long64_t entry, TTree* T);

--- a/tree/tree/inc/TTreeCloner.h
+++ b/tree/tree/inc/TTreeCloner.h
@@ -24,7 +24,9 @@
 
 class TBranch;
 class TTree;
+class TFile;
 class TFileCacheRead;
+class TDirectory;
 
 class TTreeCloner {
    TString    fWarningMsg;       ///< Text of the error message lead to an 'invalid' state
@@ -34,6 +36,8 @@ class TTreeCloner {
    UInt_t     fOptions;
    TTree     *fFromTree;
    TTree     *fToTree;
+   TDirectory*fToDirectory;
+   TFile     *fToFile;
    Option_t  *fMethod;
    TObjArray  fFromBranches;
    TObjArray  fToBranches;
@@ -88,6 +92,8 @@ private:
    TTreeCloner(const TTreeCloner&) = delete;
    TTreeCloner &operator=(const TTreeCloner&) = delete;
 
+   TTreeCloner(TTree *from, TTree *to, TDirectory *newdirectory, Option_t *method, UInt_t options = kNone);
+
 public:
    enum EClonerOptions {
       kNone       = 0,
@@ -97,6 +103,7 @@ public:
    };
 
    TTreeCloner(TTree *from, TTree *to, Option_t *method, UInt_t options = kNone);
+   TTreeCloner(TTree *from, TDirectory *newdirectory, Option_t *method, UInt_t options = kNone);
    virtual ~TTreeCloner();
 
    void   CloseOutWriteBaskets();
@@ -108,6 +115,7 @@ public:
    void   CopyStreamerInfos();
    void   CopyProcessIds();
    const char *GetWarning() const { return fWarningMsg; }
+   Bool_t IsInPlace() const { return fFromTree == fToTree; }
    Bool_t Exec();
    Bool_t IsValid() { return fIsValid; }
    Bool_t NeedConversion() { return fNeedConversion; }

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -1130,7 +1130,7 @@ void TBasket::Update(Int_t offset, Int_t skipped)
 
 Int_t TBasket::WriteBuffer()
 {
-   const Int_t kWrite = 1;
+   constexpr Int_t kWrite = 1;
 
    TFile *file = fBranch->GetFile(kWrite);
    if (!file) return 0;
@@ -1204,9 +1204,9 @@ Int_t TBasket::WriteBuffer()
       }
    }
 
-   Int_t lbuf, nout, noutot, bufmax, nzip;
-   lbuf       = fBufferRef->Length();
-   fObjlen    = lbuf - fKeylen;
+   Int_t nout, noutot, bufmax, nzip;
+
+   fObjlen = fBufferRef->Length() - fKeylen;
 
    fHeaderOnly = kTRUE;
    fCycle = fBranch->GetWriteBasket();

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2073,7 +2073,6 @@ TBranch* TBranch::GetSubBranch(const TBranch* child) const
       }
       if (branch == child) {
          // We are the direct parent of child.
-         const_cast<TBranch*>(child)->fParent = (TBranch*)this; // We can not yet use the 'mutable' keyword
          // Note: We cast away any const-ness of "this".
          const_cast<TBranch*>(child)->fParent = (TBranch*)this; // We can not yet use the 'mutable' keyword
          return (TBranch*) this;

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2894,13 +2894,13 @@ void TBranch::Streamer(TBuffer& b)
             br->fParent = this;
          }
 
-         fNBaskets = fBaskets.GetEntries();
-         for (Int_t j=fWriteBasket,n=0;j>=0 && n<fNBaskets;--j) {
+         fNBaskets = 0;
+         for (Int_t j = fWriteBasket; j>=0; --j) {
             TBasket *bk = (TBasket*)fBaskets.UncheckedAt(j);
             if (bk) {
                bk->SetBranch(this);
                // GetTree()->IncrementTotalBuffers(bk->GetBufferSize());
-               ++n;
+               ++fNBaskets;
             }
          }
          if (fWriteBasket >= fMaxBaskets) {
@@ -2968,13 +2968,13 @@ void TBranch::Streamer(TBuffer& b)
             TLeaf *leaf = (TLeaf*)fLeaves.UncheckedAt(i);
             leaf->SetBranch(this);
          }
-         fNBaskets = fBaskets.GetEntries();
-         for (j=fWriteBasket,n=0;j>=0 && n<fNBaskets;--j) {
+         fNBaskets = 0;
+         for (j = fWriteBasket; j >= 0; --j) {
             TBasket *bk = (TBasket*)fBaskets.UncheckedAt(j);
             if (bk) {
                bk->SetBranch(this);
                //GetTree()->IncrementTotalBuffers(bk->GetBufferSize());
-               ++n;
+               ++fNBaskets;
             }
          }
          if (fWriteBasket >= fMaxBaskets) {
@@ -3023,13 +3023,11 @@ void TBranch::Streamer(TBuffer& b)
          leaf->SetBranch(this);
       }
       fBaskets.Streamer(b);
-      Int_t nbaskets = fBaskets.GetEntries();
-      for (j=fWriteBasket,n=0;j>0 && n<nbaskets;--j) {
+      for (j = fWriteBasket; j > 0; --j) {
          TBasket *bk = (TBasket*)fBaskets.UncheckedAt(j);
          if (bk) {
             bk->SetBranch(this);
             //GetTree()->IncrementTotalBuffers(bk->GetBufferSize());
-            ++n;
          }
       }
       fBasketEntry = new Long64_t[fMaxBaskets];

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -626,8 +626,12 @@ void TBranch::AddLastBasket(Long64_t startEntry)
       Fatal("AddBasket","The last basket must have the highest entry number (%s/%lld/%d).",GetName(),startEntry,fWriteBasket);
 
    }
-   fBasketEntry[where] = startEntry;
-   fBaskets.AddAtAndExpand(0,fWriteBasket);
+   // The first basket (should) always start at zero. If we are asked to update
+   // it, this likely to be from merging 'empty' branches (base class node and the likes)
+   if (where) {
+      fBasketEntry[where] = startEntry;
+      fBaskets.AddAtAndExpand(0,fWriteBasket);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -3123,7 +3123,8 @@ Int_t TBranch::WriteBasketImpl(TBasket* basket, Int_t where, ROOT::Internal::TBr
    // itself might be modified after `WriteBasketImpl` exits.
    auto doUpdates = [=]() {
       Int_t nout  = basket->WriteBuffer();    //  Write buffer
-      if (nout < 0) Error("TBranch::WriteBasketImpl", "basket's WriteBuffer failed.\n");
+      if (nout < 0)
+         Error("WriteBasketImpl", "basket's WriteBuffer failed.");
       fBasketBytes[where]  = basket->GetNbytes();
       fBasketSeek[where]   = basket->GetSeekKey();
       Int_t addbytes = basket->GetObjlen() + basket->GetKeylen();

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2872,6 +2872,11 @@ void TBranch::Streamer(TBuffer& b)
             TLeaf *leaf = (TLeaf*)fLeaves.UncheckedAt(i);
             leaf->SetBranch(this);
          }
+         auto nbranches = fBranches.GetEntriesFast();
+         for (Int_t i=0;i<nbranches;i++) {
+            TBranch *br = (TBranch*)fBranches.UncheckedAt(i);
+            br->fParent = this;
+         }
 
          fNBaskets = fBaskets.GetEntries();
          for (Int_t j=fWriteBasket,n=0;j>=0 && n<fNBaskets;--j) {

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2036,6 +2036,22 @@ TBranch* TBranch::GetMother() const
 {
    if (fMother) return fMother;
 
+   {
+      TBranch *parent = fParent;
+      while(parent) {
+         if (parent->fMother) {
+            const_cast<TBranch*>(this)->fMother = parent->fMother; // We can not yet use the 'mutable' keyword
+            return fMother;
+         }
+         if (!parent->fParent) {
+            // This is the top node
+            const_cast<TBranch*>(this)->fMother = parent; // We can not yet use the 'mutable' keyword
+            return fMother;
+         }
+         parent = parent->fParent;
+      }
+   }
+
    const TObjArray* array = fTree->GetListOfBranches();
    Int_t n = array->GetEntriesFast();
    for (Int_t i = 0; i < n; ++i) {

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1169,7 +1169,7 @@ Int_t TBranch::FlushBaskets()
 Int_t TBranch::FlushOneBasket(UInt_t ibasket)
 {
    Int_t nbytes = 0;
-   if (fDirectory && fBaskets.GetEntries()) {
+   if (fDirectory && fBaskets.GetEntriesFast()) {
       TBasket *basket = (TBasket*)fBaskets.UncheckedAt(ibasket);
 
       if (basket) {

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -1143,10 +1143,12 @@ void TBranchElement::BuildTitle(const char* name)
 {
    TString branchname;
 
-   Int_t nbranches = fBranches.GetEntries();
+   Int_t nbranches = fBranches.GetEntriesFast();
 
    for (Int_t i = 0; i < nbranches; ++i) {
       TBranchElement* bre = (TBranchElement*) fBranches.At(i);
+      if (!bre)
+         continue;
       if (fType == 3) {
          bre->SetType(31);
       } else if (fType == 4) {
@@ -3235,7 +3237,7 @@ void TBranchElement::InitializeOffsets()
          {
             Int_t streamerType = subBranchElement->GetType();
             if (streamerType > TStreamerInfo::kObject
-                && subBranch->GetListOfBranches()->GetEntries()==0
+                && subBranch->GetListOfBranches()->GetEntriesFast()==0
                 && CanSelfReference(subBranchElement->GetClass()))
             {
                subBranch->SetBit(kBranchAny);

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -1225,6 +1225,14 @@ Double_t TChain::GetWeight() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Move content to a new file. (NOT IMPLEMENTED for TChain)
+Bool_t TChain::InPlaceClone(TDirectory * /* new directory */, const char * /* options */)
+{
+   Error("InPlaceClone", "not implemented");
+   return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Set the TTree to be reloaded as soon as possible.  In particular this
 /// is needed when adding a Friend.
 ///

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6856,11 +6856,11 @@ Long64_t TTree::Merge(TCollection* li, TFileMergeInfo *info)
    if (info && info->fIsFirst && info->fOutputDirectory && info->fOutputDirectory->GetFile() != GetCurrentFile()) {
       TDirectory::TContext ctxt(info->fOutputDirectory);
       TIOFeatures saved_features = fIOFeatures;
-      if (info->fIOFeatures) {
-         fIOFeatures = *(info->fIOFeatures);
-      }
       TTree *newtree = CloneTree(-1, options);
-      fIOFeatures = saved_features;
+      if (info->fIOFeatures)
+         fIOFeatures = *(info->fIOFeatures);
+      else
+         fIOFeatures = saved_features;
       if (newtree) {
          newtree->Write();
          delete newtree;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -9614,6 +9614,8 @@ void TTree::UseCurrentStyle()
 Int_t TTree::Write(const char *name, Int_t option, Int_t bufsize) const
 {
    FlushBasketsImpl();
+   if (R__unlikely(option & kOnlyPrepStep))
+      return 0;
    return TObject::Write(name, option, bufsize);
 }
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -9364,13 +9364,11 @@ static void TBranch__SetTree(TTree *tree, TObjArray &branches)
       TBranch* br = (TBranch*) branches.UncheckedAt(i);
       br->SetTree(tree);
 
-      Int_t nBaskets = br->GetListOfBaskets()->GetEntries();
       Int_t writeBasket = br->GetWriteBasket();
-      for (Int_t j=writeBasket,n=0;j>=0 && n<nBaskets;--j) {
+      for (Int_t j = writeBasket; j >= 0; --j) {
          TBasket *bk = (TBasket*)br->GetListOfBaskets()->UncheckedAt(j);
          if (bk) {
             tree->IncrementTotalBuffers(bk->GetBufferSize());
-            ++n;
          }
       }
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6779,7 +6779,7 @@ TTree* TTree::MergeTrees(TList* li, Option_t* options)
       Long64_t nentries = tree->GetEntries();
       if (nentries == 0) continue;
       if (!newtree) {
-         newtree = (TTree*)tree->CloneTree();
+         newtree = (TTree*)tree->CloneTree(-1, options);
          if (!newtree) continue;
 
          // Once the cloning is done, separate the trees,

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -314,7 +314,7 @@ TTreeCache::TTreeCache(TTree *tree, Int_t buffersize)
      fBrNames(new TList), fTree(tree), fPrefillType(GetConfiguredPrefillType())
 {
    fEntryNext = fEntryMin + fgLearnEntries;
-   Int_t nleaves = tree->GetListOfLeaves()->GetEntries();
+   Int_t nleaves = tree->GetListOfLeaves()->GetEntriesFast();
    fBranches = new TObjArray(nleaves);
 }
 

--- a/tree/tree/src/TTreeCloner.cxx
+++ b/tree/tree/src/TTreeCloner.cxx
@@ -740,10 +740,11 @@ void TTreeCloner::WriteBaskets()
             if (fFileCache && j >= notCached) {
                notCached = FillCache(notCached);
             }
-            if (from->GetBasketBytes()[index] == 0) {
-               from->GetBasketBytes()[index] = basket->ReadBasketBytes(pos, fromfile);
-            }
             Int_t len = from->GetBasketBytes()[index];
+            if (len == 0) {
+               len = basket->ReadBasketBytes(pos, fromfile);
+               from->GetBasketBytes()[index] = len;
+            }
 
             basket->LoadBasketBuffers(pos,len,fromfile,fFromTree);
             basket->IncrementPidOffset(fPidOffset);

--- a/tree/tree/src/TTreeCloner.cxx
+++ b/tree/tree/src/TTreeCloner.cxx
@@ -521,7 +521,7 @@ void TTreeCloner::CopyMemoryBaskets()
       TBranch *to   = (TBranch*)fToBranches.UncheckedAt( i );
 
       basket = (!from->GetListOfBaskets()->IsEmpty()) ? from->GetBasket(from->GetWriteBasket()) : 0;
-      if (basket) {
+      if (basket && basket->GetNevBuf()) {
          basket = (TBasket*)basket->Clone();
          basket->SetBranch(to);
          to->AddBasket(*basket, kFALSE, fToStartEntries+from->GetBasketEntry()[from->GetWriteBasket()]);

--- a/tree/tree/src/TTreeCloner.cxx
+++ b/tree/tree/src/TTreeCloner.cxx
@@ -134,8 +134,8 @@ TTreeCloner::TTreeCloner(TTree *from, TTree *to, TDirectory *newdirectory, Optio
    fToDirectory(newdirectory),
    fToFile(fToDirectory ? fToDirectory->GetFile() : nullptr),
    fMethod(method),
-   fFromBranches( from ? from->GetListOfLeaves()->GetEntries()+1 : 0),
-   fToBranches( to ? to->GetListOfLeaves()->GetEntries()+1 : 0),
+   fFromBranches( from ? from->GetListOfLeaves()->GetEntriesFast()+1 : 0),
+   fToBranches( to ? to->GetListOfLeaves()->GetEntriesFast()+1 : 0),
    fMaxBaskets(CollectBranches()),
    fBasketBranchNum(new UInt_t[fMaxBaskets]),
    fBasketNum(new UInt_t[fMaxBaskets]),
@@ -264,7 +264,7 @@ void TTreeCloner::CloseOutWriteBaskets()
    if (IsInPlace())
       return;
 
-   for(Int_t i=0; i<fToBranches.GetEntries(); ++i) {
+   for(Int_t i=0; i<fToBranches.GetEntriesFast(); ++i) {
       TBranch *to = (TBranch*)fToBranches.UncheckedAt(i);
       to->FlushOneBasket(to->GetWriteBasket());
    }
@@ -286,8 +286,8 @@ UInt_t TTreeCloner::CollectBranches(TBranch *from, TBranch *to) {
       numBaskets += CollectBranches(fromclones->fBranchCount, toclones->fBranchCount);
 
    } else if (from->InheritsFrom(TBranchElement::Class())) {
-      Int_t nb = from->GetListOfLeaves()->GetEntries();
-      Int_t fnb = to->GetListOfLeaves()->GetEntries();
+      Int_t nb = from->GetListOfLeaves()->GetEntriesFast();
+      Int_t fnb = to->GetListOfLeaves()->GetEntriesFast();
       if (nb != fnb && (nb == 0 || fnb == 0)) {
          // We might be in the case where one branch is split
          // while the other is not split.  We must reject this match.
@@ -314,8 +314,8 @@ UInt_t TTreeCloner::CollectBranches(TBranch *from, TBranch *to) {
       if (fromelem->fMaximum > toelem->fMaximum) toelem->fMaximum = fromelem->fMaximum;
    } else {
 
-      Int_t nb = from->GetListOfLeaves()->GetEntries();
-      Int_t fnb = to->GetListOfLeaves()->GetEntries();
+      Int_t nb = from->GetListOfLeaves()->GetEntriesFast();
+      Int_t fnb = to->GetListOfLeaves()->GetEntriesFast();
       if (nb != fnb) {
          fWarningMsg.Form("The export branch and the import branch (%s) do not have the same number of leaves (%d vs %d)",
                           from->GetName(), fnb, nb);
@@ -366,8 +366,8 @@ UInt_t TTreeCloner::CollectBranches(TObjArray *from, TObjArray *to)
 {
    // Since this is called from the constructor, this can not be a virtual function
 
-   Int_t fnb = from->GetEntries();
-   Int_t tnb = to->GetEntries();
+   Int_t fnb = from->GetEntriesFast();
+   Int_t tnb = to->GetEntriesFast();
    if (!fnb || !tnb) {
       return 0;
    }
@@ -450,7 +450,7 @@ UInt_t TTreeCloner::CollectBranches()
 
 void TTreeCloner::CollectBaskets()
 {
-   UInt_t len = fFromBranches.GetEntries();
+   UInt_t len = fFromBranches.GetEntriesFast();
 
    for(UInt_t i=0,bi=0; i<len; ++i) {
       TBranch *from = (TBranch*)fFromBranches.UncheckedAt(i);
@@ -516,11 +516,11 @@ void TTreeCloner::CopyMemoryBaskets()
       return;
 
    TBasket *basket = 0;
-   for(Int_t i=0; i<fToBranches.GetEntries(); ++i) {
+   for(Int_t i=0; i<fToBranches.GetEntriesFast(); ++i) {
       TBranch *from = (TBranch*)fFromBranches.UncheckedAt( i );
       TBranch *to   = (TBranch*)fToBranches.UncheckedAt( i );
 
-      basket = from->GetListOfBaskets()->GetEntries() ? from->GetBasket(from->GetWriteBasket()) : 0;
+      basket = (!from->GetListOfBaskets()->IsEmpty()) ? from->GetBasket(from->GetWriteBasket()) : 0;
       if (basket) {
          basket = (TBasket*)basket->Clone();
          basket->SetBranch(to);

--- a/tree/tree/src/TTreeCloner.cxx
+++ b/tree/tree/src/TTreeCloner.cxx
@@ -110,7 +110,7 @@ TTreeCloner::TTreeCloner(TTree *from, TTree *to, Option_t *method, UInt_t option
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.  In place cloning.
 //// This object would transfer the data from
-/// 'from' the original location to 'to' the new directory
+/// 'from' the original location to 'newdirectory' the new directory
 /// using the sorting method indicated in method.
 /// It updates the 'from' TTree with the new information.
 /// See TTreeCloner::TTreeCloner(TTree *from, TTree *to, Option_t *method, UInt_t options)


### PR DESCRIPTION
This set of improvements to TBufferMerger (and more) was inspired by the terrible performance of the parallel merging (and fast merging in general) in the case where the TTree has a very large number of branches (1000+).

Where in the original version a TBufferMerger with a file with 1000+ branches and only 50s and ran with any number of threads would take more than 3m (did not wait until the end) the new version takes 11s with 1 thread, 8s with 6 threads and 22s with 6 thread when increased to 500 events. (using the CMS file ../data//250202_181_RECO.root).

This PR includes:

* skipping the boxing/compressing/uncompressing/unboxing cycle if the TBufferMerger is available (not already merging) when the thread is writing its TMemFile.

* skipping SetBranchAddress and SetMakeClass in when doing fast cloning (where that information is not used anyway).

* Replacing calling to the slow TObjArray::GetEntries (which *counts* the slot used) by calling GetEntriesFast.

* Speeding up the GetMother implementation (caching parent's address sooner when reading, use that information in GetMother).

* In fast cloning, delay writing the output until the last input is processed (instead of writing the output after each input),

* Optimization of fast cloning handing of empty write basket.


It also contains a couple of bug fixes (RNtuple merging forgetting to merge the result of the objects in the file, iofeatures incorrectly cloned).

Also made TBufferMerger::GetQueueSize actually thread safe (it is necessary to use it to stop the producer from adding more data if the queue is too full).

Also improved TClass::GetBaseClassOffset parallelism (benefit parallel boxing/unboxing) and reduced/removed contention see in the mechanism use to determine the actual object type at run-time (TIsAProxy).





