### PR TITLE
Deleting a chunk of repeated comment

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -7419,13 +7419,6 @@ void TH1::UseCurrentStyle()
 /// See TH1::GetStats.
 ///
 /// Return mean value of this histogram along the X axis.
-///
-/// Note that the mean value/StdDev is computed using the bins in the currently
-/// defined range (see TAxis::SetRange). By default the range includes
-/// all bins from 1 to nbins included, excluding underflows and overflows.
-/// To force the underflows and overflows in the computation, one must
-/// call the static function TH1::StatOverflows(kTRUE) before filling
-/// the histogram.
 
 Double_t TH1::GetMean(Int_t axis) const
 {


### PR DESCRIPTION
Deleting a chunk of repeated comment in the description of TH1::GetMean().

<img width="623" alt="2021-04-19 22_54_28-ROOT_ TH1 Class Reference - Opera" src="https://user-images.githubusercontent.com/7541582/115295579-94c90100-a162-11eb-9c6c-0115893c3b9a.png">
