### PR TITLE
[RF] Deallocate memory owned by empty MemPoolForRooSets Arenas

### DIFF
--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -126,6 +126,7 @@ class MemPoolForRooSets {
     {
       if (inPool(ptr)) {
         --refCount;
+        tryFree(false);
 #ifndef NDEBUG
         const std::size_t index = static_cast<RooSet_t *>(ptr) - memBegin;
         if (deletedElements.count(index) != 0) {


### PR DESCRIPTION
If an arena in the MemPoolForRooSets is not referenced anymore, it
should delete the memory it has allocated.

This addresses GitHub issue https://github.com/root-project/root/issues/7933.