### PR TITLE
Fix several problems in RBrowser

### DIFF
--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -110,11 +110,20 @@ Element representing TKey from TDirectory
 
 class TKeyElement : public RElement {
    TDirectory *fDir{nullptr};
-   TKey *fKey{nullptr};
+   std::string fKeyName;
+   std::string fKeyTitle;
+   Short_t fKeyCycle{0};
+   std::string fKeyClass;
    std::shared_ptr<RElement> fElement; ///<! holder of read object
 
 public:
-   TKeyElement(TDirectory *dir, TKey *key) : fDir(dir), fKey(key) {}
+   TKeyElement(TDirectory *dir, TKey *key) : fDir(dir)
+   {
+      fKeyName = key->GetName();
+      fKeyTitle = key->GetTitle();
+      fKeyCycle = key->GetCycle();
+      fKeyClass = key->GetClassName();
+   }
 
    virtual ~TKeyElement() = default;
 
@@ -123,9 +132,10 @@ public:
    {
       if (fElement)
          return fElement->GetName();
-      std::string name = fKey->GetName();
+      std::string name = fKeyName;
       name.append(";");
-      name.append(std::to_string(fKey->GetCycle()));
+      name.append(std::to_string(fKeyCycle));
+
       return name;
    }
 
@@ -135,7 +145,7 @@ public:
       if (fElement)
          return fElement->GetTitle();
 
-      return fKey->GetTitle();
+      return fKeyTitle;
    }
 
    /** Create iterator for childs elements if any
@@ -146,12 +156,12 @@ public:
       if (fElement)
          return fElement->GetChildsIter();
 
-      std::string clname = fKey->GetClassName();
-
-      if (clname.find("TDirectory") == 0) {
-          auto subdir = fDir->GetDirectory(GetName().c_str());
-          if (!subdir) return nullptr;
-          return std::make_unique<TDirectoryLevelIter>(subdir);
+      if (fKeyClass.find("TDirectory") == 0) {
+         auto subdir = fDir->GetDirectory(fKeyName.c_str());
+         if (!subdir)
+            subdir = fDir->GetDirectory(GetName().c_str());
+         if (!subdir) return nullptr;
+         return std::make_unique<TDirectoryLevelIter>(subdir);
       }
 
       auto obj = GetObject();
@@ -171,20 +181,18 @@ public:
       if (fElement)
          return fElement->GetObject();
 
-      std::string clname = fKey->GetClassName();
-
-      auto obj_class = TClass::GetClass(clname.c_str());
+      auto obj_class = TClass::GetClass(fKeyClass.c_str());
       if (!obj_class)
          return nullptr;
 
-      void *obj = fDir->GetObjectChecked(fKey->GetName(), obj_class);
+      void *obj = fDir->GetObjectChecked(fKeyName.c_str(), obj_class);
       if (!obj)
          return nullptr;
 
       TObject *tobj = (TObject *) obj_class->DynamicCast(TObject::Class(), obj);
 
       if (tobj) {
-         bool owned_by_dir = (fDir->FindObject(tobj) == tobj) || (clname == "TGeoManager");
+         bool owned_by_dir = (fDir->FindObject(tobj) == tobj) || (fKeyClass == "TGeoManager");
 
          return std::make_unique<TObjectHolder>(tobj, !owned_by_dir);
       }
@@ -198,15 +206,13 @@ public:
       if (fElement)
          return fElement->GetDefaultAction();
 
-      std::string clname = fKey->GetClassName();
-      if (clname.empty()) return kActNone;
-      if ((clname == "TCanvas"s) || (clname == "ROOT::Experimental::RCanvas"s)) return kActCanvas;
-      if (clname == "TGeoManager"s) return kActGeom;
-      if (RProvider::CanDraw6(clname)) return kActDraw6;
-      if (RProvider::CanDraw7(clname)) return kActDraw7;
-      if (RProvider::CanHaveChilds(clname)) return kActBrowse;
+      if (fKeyClass.empty()) return kActNone;
+      if ((fKeyClass == "TCanvas"s) || (fKeyClass == "ROOT::Experimental::RCanvas"s)) return kActCanvas;
+      if (fKeyClass == "TGeoManager"s) return kActGeom;
+      if (RProvider::CanDraw6(fKeyClass)) return kActDraw6;
+      if (RProvider::CanDraw7(fKeyClass)) return kActDraw7;
+      if (RProvider::CanHaveChilds(fKeyClass)) return kActBrowse;
       return kActNone;
-
    }
 
    bool IsCapable(EActionKind action) const override
@@ -214,17 +220,16 @@ public:
       if (fElement)
          return fElement->IsCapable(action);
 
-      std::string clname = fKey->GetClassName();
-      if (clname.empty()) return false;
+      if (fKeyClass.empty()) return false;
 
       switch(action) {
-         case kActBrowse: return RProvider::CanHaveChilds(clname);
+         case kActBrowse: return RProvider::CanHaveChilds(fKeyClass);
          case kActEdit: return true;
          case kActImage:
-         case kActDraw6: return RProvider::CanDraw6(clname); // if can draw in TCanvas, can produce image
-         case kActDraw7: return RProvider::CanDraw7(clname);
-         case kActCanvas: return (clname == "TCanvas"s) || (clname == "ROOT::Experimental::RCanvas"s);
-         case kActGeom: return (clname == "TGeoManager"s);
+         case kActDraw6: return RProvider::CanDraw6(fKeyClass); // if can draw in TCanvas, can produce image
+         case kActDraw7: return RProvider::CanDraw7(fKeyClass);
+         case kActCanvas: return (fKeyClass == "TCanvas"s) || (fKeyClass == "ROOT::Experimental::RCanvas"s);
+         case kActGeom: return (fKeyClass == "TGeoManager"s);
          default: return false;
       }
 
@@ -266,7 +271,9 @@ class TDirectoryElement : public RElement {
    TDirectory *GetDir()
    {
       if (fDir) {
-         if (!gROOT->GetListOfFiles()->FindObject(fDir->GetFile()))
+         if (fDir->IsZombie())
+            fDir = nullptr;
+         else if (!gROOT->GetListOfFiles()->FindObject(fDir->GetFile()))
             fDir = nullptr;
       } else if (!fFileName.empty()) {
          fDir = TFile::Open(fFileName.c_str());

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -21,7 +21,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <map>
+#include <utility>
 
 namespace ROOT {
 namespace Experimental {
@@ -37,7 +37,7 @@ class RBrowserData {
 
    Browsable::RElementPath_t  fWorkingPath;             ///<! path showed in Breadcrumb
 
-   std::map<Browsable::RElementPath_t, std::shared_ptr<Browsable::RElement>> fCache; ///<! already requested elements
+   std::vector<std::pair<Browsable::RElementPath_t, std::shared_ptr<Browsable::RElement>>> fCache; ///<! already requested elements
 
    Browsable::RElementPath_t fLastPath;                  ///<! path to last used element
    std::shared_ptr<Browsable::RElement> fLastElement;    ///<! last element used in request

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -62,6 +62,8 @@ public:
 
    void SetWorkingPath(const Browsable::RElementPath_t &path);
 
+   void CreateDefaultElements();
+
    const Browsable::RElementPath_t &GetWorkingPath() const { return fWorkingPath; }
 
    std::string ProcessRequest(const RBrowserRequest &request);
@@ -72,7 +74,7 @@ public:
    Browsable::RElementPath_t DecomposePath(const std::string &path, bool relative_to_work_element);
    std::shared_ptr<Browsable::RElement> GetSubElement(const Browsable::RElementPath_t &path);
 
-
+   void ClearCache();
 };
 
 

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -35,7 +35,6 @@ ROOT::Experimental::RLogChannel &ROOT::Experimental::BrowserLog() {
 \brief Way to browse (hopefully) everything in %ROOT
 */
 
-
 /////////////////////////////////////////////////////////////////////
 /// set top element for browsing
 
@@ -227,13 +226,25 @@ std::shared_ptr<Browsable::RElement> RBrowserData::GetSubElement(const Browsable
    if (path.empty())
       return fTopElement;
 
+   // first check direct match in cache
+   for (auto &entry : fCache)
+      if (entry.first == path)
+         return entry.second;
+
    // find best possible entry in cache
    int pos = 0;
    auto elem = fTopElement;
 
    for (auto &entry : fCache) {
+      if (entry.first.size() >= path.size())
+         continue;
+
       auto comp = Browsable::RElement::ComparePaths(path, entry.first);
-      if (comp > pos) { pos = comp; elem = entry.second; }
+
+      if ((comp > pos) && (comp == (int) entry.first.size())) {
+         pos = comp;
+         elem = entry.second;
+      }
    }
 
    while (pos < (int) path.size()) {
@@ -259,8 +270,7 @@ std::shared_ptr<Browsable::RElement> RBrowserData::GetSubElement(const Browsable
 
       auto subpath = path;
       subpath.resize(pos+1);
-      fCache[subpath] = elem;
-
+      fCache.emplace_back(subpath, elem);
       pos++; // switch to next element
    }
 


### PR DESCRIPTION
1. Improve/fix problems with TKey/TDirectory handling.
    In some cases objects were deleted, but still used in RBrowsable classes
2. Fix bug with RBrowsable cache usage. 
    Logic was not working when more than 1 levels of sub-directories in the TFile was there
3. Empty RBrowser cache when top-level path is reloaded. Avoids holding of too many objects which are no longer used