### PR TITLE
[v624][rootcling] Emit using std after user headers, fixes #6343:

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2819,7 +2819,7 @@ void CreateDictHeader(std::ostream &dictStream, const std::string &main_dictname
 
 void AddNamespaceSTDdeclaration(std::ostream &dictStream)
 {
-   dictStream  << "// The generated code does not explicitly qualifies STL entities\n"
+   dictStream  << "// The generated code does not explicitly qualify STL entities\n"
                << "namespace std {} using namespace std;\n\n";
 }
 
@@ -4552,6 +4552,7 @@ int RootClingMain(int argc,
    }
 
    std::ostream &dictStream = (!gOptIgnoreExistingDict && !gOptDictionaryFileName.empty()) ? fileout : std::cout;
+   bool isACLiC = gOptDictionaryFileName.getValue().find("_ACLiC_dict") != std::string::npos;
 
    if (!gOptIgnoreExistingDict) {
       // Now generate a second stream for the split dictionary if it is necessary
@@ -4575,9 +4576,12 @@ int RootClingMain(int argc,
          CreateDictHeader(*splitDictStream, main_dictname);
 
       if (!gOptNoGlobalUsingStd) {
-         AddNamespaceSTDdeclaration(dictStream);
-         if (gOptSplit) {
-            AddNamespaceSTDdeclaration(*splitDictStream);
+         // ACLiC'ed macros might rely on `using namespace std` in front of user headers
+         if (isACLiC) {
+            AddNamespaceSTDdeclaration(dictStream);
+            if (gOptSplit) {
+               AddNamespaceSTDdeclaration(*splitDictStream);
+            }
          }
       }
    }
@@ -4812,6 +4816,15 @@ int RootClingMain(int argc,
          GenerateNecessaryIncludes(dictStream, includeForSource, extraIncludes);
          if (gOptSplit) {
             GenerateNecessaryIncludes(*splitDictStream, includeForSource, extraIncludes);
+         }
+      }
+      if (!gOptNoGlobalUsingStd) {
+         // ACLiC'ed macros might have relied on `using namespace std` in front of user headers
+         if (!isACLiC) {
+            AddNamespaceSTDdeclaration(dictStream);
+            if (gOptSplit) {
+               AddNamespaceSTDdeclaration(*splitDictStream);
+            }
          }
       }
       if (gDriverConfig->fInitializeStreamerInfoROOTFile) {


### PR DESCRIPTION
`using namespace std` can have detrimental side effects on user headers.
For non-ACLiC invocations, assume that user headers are compilable. In
those casesm move the using directive after the inclusion of user headers,
to not affect them, but only the generated dictionary source code
(which is using CINT-compatible std-less type names etc).

(cherry picked from commit df98daa3467bb21fe52d5eed5a2ab758a3787f84)