### PR TITLE
[cling] Extend lifetime of SectionMemoryManager::DefaultMMapper, again:

### DIFF
--- a/interpreter/llvm/src/include/llvm/ExecutionEngine/SectionMemoryManager.h
+++ b/interpreter/llvm/src/include/llvm/ExecutionEngine/SectionMemoryManager.h
@@ -186,6 +186,7 @@ private:
   MemoryGroup CodeMem;
   MemoryGroup RWDataMem;
   MemoryGroup RODataMem;
+  std::unique_ptr<MemoryMapper> DefMMapper;
   MemoryMapper &MMapper;
 };
 

--- a/interpreter/llvm/src/lib/ExecutionEngine/SectionMemoryManager.cpp
+++ b/interpreter/llvm/src/lib/ExecutionEngine/SectionMemoryManager.cpp
@@ -257,14 +257,9 @@ public:
     return sys::Memory::releaseMappedMemory(M);
   }
 };
-
-DefaultMMapper &getDefaultMMapperInstance() {
-  static DefaultMMapper Mapper;
-  return Mapper;
-};
 } // namespace
 
 SectionMemoryManager::SectionMemoryManager(MemoryMapper *MM)
-    : MMapper(MM ? *MM : getDefaultMMapperInstance()) {}
+  : DefMMapper(MM ? nullptr : new DefaultMMapper), MMapper(MM ? *MM : *DefMMapper) {}
 
 } // namespace llvm


### PR DESCRIPTION
A function-static does not guarantee the lifetime to be sufficiently
extended - at least on CentOS7. Use a unique_ptr which guarantees the
reference to stay valid for as long as the referencee is alive.

Fixes crash at exit on CentOS7.