### PR TITLE
[llvm] Prevent static destruction from ending DefaultMMapper too early:

### DIFF
--- a/interpreter/llvm/src/lib/ExecutionEngine/SectionMemoryManager.cpp
+++ b/interpreter/llvm/src/lib/ExecutionEngine/SectionMemoryManager.cpp
@@ -258,10 +258,13 @@ public:
   }
 };
 
-DefaultMMapper DefaultMMapperInstance;
+DefaultMMapper &getDefaultMMapperInstance() {
+  static DefaultMMapper Mapper;
+  return Mapper;
+};
 } // namespace
 
 SectionMemoryManager::SectionMemoryManager(MemoryMapper *MM)
-    : MMapper(MM ? *MM : DefaultMMapperInstance) {}
+    : MMapper(MM ? *MM : getDefaultMMapperInstance()) {}
 
 } // namespace llvm


### PR DESCRIPTION
On some platforms, SectionMemoryManager::MMapper has uses (during static
destruction) that happen after static destruction has ended the lifetime
of the DefaultMMapper object. Use of a function-static prevents this, as
this guarantees that SectionMemoryManager::DefaultMMapper gets destructed
after users, as long as users were constructed after
SectionMemoryManager::DefaultMMapper (which is generally the case), rather
than a random sequencing.