### PR TITLE
[IO] Fix out of bounds read in TClassEdit (6.24)

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -558,8 +558,9 @@ int   TClassEdit::STLArgs(int kind)
    static const char  stln[] =// min number of container arguments
       //     vector, list, deque, map, multimap, set, multiset, bitset,
       {    1,     1,    1,     1,   3,        3,   2,        2,      1,
-      // forward_list, unordered_set, unordered_multiset, unordered_map, unordered_multimap
-                    1,             3,                  3,             4,                  4};
+      // forward_list, unordered_set, unordered_multiset, unordered_map, unordered_multimap, ROOT::RVec
+                    1,             3,                  3,             4,                  4,          1};
+   assert(std::size_t(kind) < sizeof(stln) && "index is out of bounds");
 
    return stln[kind];
 }


### PR DESCRIPTION
When doing I/O of RVec objects, TClassEdit::STLArgs was accessing
an element one after the end of a static array. asan rightly complains.

This commit fixes #7903,
which contains more details.

This PR is a backport of #7920