### PR TITLE
[Tree] Expose tree utility functions for internal use

### DIFF
--- a/tree/tree/CMakeLists.txt
+++ b/tree/tree/CMakeLists.txt
@@ -66,8 +66,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Tree
     TTreeSQL.h
     TVirtualIndex.h
     TVirtualTreePlayer.h
+    ROOT/InternalTreeUtils.hxx
     ROOT/TIOFeatures.hxx
   SOURCES
+    src/InternalTreeUtils.cxx
     src/TBasket.cxx
     src/TBasketSQL.cxx
     src/TBranchBrowsable.cxx

--- a/tree/tree/inc/LinkDef.h
+++ b/tree/tree/inc/LinkDef.h
@@ -92,4 +92,6 @@
 #pragma read sourceClass="TTree" targetClass="TTree" version="[-16]" source="" target="fDefaultEntryOffsetLen" code="{ fDefaultEntryOffsetLen = 1000; }"
 #pragma read sourceClass="TTree" targetClass="TTree" version="[-18]" source="" target="fNClusterRange" code="{ fNClusterRange = 0; }"
 
+#pragma link C++ namespace ROOT::Internal::TreeUtils;
+
 #endif

--- a/tree/tree/inc/ROOT/InternalTreeUtils.hxx
+++ b/tree/tree/inc/ROOT/InternalTreeUtils.hxx
@@ -1,0 +1,68 @@
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/**
+ \file ROOT/InternalTreeUtils.hxx
+ \ingroup tree
+ \author Enric Tejedor Saavedra
+ \author Enrico Guiraud
+ \author Vincenzo Eduardo Padulano
+ \date 2021-03
+*/
+
+#ifndef ROOT_INTERNAL_TREEUTILS_H
+#define ROOT_INTERNAL_TREEUTILS_H
+
+#include <utility> // std::pair
+#include <vector>
+#include <string>
+
+class TTree;
+
+namespace ROOT {
+namespace Internal {
+/**
+\namespace ROOT::Internal::TreeUtils
+\ingroup tree
+\brief Namespace hosting functions and classes to retrieve tree information for internal use.
+*/
+namespace TreeUtils {
+
+using NameAlias = std::pair<std::string, std::string>; ///< A pair of name and alias of a TTree's friend tree.
+/**
+\struct ROOT::Internal::TreeUtils::RFriendInfo
+\brief Information about friend trees of a certain TTree or TChain object.
+\ingroup tree
+*/
+struct RFriendInfo {
+
+   std::vector<NameAlias> fFriendNames; ///< Pairs of names and aliases of friend trees/chains.
+   /**
+   Names of the files where each friend is stored. fFriendFileNames[i] is the
+   list of files for friend with name fFriendNames[i].
+   */
+   std::vector<std::vector<std::string>> fFriendFileNames;
+   /**
+      Names of the subtrees of a friend TChain. fFriendChainSubNames[i] is the
+      list of names of the trees that make a friend TChain whose information is
+      stored at fFriendNames[i] and fFriendFileNames[i]. If instead the friend
+      tree at position `i` is a TTree, fFriendChainSubNames[i] will be just a
+      vector with a single empty string.
+   */
+   std::vector<std::vector<std::string>> fFriendChainSubNames;
+};
+
+std::vector<std::string> GetFileNamesFromTree(const TTree &tree);
+RFriendInfo GetFriendInfo(const TTree &tree);
+std::vector<std::string> GetTreeFullPaths(const TTree &tree);
+
+} // namespace TreeUtils
+} // namespace Internal
+} // namespace ROOT
+
+#endif // ROOT_INTERNAL_TREEUTILS_H

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -1,0 +1,226 @@
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/InternalTreeUtils.hxx"
+#include "TTree.h"
+#include "TChain.h"
+#include "TFile.h"
+#include "TFriendElement.h"
+
+#include <utility> // std::pair
+#include <vector>
+#include <stdexcept> // std::runtime_error
+#include <string>
+
+namespace ROOT {
+namespace Internal {
+namespace TreeUtils {
+
+////////////////////////////////////////////////////////////////////////////////
+/// \fn std::vector<std::string> GetFileNamesFromTree(const TTree &tree)
+/// \ingroup tree
+/// \brief Get and store the file names associated with the input tree.
+/// \param[in] tree The tree from which friends information will be gathered.
+/// \throws std::runtime_error If no files could be associated with the input tree.
+std::vector<std::string> GetFileNamesFromTree(const TTree &tree)
+{
+   std::vector<std::string> filenames;
+
+   // If the input tree is a TChain, traverse its list of associated files.
+   if (auto chain = dynamic_cast<const TChain *>(&tree)) {
+      const auto *chainFiles = chain->GetListOfFiles();
+      if (!chainFiles) {
+         throw std::runtime_error("Could not retrieve a list of files from the input TChain.");
+      }
+      // Store this in a variable so it can be later used in `filenames.reserve`
+      // if it passes the check.
+      const auto nfiles = chainFiles->GetEntries();
+      if (nfiles == 0) {
+         throw std::runtime_error("The list of files associated with the input TChain is empty.");
+      }
+      filenames.reserve(nfiles);
+      for (const auto *f : *chainFiles)
+         filenames.emplace_back(f->GetTitle());
+   } else {
+      const TFile *f = tree.GetCurrentFile();
+      if (!f) {
+         throw std::runtime_error("The input TTree is not linked to any file, "
+                                  "in-memory-only trees are not supported.");
+      }
+
+      filenames.emplace_back(f->GetName());
+   }
+
+   return filenames;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \fn RFriendInfo GetFriendInfo(const TTree &tree)
+/// \ingroup tree
+/// \brief Get and store the names, aliases and file names of the direct friends of the tree.
+/// \param[in] tree The tree from which friends information will be gathered.
+/// \throws std::runtime_error If the input tree has a list of friends, but any
+///         of them could not be associated with any file.
+///
+/// Calls TTree::GetListOfFriends and parses its result for the names, aliases
+/// and file names, with different methodologies depending on whether the
+/// parameter is a TTree or a TChain.
+///
+/// \note This function only retrieves information about <b>direct friends</b>
+///       of the input tree. It will not recurse through friends of friends and
+///       does not take into account circular references in the list of friends
+///       of the input tree.
+///
+/// \returns An RFriendInfo struct, containing the information parsed from the
+/// list of friends. The struct will contain three vectors, which elements at
+/// position `i` represent the `i`-th friend of the input tree. If this friend
+/// is a TTree, the `i`-th element of each of the three vectors will contain
+/// respectively:
+/// - A pair with the name and alias of the tree (the alias might not be
+///   present, in which case it will be just an empty string).
+/// - A vector with a single string representing the path to current file where
+///   the tree is stored.
+/// - An empty vector.
+/// .
+/// If the `i`-th friend is a TChain instead, the `i`-th element of each of the
+/// three vectors will contain respectively:
+/// - A pair with the name and alias of the chain (if present, both might be
+///   empty strings).
+/// - A vector with all the paths to the files contained in the chain.
+/// - A vector with all the the names of the trees making up the chain,
+///   associated with the file names of the previous vector.
+RFriendInfo GetFriendInfo(const TTree &tree)
+{
+   std::vector<NameAlias> friendNames;
+   std::vector<std::vector<std::string>> friendFileNames;
+   std::vector<std::vector<std::string>> friendChainSubNames;
+
+   // Typically, the correct way to call GetListOfFriends would be `tree.GetTree()->GetListOfFriends()`
+   // (see e.g. the discussion at https://github.com/root-project/root/issues/6741).
+   // However, in this case, in case we are dealing with a TChain we really only care about the TChain's
+   // list of friends (which will need to be rebuilt in each processing task) while friends of the TChain's
+   // internal TTree, if any, will be automatically loaded in each task just like they would be automatically
+   // loaded here if we used tree.GetTree()->GetListOfFriends().
+   const auto *friends = tree.GetListOfFriends();
+   if (!friends)
+      return RFriendInfo();
+
+   for (auto fr : *friends) {
+      // Can't pass fr as const TObject* because TFriendElement::GetTree is not const.
+      // Also, we can't retrieve frTree as const TTree* because of TTree::GetFriendAlias(TTree *) a few lines later
+      auto frTree = static_cast<TFriendElement *>(fr)->GetTree();
+
+      // The vector of (name,alias) pairs of the current friend
+      friendFileNames.emplace_back();
+      auto &fileNames = friendFileNames.back();
+
+      // The vector of names of sub trees of the current friend, if it is a TChain.
+      // Otherwise, just an empty vector.
+      friendChainSubNames.emplace_back();
+      auto &chainSubNames = friendChainSubNames.back();
+
+      // Check if friend tree/chain has an alias
+      const auto *alias_c = tree.GetFriendAlias(frTree);
+      const std::string alias = alias_c != nullptr ? alias_c : "";
+
+      // If the current tree is a TChain
+      if (auto frChain = dynamic_cast<const TChain *>(frTree)) {
+         // Note that each TChainElement returned by TChain::GetListOfFiles has a name
+         // equal to the tree name of this TChain and a title equal to the filename.
+         // Accessing the information like this ensures that we get the correct
+         // filenames and treenames if the treename is given as part of the filename
+         // via chain.AddFile(file.root/myTree) and as well if the tree name is given
+         // in the constructor via TChain(myTree) and a file is added later by chain.AddFile(file.root).
+         // Caveat: The chain may be made of sub-trees with different names. All
+         // tree names need to be retrieved separately, see below.
+
+         // Get filelist of the current chain
+         const auto *chainFiles = frChain->GetListOfFiles();
+         if (!chainFiles || chainFiles->GetEntries() == 0) {
+            throw std::runtime_error("A TChain in the list of friends does not contain any file. "
+                                     "Friends with no associated files are not supported.");
+         }
+
+         // Retrieve the name of the chain and add a (name, alias) pair
+         friendNames.emplace_back(std::make_pair(frChain->GetName(), alias));
+         // Each file in the chain can contain a TTree with a different name wrt
+         // the main TChain. Retrieve the name of the file through `GetTitle`
+         // and the name of the tree through `GetName`
+         for (const auto *f : *chainFiles) {
+            chainSubNames.emplace_back(f->GetName());
+            fileNames.emplace_back(f->GetTitle());
+         }
+      } else {
+         // Get name of the tree
+         const auto realName = GetTreeFullPaths(*frTree)[0];
+         friendNames.emplace_back(std::make_pair(realName, alias));
+
+         // Get filename
+         const auto *f = frTree->GetCurrentFile();
+         if (!f)
+            throw std::runtime_error("A TTree in the list of friends is not linked to any file. "
+                                     "Friends with no associated files are not supported.");
+         fileNames.emplace_back(f->GetName());
+      }
+   }
+
+   return RFriendInfo{std::move(friendNames), std::move(friendFileNames), std::move(friendChainSubNames)};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \fn std::vector<std::string> GetTreeFullPaths(const TTree &tree)
+/// \ingroup tree
+/// \brief Retrieve the full path(s) to a TTree or the trees in a TChain.
+/// \param[in] tree The tree or chain from which the paths will be retrieved.
+/// \throws std::runtime_error If the input tree is a TChain but no files could
+///         be found associated with it.
+/// \return If the input argument is a TChain, returns a vector of strings with
+///         the name of the tree of each file in the chain. If the input
+///         argument is a TTree, returns a vector with a single element that is
+///         the full path of the tree in the file (e.g. the name of the tree
+///         itself or the path with the directories inside the file). Finally,
+///         the function returns a vector with just the name of the tree if it
+///         couldn't do any better.
+std::vector<std::string> GetTreeFullPaths(const TTree &tree)
+{
+   // Case 1: this is a TChain. For each file it contains, GetName returns the name of the tree in that file
+   if (auto chain = dynamic_cast<const TChain *>(&tree)) {
+      const auto *chainFiles = chain->GetListOfFiles();
+      if (!chainFiles || chainFiles->GetEntries() == 0) {
+         throw std::runtime_error("The input TChain does not contain any file.");
+      }
+      std::vector<std::string> treeNames;
+      for (const auto *f : *chainFiles)
+         treeNames.emplace_back(f->GetName());
+
+      return treeNames;
+   }
+
+   // Case 2: this is a TTree: we get the full path of it
+   if (const auto *treeDir = tree.GetDirectory()) {
+      // We have 2 subcases (ROOT-9948):
+      // - 1. treeDir is a TFile: return the name of the tree.
+      // - 2. treeDir is a directory: reconstruct the path to the tree in the directory.
+      // Use dynamic_cast to check whether the directory is a TFile
+      if (dynamic_cast<const TFile *>(treeDir)) {
+         return {tree.GetName()};
+      }
+      std::string fullPath = treeDir->GetPath();           // e.g. "file.root:/dir"
+      fullPath = fullPath.substr(fullPath.find(":/") + 1); // e.g. "/dir"
+      fullPath += "/";
+      fullPath += tree.GetName(); // e.g. "/dir/tree"
+      return {fullPath};
+   }
+
+   // We do our best and return the name of the tree
+   return {tree.GetName()};
+}
+
+} // namespace TreeUtils
+} // namespace Internal
+} // namespace ROOT

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -20,13 +20,12 @@
 #include "TTreeReader.h"
 #include "TError.h"
 #include "TEntryList.h"
-#include "TFriendElement.h"
 #include "ROOT/RMakeUnique.hxx"
 #include "ROOT/TThreadedObject.hxx"
 #include "ROOT/TThreadExecutor.hxx"
+#include "ROOT/InternalTreeUtils.hxx" // RFriendInfo
 
 #include <functional>
-#include <utility> // std::pair
 #include <vector>
 
 /** \class TTreeView
@@ -48,15 +47,6 @@ the threaded object.
 
 namespace ROOT {
 namespace Internal {
-/// Names, aliases, and file names of a TTree's or TChain's friends
-using NameAlias = std::pair<std::string, std::string>;
-struct FriendInfo {
-   /// Pairs of names and aliases of friend trees/chains
-   std::vector<Internal::NameAlias> fFriendNames;
-   /// Names of the files where each friend is stored. fFriendFileNames[i] is the list of files for friend with
-   /// name fFriendNames[i]
-   std::vector<std::vector<std::string>> fFriendFileNames;
-};
 
 class TTreeView {
 private:
@@ -67,7 +57,7 @@ private:
    std::unique_ptr<TChain> fChain;                ///< Chain on which to operate
 
    void MakeChain(const std::vector<std::string> &treeName, const std::vector<std::string> &fileNames,
-                  const FriendInfo &friendInfo, const std::vector<Long64_t> &nEntries,
+                  const TreeUtils::RFriendInfo &friendInfo, const std::vector<Long64_t> &nEntries,
                   const std::vector<std::vector<Long64_t>> &friendEntries);
 
 public:
@@ -75,7 +65,7 @@ public:
    // no-op, we don't want to copy the local TChains
    TTreeView(const TTreeView &) {}
    std::unique_ptr<TTreeReader> GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::string> &treeName,
-                                              const std::vector<std::string> &fileNames, const FriendInfo &friendInfo,
+                                              const std::vector<std::string> &fileNames, const TreeUtils::RFriendInfo &friendInfo,
                                               const TEntryList &entryList, const std::vector<Long64_t> &nEntries,
                                               const std::vector<std::vector<Long64_t>> &friendEntries);
 };
@@ -87,14 +77,13 @@ private:
    const std::vector<std::string> fTreeNames; ///< TTree names (always same size and ordering as fFileNames)
    /// User-defined selection of entry numbers to be processed, empty if none was provided
    TEntryList fEntryList;
-   const Internal::FriendInfo fFriendInfo;
+   const Internal::TreeUtils::RFriendInfo fFriendInfo;
    ROOT::TThreadExecutor fPool; ///<! Thread pool for processing.
 
    /// Thread-local TreeViews
    // Must be declared after fPool, for IMT to be initialized first!
    ROOT::TThreadedObject<ROOT::Internal::TTreeView> fTreeView{TNumSlots{ROOT::GetThreadPoolSize()}};
 
-   Internal::FriendInfo GetFriendInfo(TTree &tree);
    std::vector<std::string> FindTreeNames();
    static unsigned int fgMaxTasksPerFilePerWorker;
    static unsigned int fgTasksPerWorkerHint;

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -128,8 +128,8 @@ using ClustersAndEntries = std::pair<std::vector<std::vector<EntryCluster>>, std
 
 ////////////////////////////////////////////////////////////////////////
 /// Return a vector of cluster boundaries for the given tree and files.
-static ClustersAndEntries
-MakeClusters(const std::vector<std::string> &treeNames, const std::vector<std::string> &fileNames, const unsigned int maxTasksPerFile)
+static ClustersAndEntries MakeClusters(const std::vector<std::string> &treeNames,
+                                       const std::vector<std::string> &fileNames, const unsigned int maxTasksPerFile)
 {
    // Note that as a side-effect of opening all files that are going to be used in the
    // analysis once, all necessary streamers will be loaded into memory.
@@ -148,7 +148,7 @@ MakeClusters(const std::vector<std::string> &treeNames, const std::vector<std::s
          const auto msg = "TTreeProcessorMT::Process: an error occurred while opening file \"" + fileName + "\"";
          throw std::runtime_error(msg);
       }
-      auto *t = f->Get<TTree>(treeName.c_str());  // t will be deleted by f
+      auto *t = f->Get<TTree>(treeName.c_str()); // t will be deleted by f
 
       if (!t) {
          const auto msg = "TTreeProcessorMT::Process: an error occurred while getting tree \"" + treeName +
@@ -222,65 +222,50 @@ MakeClusters(const std::vector<std::string> &treeNames, const std::vector<std::s
 
 ////////////////////////////////////////////////////////////////////////
 /// Return a vector containing the number of entries of each file of each friend TChain
-static std::vector<std::vector<Long64_t>>
-GetFriendEntries(const std::vector<std::pair<std::string, std::string>> &friendNames,
-                 const std::vector<std::vector<std::string>> &friendFileNames)
+static std::vector<std::vector<Long64_t>> GetFriendEntries(const Internal::TreeUtils::RFriendInfo &friendInfo)
 {
+
+   const auto &friendNames = friendInfo.fFriendNames;
+   const auto &friendFileNames = friendInfo.fFriendFileNames;
+   const auto &friendChainSubNames = friendInfo.fFriendChainSubNames;
+
    std::vector<std::vector<Long64_t>> friendEntries;
    const auto nFriends = friendNames.size();
    for (auto i = 0u; i < nFriends; ++i) {
       std::vector<Long64_t> nEntries;
       const auto &thisFriendName = friendNames[i].first;
       const auto &thisFriendFiles = friendFileNames[i];
-      for (const auto &fname : thisFriendFiles) {
-         std::unique_ptr<TFile> f(TFile::Open(fname.c_str()));
-         TTree *t = nullptr; // owned by TFile
-         f->GetObject(thisFriendName.c_str(), t);
-         nEntries.emplace_back(t->GetEntries());
+      const auto &thisFriendChainSubNames = friendChainSubNames[i];
+      // If this friend has chain sub names, it means it's a TChain.
+      // In this case, we need to traverse all files that make up the TChain,
+      // retrieve the correct sub tree from each file and store the number of
+      // entries for that sub tree.
+      if (!thisFriendChainSubNames.empty()) {
+         // Traverse together filenames and respective treenames
+         for (auto fileidx = 0u; fileidx < thisFriendFiles.size(); ++fileidx) {
+            std::unique_ptr<TFile> curfile(TFile::Open(thisFriendFiles[fileidx].c_str()));
+            TTree *curtree = nullptr; // owned by TFile
+            // thisFriendChainSubNames[fileidx] stores the name of the current
+            // subtree in the TChain stored in the current file.
+            curfile->GetObject(thisFriendChainSubNames[fileidx].c_str(), curtree);
+            nEntries.emplace_back(curtree->GetEntries());
+         }
+         // Otherwise, if there are no sub names for the current friend, it means
+         // it's a TTree. We can safely use `thisFriendName` as the name of the tree
+         // to retrieve from the file in `thisFriendFiles`
+      } else {
+         for (const auto &fname : thisFriendFiles) {
+            std::unique_ptr<TFile> f(TFile::Open(fname.c_str()));
+            TTree *t = nullptr; // owned by TFile
+            f->GetObject(thisFriendName.c_str(), t);
+            nEntries.emplace_back(t->GetEntries());
+         }
       }
+      // Store the vector with entries for each file in the current tree/chain.
       friendEntries.emplace_back(std::move(nEntries));
    }
 
    return friendEntries;
-}
-
-////////////////////////////////////////////////////////////////////////
-/// Return the full path of the TTree or the trees in the TChain
-static std::vector<std::string> GetTreeFullPaths(const TTree &tree)
-{
-   // Case 1: this is a TChain. For each file it contains, GetName returns the name of the tree in that file
-   if (tree.IsA() == TChain::Class()) {
-      auto &chain = static_cast<const TChain &>(tree);
-      auto files = chain.GetListOfFiles();
-      if (!files || files->GetEntries() == 0) {
-         throw std::runtime_error("TTreeProcessorMT: input TChain does not contain any file");
-      }
-      std::vector<std::string> treeNames;
-      for (TObject *f : *files)
-         treeNames.emplace_back(f->GetName());
-
-      return treeNames;
-   }
-
-   // Case 2: this is a TTree: we get the full path of it
-   if (auto motherDir = tree.GetDirectory()) {
-      // We have 2 subcases (ROOT-9948):
-      // - 1. motherDir is a TFile
-      // - 2. motherDir is a directory
-      // If 1. we just return the name of the tree, if 2. we reconstruct the path
-      // to the file.
-      if (motherDir->InheritsFrom("TFile")) {
-         return {tree.GetName()};
-      }
-      std::string fullPath = motherDir->GetPath(); // e.g. "file.root:/dir"
-      fullPath = fullPath.substr(fullPath.find(":/") + 1); // e.g. "/dir"
-      fullPath += "/";
-      fullPath += tree.GetName(); // e.g. "/dir/tree"
-      return {fullPath};
-   }
-
-   // We do our best and return the name of the tree
-   return {tree.GetName()};
 }
 
 } // anonymous namespace
@@ -301,11 +286,13 @@ namespace Internal {
 /// \param[in] nEntries Number of entries to be processed.
 /// \param[in] friendEntries Number of entries in each friend. Expected to have same ordering as friendInfo.
 void TTreeView::MakeChain(const std::vector<std::string> &treeNames, const std::vector<std::string> &fileNames,
-                          const FriendInfo &friendInfo, const std::vector<Long64_t> &nEntries,
+                          const TreeUtils::RFriendInfo &friendInfo, const std::vector<Long64_t> &nEntries,
                           const std::vector<std::vector<Long64_t>> &friendEntries)
 {
-   const std::vector<NameAlias> &friendNames = friendInfo.fFriendNames;
-   const std::vector<std::vector<std::string>> &friendFileNames = friendInfo.fFriendFileNames;
+
+   const auto &friendNames = friendInfo.fFriendNames;
+   const auto &friendFileNames = friendInfo.fFriendFileNames;
+   const auto &friendChainSubNames = friendInfo.fFriendChainSubNames;
 
    fChain.reset(new TChain());
    const auto nFiles = fileNames.size();
@@ -317,18 +304,32 @@ void TTreeView::MakeChain(const std::vector<std::string> &treeNames, const std::
    fFriends.clear();
    const auto nFriends = friendNames.size();
    for (auto i = 0u; i < nFriends; ++i) {
-      const auto &friendName = friendNames[i];
-      const auto &name = friendName.first;
-      const auto &alias = friendName.second;
+      const auto &thisFriendNameAlias = friendNames[i];
+      const auto &thisFriendName = thisFriendNameAlias.first;
+      const auto &thisFriendAlias = thisFriendNameAlias.second;
+      const auto &thisFriendFiles = friendFileNames[i];
+      const auto &thisFriendChainSubNames = friendChainSubNames[i];
+      const auto &thisFriendEntries = friendEntries[i];
 
       // Build a friend chain
-      auto frChain = std::make_unique<TChain>(name.c_str());
+      auto frChain = std::make_unique<TChain>(thisFriendName.c_str());
       const auto nFileNames = friendFileNames[i].size();
-      for (auto j = 0u; j < nFileNames; ++j)
-         frChain->Add(friendFileNames[i][j].c_str(), friendEntries[i][j]);
+      // If there are no chain subnames, the friend was a TTree. It's safe
+      // to add to the chain the filename directly.
+      if (thisFriendChainSubNames.empty()) {
+         for (auto j = 0u; j < nFileNames; ++j) {
+            frChain->Add(thisFriendFiles[j].c_str(), thisFriendEntries[j]);
+         }
+         // Otherwise, the new friend chain needs to be built using the nomenclature
+         // "filename/treename" as argument to `TChain::Add`
+      } else {
+         for (auto j = 0u; j < nFileNames; ++j) {
+            frChain->Add((thisFriendFiles[j] + "/" + thisFriendChainSubNames[j]).c_str(), thisFriendEntries[j]);
+         }
+      }
 
       // Make it friends with the main chain
-      fChain->AddFriend(frChain.get(), alias.c_str());
+      fChain->AddFriend(frChain.get(), thisFriendAlias.c_str());
       fFriends.emplace_back(std::move(frChain));
    }
 }
@@ -337,7 +338,7 @@ void TTreeView::MakeChain(const std::vector<std::string> &treeNames, const std::
 /// Get a TTreeReader for the current tree of this view.
 std::unique_ptr<TTreeReader>
 TTreeView::GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::string> &treeNames,
-                         const std::vector<std::string> &fileNames, const FriendInfo &friendInfo,
+                         const std::vector<std::string> &fileNames, const TreeUtils::RFriendInfo &friendInfo,
                          const TEntryList &entryList, const std::vector<Long64_t> &nEntries,
                          const std::vector<std::vector<Long64_t>> &friendEntries)
 {
@@ -365,69 +366,6 @@ TTreeView::GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::st
 
 } // namespace Internal
 } // namespace ROOT
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get and store the names, aliases and file names of the friends of the tree.
-/// \param[in] tree The main tree whose friends to
-///
-/// Note that "friends of friends" and circular references in the lists of friends are not supported.
-Internal::FriendInfo TTreeProcessorMT::GetFriendInfo(TTree &tree)
-{
-   std::vector<Internal::NameAlias> friendNames;
-   std::vector<std::vector<std::string>> friendFileNames;
-
-   // Typically, the correct way to call GetListOfFriends would be `tree.GetTree()->GetListOfFriends()`
-   // (see e.g. the discussion at https://github.com/root-project/root/issues/6741).
-   // However, in this case, in case we are dealing with a TChain we really only care about the TChain's
-   // list of friends (which will need to be rebuilt in each processing task) while friends of the TChain's
-   // internal TTree, if any, will be automatically loaded in each task just like they would be automatically
-   // loaded here if we used tree.GetTree()->GetListOfFriends().
-   const auto friends = tree.GetListOfFriends();
-   if (!friends)
-      return Internal::FriendInfo();
-
-   for (auto fr : *friends) {
-      const auto frTree = static_cast<TFriendElement *>(fr)->GetTree();
-      const bool isChain = frTree->IsA() == TChain::Class();
-
-      friendFileNames.emplace_back();
-      auto &fileNames = friendFileNames.back();
-
-      // Check if friend tree/chain has an alias
-      const auto alias_c = tree.GetFriendAlias(frTree);
-      const std::string alias = alias_c != nullptr ? alias_c : "";
-
-      if (isChain) {
-         // Note that each TChainElement returned by chain.GetListOfFiles has a name
-         // equal to the tree name of this TChain and a title equal to the filename.
-         // Accessing the information like this ensures that we get the correct
-         // filenames and treenames if the treename is given as part of the filename
-         // via chain.AddFile(file.root/myTree) and as well if the tree name is given
-         // in the constructor via TChain(myTree) and a file is added later by chain.AddFile(file.root).
-
-         // Get name of the trees building the chain
-         const auto chainFiles = static_cast<TChain*>(frTree)->GetListOfFiles();
-         const auto realName = chainFiles->First()->GetName();
-         friendNames.emplace_back(std::make_pair(realName, alias));
-         // Get filenames stored in the title member
-         for (auto f : *chainFiles) {
-            fileNames.emplace_back(f->GetTitle());
-         }
-      } else {
-         // Get name of the tree
-         const auto realName = GetTreeFullPaths(*frTree)[0];
-         friendNames.emplace_back(std::make_pair(realName, alias));
-
-         // Get filename
-         const auto f = frTree->GetCurrentFile();
-         if (!f)
-            throw std::runtime_error("Friend trees with no associated file are not supported.");
-         fileNames.emplace_back(f->GetName());
-      }
-   }
-
-   return Internal::FriendInfo{std::move(friendNames), std::move(friendFileNames)};
-}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 /// Retrieve the names of the TTrees in each of the input files, throw if a TTree cannot be found.
@@ -506,32 +444,6 @@ TTreeProcessorMT::TTreeProcessorMT(const std::vector<std::string_view> &filename
    ROOT::EnableThreadSafety();
 }
 
-std::vector<std::string> GetFilesFromTree(TTree &tree)
-{
-   std::vector<std::string> filenames;
-
-   const bool isChain = tree.IsA() == TChain::Class();
-   if (isChain) {
-      TObjArray *filelist = static_cast<TChain &>(tree).GetListOfFiles();
-      const auto nFiles = filelist->GetEntries();
-      if (nFiles == 0)
-         throw std::runtime_error("The provided chain of files is empty");
-      filenames.reserve(nFiles);
-      for (auto f : *filelist)
-         filenames.emplace_back(f->GetTitle());
-   } else {
-      TFile *f = tree.GetCurrentFile();
-      if (!f) {
-         const auto msg = "The specified TTree is not linked to any file, in-memory-only trees are not supported.";
-         throw std::runtime_error(msg);
-      }
-
-      filenames.emplace_back(f->GetName());
-   }
-
-   return filenames;
-}
-
 ////////////////////////////////////////////////////////////////////////
 /// Constructor based on a TTree and a TEntryList.
 /// \param[in] tree Tree or chain of files containing the tree to process.
@@ -539,8 +451,9 @@ std::vector<std::string> GetFilesFromTree(TTree &tree)
 /// \param[in] nThreads Number of threads to create in the underlying thread-pool. The semantics of this argument are
 ///                     the same as for TThreadExecutor.
 TTreeProcessorMT::TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_t nThreads)
-   : fFileNames(GetFilesFromTree(tree)), fTreeNames(GetTreeFullPaths(tree)), fEntryList(entries),
-     fFriendInfo(GetFriendInfo(tree)), fPool(nThreads)
+   : fFileNames(Internal::TreeUtils::GetFileNamesFromTree(tree)),
+     fTreeNames(Internal::TreeUtils::GetTreeFullPaths(tree)), fEntryList(entries),
+     fFriendInfo(Internal::TreeUtils::GetFriendInfo(tree)), fPool(nThreads)
 {
    ROOT::EnableThreadSafety();
 }
@@ -550,9 +463,7 @@ TTreeProcessorMT::TTreeProcessorMT(TTree &tree, const TEntryList &entries, UInt_
 /// \param[in] tree Tree or chain of files containing the tree to process.
 /// \param[in] nThreads Number of threads to create in the underlying thread-pool. The semantics of this argument are
 ///                     the same as for TThreadExecutor.
-TTreeProcessorMT::TTreeProcessorMT(TTree &tree, UInt_t nThreads) : TTreeProcessorMT(tree, TEntryList(), nThreads)
-{
-}
+TTreeProcessorMT::TTreeProcessorMT(TTree &tree, UInt_t nThreads) : TTreeProcessorMT(tree, TEntryList(), nThreads) {}
 
 //////////////////////////////////////////////////////////////////////////////
 /// Process the entries of a TTree in parallel. The user-provided function
@@ -573,9 +484,6 @@ TTreeProcessorMT::TTreeProcessorMT(TTree &tree, UInt_t nThreads) : TTreeProcesso
 /// \param[in] func User-defined function that processes a subrange of entries
 void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
 {
-   const std::vector<Internal::NameAlias> &friendNames = fFriendInfo.fFriendNames;
-   const std::vector<std::vector<std::string>> &friendFileNames = fFriendInfo.fFriendFileNames;
-
    // compute number of tasks per file
    const unsigned int maxTasksPerFile =
       std::ceil(float(GetTasksPerWorkerHint() * fPool.GetPoolSize()) / float(fFileNames.size()));
@@ -585,7 +493,7 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    // Otherwise we can do it later, concurrently for each file, and clusters will contain local entry numbers.
    // TODO: in practice we could also find clusters per-file in the case of no friends and a TEntryList with
    // sub-entrylists.
-   const bool hasFriends = !friendNames.empty();
+   const bool hasFriends = !fFriendInfo.fFriendNames.empty();
    const bool hasEntryList = fEntryList.GetN() > 0;
    const bool shouldRetrieveAllClusters = hasFriends || hasEntryList;
    ClustersAndEntries clusterAndEntries{};
@@ -600,8 +508,7 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    const auto &entries = clusterAndEntries.second;
 
    // Retrieve number of entries for each file for each friend tree
-   const auto friendEntries =
-      hasFriends ? GetFriendEntries(friendNames, friendFileNames) : std::vector<std::vector<Long64_t>>{};
+   const auto friendEntries = hasFriends ? GetFriendEntries(fFriendInfo) : std::vector<std::vector<Long64_t>>{};
 
    // Parent task, spawns tasks that process each of the entry clusters for each input file
    // TODO: for readability we should have two versions of this lambda, for shouldRetrieveAllClusters == true/false


### PR DESCRIPTION
~~Bring utility functions from TTreeProcessorMT in their own inline namespace, to make them available for internal use in parallel algorithms.~~

### EDIT: 
After discussion it was decided that these functions are generic enough to be brought in `libTree` and given their own namespace for our internal use.