### PR TITLE
Fixing user guide markdown issues

### DIFF
--- a/documentation/users-guide/Geometry.md
+++ b/documentation/users-guide/Geometry.md
@@ -3305,7 +3305,7 @@ suppose you already did that with your simple geometry and immediately
 noticed a new ROOT canvas popping-up and having some more or less
 strange picture inside. Here are few questions that might come:
 
--   ***`Q: "The picture is strangely rotated; where are the coordinate axes?"`***
+***`Q:`*** "The picture is strangely rotated; where are the coordinate axes?"
 
 ***`A:`*** If drawn in a new canvas, any view has some default
 viewpoint, center of view and size. One can then perform mouse/keyboard
@@ -3319,21 +3319,21 @@ display as well as changing top or side viewpoints can be activated from
 the **`TView`** context menu: right-click on the picture when no object
 is selected;
 
--   ***`Q: "Every line is black! I cannot figure out what is what..."`***
+***`Q:`*** "Every line is black! I cannot figure out what is what..."
 
 ***`A:`*** Volumes can have different colors (those known by ROOT of
 course). Think at using them after each volume creation:
 `myvolume->SetLineColor(Int_t color);` otherwise everything is by
 default black.
 
--   ***`Q: "The top volume of my geometry is a box but I see only its content."`***
+***`Q:`*** "The top volume of my geometry is a box but I see only its content."
 
 ***`A:`*** By default the drawn volume is not displayed just because we
 do not want to hide its content when changing the view to HLR or solid
 mode. In order to see it in the default wire frame picture one has to
 call **`TGeoManager::SetTopVisible()`.**
 
--   ***`Q: "I do not see all volumes in my tree but just something inside."`***
+***`Q:`*** "I do not see all volumes in my tree but just something inside."
 
 ***`A:`*** By default, **`TGeoVolume`**`::Draw()` paints the content of
 a given volume three levels down. You can change this by using:
@@ -3347,7 +3347,7 @@ default one and corresponds to ‘leaves' global visualization mode
 intermediate containers, one can change this mode:
 `gGeoManager->SetVisOption(0)`.**
 
--   ***`Q: "Volumes are highlighted when moving the mouse over their vertices. What does it mean?"`***
+***`Q:`*** "Volumes are highlighted when moving the mouse over their vertices. What does it mean?"
 
 ***`A:`*** Indeed, moving the mouse close to some volume vertices
 selects it. By checking the `Event Status` entry in the root canvas
@@ -3355,7 +3355,7 @@ selects it. By checking the `Event Status` entry in the root canvas
 bottom right. Right-clicking when a volume is selected will open its
 context menu where several actions can be performed (e.g. drawing it).
 
--   ***`Q: "OK, but now I do not want to see all the geometry, but just a particular volume and its content. How can I do this?"`***
+***`Q:`*** "OK, but now I do not want to see all the geometry, but just a particular volume and its content. How can I do this?"
 
 ***`A:`*** Once you have set a convenient global visualization option
 and level, what you need is just call the `Draw()` method of your

--- a/documentation/users-guide/InputOutput.md
+++ b/documentation/users-guide/InputOutput.md
@@ -1648,7 +1648,7 @@ identify the referenced **`TObject`**.
 When a referenced object is read from a file (its bit `kIsReferenced` is
 set), this object is entered into the objects table of the corresponding
 **`TProcessID`**. Each **`TFile`** has a list of **`TProcessIDs`** (see
-**`TFile`**`::fProcessIDs`) also accessible` from `TProcessID::fgPIDs`
+`TFile::fProcessIDs`) also accessible from `TProcessID::fgPIDs`
 (for all files). When this object is deleted, it is removed from the
 table via the cleanup mechanism invoked by the **`TObject`** destructor.
 Each **`TProcessID`** has a table (`TObjArray *fObjects`) that keeps

--- a/documentation/users-guide/MathLibraries.md
+++ b/documentation/users-guide/MathLibraries.md
@@ -1445,7 +1445,8 @@ GSL library, wich is provided in the *MathMore* library of ROOT.
 
 The interface to use is the same as above. We have now the possibility to specify a different integration algorithm in the constructor of the `ROOT::Math::GSLIntegrator` class.
 ```{.cpp}
-ROOT::Math::GSLIntegrator ig(ROOT::Math::Integration::kADAPTIVE, ROOT::Math::Integration::kGAUSS51);   // create the adaptive integrator with the 51 point rule
+// create the adaptive integrator with the 51 point rule
+ROOT::Math::GSLIntegrator ig(ROOT::Math::Integration::kADAPTIVE, ROOT::Math::Integration::kGAUSS51);
 ig.SetRelTolerance(1.E-6);  // set relative tolerance
 ig.SetAbsTolerance(1.E-6);   // set absoulte tolerance
 ```

--- a/documentation/users-guide/WritingGUI.md
+++ b/documentation/users-guide/WritingGUI.md
@@ -2836,7 +2836,7 @@ return kNone;
 ```
 
 `Atom_t HandleDNDposition(Int_t x,Int_t y,Atom_t action,Int_t xroot,
-Int_t yroot)-` this
+Int_t yroot)` - this
 method should be used to handle the drag position in widget coordinates
 (`x,y`) or in root coordinates (`xroot,yroot`).
 
@@ -2850,7 +2850,7 @@ if (pad) {
 return action;
 ```
 
-`Bool_t HandleDNDdrop(`TDNDdata *data`) - this is the place where the
+`Bool_t HandleDNDdrop(TDNDdata *data)` - this is the place where the
 widget actually receives the data. First, check the data format (see
 description of **`TDNDData`** - Drag and Drop data class) and then use
 it accordingly. In the case of ROOT object, here is an example of how to


### PR DESCRIPTION
Markdown errors lead to incorrect rendering of the ROOT user guide. Some elements are rendered wider than the body width. Therefore annoying horizontal scrollbar is present on the User Guide web page:

https://root.cern/root/htmldoc/guides/users-guide/ROOTUsersGuide.html