### PR TITLE
[RF] Prevent intermittent failures in testActionHelpers.

### DIFF
--- a/roofit/RDataFrameHelpers/test/testActionHelpers.cxx
+++ b/roofit/RDataFrameHelpers/test/testActionHelpers.cxx
@@ -6,11 +6,9 @@
 #include <RooAbsDataHelper.h>
 
 #include <TROOT.h>
-#include <TRandom3.h>
+#include <Rtypes.h>
 
 #include "gtest/gtest.h"
-
-#include <vector>
 
 TEST(RooAbsDataHelper, MTConstruction)
 {
@@ -18,26 +16,24 @@ TEST(RooAbsDataHelper, MTConstruction)
   ROOT::EnableImplicitMT(4);
 #endif
 
-  const auto nSlots = ROOT::IsImplicitMTEnabled() ? ROOT::GetThreadPoolSize() : 1;
-  std::vector<TRandom3> rngs(nSlots);
-  for (unsigned int i=0; i < rngs.size(); ++i) {
-    rngs[i].SetSeed(i+1);
-  }
-
   // We create an RDataFrame with two columns filled with 2 million random numbers.
   constexpr std::size_t nEvent = 200000;
   ROOT::RDataFrame d(nEvent);
-  auto dd = d.DefineSlot("x", [&rngs](unsigned int slot){ return rngs[slot].Uniform(-5.,  5.); })
-             .DefineSlot("y", [&rngs](unsigned int slot){ return rngs[slot].Gaus(1., 3.); });
+  auto dd = d.DefineSlot("x", [](unsigned int /*slot*/, ULong64_t entry){ return -5. + 10. * ((double)entry) / nEvent; }, {"rdfentry_"})
+             .DefineSlot("y", [](unsigned int /*slot*/, ULong64_t entry){ return  0. +  2. * ((double)entry) / nEvent; }, {"rdfentry_"});
   auto meanX = dd.Mean("x");
   auto meanY = dd.Mean("y");
 
+  constexpr double targetXMean  = 0.;
+  constexpr double targetYMean  = 1.;
+  constexpr double targetXVar = 100./12.;
+  constexpr double targetYVar =   4./12.;
 
   // We create RooFit variables that will represent the dataset.
   RooRealVar x("x", "x", -5.,   5.);
   RooRealVar y("y", "y", -50., 50.);
   x.setBins(10);
-  y.setBins(20);
+  y.setBins(100);
 
 
   auto rooDataSet = dd.Book<double, double>(
@@ -60,23 +56,20 @@ TEST(RooAbsDataHelper, MTConstruction)
 
   // Run it and inspect the results
   // -------------------------------
-  EXPECT_NEAR(meanX.GetValue(), 0., 1.E-2); // Pretty bad accuracy, but might be the RNG or summation in RDF
-  EXPECT_NEAR(meanY.GetValue(), 1., 1.E-2);
+  EXPECT_NEAR(meanX.GetValue(), targetXMean, 1.E-4);
+  EXPECT_NEAR(meanY.GetValue(), targetYMean, 1.E-4);
 
-  constexpr double goodPrecision = 1.E-9;
-  constexpr double middlePrecision = 3.E-3;
-  constexpr double badPrecision = 2.E-2;
   ASSERT_EQ(rooDataSet->numEntries(), nEvent);
-  EXPECT_NEAR(rooDataSet->sumEntries(), nEvent, nEvent * goodPrecision);
-  EXPECT_NEAR(rooDataSet->mean(x),  meanX.GetValue(), goodPrecision);
-  EXPECT_NEAR(rooDataSet->moment(x, 2.), 100./12., 100./12. * middlePrecision);
-  EXPECT_NEAR(rooDataSet->mean(y),  meanY.GetValue(), goodPrecision);
-  EXPECT_NEAR(rooDataSet->moment(y, 2.), 3.*3., 3.*3. * badPrecision);
+  EXPECT_NEAR(rooDataSet->sumEntries(), nEvent, nEvent * 1.E-9);
+  EXPECT_NEAR(rooDataSet->mean(x),  targetXMean, 1.E-4);
+  EXPECT_NEAR(rooDataSet->moment(x, 2.), targetXVar, targetXVar * 1.E-4);
+  EXPECT_NEAR(rooDataSet->mean(y),  targetYMean, 1.E-4);
+  EXPECT_NEAR(rooDataSet->moment(y, 2.), targetYVar, targetYVar * 1.E-4);
 
-  EXPECT_NEAR(rooDataHist->sumEntries(), nEvent, nEvent * goodPrecision);
-  EXPECT_NEAR(rooDataHist->mean(x),  meanX.GetValue(), badPrecision);
-  EXPECT_NEAR(rooDataHist->moment(x, 2.), 100./12., 100./12. * badPrecision);
-  EXPECT_NEAR(rooDataHist->mean(y),  meanY.GetValue(), badPrecision);
-  EXPECT_NEAR(std::sqrt(rooDataHist->moment(y, 2.)), 3., 0.4); // Sigma is hard to measure in a binned distribution
+  EXPECT_NEAR(rooDataHist->sumEntries(), nEvent, nEvent * 1.E-9);
+  EXPECT_NEAR(rooDataHist->mean(x),  targetXMean, 1.E-4);
+  EXPECT_NEAR(rooDataHist->moment(x, 2.), 8.25, 1.E-2); // Variance is affected in a binned distribution
+  EXPECT_NEAR(rooDataHist->mean(y),  targetYMean, 1.E-4);
+  EXPECT_NEAR(rooDataHist->moment(y, 2.), 0.25, 1.E-2); // Variance is affected in a binned distribution
 }
 


### PR DESCRIPTION
Due to an aggressive test threshold, the RF RDF action helpers test was
    failing. Here, the RNG is removed, making it fully deterministic.

Well, not fully. The *generation* is fully deterministic in the sense that the same numbers are generated, but the order of events is unspecified.