### PR TITLE
Fix type printing of array template args

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp
@@ -411,10 +411,23 @@ void TemplateArgument::print(const PrintingPolicy &Policy,
   }
 
   case Declaration: {
-    NamedDecl *ND = getAsDecl();
-    Out << '&';
+    NamedDecl *ND = cast<NamedDecl>(getAsDecl());
+    bool needsRef = true;
+    if (auto VD = dyn_cast<ValueDecl>(ND)) {
+      const clang::Type *ArgTy = VD->getType()->getUnqualifiedDesugaredType();
+      const clang::Type *ParmTy
+        = getParamTypeForDecl()->getUnqualifiedDesugaredType();
+      clang::ASTContext& Ctx = ND->getASTContext();
+      needsRef = !Ctx.hasSameType(ArgTy, ParmTy);
+      if (needsRef && (ArgTy->isArrayType() || ArgTy->isFunctionType())) {
+        const clang::Type *decayedArgTy
+          = Ctx.getDecayedType(clang::QualType(ArgTy, 0)).getTypePtr();
+        needsRef = !Ctx.hasSameType(decayedArgTy, ParmTy);
+      }
+    }
+    if (needsRef)
+      Out << '&';
     if (ND->getDeclName()) {
-      // FIXME: distinguish between pointer and reference args?
       ND->printQualifiedName(Out);
     } else {
       Out << "(anonymous)";


### PR DESCRIPTION
Apply patch to interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp as suggested here:
https://reviews.llvm.org/D36368

This patch has been in use for some time on the CMS fork of ROOT.
