### PR TITLE
Fix clang-tidy issues in meta/metacling classes

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1463,7 +1463,6 @@ static void ResolveTypedefProcessType(const char *tname,
          }
          else {
             modified = true;
-            mod_start_of_type = start_of_type;
             result += string(tname,0,start_of_type);
             if (constprefix && typeresult.compare(0,6,"const ",6) == 0) {
                result += typeresult.substr(6,string::npos);

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6645,20 +6645,24 @@ void TClass::AdoptReferenceProxy(TVirtualRefProxy* proxy)
 
 void TClass::AdoptMemberStreamer(const char *name, TMemberStreamer *p)
 {
-   if (!fRealData) return;
+   if (fRealData) {
 
-   R__LOCKGUARD(gInterpreterMutex);
+      R__LOCKGUARD(gInterpreterMutex);
 
-   TIter next(fRealData);
-   TRealData *rd;
-   while ((rd = (TRealData*)next())) {
-      if (strcmp(rd->GetName(),name) == 0) {
-         // If there is a TStreamerElement that took a pointer to the
-         // streamer we should inform it!
-         rd->AdoptStreamer(p);
-         break;
+      TIter next(fRealData);
+      TRealData *rd;
+      while ((rd = (TRealData*)next())) {
+         if (strcmp(rd->GetName(),name) == 0) {
+            // If there is a TStreamerElement that took a pointer to the
+            // streamer we should inform it!
+            rd->AdoptStreamer(p);
+            return;
+         }
       }
    }
+
+   Error("AdoptMemberStreamer","Cannot adope member streamer for %s::%s",GetName(), name);
+   delete p;
 
 //  NOTE: This alternative was proposed but not is not used for now,
 //  One of the major difference with the code above is that the code below
@@ -6675,7 +6679,6 @@ void TClass::AdoptMemberStreamer(const char *name, TMemberStreamer *p)
 //       return;
 //    }
 //    dm->SetStreamer(p);
-   return;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TDataMember.cxx
+++ b/core/meta/src/TDataMember.cxx
@@ -624,10 +624,9 @@ void TDataMember::ExtractOptionsFromComment()
 
    char cmt[2048];
    char opt[2048];
-   const char *ptr1    = 0;
-   char *ptr2    = 0;
-   char *ptr3    = 0;
-   char *tok     = 0;
+   const char *ptr1 = nullptr;
+   char *ptr2    = nullptr;
+   char *ptr3    = nullptr;
    Int_t cnt     = 0;
    Int_t token_cnt;
    Int_t i;
@@ -658,25 +657,22 @@ void TDataMember::ExtractOptionsFromComment()
    // We'll put'em in an array for convenience;
    // You have to do it in this manner because you cannot use nested tokenizing
 
-   char *tokens[256];           // a storage for these sub-tokens.
+   std::vector<std::string> tokens;           // a storage for these sub-tokens.
    token_cnt = 0;
    cnt       = 0;
 
    do {                          //tokenizing loop
       ptr1 = R__STRTOK_R((char *)(cnt++ ? nullptr : opt), ";", &rest);
-      if (ptr1){
-         Int_t nch = strlen(ptr1)+1;
-         tok=new char[nch];
-         strlcpy(tok,ptr1,nch);
-         tokens[token_cnt]=tok;
+      if (ptr1) {
+         tokens.emplace_back(ptr1);
          token_cnt++;
       }
    } while (ptr1);
 
    // OK! Now let's check whether we have Get/Set methods encode in any string
    for (i=0;i<token_cnt;i++) {
-      if (strstr(tokens[i],"GetMethod")) {
-         ptr1 = R__STRTOK_R(tokens[i], "\"", &rest); // tokenizing-strip text "GetMethod"
+      if (strstr(tokens[i].c_str(),"GetMethod")) {
+         ptr1 = R__STRTOK_R(const_cast<char *>(tokens[i].c_str()), "\"", &rest); // tokenizing-strip text "GetMethod"
          if (ptr1 == 0) {
             Fatal("TDataMember","Internal error, found \"GetMethod\" but not \"\\\"\" in %s.",GetTitle());
             return;
@@ -694,8 +690,8 @@ void TDataMember::ExtractOptionsFromComment()
          continue; //next item!
       }
 
-      if (strstr(tokens[i],"SetMethod")) {
-         ptr1 = R__STRTOK_R(tokens[i], "\"", &rest);
+      if (strstr(tokens[i].c_str(),"SetMethod")) {
+         ptr1 = R__STRTOK_R(const_cast<char *>(tokens[i].c_str()), "\"", &rest);
          if (ptr1 == 0) {
             Fatal("TDataMember","Internal error, found \"SetMethod\" but not \"\\\"\" in %s.",GetTitle());
             return;
@@ -717,8 +713,8 @@ void TDataMember::ExtractOptionsFromComment()
    std::unique_ptr<TList> optionlist{new TList()};       //storage for options strings
 
    for (i=0;i<token_cnt;i++) {
-      if (strstr(tokens[i],"Items")) {
-         ptr1 = R__STRTOK_R(tokens[i], "()", &rest);
+      if (strstr(tokens[i].c_str(),"Items")) {
+         ptr1 = R__STRTOK_R(const_cast<char *>(tokens[i].c_str()), "()", &rest);
          if (ptr1 == 0) {
             Fatal("TDataMember","Internal error, found \"Items\" but not \"()\" in %s.",GetTitle());
             return;
@@ -799,12 +795,6 @@ void TDataMember::ExtractOptionsFromComment()
 
    }
 
-   // Garbage collection
-
-   //And dispose tokens string...
-   for (i=0;i<token_cnt;i++)
-      if(tokens[i])
-         delete [] tokens[i];
 }
 
 

--- a/core/meta/src/TMethod.cxx
+++ b/core/meta/src/TMethod.cxx
@@ -180,15 +180,14 @@ TDataMember *TMethod::FindDataMember()
       } while (ptr1);
 
       //now let's  parse all argument tokens...
-      TClass     *cl = 0;
-      TMethodArg *a  = 0;
-      TMethodArg *ar = 0;
-      TDataMember *member = 0;
+      TClass     *cl = nullptr;
+      TMethodArg *a  = nullptr;
+      TMethodArg *ar = nullptr;
+      TDataMember *member = nullptr;
 
       for (i=0; i<token_cnt;i++) {
-         cnt = 0;
          ptr1 = R__STRTOK_R(tokens[i], "=>", &rest);         // LeftHandedSide=methodarg
-         ptr2 = R__STRTOK_R((char *)0, "=>", &rest);         // RightHandedSide-points to datamember
+         ptr2 = R__STRTOK_R((char *) nullptr, "=>", &rest);  // RightHandedSide-points to datamember
 
          //find the MethodArg
          a      = 0;

--- a/core/meta/src/TProtoClass.cxx
+++ b/core/meta/src/TProtoClass.cxx
@@ -220,8 +220,8 @@ Bool_t TProtoClass::FillTClass(TClass* cl) {
       // for example in presence of daughter and mother class present in two
       // dictionaries compiled in two different libraries which are not linked
       // one with each other.
-      for (auto element: fPRealData) {
-         //if (element->IsA() == TObjString::Class()) {
+      for (auto &element : fPRealData) {
+         // if (element->IsA() == TObjString::Class()) {
          if (element.IsAClass() ) {
             if (gDebug > 1) Info("","Treating beforehand mother class %s",GetClassName(element.fClassIndex));
             TInterpreter::SuspendAutoParsing autoParseRaii(gInterpreter);
@@ -313,7 +313,7 @@ Bool_t TProtoClass::FillTClass(TClass* cl) {
    bool first = true;
    if (fPRealData.size()  > 0) {
       size_t element_next_idx = 0;
-      for (auto element: fPRealData) {
+      for (auto &element : fPRealData) {
          ++element_next_idx;
          //if (element->IsA() == TObjString::Class()) {
          if (element.IsAClass() ) {

--- a/core/meta/src/TSchemaRule.cxx
+++ b/core/meta/src/TSchemaRule.cxx
@@ -401,7 +401,7 @@ const char *TSchemaRule::GetVersion() const
 
 Bool_t TSchemaRule::TestVersion( Int_t version ) const
 {
-   if( fVersion == "" )
+   if( fVersion.IsNull() )
       return kFALSE;
 
    if( !fVersionVect )
@@ -411,11 +411,11 @@ Bool_t TSchemaRule::TestVersion( Int_t version ) const
       version = 1;
    }
 
-   std::vector<std::pair<Int_t, Int_t> >::iterator it;
-   for( it = fVersionVect->begin(); it != fVersionVect->end(); ++it ) {
-      if( version >= it->first && version <= it->second )
-         return kTRUE;
-   }
+   if (fVersionVect)
+      for (auto &it : *fVersionVect)
+         if( version >= it.first && version <= it.second )
+            return kTRUE;
+
    return kFALSE;
 }
 
@@ -436,17 +436,17 @@ Bool_t TSchemaRule::SetChecksum( const TString& checksum )
 
 Bool_t TSchemaRule::TestChecksum( UInt_t checksum ) const
 {
-   if( fChecksum == "" )
+   if( fChecksum.IsNull() )
       return kFALSE;
 
    if( !fChecksumVect )
       ProcessChecksum( fChecksum ); // At this point the checksum string should always be correct
 
-   std::vector<UInt_t>::iterator it;
-   for( it = fChecksumVect->begin(); it != fChecksumVect->end(); ++it ) {
-      if( checksum == *it )
-         return kTRUE;
-   }
+   if (fChecksumVect)
+      for (auto &it : *fChecksumVect)
+         if( checksum == it )
+            return kTRUE;
+
    return kFALSE;
 }
 
@@ -855,7 +855,7 @@ Bool_t TSchemaRule::ProcessVersion( const TString& version ) const
    if( versions.empty() )
    {
       delete fVersionVect;
-      fVersionVect = 0;
+      fVersionVect = nullptr;
       return kFALSE;
    }
 

--- a/core/meta/src/TStatusBitsChecker.cxx
+++ b/core/meta/src/TStatusBitsChecker.cxx
@@ -150,7 +150,7 @@ void TStatusBitsChecker::Registry::RegisterBits(TClass &classRef /* = false */)
 
          if (bit < 24) {
             bool need = true;
-            for (auto reg : fRegister[bit]) {
+            for (auto &reg : fRegister[bit]) {
                if (reg.fOwner == &classRef) {
                   // We have a duplicate declared in the same class
                   // let's accept this as an alias.
@@ -184,8 +184,8 @@ bool TStatusBitsChecker::Registry::Check(TClass &classRef, bool verbose /* = fal
    RegisterBits(classRef);
 
    if (verbose) {
-      for (auto cursor : fRegister) {
-         for (auto constant : cursor.second) {
+      for (auto &cursor : fRegister) {
+         for (auto &constant : cursor.second) {
             Printf("Bit %3d declared in %s as %s", cursor.first, constant.fOwner->GetName(),
                    constant.fConstantName.c_str());
          }
@@ -194,9 +194,9 @@ bool TStatusBitsChecker::Registry::Check(TClass &classRef, bool verbose /* = fal
 
    bool issuedHeader = false;
    bool result = true;
-   for (auto cursor : fRegister) {
+   for (auto &cursor : fRegister) {
       unsigned int nDuplicate = 0;
-      for (auto constant : cursor.second) {
+      for (auto &constant : cursor.second) {
          if (!constant.fIntentionalDup)
             ++nDuplicate;
       }
@@ -205,7 +205,7 @@ bool TStatusBitsChecker::Registry::Check(TClass &classRef, bool verbose /* = fal
             Error("TStatusBitsChecker", "In %s class hierarchy, there are duplicates bits:", classRef.GetName());
             issuedHeader = true;
          }
-         for (auto constant : cursor.second) {
+         for (auto &constant : cursor.second) {
             if (!constant.fIntentionalDup) {
                Error("TStatusBitsChecker", "   Bit %3d used in %s as %s", cursor.first, constant.fOwner->GetName(),
                      constant.fConstantName.c_str());

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -354,31 +354,18 @@ const char *TStreamerElement::GetFullName() const
 void TStreamerElement::GetSequenceType(TString &sequenceType) const
 {
    sequenceType.Clear();
-   Bool_t first = kTRUE;
-   if (TestBit(TStreamerElement::kWholeObject)) {
-      if (!first) sequenceType += ",";
-      first = kFALSE;
-      sequenceType += "wholeObject";
-   }
-   if (TestBit(TStreamerElement::kCache)) {
-      first = kFALSE;
-      sequenceType += "cached";
-   }
-   if (TestBit(TStreamerElement::kRepeat)) {
-      if (!first) sequenceType += ",";
-      first = kFALSE;
-      sequenceType += "repeat";
-   }
-   if (TestBit(TStreamerElement::kDoNotDelete)) {
-      if (!first) sequenceType += ",";
-      first = kFALSE;
-      sequenceType += "nodelete";
-   }
-   if (TestBit(TStreamerElement::kWrite)) {
-      if (!first) sequenceType += ",";
-      first = kFALSE;
-      sequenceType += "write";
-   }
+   auto test_bit = [this, &sequenceType](unsigned bit, const char *name) {
+      if (TestBit(bit)) {
+         if (!sequenceType.IsNull()) sequenceType += ",";
+         sequenceType += name;
+      }
+   };
+
+   test_bit(TStreamerElement::kWholeObject, "wholeObject");
+   test_bit(TStreamerElement::kCache, "cached");
+   test_bit(TStreamerElement::kRepeat, "repeat");
+   test_bit(TStreamerElement::kDoNotDelete, "nodelete");
+   test_bit(TStreamerElement::kWrite, "write");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -233,7 +233,7 @@ namespace {
       }
       if (QT->isMemberPointerType()) {
          const MemberPointerType *MPT = QT->getAs<MemberPointerType>();
-         if (MPT->isMemberDataPointer()) {
+         if (MPT && MPT->isMemberDataPointer()) {
             return (returnType)(ptrdiff_t)val.getPtr();
          }
          return (returnType)(long) val.getPtr();
@@ -1997,7 +1997,7 @@ TClingCallFunc::InitRetAndExecNoCtor(clang::QualType QT, cling::Value &ret) {
       return [this](void* address, cling::Value& ret) { exec(address, &ret.getPtr()); };
    } else if (QT->isMemberPointerType()) {
       const MemberPointerType *MPT = QT->getAs<MemberPointerType>();
-      if (MPT->isMemberDataPointer()) {
+      if (MPT && MPT->isMemberDataPointer()) {
          // A member data pointer is a actually a struct with one
          // member of ptrdiff_t, the offset from the base of the object
          // storage to the storage for the designated data member.

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -162,6 +162,8 @@ long TClingClassInfo::ClassProperty() const
    // We now have a class or a struct.
    const CXXRecordDecl *CRD =
       llvm::dyn_cast<CXXRecordDecl>(GetDecl());
+   if (!CRD)
+      return property;
    property |= kClassIsValid;
    if (CRD->isAbstract()) {
       property |= kClassIsAbstract;
@@ -1284,13 +1286,14 @@ long TClingClassInfo::Property() const
    // Note: Now we have class, struct, union only.
    const CXXRecordDecl *CRD =
       llvm::dyn_cast<CXXRecordDecl>(GetDecl());
+   if (!CRD)
+      return property;
+
    if (CRD->isClass()) {
       property |= kIsClass;
-   }
-   else if (CRD->isStruct()) {
+   } else if (CRD->isStruct()) {
       property |= kIsStruct;
-   }
-   else if (CRD->isUnion()) {
+   } else if (CRD->isUnion()) {
       property |= kIsUnion;
    }
    if (CRD->hasDefinition() && CRD->isAbstract()) {
@@ -1441,6 +1444,6 @@ const char *TClingClassInfo::TmpltName() const
       // Note: This does *not* include the template arguments!
       buf = ND->getNameAsString();
    }
-   return buf.c_str();
+   return buf.c_str();  // NOLINT
 }
 

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -426,6 +426,8 @@ long TClingDataMemberInfo::Property() const
          }
 
          declOrParent = llvm::dyn_cast<clang::Decl>(Parent);
+         if (!declOrParent)
+            break;
          if (strictestAccess < declOrParent->getAccess()) {
             strictestAccess = declOrParent->getAccess();
          }

--- a/core/metacling/src/TClingMethodArgInfo.cxx
+++ b/core/metacling/src/TClingMethodArgInfo.cxx
@@ -128,7 +128,7 @@ const char *TClingMethodArgInfo::DefaultValue() const
       }
       out.flush();
    }
-   return buf.c_str();
+   return buf.c_str(); // NOLINT
 }
 
 const TClingTypeInfo *TClingMethodArgInfo::Type() const

--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -647,7 +647,7 @@ const char *TClingMethodInfo::GetPrototype()
          buf += " const";
       }
    }
-   return buf.c_str();
+   return buf.c_str();  // NOLINT
 }
 
 const char *TClingMethodInfo::Name() const

--- a/core/metacling/src/TClingTypeInfo.cxx
+++ b/core/metacling/src/TClingTypeInfo.cxx
@@ -110,7 +110,7 @@ const char *TClingTypeInfo::Name() const
 
    R__LOCKGUARD(gInterpreterMutex);
    ROOT::TMetaUtils::GetFullyQualifiedTypeName(buf,fQualType,*fInterp);
-   return buf.c_str();
+   return buf.c_str();  // NOLINT
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -130,12 +130,16 @@ long TClingTypeInfo::Property() const
    if (tagQT) {
       // Note: Now we have class, enum, struct, union only.
       const clang::TagDecl *TD = llvm::dyn_cast<clang::TagDecl>(tagQT->getDecl());
+      if (!TD)
+         return property;
       if (TD->isEnum()) {
          property |= kIsEnum;
       } else {
          // Note: Now we have class, struct, union only.
          const clang::CXXRecordDecl *CRD =
             llvm::dyn_cast<clang::CXXRecordDecl>(TD);
+         if (!CRD)
+            return property;
          if (CRD->isClass()) {
             property |= kIsClass;
          }
@@ -240,7 +244,7 @@ const char *TClingTypeInfo::TrueName(const ROOT::TMetaUtils::TNormalizedCtxt &no
 
    ROOT::TMetaUtils::GetNormalizedName(buf,fQualType, *fInterp, normCtxt);
 
-   return buf.c_str();
+   return buf.c_str(); // NOLINT
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TClingTypedefInfo.cxx
+++ b/core/metacling/src/TClingTypedefInfo.cxx
@@ -200,6 +200,8 @@ int TClingTypedefInfo::Size() const
    }
    clang::ASTContext &context = fDecl->getASTContext();
    const clang::TypedefNameDecl *td = llvm::dyn_cast<clang::TypedefNameDecl>(fDecl);
+   if (!td)
+      return 0; // should never happens
    clang::QualType qt = td->getUnderlyingType();
    if (qt->isDependentType()) {
       // The underlying type is dependent on a template parameter,
@@ -235,6 +237,8 @@ const char *TClingTypedefInfo::TrueName(const ROOT::TMetaUtils::TNormalizedCtxt 
    TTHREAD_TLS_DECL( std::string, truename);
    truename.clear();
    const clang::TypedefNameDecl *td = llvm::dyn_cast<clang::TypedefNameDecl>(fDecl);
+   if (!td)
+      return "(badcast)";
    clang::QualType underlyingType = td->getUnderlyingType();
    if (underlyingType->isBooleanType()) {
       return "bool";
@@ -242,7 +246,7 @@ const char *TClingTypedefInfo::TrueName(const ROOT::TMetaUtils::TNormalizedCtxt 
    const clang::ASTContext &ctxt = fInterp->getCI()->getASTContext();
    ROOT::TMetaUtils::GetNormalizedName(truename, ctxt.getTypedefType(td), *fInterp, normCtxt);
 
-   return truename.c_str();
+   return truename.c_str();  // NOLINT
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/newdelete/src/NewDelete.cxx
+++ b/core/newdelete/src/NewDelete.cxx
@@ -200,7 +200,7 @@ void *operator new(size_t size)
       vp = ::calloc(RealSize(size), sizeof(char));
    if (vp == 0)
       Fatal(where, gSpaceErr, RealSize(size));
-   StoreSizeMagic(vp, size, where);
+   StoreSizeMagic(vp, size, where);  // NOLINT
    return ExtStart(vp);
 }
 
@@ -283,7 +283,7 @@ void operator delete(void *ptr) noexcept
           || !ROOT::Internal::gFreeIfTMapFile(RealStart(ptr))) {
          do {
             TSystem::ResetErrno();
-            ::free(RealStart(ptr));
+            ::free(RealStart(ptr));  // NOLINT
          } while (TSystem::GetErrno() == EINTR);
       }
       if (TSystem::GetErrno() != 0)
@@ -421,9 +421,9 @@ void *CustomReAlloc1(void *ovp, size_t size)
    if (vp == 0)
       Fatal(where, gSpaceErr, RealSize(size));
    if (size > oldsize)
-      MemClearRe(ExtStart(vp), oldsize, size-oldsize);
+      MemClearRe(ExtStart(vp), oldsize, size-oldsize);   // NOLINT
 
-   StoreSizeMagic(vp, size, where);
+   StoreSizeMagic(vp, size, where);   // NOLINT
    return ExtStart(vp);
 }
 
@@ -461,8 +461,8 @@ void *CustomReAlloc2(void *ovp, size_t size, size_t oldsize)
    if (vp == 0)
       Fatal(where, gSpaceErr, RealSize(size));
    if (size > oldsize)
-      MemClearRe(ExtStart(vp), oldsize, size-oldsize);
+      MemClearRe(ExtStart(vp), oldsize, size-oldsize);   // NOLINT
 
-   StoreSizeMagic(vp, size, where);
+   StoreSizeMagic(vp, size, where);    // NOLINT
    return ExtStart(vp);
 }


### PR DESCRIPTION
Adresses most issues from #7426

* Check nullptr in proposed places
* Mark `// NOLINT` when return static members 
* Use references in several loops like `for (auto &entry : arr)`
* Fix potential logic error in `TStreamerElement::GetSequenceType`
* Use std::vector<std::string> for tokens in `TDataMember::ExtractOptionsFromComment`
* Use static std::string in `TCling::TypeName` instead of self-maintained char buffer
* Fix potential leak when calling `TClass::AdoptMemberStreamer`

