### PR TITLE
Doxygen fixes in histpainter files

### DIFF
--- a/hist/histpainter/inc/Hoption.h
+++ b/hist/histpainter/inc/Hoption.h
@@ -14,59 +14,64 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 /*! \struct Hoption_t
-\brief Histogram option structure.
+    \brief Histograms' drawing options structure.
 
-Used internally by `THistpainter` to manage histogram drawing options.
+Used internally by THistPainter to manage histograms' drawing options.
 
 */
 
 
 typedef struct Hoption_t {
-   // The histogram's drawing option may be the concatenation of the following options:
 
-   int Axis;        ///< "A"  Axis are not drawn around the graph.
-   int Bar;         ///< "B"  A Bar chart is drawn at each point.
-   int Curve;       ///< "C"  A smooth Curve is drawn.
-   int Error;       ///< "E"  Draw Errors with current marker type and size.
-   int Fill;        ///< "F"  A fill area is drawn ("CF" draw a smooth fill area).
-   int Off;         ///< "][" With H option, the first and last vertical lines are not drawn.
-   int Keep;        ///< "K"  The status of the histogram is kept in memory
-   int Line;        ///< "L"  A simple polyline beetwen every point is drawn.
-   int Mark;        ///< "P"  The current Marker is drawn at each point
-   int Same;        ///< "S"  Histogram is plotted in the current PAD.
-   int Update;      ///< "U"  Update histogram previously plotted with option K
-   int Star;        ///< "*"  A * is plotted at each point
-   int Arrow;       ///< "ARR"    Draw 2D plot with Arrows.
-   int Box;         ///< "BOX"    Draw 2D plot with proportional Boxes.
-   int Char;        ///< "CHAR"   Draw 2D plot with a character set.
-   int Color;       ///< "COL"    Draw 2D plot with Colored boxes.
-   int Contour;     ///< "CONT"   Draw 2D plot as a Contour plot.
-   int Func;        ///< "FUNC"   Draw only the function (for example in case of fit).
-   int Hist;        ///< "HIST"   Draw only the histogram.
-   int Lego;        ///< "LEGO"   Draw as a Lego plot(LEGO,Lego=1, LEGO1,Lego1=11, LEGO2,Lego=12).
-   int Scat;        ///< "SCAT"   Draw 2D plot a Scatter plot.
-   int Surf;        ///< "SURF"   Draw as a Surface (SURF,Surf=1, SURF1,Surf=11, SURF2,Surf=12)
-   int Text;        ///< "TEXT"   Draw 2D plot with the content of each cell.
-   int Tri;         ///< "TRI"    Draw 2D plot with Delaunay triangles.
-   int Pie;         ///< "PIE"    Draw 1D plot as a pie chart.
-   long Candle;     ///< "CANDLE" Draw a 2D histogram as candle/box plot or violin plot (also with "VIOLIN").
-   int System;      ///< type of coordinate system(1=car,2=pol,3=cyl,4=sph,5=psr)
-   int Zscale;      ///< "Z"   to display the Z scale (color palette)
-   int FrontBox;    ///<  = 0 to suppress the front box
-   int BackBox;     ///<  = 0 to suppress the back box
-   int List;        ///<  = 1 to generate the TObjArray "contours"
-   int Proj;        ///<  1: Aitoff, 2: Mercator, 3: Sinusoidal, 4: Parabolic
-   int AxisPos;     ///<  Axis position
-   int Spec;        ///< TSpectrum graphics
-   int Zero;        ///< if selected with any LEGO option the empty bins are not drawn.
-   int MinimumZero; ///< "MIN0" or gStyle->GetHistMinimumZero()
+///@{
+/// @name Histogram's drawing options
+/// The drawing option may be the concatenation of some of the following options:
 
-   // The following structure members are set to 1 if the corresponding option
-   // in the current style is selected.
+   int Axis;        ///< <b>"A"</b> Axis are not drawn around the graph.
+   int Bar;         ///< <b>"B"</b>, <b>"BAR"</b> and <b>"HBAR"</b> A Bar chart is drawn at each point.
+   int Curve;       ///< <b>"C"</b> A smooth Curve is drawn.
+   int Error;       ///< <b>"En"</b> Draw Errors with current marker type and size (0 <= n <=6).
+   int Fill;        ///< <b>"F"</b> A fill area is drawn ("CF" draw a smooth fill area).
+   int Off;         ///< <b>"]["</b> The first and last vertical lines are not drawn.
+   int Line;        ///< <b>"L"</b> A simple polyline through every point is drawn.
+   int Mark;        ///< <b>"P"</b> The current Marker is drawn at each point.
+   int Same;        ///< <b>"SAME"</b>  Histogram is plotted in the current pad.
+   int Star;        ///< <b>"*"</b> With option <b>"P"</b>, a * is plotted at each point.
+   int Arrow;       ///< <b>"ARR"</b> Draw 2D plot with Arrows.
+   int Box;         ///< <b>"BOX"</b> Draw 2D plot with proportional Boxes.
+   int Char;        ///< <b>"CHAR"</b> Draw 2D plot with a character set.
+   int Color;       ///< <b>"COL"</b> Draw 2D plot with Colored boxes.
+   int Contour;     ///< <b>"CONTn"</b> Draw 2D plot as a Contour plot (0 <= n <= 5).
+   int Func;        ///< <b>"FUNC"</b> Draw only the function (for example in case of fit).
+   int Hist;        ///< <b>"HIST"</b> Draw only the histogram.
+   int Lego;        ///< <b>"LEGO"</b> and <b>"LEGOn"</b> Draw as a Lego plot(1 <= n <= 4).
+   int Scat;        ///< <b>"SCAT"</b> Draw 2D plot a Scatter plot.
+   int Surf;        ///< <b>"SURF"</b> and <b>"SURFn"</b> Draw as a Surface ((1 <= n <= 4).
+   int Text;        ///< <b>"TEXT"</b> Draw 2D plot with the content of each cell.
+   int Tri;         ///< <b>"TRI"</b> Draw TGraph2D with Delaunay triangles.
+   int Pie;         ///< <b>"PIE"</b>  Draw 1D plot as a pie chart.
+   long Candle;     ///< <b>"CANDLE"</b> and <b>"VIOLIN"</b> Draw a 2D histogram as candle/box plot or violin plot.
+   int System;      ///< <b>"POL"</b>, <b>"CYL"</b>, <b>"SPH"</b> and <b>"PSR"</b> Type of coordinate system for 3D plots.
+   int Zscale;      ///< <b>"Z"</b> Display the color palette.
+   int FrontBox;    ///< <b>"FB"</b> Suppress the front box for the 3D plots.
+   int BackBox;     ///< <b>"BB"</b> Suppress the back box for the 3D plots.
+   int List;        ///< <b>"LIST"</b> Generate the TObjArray "contours". To be used with option <b>"CONT"</b>
+   int Proj;        ///< <b>"AITOFF"</b>, <b>"MERCATOR"</b>, <b>"SINUSOIDAL"</b> and <b>"PARABOLIC"</b> projections for 2d plots.
+   int AxisPos;     ///< <b>"X+"</b> and <b>"Y+"</b> Axis position
+   int Spec;        ///< <b>"SPEC"</b> TSpectrum graphics
+   int Zero;        ///< <b>"0"</b> if selected with any LEGO option the empty bins are not drawn.
+   int MinimumZero; ///< <b>"MIN0"</b> or gStyle->GetHistMinimumZero()
+///@}
+
+///@{
+/// @name Other options
+/// The following structure members are set to 1 if the corresponding setting is selected.
 
    int Logx;        ///< log scale in X. Also set by histogram option
    int Logy;        ///< log scale in Y. Also set by histogram option
    int Logz;        ///< log scale in Z. Also set by histogram option
+
+///@}
 
 } Hoption_t;
 

--- a/hist/histpainter/inc/Hparam.h
+++ b/hist/histpainter/inc/Hparam.h
@@ -14,38 +14,39 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 /*! \struct Hparam_t
-\brief Histogram parameters structure.
+    \brief Histogram parameters structure.
 
-Structure to store current histogram parameters.
-Used internally by `THistpainter` to manage histogram parameters.
+Structure to store current histogram's parameters.
+
+Used internally by THistPainter to manage histogram parameters.
 
 */
 
 #include "RtypesCore.h"
 
 typedef struct Hparam_t {
-   Double_t  xbinsize;      ///< bin size in case of equidistant bins
-   Double_t  xlowedge;      ///< low edge of axis
-   Double_t  xmin;          ///< minimum value along X
-   Double_t  xmax;          ///< maximum value along X
-   Double_t  ybinsize;      ///< bin size in case of equidistant bins
-   Double_t  ylowedge;      ///< low edge of axis
-   Double_t  ymin;          ///< minimum value along y
-   Double_t  ymax;          ///< maximum value along y
-   Double_t  zbinsize;      ///< bin size in case of equidistant bins
-   Double_t  zlowedge;      ///< low edge of axis
-   Double_t  zmin;          ///< minimum value along Z
-   Double_t  zmax;          ///< maximum value along Z
-   Double_t  factor;        ///< multiplication factor (normalization)
-   Double_t  allchan;       ///< integrated sum of contents
-   Double_t  baroffset;     ///< offset of bin for bars or legos [0,1]
-   Double_t  barwidth;      ///< width of bin for bars and legos [0,1]
-   Int_t     xfirst;        ///< first bin number along X
-   Int_t     xlast;         ///< last bin number along X
-   Int_t     yfirst;        ///< first bin number along Y
-   Int_t     ylast;         ///< last bin number along Y
-   Int_t     zfirst;        ///< first bin number along Z
-   Int_t     zlast;         ///< last bin number along Z
+   Double_t  xbinsize;      ///< Bin size in case of equidistant bins
+   Double_t  xlowedge;      ///< Low edge of axis
+   Double_t  xmin;          ///< Minimum value along X
+   Double_t  xmax;          ///< Maximum value along X
+   Double_t  ybinsize;      ///< Bin size in case of equidistant bins
+   Double_t  ylowedge;      ///< Low edge of axis
+   Double_t  ymin;          ///< Minimum value along y
+   Double_t  ymax;          ///< Maximum value along y
+   Double_t  zbinsize;      ///< Bin size in case of equidistant bins
+   Double_t  zlowedge;      ///< Low edge of axis
+   Double_t  zmin;          ///< Minimum value along Z
+   Double_t  zmax;          ///< Maximum value along Z
+   Double_t  factor;        ///< Multiplication factor (normalization)
+   Double_t  allchan;       ///< Integrated sum of contents
+   Double_t  baroffset;     ///< Offset of bin for bars or legos [0,1]
+   Double_t  barwidth;      ///< Width of bin for bars and legos [0,1]
+   Int_t     xfirst;        ///< First bin number along X
+   Int_t     xlast;         ///< Last bin number along X
+   Int_t     yfirst;        ///< First bin number along Y
+   Int_t     ylast;         ///< Last bin number along Y
+   Int_t     zfirst;        ///< First bin number along Z
+   Int_t     zlast;         ///< Last bin number along Z
 } Hparam_t;
 
 #endif

--- a/hist/histpainter/inc/TGraph2DPainter.h
+++ b/hist/histpainter/inc/TGraph2DPainter.h
@@ -32,34 +32,34 @@ class TGraph2DPainter : public TObject {
 
 protected:
 
-   Double_t   *fX;            //!Pointer to fGraph2D->fX
-   Double_t   *fY;            //!Pointer to fGraph2D->fY
-   Double_t   *fZ;            //!Pointer to fGraph2D->fZ
-   Double_t   *fXN;           //!Pointer to fDelaunay->fXN
-   Double_t   *fYN;           //!Pointer to fDelaunay->fYN
-   Double_t   *fEX;           //!Pointer to fGraph2D->fXE
-   Double_t   *fEY;           //!Pointer to fGraph2D->fYE
-   Double_t   *fEZ;           //!Pointer to fGraph2D->fZE
-   Double_t    fXNmin;        //!Equal to fDelaunay->fXNmin
-   Double_t    fXNmax;        //!Equal to fDelaunay->fXNmax
-   Double_t    fYNmin;        //!Equal to fDelaunay->fYNmin
-   Double_t    fYNmax;        //!Equal to fDelaunay->fYNmax
-   Double_t    fXmin;         //!
-   Double_t    fXmax;         //!
-   Double_t    fYmin;         //! fGraph2D->fHistogram limits
-   Double_t    fYmax;         //!
-   Double_t    fZmin;         //!
-   Double_t    fZmax;         //!
-   Int_t       fNpoints;      //!Equal to fGraph2D->fNpoints
-   Int_t       fNdt;          //!Equal to fDelaunay->fNdt
-   Int_t      *fPTried;       //!Pointer to fDelaunay->fPTried
-   Int_t      *fNTried;       //!Pointer to fDelaunay->fNTried
-   Int_t      *fMTried;       //!Pointer to fDelaunay->fMTried
+   Double_t   *fX;            ///<! Pointer to fGraph2D->fX
+   Double_t   *fY;            ///<! Pointer to fGraph2D->fY
+   Double_t   *fZ;            ///<! Pointer to fGraph2D->fZ
+   Double_t   *fXN;           ///<! Pointer to fDelaunay->fXN
+   Double_t   *fYN;           ///<! Pointer to fDelaunay->fYN
+   Double_t   *fEX;           ///<! Pointer to fGraph2D->fXE
+   Double_t   *fEY;           ///<! Pointer to fGraph2D->fYE
+   Double_t   *fEZ;           ///<! Pointer to fGraph2D->fZE
+   Double_t    fXNmin;        ///<! Equal to fDelaunay->fXNmin
+   Double_t    fXNmax;        ///<! Equal to fDelaunay->fXNmax
+   Double_t    fYNmin;        ///<! Equal to fDelaunay->fYNmin
+   Double_t    fYNmax;        ///<! Equal to fDelaunay->fYNmax
+   Double_t    fXmin;         ///<! fGraph2D->fHistogram Xmin
+   Double_t    fXmax;         ///<! fGraph2D->fHistogram Xmax
+   Double_t    fYmin;         ///<! fGraph2D->fHistogram Ymin
+   Double_t    fYmax;         ///<! fGraph2D->fHistogram Ymax
+   Double_t    fZmin;         ///<! fGraph2D->fHistogram Zmin
+   Double_t    fZmax;         ///<! fGraph2D->fHistogram Zmax
+   Int_t       fNpoints;      ///<! Equal to fGraph2D->fNpoints
+   Int_t       fNdt;          ///<! Equal to fDelaunay->fNdt
+   Int_t      *fPTried;       ///<! Pointer to fDelaunay->fPTried
+   Int_t      *fNTried;       ///<! Pointer to fDelaunay->fNTried
+   Int_t      *fMTried;       ///<! Pointer to fDelaunay->fMTried
 
 
-   TGraphDelaunay   *fDelaunay; //! Pointer to the TGraphDelaunay2D to be painted
-   TGraphDelaunay2D *fDelaunay2D; //! Pointer to the TGraphDelaunay2D to be painted
-   TGraph2D *fGraph2D;        //! Pointer to the TGraph2D in fDelaunay
+   TGraphDelaunay   *fDelaunay;   ///<! Pointer to the TGraphDelaunay2D to be painted
+   TGraphDelaunay2D *fDelaunay2D; ///<! Pointer to the TGraphDelaunay2D to be painted
+   TGraph2D *fGraph2D;            ///<! Pointer to the TGraph2D in fDelaunay
 
    void     FindTriangles();
    void     PaintLevels(Int_t *v, Double_t *x, Double_t *y, Int_t nblev=0, Double_t *glev=0);

--- a/hist/histpainter/inc/THistPainter.h
+++ b/hist/histpainter/inc/THistPainter.h
@@ -49,25 +49,25 @@ struct THistRenderingRegion
 class THistPainter : public TVirtualHistPainter {
 
 protected:
-   TH1                  *fH;                 //pointer to histogram to paint
-   TAxis                *fXaxis;             //pointer to X axis
-   TAxis                *fYaxis;             //pointer to Y axis
-   TAxis                *fZaxis;             //pointer to Z axis
-   TList                *fFunctions;         //pointer to histogram list of functions
-   TPainter3dAlgorithms *fLego;              //pointer to a TPainter3dAlgorithms object
-   TGraph2DPainter      *fGraph2DPainter;    //pointer to a TGraph2DPainter object
-   TPie                 *fPie;               //pointer to a TPie in case of option PIE
-   Double_t             *fXbuf;              //X buffer coordinates
-   Double_t             *fYbuf;              //Y buffer coordinates
-   Int_t                 fNcuts;             //Number of graphical cuts
-   Int_t                 fCutsOpt[kMaxCuts]; //sign of each cut
-   TCutG                *fCuts[kMaxCuts];    //Pointers to graphical cuts
-   TList                *fStack;             //Pointer to stack of histograms (if any)
-   Int_t                 fShowProjection;    //True if a projection must be drawn
-   TString               fShowOption;        //Option to draw the projection
-   Int_t                 fXHighlightBin;     //X highlight bin
-   Int_t                 fYHighlightBin;     //Y highlight bin
-   TF3                  *fCurrentF3;         //current TF3 function
+   TH1                  *fH;                 ///< Pointer to histogram to paint
+   TAxis                *fXaxis;             ///< Pointer to X axis
+   TAxis                *fYaxis;             ///< Pointer to Y axis
+   TAxis                *fZaxis;             ///< Pointer to Z axis
+   TList                *fFunctions;         ///< Pointer to histogram list of functions
+   TPainter3dAlgorithms *fLego;              ///< Pointer to a TPainter3dAlgorithms object
+   TGraph2DPainter      *fGraph2DPainter;    ///< Pointer to a TGraph2DPainter object
+   TPie                 *fPie;               ///< Pointer to a TPie in case of option PIE
+   Double_t             *fXbuf;              ///< X buffer coordinates
+   Double_t             *fYbuf;              ///< Y buffer coordinates
+   Int_t                 fNcuts;             ///< Number of graphical cuts
+   Int_t                 fCutsOpt[kMaxCuts]; ///< Sign of each cut
+   TCutG                *fCuts[kMaxCuts];    ///< Pointers to graphical cuts
+   TList                *fStack;             ///< Pointer to stack of histograms (if any)
+   Int_t                 fShowProjection;    ///< True if a projection must be drawn
+   TString               fShowOption;        ///< Option to draw the projection
+   Int_t                 fXHighlightBin;     ///< X highlight bin
+   Int_t                 fYHighlightBin;     ///< Y highlight bin
+   TF3                  *fCurrentF3;         ///< Current TF3 function
 
 private:
    mutable TString fObjectInfo;

--- a/hist/histpainter/inc/TPaletteAxis.h
+++ b/hist/histpainter/inc/TPaletteAxis.h
@@ -29,8 +29,8 @@ class TH1;
 class TPaletteAxis : public TPave {
 
 protected:
-   TGaxis       fAxis;          //  palette axis
-   TH1         *fH;             //! pointer to parent histogram
+   TGaxis       fAxis;          ///<  Palette axis
+   TH1         *fH;             ///<! Pointer to parent histogram
 
 public:
    // TPaletteAxis status bits

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -66,8 +66,8 @@
 #include "strlcpy.h"
 
 /*! \class THistPainter
-\ingroup Histpainter
-\brief The histogram painter class. Implements all histograms' drawing's options.
+    \ingroup Histpainter
+    \brief The histogram painter class. Implements all histograms' drawing's options.
 
 - [Introduction](#HP00)
 - [Histograms' plotting options](#HP01)
@@ -260,6 +260,7 @@ using `TH1::GetOption`:
 | "X0"     | When used with one of the "E" option, it suppress the error bar along X as `gStyle->SetErrorX(0)` would do.|
 | "L"      | Draw a line through the bin contents.|
 | "P"      | Draw current marker at each bin except empty bins.|
+| "P*"     | Draw a star marker at each bin except empty bins.|
 | "P0"     | Draw current marker at each bin including empty bins.|
 | "PIE"    | Draw histogram as a Pie Chart.|
 | "*H"     | Draw histogram with a * at each bin.|
@@ -268,53 +269,57 @@ using `TH1::GetOption`:
 
 #### <a name="HP01c"></a> Options supported for 2D histograms
 
-| Option    | Description                                                      |
-|-----------|------------------------------------------------------------------|
-| " "       | Default (scatter plot).|
-| "ARR"     | Arrow mode. Shows gradient between adjacent cells.|
-| "BOX"     | A box is drawn for each cell with surface proportional to the content's absolute value. A negative content is marked with a X.|
-| "BOX1"    | A button is drawn for each cell with surface proportional to content's absolute value. A sunken button is drawn for negative values a raised one for positive.|
-| "COL"     | A box is drawn for each cell with a color scale varying with contents. All the none empty bins are painted. Empty bins are not painted unless some bins have a negative content because in that case the null bins might be not empty.  `TProfile2D` histograms are handled differently because, for this type of 2D histograms, it is possible to know if an empty bin has been filled or not. So even if all the bins' contents are positive some empty bins might be painted. And vice versa, if some bins have a negative content some empty bins might be not painted.|
-| "COLZ"    | Same as "COL". In addition the color palette is also drawn.|
-| "COL2"    | Alternative rendering algorithm to "COL". Can significantly improve rendering performance for large, non-sparse 2-D histograms.|
-| "COLZ2"   | Same as "COL2". In addition the color palette is also drawn.|
-| "Z CJUST" | In combination with colored options "COL","CONT0" etc: Justify labels in the color palette at color boudaries. For more details see `TPaletteAxis`|
-| "CANDLE"  | Draw a candle plot along X axis.|
-| "CANDLEX" | Same as "CANDLE".|
-| "CANDLEY" | Draw a candle plot along Y axis.|
-| "CANDLEXn"| Draw a candle plot along X axis. Different candle-styles with n from 1 to 6.|
-| "CANDLEYn"| Draw a candle plot along Y axis. Different candle-styles with n from 1 to 6.|
-| "VIOLIN"  | Draw a violin plot along X axis.|
-| "VIOLINX" | Same as "VIOLIN".|
-| "VIOLINY" | Draw a violin plot along Y axis.|
-| "VIOLINXn"| Draw a violin plot along X axis. Different violin-styles with n being 1 or 2.|
-| "VIOLINYn"| Draw a violin plot along Y axis. Different violin-styles with n being 1 or 2.|
-| "CONT"    | Draw a contour plot (same as CONT0).|
-| "CONT0"   | Draw a contour plot using surface colors to distinguish contours.|
-| "CONT1"   | Draw a contour plot using line styles to distinguish contours.|
-| "CONT2"   | Draw a contour plot using the same line style for all contours.|
-| "CONT3"   | Draw a contour plot using fill area colors.|
-| "CONT4"   | Draw a contour plot using surface colors (SURF option at theta = 0).|
-| "CONT5"   | (TGraph2D only) Draw a contour plot using Delaunay triangles.|
-| "LIST"    | Generate a list of TGraph objects for each contour.|
-| "CYL"     | Use Cylindrical coordinates. The X coordinate is mapped on the angle and the Y coordinate on the cylinder length.|
-| "POL"     | Use Polar coordinates. The X coordinate is mapped on the angle and the Y coordinate on the radius.|
-| "SAME0"   | Same as "SAME" but do not use the z-axis range of the first plot. |
-| "SAMES0"  | Same as "SAMES" but do not use the z-axis range of the first plot. |
-| "SPH"     | Use Spherical coordinates. The X coordinate is mapped on the latitude and the Y coordinate on the longitude.|
-| "PSR"     | Use PseudoRapidity/Phi coordinates. The X coordinate is mapped on Phi.|
-| "SURF"    | Draw a surface plot with hidden line removal.|
-| "SURF1"   | Draw a surface plot with hidden surface removal.|
-| "SURF2"   | Draw a surface plot using colors to show the cell contents.|
-| "SURF3"   | Same as SURF with in addition a contour view drawn on the top.|
-| "SURF4"   | Draw a surface using Gouraud shading.|
-| "SURF5"   | Same as SURF3 but only the colored contour is drawn. Used with option CYL, SPH or PSR it allows to draw colored contours on a sphere, a cylinder or a in pseudo rapidity space. In cartesian or polar coordinates, option SURF3 is used.|
-| "LEGO9"   | Draw the 3D axis only. Mainly needed for internal use |
-| "FB"      | With LEGO or SURFACE, suppress the Front-Box.|
-| "BB"      | With LEGO or SURFACE, suppress the Back-Box.|
-| "A"       | With LEGO or SURFACE, suppress the axis.|
-| "SCAT"    | Draw a scatter-plot (default).|
-| "[cutg]"  | Draw only the sub-range selected by the TCutG named "cutg".|
+| Option       | Description                                                      |
+|--------------|------------------------------------------------------------------|
+| " "          | Default (scatter plot).|
+| "ARR"        | Arrow mode. Shows gradient between adjacent cells.|
+| "BOX"        | A box is drawn for each cell with surface proportional to the content's absolute value. A negative content is marked with a X.|
+| "BOX1"       | A button is drawn for each cell with surface proportional to content's absolute value. A sunken button is drawn for negative values a raised one for positive.|
+| "COL"        | A box is drawn for each cell with a color scale varying with contents. All the none empty bins are painted. Empty bins are not painted unless some bins have a negative content because in that case the null bins might be not empty.  `TProfile2D` histograms are handled differently because, for this type of 2D histograms, it is possible to know if an empty bin has been filled or not. So even if all the bins' contents are positive some empty bins might be painted. And vice versa, if some bins have a negative content some empty bins might be not painted.|
+| "COLZ"       | Same as "COL". In addition the color palette is also drawn.|
+| "COL2"       | Alternative rendering algorithm to "COL". Can significantly improve rendering performance for large, non-sparse 2-D histograms.|
+| "COLZ2"      | Same as "COL2". In addition the color palette is also drawn.|
+| "Z CJUST"   | In combination with colored options "COL","CONT0" etc: Justify labels in the color palette at color boudaries. For more details see `TPaletteAxis`|
+| "CANDLE"     | Draw a candle plot along X axis.|
+| "CANDLEX"    | Same as "CANDLE".|
+| "CANDLEY"    | Draw a candle plot along Y axis.|
+| "CANDLEXn"   | Draw a candle plot along X axis. Different candle-styles with n from 1 to 6.|
+| "CANDLEYn"   | Draw a candle plot along Y axis. Different candle-styles with n from 1 to 6.|
+| "VIOLIN"     | Draw a violin plot along X axis.|
+| "VIOLINX"    | Same as "VIOLIN".|
+| "VIOLINY"    | Draw a violin plot along Y axis.|
+| "VIOLINXn"   | Draw a violin plot along X axis. Different violin-styles with n being 1 or 2.|
+| "VIOLINYn"   | Draw a violin plot along Y axis. Different violin-styles with n being 1 or 2.|
+| "CONT"       | Draw a contour plot (same as CONT0).|
+| "CONT0"      | Draw a contour plot using surface colors to distinguish contours.|
+| "CONT1"      | Draw a contour plot using line styles to distinguish contours.|
+| "CONT2"      | Draw a contour plot using the same line style for all contours.|
+| "CONT3"      | Draw a contour plot using fill area colors.|
+| "CONT4"      | Draw a contour plot using surface colors (SURF option at theta = 0).|
+| "CONT5"      | (TGraph2D only) Draw a contour plot using Delaunay triangles.|
+| "LIST"       | Generate a list of TGraph objects for each contour.|
+| "SAME0"      | Same as "SAME" but do not use the z-axis range of the first plot. |
+| "SAMES0"     | Same as "SAMES" but do not use the z-axis range of the first plot. |
+| "CYL"        | Use Cylindrical coordinates. The X coordinate is mapped on the angle and the Y coordinate on the cylinder length.|
+| "POL"        | Use Polar coordinates. The X coordinate is mapped on the angle and the Y coordinate on the radius.|
+| "SPH"        | Use Spherical coordinates. The X coordinate is mapped on the latitude and the Y coordinate on the longitude.|
+| "PSR"        | Use PseudoRapidity/Phi coordinates. The X coordinate is mapped on Phi.|
+| "SURF"       | Draw a surface plot with hidden line removal.|
+| "SURF1"      | Draw a surface plot with hidden surface removal.|
+| "SURF2"      | Draw a surface plot using colors to show the cell contents.|
+| "SURF3"      | Same as SURF with in addition a contour view drawn on the top.|
+| "SURF4"      | Draw a surface using Gouraud shading.|
+| "SURF5"      | Same as SURF3 but only the colored contour is drawn. Used with option CYL, SPH or PSR it allows to draw colored contours on a sphere, a cylinder or a in pseudo rapidity space. In cartesian or polar coordinates, option SURF3 is used.|
+| "AITOFF"     | Draw a contour via an AITOFF projection.|
+| "MERCATOR"   | Draw a contour via an Mercator projection.|
+| "SINUSOIDAL" | Draw a contour via an Sinusoidal projection.|
+| "PARABOLIC"  | Draw a contour via an Parabolic projection.|
+| "LEGO9"      | Draw the 3D axis only. Mainly needed for internal use |
+| "FB"         | With LEGO or SURFACE, suppress the Front-Box.|
+| "BB"         | With LEGO or SURFACE, suppress the Back-Box.|
+| "A"          | With LEGO or SURFACE, suppress the axis.|
+| "SCAT"       | Draw a scatter-plot (default).|
+| "[cutg]"     | Draw only the sub-range selected by the TCutG named "cutg".|
 
 
 #### <a name="HP01d"></a> Options supported for 3D histograms
@@ -3975,14 +3980,14 @@ Int_t THistPainter::MakeChopt(Option_t *choptin)
    strlcpy(chopt,choptin,128);
    Int_t hdim = fH->GetDimension();
 
-   Hoption.Axis = Hoption.Bar    = Hoption.Curve   = Hoption.Error   = 0;
-   Hoption.Hist = Hoption.Line   = Hoption.Mark    = Hoption.Fill    = 0;
-   Hoption.Same = Hoption.Func   = Hoption.Scat                      = 0;
-   Hoption.Star = Hoption.Arrow  = Hoption.Box     = Hoption.Text    = 0;
-   Hoption.Char = Hoption.Color  = Hoption.Contour = Hoption.Logx    = 0;
-   Hoption.Logy = Hoption.Logz   = Hoption.Lego    = Hoption.Surf    = 0;
-   Hoption.Off  = Hoption.Tri    = Hoption.Proj    = Hoption.AxisPos = 0;
-   Hoption.Spec = Hoption.Pie    = Hoption.Candle  = 0;
+   Hoption.Axis    = Hoption.Bar     = Hoption.Curve   = Hoption.Error   = 0;
+   Hoption.Hist    = Hoption.Line    = Hoption.Mark    = Hoption.Fill    = 0;
+   Hoption.Same    = Hoption.Func    = Hoption.Scat    = Hoption.Star    = 0;
+   Hoption.Arrow   = Hoption.Box     = Hoption.Text    = Hoption.Color   = 0;
+   Hoption.Contour = Hoption.Logx    = Hoption.Logy    = Hoption.Logz    = 0;
+   Hoption.Lego    = Hoption.Surf    = Hoption.Off     = Hoption.Tri     = 0;
+   Hoption.Proj    = Hoption.AxisPos = Hoption.Spec    = Hoption.Pie     = 0;
+   Hoption.Candle  = 0;
 
    //    special 2D options
    Hoption.List     = 0;
@@ -4225,7 +4230,6 @@ Int_t THistPainter::MakeChopt(Option_t *choptin)
          Hoption.Hist = 1;
       }
    }
-   l = strstr(chopt,"CHAR"); if (l) { Hoption.Char   = 1; memcpy(l,"    ",4); Hoption.Scat = 0; }
    l = strstr(chopt,"FUNC"); if (l) { Hoption.Func   = 2; memcpy(l,"    ",4); Hoption.Hist = 0; }
    l = strstr(chopt,"HIST"); if (l) { Hoption.Hist   = 2; memcpy(l,"    ",4); Hoption.Func = 0; Hoption.Error = 0;}
    l = strstr(chopt,"AXIS"); if (l) { Hoption.Axis   = 1; memcpy(l,"    ",4); }

--- a/hist/histpainter/src/TPainter3dAlgorithms.cxx
+++ b/hist/histpainter/src/TPainter3dAlgorithms.cxx
@@ -10,8 +10,8 @@
  *************************************************************************/
 
 /*! \class TPainter3dAlgorithms
-\ingroup Histpainter
-\brief The Legos and Surfaces painter class.
+    \ingroup Histpainter
+    \brief The Legos and Surfaces painter class.
 
 3D graphics representations package.
 
@@ -780,8 +780,8 @@ void TPainter3dAlgorithms::DrawFaceMove3(Int_t *icodes, Double_t *xyz, Int_t np,
    }
 
    //          Subdivide quadrilateral in two triangles
-   Int_t npol[2] = { np, 0 }; // number of vertices in subpolygons
-   Int_t ipol[2] = {  0, 0 }; // first vertices in subpolygons
+   Int_t npol[2] = { np, 0 }; // number of vertices in sub-polygons
+   Int_t ipol[2] = {  0, 0 }; // first vertices in sub-polygons
    if (np == 4 && icodes[2] != 0) {
       p3[4*3 + 0] = p3[0];
       p3[4*3 + 1] = p3[1];
@@ -864,8 +864,8 @@ void TPainter3dAlgorithms::DrawLevelLines(Int_t *icodes, Double_t *xyz, Int_t np
    }
 
    //          Subdivide quadrilateral in two triangles
-   Int_t npol[2] = { np, 0 }; // number of vertices in subpolygons
-   Int_t ipol[2] = {  0, 0 }; // first vertices in subpolygons
+   Int_t npol[2] = { np, 0 }; // number of vertices in sub-polygons
+   Int_t ipol[2] = {  0, 0 }; // first vertices in sub-polygons
    if (np == 4 && icodes[2] != 0) {
       p3[4*3 + 0] = p3[0];
       p3[4*3 + 1] = p3[1];

--- a/hist/histpainter/src/TPainter3dAlgorithms.h
+++ b/hist/histpainter/src/TPainter3dAlgorithms.h
@@ -28,27 +28,27 @@ class TView;
 class TPainter3dAlgorithms : public TAttLine, public TAttFill {
 
 private:
-   Double_t     fRmin[3];          /// Lower limits of lego
-   Double_t     fRmax[3];          /// Upper limits of lego
-   Double_t     *fAphi;            ///
-   Int_t        fNaphi;            /// Size of fAphi
-   Int_t        fSystem;           /// Coordinate system
-   Int_t       *fColorMain;        ///
-   Int_t       *fColorDark;        ///
-   Int_t        fColorTop;         ///
-   Int_t        fColorBottom;      ///
-   Int_t       *fEdgeColor;        ///
-   Int_t       *fEdgeStyle;        ///
-   Int_t       *fEdgeWidth;        ///
-   Int_t        fEdgeIdx;          ///
-   Int_t        fMesh;             /// (=1 if mesh to draw, o otherwise)
-   Int_t        fNStack;           /// Number of histograms in the stack to be painted
-   Double_t     fFmin;             /// IsoSurface minimum function value
-   Double_t     fFmax;             /// IsoSurface maximum function value
-   Int_t        fNcolor;           /// Number of colours per Iso surface
-   Int_t        fIc1;              /// Base colour for the 1st Iso Surface
-   Int_t        fIc2;              /// Base colour for the 2nd Iso Surface
-   Int_t        fIc3;              /// Base colour for the 3rd Iso Surface
+   Double_t     fRmin[3];          ///< Lower limits of lego
+   Double_t     fRmax[3];          ///< Upper limits of lego
+   Double_t     *fAphi;            ///<
+   Int_t        fNaphi;            ///< Size of fAphi
+   Int_t        fSystem;           ///< Coordinate system
+   Int_t       *fColorMain;        ///<
+   Int_t       *fColorDark;        ///<
+   Int_t        fColorTop;         ///<
+   Int_t        fColorBottom;      ///<
+   Int_t       *fEdgeColor;        ///<
+   Int_t       *fEdgeStyle;        ///<
+   Int_t       *fEdgeWidth;        ///<
+   Int_t        fEdgeIdx;          ///<
+   Int_t        fMesh;             ///< (=1 if mesh to draw, o otherwise)
+   Int_t        fNStack;           ///< Number of histograms in the stack to be painted
+   Double_t     fFmin;             ///< IsoSurface minimum function value
+   Double_t     fFmax;             ///< IsoSurface maximum function value
+   Int_t        fNcolor;           ///< Number of colours per Iso surface
+   Int_t        fIc1;              ///< Base colour for the 1st Iso Surface
+   Int_t        fIc2;              ///< Base colour for the 2nd Iso Surface
+   Int_t        fIc3;              ///< Base colour for the 3rd Iso Surface
 
 public:
    typedef void (TPainter3dAlgorithms::*DrawFaceFunc_t)(Int_t *, Double_t *, Int_t, Int_t *, Double_t *);
@@ -56,9 +56,9 @@ public:
    typedef void (TPainter3dAlgorithms::*SurfaceFunc_t)(Int_t,Int_t,Double_t*,Double_t*);
 
 private:
-   DrawFaceFunc_t  fDrawFace;        /// pointer to face drawing function
-   LegoFunc_t      fLegoFunction;    /// pointer to lego function
-   SurfaceFunc_t   fSurfaceFunction; /// pointer to surface function
+   DrawFaceFunc_t  fDrawFace;        ///< Pointer to face drawing function
+   LegoFunc_t      fLegoFunction;    ///< Pointer to lego function
+   SurfaceFunc_t   fSurfaceFunction; ///< Pointer to surface function
 
 public:
    TPainter3dAlgorithms();
@@ -123,8 +123,8 @@ private:
 
    void    Luminosity(TView *view, Double_t *anorm, Double_t &flum);
 
-//       Light and surface properties
-//
+///@{
+/// @name Light and surface properties
 public:
    void    LightSource(Int_t nl, Double_t yl, Double_t xscr, Double_t yscr, Double_t zscr, Int_t &irep);
    void    SurfaceProperty(Double_t qqa, Double_t qqd, Double_t qqs, Int_t nnqs, Int_t &irep);
@@ -139,10 +139,11 @@ private:
    Double_t     fQD;
    Double_t     fQS;
    Int_t        fNqs;
+///@}
 
-//        Moving screen - specialized hidden line removal algorithm
-//        for rendering 2D histograms
-//
+///@{
+/// @name Moving screen
+/// Specialized hidden line removal algorithm for rendering 2D histograms
 public:
    void    InitMoveScreen(Double_t xmin, Double_t xmax);
    void    FindVisibleDraw(Double_t *r1, Double_t *r2);
@@ -158,10 +159,11 @@ private:
    static const Int_t    NumOfSlices = 2000;
    Double_t    fU[NumOfSlices*2];
    Double_t    fD[NumOfSlices*2];
+///@}
 
-//        Raster screen - specialized hidden line removal algorithm
-//        for rendering 3D polygons ordered by depth (front-to-back)
-//
+///@{
+/// @name Raster screen
+/// Specialized hidden line removal algorithm for rendering 3D polygons ordered by depth (front-to-back)
 public:
    void    InitRaster(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax, Int_t nx, Int_t ny);
    void    ClearRaster();
@@ -169,19 +171,21 @@ public:
    void    FillPolygonBorder(Int_t nn, Double_t *xy);
 
 private:
-   Double_t    fXrast;     // minimal x
-   Double_t    fYrast;     // minimal y
-   Double_t    fDXrast;    // x size
-   Double_t    fDYrast;    // y size
-   Int_t       fNxrast;    // number of pixels in x
-   Int_t       fNyrast;    // number of pixels in y
-   Int_t       fIfrast;    // flag, if it not zero them the algorithm is off
-   Int_t       *fRaster;   // pointer to raster buffer
-   Int_t       fJmask[30]; // indices of subsets of n-bit masks (n is from 1 to 30)
-   Int_t       fMask[465]; // set of masks (30+29+28+...+1)=465
+   Double_t    fXrast;     ///< Minimal x
+   Double_t    fYrast;     ///< Minimal y
+   Double_t    fDXrast;    ///< X size
+   Double_t    fDYrast;    ///< Y size
+   Int_t       fNxrast;    ///< Number of pixels in x
+   Int_t       fNyrast;    ///< Number of pixels in y
+   Int_t       fIfrast;    ///< Flag, if it not zero them the algorithm is off
+   Int_t       *fRaster;   ///< Pointer to raster buffer
+   Int_t       fJmask[30]; ///< Indices of subsets of n-bit masks (n is from 1 to 30)
+   Int_t       fMask[465]; ///< Set of masks (30+29+28+...+1)=465
+///@}
 
-//        Marching Cubes 33 - construction of iso-surfaces, see publication CERN-CN-95-17
-//
+///@{
+/// @name Marching Cubes
+/// Construction of iso-surfaces, see publication CERN-CN-95-17
 public:
    void    MarchingCube(Double_t fiso, Double_t p[8][3], Double_t f[8], Double_t g[8][3], Int_t &nnod, Int_t &ntria, Double_t xyz[][3], Double_t grad[][3], Int_t itria[][3]);
 
@@ -200,17 +204,20 @@ protected:
    void    MarchingCubeFindNodes(Int_t nnod, Int_t *ie, Double_t xyz[52][3], Double_t grad[52][3]);
 
 private:
-   Double_t    fP8[8][3]; // vertices
-   Double_t    fF8[8];    // function values
-   Double_t    fG8[8][3]; // function gradients
+   Double_t    fP8[8][3]; ///< Vertices
+   Double_t    fF8[8];    ///< Function values
+   Double_t    fG8[8][3]; ///< Function gradients
+///@}
 
-//        Z-depth sorting algorithm for set of triangles
-//
+///@{
+/// @name Z-depth
+/// Sorting algorithm for set of triangles
 public:
    void    ZDepth(Double_t xyz[52][3], Int_t &nface, Int_t iface[48][3], Double_t dface[48][6], Double_t abcd[48][4], Int_t *iorder);
 
 protected:
    void    TestEdge(Double_t del, Double_t xyz[52][3], Int_t i1, Int_t i2, Int_t iface[3], Double_t abcd[4], Int_t &irep);
+///@}
 
 };
 

--- a/hist/histpainter/src/TPaletteAxis.cxx
+++ b/hist/histpainter/src/TPaletteAxis.cxx
@@ -29,8 +29,8 @@ ClassImp(TPaletteAxis);
 ////////////////////////////////////////////////////////////////////////////////
 
 /*! \class TPaletteAxis
-\ingroup Histpainter
-\brief The palette painting class.
+    \ingroup Histpainter
+    \brief The palette painting class.
 
 A `TPaletteAxis` object is used to display the color palette when
 drawing 2-d histograms.
@@ -82,13 +82,14 @@ As default labels and ticks are drawn by `TGAxis` at equidistant (lin or log)
 points as controlled by SetNdivisions.
 If option "CJUST" is given labels and ticks are justified at the
 color boundaries defined by the contour levels.
-In this case no optimization can be done. It is responsiblity of the
+In this case no optimization can be done. It is responsibility of the
 user to adjust minimum, maximum of the histogram and/or the contour levels
 to get a reasonable look of the plot.
 Only overlap of the labels is avoided if too many contour levels are used.
 
 This option is especially useful with user defined contours.
 An example is shown here:
+
 Begin_Macro(source)
 {
    gStyle->SetOptStat(0);


### PR DESCRIPTION
- Several fixes to make the documentation of data members visible in the reference guide.
- In Hoption_t, three useless struct members were removed: Keep, Char, Update. They were left over from CERNLIB fortran code !
- TPainter3dAlgorithms use the Doxygen grouping mechanism @{ and @} to show the structure in the data members which was indicated by simple C++ comments
- Few documentation update in THistPainter
- Fix typos

