### PR TITLE
Fix RooFit memory leaks with TIterator usage

### DIFF
--- a/roofit/histfactory/src/HistFactoryModelUtils.cxx
+++ b/roofit/histfactory/src/HistFactoryModelUtils.cxx
@@ -352,9 +352,9 @@ namespace HistFactory{
     // Find the "data" of the poisson term
     // This is the nominal value
     bool FoundNomMean=false;
-    TIterator* iter_pois = constraintTerm->serverIterator(); //constraint_args
+    TIter iter_pois = constraintTerm->serverIterator(); //constraint_args
     RooAbsArg* term_pois ;
-    while((term_pois=(RooAbsArg*)iter_pois->Next())) {
+    while((term_pois=(RooAbsArg*)iter_pois.Next())) {
       std::string serverName = term_pois->GetName();
       //std::cout << "Checking Server: " << serverName << std::endl;
       if( serverName.find("nom_")!=std::string::npos ) {
@@ -370,15 +370,14 @@ namespace HistFactory{
     else {
       if(verbose) std::cout << "Found Poisson 'data' term: " << pois_nom->GetName() << std::endl;
     }
-    delete iter_pois;
 
     // Taking the constraint term (a Poisson), find
     // the "mean" which is the product: gamma*tau
     // Then, from that mean, find tau
-    TIterator* iter_constr = constraintTerm->serverIterator(); //constraint_args
+    TIter iter_constr = constraintTerm->serverIterator(); //constraint_args
     RooAbsArg* pois_mean_arg=NULL;
     bool FoundPoissonMean = false;
-    while(( pois_mean_arg = (RooAbsArg*) iter_constr->Next() )) {
+    while(( pois_mean_arg = (RooAbsArg*) iter_constr.Next() )) {
       std::string serverName = pois_mean_arg->GetName();
       if( pois_mean_arg->dependsOn( *gamma_stat ) ) {
 	FoundPoissonMean=true;
@@ -395,13 +394,11 @@ namespace HistFactory{
     else {
       if(verbose) std::cout << "Found Poisson 'mean' term: " << pois_mean_arg->GetName() << std::endl;
     }
-    delete iter_constr;
 
-
-    TIterator* iter_product = pois_mean_arg->serverIterator(); //constraint_args
+    TIter iter_product = pois_mean_arg->serverIterator(); //constraint_args
     RooAbsArg* term_in_product ;
     bool FoundTau=false;
-    while((term_in_product=(RooAbsArg*)iter_product->Next())) {
+    while((term_in_product=(RooAbsArg*)iter_product.Next())) {
       std::string serverName = term_in_product->GetName();
       //std::cout << "Checking Server: " << serverName << std::endl;
       if( serverName.find("_tau")!=std::string::npos ) {
@@ -417,7 +414,6 @@ namespace HistFactory{
     else {
       if(verbose) std::cout << "Found Poisson 'tau' term: " << tau->GetName() << std::endl;
     }
-    delete iter_product;
 
     return 0;
 

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -428,7 +428,7 @@ RooMomentMorphFuncND::CacheElem *RooMomentMorphFuncND::getCache(const RooArgSet 
    int nObs = _obsList.getSize();
    int nPdf = _referenceGrid._pdfList.getSize();
 
-   TIterator *pdfItr = _pdfList.createIterator();
+   TIter pdfItr = _pdfList.createIterator();
 
    RooAbsReal *null = 0;
    vector<RooAbsReal *> meanrv(nPdf * nObs, null);
@@ -501,7 +501,7 @@ RooMomentMorphFuncND::CacheElem *RooMomentMorphFuncND::getCache(const RooArgSet 
       }
 
       // construction of unit pdfs
-      pdfItr->Reset();
+      pdfItr.Reset();
       RooAbsReal *pdf;
       RooArgList transPdfList;
 
@@ -509,7 +509,7 @@ RooMomentMorphFuncND::CacheElem *RooMomentMorphFuncND::getCache(const RooArgSet 
          _obsItr->Reset();
          RooRealVar *var;
 
-         pdf = (RooAbsReal *)pdfItr->Next();
+         pdf = (RooAbsReal *)pdfItr.Next();
          string pdfName = Form("pdf_%d", i);
          RooCustomizer cust(*pdf, pdfName.c_str());
 

--- a/roofit/roofit/src/RooMomentMorphND.cxx
+++ b/roofit/roofit/src/RooMomentMorphND.cxx
@@ -428,7 +428,7 @@ RooMomentMorphND::CacheElem *RooMomentMorphND::getCache(const RooArgSet * /*nset
    int nObs = _obsList.getSize();
    int nPdf = _referenceGrid._pdfList.getSize();
 
-   TIterator *pdfItr = _pdfList.createIterator();
+   TIter pdfItr = _pdfList.createIterator();
 
    RooAbsReal *null = 0;
    vector<RooAbsReal *> meanrv(nPdf * nObs, null);
@@ -499,7 +499,7 @@ RooMomentMorphND::CacheElem *RooMomentMorphND::getCache(const RooArgSet * /*nset
       }
 
       // construction of unit pdfs
-      pdfItr->Reset();
+      pdfItr.Reset();
       RooAbsPdf *pdf;
       RooArgList transPdfList;
 
@@ -507,7 +507,7 @@ RooMomentMorphND::CacheElem *RooMomentMorphND::getCache(const RooArgSet * /*nset
          _obsItr->Reset();
          RooRealVar *var;
 
-         pdf = (RooAbsPdf *)pdfItr->Next();
+         pdf = (RooAbsPdf *)pdfItr.Next();
          string pdfName = Form("pdf_%d", i);
          RooCustomizer cust(*pdf, pdfName.c_str());
 

--- a/roofit/roofit/src/RooStepFunction.cxx
+++ b/roofit/roofit/src/RooStepFunction.cxx
@@ -80,9 +80,9 @@ RooStepFunction::RooStepFunction(const char* name, const char* title,
   delete coefIter ;
 
   _boundIter = _boundaryList.createIterator() ;
-  TIterator* boundaryIter = boundaryList.createIterator() ;
+  TIter boundaryIter = boundaryList.createIterator() ;
   RooAbsArg* boundary ;
-  while((boundary = (RooAbsArg*)boundaryIter->Next())) {
+  while((boundary = (RooAbsArg*)boundaryIter.Next())) {
     if (!dynamic_cast<RooAbsReal*>(boundary)) {
       cout << "RooStepFunction::ctor(" << GetName() << ") ERROR: boundary " << boundary->GetName()
       << " is not of type RooAbsReal" << endl ;

--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -229,6 +229,7 @@
          while( (te = (RooThreshEntry*)iter->Next()) ) { \
            _threshList.emplace_back(te->_thresh, te->_cat.getVal()); \
          }\
+         delete iter;\
          }";
 #pragma read sourceClass="RooThresholdCategory" targetClass="RooThresholdCategory" version="[2]" \
   source="RooCatType* _defCat; std::vector<std::pair<double,RooCatType>> _threshList" target="_defIndex,_threshList" \

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -677,9 +677,9 @@ void RooAbsAnaConvPdf::printMultiline(ostream& os, Int_t contents, Bool_t verbos
   RooAbsPdf::printMultiline(os,contents,verbose,indent);
 
   os << indent << "--- RooAbsAnaConvPdf ---" << endl;
-  TIterator* iter = _convSet.createIterator() ;
+  TIter iter = _convSet.createIterator() ;
   RooResolutionModel* conv ;
-  while (((conv=(RooResolutionModel*)iter->Next()))) {
+  while (((conv=(RooResolutionModel*)iter.Next()))) {
     conv->printMultiline(os,contents,verbose,indent) ;
   }
 }

--- a/roofit/roofitcore/src/RooAbsStudy.cxx
+++ b/roofit/roofitcore/src/RooAbsStudy.cxx
@@ -130,9 +130,9 @@ void RooAbsStudy::aggregateSummaryOutput(TList* chunkList)
 {
   if (!chunkList) return ;
 
-  TIterator* iter = chunkList->MakeIterator() ;
+  TIter iter = chunkList->MakeIterator() ;
   TObject* obj ;
-  while((obj=iter->Next())) {
+  while((obj=iter.Next())) {
 
     //cout << "RooAbsStudy::aggregateSummaryOutput(" << GetName() << ") processing object " << obj->GetName() << endl ;
 
@@ -152,12 +152,11 @@ void RooAbsStudy::aggregateSummaryOutput(TList* chunkList)
     if (dlist) {
       if (TString(dlist->GetName()).BeginsWith(Form("%s_detailed_data",GetName()))) {
 	//cout << "RooAbsStudy::aggregateSummaryOutput(" << GetName() << ") found detail block " <<dlist->GetName() << " with " << dlist->GetSize() << " entries" << endl ;
-	TIterator* diter = dlist->MakeIterator() ;
+	TIter diter = dlist->MakeIterator() ;
 	TNamed* dobj ;
-	while((dobj=(TNamed*)diter->Next())) {	  
+	while((dobj=(TNamed*)diter.Next())) {	  
 	  storeDetailedOutput(*dobj) ;
 	}
-	delete diter ;
       }
     }
   }

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -330,9 +330,9 @@ RooDataHist::RooDataHist(const char *name, const char *title, const RooArgList& 
 
       // Initialize importing mapped set of TH1s
       map<string,TH1*> hmap ;
-      TIterator* hiter = impSliceHistos.MakeIterator() ;
+      TIter hiter = impSliceHistos.MakeIterator() ;
       for (const auto& token : RooHelpers::tokenise(impSliceNames, ",")) {
-        auto histo = static_cast<TH1*>(hiter->Next());
+        auto histo = static_cast<TH1*>(hiter.Next());
         assert(histo);
         hmap[token] = histo;
       }
@@ -341,9 +341,9 @@ RooDataHist::RooDataHist(const char *name, const char *title, const RooArgList& 
 
       // Initialize importing mapped set of RooDataHists
       map<string,RooDataHist*> dmap ;
-      TIterator* hiter = impSliceDHistos.MakeIterator() ;
+      TIter hiter = impSliceDHistos.MakeIterator() ;
       for (const auto& token : RooHelpers::tokenise(impSliceDNames, ",")) {
-        dmap[token] = (RooDataHist*) hiter->Next() ;
+        dmap[token] = (RooDataHist*) hiter.Next() ;
       }
       importDHistSet(vars,*indexCat,dmap,initWgt) ;
     }

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -917,15 +917,14 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
   }
 
   // Verify that all members of varList are of type RooRealVar
-  TIterator* iter = varList.createIterator() ;
+  TIter iter = varList.createIterator() ;
   RooAbsArg* arg  ;
-  while((arg=(RooAbsArg*)iter->Next())) {
+  while((arg=(RooAbsArg*)iter.Next())) {
     if (!dynamic_cast<RooRealVar*>(arg)) {
       oocoutE((TObject*)0,InputArguments) << "RooFitResult::lastMinuitFit: ERROR: variable '" << arg->GetName() << "' is not of type RooRealVar" << endl ;
       return 0 ;
     }
   }
-  delete iter ;
 
   RooFitResult* r = new RooFitResult("lastMinuitFit","Last MINUIT fit") ;
 
@@ -1003,13 +1002,13 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
 RooFitResult *RooFitResult::prefitResult(const RooArgList &paramList)
 {
    // Verify that all members of varList are of type RooRealVar
-   TIterator *iter = paramList.createIterator();
+   TIter iter = paramList.createIterator();
    RooAbsArg *arg;
-   while ((arg = (RooAbsArg *)iter->Next())) {
+   while ((arg = (RooAbsArg *)iter.Next())) {
       if (!dynamic_cast<RooRealVar *>(arg)) {
          oocoutE((TObject *)0, InputArguments) << "RooFitResult::lastMinuitFit: ERROR: variable '" << arg->GetName()
                                                << "' is not of type RooRealVar" << endl;
-         return 0;
+         return nullptr;
       }
    }
 
@@ -1020,15 +1019,14 @@ RooFitResult *RooFitResult::prefitResult(const RooArgList &paramList)
    RooArgList constPars("constPars");
    RooArgList floatPars("floatPars");
 
-   iter->Reset();
-   while ((arg = (RooAbsArg *)iter->Next())) {
+   iter.Reset();
+   while ((arg = (RooAbsArg *)iter.Next())) {
       if (arg->isConstant()) {
          constPars.addClone(*arg);
       } else {
          floatPars.addClone(*arg);
       }
    }
-   delete iter;
 
    r->setConstParList(constPars);
    r->setInitParList(floatPars);

--- a/roofit/roofitcore/src/RooGenContext.cxx
+++ b/roofit/roofitcore/src/RooGenContext.cxx
@@ -370,6 +370,7 @@ void RooGenContext::initGenerator(const RooArgSet &theEvent)
 
   // Create iterator for uniform vars (if any)
   if (_uniformVars.getSize()>0) {
+    delete _uniIter;
     _uniIter = _uniformVars.createIterator() ;
   }
 }

--- a/roofit/roofitcore/src/RooLinearVar.cxx
+++ b/roofit/roofitcore/src/RooLinearVar.cxx
@@ -152,8 +152,8 @@ Bool_t RooLinearVar::isJacobianOK(const RooArgSet& depList) const
 
   // Check if jacobian has no real-valued dependents
   RooAbsArg* arg ;
-  TIterator* dIter = depList.createIterator() ;
-  while ((arg=(RooAbsArg*)dIter->Next())) {
+  TIter dIter = depList.createIterator() ;
+  while ((arg=(RooAbsArg*)dIter.Next())) {
     if (arg->IsA()->InheritsFrom(RooAbsReal::Class())) {
       if (_slope.arg().dependsOnValue(*arg)) {
 // 	cout << "RooLinearVar::isJacobianOK(" << GetName() << ") return kFALSE because slope depends on value of " << arg->GetName() << endl ;
@@ -161,8 +161,7 @@ Bool_t RooLinearVar::isJacobianOK(const RooArgSet& depList) const
       }
     }
   }
-  delete dIter ;
-//   cout << "RooLinearVar::isJacobianOK(" << GetName() << ") return kTRUE" << endl ;
+  //   cout << "RooLinearVar::isJacobianOK(" << GetName() << ") return kTRUE" << endl ;
   return kTRUE ;
 }
 

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -876,16 +876,15 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
 
 
   // Verify that all members of varList are of type RooRealVar
-  TIterator* iter = varList.createIterator() ;
+  TIter iter = varList.createIterator() ;
   RooAbsArg* arg  ;
-  while((arg=(RooAbsArg*)iter->Next())) {
+  while((arg=(RooAbsArg*)iter.Next())) {
     if (!dynamic_cast<RooRealVar*>(arg)) {
       oocoutE((TObject*)0,InputArguments) << "RooMinimizer::lastMinuitFit: ERROR: variable '"
 					  << arg->GetName() << "' is not of type RooRealVar" << endl ;
       return 0 ;
     }
   }
-  delete iter ;
 
   RooFitResult* res = new RooFitResult("lastMinuitFit","Last MINUIT fit") ;
 

--- a/roofit/roofitcore/src/RooProofDriverSelector.cxx
+++ b/roofit/roofitcore/src/RooProofDriverSelector.cxx
@@ -43,9 +43,9 @@ void RooProofDriverSelector::SlaveBegin(TTree * /*tree*/)
   // Retrieve study pack 
   _pkg=0 ;
   if (fInput) { 
-    TIterator* iter = fInput->MakeIterator() ;
+    TIter iter = fInput->MakeIterator() ;
     TObject* obj ;
-    while((obj=iter->Next())) {
+    while((obj=iter.Next())) {
       RooStudyPackage* tmp = dynamic_cast<RooStudyPackage*>(obj) ;
       if (tmp) {
 	_pkg = tmp ;

--- a/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
+++ b/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
@@ -196,9 +196,9 @@ void RooRandomizeParamMCSModule::sampleSumGauss(const RooArgSet& paramSet, Doubl
 {
   // Check that all args are RooRealVars
   RooArgSet okset ;
-  TIterator* iter = paramSet.createIterator() ;
+  TIter iter = paramSet.createIterator() ;
   RooAbsArg* arg ;
-  while((arg=(RooAbsArg*)iter->Next())) {
+  while((arg=(RooAbsArg*)iter.Next())) {
     // Check that arg is a RooRealVar
     RooRealVar* rrv = dynamic_cast<RooRealVar*>(arg) ;
     if (!rrv) {
@@ -212,9 +212,9 @@ void RooRandomizeParamMCSModule::sampleSumGauss(const RooArgSet& paramSet, Doubl
   // If not attached, this check is repeated at the attachment moment
   RooArgSet okset2 ;
   if (genParams()) {
-    TIterator* psiter = okset.createIterator() ;
+    TIter psiter = okset.createIterator() ;
     RooAbsArg* arg2 ;
-    while ((arg2=(RooAbsArg*)psiter->Next())) {
+    while ((arg2=(RooAbsArg*)psiter.Next())) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg2->GetName())) ;
       if (!actualVar) {
 	oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform: variable " << arg2->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;	
@@ -222,7 +222,6 @@ void RooRandomizeParamMCSModule::sampleSumGauss(const RooArgSet& paramSet, Doubl
 	okset2.add(*actualVar) ;
       }
     }    
-    delete psiter ;
   } else {
 
    // If genParams() are not available, skip this check for now
@@ -321,23 +320,24 @@ Bool_t RooRandomizeParamMCSModule::initializeInstance()
 
     // Check that all listed variables are actual generator model parameters
     RooArgSet actualPSet ;
-    TIterator* psiter = ugiter->_pset.createIterator() ;
+    TIter psiter = ugiter->_pset.createIterator() ;
     RooAbsArg* arg ;
-    while ((arg=(RooAbsArg*)psiter->Next())) {
+    while ((arg=(RooAbsArg*)psiter.Next())) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg->GetName())) ;
       if (!actualVar) {
 	oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << arg->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;	
       } else {
 	actualPSet.add(*actualVar) ;
       }
-    }    
+    }
+
     ugiter->_pset.removeAll() ;
     ugiter->_pset.add(actualPSet) ;
 
     // Add variables to summary dataset to hold generator values
-    TIterator* iter = ugiter->_pset.createIterator() ;
+    TIter iter = ugiter->_pset.createIterator() ;
     RooRealVar* param ;
-    while((param=(RooRealVar*)iter->Next())) {
+    while((param=(RooRealVar*)iter.Next())) {
       TString parName = Form("%s_gen",param->GetName()) ;
       TString parTitle = Form("%s as generated",param->GetTitle()) ;
       RooRealVar* par_gen = new RooRealVar(parName.Data(),parTitle.Data(),0) ;    
@@ -435,9 +435,9 @@ Bool_t RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
     Double_t compScaleFactor = newVal/sumVal.getVal() ;
 
     // Apply multiplicative correction to each term of the sum
-    TIterator* iter = gsiter->_pset.createIterator() ;
+    TIter iter = gsiter->_pset.createIterator() ;
     RooRealVar* param ;
-    while((param=(RooRealVar*)iter->Next())) {
+    while((param=(RooRealVar*)iter.Next())) {
       param->setVal(param->getVal()*compScaleFactor) ;
       RooRealVar* genpar = static_cast<RooRealVar*>(_genParSet.find(Form("%s_gen",param->GetName()))) ;
       genpar->setVal(param->getVal()) ;

--- a/roofit/roofitcore/src/RooSimWSTool.cxx
+++ b/roofit/roofitcore/src/RooSimWSTool.cxx
@@ -452,9 +452,9 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
   TList* customizerList = new TList ;
 
   // Loop over requested physics models and build components
-  TIterator* physMIter = physModelSet.createIterator() ;
+  TIter physMIter = physModelSet.createIterator() ;
   RooAbsPdf* physModel ;
-  while((physModel=(RooAbsPdf*)physMIter->Next())) {
+  while((physModel=(RooAbsPdf*)physMIter.Next())) {
     if (verbose) coutI(ObjectHandling) << "RooSimPdfBuilder::executeBuild: processing prototype pdf " << physModel->GetName() << endl ;
 
     RooCustomizer* physCustomizer = new RooCustomizer(*physModel,*masterSplitCat,splitNodeListOwned,&splitNodeListAll) ;
@@ -525,7 +525,6 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
       physCustomizer->splitArgs(*splitIter->first,*splitCat) ;
     }
   }
-  delete physMIter ;
 
   // List all existing workspace components as prebuilt items for the customizers at this point
   splitNodeListAll.add(_ws->components()) ;

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -805,9 +805,9 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
   RooArgList wgtCompList ;
 //RooAbsPdf* pdf ;
   RooRealProxy* proxy ;
-  TIterator* pIter = _pdfProxyList.MakeIterator() ;
+  TIter pIter = _pdfProxyList.MakeIterator() ;
   Double_t sumWeight(0) ;
-  while((proxy=(RooRealProxy*)pIter->Next())) {
+  while((proxy=(RooRealProxy*)pIter.Next())) {
 
     idxCatClone->setLabel(proxy->name()) ;
 

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -1938,10 +1938,10 @@ Bool_t RooWorkspace::CodeRepo::autoImportClass(TClass* tc, Bool_t doReplace)
   // Make list of all immediate base classes of this class
   TString baseNameList ;
   TList* bl = tc->GetListOfBases() ;
-  TIterator* iter = bl->MakeIterator() ;
+  TIter iter = bl->MakeIterator() ;
   TBaseClass* base ;
   list<TClass*> bases ;
-  while((base=(TBaseClass*)iter->Next())) {
+  while((base=(TBaseClass*)iter.Next())) {
     if (baseNameList.Length()>0) {
       baseNameList += "," ;
     }

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -863,9 +863,9 @@ Bool_t RooWorkspace::defineSet(const char* name, const RooArgSet& aset, Bool_t i
   RooArgSet wsargs ;
 
   // Check all constituents of provided set
-  TIterator* iter = aset.createIterator() ;
+  TIter iter = aset.createIterator() ;
   RooAbsArg* sarg ;
-  while((sarg=(RooAbsArg*)iter->Next())) {
+  while((sarg=(RooAbsArg*)iter.Next())) {
     // If missing, either import or report error
     if (!arg(sarg->GetName())) {
       if (importMissing) {
@@ -878,7 +878,7 @@ Bool_t RooWorkspace::defineSet(const char* name, const RooArgSet& aset, Bool_t i
     }
     wsargs.add(*arg(sarg->GetName())) ;
   }
-  delete iter ;
+
 
   // Install named set
   _namedSets[name].removeAll() ;
@@ -1433,9 +1433,9 @@ RooArgSet RooWorkspace::allFunctions() const
   RooArgSet ret ;
 
   // Split list of components in pdfs, functions and variables
-  TIterator* iter = _allOwnedNodes.createIterator() ;
+  TIter iter = _allOwnedNodes.createIterator() ;
   RooAbsArg* parg ;
-  while((parg=(RooAbsArg*)iter->Next())) {
+  while((parg=(RooAbsArg*)iter.Next())) {
     if (parg->IsA()->InheritsFrom(RooAbsReal::Class()) &&
 	!parg->IsA()->InheritsFrom(RooAbsPdf::Class()) &&
 	!parg->IsA()->InheritsFrom(RooConstVar::Class()) &&
@@ -1456,9 +1456,9 @@ RooArgSet RooWorkspace::allCatFunctions() const
   RooArgSet ret ;
 
   // Split list of components in pdfs, functions and variables
-  TIterator* iter = _allOwnedNodes.createIterator() ;
+  TIter iter = _allOwnedNodes.createIterator() ;
   RooAbsArg* parg ;
-  while((parg=(RooAbsArg*)iter->Next())) {
+  while((parg=(RooAbsArg*)iter.Next())) {
     if (parg->IsA()->InheritsFrom(RooAbsCategory::Class()) &&
 	!parg->IsA()->InheritsFrom(RooCategory::Class())) {
       ret.add(*parg) ;
@@ -1477,9 +1477,9 @@ RooArgSet RooWorkspace::allResolutionModels() const
   RooArgSet ret ;
 
   // Split list of components in pdfs, functions and variables
-  TIterator* iter = _allOwnedNodes.createIterator() ;
+  TIter iter = _allOwnedNodes.createIterator() ;
   RooAbsArg* parg ;
-  while((parg=(RooAbsArg*)iter->Next())) {
+  while((parg=(RooAbsArg*)iter.Next())) {
     if (parg->IsA()->InheritsFrom(RooResolutionModel::Class())) {
       if (!((RooResolutionModel*)parg)->isConvolved()) {
 	ret.add(*parg) ;
@@ -1498,9 +1498,9 @@ RooArgSet RooWorkspace::allPdfs() const
   RooArgSet ret ;
 
   // Split list of components in pdfs, functions and variables
-  TIterator* iter = _allOwnedNodes.createIterator() ;
+  TIter iter = _allOwnedNodes.createIterator() ;
   RooAbsArg* parg ;
-  while((parg=(RooAbsArg*)iter->Next())) {
+  while((parg=(RooAbsArg*)iter.Next())) {
     if (parg->IsA()->InheritsFrom(RooAbsPdf::Class()) &&
 	!parg->IsA()->InheritsFrom(RooResolutionModel::Class())) {
       ret.add(*parg) ;

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -1986,9 +1986,9 @@ Bool_t RooWorkspace::makeDir()
   TString title= Form("TDirectory representation of RooWorkspace %s",GetName()) ;
   _dir = new WSDir(GetName(),title.Data(),this) ;
 
-  TIterator* iter = componentIterator() ;
+  TIter iter = componentIterator() ;
   RooAbsArg* darg ;
-  while((darg=(RooAbsArg*)iter->Next())) {
+  while((darg=(RooAbsArg*)iter.Next())) {
     if (darg->IsA() != RooConstVar::Class()) {
       _dir->InternalAppend(darg) ;
     }

--- a/roofit/roostats/src/HLFactory.cxx
+++ b/roofit/roostats/src/HLFactory.cxx
@@ -258,10 +258,10 @@ RooAbsPdf* HLFactory::GetTotBkgPdf(){
 
     RooArgList pdfs("pdfs");
 
-    TIterator* it = fBkgPdfNames.MakeIterator();
+    TIter it = fBkgPdfNames.MakeIterator();
     TObjString* ostring;
     TObject* obj;
-    while ((obj = it->Next())){
+    while ((obj = it.Next())){
         ostring=(TObjString*) obj;
         pdfs.add( *(fWs->pdf(ostring->String())) );
         }
@@ -542,10 +542,10 @@ void HLFactory::fCreateCategory(){
 
     fComboCat=new RooCategory(name,title);
 
-    TIterator* it=fLabelsNames.MakeIterator();
+    TIter it = fLabelsNames.MakeIterator();
     TObjString* ostring;
     TObject* obj;
-    while ((obj = it->Next())){
+    while ((obj = it.Next())){
         ostring=(TObjString*) obj;
         fComboCat->defineType(ostring->String());
         }

--- a/roofit/roostats/src/ProfileInspector.cxx
+++ b/roofit/roostats/src/ProfileInspector.cxx
@@ -117,9 +117,9 @@ TList* ProfileInspector::GetListOfProfilePlots( RooAbsData& data, RooStats::Mode
     poi->setVal(curve_x[i]);
     profile->getVal();
 
-    TIterator* nuis_params_itr=nuis_params->createIterator();
+    TIter nuis_params_itr = nuis_params->createIterator();
     TObject* nuis_params_obj;
-    while((nuis_params_obj=nuis_params_itr->Next())){
+    while((nuis_params_obj = nuis_params_itr.Next())){
        RooRealVar* nuis_param = dynamic_cast<RooRealVar*>(nuis_params_obj);
        if(nuis_param) {
           string name = nuis_param->GetName();

--- a/roofit/roostats/src/RatioOfProfiledLikelihoodsTestStat.cxx
+++ b/roofit/roostats/src/RatioOfProfiledLikelihoodsTestStat.cxx
@@ -102,13 +102,15 @@ Double_t  RooStats::RatioOfProfiledLikelihoodsTestStat::Evaluate(RooAbsData& dat
    }
    if (fDetailedOutputEnabled) {
       fDetailedOutput = new RooArgSet();
-      RooRealVar* var(0);
-      for(TIterator *it = nullset->createIterator();(var = dynamic_cast<RooRealVar*>(it->Next()));) {
+      RooRealVar* var = nullptr;
+      TIter it1 = nullset->createIterator();
+      while((var = dynamic_cast<RooRealVar*>(it1.Next()))) {
          RooRealVar* cloneVar = new RooRealVar(TString::Format("nullprof_%s", var->GetName()),
                                                TString::Format("%s for null", var->GetTitle()), var->getVal());
          fDetailedOutput->addOwned(*cloneVar);
       }
-      for(TIterator *it = altset->createIterator();(var = dynamic_cast<RooRealVar*>(it->Next()));) {
+      TIter it2 = altset->createIterator();
+      while((var = dynamic_cast<RooRealVar*>(it2.Next()))) {
          RooRealVar* cloneVar = new RooRealVar(TString::Format("altprof_%s", var->GetName()),
                                                TString::Format("%s for null", var->GetTitle()), var->getVal());
          fDetailedOutput->addOwned(*cloneVar);

--- a/roofit/roostats/src/SamplingDistPlot.cxx
+++ b/roofit/roostats/src/SamplingDistPlot.cxx
@@ -91,10 +91,12 @@ SamplingDistPlot::SamplingDistPlot(Int_t nbins, Double_t min, Double_t max) :
 ////////////////////////////////////////////////////////////////////////////////
 /// destructors - delete objects contained in the list
 
-SamplingDistPlot::~SamplingDistPlot() {
+SamplingDistPlot::~SamplingDistPlot() 
+{
    fItems.Delete();
    fOtherItems.Delete();
    if (fRooPlot) delete fRooPlot;
+   if (fIterator) delete fIterator;
 }
 
 

--- a/test/fit/WrapperRooPdf.h
+++ b/test/fit/WrapperRooPdf.h
@@ -108,11 +108,11 @@ public:
          fParamValues.resize(NPar() );
 
       // iterate on parameters and set values
-      TIterator* itr = fParams->createIterator() ;
+      TIter itr = fParams->createIterator() ;
       std::vector<double>::iterator vpitr = fParamValues.begin();
 
-      RooRealVar* var = 0;
-      while( ( var = dynamic_cast<RooRealVar*>(itr->Next() ) ) ) {
+      RooRealVar* var = nullptr;
+      while( ( var = dynamic_cast<RooRealVar*>(itr.Next() ) ) ) {
          assert(var != 0);
          *vpitr++ = var->getVal();
       }
@@ -121,10 +121,10 @@ public:
 
    std::string ParameterName(unsigned int i) const {
       // iterate on parameters and set values
-      TIterator* itr = fParams->createIterator() ;
-      RooRealVar* var = 0;
+      TIter itr = fParams->createIterator() ;
+      RooRealVar* var = nullptr;
       unsigned int index = 0;
-      while( ( var = dynamic_cast<RooRealVar*>(itr->Next() ) ) ) {
+      while( ( var = dynamic_cast<RooRealVar*>(itr.Next() ) ) ) {
          assert(var != 0);
          if (index == i) return std::string(var->GetName() );
          index++;
@@ -168,9 +168,9 @@ private:
       DoSetParameters(p);
 
       // iterate on observables
-      TIterator* itr = fX->createIterator() ;
+      TIter itr = fX->createIterator() ;
       RooRealVar* var = 0;
-      while( ( var = dynamic_cast<RooRealVar*>(itr->Next() ) ) ) {
+      while( ( var = dynamic_cast<RooRealVar*>(itr.Next() ) ) ) {
          assert(var != 0);
 #ifndef _WIN32
          var->setDirtyInhibit(true);
@@ -190,9 +190,9 @@ private:
 
    void DoSetParameters(const double * p) const {
       // iterate on parameters and set values
-      TIterator* itr = fParams->createIterator() ;
-      RooRealVar* var = 0;
-      while( ( var = dynamic_cast<RooRealVar*>(itr->Next() ) ) ) {
+      TIter itr = fParams->createIterator() ;
+      RooRealVar* var = nullptr;
+      while( ( var = dynamic_cast<RooRealVar*>(itr.Next() ) ) ) {
          assert(var != 0);
          var->setVal(*p++);
       }

--- a/tutorials/histfactory/ModifyInterpolation.C
+++ b/tutorials/histfactory/ModifyInterpolation.C
@@ -76,9 +76,9 @@ void ModifyInterpolation(){
 
 void ModifyInterpolationForAll(RooWorkspace* ws, int code){
   RooArgSet funcs = ws->allFunctions();
-  TIterator* it = funcs.createIterator();
-  TObject* tempObj=0;
-  while((tempObj=it->Next())){
+  TIter it = funcs.createIterator();
+  TObject* tempObj = nullptr;
+  while((tempObj=it.Next())){
     FlexibleInterpVar* flex = dynamic_cast<FlexibleInterpVar*>(tempObj);
     if(flex){
       flex->setAllInterpCodes(code);
@@ -88,12 +88,12 @@ void ModifyInterpolationForAll(RooWorkspace* ws, int code){
 
 void ModifyInterpolationForSet(RooArgSet* modifySet, int code){
 
-  TIterator* it = modifySet->createIterator();
-  RooRealVar* alpha=0;
-  while((alpha=(RooRealVar*)it->Next())){
-    TIterator* serverIt = alpha->clientIterator();
-    TObject* tempObj=0;
-    while((tempObj=serverIt->Next())){
+  TIter it = modifySet->createIterator();
+  RooRealVar* alpha = nullptr;
+  while((alpha=(RooRealVar*)it.Next())){
+    TIter serverIt = alpha->clientIterator();
+    TObject* tempObj = nullptr;
+    while((tempObj=serverIt.Next())){
       FlexibleInterpVar* flex = dynamic_cast<FlexibleInterpVar*>(tempObj);
       if(flex){
          flex->printAllInterpCodes();
@@ -108,9 +108,9 @@ void ModifyInterpolationForSet(RooArgSet* modifySet, int code){
 
 void CheckInterpolation(RooWorkspace* ws){
   RooArgSet funcs = ws->allFunctions();
-  TIterator* it = funcs.createIterator();
+  TIter it = funcs.createIterator();
   TObject* tempObj=0;
-  while((tempObj=it->Next())){
+  while((tempObj=it.Next())){
     FlexibleInterpVar* flex = dynamic_cast<FlexibleInterpVar*>(tempObj);
     if(flex){
       flex->printAllInterpCodes();

--- a/tutorials/roostats/ModelInspector.C
+++ b/tutorials/roostats/ModelInspector.C
@@ -201,7 +201,7 @@ ModelInspectorGUI::ModelInspectorGUI(RooWorkspace *w, ModelConfig *mc, RooAbsDat
    RooArgSet parameters;
    parameters.add(*fMC->GetParametersOfInterest());
    parameters.add(*fMC->GetNuisanceParameters());
-   TIterator *it = parameters.createIterator();
+   TIter it = parameters.createIterator();
    RooRealVar *param = NULL;
 
    // BB: This is the part needed in order to have scrollbars
@@ -212,7 +212,7 @@ ModelInspectorGUI::ModelInspectorGUI(RooWorkspace *w, ModelConfig *mc, RooAbsDat
    // And that't it!
    // Obviously, the parent of other subframes is now fVFrame instead of "this"...
 
-   while ((param = (RooRealVar *)it->Next())) {
+   while ((param = (RooRealVar *)it.Next())) {
       cout << "Adding Slider for " << param->GetName() << endl;
       TGHorizontalFrame *hframek = new TGHorizontalFrame(fVFrame, 0, 0, 0);
 

--- a/tutorials/roostats/StandardBayesianMCMCDemo.C
+++ b/tutorials/roostats/StandardBayesianMCMCDemo.C
@@ -182,10 +182,10 @@ void StandardBayesianMCMCDemo(const char *infile = "", const char *workspaceName
    }
 
    // draw a scatter plot of chain results for poi vs each nuisance parameters
-   TIterator *it = mc->GetNuisanceParameters()->createIterator();
+   TIter it = mc->GetNuisanceParameters()->createIterator();
    RooRealVar *nuis = NULL;
    int iPad = 1; // iPad, that's funny
-   while ((nuis = (RooRealVar *)it->Next())) {
+   while ((nuis = (RooRealVar *)it.Next())) {
       c2->cd(iPad++);
       plot.DrawChainScatter(*firstPOI, *nuis);
    }

--- a/tutorials/roostats/StandardHistFactoryPlotsWithCategories.C
+++ b/tutorials/roostats/StandardHistFactoryPlotsWithCategories.C
@@ -178,9 +178,9 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
    int nPlots = 0;
    if (!simPdf) {
 
-      TIterator *it = mc->GetNuisanceParameters()->createIterator();
+      TIter it = mc->GetNuisanceParameters()->createIterator();
       RooRealVar *var = NULL;
-      while ((var = (RooRealVar *)it->Next()) != NULL) {
+      while ((var = (RooRealVar *)it.Next()) != NULL) {
          RooPlot *frame = obs->frame();
          frame->SetYTitle(var->GetName());
          data->plotOn(frame, MarkerSize(1));
@@ -211,9 +211,9 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
 
          obs = ((RooRealVar *)obstmp->first());
 
-         TIterator *it = mc->GetNuisanceParameters()->createIterator();
+         TIter it = mc->GetNuisanceParameters()->createIterator();
          RooRealVar *var = NULL;
-         while (nPlots < nPlotsMax && (var = (RooRealVar *)it->Next())) {
+         while (nPlots < nPlotsMax && (var = (RooRealVar *)it.Next())) {
             TCanvas *c2 = new TCanvas("c2");
             RooPlot *frame = obs->frame();
             frame->SetName(Form("frame%d", nPlots));


### PR DESCRIPTION
Fixing #7619
In very many places in RooFit temporary TIterator instances not deleted.
In such places I replace it by
```
TIter iter = collection->MakeIterator();
```
In some sense `TIter` class is equivalent to `std::unique_ptr<TIterator>`
