### PR TITLE
Build option for distributed RDF tests that use pyspark

### DIFF
--- a/bindings/experimental/distrdf/CMakeLists.txt
+++ b/bindings/experimental/distrdf/CMakeLists.txt
@@ -21,20 +21,9 @@ set(py_sources
   DistRDF/Backends/__init__.py
   DistRDF/Backends/Base.py
   DistRDF/Backends/Utils.py
+  DistRDF/Backends/Spark/__init__.py
+  DistRDF/Backends/Spark/Backend.py
 )
-
-# Create a list to store the backends that are excluded through build options
-set(distrdf_backends_exclude_list "")
-
-if(dataframe_distpyspark)
-  list(APPEND py_sources
-    DistRDF/Backends/Spark/__init__.py
-    DistRDF/Backends/Spark/Backend.py
-  )
-else()
-  # Add the Spark backend to the excluded backends
-  list(APPEND distrdf_backends_exclude_list "Spark")
-endif()
 
 foreach(val RANGE ${how_many_pythons})
   list(GET python_executables ${val} python_executable)
@@ -48,26 +37,9 @@ foreach(val RANGE ${how_many_pythons})
 endforeach()
 
 # Install Python sources and bytecode
-if(NOT distrdf_backends_exclude_list)
-
-  install(DIRECTORY ${localruntimedir}/DistRDF
-          DESTINATION ${CMAKE_INSTALL_PYTHONDIR}
-          COMPONENT libraries)
-
-else()
-
-  # The distrdf_backends_exclude_list contains the names of the directories that
-  # should be excluded from the install step because their respective backend was
-  # not activated through the build options. A string replacement changes the list
-  # into a regex string that can be used in the install command
-  string(REPLACE ";" "|" distrdf_backends_exclude_regex "${distrdf_backends_exclude_list}")
-  install(DIRECTORY ${localruntimedir}/DistRDF
-          DESTINATION ${CMAKE_INSTALL_PYTHONDIR}
-          COMPONENT libraries
-          REGEX "${distrdf_backends_exclude_regex}" EXCLUDE)
-
-endif()
-
+install(DIRECTORY ${localruntimedir}/DistRDF
+        DESTINATION ${CMAKE_INSTALL_PYTHONDIR}
+        COMPONENT libraries)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)
 ROOT_ADD_TEST_SUBDIRECTORY(test/backend)

--- a/bindings/experimental/distrdf/test/backend/CMakeLists.txt
+++ b/bindings/experimental/distrdf/test/backend/CMakeLists.txt
@@ -19,7 +19,7 @@ ROOT_ADD_PYUNITTEST(distrdf_unit_backend_test_common test_common.py)
 ROOT_ADD_PYUNITTEST(distrdf_unit_backend_test_dist test_dist.py)
 
 # pyspark is required to run this test
-if(dataframe_distpyspark)
+if(test_distrdf_pyspark)
     ROOT_ADD_PYUNITTEST(distrdf_unit_backend_test_spark test_spark.py)
 endif()
 

--- a/cmake/modules/FindPySpark.cmake
+++ b/cmake/modules/FindPySpark.cmake
@@ -9,8 +9,7 @@
 # 2. py4j
 #
 # Java is a hard requirement in pyspark but still doing `import pyspark` does not
-# report an error if it is not installed or found. For that reason we look for Java
-# on the system with REQUIRED flag.
+# report an error if it is not installed or found.
 #
 # On the other hand, py4j should be present on the system if pyspark was installed
 # either through pip, conda or via downloading the official binaries. Thus, we can
@@ -19,38 +18,43 @@
 # Only the main Python executable that is used in the ROOT build will be used to find pyspark.
 # This module sets the following variables
 #  PySpark_FOUND - system has pyspark and it is usable
+#  PySpark_DEPENDENCIES_READY - the environment could import pyspark and Java runtime was found
 #  PySpark_VERSION_STRING - pyspark version string
 
 message(STATUS "Looking for PySpark dependency: Java")
-find_package(Java 1.8 REQUIRED COMPONENTS Runtime)
-
-message(STATUS "Found Java ${Java_JAVA_EXECUTABLE}")
-message(STATUS "Java version ${Java_VERSION_STRING}")
-
-# Import pyspark using the main Python executable, print its version and path to the __init__.py file
-execute_process(
-    COMMAND ${PYTHON_EXECUTABLE_Development_Main}
-            -c "import re, pyspark; print(pyspark.__version__); print(re.compile('/__init__.py.*').sub('',pyspark.__file__))" 
-    RESULT_VARIABLE _PYSPARK_IMPORT_SUCCESS
-    OUTPUT_VARIABLE _PYSPARK_VALUES_OUTPUT
-    ERROR_VARIABLE _PYSPARK_ERROR_VALUE
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-if(_PYSPARK_IMPORT_SUCCESS EQUAL 0)
-    # Convert the process output into a list
-    string(REGEX REPLACE "\n" ";" _PYSPARK_VALUES ${_PYSPARK_VALUES_OUTPUT})
-    # Just in case there is unexpected output from the Python command.
-    list(GET _PYSPARK_VALUES -2 _PYSPARK_VERSION)
-    list(GET _PYSPARK_VALUES -1 PySpark_HOME)
-    string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" PySpark_VERSION_STRING "${_PYSPARK_VERSION}")
+if(PySpark_FIND_REQUIRED)
+    find_package(Java 1.8 REQUIRED COMPONENTS Runtime)
 else()
-    message(STATUS "Python package 'pyspark' could not be imported with ${PYTHON_EXECUTABLE_Development_Main}\n"
-                   "${_PYSPARK_ERROR_VALUE}"
-    )
+    find_package(Java 1.8 COMPONENTS Runtime)
 endif()
 
+if(Java_FOUND)
+    message(STATUS "Found Java ${Java_JAVA_EXECUTABLE}")
+    message(STATUS "Java version ${Java_VERSION_STRING}")
+
+    # Import pyspark using the main Python executable, print its version and path to the __init__.py file
+    execute_process(
+        COMMAND ${PYTHON_EXECUTABLE_Development_Main} -c "import pyspark; print(pyspark.__version__)" 
+        RESULT_VARIABLE _PYSPARK_IMPORT_EXIT_STATUS
+        OUTPUT_VARIABLE _PYSPARK_VALUES_OUTPUT
+        ERROR_VARIABLE _PYSPARK_ERROR_VALUE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # Exit status equal to zero means success
+    if(_PYSPARK_IMPORT_EXIT_STATUS EQUAL 0)
+        # Build the version string
+        string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" PySpark_VERSION_STRING "${_PYSPARK_VALUES_OUTPUT}")
+        # Signal to CMake that the environment could import pyspark and Java runtime was found
+        set(PySpark_DEPENDENCIES_READY TRUE)
+    else()
+        message(STATUS "Python package 'pyspark' could not be imported with ${PYTHON_EXECUTABLE_Development_Main}\n"
+                    "${_PYSPARK_ERROR_VALUE}"
+        )
+    endif()
+
 find_package_handle_standard_args(PySpark
-    REQUIRED_VARS PySpark_HOME
+    REQUIRED_VARS PySpark_DEPENDENCIES_READY
     VERSION_VAR PySpark_VERSION_STRING
 )
+endif()

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -117,7 +117,7 @@ ROOT_BUILD_OPTION(cuda OFF "Enable support for CUDA (requires CUDA toolkit >= 7.
 ROOT_BUILD_OPTION(cudnn ON "Enable support for cuDNN (default when Cuda is enabled)")
 ROOT_BUILD_OPTION(cxxmodules OFF "Enable support for C++ modules")
 ROOT_BUILD_OPTION(dataframe ON "Enable ROOT RDataFrame")
-ROOT_BUILD_OPTION(dataframe_distpyspark ON "Enable distributed RDataFrame pyspark python module")
+ROOT_BUILD_OPTION(test_distrdf_pyspark OFF "Enable distributed RDataFrame tests that use pyspark")
 ROOT_BUILD_OPTION(davix ON "Enable support for Davix (HTTP/WebDAV access)")
 ROOT_BUILD_OPTION(dcache OFF "Enable support for dCache (requires libdcap from DESY)")
 ROOT_BUILD_OPTION(dev OFF "Enable recommended developer compilation flags, reduce exposed includes")
@@ -222,7 +222,7 @@ if(all)
  set(clad_defvalue ON)
  set(cuda_defvalue ON)
  set(dataframe_defvalue ON)
- set(dataframe_distpyspark_defvalue ON)
+ set(test_distrdf_pyspark_defvalue ON)
  set(davix_defvalue ON)
  set(dcache_defvalue ON)
  set(fftw3_defvalue ON)
@@ -485,12 +485,12 @@ elseif(Python3_Interpreter_Development_FOUND AND Python2_Interpreter_Development
   endif()
 endif()
 
-#---distributed RDataFrame requires both dataframe and pyroot----------------------------------
-if(dataframe_distpyspark AND (NOT dataframe OR NOT pyroot))
+#---distributed RDataFrame pyspark tests require both dataframe and pyroot----------------------------------
+if(test_distrdf_pyspark AND (NOT dataframe OR NOT pyroot))
 
-  message(STATUS "Distributed RDataFrame requires both RDataFrame and PyROOT to be enabled")
+  message(STATUS "Running the tests for distributed RDataFrame with pyspark requires both RDataFrame and PyROOT to be enabled")
   message(STATUS "    Switching it OFF because either pyroot or dataframe option is disabled")
   message(STATUS "    pyroot is set to ${pyroot} and dataframe is set to ${dataframe}")
-  set(dataframe_distpyspark OFF CACHE BOOL "Disabled because either dataframe or pyroot were disabled" FORCE)
+  set(test_distrdf_pyspark OFF CACHE BOOL "Disabled because either dataframe or pyroot were disabled" FORCE)
 
 endif()

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -1868,8 +1868,9 @@ endif()
 
 #------------------------------------------------------------------------------------
 # Check if the pyspark package is installed on the system.
-# The distributed RDataFrame module has been tested on pyspark version 2.4 and above.
-if(dataframe_distpyspark)
+# Needed to run tests of the distributed RDataFrame module that use pyspark.
+# The functionality has been tested with pyspark 2.4 and above.
+if(test_distrdf_pyspark)
   message(STATUS "Looking for PySpark")
 
   if(fail-on-missing)
@@ -1878,8 +1879,8 @@ if(dataframe_distpyspark)
 
     find_package(PySpark 2.4)
     if(NOT PySpark_FOUND)
-      message(STATUS "Switching OFF 'dataframe_distpyspark' option")
-      set(dataframe_distpyspark OFF CACHE BOOL "Disabled because PySpark not found" FORCE)
+      message(STATUS "Switching OFF 'test_distrdf_pyspark' option")
+      set(test_distrdf_pyspark OFF CACHE BOOL "Disabled because PySpark not found" FORCE)
     endif()
 
   endif()


### PR DESCRIPTION
The option `dataframe_distpyspark` is superseded by `test_distrdf_pyspark`, to clarify that finding pyspark and its dependencies (like Java) during configuration is strictly needed only for the tests.

Generally speaking, pyspark (and Java) are optional runtime dependencies that interest only users of the distributed RDataFrame python module with the Spark backend.