### PR TITLE
[webgui] add ping.cxx to tests

### DIFF
--- a/gui/webdisplay/CMakeLists.txt
+++ b/gui/webdisplay/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -9,7 +9,7 @@
 ############################################################################
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTWebDisplay
-    HEADERS 
+    HEADERS
        ROOT/RWebDisplayArgs.hxx
        ROOT/RWebDisplayHandle.hxx
        ROOT/RWebWindow.hxx
@@ -20,7 +20,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTWebDisplay
        RWebWindow.cxx
        RWebWindowsManager.cxx
     DEPENDENCIES
-       Core 
-       RHTTP 
+       Core
+       RHTTP
        MathCore
 )
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/gui/webdisplay/test/CMakeLists.txt
+++ b/gui/webdisplay/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.
+# All rights reserved.
+#
+# For the licensing terms see $ROOTSYS/LICENSE.
+# For the list of contributors see $ROOTSYS/README/CREDITS.
+
+############################################################################
+# CMakeLists.txt file for testing components from ROOT gui/webdisplay package
+############################################################################
+
+
+# test only can be run if Firefox or Chrome are detected on the system
+if (CHROME_EXECUTABLE OR FIREFOX_EXECUTABLE)
+  ROOT_ADD_TEST(test-webgui-ping
+                COPY_TO_BUILDDIR ${CMAKE_SOURCE_DIR}/tutorials/webgui/ping/ping.cxx ${CMAKE_SOURCE_DIR}/tutorials/webgui/ping/ping.html
+                COMMAND root.exe -b -q -l ping.cxx
+                PASSREGEX "PING-PONG TEST COMPLETED")
+endif()


### PR DESCRIPTION
Let test webgui integrity
- if THttpServer work properly
- if JSROOT loads on client side
- if communication runs between server and clients