### PR TITLE
[cling] Set full target for Apple M1 [v6.22]

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1198,8 +1198,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     argvCompile.reserve(argc+32);
 
 #if __APPLE__ && __arm64__
-    argvCompile.push_back("-Xclang");
-    argvCompile.push_back("-triple=arm64-apple-macosx11.0.0");
+    argvCompile.push_back("--target=arm64-apple-darwin20.3.0");
 #endif
 
     // Variables for storing the memory of the C-string arguments.


### PR DESCRIPTION
The argument -Xclang -triple=... completely bypasses Clang's Driver
logic and only sets the triple in CC1. This suffices for most code
generation tasks, but the Driver cannot compute the correct ABI and
sets the generic AArch64 "aapcs" instead of the specific "darwinpcs".
In turn, this causes integer arguments with less than 32 bits not
being sign-extended but being passed directly, which for example
manifests as (short)-1 being read as 65535 on the callee side.

The new argument --target=arm64-apple-darwin20.3.0 matches what
Apple's and LLVM main's clang return for --print-target-triple.

Fixes #7090

(cherry picked from commit f75a7c464b8b3f49b4ad1ae0e536d139235863d2)