### PR TITLE
[ntuple] Fail gracefully on unsupported RNTuple from the future

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -162,15 +162,16 @@ public:
 
    /// Analogous to Fill(), fills the default entry of the model. Returns false at the end of the ntuple.
    /// On I/O errors, raises an exception.
-   void LoadEntry(NTupleSize_t index) { LoadEntry(index, *fModel->GetDefaultEntry()); }
-   /// Fills a user provided entry after checking that the entry has been instantiated from the ntuple model
-   void LoadEntry(NTupleSize_t index, REntry &entry) {
+   void LoadEntry(NTupleSize_t index) {
       // TODO(jblomer): can be templated depending on the factory method / constructor
       if (R__unlikely(!fModel)) {
          fModel = fSource->GetDescriptor().GenerateModel();
          ConnectModel(*fModel);
       }
-
+      LoadEntry(index, *fModel->GetDefaultEntry());
+   }
+   /// Fills a user provided entry after checking that the entry has been instantiated from the ntuple model
+   void LoadEntry(NTupleSize_t index, REntry &entry) {
       for (auto& value : entry) {
          value.GetField()->Read(index, &value);
       }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -218,11 +218,6 @@ std::uint32_t DeserializeFrame(std::uint16_t protocolVersion, const void *buffer
    std::uint16_t protocolVersionMinRequired;
    bytes += DeserializeUInt16(bytes, &protocolVersionAtWrite);
    bytes += DeserializeUInt16(bytes, &protocolVersionMinRequired);
-   if (protocolVersionAtWrite < protocolVersionMinRequired) {
-      throw ROOT::Experimental::RException(R__FAIL("RNTuple version too old (version "
-         + std::to_string(protocolVersionAtWrite)
-         + "), version >= " + std::to_string(protocolVersionMinRequired) + " required"));
-   }
    if (protocolVersion < protocolVersionMinRequired) {
       throw ROOT::Experimental::RException(R__FAIL("RNTuple version too new (version "
          + std::to_string(protocolVersionMinRequired)

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -218,8 +218,16 @@ std::uint32_t DeserializeFrame(std::uint16_t protocolVersion, const void *buffer
    std::uint16_t protocolVersionMinRequired;
    bytes += DeserializeUInt16(bytes, &protocolVersionAtWrite);
    bytes += DeserializeUInt16(bytes, &protocolVersionMinRequired);
-   R__ASSERT(protocolVersionAtWrite >= protocolVersionMinRequired);
-   R__ASSERT(protocolVersion >= protocolVersionMinRequired);
+   if (protocolVersionAtWrite < protocolVersionMinRequired) {
+      throw ROOT::Experimental::RException(R__FAIL("RNTuple version too old (version "
+         + std::to_string(protocolVersionAtWrite)
+         + "), version >= " + std::to_string(protocolVersionMinRequired) + " required"));
+   }
+   if (protocolVersion < protocolVersionMinRequired) {
+      throw ROOT::Experimental::RException(R__FAIL("RNTuple version too new (version "
+         + std::to_string(protocolVersionMinRequired)
+         + "), version <= " + std::to_string(protocolVersion) + " required"));
+   }
    bytes += DeserializeUInt32(bytes, size);
    return 8;
 }

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -214,8 +214,7 @@ TEST(MiniFile, FailOnForwardIncompatibility)
    EXPECT_EQ(2u, fwrite(futureVersionLE, 1, 2, f));
    fclose(f);
 
-   try
-   {
+   try {
       auto readerFail = RNTupleReader::Open("ntuple", fileGuard.GetPath());
       FAIL() << "unsupported minimum version number should throw";
    } catch (const RException& err) {

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -172,3 +172,53 @@ TEST(MiniFile, Failures)
       EXPECT_THAT(err.what(), testing::HasSubstr("no RNTuple named 'No such RNTuple' in file '" + fileGuard.GetPath()));
    }
 }
+
+
+TEST(MiniFile, FailOnForwardIncompatibility)
+{
+   FileRaii fileGuard("test_ntuple_minifile_forward_incompat.root");
+
+   // First create a regular RNTuple
+   auto model = RNTupleModel::Create();
+   auto fldPt = model->MakeField<float>("pt", 42.0);
+   {
+      RNTupleWriteOptions options;
+      options.SetCompression(0);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
+      writer->Fill();
+   }
+   {
+      auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+      ASSERT_EQ(1U, reader->GetNEntries());
+      reader->LoadEntry(0);
+      EXPECT_EQ(42.0, *(reader->GetModel()->GetDefaultEntry()->Get<float>("pt")));
+   }
+
+   // Fix the version numbers in the header
+
+   // Figure out the header offset
+   auto rawFile = RRawFile::Create(fileGuard.GetPath());
+   RMiniFileReader reader(rawFile.get());
+   auto ntuple = reader.GetNTuple("ntuple").Inspect();
+   // Construct incompatible version numbers in little-endian binary format
+   std::uint16_t futureVersion = RNTupleDescriptor::kFrameVersionMin + 1;
+   unsigned char futureVersionLE[2];
+   futureVersionLE[0] = (futureVersion & 0x00FF);
+   futureVersionLE[1] = (futureVersion & 0xFF00) >> 8;
+   // Write out twice (min version and writer version)
+   FILE *f = fopen(fileGuard.GetPath().c_str(), "rb+");
+   ASSERT_TRUE(f != nullptr);
+   int posHeader = ntuple.fSeekHeader;
+   EXPECT_EQ(0, fseek(f, posHeader, SEEK_SET));
+   EXPECT_EQ(2u, fwrite(futureVersionLE, 1, 2, f));
+   EXPECT_EQ(2u, fwrite(futureVersionLE, 1, 2, f));
+   fclose(f);
+
+   try
+   {
+      auto readerFail = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+      FAIL() << "unsupported minimum version number should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("RNTuple version too new"));
+   }
+}


### PR DESCRIPTION
Instead of aborting on an `R__ASSERT`, with this patch RNTuple throws a meaningful exception when trying to open a file that was generated in an incompatible, future format.

Fixes lazy loading of the model in `RNTupleReader::LoadEntry()` along the way.