### PR TITLE
Use New Roofit range based iterators in RooStats::DetailedOutputAggregator

### DIFF
--- a/roofit/roostats/src/DetailedOutputAggregator.cxx
+++ b/roofit/roostats/src/DetailedOutputAggregator.cxx
@@ -52,8 +52,8 @@ namespace RooStats {
       RooArgSet *detailedOutput = new RooArgSet;
       const RooArgList &detOut = result->floatParsFinal();
       const RooArgList &truthSet = result->floatParsInit();
-      TIterator *it = detOut.createIterator();
-      while(RooAbsArg* v = dynamic_cast<RooAbsArg*>(it->Next())) {
+
+      for (RooAbsArg* v : detOut) {
          RooAbsArg* clone = v->cloneTree(TString().Append(prefix).Append(v->GetName()));
          clone->SetTitle( TString().Append(prefix).Append(v->GetTitle()) );
          RooRealVar* var = dynamic_cast<RooRealVar*>(v);
@@ -71,7 +71,6 @@ namespace RooStats {
             detailedOutput->add(*pull);
          }
       }
-      delete it;
 
       // monitor a few more variables
       detailedOutput->add( *new RooRealVar(TString().Append(prefix).Append("minNLL"), TString().Append(prefix).Append("minNLL"), result->minNll() ) );
@@ -96,8 +95,7 @@ namespace RooStats {
       if (fBuiltSet == NULL) {
          fBuiltSet = new RooArgList();
       }
-      TIterator* iter = aset->createIterator();
-      while(RooAbsArg* v = dynamic_cast<RooAbsArg*>( iter->Next() ) ) {
+      for (const RooAbsArg* v : *aset) {
          TString renamed(TString::Format("%s%s", prefix.Data(), v->GetName()));
          if (fResult == NULL) {
             // we never committed, so by default all columns are expected to not exist
@@ -120,7 +118,7 @@ namespace RooStats {
             var->SetName(renamed);
          }
       }
-      delete iter;
+
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -133,8 +131,8 @@ namespace RooStats {
          fResult = new RooDataSet("", "", RooArgSet(*fBuiltSet,wgt), RooFit::WeightVar(wgt));
       }
       fResult->add(RooArgSet(*fBuiltSet), weight);
-      TIterator* iter = fBuiltSet->createIterator();
-      while(RooAbsArg* v = dynamic_cast<RooAbsArg*>( iter->Next() ) ) {
+
+      for (RooAbsArg* v : *fBuiltSet) {
          if (RooRealVar* var= dynamic_cast<RooRealVar*>(v)) {
             // Invalidate values in case we don't set some of them next time round (eg. if fit not done)
             var->setVal(std::numeric_limits<Double_t>::quiet_NaN());
@@ -142,7 +140,6 @@ namespace RooStats {
             var->removeAsymError();
          }
       }
-      delete iter;
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -167,4 +164,3 @@ namespace RooStats {
 
 
 }  // end namespace RooStats
-


### PR DESCRIPTION
As  shown in #7631 this could fix some potential  memory leak in DetailedOutputAgregator, with a better usage of TIterators 

The DetailedOutputAggregator class is used heavily when running toys with ToyMCSampler and it might be responsible of some of the leaks observed in #7890
