### PR TITLE
[RF] Make RooAbsTestStatistic error out if multiple ranges are passed

### DIFF
--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -54,7 +54,7 @@ public:
   };
 
   // Constructors, assignment etc
-  RooAbsTestStatistic() ;
+  RooAbsTestStatistic() {}
   RooAbsTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
                       const RooArgSet& projDeps, Configuration const& cfg);
   RooAbsTestStatistic(const RooAbsTestStatistic& other, const char* name=0);
@@ -116,14 +116,14 @@ protected:
   }
 
   // Original arguments
-  RooAbsReal* _func ;              // Pointer to original input function
-  RooAbsData* _data ;              // Pointer to original input dataset
-  const RooArgSet* _projDeps ;     // Pointer to set with projected observables
-  std::string _rangeName ;         // Name of range in which to calculate test statistic
-  std::string _addCoefRangeName ;  // Name of reference to be used for RooAddPdf components
-  Bool_t _splitRange ;             // Split rangeName in RooSimultaneous index labels if true
-  Int_t _simCount ;                // Total number of component p.d.f.s in RooSimultaneous (if any)
-  Bool_t _verbose ;                // Verbose messaging if true
+  RooAbsReal* _func = nullptr;          // Pointer to original input function
+  RooAbsData* _data = nullptr;          // Pointer to original input dataset
+  const RooArgSet* _projDeps = nullptr; // Pointer to set with projected observables
+  std::string _rangeName ;              // Name of range in which to calculate test statistic
+  std::string _addCoefRangeName ;       // Name of reference to be used for RooAddPdf components
+  Bool_t _splitRange = false;           // Split rangeName in RooSimultaneous index labels if true
+  Int_t _simCount = 1;                  // Total number of component p.d.f.s in RooSimultaneous (if any)
+  Bool_t _verbose = false;              // Verbose messaging if true
 
   virtual Bool_t setDataSlave(RooAbsData& /*data*/, Bool_t /*cloneData*/=kTRUE, Bool_t /*ownNewDataAnyway*/=kFALSE) { return kTRUE ; }
 
@@ -136,27 +136,27 @@ protected:
   void initSimMode(RooSimultaneous* pdf, RooAbsData* data, const RooArgSet* projDeps, std::string const& rangeName, std::string const& addCoefRangeName) ;    
   void initMPMode(RooAbsReal* real, RooAbsData* data, const RooArgSet* projDeps, std::string const& rangeName, std::string const& addCoefRangeName) ;
 
-  mutable Bool_t _init ;          //! Is object initialized  
-  GOFOpMode   _gofOpMode ;        // Operation mode of test statistic instance 
+  mutable Bool_t _init = false;   //! Is object initialized  
+  GOFOpMode _gofOpMode = Slave;   // Operation mode of test statistic instance 
 
-  Int_t       _nEvents ;          // Total number of events in test statistic calculation
-  Int_t       _setNum ;           // Partition number of this instance in parallel calculation mode
-  Int_t       _numSets ;          // Total number of partitions in parallel calculation mode
-  Int_t       _extSet ;           //! Number of designated set to calculated extended term
+  Int_t _nEvents = 0;             // Total number of events in test statistic calculation
+  Int_t       _setNum = 0;        // Partition number of this instance in parallel calculation mode
+  Int_t       _numSets = 1;       // Total number of partitions in parallel calculation mode
+  Int_t       _extSet = 0;        //! Number of designated set to calculated extended term
 
   // Simultaneous mode data
-  Int_t          _nGof        ; // Number of sub-contexts 
-  pRooAbsTestStatistic* _gofArray ; //! Array of sub-contexts representing part of the combined test statistic
+  Int_t          _nGof = 0    ; // Number of sub-contexts 
+  pRooAbsTestStatistic* _gofArray = nullptr; //! Array of sub-contexts representing part of the combined test statistic
   std::vector<RooFit::MPSplit> _gofSplitMode ; //! GOF MP Split mode specified by component (when Auto is active)
   
   // Parallel mode data
-  Int_t          _nCPU ;      //  Number of processors to use in parallel calculation mode
-  pRooRealMPFE*  _mpfeArray ; //! Array of parallel execution frond ends
+  Int_t          _nCPU = 1;   //  Number of processors to use in parallel calculation mode
+  pRooRealMPFE*  _mpfeArray = nullptr; //! Array of parallel execution frond ends
 
-  RooFit::MPSplit        _mpinterl ; // Use interleaving strategy rather than N-wise split for partioning of dataset for multiprocessor-split
-  Bool_t         _doOffset ; // Apply interval value offset to control numeric precision?
-  mutable ROOT::Math::KahanSum<double> _offset{0.0} ; //! Offset as KahanSum to avoid loss of precision
-  mutable Double_t _evalCarry; //! carry of Kahan sum in evaluatePartition
+  RooFit::MPSplit _mpinterl = RooFit::BulkPartition; // Use interleaving strategy rather than N-wise split for partioning of dataset for multiprocessor-split
+  Bool_t         _doOffset = false; // Apply interval value offset to control numeric precision?
+  mutable ROOT::Math::KahanSum<double> _offset = 0.0; //! Offset as KahanSum to avoid loss of precision
+  mutable Double_t _evalCarry = 0.0; //! carry of Kahan sum in evaluatePartition
 
   ClassDef(RooAbsTestStatistic,2) // Abstract base class for real-valued test statistics
 

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -104,6 +104,16 @@ RooAbsTestStatistic::RooAbsTestStatistic(const char *name, const char *title, Ro
 {
   // Register all parameters as servers
   _paramSet.add(*std::unique_ptr<RooArgSet>{real.getParameters(&data)});
+
+  if (cfg.rangeName.find(',') != std::string::npos) {
+    auto errorMsg = std::string("Ranges ") + cfg.rangeName
+            + " were passed to the RooAbsTestStatistic with name \"" + name + "\", "
+            + "but it doesn't support multiple comma-separated fit ranges!\n" +
+            + "Instead, one should combine multiple RooAbsTestStatistic objects "
+            + "(see RooAbsPdf::createNLL for an example with RooNLLVar).";
+    coutE(InputArguments) <<  errorMsg << std::endl;
+    throw std::invalid_argument(errorMsg);
+  }
 }
 
 

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -75,7 +75,6 @@ namespace {
     cfg.nCPU = RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,args...);
     cfg.interleave = RooFit::Interleave;
     cfg.verbose = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,args...));
-    cfg.splitCutRange = false;
     cfg.cloneInputData = false;
     cfg.integrateOverBinsPrecision = RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {args...});
     return cfg;
@@ -83,15 +82,9 @@ namespace {
 
   template<class ...Args>
   RooAbsTestStatistic::Configuration makeRooAbsTestStatisticCfgForPdf(Args const& ... args) {
-    RooAbsTestStatistic::Configuration cfg;
-    cfg.rangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","RangeWithName",0,"",args...);
+    auto cfg = makeRooAbsTestStatisticCfgForFunc(args...);
     cfg.addCoefRangeName = RooCmdConfig::decodeStringOnTheFly("RooChi2Var::RooChi2Var","AddCoefRange",0,"",args...);
-    cfg.nCPU = RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","NumCPU",0,1,args...);
-    cfg.interleave = RooFit::Interleave;
-    cfg.verbose = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","Verbose",0,1,args...));
     cfg.splitCutRange = static_cast<bool>(RooCmdConfig::decodeIntOnTheFly("RooChi2Var::RooChi2Var","SplitRange",0,0,args...));
-    cfg.cloneInputData = false;
-    cfg.integrateOverBinsPrecision = RooCmdConfig::decodeDoubleOnTheFly("RooChi2Var::RooChi2Var", "IntegrateBins", 0, -1., {args...});
     return cfg;
   }
 }


### PR DESCRIPTION
The RooFit test statistic classes give wrong results if they are
constructed from multiple comma-separated ranges. This can cause errors,
such as the one reported in Jira issue [ROOT-10038](https://sft.its.cern.ch/jira/browse/ROOT-10038).

This commit suggests to throw an exception if multiple comma-separated
ranges are detected.