### PR TITLE
[DF] Use ImportError for Python2 compatibility

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
@@ -19,10 +19,9 @@ from DistRDF.Backends import Utils
 
 try:
     import pyspark
-except ModuleNotFoundError:
-    raise ModuleNotFoundError(
-        ("cannot import module 'pyspark'."
-         " Please make sure Spark is installed."))
+except ImportError:
+    raise ImportError(("cannot import module 'pyspark'. Refer to the Apache Spark documentation "
+                       "for installation instructions."))
 
 
 class SparkBackend(Base.BaseBackend):


### PR DESCRIPTION
Previously if a user with Python2 didn't have pyspark installed on the system it would trigger the wrong error
```
  File "/home/vpadulan/Programs/rootproject/rootinstall/devrelease/lib/DistRDF/Backends/Spark/Backend.py", line 22, in <module>
    except ModuleNotFoundError:
NameError: name 'ModuleNotFoundError' is not defined
```
Switch to the base class `ImportError` which is Python2 compatible, also improve the error message to include the link to the installation guide for pyspark (this works equally for Python2 and Python3):
```
  File "/home/vpadulan/Programs/rootproject/rootinstall/devrelease/lib/DistRDF/Backends/Spark/Backend.py", line 23, in <module>
    raise ImportError(("cannot import module 'pyspark'. Refer to "
ImportError: cannot import module 'pyspark'. Refer to https://spark.apache.org/docs/latest/api/python/getting_started/install.html for instructions on how to install PySpark on your system.
```