### PR TITLE
[skip-ci] Fix unresolved external symbol errors on Windows

### DIFF
--- a/interpreter/cling/tools/driver/CMakeLists.txt
+++ b/interpreter/cling/tools/driver/CMakeLists.txt
@@ -74,7 +74,6 @@ if(MSVC)
 
   # Most (if not all) of these MSVC decided are inlines that aren't exported
   set(cling_exports ${cling_exports} ?print@Decl@clang@@QEBAXAEAVraw_ostream@llvm@@I_N@Z
-    ?getAsString@QualType@clang@@SA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBVType@2@VQualifiers@2@@Z
     ??6raw_ostream@llvm@@QEAAAEAV01@PEBX@Z
     ?getQualifiedNameAsString@NamedDecl@clang@@QEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ
     ?insert_imp_big@SmallPtrSetImplBase@llvm@@AEAA?AU?$pair@PEBQEBX_N@std@@PEBX@Z
@@ -90,7 +89,6 @@ if(MSVC)
     ??1raw_string_ostream@llvm@@UEAA@XZ
     ?flush_nonempty@raw_ostream@llvm@@AEAAXXZ
     ?getASTContext@Decl@clang@@QEBAAEAVASTContext@2@XZ
-    ?handle@raw_ostream@llvm@@EEAAXXZ
     ?preferred_buffer_size@raw_ostream@llvm@@MEBA_KXZ
     ?write_impl@raw_string_ostream@llvm@@EEAAXPEBD_K@Z
     ?castToDeclContext@Decl@clang@@SAPEAVDeclContext@2@PEBV12@@Z


### PR DESCRIPTION
Resolves root-project/cling#399
Fix the following linker errors:
```
253>cling.exp : error LNK2001: unresolved external symbol "public: static class std::basic_string<char,struct std::char_traits,class std::allocator > __cdecl clang::QualType::getAsString(class clang::Type const *,class clang::Qualifiers)" (?getAsString@QualType@clang@@sa?AV?$basic_string@DU?$char_traits@D@std@@v?$allocator@D@2@@std@@PEBVType@2@VQualifiers@2@@z)
253>cling.exp : error LNK2001: unresolved external symbol "private: virtual void __cdecl llvm::raw_ostream::handle(void)" (?handle@raw_ostream@llvm@@EEAAXXZ)
253>D:\work\libs\cling\src\build\Release\bin\cling.exe : fatal error LNK1120: 2 unresolved externals
```