### PR TITLE
Fix unwind info relocation with large code model on AArch64 [v6.24]

### DIFF
--- a/interpreter/llvm/src/lib/MC/MCObjectFileInfo.cpp
+++ b/interpreter/llvm/src/lib/MC/MCObjectFileInfo.cpp
@@ -309,6 +309,8 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
     break;
   case Triple::ppc64:
   case Triple::ppc64le:
+  case Triple::aarch64:
+  case Triple::aarch64_be:
   case Triple::x86_64:
     FDECFIEncoding = dwarf::DW_EH_PE_pcrel |
                      (Large ? dwarf::DW_EH_PE_sdata8 : dwarf::DW_EH_PE_sdata4);


### PR DESCRIPTION
Backport of D27629, commit 18805ea951.

Original commit message:
```
Makes sure that the unwind info uses 64bits pcrel relocation if a large
code model is specified and handle the corresponding relocation in the
ExecutionEngine. This can happen with certain kernel configuration (the
same as the one in https://reviews.llvm.org/D27609, found at least on
the ArchLinux stock kernel and the one used on https://www.packet.net/)
using the builtin JIT memory manager.

Co-authored-by: Yichao Yu <yyc1992@gmail.com>
Co-authored-by: Valentin Churavy <v.churavy@gmail.com>
```

Note: The handling in ExecutionEngine was committed in a different
revision and is already part of LLVM 9. We need the part about emitting
relocations because eh_frame (allocated in a data section) may be more
than 4Gb away from the code section it references. See the discussion
in https://github.com/cms-sw/cmssw/issues/31123 for context.

(cherry picked from commit f481e8fe6df177ec1a50a10b7d76df5fb0b5c2a2)

v6.24 version of #7563 