### PR TITLE
Add `ACLiC.LinkLibs: 1` in the `.rootrc` file for Windows

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -53,6 +53,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/rootlogoff.C "{}")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/.rootrc "
 Proof.Sandbox: /tmp/proof
 Rint.History:  .root_hist
+ACLiC.LinkLibs:  1
 ")
 
 #---Definition of the helper function--------------------------------


### PR DESCRIPTION
This fixes re-running tests on Windows. According to [the documentation](https://github.com/root-project/root/blob/master/config/rootrc.in#L384-L390), this is already the default for the other platforms, while the default is 3 for Windows.