### PR TITLE
[ntuple] Basic buffered page sink

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -37,6 +37,7 @@ HEADERS
   ROOT/RPage.hxx
   ROOT/RPageAllocator.hxx
   ROOT/RPagePool.hxx
+  ROOT/RPageSinkBuf.hxx
   ROOT/RPageStorage.hxx
   ROOT/RPageStorageFile.hxx
 SOURCES
@@ -58,6 +59,7 @@ SOURCES
   v7/src/RPage.cxx
   v7/src/RPageAllocator.cxx
   v7/src/RPagePool.cxx
+  v7/src/RPageSinkBuf.cxx
   v7/src/RPageStorage.cxx
   v7/src/RPageStorageFile.cxx
 LINKDEF

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -1,0 +1,65 @@
+/// \file ROOT/RPageSinkBuf.hxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \author Max Orok <maxwellorok@gmail.com>
+/// \date 2021-03-17
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RPageSinkBuf
+#define ROOT7_RPageSinkBuf
+
+#include <ROOT/RPageStorage.hxx>
+
+#include <memory>
+
+namespace ROOT {
+namespace Experimental {
+namespace Detail {
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RPageSinkBuf
+\ingroup NTuple
+\brief Abstract sink that reorders cluster page writes
+*/
+// clang-format on
+class RPageSinkBuf : public RPageSink {
+private:
+   std::unique_ptr<RPageSink> fInner;
+
+protected:
+   void CreateImpl(const RNTupleModel &model) override;
+   RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) override;
+   RClusterDescriptor::RLocator CommitClusterImpl(NTupleSize_t nEntries) override;
+   void CommitDatasetImpl() override;
+   // Forward calls to inner descriptor builder
+   RNTupleDescriptorBuilder& GetDescriptorBuilder() override { return fInner->fDescriptorBuilder; }
+
+public:
+   explicit RPageSinkBuf(std::unique_ptr<RPageSink> inner);
+   RPageSinkBuf(const RPageSink&) = delete;
+   RPageSinkBuf& operator=(const RPageSinkBuf&) = delete;
+   RPageSinkBuf(RPageSinkBuf&&) = default;
+   RPageSinkBuf& operator=(RPageSinkBuf&&) = default;
+   virtual ~RPageSinkBuf() = default;
+
+   RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) override;
+   void ReleasePage(RPage &page) override;
+
+   RNTupleMetrics &GetMetrics() override { return fInner->GetMetrics(); }
+};
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -46,8 +46,11 @@ private:
          fBuf.second.emplace_back(page);
       }
       const RPageStorage::ColumnHandle_t &GetHandle() const { return fBuf.first; }
-      const std::vector<RPage> &GetBufferedPages() const { return fBuf.second; }
-      void Clear() { fBuf.second.clear(); }
+      std::vector<RPage> DrainBufferedPages() {
+         std::vector<RPage> drained;
+         std::swap(fBuf.second, drained);
+         return drained;
+      }
    };
 
 private:

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -35,14 +35,13 @@ namespace Detail {
 class RPageSinkBuf : public RPageSink {
 private:
    std::unique_ptr<RPageSink> fInner;
+   std::unique_ptr<RNTupleModel> fInnerModel;
 
 protected:
    void CreateImpl(const RNTupleModel &model) override;
    RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) override;
    RClusterDescriptor::RLocator CommitClusterImpl(NTupleSize_t nEntries) override;
    void CommitDatasetImpl() override;
-   // Forward calls to inner descriptor builder
-   RNTupleDescriptorBuilder& GetDescriptorBuilder() override { return fInner->fDescriptorBuilder; }
 
 public:
    explicit RPageSinkBuf(std::unique_ptr<RPageSink> inner);

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -56,7 +56,7 @@ private:
 
 private:
    /// The inner sink, responsible for actually performing I/O.
-   std::unique_ptr<RPageSink> fInner;
+   std::unique_ptr<RPageSink> fInnerSink;
    /// The buffered page sink maintains a copy of the RNTupleModel for the inner sink.
    /// For the unbuffered case, the RNTupleModel is instead managed by a RNTupleWriter.
    std::unique_ptr<RNTupleModel> fInnerModel;

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -45,8 +45,8 @@ private:
          }
          fBuf.second.emplace_back(page);
       }
-      const RPageStorage::ColumnHandle_t& GetHandle() const { return fBuf.first; }
-      const std::vector<RPage>& GetBufferedPages() const { return fBuf.second; }
+      const RPageStorage::ColumnHandle_t &GetHandle() const { return fBuf.first; }
+      const std::vector<RPage> &GetBufferedPages() const { return fBuf.second; }
       void Clear() { fBuf.second.clear(); }
    };
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -148,7 +148,6 @@ up to the given entry number are committed.
 */
 // clang-format on
 class RPageSink : public RPageStorage {
-friend class RPageSinkBuf; // to reorder page sink writes
 protected:
    RNTupleWriteOptions fOptions;
 
@@ -168,7 +167,6 @@ protected:
    /// Keeps track of the written pages in the currently open cluster. Indexed by column id.
    std::vector<RClusterDescriptor::RPageRange> fOpenPageRanges;
    RNTupleDescriptorBuilder fDescriptorBuilder;
-   virtual RNTupleDescriptorBuilder& GetDescriptorBuilder() { return fDescriptorBuilder; }
 
    virtual void CreateImpl(const RNTupleModel &model) = 0;
    virtual RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -130,6 +130,8 @@ public:
 
    /// Returns an empty metrics.  Page storage implementations usually have their own metrics.
    virtual RNTupleMetrics &GetMetrics();
+   /// Returns the NTuple name.
+   const std::string& GetNTupleName() const { return fNTupleName; }
 
    void SetTaskScheduler(RTaskScheduler *taskScheduler) { fTaskScheduler = taskScheduler; }
 };
@@ -146,6 +148,7 @@ up to the given entry number are committed.
 */
 // clang-format on
 class RPageSink : public RPageStorage {
+friend class RPageSinkBuf; // to reorder page sink writes
 protected:
    RNTupleWriteOptions fOptions;
 
@@ -165,6 +168,7 @@ protected:
    /// Keeps track of the written pages in the currently open cluster. Indexed by column id.
    std::vector<RClusterDescriptor::RPageRange> fOpenPageRanges;
    RNTupleDescriptorBuilder fDescriptorBuilder;
+   virtual RNTupleDescriptorBuilder& GetDescriptorBuilder() { return fDescriptorBuilder; }
 
    virtual void CreateImpl(const RNTupleModel &model) = 0;
    virtual RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;
@@ -191,6 +195,8 @@ public:
    static std::unique_ptr<RPageSink> Create(std::string_view ntupleName, std::string_view location,
                                             const RNTupleWriteOptions &options = RNTupleWriteOptions());
    EPageStorageType GetType() final { return EPageStorageType::kSink; }
+   /// Returns the sink's write options.
+   const RNTupleWriteOptions& GetWriteOptions() const { return fOptions; }
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
    void DropColumn(ColumnHandle_t /*columnHandle*/) final {}
@@ -263,6 +269,7 @@ public:
 
    EPageStorageType GetType() final { return EPageStorageType::kSource; }
    const RNTupleDescriptor &GetDescriptor() const { return fDescriptor; }
+   const RNTupleReadOptions& GetReadOptions() const { return fOptions; }
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
    void DropColumn(ColumnHandle_t columnHandle) final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -131,7 +131,7 @@ public:
    /// Returns an empty metrics.  Page storage implementations usually have their own metrics.
    virtual RNTupleMetrics &GetMetrics();
    /// Returns the NTuple name.
-   const std::string& GetNTupleName() const { return fNTupleName; }
+   const std::string &GetNTupleName() const { return fNTupleName; }
 
    void SetTaskScheduler(RTaskScheduler *taskScheduler) { fTaskScheduler = taskScheduler; }
 };
@@ -194,7 +194,7 @@ public:
                                             const RNTupleWriteOptions &options = RNTupleWriteOptions());
    EPageStorageType GetType() final { return EPageStorageType::kSink; }
    /// Returns the sink's write options.
-   const RNTupleWriteOptions& GetWriteOptions() const { return fOptions; }
+   const RNTupleWriteOptions &GetWriteOptions() const { return fOptions; }
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
    void DropColumn(ColumnHandle_t /*columnHandle*/) final {}
@@ -267,7 +267,7 @@ public:
 
    EPageStorageType GetType() final { return EPageStorageType::kSource; }
    const RNTupleDescriptor &GetDescriptor() const { return fDescriptor; }
-   const RNTupleReadOptions& GetReadOptions() const { return fOptions; }
+   const RNTupleReadOptions &GetReadOptions() const { return fOptions; }
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
    void DropColumn(ColumnHandle_t columnHandle) final;
 

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -1,0 +1,54 @@
+/// \file RPageSinkBuf.cxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \author Max Orok <maxwellorok@gmail.com>
+/// \date 2021-03-17
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RPageSinkBuf.hxx>
+
+ROOT::Experimental::Detail::RPageSinkBuf::RPageSinkBuf(std::unique_ptr<RPageSink> inner)
+   : RPageSink(inner->GetNTupleName(), inner->GetWriteOptions()), fInner(std::move(inner)) {}
+
+void ROOT::Experimental::Detail::RPageSinkBuf::CreateImpl(const RNTupleModel &model)
+{
+   fInner->CreateImpl(model);
+}
+
+ROOT::Experimental::RClusterDescriptor::RLocator
+ROOT::Experimental::Detail::RPageSinkBuf::CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page)
+{
+   return fInner->CommitPageImpl(columnHandle, page);
+}
+
+ROOT::Experimental::RClusterDescriptor::RLocator
+ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::NTupleSize_t nEntries)
+{
+   return fInner->CommitClusterImpl(nEntries);
+}
+
+void ROOT::Experimental::Detail::RPageSinkBuf::CommitDatasetImpl()
+{
+   fInner->CommitDatasetImpl();
+}
+
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPageSinkBuf::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
+{
+   return fInner->ReservePage(columnHandle, nElements);
+}
+
+void ROOT::Experimental::Detail::RPageSinkBuf::ReleasePage(RPage &page)
+{
+   fInner->ReleasePage(page);
+}

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -40,13 +40,13 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitPageImpl(ColumnHandle_t columnHa
 ROOT::Experimental::RClusterDescriptor::RLocator
 ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::NTupleSize_t nEntries)
 {
-   for (const auto& bufColumn : fBufferedColumns) {
-      const auto& columnHandle = bufColumn.GetHandle();
-      for (const auto& bufPage : bufColumn.GetBufferedPages()) {
+   for (const auto &bufColumn : fBufferedColumns) {
+      const auto &columnHandle = bufColumn.GetHandle();
+      for (const auto &bufPage : bufColumn.GetBufferedPages()) {
          fInner->CommitPage(columnHandle, bufPage);
       }
    }
-   for (auto& bufColumn : fBufferedColumns) {
+   for (auto &bufColumn : fBufferedColumns) {
       bufColumn.Clear();
    }
    fInner->CommitCluster(nEntries);

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -40,14 +40,10 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitPageImpl(ColumnHandle_t columnHa
 ROOT::Experimental::RClusterDescriptor::RLocator
 ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::NTupleSize_t nEntries)
 {
-   for (const auto &bufColumn : fBufferedColumns) {
-      const auto &columnHandle = bufColumn.GetHandle();
-      for (const auto &bufPage : bufColumn.GetBufferedPages()) {
-         fInner->CommitPage(columnHandle, bufPage);
-      }
-   }
    for (auto &bufColumn : fBufferedColumns) {
-      bufColumn.Clear();
+      for (const auto &bufPage : bufColumn.DrainBufferedPages()) {
+         fInner->CommitPage(bufColumn.GetHandle(), bufPage);
+      }
    }
    fInner->CommitCluster(nEntries);
    // at this point we're feeding bad locators to fOpenColumnRanges

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -15,6 +15,7 @@
  *************************************************************************/
 
 #include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RPageSinkBuf.hxx>
 
 ROOT::Experimental::Detail::RPageSinkBuf::RPageSinkBuf(std::unique_ptr<RPageSink> inner)
@@ -22,24 +23,27 @@ ROOT::Experimental::Detail::RPageSinkBuf::RPageSinkBuf(std::unique_ptr<RPageSink
 
 void ROOT::Experimental::Detail::RPageSinkBuf::CreateImpl(const RNTupleModel &model)
 {
-   fInner->CreateImpl(model);
+   fInnerModel = model.Clone();
+   fInner->Create(*fInnerModel);
 }
 
 ROOT::Experimental::RClusterDescriptor::RLocator
 ROOT::Experimental::Detail::RPageSinkBuf::CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page)
 {
-   return fInner->CommitPageImpl(columnHandle, page);
+   fInner->CommitPage(columnHandle, page);
+   return RClusterDescriptor::RLocator{};
 }
 
 ROOT::Experimental::RClusterDescriptor::RLocator
 ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::NTupleSize_t nEntries)
 {
-   return fInner->CommitClusterImpl(nEntries);
+   fInner->CommitCluster(nEntries);
+   return RClusterDescriptor::RLocator{};
 }
 
 void ROOT::Experimental::Detail::RPageSinkBuf::CommitDatasetImpl()
 {
-   fInner->CommitDatasetImpl();
+   fInner->CommitDataset();
 }
 
 ROOT::Experimental::Detail::RPage

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -150,19 +150,21 @@ std::unique_ptr<ROOT::Experimental::Detail::RPageSink> ROOT::Experimental::Detai
 ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
 ROOT::Experimental::Detail::RPageSink::AddColumn(DescriptorId_t fieldId, const RColumn &column)
 {
+   auto& descriptorBuilder = GetDescriptorBuilder();
    auto columnId = fLastColumnId++;
-   fDescriptorBuilder.AddColumn(columnId, fieldId, column.GetVersion(), column.GetModel(), column.GetIndex());
+   descriptorBuilder.AddColumn(columnId, fieldId, column.GetVersion(), column.GetModel(), column.GetIndex());
    return ColumnHandle_t{columnId, &column};
 }
 
 
 void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
 {
-   fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription(), "undefined author",
+   auto& descriptorBuilder = GetDescriptorBuilder();
+   descriptorBuilder.SetNTuple(fNTupleName, model.GetDescription(), "undefined author",
                                 model.GetVersion(), model.GetUuid());
 
    auto &fieldZero = *model.GetFieldZero();
-   fDescriptorBuilder.AddField(
+   descriptorBuilder.AddField(
       RDanglingFieldDescriptor::FromField(fieldZero)
          .FieldId(fLastFieldId)
          .MakeDescriptor()
@@ -171,13 +173,13 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
    fieldZero.SetOnDiskId(fLastFieldId);
    for (auto& f : *model.GetFieldZero()) {
       fLastFieldId++;
-      fDescriptorBuilder.AddField(
+      descriptorBuilder.AddField(
          RDanglingFieldDescriptor::FromField(f)
             .FieldId(fLastFieldId)
             .MakeDescriptor()
             .Unwrap()
       );
-      fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fLastFieldId);
+      descriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fLastFieldId);
       f.SetOnDiskId(fLastFieldId);
       f.ConnectPageStorage(*this); // issues in turn one or several calls to AddColumn()
    }
@@ -214,14 +216,15 @@ void ROOT::Experimental::Detail::RPageSink::CommitPage(ColumnHandle_t columnHand
 
 void ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
 {
+   auto& descriptorBuilder = GetDescriptorBuilder();
    auto locator = CommitClusterImpl(nEntries);
 
    R__ASSERT((nEntries - fPrevClusterNEntries) < ClusterSize_t(-1));
-   fDescriptorBuilder.AddCluster(fLastClusterId, RNTupleVersion(), fPrevClusterNEntries,
+   descriptorBuilder.AddCluster(fLastClusterId, RNTupleVersion(), fPrevClusterNEntries,
                                  ClusterSize_t(nEntries - fPrevClusterNEntries));
-   fDescriptorBuilder.SetClusterLocator(fLastClusterId, locator);
+   descriptorBuilder.SetClusterLocator(fLastClusterId, locator);
    for (auto &range : fOpenColumnRanges) {
-      fDescriptorBuilder.AddClusterColumnRange(fLastClusterId, range);
+      descriptorBuilder.AddClusterColumnRange(fLastClusterId, range);
       range.fFirstElementIndex += range.fNElements;
       range.fNElements = 0;
    }
@@ -229,7 +232,7 @@ void ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experimental::NT
       RClusterDescriptor::RPageRange fullRange;
       std::swap(fullRange, range);
       range.fColumnId = fullRange.fColumnId;
-      fDescriptorBuilder.AddClusterPageRange(fLastClusterId, std::move(fullRange));
+      descriptorBuilder.AddClusterPageRange(fLastClusterId, std::move(fullRange));
    }
    ++fLastClusterId;
    fPrevClusterNEntries = nEntries;

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -137,9 +137,9 @@ TEST(RPageSinkBuf, Basics)
    }
 
    std::vector<std::pair<DescriptorId_t, std::int64_t>> pagePositions;
-   auto num_columns = 10;
+   std::size_t num_columns = 10;
    const auto &cluster0 = ntupleBuf->GetDescriptor().GetClusterDescriptor(0);
-   for (auto i = 0; i < num_columns; i++) {
+   for (std::size_t i = 0; i < num_columns; i++) {
       const auto &columnPages = cluster0.GetPageRange(i);
       for (const auto &page: columnPages.fPageInfos) {
          pagePositions.push_back(std::make_pair(i, page.fLocator.fPosition));

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -145,10 +145,13 @@ TEST(RPageSinkBuf, Basics)
          pagePositions.push_back(std::make_pair(i, page.fLocator.fPosition));
       }
    }
+
    auto sortedPages = pagePositions;
    std::sort(begin(sortedPages), end(sortedPages),
       [](const auto &a, const auto &b) { return a.second < b.second; });
 
+   // For this test, ensure at least some columns have multiple pages
+   ASSERT_TRUE(sortedPages.size() > num_columns);
    // Buffered sink cluster column pages are written out together
    for (std::size_t i = 0; i < pagePositions.size() - 1; i++) {
       // if the next page belongs to another column, skip the check

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -18,6 +18,7 @@
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RPageAllocator.hxx>
 #include <ROOT/RPagePool.hxx>
+#include <ROOT/RPageSinkBuf.hxx>
 #include <ROOT/RPageStorage.hxx>
 #include <ROOT/RPageStorageFile.hxx>
 #include <ROOT/RRawFile.hxx>
@@ -85,6 +86,7 @@ using RPageAllocatorHeap = ROOT::Experimental::Detail::RPageAllocatorHeap;
 using RPageDeleter = ROOT::Experimental::Detail::RPageDeleter;
 using RPagePool = ROOT::Experimental::Detail::RPagePool;
 using RPageSink = ROOT::Experimental::Detail::RPageSink;
+using RPageSinkBuf = ROOT::Experimental::Detail::RPageSinkBuf;
 using RPageSinkFile = ROOT::Experimental::Detail::RPageSinkFile;
 using RPageSource = ROOT::Experimental::Detail::RPageSource;
 using RPageSourceFile = ROOT::Experimental::Detail::RPageSourceFile;


### PR DESCRIPTION
Implement a basic buffered page sink, to try and coalesce column page writes within a single cluster. The buffered sink `RPageSinkBuf` wraps another page sink, e.g. `RPageSinkFile` and buffers calls to the inner sink's `CommitPage` method.