### PR TITLE
[RF] Use unique_ptr in RooCacheManager and new try_emplace method

### DIFF
--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -677,20 +677,8 @@ Int_t ParamHistFunc::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& anal
   // Select subset of allVars that are actual dependents
   analVars.add(allVars) ;
 
-  // Check if this configuration was created before
-  Int_t sterileIdx(-1) ;
-  CacheElem* cache = (CacheElem*) _normIntMgr.getObj(normSet,&analVars,&sterileIdx,(const char*)0) ;
-  if (cache) {
-    return _normIntMgr.lastIndex()+1 ;
-  }
-  
-  // Create new cache element
-  cache = new CacheElem ;
-
-  // Store cache element
-  Int_t code = _normIntMgr.setObj(normSet,&analVars,(RooAbsCacheElement*)cache,0) ;
-
-  return code+1 ; 
+  // Emplace cache element
+  return _normIntMgr.try_emplace<CacheElem>({normSet,&analVars}).code + 1 ;
 
 }
 

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -372,16 +372,12 @@ Int_t PiecewiseInterpolation::getAnalyticalIntegralWN(RooArgSet& allVars, RooArg
   //  RooArgSet* normSet = getObservables();
   //  RooArgSet* normSet = 0;
 
-
-  // Check if this configuration was created before
-  Int_t sterileIdx(-1) ;
-  CacheElem* cache = (CacheElem*) _normIntMgr.getObj(normSet,&analVars,&sterileIdx) ;
-  if (cache) {
-    return _normIntMgr.lastIndex()+1 ;
+  // Emplace new cache element
+  auto emplaceResult = _normIntMgr.try_emplace<CacheElem>({normSet,&analVars}) ;
+  if(!emplaceResult.insertionHappened) {
+    return emplaceResult.code + 1;
   }
-  
-  // Create new cache element
-  cache = new CacheElem ;
+  auto * cache = emplaceResult.cache;
 
   // Make list of function projection and normalization integrals 
   RooAbsReal *func ;
@@ -410,10 +406,7 @@ Int_t PiecewiseInterpolation::getAnalyticalIntegralWN(RooArgSet& allVars, RooArg
     ++i;
   }
 
-  // Store cache element
-  Int_t code = _normIntMgr.setObj(normSet,&analVars,(RooAbsCacheElement*)cache,0) ;
-
-  return code+1 ; 
+  return emplaceResult.code + 1 ; 
 }
 
 

--- a/roofit/roofit/src/RooJeffreysPrior.cxx
+++ b/roofit/roofit/src/RooJeffreysPrior.cxx
@@ -99,9 +99,10 @@ Double_t RooJeffreysPrior::evaluate() const
 {
   RooHelpers::LocalChangeMsgLevel msgLvlRAII(RooFit::WARNING);
 
+  auto emplaceResult = _cacheMgr.try_emplace<CacheElem>({});
+  auto cacheElm = emplaceResult.cache;
 
-  CacheElem* cacheElm = (CacheElem*) _cacheMgr.getObj(nullptr);
-  if (!cacheElm) {
+  if (emplaceResult.insertionHappened) {
     //Internally, we have to enlarge the range of fit parameters to make
     //fits converge even if we are close to the limit of a parameter. Therefore, we clone the pdf and its
     //observables here. If something happens to the external PDF, the cache is wiped,
@@ -116,11 +117,8 @@ Double_t RooJeffreysPrior::evaluate() const
       var.setRange(range.first - 0.1*span, range.second + 0.1 * span);
     }
 
-    cacheElm = new CacheElem;
     cacheElm->_pdf.reset(clonePdf);
     cacheElm->_pdfVariables.reset(vars);
-
-    _cacheMgr.setObj(nullptr, cacheElm);
   }
 
   auto& cachedPdf = *cacheElm->_pdf;

--- a/roofit/roofit/src/RooMomentMorph.cxx
+++ b/roofit/roofit/src/RooMomentMorph.cxx
@@ -350,8 +350,7 @@ RooMomentMorph::CacheElem* RooMomentMorph::getCache(const RooArgSet* /*nset*/) c
   RooChangeTracker* tracker = new RooChangeTracker(trackerName.c_str(),trackerName.c_str(),m.arg(),kTRUE) ;
 
   // Store it in the cache
-  cache = new CacheElem(*theSumPdf,*tracker,fracl) ;
-  _cacheMgr.setObj(0,0,cache,0) ;
+  cache = _cacheMgr.try_emplace<CacheElem>({}, *theSumPdf,*tracker,fracl).cache;
 
   cache->calculateFractions(*this, kFALSE);
   return cache ;

--- a/roofit/roofit/src/RooMomentMorphFunc.cxx
+++ b/roofit/roofit/src/RooMomentMorphFunc.cxx
@@ -337,10 +337,7 @@ RooMomentMorphFunc::CacheElem *RooMomentMorphFunc::getCache(const RooArgSet * /*
    RooChangeTracker *tracker = new RooChangeTracker(trackerName.c_str(), trackerName.c_str(), m.arg(), kTRUE);
 
    // Store it in the cache
-   cache = new CacheElem(*theSumFunc, *tracker, fracl);
-   _cacheMgr.setObj(0, 0, cache, 0);
-
-   return cache;
+   return _cacheMgr.try_emplace<CacheElem>({}, *theSumFunc, *tracker, fracl).cache;
 }
 
 //_____________________________________________________________________________

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -558,10 +558,7 @@ RooMomentMorphFuncND::CacheElem *RooMomentMorphFuncND::getCache(const RooArgSet 
    RooChangeTracker *tracker = new RooChangeTracker(trackerName.c_str(), trackerName.c_str(), _parList, kTRUE);
 
    // Store it in the cache
-   cache = new CacheElem(*theSumFunc, *tracker, fracl);
-   _cacheMgr.setObj(0, 0, cache, 0);
-
-   return cache;
+   return _cacheMgr.try_emplace<CacheElem>({}, *theSumFunc, *tracker, fracl).cache;
 }
 
 //_____________________________________________________________________________

--- a/roofit/roofit/src/RooMomentMorphND.cxx
+++ b/roofit/roofit/src/RooMomentMorphND.cxx
@@ -556,8 +556,7 @@ RooMomentMorphND::CacheElem *RooMomentMorphND::getCache(const RooArgSet * /*nset
    RooChangeTracker *tracker = new RooChangeTracker(trackerName.c_str(), trackerName.c_str(), _parList, kTRUE);
 
    // Store it in the cache
-   cache = new CacheElem(*theSumPdf, *tracker, fracl);
-   _cacheMgr.setObj(0, 0, cache, 0);
+   cache = _cacheMgr.try_emplace<CacheElem>({}, *theSumPdf, *tracker, fracl).cache;
 
    cache->calculateFractions(*this, kFALSE);
    return cache;

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -605,10 +605,9 @@ Double_t RooAbsAnaConvPdf::getCoefNorm(Int_t coefIdx, const RooArgSet* nset, con
 {
   if (nset==0) return coefficient(coefIdx) ;
 
-  CacheElem* cache = (CacheElem*) _coefNormMgr.getObj(nset,0,0,rangeName) ;
-  if (!cache) {
-
-    cache = new CacheElem ;
+  auto emplaceResult = _coefNormMgr.try_emplace<CacheElem>({nset,nullptr,rangeName}) ;
+  auto cache = emplaceResult.cache;
+  if (emplaceResult.insertionHappened) {
 
     // Make list of coefficient normalizations
     Int_t i ;
@@ -618,8 +617,6 @@ Double_t RooAbsAnaConvPdf::getCoefNorm(Int_t coefIdx, const RooArgSet* nset, con
       RooAbsReal* coefInt = static_cast<RooAbsReal&>(*cache->_coefVarList.at(i)).createIntegral(*nset,RooNameReg::str(rangeName)) ;
       cache->_normList.addOwned(*coefInt) ;      
     }  
-
-    _coefNormMgr.setObj(nset,0,cache,rangeName) ;
   }
 
   return ((RooAbsReal*)cache->_normList.at(coefIdx))->getVal() ;

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -169,7 +169,8 @@ RooAbsCachedPdf::PdfCacheElem* RooAbsCachedPdf::getCache(const RooArgSet* nset, 
   }
 
   // Create and fill cache
-  cache = createCache(nset) ;
+  std::unique_ptr<PdfCacheElem> cacheUniqePtr{createCache(nset)} ;
+  cache = cacheUniqePtr.get(); // non-owning pointer
 
   // Check if we have contents registered already in global expensive object cache
   RooDataHist* htmp = (RooDataHist*) expensiveObjectCache().retrieveObject(cache->hist()->GetName(),RooDataHist::Class(),cache->paramTracker()->parameters()) ;
@@ -191,7 +192,7 @@ RooAbsCachedPdf::PdfCacheElem* RooAbsCachedPdf::getCache(const RooArgSet* nset, 
 
 
   // Store this cache configuration
-  Int_t code = _cacheMgr.setObj(nset,0,((RooAbsCacheElement*)cache),0) ;
+  Int_t code = _cacheMgr.setObj(nset,0,std::move(cacheUniqePtr),0) ;
 
   coutI(Caching) << "RooAbsCachedPdf::getCache(" << GetName() << ") creating new cache " << cache << " with pdf "
 		 << cache->pdf()->GetName() << " for nset " << (nset?*nset:RooArgSet()) << " with code " << code ;

--- a/roofit/roofitcore/src/RooAbsCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedReal.cxx
@@ -148,7 +148,8 @@ RooAbsCachedReal::FuncCacheElem* RooAbsCachedReal::getCache(const RooArgSet* nse
     return cache ;
   }
 
-  cache = createCache(nset) ;
+  std::unique_ptr<FuncCacheElem> cacheUniquePtr{createCache(nset)} ;
+  cache = cacheUniquePtr.get(); // non-owning pointer
 
   // Set cache function data to ADirty since function will need update every time in cache update process
   RooFIter iarg( cache->hist()->get()->fwdIterator() );
@@ -175,7 +176,7 @@ RooAbsCachedReal::FuncCacheElem* RooAbsCachedReal::getCache(const RooArgSet* nse
   } 
 
   // Store this cache configuration
-  Int_t code = _cacheMgr.setObj(nset,0,((RooAbsCacheElement*)cache),0) ;
+  Int_t code = _cacheMgr.setObj(nset,0,std::move(cacheUniquePtr),0) ;
   ccoutD(Caching) << "RooAbsCachedReal("<<this<<")::getCache(" << GetName() << ") creating new cache " << cache->func()->GetName() << " for nset " << (nset?*nset:RooArgSet()) << " with code " << code << endl ;
   
   return cache ;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -482,8 +482,7 @@ const RooAbsReal* RooAbsPdf::getNormObj(const RooArgSet* nset, const RooArgSet* 
   delete depList ;
 
   // Store it in the cache
-  cache = new CacheElem(*norm) ;
-  _normMgr.setObj(nset,iset,cache,rangeName) ;
+  _normMgr.try_emplace<CacheElem>({nset,iset,rangeName}, *norm);
 
   // And return the newly created integral
   return norm ;
@@ -587,8 +586,7 @@ Bool_t RooAbsPdf::syncNormalization(const RooArgSet* nset, Bool_t adjustProxies)
   }
 
   // Register new normalization with manager (takes ownership)
-  cache = new CacheElem(*_norm) ;
-  _normMgr.setObj(nset,cache) ;
+  _normMgr.try_emplace<CacheElem>({nset}, *_norm) ;
 
 //   cout << "making new object " << _norm->GetName() << endl ;
 

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -413,15 +413,12 @@ void RooAddPdf::fixCoefRange(const char* rangeName)
 
 RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooArgSet* iset, const char* rangeName) const
 {
-
-  // Check if cache already exists
-  CacheElem* cache = (CacheElem*) _projCacheMgr.getObj(nset,iset,0,rangeName) ;
-  if (cache) {
+  // Create new cache if it doesn't exit already
+  auto emplaceResult = _projCacheMgr.try_emplace<CacheElem>({nset,iset,RooNameReg::ptr(rangeName)}) ;
+  auto cache = emplaceResult.cache;
+  if (!emplaceResult.insertionHappened) {
     return cache ;
   }
-
-  //Create new cache
-  cache = new CacheElem ;
 
   // *** PART 1 : Create supplemental normalization list ***
 
@@ -487,7 +484,6 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
 
   // If no projections required stop here
   if (!_projectCoefs && !rangeName) {
-    _projCacheMgr.setObj(nset,iset,cache,RooNameReg::ptr(rangeName)) ;
 //     cout << " no projection required" << endl ;
     return cache ;
   }
@@ -641,8 +637,6 @@ RooAddPdf::CacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooAr
   }
 
   delete nset2 ;
-
-  _projCacheMgr.setObj(nset,iset,cache,RooNameReg::ptr(rangeName)) ;
 
   return cache ;
 }

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -317,15 +317,12 @@ Int_t RooRealSumPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& anal
 
 
   // Check if this configuration was created before
-  Int_t sterileIdx(-1) ;
-  CacheElem* cache = (CacheElem*) _normIntMgr.getObj(normSet,&analVars,&sterileIdx,RooNameReg::ptr(rangeName)) ;
-  if (cache) {
+  auto emplaceResult = _normIntMgr.try_emplace<CacheElem>({normSet,&analVars,RooNameReg::ptr(rangeName)}) ;
+  if (!emplaceResult.insertionHappened) {
     //cout << "RooRealSumPdf("<<this<<")::getAnalyticalIntegralWN:"<<GetName()<<"("<<allVars<<","<<analVars<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>") << " -> " << _normIntMgr.lastIndex()+1 << " (cached)" << endl;
-    return _normIntMgr.lastIndex()+1 ;
+    return emplaceResult.code+1 ;
   }
-  
-  // Create new cache element
-  cache = new CacheElem ;
+  auto cache = emplaceResult.cache;
 
   // Make list of function projection and normalization integrals 
   for (const auto elm : _funcList) {
@@ -340,15 +337,12 @@ Int_t RooRealSumPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& anal
     }
   }
 
-  // Store cache element
-  Int_t code = _normIntMgr.setObj(normSet,&analVars,(RooAbsCacheElement*)cache,RooNameReg::ptr(rangeName)) ;
-
   if (normSet) {
     delete normSet ;
   }
 
   //cout << "RooRealSumPdf("<<this<<")::getAnalyticalIntegralWN:"<<GetName()<<"("<<allVars<<","<<analVars<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>") << " -> " << code+1 << endl;
-  return code+1 ; 
+  return emplaceResult.code+1 ; 
 }
 
 


### PR DESCRIPTION
This is to avoid having to call `new` and `delete` in the context of
caching in RooFit, as it has lead to memory leaks in the past.