### PR TITLE
Fix assertion failure on Windows

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2550,7 +2550,9 @@ Long_t TCling::ProcessLine(const char* line, EErrorCode* error/*=0*/)
          {
             std::string code;
             std::string codeline;
-            std::ifstream in(fname);
+            // Windows requires std::ifstream::binary to properly handle
+            // CRLF and LF line endings
+            std::ifstream in(fname, std::ifstream::binary);
             while (in) {
                std::getline(in, codeline);
                code += codeline + "\n";


### PR DESCRIPTION
Fixes the following error on Windows with macros containing Windows line endings (CR/LF):
```
Assertion failed: content[posOpenCurly] == '{' && "No curly at claimed position of opening curly!",
file C:\Users\bellenot\git\master\interpreter\cling\lib\MetaProcessor\MetaProcessor.cpp, line 431
```