### PR TITLE
Follow HTTP redirects when using curl

### DIFF
--- a/tmva/pymva/test/testPyAdaBoostClassification.C
+++ b/tmva/pymva/test/testPyAdaBoostClassification.C
@@ -14,7 +14,7 @@ int testPyAdaBoostClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
+      gSystem->Exec("curl -L -O http://root.cern.ch/files/tmva_class_example.root");
    TFile *input = TFile::Open(fname);
 
    // Setup PyMVA and factory

--- a/tmva/pymva/test/testPyAdaBoostClassification.C
+++ b/tmva/pymva/test/testPyAdaBoostClassification.C
@@ -14,7 +14,7 @@ int testPyAdaBoostClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root");
+      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
    TFile *input = TFile::Open(fname);
 
    // Setup PyMVA and factory

--- a/tmva/pymva/test/testPyGTBClassification.C
+++ b/tmva/pymva/test/testPyGTBClassification.C
@@ -14,7 +14,7 @@ int testPyGTBClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root");
+      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
    TFile *input = TFile::Open(fname);
 
    // Setup PyMVA and factory

--- a/tmva/pymva/test/testPyGTBClassification.C
+++ b/tmva/pymva/test/testPyGTBClassification.C
@@ -14,7 +14,7 @@ int testPyGTBClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
+      gSystem->Exec("curl -L -O http://root.cern.ch/files/tmva_class_example.root");
    TFile *input = TFile::Open(fname);
 
    // Setup PyMVA and factory

--- a/tmva/pymva/test/testPyKerasClassification.C
+++ b/tmva/pymva/test/testPyKerasClassification.C
@@ -25,7 +25,7 @@ int testPyKerasClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
+      gSystem->Exec("curl -L -O http://root.cern.ch/files/tmva_class_example.root");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tmva/pymva/test/testPyKerasClassification.C
+++ b/tmva/pymva/test/testPyKerasClassification.C
@@ -25,7 +25,7 @@ int testPyKerasClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root");
+      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tmva/pymva/test/testPyKerasRegression.C
+++ b/tmva/pymva/test/testPyKerasRegression.C
@@ -25,7 +25,7 @@ int testPyKerasRegression(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_reg_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_reg_example.root -L");
+      gSystem->Exec("curl -L -O http://root.cern.ch/files/tmva_reg_example.root");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tmva/pymva/test/testPyKerasRegression.C
+++ b/tmva/pymva/test/testPyKerasRegression.C
@@ -25,7 +25,7 @@ int testPyKerasRegression(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_reg_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_reg_example.root");
+      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_reg_example.root -L");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tmva/pymva/test/testPyRandomForestClassification.C
+++ b/tmva/pymva/test/testPyRandomForestClassification.C
@@ -14,7 +14,7 @@ int testPyRandomForestClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root");
+      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
    TFile *input = TFile::Open(fname);
 
    // Setup PyMVA and factory

--- a/tmva/pymva/test/testPyRandomForestClassification.C
+++ b/tmva/pymva/test/testPyRandomForestClassification.C
@@ -14,7 +14,7 @@ int testPyRandomForestClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
+      gSystem->Exec("curl -L -O http://root.cern.ch/files/tmva_class_example.root");
    TFile *input = TFile::Open(fname);
 
    // Setup PyMVA and factory

--- a/tmva/pymva/test/testPyTorchClassification.C
+++ b/tmva/pymva/test/testPyTorchClassification.C
@@ -15,7 +15,7 @@ int testPyTorchClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
+      gSystem->Exec("curl -L -O http://root.cern.ch/files/tmva_class_example.root");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tmva/pymva/test/testPyTorchClassification.C
+++ b/tmva/pymva/test/testPyTorchClassification.C
@@ -15,7 +15,7 @@ int testPyTorchClassification(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_class_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root");
+      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_class_example.root -L");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tmva/pymva/test/testPyTorchRegression.C
+++ b/tmva/pymva/test/testPyTorchRegression.C
@@ -15,7 +15,7 @@ int testPyTorchRegression(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_reg_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_reg_example.root");
+      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_reg_example.root -L");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tmva/pymva/test/testPyTorchRegression.C
+++ b/tmva/pymva/test/testPyTorchRegression.C
@@ -15,7 +15,7 @@ int testPyTorchRegression(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_reg_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -L http://root.cern.ch/files/tmva_reg_example.root -L");
+      gSystem->Exec("curl -O -L http://root.cern.ch/files/tmva_reg_example.root");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tmva/pymva/test/testPyTorchRegression.C
+++ b/tmva/pymva/test/testPyTorchRegression.C
@@ -15,7 +15,7 @@ int testPyTorchRegression(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_reg_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O http://root.cern.ch/files/tmva_reg_example.root -L");
+      gSystem->Exec("curl -L http://root.cern.ch/files/tmva_reg_example.root -L");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tmva/pymva/test/testPyTorchRegression.C
+++ b/tmva/pymva/test/testPyTorchRegression.C
@@ -15,7 +15,7 @@ int testPyTorchRegression(){
    std::cout << "Get test data..." << std::endl;
    TString fname = "./tmva_reg_example.root";
    if (gSystem->AccessPathName(fname))  // file does not exist in local directory
-      gSystem->Exec("curl -O -L http://root.cern.ch/files/tmva_reg_example.root");
+      gSystem->Exec("curl -L -O http://root.cern.ch/files/tmva_reg_example.root");
    TFile *input = TFile::Open(fname);
 
    // Build model from python file

--- a/tutorials/tmva/keras/ApplicationClassificationKeras.py
+++ b/tutorials/tmva/keras/ApplicationClassificationKeras.py
@@ -21,7 +21,7 @@ reader = TMVA.Reader("Color:!Silent")
 
 # Load data
 if not isfile('tmva_class_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root'])
+    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root', '-L'])
 
 data = TFile.Open('tmva_class_example.root')
 signal = data.Get('TreeS')

--- a/tutorials/tmva/keras/ApplicationClassificationKeras.py
+++ b/tutorials/tmva/keras/ApplicationClassificationKeras.py
@@ -21,7 +21,7 @@ reader = TMVA.Reader("Color:!Silent")
 
 # Load data
 if not isfile('tmva_class_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root', '-L'])
+    call(['curl', '-L', '-O', 'http://root.cern.ch/files/tmva_class_example.root'])
 
 data = TFile.Open('tmva_class_example.root')
 signal = data.Get('TreeS')

--- a/tutorials/tmva/keras/ApplicationRegressionKeras.py
+++ b/tutorials/tmva/keras/ApplicationRegressionKeras.py
@@ -21,7 +21,7 @@ reader = TMVA.Reader("Color:!Silent")
 
 # Load data
 if not isfile('tmva_reg_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root'])
+    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root', '-L'])
 
 data = TFile.Open('tmva_reg_example.root')
 tree = data.Get('TreeR')

--- a/tutorials/tmva/keras/ApplicationRegressionKeras.py
+++ b/tutorials/tmva/keras/ApplicationRegressionKeras.py
@@ -21,7 +21,7 @@ reader = TMVA.Reader("Color:!Silent")
 
 # Load data
 if not isfile('tmva_reg_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root', '-L'])
+    call(['curl', '-L', '-O', 'http://root.cern.ch/files/tmva_reg_example.root'])
 
 data = TFile.Open('tmva_reg_example.root')
 tree = data.Get('TreeR')

--- a/tutorials/tmva/keras/ClassificationKeras.py
+++ b/tutorials/tmva/keras/ClassificationKeras.py
@@ -28,7 +28,7 @@ factory = TMVA.Factory('TMVAClassification', output,
 
 # Load data
 if not isfile('tmva_class_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root', '-L'])
+    call(['curl', '-L', '-O', 'http://root.cern.ch/files/tmva_class_example.root'])
 
 data = TFile.Open('tmva_class_example.root')
 signal = data.Get('TreeS')

--- a/tutorials/tmva/keras/ClassificationKeras.py
+++ b/tutorials/tmva/keras/ClassificationKeras.py
@@ -28,7 +28,7 @@ factory = TMVA.Factory('TMVAClassification', output,
 
 # Load data
 if not isfile('tmva_class_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root'])
+    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root', '-L'])
 
 data = TFile.Open('tmva_class_example.root')
 signal = data.Get('TreeS')

--- a/tutorials/tmva/keras/RegressionKeras.py
+++ b/tutorials/tmva/keras/RegressionKeras.py
@@ -28,7 +28,7 @@ factory = TMVA.Factory('TMVARegression', output,
 
 # Load data
 if not isfile('tmva_reg_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root', '-L'])
+    call(['curl', '-L', '-O', 'http://root.cern.ch/files/tmva_reg_example.root'])
 
 data = TFile.Open('tmva_reg_example.root')
 tree = data.Get('TreeR')

--- a/tutorials/tmva/keras/RegressionKeras.py
+++ b/tutorials/tmva/keras/RegressionKeras.py
@@ -28,7 +28,7 @@ factory = TMVA.Factory('TMVARegression', output,
 
 # Load data
 if not isfile('tmva_reg_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root'])
+    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root', '-L'])
 
 data = TFile.Open('tmva_reg_example.root')
 tree = data.Get('TreeR')

--- a/tutorials/tmva/pytorch/ApplicationClassificationPyTorch.py
+++ b/tutorials/tmva/pytorch/ApplicationClassificationPyTorch.py
@@ -24,7 +24,7 @@ reader = TMVA.Reader("Color:!Silent")
 
 # Load data
 if not isfile('tmva_class_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root'])
+    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root', '-L'])
 
 data = TFile.Open('tmva_class_example.root')
 signal = data.Get('TreeS')

--- a/tutorials/tmva/pytorch/ApplicationClassificationPyTorch.py
+++ b/tutorials/tmva/pytorch/ApplicationClassificationPyTorch.py
@@ -24,7 +24,7 @@ reader = TMVA.Reader("Color:!Silent")
 
 # Load data
 if not isfile('tmva_class_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root', '-L'])
+    call(['curl', '-L', '-O', 'http://root.cern.ch/files/tmva_class_example.root'])
 
 data = TFile.Open('tmva_class_example.root')
 signal = data.Get('TreeS')

--- a/tutorials/tmva/pytorch/ApplicationRegressionPyTorch.py
+++ b/tutorials/tmva/pytorch/ApplicationRegressionPyTorch.py
@@ -24,7 +24,7 @@ reader = TMVA.Reader("Color:!Silent")
 
 # Load data
 if not isfile('tmva_reg_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root'])
+    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root', '-L'])
 
 data = TFile.Open('tmva_reg_example.root')
 tree = data.Get('TreeR')

--- a/tutorials/tmva/pytorch/ApplicationRegressionPyTorch.py
+++ b/tutorials/tmva/pytorch/ApplicationRegressionPyTorch.py
@@ -24,7 +24,7 @@ reader = TMVA.Reader("Color:!Silent")
 
 # Load data
 if not isfile('tmva_reg_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root', '-L'])
+    call(['curl', '-L', '-O', 'http://root.cern.ch/files/tmva_reg_example.root'])
 
 data = TFile.Open('tmva_reg_example.root')
 tree = data.Get('TreeR')

--- a/tutorials/tmva/pytorch/ClassificationPyTorch.py
+++ b/tutorials/tmva/pytorch/ClassificationPyTorch.py
@@ -30,7 +30,7 @@ factory = TMVA.Factory('TMVAClassification', output,
 
 # Load data
 if not isfile('tmva_class_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root', '-L'])
+    call(['curl', '-L', '-O', 'http://root.cern.ch/files/tmva_class_example.root'])
 
 data = TFile.Open('tmva_class_example.root')
 signal = data.Get('TreeS')

--- a/tutorials/tmva/pytorch/ClassificationPyTorch.py
+++ b/tutorials/tmva/pytorch/ClassificationPyTorch.py
@@ -30,7 +30,7 @@ factory = TMVA.Factory('TMVAClassification', output,
 
 # Load data
 if not isfile('tmva_class_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root'])
+    call(['curl', '-O', 'http://root.cern.ch/files/tmva_class_example.root', '-L'])
 
 data = TFile.Open('tmva_class_example.root')
 signal = data.Get('TreeS')

--- a/tutorials/tmva/pytorch/RegressionPyTorch.py
+++ b/tutorials/tmva/pytorch/RegressionPyTorch.py
@@ -30,7 +30,7 @@ factory = TMVA.Factory('TMVARegression', output,
 
 # Load data
 if not isfile('tmva_reg_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root'])
+    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root', '-L'])
 
 data = TFile.Open('tmva_reg_example.root')
 tree = data.Get('TreeR')

--- a/tutorials/tmva/pytorch/RegressionPyTorch.py
+++ b/tutorials/tmva/pytorch/RegressionPyTorch.py
@@ -30,7 +30,7 @@ factory = TMVA.Factory('TMVARegression', output,
 
 # Load data
 if not isfile('tmva_reg_example.root'):
-    call(['curl', '-O', 'http://root.cern.ch/files/tmva_reg_example.root', '-L'])
+    call(['curl', '-L', '-O', 'http://root.cern.ch/files/tmva_reg_example.root'])
 
 data = TFile.Open('tmva_reg_example.root')
 tree = data.Get('TreeR')


### PR DESCRIPTION
curls default behaviour is to not follow HTTP redirects, resulting in some of the tutorials not functioning as users attempt to operate on HTML error pages rather than valid ROOT files. A specific example prior to this commit would be the URL for ClassificationKeras.py

Since it's impossible to know in advance which URL's might end up having redirects in the future, I've simply added '-L' to every invocation of CURL (including in a few tests) which should prevent any issues in the future and otherwise work exactly the same for files which don't have redirects today.

(curl behaviour tested on Ubuntu 20.04)