### PR TITLE
[DF] Add branch name to list of valid column names if it has one leaf

### DIFF
--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -164,7 +164,7 @@ std::string GetLeafTypeName(TLeaf *leaf, const std::string &colName)
 std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
 {
    // look for TLeaf either with GetLeaf(colName) or with GetLeaf(branchName, leafName) (splitting on last dot)
-   auto leaf = t.GetLeaf(colName.c_str());
+   auto *leaf = t.GetLeaf(colName.c_str());
    if (!leaf)
       leaf = t.FindLeaf(colName.c_str()); // try harder
    if (!leaf) {
@@ -180,7 +180,7 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
    if (leaf)
       return GetLeafTypeName(leaf, colName);
 
-   // we could not find a leaf named colName, so we look for a TBranchElement
+   // we could not find a leaf named colName, so we look for a branch called like this
    auto branch = t.GetBranch(colName.c_str());
    if (!branch)
       branch = t.FindBranch(colName.c_str()); // try harder
@@ -202,10 +202,15 @@ std::string GetBranchOrLeafTypeName(TTree &t, const std::string &colName)
             }
             return be->GetClassName();
          }
+      } else if (branch->IsA() == TBranch::Class() && branch->GetListOfLeaves()->GetEntries() == 1) {
+         // normal branch (not a TBranchElement): if it has only one leaf, we pick the type of the leaf:
+         // RDF and TTreeReader allow referring to branch.leaf as just branch if branch has only one leaf
+         leaf = static_cast<TLeaf *>(branch->GetListOfLeaves()->UncheckedAt(0));
+         return GetLeafTypeName(leaf, colName + '.' + leaf->GetName());
       }
    }
 
-   // colName is not a leaf nor a TBranchElement
+   // we could not find a branch or a leaf called colName
    return std::string();
 }
 

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -151,10 +151,7 @@ static void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, Colum
             auto listOfLeaves = branch->GetListOfLeaves();
             if (listOfLeaves->GetEntries() == 1) {
                auto leaf = static_cast<TLeaf *>(listOfLeaves->UncheckedAt(0));
-               const auto leafName = std::string(leaf->GetName());
-               if (leafName == branchName) {
-                  UpdateList(bNamesReg, bNames, branchName, friendName, foundLeaves, leaf, allowDuplicates);
-               }
+               UpdateList(bNamesReg, bNames, branchName, friendName, foundLeaves, leaf, allowDuplicates);
             }
 
             for (auto leaf : *listOfLeaves) {

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -74,7 +74,6 @@ static bool ContainsLeaf(const std::set<TLeaf *> &leaves, TLeaf *leaf)
 static void UpdateList(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, const std::string &branchName,
                        const std::string &friendName)
 {
-
    if (!friendName.empty()) {
       // In case of a friend tree, users might prepend its name/alias to the branch names
       const auto friendBName = friendName + "." + branchName;
@@ -87,7 +86,7 @@ static void UpdateList(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// This overloads makes sure that the TLeaf has not been already inserted.
+/// This overload makes sure that the TLeaf has not been already inserted.
 static void UpdateList(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, const std::string &branchName,
                        const std::string &friendName, std::set<TLeaf *> &foundLeaves, TLeaf *leaf, bool allowDuplicates)
 {

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -150,7 +150,7 @@ static void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, Colum
             // Leaf list
             auto listOfLeaves = branch->GetListOfLeaves();
             if (listOfLeaves->GetEntries() == 1) {
-               auto leaf = static_cast<TLeaf *>(listOfLeaves->At(0));
+               auto leaf = static_cast<TLeaf *>(listOfLeaves->UncheckedAt(0));
                const auto leafName = std::string(leaf->GetName());
                if (leafName == branchName) {
                   UpdateList(bNamesReg, bNames, branchName, friendName, foundLeaves, leaf, allowDuplicates);

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -617,3 +617,15 @@ TEST(RDataFrameInterface, Describe)
                      "myFloat                 Float_t                         Dataset";
    EXPECT_EQ(df3.Describe(), ref2);
 }
+
+// https://sft.its.cern.ch/jira/browse/ROOT-9558
+TEST(RDFSimpleTests, LeafWithDifferentNameThanBranch)
+{
+   TTree t("t", "t");
+   int x = 42;
+   t.Branch("x", &x, "y/I");
+   t.Fill();
+
+   auto m = ROOT::RDataFrame(t).Max<int>("x");
+   EXPECT_EQ(*m, 42);
+}


### PR DESCRIPTION
Before this patch, given a TTree with a branch with name _different_
from its leaf, e.g. like this:

```
*Br    0 :NUD_total_ADC : nud_total_adc/D
```

RDataFrame only added "branchname.leafname" to the list of available
columns (i.e. "NUD_total_ADC.nud_total_adc" in the example).

In comparison, in a similar situation `TTree::Draw` also accepts
just "NUD_total_ADC" as it assumes that the desired leaf is the
first sub-leaf of the specified branch.

With this patch, RDataFrame also considers "NUD_total_ADC" as a valid
column name as long as it has only one sub-leaf.

This, together with previous fixes in TTreeReader, fixes ROOT-9558.