### PR TITLE
[relnotes] Updated v6.24 release notes for Cling

### DIFF
--- a/README/ReleaseNotes/v624/index.md
+++ b/README/ReleaseNotes/v624/index.md
@@ -25,6 +25,7 @@ The following people have contributed to this new version:
  Claire Guyot, CERN/SFT,\
  Stephan Hageboeck, CERN/SFT,\
  Sergey Linev, GSI,\
+ Javier Lopez-Gomez, CERN/SFT,\
  Pere Mato, CERN/SFT,\
  Lorenzo Moneta, CERN/SFT,\
  Alja Mrak-Tadel, UCSD/CMS,\
@@ -63,6 +64,7 @@ See the discussion at [ROOT-11014](https://sft.its.cern.ch/jira/browse/ROOT-1101
 
 ### Interpreter
 - cling's LLVM is upgraded to version 9.0
+- New interface to enable/disable optional cling features. Currently, it can be used to enable/disable support for redefinitions. See [this](https://github.com/root-project/cling/issues/360) issue for more information.
 
 ## I/O Libraries
 


### PR DESCRIPTION
Backport of the v6.24 release notes update introduced in commit 167039e2b4eb.

[skip-ci]