### PR TITLE
[cxxmodules] Allow submodules to contain headers which may be missing.

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -309,7 +309,7 @@ module "std" [system] {
     header "string"
   }
   module "string_view" {
-    requires cplusplus17, !header_existence
+    requires !header_existence
     export *
     textual header "string_view"
   }

--- a/interpreter/llvm/src/tools/clang/lib/Basic/Module.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Basic/Module.cpp
@@ -104,7 +104,7 @@ static bool isPlatformEnvironment(const TargetInfo &Target, StringRef Feature) {
 /// Determine whether a translation unit built using the current
 /// language options has the given feature.
 static bool hasFeature(StringRef Feature, const LangOptions &LangOpts,
-                       const TargetInfo &Target) {
+                       const TargetInfo &Target, bool HasMissingHeaders) {
   bool HasFeature = llvm::StringSwitch<bool>(Feature)
                         .Case("altivec", LangOpts.AltiVec)
                         .Case("blocks", LangOpts.Blocks)
@@ -121,6 +121,7 @@ static bool hasFeature(StringRef Feature, const LangOptions &LangOpts,
                         .Case("objc", LangOpts.ObjC)
                         .Case("objc_arc", LangOpts.ObjCAutoRefCount)
                         .Case("opencl", LangOpts.OpenCL)
+                        .Case("header_existence", !HasMissingHeaders)
                         .Case("tls", Target.isTLSSupported())
                         .Case("zvector", LangOpts.ZVector)
                         .Default(Target.hasFeature(Feature) ||
@@ -144,14 +145,16 @@ bool Module::isAvailable(const LangOptions &LangOpts, const TargetInfo &Target,
       ShadowingModule = Current->ShadowingModule;
       return false;
     }
+    bool HasMissingHeaders = !Current->MissingHeaders.empty();
     for (unsigned I = 0, N = Current->Requirements.size(); I != N; ++I) {
-      if (hasFeature(Current->Requirements[I].first, LangOpts, Target) !=
-              Current->Requirements[I].second) {
+      if (hasFeature(Current->Requirements[I].first, LangOpts, Target,
+                     HasMissingHeaders) !=
+          Current->Requirements[I].second) {
         Req = Current->Requirements[I];
         return false;
       }
     }
-    if (!Current->MissingHeaders.empty()) {
+    if (HasMissingHeaders) {
       MissingHeader = Current->MissingHeaders.front();
       return false;
     }
@@ -279,7 +282,8 @@ void Module::addRequirement(StringRef Feature, bool RequiredState,
   Requirements.push_back(Requirement(Feature, RequiredState));
 
   // If this feature is currently available, we're done.
-  if (hasFeature(Feature, LangOpts, Target) == RequiredState)
+  if (hasFeature(Feature, LangOpts, Target, !MissingHeaders.empty()) ==
+      RequiredState)
     return;
 
   markUnavailable(/*MissingRequirement*/true);


### PR DESCRIPTION
This allows us to use a single modulemap file across multiple libstdc++
versions and gives us a way forward to deal with deprecated files.

This patch will be submitted for a review upstream. It fixes our
gcc 4.8 builds where codecvt, cuchar and string_view header files do not exist.