### PR TITLE
[PyROOT] Test that RVec is accessible from the ROOT namespace

### DIFF
--- a/bindings/pyroot/pythonizations/test/rvec.py
+++ b/bindings/pyroot/pythonizations/test/rvec.py
@@ -27,5 +27,14 @@ class RVec(unittest.TestCase):
             self.assertEqual(c, 3)
 
 
+    def test_from_root_namespace(self):
+        '''
+        Test that RVec is accessible from the ROOT and ROOT::VecOps namespace
+        '''
+
+        v1 = ROOT.VecOps.RVec['float']()
+        v2 = ROOT.RVec['float']()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Improves the test coverage, which we need for #7502 