### PR TITLE
prevent crash when using TPython after 'import ROOT' failed

### DIFF
--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -412,7 +412,7 @@ const TPyReturn TPython::Eval(const char *expr)
       return TPyReturn();
    }
 
-   // results that require no convserion
+   // results that require no conversion
    if (result == Py_None || CPyCppyy::CPPInstance_Check(result) || PyBytes_Check(result) || PyFloat_Check(result) ||
        PyLong_Check(result) || PyInt_Check(result))
       return TPyReturn(result);

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -141,7 +141,12 @@ Bool_t TPython::Initialize()
       PySys_SetArgv(sizeof(argv) / sizeof(argv[0]), argv);
 
       // force loading of the ROOT module
-      PyRun_SimpleString(const_cast<char *>("import ROOT"));
+      const int ret = PyRun_SimpleString(const_cast<char *>("import ROOT"));
+      if( ret != 0 )
+      {
+          std::cerr << "Error: import ROOT failed, check your PYTHONPATH environmental variable." << std::endl;
+          return kFALSE;
+      }
    }
 
    if (!gMainDict) {


### PR DESCRIPTION
@etejedor supersedes https://github.com/root-project/root/pull/7370