### PR TITLE
[webgui] Reintroduce headless mode for RWebWindow, adjust ping.cxx

### DIFF
--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -411,7 +411,7 @@ void RCanvasPainter::DoWhenReady(const std::string &name, const std::string &arg
       connid = fWindow->GetConnectionId();
    } else {
       // create batch job to execute action
-      connid = fWindow->MakeBatch();
+      // connid = fWindow->MakeBatch();
    }
 
    if (!connid) {

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -50,6 +50,7 @@ protected:
    std::string fExtraArgs;        ///<! extra arguments which will be append to exec string
    std::string fPageContent;      ///<! HTML page content
    std::string fRedirectOutput;   ///<! filename where browser output should be redirected
+   bool fBatchMode{false};        ///<! is browser runs in batch mode
    bool fHeadless{false};         ///<! is browser runs in headless mode
    bool fStandalone{true};        ///<! indicates if browser should run isolated from other browser instances
    THttpServer *fServer{nullptr}; ///<! http server which handle all requests
@@ -127,6 +128,11 @@ public:
 
    /// returns window url with append options
    std::string GetFullUrl() const;
+
+   /// set batch mode
+   void SetBatchMode(bool on = true) { fBatchMode = on; }
+   /// returns batch mode
+   bool IsBatchMode() const { return fBatchMode; }
 
    /// set headless mode
    void SetHeadless(bool on = true) { fHeadless = on; }

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -96,10 +96,10 @@ public:
       return (GetBrowserKind() == kLocal) || (GetBrowserKind() == kCEF) || (GetBrowserKind() == kQt5);
    }
 
-   /// returns true if browser supports headless (batch) mode, used for image production
+   /// returns true if browser supports headless mode
    bool IsSupportHeadless() const
    {
-      return (GetBrowserKind() == kNative) || (GetBrowserKind() == kChrome) || (GetBrowserKind() == kCEF) || (GetBrowserKind() == kQt5);
+      return (GetBrowserKind() == kNative) || (GetBrowserKind() == kChrome) || (GetBrowserKind() == kFirefox) || (GetBrowserKind() == kCEF) || (GetBrowserKind() == kQt5);
    }
 
    /// set window url

--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -40,6 +40,7 @@ protected:
    protected:
       std::string fProg;  ///< browser executable
       std::string fExec;  ///< standard execute line
+      std::string fHeadlessExec; ///< headless execute line
       std::string fBatchExec; ///< batch execute line
 
       void TestProg(const std::string &nexttry, bool check_std_paths = false);

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -68,7 +68,7 @@ private:
 
    struct WebConn {
       unsigned fConnId{0};                 ///<! connection id (unique inside the window)
-      bool fBatchMode{false};              ///<! indicate if connection represent batch job
+      bool fHeadlessMode{false};           ///<! indicate if connection represent batch job
       std::string fKey;                    ///<! key value supplied to the window (when exists)
       std::unique_ptr<RWebDisplayHandle> fDisplayHandle;  ///<! handle assigned with started web display (when exists)
       std::shared_ptr<THttpCallArg> fHold; ///<! request used to hold headless browser
@@ -87,8 +87,8 @@ private:
       WebConn() = default;
       WebConn(unsigned connid) : fConnId(connid) {}
       WebConn(unsigned connid, unsigned wsid) : fConnId(connid), fActive(true), fWSId(wsid) {}
-      WebConn(unsigned connid, bool batch_mode, const std::string &key)
-         : fConnId(connid), fBatchMode(batch_mode), fKey(key)
+      WebConn(unsigned connid, bool headless_mode, const std::string &key)
+         : fConnId(connid), fHeadlessMode(headless_mode), fKey(key)
       {
          ResetStamps();
       }
@@ -180,7 +180,7 @@ private:
 
    void CheckInactiveConnections();
 
-   unsigned AddDisplayHandle(bool batch_mode, const std::string &key, std::unique_ptr<RWebDisplayHandle> &handle);
+   unsigned AddDisplayHandle(bool headless_mode, const std::string &key, std::unique_ptr<RWebDisplayHandle> &handle);
 
    unsigned AddEmbedWindow(std::shared_ptr<RWebWindow> window, int channel);
 
@@ -189,6 +189,10 @@ private:
    bool ProcessBatchHolder(std::shared_ptr<THttpCallArg> &arg);
 
    std::string GetConnToken() const;
+
+   unsigned MakeHeadless(bool create_new = false);
+
+   unsigned FindHeadlessConnection();
 
 public:
 
@@ -283,10 +287,6 @@ public:
 
    /// Returns true when window was shown at least once
    bool IsShown() const { return GetDisplayConnection() != 0; }
-
-   unsigned MakeBatch(bool create_new = false, const RWebDisplayArgs &args = "");
-
-   unsigned FindBatch();
 
    bool CanSend(unsigned connid, bool direct = true) const;
 

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -53,7 +53,7 @@ private:
    void Unregister(RWebWindow &win);
 
    /// Show window in specified location, see Show() method for more details
-   unsigned ShowWindow(RWebWindow &win, bool batch_mode, const RWebDisplayArgs &args);
+   unsigned ShowWindow(RWebWindow &win, const RWebDisplayArgs &args);
 
    int WaitFor(RWebWindow &win, WebWindowWaitFunc_t check, bool timed = false, double tm = -1);
 

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -178,6 +178,13 @@ RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
       kind.erase(pos, epos-pos);
    }
 
+   pos = kind.rfind("headless");
+   if ((pos != std::string::npos) && (pos == kind.length() - 8)) {
+      SetHeadless(true);
+      kind.resize(pos);
+      if ((pos > 0) && (kind[pos-1] == ';')) kind.resize(pos-1);
+   }
+
    // very special handling of qt5 which can specify pointer as a string
    if (kind.find("qt5:") == 0) {
       SetDriverData((void *) std::stoul(kind.substr(4)));

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -377,11 +377,11 @@ RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserCreator(true)
 
 #ifdef _MSC_VER
    fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "$prog --headless $geometry $url");
-   fHeadlessExec = gEnv->GetValue("WebGui.ChromeBatch", "fork: --headless --disable-gpu $geometry $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.ChromeHeadless", "$prog --headless --disable-gpu $geometry $url &");
    fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --app=$url &"); // & in windows mean usage of spawn
 #else
    fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "$prog --headless --incognito $geometry $url");
-   fHeadlessExec = gEnv->GetValue("WebGui.ChromeBatch", "fork: --headless --incognito $geometry $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.ChromeHeadless", "fork: --headless --incognito $geometry $url");
    fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --incognito --app=\'$url\' &");
 #endif
 }
@@ -429,7 +429,15 @@ std::string RWebDisplayHandle::ChromeCreator::MakeProfile(std::string &exec, boo
       profile_arg = chrome_profile;
    } else {
       gRandom->SetSeed(0);
-      rmdir = profile_arg = std::string(gSystem->TempDirectory()) + "/root_chrome_profile_"s + std::to_string(gRandom->Integer(0x100000));
+      std::string rnd_profile = "root_chrome_profile_"s + std::to_string(gRandom->Integer(0x100000));
+      profile_arg = gSystem->TempDirectory();
+
+#ifdef _MSC_VER
+      profile_arg += "\\"s + rnd_profile;
+#else
+      profile_arg += "/"s + rnd_profile;
+#endif
+      rmdir = profile_arg;
    }
 
    exec = std::regex_replace(exec, std::regex("\\$profile"), profile_arg);
@@ -458,10 +466,10 @@ RWebDisplayHandle::FirefoxCreator::FirefoxCreator() : BrowserCreator(true)
 #ifdef _MSC_VER
    // there is a problem when specifying the window size with wmic on windows:
    // It gives: Invalid format. Hint: <paramlist> = <param> [, <paramlist>].
-   fHeadlessExec = gEnv->GetValue("WebGui.FirefoxBatch", "fork: -headless -no-remote $profile $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.FirefoxHeadless", "$prog -headless -no-remote $profile $url &");
    fExec = gEnv->GetValue("WebGui.FirefoxInteractive", "$prog -no-remote $profile $url &");
 #else
-   fHeadlessExec = gEnv->GetValue("WebGui.FirefoxBatch", "fork:--headless --private-window --no-remote $profile $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.FirefoxHeadless", "fork:--headless --private-window --no-remote $profile $url");
    fExec = gEnv->GetValue("WebGui.FirefoxInteractive", "$prog --private-window \'$url\' &");
 #endif
 }
@@ -487,7 +495,13 @@ std::string RWebDisplayHandle::FirefoxCreator::MakeProfile(std::string &exec, bo
 
       gRandom->SetSeed(0);
       std::string rnd_profile = "root_ff_profile_"s + std::to_string(gRandom->Integer(0x100000));
-      std::string profile_dir = std::string(gSystem->TempDirectory()) + "/"s + rnd_profile;
+      std::string profile_dir = gSystem->TempDirectory();
+
+#ifdef _MSC_VER
+      profile_dir += "\\"s + rnd_profile;
+#else
+      profile_dir += "/"s + rnd_profile;
+#endif
 
       profile_arg = "-profile "s + profile_dir;
 

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -205,8 +205,10 @@ RWebDisplayHandle::BrowserCreator::Display(const RWebDisplayArgs &args)
       return nullptr;
 
    std::string exec;
-   if (args.IsHeadless())
+   if (args.IsBatchMode())
       exec = fBatchExec;
+   else if (args.IsHeadless())
+      exec = fHeadlessExec;
    else if (args.IsStandalone())
       exec = fExec;
    else
@@ -374,12 +376,12 @@ RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserCreator(true)
 #endif
 
 #ifdef _MSC_VER
-   // fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "fork: --headless --disable-gpu $geometry $url");
-
    fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "$prog --headless $geometry $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.ChromeBatch", "fork: --headless --disable-gpu $geometry $url");
    fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --app=$url &"); // & in windows mean usage of spawn
 #else
    fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "$prog --headless --incognito $geometry $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.ChromeBatch", "fork: --headless --incognito $geometry $url");
    fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --incognito --app=\'$url\' &");
 #endif
 }
@@ -456,10 +458,10 @@ RWebDisplayHandle::FirefoxCreator::FirefoxCreator() : BrowserCreator(true)
 #ifdef _MSC_VER
    // there is a problem when specifying the window size with wmic on windows:
    // It gives: Invalid format. Hint: <paramlist> = <param> [, <paramlist>].
-   // fBatchExec = gEnv->GetValue("WebGui.FirefoxBatch", "fork: -headless -no-remote $profile $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.FirefoxBatch", "fork: -headless -no-remote $profile $url");
    fExec = gEnv->GetValue("WebGui.FirefoxInteractive", "$prog -no-remote $profile $url &");
 #else
-   // fBatchExec = gEnv->GetValue("WebGui.FirefoxBatch", "fork:--headless --private-window --no-remote $profile $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.FirefoxBatch", "fork:--headless --private-window --no-remote $profile $url");
    fExec = gEnv->GetValue("WebGui.FirefoxInteractive", "$prog --private-window \'$url\' &");
 #endif
 }
@@ -737,6 +739,7 @@ try_again:
 
    args.SetStandalone(true);
    args.SetHeadless(true);
+   args.SetBatchMode(true);
    args.SetSize(width, height);
 
    if (draw_kind == "draw") {

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -436,7 +436,6 @@ std::string RWebWindowsManager::GetUrl(const RWebWindow &win, bool remote)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// Show web window in specified location.
 ///
-/// \param batch_mode indicates that browser will run in headless mode
 /// \param user_args specifies where and how display web window
 ///
 /// As display args one can use string like "firefox" or "chrome" - these are two main supported web browsers.
@@ -469,10 +468,10 @@ std::string RWebWindowsManager::GetUrl(const RWebWindow &win, bool remote)
 ///
 ///   HTTP-server related parameters documented in RWebWindowsManager::CreateServer() method
 
-unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, bool batch_mode, const RWebDisplayArgs &user_args)
+unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, const RWebDisplayArgs &user_args)
 {
    // silently ignore regular Show() calls in batch mode
-   if (!batch_mode && gROOT->IsWebDisplayBatch())
+   if (!user_args.IsHeadless() && gROOT->IsWebDisplayBatch())
       return 0;
 
    // for embedded window no any browser need to be started
@@ -503,12 +502,11 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, bool batch_mode, const 
 
    RWebDisplayArgs args(user_args);
 
-   if (batch_mode && !args.IsSupportHeadless()) {
+   if (args.IsHeadless() && !args.IsSupportHeadless()) {
       R__LOG_ERROR(WebGUILog()) << "Cannot use batch mode with " << args.GetBrowserName();
       return 0;
    }
 
-   args.SetHeadless(batch_mode);
    if (args.GetWidth() <= 0) args.SetWidth(win.GetWidth());
    if (args.GetHeight() <= 0) args.SetHeight(win.GetHeight());
 
@@ -529,7 +527,7 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, bool batch_mode, const 
    args.SetUrl(url);
 
    args.AppendUrlOpt(std::string("key=") + key);
-   if (batch_mode) args.AppendUrlOpt("batch_mode");
+   if (args.IsHeadless()) args.AppendUrlOpt("headless"); // used to create holder request
    if (!token.empty())
       args.AppendUrlOpt(std::string("token=") + token);
 
@@ -543,7 +541,7 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, bool batch_mode, const 
       return 0;
    }
 
-   return win.AddDisplayHandle(batch_mode, key, handle);
+   return win.AddDisplayHandle(args.IsHeadless(), key, handle);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -105,7 +105,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "1/04/2021";
+   JSROOT.version_date = "12/04/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}
@@ -933,6 +933,9 @@
             delete value['$pair'];
             return; // pair object is not counted in the objects map
          }
+
+        // prevent endless loop
+        if (map.indexOf(value) >= 0) return;
 
          // add object to object map
          map.push(value);

--- a/js/scripts/JSRoot.geobase.js
+++ b/js/scripts/JSRoot.geobase.js
@@ -3752,7 +3752,7 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
 
       let toplevel = new THREE.Object3D();
 
-      for (let n=0; n < draw_nodes.length;++n) {
+      for (let n = 0; n < draw_nodes.length; ++n) {
          let entry = draw_nodes[n];
          if (entry.done) continue;
 
@@ -3788,6 +3788,8 @@ JSROOT.define(['three', 'csg'], (THREE, ThreeBSP) => {
          } else {
             mesh = createFlippedMesh(shape, prop.material);
          }
+
+         mesh.name = clones.getNodeName(entry.nodeid);
 
          obj3d.add(mesh);
 

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -4357,6 +4357,57 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          // redraw all objects in pad, inform dependent objects
          this.interactiveRedraw("pad", "drawopt");
       });
+
+      if (!this.snapid && !this.isTProfile())
+         menu.addRebinMenu(sz => this.rebinHist(sz));
+   }
+
+   /** @summary Rebin 1 dim histogram, used via context menu
+     * @private */
+   TH1Painter.prototype.rebinHist = function(sz) {
+      let histo = this.getHisto(),
+          xaxis = histo.fXaxis,
+          nbins = Math.floor(xaxis.fNbins/ sz);
+      if (nbins < 2) return;
+
+      let arr = new Array(nbins+2), xbins = null;
+
+      if (xaxis.fXbins.length > 0)
+         xbins = new Array(nbins);
+
+      arr[0] = histo.fArray[0];
+      let indx = 1;
+
+      for (let i = 1; i <= nbins; ++i) {
+         if (xbins) xbins[i-1] = xaxis.fXbins[indx-1];
+         let sum = 0;
+         for (let k = 0; k < sz; ++k)
+           sum += histo.fArray[indx++];
+         arr[i] = sum;
+
+      }
+
+      if (xbins) {
+         if (indx <= xaxis.fXbins.length)
+            xaxis.fXmax = xaxis.fXbins[indx-1];
+         xaxis.fXbins = xbins;
+      } else {
+         xaxis.fXmax = xaxis.fXmin + (xaxis.fXmax - xaxis.fXmin) / xaxis.fNbins * nbins * sz;
+      }
+
+      xaxis.fNbins = nbins;
+
+      let overflow = 0;
+      while (indx < histo.fArray.length)
+         overflow += histo.fArray[indx++];
+      arr[nbins+1] = overflow;
+
+      histo.fArray = arr;
+      histo.fSumw2 = [];
+
+      this.scanContent();
+
+      this.interactiveRedraw("pad");
    }
 
    /** @summary Perform automatic zoom inside non-zero region of histogram

--- a/js/scripts/JSRoot.io.js
+++ b/js/scripts/JSRoot.io.js
@@ -224,10 +224,12 @@ JSROOT.define(['rawinflate'], () => {
                   return new Promise((resolveFunc, rejectFunc) => {
 
                      ZstdCodec.run(zstd => {
-                        const simple = new zstd.Simple();
-                        // streaming = new zstd.Streaming();
+                        // const simple = new zstd.Simple();
+                        const streaming = new zstd.Streaming();
 
-                        const data2 = simple.decompress(uint8arr);
+                        // const data2 = simple.decompress(uint8arr);
+                        const data2 = streaming.decompress(uint8arr);
+
                         // console.log(`tgtsize ${tgtsize} zstd size ${data2.length} offset ${data2.byteOffset} rawlen ${data2.buffer.byteLength}`);
 
                         const reslen = data2.length;

--- a/js/scripts/JSRoot.jq2d.js
+++ b/js/scripts/JSRoot.jq2d.js
@@ -1859,7 +1859,8 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
 
          main.html("<div class='treedraw_buttons' style='padding-left:0.5em'>" +
                "<button class='treedraw_exe' title='Execute draw expression'>Draw</button>" +
-               " Expr:<input class='treedraw_varexp ui-corner-all ui-widget' style='width:12em;margin-left:5px' title='draw expression'></input> " +
+               " Expr:<input class='treedraw_varexp treedraw_varexp_info ui-corner-all ui-widget' style='width:12em;margin-left:5px' title='draw expression'></input> " +
+               "<label class='treedraw_varexp_info'>\u24D8</label>" +
                (show_extra ? "" : "<button class='treedraw_more'>More</button>") +
                "</div>" +
                "<hr/>" +
@@ -1872,11 +1873,23 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
          let p = this;
 
          if (this.local_tree)
-            main.find('.treedraw_buttons').attr('title', "Tree draw player for: " + this.local_tree.fName);
-         main.find('.treedraw_exe').button().click(() => p.PerformDraw());
+            main.find('.treedraw_buttons')
+                .prop("title", "Tree draw player for: " + this.local_tree.fName);
+         main.find('.treedraw_exe')
+             .button().click(() => p.PerformDraw());
          main.find('.treedraw_varexp')
               .val(args && args.parse_expr ? args.parse_expr : (this.dflt_expr || "px:py"))
               .keyup(this.keyup);
+         main.find('.treedraw_varexp_info')
+             .prop('title', "Example of valid draw expressions:\n" +
+                          "  px  - 1-dim draw\n" +
+                          "  px:py  - 2-dim draw\n" +
+                          "  px:py:pz  - 3-dim draw\n" +
+                          "  px+py:px-py - use any expressions\n" +
+                          "  px:py>>Graph - create and draw TGraph\n" +
+                          "  px:py>>dump - dump extracted variables\n" +
+                          "  px:py>>h(50,-5,5,50,-5,5) - custom histogram\n" +
+                          "  px:py;hbins:100 - custom number of bins");
 
          if (show_extra) {
             this.ShowExtraButtons(args);
@@ -1888,6 +1901,8 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
          }
 
          this.checkResize();
+
+         jsrp.registerForResize(this);
       }
 
       player.PerformLocalDraw = function() {

--- a/js/scripts/JSRoot.menu.js
+++ b/js/scripts/JSRoot.menu.js
@@ -213,6 +213,19 @@ JSROOT.define(['d3', 'jquery', 'painter', 'jquery-ui'], (d3, $, jsrp) => {
          this.add("endsub:");
       }
 
+      addRebinMenu(rebin_func) {
+        this.add("sub:Rebin", function() {
+            let sz = prompt("Enter rebin value", 2);
+            if (!sz) return;
+            sz = parseInt(sz);
+            if (Number.isInteger(sz) && (sz > 1)) rebin_func(sz);
+         });
+         for (let sz = 2; sz <= 7; sz++) {
+            this.add(sz.toString(), sz, res => rebin_func(parseInt(res)));
+         }
+         this.add("endsub:");
+      }
+
       /** @summary Add selection menu entries
         * @protected */
       addSelectMenu(name, values, value, set_func) {

--- a/js/scripts/JSRoot.webwindow.js
+++ b/js/scripts/JSRoot.webwindow.js
@@ -670,8 +670,8 @@ JSROOT.define([], () => {
 
       let d = JSROOT.decodeUrl();
 
-      // special hold script, prevents headless browser from too early exit
-      if (d.has("batch_mode") && d.get("key") && (JSROOT.browser.isChromeHeadless || JSROOT.browser.isChrome))
+      // special holder script, prevents headless chrome browser from too early exit
+      if (d.has("headless") && d.get("key") && (JSROOT.browser.isChromeHeadless || JSROOT.browser.isChrome))
          JSROOT.loadScript("root_batch_holder.js?key=" + d.get("key"));
 
       if (!arg.platform)
@@ -683,7 +683,7 @@ JSROOT.define([], () => {
          JSROOT.browser.cef3 = true;
 
       if (arg.batch === undefined)
-         arg.batch = d.has("batch_mode");
+         arg.batch = d.has("headless");
 
       if (arg.batch) JSROOT.batch_mode = true;
 

--- a/tutorials/webgui/ping/Readme.md
+++ b/tutorials/webgui/ping/Readme.md
@@ -1,7 +1,7 @@
 # Latency tests for RWebWindow
 
 Provide round-trip test under different conditions.
-To run, execute `root "ping.cxx(10,0)", where first argument is number of connections tested and
+To run, execute `root "ping.cxx(10,0)"`, where first argument is number of connections tested and
 second argument is running mode.
 
 Can be tested:
@@ -11,4 +11,8 @@ Can be tested:
 3 - in addition to special THttpThread also window starts own thread
 4 - let invoke webwindow callbacks in the civetweb threads, expert mode only
 
-One also can perform same tests with longpoll emulation of web sockets, if asdding 10 to second parameter
+One also can perform same tests with longpoll emulation of web sockets, if adding 10 to second parameter
+
+When running in batch mode, function blocked until 200 round-trip packets send by the client
+or 50s elappsed. Therefore ping.cxx test can be used for RWebWindow functionality tests 
+like `root -l -b "ping.cxx(10,2)" -q`

--- a/tutorials/webgui/ping/ping.html
+++ b/tutorials/webgui/ping/ping.html
@@ -78,7 +78,7 @@
                 this.sendPing();
              }
              if (this.is_main && this.handle && this.last_output && (tm - this.last_show > 2000)) {
-                // this.handle.send("SHOW:" + this.last_output.replace("&plusmn;","+-"));
+                this.handle.send("SHOW:" + this.last_output.replace("&plusmn;","+-"));
                 this.last_show = tm;
              }
 


### PR DESCRIPTION
Batch mode, which is now only supported by Chrome, allows to run
JS code loaded from file and dump result to output file - no any
communication with host application required

Now extra headless mode is introduced, which allows to run client
code in the headless browser and communicate with it. It was original
way to produce batch images, therefore need to rename some methods
to clearly separate from old functionality.

Adjust `tutorials/webgui/ping` tutorial to let it run in "headless" mode when -b specified.
In such case macro waits until 200 round-trip packets arrived and automatically ends.
Can be used in PR/Nightly testings

Testes on Windows/Mac/Linux