### PR TITLE
Backport: Dynamic Path: ROOT_LIBRARY_PATH

### DIFF
--- a/README/ReleaseNotes/v624/index.md
+++ b/README/ReleaseNotes/v624/index.md
@@ -40,6 +40,7 @@ The following people have contributed to this new version:
  Andrea Sciandra, SCIPP-UCSC/Atlas, \
  Oksana Shadura, UNL/CMS,\
  Enric Tejedor Saavedra, CERN/SFT,\
+ Christian Tacke, GSI, \
  Matevz Tadel, UCSD/CMS,\
  Vassil Vassilev, Princeton/CMS,\
  Wouter Verkerke, NIKHEF/Atlas,\
@@ -68,6 +69,20 @@ interfaces in recent TBB versions, as of v6.24 ROOT will not honor a maximum con
 Note that the preferred way to steer ROOT's concurrency level is still through `[ROOT::EnableImplicitMT](https://root.cern/doc/master/namespaceROOT.html#a06f2b8b216b615e5abbc872c9feff40f)` or by passing the appropriate parameter to executors' constructors, as in `[TThreadExecutor::TThreadExecutor](https://root.cern/doc/master/classROOT_1_1TThreadExecutor.html#ac7783d52c56cc7875d3954cf212247bb)`.
 
 See the discussion at [ROOT-11014](https://sft.its.cern.ch/jira/browse/ROOT-11014) for more context.
+
+### Dynamic Path: `ROOT_LIBRARY_PATH`
+
+A new way to set ROOT's "Dynamic Path" was added: the
+environment variable `ROOT_LIBRARY_PATH`.  On Unix it should contain a colon
+separated list of paths, on Windows a semicolon separated list. It is
+intended to be cross platform and to be specific to ROOT (and thus not
+interfere with the system's shared linker).
+The final "Dynamic Path" is now composed of these sources in order:
+1. `ROOT_LIBRARY_PATH` environment variable
+2. System specific shared linker environment variables like
+   `LD_LIBRARY_PATH`, `LIBPATH`, or `PATH`.
+3. Setting from rootrc
+4. ROOT's builtin library directory
 
 ### Interpreter
 - cling's LLVM is upgraded to version 9.0

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -4590,6 +4590,7 @@ static const char *DynamicPath(const char *newpath = 0, Bool_t reset = kFALSE)
       dynpath = newpath;
    } else if (reset || !initialized) {
       initialized = kTRUE;
+      dynpath = gSystem->Getenv("ROOT_LIBRARY_PATH");
       TString rdynpath = gEnv->GetValue("Root.DynamicPath", (char*)0);
       rdynpath.ReplaceAll(": ", ":");  // in case DynamicPath was extended
       if (rdynpath.IsNull()) {
@@ -4609,10 +4610,15 @@ static const char *DynamicPath(const char *newpath = 0, Bool_t reset = kFALSE)
 #else
       ldpath = gSystem->Getenv("LD_LIBRARY_PATH");
 #endif
-      if (ldpath.IsNull())
-         dynpath = rdynpath;
-      else {
-         dynpath = ldpath; dynpath += ":"; dynpath += rdynpath;
+      if (!ldpath.IsNull()) {
+         if (!dynpath.IsNull())
+            dynpath += ":";
+         dynpath += ldpath;
+      }
+      if (!rdynpath.IsNull()) {
+         if (!dynpath.IsNull())
+            dynpath += ":";
+         dynpath += rdynpath;
       }
       if (!dynpath.Contains(TROOT::GetLibDir())) {
          dynpath += ":"; dynpath += TROOT::GetLibDir();

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -358,24 +358,26 @@ namespace {
          dynpath = "";
       }
       if (newpath) {
-
          dynpath = newpath;
-
       } else if (dynpath == "") {
+         dynpath = gSystem->Getenv("ROOT_LIBRARY_PATH");
          TString rdynpath = gEnv ? gEnv->GetValue("Root.DynamicPath", (char*)0) : "";
          rdynpath.ReplaceAll("; ", ";");  // in case DynamicPath was extended
          if (rdynpath == "") {
             rdynpath = ".;"; rdynpath += TROOT::GetBinDir();
          }
          TString path = gSystem->Getenv("PATH");
-         if (path == "")
-            dynpath = rdynpath;
-         else {
-            dynpath = path; dynpath += ";"; dynpath += rdynpath;
+         if (!path.IsNull()) {
+            if (!dynpath.IsNull())
+               dynpath += ";";
+            dynpath += path;
          }
-
+         if (!rdynpath.IsNull()) {
+            if (!dynpath.IsNull())
+               dynpath += ";";
+            dynpath += rdynpath;
+         }
       }
-
       if (!dynpath.Contains(TROOT::GetLibDir())) {
          dynpath += ";"; dynpath += TROOT::GetLibDir();
       }


### PR DESCRIPTION
This is a backport of #7031 to the 6-24-00-patches branch.

I cherry-picked two of the three commits.
I left the test suite out, as it finally should go to roottest.git, as far as I understood it.

This is basically to get the thing started.

cc:  @pcanal, @dennisklein 