### PR TITLE
[DF] Give priority to user provided npartitions in distributed rdf

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -122,7 +122,6 @@ class BaseBackend(ABC):
         initialization = self.initialization
 
         # Build the ranges for the current dataset
-        headnode.npartitions = self.optimize_npartitions(headnode.npartitions)
         ranges = headnode.build_ranges()
 
         def mapper(current_range):

--- a/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
+++ b/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
@@ -24,6 +24,8 @@ class RDataFrame(object):
     Interface to an RDataFrame that can run its computation graph distributedly.
     """
 
+    MIN_NPARTITIONS = 2
+
     def __init__(self, headnode, backend, **kwargs):
         """Initialization of """
 
@@ -31,7 +33,12 @@ class RDataFrame(object):
 
         self._headnode.backend = backend
 
-        self._headnode.npartitions = kwargs.get("npartitions", 2)
+        # Set the number of partitions for this dataset, one of the following:
+        # 1. User-supplied `npartitions` optional argument
+        # 2. An educated guess according to the backend, using the backend's
+        #    `optimize_npartitions` function
+        # 3. Set `npartitions` to 2
+        self._headnode.npartitions = kwargs.get("npartitions", backend.optimize_npartitions(RDataFrame.MIN_NPARTITIONS))
 
         self._headproxy = Proxy.TransformationProxy(self._headnode)
 


### PR DESCRIPTION
The distributed RDataFrame constructor accepts an optional `npartitions` keyword argument. Previously, if this argument was provided by the user, it set the number of partitions in which the rdf would split the distributed computations.
But then, right before starting the execution, the distributed backend implementation tried to optimize this number. In the case of Spark, an educated guess for the number of partitions would be spark.executor.cores * spark.executor.instances, that is the number of distributed nodes times the number of cores used for each node.
If we let this optimization happen just before the start of the execution, it means we completely disregard the user provided value for `npartitions`. Instead, the backend guessing at a number of partitions should happen only if the user doesn't supply one.
This commit addresses the issue by moving the call to `backend.optimize_npartitions` inside the initialization of the distributed dataframe object, plus adds a couple of tests to check the behaviour in the Spark backend.