### PR TITLE
Fix printing of warning message when calling without a normalization set but fixCoefNormalization has been called

### DIFF
--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -810,18 +810,11 @@ Double_t RooAddPdf::getValV(const RooArgSet *nset) const
 {
    // special handling in case when an empty set is passed
    // use saved normalization set when it is available
+   //when nset is a nullptr the subsequent call to RooAddPdf::evaluate called from
+   // RooAbsPdf::getValV will result in a warning message since in this case interpretation of coefficient is arbitrary
    if (nset == nullptr) {
       nset = _normSet;
-      // check that nset is not a null pointer
-      // in this case interpretation of coefficient is arbitrary
-      if (!nset) {
-         oocoutW(this, Eval) << "Evaluating RooAddPdf without a defined normalization set. This can lead to ambiguos "
-                                "coefficients definition and incorrect results."
-                             << " Use RooAddPdf::fixCoefNormalization(nset) to provide a normalization set for "
-                                "defining uniquely RooAddPdf coefficients!"
-                             << std::endl;
-      }
-   }
+    }
    return RooAbsPdf::getValV(nset);
 }
 
@@ -833,6 +826,15 @@ Double_t RooAddPdf::evaluate() const
   auto normAndCache = getNormAndCache();
   const RooArgSet* nset = normAndCache.first;
   CacheElem* cache = normAndCache.second;
+
+  // nset is obtained from _normSet or if it is a null pointer from _refCoefNorm
+  if (!nset) {
+     oocoutW(this, Eval) << "Evaluating RooAddPdf without a defined normalization set. This can lead to ambiguos "
+        "coefficients definition and incorrect results."
+                         << " Use RooAddPdf::fixCoefNormalization(nset) to provide a normalization set for "
+        "defining uniquely RooAddPdf coefficients!"
+                         << std::endl;
+  }
 
   // Do running sum of coef/pdf pairs, calculate lastCoef.
   Double_t value(0);


### PR DESCRIPTION
This fixes the warning messages observed in RootBench when evaluating a not normalised RooAddPdf
where fixCoefNormalizationSet has been called.

This PR should be back ported to 6.24.


Now `RooAddPdf::getValV` does not print anymore the warning but avoids that `RooAbsPdf::getValV` set the stored `_normSet` to a null pointer when the passed `nset` is a null pointer. In this case `RooAddPdf` uses the default normalization set for defining the coefficients and evaluating when a normalization set is not passed explicitly , i.e. when calling `RooAddPdf::getVal(nulptr)`. 
This might have the side effect to not use the reference normalization that could have been defined previously using `fixCoefNormalization`. It is not clear if this is a wanted feature, since I don't see cases where one would need to evaluate an unnormalized `RooAddPdf`.

Eventually another PR could remove `RooAddPdf::getValV`. 