### PR TITLE
Add N-dimensional and more flexible histogram filling to RDataFrame

### DIFF
--- a/hist/hist/inc/THn.h
+++ b/hist/hist/inc/THn.h
@@ -28,15 +28,12 @@ class THnSparse;
 class TF1;
 
 class THn: public THnBase {
-private:
-   THn(const THn&); // Not implemented
-   THn& operator=(const THn&); // Not implemented
 
 protected:
    void AllocCoordBuf() const;
    void InitStorage(Int_t* nbins, Int_t chunkSize);
 
-   THn(): fCoordBuf() {}
+   THn() = default;
    THn(const char* name, const char* title, Int_t dim, const Int_t* nbins,
        const Double_t* xmin, const Double_t* xmax);
 
@@ -57,18 +54,20 @@ public:
       return GetArray().GetBin(idx);
    }
    Long64_t GetBin(const Double_t* x) const {
-      if (!fCoordBuf) AllocCoordBuf();
+      if (fCoordBuf.empty())
+         AllocCoordBuf();
       for (Int_t d = 0; d < fNdimensions; ++d) {
          fCoordBuf[d] = GetAxis(d)->FindFixBin(x[d]);
       }
-      return GetArray().GetBin(fCoordBuf);
+      return GetArray().GetBin(fCoordBuf.data());
    }
    Long64_t GetBin(const char* name[]) const {
-      if (!fCoordBuf) AllocCoordBuf();
+      if (fCoordBuf.empty())
+         AllocCoordBuf();
       for (Int_t d = 0; d < fNdimensions; ++d) {
          fCoordBuf[d] = GetAxis(d)->FindBin(name[d]);
       }
-      return GetArray().GetBin(fCoordBuf);
+      return GetArray().GetBin(fCoordBuf.data());
    }
 
    Long64_t GetBin(const Int_t* idx, Bool_t /*allocate*/ = kTRUE) {
@@ -176,7 +175,7 @@ public:
 
 protected:
    TNDArrayT<Double_t> fSumw2; // bin error, lazy allocation happens in TNDArrayT
-   mutable Int_t* fCoordBuf; //! Temporary buffer
+   mutable std::vector<Int_t> fCoordBuf; //! Temporary buffer
 
    ClassDef(THn, 1); //Base class for multi-dimensional histogram
 };

--- a/hist/hist/inc/THn.h
+++ b/hist/hist/inc/THn.h
@@ -37,6 +37,9 @@ protected:
    THn(const char* name, const char* title, Int_t dim, const Int_t* nbins,
        const Double_t* xmin, const Double_t* xmax);
 
+   THn(const char *name, const char *title, Int_t dim, const Int_t *nbins,
+       const std::vector<std::vector<double>> &xbins);
+
 public:
    virtual ~THn();
 
@@ -222,6 +225,12 @@ public:
        const Double_t* xmin, const Double_t* xmax):
    THn(name, title, dim, nbins, xmin, xmax),
    fArray(dim, nbins, true)  {}
+
+   THnT(const char *name, const char *title, Int_t dim, const Int_t *nbins,
+        const std::vector<std::vector<double>> &xbins)
+      : THn(name, title, dim, nbins, xbins), fArray(dim, nbins, true)
+   {
+   }
 
    const TNDArray& GetArray() const { return fArray; }
    TNDArray& GetArray() { return fArray; }

--- a/hist/hist/inc/THnBase.h
+++ b/hist/hist/inc/THnBase.h
@@ -63,6 +63,9 @@ protected:
     THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins, const Double_t *xmin,
             const Double_t *xmax);
 
+    THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins,
+            const std::vector<std::vector<double>> &xbins);
+
     void UpdateXStat(const Double_t *x, Double_t w = 1.)
     {
        if (GetCalculateErrors()) {

--- a/hist/hist/inc/THnBase.h
+++ b/hist/hist/inc/THnBase.h
@@ -50,35 +50,29 @@ protected:
    Double_t   fTsumw2;       ///<  Total sum of weights squared; -1 if no errors are calculated
    TArrayD    fTsumwx;       ///<  Total sum of weight*X for each dimension
    TArrayD    fTsumwx2;      ///<  Total sum of weight*X*X for each dimension
-   Double_t  *fIntegral;     ///<! Array with bin weight sums
+   std::vector<Double_t> fIntegral; ///<! vector with bin weight sums
    enum {
       kNoInt,
       kValidInt,
       kInvalidInt
    } fIntegralStatus;        ///<! status of integral
 
-private:
-   THnBase(const THnBase&); // Not implemented
-   THnBase& operator=(const THnBase&); // Not implemented
-
  protected:
-   THnBase():
-      fNdimensions(0), fEntries(0),
-      fTsumw(0), fTsumw2(-1.), fIntegral(0), fIntegralStatus(kNoInt)
-   {}
+    THnBase() : fNdimensions(0), fEntries(0), fTsumw(0), fTsumw2(-1.), fIntegral(), fIntegralStatus(kNoInt) {}
 
-   THnBase(const char* name, const char* title, Int_t dim,
-           const Int_t* nbins, const Double_t* xmin, const Double_t* xmax);
+    THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins, const Double_t *xmin,
+            const Double_t *xmax);
 
-   void UpdateXStat(const Double_t *x, Double_t w = 1.) {
-      if (GetCalculateErrors()) {
-         for (Int_t d = 0; d < fNdimensions; ++d) {
-            const Double_t xd = x[d];
-            fTsumwx[d]  += w * xd;
-            fTsumwx2[d] += w * xd * xd;
-         }
-      }
-   }
+    void UpdateXStat(const Double_t *x, Double_t w = 1.)
+    {
+       if (GetCalculateErrors()) {
+          for (Int_t d = 0; d < fNdimensions; ++d) {
+             const Double_t xd = x[d];
+             fTsumwx[d] += w * xd;
+             fTsumwx2[d] += w * xd * xd;
+          }
+       }
+    }
 
    /// Increment the statistics due to filled weight "w",
    void FillBinBase(Double_t w) {

--- a/hist/hist/inc/THnBase.h
+++ b/hist/hist/inc/THnBase.h
@@ -150,6 +150,28 @@ protected:
       return bin;
    }
 
+   /// Fill with the provided variadic arguments.
+   /// The number of arguments must be equal to the number of histogram dimensions or, for weighted fills, to the
+   /// number of dimensions + 1; in the latter case, the last function argument is used as weight.
+   /// A separate `firstval` argument is needed so the compiler does not pick this overload instead of the non-templated
+   /// Fill overloads
+   template <typename... MoreTypes>
+   Long64_t Fill(Double_t firstval, MoreTypes... morevals)
+   {
+      const std::array<double, 1 + sizeof...(morevals)> x{firstval, static_cast<double>(morevals)...};
+      if (Int_t(x.size()) == GetNdimensions()) {
+         // without weight
+         return Fill(x.data());
+      } else if (Int_t(x.size()) == (GetNdimensions() + 1)) {
+         // with weight
+         return Fill(x.data(), x.back());
+      } else {
+         Error("Fill", "Wrong number of arguments for number of histogram axes.");
+      }
+
+      return -1;
+   }
+
    virtual void FillBin(Long64_t bin, Double_t w) = 0;
 
    void SetBinEdges(Int_t idim, const Double_t* bins);

--- a/hist/hist/inc/TNDArray.h
+++ b/hist/hist/inc/TNDArray.h
@@ -45,22 +45,17 @@ to double: double value = arr[0][1][2];
 
 class TNDArray: public TObject {
 public:
-   TNDArray(): fNdimPlusOne(), fSizes() {}
+   TNDArray() : fSizes() {}
 
-   TNDArray(Int_t ndim, const Int_t* nbins, bool addOverflow = false):
-   fNdimPlusOne(), fSizes() {
+   TNDArray(Int_t ndim, const Int_t *nbins, bool addOverflow = false) : fSizes()
+   {
       TNDArray::Init(ndim, nbins, addOverflow);
-   }
-   ~TNDArray() {
-      delete[] fSizes;
    }
 
    virtual void Init(Int_t ndim, const Int_t* nbins, bool addOverflow = false) {
       // Calculate fSize based on ndim dimensions, nbins for each dimension,
       // possibly adding over- and underflow bin to each dimensions' nbins.
-      delete[] fSizes;
-      fNdimPlusOne = ndim + 1;
-      fSizes = new Long64_t[ndim + 1];
+      fSizes.resize(ndim + 1);
       Int_t overBins = addOverflow ? 2 : 0;
       fSizes[ndim] = 1;
       for (Int_t i = 0; i < ndim; ++i) {
@@ -70,14 +65,14 @@ public:
 
    virtual void Reset(Option_t* option = "") = 0;
 
-   Int_t GetNdimensions() const { return fNdimPlusOne - 1; }
+   Int_t GetNdimensions() const { return fSizes.size() - 1; }
    Long64_t GetNbins() const { return fSizes[0]; }
    Long64_t GetCellSize(Int_t dim) const { return fSizes[dim + 1]; }
 
    Long64_t GetBin(const Int_t* idx) const {
       // Get the linear bin number for each dimension's bin index
-      Long64_t bin = idx[fNdimPlusOne - 2];
-      for (Int_t d = 0; d < fNdimPlusOne - 2; ++d) {
+      Long64_t bin = idx[fSizes.size() - 2];
+      for (unsigned int d = 0; d < fSizes.size() - 2; ++d) {
          bin += fSizes[d + 1] * idx[d];
       }
       return bin;
@@ -87,14 +82,9 @@ public:
    virtual void SetAsDouble(ULong64_t linidx, Double_t value) = 0;
    virtual void AddAt(ULong64_t linidx, Double_t value) = 0;
 
-private:
-   TNDArray(const TNDArray&); // intentionally not implemented
-   TNDArray& operator=(const TNDArray&); // intentionally not implemented
-
 protected:
-   Int_t  fNdimPlusOne;   ///< Number of dimensions plus one
-   Long64_t* fSizes;      ///<[fNdimPlusOne] bin count
-   ClassDef(TNDArray, 1); ///< Base for n-dimensional array
+   std::vector<Long64_t> fSizes; ///< bin count
+   ClassDef(TNDArray, 2);        ///< Base for n-dimensional array
 };
 
 template <typename T>
@@ -123,38 +113,25 @@ private:
 template <typename T>
 class TNDArrayT: public TNDArray {
 public:
-   TNDArrayT(): fNumData(), fData() {}
+   TNDArrayT() : fData() {}
 
-   TNDArrayT(Int_t ndim, const Int_t* nbins, bool addOverflow = false):
-   TNDArray(ndim, nbins, addOverflow),
-   fNumData(), fData() {
-      fNumData = fSizes[0];
-   }
-   ~TNDArrayT() {
-      delete[] fData;
-   }
+   TNDArrayT(Int_t ndim, const Int_t *nbins, bool addOverflow = false) : TNDArray(ndim, nbins, addOverflow), fData() {}
 
    void Init(Int_t ndim, const Int_t* nbins, bool addOverflow = false) {
-      delete[] fData;
-      fData = 0;
+      fData.clear();
       TNDArray::Init(ndim, nbins, addOverflow);
-      fNumData = fSizes[0];
    }
 
    void Reset(Option_t* /*option*/ = "") {
       // Reset the content
-
-      // Use placement-new with value initialization:
-      if (fData) {
-         new (fData) T[fNumData]();
-      }
+      fData.assign(fSizes[0], T());
    }
 
 #ifndef __CINT__
    TNDArrayRef<T> operator[](Int_t idx) const {
       if (!fData) return TNDArrayRef<T>(0, 0);
       R__ASSERT(idx < fSizes[0] / fSizes[1] && "index out of range!");
-      return TNDArrayRef<T>(fData + idx * fSizes[1], fSizes + 2);
+      return TNDArrayRef<T>(fData.data() + idx * fSizes[1], fSizes.data() + 2);
    }
 #endif // __CINT__
 
@@ -165,31 +142,35 @@ public:
       return At(GetBin(idx));
    }
    T At(ULong64_t linidx) const {
-      if (!fData) return T();
+      if (fData.empty())
+         return T();
       return fData[linidx];
    }
    T& At(ULong64_t linidx) {
-      if (!fData) fData = new T[fNumData]();
+      if (fData.empty())
+         fData.resize(fSizes[0], T());
       return fData[linidx];
    }
 
    Double_t AtAsDouble(ULong64_t linidx) const {
-      if (!fData) return 0.;
+      if (fData.empty())
+         return 0.;
       return fData[linidx];
    }
    void SetAsDouble(ULong64_t linidx, Double_t value) {
-      if (!fData) fData = new T[fNumData]();
+      if (fData.empty())
+         fData.resize(fSizes[0], T());
       fData[linidx] = (T) value;
    }
    void AddAt(ULong64_t linidx, Double_t value) {
-      if (!fData) fData = new T[fNumData]();
+      if (fData.empty())
+         fData.resize(fSizes[0], T());
       fData[linidx] += (T) value;
    }
 
 protected:
-   int fNumData; // number of bins, product of fSizes
-   T*  fData; //[fNumData] data
-   ClassDef(TNDArrayT, 1); // N-dimensional array
+   std::vector<T> fData;   // data
+   ClassDef(TNDArrayT, 2); // N-dimensional array
 };
 
 // FIXME: Remove once we implement https://sft.its.cern.ch/jira/browse/ROOT-6284

--- a/hist/hist/src/THn.cxx
+++ b/hist/hist/src/THn.cxx
@@ -192,7 +192,6 @@ THn::THn(const char* name, const char* title,
 
 THn::~THn()
 {
-   delete [] fCoordBuf;
 }
 
 
@@ -226,7 +225,7 @@ void THn::Sumw2() {
 
 void THn::AllocCoordBuf() const
 {
-   fCoordBuf = new Int_t[fNdimensions]();
+   fCoordBuf.assign(fNdimensions, 0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -234,7 +233,7 @@ void THn::AllocCoordBuf() const
 
 void THn::InitStorage(Int_t* nbins, Int_t /*chunkSize*/)
 {
-   fCoordBuf = new Int_t[fNdimensions]();
+   fCoordBuf.assign(fNdimensions, 0);
    GetArray().Init(fNdimensions, nbins, true /*addOverflow*/);
    fSumw2.Init(fNdimensions, nbins, true /*addOverflow*/);
 }

--- a/hist/hist/src/THn.cxx
+++ b/hist/hist/src/THn.cxx
@@ -187,6 +187,12 @@ THn::THn(const char* name, const char* title,
    fCoordBuf() {
 }
 
+THn::THn(const char *name, const char *title, Int_t dim, const Int_t *nbins,
+         const std::vector<std::vector<double>> &xbins)
+   : THnBase(name, title, dim, nbins, xbins), fSumw2(dim, nbins, kTRUE /*overflow*/), fCoordBuf()
+{
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Destruct a THn
 

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -62,6 +62,27 @@ fIntegral(0), fIntegralStatus(kNoInt)
    fAxes.SetOwner();
 }
 
+THnBase::THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins,
+                 const std::vector<std::vector<double>> &xbins)
+   : TNamed(name, title), fNdimensions(dim), fAxes(dim), fBrowsables(dim), fEntries(0), fTsumw(0), fTsumw2(-1.),
+     fTsumwx(dim), fTsumwx2(dim), fIntegral(0), fIntegralStatus(kNoInt)
+{
+   if (Int_t(xbins.size()) != fNdimensions) {
+      Error("THnBase", "Mismatched number of dimensions %d with number of bin edge vectors %lu", fNdimensions,
+            xbins.size());
+   }
+   for (Int_t i = 0; i < fNdimensions; ++i) {
+      if (Int_t(xbins[i].size()) != (nbins[i] + 1)) {
+         Error("THnBase", "Mismatched number of bins %d with number of bin edges %lu", nbins[i], xbins[i].size());
+      }
+      TAxis *axis = new TAxis(nbins[i], xbins[i].data());
+      axis->SetName(TString::Format("axis%d", i));
+      fAxes.AddAtAndExpand(axis, i);
+   }
+   SetTitle(title);
+   fAxes.SetOwner();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Destruct a THnBase
 

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -68,12 +68,12 @@ THnBase::THnBase(const char *name, const char *title, Int_t dim, const Int_t *nb
      fTsumwx(dim), fTsumwx2(dim), fIntegral(0), fIntegralStatus(kNoInt)
 {
    if (Int_t(xbins.size()) != fNdimensions) {
-      Error("THnBase", "Mismatched number of dimensions %d with number of bin edge vectors %lu", fNdimensions,
+      Error("THnBase", "Mismatched number of dimensions %d with number of bin edge vectors %zu", fNdimensions,
             xbins.size());
    }
    for (Int_t i = 0; i < fNdimensions; ++i) {
       if (Int_t(xbins[i].size()) != (nbins[i] + 1)) {
-         Error("THnBase", "Mismatched number of bins %d with number of bin edges %lu", nbins[i], xbins[i].size());
+         Error("THnBase", "Mismatched number of bins %d with number of bin edges %zu", nbins[i], xbins[i].size());
       }
       TAxis *axis = new TAxis(nbins[i], xbins[i].data());
       axis->SetName(TString::Format("axis%d", i));

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -66,7 +66,8 @@ fIntegral(0), fIntegralStatus(kNoInt)
 /// Destruct a THnBase
 
 THnBase::~THnBase() {
-   if (fIntegralStatus != kNoInt) delete [] fIntegral;
+   if (fIntegralStatus != kNoInt)
+      fIntegral.clear();
 }
 
 
@@ -398,7 +399,7 @@ void THnBase::GetRandom(Double_t *rand, Bool_t subBinRandom /* = kTRUE */)
 
    // generate a random bin
    Double_t p = gRandom->Rndm();
-   Long64_t idx = TMath::BinarySearch(GetNbins() + 1, fIntegral, p);
+   Long64_t idx = TMath::BinarySearch(GetNbins() + 1, fIntegral.data(), p);
    const Int_t nStaticBins = 40;
    Int_t bin[nStaticBins];
    Int_t* pBin = bin;
@@ -1154,8 +1155,7 @@ void THnBase::ResetBase(Option_t * /*option = ""*/)
    fTsumw = 0.;
    fTsumw2 = -1.;
    if (fIntegralStatus != kNoInt) {
-      delete [] fIntegral;
-      fIntegral = nullptr;
+      fIntegral.clear();
       fIntegralStatus = kNoInt;
    }
 }
@@ -1167,8 +1167,7 @@ Double_t THnBase::ComputeIntegral()
 {
    // delete old integral
    if (fIntegralStatus != kNoInt) {
-      delete [] fIntegral;
-      fIntegral = nullptr;
+      fIntegral.clear();
       fIntegralStatus = kNoInt;
    }
 
@@ -1179,7 +1178,7 @@ Double_t THnBase::ComputeIntegral()
    }
 
    // allocate integral array
-   fIntegral = new Double_t [GetNbins() + 1];
+   fIntegral.resize(GetNbins() + 1);
    fIntegral[0] = 0.;
 
    // fill integral array with contents of regular bins (non over/underflow)
@@ -1208,8 +1207,7 @@ Double_t THnBase::ComputeIntegral()
    // check sum of weights
    if (fIntegral[GetNbins()] == 0.) {
       Error("ComputeIntegral", "No hits in regular bins (non over/underflow).");
-      delete [] fIntegral;
-      fIntegral = nullptr;
+      fIntegral.clear();
       return 0.;
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/HistoModels.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/HistoModels.hxx
@@ -17,6 +17,9 @@
 class TH1D;
 class TH2D;
 class TH3D;
+template <typename T>
+class THnT;
+using THnD = THnT<double>;
 class TProfile;
 class TProfile2D;
 
@@ -94,6 +97,30 @@ struct TH3DModel {
    TH3DModel(const char *name, const char *title, int nbinsx, const double *xbins, int nbinsy, const double *ybins,
              int nbinsz, const double *zbins);
    std::shared_ptr<::TH3D> GetHistogram() const;
+};
+
+struct THnDModel {
+   TString fName;
+   TString fTitle;
+   int fDim;
+   std::vector<int> fNbins;
+   std::vector<double> fXmin;
+   std::vector<double> fXmax;
+   std::vector<std::vector<double>> fBinEdges;
+
+   THnDModel() = default;
+   THnDModel(const THnDModel &) = default;
+   ~THnDModel();
+   THnDModel(const ::THnD &h);
+   THnDModel(const char *name, const char *title, int dim, const int *nbins, const double *xmin, const double *xmax);
+   // alternate version with std::vector to allow more convenient initialization from PyRoot
+   THnDModel(const char *name, const char *title, int dim, const std::vector<int> &nbins,
+             const std::vector<double> &xmin, const std::vector<double> &xmax);
+   THnDModel(const char *name, const char *title, int dim, const int *nbins,
+             const std::vector<std::vector<double>> &xbins);
+   THnDModel(const char *name, const char *title, int dim, const std::vector<int> &nbins,
+             const std::vector<std::vector<double>> &xbins);
+   std::shared_ptr<::THnD> GetHistogram() const;
 };
 
 struct TProfile1DModel {

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -91,6 +91,7 @@ namespace ActionTags {
 struct Histo1D{};
 struct Histo2D{};
 struct Histo3D{};
+struct HistoND{};
 struct Graph{};
 struct Profile1D{};
 struct Profile2D{};
@@ -122,7 +123,7 @@ struct HistoUtils<T, false> {
    static bool HasAxisLimits(T &) { return true; }
 };
 
-// Generic filling (covers Histo2D, Histo3D, Profile1D and Profile2D actions, with and without weights)
+// Generic filling (covers Histo2D, Histo3D, HistoND, Profile1D and Profile2D actions, with and without weights)
 template <typename... ColTypes, typename ActionTag, typename ActionResultType, typename PrevNodeType>
 std::unique_ptr<RActionBase>
 BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &h, const unsigned int nSlots,

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -223,6 +223,40 @@ constexpr std::size_t CacheLineStep() {
 
 void CheckDefineType(RDefineBase &define, const std::type_info &tid);
 
+// TODO in C++17 this could be a lambda within FillParHelper::Exec
+template <typename T>
+constexpr std::size_t FindIdxTrue(const T &arr)
+{
+   for (size_t i = 0; i < arr.size(); ++i) {
+      if (arr[i])
+         return i;
+   }
+   return arr.size();
+}
+
+// return type has to be decltype(auto) to preserve perfect forwarding
+template <std::size_t N, typename... Ts>
+decltype(auto) GetNthElement(Ts &&...args)
+{
+   auto tuple = std::forward_as_tuple(args...);
+   return std::get<N>(tuple);
+}
+
+#if __cplusplus >= 201703L
+template <class... Ts>
+using Disjunction = std::disjunction<Ts...>;
+#else
+template <class...>
+struct Disjunction : std::false_type {
+};
+template <class B1>
+struct Disjunction<B1> : B1 {
+};
+template <class B1, class... Bn>
+struct Disjunction<B1, Bn...> : std::conditional_t<bool(B1::value), B1, Disjunction<Bn...>> {
+};
+#endif
+
 } // end NS RDF
 } // end NS Internal
 } // end NS ROOT

--- a/tree/dataframe/test/dataframe_histomodels.cxx
+++ b/tree/dataframe/test/dataframe_histomodels.cxx
@@ -275,6 +275,67 @@ TEST(RDataFrameHistoModels, Histo3D)
    CheckBins(hm0w->GetZaxis(), ref0);
 }
 
+TEST(RDataFrameHistoModels, HistoND)
+{
+   ROOT::RDataFrame tdf(10);
+   auto x = 0.;
+   auto d = tdf.Define("x0", [&x]() { return x++; })
+               .Define("x1", [&x]() { return x + .1; })
+               .Define("x2", [&x]() { return x + .1; })
+               .Define("x3", [&x]() { return x + .1; });
+   int nbins[4] = {10, 5, 2, 2};
+   double xmin[4] = {0., 0., 0., 0.};
+   double xmax[4] = {10., 10., 10., 10.};
+   auto h1 = d.HistoND(::THnD("h1", "h1", 4, nbins, xmin, xmax), {"x0", "x1", "x2", "x3"});
+   auto h2 = d.HistoND({"h2", "h2", 4, nbins, xmin, xmax}, {"x0", "x1", "x2", "x3"});
+
+   std::vector<double> edges0{1, 2, 3, 4, 5, 6, 10};
+   std::vector<double> edges1{1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 10.1};
+   std::vector<double> edges2{1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 10.2};
+   std::vector<double> edges3{1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 10.3};
+   std::vector<std::vector<double>> edges = {edges0, edges1, edges2, edges3};
+   int nbinse[4];
+   for (unsigned int idim = 0; idim < edges.size(); ++idim) {
+      nbinse[idim] = edges[idim].size() - 1;
+   }
+   auto h1e = d.HistoND(::THnD("h1e", "h1e", 4, nbinse, edges), {"x0", "x1", "x2", "x3"});
+   auto h2e = d.HistoND({"h2e", "h2e", 4, nbinse, edges}, {"x0", "x1", "x2", "x3"});
+
+   THnDModel m0("m0", "m0", 4, nbins, xmin, xmax);
+   THnDModel m1(::THnD("m1", "m1", 4, nbins, xmin, xmax));
+
+   auto hm0 = d.HistoND(m0, {"x0", "x1", "x2", "x3"});
+   auto hm1 = d.HistoND(m1, {"x0", "x1", "x2", "x3"});
+   auto hm0w = d.HistoND(m0, {"x0", "x1", "x2", "x3", "x3"});
+   auto hm1w = d.HistoND(m1, {"x0", "x1", "x2", "x3", "x3"});
+
+   std::vector<double> ref0({0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.});
+   std::vector<double> ref1({0., 2., 4., 6., 8., 10.});
+   std::vector<double> ref2({0., 5., 10.});
+   std::vector<double> ref3({0., 5., 10.});
+
+   std::vector<std::vector<double>> ref = {ref0, ref1, ref2, ref3};
+
+   for (unsigned int idim = 0; idim < edges.size(); ++idim) {
+      CheckBins(h1e->GetAxis(idim), edges[idim]);
+   }
+   for (unsigned int idim = 0; idim < edges.size(); ++idim) {
+      CheckBins(h2e->GetAxis(idim), edges[idim]);
+   }
+   for (unsigned int idim = 0; idim < ref.size(); ++idim) {
+      CheckBins(h1->GetAxis(idim), ref[idim]);
+   }
+   for (unsigned int idim = 0; idim < ref.size(); ++idim) {
+      CheckBins(h2->GetAxis(idim), ref[idim]);
+   }
+   for (unsigned int idim = 0; idim < ref.size(); ++idim) {
+      CheckBins(hm0->GetAxis(idim), ref[idim]);
+   }
+   for (unsigned int idim = 0; idim < ref.size(); ++idim) {
+      CheckBins(hm0w->GetAxis(idim), ref[idim]);
+   }
+}
+
 TEST(RDataFrameHisto, FillVecBool)
 {
     const auto n = 10u;

--- a/tree/dataframe/test/dataframe_merge_results.cxx
+++ b/tree/dataframe/test/dataframe_merge_results.cxx
@@ -138,7 +138,7 @@ TEST(RDataFrameMergeResults, MergeHistoND)
    auto col3 = col2.Define("x2", [](ULong64_t e) { return double(e); }, {"rdfentry_"});
    auto col4 = col3.Define("x3", [](ULong64_t e) { return double(e); }, {"rdfentry_"});
 
-   int nbins[4] = {100, 100, 100, 100};
+   int nbins[4] = {10, 10, 10, 10};
    double xmin[4] = {0., 0., 0., 0.};
    double xmax[4] = {100., 100., 100., 100.};
    auto hist1 =

--- a/tree/dataframe/test/dataframe_merge_results.cxx
+++ b/tree/dataframe/test/dataframe_merge_results.cxx
@@ -129,6 +129,33 @@ TEST(RDataFrameMergeResults, MergeHisto2D)
    EXPECT_DOUBLE_EQ(mh.GetMean(), 49.5);
 }
 
+TEST(RDataFrameMergeResults, MergeHistoND)
+{
+   ROOT::RDataFrame df{100};
+
+   auto col1 = df.Define("x0", [](ULong64_t e) { return double(e); }, {"rdfentry_"});
+   auto col2 = col1.Define("x1", [](ULong64_t e) { return double(e); }, {"rdfentry_"});
+   auto col3 = col2.Define("x2", [](ULong64_t e) { return double(e); }, {"rdfentry_"});
+   auto col4 = col3.Define("x3", [](ULong64_t e) { return double(e); }, {"rdfentry_"});
+
+   int nbins[4] = {100, 100, 100, 100};
+   double xmin[4] = {0., 0., 0., 0.};
+   double xmax[4] = {100., 100., 100., 100.};
+   auto hist1 =
+      col4.HistoND<double, double, double, double>({"name", "title", 4, nbins, xmin, xmax}, {"x0", "x1", "x2", "x3"});
+   auto hist2 =
+      col4.HistoND<double, double, double, double>({"name", "title", 4, nbins, xmin, xmax}, {"x0", "x1", "x2", "x3"});
+
+   auto mh1 = GetMergeableValue(hist1);
+   auto mh2 = GetMergeableValue(hist2);
+
+   auto mergedptr = MergeValues(std::move(mh1), std::move(mh2));
+
+   const auto &mh = mergedptr->GetValue();
+
+   EXPECT_EQ(mh.GetEntries(), 200);
+}
+
 TEST(RDataFrameMergeResults, MergeProfile1D)
 {
    ROOT::RDataFrame df{100};


### PR DESCRIPTION
This PR does a few things
1) Extends the RDF Fill functionality to support arbitrary types and number of columns and an arbitrary mix of individual objects and containers with variadic templates.

Note that this will likely result in slower code being generated in case of compiling/jitting without optimization.

2) Adds a HistoND function to RDF to fill a THnD with arbitrary number of dimensions

The main issue here was actually that THnT does not have a publicly accessible copy constructor or assignment operator, which are needed for use with RDF.  I didn't have the patience to implement this by hand for all the classes in the inheritance chain, so the relevant classes have been migrated from C-style arrays to std::vector such that default copy (and move) constructors and assignment operators can be automatically generated.

3) Appropriate constructors have been added to allow THnT to be used with variable binning.
