### PR TITLE
Fix the Warning of evaluating RooAddPdf without a normalization set

### DIFF
--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -82,6 +82,8 @@ public:
   const RooArgSet& getCoefNormalization() const { return _refCoefNorm ; }
   const char* getCoefRange() const { return _refCoefRangeName?RooNameReg::str(_refCoefRangeName):"" ; }
 
+  virtual Double_t getValV(const RooArgSet *set = 0) const;
+  
   virtual void resetErrorCounters(Int_t resetValue=10) ;
 
   virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ; 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -95,6 +95,7 @@ for single nodes.
 #include "RooVectorDataStore.h"
 #include "RooTreeDataStore.h"
 #include "ROOT/RMakeUnique.hxx"
+#include "RooHelpers.h"
 
 #include <iostream>
 #include <fstream>
@@ -2030,6 +2031,9 @@ void RooAbsArg::graphVizTree(ostream& os, const char* delimiter, bool useTitle, 
   if (!os) {
     coutE(InputArguments) << "RooAbsArg::graphVizTree() ERROR: output stream provided as input argument is in invalid state" << endl ;
   }
+
+  // silent warning messages coming when evaluating a RooAddPdf without a normalization set
+  RooHelpers::LocalChangeMsgLevel locmsg(RooFit::WARNING, 0u, RooFit::Eval, false);
 
   // Write header
   os << "digraph \"" << GetName() << "\"{" << endl ;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1986,6 +1986,9 @@ RooAbsReal* RooAbsPdf::createChi2(RooDataSet& data, const RooLinkedList& cmdList
 
 void RooAbsPdf::printValue(ostream& os) const
 {
+  // silent warning messages coming when evaluating a RooAddPdf without a normalization set
+  RooHelpers::LocalChangeMsgLevel locmsg(RooFit::WARNING, 0u, RooFit::Eval, false);
+
   getVal() ;
 
   if (_norm) {


### PR DESCRIPTION
- Add an implementation of getValV for RooAddPdf to use stored normalization as default one when the pdf is evaluated without passing a norm. set.
- Disable printing of warning message when evaluating un-normalized RooAddPdf in : 
  -   RooAbsPdf::printValue
  - RooAbsArg::graphVizTree
  - when getVal(0) is called in constructor of RooRealIntegral when a normalization set is not defined.

