### PR TITLE
Avoid self comparison when sorting RooAbsArg

### DIFF
--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -967,6 +967,8 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
 
   // Step 2 - reorder tracked nodes
   std::sort(trackArgs.begin(), trackArgs.end(), [](RooAbsArg* left, RooAbsArg* right){
+    //LM: exclude same comparison. This avoids an issue when using sort in MacOS  versions
+    if (left == right) return false;
     return right->dependsOn(*left);
   });
 


### PR DESCRIPTION
On MacOS this simple code using std::sort of RooAbsArg crashed because std::sort MacOS implementation goes to element outside of the collection. 
This simple code reproduced the problem by crashing on MacOS

```
 std::vector<RooAbsArg*> v;
   int n = 38;

   for (int i = 0; i < n; ++i) {
      TString name = TString::Format("a_%d",i);
      v.push_back( new RooRealVar (name, name, 10,0,20) );
   }

   std::sort(v.begin(), v.end(), [](RooAbsArg*a, RooAbsArg*b) { return a->dependsOn(*b); } );
```
 
The PR with the simple check avoid a crash observed running the example in 
https://root-forum.cern.ch/t/upper-limit-for-signal-strength-on-off-problem-multiple-independent-runs/44657
