### PR TITLE
[Tutorials] Veto rf408 when RDataFrame is deactivated.

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -83,6 +83,8 @@ if (NOT dataframe)
     list(APPEND dataframe_veto graphs/timeSeriesFromCSV_TDF.C)
     # TMVA tutorials dependent on RDataFrame
     list(APPEND dataframe_veto tmva/tmva*.C)
+    # RooFit tutorial depending on RDataFrame
+    list(APPEND dataframe_veto roofit/rf408*)
 elseif(MSVC AND NOT win_broken_tests)
     list(APPEND dataframe_veto dataframe/*.py)
 endif()


### PR DESCRIPTION
Since rf408 depends on RDF, it make sense to veto it when RDF is off.