### PR TITLE
[DF] Fix namespace in LinkDef file

### DIFF
--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -21,7 +21,7 @@
 #pragma link C++ namespace ROOT::Detail::RDF;
 #pragma link C++ namespace ROOT::RDF;
 #pragma link C++ class ROOT::Internal::RDF::RActionBase-;
-#pragma link C++ class ROOT::Detail::RDF::RJittedAction-;
+#pragma link C++ class ROOT::Internal::RDF::RJittedAction-;
 #pragma link C++ class ROOT::Detail::RDF::RFilterBase-;
 #pragma link C++ class ROOT::Detail::RDF::RJittedFilter-;
 #pragma link C++ class ROOT::Detail::RDF::RDefineBase-;


### PR DESCRIPTION
This removes cling warnings about an unused rule for the non-existing
type.