### PR TITLE
Refactor TFormula::Eval() to reduce code duplication

### DIFF
--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -190,10 +190,8 @@ public:
    Int_t          Compile(const char *expression="");
    virtual void   Copy(TObject &f1) const;
    virtual void   Clear(Option_t * option="");
-   Double_t       Eval(Double_t x) const;
-   Double_t       Eval(Double_t x, Double_t y) const;
-   Double_t       Eval(Double_t x, Double_t y , Double_t z) const;
-   Double_t       Eval(Double_t x, Double_t y , Double_t z , Double_t t ) const;
+   template <typename... Args>
+   Double_t       Eval(Args... args) const;
    Double_t       EvalPar(const Double_t *x, const Double_t *params=0) const;
 
    /// Generate gradient computation routine with respect to the parameters.
@@ -261,4 +259,19 @@ public:
 
    ClassDef(TFormula,13)
 };
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set first 1, 2, 3 or 4 variables (e.g. x, y, z and t)
+/// and evaluate formula.
+
+template <typename... Args>
+Double_t TFormula::Eval(Args... args) const 
+{
+   if (sizeof...(args) > 4) {
+      Error("Eval", "Eval() only support setting upto 4 variables");
+   }
+   double xxx[] = {static_cast<Double_t>(args)...};
+   return EvalPar(xxx, nullptr);
+};
+
 #endif

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -3273,42 +3273,6 @@ ROOT::Double_v TFormula::EvalParVec(const ROOT::Double_v *x, const Double_t *par
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Sets first 4  variables (e.g. x, y, z, t) and evaluate formula.
-
-Double_t TFormula::Eval(Double_t x, Double_t y, Double_t z, Double_t t) const
-{
-   double xxx[4] = {x,y,z,t};
-   return EvalPar(xxx, nullptr); // takes care of case where formula is vectorized
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Sets first 3  variables (e.g. x, y, z) and evaluate formula.
-
-Double_t TFormula::Eval(Double_t x, Double_t y , Double_t z) const
-{
-   double xxx[3] = {x,y,z};
-   return EvalPar(xxx, nullptr);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Sets first 2  variables (e.g. x and y) and evaluate formula.
-
-Double_t TFormula::Eval(Double_t x, Double_t y) const
-{
-   double xxx[2] = {x,y};
-   return EvalPar(xxx, nullptr);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Sets first variable (e.g. x) and evaluate formula.
-
-Double_t TFormula::Eval(Double_t x) const
-{
-   double * xxx = &x;
-   return EvalPar(xxx, nullptr);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Evaluate formula.
 /// If formula is not ready to execute(missing parameters/variables),
 /// print these which are not known.


### PR DESCRIPTION
This PR aims to reduce code duplication in `TFormula` class by replacing 4 overloaded `Eval` functions by one variadic template function.
We can also add an extra check to ensure all arguments passed to the template function are of arithmetic type. Please tell if I should add this extra check. 