### PR TITLE
Use SafeDelete in several gui classes

### DIFF
--- a/core/gui/src/TBrowser.cxx
+++ b/core/gui/src/TBrowser.cxx
@@ -259,9 +259,9 @@ void TBrowser::Destructor()
    if (fImp) fImp->CloseTabs();
    R__LOCKGUARD(gROOTMutex);
    gROOT->GetListOfBrowsers()->Remove(this);
-   delete fContextMenu;
-   delete fTimer;
-   if (fImp) delete fImp;
+   SafeDelete(fContextMenu);
+   SafeDelete(fTimer);
+   SafeDelete(fImp);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/inc/TClassTree.h
+++ b/graf2d/gpad/inc/TClassTree.h
@@ -14,6 +14,7 @@
 
 
 #include "TNamed.h"
+#include <vector>
 
 class TClass;
 class TObjString;
@@ -40,6 +41,8 @@ protected:
    TString **fOptions;    ///<![fNclasses] List of options per class
    TString   fSourceDir;  ///<Concatenated source directories
    TList   **fLinks;      ///<![fNclasses] for each class, the list of referenced(ing) classes
+   std::vector<Int_t> fNsons;  ///<! internal variable, used during painting
+   std::vector<Int_t> fNtsons;  ///<! internal variable, used during painting
 
    virtual  void FindClassPosition(const char *classname, Float_t &x, Float_t &y);
    virtual  void FindClassesUsedBy(Int_t iclass);

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -689,13 +689,13 @@ void TCanvas::Destructor()
 
    if (!TestBit(kNotDeleted)) return;
 
-   if (fContextMenu) { delete fContextMenu; fContextMenu = 0; }
+   SafeDelete(fContextMenu);
    if (!gPad) return;
 
    Close();
 
    //If not yet (batch mode?).
-   delete fPainter;
+   SafeDelete(fPainter);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2622,8 +2622,7 @@ void TCanvas::DeleteCanvasPainter()
       gGLManager->MakeCurrent(fGLDevice);
    }
 
-   delete fPainter;
-   fPainter = 0;
+   SafeDelete(fPainter);
 
    if (fGLDevice != -1) {
       gGLManager->DeleteGLContext(fGLDevice);//?

--- a/graf2d/gpad/src/TClassTree.cxx
+++ b/graf2d/gpad/src/TClassTree.cxx
@@ -46,7 +46,6 @@ const Int_t kIsaPointer  = BIT(20);
 const Int_t kIsBasic     = BIT(21);
 
 static Float_t gXsize, gYsize, gDx, gDy, gLabdx, gLabdy, gDxx, gCsize;
-static Int_t *gNtsons, *gNsons;
 
 ClassImp(TClassTree);
 
@@ -466,8 +465,8 @@ void TClassTree::Paint(Option_t *)
    Int_t nch      = strlen(GetClasses());
    if (nch == 0) return;
    char *classes  = new char[nch+1];
-   gNsons   = new Int_t[fNclasses];
-   gNtsons  = new Int_t[fNclasses];
+   fNsons.resize(fNclasses, 0);
+   fNtsons.resize(fNclasses, 0);
    strlcpy(classes,GetClasses(),nch+1);
    Int_t i,j;
    char *derived;
@@ -519,7 +518,7 @@ void TClassTree::Paint(Option_t *)
    }
     //mark base classes of referenced classes
    for (i=0;i<fNclasses;i++) {
-      gNsons[i] = gNtsons[i] = 0;
+      fNsons[i] = fNtsons[i] = 0;
    }
    for (i=0;i<fNclasses;i++) {
       if (fCstatus[i] == 0) continue;
@@ -537,7 +536,7 @@ void TClassTree::Paint(Option_t *)
       j = fParents[i];
       if (j >=0 ) {
          fCparent[i] = j;
-         gNsons[j]++;
+         fNsons[j]++;
       }
    }
     //compute total number of sons for each node
@@ -545,14 +544,14 @@ void TClassTree::Paint(Option_t *)
    Int_t icl,ip;
    for (i=0;i<fNclasses;i++) {
       if (fCstatus[i] == 0) continue;
-      if (gNsons[i] != 0) continue;
+      if (fNsons[i] != 0) continue;
       icl = i;
       Int_t nlevel = 1;
       while (fCparent[icl] >= 0) {
          nlevel++;
          if (nlevel > maxlev) maxlev = nlevel;
          ip = fCparent[icl];
-         gNtsons[ip]++;
+         fNtsons[ip]++;
          icl = ip;
       }
    }
@@ -563,7 +562,7 @@ void TClassTree::Paint(Option_t *)
    for (i=0;i<fNclasses;i++) {
       if (fCstatus[i] == 0) continue;
       if (fCparent[i] < 0) {
-         ndiv += gNtsons[i]+1;
+         ndiv += fNtsons[i]+1;
          nmore++;
       }
    }
@@ -597,10 +596,10 @@ void TClassTree::Paint(Option_t *)
    for (i=0;i<fNclasses;i++) {
       if (fCstatus[i] == 0) continue;
       if (fCparent[i] < 0) {
-         y -= gDy+0.5*gNtsons[i]*gDy;
+         y -= gDy+0.5*fNtsons[i]*gDy;
          if (!fCnames[i]->CompareTo("TObject")) y += ymore;
          PaintClass(i,xleft,y);
-         y -= 0.5*gNtsons[i]*gDy;
+         y -= 0.5*fNtsons[i]*gDy;
       }
    }
 
@@ -626,8 +625,8 @@ void TClassTree::Paint(Option_t *)
 
    //cleanup
    delete [] classes;
-   delete [] gNsons;
-   delete [] gNtsons;
+   fNsons.clear();
+   fNtsons.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -636,7 +635,7 @@ void TClassTree::Paint(Option_t *)
 void TClassTree::PaintClass(Int_t iclass, Float_t xleft, Float_t y)
 {
    Float_t u[2],yu=0,yl=0;
-   Int_t ns = gNsons[iclass];
+   Int_t ns = fNsons[iclass];
    u[0] = xleft;
    u[1] = u[0]+gDxx;
    if(ns != 0) u[1] = u[0]+gDx;
@@ -655,16 +654,16 @@ void TClassTree::PaintClass(Int_t iclass, Float_t xleft, Float_t y)
    if (ns == 0) return;
 
    // drawing sons
-   y +=  0.5*gNtsons[iclass]*gDy;
+   y +=  0.5*fNtsons[iclass]*gDy;
    Int_t first =0;
    for (Int_t i=0;i<fNclasses;i++) {
       if(fCparent[i] != iclass) continue;
-      if (gNtsons[i] > 1) y -= 0.5*gNtsons[i]*gDy;
+      if (fNtsons[i] > 1) y -= 0.5*fNtsons[i]*gDy;
       else               y -= 0.5*gDy;
       if (!first) {first=1; yu = y;}
       PaintClass(i,u[1],y);
       yl = y;
-      if (gNtsons[i] > 1) y -= 0.5*gNtsons[i]*gDy;
+      if (fNtsons[i] > 1) y -= 0.5*fNtsons[i]*gDy;
       else               y -= 0.5*gDy;
    }
    if (ns == 1) return;

--- a/gui/gui/src/TGButton.cxx
+++ b/gui/gui/src/TGButton.cxx
@@ -623,8 +623,7 @@ TGTextButton::~TGTextButton()
 
 void TGTextButton::Layout()
 {
-   delete fTLayout;
-   fTLayout = nullptr;
+   SafeDelete(fTLayout);
 
    TGFont *font = fClient->GetFontPool()->FindFont(fFontStruct);
    if (!font) {
@@ -3183,7 +3182,7 @@ Bool_t TGSplitButton::HandleMotion(Event_t *event)
 void TGSplitButton::Layout()
 {
    UInt_t dummya = 0, dummyb = 0;
-   delete fTLayout;
+   SafeDelete(fTLayout);
 
    TGFont *font = fClient->GetFontPool()->FindFont(fFontStruct);
    if (!font) {

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -1209,6 +1209,7 @@ Double_t THnBase::ComputeIntegral()
    if (fIntegral[GetNbins()] == 0.) {
       Error("ComputeIntegral", "No hits in regular bins (non over/underflow).");
       delete [] fIntegral;
+      fIntegral = nullptr;
       return 0.;
    }
 


### PR DESCRIPTION
Fixes multiple warnings from DeepCode analyzer.
Main problem - pointer on deleted object kept not reset in some methods, which are not direct class destructors