### PR TITLE
TDataType: Compare typeid's directly

### DIFF
--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -190,39 +190,39 @@ EDataType TDataType::GetType(const std::type_info &typeinfo)
 {
    EDataType retType = kOther_t;
 
-   if (!strcmp(typeid(unsigned int).name(), typeinfo.name())) {
+   if (typeid(unsigned int) == typeinfo) {
       retType = kUInt_t;
-   } else if (!strcmp(typeid(int).name(), typeinfo.name())) {
+   } else if (typeid(int) == typeinfo) {
       retType = kInt_t;
-   } else if (!strcmp(typeid(ULong_t).name(), typeinfo.name())) {
+   } else if (typeid(ULong_t) == typeinfo) {
       retType = kULong_t;
-   } else if (!strcmp(typeid(Long_t).name(), typeinfo.name())) {
+   } else if (typeid(Long_t) == typeinfo) {
       retType = kLong_t;
-   } else if (!strcmp(typeid(ULong64_t).name(), typeinfo.name())) {
+   } else if (typeid(ULong64_t) == typeinfo) {
       retType = kULong64_t;
-   } else if (!strcmp(typeid(Long64_t).name(), typeinfo.name())) {
+   } else if (typeid(Long64_t) == typeinfo) {
       retType = kLong64_t;
-   } else if (!strcmp(typeid(unsigned short).name(), typeinfo.name())) {
+   } else if (typeid(unsigned short) == typeinfo) {
       retType = kUShort_t;
-   } else if (!strcmp(typeid(short).name(), typeinfo.name())) {
+   } else if (typeid(short) == typeinfo) {
       retType = kShort_t;
-   } else if (!strcmp(typeid(unsigned char).name(), typeinfo.name())) {
+   } else if (typeid(unsigned char) == typeinfo) {
       retType = kUChar_t;
-   } else if (!strcmp(typeid(char).name(), typeinfo.name())) {
+   } else if (typeid(char) == typeinfo) {
       retType = kChar_t;
-   } else if (!strcmp(typeid(Bool_t).name(), typeinfo.name())) {
+   } else if (typeid(Bool_t) == typeinfo) {
       retType = kBool_t;
-   } else if (!strcmp(typeid(float).name(), typeinfo.name())) {
+   } else if (typeid(float) == typeinfo) {
       retType = kFloat_t;
-   } else if (!strcmp(typeid(Float16_t).name(), typeinfo.name())) {
+   } else if (typeid(Float16_t) == typeinfo) {
       retType = kFloat16_t;
-   } else if (!strcmp(typeid(double).name(), typeinfo.name())) {
+   } else if (typeid(double) == typeinfo) {
       retType = kDouble_t;
-   } else if (!strcmp(typeid(Double32_t).name(), typeinfo.name())) {
+   } else if (typeid(Double32_t) == typeinfo) {
       retType = kDouble32_t;
-   } else if (!strcmp(typeid(char*).name(), typeinfo.name())) {
+   } else if (typeid(char*) == typeinfo) {
       retType = kCharStar;
-   } else if (!strcmp(typeid(signed char).name(), typeinfo.name())) {
+   } else if (typeid(signed char) == typeinfo) {
       retType = kDataTypeAliasSignedChar_t;
    }
    return retType;

--- a/core/meta/test/CMakeLists.txt
+++ b/core/meta/test/CMakeLists.txt
@@ -9,6 +9,7 @@ ROOT_ADD_GTEST(testHashRecursiveRemove testHashRecursiveRemove.cxx LIBRARIES Cor
 if(NOT MSVC OR win_broken_tests)
   ROOT_ADD_GTEST(testTClass testTClass.cxx LIBRARIES Core)
 endif()
+ROOT_ADD_GTEST(testTDataType testTDataType.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testTEnum testTEnum.cxx LIBRARIES Core)
 configure_file(stlDictCheck.h . COPYONLY)
 configure_file(stlDictCheckAux.h . COPYONLY)

--- a/core/meta/test/testTDataType.cxx
+++ b/core/meta/test/testTDataType.cxx
@@ -1,0 +1,13 @@
+#include "TDataType.h"
+#include "TInterpreter.h"
+
+#include "gtest/gtest.h"
+
+TEST(TDataType, GetType)
+{
+   auto interpreted = gInterpreter->Calc("TDataType::GetType(typeid(int))");
+   auto compiled = TDataType::GetType(typeid(int));
+
+   EXPECT_EQ(kInt_t, interpreted);
+   EXPECT_EQ(kInt_t, compiled);
+}


### PR DESCRIPTION
According to Itanium C++ ABI 2.9.2, "Basic type information [...] will be kept in the run-time support library. Specifically, the run-time support library should contain type_info objects for the types [...]", where all types TDataType::GetType cares about are listed. Since the ABI library contains the objects, equality is guaranteed in the whole process - even for JIT.