### PR TITLE
Correct cycle order in file merging for non-mergeable obj.

### DIFF
--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -63,7 +63,7 @@ protected:
                 TFileMergeInfo &info, TString &oldkeyname, THashList &allNames, Bool_t &status, Bool_t &onlyListed,
                 const TString &path,
                 TDirectory *current_sourcedir, TFile *current_file,
-                TKey *key, TObject *obj);
+                TKey *key, TObject *obj, TIter &nextkey);
 public:
    /// Type of the partial merge
    enum EPartialMergeType {

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -386,12 +386,71 @@ Long64_t MergeRNTuples(TClass* rntupleHandle, const TString& /* target */, const
    return func(static_cast<void*>(rntupleHandle), nullptr, nullptr);
 }
 
+Bool_t IsMergeable(TClass *cl)
+{
+   return (cl->GetMerge() || cl->InheritsFrom(TDirectory::Class()) ||
+            (cl->IsTObject() && !cl->IsLoaded() &&
+            /* If it has a dictionary and GetMerge() is nullptr then we already know the answer
+               to the next question is 'no, if we were to ask we would useless trigger
+               auto-parsing */
+            (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*") ||
+               cl->GetMethodWithPrototype("Merge", "TCollection*"))));
+};
+
+Bool_t WriteOneAndDelete(const TString &name, TClass *cl, TObject *obj, bool canBeMerged, Bool_t ownobj, TDirectory *target)
+{
+   Bool_t status = kTRUE;
+   if (cl->InheritsFrom(TCollection::Class())) {
+      // Don't overwrite, if the object were not merged.
+      if (obj->Write(name, canBeMerged ? TObject::kSingleKey | TObject::kOverwrite : TObject::kSingleKey) <= 0) {
+         status = kFALSE;
+      }
+      ((TCollection *)obj)->SetOwner();
+      if (ownobj)
+         delete obj;
+   } else {
+      // Don't overwrite, if the object were not merged.
+      // NOTE: this is probably wrong for emulated objects.
+      if (cl->IsTObject()) {
+         if (obj->Write(name, canBeMerged ? TObject::kOverwrite : 0) <= 0) {
+            status = kFALSE;
+         }
+         obj->ResetBit(kMustCleanup);
+      } else {
+         if (target->WriteObjectAny((void *)obj, cl, name, canBeMerged ? "OverWrite" : "") <= 0) {
+            status = kFALSE;
+         }
+      }
+      if (ownobj)
+         cl->Destructor(obj); // just in case the class is not loaded.
+   }
+   return status;
+}
+
+Bool_t WriteCycleInOrder(const TString &name, TIter &nextkey, TIter &peeknextkey, TDirectory *target)
+{
+   // Recurse until we find a different name or type appear.
+   TKey *key = (TKey*)peeknextkey();
+   if (!key || name != key->GetName()) {
+      return kTRUE;
+   }
+   TClass *cl = TClass::GetClass(key->GetClassName());
+   if (IsMergeable(cl))
+      return kTRUE;
+   // Now we can advance the real iterator
+   (void)nextkey();
+   Bool_t result = WriteCycleInOrder(name, nextkey, peeknextkey, target);
+   TObject *obj = key->ReadObj();
+
+   return WriteOneAndDelete(name, cl, obj, kFALSE, kTRUE, target) && result;
+};
+
 } // anonymous namespace
 
 Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, TFileMergeInfo &info,
                              TString &oldkeyname, THashList &allNames, Bool_t &status, Bool_t &onlyListed,
                              const TString &path, TDirectory *current_sourcedir, TFile *current_file, TKey *key,
-                             TObject *obj)
+                             TObject *obj, TIter &nextkey)
 {
    const char *keyname = obj ? obj->GetName() : key->GetName();
    const char *keyclassname = obj ? obj->IsA()->GetName() : key->GetClassName();
@@ -425,13 +484,7 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
    }
    // For mergeable objects we add the names in a local hashlist handling them
    // again (see above)
-   if (cl->GetMerge() || cl->InheritsFrom(TDirectory::Class()) ||
-      (cl->IsTObject() && !cl->IsLoaded() &&
-         /* If it has a dictionary and GetMerge() is nullptr then we already know the answer
-            to the next question is 'no, if we were to ask we would useless trigger
-            auto-parsing */
-         (cl->GetMethodWithPrototype("Merge", "TCollection*,TFileMergeInfo*") ||
-         cl->GetMethodWithPrototype("Merge", "TCollection*"))))
+   if (IsMergeable(cl))
       allNames.Add(new TObjString(keyname));
 
    if (fNoTrees && cl->InheritsFrom(R__TTree_Class)) {
@@ -737,30 +790,12 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
       }
    } else if (!canBeFound) { // Don't write the partial result for TTree and TH1
 
-      // Don't overwrite, if the object were not merged.
-      // NOTE: this is probably wrong for emulated objects.
-      if (cl->InheritsFrom(TCollection::Class())) {
-         // Don't overwrite, if the object were not merged.
-         if (obj->Write(oldkeyname, canBeMerged ? TObject::kSingleKey | TObject::kOverwrite : TObject::kSingleKey) <=
-               0) {
-            status = kFALSE;
-         }
-         ((TCollection *)obj)->SetOwner();
-         if (ownobj)
-            delete obj;
+      if (!canBeMerged) {
+         TIter peeknextkey(nextkey);
+         status = WriteCycleInOrder(oldkeyname, nextkey, peeknextkey, target) && status;
+         status = WriteOneAndDelete(oldkeyname, cl, obj, kFALSE, ownobj, target) && status;
       } else {
-         if (cl->IsTObject()) {
-            if (obj->Write(oldkeyname, canBeMerged ? TObject::kOverwrite : 0) <= 0) {
-               status = kFALSE;
-            }
-            obj->ResetBit(kMustCleanup);
-         } else {
-            if (target->WriteObjectAny((void *)obj, cl, oldkeyname, canBeMerged ? "OverWrite" : "") <= 0) {
-               status = kFALSE;
-            }
-         }
-         if (ownobj)
-            cl->Destructor(obj); // just in case the class is not loaded.
+         status = WriteOneAndDelete(oldkeyname, cl, obj, kTRUE, ownobj, target) && status;
       }
    }
    info.Reset();
@@ -829,7 +864,7 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
             auto result = MergeOne(target, sourcelist, type,
                                    info, oldkeyname, allNames, status, onlyListed, path,
                                    current_sourcedir, current_file,
-                                   nullptr, obj);
+                                   nullptr, obj, nextobj);
             if (!result)
                return kFALSE; // Stop completely in case of error.
          } // while ( (obj = (TKey*)nextobj()))
@@ -842,7 +877,7 @@ Bool_t TFileMerger::MergeRecursive(TDirectory *target, TList *sourcelist, Int_t 
             auto result = MergeOne(target, sourcelist, type,
                                    info, oldkeyname, allNames, status, onlyListed, path,
                                    current_sourcedir, current_file,
-                                   key, nullptr);
+                                   key, nullptr, nextkey);
             if (!result)
                return kFALSE; // Stop completely in case of error.
          } // while ( ( TKey *key = (TKey*)nextkey() ) )

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -735,29 +735,33 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
          ndir->ResetBit(kMustCleanup);
          delete ndir;
       }
-   } else if (cl->InheritsFrom(TCollection::Class())) {
-      // Don't overwrite, if the object were not merged.
-      if (obj->Write(oldkeyname, canBeMerged ? TObject::kSingleKey | TObject::kOverwrite : TObject::kSingleKey) <=
-            0) {
-         status = kFALSE;
-      }
-      ((TCollection *)obj)->SetOwner();
-      delete obj;
    } else if (!canBeFound) { // Don't write the partial result for TTree and TH1
+
       // Don't overwrite, if the object were not merged.
       // NOTE: this is probably wrong for emulated objects.
-      if (cl->IsTObject()) {
-         if (obj->Write(oldkeyname, canBeMerged ? TObject::kOverwrite : 0) <= 0) {
+      if (cl->InheritsFrom(TCollection::Class())) {
+         // Don't overwrite, if the object were not merged.
+         if (obj->Write(oldkeyname, canBeMerged ? TObject::kSingleKey | TObject::kOverwrite : TObject::kSingleKey) <=
+               0) {
             status = kFALSE;
          }
-         obj->ResetBit(kMustCleanup);
+         ((TCollection *)obj)->SetOwner();
+         if (ownobj)
+            delete obj;
       } else {
-         if (target->WriteObjectAny((void *)obj, cl, oldkeyname, canBeMerged ? "OverWrite" : "") <= 0) {
-            status = kFALSE;
+         if (cl->IsTObject()) {
+            if (obj->Write(oldkeyname, canBeMerged ? TObject::kOverwrite : 0) <= 0) {
+               status = kFALSE;
+            }
+            obj->ResetBit(kMustCleanup);
+         } else {
+            if (target->WriteObjectAny((void *)obj, cl, oldkeyname, canBeMerged ? "OverWrite" : "") <= 0) {
+               status = kFALSE;
+            }
          }
+         if (ownobj)
+            cl->Destructor(obj); // just in case the class is not loaded.
       }
-      if (ownobj)
-         cl->Destructor(obj); // just in case the class is not loaded.
    }
    info.Reset();
 


### PR DESCRIPTION
Fixes #7676

