### PR TITLE
Fix clang-tidy issues in rest of core libs

### DIFF
--- a/core/rint/inc/TTabCom.h
+++ b/core/rint/inc/TTabCom.h
@@ -192,7 +192,7 @@ private: // member functions
 
    Int_t      Complete(const TRegexp& re, const TSeqCollection* pListOfCandidates,
                        const char appendage[], std::ostream& out, TString::ECaseCompare cmp = TString::kExact);
-   void       CopyMatch( char dest[], const char localName[], const char appendage[] = nullptr, const char fullName[] = nullptr) const;
+   void       CopyMatch(char *dest, int dest_len, const char *localName, const char *appendage = nullptr, const char *fullName = nullptr) const;
    EContext_t DetermineContext() const;
    TString    DeterminePath( const TString& fileName, const char defaultPath[] ) const;
    TString    ExtendPath( const char originalPath[], TString newBase ) const;

--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -1292,7 +1292,7 @@ Int_t TTabCom::Complete(const TRegexp & re,
          }
       }
 
-      CopyMatch(match, short_name, appendage, full_name);
+      CopyMatch(match, sizeof(match), short_name, appendage, full_name);
    } else {
       // multiple matches ==> complete as far as possible
       Char_t ch;
@@ -1319,14 +1319,14 @@ Int_t TTabCom::Complete(const TRegexp & re,
          while (ExcludedByFignore(s));
 
          // and use it.
-         CopyMatch(match, s, appendage, s0);
+         CopyMatch(match, sizeof(match), s, appendage, s0);
       } else {
          IfDebug(std::cerr << "more than 1 GoodString" << std::endl);
 
          if (partialMatch.Length() > s3.Length())
             // this partial match is our (partial) completion.
          {
-            CopyMatch(match, partialMatch.Data());
+            CopyMatch(match, sizeof(match), partialMatch.Data());
          } else
             // couldn't do any completing at all,
             // print a list of all the ambiguous matches
@@ -1354,7 +1354,7 @@ Int_t TTabCom::Complete(const TRegexp & re,
             // update the matching part, will have changed
             // capitalization because only cmp == TString::kIgnoreCase
             // matches.
-            CopyMatch(match, partialMatch.Data());
+            CopyMatch(match, sizeof(match), partialMatch.Data());
          }
       }
    }
@@ -1411,9 +1411,10 @@ done:                         // <----- goto label
 ////////////////////////////////////////////////////////////////////////////////
 /// [private]
 
-void TTabCom::CopyMatch(char dest[], const char localName[],
-                        const char appendage[],
-                        const char fullName[]) const
+void TTabCom::CopyMatch(char *dest, int dest_len,
+                        const char *localName,
+                        const char *appendage,
+                        const char *fullName) const
 {
    // if "appendage" is 0, no appendage is applied.
    //
@@ -1428,7 +1429,7 @@ void TTabCom::CopyMatch(char dest[], const char localName[],
    assert(localName != 0);
 
    // potential buffer overflow.
-   strcpy(dest, localName);
+   strlcpy(dest, localName, dest_len);
 
    const char *key = "filename";
    const int key_len = strlen(key);
@@ -1449,14 +1450,14 @@ void TTabCom::CopyMatch(char dest[], const char localName[],
       IfDebug(std::cerr << "new appendage: " << appendage << std::endl);
       if (IsDirectory(fullName)) {
          if (fullName)
-            strcpy(dest + strlen(localName), "/");
+            strlcat(dest, "/", dest_len);
       } else {
          if (appendage)
-            strcpy(dest + strlen(localName), appendage);
+            strlcat(dest, appendage, dest_len);
       }
    } else {
       if (appendage)
-         strcpy(dest + strlen(localName), appendage);
+         strlcat(dest, appendage, dest_len);
    }
 }
 

--- a/core/textinput/src/textinput/TerminalConfigUnix.cpp
+++ b/core/textinput/src/textinput/TerminalConfigUnix.cpp
@@ -90,7 +90,6 @@ TerminalConfigUnix::HandleSignal(int signum) {
   // Process has received a fatal signal, detach.
   bool sSignalHandlerActive = false;
   if (!sSignalHandlerActive) {
-    sSignalHandlerActive = true;
     Detach();
     // find previous signal handler index:
     for (int i = 0; i < kNumHandledSignals; ++i) {
@@ -99,7 +98,6 @@ TerminalConfigUnix::HandleSignal(int signum) {
         if (fPrevHandler[i]) {
           fPrevHandler[i](signum);
           // should not end up here...
-          sSignalHandlerActive = false;
           return;
         } else break;
       }

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -686,7 +686,7 @@ void TUnixSystem::SetDisplay()
                char hbuf[NI_MAXHOST + 4];
                if (getnameinfo(sa, sizeof(struct sockaddr), hbuf, sizeof(hbuf), nullptr, 0, NI_NAMEREQD) == 0) {
                   assert( strlen(hbuf) < NI_MAXHOST );
-                  strcat(hbuf, ":0.0");
+                  strlcat(hbuf, ":0.0", sizeof(hbuf));
                   Setenv("DISPLAY", hbuf);
                   Warning("SetDisplay", "DISPLAY not set, setting it to %s",
                           hbuf);
@@ -4243,7 +4243,7 @@ int TUnixSystem::UnixUnixConnect(const char *sockpath)
               sockpath, (UInt_t)sizeof(unserver.sun_path)-1);
       return -1;
    }
-   strcpy(unserver.sun_path, sockpath);
+   strlcpy(unserver.sun_path, sockpath, sizeof(unserver.sun_path));
 
    // Open socket
    if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
@@ -4455,7 +4455,7 @@ int TUnixSystem::UnixUnixService(const char *sockpath, int backlog)
               sockpath, (UInt_t)sizeof(unserver.sun_path)-1);
       return -1;
    }
-   strcpy(unserver.sun_path, sockpath);
+   strlcpy(unserver.sun_path, sockpath, sizeof(unserver.sun_path));
 
    // Create socket
    if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -217,7 +217,9 @@ static void R__zipZLIB(int cxlevel, int *srcsize, char *src, int *tgtsize, char 
        }
     }
 
-    deflateEnd(&stream);
+    err = deflateEnd(&stream);
+    if (err != Z_OK)
+       printf("error %d in deflateEnd (zlib)\n",err);
 
     tgt[0] = 'Z';               /* Signature ZLib */
     tgt[1] = 'L';

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -217,7 +217,7 @@ static void R__zipZLIB(int cxlevel, int *srcsize, char *src, int *tgtsize, char 
        }
     }
 
-    err = deflateEnd(&stream);
+    deflateEnd(&stream);
 
     tgt[0] = 'Z';               /* Signature ZLib */
     tgt[1] = 'L';
@@ -234,7 +234,6 @@ static void R__zipZLIB(int cxlevel, int *srcsize, char *src, int *tgtsize, char 
     tgt[8] = (char)((l_in_size >> 16) & 0xff);
 
     *irep = stream.total_out + HDRSIZE;
-    return;
 }
 
 


### PR DESCRIPTION
Fixing most of the topics from #7427 

* Remove unused variable/values, 
* replace strcpy by strlcpy/strlcat

Keep `C` code warnings as is - maybe one can just disable them
