### PR TITLE
Fix #8033: string array StreamerElement not recorded properly

### DIFF
--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -1997,6 +1997,7 @@ void TStreamerSTL::Streamer(TBuffer &R__b)
       tmp.fTitle = fTitle;
       tmp.fType = TVirtualStreamerInfo::kStreamer;
       tmp.fSize = fSize;
+      tmp.fArrayDim = fArrayDim;
       tmp.fArrayLength = fArrayLength;
       for(int i = 0; i < 5; ++i)
          tmp.fMaxIndex[i] = fMaxIndex[i];

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -1955,6 +1955,12 @@ void TStreamerSTL::Streamer(TBuffer &R__b)
          R__b >> fCtype;
          R__b.CheckByteCount(R__s, R__c, TStreamerSTL::IsA());
       }
+      // In old versions (prior to v6.24/02) the value of fArrayDim was not stored properly.
+      if (fArrayDim == 0 && fArrayLength > 0) {
+         while(fArrayDim < 5 && fMaxIndex[fArrayDim] != 0) {
+            ++fArrayDim;
+         }
+      }
       if (fSTLtype == ROOT::kSTLmultimap || fSTLtype == ROOT::kSTLset) {
          // For a long time those where inverted in TStreamerElement
          // compared to the other definitions.  When we moved to version '4',


### PR DESCRIPTION
The number of dimensions was not properly recorded in TStreamerSTL's custom streamer.