### PR TITLE
[DF] Refactor tree and friends information retrieval in distrdf

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -116,7 +116,6 @@ class BaseBackend(ABC):
         computation_graph_callable = generator.get_callable()
         # Arguments needed to create PyROOT RDF object
         rdf_args = headnode.args
-        treename = headnode.get_treename()
         selected_branches = headnode.get_branches()
 
         # Avoid having references to the instance inside the mapper
@@ -142,7 +141,6 @@ class BaseBackend(ABC):
                 action nodes in the computational graph.
             """
             import ROOT
-
             # We have to decide whether to do this in Dist or in subclasses
             # Utils.declare_headers(worker_includes)  # Declare headers if any
             # Run initialization method to prepare the worker runtime
@@ -153,43 +151,44 @@ class BaseBackend(ABC):
             start = int(current_range.start)
             end = int(current_range.end)
 
-            if treename:
+            if current_range.treename is not None:
                 # Build TChain of files for this range:
-                chain = ROOT.TChain(treename)
-                for f in current_range.filelist:
+                chain = ROOT.TChain(current_range.treename)
+                for f in current_range.treefilenames:
+                    # f can be Python string or C++ std::string
                     chain.Add(str(f))
 
                 # We assume 'end' is exclusive
                 chain.SetCacheEntryRange(start, end)
 
                 # Gather information about friend trees
-                friend_info = current_range.friend_info
-                if friend_info:
+                if current_range.friendnamesalias is not None:
                     # Zip together the treenames of the friend trees and the
                     # respective file names. Each friend treename can have
                     # multiple corresponding friend file names.
                     tree_files_names = zip(
-                        friend_info.friend_names,
-                        friend_info.friend_file_names
+                        current_range.friendnamesalias,
+                        current_range.friendfilenames
                     )
-                    for friend_treename, friend_filenames in tree_files_names:
+                    for friend_namealias, friend_filenames in tree_files_names:
                         # Start a TChain with the current friend treename
-                        friend_chain = ROOT.TChain(friend_treename)
+                        friend_chain = ROOT.TChain(friend_namealias.first)
                         # Add each corresponding file to the TChain
                         for filename in friend_filenames:
-                            friend_chain.Add(filename)
+                            # filename is an std::string, Add accepts a const char*
+                            friend_chain.Add(filename.c_str())
 
                         # Set cache on the same range as the parent TChain
                         friend_chain.SetCacheEntryRange(start, end)
-                        # Finally add friend TChain to the parent
-                        chain.AddFriend(friend_chain)
+                        # Finally add friend TChain to the parent (with alias)
+                        chain.AddFriend(friend_chain, friend_namealias.second)
 
                 if selected_branches:
-                    rdf = ROOT.ROOT.RDataFrame(chain, selected_branches)
+                    rdf = ROOT.RDataFrame(chain, selected_branches)
                 else:
-                    rdf = ROOT.ROOT.RDataFrame(chain)
+                    rdf = ROOT.RDataFrame(chain)
             else:
-                rdf = ROOT.ROOT.RDataFrame(*rdf_args)  # PyROOT RDF object
+                rdf = ROOT.RDataFrame(*rdf_args)  # PyROOT RDF object
 
             # # TODO : If we want to run multi-threaded in a Spark node in
             # # the future, use `TEntryList` instead of `Range`

--- a/bindings/experimental/distrdf/test/test_buildranges.py
+++ b/bindings/experimental/distrdf/test/test_buildranges.py
@@ -1,5 +1,6 @@
 from DistRDF.Node import HeadNode
 from DistRDF.Node import RangesBuilder
+from DistRDF.Node import TreeInfo
 import warnings
 import unittest
 
@@ -116,7 +117,8 @@ class BuildRangesTest(unittest.TestCase):
         filelist = ["backend/Slimmed_ntuple.root"]
         headnode.npartitions = 1
 
-        crs = builder._get_clustered_ranges(treename, filelist)
+        treeinfo = TreeInfo([treename], filelist, None, None)
+        crs = builder._get_clustered_ranges(treeinfo)
         ranges = rangesToTuples(crs)
 
         ranges_reqd = [(0, 10)]
@@ -138,10 +140,10 @@ class BuildRangesTest(unittest.TestCase):
         headnode.npartitions = 2
 
         ranges_reqd = [(0, 10)]
-
+        treeinfo = TreeInfo([treename], filelist, None, None)
         with warnings.catch_warnings(record=True) as w:
             # Trigger warning
-            crs = builder._get_clustered_ranges(treename, filelist)
+            crs = builder._get_clustered_ranges(treeinfo)
             ranges = rangesToTuples(crs)
 
             # Verify ranges
@@ -164,7 +166,8 @@ class BuildRangesTest(unittest.TestCase):
         filelist = ["backend/2clusters.root"]
         headnode.npartitions = 2
 
-        crs = builder._get_clustered_ranges(treename, filelist)
+        treeinfo = TreeInfo([treename], filelist, None, None)
+        crs = builder._get_clustered_ranges(treeinfo)
         ranges = rangesToTuples(crs)
 
         ranges_reqd = [
@@ -187,7 +190,8 @@ class BuildRangesTest(unittest.TestCase):
         filelist = ["backend/4clusters.root"]
         headnode.npartitions = 4
 
-        crs = builder._get_clustered_ranges(treename, filelist)
+        treeinfo = TreeInfo([treename], filelist, None, None)
+        crs = builder._get_clustered_ranges(treeinfo)
         ranges = rangesToTuples(crs)
 
         ranges_reqd = [
@@ -212,7 +216,8 @@ class BuildRangesTest(unittest.TestCase):
         filelist = ["backend/1000clusters.root"]
         headnode.npartitions = 4
 
-        crs = builder._get_clustered_ranges(treename, filelist)
+        treeinfo = TreeInfo([treename], filelist, None, None)
+        crs = builder._get_clustered_ranges(treeinfo)
         ranges = rangesToTuples(crs)
 
         ranges_reqd = [
@@ -238,7 +243,8 @@ class BuildRangesTest(unittest.TestCase):
         filelist = ["backend/1000clusters.root"]
         headnode.npartitions = 1000
 
-        crs = builder._get_clustered_ranges(treename, filelist)
+        treeinfo = TreeInfo([treename], filelist, None, None)
+        crs = builder._get_clustered_ranges(treeinfo)
         ranges = rangesToTuples(crs)
 
         start = 0

--- a/tree/treeplayer/CMakeLists.txt
+++ b/tree/treeplayer/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(TreePlayer
   HEADERS
+    ROOT/ParallelismUtils.hxx
     ROOT/TTreeReaderFast.hxx
     ROOT/TTreeReaderValueFast.hxx
     TBranchProxyClassDescriptor.h
@@ -66,6 +67,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TreePlayer
     src/TFormLeafInfoReference.cxx
     src/TFriendProxy.cxx
     src/TFriendProxyDescriptor.cxx
+    src/ParallelismUtils.cxx
     src/TRefArrayProxy.cxx
     src/TRefProxy.cxx
     src/TSelectorDraw.cxx

--- a/tree/treeplayer/inc/LinkDef.h
+++ b/tree/treeplayer/inc/LinkDef.h
@@ -110,6 +110,6 @@
 #pragma link C++ class TNotifyLink<ROOT::Detail::TBranchProxy>;
 #pragma link C++ class TNotifyLink<TTreeReader>;
 
+#pragma link C++ namespace ROOT::Internal::Parallelism;
+
 #endif
-
-

--- a/tree/treeplayer/inc/ROOT/ParallelismUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/ParallelismUtils.hxx
@@ -1,0 +1,59 @@
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/**
+  \defgroup Parallelism Parallelism
+Functions and classes that allow parallel execution of ROOT code.
+*/
+
+/**
+ \file ROOT/ParallelismUtils.hxx
+ \ingroup Parallelism
+ \author Vincenzo Eduardo Padulano
+ \date 2021-03
+*/
+
+#ifndef PARALLELISM_UTILS_H
+#define PARALLELISM_UTILS_H
+
+#include <utility> // std::pair
+#include <vector>
+#include <string>
+
+class TTree;
+
+namespace ROOT {
+namespace Internal {
+/**
+\namespace ROOT::Internal::Parallelism
+\ingroup Parallelism
+\brief inline namespace hosting functions and classes that help in parallel workflows.
+*/
+inline namespace Parallelism {
+
+using NameAlias = std::pair<std::string, std::string>; ///< A pair of name and alias of a TTree's friend tree.
+/**
+\struct ROOT::Internal::Parallelism::FriendInfo
+\brief Information about friend trees of a certain TTree or TChain object.
+\ingroup Parallelism
+*/
+struct FriendInfo {
+   std::vector<NameAlias> fFriendNames;                    ///< Pairs of names and aliases of friend trees/chains
+   std::vector<std::vector<std::string>> fFriendFileNames; ///< Names of the files where each friend is stored.
+                                                           ///< fFriendFileNames[i] is the list of files for friend with
+                                                           ///< name fFriendNames[i]
+};
+
+std::vector<std::string> GetTreeFullPaths(const TTree &tree);
+FriendInfo GetFriendInfo(const TTree &tree);
+
+} // namespace Parallelism
+} // namespace Internal
+} // namespace ROOT
+
+#endif // PARALLELISM_UTILS_H

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -20,13 +20,12 @@
 #include "TTreeReader.h"
 #include "TError.h"
 #include "TEntryList.h"
-#include "TFriendElement.h"
 #include "ROOT/RMakeUnique.hxx"
 #include "ROOT/TThreadedObject.hxx"
 #include "ROOT/TThreadExecutor.hxx"
+#include "ROOT/ParallelismUtils.hxx"
 
 #include <functional>
-#include <utility> // std::pair
 #include <vector>
 
 /** \class TTreeView
@@ -48,15 +47,6 @@ the threaded object.
 
 namespace ROOT {
 namespace Internal {
-/// Names, aliases, and file names of a TTree's or TChain's friends
-using NameAlias = std::pair<std::string, std::string>;
-struct FriendInfo {
-   /// Pairs of names and aliases of friend trees/chains
-   std::vector<Internal::NameAlias> fFriendNames;
-   /// Names of the files where each friend is stored. fFriendFileNames[i] is the list of files for friend with
-   /// name fFriendNames[i]
-   std::vector<std::vector<std::string>> fFriendFileNames;
-};
 
 class TTreeView {
 private:
@@ -94,7 +84,6 @@ private:
    // Must be declared after fPool, for IMT to be initialized first!
    ROOT::TThreadedObject<ROOT::Internal::TTreeView> fTreeView{TNumSlots{ROOT::GetThreadPoolSize()}};
 
-   Internal::FriendInfo GetFriendInfo(TTree &tree);
    std::vector<std::string> FindTreeNames();
    static unsigned int fgMaxTasksPerFilePerWorker;
    static unsigned int fgTasksPerWorkerHint;

--- a/tree/treeplayer/src/ParallelismUtils.cxx
+++ b/tree/treeplayer/src/ParallelismUtils.cxx
@@ -1,0 +1,140 @@
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/ParallelismUtils.hxx"
+#include "TTree.h"
+#include "TChain.h"
+#include "TFile.h"
+#include "TFriendElement.h"
+
+#include <utility> // std::pair
+#include <vector>
+#include <string>
+
+namespace ROOT {
+namespace Internal {
+inline namespace Parallelism {
+
+////////////////////////////////////////////////////////////////////////////////
+/// \fn std::vector<std::string> GetTreeFullPaths(const TTree &tree)
+/// \ingroup Parallelism
+/// \brief Retrieve the full path(s) to a TTree or the trees in a TChain.
+/// \param[in] tree The tree or chain from which the paths will be retrieved.
+/// \return If the input argument is a TChain, returns a vector of strings with
+///         the name of the tree of each file in the chain. If the input
+///         argument is a TTree, returns a vector with a single element that is
+///         the full path of the tree in the file (e.g. the name of the tree
+///         itself or the path with the directories inside the file). Finally,
+///         the function returns just the name of the tree if it couldn't do any
+///         better.
+std::vector<std::string> GetTreeFullPaths(const TTree &tree)
+{
+   // Case 1: this is a TChain. For each file it contains, GetName returns the name of the tree in that file
+   if (tree.IsA() == TChain::Class()) {
+      auto &chain = static_cast<const TChain &>(tree);
+      auto files = chain.GetListOfFiles();
+      if (!files || files->GetEntries() == 0) {
+         throw std::runtime_error("Input TChain does not contain any file");
+      }
+      std::vector<std::string> treeNames;
+      for (TObject *f : *files)
+         treeNames.emplace_back(f->GetName());
+
+      return treeNames;
+   }
+
+   // Case 2: this is a TTree: we get the full path of it
+   if (auto motherDir = tree.GetDirectory()) {
+      // We have 2 subcases (ROOT-9948):
+      // - 1. motherDir is a TFile
+      // - 2. motherDir is a directory
+      // If 1. we just return the name of the tree, if 2. we reconstruct the path
+      // to the file.
+      if (motherDir->InheritsFrom("TFile")) {
+         return {tree.GetName()};
+      }
+      std::string fullPath = motherDir->GetPath();         // e.g. "file.root:/dir"
+      fullPath = fullPath.substr(fullPath.find(":/") + 1); // e.g. "/dir"
+      fullPath += "/";
+      fullPath += tree.GetName(); // e.g. "/dir/tree"
+      return {fullPath};
+   }
+
+   // We do our best and return the name of the tree
+   return {tree.GetName()};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \fn FriendInfo GetFriendInfo(const TTree &tree)
+/// \ingroup Parallelism
+/// \brief Get and store the names, aliases and file names of the friends of the tree.
+/// \param[in] tree The tree from which friends information will be gathered.
+///
+/// \note "friends of friends" and circular references in the lists of friends
+///       are not supported.
+FriendInfo GetFriendInfo(const TTree &tree)
+{
+   std::vector<NameAlias> friendNames;
+   std::vector<std::vector<std::string>> friendFileNames;
+
+   // Typically, the correct way to call GetListOfFriends would be `tree.GetTree()->GetListOfFriends()`
+   // (see e.g. the discussion at https://github.com/root-project/root/issues/6741).
+   // However, in this case, in case we are dealing with a TChain we really only care about the TChain's
+   // list of friends (which will need to be rebuilt in each processing task) while friends of the TChain's
+   // internal TTree, if any, will be automatically loaded in each task just like they would be automatically
+   // loaded here if we used tree.GetTree()->GetListOfFriends().
+   const auto friends = tree.GetListOfFriends();
+   if (!friends)
+      return FriendInfo();
+
+   for (auto fr : *friends) {
+      const auto frTree = static_cast<TFriendElement *>(fr)->GetTree();
+      const bool isChain = frTree->IsA() == TChain::Class();
+
+      friendFileNames.emplace_back();
+      auto &fileNames = friendFileNames.back();
+
+      // Check if friend tree/chain has an alias
+      const auto alias_c = tree.GetFriendAlias(frTree);
+      const std::string alias = alias_c != nullptr ? alias_c : "";
+
+      if (isChain) {
+         // Note that each TChainElement returned by chain.GetListOfFiles has a name
+         // equal to the tree name of this TChain and a title equal to the filename.
+         // Accessing the information like this ensures that we get the correct
+         // filenames and treenames if the treename is given as part of the filename
+         // via chain.AddFile(file.root/myTree) and as well if the tree name is given
+         // in the constructor via TChain(myTree) and a file is added later by chain.AddFile(file.root).
+
+         // Get name of the trees building the chain
+         const auto chainFiles = static_cast<TChain *>(frTree)->GetListOfFiles();
+         const auto realName = chainFiles->First()->GetName();
+         friendNames.emplace_back(std::make_pair(realName, alias));
+         // Get filenames stored in the title member
+         for (auto f : *chainFiles) {
+            fileNames.emplace_back(f->GetTitle());
+         }
+      } else {
+         // Get name of the tree
+         const auto realName = GetTreeFullPaths(*frTree)[0];
+         friendNames.emplace_back(std::make_pair(realName, alias));
+
+         // Get filename
+         const auto f = frTree->GetCurrentFile();
+         if (!f)
+            throw std::runtime_error("Friend trees with no associated file are not supported.");
+         fileNames.emplace_back(f->GetName());
+      }
+   }
+
+   return FriendInfo{std::move(friendNames), std::move(friendFileNames)};
+}
+
+} // namespace Parallelism
+} // namespace Internal
+} // namespace ROOT

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -244,45 +244,6 @@ GetFriendEntries(const std::vector<std::pair<std::string, std::string>> &friendN
    return friendEntries;
 }
 
-////////////////////////////////////////////////////////////////////////
-/// Return the full path of the TTree or the trees in the TChain
-static std::vector<std::string> GetTreeFullPaths(const TTree &tree)
-{
-   // Case 1: this is a TChain. For each file it contains, GetName returns the name of the tree in that file
-   if (tree.IsA() == TChain::Class()) {
-      auto &chain = static_cast<const TChain &>(tree);
-      auto files = chain.GetListOfFiles();
-      if (!files || files->GetEntries() == 0) {
-         throw std::runtime_error("TTreeProcessorMT: input TChain does not contain any file");
-      }
-      std::vector<std::string> treeNames;
-      for (TObject *f : *files)
-         treeNames.emplace_back(f->GetName());
-
-      return treeNames;
-   }
-
-   // Case 2: this is a TTree: we get the full path of it
-   if (auto motherDir = tree.GetDirectory()) {
-      // We have 2 subcases (ROOT-9948):
-      // - 1. motherDir is a TFile
-      // - 2. motherDir is a directory
-      // If 1. we just return the name of the tree, if 2. we reconstruct the path
-      // to the file.
-      if (motherDir->InheritsFrom("TFile")) {
-         return {tree.GetName()};
-      }
-      std::string fullPath = motherDir->GetPath(); // e.g. "file.root:/dir"
-      fullPath = fullPath.substr(fullPath.find(":/") + 1); // e.g. "/dir"
-      fullPath += "/";
-      fullPath += tree.GetName(); // e.g. "/dir/tree"
-      return {fullPath};
-   }
-
-   // We do our best and return the name of the tree
-   return {tree.GetName()};
-}
-
 } // anonymous namespace
 
 namespace ROOT {
@@ -365,69 +326,6 @@ TTreeView::GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::st
 
 } // namespace Internal
 } // namespace ROOT
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get and store the names, aliases and file names of the friends of the tree.
-/// \param[in] tree The main tree whose friends to
-///
-/// Note that "friends of friends" and circular references in the lists of friends are not supported.
-Internal::FriendInfo TTreeProcessorMT::GetFriendInfo(TTree &tree)
-{
-   std::vector<Internal::NameAlias> friendNames;
-   std::vector<std::vector<std::string>> friendFileNames;
-
-   // Typically, the correct way to call GetListOfFriends would be `tree.GetTree()->GetListOfFriends()`
-   // (see e.g. the discussion at https://github.com/root-project/root/issues/6741).
-   // However, in this case, in case we are dealing with a TChain we really only care about the TChain's
-   // list of friends (which will need to be rebuilt in each processing task) while friends of the TChain's
-   // internal TTree, if any, will be automatically loaded in each task just like they would be automatically
-   // loaded here if we used tree.GetTree()->GetListOfFriends().
-   const auto friends = tree.GetListOfFriends();
-   if (!friends)
-      return Internal::FriendInfo();
-
-   for (auto fr : *friends) {
-      const auto frTree = static_cast<TFriendElement *>(fr)->GetTree();
-      const bool isChain = frTree->IsA() == TChain::Class();
-
-      friendFileNames.emplace_back();
-      auto &fileNames = friendFileNames.back();
-
-      // Check if friend tree/chain has an alias
-      const auto alias_c = tree.GetFriendAlias(frTree);
-      const std::string alias = alias_c != nullptr ? alias_c : "";
-
-      if (isChain) {
-         // Note that each TChainElement returned by chain.GetListOfFiles has a name
-         // equal to the tree name of this TChain and a title equal to the filename.
-         // Accessing the information like this ensures that we get the correct
-         // filenames and treenames if the treename is given as part of the filename
-         // via chain.AddFile(file.root/myTree) and as well if the tree name is given
-         // in the constructor via TChain(myTree) and a file is added later by chain.AddFile(file.root).
-
-         // Get name of the trees building the chain
-         const auto chainFiles = static_cast<TChain*>(frTree)->GetListOfFiles();
-         const auto realName = chainFiles->First()->GetName();
-         friendNames.emplace_back(std::make_pair(realName, alias));
-         // Get filenames stored in the title member
-         for (auto f : *chainFiles) {
-            fileNames.emplace_back(f->GetTitle());
-         }
-      } else {
-         // Get name of the tree
-         const auto realName = GetTreeFullPaths(*frTree)[0];
-         friendNames.emplace_back(std::make_pair(realName, alias));
-
-         // Get filename
-         const auto f = frTree->GetCurrentFile();
-         if (!f)
-            throw std::runtime_error("Friend trees with no associated file are not supported.");
-         fileNames.emplace_back(f->GetName());
-      }
-   }
-
-   return Internal::FriendInfo{std::move(friendNames), std::move(friendFileNames)};
-}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 /// Retrieve the names of the TTrees in each of the input files, throw if a TTree cannot be found.
@@ -539,8 +437,8 @@ std::vector<std::string> GetFilesFromTree(TTree &tree)
 /// \param[in] nThreads Number of threads to create in the underlying thread-pool. The semantics of this argument are
 ///                     the same as for TThreadExecutor.
 TTreeProcessorMT::TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_t nThreads)
-   : fFileNames(GetFilesFromTree(tree)), fTreeNames(GetTreeFullPaths(tree)), fEntryList(entries),
-     fFriendInfo(GetFriendInfo(tree)), fPool(nThreads)
+   : fFileNames(GetFilesFromTree(tree)), fTreeNames(Internal::GetTreeFullPaths(tree)), fEntryList(entries),
+     fFriendInfo(Internal::GetFriendInfo(tree)), fPool(nThreads)
 {
    ROOT::EnableThreadSafety();
 }


### PR DESCRIPTION
Improved support of TChain construction on the distributed executors with information
of the input TTree and its friends. Steps:
1. Bring utility functions from TTreeProcessorMT in their own inline namespace
2. Call them in HeadNode.get_treeinfo to retrieve information about the full path to the tree and the information about its friends
3. Create a new namedtuple `TreeInfo` and use that to pass information around
4. In particular construct `Range` objects starting from the information contained in `TreeInfo` objects
5. The mapper function will in turn use `Range`s

This improved logic allows also support for friend trees with aliases. DistRDF tests have been adjusted according to the new functions

TODO:
- [x] Add doxygen in TreePlayerUtils
- [ ] Add c++ only specific test for GetFriendInfo and GetTreeFullPaths functions