### PR TITLE
[ntuple] Add RField description members

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -229,6 +229,7 @@ public:
    bool IsSimple() const { return fIsSimple; }
    /// Get the field's description
    std::string GetDescription() const { return fDescription; }
+   void SetDescription(std::string_view description) { fDescription = std::string(description); }
 
    DescriptorId_t GetOnDiskId() const { return fOnDiskId; }
    void SetOnDiskId(DescriptorId_t id) { fOnDiskId = id; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -87,6 +87,8 @@ private:
    /// corresponding RNTuple descriptor. This on-disk ID is set in RPageSink::Create() for writing and by
    /// RFieldDescriptor::CreateField() when recreating a field / model from the stored descriptor.
    DescriptorId_t fOnDiskId = kInvalidDescriptorId;
+   /// Free text set by the user
+   std::string fDescription;
 
 protected:
    /// Collections and classes own sub fields
@@ -225,6 +227,8 @@ public:
    const RFieldBase *GetParent() const { return fParent; }
    std::vector<const RFieldBase *> GetSubFields() const;
    bool IsSimple() const { return fIsSimple; }
+   /// Get the field's description
+   std::string GetDescription() const { return fDescription; }
 
    DescriptorId_t GetOnDiskId() const { return fOnDiskId; }
    void SetOnDiskId(DescriptorId_t id) { fOnDiskId = id; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -67,8 +67,18 @@ public:
    /// Creates a new field and a corresponding tree value that is managed by a shared pointer.
    template <typename T, typename... ArgsT>
    std::shared_ptr<T> MakeField(std::string_view fieldName, ArgsT&&... args) {
-      EnsureValidFieldName(fieldName);
-      auto field = std::make_unique<RField<T>>(fieldName);
+      return MakeField<T>({fieldName, ""}, std::forward<ArgsT>(args)...);
+   }
+
+   /// Creates a new field given a `{name, description}` pair and a corresponding tree value that
+   /// is managed by a shared pointer.
+   template <typename T, typename... ArgsT>
+   std::shared_ptr<T> MakeField(std::pair<std::string_view, std::string_view> fieldNameDesc,
+      ArgsT&&... args)
+   {
+      EnsureValidFieldName(fieldNameDesc.first);
+      auto field = std::make_unique<RField<T>>(fieldNameDesc.first);
+      field->SetDescription(fieldNameDesc.second);
       auto ptr = fDefaultEntry->AddValue<T>(field.get(), std::forward<ArgsT>(args)...);
       fFieldZero->Attach(std::move(field));
       return ptr;
@@ -79,8 +89,14 @@ public:
 
    template <typename T>
    void AddField(std::string_view fieldName, T* fromWhere) {
-      EnsureValidFieldName(fieldName);
-      auto field = std::make_unique<RField<T>>(fieldName);
+      AddField<T>({fieldName, ""}, fromWhere);
+   }
+
+   template <typename T>
+   void AddField(std::pair<std::string_view, std::string_view> fieldNameDesc, T* fromWhere) {
+      EnsureValidFieldName(fieldNameDesc.first);
+      auto field = std::make_unique<RField<T>>(fieldNameDesc.first);
+      field->SetDescription(fieldNameDesc.second);
       fDefaultEntry->CaptureValue(field->CaptureValue(fromWhere));
       fFieldZero->Attach(std::move(field));
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -55,6 +55,9 @@ class RNTupleModel {
    /// of this NTuple model. Throws an RException for invalid names.
    void EnsureValidFieldName(std::string_view fieldName);
 
+   /// Free text set by the user
+   std::string fDescription;
+
 public:
    RNTupleModel();
    RNTupleModel(const RNTupleModel&) = delete;
@@ -115,7 +118,8 @@ public:
    REntry *GetDefaultEntry() { return fDefaultEntry.get(); }
    std::unique_ptr<REntry> CreateEntry();
    RNTupleVersion GetVersion() const { return RNTupleVersion(); }
-   std::string GetDescription() const { return ""; /* TODO */ }
+   std::string GetDescription() const { return fDescription; }
+   void SetDescription(std::string_view description) { fDescription = std::string(description); }
    RNTupleUuid GetUuid() const { return RNTupleUuid(); /* TODO */ }
 };
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1156,6 +1156,7 @@ ROOT::Experimental::RCollectionField::RCollectionField(
       auto& subField = collectionModel->GetFieldZero()->fSubFields[i];
       Attach(std::move(subField));
    }
+   SetDescription(collectionModel->GetDescription());
 }
 
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -976,6 +976,7 @@ ROOT::Experimental::RDanglingFieldDescriptor::FromField(const Detail::RFieldBase
    fieldDesc.FieldVersion(field.GetFieldVersion())
       .TypeVersion(field.GetTypeVersion())
       .FieldName(field.GetName())
+      .FieldDescription(field.GetDescription())
       .TypeName(field.GetType())
       .Structure(field.GetStructure())
       .NRepetitions(field.GetNRepetitions());

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -268,3 +268,32 @@ TEST(RNTupleModel, EnforceValidFieldNames)
    auto otherField = otherModel->MakeField<float>("pt", 42.0);
    auto collection = model->MakeCollection("otherModel", std::move(otherModel));
 }
+
+TEST(RNTupleModel, FieldDescriptions)
+{
+   FileRaii fileGuard("test_ntuple_field_descriptions.root");
+   auto model = RNTupleModel::Create();
+
+   auto pt = model->MakeField<float>({"pt", "transverse momentum"}, 42.0);
+
+   float num = 10.0;
+   model->AddField({"mass", "mass"}, &num);
+
+   auto charge = std::make_unique<RField<float>>(RField<float>("charge"));
+   charge->SetDescription("electric charge");
+   model->AddField(std::move(charge));
+
+   {
+      RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   std::vector<std::string> fieldDescriptions;
+   for (auto& f: ntuple->GetDescriptor().GetTopLevelFields()) {
+      fieldDescriptions.push_back(f.GetFieldDescription());
+   }
+   ASSERT_EQ(3, fieldDescriptions.size());
+   EXPECT_EQ(std::string("transverse momentum"), fieldDescriptions[0]);
+   EXPECT_EQ(std::string("mass"), fieldDescriptions[1]);
+   EXPECT_EQ(std::string("electric charge"), fieldDescriptions[2]);
+}

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -297,3 +297,20 @@ TEST(RNTupleModel, FieldDescriptions)
    EXPECT_EQ(std::string("mass"), fieldDescriptions[1]);
    EXPECT_EQ(std::string("electric charge"), fieldDescriptions[2]);
 }
+
+TEST(RNTupleModel, CollectionFieldDescriptions)
+{
+   FileRaii fileGuard("test_ntuple_collection_field_descriptions.root");
+   {
+      auto muon = RNTupleModel::Create();
+      muon->SetDescription("muons after basic selection");
+
+      auto model = RNTupleModel::Create();
+      model->MakeCollection("Muon", std::move(muon));
+      RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   const auto& muon_desc = *ntuple->GetDescriptor().GetTopLevelFields().begin();
+   EXPECT_EQ(std::string("muons after basic selection"), muon_desc.GetFieldDescription());
+}


### PR DESCRIPTION
Allow setting RNTuple field descriptions. The immediate motivation for this PR is for use by the ongoing CMS RNTuple NanoAOD output module. The new APIs are a direct analogue to `TBranch::SetTitle`. Field descriptions are added at the `RNTupleModel` level. There currently is no way to adjust field descriptions after creation. 

There is a new  `RNTupleModel::AddField` overload that takes a description parameter and a new `RNTupleModel::MakeFieldWithDescription` method. The latter was added because of difficulties overloading the existing variadic template method `MakeField`. 