### PR TITLE
[asimage] set screen gamma to SCREEN_GAMMA

### DIFF
--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -6048,8 +6048,8 @@ Bool_t TASImage::SetImageBuffer(char **buffer, EImageFileTypes type)
    params.width = 0;
    params.height = 0 ;
    params.filter = SCL_DO_ALL;
-   params.gamma = 1;
-   params.gamma_table = 0;
+   params.gamma = SCREEN_GAMMA;
+   params.gamma_table = nullptr;
    params.compression = 0;
    params.format = ASA_ASImage;
    params.search_path = 0;

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -6048,7 +6048,7 @@ Bool_t TASImage::SetImageBuffer(char **buffer, EImageFileTypes type)
    params.width = 0;
    params.height = 0 ;
    params.filter = SCL_DO_ALL;
-   params.gamma = 0;
+   params.gamma = 1;
    params.gamma_table = 0;
    params.compression = 0;
    params.format = ASA_ASImage;


### PR DESCRIPTION
With latest libpng versions value 0 recognized as error and
produced results are wrong.
Mean on newest Linux distributions one get problem to use TASImage class