### PR TITLE
proper doxygen formatting for treeplayer headers

### DIFF
--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -43,8 +43,8 @@ class TStreamerElement;
 
 namespace ROOT {
 namespace Internal {
-   //_______________________________________________
-   // String builder to be used in the constructors.
+   ////////////////////////////////////////////////////////////////////////////////
+   /// String builder to be used in the constructors.
    class TBranchProxyHelper {
    public:
       TString fName;
@@ -516,8 +516,8 @@ public:
 
 namespace Internal {
 
-   //____________________________________________________________________________________________
-   // Concrete Implementation of the branch proxy around the data members which are array of char
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Concrete Implementation of the branch proxy around the data members which are array of char
    class TArrayCharProxy : public Detail::TBranchProxy {
    public:
       void Print() override {
@@ -575,8 +575,8 @@ namespace Internal {
 
    };
 
-   //_______________________________________________________
-   // Base class for the proxy around object in TClonesArray.
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Base class for the proxy around object in TClonesArray.
    class TClaProxy : public Detail::TBranchProxy {
    public:
       void Print() override {
@@ -617,8 +617,8 @@ namespace Internal {
 
    };
 
-   //_______________________________________________
-   // Base class for the proxy around STL containers.
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Base class for the proxy around STL containers.
    class TStlProxy : public Detail::TBranchProxy {
    public:
       void Print() override {
@@ -657,8 +657,8 @@ namespace Internal {
 
    };
 
-   //______________________________________
-   // Template of the proxy around objects.
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Template of the proxy around objects.
    template <class T>
    class TImpProxy : public Detail::TBranchProxy {
    public:
@@ -683,31 +683,31 @@ namespace Internal {
 
    };
 
-   //____________________________________________
-   // Helper template to be able to determine and
-   // use array dimentsions.
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Helper template to be able to determine and
+   /// use array dimensions.
    template <class T, int d = 0> struct TArrayType {
       typedef T type_t;
       typedef T array_t[d];
       static constexpr int gSize = d;
    };
-   //____________________________________________
-   // Helper class for proxy around multi dimension array
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Helper class for proxy around multi dimension array
    template <class T> struct TArrayType<T,0> {
       typedef T type_t;
       typedef T array_t;
       static constexpr int gSize = 0;
    };
-   //____________________________________________
-   // Helper class for proxy around multi dimension array
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Helper class for proxy around multi dimension array
    template <class T, int d> struct TMultiArrayType {
       typedef typename T::type_t type_t;
       typedef typename T::array_t array_t[d];
       static constexpr int gSize = d;
    };
 
-   //____________________________________________
-   // Template for concrete implementation of proxy around array of T
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Template for concrete implementation of proxy around array of T
    template <class T>
    class TArrayProxy : public Detail::TBranchProxy {
    public:
@@ -747,8 +747,8 @@ namespace Internal {
       const array_t &operator [](UInt_t i) { return At(i); }
    };
 
-   //_____________________________________________________________________________________
-   // Template of the Concrete Implementation of the branch proxy around TClonesArray of T
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Template of the Concrete Implementation of the branch proxy around TClonesArray of T
    template <class T>
    class TClaImpProxy : public TClaProxy {
    public:
@@ -777,8 +777,8 @@ namespace Internal {
 
    };
 
-   //_________________________________________________________________________________________
-   // Template of the Concrete Implementation of the branch proxy around an stl container of T
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Template of the Concrete Implementation of the branch proxy around an stl container of T
    template <class T>
    class TStlImpProxy : public TStlProxy {
    public:
@@ -807,8 +807,8 @@ namespace Internal {
 
    };
 
-   //_________________________________________________________________________________________________
-   // Template of the Concrete Implementation of the branch proxy around an TClonesArray of array of T
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Template of the Concrete Implementation of the branch proxy around an TClonesArray of array of T
    template <class T>
    class TClaArrayProxy : public TClaProxy {
    public:
@@ -836,8 +836,8 @@ namespace Internal {
    };
 
 
-   //__________________________________________________________________________________________________
-   // Template of the Concrete Implementation of the branch proxy around an stl container of array of T
+   ////////////////////////////////////////////////////////////////////////////////
+   /// Template of the Concrete Implementation of the branch proxy around an stl container of array of T
    template <class T>
    class TStlArrayProxy : public TStlProxy {
    public:
@@ -920,7 +920,7 @@ namespace Internal {
    typedef TClaArrayProxy<TArrayType<ULong_t> >     TClaArrayULongProxy;    // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of unsigned long
    typedef TClaArrayProxy<TArrayType<ULong64_t> >   TClaArrayULong64Proxy;  // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of unsigned long long
    typedef TClaArrayProxy<TArrayType<UShort_t> >    TClaArrayUShortProxy;   // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of unsigned short
-   typedef TClaArrayProxy<TArrayType<UChar_t> >     TClaArrayUCharProxy;    // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of nsigned char
+   typedef TClaArrayProxy<TArrayType<UChar_t> >     TClaArrayUCharProxy;    // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of unsigned char
    typedef TClaArrayProxy<TArrayType<Int_t> >       TClaArrayIntProxy;      // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of int
    typedef TClaArrayProxy<TArrayType<Long_t> >      TClaArrayLongProxy;     // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of long
    typedef TClaArrayProxy<TArrayType<Long64_t> >    TClaArrayLong64Proxy;   // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of long long
@@ -950,10 +950,10 @@ namespace Internal {
    typedef TStlArrayProxy<TArrayType<Float_t> >     TStlArrayFloatProxy;    // Concrete Implementation of the branch proxy around an stl container of float
    typedef TStlArrayProxy<TArrayType<Float16_t> >   TStlArrayFloat16Proxy;  // Concrete Implementation of the branch proxy around an stl container of float16_t
    typedef TStlArrayProxy<TArrayType<UInt_t> >      TStlArrayUIntProxy;     // Concrete Implementation of the branch proxy around an stl container of unsigned int
-   typedef TStlArrayProxy<TArrayType<ULong_t> >     TStlArrayULongProxy;    // Concrete Implementation of the branch proxy around an stl container of usigned long
+   typedef TStlArrayProxy<TArrayType<ULong_t> >     TStlArrayULongProxy;    // Concrete Implementation of the branch proxy around an stl container of unsigned long
    typedef TStlArrayProxy<TArrayType<ULong64_t> >   TStlArrayULong64Proxy;  // Concrete Implementation of the branch proxy around an stl contained of unsigned long long
-   typedef TStlArrayProxy<TArrayType<UShort_t> >    TStlArrayUShortProxy;   // Concrete Implementation of the branch proxy around an stl container of unisgned short
-   typedef TStlArrayProxy<TArrayType<UChar_t> >     TStlArrayUCharProxy;    // Concrete Implementation of the branch proxy around an stl container of unsingned char
+   typedef TStlArrayProxy<TArrayType<UShort_t> >    TStlArrayUShortProxy;   // Concrete Implementation of the branch proxy around an stl container of unsigned short
+   typedef TStlArrayProxy<TArrayType<UChar_t> >     TStlArrayUCharProxy;    // Concrete Implementation of the branch proxy around an stl container of unsigned char
    typedef TStlArrayProxy<TArrayType<Int_t> >       TStlArrayIntProxy;      // Concrete Implementation of the branch proxy around an stl container of int
    typedef TStlArrayProxy<TArrayType<Long_t> >      TStlArrayLongProxy;     // Concrete Implementation of the branch proxy around an stl container of long
    typedef TStlArrayProxy<TArrayType<Long64_t> >    TStlArrayLong64Proxy;   // Concrete Implementation of the branch proxy around an stl container of long long

--- a/tree/treeplayer/inc/TBranchProxyDirector.h
+++ b/tree/treeplayer/inc/TBranchProxyDirector.h
@@ -29,14 +29,14 @@ namespace Detail {
 namespace Internal{
    class TFriendProxy;
 
-   // Helper function to call SetReadEntry on all TFriendProxy
+   /// Helper function to call SetReadEntry on all TFriendProxy
    void ResetReadEntry(TFriendProxy *fp);
 
    class TBranchProxyDirector {
 
       //This class could actually be the selector itself.
-      TTree   *fTree;  // TTree we are currently looking at.
-      Long64_t fEntry; // Entry currently being read (in the local TTree rather than the TChain)
+      TTree   *fTree;  ///< TTree we are currently looking at.
+      Long64_t fEntry; ///< Entry currently being read (in the local TTree rather than the TChain)
 
       std::list<Detail::TBranchProxy*> fDirected;
       std::vector<TFriendProxy*> fFriends;

--- a/tree/treeplayer/inc/TFileDrawMap.h
+++ b/tree/treeplayer/inc/TFileDrawMap.h
@@ -32,12 +32,12 @@ class TBranch;
 class TFileDrawMap : public TNamed {
 
 protected:
-   TFile         *fFile;           //pointer to the file
-   TH1           *fFrame;          //histogram used to draw the map frame
-   TString        fKeys;           //list of keys
-   TString        fOption;         //drawing options
-   Int_t          fXsize;          //size in bytes of X axis
-   Int_t          fYsize;          //size in K/Mbytes of Y axis
+   TFile         *fFile;           ///< Pointer to the file
+   TH1           *fFrame;          ///< Histogram used to draw the map frame
+   TString        fKeys;           ///< List of keys
+   TString        fOption;         ///< Drawing options
+   Int_t          fXsize;          ///< Size in bytes of X axis
+   Int_t          fYsize;          ///< Size in K/Mbytes of Y axis
 
    virtual void     DrawMarker(Int_t marker, Long64_t eseek);
    virtual Bool_t   GetObjectInfoDir(TDirectory *dir, Int_t px, Int_t py, TString &info) const;

--- a/tree/treeplayer/inc/TFormLeafInfo.h
+++ b/tree/treeplayer/inc/TFormLeafInfo.h
@@ -59,14 +59,14 @@ public:
    TFormLeafInfo &operator=(const TFormLeafInfo &orig);
 
    // Data Members
-   TClass           *fClass;   //! This is the class of the data pointed to
-   //TStreamerInfo  *fInfo;    //! == fClass->GetStreamerInfo()
-   Long_t            fOffset;  //! Offset of the data pointed inside the class fClass
-   TStreamerElement *fElement; //! Descriptor of the data pointed to.
+   TClass           *fClass;   ///<! This is the class of the data pointed to
+   //TStreamerInfo  *fInfo;    ///<! == fClass->GetStreamerInfo()
+   Long_t            fOffset;  ///<! Offset of the data pointed inside the class fClass
+   TStreamerElement *fElement; ///<! Descriptor of the data pointed to.
          //Warning, the offset in fElement is NOT correct because it does not take into
          //account base classes and nested objects (which fOffset does).
    TFormLeafInfo    *fCounter;
-   TFormLeafInfo    *fNext;    // follow this to grab the inside information
+   TFormLeafInfo    *fNext;    ///< follow this to grab the inside information
    TString fClassName;
    TString fElementName;
 

--- a/tree/treeplayer/inc/TFormLeafInfoReference.h
+++ b/tree/treeplayer/inc/TFormLeafInfoReference.h
@@ -20,59 +20,59 @@ class TVirtualRefProxy;
 class TFormLeafInfoReference : public TFormLeafInfo {
    typedef TVirtualRefProxy Proxy;
 public:
-   Proxy*      fProxy;         //! Cached pointer to reference proxy
-   TBranch*    fBranch;        //! Cached pointer to branch object
+   Proxy*      fProxy;         ///<! Cached pointer to reference proxy
+   TBranch*    fBranch;        ///<! Cached pointer to branch object
 public:
-   // Initializing constructor
+   /// Initializing constructor
    TFormLeafInfoReference(TClass* classptr, TStreamerElement* element, int off);
-   // Copy constructor
+   /// Copy constructor
    TFormLeafInfoReference(const TFormLeafInfoReference& orig);
-   // Default destructor
+   /// Default destructor
    virtual ~TFormLeafInfoReference();
-   // Exception safe swap.
+   /// Exception safe swap.
    void Swap(TFormLeafInfoReference &other);
-   // Exception safe assignment operator.
+   /// Exception safe assignment operator.
    TFormLeafInfoReference &operator=(const TFormLeafInfoReference &orig);
-   // Virtual copy constructor
+   /// Virtual copy constructor
    virtual TFormLeafInfo* DeepCopy()  const;
 
-   // Access to the info's proxy
+   /// Access to the info's proxy
    Proxy*           GetProxy()        const      {  return fProxy;        }
-   // Access to the info's connected branch
+   /// Access to the info's connected branch
    TBranch*         GetBranch()       const      {  return fBranch;       }
-   // Access to the info's connected branch
+   /// Access to the info's connected branch
    void             SetBranch(TBranch* branch)
    {  fBranch = branch; if ( fNext ) fNext->SetBranch(branch);            }
-   // Access to the offset of the data
+   /// Access to the offset of the data
    virtual Int_t    GetOffset()       const     {  return fOffset;       }
-   // Return true only if the underlying data is an integral value
+   /// Return true only if the underlying data is an integral value
    virtual Bool_t   IsInteger()       const     {  return kFALSE;         }
-   // Return true only if the underlying data is a string
+   /// Return true only if the underlying data is a string
    virtual Bool_t   IsString()        const     {  return kFALSE;         }
-   // Return true only if the underlying data is a reference
+   /// Return true only if the underlying data is a reference
    virtual Bool_t   IsReference()     const     {  return kTRUE;          }
-   // Access to target class pointer (if available)
+   /// Access to target class pointer (if available)
    virtual TClass*  GetClass()        const;
-   // Access to the value class of the reference proxy
+   /// Access to the value class of the reference proxy
    virtual TClass*  GetValueClass(TLeaf* from);
-   // Access to the value class from the object pointer
+   /// Access to the value class from the object pointer
    virtual TClass*  GetValueClass(void* from);
-   // Return the address of the local value
+   /// Return the address of the local value
    virtual void    *GetLocalValuePointer( TLeaf *from, Int_t instance = 0);
-   // Return the address of the local value
+   /// Return the address of the local value
    virtual void    *GetLocalValuePointer(char *from, Int_t instance = 0);
-   // Return true if any of underlying data has a array size counter
+   /// Return true if any of underlying data has a array size counter
    virtual Bool_t HasCounter() const;
-   // Return the size of the underlying array for the current entry in the TTree.
+   /// Return the size of the underlying array for the current entry in the TTree.
    virtual Int_t ReadCounterValue(char *where);
-   // Return the current size of the array container
+   /// Return the current size of the array container
    virtual Int_t GetCounterValue(TLeaf* leaf);
 
-   // Access value of referenced object (macro from TFormLeafInfo.g)
+   /// Access value of referenced object (macro from TFormLeafInfo.g)
    DECLARE_GETVAL;
-   // Read value of referenced object
+   /// Read value of referenced object
    DECLARE_READVAL;
-   // TFormLeafInfo overload: Update (and propagate) cached information
+   /// TFormLeafInfo overload: Update (and propagate) cached information
    virtual Bool_t   Update();
 };
 

--- a/tree/treeplayer/inc/TFriendProxy.h
+++ b/tree/treeplayer/inc/TFriendProxy.h
@@ -21,8 +21,8 @@ namespace Internal {
 
    class TFriendProxy {
    protected:
-      TBranchProxyDirector fDirector; // contain pointer to TTree and entry to be read
-      Int_t  fIndex; // Index of this tree in the list of friends
+      TBranchProxyDirector fDirector; ///< Contain pointer to TTree and entry to be read
+      Int_t  fIndex;                  ///< Index of this tree in the list of friends
 
    public:
       TFriendProxy();

--- a/tree/treeplayer/inc/TMPWorkerTree.h
+++ b/tree/treeplayer/inc/TMPWorkerTree.h
@@ -31,9 +31,7 @@
 #include <vector>
 
 class TMPWorkerTree : public TMPWorker {
-   /// \cond
-//   ClassDef(TMPWorkerTree, 0);
-   /// \endcond
+
 public:
    TMPWorkerTree();
    TMPWorkerTree(const std::vector<std::string> &fileNames, TEntryList *entries, const std::string &treeName,
@@ -126,7 +124,7 @@ private:
 };
 
 //////////////////////////////////////////////////////////////////////////
-/// Auxilliary templated functions
+/// Auxiliary templated functions
 /// If the user lambda returns a TH1F*, TTree*, TEventList*, we incur in the
 /// problem of that object being automatically owned by the current open file.
 /// For these three types, we call SetDirectory(nullptr) to detach the returned

--- a/tree/treeplayer/inc/TSelectorDraw.h
+++ b/tree/treeplayer/inc/TSelectorDraw.h
@@ -35,33 +35,33 @@ class TSelectorDraw : public TSelector {
 protected:
    enum EStatusBits { kWarn = BIT(12) };
 
-   TTree         *fTree;           //  Pointer to current Tree
-   TTreeFormula **fVar;            //![fDimension] Array of pointers to variables formula
-   TTreeFormula  *fSelect;         //  Pointer to selection formula
-   TTreeFormulaManager *fManager;  //  Pointer to the formula manager
-   TObject       *fTreeElist;      //  pointer to Tree Event list
-   TEntryListArray *fTreeElistArray;   //!  pointer to Tree Event list array
-   TH1           *fOldHistogram;   //! Pointer to previously used histogram
-   Int_t          fAction;         //! Action type
-   Long64_t       fDraw;           //! Last entry loop number when object was drawn
-   Int_t          fNfill;          //! Total number of histogram fills
-   Int_t          fMultiplicity;   //  Indicator of the variability of the size of entries
-   Int_t          fDimension;      //  Dimension of the current expression
-   Long64_t       fSelectedRows;   //  Number of selected entries
-   Long64_t       fOldEstimate;    //  value of Tree fEstimate when selector is called
-   Int_t          fForceRead;      //  Force Read flag
-   Int_t         *fNbins;          //![fDimension] Number of bins per dimension
-   Double_t      *fVmin;           //![fDimension] Minima of varexp columns
-   Double_t      *fVmax;           //![fDimension] Maxima of varexp columns
-   Double_t       fWeight;         //  Tree weight (see TTree::SetWeight)
-   Double_t     **fVal;            //![fSelectedRows][fDimension] Local buffer for the variables
+   TTree         *fTree;             ///<  Pointer to current Tree
+   TTreeFormula **fVar;              ///<![fDimension] Array of pointers to variables formula
+   TTreeFormula  *fSelect;           ///<  Pointer to selection formula
+   TTreeFormulaManager *fManager;    ///<  Pointer to the formula manager
+   TObject       *fTreeElist;        ///<  Pointer to Tree Event list
+   TEntryListArray *fTreeElistArray; ///<! Pointer to Tree Event list array
+   TH1           *fOldHistogram;     ///<! Pointer to previously used histogram
+   Int_t          fAction;           ///<! Action type
+   Long64_t       fDraw;             ///<! Last entry loop number when object was drawn
+   Int_t          fNfill;            ///<! Total number of histogram fills
+   Int_t          fMultiplicity;     ///<  Indicator of the variability of the size of entries
+   Int_t          fDimension;        ///<  Dimension of the current expression
+   Long64_t       fSelectedRows;     ///<  Number of selected entries
+   Long64_t       fOldEstimate;      ///<  Value of Tree fEstimate when selector is called
+   Int_t          fForceRead;        ///<  Force Read flag
+   Int_t         *fNbins;            ///<![fDimension] Number of bins per dimension
+   Double_t      *fVmin;             ///<![fDimension] Minima of varexp columns
+   Double_t      *fVmax;             ///<![fDimension] Maxima of varexp columns
+   Double_t       fWeight;           ///<  Tree weight (see TTree::SetWeight)
+   Double_t     **fVal;              ///<![fSelectedRows][fDimension] Local buffer for the variables
    Int_t          fValSize;
-   Double_t      *fW;              //![fSelectedRows]Local buffer for weights
-   Bool_t        *fVarMultiple;    //![fDimension] true if fVar[i] has a variable index
-   Bool_t         fSelectMultiple; //  true if selection has a variable index
-   Bool_t         fCleanElist;     //  true if original Tree elist must be saved
-   Bool_t         fObjEval;        //  true if fVar1 returns an object (or pointer to).
-   Long64_t       fCurrentSubEntry; // Current subentry when fSelectMultiple is true. Used to fill TEntryListArray
+   Double_t      *fW;                ///<![fSelectedRows]Local buffer for weights
+   Bool_t        *fVarMultiple;      ///<![fDimension] True if fVar[i] has a variable index
+   Bool_t         fSelectMultiple;   ///<  True if selection has a variable index
+   Bool_t         fCleanElist;       ///<  True if original Tree elist must be saved
+   Bool_t         fObjEval;          ///<  True if fVar1 returns an object (or pointer to).
+   Long64_t       fCurrentSubEntry;  ///<  Current subentry when fSelectMultiple is true. Used to fill TEntryListArray
 
 protected:
    virtual void      ClearFormula();
@@ -89,22 +89,22 @@ public:
    virtual Long64_t  GetSelectedRows() const {return fSelectedRows;}
    TTree            *GetTree() const {return fTree;}
    TTreeFormula     *GetVar(Int_t i) const;
-   // See TSelectorDraw::GetVar
+   /// See TSelectorDraw::GetVar
    TTreeFormula     *GetVar1() const {return GetVar(0);}
-   // See TSelectorDraw::GetVar
+   /// See TSelectorDraw::GetVar
    TTreeFormula     *GetVar2() const {return GetVar(1);}
-   // See TSelectorDraw::GetVar
+   /// See TSelectorDraw::GetVar
    TTreeFormula     *GetVar3() const {return GetVar(2);}
-   // See TSelectorDraw::GetVar
+   /// See TSelectorDraw::GetVar
    TTreeFormula     *GetVar4() const {return GetVar(3);}
    virtual Double_t *GetVal(Int_t i) const;
-   // See TSelectorDraw::GetVal
+   /// See TSelectorDraw::GetVal
    virtual Double_t *GetV1() const   {return GetVal(0);}
-   // See TSelectorDraw::GetVal
+   /// See TSelectorDraw::GetVal
    virtual Double_t *GetV2() const   {return GetVal(1);}
-   // See TSelectorDraw::GetVal
+   /// See TSelectorDraw::GetVal
    virtual Double_t *GetV3() const   {return GetVal(2);}
-   // See TSelectorDraw::GetVal
+   /// See TSelectorDraw::GetVal
    virtual Double_t *GetV4() const   {return GetVal(3);}
    virtual Double_t *GetW() const    {return fW;}
    virtual Bool_t    Notify();

--- a/tree/treeplayer/inc/TSelectorEntries.h
+++ b/tree/treeplayer/inc/TSelectorEntries.h
@@ -20,7 +20,7 @@
 // The selection is passed either via the constructor or via            //
 // SetSelection.  The number of entries passing the selection (or       //
 // at least one element of the arrays or collections used in the        //
-// selection is passing the slection) is stored in fSeletedRwos         //
+// selection is passing the selection) is stored in fSeletedRwos        //
 // which can be retrieved via GetSelectedRows.                          //
 // See a usage example in TTreePlayer::GetEntries.                      //
 //                                                                      //
@@ -32,12 +32,12 @@ class TTree;
 class TTreeFormula;
 
 class TSelectorEntries : public TSelector {
-   Bool_t          fOwnInput;       // true if we created the input list.
+   Bool_t          fOwnInput;       ///<  True if we created the input list.
 public :
-   TTree          *fChain;          //! pointer to the analyzed TTree or TChain
-   TTreeFormula   *fSelect;         //  Pointer to selection formula
-   Long64_t        fSelectedRows;   //  Number of selected entries
-   Bool_t          fSelectMultiple; //  true if selection has a variable index
+   TTree          *fChain;          ///<! Pointer to the analyzed TTree or TChain
+   TTreeFormula   *fSelect;         ///<  Pointer to selection formula
+   Long64_t        fSelectedRows;   ///<  Number of selected entries
+   Bool_t          fSelectMultiple; ///<  True if selection has a variable index
 
    TSelectorEntries(TTree *tree = 0, const char *selection = 0);
    TSelectorEntries(const char *selection);

--- a/tree/treeplayer/inc/TSimpleAnalysis.h
+++ b/tree/treeplayer/inc/TSimpleAnalysis.h
@@ -36,19 +36,19 @@ private:
    std::string              fConfigFile; ///< Name of the configuration file
    std::vector<std::string> fInputFiles; ///< .root input files
    std::string              fOutputFile; ///< Output file in which are stored the histograms
-   std::string              fTreeName; ///< Name of the input tree
-   std::ifstream            fIn; ///< Stream for the input file
+   std::string              fTreeName;   ///< Name of the input tree
+   std::ifstream            fIn;         ///< Stream for the input file
 
-   //The map contains in the first part the names of the histograms written in the output file, in the
-   //second part the pair of what is shown in the histograms and the cut applied on the variables
+   /// The map contains in the first part the names of the histograms written in the output file, in the
+   /// second part the pair of what is shown in the histograms and the cut applied on the variables
    std::map<std::string, std::pair<std::string, std::string>> fHists;
 
-   //The elements of the enumeration refer to the different types of elements
-   //that are in the input file
+   /// The elements of the enumeration refer to the different types of elements
+   /// that are in the input file
    enum EReadingWhat {
-      kReadingOutput, ///< Reading the name of the output file
-      kReadingTreeName, ///< Reading the name of the tree
-      kReadingInput, ///< Reading the name of the .root input files
+      kReadingOutput,     ///< Reading the name of the output file
+      kReadingTreeName,   ///< Reading the name of the tree
+      kReadingInput,      ///< Reading the name of the .root input files
       kReadingExpressions ///< Reading the expressions
    };
 

--- a/tree/treeplayer/inc/TTreeDrawArgsParser.h
+++ b/tree/treeplayer/inc/TTreeDrawArgsParser.h
@@ -44,32 +44,32 @@ public:
       kHISTOGRAM3D
    };
 
-   static Int_t   fgMaxDimension;      // = 4
-   static Int_t   fgMaxParameters;     // = 9
+   static Int_t   fgMaxDimension;     ///< = 4
+   static Int_t   fgMaxParameters;    ///< = 9
 
 protected:
-   TString        fExp;        // complete variable expression
-   TString        fSelection;  // selection expression
-   TString        fOption;     // draw options
+   TString        fExp;               ///< Complete variable expression
+   TString        fSelection;         ///< Selection expression
+   TString        fOption;            ///< Draw options
 
-   Int_t          fDimension;  // dimension of the histogram/plot
-   TString        fVarExp[4];  // variable expression 0 - X, 1 - Y, 2 - Z, 3 - W
-                              // if dimension < fgMaxDimension then some
-                              // expressions are empty
+   Int_t          fDimension;         ///< Dimension of the histogram/plot
+   TString        fVarExp[4];         ///< Variable expression 0 - X, 1 - Y, 2 - Z, 3 - W
+                                      ///< If dimension < fgMaxDimension then some
+                                      ///< Expressions are empty
 
-   Bool_t         fAdd;        // values should be added to an existing object
-   TString        fName;       // histogram's/plot's name
+   Bool_t         fAdd;               ///< Values should be added to an existing object
+   TString        fName;              ///< Histogram's/plot's name
 
-   Int_t          fNoParameters;      // if dimensions of the plot was specified
-   Bool_t         fParameterGiven[9]; // true if the parameter was given, otherwise false
-   Double_t       fParameters[9];     // parameters in brackets
+   Int_t          fNoParameters;      ///< If dimensions of the plot was specified
+   Bool_t         fParameterGiven[9]; ///< True if the parameter was given, otherwise false
+   Double_t       fParameters[9];     ///< Parameters in brackets
 
-   Bool_t         fShouldDraw;        // if to draw the plot
-   Bool_t         fOptionSame;        // if option contained "same"
-   Bool_t         fEntryList;         // if fill a TEntryList
-   TObject       *fOriginal;          // original plot (if it is to be reused)
-   Bool_t         fDrawProfile;       // true if the options contain :"prof"
-   EOutputType    fOutputType;        // type of the output
+   Bool_t         fShouldDraw;        ///< If to draw the plot
+   Bool_t         fOptionSame;        ///< If option contained "same"
+   Bool_t         fEntryList;         ///< If fill a TEntryList
+   TObject       *fOriginal;          ///< Original plot (if it is to be reused)
+   Bool_t         fDrawProfile;       ///< True if the options contain :"prof"
+   EOutputType    fOutputType;        ///< Type of the output
 
    void           ClearPrevious();
    TTreeDrawArgsParser::EOutputType DefineType();

--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -92,44 +92,44 @@ protected:
       Int_t fVirtAccumCache = 0;
    };
 
-   TTree      *fTree;             //! pointer to Tree
-   Int_t       fCodes[kMAXCODES]; //  List of leaf numbers referenced in formula
-   Int_t       fNdata[kMAXCODES]; //! This caches the physical number of element in the leaf or data member.
-   Int_t       fNcodes;           //  Number of leaves referenced in formula
-   Bool_t      fHasCast;          //  Record whether the formula contain a cast operation or not
-   Int_t       fMultiplicity;     //  Indicator of the variability of the formula
-   Int_t       fNindex;           //  Size of fIndex
-   Int_t      *fLookupType;       //[fNindex] array indicating how each leaf should be looked-up
-   TObjArray   fLeaves;           //!  List of leaf used in this formula.
-   TObjArray   fDataMembers;      //!  List of leaf data members
-   TObjArray   fMethods;          //!  List of leaf method calls
-   TObjArray   fExternalCuts;     //!  List of TCutG and TEntryList used in the formula
-   TObjArray   fAliases;          //!  List of TTreeFormula for each alias used.
-   TObjArray   fLeafNames;        //   List of TNamed describing leaves
-   TObjArray   fBranches;         //!  List of branches to read.  Similar to fLeaves but duplicates are zeroed out.
-   Bool_t      fQuickLoad;        //!  If true, branch GetEntry is only called when the entry number changes.
-   Bool_t      fNeedLoading;      //!  If true, the current entry has not been loaded yet.
+   TTree      *fTree;             ///<! Pointer to Tree
+   Int_t       fCodes[kMAXCODES]; ///<  List of leaf numbers referenced in formula
+   Int_t       fNdata[kMAXCODES]; ///<! This caches the physical number of element in the leaf or data member.
+   Int_t       fNcodes;           ///<  Number of leaves referenced in formula
+   Bool_t      fHasCast;          ///<  Record whether the formula contain a cast operation or not
+   Int_t       fMultiplicity;     ///<  Indicator of the variability of the formula
+   Int_t       fNindex;           ///<  Size of fIndex
+   Int_t      *fLookupType;       ///<[fNindex] Array indicating how each leaf should be looked-up
+   TObjArray   fLeaves;           ///<!  List of leaf used in this formula.
+   TObjArray   fDataMembers;      ///<!  List of leaf data members
+   TObjArray   fMethods;          ///<!  List of leaf method calls
+   TObjArray   fExternalCuts;     ///<!  List of TCutG and TEntryList used in the formula
+   TObjArray   fAliases;          ///<!  List of TTreeFormula for each alias used.
+   TObjArray   fLeafNames;        ///<   List of TNamed describing leaves
+   TObjArray   fBranches;         ///<!  List of branches to read.  Similar to fLeaves but duplicates are zeroed out.
+   Bool_t      fQuickLoad;        ///<!  If true, branch GetEntry is only called when the entry number changes.
+   Bool_t      fNeedLoading;      ///<!  If true, the current entry has not been loaded yet.
 
-   Int_t       fNdimensions[kMAXCODES];              //Number of array dimensions in each leaf
-   Int_t       fFixedSizes[kMAXCODES][kMAXFORMDIM];  //Physical sizes of lower dimensions for each leaf
-   UChar_t     fHasMultipleVarDim[kMAXCODES];        //True if the corresponding variable is an array with more than one variable dimension.
+   Int_t       fNdimensions[kMAXCODES];               ///< Number of array dimensions in each leaf
+   Int_t       fFixedSizes[kMAXCODES][kMAXFORMDIM];   ///< Physical sizes of lower dimensions for each leaf
+   UChar_t     fHasMultipleVarDim[kMAXCODES];         ///< True if the corresponding variable is an array with more than one variable dimension.
 
    //the next line should have a mutable in front. See GetNdata()
-   Int_t       fCumulSizes[kMAXCODES][kMAXFORMDIM];  //Accumulated sizes of lower dimensions for each leaf after variable dimensions has been calculated
-   Int_t       fIndexes[kMAXCODES][kMAXFORMDIM];     //Index of array selected by user for each leaf
-   TTreeFormula *fVarIndexes[kMAXCODES][kMAXFORMDIM];  //Pointer to a variable index.
+   Int_t       fCumulSizes[kMAXCODES][kMAXFORMDIM];   ///< Accumulated sizes of lower dimensions for each leaf after variable dimensions has been calculated
+   Int_t       fIndexes[kMAXCODES][kMAXFORMDIM];      ///< Index of array selected by user for each leaf
+   TTreeFormula *fVarIndexes[kMAXCODES][kMAXFORMDIM]; ///< Pointer to a variable index.
 
-   TAxis                    *fAxis;           //! pointer to histogram axis if this is a string
-   Bool_t                    fDidBooleanOptimization;  //! True if we executed one boolean optimization since the last time instance number 0 was evaluated
-   TTreeFormulaManager      *fManager;        //! The dimension coordinator.
+   TAxis                    *fAxis;                   ///<! pointer to histogram axis if this is a string
+   Bool_t                    fDidBooleanOptimization; ///<! True if we executed one boolean optimization since the last time instance number 0 was evaluated
+   TTreeFormulaManager      *fManager;                ///<! The dimension coordinator.
 
    // Helper members and function used during the construction and parsing
-   TList                    *fDimensionSetup; //! list of dimension setups, for delayed creation of the dimension information.
-   std::vector<std::string>  fAliasesUsed;    //! List of aliases used during the parsing of the expression.
+   TList                    *fDimensionSetup;         ///<! list of dimension setups, for delayed creation of the dimension information.
+   std::vector<std::string>  fAliasesUsed;            ///<! List of aliases used during the parsing of the expression.
 
-   LongDouble_t*        fConstLD;   //! local version of fConsts able to store bigger numbers
+   LongDouble_t*        fConstLD;                     ///<! local version of fConsts able to store bigger numbers
 
-   RealInstanceCache fRealInstanceCache; //! Cache accelerating the GetRealInstance function
+   RealInstanceCache fRealInstanceCache;              ///<! Cache accelerating the GetRealInstance function
 
    TTreeFormula(const char *name, const char *formula, TTree *tree, const std::vector<std::string>& aliases);
    void Init(const char *name, const char *formula);

--- a/tree/treeplayer/inc/TTreeFormulaManager.h
+++ b/tree/treeplayer/inc/TTreeFormulaManager.h
@@ -30,17 +30,17 @@ class TArrayI;
 class TTreeFormulaManager : public TObject {
 private:
    TObjArray   fFormulas;
-   Int_t       fMultiplicity;     // Indicator of the variability of the formula
-   Bool_t      fMultiVarDim;      // True if one of the variable has 2 variable size dimensions.
-   Int_t       fNdata;            //! Last value calculated by GetNdata
+   Int_t       fMultiplicity;     ///< Indicator of the variability of the formula
+   Bool_t      fMultiVarDim;      ///< True if one of the variable has 2 variable size dimensions.
+   Int_t       fNdata;            ///<! Last value calculated by GetNdata
 
    //the next line should be: mutable Int_t fCumulUsedSizes[kMAXFORMDIM+1]; See GetNdata()
-   Int_t       fCumulUsedSizes[kMAXFORMDIM+1];      //Accumulated size of lower dimensions as seen for this entry
-   TArrayI    *fCumulUsedVarDims;                   //fCumulUsedSizes(1) for multi variable dimensions case
+   Int_t       fCumulUsedSizes[kMAXFORMDIM+1];      ///< Accumulated size of lower dimensions as seen for this entry
+   TArrayI    *fCumulUsedVarDims;                   ///< fCumulUsedSizes(1) for multi variable dimensions case
    //the next line should be: mutable Int_t fUsedSizes[kMAXFORMDIM+1]; See GetNdata()
-   Int_t       fUsedSizes[kMAXFORMDIM+1];           //Actual size of the dimensions as seen for this entry.
-   TArrayI    *fVarDims[kMAXFORMDIM+1];             //List of variable sizes dimensions.
-   Int_t       fVirtUsedSizes[kMAXFORMDIM+1];       //Virtual size of lower dimensions as seen for this formula
+   Int_t       fUsedSizes[kMAXFORMDIM+1];           ///< Actual size of the dimensions as seen for this entry.
+   TArrayI    *fVarDims[kMAXFORMDIM+1];             ///< List of variable sizes dimensions.
+   Int_t       fVirtUsedSizes[kMAXFORMDIM+1];       ///< Virtual size of lower dimensions as seen for this formula
 
    Bool_t      fNeedSync;         // Indicate whether a new formula has been added since the last synchronization
 

--- a/tree/treeplayer/inc/TTreeGeneratorBase.h
+++ b/tree/treeplayer/inc/TTreeGeneratorBase.h
@@ -35,9 +35,9 @@ namespace ROOT {
 namespace Internal {
    class TTreeGeneratorBase {
       public:
-         TList    fListOfHeaders;     // List of included headers
-         TTree   *fTree;              // Pointer to the tree
-         TString  fOptionStr;         // User options as a string
+         TList    fListOfHeaders;     ///< List of included headers
+         TTree   *fTree;              ///< Pointer to the tree
+         TString  fOptionStr;         ///< User options as a string
 
          TTreeGeneratorBase(TTree *tree, const char *option);
 

--- a/tree/treeplayer/inc/TTreeIndex.h
+++ b/tree/treeplayer/inc/TTreeIndex.h
@@ -29,16 +29,16 @@ class TTreeFormula;
 class TTreeIndex : public TVirtualIndex {
 
 protected:
-   TString        fMajorName;           // Index major name
-   TString        fMinorName;           // Index minor name
-   Long64_t       fN;                   // Number of entries
-   Long64_t      *fIndexValues;         //[fN] Sorted index values, higher 64bits
-   Long64_t      *fIndexValuesMinor;    //[fN] Sorted index values, lower 64bits
-   Long64_t      *fIndex;               //[fN] Index of sorted values
-   TTreeFormula  *fMajorFormula;        //! Pointer to major TreeFormula
-   TTreeFormula  *fMinorFormula;        //! Pointer to minor TreeFormula
-   TTreeFormula  *fMajorFormulaParent;  //! Pointer to major TreeFormula in Parent tree (if any)
-   TTreeFormula  *fMinorFormulaParent;  //! Pointer to minor TreeFormula in Parent tree (if any)
+   TString        fMajorName;           ///< Index major name
+   TString        fMinorName;           ///< Index minor name
+   Long64_t       fN;                   ///< Number of entries
+   Long64_t      *fIndexValues;         ///<[fN] Sorted index values, higher 64bits
+   Long64_t      *fIndexValuesMinor;    ///<[fN] Sorted index values, lower 64bits
+   Long64_t      *fIndex;               ///<[fN] Index of sorted values
+   TTreeFormula  *fMajorFormula;        ///<! Pointer to major TreeFormula
+   TTreeFormula  *fMinorFormula;        ///<! Pointer to minor TreeFormula
+   TTreeFormula  *fMajorFormulaParent;  ///<! Pointer to major TreeFormula in Parent tree (if any)
+   TTreeFormula  *fMinorFormulaParent;  ///<! Pointer to minor TreeFormula in Parent tree (if any)
 
    TTreeFormula  *GetMajorFormulaParent(const TTree *parent);
    TTreeFormula  *GetMinorFormulaParent(const TTree *parent);

--- a/tree/treeplayer/inc/TTreePerfStats.h
+++ b/tree/treeplayer/inc/TTreePerfStats.h
@@ -39,39 +39,39 @@ class TTreePerfStats : public TVirtualPerfStats {
 
 public:
    struct BasketInfo {
-      UInt_t fUsed = {0};       // Number of times the basket was requested from the disk.
-      UInt_t fLoaded = {0};     // Number of times the basket was put in the primary TTreeCache
-      UInt_t fLoadedMiss = {0}; // Number of times the basket was put in the secondary cache
-      UInt_t fMissed = {0};     // Number of times the basket was read directly from the file.
+      UInt_t fUsed = {0};        ///<  Number of times the basket was requested from the disk.
+      UInt_t fLoaded = {0};      ///<  Number of times the basket was put in the primary TTreeCache
+      UInt_t fLoadedMiss = {0};  ///<  Number of times the basket was put in the secondary cache
+      UInt_t fMissed = {0};      ///<  Number of times the basket was read directly from the file.
    };
 
    using BasketList_t = std::vector<std::pair<TBranch*, std::vector<size_t>>>;
 
 protected:
-   Int_t         fTreeCacheSize; //TTreeCache buffer size
-   Int_t         fNleaves;       //Number of leaves in the tree
-   Int_t         fReadCalls;     //Number of read calls
-   Int_t         fReadaheadSize; //Readahead cache size
-   Long64_t      fBytesRead;     //Number of bytes read
-   Long64_t      fBytesReadExtra;//Number of bytes (overhead) of the readahead cache
-   Double_t      fRealNorm;      //Real time scale factor for fGraphTime
-   Double_t      fRealTime;      //Real time
-   Double_t      fCpuTime;       //Cpu time
-   Double_t      fDiskTime;      //Time spent in pure raw disk IO
-   Double_t      fUnzipTime;     //Time spent uncompressing the data.
-   Long64_t      fUnzipInputSize;//Compressed bytes seen by the decompressor.
-   Long64_t      fUnzipObjSize;  //Uncompressed bytes produced by the decompressor.
-   Double_t      fCompress;      //Tree compression factor
-   TString       fName;          //name of this TTreePerfStats
-   TString       fHostInfo;      //name of the host system, ROOT version and date
-   TFile        *fFile;          //!pointer to the file containing the Tree
-   TTree        *fTree;          //!pointer to the Tree being monitored
-   TGraphErrors *fGraphIO ;      //pointer to the graph with IO data
-   TGraphErrors *fGraphTime ;    //pointer to the graph with timestamp info
-   TPaveText    *fPave;          //pointer to annotation pavetext
-   TStopwatch   *fWatch;         //TStopwatch pointer
-   TGaxis       *fRealTimeAxis;  //pointer to TGaxis object showing real-time
-   TText        *fHostInfoText;  //Graphics Text object with the fHostInfo data
+   Int_t         fTreeCacheSize; ///<  TTreeCache buffer size
+   Int_t         fNleaves;       ///<  Number of leaves in the tree
+   Int_t         fReadCalls;     ///<  Number of read calls
+   Int_t         fReadaheadSize; ///<  Read-ahead cache size
+   Long64_t      fBytesRead;     ///<  Number of bytes read
+   Long64_t      fBytesReadExtra;///<  Number of bytes (overhead) of the read-ahead cache
+   Double_t      fRealNorm;      ///<  Real time scale factor for fGraphTime
+   Double_t      fRealTime;      ///<  Real time
+   Double_t      fCpuTime;       ///<  Cpu time
+   Double_t      fDiskTime;      ///<  Time spent in pure raw disk IO
+   Double_t      fUnzipTime;     ///<  Time spent uncompressing the data.
+   Long64_t      fUnzipInputSize;///<  Compressed bytes seen by the decompressor.
+   Long64_t      fUnzipObjSize;  ///<  Uncompressed bytes produced by the decompressor.
+   Double_t      fCompress;      ///<  Tree compression factor
+   TString       fName;          ///<  Name of this TTreePerfStats
+   TString       fHostInfo;      ///<  Name of the host system, ROOT version and date
+   TFile        *fFile;          ///<! Pointer to the file containing the Tree
+   TTree        *fTree;          ///<! Pointer to the Tree being monitored
+   TGraphErrors *fGraphIO ;      ///<  Pointer to the graph with IO data
+   TGraphErrors *fGraphTime ;    ///<  Pointer to the graph with timestamp info
+   TPaveText    *fPave;          ///<  Pointer to annotation pavetext
+   TStopwatch   *fWatch;         ///<  TStopwatch pointer
+   TGaxis       *fRealTimeAxis;  ///<  Pointer to TGaxis object showing real-time
+   TText        *fHostInfoText;  ///<  Graphics Text object with the fHostInfo data
 
    std::unordered_map<TBranch*, size_t>  fBranchIndexCache; // Cache the index of the branch in the cache's array.
    std::vector<std::vector<BasketInfo> > fBasketsInfo;      // Details on which baskets was used, cached, 'miss-cached' or read uncached.Browse

--- a/tree/treeplayer/inc/TTreePlayer.h
+++ b/tree/treeplayer/inc/TTreePlayer.h
@@ -41,18 +41,18 @@ private:
    TTreePlayer& operator=(const TTreePlayer &) = delete;
 
 protected:
-   TTree         *fTree;            //!  Pointer to current Tree
-   Bool_t         fScanRedirect;    //  Switch to redirect TTree::Scan output to a file
-   const char    *fScanFileName;    //  Name of the file where Scan is redirected
-   Int_t          fDimension;       //  Dimension of the current expression
-   Long64_t       fSelectedRows;    //  Number of selected entries
-   TH1           *fHistogram;       //! Pointer to histogram used for the projection
-   TSelectorDraw *fSelector;        //! Pointer to current selector
-   TSelector     *fSelectorFromFile;//! Pointer to a user defined selector created by this TTreePlayer object
-   TClass        *fSelectorClass;   //! Pointer to the actual class of the TSelectorFromFile
-   TList         *fInput;           //! input list to the selector
-   TList         *fFormulaList;     //! Pointer to a list of coordinated list TTreeFormula (used by Scan and Query)
-   TSelector     *fSelectorUpdate;  //! Set to the selector address when it's entry list needs to be updated by the UpdateFormulaLeaves function
+   TTree         *fTree;            ///<! Pointer to current Tree
+   Bool_t         fScanRedirect;    ///<  Switch to redirect TTree::Scan output to a file
+   const char    *fScanFileName;    ///<  Name of the file where Scan is redirected
+   Int_t          fDimension;       ///<  Dimension of the current expression
+   Long64_t       fSelectedRows;    ///<  Number of selected entries
+   TH1           *fHistogram;       ///<! Pointer to histogram used for the projection
+   TSelectorDraw *fSelector;        ///<! Pointer to current selector
+   TSelector     *fSelectorFromFile;///<! Pointer to a user defined selector created by this TTreePlayer object
+   TClass        *fSelectorClass;   ///<! Pointer to the actual class of the TSelectorFromFile
+   TList         *fInput;           ///<! input list to the selector
+   TList         *fFormulaList;     ///<! Pointer to a list of coordinated list TTreeFormula (used by Scan and Query)
+   TSelector     *fSelectorUpdate;  ///<! Set to the selector address when it's entry list needs to be updated by the UpdateFormulaLeaves function
 
 protected:
    const   char  *GetNameByIndex(TString &varexp, Int_t *index,Int_t colindex);
@@ -81,25 +81,25 @@ public:
    virtual Long64_t  GetSelectedRows() const {return fSelectedRows;}
    virtual TSelector *GetSelector() const {return fSelector;}
    virtual TSelector *GetSelectorFromFile() const {return fSelectorFromFile;}
-   // See TSelectorDraw::GetVar
+   /// See TSelectorDraw::GetVar
    TTreeFormula     *GetVar(Int_t i) const {return fSelector->GetVar(i);};
-   // See TSelectorDraw::GetVar
+   /// See TSelectorDraw::GetVar
    TTreeFormula     *GetVar1() const {return fSelector->GetVar1();}
-   // See TSelectorDraw::GetVar
+   /// See TSelectorDraw::GetVar
    TTreeFormula     *GetVar2() const {return fSelector->GetVar2();}
-   // See TSelectorDraw::GetVar
+   /// See TSelectorDraw::GetVar
    TTreeFormula     *GetVar3() const {return fSelector->GetVar3();}
-   // See TSelectorDraw::GetVar
+   /// See TSelectorDraw::GetVar
    TTreeFormula     *GetVar4() const {return fSelector->GetVar4();}
-   // See TSelectorDraw::GetVal
+   /// See TSelectorDraw::GetVal
    virtual Double_t *GetVal(Int_t i) const {return fSelector->GetVal(i);};
-   // See TSelectorDraw::GetVal
+   /// See TSelectorDraw::GetVal
    virtual Double_t *GetV1() const   {return fSelector->GetV1();}
-   // See TSelectorDraw::GetVal
+   /// See TSelectorDraw::GetVal
    virtual Double_t *GetV2() const   {return fSelector->GetV2();}
-   // See TSelectorDraw::GetVal
+   /// See TSelectorDraw::GetVal
    virtual Double_t *GetV3() const   {return fSelector->GetV3();}
-   // See TSelectorDraw::GetVal
+   /// See TSelectorDraw::GetVal
    virtual Double_t *GetV4() const   {return fSelector->GetV4();}
    virtual Double_t *GetW() const    {return fSelector->GetW();}
    virtual Int_t     MakeClass(const char *classname, Option_t *option);

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -98,7 +98,7 @@ public:
             this->operator*();
             // Don't set the old entry: op* will if needed, and
             // in most cases it just adds a lot of spinning back
-            // and forth: in most cases teh sequence is ++i; *i.
+            // and forth: in most cases the sequence is ++i; *i.
          }
          return *this;
       }

--- a/tree/treeplayer/inc/TTreeReaderGenerator.h
+++ b/tree/treeplayer/inc/TTreeReaderGenerator.h
@@ -33,17 +33,17 @@ class TLeaf;
 namespace ROOT {
 namespace Internal {
 
-   // 0 for the general case, 1 when this a split clases inside a TClonesArray,
-   // 2 when this is a split classes inside an STL container.
+   /// 0 for the general case, 1 when this a split clases inside a TClonesArray,
+   /// 2 when this is a split classes inside an STL container.
    enum ELocation { kOut=0, kClones, kSTL };
 
    class TTreeReaderDescriptor : public TObject {
    public:
       enum ReaderType { kValue, kArray };
-      ReaderType fType;    // Type of the reader: Value or Array
-      TString fDataType;   // Data type of reader
-      TString fName;       // Reader name
-      TString fBranchName; // Branch corresponding to the reader
+      ReaderType fType;    ///< Type of the reader: Value or Array
+      TString fDataType;   ///< Data type of reader
+      TString fName;       ///< Reader name
+      TString fBranchName; ///< Branch corresponding to the reader
 
       TTreeReaderDescriptor(ReaderType type, TString dataType, TString name, TString branchName) :
          fType(type),
@@ -54,12 +54,12 @@ namespace Internal {
 
    class TBranchDescriptor : public TNamed {
    public:
-      ELocation             fIsClones;       // Type of container
-      TString               fContainerName;  // Name of the container
-      TString               fBranchName;     // Name of the branch
-      TString               fSubBranchPrefix;// Prefix (e.g. if the branch name is "A." the prefix is "A"
-      TVirtualStreamerInfo *fInfo;           // Streamer info
-      TBranchDescriptor    *fParent;         // Descriptor of the parent branch (NULL for topmost)
+      ELocation             fIsClones;       ///< Type of container
+      TString               fContainerName;  ///< Name of the container
+      TString               fBranchName;     ///< Name of the branch
+      TString               fSubBranchPrefix;///< Prefix (e.g. if the branch name is "A." the prefix is "A"
+      TVirtualStreamerInfo *fInfo;           ///< Streamer info
+      TBranchDescriptor    *fParent;         ///< Descriptor of the parent branch (NULL for topmost)
 
       TBranchDescriptor(const char *type, TVirtualStreamerInfo *info,
                         const char *branchname, const char *subBranchPrefix, ELocation isclones,
@@ -84,12 +84,12 @@ namespace Internal {
 
    class TTreeReaderGenerator : public TTreeGeneratorBase
    {
-      TString               fClassname;         // Class name of the selector
-      TList                 fListOfReaders;     // List of readers
-      Bool_t                fIncludeAllLeaves;  // Should all leaves be included
-      Bool_t                fIncludeAllTopmost; // Should all topmost branches be included
-      std::vector<TString>  fIncludeLeaves;     // Branches whose leaves should be included
-      std::vector<TString>  fIncludeStruct;     // Branches whom should be included
+      TString               fClassname;         ///< Class name of the selector
+      TList                 fListOfReaders;     ///< List of readers
+      Bool_t                fIncludeAllLeaves;  ///< Should all leaves be included
+      Bool_t                fIncludeAllTopmost; ///< Should all topmost branches be included
+      std::vector<TString>  fIncludeLeaves;     ///< Branches whose leaves should be included
+      std::vector<TString>  fIncludeStruct;     ///< Branches whom should be included
 
       void   AddReader(TTreeReaderDescriptor::ReaderType type, TString dataType, TString name,
                        TString branchName, TBranchDescriptor *parent = 0, Bool_t isLeaf = kTRUE);

--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -44,30 +44,30 @@ Base class of TTreeReaderValue.
    class TTreeReaderValueBase {
    public:
 
-      // Status flags, 0 is good
+      /// Status flags, 0 is good
       enum ESetupStatus {
-         kSetupNotSetup = -7, /// No initialization has happened yet.
-         kSetupTreeDestructed = -8, /// The TTreeReader has been destructed / not set.
-         kSetupMakeClassModeMismatch = -9, // readers disagree on whether TTree::SetMakeBranch() should be on
-         kSetupMissingCounterBranch = -6, /// The array cannot find its counter branch: Array[CounterBranch]
-         kSetupMissingBranch = -5, /// The specified branch cannot be found.
-         kSetupInternalError = -4, /// Some other error - hopefully the error message helps.
-         kSetupMissingDictionary = -3, /// To read this branch, we need a dictionary.
-         kSetupMismatch = -2, /// Mismatch of branch type and reader template type.
-         kSetupNotACollection = -1, /// The branch class type is not a collection.
-         kSetupMatch = 0, /// This branch has been set up, branch data type and reader template type match, reading should succeed.
-         kSetupMatchBranch = 7, /// This branch has been set up, branch data type and reader template type match, reading should succeed.
+         kSetupNotSetup = -7,              ///< No initialization has happened yet.
+         kSetupTreeDestructed = -8,        ///< The TTreeReader has been destructed / not set.
+         kSetupMakeClassModeMismatch = -9, ///< readers disagree on whether TTree::SetMakeBranch() should be on
+         kSetupMissingCounterBranch = -6,  ///< The array cannot find its counter branch: Array[CounterBranch]
+         kSetupMissingBranch = -5,         ///< The specified branch cannot be found.
+         kSetupInternalError = -4,         ///< Some other error - hopefully the error message helps.
+         kSetupMissingDictionary = -3,     ///< To read this branch, we need a dictionary.
+         kSetupMismatch = -2,              ///< Mismatch of branch type and reader template type.
+         kSetupNotACollection = -1,        ///< The branch class type is not a collection.
+         kSetupMatch = 0,                  ///< This branch has been set up, branch data type and reader template type match, reading should succeed.
+         kSetupMatchBranch = 7,            ///< This branch has been set up, branch data type and reader template type match, reading should succeed.
          //kSetupMatchConversion = 1, /// This branch has been set up, the branch data type can be converted to the reader template type, reading should succeed.
          //kSetupMatchConversionCollection = 2, /// This branch has been set up, the data type of the branch's collection elements can be converted to the reader template type, reading should succeed.
          //kSetupMakeClass = 3, /// This branch has been set up, enabling MakeClass mode for it, reading should succeed.
          // kSetupVoidPtr = 4,
          kSetupNoCheck = 5,
-         kSetupMatchLeaf = 6 /// This branch (or TLeaf, really) has been set up, reading should succeed.
+         kSetupMatchLeaf = 6               ///< This branch (or TLeaf, really) has been set up, reading should succeed.
       };
       enum EReadStatus {
-         kReadSuccess = 0, // data read okay
-         kReadNothingYet, // data now yet accessed
-         kReadError // problem reading data
+         kReadSuccess = 0,                 ///< Data read okay
+         kReadNothingYet,                  ///< Data now yet accessed
+         kReadError                        ///< Problem reading data
       };
 
       EReadStatus ProxyRead() { return (this->*fProxyReadFunc)(); }
@@ -118,15 +118,15 @@ Base class of TTreeReaderValue.
       /// Stringify the template argument.
       static std::string GetElementTypeName(const std::type_info& ti);
 
-      int          fHaveLeaf : 1; // Whether the data is in a leaf
-      int          fHaveStaticClassOffsets : 1; // Whether !fStaticClassOffsets.empty()
-      EReadStatus  fReadStatus : 2; // read status of this data access
-      ESetupStatus fSetupStatus = kSetupNotSetup; // setup status of this data access
-      TString      fBranchName; // name of the branch to read data from.
+      int          fHaveLeaf : 1;                 ///< Whether the data is in a leaf
+      int          fHaveStaticClassOffsets : 1;   ///< Whether !fStaticClassOffsets.empty()
+      EReadStatus  fReadStatus : 2;               ///< Read status of this data access
+      ESetupStatus fSetupStatus = kSetupNotSetup; ///< Setup status of this data access
+      TString      fBranchName;                   ///< Name of the branch to read data from.
       TString      fLeafName;
-      TTreeReader* fTreeReader; // tree reader we belong to
-      TDictionary* fDict; // type that the branch should contain
-      Detail::TBranchProxy* fProxy = nullptr; // proxy for this branch, owned by TTreeReader
+      TTreeReader* fTreeReader;                   ///< Tree reader we belong to
+      TDictionary* fDict;                         ///< Type that the branch should contain
+      Detail::TBranchProxy* fProxy = nullptr;     ///< Proxy for this branch, owned by TTreeReader
       TLeaf*       fLeaf = nullptr;
       std::vector<Long64_t> fStaticClassOffsets;
       typedef EReadStatus (TTreeReaderValueBase::*Read_t)();

--- a/tree/treeplayer/inc/TTreeTableInterface.h
+++ b/tree/treeplayer/inc/TTreeTableInterface.h
@@ -25,19 +25,19 @@ class TList;
 class TTreeTableInterface : public TVirtualTableInterface {
 
 private:
-   TTree               *fTree;       // Data in a TTree
-   TList               *fFormulas;   // Array of TTreeFormulas to display values
-   Long64_t             fEntry;      // Present entry number in fTree.
-   Long64_t             fNEntries;   // Number of entries in the tree.
-   Long64_t             fFirstEntry; // First entry.
-   TTreeFormulaManager *fManager;    // Coordinator for the formulas.
-   TTreeFormula        *fSelect;     // Selection condition
-   TSelectorDraw       *fSelector;   // Selector
-   TList               *fInput;      // Used for fSelector.
-   Bool_t               fForceDim;   // Force dimension.
-   TEntryList          *fEntries;    // Currently active entries
-   UInt_t               fNRows;      // Amount of rows in the data
-   UInt_t               fNColumns;   // Amount of columns in the data
+   TTree               *fTree;       ///< Data in a TTree
+   TList               *fFormulas;   ///< Array of TTreeFormulas to display values
+   Long64_t             fEntry;      ///< Present entry number in fTree.
+   Long64_t             fNEntries;   ///< Number of entries in the tree.
+   Long64_t             fFirstEntry; ///< First entry.
+   TTreeFormulaManager *fManager;    ///< Coordinator for the formulas.
+   TTreeFormula        *fSelect;     ///< Selection condition
+   TSelectorDraw       *fSelector;   ///< Selector
+   TList               *fInput;      ///< Used for fSelector.
+   Bool_t               fForceDim;   ///< Force dimension.
+   TEntryList          *fEntries;    ///< Currently active entries
+   UInt_t               fNRows;      ///< Amount of rows in the data
+   UInt_t               fNColumns;   ///< Amount of columns in the data
 
    void SetVariablesExpression(const char *varexp);
    void SyncFormulas();

--- a/tree/treeplayer/src/TTreeGeneratorBase.cxx
+++ b/tree/treeplayer/src/TTreeGeneratorBase.cxx
@@ -24,6 +24,10 @@
 #include "TVirtualCollectionProxy.h"
 #include "TVirtualStreamerInfo.h"
 
+/** \class ROOT::Internal::TTreeGeneratorBase
+Base class for code generators like TTreeProxyGenerator and TTreeReaderGenerator
+*/
+
 namespace ROOT {
 namespace Internal {
 


### PR DESCRIPTION
- Proper Doxygen formatting. A lot of documentation was not visible on the reference guide because of wrong doxygen formatting. Some comment appeared on the wrong date members.
- Fix typos