### PR TITLE
[cling] Better SFINAE check to print collection values

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
+++ b/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
@@ -155,7 +155,7 @@ namespace cling {
         const CollectionType* obj,
         typename std::enable_if<
             std::is_reference<decltype(*std::begin(*obj))>::value>::type* = 0)
-        -> decltype(std::begin(*obj), std::end(*obj), std::string()) {
+        -> decltype(std::end(*obj), std::string()) {
       auto iter = obj->begin(), iterEnd = obj->end();
       if (iter == iterEnd) return valuePrinterInternal::kEmptyCollection;
 

--- a/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
+++ b/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
@@ -154,8 +154,8 @@ namespace cling {
     inline auto printValue_impl(
         const CollectionType* obj,
         typename std::enable_if<
-            std::is_reference<decltype(*(obj->begin()))>::value>::type* = 0)
-        -> decltype(++(obj->begin()), obj->end(), std::string()) {
+            std::is_reference<decltype(*std::begin(*obj))>::value>::type* = 0)
+        -> decltype(std::begin(*obj), std::end(*obj), std::string()) {
       auto iter = obj->begin(), iterEnd = obj->end();
       if (iter == iterEnd) return valuePrinterInternal::kEmptyCollection;
 


### PR DESCRIPTION
In order to specialize cling's value-printing logic for collections
we perform some SFINAE checks. Among other things, the checks
asserts that `++(obj.begin())` is well-formed. That compiles for
`std::vector` and other collections with "fat" iterators, but does
not compile for collections that use raw pointers as iterators:

```cpp
auto beg(std::vector<int> &v) {
    return v.begin();
}

int *beg2(std::vector<int> &v) {
    return &v[0];
}

int main() {
    std::vector<int> v{1,2,3};
    beg(v) += 1;
    //beg2(v) += 1; // does not compile - beg2(v) is not an lvalue

    return 0;
}
```

Requiring instead `std::begin(obj)` to be well-formed should be
backward compatible and it should allow collections that use raw
pointers as iterators to also be pretty-printed by cling.

This fixes pretty-printing of RVec 2.0, i.e. the implementation based on LLVM's SmallVector, which uses raw pointers as iterators.