### PR TITLE
[io] Catch RIoUring constructor exceptions in RRawFileUnix::ReadV

### DIFF
--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -27,17 +27,6 @@ private:
    struct io_uring fRing;
    std::uint32_t fDepth = 0;
 
-   static bool CheckIsAvailable() {
-      try {
-         RIoUring(1);
-         return true;
-      }
-      catch (const std::runtime_error& err) {
-         Warning("RIoUring", "io_uring is not available\n%s", err.what());
-      }
-      return false;
-   }
-
 public:
    // Create an io_uring instance. The ring selects an appropriate queue depth. which can be queried
    // afterwards using GetQueueDepth(). The depth is typically 1024 or lower. Throws an exception if
@@ -80,12 +69,6 @@ public:
    ~RIoUring() {
       // todo(max) try submitting any pending events before exiting
       io_uring_queue_exit(&fRing);
-   }
-
-   /// Check if io_uring is available on this system.
-   static bool IsAvailable() {
-      static const bool available = RIoUring::CheckIsAvailable();
-      return available;
    }
 
    std::uint32_t GetQueueDepth() {

--- a/io/io/inc/ROOT/RIoUring.hxx
+++ b/io/io/inc/ROOT/RIoUring.hxx
@@ -57,7 +57,7 @@ public:
          // try again with a smaller queue for ENOMEM
          queueDepth /= 2;
          if (queueDepth == 0) {
-            throw std::runtime_error("Fatal Error: failed to allocate memory for the smallest possible "
+            throw std::runtime_error("Failed to allocate memory for the smallest possible "
                "io_uring instance. 'memlock' memory has been exhausted for this user");
          }
       }

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -115,31 +115,29 @@ void ROOT::Internal::RRawFileUnix::OpenImpl()
 void ROOT::Internal::RRawFileUnix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
 #ifdef R__HAS_URING
-   if (RIoUring::IsAvailable()) {
-      try {
-         RIoUring ring; // throws std::runtime_error
-         std::vector<RIoUring::RReadEvent> reads;
-         reads.reserve(nReq);
-         for (std::size_t i = 0; i < nReq; ++i) {
-            RIoUring::RReadEvent ev;
-            ev.fBuffer = ioVec[i].fBuffer;
-            ev.fOffset = ioVec[i].fOffset;
-            ev.fSize = ioVec[i].fSize;
-            ev.fFileDes = fFileDes;
-            reads.push_back(ev);
-         }
-         ring.SubmitReadsAndWait(reads.data(), nReq);
-         for (std::size_t i = 0; i < nReq; ++i) {
-            ioVec[i].fOutBytes = reads.at(i).fOutBytes;
-         }
-         return;
+   try {
+      RIoUring ring; // throws std::runtime_error
+      std::vector<RIoUring::RReadEvent> reads;
+      reads.reserve(nReq);
+      for (std::size_t i = 0; i < nReq; ++i) {
+         RIoUring::RReadEvent ev;
+         ev.fBuffer = ioVec[i].fBuffer;
+         ev.fOffset = ioVec[i].fOffset;
+         ev.fSize = ioVec[i].fSize;
+         ev.fFileDes = fFileDes;
+         reads.push_back(ev);
       }
-      catch(const std::runtime_error &e) {
-         Warning("RIoUring", "io_uring is not available\n%s", e.what());
+      ring.SubmitReadsAndWait(reads.data(), nReq);
+      for (std::size_t i = 0; i < nReq; ++i) {
+         ioVec[i].fOutBytes = reads.at(i).fOutBytes;
       }
+      return;
    }
-   Warning("RRawFileUnix",
+   catch(const std::runtime_error &e) {
+      Warning("RIoUring", "io_uring is not available\n%s", e.what());
+      Warning("RRawFileUnix",
            "io_uring setup failed, falling back to default ReadV implementation");
+   }
 #endif
    RRawFile::ReadVImpl(ioVec, nReq);
 }

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -115,28 +115,32 @@ void ROOT::Internal::RRawFileUnix::OpenImpl()
 void ROOT::Internal::RRawFileUnix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
 {
 #ifdef R__HAS_URING
-   try {
-      RIoUring ring; // throws std::runtime_error
-      std::vector<RIoUring::RReadEvent> reads;
-      reads.reserve(nReq);
-      for (std::size_t i = 0; i < nReq; ++i) {
-         RIoUring::RReadEvent ev;
-         ev.fBuffer = ioVec[i].fBuffer;
-         ev.fOffset = ioVec[i].fOffset;
-         ev.fSize = ioVec[i].fSize;
-         ev.fFileDes = fFileDes;
-         reads.push_back(ev);
+   thread_local bool uring_failed = false;
+   if (!uring_failed) {
+      try {
+         RIoUring ring; // throws std::runtime_error
+         std::vector<RIoUring::RReadEvent> reads;
+         reads.reserve(nReq);
+         for (std::size_t i = 0; i < nReq; ++i) {
+            RIoUring::RReadEvent ev;
+            ev.fBuffer = ioVec[i].fBuffer;
+            ev.fOffset = ioVec[i].fOffset;
+            ev.fSize = ioVec[i].fSize;
+            ev.fFileDes = fFileDes;
+            reads.push_back(ev);
+         }
+         ring.SubmitReadsAndWait(reads.data(), nReq);
+         for (std::size_t i = 0; i < nReq; ++i) {
+            ioVec[i].fOutBytes = reads.at(i).fOutBytes;
+         }
+         return;
       }
-      ring.SubmitReadsAndWait(reads.data(), nReq);
-      for (std::size_t i = 0; i < nReq; ++i) {
-         ioVec[i].fOutBytes = reads.at(i).fOutBytes;
+      catch(const std::runtime_error &e) {
+         Warning("RIoUring", "io_uring is unexpectedly not available because:\n%s", e.what());
+         Warning("RRawFileUnix",
+              "io_uring setup failed, falling back to blocking I/O in ReadV");
+         uring_failed = true;
       }
-      return;
-   }
-   catch(const std::runtime_error &e) {
-      Warning("RIoUring", "io_uring is unexpectedly not available because:\n%s", e.what());
-      Warning("RRawFileUnix",
-           "io_uring setup failed, falling back to blocking I/O in ReadV");
    }
 #endif
    RRawFile::ReadVImpl(ioVec, nReq);

--- a/io/io/src/RRawFileUnix.cxx
+++ b/io/io/src/RRawFileUnix.cxx
@@ -134,9 +134,9 @@ void ROOT::Internal::RRawFileUnix::ReadVImpl(RIOVec *ioVec, unsigned int nReq)
       return;
    }
    catch(const std::runtime_error &e) {
-      Warning("RIoUring", "io_uring is not available\n%s", e.what());
+      Warning("RIoUring", "io_uring is unexpectedly not available because:\n%s", e.what());
       Warning("RRawFileUnix",
-           "io_uring setup failed, falling back to default ReadV implementation");
+           "io_uring setup failed, falling back to blocking I/O in ReadV");
    }
 #endif
    RRawFile::ReadVImpl(ioVec, nReq);


### PR DESCRIPTION
Handle case where CheckIsAvailable succeeds but constructing a
potentially larger io_uring instance fails. Reported as part of:
<https://github.com/root-project/root/issues/7936>

h/t @amadio 