### PR TITLE
[RF] Add unit test for pythonization of RooArgList iterator

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -125,6 +125,8 @@ if(roofit)
 
   # RooWorkspace pythonizations
   ROOT_ADD_PYUNITTEST(pyroot_pyz_rooworkspace rooworkspace.py)
+
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooarglist roofit/rooarglist.py)
 endif()
 
 if (dataframe)

--- a/bindings/pyroot/pythonizations/test/roofit/rooarglist.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooarglist.py
@@ -1,0 +1,28 @@
+import unittest
+
+import ROOT
+
+
+class TestRooArgList(unittest.TestCase):
+    """
+    Tests for RooArgList.
+    """
+
+    # Tests
+    def test_rooarglist_iterator(self):
+        a = ROOT.RooRealVar("a", "", 0)
+        b = ROOT.RooRealVar("b", "", 0)
+
+        l = ROOT.RooArgList(a, b)
+
+        it = iter(l)
+
+        self.assertEqual(next(it).GetName(), "a")
+        self.assertEqual(next(it).GetName(), "b")
+
+        with self.assertRaises(StopIteration):
+            next(it)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In Jira issue [ROOT-10457](https://sft.its.cern.ch/jira/browse/ROOT-10457), it was reported that creating an iterator form
a RooArgList in Python does not work.

In ROOT master it seems to work, and this commit suggests to put the
issue in a unit test so that we are sure that is works on all platforms.