### PR TITLE
[RF] Use more RooAbsReal in constructors of RooFit classes

### DIFF
--- a/roofit/roofit/inc/RooDecay.h
+++ b/roofit/roofit/inc/RooDecay.h
@@ -26,7 +26,7 @@ public:
 
   // Constructors, assignment etc
   inline RooDecay() { }
-  RooDecay(const char *name, const char *title, RooRealVar& t,
+  RooDecay(const char *name, const char *title, RooAbsReal& t,
       RooAbsReal& tau, const RooResolutionModel& model, DecayType type) ;
   RooDecay(const RooDecay& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooDecay(*this,newname) ; }

--- a/roofit/roofit/inc/RooGaussModel.h
+++ b/roofit/roofit/inc/RooGaussModel.h
@@ -39,11 +39,11 @@ public:
 
   // Constructors, assignment etc
   inline RooGaussModel() : _flatSFInt(kFALSE), _asympInt(kFALSE) { }
-  RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
+  RooGaussModel(const char *name, const char *title, RooAbsReal& x,
       RooAbsReal& mean, RooAbsReal& sigma) ;
-  RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
+  RooGaussModel(const char *name, const char *title, RooAbsReal& x,
       RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& msSF) ;
-  RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
+  RooGaussModel(const char *name, const char *title, RooAbsReal& x,
       RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& meanSF, RooAbsReal& sigmaSF) ;
   RooGaussModel(const RooGaussModel& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooGaussModel(*this,newname) ; }

--- a/roofit/roofit/src/RooDecay.cxx
+++ b/roofit/roofit/src/RooDecay.cxx
@@ -32,7 +32,6 @@ for the analytical convolution with a RooResolutionModel. See RooAbsAnaConvPdf.
 #include "RooDecay.h"
 
 #include "RooFit.h"
-#include "RooRealVar.h"
 #include "RooRandom.h"
 
 #include "TError.h"
@@ -50,7 +49,7 @@ ClassImp(RooDecay);
 /// \param[in] model Resolution model for the convolution.
 /// \param[in] type One of the decays types `SingleSided, Flipped, DoubleSided`
 RooDecay::RooDecay(const char *name, const char *title,
-         RooRealVar& t, RooAbsReal& tau,
+         RooAbsReal& t, RooAbsReal& tau,
          const RooResolutionModel& model, DecayType type) :
   RooAbsAnaConvPdf(name,title,model,t),
   _t("t","time",this,t),

--- a/roofit/roofit/src/RooGaussModel.cxx
+++ b/roofit/roofit/src/RooGaussModel.cxx
@@ -38,7 +38,7 @@ ClassImp(RooGaussModel);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsRealLValue& xIn,
+RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsReal& xIn,
               RooAbsReal& _mean, RooAbsReal& _sigma) :
   RooResolutionModel(name,title,xIn),
   _flatSFInt(kFALSE),
@@ -52,7 +52,7 @@ RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsRealLVal
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsRealLValue& xIn,
+RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsReal& xIn,
               RooAbsReal& _mean, RooAbsReal& _sigma,
               RooAbsReal& _msSF) :
   RooResolutionModel(name,title,xIn),
@@ -67,7 +67,7 @@ RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsRealLVal
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsRealLValue& xIn,
+RooGaussModel::RooGaussModel(const char *name, const char *title, RooAbsReal& xIn,
               RooAbsReal& _mean, RooAbsReal& _sigma,
               RooAbsReal& _meanSF, RooAbsReal& _sigmaSF) :
   RooResolutionModel(name,title,xIn),

--- a/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
+++ b/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
@@ -27,7 +27,6 @@ class TIterator  ;
 #include "RooAbsCacheElement.h"
 
 class RooResolutionModel ;
-class RooRealVar ;
 class RooAbsGenContext ;
 class RooConvGenContext ;
 
@@ -38,7 +37,7 @@ public:
   RooAbsAnaConvPdf() ;
   RooAbsAnaConvPdf(const char *name, const char *title, 
 		   const RooResolutionModel& model, 
-		   RooRealVar& convVar) ;
+		   RooAbsReal& convVar) ;
 
   RooAbsAnaConvPdf(const RooAbsAnaConvPdf& other, const char* name=0);
   virtual ~RooAbsAnaConvPdf();
@@ -76,9 +75,9 @@ public:
   virtual Bool_t changeModel(const RooResolutionModel& newModel) ;
 
   /// Retrieve the convolution variable.
-  RooAbsRealLValue* convVar();
+  RooAbsReal* convVar();
   /// Retrieve the convolution variable.
-  const RooAbsRealLValue* convVar() const {
+  const RooAbsReal* convVar() const {
     return const_cast<RooAbsAnaConvPdf*>(this)->convVar();
   }
 

--- a/roofit/roofitcore/inc/RooResolutionModel.h
+++ b/roofit/roofitcore/inc/RooResolutionModel.h
@@ -28,7 +28,7 @@ public:
 
   // Constructors, assignment etc
   inline RooResolutionModel() : _basis(0) { }
-  RooResolutionModel(const char *name, const char *title, RooAbsRealLValue& x) ;
+  RooResolutionModel(const char *name, const char *title, RooAbsReal& x) ;
   RooResolutionModel(const RooResolutionModel& other, const char* name=0);
   virtual TObject* clone(const char* newname) const = 0 ;
   virtual ~RooResolutionModel();
@@ -40,7 +40,7 @@ public:
   Double_t getValV(const RooArgSet* nset=0) const ;
   virtual RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const ;
   /// Return the convolution variable of the resolution model.
-  RooAbsRealLValue& convVar() const {return *x;}
+  RooAbsReal& convVar() const {return *x;}
   const RooRealVar& basisConvVar() const ;
 
   inline Bool_t isBasisSupported(const char* name) const { return basisCode(name)?kTRUE:kFALSE ; }
@@ -62,7 +62,7 @@ protected:
 
   friend class RooConvGenContext ;
   friend class RooAddModel ;
-  RooTemplateProxy<RooAbsRealLValue> x;                   // Dependent/convolution variable
+  RooTemplateProxy<RooAbsReal> x;                   // Dependent/convolution variable
 
   virtual Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
 //  Bool_t traceEvalHook(Double_t value) const ;

--- a/roofit/roofitcore/inc/RooTruthModel.h
+++ b/roofit/roofitcore/inc/RooTruthModel.h
@@ -36,7 +36,7 @@ public:
 
   // Constructors, assignment etc
   inline RooTruthModel() { }
-  RooTruthModel(const char *name, const char *title, RooAbsRealLValue& x) ;
+  RooTruthModel(const char *name, const char *title, RooAbsReal& x) ;
   RooTruthModel(const RooTruthModel& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooTruthModel(*this,newname) ; }
   virtual ~RooTruthModel();

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -66,7 +66,6 @@
 #include "RooMsgService.h"
 #include "Riostream.h"
 #include "RooResolutionModel.h"
-#include "RooRealVar.h"
 #include "RooFormulaVar.h"
 #include "RooConvGenContext.h"
 #include "RooGenContext.h"
@@ -94,7 +93,7 @@ RooAbsAnaConvPdf::RooAbsAnaConvPdf() :
 /// convoluted variable as this physics model ('convVar')
 
 RooAbsAnaConvPdf::RooAbsAnaConvPdf(const char *name, const char *title, 
-				   const RooResolutionModel& model, RooRealVar& cVar) :
+				   const RooResolutionModel& model, RooAbsReal& cVar) :
   RooAbsPdf(name,title), _isCopy(kFALSE),
   _model("!model","Original resolution model",this,(RooResolutionModel&)model,kFALSE,kFALSE),
   _convVar("!convVar","Convolution variable",this,cVar,kFALSE,kFALSE),
@@ -309,7 +308,7 @@ Bool_t RooAbsAnaConvPdf::isDirectGenSafe(const RooAbsArg& arg) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return a pointer to the convolution variable instance used in the resolution model
 
-RooAbsRealLValue* RooAbsAnaConvPdf::convVar()
+RooAbsReal* RooAbsAnaConvPdf::convVar()
 {
   RooResolutionModel* conv = (RooResolutionModel*) _convSet.at(0) ;
   if (!conv) return 0 ;  

--- a/roofit/roofitcore/src/RooResolutionModel.cxx
+++ b/roofit/roofitcore/src/RooResolutionModel.cxx
@@ -80,7 +80,7 @@ ClassImp(RooResolutionModel);
 /// The convolution variable needs to be convertable to real values, and be able
 /// to give information about its range. This is supported by e.g. RooRealVar or RooLinearVar, which
 /// accepts offsetting and scaling an observable.
-RooResolutionModel::RooResolutionModel(const char *name, const char *title, RooAbsRealLValue& _x) :
+RooResolutionModel::RooResolutionModel(const char *name, const char *title, RooAbsReal& _x) :
   RooAbsPdf(name,title), 
   x("x","Dependent or convolution variable",this,_x),
   _basisCode(0), _basis(0), 

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -46,7 +46,7 @@ ClassImp(RooTruthModel);
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor of a truth resolution model, i.e. a delta function in observable 'xIn'
 
-RooTruthModel::RooTruthModel(const char *name, const char *title, RooAbsRealLValue& xIn) :
+RooTruthModel::RooTruthModel(const char *name, const char *title, RooAbsReal& xIn) :
   RooResolutionModel(name,title,xIn)
 {  
 }


### PR DESCRIPTION
Some RooFit classes used the RooRealVar or RooAbsRealLValue types for
some of their parameters in the constructor, which is not as flexible as
RooRealVar because they are further down in the dependency hierachy.

This commit sustitutes `RooRealVar` in for some of these cases that were
encountered when investigating RooFit problems reported in the forum.
More precisely, I wanted to use a `RooFormulaVar` in a `RooDecay` which
was not possible before but now it is.