### PR TITLE
[RF] Speedup histfactory ParamHistFunc

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -12,8 +12,6 @@
 #ifndef ROO_PARAMHISTFUNC
 #define ROO_PARAMHISTFUNC
 
-#include <map>
-#include <vector>
 #include <list>
 #include <string>
 
@@ -97,7 +95,18 @@ protected:
   //RooAbsBinning* _binning;  // Holds the binning of the dataVar (at construction time)
 
   Int_t _numBins;
-  mutable std::vector<int> _binMapVector; //!
+  struct NumBins {
+    NumBins() {}
+    NumBins(int nx, int ny, int nz) : x{nx}, y{ny}, z{nz}, xy{x*y}, xz{x*z}, yz{y*z}, xyz{xy*z} {}
+    int x = 0;
+    int y = 0;
+    int z = 0;
+    int xy = 0;
+    int xz = 0;
+    int yz = 0;
+    int xyz = 0;
+  };
+  mutable NumBins _numBinsPerDim; //!
   mutable RooDataHist _dataSet;
    //Bool_t _normalized;
 
@@ -111,7 +120,7 @@ protected:
   Double_t evaluate() const;
 
 private:
-  std::vector<int> const& getParamSetBinMap() const;
+  static NumBins getNumBinsPerDim(RooArgSet const& vars);
 
   ClassDef(ParamHistFunc,6) // Sum of RooAbsReal objects
 };

--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -97,7 +97,7 @@ protected:
   //RooAbsBinning* _binning;  // Holds the binning of the dataVar (at construction time)
 
   Int_t _numBins;
-  mutable std::map<Int_t, Int_t> _binMap;
+  mutable std::vector<int> _binMapVector; //!
   mutable RooDataHist _dataSet;
    //Bool_t _normalized;
 
@@ -110,7 +110,10 @@ protected:
   static Int_t GetNumBins( const RooArgSet& vars );
   Double_t evaluate() const;
 
-  ClassDef(ParamHistFunc,5) // Sum of RooAbsReal objects
+private:
+  std::vector<int> const& getParamSetBinMap() const;
+
+  ClassDef(ParamHistFunc,6) // Sum of RooAbsReal objects
 };
 
 #endif

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -164,11 +164,10 @@ Int_t ParamHistFunc::GetNumBins( const RooArgSet& vars ) {
 
   for (auto comp : vars) {
     if (!dynamic_cast<RooRealVar*>(comp)) {
-      std::cout << "ParamHistFunc::GetNumBins" << vars.GetName() << ") ERROR: component " 
-	   << comp->GetName() 
-	   << " in vars list is not of type RooRealVar" << std::endl ;
-      RooErrorHandler::softAbort() ;
-      return -1;
+      auto errorMsg = std::string("ParamHistFunc::GetNumBins") + vars.GetName() + ") ERROR: component "
+                      + comp->GetName() + " in vars list is not of type RooRealVar";
+      oocoutE(static_cast<TObject*>(nullptr), InputArguments) <<  errorMsg << std::endl;
+      throw std::runtime_error(errorMsg);
     }
     RooRealVar* var = (RooRealVar*) comp;
 
@@ -556,11 +555,10 @@ std::vector<int> const& ParamHistFunc::getParamSetBinMap() const {
 Int_t ParamHistFunc::addVarSet( const RooArgList& vars ) {
   for(auto const& comp : vars) {
     if (!dynamic_cast<RooRealVar*>(comp)) {
-      coutE(InputArguments) << "ParamHistFunc::(" << GetName() << ") ERROR: component " 
-                            << comp->GetName() << " in variables list is not of type RooRealVar" 
-                            << std::endl;
-      RooErrorHandler::softAbort() ;
-      return 1;
+      auto errorMsg = std::string("ParamHistFunc::(") + GetName() + ") ERROR: component "
+                      + comp->GetName() + " in variables list is not of type RooRealVar";
+      coutE(InputArguments) <<  errorMsg << std::endl;
+      throw std::runtime_error(errorMsg);
     }
     _dataVars.add( *comp );
   }
@@ -599,11 +597,10 @@ Int_t ParamHistFunc::addParamSet( const RooArgList& params ) {
   RooAbsArg* comp ;
   while((comp = (RooAbsArg*) paramIter.next())) {
     if (!dynamic_cast<RooRealVar*>(comp)) {
-      coutE(InputArguments) << "ParamHistFunc::(" << GetName() << ") ERROR: component " 
-			    << comp->GetName() << " in paramater list is not of type RooRealVar" 
-			    << std::endl;
-      RooErrorHandler::softAbort() ;
-      return 1;
+      auto errorMsg = std::string("ParamHistFunc::(") + GetName() + ") ERROR: component "
+                      + comp->GetName() + " in paramater list is not of type RooRealVar";
+      coutE(InputArguments) <<  errorMsg << std::endl;
+      throw std::runtime_error(errorMsg);
     }
 
     _paramSet.add( *comp );


### PR DESCRIPTION
The ParamHistFunc in the histfactory has a persistent `std::map<int,int>`
data member. It can be replaced with a `std::vector<int>` where the
previous key is the index in the vector. This is much faster.

As the igprof reports below show, it is even faster to calculate the bin indices on the fly, which is proposed in this PR.

Schema evolution is not a problem here. With this commit, the data
member is made non-persistent because it can be computed from other
persistent data members.

This PR was benchmarked with [an example from the ROOT forum](https://root-forum.cern.ch/t/bias-in-histfactory-fit/44330/7):
* igprof report [before this PR (caching with `std::map`)](https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/hf_ParamHistFunc_1_old)
* igprof report [after the first commit of the PR (caching with `std::vector`)](https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/hf_ParamHistFunc_1_new)
* igprof report [after the PR (calculating on the fly)](https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/hf_ParamHistFunc_1_new_2)

The difference is about a 50 % speedup of `ParamHistFunc::evaluate()` and a 10 % speedup of the full example.