### PR TITLE
TTreeCache: start a new fill at the end of the previous one. 

### DIFF
--- a/tree/tree/inc/TBranchCacheInfo.h
+++ b/tree/tree/inc/TBranchCacheInfo.h
@@ -138,16 +138,22 @@ public:
    }
 
    /// Print the info we have for the baskets.
-   void Print(const char *owner, Long64_t *entries) const
+   void Print(const char *owner, Long64_t *entries, Int_t nBaskets, Long64_t nEntries) const
    {
       if (!owner || !entries)
          return;
       auto len = fInfo.GetNbits() / kSize + 1;
-      if (fBasketPedestal >= 0)
+      if ( (fBasketPedestal + len) > (UInt_t)nBaskets)
+         len = nBaskets - fBasketPedestal;
+      if (fBasketPedestal >= 0 && len) {
          for (UInt_t b = 0; b < len; ++b) {
             Printf("Branch %s : basket %d loaded=%d used=%d start entry=%lld", owner, b + fBasketPedestal,
                    (bool)fInfo[kSize * b + kLoaded], (bool)fInfo[kSize * b + kUsed], entries[fBasketPedestal + b]);
          }
+         Printf("Branch %s : entry range: [ %lld, %lld [", owner,
+                entries[fBasketPedestal],
+                (fBasketPedestal + len) >= (UInt_t)nBaskets ? nEntries :  entries[fBasketPedestal + len]);
+      }
    }
 };
 

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -2363,7 +2363,7 @@ void TBranch::Print(Option_t *option) const
 
 void TBranch::PrintCacheInfo() const
 {
-   fCacheInfo.Print(GetName(), fBasketEntry);
+   fCacheInfo.Print(GetName(), fBasketEntry, fMaxBaskets, fEntries);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1266,6 +1266,8 @@ Bool_t TTreeCache::FillBuffer()
    if (showMore || gDebug > 6)
       Info("FillBuffer", "Looking at cluster spanning from %lld to %lld", fEntryCurrent, fEntryNext);
 
+   if (0 <= fNextClusterStart && fEntryCurrent < fNextClusterStart && !(fEntryCurrent < fNextClusterStart))
+      fEntryCurrent = fNextClusterStart;
    if (fEntryCurrent < fEntryMin) fEntryCurrent = fEntryMin;
    if (fEntryMax <= 0) fEntryMax = tree->GetEntries();
    if (fEntryNext > fEntryMax) fEntryNext = fEntryMax;


### PR DESCRIPTION
See cms-sw/cmssw#33361

Fixes #8048

Now, set the start point of the filling to be the end of the previous filling rather than the start of the current cluster (which can sometimes
be before the end of the previous filling)

Issue: The error message was inaccurate, it did not take into account jagged filling of the TTreeCache.  In this case, the cache was filled with a little more than one cluster and when it needs to do the next refill it restarted from the cluster start boundary of that partially downloaded cluster which is “indeed” within the range of the last TreeCache fill (i.e. the error).

We did not see the problem with a local file because the TTreeCache usage is different.  CMSSW take note of whether prefetching (asynchronous reads) is available for a while or not.  In the setup CMSSW has, the prefetching (asynchronous reads) is available for the local file but not for the network/remote file.  In addition when prefetching (asynchronous reads) is not available, CMSSW uses multiple TTreeCache for a given TTree while it uses only one when prefetching (asynchronous reads) is available.  This results in the pattern of filling to be different between the 2 cases.

