### PR TITLE
[math] Fix inconsistent behaviour of TFormula parameter functions

### DIFF
--- a/core/foundation/inc/ROOT/TypeTraits.hxx
+++ b/core/foundation/inc/ROOT/TypeTraits.hxx
@@ -201,22 +201,6 @@ using InvokeResult_t = std::invoke_result_t<F, Args...>;
 using InvokeResult_t = std::result_of_t<F(Args...)>;
 #endif
 
-/// Checks whether all types in template parameter pack have
-/// static member value equal to true
-template <typename... Condition>
-struct And : std::true_type {};
-
-template <typename Condition, typename... RemainingConditions>
-struct And <Condition, RemainingConditions...> : std::conditional <Condition::value, 
-                                                          And <RemainingConditions...>,
-                                                          std::false_type>::type {};
-
-/// Checks whether all types in template parameter pack are arithmetic type,
-/// provides the static member constant value which is equal to true if 
-/// they are, otherwise value is equal to false.
-template <typename... Args>
-struct AllArithmetic : And<std::is_arithmetic<Args>...> {}; 
-
 } // ns TypeTraits
 } // ns ROOT
 #endif // ROOT_TTypeTraits

--- a/core/foundation/inc/ROOT/TypeTraits.hxx
+++ b/core/foundation/inc/ROOT/TypeTraits.hxx
@@ -201,6 +201,22 @@ using InvokeResult_t = std::invoke_result_t<F, Args...>;
 using InvokeResult_t = std::result_of_t<F(Args...)>;
 #endif
 
+/// Checks whether all types in template parameter pack have
+/// static member value equal to true
+template <typename... Condition>
+struct And : std::true_type {};
+
+template <typename Condition, typename... RemainingConditions>
+struct And <Condition, RemainingConditions...> : std::conditional <Condition::value, 
+                                                          And <RemainingConditions...>,
+                                                          std::false_type>::type {};
+
+/// Checks whether all types in template parameter pack are arithmetic type,
+/// provides the static member constant value which is equal to true if 
+/// they are, otherwise value is equal to false.
+template <typename... Args>
+struct AllArithmetic : And<std::is_arithmetic<Args>...> {}; 
+
 } // ns TypeTraits
 } // ns ROOT
 #endif // ROOT_TTypeTraits

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -36,6 +36,8 @@
 #include "Math/Types.h"
 #include "Math/ParamFunctor.h"
 
+#include <string>
+
 class TF1;
 class TH1;
 class TAxis;
@@ -109,9 +111,8 @@ public:
    {
       std::copy(params, params + fParameters.size(), fParameters.begin());
    }
-   void  SetParameters(Double_t p0, Double_t p1, Double_t p2 = 0, Double_t p3 = 0, Double_t p4 = 0,
-                       Double_t p5 = 0, Double_t p6 = 0, Double_t p7 = 0, Double_t p8 = 0,
-                       Double_t p9 = 0, Double_t p10 = 0);
+   template <typename... Args>
+   void   SetParameters(Double_t arg1, Args &&... args);
 
    void   SetParameter(const char *name, Double_t value)
    {
@@ -122,12 +123,8 @@ public:
       if (!CheckIndex(iparam)) return;
       fParNames[iparam] = std::string(name);
    }
-   void   SetParNames(const char *name0 = "p0", const char *name1 = "p1", const char *name2 = "p2",
-                      const char *name3 = "p3", const char *name4 = "p4", const char *name5 = "p5",
-                      const char *name6 = "p6", const char *name7 = "p7", const char *name8 = "p8",
-                      const char *name9 = "p9", const char *name10 = "p10");
-
-
+   template <typename... Args>
+   void   SetParNames(Args &&... args);
 
    ClassDef(TF1Parameters, 1)  // The Parameters of a parameteric function
 private:
@@ -140,6 +137,28 @@ private:
    std::vector<Double_t> fParameters;    // parameter values
    std::vector<std::string> fParNames;   // parameter names
 };
+
+/// Set parameter values.
+/// NaN values will be skipped, meaning that the corresponding parameters will not be changed.
+template <typename... Args>
+void TF1Parameters::SetParameters(Double_t arg1, Args &&...args)
+{
+   int i = 0;
+   for (double val : {arg1, static_cast<Double_t>(args)...}) {
+      if(!TMath::IsNaN(val)) SetParameter(i++, val);
+   }
+}
+
+/// Set parameter names.
+/// Empty strings will be skipped, meaning that the corresponding name will not be changed.
+template <typename... Args>
+void TF1Parameters::SetParNames(Args &&...args)
+{
+   int i = 0;
+   for (auto name : {static_cast<std::string const&>(args)...}) {
+      if(!name.empty()) SetParName(i++, name.c_str());
+   }
+}
 
 namespace ROOT {
    namespace Internal {
@@ -651,19 +670,27 @@ public:
       (fFormula) ? fFormula->SetParameters(params) : fParams->SetParameters(params);
       Update();
    }
-   virtual void     SetParameters(double p0, double p1 = 0.0, double p2 = 0.0, double p3 = 0.0, double p4 = 0.0,
-                                  double p5 = 0.0, double p6 = 0.0, double p7 = 0.0, double p8 = 0.0,
-                                  double p9 = 0.0, double p10 = 0.0)
+   /// Set parameter values.
+   /// NaN values will be skipped, meaning that the corresponding parameters will not be changed.
+   virtual void SetParameters(double p0, double p1 = TMath::QuietNaN(), double p2 = TMath::QuietNaN(),
+                              double p3 = TMath::QuietNaN(), double p4 = TMath::QuietNaN(), double p5 = TMath::QuietNaN(),
+                              double p6 = TMath::QuietNaN(), double p7 = TMath::QuietNaN(), double p8 = TMath::QuietNaN(),
+                              double p9 = TMath::QuietNaN(), double p10 = TMath::QuietNaN())
    {
+      // Note: this is not made a variadic template method because it would
+      // presumably break the context menu in the TBrowser. Also, probably this
+      // method should not be virtual, because if the user wants to change
+      // parameter setting behavior, the SetParameter() method can be
+      // overridden.
       if (fFormula) fFormula->SetParameters(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
       else          fParams->SetParameters(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
       Update();
    } // *MENU*
    virtual void     SetParName(Int_t ipar, const char *name);
-   virtual void     SetParNames(const char *name0 = "p0", const char *name1 = "p1", const char *name2 = "p2",
-                                const char *name3 = "p3", const char *name4 = "p4", const char *name5 = "p5",
-                                const char *name6 = "p6", const char *name7 = "p7", const char *name8 = "p8",
-                                const char *name9 = "p9", const char *name10 = "p10"); // *MENU*
+   virtual void     SetParNames(const char *name0 = "", const char *name1 = "", const char *name2 = "",
+                                const char *name3 = "", const char *name4 = "", const char *name5 = "",
+                                const char *name6 = "", const char *name7 = "", const char *name8 = "",
+                                const char *name9 = "", const char *name10 = ""); // *MENU*
    virtual void     SetParError(Int_t ipar, Double_t error);
    virtual void     SetParErrors(const Double_t *errors);
    virtual void     SetParLimits(Int_t ipar, Double_t parmin, Double_t parmax);

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3455,11 +3455,17 @@ void TF1::SetParName(Int_t ipar, const char *name)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set up to 10 parameter names
+/// Set up to 10 parameter names.
+/// Empty strings will be skipped, meaning that the corresponding name will not be changed.
 
 void TF1::SetParNames(const char *name0, const char *name1, const char *name2, const char *name3, const char *name4,
                       const char *name5, const char *name6, const char *name7, const char *name8, const char *name9, const char *name10)
 {
+   // Note: this is not made a variadic template method because it would
+   // presumably break the context menu in the TBrowser. Also, probably this
+   // method should not be virtual, because if the user wants to change
+   // parameter name setting behavior, the SetParName() method can be
+   // overridden.
    if (fFormula)
       fFormula->SetParNames(name0, name1, name2, name3, name4, name5, name6, name7, name8, name9, name10);
    else
@@ -3812,46 +3818,4 @@ Int_t TF1Parameters::GetParNumber(const char *name) const
       if (fParNames[i] == std::string(name)) return i;
    }
    return -1;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set parameter values
-
-void  TF1Parameters::SetParameters(Double_t p0, Double_t p1, Double_t p2, Double_t p3, Double_t p4,
-                                   Double_t p5, Double_t p6, Double_t p7, Double_t p8,
-                                   Double_t p9, Double_t p10)
-{
-   unsigned int npar = fParameters.size();
-   if (npar > 0) fParameters[0] = p0;
-   if (npar > 1) fParameters[1] = p1;
-   if (npar > 2) fParameters[2] = p2;
-   if (npar > 3) fParameters[3] = p3;
-   if (npar > 4) fParameters[4] = p4;
-   if (npar > 5) fParameters[5] = p5;
-   if (npar > 6) fParameters[6] = p6;
-   if (npar > 7) fParameters[7] = p7;
-   if (npar > 8) fParameters[8] = p8;
-   if (npar > 9) fParameters[9] = p9;
-   if (npar > 10) fParameters[10] = p10;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set parameter names
-
-void TF1Parameters::SetParNames(const char *name0, const char *name1, const char *name2, const char *name3,
-                                const char *name4, const char *name5, const char *name6, const char *name7,
-                                const char *name8, const char *name9, const char *name10)
-{
-   unsigned int npar = fParNames.size();
-   if (npar > 0) fParNames[0] = name0;
-   if (npar > 1) fParNames[1] = name1;
-   if (npar > 2) fParNames[2] = name2;
-   if (npar > 3) fParNames[3] = name3;
-   if (npar > 4) fParNames[4] = name4;
-   if (npar > 5) fParNames[5] = name5;
-   if (npar > 6) fParNames[6] = name6;
-   if (npar > 7) fParNames[7] = name7;
-   if (npar > 8) fParNames[8] = name8;
-   if (npar > 9) fParNames[9] = name9;
-   if (npar > 10) fParNames[10] = name10;
 }

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -2974,27 +2974,6 @@ void TFormula::SetParameters(const Double_t *params)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set a list of parameters.
-/// The order is by default the alphabetic order given to the parameters
-/// apart if the users has defined explicitly the parameter names
-
-void TFormula::SetParameters(Double_t p0, Double_t p1, Double_t p2, Double_t p3, Double_t p4, Double_t p5, Double_t p6,
-                             Double_t p7, Double_t p8, Double_t p9, Double_t p10)
-{
-   if(fNpar >= 1) SetParameter(0,p0);
-   if(fNpar >= 2) SetParameter(1,p1);
-   if(fNpar >= 3) SetParameter(2,p2);
-   if(fNpar >= 4) SetParameter(3,p3);
-   if(fNpar >= 5) SetParameter(4,p4);
-   if(fNpar >= 6) SetParameter(5,p5);
-   if(fNpar >= 7) SetParameter(6,p6);
-   if(fNpar >= 8) SetParameter(7,p7);
-   if(fNpar >= 9) SetParameter(8,p8);
-   if(fNpar >= 10) SetParameter(9,p9);
-   if(fNpar >= 11) SetParameter(10,p10);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Set a parameter given a parameter index
 /// The parameter index is by default the alphabetic order given to the parameters
 /// apart if the users has defined explicitly the parameter names
@@ -3006,35 +2985,6 @@ void TFormula::SetParameter(Int_t param, Double_t value)
    fClingParameters[param] = value;
    // TString name = TString::Format("%d",param);
    // SetParameter(name,value);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void TFormula::SetParNames(const char *name0, const char *name1, const char *name2, const char *name3,
-                           const char *name4, const char *name5, const char *name6, const char *name7,
-                           const char *name8, const char *name9, const char *name10)
-{
-   if (fNpar >= 1)
-      SetParName(0, name0);
-   if (fNpar >= 2)
-      SetParName(1, name1);
-   if (fNpar >= 3)
-      SetParName(2, name2);
-   if (fNpar >= 4)
-      SetParName(3, name3);
-   if (fNpar >= 5)
-      SetParName(4, name4);
-   if (fNpar >= 6)
-      SetParName(5, name5);
-   if (fNpar >= 7)
-      SetParName(6, name6);
-   if (fNpar >= 8)
-      SetParName(7, name7);
-   if (fNpar >= 9)
-      SetParName(8, name8);
-   if (fNpar >= 10)
-      SetParName(9, name9);
-   if (fNpar >= 11)
-      SetParName(10, name10);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -12,7 +12,6 @@
 #include "TROOT.h"
 #include "TBuffer.h"
 #include "TMethod.h"
-#include "TMath.h"
 #include "TF1.h"
 #include "TMethodCall.h"
 #include <TBenchmark.h>
@@ -25,7 +24,6 @@
 #include "ROOT/StringUtils.hxx"
 
 #include <array>
-#include <cassert>
 #include <iostream>
 #include <unordered_map>
 #include <functional>
@@ -2974,9 +2972,9 @@ void TFormula::SetParameters(const Double_t *params)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set a parameter given a parameter index
-/// The parameter index is by default the alphabetic order given to the parameters
-/// apart if the users has defined explicitly the parameter names
+/// Set a parameter given a parameter index.
+/// The parameter index is by default the alphabetic order given to the parameters,
+/// apart if the users has defined explicitly the parameter names.
 
 void TFormula::SetParameter(Int_t param, Double_t value)
 {


### PR DESCRIPTION
This PR aims to fix the problem of inconsistency in `TFormula::SetParNames()` and `TFormula::SetParameters()` functions as described in #7805.

I have added warning if more values are provided than the actual number of parameters of `TFormula` object, original behaviour of the function is maintained apart from the added warning.

Some test will fail due to the added warning, please tell if I should remove the warning or resolve the root cause of the warnings ( For instance, `TF1` using `TFormula::SetParameters()` and always passing 11 arguments is one cause of failing tests) 

I would also like to slightly modify behaviour of these functions such that value and names of only specified parameters should be changed, current behaviour is to reset the value and names of parameters which aren't specified, but this change may negatively impact programs using these functions. But still, I think this change will make these functions more intuitive. Please tell if I should add this change. 

This PR fixes #7805