### PR TITLE
[ntuple] Add null checks to high-level RNTuple API

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -132,6 +132,7 @@ public:
    };
 
 
+   /// Throws an exception if the model is null.
    static std::unique_ptr<RNTupleReader> Open(std::unique_ptr<RNTupleModel> model,
                                               std::string_view ntupleName,
                                               std::string_view storage,
@@ -140,9 +141,14 @@ public:
                                               std::string_view storage,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
 
-   /// The user imposes an ntuple model, which must be compatible with the model found in the data on storage
+   /// The user imposes an ntuple model, which must be compatible with the model found in the data on
+   /// storage.
+   ///
+   /// Throws an exception if the model or the source is null.
    RNTupleReader(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Detail::RPageSource> source);
    /// The model is generated from the ntuple metadata on storage
+   ///
+   /// Throws an exception if the source is null.
    explicit RNTupleReader(std::unique_ptr<Detail::RPageSource> source);
    std::unique_ptr<RNTupleReader> Clone() { return std::make_unique<RNTupleReader>(fSource->Clone()); }
    ~RNTupleReader();
@@ -222,14 +228,17 @@ private:
    NTupleSize_t fNEntries;
 
 public:
+   /// Throws an exception if the model is null.
    static std::unique_ptr<RNTupleWriter> Recreate(std::unique_ptr<RNTupleModel> model,
                                                   std::string_view ntupleName,
                                                   std::string_view storage,
                                                   const RNTupleWriteOptions &options = RNTupleWriteOptions());
+   /// Throws an exception if the model is null.
    static std::unique_ptr<RNTupleWriter> Append(std::unique_ptr<RNTupleModel> model,
                                                 std::string_view ntupleName,
                                                 TFile &file,
                                                 const RNTupleWriteOptions &options = RNTupleWriteOptions());
+   /// Throws an exception if the model or the sink is null.
    RNTupleWriter(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Detail::RPageSink> sink);
    RNTupleWriter(const RNTupleWriter&) = delete;
    RNTupleWriter& operator=(const RNTupleWriter&) = delete;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -92,11 +92,13 @@ public:
    /// Throws an exception if the field is null.
    void AddField(std::unique_ptr<Detail::RFieldBase> field);
 
+   /// Throws an exception if fromWhere is null.
    template <typename T>
    void AddField(std::string_view fieldName, T* fromWhere) {
       AddField<T>({fieldName, ""}, fromWhere);
    }
 
+   /// Throws an exception if fromWhere is null.
    template <typename T>
    void AddField(std::pair<std::string_view, std::string_view> fieldNameDesc, T* fromWhere) {
       EnsureValidFieldName(fieldNameDesc.first);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -88,6 +88,8 @@ public:
    }
 
    /// Adds a field whose type is not known at compile time.  Thus there is no shared pointer returned.
+   ///
+   /// Throws an exception if the field is null.
    void AddField(std::unique_ptr<Detail::RFieldBase> field);
 
    template <typename T>
@@ -98,6 +100,9 @@ public:
    template <typename T>
    void AddField(std::pair<std::string_view, std::string_view> fieldNameDesc, T* fromWhere) {
       EnsureValidFieldName(fieldNameDesc.first);
+      if (!fromWhere) {
+         throw RException(R__FAIL("null field fromWhere"));
+      }
       auto field = std::make_unique<RField<T>>(fieldNameDesc.first);
       field->SetDescription(fieldNameDesc.second);
       fDefaultEntry->CaptureValue(field->CaptureValue(fromWhere));
@@ -110,6 +115,8 @@ public:
    }
 
    /// Ingests a model for a sub collection and attaches it to the current model
+   ///
+   /// Throws an exception if collectionModel is null.
    std::shared_ptr<RCollectionNTupleWriter> MakeCollection(
       std::string_view fieldName,
       std::unique_ptr<RNTupleModel> collectionModel);

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -92,6 +92,12 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(
    , fModel(std::move(model))
    , fMetrics("RNTupleReader")
 {
+   if (!fSource) {
+      throw RException(R__FAIL("null source"));
+   }
+   if (!fModel) {
+      throw RException(R__FAIL("null model"));
+   }
    InitPageSource();
    ConnectModel(*fModel);
 }
@@ -101,6 +107,9 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
    , fModel(nullptr)
    , fMetrics("RNTupleReader")
 {
+   if (!fSource) {
+      throw RException(R__FAIL("null source"));
+   }
    InitPageSource();
 }
 
@@ -255,6 +264,12 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
    , fLastCommitted(0)
    , fNEntries(0)
 {
+   if (!fModel) {
+      throw RException(R__FAIL("null model"));
+   }
+   if (!fSink) {
+      throw RException(R__FAIL("null sink"));
+   }
    fSink->Create(*fModel.get());
    fMetrics.ObserveMetrics(fSink->GetMetrics());
 }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -52,6 +52,9 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
 
 void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBase> field)
 {
+   if (!field) {
+      throw RException(R__FAIL("null field"));
+   }
    EnsureValidFieldName(field->GetName());
    fDefaultEntry->AddValue(field->GenerateValue());
    fFieldZero->Attach(std::move(field));
@@ -62,6 +65,9 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental:
    std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)
 {
    EnsureValidFieldName(fieldName);
+   if (!collectionModel) {
+      throw RException(R__FAIL("null collectionModel"));
+   }
    auto collectionNTuple = std::make_shared<RCollectionNTupleWriter>(std::move(collectionModel->fDefaultEntry));
    auto field = std::make_unique<RCollectionField>(fieldName, collectionNTuple, std::move(collectionModel));
    fDefaultEntry->CaptureValue(field->CaptureValue(collectionNTuple->GetOffsetPtr()));

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -337,4 +337,59 @@ TEST(RNTuple, NullSafety)
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("null field fromWhere"));
    }
+
+   // RNTupleReader and RNTupleWriter
+   FileRaii fileGuard("test_ntuple_null_safety.root");
+   try {
+      RNTupleWriter ntuple(nullptr,
+         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
+      FAIL() << "null models should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
+   }
+   try {
+      RNTupleWriter ntuple(std::move(model), nullptr);
+      FAIL() << "null sinks should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null sink"));
+   }
+   try {
+      auto ntuple = RNTupleWriter::Recreate(nullptr, "myNtuple", fileGuard.GetPath());
+      FAIL() << "null models should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
+   }
+   try {
+      auto file = std::make_unique<TFile>(fileGuard.GetPath().c_str(), "RECREATE", "", 101);
+      auto ntuple = RNTupleWriter::Append(nullptr, "myNtuple", *file);
+      FAIL() << "null models should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
+   }
+
+   try {
+      auto ntuple = RNTupleReader::Open(nullptr, "myNTuple", fileGuard.GetPath());
+      FAIL() << "null models should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
+   }
+   try {
+      RNTupleReader ntuple(nullptr,
+         std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
+      FAIL() << "null models should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null model"));
+   }
+   try {
+      RNTupleReader ntuple(RNTupleModel::Create(), nullptr);
+      FAIL() << "null sources should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null source"));
+   }
+   try {
+      RNTupleReader ntuple(nullptr);
+      FAIL() << "null sources should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null source"));
+   }
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -314,3 +314,27 @@ TEST(RNTupleModel, CollectionFieldDescriptions)
    const auto& muon_desc = *ntuple->GetDescriptor().GetTopLevelFields().begin();
    EXPECT_EQ(std::string("muons after basic selection"), muon_desc.GetFieldDescription());
 }
+
+TEST(RNTuple, NullSafety)
+{
+   // RNTupleModel
+   auto model = RNTupleModel::Create();
+   try {
+      auto bad = model->MakeCollection("bad", nullptr);
+      FAIL() << "null submodels should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null collectionModel"));
+   }
+   try {
+      model->AddField(nullptr);
+      FAIL() << "null fields should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null field"));
+   }
+   try {
+      model->AddField<float>("pt", nullptr);
+      FAIL() << "null fields should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("null field fromWhere"));
+   }
+}


### PR DESCRIPTION
Add null checks to some important high-level RNTuple APIs. In general, they are not the most complicated errors but it would be nice to be completely segfault free.

e.g.
```cpp
auto model = RNTupleModel::Create();
model->AddField(nullptr);
```

Before: 
```
 *** Break *** segmentation violation
```
After: 
```
C++ exception with description "null field
At:
  void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>) [/home/max/projects/rootdev/root/tree/ntuple/v7/src/RNTupleModel.cxx:56]
" thrown in the test body.
```