### PR TITLE
Fix TCreatePrimitives::Ellipse for logarithmic axes

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -52,9 +52,7 @@
 class TCanvasInit {
 public:
    TCanvasInit() { TApplication::NeedGraphicsLibs(); }
-};
-static TCanvasInit gCanvasInit;
-
+} gCanvasInit;
 
 //*-*x16 macros/layout_canvas
 

--- a/graf2d/gpad/src/TCreatePrimitives.cxx
+++ b/graf2d/gpad/src/TCreatePrimitives.cxx
@@ -67,24 +67,28 @@ TCreatePrimitives::~TCreatePrimitives()
 
 void TCreatePrimitives::Ellipse(Int_t event, Int_t px, Int_t py, Int_t mode)
 {
-   static Double_t x0, y0, x1, y1;
-   Double_t xc,yc,r1,r2,xold,yold;
+   static Double_t x0, y0;
+   Double_t x1,y1,xc,yc,r1,r2,xold,yold;
 
    switch (event) {
 
    case kButton1Down:
-      x0   = gPad->AbsPixeltoX(px);
-      y0   = gPad->AbsPixeltoY(py);
-      xold = gPad->AbsPixeltoX(px);
-      yold = gPad->AbsPixeltoY(py);
+      x0 = gPad->AbsPixeltoX(px);
+      if (gPad->GetLogx())
+         x0 = TMath::Power(10,x0);
+      y0 = gPad->AbsPixeltoY(py);
+      if (gPad->GetLogy())
+         y0 = TMath::Power(10,y0);
       break;
 
    case kButton1Motion:
       xold = gPad->AbsPixeltoX(px);
       yold = gPad->AbsPixeltoY(py);
 
-      if (gPad->GetLogx()) xold = TMath::Power(10,xold);
-      if (gPad->GetLogy()) yold = TMath::Power(10,yold);
+      if (gPad->GetLogx())
+         xold = TMath::Power(10,xold);
+      if (gPad->GetLogy())
+         yold = TMath::Power(10,yold);
 
       xc = 0.5*(x0+xold);
       yc = 0.5*(y0+yold);
@@ -122,24 +126,18 @@ void TCreatePrimitives::Ellipse(Int_t event, Int_t px, Int_t py, Int_t mode)
    case kButton1Up:
       x1 = gPad->AbsPixeltoX(px);
       y1 = gPad->AbsPixeltoY(py);
-      if (gPad->GetLogx()) {
-         x0 = TMath::Power(10,x0);
+      if (gPad->GetLogx())
          x1 = TMath::Power(10,x1);
-      }
-      if (gPad->GetLogy()) {
-         y0 = TMath::Power(10,y0);
+      if (gPad->GetLogy())
          y1 = TMath::Power(10,y1);
-      }
-      xc = 0.5*(x0+x1);
-      yc = 0.5*(y0+y1);
 
       if (mode == kArc) {
          gPad->GetCanvas()->Selected(gPad, fgArc, kButton1Down);
-         fgArc = 0;
+         fgArc = nullptr;
       }
       if (mode == kEllipse) {
          gPad->GetCanvas()->Selected(gPad, fgEllipse, kButton1Down);
-         fgEllipse = 0;
+         fgEllipse = nullptr;
       }
 
       gROOT->SetEditorMode();

--- a/graf2d/gpad/src/TCreatePrimitives.cxx
+++ b/graf2d/gpad/src/TCreatePrimitives.cxx
@@ -271,7 +271,7 @@ void TCreatePrimitives::Pad(Int_t event, Int_t px, Int_t py, Int_t)
 {
    static Int_t px1old, py1old, px2old, py2old;
    static Int_t px1, py1, px2, py2, pxl, pyl, pxt, pyt;
-   static TPad *padsav;
+   static TPad *padsav = nullptr;
    Double_t xlow, ylow, xup, yup;
    TPad * newpad;
 
@@ -338,7 +338,10 @@ void TCreatePrimitives::Pad(Int_t event, Int_t px, Int_t py, Int_t)
       newpad->Draw();
       TCanvas *canvas = gPad->GetCanvas();
       if (canvas) canvas->Selected((TPad*)gPad, newpad, kButton1Down);
-      padsav->cd();
+      if (padsav) {
+         padsav->cd();
+         padsav = nullptr;
+      }
       break;
    }
 }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5698,15 +5698,18 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    char quote='"';
    char lcname[10];
    const char *cname = GetName();
-   Int_t nch = strlen(cname);
-   if (nch < 10) {
-      strlcpy(lcname,cname,10);
-      for (Int_t k=1;k<=nch;k++) {if (lcname[nch-k] == ' ') lcname[nch-k] = 0;}
-      if (lcname[0] == 0) {
-         if (this == gPad->GetCanvas()) {strlcpy(lcname,"c1",10);  nch = 2;}
-         else                           {strlcpy(lcname,"pad",10); nch = 3;}
-      }
-      cname = lcname;
+   size_t nch = strlen(cname);
+   if (nch < sizeof(lcname)) {
+      strlcpy(lcname, cname, sizeof(lcname));
+      for(size_t k = 0; k < nch; k++)
+         if (lcname[k] == ' ')
+            lcname[k] = 0;
+      if (lcname[0] != 0)
+         cname = lcname;
+      else if (this == gPad->GetCanvas())
+         cname = "c1";
+      else
+         cname = "pad";
    }
 
    //   Write pad parameters


### PR DESCRIPTION
Events handling was not correct with log axes.
`x0,y0` values where not converted and interpreted wrong during mouse moving.

Also simplify pad name handling in TPad::SavePrimitive

And apply few other clang-tidy warnings from #7432 
