### PR TITLE
ROOT-10998 for v624

### DIFF
--- a/cmake/modules/SetUpMacOS.cmake
+++ b/cmake/modules/SetUpMacOS.cmake
@@ -18,7 +18,7 @@ if(CMAKE_VERSION VERSION_LESS 3.14.4)
         RESULT_VARIABLE NINJAVERSIONRES)
       if(${NINJAVERSIONRES} EQ 0)
         if(${NINJAVERSION} VERSION_GREATER 1.8.2)
-          message(FATAL_ERROR "You have hit https://gitlab.kitware.com/cmake/cmake/issues/19222\n"
+          message(WARNING "You have hit https://gitlab.kitware.com/cmake/cmake/issues/19222\n"
             "Your build will be indeterministic, i.e. unreliable for incremental builds."
             "To fix this, please install CMake >= 3.14.4!")
         endif()


### PR DESCRIPTION
We wanted FATAL_ERROR for our Jenkins. That has been running for many
months now; switch to WARNING for the release as this still allows
users to get a proper ROOT build.

(cherry picked from commit 193c3160c0442e099d80e9ec43306efe299f2edc)