### PR TITLE
[DF] Write RVecs out from Snapshot as RVecs, not as std::vectors 

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -44,35 +44,16 @@
 #include <utility>
 #include <tuple>
 
-// TODO remove when fData is removed (6.26)
-#include <map>
-#include <string>
-
 #ifdef R__HAS_VDT
 #include <vdt/vdtMath.h>
 #endif
 
-
-// TODO remove when fData is removed (6.26)
-class TTree;
-class TBranch;
 
 namespace ROOT {
 
 namespace VecOps {
 template<typename T>
 class RVec;
-}
-
-// TODO remove when fData is removed (6.26)
-namespace Internal {
-namespace RDF {
-class BoolArray;
-using BoolArrayMap = std::map<std::string, BoolArray>;
-template <typename T>
-void SetBranchesHelper(BoolArrayMap &boolArrays, TTree *inputTree, TTree &outputTree, const std::string &inName,
-                       const std::string &outName, TBranch *&branch, void *&branchAddress, ROOT::VecOps::RVec<T> *ab);
-}
 }
 
 namespace Detail {
@@ -292,12 +273,6 @@ hpt->Draw();
 // clang-format on
 template <typename T>
 class RVec {
-   // TODO remove this friendship in 6.26, when fData is removed
-   friend void ::ROOT::Internal::RDF::SetBranchesHelper<T>(ROOT::Internal::RDF::BoolArrayMap &boolArrays,
-                                                           TTree *inputTree, TTree &outputTree,
-                                                           const std::string &inName, const std::string &outName,
-                                                           TBranch *&branch, void *&branchAddress, RVec<T> *ab);
-
    // Here we check if T is a bool. This is done in order to decide what type
    // to use as a storage. If T is anything but bool, we use a vector<T, RAdoptAllocator<T>>.
    // If T is a bool, we opt for a plain vector<bool> otherwise we'll not be able

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1161,10 +1161,10 @@ void SetBranchesHelper(BoolArrayMap &boolArrays, TTree *inputTree, TTree &output
       }
    }
    const bool isTClonesArray = inputBranch != nullptr && std::string(inputBranch->GetClassName()) == "TClonesArray";
-   const auto mustWriteStdVec = !inputBranch || isTClonesArray ||
-                                ROOT::ESTLType::kSTLvector == TClassEdit::IsSTLCont(inputBranch->GetClassName());
+   const auto mustWriteRVec = !inputBranch || isTClonesArray ||
+                              ROOT::ESTLType::kSTLvector == TClassEdit::IsSTLCont(inputBranch->GetClassName());
 
-   if (mustWriteStdVec) {
+   if (mustWriteRVec) {
       // Treat:
       // 2. RVec coming from a custom column or a source
       // 3. RVec coming from a column on disk of type vector (the RVec is adopting the data of that vector)
@@ -1176,7 +1176,7 @@ void SetBranchesHelper(BoolArrayMap &boolArrays, TTree *inputTree, TTree &output
                  "be written out as a std::vector instead of a TClonesArray. Specify that the type of the branch is "
                  "TClonesArray as a Snapshot template parameter to write out a TClonesArray instead.", inName.c_str());
       }
-      outputTree.Branch(outName.c_str(), &(ab->fData));
+      outputTree.Branch(outName.c_str(), ab);
       return;
    }
 

--- a/tree/dataframe/test/dataframe_vecops.cxx
+++ b/tree/dataframe/test/dataframe_vecops.cxx
@@ -58,7 +58,7 @@ TEST(RDFAndVecOps, SnapshotRVec)
    auto b = static_cast<TBranchElement *>(t->GetBranch("v"));
    ASSERT_TRUE(b != nullptr);
    auto branchTypeName = b->GetClassName();
-   EXPECT_STREQ(branchTypeName, "vector<int,ROOT::Detail::VecOps::RAdoptAllocator<int> >");
+   EXPECT_STREQ(branchTypeName, "ROOT::VecOps::RVec<int>");
 
    gSystem->Unlink(fname);
 }


### PR DESCRIPTION
Now that we use the "collection proxy" mechanism to write RVecs,
they can still be read back as std::vectors or with TTreeReaderArrays
without issues, which removes the motivation for performing this
type-to-type translation on the fly.

Users might notice the change but it should not have any problematic
consequence as RDF and ROOT will still be able to read the RVec
branches written before this commit (without any change in user code
thanks to the "collection proxy" mechanism).