### PR TITLE
[ntuple] Use TFile's compression for most RNTuples

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -217,6 +217,10 @@ public:
    RNTupleFileWriter &operator =(RNTupleFileWriter &&other) = delete;
    ~RNTupleFileWriter();
 
+   /// Get the TFile's compression setting, if any. Calling this method on a bare file writer
+   /// is an error.
+   int GetTFileCompression() const;
+
    /// Writes the compressed header and registeres its location; lenHeader is the size of the uncompressed header.
    std::uint64_t WriteNTupleHeader(const void *data, size_t nbytes, size_t lenHeader);
    /// Writes the compressed footer and registeres its location; lenFooter is the size of the uncompressed footer.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -47,6 +47,9 @@ All page sink classes need to support the common options.
 class RNTupleWriteOptions {
    int fCompression{RCompressionSetting::EDefaults::kUseAnalysis};
    ENTupleContainerFormat fContainerFormat{ENTupleContainerFormat::kTFile};
+   /// Whether the user has explicitly set these options, e.g. to override a
+   /// TFile's compression setting.
+   bool fIsCompressionOverride = false;
    NTupleSize_t fNEntriesPerCluster = 64000;
    NTupleSize_t fNElementsPerPage = 10000;
    bool fUseBufferedWrite = true;
@@ -57,10 +60,15 @@ public:
    { return std::make_unique<RNTupleWriteOptions>(*this); }
 
    int GetCompression() const { return fCompression; }
-   void SetCompression(int val) { fCompression = val; }
-   void SetCompression(RCompressionSetting::EAlgorithm algorithm, int compressionLevel) {
-     fCompression = CompressionSettings(algorithm, compressionLevel);
+   void SetCompression(int val) {
+      fIsCompressionOverride = true;
+      fCompression = val;
    }
+   void SetCompression(RCompressionSetting::EAlgorithm algorithm, int compressionLevel) {
+      SetCompression(CompressionSettings(algorithm, compressionLevel));
+   }
+   /// Returns true if the compression settings were explicitly set by the user.
+   bool IsCompressionOverride() const { return fIsCompressionOverride; }
 
    ENTupleContainerFormat GetContainerFormat() const { return fContainerFormat; }
    void SetContainerFormat(ENTupleContainerFormat val) { fContainerFormat = val; }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -62,6 +62,7 @@ private:
    /// Byte offset of the end of the last page of the current cluster
    std::uint64_t fClusterMaxOffset = 0;
    RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
+   int UpdateCompression();
 
    RClusterDescriptor::RLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage,
                                                 std::size_t bytesPacked);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -76,8 +76,12 @@ protected:
 
 public:
    RPageSinkFile(std::string_view ntupleName, std::string_view path, const RNTupleWriteOptions &options);
+   /// RNTuples with the default RNTupleWriteOptions compression setting will use the TFile's
+   /// compression setting.
    RPageSinkFile(std::string_view ntupleName, std::string_view path, const RNTupleWriteOptions &options,
                  std::unique_ptr<TFile> &file);
+   /// RNTuples with the default RNTupleWriteOptions compression setting will use the TFile's
+   /// compression setting.
    RPageSinkFile(std::string_view ntupleName, TFile &file, const RNTupleWriteOptions &options);
    RPageSinkFile(const RPageSinkFile&) = delete;
    RPageSinkFile& operator=(const RPageSinkFile&) = delete;

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1226,6 +1226,10 @@ void ROOT::Experimental::Internal::RNTupleFileWriter::Commit()
    fflush(fFileSimple.fFile);
 }
 
+int ROOT::Experimental::Internal::RNTupleFileWriter::GetTFileCompression() const {
+   R__ASSERT(fFileProper && "Internal error: called GetTFileCompression on a bare file");
+   return fFileProper.fFile->GetCompressionSettings();
+}
 
 std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::WriteBlob(const void *data, size_t nbytes, size_t len)
 {

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -28,6 +28,7 @@
 
 #include <RVersion.h>
 #include <TError.h>
+#include <TFile.h>
 
 #include <algorithm>
 #include <cstdio>
@@ -67,6 +68,9 @@ ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntuple
    const RNTupleWriteOptions &options)
    : RPageSinkFile(ntupleName, options)
 {
+   if (RPageSink::fOptions.GetCompression() == RCompressionSetting::EDefaults::kUseAnalysis) {
+      RPageSink::fOptions.SetCompression(file.GetCompressionSettings());
+   }
    fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(Internal::RNTupleFileWriter::Append(ntupleName, file));
 }
 
@@ -75,6 +79,9 @@ ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntuple
    const RNTupleWriteOptions &options, std::unique_ptr<TFile> &file)
    : RPageSinkFile(ntupleName, options)
 {
+   if (RPageSink::fOptions.GetCompression() == RCompressionSetting::EDefaults::kUseAnalysis) {
+      RPageSink::fOptions.SetCompression(file->GetCompressionSettings());
+   }
    fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(
       Internal::RNTupleFileWriter::Recreate(ntupleName, path, file));
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -96,6 +96,10 @@ int ROOT::Experimental::Detail::RPageSinkFile::UpdateCompression() {
    }
    auto compression = fWriter->GetTFileCompression();
    for (auto &columnRange : RPageSink::fOpenColumnRanges) {
+      // if the compression hasn't changed since last we checked, return
+      if (columnRange.fCompressionSettings == compression) {
+         return compression;
+      }
       columnRange.fCompressionSettings = compression;
    }
    return compression;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -68,7 +68,7 @@ ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntuple
    const RNTupleWriteOptions &options)
    : RPageSinkFile(ntupleName, options)
 {
-   if (RPageSink::fOptions.GetCompression() == RCompressionSetting::EDefaults::kUseAnalysis) {
+   if (!options.IsCompressionOverride()) {
       RPageSink::fOptions.SetCompression(file.GetCompressionSettings());
    }
    fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(Internal::RNTupleFileWriter::Append(ntupleName, file));
@@ -79,7 +79,7 @@ ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntuple
    const RNTupleWriteOptions &options, std::unique_ptr<TFile> &file)
    : RPageSinkFile(ntupleName, options)
 {
-   if (RPageSink::fOptions.GetCompression() == RCompressionSetting::EDefaults::kUseAnalysis) {
+   if (!options.IsCompressionOverride()) {
       RPageSink::fOptions.SetCompression(file->GetCompressionSettings());
    }
    fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -79,11 +79,11 @@ ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile(std::string_view ntuple
    const RNTupleWriteOptions &options, std::unique_ptr<TFile> &file)
    : RPageSinkFile(ntupleName, options)
 {
+   fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(
+      Internal::RNTupleFileWriter::Recreate(ntupleName, path, file));
    if (!options.IsCompressionOverride()) {
       RPageSink::fOptions.SetCompression(file->GetCompressionSettings());
    }
-   fWriter = std::unique_ptr<Internal::RNTupleFileWriter>(
-      Internal::RNTupleFileWriter::Recreate(ntupleName, path, file));
 }
 
 

--- a/tree/ntuple/v7/test/ntuple_zip.cxx
+++ b/tree/ntuple/v7/test/ntuple_zip.cxx
@@ -99,12 +99,13 @@ TEST(RNTupleZip, TFileCompressionSettings)
          std::make_unique<RPageSinkFile>("ntuple0", fileGuard.GetPath(), RNTupleWriteOptions(), file));
       ntuple0->Fill();
    }
-   std::ostringstream oss;
-   // ... ntuple0 uses the TFile's compression level
-   auto ntuple0 = RNTupleReader::Open("ntuple0", fileGuard.GetPath());
-   ntuple0->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails, oss);
-   EXPECT_THAT(oss.str(), testing::HasSubstr("Compression: 101"));
-   oss.str("");
+   {
+      std::ostringstream oss;
+      // ... ntuple0 uses the TFile's compression level
+      auto ntuple0 = RNTupleReader::Open("ntuple0", fileGuard.GetPath());
+      ntuple0->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails, oss);
+      EXPECT_THAT(oss.str(), testing::HasSubstr("Compression: 101"));
+   }
 
    RNTupleWriteOptions overrideCompression;
    overrideCompression.SetCompression(505);
@@ -114,7 +115,7 @@ TEST(RNTupleZip, TFileCompressionSettings)
       auto model = RNTupleModel::Create();
       auto field = model->MakeField<float>("field");
       auto ntuple1 = std::make_unique<RNTupleWriter>(std::move(model),
-         std::make_unique<RPageSinkFile>("ntuple1", fileGuard.GetPath(), overrideCompression, file));
+         std::make_unique<RPageSinkFile>("ntuple1", *file, overrideCompression));
       ntuple1->Fill();
    }
    // test using RNTupleWriter::Append (which calls the RPageSinkFile TFile& constructor)
@@ -139,6 +140,7 @@ TEST(RNTupleZip, TFileCompressionSettings)
    }
    file.reset();
 
+   std::ostringstream oss;
    // ... ntuple1 uses the specific compression level
    auto ntuple1 = RNTupleReader::Open("ntuple1", fileGuard.GetPath());
    ntuple1->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails, oss);

--- a/tree/ntuple/v7/test/ntuple_zip.cxx
+++ b/tree/ntuple/v7/test/ntuple_zip.cxx
@@ -104,10 +104,11 @@ TEST(RNTupleZip, TFilePtrCompressionSettings)
       auto model = RNTupleModel::Create();
       auto field = model->MakeField<float>("field");
       auto klassVec = model->MakeField<std::vector<CustomStruct>>("klassVec");
+      RNTupleWriteOptions options;
+      options.SetCompression(404);
       auto ntuple = std::make_unique<RNTupleWriter>(std::move(model),
-         std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), RNTupleWriteOptions(), file
+         std::make_unique<RPageSinkFile>("ntuple", fileGuard.GetPath(), options, file
       ));
-      file->SetCompressionSettings(404);
       for (int i = 0; i < 20000; i++) {
          *field = static_cast<float>(i);
          CustomStruct klass;

--- a/tree/ntuple/v7/test/ntuple_zip.cxx
+++ b/tree/ntuple/v7/test/ntuple_zip.cxx
@@ -85,11 +85,11 @@ TEST(RNTupleZip, Large)
    EXPECT_EQ(data, std::string(unzipBuffer.get(), N));
 }
 
-TEST(RNTupleZip, TFileCompressionSettings)
+TEST(RNTupleZip, TFilePtrCompressionSettings)
 {
-   // TFile compression will be set to 101 (zlib), but some RNTuples will override this setting
-
-   FileRaii fileGuard("test_ntuple_zip_tfile_comp.root");
+   // RNTuple added to a TFile using the std::unique_ptr<TFile>& method uses the
+   // TFile's compression
+   FileRaii fileGuard("test_ntuple_zip_tfileptr_comp.root");
    // test using RPageSinkFile constructor taking std::unique_ptr<TFile>&
    {
       auto file = std::make_unique<TFile>(fileGuard.GetPath().c_str(), "RECREATE", "", 101);
@@ -106,7 +106,12 @@ TEST(RNTupleZip, TFileCompressionSettings)
       ntuple0->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails, oss);
       EXPECT_THAT(oss.str(), testing::HasSubstr("Compression: 101"));
    }
+}
 
+TEST(RNTupleZip, TFileCompressionSettings)
+{
+   // TFile compression will be set to 101 (zlib), but some RNTuples will override this setting
+   FileRaii fileGuard("test_ntuple_zip_tfile_comp.root");
    RNTupleWriteOptions overrideCompression;
    overrideCompression.SetCompression(505);
    auto file = std::make_unique<TFile>(fileGuard.GetPath().c_str(), "RECREATE", "", 101);


### PR DESCRIPTION
If users have not explicitly set the RNTuple's compression settings through `RNTupleWriteOptions` and are added to a TFile, use the TFile's compression.

Before: 
```cpp
{
   // set file compression algo to 101 (zlib)
   auto file = std::make_unique<TFile>(fileGuard.GetPath().c_str(), "RECREATE", "", 101);
   auto model = RNTupleModel::Create();
   auto field = model->MakeField<float>("field");
   auto ntuple = RNTupleWriter::Append(std::move(model), "Events", *file);
   ntuple->Fill();
}

// ntuple uses default compression level 404 (lz4)
std::ostringstream oss;
auto ntuple = RNTupleReader::Open("Events", fileGuard.GetPath());
ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails, oss);
EXPECT_THAT(oss.str(), testing::HasSubstr("Compression: 404"));
```

After:
```cpp
{
   // set file compression algo to 101 (zlib)
   auto file = std::make_unique<TFile>(fileGuard.GetPath().c_str(), "RECREATE", "", 101);
   auto model = RNTupleModel::Create();
   auto field = model->MakeField<float>("field");
   auto ntuple = RNTupleWriter::Append(std::move(model), "Events", *file);
   ntuple->Fill();
}

// ntuple uses TFile's compression level
std::ostringstream oss;
auto ntuple = RNTupleReader::Open("Events", fileGuard.GetPath());
ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails, oss);
EXPECT_THAT(oss.str(), testing::HasSubstr("Compression: 101"));
```

Specify we want compression level 404: 
```cpp
{
   // set file compression algo to 101 (zlib)
   auto file = std::make_unique<TFile>(fileGuard.GetPath().c_str(), "RECREATE", "", 101);
   auto model = RNTupleModel::Create();
   auto field = model->MakeField<float>("field");
   RNTupleWriteOptions opt;
   opt.SetCompression(404);
   auto ntuple = RNTupleWriter::Append(std::move(model), "Events", *file, opt);
   ntuple->Fill();
}

// ntuple uses explicitly set compression level
std::ostringstream oss;
auto ntuple = RNTupleReader::Open("Events", fileGuard.GetPath());
ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails, oss);
EXPECT_THAT(oss.str(), testing::HasSubstr("Compression: 404"));
```