### PR TITLE
[Doxygen] Enable documentation for classes declared in .cxx

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -464,7 +464,7 @@ EXTRACT_STATIC         = YES
 # for Java sources.
 # The default value is: YES.
 
-EXTRACT_LOCAL_CLASSES  = NO
+EXTRACT_LOCAL_CLASSES  = YES
 
 # This flag is only useful for Objective-C code. If set to YES, local methods,
 # which are defined in the implementation section but not in the interface are


### PR DESCRIPTION
[skip-ci]

Doxygen was omitting classes that are defined in a .cxx. Although their
interface might not be too relevant for users, enabling those should help
developers.

See, for example [this](https://root.cern/doc/master/namespaceRooBatchCompute_1_1RF__ARCH.html)
It should in theory list the classes that are used for RF computations, but these never show up in doxygen.
Instead, we only see three helper functions.

(Not to worry, the docs of this library are improved more in #7451)

Especially the broken link in the **See also** is a bit unfortunate:
![image](https://user-images.githubusercontent.com/16205615/110686280-90aed880-81df-11eb-8246-7f5ffba11183.png)
