### PR TITLE
[test] Update location of xrootd test files:

### DIFF
--- a/test/stressIOPlugins.cxx
+++ b/test/stressIOPlugins.cxx
@@ -157,7 +157,7 @@ int setPath(const char *proto)
    TString p(proto);
    gCurProtoName = p;
    if (p == "root" || p == "xroot") {
-      gPfx = p + "://eospublic.cern.ch//eos/opstest/dhsmith/StressIOPluginsTestFiles/";
+      gPfx = p + "://eospublic.cern.ch//eos/root-eos/StressIOPluginsTestFiles/";
       return 0;
    }
    if (p == "http" || p == "https") {


### PR DESCRIPTION
The original directory was removed.

(cherry picked from commit ca9ab88c7e38046dae309d039b7912e294a5435d)