### PR TITLE
Added Polar coordinates related features

### DIFF
--- a/math/physics/inc/TVector3.h
+++ b/math/physics/inc/TVector3.h
@@ -34,6 +34,9 @@ public:
    TVector3(const Float_t *);
    // Constructors from an array
 
+   TVector3(Double_t phi, Double_t theta);
+   // Creates a Cartesian TVector3 from two angles Phi and Theta
+
    TVector3(const TVector3 &);
    // The copy constructor.
 
@@ -104,7 +107,6 @@ public:
 
    inline void SetPerp(Double_t);
    // Set the transverse component keeping phi and z constant.
-
    inline Double_t Perp2(const TVector3 &) const;
    // The transverse component w.r.t. given axis squared.
 
@@ -139,12 +141,10 @@ public:
 
    TVector3 Unit() const;
    // Unit vector parallel to this.
-   
-   TVector3 ToSpherical(const TVector3 &c) const;
-   // Converts a Cartesian Vector into a Spherical Vector
-   
-   TVector3 Cartesian(Double_t phi, Double_t theta) const;
-   // Converts two angles into a Cartesian Trabsformation Vector
+
+   TVector3 ToSpherical() const;
+   /// Converts a Cartesian Vector into a Spherical Vector
+   /// Spherical Vector: (r, theta, phi)
 
    inline TVector3 Orthogonal() const;
    // Vector orthogonal to this (Geant4).
@@ -265,6 +265,10 @@ inline TVector3::TVector3(const Double_t * x0)
 inline TVector3::TVector3(const Float_t * x0)
 : fX(x0[0]), fY(x0[1]), fZ(x0[2]) {}
 
+inline TVector3::TVector3(Double_t phi, Double_t theta)
+   : fX(TMath::Sin(theta) * TMath::Cos(phi)), fY(TMath::Sin(theta) * TMath::Sin(phi)), fZ(TMath::Cos(theta))
+{
+}
 
 inline Double_t TVector3::operator () (int i) const {
    switch(i) {

--- a/math/physics/inc/TVector3.h
+++ b/math/physics/inc/TVector3.h
@@ -76,7 +76,7 @@ public:
 
    Double_t Theta() const;
    // The polar angle.
-
+   
    inline Double_t CosTheta() const;
    // Cosine of the polar angle.
 
@@ -139,6 +139,12 @@ public:
 
    TVector3 Unit() const;
    // Unit vector parallel to this.
+   
+   TVector3 ToSpherical(const TVector3 &c) const;
+   // Converts a Cartesian Vector into a Spherical Vector
+   
+   TVector3 Cartesian(Double_t phi, Double_t theta) const;
+   // Converts two angles into a Cartesian Trabsformation Vector
 
    inline TVector3 Orthogonal() const;
    // Vector orthogonal to this (Geant4).

--- a/math/physics/src/TVector3.cxx
+++ b/math/physics/src/TVector3.cxx
@@ -233,7 +233,7 @@ Double_t TVector3::Phi() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Convert two angles Theta and Phi into a Sperical Vector
+/// Convert two angles Theta and Phi into a Cartesian Transformation Vector
 
 TVector3 TVector3::Spherical(Double_t phi, Double_t theta)
 {

--- a/math/physics/src/TVector3.cxx
+++ b/math/physics/src/TVector3.cxx
@@ -178,6 +178,15 @@ ClassImp(TVector3);
 
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Convert two angles Theta and Phi into a Cartesian Transformation Vector
+
+TVector3 TVector3::Cartesian(Double_t phi, Double_t theta)
+{
+   return TVector3 spherical(TMath::Sin(theta) * TMath::Cos(phi), TMath::Sin(theta) * TMath::Sin(phi),
+                             TMath::Cos(theta));
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Multiplication operator
 
 TVector3 & TVector3::operator *= (const TRotation & m){
@@ -230,15 +239,6 @@ Double_t TVector3::Perp(const TVector3 & p) const
 Double_t TVector3::Phi() const
 {
    return fX == 0.0 && fY == 0.0 ? 0.0 : TMath::ATan2(fY,fX);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Convert two angles Theta and Phi into a Cartesian Transformation Vector
-
-TVector3 TVector3::Spherical(Double_t phi, Double_t theta)
-{
-   return TVector3 spherical(TMath::Sin(theta) * TMath::Cos(phi), TMath::Sin(theta) * TMath::Sin(phi),
-                             TMath::Cos(theta));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/math/physics/src/TVector3.cxx
+++ b/math/physics/src/TVector3.cxx
@@ -233,11 +233,31 @@ Double_t TVector3::Phi() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Convert two angles Theta and Phi into a Sperical Vector
+
+TVector3 TVector3::Spherical(Double_t phi, Double_t theta)
+{
+   return TVector3 spherical(TMath::Sin(theta) * TMath::Cos(phi), TMath::Sin(theta) * TMath::Sin(phi),
+                             TMath::Cos(theta));
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return the polar angle
 
 Double_t TVector3::Theta() const
 {
    return fX == 0.0 && fY == 0.0 && fZ == 0.0 ? 0.0 : TMath::ATan2(Perp(),fZ);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Convert a Cartesian Vector into a Spherical Vector
+/// Spherical Vector: (r, theta, phi)
+
+TVector3 TVector3::ToSpherical(const TVector3 &c)
+{
+   return TVector3 sphericalVector(TMath::Sqrt(c.X() * c.X() + c.Y() * c.Y() + c.Z() * c.Z()),
+                                   TMath::ACos(c.Z() / TMath::Sqrt(c.X() * c.X() + c.Y() * c.Y() + c.Z() * c.Z())),
+                                   TMath::ATan(c.Y() / c.X()));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/math/physics/src/TVector3.cxx
+++ b/math/physics/src/TVector3.cxx
@@ -178,15 +178,6 @@ ClassImp(TVector3);
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Convert two angles Theta and Phi into a Cartesian Transformation Vector
-
-TVector3 TVector3::Cartesian(Double_t phi, Double_t theta)
-{
-   return TVector3 spherical(TMath::Sin(theta) * TMath::Cos(phi), TMath::Sin(theta) * TMath::Sin(phi),
-                             TMath::Cos(theta));
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Multiplication operator
 
 TVector3 & TVector3::operator *= (const TRotation & m){
@@ -253,11 +244,11 @@ Double_t TVector3::Theta() const
 /// Convert a Cartesian Vector into a Spherical Vector
 /// Spherical Vector: (r, theta, phi)
 
-TVector3 TVector3::ToSpherical(const TVector3 &c)
+TVector3 TVector3::ToSpherical() const
 {
-   return TVector3 sphericalVector(TMath::Sqrt(c.X() * c.X() + c.Y() * c.Y() + c.Z() * c.Z()),
-                                   TMath::ACos(c.Z() / TMath::Sqrt(c.X() * c.X() + c.Y() * c.Y() + c.Z() * c.Z())),
-                                   TMath::ATan(c.Y() / c.X()));
+   TVector3 sphericalVector(TMath::Sqrt(fX * fX + fY * fY + fZ * fZ),
+                            TMath::ACos(fZ / TMath::Sqrt(fX * fX + fY * fY + fZ * fZ)), TMath::ATan(fY / fX));
+   return sphericalVector;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This was not in any issue, but I thought this would be very helpful. This way, you don't need to convert theta and phi into Cartesian vectors manually, and vice-versa.

I tested it on Ubuntu 20.04 and it works flawlessly.