### PR TITLE
[DF] Do not warn needlessly in ~RResultPtr

### DIFF
--- a/tree/dataframe/inc/ROOT/RResultPtr.hxx
+++ b/tree/dataframe/inc/ROOT/RResultPtr.hxx
@@ -180,7 +180,12 @@ public:
    RResultPtr &operator=(const RResultPtr &) = default;
    RResultPtr &operator=(RResultPtr &&) = default;
    explicit operator bool() const { return bool(fObjPtr); }
-   ~RResultPtr() { ROOT::Internal::RDF::WarnOnLazySnapshotNotTriggered(*this); }
+   ~RResultPtr()
+   {
+      if (fObjPtr.use_count() == 1) {
+         ROOT::Internal::RDF::WarnOnLazySnapshotNotTriggered(*this);
+      }
+   }
 
    /// Convert a RResultPtr<T2> to a RResultPtr<T>.
    ///

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -682,6 +682,23 @@ TEST(RDFSnapshotMore, LazyNotTriggered)
    ROOT_EXPECT_WARNING(BookLazySnapshot(), "Snapshot", "A lazy Snapshot action was booked but never triggered.");
 }
 
+RResultPtr<RInterface<RLoopManager, void>> ReturnLazySnapshot(const char *fname)
+{
+   auto d = ROOT::RDataFrame(1);
+   ROOT::RDF::RSnapshotOptions opts;
+   opts.fLazy = true;
+   auto res = d.Snapshot<ULong64_t>("t", fname, {"rdfentry_"}, opts);
+   RResultPtr<RInterface<RLoopManager, void>> res2 = res;
+   return res;
+}
+
+TEST(RDFSnapshotMore, LazyTriggeredAfterCopy)
+{
+   const auto fname = "lazysnapshottriggeredaftercopy.root";
+   ROOT_EXPECT_NODIAG(*ReturnLazySnapshot(fname));
+   gSystem->Unlink(fname);
+}
+
 void CheckTClonesArrayOutput(const RVec<TH1D> &hvec)
 {
    ASSERT_EQ(hvec.size(), 3);


### PR DESCRIPTION
We want to warn users if a RResultPtr returned by a lazy Snapshot
action is destroyed before the event loop is run, but _only_ if there
are no other RResultPtr objects that share ownership of the result,
i.e. if there is no way to trigger this Snapshot in the future.