### PR TITLE
prevent crash when TPython::Import is called in standalone projects

### DIFF
--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -143,6 +143,12 @@ Bool_t TPython::Initialize()
       // force loading of the ROOT module
       PyRun_SimpleString(const_cast<char *>("import ROOT"));
    }
+   
+   // verify that import ROOT was successful (and of its depending cppyy lib)   
+   if (!CPyCppyy::gThisModule) {
+      std::cerr << "Error: import ROOT failed, check your PYTHONPATH environmental variable." << std::endl;
+      return kFALSE;
+   }
 
    if (!gMainDict) {
       // retrieve the main dictionary
@@ -176,10 +182,6 @@ Bool_t TPython::Import(const char *mod_name)
 
    // allow finding to prevent creation of a python proxy for the C++ proxy
    Py_INCREF(mod);
-   if (!CPyCppyy::gThisModule) {
-      std::cerr << "Error: import ROOT failed, check your PYTHONPATH environmental variable." << std::endl;
-      return kFALSE;
-   }
    PyModule_AddObject(CPyCppyy::gThisModule, mod_name, mod);
 
    // force creation of the module as a namespace

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -176,8 +176,10 @@ Bool_t TPython::Import(const char *mod_name)
 
    // allow finding to prevent creation of a python proxy for the C++ proxy
    Py_INCREF(mod);
-   if (!CPyCppyy::gThisModule)
+   if (!CPyCppyy::gThisModule) {
+      std::cerr << "Error: import ROOT failed, check your PYTHONPATH environmental variable." << std::endl;
       return kFALSE;
+   }
    PyModule_AddObject(CPyCppyy::gThisModule, mod_name, mod);
 
    // force creation of the module as a namespace

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -176,6 +176,8 @@ Bool_t TPython::Import(const char *mod_name)
 
    // allow finding to prevent creation of a python proxy for the C++ proxy
    Py_INCREF(mod);
+   if (!CPyCppyy::gThisModule)
+      return kFALSE;
    PyModule_AddObject(CPyCppyy::gThisModule, mod_name, mod);
 
    // force creation of the module as a namespace

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -411,7 +411,7 @@ const TPyReturn TPython::Eval(const char *expr)
       return TPyReturn();
    }
 
-   // results that require no convserion
+   // results that require no conversion
    if (result == Py_None || CPyCppyy::CPPInstance_Check(result) || PyBytes_Check(result) || PyFloat_Check(result) ||
        PyLong_Check(result) || PyInt_Check(result))
       return TPyReturn(result);


### PR DESCRIPTION
from a standalone C++ project including ROOTTPython libs.

Side note:
Is there any way to make TPython work outside ROOT, in a C++ project?

`TPython::Exec("import numpy");`

returns `kTRUE` (no error)

but the result is a `_Py_NoneStruct`