### PR TITLE
[metacling] Skip parameter packs as empty when default-instantiating template functions

### DIFF
--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -147,22 +147,6 @@ TClingCXXRecMethIter::InstantiateTemplateWithDefaults(const clang::RedeclarableT
    if (templateParms->getMinRequiredArguments() > 0)
       return nullptr;
 
-   if (templateParms->size() > 0) {
-      NamedDecl *arg0 = *templateParms->begin();
-      if (arg0->isTemplateParameterPack())
-         return nullptr;
-      if (auto TTP = dyn_cast<TemplateTypeParmDecl>(*templateParms->begin())) {
-         if (!TTP->hasDefaultArgument())
-            return nullptr;
-      } else if (auto NTTP = dyn_cast<NonTypeTemplateParmDecl>(*templateParms->begin())) {
-         if (!NTTP->hasDefaultArgument())
-            return nullptr;
-      } else {
-         // TemplateTemplateParmDecl, pack
-         return nullptr;
-      }
-   }
-
    const FunctionDecl *templatedDecl = llvm::dyn_cast<FunctionDecl>(TD->getTemplatedDecl());
    const Decl *declCtxDecl = dyn_cast<Decl>(TD->getDeclContext());
 

--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -158,26 +158,22 @@ TClingCXXRecMethIter::InstantiateTemplateWithDefaults(const clang::RedeclarableT
    // If the function argument type is dependent (a1 and a2) we need to
    // substitute the types first, using the template arguments derived from the
    // template parameters' defaults.
-   llvm::SmallVector<TemplateArgument, 8> defaultTemplateArgs(templateParms->size());
-   for (int iParam = 0, nParams = templateParms->size(); iParam < nParams; ++iParam) {
-      const NamedDecl *templateParm = templateParms->getParam(iParam);
+   llvm::SmallVector<TemplateArgument, 8> defaultTemplateArgs;
+   for (const NamedDecl *templateParm: *templateParms) {
       if (templateParm->isTemplateParameterPack()) {
-         // shouldn't end up here
-         assert(0 && "unexpected template parameter pack");
-         return nullptr;
-      }
-      if (auto TTP = dyn_cast<TemplateTypeParmDecl>(templateParm)) {
+         defaultTemplateArgs.emplace_back(ArrayRef<TemplateArgument>{}); // empty pack.
+      } else if (auto TTP = dyn_cast<TemplateTypeParmDecl>(templateParm)) {
          if (!TTP->hasDefaultArgument())
             return nullptr;
-         defaultTemplateArgs[iParam] = TemplateArgument(TTP->getDefaultArgument());
+         defaultTemplateArgs.emplace_back(TTP->getDefaultArgument());
       } else if (auto NTTP = dyn_cast<NonTypeTemplateParmDecl>(templateParm)) {
          if (!NTTP->hasDefaultArgument())
             return nullptr;
-         defaultTemplateArgs[iParam] = TemplateArgument(NTTP->getDefaultArgument());
+         defaultTemplateArgs.emplace_back(NTTP->getDefaultArgument());
       } else if (auto TTP = dyn_cast<TemplateTemplateParmDecl>(templateParm)) {
          if (!TTP->hasDefaultArgument())
             return nullptr;
-         defaultTemplateArgs[iParam] = TemplateArgument(TTP->getDefaultArgument().getArgument());
+         defaultTemplateArgs.emplace_back(TTP->getDefaultArgument().getArgument());
       } else {
          // shouldn't end up here
          assert(0 && "unexpected template parameter kind");

--- a/core/metacling/test/TClingMethodInfoTests.cxx
+++ b/core/metacling/test/TClingMethodInfoTests.cxx
@@ -446,6 +446,28 @@ namespace Templates {
    TListOfFunctions *methods = (TListOfFunctions *)clMyMethods->GetListOfMethods();
    ASSERT_NE(methods, nullptr);
 
+   std::set<std::string> names;
+   for (auto *obj: *methods)
+      names.insert(obj->GetName());
+   EXPECT_EQ(names.count("Na"), 0);
+   EXPECT_EQ(names.count("Nb"), 0);
+   EXPECT_EQ(names.count("Nc"), 0);
+   EXPECT_EQ(names.count("Nd"), 0);
+
+   //[1]: See comment in TClingCXXRecMethIter::InstantiateTemplateWithDefaults()
+   // handling parameter packs.
+   EXPECT_EQ(names.count("Ya<int>"), 1);
+   //EXPECT_EQ(names.count("Yb"), 1); //[1]
+   EXPECT_EQ(names.count("Yc<12>"), 1);
+   EXPECT_EQ(names.count("Yd<TTArg>"), 1);
+   EXPECT_EQ(names.count("Ye<int>"), 1);
+   EXPECT_EQ(names.count("Yf<int>"), 1);
+   //EXPECT_EQ(names.count("Yg<int>"), 1); //[1]
+   //EXPECT_EQ(names.count("Yh<int, int>"), 1); //[1]
+
+   // These do a lookup / overload set, and can materialize functions (like Yb)
+   // that the enumeration above failed to catch; see overriding
+   // `TListOfFunctions::FindObject()`.
    EXPECT_EQ(methods->FindObject("Na"), nullptr);
    EXPECT_EQ(methods->FindObject("Nb"), nullptr);
    EXPECT_EQ(methods->FindObject("Nc"), nullptr);

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -1112,6 +1112,23 @@ namespace cling {
     }
 
     //
+    //  Tell the diagnostic engine to ignore all diagnostics.
+    //
+    bool OldSuppressAllDiagnostics
+      = S.getDiagnostics().getSuppressAllDiagnostics();
+    S.getDiagnostics().setSuppressAllDiagnostics(
+        diagOnOff == LookupHelper::NoDiagnostics);
+
+    struct ResetDiagSuppression {
+      bool _Old;
+      Sema& _S;
+      ResetDiagSuppression(Sema &S, bool Old): _Old(Old), _S(S) {}
+      ~ResetDiagSuppression() {
+        _S.getDiagnostics().setSuppressAllDiagnostics();
+      }
+    } DiagSuppressionRAII(S, OldSuppressAllDiagnostics);
+
+    //
     //  Construct the overload candidate set.
     //
     OverloadCandidateSet Candidates(FuncNameInfo.getLoc(),
@@ -1192,17 +1209,8 @@ namespace cling {
           // of comparison.
           TheDecl = TheDecl->getCanonicalDecl();
           if (TheDecl->isTemplateInstantiation() && !TheDecl->isDefined()) {
-            //
-            //  Tell the diagnostic engine to ignore all diagnostics.
-            //
-            bool OldSuppressAllDiagnostics
-              = S.getDiagnostics().getSuppressAllDiagnostics();
-            S.getDiagnostics().setSuppressAllDiagnostics(
-                diagOnOff == LookupHelper::NoDiagnostics);
-
             S.InstantiateFunctionDefinition(SourceLocation(), TheDecl,
                                             true /*recursive instantiation*/);
-            S.getDiagnostics().setSuppressAllDiagnostics(OldSuppressAllDiagnostics);
           }
           if (TheDecl->isInvalidDecl()) {
             // if the decl is invalid try to clean up


### PR DESCRIPTION
Fixes https://github.com/root-project/root/pull/7630#issuecomment-819501708 (hopefully).