### PR TITLE
[eve7] implement cleanup of GLViewer [skip-ci]

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -1,15 +1,22 @@
 # JSROOT changelog
 
 ## Changes in dev
-1. Fix problem with matrixes in eve geometries (#206)
 2. Fix problem with TF1 drawing from histogram list of primitives
 3. Let disable showing of StreamerInfo in the GUI by adding &skipsi to URL
 4. Support drawing produced by TRatioPlot, including interactive zooming
 5. Provide tooltips when TH1 drawn with "E" or "P" option
+6. Fix problem with zooming of many overlayed histograms
+7. API change -> PadPainter.zoom function returns Promise now
+
+
+## Changes in 6.0.1
+1. Fix problem with matrix calculations in Eve classes (#206)
+2. Fix errors in TNodejsFile (#208)
+3. Fix TGraph tooltips handling
+4. Fix TH2Poly tooltips handling
 
 
 ## Changes in 6.0.0
-
 1. Major release with:
    - incompatible changes in API
    - heavy use of Promise class
@@ -53,7 +60,6 @@
 
 
 ## Changes in 5.9.1
-
 1. Fix zooming in color palette
 2. Fix interactive update of TGraph painting on time scale
 3. Fix I/O error in reading std::map (#204)

--- a/js/scripts/JSRoot.base3d.js
+++ b/js/scripts/JSRoot.base3d.js
@@ -118,10 +118,15 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
       let can3d = this.access3dKind(null);
       if (can3d < 0) {
          // remove first child from main element - if it is canvas
-         let main = this.selectDom().node();
-         if (main && main.firstChild && main.firstChild.$jsroot) {
-            delete main.firstChild.painter;
-            main.removeChild(main.firstChild);
+         let main = this.selectDom().node(),
+             chld = main ? main.firstChild : null;
+
+         if (chld && !chld.$jsroot)
+            chld = chld.nextSibling;
+
+         if (chld && chld.$jsroot) {
+            delete chld.painter;
+            main.removeChild(chld);
          }
          return can3d;
       }
@@ -638,8 +643,8 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
       }
 
       if (enable_zoom || enable_select) {
-         renderer.domElement.addEventListener( 'pointerdown', control_mousedown);
-         renderer.domElement.addEventListener( 'pointerup', control_mouseup);
+         renderer.domElement.addEventListener('pointerdown', control_mousedown);
+         renderer.domElement.addEventListener('pointerup', control_mouseup);
       }
 
       control = new THREE.OrbitControls(camera, renderer.domElement);
@@ -676,10 +681,10 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
 
       control.cleanup = function() {
          if (JSROOT.settings.Zooming && JSROOT.settings.ZoomWheel)
-            this.domElement.removeEventListener( 'wheel', control_mousewheel);
+            this.domElement.removeEventListener('wheel', control_mousewheel);
          if (this.enable_zoom || this.enable_select) {
-            this.domElement.removeEventListener( 'mousedown', control_mousedown);
-            this.domElement.removeEventListener( 'mouseup', control_mouseup);
+            this.domElement.removeEventListener('pointerdown', control_mousedown);
+            this.domElement.removeEventListener('pointerup', control_mouseup);
          }
 
          if (this.lstn_click)
@@ -983,7 +988,7 @@ JSROOT.define(['d3', 'threejs_jsroot', 'painter'], (d3, THREE, jsrp) => {
 
             // if normal event, set longer timeout waiting if double click not detected
             if (evnt.detail != 2)
-               this.single_click_tmout = setTimeout(this.ProcessClick.bind(this, this.getMousePos(evnt, {})), 300);
+               this.single_click_tmout = setTimeout(this.processClick.bind(this, this.getMousePos(evnt, {})), 300);
          }.bind(control);
       }
 

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "26/02/2021";
+   JSROOT.version_date = "1/03/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -1279,8 +1279,9 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       return false;
    }
 
+   /** @summary redraw pave object */
    TPavePainter.prototype.redraw = function() {
-      this.drawPave();
+      return this.drawPave();
    }
 
    TPavePainter.prototype.cleanup = function() {
@@ -5490,7 +5491,9 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       return cmd;
    }
 
-   TH2Painter.prototype.DrawPolyBinsColor = function() {
+   /** @summary draw TH2Poly as color
+     * @private */
+   TH2Painter.prototype.drawPolyBinsColor = function() {
       let histo = this.getObject(),
           pmain = this.getFramePainter(),
           h = pmain.getFrameHeight(),
@@ -6094,7 +6097,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       let handle = null;
 
       if (this.isTH2Poly()) {
-         handle = this.DrawPolyBinsColor();
+         handle = this.drawPolyBinsColor();
       } else {
          if (this.options.Scat)
             handle = this.drawBinsScatter();
@@ -6224,8 +6227,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          // process tooltips from TH2Poly
 
          let pmain = this.getFramePainter(), foundindx = -1, bin;
-         const realx = (pmain.grx === pmain.x) ? pmain.x.invert(pnt.x) : undefined,
-               realy = (pmain.gry === pmain.y) ? pmain.y.invert(pnt.y) : undefined;
+         const realx = pmain.revertAxis("x", pnt.x),
+               realy = pmain.revertAxis("y", pnt.y);
 
          if ((realx!==undefined) && (realy!==undefined)) {
             const len = histo.fBins.arr.length;

--- a/js/scripts/JSRoot.interactive.js
+++ b/js/scripts/JSRoot.interactive.js
@@ -1036,11 +1036,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          let kind = "xyz";
          if (!valid_x) kind = this.swap_xy ? "x" : "y"; else
          if (!valid_y) kind = this.swap_xy ? "y" : "x";
-         if (this.unzoom(kind)) return;
-
-         let pp = this.getPadPainter();
-         let rect = this.getFrameRect();
-         if (pp) pp.selectObjectPainter(pp, { x: m[0] + rect.x, y: m[1] + rect.y, dbl: true });
+         this.unzoom(kind).then(changed => {
+            if (changed) return;
+            let pp = this.getPadPainter(), rect = this.getFrameRect();
+            if (pp) pp.selectObjectPainter(pp, { x: m[0] + rect.x, y: m[1] + rect.y, dbl: true });
+         });
       },
 
       startTouchZoom: function(evnt) {

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -14,6 +14,11 @@ JSROOT.define(['d3'], (d3) => {
    else if (d3.version !== '6.1.1')
       console.log(`Reuse existing d3.js version ${d3.version}, expected 6.1.1`);
 
+
+   function isPromise(obj) {
+      return obj && (typeof obj == 'object') && (typeof obj.then == 'function');
+   }
+
    // ==========================================================================================
 
    /** @summary Draw options interpreter
@@ -2262,33 +2267,41 @@ JSROOT.define(['d3'], (d3) => {
 
    /** @summary indicate that redraw was invoked via interactive action (like context menu or zooming)
      * @desc Use to catch such action by GED and by server-side
+     * @returns {Promise} when completed
      * @private */
    ObjectPainter.prototype.interactiveRedraw = function(arg, info, subelem) {
 
-      let reason;
+      let reason, res;
       if ((typeof info == "string") && (info.indexOf("exec:") != 0)) reason = info;
       if (arg == "pad")
-         this.redrawPad(reason);
+         res = this.redrawPad(reason);
       else if (arg !== false)
-         this.redraw(reason);
+         res = this.redraw(reason);
 
-      // inform GED that something changes
-      let canp = this.getCanvPainter();
+      if (!isPromise(res)) res = Promise.resolve(false);
 
-      if (canp && (typeof canp.producePadEvent == 'function'))
-         canp.producePadEvent("redraw", this.getPadPainter(), this, null, subelem);
+      return res.then(() => {
+         // inform GED that something changes
+         let canp = this.getCanvPainter();
 
-      // inform server that drawopt changes
-      if (canp && (typeof canp.processChanges == 'function'))
-         canp.processChanges(info, this, subelem);
+         if (canp && (typeof canp.producePadEvent == 'function'))
+            canp.producePadEvent("redraw", this.getPadPainter(), this, null, subelem);
+
+         // inform server that drawopt changes
+         if (canp && (typeof canp.processChanges == 'function'))
+            canp.processChanges(info, this, subelem);
+
+         return this;
+      });
    }
 
    /** @summary Redraw all objects in the current pad
      * @param {string} [reason] - like 'resize' or 'zoom'
+     * @returns {Promise} when pad redraw completed
      * @protected */
    ObjectPainter.prototype.redrawPad = function(reason) {
       let pp = this.getPadPainter();
-      if (pp) pp.redraw(reason);
+      return pp ? pp.redrawPad(reason) : Promise.resolve(false);
    }
 
    /** @summary execute selected menu command, either locally or remotely
@@ -3599,10 +3612,6 @@ JSROOT.define(['d3'], (d3) => {
          }
 
          return Promise.reject(Error(`Function not specified to draw object ${type_info}`));
-      }
-
-      function isPromise(obj) {
-         return obj && (typeof obj == 'object') && (typeof obj.then == 'function');
       }
 
       function performDraw() {

--- a/js/scripts/JSRoot.v7hist.js
+++ b/js/scripts/JSRoot.v7hist.js
@@ -2723,7 +2723,9 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
       return cmd;
    }
 
-   RH2Painter.prototype.DrawPolyBinsColor = function() {
+   /** @summary draw TH2Poly as color
+     * @private */
+   RH2Painter.prototype.drawPolyBinsColor = function() {
       let histo = this.getHisto(),
           pmain = this.getFramePainter(),
           colPaths = [], textbins = [],
@@ -3307,7 +3309,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
       // if (this.lineatt.color == 'none') this.lineatt.color = 'cyan';
 
       if (this.isRH2Poly()) {
-         handle = this.DrawPolyBinsColor();
+         handle = this.drawPolyBinsColor();
       } else {
          if (this.options.Scat)
             handle = this.drawBinsScatter();
@@ -3442,8 +3444,8 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
          // process tooltips from TH2Poly
 
          let pmain = this.getFramePainter(), foundindx = -1, bin;
-         const realx = (pmain.grx === pmain.x) ? pmain.x.invert(pnt.x) : undefined,
-               realy = (pmain.gry === pmain.y) ? pmain.y.invert(pnt.y) : undefined;
+         const realx = pmain.revertAxis("x", pnt.x),
+               realy = pmain.revertAxis("y", pnt.y);
 
          if ((realx!==undefined) && (realy!==undefined)) {
             const len = histo.fBins.arr.length;

--- a/ui5/eve7/controller/GL.controller.js
+++ b/ui5/eve7/controller/GL.controller.js
@@ -49,11 +49,9 @@ sap.ui.define([
       {
          let args = oEvent.getParameter("arguments");
 
-         console.log('ON MATCHED', args.viewName);
-
-         console.log('MORE DATA', JSROOT.$eve7tmp);
-
-         console.log('COMPONENT DATA', Component.getOwnerComponentFor(this.getView()).getComponentData());
+         // console.log('ON MATCHED', args.viewName);
+         // console.log('MORE DATA', JSROOT.$eve7tmp);
+         // console.log('COMPONENT DATA', Component.getOwnerComponentFor(this.getView()).getComponentData());
 
          this.setupManagerAndViewType(Component.getOwnerComponentFor(this.getView()).getComponentData(),
                                       args.viewName, JSROOT.$eve7tmp);
@@ -66,6 +64,13 @@ sap.ui.define([
       // Initialization that can be done immediately onInit or later through UI5 bootstrap callbacks.
       setupManagerAndViewType: function(data, viewName, moredata)
       {
+         delete this.standalone;
+         delete this.viewer_class;
+         if (this.viewer) {
+            this.viewer.cleanup();
+            delete this.viewer;
+         }
+
          if (viewName)
          {
             data.standalone = viewName;
@@ -80,7 +85,6 @@ sap.ui.define([
             this.eveViewerId  = moredata.eveViewerId;
             this.kind       = moredata.kind;
             this.standalone = viewName;
-
             this.checkViewReady();
          }
          else if (data.standalone && data.conn_handle)
@@ -212,10 +216,18 @@ sap.ui.define([
 
       redrawScenes: function()
       {
+         if (!this.created_scenes) return;
+
          for (let s of this.created_scenes)
-         {
             s.redrawScene();
-         }
+      },
+
+      removeScenes: function() {
+         if (!this.created_scenes) return;
+
+         for (let s of this.created_scenes)
+            s.removeScene();
+         delete this.created_scenes;
       },
 
       /// invoked from ResizeHandler

--- a/ui5/eve7/controller/GL.controller.js
+++ b/ui5/eve7/controller/GL.controller.js
@@ -115,7 +115,7 @@ sap.ui.define([
          this.checkViewReady();
       },
 
-      OnEveManagerInit: function()
+      onEveManagerInit: function()
       {
          // called when manager was updated, need only in standalone modes to detect own element id
          if (!this.standalone) return;

--- a/ui5/eve7/controller/Main.controller.js
+++ b/ui5/eve7/controller/Main.controller.js
@@ -137,7 +137,7 @@ sap.ui.define(['sap/ui/core/Component',
          }
       },
 
-      OnEveManagerInit: function() {
+      onEveManagerInit: function() {
          console.log("manager updated");
          this.UpdateCommandsButtons(this.mgr.commands);
          this.updateViewers();

--- a/ui5/eve7/controller/Summary.controller.js
+++ b/ui5/eve7/controller/Summary.controller.js
@@ -122,7 +122,7 @@ sap.ui.define([
          this.selected = {}; // container of selected objects
       },
 
-      OnEveManagerInit: function() {
+      onEveManagerInit: function() {
          var model = this.getView().getModel("treeModel");
          model.setData(this.createModel());
          model.refresh();

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -513,12 +513,10 @@ sap.ui.define([], function() {
       let lastChild = scenes.childs.length -1;
 
       if (scenes.childs[lastChild].fElementId == msg.fSceneId)
-      {
-         for (let i = 0; i < this.controllers.length; ++i)
-         {
-            this.controllers[i]["OnEveManagerInit"]();
-         }
-      }
+         this.controllers.forEach(ctrl => {
+            if (ctrl.onEveManagerInit) 
+               ctrl.onEveManagerInit();
+         });
    },
 
    //------------------------------------------------------------------------------

--- a/ui5/eve7/lib/EveScene.js
+++ b/ui5/eve7/lib/EveScene.js
@@ -122,7 +122,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
    /** method insert all objects into three.js container */
    EveScene.prototype.redrawScene = function()
    {
-      if ( ! this.glctrl) return;
+      if (!this.glctrl) return;
 
       let res3d = this.create3DObjects(true);
       if ( ! res3d.length && this.first_time) return;
@@ -138,6 +138,17 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       this.applySelectionOnSceneCreate(this.mgr.global_highlight_id);
 
       this.first_time = false;
+   }
+
+   EveScene.prototype.removeScene = function()
+   {
+      if (!this.glctrl) return;
+
+      let cont = this.glctrl.getSceneContainer("scene" + this.id);
+      while (cont.children.length > 0)
+         cont.remove(cont.children[0]);
+
+      this.first_time = true;
    }
 
    EveScene.prototype.update3DObjectsVisibility = function(arr, all_ancestor_children_visible)

--- a/ui5/eve7/lib/GlViewer.js
+++ b/ui5/eve7/lib/GlViewer.js
@@ -6,18 +6,24 @@ sap.ui.define([], function() {
    {
       this.viewer_class = viewer_class;
 
-      console.log(this.get_name() + " - constructor");
+      // console.log(this.get_name() + " - constructor");
    };
 
    GlViewer.prototype = {
 
       init: function(controller)
       {
-         console.log(this.get_name() + ".init()");
+         // console.log(this.get_name() + ".init()");
 
          if (this.controller) throw new Error(this.get_name() + "already initialized.");
 
          this.controller = controller;
+      },
+
+      cleanup: function()
+      {
+         // console.log(this.get_name() + ".cleanup()");
+         delete this.controller;
       },
 
       //==============================================================================

--- a/ui5/eve7/lib/GlViewerJSRoot.js
+++ b/ui5/eve7/lib/GlViewerJSRoot.js
@@ -27,6 +27,15 @@ sap.ui.define([
          this.createGeoPainter();
       },
 
+      cleanup: function() {
+         if (this.geo_painter) {
+            this.geo_painter.cleanup();
+            delete this.geo_painter;
+         }
+
+         GlViewer.prototype.cleanup.call(this);
+      },
+
       //==============================================================================
 
       make_object: function(name)

--- a/ui5/eve7/lib/GlViewerThree.js
+++ b/ui5/eve7/lib/GlViewerThree.js
@@ -61,7 +61,6 @@ sap.ui.define([
          GlViewer.prototype.cleanup.call(this);
       },
 
-
       //==============================================================================
 
       make_object: function(name) {

--- a/ui5/eve7/lib/GlViewerThree.js
+++ b/ui5/eve7/lib/GlViewerThree.js
@@ -55,6 +55,13 @@ sap.ui.define([
          this.controller.glViewerInitDone();
       },
 
+      cleanup: function() {
+         if (this.controller) this.controller.removeScenes();
+         this.destroyThreejsRenderer();
+         GlViewer.prototype.cleanup.call(this);
+      },
+
+
       //==============================================================================
 
       make_object: function(name) {
@@ -70,10 +77,9 @@ sap.ui.define([
       //==============================================================================
 
       createThreejsRenderer: function() {
-         var w = this.get_width();
-         var h = this.get_height();
+         var w = this.get_width(), h = this.get_height();
 
-         // console.log("createThreejsRenderer", this.kind, "w=", w, "h=", h);
+         // console.log("createThreejsRenderer", this.controller.kind, "w=", w, "h=", h);
 
          this.scene = new THREE.Scene();
          // this.scene.fog = new THREE.FogExp2( 0xaaaaaa, 0.05 );
@@ -135,6 +141,15 @@ sap.ui.define([
          this.fxaa_pass.renderToScreen = true;
 
          this.composer.addPass(this.fxaa_pass);
+      },
+
+      destroyThreejsRenderer: function() {
+         if (this.renderer)
+            this.get_view().getDomRef().removeChild(this.renderer.domElement);
+
+         delete this.renderer;
+         delete this.scene;
+         delete this.composer;
       },
 
       setupThreejsDomAndEventHandlers: function() {
@@ -449,8 +464,7 @@ sap.ui.define([
             this.ttip.style.top = null;
          }
 
-         // show tooltip only in static mode
-         if (this.handle.kind != "file") this.ttip.style.display = "block";
+         this.ttip.style.display = "block";
       },
       remoteToolTip: function(msg) {
          this.ttip_text.innerHTML = msg;


### PR DESCRIPTION
When drawing different projections via View -> Browse to menu
command, one have to cleanup previousely shown views.
Implement for plain three.js and JSROOT-based views,
to be implemented for `RCore` renderer.
Update JSROOT with correspondent fixes