### PR TITLE
Fix bug in cling's diagnostic engine, if CUDA mode is enable

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1355,7 +1355,9 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     // e.g. in CUDA mode
     std::string ExeName = "";
     if (COpts.CUDAHost)
-      ExeName = COpts.CUDADevice ? "cling-ptx" : "cling";
+      ExeName = "cling";
+    if (COpts.CUDADevice)
+      ExeName = "cling-ptx";
     llvm::IntrusiveRefCntPtr<DiagnosticsEngine> Diags =
         SetupDiagnostics(DiagOpts, ExeName);
     if (!Diags) {


### PR DESCRIPTION
Fix function, which was introduced with commit  822106a898267fca74214fc83d64d6110b2d66c5
Now, error messages of the device compiler are correctly prefixed with `cling-ptx: `