### PR TITLE
Fix and simplify copy_headers for Travis

### DIFF
--- a/.ci/copy_headers.sh
+++ b/.ci/copy_headers.sh
@@ -9,18 +9,7 @@ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -Dall=On -Dtesting=On -Dx11=Off -Dalien
       -Dcuda=Off -Dtmva-gpu=Off -Dveccore=Off ../root
 # We need to prebuild a minimal set of targets which are responsible for header copy
 # or generation.
-make -j4 move_headers intrinsics_gen ClangCommentCommandList ClangCommentCommandInfo \
-         ClangCommentHTMLNamedCharacterReferences ClangCommentHTMLTagsProperties     \
-         ClangCommentNodes ClangAttrImpl ClangStmtNodes ClangAttrClasses             \
-         ClangAttrDump ClangCommentHTMLTags ClangDeclNodes ClangAttrVisitor          \
-         ClangDiagnosticCommon ClangARMNeon ClangDiagnosticIndexName                 \
-         ClangDiagnosticParse ClangDiagnosticComment ClangDiagnosticFrontend         \
-         ClangDiagnosticGroups ClangDiagnosticSerialization ClangDiagnosticLex       \
-         ClangDiagnosticSema ClangAttrList ClangAttrHasAttributeImpl                 \
-         ClangDiagnosticAST ClangDiagnosticDriver ClangDiagnosticAnalysis            \
-         ClangDriverOptions ClangAttrParserStringSwitches ClangAttrParsedAttrList    \
-         ClangAttrTemplateInstantiate ClangAttrSpellingListIndex                     \
-         ClangAttrParsedAttrImpl ClangAttrParsedAttrKinds googletest Dictgen         \
-         ClangAttrSubjectMatchRuleList BaseTROOT
+make -j4 move_headers intrinsics_gen clang-tablegen-targets ClangDriverOptions \
+         googletest Dictgen BaseTROOT
 ln -s $PWD/compile_commands.json $PWD/../root/
 


### PR DESCRIPTION
Use `clang-tablegen-targets` for all generated headers, except for `ClangDriverOptions` which is added via `add_public_tablegen_target`.