### PR TITLE
[cmake] Build only the library of the xrootd client

### DIFF
--- a/builtins/xrootd/CMakeLists.txt
+++ b/builtins/xrootd/CMakeLists.txt
@@ -47,6 +47,7 @@ ExternalProject_Add(
                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
                -DENABLE_PYTHON=OFF
                -DENABLE_CEPH=OFF
+               -DXRDCL_LIB_ONLY=ON
                ${XROOTD_WITH_OPENSSL3}
                -DCMAKE_INSTALL_RPATH:STRING=${XROOTD_PREFIX}/${XROOTD_LIBDIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install


### PR DESCRIPTION
Hey! One commit I found locally, may be used to fix #7441 

- Enabled by the XRDCL_LIB_ONLY=ON cmake flag
- Prevents building the client binaries such as xrdcp in our build dir
but not exposing them in the installation

Fixes #7441