### PR TITLE
[eve7] let use with multi-threaded app, fix cleanup

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -57,8 +57,6 @@ private:
 
    int WaitFor(RWebWindow &win, WebWindowWaitFunc_t check, bool timed = false, double tm = -1);
 
-   static bool IsMainThrd();
-
    std::string GetUrl(const RWebWindow &win, bool remote = false);
 
    bool CreateServer(bool with_http = false);
@@ -79,6 +77,9 @@ public:
    std::shared_ptr<RWebWindow> CreateWindow();
 
    void Terminate();
+
+   static bool IsMainThrd();
+   static void AssignMainThrd();
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -67,11 +67,27 @@ static std::thread::id gWebWinMainThrd = std::this_thread::get_id();
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Returns true when called from main process
 /// Main process recognized at the moment when library is loaded
+/// It supposed to be a thread where gApplication->Run() will be called
+/// If application runs in separate thread, one have to use AssignMainThrd() method
+/// to let RWebWindowsManager correctly recognize such situation
 
 bool RWebWindowsManager::IsMainThrd()
 {
    return std::this_thread::get_id() == gWebWinMainThrd;
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////
+/// Re-assigns main thread id
+/// Normally main thread id recognized at the moment when library is loaded
+/// It supposed to be a thread where gApplication->Run() will be called
+/// If application runs in separate thread, one have to call this method
+/// to let RWebWindowsManager correctly recognize such situation
+
+void RWebWindowsManager::AssignMainThrd()
+{
+   gWebWinMainThrd = std::this_thread::get_id();
+}
+
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// window manager constructor

--- a/js/scripts/JSRootCore.js
+++ b/js/scripts/JSRootCore.js
@@ -182,7 +182,15 @@ if ((typeof document === "undefined") || (typeof window === "undefined")) {
      _redirects.push(["redraw", divid, obj, opt, call_back]);
    }
 
+   tmpJSROOT.connectWebWindow = function(arg) {
+      if (JSROOT !== tmpJSROOT)
+         return JSROOT.connectWebWindow(arg);
+      return new Promise(resolve => _redirects.push([resolve, "connectWebWindow", arg]));
+   }
+
    // until real JSROOT is loaded, provide minimal functions
    globalThis.JSROOT = tmpJSROOT;
+
+   console.warn("Do not use JSRootCore.js, please replace with JSRoot.core.js")
 
 })();

--- a/ui5/eve7/lib/GlViewerThree.js
+++ b/ui5/eve7/lib/GlViewerThree.js
@@ -156,6 +156,10 @@ sap.ui.define([
          delete this.renderer;
          delete this.scene;
          delete this.composer;
+         if (this.controls) {
+            this.controls.dispose();
+            delete this.controls;
+         }
       },
 
       mouseMoveHandler: function(event) {


### PR DESCRIPTION
If TApplication runs in special thread, one should call `RWebWindowManager::AssignMainThrd()` to indicate this
Correctly cleanup JS handlers to be able make new GL drawing