### PR TITLE
Fix clang-tidy warnings in executables

### DIFF
--- a/main/src/nbmain.cxx
+++ b/main/src/nbmain.cxx
@@ -43,10 +43,10 @@ using namespace std;
 
 #ifdef WIN32
 #include <process.h>
-static string pathsep("\\");
+std::string pathsep = "\\";
 #define execlp _execlp
 #else
-static string pathsep("/");
+std::string pathsep = "/";
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -224,5 +224,6 @@ int main(int argc, char **argv)
    fprintf(stderr,
            "Error starting ROOT notebook -- please check that Jupyter is installed\n");
 
+   delete [] jargv;
    return 1;
 }

--- a/main/src/nbmain.cxx
+++ b/main/src/nbmain.cxx
@@ -43,10 +43,10 @@ using namespace std;
 
 #ifdef WIN32
 #include <process.h>
-std::string pathsep = "\\";
+constexpr const char *pathsep = "\\";
 #define execlp _execlp
 #else
-std::string pathsep = "/";
+constexpr const char *pathsep = "/";
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/main/src/pmain.cxx
+++ b/main/src/pmain.cxx
@@ -34,6 +34,7 @@
 #include "TInterpreter.h"
 #include "TROOT.h"
 #include "TSystem.h"
+#include "strlcpy.h"
 
 
 static Int_t gLogLevel = 0;
@@ -66,8 +67,8 @@ static void ReadPutEnvs(const char *envfile)
       if (!strchr(ln, '=')) continue;
       // Good line
       char *ev = new char[l+1];
-      strcpy(ev, ln);
-      putenv(ev);
+      strlcpy(ev, ln, l+1);
+      putenv(ev); // NOLINT: do not release memory in ev, will be used by environment variable
    }
 
    // Close the file

--- a/rootx/src/rootx.cxx
+++ b/rootx/src/rootx.cxx
@@ -142,7 +142,7 @@ static void SetRootSys()
             int l2 = strlen(ep) + 10;
             char *env = new char[l2];
             snprintf(env, l2, "ROOTSYS=%s", ep);
-            putenv(env);
+            putenv(env); // NOLINT: allocated memory now used by environment variable
          }
       }
       delete [] ep;
@@ -351,6 +351,8 @@ int main(int argc, char **argv)
       fprintf(stderr, "%s: can't start ROOT notebook -- this option is only available when building with CMake, please check that %s exists\n",
               argv[0], arg0);
 
+      delete [] argvv;
+
       return 1;
    }
 
@@ -467,6 +469,8 @@ int main(int argc, char **argv)
    // Exec failed
    fprintf(stderr, "%s: can't start ROOT -- check that %s exists!\n",
            argv[0], arg0);
+
+   delete [] argvv;
 
    return 1;
 }

--- a/rootx/src/rootxx.cxx
+++ b/rootx/src/rootxx.cxx
@@ -30,6 +30,7 @@
 
 #include "Rtypes.h"
 #include "snprintf.h"
+#include "strlcpy.h"
 
 #include "rootcoreteam.h"
 
@@ -779,8 +780,9 @@ int DrawCredits(bool draw, bool extended)
 
       struct passwd *pwd = getpwuid(getuid());
       if (pwd) {
-         char *name = new char [strlen(pwd->pw_gecos)+1];
-         strcpy(name, pwd->pw_gecos);
+         size_t sz = strlen(pwd->pw_gecos)+1;
+         char *name = new char [sz];
+         strlcpy(name, pwd->pw_gecos, sz);
          char *s = strchr(name, ',');
          if (s) *s = 0;
          char line[1024];


### PR DESCRIPTION
Fixes #7527 