### PR TITLE
[DF] Allow `#var` as an alias for `__rdf_sizeof_var` 

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -287,6 +287,8 @@ void CheckFilter(Filter &)
                  "filter expression returns a type that is not convertible to bool");
 }
 
+ColumnNames_t FilterArraySizeColNames(const ColumnNames_t &columnNames, const std::string &action);
+
 std::string ResolveAlias(const std::string &col, const std::map<std::string, std::string> &aliasMap);
 
 void CheckValidCppVarName(std::string_view var, const std::string &where);

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -287,6 +287,8 @@ void CheckFilter(Filter &)
                  "filter expression returns a type that is not convertible to bool");
 }
 
+std::string ResolveAlias(const std::string &col, const std::map<std::string, std::string> &aliasMap);
+
 void CheckValidCppVarName(std::string_view var, const std::string &where);
 
 void CheckForRedefinition(const std::string &where, std::string_view definedCol, const ColumnNames_t &customCols,

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -547,6 +547,11 @@ public:
    /// single-thread and multi-thread runs is different: in single-thread runs, Snapshot will write out a TTree with
    /// the specified name and zero entries; in multi-thread runs, no TTree object will be written out to disk.
    ///
+   /// \note Snapshot will refuse to process columns with names of the form `#columnname`. These are special columns
+   /// made available by some data sources (e.g. RNTupleDS) that represent the size of column `columnname`, and are
+   /// not meant to be written out with that name (which is not a valid C++ variable name). Instead, go through an
+   /// Alias(): `df.Alias("nbar", "#bar").Snapshot(..., {"nbar"})`.
+   ///
    /// ### Example invocations:
    ///
    /// ~~~{.cpp}
@@ -679,6 +684,11 @@ public:
    ///
    /// Use `Cache` if you know you will only need a subset of the (`Filter`ed) data that
    /// fits in memory and that will be accessed many times.
+   ///
+   /// \note Cache will refuse to process columns with names of the form `#columnname`. These are special columns
+   /// made available by some data sources (e.g. RNTupleDS) that represent the size of column `columnname`, and are
+   /// not meant to be written out with that name (which is not a valid C++ variable name). Instead, go through an
+   /// Alias(): `df.Alias("nbar", "#bar").Cache<std::size_t>(..., {"nbar"})`.
    ///
    /// ### Example usage:
    ///

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -588,7 +588,8 @@ public:
                                                  const ColumnNames_t &columnList,
                                                  const RSnapshotOptions &options = RSnapshotOptions())
    {
-      const auto validCols = GetValidatedColumnNames(columnList.size(), columnList);
+      const auto columnListWithoutSizeColumns = RDFInternal::FilterArraySizeColNames(columnList, "Snapshot");
+      const auto validCols = GetValidatedColumnNames(columnListWithoutSizeColumns.size(), columnListWithoutSizeColumns);
 
       const auto fullTreeName = treename;
       const auto parsedTreePath = RDFInternal::ParseTreePath(fullTreeName);
@@ -596,7 +597,7 @@ public:
       const auto &dirname = parsedTreePath.fDirName;
 
       auto snapHelperArgs = std::make_shared<RDFInternal::SnapshotHelperArgs>(RDFInternal::SnapshotHelperArgs{
-         std::string(filename), std::string(dirname), std::string(treename), columnList, options});
+         std::string(filename), std::string(dirname), std::string(treename), columnListWithoutSizeColumns, options});
 
       ::TDirectory::TContext ctxt;
       auto newRDF = std::make_shared<ROOT::RDataFrame>(fullTreeName, filename, validCols);
@@ -630,11 +631,15 @@ public:
       auto *tree = fLoopManager->GetTree();
       const auto treeBranchNames = tree != nullptr ? RDFInternal::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
       const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
+      // Ignore __rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
+      ColumnNames_t dsColumnsWithoutSizeColumns;
+      std::copy_if(dsColumns.begin(), dsColumns.end(), std::back_inserter(dsColumnsWithoutSizeColumns),
+                   [](const std::string &name) { return name.size() < 13 || name.substr(0, 13) != "__rdf_sizeof_"; });
       ColumnNames_t columnNames;
-      columnNames.reserve(definedColumns.size() + treeBranchNames.size() + dsColumns.size());
+      columnNames.reserve(definedColumns.size() + treeBranchNames.size() + dsColumnsWithoutSizeColumns.size());
       columnNames.insert(columnNames.end(), definedColumns.begin(), definedColumns.end());
       columnNames.insert(columnNames.end(), treeBranchNames.begin(), treeBranchNames.end());
-      columnNames.insert(columnNames.end(), dsColumns.begin(), dsColumns.end());
+      columnNames.insert(columnNames.end(), dsColumnsWithoutSizeColumns.begin(), dsColumnsWithoutSizeColumns.end());
       const auto selectedColumns = RDFInternal::ConvertRegexToColumns(columnNames, columnNameRegexp, "Snapshot");
       return Snapshot(treename, filename, selectedColumns, options);
    }
@@ -726,15 +731,18 @@ public:
                 << ") = reinterpret_cast<ROOT::RDF::RInterface<ROOT::Detail::RDF::RNodeBase>*>("
                 << RDFInternal::PrettyPrintAddr(&upcastInterface) << ")->Cache<";
 
-      const auto validColumnNames = GetValidatedColumnNames(columnList.size(), columnList);
+      const auto columnListWithoutSizeColumns = RDFInternal::FilterArraySizeColNames(columnList, "Cache");
+
+      const auto validColumnNames =
+         GetValidatedColumnNames(columnListWithoutSizeColumns.size(), columnListWithoutSizeColumns);
       const auto colTypes = GetValidatedArgTypes(validColumnNames, fDefines, fLoopManager->GetTree(), fDataSource,
                                                  "Cache", /*vector2rvec=*/false);
       for (const auto &colType : colTypes)
          cacheCall << colType << ", ";
-      if (!columnList.empty())
+      if (!columnListWithoutSizeColumns.empty())
          cacheCall.seekp(-2, cacheCall.cur);                         // remove the last ",
       cacheCall << ">(*reinterpret_cast<std::vector<std::string>*>(" // vector<string> should be ColumnNames_t
-                << RDFInternal::PrettyPrintAddr(&columnList) << "));";
+                << RDFInternal::PrettyPrintAddr(&columnListWithoutSizeColumns) << "));";
 
       // book the code to jit with the RLoopManager and trigger the event loop
       fLoopManager->ToJitExec(cacheCall.str());
@@ -756,6 +764,10 @@ public:
       auto *tree = fLoopManager->GetTree();
       const auto treeBranchNames = tree != nullptr ? RDFInternal::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
       const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
+      // Ignore __rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
+      ColumnNames_t dsColumnsWithoutSizeColumns;
+      std::copy_if(dsColumns.begin(), dsColumns.end(), std::back_inserter(dsColumnsWithoutSizeColumns),
+                   [](const std::string &name) { return name.size() < 13 || name.substr(0, 13) != "__rdf_sizeof_"; });
       ColumnNames_t columnNames;
       columnNames.reserve(definedColumns.size() + treeBranchNames.size() + dsColumns.size());
       columnNames.insert(columnNames.end(), definedColumns.begin(), definedColumns.end());
@@ -2660,9 +2672,10 @@ private:
    RResultPtr<RInterface<RLoopManager>> SnapshotImpl(std::string_view fullTreeName, std::string_view filename,
                                                      const ColumnNames_t &columnList, const RSnapshotOptions &options)
    {
-      RDFInternal::CheckTypesAndPars(sizeof...(ColumnTypes), columnList.size());
+      const auto columnListWithoutSizeColumns = RDFInternal::FilterArraySizeColNames(columnList, "Snapshot");
 
-      const auto validCols = GetValidatedColumnNames(columnList.size(), columnList);
+      RDFInternal::CheckTypesAndPars(sizeof...(ColumnTypes), columnListWithoutSizeColumns.size());
+      const auto validCols = GetValidatedColumnNames(columnListWithoutSizeColumns.size(), columnListWithoutSizeColumns);
       CheckAndFillDSColumns(validCols, TTraits::TypeList<ColumnTypes...>());
 
       const auto parsedTreePath = RDFInternal::ParseTreePath(fullTreeName);
@@ -2670,7 +2683,7 @@ private:
       const auto &dirname = parsedTreePath.fDirName;
 
       auto snapHelperArgs = std::make_shared<RDFInternal::SnapshotHelperArgs>(RDFInternal::SnapshotHelperArgs{
-         std::string(filename), std::string(dirname), std::string(treename), columnList, options});
+         std::string(filename), std::string(dirname), std::string(treename), columnListWithoutSizeColumns, options});
 
       ::TDirectory::TContext ctxt;
       auto newRDF = std::make_shared<ROOT::RDataFrame>(fullTreeName, filename, validCols);
@@ -2687,17 +2700,20 @@ private:
    template <typename... ColTypes, std::size_t... S>
    RInterface<RLoopManager> CacheImpl(const ColumnNames_t &columnList, std::index_sequence<S...>)
    {
+      const auto columnListWithoutSizeColumns = RDFInternal::FilterArraySizeColNames(columnList, "Snapshot");
+
       // Check at compile time that the columns types are copy constructible
       constexpr bool areCopyConstructible =
          RDFInternal::TEvalAnd<std::is_copy_constructible<ColTypes>::value...>::value;
       static_assert(areCopyConstructible, "Columns of a type which is not copy constructible cannot be cached yet.");
 
-      RDFInternal::CheckTypesAndPars(sizeof...(ColTypes), columnList.size());
+      RDFInternal::CheckTypesAndPars(sizeof...(ColTypes), columnListWithoutSizeColumns.size());
 
-      auto colHolders = std::make_tuple(Take<ColTypes>(columnList[S])...);
-      auto ds = std::make_unique<RLazyDS<ColTypes...>>(std::make_pair(columnList[S], std::get<S>(colHolders))...);
+      auto colHolders = std::make_tuple(Take<ColTypes>(columnListWithoutSizeColumns[S])...);
+      auto ds = std::make_unique<RLazyDS<ColTypes...>>(
+         std::make_pair(columnListWithoutSizeColumns[S], std::get<S>(colHolders))...);
 
-      RInterface<RLoopManager> cachedRDF(std::make_shared<RLoopManager>(std::move(ds), columnList));
+      RInterface<RLoopManager> cachedRDF(std::make_shared<RLoopManager>(std::move(ds), columnListWithoutSizeColumns));
 
       return cachedRDF;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1962,13 +1962,7 @@ public:
    ///
    std::string GetColumnType(std::string_view column)
    {
-      auto col = std::string(column);
-
-      // if "col" is an alias, resolve it before doing anything else
-      const auto aliasMap = fLoopManager->GetAliasMap();
-      const auto it = aliasMap.find(col);
-      if (it != aliasMap.end())
-         col = it->second;
+      const auto col = RDFInternal::ResolveAlias(std::string(column), fLoopManager->GetAliasMap());
 
       RDFDetail::RDefineBase *define = fDefines.HasName(col) ? fDefines.GetColumns().at(col).get() : nullptr;
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <initializer_list>
+#include <iterator> // std::back_insterter
 #include <limits>
 #include <memory>
 #include <sstream>
@@ -1940,8 +1941,10 @@ public:
       }
 
       if (fDataSource) {
-         auto &dsColNames = fDataSource->GetColumnNames();
-         allColumns.insert(allColumns.end(), dsColNames.begin(), dsColNames.end());
+         const auto &dsColNames = fDataSource->GetColumnNames();
+         // ignore columns starting with __rdf_sizeof_
+         std::copy_if(dsColNames.begin(), dsColNames.end(), std::back_inserter(allColumns),
+                                 [](const std::string &s) { return s.rfind("__rdf_sizeof", 0) != 0; });
       }
 
       return allColumns;

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -342,6 +342,34 @@ namespace ROOT {
 namespace Internal {
 namespace RDF {
 
+/// Take a list of column names, return that list with entries starting by '#' filtered out.
+/// The function throws when filtering out a column this way.
+ColumnNames_t FilterArraySizeColNames(const ColumnNames_t &columnNames, const std::string &action)
+{
+   ColumnNames_t columnListWithoutSizeColumns;
+   ColumnNames_t filteredColumns;
+   std::copy_if(columnNames.begin(), columnNames.end(), std::back_inserter(columnListWithoutSizeColumns),
+                [&](const std::string &name) {
+                   if (name[0] == '#') {
+                     filteredColumns.emplace_back(name);
+                      return false;
+                   } else {
+                      return true;
+                   }
+                });
+
+   if (!filteredColumns.empty()) {
+      std::string msg = "Column name(s) {";
+      for (auto &c : filteredColumns)
+         msg += c + ", ";
+      msg[msg.size() - 2] = '}';
+      msg += "will be ignored. Please go through a valid Alias to " + action + " an array size column";
+      throw std::runtime_error(msg);
+   }
+
+   return columnListWithoutSizeColumns;
+}
+
 std::string ResolveAlias(const std::string &col, const std::map<std::string, std::string> &aliasMap)
 {
    const auto it = aliasMap.find(col);

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -764,7 +764,7 @@ ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColu
       const auto aliasColumnNameIt = aliasMap.find(colName);
       if (aliasMapEnd != aliasColumnNameIt)
          colName = aliasColumnNameIt->second;
-      if (colName[0] == '#')
+      if (colName[0] == '#' && colName.length() > 1) // otherwise the column name is "#" and we'll error out later
          colName = "__rdf_sizeof_" + colName.substr(1);
    }
 

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -148,8 +148,10 @@ static ParsedExpression ParseRDFExpression(std::string_view expr, const ColumnNa
 {
    // transform `#var` into `__rdf_sizeof_var`
    TString preProcessedExpr(expr);
-   TPRegexp colSizeReplacer("(^|\\W)#([a-zA-Z_][a-zA-Z0-9_]*)"); // match #varname at beginning or after not-a-word
-   colSizeReplacer.Substitute(preProcessedExpr, "$1__rdf_sizeof_$2", "g");
+   // match #varname at beginning of the sentence or after not-a-word, but exclude preprocessor directives like #ifdef
+   TPRegexp colSizeReplacer(
+      "(^|\\W)#(?!(ifdef|ifndef|if|else|elif|endif|pragma|define|undef|include|line))([a-zA-Z_][a-zA-Z0-9_]*)");
+   colSizeReplacer.Substitute(preProcessedExpr, "$1__rdf_sizeof_$3", "g");
 
    const auto usedColsAndAliases =
       FindUsedColumns(std::string(preProcessedExpr), treeBranchNames, customColNames, dataSourceColNames, aliasMap);

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -49,7 +49,7 @@ protected:
    }
 
 public:
-   static std::string TypeName() { return "ROOT::Experimental::ClusterSize_t::ValueType"; }
+   static std::string TypeName() { return "std::size_t"; }
    RRDFCardinalityField()
       : ROOT::Experimental::Detail::RFieldBase("", TypeName(), ENTupleStructure::kLeaf, false /* isSimple */) {}
    RRDFCardinalityField(RRDFCardinalityField &&other) = default;
@@ -69,20 +69,22 @@ public:
 
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final
    {
-      return ROOT::Experimental::Detail::RFieldValue(this, static_cast<ClusterSize_t *>(where));
+      return ROOT::Experimental::Detail::RFieldValue(this, static_cast<std::size_t *>(where));
    }
    ROOT::Experimental::Detail::RFieldValue CaptureValue(void *where) final
    {
       return ROOT::Experimental::Detail::RFieldValue(true /* captureFlag */, this, where);
    }
-   size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
+   size_t GetValueSize() const final { return sizeof(std::size_t); }
 
    /// Get the number of elements of the collection identified by globalIndex
    void
    ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, ROOT::Experimental::Detail::RFieldValue *value) final
    {
       RClusterIndex collectionStart;
-      fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, value->Get<ClusterSize_t>());
+      ClusterSize_t size;
+      fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
+      *value->Get<std::size_t>() = size;
    }
 
    /// Get the number of elements of the collection identified by clusterIndex
@@ -90,7 +92,9 @@ public:
                           ROOT::Experimental::Detail::RFieldValue *value) final
    {
       RClusterIndex collectionStart;
-      fPrincipalColumn->GetCollectionInfo(clusterIndex, &collectionStart, value->Get<ClusterSize_t>());
+      ClusterSize_t size;
+      fPrincipalColumn->GetCollectionInfo(clusterIndex, &collectionStart, &size);
+      *value->Get<std::size_t>() = size;
    }
 };
 

--- a/tree/dataframe/test/RArraysDS.hxx
+++ b/tree/dataframe/test/RArraysDS.hxx
@@ -1,0 +1,84 @@
+#ifndef ROOT_RARRAYSDS
+#define ROOT_RARRAYSDS
+
+#include "ROOT/RDataSource.hxx"
+#include "ROOT/RDF/RColumnReaderBase.hxx"
+#include <Rtypes.h>
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+class R__CLING_PTRCHECK(off) RArraysDSVarReader final : public ROOT::Detail::RDF::RColumnReaderBase {
+   std::vector<int> *fPtr = nullptr;
+   void *GetImpl(Long64_t) final { return fPtr; }
+
+public:
+   RArraysDSVarReader(std::vector<int> &v) : fPtr(&v) {}
+};
+
+class R__CLING_PTRCHECK(off) RArraysDSVarSizeReader final : public ROOT::Detail::RDF::RColumnReaderBase {
+   std::vector<int> *fPtr = nullptr;
+   std::size_t fSize = 0;
+   void *GetImpl(Long64_t) final
+   {
+      fSize = fPtr->size();
+      return &fSize;
+   }
+
+public:
+   RArraysDSVarSizeReader(std::vector<int> &v) : fPtr(&v) {}
+};
+
+/// A RDataSource to test the #var feature
+class RArraysDS : public ROOT::RDF::RDataSource {
+   std::vector<int> fVar = {42};
+   std::vector<std::string> fColumnNames = {"__rdf_sizeof_var", "var"};
+   std::vector<std::pair<ULong64_t, ULong64_t>> fRanges = {{0ull, 1ull}};
+
+   bool IsSizeColumn(std::string_view colName) const { return colName.substr(0, 13) == "__rdf_sizeof_"; }
+
+public:
+   void SetNSlots(unsigned int) final { }
+
+   const std::vector<std::string> &GetColumnNames() const final { return fColumnNames; }
+
+   bool HasColumn(std::string_view name) const final
+   {
+      return name == "var" || name == "__rdf_sizeof_var";
+   }
+
+   std::string GetTypeName(std::string_view name) const final
+   {
+      return IsSizeColumn(name) ? "std::size_t" : "std::vector<int>";
+   }
+
+   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() final
+   {
+      return std::move(fRanges);
+   }
+
+   bool SetEntry(unsigned int, ULong64_t) final { return true; }
+
+   void Initialise() final { fRanges = {{0ull, 1ull}}; }
+
+   std::string GetLabel() final { return "ArraysDS"; }
+
+protected:
+   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &) final
+   {
+      // we use the new column reader API
+      return {};
+   }
+
+   std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase>
+   GetColumnReaders(unsigned int /*slot*/, std::string_view name, const std::type_info &) final
+   {
+      return IsSizeColumn(name)
+                ? std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase>(new RArraysDSVarSizeReader(fVar))
+                : std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase>(new RArraysDSVarReader(fVar));
+   }
+};
+
+#endif

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -709,3 +709,17 @@ TEST(RDataFrameInterface, DescribeDataset)
    auto df3 = ROOT::RDF::MakeCsvDataFrame("RCsvDS_test_headers.csv");
    EXPECT_EQ(df3.DescribeDataset(), "Dataframe from datasource RCsv");
 }
+
+// #var is a convenience alias for __rdf_sizeof_var.
+TEST(RDataFrameInterface, ShortSyntaxForCollectionSizes)
+{
+   auto df = ROOT::RDataFrame(1).Define("__rdf_sizeof_x", [] { return 42; });
+   auto m1 = df.Max<int>("#x");
+   auto m2 = df.Max("#x");
+   auto m3 = df.Define("y", [] (int xs) { return xs; }, {"#x"}).Max<int>("y");
+   auto m4 = df.Filter("2 + pow(#x, 2) > 0").Max<int>("#x");
+   EXPECT_EQ(*m1, 42);
+   EXPECT_EQ(*m2, 42);
+   EXPECT_EQ(*m3, 42);
+   EXPECT_EQ(*m4, 42);
+}

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -718,8 +718,13 @@ TEST(RDataFrameInterface, ShortSyntaxForCollectionSizes)
    auto m2 = df.Max("#x");
    auto m3 = df.Define("y", [] (int xs) { return xs; }, {"#x"}).Max<int>("y");
    auto m4 = df.Filter("2 + pow(#x, 2) > 0").Max<int>("#x");
+   auto dfWithAlias = df.Alias("szx", "#x");
+   auto m5 = dfWithAlias.Max<int>("szx");
+   auto m6 = dfWithAlias.Max("szx");
    EXPECT_EQ(*m1, 42);
    EXPECT_EQ(*m2, 42);
    EXPECT_EQ(*m3, 42);
    EXPECT_EQ(*m4, 42);
+   EXPECT_EQ(*m5, 42);
+   EXPECT_EQ(*m6, 42);
 }

--- a/tree/dataframe/test/datasource_more.cxx
+++ b/tree/dataframe/test/datasource_more.cxx
@@ -1,10 +1,13 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RMakeUnique.hxx>
 #include <TROOT.h>
+#include <TSystem.h>
 
 #include "RNonCopiableColumnDS.hxx"
 #include "RStreamingDS.hxx"
+#include "RArraysDS.hxx"
 
+#include "ROOTUnitTestSupport.h"
 #include "gtest/gtest.h"
 
 using namespace ROOT::RDF;
@@ -31,6 +34,58 @@ TEST(RStreamingDS, MultipleEntryRanges)
    EXPECT_EQ(*c, 4ull);
    EXPECT_EQ(*ansmin, *ansmax);
    EXPECT_EQ(*ansmin, 42);
+}
+
+TEST(RArraysDS, ShortSyntaxForCollectionSizes)
+{
+   ROOT::RDataFrame df(std::make_unique<RArraysDS>());
+   // GetColumnNames must hide column "__rdf_sizeof_var"...
+   EXPECT_EQ(df.GetColumnNames(), std::vector<std::string>{"var"});
+   // ...but it must nonetheless be a valid column
+   EXPECT_EQ(df.GetColumnType("#var"), "std::size_t");
+   EXPECT_EQ(df.GetColumnType("var"), "std::vector<int>");
+   EXPECT_EQ(df.Take<std::size_t>("#var").GetValue(), std::vector<std::size_t>{1ull});
+   EXPECT_EQ(df.Take<std::vector<int>>("var").GetValue(), std::vector<std::vector<int>>{{42}});
+}
+
+TEST(RArraysDS, SnapshotAndShortSyntaxForCollectionSizes)
+{
+   const auto fname = "snapshotandshortsyntaxforcollectionsizes.root";
+   ROOT::RDataFrame df(std::make_unique<RArraysDS>());
+
+   // Snapshot must ignore the #var columns
+   df.Snapshot("t", fname);
+   TFile f(fname);
+   auto *t = f.Get<TTree>("t");
+   auto *blist = t->GetListOfBranches();
+   EXPECT_EQ(blist->GetEntries(), 1u);
+   EXPECT_STREQ(blist->At(0)->GetName(), "var");
+
+   // Snapshot must throw if #var is passed explicitly
+   EXPECT_THROW(df.Snapshot<std::size_t>("t", fname, {"#var"}), std::runtime_error);
+
+   // ...and work if the Snapshot is performed via an Alias
+   const auto nvar =
+      df.Alias("nvar", "#var").Snapshot<std::size_t>("t", fname, {"nvar"})->Take<std::size_t>("nvar").GetValue();
+   EXPECT_EQ(nvar, std::vector<std::size_t>{1});
+
+   gSystem->Unlink(fname);
+}
+
+TEST(RArraysDS, CacheAndShortSyntaxForCollectionSizes)
+{
+   ROOT::RDataFrame df(std::make_unique<RArraysDS>());
+
+   // Cache must ignore the #var columns
+   auto cached = df.Cache();
+   EXPECT_EQ(cached.GetColumnNames(), std::vector<std::string>{"var"});
+
+   // Cache must throw if #var is passed explicitly...
+   EXPECT_THROW(df.Cache<std::size_t>({"#var"}), std::runtime_error);
+
+   // ...and work if the caching is performed via an Alias
+   const auto nvar = df.Alias("nvar", "#var").Cache<std::size_t>({"nvar"}).Take<std::size_t>("nvar").GetValue();
+   EXPECT_EQ(nvar, std::vector<std::size_t>{1});
 }
 
 #ifdef R__USE_IMT

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -64,11 +64,21 @@ TEST_F(RNTupleDSTest, CardinalityColumn)
 {
    auto df = ROOT::Experimental::MakeNTupleDataFrame(fNtplName, fFileName);
 
-   // Check that the special column #<collection> works with jitting
-   auto max_njets = df.Define("njets", "__rdf_sizeof_jets").Max("njets");
-   EXPECT_EQ(2, *max_njets);
-}
+   // Check that the special column #<collection> works without jitting...
+   auto identity = [](std::size_t sz) { return sz; };
+   auto max_njets = df.Define("njets", identity, {"__rdf_sizeof_jets"}).Max<std::size_t>("njets");
+   auto max_njets2 = df.Max<std::size_t>("#jets");
+   EXPECT_EQ(*max_njets, *max_njets2);
+   EXPECT_EQ(*max_njets, 2);
 
+   // ...and with jitting
+   auto max_njets_jitted = df.Define("njets", "__rdf_sizeof_jets").Max<std::size_t>("njets");
+   auto max_njets_jitted2 = df.Define("njets", "#jets").Max<std::size_t>("njets");
+   auto max_njets_jitted3 = df.Max("#jets");
+   EXPECT_EQ(*max_njets_jitted, *max_njets_jitted2);
+   EXPECT_EQ(*max_njets_jitted3, *max_njets_jitted2);
+   EXPECT_EQ(2, *max_njets_jitted);
+}
 
 void ReadTest(const std::string &name, const std::string &fname) {
    auto df = ROOT::Experimental::MakeNTupleDataFrame(name, fname);

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -56,7 +56,7 @@ TEST_F(RNTupleDSTest, ColTypeNames)
 
    EXPECT_STREQ("std::string", tds.GetTypeName("tag").c_str());
    EXPECT_STREQ("float", tds.GetTypeName("energy").c_str());
-   EXPECT_STREQ("ROOT::Experimental::ClusterSize_t::ValueType", tds.GetTypeName("__rdf_sizeof_jets").c_str());
+   EXPECT_STREQ("std::size_t", tds.GetTypeName("__rdf_sizeof_jets").c_str());
 }
 
 


### PR DESCRIPTION
Data sources such as RNTuple that have efficient ways to get the
size of a collection can recognize the `__rdf_sizeof_` prefix and
connect that variable to the column representing the size of `var`.

To do:
- [x] test interaction of `#var` and `Alias`
- [x] nicer error handling in case of column name that is just `"#"` (Jakob's comment)
- [x] do not expand `#define`, `#pragma` and other preprocessor directives
- [x] do not return `__rdf_sizeof_XXX` columns from `GetColumnNames` (RNTupleDS can, but RDF should filter them out)
- [x] ignore `__rdf_sizeof_XXX` columns in `Snapshot` (~~printing a warning~~ throwing if passed explicitly by the user)
- [x] same for `Cache`
- [x] document interaction of `Snapshot` and `Cache` with the `#var` columns
- [x] test interaction of `Cache` and `#var`
- [x] RNTuple's `#var` columns should probably be `std::size_t` instead of `unsigned int`s? that would be the less surprising. Also I got _some_ numbers out rather than an exception when I used the wrong type