### PR TITLE
Fix TGraph copy constructor and assign operator (#7302) [6.22]

### DIFF
--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -162,8 +162,12 @@ TGraph::TGraph(const TGraph &gr)
    fMaxSize = gr.fMaxSize;
    if (gr.fFunctions) fFunctions = (TList*)gr.fFunctions->Clone();
    else fFunctions = new TList;
-   if (gr.fHistogram) fHistogram = (TH1F*)gr.fHistogram->Clone();
-   else fHistogram = 0;
+   if (gr.fHistogram) {
+      fHistogram = (TH1F*)gr.fHistogram->Clone();
+      fHistogram->SetDirectory(nullptr);
+   } else {
+      fHistogram = nullptr;
+   }
    fMinimum = gr.fMinimum;
    fMaximum = gr.fMaximum;
    if (!fMaxSize) {
@@ -213,8 +217,12 @@ TGraph& TGraph::operator=(const TGraph &gr)
       else fFunctions = new TList;
 
       if (fHistogram) delete fHistogram;
-      if (gr.fHistogram) fHistogram = new TH1F(*(gr.fHistogram));
-      else fHistogram = 0;
+      if (gr.fHistogram) {
+         fHistogram = new TH1F(*(gr.fHistogram));
+         fHistogram->SetDirectory(nullptr);
+      } else {
+         fHistogram = nullptr;
+      }
 
       fMinimum = gr.fMinimum;
       fMaximum = gr.fMaximum;


### PR DESCRIPTION
Cloned histogram should not be assign to current directory