### PR TITLE
GUI: removed erroneous delete from TGText::AsString().  Closes #7460.

### DIFF
--- a/gui/gui/src/TGText.cxx
+++ b/gui/gui/src/TGText.cxx
@@ -1251,7 +1251,6 @@ TString TGText::AsString()
       }
       char *txt = travel->GetText();
       ret += txt;
-      delete [] txt;
       travel = travel->fNext;
       if (travel) ret += '\n';
       line_count++;


### PR DESCRIPTION
There are two overloads of TGTextLine::GetText().  One that allocates a new string and returns it, and one that just returns the object's line buffer.  The method used in TGText::AsString() just returns the line buffer, so the return value should not be deleted.