### PR TITLE
[ntuple] Make cluster entries and elements per page configurable

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -247,7 +247,6 @@ triggered by Flush() or by destructing the ntuple.  On I/O errors, an exception 
 // clang-format on
 class RNTupleWriter {
 private:
-   static constexpr NTupleSize_t kDefaultClusterSizeEntries = 64000;
    std::unique_ptr<Detail::RPageSink> fSink;
    /// Needs to be destructed before fSink
    std::unique_ptr<RNTupleModel> fModel;
@@ -282,7 +281,7 @@ public:
          value.GetField()->Append(value);
       }
       fNEntries++;
-      if ((fNEntries % fClusterSizeEntries) == 0)
+      if ((fNEntries % fSink->GetWriteOptions().GetNClusterEntries()) == 0)
          CommitCluster();
    }
    /// Ensure that the data from the so far seen Fill calls has been written to storage

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -30,8 +30,8 @@ namespace Experimental {
 */
 // clang-format on
 enum class ENTupleContainerFormat {
-  kTFile, // ROOT TFile
-  kBare, // A thin envelope supporting a single RNTuple only
+   kTFile, // ROOT TFile
+   kBare, // A thin envelope supporting a single RNTuple only
 };
 
 
@@ -45,30 +45,30 @@ All page sink classes need to support the common options.
 */
 // clang-format on
 class RNTupleWriteOptions {
-  int fCompression{RCompressionSetting::EDefaults::kUseAnalysis};
-  ENTupleContainerFormat fContainerFormat{ENTupleContainerFormat::kTFile};
-  NTupleSize_t fNClusterEntries = 64000;
-  NTupleSize_t fNElementsPerPage = 10000;
-  bool fUseBufferedWrite = true;
+   int fCompression{RCompressionSetting::EDefaults::kUseAnalysis};
+   ENTupleContainerFormat fContainerFormat{ENTupleContainerFormat::kTFile};
+   NTupleSize_t fNClusterEntries = 64000;
+   NTupleSize_t fNElementsPerPage = 10000;
+   bool fUseBufferedWrite = true;
 
 public:
-  int GetCompression() const { return fCompression; }
-  void SetCompression(int val) { fCompression = val; }
-  void SetCompression(RCompressionSetting::EAlgorithm algorithm, int compressionLevel) {
-    fCompression = CompressionSettings(algorithm, compressionLevel);
-  }
+   int GetCompression() const { return fCompression; }
+   void SetCompression(int val) { fCompression = val; }
+   void SetCompression(RCompressionSetting::EAlgorithm algorithm, int compressionLevel) {
+     fCompression = CompressionSettings(algorithm, compressionLevel);
+   }
 
-  ENTupleContainerFormat GetContainerFormat() const { return fContainerFormat; }
-  void SetContainerFormat(ENTupleContainerFormat val) { fContainerFormat = val; }
+   ENTupleContainerFormat GetContainerFormat() const { return fContainerFormat; }
+   void SetContainerFormat(ENTupleContainerFormat val) { fContainerFormat = val; }
 
-  NTupleSize_t GetNClusterEntries() const { return fNClusterEntries; }
-  void SetNClusterEntries(NTupleSize_t val) { fNClusterEntries = val; }
+   NTupleSize_t GetNClusterEntries() const { return fNClusterEntries; }
+   void SetNClusterEntries(NTupleSize_t val) { fNClusterEntries = val; }
 
-  NTupleSize_t GetNElementsPerPage() const { return fNElementsPerPage; }
-  void SetNElementsPerPage(NTupleSize_t val) { fNElementsPerPage = val; }
+   NTupleSize_t GetNElementsPerPage() const { return fNElementsPerPage; }
+   void SetNElementsPerPage(NTupleSize_t val) { fNElementsPerPage = val; }
 
-  bool GetUseBufferedWrite() const { return fUseBufferedWrite; }
-  void SetUseBufferedWrite(bool val) { fUseBufferedWrite = val; }
+   bool GetUseBufferedWrite() const { return fUseBufferedWrite; }
+   void SetUseBufferedWrite(bool val) { fUseBufferedWrite = val; }
 };
 
 
@@ -83,7 +83,7 @@ All page source classes need to support the common options.
 // clang-format on
 class RNTupleReadOptions {
 public:
-  enum EClusterCache {
+   enum EClusterCache {
       kOff,
       kOn,
       kDefault = kOn,

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RNTupleOptions
 
 #include <Compression.h>
+#include <ROOT/RNTupleUtil.hxx>
 
 namespace ROOT {
 namespace Experimental {
@@ -46,6 +47,7 @@ All page sink classes need to support the common options.
 class RNTupleWriteOptions {
   int fCompression{RCompressionSetting::EDefaults::kUseAnalysis};
   ENTupleContainerFormat fContainerFormat{ENTupleContainerFormat::kTFile};
+  NTupleSize_t fNClusterEntries = 64000;
   bool fUseBufferedWrite = true;
 
 public:
@@ -57,6 +59,9 @@ public:
 
   ENTupleContainerFormat GetContainerFormat() const { return fContainerFormat; }
   void SetContainerFormat(ENTupleContainerFormat val) { fContainerFormat = val; }
+
+  NTupleSize_t GetNClusterEntries() const { return fNClusterEntries; }
+  void SetNClusterEntries(NTupleSize_t val) { fNClusterEntries = val; }
 
   bool GetUseBufferedWrite() const { return fUseBufferedWrite; }
   void SetUseBufferedWrite(bool val) { fUseBufferedWrite = val; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -48,6 +48,7 @@ class RNTupleWriteOptions {
   int fCompression{RCompressionSetting::EDefaults::kUseAnalysis};
   ENTupleContainerFormat fContainerFormat{ENTupleContainerFormat::kTFile};
   NTupleSize_t fNClusterEntries = 64000;
+  NTupleSize_t fNElementsPerPage = 10000;
   bool fUseBufferedWrite = true;
 
 public:
@@ -62,6 +63,9 @@ public:
 
   NTupleSize_t GetNClusterEntries() const { return fNClusterEntries; }
   void SetNClusterEntries(NTupleSize_t val) { fNClusterEntries = val; }
+
+  NTupleSize_t GetNElementsPerPage() const { return fNElementsPerPage; }
+  void SetNElementsPerPage(NTupleSize_t val) { fNElementsPerPage = val; }
 
   bool GetUseBufferedWrite() const { return fUseBufferedWrite; }
   void SetUseBufferedWrite(bool val) { fUseBufferedWrite = val; }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -86,8 +86,6 @@ Currently, an object is allocated for each page + 3 additional objects (anchor/h
 // clang-format on
 class RPageSinkDaos : public RPageSink {
 private:
-   static constexpr std::size_t kDefaultElementsPerPage = 10000;
-
    RNTupleMetrics fMetrics;
    std::unique_ptr<RPageAllocatorHeap> fPageAllocator;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -54,9 +54,6 @@ The written file can be either in ROOT format or in RNTuple bare format.
 */
 // clang-format on
 class RPageSinkFile : public RPageSink {
-public:
-   static constexpr std::size_t kDefaultElementsPerPage = 10000;
-
 private:
    /// I/O performance counters that get registered in fMetrics
    struct RCounters {

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -272,7 +272,6 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
    : fSink(std::move(sink))
    , fModel(std::move(model))
    , fMetrics("RNTupleWriter")
-   , fClusterSizeEntries(kDefaultClusterSizeEntries)
    , fLastCommitted(0)
    , fNEntries(0)
 {

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -220,7 +220,7 @@ ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSinkDaos::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
 {
    if (nElements == 0)
-      nElements = kDefaultElementsPerPage;
+      nElements = fOptions.GetNElementsPerPage();
    auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
    return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -171,7 +171,7 @@ ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSinkFile::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
 {
    if (nElements == 0)
-      nElements = kDefaultElementsPerPage;
+      nElements = fOptions.GetNElementsPerPage();
    auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
    return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -212,6 +212,27 @@ TEST(RNTuple, Clusters)
    EXPECT_EQ(24.0, (*rdFourVec)[1]);
 }
 
+TEST(RNTuple, ClusterEntries)
+{
+   FileRaii fileGuard("test_ntuple_cluster_entries.root");
+   auto model = RNTupleModel::Create();
+   auto field = model->MakeField<float>({"pt", "transverse momentum"}, 42.0);
+
+   {
+      RNTupleWriteOptions opt;
+      opt.SetNClusterEntries(5);
+      auto ntuple = RNTupleWriter::Recreate(
+         std::move(model), "ntuple", fileGuard.GetPath(), opt
+      );
+      for (int i = 0; i < 100; i++) {
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   // 100 entries / 5 entries per cluster
+   EXPECT_EQ(20, ntuple->GetDescriptor().GetNClusters());
+}
 
 TEST(RNTupleModel, EnforceValidFieldNames)
 {


### PR DESCRIPTION
Allow users to adjust the number of entries per cluster and the number of elements per page using `RNTupleWriteOptions`. 
I also took the opportunity to fix some whitespace errors in `RNTupleOptions.hxx`. Fixes #7853.

Usage (see tests as well): 
```cpp
RNTupleWriteOptions opt;
opt.SetNClusterEntries(100000);
opt.SetNElementsPerPage(40000);
auto ntuple = RNTupleWriter::Recreate(
   std::move(model), "ntuple", fileGuard.GetPath(), opt
);
```

As was pointed out in https://github.com/root-project/root/pull/7112#issue-564081466, there are some `NElementsPerPage` inputs that could cause compression problems (i.e. those where the total page memory is larger than `0xffffff`). Should we have some error checking at the `RNTupleWriteOptions` level? Or maybe this should be considered a bug on the compression side of things.

cc @jalopezg-r00t 