### PR TITLE
[metacling] Offer RLogger interface to trace autoparsing:

### DIFF
--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -59,6 +59,9 @@ struct InterpreterMutexRegistrationRAII {
    ~InterpreterMutexRegistrationRAII();
 };
 }
+namespace Experimental {
+   class RLogChannel;
+}
 }
 
 class TInterpreter : public TNamed {
@@ -548,6 +551,8 @@ public:
    virtual const char *TypedefInfo_Title(TypedefInfo_t * /* tinfo */) const {return 0;}
 
    static TInterpreter *Instance();
+
+   ROOT::Experimental::RLogChannel &PerfLog() const;
 
    ClassDef(TInterpreter,0)  //ABC defining interface to generic interpreter
 };

--- a/core/meta/src/TInterpreter.cxx
+++ b/core/meta/src/TInterpreter.cxx
@@ -20,6 +20,7 @@ interpreter.
 #include "TError.h"
 #include "TGlobal.h"
 
+#include "ROOT/RLogger.hxx"
 
 TInterpreter*   gCling = nullptr; // returns pointer to global TCling object
 static TInterpreter *gInterpreterLocal = nullptr; // The real holder of the pointer.
@@ -64,4 +65,14 @@ TInterpreter *TInterpreter::Instance()
       }
    }
    return gInterpreterLocal;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Access the log channel for observice performance-critical actions.
+/// The channel name is "ROOT.InterpreterPerf"
+
+ROOT::Experimental::RLogChannel &TInterpreter::PerfLog() const
+{
+   static ROOT::Experimental::RLogChannel sLog("ROOT.InterpreterPerf");
+   return sLog;
 }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -20,6 +20,7 @@ clang/LLVM technology.
 #include "TCling.h"
 
 #include "ROOT/FoundationUtils.hxx"
+#include "ROOT/RLogger.hxx"
 
 #include "TClingBaseClassInfo.h"
 #include "TClingCallFunc.h"
@@ -6353,13 +6354,16 @@ UInt_t TCling::AutoParseImplRecurse(const char *cls, bool topLevel)
                   } else {
                      fParsedPayloadsAddresses.insert(hName);
                      nHheadersParsed++;
+                     ProcInfo_t info;
+                     gSystem->GetProcInfo(&info);
+                     float endRSSval = 1e-3*info.fMemResident;
+                     float endVSIZEval = 1e-3*info.fMemVirtual;
                      if (gDebug > 0){
-                        ProcInfo_t info;
-                        gSystem->GetProcInfo(&info);
-                        float endRSSval = 1e-3*info.fMemResident;
-                        float endVSIZEval = 1e-3*info.fMemVirtual;
                         Info("Autoparse", ">>> RSS key %s - before %.3f MB - after %.3f MB - delta %.3f MB", apKey, initRSSval, endRSSval, endRSSval-initRSSval);
                         Info("Autoparse", ">>> VSIZE key %s - before %.3f MB - after %.3f MB - delta %.3f MB", apKey, initVSIZEval, endVSIZEval, endVSIZEval-initVSIZEval);
+                     } else {
+                        R__LOG_DEBUG(1, PerfLog()) << "Autoparse request `" << cls << "`, key `" << apKey << "`: parsed \"" << hName
+                           << "\" RSS cost " << endRSSval-initRSSval << "MB\n";
                      }
                   }
                } else if (!IsLoaded(hName)) {


### PR DESCRIPTION
It allows (e.g. CMS) to set
```
RLogScopedVerbosity debugThis(gInterpreter->PerfLog(), ELogLevel::kDebug + 1);
```
to trace invocations of the autoparsing (and only that).