### PR TITLE
Fix memory leaks

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -49,6 +49,7 @@ allows a simple partial implementation for new OS'es.
 #include <functional>
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <sys/stat.h>
@@ -3658,7 +3659,8 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
    TString librariesWithQuotes;
    TString singleLibrary;
    Bool_t collectingSingleLibraryNameTokens = kFALSE;
-   for (auto tokenObj : *linkLibrariesNoQuotes.Tokenize(" ")) {
+   std::unique_ptr<TObjArray> tokens( linkLibrariesNoQuotes.Tokenize(" ") );
+   for (auto tokenObj : *tokens) {
       singleLibrary = ((TObjString*)tokenObj)->GetString();
       if (singleLibrary[0]=='-' || !AccessPathName(singleLibrary)) {
          if (collectingSingleLibraryNameTokens) {

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -21,7 +21,11 @@
 
 class RooArgList ;
 
-
+// Use a memory pool for RooArgSet.
+// RooFit assumes (e.g. for caching results) that arg sets that have the same pointer have
+// the same contents. Trying to remove that memory pool lead to wrong results, because the
+// OS *occasionally* returns the same address, and the caching goes wrong.
+// It's hard to track down, so disable this only when e.g. looking for memory leaks!
 #define USEMEMPOOLFORARGSET
 template <class RooSet_t, size_t>
 class MemPoolForRooSets;

--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -12,13 +12,38 @@
  * \class MemPoolForRooSets
  * \ingroup roofitcore
  * RooArgSet and RooDataSet were using a mempool that guarantees that allocating,
- * de-allocating and re-allocating a set does not yield the same pointer. Since
- * both were using the same logic, the functionality has been put in this class.
- * This class solves RooFit's static destruction order problems by intentionally leaking
- * arenas of the mempool that still contain live objects at the end of the program.
+ * de-allocating and re-allocating a set does not yield the same pointer.
+ * RooFit relies on this, unfortunately, because it compares the pointers of RooArgSets
+ * to figure out caching, e.g. of integrals.
  *
- * When the set types are compared based on a unique ID instead of their pointer,
- * one can go back to normal memory management, and this class becomes obsolete.
+ * Since both RooArgSet and RooDataSet were using the same logic to manage their memory pools,
+ * the functionality has been put here in a single place.
+ * The introduction of this common mempool also solved RooFit's static destruction order
+ * problems by letting arenas of the mempool leak if RooArgSets are still alive.
+ * This is necessary if the tear down of the mempool happens before all RooArgSets of the entire
+ * process have been deleted. This might e.g. happen in static configs for integrators or when a
+ * plot of a PDF is alive when quitting the interpreter.
+ *
+ * ### If this memory pool seems to leak memory:
+ * - It is likely a leaking RooArgSet / RooDataSet
+ * - Disable the memory pool using the `#define` in RooArgSet.h / RooDataSet.h
+ * - Rerun the leak check to find the leaking RooXSet
+ * - Fix it
+ * - Re-enable the memory pool
+ *
+ * \warning Disabling the memory pools might seem to work at first sight, but can eventually
+ * lead to wrong computations. This would happen if the operating system decides
+ * to assign the same memory address when a RooArgSet is deleted and re-allocated, and both the deleted
+ * as well as the new set happen to be used in the same computation graph. RooFit will
+ * think that the cache doesn't have to be recalculated, and will return an outdated result.
+ * These errors are hard to track down, because they might only happen in a specific toy
+ * MC run on a specific OS / architecture.
+ *
+ * ### How to get rid of the memory pool
+ * If RooArgSet or RooDataSet were compared based on a unique ID instead of their pointer,
+ * this class would become obsolete.
+ * It should be tested, though, if handing memory management over to the OS has an impact on speed.
+ * This is less of a worry, though, because OSs got smarter over RooFit's life time.
  */
 
 #ifndef ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_
@@ -223,7 +248,9 @@ class MemPoolForRooSets {
   ////////////////////////////////////////////////////////////////////////////////
   /// Free memory in arenas that don't have space and no users.
   /// In fTeardownMode, it will also delete the arena that still has space.
-  ///
+  /// Arenas are never deleted, because the pointers of RooArgSets/RooDataSets need
+  /// to be unique for RooFit's caching to work. The arenas only give back the memory to
+  /// the OS.
   void prune()
   {
     for (auto & arena : fArenas) {

--- a/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
@@ -106,7 +106,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
          }
 
          if( p == NULL && fNullDensities.size() >= 1 ) p = fNullDensities[0];
-         if( s == NULL ) s = fParametersForTestStat;
+         if( s == NULL ) s = fParametersForTestStat.get();
          if( s ) s = (const RooArgSet*)s->snapshot();
 
          fNullDensities.push_back( p );

--- a/roofit/roostats/inc/RooStats/ToyMCSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCSampler.h
@@ -13,14 +13,6 @@
 #ifndef ROOSTATS_ToyMCSampler
 #define ROOSTATS_ToyMCSampler
 
-
-#include "Rtypes.h"
-
-#include <vector>
-#include <list>
-#include <string>
-#include <sstream>
-
 #include "RooStats/TestStatSampler.h"
 #include "RooStats/SamplingDistribution.h"
 #include "RooStats/TestStatistic.h"
@@ -33,6 +25,10 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 
+#include <vector>
+#include <list>
+#include <string>
+#include <sstream>
 #include <memory>
 
 namespace RooStats {
@@ -47,14 +43,11 @@ class NuisanceParametersSampler {
          fParams(parameters),
          fNToys(nToys),
          fExpected(asimov),
-         fPoints(NULL),
          fIndex(0)
       {
          if(prior) Refresh();
       }
-      virtual ~NuisanceParametersSampler() {
-         if(fPoints) { delete fPoints; fPoints = NULL; }
-      }
+      virtual ~NuisanceParametersSampler() = default;
 
       void NextPoint(RooArgSet& nuisPoint, Double_t& weight);
 
@@ -67,7 +60,7 @@ class NuisanceParametersSampler {
       Int_t fNToys;
       Bool_t fExpected;
 
-      RooAbsData *fPoints;         // generated nuisance parameter points
+      std::unique_ptr<RooAbsData> fPoints;         // generated nuisance parameter points
       Int_t fIndex;                // current index in fPoints array
 };
 
@@ -283,14 +276,14 @@ class ToyMCSampler: public TestStatSampler {
       mutable NuisanceParametersSampler *fNuisanceParametersSampler; //!
 
       // objects below cache information and are mutable and non-persistent
-      mutable RooArgSet* _allVars ; //!
-      mutable std::list<RooAbsPdf*> _pdfList ; //!
-      mutable std::list<RooArgSet*> _obsList ; //!
-      mutable std::list<RooAbsPdf::GenSpec*> _gsList ; //!
-      mutable RooAbsPdf::GenSpec* _gs1 ; //! GenSpec #1
-      mutable RooAbsPdf::GenSpec* _gs2 ; //! GenSpec #2
-      mutable RooAbsPdf::GenSpec* _gs3 ; //! GenSpec #3
-      mutable RooAbsPdf::GenSpec* _gs4 ; //! GenSpec #4
+      mutable std::unique_ptr<RooArgSet> _allVars; //!
+      mutable std::vector<RooAbsPdf*> _pdfList; //! We don't own those objects
+      mutable std::vector<std::unique_ptr<RooArgSet>> _obsList; //!
+      mutable std::vector<std::unique_ptr<RooAbsPdf::GenSpec>> _gsList; //!
+      mutable std::unique_ptr<RooAbsPdf::GenSpec> _gs1; //! GenSpec #1
+      mutable std::unique_ptr<RooAbsPdf::GenSpec> _gs2; //! GenSpec #2
+      mutable std::unique_ptr<RooAbsPdf::GenSpec> _gs3; //! GenSpec #3
+      mutable std::unique_ptr<RooAbsPdf::GenSpec> _gs4; //! GenSpec #4
 
       static Bool_t fgAlwaysUseMultiGen ;  // Use PrepareMultiGen always
       Bool_t fUseMultiGen ; // Use PrepareMultiGen?

--- a/roofit/roostats/inc/RooStats/ToyMCSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCSampler.h
@@ -31,8 +31,9 @@
 #include "RooMsgService.h"
 #include "RooAbsPdf.h"
 #include "RooRealVar.h"
-
 #include "RooDataSet.h"
+
+#include <memory>
 
 namespace RooStats {
 
@@ -155,8 +156,7 @@ class ToyMCSampler: public TestStatSampler {
 
       // Set the Pdf, add to the the workspace if not already there
       virtual void SetParametersForTestStat(const RooArgSet& nullpoi) {
-         if( fParametersForTestStat ) delete fParametersForTestStat;
-         fParametersForTestStat = (const RooArgSet*)nullpoi.snapshot();
+         fParametersForTestStat.reset( nullpoi.snapshot() );
       }
 
       virtual void SetPdf(RooAbsPdf& pdf) { fPdf = &pdf; ClearCache(); }
@@ -249,7 +249,7 @@ class ToyMCSampler: public TestStatSampler {
 
       // densities, snapshots, and test statistics to reweight to
       RooAbsPdf *fPdf; // model (can be alt or null)
-      const RooArgSet* fParametersForTestStat;
+      std::unique_ptr<const RooArgSet> fParametersForTestStat;
       std::vector<TestStatistic*> fTestStatistics;
 
       std::string fSamplingDistName; // name of the model
@@ -296,7 +296,7 @@ class ToyMCSampler: public TestStatSampler {
       Bool_t fUseMultiGen ; // Use PrepareMultiGen?
 
    protected:
-   ClassDef(ToyMCSampler,3) // A simple implementation of the TestStatSampler interface
+   ClassDef(ToyMCSampler, 4) // A simple implementation of the TestStatSampler interface
 };
 }
 

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -154,7 +154,6 @@ ToyMCSampler::ToyMCSampler() : fSamplingDistName("SD"), fNToys(1)
 {
 
    fPdf = NULL;
-   fParametersForTestStat = NULL;
    fPriorNuisance = NULL;
    fNuisancePars = NULL;
    fObservables = NULL;
@@ -194,7 +193,6 @@ ToyMCSampler::ToyMCSampler() : fSamplingDistName("SD"), fNToys(1)
 ToyMCSampler::ToyMCSampler(TestStatistic &ts, Int_t ntoys) : fSamplingDistName(ts.GetVarName().Data()), fNToys(ntoys)
 {
    fPdf = NULL;
-   fParametersForTestStat = NULL;
    fPriorNuisance = NULL;
    fNuisancePars = NULL;
    fObservables = NULL;

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -93,8 +93,6 @@ void NuisanceParametersSampler::Refresh() {
 
    if (!fPrior || !fParams) return;
 
-   if (fPoints) delete fPoints;
-
    if (fExpected) {
       // UNDER CONSTRUCTION
       oocoutI((TObject*)NULL,InputArguments) << "Using expected nuisance parameters." << endl;
@@ -110,12 +108,12 @@ void NuisanceParametersSampler::Refresh() {
       }
 
 
-      fPoints = fPrior->generate(
+      fPoints.reset( fPrior->generate(
          *fParams,
          AllBinned(),
          ExpectedData(),
          NumEvents(1) // for Asimov set, this is only a scale factor
-      );
+      ));
       if(fPoints->numEntries() != fNToys) {
          fNToys = fPoints->numEntries();
          oocoutI((TObject*)NULL,InputArguments) <<
@@ -137,7 +135,7 @@ void NuisanceParametersSampler::Refresh() {
    }else{
       oocoutI((TObject*)NULL,InputArguments) << "Using randomized nuisance parameters." << endl;
 
-      fPoints = fPrior->generate(*fParams, fNToys);
+      fPoints.reset(fPrior->generate(*fParams, fNToys));
    }
 }
 
@@ -176,12 +174,6 @@ ToyMCSampler::ToyMCSampler() : fSamplingDistName("SD"), fNToys(1)
    fProofConfig = NULL;
    fNuisanceParametersSampler = NULL;
 
-   _allVars = NULL ;
-   _gs1 = NULL ;
-   _gs2 = NULL ;
-   _gs3 = NULL ;
-   _gs4 = NULL ;
-
    //suppress messages for num integration of Roofit
    RooMsgService::instance().getStream(1).removeTopic(RooFit::NumIntegration);
 
@@ -214,12 +206,6 @@ ToyMCSampler::ToyMCSampler(TestStatistic &ts, Int_t ntoys) : fSamplingDistName(t
 
    fProofConfig = NULL;
    fNuisanceParametersSampler = NULL;
-
-   _allVars = NULL ;
-   _gs1 = NULL ;
-   _gs2 = NULL ;
-   _gs3 = NULL ;
-   _gs4 = NULL ;
 
    //suppress messages for num integration of Roofit
    RooMsgService::instance().getStream(1).removeTopic(RooFit::NumIntegration);
@@ -488,7 +474,7 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
 
          const RooArgSet *values = one->get(0);
          if (!_allVars) {
-            _allVars = pdf.getVariables();
+            _allVars.reset(pdf.getVariables());
          }
          *_allVars = *values;
          delete one;
@@ -505,18 +491,15 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
                RooArgSet* globtmp = pdftmp->getObservables(*fGlobalObservables);
                RooAbsPdf::GenSpec* gs = pdftmp->prepareMultiGen(*globtmp, NumEvents(1));
                _pdfList.push_back(pdftmp);
-               _obsList.push_back(globtmp);
-               _gsList.push_back(gs);
+               _obsList.emplace_back(globtmp);
+               _gsList.emplace_back(gs);
             }
          }
 
-         list<RooArgSet*>::iterator oiter = _obsList.begin();
-         list<RooAbsPdf::GenSpec*>::iterator giter = _gsList.begin();
-         for (list<RooAbsPdf*>::iterator iter = _pdfList.begin(); iter != _pdfList.end(); ++iter, ++giter, ++oiter) {
-            //RooDataSet* tmp = (*iter)->generate(**oiter,1) ;
-            RooDataSet* tmp = (*iter)->generate(**giter);
-            **oiter = *tmp->get(0);
-            delete tmp;
+         // Assign generated values to the observables in _obsList
+         for (unsigned int i = 0; i < _pdfList.size(); ++i) {
+           std::unique_ptr<RooDataSet> tmp( _pdfList[i]->generate(*_gsList[i]) );
+           *_obsList[i] = *tmp->get(0);
          }
       }
 
@@ -631,14 +614,14 @@ RooAbsData* ToyMCSampler::Generate(RooAbsPdf &pdf, RooArgSet &observables, const
       } else {
         if (protoData) {
           if (useMultiGen) {
-            if (!_gs2) { _gs2 = pdf.prepareMultiGen(observables, Extended(), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag), ProtoData(*protoData, true, true)) ; }
+            if (!_gs2) _gs2.reset( pdf.prepareMultiGen(observables, Extended(), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag), ProtoData(*protoData, true, true)) );
             data = pdf.generate(*_gs2) ;
           } else {
             data = pdf.generate                    (observables, Extended(), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag), ProtoData(*protoData, true, true));
           }
         } else {
           if (useMultiGen) {
-            if (!_gs1) { _gs1 = pdf.prepareMultiGen(observables, Extended(), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag) ) ; }
+            if (!_gs1) _gs1.reset( pdf.prepareMultiGen(observables, Extended(), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag)) );
             data = pdf.generate(*_gs1) ;
           } else {
             data = pdf.generate                    (observables, Extended(), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag) );
@@ -658,14 +641,14 @@ RooAbsData* ToyMCSampler::Generate(RooAbsPdf &pdf, RooArgSet &observables, const
     } else {
       if (protoData) {
         if (useMultiGen) {
-          if (!_gs3) { _gs3 = pdf.prepareMultiGen(observables, NumEvents(events), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag), ProtoData(*protoData, true, true)); }
+          if (!_gs3) _gs3.reset( pdf.prepareMultiGen(observables, NumEvents(events), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag), ProtoData(*protoData, true, true)) );
           data = pdf.generate(*_gs3) ;
         } else {
           data = pdf.generate                    (observables, NumEvents(events), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag), ProtoData(*protoData, true, true));
         }
       } else {
         if (useMultiGen) {
-          if (!_gs4) { _gs4 = pdf.prepareMultiGen(observables, NumEvents(events), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag)); }
+          if (!_gs4) _gs4.reset( pdf.prepareMultiGen(observables, NumEvents(events), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag)) );
           data = pdf.generate(*_gs4) ;
         } else {
           data = pdf.generate                    (observables, NumEvents(events), AutoBinned(fGenerateAutoBinned), GenBinned(fGenerateBinnedTag));
@@ -673,12 +656,6 @@ RooAbsData* ToyMCSampler::Generate(RooAbsPdf &pdf, RooArgSet &observables, const
       }
     }
   }
-
-  // in case of number counting print observables
-  // if (data->numEntries() == 1) {
-  //    std::cout << "generate observables : ";
-  //    RooStats::PrintListContent(*data->get(0), std::cout);
-  // }
 
   return data;
 }
@@ -710,32 +687,18 @@ SamplingDistribution* ToyMCSampler::AppendSamplingDistribution(
 /// needs to be called every time the model pdf (fPdf) changes
 
 void ToyMCSampler::ClearCache() {
+  _gs1 = nullptr;
+  _gs2 = nullptr;
+  _gs3 = nullptr;
+  _gs4 = nullptr;
+  _allVars = nullptr;
 
-   if (_gs1) delete _gs1;
-   _gs1 = 0;
-   if (_gs2) delete _gs2;
-   _gs2 = 0;
-   if (_gs3) delete _gs3;
-   _gs3 = 0;
-   if (_gs4) delete _gs4;
-   _gs4 = 0;
-
-   // no need to delete the _pdfList since it is managed by the RooSimultaneous object
-   if (_pdfList.size() > 0) {
-      std::list<RooArgSet*>::iterator oiter = _obsList.begin();
-      for (std::list<RooAbsPdf::GenSpec*>::iterator giter  = _gsList.begin(); giter != _gsList.end(); ++giter, ++oiter) {
-         delete *oiter;
-         delete *giter;
-      }
-      _pdfList.clear();
-      _obsList.clear();
-      _gsList.clear();
-   }
-
-   //LM: is this set really needed ??
-   if (_allVars) delete _allVars;
-   _allVars = 0;
-
+  // no need to delete the _pdfList since it is managed by the RooSimultaneous object
+  if (_pdfList.size() > 0) {
+    _pdfList.clear();
+    _obsList.clear();
+    _gsList.clear();
+  }
 }
 
 } // end namespace RooStats


### PR DESCRIPTION
Fixed three leaks here:
- TSystem
- Metacling
- RooStats

Leaks before fixes (using `ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=max_leaks=-1 root.exe ...`):
[lsan_before.log](https://github.com/root-project/root/files/6326991/lsan_before.log)

After fixes:
[Don't have it yet, because after rebasing, #7903 and #6577 broke my asan build. There are leaks in cling, though]. 

@Axel-Naumann:
Please check the first two commits. One needed a shared_ptr or you need a proper copy constructor. I leave it to you to decide if the shared_ptr is the best choice here.

@guitargeek @lmoneta :
Since I waved the magic `unique_ptr` wand on ToyMCSampler anyway, I added a second commit to take it all the way.
I think it would be nice if you backported at least the fix of the leak (the smaller commit), and the larger one can just go in master for a better future. See #7890 regarding the ToyMCSampler leak and where backports are needed. I will leave it open.


Finding those leaks was a bit trickier, because RooFit uses a memory pool. To find those RooArgSet leaks,
- you switch off the mempool
- track down the leak
- switch it on again.

I added two commits mostly for @guitargeek with documentation for you to understand why things are a bit complicated here.