### PR TITLE
[ntuple] Resolve typedef names during serialization

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -546,8 +546,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
    }
    TIter next(fClass->GetListOfDataMembers());
    while (auto dataMember = static_cast<TDataMember *>(next())) {
-      //printf("Now looking at %s %s\n", dataMember->GetName(), dataMember->GetFullTypeName());
-      auto subField = Detail::RFieldBase::Create(dataMember->GetName(), dataMember->GetFullTypeName()).Unwrap();
+      auto subField = Detail::RFieldBase::Create(dataMember->GetName(), dataMember->GetTrueTypeName()).Unwrap();
       fMaxAlignment = std::max(fMaxAlignment, subField->GetAlignment());
       Attach(std::move(subField));
    }

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -8,5 +8,6 @@ struct CustomStruct {
    float a = 0.0;
    std::vector<float> v1;
    std::vector<std::vector<float>> v2;
-   std::string s;
+   typedef std::string typedef_string;
+   typedef_string s;
 };


### PR DESCRIPTION
Fixes #7861 by using `GetTrueTypeName` instead of `GetFullTypeName`. See the issue for more information.