### PR TITLE
[RF] Avoid clearing full RunContext after each NLL evaluation

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -227,6 +227,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooWrapperPdf.h
     RooNaNPacker.h
     RooBinSamplingPdf.h
+    RunContextTracker.h
     RooFitLegacy/RooCatTypeLegacy.h
     RooFitLegacy/RooCategorySharedProperties.h
     RooFitLegacy/RooTreeData.h
@@ -440,6 +441,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooHelpers.cxx
     src/RooWrapperPdf.cxx
     src/RooBinSamplingPdf.cxx
+    src/RunContextTracker.cxx
     src/RooFitLegacy/RooCatTypeLegacy.cxx
     src/RooFitLegacy/RooCategorySharedProperties.cxx
     src/RooFitLegacy/RooMultiCatIter.cxx

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -662,7 +662,6 @@ private:
 
   mutable Bool_t _valueDirty ;  // Flag set if value needs recalculating because input values modified
   mutable Bool_t _shapeDirty ;  // Flag set if value needs recalculating because input shapes modified
-  mutable bool _allBatchesDirty{true}; //! Mark batches as dirty (only meaningful for RooAbsReal).
 
   mutable OperMode _operMode ; // Dirty state propagation mode
   mutable Bool_t _fast ; // Allow fast access mode in getVal() and proxies

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -51,6 +51,7 @@ public:
     bool cloneInputData = true;
     double integrateOverBinsPrecision = -1.;
     bool binnedL = false;
+    bool batchMode = false;
   };
 
   // Constructors, assignment etc
@@ -154,6 +155,7 @@ protected:
   pRooRealMPFE*  _mpfeArray = nullptr; //! Array of parallel execution frond ends
 
   RooFit::MPSplit _mpinterl = RooFit::BulkPartition; // Use interleaving strategy rather than N-wise split for partioning of dataset for multiprocessor-split
+  Bool_t _batchMode = false ; //! If batch mode is activated or not
   Bool_t         _doOffset = false; // Apply interval value offset to control numeric precision?
   mutable ROOT::Math::KahanSum<double> _offset = 0.0; //! Offset as KahanSum to avoid loss of precision
   mutable Double_t _evalCarry = 0.0; //! carry of Kahan sum in evaluatePartition

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -19,6 +19,8 @@
 #include "RooAbsOptTestStatistic.h"
 #include "RooCmdArg.h"
 #include "RooAbsPdf.h"
+#include "RunContextTracker.h"
+
 #include <vector>
 #include <utility>
 
@@ -78,6 +80,7 @@ private:
   mutable std::vector<Double_t> _binw ; //!
   mutable RooRealSumPdf* _binnedPdf{nullptr}; //!
   mutable std::unique_ptr<RooBatchCompute::RunContext> _evalData; //! Struct to store function evaluation workspaces.
+  mutable std::unique_ptr<RunContextTracker> _runContextTracker; //!
    
   ClassDef(RooNLLVar,3) // Function representing (extended) -log(L) of p.d.f and dataset
 };

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -56,10 +56,6 @@ public:
 
   virtual Double_t defaultErrorLevel() const { return 0.5 ; }
 
-  void batchMode(bool on = true) {
-    _batchEvaluations = on;
-  }
-
   using ComputeResult = std::pair<ROOT::Math::KahanSum<double>, double>;
 
 protected:

--- a/roofit/roofitcore/inc/RunContextTracker.h
+++ b/roofit/roofitcore/inc/RunContextTracker.h
@@ -1,0 +1,55 @@
+// Author: Jonas Rembser, CERN  Feb 2021
+
+/*****************************************************************************
+ * RooFit
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2020, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#ifndef roofit_roofitcore_RunContextTracker_h
+#define roofit_roofitcore_RunContextTracker_h
+
+#include "RooChangeTracker.h"
+
+#include <memory>
+#include <unordered_map>
+
+class RooAbsArg;
+class RooAbsReal;
+class RooChangeTracker;
+
+namespace RooBatchCompute {
+struct RunContext;
+}
+
+/// Keeping track of which results can be erased from a RooBatchCompute::RunContext to clean a RunContext if needed.
+/// This is achieved by owning a RooChangeTracker for each RooAbsReal whose result is cached in a RunContext.
+/// Enable logging by adding this line to your script:
+/// ~~~{.cpp}
+/// RooMsgService::instance().addStream(DEBUG, Topic(FastEvaluations));
+/// ~~~
+class RunContextTracker {
+
+public:
+   RunContextTracker(RooBatchCompute::RunContext const &runContext);
+
+   void resetTrackers();
+   void cleanRunContext(RooAbsArg const &caller, RooBatchCompute::RunContext &runContext);
+
+private:
+   void addTracker(const RooAbsReal *absReal);
+   void checkIfCovers(RooBatchCompute::RunContext const &runContext) const;
+
+   // member variables
+   std::unordered_map<const RooAbsReal *, std::unique_ptr<RooChangeTracker>> _trackers;
+};
+
+#endif

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -858,8 +858,6 @@ Bool_t RooAbsArg::observableOverlaps(const RooArgSet* nset, const RooAbsArg& tes
 
 void RooAbsArg::setValueDirty(const RooAbsArg* source)
 {
-  _allBatchesDirty = true;
-
   if (_operMode!=Auto || _inhibitDirty) return ;
 
   // Handle no-propagation scenarios first

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -573,8 +573,10 @@ void RooAbsOptTestStatistic::optimizeCaching()
   // so that cache contents can be processed immediately
   _funcClone->getVal(_normSet) ;
 
-  // Set value caching mode for all nodes that depend on any of the observables to ADirty
-  _funcClone->optimizeCacheMode(*_funcObsSet) ;
+  if(!_batchMode) {
+    // Set value caching mode for all nodes that depend on any of the observables to ADirty
+    _funcClone->optimizeCacheMode(*_funcObsSet) ;
+  }
 
   // Disable propagation of dirty state flags for observables
   _dataClone->setDirtyProp(kFALSE) ;  

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1109,14 +1109,13 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
   cfg.cloneInputData = static_cast<bool>(cloneData);
   cfg.integrateOverBinsPrecision = pc.getDouble("IntegrateBins");
   cfg.binnedL = false;
+  cfg.batchMode = pc.getInt("BatchMode");
   if (!rangeName || strchr(rangeName,',')==0) {
     // Simple case: default range, or single restricted range
     //cout<<"FK: Data test 1: "<<data.sumEntries()<<endl;
 
     cfg.rangeName = rangeName ? rangeName : "";
-    auto theNLL = new RooNLLVar(baseName.c_str(),"-log(likelihood)",*this,data,projDeps,cfg, ext);
-    theNLL->batchMode(pc.getInt("BatchMode"));
-    nll = theNLL;
+    nll = new RooNLLVar(baseName.c_str(),"-log(likelihood)",*this,data,projDeps,cfg, ext);
   } else {
     // Composite case: multiple ranges
     RooArgList nllList ;
@@ -1129,7 +1128,6 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
       cfg.rangeName = token;
       auto nllComp = new RooNLLVar((baseName + "_" + token).c_str(),"-log(likelihood)",
                                    *this,data,projDeps,cfg,ext);
-      nllComp->batchMode(pc.getInt("BatchMode"));
       nllList.add(*nllComp) ;
     }
 

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -100,7 +100,8 @@ RooAbsTestStatistic::RooAbsTestStatistic(const char *name, const char *title, Ro
   _gofOpMode{(cfg.nCPU>1 || cfg.nCPU==-1) ? MPMaster : (dynamic_cast<RooSimultaneous*>(_func) ? SimMaster : Slave)},
   _nEvents{data.numEntries()},
   _nCPU(cfg.nCPU != -1 ? cfg.nCPU : 1),
-  _mpinterl(cfg.interleave)
+  _mpinterl(cfg.interleave),
+  _batchMode(cfg.batchMode)
 {
   // Register all parameters as servers
   _paramSet.add(*std::unique_ptr<RooArgSet>{real.getParameters(&data)});
@@ -137,6 +138,7 @@ RooAbsTestStatistic::RooAbsTestStatistic(const RooAbsTestStatistic& other, const
   _gofSplitMode(other._gofSplitMode),
   _nCPU(other._nCPU != -1 ? other._nCPU : 1),
   _mpinterl(other._mpinterl),
+  _batchMode(other._batchMode),
   _doOffset(other._doOffset),
   _offset(other._offset),
   _evalCarry(other._evalCarry)

--- a/roofit/roofitcore/src/RunContextTracker.cxx
+++ b/roofit/roofitcore/src/RunContextTracker.cxx
@@ -1,0 +1,83 @@
+// Author: Jonas Rembser, CERN  Feb 2021
+
+/*****************************************************************************
+ * RooFit
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2020, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#include "RunContextTracker.h"
+
+#include "RooAbsArg.h"
+#include "RooAbsReal.h"
+#include "RunContext.h"
+#include "RooMsgService.h"
+
+#include "ROOT/RMakeUnique.hxx"
+
+// Create a RunContextTracker that installs RooChangeTrackers for all arguments
+// where results are cached in the RunContext.
+/// \param[in] runContext The runContext used to look up the RooAbsArgs that need to be tracked.
+RunContextTracker::RunContextTracker(RooBatchCompute::RunContext const &runContext)
+{
+   for (auto const &item : runContext.spans) {
+      addTracker(item.first);
+   }
+}
+
+/// Reset all change trackers to a clean state.
+/// This should be called after evaluating the computation graph. In this way,
+/// one can figure out which nodes need to be recomputed in the next evaluation
+/// round depending on which fundamental parameters are changed in the meantime.
+void RunContextTracker::resetTrackers()
+{
+   for (auto const &item : _trackers) {
+      auto &tracker = *item.second;
+      tracker.hasChanged(true);
+   }
+}
+
+/// Clean a RunContext from results that need to be recalculated.
+/// This should be called just before evaluating the computation graph.
+/// \param[in] caller The class that is calling this function (information used for debug messages).
+/// \param[in] runContext The runContext that will be cleaned from results.
+void RunContextTracker::cleanRunContext(RooAbsArg const &caller, RooBatchCompute::RunContext &runContext)
+{
+   for (auto const &item : _trackers) {
+      auto const *arg = item.first;
+      auto &tracker = *item.second;
+      if (tracker.hasChanged(false)) {
+         auto found = runContext.spans.find(arg);
+         if (found != runContext.spans.end()) {
+            runContext.spans.erase(found);
+         }
+      } else {
+         if (oodologD(&caller, FastEvaluations)) {
+            if (runContext.spans.find(arg) != runContext.spans.end()) {
+               oocxcoutD(&caller, FastEvaluations)
+                  << "Value of " << arg->GetName() << " kept in RunContext by RunContextTracker::cleanRunContext"
+                  << std::endl;
+            }
+         }
+      }
+   }
+}
+
+/// Add a RooChangeTracker that tracks only a given RooAbsReal.
+/// \param[in] absReal The RooAbsReal to create a RooChangeTracker for.
+void RunContextTracker::addTracker(const RooAbsReal *absReal)
+{
+   if (absReal && _trackers.find(absReal) == _trackers.end()) {
+      auto trackerName = std::string(absReal->GetName()) + "_tracker";
+      _trackers[absReal] =
+         std::make_unique<RooChangeTracker>(trackerName.c_str(), trackerName.c_str(), RooArgSet{*absReal});
+   }
+}

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -19,6 +19,7 @@ ROOT_ADD_GTEST(testRooAbsPdf testRooAbsPdf.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooAbsCollection testRooAbsCollection.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)
 ROOT_ADD_GTEST(testRooFormula testRooFormula.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testRunContextTracker testRunContextTracker.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testProxiesAndCategories testProxiesAndCategories.cxx
   LIBRARIES RooFitCore
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testProxiesAndCategories_1.root

--- a/roofit/roofitcore/test/testRunContextTracker.cxx
+++ b/roofit/roofitcore/test/testRunContextTracker.cxx
@@ -1,0 +1,217 @@
+// Tests for the RooRunContextTracker
+// Authors: Jonas Rembser, CERN  03/2020
+
+#include "RooHelpers.h"
+#include "RooDataSet.h"
+#include "RooPolyVar.h"
+#include "RooGaussian.h"
+#include "RooRealVar.h"
+#include "RooNLLVar.h"
+#include "RunContext.h"
+#include "RunContextTracker.h"
+
+#include "TRandom.h"
+
+#include "gtest/gtest.h"
+
+#include <memory>
+
+RooDataSet makeFakeDataXY()
+{
+   RooRealVar x("x", "x", -10, 10);
+   RooRealVar y("y", "y", -10, 10);
+   RooArgSet coord(x, y);
+
+   RooDataSet dataSet{"dataSet", "dataSet", RooArgSet(x, y)};
+
+   for (int i = 0; i < 10000; i++) {
+      Double_t tmpy = gRandom->Gaus(0, 10);
+      Double_t tmpx = gRandom->Gaus(0.5 * tmpy, 1);
+      if (fabs(tmpy) < 10 && fabs(tmpx) < 10) {
+         x = tmpx;
+         y = tmpy;
+         dataSet.add(coord);
+      }
+   }
+
+   return dataSet;
+}
+
+TEST(RooRunContextTracker, Standalone)
+{
+   // Optionally enable message logging on FastEvaluations for debugging
+   // RooMsgService::instance().addStream(RooFit::DEBUG, Topic(RooFit::FastEvaluations));
+
+   // Create observables
+   RooRealVar x("x", "x", -10, 10);
+   RooRealVar y("y", "y", -10, 10);
+
+   // Create function f(y) = a0 + a1*y
+   RooRealVar a0("a0", "a0", -0.5, -5, 5);
+   RooRealVar a1("a1", "a1", -0.5, -1, 1);
+   RooPolyVar fy("fy", "fy", y, RooArgSet(a0, a1));
+
+   // Create gauss(x,f(y),s)
+   RooRealVar sigma("sigma", "width of gaussian", 0.5, 0.1, 2.0);
+   RooGaussian model("model", "Gaussian with shifting mean", x, fy, sigma);
+
+   auto dataSet = makeFakeDataXY();
+   const std::size_t numEntries = static_cast<std::size_t>(dataSet.numEntries());
+
+   // Evaluate model in batchMode
+   RooBatchCompute::RunContext runContext{};
+
+   auto hasKept = [](RooBatchCompute::RunContext const &context, RooAbsReal const &arg) {
+      return context.spans.find(&arg) != context.spans.end();
+   };
+   auto changeVal = [](RooRealVar &var) { var.setVal(var.getVal() + 0.001); };
+
+   dataSet.getBatches(runContext, 0, numEntries);
+   RooArgSet nset{x, y};
+
+   // 1st iteration
+   model.getValues(runContext, &nset);
+
+   // In the first iteration create the RunContextTracker. This has to be done
+   // after this first call to `getValues` for the RunContextTracker to know
+   // which arguments to track
+   RunContextTracker runContextTracker{runContext};
+   {
+      runContextTracker.resetTrackers();
+
+      changeVal(a0);
+
+      // The first argument is just to have a caller for the RooMsgService
+      runContextTracker.cleanRunContext(model, runContext);
+
+      // Let's think about what the runContextTracker should have cleared
+      // based on the computation graph topology
+      ASSERT_FALSE(hasKept(runContext, a0));
+      ASSERT_TRUE(hasKept(runContext, a1));
+      ASSERT_FALSE(hasKept(runContext, fy));
+      ASSERT_TRUE(hasKept(runContext, sigma));
+      ASSERT_FALSE(hasKept(runContext, model));
+      ASSERT_TRUE(hasKept(runContext, x));
+      ASSERT_TRUE(hasKept(runContext, y));
+   }
+   {
+      // 2nd iteration
+      model.getValues(runContext, &nset);
+      runContextTracker.resetTrackers();
+
+      changeVal(a0);
+      changeVal(a1);
+      changeVal(sigma);
+
+      runContextTracker.cleanRunContext(model, runContext);
+
+      ASSERT_FALSE(hasKept(runContext, a0));
+      ASSERT_FALSE(hasKept(runContext, a1));
+      ASSERT_FALSE(hasKept(runContext, fy));
+      ASSERT_FALSE(hasKept(runContext, sigma));
+      ASSERT_FALSE(hasKept(runContext, model));
+      ASSERT_TRUE(hasKept(runContext, x));
+      ASSERT_TRUE(hasKept(runContext, y));
+   }
+   {
+      // 3rd iteration
+      model.getValues(runContext, &nset);
+      runContextTracker.resetTrackers();
+
+      changeVal(sigma);
+
+      runContextTracker.cleanRunContext(model, runContext);
+
+      ASSERT_TRUE(hasKept(runContext, a0));
+      ASSERT_TRUE(hasKept(runContext, a1));
+      ASSERT_TRUE(hasKept(runContext, fy));
+      ASSERT_FALSE(hasKept(runContext, sigma));
+      ASSERT_FALSE(hasKept(runContext, model));
+      ASSERT_TRUE(hasKept(runContext, x));
+      ASSERT_TRUE(hasKept(runContext, y));
+   }
+}
+
+TEST(RooRunContextTracker, InsideRooNLLVar)
+{
+   // It is important to also test the RooRunContextTracker as it is used
+   // inside RooNLLVar, because there are many things that can go wrong when
+   // the operation modes are changed during the construction of the RooNLLVar
+
+   // Create observables
+   RooRealVar x("x", "x", -10, 10);
+   RooRealVar y("y", "y", -10, 10);
+
+   // Create function f(y) = a0 + a1*y
+   RooRealVar a0("a0", "a0", -0.5, -5, 5);
+   RooRealVar a1("a1", "a1", -0.5, -1, 1);
+   RooPolyVar fy("fy", "fy", y, RooArgSet(a0, a1));
+
+   // Create gauss(x,f(y),s)
+   RooRealVar sigma("sigma", "width of gaussian", 0.5, 0.1, 2.0);
+   RooGaussian model("model", "Gaussian with shifting mean", x, fy, sigma);
+
+   auto dataSet = makeFakeDataXY();
+
+   auto changeVal = [](RooRealVar &var) { var.setVal(var.getVal() + 0.001); };
+   auto hasKept = [](std::string const &logStr, RooAbsReal const &arg) {
+      return logStr.find(std::string(arg.GetName()) + " kept", 0) != std::string::npos;
+   };
+
+   // Create the NLL object
+   std::unique_ptr<RooAbsReal> nll{ model.createNLL(dataSet, RooFit::BatchMode(true)) };
+
+   nll->getVal();
+
+   {
+      RooHelpers::HijackMessageStream hijack(RooFit::DEBUG, RooFit::FastEvaluations);
+
+      changeVal(a0);
+
+      nll->getVal();
+      auto const &logString = hijack.str();
+
+      ASSERT_FALSE(hasKept(logString, a0));
+      ASSERT_TRUE(hasKept(logString, a1));
+      ASSERT_FALSE(hasKept(logString, fy));
+      ASSERT_TRUE(hasKept(logString, sigma));
+      ASSERT_FALSE(hasKept(logString, model));
+      ASSERT_TRUE(hasKept(logString, x));
+      ASSERT_TRUE(hasKept(logString, y));
+   }
+
+   {
+      RooHelpers::HijackMessageStream hijack(RooFit::DEBUG, RooFit::FastEvaluations);
+
+      changeVal(a0);
+      changeVal(a1);
+      changeVal(sigma);
+
+      nll->getVal();
+      auto const &logString = hijack.str();
+
+      ASSERT_FALSE(hasKept(logString, a0));
+      ASSERT_FALSE(hasKept(logString, a1));
+      ASSERT_FALSE(hasKept(logString, fy));
+      ASSERT_FALSE(hasKept(logString, sigma));
+      ASSERT_FALSE(hasKept(logString, model));
+      ASSERT_TRUE(hasKept(logString, x));
+      ASSERT_TRUE(hasKept(logString, y));
+   }
+   {
+      RooHelpers::HijackMessageStream hijack(RooFit::DEBUG, RooFit::FastEvaluations);
+
+      changeVal(sigma);
+
+      nll->getVal();
+      auto const &logString = hijack.str();
+
+      ASSERT_TRUE(hasKept(logString, a0));
+      ASSERT_TRUE(hasKept(logString, a1));
+      ASSERT_TRUE(hasKept(logString, fy));
+      ASSERT_FALSE(hasKept(logString, sigma));
+      ASSERT_FALSE(hasKept(logString, model));
+      ASSERT_TRUE(hasKept(logString, x));
+      ASSERT_TRUE(hasKept(logString, y));
+   }
+}


### PR DESCRIPTION
In the batched evaluation mode, the RunContext object that cached the values of nodes in the computation graph has so far been completely cleared after each NLL evaluation.

In this PR, a new class `RunContextTracker` is introduced. It makes use of the `RooChangeTracker` class to determine whether a cached result for a given node needs to be recomputed after the change of a given fundamental parameter or not.

This should speed up likelihood fits, as often only one fundamental parameter is changed at the time for the numeric gradient determination.

For the example [rf303_conditional.C](https://root.cern.ch/doc/master/rf303__conditional_8C.html), a reproducible 10 % speedup was observed in batch mode after this PR. The speedup is expected to be more significant for wider computational graphs where more intermediate node results can be kept in the RunContext after each evaluation.

This PR implements one of the ideas suggested in https://github.com/root-project/root/issues/6557, namely the bullet point of "Don't clear all intermediate values in batch fits between fit cycles. Only the ones that changed."

This might be interesting for @lmoneta, @hageboeck and @manolismih. 