### PR TITLE
Fix ppc64le compilation with gcc 10

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Lex/Lexer.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Lex/Lexer.cpp
@@ -2546,7 +2546,7 @@ bool Lexer::SkipBlockComment(Token &Result, const char *CurPtr,
         '/', '/', '/', '/',  '/', '/', '/', '/'
       };
       while (CurPtr+16 <= BufferEnd &&
-             !vec_any_eq(*(const vector unsigned char*)CurPtr, Slashes))
+             !vec_any_eq(*(const __vector unsigned char*)CurPtr, Slashes))
         CurPtr += 16;
 #else
       // Scan for '/' quickly.  Many block comments are very large.


### PR DESCRIPTION
Reapply fix lost in the LLVM 9 upgrade. This fix is in LLVM 10.

Backported from llvm upstream
https://reviews.llvm.org/D74129