### PR TITLE
[pgsql] Move #include <pg_config.h> out of headers:

### DIFF
--- a/sql/pgsql/inc/TPgSQLStatement.h
+++ b/sql/pgsql/inc/TPgSQLStatement.h
@@ -15,7 +15,6 @@
 #include "TSQLStatement.h"
 
 #include <libpq-fe.h>
-#include <pg_config.h> // to get PG_VERSION_NUM
 
 struct PgSQL_Stmt_t {
    PGconn   *fConn;

--- a/sql/pgsql/src/TPgSQLServer.cxx
+++ b/sql/pgsql/src/TPgSQLServer.cxx
@@ -19,6 +19,8 @@
 #include "TUrl.h"
 #include "TList.h"
 
+#include <pg_config.h> // to get PG_VERSION_NUM
+
 #define pgsql_success(x) (((x) == PGRES_EMPTY_QUERY) \
                         || ((x) == PGRES_COMMAND_OK) \
                         || ((x) == PGRES_TUPLES_OK))

--- a/sql/pgsql/src/TPgSQLStatement.cxx
+++ b/sql/pgsql/src/TPgSQLStatement.cxx
@@ -27,6 +27,8 @@
 
 #include <cstdlib>
 
+#include <pg_config.h> // to get PG_VERSION_NUM
+
 #define pgsql_success(x) (((x) == PGRES_EMPTY_QUERY) \
                         || ((x) == PGRES_COMMAND_OK) \
                         || ((x) == PGRES_TUPLES_OK))


### PR DESCRIPTION
Works around clash with R, both defining HAVE_UINTPTR_T.