### PR TITLE
[RF] Fix the integration of a cloned RooParamHistFunc with range

### DIFF
--- a/roofit/roofit/src/RooParamHistFunc.cxx
+++ b/roofit/roofit/src/RooParamHistFunc.cxx
@@ -264,7 +264,6 @@ Double_t RooParamHistFunc::analyticalIntegralWN(Int_t code, const RooArgSet* /*n
 
   auto getBinScale = [&](int iBin){ return static_cast<const RooAbsReal&>(_p[iBin]).getVal(); };
 
-  auto integrationSet = _dh.get();
   RooArgSet sliceSet{};
-  return const_cast<RooDataHist&>(_dh).sum(*integrationSet, sliceSet, true, false, ranges, getBinScale);
+  return const_cast<RooDataHist&>(_dh).sum(_x, sliceSet, true, false, ranges, getBinScale);
 }


### PR DESCRIPTION
After commit a0fa4fa, the integration of a RooParamHistFunc still
doesn't work when the RooParamHistFunc was cloned with `cloneTree`.
This was because the ranges were stored in a hash map keyed by argument
pointer and then not the correct clones of the arguments were used to
look up the ranges afterwards. This commit is fixing that.