### PR TITLE
[ntuple] Add RNTupleModel::HasField

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -23,7 +23,6 @@
 #include <ROOT/RStringView.hxx>
 
 #include <memory>
-#include <unordered_set>
 #include <utility>
 
 namespace ROOT {
@@ -48,8 +47,6 @@ class RNTupleModel {
    std::unique_ptr<RFieldZero> fFieldZero;
    /// Contains field values corresponding to the created top-level fields
    std::unique_ptr<REntry> fDefaultEntry;
-   /// Keeps track of which field names are taken.
-   std::unordered_set<std::string> fFieldNames;
 
    /// Checks that user-provided field names are valid in the context
    /// of this NTuple model. Throws an RException for invalid names.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -109,6 +109,9 @@ public:
       return fDefaultEntry->Get<T>(fieldName);
    }
 
+   /// Check if a field name already exists in the model.
+   bool HasField(std::string_view fieldName) const;
+
    /// Ingests a model for a sub collection and attaches it to the current model
    std::shared_ptr<RCollectionNTupleWriter> MakeCollection(
       std::string_view fieldName,

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -109,7 +109,8 @@ public:
       return fDefaultEntry->Get<T>(fieldName);
    }
 
-   /// Check if a field name already exists in the model.
+   /// Checks if a field with the given name already exists in the model. Works for
+   /// both top-level fields (`HasField("flag")`) and sub-fields (`HasField("particle.pos.x")`).
    bool HasField(std::string_view fieldName) const;
 
    /// Ingests a model for a sub collection and attaches it to the current model

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -57,6 +57,9 @@ void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBa
    fFieldZero->Attach(std::move(field));
 }
 
+bool ROOT::Experimental::RNTupleModel::HasField(std::string_view fieldName) const {
+   return fFieldNames.find(std::string(fieldName)) != fFieldNames.end();
+}
 
 std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental::RNTupleModel::MakeCollection(
    std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -15,13 +15,53 @@
 
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
+#include <ROOT/RFieldVisitor.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTuple.hxx>
 
 #include <cstdlib>
 #include <memory>
+#include <sstream>
 #include <utility>
 
+namespace {
+
+class RHasFieldVisitor : public ROOT::Experimental::Detail::RFieldVisitor {
+private:
+   std::string fRest;
+   bool fHasField = false;
+   bool StopRecurse() {
+      return fRest.empty();
+   }
+   std::string PopTopLevelField() {
+      std::istringstream iss(fRest);
+      std::string topLevelField;
+      std::getline(iss, topLevelField, '.');
+      std::string rest;
+      std::getline(iss, rest);
+      fRest = rest;
+      return topLevelField;
+   }
+public:
+   RHasFieldVisitor(std::string_view fieldName) : fRest(std::string(fieldName)) {}
+   bool HasField() const {
+      return fHasField;
+   }
+   void VisitField(const ROOT::Experimental::Detail::RFieldBase &field) final {
+      auto fieldName = PopTopLevelField();
+      for (auto f: field.GetSubFields()) {
+         if (fieldName == f->GetName()) {
+            if (StopRecurse()) {
+               fHasField = true;
+               return;
+            }
+            VisitField(*f);
+         }
+      }
+   }
+};
+
+} // anonymous namespace
 
 void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fieldName)
 {
@@ -58,16 +98,15 @@ void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBa
 }
 
 bool ROOT::Experimental::RNTupleModel::HasField(std::string_view fieldName) const {
-   return fFieldNames.find(std::string(fieldName)) != fFieldNames.end();
+   RHasFieldVisitor vis(fieldName);
+   fFieldZero->AcceptVisitor(vis);
+   return vis.HasField();
 }
 
 std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental::RNTupleModel::MakeCollection(
    std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)
 {
    EnsureValidFieldName(fieldName);
-   for (const auto& subField: collectionModel->fFieldNames) {
-      fFieldNames.insert(std::string(fieldName).append(".").append(subField));
-   }
    auto collectionNTuple = std::make_shared<RCollectionNTupleWriter>(std::move(collectionModel->fDefaultEntry));
    auto field = std::make_unique<RCollectionField>(fieldName, collectionNTuple, std::move(collectionModel));
    fDefaultEntry->CaptureValue(field->CaptureValue(collectionNTuple->GetOffsetPtr()));

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -69,9 +69,12 @@ void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fie
    if (!nameValid) {
       nameValid.Throw();
    }
-   auto fieldNameStr = std::string(fieldName);
-   if (fFieldNames.insert(fieldNameStr).second == false) {
-      throw RException(R__FAIL("field name '" + fieldNameStr + "' already exists in NTuple model"));
+   RHasFieldVisitor vis(fieldName);
+   fFieldZero->AcceptVisitor(vis);
+   if (vis.HasField()) {
+      throw RException(R__FAIL(
+         "field name '" + std::string(fieldName) + "' already exists in NTuple model"
+      ));
    }
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -65,6 +65,9 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental:
    std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)
 {
    EnsureValidFieldName(fieldName);
+   for (const auto& subField: collectionModel->fFieldNames) {
+      fFieldNames.insert(std::string(fieldName).append(".").append(subField));
+   }
    auto collectionNTuple = std::make_shared<RCollectionNTupleWriter>(std::move(collectionModel->fDefaultEntry));
    auto field = std::make_unique<RCollectionField>(fieldName, collectionNTuple, std::move(collectionModel));
    fDefaultEntry->CaptureValue(field->CaptureValue(collectionNTuple->GetOffsetPtr()));

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -221,8 +221,14 @@ TEST(RNTupleModel, HasField)
 
    EXPECT_FALSE(model->HasField("muon"));
    auto muon = RNTupleModel::Create();
+   auto pt = muon->MakeField<float>("pt", 0.0);
+   auto subCollection = RNTupleModel::Create();
+   auto subField = subCollection->MakeField<float>("pt", 0.0);
+   muon->MakeCollection("sub", std::move(subCollection));
    model->MakeCollection("muon", std::move(muon));
    EXPECT_TRUE(model->HasField("muon"));
+   EXPECT_TRUE(model->HasField("muon.pt"));
+   EXPECT_TRUE(model->HasField("muon.sub.pt"));
 }
 
 TEST(RNTupleModel, EnforceValidFieldNames)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -212,6 +212,18 @@ TEST(RNTuple, Clusters)
    EXPECT_EQ(24.0, (*rdFourVec)[1]);
 }
 
+TEST(RNTupleModel, HasField)
+{
+   auto model = RNTupleModel::Create();
+   EXPECT_FALSE(model->HasField("pt"));
+   auto field = model->MakeField<float>("pt", 42.0);
+   EXPECT_TRUE(model->HasField("pt"));
+
+   EXPECT_FALSE(model->HasField("muon"));
+   auto muon = RNTupleModel::Create();
+   model->MakeCollection("muon", std::move(muon));
+   EXPECT_TRUE(model->HasField("muon"));
+}
 
 TEST(RNTupleModel, EnforceValidFieldNames)
 {

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -217,6 +217,7 @@ TEST(RNTupleModel, HasField)
    auto model = RNTupleModel::Create();
    EXPECT_FALSE(model->HasField("pt"));
    auto field = model->MakeField<float>("pt", 42.0);
+   EXPECT_FALSE(model->HasField(""));
    EXPECT_TRUE(model->HasField("pt"));
 
    EXPECT_FALSE(model->HasField("muon"));
@@ -229,6 +230,9 @@ TEST(RNTupleModel, HasField)
    EXPECT_TRUE(model->HasField("muon"));
    EXPECT_TRUE(model->HasField("muon.pt"));
    EXPECT_TRUE(model->HasField("muon.sub.pt"));
+
+   auto ptrKlass = model->MakeField<CustomStruct>("klass");
+   EXPECT_TRUE(model->HasField("klass.a"));
 }
 
 TEST(RNTupleModel, EnforceValidFieldNames)


### PR DESCRIPTION
Add a helper method to check whether a model has a field with the
given name. We're using `string_view` on the API boundary, but this
unfortunately requires a `std::string` temporary to check if the name
exists in the unordered_set of field names until P0919R3 lands in
C++20. Switching to a plain `std::set` would also avoid this problem.