### PR TITLE
Backport 6.24: Define R__B64 when on ARM 64

### DIFF
--- a/core/foundation/inc/ROOT/RConfig.hxx
+++ b/core/foundation/inc/ROOT/RConfig.hxx
@@ -292,10 +292,14 @@
 #   if defined(__i386__)
 #      define R__BYTESWAP
 #   endif
-#   if defined(__arm__) || defined (__arm64__)
+#   if defined(__x86_64__)
+#      define R__BYTESWAP
+#      define R__B64      /* enable when 64 bit machine */
+#   endif
+#   if defined(__arm__)
 #      define R__BYTESWAP
 #   endif
-#   if defined(__x86_64__)
+#   if defined (__arm64__)
 #      define R__BYTESWAP
 #      define R__B64      /* enable when 64 bit machine */
 #   endif


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/8020