### PR TITLE
Provide assign operator for TIter 

### DIFF
--- a/core/cont/inc/TCollection.h
+++ b/core/cont/inc/TCollection.h
@@ -261,6 +261,13 @@ public:
    Bool_t             operator!=(const TIter &aIter) const {
       return !(*this == aIter);
    }
+   TIter &operator=(TIterator *iter)
+   {
+      if (fIterator)
+         delete fIterator;
+      fIterator = iter;
+      return *this;
+   }
    TObject           *operator*() const { return fIterator ? *(*fIterator): nullptr; }
    TIter             &Begin();
    static TIter       End();

--- a/core/cont/inc/TIterator.h
+++ b/core/cont/inc/TIterator.h
@@ -34,7 +34,7 @@ protected:
    TIterator(const TIterator &) { }
 
 public:
-   virtual TIterator &operator=(const TIterator &) { return *this; }
+   virtual TIterator &operator=(const TIterator &) = 0;
    virtual ~TIterator() { }
    virtual const TCollection *GetCollection() const = 0;
    virtual Option_t *GetOption() const { return ""; }

--- a/core/cont/src/TList.cxx
+++ b/core/cont/src/TList.cxx
@@ -1080,7 +1080,6 @@ TIterator &TListIter::operator=(const TIterator &rhs)
    const TListIter *rhs1 = dynamic_cast<const TListIter *>(&rhs);
    if (this != &rhs && rhs1) {
       R__COLLECTION_ITER_GUARD(rhs1->fList);
-      TIterator::operator=(rhs);
       fList      = rhs1->fList;
       fCurCursor = rhs1->fCurCursor;
       fCursor    = rhs1->fCursor;
@@ -1097,7 +1096,6 @@ TListIter &TListIter::operator=(const TListIter &rhs)
 {
    if (this != &rhs) {
       R__COLLECTION_ITER_GUARD(rhs.fList);
-      TIterator::operator=(rhs);
       fList      = rhs.fList;
       fCurCursor = rhs.fCurCursor;
       fCursor    = rhs.fCursor;

--- a/core/cont/test/CMakeLists.txt
+++ b/core/cont/test/CMakeLists.txt
@@ -8,3 +8,4 @@ ROOT_ADD_UNITTEST_DIR(Core)
 
 ROOT_ADD_GTEST(testTypedIteration testTypedIteration.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(TSeqTests TSeqTests.cxx LIBRARIES Core)
+ROOT_ADD_GTEST(testIter testIter.cxx LIBRARIES Core)

--- a/core/cont/test/testIter.cxx
+++ b/core/cont/test/testIter.cxx
@@ -1,0 +1,79 @@
+#include "TList.h"
+#include "TNamed.h"
+
+#include "gtest/gtest.h"
+
+TEST(TIter, Loop)
+{
+   TList lst;
+   lst.SetOwner(kTRUE);
+   lst.Add(new TNamed("first","title"));
+   lst.Add(new TNamed("second","title"));
+   lst.Add(new TNamed("third","title"));
+
+   int cnt = 0;
+   TIter iter(&lst);
+
+   while (iter.Next()) cnt++;
+
+   EXPECT_EQ(cnt, 3);
+}
+
+
+class TListIterTest : public TListIter {
+public:
+   Bool_t *fDestroyed{nullptr};
+
+   TListIterTest(Bool_t *destroyed, TList *lst, Bool_t dir = kIterForward) : TListIter(lst, dir)
+   {
+      fDestroyed = destroyed;
+   }
+   virtual ~TListIterTest()
+   {
+      if (fDestroyed) *fDestroyed = kTRUE;
+   }
+
+   TIterator &operator=(const TIterator &rhs)
+   {
+      if (this != &rhs)
+         TListIter::operator=(rhs);
+      return *this;
+   }
+
+   TListIterTest &operator=(const TListIterTest &rhs)
+   {
+      if (this != &rhs)
+         TListIter::operator=(rhs);
+      return *this;
+   }
+};
+
+TEST(TIter, Assign)
+{
+   TList lst;
+   lst.SetOwner(kTRUE);
+   lst.Add(new TNamed("first","title"));
+   lst.Add(new TNamed("second","title"));
+   lst.Add(new TNamed("third","title"));
+
+   Bool_t flag = kFALSE;
+
+   {
+      TIter iter(&lst);
+      Int_t cnt = 0;
+      while (iter.Next()) cnt++;
+      EXPECT_EQ(cnt, 3);
+
+      // check that iterator assigned without copying
+      iter = new TListIterTest(&flag, &lst);
+
+      EXPECT_EQ(flag, kFALSE);
+
+      cnt = 0;
+      while (iter.Next()) cnt++;
+
+      EXPECT_EQ(cnt, 3);
+   }
+
+   EXPECT_EQ(flag, kTRUE);
+}


### PR DESCRIPTION
Let assign TIterator* directly without need of creating
temporary TIter object in between.
Solves #7633