### PR TITLE
[ntuple] Throw on missing field names in GetView

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -180,14 +180,28 @@ public:
 
    /// Provides access to an individual field that can contain either a scalar value or a collection, e.g.
    /// GetView<double>("particles.pt") or GetView<std::vector<double>>("particle").  It can as well be the index
-   /// field of a collection itself, like GetView<NTupleSize_t>("particle")
+   /// field of a collection itself, like GetView<NTupleSize_t>("particle").
+   ///
+   /// Raises an exception if there is no field with the given name.
    template <typename T>
    RNTupleView<T> GetView(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);
+      if (fieldId == kInvalidDescriptorId) {
+         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '"
+            + fSource->GetDescriptor().GetName() + "'"
+         ));
+      }
       return RNTupleView<T>(fieldId, fSource.get());
    }
+
+   /// Raises an exception if there is no field with the given name.
    RNTupleViewCollection GetViewCollection(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);
+      if (fieldId == kInvalidDescriptorId) {
+         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '"
+            + fSource->GetDescriptor().GetName() + "'"
+         ));
+      }
       return RNTupleViewCollection(fieldId, fSource.get());
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -248,13 +248,25 @@ public:
                                  collectionStart.GetIndex() + size);
    }
 
+   /// Raises an exception if there is no field with the given name.
    template <typename T>
    RNTupleView<T> GetView(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName, fCollectionFieldId);
+      if (fieldId == kInvalidDescriptorId) {
+         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '"
+            + fSource->GetDescriptor().GetName() + "'"
+         ));
+      }
       return RNTupleView<T>(fieldId, fSource);
    }
+   /// Raises an exception if there is no field with the given name.
    RNTupleViewCollection GetViewCollection(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName, fCollectionFieldId);
+      if (fieldId == kInvalidDescriptorId) {
+         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '"
+            + fSource->GetDescriptor().GetName() + "'"
+         ));
+      }
       return RNTupleViewCollection(fieldId, fSource);
    }
 


### PR DESCRIPTION
If a field name doesn't exist in the RNTupleModel, we raise an
exception with the problematic field name and NTuple. There are
some other possible errors to be considered:
  * Calling GetViewCollection on a non-collection field?
  * Calling GetView<T> on a field with a different type U?

Before this change, missing names caused an out of range exception.