### PR TITLE
[DF] Remove false sharing in RFilter, RDefine

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -635,6 +635,22 @@ else()
    set(has_found_attribute_noinline undef)
 endif()
 
+# We could just check `#ifdef __cpp_lib_hardware_interference_size`, but on at least Mac 11
+# libc++ defines that macro but is missing the actual feature
+# (see https://github.com/llvm/llvm-project/commit/174322c2737d699e199db4762aaf4217305ec465).
+# So we need to "manually" check instead.
+# `#ifdef R__HAS_HARDWARE_INTERFERENCE_SIZE` could be substituted by `#ifdef __cpp_lib_hardware_interference_size`
+# when Mac 11's life has ended (assuming the libc++ fix makes it in the next MacOS version).
+CHECK_CXX_SOURCE_COMPILES("
+#include <new>
+using Check_t = char[std::hardware_destructive_interference_size];
+" found_hardware_interference_size)
+if(found_hardware_interference_size)
+   set(hashardwareinterferencesize define)
+else()
+   set(hashardwareinterferencesize undef)
+endif()
+
 if(root7 AND webgui)
    set(root_browser_class "ROOT::Experimental::RWebBrowserImp")
 else()

--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -42,6 +42,7 @@
 #@hasstdindexsequence@ R__HAS_STD_INDEX_SEQUENCE /**/
 #@has_found_attribute_always_inline@ R__HAS_ATTRIBUTE_ALWAYS_INLINE /**/
 #@has_found_attribute_noinline@ R__HAS_ATTRIBUTE_NOINLINE /**/
+#@hashardwareinterferencesize@ R__HAS_HARDWARE_INTERFERENCE_SIZE /**/
 #@useimt@ R__USE_IMT   /**/
 #@memory_term@ R__COMPLETE_MEM_TERMINATION /**/
 #@hascefweb@ R__HAS_CEFWEB  /**/

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -83,19 +83,20 @@ public:
 
    bool CheckFilters(unsigned int slot, Long64_t entry) final
    {
-      if (entry != fLastCheckedEntry[slot]) {
+      if (entry != fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()]) {
          if (!fPrevData.CheckFilters(slot, entry)) {
             // a filter upstream returned false, cache the result
-            fLastResult[slot] = false;
+            fLastResult[slot * RDFInternal::CacheLineStep<int>()] = false;
          } else {
             // evaluate this filter, cache the result
             auto passed = CheckFilterHelper(slot, entry, ColumnTypes_t{}, TypeInd_t{});
-            passed ? ++fAccepted[slot] : ++fRejected[slot];
-            fLastResult[slot] = passed;
+            passed ? ++fAccepted[slot * RDFInternal::CacheLineStep<ULong64_t>()]
+                   : ++fRejected[slot * RDFInternal::CacheLineStep<ULong64_t>()];
+            fLastResult[slot * RDFInternal::CacheLineStep<int>()] = passed;
          }
-         fLastCheckedEntry[slot] = entry;
+         fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = entry;
       }
-      return fLastResult[slot];
+      return fLastResult[slot * RDFInternal::CacheLineStep<int>()];
    }
 
    template <typename... ColTypes, std::size_t... S>

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -204,8 +204,11 @@ bool IsInternalColumn(std::string_view colName);
 /// Get optimal column width for printing a table given the names and the desired minimal space between columns
 unsigned int GetColumnWidth(const std::vector<std::string>& names, const unsigned int minColumnSpace = 8u);
 
-#ifdef __cpp_lib_hardware_interference_size
-   // C++17 feature (so we can use inline variables), but very few implementations support it as of 2021
+// We could just check `#ifdef __cpp_lib_hardware_interference_size`, but at least on Mac 11
+// libc++ defines that macro but is missing the actual feature, so we use an ad-hoc ROOT macro instead.
+// See the relevant entry in cmake/modules/RootConfiguration.cmake for more info.
+#ifdef R__HAS_HARDWARE_INTERFERENCE_SIZE
+   // C++17 feature (so we can use inline variables)
    inline constexpr std::size_t kCacheLineSize = std::hardware_destructive_interference_size;
 #else
    // safe bet: assume the typical 64 bytes

--- a/tree/dataframe/src/RDefineBase.cxx
+++ b/tree/dataframe/src/RDefineBase.cxx
@@ -9,6 +9,7 @@
  *************************************************************************/
 
 #include "ROOT/RDF/RDefineBase.hxx"
+#include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RStringView.hxx"
 #include "RtypesCore.h" // Long64_t
 
@@ -28,7 +29,8 @@ unsigned int RDefineBase::GetNextID()
 RDefineBase::RDefineBase(std::string_view name, std::string_view type, unsigned int nSlots,
                          const RDFInternal::RBookedDefines &defines,
                          const std::map<std::string, std::vector<void *>> &DSValuePtrs, ROOT::RDF::RDataSource *ds)
-   : fName(name), fType(type), fNSlots(nSlots), fLastCheckedEntry(fNSlots, -1), fDefines(defines),
+   : fName(name), fType(type), fNSlots(nSlots),
+     fLastCheckedEntry(fNSlots * RDFInternal::CacheLineStep<Long64_t>(), -1), fDefines(defines),
      fIsInitialized(nSlots, false), fDSValuePtrs(DSValuePtrs), fDataSource(ds)
 {
 }


### PR DESCRIPTION
Use larger vectors and access them more sparsely if needed (e.g.
threads now access one every 16 elements in hot std::vector<int>
on systems where a cache line is 64 bytes).

In some edge cases in which the analysis workload is light and/or many
threads (48, 64) are involved, this patch reduces runtimes by factors.
The increase in memory usage should be little relative to the memory
required e.g. by jitting or by per-thread histograms.