### PR TITLE
cling Debug Info

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1660,7 +1660,9 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
                        ? CodeGenOptions::OnlyAlwaysInlining
                        : CodeGenOptions::NormalInlining);
 
-    // CGOpts.setDebugInfo(clang::CodeGenOptions::FullDebugInfo);
+    CGOpts.setDebugInfo(clang::codegenoptions::FullDebugInfo);
+    CGOpts.DebugInfoForProfiling = 1;
+
     // CGOpts.EmitDeclMetadata = 1; // For unloading, for later
     // aliasing the complete ctor to the base ctor causes the JIT to crash
     CGOpts.CXXCtorDtorAliases = 0;

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -367,7 +367,7 @@ IncrementalJIT::IncrementalJIT(IncrementalExecutor& exe,
   llvm::sys::DynamicLibrary::LoadLibraryPermanently(0, 0);
 
   // Make debug symbols available.
-  m_GDBListener = 0; // JITEventListener::createGDBRegistrationListener();
+  m_GDBListener = JITEventListener::createGDBRegistrationListener();
 
 // #if MCJIT
 //   llvm::EngineBuilder builder(std::move(m));

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.h
@@ -54,7 +54,7 @@ private:
     NotifyObjectLoadedT(IncrementalJIT &jit) : m_JIT(jit) {}
     void operator()(llvm::orc::VModuleKey K,
                     const llvm::object::ObjectFile &Object,
-                    const llvm::LoadedObjectInfo &/*Info*/) const {
+                    const llvm::RuntimeDyld::LoadedObjectInfo &Info) const {
       m_JIT.m_UnfinalizedSections[K]
         = std::move(m_JIT.m_SectionsAllocatedSinceLastLoad);
       m_JIT.m_SectionsAllocatedSinceLastLoad = SectionAddrSet();
@@ -66,8 +66,8 @@ private:
       // disabling this since we have globally disabled this functionality in
       // IncrementalJIT.cpp (m_GDBListener = 0).
       //
-      // if (auto GDBListener = m_JIT.m_GDBListener)
-      //   GDBListener->NotifyObjectEmitted(*Object->getBinary(), Info);
+      if (auto GDBListener = m_JIT.m_GDBListener)
+        GDBListener->notifyObjectLoaded(K, Object, Info);
 
       for (const auto &Symbol: Object.symbols()) {
         auto Flags = Symbol.getFlags();


### PR DESCRIPTION
works with gdb and lldb built from llvm>=11 (i.e. likely not Xcode).
You need to first set a breakpoint "into the blue", e.g. `b hsimple.C:40`.
It will get resolved as the JIT emits symbols. Upon re-running the
process, the breakpoint will *not* get picked up again.

Next: disabled-by-default (because it duplicates all JIT objects, i.e.
increases memory size) and some kind of option to turn it on.