### PR TITLE
[cppyy] fix potential double deletion of memory in CPPMethod

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx
@@ -45,7 +45,7 @@ inline void CPyCppyy::CPPMethod::Copy_(const CPPMethod& /* other */)
 }
 
 //----------------------------------------------------------------------------
-inline void CPyCppyy::CPPMethod::Destroy_() const
+inline void CPyCppyy::CPPMethod::Destroy_()
 {
 // destroy executor and argument converters
     if (fExecutor && fExecutor->HasState()) delete fExecutor;
@@ -55,6 +55,11 @@ inline void CPyCppyy::CPPMethod::Destroy_() const
     }
 
     delete fArgIndices;
+
+    fExecutor = nullptr;
+    fArgIndices = nullptr;
+    fConverters.clear();
+    fArgsRequired = -1;
 }
 
 //----------------------------------------------------------------------------

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.h
@@ -61,7 +61,7 @@ protected:
 
 private:
     void Copy_(const CPPMethod&);
-    void Destroy_() const;
+    void Destroy_();
 
     PyObject* ExecuteFast(void*, ptrdiff_t, CallContext*);
     PyObject* ExecuteProtected(void*, ptrdiff_t, CallContext*);


### PR DESCRIPTION
After use of assign operator some fields can be destroyed twice

Fixes #7692 

Indirectly discovered via DeepCode
