### PR TITLE
The Sema::LookupConstructor is not iteration safe.

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/AST/DeclContextInternals.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/AST/DeclContextInternals.h
@@ -33,7 +33,7 @@ class DependentDiagnostic;
 /// one entry.
 struct StoredDeclsList {
   /// When in vector form, this is what the Data pointer points to.
-  using DeclsTy = SmallVector<NamedDecl *, 8>;
+  using DeclsTy = SmallVector<NamedDecl *, 32>;
 
   /// A collection of declarations, with a flag to indicate if we have
   /// further external declarations.


### PR DESCRIPTION
When looking up a ctor the modules infrasturcture deserializes more ctor
candidates in the body of the function causing the internal vector implementation
to rellocate and invalidate the pointers.

This workaround should address the failures reported by LCG.

The real fix is being processed here https://reviews.llvm.org/D91524 and we
after being merged we should be able to backport it.