### PR TITLE
Remove fName member from TPaletteAxis class

### DIFF
--- a/hist/histpainter/inc/TPaletteAxis.h
+++ b/hist/histpainter/inc/TPaletteAxis.h
@@ -31,7 +31,6 @@ class TPaletteAxis : public TPave {
 protected:
    TGaxis       fAxis;          //  palette axis
    TH1         *fH;             //! pointer to parent histogram
-   TString      fName;          //  Pave name
 
 public:
    // TPaletteAxis status bits
@@ -49,13 +48,11 @@ public:
    TGaxis       *GetAxis() {return &fAxis;}
    Int_t         GetBinColor(Int_t i, Int_t j);
    TH1*          GetHistogram(){return fH;}
-   Option_t     *GetName() const {return fName.Data();}
    virtual char *GetObjectInfo(Int_t px, Int_t py) const;
    Int_t         GetValueColor(Double_t zc);
    virtual void  Paint(Option_t *option="");
    virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
    void          SetHistogram(TH1* h) {fH = h;}
-   virtual void  SetName(const char *name="") {fName = name;} // *MENU*
    virtual void  SetLabelColor(Int_t labelcolor) {fAxis.SetLabelColor(labelcolor);} // *MENU*
    virtual void  SetLabelFont(Int_t labelfont) {fAxis.SetLabelFont(labelfont);} // *MENU*
    virtual void  SetLabelOffset(Float_t labeloffset) {fAxis.SetLabelOffset(labeloffset);} // *MENU*
@@ -66,7 +63,7 @@ public:
    virtual void  SetLineWidth(Width_t linewidth) {fAxis.SetLineWidth(linewidth);} // *MENU*
    virtual void  UnZoom();  // *MENU*
 
-   ClassDef(TPaletteAxis,3)  //class used to display a color palette axis for 2-d plots
+   ClassDef(TPaletteAxis,4)  //class used to display a color palette axis for 2-d plots
 };
 
 #endif

--- a/hist/histpainter/src/TPaletteAxis.cxx
+++ b/hist/histpainter/src/TPaletteAxis.cxx
@@ -172,7 +172,6 @@ void TPaletteAxis::Copy(TObject &obj) const
 {
    TPave::Copy(obj);
    ((TPaletteAxis&)obj).fH    = fH;
-   ((TPaletteAxis&)obj).fName = fName;
 }
 
 


### PR DESCRIPTION
It fully duplicates TPave::fName member and not required here
Detected in JSON code for TPaletteAxis class
