### PR TITLE
[RF] Check if ranges are not overlapping in multi-range fit

### DIFF
--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -26,6 +26,9 @@
 #include <string>
 #include <utility>
 
+class RooAbsPdf;
+class RooAbsData;
+
 
 namespace RooHelpers {
 
@@ -94,7 +97,7 @@ std::vector<std::string> tokenise(const std::string &str, const std::string &del
 /// Check if the parameters have a range, and warn if the range extends below / above the set limits.
 void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_list<const RooAbsReal*> pars,
     double min = -std::numeric_limits<double>::max(), double max = std::numeric_limits<double>::max(),
-    bool limitsInAllowedRange = false, std::string extraMessage = "");
+    bool limitsInAllowedRange = false, std::string const& extraMessage = "");
 
 
 /// Disable all caches for sub-branches in an expression tree.
@@ -116,6 +119,7 @@ struct DisableCachingRAII {
 
 std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const char* rangeName);
 
+bool checkIfRangesOverlap(RooAbsPdf const& pdf, RooAbsData const& data, std::vector<std::string> const& rangeNames);
 
 }
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -94,6 +94,7 @@ For the inverse conversion, see `RooAbsData::convertToVectorStore()`.
 #include "RooTrace.h"
 #include "RooHelpers.h"
 
+#include "Math/Util.h"
 #include "TTree.h"
 #include "TH2.h"
 #include "TFile.h"
@@ -1064,26 +1065,6 @@ const RooArgSet* RooDataSet::get(Int_t index) const
 Double_t RooDataSet::sumEntries() const 
 {
   return store()->sumEntries() ;
-  
-  //---------
-
-  // Shortcut for unweighted unselected datasets
-  if (!isWeighted()) {
-    return numEntries() ;
-  }
-
-  // Otherwise sum the weights in the event
-  Double_t sumw(0), carry(0);
-  Int_t i ;
-  for (i=0 ; i<numEntries() ; i++) {
-    get(i) ;
-    Double_t y = weight() - carry;
-    Double_t t = sumw + y;
-    carry = (t - sumw) - y;
-    sumw = t;
-  }  
-
-  return sumw ;  
 }
 
 
@@ -1094,9 +1075,9 @@ Double_t RooDataSet::sumEntries() const
 Double_t RooDataSet::sumEntries(const char* cutSpec, const char* cutRange) const 
 {
   // Setup RooFormulaVar for cutSpec if it is present
-  RooFormula* select = 0 ;
+  std::unique_ptr<RooFormula> select = nullptr ;
   if (cutSpec && strlen(cutSpec) > 0) {
-    select = new RooFormula("select",cutSpec,*get()) ;
+    select = std::make_unique<RooFormula>("select",cutSpec,*get()) ;
   }
   
   // Shortcut for unweighted unselected datasets
@@ -1105,21 +1086,15 @@ Double_t RooDataSet::sumEntries(const char* cutSpec, const char* cutRange) const
   }
 
   // Otherwise sum the weights in the event
-  Double_t sumw(0), carry(0);
-  Int_t i ;
-  for (i=0 ; i<numEntries() ; i++) {
+  ROOT::Math::KahanSum<double> sumw{0.0};
+  for (int i = 0 ; i<numEntries() ; i++) {
     get(i) ;
     if (select && select->eval()==0.) continue ;
     if (cutRange && !_vars.allInRange(cutRange)) continue ;
-    Double_t y = weight() - carry;
-    Double_t t = sumw + y;
-    carry = (t - sumw) - y;
-    sumw = t;
+    sumw += weight();
   }
 
-  if (select) delete select ;
-
-  return sumw ;  
+  return sumw.Sum() ;
 }
 
 

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -15,6 +15,10 @@
  *****************************************************************************/
 
 #include "RooHelpers.h"
+#include "RooAbsPdf.h"
+#include "RooAbsData.h"
+#include "RooDataHist.h"
+#include "RooDataSet.h"
 #include "RooAbsRealLValue.h"
 
 #include "TClass.h"
@@ -115,7 +119,7 @@ HijackMessageStream::~HijackMessageStream() {
 /// \param[in] limitsInAllowedRange If true, the limits passed as parameters are part of the allowed range.
 /// \param[in] extraMessage Message that should be appended to the warning.
 void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_list<const RooAbsReal*> pars,
-    double min, double max, bool limitsInAllowedRange, std::string extraMessage) {
+    double min, double max, bool limitsInAllowedRange, std::string const& extraMessage) {
   const char openBr = limitsInAllowedRange ? '[' : '(';
   const char closeBr = limitsInAllowedRange ? ']' : ')';
 
@@ -145,6 +149,17 @@ void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_lis
 }
 
 
+namespace {
+  std::pair<double, double> getBinningInterval(RooAbsBinning const& binning) {
+    if (!binning.isParameterized()) {
+      return {binning.lowBound(), binning.highBound()};
+    } else {
+      return {binning.lowBoundFunc()->getVal(), binning.highBoundFunc()->getVal()};
+    }
+  }
+} // namespace
+
+
 /// Get the lower and upper bound of parameter range if arg can be casted to RooAbsRealLValue.
 /// If no range with rangeName is defined for the argument, this will check if a binning of the
 /// same name exists and return the interval covered by the binning.
@@ -155,18 +170,79 @@ void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_lis
 std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const char* rangeName) {
   auto rlv = dynamic_cast<RooAbsRealLValue const*>(arg);
   if (rlv) {
-    const RooAbsBinning* binning = rlv->getBinningPtr(rangeName);
     if (rangeName && rlv->hasRange(rangeName)) {
       return {rlv->getMin(rangeName), rlv->getMax(rangeName)};
-    } else if (binning) {
-      if (!binning->isParameterized()) {
-        return {binning->lowBound(), binning->highBound()};
-      } else {
-        return {binning->lowBoundFunc()->getVal(), binning->highBoundFunc()->getVal()};
-      }
+    } else if (auto binning = rlv->getBinningPtr(rangeName)) {
+      return getBinningInterval(*binning);
     }
   }
   return {-std::numeric_limits<double>::infinity(), +std::numeric_limits<double>::infinity()};
+}
+
+
+/// Check if there is any overlap when a list of ranges is applied to a set of observables.
+/// \param[in] arg RooAbsCollection with the observables to check for overlap.
+/// \param[in] rangeName The names of the ranges.
+bool checkIfRangesOverlap(RooAbsPdf const& pdf, RooAbsData const& data, std::vector<std::string> const& rangeNames) {
+
+  auto observables = *pdf.getObservables(data);
+
+  auto getLimits = [&](RooAbsRealLValue const& rlv, const char* rangeName) {
+    
+    // RooDataHistCase
+    if(dynamic_cast<RooDataHist const*>(&data)) {
+      if (auto binning = rlv.getBinningPtr(rangeName)) {
+        return getBinningInterval(*binning);
+      } else {
+        // default binning if range is not defined
+        return getBinningInterval(*rlv.getBinningPtr(nullptr));
+      }
+    }
+
+    // RooDataSet and other cases
+    if (rlv.hasRange(rangeName)) {
+      return std::pair<double, double>{rlv.getMin(rangeName), rlv.getMax(rangeName)};
+    }
+    // default range if range with given name is not defined
+    return std::pair<double, double>{rlv.getMin(), rlv.getMax()};
+  };
+
+  auto nObs = observables.size();
+  auto nRanges = rangeNames.size();
+
+  // cache the range limits in a flat vector
+  std::vector<std::pair<double,double>> limits;
+  limits.reserve(nRanges * nObs);
+
+  for (auto const& range : rangeNames) {
+    for (auto const& obs : observables) {
+      auto rlv = dynamic_cast<RooAbsRealLValue const*>(obs);
+      if(!rlv) {
+        throw std::logic_error("Classes that represent observables are expected to inherit from RooAbsRealLValue!");
+      }
+      limits.push_back(getLimits(*rlv, range.c_str()));
+    }
+  }
+
+  // loop over pairs of ranges
+  for(size_t ir1 = 0; ir1 < nRanges; ++ir1) {
+    for(size_t ir2 = ir1 + 1; ir2 < nRanges; ++ir2) {
+
+      // Loop over observables. If all observables have overlapping limits for
+      // these ranges, the hypercubes defining the range are overlapping and we
+      // can return `true`.
+      size_t overlaps = 0;
+      for(size_t io1 = 0; io1 < nObs; ++io1) {
+        auto r1 = limits[ir1 * nObs + io1];
+        auto r2 = limits[ir2 * nObs + io1];
+        overlaps += (r1.second > r2.first && r1.first < r2.second)
+                 || (r2.second > r1.first && r2.first < r1.second);
+      }
+      if(overlaps == nObs) return true;
+    }
+  }
+
+  return false;
 }
 
 


### PR DESCRIPTION
Events are double counted if one accidentally defines overlapping ranges
and uses them in a multi-range fit. This happened for example in Jira
issue ROOT-9548 where the whole dataset was double counted, leading to
the parameter uncertainties being underestimated by a factor of sqrt(2).
    
That situation should be avoided. This commit introduces a check for
overlapping ranges before the multi-range likelihood is created.

Confusing situations such as reported in [ROOT-9548](https://sft.its.cern.ch/jira/browse/ROOT-9548) are avoided now.