### PR TITLE
[ntuple] Round out fixed-width integer support

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -173,6 +173,17 @@ public:
    std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
 };
 
+template<>
+class RColumnElement<std::uint16_t, EColumnType::kInt16> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = true;
+   static constexpr std::size_t kSize = sizeof(std::uint16_t);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(std::uint16_t *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
 template <>
 class RColumnElement<std::int32_t, EColumnType::kInt32> : public RColumnElementBase {
 public:

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -141,6 +141,17 @@ public:
 };
 
 template <>
+class RColumnElement<std::int8_t, EColumnType::kByte> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = true;
+   static constexpr std::size_t kSize = sizeof(std::int8_t);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(std::int8_t *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
 class RColumnElement<std::uint8_t, EColumnType::kByte> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -162,6 +162,17 @@ public:
    std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
 };
 
+template<>
+class RColumnElement<std::int16_t, EColumnType::kInt16> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = true;
+   static constexpr std::size_t kSize = sizeof(std::int16_t);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(std::int16_t *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
 template <>
 class RColumnElement<std::int32_t, EColumnType::kInt32> : public RColumnElementBase {
 public:

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -797,6 +797,47 @@ public:
 };
 
 template <>
+class RField<std::uint16_t> : public Detail::RFieldBase {
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {
+      return std::make_unique<RField>(newName);
+   }
+
+public:
+   static std::string TypeName() { return "std::uint16_t"; }
+   explicit RField(std::string_view name)
+     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+
+   void GenerateColumnsImpl() final;
+
+   std::uint16_t *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<std::uint16_t, EColumnType::kInt16>(globalIndex);
+   }
+   std::uint16_t *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<std::uint16_t, EColumnType::kInt16>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<std::uint16_t, EColumnType::kInt16>(static_cast<std::uint16_t*>(where)),
+         this, static_cast<std::uint16_t*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<std::uint16_t, EColumnType::kInt16>(static_cast<std::uint16_t*>(where)), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(std::uint16_t); }
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
+
+template <>
 class RField<std::int32_t> : public Detail::RFieldBase {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -837,6 +837,46 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
+template <>
+class RField<std::int64_t> : public Detail::RFieldBase {
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {
+      return std::make_unique<RField>(newName);
+   }
+
+public:
+   static std::string TypeName() { return "std::int64_t"; }
+   explicit RField(std::string_view name)
+     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+
+   void GenerateColumnsImpl() final;
+
+   std::int64_t *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<std::int64_t, EColumnType::kInt64>(globalIndex);
+   }
+   std::int64_t *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<std::int64_t, EColumnType::kInt64>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<std::int64_t, EColumnType::kInt64>(static_cast<std::int64_t*>(where)),
+         this, static_cast<std::int64_t*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<std::int64_t, EColumnType::kInt64>(static_cast<std::int64_t*>(where)), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(std::int64_t); }
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
 
 template <>
 class RField<std::string> : public Detail::RFieldBase {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -674,6 +674,47 @@ public:
 };
 
 template <>
+class RField<char> : public Detail::RFieldBase {
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {
+      return std::make_unique<RField>(newName);
+   }
+
+public:
+   static std::string TypeName() { return "char"; }
+   explicit RField(std::string_view name)
+     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+
+   void GenerateColumnsImpl() final;
+
+   char *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<char, EColumnType::kByte>(globalIndex);
+   }
+   char *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<char, EColumnType::kByte>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<char, EColumnType::kByte>(static_cast<char*>(where)),
+         this, static_cast<char*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<char, EColumnType::kByte>(static_cast<char*>(where)), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(char); }
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
+
+template <>
 class RField<std::int8_t> : public Detail::RFieldBase {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -674,6 +674,47 @@ public:
 };
 
 template <>
+class RField<std::int8_t> : public Detail::RFieldBase {
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {
+      return std::make_unique<RField>(newName);
+   }
+
+public:
+   static std::string TypeName() { return "std::int8_t"; }
+   explicit RField(std::string_view name)
+     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+
+   void GenerateColumnsImpl() final;
+
+   std::int8_t *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<std::int8_t, EColumnType::kByte>(globalIndex);
+   }
+   std::int8_t *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<std::int8_t, EColumnType::kByte>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<std::int8_t, EColumnType::kByte>(static_cast<std::int8_t*>(where)),
+         this, static_cast<std::int8_t*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<std::int8_t, EColumnType::kByte>(static_cast<std::int8_t*>(where)), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(std::int8_t); }
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
+
+template <>
 class RField<std::uint8_t> : public Detail::RFieldBase {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -756,6 +756,47 @@ public:
 };
 
 template <>
+class RField<std::int16_t> : public Detail::RFieldBase {
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {
+      return std::make_unique<RField>(newName);
+   }
+
+public:
+   static std::string TypeName() { return "std::int16_t"; }
+   explicit RField(std::string_view name)
+     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+
+   void GenerateColumnsImpl() final;
+
+   std::int16_t *Map(NTupleSize_t globalIndex) {
+      return fPrincipalColumn->Map<std::int16_t, EColumnType::kInt16>(globalIndex);
+   }
+   std::int16_t *Map(const RClusterIndex &clusterIndex) {
+      return fPrincipalColumn->Map<std::int16_t, EColumnType::kInt16>(clusterIndex);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(
+         Detail::RColumnElement<std::int16_t, EColumnType::kInt16>(static_cast<std::int16_t*>(where)),
+         this, static_cast<std::int16_t*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
+   Detail::RFieldValue CaptureValue(void *where) final {
+      return Detail::RFieldValue(true /* captureFlag */,
+         Detail::RColumnElement<std::int16_t, EColumnType::kInt16>(static_cast<std::int16_t*>(where)), this, where);
+   }
+   size_t GetValueSize() const final { return sizeof(std::int16_t); }
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
+
+template <>
 class RField<std::int32_t> : public Detail::RFieldBase {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -52,6 +52,7 @@ public:
    virtual void VisitClusterSizeField(const RField<ClusterSize_t> &field) { VisitField(field); }
    virtual void VisitDoubleField(const RField<double> &field) { VisitField(field); }
    virtual void VisitFloatField(const RField<float> &field) { VisitField(field); }
+   virtual void VisitInt8Field(const RField<std::int8_t> &field) { VisitField(field); }
    virtual void VisitIntField(const RField<int> &field) { VisitField(field); }
    virtual void VisitInt64Field(const RField<std::int64_t> &field) { VisitField(field); }
    virtual void VisitStringField(const RField<std::string> &field) { VisitField(field); }
@@ -190,6 +191,7 @@ public:
    void VisitBoolField(const RField<bool> &field) final;
    void VisitDoubleField(const RField<double> &field) final;
    void VisitFloatField(const RField<float> &field) final;
+   void VisitInt8Field(const RField<std::int8_t> &field) final;
    void VisitIntField(const RField<int> &field) final;
    void VisitInt64Field(const RField<std::int64_t> &field) final;
    void VisitStringField(const RField<std::string> &field) final;

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -53,6 +53,7 @@ public:
    virtual void VisitDoubleField(const RField<double> &field) { VisitField(field); }
    virtual void VisitFloatField(const RField<float> &field) { VisitField(field); }
    virtual void VisitIntField(const RField<int> &field) { VisitField(field); }
+   virtual void VisitInt64Field(const RField<std::int64_t> &field) { VisitField(field); }
    virtual void VisitStringField(const RField<std::string> &field) { VisitField(field); }
    virtual void VisitUInt32Field(const RField<std::uint32_t> &field) { VisitField(field); }
    virtual void VisitUInt64Field(const RField<std::uint64_t> &field) { VisitField(field); }
@@ -190,6 +191,7 @@ public:
    void VisitDoubleField(const RField<double> &field) final;
    void VisitFloatField(const RField<float> &field) final;
    void VisitIntField(const RField<int> &field) final;
+   void VisitInt64Field(const RField<std::int64_t> &field) final;
    void VisitStringField(const RField<std::string> &field) final;
    void VisitUInt8Field(const RField<std::uint8_t> &field) final;
    void VisitUInt32Field(const RField<std::uint32_t> &field) final;

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -52,6 +52,7 @@ public:
    virtual void VisitClusterSizeField(const RField<ClusterSize_t> &field) { VisitField(field); }
    virtual void VisitDoubleField(const RField<double> &field) { VisitField(field); }
    virtual void VisitFloatField(const RField<float> &field) { VisitField(field); }
+   virtual void VisitCharField(const RField<char> &field) { VisitField(field); }
    virtual void VisitInt8Field(const RField<std::int8_t> &field) { VisitField(field); }
    virtual void VisitInt16Field(const RField<std::int16_t> &field) { VisitField(field); }
    virtual void VisitIntField(const RField<int> &field) { VisitField(field); }
@@ -193,6 +194,7 @@ public:
    void VisitBoolField(const RField<bool> &field) final;
    void VisitDoubleField(const RField<double> &field) final;
    void VisitFloatField(const RField<float> &field) final;
+   void VisitCharField(const RField<char> &field) final;
    void VisitInt8Field(const RField<std::int8_t> &field) final;
    void VisitInt16Field(const RField<std::int16_t> &field) final;
    void VisitIntField(const RField<int> &field) final;

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -53,6 +53,7 @@ public:
    virtual void VisitDoubleField(const RField<double> &field) { VisitField(field); }
    virtual void VisitFloatField(const RField<float> &field) { VisitField(field); }
    virtual void VisitInt8Field(const RField<std::int8_t> &field) { VisitField(field); }
+   virtual void VisitInt16Field(const RField<std::int16_t> &field) { VisitField(field); }
    virtual void VisitIntField(const RField<int> &field) { VisitField(field); }
    virtual void VisitInt64Field(const RField<std::int64_t> &field) { VisitField(field); }
    virtual void VisitStringField(const RField<std::string> &field) { VisitField(field); }
@@ -192,6 +193,7 @@ public:
    void VisitDoubleField(const RField<double> &field) final;
    void VisitFloatField(const RField<float> &field) final;
    void VisitInt8Field(const RField<std::int8_t> &field) final;
+   void VisitInt16Field(const RField<std::int16_t> &field) final;
    void VisitIntField(const RField<int> &field) final;
    void VisitInt64Field(const RField<std::int64_t> &field) final;
    void VisitStringField(const RField<std::string> &field) final;

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -57,6 +57,7 @@ public:
    virtual void VisitIntField(const RField<int> &field) { VisitField(field); }
    virtual void VisitInt64Field(const RField<std::int64_t> &field) { VisitField(field); }
    virtual void VisitStringField(const RField<std::string> &field) { VisitField(field); }
+   virtual void VisitUInt16Field(const RField<std::uint16_t> &field) { VisitField(field); }
    virtual void VisitUInt32Field(const RField<std::uint32_t> &field) { VisitField(field); }
    virtual void VisitUInt64Field(const RField<std::uint64_t> &field) { VisitField(field); }
    virtual void VisitUInt8Field(const RField<std::uint8_t> &field) { VisitField(field); }
@@ -198,6 +199,7 @@ public:
    void VisitInt64Field(const RField<std::int64_t> &field) final;
    void VisitStringField(const RField<std::string> &field) final;
    void VisitUInt8Field(const RField<std::uint8_t> &field) final;
+   void VisitUInt16Field(const RField<std::uint16_t> &field) final;
    void VisitUInt32Field(const RField<std::uint32_t> &field) final;
    void VisitUInt64Field(const RField<std::uint64_t> &field) final;
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -99,6 +99,8 @@ std::string GetNormalizedType(const std::string &typeName) {
    if (normalizedType == "uint8_t") normalizedType = "std::uint8_t";
    if (normalizedType == "Short_t") normalizedType = "std::int16_t";
    if (normalizedType == "int16_t") normalizedType = "std::int16_t";
+   if (normalizedType == "UShort_t") normalizedType = "std::uint16_t";
+   if (normalizedType == "uint16_t") normalizedType = "std::uint16_t";
    if (normalizedType == "Int_t") normalizedType = "std::int32_t";
    if (normalizedType == "int") normalizedType = "std::int32_t";
    if (normalizedType == "int32_t") normalizedType = "std::int32_t";
@@ -155,6 +157,8 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       result = std::make_unique<RField<std::uint8_t>>(fieldName);
    } else if (normalizedType == "std::int16_t") {
       result = std::make_unique<RField<std::int16_t>>(fieldName);
+   } else if (normalizedType == "std::uint16_t") {
+      result = std::make_unique<RField<std::uint16_t>>(fieldName);
    } else if (normalizedType == "std::int32_t") {
       result = std::make_unique<RField<std::int32_t>>(fieldName);
    } else if (normalizedType == "std::uint32_t") {
@@ -479,6 +483,21 @@ void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl()
 void ROOT::Experimental::RField<std::int16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitInt16Field(*this);
+}
+
+//------------------------------------------------------------------------------
+
+void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl()
+{
+   RColumnModel model(EColumnType::kInt16, false /* isSorted*/);
+   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
+      std::uint16_t, EColumnType::kInt16>(model, 0)));
+   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitUInt16Field(*this);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -97,6 +97,8 @@ std::string GetNormalizedType(const std::string &typeName) {
    if (normalizedType == "UChar_t") normalizedType = "std::uint8_t";
    if (normalizedType == "unsigned char") normalizedType = "std::uint8_t";
    if (normalizedType == "uint8_t") normalizedType = "std::uint8_t";
+   if (normalizedType == "Short_t") normalizedType = "std::int16_t";
+   if (normalizedType == "int16_t") normalizedType = "std::int16_t";
    if (normalizedType == "Int_t") normalizedType = "std::int32_t";
    if (normalizedType == "int") normalizedType = "std::int32_t";
    if (normalizedType == "int32_t") normalizedType = "std::int32_t";
@@ -151,6 +153,8 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       result = std::make_unique<RField<std::int8_t>>(fieldName);
    } else if (normalizedType == "std::uint8_t") {
       result = std::make_unique<RField<std::uint8_t>>(fieldName);
+   } else if (normalizedType == "std::int16_t") {
+      result = std::make_unique<RField<std::int16_t>>(fieldName);
    } else if (normalizedType == "std::int32_t") {
       result = std::make_unique<RField<std::int32_t>>(fieldName);
    } else if (normalizedType == "std::uint32_t") {
@@ -460,6 +464,21 @@ void ROOT::Experimental::RField<double>::GenerateColumnsImpl()
 void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitDoubleField(*this);
+}
+
+//------------------------------------------------------------------------------
+
+void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl()
+{
+   RColumnModel model(EColumnType::kInt16, false /* isSorted*/);
+   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
+      std::int16_t, EColumnType::kInt16>(model, 0)));
+   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::int16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitInt16Field(*this);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -92,6 +92,8 @@ std::string GetNormalizedType(const std::string &typeName) {
    if (normalizedType == "Bool_t") normalizedType = "bool";
    if (normalizedType == "Float_t") normalizedType = "float";
    if (normalizedType == "Double_t") normalizedType = "double";
+   if (normalizedType == "Char_t") normalizedType = "std::int8_t";
+   if (normalizedType == "int8_t") normalizedType = "std::int8_t";
    if (normalizedType == "UChar_t") normalizedType = "std::uint8_t";
    if (normalizedType == "unsigned char") normalizedType = "std::uint8_t";
    if (normalizedType == "uint8_t") normalizedType = "std::uint8_t";
@@ -145,6 +147,8 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       result = std::make_unique<RField<ClusterSize_t>>(fieldName);
    } else if (normalizedType == "bool") {
       result = std::make_unique<RField<bool>>(fieldName);
+   } else if (normalizedType == "std::int8_t") {
+      result = std::make_unique<RField<std::int8_t>>(fieldName);
    } else if (normalizedType == "std::uint8_t") {
       result = std::make_unique<RField<std::uint8_t>>(fieldName);
    } else if (normalizedType == "std::int32_t") {
@@ -378,6 +382,21 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColu
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitClusterSizeField(*this);
+}
+
+//------------------------------------------------------------------------------
+
+void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl()
+{
+   RColumnModel model(EColumnType::kByte, false /* isSorted*/);
+   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
+      std::int8_t, EColumnType::kByte>(model, 0)));
+   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::int8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitInt8Field(*this);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -92,7 +92,7 @@ std::string GetNormalizedType(const std::string &typeName) {
    if (normalizedType == "Bool_t") normalizedType = "bool";
    if (normalizedType == "Float_t") normalizedType = "float";
    if (normalizedType == "Double_t") normalizedType = "double";
-   if (normalizedType == "Char_t") normalizedType = "std::int8_t";
+   if (normalizedType == "Char_t") normalizedType = "char";
    if (normalizedType == "int8_t") normalizedType = "std::int8_t";
    if (normalizedType == "UChar_t") normalizedType = "std::uint8_t";
    if (normalizedType == "unsigned char") normalizedType = "std::uint8_t";
@@ -151,6 +151,8 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       result = std::make_unique<RField<ClusterSize_t>>(fieldName);
    } else if (normalizedType == "bool") {
       result = std::make_unique<RField<bool>>(fieldName);
+   } else if (normalizedType == "char") {
+      result = std::make_unique<RField<char>>(fieldName);
    } else if (normalizedType == "std::int8_t") {
       result = std::make_unique<RField<std::int8_t>>(fieldName);
    } else if (normalizedType == "std::uint8_t") {
@@ -390,6 +392,21 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColu
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitClusterSizeField(*this);
+}
+
+//------------------------------------------------------------------------------
+
+void ROOT::Experimental::RField<char>::GenerateColumnsImpl()
+{
+   RColumnModel model(EColumnType::kByte, false /* isSorted*/);
+   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
+      char, EColumnType::kByte>(model, 0)));
+   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<char>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitCharField(*this);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -102,6 +102,9 @@ std::string GetNormalizedType(const std::string &typeName) {
    if (normalizedType == "unsigned int") normalizedType = "std::uint32_t";
    if (normalizedType == "UInt_t") normalizedType = "std::uint32_t";
    if (normalizedType == "uint32_t") normalizedType = "std::uint32_t";
+   if (normalizedType == "Long64_t") normalizedType = "std::int64_t";
+   if (normalizedType == "Long_t") normalizedType = "std::int64_t";
+   if (normalizedType == "int64_t") normalizedType = "std::int64_t";
    if (normalizedType == "ULong64_t") normalizedType = "std::uint64_t";
    if (normalizedType == "uint64_t") normalizedType = "std::uint64_t";
    if (normalizedType == "string") normalizedType = "std::string";
@@ -148,6 +151,8 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       result = std::make_unique<RField<std::int32_t>>(fieldName);
    } else if (normalizedType == "std::uint32_t") {
       result = std::make_unique<RField<std::uint32_t>>(fieldName);
+   } else if (normalizedType == "std::int64_t") {
+      result = std::make_unique<RField<std::int64_t>>(fieldName);
    } else if (normalizedType == "std::uint64_t") {
       result = std::make_unique<RField<std::uint64_t>>(fieldName);
    } else if (normalizedType == "float") {
@@ -485,6 +490,20 @@ void ROOT::Experimental::RField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisi
 
 //------------------------------------------------------------------------------
 
+void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl()
+{
+   RColumnModel model(EColumnType::kInt64, false /* isSorted*/);
+   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
+      Detail::RColumn::Create<std::int64_t, EColumnType::kInt64>(model, 0)));
+   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::int64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitInt64Field(*this);
+}
+
+//------------------------------------------------------------------------------
 
 void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl()
 {

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -181,6 +181,12 @@ void ROOT::Experimental::RPrintValueVisitor::VisitFloatField(const RField<float>
    fOutput << *fValue.Get<float>();
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitInt8Field(const RField<std::int8_t> &field)
+{
+   PrintIndent();
+   PrintName(field);
+   fOutput << *fValue.Get<std::int8_t>();
+}
 
 void ROOT::Experimental::RPrintValueVisitor::VisitIntField(const RField<int> &field)
 {

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -189,6 +189,12 @@ void ROOT::Experimental::RPrintValueVisitor::VisitIntField(const RField<int> &fi
    fOutput << *fValue.Get<int>();
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitInt64Field(const RField<std::int64_t> &field)
+{
+   PrintIndent();
+   PrintName(field);
+   fOutput << *fValue.Get<std::int64_t>();
+}
 
 void ROOT::Experimental::RPrintValueVisitor::VisitStringField(const RField<std::string> &field)
 {

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -188,6 +188,13 @@ void ROOT::Experimental::RPrintValueVisitor::VisitInt8Field(const RField<std::in
    fOutput << *fValue.Get<std::int8_t>();
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitInt16Field(const RField<std::int16_t> &field)
+{
+   PrintIndent();
+   PrintName(field);
+   fOutput << *fValue.Get<std::int16_t>();
+}
+
 void ROOT::Experimental::RPrintValueVisitor::VisitIntField(const RField<int> &field)
 {
    PrintIndent();

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -181,6 +181,13 @@ void ROOT::Experimental::RPrintValueVisitor::VisitFloatField(const RField<float>
    fOutput << *fValue.Get<float>();
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitCharField(const RField<char> &field)
+{
+   PrintIndent();
+   PrintName(field);
+   fOutput << *fValue.Get<char>();
+}
+
 void ROOT::Experimental::RPrintValueVisitor::VisitInt8Field(const RField<std::int8_t> &field)
 {
    PrintIndent();

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -225,6 +225,12 @@ void ROOT::Experimental::RPrintValueVisitor::VisitUInt8Field(const RField<std::u
    fOutput << static_cast<int>(*fValue.Get<std::uint8_t>());
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitUInt16Field(const RField<std::uint16_t> &field)
+{
+   PrintIndent();
+   PrintName(field);
+   fOutput << *fValue.Get<std::uint16_t>();
+}
 
 void ROOT::Experimental::RPrintValueVisitor::VisitUInt32Field(const RField<std::uint32_t> &field)
 {

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -39,6 +39,13 @@ TEST(RNTuple, Int16_t)
    ASSERT_EQ("std::int16_t", RFieldBase::Create("myShort", "Short_t").Unwrap()->GetType());
 }
 
+TEST(RNTuple, UInt16_t)
+{
+   auto field = RField<std::uint16_t>("uint16");
+   auto otherField = RFieldBase::Create("test", "std::uint16_t").Unwrap();
+   ASSERT_EQ("std::uint16_t", RFieldBase::Create("myUShort", "UShort_t").Unwrap()->GetType());
+}
+
 TEST(RNTuple, UnsupportedStdTypes)
 {
    try {

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -23,6 +23,15 @@ TEST(RNTuple, Int64_t)
    auto otherField = RFieldBase::Create("test", "std::int64_t").Unwrap();
 }
 
+TEST(RNTuple, Int8_t)
+{
+   auto field = RField<std::int8_t>("int8");
+   auto otherField = RFieldBase::Create("test", "std::int8_t").Unwrap();
+   // does not compile
+   // -- RField.hxx:450:39: error: static assertion failed: no I/O support for this basic C++ type
+   // auto charField = RField<char>("char");
+}
+
 TEST(RNTuple, UnsupportedStdTypes)
 {
    try {

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -32,6 +32,13 @@ TEST(RNTuple, Int8_t)
    // auto charField = RField<char>("char");
 }
 
+TEST(RNTuple, Int16_t)
+{
+   auto field = RField<std::int16_t>("int16");
+   auto otherField = RFieldBase::Create("test", "std::int16_t").Unwrap();
+   ASSERT_EQ("std::int16_t", RFieldBase::Create("myShort", "Short_t").Unwrap()->GetType());
+}
+
 TEST(RNTuple, UnsupportedStdTypes)
 {
    try {

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -23,13 +23,20 @@ TEST(RNTuple, Int64_t)
    auto otherField = RFieldBase::Create("test", "std::int64_t").Unwrap();
 }
 
+TEST(RNTuple, Char)
+{
+   auto charField = RField<char>("char");
+   auto otherField = RFieldBase::Create("test", "char").Unwrap();
+   ASSERT_EQ("char", otherField->GetType());
+
+   auto charTField = RField<Char_t>("char");
+   ASSERT_EQ("char", charTField.GetType());
+}
+
 TEST(RNTuple, Int8_t)
 {
    auto field = RField<std::int8_t>("int8");
    auto otherField = RFieldBase::Create("test", "std::int8_t").Unwrap();
-   // does not compile
-   // -- RField.hxx:450:39: error: static assertion failed: no I/O support for this basic C++ type
-   // auto charField = RField<char>("char");
 }
 
 TEST(RNTuple, Int16_t)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -17,6 +17,12 @@ TEST(RNTuple, CreateField)
    field->DestroyValue(value);
 }
 
+TEST(RNTuple, Int64_t)
+{
+   auto field = RField<std::int64_t>("int64");
+   auto otherField = RFieldBase::Create("test", "std::int64_t").Unwrap();
+}
+
 TEST(RNTuple, UnsupportedStdTypes)
 {
    try {


### PR DESCRIPTION
Fill in support for fixed-width integer types: 
* [x] std::int64_t
* [x] std::int8_t
* [x] std::int16_t
* [x] std::uint16_t
* [x] char (not guaranteed fixed-width but defacto 8-bit and annoyingly distinct from `std::int8_t` and `std::uint8_t`)
