### PR TITLE
[treereader] Try harder when looking for a leaf (6.24)

### DIFF
--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -745,6 +745,12 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
       if ((!dataTypeName || !dataTypeName[0])
           && branch->IsA() == TBranch::Class()) {
          TLeaf *myLeaf = branch->GetLeaf(branch->GetName());
+         if (!myLeaf) {
+            myLeaf = branch->FindLeaf(branch->GetName());
+         }
+         if (!myLeaf && branch->GetListOfLeaves()->GetEntries() == 1) {
+            myLeaf = static_cast<TLeaf *>(branch->GetListOfLeaves()->UncheckedAt(0));
+         }
          if (myLeaf){
             TDictionary *myDataType = TDictionary::GetDictionary(myLeaf->GetTypeName());
             if (myDataType && myDataType->IsA() == TDataType::Class()){


### PR DESCRIPTION
Before this patch, given a TTree with a branch with name different
from its leaf, e.g. like this:

```
*Br    0 :NUD_total_ADC : nud_total_adc/D
```

TTreeReaderValue failed to retrieve the leaf when the named passed
to the constructor was just "NUD_total_ADC" (while it worked fine
with "NUD_total_ADC.nud_total_adc"). In comparison, in a similar
situation `TTree::Draw` "tries harder" and it assumes that the
desired leaf is the first sub-leaf of the specified branch.

With this patch, TTreeReaderValue tries `FindLeaf` after `GetLeaf`
and as a last resort it picks the branch sub-leaf if it exists and
it is unique.

This fixes #6881.