### PR TITLE
[RF] Speed up getting weights from RooDataHist

### DIFF
--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -212,7 +212,7 @@ ParamHistFunc::~ParamHistFunc()
 ///
 /// RooRealVar currentParam = getParameter( getCurrentBin() );
 Int_t ParamHistFunc::getCurrentBin() const {
-  Int_t dataSetIndex = _dataSet.getIndex( _dataVars ); // calcTreeIndex();
+  Int_t dataSetIndex = _dataSet.getIndex( _dataVars, true ); // calcTreeIndex();
   return dataSetIndex;
 
 }

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -96,6 +96,7 @@ public:
 
   /// Return weight of i-th bin. \see getIndex()
   double weight(std::size_t i) const { return _wgt[i]; }
+  double weightFast(const RooArgSet& bin, Int_t intOrder=1, Bool_t correctForBinSize=kFALSE, Bool_t cdfBoundaries=kFALSE);
   Double_t weight(const RooArgSet& bin, Int_t intOrder=1, Bool_t correctForBinSize=kFALSE, Bool_t cdfBoundaries=kFALSE, Bool_t oneSafe=kFALSE);
   /// Return squared weight sum of i-th bin. \see getIndex()
   double weightSquared(std::size_t i) const { return get_sumw2(i); }
@@ -250,7 +251,7 @@ protected:
   mutable double* _sumw2{nullptr}; //[_arrSize] Sum of weights^2
   double*         _binv {nullptr}; //[_arrSize] Bin volume array
 
-  RooArgSet  _realVars ; // Real dimensions of the dataset 
+  RooArgSet  _realVars ; // Real dimensions of the dataset
   mutable std::vector<double> _maskedWeights; //! Copy of _wgtVec, but masked events have a weight of zero.
  
   mutable std::size_t _curIndex{std::numeric_limits<std::size_t>::max()}; // Current index

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -96,7 +96,7 @@ public:
 
   /// Return weight of i-th bin. \see getIndex()
   double weight(std::size_t i) const { return _wgt[i]; }
-  double weightFast(const RooArgSet& bin, Int_t intOrder=1, Bool_t correctForBinSize=kFALSE, Bool_t cdfBoundaries=kFALSE);
+  double weightFast(const RooArgSet& bin, int intOrder, bool correctForBinSize, bool cdfBoundaries);
   Double_t weight(const RooArgSet& bin, Int_t intOrder=1, Bool_t correctForBinSize=kFALSE, Bool_t cdfBoundaries=kFALSE, Bool_t oneSafe=kFALSE);
   /// Return squared weight sum of i-th bin. \see getIndex()
   double weightSquared(std::size_t i) const { return get_sumw2(i); }
@@ -225,7 +225,7 @@ protected:
         const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop, Bool_t copyCache) ;
   RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0, 
                   std::size_t nStart=0, std::size_t nStop=std::numeric_limits<std::size_t>::max(), Bool_t copyCache=kTRUE) override;
-  Double_t interpolateDim(RooRealVar& dim, const RooAbsBinning* binning, Double_t xval, Int_t intOrder, Bool_t correctForBinSize, Bool_t cdfBoundaries) ;
+  double interpolateDim(int iDim, double xval, size_t centralIdx, int intOrder, bool correctForBinSize, bool cdfBoundaries) ;
   const std::vector<double>& calculatePartialBinVolume(const RooArgSet& dimSet) const ;
   void checkBinBounds() const;
 
@@ -272,6 +272,8 @@ protected:
   mutable Double_t _cache_sum{0.}; //! Cache for sum of entries ;
 
 private:
+  double weightInterpolated(const RooArgSet& bin, int intOrder, bool correctForBinSize, bool cdfBoundaries);
+
   void _adjustBinning(RooRealVar &theirVar, const TAxis &axis, RooRealVar *ourVar, Int_t *offset);
   void registerWeightArraysToDataStore() const;
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -200,6 +200,8 @@ public:
   ///@}
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+  /// Structure to cache information on the histogram variable that is
+  /// frequently used for histogram weights retrieval.
   struct VarInfo {
     size_t nRealVars = 0;
     size_t realVarIdx1 = 0;

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -200,6 +200,13 @@ public:
   ///@}
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+  struct VarInfo {
+    size_t nRealVars = 0;
+    size_t realVarIdx1 = 0;
+    size_t realVarIdx2 = 0;
+    bool initialized = false;
+  };
+
 protected:
 
   friend class RooAbsCachedPdf ;
@@ -251,7 +258,6 @@ protected:
   mutable double* _sumw2{nullptr}; //[_arrSize] Sum of weights^2
   double*         _binv {nullptr}; //[_arrSize] Bin volume array
 
-  RooArgSet  _realVars ; // Real dimensions of the dataset
   mutable std::vector<double> _maskedWeights; //! Copy of _wgtVec, but masked events have a weight of zero.
  
   mutable std::size_t _curIndex{std::numeric_limits<std::size_t>::max()}; // Current index
@@ -269,7 +275,10 @@ private:
   void _adjustBinning(RooRealVar &theirVar, const TAxis &axis, RooRealVar *ourVar, Int_t *offset);
   void registerWeightArraysToDataStore() const;
 
-  ClassDefOverride(RooDataHist, 5) // Binned data set
+  VarInfo _varInfo; //!
+  VarInfo const& getVarInfo();
+
+  ClassDefOverride(RooDataHist, 6) // Binned data set
 };
 
 #endif

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -1076,6 +1076,36 @@ RooPlot *RooDataHist::plotOn(RooPlot *frame, PlotOpt o) const
   return RooAbsData::plotOn(frame,o) ;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// A faster version of RooDataHist::weight that assumes the passed arguments
+/// are aligned with the histogram variables.
+///
+/// For the interpolation case, the slow version is still used.
+
+double RooDataHist::weightFast(const RooArgSet& bin, Int_t intOrder, Bool_t correctForBinSize, Bool_t cdfBoundaries)
+{
+  checkInit() ;
+
+  // Handle illegal intOrder values
+  if (intOrder<0) {
+    coutE(InputArguments) << "RooDataHist::weight(" << GetName() << ") ERROR: interpolation order must be positive" << endl ;
+    return 0 ;
+  }
+
+  // Handle no-interpolation case
+  if (intOrder==0) {
+    const auto idx = calcTreeIndex(bin, true);
+    if (correctForBinSize) {
+      return get_wgt(idx) / _binv[idx];
+    } else {
+      return get_wgt(idx);
+    }
+  }
+
+  // Handle all interpolation cases with the slow version
+  return weight(bin, intOrder, correctForBinSize, cdfBoundaries);
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the weight at given coordinates with optional interpolation.

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -196,7 +196,7 @@ Double_t RooHistFunc::evaluate() const
     }
   }
 
-  Double_t ret =  _dataHist->weight(_histObsList,_intOrder,kFALSE,_cdfBoundaries) ;  
+  Double_t ret =  _dataHist->weightFast(_histObsList,_intOrder,kFALSE,_cdfBoundaries) ;  
   return ret ;
 }
 

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -217,7 +217,7 @@ Double_t RooHistPdf::evaluate() const
     }
   }
 
-  Double_t ret = _dataHist->weight(_histObsList, _intOrder, !_unitNorm, _cdfBoundaries);
+  Double_t ret = _dataHist->weightFast(_histObsList, _intOrder, !_unitNorm, _cdfBoundaries);
 //  cout << "RooHistPdf::evaluate(" << GetName() << ") ret = " << ret << " ";
 //  cout << _histObsList[0] << " ";
 //  _histObsList[0]->Print("");

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -217,17 +217,9 @@ Double_t RooHistPdf::evaluate() const
     }
   }
 
-  Double_t ret = _dataHist->weightFast(_histObsList, _intOrder, !_unitNorm, _cdfBoundaries);
-//  cout << "RooHistPdf::evaluate(" << GetName() << ") ret = " << ret << " ";
-//  cout << _histObsList[0] << " ";
-//  _histObsList[0]->Print("");
-//  _dataHist->Print("V");
-//  _dataHist->dump2();
+  double ret = _dataHist->weightFast(_histObsList, _intOrder, !_unitNorm, _cdfBoundaries);
 
-  if (ret<0) {
-    ret=0 ;
-  }  
-  return ret ;
+  return std::max(ret, 0.0);
 }
 
 


### PR DESCRIPTION
Retreiving weights from a RooDataHist can be sped up signifcantly if it
is assumed that parameters passed to `RooDataHist::weight` are aligned
with the histogram variables.

This commit introduces a `RooDataHist::weightFast` function that makes
this assumption. It is used by RooHistFunc and RooHistPdf.

This was benchmarked with the same hist factory example as in https://github.com/root-project/root/pull/7838:

* [without this PR, but with #7838](https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/hf_ParamHistFunc_1_new_2)
* [also with this PR](https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/hf_ParamHistFunc_1_new_3)

The effect is a 15 % speedup of the HistFactory example.