### PR TITLE
Streamer info docs and linking of cling

### DIFF
--- a/core/meta/inc/TVirtualStreamerInfo.h
+++ b/core/meta/inc/TVirtualStreamerInfo.h
@@ -180,11 +180,12 @@ public:
    static void         SetCanDelete(Bool_t opt=kTRUE);
    static void         SetFactory(TVirtualStreamerInfo *factory);
 
-   // \brief Generate the TClass and TStreamerInfo for the requested pair.
-   // This creates a TVirtualStreamerInfo for the pair and trigger the BuildCheck/Old to
-   // provokes the creation of the corresponding TClass.  This relies on the dictionary for
-   // std::pair<const int, int> to already exist (or the interpreter information being available)
-   // as it is used as a template.
+   /// \brief Generate the TClass and TStreamerInfo for the requested pair.
+   /// This creates a TVirtualStreamerInfo for the pair and trigger the BuildCheck/Old to
+   /// provokes the creation of the corresponding TClass.  This relies on the dictionary for
+   /// std::pair<const int, int> to already exist (or the interpreter information being available)
+   /// as it is used as a template.
+   /// \note The returned object is owned by the caller.
    virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &pairclassname, bool silent, size_t hint_pair_offset, size_t hint_pair_size) = 0;
    virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &firstname, const std::string &secondname, bool silent, size_t hint_pair_offset, size_t hint_pair_size) = 0;
 

--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -104,6 +104,12 @@ ROOT_LINKER_LIBRARY(Cling
         $<TARGET_OBJECTS:MetaCling>
         LIBRARIES ${CLING_LIBRARIES} ${LINK_LIBS} ${CLING_PLUGIN_LINK_LIBS})
 
+string(TOUPPER ${LLVM_BUILD_TYPE} THE_BUILD_TYPE)
+if(${THE_BUILD_TYPE} STREQUAL DEBUG OR ${THE_BUILD_TYPE} STREQUAL RELWITHDEBINFO)
+  # When these two link at the same time, they can exhaust the RAM on many machines, since they both link against llvm.
+  add_dependencies(Cling rootcling_stage1)
+endif()
+
 if(MSVC)
   set_target_properties(Cling PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
   set(cling_exports ${cling_exports}

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -275,11 +275,12 @@ private:
 public:
    virtual void        Update(const TClass *oldClass, TClass *newClass);
 
-   // \brief Generate the TClass and TStreamerInfo for the requested pair.
-   // This creates a TVirtualStreamerInfo for the pair and trigger the BuildCheck/Old to
-   // provokes the creation of the corresponding TClass.  This relies on the dictionary for
-   // std::pair<const int, int> to already exist (or the interpreter information being available)
-   // as it is used as a template.
+   /// \brief Generate the TClass and TStreamerInfo for the requested pair.
+   /// This creates a TVirtualStreamerInfo for the pair and trigger the BuildCheck/Old to
+   /// provokes the creation of the corresponding TClass.  This relies on the dictionary for
+   /// std::pair<const int, int> to already exist (or the interpreter information being available)
+   /// as it is used as a template.
+   /// \note The returned object is owned by the caller.
    virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &pairclassname, bool silent, size_t hint_pair_offset, size_t hint_pair_size);
    virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &firstname, const std::string &secondname, bool silent, size_t hint_pair_offset, size_t hint_pair_size);
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5690,11 +5690,12 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
    }
 }
 
-// \brief Generate the TClass and TStreamerInfo for the requested pair.
-// This creates a TVirtualStreamerInfo for the pair and trigger the BuildCheck/Old to
-// provoke the creation of the corresponding TClass.  This relies on the dictionary for
-// std::pair<const int, int> to already exist (or the interpreter information being available)
-// as it is used as a template.
+/// \brief Generate the TClass and TStreamerInfo for the requested pair.
+/// This creates a TVirtualStreamerInfo for the pair and trigger the BuildCheck/Old to
+/// provoke the creation of the corresponding TClass.  This relies on the dictionary for
+/// std::pair<const int, int> to already exist (or the interpreter information being available)
+/// as it is used as a template.
+/// \note The returned object is owned by the caller.
 TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firstname, const std::string &secondname, bool silent, size_t hint_pair_offset, size_t hint_pair_size)
 {
    // Generate a TStreamerInfo for a std::pair<fname,sname>


### PR DESCRIPTION
- Fix documentation of StreamerInfo::GenerateInfoForPair
- Prevent linking of rootcling_stage1 and libCling at the same time.

@Axel-Naumann This is what we talked about for faster linking when debug symbols are in use.