### PR TITLE
Add context menu to save the page content

### DIFF
--- a/gui/guihtml/inc/TGHtml.h
+++ b/gui/guihtml/inc/TGHtml.h
@@ -44,6 +44,7 @@ class TGFont;
 class TGIdleHandler;
 class THashTable;
 class TTimer;
+class TGPopupMenu;
 
 //----------------------------------------------------------------------
 
@@ -960,6 +961,9 @@ public:   // reloadable methods
 public:
    const char *GetText() const { return fZText; }
 
+   void HandleMenu(Int_t);
+   void SaveAs();
+
    int GetMarginWidth() { return fMargins.fL + fMargins.fR; }
    int GetMarginHeight() { return fMargins.fT + fMargins.fB; }
 
@@ -1125,6 +1129,10 @@ protected:
    virtual void UpdateBackgroundStart();
 
 protected:
+   enum {
+      kM_FILE_SAVEAS, kM_FILE_PRINT
+   };
+
    TGHtmlElement *fPFirst;          // First HTML token on a list of them all
    TGHtmlElement *fPLast;           // Last HTML token on the list
    int            fNToken;          // Number of HTML tokens on the list.
@@ -1179,6 +1187,7 @@ protected:
    TGHtmlScript  *fPScript;         // <SCRIPT> currently being parsed
 
    TGIdleHandler *fIdle;
+   TGPopupMenu   *fMenu;            // popup menu with user actions
 
    // These fields hold state information used by the HtmlAddStyle routine.
    // We have to store this state information here since HtmlAddStyle

--- a/gui/guihtml/inc/TGHtml.h
+++ b/gui/guihtml/inc/TGHtml.h
@@ -962,7 +962,7 @@ public:
    const char *GetText() const { return fZText; }
 
    void HandleMenu(Int_t);
-   void SaveAs();
+   void SaveFileAs();
 
    int GetMarginWidth() { return fMargins.fL + fMargins.fR; }
    int GetMarginHeight() { return fMargins.fT + fMargins.fB; }

--- a/gui/guihtml/src/TGHtml.cxx
+++ b/gui/guihtml/src/TGHtml.cxx
@@ -1403,6 +1403,7 @@ Bool_t TGHtml::HandleButton(Event_t *event)
       int x = event->fX + fVisible.fX;
       int y = event->fY + fVisible.fY;
       const char *uri = GetHref(x, y);
+      void *dummy;
 
 #if 0  // insertion cursor test
       char ix[20];
@@ -1417,6 +1418,8 @@ Bool_t TGHtml::HandleButton(Event_t *event)
             //!!delete[] uri;
          }
       }
+      fMenu->EndMenu(dummy);
+      gVirtualX->GrabPointer(0, 0, 0, 0, kFALSE);
    } else if ((event->fType == kButtonPress) && (event->fCode == kButton3)) {
       fMenu->PlaceMenu(event->fXRoot, event->fYRoot, kTRUE, kTRUE);
    } else if (event->fCode == kButton4) {

--- a/gui/guihtml/src/TGHtml.cxx
+++ b/gui/guihtml/src/TGHtml.cxx
@@ -1345,7 +1345,7 @@ void TGHtml::SubmitClicked(const char *val)
 /// Save file. Ask user for a file name via the file dialog. The pre-filled
 /// file name will be extracted from the current URI, if any
 
-void TGHtml::SaveAs()
+void TGHtml::SaveFileAs()
 {
    TGFileInfo fi;
    static const char *inputFileTypes[] = {
@@ -1374,7 +1374,7 @@ void TGHtml::HandleMenu(Int_t id)
 {
    switch(id) {
       case kM_FILE_SAVEAS:
-         SaveAs();
+         SaveFileAs();
          break;
       case kM_FILE_PRINT:
          break;

--- a/gui/guihtml/src/TGHtml.cxx
+++ b/gui/guihtml/src/TGHtml.cxx
@@ -210,7 +210,7 @@ TGHtml::TGHtml(const TGWindow *p, int w, int h, int id) : TGView(p, w, h, id)
 
    fMenu = new TGPopupMenu(gClient->GetDefaultRoot());
    fMenu->AddEntry(" Save &As...\tCtrl+A", kM_FILE_SAVEAS, 0, gClient->GetPicture("ed_save.png"));
-   fMenu->AddEntry(" Print...", kM_FILE_PRINT, 0, gClient->GetPicture("ed_print.png"));
+   fMenu->AddEntry(" &Print...\tCtrl+P", kM_FILE_PRINT, 0, gClient->GetPicture("ed_print.png"));
    fMenu->DisableEntry(kM_FILE_PRINT);
    fMenu->Connect("Activated(Int_t)", "TGHtml", this, "HandleMenu(Int_t)");
 


### PR DESCRIPTION
Add `Save As` and `Print` popup menu entries in the Html view widget, with only `Save As` being enabled for the time being. The file name in the file save dialog is pre-filled with the current URI page name, if any. This could supersede PR #7352 