### PR TITLE
Fix TStatistic::GetMax

### DIFF
--- a/math/mathcore/inc/TStatistic.h
+++ b/math/mathcore/inc/TStatistic.h
@@ -44,7 +44,7 @@ private:
 
 public:
 
-   TStatistic(const char *name = "") : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fMin(TMath::Limits<Double_t>::Max()), fMax(TMath::Limits<Double_t>::Min()) { }
+   TStatistic(const char *name = "") : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fMin(TMath::Limits<Double_t>::Max()), fMax(-TMath::Limits<Double_t>::Max()) { }
    TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w = nullptr);
    ~TStatistic();
 

--- a/math/mathcore/src/TStatistic.cxx
+++ b/math/mathcore/src/TStatistic.cxx
@@ -33,7 +33,8 @@ templateClassImp(TStatistic);
 ///
 /// Recursively calls the TStatistic::Fill() function to fill the object.
 TStatistic::TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w)
-         : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fMin(TMath::Limits<Double_t>::Max()), fMax(TMath::Limits<Double_t>::Min())
+         : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), 
+         fMin(TMath::Limits<Double_t>::Max()), fMax(-TMath::Limits<Double_t>::Max())
 {
    if (n > 0) {
       for (Int_t i = 0; i < n; i++) {


### PR DESCRIPTION
Fix the default values for fMax
This fixes TStatistic::GetMax() when all entries are negatives.
See https://root-forum.cern.ch/t/problems-with-getmax-in-tstatistic/44324