### PR TITLE
Next bunch of changes for Win64

### DIFF
--- a/core/base/inc/Bytes.h
+++ b/core/base/inc/Bytes.h
@@ -467,7 +467,7 @@ inline UInt_t host2net(UInt_t x)
 
 inline ULong_t host2net(ULong_t x)
 {
-#ifdef R__B64
+#if defined(R__B64) && !defined(_WIN64)
 # if defined(R__USEASMSWAP)
    return Rbswap_64(x);
 # else

--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -84,7 +84,7 @@ protected:
 
    TApplication();
 
-   virtual Long_t     ProcessRemote(const char *line, Int_t *error = 0);
+   virtual Longptr_t  ProcessRemote(const char *line, Int_t *error = 0);
    virtual void       Help(const char *line);
    virtual void       LoadGraphicsLibs();
    virtual void       MakeBatch();
@@ -111,8 +111,8 @@ public:
    virtual void    HandleIdleTimer();   //*SIGNAL*
    virtual Bool_t  HandleTermInput() { return kFALSE; }
    virtual void    Init() { fAppImp->Init(); }
-   virtual Long_t  ProcessLine(const char *line, Bool_t sync = kFALSE, Int_t *error = 0);
-   virtual Long_t  ProcessFile(const char *file, Int_t *error = 0, Bool_t keep = kFALSE);
+   virtual Longptr_t ProcessLine(const char *line, Bool_t sync = kFALSE, Int_t *error = 0);
+   virtual Longptr_t ProcessFile(const char *file, Int_t *error = 0, Bool_t keep = kFALSE);
    virtual void    Run(Bool_t retrn = kFALSE);
    virtual void    SetIdleTimer(UInt_t idleTimeInSec, const char *command);
    virtual void    RemoveIdleTimer();
@@ -155,7 +155,7 @@ public:
    virtual void    ReturnPressed(char *text );        //*SIGNAL*
    virtual Int_t   TabCompletionHook(char *buf, int *pLoc, std::ostream& out);
 
-   static Long_t   ExecuteFile(const char *file, Int_t *error = 0, Bool_t keep = kFALSE);
+   static Longptr_t ExecuteFile(const char *file, Int_t *error = 0, Bool_t keep = kFALSE);
    static TList   *GetApplications();
    static void     CreateApplication();
    static void     NeedGraphicsLibs();

--- a/core/base/inc/TObject.h
+++ b/core/base/inc/TObject.h
@@ -40,8 +40,8 @@ private:
    UInt_t         fUniqueID;   ///< object unique identifier
    UInt_t         fBits;       ///< bit field status word
 
-   static Long_t  fgDtorOnly;    ///< object for which to call dtor only (i.e. no delete)
-   static Bool_t  fgObjectStat;  ///< if true keep track of objects in TObjectTable
+   static Longptr_t fgDtorOnly;    ///< object for which to call dtor only (i.e. no delete)
+   static Bool_t    fgObjectStat;  ///< if true keep track of objects in TObjectTable
 
    static void AddToTObjectTable(TObject *);
 
@@ -220,7 +220,7 @@ public:
    void     Obsolete(const char *method, const char *asOfVers, const char *removedFromVers) const;
 
    //---- static functions
-   static Long_t    GetDtorOnly();
+   static Longptr_t GetDtorOnly();
    static void      SetDtorOnly(void *obj);
    static Bool_t    GetObjectStat();
    static void      SetObjectStat(Bool_t stat);

--- a/core/base/inc/TPluginManager.h
+++ b/core/base/inc/TPluginManager.h
@@ -144,7 +144,7 @@ public:
    Int_t       CheckPlugin() const;
    Int_t       LoadPlugin();
 
-   template <typename... T> Long_t ExecPluginImpl(const T&... params)
+   template <typename... T> Longptr_t ExecPluginImpl(const T&... params)
    {
       auto nargs = sizeof...(params);
       if (!CheckForExecPlugin(nargs)) return 0;
@@ -156,13 +156,13 @@ public:
       R__LOCKGUARD(gInterpreterMutex);
       fCallEnv->SetParams(params...);
 
-      Long_t ret;
+      Longptr_t ret;
       fCallEnv->Execute(ret);
 
       return ret;
    }
 
-   template <typename... T> Long_t ExecPlugin(int nargs, const T&... params)
+   template <typename... T> Longptr_t ExecPlugin(int nargs, const T&... params)
    {
       // For backward compatibility.
       if ((gDebug > 1) && (nargs != (int)sizeof...(params))) {

--- a/core/base/inc/TQConnection.h
+++ b/core/base/inc/TQConnection.h
@@ -58,7 +58,7 @@ protected:
    virtual void SetArg(ULong64_t param) override { SetArgImpl(param); }
    virtual void SetArg(const char * param) override { SetArgImpl(param); }
 
-   virtual void SetArg(const Long_t *params, Int_t nparam = -1) override;
+   virtual void SetArg(const Longptr_t *params, Int_t nparam = -1) override;
 
    template <typename T> void SetArgImpl(T arg)
    {
@@ -110,7 +110,7 @@ public:
    void ExecuteMethod(Long_t param);
    void ExecuteMethod(Long64_t param);
    void ExecuteMethod(Double_t param);
-   void ExecuteMethod(Long_t *params, Int_t nparam = -1);
+   void ExecuteMethod(Longptr_t *params, Int_t nparam = -1);
    void ExecuteMethod(const char *params);
    void ls(Option_t *option="") const override;
 

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -291,13 +291,13 @@ public:
    Int_t             LoadClass(const char *classname, const char *libname, Bool_t check = kFALSE);
    TClass           *LoadClass(const char *name, Bool_t silent = kFALSE) const;
    Int_t             LoadMacro(const char *filename, Int_t *error = 0, Bool_t check = kFALSE);
-   Long_t            Macro(const char *filename, Int_t *error = 0, Bool_t padUpdate = kTRUE);
+   Longptr_t         Macro(const char *filename, Int_t *error = 0, Bool_t padUpdate = kTRUE);
    TCanvas          *MakeDefCanvas() const;
    void              Message(Int_t id, const TObject *obj);
    Bool_t            MustClean() const { return fMustClean; }
-   Long_t            ProcessLine(const char *line, Int_t *error = 0);
-   Long_t            ProcessLineSync(const char *line, Int_t *error = 0);
-   Long_t            ProcessLineFast(const char *line, Int_t *error = 0);
+   Longptr_t         ProcessLine(const char *line, Int_t *error = 0);
+   Longptr_t         ProcessLineSync(const char *line, Int_t *error = 0);
+   Longptr_t         ProcessLineFast(const char *line, Int_t *error = 0);
    Bool_t            ReadingObject() const;
    void              RecursiveRemove(TObject *obj);
    void              RefreshBrowsers();

--- a/core/base/inc/TVirtualQConnection.h
+++ b/core/base/inc/TVirtualQConnection.h
@@ -31,18 +31,18 @@ protected:
    virtual void SetArg(ULong64_t) = 0;
 
    // Note: sets argument list (for potentially more than one arg).
-   virtual void SetArg(const Long_t *, Int_t = -1) = 0;
+   virtual void SetArg(const Longptr_t *, Int_t = -1) = 0;
    virtual void SetArg(const char *) = 0;
-   void SetArg(const void *ptr) { SetArg((Long_t)ptr); };
+   void SetArg(const void *ptr) { SetArg((Longptr_t)ptr); };
 
    // We should 'widen' all types to one of the SetArg overloads.
    template <class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
    void SetArg(const T& val)
    {
       if (std::is_signed<T>::value)
-         SetArg((Long_t)val);
+         SetArg((Longptr_t)val);
       else
-         SetArg((ULong_t)val);
+         SetArg((ULongptr_t)val);
    }
 
    // We pass arrays as Lont_t*. In the template instance we can deduce their
@@ -52,7 +52,7 @@ protected:
    {
       constexpr size_t size = sizeof(val)/sizeof(val[0]);
       static_assert(size > 0, "The array must have at least one element!");
-      SetArg((Long_t*)val, size);
+      SetArg((Longptr_t*)val, size);
    }
 
    void SetArgsImpl() {} // SetArgsImpl terminator
@@ -81,7 +81,7 @@ public:
    /// Sets an array of arguments passed as a pointer type and size. If nargs is not specified
    /// the number of arguments expected by the slot is used.
    ///
-   void SetArgs(const Long_t* argArray, Int_t nargs = -1)
+   void SetArgs(const Longptr_t* argArray, Int_t nargs = -1)
    {
       SetArg(argArray, nargs);
    }

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -1247,7 +1247,7 @@ Int_t TApplication::ParseRemoteLine(const char *ln,
 /// The last argument 'script' allows to specify an alternative script to
 /// be executed remotely to startup the session.
 
-Long_t TApplication::ProcessRemote(const char *line, Int_t *)
+Longptr_t TApplication::ProcessRemote(const char *line, Int_t *)
 {
    if (!line) return 0;
 
@@ -1327,7 +1327,7 @@ namespace {
 /// command starting with a ".".
 /// Return the return value of the command cast to a long.
 
-Long_t TApplication::ProcessLine(const char *line, Bool_t sync, Int_t *err)
+Longptr_t TApplication::ProcessLine(const char *line, Bool_t sync, Int_t *err)
 {
    if (!line || !*line) return 0;
 
@@ -1421,7 +1421,7 @@ Long_t TApplication::ProcessLine(const char *line, Bool_t sync, Int_t *err)
          Warning("ProcessLine", "argument(s) \"%s\" ignored with .%c", arguments.Data(),
                  line[1]);
       }
-      Long_t retval = 0;
+      Longptr_t retval = 0;
       if (!mac)
          Error("ProcessLine", "macro %s not found in path %s", fname.Data(),
                TROOT::GetMacroPath());
@@ -1475,7 +1475,7 @@ Long_t TApplication::ProcessLine(const char *line, Bool_t sync, Int_t *err)
 ////////////////////////////////////////////////////////////////////////////////
 /// Process a file containing a C++ macro.
 
-Long_t TApplication::ProcessFile(const char *file, Int_t *error, Bool_t keep)
+Longptr_t TApplication::ProcessFile(const char *file, Int_t *error, Bool_t keep)
 {
    return ExecuteFile(file, error, keep);
 }
@@ -1484,7 +1484,7 @@ Long_t TApplication::ProcessFile(const char *file, Int_t *error, Bool_t keep)
 /// Execute a file containing a C++ macro (static method). Can be used
 /// while TApplication is not yet created.
 
-Long_t TApplication::ExecuteFile(const char *file, Int_t *error, Bool_t keep)
+Longptr_t TApplication::ExecuteFile(const char *file, Int_t *error, Bool_t keep)
 {
    static const Int_t kBufSize = 1024;
 
@@ -1522,7 +1522,7 @@ Long_t TApplication::ExecuteFile(const char *file, Int_t *error, Bool_t keep)
    int ifdef    = 0;
    char *s      = 0;
    Bool_t execute = kFALSE;
-   Long_t retval = 0;
+   Longptr_t retval = 0;
 
    while (1) {
       bool res = (bool)macro.getline(currentline, kBufSize);

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1202,7 +1202,7 @@ Int_t TDirectory::SaveObjectAs(const TObject *obj, const char *filename, Option_
    }
    TString cmd;
    if (fname.Index(".json") > 0) {
-      cmd.Form("TBufferJSON::ExportToFile(\"%s\",(TObject*) %s, \"%s\");", fname.Data(), TString::LLtoa((Long_t)obj, 10).Data(), (option ? option : ""));
+      cmd.Form("TBufferJSON::ExportToFile(\"%s\",(TObject*) %s, \"%s\");", fname.Data(), TString::LLtoa((Longptr_t)obj, 10).Data(), (option ? option : ""));
       nbytes = gROOT->ProcessLine(cmd);
    } else {
       cmd.Form("TFile::Open(\"%s\",\"recreate\");",fname.Data());

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -51,7 +51,7 @@ class hierarchies (watch out for overlaps).
 #include "TRefTable.h"
 #include "TProcessID.h"
 
-Long_t TObject::fgDtorOnly = 0;
+Longptr_t TObject::fgDtorOnly = 0;
 Bool_t TObject::fgObjectStat = kTRUE;
 
 ClassImp(TObject);
@@ -979,7 +979,7 @@ void TObject::SetObjectStat(Bool_t stat)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return destructor only flag
 
-Long_t TObject::GetDtorOnly()
+Longptr_t TObject::GetDtorOnly()
 {
    return fgDtorOnly;
 }
@@ -989,7 +989,7 @@ Long_t TObject::GetDtorOnly()
 
 void TObject::SetDtorOnly(void *obj)
 {
-   fgDtorOnly = (Long_t) obj;
+   fgDtorOnly = (Longptr_t) obj;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -997,7 +997,7 @@ void TObject::SetDtorOnly(void *obj)
 
 void TObject::operator delete(void *ptr)
 {
-   if ((Long_t) ptr != fgDtorOnly)
+   if ((Longptr_t) ptr != fgDtorOnly)
       TStorage::ObjectDealloc(ptr);
    else
       fgDtorOnly = 0;
@@ -1008,7 +1008,7 @@ void TObject::operator delete(void *ptr)
 
 void TObject::operator delete[](void *ptr)
 {
-   if ((Long_t) ptr != fgDtorOnly)
+   if ((Longptr_t) ptr != fgDtorOnly)
       TStorage::ObjectDealloc(ptr);
    else
       fgDtorOnly = 0;
@@ -1020,7 +1020,7 @@ void TObject::operator delete[](void *ptr)
 
 void TObject::operator delete(void *ptr, size_t size)
 {
-   if ((Long_t) ptr != fgDtorOnly)
+   if ((Longptr_t) ptr != fgDtorOnly)
       TStorage::ObjectDealloc(ptr, size);
    else
       fgDtorOnly = 0;
@@ -1031,7 +1031,7 @@ void TObject::operator delete(void *ptr, size_t size)
 
 void TObject::operator delete[](void *ptr, size_t size)
 {
-   if ((Long_t) ptr != fgDtorOnly)
+   if ((Longptr_t) ptr != fgDtorOnly)
       TStorage::ObjectDealloc(ptr, size);
    else
       fgDtorOnly = 0;

--- a/core/base/src/TPluginManager.cxx
+++ b/core/base/src/TPluginManager.cxx
@@ -412,7 +412,7 @@ void TPluginManager::LoadHandlerMacros(const char *path)
       while ((s = (TObjString*)next())) {
          if (gDebug > 1)
             Info("LoadHandlerMacros", "   plugin macro: %s", s->String().Data());
-         Long_t res;
+         Longptr_t res;
          if ((res = gROOT->Macro(s->String(), 0, kFALSE)) < 0) {
             Error("LoadHandlerMacros", "pluging macro %s returned %ld",
                   s->String().Data(), res);

--- a/core/base/src/TQConnection.cxx
+++ b/core/base/src/TQConnection.cxx
@@ -48,7 +48,7 @@ protected:
    CallFunc_t    *fFunc;      // CINT method invocation environment
    ClassInfo_t   *fClass;     // CINT class for fFunc
    TFunction     *fMethod;    // slot method or global function
-   Long_t         fOffset;    // offset added to object pointer
+   Longptr_t      fOffset;    // offset added to object pointer
    TString        fName;      // full name of method
    Int_t          fExecuting; // true if one of this slot's ExecuteMethod methods is being called
 public:
@@ -57,7 +57,7 @@ public:
    virtual ~TQSlot();
 
    Bool_t      CheckSlot(Int_t nargs) const;
-   Long_t      GetOffset() const { return fOffset; }
+   Longptr_t   GetOffset() const { return fOffset; }
    CallFunc_t *StartExecuting();
    CallFunc_t *GetFunc() const { return fFunc; }
    void        EndExecuting();
@@ -74,7 +74,7 @@ public:
    void ExecuteMethod(void *object, Long64_t param);
    void ExecuteMethod(void *object, Double_t param);
    void ExecuteMethod(void *object, const char *params);
-   void ExecuteMethod(void *object, Long_t *paramArr, Int_t nparam = -1);
+   void ExecuteMethod(void *object, Longptr_t *paramArr, Int_t nparam = -1);
    void Print(Option_t *opt = "") const;
    void ls(Option_t *opt = "") const {
       Print(opt);
@@ -249,7 +249,7 @@ TQSlot::~TQSlot()
 
 inline void TQSlot::ExecuteMethod(void *object)
 {
-   ExecuteMethod(object, (Long_t*)nullptr, 0);
+   ExecuteMethod(object, (Longptr_t*)nullptr, 0);
 
 }
 
@@ -300,8 +300,7 @@ void TQSlot::EndExecuting() {
 
 inline void TQSlot::ExecuteMethod(void *object, Long_t param)
 {
-   ExecuteMethod(object, &param, 1);
-
+   ExecuteMethod(object, (Longptr_t *)&param, 1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -310,9 +309,8 @@ inline void TQSlot::ExecuteMethod(void *object, Long_t param)
 
 inline void TQSlot::ExecuteMethod(void *object, Long64_t param)
 {
-   Long_t *arg = reinterpret_cast<Long_t *>(&param);
+   Longptr_t *arg = reinterpret_cast<Longptr_t *>(&param);
    ExecuteMethod(object, arg, 1);
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -321,9 +319,8 @@ inline void TQSlot::ExecuteMethod(void *object, Long64_t param)
 
 inline void TQSlot::ExecuteMethod(void *object, Double_t param)
 {
-   Long_t *arg = reinterpret_cast<Long_t *>(&param);
+   Longptr_t *arg = reinterpret_cast<Longptr_t *>(&param);
    ExecuteMethod(object, arg, 1);
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -331,9 +328,8 @@ inline void TQSlot::ExecuteMethod(void *object, Double_t param)
 
 inline void TQSlot::ExecuteMethod(void *object, const char *param)
 {
-   Long_t arg = reinterpret_cast<Long_t>(param);
+   Longptr_t arg = reinterpret_cast<Longptr_t>(param);
    ExecuteMethod(object, &arg, 1);
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -345,12 +341,12 @@ inline void TQSlot::ExecuteMethod(void *object, const char *param)
 /// Nargs is the number of all arguments and NargsOpt is the number
 /// of default arguments.
 
-inline void TQSlot::ExecuteMethod(void *object, Long_t *paramArr, Int_t nparam)
+inline void TQSlot::ExecuteMethod(void *object, Longptr_t *paramArr, Int_t nparam)
 {
    void *address = 0;
    R__LOCKGUARD(gInterpreterMutex);
    if (paramArr) gCling->CallFunc_SetArgArray(fFunc, paramArr, nparam);
-   if (object) address = (void *)((Long_t)object + fOffset);
+   if (object) address = (void *)((Longptr_t)object + fOffset);
    fExecuting++;
    gCling->CallFunc_Exec(fFunc, address);
    fExecuting--;
@@ -445,13 +441,13 @@ void TQSlotPool::Free(TQSlot *slot)
 
 static TQSlotPool gSlotPool;  // global pool of slots
 
-void TQConnection::SetArg(const Long_t *params, Int_t nparam/* = -1*/) {
+void TQConnection::SetArg(const Longptr_t *params, Int_t nparam/* = -1*/) {
    if (nparam == -1)
       nparam = fSlot->GetMethodNargs();
 
    // FIXME: Why TInterpreter needs non-const SetArgArray. TClingCallFunc
    // doesn't modify the value.
-   gInterpreter->CallFunc_SetArgArray(fSlot->GetFunc(), const_cast<Long_t*>(params), nparam);
+   gInterpreter->CallFunc_SetArgArray(fSlot->GetFunc(), const_cast<Longptr_t*>(params), nparam);
 }
 
 
@@ -621,7 +617,7 @@ void TQConnection::ExecuteMethod(Double_t param)
 /// Apply slot-method to the fReceiver object with variable
 /// number of argument values.
 
-void TQConnection::ExecuteMethod(Long_t *params, Int_t nparam)
+void TQConnection::ExecuteMethod(Longptr_t *params, Int_t nparam)
 {
    // This connection might be deleted in result of the method execution
    // (for example in case of a Disconnect).  Hence we do not assume
@@ -657,7 +653,7 @@ Bool_t TQConnection::CheckSlot(Int_t nargs) const {
 /// Return the object address to be passed to the function.
 
 void *TQConnection::GetSlotAddress() const {
-   if (fReceiver) return (void *)((Long_t)fReceiver + fSlot->GetOffset());
+   if (fReceiver) return (void *)((Longptr_t)fReceiver + fSlot->GetOffset());
    else return nullptr;
 }
 

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1136,7 +1136,7 @@ void TROOT::CloseFiles()
          fSockets->SetBit(kMustCleanup);
       }
       CallFunc_t *socketCloser = gInterpreter->CallFunc_Factory();
-      Long_t offset = 0;
+      Longptr_t offset = 0;
       TClass *socketClass = TClass::GetClass("TSocket");
       gInterpreter->CallFunc_SetFuncProto(socketCloser, socketClass->GetClassInfo(), "Close", "", &offset);
       if (gInterpreter->CallFunc_IsValid(socketCloser)) {
@@ -1162,7 +1162,7 @@ void TROOT::CloseFiles()
                fClosedObjects->AddLast(socket);
             } else {
                // Crap ... this is not a socket, likely Proof or something, let's try to find a Close
-               Long_t other_offset;
+               Longptr_t other_offset;
                CallFunc_t *otherCloser = gInterpreter->CallFunc_Factory();
                gInterpreter->CallFunc_SetFuncProto(otherCloser, socket->IsA()->GetClassInfo(), "Close", "", &other_offset);
                if (gInterpreter->CallFunc_IsValid(otherCloser)) {
@@ -1579,7 +1579,7 @@ TGlobal *TROOT::GetGlobal(const char *name, Bool_t load) const
 
 TGlobal *TROOT::GetGlobal(const TObject *addr, Bool_t /* load */) const
 {
-   if (addr == 0 || ((Long_t)addr) == -1) return 0;
+   if (addr == 0 || ((Longptr_t)addr) == -1) return 0;
 
    TInterpreter::DeclId_t decl = gInterpreter->GetDataMemberAtAddr(addr);
    if (decl) {
@@ -2263,9 +2263,9 @@ Int_t TROOT::LoadMacro(const char *filename, int *error, Bool_t check)
 /// If padUpdate is true (default) update the current pad.
 /// Returns the macro return value.
 
-Long_t TROOT::Macro(const char *filename, Int_t *error, Bool_t padUpdate)
+Longptr_t TROOT::Macro(const char *filename, Int_t *error, Bool_t padUpdate)
 {
-   Long_t result = 0;
+   Longptr_t result = 0;
 
    if (fInterpreter) {
       TString aclicMode;
@@ -2315,9 +2315,9 @@ void  TROOT::Message(Int_t id, const TObject *obj)
 /// The possible error codes are defined by TInterpreter::EErrorCode. In
 /// particular, error will equal to TInterpreter::kProcessing until the
 /// CINT interpreted thread has finished executing the line.
-/// Returns the result of the command, cast to a Long_t.
+/// Returns the result of the command, cast to a Longptr_t.
 
-Long_t TROOT::ProcessLine(const char *line, Int_t *error)
+Longptr_t TROOT::ProcessLine(const char *line, Int_t *error)
 {
    TString sline = line;
    sline = sline.Strip(TString::kBoth);
@@ -2335,9 +2335,9 @@ Long_t TROOT::ProcessLine(const char *line, Int_t *error)
 /// the line). On non-Win32 platforms there is no difference between
 /// ProcessLine() and ProcessLineSync().
 /// The possible error codes are defined by TInterpreter::EErrorCode.
-/// Returns the result of the command, cast to a Long_t.
+/// Returns the result of the command, cast to a Longptr_t.
 
-Long_t TROOT::ProcessLineSync(const char *line, Int_t *error)
+Longptr_t TROOT::ProcessLineSync(const char *line, Int_t *error)
 {
    TString sline = line;
    sline = sline.Strip(TString::kBoth);
@@ -2354,7 +2354,7 @@ Long_t TROOT::ProcessLineSync(const char *line, Int_t *error)
 /// In all other cases use TROOT::ProcessLine().
 /// The possible error codes are defined by TInterpreter::EErrorCode.
 
-Long_t TROOT::ProcessLineFast(const char *line, Int_t *error)
+Longptr_t TROOT::ProcessLineFast(const char *line, Int_t *error)
 {
    TString sline = line;
    sline = sline.Strip(TString::kBoth);
@@ -2362,7 +2362,7 @@ Long_t TROOT::ProcessLineFast(const char *line, Int_t *error)
    if (!fApplication.load())
       TApplication::CreateApplication();
 
-   Long_t result = 0;
+   Longptr_t result = 0;
 
    if (fInterpreter) {
       TInterpreter::EErrorCode *code = (TInterpreter::EErrorCode*)error;

--- a/core/foundation/inc/RtypesCore.h
+++ b/core/foundation/inc/RtypesCore.h
@@ -69,8 +69,13 @@ typedef float          Real_t;      //TVector and TMatrix element type (float)
 #if defined(R__WIN32) && !defined(__CINT__)
 typedef __int64          Long64_t;  //Portable signed long integer 8 bytes
 typedef unsigned __int64 ULong64_t; //Portable unsigned long integer 8 bytes
-typedef intptr_t       Longptr_t;   //Integer large enough to hold a pointer
-typedef uintptr_t      ULongptr_t;  //Unsigned integer large enough to hold a pointer
+#ifdef _WIN64
+typedef long long      Longptr_t;   //Integer large enough to hold a pointer
+typedef unsigned long long ULongptr_t;  //Unsigned integer large enough to hold a pointer
+#else
+typedef long           Longptr_t;   //Integer large enough to hold a pointer
+typedef unsigned long  ULongptr_t;  //Unsigned integer large enough to hold a pointer
+#endif
 #else
 typedef long long          Long64_t; //Portable signed long integer 8 bytes
 typedef unsigned long long ULong64_t;//Portable unsigned long integer 8 bytes

--- a/core/gui/inc/TToggle.h
+++ b/core/gui/inc/TToggle.h
@@ -50,7 +50,7 @@ private:
    Bool_t       fState;        //Object's state - "a local copy"
    Long_t       fOnValue;      //Value recognized as switched ON (Def=1)
    Long_t       fOffValue;     //Value recognized as switched OFF(Def=0)
-   Long_t       fValue;        //Local copy of a value returned by called function
+   Longptr_t    fValue;        //Local copy of a value returned by called function
 
 protected:
    Bool_t       fInitialized;  //True if either SetToggledObject or SetToggledVariable called - enables Toggle() method.

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -269,7 +269,7 @@ private:
    }
    mutable std::atomic<UChar_t> fRuntimeProperties;    //! Properties that can only be evaluated at run-time
 
-   mutable Long_t     fOffsetStreamer;  //!saved info to call Streamer
+   mutable Longptr_t  fOffsetStreamer;  //!saved info to call Streamer
    Int_t              fStreamerType;    //!cached of the streaming method to use
    EState             fState;           //!Current 'state' of the class (Emulated,Interpreted,Loaded)
    mutable std::atomic<TVirtualStreamerInfo*>  fCurrentInfo;     //!cached current streamer info.
@@ -286,7 +286,7 @@ private:
 
    Bool_t             CanSplitBaseAllow();
    TListOfFunctions  *GetMethodList();
-   TMethod           *GetClassMethod(Long_t faddr);
+   TMethod           *GetClassMethod(Longptr_t faddr);
    TMethod           *FindClassOrBaseMethodWithId(DeclId_t faddr);
    Int_t              GetBaseClassOffsetRecurse(const TClass *toBase);
    void Init(const char *name, Version_t cversion, const std::type_info *info,
@@ -384,7 +384,7 @@ public:
    void               AdoptSchemaRules( ROOT::Detail::TSchemaRuleSet *rules );
    virtual void       Browse(TBrowser *b);
    void               BuildRealData(void *pointer=0, Bool_t isTransient = kFALSE);
-   void               BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl, Bool_t isTransient = kFALSE);
+   void               BuildEmulatedRealData(const char *name, Longptr_t offset, TClass *cl, Bool_t isTransient = kFALSE);
    void               CalculateStreamerOffset() const;
    Bool_t             CallShowMembers(const void* obj, TMemberInspector &insp, Bool_t isTransient = kFALSE) const;
    Bool_t             CanSplit() const;
@@ -421,7 +421,7 @@ public:
    }
    Int_t              GetClassSize() const { return Size(); }
    TDataMember       *GetDataMember(const char *datamember) const;
-   Long_t             GetDataMemberOffset(const char *membername) const;
+   Longptr_t          GetDataMemberOffset(const char *membername) const;
    const char        *GetDeclFileName() const;
    Short_t            GetDeclFileLine() const { return fDeclFileLine; }
    ROOT::DelFunc_t    GetDelete() const;

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -177,8 +177,8 @@ public:
    virtual Int_t    ReloadAllSharedLibraryMaps() = 0;
    virtual Int_t    UnloadAllSharedLibraryMaps() = 0;
    virtual Int_t    UnloadLibraryMap(const char *library) = 0;
-   virtual Long_t   ProcessLine(const char *line, EErrorCode *error = 0) = 0;
-   virtual Long_t   ProcessLineSynch(const char *line, EErrorCode *error = 0) = 0;
+   virtual Longptr_t ProcessLine(const char *line, EErrorCode *error = 0) = 0;
+   virtual Longptr_t ProcessLineSynch(const char *line, EErrorCode *error = 0) = 0;
    virtual void     PrintIntro() = 0;
    virtual bool     RegisterPrebuiltModulePath(const std::string& FullPath,
                                                const std::string& ModuleMapName = "module.modulemap") const = 0;
@@ -235,7 +235,7 @@ public:
    virtual void     Execute(TObject *obj, TClass *cl, const char *method, const char *params, int *error = 0) = 0;
    virtual void     Execute(TObject *obj, TClass *cl, TMethod *method, TObjArray *params, int *error = 0) = 0;
    virtual void     ExecuteWithArgsAndReturn(TMethod *method, void* address, const void* args[] = 0, int /*nargs*/ = 0, void* ret= 0) const = 0;
-   virtual Long_t   ExecuteMacro(const char *filename, EErrorCode *error = 0) = 0;
+   virtual Longptr_t ExecuteMacro(const char *filename, EErrorCode *error = 0) = 0;
    virtual Bool_t   IsErrorMessagesEnabled() const = 0;
    virtual Bool_t   SetErrorMessages(Bool_t enable = kTRUE) = 0;
    virtual Bool_t   IsProcessLineLocked() const = 0;
@@ -316,7 +316,7 @@ public:
    virtual void   CallFunc_Exec(CallFunc_t * /* func */, void * /* address */, TInterpreterValue& /* val */) const {;}
    virtual void   CallFunc_ExecWithReturn(CallFunc_t * /* func */, void * /* address */, void * /* ret */) const {;}
    virtual void   CallFunc_ExecWithArgsAndReturn(CallFunc_t * /* func */, void * /* address */, const void* /* args */ [] = 0, int /*nargs*/ = 0, void * /* ret */ = 0) const {}
-   virtual Long_t    CallFunc_ExecInt(CallFunc_t * /* func */, void * /* address */) const {return 0;}
+   virtual Longptr_t CallFunc_ExecInt(CallFunc_t * /* func */, void * /* address */) const {return 0;}
    virtual Long64_t  CallFunc_ExecInt64(CallFunc_t * /* func */, void * /* address */) const {return 0;}
    virtual Double_t  CallFunc_ExecDouble(CallFunc_t * /* func */, void * /* address */) const {return 0;}
    virtual CallFunc_t   *CallFunc_Factory() const {return 0;}
@@ -327,7 +327,7 @@ public:
    virtual Bool_t CallFunc_IsValid(CallFunc_t * /* func */) const {return 0;}
    virtual CallFuncIFacePtr_t CallFunc_IFacePtr(CallFunc_t * /* func */) const {return CallFuncIFacePtr_t();}
    virtual void   CallFunc_ResetArg(CallFunc_t * /* func */) const {;}
-   virtual void   CallFunc_SetArgArray(CallFunc_t * /* func */, Long_t * /* paramArr */, Int_t /* nparam */) const {;}
+   virtual void   CallFunc_SetArgArray(CallFunc_t * /* func */, Longptr_t * /* paramArr */, Int_t /* nparam */) const {;}
    virtual void   CallFunc_SetArgs(CallFunc_t * /* func */, const char * /* param */) const {;}
 
    virtual void   CallFunc_SetArg(CallFunc_t * /*func */, Long_t /* param */) const = 0;
@@ -337,26 +337,26 @@ public:
    virtual void   CallFunc_SetArg(CallFunc_t * /* func */, Long64_t /* param */) const = 0;
    virtual void   CallFunc_SetArg(CallFunc_t * /* func */, ULong64_t /* param */) const = 0;
 
-   void CallFunc_SetArg(CallFunc_t * func, Char_t param) const { CallFunc_SetArg(func,(Long_t)param); }
-   void CallFunc_SetArg(CallFunc_t * func, Short_t param) const { CallFunc_SetArg(func,(Long_t)param); }
-   void CallFunc_SetArg(CallFunc_t * func, Int_t param) const { CallFunc_SetArg(func,(Long_t)param); }
+   void CallFunc_SetArg(CallFunc_t * func, Char_t param) const { CallFunc_SetArg(func,(Longptr_t)param); }
+   void CallFunc_SetArg(CallFunc_t * func, Short_t param) const { CallFunc_SetArg(func,(Longptr_t)param); }
+   void CallFunc_SetArg(CallFunc_t * func, Int_t param) const { CallFunc_SetArg(func,(Longptr_t)param); }
 
-   void CallFunc_SetArg(CallFunc_t * func, UChar_t param) const { CallFunc_SetArg(func,(ULong_t)param); }
-   void CallFunc_SetArg(CallFunc_t * func, UShort_t param) const { CallFunc_SetArg(func,(ULong_t)param); }
-   void CallFunc_SetArg(CallFunc_t * func, UInt_t param) const { CallFunc_SetArg(func,(ULong_t)param); }
+   void CallFunc_SetArg(CallFunc_t * func, UChar_t param) const { CallFunc_SetArg(func,(ULongptr_t)param); }
+   void CallFunc_SetArg(CallFunc_t * func, UShort_t param) const { CallFunc_SetArg(func,(ULongptr_t)param); }
+   void CallFunc_SetArg(CallFunc_t * func, UInt_t param) const { CallFunc_SetArg(func,(ULongptr_t)param); }
 
    template <typename T>
-   void CallFunc_SetArgRef(CallFunc_t * func, T &param) const { CallFunc_SetArg(func,(ULong_t)&param); }
+   void CallFunc_SetArgRef(CallFunc_t * func, T &param) const { CallFunc_SetArg(func,(ULongptr_t)&param); }
 
    void CallFunc_SetArg(CallFunc_t *func, void *arg)
    {
-      CallFunc_SetArg(func,(Long_t) arg);
+      CallFunc_SetArg(func,(Longptr_t) arg);
    }
 
    template <typename T>
    void CallFunc_SetArg(CallFunc_t *func, const T *arg)
    {
-      CallFunc_SetArg(func,(Long_t) arg);
+      CallFunc_SetArg(func,(Longptr_t) arg);
    }
 
    void CallFunc_SetArgImpl(CallFunc_t * /* func */)
@@ -385,13 +385,13 @@ public:
       CallFunc_SetArgImpl(func,args...);
    }
 
-   virtual void   CallFunc_SetFunc(CallFunc_t * /* func */, ClassInfo_t * /* info */, const char * /* method */, const char * /* params */, bool /* objectIsConst */, Long_t * /* Offset */) const {;}
-   virtual void   CallFunc_SetFunc(CallFunc_t * /* func */, ClassInfo_t * /* info */, const char * /* method */, const char * /* params */, Long_t * /* Offset */) const {;}
+   virtual void   CallFunc_SetFunc(CallFunc_t * /* func */, ClassInfo_t * /* info */, const char * /* method */, const char * /* params */, bool /* objectIsConst */, Longptr_t * /* Offset */) const {;}
+   virtual void   CallFunc_SetFunc(CallFunc_t * /* func */, ClassInfo_t * /* info */, const char * /* method */, const char * /* params */, Longptr_t * /* Offset */) const {;}
    virtual void   CallFunc_SetFunc(CallFunc_t * /* func */, MethodInfo_t * /* info */) const {;}
-   virtual void   CallFunc_SetFuncProto(CallFunc_t * /* func */, ClassInfo_t * /* info */, const char * /* method */, const char * /* proto */, Long_t * /* Offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {;}
-   virtual void   CallFunc_SetFuncProto(CallFunc_t * /* func */, ClassInfo_t * /* info */, const char * /* method */, const char * /* proto */, bool /* objectIsConst */, Long_t * /* Offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {;}
-   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, Long_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const = 0;
-   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, bool objectIsConst, Long_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const = 0;
+   virtual void   CallFunc_SetFuncProto(CallFunc_t * /* func */, ClassInfo_t * /* info */, const char * /* method */, const char * /* proto */, Longptr_t * /* Offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {;}
+   virtual void   CallFunc_SetFuncProto(CallFunc_t * /* func */, ClassInfo_t * /* info */, const char * /* method */, const char * /* proto */, bool /* objectIsConst */, Longptr_t * /* Offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {;}
+   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, Longptr_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const = 0;
+   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, bool objectIsConst, Longptr_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const = 0;
 
    virtual std::string CallFunc_GetWrapperCode(CallFunc_t *func) const = 0;
 
@@ -406,7 +406,7 @@ public:
    virtual ClassInfo_t  *ClassInfo_Factory(ClassInfo_t * /* cl */) const = 0;
    virtual ClassInfo_t  *ClassInfo_Factory(const char * /* name */) const = 0;
    virtual ClassInfo_t  *ClassInfo_Factory(DeclId_t declid) const = 0;
-   virtual Long_t   ClassInfo_GetBaseOffset(ClassInfo_t* /* fromDerived */,
+   virtual Longptr_t ClassInfo_GetBaseOffset(ClassInfo_t* /* fromDerived */,
                                             ClassInfo_t* /* toBase */, void* /* address */ = 0, bool /*isderived*/ = true) const {return 0;}
    virtual int    ClassInfo_GetMethodNArg(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Bool_t /* objectIsConst */ = false, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
    virtual Bool_t ClassInfo_HasDefaultConstructor(ClassInfo_t * /* info */, Bool_t = kFALSE) const {return kFALSE;}
@@ -419,8 +419,8 @@ public:
    virtual EDataType ClassInfo_GetUnderlyingType(ClassInfo_t * /* info */) const {return kNumDataTypes;}
    virtual Bool_t ClassInfo_IsLoaded(ClassInfo_t * /* info */) const {return 0;}
    virtual Bool_t ClassInfo_IsValid(ClassInfo_t * /* info */) const {return 0;}
-   virtual Bool_t ClassInfo_IsValidMethod(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Long_t * /* offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
-   virtual Bool_t ClassInfo_IsValidMethod(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Bool_t /* objectIsConst */, Long_t * /* offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
+   virtual Bool_t ClassInfo_IsValidMethod(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Longptr_t * /* offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
+   virtual Bool_t ClassInfo_IsValidMethod(ClassInfo_t * /* info */, const char * /* method */,const char * /* proto */, Bool_t /* objectIsConst */, Longptr_t * /* offset */, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const {return 0;}
    virtual int    ClassInfo_Next(ClassInfo_t * /* info */) const {return 0;}
    virtual void  *ClassInfo_New(ClassInfo_t * /* info */) const {return 0;}
    virtual void  *ClassInfo_New(ClassInfo_t * /* info */, int /* n */) const {return 0;}
@@ -428,7 +428,7 @@ public:
    virtual void  *ClassInfo_New(ClassInfo_t * /* info */, void * /* arena */) const {return 0;}
    virtual Long_t ClassInfo_Property(ClassInfo_t * /* info */) const {return 0;}
    virtual int    ClassInfo_Size(ClassInfo_t * /* info */) const {return 0;}
-   virtual Long_t ClassInfo_Tagnum(ClassInfo_t * /* info */) const {return 0;}
+   virtual Longptr_t ClassInfo_Tagnum(ClassInfo_t * /* info */) const {return 0;}
    virtual const char *ClassInfo_FileName(ClassInfo_t * /* info */) const {return 0;}
    virtual const char *ClassInfo_FullName(ClassInfo_t * /* info */) const {return 0;}
    virtual const char *ClassInfo_Name(ClassInfo_t * /* info */) const {return 0;}
@@ -443,9 +443,9 @@ public:
                                                    ClassInfo_t* /* base */) const {return 0;}
    virtual int    BaseClassInfo_Next(BaseClassInfo_t * /* bcinfo */) const {return 0;}
    virtual int    BaseClassInfo_Next(BaseClassInfo_t * /* bcinfo */, int  /* onlyDirect */) const {return 0;}
-   virtual Long_t BaseClassInfo_Offset(BaseClassInfo_t * /* toBaseClassInfo */, void* /* address */ = 0 /*default for non-virtual*/, bool /*isderived*/ = true /*default for non-virtual*/) const {return 0;}
+   virtual Longptr_t BaseClassInfo_Offset(BaseClassInfo_t * /* toBaseClassInfo */, void* /* address */ = 0 /*default for non-virtual*/, bool /*isderived*/ = true /*default for non-virtual*/) const {return 0;}
    virtual Long_t BaseClassInfo_Property(BaseClassInfo_t * /* bcinfo */) const {return 0;}
-   virtual Long_t BaseClassInfo_Tagnum(BaseClassInfo_t * /* bcinfo */) const {return 0;}
+   virtual Longptr_t BaseClassInfo_Tagnum(BaseClassInfo_t * /* bcinfo */) const {return 0;}
    virtual ClassInfo_t*BaseClassInfo_ClassInfo(BaseClassInfo_t * /* bcinfo */) const = 0;
    virtual const char *BaseClassInfo_FullName(BaseClassInfo_t * /* bcinfo */) const {return 0;}
    virtual const char *BaseClassInfo_Name(BaseClassInfo_t * /* bcinfo */) const {return 0;}
@@ -460,7 +460,7 @@ public:
    virtual Bool_t DataMemberInfo_IsValid(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual int    DataMemberInfo_MaxIndex(DataMemberInfo_t * /* dminfo */, Int_t  /* dim */) const {return 0;}
    virtual int    DataMemberInfo_Next(DataMemberInfo_t * /* dminfo */) const {return 0;}
-   virtual Long_t DataMemberInfo_Offset(DataMemberInfo_t * /* dminfo */) const {return 0;}
+   virtual Longptr_t DataMemberInfo_Offset(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual Long_t DataMemberInfo_Property(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual Long_t DataMemberInfo_TypeProperty(DataMemberInfo_t * /* dminfo */) const {return 0;}
    virtual int    DataMemberInfo_TypeSize(DataMemberInfo_t * /* dminfo */) const {return 0;}

--- a/core/meta/inc/TMethodCall.h
+++ b/core/meta/inc/TMethodCall.h
@@ -52,7 +52,7 @@ public:
 
 private:
    CallFunc_t    *fFunc;      //CINT method invocation environment
-   Long_t         fOffset;    //offset added to object pointer before method invocation
+   Longptr_t      fOffset;    //offset added to object pointer before method invocation
    TClass        *fClass;     //pointer to the class info
    TFunction     *fMetPtr;    //pointer to the method or function info
    TString        fMethod;    //method name
@@ -68,7 +68,7 @@ private:
 
 public:
    TMethodCall();
-   TMethodCall(TClass *cl, CallFunc_t *callfunc, Long_t offset = 0);
+   TMethodCall(TClass *cl, CallFunc_t *callfunc, Longptr_t offset = 0);
    TMethodCall(TClass *cl, const char *method, const char *params);
    TMethodCall(const char *function, const char *params);
    TMethodCall(const TFunction *func);
@@ -77,7 +77,7 @@ public:
    ~TMethodCall();
 
    void           Init(const TFunction *func);
-   void           Init(TClass *cl, CallFunc_t *func, Long_t offset = 0);
+   void           Init(TClass *cl, CallFunc_t *func, Longptr_t offset = 0);
    void           Init(TClass *cl, const char *method, const char *params, Bool_t objectIsConst = kFALSE);
    void           Init(const char *function, const char *params);
    void           InitWithPrototype(TClass *cl, const char *method, const char *proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
@@ -108,8 +108,8 @@ public:
 
    void     Execute(void *object);
    void     Execute(void *object, const char *params);
-   void     Execute(void *object, Long_t &retLong);
-   void     Execute(void *object, const char *params, Long_t &retLong);
+   void     Execute(void *object, Longptr_t &retLong);
+   void     Execute(void *object, const char *params, Longptr_t &retLong);
    void     Execute(void *object, Double_t &retDouble);
    void     Execute(void *object, const char *params, Double_t &retDouble);
 
@@ -118,8 +118,8 @@ public:
 
    void     Execute();
    void     Execute(const char *params);
-   void     Execute(Long_t &retLong);
-   void     Execute(const char *params, Long_t &retLong);
+   void     Execute(Longptr_t &retLong);
+   void     Execute(const char *params, Longptr_t &retLong);
    void     Execute(Double_t &retDouble);
    void     Execute(const char *params, Double_t &retDouble);
 
@@ -132,9 +132,9 @@ inline void TMethodCall::Execute()
    { Execute((void *)0); }
 inline void TMethodCall::Execute(const char *params)
    { Execute((void *)0, params); }
-inline void TMethodCall::Execute(Long_t &retLong)
+inline void TMethodCall::Execute(Longptr_t &retLong)
    { Execute((void *)0, retLong); }
-inline void TMethodCall::Execute(const char *params, Long_t &retLong)
+inline void TMethodCall::Execute(const char *params, Longptr_t &retLong)
    { Execute((void *)0, params, retLong); }
 inline void TMethodCall::Execute(Double_t &retDouble)
    { Execute((void *)0, retDouble); }

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -111,7 +111,7 @@ public:
    virtual const char *GetFullName() const;
    virtual const char *GetInclude() const {return "";}
    Int_t            GetMaxIndex(Int_t i) const {return fMaxIndex[i];}
-   virtual ULong_t  GetMethod() const {return ULong_t(fStreamer);}
+   virtual ULongptr_t GetMethod() const {return ULongptr_t(fStreamer);}
    TMemberStreamer *GetStreamer() const;
    virtual Int_t    GetSize() const;
    Int_t            GetNewType() const {return fNewType;}
@@ -177,7 +177,7 @@ public:
    const char      *GetErrorMessage() const { return fErrorMsg; }
    const char      *GetInclude() const;
    TClass          *GetNewBaseClass() { return fNewBaseClass; }
-   ULong_t          GetMethod() const {return 0;}
+   ULongptr_t       GetMethod() const {return 0;}
    Int_t            GetSize() const;
    TVirtualStreamerInfo *GetBaseStreamerInfo () const { return fStreamerInfo; }
    virtual void     Init(TVirtualStreamerInfo *obj=0);
@@ -218,7 +218,7 @@ public:
    const char    *GetCountClass()   const {return fCountClass.Data();}
    const char    *GetCountName()    const {return fCountName.Data();}
    Int_t          GetCountVersion() const {return fCountVersion;}
-   ULong_t        GetMethod() const;
+   ULongptr_t     GetMethod() const;
    Int_t          GetSize() const;
    virtual void   Init(TVirtualStreamerInfo *obj=0);
    virtual Bool_t HasCounter() const                {return fCounter!=0;   }
@@ -254,7 +254,7 @@ public:
    const char    *GetCountName()    const {return fCountName.Data();}
    Int_t          GetCountVersion() const {return fCountVersion;}
    const char    *GetInclude() const;
-   ULong_t        GetMethod() const;
+   ULongptr_t     GetMethod() const;
    Int_t          GetSize() const;
    virtual void   Init(TVirtualStreamerInfo *obj = nullptr);
    virtual Bool_t IsaPointer() const                {return kTRUE;         }
@@ -283,7 +283,7 @@ public:
    virtual       ~TStreamerBasicType();
    TClass        *GetClassPointer() const { return nullptr; }
    Int_t          GetCounter() const {return fCounter;}
-   ULong_t        GetMethod() const;
+   ULongptr_t     GetMethod() const;
    Int_t          GetSize() const;
    virtual void   Update(const TClass * /* oldClass */, TClass * /* newClass */) {}
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -664,7 +664,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"->0");
       else if (!isbasic) {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Long64_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%zx ", (Longptr_t)p3pointer);
          }
       } else if (membertype) {
          if (!strcmp(membertype->GetTypeName(), "char")) {
@@ -705,7 +705,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          }
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Long64_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%zx ", (Longptr_t)p3pointer);
          }
       }
    } else if (membertype) {
@@ -727,7 +727,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"%s",str->Data());
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Long64_t)pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%zx ", (Longptr_t)pointer);
          }
       }
    }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -664,7 +664,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"->0");
       else if (!isbasic) {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%p ", p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Longptr_t)p3pointer);
          }
       } else if (membertype) {
          if (!strcmp(membertype->GetTypeName(), "char")) {
@@ -705,7 +705,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          }
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%p ", p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Longptr_t)p3pointer);
          }
       }
    } else if (membertype) {
@@ -727,7 +727,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"%s",str->Data());
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%p ", pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Longptr_t)pointer);
          }
       }
    }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -664,7 +664,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"->0");
       else if (!isbasic) {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%zx ", (Longptr_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%zx ", (size_t)p3pointer);
          }
       } else if (membertype) {
          if (!strcmp(membertype->GetTypeName(), "char")) {
@@ -705,7 +705,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          }
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%zx ", (Longptr_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%zx ", (size_t)p3pointer);
          }
       }
    } else if (membertype) {
@@ -727,7 +727,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"%s",str->Data());
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%zx ", (Longptr_t)pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%zx ", (size_t)pointer);
          }
       }
    }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -664,7 +664,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"->0");
       else if (!isbasic) {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%lx ", (Longptr_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Long64_t)p3pointer);
          }
       } else if (membertype) {
          if (!strcmp(membertype->GetTypeName(), "char")) {
@@ -705,7 +705,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          }
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%lx ", (Longptr_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Long64_t)p3pointer);
          }
       }
    } else if (membertype) {
@@ -727,7 +727,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"%s",str->Data());
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%lx ", (Longptr_t)pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Long64_t)pointer);
          }
       }
    }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -664,7 +664,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"->0");
       else if (!isbasic) {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Longptr_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%lx ", (Longptr_t)p3pointer);
          }
       } else if (membertype) {
          if (!strcmp(membertype->GetTypeName(), "char")) {
@@ -705,7 +705,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          }
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Longptr_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%lx ", (Longptr_t)p3pointer);
          }
       }
    } else if (membertype) {
@@ -727,7 +727,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"%s",str->Data());
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%llx ", (Longptr_t)pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%lx ", (Longptr_t)pointer);
          }
       }
    }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -664,7 +664,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"->0");
       else if (!isbasic) {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%lx ", (Long_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%p ", p3pointer);
          }
       } else if (membertype) {
          if (!strcmp(membertype->GetTypeName(), "char")) {
@@ -705,7 +705,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          }
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%lx ", (Long_t)p3pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%p ", p3pointer);
          }
       }
    } else if (membertype) {
@@ -727,7 +727,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          snprintf(&line[kvalue],kline-kvalue,"%s",str->Data());
       } else {
          if (!fNoAddr) {
-            snprintf(&line[kvalue],kline-kvalue,"->%lx ", (Long_t)pointer);
+            snprintf(&line[kvalue],kline-kvalue,"->%p ", pointer);
          }
       }
    }
@@ -817,7 +817,7 @@ void TBuildRealData::Inspect(TClass* cl, const char* pname, const char* mname, c
       }
    }
 
-   Long_t offset = Long_t(((Long_t) add) - ((Long_t) fRealDataObject));
+   Longptr_t offset = Longptr_t(((Longptr_t) add) - ((Longptr_t) fRealDataObject));
 
    if (TClassEdit::IsStdArray(dm->GetTypeName())){ // We tackle the std array case
       TString rdName;
@@ -2087,7 +2087,7 @@ void TClass::BuildRealData(void* pointer, Bool_t isTransient)
 ////////////////////////////////////////////////////////////////////////////////
 /// Build the list of real data for an emulated class
 
-void TClass::BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl, Bool_t isTransient)
+void TClass::BuildEmulatedRealData(const char *name, Longptr_t offset, TClass *cl, Bool_t isTransient)
 {
    R__LOCKGUARD(gInterpreterMutex);
 
@@ -2108,7 +2108,7 @@ void TClass::BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl, 
    TStreamerElement *element;
    while ((element = (TStreamerElement*)next())) {
       Int_t etype    = element->GetType();
-      Long_t eoffset = element->GetOffset();
+      Longptr_t eoffset = element->GetOffset();
       TClass *cle    = element->GetClassPointer();
       if (element->IsBase() || etype == TVirtualStreamerInfo::kBase) {
          //base class are skipped in this loop, they will be added at the end.
@@ -2144,7 +2144,7 @@ void TClass::BuildEmulatedRealData(const char *name, Long_t offset, TClass *cl, 
       Int_t etype    = element->GetType();
       if (element->IsBase() || etype == TVirtualStreamerInfo::kBase) {
          //base class
-         Long_t eoffset = element->GetOffset();
+         Longptr_t eoffset = element->GetOffset();
          TClass *cle    = element->GetClassPointer();
          if (cle) cle->BuildEmulatedRealData(name,offset+eoffset,cl, isTransient);
       }
@@ -2514,12 +2514,12 @@ void TClass::Draw(Option_t *option)
 void TClass::Dump(const void *obj, Bool_t noAddr /*=kFALSE*/) const
 {
 
-   Long_t prObj = noAddr ? 0 : (Long_t)obj;
+   Longptr_t prObj = noAddr ? 0 : (Longptr_t)obj;
    if (IsTObject()) {
       if (!fIsOffsetStreamerSet) {
          CalculateStreamerOffset();
       }
-      TObject *tobj = (TObject*)((Long_t)obj + fOffsetStreamer);
+      TObject *tobj = (TObject*)((Longptr_t)obj + fOffsetStreamer);
 
 
       if (sizeof(this) == 4)
@@ -2843,12 +2843,12 @@ namespace {
             if (*thread_ptr==0) *thread_ptr = new TExMap();
             TExMap *lmap = (TExMap*)(*thread_ptr);
             ULong_t hash = TString::Hash(&cl, sizeof(void*));
-            ULong_t local = 0;
+            ULongptr_t local = 0;
             UInt_t slot;
-            if ((local = (ULong_t)lmap->GetValue(hash, (Long_t)cl, slot)) != 0) {
+            if ((local = (ULongptr_t)lmap->GetValue(hash, (Longptr_t)cl, slot)) != 0) {
             } else {
-               local = (ULong_t) new TClassLocalStorage();
-               lmap->AddAt(slot, hash, (Long_t)cl, local);
+               local = (ULongptr_t) new TClassLocalStorage();
+               lmap->AddAt(slot, hash, (Longptr_t)cl, local);
             }
             return (TClassLocalStorage*)local;
          }
@@ -3418,7 +3418,7 @@ const char *TClass::GetDeclFileName() const
 ///
 /// In case of an emulated class, the list of emulated TRealData is built
 
-Long_t TClass::GetDataMemberOffset(const char *name) const
+Longptr_t TClass::GetDataMemberOffset(const char *name) const
 {
    TRealData *rd = GetRealData(name);
    if (rd) return rd->GetThisOffset();
@@ -4464,14 +4464,14 @@ TMethod *TClass::GetMethodWithPrototype(const char *method, const char *proto,
 /// Look for a method in this class that has the interface function
 /// address faddr.
 
-TMethod *TClass::GetClassMethod(Long_t faddr)
+TMethod *TClass::GetClassMethod(Longptr_t faddr)
 {
    if (!HasInterpreterInfo()) return 0;
 
    TMethod *m;
    TIter    next(GetListOfMethods());
    while ((m = (TMethod *) next())) {
-      if (faddr == (Long_t)m->InterfaceMethod())
+      if (faddr == (Longptr_t)m->InterfaceMethod())
          return m;
    }
    return 0;
@@ -4905,9 +4905,9 @@ void *TClass::DynamicCast(const TClass *cl, void *obj, Bool_t up)
    Int_t off;
    if ((off = GetBaseClassOffset(cl, obj)) != -1) {
       if (up)
-         return (void*)((Long_t)obj+off);
+         return (void*)((Longptr_t)obj+off);
       else
-         return (void*)((Long_t)obj-off);
+         return (void*)((Longptr_t)obj-off);
    }
    return 0;
 }
@@ -6747,7 +6747,7 @@ void TClass::StreamerTObject(const TClass* pThis, void *object, TBuffer &b, cons
    if (!pThis->fIsOffsetStreamerSet) {
       pThis->CalculateStreamerOffset();
    }
-   TObject *tobj = (TObject*)((Long_t)object + pThis->fOffsetStreamer);
+   TObject *tobj = (TObject*)((Longptr_t)object + pThis->fOffsetStreamer);
    tobj->Streamer(b);
 }
 
@@ -6756,7 +6756,7 @@ void TClass::StreamerTObject(const TClass* pThis, void *object, TBuffer &b, cons
 
 void TClass::StreamerTObjectInitialized(const TClass* pThis, void *object, TBuffer &b, const TClass * /* onfile_class */)
 {
-   TObject *tobj = (TObject*)((Long_t)object + pThis->fOffsetStreamer);
+   TObject *tobj = (TObject*)((Longptr_t)object + pThis->fOffsetStreamer);
    tobj->Streamer(b);
 }
 

--- a/core/meta/src/TMethodCall.cxx
+++ b/core/meta/src/TMethodCall.cxx
@@ -43,7 +43,7 @@ fFunc(0), fOffset(0), fClass(0), fMetPtr(0), fDtorOnly(kFALSE), fRetType(kNone)
 /// Create a method invocation environment for a specific class, method
 /// described by the callfunc.
 
-TMethodCall::TMethodCall(TClass *cl, CallFunc_t *callfunc, Long_t offset):
+TMethodCall::TMethodCall(TClass *cl, CallFunc_t *callfunc, Longptr_t offset):
 fFunc(0), fOffset(0), fClass(0), fMetPtr(0), fDtorOnly(kFALSE), fRetType(kNone)
 {
    Init(cl, callfunc, offset);
@@ -179,7 +179,7 @@ static TClass *R__FindScope(const char *function, UInt_t &pos, ClassInfo_t *cinf
 /// Initialize the method invocation environment based on
 /// the CallFunc object and the TClass describing the function context.
 
-void TMethodCall::Init(TClass *cl, CallFunc_t *function, Long_t offset)
+void TMethodCall::Init(TClass *cl, CallFunc_t *function, Longptr_t offset)
 {
    if (!function) {
       fOffset = 0;
@@ -420,7 +420,7 @@ void TMethodCall::Execute(void *object)
    if (!fFunc) return;
 
    void *address = 0;
-   if (object) address = (void*)((Long_t)object + fOffset);
+   if (object) address = (void*)((Longptr_t)object + fOffset);
    if (!fDtorOnly && fMethod[0]=='~') {
       Error("Execute","TMethodCall can no longer be use to call the operator delete and the destructor at the same time");
    }
@@ -438,7 +438,7 @@ void TMethodCall::Execute(void *object, const char *params)
    gCling->CallFunc_SetArgs(fFunc, (char *)params);
 
    void *address = 0;
-   if (object) address = (void*)((Long_t)object + fOffset);
+   if (object) address = (void*)((Longptr_t)object + fOffset);
    gCling->SetTempLevel(1);
    gCling->CallFunc_Exec(fFunc,address);
    gCling->SetTempLevel(-1);
@@ -447,12 +447,12 @@ void TMethodCall::Execute(void *object, const char *params)
 ////////////////////////////////////////////////////////////////////////////////
 /// Execute the method (with preset arguments) for the specified object.
 
-void TMethodCall::Execute(void *object, Long_t &retLong)
+void TMethodCall::Execute(void *object, Longptr_t &retLong)
 {
    if (!fFunc) return;
 
    void *address = 0;
-   if (object) address = (void*)((Long_t)object + fOffset);
+   if (object) address = (void*)((Longptr_t)object + fOffset);
    gCling->SetTempLevel(1);
    retLong = gCling->CallFunc_ExecInt(fFunc,address);
    gCling->SetTempLevel(-1);
@@ -461,7 +461,7 @@ void TMethodCall::Execute(void *object, Long_t &retLong)
 ////////////////////////////////////////////////////////////////////////////////
 /// Execute the method for the specified object and argument values.
 
-void TMethodCall::Execute(void *object, const char *params, Long_t &retLong)
+void TMethodCall::Execute(void *object, const char *params, Longptr_t &retLong)
 {
    if (!fFunc) return;
 
@@ -469,7 +469,7 @@ void TMethodCall::Execute(void *object, const char *params, Long_t &retLong)
    gCling->CallFunc_SetArgs(fFunc, (char *)params);
 
    void *address = 0;
-   if (object) address = (void*)((Long_t)object + fOffset);
+   if (object) address = (void*)((Longptr_t)object + fOffset);
    gCling->SetTempLevel(1);
    retLong = gCling->CallFunc_ExecInt(fFunc,address);
    gCling->SetTempLevel(-1);
@@ -483,7 +483,7 @@ void TMethodCall::Execute(void *object, Double_t &retDouble)
    if (!fFunc) return;
 
    void *address = 0;
-   if (object) address = (void*)((Long_t)object + fOffset);
+   if (object) address = (void*)((Longptr_t)object + fOffset);
    gCling->SetTempLevel(1);
    retDouble = gCling->CallFunc_ExecDouble(fFunc,address);
    gCling->SetTempLevel(-1);
@@ -499,7 +499,7 @@ void TMethodCall::Execute(void *object, const char *params, Double_t &retDouble)
    gCling->CallFunc_SetArgs(fFunc, (char *)params);
 
    void *address = 0;
-   if (object) address = (void*)((Long_t)object + fOffset);
+   if (object) address = (void*)((Longptr_t)object + fOffset);
    gCling->SetTempLevel(1);
    retDouble = gCling->CallFunc_ExecDouble(fFunc,address);
    gCling->SetTempLevel(-1);
@@ -513,7 +513,7 @@ void TMethodCall::Execute(void *object, char **retText)
    if (!fFunc) return;
 
    void *address = 0;
-   if (object) address = (void*)((Long_t)object + fOffset);
+   if (object) address = (void*)((Longptr_t)object + fOffset);
    gCling->SetTempLevel(1);
    *retText =(char*) (gCling->CallFunc_ExecInt(fFunc,address));
    gCling->SetTempLevel(-1);
@@ -530,7 +530,7 @@ void TMethodCall::Execute(void *object, const char *params, char **retText)
    gCling->CallFunc_SetArgs(fFunc, (char *)params);
 
    void *address = 0;
-   if (object) address = (void*)((Long_t)object + fOffset);
+   if (object) address = (void*)((Longptr_t)object + fOffset);
    gCling->SetTempLevel(1);
    *retText =(char*)(gCling->CallFunc_ExecInt(fFunc,address));
    gCling->SetTempLevel(-1);
@@ -585,7 +585,7 @@ TMethodCall::EReturnType TMethodCall::ReturnType()
 void TMethodCall::SetParamPtrs(void *paramArr, Int_t nparam)
 {
    if (!fFunc) return;
-   gCling->CallFunc_SetArgArray(fFunc,(Long_t *)paramArr, nparam);
+   gCling->CallFunc_SetArgArray(fFunc,(Longptr_t *)paramArr, nparam);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -931,7 +931,7 @@ TStreamerBasicPointer::~TStreamerBasicPointer()
 ////////////////////////////////////////////////////////////////////////////////
 /// return offset of counter
 
-ULong_t TStreamerBasicPointer::GetMethod() const
+ULongptr_t TStreamerBasicPointer::GetMethod() const
 {
    if (!fCounter) ((TStreamerBasicPointer*)this)->Init();
    if (!fCounter) return 0;
@@ -940,7 +940,7 @@ ULong_t TStreamerBasicPointer::GetMethod() const
    // the left most (non virtual) base classes.  For the other we would
    // really need to use the object coming from the list of real data.
    // (and even that need analysis for virtual base class).
-   return (ULong_t)fCounter->GetOffset();
+   return (ULongptr_t)fCounter->GetOffset();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1040,14 +1040,14 @@ TStreamerLoop::~TStreamerLoop()
 ////////////////////////////////////////////////////////////////////////////////
 /// return address of counter
 
-ULong_t TStreamerLoop::GetMethod() const
+ULongptr_t TStreamerLoop::GetMethod() const
 {
    //if (!fCounter) {
    //   Init();
    //   if (!fCounter) return 0;
    //}
    if (!fCounter) return 0;
-   return (ULong_t)fCounter->GetOffset();
+   return (ULongptr_t)fCounter->GetOffset();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1140,10 +1140,10 @@ TStreamerBasicType::~TStreamerBasicType()
 ////////////////////////////////////////////////////////////////////////////////
 /// return address of counter
 
-ULong_t TStreamerBasicType::GetMethod() const
+ULongptr_t TStreamerBasicType::GetMethod() const
 {
    if (fType ==  TVirtualStreamerInfo::kCounter ||
-       fType == (TVirtualStreamerInfo::kCounter+TVirtualStreamerInfo::kSkip)) return (ULong_t)&fCounter;
+       fType == (TVirtualStreamerInfo::kCounter+TVirtualStreamerInfo::kSkip)) return (ULongptr_t)&fCounter;
    return 0;
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2448,7 +2448,7 @@ bool TCling::DiagnoseIfInterpreterException(const std::exception &e) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Long_t TCling::ProcessLine(const char* line, EErrorCode* error/*=0*/)
+Longptr_t TCling::ProcessLine(const char* line, EErrorCode* error/*=0*/)
 {
    // Copy the passed line, it comes from a static buffer in TApplication
    // which can be reentered through the Cling evaluation routines,
@@ -2606,7 +2606,7 @@ Long_t TCling::ProcessLine(const char* line, EErrorCode* error/*=0*/)
        && result.isValid()
        && !result.isVoid())
    {
-      return result.simplisticCastAs<long>();
+      return result.simplisticCastAs<Longptr_t>();
    }
    return 0;
 }
@@ -3475,7 +3475,7 @@ void TCling::LoadMacro(const char* filename, EErrorCode* error)
 ////////////////////////////////////////////////////////////////////////////////
 /// Let cling process a command line asynch.
 
-Long_t TCling::ProcessLineAsynch(const char* line, EErrorCode* error)
+Longptr_t TCling::ProcessLineAsynch(const char* line, EErrorCode* error)
 {
    return ProcessLine(line, error);
 }
@@ -3484,7 +3484,7 @@ Long_t TCling::ProcessLineAsynch(const char* line, EErrorCode* error)
 /// Let cling process a command line synchronously, i.e we are waiting
 /// it will be finished.
 
-Long_t TCling::ProcessLineSynch(const char* line, EErrorCode* error)
+Longptr_t TCling::ProcessLineSynch(const char* line, EErrorCode* error)
 {
    R__LOCKGUARD_CLING(fLockProcessLine ? gInterpreterMutex : 0);
    if (gApplication) {
@@ -4845,13 +4845,13 @@ TString TCling::GetMangledName(TClass* cl, const char* method,
    R__LOCKGUARD(gInterpreterMutex);
    TClingCallFunc func(GetInterpreterImpl(), *fNormalizedCtxt);
    if (cl) {
-      Long_t offset;
+      Longptr_t offset;
       func.SetFunc((TClingClassInfo*)cl->GetClassInfo(), method, params, objectIsConst,
          &offset);
    }
    else {
       TClingClassInfo gcl(GetInterpreterImpl());
-      Long_t offset;
+      Longptr_t offset;
       func.SetFunc(&gcl, method, params, &offset);
    }
    TClingMethodInfo* mi = (TClingMethodInfo*) func.FactoryMethod();
@@ -4890,13 +4890,13 @@ void* TCling::GetInterfaceMethod(TClass* cl, const char* method,
    R__LOCKGUARD(gInterpreterMutex);
    TClingCallFunc func(GetInterpreterImpl(), *fNormalizedCtxt);
    if (cl) {
-      Long_t offset;
+      Longptr_t offset;
       func.SetFunc((TClingClassInfo*)cl->GetClassInfo(), method, params, objectIsConst,
                    &offset);
    }
    else {
       TClingClassInfo gcl(GetInterpreterImpl());
-      Long_t offset;
+      Longptr_t offset;
       func.SetFunc(&gcl, method, params, &offset);
    }
    return (void*) func.InterfaceMethod();
@@ -5117,7 +5117,7 @@ void TCling::Execute(const char* function, const char* params, int* error)
       *error = TInterpreter::kNoError;
    }
    TClingClassInfo cl(GetInterpreterImpl());
-   Long_t offset = 0L;
+   Longptr_t offset = 0L;
    TClingCallFunc func(GetInterpreterImpl(), *fNormalizedCtxt);
    func.SetFunc(&cl, function, params, &offset);
    func.Exec(0);
@@ -5145,10 +5145,10 @@ void TCling::Execute(TObject* obj, TClass* cl, const char* method,
    // 'obj' is unlikely to be the start of the object (as described by IsA()),
    // hence gInterpreter->Execute will improperly correct the offset.
    void* addr = cl->DynamicCast(TObject::Class(), obj, kFALSE);
-   Long_t offset = 0L;
+   Longptr_t offset = 0L;
    TClingCallFunc func(GetInterpreterImpl(), *fNormalizedCtxt);
    func.SetFunc((TClingClassInfo*)cl->GetClassInfo(), method, params, objectIsConst, &offset);
-   void* address = (void*)((Long_t)addr + offset);
+   void* address = (void*)((Longptr_t)addr + offset);
    func.Exec(address);
 }
 
@@ -5255,8 +5255,8 @@ void TCling::Execute(TObject* obj, TClass* cl, TMethod* method,
    // Now calculate the 'this' pointer offset for the method
    // when starting from the class described by cl.
    const CXXMethodDecl * mdecl = dyn_cast<CXXMethodDecl>(minfo->GetTargetFunctionDecl());
-   Long_t offset = ((TClingClassInfo*)cl->GetClassInfo())->GetOffset(mdecl);
-   void* address = (void*)((Long_t)addr + offset);
+   Longptr_t offset = ((TClingClassInfo*)cl->GetClassInfo())->GetOffset(mdecl);
+   void* address = (void*)((Longptr_t)addr + offset);
    func.Exec(address);
 }
 
@@ -5280,11 +5280,11 @@ void TCling::ExecuteWithArgsAndReturn(TMethod* method, void* address,
 ////////////////////////////////////////////////////////////////////////////////
 /// Execute a cling macro.
 
-Long_t TCling::ExecuteMacro(const char* filename, EErrorCode* error)
+Longptr_t TCling::ExecuteMacro(const char* filename, EErrorCode* error)
 {
    R__LOCKGUARD_CLING(fLockProcessLine ? gInterpreterMutex : 0);
    fCurExecutingMacros.push_back(filename);
-   Long_t result = TApplication::ExecuteFile(filename, (int*)error);
+   Longptr_t result = TApplication::ExecuteFile(filename, (int*)error);
    fCurExecutingMacros.pop_back();
    return result;
 }
@@ -7815,7 +7815,7 @@ void TCling::CallFunc_ExecWithArgsAndReturn(CallFunc_t* func, void* address,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Long_t TCling::CallFunc_ExecInt(CallFunc_t* func, void* address) const
+Longptr_t TCling::CallFunc_ExecInt(CallFunc_t* func, void* address) const
 {
    TClingCallFunc* f = (TClingCallFunc*) func;
    return f->ExecInt(address);
@@ -7952,7 +7952,7 @@ void TCling::CallFunc_SetArg(CallFunc_t* func, ULong64_t param) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TCling::CallFunc_SetArgArray(CallFunc_t* func, Long_t* paramArr, Int_t nparam) const
+void TCling::CallFunc_SetArgArray(CallFunc_t* func, Longptr_t* paramArr, Int_t nparam) const
 {
    TClingCallFunc* f = (TClingCallFunc*) func;
    f->SetArgArray(paramArr, nparam);
@@ -7968,7 +7968,7 @@ void TCling::CallFunc_SetArgs(CallFunc_t* func, const char* param) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TCling::CallFunc_SetFunc(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* params, Long_t* offset) const
+void TCling::CallFunc_SetFunc(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* params, Longptr_t* offset) const
 {
    TClingCallFunc* f = (TClingCallFunc*) func;
    TClingClassInfo* ci = (TClingClassInfo*) info;
@@ -7977,7 +7977,7 @@ void TCling::CallFunc_SetFunc(CallFunc_t* func, ClassInfo_t* info, const char* m
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TCling::CallFunc_SetFunc(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* params, bool objectIsConst, Long_t* offset) const
+void TCling::CallFunc_SetFunc(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* params, bool objectIsConst, Longptr_t* offset) const
 {
    TClingCallFunc* f = (TClingCallFunc*) func;
    TClingClassInfo* ci = (TClingClassInfo*) info;
@@ -7995,7 +7995,7 @@ void TCling::CallFunc_SetFunc(CallFunc_t* func, MethodInfo_t* info) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Interface to cling function
 
-void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* proto, Long_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
+void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* proto, Longptr_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
 {
    TClingCallFunc* f = (TClingCallFunc*) func;
    TClingClassInfo* ci = (TClingClassInfo*) info;
@@ -8005,7 +8005,7 @@ void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const ch
 ////////////////////////////////////////////////////////////////////////////////
 /// Interface to cling function
 
-void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* proto, bool objectIsConst, Long_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
+void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* proto, bool objectIsConst, Longptr_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
 {
    TClingCallFunc* f = (TClingCallFunc*) func;
    TClingClassInfo* ci = (TClingClassInfo*) info;
@@ -8015,7 +8015,7 @@ void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const ch
 ////////////////////////////////////////////////////////////////////////////////
 /// Interface to cling function
 
-void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, Long_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
+void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, Longptr_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
 {
    TClingCallFunc* f = (TClingCallFunc*) func;
    TClingClassInfo* ci = (TClingClassInfo*) info;
@@ -8030,7 +8030,7 @@ void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const ch
 ////////////////////////////////////////////////////////////////////////////////
 /// Interface to cling function
 
-void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, bool objectIsConst, Long_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
+void TCling::CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, bool objectIsConst, Longptr_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
 {
    TClingCallFunc* f = (TClingCallFunc*) func;
    TClingClassInfo* ci = (TClingClassInfo*) info;
@@ -8266,7 +8266,7 @@ bool TCling::ClassInfo_IsValid(ClassInfo_t* cinfo) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TCling::ClassInfo_IsValidMethod(ClassInfo_t* cinfo, const char* method, const char* proto, Long_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
+bool TCling::ClassInfo_IsValidMethod(ClassInfo_t* cinfo, const char* method, const char* proto, Longptr_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
 {
    TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
    return TClinginfo->IsValidMethod(method, proto, false, offset, mode);
@@ -8274,7 +8274,7 @@ bool TCling::ClassInfo_IsValidMethod(ClassInfo_t* cinfo, const char* method, con
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool TCling::ClassInfo_IsValidMethod(ClassInfo_t* cinfo, const char* method, const char* proto, Bool_t objectIsConst, Long_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
+bool TCling::ClassInfo_IsValidMethod(ClassInfo_t* cinfo, const char* method, const char* proto, Bool_t objectIsConst, Longptr_t* offset, EFunctionMatchMode mode /* = kConversionMatch */) const
 {
    TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
    return TClinginfo->IsValidMethod(method, proto, objectIsConst, offset, mode);
@@ -8338,7 +8338,7 @@ int TCling::ClassInfo_Size(ClassInfo_t* cinfo) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Long_t TCling::ClassInfo_Tagnum(ClassInfo_t* cinfo) const
+Longptr_t TCling::ClassInfo_Tagnum(ClassInfo_t* cinfo) const
 {
    TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
    return TClinginfo->Tagnum();
@@ -8438,7 +8438,7 @@ int TCling::BaseClassInfo_Next(BaseClassInfo_t* bcinfo, int onlyDirect) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Long_t TCling::BaseClassInfo_Offset(BaseClassInfo_t* toBaseClassInfo, void * address, bool isDerivedObject) const
+Longptr_t TCling::BaseClassInfo_Offset(BaseClassInfo_t* toBaseClassInfo, void * address, bool isDerivedObject) const
 {
    TClingBaseClassInfo* TClinginfo = (TClingBaseClassInfo*) toBaseClassInfo;
    return TClinginfo->Offset(address, isDerivedObject);
@@ -8446,7 +8446,7 @@ Long_t TCling::BaseClassInfo_Offset(BaseClassInfo_t* toBaseClassInfo, void * add
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Long_t TCling::ClassInfo_GetBaseOffset(ClassInfo_t* fromDerived, ClassInfo_t* toBase, void * address, bool isDerivedObject) const
+Longptr_t TCling::ClassInfo_GetBaseOffset(ClassInfo_t* fromDerived, ClassInfo_t* toBase, void * address, bool isDerivedObject) const
 {
    TClingClassInfo* TClinginfo = (TClingClassInfo*) fromDerived;
    TClingClassInfo* TClinginfoBase = (TClingClassInfo*) toBase;
@@ -8475,7 +8475,7 @@ ClassInfo_t *TCling::BaseClassInfo_ClassInfo(BaseClassInfo_t *bcinfo) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Long_t TCling::BaseClassInfo_Tagnum(BaseClassInfo_t* bcinfo) const
+Longptr_t TCling::BaseClassInfo_Tagnum(BaseClassInfo_t* bcinfo) const
 {
    TClingBaseClassInfo* TClinginfo = (TClingBaseClassInfo*) bcinfo;
    return TClinginfo->Tagnum();
@@ -8580,7 +8580,7 @@ int TCling::DataMemberInfo_Next(DataMemberInfo_t* dminfo) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Long_t TCling::DataMemberInfo_Offset(DataMemberInfo_t* dminfo) const
+Longptr_t TCling::DataMemberInfo_Offset(DataMemberInfo_t* dminfo) const
 {
    TClingDataMemberInfo* TClinginfo = (TClingDataMemberInfo*) dminfo;
    return TClinginfo->Offset();

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -237,9 +237,9 @@ public: // Public Interface
    Int_t   ReloadAllSharedLibraryMaps();
    Int_t   UnloadAllSharedLibraryMaps();
    Int_t   UnloadLibraryMap(const char* library);
-   Long_t  ProcessLine(const char* line, EErrorCode* error = 0);
-   Long_t  ProcessLineAsynch(const char* line, EErrorCode* error = 0);
-   Long_t  ProcessLineSynch(const char* line, EErrorCode* error = 0);
+   Longptr_t ProcessLine(const char* line, EErrorCode* error = 0);
+   Longptr_t ProcessLineAsynch(const char* line, EErrorCode* error = 0);
+   Longptr_t ProcessLineSynch(const char* line, EErrorCode* error = 0);
    void    PrintIntro();
    bool    RegisterPrebuiltModulePath(const std::string& FullPath,
                                       const std::string& ModuleMapName = "module.modulemap") const;
@@ -312,7 +312,7 @@ public: // Public Interface
    void    Execute(TObject* obj, TClass* cl, const char* method, const char* params, Bool_t objectIsConst, int* error = 0);
    void    Execute(TObject* obj, TClass* cl, TMethod* method, TObjArray* params, int* error = 0);
    void    ExecuteWithArgsAndReturn(TMethod* method, void* address, const void* args[] = 0, int nargs = 0, void* ret= 0) const;
-   Long_t  ExecuteMacro(const char* filename, EErrorCode* error = 0);
+   Longptr_t ExecuteMacro(const char* filename, EErrorCode* error = 0);
    void    RecursiveRemove(TObject* obj);
    Bool_t  IsErrorMessagesEnabled() const;
    Bool_t  SetErrorMessages(Bool_t enable = kTRUE);
@@ -379,7 +379,7 @@ public: // Public Interface
    virtual void   CallFunc_Exec(CallFunc_t* func, void* address, TInterpreterValue& val) const;
    virtual void   CallFunc_ExecWithReturn(CallFunc_t* func, void* address, void* ret) const;
    virtual void   CallFunc_ExecWithArgsAndReturn(CallFunc_t* func, void* address, const void* args[] = 0, int nargs = 0, void* ret = 0) const;
-   virtual Long_t    CallFunc_ExecInt(CallFunc_t* func, void* address) const;
+   virtual Longptr_t CallFunc_ExecInt(CallFunc_t* func, void* address) const;
    virtual Long64_t  CallFunc_ExecInt64(CallFunc_t* func, void* address) const;
    virtual Double_t  CallFunc_ExecDouble(CallFunc_t* func, void* address) const;
    virtual CallFunc_t*   CallFunc_Factory() const;
@@ -396,15 +396,15 @@ public: // Public Interface
    virtual void   CallFunc_SetArg(CallFunc_t* func, Double_t param) const;
    virtual void   CallFunc_SetArg(CallFunc_t* func, Long64_t param) const;
    virtual void   CallFunc_SetArg(CallFunc_t* func, ULong64_t param) const;
-   virtual void   CallFunc_SetArgArray(CallFunc_t* func, Long_t* paramArr, Int_t nparam) const;
+   virtual void   CallFunc_SetArgArray(CallFunc_t* func, Longptr_t* paramArr, Int_t nparam) const;
    virtual void   CallFunc_SetArgs(CallFunc_t* func, const char* param) const;
-   virtual void   CallFunc_SetFunc(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* params, Long_t* Offset) const;
-   virtual void   CallFunc_SetFunc(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* params, bool objectIsConst, Long_t* Offset) const;
+   virtual void   CallFunc_SetFunc(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* params, Longptr_t* Offset) const;
+   virtual void   CallFunc_SetFunc(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* params, bool objectIsConst, Longptr_t* Offset) const;
    virtual void   CallFunc_SetFunc(CallFunc_t* func, MethodInfo_t* info) const;
-   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* proto, Long_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
-   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* proto, bool objectIsConst, Long_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
-   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, Long_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
-   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, bool objectIsConst, Long_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
+   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* proto, Longptr_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
+   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const char* proto, bool objectIsConst, Longptr_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
+   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, Longptr_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
+   virtual void   CallFunc_SetFuncProto(CallFunc_t* func, ClassInfo_t* info, const char* method, const std::vector<TypeInfo_t*> &proto, bool objectIsConst, Longptr_t* Offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
 
    virtual std::string CallFunc_GetWrapperCode(CallFunc_t *func) const;
 
@@ -420,7 +420,7 @@ public: // Public Interface
    virtual ClassInfo_t*  ClassInfo_Factory(ClassInfo_t* cl) const;
    virtual ClassInfo_t*  ClassInfo_Factory(const char* name) const;
    virtual ClassInfo_t*  ClassInfo_Factory(DeclId_t declid) const;
-   virtual Long_t   ClassInfo_GetBaseOffset(ClassInfo_t* fromDerived, ClassInfo_t* toBase, void * address, bool isDerivedObject) const;
+   virtual Longptr_t ClassInfo_GetBaseOffset(ClassInfo_t* fromDerived, ClassInfo_t* toBase, void * address, bool isDerivedObject) const;
    virtual int    ClassInfo_GetMethodNArg(ClassInfo_t* info, const char* method, const char* proto, Bool_t objectIsConst = false, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
    virtual bool   ClassInfo_HasDefaultConstructor(ClassInfo_t* info, Bool_t testio = kFALSE) const;
    virtual bool   ClassInfo_HasMethod(ClassInfo_t* info, const char* name) const;
@@ -432,8 +432,8 @@ public: // Public Interface
    virtual EDataType ClassInfo_GetUnderlyingType(ClassInfo_t* info) const;
    virtual bool   ClassInfo_IsLoaded(ClassInfo_t* info) const;
    virtual bool   ClassInfo_IsValid(ClassInfo_t* info) const;
-   virtual bool   ClassInfo_IsValidMethod(ClassInfo_t* info, const char* method, const char* proto, Long_t* offset, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const;
-   virtual bool   ClassInfo_IsValidMethod(ClassInfo_t* info, const char* method, const char* proto, Bool_t objectIsConst, Long_t* offset, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const;
+   virtual bool   ClassInfo_IsValidMethod(ClassInfo_t* info, const char* method, const char* proto, Longptr_t* offset, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const;
+   virtual bool   ClassInfo_IsValidMethod(ClassInfo_t* info, const char* method, const char* proto, Bool_t objectIsConst, Longptr_t* offset, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) const;
    virtual int    ClassInfo_Next(ClassInfo_t* info) const;
    virtual void*  ClassInfo_New(ClassInfo_t* info) const;
    virtual void*  ClassInfo_New(ClassInfo_t* info, int n) const;
@@ -441,7 +441,7 @@ public: // Public Interface
    virtual void*  ClassInfo_New(ClassInfo_t* info, void* arena) const;
    virtual Long_t ClassInfo_Property(ClassInfo_t* info) const;
    virtual int    ClassInfo_Size(ClassInfo_t* info) const;
-   virtual Long_t ClassInfo_Tagnum(ClassInfo_t* info) const;
+   virtual Longptr_t ClassInfo_Tagnum(ClassInfo_t* info) const;
    virtual const char* ClassInfo_FileName(ClassInfo_t* info) const;
    virtual const char* ClassInfo_FullName(ClassInfo_t* info) const;
    virtual const char* ClassInfo_Name(ClassInfo_t* info) const;
@@ -455,9 +455,9 @@ public: // Public Interface
                                                    ClassInfo_t* base) const;
    virtual int    BaseClassInfo_Next(BaseClassInfo_t* bcinfo) const;
    virtual int    BaseClassInfo_Next(BaseClassInfo_t* bcinfo, int onlyDirect) const;
-   virtual Long_t BaseClassInfo_Offset(BaseClassInfo_t* toBaseClassInfo, void * address, bool isDerivedObject) const;
+   virtual Longptr_t BaseClassInfo_Offset(BaseClassInfo_t* toBaseClassInfo, void * address, bool isDerivedObject) const;
    virtual Long_t BaseClassInfo_Property(BaseClassInfo_t* bcinfo) const;
-   virtual Long_t BaseClassInfo_Tagnum(BaseClassInfo_t* bcinfo) const;
+   virtual Longptr_t BaseClassInfo_Tagnum(BaseClassInfo_t* bcinfo) const;
    virtual ClassInfo_t*BaseClassInfo_ClassInfo(BaseClassInfo_t * /* bcinfo */) const;
    virtual const char* BaseClassInfo_FullName(BaseClassInfo_t* bcinfo) const;
    virtual const char* BaseClassInfo_Name(BaseClassInfo_t* bcinfo) const;
@@ -473,7 +473,7 @@ public: // Public Interface
    virtual bool   DataMemberInfo_IsValid(DataMemberInfo_t* dminfo) const;
    virtual int    DataMemberInfo_MaxIndex(DataMemberInfo_t* dminfo, Int_t dim) const;
    virtual int    DataMemberInfo_Next(DataMemberInfo_t* dminfo) const;
-   virtual Long_t DataMemberInfo_Offset(DataMemberInfo_t* dminfo) const;
+   virtual Longptr_t DataMemberInfo_Offset(DataMemberInfo_t* dminfo) const;
    virtual Long_t DataMemberInfo_Property(DataMemberInfo_t* dminfo) const;
    virtual Long_t DataMemberInfo_TypeProperty(DataMemberInfo_t* dminfo) const;
    virtual int    DataMemberInfo_TypeSize(DataMemberInfo_t* dminfo) const;

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -2127,9 +2127,9 @@ T TClingCallFunc::ExecT(void *address)
    return sv_to<T>(ret);
 }
 
-Long_t TClingCallFunc::ExecInt(void *address)
+Longptr_t TClingCallFunc::ExecInt(void *address)
 {
-   return ExecT<long>(address);
+   return ExecT<Longptr_t>(address);
 }
 
 long long TClingCallFunc::ExecInt64(void *address)
@@ -2355,7 +2355,7 @@ void TClingCallFunc::SetArg(unsigned long long param)
    fArgVals.back().getULL() = param;
 }
 
-void TClingCallFunc::SetArgArray(long *paramArr, int nparam)
+void TClingCallFunc::SetArgArray(Longptr_t *paramArr, int nparam)
 {
    ResetArg();
    for (int i = 0; i < nparam; ++i) {
@@ -2370,13 +2370,13 @@ void TClingCallFunc::SetArgs(const char *params)
 }
 
 void TClingCallFunc::SetFunc(const TClingClassInfo *info, const char *method, const char *arglist,
-                             long *poffset)
+                             Longptr_t *poffset)
 {
    SetFunc(info, method, arglist, false, poffset);
 }
 
 void TClingCallFunc::SetFunc(const TClingClassInfo *info, const char *method, const char *arglist,
-                             bool objectIsConst, long *poffset)
+                             bool objectIsConst, Longptr_t *poffset)
 {
    Init(std::unique_ptr<TClingMethodInfo>(new TClingMethodInfo(fInterp)));
    if (poffset) {
@@ -2413,14 +2413,14 @@ void TClingCallFunc::SetFunc(const TClingMethodInfo *info)
 }
 
 void TClingCallFunc::SetFuncProto(const TClingClassInfo *info, const char *method,
-                                  const char *proto, long *poffset,
+                                  const char *proto, Longptr_t *poffset,
                                   EFunctionMatchMode mode/*=kConversionMatch*/)
 {
    SetFuncProto(info, method, proto, false, poffset, mode);
 }
 
 void TClingCallFunc::SetFuncProto(const TClingClassInfo *info, const char *method,
-                                  const char *proto, bool objectIsConst, long *poffset,
+                                  const char *proto, bool objectIsConst, Longptr_t *poffset,
                                   EFunctionMatchMode mode/*=kConversionMatch*/)
 {
    Init(std::unique_ptr<TClingMethodInfo>(new TClingMethodInfo(fInterp)));
@@ -2441,7 +2441,7 @@ void TClingCallFunc::SetFuncProto(const TClingClassInfo *info, const char *metho
 }
 
 void TClingCallFunc::SetFuncProto(const TClingClassInfo *info, const char *method,
-                                  const llvm::SmallVectorImpl<clang::QualType> &proto, long *poffset,
+                                  const llvm::SmallVectorImpl<clang::QualType> &proto, Longptr_t *poffset,
                                   EFunctionMatchMode mode/*=kConversionMatch*/)
 {
    SetFuncProto(info, method, proto, false, poffset, mode);
@@ -2449,7 +2449,7 @@ void TClingCallFunc::SetFuncProto(const TClingClassInfo *info, const char *metho
 
 void TClingCallFunc::SetFuncProto(const TClingClassInfo *info, const char *method,
                                   const llvm::SmallVectorImpl<clang::QualType> &proto,
-                                  bool objectIsConst, long *poffset,
+                                  bool objectIsConst, Longptr_t *poffset,
                                   EFunctionMatchMode mode/*=kConversionMatch*/)
 {
    Init(std::unique_ptr<TClingMethodInfo>(new TClingMethodInfo(fInterp)));

--- a/core/metacling/src/TClingCallFunc.h
+++ b/core/metacling/src/TClingCallFunc.h
@@ -190,7 +190,7 @@ public:
                               int nargs = 0,
                               void* ret = 0);
    void Exec(void* address, TInterpreterValue* interpVal = 0);
-   long ExecInt(void* address);
+   Longptr_t ExecInt(void* address);
    long long ExecInt64(void* address);
    double ExecDouble(void* address);
    TClingMethodInfo* FactoryMethod() const;
@@ -226,26 +226,26 @@ public:
    void SetArg(double arg);
    void SetArg(long long arg);
    void SetArg(unsigned long long arg);
-   void SetArgArray(long* argArr, int narg);
+   void SetArgArray(Longptr_t* argArr, int narg);
    void SetArgs(const char* args);
    void SetFunc(const TClingClassInfo* info, const char* method,
-                const char* arglist, long* poffset);
+                const char* arglist, Longptr_t* poffset);
    void SetFunc(const TClingClassInfo* info, const char* method,
-                const char* arglist, bool objectIsConst, long* poffset);
+                const char* arglist, bool objectIsConst, Longptr_t* poffset);
    void SetFunc(const TClingMethodInfo* info);
    void SetFuncProto(const TClingClassInfo* info, const char* method,
-                     const char* proto, long* poffset,
+                     const char* proto, Longptr_t* poffset,
                      ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    void SetFuncProto(const TClingClassInfo* info, const char* method,
-                     const char* proto, bool objectIsConst, long* poffset,
-                     ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
-   void SetFuncProto(const TClingClassInfo* info, const char* method,
-                     const llvm::SmallVectorImpl<clang::QualType>& proto,
-                     long* poffset,
+                     const char* proto, bool objectIsConst, Longptr_t* poffset,
                      ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    void SetFuncProto(const TClingClassInfo* info, const char* method,
                      const llvm::SmallVectorImpl<clang::QualType>& proto,
-                     bool objectIsConst, long* poffset,
+                     Longptr_t* poffset,
+                     ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
+   void SetFuncProto(const TClingClassInfo* info, const char* method,
+                     const llvm::SmallVectorImpl<clang::QualType>& proto,
+                     bool objectIsConst, Longptr_t* poffset,
                      ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
 };
 

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -331,7 +331,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname) const
 }
 
 TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
-      const char *proto, long *poffset, EFunctionMatchMode mode /*= kConversionMatch*/,
+      const char *proto, Longptr_t *poffset, EFunctionMatchMode mode /*= kConversionMatch*/,
       EInheritanceMode imode /*= kWithInheritance*/) const
 {
    return GetMethod(fname,proto,false,poffset,mode,imode);
@@ -339,7 +339,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
 
 TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
       const char *proto, bool objectIsConst,
-      long *poffset, EFunctionMatchMode mode /*= kConversionMatch*/,
+      Longptr_t *poffset, EFunctionMatchMode mode /*= kConversionMatch*/,
       EInheritanceMode imode /*= kWithInheritance*/) const
 {
    if (poffset) {
@@ -425,7 +425,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
 
 TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
                                             const llvm::SmallVectorImpl<clang::QualType> &proto,
-                                            long *poffset, EFunctionMatchMode mode /*= kConversionMatch*/,
+                                            Longptr_t *poffset, EFunctionMatchMode mode /*= kConversionMatch*/,
                                             EInheritanceMode imode /*= kWithInheritance*/) const
 {
    return GetMethod(fname,proto,false,poffset,mode,imode);
@@ -433,7 +433,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
 
 TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
                                             const llvm::SmallVectorImpl<clang::QualType> &proto, bool objectIsConst,
-                                            long *poffset, EFunctionMatchMode mode /*= kConversionMatch*/,
+                                            Longptr_t *poffset, EFunctionMatchMode mode /*= kConversionMatch*/,
                                             EInheritanceMode imode /*= kWithInheritance*/) const
 {
    if (poffset) {
@@ -498,7 +498,7 @@ TClingMethodInfo TClingClassInfo::GetMethod(const char *fname,
 }
 
 TClingMethodInfo TClingClassInfo::GetMethodWithArgs(const char *fname,
-      const char *arglist, long *poffset, EFunctionMatchMode mode /* = kConversionMatch*/,
+      const char *arglist, Longptr_t *poffset, EFunctionMatchMode mode /* = kConversionMatch*/,
       EInheritanceMode imode /* = kWithInheritance*/) const
 {
    return GetMethodWithArgs(fname,arglist,false,poffset,mode,imode);
@@ -506,7 +506,7 @@ TClingMethodInfo TClingClassInfo::GetMethodWithArgs(const char *fname,
 
 TClingMethodInfo TClingClassInfo::GetMethodWithArgs(const char *fname,
       const char *arglist, bool objectIsConst,
-      long *poffset, EFunctionMatchMode /*mode = kConversionMatch*/,
+      Longptr_t *poffset, EFunctionMatchMode /*mode = kConversionMatch*/,
       EInheritanceMode /* imode = kWithInheritance*/) const
 {
 
@@ -583,12 +583,12 @@ int TClingClassInfo::GetMethodNArg(const char *method, const char *proto,
    return clang_val;
 }
 
-long TClingClassInfo::GetOffset(const CXXMethodDecl* md) const
+Longptr_t TClingClassInfo::GetOffset(const CXXMethodDecl* md) const
 {
 
    R__LOCKGUARD(gInterpreterMutex);
 
-   long offset = 0L;
+   Longptr_t offset = 0L;
    const CXXRecordDecl* definer = md->getParent();
    const CXXRecordDecl* accessor =
       llvm::cast<CXXRecordDecl>(GetDecl());
@@ -910,7 +910,7 @@ bool TClingClassInfo::IsLoaded() const
 
 bool TClingClassInfo::IsValidMethod(const char *method, const char *proto,
                                     Bool_t objectIsConst,
-                                    long *offset,
+                                    Longptr_t *offset,
                                     EFunctionMatchMode mode /*= kConversionMatch*/) const
 {
    // Check if the method with the given prototype exist.
@@ -1349,12 +1349,12 @@ int TClingClassInfo::Size() const
    return clang_size;
 }
 
-long TClingClassInfo::Tagnum() const
+Longptr_t TClingClassInfo::Tagnum() const
 {
    if (!IsValid()) {
       return -1L;
    }
-   return reinterpret_cast<long>(GetDecl());
+   return reinterpret_cast<Longptr_t>(GetDecl());
 }
 
 const char *TClingClassInfo::FileName()

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -119,25 +119,25 @@ public:
    const clang::FunctionTemplateDecl *GetFunctionTemplate(const char *fname) const;
    TClingMethodInfo     GetMethod(const char *fname) const;
    TClingMethodInfo     GetMethod(const char *fname, const char *proto,
-                                  long *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
+                                  Longptr_t *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
                                   EInheritanceMode imode = kWithInheritance) const;
    TClingMethodInfo     GetMethodWithArgs(const char *fname, const char *arglist,
-                                  long *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
+                                  Longptr_t *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
                                   EInheritanceMode imode = kWithInheritance) const;
    TClingMethodInfo     GetMethod(const char *fname, const char *proto, bool objectIsConst,
-                                  long *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
+                                  Longptr_t *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
                                   EInheritanceMode imode = kWithInheritance) const;
    TClingMethodInfo     GetMethodWithArgs(const char *fname, const char *arglist, bool objectIsConst,
-                                  long *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
+                                  Longptr_t *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
                                   EInheritanceMode imode = kWithInheritance) const;
    TClingMethodInfo     GetMethod(const char *fname, const llvm::SmallVectorImpl<clang::QualType> &proto,
-                                  long *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
+                                  Longptr_t *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
                                   EInheritanceMode imode = kWithInheritance) const;
    TClingMethodInfo     GetMethod(const char *fname, const llvm::SmallVectorImpl<clang::QualType> &proto, bool objectIsConst,
-                                  long *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
+                                  Longptr_t *poffset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch,
                                   EInheritanceMode imode = kWithInheritance) const;
    int                  GetMethodNArg(const char *method, const char *proto, Bool_t objectIsConst, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
-   long                 GetOffset(const clang::CXXMethodDecl* md) const;
+   Longptr_t            GetOffset(const clang::CXXMethodDecl* md) const;
    ptrdiff_t            GetBaseOffset(TClingClassInfo* toBase, void* address, bool isDerivedObject);
    const clang::Type   *GetType() const { return fType; } // Underlying representation with Double32_t
    std::vector<std::string> GetUsingNamespaces();
@@ -152,7 +152,7 @@ public:
    bool                 IsScopedEnum() const;
    EDataType            GetUnderlyingType() const;
    bool                 IsLoaded() const;
-   bool                 IsValidMethod(const char *method, const char *proto, Bool_t objectIsConst, long *offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
+   bool                 IsValidMethod(const char *method, const char *proto, Bool_t objectIsConst, Longptr_t *offset, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) const;
    int                  InternalNext();
    int                  Next();
    void                *New(const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;
@@ -162,7 +162,7 @@ public:
    long                 Property() const;
    int                  RootFlag() const;
    int                  Size() const;
-   long                 Tagnum() const;
+   Longptr_t            Tagnum() const;
    const char          *FileName();
    void                 FullName(std::string &output, const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;
    const char          *Title();

--- a/core/rint/inc/TRint.h
+++ b/core/rint/inc/TRint.h
@@ -43,8 +43,8 @@ private:
    TRint& operator=(const TRint&) = delete;
 
    void    ExecLogon();
-   Long_t  ProcessRemote(const char *line, Int_t *error = nullptr);
-   Long_t  ProcessLineNr(const char* filestem, const char *line, Int_t *error = nullptr);
+   Longptr_t ProcessRemote(const char *line, Int_t *error = nullptr);
+   Longptr_t ProcessLineNr(const char* filestem, const char *line, Int_t *error = nullptr);
 
 public:
    TRint(const char *appClassName, int *argc, char **argv,

--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -350,7 +350,7 @@ void TRint::Run(Bool_t retrn)
       Getlinem(kInit, GetPrompt());
    }
 
-   Long_t retval = 0;
+   Longptr_t retval = 0;
    Int_t  error = 0;
    volatile Bool_t needGetlinemInit = kFALSE;
 
@@ -719,9 +719,9 @@ void TRint::SetEchoMode(Bool_t mode)
 /// The last argument 'script' allows to specify an alternative script to
 /// be executed remotely to startup the session.
 
-Long_t TRint::ProcessRemote(const char *line, Int_t *)
+Longptr_t TRint::ProcessRemote(const char *line, Int_t *)
 {
-   Long_t ret = TApplication::ProcessRemote(line);
+   Longptr_t ret = TApplication::ProcessRemote(line);
 
    if (ret == 1) {
       if (fAppRemote) {
@@ -741,7 +741,7 @@ Long_t TRint::ProcessRemote(const char *line, Int_t *)
 /// better diagnostics. Must be called after fNcmd has been increased for
 /// the next line.
 
-Long_t  TRint::ProcessLineNr(const char* filestem, const char *line, Int_t *error /*= 0*/)
+Longptr_t  TRint::ProcessLineNr(const char* filestem, const char *line, Int_t *error /*= 0*/)
 {
    Int_t err;
    if (!error)

--- a/math/mathcore/src/mixmax.icc
+++ b/math/mathcore/src/mixmax.icc
@@ -239,7 +239,7 @@ myuint precalc(rng_state_t* X){
 
 int rng_get_N(void){return N;}
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) && !defined(_WIN64)
 inline myuint mod128(__uint128_t s){
     myuint s1;
     s1 = ( (  ((myuint)s)&MERSBASE )    + (  ((myuint)(s>>64)) * 8 )  + ( ((myuint)s) >>BITS) );


### PR DESCRIPTION
 - Use different typedefs for (U)Longptr_t to prevent overload errors on Win32
 - First round of replacing (U)Long_t with (U)Longptr_t where applicable (mostly on core) and fix the following kind of warnings (leading to errors when truncating pointers)
   `warning C4311: 'type cast': pointer truncation from 'void *' to 'Long_t'`
   `warning C4312: 'type cast': conversion from 'Long_t' to 'void *' of greater size`