### PR TITLE
[treereader] Try harder when looking for a leaf

### DIFF
--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -745,6 +745,12 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
       if ((!dataTypeName || !dataTypeName[0])
           && branch->IsA() == TBranch::Class()) {
          TLeaf *myLeaf = branch->GetLeaf(branch->GetName());
+         if (!myLeaf) {
+            myLeaf = branch->FindLeaf(branch->GetName());
+         }
+         if (!myLeaf && branch->GetListOfLeaves()->GetEntries() == 1) {
+            myLeaf = static_cast<TLeaf *>(branch->GetListOfLeaves()->UncheckedAt(0));
+         }
          if (myLeaf){
             TDictionary *myDataType = TDictionary::GetDictionary(myLeaf->GetTypeName());
             if (myDataType && myDataType->IsA() == TDataType::Class()){

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -234,3 +234,18 @@ TEST(TTreeReaderLeafs, MultipleReaders) {
    EXPECT_EQ(*v2, 1) << "Wrong value read for rv2!";
    EXPECT_EQ(*v3, 1) << "Wrong value read for rv3!";
 }
+
+// Test for https://github.com/root-project/root/issues/6881
+TEST(TTreeReaderLeafs, BranchAndLeafWithDifferentNames)
+{
+   TTree t("t", "t");
+   int x = 42;
+   t.Branch("x", &x, "y/I");
+   t.Fill();
+
+   TTreeReader r(&t);
+   TTreeReaderValue<int> rv(r, "x");
+   ASSERT_TRUE(r.Next());
+   EXPECT_EQ(*rv, 42);
+   EXPECT_FALSE(r.Next());
+}

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -246,7 +246,9 @@ TEST(TTreeReaderLeafs, BranchAndLeafWithDifferentNames)
 
    TTreeReader r(&t);
    TTreeReaderValue<int> rv(r, "x");
+   TTreeReaderValue<int> rvwithdot(r, "x.y");
    ASSERT_TRUE(r.Next());
    EXPECT_EQ(*rv, 42);
+   EXPECT_EQ(*rvwithdot, 42);
    EXPECT_FALSE(r.Next());
 }

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -218,10 +218,11 @@ struct Event {
    int truth_type = 1;
 };
 
-TEST(TTreeReaderLeafs, MultipleReaders) {
-   TTree t("t","t");
+TEST(TTreeReaderLeafs, MultipleReaders)
+{
+   TTree t("t", "t");
    Event event;
-   t.Branch ("event", &event, "bla/F:truth_type/I");
+   t.Branch("event", &event, "bla/F:truth_type/I");
    t.Fill();
 
    TTreeReader r(&t);


### PR DESCRIPTION
Before this patch, given a TTree with a branch with name different
from its leaf, e.g. like this:

```
*Br    0 :NUD_total_ADC : nud_total_adc/D
```

TTreeReaderValue failed to retrieve the leaf when the named passed
to the constructor was just "NUD_total_ADC" (while it worked fine
with "NUD_total_ADC.nud_total_adc"). In comparison, in a similar
situation `TTree::Draw` "tries harder" and it assumes that the
desired leaf is the first sub-leaf of the specified branch.

With this patch, TTreeReaderValue tries `FindLeaf` after `GetLeaf`
and as a last resort it picks the branch sub-leaf if it exists and
it is unique.

This fixes #6881.