### PR TITLE
[cling] Skip non-regular files to find dylibs:

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
@@ -249,6 +249,15 @@ namespace cling {
   bool DynamicLibraryManager::isSharedLibrary(llvm::StringRef libFullPath,
                                               bool* exists /*=0*/) {
     using namespace llvm;
+    auto filetype = sys::fs::get_file_type(libFullPath, /*Follow*/ true);
+    if (filetype != sys::fs::file_type::regular_file) {
+      if (exists) {
+        // get_file_type returns status_error also in case of file_not_found.
+        *exists = filetype != sys::fs::file_type::status_error;
+      }
+      return false;
+    }
+
     file_magic Magic;
     const std::error_code Error = identify_magic(libFullPath, Magic);
     if (exists)


### PR DESCRIPTION
To determine the file magic, the file needs to be opened and read.
This is done with *each* file in $LD_LIBRARY_PATH, including ./
If one of them is e.g. a FIFO then reading blocks until someone
writes into the FIFO, which might cause the process to hang. This
was reported a couple of times, such as at https://root-forum.cern.ch/t/compiling-from-source-first-interactive-command-hangs/43997/5

Solution: only check for the file magic of *regular* files.

Fixes https://github.com/root-project/root/issues/7010