### PR TITLE
[v620][RF] Use again operator new instead of ObjectAlloc in MemPoolForRooSets

### DIFF
--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -24,8 +24,6 @@
 #ifndef ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_
 #define ROOFIT_ROOFITCORE_SRC_MEMPOOLFORROOSETS_H_
 
-#include "TStorage.h"
-
 #include <algorithm>
 #include <array>
 #include <bitset>
@@ -36,9 +34,10 @@ class MemPoolForRooSets {
 
   struct Arena {
     Arena()
-      : ownedMemory{static_cast<RooSet_t *>(TStorage::ObjectAlloc(2 * POOLSIZE * sizeof(RooSet_t)))},
+      : ownedMemory{static_cast<RooSet_t *>(::operator new(2 * POOLSIZE * sizeof(RooSet_t)))},
         memBegin{ownedMemory}, nextItem{ownedMemory},
-        memEnd{memBegin + 2 * POOLSIZE}
+        memEnd{memBegin + 2 * POOLSIZE},
+        cycle{}
     {}
 
     Arena(const Arena &) = delete;
@@ -47,7 +46,8 @@ class MemPoolForRooSets {
         memBegin{other.memBegin}, nextItem{other.nextItem}, memEnd{other.memEnd},
         refCount{other.refCount},
         totCount{other.totCount},
-        assigned{other.assigned}
+        assigned{other.assigned},
+        cycle{}
     {
       // Needed for unique ownership
       other.ownedMemory = nullptr;


### PR DESCRIPTION
This reverts a change from commit 64f299ce3c08501d3ba42e164ad6e40c151bb25b from https://github.com/root-project/root/pull/7973.

The change was causing crashes in in python code.

This PR is analogous to https://github.com/root-project/root/pull/7994. Even thought crashes were not observed in 6.20, I think it's better to also not use `TStorage:: ObjectAlloc` in 6.20 because it has not been used before either.

In addition, the following [warnings](https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-v6-20-00-patches/LABEL=ROOT-centos7,SPEC=noimt,V=6-20/178/parsed_console/) that appeared in the nightly builds should be fixed by this commit:

`warning: missing initializer for member ‘std::array<int, 6000ul>::_M_elems’ [-Wmissing-field-initializers]`