### PR TITLE
Try to fix some clang-tidy issues in core

### DIFF
--- a/core/base/inc/TStorage.h
+++ b/core/base/inc/TStorage.h
@@ -110,13 +110,13 @@ inline Bool_t TStorage::FilledByObjectAlloc(volatile const UInt_t *const member)
    //      the object.
    // The consequence would be that those objects would be deleted twice, once
    // by the TDirectory and once automatically when going out of scope
-   // (and thus quite visible).  A false negative (which is not posible with
+   // (and thus quite visible).  A false negative (which is not possible with
    // this implementation) would have been a silent memory leak.
 
    // This will be reported by valgrind as uninitialized memory reads for
    // object created on the stack, use $ROOTSYS/etc/valgrind-root.supp
 R__INTENTIONALLY_UNINIT_BEGIN
-   return *member == kObjectAllocMemValue;
+   return *member == kObjectAllocMemValue; // NOLINT
 R__INTENTIONALLY_UNINIT_END
 }
 

--- a/core/base/src/Match.cxx
+++ b/core/base/src/Match.cxx
@@ -380,7 +380,7 @@ static int omatch(const char**      strp,
 
    // Notice: cases above don't advance.
    // Match any except newline
-   case kANY: if (**strp == '\n') return 0;
+   case kANY: if (*strp && (**strp == '\n')) return 0;
       break;
 
    // Set match
@@ -388,7 +388,7 @@ static int omatch(const char**      strp,
       break;
 
    // Literal match
-   default:    if (*slenp == 0 || (unsigned char) **strp != *pat)  return 0;
+   default:    if (*slenp == 0 || *strp == nullptr || (unsigned char) **strp != *pat) return 0;
       break;
    }
 

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -450,7 +450,8 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
                if (!file) {
                   if (!dynamic_cast<TNamed*>(f)) {
                      Error("GetOptions()", "Inconsistent file entry (not a TObjString)!");
-                     if (f) f->Dump();
+                     if (f)
+                        f->Dump();
                   } // else we did not find the file.
                   continue;
                }

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -446,11 +446,11 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
 
          if (fFiles) {
             for (auto f: *fFiles) {
-               TObjString* file = dynamic_cast<TObjString*>(f);
+               TObjString *file = dynamic_cast<TObjString *>(f);
                if (!file) {
                   if (!dynamic_cast<TNamed*>(f)) {
                      Error("GetOptions()", "Inconsistent file entry (not a TObjString)!");
-                     f->Dump();
+                     if (f) f->Dump();
                   } // else we did not find the file.
                   continue;
                }
@@ -1223,7 +1223,7 @@ Int_t TApplication::ParseRemoteLine(const char *ln,
             script = tkn;
             script.Insert(0, "\"");
             script += "\"";
-            isScript = kFALSE;
+            // isScript = kFALSE; // [clang-tidy] never read
             break;
          }
       }

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1594,23 +1594,20 @@ void TColor::Print(Option_t *) const
 void TColor::RGB2HLS(Float_t rr, Float_t gg, Float_t bb,
                      Float_t &hue, Float_t &light, Float_t &satur)
 {
-   Float_t rnorm, gnorm, bnorm, minval, maxval, msum, mdiff, r, g, b;
-   minval = maxval =0 ;
-   r = g = b = 0;
+   Float_t r = 0, g = 0, b = 0;
    if (rr > 0) { r = rr; if (r > 1) r = 1; }
    if (gg > 0) { g = gg; if (g > 1) g = 1; }
    if (bb > 0) { b = bb; if (b > 1) b = 1; }
 
-   minval = r;
+   Float_t minval = r, maxval = r;
    if (g < minval) minval = g;
    if (b < minval) minval = b;
-   maxval = r;
    if (g > maxval) maxval = g;
    if (b > maxval) maxval = b;
 
-   rnorm = gnorm = bnorm = 0;
-   mdiff = maxval - minval;
-   msum  = maxval + minval;
+   Float_t rnorm, gnorm, bnorm;
+   Float_t mdiff = maxval - minval;
+   Float_t msum  = maxval + minval;
    light = 0.5f * msum;
    if (maxval != minval) {
       rnorm = (maxval - r)/mdiff;

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1068,7 +1068,6 @@ TDirectory *TDirectory::mkdir(const char *name, const char *title, Bool_t return
          tmpdir = mkdir(workname,title);
       delete[] workname;
       if (!tmpdir) return nullptr;
-      if (!newdir) newdir = tmpdir;
       return tmpdir->mkdir(slash+1);
    }
 
@@ -1257,7 +1256,7 @@ void TDirectory::DecodeNameCycle(const char *buffer, char *name, Short_t &cycle,
                                  const size_t namesize)
 {
    size_t len = 0;
-   const char *ni = strchr(buffer, ';');
+   const char *ni = buffer ? strchr(buffer, ';') : nullptr;
 
    if (ni) {
       // Found ';'

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1056,7 +1056,6 @@ TDirectory *TDirectory::mkdir(const char *name, const char *title, Bool_t return
    }
    if (!name || !title || !name[0]) return nullptr;
    if (!title[0]) title = name;
-   TDirectory *newdir = nullptr;
    if (const char *slash = strchr(name,'/')) {
       Long_t size = Long_t(slash-name);
       char *workname = new char[size+1];
@@ -1073,9 +1072,7 @@ TDirectory *TDirectory::mkdir(const char *name, const char *title, Bool_t return
 
    TDirectory::TContext ctxt(this);
 
-   newdir = new TDirectory(name, title, "", this);
-
-   return newdir;
+   return new TDirectory(name, title, "", this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TFolder.cxx
+++ b/core/base/src/TFolder.cxx
@@ -311,41 +311,35 @@ TObject *TFolder::FindObject(const TObject *) const
 
 TObject *TFolder::FindObject(const char *name) const
 {
-   if (!fFolders) return 0;
-   if (name == 0) return 0;
+   if (!fFolders || !name) return nullptr;
    if (name[0] == '/') {
       if (name[1] == '/') {
-         if (!strstr(name,"//root/")) return 0;
+         if (!strstr(name,"//root/")) return nullptr;
          return gROOT->GetRootFolder()->FindObject(name+7);
       } else {
          return gROOT->GetRootFolder()->FindObject(name+1);
       }
    }
    Int_t nch = strlen(name);
-   char *cname;
    char csname[128];
-   if (nch < (int)sizeof(csname))
-      cname = csname;
-   else
-      cname = new char[nch+1];
-   strcpy(cname, name);
-   TObject *obj;
+   char *cname = csname;
+   Int_t len = sizeof(csname);
+   if (nch >= len) {
+      len = nch+1;
+      cname = new char[len];
+   }
+   strncpy(cname, name, len);
+   TObject *ret = nullptr;
    char *slash = strchr(cname,'/');
    if (slash) {
       *slash = 0;
-      obj = fFolders->FindObject(cname);
-      if (!obj) {
-         if (nch >= (int)sizeof(csname)) delete [] cname;
-         return 0;
-      }
-      TObject *ret = obj->FindObject(slash+1);
-      if (nch >= (int)sizeof(csname)) delete [] cname;
-      return ret;
+      TObject *obj = fFolders->FindObject(cname);
+      if (obj) ret = obj->FindObject(slash+1);
    } else {
-      TObject *ret = fFolders->FindObject(cname);
-      if (nch >= (int)sizeof(csname)) delete [] cname;
-      return ret;
+      ret = fFolders->FindObject(cname);
    }
+   if (cname != csname) delete [] cname;
+   return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TFolder.cxx
+++ b/core/base/src/TFolder.cxx
@@ -338,7 +338,8 @@ TObject *TFolder::FindObject(const char *name) const
    } else {
       ret = fFolders->FindObject(cname);
    }
-   if (cname != csname) delete [] cname;
+   if (cname != csname)
+      delete [] cname;
    return ret;
 }
 

--- a/core/base/src/TFolder.cxx
+++ b/core/base/src/TFolder.cxx
@@ -328,13 +328,13 @@ TObject *TFolder::FindObject(const char *name) const
       len = nch+1;
       cname = new char[len];
    }
-   strncpy(cname, name, len);
+   strlcpy(cname, name, len);
    TObject *ret = nullptr;
    char *slash = strchr(cname,'/');
    if (slash) {
       *slash = 0;
-      TObject *obj = fFolders->FindObject(cname);
-      if (obj) ret = obj->FindObject(slash+1);
+      if (TObject *obj = fFolders->FindObject(cname))
+         ret = obj->FindObject(slash+1);
    } else {
       ret = fFolders->FindObject(cname);
    }

--- a/core/base/src/TPRegexp.cxx
+++ b/core/base/src/TPRegexp.cxx
@@ -399,7 +399,7 @@ Int_t TPRegexp::SubstituteInternal(TString &s, const TString &replacePattern,
 {
    Int_t *offVec = new Int_t[3*nMaxMatch];
 
-   TString final;
+   TString fin;
    Int_t nrSubs = 0;
    Int_t offset = start;
    Int_t last = 0;
@@ -413,7 +413,6 @@ Int_t TPRegexp::SubstituteInternal(TString &s, const TString &replacePattern,
                                 offVec, 3*nMaxMatch);
 
       if (nrMatch == PCRE_ERROR_NOMATCH) {
-         nrMatch = 0;
          break;
       } else if (nrMatch <= 0) {
          Error("Substitute", "pcre_exec error = %d", nrMatch);
@@ -422,15 +421,15 @@ Int_t TPRegexp::SubstituteInternal(TString &s, const TString &replacePattern,
 
       // append anything previously unmatched, but not substituted
       if (last <= offVec[0]) {
-         final += s(last,offVec[0]-last);
+         fin += s(last,offVec[0]-last);
          last = offVec[1];
       }
 
       // replace stuff in s
       if (doDollarSubst) {
-         ReplaceSubs(s, final, replacePattern, offVec, nrMatch);
+         ReplaceSubs(s, fin, replacePattern, offVec, nrMatch);
       } else {
-         final += replacePattern;
+         fin += replacePattern;
       }
       ++nrSubs;
 
@@ -438,20 +437,19 @@ Int_t TPRegexp::SubstituteInternal(TString &s, const TString &replacePattern,
       if (!(fPCREOpts & kPCRE_GLOBAL))
          break;
 
-      if (offVec[0] != offVec[1])
+      if (offVec[0] != offVec[1]) {
          offset = offVec[1];
-      else {
+      } else {
          // matched empty string
-         if (offVec[1] == s.Length())
-         break;
+         if (offVec[1] == s.Length()) break;
          offset = offVec[1]+1;
       }
    }
 
    delete [] offVec;
 
-   final += s(last,s.Length()-last);
-   s = final;
+   fin += s(last,s.Length()-last);
+   s = fin;
 
    return nrSubs;
 }

--- a/core/base/src/TQConnection.cxx
+++ b/core/base/src/TQConnection.cxx
@@ -113,7 +113,8 @@ TQSlot::TQSlot(TClass *cl, const char *method_name,
 
    auto len = strlen(method_name) + 1;
    char *method = new char[len];
-   if (method) strncpy(method, method_name, len);
+   if (method)
+      strncpy(method, method_name, len);
 
    char *proto;
    char *tmp;
@@ -185,7 +186,8 @@ TQSlot::TQSlot(const char *class_name, const char *funcname) :
 
    auto len = strlen(funcname) + 1;
    char *method = new char[len];
-   if (method) strncpy(method, funcname, len);
+   if (method)
+      strncpy(method, funcname, len);
 
    char *proto;
    char *tmp;

--- a/core/base/src/TQConnection.cxx
+++ b/core/base/src/TQConnection.cxx
@@ -32,6 +32,7 @@ TQConnection:
 #include <iostream>
 #include "TVirtualMutex.h"
 #include "THashTable.h"
+#include "strlcpy.h"
 
 ClassImpQ(TQConnection)
 
@@ -114,7 +115,7 @@ TQSlot::TQSlot(TClass *cl, const char *method_name,
    auto len = strlen(method_name) + 1;
    char *method = new char[len];
    if (method)
-      strncpy(method, method_name, len);
+      strlcpy(method, method_name, len);
 
    char *proto;
    char *tmp;
@@ -187,7 +188,7 @@ TQSlot::TQSlot(const char *class_name, const char *funcname) :
    auto len = strlen(funcname) + 1;
    char *method = new char[len];
    if (method)
-      strncpy(method, funcname, len);
+      strlcpy(method, funcname, len);
 
    char *proto;
    char *tmp;

--- a/core/base/src/TQConnection.cxx
+++ b/core/base/src/TQConnection.cxx
@@ -111,8 +111,9 @@ TQSlot::TQSlot(TClass *cl, const char *method_name,
 
    fName = method_name;
 
-   char *method = new char[strlen(method_name) + 1];
-   if (method) strcpy(method, method_name);
+   auto len = strlen(method_name) + 1;
+   char *method = new char[len];
+   if (method) strncpy(method, method_name, len);
 
    char *proto;
    char *tmp;
@@ -182,12 +183,13 @@ TQSlot::TQSlot(const char *class_name, const char *funcname) :
    fName      = funcname;
    fExecuting = 0;
 
-   char *method = new char[strlen(funcname) + 1];
-   if (method) strcpy(method, funcname);
+   auto len = strlen(funcname) + 1;
+   char *method = new char[len];
+   if (method) strncpy(method, funcname, len);
 
    char *proto;
    char *tmp;
-   char *params = 0;
+   char *params = nullptr;
 
    // separate method and prototype strings
 
@@ -202,11 +204,9 @@ TQSlot::TQSlot(const char *class_name, const char *funcname) :
    gCling->CallFunc_IgnoreExtraArgs(fFunc, true);
 
    fClass = gCling->ClassInfo_Factory();
-   TClass *cl = 0;
+   TClass *cl = nullptr;
 
-   if (!class_name)
-      ;                       // function
-   else {
+   if (class_name) {
       gCling->ClassInfo_Init(fClass, class_name);  // class
       cl = TClass::GetClass(class_name);
    }

--- a/core/base/src/TQObject.cxx
+++ b/core/base/src/TQObject.cxx
@@ -69,6 +69,7 @@ General purpose message signal
 #include "RQ_OBJECT.h"
 #include "TVirtualMutex.h"
 #include "RConfigure.h"
+#include "strlcpy.h"
 
 void *gTQSender; // A pointer to the object that sent the last signal.
                  // Getting access to the sender might be practical
@@ -181,7 +182,7 @@ Int_t TQObject::CheckConnectArgs(TQObject *sender,
 {
    auto len = strlen(signal)+1;
    char *signal_method = new char[len];
-   if (signal_method) strncpy(signal_method, signal, len);
+   if (signal_method) strlcpy(signal_method, signal, len);
 
    char *signal_proto;
    char *tmp;
@@ -239,7 +240,7 @@ Int_t TQObject::CheckConnectArgs(TQObject *sender,
 
    auto len2 = strlen(slot)+1;
    char *slot_method = new char[len2];
-   if (slot_method) strncpy(slot_method, slot, len2);
+   if (slot_method) strlcpy(slot_method, slot, len2);
 
    char *slot_proto;
    char *slot_params = nullptr;

--- a/core/base/src/TQObject.cxx
+++ b/core/base/src/TQObject.cxx
@@ -179,8 +179,9 @@ Int_t TQObject::CheckConnectArgs(TQObject *sender,
                                  TClass *sender_class, const char *signal,
                                  TClass *receiver_class, const char *slot)
 {
-   char *signal_method = new char[strlen(signal)+1];
-   if (signal_method) strcpy(signal_method, signal);
+   auto len = strlen(signal)+1;
+   char *signal_method = new char[len];
+   if (signal_method) strncpy(signal_method, signal, len);
 
    char *signal_proto;
    char *tmp;
@@ -236,11 +237,12 @@ Int_t TQObject::CheckConnectArgs(TQObject *sender,
    // cleaning
    delete [] signal_method;
 
-   char *slot_method = new char[strlen(slot)+1];
-   if (slot_method) strcpy(slot_method, slot);
+   auto len2 = strlen(slot)+1;
+   char *slot_method = new char[len2];
+   if (slot_method) strncpy(slot_method, slot, len2);
 
    char *slot_proto;
-   char *slot_params = 0;
+   char *slot_params = nullptr;
 
    if ((slot_proto = strchr(slot_method,'('))) {
 
@@ -254,7 +256,7 @@ Int_t TQObject::CheckConnectArgs(TQObject *sender,
    if (!slot_proto) slot_proto = (char*)"";     // avoid zero strings
    if ((slot_params = strchr(slot_proto,'='))) *slot_params = ' ';
 
-   TFunction *slotMethod = 0;
+   TFunction *slotMethod = nullptr;
    if (!receiver_class) {
       // case of slot_method is compiled/intrepreted function
       slotMethod = gROOT->GetGlobalFunction(slot_method,0,kFALSE);

--- a/core/base/src/TRegexp.cxx
+++ b/core/base/src/TRegexp.cxx
@@ -270,7 +270,7 @@ TSubString TString::operator()(const TRegexp& r, Ssiz_t start) const
 {
    Ssiz_t len = 0;
    Ssiz_t begin = Index(r, &len, start);
-   return TSubString(*this, begin, len); // [clang-tidy] here len used and must be initialized
+   return TSubString(*this, begin, len);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TRegexp.cxx
+++ b/core/base/src/TRegexp.cxx
@@ -268,9 +268,9 @@ Ssiz_t TString::Index(const TRegexp& r, Ssiz_t* extent, Ssiz_t start) const
 
 TSubString TString::operator()(const TRegexp& r, Ssiz_t start) const
 {
-   Ssiz_t len;
+   Ssiz_t len = 0;
    Ssiz_t begin = Index(r, &len, start);
-   return TSubString(*this, begin, len);
+   return TSubString(*this, begin, len); // [clang-tidy] here len used and must be initialized
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -224,12 +224,12 @@ TString::TString(const char *a1, Ssiz_t n1, const char *a2, Ssiz_t n2)
       Zero();
       return;
    }
-   if (!a1) n1=0;
-   if (!a2) n2=0;
+   if (!a1) n1 = 0;
+   if (!a2) n2 = 0;
    Ssiz_t tot = n1+n2;
    char *data = Init(tot, tot);
-   memcpy(data,    a1, n1);
-   memcpy(data+n1, a2, n2);
+   if (a1) memcpy(data,    a1, n1);
+   if (a2) memcpy(data+n1, a2, n2);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1028,7 +1028,9 @@ TString &TString::Replace(Ssiz_t pos, Ssiz_t n1, const char *cs, Ssiz_t n2)
             if (n1 > n2) {
                if (n2) memmove(p + pos, cs, n2);
                memmove(p + pos + n2, p + pos + n1, rem);
-               goto finish;
+               SetSize(tot);
+               p[tot] = 0;
+               return *this;
             }
             if (p + pos < cs && cs < p + len) {
                if (p + pos + n1 <= cs)
@@ -1045,7 +1047,6 @@ TString &TString::Replace(Ssiz_t pos, Ssiz_t n1, const char *cs, Ssiz_t n2)
          }
       }
       if (n2) memmove(p + pos, cs, n2);
-finish:
       SetSize(tot);
       p[tot] = 0;
    } else {
@@ -2509,10 +2510,11 @@ char *Strip(const char *s, char c)
 
 char *StrDup(const char *str)
 {
-   if (!str) return 0;
+   if (!str) return nullptr;
 
-   char *s = new char[strlen(str)+1];
-   if (s) strcpy(s, str);
+   auto len = strlen(str)+1;
+   char *s = new char[len];
+   if (s) strncpy(s, str, len);
 
    return s;
 }

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -42,6 +42,7 @@ as a TString, construct a TString from it, eg:
 #include <algorithm>
 
 #include "Varargs.h"
+#include "strlcpy.h"
 #include "TString.h"
 #include "TBuffer.h"
 #include "TError.h"
@@ -2514,7 +2515,7 @@ char *StrDup(const char *str)
 
    auto len = strlen(str)+1;
    char *s = new char[len];
-   if (s) strncpy(s, str, len);
+   if (s) strlcpy(s, str, len);
 
    return s;
 }

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2871,7 +2871,7 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
       }
    }
    UInt_t verboseLevel = verbose ? 7 : gDebug;
-   Bool_t flatBuildDir = (fAclicProperties & kFlatBuildDir) || (strchr(opt,'-')!=0);
+   Bool_t flatBuildDir = (fAclicProperties & kFlatBuildDir) || (opt && strchr(opt,'-')!=0);
 
    // if non-zero, build_loc indicates where to build the shared library.
    TString build_loc = ExpandFileName(GetBuildDir());


### PR DESCRIPTION
As reported in #7412

Most of them use of `strcpy` and nullptr in `strchr`
Also several unused variables removed
Simplify TFolder::FindObject