### PR TITLE
Update the ROOT file layout documentation with a correction, ROOT 3 -> 6 changes, and more detail.

### DIFF
--- a/io/doc/TFile/TDirectory.txt
+++ b/io/doc/TFile/TDirectory.txt
@@ -1,3 +1,41 @@
+// Format of a TDirectory record in release 6.22.06.  It is never compressed.
+//
+// If the SeekKeys or SeekPdir in the TKey are located past the 32 bit file limit (> 2000000000),
+// then these fields will be 8 instead of 4 bytes and 1000 is added to the TKey Version.
+//
+// If the SeekDir, SeekParent, or SeekKeys in the TDirectory header are past the 32 bit file limit,
+// then these fields will be 8 instead of 4 bytes and 1000 is added to the TDirectory Version.
+// ----------TKey--------------
+//  byte 0->3           Nbytes    = Number of bytes in compressed record (Tkey+data)           TKey::fNbytes
+//       4->5           Version   = TKey class version identifier                              TKey::fVersion
+//       6->9           ObjLen    = Number of bytes of uncompressed data                       TKey::fObjLen
+//      10->13          Datime    = Date and time when record was written to file              TKey::fDatime
+//                                | (year-1995)<<26|month<<22|day<<17|hour<<12|minute<<6|second
+//      14->15          KeyLen    = Number of bytes in key structure (TKey)                    TKey::fKeyLen
+//      16->17          Cycle     = Cycle of key                                               TKey::fCycle
+//      18->21 [18->25] SeekKey   = Byte offset of record itself (consistency check)           TKey::fSeekKey
+//      22->25 [26->33] SeekPdir  = Byte offset of parent directory record                     TKey::fSeekPdir
+//      26->26 [33->33] lname     = Number of bytes in the class name (10)                     TKey::fClassName
+//      27->.. [34->..] ClassName = Object Class Name ("TDirectory")                           TKey::fClassName
+//       0->0           lname     = Number of bytes in the object name                         TNamed::fName
+//       1->..          Name      = lName bytes with the name of the object <directory name>   TNamed::fName
+//       0->0           lTitle    = Number of bytes in the object title                        TNamed::fTitle
+//       1->..          Title     = lTitle bytes with the title of the object <direcory title> TNamed::fTitle
+// --------DATA----------------
+//       0->1           Version   = TDirectory class version identifier                        TDirectory::Class_Version()
+//       2->5           DatimeC   = Date and time when directory was created                   TDirectory::fDatimeC
+//                                | (year-1995)<<26|month<<22|day<<17|hour<<12|minute<<6|second
+//       6->9           DatimeM   = Date and time when directory was last modified             TDirectory::fDatimeM
+//                                | (year-1995)<<26|month<<22|day<<17|hour<<12|minute<<6|second
+//      10->13          NbytesKeys= Number of bytes in the associated KeysList record          TDirectory::fNbyteskeys
+//      14->17          NbytesName= Number of bytes in TKey+TNamed at creation                 TDirectory::fNbytesName
+//      18->21 [18->25] SeekDir   = Byte offset of directory record in file                    TDirectory::fSeekDir
+//      22->25 [26->33] SeekParent= Byte offset of parent directory record in file             TDirectory::fSeekParent
+//      26->29 [34->41] SeekKeys  = Byte offset of associated KeysList record in file          TDirectory::fSeekKeys
+//      30->31 [42->43] UUID vers = TUUID class version identifier                             TUUID::Class_Version()
+//      32->47 [44->59] UUID      = Universally Unique Identifier                              TUUID::fTimeLow through fNode[6]
+//      48->59          Extra space to allow SeekKeys to become 64 bit without moving this header
+
 //  Format of a TDirectory record in release 3.02.06.  It is never compressed.
 // ----------TKey--------------
 //  byte 0->3  Nbytes    = Number of bytes in compressed record (Tkey+data)           TKey::fNbytes

--- a/io/doc/TFile/TFile.txt
+++ b/io/doc/TFile/TFile.txt
@@ -1,7 +1,13 @@
-// A ROOT file is a suite of consecutive data records (TKey's) with
-// the following format (see also the TKey class). If the key is
-// located past the 32 bit file limit (> 2 GB) then some fields will
-// be 8 instead of 4 bytes:
+// Format of the root (first) directory record in release 6.22.06.  It is never compressed.
+//
+// This directory record differs from subdirectories (see TDirectory.txt) in the additional
+// Name and Title at the beginning of the DATA (after the TKey).
+//
+// If the SeekKeys or SeekPdir in the TKey are located past the 32 bit file limit (> 2000000000),
+// then these fields will be 8 instead of 4 bytes and 1000 is added to the TKey Version.
+//
+// If the SeekDir, SeekParent, or SeekKeys in the TDirectory header are past the 32 bit file limit,
+// then these fields will be 8 instead of 4 bytes and 1000 is added to the TDirectory Version.
 // ----------TKey---------------
 //  byte 0->3           Nbytes    = Number of bytes compressed record (TKey+data)          TKey::fNbytes
 //       4->5           Version   = TKey class version identifier                          TKey::fVersion
@@ -23,8 +29,7 @@
 //       1->.. Name      = lName bytes with the name of the TFile <file name>              TNamed::fName
 //       0->0           lTitle    = Number of bytes in the TFile title                     TNamed::fTitle
 //       1->..          Title     = lTitle bytes with the title of the TFile <file title>  TNamed::fTitle
-//       0->0           Modified  = True if directory has been modified                    TDirectory::fModified
-//       1->1           Writable = True if directory is writable                           TDirectory::fWriteable
+//       0->1           Version   = TDirectory class version identifier                    TDirectory::Class_Version()
 //       2->5           DatimeC   = Date and time when directory was created               TDirectory::fDatimeC
 //                       | (year-1995)<<26|month<<22|day<<17|hour<<12|minute<<6|second
 //       6->9           DatimeM   = Date and time when directory was last modified         TDirectory::fDatimeM

--- a/io/doc/TFile/freesegments.txt
+++ b/io/doc/TFile/freesegments.txt
@@ -1,24 +1,31 @@
-//Format of FreeSegments record, release 3.02.06.  It is never compressed.
-//It is probably not accessed by its key, but from its offset given in the file header.
+// Format of FreeSegments record, release 6.22.06.  It is never compressed.
+// It is probably not accessed by its key, but from its offset given in the file header.
+//
+// If any *individual* free segments refer to bytes beyond 2000000000,
+// their fFirst/fLast have 8 bytes, not 4 and 1000 is added to the TFree Version.
+//
+// Some free segment records may be 32 bit while others are 64 bit.
 // ----------TKey---------------
-//  byte 0->3  Nbytes    = Number of bytes in compressed record (TKey+data)       TKey::fNbytes
-//       4->5  Version   = TKey class version identifier                          TKey::fVersion
-//       6->9  ObjLen    = Number of bytes of uncompressed data                   TKey::fObjLen
-//      10->13 Datime    = Date and time when record was written to file          TKey::fDatime
-//                       | (year-1995)<<26|month<<22|day<<17|hour<<12|minute<<6|second
-//      14->15 KeyLen    = Number of bytes in key structure  (TKey)               TKey::fKeyLen
-//      16->17 Cycle     = Cycle of key                                           TKey::fCycle
-//      18->21 SeekKey   = Byte offset of record itself (consistency check)       TKey::fSeekKey
-//      22->25 SeekPdir  = Byte offset of parent directory record (TFile)         TKey::fSeekPdir
-//      26->26 lname     = Number of bytes in the class name (5)                  TKey::fClassName
-//      27->.. ClassName = Object Class Name ("TFile")                            TKey::fClassName
-//       0->0  lname     = Number of bytes in the object name                     TNamed::fName
-//       1->.. Name      = lName bytes with the name of the object <file name>    TNamed::fName
-//       0->0  lTitle    = Number of bytes in the object title                    TNamed::fTitle
-//       1->.. Title     = lTitle bytes with the title of the object <file title> TNamed::fTitle
+//  byte 0->3           Nbytes    = Number of bytes in compressed record (TKey+data)       TKey::fNbytes
+//       4->5           Version   = TKey class version identifier                          TKey::fVersion
+//       6->9           ObjLen    = Number of bytes of uncompressed data                   TKey::fObjLen
+//      10->13          Datime    = Date and time when record was written to file          TKey::fDatime
+//                                | (year-1995)<<26|month<<22|day<<17|hour<<12|minute<<6|second
+//      14->15          KeyLen    = Number of bytes in key structure  (TKey)               TKey::fKeyLen
+//      16->17          Cycle     = Cycle of key                                           TKey::fCycle
+//      18->21 [18->25] SeekKey   = Byte offset of record itself (consistency check)       TKey::fSeekKey
+//      22->25 [26->33] SeekPdir  = Byte offset of parent directory record (TFile)         TKey::fSeekPdir
+//      26->26 [34->34] lname     = Number of bytes in the class name (5)                  TKey::fClassName
+//      27->.. [35->..] ClassName = Object Class Name ("TFile")                            TKey::fClassName
+//       0->0           lname     = Number of bytes in the object name                     TNamed::fName
+//       1->..          Name      = lName bytes with the name of the object <file name>    TNamed::fName
+//       0->0           lTitle    = Number of bytes in the object title                    TNamed::fTitle
+//       1->..          Title     = lTitle bytes with the title of the object <file title> TNamed::fTitle
 // ----------DATA---------------
-//       0->1  Version   = TFree class version identifier                         TFree::Class_Version()
-//       2->5  fFirst    = First free byte of first free segment                  TFree::fFirst
-//       6->9  fLast     = Byte after last free byte of first free segment        TFree::fLast
-//       ....  Sequentially, Version, fFirst and fLast of additional free segments.
-//       ....  There is always one free segment beginning at file end and ending before 2000000000.
+//       0->1           Version   = TFree class version identifier                         TFree::Class_Version()
+//       2->5  [ 2-> 9] fFirst    = First free byte of first free segment                  TFree::fFirst
+//       6->9  [10->17] fLast     = Last free byte of first free segment (inclusive)       TFree::fLast
+//                                  (e.g. a free segment that is 1 byte long would have fFirst == fLast)
+//       ....           Sequentially, Version, fFirst and fLast of additional free segments.
+//       ....           There is always one free segment beginning at file end and ending before 2000000000.
+//       ....           If the file size is larger than 2000000000, the last segment ends with 4000000000.

--- a/io/doc/TFile/header.txt
+++ b/io/doc/TFile/header.txt
@@ -1,3 +1,26 @@
+// Here is the file header format as of release 6.22.06.  It is never compressed.
+//
+// If END, SeekFree, or SeekInfo are located past the 32 bit file limit (> 2000000000)
+// then these fields will be 8 instead of 4 bytes and 1000000 is added to the flie format version.
+// -----------------------------------
+// byte  0->3  "root"               = Identifies this file as a ROOT file.
+//       4->7  Version              = File format version                         TFile::fVersion
+//                                  |  (10000*major+100*minor+cycle (e.g. 62206 for 6.22.06))
+//       8->11          BEGIN       = Byte offset of first data record (100)      TFile::fBEGIN
+//      12->15 [12->19] END         = Pointer to first free word at the EOF       TFile::fEND
+//                                  | (will be == to file size in bytes)
+//      16->19 [20->27] SeekFree    = Byte offset of FreeSegments record          TFile::fSeekFree
+//      20->23 [28->31] NbytesFree  = Number of bytes in FreeSegments record      TFile::fNBytesFree
+//      24->27 [32->35] nfree       = Number of free data records
+//      28->31 [36->39] NbytesName  = Number of bytes in TKey+TNamed for TFile at creation TDirectory::fNbytesName
+//      32->32 [40->40] Units       = Number of bytes for file pointers (4)       TFile::fUnits
+//      33->36 [41->44] Compress    = Zip compression level (i.e. 0-9)            TFile::fCompress
+//      37->40 [45->52] SeekInfo    = Byte offset of StreamerInfo record          TFile::fSeekInfo
+//      41->44 [53->56] NbytesInfo  = Number of bytes in StreamerInfo record      TFile::fNbytesInfo
+//      45->46 [57->58] UUID vers   = TUUID class version identifier              TUUID::Class_Version()
+//      47->62 [59->74] UUID        = Universally Unique Identifier               TUUID::fTimeLow through fNode[6]
+//      63->99 [75->99] Extra space to allow END, SeekFree, or SeekInfo to become 64 bit without moving this header
+
 // Here is the file header format as of release 3.02.06.  It is never compressed.
 // -----------------------------------
 // byte  0->3  "root"      = Identifies this file as a ROOT file.


### PR DESCRIPTION
The io/doc/TFile directory (from 2009!) can be used as a descriptive specification, but there are a few points to fix:

   * an off-by-one error in the freesegments.txt file (description of `fLast`)
   * a likely change in the interpretation of the first two bytes of a TDirectory header, from two bools (`Modified` and `Writable`) to a version (`TDirectory::Class_Version()`, which is now `5`)
   * some missing indicators of how 32-bit values expand into 64-bit values.

This PR only addresses the files that it modifies: header.txt, TFile.txt, TDirectory.txt, and freesegments.txt. In cases where I think the format might have changed, I left the original text in the file. If I'm wrong about that, the original text can be deleted.

To demonstrate the way TDirectory works now (no `Modified` and `Writable` booleans), the following script creates a file with a few objects and a subdirectory, then interprets its raw bytes to show that the first two bytes of both root directory and subdirectory are `5`, [in agreement with the current class version](https://github.com/root-project/root/blob/df70fffe7e759f35e281f7e52dc81297c0458bfb/core/base/inc/TDirectory.h#L278).

Here's the script (Python 3.6+), and below it is sample output.

```python
import datetime
import struct
import uuid

import ROOT

file = ROOT.TFile("sample.root", "recreate")
x = ROOT.TObjString("one")
x.Write()
file.mkdir("subdir")
file.cd("subdir")
y = ROOT.TObjString("two")
y.Write()
file.Close()


def datime(number):
    return datetime.datetime(
        ((number & 0b11111100000000000000000000000000) >> 26) + 1995,
        ((number & 0b00000011110000000000000000000000) >> 22),
        ((number & 0b00000000001111100000000000000000) >> 17),
        ((number & 0b00000000000000011111000000000000) >> 12),
        ((number & 0b00000000000000000000111111000000) >> 6),
        ((number & 0b00000000000000000000000000111111)),
    )


file = open("sample.root", "rb")

(
    magic,
    fVersion,
    fBEGIN,
    fEND,
    fSeekFree,
    fNbytesFree,
    nfree,
    fNbytesName,
    fUnits,
    fCompress,
    fSeekInfo,
    fNbytesInfo,
    fUUID_version,
    fUUID,
) = struct.unpack(">4siiiiiiiBiiiH16s", file.read(63))
print(f"""The ROOT file header:
{magic = }
{fVersion = }
{fBEGIN = }
{fEND = }
{fSeekFree = }
{fNbytesFree = }
{nfree = }
{fNbytesName = }
{fUnits = }
{fCompress = }
{fSeekInfo = }
{fNbytesInfo = }
{fUUID_version = }
{uuid.UUID(bytes=fUUID) = }

The rest of the header up to fBEGIN:
{file.read(fBEGIN - 63) = }
{file.tell() = }""")

(
    fNbytes,
    fVersion,
    fObjlen,
    fDatime,
    fKeylen,
    fCycle,
    fSeekKey,
    fSeekPdir,
) = struct.unpack(">ihiIhhii", file.read(26))
print(f"""
The TKey before the root directory:
{fNbytes = }
{fVersion = }
{fObjlen = }
{datime(fDatime) = }
{fKeylen = }
{fCycle = }
{fSeekKey = }
{fSeekPdir = }
fClassName = {file.read(ord(file.read(1)))}
fName = {file.read(ord(file.read(1)))}
fTitle = {file.read(ord(file.read(1)))}""")

print(f"""
Then the root directory has two TNamed strings that subdirectories don't have:
fName (again) = {file.read(ord(file.read(1)))}
fTitle (again) = {file.read(ord(file.read(1)))}""")

(
    fVersion,
    fDatimeC,
    fDatimeM,
    fNbytesKeys,
    fNbytesName,
    fSeekDir,
    fSeekParent,
    fSeekKeys,
) = struct.unpack(">hIIiiiii", file.read(30))
print(f"""
The TDirectory header doesn't have modified/writable bools, but it does have a version:
{fVersion = }
{datime(fDatimeC) = }
{datime(fDatimeM) = }
{fNbytesKeys = }
{fNbytesName = }
{fSeekDir = }
{fSeekParent = }
{fSeekKeys = }

and it also has a TUUID, not in the original documentation:
uuid_version = {struct.unpack(">H", file.read(2))[0]}
uuid = {uuid.UUID(bytes=file.read(16))!r}

It also has some space to grow, in case fSeekDir/fSeekParent/fSeekKeys are 64-bit:
12 extra bytes = {file.read(12)}

Now we've reached the fNbytes that the TKey promised:
{fSeekKey + fNbytes = } and {file.tell() = }

From here, we have to follow fSeekKeys to find the directory listing:
{file.seek(fSeekKeys) = }""")

(
    fNbytes,
    fVersion,
    fObjlen,
    fDatime,
    fKeylen,
    fCycle,
    fSeekKey,
    fSeekPdir,
) = struct.unpack(">ihiIhhii", file.read(26))
print(f"""
Here's the TKey before the directory listing:
{fNbytes = }
{fVersion = }
{fObjlen = }
{datime(fDatime) = }
{fKeylen = }
{fCycle = }
{fSeekKey = }
{fSeekPdir = }
fClassName = {file.read(ord(file.read(1)))}
fName = {file.read(ord(file.read(1)))}
fTitle = {file.read(ord(file.read(1)))}""")

list_of_keys_fNbytes, list_of_keys_fSeekKey = fNbytes, fSeekKey

num_keys = struct.unpack(">I", file.read(4))[0]
print(f"""
And now the listing itself starts with a number of keys:
{num_keys = }""")

for _ in range(num_keys):
    (
        fNbytes,
        fVersion,
        fObjlen,
        fDatime,
        fKeylen,
        fCycle,
        fSeekKey,
        fSeekPdir,
    ) = struct.unpack(">ihiIhhii", file.read(26))
    print(f"""
    TKey for an object in this directory:
    {fNbytes = }
    {fVersion = }
    {fObjlen = }
    {datime(fDatime) = }
    {fKeylen = }
    {fCycle = }
    {fSeekKey = }
    {fSeekPdir = }
    fClassName = {file.read(ord(file.read(1)))}
    fName = {file.read(ord(file.read(1)))}
    fTitle = {file.read(ord(file.read(1)))}""")

print(f"""
Now we're at the end of the list of keys.
{list_of_keys_fSeekKey + list_of_keys_fNbytes = } {file.tell() = }

Let's follow the last key, which goes to a subdirectory:
{file.seek(fSeekKey) = }""")

(
    fNbytes,
    fVersion,
    fObjlen,
    fDatime,
    fKeylen,
    fCycle,
    fSeekKey,
    fSeekPdir,
) = struct.unpack(">ihiIhhii", file.read(26))
print(f"""
Just like the root directory, there's a TKey before the TDirectory header:
{fNbytes = }
{fVersion = }
{fObjlen = }
{datime(fDatime) = }
{fKeylen = }
{fCycle = }
{fSeekKey = }
{fSeekPdir = }
fClassName = {file.read(ord(file.read(1)))}
fName = {file.read(ord(file.read(1)))}
fTitle = {file.read(ord(file.read(1)))}

But now we don't have an extra fName/fTitle from TNamed.
That was only in the root directory.""")

(
    fVersion,
    fDatimeC,
    fDatimeM,
    fNbytesKeys,
    fNbytesName,
    fSeekDir,
    fSeekParent,
    fSeekKeys,
) = struct.unpack(">hIIiiiii", file.read(30))
print(f"""
The TDirectory header follows.
Other than lacking the extra fName/fTitle, it's just like the root directory:
{fVersion = }
{datime(fDatimeC) = }
{datime(fDatimeM) = }
{fNbytesKeys = }
{fNbytesName = }
{fSeekDir = }
{fSeekParent = }
{fSeekKeys = }
uuid_version = {struct.unpack(">H", file.read(2))[0]}
uuid = {uuid.UUID(bytes=file.read(16))!r}

Including the extra space to grow for 64-bit fSeekDir/fSeekParent/fSeekKeys:
12 extra bytes = {file.read(12)}

Now we've reached the fNbytes that the TKey promised:
{fSeekKey + fNbytes = } and {file.tell() = }

For completeness, let's go to the subdirectories list of keys:
{file.seek(fSeekKeys) = }""")

(
    fNbytes,
    fVersion,
    fObjlen,
    fDatime,
    fKeylen,
    fCycle,
    fSeekKey,
    fSeekPdir,
) = struct.unpack(">ihiIhhii", file.read(26))
print(f"""
Here's the TKey before the subdirectory listing:
{fNbytes = }
{fVersion = }
{fObjlen = }
{datime(fDatime) = }
{fKeylen = }
{fCycle = }
{fSeekKey = }
{fSeekPdir = }
fClassName = {file.read(ord(file.read(1)))}
fName = {file.read(ord(file.read(1)))}
fTitle = {file.read(ord(file.read(1)))}""")

list_of_keys_fNbytes, list_of_keys_fSeekKey = fNbytes, fSeekKey

num_keys = struct.unpack(">I", file.read(4))[0]
print(f"""
Here's the number of keys in the subdirectory:
{num_keys = }""")

for _ in range(num_keys):
    (
        fNbytes,
        fVersion,
        fObjlen,
        fDatime,
        fKeylen,
        fCycle,
        fSeekKey,
        fSeekPdir,
    ) = struct.unpack(">ihiIhhii", file.read(26))
    print(f"""
    TKey for an object in this subdirectory:
    {fNbytes = }
    {fVersion = }
    {fObjlen = }
    {datime(fDatime) = }
    {fKeylen = }
    {fCycle = }
    {fSeekKey = }
    {fSeekPdir = }
    fClassName = {file.read(ord(file.read(1)))}
    fName = {file.read(ord(file.read(1)))}
    fTitle = {file.read(ord(file.read(1)))}""")

print(f"""
Now we're at the end of the list of keys.
{list_of_keys_fSeekKey + list_of_keys_fNbytes = } {file.tell() = }""")
```

Here is the output.

```
The ROOT file header:
magic = b'root'
fVersion = 62206
fBEGIN = 100
fEND = 1124
fSeekFree = 1069
fNbytesFree = 55
nfree = 1
fNbytesName = 58
fUnits = 4
fCompress = 101
fSeekInfo = 501
fNbytesInfo = 281
fUUID_version = 1
uuid.UUID(bytes=fUUID) = UUID('b856ad48-9983-11eb-8a1a-d201a8c0beef')

The rest of the header up to fBEGIN:
file.read(fBEGIN - 63) = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
file.tell() = 100

The TKey before the root directory:
fNbytes = 118
fVersion = 4
fObjlen = 73
datime(fDatime) = datetime.datetime(2021, 4, 9, 17, 34, 17)
fKeylen = 45
fCycle = 1
fSeekKey = 100
fSeekPdir = 0
fClassName = b'TFile'
fName = b'sample.root'
fTitle = b''

Then the root directory has two TNamed strings that subdirectories don't have:
fName (again) = b'sample.root'
fTitle (again) = b''

The TDirectory header doesn't have modified/writable bools, but it does have a version:
fVersion = 5
datime(fDatimeC) = datetime.datetime(2021, 4, 9, 17, 34, 17)
datime(fDatimeM) = datetime.datetime(2021, 4, 9, 17, 34, 17)
fNbytesKeys = 166
fNbytesName = 58
fSeekDir = 100
fSeekParent = 0
fSeekKeys = 782

and it also has a TUUID, not in the original documentation:
uuid_version = 1
uuid = UUID('b856ad48-9983-11eb-8a1a-d201a8c0beef')

It also has some space to grow, in case fSeekDir/fSeekParent/fSeekKeys are 64-bit:
12 extra bytes = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'

Now we've reached the fNbytes that the TKey promised:
fSeekKey + fNbytes = 218 and file.tell() = 218

From here, we have to follow fSeekKeys to find the directory listing:
file.seek(fSeekKeys) = 782

Here's the TKey before the directory listing:
fNbytes = 166
fVersion = 4
fObjlen = 121
datime(fDatime) = datetime.datetime(2021, 4, 9, 17, 34, 17)
fKeylen = 45
fCycle = 1
fSeekKey = 782
fSeekPdir = 100
fClassName = b'TFile'
fName = b'sample.root'
fTitle = b''

And now the listing itself starts with a number of keys:
num_keys = 2

    TKey for an object in this directory:
    fNbytes = 86
    fVersion = 4
    fObjlen = 20
    datime(fDatime) = datetime.datetime(2021, 4, 9, 17, 34, 17)
    fKeylen = 66
    fCycle = 1
    fSeekKey = 218
    fSeekPdir = 100
    fClassName = b'TObjString'
    fName = b'one'
    fTitle = b'Collectable string class'

    TKey for an object in this directory:
    fNbytes = 111
    fVersion = 4
    fObjlen = 60
    datime(fDatime) = datetime.datetime(2021, 4, 9, 17, 34, 17)
    fKeylen = 51
    fCycle = 1
    fSeekKey = 304
    fSeekPdir = 100
    fClassName = b'TDirectory'
    fName = b'subdir'
    fTitle = b'subdir'

Now we're at the end of the list of keys.
list_of_keys_fSeekKey + list_of_keys_fNbytes = 948 file.tell() = 948

Let's follow the last key, which goes to a subdirectory:
file.seek(fSeekKey) = 304

Just like the root directory, there's a TKey before the TDirectory header:
fNbytes = 111
fVersion = 4
fObjlen = 60
datime(fDatime) = datetime.datetime(2021, 4, 9, 17, 34, 17)
fKeylen = 51
fCycle = 1
fSeekKey = 304
fSeekPdir = 100
fClassName = b'TDirectory'
fName = b'subdir'
fTitle = b'subdir'

But now we don't have an extra fName/fTitle from TNamed.
That was only in the root directory.

The TDirectory header follows.
Other than lacking the extra fName/fTitle, it's just like the root directory:
fVersion = 5
datime(fDatimeC) = datetime.datetime(2021, 4, 9, 17, 34, 17)
datime(fDatimeM) = datetime.datetime(2021, 4, 9, 17, 34, 17)
fNbytesKeys = 121
fNbytesName = 51
fSeekDir = 304
fSeekParent = 100
fSeekKeys = 948
uuid_version = 1
uuid = UUID('b85a2f9a-9983-11eb-8a1a-d201a8c0beef')

Including the extra space to grow for 64-bit fSeekDir/fSeekParent/fSeekKeys:
12 extra bytes = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'

Now we've reached the fNbytes that the TKey promised:
fSeekKey + fNbytes = 415 and file.tell() = 415

For completeness, let's go to the subdirectories list of keys:
file.seek(fSeekKeys) = 948

Here's the TKey before the subdirectory listing:
fNbytes = 121
fVersion = 4
fObjlen = 70
datime(fDatime) = datetime.datetime(2021, 4, 9, 17, 34, 17)
fKeylen = 51
fCycle = 1
fSeekKey = 948
fSeekPdir = 304
fClassName = b'TDirectory'
fName = b'subdir'
fTitle = b'subdir'

Here's the number of keys in the subdirectory:
num_keys = 1

    TKey for an object in this subdirectory:
    fNbytes = 86
    fVersion = 4
    fObjlen = 20
    datime(fDatime) = datetime.datetime(2021, 4, 9, 17, 34, 17)
    fKeylen = 66
    fCycle = 1
    fSeekKey = 415
    fSeekPdir = 304
    fClassName = b'TObjString'
    fName = b'two'
    fTitle = b'Collectable string class'

Now we're at the end of the list of keys.
list_of_keys_fSeekKey + list_of_keys_fNbytes = 1069 file.tell() = 1069
```