### PR TITLE
[skip-ci] "Reserve" _build as the name of a build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ CMakeLists.txt.user
 # Vim
 *.swp
 
+# Directory name reserved for build directory
+_build
+
 # Other Stuff
 tags
 *.d


### PR DESCRIPTION
This makes it possible to use _build as a build directory name under
the source directory. The actual preferred build directory name would
be `build`, but it's already taken by project files.

There is a precedent in roottest in reserving `build` in .gitignore,
and some C++ project layout guidelines such as [pitchfork](https://bit.ly/3vlQwC9)
suggest the usage of `build` as a reserved, preferred name for build
directories (or `_build` as a fallback).
Other precedents are entries such as `cmake-build` and `.build` in
this .gitignore, with the exact same rationale, because those are
the build directory names that CLion and VSCode pick.