### PR TITLE
Fix unwind info relocation with large code model on PowerPC and AArch64 [v6.20]

### DIFF
--- a/interpreter/llvm/src/lib/MC/MCObjectFileInfo.cpp
+++ b/interpreter/llvm/src/lib/MC/MCObjectFileInfo.cpp
@@ -284,6 +284,8 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T) {
   case Triple::mips64el:
     FDECFIEncoding = dwarf::DW_EH_PE_sdata8;
     break;
+  case Triple::ppc64:
+  case Triple::ppc64le:
   case Triple::x86_64:
     FDECFIEncoding = dwarf::DW_EH_PE_pcrel |
                      ((CMModel == CodeModel::Large) ? dwarf::DW_EH_PE_sdata8

--- a/interpreter/llvm/src/lib/MC/MCObjectFileInfo.cpp
+++ b/interpreter/llvm/src/lib/MC/MCObjectFileInfo.cpp
@@ -286,6 +286,8 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T) {
     break;
   case Triple::ppc64:
   case Triple::ppc64le:
+  case Triple::aarch64:
+  case Triple::aarch64_be:
   case Triple::x86_64:
     FDECFIEncoding = dwarf::DW_EH_PE_pcrel |
                      ((CMModel == CodeModel::Large) ? dwarf::DW_EH_PE_sdata8


### PR DESCRIPTION
v6.20 version of #7563 plus the same fix for PowerPC (see also #7607)