### PR TITLE
[ntuple] Fix warning in RPageSourceFriends

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
@@ -36,7 +36,7 @@ namespace Detail {
 \brief Virtual storage that combines several other sources horizontally
 */
 // clang-format on
-class RPageSourceFriends : public RPageSource {
+class RPageSourceFriends final : public RPageSource {
 private:
    struct ROriginId {
       std::size_t fSourceIdx = 0;


### PR DESCRIPTION
This should fix the following warning in clang 10:

```
warning: class with destructor marked 'final' cannot be inherited from [-Wfinal-dtor-non-final-class]
~RPageSourceFriends() final;
                         ^
.../v7/inc/ROOT/RPageSourceFriends.hxx:39:7: note: mark 'ROOT::Experimental::Detail::RPageSourceFriends' as 'final' to silence this warning
class RPageSourceFriends : public RPageSource {
      ^
```