### PR TITLE
fix opening reference guide with .help Class

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -684,7 +684,7 @@ static TString UrlGenerator(TString scopeName, EUrl scopeType)
    // We start the URL with a static part, the same for all scopes and members.
    TString url = "https://root.cern/doc/";
    // Then we check the ROOT version used.
-   TPRegexp re4(R"(.*/v(\d)-(\d\d)-00-patches)");
+   TPRegexp re4(R"(.*/(v\d)-(\d\d)-00-patches)");
    const char *branchName = gROOT->GetGitBranch();
    TObjArray *objarr = re4.MatchS(branchName);
    TString version;
@@ -697,7 +697,6 @@ static TString UrlGenerator(TString scopeName, EUrl scopeType)
       version = "master";
    }
    delete objarr;
-   url.Append("v");
    url.Append(version);
    url.Append("/");
    // We will replace all "::" with "_1_1" and all "_" with "__" in the

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -697,6 +697,7 @@ static TString UrlGenerator(TString scopeName, EUrl scopeType)
       version = "master";
    }
    delete objarr;
+   url.Append("v");
    url.Append(version);
    url.Append("/");
    // We will replace all "::" with "_1_1" and all "_" with "__" in the


### PR DESCRIPTION
As the current path for the reference guide would be "/doc/v624/...", there needs to be an extra "v" in the constructed path for the reference document.