### PR TITLE
[RF] Remove usage of RooNameSet and use helper functions instead

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -146,7 +146,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooMultiGenFunction.h
     RooMultiVarGaussian.h
     RooNameReg.h
-    RooNameSet.h
     RooNLLVar.h
     RooNormSetCache.h
     RooNumber.h
@@ -229,6 +228,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooBinSamplingPdf.h
     RooFitLegacy/RooCatTypeLegacy.h
     RooFitLegacy/RooCategorySharedProperties.h
+    RooFitLegacy/RooNameSet.h
     RooFitLegacy/RooTreeData.h
   SOURCES
     src/BidirMMapPipe.cxx
@@ -363,7 +363,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooMultiGenFunction.cxx
     src/RooMultiVarGaussian.cxx
     src/RooNameReg.cxx
-    src/RooNameSet.cxx
     src/RooNLLVar.cxx
     src/RooNormSetCache.cxx
     src/RooNumber.cxx
@@ -443,6 +442,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooFitLegacy/RooCatTypeLegacy.cxx
     src/RooFitLegacy/RooCategorySharedProperties.cxx
     src/RooFitLegacy/RooMultiCatIter.cxx
+    src/RooFitLegacy/RooNameSet.cxx
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
   LIBRARIES

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -17,8 +17,6 @@
 #define ROO_ABS_PDF
 
 #include "RooAbsReal.h"
-//#include "RooRealIntegral.h"
-#include "RooNameSet.h"
 #include "RooObjCacheManager.h"
 #include "RooCmdArg.h"
 

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -21,7 +21,6 @@
 #include "RooSetProxy.h"
 #include "RooAICRegistry.h"
 #include "RooNormSetCache.h"
-#include "RooNameSet.h"
 #include "RooObjCacheManager.h"
 
 class RooAddModel : public RooResolutionModel {

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -21,7 +21,6 @@
 #include "RooSetProxy.h"
 #include "RooAICRegistry.h"
 #include "RooNormSetCache.h"
-#include "RooNameSet.h"
 #include "RooObjCacheManager.h"
 #include "RooNameReg.h"
 

--- a/roofit/roofitcore/inc/RooCacheManager.h
+++ b/roofit/roofitcore/inc/RooCacheManager.h
@@ -26,9 +26,10 @@
 #include "RooAbsCache.h"
 #include "RooAbsCacheElement.h"
 #include "RooNameReg.h"
+#include "RooHelpers.h"
+#include "ROOT/RMakeUnique.hxx"
 #include <vector>
-
-class RooNameSet ;
+#include <memory>
 
 
 template<class T>
@@ -84,8 +85,8 @@ public:
   } 
 
   T* getObjByIndex(Int_t index) const ;
-  const RooNameSet* nameSet1ByIndex(Int_t index) const ;
-  const RooNameSet* nameSet2ByIndex(Int_t index) const ;
+  RooArgSet selectFromSet1(RooArgSet const& argSet, int index) const ;
+  RooArgSet selectFromSet2(RooArgSet const& argSet, int index) const ;
 
   virtual void insertObjectHook(T&) {
     // Interface function to perform post-insert operations on cached object
@@ -317,29 +318,21 @@ T* RooCacheManager<T>::getObjByIndex(Int_t index) const
 }
 
 
-/// Retrieve RooNameSet associated with slot at given index.
+/// Create RooArgSet contatining the objects that are both in the cached set 1
+//with a given index and an input argSet.
 template<class T>
-const RooNameSet* RooCacheManager<T>::nameSet1ByIndex(Int_t index) const
+RooArgSet RooCacheManager<T>::selectFromSet1(RooArgSet const& argSet, int index) const
 {
-  if (index<0||index>=_size) {
-    oocoutE(_owner,ObjectHandling) << "RooCacheManager::getNormListByIndex: ERROR index (" 
-				   << index << ") out of range [0," << _size-1 << "]" << std::endl ;
-    return 0 ;
-  }
-  return &_nsetCache[index].nameSet1() ;
+  return RooHelpers::selectFromArgSet(argSet, _nsetCache.at(index).nameSet1());
 }
 
 
-/// Retrieve RooNameSet associated with slot at given index.
+/// Create RooArgSet contatining the objects that are both in the cached set 2
+//with a given index and an input argSet.
 template<class T>
-const RooNameSet* RooCacheManager<T>::nameSet2ByIndex(Int_t index) const 
+RooArgSet RooCacheManager<T>::selectFromSet2(RooArgSet const& argSet, int index) const 
 {
-  if (index<0||index>=_size) {
-    oocoutE(_owner,ObjectHandling) << "RooCacheManager::getNormListByIndex: ERROR index (" 
-				   << index << ") out of range [0," << _size-1 << "]" << std::endl ;
-    return 0 ;
-  }
-  return &_nsetCache[index].nameSet2() ;
+  return RooHelpers::selectFromArgSet(argSet, _nsetCache.at(index).nameSet2());
 }
 
 

--- a/roofit/roofitcore/inc/RooFitLegacy/RooNameSet.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooNameSet.h
@@ -19,6 +19,8 @@
 #include "TObject.h"
 #include "RooPrintable.h"
 
+#include <ROOT/RConfig.hxx>
+
 class RooArgSet;
 
 class RooNameSet : public TObject, public RooPrintable {
@@ -59,6 +61,6 @@ protected:
   static void strdup(Int_t& dstlen, char* &dstbuf, const char* str);
 
   ClassDef(RooNameSet,1) // A sterile version of RooArgSet, containing only the names of the contained RooAbsArgs
-};
+} R__SUGGEST_ALTERNATIVE("Please use RooHelpers::getColonSeparatedNameString() and RooHelpers::selectFromArgSet().");
 
 #endif

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -121,6 +121,9 @@ std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const 
 
 bool checkIfRangesOverlap(RooAbsPdf const& pdf, RooAbsData const& data, std::vector<std::string> const& rangeNames);
 
+std::string getColonSeparatedNameString(RooArgSet const& argSet);
+RooArgSet selectFromArgSet(RooArgSet const&, std::string const& names);
+
 }
 
 

--- a/roofit/roofitcore/inc/RooNormSetCache.h
+++ b/roofit/roofitcore/inc/RooNormSetCache.h
@@ -18,9 +18,9 @@
 
 #include <vector>
 #include <map>
+#include <string>
 
 #include "Rtypes.h"
-#include "RooNameSet.h"
 
 class RooAbsArg;
 class RooArgSet;
@@ -75,8 +75,8 @@ public:
 
   const RooArgSet* lastSet1() const { return _pairs.empty()?0:_pairs.back().first; }
   const RooArgSet* lastSet2() const { return _pairs.empty()?0:_pairs.back().second; }
-  const RooNameSet& nameSet1() const { return _name1; }
-  const RooNameSet& nameSet2() const { return _name2; }
+  const std::string& nameSet1() const { return _name1; }
+  const std::string& nameSet2() const { return _name2; }
 
   Bool_t autoCache(const RooAbsArg* self, const RooArgSet* set1,
       const RooArgSet* set2 = 0, const TNamed* set2RangeName = 0,
@@ -94,8 +94,8 @@ protected:
   ULong_t _max; //!
   ULong_t _next; //!
 
-  RooNameSet _name1;   //!
-  RooNameSet _name2;   //!
+  std::string _name1;   //!
+  std::string _name2;   //!
   TNamed*    _set2RangeName; //!
 
   ClassDef(RooNormSetCache, 0) // Management tool for tracking sets of similar integration/normalization sets

--- a/roofit/roofitcore/inc/RooObjCacheManager.h
+++ b/roofit/roofitcore/inc/RooObjCacheManager.h
@@ -26,8 +26,6 @@
 #include "RooAbsCacheElement.h"
 #include "RooCacheManager.h"
 
-class RooNameSet;
-
 
 class RooObjCacheManager : public RooCacheManager<RooAbsCacheElement> {
 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -74,7 +74,6 @@ for single nodes.
 #include "strlcpy.h"
 
 #include "RooSecondMoment.h"
-#include "RooNameSet.h"
 #include "RooWorkspace.h"
 
 #include "RooMsgService.h"
@@ -641,11 +640,12 @@ RooArgSet* RooAbsArg::getParameters(const RooArgSet* observables, bool stripDisc
 
 bool RooAbsArg::getParameters(const RooArgSet* observables, RooArgSet& outputSet, bool stripDisconnected) const
 {
+   using RooHelpers::getColonSeparatedNameString;
 
    // Check for cached parameter set
    if (_myws) {
-      RooNameSet nsetObs(observables ? *observables : RooArgSet());
-      const RooArgSet *paramSet = _myws->set(Form("CACHE_PARAMS_OF_PDF_%s_FOR_OBS_%s", GetName(), nsetObs.content()));
+      auto nsetObs = getColonSeparatedNameString(observables ? *observables : RooArgSet());
+      const RooArgSet *paramSet = _myws->set(Form("CACHE_PARAMS_OF_PDF_%s_FOR_OBS_%s", GetName(), nsetObs.c_str()));
       if (paramSet) {
          outputSet.add(*paramSet);
          return false;
@@ -660,9 +660,9 @@ bool RooAbsArg::getParameters(const RooArgSet* observables, RooArgSet& outputSet
    outputSet.sort();
 
    // Cache parameter set
-   if (_myws && outputSet.getSize() > 10) {
-      RooNameSet nsetObs(observables ? *observables : RooArgSet());
-      _myws->defineSetInternal(Form("CACHE_PARAMS_OF_PDF_%s_FOR_OBS_%s", GetName(), nsetObs.content()), outputSet);
+   if (_myws && outputSet.size() > 10) {
+      auto nsetObs = getColonSeparatedNameString(observables ? *observables : RooArgSet());
+      _myws->defineSetInternal(Form("CACHE_PARAMS_OF_PDF_%s_FOR_OBS_%s", GetName(), nsetObs.c_str()), outputSet);
       // cout << " caching parameters in workspace for pdf " << IsA()->GetName() << "::" << GetName() << endl ;
    }
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -701,15 +701,13 @@ RooAbsReal* RooAbsReal::createIntObj(const RooArgSet& iset2, const RooArgSet* ns
 
     RooArgSet* intParams = integral->getVariables() ;
 
-    RooNameSet cacheParamNames ;
-    cacheParamNames.setNameList(cacheParamsStr) ;
-    RooArgSet* cacheParams = cacheParamNames.select(*intParams) ;
+    RooArgSet cacheParams = RooHelpers::selectFromArgSet(*intParams, cacheParamsStr);
 
-    if (cacheParams->getSize()>0) {
-      cxcoutD(Caching) << "RooAbsReal::createIntObj(" << GetName() << ") INFO: constructing " << cacheParams->getSize()
-		     << "-dim value cache for integral over " << iset2 << " as a function of " << *cacheParams << " in range " << (rangeName?rangeName:"<none>") <<  endl ;
-      string name = Form("%s_CACHE_[%s]",integral->GetName(),cacheParams->contentsString().c_str()) ;
-      RooCachedReal* cachedIntegral = new RooCachedReal(name.c_str(),name.c_str(),*integral,*cacheParams) ;
+    if (cacheParams.getSize()>0) {
+      cxcoutD(Caching) << "RooAbsReal::createIntObj(" << GetName() << ") INFO: constructing " << cacheParams.getSize()
+		     << "-dim value cache for integral over " << iset2 << " as a function of " << cacheParams << " in range " << (rangeName?rangeName:"<none>") <<  endl ;
+      string name = Form("%s_CACHE_[%s]",integral->GetName(),cacheParams.contentsString().c_str()) ;
+      RooCachedReal* cachedIntegral = new RooCachedReal(name.c_str(),name.c_str(),*integral,cacheParams) ;
       cachedIntegral->setInterpolationOrder(2) ;
       cachedIntegral->addOwnedComponents(*integral) ;
       cachedIntegral->setCacheSource(kTRUE) ;
@@ -720,7 +718,6 @@ RooAbsReal* RooAbsReal::createIntObj(const RooArgSet& iset2, const RooArgSet* ns
       integral = cachedIntegral ;
     }
 
-    delete cacheParams ;
     delete intParams ;
   }
 

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -741,16 +741,12 @@ Double_t RooAddModel::analyticalIntegralWN(Int_t code, const RooArgSet* normSet,
 
   // If cache has been sterilized, revive this slot
   if (cache==0) {
-    RooArgSet* vars = getParameters(RooArgSet()) ;
-    RooArgSet* nset = _intCacheMgr.nameSet1ByIndex(code-1)->select(*vars) ;
-    RooArgSet* iset = _intCacheMgr.nameSet2ByIndex(code-1)->select(*vars) ;
+    std::unique_ptr<RooArgSet> vars{getParameters(RooArgSet())} ;
+    RooArgSet nset = _intCacheMgr.selectFromSet1(*vars, code-1) ;
+    RooArgSet iset = _intCacheMgr.selectFromSet2(*vars, code-1) ;
 
-    Int_t code2(-1) ;
-    getCompIntList(nset,iset,compIntList,code2,rangeName) ;
-
-    delete vars ;
-    delete nset ;
-    delete iset ;
+    int code2 = -1 ;
+    getCompIntList(&nset,&iset,compIntList,code2,rangeName) ;
   } else {
 
     compIntList = &cache->_intList ;

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -303,9 +303,9 @@ Double_t RooAddition::analyticalIntegral(Int_t code, const char* rangeName) cons
   if (cache==0) {
     // cache got sterilized, trigger repopulation of this slot, then try again...
     std::unique_ptr<RooArgSet> vars( getParameters(RooArgSet()) );
-    std::unique_ptr<RooArgSet> iset(  _cacheMgr.nameSet2ByIndex(code-1)->select(*vars) );
+    RooArgSet iset = _cacheMgr.selectFromSet2(*vars, code-1);
     RooArgSet dummy;
-    Int_t code2 = getAnalyticalIntegral(*iset,dummy,rangeName);
+    Int_t code2 = getAnalyticalIntegral(iset,dummy,rangeName);
     assert(code==code2); // must have revived the right (sterilized) slot...
     return analyticalIntegral(code2,rangeName);
   }

--- a/roofit/roofitcore/src/RooFitLegacy/RooNameSet.cxx
+++ b/roofit/roofitcore/src/RooFitLegacy/RooNameSet.cxx
@@ -17,7 +17,7 @@
 /**
 \file RooNameSet.cxx
 \class RooNameSet
-\ingroup Roofitcore
+\ingroup Roofitlegacy
 
 RooNameSet is a utility class that stores the names the objects
 in a RooArget. This allows to preserve the contents of a RooArgSet
@@ -26,15 +26,16 @@ the RooArgSet. A new RooArgSet can be created from a RooNameSet
 by offering it a list of new RooAbsArg objects. 
 **/
 
-#include <cstring>
+#include "RooFitLegacy/RooNameSet.h"
 
 #include "RooFit.h"
 #include "Riostream.h"
 
 #include "TClass.h"
-#include "RooNameSet.h"
 #include "RooArgSet.h"
 #include "RooArgList.h"
+
+#include <cstring>
 
 ClassImp(RooNameSet);
 

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -20,6 +20,7 @@
 #include "RooDataHist.h"
 #include "RooDataSet.h"
 #include "RooAbsRealLValue.h"
+#include "RooArgList.h"
 
 #include "TClass.h"
 
@@ -262,6 +263,38 @@ bool checkIfRangesOverlap(RooAbsPdf const& pdf, RooAbsData const& data, std::vec
   }
 
   return false;
+}
+
+
+/// Create a string with all sorted names of RooArgSet elements separated by colons.
+/// \param[in] arg argSet The input RooArgSet.
+std::string getColonSeparatedNameString(RooArgSet const& argSet) {
+
+  RooArgList tmp(argSet);
+  tmp.sort();
+
+  std::string content;
+  for(auto const& arg : tmp) {
+    content += arg->GetName();
+    content += ":";
+  }
+  if(!content.empty()) {
+    content.pop_back();
+  }
+  return content;
+}
+
+
+/// Construct a RooArgSet of objects in a RooArgSet whose names match to those
+/// in the names string.
+/// \param[in] arg argSet The input RooArgSet.
+/// \param[in] arg names The names of the objects to select in a colon-separated string.
+RooArgSet selectFromArgSet(RooArgSet const& argSet, std::string const& names) {
+  RooArgSet output;
+  for(auto const& name : tokenise(names, ":")) {
+    if(auto arg = argSet.find(name.c_str())) output.add(*arg);
+  }
+  return output;
 }
 
 

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -35,6 +35,7 @@ discrete dimensions and may have negative values.
 #include "RooCategory.h"
 #include "RooWorkspace.h"
 #include "RooHistPdf.h"
+#include "RooHelpers.h"
 
 #include "TError.h"
 
@@ -501,7 +502,8 @@ Bool_t RooHistFunc::areIdentical(const RooDataHist& dh1, const RooDataHist& dh2)
     dh2.get(i) ;
     if (fabs(dh1.weight()-dh2.weight())>1e-8) return kFALSE ;
   }
-  if (!(RooNameSet(*dh1.get())==RooNameSet(*dh2.get()))) return kFALSE ;
+  using RooHelpers::getColonSeparatedNameString;
+  if (getColonSeparatedNameString(*dh1.get()) != getColonSeparatedNameString(*dh2.get())) return kFALSE ;
   return kTRUE ;
 }
 

--- a/roofit/roofitcore/src/RooNormSetCache.cxx
+++ b/roofit/roofitcore/src/RooNormSetCache.cxx
@@ -35,6 +35,7 @@ during their lifetime.
 
 #include "RooNormSetCache.h"
 #include "RooArgSet.h"
+#include "RooHelpers.h"
 
 ClassImp(RooNormSetCache);
 ;
@@ -122,7 +123,6 @@ Bool_t RooNormSetCache::autoCache(const RooAbsArg* self, const RooArgSet* set1,
   }
 
   // B - Check if dependents(set1/set2) are compatible with current cache
-  RooNameSet nset1d, nset2d;
 
 //   cout << "RooNormSetCache::autoCache set1 = " << (set1?*set1:RooArgSet()) << " set2 = " << (set2?*set2:RooArgSet()) << endl;
 //   if (set1) set1->Print("v");
@@ -140,10 +140,11 @@ Bool_t RooNormSetCache::autoCache(const RooAbsArg* self, const RooArgSet* set1,
 
 //   cout << "RooNormSetCache::autoCache set1d = " << *set1d << " set2 = " << *set2d << endl;
 
-  nset1d.refill(*set1d);
-  nset2d.refill(*set2d);
+  using RooHelpers::getColonSeparatedNameString;
 
-  if (nset1d == _name1 && nset2d == _name2 && _set2RangeName == set2RangeName) {
+  if (   getColonSeparatedNameString(*set1d) == _name1
+      && getColonSeparatedNameString(*set2d) == _name2
+      && _set2RangeName == set2RangeName) {
     // Compatible - Add current set1/2 to cache
     add(set1,set2);
 
@@ -156,8 +157,8 @@ Bool_t RooNormSetCache::autoCache(const RooAbsArg* self, const RooArgSet* set1,
   if (doRefill) {
     clear();
     add(set1,set2);
-    _name1.refill(*set1d);
-    _name2.refill(*set2d);
+    _name1 = getColonSeparatedNameString(*set1d);
+    _name2 = getColonSeparatedNameString(*set2d);
 //     cout << "RooNormSetCache::autoCache() _name1 refilled from " << *set1d << " to " ; _name1.printValue(cout) ; cout << endl;
 //     cout << "RooNormSetCache::autoCache() _name2 refilled from " << *set2d << " to " ; _name2.printValue(cout) ; cout << endl;
     _set2RangeName = (TNamed*) set2RangeName;

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -309,8 +309,8 @@ Double_t RooProduct::analyticalIntegral(Int_t code, const char* rangeName) const
   if (cache==0) { 
     // cache got sterilized, trigger repopulation of this slot, then try again...
     std::unique_ptr<RooArgSet> vars( getParameters(RooArgSet()) );
-    std::unique_ptr<RooArgSet> iset(  _cacheMgr.nameSet2ByIndex(code-1)->select(*vars) );
-    Int_t code2 = getPartIntList(iset.get(),rangeName)+1;
+    RooArgSet iset = _cacheMgr.selectFromSet2(*vars, code-1);
+    Int_t code2 = getPartIntList(&iset,rangeName)+1;
     assert(code==code2); // must have revived the right (sterilized) slot...
     return analyticalIntegral(code2,rangeName);
   }

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -187,24 +187,17 @@ Double_t RooProjectedPdf::analyticalIntegralWN(Int_t code, const RooArgSet* /*no
   CacheElem *cache = (CacheElem*) _cacheMgr.getObjByIndex(code-1) ;
   
   if (cache) {
-    Double_t ret= cache->_projection->getVal() ;
-    return ret ;
+    return cache->_projection->getVal() ;
   } else {
     
-    RooArgSet* vars = getParameters(RooArgSet()) ;
+    std::unique_ptr<RooArgSet> vars{getParameters(RooArgSet())} ;
     vars->add(intobs) ;
-    RooArgSet* iset = _cacheMgr.nameSet1ByIndex(code-1)->select(*vars) ;
-    RooArgSet* nset = _cacheMgr.nameSet2ByIndex(code-1)->select(*vars) ;
+    RooArgSet iset = _cacheMgr.selectFromSet1(*vars, code-1) ;
+    RooArgSet nset = _cacheMgr.selectFromSet2(*vars, code-1) ;
     
-    Int_t code2(-1) ;
-    const RooAbsReal* proj = getProjection(iset,nset,rangeName,code2) ;
-    
-    delete vars ;
-    delete nset ;
-    delete iset ;
-    
-    Double_t ret =  proj->getVal() ;
-    return ret ;
+    int code2 = -1 ;
+
+    return getProjection(&iset,&nset,rangeName,code2)->getVal() ;
   } 
   
 } 

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -356,10 +356,10 @@ Double_t RooRealSumFunc::analyticalIntegralWN(Int_t code, const RooArgSet *normS
       // "RooRealSumFunc("<<this<<")::analyticalIntegralWN:"<<GetName()<<"("<<code<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>")
       // << ": reviving cache "<< endl;
       std::unique_ptr<RooArgSet> vars(getParameters(RooArgSet()));
-      std::unique_ptr<RooArgSet> iset(_normIntMgr.nameSet2ByIndex(code - 1)->select(*vars));
-      std::unique_ptr<RooArgSet> nset(_normIntMgr.nameSet1ByIndex(code - 1)->select(*vars));
+      RooArgSet iset = _normIntMgr.selectFromSet2(*vars, code - 1);
+      RooArgSet nset = _normIntMgr.selectFromSet1(*vars, code - 1);
       RooArgSet dummy;
-      Int_t code2 = getAnalyticalIntegralWN(*iset, dummy, nset.get(), rangeName);
+      Int_t code2 = getAnalyticalIntegralWN(iset, dummy, &nset, rangeName);
       assert(code == code2); // must have revived the right (sterilized) slot...
       (void)code2;
       cache = (CacheElem *)_normIntMgr.getObjByIndex(code - 1);

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -369,10 +369,10 @@ Double_t RooRealSumPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSe
   if (cache==0) { // revive the (sterilized) cache
     //cout << "RooRealSumPdf("<<this<<")::analyticalIntegralWN:"<<GetName()<<"("<<code<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>") << ": reviving cache "<< endl;
     std::unique_ptr<RooArgSet> vars( getParameters(RooArgSet()) );
-    std::unique_ptr<RooArgSet> iset(  _normIntMgr.nameSet2ByIndex(code-1)->select(*vars) );
-    std::unique_ptr<RooArgSet> nset(  _normIntMgr.nameSet1ByIndex(code-1)->select(*vars) );
+    RooArgSet iset = _normIntMgr.selectFromSet2(*vars, code-1);
+    RooArgSet nset = _normIntMgr.selectFromSet1(*vars, code-1);
     RooArgSet dummy;
-    Int_t code2 = getAnalyticalIntegralWN(*iset,dummy,nset.get(),rangeName);
+    Int_t code2 = getAnalyticalIntegralWN(iset,dummy,&nset,rangeName);
     R__ASSERT(code==code2); // must have revived the right (sterilized) slot...
     cache = (CacheElem*) _normIntMgr.getObjByIndex(code-1) ;
     R__ASSERT(cache!=0);

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -39,7 +39,6 @@ which returns spans pointing directly to the data.
 #include "RooFormulaVar.h"
 #include "RooRealVar.h"
 #include "RooCategory.h"
-#include "RooNameSet.h"
 #include "RooHistError.h"
 #include "RooTrace.h"
 #include "RooHelpers.h"
@@ -1006,7 +1005,6 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
   std::vector<RooArgSet*> argObsList ;
 
   // Now need to attach branch buffers of clones
-  RooArgSet *anset(0), *acset(0) ;
   for (const auto arg : cloneSet) {
     arg->attachToVStore(*newCache) ;
     
@@ -1017,20 +1015,17 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
     const char* catNset = arg->getStringAttribute("CATNormSet") ;
     if (catNset) {
 //       cout << "RooVectorDataStore::cacheArgs() cached node " << arg->GetName() << " has a normalization set specification CATNormSet = " << catNset << endl ;
-      RooNameSet rns ;
-      rns.setNameList(catNset) ;
-      anset = rns.select(nset?*nset:RooArgSet()) ;
-      normSet = (RooArgSet*) anset->selectCommon(*argObs) ;
+
+      RooArgSet anset = RooHelpers::selectFromArgSet(nset ? *nset : RooArgSet{}, catNset);
+      normSet = (RooArgSet*) anset.selectCommon(*argObs) ;
       
     }
     const char* catCset = arg->getStringAttribute("CATCondSet") ;
     if (catCset) {
 //       cout << "RooVectorDataStore::cacheArgs() cached node " << arg->GetName() << " has a conditional observable set specification CATCondSet = " << catCset << endl ;
-      RooNameSet rns ;
-      rns.setNameList(catCset) ;
-      acset = rns.select(nset?*nset:RooArgSet()) ;
-      
-      argObs->remove(*acset,kTRUE,kTRUE) ;
+
+      RooArgSet acset = RooHelpers::selectFromArgSet(nset ? *nset : RooArgSet{}, catCset);
+      argObs->remove(acset,kTRUE,kTRUE) ;
       normSet = argObs ;
     }
 

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -7,6 +7,7 @@
 # @author Danilo Piparo CERN, 2018
 
 ROOT_ADD_GTEST(simple simple.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testRooCacheManager testRooCacheManager.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testWorkspace testWorkspace.cxx LIBRARIES RooFitCore RooFit RooStats)
 if(NOT MSVC OR win_broken_tests)
   ROOT_ADD_GTEST(testRooDataHist testRooDataHist.cxx LIBRARIES RooFitCore

--- a/roofit/roofitcore/test/testRooCacheManager.cxx
+++ b/roofit/roofitcore/test/testRooCacheManager.cxx
@@ -1,0 +1,62 @@
+// Tests for the RooCacheManager
+// Author: Jonas Rembser, CERN, May 2021
+
+#include "RooObjCacheManager.h"
+#include "RooRealVar.h"
+
+#include "gtest/gtest.h"
+
+#include <string>
+#include <vector>
+
+TEST(RooCacheManager, TestSelectFromArgSet)
+{
+   // Test RooCacheManager::selectFromSet1 and RooCacheManager::selectFromSet2.
+
+   // the cached class doesn't matter for this test, it just has to be an object that the cache is going to own
+   class CacheElem : public RooAbsCacheElement {
+   public:
+      virtual ~CacheElem() {}
+      virtual RooArgList containedArgs(Action) { return {}; }
+   };
+
+   // RooObjCacheManager is a wrapper around RooCacheManager
+   RooObjCacheManager mgr{nullptr, 100};
+
+   // fill some vector with RooAbsReals for testing
+   std::vector<RooRealVar> vars;
+   for (int i = 0; i < 10; ++i) {
+      auto name = std::string("v") + std::to_string(i);
+      vars.emplace_back(name.c_str(), name.c_str(), static_cast<double>(i));
+   }
+
+   RooArgSet nset1{vars[0], vars[1], "nset1"};
+   RooArgSet iset1{vars[2], vars[3], vars[4], "nset2"};
+
+   RooArgSet nset2{vars[5], vars[6], vars[7], "nset1"};
+   RooArgSet iset2{vars[8], vars[9], "nset2"};
+
+   int idx1 = mgr.setObj(&nset1, &iset1, new CacheElem);
+   int idx2 = mgr.setObj(&nset2, &iset2, new CacheElem);
+
+   std::cout << idx1 << std::endl;
+   std::cout << idx2 << std::endl;
+
+   auto sel11 = mgr.selectFromSet1({vars[0], vars[4]}, idx1);
+   auto sel12 = mgr.selectFromSet2({vars[2], vars[4]}, idx1);
+
+   auto sel21 = mgr.selectFromSet1({vars[1], vars[6]}, idx2);
+   auto sel22 = mgr.selectFromSet2({vars[0], vars[1]}, idx2);
+
+   // check if the expected number of args were selected
+   EXPECT_EQ(sel11.size(), 1);
+   EXPECT_EQ(sel12.size(), 2);
+   EXPECT_EQ(sel21.size(), 1);
+   EXPECT_EQ(sel22.size(), 0);
+
+   // check if the correct args were selected
+   EXPECT_TRUE(sel11.containsInstance(vars[0]));
+   EXPECT_TRUE(sel12.containsInstance(vars[2]));
+   EXPECT_TRUE(sel12.containsInstance(vars[4]));
+   EXPECT_TRUE(sel21.containsInstance(vars[6]));
+}


### PR DESCRIPTION
The RooNameSet class is too complicated considering that it fulfills a
rather simple purpose, which is to serialize the names of objects in a
RooArgSet to a string that can be used to select objects from other
RooArgSets.

This commit proposes to replace the RooNameSet class by new functions in
the RooHelpers namespace: `getColonSeparatedNameString` and
`selectFromArgSet`. These functions make use of `std::string` to be much
less verbose than the original RooNameSet class.