### PR TITLE
Backport in 6.24 of Fix the Warning of evaluating RooAddPdf without a normalization set

### DIFF
--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -82,6 +82,8 @@ public:
   const RooArgSet& getCoefNormalization() const { return _refCoefNorm ; }
   const char* getCoefRange() const { return _refCoefRangeName?RooNameReg::str(_refCoefRangeName):"" ; }
 
+  virtual Double_t getValV(const RooArgSet *set = 0) const;
+  
   virtual void resetErrorCounters(Int_t resetValue=10) ;
 
   virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ; 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -95,6 +95,7 @@ for single nodes.
 #include "RooVectorDataStore.h"
 #include "RooTreeDataStore.h"
 #include "ROOT/RMakeUnique.hxx"
+#include "RooHelpers.h"
 
 #include <iostream>
 #include <fstream>
@@ -2026,6 +2027,9 @@ void RooAbsArg::graphVizTree(ostream& os, const char* delimiter, bool useTitle, 
   if (!os) {
     coutE(InputArguments) << "RooAbsArg::graphVizTree() ERROR: output stream provided as input argument is in invalid state" << endl ;
   }
+
+  // silent warning messages coming when evaluating a RooAddPdf without a normalization set
+  RooHelpers::LocalChangeMsgLevel locmsg(RooFit::WARNING, 0u, RooFit::Eval, false);
 
   // Write header
   os << "digraph \"" << GetName() << "\"{" << endl ;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1941,6 +1941,9 @@ RooAbsReal* RooAbsPdf::createChi2(RooDataSet& data, const RooLinkedList& cmdList
 
 void RooAbsPdf::printValue(ostream& os) const
 {
+  // silent warning messages coming when evaluating a RooAddPdf without a normalization set
+  RooHelpers::LocalChangeMsgLevel locmsg(RooFit::WARNING, 0u, RooFit::Eval, false);
+
   getVal() ;
 
   if (_norm) {

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -47,6 +47,9 @@ integration is performed in the various implementations of the RooAbsIntegrator 
 #include "RooConstVar.h"
 #include "RooDouble.h"
 #include "RooTrace.h"
+#include "RooHelpers.h"
+
+#include "ROOT/RMakeUnique.hxx"
 
 #include "TClass.h"
 
@@ -428,9 +431,21 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
     oocxcoutI(&function,Integration) << function.GetName() << ": Function integrated observables " << _anaList << " internally with code " << _mode << endl ;
   }
 
+  // when _funcNormSet is a nullptr a warning message appears for RooAddPdf functions
+  // This is not a problem since we do noty use the returned value from getVal()
+  // we then disable the produced warning message in the RooFit::Eval topic
+  std::unique_ptr<RooHelpers::LocalChangeMsgLevel> msgChanger;
+  if (_funcNormSet == nullptr) {
+     // remove only the RooFit::Eval message topic from current active streams
+     // passed level can be whatever if we provide a false as last argument   
+     msgChanger = std::make_unique<RooHelpers::LocalChangeMsgLevel>(RooFit::WARNING, 0u, RooFit::Eval, false);
+  }
 
   // WVE kludge: synchronize dset for use in analyticalIntegral
+  // LM : is this really needed ??
   function.getVal(_funcNormSet) ;
+  // delete LocalChangeMsgLevel which will restore previous message level
+  msgChanger.reset(nullptr); 
 
   // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
   // * F) Make list of numerical integration variables consisting of:            *  
@@ -1149,5 +1164,3 @@ Int_t RooRealIntegral::getCacheAllNumeric()
 {
   return _cacheAllNDim ;
 }
-
-


### PR DESCRIPTION
Backport of #7750

Add an implementation of getValV for RooAddPdf to use stored normalization set by default when the pdf is evaluated without passing a set.

Disable printing of warning message of evaluating un-normalized RooAddPdf when doing:
- Call getVal in constructor of RooRealIntegral (not sure why this is needed)
- printValue of any RooAbsPdf, where getVal(0) is also called
- RooAbsArg::graphVizTree where also getVal(0) is called when exporting the tree in a graphVizTree

This avoids having un-needed warning messages when printing or examing RooWorkspaces or pdf's