### PR TITLE
Improve RBrowser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ CMakeLists.txt.user
 .cproject
 .project
 .externalToolBuilders
+.pydevproject
 
 # Vim
 *.swp

--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -53,6 +53,7 @@ public:
       kActImage,   ///< can be shown in image viewer, can provide image
       kActDraw6,   ///< can be drawn inside ROOT6 canvas
       kActDraw7,   ///< can be drawn inside ROOT7 canvas
+      kActCanvas,  ///< indicate that it is canvas and should be drawn directly
       kActGeom     ///< can be shown in geometry viewer
    };
 

--- a/gui/browsable/src/RProvider.cxx
+++ b/gui/browsable/src/RProvider.cxx
@@ -417,6 +417,7 @@ public:
       RegisterClass("ROOT::Experimental::RH1D", "sap-icon://bar-chart", "", "", "libROOTHistDrawProvider");
       RegisterClass("ROOT::Experimental::RH2D", "sap-icon://pixelate", "", "", "libROOTHistDrawProvider");
       RegisterClass("ROOT::Experimental::RH3D", "sap-icon://product", "", "", "libROOTHistDrawProvider");
+      RegisterClass("ROOT::Experimental::RCanvas", "sap-icon://business-objects-experience", "", "", "libROOTHistDrawProvider");
       RegisterClass("ROOT::Experimental::RNTuple", "sap-icon://table-chart", "libROOTNTupleBrowseProvider", "libROOTNTupleDraw6Provider", "libROOTNTupleDraw7Provider");
    }
 

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -199,7 +199,8 @@ public:
 
       std::string clname = fKey->GetClassName();
       if (clname.empty()) return kActNone;
-      if (clname == "TGeoManager") return kActGeom;
+      if ((clname == "TCanvas"s) || (clname == "ROOT::Experimental::RCanvas"s)) return kActCanvas;
+      if (clname == "TGeoManager"s) return kActGeom;
       if (RProvider::CanDraw6(clname)) return kActDraw6;
       if (RProvider::CanDraw7(clname)) return kActDraw7;
       if (RProvider::CanHaveChilds(clname)) return kActBrowse;
@@ -221,7 +222,8 @@ public:
          case kActImage:
          case kActDraw6: return RProvider::CanDraw6(clname); // if can draw in TCanvas, can produce image
          case kActDraw7: return RProvider::CanDraw7(clname);
-         case kActGeom: return (clname == "TGeoManager");
+         case kActCanvas: return (clname == "TCanvas"s) || (clname == "ROOT::Experimental::RCanvas"s);
+         case kActGeom: return (clname == "TGeoManager"s);
          default: return false;
       }
 

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -365,6 +365,7 @@ RElement::EActionKind TObjectElement::GetDefaultAction() const
 {
    auto cl = GetClass();
    if (!cl) return kActNone;
+   if ("TCanvas"s == cl->GetName()) return kActCanvas;
    if (("TGeoManager"s == cl->GetName()) || ("TGeoVolume"s == cl->GetName())) return kActGeom;
    if (RProvider::CanDraw6(cl)) return kActDraw6;
    if (RProvider::CanDraw7(cl)) return kActDraw7;
@@ -386,6 +387,7 @@ bool TObjectElement::IsCapable(RElement::EActionKind action) const
       case kActImage:
       case kActDraw6: return RProvider::CanDraw6(cl); // if can draw in TCanvas, can produce image
       case kActDraw7: return RProvider::CanDraw7(cl);
+      case kActCanvas: return "TCanvas"s == cl->GetName();
       case kActGeom: return ("TGeoManager"s == cl->GetName()) || ("TGeoVolume"s == cl->GetName());
       default: return false;
    }

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -243,14 +243,15 @@ std::string RBrowser::ProcessDblClick(std::vector<std::string> &args)
    if (!elem) return ""s;
 
    auto dflt_action = elem->GetDefaultAction();
-   // special case when canvas is clicked - start new widget
+
+   // special case when canvas is clicked - always start new widget
    if (dflt_action == Browsable::RElement::kActCanvas) {
       std::string widget_kind;
 
-      if (elem->IsCapable(Browsable::RElement::kActDraw6))
-         widget_kind = "tcanvas";
-      else
+      if (elem->IsCapable(Browsable::RElement::kActDraw7))
          widget_kind = "rcanvas";
+      else
+         widget_kind = "tcanvas";
 
       std::string name = widget_kind + std::to_string(++fWidgetCnt);
 
@@ -265,7 +266,6 @@ std::string RBrowser::ProcessDblClick(std::vector<std::string> &args)
 
       return NewWidgetMsg(new_widget);
    }
-
 
    auto widget = GetActiveWidget();
    if (widget && widget->DrawElement(elem, drawingOptions)) {

--- a/gui/browserv7/src/RBrowserRCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserRCanvasWidget.cxx
@@ -76,6 +76,12 @@ protected:
    {
       return std::make_shared<RBrowserRCanvasWidget>(name);
    }
+
+   std::shared_ptr<RBrowserWidget> CreateFor(const std::string &name, std::shared_ptr<Browsable::RElement> &elem) final
+   {
+      return nullptr;
+   }
+
 public:
    RBrowserRCanvasProvider() : RBrowserWidgetProvider("rcanvas") {}
    ~RBrowserRCanvasProvider() = default;

--- a/gui/browserv7/src/RBrowserRCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserRCanvasWidget.cxx
@@ -51,6 +51,11 @@ public:
       return "../"s + fCanvas->GetWindowAddr() + "/"s;
    }
 
+   std::string GetTitle() override
+   {
+      return fCanvas->GetTitle();
+   }
+
    bool DrawElement(std::shared_ptr<Browsable::RElement> &elem, const std::string &opt) override
    {
       if (!elem->IsCapable(Browsable::RElement::kActDraw7))

--- a/gui/browserv7/src/RBrowserRCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserRCanvasWidget.cxx
@@ -32,6 +32,11 @@ public:
       fCanvas = RCanvas::Create(name);
    }
 
+   RBrowserRCanvasWidget(const std::string &name, std::shared_ptr<RCanvas> &canv) : RBrowserWidget(name)
+   {
+      fCanvas = std::move(canv);
+   }
+
    virtual ~RBrowserRCanvasWidget() = default;
 
    std::string GetKind() const override { return "rcanvas"s; }
@@ -79,7 +84,13 @@ protected:
 
    std::shared_ptr<RBrowserWidget> CreateFor(const std::string &name, std::shared_ptr<Browsable::RElement> &elem) final
    {
-      return nullptr;
+      auto holder = elem->GetObject();
+      if (!holder) return nullptr;
+
+      auto canv = holder->get_shared<RCanvas>();
+      if (!canv) return nullptr;
+
+      return std::make_shared<RBrowserRCanvasWidget>(name, canv);
    }
 
 public:

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -38,6 +38,7 @@ public:
       fCanvas->SetTitle(name.c_str());
       fCanvas->ResetBit(TCanvas::kShowEditor);
       fCanvas->ResetBit(TCanvas::kShowToolBar);
+      fCanvas->SetBit(TCanvas::kMenuBar, kTRUE);
       fCanvas->SetCanvas(fCanvas.get());
       fCanvas->SetBatch(kTRUE); // mark canvas as batch
       fCanvas->SetEditable(kTRUE); // ensure fPrimitives are created

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -77,6 +77,11 @@ public:
       return "../"s + fWebCanvas->GetWebWindow()->GetAddr() + "/"s;
    }
 
+   std::string GetTitle() override
+   {
+      return fCanvas->GetName();
+   }
+
    bool DrawElement(std::shared_ptr<Browsable::RElement> &elem, const std::string &opt) override
    {
       if (!elem->IsCapable(Browsable::RElement::kActDraw6))

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -50,6 +50,19 @@ public:
       fCanvas->SetCanvasImp(fWebCanvas);
    }
 
+   RBrowserTCanvasWidget(const std::string &name, std::unique_ptr<TCanvas> &canv) : RBrowserWidget(name)
+   {
+      fCanvas = std::move(canv);
+      fCanvas->SetBatch(kTRUE); // mark canvas as batch
+
+      // create implementation
+      fWebCanvas = new TWebCanvas(fCanvas.get(), "title", 0, 0, 800, 600);
+
+      // assign implementation
+      fCanvas->SetCanvasImp(fWebCanvas);
+   }
+
+
    virtual ~RBrowserTCanvasWidget() = default;
 
    std::string GetKind() const override { return "tcanvas"s; }
@@ -89,6 +102,18 @@ protected:
    {
       return std::make_shared<RBrowserTCanvasWidget>(name);
    }
+
+   std::shared_ptr<RBrowserWidget> CreateFor(const std::string &name, std::shared_ptr<Browsable::RElement> &elem) final
+   {
+      auto holder = elem->GetObject();
+      if (!holder) return nullptr;
+
+      auto canv = holder->get_unique<TCanvas>();
+      if (!canv) return nullptr;
+
+      return std::make_shared<RBrowserTCanvasWidget>(name, canv);
+   }
+
 public:
    RBrowserTCanvasProvider() : RBrowserWidgetProvider("tcanvas") {}
    ~RBrowserTCanvasProvider() = default;

--- a/gui/browserv7/src/RBrowserWidget.cxx
+++ b/gui/browserv7/src/RBrowserWidget.cxx
@@ -62,3 +62,26 @@ std::shared_ptr<RBrowserWidget> RBrowserWidgetProvider::CreateWidget(const std::
    }
    return iter->second->Create(name);
 }
+
+///////////////////////////////////////////////////////////////
+/// Create specified widget for existing object
+
+
+std::shared_ptr<RBrowserWidget> RBrowserWidgetProvider::CreateWidgetFor(const std::string &kind, const std::string &name, std::shared_ptr<Browsable::RElement> &element)
+{
+   auto &map = GetMap();
+   auto iter = map.find(kind);
+   if (iter == map.end()) {
+      // try to load necessary libraries
+      if (kind == "geom")
+         gSystem->Load("libROOTBrowserGeomWidget");
+      else if (kind == "tcanvas")
+         gSystem->Load("libROOTBrowserTCanvasWidget");
+      else if (kind == "rcanvas")
+         gSystem->Load("libROOTBrowserRCanvasWidget");
+      iter = map.find(kind);
+      if (iter == map.end())
+         return nullptr;
+   }
+   return iter->second->CreateFor(name, element);
+}

--- a/gui/browserv7/src/RBrowserWidget.hxx
+++ b/gui/browserv7/src/RBrowserWidget.hxx
@@ -61,6 +61,8 @@ protected:
 
    virtual std::shared_ptr<RBrowserWidget> Create(const std::string &) = 0;
 
+   virtual std::shared_ptr<RBrowserWidget> CreateFor(const std::string &, std::shared_ptr<Browsable::RElement> &) { return nullptr; }
+
    static ProvidersMap_t& GetMap();
 
 public:
@@ -69,6 +71,8 @@ public:
    virtual ~RBrowserWidgetProvider();
 
    static std::shared_ptr<RBrowserWidget> CreateWidget(const std::string &kind, const std::string &name);
+
+   static std::shared_ptr<RBrowserWidget> CreateWidgetFor(const std::string &kind, const std::string &name, std::shared_ptr<Browsable::RElement> &element);
 };
 
 

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -34,6 +34,7 @@
 #include "TList.h"
 #include "TEnv.h"
 #include "TROOT.h"
+#include "TFile.h"
 #include "TClass.h"
 #include "TBufferJSON.h"
 #include "TBase64.h"
@@ -512,6 +513,12 @@ void RCanvasPainter::ProcessData(unsigned connid, const std::string &arg)
       }
    } else if (check_header("SAVE:")) {
       SaveCreatedFile(cdata);
+   } else if (check_header("PRODUCE:")) {
+      R__LOG_DEBUG(0, CanvasPainerLog()) << "Create file " << cdata;
+
+      TFile *f = TFile::Open(cdata.c_str(), "RECREATE");
+      f->WriteObject(&fCanvas, "Canvas");
+      delete f;
    } else if (check_header("REQ:")) {
       auto req = TBufferJSON::FromJSON<RDrawableRequest>(cdata);
       if (req) {

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "24/03/2021";
+   JSROOT.version_date = "25/03/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "23/03/2021";
+   JSROOT.version_date = "24/03/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -1,4 +1,4 @@
-/// @file JSRoot.gpad.js
+// @file JSRoot.gpad.js
 /// JSROOT TPad/TCanvas/TFrame support
 
 JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
@@ -2680,7 +2680,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       menu.add("separator");
 
-      if (this.activateStatusBar)
+      if (typeof this.hasMenuBar == 'function' && typeof this.actiavteMenuBar == 'function')
+         menu.addchk(this.hasMenuBar(), "Menu bar", flag => this.actiavteMenuBar(flag));
+
+      if (typeof this.hasEventStatus == 'function' && typeof this.activateStatusBar == 'function')
          menu.addchk(this.hasEventStatus(), "Event status", () => this.activateStatusBar('toggle'));
 
       if (this.enlargeMain() || (this.has_canvas && this.hasObjectsToDraw()))
@@ -4195,7 +4198,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    TCanvasPainter.prototype.completeCanvasSnapDrawing = function() {
       if (!this.pad) return;
 
-      if (document) document.title = this.pad.fTitle;
+      if (document && !this.embed_canvas)
+         document.title = this.pad.fTitle;
 
       if (this._all_sections_showed) return;
       this._all_sections_showed = true;

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -3735,10 +3735,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
    /** @summary Cleanup canvas painter */
    TCanvasPainter.prototype.cleanup = function() {
-     if (this._changed_layout)
-        this.setLayoutKind('simple');
-     delete this._changed_layout;
-     TPadPainter.prototype.cleanup.call(this);
+      if (this._changed_layout)
+         this.setLayoutKind('simple');
+      delete this._changed_layout;
+      TPadPainter.prototype.cleanup.call(this);
    }
 
    /** @summary Returns layout kind */

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -2879,10 +2879,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
      * @private */
    RPadPainter.prototype.fillContextMenu = function(menu) {
 
-      if (this.pad)
-         menu.add("header: " + this.pad._typename + "::" + this.pad.fName);
+      if (this.iscan)
+         menu.add("header: RCanvas");
       else
-         menu.add("header: Canvas");
+         menu.add("header: RPad");
 
       menu.addchk(this.isTooltipAllowed(), "Show tooltips", () => this.setTooltipAllowed("toggle"));
 
@@ -2922,7 +2922,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       menu.add("separator");
 
-      if (this.activateStatusBar)
+      if (typeof this.hasMenuBar == 'function' && typeof this.actiavteMenuBar == 'function')
+         menu.addchk(this.hasMenuBar(), "Menu bar", flag => this.actiavteMenuBar(flag));
+
+      if (typeof this.hasEventStatus == 'function' && typeof this.activateStatusBar == 'function')
          menu.addchk(this.hasEventStatus(), "Event status", () => this.activateStatusBar('toggle'));
 
       if (this.enlargeMain() || (this.has_canvas && this.hasObjectsToDraw()))
@@ -3223,7 +3226,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       // if canvas size not specified in batch mode, temporary use 900x700 size
       // if (this.batch_mode && this.iscan && (!padattr.fCw || !padattr.fCh)) { padattr.fCw = 900; padattr.fCh = 700; }
 
-      if (this.iscan && snap.fTitle && (typeof document !== "undefined"))
+      if (this.iscan && snap.fTitle && !this.embed_canvas && (typeof document !== "undefined"))
          document.title = snap.fTitle;
 
       if (this.snapid === undefined) {
@@ -3770,6 +3773,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       RPadPainter.call(this, divid, canvas, true);
       this._websocket = null;
       this.tooltip_allowed = JSROOT.settings.Tooltip;
+      this.v7canvas = true;
    }
 
    RCanvasPainter.prototype = Object.create(RPadPainter.prototype);
@@ -3917,7 +3921,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    RCanvasPainter.prototype.saveCanvasAsFile = function(fname) {
       let pnt = fname.indexOf(".");
       this.createImage(fname.substr(pnt+1))
-          .then(res => this.sendWebsocket("SAVE:" + fname + ":" + res));
+          .then(res => { console.log('save', fname, res.length); this.sendWebsocket("SAVE:" + fname + ":" + res); });
    }
 
    /** @summary Send command to server to save canvas with specified name

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -653,7 +653,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          if (oModel && oModel.getProperty("/can_close"))
             return this.doCloseTabItem(oItemToClose);
 
-         MessageBox.confirm('Do you really want to close the "' + oItemToClose.getName() + '" tab?', {
+         MessageBox.confirm('Do you really want to close the "' + oItemToClose.getAdditionalText() + '" tab?', {
             onClose: oAction => {
                if (oAction === MessageBox.Action.OK) {
                    this.doCloseTabItem(oItemToClose);
@@ -662,10 +662,6 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             }
          });
       },
-
-      /* ============================================ */
-      /* =============== TabContainer =============== */
-      /* ============================================ */
 
       /* ======================================== */
       /* =============== Terminal =============== */
@@ -991,13 +987,13 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          })).then(oView => item.addContent(oView));
       },
 
-      createCanvas: async function(kind, url, name) {
+      createCanvas: async function(kind, url, name, title) {
          if (!url || !name || (kind != "tcanvas" && kind != "rcanvas")) return;
 
          let item = new TabContainerItem({
-            name: "ROOT Canvas",
+            name: (kind == "rcanvas") ? "RCanvas" : "TCanvas",
             key: name,
-            additionalText: name,
+            additionalText: title || name,
             icon: "sap-icon://column-chart-dual-axis"
          });
 
@@ -1026,8 +1022,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
          let ctrl = oView.getController();
          ctrl.onCloseCanvasPress = this.doCloseTabItem.bind(this, item);
-
-      },
+      }
 
    });
 

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -635,28 +635,28 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             this.websocket.send("WIDGET_SELECTED:" + item.getKey());
       },
 
+      doCloseTabItem: function(item) {
+         let oTabContainer = this.byId("tabContainer");
+         if (item.getKey())
+            this.websocket.send("CLOSE_TAB:" + item.getKey());
+         oTabContainer.removeItem(item);
+      },
+
       /** @brief Close Tab event handler */
       handleTabClose: function(oEvent) {
          // prevent the tab being closed by default
          oEvent.preventDefault();
 
-         let oTabContainer = this.byId("tabContainer");
-         let oItemToClose = oEvent.getParameter('item');
-         let oModel = oItemToClose.getModel();
-
-         let closeItem = () => {
-            if (oItemToClose.getKey())
-               this.websocket.send("CLOSE_TAB:" + oItemToClose.getKey());
-            oTabContainer.removeItem(oItemToClose);
-         }
+         let oItemToClose = oEvent.getParameter('item'),
+             oModel = oItemToClose.getModel();
 
          if (oModel && oModel.getProperty("/can_close"))
-            return closeItem();
+            return this.doCloseTabItem(oItemToClose);
 
          MessageBox.confirm('Do you really want to close the "' + oItemToClose.getName() + '" tab?', {
             onClose: oAction => {
                if (oAction === MessageBox.Action.OK) {
-                   closeItem();
+                   this.doCloseTabItem(oItemToClose);
                    MessageToast.show('Closed the "' + oItemToClose.getName() + '" tab', { duration: 1500 });
                 }
             }
@@ -1023,6 +1023,10 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          });
 
          item.addContent(oView);
+
+         let ctrl = oView.getController();
+         ctrl.onCloseCanvasPress = this.doCloseTabItem.bind(this, item);
+
       },
 
    });

--- a/ui5/browser/view/settingsmenu.fragment.xml
+++ b/ui5/browser/view/settingsmenu.fragment.xml
@@ -5,10 +5,10 @@
         <content>
           <Panel>
             <content>
-              <f:Form>
+              <f:Form editable="true">
                 <f:layout>
                   <f:ResponsiveGridLayout
-                          labelSpanS="2"
+                          labelSpanS="3"
                           emptySpanS="0"
                           singleContainerFullSize="false" />
                 </f:layout>
@@ -60,8 +60,8 @@
         <content>
           <VBox>
             <HBox>
-               <Label text="Sorting" wrapping="true" />
-               <ComboBox items="{ path: '/SortMethods' }" selectedKey="{/SortMethod}">
+               <Label text="Sorting" wrapping="true" labelFor="sortMethodsCombo" class="sapUiSmallMarginTop sapUiSmallMarginBottom"/>
+               <ComboBox id="sortMethodsCombo" items="{ path: '/SortMethods' }" selectedKey="{/SortMethod}">
                    <core:Item text="{name}" key="{value}"/>
                </ComboBox>
             </HBox>

--- a/ui5/browser/view/settingsmenu.fragment.xml
+++ b/ui5/browser/view/settingsmenu.fragment.xml
@@ -59,8 +59,8 @@
       <ViewSettingsCustomTab icon="sap-icon://action-settings" >
         <content>
           <VBox>
-            <HBox>
-               <Label text="Sorting" wrapping="true" labelFor="sortMethodsCombo" class="sapUiSmallMarginTop sapUiSmallMarginBottom"/>
+            <HBox alignItems="Center">
+               <Label text="Sorting" wrapping="true" labelFor="sortMethodsCombo"/>
                <ComboBox id="sortMethodsCombo" items="{ path: '/SortMethods' }" selectedKey="{/SortMethod}">
                    <core:Item text="{name}" key="{value}"/>
                </ComboBox>

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -24,7 +24,7 @@ sap.ui.define([
          this.bottomVisible = false;
 
          let model = new JSONModel({ GedIcon: "", StatusIcon: "", ToolbarIcon: "", TooltipIcon: "sap-icon://accept",
-                                     StatusLbl1:"", StatusLbl2:"", StatusLbl3:"", StatusLbl4:"" });
+                                     StatusLbl1:"", StatusLbl2:"", StatusLbl3:"", StatusLbl4:"", Standalone: true });
          this.getView().setModel(model);
 
          let vd = this.getView().getViewData();
@@ -33,6 +33,9 @@ sap.ui.define([
          if (!cp) cp = Component.getOwnerComponentFor(this.getView()).getComponentData().canvas_painter;
 
          if (cp) {
+
+            if (cp.embed_canvas) model.setProperty("/Standalone", false);
+
             this.getView().byId("MainPanel").getController().setPainter(cp);
 
             cp.executeObjectMethod = this.executeObjectMethod.bind(this);

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -32,7 +32,8 @@ sap.ui.define([
                                      StatusIcon: chk_icon(false),
                                      ToolbarIcon: chk_icon(false),
                                      TooltipIcon: chk_icon(true),
-                                     StatusLbl1:"", StatusLbl2:"", StatusLbl3:"", StatusLbl4:"", Standalone: true });
+                                     StatusLbl1:"", StatusLbl2:"", StatusLbl3:"", StatusLbl4:"",
+                                     Standalone: true, isRoot6: true });
          this.getView().setModel(model);
 
          let vd = this.getView().getViewData();
@@ -65,9 +66,16 @@ sap.ui.define([
             cp.drawInUI5ProjectionArea = this.drawInProjectionArea.bind(this);
 
             cp.showUI5Panel = this.showPanelInLeftArea.bind(this);
+
+            if (cp.v7canvas) model.setProperty("/isRoot6", false);
          }
 
          // this.toggleGedEditor();
+      },
+
+      isv7: function() {
+         let cp = this.getCanvasPainter();
+         return cp && cp.v7canvas;
       },
 
       executeObjectMethod: function(painter, method, menu_obj_id) {
@@ -288,7 +296,8 @@ sap.ui.define([
              p = this.getCanvasPainter();
          if (p) p.registerForPadEvents(null);
          if (ged) ged.cleanupGed();
-         if (p && p.processChanges) p.processChanges("sbits", p);
+         if (p && p.processChanges)
+            p.processChanges("sbits", p);
       },
 
       getLeftController: function(name) {

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -217,9 +217,15 @@ sap.ui.define([
          let name = oEvent.getParameter("item").getText();
 
          switch (name) {
-            case "Close canvas": p.onWebsocketClosed(); p.closeWebsocket(true); break;
-            case "Interrupt": p.sendWebsocket("INTERRUPT"); break;
-            case "Quit ROOT": p.sendWebsocket("QUIT"); break;
+            case "Close canvas":
+               this.onCloseCanvasPress();
+               break;
+            case "Interrupt":
+               p.sendWebsocket("INTERRUPT");
+               break;
+            case "Quit ROOT":
+               p.sendWebsocket("QUIT");
+               break;
             case "Canvas.png":
             case "Canvas.jpeg":
             case "Canvas.svg":

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -22,9 +22,9 @@
                               <MenuItem text="Canvas.svg" tooltip="Creates SVG snapshot of browser window"/>
                               <MenuItem text="Canvas.jpeg" tooltip="Creates JPEG snapshot of browser window"/>
                               <MenuItem text="Canvas.root" startsSection="true" tooltip="Produces ROOT output on C++ side"/>
-                              <MenuItem text="Canvas.pdf" tooltip="Produces PDF output on C++ side"/>
-                              <MenuItem text="Canvas.ps" tooltip="Produces PS output on C++ side"/>
-                              <MenuItem text="Canvas.C" tooltip="Produces C output on server side"/>
+                              <MenuItem text="Canvas.pdf" enabled="{/isRoot6}" tooltip="Produces PDF output on C++ side"/>
+                              <MenuItem text="Canvas.ps" enabled="{/isRoot6}" tooltip="Produces PS output on C++ side"/>
+                              <MenuItem text="Canvas.C" enabled="{/isRoot6}" tooltip="Produces C output on server side"/>
                            </items>
                         </MenuItem>
                         <MenuItem text="Save as ..." icon="sap-icon://save" enabled="false"/>

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -40,13 +40,14 @@
                <menu>
                   <Menu itemSelected="onViewMenuAction">
                      <items>
+                        <MenuItem text="Menu" icon="{/MenuBarIcon}" tooltip="Toggle menu bar"/>
                         <MenuItem text="Editor" icon="{/GedIcon}" tooltip="Toggle graphics attribute editor"/>
                         <MenuItem text="Toolbar" icon="{/ToolbarIcon}" tooltip="Toolbar with several shortcuts"/>
                         <MenuItem text="Event statusbar" icon="{/StatusIcon}" />
                         <MenuItem text="Tooltip info" icon="{/TooltipIcon}" />
-                        <MenuItem text="Colors" startsSection="true" enabled="false"/>
-                        <MenuItem text="Fonts" enabled="false"/>
-                        <MenuItem text="Markers" enabled="false"/>
+                        <MenuItem text="Colors" startsSection="true" icon="sap-icon://palette" enabled="false"/>
+                        <MenuItem text="Fonts" icon="sap-icon://text" enabled="false"/>
+                        <MenuItem text="Markers" icon="sap-icon://tags" enabled="false"/>
                      </items>
                   </Menu>
                </menu>

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -4,7 +4,7 @@
       showSubHeader="false" id="CanvasMainPage">
       <customHeader>
          <OverflowToolbar id="otb1">
-            <Button icon="sap-icon://log" type="Transparent"
+            <Button icon="sap-icon://log" type="Transparent" visible="{/Standalone}"
                tooltip="Quit ROOT session" press="onQuitRootPress" />
             <!--  Button icon="sap-icon://refresh" type="Transparent"
                tooltip="Reload canvas from server" press="onReloadPress" /-->
@@ -28,8 +28,8 @@
                            </items>
                         </MenuItem>
                         <MenuItem text="Save as ..." icon="sap-icon://save" enabled="false"/>
-                        <MenuItem text="Interrupt" startsSection="true" icon="sap-icon://stop" tooltip="Interrupts current event loop"/>
-                        <MenuItem text="Quit ROOT" icon="sap-icon://log" tooltip="Quit ROOT session"/>
+                        <MenuItem text="Interrupt" startsSection="true" icon="sap-icon://stop" enabled="{/Standalone}" tooltip="Interrupts current event loop"/>
+                        <MenuItem text="Quit ROOT" icon="sap-icon://log" enabled="{/Standalone}" tooltip="Quit ROOT session"/>
 
                      </items>
                   </Menu>


### PR DESCRIPTION
1. Support direct draw of TCanvas and RCanvas, do not try to draw them inside other canvases
2. Show `Menu bar` for both canvas classes, let toggle it via context menu
3. Hide some buttons (like Quit ROOT) in case of embed canvas
4. Correctly handle "Close canvas" for embed canvas
5. Implement "Save as Canvas.root" for RCanvas, disable PDF, PS and C output for RCanvas
6. Display real canvas name in RBrowser tabs
7. Small ui5 layout improvements