### PR TITLE
[backport] Remove register keyword which is deprecated in c++17

### DIFF
--- a/math/mathcore/src/mixmax.icc
+++ b/math/mathcore/src/mixmax.icc
@@ -257,7 +257,7 @@ inline myuint fmodmulM61(myuint cum, myuint a, myuint b){
 
 inline myuint fmodmulM61(myuint cum, myuint s, myuint a)
 {
-    register myuint o,ph,pl,ah,al;
+    myuint o,ph,pl,ah,al;
     o=(s)*a;
     ph = ((s)>>32);
     pl = (s) & MASK32;


### PR DESCRIPTION
Remove register keyword which is deprecated in c++17. Backport of d113c9fcf7e1d88c573717c676aa4b97f1db2ea2.

Required for M1 support with C++17 enabled.