### PR TITLE
v6.24 Silent many warning C4624 on Windows

### DIFF
--- a/interpreter/llvm/src/include/llvm/Support/type_traits.h
+++ b/interpreter/llvm/src/include/llvm/Support/type_traits.h
@@ -22,6 +22,10 @@
 #define __has_feature(x) 0
 #endif
 
+#ifdef _MSC_VER
+#pragma warning(disable : 4624)
+#endif
+
 namespace llvm {
 
 


### PR DESCRIPTION
Backport from master: Silent the following zillion of warnings on Windows:
```
C:\Users\sftnight\git\master\interpreter\llvm\src\include\llvm/Support/type_traits.h(97,1): warning C4624: 'llvm::detail::trivial_helper<T>': destructor was implicitly defined as deleted [C:\Users\sftnight\build\relwithdebinfo\interpreter\cling\lib\Interpreter\obj.clingInterpreter.vcxproj]
with
[
T=clang::Sema::ModuleScope
]
C:\Users\sftnight\git\master\interpreter\llvm\src\include\llvm/Support/type_traits.h(150): message : see reference to class template instantiation 'llvm::detail::trivial_helper<T>' being compiled [C:\Users\sftnight\build\relwithdebinfo\interpreter\cling\lib\Interpreter\obj.clingInterpreter.vcxproj]
with
[
T=clang::Sema::ModuleScope
]
C:\Users\sftnight\git\master\interpreter\llvm\src\include\llvm/ADT/SmallVector.h(315): message : see reference to class template instantiation 'llvm::is_trivially_copyable<T>' being compiled [C:\Users\sftnight\build\relwithdebinfo\interpreter\cling\lib\Interpreter\obj.clingInterpreter.vcxproj]
with
[
T=clang::Sema::ModuleScope
]
C:\Users\sftnight\git\master\interpreter\llvm\src\include\llvm/ADT/SmallVector.h(837): message : see reference to class template instantiation 'llvm::SmallVectorImpl<T>' being compiled [C:\Users\sftnight\build\relwithdebinfo\interpreter\cling\lib\Interpreter\obj.clingInterpreter.vcxproj]
with
[
T=clang::Sema::ModuleScope
]
C:\Users\sftnight\git\master\interpreter\llvm\src\tools\clang\include\clang/Sema/Sema.h(1724): message : see reference to class template instantiation 'llvm::SmallVector<clang::Sema::ModuleScope,16>' being compiled [C:\Users\sftnight\build\relwithdebinfo\interpreter\cling\lib\Interpreter\obj.clingInterpreter.vcxproj]
```