### PR TITLE
[ntuple, daos] Defer `daos_init()` call until needed

### DIFF
--- a/tree/ntuple/v7/src/RDaos.cxx
+++ b/tree/ntuple/v7/src/RDaos.cxx
@@ -20,6 +20,13 @@
 #include <stdexcept>
 
 ROOT::Experimental::Detail::RDaosPool::RDaosPool(std::string_view poolUuid, std::string_view serviceReplicas) {
+   {
+      static struct RDaosRAII {
+         RDaosRAII() { daos_init(); }
+         ~RDaosRAII() { daos_fini(); }
+      } RAII = {};
+   }
+
    struct SvcRAII {
       d_rank_list_t *rankList;
       SvcRAII(std::string_view ranks) { rankList = daos_rank_list_parse(ranks.data(), "_"); }
@@ -173,14 +180,3 @@ ROOT::Experimental::Detail::RDaosContainer::WriteObject(const void *buffer, std:
    fSequentialWrOid.lo++;
    return ret;
 }
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-
-namespace {
-static struct RDaosRAII {
-   RDaosRAII() { daos_init(); }
-   ~RDaosRAII() { daos_fini(); }
-} RAII{};
-} // anonymous namespace


### PR DESCRIPTION
The RAII object in RDaos.cxx was constructed statically, which causes a DAOS-enabled RNTuple build to call `daos_init()` (or `daos_fini()` at exit) even if the only the file backend was used by user code.

This commit turns the RAII object into a static variable in `RDaosPool::RDaosPool()` which is initialized during the first call to the
constructor.  Note that static variable initialization is guaranteed to be thread-safe by ISO C++.