### PR TITLE
Fix clang-tidy issues in dictgen

### DIFF
--- a/core/dictgen/src/BaseSelectionRule.cxx
+++ b/core/dictgen/src/BaseSelectionRule.cxx
@@ -450,8 +450,6 @@ bool BaseSelectionRule::CheckPattern(const std::string& test, const std::string&
    }
 
    std::list<std::string>::const_iterator it = patterns_list.begin();
-   size_t pos1, pos2, pos3;
-   pos1= pos2= pos3= std::string::npos;
    bool end = pattern.back() == '*';
 
    // we first check if the last sub-pattern is contained in the test string
@@ -471,7 +469,7 @@ bool BaseSelectionRule::CheckPattern(const std::string& test, const std::string&
    }
 
    // position of the first sub-pattern
-   pos1 = test.find(*it);
+   size_t pos1 = test.find(*it);
 
 
    if (pos1 == std::string::npos || (!begin && pos1 != 0)) { // if the first sub-pattern isn't found in test or if it is found but the
@@ -503,7 +501,7 @@ bool BaseSelectionRule::CheckPattern(const std::string& test, const std::string&
 
    for (; it != patterns_list.end(); ++it) {
       // std::cout<<"sub-pattern = "<<*it<<std::endl;
-      pos2 = test.find(*it);
+      size_t pos2 = test.find(*it);
       if (pos2 <= pos1) {
          return false;
       }

--- a/core/dictgen/src/SelectionRules.cxx
+++ b/core/dictgen/src/SelectionRules.cxx
@@ -441,13 +441,16 @@ bool SelectionRules::GetDeclName(const clang::Decl* D, std::string& name, std::s
    return true;
 }
 
-void SelectionRules::GetDeclQualName(const clang::Decl* D, std::string& qual_name) const{
+void SelectionRules::GetDeclQualName(const clang::Decl* D, std::string& qual_name) const
+{
    const clang::NamedDecl* N = static_cast<const clang::NamedDecl*> (D);
    llvm::raw_string_ostream stream(qual_name);
-   N->getNameForDiagnostic(stream,N->getASTContext().getPrintingPolicy(),true);
-   }
+   if (N)
+      N->getNameForDiagnostic(stream,N->getASTContext().getPrintingPolicy(),true);
+}
 
-bool SelectionRules::GetFunctionPrototype(const clang::FunctionDecl* F, std::string& prototype) const {
+bool SelectionRules::GetFunctionPrototype(const clang::FunctionDecl* F, std::string& prototype) const
+{
 
    if (!F) {
       return false;
@@ -496,8 +499,10 @@ bool SelectionRules::GetFunctionPrototype(const clang::FunctionDecl* F, std::str
 bool SelectionRules::IsParentClass(const clang::Decl* D) const
 {
    //TagDecl has methods to understand of what kind is the Decl - class, struct or union
-   if (const clang::TagDecl* T
-       = llvm::dyn_cast<clang::TagDecl>(D->getDeclContext()))
+   if (!D)
+      return false;
+   if (const clang::TagDecl *T = llvm::dyn_cast<clang::TagDecl>(
+         D->getDeclContext()))
       return T->isClass() || T->isStruct();
    return false;
 }

--- a/core/dictgen/src/XMLReader.cxx
+++ b/core/dictgen/src/XMLReader.cxx
@@ -875,19 +875,23 @@ bool XMLReader::Parse(const std::string &fileName, SelectionRules& out)
 
             if (!exclusion && !IsClosingTag(tagStr)) { // exclusion should be false, we are not interested in closing tags
                // as well as in key-tags such as <selection> and <lcgdict>
-               if (tagKind == kLcgdict || tagKind == kSelection)
+               if (tagKind == kLcgdict || tagKind == kSelection) {
                   ;// DEBUG std::cout<<"Don't care (don't create sel rule)"<<std::endl;
-               else {
+               } else {
                   // DEBUG std::cout<<"Yes"<<std::endl;
-                  if (tagKind == kField || tagKind == kMethod) bsrChild->SetSelected(BaseSelectionRule::kYes); // if kMethod or kField - add to child
-                  else bsr->SetSelected(BaseSelectionRule::kYes);
+                  if (tagKind == kField || tagKind == kMethod)
+                     bsrChild->SetSelected(BaseSelectionRule::kYes); // if kMethod or kField - add to child
+                  else if (bsr)
+                     bsr->SetSelected(BaseSelectionRule::kYes);
                }
             }
             else { // if exclusion = true
-               if (IsStandaloneTag(tagStr)){
+               if (IsStandaloneTag(tagStr)) {
                   // DEBUG std::cout<<"No"<<std::endl;
-                  if (tagKind == kField || tagKind == kMethod) bsrChild->SetSelected(BaseSelectionRule::kNo);
-                  else bsr->SetSelected(BaseSelectionRule::kNo);
+                  if (tagKind == kField || tagKind == kMethod)
+                     bsrChild->SetSelected(BaseSelectionRule::kNo);
+                  else if (bsr)
+                     bsr->SetSelected(BaseSelectionRule::kNo);
                }
                else if (tagKind == kClass) {
                   // DEBUG std::cout<<"Don't care (create sel rule)"<<std::endl; // if it is not a standalone tag,
@@ -978,7 +982,7 @@ bool XMLReader::Parse(const std::string &fileName, SelectionRules& out)
                         out.SetHasFileNameRule(true);
                      }
                   }
-                  else {
+                  else if (bsrChild) {
                      if (bsrChild->HasAttributeWithName(iAttrName)) {
                         std::string preExistingValue;
                         bsrChild->GetAttributeValue(iAttrName,preExistingValue);

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4998,7 +4998,7 @@ int RootClingMain(int argc,
                                               scan.fSelectedTypedefs,
                                               interp);
 
-      rootclingRetCode = CreateNewRootMapFile(gOptRootMapFileName,
+      rootclingRetCode += CreateNewRootMapFile(gOptRootMapFileName,
                                           rootmapLibName,
                                           classesDefsList,
                                           classesNamesForRootmap,

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -404,6 +404,8 @@ void AnnotateDecl(clang::CXXRecordDecl &CXXRD,
 
 size_t GetFullArrayLength(const clang::ConstantArrayType *arrayType)
 {
+   if (!arrayType)
+      return 0;
    llvm::APInt len = arrayType->getSize();
    while (const clang::ConstantArrayType *subArrayType = llvm::dyn_cast<clang::ConstantArrayType>(arrayType->getArrayElementTypeNoTypeQual())) {
       len *= subArrayType->getSize();
@@ -858,11 +860,10 @@ int STLContainerStreamer(const clang::FieldDecl &m,
    clang::QualType utype(ROOT::TMetaUtils::GetUnderlyingType(m.getType()), 0);
    Internal::RStl::Instance().GenerateTClassFor(utype, interp, normCtxt);
 
-   if (clxx->getTemplateSpecializationKind() == clang::TSK_Undeclared) return 0;
+   if (!clxx || clxx->getTemplateSpecializationKind() == clang::TSK_Undeclared) return 0;
 
    const clang::ClassTemplateSpecializationDecl *tmplt_specialization = llvm::dyn_cast<clang::ClassTemplateSpecializationDecl> (clxx);
    if (!tmplt_specialization) return 0;
-
 
    string stlType(ROOT::TMetaUtils::ShortTypeName(mTypename.c_str()));
    string stlName;
@@ -4220,7 +4221,7 @@ int RootClingMain(int argc,
          remove((moduleCachePath + llvm::sys::path::get_separator() + "vcruntime.pcm").str().c_str());
          remove((moduleCachePath + llvm::sys::path::get_separator() + "services.pcm").str().c_str());
 #endif
-         
+
 #ifdef R__MACOSX
          remove((moduleCachePath + llvm::sys::path::get_separator() + "Darwin.pcm").str().c_str());
 #else
@@ -5647,7 +5648,7 @@ int GenReflexMain(int argc, char **argv)
          "      library (needs target library switch. See its documentation).\n"
       },
 
-      
+
       {
          NOGLOBALUSINGSTD,
          NOTYPE ,


### PR DESCRIPTION
Extra checks for nullptr, exclude unused variables.
Last commit - bugfix in error code handling
Closing #7425 