### PR TITLE
[RF] Reorganize RooAbsTestStatistic configuration with configuration struct

### DIFF
--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -32,7 +32,7 @@ public:
   RooAbsOptTestStatistic() ;
   RooAbsOptTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
                          const RooArgSet& projDeps,
-                         RooAbsTestStatistic::Configuration && cfg);
+                         RooAbsTestStatistic::Configuration const& cfg);
   RooAbsOptTestStatistic(const RooAbsOptTestStatistic& other, const char* name=0);
   virtual ~RooAbsOptTestStatistic();
 
@@ -64,6 +64,7 @@ protected:
 		 const char* addCoefRangeName)  ;
 
   friend class RooAbsReal ;
+  friend class RooAbsTestStatistic ;
 
   virtual Bool_t allowFunctionCache() { return kTRUE ;  }
   void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTrackingOpt=kTRUE) ;

--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -31,9 +31,8 @@ public:
   // Constructors, assignment etc
   RooAbsOptTestStatistic() ;
   RooAbsOptTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
-			 const RooArgSet& projDeps, const char* rangeName=0, const char* addCoefRangeName=0,
-			 Int_t nCPU=1, RooFit::MPSplit interleave=RooFit::BulkPartition, Bool_t verbose=kTRUE, Bool_t splitCutRange=kFALSE,
-			 Bool_t cloneInputData = true, double integrateOverBinsPrecision = -1.);
+                         const RooArgSet& projDeps,
+                         RooAbsTestStatistic::Configuration && cfg);
   RooAbsOptTestStatistic(const RooAbsOptTestStatistic& other, const char* name=0);
   virtual ~RooAbsOptTestStatistic();
 

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -88,6 +88,11 @@ public:
         _value = value;
       }
 
+      ConfParam& operator=(T const& value) {
+        setValue(value);
+        return *this;
+      }
+
       /// Get the configuration parameter value.
       T const& operator*() const { return _value ; }
 

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -22,7 +22,6 @@
 #include "TStopwatch.h"
 #include "Math/Util.h"
 
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -42,99 +41,26 @@ class RooAbsTestStatistic : public RooAbsReal {
 public:
 
   struct Configuration {
-
     /// Stores the configuration parameters for RooAbsTestStatistic.
-
-    template<class T>
-    struct DefaultValue { const T val; };
-
-    template<class T>
-    DefaultValue<T> makeDefault(T const& value) { return {value}; }
-
-    template<class T>
-    class ConfParam {
-
-    /// Manages a configuration parameter.
-    /// It supports setting a default value, can determine if a value has been
-    /// set by the user, and allows to change the default value after
-    /// construction.
-
-    private:
-
-      friend struct Configuration;
-
-      /// Constructs a configuration parameter where the value is set to a default value
-      /// that can still be changed after construction.
-      /// This constructor should only be used in the declaration of the configuration struct.
-      ConfParam(DefaultValue<T> const& value) : _isSet{false}, _value{value.val} {}
-
-    public:
-
-      /// Constructs a configuration parameter where the value is set immediately.
-      ConfParam(T const& value) : _isSet{true}, _value{value} {}
-
-      /// Check if a given configuration parameter is set.
-      bool isSet() const { return _isSet ; }
-
-      /// Set a configuration value after construction time.
-      /// A given parameter should only be set once, otherwise this
-      /// hints to an error in the code and an exception is thrown,
-      /// hence the runtime_error throw.
-      void setValue(T const& value) {
-        if(_isSet) {
-          throw std::runtime_error("Can't set the value of a configuration parameter that has already been set.");
-        }
-        _isSet = true;
-        _value = value;
-      }
-
-      ConfParam& operator=(T const& value) {
-        setValue(value);
-        return *this;
-      }
-
-      /// Get the configuration parameter value.
-      T const& operator*() const { return _value ; }
-
-    private:
-
-      friend class  RooChi2Var;
-
-      /// Change the default value after construction time.
-      /// This is a hack to reproduce the situation before, where the default
-      /// values were set in the constructor parameters of RooAbsTestStatistic
-      /// and its derived classes and the defaults were not consistent over the
-      /// dependency hierachy.
-      void setDefaultValue(T const& value) {
-        if(!_isSet) {
-          _value = value;
-        }
-      }
-
-      bool _isSet = false;
-      T _value{};
-    };
-
-    ConfParam<std::string> rangeName = makeDefault(std::string(""));
-    ConfParam<std::string> addCoefRangeName = makeDefault(std::string(""));
-    ConfParam<int> nCPU = makeDefault(1);
-    ConfParam<RooFit::MPSplit> interleave = makeDefault(RooFit::BulkPartition);
-    ConfParam<bool> verbose = makeDefault(true);
-    ConfParam<bool> splitCutRange = makeDefault(false);
-    ConfParam<bool> cloneInputData = makeDefault(true);
-    ConfParam<double> integrateOverBinsPrecision = makeDefault(-1.);
-    ConfParam<bool> binnedL = makeDefault(false);
-
+    std::string rangeName = "";
+    std::string addCoefRangeName = "";
+    int nCPU = 1;
+    RooFit::MPSplit interleave = RooFit::BulkPartition;
+    bool verbose = true;
+    bool splitCutRange = false;
+    bool cloneInputData = true;
+    double integrateOverBinsPrecision = -1.;
+    bool binnedL = false;
   };
 
   // Constructors, assignment etc
   RooAbsTestStatistic() ;
   RooAbsTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
-                      const RooArgSet& projDeps, Configuration && cfg);
+                      const RooArgSet& projDeps, Configuration const& cfg);
   RooAbsTestStatistic(const RooAbsTestStatistic& other, const char* name=0);
   virtual ~RooAbsTestStatistic();
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
-                                      const RooArgSet& projDeps, Configuration && cfg) = 0;
+                                      const RooArgSet& projDeps, Configuration const& cfg) = 0;
 
   virtual void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTrackingOpt=kTRUE) ;
 

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -115,8 +115,8 @@ public:
       T _value{};
     };
 
-    ConfParam<const char*> rangeName = makeDefault((const char*)nullptr);
-    ConfParam<const char*> addCoefRangeName = makeDefault((const char*)nullptr);
+    ConfParam<std::string> rangeName = makeDefault(std::string(""));
+    ConfParam<std::string> addCoefRangeName = makeDefault(std::string(""));
     ConfParam<int> nCPU = makeDefault(1);
     ConfParam<RooFit::MPSplit> interleave = makeDefault(RooFit::BulkPartition);
     ConfParam<bool> verbose = makeDefault(true);
@@ -207,8 +207,8 @@ protected:
   virtual Bool_t processEmptyDataSets() const { return kTRUE ; }
 
   Bool_t initialize() ;
-  void initSimMode(RooSimultaneous* pdf, RooAbsData* data, const RooArgSet* projDeps, const char* rangeName, const char* addCoefRangeName) ;    
-  void initMPMode(RooAbsReal* real, RooAbsData* data, const RooArgSet* projDeps, const char* rangeName, const char* addCoefRangeName) ;
+  void initSimMode(RooSimultaneous* pdf, RooAbsData* data, const RooArgSet* projDeps, std::string const& rangeName, std::string const& addCoefRangeName) ;    
+  void initMPMode(RooAbsReal* real, RooAbsData* data, const RooArgSet* projDeps, std::string const& rangeName, std::string const& addCoefRangeName) ;
 
   mutable Bool_t _init ;          //! Is object initialized  
   GOFOpMode   _gofOpMode ;        // Operation mode of test statistic instance 

--- a/roofit/roofitcore/inc/RooChi2Var.h
+++ b/roofit/roofitcore/inc/RooChi2Var.h
@@ -39,21 +39,21 @@ public:
   enum FuncMode { Function, Pdf, ExtendedPdf } ;
 
   RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooDataHist& data,
-             RooAbsTestStatistic::Configuration && cfg=RooAbsTestStatistic::Configuration{},
+             RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{},
              bool extended=false, RooDataHist::ErrorType=RooDataHist::SumW2) ;
 
   RooChi2Var(const char *name, const char *title, RooAbsReal& func, RooDataHist& data,
              const RooArgSet& projDeps, FuncMode funcMode,
-             RooAbsTestStatistic::Configuration && cfg=RooAbsTestStatistic::Configuration{},
+             RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{},
              RooDataHist::ErrorType=RooDataHist::SumW2) ;
 
   RooChi2Var(const RooChi2Var& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooChi2Var(*this,newname); }
 
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& dhist,
-                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration && cfg) {
+                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg) {
     // Virtual constructor
-    return new RooChi2Var(name,title,(RooAbsPdf&)pdf,(RooDataHist&)dhist,projDeps,_funcMode,std::move(cfg),_etype) ;
+    return new RooChi2Var(name,title,(RooAbsPdf&)pdf,(RooDataHist&)dhist,projDeps,_funcMode,cfg,_etype) ;
   }
   
   virtual ~RooChi2Var();
@@ -73,16 +73,6 @@ protected:
   virtual Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const ;
   
   ClassDef(RooChi2Var,1) // Chi^2 function of p.d.f w.r.t a binned dataset
-
-private:
-  // RooChi2Var was the only class that had a default configuration value that
-  // was different form the default value in the base class
-  // RooAbsOptTestStatistic. This function changes the default confuration
-  // values to what they were in the past.
-  static inline RooAbsTestStatistic::Configuration& customizeCfgDefaults(RooAbsTestStatistic::Configuration & cfg) {
-      cfg.splitCutRange.setDefaultValue(true);
-      return cfg;
-  };
 };
 
 

--- a/roofit/roofitcore/inc/RooChi2Var.h
+++ b/roofit/roofitcore/inc/RooChi2Var.h
@@ -27,34 +27,42 @@ public:
 
   // Constructors, assignment etc
   RooChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataHist& data,
-	     const RooCmdArg& arg1                , const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
+	     const RooCmdArg& arg1                  , const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
 	     const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
 	     const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
 
   RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooDataHist& data,
-	     const RooCmdArg& arg1                , const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
+	     const RooCmdArg& arg1                  , const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
 	     const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
 	     const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
 
   enum FuncMode { Function, Pdf, ExtendedPdf } ;
 
+  // RooChi2Var was the only class that had a default configuration value that
+  // was different form the default value in the base class
+  // RooAbsOptTestStatistic. This function changes the default confuration
+  // values to what they were in the past.
+  static inline RooAbsTestStatistic::Configuration& customizeCfgDefaults(RooAbsTestStatistic::Configuration & cfg) {
+      cfg.splitCutRange.setDefaultValue(true);
+      return cfg;
+  } ;
+
   RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooDataHist& data,
-	    Bool_t extended=kFALSE, const char* rangeName=0, const char* addCoefRangeName=0, 
-	     Int_t nCPU=1, RooFit::MPSplit interleave=RooFit::BulkPartition, Bool_t verbose=kTRUE, Bool_t splitCutRange=kTRUE, RooDataHist::ErrorType=RooDataHist::SumW2) ;
+             RooAbsTestStatistic::Configuration && cfg=RooAbsTestStatistic::Configuration{},
+             bool extended=false, RooDataHist::ErrorType=RooDataHist::SumW2) ;
 
   RooChi2Var(const char *name, const char *title, RooAbsReal& func, RooDataHist& data,
-	     const RooArgSet& projDeps, FuncMode funcMode, const char* rangeName=0, const char* addCoefRangeName=0, 
-	     Int_t nCPU=1, RooFit::MPSplit interleave=RooFit::BulkPartition, Bool_t verbose=kTRUE, Bool_t splitCutRange=kTRUE, RooDataHist::ErrorType=RooDataHist::SumW2) ;
+             const RooArgSet& projDeps, FuncMode funcMode,
+             RooAbsTestStatistic::Configuration && cfg=RooAbsTestStatistic::Configuration{},
+             RooDataHist::ErrorType=RooDataHist::SumW2) ;
 
   RooChi2Var(const RooChi2Var& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooChi2Var(*this,newname); }
 
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& dhist,
-				      const RooArgSet& projDeps, const char* rangeName=0, const char* addCoefRangeName=0, 
-				      Int_t nCPU=1, RooFit::MPSplit interleave=RooFit::BulkPartition,Bool_t verbose=kTRUE, Bool_t splitCutRange=kTRUE, Bool_t = kFALSE) {
+                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration && cfg) {
     // Virtual constructor
-    return new RooChi2Var(name,title,(RooAbsPdf&)pdf,(RooDataHist&)dhist,projDeps,_funcMode,rangeName,
-			  addCoefRangeName,nCPU,interleave,verbose, splitCutRange,_etype) ;
+    return new RooChi2Var(name,title,(RooAbsPdf&)pdf,(RooDataHist&)dhist,projDeps,_funcMode,std::move(cfg),_etype) ;
   }
   
   virtual ~RooChi2Var();

--- a/roofit/roofitcore/inc/RooChi2Var.h
+++ b/roofit/roofitcore/inc/RooChi2Var.h
@@ -38,15 +38,6 @@ public:
 
   enum FuncMode { Function, Pdf, ExtendedPdf } ;
 
-  // RooChi2Var was the only class that had a default configuration value that
-  // was different form the default value in the base class
-  // RooAbsOptTestStatistic. This function changes the default confuration
-  // values to what they were in the past.
-  static inline RooAbsTestStatistic::Configuration& customizeCfgDefaults(RooAbsTestStatistic::Configuration & cfg) {
-      cfg.splitCutRange.setDefaultValue(true);
-      return cfg;
-  } ;
-
   RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooDataHist& data,
              RooAbsTestStatistic::Configuration && cfg=RooAbsTestStatistic::Configuration{},
              bool extended=false, RooDataHist::ErrorType=RooDataHist::SumW2) ;
@@ -82,6 +73,16 @@ protected:
   virtual Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const ;
   
   ClassDef(RooChi2Var,1) // Chi^2 function of p.d.f w.r.t a binned dataset
+
+private:
+  // RooChi2Var was the only class that had a default configuration value that
+  // was different form the default value in the base class
+  // RooAbsOptTestStatistic. This function changes the default confuration
+  // values to what they were in the past.
+  static inline RooAbsTestStatistic::Configuration& customizeCfgDefaults(RooAbsTestStatistic::Configuration & cfg) {
+      cfg.splitCutRange.setDefaultValue(true);
+      return cfg;
+  };
 };
 
 

--- a/roofit/roofitcore/inc/RooDataWeightedAverage.h
+++ b/roofit/roofitcore/inc/RooDataWeightedAverage.h
@@ -28,16 +28,16 @@ public:
   } ;  
 
   RooDataWeightedAverage(const char *name, const char *title, RooAbsReal& real, RooAbsData& data, const RooArgSet& projDeps,
-			 Int_t nCPU=1, RooFit::MPSplit interleave=RooFit::BulkPartition, Bool_t showProgress=kFALSE, Bool_t verbose=kTRUE) ;
+                         RooAbsTestStatistic::Configuration && cfg, bool showProgress=false) ;
 
   RooDataWeightedAverage(const RooDataWeightedAverage& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooDataWeightedAverage(*this,newname); }
 
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& real, RooAbsData& adata,
-				      const RooArgSet& projDeps, const char* /*rangeName*/=0, const char* /*addCoefRangeName*/=0, 
-				      Int_t nCPU=1, RooFit::MPSplit interleave=RooFit::BulkPartition, Bool_t verbose=kTRUE, Bool_t /*splitCutRange*/=kFALSE, Bool_t = kFALSE) {
+                                      const RooArgSet& projDeps,
+                                      RooAbsTestStatistic::Configuration && cfg) {
     // Virtual constructor
-    return new RooDataWeightedAverage(name,title,real,adata,projDeps,nCPU,interleave,verbose) ;
+    return new RooDataWeightedAverage(name,title,real,adata,projDeps,std::move(cfg)) ;
   }
 
   virtual Double_t globalNormalization() const ;

--- a/roofit/roofitcore/inc/RooDataWeightedAverage.h
+++ b/roofit/roofitcore/inc/RooDataWeightedAverage.h
@@ -28,16 +28,16 @@ public:
   } ;  
 
   RooDataWeightedAverage(const char *name, const char *title, RooAbsReal& real, RooAbsData& data, const RooArgSet& projDeps,
-                         RooAbsTestStatistic::Configuration && cfg, bool showProgress=false) ;
+                         RooAbsTestStatistic::Configuration const& cfg, bool showProgress=false) ;
 
   RooDataWeightedAverage(const RooDataWeightedAverage& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooDataWeightedAverage(*this,newname); }
 
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& real, RooAbsData& adata,
                                       const RooArgSet& projDeps,
-                                      RooAbsTestStatistic::Configuration && cfg) {
+                                      RooAbsTestStatistic::Configuration const& cfg) {
     // Virtual constructor
-    return new RooDataWeightedAverage(name,title,real,adata,projDeps,std::move(cfg)) ;
+    return new RooDataWeightedAverage(name,title,real,adata,projDeps,cfg) ;
   }
 
   virtual Double_t globalNormalization() const ;

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -38,21 +38,17 @@ public:
 	    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
 
   RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& data,
-	    Bool_t extended, const char* rangeName=0, const char* addCoefRangeName=0, 
-	    Int_t nCPU=1, RooFit::MPSplit interleave=RooFit::BulkPartition, Bool_t verbose=kTRUE, Bool_t splitRange=kFALSE, 
-	    Bool_t cloneData=kTRUE, Bool_t binnedL=kFALSE, double integrateBinsPrecision = -1.) ;
+            RooAbsTestStatistic::Configuration && cfg, bool extended);
   
   RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& data,
-	    const RooArgSet& projDeps, Bool_t extended=kFALSE, const char* rangeName=0, 
-	    const char* addCoefRangeName=0, Int_t nCPU=1, RooFit::MPSplit interleave=RooFit::BulkPartition, Bool_t verbose=kTRUE, Bool_t splitRange=kFALSE, 
-	    Bool_t cloneData=kTRUE, Bool_t binnedL=kFALSE, double integrateBinsPrecision = -1.) ;
+            const RooArgSet& projDeps, RooAbsTestStatistic::Configuration && cfg,
+            bool extended = false) ;
 
   RooNLLVar(const RooNLLVar& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooNLLVar(*this,newname); }
 
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
-				      const RooArgSet& projDeps, const char* rangeName, const char* addCoefRangeName=0, 
-				      Int_t nCPU=1, RooFit::MPSplit interleave=RooFit::BulkPartition, Bool_t verbose=kTRUE, Bool_t splitRange=kFALSE, Bool_t binnedL=kFALSE);
+                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration && cfg);
   
   virtual ~RooNLLVar();
 

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -38,17 +38,17 @@ public:
 	    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
 
   RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& data,
-            RooAbsTestStatistic::Configuration && cfg, bool extended);
+            RooAbsTestStatistic::Configuration const& cfg, bool extended);
   
   RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& data,
-            const RooArgSet& projDeps, RooAbsTestStatistic::Configuration && cfg,
+            const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg,
             bool extended = false) ;
 
   RooNLLVar(const RooNLLVar& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooNLLVar(*this,newname); }
 
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
-                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration && cfg);
+                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg);
   
   virtual ~RooNLLVar();
 

--- a/roofit/roofitcore/inc/RooXYChi2Var.h
+++ b/roofit/roofitcore/inc/RooXYChi2Var.h
@@ -40,7 +40,7 @@ public:
   virtual TObject* clone(const char* newname) const { return new RooXYChi2Var(*this,newname); }
 
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
-                                      const RooArgSet&, RooAbsTestStatistic::Configuration &&) {
+                                      const RooArgSet&, RooAbsTestStatistic::Configuration const&) {
     // Virtual constructor
     return new RooXYChi2Var(name,title,pdf,(RooDataSet&)adata) ;
   }

--- a/roofit/roofitcore/inc/RooXYChi2Var.h
+++ b/roofit/roofitcore/inc/RooXYChi2Var.h
@@ -40,7 +40,7 @@ public:
   virtual TObject* clone(const char* newname) const { return new RooXYChi2Var(*this,newname); }
 
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
-				      const RooArgSet&, const char*, const char*,Int_t, RooFit::MPSplit,Bool_t, Bool_t, Bool_t) {
+                                      const RooArgSet&, RooAbsTestStatistic::Configuration &&) {
     // Virtual constructor
     return new RooXYChi2Var(name,title,pdf,(RooDataSet&)adata) ;
   }
@@ -83,7 +83,7 @@ protected:
   RooNumIntConfig   _intConfig ; // Numeric integrator configuration for integration of function over bin
   RooAbsReal*       _funcInt ; //! Function integral
   std::list<RooAbsBinning*> _binList ; //! Bin ranges
-  
+
   ClassDef(RooXYChi2Var,1) // Chi^2 function of p.d.f w.r.t a unbinned dataset with X and Y values
 };
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -116,13 +116,12 @@ RooAbsOptTestStatistic:: RooAbsOptTestStatistic()
 /// only unbinned PDFs fit to RooDataHist are integrated. If < 0, PDFs are never integrated.
 RooAbsOptTestStatistic::RooAbsOptTestStatistic(const char *name, const char *title, RooAbsReal& real,
                                                RooAbsData& indata, const RooArgSet& projDeps,
-                                               RooAbsTestStatistic::Configuration && cfg) :
-  // we explicitely copy the configuration instead of moving it so we can still use it in this constructor
-  RooAbsTestStatistic(name,title,real,indata,projDeps,RooAbsTestStatistic::Configuration(cfg)),
+                                               RooAbsTestStatistic::Configuration const& cfg) :
+  RooAbsTestStatistic(name,title,real,indata,projDeps,cfg),
   _projDeps(0),
   _sealed(kFALSE), 
   _optimized(kFALSE),
-  _integrateBinsPrecision(*cfg.integrateOverBinsPrecision)
+  _integrateBinsPrecision(cfg.integrateOverBinsPrecision)
 {
   // Don't do a thing in master mode
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -114,15 +114,15 @@ RooAbsOptTestStatistic:: RooAbsOptTestStatistic()
 /// \param[in] cloneInputData Not used. Data is always cloned.
 /// \param[in] integrateOverBinsPrecision If > 0, PDF in binned fits are integrated over the bins. This sets the precision. If = 0,
 /// only unbinned PDFs fit to RooDataHist are integrated. If < 0, PDFs are never integrated.
-RooAbsOptTestStatistic::RooAbsOptTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& indata,
-					       const RooArgSet& projDeps, const char* rangeName, const char* addCoefRangeName,
-					       Int_t nCPU, RooFit::MPSplit interleave, Bool_t verbose, Bool_t splitCutRange, Bool_t /*cloneInputData*/,
-					       double integrateOverBinsPrecision) :
-  RooAbsTestStatistic(name,title,real,indata,projDeps,rangeName, addCoefRangeName, nCPU, interleave, verbose, splitCutRange),
+RooAbsOptTestStatistic::RooAbsOptTestStatistic(const char *name, const char *title, RooAbsReal& real,
+                                               RooAbsData& indata, const RooArgSet& projDeps,
+                                               RooAbsTestStatistic::Configuration && cfg) :
+  // we explicitely copy the configuration instead of moving it so we can still use it in this constructor
+  RooAbsTestStatistic(name,title,real,indata,projDeps,RooAbsTestStatistic::Configuration(cfg)),
   _projDeps(0),
   _sealed(kFALSE), 
   _optimized(kFALSE),
-  _integrateBinsPrecision(integrateOverBinsPrecision)
+  _integrateBinsPrecision(*cfg.integrateOverBinsPrecision)
 {
   // Don't do a thing in master mode
 
@@ -142,7 +142,7 @@ RooAbsOptTestStatistic::RooAbsOptTestStatistic(const char *name, const char *tit
   _origFunc = 0 ; //other._origFunc ;
   _origData = 0 ; // other._origData ;
 
-  initSlave(real,indata,projDeps,rangeName,addCoefRangeName) ;
+  initSlave(real, indata, projDeps, *cfg.rangeName, *cfg.addCoefRangeName) ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -142,7 +142,7 @@ RooAbsOptTestStatistic::RooAbsOptTestStatistic(const char *name, const char *tit
   _origFunc = 0 ; //other._origFunc ;
   _origData = 0 ; // other._origData ;
 
-  initSlave(real, indata, projDeps, *cfg.rangeName, *cfg.addCoefRangeName) ;
+  initSlave(real, indata, projDeps, _rangeName.c_str(), _addCoefRangeName.c_str()) ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1048,8 +1048,18 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     //cout<<"FK: Data test 1: "<<data.sumEntries()<<endl;
 
     auto theNLL = new RooNLLVar(baseName.c_str(),"-log(likelihood)",
-        *this,data,projDeps,ext,rangeName,addCoefRangeName,numcpu,interl,
-        verbose,splitr,cloneData,/*binnedL=*/false, pc.getDouble("IntegrateBins"));
+        *this,data,projDeps,
+           {.rangeName=rangeName,
+            .addCoefRangeName=addCoefRangeName,
+            .nCPU=numcpu,
+            .interleave=interl,
+            .verbose=verbose,
+            .splitCutRange=static_cast<bool>(splitr),
+            .cloneInputData=static_cast<bool>(cloneData),
+            .integrateOverBinsPrecision=pc.getDouble("IntegrateBins"),
+            .binnedL=false},
+            ext
+        );
     theNLL->batchMode(pc.getInt("BatchMode"));
     nll = theNLL;
   } else {
@@ -1058,8 +1068,18 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     auto tokens = RooHelpers::tokenise(rangeName, ",");
     for (const auto& token : tokens) {
       auto nllComp = new RooNLLVar(Form("%s_%s",baseName.c_str(),token.c_str()),"-log(likelihood)",
-          *this,data,projDeps,ext,token.c_str(),addCoefRangeName,numcpu,interl,
-          verbose,splitr,cloneData, /*binnedL=*/false, pc.getDouble("IntegrateBins"));
+          *this,data,projDeps,
+           {.rangeName=token.c_str(),
+            .addCoefRangeName=addCoefRangeName,
+            .nCPU=numcpu,
+            .interleave=interl,
+            .verbose=verbose,
+            .splitCutRange=static_cast<bool>(splitr),
+            .cloneInputData=static_cast<bool>(cloneData),
+            .integrateOverBinsPrecision=pc.getDouble("IntegrateBins"),
+            .binnedL=false},
+            ext
+        );
       nllComp->batchMode(pc.getInt("BatchMode"));
       nllList.add(*nllComp) ;
     }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1048,8 +1048,8 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     //cout<<"FK: Data test 1: "<<data.sumEntries()<<endl;
 
     RooAbsTestStatistic::Configuration cfg;
-    cfg.rangeName = rangeName;
-    cfg.addCoefRangeName = addCoefRangeName;
+    cfg.rangeName = rangeName ? rangeName : "";
+    cfg.addCoefRangeName = addCoefRangeName ? addCoefRangeName : "";
     cfg.nCPU = numcpu;
     cfg.interleave = interl;
     cfg.verbose = verbose;
@@ -1066,8 +1066,8 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     auto tokens = RooHelpers::tokenise(rangeName, ",");
     for (const auto& token : tokens) {
       RooAbsTestStatistic::Configuration cfg;
-      cfg.rangeName = token.c_str();
-      cfg.addCoefRangeName = addCoefRangeName;
+      cfg.rangeName = token;
+      cfg.addCoefRangeName = addCoefRangeName ? addCoefRangeName : "";
       cfg.nCPU = numcpu;
       cfg.interleave = interl;
       cfg.verbose = verbose;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1047,19 +1047,17 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     // Simple case: default range, or single restricted range
     //cout<<"FK: Data test 1: "<<data.sumEntries()<<endl;
 
-    auto theNLL = new RooNLLVar(baseName.c_str(),"-log(likelihood)",
-        *this,data,projDeps,
-           {.rangeName=rangeName,
-            .addCoefRangeName=addCoefRangeName,
-            .nCPU=numcpu,
-            .interleave=interl,
-            .verbose=verbose,
-            .splitCutRange=static_cast<bool>(splitr),
-            .cloneInputData=static_cast<bool>(cloneData),
-            .integrateOverBinsPrecision=pc.getDouble("IntegrateBins"),
-            .binnedL=false},
-            ext
-        );
+    RooAbsTestStatistic::Configuration cfg;
+    cfg.rangeName = rangeName;
+    cfg.addCoefRangeName = addCoefRangeName;
+    cfg.nCPU = numcpu;
+    cfg.interleave = interl;
+    cfg.verbose = verbose;
+    cfg.splitCutRange = static_cast<bool>(splitr);
+    cfg.cloneInputData = static_cast<bool>(cloneData);
+    cfg.integrateOverBinsPrecision = pc.getDouble("IntegrateBins");
+    cfg.binnedL = false;
+    auto theNLL = new RooNLLVar(baseName.c_str(),"-log(likelihood)",*this,data,projDeps,std::move(cfg), ext);
     theNLL->batchMode(pc.getInt("BatchMode"));
     nll = theNLL;
   } else {
@@ -1067,19 +1065,18 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     RooArgList nllList ;
     auto tokens = RooHelpers::tokenise(rangeName, ",");
     for (const auto& token : tokens) {
+      RooAbsTestStatistic::Configuration cfg;
+      cfg.rangeName = token.c_str();
+      cfg.addCoefRangeName = addCoefRangeName;
+      cfg.nCPU = numcpu;
+      cfg.interleave = interl;
+      cfg.verbose = verbose;
+      cfg.splitCutRange = static_cast<bool>(splitr);
+      cfg.cloneInputData = static_cast<bool>(cloneData);
+      cfg.integrateOverBinsPrecision = pc.getDouble("IntegrateBins");
+      cfg.binnedL = false;
       auto nllComp = new RooNLLVar(Form("%s_%s",baseName.c_str(),token.c_str()),"-log(likelihood)",
-          *this,data,projDeps,
-           {.rangeName=token.c_str(),
-            .addCoefRangeName=addCoefRangeName,
-            .nCPU=numcpu,
-            .interleave=interl,
-            .verbose=verbose,
-            .splitCutRange=static_cast<bool>(splitr),
-            .cloneInputData=static_cast<bool>(cloneData),
-            .integrateOverBinsPrecision=pc.getDouble("IntegrateBins"),
-            .binnedL=false},
-            ext
-        );
+                                   *this,data,projDeps,std::move(cfg),ext);
       nllComp->batchMode(pc.getInt("BatchMode"));
       nllList.add(*nllComp) ;
     }

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2209,8 +2209,11 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
     projection->attachDataSet(*projDataSel) ;
 
     // Construct optimized data weighted average
+    RooAbsTestStatistic::Configuration cfg;
+    cfg.nCPU = o.numCPU;
+    cfg.interleave = o.interleave;
     RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*projection,*projDataSel,RooArgSet()/**projDataSel->get()*/,
-            {.nCPU=o.numCPU,.interleave=o.interleave}, true) ;
+            std::move(cfg), true) ;
     //RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*projection,*projDataSel,*projDataSel->get(),o.numCPU,o.interleave,kTRUE) ;
 
     // Do _not_ activate cache-and-track as necessary information to define normalization observables are not present in the underlying dataset
@@ -2581,8 +2584,11 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
     }
 
 
+    RooAbsTestStatistic::Configuration cfg;
+    cfg.nCPU = o.numCPU;
+    cfg.interleave = o.interleave;
     RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*funcAsym,*projDataSel,RooArgSet()/**projDataSel->get()*/,
-            {.nCPU=o.numCPU,.interleave=o.interleave},true) ;
+            std::move(cfg),true) ;
     //RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*funcAsym,*projDataSel,*projDataSel->get(),o.numCPU,o.interleave,kTRUE) ;
     dwa.constOptimizeTestStatistic(Activate) ;
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2209,7 +2209,8 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
     projection->attachDataSet(*projDataSel) ;
 
     // Construct optimized data weighted average
-    RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*projection,*projDataSel,RooArgSet()/**projDataSel->get()*/,o.numCPU,o.interleave,kTRUE) ;
+    RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*projection,*projDataSel,RooArgSet()/**projDataSel->get()*/,
+            {.nCPU=o.numCPU,.interleave=o.interleave}, true) ;
     //RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*projection,*projDataSel,*projDataSel->get(),o.numCPU,o.interleave,kTRUE) ;
 
     // Do _not_ activate cache-and-track as necessary information to define normalization observables are not present in the underlying dataset
@@ -2580,7 +2581,8 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
     }
 
 
-    RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*funcAsym,*projDataSel,RooArgSet()/**projDataSel->get()*/,o.numCPU,o.interleave,kTRUE) ;
+    RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*funcAsym,*projDataSel,RooArgSet()/**projDataSel->get()*/,
+            {.nCPU=o.numCPU,.interleave=o.interleave},true) ;
     //RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*funcAsym,*projDataSel,*projDataSel->get(),o.numCPU,o.interleave,kTRUE) ;
     dwa.constOptimizeTestStatistic(Activate) ;
 

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -99,23 +99,22 @@ RooAbsTestStatistic::RooAbsTestStatistic() :
 /// if the categories are called "pi0" and "gamma".
 
 RooAbsTestStatistic::RooAbsTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
-					 const RooArgSet& projDeps, const char* rangeName, const char* addCoefRangeName,
-					 Int_t nCPU, RooFit::MPSplit interleave, Bool_t verbose, Bool_t splitCutRange) :
+                                         const RooArgSet& projDeps, RooAbsTestStatistic::Configuration && cfg) :
   RooAbsReal(name,title),
   _paramSet("paramSet","Set of parameters",this),
   _func(&real),
   _data(&data),
   _projDeps((RooArgSet*)projDeps.Clone()),
-  _rangeName(rangeName?rangeName:""),
-  _addCoefRangeName(addCoefRangeName?addCoefRangeName:""),
-  _splitRange(splitCutRange),
+  _rangeName(*cfg.rangeName?*cfg.rangeName:""),
+  _addCoefRangeName(*cfg.addCoefRangeName?*cfg.addCoefRangeName:""),
+  _splitRange(*cfg.splitCutRange),
   _simCount(1),
-  _verbose(verbose),
+  _verbose(*cfg.verbose),
   _nGof(0),
   _gofArray(0),
-  _nCPU(nCPU),
+  _nCPU(*cfg.nCPU),
   _mpfeArray(0),
-  _mpinterl(interleave),
+  _mpinterl(*cfg.interleave),
   _doOffset(kFALSE),
   _evalCarry(0)
 {
@@ -464,7 +463,13 @@ void RooAbsTestStatistic::initMPMode(RooAbsReal* real, RooAbsData* data, const R
   _mpfeArray = new pRooRealMPFE[_nCPU];
 
   // Create proto-goodness-of-fit
-  RooAbsTestStatistic* gof = create(GetName(),GetTitle(),*real,*data,*projDeps,rangeName,addCoefRangeName,1,_mpinterl,_verbose,_splitRange);
+  RooAbsTestStatistic* gof = create(GetName(),GetTitle(),*real,*data,*projDeps,
+          {.rangeName=rangeName,
+           .addCoefRangeName=addCoefRangeName,
+           .nCPU=1,
+           .interleave=_mpinterl,
+           .verbose=_verbose,
+           .splitCutRange=_splitRange});
   gof->recursiveRedirectServers(_paramSet);
 
   for (Int_t i = 0; i < _nCPU; ++i) {
@@ -565,10 +570,24 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
       // and omitting them reduces model complexity and associated handling/cloning times
       if (_splitRange && rangeName) {
         _gofArray[n] = create(catName.c_str(), catName.c_str(),(binnedPdf?*binnedPdf:*pdf),*dset,*projDeps,
-            Form("%s_%s",rangeName,catName.c_str()),addCoefRangeName,_nCPU*(_mpinterl?-1:1),_mpinterl,_verbose,_splitRange,binnedL);
+                {.rangeName=Form("%s_%s",rangeName,catName.c_str()),
+                 .addCoefRangeName=addCoefRangeName,
+                 .nCPU=_nCPU*(_mpinterl?-1:1),
+                 .interleave=_mpinterl,
+                 .verbose=_verbose,
+                 .splitCutRange=_splitRange,
+                 .binnedL=binnedL}
+        );
       } else {
         _gofArray[n] = create(catName.c_str(),catName.c_str(),(binnedPdf?*binnedPdf:*pdf),*dset,*projDeps,
-            rangeName,addCoefRangeName,_nCPU,_mpinterl,_verbose,_splitRange,binnedL);
+                {.rangeName=rangeName,
+                 .addCoefRangeName=addCoefRangeName,
+                 .nCPU=_nCPU,
+                 .interleave=_mpinterl,
+                 .verbose=_verbose,
+                 .splitCutRange=_splitRange,
+                 .binnedL=binnedL}
+        );
       }
       _gofArray[n]->setSimCount(_nGof);
       // *** END HERE

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -224,8 +224,8 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
 /// name cutRange_{indexStateName}.
 
 RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooDataHist& hdata,
-                       RooAbsTestStatistic::Configuration && cfg, bool extended, RooDataHist::ErrorType etype) :
-  RooAbsOptTestStatistic(name,title,pdf,hdata,RooArgSet(), std::move(customizeCfgDefaults(cfg))),
+                       RooAbsTestStatistic::Configuration const& cfg, bool extended, RooDataHist::ErrorType etype) :
+  RooAbsOptTestStatistic(name,title,pdf,hdata,RooArgSet(), cfg),
    _etype(etype), _funcMode(extended?ExtendedPdf:Pdf)
 {
 }
@@ -251,9 +251,9 @@ RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooD
 
 RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsReal& func, RooDataHist& hdata,
                        const RooArgSet& projDeps, RooChi2Var::FuncMode fmode,
-                       RooAbsTestStatistic::Configuration && cfg,
+                       RooAbsTestStatistic::Configuration const& cfg,
                        RooDataHist::ErrorType etype) : 
-  RooAbsOptTestStatistic(name,title,func,hdata,projDeps,std::move(customizeCfgDefaults(cfg))),
+  RooAbsOptTestStatistic(name,title,func,hdata,projDeps,cfg),
   _etype(etype), _funcMode(fmode)
 {
 }

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -71,8 +71,7 @@ namespace {
   template<class ...Args>
   RooAbsTestStatistic::Configuration makeRooAbsTestStatisticCfgForFunc(Args const& ... args) {
     RooAbsTestStatistic::Configuration cfg;
-    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",args...).c_str();
-    cfg.addCoefRangeName = 0;
+    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",args...);
     cfg.nCPU = RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,args...);
     cfg.interleave = RooFit::Interleave;
     cfg.verbose = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,args...));
@@ -85,8 +84,8 @@ namespace {
   template<class ...Args>
   RooAbsTestStatistic::Configuration makeRooAbsTestStatisticCfgForPdf(Args const& ... args) {
     RooAbsTestStatistic::Configuration cfg;
-    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",args...).c_str();
-    cfg.addCoefRangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","AddCoefRange",0,"",args...).c_str();
+    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",args...);
+    cfg.addCoefRangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","AddCoefRange",0,"",args...);
     cfg.nCPU = RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,args...);
     cfg.interleave = RooFit::Interleave;
     cfg.verbose = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,args...));
@@ -127,7 +126,7 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsReal& func, Ro
 		       const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,
 		       const RooCmdArg& arg7,const RooCmdArg& arg8,const RooCmdArg& arg9) :
   RooAbsOptTestStatistic(name,title,func,hdata,_emptySet,
-          std::move(makeRooAbsTestStatisticCfgForFunc(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)))
+          makeRooAbsTestStatisticCfgForFunc(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9))
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
   pc.defineInt("etype","DataError",0,(Int_t)RooDataHist::Auto) ;  
@@ -188,7 +187,7 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
   RooAbsOptTestStatistic(name,title,pdf,hdata,
                          *static_cast<const RooArgSet*>(RooCmdConfig::decodeObjOnTheFly("RooChi2Var::RooChi2Var","ProjectedObservables",0,&_emptySet,
                                  arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
-                         std::move(makeRooAbsTestStatisticCfgForPdf(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)))
+                         makeRooAbsTestStatisticCfgForPdf(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9))
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
   pc.defineInt("extended","Extended",0,kFALSE) ;

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -67,6 +67,36 @@
 
 using namespace std;
 
+namespace {
+  template<class ...Args>
+  RooAbsTestStatistic::Configuration makeRooAbsTestStatisticCfgForFunc(Args const& ... args) {
+    RooAbsTestStatistic::Configuration cfg;
+    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",args...).c_str();
+    cfg.addCoefRangeName = 0;
+    cfg.nCPU = RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,args...);
+    cfg.interleave = RooFit::Interleave;
+    cfg.verbose = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,args...));
+    cfg.splitCutRange = false;
+    cfg.cloneInputData = false;
+    cfg.integrateOverBinsPrecision = RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {args...});
+    return cfg;
+  }
+
+  template<class ...Args>
+  RooAbsTestStatistic::Configuration makeRooAbsTestStatisticCfgForPdf(Args const& ... args) {
+    RooAbsTestStatistic::Configuration cfg;
+    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",args...).c_str();
+    cfg.addCoefRangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","AddCoefRange",0,"",args...).c_str();
+    cfg.nCPU = RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,args...);
+    cfg.interleave = RooFit::Interleave;
+    cfg.verbose = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,args...));
+    cfg.splitCutRange = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","SplitRange",0,0,args...));
+    cfg.cloneInputData = false;
+    cfg.integrateOverBinsPrecision = RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {args...});
+    return cfg;
+  }
+}
+
 ClassImp(RooChi2Var);
 ;
 
@@ -97,14 +127,7 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsReal& func, Ro
 		       const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,
 		       const RooCmdArg& arg7,const RooCmdArg& arg8,const RooCmdArg& arg9) :
   RooAbsOptTestStatistic(name,title,func,hdata,_emptySet,
-			{.rangeName=RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
-			 .addCoefRangeName=0,
-			 .nCPU=RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			 .interleave=RooFit::Interleave,
-			 .verbose=static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
-			 .splitCutRange=false,
-			 .cloneInputData=false,
-			 .integrateOverBinsPrecision=RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9})})
+          std::move(makeRooAbsTestStatisticCfgForFunc(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)))
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
   pc.defineInt("etype","DataError",0,(Int_t)RooDataHist::Auto) ;  
@@ -163,16 +186,9 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
 		       const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,
 		       const RooCmdArg& arg7,const RooCmdArg& arg8,const RooCmdArg& arg9) :
   RooAbsOptTestStatistic(name,title,pdf,hdata,
-			 *(const RooArgSet*)RooCmdConfig::decodeObjOnTheFly("RooChi2Var::RooChi2Var","ProjectedObservables",0,&_emptySet
-									    ,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			{.rangeName=RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
-			 .addCoefRangeName=RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","AddCoefRange",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
-			 .nCPU=RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			 .interleave=RooFit::Interleave,
-			 .verbose=static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
-			 .splitCutRange=static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","SplitRange",0,0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
-			 .cloneInputData=false,
-			 .integrateOverBinsPrecision=RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9})})
+                         *static_cast<const RooArgSet*>(RooCmdConfig::decodeObjOnTheFly("RooChi2Var::RooChi2Var","ProjectedObservables",0,&_emptySet,
+                                 arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
+                         std::move(makeRooAbsTestStatisticCfgForPdf(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)))
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
   pc.defineInt("extended","Extended",0,kFALSE) ;

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -97,14 +97,14 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsReal& func, Ro
 		       const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,
 		       const RooCmdArg& arg7,const RooCmdArg& arg8,const RooCmdArg& arg9) :
   RooAbsOptTestStatistic(name,title,func,hdata,_emptySet,
-			 RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
-			 /*addCoefRangeName=*/0,
-			 RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			 RooFit::Interleave,
-			 RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			 /*splitCutRange=*/0,
-			 /*cloneInputData=*/false,
-			 RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9}))
+			{.rangeName=RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
+			 .addCoefRangeName=0,
+			 .nCPU=RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
+			 .interleave=RooFit::Interleave,
+			 .verbose=static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
+			 .splitCutRange=false,
+			 .cloneInputData=false,
+			 .integrateOverBinsPrecision=RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9})})
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
   pc.defineInt("etype","DataError",0,(Int_t)RooDataHist::Auto) ;  
@@ -165,14 +165,14 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
   RooAbsOptTestStatistic(name,title,pdf,hdata,
 			 *(const RooArgSet*)RooCmdConfig::decodeObjOnTheFly("RooChi2Var::RooChi2Var","ProjectedObservables",0,&_emptySet
 									    ,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			 RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
-			 RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","AddCoefRange",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
-			 RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			 RooFit::Interleave,
-			 RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			 RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","SplitRange",0,0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			 /*cloneInputData=*/false,
-			 RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9}))
+			{.rangeName=RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
+			 .addCoefRangeName=RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","AddCoefRange",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
+			 .nCPU=RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
+			 .interleave=RooFit::Interleave,
+			 .verbose=static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
+			 .splitCutRange=static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","SplitRange",0,0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
+			 .cloneInputData=false,
+			 .integrateOverBinsPrecision=RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9})})
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
   pc.defineInt("extended","Extended",0,kFALSE) ;
@@ -209,9 +209,8 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
 /// name cutRange_{indexStateName}.
 
 RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooDataHist& hdata,
-		       Bool_t extended, const char* cutRange, const char* addCoefRange,
-		       Int_t nCPU, RooFit::MPSplit interleave, Bool_t verbose, Bool_t splitCutRange, RooDataHist::ErrorType etype) : 
-  RooAbsOptTestStatistic(name,title,pdf,hdata,RooArgSet(),cutRange,addCoefRange,nCPU,interleave,verbose,splitCutRange),
+                       RooAbsTestStatistic::Configuration && cfg, bool extended, RooDataHist::ErrorType etype) :
+  RooAbsOptTestStatistic(name,title,pdf,hdata,RooArgSet(), std::move(customizeCfgDefaults(cfg))),
    _etype(etype), _funcMode(extended?ExtendedPdf:Pdf)
 {
 }
@@ -236,9 +235,10 @@ RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooD
 /// name cutRange_{indexStateName}.
 
 RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsReal& func, RooDataHist& hdata,
-		       const RooArgSet& projDeps, RooChi2Var::FuncMode fmode, const char* cutRange, const char* addCoefRange, 
-		       Int_t nCPU, RooFit::MPSplit interleave, Bool_t verbose, Bool_t splitCutRange, RooDataHist::ErrorType etype) : 
-  RooAbsOptTestStatistic(name,title,func,hdata,projDeps,cutRange,addCoefRange,nCPU,interleave,verbose,splitCutRange),
+                       const RooArgSet& projDeps, RooChi2Var::FuncMode fmode,
+                       RooAbsTestStatistic::Configuration && cfg,
+                       RooDataHist::ErrorType etype) : 
+  RooAbsOptTestStatistic(name,title,func,hdata,projDeps,std::move(customizeCfgDefaults(cfg))),
   _etype(etype), _funcMode(fmode)
 {
 }

--- a/roofit/roofitcore/src/RooDataWeightedAverage.cxx
+++ b/roofit/roofitcore/src/RooDataWeightedAverage.cxx
@@ -55,9 +55,9 @@ ClassImp(RooDataWeightedAverage);
 /// rather than a bulk-split pattern.
 
 RooDataWeightedAverage::RooDataWeightedAverage(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& indata, 
-                                               const RooArgSet& projdeps, RooAbsTestStatistic::Configuration && cfg,
+                                               const RooArgSet& projdeps, RooAbsTestStatistic::Configuration const& cfg,
                                                bool showProgress) : 
-  RooAbsOptTestStatistic(name,title,pdf,indata,projdeps,std::move(cfg)),
+  RooAbsOptTestStatistic(name,title,pdf,indata,projdeps,cfg),
   _showProgress(showProgress)
 {
   if (_showProgress) {

--- a/roofit/roofitcore/src/RooDataWeightedAverage.cxx
+++ b/roofit/roofitcore/src/RooDataWeightedAverage.cxx
@@ -55,8 +55,9 @@ ClassImp(RooDataWeightedAverage);
 /// rather than a bulk-split pattern.
 
 RooDataWeightedAverage::RooDataWeightedAverage(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& indata, 
-					       const RooArgSet& projdeps, Int_t nCPU, RooFit::MPSplit interleave, Bool_t showProgress, Bool_t verbose) : 
-  RooAbsOptTestStatistic(name,title,pdf,indata,projdeps,0,0,nCPU,interleave,verbose,kFALSE),
+                                               const RooArgSet& projdeps, RooAbsTestStatistic::Configuration && cfg,
+                                               bool showProgress) : 
+  RooAbsOptTestStatistic(name,title,pdf,indata,projdeps,std::move(cfg)),
   _showProgress(showProgress)
 {
   if (_showProgress) {

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -124,15 +124,15 @@ RooNLLVar::RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbs
 /// For internal use.
 
 RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& indata,
-                     RooAbsTestStatistic::Configuration && cfg, bool extended) :
-  RooAbsOptTestStatistic(name,title,pdf,indata,RooArgSet(),RooAbsTestStatistic::Configuration(cfg)),
+                     RooAbsTestStatistic::Configuration const& cfg, bool extended) :
+  RooAbsOptTestStatistic(name,title,pdf,indata,RooArgSet(),cfg),
   _extended(extended),
   _weightSq(kFALSE),
   _first(kTRUE)
 {
   // If binned likelihood flag is set, pdf is a RooRealSumPdf representing a yield vector
   // for a binned likelihood calculation
-  _binnedPdf = *cfg.binnedL ? (RooRealSumPdf*)_funcClone : 0 ;
+  _binnedPdf = cfg.binnedL ? (RooRealSumPdf*)_funcClone : 0 ;
 
   // Retrieve and cache bin widths needed to convert un-normalized binnedPdf values back to yields
   if (_binnedPdf) {
@@ -169,15 +169,15 @@ RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbs
 
 RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& indata,
                      const RooArgSet& projDeps,
-                     RooAbsTestStatistic::Configuration && cfg, bool extended) :
-  RooAbsOptTestStatistic(name,title,pdf,indata,projDeps, RooAbsTestStatistic::Configuration(cfg)),
+                     RooAbsTestStatistic::Configuration const& cfg, bool extended) :
+  RooAbsOptTestStatistic(name,title,pdf,indata,projDeps, cfg),
   _extended(extended),
   _weightSq(kFALSE),
   _first(kTRUE)
 {
   // If binned likelihood flag is set, pdf is a RooRealSumPdf representing a yield vector
   // for a binned likelihood calculation
-  _binnedPdf = *cfg.binnedL ? (RooRealSumPdf*)_funcClone : 0 ;
+  _binnedPdf = cfg.binnedL ? (RooRealSumPdf*)_funcClone : 0 ;
 
   // Retrieve and cache bin widths needed to convert un-normalized binnedPdf values back to yields
   if (_binnedPdf) {
@@ -224,15 +224,12 @@ RooNLLVar::RooNLLVar(const RooNLLVar& other, const char* name) :
 /// Create a test statistic using several properties of the current instance. This is used to duplicate
 /// the test statistic in multi-processing scenarios.
 RooAbsTestStatistic* RooNLLVar::create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
-            const RooArgSet& projDeps, RooAbsTestStatistic::Configuration && cfg) {
+            const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg) {
   RooAbsPdf & thePdf = dynamic_cast<RooAbsPdf&>(pdf);
   // check if pdf can be extended
   bool extendedPdf = _extended && thePdf.canBeExtended();
 
-  // some configuration parameters are fixed
-  cfg.integrateOverBinsPrecision.setValue(_integrateBinsPrecision);
-
-  auto testStat = new RooNLLVar(name, title, thePdf, adata, projDeps, std::move(cfg), extendedPdf);
+  auto testStat = new RooNLLVar(name, title, thePdf, adata, projDeps, cfg, extendedPdf);
   testStat->batchMode(_batchEvaluations);
   return testStat;
 }

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -55,8 +55,8 @@ namespace {
   template<class ...Args>
   RooAbsTestStatistic::Configuration makeRooAbsTestStatisticCfg(Args const& ... args) {
     RooAbsTestStatistic::Configuration cfg;
-    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooNLLVar::RooNLLVar","RangeWithName",0,"",args...).c_str();
-    cfg.addCoefRangeName = RooCmdConfig::decodeStringOnTheFly("RooNLLVar::RooNLLVar","AddCoefRange",0,"",args...).c_str();
+    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooNLLVar::RooNLLVar","RangeWithName",0,"",args...);
+    cfg.addCoefRangeName = RooCmdConfig::decodeStringOnTheFly("RooNLLVar::RooNLLVar","AddCoefRange",0,"",args...);
     cfg.nCPU = RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","NumCPU",0,1,args...);
     cfg.interleave = RooFit::BulkPartition;
     cfg.verbose = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","Verbose",0,1,args...));
@@ -97,7 +97,7 @@ RooNLLVar::RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbs
                          *static_cast<const RooArgSet*>(RooCmdConfig::decodeObjOnTheFly(
                              "RooNLLVar::RooNLLVar","ProjectedObservables",0,&_emptySet,
                              arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
-                         std::move(makeRooAbsTestStatisticCfg(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)))
+                         makeRooAbsTestStatisticCfg(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9))
 {
   RooCmdConfig pc("RooNLLVar::RooNLLVar") ;
   pc.allowUndefined() ;

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -51,6 +51,22 @@ In extended mode, a
 
 #include <algorithm>
 
+namespace {
+  template<class ...Args>
+  RooAbsTestStatistic::Configuration makeRooAbsTestStatisticCfg(Args const& ... args) {
+    RooAbsTestStatistic::Configuration cfg;
+    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooNLLVar::RooNLLVar","RangeWithName",0,"",args...).c_str();
+    cfg.addCoefRangeName = RooCmdConfig::decodeStringOnTheFly("RooNLLVar::RooNLLVar","AddCoefRange",0,"",args...).c_str();
+    cfg.nCPU = RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","NumCPU",0,1,args...);
+    cfg.interleave = RooFit::BulkPartition;
+    cfg.verbose = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","Verbose",0,1,args...));
+    cfg.splitCutRange = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","SplitRange",0,0,args...));
+    cfg.cloneInputData = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","CloneData",0,1,args...));
+    cfg.integrateOverBinsPrecision = RooCmdConfig::decodeDoubleOnTheFly("RooNLLVar::RooNLLVar", "IntegrateBins", 0, -1., {args...});
+    return cfg;
+  }
+}
+
 ClassImp(RooNLLVar)
 
 RooArgSet RooNLLVar::_emptySet ;
@@ -78,16 +94,10 @@ RooNLLVar::RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbs
 		     const RooCmdArg& arg4, const RooCmdArg& arg5,const RooCmdArg& arg6,
 		     const RooCmdArg& arg7, const RooCmdArg& arg8,const RooCmdArg& arg9) :
   RooAbsOptTestStatistic(name,title,pdf,indata,
-			 *(const RooArgSet*)RooCmdConfig::decodeObjOnTheFly("RooNLLVar::RooNLLVar","ProjectedObservables",0,&_emptySet
-									    ,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			{.rangeName=RooCmdConfig::decodeStringOnTheFly("RooNLLVar::RooNLLVar","RangeWithName",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
-			 .addCoefRangeName=RooCmdConfig::decodeStringOnTheFly("RooNLLVar::RooNLLVar","AddCoefRange",0,"",arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9).c_str(),
-			 .nCPU=RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","NumCPU",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
-			 .interleave=RooFit::BulkPartition,
-			 .verbose=static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","Verbose",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
-			 .splitCutRange=static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","SplitRange",0,0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
-			 .cloneInputData=static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooNLLVar::RooNLLVar","CloneData",0,1,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
-			 .integrateOverBinsPrecision=RooCmdConfig::decodeDoubleOnTheFly("RooNLLVar::RooNLLVar", "IntegrateBins", 0, -1., {arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9})})
+                         *static_cast<const RooArgSet*>(RooCmdConfig::decodeObjOnTheFly(
+                             "RooNLLVar::RooNLLVar","ProjectedObservables",0,&_emptySet,
+                             arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
+                         std::move(makeRooAbsTestStatisticCfg(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)))
 {
   RooCmdConfig pc("RooNLLVar::RooNLLVar") ;
   pc.allowUndefined() ;

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -86,7 +86,7 @@ RooXYChi2Var::RooXYChi2Var()
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataSet& xydata, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),std::move(makeRooAbsTestStatisticCfg())),
+  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),makeRooAbsTestStatisticCfg()),
   _extended(kFALSE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),
@@ -114,7 +114,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataSet& xydata, RooRealVar& yvar, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),std::move(makeRooAbsTestStatisticCfg())),
+  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),makeRooAbsTestStatisticCfg()),
   _extended(kFALSE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),
@@ -145,7 +145,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& xydata, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),std::move(makeRooAbsTestStatisticCfg())),
+  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),makeRooAbsTestStatisticCfg()),
   _extended(kTRUE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),
@@ -179,7 +179,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPd
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& xydata, RooRealVar& yvar, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),std::move(makeRooAbsTestStatisticCfg())),
+  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),makeRooAbsTestStatisticCfg()),
   _extended(kTRUE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -78,7 +78,7 @@ RooXYChi2Var::RooXYChi2Var()
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataSet& xydata, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),0,0,1,RooFit::Interleave,0,0),
+  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),{.verbose=false}),
   _extended(kFALSE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),
@@ -106,7 +106,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataSet& xydata, RooRealVar& yvar, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),0,0,1,RooFit::Interleave,0,0),
+  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),{.verbose=false}),
   _extended(kFALSE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),
@@ -137,7 +137,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& xydata, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),0,0,1,RooFit::Interleave,0,0),
+  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),{.verbose=false}),
   _extended(kTRUE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),
@@ -171,7 +171,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPd
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& xydata, RooRealVar& yvar, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),0,0,1,RooFit::Interleave,0,0),
+  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),{.verbose=false}),
   _extended(kTRUE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -51,6 +51,14 @@ using namespace std;
 ClassImp(RooXYChi2Var);
 ;
 
+namespace {
+  RooAbsTestStatistic::Configuration makeRooAbsTestStatisticCfg() {
+    RooAbsTestStatistic::Configuration cfg;
+    cfg.verbose = false;
+    return cfg;
+  }
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// coverity[UNINIT_CTOR]
@@ -78,7 +86,7 @@ RooXYChi2Var::RooXYChi2Var()
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataSet& xydata, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),{.verbose=false}),
+  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),std::move(makeRooAbsTestStatisticCfg())),
   _extended(kFALSE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),
@@ -106,7 +114,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataSet& xydata, RooRealVar& yvar, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),{.verbose=false}),
+  RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),std::move(makeRooAbsTestStatisticCfg())),
   _extended(kFALSE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),
@@ -137,7 +145,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& xydata, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),{.verbose=false}),
+  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),std::move(makeRooAbsTestStatisticCfg())),
   _extended(kTRUE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),
@@ -171,7 +179,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPd
 ///
 
 RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& xydata, RooRealVar& yvar, Bool_t integrate) :
-  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),{.verbose=false}),
+  RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),std::move(makeRooAbsTestStatisticCfg())),
   _extended(kTRUE),
   _integrate(integrate),
   _intConfig(*defaultIntegratorConfig()),


### PR DESCRIPTION
In the previous PR https://github.com/root-project/root/pull/7344, the biggest challenge has been to make `RooAbsOptTestStatistic` aware if batch mode is enabled to skip the cache optimization.

The cleanest way of disabling the cache optimization is to do so directly in the `RooAbsOptTestStatistic` constructor so it is skipped. Unfortunately, the constructor of `RooAbsOptTestStatistic` and its base class `RooAbsTestStatistic` has already a very long signature, and it is already challenging to correctly align all parameters correctly with the position they should have.

That's why I propose in this PR to use a struct to group all `RooAbsTestStatistic` parameters. This has several advantages:
* the struct can be initialized with tagged initialization, so alignment errors can be easily avoided
* if a new parameter is added (such as the `batchMode` flag in this PR), only the configuration struct declaration struct needs to be changed
* the default values are defined in a central place and not redundantly in all the relevant constructor declarations/`RooAbsTestStatistic::create` overrides

To make the review easier, this PR only includes the configuration refactor and disabling the cache optimization is batch mode is used. The `RunContextTracker`-related commits would follow in a separate PR, but I already tested that everything together does work and the unit test I created for the `RunContextTracker` succeeds.

Two open questions are still:
* the `RooNLLVar::_batchEvaluations` flag is now redundant, but I still kept it to not have to change class versions too often. Is this acceptable?
* the new `RooAbsTestStatistic::_batchMode` takes part in the IO, entailing an increment of the class version. I that acceptable? The advantage here is that if one reads back a serialized RooFit workspace, it can remember if batch mode is used