### PR TITLE
[ntuple] `std::pair` RField support

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -586,6 +586,11 @@ Variants are stored in $n+1$ fields:
   - Variant mother field of type Switch; the dispatch tag points to the principle column of the active type
   - Child fields of types `T1`, ..., `Tn`; their names are `_0`, `_1`, ...
 
+#### std::pair<T1, T2>
+
+A pair is stored as two fields, i.e. one of type `T1` and one of type `T2`. `T1` and `T2` must be types with RNTuple I/O support.
+The child fileds are named `_0` and `_1`.
+
 ### User-defined classes
 
 User defined C++ classes are supported with the following limitations

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -339,8 +339,6 @@ private:
    std::size_t fMaxAlignment = 1;
    std::size_t fSize = 0;
 
-   std::size_t GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment) const;
-
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
    std::size_t AppendImpl(const Detail::RFieldValue& value) final;
@@ -363,6 +361,7 @@ public:
    size_t GetValueSize() const final { return fSize; }
    size_t GetAlignment() const final { return fMaxAlignment; }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   static std::size_t GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment);
 };
 
 /// The generic field for a (nested) std::vector<Type> except for std::vector<bool>
@@ -1538,6 +1537,66 @@ public:
    }
    size_t GetValueSize() const final { return sizeof(ContainerT); }
    size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
+};
+
+class RPairField : public Detail::RFieldBase {
+private:
+   std::size_t fMaxAlignment = 1;
+   std::size_t fSize = 0;
+   static std::string GetTypeList(
+      const std::pair<Detail::RFieldBase*, Detail::RFieldBase*> &itemFields);
+
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
+   std::size_t AppendImpl(const Detail::RFieldValue& value) final;
+   void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
+   void ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value) final;
+
+public:
+   RPairField(std::string_view fieldName,
+      const std::pair<Detail::RFieldBase*, Detail::RFieldBase*> &itemFields);
+   RPairField(RPairField &&other) = default;
+   RPairField& operator =(RPairField &&other) = default;
+   ~RPairField() = default;
+
+   void GenerateColumnsImpl() final {};
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
+   using Detail::RFieldBase::GenerateValue;
+   Detail::RFieldValue GenerateValue(void *where) override;
+   void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
+   Detail::RFieldValue CaptureValue(void *where) final;
+   size_t GetValueSize() const final { return fSize; }
+   size_t GetAlignment() const final { return fMaxAlignment; }
+};
+
+template <typename T1, typename T2>
+class RField<std::pair<T1, T2>> : public RPairField {
+private:
+   using ContainerT = typename std::pair<T1,T2>;
+   template <typename Ty1, typename Ty2>
+   static std::pair<Detail::RFieldBase*, Detail::RFieldBase*> BuildItemFields()
+   {
+      return std::make_pair(new RField<Ty1>("first"), new RField<Ty2>("second"));
+   }
+
+public:
+   static std::string TypeName() {
+      return "std::pair<" + RField<T1>::TypeName() + "," + RField<T2>::TypeName() + ">";
+   }
+   explicit RField(std::string_view name) : RPairField(name, BuildItemFields<T1, T2>()) {}
+   RField(RField&& other) = default;
+   RField& operator =(RField&& other) = default;
+   ~RField() = default;
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
+   {
+      return Detail::RFieldValue(this, static_cast<ContainerT*>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final {
+      return GenerateValue(where, ContainerT());
+   }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -216,11 +216,10 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
    if (normalizedType.substr(0, 10) == "std::pair<") {
       auto innerTypes = TokenizeTypeList(normalizedType.substr(10, normalizedType.length() - 11));
       R__ASSERT(innerTypes.size() == 2);
-      auto items = std::make_pair(
-         Create("first", innerTypes[0]).Unwrap().release(),
-         Create("second", innerTypes[1]).Unwrap().release()
-      );
-      result = std::make_unique<RPairField>(fieldName, items);
+      std::vector<std::unique_ptr<Detail::RFieldBase>> items;
+      items.push_back(Create("_0", innerTypes[0]).Unwrap());
+      items.push_back(Create("_1", innerTypes[1]).Unwrap());
+      result = std::make_unique<RRecordField>(fieldName, normalizedType, items);
    }
    // TODO: create an RCollectionField?
    if (normalizedType == ":Collection:")
@@ -897,8 +896,8 @@ void ROOT::Experimental::RClassField::AcceptVisitor(Detail::RFieldVisitor &visit
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RRecordField::RRecordField(
-   std::string_view fieldName, std::vector<std::unique_ptr<Detail::RFieldBase>> &itemFields)
-   : ROOT::Experimental::Detail::RFieldBase(fieldName, "", ENTupleStructure::kRecord, false /* isSimple */)
+   std::string_view fieldName, std::string_view type, std::vector<std::unique_ptr<Detail::RFieldBase>> &&itemFields)
+   : ROOT::Experimental::Detail::RFieldBase(fieldName, type, ENTupleStructure::kRecord, false /* isSimple */)
 {
    for (auto &item : itemFields) {
       fMaxAlignment = std::max(fMaxAlignment, item->GetAlignment());
@@ -908,7 +907,7 @@ ROOT::Experimental::RRecordField::RRecordField(
 }
 
 
-std::size_t ROOT::Experimental::RRecordField::GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment)
+std::size_t ROOT::Experimental::RRecordField::GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment) const
 {
    if (itemAlignment > 1) {
       auto remainder = baseOffset % itemAlignment;
@@ -924,7 +923,7 @@ ROOT::Experimental::RRecordField::CloneImpl(std::string_view newName) const
    std::vector<std::unique_ptr<Detail::RFieldBase>> cloneItems;
    for (auto &item : fSubFields)
       cloneItems.emplace_back(item->Clone(item->GetName()));
-   return std::make_unique<RRecordField>(newName, cloneItems);
+   return std::unique_ptr<RRecordField>(new RRecordField(newName, GetType(), cloneItems));
 }
 
 std::size_t ROOT::Experimental::RRecordField::AppendImpl(const Detail::RFieldValue &value) {
@@ -1440,95 +1439,6 @@ void ROOT::Experimental::RVariantField::CommitCluster()
    std::fill(fNWritten.begin(), fNWritten.end(), 0);
 }
 #endif
-
-//------------------------------------------------------------------------------
-
-std::string ROOT::Experimental::RPairField::RPairField::GetTypeList(
-   const std::pair<Detail::RFieldBase*, Detail::RFieldBase*> &itemFields)
-{
-   return itemFields.first->GetType() + "," + itemFields.second->GetType();
-}
-
-ROOT::Experimental::RPairField::RPairField(std::string_view fieldName,
-   const std::pair<Detail::RFieldBase*, Detail::RFieldBase*> &itemFields)
-   : ROOT::Experimental::Detail::RFieldBase(fieldName,
-      "std::pair<" + GetTypeList(itemFields) + ">", ENTupleStructure::kRecord, false /* isSimple */)
-{
-   for (const auto &item : {itemFields.first, itemFields.second}) {
-      fMaxAlignment = std::max(fMaxAlignment, item->GetAlignment());
-      fSize += RRecordField::GetItemPadding(fSize, item->GetAlignment()) + item->GetValueSize();
-      Attach(std::unique_ptr<Detail::RFieldBase>(item));
-   }
-}
-
-std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
-ROOT::Experimental::RPairField::CloneImpl(std::string_view newName) const
-{
-   return std::make_unique<RPairField>(newName, std::make_pair(
-      fSubFields[0]->Clone(fSubFields[0]->GetName()).release(),
-      fSubFields[1]->Clone(fSubFields[1]->GetName()).release()
-   ));
-}
-
-std::size_t ROOT::Experimental::RPairField::AppendImpl(const Detail::RFieldValue& value)
-{
-   std::size_t nbytes = 0;
-   std::size_t offset = 0;
-   for (auto &item : fSubFields) {
-      auto memberValue = item->CaptureValue(value.Get<unsigned char>() + offset);
-      nbytes += item->Append(memberValue);
-      offset += RRecordField::GetItemPadding(offset, item->GetAlignment()) + item->GetValueSize();
-   }
-   return nbytes;
-}
-
-void ROOT::Experimental::RPairField::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value)
-{
-   std::size_t offset = 0;
-   for (auto &item : fSubFields) {
-      auto memberValue = item->CaptureValue(value->Get<unsigned char>() + offset);
-      item->Read(globalIndex, &memberValue);
-      offset += RRecordField::GetItemPadding(offset, item->GetAlignment()) + item->GetValueSize();
-   }
-}
-
-void ROOT::Experimental::RPairField::ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value)
-{
-   std::size_t offset = 0;
-   for (auto &item : fSubFields) {
-      auto memberValue = item->CaptureValue(value->Get<unsigned char>() + offset);
-      item->Read(clusterIndex, &memberValue);
-      offset += RRecordField::GetItemPadding(offset, item->GetAlignment()) + item->GetValueSize();
-   }
-}
-
-ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RPairField::GenerateValue(void *where)
-{
-   std::size_t offset = 0;
-   for (auto &item : fSubFields) {
-      item->GenerateValue(static_cast<unsigned char *>(where) + offset);
-      offset += RRecordField::GetItemPadding(offset, item->GetAlignment()) + item->GetValueSize();
-   }
-   return Detail::RFieldValue(true /* captureFlag */, this, where);
-}
-
-void ROOT::Experimental::RPairField::DestroyValue(const Detail::RFieldValue& value, bool dtorOnly)
-{
-   std::size_t offset = 0;
-   for (auto &item : fSubFields) {
-      auto memberValue = item->CaptureValue(value.Get<unsigned char>() + offset);
-      item->DestroyValue(memberValue, true /* dtorOnly */);
-      offset += RRecordField::GetItemPadding(offset, item->GetAlignment()) + item->GetValueSize();
-   }
-
-   if (!dtorOnly)
-      free(value.GetRawPtr());
-}
-
-ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RPairField::CaptureValue(void *where)
-{
-   return Detail::RFieldValue(true /* captureFlag */, this, where);
-}
 
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -904,6 +904,8 @@ ROOT::Experimental::RRecordField::RRecordField(
       fSize += GetItemPadding(fSize, item->GetAlignment()) + item->GetValueSize();
       Attach(std::move(item));
    }
+   // Trailing padding to comply with the alignment requirements of the type with stricter alignment
+   fSize += GetItemPadding(fSize, fMaxAlignment);
 }
 
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -31,7 +31,6 @@ TEST(RNTuple, StdPair)
    auto field = RField<std::pair<int64_t, float>>("pairField");
    EXPECT_STREQ("std::pair<std::int64_t,float>", field.GetType().c_str());
    auto otherField = RFieldBase::Create("test", "std::pair<int64_t, float>").Unwrap();
-   EXPECT_STREQ(field.GetType().c_str(), otherField->GetType().c_str());
    // sizeof check fails, RPairField does not take into account 4 trailing padding bytes
    EXPECT_EQ((sizeof(std::pair<int64_t, float>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::pair<int64_t, float>)), otherField->GetValueSize());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -31,7 +31,6 @@ TEST(RNTuple, StdPair)
    auto field = RField<std::pair<int64_t, float>>("pairField");
    EXPECT_STREQ("std::pair<std::int64_t,float>", field.GetType().c_str());
    auto otherField = RFieldBase::Create("test", "std::pair<int64_t, float>").Unwrap();
-   // sizeof check fails, RPairField does not take into account 4 trailing padding bytes
    EXPECT_EQ((sizeof(std::pair<int64_t, float>)), field.GetValueSize());
    EXPECT_EQ((sizeof(std::pair<int64_t, float>)), otherField->GetValueSize());
    EXPECT_EQ((alignof(std::pair<int64_t, float>)), field.GetAlignment());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -12,6 +12,9 @@ TEST(RNTuple, TypeName) {
 
    auto field = RField<DerivedB>("derived");
    EXPECT_EQ(sizeof(DerivedB), field.GetValueSize());
+
+   EXPECT_STREQ("std::pair<std::pair<float,CustomStruct>,std::int32_t>", (ROOT::Experimental::RField<
+                 std::pair<std::pair<float,CustomStruct>,int>>::TypeName().c_str()));
 }
 
 
@@ -21,6 +24,50 @@ TEST(RNTuple, CreateField)
    EXPECT_STREQ("std::vector<std::uint32_t>", field->GetType().c_str());
    auto value = field->GenerateValue();
    field->DestroyValue(value);
+}
+
+TEST(RNTuple, StdPair)
+{
+   auto field = RField<std::pair<int64_t, float>>("pairField");
+   EXPECT_STREQ("std::pair<std::int64_t,float>", field.GetType().c_str());
+   auto otherField = RFieldBase::Create("test", "std::pair<int64_t, float>").Unwrap();
+   EXPECT_STREQ(field.GetType().c_str(), otherField->GetType().c_str());
+   // sizeof check fails, RPairField does not take into account 4 trailing padding bytes
+   EXPECT_EQ((sizeof(std::pair<int64_t, float>)), field.GetValueSize());
+   EXPECT_EQ((sizeof(std::pair<int64_t, float>)), otherField->GetValueSize());
+   EXPECT_EQ((alignof(std::pair<int64_t, float>)), field.GetAlignment());
+   EXPECT_EQ((alignof(std::pair<int64_t, float>)), otherField->GetAlignment());
+
+   auto pairPairField = RField<std::pair<std::pair<int64_t, float>,
+      std::vector<std::pair<CustomStruct, double>>>>("pairPairField");
+   EXPECT_STREQ(
+      "std::pair<std::pair<std::int64_t,float>,std::vector<std::pair<CustomStruct,double>>>",
+      pairPairField.GetType().c_str());
+
+   FileRaii fileGuard("test_ntuple_rfield_stdpair.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto pair_field = model->MakeField<std::pair<double, std::string>>(
+         {"myPair", "a very cool field"}
+      );
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "pair_ntuple", fileGuard.GetPath());
+      for (int i = 0; i < 100; i++) {
+         *pair_field = {static_cast<double>(i), std::to_string(i)};
+         ntuple->Fill();
+         if (i % 10 == 0) {
+            ntuple->CommitCluster();
+         }
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("pair_ntuple", fileGuard.GetPath());
+   EXPECT_EQ(100, ntuple->GetNEntries());
+
+   auto viewPair = ntuple->GetView<std::pair<double, std::string>>("myPair");
+   for (auto i : ntuple->GetEntryRange()) {
+      EXPECT_EQ(static_cast<double>(i), viewPair(i).first);
+      EXPECT_EQ(std::to_string(i), viewPair(i).second);
+   }
 }
 
 TEST(RNTuple, Int64_t)
@@ -61,18 +108,6 @@ TEST(RNTuple, UInt16_t)
 
 TEST(RNTuple, UnsupportedStdTypes)
 {
-   try {
-      auto field = RFieldBase::Create("pair_field", "std::pair<int, float>").Unwrap();
-      FAIL() << "should not be able to make a std::pair field";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("pair<int,float> is not supported"));
-   }
-   try {
-      auto field = RField<std::pair<int, float>>("pair_field");
-      FAIL() << "should not be able to make a std::pair field";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("pair<int,float> is not supported"));
-   }
    try {
       auto field = RField<std::weak_ptr<int>>("myWeakPtr");
       FAIL() << "should not be able to make a std::weak_ptr field";


### PR DESCRIPTION
Motivation: `std::pair` is used by one of the NanoAOD auxiliary trees (`ParameterSets`).

The `std::pair` implementation largely follows `RRecordField`. There is a
question about whether `RField<std::pair<T1,T2>>::GetValueSize()` should
equal `sizeof(std::pair<T1,T2>)`, since currently the former does not add
trailing padding bytes, which are implementation defined. 

E.g the following test fails on a 64-bit machine (but would pass on 32bit):

```cpp
auto field = RField<std::pair<int64_t, float>>("pairField");
// sizeof check fails, RPairField does not take into account 4 trailing padding bytes
EXPECT_EQ((sizeof(std::pair<int64_t, float>)), field.GetValueSize());
```
```
Expected equality of these values:
  (sizeof(std::pair<int64_t, float>))
    Which is: 16
  field.GetValueSize()
    Which is: 12
```

(EDIT: this has been fixed in the relevant commit and the PR should be ready for review and merge.)