### PR TITLE
[ntuple] Catch std types passed to RClassField

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -544,6 +544,10 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
    if (fClass == nullptr) {
       throw std::runtime_error("RField: no I/O support for type " + std::string(className));
    }
+   // avoid accidentally supporting std types through TClass
+   if (fClass->Property() & kIsDefinedInStd) {
+      throw RException(R__FAIL(std::string(className) + " is not supported"));
+   }
    TIter next(fClass->GetListOfDataMembers());
    while (auto dataMember = static_cast<TDataMember *>(next())) {
       //printf("Now looking at %s %s\n", dataMember->GetName(), dataMember->GetFullTypeName());

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -544,7 +544,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
    if (fClass == nullptr) {
       throw std::runtime_error("RField: no I/O support for type " + std::string(className));
    }
-   // avoid accidentally supporting std types through TClass
+   // Avoid accidentally supporting std types through TClass.
    if (fClass->Property() & kIsDefinedInStd) {
       throw RException(R__FAIL(std::string(className) + " is not supported"));
    }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -16,3 +16,31 @@ TEST(RNTuple, CreateField)
    auto value = field->GenerateValue();
    field->DestroyValue(value);
 }
+
+TEST(RNTuple, UnsupportedStdTypes)
+{
+   try {
+      auto field = RFieldBase::Create("pair_field", "std::pair<int, float>").Unwrap();
+      FAIL() << "should not be able to make a std::pair field";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("std::pair<int, float> is not supported"));
+   }
+   try {
+      auto field = RField<std::pair<int, float>>("pair_field");
+      FAIL() << "should not be able to make a std::pair field";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("pair<int,float> is not supported"));
+   }
+   try {
+      auto field = RField<std::weak_ptr<int>>("weak_ptr");
+      FAIL() << "should not be able to make a std::weak_ptr field";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("weak_ptr<int> is not supported"));
+   }
+   try {
+      auto field = RField<std::vector<std::weak_ptr<int>>>("weak_ptr_vec");
+      FAIL() << "should not be able to make a std::vector<std::weak_ptr> field";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("weak_ptr<int> is not supported"));
+   }
+}


### PR DESCRIPTION
Std library types are picked up by rootcling as `TClasses`. If there is no
`RField` specialization for them, they are passed to the `RClassField`
constructor. This led to accidental support of those std types by
RNTuple. For some types, this appeared to be benign (e.g. `std::pair`) but
for others there were errors (e.g. `std::optional`).

Change the `RClassField` constructor to throw an exception if any std type
is passed in.

cc @pcanal 