### PR TITLE
Fixing clang-tidy warnings in core/cont classes

### DIFF
--- a/core/cont/inc/TBits.h
+++ b/core/cont/inc/TBits.h
@@ -52,10 +52,11 @@ public:
       TBits  &fBits; //!
       UInt_t  fPos;  //!
 
-      TReference(); // left undefined
+      TReference() = delete;
 
-public:
-      TReference(TBits& bit, UInt_t pos) : fBits(bit),fPos(pos) { }
+   public:
+      TReference(TBits& bit, UInt_t pos) : fBits(bit), fPos(pos) {}
+      TReference(const TReference &rhs) : fBits(rhs.fBits), fPos(rhs.fPos) {}
       ~TReference() { }
 
        // For b[i] = val;

--- a/core/cont/inc/TBtree.h
+++ b/core/cont/inc/TBtree.h
@@ -189,7 +189,7 @@ private:
    TBtItem    *fItem;   // actually fItem[MaxIndex()+1] is desired
 
 public:
-   TBtInnerNode(TBtInnerNode *parent, TBtree *t = 0);
+   TBtInnerNode(TBtInnerNode *parent, TBtree *t = nullptr);
    TBtInnerNode(TBtInnerNode *parent, TBtree *tree, TBtNode *oldroot);
    ~TBtInnerNode();
 
@@ -245,8 +245,8 @@ public:
 
    Int_t     Psize() const { return fLast; }
    Int_t     Vsize() const;
-   Int_t     MaxIndex() const { return fTree->fInnerMaxIndex; }
-   Int_t     MaxPsize() const { return fTree->fInnerMaxIndex; }
+   Int_t     MaxIndex() const { return fTree ? fTree->fInnerMaxIndex : 0; }
+   Int_t     MaxPsize() const { return fTree ? fTree->fInnerMaxIndex : 0; }
 
    // void      PrintOn(std::ostream &os) const;
 
@@ -275,7 +275,7 @@ private:
    TObject **fItem; // actually TObject *fItem[MaxIndex()+1] is desired
 
 public:
-   TBtLeafNode(TBtInnerNode *p, const TObject *obj = 0, TBtree *t = 0);
+   TBtLeafNode(TBtInnerNode *p, const TObject *obj = nullptr, TBtree *t = nullptr);
    ~TBtLeafNode();
 
 #ifndef __CINT__
@@ -311,8 +311,8 @@ public:
 
    Int_t      Psize() const { return fLast + 1; }
    Int_t      Vsize() const;
-   Int_t      MaxIndex() const { return fTree->fLeafMaxIndex; }
-   Int_t      MaxPsize() const { return fTree->fLeafMaxIndex + 1; }
+   Int_t      MaxIndex() const { return fTree ? fTree->fLeafMaxIndex : 0; }
+   Int_t      MaxPsize() const { return fTree ? fTree->fLeafMaxIndex + 1 : 0; }
 
    // void       PrintOn(std::ostream &os) const;
 

--- a/core/cont/src/TArrayC.cxx
+++ b/core/cont/src/TArrayC.cxx
@@ -111,10 +111,11 @@ void TArrayC::Set(Int_t n)
          fArray = new Char_t[n];
          if (n < fN) {
             memcpy(fArray, temp, n*sizeof(Char_t));
+         } else if (temp) {
+            memcpy(fArray, temp, fN*sizeof(Char_t));
+            memset(&fArray[fN], 0, (n-fN)*sizeof(Char_t));
          } else {
-            if (temp)
-               memcpy(fArray, temp, fN*sizeof(Char_t));
-            memset(&fArray[fN],0,(n-fN)*sizeof(Char_t));
+            memset(fArray, 0, n*sizeof(Char_t));
          }
       } else {
          fArray = nullptr;

--- a/core/cont/src/TArrayC.cxx
+++ b/core/cont/src/TArrayC.cxx
@@ -25,7 +25,7 @@ ClassImp(TArrayC);
 
 TArrayC::TArrayC()
 {
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ TArrayC::TArrayC()
 
 TArrayC::TArrayC(Int_t n)
 {
-   fArray = 0;
+   fArray = nullptr;
    if (n > 0) Set(n);
 }
 
@@ -42,7 +42,7 @@ TArrayC::TArrayC(Int_t n)
 
 TArrayC::TArrayC(Int_t n, const Char_t *array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(n, array);
 }
 
@@ -51,7 +51,7 @@ TArrayC::TArrayC(Int_t n, const Char_t *array)
 
 TArrayC::TArrayC(const TArrayC &array) : TArray(array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(array.fN, array.fArray);
 }
 
@@ -71,7 +71,7 @@ TArrayC &TArrayC::operator=(const TArrayC &rhs)
 TArrayC::~TArrayC()
 {
    delete [] fArray;
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,13 +109,15 @@ void TArrayC::Set(Int_t n)
       Char_t *temp = fArray;
       if (n != 0) {
          fArray = new Char_t[n];
-         if (n < fN) memcpy(fArray,temp, n*sizeof(Char_t));
-         else {
-            memcpy(fArray,temp,fN*sizeof(Char_t));
+         if (n < fN) {
+            memcpy(fArray, temp, n*sizeof(Char_t));
+         } else {
+            if (temp)
+               memcpy(fArray, temp, fN*sizeof(Char_t));
             memset(&fArray[fN],0,(n-fN)*sizeof(Char_t));
          }
       } else {
-         fArray = 0;
+         fArray = nullptr;
       }
       if (fN) delete [] temp;
       fN = n;
@@ -130,11 +132,11 @@ void TArrayC::Set(Int_t n, const Char_t *array)
 {
    if (fArray && fN != n) {
       delete [] fArray;
-      fArray = 0;
+      fArray = nullptr;
    }
    fN = n;
-   if (fN == 0) return;
-   if (array == 0) return;
+   if ((fN == 0) || !array)
+      return;
    if (!fArray) fArray = new Char_t[fN];
    memmove(fArray, array, n*sizeof(Char_t));
 }

--- a/core/cont/src/TArrayD.cxx
+++ b/core/cont/src/TArrayD.cxx
@@ -25,7 +25,7 @@ ClassImp(TArrayD);
 
 TArrayD::TArrayD()
 {
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ TArrayD::TArrayD()
 
 TArrayD::TArrayD(Int_t n)
 {
-   fArray = 0;
+   fArray = nullptr;
    if (n > 0) Set(n);
 }
 
@@ -42,7 +42,7 @@ TArrayD::TArrayD(Int_t n)
 
 TArrayD::TArrayD(Int_t n, const Double_t *array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(n, array);
 }
 
@@ -51,7 +51,7 @@ TArrayD::TArrayD(Int_t n, const Double_t *array)
 
 TArrayD::TArrayD(const TArrayD &array) : TArray(array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(array.fN, array.fArray);
 }
 
@@ -71,7 +71,7 @@ TArrayD &TArrayD::operator=(const TArrayD &rhs)
 TArrayD::~TArrayD()
 {
    delete [] fArray;
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -88,8 +88,8 @@ void TArrayD::Adopt(Int_t n, Double_t *arr)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set the double c value at position i in the array. Check for out of bounds. 
-/// Warning: the name of the method is misleading, it actually overwrites the position i. 
+/// Set the double c value at position i in the array. Check for out of bounds.
+/// Warning: the name of the method is misleading, it actually overwrites the position i.
 
 void TArrayD::AddAt(Double_t c, Int_t i)
 {
@@ -110,13 +110,15 @@ void TArrayD::Set(Int_t n)
       Double_t *temp = fArray;
       if (n != 0) {
          fArray = new Double_t[n];
-         if (n < fN) memcpy(fArray,temp, n*sizeof(Double_t));
-         else {
-            memcpy(fArray,temp,fN*sizeof(Double_t));
+         if (n < fN) {
+            memcpy(fArray,temp, n*sizeof(Double_t));
+         } else {
+            if (temp)
+               memcpy(fArray,temp,fN*sizeof(Double_t));
             memset(&fArray[fN],0,(n-fN)*sizeof(Double_t));
          }
       } else {
-         fArray = 0;
+         fArray = nullptr;
       }
       if (fN) delete [] temp;
       fN = n;
@@ -131,11 +133,11 @@ void TArrayD::Set(Int_t n, const Double_t *array)
 {
    if (fArray && fN != n) {
       delete [] fArray;
-      fArray = 0;
+      fArray = nullptr;
    }
    fN = n;
-   if (fN == 0) return;
-   if (array == 0) return;
+   if ((fN == 0) || !array)
+      return;
    if (!fArray) fArray = new Double_t[fN];
    memmove(fArray, array, n*sizeof(Double_t));
 }

--- a/core/cont/src/TArrayD.cxx
+++ b/core/cont/src/TArrayD.cxx
@@ -111,11 +111,12 @@ void TArrayD::Set(Int_t n)
       if (n != 0) {
          fArray = new Double_t[n];
          if (n < fN) {
-            memcpy(fArray,temp, n*sizeof(Double_t));
+            memcpy(fArray, temp, n*sizeof(Double_t));
+         } else if (temp) {
+            memcpy(fArray, temp, fN*sizeof(Double_t));
+            memset(&fArray[fN], 0, (n-fN)*sizeof(Double_t));
          } else {
-            if (temp)
-               memcpy(fArray,temp,fN*sizeof(Double_t));
-            memset(&fArray[fN],0,(n-fN)*sizeof(Double_t));
+            memset(fArray, 0, n*sizeof(Double_t));
          }
       } else {
          fArray = nullptr;

--- a/core/cont/src/TArrayF.cxx
+++ b/core/cont/src/TArrayF.cxx
@@ -111,10 +111,11 @@ void TArrayF::Set(Int_t n)
          fArray = new Float_t[n];
          if (n < fN) {
             memcpy(fArray, temp, n*sizeof(Float_t));
-         } else {
-            if (temp)
-               memcpy(fArray, temp, fN*sizeof(Float_t));
+         } else if (temp) {
+            memcpy(fArray, temp, fN*sizeof(Float_t));
             memset(&fArray[fN], 0, (n-fN)*sizeof(Float_t));
+         } else {
+            memset(fArray, 0, n*sizeof(Float_t));
          }
       } else {
          fArray = nullptr;

--- a/core/cont/src/TArrayF.cxx
+++ b/core/cont/src/TArrayF.cxx
@@ -25,7 +25,7 @@ ClassImp(TArrayF);
 
 TArrayF::TArrayF()
 {
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ TArrayF::TArrayF()
 
 TArrayF::TArrayF(Int_t n)
 {
-   fArray = 0;
+   fArray = nullptr;
    if (n > 0) Set(n);
 }
 
@@ -42,7 +42,7 @@ TArrayF::TArrayF(Int_t n)
 
 TArrayF::TArrayF(Int_t n, const Float_t *array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(n, array);
 }
 
@@ -51,7 +51,7 @@ TArrayF::TArrayF(Int_t n, const Float_t *array)
 
 TArrayF::TArrayF(const TArrayF &array) : TArray(array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(array.fN, array.fArray);
 }
 
@@ -71,7 +71,7 @@ TArrayF &TArrayF::operator=(const TArrayF &rhs)
 TArrayF::~TArrayF()
 {
    delete [] fArray;
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,13 +109,15 @@ void TArrayF::Set(Int_t n)
       Float_t *temp = fArray;
       if (n != 0) {
          fArray = new Float_t[n];
-         if (n < fN) memcpy(fArray,temp, n*sizeof(Float_t));
-         else {
-            memcpy(fArray,temp,fN*sizeof(Float_t));
-            memset(&fArray[fN],0,(n-fN)*sizeof(Float_t));
+         if (n < fN) {
+            memcpy(fArray, temp, n*sizeof(Float_t));
+         } else {
+            if (temp)
+               memcpy(fArray, temp, fN*sizeof(Float_t));
+            memset(&fArray[fN], 0, (n-fN)*sizeof(Float_t));
          }
       } else {
-         fArray = 0;
+         fArray = nullptr;
       }
       if (fN) delete [] temp;
       fN = n;
@@ -130,11 +132,11 @@ void TArrayF::Set(Int_t n, const Float_t *array)
 {
    if (fArray && fN != n) {
       delete [] fArray;
-      fArray = 0;
+      fArray = nullptr;
    }
    fN = n;
-   if (fN == 0) return;
-   if (array == 0) return;
+   if ((fN == 0) || !array)
+      return;
    if (!fArray) fArray = new Float_t[fN];
    memmove(fArray, array, n*sizeof(Float_t));
 }

--- a/core/cont/src/TArrayI.cxx
+++ b/core/cont/src/TArrayI.cxx
@@ -25,7 +25,7 @@ ClassImp(TArrayI);
 
 TArrayI::TArrayI()
 {
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ TArrayI::TArrayI()
 
 TArrayI::TArrayI(Int_t n)
 {
-   fArray = 0;
+   fArray = nullptr;
    if (n > 0) Set(n);
 }
 
@@ -42,7 +42,7 @@ TArrayI::TArrayI(Int_t n)
 
 TArrayI::TArrayI(Int_t n, const Int_t *array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(n, array);
 }
 
@@ -51,7 +51,7 @@ TArrayI::TArrayI(Int_t n, const Int_t *array)
 
 TArrayI::TArrayI(const TArrayI &array) : TArray(array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(array.fN, array.fArray);
 }
 
@@ -71,7 +71,7 @@ TArrayI &TArrayI::operator=(const TArrayI &rhs)
 TArrayI::~TArrayI()
 {
    delete [] fArray;
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,13 +109,15 @@ void TArrayI::Set(Int_t n)
       Int_t *temp = fArray;
       if (n != 0) {
          fArray = new Int_t[n];
-         if (n < fN) memcpy(fArray,temp, n*sizeof(Int_t));
-         else {
-            memcpy(fArray,temp,fN*sizeof(Int_t));
-            memset(&fArray[fN],0,(n-fN)*sizeof(Int_t));
+         if (n < fN) {
+            memcpy(fArray, temp, n*sizeof(Int_t));
+         } else {
+            if(temp)
+               memcpy(fArray, temp, fN*sizeof(Int_t));
+            memset(&fArray[fN], 0, (n-fN)*sizeof(Int_t));
          }
       } else {
-         fArray = 0;
+         fArray = nullptr;
       }
       if (fN) delete [] temp;
       fN = n;
@@ -130,11 +132,11 @@ void TArrayI::Set(Int_t n, const Int_t *array)
 {
    if (fArray && fN != n) {
       delete [] fArray;
-      fArray = 0;
+      fArray = nullptr;
    }
    fN = n;
-   if (fN == 0) return;
-   if (array == 0) return;
+   if ((fN == 0) || !array)
+      return;
    if (!fArray) fArray = new Int_t[fN];
    memmove(fArray, array, n*sizeof(Int_t));
 }

--- a/core/cont/src/TArrayI.cxx
+++ b/core/cont/src/TArrayI.cxx
@@ -111,10 +111,11 @@ void TArrayI::Set(Int_t n)
          fArray = new Int_t[n];
          if (n < fN) {
             memcpy(fArray, temp, n*sizeof(Int_t));
-         } else {
-            if(temp)
-               memcpy(fArray, temp, fN*sizeof(Int_t));
+         } else if(temp) {
+            memcpy(fArray, temp, fN*sizeof(Int_t));
             memset(&fArray[fN], 0, (n-fN)*sizeof(Int_t));
+         } else {
+            memset(fArray, 0, n*sizeof(Int_t));
          }
       } else {
          fArray = nullptr;

--- a/core/cont/src/TArrayL.cxx
+++ b/core/cont/src/TArrayL.cxx
@@ -111,10 +111,11 @@ void TArrayL::Set(Int_t n)
          fArray = new Long_t[n];
          if (n < fN) {
             memcpy(fArray, temp, n*sizeof(Long_t));
-         } else {
-            if (temp)
-               memcpy(fArray, temp, fN*sizeof(Long_t));
+         } else if (temp) {
+            memcpy(fArray, temp, fN*sizeof(Long_t));
             memset(&fArray[fN], 0, (n-fN)*sizeof(Long_t));
+         } else {
+            memset(fArray, 0, n*sizeof(Long_t));
          }
       } else {
          fArray = nullptr;

--- a/core/cont/src/TArrayL.cxx
+++ b/core/cont/src/TArrayL.cxx
@@ -25,7 +25,7 @@ ClassImp(TArrayL);
 
 TArrayL::TArrayL()
 {
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ TArrayL::TArrayL()
 
 TArrayL::TArrayL(Int_t n)
 {
-   fArray = 0;
+   fArray = nullptr;
    if (n > 0) Set(n);
 }
 
@@ -42,7 +42,7 @@ TArrayL::TArrayL(Int_t n)
 
 TArrayL::TArrayL(Int_t n, const Long_t *array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(n, array);
 }
 
@@ -51,7 +51,7 @@ TArrayL::TArrayL(Int_t n, const Long_t *array)
 
 TArrayL::TArrayL(const TArrayL &array) : TArray(array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(array.fN, array.fArray);
 }
 
@@ -71,7 +71,7 @@ TArrayL &TArrayL::operator=(const TArrayL &rhs)
 TArrayL::~TArrayL()
 {
    delete [] fArray;
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,13 +109,15 @@ void TArrayL::Set(Int_t n)
       Long_t *temp = fArray;
       if (n != 0) {
          fArray = new Long_t[n];
-         if (n < fN) memcpy(fArray,temp, n*sizeof(Long_t));
-         else {
-            memcpy(fArray,temp,fN*sizeof(Long_t));
-            memset(&fArray[fN],0,(n-fN)*sizeof(Long_t));
+         if (n < fN) {
+            memcpy(fArray, temp, n*sizeof(Long_t));
+         } else {
+            if (temp)
+               memcpy(fArray, temp, fN*sizeof(Long_t));
+            memset(&fArray[fN], 0, (n-fN)*sizeof(Long_t));
          }
       } else {
-         fArray = 0;
+         fArray = nullptr;
       }
       if (fN) delete [] temp;
       fN = n;
@@ -130,11 +132,11 @@ void TArrayL::Set(Int_t n, const Long_t *array)
 {
    if (fArray && fN != n) {
       delete [] fArray;
-      fArray = 0;
+      fArray = nullptr;
    }
    fN = n;
-   if (fN == 0) return;
-   if (array == 0) return;
+   if ((fN == 0) || !array)
+      return;
    if (!fArray) fArray = new Long_t[fN];
    memmove(fArray, array, n*sizeof(Long_t));
 }

--- a/core/cont/src/TArrayL64.cxx
+++ b/core/cont/src/TArrayL64.cxx
@@ -25,7 +25,7 @@ ClassImp(TArrayL64);
 
 TArrayL64::TArrayL64()
 {
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ TArrayL64::TArrayL64()
 
 TArrayL64::TArrayL64(Int_t n)
 {
-   fArray = 0;
+   fArray = nullptr;
    if (n > 0) Set(n);
 }
 
@@ -42,7 +42,7 @@ TArrayL64::TArrayL64(Int_t n)
 
 TArrayL64::TArrayL64(Int_t n, const Long64_t *array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(n, array);
 }
 
@@ -51,7 +51,7 @@ TArrayL64::TArrayL64(Int_t n, const Long64_t *array)
 
 TArrayL64::TArrayL64(const TArrayL64 &array) : TArray(array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(array.fN, array.fArray);
 }
 
@@ -109,13 +109,15 @@ void TArrayL64::Set(Int_t n)
       Long64_t *temp = fArray;
       if (n != 0) {
          fArray = new Long64_t[n];
-         if (n < fN) memcpy(fArray,temp, n*sizeof(Long64_t));
-         else {
-            memcpy(fArray,temp,fN*sizeof(Long64_t));
-            memset(&fArray[fN],0,(n-fN)*sizeof(Long64_t));
+         if (n < fN) {
+            memcpy(fArray, temp, n*sizeof(Long64_t));
+         } else {
+            if (temp)
+               memcpy(fArray, temp, fN*sizeof(Long64_t));
+            memset(&fArray[fN], 0, (n-fN)*sizeof(Long64_t));
          }
       } else {
-         fArray = 0;
+         fArray = nullptr;
       }
       if (fN) delete [] temp;
       fN = n;
@@ -130,11 +132,11 @@ void TArrayL64::Set(Int_t n, const Long64_t *array)
 {
    if (fArray && fN != n) {
       delete [] fArray;
-      fArray = 0;
+      fArray = nullptr;
    }
    fN = n;
-   if (fN == 0) return;
-   if (array == 0) return;
+   if ((fN == 0) || !array)
+      return;
    if (!fArray) fArray = new Long64_t[fN];
    memmove(fArray, array, n*sizeof(Long64_t));
 }

--- a/core/cont/src/TArrayL64.cxx
+++ b/core/cont/src/TArrayL64.cxx
@@ -111,10 +111,11 @@ void TArrayL64::Set(Int_t n)
          fArray = new Long64_t[n];
          if (n < fN) {
             memcpy(fArray, temp, n*sizeof(Long64_t));
-         } else {
-            if (temp)
-               memcpy(fArray, temp, fN*sizeof(Long64_t));
+         } else if (temp) {
+            memcpy(fArray, temp, fN*sizeof(Long64_t));
             memset(&fArray[fN], 0, (n-fN)*sizeof(Long64_t));
+         } else {
+            memset(fArray, 0, n*sizeof(Long64_t));
          }
       } else {
          fArray = nullptr;

--- a/core/cont/src/TArrayS.cxx
+++ b/core/cont/src/TArrayS.cxx
@@ -25,7 +25,7 @@ ClassImp(TArrayS);
 
 TArrayS::TArrayS()
 {
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ TArrayS::TArrayS()
 
 TArrayS::TArrayS(Int_t n)
 {
-   fArray = 0;
+   fArray = nullptr;
    if (n > 0) Set(n);
 }
 
@@ -42,7 +42,7 @@ TArrayS::TArrayS(Int_t n)
 
 TArrayS::TArrayS(Int_t n, const Short_t *array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(n, array);
 }
 
@@ -51,7 +51,7 @@ TArrayS::TArrayS(Int_t n, const Short_t *array)
 
 TArrayS::TArrayS(const TArrayS &array) : TArray(array)
 {
-   fArray = 0;
+   fArray = nullptr;
    Set(array.fN, array.fArray);
 }
 
@@ -71,7 +71,7 @@ TArrayS &TArrayS::operator=(const TArrayS &rhs)
 TArrayS::~TArrayS()
 {
    delete [] fArray;
-   fArray = 0;
+   fArray = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,13 +109,15 @@ void TArrayS::Set(Int_t n)
       Short_t *temp = fArray;
       if (n != 0) {
          fArray = new Short_t[n];
-         if (n < fN) memcpy(fArray,temp, n*sizeof(Short_t));
-         else {
-            memcpy(fArray,temp,fN*sizeof(Short_t));
-            memset(&fArray[fN],0,(n-fN)*sizeof(Short_t));
+         if (n < fN) {
+            memcpy(fArray, temp, n*sizeof(Short_t));
+         } else {
+            if (temp)
+               memcpy(fArray, temp, fN*sizeof(Short_t));
+            memset(&fArray[fN], 0, (n-fN)*sizeof(Short_t));
          }
       } else {
-         fArray = 0;
+         fArray = nullptr;
       }
       if (fN) delete [] temp;
       fN = n;
@@ -130,11 +132,11 @@ void TArrayS::Set(Int_t n, const Short_t *array)
 {
    if (fArray && fN != n) {
       delete [] fArray;
-      fArray = 0;
+      fArray = nullptr;
    }
    fN = n;
-   if (fN == 0) return;
-   if (array == 0) return;
+   if ((fN == 0) || !array)
+      return;
    if (!fArray) fArray = new Short_t[fN];
    memmove(fArray, array, n*sizeof(Short_t));
 }

--- a/core/cont/src/TArrayS.cxx
+++ b/core/cont/src/TArrayS.cxx
@@ -111,10 +111,11 @@ void TArrayS::Set(Int_t n)
          fArray = new Short_t[n];
          if (n < fN) {
             memcpy(fArray, temp, n*sizeof(Short_t));
-         } else {
-            if (temp)
-               memcpy(fArray, temp, fN*sizeof(Short_t));
+         } else if (temp) {
+            memcpy(fArray, temp, fN*sizeof(Short_t));
             memset(&fArray[fN], 0, (n-fN)*sizeof(Short_t));
+         } else {
+            memset(fArray, 0, n*sizeof(Short_t));
          }
       } else {
          fArray = nullptr;

--- a/core/cont/src/TRefArray.cxx
+++ b/core/cont/src/TRefArray.cxx
@@ -109,7 +109,7 @@ ClassImp(TRefArray);
 TRefArray::TRefArray(TProcessID *pid)
 {
    fPID  = pid ? pid : TProcessID::GetSessionProcessID();
-   fUIDs = 0;
+   fUIDs = nullptr;
    fSize = 0;
    fLast = -1;
    fLowerBound = 0;
@@ -129,7 +129,7 @@ TRefArray::TRefArray(Int_t s, TProcessID *pid)
    }
 
    fPID  = pid ? pid : TProcessID::GetSessionProcessID();
-   fUIDs = 0;
+   fUIDs = nullptr;
    Init(s, 0);
 }
 
@@ -146,7 +146,7 @@ TRefArray::TRefArray(Int_t s, Int_t lowerBound, TProcessID *pid)
    }
 
    fPID  = pid ? pid : TProcessID::GetSessionProcessID();
-   fUIDs = 0;
+   fUIDs = nullptr;
    Init(s, lowerBound);
 }
 
@@ -156,7 +156,7 @@ TRefArray::TRefArray(Int_t s, Int_t lowerBound, TProcessID *pid)
 TRefArray::TRefArray(const TRefArray &a) : TSeqCollection()
 {
    fPID  = a.fPID;
-   fUIDs = 0;
+   fUIDs = nullptr;
    Init(a.fSize, a.fLowerBound);
 
    for (Int_t i = 0; i < fSize; i++)
@@ -197,7 +197,7 @@ TRefArray::~TRefArray()
 {
    if (fUIDs) delete [] fUIDs;
    fPID  = 0;
-   fUIDs = 0;
+   fUIDs = nullptr;
    fSize = 0;
 }
 
@@ -345,7 +345,7 @@ void TRefArray::AddAtAndExpand(TObject *obj, Int_t idx)
    // Check if the object can belong here
    Int_t uid;
    if (GetObjectUID(uid, obj, "AddAtAndExpand")) {
-      fUIDs[idx-fLowerBound] = uid;
+      fUIDs[idx-fLowerBound] = uid;   // NOLINT
       fLast = TMath::Max(idx-fLowerBound, GetAbsLast());
       Changed();
    }
@@ -363,7 +363,7 @@ void TRefArray::AddAt(TObject *obj, Int_t idx)
    // Check if the object can belong here
    Int_t uid;
    if (GetObjectUID(uid, obj, "AddAt")) {
-      fUIDs[idx-fLowerBound] = uid;;
+      fUIDs[idx-fLowerBound] = uid;
       fLast = TMath::Max(idx-fLowerBound, GetAbsLast());
       Changed();
    }
@@ -383,7 +383,7 @@ Int_t  TRefArray::AddAtFree(TObject *obj)
             // Check if the object can belong here
             Int_t uid;
             if (GetObjectUID(uid, obj, "AddAtFree")) {
-               fUIDs[i] = uid;
+               fUIDs[i] = uid;    // NOLINT
                fLast = TMath::Max(i, GetAbsLast());
                Changed();
                return i+fLowerBound;
@@ -461,7 +461,7 @@ void TRefArray::Delete(Option_t *)
    fSize = 0;
    if (fUIDs) {
       delete [] fUIDs;
-      fUIDs = 0;
+      fUIDs = nullptr;
    }
 
    Changed();
@@ -480,13 +480,15 @@ void TRefArray::Expand(Int_t newSize)
    UInt_t *temp = fUIDs;
    if (newSize != 0) {
       fUIDs = new UInt_t[newSize];
-      if (newSize < fSize) memcpy(fUIDs,temp, newSize*sizeof(UInt_t));
-      else {
-         memcpy(fUIDs,temp,fSize*sizeof(UInt_t));
-         memset(&fUIDs[fSize],0,(newSize-fSize)*sizeof(UInt_t));
+      if (newSize < fSize) {
+         memcpy(fUIDs, temp, newSize*sizeof(UInt_t));
+      } else {
+         if (temp)
+            memcpy(fUIDs, temp, fSize*sizeof(UInt_t));
+         memset(&fUIDs[fSize], 0, (newSize-fSize)*sizeof(UInt_t));
       }
    } else {
-      fUIDs = 0;
+      fUIDs = nullptr;
    }
    if (temp) delete [] temp;
    fSize = newSize;
@@ -681,7 +683,7 @@ void TRefArray::Init(Int_t s, Int_t lowerBound)
 {
    if (fUIDs && fSize != s) {
       delete [] fUIDs;
-      fUIDs = 0;
+      fUIDs = nullptr;
    }
 
    fSize = s;
@@ -690,7 +692,7 @@ void TRefArray::Init(Int_t s, Int_t lowerBound)
       fUIDs = new UInt_t[fSize];
       for (Int_t i=0;i<s;i++) fUIDs[i] = 0;
    } else {
-      fUIDs = 0;
+      fUIDs = nullptr;
    }
    fLowerBound = lowerBound;
    fLast = -1;

--- a/core/cont/src/TRefArray.cxx
+++ b/core/cont/src/TRefArray.cxx
@@ -482,10 +482,11 @@ void TRefArray::Expand(Int_t newSize)
       fUIDs = new UInt_t[newSize];
       if (newSize < fSize) {
          memcpy(fUIDs, temp, newSize*sizeof(UInt_t));
-      } else {
-         if (temp)
-            memcpy(fUIDs, temp, fSize*sizeof(UInt_t));
+      } else if (temp) {
+         memcpy(fUIDs, temp, fSize*sizeof(UInt_t));
          memset(&fUIDs[fSize], 0, (newSize-fSize)*sizeof(UInt_t));
+      } else {
+         memset(fUIDs, 0, newSize*sizeof(UInt_t));
       }
    } else {
       fUIDs = nullptr;


### PR DESCRIPTION
Fixing #7424
Mostly checks for nullptr in memcpy
Providing copy constructor for TBits::TReference if assign operator implemented