### PR TITLE
Bump the preallocated items more.

### DIFF
--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -271,7 +271,9 @@ TClingMethodInfo::TClingMethodInfo(cling::Interpreter *interp,
 
       // Assemble special functions (or FunctionTemplate-s) that are synthesized from DefinitionData but
       // won't be enumerated as part of decls_begin()/decls_end().
-      for (clang::NamedDecl *ctor : SemaRef.LookupConstructors(CXXRD)) {
+      llvm::SmallVector<NamedDecl*, 16> Ctors;
+      SemaRef.LookupConstructors(CXXRD, Ctors);
+      for (clang::NamedDecl *ctor : Ctors) {
          // Filter out constructor templates, they are not functions we can iterate over:
          if (auto *CXXCD = llvm::dyn_cast<clang::CXXConstructorDecl>(ctor))
             SpecFuncs.emplace_back(CXXCD);

--- a/interpreter/llvm/src/tools/clang/include/clang/AST/DeclContextInternals.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/AST/DeclContextInternals.h
@@ -33,7 +33,7 @@ class DependentDiagnostic;
 /// one entry.
 struct StoredDeclsList {
   /// When in vector form, this is what the Data pointer points to.
-  using DeclsTy = SmallVector<NamedDecl *, 32>;
+  using DeclsTy = SmallVector<NamedDecl *, 8>;
 
   /// A collection of declarations, with a flag to indicate if we have
   /// further external declarations.

--- a/interpreter/llvm/src/tools/clang/include/clang/Sema/Sema.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Sema/Sema.h
@@ -3463,7 +3463,8 @@ public:
   LabelDecl *LookupOrCreateLabel(IdentifierInfo *II, SourceLocation IdentLoc,
                                  SourceLocation GnuLabelLoc = SourceLocation());
 
-  DeclContextLookupResult LookupConstructors(CXXRecordDecl *Class);
+  void LookupConstructors(CXXRecordDecl *Class,
+                          llvm::SmallVectorImpl<NamedDecl*> &Constructors);
   CXXConstructorDecl *LookupDefaultConstructor(CXXRecordDecl *Class);
   CXXConstructorDecl *LookupCopyingConstructor(CXXRecordDecl *Class,
                                                unsigned Quals);

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaCodeComplete.cpp
@@ -5212,7 +5212,9 @@ QualType Sema::ProduceConstructorSignatureHelp(Scope *S, QualType Type,
 
   OverloadCandidateSet CandidateSet(Loc, OverloadCandidateSet::CSK_Normal);
 
-  for (NamedDecl *C : LookupConstructors(RD)) {
+  llvm::SmallVector<NamedDecl*, 4> Ctors;
+  LookupConstructors(RD, Ctors);
+  for (NamedDecl *C : Ctors) {
     if (auto *FD = dyn_cast<FunctionDecl>(C)) {
       AddOverloadCandidate(FD, DeclAccessPair::make(FD, C->getAccess()), Args,
                            CandidateSet,

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaDeclCXX.cpp
@@ -10162,7 +10162,9 @@ NamedDecl *Sema::BuildUsingDeclaration(
         UsingName.setName(Context.DeclarationNames.getCXXConstructorName(
             Context.getCanonicalType(Context.getRecordType(CurClass))));
         UsingName.setNamedTypeInfo(nullptr);
-        for (auto *Ctor : LookupConstructors(RD))
+        llvm::SmallVector<NamedDecl*, 4> Ctors;
+        LookupConstructors(RD, Ctors);
+        for (auto *Ctor : Ctors)
           R.addDecl(Ctor);
         R.resolveKind();
       } else {

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaExprCXX.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaExprCXX.cpp
@@ -4804,7 +4804,9 @@ static bool EvaluateUnaryTypeTrait(Sema &Self, TypeTrait UTT,
 
       bool FoundConstructor = false;
       unsigned FoundTQs;
-      for (const auto *ND : Self.LookupConstructors(RD)) {
+      llvm::SmallVector<NamedDecl*, 4> Ctors;
+      Self.LookupConstructors(RD, Ctors);
+      for (const auto *ND : Ctors) {
         // A template constructor is never a copy constructor.
         // FIXME: However, it may actually be selected at the actual overload
         // resolution point.
@@ -4845,7 +4847,9 @@ static bool EvaluateUnaryTypeTrait(Sema &Self, TypeTrait UTT,
         return true;
 
       bool FoundConstructor = false;
-      for (const auto *ND : Self.LookupConstructors(RD)) {
+      llvm::SmallVector<NamedDecl*, 4> Ctors;
+      Self.LookupConstructors(RD, Ctors);
+      for (const auto *ND : Ctors) {
         // FIXME: In C++0x, a constructor template can be a default constructor.
         if (isa<FunctionTemplateDecl>(ND->getUnderlyingDecl()))
           continue;

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaLookup.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaLookup.cpp
@@ -3214,7 +3214,8 @@ CXXConstructorDecl *Sema::LookupMovingConstructor(CXXRecordDecl *Class,
 }
 
 /// Look up the constructors for the given class.
-DeclContext::lookup_result Sema::LookupConstructors(CXXRecordDecl *Class) {
+void Sema::LookupConstructors(CXXRecordDecl *Class,
+                              llvm::SmallVectorImpl<NamedDecl*> &Constructors) {
   // If the implicit constructors have not yet been declared, do so now.
   if (CanDeclareSpecialMemberFunction(Class)) {
     if (Class->needsImplicitDefaultConstructor())
@@ -3227,7 +3228,10 @@ DeclContext::lookup_result Sema::LookupConstructors(CXXRecordDecl *Class) {
 
   CanQualType T = Context.getCanonicalType(Context.getTypeDeclType(Class));
   DeclarationName Name = Context.DeclarationNames.getCXXConstructorName(T);
-  return Class->lookup(Name);
+  // Working directly on R might trigger a deserialization, invalidating R if
+  // the underlying data structure needs to reallocate the storage.
+  DeclContext::lookup_result R = Class->lookup(Name);
+  Constructors.append(R.begin(), R.end());
 }
 
 /// Look up the copying assignment operator for the given class.
@@ -3462,7 +3466,10 @@ void Sema::ArgumentDependentLookup(DeclarationName Name, SourceLocation Loc,
     //        namespaces even if they are not visible during an ordinary
     //        lookup (11.4).
     DeclContext::lookup_result R = NS->lookup(Name);
-    for (auto *D : R) {
+    // The loop might trigger a deserialization, invalidating R if the
+    // underlying data structure needs to reallocate the storage.
+    llvm::SmallVector<NamedDecl*, 8> RCopy(R.begin(), R.end());
+    for (auto *D : RCopy) {
       auto *Underlying = D;
       if (auto *USD = dyn_cast<UsingShadowDecl>(D))
         Underlying = USD->getTargetDecl();

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaOverload.cpp
@@ -3230,7 +3230,9 @@ IsInitializerListConstructorConversion(Sema &S, Expr *From, QualType ToType,
                                        OverloadCandidateSet &CandidateSet,
                                        bool AllowExplicit) {
   CandidateSet.clear(OverloadCandidateSet::CSK_InitByUserDefinedConversion);
-  for (auto *D : S.LookupConstructors(To)) {
+  llvm::SmallVector<NamedDecl*, 4> Ctors;
+  S.LookupConstructors(To, Ctors);
+  for (auto *D : Ctors) {
     auto Info = getConstructorInfo(D);
     if (!Info)
       continue;
@@ -3353,7 +3355,9 @@ IsUserDefinedConversion(Sema &S, Expr *From, QualType ToType,
         ListInitializing = true;
       }
 
-      for (auto *D : S.LookupConstructors(ToRecordDecl)) {
+      llvm::SmallVector<NamedDecl*, 4> Ctors;
+      S.LookupConstructors(ToRecordDecl, Ctors);
+      for (auto *D : Ctors) {
         auto Info = getConstructorInfo(D);
         if (!Info)
           continue;

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplate.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaTemplate.cpp
@@ -2158,7 +2158,9 @@ void Sema::DeclareImplicitDeductionGuides(TemplateDecl *Template,
   // for which some class template parameter without a default argument never
   // appears in a deduced context).
   bool AddedAny = false;
-  for (NamedDecl *D : LookupConstructors(Transform.Primary)) {
+  llvm::SmallVector<NamedDecl*, 4> Ctors;
+  LookupConstructors(Transform.Primary, Ctors);
+  for (NamedDecl *D : Ctors) {
     D = D->getUnderlyingDecl();
     if (D->isInvalidDecl() || D->isImplicit())
       continue;


### PR DESCRIPTION
Original commit message:

The Sema::LookupConstructor is not iteration safe.

When looking up a ctor the modules infrasturcture deserializes more ctor
candidates in the body of the function causing the internal vector implementation
to rellocate and invalidate the pointers.

This workaround should address the failures reported by LCG.

The real fix is being processed here https://reviews.llvm.org/D91524 and we
after being merged we should be able to backport it.