### PR TITLE
Fix libAfterImage building, backport to 6.24

### DIFF
--- a/graf2d/asimage/src/libAfterImage/Makefile.in
+++ b/graf2d/asimage/src/libAfterImage/Makefile.in
@@ -78,7 +78,7 @@ CCFLAGS         = @CFLAGS@  @MMX_CFLAGS@
 EXTRA_DEFINES	= @DEFINE_XLOCALE@
 
 RANLIB		= @RANLIB@
-AR		= ar clq
+AR		= ar cq
 CP		= @CP@
 MV		= @MV@
 RM		= @RM@


### PR DESCRIPTION
Remove "l" from "ar clq" command while there is no extra library
linked to libAfterImage.a