### PR TITLE
[DF] Lazily import numpy in distributed reduce step.

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -14,7 +14,6 @@ import functools
 from abc import ABCMeta
 from abc import abstractmethod
 
-import numpy
 import ROOT
 from DistRDF.Backends import Utils
 
@@ -240,6 +239,11 @@ class BaseBackend(ABC):
                 # Concatenate the partial numpy arrays along the same key of
                 # the dictionary.
                 elif isinstance(mergeable_out, dict):
+                    # Import numpy lazily
+                    try:
+                        import numpy
+                    except ImportError:
+                        raise ImportError("Failed to import numpy during distributed RDataFrame reduce step.")
                     mergeables_out[index] = {
                         key: numpy.concatenate([mergeable_out[key],
                                                 mergeable_in[key]])


### PR DESCRIPTION
Otherwise distributed RDF would import numpy also in applications not actually using `df.AsNumpy`