### PR TITLE
[core] ACLiC: speed up building / loading:

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -22,6 +22,7 @@ allows a simple partial implementation for new OS'es.
 */
 
 #include <ROOT/FoundationUtils.hxx>
+#include <ROOT/StringUtils.hxx>
 #include "strlcpy.h"
 #include "TSystem.h"
 #include "TApplication.h"
@@ -3346,16 +3347,19 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
          if (!f(I->c_str()))
             break;
    };
-   auto LoadLibrary = [useCxxModules, produceRootmap, ForeachSharedLibDep](const TString &lib) {
+
+   auto LoadLibrary = [linkDepLibraries, useCxxModules, produceRootmap, ForeachSharedLibDep](const TString &lib) {
       // We have no rootmap files or modules to construct `-l` flags enabling
       // explicit linking. We have to resolve the dependencies by ourselves
       // taking the job of the dyld.
+      // If !linkDepLibraries then the library might not know its dependencies
+      // and "just load the library" might fail.
       // FIXME: This is a rare case where we have rootcling running with
       // modules disabled. Remove this code once we fully switch to modules,
       // or implement a special flag in rootcling which selective enables
       // modules for dependent libraries and does not produce a module for
       // the ACLiC library.
-      if (useCxxModules && !produceRootmap) {
+      if (!linkDepLibraries && useCxxModules && !produceRootmap) {
          std::function<bool(const char *)> LoadLibF = [](const char *dep) {
             return gInterpreter->Load(dep, /*skipReload*/ true) >= 0;
          };
@@ -3373,8 +3377,6 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
          k->SetUniqueID(lib_time);
          if (!keep) k->SetBit(kMustCleanup);
          fCompiled->Add(k);
-
-         gInterpreter->GetSharedLibDeps(library);
 
          return LoadLibrary(library);
       }

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3317,15 +3317,17 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
 #endif
    Bool_t linkDepLibraries = !produceRootmap;
    if (gEnv) {
-#if (defined(R__MACOSX) && !defined(MAC_OS_X_VERSION_10_5))
-      Int_t linkLibs = gEnv->GetValue("ACLiC.LinkLibs",2);
-#elif defined(R__WIN32)
+#if defined(R__WIN32)
       Int_t linkLibs = gEnv->GetValue("ACLiC.LinkLibs",3);
 #else
       Int_t linkLibs = gEnv->GetValue("ACLiC.LinkLibs",1);
 #endif
       produceRootmap = linkLibs & 0x2;
       linkDepLibraries = linkLibs & 0x1;
+      if (!linkDepLibraries) {
+         static int onetime = (Warning("ACLiC", "Unsetting `ACLiC.LinkLibs & 1` is deprecated!"), 1);
+         (void)onetime;
+      }
    }
 
    // FIXME: Triggers clang false positive warning -Wunused-lambda-capture.


### PR DESCRIPTION
Instead of looking for libraries resolving each unresolved symbol,
just load each lib resolving symbols: this will allow subsequent
missing symbols to be resolved from the loaded library quickly,
without touching disk.

When loading an existing ACLiC library, and if we expect it
to contain the dependencies (explicit linking), just load itt,
instead of trying to (re-)determine its dependencies from its
undefined symbols: the outcome should be just the library
dependencies we expect the library to know already.