### PR TITLE
Improve usability of root-config.bat

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -838,6 +838,7 @@ if(WIN32)
 endif()
 
 #--Local root-configure
+set(all_features ${ROOT_ALL_OPTIONS})
 set(prefix $ROOTSYS)
 set(bindir $ROOTSYS/bin)
 set(libdir $ROOTSYS/lib)

--- a/config/root-config.bat.in
+++ b/config/root-config.bat.in
@@ -55,6 +55,7 @@ set rootevelibs=libEve.lib libEG.lib libGeom.lib libGed.lib libRGL.lib
 set rootlibs=libCore.lib libImt.lib libRIO.lib libNet.lib libHist.lib libGraf.lib libGraf3d.lib libGpad.lib libROOTVecOps.lib libTree.lib libTreePlayer.lib libRint.lib libPostscript.lib libMatrix.lib libPhysics.lib libMathCore.lib libThread.lib
 
 set out=
+set err=0
 
 for %%w in (%*) do (
    set arg=%%w
@@ -88,6 +89,7 @@ for %%w in (%*) do (
          ) else (
             set out=!out! no
          )
+         set err=1
       )
    )
    if "!arg!"=="--version" (
@@ -101,7 +103,7 @@ for %%w in (%*) do (
          set out=!out! !ROOT_RELEASE!
       ) else (
          echo "cannot read ${incdir}/RVersion.h"
-         exit 1
+         exit /b 1
       )
    )
    if "!arg!"=="--git-revision" (
@@ -193,13 +195,14 @@ for %%w in (%*) do (
 )
 
 if "!out!"=="" (
+   set err=1
    echo !arg!: Unknown option or argument^^!
    echo.
    goto print_help
 )
 echo !out!
 
-exit /b 0
+exit /b !err!
 
 :print_help
 
@@ -232,4 +235,5 @@ echo   --cxx                 Print alternative C++ compiler specified when ROOT 
 echo   --f77                 Print alternative Fortran compiler specified when ROOT was built
 echo   --ld                  Print alternative Linker specified when ROOT was built
 echo   --help                Print this message
-exit /b 0
+
+exit /b !err!

--- a/config/root-config.bat.in
+++ b/config/root-config.bat.in
@@ -28,6 +28,7 @@ set libdir=%ROOTSYS%\lib
 set incdir=%ROOTSYS%\include
 set etcdir=%ROOTSYS%\etc
 set tutdir=%ROOTSYS%\tutorials
+set all_features=@all_features@
 set features=@features@
 set configargs="@configargs@"
 set altcc=@altcc@
@@ -69,6 +70,7 @@ for %%w in (%*) do (
       rem Check for feature
       set feature=!arg:~6!
       set res=""
+      set known=""
       for %%f in (%features%) do (
          if %%f==!feature! (
             set res=%%f
@@ -76,7 +78,16 @@ for %%w in (%*) do (
          )
       )
       if !res!=="" (
-         set out=!out! no
+         for %%f in (%all_features%) do (
+            if %%f==!feature! (
+               set known=%%f
+            )
+         )
+         if !known!=="" (
+            set out=!out! --has-!feature!: unknown feature^^!
+         ) else (
+            set out=!out! no
+         )
       )
    )
    if "!arg!"=="--version" (
@@ -181,6 +192,11 @@ for %%w in (%*) do (
    )
 )
 
+if "!out!"=="" (
+   echo !arg!: Unknown option or argument^^!
+   echo.
+   goto print_help
+)
 echo !out!
 
 exit /b 0


### PR DESCRIPTION
Handle unknown feature and/or option, addressing the issue #7662 on Windows. Gives something like:
```
C:\Users\sftnight>root-config --flags
--flags: Unknown option or argument!

Usage: root-config [options]

  --arch                Print the architecture (compiler/OS)
  --platform            Print the platform (OS)
  --libs                Print regular ROOT libraries
  --glibs               Print regular + GUI ROOT libraries
  --evelibs             Print regular + GUI + Eve libraries
  --cflags              Print compiler flags and header path
  --bindir              Print the executable directory
  --libdir              Print the library directory
  --incdir              Print the header directory
  --etcdir              Print the configuration directory
  --tutdir              Print the tutorials directory
  --srcdir              Print the top of the original source directory
  --auxlibs             Print auxiliary libraries
  --config              Print arguments used for configuration with CMake
  --features            Print list of all supported features
  --has-<feature>       Test if <feature> is compiled in
  --version             Print the ROOT version
  --git-revision        Print the ROOT git revision number
  --python-version      Print the Python version used by ROOT
  --python2-version     Print the Python2 version used by PyROOT
  --python3-version     Print the Python3 version used by PyROOT
  --ncpu                Print number of available (hyperthreaded) cores
  --cc                  Print alternative C compiler specified when ROOT was built
  --cxx                 Print alternative C++ compiler specified when ROOT was built
  --f77                 Print alternative Fortran compiler specified when ROOT was built
  --ld                  Print alternative Linker specified when ROOT was built
  --help                Print this message

C:\Users\sftnight>root-config --has-feet
 --has-feet: unknown feature!

C:\Users\sftnight>root-config --has-feet --has-pyroot
 --has-feet: unknown feature! yes
```