### PR TITLE
Fix build time on Windows when nothing changed in the code

### DIFF
--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -43,7 +43,7 @@ if(imt)
     DEPENDENCIES
       Core
       Thread
-      MultiProc
+      ${MULTIPROC_LIB}
     BUILTINS
       TBB
   )
@@ -69,7 +69,7 @@ else()
       Imt
     DEPENDENCIES
       Core
-      MultiProc
+      ${MULTIPROC_LIB}
   )
 endif()
 


### PR DESCRIPTION
Without this patch, CMake was always re-generating G__Imt.cxx, the re-buildding Core, and re-generating all the dictionaries, extending the build time from around two minutes to more than 30 minutes when nothing changed in the code.