### PR TITLE
[TMVA] Add capability to pass optimizer options in training string for MethodDL.

### DIFF
--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -81,6 +81,7 @@ struct TTrainingSettings {
    Double_t momentum;
    Double_t weightDecay;
    std::vector<Double_t> dropoutProbabilities;
+   std::map<TString,double> optimizerParams;
    bool multithreading;
 };
 

--- a/tutorials/tmva/TMVA_Higgs_Classification.C
+++ b/tutorials/tmva/TMVA_Higgs_Classification.C
@@ -256,7 +256,8 @@ We can then book the DL method using the built option string
       TString training1("LearningRate=1e-3,Momentum=0.9,"
                         "ConvergenceSteps=10,BatchSize=128,TestRepetitions=1,"
                         "MaxEpochs=30,WeightDecay=1e-4,Regularization=None,"
-                        "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.");
+                        "Optimizer=ADAM,ADAM_beta1=0.9,ADAM_beta2=0.999,ADAM_eps=1.E-7," // ADAM default parameters
+                        "DropConfig=0.0+0.0+0.0+0.");
       //     TString training2("LearningRate=1e-3,Momentum=0.9"
       //                       "ConvergenceSteps=10,BatchSize=128,TestRepetitions=1,"
       //                       "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"


### PR DESCRIPTION
With this PR one can setup the options for the ADAM minimizer,
ADAM_beta1, ADAM_beta2 and ADAM_eps.
Example is provided in the TMVA_Higgs_Classification.C tutorial

This has been requested in https://root-forum.cern.ch/t/setting-adam-optimizer-parameters/43450