### PR TITLE
ROOT-9066: do not mark TBB include as SYSTEM

### DIFF
--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -55,7 +55,7 @@ if(imt)
     src/TThreadExecutor.cxx
   )
 
-  target_include_directories(Imt SYSTEM PRIVATE ${TBB_INCLUDE_DIRS})
+  target_include_directories(Imt PRIVATE ${TBB_INCLUDE_DIRS})
   target_link_libraries(Imt PRIVATE ${TBB_LIBRARIES})
   set_target_properties(Imt PROPERTIES COMPILE_FLAGS "${TBB_CXXFLAGS}")
 

--- a/core/thread/CMakeLists.txt
+++ b/core/thread/CMakeLists.txt
@@ -82,7 +82,7 @@ set_source_files_properties(src/RConcurrentHashColl.cxx
   PROPERTIES COMPILE_FLAGS -I${CMAKE_SOURCE_DIR}/core/foundation/res)
 
 if((tbb OR builtin_tbb) AND NOT MSVC)
-  target_include_directories(Thread SYSTEM PRIVATE ${TBB_INCLUDE_DIRS})
+  target_include_directories(Thread PRIVATE ${TBB_INCLUDE_DIRS})
   target_link_libraries(Thread PRIVATE ${TBB_LIBRARIES})
   set_target_properties(Thread PROPERTIES COMPILE_FLAGS "${TBB_CXXFLAGS}")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -361,7 +361,7 @@ ROOT_ADD_TEST(test-TFormulaTests COMMAND TFormulaTests FAILREGEX "FAILED|Error i
 
 #--TBB basic test----------------------------------------------------------------------------------
 if(ROOT_imt_FOUND)
-  include_directories(SYSTEM ${TBB_INCLUDE_DIRS})
+  include_directories(${TBB_INCLUDE_DIRS})
   ROOT_EXECUTABLE(testTBB testTBB.cxx LIBRARIES ${TBB_LIBRARIES} BUILTINS TBB)
   set_target_properties(testTBB PROPERTIES COMPILE_FLAGS "${TBB_CXXFLAGS}")
   ROOT_ADD_TEST(test-TBB COMMAND testTBB FAILREGEX "FAILED|Error in")

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -439,7 +439,7 @@ if(vdt OR builtin_vdt)
 endif()
 
 if(tmva-cpu)
-  target_include_directories(TMVA SYSTEM PRIVATE ${TBB_INCLUDE_DIRS})
+  target_include_directories(TMVA PRIVATE ${TBB_INCLUDE_DIRS})
   target_link_libraries(TMVA PRIVATE ${TBB_LIBRARIES})
   set_target_properties(TMVA PROPERTIES COMPILE_FLAGS "${TBB_CXXFLAGS}")
 

--- a/tmva/tmva/test/DNN/CNN/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/CNN/CMakeLists.txt
@@ -110,8 +110,6 @@ endif()
 #--- CPU tests. ----------------------------
 if ((BLAS_FOUND OR mathmore) AND imt AND tmva-cpu)
 
-include_directories(SYSTEM ${TBB_INCLUDE_DIRS})
-
 ROOT_EXECUTABLE(testIm2ColCpu TestIm2ColCpu.cxx LIBRARIES ${Libraries})
 ROOT_ADD_TEST(TMVA-DNN-CNN-Im2Col-CPU COMMAND testIm2ColCpu)
 

--- a/tmva/tmva/test/DNN/GRU/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/GRU/CMakeLists.txt
@@ -29,7 +29,6 @@ endif (CUDA_FOUND AND tmva-gpu AND tmva-cudnn)
 
 #--- CPU tests. ----------------------------
 if (BLAS_FOUND AND imt)
-    include_directories(SYSTEM ${TBB_INCLUDE_DIRS})
 
     # GRU - Forward CPU
     ROOT_EXECUTABLE(testGRUForwardPassCpu TestGRUForwardPassCpu.cxx LIBRARIES ${Libraries})

--- a/tmva/tmva/test/DNN/LSTM/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/LSTM/CMakeLists.txt
@@ -41,7 +41,6 @@ endif (CUDA_FOUND AND tmva-gpu AND tmva-cudnn)
 
 #--- CPU tests. ----------------------------
 if (BLAS_FOUND AND imt)
-    include_directories(SYSTEM ${TBB_INCLUDE_DIRS})
 
     # LSTM - Forward CPU
     ROOT_EXECUTABLE(testLSTMForwardPassCpu TestLSTMForwardPassCpu.cxx LIBRARIES ${Libraries})

--- a/tmva/tmva/test/DNN/RNN/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/RNN/CMakeLists.txt
@@ -66,18 +66,16 @@ endif()
 
 #--- CPU tests. ----------------------------
 if ((BLAS_FOUND OR mathmore) AND imt AND tmva-cpu)
-  include_directories(SYSTEM ${TBB_INCLUDE_DIRS})
 
   # DNN - Forward CPU
   ROOT_EXECUTABLE(testRecurrentForwardPassCpu TestRecurrentForwardPassCpu.cxx LIBRARIES ${Libraries})
   ROOT_ADD_TEST(TMVA-DNN-RNN-Forward-Cpu COMMAND testRecurrentForwardPassCpu)
 
- ROOT_EXECUTABLE(testRecurrentBackpropagationCpu TestRecurrentBackpropagationCpu.cxx LIBRARIES ${Libraries})
- ROOT_ADD_TEST(TMVA-DNN-RNN-Backpropagation-Cpu COMMAND testRecurrentBackpropagationCpu)
+  ROOT_EXECUTABLE(testRecurrentBackpropagationCpu TestRecurrentBackpropagationCpu.cxx LIBRARIES ${Libraries})
+  ROOT_ADD_TEST(TMVA-DNN-RNN-Backpropagation-Cpu COMMAND testRecurrentBackpropagationCpu)
 
-# RNN - Full Test Reference
-ROOT_EXECUTABLE(testFullRNNCpu TestFullRNNCpu.cxx LIBRARIES ${Libraries})
-ROOT_ADD_TEST(TMVA-DNN-RNN-Full-Cpu COMMAND testFullRNNCpu)
-
+  # RNN - Full Test Reference
+  ROOT_EXECUTABLE(testFullRNNCpu TestFullRNNCpu.cxx LIBRARIES ${Libraries})
+  ROOT_ADD_TEST(TMVA-DNN-RNN-Full-Cpu COMMAND testFullRNNCpu)
 
 endif ()


### PR DESCRIPTION
As that would make $ROOTSYS/include/ a SYSTEM include for builtin-tbb.

