### PR TITLE
Added missing include for std::string

### DIFF
--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
+#include <string>
 
 #include <liburing.h>
 #include <liburing/io_uring.h>


### PR DESCRIPTION
Solved missing include of std::string referenced in error handling. Needed to compile using clang and libc++