### PR TITLE
[ntuple] Add RNTupleView range checks

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -226,7 +226,7 @@ public:
    std::string GetType() const { return fType; }
    ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }
-   NTupleSize_t GetNElements() const { return fPrincipalColumn->GetNElements(); }
+   NTupleSize_t GetNElements() const;
    RFieldBase *GetParent() const { return fParent; }
    std::vector<RFieldBase *> GetSubFields() const;
    bool IsSimple() const { return fIsSimple; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -182,13 +182,29 @@ public:
 
    RNTupleGlobalRange GetFieldRange() const { return RNTupleGlobalRange(0, fField.GetNElements()); }
 
+   /// Throws an exception if the index is out of bounds.
    template <typename C = T>
    typename std::enable_if_t<Internal::IsMappable<FieldT>::value, const C&>
-   operator()(NTupleSize_t globalIndex) { return *fField.Map(globalIndex); }
+   operator()(NTupleSize_t globalIndex) {
+      auto n_elts = fField.GetNElements();
+      if (globalIndex >= n_elts) {
+         throw RException(R__FAIL("index " + std::to_string(globalIndex) +
+            " out of bounds for field '" + fField.GetName() + "' with " +
+               std::to_string(n_elts) + ((n_elts == 1) ? " entry" : " entries")));
+      }
+      return *fField.Map(globalIndex);
+   }
 
+   /// Throws an exception if the index is out of bounds.
    template <typename C = T>
    typename std::enable_if_t<!Internal::IsMappable<FieldT>::value, const C&>
    operator()(NTupleSize_t globalIndex) {
+      auto n_elts = fField.GetNElements();
+      if (globalIndex >= n_elts) {
+         throw RException(R__FAIL("index " + std::to_string(globalIndex) +
+            " out of bounds for field '" + fField.GetName() + "' with " +
+               std::to_string(n_elts) + ((n_elts == 1) ? " entry" : " entries")));
+      }
       fField.Read(globalIndex, &fValue);
       return *fValue.Get<T>();
    }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -258,6 +258,17 @@ void ROOT::Experimental::Detail::RFieldBase::Attach(
    fSubFields.emplace_back(std::move(child));
 }
 
+ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RFieldBase::GetNElements() const {
+   if (fPrincipalColumn) {
+      return fPrincipalColumn->GetNElements();
+   }
+   // Class fields have subfields but no principal column
+   if (!fSubFields.empty()) {
+      return fSubFields[0]->GetNElements();
+   }
+   // otherwise, this field's columns have not been generated yet
+   return 0;
+}
 
 std::vector<ROOT::Experimental::Detail::RFieldBase *> ROOT::Experimental::Detail::RFieldBase::GetSubFields() const
 {

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -1,5 +1,13 @@
 #include "ntuple_test.hxx"
 
+TEST(RNTuple, ClassNElts) {
+   auto floatField = std::make_unique<RField<float>>("f32");
+   EXPECT_EQ(0, floatField->GetNElements());
+
+   auto classField = std::make_unique<RField<CustomStruct>>("klass");
+   EXPECT_EQ(0, classField->GetNElements());
+}
+
 TEST(RNTuple, ClassVector)
 {
    FileRaii fileGuard("test_ntuple_classvector.root");


### PR DESCRIPTION
Add range checks to `RNTupleView`'s indexing operators. Before this change out of bounds accesses were being caught by an internal assert (in `RPageStorageFile::PopulatePage`)
```cpp
   auto model = RNTupleModel::Create();
   auto fieldPt = model->MakeField<float>("pt", 42.0);
   {
      auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", path);
      ntuple->Fill();
      ntuple->Fill();
      // ntuple has 2 entries
   }
   auto ntuple = RNTupleReader::Open("myNTuple", path);
   auto viewPt = ntuple->GetView<float>("pt");
   std::cout << viewPt(2); // attempt to access the pt field at offset 2 
```

Before:
```
Fatal: clusterId != kInvalidDescriptorId violated at line 400 of `/home/max/projects/rootdev/root/tree/ntuple/v7/src/RPageStorageFile.cxx'
aborting
```

The assert location:
https://github.com/root-project/root/blob/a4b812bad84be0986ee416bbd65cf44527b92404/tree/ntuple/v7/src/RPageStorageFile.cxx#L391-L400

After this change we throw an exception like:
```
index 2 out of bounds for field 'pt' with 2 elements
```

This also required a change to `RFieldBase::GetNElements` to handle a few field corner cases: 
* before columns are generated
* class fields (which do not have a principal column)