### PR TITLE
Fix libAfterImage building

### DIFF
--- a/graf2d/asimage/src/libAfterImage/Makefile.in
+++ b/graf2d/asimage/src/libAfterImage/Makefile.in
@@ -78,7 +78,7 @@ CCFLAGS         = @CFLAGS@  @MMX_CFLAGS@
 EXTRA_DEFINES	= @DEFINE_XLOCALE@
 
 RANLIB		= @RANLIB@
-AR		= ar clq
+AR		= ar cq
 CP		= @CP@
 MV		= @MV@
 RM		= @RM@


### PR DESCRIPTION
Remove "l" from "ar clq" command while there is no extra library
linked to libAfterImage.a. 
Fixing build error on latest OpenSUSE.
Most probably caused by latest `ar`:
```
% ar --version
GNU ar (GNU Binutils; openSUSE Tumbleweed) 2.36.0.20210204-1
Copyright (C) 2021 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) any later version.
This program has absolutely no warranty.
```