### PR TITLE
[webgui] let reassign main thread id [6.22]

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -60,8 +60,6 @@ private:
 
    int WaitFor(RWebWindow &win, WebWindowWaitFunc_t check, bool timed = false, double tm = -1);
 
-   static bool IsMainThrd();
-
    std::string GetUrl(const RWebWindow &win, bool remote = false);
 
    bool CreateServer(bool with_http = false);
@@ -82,6 +80,9 @@ public:
    std::shared_ptr<RWebWindow> CreateWindow();
 
    void Terminate();
+
+   static bool IsMainThrd();
+   static void AssignMainThrd();
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -69,11 +69,27 @@ static std::thread::id gWebWinMainThrd = std::this_thread::get_id();
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Returns true when called from main process
 /// Main process recognized at the moment when library is loaded
+/// It supposed to be a thread where gApplication->Run() will be called
+/// If application runs in separate thread, one have to use AssignMainThrd() method
+/// to let RWebWindowsManager correctly recognize such situation
 
 bool ROOT::Experimental::RWebWindowsManager::IsMainThrd()
 {
    return std::this_thread::get_id() == gWebWinMainThrd;
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////
+/// Re-assigns main thread id
+/// Normally main thread id recognized at the moment when library is loaded
+/// It supposed to be a thread where gApplication->Run() will be called
+/// If application runs in separate thread, one have to call this method
+/// to let RWebWindowsManager correctly recognize such situation
+
+void ROOT::Experimental::RWebWindowsManager::AssignMainThrd()
+{
+   gWebWinMainThrd = std::this_thread::get_id();
+}
+
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// window manager constructor


### PR DESCRIPTION
If application runs in special thread, one should
call RWebWindowManager::AssignMainThrd() to indicate this