### PR TITLE
[cling] Do not lex beyond end of input:

### DIFF
--- a/interpreter/cling/include/cling/MetaProcessor/MetaLexer.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaLexer.h
@@ -84,6 +84,7 @@ namespace cling {
   class MetaLexer {
   protected:
     const char* bufferStart;
+    const char* bufferEnd;
     const char* curPos;
   public:
     MetaLexer(llvm::StringRef input, bool skipWhiteSpace = false);
@@ -94,8 +95,10 @@ namespace cling {
 
     static void LexPunctuator(const char* C, Token& Tok);
     // TODO: Revise. We might not need that.
-    static bool LexPunctuatorAndAdvance(const char*& curPos, Token& Tok);
-    static void LexQuotedStringAndAdvance(const char*& curPos, Token& Tok);
+    static bool LexPunctuatorAndAdvance(const char*& curPos, Token& Tok,
+                                        const char* lineEnd);
+    static void LexQuotedStringAndAdvance(const char*& curPos, Token& Tok,
+                                          const char* lineEnd);
     void LexConstant(char C, Token& Tok);
     void LexIdentifier(char C, Token& Tok);
     void LexEndOfFile(char C, Token& Tok);

--- a/interpreter/cling/lib/MetaProcessor/InputValidator.cpp
+++ b/interpreter/cling/lib/MetaProcessor/InputValidator.cpp
@@ -77,7 +77,7 @@ namespace cling {
       lastKind = int(Tok.getKind());
 
       const char* prevStart = curPos;
-      MetaLexer::LexPunctuatorAndAdvance(curPos, Tok);
+      MetaLexer::LexPunctuatorAndAdvance(curPos, Tok, line.end());
       const int kind = (int)Tok.getKind();
 
       if (kind == commentTok) {
@@ -181,7 +181,7 @@ namespace cling {
             m_ParenStack.pop_back();
         }
         else if (kind >= (int)tok::stringlit && kind <= (int)tok::charlit) {
-          MetaLexer::LexQuotedStringAndAdvance(curPos, Tok);
+          MetaLexer::LexQuotedStringAndAdvance(curPos, Tok, line.end());
         }
       }
     } while (Tok.isNot(tok::eof));


### PR DESCRIPTION
asan builds were reporting this when running roottest/cling/other/runfileClose.C