### PR TITLE
[RF] Don't clone computation graph in getPropagatedError

### DIFF
--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -122,7 +122,7 @@ public:
   /// by this change, please consult the release notes for ROOT 6.24 for guidance on how to make this transition.
   virtual RooSpan<const double> getValues(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet = nullptr) const;
 
-  Double_t getPropagatedError(const RooFitResult &fr, const RooArgSet &nset = RooArgSet()) const;
+  double getPropagatedError(const RooFitResult &fr, const RooArgSet &nset = RooArgSet()) const;
 
   Bool_t operator==(Double_t value) const ;
   virtual Bool_t operator==(const RooAbsArg& other) const;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2721,14 +2721,12 @@ Double_t RooAbsReal::getPropagatedError(const RooFitResult &fr, const RooArgSet 
       }
    }
 
-   // Clone self for internal use
-   RooAbsReal *cloneFunc = (RooAbsReal *)cloneTree();
-   RooArgSet *errorParams = cloneFunc->getObservables(fpf_stripped);
+   RooArgSet *errorParams = getObservables(fpf_stripped);
 
    RooArgSet *nset =
-      nset_in.getSize() == 0 ? cloneFunc->getParameters(*errorParams) : cloneFunc->getObservables(nset_in);
+      nset_in.getSize() == 0 ? getParameters(*errorParams) : getObservables(nset_in);
 
-   // Make list of parameter instances of cloneFunc in order of error matrix
+   // Make list of parameter instances in order of error matrix
    RooArgList paramList;
    const RooArgList &fpf = fpf_stripped;
    vector<int> fpf_idx;
@@ -2756,11 +2754,11 @@ Double_t RooAbsReal::getPropagatedError(const RooFitResult &fr, const RooArgSet 
 
     // Make Plus variation
     ((RooRealVar*)paramList.at(ivar))->setVal(cenVal+errVal) ;
-    plusVar.push_back(cloneFunc->getVal(nset)) ;
+    plusVar.push_back(getVal(nset)) ;
 
     // Make Minus variation
     ((RooRealVar*)paramList.at(ivar))->setVal(cenVal-errVal) ;
-    minusVar.push_back(cloneFunc->getVal(nset)) ;
+    minusVar.push_back(getVal(nset)) ;
 
     ((RooRealVar*)paramList.at(ivar))->setVal(cenVal) ;
   }
@@ -2784,7 +2782,6 @@ Double_t RooAbsReal::getPropagatedError(const RooFitResult &fr, const RooArgSet 
   // Calculate error in linear approximation from variations and correlation coefficient
   Double_t sum = F*(C*F) ;
 
-  delete cloneFunc ;
   delete errorParams ;
   delete nset ;
 


### PR DESCRIPTION
In `RooAbsReal::getPropagatedError`, the whole computation graph is
cloned with `RooAbsArg::cloneTree` just to evaluate the variations.  The
original parameter values are reset after the variations, so it is safe
to use the original graph instead of a clone.

The motivation for this change was that when the uncertainties of a
RooRealIntegral are evaluated with `RooAbsReal::getPropagatedError`, a
custom observable range is not effective anymore after cloning the
integral with `cloneTree`.

Besides from the integral problem, it's probably good to avoid the clone
because there might be other issues related to the cloning that have not
been discovered yet.