### PR TITLE
[RF] Implement move constructor/assignment operator of RooLinkedListIter

### DIFF
--- a/roofit/roofitcore/inc/RooLinkedListIter.h
+++ b/roofit/roofitcore/inc/RooLinkedListIter.h
@@ -210,9 +210,18 @@ class RooLinkedListIter final : public TIterator {
   }
 
   RooLinkedListIter(const RooLinkedListIter &) = delete;
-  RooLinkedListIter(RooLinkedListIter &&) = default;
   RooLinkedListIter & operator=(const RooLinkedListIter &) = delete;
-  RooLinkedListIter & operator=(RooLinkedListIter &&) = default;
+
+  // Setting the move constructor and assignment operator to = default might
+  // seem to work, but it causes linker errors when using it because
+  // TIterator::operator= is not implemented.
+  RooLinkedListIter(RooLinkedListIter && other)
+    : fIterImpl{std::move(other.fIterImpl)}
+  {}
+  RooLinkedListIter & operator=(RooLinkedListIter && other) {
+    fIterImpl = std::move(other.fIterImpl);
+    return *this;
+  }
 
   TIterator &operator=(const TIterator & other) override {fIterImpl->operator=(other); return *this;}
   const TCollection *GetCollection() const override {return nullptr;}


### PR DESCRIPTION
Setting the move constructor and move assignment operator to = default
causes linker errors because the copy assignment operator is not
implemented in the TIterator base class.

Having the RooLinkedListIter move constructor and assignment operators
work is important to keep user code compatibility.

This is done to avoid breaking user code in the upcoming release (doesn't affect ROOT 6.24 because problem exists only since https://github.com/root-project/root/pull/7641).

With the current master, the linker error can be reproduces like this;
```C++
void iterator_test() {

    RooArgSet argSet1;
    RooArgSet argSet2;

    RooLinkedListIter iter{argSet1.iterator()};

    iter = argSet2.iterator();
}
```