### PR TITLE
Fix several tutorials on Windows

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -13,6 +13,7 @@ if(WIN32)
   ROOT_EXECUTABLE(bindexplib
     win/bindexplib/bindexplib.cxx
   )
+  file(COPY win/w32pragma.h DESTINATION ${CMAKE_BINARY_DIR}/include/)
 endif()
 
 ROOT_EXECUTABLE(rmkdepend

--- a/tutorials/eve/pythia_display.C
+++ b/tutorials/eve/pythia_display.C
@@ -52,6 +52,11 @@ const Color_t  kColors[3] = { kRed, kGreen, kYellow };
 // Global variables.
 //------------------------------------------------------------------------------
 
+#include "TEveTrack.h"
+#include "TEveTrackPropagator.h"
+#include "TEveElement.h"
+#include "TEveGeoShape.h"
+
 #include "TPythia6.h"
 #include "TGeoTube.h"
 #include "TMCParticle.h"
@@ -228,7 +233,7 @@ void pythia_next_event()
    gTrackList->MakeTracks();
 
 
-   TEveElement* top = gEve->GetCurrentEvent();
+   TEveElement* top = (TEveElement *)gEve->GetCurrentEvent();
 
    gMultiView->DestroyEventRPhi();
    gMultiView->ImportEventRPhi(top);

--- a/tutorials/eve/pythia_display.C
+++ b/tutorials/eve/pythia_display.C
@@ -16,7 +16,7 @@ void pythia_display()
    dir.ReplaceAll("/./","/");
    gROOT->LoadMacro(dir +"MultiView.C+");
 
-#ifndef G__WIN32 // libPythia6 is a static library on Windoze
+#ifndef R__WIN32 // libPythia6 is a static library on Windoze
    if (gSystem->Load("libPythia6") < 0)
    {
       Error("pythia_display()",

--- a/tutorials/eve/pythia_display.C
+++ b/tutorials/eve/pythia_display.C
@@ -233,7 +233,7 @@ void pythia_next_event()
    gTrackList->MakeTracks();
 
 
-   TEveElement* top = (TEveElement *)gEve->GetCurrentEvent();
+   TEveElement* top = static_cast<TEveElement *>(gEve->GetCurrentEvent());
 
    gMultiView->DestroyEventRPhi();
    gMultiView->ImportEventRPhi(top);
@@ -300,4 +300,3 @@ void pythia_make_gui()
 }
 
 #endif
-

--- a/tutorials/graphs/timeonaxis3.C
+++ b/tutorials/graphs/timeonaxis3.C
@@ -11,16 +11,6 @@
 ///
 /// \authors Philippe Gras, Bertrand Bellenot, Olivier Couet
 
-#if defined(G__WIN32) && defined(__CINT__) && !defined(__MAKECINT__)
-{
-   // timeonaxis3.C has to be run in compiled mode on Windows.
-   // the following code does it.
-
-   gSystem->CompileMacro("timeonaxis3.C");
-   timeonaxis3();
-}
-#else
-
 #include "TAxis.h"
 #include "TGaxis.h"
 #include "TCanvas.h"
@@ -119,4 +109,3 @@ TCanvas *timeonaxis3() {
    }
    return c;
 }
-#endif

--- a/tutorials/gui/drag_and_drop.C
+++ b/tutorials/gui/drag_and_drop.C
@@ -199,7 +199,7 @@ DNDMainFrame::DNDMainFrame(const TGWindow *p, int w, int h) :
    item->SetDNDSource(kTRUE);
 
    TString rootsys(gSystem->UnixPathName(gSystem->Getenv("ROOTSYS")));
-#ifdef G__WIN32
+#ifdef R__WIN32
    // remove the drive letter (e.g. "C:/") from $ROOTSYS, if any
    if (rootsys[1] == ':' && rootsys[2] == '/')
       rootsys.Remove(0, 3);

--- a/tutorials/gui/guitest.C
+++ b/tutorials/gui/guitest.C
@@ -1914,7 +1914,7 @@ TestDirList::TestDirList(const TGWindow *p, const TGWindow *main,
                       "OnDoubleClick(TGListTreeItem*,Int_t)");
    fContents->Connect("Clicked(TGListTreeItem*,Int_t)","TestDirList",this,
                       "OnDoubleClick(TGListTreeItem*,Int_t)");
-#ifdef G__WIN32
+#ifdef R__WIN32
    fContents->AddItem(0,"c:\\");  // browse the upper directory
 #else
    fContents->AddItem(0,"/");  // browse the upper directory


### PR DESCRIPTION
- Copy the missing `w32pragma.h` header in the `include` directory
- Change `G__WIN32` into `R__WIN32` in a couple of macros
- Don't compile the `timeonaxis3.C` macro (not needed anymore)