### PR TITLE
Fix bug in TBits

### DIFF
--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -21,6 +21,7 @@ ROOT_ADD_GTEST(CoreBaseTests
   TQObjectTests.cxx
   TExceptionHandlerTests.cxx
   TStringTest.cxx
+  TBitsTests.cxx
   LIBRARIES Core RIO ${extralibs})
 
 ROOT_ADD_GTEST(CoreErrorTests TErrorTests.cxx LIBRARIES Core)

--- a/core/base/test/TBitsTests.cxx
+++ b/core/base/test/TBitsTests.cxx
@@ -1,0 +1,16 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "TBits.h"
+
+TEST(TBits, CountBits)
+{
+   TBits b(50);
+   b.SetBitNumber(1);
+   EXPECT_EQ( b.CountBits(), 1 );
+   EXPECT_EQ( b.CountBits(2), 0 );
+   b.SetBitNumber(7);
+   EXPECT_EQ( b.CountBits(), 2);
+   EXPECT_EQ( b.CountBits(2), 1 );
+   EXPECT_EQ( b.CountBits(8), 0);
+}

--- a/core/cont/src/TBits.cxx
+++ b/core/cont/src/TBits.cxx
@@ -147,7 +147,7 @@ UInt_t TBits::CountBits(UInt_t startBit) const
    UInt_t ibit = startBit%8;
    if (ibit) {
       for (i=ibit;i<8;i++) {
-         if (fAllBits[startByte] & (1<<ibit)) count++;
+         if (fAllBits[startByte] & (1<<i)) count++;
       }
       startByte++;
    }


### PR DESCRIPTION
Was initially miffed why the following example would give "7" instead of "2", but then I spotted the bug!

```
TBits b(50); b.SetBitNumber(1); b.SetBitNumber(7); b.CountBits(1)
```


