### PR TITLE
[LLVM] Replace "&" printing patch with LLVM commit

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp
@@ -85,6 +85,26 @@ static void printIntegral(const TemplateArgument &TemplArg,
   }
 }
 
+static unsigned getArrayDepth(QualType type) {
+  unsigned count = 0;
+  while (const auto *arrayType = type->getAsArrayTypeUnsafe()) {
+    count++;
+    type = arrayType->getElementType();
+  }
+  return count;
+}
+
+static bool needsAmpersandOnTemplateArg(QualType paramType, QualType argType) {
+  // Generally, if the parameter type is a pointer, we must be taking the
+  // address of something and need a &.  However, if the argument is an array,
+  // this could be implicit via array-to-pointer decay.
+  if (!paramType->isPointerType())
+    return paramType->isMemberPointerType();
+  if (argType->isArrayType())
+    return getArrayDepth(argType) == getArrayDepth(paramType->getPointeeType());
+  return true;
+}
+
 //===----------------------------------------------------------------------===//
 // TemplateArgument Implementation
 //===----------------------------------------------------------------------===//
@@ -412,7 +432,10 @@ void TemplateArgument::print(const PrintingPolicy &Policy,
 
   case Declaration: {
     NamedDecl *ND = getAsDecl();
-    Out << '&';
+    if (auto *VD = dyn_cast<ValueDecl>(ND)) {
+      if (needsAmpersandOnTemplateArg(getParamTypeForDecl(), VD->getType()))
+        Out << "&";
+    }
     if (ND->getDeclName()) {
       // FIXME: distinguish between pointer and reference args?
       ND->printQualifiedName(Out);

--- a/interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/TemplateBase.cpp
@@ -411,23 +411,10 @@ void TemplateArgument::print(const PrintingPolicy &Policy,
   }
 
   case Declaration: {
-    NamedDecl *ND = cast<NamedDecl>(getAsDecl());
-    bool needsRef = true;
-    if (auto VD = dyn_cast<ValueDecl>(ND)) {
-      const clang::Type *ArgTy = VD->getType()->getUnqualifiedDesugaredType();
-      const clang::Type *ParmTy
-        = getParamTypeForDecl()->getUnqualifiedDesugaredType();
-      clang::ASTContext& Ctx = ND->getASTContext();
-      needsRef = !Ctx.hasSameType(ArgTy, ParmTy);
-      if (needsRef && (ArgTy->isArrayType() || ArgTy->isFunctionType())) {
-        const clang::Type *decayedArgTy
-          = Ctx.getDecayedType(clang::QualType(ArgTy, 0)).getTypePtr();
-        needsRef = !Ctx.hasSameType(decayedArgTy, ParmTy);
-      }
-    }
-    if (needsRef)
-      Out << '&';
+    NamedDecl *ND = getAsDecl();
+    Out << '&';
     if (ND->getDeclName()) {
+      // FIXME: distinguish between pointer and reference args?
       ND->printQualifiedName(Out);
     } else {
       Out << "(anonymous)";


### PR DESCRIPTION
Revert ROOT's "&" printing patch of LLVM and backport https://reviews.llvm.org/rG8518742104ab075296722ef6151f65aee7a0646d