### PR TITLE
[v618][RF] Use again operator new instead of ObjectAlloc in MemPoolForRooSets

### DIFF
--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -24,8 +24,6 @@
 #ifndef ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_
 #define ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_
 
-#include "TStorage.h"
-
 #include <algorithm>
 #include <array>
 #include <bitset>
@@ -36,7 +34,7 @@ class MemPoolForRooSets {
 
   struct Arena {
     Arena()
-      : ownedMemory{static_cast<RooSet_t *>(TStorage::ObjectAlloc(2 * POOLSIZE * sizeof(RooSet_t)))},
+      : ownedMemory{static_cast<RooSet_t *>(::operator new(2 * POOLSIZE * sizeof(RooSet_t)))},
         memBegin{ownedMemory}, nextItem{ownedMemory},
         memEnd{memBegin + 2 * POOLSIZE}
     {}


### PR DESCRIPTION
This reverts a change from commit b874ed534f40ad80db3f8a3395d5dd44183811bb from https://github.com/root-project/root/pull/7972.

The change was causing crashes in in python code.

The problem was that I took the same MemPoolForRooSets code from master also for the old releases, not noticing that the old releases didn't use `TStroage::ObjectAlloc` yet, which caused problems.

The problem can be reproduced with the following python code and is fixed with this commit (thanks @lmoneta for having providing the code):
```Python
import ROOT
x = ROOT.RooRealVar("x","x",1)
d = ROOT.RooDataSet("d","d",ROOT.RooArgSet(x))
w = ROOT.RooWorkspace("w")
getattr(w, 'import')(d)
w.Print()
```