### PR TITLE
Fix several bugs in TBrowser [6.24]

### DIFF
--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -21,7 +21,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <map>
+#include <utility>
 
 namespace ROOT {
 namespace Experimental {
@@ -37,7 +37,7 @@ class RBrowserData {
 
    Browsable::RElementPath_t  fWorkingPath;             ///<! path showed in Breadcrumb
 
-   std::map<Browsable::RElementPath_t, std::shared_ptr<Browsable::RElement>> fCache; ///<! already requested elements
+   std::vector<std::pair<Browsable::RElementPath_t, std::shared_ptr<Browsable::RElement>>> fCache; ///<! already requested elements
 
    Browsable::RElementPath_t fLastPath;                  ///<! path to last used element
    std::shared_ptr<Browsable::RElement> fLastElement;    ///<! last element used in request

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -35,7 +35,6 @@ ROOT::Experimental::RLogChannel &ROOT::Experimental::BrowserLog() {
 \brief Way to browse (hopefully) everything in %ROOT
 */
 
-
 /////////////////////////////////////////////////////////////////////
 /// set top element for browsing
 
@@ -227,13 +226,25 @@ std::shared_ptr<Browsable::RElement> RBrowserData::GetSubElement(const Browsable
    if (path.empty())
       return fTopElement;
 
+   // first check direct match in cache
+   for (auto &entry : fCache)
+      if (entry.first == path)
+         return entry.second;
+
    // find best possible entry in cache
    int pos = 0;
    auto elem = fTopElement;
 
    for (auto &entry : fCache) {
+      if (entry.first.size() >= path.size())
+         continue;
+
       auto comp = Browsable::RElement::ComparePaths(path, entry.first);
-      if (comp > pos) { pos = comp; elem = entry.second; }
+
+      if ((comp > pos) && (comp == (int) entry.first.size())) {
+         pos = comp;
+         elem = entry.second;
+      }
    }
 
    while (pos < (int) path.size()) {
@@ -259,8 +270,7 @@ std::shared_ptr<Browsable::RElement> RBrowserData::GetSubElement(const Browsable
 
       auto subpath = path;
       subpath.resize(pos+1);
-      fCache[subpath] = elem;
-
+      fCache.emplace_back(subpath, elem);
       pos++; // switch to next element
    }
 

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -1738,9 +1738,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          menu.add("separator");
       }
 
-      menu.addchk(this.isTooltipAllowed(), "Show tooltips", function() {
-         this.setTooltipAllowed("toggle");
-      });
+      menu.addchk(this.isTooltipAllowed(), "Show tooltips", () => this.setTooltipAllowed("toggle"));
       menu.addAttributesMenu(this, alone ? "" : "Frame ");
       menu.add("separator");
       menu.add("Save as frame.png", () => pp.saveAs("png", 'frame', 'frame.png'));

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -2490,7 +2490,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
    /** @summary Returns true if stats box fill can be ingored
      * @private */
    THistPainter.prototype.isIgnoreStatsFill = function() {
-      return !this.getObject() || (!this.draw_content && !this.create_stats) || (this.options.Axis > 0);
+      return !this.getObject() || (!this.draw_content && !this.create_stats && !this.snapid) || (this.options.Axis > 0);
    }
 
    /** @summary Create stat box for histogram if required */
@@ -2503,7 +2503,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       if (!force && !this.options.ForceStat) {
          if (this.options.NoStat || histo.TestBit(TH1StatusBits.kNoStats) || !JSROOT.settings.AutoStat) return null;
 
-         if (!this.draw_content || !this.isMainPainter()) return null;
+         if ((this.options.Axis > 0) || !this.isMainPainter()) return null;
       }
 
       let stats = this.findStat(), st = JSROOT.gStyle,
@@ -4782,7 +4782,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       // this value used for logz scale drawing
       if (this.gminposbin === null) this.gminposbin = this.gmaxbin*1e-4;
 
-      if (this.options.Axis > 0) { // Paint histogram axis only
+      if (this.options.Axis > 0) {
+         // Paint histogram axis only
          this.draw_content = false;
       } else {
          this.draw_content = (this.gmaxbin > 0);

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -2267,10 +2267,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       //   menu.addchk(pad.fLogz, "SetLogz", this.toggleAxisLog.bind(main,"z"));
       menu.add("separator");
 
-
-      menu.addchk(this.isTooltipAllowed(), "Show tooltips", function() {
-         this.setTooltipAllowed("toggle");
-      });
+      menu.addchk(this.isTooltipAllowed(), "Show tooltips", () => this.setTooltipAllowed("toggle"));
       menu.addAttributesMenu(this, alone ? "" : "Frame ");
       menu.add("separator");
       menu.add("Save as frame.png", () => this.getPadPainter().saveAs("png", 'frame', 'frame.png'));


### PR DESCRIPTION
1. Improve/fix problems with TKey/TDirectory handling.
    In some cases objects were deleted, but still used in RBrowsable classes
2. Fix bug with RBrowsable cache usage. 
    Logic was not working when more than 1 levels of sub-directories in the TFile was there
3. Fix statbox handling for empty histograms in JSROOT