### PR TITLE
[Cling] Update cpt to build Cling using LLVM 9

### DIFF
--- a/interpreter/cling/.github/workflows/ci.yml
+++ b/interpreter/cling/.github/workflows/ci.yml
@@ -17,19 +17,15 @@ jobs:
       matrix:
 
         include:
-          - name: ubuntu-16.04-gcc
+          - name: ubuntu-16.04-gcc-compile
             os: ubuntu-16.04
             compiler: gcc
 
-          - name: ubuntu-16.04-clang
-            os: ubuntu-16.04
-            compiler: clang
-
-          - name: ubuntu-18.04-gcc
+          - name: ubuntu-18.04-gcc-compile
             os: ubuntu-18.04
             compiler: gcc
 
-          - name: ubuntu-18.04-clang
+          - name: ubuntu-18.04-clang-compile
             os: ubuntu-18.04
             compiler: clang
 
@@ -41,7 +37,7 @@ jobs:
             os: ubuntu-20.04
             compiler: clang
 
-          - name: macos-10.15-xcode-11.2.1-fromtar
+          - name: macos-10.15-xcode-11.2.1-compile
             os: macOS-10.15
             compiler: clang
             xcode-version: "11.2.1"
@@ -103,3 +99,7 @@ jobs:
           python3 cpt.py -y --check-requirements --current-dev=tar --with-cmake-flags="$CLING_BUILD_FLAGS" --with-cling-url=https://github.com/$REPO --cling-branch=${{ github.head_ref }} --with-binary-llvm
         fi
       working-directory: tools/packaging/
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 1 # When debugging increase to a suitable value!

--- a/interpreter/cling/tools/packaging/cpt.py
+++ b/interpreter/cling/tools/packaging/cpt.py
@@ -431,9 +431,8 @@ def set_vars():
     if not os.path.isfile(os.path.join(LLVM_OBJ_ROOT, 'test', 'lit.site.cfg')):
         if not os.path.exists(os.path.join(LLVM_OBJ_ROOT, 'test')):
             os.mkdir(os.path.join(LLVM_OBJ_ROOT, 'test'))
-        exec_subprocess_call('make lit.site.cfg', os.path.join(LLVM_OBJ_ROOT, 'test'))
 
-    with open(os.path.join(LLVM_OBJ_ROOT, 'test', 'lit.site.cfg'), 'r') as lit_site_cfg:
+    with open(os.path.join(LLVM_OBJ_ROOT, 'test', 'lit.site.cfg.py'), 'r') as lit_site_cfg:
         for line in lit_site_cfg:
             if re.match('^config.llvm_shlib_ext = ', line):
                 SHLIBEXT = re.sub('^config.llvm_shlib_ext = ', '', line).replace('"', '').strip()


### PR DESCRIPTION
Only builds using LLVM 9 source works right now (using `--with-binary-llvm` and `--with-llvm-tar` flags will cause a build error).

A single test fails. Reproducer - `cat <path to cling source dir>/test/Lookup/template.C | cling --nologo -I<path to build dir>/tools/clang/include -Xclang -verify -fno-rtti 2>&1`