### PR TITLE
[cxxmodules] Install vc.modulemap unconditionally.

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -105,9 +105,10 @@ set(clinginclude ${CMAKE_SOURCE_DIR}/interpreter/cling/include)
 set(custom_modulemaps)
 if (runtime_cxxmodules)
   set(custom_modulemaps boost.modulemap tinyxml2.modulemap cuda.modulemap module.modulemap.build)
-  if (Vc_FOUND)
-    set(custom_modulemaps ${custom_modulemaps} vc.modulemap)
-  endif(Vc_FOUND)
+  # FIXME: We should install vc.modulemap only when Vc is found (Vc_FOUND) but
+  # some systems install it under /usr/include/Vc/Vc which allows rootcling to
+  # discover it and assert that the modulemap is not found.
+  set(custom_modulemaps ${custom_modulemaps} vc.modulemap)
   if (NOT libcxx)
     if (MSVC)
       set(custom_modulemaps ${custom_modulemaps} vcruntime.modulemap)


### PR DESCRIPTION
Some systems install Vc under /usr/include which makes it reachable from within rootcling, however,  the build system does not find it and Vc_FOUND is not set.

In that case rootcling finds the relevant Vc header but does not find the corresponding modulemap to match.

This case is a classic example of a borderline build system/C++ modules issue where the responsibility for setting up is shared.

This patch should address a recent issue coming from the llvm9 upgrade where we also added a module for Vc.