### PR TITLE
[RF] Make RooAbsTestStatistic normalization work for nCPU > 1

### DIFF
--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -231,6 +231,11 @@ Double_t RooAbsTestStatistic::evaluate() const
 
     Double_t ret = sum ;
     _evalCarry = carry;
+
+    const Double_t norm = globalNormalization();
+    ret /= norm;
+    _evalCarry /= norm;
+
     return ret ;
 
   } else {


### PR DESCRIPTION
If a RooAbsTestStatistic is evaluated with nCPU > 1, the "Slave" test
statistic objects don't apply the global normalization factor.

It is therefore the responsability of the "MPMaster" test statistic
object to apply the global normalization in the end. However, this was
not done before this commit.

Fixes Jira issue [ROOT-5557](https://sft.its.cern.ch/jira/browse/ROOT-5557).