### PR TITLE
Fix multicore tests when running on machines with few cores

### DIFF
--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -7,6 +7,8 @@
 
 #include "gtest/gtest.h"
 
+#include <thread>
+
 using namespace ROOT;
 using namespace ROOT::RDF;
 
@@ -351,9 +353,10 @@ TEST(RDataFrameInterface, GetNSlots)
    ROOT::RDataFrame df0(1);
    EXPECT_EQ(1U, df0.GetNSlots());
 #ifdef R__USE_IMT
-   ROOT::EnableImplicitMT(3);
+   unsigned int nslots = std::min(3U, std::thread::hardware_concurrency());
+   ROOT::EnableImplicitMT(nslots);
    ROOT::RDataFrame df3(1);
-   EXPECT_EQ(3U, df3.GetNSlots());
+   EXPECT_EQ(nslots, df3.GetNSlots());
    ROOT::DisableImplicitMT();
    ROOT::RDataFrame df1(1);
    EXPECT_EQ(1U, df1.GetNSlots());

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -28,7 +28,7 @@ using namespace ROOT::VecOps;
 // Fixture for all tests in this file. If parameter is true, run with implicit MT, else run sequentially
 class RDFSimpleTests : public ::testing::TestWithParam<bool> {
 protected:
-   RDFSimpleTests() : NSLOTS(GetParam() ? 4u : 1u)
+   RDFSimpleTests() : NSLOTS(GetParam() ? std::min(4u, std::thread::hardware_concurrency()) : 1u)
    {
       if (GetParam())
          ROOT::EnableImplicitMT(NSLOTS);

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include <limits>
 #include <memory>
+#include <thread>
 using namespace ROOT;         // RDataFrame
 using namespace ROOT::RDF;    // RInterface
 using namespace ROOT::VecOps; // RVec
@@ -1041,9 +1042,10 @@ TEST(RDFSnapshotMore, EmptyBuffersMT)
 {
    const auto fname = "emptybuffersmt.root";
    const auto treename = "t";
-   ROOT::EnableImplicitMT(4);
+   const unsigned int nslots = std::min(4U, std::thread::hardware_concurrency());
+   ROOT::EnableImplicitMT(nslots);
    ROOT::RDataFrame d(10);
-   auto dd = d.DefineSlot("x", [](unsigned int s) { return s == 3 ? 0 : 1; })
+   auto dd = d.DefineSlot("x", [&](unsigned int s) { return s == nslots - 1 ? 0 : 1; })
                .Filter([](int x) { return x == 0; }, {"x"}, "f");
    auto r = dd.Report();
    dd.Snapshot<int>(treename, fname, {"x"});

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -294,14 +294,27 @@ TEST(TreeProcessorMT, LimitNTasks_CheckEntries)
       }
    };
 
-   ROOT::EnableImplicitMT(4);
+   const unsigned int nslots = std::min(4U, std::thread::hardware_concurrency());
+   ROOT::EnableImplicitMT(nslots);
 
    ROOT::TTreeProcessorMT p(filename, treename);
    p.Process(f);
 
-   EXPECT_EQ(nTasks, 96U) << "Wrong number of tasks generated!\n";
-   EXPECT_EQ(nEntriesCountsMap[10], 65U) << "Wrong number of tasks with 10 clusters each!\n";
-   EXPECT_EQ(nEntriesCountsMap[11], 31U) << "Wrong number of tasks with 11 clusters each!\n";
+   if (nslots == 4) {
+      EXPECT_EQ(nTasks, 96U) << "Wrong number of tasks generated!\n";
+      EXPECT_EQ(nEntriesCountsMap[10], 65U) << "Wrong number of tasks with 10 clusters each!\n";
+      EXPECT_EQ(nEntriesCountsMap[11], 31U) << "Wrong number of tasks with 11 clusters each!\n";
+   }
+   else if (nslots == 2) {
+      EXPECT_EQ(nTasks, 48U) << "Wrong number of tasks generated!\n";
+      EXPECT_EQ(nEntriesCountsMap[20], 17U) << "Wrong number of tasks with 20 clusters each!\n";
+      EXPECT_EQ(nEntriesCountsMap[21], 31U) << "Wrong number of tasks with 21 clusters each!\n";
+   }
+   else if (nslots == 1) {
+      EXPECT_EQ(nTasks, 24U) << "Wrong number of tasks generated!\n";
+      EXPECT_EQ(nEntriesCountsMap[41], 17U) << "Wrong number of tasks with 41 clusters each!\n";
+      EXPECT_EQ(nEntriesCountsMap[42], 7U) << "Wrong number of tasks with 42 clusters each!\n";
+   }
 
    gSystem->Unlink(filename);
    ROOT::DisableImplicitMT();


### PR DESCRIPTION
When running on machines with few cores, enabling multithreading can
give you fewer cores than requested. For most of the tests this does
not matter. However, some tests verify the number of threads used.
This commit adapts those tests for this situation.