### PR TITLE
[metacling] Specify the class of the called function (#6637):

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -447,6 +447,7 @@ void TClingCallFunc::make_narg_call(const std::string &return_type, const unsign
          callbuf << "((const " << class_name << "*)obj)->";
       else
          callbuf << "((" << class_name << "*)obj)->";
+      callbuf << class_name << "::";
    } else if (const NamedDecl *ND =
                  dyn_cast<NamedDecl>(GetDeclContext())) {
       // This is a namespace member.


### PR DESCRIPTION
When invoking virtual functions, TClingCallFunc is told which class
to call that function on. It is unclear whether havoc will break
loose from this change because uses expect to evaluate the vtable
when invoking a function on a base class, or whether (as in #6637)
that exact function of the class should be invoked. I.e. change from
invoking `((Klass*)obj)->VirtFunc()` to `((Klass*)obj)->Klass::VirtFunc()`
which does not anymore call `VirtFun()` overridden by a class derived
from `Klass` that `obj` is pointing to.