### PR TITLE
Small RBrowser improvments

### DIFF
--- a/gui/browsable/inc/ROOT/Browsable/RItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RItem.hxx
@@ -10,6 +10,7 @@
 #define ROOT7_Browsable_RItem
 
 #include <string>
+#include "RtypesCore.h"
 
 namespace ROOT {
 namespace Experimental {
@@ -26,6 +27,7 @@ protected:
    int nchilds{0};       ///< number of childs
    std::string icon;     ///< icon associated with item
    std::string title;    ///< item title
+   std::string fsize;    ///< item size
    bool checked{false};  ///< is checked, not yet used
    bool expanded{false}; ///< is expanded
 public:
@@ -38,6 +40,7 @@ public:
    const std::string &GetName() const { return name; }
    const std::string &GetIcon() const { return icon; }
    const std::string &GetTitle() const { return title; }
+   const std::string &GetSize() const { return fsize; }
    virtual bool IsFolder() const { return false; }
    virtual bool IsHidden() const { return false; }
 
@@ -45,6 +48,23 @@ public:
    void SetExpanded(bool on = true) { expanded = on; }
    void SetIcon(const std::string &_icon) { icon = _icon; }
    void SetTitle(const std::string &_title) { title = _title; }
+   void SetSize(const std::string &_size) { fsize = _size; }
+
+   void SetSize(Long64_t _size)
+   {
+      if (_size > 1024) {
+         Long64_t _ksize = _size / 1024;
+         if (_ksize > 1024) {
+            // 3.7MB is more informative than just 3MB
+            fsize = std::to_string(_ksize/1024) + "." + std::to_string((_ksize%1024)/103) + "M";
+         } else {
+            fsize = std::to_string(_ksize) + "." + std::to_string((_size%1024)/103) + "K";
+         }
+      } else {
+         fsize = std::to_string(_size);
+      }
+   }
+
 
    virtual bool Compare(const RItem *b, const std::string &) const
    {

--- a/gui/browsable/inc/ROOT/Browsable/RItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RItem.hxx
@@ -46,8 +46,10 @@ public:
 
    void SetChecked(bool on = true) { checked = on; }
    void SetExpanded(bool on = true) { expanded = on; }
-   void SetIcon(const std::string &_icon) { icon = _icon; }
+
+   void SetName(const std::string &_name) { name = _name; }
    void SetTitle(const std::string &_title) { title = _title; }
+   void SetIcon(const std::string &_icon) { icon = _icon; }
    void SetSize(const std::string &_size) { fsize = _size; }
 
    void SetSize(Long64_t _size)

--- a/gui/browsable/inc/ROOT/Browsable/RSysFileItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RSysFileItem.hxx
@@ -32,7 +32,6 @@ public:
    int64_t size{0};         ///<! file size
 
    // this is part for browser, visible for I/O
-   std::string fsize;    ///< file size
    std::string mtime;    ///< modification time
    std::string ftype;    ///< file attributes
    std::string fuid;     ///< user id

--- a/gui/browsable/inc/ROOT/Browsable/TKeyItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TKeyItem.hxx
@@ -24,7 +24,6 @@ Representation of single item in the file browser for object from TKey
 
 class TKeyItem : public RItem {
    std::string className; ///< class name
-   std::string fsize;     ///< size of object
 
 public:
 
@@ -36,7 +35,6 @@ public:
    virtual ~TKeyItem() = default;
 
    void SetClassName(const std::string &_className) { className = _className; }
-   void SetSize(const std::string &_size) { fsize = _size; }
 };
 
 } // namespace Browsable

--- a/gui/browsable/inc/ROOT/Browsable/TKeyItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TKeyItem.hxx
@@ -24,6 +24,7 @@ Representation of single item in the file browser for object from TKey
 
 class TKeyItem : public RItem {
    std::string className; ///< class name
+   std::string fsize;     ///< size of object
 
 public:
 
@@ -35,6 +36,7 @@ public:
    virtual ~TKeyItem() = default;
 
    void SetClassName(const std::string &_className) { className = _className; }
+   void SetSize(const std::string &_size) { fsize = _size; }
 };
 
 } // namespace Browsable

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -51,6 +51,9 @@ public:
    /** Title of TObject */
    std::string GetTitle() const override;
 
+   /** Size of TObject */
+   virtual Long64_t GetSize() const { return -1; }
+
    bool IsFolder();
 
    /** Create iterator for childs elements if any */

--- a/gui/browsable/inc/ROOT/Browsable/TObjectItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectItem.hxx
@@ -25,7 +25,6 @@ namespace Browsable {
 
 class TObjectItem : public RItem {
    std::string className; ///< class name
-   std::string fsize;     ///< size
 public:
 
    TObjectItem() = default;
@@ -36,7 +35,6 @@ public:
    virtual ~TObjectItem() = default;
 
    void SetClassName(const std::string &_className) { className = _className; }
-   void SetSize(const std::string &_size) { fsize = _size; }
 };
 
 } // namespace Browsable

--- a/gui/browsable/inc/ROOT/Browsable/TObjectItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectItem.hxx
@@ -25,7 +25,7 @@ namespace Browsable {
 
 class TObjectItem : public RItem {
    std::string className; ///< class name
-
+   std::string fsize;     ///< size
 public:
 
    TObjectItem() = default;
@@ -36,6 +36,7 @@ public:
    virtual ~TObjectItem() = default;
 
    void SetClassName(const std::string &_className) { className = _className; }
+   void SetSize(const std::string &_size) { fsize = _size; }
 };
 
 } // namespace Browsable

--- a/gui/browsable/src/RSysFile.cxx
+++ b/gui/browsable/src/RSysFile.cxx
@@ -168,9 +168,9 @@ class RSysDirLevelIter : public RLevelIter {
       if (pathinfores) {
 
          if (fCurrentStat.fIsLink) {
-            R__LOG_ERROR(BrowsableLog()) << "Broken symlink of " << path;
+            R__LOG_DEBUG(0, BrowsableLog()) << "Broken symlink of " << path;
          } else {
-            R__LOG_ERROR(BrowsableLog()) << "Can't read file attributes of \"" <<  path << "\" err:" << gSystem->GetError();
+            R__LOG_DEBUG(0, BrowsableLog()) << "Can't read file attributes of \"" <<  path << "\" err:" << gSystem->GetError();
          }
          return false;
       }
@@ -420,9 +420,9 @@ RSysFile::RSysFile(const std::string &filename) : fFileName(filename)
 {
    if (gSystem->GetPathInfo(fFileName.c_str(), fStat)) {
       if (fStat.fIsLink) {
-         R__LOG_ERROR(BrowsableLog()) << "Broken symlink of " << fFileName;
+         R__LOG_DEBUG(0, BrowsableLog()) << "Broken symlink of " << fFileName;
       } else {
-         R__LOG_ERROR(BrowsableLog()) << "Can't read file attributes of \"" << fFileName
+         R__LOG_DEBUG(0, BrowsableLog()) << "Can't read file attributes of \"" << fFileName
                                     << "\" err:" << gSystem->GetError();
       }
    }

--- a/gui/browsable/src/RSysFile.cxx
+++ b/gui/browsable/src/RSysFile.cxx
@@ -274,20 +274,8 @@ public:
       else
          item->SetIcon(RSysFile::GetFileIcon(GetItemName()));
 
-      // file size
-      Long64_t _fsize = item->size, bsize = item->size;
-      if (_fsize > 1024) {
-         _fsize /= 1024;
-         if (_fsize > 1024) {
-            // 3.7MB is more informative than just 3MB
-            snprintf(tmp, sizeof(tmp), "%lld.%lldM", _fsize/1024, (_fsize%1024)/103);
-         } else {
-            snprintf(tmp, sizeof(tmp), "%lld.%lldK", bsize/1024, (bsize%1024)/103);
-         }
-      } else {
-         snprintf(tmp, sizeof(tmp), "%lld", bsize);
-      }
-      item->fsize = tmp;
+      // set file size as string
+      item->SetSize(item->size);
 
       // modification time
       time_t loctime = (time_t) item->modtime;

--- a/gui/browsable/src/TBranchBrowseProvider.cxx
+++ b/gui/browsable/src/TBranchBrowseProvider.cxx
@@ -10,6 +10,9 @@
 #include <ROOT/Browsable/RProvider.hxx>
 #include <ROOT/Browsable/RLevelIter.hxx>
 
+#include "TTree.h"
+#include "TNtuple.h"
+#include "TBranch.h"
 #include "TBranchElement.h"
 #include "TBranchBrowsable.h"
 
@@ -17,29 +20,33 @@ using namespace ROOT::Experimental::Browsable;
 
 
 ////////////////////////////////////////////////////////////
-/// Representing TBranchElement in browsables
-/// Kept here only for a demo - default TObject-based API is enough for handling TBranchElement
+/// Representing TBranch in browsables
 
 class TBrElement : public TObjectElement {
 
 public:
    TBrElement(std::unique_ptr<RHolder> &br) : TObjectElement(br) {}
 
-   virtual ~TBrElement() = default;
-
-   int GetNumChilds() override
+   Long64_t GetSize() const override
    {
-      auto br = fObject->Get<TBranchElement>();
-      return br && br->IsFolder() ? TObjectElement::GetNumChilds() : 0;
+      auto br = fObject->Get<TBranch>();
+      return br ? br->GetTotalSize() : -1;
    }
+};
 
-   /** Create iterator for childs elements if any */
-   std::unique_ptr<RLevelIter> GetChildsIter() override
+////////////////////////////////////////////////////////////
+/// Representing TTree in browsables
+
+class TTreeElement : public TObjectElement {
+
+public:
+   TTreeElement(std::unique_ptr<RHolder> &br) : TObjectElement(br) {}
+
+   Long64_t GetSize() const override
    {
-      auto br = fObject->Get<TBranchElement>();
-      if (br && br->IsFolder())
-         return TObjectElement::GetChildsIter();
-      return nullptr;
+      auto tr = fObject->Get<TTree>();
+      printf("Return TTree size %ld\n", (long) (tr ? tr->GetTotBytes() : -1));
+      return tr ? tr->GetTotBytes() : -1;
    }
 };
 
@@ -78,8 +85,17 @@ class TBranchBrowseProvider : public RProvider {
 public:
    TBranchBrowseProvider()
    {
+      RegisterBrowse(TBranch::Class(), [](std::unique_ptr<RHolder> &object) -> std::shared_ptr<RElement> {
+         return std::make_shared<TBrElement>(object);
+      });
       RegisterBrowse(TBranchElement::Class(), [](std::unique_ptr<RHolder> &object) -> std::shared_ptr<RElement> {
          return std::make_shared<TBrElement>(object);
+      });
+      RegisterBrowse(TTree::Class(), [](std::unique_ptr<RHolder> &object) -> std::shared_ptr<RElement> {
+         return std::make_shared<TTreeElement>(object);
+      });
+      RegisterBrowse(TNtuple::Class(), [](std::unique_ptr<RHolder> &object) -> std::shared_ptr<RElement> {
+         return std::make_shared<TTreeElement>(object);
       });
    }
 

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -89,6 +89,7 @@ public:
       item->SetClassName(fKey->GetClassName());
       item->SetIcon(RProvider::GetClassIcon(fKey->GetClassName()));
       item->SetTitle(fKey->GetTitle());
+      item->SetSize(std::to_string(fKey->GetNbytes()));
       return item;
    }
 

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -83,6 +83,10 @@ public:
 
       item->SetTitle(elem->GetTitle());
 
+      auto sz = elem->GetSize();
+      if (sz >= 0)
+         item->SetSize(std::to_string(sz));
+
       return item;
    }
 
@@ -426,11 +430,11 @@ public:
 
    RTObjectProvider()
    {
-      RegisterTObject("TTree", "sap-icon://tree", true, 0);
-      RegisterTObject("TNtuple", "sap-icon://tree", true, 0);
+      RegisterClass("TTree", "sap-icon://tree", "libROOTBranchBrowseProvider");
+      RegisterClass("TNtuple", "sap-icon://tree", "libROOTBranchBrowseProvider");
       RegisterClass("TBranchElement", "sap-icon://e-care", "libROOTBranchBrowseProvider", "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
       RegisterClass("TLeaf", "sap-icon://e-care", ""s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
-      RegisterClass("TBranch", "sap-icon://e-care", ""s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
+      RegisterClass("TBranch", "sap-icon://e-care", "libROOTBranchBrowseProvider"s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
       RegisterClass("TVirtualBranchBrowsable", "sap-icon://e-care", ""s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
 
       RegisterTObject("TDirectory", "sap-icon://folder-blank", true, 0);

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -18,6 +18,7 @@
 #include "TBrowserImp.h"
 #include "TFolder.h"
 #include "TList.h"
+#include "TColor.h"
 #include "TDirectory.h"
 #include "TBufferJSON.h"
 
@@ -189,6 +190,11 @@ public:
       item->SetIcon(RProvider::GetClassIcon(obj->IsA(), obj->IsFolder()));
 
       item->SetTitle(obj->GetTitle());
+
+      if (obj->IsA() == TColor::Class()) {
+         if (item->GetName().empty())
+            item->SetName("Color"s + std::to_string(static_cast<TColor *>(obj)->GetNumber()));
+      }
 
       return item;
    }
@@ -436,6 +442,8 @@ public:
       RegisterClass("TLeaf", "sap-icon://e-care", ""s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
       RegisterClass("TBranch", "sap-icon://e-care", "libROOTBranchBrowseProvider"s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
       RegisterClass("TVirtualBranchBrowsable", "sap-icon://e-care", ""s, "libROOTLeafDraw6Provider", "libROOTLeafDraw7Provider");
+      RegisterClass("TColor", "sap-icon://palette");
+      RegisterClass("TStyle", "sap-icon://badge");
 
       RegisterTObject("TDirectory", "sap-icon://folder-blank", true, 0);
       RegisterTObject("TH1", "sap-icon://bar-chart");

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -65,7 +65,7 @@ void draw_frame()
    frame1->AttrX().AttrLine().SetColor(RColor::kGreen);
    frame1->AttrY().AttrLine().SetColor(RColor::kBlue);
 
-   frame1->AttrX().SetLog(true);
+   frame1->AttrX().SetLog(2.);
    frame1->AttrX().SetZoom(2.,80.);
    frame1->AttrY().SetZoom(2,8);
 

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -67,7 +67,7 @@ void draw_rh1()
    subpads[0][1]->Draw(pHist1)->Text(true).AttrText().SetColor(col1);
    subpads[0][1]->Draw(pHist2)->Marker().AttrMarker().SetColor(col2).SetStyle(30).SetSize(1.5);
 
-   // text and marker draw options
+   // bar draw options
    subpads[1][1]->Draw<RFrameTitle>("Bar() draw options");
    subpads[1][1]->Draw(pHist1)->Bar(0,0.5).AttrFill().SetColor(col1);
    subpads[1][1]->Draw(pHist2)->Bar(0.5,0.5,true).AttrFill().SetColor(col2);

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -47,7 +47,7 @@ void draw_v6()
    }
 
    static constexpr int nth2points = 40;
-   auto th2 = std::make_shared<TH2I>("gaus2", "Example of TH1", nth2points, -5, 5, nth2points, -5, 5);
+   auto th2 = std::make_shared<TH2I>("gaus2", "Example of TH2", nth2points, -5, 5, nth2points, -5, 5);
    th2->SetDirectory(nullptr);
    for (int n=0;n<nth2points;++n) {
       for (int k=0;k<nth2points;++k) {

--- a/tutorials/v7/lineRStyle.cxx
+++ b/tutorials/v7/lineRStyle.cxx
@@ -40,7 +40,7 @@ void lineRStyle()
 
    style->AddBlock(".user_class_1").AddInt("line_style", 4); // all lines with user_class_1 should get style 1
    style->AddBlock(".user_class_2").AddDouble("line_width", 5.); // all lines with user_class_2 should get line width 5
-   style->AddBlock("#obj7").AddString("line_color_rgb", "0000FF"); // line with id obj7 should be red
+   style->AddBlock("#obj7").AddString("line_color_rgb", "0000FF"); // line with id obj7 should be blue
 
    style->AddBlock("line").AddString("line_color_rgb", "FF0000"); // all lines should get red color
 


### PR DESCRIPTION
Suppress error output on broken symlinks (use debug output)
Provide size field for several objects kinds like TKey or TBranch
Provide special handling for TColor (appears in global ROOT lists)