### PR TITLE
[RF] ActionHelper for RDF

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -50,7 +50,19 @@ The following people have contributed to this new version:
 
 
 ## RooFit Libraries
-
+### Creating RooFit datasets from RDataFrame
+RooFit now contains two RDataFrame action helpers, `RooDataSetHelper` and `RooDataHistHelper`, which allow for creating RooFit datasets by booking an action:
+```c++
+  RooRealVar x("x", "x", -5.,   5.);
+  RooRealVar y("y", "y", -50., 50.);
+  auto myDataSet = rdataframe.Book<double, double>(
+    RooDataSetHelper{"dataset",          // Name   (directly forwarded to RooDataSet::RooDataSet())
+                    "Title of dataset",  // Title  (                   ~ " ~                      )
+                    RooArgSet(x, y) },   // Variables to create in dataset
+    {"x", "y"}                           // Column names from RDataFrame
+  );
+```
+For more details, consult the tutorial [rf408_RDataFrameToRooFit](https://root.cern/doc/v626/rf408__RDataFrameToRooFit_8C.html).
 
 ## 2D Graphics Libraries
 

--- a/math/mathcore/inc/Math/Util.h
+++ b/math/mathcore/inc/Math/Util.h
@@ -230,6 +230,14 @@ namespace ROOT {
          return *this;
        }
 
+       /// Add `arg` into accumulator. Does not vectorise.
+       template<typename U>
+       KahanSum& operator+=(const KahanSum<U>& arg) {
+         Add(arg.Sum());
+         fCarry[0] += arg.Carry();
+         return *this;
+       }
+
      private:
        T fSum[N];
        T fCarry[N];

--- a/roofit/CMakeLists.txt
+++ b/roofit/CMakeLists.txt
@@ -14,3 +14,5 @@ add_subdirectory(roostats)
 if(xml)
   add_subdirectory(histfactory)
 endif()
+add_subdirectory(RDataFrameHelpers)
+

--- a/roofit/RDataFrameHelpers/CMakeLists.txt
+++ b/roofit/RDataFrameHelpers/CMakeLists.txt
@@ -26,3 +26,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitRDataFrameHelpers
     RooFitCore
 )
 
+ROOT_ADD_TEST_SUBDIRECTORY(test)
+
+

--- a/roofit/RDataFrameHelpers/CMakeLists.txt
+++ b/roofit/RDataFrameHelpers/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.
+# All rights reserved.
+#
+# For the licensing terms see $ROOTSYS/LICENSE.
+# For the list of contributors see $ROOTSYS/README/CREDITS.
+
+############################################################################
+# CMakeLists.txt for registering a RooFit RDataFrameHelper
+############################################################################
+
+# This library enables compatibility of RooFit and RDataFrame.
+# Since these two packages don't know about each other, we connect them here.
+
+if(NOT dataframe)
+  return()
+endif()
+
+ROOT_STANDARD_LIBRARY_PACKAGE(RooFitRDataFrameHelpers
+  HEADERS
+    RooAbsDataHelper.h
+  NO_SOURCES
+  LINKDEF
+    LinkDef.h
+  DEPENDENCIES
+    ROOTDataFrame
+    RooFitCore
+)
+

--- a/roofit/RDataFrameHelpers/inc/LinkDef.h
+++ b/roofit/RDataFrameHelpers/inc/LinkDef.h
@@ -1,0 +1,6 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+
+#endif

--- a/roofit/RDataFrameHelpers/inc/RooAbsDataHelper.h
+++ b/roofit/RDataFrameHelpers/inc/RooAbsDataHelper.h
@@ -1,0 +1,179 @@
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * Package: RooFitCore                                                       *
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2021, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+/// Create RooDataSet/RooDataHist from RDataFrame.
+/// \date Mar 2021
+/// \author Stephan Hageboeck (CERN)
+#ifndef ROOABSDATAHELPER
+#define ROOABSDATAHELPER
+
+#include <RooRealVar.h>
+#include <RooArgSet.h>
+#include <RooDataSet.h>
+#include <RooDataHist.h>
+
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RDF/ActionHelpers.hxx>
+#include <TROOT.h>
+
+#include <vector>
+#include <mutex>
+#include <memory>
+#include <cstddef>
+#include <string>
+#include <stdexcept>
+
+class TTreeReader;
+
+/// This is a helper for an RDataFrame action, which fills RooFit data classes.
+///
+/// \tparam DataSet_t Either RooDataSet or RooDataHist.
+///
+/// To construct RooDataSet / RooDataHist within RDataFrame
+/// - Construct one of the two action helpers RooDataSetHelper or RooDataHistHelper. Pass constructor arguments
+///   to RooAbsDataHelper::RooAbsDataHelper() as for the original classes.
+///   The arguments are forwarded to the actual data classes without any changes.
+/// - Book the helper as an RDataFrame action. Here, the RDataFrame column types have to be passed as template parameters.
+/// - Pass the column names to the Book action. These are matched by position to the variables of the dataset.
+///
+/// All arguments passed to  are forwarded to RooDataSet::RooDataSet() / RooDataHist::RooDataHist().
+///
+/// #### Usage example:
+/// ```
+///    RooRealVar x("x", "x", -5.,   5.);
+///    RooRealVar y("y", "y", -50., 50.);
+///    auto myDataSet = rdataframe.Book<double, double>(
+///      RooDataSetHelper{"dataset",          // Name   (directly forwarded to RooDataSet::RooDataSet())
+///                      "Title of dataset",  // Title  (                   ~ " ~                      )
+///                      RooArgSet(x, y) },   // Variables to create in dataset
+///      {"x", "y"}                           // Column names from RDataFrame
+///    );
+///
+/// ```
+/// \warning Variables in the dataset and columns in RDataFrame are **matched by position, not by name**.
+/// This enables the easy exchanging of columns that should be filled into the dataset.
+template<class DataSet_t>
+class RooAbsDataHelper : public ROOT::Detail::RDF::RActionImpl<RooAbsDataHelper<DataSet_t>> {
+public:
+  using Result_t = DataSet_t;
+
+private:
+  std::shared_ptr<DataSet_t> _dataset;
+  std::mutex _mutex_dataset;
+
+  std::vector<std::vector<double>> _events; // One vector of values per data-processing slot
+  const std::size_t _eventSize; // Number of variables in dataset
+
+public:
+
+  /// Construct a helper to create RooDataSet/RooDataHist.
+  /// \tparam Args_t Parameter pack of arguments.
+  /// \param args Constructor arguments for RooDataSet::RooDataSet() or RooDataHist::RooDataHist().
+  /// All arguments will be forwarded as they are.
+  template<typename... Args_t>
+  RooAbsDataHelper(Args_t&&... args) :
+  _dataset{ new DataSet_t(std::forward<Args_t>(args)...) },
+  _eventSize{ _dataset->get()->size() }
+  {
+    const auto nSlots = ROOT::IsImplicitMTEnabled() ? ROOT::GetThreadPoolSize() : 1;
+    _events.resize(nSlots);
+  }
+
+
+  /// Move constructor. It transfers ownership of the internal RooAbsData object.
+  RooAbsDataHelper(RooAbsDataHelper&& other) :
+  _dataset{ std::move(other._dataset) },
+  _mutex_dataset(),
+  _events{ std::move(other._events) },
+  _eventSize{ other._eventSize }
+  {
+
+  }
+
+  /// Copy is discouraged.
+  /// Use `rdataframe.Book<...>(std::move(absDataHelper), ...)` instead.
+  RooAbsDataHelper(const RooAbsDataHelper&) = delete;
+  /// Return internal dataset/hist.
+  std::shared_ptr<DataSet_t> GetResultPtr() const { return _dataset; }
+  /// RDataFrame interface method. Nothing has to be initialised.
+  void Initialize() {}
+  /// RDataFrame interface method. No tasks.
+  void InitTask(TTreeReader *, unsigned int) {}
+  /// RDataFrame interface method.
+  std::string GetActionName() { return "RooDataSetHelper"; }
+
+  /// Method that RDataFrame calls to pass a new event.
+  ///
+  /// \param slot When IMT is used, this is a number in the range [0, nSlots) to fill lock free.
+  /// \param values x, y, z, ... coordinates of the event.
+  template <typename... ColumnTypes>
+  void Exec(unsigned int slot, ColumnTypes... values)
+  {
+    if (sizeof...(values) != _eventSize) {
+      throw std::invalid_argument(std::string("RooDataSet can hold ")
+      + std::to_string(_eventSize)
+      + " variables per event, but RDataFrame passed "
+      + std::to_string(sizeof...(values))
+      + " columns.");
+    }
+
+    auto& vector = _events[slot];
+    for (auto&& val : {values...}) {
+      vector.push_back(val);
+    }
+
+    if (vector.size() > 1024 && _mutex_dataset.try_lock()) {
+      const std::lock_guard<std::mutex> guard(_mutex_dataset, std::adopt_lock_t());
+      FillDataSet(vector, _eventSize);
+      vector.clear();
+    }
+  }
+
+  /// Empty all buffers into the dataset/hist to finish processing.
+  void Finalize() {
+    for (auto& vector : _events) {
+      FillDataSet(vector, _eventSize);
+      vector.clear();
+    }
+  }
+
+
+private:
+  /// Append all `events` to the internal RooDataSet or increment the bins of a RooDataHist at the given locations.
+  ///
+  /// \param events Events to fill into `data`. The layout is assumed to be `(x, y, z, ...) (x, y, z, ...), (...)`.
+  /// \note The order of the variables inside `events` must be consistent with the order given in the constructor.
+  /// No matching by name is performed.
+  /// \param eventSize Size of a single event.
+  void FillDataSet(const std::vector<double>& events, unsigned int eventSize) {
+    if (events.size() == 0)
+      return;
+
+    const RooArgSet& argSet = *_dataset->get();
+
+    for (std::size_t i = 0; i < events.size(); i += eventSize) {
+      for (std::size_t j=0; j < eventSize; ++j) {
+        static_cast<RooAbsRealLValue*>(argSet[j])->setVal(events[i+j]);
+      }
+      _dataset->add(argSet);
+    }
+  }
+};
+
+/// Helper for creating a RooDataSet inside RDataFrame. \see RooAbsDataHelper
+using RooDataSetHelper = RooAbsDataHelper<RooDataSet>;
+/// Helper for creating a RooDataHist inside RDataFrame. \see RooAbsDataHelper
+using RooDataHistHelper = RooAbsDataHelper<RooDataHist>;
+
+#endif

--- a/roofit/RDataFrameHelpers/test/CMakeLists.txt
+++ b/roofit/RDataFrameHelpers/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+ROOT_ADD_GTEST(testActionHelpers testActionHelpers.cxx LIBRARIES RooFitRDataFrameHelpers)

--- a/roofit/RDataFrameHelpers/test/testActionHelpers.cxx
+++ b/roofit/RDataFrameHelpers/test/testActionHelpers.cxx
@@ -1,0 +1,82 @@
+/// Test the action helpers that fill roofit datasets from RDataFrame.
+///
+/// \date Mar 2021
+/// \author Stephan Hageboeck (CERN)
+
+#include <RooAbsDataHelper.h>
+
+#include <TROOT.h>
+#include <TRandom3.h>
+
+#include "gtest/gtest.h"
+
+#include <vector>
+
+TEST(RooAbsDataHelper, MTConstruction)
+{
+#ifdef R__USE_IMT
+  ROOT::EnableImplicitMT(4);
+#endif
+
+  const auto nSlots = ROOT::IsImplicitMTEnabled() ? ROOT::GetThreadPoolSize() : 1;
+  std::vector<TRandom3> rngs(nSlots);
+  for (unsigned int i=0; i < rngs.size(); ++i) {
+    rngs[i].SetSeed(i+1);
+  }
+
+  // We create an RDataFrame with two columns filled with 2 million random numbers.
+  constexpr std::size_t nEvent = 200000;
+  ROOT::RDataFrame d(nEvent);
+  auto dd = d.DefineSlot("x", [&rngs](unsigned int slot){ return rngs[slot].Uniform(-5.,  5.); })
+             .DefineSlot("y", [&rngs](unsigned int slot){ return rngs[slot].Gaus(1., 3.); });
+  auto meanX = dd.Mean("x");
+  auto meanY = dd.Mean("y");
+
+
+  // We create RooFit variables that will represent the dataset.
+  RooRealVar x("x", "x", -5.,   5.);
+  RooRealVar y("y", "y", -50., 50.);
+  x.setBins(10);
+  y.setBins(20);
+
+
+  auto rooDataSet = dd.Book<double, double>(
+      RooDataSetHelper("dataset", // Name
+          "Title of dataset",     // Title
+          RooArgSet(x, y)         // Variables in this dataset
+          ),
+      {"x", "y"}                  // Column names in RDataFrame.
+  );
+
+  RooDataHistHelper rdhMaker{"datahist",  // Name
+    "Title of data hist",                 // Title
+    RooArgSet(x, y)                       // Variables in this dataset
+  };
+
+  // Then, we move it into the RDataFrame action:
+  auto rooDataHist = dd.Book<double, double>(std::move(rdhMaker), {"x", "y"});
+
+
+
+  // Run it and inspect the results
+  // -------------------------------
+  EXPECT_NEAR(meanX.GetValue(), 0., 1.E-2); // Pretty bad accuracy, but might be the RNG or summation in RDF
+  EXPECT_NEAR(meanY.GetValue(), 1., 1.E-2);
+
+  constexpr double goodPrecision = 1.E-9;
+  constexpr double middlePrecision = 3.E-3;
+  constexpr double badPrecision = 2.E-2;
+  ASSERT_EQ(rooDataSet->numEntries(), nEvent);
+  EXPECT_NEAR(rooDataSet->sumEntries(), nEvent, nEvent * goodPrecision);
+  EXPECT_NEAR(rooDataSet->mean(x),  meanX.GetValue(), goodPrecision);
+  EXPECT_NEAR(rooDataSet->moment(x, 2.), 100./12., 100./12. * middlePrecision);
+  EXPECT_NEAR(rooDataSet->mean(y),  meanY.GetValue(), goodPrecision);
+  EXPECT_NEAR(rooDataSet->moment(y, 2.), 3.*3., 3.*3. * badPrecision);
+
+  EXPECT_NEAR(rooDataHist->sumEntries(), nEvent, nEvent * goodPrecision);
+  EXPECT_NEAR(rooDataHist->mean(x),  meanX.GetValue(), badPrecision);
+  EXPECT_NEAR(rooDataHist->moment(x, 2.), 100./12., 100./12. * badPrecision);
+  EXPECT_NEAR(rooDataHist->mean(y),  meanY.GetValue(), badPrecision);
+  EXPECT_NEAR(std::sqrt(rooDataHist->moment(y, 2.)), 3., 0.4); // Sigma is hard to measure in a binned distribution
+}
+

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -62,6 +62,7 @@ points for its contents and provides an iterator over its elements
 #include "TH1.h"
 #include "TH2.h"
 #include "TH3.h"
+#include "Math/Util.h"
 
 
 using namespace std;
@@ -883,15 +884,15 @@ Double_t RooAbsData::moment(const RooRealVar& var, Double_t order, Double_t offs
 
 
   // Calculate requested moment
-  Double_t sum(0);
-  const RooArgSet* vars ;
+  ROOT::Math::KahanSum<double> sum;
   for(Int_t index= 0; index < numEntries(); index++) {
-    vars = get(index) ;
+    const RooArgSet* vars = get(index) ;
     if (select && select->eval()==0) continue ;
     if (cutRange && vars->allInRange(cutRange)) continue ;
 
-    sum+= weight() * TMath::Power(varPtr->getVal() - offset,order);
+    sum += weight() * TMath::Power(varPtr->getVal() - offset,order);
   }
+
   return sum/sumEntries(cutSpec, cutRange);
 }
 

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -22,6 +22,24 @@
 The RooDataHist is a container class to hold N-dimensional binned data. Each bin's central
 coordinates in N-dimensional space are represented by a RooArgSet containing RooRealVar, RooCategory
 or RooStringVar objects, thus data can be binned in real and/or discrete dimensions.
+
+There is an unbinned equivalent, RooDataSet.
+
+### Inspecting a datahist
+Inspect a datahist using Print() to get the coordinates and `weight()` to get the bin contents:
+```
+datahist->Print("V");
+datahist->get(0)->Print("V"); std::cout << "w=" << datahist->weight(0) << std::endl;
+datahist->get(1)->Print("V"); std::cout << "w=" << datahist->weight(1) << std::endl;
+...
+```
+
+### Plotting data.
+See RooAbsData::plotOn().
+
+### Creating a datahist using RDataFrame
+\see RooAbsDataHelper, rf408_RDataFrameToRooFit.C
+
 **/
 
 #include "RooDataHist.h"

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -67,6 +67,10 @@ being read stays in RAM.
 
 For the inverse conversion, see `RooAbsData::convertToVectorStore()`.
 
+
+### Creating a dataset using RDataFrame
+\see RooAbsDataHelper, rf408_RDataFrameToRooFit.C
+
 **/
 
 #include "RooDataSet.h"

--- a/tutorials/roofit/rf408_RDataFrameToRooFit.C
+++ b/tutorials/roofit/rf408_RDataFrameToRooFit.C
@@ -1,0 +1,101 @@
+/// \file
+/// \ingroup tutorial_roofit
+/// \notebook
+/// Fill RooDataSet/RooDataHist in RDataFrame.
+///
+/// This tutorial shows how to fill RooFit data classes directly from RDataFrame.
+/// Using two small helpers, we tell RDataFrame where the data has to go.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date Mar 2021
+/// \author Stephan Hageboeck (CERN)
+
+#include <RooAbsDataHelper.h>
+
+#include <TROOT.h>
+#include <TRandom.h>
+
+#include <initializer_list>
+
+void rf408_RDataFrameToRooFit()
+{
+  // Set up
+  // ------------------------
+
+  // We enable implicit parallelism, so RDataFrame runs in parallel.
+  ROOT::EnableImplicitMT();
+
+  // We create an RDataFrame with two columns filled with 2 million random numbers.
+  ROOT::RDataFrame d(2000000);
+  auto dd = d.Define("x", [](){ return gRandom->Uniform(-5.,  5.); })
+             .Define("y", [](){ return gRandom->Gaus(1., 3.); });
+
+
+  // We create RooFit variables that will represent the dataset.
+  RooRealVar x("x", "x", -5.,   5.);
+  RooRealVar y("y", "y", -50., 50.);
+  x.setBins(10);
+  y.setBins(20);
+
+
+
+  // Booking the creation of RooDataSet / RooDataHist in RDataFrame
+  // ----------------------------------------------------------------
+
+  // Method 1:
+  // We directly book the RooDataSetMaker action.
+  // We need to pass
+  // - the RDataFrame column types as template parameters
+  // - the constructor arguments for RooDataSet (they follow the same syntax as the usual RooDataSet constructors)
+  // - the column names that RDataFrame should fill into the dataset
+  //
+  // NOTE: RDataFrame columns are matched to RooFit variables by position, *not by name*!
+  auto rooDataSet = dd.Book<double, double>(
+      RooDataSetHelper("dataset", // Name
+          "Title of dataset",     // Title
+          RooArgSet(x, y)         // Variables in this dataset
+          ),
+      {"x", "y"}                  // Column names in RDataFrame.
+  );
+
+
+  // Method 2:
+  // We first declare the RooDataHistMaker
+  RooDataHistHelper rdhMaker{"datahist",  // Name
+    "Title of data hist",                 // Title
+    RooArgSet(x, y)                       // Variables in this dataset
+  };
+
+  // Then, we move it into the RDataFrame action:
+  auto rooDataHist = dd.Book<double, double>(std::move(rdhMaker), {"x", "y"});
+
+
+
+  // Run it and inspect the results
+  // -------------------------------
+
+  // Let's inspect the dataset / datahist.
+  // Note that the first time we touch one of those objects, the RDataFrame event loop will run.
+  for (const RooAbsData* data : std::initializer_list<const RooAbsData*>{rooDataSet.GetPtr(), rooDataHist.GetPtr()} ) {
+    std::cout << std::endl;
+    data->Print();
+
+    for (int i=0; i < data->numEntries() && i < 20; ++i) {
+      std::cout << "(";
+      for (auto var : *data->get(i)) {
+        std::cout << std::setprecision(3) << std::right << std::fixed << std::setw(8) << static_cast<const RooAbsReal*>(var)->getVal() << ", ";
+      }
+      std::cout << ")\tweight=" << std::setw(10) << data->weight() << std::endl;
+    }
+
+    std::cout << "mean(x) = " << data->mean(x) << "\tsigma(x) = " << std::sqrt(data->moment(x, 2.))
+      << "\n" << "mean(y) = " << data->mean(y) << "\tsigma(y) = " << std::sqrt(data->moment(y, 2.)) << std::endl;
+  }
+}
+
+int main() {
+  rf408_RDataFrameToRooFit();
+  return 0;
+}


### PR DESCRIPTION
To facilitate the creation of RooFit datasets from RDataFrame, an
ActionHelper is added to RooFit.
It lives in its own mini library, because it depends on RDF, which RooFit is not.

This adresses #7223, but weighted filling is missing, so I'm not closing that.