### PR TITLE
[io] use emplace_back in TStreamerInfoActions 

### DIFF
--- a/io/io/inc/TStreamerInfoActions.h
+++ b/io/io/inc/TStreamerInfoActions.h
@@ -182,7 +182,7 @@ namespace TStreamerInfoActions {
 
       template <typename action_t>
       void AddAction( action_t action, TConfiguration *conf ) {
-         fActions.push_back( TConfiguredAction(action, conf) );
+         fActions.emplace_back( action, conf );
       }
       void AddAction(const TConfiguredAction &action ) {
          fActions.push_back( action );

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -4520,8 +4520,7 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
       if (!rule) continue;
 
       TStreamerArtificial *newel;
-      typedef std::vector<TStreamerArtificial*> vec_t;
-      vec_t toAdd;
+      std::vector<TStreamerArtificial*> toAdd;
 
       if (rule->GetTarget()==0) {
          TString newName;
@@ -4591,8 +4590,8 @@ void TStreamerInfo::InsertArtificialElements(std::vector<const ROOT::TSchemaRule
          }
       }
       if (loc == -1) {
-         for(vec_t::iterator iter = toAdd.begin(); iter != toAdd.end(); ++iter) {
-            fElements->Add(*iter);
+         for(auto &el : toAdd) {
+            fElements->Add(el);
          }
       } else {
          R__TObjArray_InsertAt(fElements, toAdd, loc);


### PR DESCRIPTION
Should slightly improve performance while there is no need to create temporary object instance