### PR TITLE
Fix diagnostics for `cling pragma load` with missing library

### DIFF
--- a/interpreter/cling/test/Pragmas/load.C
+++ b/interpreter/cling/test/Pragmas/load.C
@@ -10,7 +10,6 @@
 // RUN: cat %s | %cling -L %T -Xclang -verify 2>&1 | FileCheck %s
 
 #pragma cling load("DoesNotExistPleaseRecover")
-// expected-error@input_line_12:1{{expected is not a library; did you mean #include "DoesNotExistPleaseRecover"}}
 // expected-error@input_line_12:1{{'DoesNotExistPleaseRecover' file not found}}
 
 #pragma cling load("libcall_lib")

--- a/interpreter/cling/test/Pragmas/multiArgument.C
+++ b/interpreter/cling/test/Pragmas/multiArgument.C
@@ -8,6 +8,6 @@
 
 // RUN: cat %s | %cling -I%S -Xclang -verify 2>&1
 
-#pragma cling load("P0.h", "P1.h","P2.h") //expected-error {{expected is not a library; did you mean #include "P0.h"}}
+#pragma cling load("P0.h", "P1.h","P2.h") //expected-error {{expected P0.h to be a library, but it is not. If this is a source file, use `#include "P0.h"`}}
 
 .q


### PR DESCRIPTION
I don't understand `error: expected is not a library`, just re-use `error: file not found` when the file doesn't exist, and continue to be helpful ("maybe you meant...") if the file can be found through `HeaderSearch`.