### PR TITLE
[RF] Rename RooHistFunc::getObservables

### DIFF
--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -1779,7 +1779,7 @@ RooRealVar *RooLagrangianMorphFunc::setupObservable(const char *obsname,
 
   if (mode && mode->InheritsFrom(RooHistFunc::Class())) {
     obs = (RooRealVar *)(dynamic_cast<RooHistFunc *>(inputExample)
-                             ->getObservables()
+                             ->getHistObsList()
                              .first());
     obsExists = true;
     this->_observables.add(*obs);

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -78,7 +78,7 @@ public:
   virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
   virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ; 
   virtual Bool_t isBinnedDistribution(const RooArgSet&) const { return _intOrder==0 ; }
-  const RooArgSet getObservables() const { return _histObsList; }
+  RooArgSet const& getHistObsList() const { return _histObsList; }
 
 
 protected:


### PR DESCRIPTION
Rename RooHistFunc::getObservables to not hide
RooAbsArg::getObservables.

This is done to avoid breaking user code in the upcoming release (doesn't affect ROOT 6.24).