### PR TITLE
Temporary change to debug assertion failure on Windows

### DIFF
--- a/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
@@ -435,7 +435,7 @@ namespace cling {
           << "in " << llvm::sys::path::filename(filename) << "\n"
           << "content[" << posOpenCurly << "] = \'"
           << content[posOpenCurly]
-          << "\'\n";
+          << "\'\n"
           << "content = \"" << content << "\"\n";
         assert(content[posOpenCurly] == '{');
       }

--- a/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
@@ -427,8 +427,17 @@ namespace cling {
     }
 
     if (posOpenCurly != (size_t)-1 && !content.empty()) {
-      assert(content[posOpenCurly] == '{'
-             && "No curly at claimed position of opening curly!");
+//      assert(content[posOpenCurly] == '{'
+//             && "No curly at claimed position of opening curly!");
+      if (content[posOpenCurly] != '{') {
+        cling::errs()
+          << "cling::MetaProcessor: No curly at claimed position of opening curly!\n"
+          << "in " << llvm::sys::path::filename(filename) << "\n"
+          << "content[" << posOpenCurly << "] = "
+          << content[posOpenCurly]
+          << "\n";
+        assert(content[posOpenCurly] == '{');
+      }
       // hide the curly brace:
       content[posOpenCurly] = ' ';
       // and the matching closing '}'

--- a/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
@@ -433,9 +433,10 @@ namespace cling {
         cling::errs()
           << "cling::MetaProcessor: No curly at claimed position of opening curly!\n"
           << "in " << llvm::sys::path::filename(filename) << "\n"
-          << "content[" << posOpenCurly << "] = "
+          << "content[" << posOpenCurly << "] = \'"
           << content[posOpenCurly]
-          << "\n";
+          << "\'\n";
+          << "content = \"" << content << "\"\n";
         assert(content[posOpenCurly] == '{');
       }
       // hide the curly brace:


### PR DESCRIPTION
Try to print some hints about why there is this: `Assertion failed: content[posOpenCurly] == '{' && "No curly at claimed position of opening curly!"`