### PR TITLE
Legend auto-placement fix

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -560,6 +560,7 @@ TLegend *TPad::BuildLegend(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
             leg->AddEntry( obj, mes.Data(), opt );
          }
       }
+      opt = "";
    }
    if (leg) {
       TVirtualPad *gpadsave;

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -3242,10 +3242,10 @@ void TPad::FillCollideGridTGraph(TObject *o)
    Double_t ys   = (fY2-fY1)/fCGny;
 
    Int_t n = g->GetN();
+   Int_t s = TMath::Max(n/10,1);
    Double_t x1, x2, y1, y2;
-
-   for (Int_t i=1; i<n; i++) {
-      g->GetPoint(i-1,x1,y1);
+   for (Int_t i=s; i<n; i=i+s) {
+      g->GetPoint(TMath::Max(0,i-s),x1,y1);
       g->GetPoint(i  ,x2,y2);
       if (fLogx) {
          if (x1 > 0) x1 = TMath::Log10(x1);


### PR DESCRIPTION
When a TCanvas contains TGraph with a huge number of points, the auto-placement of TLegend took ages. It may even look like an infinite loop. This was found by this forum report:
 https://root-forum.cern.ch/t/buildlegend-takes-ages-with-tgraph-with-many-points/44187