### PR TITLE
[RF] Fix memory leak in RooProdPdf::factorizeProduct

### DIFF
--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -650,14 +650,12 @@ void RooProdPdf::factorizeProduct(const RooArgSet& normSet, const RooArgSet& int
 	term->add(*pdf);
 	termNormDeps->add(pdfNormDeps, kFALSE);
 	termAllDeps->add(pdfAllDeps, kFALSE);
-	if (!termIntDeps) {
-	  termIntDeps = new RooArgSet("termIntDeps");
+	if (termIntDeps) {
+	  termIntDeps->add(*pdfIntSet, kFALSE);
 	}
-	termIntDeps->add(*pdfIntSet, kFALSE);
-	if (!termIntNoNormDeps) {
-	  termIntNoNormDeps = new RooArgSet("termIntNoNormDeps");
+	if (termIntNoNormDeps) {
+	  termIntNoNormDeps->add(pdfIntNoNormDeps, kFALSE);
 	}
-	termIntNoNormDeps->add(pdfIntNoNormDeps, kFALSE);
 	done = kTRUE;
       }
     }


### PR DESCRIPTION
This memory leak was reported in https://github.com/root-project/root/issues/7890#issuecomment-820445272.

Both `termIntDeps` and `termIntNoNormDeps` are only used again a few lines below the lines with the change, and they are only passed to an owning collection *after* newly allocated memory gets assigned to them again.