### PR TITLE
[ntuple] Parallel page compression

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -247,6 +247,9 @@ triggered by Flush() or by destructing the ntuple.  On I/O errors, an exception 
 // clang-format on
 class RNTupleWriter {
 private:
+   /// The page sink's parallel page compression scheduler if IMT is on.
+   /// Needs to be destructed after the page sink is destructed and so declared before.
+   std::unique_ptr<Detail::RPageStorage::RTaskScheduler> fZipTasks;
    std::unique_ptr<Detail::RPageSink> fSink;
    /// Needs to be destructed before fSink
    std::unique_ptr<RNTupleModel> fModel;

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -69,6 +69,7 @@ class RNTupleImtTaskScheduler : public Detail::RPageStorage::RTaskScheduler {
 private:
    std::unique_ptr<TTaskGroup> fTaskGroup;
 public:
+   RNTupleImtTaskScheduler();
    virtual ~RNTupleImtTaskScheduler() = default;
    void Reset() final;
    void AddTask(const std::function<void(void)> &taskFunc) final;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
@@ -120,7 +120,44 @@ public:
       return nbytes;
    }
 
-   const void *GetZipBuffer() { return fZipBuffer->data(); }
+   /// Returns the size of the compressed data, written into the provided output buffer.
+   static std::size_t Zip(const void *from, std::size_t nbytes, int compression, void *to) {
+      R__ASSERT(from != nullptr);
+      R__ASSERT(to != nullptr);
+      auto cxLevel = compression % 100;
+      if (cxLevel == 0) {
+         memcpy(to, from, nbytes);
+         return nbytes;
+      }
+
+      auto cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(compression / 100);
+      unsigned int nZipBlocks = 1 + (nbytes - 1) / kMAXZIPBUF;
+      char *source = const_cast<char *>(static_cast<const char *>(from));
+      int szTarget = nbytes;
+      char *target = reinterpret_cast<char *>(to);
+      int szOutBlock = 0;
+      int szRemaining = nbytes;
+      size_t szZipData = 0;
+      for (unsigned int i = 0; i < nZipBlocks; ++i) {
+         int szSource = std::min(static_cast<int>(kMAXZIPBUF), szRemaining);
+         R__zipMultipleAlgorithm(cxLevel, &szSource, source, &szTarget, target, &szOutBlock, cxAlgorithm);
+         R__ASSERT(szOutBlock >= 0);
+         if ((szOutBlock == 0) || (szOutBlock >= szSource)) {
+            // Uncompressible block, we have to store the entire input data stream uncompressed
+            memcpy(to, from, nbytes);
+            return nbytes;
+         }
+
+         szZipData += szOutBlock;
+         source += szSource;
+         szRemaining -= szSource;
+      }
+      R__ASSERT(szRemaining == 0);
+      R__ASSERT(szZipData < nbytes);
+      return szZipData;
+   }
+
+   void *GetZipBuffer() { return fZipBuffer->data(); }
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -17,6 +17,7 @@
 #ifndef ROOT7_RPageSinkBuf
 #define ROOT7_RPageSinkBuf
 
+#include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RPageStorage.hxx>
 
 #include <iterator>
@@ -88,6 +89,12 @@ private:
    };
 
 private:
+   /// I/O performance counters that get registered in fMetrics
+   struct RCounters {
+      RNTuplePlainCounter &fParallelZip;
+   };
+   std::unique_ptr<RCounters> fCounters;
+   RNTupleMetrics fMetrics;
    /// The inner sink, responsible for actually performing I/O.
    std::unique_ptr<RPageSink> fInnerSink;
    /// The buffered page sink maintains a copy of the RNTupleModel for the inner sink.
@@ -114,7 +121,7 @@ public:
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) final;
    void ReleasePage(RPage &page) final;
 
-   RNTupleMetrics &GetMetrics() final { return fInnerSink->GetMetrics(); }
+   RNTupleMetrics &GetMetrics() final { return fMetrics; }
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -54,6 +54,13 @@ private:
             fBuf = std::make_unique<unsigned char[]>(fPage.GetSize());
          }
       };
+   public:
+      RColumnBuf() = default;
+      RColumnBuf(const RColumnBuf&) = delete;
+      RColumnBuf& operator=(const RColumnBuf&) = delete;
+      RColumnBuf(RColumnBuf&&) = default;
+      RColumnBuf& operator=(RColumnBuf&&) = default;
+      ~RColumnBuf() = default;
       /// Returns an iterator to the newly buffered page. The iterator remains
       /// valid until the return value of DrainBufferedPages() is destroyed.
       std::list<RPageZipItem>::iterator BufferPage(

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -48,7 +48,7 @@ private:
          RPageStorage::RSealedPage fSealedPage;
          explicit RPageZipItem(RPage page)
             : fPage(page), fBuf(nullptr) {}
-         bool IsSealed() {
+         bool IsSealed() const {
             return fSealedPage.fBuffer != nullptr;
          }
          void AllocateSealedPageBuf() {
@@ -112,7 +112,7 @@ protected:
 
 public:
    explicit RPageSinkBuf(std::unique_ptr<RPageSink> inner);
-   RPageSinkBuf(const RPageSink&) = delete;
+   RPageSinkBuf(const RPageSinkBuf&) = delete;
    RPageSinkBuf& operator=(const RPageSinkBuf&) = delete;
    RPageSinkBuf(RPageSinkBuf&&) = default;
    RPageSinkBuf& operator=(RPageSinkBuf&&) = default;

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -63,6 +63,9 @@ private:
    /// Vector of buffered column pages. Indexed by column id.
    std::vector<RColumnBuf> fBufferedColumns;
 
+   /// Compress and commit buffered cluster pages in parallel.
+   void ParallelClusterZip(NTupleSize_t nEntries);
+
 protected:
    void CreateImpl(const RNTupleModel &model) final;
    RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -112,7 +112,7 @@ public:
 
       /// Returns true for a valid column handle; fColumn and fId should always either both
       /// be valid or both be invalid.
-      operator bool() const { return fId != kInvalidDescriptorId && fColumn; }
+      explicit operator bool() const { return fId != kInvalidDescriptorId && fColumn; }
    };
    /// The column handle identifies a column with the current open page storage
    using ColumnHandle_t = RColumnHandle;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -182,6 +182,10 @@ protected:
    /// Usage of this method requires construction of fCompressor.
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element, int compressionSetting);
 
+   /// Seal a page using the provided buffer.
+   static RSealedPage SealPage(const RPage &page, const RColumnElementBase &element,
+      int compressionSetting, void *buf);
+
 public:
    RPageSink(std::string_view ntupleName, const RNTupleWriteOptions &options);
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -281,6 +281,12 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
    if (!fSink) {
       throw RException(R__FAIL("null sink"));
    }
+#ifdef R__USE_IMT
+   if (IsImplicitMTEnabled()) {
+      fZipTasks = std::make_unique<RNTupleImtTaskScheduler>();
+      fSink->SetTaskScheduler(fZipTasks.get());
+   }
+#endif
    fSink->Create(*fModel.get());
    fMetrics.ObserveMetrics(fSink->GetMetrics());
 }

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -40,6 +40,11 @@
 
 
 #ifdef R__USE_IMT
+ROOT::Experimental::RNTupleImtTaskScheduler::RNTupleImtTaskScheduler()
+{
+   Reset();
+}
+
 void ROOT::Experimental::RNTupleImtTaskScheduler::Reset()
 {
    fTaskGroup = std::make_unique<TTaskGroup>();

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -288,7 +288,7 @@ ROOT::Experimental::Detail::RPageSink::SealPage(
    auto zippedBytes = packedBytes;
 
    if ((compressionSetting != 0) || !element.IsMappable()) {
-      zippedBytes = fCompressor->Zip(buffer, packedBytes, fOptions.GetCompression());
+      zippedBytes = fCompressor->Zip(buffer, packedBytes, compressionSetting);
       if (!isAdoptedBuffer)
          delete[] buffer;
       buffer = const_cast<unsigned char *>(reinterpret_cast<const unsigned char *>(fCompressor->GetZipBuffer()));

--- a/tree/ntuple/v7/test/ntuple_metrics.cxx
+++ b/tree/ntuple/v7/test/ntuple_metrics.cxx
@@ -106,7 +106,8 @@ TEST(Metrics, RNTupleWriter)
    *float_field = 10.0;
    ntuple->Fill();
    ntuple->CommitCluster();
-   auto* page_counter = ntuple->GetMetrics().GetCounter("RNTupleWriter.RPageSinkFile.nPageCommitted");
+   auto* page_counter = ntuple->GetMetrics().GetCounter(
+      "RNTupleWriter.RPageSinkBuf.RPageSinkFile.nPageCommitted");
    ASSERT_FALSE(page_counter == nullptr);
    // one page for the int field, one for the float field
    EXPECT_EQ(2, page_counter->GetValueAsInt());

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -165,3 +165,45 @@ TEST(RPageSinkBuf, Basics)
       ASSERT_EQ(column, next_page->first);
    }
 }
+
+TEST(RPageSinkBuf, ParallelZip) {
+   ROOT::EnableImplicitMT();
+
+   FileRaii fileGuard("test_ntuple_sinkbuf_pzip.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto floatField = model->MakeField<float>("pt");
+      auto fieldKlassVec = model->MakeField<std::vector<CustomStruct>>("klassVec");
+      auto ntuple = std::make_unique<RNTupleWriter>(std::move(model),
+         std::make_unique<RPageSinkBuf>(std::make_unique<RPageSinkFile>(
+            "buf_pzip", fileGuard.GetPath(), RNTupleWriteOptions()
+      )));
+
+      for (int i = 0; i < 20000; i++) {
+         *floatField = static_cast<float>(i);
+         CustomStruct klass;
+         klass.a = 42.0;
+         klass.v1.emplace_back(static_cast<float>(i));
+         klass.v2.emplace_back(std::vector<float>(3, static_cast<float>(i)));
+         klass.s = "hi" + std::to_string(i);
+         *fieldKlassVec = std::vector<CustomStruct>{klass};
+         ntuple->Fill();
+         if (i && i % 15000 == 0) {
+            ntuple->CommitCluster();
+         }
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("buf_pzip", fileGuard.GetPath());
+   EXPECT_EQ(20000, ntuple->GetNEntries());
+
+   auto viewPt = ntuple->GetView<float>("pt");
+   auto viewKlassVec = ntuple->GetView<std::vector<CustomStruct>>("klassVec");
+   for (auto i : ntuple->GetEntryRange()) {
+      float fi = static_cast<float>(i);
+      EXPECT_EQ(fi, viewPt(i));
+      EXPECT_EQ(std::vector<float>{fi}, viewKlassVec(i).at(0).v1);
+      EXPECT_EQ((std::vector<float>(3, fi)), viewKlassVec(i).at(0).v2.at(0));
+      EXPECT_EQ("hi" + std::to_string(i), viewKlassVec(i).at(0).s);
+   }
+}


### PR DESCRIPTION
Implement parallel page compression using `RPageSinkBuf`. When it's time to commit the cluster, the buffered pages are passed to the task scheduler to be compressed. Each page is given a `RNTupleCompressor` which both handles the compression and serves as the compression scratch buffer. `RNTupleCompressor` was adjusted to take a user-provided size to avoid wasting memory for small pages (16MB was the fixed size). 