### PR TITLE
Add pyspark to requirements.txt, ignore in dependency_versions.py

### DIFF
--- a/bindings/pyroot/pythonizations/test/dependency_versions.py
+++ b/bindings/pyroot/pythonizations/test/dependency_versions.py
@@ -8,13 +8,20 @@ import sys
 # Compile list of packages to be ignored in the test
 ignore = []
 
-if sys.version_info[0] == 2 and "ROOTTEST_IGNORE_NUMBA_PY2" in os.environ or \
-   sys.version_info[0] == 3 and "ROOTTEST_IGNORE_NUMBA_PY3" in os.environ:
-       ignore += ['numba', 'cffi']
+# pyspark is always ignored in this test since we use the build option
+# `test_distrdf_pyspark` to check whether the CTest environment is ready for
+# distributed RDataFrame tests of the Spark backend. Those tests will be run
+# only on the nodes where the build option is enabled and `FindPySpark.cmake`
+# was succesfully run during the configuration step.
+ignore.append('pyspark')
 
-if sys.version_info[0] == 2 and "ROOTTEST_IGNORE_JUPYTER_PY2" in os.environ or \
-   sys.version_info[0] == 3 and "ROOTTEST_IGNORE_JUPYTER_PY3" in os.environ:
-       ignore += ['notebook', 'metakernel']
+if sys.version_info[0] == 2 and 'ROOTTEST_IGNORE_NUMBA_PY2' in os.environ or \
+   sys.version_info[0] == 3 and 'ROOTTEST_IGNORE_NUMBA_PY3' in os.environ:
+    ignore += ['numba', 'cffi']
+
+if sys.version_info[0] == 2 and 'ROOTTEST_IGNORE_JUPYTER_PY2' in os.environ or \
+   sys.version_info[0] == 3 and 'ROOTTEST_IGNORE_JUPYTER_PY3' in os.environ:
+    ignore += ['notebook', 'metakernel']
 
 
 class DependencyVersions(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ cffi>=1.9.1
 # Notebooks: ROOT C++ kernel
 notebook>=4.4.1
 metakernel>=0.20.0
+
+# Distributed RDataFrame: Spark backend
+pyspark>=2.4


### PR DESCRIPTION
pyspark is added to requirements.txt along the other python runtime dependencies. For now it is ignored in `dependency_versions.py` since we already check that pyspark tests can be run in the environment through the `test_distrdf_pyspark` build option. At the same time, on some nodes where `dependency_versions.py` is run (because it's [always activated with the pythonization tests except for windows](https://github.com/root-project/root/blob/296fad253ee07a2e081d68020a9fbf3ad5980a72/bindings/pyroot/pythonizations/test/CMakeLists.txt#L19) ) pyspark could not be present for various reasons. So we resort to using the build option only to check this dependency for now