### PR TITLE
Fixing calng-tidy issues in clingutils

### DIFF
--- a/core/clingutils/src/RStl.cxx
+++ b/core/clingutils/src/RStl.cxx
@@ -72,6 +72,7 @@ void ROOT::Internal::RStl::GenerateTClassFor(const clang::QualType &type, const 
    if (!templateCl) {
       ROOT::TMetaUtils::Error("RStl::GenerateTClassFor","%s not in a template",
             ROOT::TMetaUtils::GetQualifiedName(*stlclass).c_str());
+      return;
    }
 
    if ( TClassEdit::STLKind( stlclass->getName().str() )  == ROOT::kSTLvector ) {
@@ -127,9 +128,10 @@ void ROOT::Internal::RStl::GenerateTClassFor(const char *requestedName, const cl
    // Force the generation of the TClass for the given class.
    const clang::ClassTemplateSpecializationDecl *templateCl = llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(stlclass);
 
-   if (templateCl == 0) {
+   if (!templateCl) {
       ROOT::TMetaUtils::Error("RStl::GenerateTClassFor","%s not in a template",
             ROOT::TMetaUtils::GetQualifiedName(*stlclass).c_str());
+      return;
    }
 
 

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -3188,14 +3188,12 @@ llvm::StringRef ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(const clang::D
          }
       } else { // current token is not a digit
          // first let's see if it is a data member:
-         int found = 0;
          const clang::CXXRecordDecl *parent_clxx = llvm::dyn_cast<clang::CXXRecordDecl>(m.getDeclContext());
          const clang::FieldDecl *index1 = 0;
          if (parent_clxx)
             index1 = GetDataMemberFromAll(*parent_clxx, current );
          if ( index1 ) {
             if ( IsFieldDeclInt(index1) ) {
-               found = 1;
                // Let's see if it has already been written down in the
                // Streamer.
                // Let's see if we already wrote it down in the
@@ -3229,6 +3227,7 @@ llvm::StringRef ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(const clang::D
          } else {
             // There is no variable by this name in this class, let see
             // the base classes!:
+            int found = 0;
             index1 = GetDataMemberFromAllParents( *parent_clxx, current );
             if ( index1 ) {
                if ( IsFieldDeclInt(index1) ) {

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -3189,7 +3189,7 @@ llvm::StringRef ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(const clang::D
       } else { // current token is not a digit
          // first let's see if it is a data member:
          const clang::CXXRecordDecl *parent_clxx = llvm::dyn_cast<clang::CXXRecordDecl>(m.getDeclContext());
-         const clang::FieldDecl *index1 = 0;
+         const clang::FieldDecl *index1 = nullptr;
          if (parent_clxx)
             index1 = GetDataMemberFromAll(*parent_clxx, current );
          if ( index1 ) {
@@ -3228,7 +3228,8 @@ llvm::StringRef ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(const clang::D
             // There is no variable by this name in this class, let see
             // the base classes!:
             int found = 0;
-            index1 = GetDataMemberFromAllParents( *parent_clxx, current );
+            if (parent_clxx)
+               index1 = GetDataMemberFromAllParents( *parent_clxx, current );
             if ( index1 ) {
                if ( IsFieldDeclInt(index1) ) {
                   found = 1;

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -109,11 +109,11 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 /// Add default parameter to the scope if needed.
 
-static clang::NestedNameSpecifier* AddDefaultParametersNNS(const clang::ASTContext& Ctx,
+static clang::NestedNameSpecifier *AddDefaultParametersNNS(const clang::ASTContext& Ctx,
                                                            clang::NestedNameSpecifier* scope,
                                                            const cling::Interpreter &interpreter,
                                                            const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) {
-   if (!scope) return 0;
+   if (!scope) return nullptr;
 
    const clang::Type* scope_type = scope->getAsType();
    if (scope_type) {
@@ -158,11 +158,11 @@ static bool CheckDefinition(const clang::CXXRecordDecl *cl, const clang::CXXReco
 /// instantiating the class template instance and replace it with the
 /// partially sugared types we have from 'instance'.
 
-static clang::NestedNameSpecifier* ReSubstTemplateArgNNS(const clang::ASTContext &Ctxt,
+static clang::NestedNameSpecifier *ReSubstTemplateArgNNS(const clang::ASTContext &Ctxt,
                                                          clang::NestedNameSpecifier *scope,
                                                          const clang::Type *instance)
 {
-   if (!scope) return 0;
+   if (!scope) return nullptr;
 
    const clang::Type* scope_type = scope->getAsType();
    if (scope_type) {
@@ -211,8 +211,7 @@ static const clang::FieldDecl *GetDataMemberFromAll(const clang::CXXRecordDecl &
          return *field_iter;
       }
    }
-   return 0;
-
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -273,7 +272,7 @@ static const clang::FieldDecl *GetDataMemberFromAllParents(const clang::CXXRecor
          return found;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 static
@@ -2848,7 +2847,7 @@ clang::RecordDecl *ROOT::TMetaUtils::GetUnderlyingRecordDecl(clang::QualType typ
 
    if (rawtype->isFundamentalType() || rawtype->isEnumeralType()) {
       // not an object.
-      return 0;
+      return nullptr;
    }
    return rawtype->getAsCXXRecordDecl();
 }
@@ -4860,10 +4859,10 @@ ROOT::ESTLType ROOT::TMetaUtils::STLKind(const llvm::StringRef type)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const clang::TypedefNameDecl* ROOT::TMetaUtils::GetAnnotatedRedeclarable(const clang::TypedefNameDecl* TND)
+const clang::TypedefNameDecl *ROOT::TMetaUtils::GetAnnotatedRedeclarable(const clang::TypedefNameDecl *TND)
 {
    if (!TND)
-      return 0;
+      return nullptr;
 
    TND = TND->getMostRecentDecl();
    while (TND && !(TND->hasAttrs()))
@@ -4874,10 +4873,10 @@ const clang::TypedefNameDecl* ROOT::TMetaUtils::GetAnnotatedRedeclarable(const c
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const clang::TagDecl* ROOT::TMetaUtils::GetAnnotatedRedeclarable(const clang::TagDecl* TD)
+const clang::TagDecl *ROOT::TMetaUtils::GetAnnotatedRedeclarable(const clang::TagDecl *TD)
 {
    if (!TD)
-      return 0;
+      return nullptr;
 
    TD = TD->getMostRecentDecl();
    while (TD && !(TD->hasAttrs() && TD->isThisDeclarationADefinition()))
@@ -4936,11 +4935,11 @@ void ROOT::TMetaUtils::ExtractCtxtEnclosingNameSpaces(const clang::DeclContext& 
 /// Extract the names and types of containing scopes.
 /// Stop if a class is met and return its pointer.
 
-const clang::RecordDecl* ROOT::TMetaUtils::ExtractEnclosingScopes(const clang::Decl& decl,
+const clang::RecordDecl *ROOT::TMetaUtils::ExtractEnclosingScopes(const clang::Decl& decl,
                                                                   std::list<std::pair<std::string,unsigned int> >& enclosingSc)
 {
    const clang::DeclContext* enclosingDeclCtxt = decl.getDeclContext();
-   if (!enclosingDeclCtxt) return 0;
+   if (!enclosingDeclCtxt) return nullptr;
 
    unsigned int scopeType;
 
@@ -4957,7 +4956,6 @@ const clang::RecordDecl* ROOT::TMetaUtils::ExtractEnclosingScopes(const clang::D
    }
 
    return nullptr;
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -27,6 +27,7 @@
 #include <ROOT/RConfig.hxx>
 #include <ROOT/FoundationUtils.hxx>
 #include "Rtypes.h"
+#include "strlcpy.h"
 
 #include "RStl.h"
 
@@ -3285,34 +3286,39 @@ void ROOT::TMetaUtils::GetCppName(std::string &out, const char *in)
       if (out.capacity() < (j+3)) {
          out.resize(2*j+3);
       }
+      const char *repl = nullptr;
       switch(c) { // We resized the underlying buffer if needed
-         case '+': strcpy(const_cast<char*>(out.data())+j,"pL"); j+=2; break;
-         case '-': strcpy(const_cast<char*>(out.data())+j,"mI"); j+=2; break;
-         case '*': strcpy(const_cast<char*>(out.data())+j,"mU"); j+=2; break;
-         case '/': strcpy(const_cast<char*>(out.data())+j,"dI"); j+=2; break;
-         case '&': strcpy(const_cast<char*>(out.data())+j,"aN"); j+=2; break;
-         case '%': strcpy(const_cast<char*>(out.data())+j,"pE"); j+=2; break;
-         case '|': strcpy(const_cast<char*>(out.data())+j,"oR"); j+=2; break;
-         case '^': strcpy(const_cast<char*>(out.data())+j,"hA"); j+=2; break;
-         case '>': strcpy(const_cast<char*>(out.data())+j,"gR"); j+=2; break;
-         case '<': strcpy(const_cast<char*>(out.data())+j,"lE"); j+=2; break;
-         case '=': strcpy(const_cast<char*>(out.data())+j,"eQ"); j+=2; break;
-         case '~': strcpy(const_cast<char*>(out.data())+j,"wA"); j+=2; break;
-         case '.': strcpy(const_cast<char*>(out.data())+j,"dO"); j+=2; break;
-         case '(': strcpy(const_cast<char*>(out.data())+j,"oP"); j+=2; break;
-         case ')': strcpy(const_cast<char*>(out.data())+j,"cP"); j+=2; break;
-         case '[': strcpy(const_cast<char*>(out.data())+j,"oB"); j+=2; break;
-         case ']': strcpy(const_cast<char*>(out.data())+j,"cB"); j+=2; break;
-         case '!': strcpy(const_cast<char*>(out.data())+j,"nO"); j+=2; break;
-         case ',': strcpy(const_cast<char*>(out.data())+j,"cO"); j+=2; break;
-         case '$': strcpy(const_cast<char*>(out.data())+j,"dA"); j+=2; break;
-         case ' ': strcpy(const_cast<char*>(out.data())+j,"sP"); j+=2; break;
-         case ':': strcpy(const_cast<char*>(out.data())+j,"cL"); j+=2; break;
-         case '"': strcpy(const_cast<char*>(out.data())+j,"dQ"); j+=2; break;
-         case '@': strcpy(const_cast<char*>(out.data())+j,"aT"); j+=2; break;
-         case '\'': strcpy(const_cast<char*>(out.data())+j,"sQ"); j+=2; break;
-         case '\\': strcpy(const_cast<char*>(out.data())+j,"fI"); j+=2; break;
+         case '+': repl = "pL"; break;
+         case '-': repl = "mI"; break;
+         case '*': repl = "mU"; break;
+         case '/': repl = "dI"; break;
+         case '&': repl = "aN"; break;
+         case '%': repl = "pE"; break;
+         case '|': repl = "oR"; break;
+         case '^': repl = "hA"; break;
+         case '>': repl = "gR"; break;
+         case '<': repl = "lE"; break;
+         case '=': repl = "eQ"; break;
+         case '~': repl = "wA"; break;
+         case '.': repl = "dO"; break;
+         case '(': repl = "oP"; break;
+         case ')': repl = "cP"; break;
+         case '[': repl = "oB"; break;
+         case ']': repl = "cB"; break;
+         case '!': repl = "nO"; break;
+         case ',': repl = "cO"; break;
+         case '$': repl = "dA"; break;
+         case ' ': repl = "sP"; break;
+         case ':': repl = "cL"; break;
+         case '"': repl = "dQ"; break;
+         case '@': repl = "aT"; break;
+         case '\'': repl = "sQ"; break;
+         case '\\': repl = "fI"; break;
          default: out[j++]=c; break;
+      }
+      if (repl) {
+         strlcpy(const_cast<char*>(out.data())+j, repl, out.capacity()-j);
+         j+=2;
       }
       ++i;
    }
@@ -3321,8 +3327,6 @@ void ROOT::TMetaUtils::GetCppName(std::string &out, const char *in)
    // Remove initial numbers if any
    std::size_t firstNonNumber = out.find_first_not_of("0123456789");
    out.replace(0,firstNonNumber,"");
-
-   return;
 }
 
 static clang::SourceLocation


### PR DESCRIPTION
Addressing report in #7423 
In most cases - potential access to nullptr.
Plus improving GetCppName.