### PR TITLE
[core] Update RStringView.hxx

### DIFF
--- a/core/foundation/inc/ROOT/RStringView.hxx
+++ b/core/foundation/inc/ROOT/RStringView.hxx
@@ -14,7 +14,7 @@
 
 #include "RConfigure.h"
 
-#if defined(R__HAS_STD_STRING_VIEW) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || ( __cplusplus >= 201703L )
+#if defined(R__HAS_STD_STRING_VIEW) || _MSVC_LANG >= 201703L || __cplusplus >= 201703L
 
 #include <string_view>
 

--- a/core/foundation/inc/ROOT/RStringView.hxx
+++ b/core/foundation/inc/ROOT/RStringView.hxx
@@ -14,7 +14,7 @@
 
 #include "RConfigure.h"
 
-#ifdef R__HAS_STD_STRING_VIEW
+#ifdef R__HAS_STD_STRING_VIEW || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L
 
 #include <string_view>
 
@@ -55,7 +55,7 @@ namespace std {
 
 #endif // ifdef else R__HAS_STD_STRING_VIEW
 
-#ifndef R__HAS_OP_EQUAL_PLUS_STRING_VIEW
+#ifndef R__HAS_OP_EQUAL_PLUS_STRING_VIEW || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L
 
 #include <string>
 

--- a/core/foundation/inc/ROOT/RStringView.hxx
+++ b/core/foundation/inc/ROOT/RStringView.hxx
@@ -55,7 +55,7 @@ namespace std {
 
 #endif // ifdef else R__HAS_STD_STRING_VIEW
 
-#if !defined(R__HAS_OP_EQUAL_PLUS_STRING_VIEW) && !( defined(_MSVC_LANG) && _MSVC_LANG >= 201703L ) && ! ( __cplusplus >= 201703L )
+#if !(defined(R__HAS_OP_EQUAL_PLUS_STRING_VIEW) || _MSVC_LANG >= 201703L || __cplusplus >= 201703L)
 
 #include <string>
 

--- a/core/foundation/inc/ROOT/RStringView.hxx
+++ b/core/foundation/inc/ROOT/RStringView.hxx
@@ -14,7 +14,7 @@
 
 #include "RConfigure.h"
 
-#ifdef R__HAS_STD_STRING_VIEW || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L
+#if defined(R__HAS_STD_STRING_VIEW) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || ( __cplusplus >= 201703L )
 
 #include <string_view>
 
@@ -55,7 +55,7 @@ namespace std {
 
 #endif // ifdef else R__HAS_STD_STRING_VIEW
 
-#ifndef R__HAS_OP_EQUAL_PLUS_STRING_VIEW || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L
+#if !defined(R__HAS_OP_EQUAL_PLUS_STRING_VIEW) && !( defined(_MSVC_LANG) && _MSVC_LANG >= 201703L ) && ! ( __cplusplus >= 201703L )
 
 #include <string>
 


### PR DESCRIPTION
The motivtion of this update is the following:

It would be nice to be able to use ROOT compied with c++14  in projects that require c++ 17.
Right now it is not possible because of this header even if everything was compiled with the same compiller.
e.g. that is the case for recent Fedora builds, where root is build with gcc11 (default c++17) but with c++14 standard.

An alternative is to be able regulate this behaviour with a flag, i.e.
```
#if defined( R__HAS_STD_STRING_VIEW)  ||  ( ROOT_IGNORE_RCONFIGURE  &&  (  (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)  || __cplusplus >= 201703L ) )

#else


```
Best regards,

Andrii