### PR TITLE
[DF] Add enum34 in requirements.txt for Python2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,8 @@ cffi>=1.9.1
 notebook>=4.4.1
 metakernel>=0.20.0
 
-# Distributed RDataFrame: Spark backend
+# Distributed RDataFrame
+# Spark backend
 pyspark>=2.4
+# Checking RDataFrame operation type through enums. Requires pip 6.0 and later
+enum34 ; python_version < '3.4'


### PR DESCRIPTION
Distributed RDataFrame internally checks the category an operation belongs to (e.g. transformation, action) through enums in Python. The enum package was added in Python 3.4 and can be installed in previous Python versions, so it should be added to requirements.txt with a check on the python version.