### PR TITLE
[webgui] configure special mode for PyROOT

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_application.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_application.py
@@ -11,7 +11,7 @@
 import sys
 import time
 
-from cppyy.gbl import gSystem, gInterpreter
+from cppyy.gbl import gSystem, gInterpreter, gEnv
 
 from libROOTPythonizations import InitApplication, InstallGUIEventInputHook
 
@@ -98,3 +98,6 @@ class PyROOTApplication(object):
             update_thread.start()
 
         self._set_display_hook()
+
+        # indicate that ProcessEvents called in different thread, let ignore thread id checks in RWebWindow
+        gEnv.SetValue("WebGui.ExternalProcessEvents", "yes")

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -194,6 +194,8 @@ private:
 
    unsigned FindHeadlessConnection();
 
+   void CheckThreadAssign();
+
 public:
 
    RWebWindow();

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -24,6 +24,7 @@
 
 class THttpServer;
 class THttpWSHandler;
+class TExec;
 
 namespace ROOT {
 namespace Experimental {
@@ -40,6 +41,8 @@ private:
    bool fUseHttpThrd{false};             ///<! use special thread for THttpServer
    bool fUseSenderThreads{false};        ///<! use extra threads for sending data from RWebWindow to clients
    float fLaunchTmout{30.};              ///<! timeout in seconds to start browser process, default 30s
+   bool fExternalProcessEvents{false};   ///<! indicate that there are external process events engine
+   std::unique_ptr<TExec> fAssgnExec;    ///<! special exec to assign thread id via ProcessEvents
 
    /// Returns true if http server use special thread for requests processing (default off)
    bool IsUseHttpThread() const { return fUseHttpThrd; }
@@ -60,6 +63,8 @@ private:
    std::string GetUrl(const RWebWindow &win, bool remote = false);
 
    bool CreateServer(bool with_http = false);
+
+   void AssignWindowThreadId(RWebWindow &win);
 
 public:
    RWebWindowsManager();

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -567,6 +567,16 @@ std::string RWebWindow::GetConnToken() const
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
+/// Internal method to verify and thread id has to be assigned from manager again
+/// Special case when ProcessMT was enabled just until thread id will be assigned
+
+void RWebWindow::CheckThreadAssign()
+{
+   if (fProcessMT && fMgr->fExternalProcessEvents)
+      fMgr->AssignWindowThreadId(*this);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
 /// Processing of websockets call-backs, invoked from RWebWindowWSHandler
 /// Method invoked from http server thread, therefore appropriate mutex must be used on all relevant data
 

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -113,7 +113,13 @@ public:
 
    /// Process websocket request - called from THttpServer thread
    /// THttpWSHandler interface
-   Bool_t ProcessWS(THttpCallArg *arg) override { return arg && !IsDisabled() ? fWindow.ProcessWS(*arg) : kFALSE; }
+   Bool_t ProcessWS(THttpCallArg *arg) override
+   {
+      if (!arg || IsDisabled()) return kFALSE;
+      auto res = fWindow.ProcessWS(*arg);
+      fWindow.CheckThreadAssign();
+      return res;
+   }
 
    /// Allow processing of WS actions in arbitrary thread
    Bool_t AllowMTProcess() const override { return fWindow.fProcessMT; }

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -33,8 +33,6 @@
 
 using namespace ROOT::Experimental;
 
-
-
 ///////////////////////////////////////////////////////////////
 /// Parse boolean gEnv variable which should be "yes" or "no"
 /// Returns -1 if not defined
@@ -110,7 +108,6 @@ void RWebWindowsManager::AssignMainThrd()
 {
    gWebWinMainThrd = std::this_thread::get_id();
 }
-
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// window manager constructor
@@ -383,7 +380,7 @@ std::shared_ptr<RWebWindow> RWebWindowsManager::CreateWindow()
       win->RecordData(fname, prefix);
    }
 
-   if (IsUseHttpThread())
+   if (IsUseHttpThread() || (RWebWindowWSHandler::GetBoolEnv("WebGui.ExternalProcessEvents") == 1))
       win->UseServerThreads();
 
    const char *token = gEnv->GetValue("WebGui.ConnToken", "");

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -970,6 +970,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       /** @summary Quit ROOT session */
       onQuitRootPress: function() {
          this.websocket.send("QUIT_ROOT");
+         setTimeout(() => { if (window) window.close(); }, 2000);
       },
 
       onSearch : function(oEvt) {


### PR DESCRIPTION
Solves problem with `rootbrowse` utility.

In PyROOT there are different ways how event loop is running.
Finally there is special thread where gSystem->ProcessEvents() regularly called.

In such special case webgui should be informed that ProcessEvents called from special thread - 
via `gEnv->SetValue("WebGui.ExternalProcessEvents", "yes")`.
In such case RWebWindowManager tries to detect thread id and really use ProcessEvents context to process WebGui functionality. In such configuration extra http thread not required and will be disabled.

