### PR TITLE
[ntuple] Add support for column type casting

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -56,7 +56,8 @@ public:
    RRDFCardinalityField &operator=(RRDFCardinalityField &&other) = default;
    ~RRDFCardinalityField() = default;
 
-   void GenerateColumnsImpl() final
+   void GenerateColumnsImpl() final { R__ASSERT(false); } // Field is only used for reading
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final
    {
       RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
       fColumns.emplace_back(std::unique_ptr<ROOT::Experimental::Detail::RColumn>(
@@ -117,9 +118,9 @@ public:
    /// Connect the field and its subfields to the page source
    void Connect(RPageSource &source)
    {
-      fField->ConnectPageStorage(source);
+      fField->ConnectPageSource(source);
       for (auto &f : *fField)
-         f.ConnectPageStorage(source);
+         f.ConnectPageSource(source);
    }
 
    void *GetImpl(Long64_t entry) final

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -56,7 +56,9 @@ public:
    RRDFCardinalityField &operator=(RRDFCardinalityField &&other) = default;
    ~RRDFCardinalityField() = default;
 
-   void GenerateColumnsImpl() final { R__ASSERT(false); } // Field is only used for reading
+   // Field is only used for reading
+   void GenerateColumnsImpl() final { R__ASSERT(false && "Cardinality fields must only be used for reading"); }
+
    void GenerateColumnsImpl(const RNTupleDescriptor &) final
    {
       RColumnModel model(EColumnType::kIndex, true /* isSorted*/);

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -165,7 +165,7 @@ public:
       }
       return reinterpret_cast<CppT*>(
          static_cast<unsigned char *>(fCurrentPage.GetBuffer()) +
-         (globalIndex - fCurrentPage.GetGlobalRangeFirst()) * RColumnElement<CppT, EColumnType::kUnknown>::kSize);
+         (globalIndex - fCurrentPage.GetGlobalRangeFirst()) * RColumnElement<CppT>::kSize);
    }
 
    template <typename CppT>
@@ -175,8 +175,7 @@ public:
       }
       return reinterpret_cast<CppT*>(
          static_cast<unsigned char *>(fCurrentPage.GetBuffer()) +
-            (clusterIndex.GetIndex() - fCurrentPage.GetClusterRangeFirst()) *
-               RColumnElement<CppT, EColumnType::kUnknown>::kSize);
+            (clusterIndex.GetIndex() - fCurrentPage.GetClusterRangeFirst()) * RColumnElement<CppT>::kSize);
    }
 
    NTupleSize_t GetGlobalIndex(const RClusterIndex &clusterIndex) {

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -158,24 +158,25 @@ public:
       }
    }
 
-   template <typename CppT, EColumnType ColumnT>
+   template <typename CppT>
    CppT *Map(const NTupleSize_t globalIndex) {
       if (!fCurrentPage.Contains(globalIndex)) {
          MapPage(globalIndex);
       }
       return reinterpret_cast<CppT*>(
          static_cast<unsigned char *>(fCurrentPage.GetBuffer()) +
-         (globalIndex - fCurrentPage.GetGlobalRangeFirst()) * RColumnElement<CppT, ColumnT>::kSize);
+         (globalIndex - fCurrentPage.GetGlobalRangeFirst()) * RColumnElement<CppT, EColumnType::kUnknown>::kSize);
    }
 
-   template <typename CppT, EColumnType ColumnT>
+   template <typename CppT>
    CppT *Map(const RClusterIndex &clusterIndex) {
       if (!fCurrentPage.Contains(clusterIndex)) {
          MapPage(clusterIndex);
       }
       return reinterpret_cast<CppT*>(
          static_cast<unsigned char *>(fCurrentPage.GetBuffer()) +
-         (clusterIndex.GetIndex() - fCurrentPage.GetClusterRangeFirst()) * RColumnElement<CppT, ColumnT>::kSize);
+            (clusterIndex.GetIndex() - fCurrentPage.GetClusterRangeFirst()) *
+               RColumnElement<CppT, EColumnType::kUnknown>::kSize);
    }
 
    NTupleSize_t GetGlobalIndex(const RClusterIndex &clusterIndex) {
@@ -196,8 +197,8 @@ public:
    /// For offset columns only, look at the two adjacent values that define a collection's coordinates
    void GetCollectionInfo(const NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *collectionSize)
    {
-      auto idxStart = (globalIndex == 0) ? 0 : *Map<ClusterSize_t, EColumnType::kIndex>(globalIndex - 1);
-      auto idxEnd = *Map<ClusterSize_t, EColumnType::kIndex>(globalIndex);
+      auto idxStart = (globalIndex == 0) ? 0 : *Map<ClusterSize_t>(globalIndex - 1);
+      auto idxEnd = *Map<ClusterSize_t>(globalIndex);
       auto selfOffset = fCurrentPage.GetClusterInfo().GetIndexOffset();
       if (globalIndex == selfOffset) {
          // Passed cluster boundary
@@ -211,15 +212,15 @@ public:
                           RClusterIndex *collectionStart, ClusterSize_t *collectionSize)
    {
       auto index = clusterIndex.GetIndex();
-      auto idxStart = (index == 0) ? 0 : *Map<ClusterSize_t, EColumnType::kIndex>(clusterIndex - 1);
-      auto idxEnd = *Map<ClusterSize_t, EColumnType::kIndex>(clusterIndex);
+      auto idxStart = (index == 0) ? 0 : *Map<ClusterSize_t>(clusterIndex - 1);
+      auto idxEnd = *Map<ClusterSize_t>(clusterIndex);
       *collectionSize = idxEnd - idxStart;
       *collectionStart = RClusterIndex(clusterIndex.GetClusterId(), idxStart);
    }
 
    /// Get the currently active cluster id
    void GetSwitchInfo(NTupleSize_t globalIndex, RClusterIndex *varIndex, std::uint32_t *tag) {
-      auto varSwitch = Map<RColumnSwitch, EColumnType::kSwitch>(globalIndex);
+      auto varSwitch = Map<RColumnSwitch>(globalIndex);
       *varIndex = RClusterIndex(fCurrentPage.GetClusterInfo().GetId(), varSwitch->GetIndex());
       *tag = varSwitch->GetTag();
    }

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -213,7 +213,7 @@ public:
 template <>
 class RColumnElement<RColumnSwitch, EColumnType::kUnknown> : public RColumnElementBase {
 public:
-   static constexpr std::size_t kSize = sizeof(ClusterSize_t);
+   static constexpr std::size_t kSize = sizeof(RColumnSwitch);
    explicit RColumnElement(RColumnSwitch *value) : RColumnElementBase(value, kSize) {}
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -106,7 +106,7 @@ public:
 /**
  * Pairs of C++ type and column type, like float and EColumnType::kReal32
  */
-template <typename CppT, EColumnType ColumnT>
+template <typename CppT, EColumnType ColumnT = EColumnType::kUnknown>
 class RColumnElement : public RColumnElementBase {
 public:
    explicit RColumnElement(CppT* value) : RColumnElementBase(value, sizeof(CppT))

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -214,7 +214,7 @@ template <>
 class RColumnElement<RColumnSwitch, EColumnType::kUnknown> : public RColumnElementBase {
 public:
    static constexpr std::size_t kSize = sizeof(ClusterSize_t);
-   explicit RColumnElement(ClusterSize_t *value) : RColumnElementBase(value, kSize) {}
+   explicit RColumnElement(RColumnSwitch *value) : RColumnElementBase(value, kSize) {}
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -117,6 +117,104 @@ public:
    }
 };
 
+template <>
+class RColumnElement<bool, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(bool);
+   explicit RColumnElement(bool *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<char, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(char);
+   explicit RColumnElement(char *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<std::int8_t, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(std::int8_t);
+   explicit RColumnElement(std::int8_t *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<std::uint8_t, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(std::uint8_t);
+   explicit RColumnElement(std::uint8_t *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<std::int16_t, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(std::int16_t);
+   explicit RColumnElement(std::int16_t *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<std::uint16_t, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(std::uint16_t);
+   explicit RColumnElement(std::uint16_t *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<std::int32_t, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(std::int32_t);
+   explicit RColumnElement(std::int32_t *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<std::uint32_t, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(std::uint32_t);
+   explicit RColumnElement(std::uint32_t *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<std::int64_t, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(std::int64_t);
+   explicit RColumnElement(std::int64_t *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<std::uint64_t, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(std::uint64_t);
+   explicit RColumnElement(std::uint64_t *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<float, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(float);
+   explicit RColumnElement(float *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<double, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(double);
+   explicit RColumnElement(double *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<ClusterSize_t, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(ClusterSize_t);
+   explicit RColumnElement(ClusterSize_t *value) : RColumnElementBase(value, kSize) {}
+};
+
+template <>
+class RColumnElement<RColumnSwitch, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(ClusterSize_t);
+   explicit RColumnElement(ClusterSize_t *value) : RColumnElementBase(value, kSize) {}
+};
+
 
 template <>
 class RColumnElement<float, EColumnType::kReal32> : public RColumnElementBase {

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -375,6 +375,20 @@ public:
    void Unpack(void *dst, void *src, std::size_t count) const final;
 };
 
+template <>
+class RColumnElement<std::int64_t, EColumnType::kInt32> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(std::int64_t);
+   static constexpr std::size_t kBitsOnStorage = 32;
+   explicit RColumnElement(std::int64_t *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final;
+   void Unpack(void *dst, void *src, std::size_t count) const final;
+};
+
 } // namespace Detail
 } // namespace Experimental
 } // namespace ROOT

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -24,6 +24,7 @@
 #include <cstring> // for memcpy
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <type_traits>
 
 namespace ROOT {
@@ -71,6 +72,7 @@ public:
 
    static std::unique_ptr<RColumnElementBase> Generate(EColumnType type);
    static std::size_t GetBitsOnStorage(EColumnType type);
+   static std::string GetTypeName(EColumnType type);
 
    /// Write one or multiple column elements into destination
    void WriteTo(void *destination, std::size_t count) const {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -484,12 +484,12 @@ public:
    using Detail::RFieldBase::GenerateValue;
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final {
       return Detail::RFieldValue(
-         Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)),
+         Detail::RColumnElement<ClusterSize_t>(static_cast<ClusterSize_t*>(where)),
          this, static_cast<ClusterSize_t*>(where));
    }
    Detail::RFieldValue CaptureValue(void* where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)), this, where);
+         Detail::RColumnElement<ClusterSize_t>(static_cast<ClusterSize_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return 0; }
    void CommitCluster() final;
@@ -528,13 +528,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)),
+         Detail::RColumnElement<ClusterSize_t>(static_cast<ClusterSize_t*>(where)),
          this, static_cast<ClusterSize_t*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex>(static_cast<ClusterSize_t*>(where)), this, where);
+         Detail::RColumnElement<ClusterSize_t>(static_cast<ClusterSize_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
 
@@ -578,13 +578,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<bool, EColumnType::kBit>(static_cast<bool*>(where)),
+         Detail::RColumnElement<bool>(static_cast<bool*>(where)),
          this, static_cast<bool*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, false); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<bool, EColumnType::kBit>(static_cast<bool*>(where)), this, where);
+         Detail::RColumnElement<bool>(static_cast<bool*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(bool); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -619,13 +619,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<float, EColumnType::kReal32>(static_cast<float*>(where)),
+         Detail::RColumnElement<float>(static_cast<float*>(where)),
          this, static_cast<float*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<float, EColumnType::kReal32>(static_cast<float*>(where)), this, where);
+         Detail::RColumnElement<float>(static_cast<float*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(float); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -661,13 +661,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<double, EColumnType::kReal64>(static_cast<double*>(where)),
+         Detail::RColumnElement<double>(static_cast<double*>(where)),
          this, static_cast<double*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<double, EColumnType::kReal64>(static_cast<double*>(where)), this, where);
+         Detail::RColumnElement<double>(static_cast<double*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(double); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -702,13 +702,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<char, EColumnType::kByte>(static_cast<char*>(where)),
+         Detail::RColumnElement<char>(static_cast<char*>(where)),
          this, static_cast<char*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<char, EColumnType::kByte>(static_cast<char*>(where)), this, where);
+         Detail::RColumnElement<char>(static_cast<char*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(char); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -743,13 +743,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<std::int8_t, EColumnType::kByte>(static_cast<std::int8_t*>(where)),
+         Detail::RColumnElement<std::int8_t>(static_cast<std::int8_t*>(where)),
          this, static_cast<std::int8_t*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::int8_t, EColumnType::kByte>(static_cast<std::int8_t*>(where)), this, where);
+         Detail::RColumnElement<std::int8_t>(static_cast<std::int8_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::int8_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -784,13 +784,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<std::uint8_t, EColumnType::kByte>(static_cast<std::uint8_t*>(where)),
+         Detail::RColumnElement<std::uint8_t>(static_cast<std::uint8_t*>(where)),
          this, static_cast<std::uint8_t*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::uint8_t, EColumnType::kByte>(static_cast<std::uint8_t*>(where)), this, where);
+         Detail::RColumnElement<std::uint8_t>(static_cast<std::uint8_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint8_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -825,13 +825,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<std::int16_t, EColumnType::kInt16>(static_cast<std::int16_t*>(where)),
+         Detail::RColumnElement<std::int16_t>(static_cast<std::int16_t*>(where)),
          this, static_cast<std::int16_t*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::int16_t, EColumnType::kInt16>(static_cast<std::int16_t*>(where)), this, where);
+         Detail::RColumnElement<std::int16_t>(static_cast<std::int16_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::int16_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -866,13 +866,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<std::uint16_t, EColumnType::kInt16>(static_cast<std::uint16_t*>(where)),
+         Detail::RColumnElement<std::uint16_t>(static_cast<std::uint16_t*>(where)),
          this, static_cast<std::uint16_t*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::uint16_t, EColumnType::kInt16>(static_cast<std::uint16_t*>(where)), this, where);
+         Detail::RColumnElement<std::uint16_t>(static_cast<std::uint16_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint16_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -907,13 +907,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<std::int32_t, EColumnType::kInt32>(static_cast<std::int32_t*>(where)),
+         Detail::RColumnElement<std::int32_t>(static_cast<std::int32_t*>(where)),
          this, static_cast<std::int32_t*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::int32_t, EColumnType::kInt32>(static_cast<std::int32_t*>(where)), this, where);
+         Detail::RColumnElement<std::int32_t>(static_cast<std::int32_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::int32_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -948,13 +948,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<std::uint32_t, EColumnType::kInt32>(static_cast<std::uint32_t*>(where)),
+         Detail::RColumnElement<std::uint32_t>(static_cast<std::uint32_t*>(where)),
          this, static_cast<std::uint32_t*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::uint32_t, EColumnType::kInt32>(static_cast<std::uint32_t*>(where)), this, where);
+         Detail::RColumnElement<std::uint32_t>(static_cast<std::uint32_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint32_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -989,13 +989,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<std::uint64_t, EColumnType::kInt64>(static_cast<std::uint64_t*>(where)),
+         Detail::RColumnElement<std::uint64_t>(static_cast<std::uint64_t*>(where)),
          this, static_cast<std::uint64_t*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::uint64_t, EColumnType::kInt64>(static_cast<std::uint64_t*>(where)), this, where);
+         Detail::RColumnElement<std::uint64_t>(static_cast<std::uint64_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint64_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
@@ -1030,13 +1030,13 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
       return Detail::RFieldValue(
-         Detail::RColumnElement<std::int64_t, EColumnType::kInt64>(static_cast<std::int64_t*>(where)),
+         Detail::RColumnElement<std::int64_t>(static_cast<std::int64_t*>(where)),
          this, static_cast<std::int64_t*>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
       return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::int64_t, EColumnType::kInt64>(static_cast<std::int64_t*>(where)), this, where);
+         Detail::RColumnElement<std::int64_t>(static_cast<std::int64_t*>(where)), this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::int64_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -120,6 +120,11 @@ protected:
       ReadGlobalImpl(fPrincipalColumn->GetGlobalIndex(clusterIndex), value);
    }
 
+   /// Throws an exception if the column given by fOnDiskId and the columnIndex in the provided descriptor
+   /// is not of one of the allowed types.
+   ROOT::Experimental::EColumnType EnsureColumnType(const std::vector<EColumnType> &allowedTypes,
+                                                    unsigned int columnIndex, const RNTupleDescriptor &desc);
+
 public:
    /// Iterates over the sub tree of fields in depth-first search order
    class RSchemaIterator {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -517,10 +517,10 @@ public:
    void GenerateColumnsImpl() final;
 
    ClusterSize_t *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<ClusterSize_t, EColumnType::kIndex>(globalIndex);
+      return fPrincipalColumn->Map<ClusterSize_t>(globalIndex);
    }
    ClusterSize_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<ClusterSize_t, EColumnType::kIndex>(clusterIndex);
+      return fPrincipalColumn->Map<ClusterSize_t>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -567,10 +567,10 @@ public:
    void GenerateColumnsImpl() final;
 
    bool *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<bool, EColumnType::kBit>(globalIndex);
+      return fPrincipalColumn->Map<bool>(globalIndex);
    }
    bool *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<bool, EColumnType::kBit>(clusterIndex);
+      return fPrincipalColumn->Map<bool>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -608,10 +608,10 @@ public:
    void GenerateColumnsImpl() final;
 
    float *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<float, EColumnType::kReal32>(globalIndex);
+      return fPrincipalColumn->Map<float>(globalIndex);
    }
    float *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<float, EColumnType::kReal32>(clusterIndex);
+      return fPrincipalColumn->Map<float>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -650,10 +650,10 @@ public:
    void GenerateColumnsImpl() final;
 
    double *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<double, EColumnType::kReal64>(globalIndex);
+      return fPrincipalColumn->Map<double>(globalIndex);
    }
    double *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<double, EColumnType::kReal64>(clusterIndex);
+      return fPrincipalColumn->Map<double>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -691,10 +691,10 @@ public:
    void GenerateColumnsImpl() final;
 
    char *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<char, EColumnType::kByte>(globalIndex);
+      return fPrincipalColumn->Map<char>(globalIndex);
    }
    char *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<char, EColumnType::kByte>(clusterIndex);
+      return fPrincipalColumn->Map<char>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -732,10 +732,10 @@ public:
    void GenerateColumnsImpl() final;
 
    std::int8_t *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<std::int8_t, EColumnType::kByte>(globalIndex);
+      return fPrincipalColumn->Map<std::int8_t>(globalIndex);
    }
    std::int8_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::int8_t, EColumnType::kByte>(clusterIndex);
+      return fPrincipalColumn->Map<std::int8_t>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -773,10 +773,10 @@ public:
    void GenerateColumnsImpl() final;
 
    std::uint8_t *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<std::uint8_t, EColumnType::kByte>(globalIndex);
+      return fPrincipalColumn->Map<std::uint8_t>(globalIndex);
    }
    std::uint8_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::uint8_t, EColumnType::kByte>(clusterIndex);
+      return fPrincipalColumn->Map<std::uint8_t>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -814,10 +814,10 @@ public:
    void GenerateColumnsImpl() final;
 
    std::int16_t *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<std::int16_t, EColumnType::kInt16>(globalIndex);
+      return fPrincipalColumn->Map<std::int16_t>(globalIndex);
    }
    std::int16_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::int16_t, EColumnType::kInt16>(clusterIndex);
+      return fPrincipalColumn->Map<std::int16_t>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -855,10 +855,10 @@ public:
    void GenerateColumnsImpl() final;
 
    std::uint16_t *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<std::uint16_t, EColumnType::kInt16>(globalIndex);
+      return fPrincipalColumn->Map<std::uint16_t>(globalIndex);
    }
    std::uint16_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::uint16_t, EColumnType::kInt16>(clusterIndex);
+      return fPrincipalColumn->Map<std::uint16_t>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -896,10 +896,10 @@ public:
    void GenerateColumnsImpl() final;
 
    std::int32_t *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<std::int32_t, EColumnType::kInt32>(globalIndex);
+      return fPrincipalColumn->Map<std::int32_t>(globalIndex);
    }
    std::int32_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::int32_t, EColumnType::kInt32>(clusterIndex);
+      return fPrincipalColumn->Map<std::int32_t>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -937,10 +937,10 @@ public:
    void GenerateColumnsImpl() final;
 
    std::uint32_t *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<std::uint32_t, EColumnType::kInt32>(globalIndex);
+      return fPrincipalColumn->Map<std::uint32_t>(globalIndex);
    }
    std::uint32_t *Map(const RClusterIndex clusterIndex) {
-      return fPrincipalColumn->Map<std::uint32_t, EColumnType::kInt32>(clusterIndex);
+      return fPrincipalColumn->Map<std::uint32_t>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -978,10 +978,10 @@ public:
    void GenerateColumnsImpl() final;
 
    std::uint64_t *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<std::uint64_t, EColumnType::kInt64>(globalIndex);
+      return fPrincipalColumn->Map<std::uint64_t>(globalIndex);
    }
    std::uint64_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::uint64_t, EColumnType::kInt64>(clusterIndex);
+      return fPrincipalColumn->Map<std::uint64_t>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;
@@ -1019,10 +1019,10 @@ public:
    void GenerateColumnsImpl() final;
 
    std::int64_t *Map(NTupleSize_t globalIndex) {
-      return fPrincipalColumn->Map<std::int64_t, EColumnType::kInt64>(globalIndex);
+      return fPrincipalColumn->Map<std::int64_t>(globalIndex);
    }
    std::int64_t *Map(const RClusterIndex &clusterIndex) {
-      return fPrincipalColumn->Map<std::int64_t, EColumnType::kInt64>(clusterIndex);
+      return fPrincipalColumn->Map<std::int64_t>(clusterIndex);
    }
 
    using Detail::RFieldBase::GenerateValue;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -165,11 +165,11 @@ private:
      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName()), fValue(fField.GenerateValue())
    {
       fField.SetOnDiskId(fieldId);
-      fField.ConnectPageStorage(*pageSource);
+      fField.ConnectPageSource(*pageSource);
       for (auto &f : fField) {
          auto subFieldId = pageSource->GetDescriptor().FindFieldId(f.GetName(), f.GetParent()->GetOnDiskId());
          f.SetOnDiskId(subFieldId);
-         f.ConnectPageStorage(*pageSource);
+         f.ConnectPageSource(*pageSource);
       }
    }
 

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -32,6 +32,8 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType type) {
       return std::make_unique<RColumnElement<double, EColumnType::kReal64>>(nullptr);
    case EColumnType::kByte:
       return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>(nullptr);
+   case EColumnType::kInt16:
+      return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>(nullptr);
    case EColumnType::kInt32:
       return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>(nullptr);
    case EColumnType::kInt64:
@@ -57,6 +59,8 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
       return 64;
    case EColumnType::kByte:
       return 8;
+   case EColumnType::kInt16:
+      return 16;
    case EColumnType::kInt32:
       return 32;
    case EColumnType::kInt64:
@@ -72,6 +76,31 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
    }
    // never here
    return 0;
+}
+
+std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnType type) {
+   switch (type) {
+   case EColumnType::kReal32:
+      return "Real32";
+   case EColumnType::kReal64:
+      return "Real64";
+   case EColumnType::kByte:
+      return "Byte";
+   case EColumnType::kInt16:
+      return "Int16";
+   case EColumnType::kInt32:
+      return "Int32";
+   case EColumnType::kInt64:
+      return "Int64";
+   case EColumnType::kBit:
+      return "Bit";
+   case EColumnType::kIndex:
+      return "Index";
+   case EColumnType::kSwitch:
+      return "Switch";
+   default:
+      return "UNKNOWN";
+   }
 }
 
 void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Pack(

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -136,3 +136,24 @@ void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColum
       }
    }
 }
+
+
+void ROOT::Experimental::Detail::RColumnElement<std::int64_t, ROOT::Experimental::EColumnType::kInt32>::Pack(
+  void *dst, void *src, std::size_t count) const
+{
+   std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(src);
+   std::int32_t *int32Array = reinterpret_cast<std::int32_t *>(dst);
+   for (std::size_t i = 0; i < count; ++i) {
+      int32Array[i] = int64Array[i];
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<std::int64_t, ROOT::Experimental::EColumnType::kInt32>::Unpack(
+  void *dst, void *src, std::size_t count) const
+{
+   std::int32_t *int32Array = reinterpret_cast<std::int32_t *>(src);
+   std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(dst);
+   for (std::size_t i = 0; i < count; ++i) {
+      int64Array[i] = int32Array[i];
+   }
+}

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -297,12 +297,27 @@ void ROOT::Experimental::Detail::RFieldBase::Flush() const
 }
 
 
-void ROOT::Experimental::Detail::RFieldBase::ConnectPageStorage(RPageStorage &pageStorage)
+void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink)
 {
-   if (fColumns.empty())
+   if (fColumns.empty()) {
       GenerateColumnsImpl();
+      if (!fColumns.empty())
+         fPrincipalColumn = fColumns[0].get();
+   }
    for (auto& column : fColumns)
-      column->Connect(fOnDiskId, &pageStorage);
+      column->Connect(fOnDiskId, &pageSink);
+}
+
+
+void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &pageSource)
+{
+   if (fColumns.empty()) {
+      GenerateColumnsImpl(pageSource.GetDescriptor());
+      if (!fColumns.empty())
+         fPrincipalColumn = fColumns[0].get();
+   }
+   for (auto& column : fColumns)
+      column->Connect(fOnDiskId, &pageSource);
 }
 
 
@@ -387,7 +402,11 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColu
    RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -402,7 +421,11 @@ void ROOT::Experimental::RField<char>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kByte, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
       char, EColumnType::kByte>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<char>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<char>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -417,7 +440,11 @@ void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kByte, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
       std::int8_t, EColumnType::kByte>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<std::int8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -432,7 +459,11 @@ void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kByte, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
       std::uint8_t, EColumnType::kByte>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<std::uint8_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -448,7 +479,11 @@ void ROOT::Experimental::RField<bool>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kBit, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<bool, EColumnType::kBit>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<bool>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<bool>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -464,7 +499,11 @@ void ROOT::Experimental::RField<float>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kReal32, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<float, EColumnType::kReal32>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<float>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -480,7 +519,11 @@ void ROOT::Experimental::RField<double>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kReal64, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<double, EColumnType::kReal64>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<double>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -495,7 +538,11 @@ void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kInt16, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
       std::int16_t, EColumnType::kInt16>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<std::int16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -510,7 +557,11 @@ void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kInt16, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
       std::uint16_t, EColumnType::kInt16>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -525,7 +576,11 @@ void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kInt32, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
       std::int32_t, EColumnType::kInt32>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<std::int32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -540,7 +595,11 @@ void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kInt32, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<std::uint32_t, EColumnType::kInt32>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<std::uint32_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -555,7 +614,11 @@ void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kInt64, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<std::uint64_t, EColumnType::kInt64>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -570,7 +633,11 @@ void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl()
    RColumnModel model(EColumnType::kInt64, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<std::int64_t, EColumnType::kInt64>(model, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<std::int64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -589,7 +656,11 @@ void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl()
    RColumnModel modelChars(EColumnType::kByte, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<char, EColumnType::kByte>(modelChars, 1)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 void ROOT::Experimental::RField<std::string>::AppendImpl(const ROOT::Experimental::Detail::RFieldValue& value)
@@ -690,6 +761,10 @@ void ROOT::Experimental::RClassField::ReadInClusterImpl(const RClusterIndex &clu
 }
 
 void ROOT::Experimental::RClassField::GenerateColumnsImpl()
+{
+}
+
+void ROOT::Experimental::RClassField::GenerateColumnsImpl(const RNTupleDescriptor &)
 {
 }
 
@@ -897,7 +972,11 @@ void ROOT::Experimental::RVectorField::GenerateColumnsImpl()
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RVectorField::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RVectorField::GenerateValue(void* where)
@@ -993,7 +1072,11 @@ void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl()
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 std::vector<ROOT::Experimental::Detail::RFieldValue>
@@ -1077,6 +1160,10 @@ void ROOT::Experimental::RArrayField::ReadInClusterImpl(const RClusterIndex &clu
 }
 
 void ROOT::Experimental::RArrayField::GenerateColumnsImpl()
+{
+}
+
+void ROOT::Experimental::RArrayField::GenerateColumnsImpl(const RNTupleDescriptor &)
 {
 }
 
@@ -1207,7 +1294,11 @@ void ROOT::Experimental::RVariantField::GenerateColumnsImpl()
    RColumnModel modelSwitch(EColumnType::kSwitch, false);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<RColumnSwitch, EColumnType::kSwitch>(modelSwitch, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RVariantField::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RVariantField::GenerateValue(void *where)
@@ -1270,7 +1361,11 @@ void ROOT::Experimental::RCollectionField::GenerateColumnsImpl()
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
-   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RCollectionField::GenerateColumnsImpl(const RNTupleDescriptor &)
+{
+   GenerateColumnsImpl();
 }
 
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -312,10 +312,9 @@ ROOT::Experimental::EColumnType ROOT::Experimental::Detail::RFieldBase::EnsureCo
       if (type == columnDesc.GetModel().GetType())
          return type;
    }
-   // TODO(jblomer): spell out column type
-   throw RException(R__FAIL("Unexpected column type: " + std::to_string(int(columnDesc.GetModel().GetType())) + " of "
-                            "column #" + std::to_string(columnIndex) +
-                            " for field " + fName));
+   throw RException(R__FAIL(
+      "Unexpected column type: " + RColumnElementBase::GetTypeName(columnDesc.GetModel().GetType()) + " of "
+      "column #" + std::to_string(columnIndex) + " for field " + fName));
    return columnDesc.GetModel().GetType();
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -299,11 +299,10 @@ void ROOT::Experimental::Detail::RFieldBase::Flush() const
 
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink)
 {
-   if (fColumns.empty()) {
-      GenerateColumnsImpl();
-      if (!fColumns.empty())
-         fPrincipalColumn = fColumns[0].get();
-   }
+   R__ASSERT(fColumns.empty());
+   GenerateColumnsImpl();
+   if (!fColumns.empty())
+      fPrincipalColumn = fColumns[0].get();
    for (auto& column : fColumns)
       column->Connect(fOnDiskId, &pageSink);
 }
@@ -311,11 +310,10 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink
 
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &pageSource)
 {
-   if (fColumns.empty()) {
-      GenerateColumnsImpl(pageSource.GetDescriptor());
-      if (!fColumns.empty())
-         fPrincipalColumn = fColumns[0].get();
-   }
+   R__ASSERT(fColumns.empty());
+   GenerateColumnsImpl(pageSource.GetDescriptor());
+   if (!fColumns.empty())
+      fPrincipalColumn = fColumns[0].get();
    for (auto& column : fColumns)
       column->Connect(fOnDiskId, &pageSource);
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -297,6 +297,29 @@ void ROOT::Experimental::Detail::RFieldBase::Flush() const
 }
 
 
+ROOT::Experimental::EColumnType ROOT::Experimental::Detail::RFieldBase::EnsureColumnType(
+   const std::vector<EColumnType> &allowedTypes, unsigned int columnIndex, const RNTupleDescriptor &desc)
+{
+   R__ASSERT(!allowedTypes.empty());
+   auto columnId = desc.FindColumnId(fOnDiskId, columnIndex);
+   if (columnId == kInvalidDescriptorId) {
+      throw RException(R__FAIL("Column missing: column #" + std::to_string(columnIndex) +
+                               " for field " + fName));
+   }
+
+   const auto &columnDesc = desc.GetColumnDescriptor(columnId);
+   for (auto type : allowedTypes) {
+      if (type == columnDesc.GetModel().GetType())
+         return type;
+   }
+   // TODO(jblomer): spell out column type
+   throw RException(R__FAIL("Unexpected column type: " + std::to_string(int(columnDesc.GetModel().GetType())) + " of "
+                            "column #" + std::to_string(columnIndex) +
+                            " for field " + fName));
+   return columnDesc.GetModel().GetType();
+}
+
+
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink)
 {
    R__ASSERT(fColumns.empty());
@@ -402,8 +425,9 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColu
       Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
 }
 
-void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kIndex}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -421,8 +445,9 @@ void ROOT::Experimental::RField<char>::GenerateColumnsImpl()
       char, EColumnType::kByte>(model, 0)));
 }
 
-void ROOT::Experimental::RField<char>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<char>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kByte}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -440,8 +465,9 @@ void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl()
       std::int8_t, EColumnType::kByte>(model, 0)));
 }
 
-void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kByte}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -459,8 +485,9 @@ void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl()
       std::uint8_t, EColumnType::kByte>(model, 0)));
 }
 
-void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kByte}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -479,8 +506,9 @@ void ROOT::Experimental::RField<bool>::GenerateColumnsImpl()
       Detail::RColumn::Create<bool, EColumnType::kBit>(model, 0)));
 }
 
-void ROOT::Experimental::RField<bool>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<bool>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kBit}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -499,8 +527,9 @@ void ROOT::Experimental::RField<float>::GenerateColumnsImpl()
       Detail::RColumn::Create<float, EColumnType::kReal32>(model, 0)));
 }
 
-void ROOT::Experimental::RField<float>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<float>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kReal32}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -519,8 +548,9 @@ void ROOT::Experimental::RField<double>::GenerateColumnsImpl()
       Detail::RColumn::Create<double, EColumnType::kReal64>(model, 0)));
 }
 
-void ROOT::Experimental::RField<double>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<double>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kReal64}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -538,8 +568,9 @@ void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl()
       std::int16_t, EColumnType::kInt16>(model, 0)));
 }
 
-void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kInt16}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -557,8 +588,9 @@ void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl()
       std::uint16_t, EColumnType::kInt16>(model, 0)));
 }
 
-void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kInt16}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -576,8 +608,9 @@ void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl()
       std::int32_t, EColumnType::kInt32>(model, 0)));
 }
 
-void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kInt32}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -595,8 +628,9 @@ void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl()
       Detail::RColumn::Create<std::uint32_t, EColumnType::kInt32>(model, 0)));
 }
 
-void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kInt32}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -614,8 +648,9 @@ void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl()
       Detail::RColumn::Create<std::uint64_t, EColumnType::kInt64>(model, 0)));
 }
 
-void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kInt64}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -633,8 +668,9 @@ void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl()
       Detail::RColumn::Create<std::int64_t, EColumnType::kInt64>(model, 0)));
 }
 
-void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kInt64}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -656,8 +692,10 @@ void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl()
       Detail::RColumn::Create<char, EColumnType::kByte>(modelChars, 1)));
 }
 
-void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kIndex}, 0, desc);
+   EnsureColumnType({EColumnType::kByte}, 1, desc);
    GenerateColumnsImpl();
 }
 
@@ -972,8 +1010,9 @@ void ROOT::Experimental::RVectorField::GenerateColumnsImpl()
       Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
 }
 
-void ROOT::Experimental::RVectorField::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RVectorField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kIndex}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -1072,8 +1111,9 @@ void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl()
       Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
 }
 
-void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kIndex}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -1294,8 +1334,9 @@ void ROOT::Experimental::RVariantField::GenerateColumnsImpl()
       Detail::RColumn::Create<RColumnSwitch, EColumnType::kSwitch>(modelSwitch, 0)));
 }
 
-void ROOT::Experimental::RVariantField::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RVariantField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kSwitch}, 0, desc);
    GenerateColumnsImpl();
 }
 
@@ -1361,8 +1402,9 @@ void ROOT::Experimental::RCollectionField::GenerateColumnsImpl()
       Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
 }
 
-void ROOT::Experimental::RCollectionField::GenerateColumnsImpl(const RNTupleDescriptor &)
+void ROOT::Experimental::RCollectionField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
+   EnsureColumnType({EColumnType::kIndex}, 0, desc);
    GenerateColumnsImpl();
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -596,7 +596,7 @@ void ROOT::Experimental::RField<std::string>::AppendImpl(const ROOT::Experimenta
 {
    auto typedValue = value.Get<std::string>();
    auto length = typedValue->length();
-   Detail::RColumnElement<char, EColumnType::kByte> elemChars(const_cast<char*>(typedValue->data()));
+   Detail::RColumnElement<char> elemChars(const_cast<char*>(typedValue->data()));
    fColumns[1]->AppendV(elemChars, length);
    fIndex += length;
    fColumns[0]->Append(fElemIndex);
@@ -613,7 +613,7 @@ void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(
       typedValue->clear();
    } else {
       typedValue->resize(nChars);
-      Detail::RColumnElement<char, EColumnType::kByte> elemChars(const_cast<char*>(typedValue->data()));
+      Detail::RColumnElement<char> elemChars(const_cast<char*>(typedValue->data()));
       fColumns[1]->ReadV(collectionStart, nChars, &elemChars);
    }
 }
@@ -872,7 +872,7 @@ void ROOT::Experimental::RVectorField::AppendImpl(const Detail::RFieldValue& val
       auto itemValue = fSubFields[0]->CaptureValue(typedValue->data() + (i * fItemSize));
       fSubFields[0]->Append(itemValue);
    }
-   Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
+   Detail::RColumnElement<ClusterSize_t> elemIndex(&fNWritten);
    fNWritten += count;
    fColumns[0]->Append(elemIndex);
 }
@@ -966,7 +966,7 @@ void ROOT::Experimental::RField<std::vector<bool>>::AppendImpl(const Detail::RFi
       auto itemValue = fSubFields[0]->CaptureValue(&bval);
       fSubFields[0]->Append(itemValue);
    }
-   Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
+   Detail::RColumnElement<ClusterSize_t> elemIndex(&fNWritten);
    fNWritten += count;
    fColumns[0]->Append(elemIndex);
 }
@@ -1186,7 +1186,7 @@ void ROOT::Experimental::RVariantField::AppendImpl(const Detail::RFieldValue& va
       index = fNWritten[tag - 1]++;
    }
    RColumnSwitch varSwitch(ClusterSize_t(index), tag);
-   Detail::RColumnElement<RColumnSwitch, EColumnType::kSwitch> elemSwitch(&varSwitch);
+   Detail::RColumnElement<RColumnSwitch> elemSwitch(&varSwitch);
    fColumns[0]->Append(elemSwitch);
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -669,8 +669,15 @@ void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl()
 
 void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
-   EnsureColumnType({EColumnType::kInt64}, 0, desc);
-   GenerateColumnsImpl();
+   auto type = EnsureColumnType({EColumnType::kInt64, EColumnType::kInt32}, 0, desc);
+   RColumnModel model(type, false /* isSorted*/);
+   if (type == EColumnType::kInt64) {
+      fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
+         Detail::RColumn::Create<std::int64_t, EColumnType::kInt64>(model, 0)));
+   } else {
+      fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
+         Detail::RColumn::Create<std::int64_t, EColumnType::kInt32>(model, 0)));
+   }
 }
 
 void ROOT::Experimental::RField<std::int64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -71,7 +71,7 @@ void ROOT::Experimental::RNTupleReader::ConnectModel(const RNTupleModel &model) 
       if (field.GetOnDiskId() == kInvalidDescriptorId) {
          field.SetOnDiskId(desc.FindFieldId(field.GetName(), field.GetParent()->GetOnDiskId()));
       }
-      field.ConnectPageStorage(*fSource);
+      field.ConnectPageSource(*fSource);
    }
 }
 

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -69,30 +69,6 @@ static std::string GetFieldName(ROOT::Experimental::DescriptorId_t fieldId,
    return GetFieldName(fieldDesc.GetParentId(), ntupleDesc) + "." + fieldDesc.GetFieldName();
 }
 
-static std::string GetColumnTypeName(ROOT::Experimental::EColumnType type)
-{
-   switch (type) {
-   case ROOT::Experimental::EColumnType::kBit:
-      return "Bit";
-   case ROOT::Experimental::EColumnType::kByte:
-      return "Byte";
-   case ROOT::Experimental::EColumnType::kInt32:
-      return "Int32";
-   case ROOT::Experimental::EColumnType::kInt64:
-      return "Int64";
-   case ROOT::Experimental::EColumnType::kReal32:
-      return "Real32";
-   case ROOT::Experimental::EColumnType::kReal64:
-      return "Real64";
-   case ROOT::Experimental::EColumnType::kIndex:
-      return "Index";
-   case ROOT::Experimental::EColumnType::kSwitch:
-      return "Switch";
-   default:
-      return "UNKNOWN";
-   }
-}
-
 } // anonymous namespace
 
 void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) const
@@ -191,7 +167,7 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
       auto avgPageSize = (col.fNPages == 0) ? 0 : (col.fBytesOnStorage / col.fNPages);
       auto avgElementsPerPage = (col.fNPages == 0) ? 0 : (col.fNElements / col.fNPages);
       std::string nameAndType = std::string("  ") + col.fFieldName + " [#" + std::to_string(col.fLocalOrder) + "]"
-         + "  --  " + GetColumnTypeName(col.fType);
+         + "  --  " + Detail::RColumnElementBase::GetTypeName(col.fType);
       std::string id = std::string("{id:") + std::to_string(col.fColumnId) + "}";
       output << nameAndType << std::setw(60 - nameAndType.length()) << id << std::endl;
       output << "    # Elements:          " << col.fNElements << std::endl;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -183,7 +183,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
       );
       fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fLastFieldId);
       f.SetOnDiskId(fLastFieldId);
-      f.ConnectPageStorage(*this); // issues in turn one or several calls to AddColumn()
+      f.ConnectPageSink(*this); // issues in turn one or several calls to AddColumn()
    }
 
    auto nColumns = fLastColumnId;

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -90,9 +90,19 @@ TEST(RNTuple, Casting)
       auto writer = RNTupleWriter::Recreate(std::move(modelA), "ntuple", fileGuard.GetPath());
       writer->Fill();
    }
-   auto modelB = RNTupleModel::Create();
-   auto fieldCast = modelB->MakeField<std::int64_t>("int");
-   auto reader = RNTupleReader::Open(std::move(modelB), "ntuple", fileGuard.GetPath());
+
+   try {
+      auto modelB = RNTupleModel::Create();
+      auto fieldCast = modelB->MakeField<float>("int");
+      auto reader = RNTupleReader::Open(std::move(modelB), "ntuple", fileGuard.GetPath());
+      FAIL() << "should not be able to cast int to float";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("Unexpected column type"));
+   }
+
+   auto modelC = RNTupleModel::Create();
+   auto fieldCast = modelC->MakeField<std::int64_t>("int");
+   auto reader = RNTupleReader::Open(std::move(modelC), "ntuple", fileGuard.GetPath());
    reader->LoadEntry(0);
    EXPECT_EQ(42, *fieldCast);
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -80,3 +80,19 @@ TEST(RNTuple, UnsupportedStdTypes)
       EXPECT_THAT(err.what(), testing::HasSubstr("weak_ptr<int> is not supported"));
    }
 }
+
+TEST(RNTuple, Casting)
+{
+   FileRaii fileGuard("test_ntuple_casting.root");
+   auto modelA = RNTupleModel::Create();
+   modelA->MakeField<std::int32_t>("int", 42);
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(modelA), "ntuple", fileGuard.GetPath());
+      writer->Fill();
+   }
+   auto modelB = RNTupleModel::Create();
+   auto fieldCast = modelB->MakeField<std::int64_t>("int");
+   auto reader = RNTupleReader::Open(std::move(modelB), "ntuple", fileGuard.GetPath());
+   reader->LoadEntry(0);
+   EXPECT_EQ(42, *fieldCast);
+}

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -62,11 +62,11 @@ TEST(RNTuple, InsideCollection)
    ASSERT_NE(idA, ROOT::Experimental::kInvalidDescriptorId);
    auto fieldInner = std::unique_ptr<RFieldBase>(RFieldBase::Create("klassVec.a", "float").Unwrap());
    fieldInner->SetOnDiskId(idA);
-   fieldInner->ConnectPageStorage(*source);
+   fieldInner->ConnectPageSource(*source);
 
    auto field = std::make_unique<ROOT::Experimental::RVectorField>("klassVec", std::move(fieldInner));
    field->SetOnDiskId(idKlassVec);
-   field->ConnectPageStorage(*source);
+   field->ConnectPageSource(*source);
 
    auto value = field->GenerateValue();
    field->Read(0, &value);


### PR DESCRIPTION
When connecting fields of fundamental types and their columns, distinguish between reading and writing. On writing, pick a preferred column type for a given fundamental memory type. On reading
  - Check the column types found on disk and bail out if they don't match
  - Allow for certain type conversions

This PR adds support to read an `std::int32_t` on disk in an `std::int64_t` in memory.  The mechanics can later be reused to add support for more type conversions.