### PR TITLE
[core] Next bunch of changes for Win64

### DIFF
--- a/core/base/inc/TMacro.h
+++ b/core/base/inc/TMacro.h
@@ -47,7 +47,7 @@ public:
    virtual TMD5        *Checksum();
    virtual TObjString  *GetLineWith(const char *text) const;
    virtual Bool_t       Load() const; //*MENU*
-   virtual Long_t       Exec(const char *params = 0, Int_t* error = 0); //*MENU*
+   virtual Longptr_t    Exec(const char *params = 0, Int_t* error = 0); //*MENU*
    TList               *GetListOfLines() const {return fLines;}
    virtual void         Paint(Option_t *option="");
    virtual void         Print(Option_t *option="") const;  //*MENU*

--- a/core/base/inc/TPluginManager.h
+++ b/core/base/inc/TPluginManager.h
@@ -147,7 +147,7 @@ public:
    template <typename... T> Longptr_t ExecPluginImpl(const T&... params)
    {
       auto nargs = sizeof...(params);
-      if (!CheckForExecPlugin(nargs)) return 0;
+      if (!CheckForExecPlugin((Int_t)nargs)) return 0;
 
       // The fCallEnv object is shared, since the PluginHandler is a global
       // resource ... and both SetParams and Execute ends up taking the lock

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -562,7 +562,7 @@ operator+(T f, const TString &s)
 }
 
 inline TString &TString::Append(const char *cs)
-{ return Replace(Length(), 0, cs, cs ? strlen(cs) : 0); }
+{ return Replace(Length(), 0, cs, cs ? (Ssiz_t)strlen(cs) : 0); }
 
 inline TString &TString::Append(const char *cs, Ssiz_t n)
 { return Replace(Length(), 0, cs, n); }
@@ -574,7 +574,7 @@ inline TString &TString::Append(const TString &s, Ssiz_t n)
 { return Replace(Length(), 0, s.Data(), TMath::Min(n, s.Length())); }
 
 inline TString &TString::operator+=(const char *cs)
-{ return Append(cs, cs ? strlen(cs) : 0); }
+{ return Append(cs, cs ? (Ssiz_t)strlen(cs) : 0); }
 
 inline TString &TString::operator+=(const TString &s)
 { return Append(s.Data(), s.Length()); }
@@ -613,7 +613,7 @@ inline typename std::enable_if<ROOT::TypeTraits::IsFloatNumeral<T>::value,TStrin
 }
 
 inline Bool_t TString::BeginsWith(const char *s, ECaseCompare cmp) const
-{ return Index(s, s ? strlen(s) : (Ssiz_t)0, (Ssiz_t)0, cmp) == 0; }
+{ return Index(s, s ? (Ssiz_t)strlen(s) : (Ssiz_t)0, (Ssiz_t)0, cmp) == 0; }
 
 inline Bool_t TString::BeginsWith(const TString &pat, ECaseCompare cmp) const
 { return Index(pat.Data(), pat.Length(), (Ssiz_t)0, cmp) == 0; }
@@ -622,7 +622,7 @@ inline Bool_t TString::Contains(const TString &pat, ECaseCompare cmp) const
 { return Index(pat.Data(), pat.Length(), (Ssiz_t)0, cmp) != kNPOS; }
 
 inline Bool_t TString::Contains(const char *s, ECaseCompare cmp) const
-{ return Index(s, s ? strlen(s) : 0, (Ssiz_t)0, cmp) != kNPOS; }
+{ return Index(s, s ? (Ssiz_t)strlen(s) : 0, (Ssiz_t)0, cmp) != kNPOS; }
 
 inline Bool_t TString::Contains(const TRegexp &pat) const
 { return Index(pat, (Ssiz_t)0) != kNPOS; }
@@ -637,7 +637,7 @@ inline Bool_t TString::EqualTo(const TString &st, ECaseCompare cmp) const
 { return (CompareTo(st, cmp) == 0) ? kTRUE : kFALSE; }
 
 inline Ssiz_t TString::Index(const char *s, Ssiz_t i, ECaseCompare cmp) const
-{ return Index(s, s ? strlen(s) : 0, i, cmp); }
+{ return Index(s, s ? (Ssiz_t)strlen(s) : 0, i, cmp); }
 
 inline Ssiz_t TString::Index(const TString &s, Ssiz_t i, ECaseCompare cmp) const
 { return Index(s.Data(), s.Length(), i, cmp); }
@@ -647,7 +647,7 @@ inline Ssiz_t TString::Index(const TString &pat, Ssiz_t patlen, Ssiz_t i,
 { return Index(pat.Data(), patlen, i, cmp); }
 
 inline TString &TString::Insert(Ssiz_t pos, const char *cs)
-{ return Replace(pos, 0, cs, cs ? strlen(cs) : 0); }
+{ return Replace(pos, 0, cs, cs ? (Ssiz_t)strlen(cs) : 0); }
 
 inline TString &TString::Insert(Ssiz_t pos, const char *cs, Ssiz_t n)
 { return Replace(pos, 0, cs, n); }
@@ -659,7 +659,7 @@ inline TString &TString::Insert(Ssiz_t pos, const TString &s, Ssiz_t n)
 { return Replace(pos, 0, s.Data(), TMath::Min(n, s.Length())); }
 
 inline TString &TString::Prepend(const char *cs)
-{ return Replace(0, 0, cs, cs ? strlen(cs) : 0); }
+{ return Replace(0, 0, cs, cs ? (Ssiz_t)strlen(cs) : 0); }
 
 inline TString &TString::Prepend(const char *cs, Ssiz_t n)
 { return Replace(0, 0, cs, n); }
@@ -680,7 +680,7 @@ inline TString &TString::Chop()
 { return Remove(TMath::Max(0, Length()-1)); }
 
 inline TString &TString::Replace(Ssiz_t pos, Ssiz_t n, const char *cs)
-{ return Replace(pos, n, cs, cs ? strlen(cs) : 0); }
+{ return Replace(pos, n, cs, cs ? (Ssiz_t)strlen(cs) : 0); }
 
 inline TString &TString::Replace(Ssiz_t pos, Ssiz_t n, const TString& s)
 { return Replace(pos, n, s.Data(), s.Length()); }
@@ -693,13 +693,13 @@ inline TString &TString::ReplaceAll(const TString &s1, const TString &s2)
 { return ReplaceAll(s1.Data(), s1.Length(), s2.Data(), s2.Length()) ; }
 
 inline TString &TString::ReplaceAll(const TString &s1, const char *s2)
-{ return ReplaceAll(s1.Data(), s1.Length(), s2, s2 ? strlen(s2) : 0); }
+{ return ReplaceAll(s1.Data(), s1.Length(), s2, s2 ? (Ssiz_t)strlen(s2) : 0); }
 
 inline TString &TString::ReplaceAll(const char *s1, const TString &s2)
-{ return ReplaceAll(s1, s1 ? strlen(s1) : 0, s2.Data(), s2.Length()); }
+{ return ReplaceAll(s1, s1 ? (Ssiz_t)strlen(s1) : 0, s2.Data(), s2.Length()); }
 
 inline TString &TString::ReplaceAll(const char *s1,const char *s2)
-{ return ReplaceAll(s1, s1 ? strlen(s1) : 0, s2, s2 ? strlen(s2) : 0); }
+{ return ReplaceAll(s1, s1 ? (Ssiz_t)strlen(s1) : 0, s2, s2 ? (Ssiz_t)strlen(s2) : 0); }
 
 inline TString &TString::Swap(TString &other) {
    // Swap the contents of other and this without reallocation.

--- a/core/base/inc/TVirtualX.h
+++ b/core/base/inc/TVirtualX.h
@@ -105,10 +105,10 @@ public:
    virtual Float_t   GetTextMagnitude();
    virtual Window_t  GetWindowID(Int_t wid);
    virtual Bool_t    HasTTFonts() const;
-   virtual Int_t     InitWindow(ULong_t window);
-   virtual Int_t     AddWindow(ULong_t qwid, UInt_t w, UInt_t h);
-   virtual Int_t     AddPixmap(ULong_t pixid, UInt_t w, UInt_t h);
-   virtual void      RemoveWindow(ULong_t qwid);
+   virtual Int_t     InitWindow(ULongptr_t window);
+   virtual Int_t     AddWindow(ULongptr_t qwid, UInt_t w, UInt_t h);
+   virtual Int_t     AddPixmap(ULongptr_t pixid, UInt_t w, UInt_t h);
+   virtual void      RemoveWindow(ULongptr_t qwid);
    virtual void      MoveWindow(Int_t wid, Int_t x, Int_t y);
    virtual Int_t     OpenPixmap(UInt_t w, UInt_t h);
    virtual void      QueryPointer(Int_t &ix, Int_t &iy);
@@ -167,7 +167,7 @@ public:
    virtual void         MoveResizeWindow(Window_t id, Int_t x, Int_t y, UInt_t w, UInt_t h);
    virtual void         ResizeWindow(Window_t id, UInt_t w, UInt_t h);
    virtual void         IconifyWindow(Window_t id);
-   virtual Bool_t       NeedRedraw(ULong_t tgwindow, Bool_t force);
+   virtual Bool_t       NeedRedraw(ULongptr_t tgwindow, Bool_t force);
    virtual void         ReparentWindow(Window_t id, Window_t pid, Int_t x, Int_t y);
    virtual void         SetWindowBackground(Window_t id, ULong_t color);
    virtual void         SetWindowBackgroundPixmap(Window_t id, Pixmap_t pxm);

--- a/core/base/src/TBuffer.cxx
+++ b/core/base/src/TBuffer.cxx
@@ -248,7 +248,7 @@ void TBuffer::Expand(Int_t newsize, Bool_t copy)
       } else if (fReAllocFunc == R__NoReAllocChar) {
          Fatal("Expand","Failed to expand the data buffer because TBuffer does not own it and no custom memory reallocator was provided.");
       } else {
-         Fatal("Expand","Failed to expand the data buffer using custom memory reallocator 0x%lx.", (Long_t)fReAllocFunc);
+         Fatal("Expand","Failed to expand the data buffer using custom memory reallocator 0x%zx.", (size_t)fReAllocFunc);
       }
    }
    fBufSize = newsize;

--- a/core/base/src/TMacro.cxx
+++ b/core/base/src/TMacro.cxx
@@ -183,7 +183,7 @@ void TMacro::Browse(TBrowser * /*b*/)
       return;
    }
    if (opt.Contains(".C")) {
-      const char *cmd = Form(".x %s((TMacro*)0x%lx)",opt.Data(),(ULong_t)this);
+      const char *cmd = Form(".x %s((TMacro*)0x%zx)",opt.Data(),(size_t)this);
       gROOT->ProcessLine(cmd);
       return;
    }
@@ -265,7 +265,7 @@ Bool_t TMacro::Load() const
 /// Returns the result of the macro (return value or value of the last
 /// expression), cast to a Long_t.
 
-Long_t TMacro::Exec(const char *params, Int_t* error)
+Longptr_t TMacro::Exec(const char *params, Int_t* error)
 {
    if ( !gROOT->GetGlobalFunction(GetName(), 0, kTRUE) ) {
       if (!Load()) {
@@ -286,7 +286,7 @@ Long_t TMacro::Exec(const char *params, Int_t* error)
          exec += "(" + p + ")";
       else
          exec += "()";
-      Long_t ret = gROOT->ProcessLine(exec, error);
+      Longptr_t ret = gROOT->ProcessLine(exec, error);
       //enable gROOT->Reset
       gROOT->SetExecutingMacro(kFALSE);
       return ret;

--- a/core/base/src/TProcessID.cxx
+++ b/core/base/src/TProcessID.cxx
@@ -272,7 +272,7 @@ TProcessID *TProcessID::GetProcessWithUID(UInt_t uid, const void *obj)
       ULong_t hash = Void_Hash(obj);
 
       R__READ_LOCKGUARD(ROOT::gCoreMutex);
-      pid = fgObjPIDs->GetValue(hash,(Long_t)obj);
+      pid = fgObjPIDs->GetValue(hash,(Longptr_t)obj);
       return (TProcessID*)fgPIDs->At(pid);
    } else {
       auto current = gGetProcessWithUIDCache.load();
@@ -401,7 +401,7 @@ void TProcessID::PutObjectWithID(TObject *obj, UInt_t uid)
       // if the address has already been registered, we want to
       // update it's uniqueID (this can easily happen when the
       // referenced object have been stored in a TClonesArray.
-      (*fgObjPIDs)(hash, (Long_t)obj) = GetUniqueID();
+      (*fgObjPIDs)(hash, (Longptr_t)obj) = GetUniqueID();
    }
 }
 

--- a/core/base/src/TQCommand.cxx
+++ b/core/base/src/TQCommand.cxx
@@ -1012,7 +1012,7 @@ void TQUndoManager::Add(TObject *obj, Option_t *opt)
 
 void TQUndoManager::CurrentChanged(TQCommand *c)
 {
-   Emit("CurrentChanged(TQCommand*)", (long)c);
+   Emit("CurrentChanged(TQCommand*)", (Longptr_t)c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TRef.cxx
+++ b/core/base/src/TRef.cxx
@@ -496,7 +496,7 @@ void TRef::Streamer(TBuffer &R__b)
          fPID = pid;
          SetUniqueID(number);
          if (gDebug > 1) {
-            printf("Reading TRef (HasUUID) uid=%d, obj=%lx\n",GetUniqueID(),(Long_t)GetObject());
+            printf("Reading TRef (HasUUID) uid=%d, obj=%zx\n",GetUniqueID(),(size_t)GetObject());
          }
       } else {
          R__b >> pidf;
@@ -509,7 +509,7 @@ void TRef::Streamer(TBuffer &R__b)
          Int_t execid = R__b.GetTRefExecId();
          if (execid) SetBit(execid<<16);
          if (gDebug > 1) {
-            printf("Reading TRef, pidf=%d, fPID=%lx, uid=%d, obj=%lx\n",pidf,(Long_t)fPID,GetUniqueID(),(Long_t)GetObject());
+            printf("Reading TRef, pidf=%d, fPID=%zx, uid=%d, obj=%zx\n",pidf,(size_t)fPID,GetUniqueID(),(size_t)GetObject());
          }
       }
    } else {
@@ -519,13 +519,13 @@ void TRef::Streamer(TBuffer &R__b)
          TObjString *objs = gROOT->GetUUIDs()->FindUUID(GetUniqueID());
          objs->String().Streamer(R__b);
          if (gDebug > 1) {
-            printf("Writing TRef (HasUUID) uid=%d, obj=%lx\n",GetUniqueID(),(Long_t)GetObject());
+            printf("Writing TRef (HasUUID) uid=%d, obj=%zx\n",GetUniqueID(),(size_t)GetObject());
          }
       } else {
          pidf = R__b.WriteProcessID(fPID);
          R__b << pidf;
          if (gDebug > 1) {
-            printf("Writing TRef, pidf=%d, fPID=%lx, uid=%d, obj=%lx\n",pidf,(Long_t)fPID,GetUniqueID(),(Long_t)GetObject());
+            printf("Writing TRef, pidf=%d, fPID=%zx, uid=%d, obj=%zx\n",pidf,(size_t)fPID,GetUniqueID(),(size_t)GetObject());
          }
       }
    }

--- a/core/base/src/TRemoteObject.cxx
+++ b/core/base/src/TRemoteObject.cxx
@@ -60,7 +60,7 @@ TRemoteObject::TRemoteObject(const char *name, const char *title,
        !strcmp(classname, "TSystemFile")) {
       gSystem->GetPathInfo(name, fFileStat);
    }
-   Long_t raddr = (Long_t) this;
+   Long64_t raddr = (Long64_t) this;
    fRemoteAddress = raddr;
 }
 
@@ -92,7 +92,7 @@ void TRemoteObject::Browse(TBrowser *b)
       TObject *obj = (TObject *)gROOT->ProcessLine(Form("((TApplicationServer *)gApplication)->BrowseKey(\"%s\");", GetName()));
       if (obj) {
          if (obj->IsA()->GetMethodWithPrototype("SetDirectory", "TDirectory*"))
-            gROOT->ProcessLine(Form("((%s *)0x%lx)->SetDirectory(0);", obj->ClassName(), (ULong_t)obj));
+            gROOT->ProcessLine(Form("((%s *)0x%zx)->SetDirectory(0);", obj->ClassName(), (size_t)obj));
          obj->Browse(b);
          b->SetRefreshFlag(kTRUE);
       }

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -561,7 +561,7 @@ UInt_t Hash(const char *str)
    UInt_t hv  = len; // Mix in the string length.
    UInt_t i   = hv*sizeof(char)/sizeof(UInt_t);
 
-   if (((ULong_t)str)%sizeof(UInt_t) == 0) {
+   if (((ULongptr_t)str)%sizeof(UInt_t) == 0) {
       // str is word aligned
       const UInt_t *p = (const UInt_t*)str;
 

--- a/core/base/src/TVirtualX.cxx
+++ b/core/base/src/TVirtualX.cxx
@@ -536,7 +536,7 @@ Window_t TVirtualX::GetWindowID(Int_t /*wid*/)
 /// Creates a new window and return window number.
 /// Returns -1 if window initialization fails.
 
-Int_t TVirtualX::InitWindow(ULong_t /*window*/)
+Int_t TVirtualX::InitWindow(ULongptr_t /*window*/)
 {
    return 0;
 }
@@ -547,7 +547,7 @@ Int_t TVirtualX::InitWindow(ULong_t /*window*/)
 /// \param [in] qwid   window identifier
 /// \param [in] w, h   the width and height, which define the window size
 
-Int_t TVirtualX::AddWindow(ULong_t /*qwid*/, UInt_t /*w*/, UInt_t /*h*/)
+Int_t TVirtualX::AddWindow(ULongptr_t /*qwid*/, UInt_t /*w*/, UInt_t /*h*/)
 {
    return 0;
 }
@@ -558,7 +558,7 @@ Int_t TVirtualX::AddWindow(ULong_t /*qwid*/, UInt_t /*w*/, UInt_t /*h*/)
 /// \param [in] pixid  pixmap identifier
 /// \param [in] w, h   the width and height, which define the pixmap size
 
-Int_t TVirtualX::AddPixmap(ULong_t /*pixid*/, UInt_t /*w*/, UInt_t /*h*/)
+Int_t TVirtualX::AddPixmap(ULongptr_t /*pixid*/, UInt_t /*w*/, UInt_t /*h*/)
 {
    return 0;
 }
@@ -567,7 +567,7 @@ Int_t TVirtualX::AddPixmap(ULong_t /*pixid*/, UInt_t /*w*/, UInt_t /*h*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Removes the created by Qt window "qwid".
 
-void TVirtualX::RemoveWindow(ULong_t /*qwid*/)
+void TVirtualX::RemoveWindow(ULongptr_t /*qwid*/)
 {
 }
 
@@ -1123,7 +1123,7 @@ void TVirtualX::IconifyWindow(Window_t /*id*/)
 /// all paint operations within "expose" / "paint" like low level event
 /// or equivalent
 
-Bool_t TVirtualX::NeedRedraw(ULong_t /*tgwindow*/, Bool_t /*force*/)
+Bool_t TVirtualX::NeedRedraw(ULongptr_t /*tgwindow*/, Bool_t /*force*/)
 {
    return kFALSE;
 }

--- a/core/cont/src/TArray.cxx
+++ b/core/cont/src/TArray.cxx
@@ -29,7 +29,7 @@ ClassImp(TArray);
 
 Bool_t TArray::OutOfBoundsError(const char *where, Int_t i) const
 {
-   ::Error(where, "index %d out of bounds (size: %d, this: 0x%lx)", i, fN, (Long_t)this);
+   ::Error(where, "index %d out of bounds (size: %d, this: 0x%zx)", i, fN, (size_t)this);
    return kFALSE;
 }
 

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -132,7 +132,7 @@ namespace ROOT {
       void Print() {
          Info("TMapTypeToClassRec::Print", "printing the typeinfo map in TClassTable");
          for (const_iterator iter = fMap.begin(); iter != fMap.end(); ++iter) {
-            printf("Key: %40s 0x%lx\n", iter->first.c_str(), (unsigned long)iter->second);
+            printf("Key: %40s 0x%zx\n", iter->first.c_str(), (size_t)iter->second);
          }
       }
 #else
@@ -592,7 +592,7 @@ DictFuncPtr_t TClassTable::GetDict(const std::type_info& info)
    if (!CheckClassTableInit()) return nullptr;
 
    if (gDebug > 9) {
-      ::Info("GetDict", "searches for %s at 0x%lx", info.name(), (Long_t)&info);
+      ::Info("GetDict", "searches for %s at 0x%zx", info.name(), (size_t)&info);
       fgIdMap->Print();
    }
 

--- a/core/cont/src/TClonesArray.cxx
+++ b/core/cont/src/TClonesArray.cxx
@@ -908,7 +908,7 @@ void TClonesArray::Streamer(TBuffer &b)
 TObject *&TClonesArray::operator[](Int_t idx)
 {
    if (idx < 0) {
-      Error("operator[]", "out of bounds at %d in %lx", idx, (Long_t)this);
+      Error("operator[]", "out of bounds at %d in %zx", idx, (size_t)this);
       return fCont[0];
    }
    if (!fClass) {
@@ -942,7 +942,7 @@ TObject *&TClonesArray::operator[](Int_t idx)
 TObject *TClonesArray::operator[](Int_t idx) const
 {
    if (idx < 0 || idx >= fSize) {
-      Error("operator[]", "out of bounds at %d in %lx", idx, (Long_t)this);
+      Error("operator[]", "out of bounds at %d in %zx", idx, (size_t)this);
       return 0;
    }
 
@@ -956,7 +956,7 @@ TObject *TClonesArray::operator[](Int_t idx) const
 TObject *TClonesArray::New(Int_t idx)
 {
    if (idx < 0) {
-      Error("New", "out of bounds at %d in %lx", idx, (Long_t)this);
+      Error("New", "out of bounds at %d in %zx", idx, (size_t)this);
       return 0;
    }
    if (!fClass) {

--- a/core/cont/src/TObjArray.cxx
+++ b/core/cont/src/TObjArray.cxx
@@ -237,7 +237,7 @@ void TObjArray::AddAtAndExpand(TObject *obj, Int_t idx)
    R__COLLECTION_WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    if (idx < fLowerBound) {
-      Error("AddAt", "out of bounds at %d in %lx", idx, (Long_t)this);
+      Error("AddAt", "out of bounds at %d in %zx", idx, (size_t)this);
       return;
    }
    if (idx-fLowerBound >= fSize)
@@ -657,7 +657,7 @@ TIterator *TObjArray::MakeIterator(Bool_t dir) const
 
 Bool_t TObjArray::OutOfBoundsError(const char *where, Int_t i) const
 {
-   Error(where, "index %d out of bounds (size: %d, this: 0x%lx)", i, fSize, (Long_t)this);
+   Error(where, "index %d out of bounds (size: %d, this: 0x%zx)", i, fSize, (size_t)this);
    return kFALSE;
 }
 

--- a/core/cont/src/TObjectTable.cxx
+++ b/core/cont/src/TObjectTable.cxx
@@ -131,7 +131,7 @@ void TObjectTable::Print(Option_t *option) const
          if (!fTable[i]) continue;
          num++;
          obj = fTable[i];
-         printf("%-8d 0x%-16lx %-24s %s\n", num, (Long_t)obj, obj->ClassName(),
+         printf("%-8d 0x%-16zx %-24s %s\n", num, (size_t)obj, obj->ClassName(),
                 obj->GetName());
       }
       Printf("================================================================================\n");
@@ -218,10 +218,10 @@ void TObjectTable::Remove(TObject *op)
 
    Int_t i = FindElement(op);
    if (fTable[i] == 0) {
-      Warning("Remove", "0x%lx not found at %d", (Long_t)op, i);
+      Warning("Remove", "0x%zx not found at %d", (size_t)op, i);
       for (int j = 0; j < fSize; j++) {
          if (fTable[j] == op) {
-            Error("Remove", "0x%lx found at %d !!!", (Long_t)op, j);
+            Error("Remove", "0x%zx found at %d !!!", (size_t)op, j);
             i = j;
          }
       }
@@ -385,7 +385,7 @@ void TObjectTable::UpdateInstCount() const
          if (op->TestBit(TObject::kNotDeleted))
             op->IsA()->AddInstance(op->IsOnHeap());
          else
-            Error("UpdateInstCount", "oops 0x%lx\n", (Long_t)op);
+            Error("UpdateInstCount", "oops 0x%zx\n", (size_t)op);
       }
 }
 
@@ -397,7 +397,7 @@ void *TObjectTable::CheckPtrAndWarn(const char *msg, void *vp)
 {
    if (fTable && vp && fTable[FindElement((TObject*)vp)]) {
       Remove((TObject*)vp);
-      Warning("CheckPtrAndWarn", "%s (0x%lx)\n", msg, (Long_t)vp);
+      Warning("CheckPtrAndWarn", "%s (0x%zx)\n", msg, (size_t)vp);
    }
    return vp;
 }

--- a/core/cont/src/TRefArray.cxx
+++ b/core/cont/src/TRefArray.cxx
@@ -336,7 +336,7 @@ void TRefArray::AddAtAndExpand(TObject *obj, Int_t idx)
 {
    if (!obj) return;
    if (idx < fLowerBound) {
-      Error("AddAt", "out of bounds at %d in %lx", idx, (Long_t)this);
+      Error("AddAt", "out of bounds at %d in %zx", idx, (size_t)this);
       return;
    }
    if (idx-fLowerBound >= fSize)
@@ -528,7 +528,7 @@ void TRefArray::Streamer(TBuffer &R__b)
       R__b >> pidf;
       pidf += R__b.GetPidOffset();
       fPID = R__b.ReadProcessID(pidf);
-      if (gDebug > 1) printf("Reading TRefArray, pidf=%d, fPID=%lx, nobjects=%d\n",pidf,(Long_t)fPID,nobjects);
+      if (gDebug > 1) printf("Reading TRefArray, pidf=%d, fPID=%zx, nobjects=%d\n",pidf,(size_t)fPID,nobjects);
       for (Int_t i = 0; i < nobjects; i++) {
          R__b >> fUIDs[i];
          if (fUIDs[i] != 0) fLast = i;
@@ -549,7 +549,7 @@ void TRefArray::Streamer(TBuffer &R__b)
       R__b << fLowerBound;
       pidf = R__b.WriteProcessID(fPID);
       R__b << pidf;
-      if (gDebug > 1) printf("Writing TRefArray, pidf=%d, fPID=%lx, nobjects=%d\n",pidf,(Long_t)fPID,nobjects);
+      if (gDebug > 1) printf("Writing TRefArray, pidf=%d, fPID=%zx, nobjects=%d\n",pidf,(size_t)fPID,nobjects);
 
       for (Int_t i = 0; i < nobjects; i++) {
          R__b << fUIDs[i];
@@ -713,7 +713,7 @@ TIterator *TRefArray::MakeIterator(Bool_t dir) const
 
 Bool_t TRefArray::OutOfBoundsError(const char *where, Int_t i) const
 {
-   Error(where, "index %d out of bounds (size: %d, this: 0x%lx)", i, fSize, (Long_t)this);
+   Error(where, "index %d out of bounds (size: %d, this: 0x%zx)", i, fSize, (size_t)this);
    return kFALSE;
 }
 

--- a/core/cont/src/TSeqCollection.cxx
+++ b/core/cont/src/TSeqCollection.cxx
@@ -272,7 +272,7 @@ Long64_t TSeqCollection::Merge(TCollection *list)
       }
       // Merge current object with objects in the temporary list
       if (mergeable) {
-         callEnv.SetParam((Long_t) templist);
+         callEnv.SetParam((Longptr_t) templist);
          callEnv.Execute(object);
          SafeDelete(templist);
       }

--- a/core/gui/inc/GuiTypes.h
+++ b/core/gui/inc/GuiTypes.h
@@ -23,7 +23,7 @@
 #include <climits>
 
 // Basic GUI types
-typedef ULong_t            Handle_t;     ///< Generic resource handle
+typedef ULongptr_t         Handle_t;     ///< Generic resource handle
 typedef Handle_t           Display_t;    ///< Display handle
 typedef Handle_t           Visual_t;     ///< Visual handle
 typedef Handle_t           Window_t;     ///< Window handle
@@ -184,7 +184,7 @@ struct Event_t {
    Bool_t      fSendEvent;         ///< true if event came from SendEvent
    Handle_t    fHandle;            ///< general resource handle (used for atoms or windows)
    Int_t       fFormat;            ///< Next fields only used by kClientMessageEvent
-   Long_t      fUser[5];           ///< 5 longs can be used by client message events
+   Longptr_t   fUser[5];           ///< 5 longs can be used by client message events
                                    ///< NOTE: only [0], [1] and [2] may be used.
                                    ///< [1] and [2] may contain >32 bit quantities
                                    ///< (i.e. pointers on 64 bit machines)

--- a/core/gui/src/TContextMenu.cxx
+++ b/core/gui/src/TContextMenu.cxx
@@ -161,7 +161,7 @@ void TContextMenu::Action(TClassMenuItem *menuitem)
 #endif
             } else {
 #ifndef WIN32
-               Execute(object, method, Form("(TObject*)0x%zx",(Long_t)fSelectedObject));
+               Execute(object, method, Form("(TObject*)0x%zx",(size_t)fSelectedObject));
 #else
                // It is a workaround of the "Dead lock under Windows
                char *cmd = Form("((TContextMenu *)0x%zx)->Execute((TObject *)0x%zx,"

--- a/core/gui/src/TContextMenu.cxx
+++ b/core/gui/src/TContextMenu.cxx
@@ -152,22 +152,22 @@ void TContextMenu::Action(TClassMenuItem *menuitem)
                Execute(object, method, "");
 #else
                // It is a workaround of the "Dead lock under Windows
-               char *cmd = Form("((TContextMenu *)0x%lx)->Execute((TObject *)0x%lx,"
-                                "(TMethod *)0x%lx,\"\");",
-                                (Long_t)this,(Long_t)object,(Long_t)method);
+               char *cmd = Form("((TContextMenu *)0x%zx)->Execute((TObject *)0x%zx,"
+                                "(TMethod *)0x%zx,\"\");",
+                                (size_t)this,(size_t)object,(size_t)method);
                //Printf("%s", cmd);
                gROOT->ProcessLine(cmd);
                //Execute( object, method, (TObjArray *)NULL );
 #endif
             } else {
 #ifndef WIN32
-               Execute(object, method, Form("(TObject*)0x%lx",(Long_t)fSelectedObject));
+               Execute(object, method, Form("(TObject*)0x%zx",(Long_t)fSelectedObject));
 #else
                // It is a workaround of the "Dead lock under Windows
-               char *cmd = Form("((TContextMenu *)0x%lx)->Execute((TObject *)0x%lx,"
-                                "(TMethod *)0x%lx,(TObject*)0x%lx);",
-                                (Long_t)this,(Long_t)object,(Long_t)method,
-                                (Long_t)fSelectedObject);
+               char *cmd = Form("((TContextMenu *)0x%zx)->Execute((TObject *)0x%zx,"
+                                "(TMethod *)0x%zx,(TObject*)0x%zx);",
+                                (size_t)this,(size_t)object,(size_t)method,
+                                (size_t)fSelectedObject);
                //Printf("%s", cmd);
                gROOT->ProcessLine(cmd);
                //Execute( object, method, (TObjArray *)NULL );
@@ -192,8 +192,8 @@ void TContextMenu::Action(TClassMenuItem *menuitem)
             if (menuitem->GetSelfObjectPos() < 0) {
                cmd = Form("%s();", menuitem->GetFunctionName());
             } else {
-              cmd = Form("%s((TObject*)0x%lx);",
-                     menuitem->GetFunctionName(), (Long_t)fSelectedObject);
+              cmd = Form("%s((TObject*)0x%zx);",
+                     menuitem->GetFunctionName(), (size_t)fSelectedObject);
             }
             gROOT->ProcessLine(cmd);
          }

--- a/core/gui/src/TGuiFactory.cxx
+++ b/core/gui/src/TGuiFactory.cxx
@@ -115,6 +115,6 @@ TInspectorImp *TGuiFactory::CreateInspectorImp(const TObject *obj, UInt_t width,
       return new TInspectorImp(obj, width, height);
    }
 
-   gROOT->ProcessLine(Form("TInspectCanvas::Inspector((TObject*)0x%lx);", (ULong_t)obj));
+   gROOT->ProcessLine(Form("TInspectCanvas::Inspector((TObject*)0x%zx);", (size_t)obj));
    return 0;
 }

--- a/core/gui/src/TToggle.cxx
+++ b/core/gui/src/TToggle.cxx
@@ -122,7 +122,7 @@ void TToggle::Toggle()
          fValue=( (fValue==fOnValue) ? fOffValue:fOnValue);
          fState=(!(fValue!=fOnValue));
          char stringon[20];
-         snprintf(stringon,sizeof(stringon),"%li",fValue);
+         snprintf(stringon,sizeof(stringon),"%zi",(size_t)fValue);
          fSetter->Execute(fObject, stringon);
       }
    }

--- a/core/meta/inc/TDataMember.h
+++ b/core/meta/inc/TDataMember.h
@@ -39,7 +39,7 @@ private:
    TClass             *fClass;        //!pointer to the class
    TDataType          *fDataType;     //!pointer to data basic type descriptor
 
-   Long_t              fOffset;       //offset
+   Longptr_t           fOffset;       //offset
    Int_t               fSTLCont;      //STL type
    Long_t              fProperty;     //Property
    Int_t               fArrayDim;     //Number of array dimensions
@@ -74,8 +74,8 @@ public:
    Int_t          GetMaxIndex(Int_t dim) const;
    TClass        *GetClass() const { return fClass; }
    TDataType     *GetDataType() const { return fDataType; } //only for basic type
-   Long_t         GetOffset() const;
-   Long_t         GetOffsetCint() const;
+   Longptr_t      GetOffset() const;
+   Longptr_t      GetOffsetCint() const;
    const char    *GetTypeName() const;
    const char    *GetFullTypeName() const;
    const char    *GetTrueTypeName() const;

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -220,7 +220,7 @@ public:
    virtual ECheckClassInfo CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamespaceOnly = kFALSE) = 0;
 
    virtual Bool_t   CheckClassTemplate(const char *name) = 0;
-   virtual Long_t   Calc(const char *line, EErrorCode* error = 0) = 0;
+   virtual Longptr_t Calc(const char *line, EErrorCode* error = 0) = 0;
    virtual void     CreateListOfBaseClasses(TClass *cl) const = 0;
    virtual void     CreateListOfDataMembers(TClass *cl) const = 0;
    virtual void     CreateListOfMethods(TClass *cl) const = 0;

--- a/core/meta/src/TDataMember.cxx
+++ b/core/meta/src/TDataMember.cxx
@@ -431,7 +431,7 @@ const char *TDataMember::GetTrueTypeName() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Get offset from "this".
 
-Long_t TDataMember::GetOffset() const
+Longptr_t TDataMember::GetOffset() const
 {
    if (fOffset>=0) return fOffset;
 
@@ -480,7 +480,7 @@ Long_t TDataMember::GetOffset() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Get offset from "this" using the information in CINT only.
 
-Long_t TDataMember::GetOffsetCint() const
+Longptr_t TDataMember::GetOffsetCint() const
 {
    if (fOffset>=0) return fOffset;
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3504,7 +3504,7 @@ Longptr_t TCling::ProcessLineSynch(const char* line, EErrorCode* error)
 /// Directly execute an executable statement (e.g. "func()", "3+5", etc.
 /// however not declarations, like "Int_t x;").
 
-Long_t TCling::Calc(const char* line, EErrorCode* error)
+Longptr_t TCling::Calc(const char* line, EErrorCode* error)
 {
 #ifdef R__WIN32
    // Test on ApplicationImp not being 0 is needed because only at end of
@@ -3561,7 +3561,7 @@ Long_t TCling::Calc(const char* line, EErrorCode* error)
       gROOT->SetLineHasBeenProcessed();
    }
 #endif // R__WIN32
-   return valRef.simplisticCastAs<long>();
+   return valRef.simplisticCastAs<Longptr_t>();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -277,7 +277,7 @@ public: // Public Interface
    ECheckClassInfo CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamespaceOnly = kFALSE);
 
    Bool_t  CheckClassTemplate(const char *name);
-   Long_t  Calc(const char* line, EErrorCode* error = 0);
+   Longptr_t Calc(const char* line, EErrorCode* error = 0);
    void    CreateListOfBaseClasses(TClass* cl) const;
    void    CreateListOfDataMembers(TClass* cl) const;
    void    CreateListOfMethods(TClass* cl) const;

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -223,7 +223,7 @@ namespace {
       }
       if (QT->isPointerType() || QT->isArrayType() || QT->isRecordType() ||
             QT->isReferenceType()) {
-         return (returnType)(long) val.getPtr();
+         return (returnType)(Longptr_t) val.getPtr();
       }
       if (const EnumType *ET = dyn_cast<EnumType>(&*QT)) {
          if (ET->getDecl()->getIntegerType()->hasSignedIntegerRepresentation())
@@ -236,7 +236,7 @@ namespace {
          if (MPT && MPT->isMemberDataPointer()) {
             return (returnType)(ptrdiff_t)val.getPtr();
          }
-         return (returnType)(long) val.getPtr();
+         return (returnType)(Longptr_t) val.getPtr();
       }
       ::Error("TClingCallFunc::sv_to", "Invalid Type!");
       QT->dump();

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -313,7 +313,7 @@ int TClingDataMemberInfo::Next()
    return fIter.IsValid();
 }
 
-long TClingDataMemberInfo::Offset()
+Longptr_t TClingDataMemberInfo::Offset()
 {
    using namespace clang;
 
@@ -329,7 +329,7 @@ long TClingDataMemberInfo::Offset()
       const clang::ASTRecordLayout &Layout = C.getASTRecordLayout(RD);
       uint64_t bits = Layout.getFieldOffset(FldD->getFieldIndex());
       int64_t offset = C.toCharUnitsFromBits(bits).getQuantity();
-      return static_cast<long>(offset);
+      return static_cast<Longptr_t>(offset);
    }
    else if (const VarDecl *VD = dyn_cast<VarDecl>(D)) {
       // Could trigger deserialization of decls, in particular in case
@@ -337,33 +337,33 @@ long TClingDataMemberInfo::Offset()
       //   static constexpr Long64_t something = std::numeric_limits<Long64_t>::max();
       cling::Interpreter::PushTransactionRAII RAII(fInterp);
 
-      if (long addr = reinterpret_cast<long>(fInterp->getAddressOfGlobal(GlobalDecl(VD))))
+      if (Longptr_t addr = reinterpret_cast<Longptr_t>(fInterp->getAddressOfGlobal(GlobalDecl(VD))))
          return addr;
       auto evalStmt = VD->ensureEvaluatedStmt();
       if (evalStmt && evalStmt->Value) {
          if (const APValue* val = VD->evaluateValue()) {
             if (VD->getType()->isIntegralType(C)) {
-               return reinterpret_cast<long>(val->getInt().getRawData());
+               return reinterpret_cast<Longptr_t>(val->getInt().getRawData());
             } else {
                // The VD stores the init value; its lifetime should the lifetime of
                // this offset.
                switch (val->getKind()) {
                case APValue::Int: {
                   if (val->getInt().isSigned())
-                     fConstInitVal.fLong = (long)val->getInt().getSExtValue();
+                     fConstInitVal.fLong = (Longptr_t)val->getInt().getSExtValue();
                   else
-                     fConstInitVal.fLong = (long)val->getInt().getZExtValue();
-                  return (long) &fConstInitVal.fLong;
+                     fConstInitVal.fLong = (Longptr_t)val->getInt().getZExtValue();
+                  return (Longptr_t) &fConstInitVal.fLong;
                }
                case APValue::Float:
                   if (&val->getFloat().getSemantics()
                       == (const llvm::fltSemantics*)&llvm::APFloat::IEEEsingle()) {
                      fConstInitVal.fFloat = val->getFloat().convertToFloat();
-                     return (long)&fConstInitVal.fFloat;
+                     return (Longptr_t)&fConstInitVal.fFloat;
                   } else if (&val->getFloat().getSemantics()
                              == (const llvm::fltSemantics*) &llvm::APFloat::IEEEdouble()) {
                      fConstInitVal.fDouble = val->getFloat().convertToDouble();
-                     return (long)&fConstInitVal.fDouble;
+                     return (Longptr_t)&fConstInitVal.fDouble;
                   }
                   // else fall-through
                default:
@@ -384,10 +384,10 @@ long TClingDataMemberInfo::Offset()
       // part.
 #ifdef R__BYTESWAP
       // In this case at the beginning.
-      return reinterpret_cast<long>(ECD->getInitVal().getRawData());
+      return reinterpret_cast<Longptr_t>(ECD->getInitVal().getRawData());
 #else
       // In this case in the second part.
-      return reinterpret_cast<long>(((char*)ECD->getInitVal().getRawData())+sizeof(long) );
+      return reinterpret_cast<Longptr_t>(((char*)ECD->getInitVal().getRawData())+sizeof(Longptr_t) );
 #endif
    return -1L;
 }

--- a/core/metacling/src/TClingDataMemberInfo.h
+++ b/core/metacling/src/TClingDataMemberInfo.h
@@ -123,7 +123,7 @@ public:
    const clang::Type *GetClassAsType() const;
    int                MaxIndex(int dim) const;
    int                Next();
-   long               Offset();
+   Longptr_t          Offset();
    long               Property() const;
    long               TypeProperty() const;
    int                TypeSize() const;

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -22,7 +22,7 @@ TEST(TClingCallFunc, FunctionWrapper)
 
    ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperFunc", "int, float", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
@@ -44,7 +44,7 @@ TEST(TClingCallFunc, FunctionWrapperPointer)
 
    ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperFuncPtr", "int, float", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
@@ -69,7 +69,7 @@ TEST(TClingCallFunc, FunctionWrapperReference)
 
    ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperFuncRef", "int*, float", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
@@ -94,7 +94,7 @@ TEST(TClingCallFunc, FunctionWrapperVoid)
 
    ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperFuncVoid", "int", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
@@ -114,7 +114,7 @@ TEST(TClingCallFunc, FunctionWrapperRValueRefArg)
 
    ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperFuncRValueRefArg", "int&&", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
@@ -134,7 +134,7 @@ TEST(TClingCallFunc, FunctionWrapperVariadic)
 
    ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperFuncVariadic", "int", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
@@ -156,7 +156,7 @@ TEST(TClingCallFunc, FunctionWrapperDefaultArg)
 
    ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperFuncDefaultArg", "", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
@@ -182,7 +182,7 @@ TEST(TClingCallFunc, TemplateFunctionWrapper)
 
    ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "TemplateFunctionWrapperFunc", "int", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
@@ -205,7 +205,7 @@ TEST(TClingCallFunc, FunctionWrapperIncompleteReturnType)
 
    ClassInfo_t *GlobalNamespace = gInterpreter->ClassInfo_Factory("");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, GlobalNamespace, "FunctionWrapperIncompleteType", "", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
@@ -227,7 +227,7 @@ TEST(TClingCallFunc, MemberMethodWrapper)
 
    ClassInfo_t *FooNamespace = gInterpreter->ClassInfo_Factory("TClingCallFunc_TestClass1");
    CallFunc_t *mc = gInterpreter->CallFunc_Factory();
-   long offset = 0;
+   Longptr_t offset = 0;
 
    gInterpreter->CallFunc_SetFuncProto(mc, FooNamespace, "foo", "int", &offset);
    std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);

--- a/core/thread/inc/TThread.h
+++ b/core/thread/inc/TThread.h
@@ -78,7 +78,7 @@ private:
    EState         fState;                 // thread state
    EState         fStateComing;           // coming thread state
    Long_t         fId;                    // thread id
-   Long_t         fHandle;                // Win32 thread handle
+   Longptr_t      fHandle;                // Win32 thread handle
    Bool_t         fDetached;              // kTRUE if thread is Detached
    Bool_t         fNamed;                 // kTRUE if thread is Named
    VoidRtnFunc_t  fFcnRetn;               // void* start function of thread

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -863,7 +863,7 @@ void TThread::Ps()
    for (l = fgMain; l; l = l->fNext) { // loop over threads
       memset(cbuf, ' ', sizeof(cbuf));
       snprintf(cbuf, sizeof(cbuf), "%3d  %s:0x%lx", num--, l->GetName(), l->fId);
-      i = strlen(cbuf);
+      i = (int)strlen(cbuf);
       if (i < 30)
          cbuf[i] = ' ';
       cbuf[30] = 0;
@@ -985,7 +985,7 @@ again:
       bp = buf;
 
    void *arr[4];
-   arr[1] = (void*) Long_t(level);
+   arr[1] = (void*) Longptr_t(level);
    arr[2] = (void*) location;
    arr[3] = (void*) bp;
    if (XARequest("ERRO", 4, arr, 0)) return;
@@ -1095,7 +1095,7 @@ void TThread::XAction()
 
       case kERRO:
          {
-            int level = (int)Long_t(fgXArr[1]);
+            int level = (int)Longptr_t(fgXArr[1]);
             const char *location = (const char*)fgXArr[2];
             char *mess = (char*)fgXArr[3];
             if (level != kFatal)
@@ -1122,7 +1122,7 @@ void TThread::XAction()
 
             case 2:
                //((TCanvas*)fgXArr[1])->Constructor();
-               cmd = Form("((TCanvas *)0x%lx)->Constructor();",(Long_t)fgXArr[1]);
+               cmd = Form("((TCanvas *)0x%zx)->Constructor();",(size_t)fgXArr[1]);
                gROOT->ProcessLine(cmd);
                break;
 
@@ -1131,7 +1131,7 @@ void TThread::XAction()
                //                 (char*)fgXArr[2],
                //                 (char*)fgXArr[3],
                //                *((Int_t*)(fgXArr[4])));
-               cmd = Form("((TCanvas *)0x%lx)->Constructor((char*)0x%lx,(char*)0x%lx,*((Int_t*)(0x%lx)));",(Long_t)fgXArr[1],(Long_t)fgXArr[2],(Long_t)fgXArr[3],(Long_t)fgXArr[4]);
+               cmd = Form("((TCanvas *)0x%zx)->Constructor((char*)0x%zx,(char*)0x%zx,*((Int_t*)(0x%zx)));",(size_t)fgXArr[1],(size_t)fgXArr[2],(size_t)fgXArr[3],(size_t)fgXArr[4]);
                gROOT->ProcessLine(cmd);
                break;
             case 6:
@@ -1140,7 +1140,7 @@ void TThread::XAction()
                //                 (char*)fgXArr[3],
                //                *((Int_t*)(fgXArr[4])),
                //                *((Int_t*)(fgXArr[5])));
-               cmd = Form("((TCanvas *)0x%lx)->Constructor((char*)0x%lx,(char*)0x%lx,*((Int_t*)(0x%lx)),*((Int_t*)(0x%lx)));",(Long_t)fgXArr[1],(Long_t)fgXArr[2],(Long_t)fgXArr[3],(Long_t)fgXArr[4],(Long_t)fgXArr[5]);
+               cmd = Form("((TCanvas *)0x%zx)->Constructor((char*)0x%zx,(char*)0x%zx,*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)));",(size_t)fgXArr[1],(size_t)fgXArr[2],(size_t)fgXArr[3],(size_t)fgXArr[4],(size_t)fgXArr[5]);
                gROOT->ProcessLine(cmd);
                break;
 
@@ -1152,7 +1152,7 @@ void TThread::XAction()
                //               *((Int_t*)(fgXArr[5])),
                //               *((Int_t*)(fgXArr[6])),
                //               *((Int_t*)(fgXArr[7])));
-               cmd = Form("((TCanvas *)0x%lx)->Constructor((char*)0x%lx,(char*)0x%lx,*((Int_t*)(0x%lx)),*((Int_t*)(0x%lx)),*((Int_t*)(0x%lx)),*((Int_t*)(0x%lx)));",(Long_t)fgXArr[1],(Long_t)fgXArr[2],(Long_t)fgXArr[3],(Long_t)fgXArr[4],(Long_t)fgXArr[5],(Long_t)fgXArr[6],(Long_t)fgXArr[7]);
+               cmd = Form("((TCanvas *)0x%zx)->Constructor((char*)0x%zx,(char*)0x%zx,*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)));",(size_t)fgXArr[1],(size_t)fgXArr[2],(size_t)fgXArr[3],(size_t)fgXArr[4],(size_t)fgXArr[5],(size_t)fgXArr[6],(size_t)fgXArr[7]);
                gROOT->ProcessLine(cmd);
                break;
 
@@ -1161,7 +1161,7 @@ void TThread::XAction()
 
       case kCDEL:
          //((TCanvas*)fgXArr[1])->Destructor();
-         cmd = Form("((TCanvas *)0x%lx)->Destructor();",(Long_t)fgXArr[1]);
+         cmd = Form("((TCanvas *)0x%zx)->Destructor();",(size_t)fgXArr[1]);
          gROOT->ProcessLine(cmd);
          break;
 

--- a/core/thread/src/TWin32Thread.cxx
+++ b/core/thread/src/TWin32Thread.cxx
@@ -40,7 +40,7 @@ Int_t TWin32Thread::Run(TThread *th)
       ::CloseHandle(hHandle);
       th->fHandle = 0L;
    } else
-      th->fHandle = (Long_t)hHandle;
+      th->fHandle = (Longptr_t)hHandle;
 
    th->fId = dwThreadId;
 
@@ -111,7 +111,7 @@ Int_t TWin32Thread::CleanUpPop(void **main,Int_t exe)
 
 Int_t TWin32Thread::CleanUp(void **main)
 {
-   fprintf(stderr," CleanUp %lx\n",(ULong_t)*main);
+   fprintf(stderr," CleanUp %zx\n",(size_t)*main);
    while(!CleanUpPop(main,1)) { }
    return 0;
 }

--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -263,6 +263,6 @@ public:
    ClassDefOverride(TWinNTSystem, 0)
 };
 
-R__EXTERN ULong_t gConsoleWindow;   // console window handle
+R__EXTERN ULongptr_t gConsoleWindow;   // console window handle
 
 #endif

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -929,7 +929,7 @@ namespace {
       // ensure window title has been updated
       ::Sleep(40);
       // look for NewWindowTitle
-      gConsoleWindow = (ULong_t)::FindWindow(0, pszNewWindowTitle);
+      gConsoleWindow = (ULongptr_t)::FindWindow(0, pszNewWindowTitle);
       if (gConsoleWindow) {
          // restore original window title
          ::ShowWindow((HWND)gConsoleWindow, SW_RESTORE);
@@ -952,7 +952,7 @@ namespace {
 ///////////////////////////////////////////////////////////////////////////////
 ClassImp(TWinNTSystem);
 
-ULong_t gConsoleWindow = 0;
+ULongptr_t gConsoleWindow = 0;
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
@@ -1186,13 +1186,13 @@ const char *TWinNTSystem::BaseName(const char *name)
 
 void TWinNTSystem::SetProgname(const char *name)
 {
-   ULong_t  idot = 0;
+   size_t idot = 0;
    char *dot = nullptr;
    char *progname;
    char *fullname = nullptr; // the program name with extension
 
   // On command prompt the progname can be supplied with no extension (under Windows)
-   ULong_t namelen=name ? strlen(name) : 0;
+   size_t namelen = name ? strlen(name) : 0;
    if (name && namelen > 0) {
       // Check whether the name contains "extention"
       fullname = new char[namelen+5];
@@ -1202,7 +1202,7 @@ void TWinNTSystem::SetProgname(const char *name)
 
       progname = StrDup(BaseName(fullname));
       dot = strrchr(progname, '.');
-      idot = dot ? (ULong_t)(dot - progname) : strlen(progname);
+      idot = dot ? (size_t)(dot - progname) : strlen(progname);
 
       char *which = nullptr;
 
@@ -2052,7 +2052,7 @@ void *TWinNTSystem::OpenDirectory(const char *fdir)
    else
       strlcpy(dir, sdir,MAX_PATH);
 
-   int nche = strlen(dir)+3;
+   size_t nche = strlen(dir)+3;
    char *entry = new char[nche];
    struct _stati64 finfo;
 
@@ -2602,7 +2602,7 @@ int TWinNTSystem::GetPathInfo(const char *path, FileStat_t &buf)
    // Remove trailing backslashes
    const char *proto = (strstr(path, "file:///")) ? "file://" : "file:";
    char *newpath = StrDup(StripOffProto(path, proto));
-   int l = strlen(newpath);
+   size_t l = strlen(newpath);
    while (l > 1) {
       if (newpath[--l] != '\\' || newpath[--l] != '/') {
          break;
@@ -3874,10 +3874,10 @@ void TWinNTSystem::Exit(int code, Bool_t mode)
             TIter next(gROOT->GetListOfBrowsers());
             while ((b = (TBrowser*) next()))
                gROOT->ProcessLine(TString::Format("\
-                  if (((TBrowser*)0x%lx)->GetBrowserImp() &&\
-                      ((TBrowser*)0x%lx)->GetBrowserImp()->GetMainFrame()) \
-                     ((TBrowser*)0x%lx)->GetBrowserImp()->GetMainFrame()->CloseWindow();\
-                  else delete (TBrowser*)0x%lx", (ULong_t)b, (ULong_t)b, (ULong_t)b, (ULong_t)b));
+                  if (((TBrowser*)0x%zx)->GetBrowserImp() &&\
+                      ((TBrowser*)0x%zx)->GetBrowserImp()->GetMainFrame()) \
+                     ((TBrowser*)0x%zx)->GetBrowserImp()->GetMainFrame()->CloseWindow();\
+                  else delete (TBrowser*)0x%zx", (size_t)b, (size_t)b, (size_t)b, (size_t)b));
          }
       }
    }


### PR DESCRIPTION
- Replace some more `long` types by `Longptr_t`
- Fix pointer formatting (use `%zx` and `size_t` for architecture dependent format)
- Fix several `warning C4267: 'argument': conversion from 'size_t' to 'Ssiz_t', possible loss of data`