### PR TITLE
When injecting symbols, do not rely on the last Module:

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -312,23 +312,17 @@ namespace cling {
     // Now that the transactions have been commited, force symbol emission
     // and overrides.
     if (!isInSyntaxOnlyMode() && !m_Opts.CompilerOpts.CUDADevice) {
-      if (const Transaction* T = getLastTransaction()) {
-        if (auto M = T->getModule()) {
-          for (const llvm::StringRef& Sym : Syms) {
-            const llvm::GlobalValue* GV = M->getNamedValue(Sym);
+      for (const llvm::StringRef& Sym : Syms) {
+        void* Addr = m_Executor->getPointerToGlobalFromJIT(Sym);
 #if defined(__linux__)
-            // libstdc++ mangles at_quick_exit on Linux when g++ < 5
-            if (!GV && Sym.equals("at_quick_exit"))
-                GV = M->getNamedValue("_Z13at_quick_exitPFvvE");
+        // libstdc++ mangles at_quick_exit on Linux when g++ < 5
+        if (!Addr && Sym.equals("at_quick_exit"))
+          Addr = m_Executor->getPointerToGlobalFromJIT("_Z13at_quick_exitPFvvE");
 #endif
-            if (GV) {
-              if (void* Addr = m_Executor->getPointerToGlobalFromJIT(Sym))
-                m_Executor->addSymbol(Sym.str().c_str(), Addr, true);
-              else
-                cling::errs() << Sym << " not defined\n";
-            } else
-                cling::errs() << Sym << " not in Module!\n";
-          }
+        if (!Addr) {
+          cling::errs() << "Replaced symbol " << Sym << " cannot be found in JIT!\n";
+        } else {
+          m_Executor->addSymbol(Sym.str().c_str(), Addr, true);
         }
       }
     }


### PR DESCRIPTION
With llvm9, the module ptr gets reset upon emission.
Instead, just look for the symbol in the JIT - where it should be found,
as Init() is injecting it there, and we want to find *that* symbol,
not the one from the binary.

Fixes `CodeUnloading/AtExit.C` cling test.