### PR TITLE
[RF] Reduce memory consumption of MemPoolForRooSets

### DIFF
--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -26,38 +26,35 @@
 
 #include "TStorage.h"
 
-#include <vector>
 #include <algorithm>
-#include <set>
+#include <array>
+#include <bitset>
+#include <vector>
 
 template <class RooSet_t, std::size_t POOLSIZE>
 class MemPoolForRooSets {
 
   struct Arena {
     Arena()
-      : ownedMemory{static_cast<RooSet_t *>(TStorage::ObjectAlloc(POOLSIZE * sizeof(RooSet_t)))},
+      : ownedMemory{static_cast<RooSet_t *>(TStorage::ObjectAlloc(2 * POOLSIZE * sizeof(RooSet_t)))},
         memBegin{ownedMemory}, nextItem{ownedMemory},
-        memEnd{memBegin + POOLSIZE}, refCount{0}
-    {
-    }
-
-
+        memEnd{memBegin + 2 * POOLSIZE}
+    {}
 
     Arena(const Arena &) = delete;
     Arena(Arena && other)
       : ownedMemory{other.ownedMemory},
         memBegin{other.memBegin}, nextItem{other.nextItem}, memEnd{other.memEnd},
-        refCount{other.refCount}
-#ifndef NDEBUG
-      , deletedElements { std::move(other.deletedElements) }
-#endif
+        refCount{other.refCount},
+        totCount{other.totCount},
+        assigned{other.assigned}
     {
       // Needed for unique ownership
       other.ownedMemory = nullptr;
       other.refCount = 0;
+      other.totCount = 0;
+      other.assigned = 0;
     }
-
-
 
     Arena & operator=(const Arena &) = delete;
     Arena & operator=(Arena && other)
@@ -66,18 +63,17 @@ class MemPoolForRooSets {
       memBegin = other.memBegin;
       nextItem = other.nextItem;
       memEnd   = other.memEnd;
-#ifndef NDEBUG
-      deletedElements = std::move(other.deletedElements);
-#endif
       refCount     = other.refCount;
+      totCount     = other.totCount;
+      assigned     = other.assigned;
 
       other.ownedMemory = nullptr;
       other.refCount = 0;
+      other.totCount = 0;
+      other.assigned = 0;
 
       return *this;
     }
-
-
 
     // If there is any user left, the arena shouldn't be deleted.
     // If this happens, nevertheless, one has an order of destruction problem.
@@ -104,7 +100,9 @@ class MemPoolForRooSets {
       return inPool(static_cast<const RooSet_t * const>(ptr));
     }
 
-    bool hasSpace() const { return ownedMemory && nextItem < memEnd; }
+    bool hasSpace() const {
+        return totCount < POOLSIZE * sizeof(RooSet_t) && refCount < POOLSIZE;
+    }
     bool empty() const { return refCount == 0; }
 
     void tryFree(bool freeNonFull) {
@@ -118,8 +116,26 @@ class MemPoolForRooSets {
     {
       if (!hasSpace()) return nullptr;
 
-      ++refCount;
-      return nextItem++;
+      for(std::size_t i = 0; i < POOLSIZE; ++i) {
+        if (nextItem == memEnd) {
+          nextItem = ownedMemory;
+        }
+        std::size_t index = (static_cast<RooSet_t *>(nextItem) - memBegin) / 2;
+        nextItem += 2;
+        if(!assigned[index]) {
+          if (cycle[index] == sizeof(RooSet_t)) {
+            continue;
+          }
+          ++refCount;
+          ++totCount;
+          assigned[index] = true;
+          auto ptr = reinterpret_cast<RooSet_t*>(reinterpret_cast<char*>(ownedMemory + 2 * index) + cycle[index]);
+          cycle[index]++;
+          return ptr;
+        }
+      }
+
+      return nullptr;
     }
 
     bool tryDeallocate(void * ptr)
@@ -127,15 +143,15 @@ class MemPoolForRooSets {
       if (inPool(ptr)) {
         --refCount;
         tryFree(false);
+        const std::size_t index = ( (reinterpret_cast<const char *>(ptr) - reinterpret_cast<const char *>(memBegin)) / 2) / sizeof(RooSet_t);
 #ifndef NDEBUG
-        const std::size_t index = static_cast<RooSet_t *>(ptr) - memBegin;
-        if (deletedElements.count(index) != 0) {
+        if (assigned[index] == false) {
           std::cerr << "Double delete of " << ptr << " at index " << index << " in Arena with refCount " << refCount
               << ".\n\tArena: |" << memBegin << "\t" << ptr << "\t" << memEnd << "|" << std::endl;
           throw;
         }
-        deletedElements.insert(index);
 #endif
+        assigned[index] = false;
         return true;
       } else
         return false;
@@ -150,10 +166,11 @@ class MemPoolForRooSets {
     const RooSet_t * memBegin;
     RooSet_t * nextItem;
     const RooSet_t * memEnd;
-    std::size_t refCount;
-#ifndef NDEBUG
-    std::set<std::size_t> deletedElements;
-#endif
+    std::size_t refCount = 0;
+    std::size_t totCount = 0;
+
+    std::bitset<POOLSIZE> assigned = {};
+    std::array<int, POOLSIZE> cycle = {};
   };
 
 
@@ -179,20 +196,24 @@ class MemPoolForRooSets {
     }
   }
 
-
-
   /// Allocate memory for the templated set type. Fails if bytes != sizeof(RooSet_t).
   void * allocate(std::size_t bytes)
   {
     if (bytes != sizeof(RooSet_t))
       throw std::bad_alloc();
 
-    if (fArenas.empty() || !fArenas.back().hasSpace()) {
+    if (fArenas.empty()) {
       newArena();
-      prune();
     }
 
     void * ptr = fArenas.back().tryAllocate();
+
+    if (ptr == nullptr) {
+      newArena();
+      prune();
+      ptr = fArenas.back().tryAllocate();
+    }
+
     assert(ptr != nullptr);
 
     return ptr;
@@ -271,7 +292,7 @@ class MemPoolForRooSets {
       Arena ar;
       if (std::none_of(fArenas.begin(), fArenas.end(),
           [&ar](Arena& other){return ar.memoryOverlaps(other);})) {
-        fArenas.push_back(std::move(ar));
+        fArenas.emplace_back(std::move(ar));
         break;
       }
       else {


### PR DESCRIPTION
The MemPoolForRooSets has two problems:

 1. Scaling issues: increasing memory and CPU consumption with
    increasing number of arenas, becuase trying to allocate a new
    non-overlapping arena often fails.

 2. Amplification of memory leaks in user code:
    If one of the elements in the arena leaks, the whole arena will
    leak. Since each arena has 6000 elements, this means a leak of a
    RooArgSet will be ampilfied by a factor 6000 in the worst case.

This commit proposes a solution to the scaling/performance issues and
the leak amplification.

Explained for the example for RooArgSet, the idea is to use each arena
120 times because this is the size of RooArgSet in bytes. This can be
done while still having unique adresses for each RooArgSet:

 1. Keep a gap of 120 bytes between each RooArgSet
 2. When an address was used before, add one byte and in can be used
    again

So at the cost of allocating 2x more memory per arena, we can reuse each
arena 120 times.

Now, the good thing is that the interval of creating/deleting
RooArgSets is usually higher than 6000. So when reusing an arena
multiple times, they will eventually be filled only by leaking
RooArgSets if there is a leak. Meaning the leak amplification effect
should be gone.

This was checked with the CMS Higgs combine toy fit example from the
Higgs combine tutorial. Without this commit, there is a GB-level leak
that can be clearly observed with `top`, but with this commit the leak
becomes negligible again.

The PR is still kind of a draft PR. I will check with the bot if this solution works on all platforms and then continue improving the code.

This should be backported together with https://github.com/root-project/root/pull/7935.

This should finally fix https://github.com/root-project/root/issues/7933.

Profile of the CMS toy experiment example with a ROOT Debug build:
* [without this PR](https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/combine_example_2_old)
* [with this PR](https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/arena_1_new)