### PR TITLE
Define R__B64 when on ARM 64

### DIFF
--- a/core/foundation/inc/ROOT/RConfig.hxx
+++ b/core/foundation/inc/ROOT/RConfig.hxx
@@ -292,10 +292,14 @@
 #   if defined(__i386__)
 #      define R__BYTESWAP
 #   endif
-#   if defined(__arm__) || defined (__arm64__)
+#   if defined(__x86_64__)
+#      define R__BYTESWAP
+#      define R__B64      /* enable when 64 bit machine */
+#   endif
+#   if defined(__arm__)
 #      define R__BYTESWAP
 #   endif
-#   if defined(__x86_64__)
+#   if defined (__arm64__)
 #      define R__BYTESWAP
 #      define R__B64      /* enable when 64 bit machine */
 #   endif


### PR DESCRIPTION
Fixes https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-v6-24-00-patches/30/LABEL=mac11arm,SPEC=noimt,V=6-24/testReport/junit/projectroot.roottest.python/cpp/roottest_python_cpp_cpp/

(to be backported to 6.24)