### PR TITLE
Eve-7 Use server threads

### DIFF
--- a/graf3d/eve7/inc/LinkDef.h
+++ b/graf3d/eve7/inc/LinkDef.h
@@ -75,9 +75,12 @@
 // REveTrans
 #pragma link C++ class ROOT::Experimental::REveTrans-;
 
+// REveTypes
+#pragma link C++ class ROOT::Experimental::REveException+;
+#pragma link C++ class ROOT::Experimental::REveLog+;
+
 // REveUtil
 #pragma link C++ class ROOT::Experimental::REveUtil+;
-#pragma link C++ class ROOT::Experimental::REveException+;
 #pragma link C++ class ROOT::Experimental::REveGeoManagerHolder+;
 #pragma link C++ class ROOT::Experimental::REveRefCnt+;
 #pragma link C++ class ROOT::Experimental::REveRefBackPtr+;

--- a/graf3d/eve7/inc/LinkDef.h
+++ b/graf3d/eve7/inc/LinkDef.h
@@ -85,8 +85,6 @@
 // REveManager
 #pragma link C++ class ROOT::Experimental::REveManager+;
 #pragma link C++ global ROOT::Experimental::gEve;
-#pragma link C++ class ROOT::Experimental::REveManager::RRedrawDisabler+;
-#pragma link C++ class ROOT::Experimental::REveManager::RExceptionHandler+;
 
 // REveVSD
 #pragma link C++ class ROOT::Experimental::REveMCTrack+;

--- a/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
@@ -136,7 +136,7 @@ public:
   }
    REveDataItemList* GetItemList() {return fItemList;}
 
-   void SetFilterExpr(const TString &filter);
+   void SetFilterExpr(const char* filter);
    void ApplyFilter();
 
    Int_t GetNItems() const { return (Int_t) fItemList->fItems.size(); }

--- a/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilder.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilder.hxx
@@ -12,6 +12,7 @@
 #ifndef ROOT7_REveDataProxySimpleBuilder
 #define ROOT7_REveDataProxySimpleBuilder
 
+#include<list>
 #include <ROOT/REveDataProxyBuilderBase.hxx>
 
 namespace ROOT {
@@ -20,11 +21,32 @@ namespace Experimental {
 class REveDataCollection;
 class REveElement;
 
+class REveCollectionCompound : public REveCompound // ?? Should this be in as REveDataSimpleProxyBuilder.hxx ?????
+{
+private:
+   REveDataCollection *fCollection{nullptr};   
+public:
+   REveCollectionCompound(REveDataCollection *c);
+   virtual ~REveCollectionCompound();
+   virtual REveElement *GetSelectionMaster() override;
+};
+
+//
+//____________________________________________________________________________________
+//
 class REveDataSimpleProxyBuilder : public REveDataProxyBuilderBase
 {
+
 public:
    REveDataSimpleProxyBuilder();
    virtual ~REveDataSimpleProxyBuilder();
+
+   struct SPBProduct {
+      std::map<int, REveCollectionCompound*> map;
+      std::list<REveCollectionCompound*> cache;
+   }; 
+   
+   typedef  std::map<REveElement*, std::unique_ptr<SPBProduct*> > EProductMap_t;
 
 protected:
    void Build(const REveDataCollection* iCollection, REveElement* product, const REveViewContext*) override;
@@ -39,9 +61,9 @@ protected:
    void ModelChanges(const REveDataCollection::Ids_t& iIds, Product* p) override;
    void FillImpliedSelected(REveElement::Set_t& impSet, Product* p) override;
    void Clean() override; // Utility
-   REveCompound* CreateCompound(bool set_color=true, bool propagate_color_to_all_children=false);
+   REveCollectionCompound* CreateCompound(bool set_color=true, bool propagate_color_to_all_children=false);
 
-
+   //int GetItemIdxForCompound() const;
 private:
    REveDataSimpleProxyBuilder(const REveDataSimpleProxyBuilder&); // stop default
 
@@ -49,22 +71,11 @@ private:
 
    bool VisibilityModelChanges(int idx, REveElement*, const std::string& viewType, const REveViewContext*) override;
 
+ std::map<REveElement*, SPBProduct*> fProductMap;
+   REveCompound* GetHolder(REveElement *product, int idx);
+
 };
 //==============================================================================
-
-class REveCollectionCompound : public REveCompound // ?? Should this be in as REveDataSimpleProxyBuilder.hxx ?????
-{
-private:
-   REveDataCollection* fCollection {nullptr};
-
-public:
-   REveCollectionCompound(REveDataCollection* c);
-   virtual ~REveCollectionCompound();
-   //   Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
-
-   // virtual REveElement* GetSelectionMaster(const bool &secondary = false, const std::set<int>& secondary_idcs = {});
-   virtual REveElement* GetSelectionMaster() override;
-};
 
 
 } // namespace Experimental

--- a/graf3d/eve7/inc/ROOT/REveDataTable.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataTable.hxx
@@ -50,6 +50,7 @@ public:
    TString fExpression;
    FieldType_e fType; // can we auto detect this?
    Int_t fPrecision{2};
+   TClass* fClassType{nullptr};
 
    std::string fTrue{"*"};
    std::string fFalse{" "};
@@ -64,6 +65,7 @@ public:
 
    void SetExpressionAndType(const std::string &expr, FieldType_e type);
    void SetExpressionAndType(const std::string &expr, FieldType_e type, TClass* c);
+   std::string GetFunctionExpressionString() const;
    void SetPrecision(Int_t prec);
 
    std::string EvalExpr(void *iptr) const;

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -17,7 +17,6 @@
 #include <ROOT/RWebDisplayArgs.hxx>
 
 #include "TSysEvtHandler.h"
-#include "TTimer.h"
 
 #include <thread>
 #include <mutex>
@@ -55,9 +54,7 @@ public:
       RExceptionHandler() : TStdExceptionHandler() { Add(); }
       virtual ~RExceptionHandler()                 { Remove(); }
 
-      virtual EStatus  Handle(std::exception& exc);
-
-      ClassDef(RExceptionHandler, 0);
+      virtual EStatus Handle(std::exception& exc);
    };
 
    class ChangeGuard {
@@ -118,7 +115,6 @@ protected:
    Bool_t                    fResetCameras{kFALSE};
    Bool_t                    fDropLogicals{kFALSE};
    Bool_t                    fKeepEmptyCont{kFALSE};
-   Bool_t                    fTimerActive{kFALSE};
 
    // ElementId management
    std::unordered_map<ElementId_t, REveElement*> fElementIdMap;
@@ -234,12 +230,12 @@ public:
 
    static REveManager* Create();
    static void         Terminate();
+   static void         ExecuteInMainThread(std::function<void()> func);
+   static void         QuitRoot();
 
 
    // Access to internals, needed for low-level control in advanced
    // applications.
-
-   void EnforceTimerActive (Bool_t ta) { fTimerActive = ta; }
 
    std::shared_ptr<RWebWindow> GetWebWindow() const { return fWebWindow; }
 

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -252,10 +252,6 @@ public:
    void Send(unsigned connid, const std::string &data);
    void SendBinary(unsigned connid, const void *data, std::size_t len);
 
-   void DestroyElementsOf(REveElement::List_t &els);
-
-   void BroadcastElementsOf(REveElement::List_t &els);
-
    void Show(const RWebDisplayArgs &args = "");
 
    std::shared_ptr<REveGeomViewer> ShowGeometry(const RWebDisplayArgs &args = "");

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -50,27 +50,6 @@ class REveManager
    REveManager& operator=(const REveManager&) = delete;
 
 public:
-/*
-   class RRedrawDisabler {
-   private:
-      RRedrawDisabler(const RRedrawDisabler &) = delete;
-      RRedrawDisabler &operator=(const RRedrawDisabler &) = delete;
-
-      REveManager *fMgr{nullptr};
-
-   public:
-      RRedrawDisabler(REveManager *m) : fMgr(m)
-      {
-         if (fMgr)
-            fMgr->DisableRedraw();
-      }
-      virtual ~RRedrawDisabler()
-      {
-         if (fMgr)
-            fMgr->EnableRedraw();
-      }
-   };
-*/
    class RExceptionHandler : public TStdExceptionHandler {
    public:
       RExceptionHandler() : TStdExceptionHandler() { Add(); }

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -44,6 +44,7 @@ class REveSceneList;
 class RWebWindow;
 class REveGeomViewer;
 
+
 class REveManager
 {
    REveManager(const REveManager&) = delete;
@@ -58,6 +59,12 @@ public:
       virtual EStatus  Handle(std::exception& exc);
 
       ClassDef(RExceptionHandler, 0);
+   };
+
+   class ChangeGuard {
+      public:
+      ChangeGuard();
+      ~ChangeGuard();
    };
 
    struct Conn
@@ -162,6 +169,9 @@ public:
 
    REveViewer *SpawnNewViewer(const char *name, const char *title = "");
    REveScene *SpawnNewScene(const char *name, const char *title = "");
+
+   void BeginChangeGuard();
+   void EndChangeGuard();
 
    void SceneSubscriberProcessingChanges(unsigned cinnId);
    void SceneSubscriberWaitingResponse(unsigned cinnId);

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -129,7 +129,7 @@ protected:
 
    std::shared_ptr<ROOT::Experimental::RWebWindow>  fWebWindow;
    std::vector<Conn>                                fConnList;
-   std::queue<MIR*>                                 fMIRqueue;
+   std::queue<std::shared_ptr<MIR> >                                 fMIRqueue;
 
    std::thread                                      fMIRExecThread;
 
@@ -140,7 +140,7 @@ protected:
    void WindowDisconnect(unsigned connid);
 
    void MIRExecThread();
-   void ExecuteMIR(MIR* mir);
+   void ExecuteMIR(std::shared_ptr<MIR> mir);
    void PublishChanges();
 
 public:

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -81,6 +81,17 @@ public:
       EServerState fVal{Waiting};
    };
 
+   class MIR
+   {
+      public:
+       MIR(const std::string& cmd, ElementId_t id, const std::string& ctype)
+       :fCmd(cmd), fId(id), fCtype(ctype){}
+
+       std::string fCmd;
+       ElementId_t fId;
+       std::string fCtype;
+   };
+
 protected:
    RExceptionHandler        *fExcHandler{nullptr};   //!< exception handler
 
@@ -118,7 +129,7 @@ protected:
 
    std::shared_ptr<ROOT::Experimental::RWebWindow>  fWebWindow;
    std::vector<Conn>                                fConnList;
-   std::queue<std::string>                          fMIRqueue;
+   std::queue<MIR*>                                 fMIRqueue;
 
    std::thread                                      fMIRExecThread;
 
@@ -129,7 +140,7 @@ protected:
    void WindowDisconnect(unsigned connid);
 
    void MIRExecThread();
-   void ExecuteMIR(const std::string &cmd);
+   void ExecuteMIR(MIR* mir);
    void PublishChanges();
 
 public:
@@ -214,7 +225,7 @@ public:
    void SetDefaultHtmlPage(const std::string& path);
    void SetClientVersion(const std::string& version);
 
-   void ScheduleMIR(const std::string &cmd);
+   void ScheduleMIR(const std::string &cmd, ElementId_t i, const std::string& ctype);
 
    static REveManager* Create();
    static void         Terminate();

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -164,8 +164,8 @@ public:
    REveViewer *SpawnNewViewer(const char *name, const char *title = "");
    REveScene  *SpawnNewScene (const char *name, const char *title = "");
 
-   void BeginChangeGuard();
-   void EndChangeGuard();
+   void BeginChange();
+   void EndChange();
 
    void SceneSubscriberProcessingChanges(unsigned cinnId);
    void SceneSubscriberWaitingResponse(unsigned cinnId);

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -49,6 +49,7 @@ class REveManager
    REveManager& operator=(const REveManager&) = delete;
 
 public:
+/*
    class RRedrawDisabler {
    private:
       RRedrawDisabler(const RRedrawDisabler &) = delete;
@@ -68,7 +69,7 @@ public:
             fMgr->EnableRedraw();
       }
    };
-
+*/
    class RExceptionHandler : public TStdExceptionHandler {
    public:
       RExceptionHandler() : TStdExceptionHandler() { Add(); }
@@ -121,14 +122,10 @@ protected:
 
    REveScene                *fGlobalScene{nullptr};
    REveScene                *fEventScene{nullptr};
-
-   Int_t                     fRedrawDisabled{0};
-   Bool_t                    fFullRedraw{kFALSE};
    Bool_t                    fResetCameras{kFALSE};
    Bool_t                    fDropLogicals{kFALSE};
    Bool_t                    fKeepEmptyCont{kFALSE};
    Bool_t                    fTimerActive{kFALSE};
-   TTimer                    fRedrawTimer;
 
    // ElementId management
    std::unordered_map<ElementId_t, REveElement*> fElementIdMap;
@@ -184,14 +181,12 @@ public:
    TFolder *GetMacroFolder() const { return fMacroFolder; }
    TMacro *GetMacro(const char *name) const;
 
-   void DisableRedraw() { ++fRedrawDisabled; }
-   void EnableRedraw()  { --fRedrawDisabled; if (fRedrawDisabled <= 0) Redraw3D(); }
+   void DisableRedraw() { printf("REveManager::DisableRedraw obsolete \n");}
+   void EnableRedraw()  {  printf("REveManager::EnableRedraw obsolete \n");}
 
    void Redraw3D(Bool_t resetCameras = kFALSE, Bool_t dropLogicals = kFALSE)
    {
-      if (fRedrawDisabled <= 0 && !fTimerActive) RegisterRedraw3D();
-      if (resetCameras) fResetCameras = kTRUE;
-      if (dropLogicals) fDropLogicals = kTRUE;
+     printf("REveManager::Redraw3D oboslete %d %d\n",resetCameras , dropLogicals);
    }
    void RegisterRedraw3D();
    void DoRedraw3D();
@@ -245,6 +240,7 @@ public:
 
 
    void ExecuteCommand(const std::string &cmd);
+   void PublishChanges();
 
    // Access to internals, needed for low-level control in advanced
    // applications.

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -134,7 +134,7 @@ protected:
    // MIR execution
    std::thread       fMIRExecThread;
    ServerState       fServerState;
-   std::unordered_map<std::string, TMethodCall*> fMethCallMap;
+   std::unordered_map<std::string, std::shared_ptr<TMethodCall> > fMethCallMap;
 
    void WindowConnect(unsigned connid);
    void WindowData(unsigned connid, const std::string &arg);

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -28,9 +28,8 @@
 
 class TMap;
 class TExMap;
-class TMacro;
-class TFolder;
 class TGeoManager;
+class TMethodCall;
 
 namespace ROOT {
 namespace Experimental {
@@ -109,8 +108,6 @@ protected:
    TMap                     *fGeometries{nullptr};      //  TODO: use std::map<std::string, std::unique_ptr<TGeoManager>>
    TMap                     *fGeometryAliases{nullptr}; //  TODO: use std::map<std::string, std::string>
 
-   TFolder                  *fMacroFolder{nullptr};
-
    REveScene                *fWorld{nullptr};
 
    REveViewerList           *fViewers{nullptr};
@@ -136,11 +133,12 @@ protected:
 
    std::shared_ptr<ROOT::Experimental::RWebWindow>  fWebWindow;
    std::vector<Conn>                                fConnList;
-   std::queue<std::shared_ptr<MIR> >                                 fMIRqueue;
+   std::queue<std::shared_ptr<MIR> >                fMIRqueue;
 
-   std::thread                                      fMIRExecThread;
-
+   // MIR execution
+   std::thread       fMIRExecThread;
    ServerState       fServerState;
+   std::unordered_map<std::string, TMethodCall*> fMethCallMap;
 
    void WindowConnect(unsigned connid);
    void WindowData(unsigned connid, const std::string &arg);
@@ -159,16 +157,16 @@ public:
    REveSelection *GetSelection() const { return fSelection; }
    REveSelection *GetHighlight() const { return fHighlight; }
 
-   REveSceneList *GetScenes() const { return fScenes; }
+   REveSceneList  *GetScenes()  const { return fScenes;  }
    REveViewerList *GetViewers() const { return fViewers; }
 
    REveScene *GetGlobalScene() const { return fGlobalScene; }
-   REveScene *GetEventScene() const { return fEventScene; }
+   REveScene *GetEventScene()  const { return fEventScene;  }
 
    REveScene *GetWorld() const { return fWorld; }
 
    REveViewer *SpawnNewViewer(const char *name, const char *title = "");
-   REveScene *SpawnNewScene(const char *name, const char *title = "");
+   REveScene  *SpawnNewScene (const char *name, const char *title = "");
 
    void BeginChangeGuard();
    void EndChangeGuard();
@@ -178,11 +176,8 @@ public:
 
    bool ClientConnectionsFree() const;
 
-   TFolder *GetMacroFolder() const { return fMacroFolder; }
-   TMacro *GetMacro(const char *name) const;
-
-   void DisableRedraw() { printf("REveManager::DisableRedraw obsolete \n");}
-   void EnableRedraw()  {  printf("REveManager::EnableRedraw obsolete \n");}
+   void DisableRedraw() { printf("REveManager::DisableRedraw obsolete \n"); }
+   void EnableRedraw()  { printf("REveManager::EnableRedraw obsolete \n");  }
 
    void Redraw3D(Bool_t resetCameras = kFALSE, Bool_t dropLogicals = kFALSE)
    {

--- a/graf3d/eve7/inc/ROOT/REveScene.hxx
+++ b/graf3d/eve7/inc/ROOT/REveScene.hxx
@@ -144,7 +144,7 @@ public:
 
    // void DestroyElementRenderers(REveElement* element);
    void AcceptChanges(bool);
-
+   bool AnyChanges() const;
    void ProcessSceneChanges();
 };
 

--- a/graf3d/eve7/inc/ROOT/REveSelection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSelection.hxx
@@ -145,6 +145,7 @@ public:
    virtual void UserUnPickedElement(REveElement *el);
 
    void NewElementPicked(ElementId_t id, bool multi, bool secondary, const std::set<int>& secondary_idcs={});
+   void NewElementPickedStr(ElementId_t id, bool multi, bool secondary, const char* secondary_idcs="");
    void ClearSelection();
 
    int  RemoveImpliedSelectedReferencesTo(REveElement *el);

--- a/graf3d/eve7/inc/ROOT/REveTableInfo.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTableInfo.hxx
@@ -94,7 +94,7 @@ public:
    void SetDisplayedCollection(ElementId_t);
    ElementId_t GetDisplayedCollection() const  { return fDisplayedCollection; }
 
-   void AddNewColumnToCurrentCollection(const std::string& expr, const std::string& title, int prec = 2);
+   void AddNewColumnToCurrentCollection(const char* expr, const char* title, int prec = 2);
 
    void AddDelegate(Delegate_t d) { fDelegates.push_back(d); }
 

--- a/graf3d/eve7/inc/ROOT/REveTypes.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTypes.hxx
@@ -53,6 +53,25 @@ REveException operator+(const REveException &s1, const TString &s2);
 REveException operator+(const REveException &s1, const char *s2);
 REveException operator+(const REveException &s1, ElementId_t x);
 
+////////////////////////////////////////////////////////////////////////////////
+/// REveLogger
+/// Collect log entries during building of Eve scenes / objects and report
+/// them to stdout and to web clients.
+////////////////////////////////////////////////////////////////////////////////
+
+class REveLog
+{
+   friend class REveManager; // ?
+   std::string fLog;
+public:
+   void add(const char* txt);
+   void add(const std::string& txt);
+   bool has_contents();
+   void clear();
+};
+
+extern thread_local REveLog gEveLog;
+
 } // namespace Experimental
 } // namespace ROOT
 

--- a/graf3d/eve7/inc/ROOT/REveTypes.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTypes.hxx
@@ -18,6 +18,7 @@
 #include "TString.h"
 
 #include <sstream>
+#include <iostream>
 class TGeoManager;
 
 namespace ROOT {
@@ -70,7 +71,13 @@ public:
    bool has_contents();
    void clear();
 
-   REveLog& operator << (const std::string& txt);
+   template <typename T>
+   REveLog &operator<<(const T &x)
+   {
+      fLog << x;
+      std::cout << x;
+      return *this;
+   }
 
    REveLog &operator<<(std::ostream &(*os)(std::ostream &));
 };

--- a/graf3d/eve7/inc/ROOT/REveTypes.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTypes.hxx
@@ -17,6 +17,7 @@
 
 #include "TString.h"
 
+#include <sstream>
 class TGeoManager;
 
 namespace ROOT {
@@ -61,13 +62,25 @@ REveException operator+(const REveException &s1, ElementId_t x);
 
 class REveLog
 {
-   friend class REveManager; // ?
-   std::string fLog;
+   friend class REveManager;
+   std::stringstream fLog;
 public:
    void add(const char* txt);
    void add(const std::string& txt);
    bool has_contents();
    void clear();
+
+   REveLog& operator << (const std::string& txt)
+   {
+      add(txt);
+      return *this;
+   }
+
+   REveLog &operator<<(std::ostream &(*os)(std::ostream &))
+   {
+      fLog << os;
+      return *this;
+   }
 };
 
 extern thread_local REveLog gEveLog;

--- a/graf3d/eve7/inc/ROOT/REveTypes.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTypes.hxx
@@ -70,17 +70,9 @@ public:
    bool has_contents();
    void clear();
 
-   REveLog& operator << (const std::string& txt)
-   {
-      add(txt);
-      return *this;
-   }
+   REveLog& operator << (const std::string& txt);
 
-   REveLog &operator<<(std::ostream &(*os)(std::ostream &))
-   {
-      fLog << os;
-      return *this;
-   }
+   REveLog &operator<<(std::ostream &(*os)(std::ostream &));
 };
 
 extern thread_local REveLog gEveLog;

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -268,7 +268,7 @@ void REveDataCollection::SetFilterExpr(const TString& filter)
    }
    catch (const std::exception &exc)
    {
-      gEveLog.add(Form("EveDataCollection::SetFilterExpr %s\n", exc.what()));
+      gEveLog << "EveDataCollection::SetFilterExpr" << exc.what();
    }
 }
 

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -247,7 +247,7 @@ void REveDataCollection::AddItem(void *data_ptr, const std::string& /*n*/, const
 
 //------------------------------------------------------------------------------
 
-void REveDataCollection::SetFilterExpr(const TString& filter)
+void REveDataCollection::SetFilterExpr(const char* filter)
 {
    static const REveException eh("REveDataCollection::SetFilterExpr ");
 

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -258,7 +258,7 @@ void REveDataCollection::SetFilterExpr(const char* filter)
    std::stringstream s;
    s << "*((std::function<bool(" << fItemClass->GetName() << "*)>*)" << std::hex << std::showbase << (size_t)&fFilterFoo
      << ") = [](" << fItemClass->GetName() << "* p){" << fItemClass->GetName() << " &i=*p; return ("
-     << fFilterExpr.Data() << "); }";
+     << fFilterExpr.Data() << "); };";
 
    // printf("%s\n", s.Data());
    try {

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -268,7 +268,7 @@ void REveDataCollection::SetFilterExpr(const TString& filter)
    }
    catch (const std::exception &exc)
    {
-      std::cerr << "EveDataCollection::SetFilterExpr" << exc.what();
+      gEveLog.add(Form("EveDataCollection::SetFilterExpr %s\n", exc.what()));
    }
 }
 

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -158,8 +158,7 @@ void REveDataProxyBuilderBase::Build()
       }
       catch (const std::runtime_error& iException)
       {
-         std::cout << "Caught exception in build function for item " << m_collection->GetName() << ":\n"
-                              << iException.what() << std::endl;
+         gEveLog.add(Form("Caught exception in build function for item %s: %s\n", m_collection->GetCName(), iException.what()));
          exit(1);
       }
    }

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -156,10 +156,9 @@ void REveDataProxyBuilderBase::Build()
             */
          }
       }
-      catch (const std::runtime_error& iException)
-      {
-         gEveLog.add(Form("Caught exception in build function for item %s: %s\n", m_collection->GetCName(), iException.what()));
-         exit(1);
+      catch (const std::runtime_error &iException) {
+         gEveLog << "Caught exception in build function for item " << m_collection->GetName() << ":\n"
+                 << iException.what() << std::endl;
       }
    }
 }

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -276,7 +276,8 @@ REveElement *REveCollectionCompound::GetSelectionMaster()
       // printf("REveCollectionCompound::GetSelectionMaster %d\n", idx);
       fCollection->GetItemList()->RefSelectedSet().insert(idx);
    } catch (std::exception& e) {
-      gEveLog.add(Form("REveCollectionCompound::GetSelectionMaster %s \n", e.what()));
+       gEveLog << "REveCollectionCompound::GetSelectionMaster " << e.what() << std::endl;
+       fCollection->GetItemList()->RefSelectedSet().insert(0);
    }
    return fCollection->GetItemList();
 }

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -276,8 +276,7 @@ REveElement *REveCollectionCompound::GetSelectionMaster()
       // printf("REveCollectionCompound::GetSelectionMaster %d\n", idx);
       fCollection->GetItemList()->RefSelectedSet().insert(idx);
    } catch (std::exception& e) {
-      std::cout << "REveCollectionCompound::GetSelectionMaster " << e.what() << std::endl;
-      fCollection->GetItemList()->RefSelectedSet().insert(0);
+      gEveLog.add(Form("REveCollectionCompound::GetSelectionMaster %s \n", e.what()));
    }
    return fCollection->GetItemList();
 }

--- a/graf3d/eve7/src/REveDataTable.cxx
+++ b/graf3d/eve7/src/REveDataTable.cxx
@@ -121,7 +121,7 @@ void REveDataColumn::SetExpressionAndType(const std::string& expr, FieldType_e t
    }
    catch (const std::exception &exc)
    {
-      std::cerr << "REveDataColumn::SetExpressionAndType" << exc.what();
+      gEveLog.add(Form("REveDataColumn::SetExpressionAndType %s\n", exc.what()));
    }
 }
 //______________________________________________________________________________

--- a/graf3d/eve7/src/REveDataTable.cxx
+++ b/graf3d/eve7/src/REveDataTable.cxx
@@ -121,7 +121,7 @@ void REveDataColumn::SetExpressionAndType(const std::string& expr, FieldType_e t
    }
    catch (const std::exception &exc)
    {
-      gEveLog.add(Form("REveDataColumn::SetExpressionAndType %s\n", exc.what()));
+      gEveLog << "REveDataColumn::SetExpressionAndType" << exc.what() << std::endl;
    }
 }
 //______________________________________________________________________________

--- a/graf3d/eve7/src/REveDataTable.cxx
+++ b/graf3d/eve7/src/REveDataTable.cxx
@@ -113,7 +113,7 @@ void REveDataColumn::SetExpressionAndType(const std::string& expr, FieldType_e t
    std::stringstream s;
    s << "*((std::function<" << rtyp << "(" << icls->GetName() << "*)>*)" << std::hex << std::showbase << (size_t)fooptr
      << ") = [](" << icls->GetName() << "* p){" << icls->GetName() << " &i=*p; return (" << fExpression.Data()
-     << "); }";
+     << "); };";
 
    // printf("%s\n", s.str().c_str());
    try {

--- a/graf3d/eve7/src/REveDataTable.cxx
+++ b/graf3d/eve7/src/REveDataTable.cxx
@@ -77,7 +77,6 @@ void REveDataTable::AddNewColumn(const std::string& expr, const std::string& tit
 {
    auto c = new REveDataColumn(title);
    AddElement(c);
-
    c->SetExpressionAndType(expr, REveDataColumn::FT_Double);
    c->SetPrecision(prec);
 
@@ -99,7 +98,27 @@ void REveDataColumn::SetExpressionAndType(const std::string& expr, FieldType_e t
 {
    fExpression = expr;
    fType       = type;
+   fClassType  = icls;
+}
 
+//______________________________________________________________________________
+void REveDataColumn::SetExpressionAndType(const std::string& expr, FieldType_e type)
+{
+   auto table = dynamic_cast<REveDataTable*>(fMother);
+   auto coll = table->GetCollection();
+   auto icls = coll->GetItemClass();
+   SetExpressionAndType(expr, type, icls);
+}
+
+//______________________________________________________________________________
+void REveDataColumn::SetPrecision(Int_t prec)
+{
+   fPrecision = prec;
+}
+
+//______________________________________________________________________________
+std::string REveDataColumn::GetFunctionExpressionString() const
+{
    const char *rtyp   = nullptr;
    const void *fooptr = nullptr;
 
@@ -111,36 +130,20 @@ void REveDataColumn::SetExpressionAndType(const std::string& expr, FieldType_e t
    }
 
    std::stringstream s;
-   s << "*((std::function<" << rtyp << "(" << icls->GetName() << "*)>*)" << std::hex << std::showbase << (size_t)fooptr
-     << ") = [](" << icls->GetName() << "* p){" << icls->GetName() << " &i=*p; return (" << fExpression.Data()
+   s << "*((std::function<" << rtyp << "(" << fClassType->GetName() << "*)>*)" << std::hex << std::showbase << (size_t)fooptr
+     << ") = [](" << fClassType->GetName() << "* p){" << fClassType->GetName() << " &i=*p; return (" << fExpression.Data()
      << "); };";
 
-   // printf("%s\n", s.str().c_str());
-   try {
-      gROOT->ProcessLine(s.str().c_str());
-   }
-   catch (const std::exception &exc)
-   {
-      gEveLog << "REveDataColumn::SetExpressionAndType" << exc.what() << std::endl;
-   }
+
+  return s.str();
 }
+
 //______________________________________________________________________________
-
-void REveDataColumn::SetExpressionAndType(const std::string& expr, FieldType_e type)
-{
-   auto table = dynamic_cast<REveDataTable*>(fMother);
-   auto coll = table->GetCollection();
-   auto icls = coll->GetItemClass();
-   SetExpressionAndType(expr, type, icls);
-}
-
-void REveDataColumn::SetPrecision(Int_t prec)
-{
-   fPrecision = prec;
-}
-
 std::string REveDataColumn::EvalExpr(void *iptr) const
 {
+   if (!(fDoubleFoo || fBoolFoo || fStringFoo))
+      gROOT->ProcessLine(GetFunctionExpressionString().c_str());
+
    switch (fType)
    {
       case FT_Double:

--- a/graf3d/eve7/src/REveElement.cxx
+++ b/graf3d/eve7/src/REveElement.cxx
@@ -439,7 +439,6 @@ void REveElement::VizDB_Apply(const std::string& tag)
    if (ApplyVizTag(tag))
    {
       PropagateVizParamsToProjecteds();
-      REX::gEve->Redraw3D();
    }
 }
 
@@ -453,7 +452,6 @@ void REveElement::VizDB_Reapply()
    {
       CopyVizParamsFromDB();
       PropagateVizParamsToProjecteds();
-      REX::gEve->Redraw3D();
    }
 }
 
@@ -475,7 +473,6 @@ void REveElement::VizDB_UpdateModel(Bool_t update)
          // XXX have a matching fVizModel. Or something.
          Error("VizDB_UpdateModel", "update from vizdb -> elements not implemented.");
          // fVizModel->PropagateVizParamsToElements(fVizModel);
-         // REX::gEve->Redraw3D();
       }
    }
    else
@@ -500,9 +497,7 @@ void REveElement::VizDB_Insert(const std::string& tag, Bool_t replace, Bool_t up
       return;
    }
    el->CopyVizParams(this);
-   Bool_t succ = REX::gEve->InsertVizDBEntry(tag, el, replace, update);
-   if (succ && update)
-      REX::gEve->Redraw3D();
+   REX::gEve->InsertVizDBEntry(tag, el, replace, update);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1210,7 +1205,6 @@ void REveElement::Annihilate()
    AnnihilateRecursively();
 
    // XXXX ????? Annihilate flag ???? Is it different than regular remove ????
-   // REX::gEve->Redraw3D();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1241,7 +1235,6 @@ void REveElement::Destroy()
 
    PreDeleteElement();
    delete this;
-   REX::gEve->Redraw3D();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1284,8 +1277,6 @@ void REveElement::DestroyElements()
          RemoveElement(c);
       }
    }
-
-   REX::gEve->Redraw3D();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REveGeoShape.cxx
+++ b/graf3d/eve7/src/REveGeoShape.cxx
@@ -317,7 +317,6 @@ REveGeoShape *REveGeoShape::ImportShapeExtract(REveGeoShapeExtract* gse,
                                                REveElement*         parent)
 {
    REveGeoManagerHolder gmgr(fgGeoManager);
-   REveManager::RRedrawDisabler redrawOff(REX::gEve);
    REveGeoShape* gsre = SubImportShapeExtract(gse, parent);
    gsre->StampObjProps();
    return gsre;

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -829,14 +829,14 @@ void REveManager::WindowData(unsigned connid, const std::string &arg)
 void REveManager::ScheduleMIR(const std::string &cmd, ElementId_t id, const std::string& ctype)
 {
    std::unique_lock lock(fServerState.fMutex);
-   fMIRqueue.push(new MIR(cmd, id, ctype));
+   fMIRqueue.push(std::shared_ptr<MIR>(new MIR(cmd, id, ctype)));
    if (fServerState.fVal == ServerState::Waiting)
       fServerState.fCV.notify_all();
 }
 
 //
 //____________________________________________________________________
-void REveManager::ExecuteMIR(MIR* mir)
+void REveManager::ExecuteMIR(std::shared_ptr<MIR> mir)
 {
    class ChangeSentry {
    public:
@@ -915,7 +915,7 @@ void REveManager::MIRExecThread()
       }
       else if (fServerState.fVal == ServerState::Waiting)
       {
-         MIR* mir = fMIRqueue.front();
+         std::shared_ptr<MIR> mir = fMIRqueue.front();
          fMIRqueue.pop();
          fServerState.fVal = ServerState::UpdatingScenes;
          lock.unlock();

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -904,6 +904,12 @@ void REveManager::ExecuteMIR(std::shared_ptr<MIR> mir)
    } catch (...) {
       std::cout << "REveManager::ExecuteCommand unknown exception.\n";
    }
+
+   if (gEveLog.has_contents())
+   {
+      std::cout << "Culokafoor: " << gEveLog.fLog << "\n";
+      gEveLog.clear();
+   }
 }
 
 //

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -184,8 +184,6 @@ REveManager::~REveManager()
    fHighlight->DecDenyDestroy();
    fSelection->DecDenyDestroy();
 
-   for (auto i = fMethCallMap.begin(); i != fMethCallMap.end(); ++i) delete i->second;
-
    delete fGeometryAliases;
    delete fGeometries;
    delete fVizDB;
@@ -873,7 +871,7 @@ void REveManager::ExecuteMIR(std::shared_ptr<MIR> mir)
          throw eh + "Dynamic cast from REveElement to '" + mir->fCtype + "' failed.";
 
       std::string tag(mir->fCtype + "::" + m.str(1));
-      TMethodCall *mc;
+      std::shared_ptr<TMethodCall> mc;
 
       auto mmi = fMethCallMap.find(tag);
       if (mmi != fMethCallMap.end())
@@ -885,7 +883,7 @@ void REveManager::ExecuteMIR(std::shared_ptr<MIR> mir)
          const TMethod *meth = call_cls->GetMethodAllAny(m.str(1).c_str());
          if ( ! meth)
             throw eh + "Can not find TMethod matching '" + m.str(1) + "'.";
-         mc = new TMethodCall(meth);
+         mc = std::make_shared<TMethodCall>(meth);
          fMethCallMap.insert(std::make_pair(tag, mc));
       }
 

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -139,7 +139,7 @@ REveManager::REveManager()
    TColor::SetColorThreshold(0.1);
 
    fWebWindow = RWebWindow::Create();
-   fWebWindow->AssignCallbackThreadId();
+   fWebWindow->UseServerThreads();
    fWebWindow->SetDefaultPage("file:rootui5sys/eve7/index.html");
 
    const char *gl_viewer = gEnv->GetValue("WebEve.GLViewer", "Three");

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -968,67 +968,6 @@ void REveManager::SceneSubscriberWaitingResponse(unsigned cinnId)
    }
 }
 
-//------------------------------------------------------------------------------
-
-void REveManager::DestroyElementsOf(REveElement::List_t &els)
-{
-   // XXXXX - not called, what's with end accepting changes?
-
-   fWorld->EndAcceptingChanges();
-   fScenes->AcceptChanges(false);
-
-   nlohmann::json jarr = nlohmann::json::array();
-
-   nlohmann::json jhdr = {};
-   jhdr["content"] = "REveManager::DestroyElementsOf";
-
-   nlohmann::json jels = nlohmann::json::array();
-
-   for (auto &ep : els) {
-      jels.push_back(ep->GetElementId());
-
-      ep->DestroyElements();
-   }
-
-   jhdr["element_ids"] = jels;
-
-   jarr.push_back(jhdr);
-
-   std::string msg = jarr.dump();
-
-   // XXXX Do we have broadcast?
-
-   for (auto &conn : fConnList) {
-      fWebWindow->Send(conn.fId, msg);
-   }
-}
-
-void REveManager::BroadcastElementsOf(REveElement::List_t &els)
-{
-   // XXXXX - not called, what's with begin accepting changes?
-
-   for (auto &ep : els) {
-      REveScene *scene = dynamic_cast<REveScene *>(ep);
-      assert(scene != nullptr);
-
-      printf("\nEVEMNG ............. streaming scene %s [%s]\n", scene->GetCTitle(), scene->GetCName());
-
-      // This prepares core and render data buffers.
-      scene->StreamElements();
-
-      for (auto &conn : fConnList) {
-         printf("   sending json, len = %d --> to conn_id = %d\n", (int)scene->fOutputJson.size(), conn.fId);
-         fWebWindow->Send(conn.fId, scene->fOutputJson);
-         printf("   sending binary, len = %d --> to conn_id = %d\n", scene->fTotalBinarySize, conn.fId);
-         fWebWindow->SendBinary(conn.fId, &scene->fOutputBinary[0], scene->fTotalBinarySize);
-      }
-   }
-
-   // AMT: These calls may not be necessary
-   fScenes->AcceptChanges(true);
-   fWorld->BeginAcceptingChanges();
-}
-
 //////////////////////////////////////////////////////////////////
 /// Show eve manager in specified browser.
 

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -849,7 +849,7 @@ void REveManager::ExecuteMIR(std::shared_ptr<MIR> mir)
    };
    ChangeSentry cs;
 
-   if (gDebug > 0)
+   //if (gDebug > 0)
       ::Info("REveManager::ExecuteCommand", "MIR cmd %s", mir->fCmd.c_str());
 
    try {

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -917,7 +917,6 @@ void REveManager::PublishChanges()
    // Process changes in scenes.
    fWorld->ProcessChanges();
    fScenes->ProcessSceneChanges();
-
    jobj["content"] = "EndChanges";
 
    if (gEveLog.has_contents())

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -900,9 +900,9 @@ void REveManager::ExecuteMIR(std::shared_ptr<MIR> mir)
       // std::cout << cmd.str() << std::endl;
       // gROOT->ProcessLine(cmd.str().c_str());
    } catch (std::exception &e) {
-      gEveLog.add(Form("REveManager::ExecuteCommand %s\n", e.what()));
+      gEveLog << "REveManager::ExecuteCommand " << e.what() << std::endl;
    } catch (...) {
-      gEveLog.add(Form("REveManager::ExecuteCommand unknow execption \n"));
+      gEveLog << "REveManager::ExecuteCommand unknow execption \n";
    }
 }
 
@@ -922,7 +922,7 @@ void REveManager::PublishChanges()
 
    if (gEveLog.has_contents())
    {
-      jobj["log"] = gEveLog.fLog;
+      jobj["log"] = gEveLog.fLog.str();
       gEveLog.clear();
    }
    fWebWindow->Send(0, jobj.dump());

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -1038,7 +1038,7 @@ std::shared_ptr<REveGeomViewer> REveManager::ShowGeometry(const RWebDisplayArgs 
 }
 
 //____________________________________________________________________
-void REveManager::BeginChangeGuard()
+void REveManager::BeginChange()
 {
    {
       std::unique_lock lock(fServerState.fMutex);
@@ -1052,7 +1052,7 @@ void REveManager::BeginChangeGuard()
 }
 
 //____________________________________________________________________
-void REveManager::EndChangeGuard()
+void REveManager::EndChange()
 {
    GetScenes()->AcceptChanges(false);
    GetWorld()->EndAcceptingChanges();
@@ -1075,12 +1075,12 @@ RAII guard for locking Eve manager (ctor) and processing changes (dtor).
 //
 REveManager::ChangeGuard::ChangeGuard()
 {
-   gEve->BeginChangeGuard();
+   gEve->BeginChange();
 }
 
 REveManager::ChangeGuard::~ChangeGuard()
 {
-   gEve->EndChangeGuard();
+   gEve->EndChange();
 }
 
 /** \class REveManager::RExceptionHandler

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -900,15 +900,9 @@ void REveManager::ExecuteMIR(std::shared_ptr<MIR> mir)
       // std::cout << cmd.str() << std::endl;
       // gROOT->ProcessLine(cmd.str().c_str());
    } catch (std::exception &e) {
-      std::cout << "REveManager::ExecuteCommand " << e.what() << std::endl;
+      gEveLog.add(Form("REveManager::ExecuteCommand %s\n", e.what()));
    } catch (...) {
-      std::cout << "REveManager::ExecuteCommand unknown exception.\n";
-   }
-
-   if (gEveLog.has_contents())
-   {
-      std::cout << "Culokafoor: " << gEveLog.fLog << "\n";
-      gEveLog.clear();
+      gEveLog.add(Form("REveManager::ExecuteCommand unknow execption \n"));
    }
 }
 
@@ -925,6 +919,12 @@ void REveManager::PublishChanges()
    fScenes->ProcessSceneChanges();
 
    jobj["content"] = "EndChanges";
+
+   if (gEveLog.has_contents())
+   {
+      jobj["log"] = gEveLog.fLog;
+      gEveLog.clear();
+   }
    fWebWindow->Send(0, jobj.dump());
 }
 

--- a/graf3d/eve7/src/REveScene.cxx
+++ b/graf3d/eve7/src/REveScene.cxx
@@ -97,7 +97,12 @@ void REveScene::BeginAcceptingChanges()
 {
    if (fAcceptingChanges) return;
 
-   if (HasSubscribers()) fAcceptingChanges = kTRUE;
+   if (HasSubscribers()) {
+      fAcceptingChanges = kTRUE;
+      for (auto &&client : fSubscribers) {
+         REX::gEve->SceneSubscriberProcessingChanges(client->fId);
+      }
+   }
 }
 
 void REveScene::SceneElementChanged(REveElement* element)
@@ -330,6 +335,7 @@ void REveScene::SendChangesToSubscribers()
             printf("   sending binary, len = %d --> to conn_id = %d\n", fTotalBinarySize, client->fId);
          client->fWebWindow->SendBinary(client->fId, &fOutputBinary[0], fTotalBinarySize);
       }
+      REX::gEve->SceneSubscriberWaitingResponse(client->fId);
    }
 }
 
@@ -548,6 +554,17 @@ void REveSceneList::DestroyElementRenderers(REveElement* element)
 }
 
 */
+
+bool REveSceneList::AnyChanges() const
+{
+   for (auto &el : fChildren)
+   {
+      if (((REveScene*) el)->IsChanged())
+      return true;
+   }
+   return false;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/graf3d/eve7/src/REveSelection.cxx
+++ b/graf3d/eve7/src/REveSelection.cxx
@@ -627,8 +627,6 @@ void REveSelection::NewElementPickedStr(ElementId_t id, bool multi, bool seconda
 {
    static const REveException eh("REveSelection::NewElementPickedStr ");
 
-   gEveLog.add("Loitse WOZ hereh!");
-
    if (secondary_idcs == 0 || secondary_idcs[0] == 0)
    {
       NewElementPicked(id, multi, secondary);

--- a/graf3d/eve7/src/REveSelection.cxx
+++ b/graf3d/eve7/src/REveSelection.cxx
@@ -627,6 +627,8 @@ void REveSelection::NewElementPickedStr(ElementId_t id, bool multi, bool seconda
 {
    static const REveException eh("REveSelection::NewElementPickedStr ");
 
+   gEveLog.add("Loitse WOZ hereh!");
+
    if (secondary_idcs == 0 || secondary_idcs[0] == 0)
    {
       NewElementPicked(id, multi, secondary);

--- a/graf3d/eve7/src/REveTableInfo.cxx
+++ b/graf3d/eve7/src/REveTableInfo.cxx
@@ -42,7 +42,7 @@ void REveTableViewInfo::SetDisplayedCollection(ElementId_t collectionId)
    StampObjProps();
 }
 
-void REveTableViewInfo::AddNewColumnToCurrentCollection(const std::string &expr, const std::string &title, int prec)
+void REveTableViewInfo::AddNewColumnToCurrentCollection(const char* expr, const char* title, int prec)
 {
    if (!fDisplayedCollection)
       return;

--- a/graf3d/eve7/src/REveTableProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveTableProxyBuilder.cxx
@@ -10,6 +10,7 @@
  *************************************************************************/
 
 #include "TClass.h"
+#include "TROOT.h"
 #include <ROOT/REveTableProxyBuilder.hxx>
 #include <ROOT/REveTableInfo.hxx>
 #include <ROOT/REveViewContext.hxx>
@@ -51,15 +52,20 @@ void REveTableProxyBuilder::Build(const REveDataCollection* collection, REveElem
 
    if (info->GetConfigChanged() || fTable->NumChildren() == 0) {
       fTable->DestroyElements();
+      std::stringstream ss;
       REveTableHandle::Entries_t& tableEntries =  context->GetTableViewInfo()->RefTableEntries(collection->GetItemClass()->GetName());
       for (const REveTableEntry& spec : tableEntries) {
          auto c = new REveDataColumn(spec.fName.c_str());
          fTable->AddElement(c);
          using namespace std::string_literals;
          std::string exp  =  spec.fExpression;
-         c->SetExpressionAndType(exp.c_str(), spec.fType);
          c->SetPrecision(spec.fPrecision);
+         c->SetExpressionAndType(exp.c_str(), spec.fType);
+         ss << c->GetFunctionExpressionString();
+         ss << "\n";
       }
+      // std::cout << ss.str();
+      gROOT->ProcessLine(ss.str().c_str());
    }
    fTable->StampObjProps();
 }

--- a/graf3d/eve7/src/REveTypes.cxx
+++ b/graf3d/eve7/src/REveTypes.cxx
@@ -45,7 +45,7 @@ REveException REX::operator+(const REveException &s1, ElementId_t x)
 
 thread_local REX::REveLog REX::gEveLog;
 
-void REveLog::add(const char* txt) { fLog += txt; std::cout << txt << std::endl;}
-void REveLog::add(const std::string& txt) { fLog += txt; std::cout << txt << std::endl;}
-bool REveLog::has_contents() { return ! fLog.empty(); }
+void REveLog::add(const char* txt) { fLog << txt; std::cout << txt << std::endl;}
+void REveLog::add(const std::string& txt) { fLog << txt; std::cout << txt << std::endl;}
+bool REveLog::has_contents() { return ! fLog.str().empty(); }
 void REveLog::clear() { fLog.clear(); }

--- a/graf3d/eve7/src/REveTypes.cxx
+++ b/graf3d/eve7/src/REveTypes.cxx
@@ -10,7 +10,7 @@
  *************************************************************************/
 
 #include <ROOT/REveTypes.hxx>
-
+#include <iostream>
 using namespace ROOT::Experimental;
 namespace REX = ROOT::Experimental;
 
@@ -45,7 +45,7 @@ REveException REX::operator+(const REveException &s1, ElementId_t x)
 
 thread_local REX::REveLog REX::gEveLog;
 
-void REveLog::add(const char* txt) { fLog += txt; }
-void REveLog::add(const std::string& txt) { fLog += txt; }
+void REveLog::add(const char* txt) { fLog += txt; std::cout << txt << std::endl;}
+void REveLog::add(const std::string& txt) { fLog += txt; std::cout << txt << std::endl;}
 bool REveLog::has_contents() { return ! fLog.empty(); }
 void REveLog::clear() { fLog.clear(); }

--- a/graf3d/eve7/src/REveTypes.cxx
+++ b/graf3d/eve7/src/REveTypes.cxx
@@ -49,3 +49,17 @@ void REveLog::add(const char* txt) { fLog << txt; std::cout << txt << std::endl;
 void REveLog::add(const std::string& txt) { fLog << txt; std::cout << txt << std::endl;}
 bool REveLog::has_contents() { return ! fLog.str().empty(); }
 void REveLog::clear() { fLog.clear(); }
+
+REveLog &REveLog::operator<<(const std::string &txt)
+{
+   fLog << txt;
+   std::cout << txt;
+   return *this;
+}
+REveLog &REveLog::operator<<(std::ostream &(*os)(std::ostream &))
+{
+   fLog << os;
+ //  if (os == std::endl)
+   std::cout << os;
+   return *this;
+}

--- a/graf3d/eve7/src/REveTypes.cxx
+++ b/graf3d/eve7/src/REveTypes.cxx
@@ -40,3 +40,12 @@ REveException REX::operator+(const REveException &s1,  const char *s2)
 
 REveException REX::operator+(const REveException &s1, ElementId_t x)
 { REveException r(s1); r.append(std::to_string(x)); return r; }
+
+////////////////////////////////////////////////////////////////////////////////
+
+thread_local REX::REveLog REX::gEveLog;
+
+void REveLog::add(const char* txt) { fLog += txt; }
+void REveLog::add(const std::string& txt) { fLog += txt; }
+bool REveLog::has_contents() { return ! fLog.empty(); }
+void REveLog::clear() { fLog.clear(); }

--- a/graf3d/eve7/src/REveTypes.cxx
+++ b/graf3d/eve7/src/REveTypes.cxx
@@ -50,16 +50,10 @@ void REveLog::add(const std::string& txt) { fLog << txt; std::cout << txt << std
 bool REveLog::has_contents() { return ! fLog.str().empty(); }
 void REveLog::clear() { fLog.clear(); }
 
-REveLog &REveLog::operator<<(const std::string &txt)
-{
-   fLog << txt;
-   std::cout << txt;
-   return *this;
-}
+
 REveLog &REveLog::operator<<(std::ostream &(*os)(std::ostream &))
 {
    fLog << os;
- //  if (os == std::endl)
    std::cout << os;
    return *this;
 }

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -56,7 +56,7 @@ class RWebWindow {
    friend class RWebWindowWSHandler;
    friend class RWebDisplayHandle;
 
-private:
+public:
    using timestamp_t = std::chrono::time_point<std::chrono::system_clock>;
 
    struct QueueItem {

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -56,7 +56,7 @@ class RWebWindow {
    friend class RWebWindowWSHandler;
    friend class RWebDisplayHandle;
 
-public:
+private:
    using timestamp_t = std::chrono::time_point<std::chrono::system_clock>;
 
    struct QueueItem {

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1219,8 +1219,11 @@ void RWebWindow::SendBinary(unsigned connid, const void *data, std::size_t len)
 
 void RWebWindow::AssignThreadId()
 {
-   fUseServerThreads = false;
-   fProcessMT = false;
+   // Hack to execute in http ws thread.
+   fProcessMT = true;
+   fCallbacksThrdIdSet = false;
+   return;
+
    fCallbacksThrdIdSet = true;
    fCallbacksThrdId = std::this_thread::get_id();
    if (!RWebWindowsManager::IsMainThrd()) {

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1219,6 +1219,8 @@ void RWebWindow::SendBinary(unsigned connid, const void *data, std::size_t len)
 
 void RWebWindow::AssignThreadId()
 {
+   fUseServerThreads = false;
+   fProcessMT = false;
    fCallbacksThrdIdSet = true;
    fCallbacksThrdId = std::this_thread::get_id();
    if (!RWebWindowsManager::IsMainThrd()) {

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1219,11 +1219,6 @@ void RWebWindow::SendBinary(unsigned connid, const void *data, std::size_t len)
 
 void RWebWindow::AssignThreadId()
 {
-   // Hack to execute in http ws thread.
-   fProcessMT = true;
-   fCallbacksThrdIdSet = false;
-   return;
-
    fCallbacksThrdIdSet = true;
    fCallbacksThrdId = std::this_thread::get_id();
    if (!RWebWindowsManager::IsMainThrd()) {

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -38,9 +38,9 @@
 #include <iostream>
 
 
-const Double_t kR_min = 300;
-const Double_t kR_max = 299;
-const Double_t kZ_d   = 300;
+const Double_t kR_min = 299;
+const Double_t kR_max = 300;
+const Double_t kZ_d   = 500;
 
 
 namespace fw3dlego {

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -772,12 +772,10 @@ public:
 
    virtual void NextEvent()
    {
-      eveMng->DisableRedraw();
       eveMng->GetSelection()->ClearSelection();
       eveMng->GetHighlight()->ClearSelection();
       fEvent->Create();
       fCMng->LoadEvent();
-      eveMng->EnableRedraw();
    }
 };
 

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -23,6 +23,7 @@
 #include <ROOT/REveScene.hxx>
 #include <ROOT/REveViewer.hxx>
 #include <ROOT/REveElement.hxx>
+#include <ROOT/REveCompound.hxx>
 #include <ROOT/REveManager.hxx>
 #include <ROOT/REveUtil.hxx>
 #include <ROOT/REveGeoShape.hxx>
@@ -105,14 +106,14 @@ void addTracks()
    int N_Tracks = 10 + r.Integer(20);
    for (int i = 0; i < N_Tracks; i++)
    {
-      TParticle* p = new TParticle();
+      TParticle p;
 
       int pdg = 11 * (r.Integer(2) > 0 ? 1 : -1);
-      p->SetPdgCode(pdg);
+      p.SetPdgCode(pdg);
 
-      p->SetProductionVertex(r.Uniform(-v,v), r.Uniform(-v,v), r.Uniform(-v,v), 1);
-      p->SetMomentum(r.Uniform(-m,m), r.Uniform(-m,m), r.Uniform(-m,m)*r.Uniform(1, 3), 1);
-      auto track = new REX::REveTrack(p, 1, prop);
+      p.SetProductionVertex(r.Uniform(-v,v), r.Uniform(-v,v), r.Uniform(-v,v), 1);
+      p.SetMomentum(r.Uniform(-m,m), r.Uniform(-m,m), r.Uniform(-m,m)*r.Uniform(1, 3), 1);
+      auto track = new REX::REveTrack(&p, 1, prop);
       track->MakeTrack();
       if (i % 4 == 3) track->SetLineStyle(2); // enabled dashed style for some tracks
       track->SetMainColor(kBlue);
@@ -225,7 +226,8 @@ class EventManager : public REX::REveElement
 {
 private:
    bool fAutoplay{false};
-   int fPlayDelay{10};
+   int  fPlayDelay{10};
+   int  fCount{0};
 
    std::chrono::time_point<std::chrono::system_clock> fPrevTime;
    std::chrono::duration<double> fDeltaTime{1};
@@ -255,6 +257,7 @@ public:
          if (mngRhoZ)
             mngRhoZ->ImportElements(ie, rhoZEventScene);
       }
+      // if (++fCount % 10 == 0) printf("At event %d\n", fCount);
    }
 
    void autoplay_scheduler()

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -70,7 +70,7 @@ void addPoints()
 {
    REX::REveElement* event = eveMng->GetEventScene();
 
-   auto pntHolder = new REX::REveElement("Hits");
+   auto pntHolder = new REX::REveCompound("Hits");
 
    auto ps1 = getPointSet(20, 100);
    ps1->SetName("Points_1");
@@ -97,7 +97,7 @@ void addTracks()
    prop->SetMaxZ(600);
    prop->SetMaxOrbs(6);
 
-   auto trackHolder = new REX::REveElement("Tracks");
+   auto trackHolder = new REX::REveCompound("Tracks");
 
    double v = 0.2;
    double m = 5;
@@ -129,7 +129,7 @@ void addJets()
    TRandom &r = *gRandom;
 
    REX::REveElement *event = eveMng->GetEventScene();
-   auto jetHolder = new REX::REveElement("Jets");
+   auto jetHolder = new REX::REveCompound("Jets");
 
    int N_Jets = 5 + r.Integer(5);
    for (int i = 0; i < N_Jets; i++)

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -258,7 +258,6 @@ public:
 
    virtual void NextEvent()
    {
-      eveMng->DisableRedraw();
       auto scene =  eveMng->GetEventScene();
       scene->DestroyElements();
       makeEventScene();
@@ -269,8 +268,6 @@ public:
          if (mngRhoZ)
          mngRhoZ  ->ImportElements(ie, rhoZEventScene);
       }
-      eveMng->EnableRedraw();
-      eveMng->DoRedraw3D();
    }
 
    virtual void QuitRoot()
@@ -281,13 +278,9 @@ public:
 
    virtual void TimerDone()
    {
-      eveMng->GetWorld()->BeginAcceptingChanges();
-      eveMng->GetScenes()->AcceptChanges(true);
-      NextEvent();
-
-      eveMng->GetScenes()->AcceptChanges(false);
-      eveMng->GetWorld()->EndAcceptingChanges();
-      fTimer->Start(40, kTRUE); 
+      std::stringstream cmd;
+      cmd << "((EventManager*)" << std::hex << std::showbase << (size_t)this << ")->NextEvent();";
+      eveMng->ExecuteCommand(cmd.str().c_str());
    }
 
    virtual void Autoplay()
@@ -301,7 +294,7 @@ public:
 
    void XXX() {
       if (fAutoplay)
-        fTimer->Start(500, kTRUE); 
+        fTimer->Start(10, kTRUE); 
    }
 };
 

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -246,8 +246,9 @@ public:
    EventManager() { 
 
    fTimer = new TTimer();
-fTimer->Connect("Timeout()", "EventManager",
+   fTimer->Connect("Timeout()", "EventManager",
                this, "TimerDone()");
+   eveMng->SetCBClientsFree([this]{XXX();});
 //  timer->Start(2000, kTRUE);   // 2 seconds single-shot
    }
 
@@ -286,7 +287,7 @@ fTimer->Connect("Timeout()", "EventManager",
 
       eveMng->GetScenes()->AcceptChanges(false);
       eveMng->GetWorld()->EndAcceptingChanges();
-      fTimer->Start(500, kTRUE); 
+      fTimer->Start(40, kTRUE); 
    }
 
    virtual void Autoplay()
@@ -296,6 +297,11 @@ fTimer->Connect("Timeout()", "EventManager",
          fTimer->Start(0, kTRUE);
       else
          fTimer->Stop();
+   }
+
+   void XXX() {
+      if (fAutoplay)
+        fTimer->Start(500, kTRUE); 
    }
 };
 

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -239,7 +239,7 @@ private:
 public:
    EventManager()
    {
-      std::chrono::milliseconds ms(100);
+      std::chrono::milliseconds ms(50);
       fDeltaTime = ms;
    }
 
@@ -265,8 +265,8 @@ public:
          {
             std::unique_lock<std::mutex> lock{fMutex};
             if (!fAutoplay) {
-                  // printf("exit thread pre wait\n");
-                  return;
+               // printf("exit thread pre wait\n");
+               return;
             }
             if (fCV.wait_for(lock, fDeltaTime) != std::cv_status::timeout) {
                printf("autoplay not timed out \n");
@@ -279,10 +279,9 @@ public:
             }
             autoplay = fAutoplay;
          }
-         if (autoplay)
-         {
-               REX::REveManager::ChangeGuard ch;
-               NextEvent();
+         if (autoplay) {
+            REX::REveManager::ChangeGuard ch;
+            NextEvent();
          } else {
             return;
          }
@@ -302,6 +301,7 @@ public:
                delete fTimerThread;
                fTimerThread = nullptr;
             }
+            NextEvent();
             fTimerThread = new std::thread{[this] { autoplay_scheduler(); }};
          } else {
             fCV.notify_all();
@@ -312,6 +312,7 @@ public:
    virtual void QuitRoot()
    {
       printf("Quit ROOT\n");
+      if (fAutoplay) Autoplay();
       if (gApplication)
          gApplication->Terminate();
    }

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -31,7 +31,6 @@
 #include <ROOT/REvePointSet.hxx>
 #include <ROOT/REveJetCone.hxx>
 #include <ROOT/REveTrans.hxx>
-#include <ROOT/REveChange.hxx>
 
 #include <ROOT/REveTrack.hxx>
 #include <ROOT/REveTrackPropagator.hxx>
@@ -239,7 +238,7 @@ private:
 public:
    EventManager()
    {
-      std::chrono::milliseconds ms(50);
+      std::chrono::milliseconds ms(100);
       fDeltaTime = ms;
    }
 
@@ -312,7 +311,6 @@ public:
    virtual void QuitRoot()
    {
       printf("Quit ROOT\n");
-      if (fAutoplay) Autoplay();
       if (gApplication)
          gApplication->Terminate();
    }

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -314,8 +314,7 @@ public:
    virtual void QuitRoot()
    {
       printf("Quit ROOT\n");
-      if (gApplication)
-         gApplication->Terminate();
+      REX::REveManager::QuitRoot();
    }
 };
 

--- a/ui5/eve7/controller/Main.controller.js
+++ b/ui5/eve7/controller/Main.controller.js
@@ -235,7 +235,7 @@ sap.ui.define(['sap/ui/core/Component',
 
       loadLog: function () {
          let oFT = sap.ui.getCore().byId("EveConsoleText");
-         oFT.setHtmlText(JSROOT.EVE.console.txt);
+         oFT.setHtmlText(JSROOT.EVE.console.txt.replace(/\n/g, "<p>"));
       },
 
       showUserURL : function(oEvent) {

--- a/ui5/eve7/controller/Summary.controller.js
+++ b/ui5/eve7/controller/Summary.controller.js
@@ -169,7 +169,7 @@ sap.ui.define([
          }
 
          // FIXME: provide more generic code which should
-         this.mgr.SendMIR("NewElementPicked(" + objid + ",false,false)",
+         this.mgr.SendMIR("NewElementPickedStr(" + objid + ",false,false)",
                           this.mgr.global_highlight_id, "ROOT::Experimental::REveSelection");
       },
 

--- a/ui5/eve7/lib/EveElements.js
+++ b/ui5/eve7/lib/EveElements.js
@@ -28,7 +28,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
    {
       if (!this.obj3d) return false;
 
-      var s = this.obj3d.scene;
+      let s = this.obj3d.scene;
       if (s && (typeof s[fname] == "function"))
          return s[fname](this.obj3d, arg, this.event);
       return false;
@@ -73,7 +73,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
       if (obj && rnrData && rnrData.vtxBuff) return false;
 
-      var cnt = this[name] || 0;
+      let cnt = this[name] || 0;
 
       if (cnt++ < 5) console.log(name, obj, rnrData);
 
@@ -82,27 +82,27 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       return true;
    }
 
-   EveElements.prototype.makeHit = function(hit, rnrData) {
+   EveElements.prototype.makeHit = function(hit, rnrData)
+   {
       if (this.TestRnr("hit", hit, rnrData)) return null;
 
-      var hit_size = 8 * rnrData.fMarkerSize;
-      var size     = rnrData.vtxBuff.length / 3;
-      var pnts     = new jsrp.PointsCreator(size, true, hit_size);
+      let hit_size = 8 * rnrData.fMarkerSize;
+      let size     = rnrData.vtxBuff.length / 3;
+      let pnts     = new jsrp.PointsCreator(size, true, hit_size);
 
-      for (var i=0; i<size; i++)
+      for (let i=0; i<size; i++)
          pnts.addPoint(rnrData.vtxBuff[i*3],rnrData.vtxBuff[i*3+1],rnrData.vtxBuff[i*3+2]);
 
-      var mesh = pnts.createPoints(jsrp.getColor(hit.fMarkerColor));
-
-      // use points control to toggle highlight and selection
-      // mesh.get_ctrl = function() { return new jsrp.PointsControl(this); }
-
-      mesh.get_ctrl = function() { return new EveElemControl(this); }
+      let mesh = pnts.createPoints(jsrp.getColor(hit.fMarkerColor));
 
       mesh.highlightScale = 2;
 
       mesh.material.sizeAttenuation = false;
       mesh.material.size = hit.fMarkerSize;
+
+      mesh.get_ctrl = function() { return new EveElemControl(this); };
+      mesh.dispose  = function() { this.geometry.dispose(); this.material.dispose(); };
+
       return mesh;
    }
 
@@ -110,19 +110,19 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
    {
       if (this.TestRnr("track", track, rnrData)) return null;
 
-      var N = rnrData.vtxBuff.length/3;
-      var track_width = track.fLineWidth || 1;
-      var track_color = jsrp.getColor(track.fLineColor) || "rgb(255,0,255)";
+      let N = rnrData.vtxBuff.length/3;
+      let track_width = track.fLineWidth || 1;
+      let track_color = jsrp.getColor(track.fLineColor) || "rgb(255,0,255)";
 
-      var buf = new Float32Array((N-1) * 6), pos = 0;
-      for (var k=0;k<(N-1);++k) {
+      let buf = new Float32Array((N-1) * 6), pos = 0;
+      for (let k=0;k<(N-1);++k) {
          buf[pos]   = rnrData.vtxBuff[k*3];
          buf[pos+1] = rnrData.vtxBuff[k*3+1];
          buf[pos+2] = rnrData.vtxBuff[k*3+2];
 
-         var breakTrack = false;
+         let breakTrack = false;
          if (rnrData.idxBuff)
-            for (var b = 0; b < rnrData.idxBuff.length; b++) {
+            for (let b = 0; b < rnrData.idxBuff.length; b++) {
                if ( (k+1) == rnrData.idxBuff[b]) {
                   breakTrack = true;
                   break;
@@ -142,7 +142,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          pos+=6;
       }
 
-      var style = (track.fLineStyle > 1) ? jsrp.root_line_styles[track.fLineStyle] : "",
+      let style = (track.fLineStyle > 1) ? jsrp.root_line_styles[track.fLineStyle] : "",
           dash = style ? style.split(",") : [], lineMaterial;
 
       if (dash && (dash.length > 1)) {
@@ -151,9 +151,9 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          lineMaterial = new THREE.LineBasicMaterial({ color: track_color, linewidth: track_width });
       }
 
-      var geom = new THREE.BufferGeometry();
+      let geom = new THREE.BufferGeometry();
       geom.setAttribute( 'position', new THREE.BufferAttribute( buf, 3 )  );
-      var line = new THREE.LineSegments(geom, lineMaterial);
+      let line = new THREE.LineSegments(geom, lineMaterial);
 
       // required for the dashed material
       if (dash && (dash.length > 1))
@@ -161,7 +161,8 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
       line.hightlightWidthScale = 2;
 
-      line.get_ctrl = function() { return new EveElemControl(this); }
+      line.get_ctrl = function() { return new EveElemControl(this); };
+      line.dispose  = function() { this.geometry.dispose(); this.material.dispose(); };
 
       return line;
    }
@@ -171,43 +172,47 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       if (this.TestRnr("jet", jet, rnrData)) return null;
 
       // console.log("make jet ", jet);
-      // var jet_ro = new THREE.Object3D();
-      var pos_ba = new THREE.BufferAttribute( rnrData.vtxBuff, 3 );
-      var N      = rnrData.vtxBuff.length / 3;
+      // let jet_ro = new THREE.Object3D();
+      let pos_ba = new THREE.BufferAttribute( rnrData.vtxBuff, 3 );
+      let N      = rnrData.vtxBuff.length / 3;
 
-      var geo_body = new THREE.BufferGeometry();
+      let geo_body = new THREE.BufferGeometry();
       geo_body.setAttribute('position', pos_ba);
-      var idcs = [0, N-1, 1];
-      for (var i = 1; i < N - 1; ++i)
+      let idcs = [0, N-1, 1];
+      for (let i = 1; i < N - 1; ++i)
          idcs.push( 0, i, i + 1 );
       geo_body.setIndex( idcs );
       geo_body.computeVertexNormals();
 
-      var geo_rim = new THREE.BufferGeometry();
+      let geo_rim = new THREE.BufferGeometry();
       geo_rim.setAttribute('position', pos_ba);
       idcs = new Uint16Array(N-1);
-      for (var i = 1; i < N; ++i) idcs[i-1] = i;
+      for (let i = 1; i < N; ++i) idcs[i-1] = i;
       geo_rim.setIndex(new THREE.BufferAttribute( idcs, 1 ));
 
-      var geo_rays = new THREE.BufferGeometry();
+      let geo_rays = new THREE.BufferGeometry();
       geo_rays.setAttribute('position', pos_ba);
       idcs = [];
-      for (var i = 1; i < N; i += 4)
+      for (let i = 1; i < N; i += 4)
          idcs.push( 0, i );
       geo_rays.setIndex( idcs );
 
-      var mcol = jsrp.getColor(jet.fMainColor);
-      var lcol = jsrp.getColor(jet.fLineColor);
+      let mcol = jsrp.getColor(jet.fMainColor);
+      let lcol = jsrp.getColor(jet.fLineColor);
 
-      var mesh = new THREE.Mesh(geo_body, new THREE.MeshPhongMaterial({ depthWrite: false, color: mcol, transparent: true, opacity: 0.5, side: THREE.DoubleSide }));
-      var line1 = new THREE.LineLoop(geo_rim,  new THREE.LineBasicMaterial({ linewidth: 2,   color: lcol, transparent: true, opacity: 0.5 }));
-      var line2 = new THREE.LineSegments(geo_rays, new THREE.LineBasicMaterial({ linewidth: 0.5, color: lcol, transparent: true, opacity: 0.5 }));
+      let mesh = new THREE.Mesh(geo_body, new THREE.MeshPhongMaterial({ depthWrite: false, color: mcol, transparent: true, opacity: 0.5, side: THREE.DoubleSide }));
+      let line1 = new THREE.LineLoop(geo_rim,  new THREE.LineBasicMaterial({ linewidth: 2,   color: lcol, transparent: true, opacity: 0.5 }));
+      let line2 = new THREE.LineSegments(geo_rays, new THREE.LineBasicMaterial({ linewidth: 0.5, color: lcol, transparent: true, opacity: 0.5 }));
 
       // jet_ro.add( mesh  );
       mesh.add( line1 );
       mesh.add( line2 );
 
-      mesh.get_ctrl = function() { return new EveElemControl(this); }
+      mesh.get_ctrl = function() { return new EveElemControl(this); };
+      mesh.dispose  = function() {
+         this.children.forEach(c => { c.geometry.dispose(); c.material.dispose(); });
+         this.geometry.dispose(); this.material.dispose();
+      };
 
       return mesh;
    }
@@ -222,58 +227,62 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       if (this.TestRnr("jetp", jet, rnrData)) return null;
 
 
-      var pos_ba = new THREE.BufferAttribute( rnrData.vtxBuff, 3 );
-      var N      = rnrData.vtxBuff.length / 3;
+      let pos_ba = new THREE.BufferAttribute( rnrData.vtxBuff, 3 );
+      let N      = rnrData.vtxBuff.length / 3;
 
-      var geo_body = new THREE.BufferGeometry();
+      let geo_body = new THREE.BufferGeometry();
       geo_body.setAttribute('position', pos_ba);
-      var idcs = [0, 2, 1];
+      let idcs = [0, 2, 1];
       if (N > 3)
          idcs.push( 0, 3, 2 );
       geo_body.setIndex( idcs );
       geo_body.computeVertexNormals();
 
-      var geo_rim = new THREE.BufferGeometry();
+      let geo_rim = new THREE.BufferGeometry();
       geo_rim.setAttribute('position', pos_ba);
       idcs = new Uint16Array(N-1);
-      for (var i = 1; i < N; ++i) idcs[i-1] = i;
+      for (let i = 1; i < N; ++i) idcs[i-1] = i;
       geo_rim.setIndex(new THREE.BufferAttribute( idcs, 1 ));
 
-      var geo_rays = new THREE.BufferGeometry();
+      let geo_rays = new THREE.BufferGeometry();
       geo_rays.setAttribute('position', pos_ba);
       idcs = [ 0, 1, 0, N-1 ];
       geo_rays.setIndex( idcs );
 
-      var fcol = jsrp.getColor(jet.fFillColor);
-      var lcol = jsrp.getColor(jet.fLineColor);
+      let fcol = jsrp.getColor(jet.fFillColor);
+      let lcol = jsrp.getColor(jet.fLineColor);
       // Process transparency !!!
       // console.log("cols", fcol, lcol);
 
       // double-side material required for correct tracing of colors - otherwise points sequence should be changed
-      var mesh = new THREE.Mesh(geo_body, new THREE.MeshBasicMaterial({ depthWrite: false, color: fcol, transparent: true, opacity: 0.5, side: THREE.DoubleSide }));
-      var line1 = new THREE.Line(geo_rim,  new THREE.LineBasicMaterial({ linewidth: 2, color: lcol, transparent: true, opacity: 0.5 }));
-      var line2 = new THREE.LineSegments(geo_rays, new THREE.LineBasicMaterial({ linewidth: 1, color: lcol, transparent: true, opacity: 0.5 }));
+      let mesh = new THREE.Mesh(geo_body, new THREE.MeshBasicMaterial({ depthWrite: false, color: fcol, transparent: true, opacity: 0.5, side: THREE.DoubleSide }));
+      let line1 = new THREE.Line(geo_rim,  new THREE.LineBasicMaterial({ linewidth: 2, color: lcol, transparent: true, opacity: 0.5 }));
+      let line2 = new THREE.LineSegments(geo_rays, new THREE.LineBasicMaterial({ linewidth: 1, color: lcol, transparent: true, opacity: 0.5 }));
 
       // jet_ro.add( mesh  );
       mesh.add( line1 );
       mesh.add( line2 );
 
-      mesh.get_ctrl = function() { return new EveElemControl(this); }
+      mesh.get_ctrl = function() { return new EveElemControl(this); };
+      mesh.dispose  = function() {
+         this.children.forEach(c => { c.geometry.dispose(); c.material.dispose(); });
+         this.geometry.dispose(); this.material.dispose();
+      };
 
       return mesh;
    }
 
 
-   EveElements.prototype.makeFlatBox = function(ebox, rnrData, idxBegin, idxEnd )
+   EveElements.prototype.makeFlatBox = function(ebox, rnrData, idxBegin, idxEnd)
    {
-      var fcol = jsrp.getColor(ebox.fMainColor);
-      var boxMaterial = new THREE.MeshPhongMaterial({color: fcol,  flatShading: true});
+      let fcol = jsrp.getColor(ebox.fMainColor);
+      let boxMaterial = new THREE.MeshPhongMaterial({color: fcol,  flatShading: true});
 
       // console.log("EveElements.prototype.makeFlatBox triangulate", idxBegin, idxEnd);
       let nTriang = (idxEnd - idxBegin) -2;
       let idxBuff =  new Uint16Array(nTriang * 3);
       let nt = 0;
-      for (var i = idxBegin; i < (idxEnd-2 ); ++i)
+      for (let i = idxBegin; i < (idxEnd-2 ); ++i)
       {
          idxBuff[nt*3] = idxBegin;
          idxBuff[nt*3+1] = i + 1 ;
@@ -281,65 +290,68 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          // console.log("set index ", nt,":", idxBuff[nt*3], idxBuff[nt*3+1],idxBuff[nt*3+2]);
          nt++;
       }
-      var idcs = new THREE.BufferAttribute(idxBuff,1);
+      let idcs = new THREE.BufferAttribute(idxBuff,1);
 
-      var body = new THREE.BufferGeometry();
+      let body = new THREE.BufferGeometry();
       body.setAttribute('position', new THREE.BufferAttribute( rnrData.vtxBuff, 3 ));
       body.setIndex(new THREE.BufferAttribute(idxBuff,1));
       body.computeVertexNormals();
-      var mesh = new THREE.Mesh(body, boxMaterial);
+      let mesh = new THREE.Mesh(body, boxMaterial);
       return mesh;
    }
 
-
-
    EveElements.prototype.makeBoxProjected = function(ebox, rnrData)
    {
-      var nPnts    = parseInt(rnrData.vtxBuff.length/3);
-      var breakIdx = parseInt(ebox.fBreakIdx);
+      let nPnts    = parseInt(rnrData.vtxBuff.length/3);
+      let breakIdx = parseInt(ebox.fBreakIdx);
       if ( ebox.fBreakIdx == 0 )
          breakIdx = nPnts;
 
       let mesh1 = this.makeFlatBox(ebox, rnrData, 0, breakIdx);
       let testBreak = breakIdx + 2;
-      if ( testBreak < nPnts)
+      if (testBreak < nPnts)
       {
-         var mesh2 = this.makeFlatBox(ebox, rnrData, breakIdx, nPnts);
+         let mesh2 = this.makeFlatBox(ebox, rnrData, breakIdx, nPnts);
          mesh2.get_ctrl = function() { return new EveElemControl(this); }
          mesh1.add(mesh2);
       }
 
-      mesh1.get_ctrl = function() { return new EveElemControl(this); }
+      mesh1.get_ctrl = function() { return new EveElemControl(this); };
+      mesh1.dispose  = function() {
+         this.children.forEach(c => { c.geometry.dispose(); c.material.dispose(); });
+         this.geometry.dispose(); this.material.dispose();
+      };
+
       return mesh1;
    }
 
    EveElements.prototype.makeBox = function(ebox, rnr_data)
    {
-      var idxBuff = [0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0, 1, 2, 3, 1, 3, 0, 4, 7, 6, 4, 6, 5];
-      var vBuff = rnr_data.vtxBuff;
+      let idxBuff = [0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0, 1, 2, 3, 1, 3, 0, 4, 7, 6, 4, 6, 5];
+      let vBuff = rnr_data.vtxBuff;
 
-      var body = new THREE.BufferGeometry();
+      let body = new THREE.BufferGeometry();
       body.setAttribute('position', new THREE.BufferAttribute( vBuff, 3 ));
       body.setIndex( idxBuff );
 
-      var fcol = jsrp.getColor(ebox.fMainColor);
-      var boxMaterial = new THREE.MeshPhongMaterial({color: fcol,  flatShading: true});
+      let fcol = jsrp.getColor(ebox.fMainColor);
+      let boxMaterial = new THREE.MeshPhongMaterial({color: fcol,  flatShading: true});
       if (ebox.fMainTransparency) {
          boxMaterial.transparent = true;
          boxMaterial.opacity = (100 - ebox.fMainTransparency)/100.0;
          boxMaterial.depthWrite = false;
       }
 
-      var mesh = new THREE.Mesh(body, boxMaterial);
-      var geo_rim = new THREE.BufferGeometry();
+      let mesh = new THREE.Mesh(body, boxMaterial);
+      let geo_rim = new THREE.BufferGeometry();
 
       geo_rim.setAttribute('position', vBuff);
 
       let nTrigs      = 6 * 2;
       let nSegs       = 6 * 2 * 3;
       let nIdcsTrings = 6 * 2 * 3 * 2;
-      var idcs = new Uint16Array(nIdcsTrings);
-      for (var i = 0; i < nTrigs; ++i)
+      let idcs = new Uint16Array(nIdcsTrings);
+      for (let i = 0; i < nTrigs; ++i)
       {
          let ibo = i * 3;
          let sbo = i * 6;
@@ -351,18 +363,23 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          idcs[sbo + 5] = idxBuff[ibo];
       }
       geo_rim.setIndex(new THREE.BufferAttribute( idcs, 1 ));
-      var lcol = jsrp.getColor(ebox.fLineColor);
-      var line = new THREE.LineSegments(geo_rim,  new THREE.LineBasicMaterial({ linewidth: 2, color: lcol, transparent: true, opacity: 0.5 }));
+      let lcol = jsrp.getColor(ebox.fLineColor);
+      let line = new THREE.LineSegments(geo_rim,  new THREE.LineBasicMaterial({ linewidth: 2, color: lcol, transparent: true, opacity: 0.5 }));
       mesh.add(line);
 
       mesh.get_ctrl = function() { return new EveElemControl(this); }
+      mesh.dispose  = function() {
+         this.children.forEach(c => { c.geometry.dispose(); c.material.dispose(); });
+         this.geometry.dispose(); this.material.dispose();
+      };
+
       return mesh;
    }
 
 
    EveElements.prototype.makeBoxSet = function(boxset, rnr_data)
    {
-      var vBuff;
+      let vBuff;
       if (boxset.boxType == 1) // free box
       {
          vBuff = rnr_data.vtxBuff;
@@ -372,7 +389,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          let N = rnr_data.vtxBuff.length/6;
          vBuff = new Float32Array(N*8*3);
 
-         var off = 0;
+         let off = 0;
          for (let i = 0; i < N; ++i)
          {
             let rdoff = i*6;
@@ -404,11 +421,10 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          }
       }
 
-
       let protoSize = 6 * 2 * 3;
       let protoIdcs = [0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0, 1, 2, 3, 1, 3, 0, 4, 7, 6, 4, 6, 5];
-      var nBox = vBuff.length / 24;
-      var idxBuff = [];
+      let nBox = vBuff.length / 24;
+      let idxBuff = [];
       for (let i = 0; i < nBox; ++i)
       {
          for (let c = 0; c < protoSize; c++) {
@@ -417,24 +433,24 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          }
       }
 
-      var body = new THREE.BufferGeometry();
+      let body = new THREE.BufferGeometry();
       body.setAttribute('position', new THREE.BufferAttribute( vBuff, 3 ));
       body.setIndex( idxBuff );
 
       //
       // set colors
-      var material = 0;
+      let material = 0;
       if (boxset.fSingleColor == false)
       {
-         var ci = rnr_data.idxBuff;
+         let ci = rnr_data.idxBuff;
          let off = 0
-         var colBuff = new Float32Array( nBox * 8 *3 );
+         let colBuff = new Float32Array( nBox * 8 *3 );
          for (let x = 0; x < ci.length; ++x)
          {
             let r = (ci[x] & 0x000000FF) >>  0;
             let g = (ci[x] & 0x0000FF00) >>  8;
             let b = (ci[x] & 0x00FF0000) >> 16;
-            for (var i = 0; i < 8; ++i)
+            for (let i = 0; i < 8; ++i)
             {
                colBuff[off    ] = r/256;
                colBuff[off + 1] = g/256;
@@ -444,14 +460,15 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          }
          body.setAttribute( 'color', new THREE.BufferAttribute( colBuff, 3 ) );
          material = new THREE.MeshPhongMaterial( {
-	    color: 0xffffff,
-	    flatShading: true,
-	    vertexColors: THREE.VertexColors,
-	    shininess: 0
+            color: 0xffffff,
+            flatShading: true,
+            vertexColors: THREE.VertexColors,
+            shininess: 0
          } );
       }
-      else {
-         var fcol = jsrp.getColor(boxset.fMainColor);
+      else
+      {
+         let fcol = jsrp.getColor(boxset.fMainColor);
          material = new THREE.MeshPhongMaterial({color:fcol, flatShading: true});
          if (boxset.fMainTransparency) {
             material.transparent = true;
@@ -460,11 +477,12 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          }
       }
 
-      var mesh = new THREE.Mesh(body, material);
+      let mesh = new THREE.Mesh(body, material);
       if (boxset.fSecondarySelect)
          mesh.get_ctrl = function() { return new BoxSetControl(mesh); };
       else
          mesh.get_ctrl = function() { return new EveElemControl(mesh); };
+      mesh.dispose  = function() { this.geometry.dispose(); this.material.dispose(); };
 
       return mesh;
    }
@@ -478,7 +496,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
    BoxSetControl.prototype.DrawForSelection = function(sec_idcs, res)
    {
-      var geobox = new THREE.BufferGeometry();
+      let geobox = new THREE.BufferGeometry();
       geobox.setAttribute( 'position', this.obj3d.geometry.getAttribute("position") );
 
       let protoIdcs = [0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0, 1, 2, 3, 1, 3, 0, 4, 7, 6, 4, 6, 5];
@@ -515,8 +533,8 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
    BoxSetControl.prototype.getTooltipText = function(intersect)
    {
-      var t = this.obj3d.eve_el.fTitle || this.obj3d.eve_el.fName || "";
-      var idx = this.extractIndex(intersect);
+      let t = this.obj3d.eve_el.fTitle || this.obj3d.eve_el.fName || "";
+      let idx = this.extractIndex(intersect);
       if (this.obj3d.eve_el.fDetIdsAsSecondaryIndices) {
 	 let N = this.obj3d.eve_el.render_data.idxBuff.length / 2;
 	 let id = this.obj3d.eve_el.render_data.idxBuff[N + idx];
@@ -548,14 +566,16 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       return true; // means index is different
    }
 
-    //==============================================================================
+
+   //==============================================================================
+
     EveElements.prototype.makeCalo2D = function(calo2D, rnrData)
     {
-        var nSquares =  rnrData.vtxBuff.length / 12;
-        var nTriang = 2* nSquares;
+        let nSquares =  rnrData.vtxBuff.length / 12;
+        let nTriang = 2* nSquares;
 
         let idxBuff =  new Uint16Array(nTriang * 3);
-        for (var s = 0; s < nSquares; ++s)
+        for (let s = 0; s < nSquares; ++s)
         {
             let boff = s * 6;
             let ioff = s * 4;
@@ -570,23 +590,22 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
             idxBuff[boff + 4] = ioff + 3;
             idxBuff[boff + 5] = ioff;
         }
-        var idcs = new THREE.BufferAttribute(idxBuff,1);
+        let idcs = new THREE.BufferAttribute(idxBuff,1);
 
-        var body = new THREE.BufferGeometry();
+        let body = new THREE.BufferGeometry();
         body.setAttribute('position', new THREE.BufferAttribute( rnrData.vtxBuff, 3 ));
         body.setIndex(new THREE.BufferAttribute(idxBuff,1));
         body.computeVertexNormals();
 
-
-        var ci = rnrData.idxBuff;
-        var colBuff = new Float32Array( nSquares * 4 *3 );
+        let ci = rnrData.idxBuff;
+        let colBuff = new Float32Array( nSquares * 4 *3 );
         let off = 0;
         for (let x = 0; x < ci.length; ++x)
         {
-            var slice = ci[x*2];
-            var sliceColor =  calo2D.sliceColors[slice];
-            var tc = new THREE.Color(jsrp.getColor(sliceColor));
-            for (var i = 0; i < 4; ++i)
+            let slice = ci[x*2];
+            let sliceColor =  calo2D.sliceColors[slice];
+            let tc = new THREE.Color(jsrp.getColor(sliceColor));
+            for (let i = 0; i < 4; ++i)
             {
                 colBuff[off    ] = tc.r;
                 colBuff[off + 1] = tc.g;
@@ -602,9 +621,11 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 	    vertexColors: THREE.VertexColors,
 	    shininess: 0
         } );
-        var mesh = new THREE.Mesh(body, material);
+        let mesh = new THREE.Mesh(body, material);
 
         mesh.get_ctrl = function() { return new Calo2DControl(mesh); };
+        mesh.dispose  = function() { this.geometry.dispose(); this.material.dispose(); };
+
         return mesh;
     }
 
@@ -648,7 +669,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
               }
            }
         }
-        var idxBuff = [];
+        let idxBuff = [];
         let vtxBuff =  new Float32Array(nBoxSelected * 4 * 3 );
         let protoIdcs = [0, 1, 2, 2, 3, 0];
         let rnr_data = this.obj3d.eve_el.render_data;
@@ -697,7 +718,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
         body.setAttribute('position', new THREE.BufferAttribute( vtxBuff, 3 ));
         body.setIndex( idxBuff );
 
-        var mesh = new THREE.Mesh(body);
+        let mesh = new THREE.Mesh(body);
         res.geom.push(mesh);
     }
 
@@ -709,7 +730,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
    Calo2DControl.prototype.getTooltipText = function(intersect)
     {
-        var idx = this.extractIndex(intersect);
+        let idx = this.extractIndex(intersect);
         let idxBuff = this.obj3d.eve_el.render_data.idxBuff;
         let bin =  idxBuff[idx*2 + 1];
         let val = this.obj3d.eve_el.render_data.nrmBuff[idx];
@@ -783,11 +804,11 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
     EveElements.prototype.makeCalo3D = function(calo3D, rnr_data)
     {
-        var vBuff = rnr_data.vtxBuff;
+        let vBuff = rnr_data.vtxBuff;
         let protoSize = 6 * 2 * 3;
         let protoIdcs = [0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0, 1, 2, 3, 1, 3, 0, 4, 7, 6, 4, 6, 5];
-        var nBox = vBuff.length / 24;
-        var idxBuff = [];
+        let nBox = vBuff.length / 24;
+        let idxBuff = [];
         for (let i = 0; i < nBox; ++i)
         {
             for (let c = 0; c < protoSize; c++) {
@@ -796,21 +817,21 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
             }
         }
 
-        var body = new THREE.BufferGeometry();
+        let body = new THREE.BufferGeometry();
         body.setAttribute('position', new THREE.BufferAttribute( vBuff, 3 ));
         body.setIndex( idxBuff );
 
-        var material = 0;
+        let material = 0;
 
-        var ci = rnr_data.idxBuff;
+        let ci = rnr_data.idxBuff;
         let off = 0
-        var colBuff = new Float32Array( nBox * 8 *3 );
+        let colBuff = new Float32Array( nBox * 8 *3 );
         for (let x = 0; x < nBox; ++x)
         {
-            var slice = ci[x*2];
-            var sliceColor =  calo3D.sliceColors[slice];
-            var tc = new THREE.Color(jsrp.getColor(sliceColor));
-            for (var i = 0; i < 8; ++i)
+            let slice = ci[x*2];
+            let sliceColor =  calo3D.sliceColors[slice];
+            let tc = new THREE.Color(jsrp.getColor(sliceColor));
+            for (let i = 0; i < 8; ++i)
             {
                 colBuff[off    ] = tc.r;
                 colBuff[off + 1] = tc.g;
@@ -820,15 +841,17 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
         }
         body.setAttribute( 'color', new THREE.BufferAttribute( colBuff, 3 ) );
         material = new THREE.MeshPhongMaterial( {
-	    color: 0xffffff,
-	    flatShading: true,
-	    vertexColors: THREE.VertexColors,
-	    shininess: 0
+            color: 0xffffff,
+            flatShading: true,
+            vertexColors: THREE.VertexColors,
+            shininess: 0
         } );
 
 
-        var mesh = new THREE.Mesh(body, material);
+        let mesh = new THREE.Mesh(body, material);
         mesh.get_ctrl = function() { return new Calo3DControl(mesh); };
+        mesh.dispose  = function() { this.geometry.dispose(); this.material.dispose(); };
+
         return mesh;
     }
 
@@ -866,7 +889,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       }
       let rnr_data = this.obj3d.eve_el.render_data;
       let protoIdcs = [0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0, 1, 2, 3, 1, 3, 0, 4, 7, 6, 4, 6, 5];
-      var idxBuff = [];
+      let idxBuff = [];
       let vtxBuff = new Float32Array(nbox * 8 * 3);
       for (let i = 0; i < nBoxSelected; ++i) {
          let BoxIdcs = boxIdcs[i];
@@ -906,7 +929,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       body.setAttribute('position', new THREE.BufferAttribute(vtxBuff, 3));
       body.setIndex(idxBuff);
 
-      var mesh = new THREE.Mesh(body);
+      let mesh = new THREE.Mesh(body);
       res.geom.push(mesh);
    }
 
@@ -962,8 +985,8 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
         let idx = pidx;
         let calo =  this.obj3d.eve_el;
         let idxBuff = calo.render_data.idxBuff;
-        var scene = this.obj3d.scene;
-        var selectionId = scene.mgr.global_highlight_id;
+        let scene = this.obj3d.scene;
+        let selectionId = scene.mgr.global_highlight_id;
         let fcall = "NewTowerPicked(" +  idxBuff[idx*2 + 1] + ", " +  idxBuff[idx*2] + ", " + selectionId + ", false);"
         scene.mgr.SendMIR(fcall, calo.fElementId, "ROOT::Experimental::REveCalo3D");
     }
@@ -991,50 +1014,16 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
       if (rnr_data.idxBuff.length != nVert + 2) throw "Expect single list of triangles in index buffer.";
 
-      if (this.useIndexAsIs)
-      {
-         var body = new THREE.BufferGeometry();
-         body.setAttribute('position', new THREE.BufferAttribute( rnr_data.vtxBuff, 3 ));
-         body.setIndex(new THREE.BufferAttribute( rnr_data.idxBuff, 1 ));
-         body.setDrawRange(2, nVert);
-         // this does not work correctly - draw range ignored when calculating normals
-         // even worse - shift 2 makes complete logic wrong while wrong triangle are extracted
-         // Let see if it will be fixed https://github.com/mrdoob/three.js/issues/15560
-         body.computeVertexNormalsIdxRange(2, nVert);
-         return body;
-      }
+      let body = new THREE.BufferGeometry();
+      body.setAttribute('position', new THREE.BufferAttribute( rnr_data.vtxBuff, 3 ));
+      body.setIndex(new THREE.BufferAttribute( rnr_data.idxBuff, 1 ));
+      body.setDrawRange(2, nVert);
+      // this does not work correctly - draw range ignored when calculating normals
+      // even worse - shift 2 makes complete logic wrong while wrong triangle are extracted
+      // Let see if it will be fixed https://github.com/mrdoob/three.js/issues/15560
+      body.computeVertexNormalsIdxRange(2, nVert);
 
-      var vBuf = new Float32Array(nVert*3); // plain buffer with all vertices
-      var nBuf = null;                      // plaint buffer with normals per vertex
-
-      if (rnr_data.nrmBuff) {
-         if (rnr_data.nrmBuff.length !== nVert) throw "Expect normals per face";
-         nBuf = new Float32Array(nVert*3);
-      }
-
-      for (var i=0;i<nVert;++i) {
-         var pos = rnr_data.idxBuff[i+2];
-         vBuf[i*3] = rnr_data.vtxBuff[pos*3];
-         vBuf[i*3+1] = rnr_data.vtxBuff[pos*3+1];
-         vBuf[i*3+2] = rnr_data.vtxBuff[pos*3+2];
-         if (nBuf) {
-            pos = i - i%3;
-            nBuf[i*3] = rnr_data.nrmBuff[pos];
-            nBuf[i*3+1] = rnr_data.nrmBuff[pos+1];
-            nBuf[i*3+2] = rnr_data.nrmBuff[pos+2];
-         }
-      }
-
-      var body = new THREE.BufferGeometry();
-
-      body.setAttribute('position', new THREE.BufferAttribute( vBuf, 3 ));
-
-      if (nBuf)
-         body.setAttribute('normal', new THREE.BufferAttribute( nBuf, 3 ));
-      else
-         body.computeVertexNormals();
-
-      body.get_ctrl = function() { return new EveElemControl(this); }
+      return body;
 
       // XXXX Fix this. It seems we could have flat shading with usage of simple shaders.
       // XXXX Also, we could do edge detect on the server for outlines.
@@ -1044,61 +1033,55 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       // XXXX triangles is trivial, we could do it before invoking the big guns (if they are even needed).
       // XXXX Oh, and once triangulated, we really don't need to store 3 as number of verts in a poly each time.
       // XXXX Or do we? We might need it for projection stuff.
-
-      return body;
    }
 
    EveElements.prototype.makeEveGeoShape = function(egs, rnr_data)
    {
-      var egs_ro = new THREE.Object3D();
+      let geom = this.makeEveGeometry(rnr_data);
 
-      var geom = this.makeEveGeometry(rnr_data);
+      let fcol = jsrp.getColor(egs.fFillColor);
 
-      var fcol = jsrp.getColor(egs.fFillColor);
-
-      var material = new THREE.MeshPhongMaterial({// side: THREE.DoubleSide,
+      let material = new THREE.MeshPhongMaterial({// side: THREE.DoubleSide,
                           depthWrite: false, color:fcol, transparent: true, opacity: 0.2 });
 
-      var mesh = new THREE.Mesh(geom, material);
+      let mesh = new THREE.Mesh(geom, material);
 
-      egs_ro.add(mesh);
+      mesh.get_ctrl = function() { return new EveElemControl(this); };
+      mesh.dispose  = function() { this.geometry.dispose(); this.material.dispose(); };
 
-      egs_ro.get_ctrl = function() { return new EveElemControl(this); }
-
-      return egs_ro;
+      return mesh;
    }
 
-   /** Keep this old code for reference, arbitrary referencing via index does not work */
-   EveElements.prototype.makePolygonSetProjectedOld = function(psp, rnr_data)
+   EveElements.prototype.makePolygonSetProjected = function(psp, rnr_data)
    {
-      var psp_ro = new THREE.Object3D();
-      var pos_ba = new THREE.BufferAttribute( rnr_data.vtxBuff, 3 );
-      var idx_ba = new THREE.BufferAttribute( rnr_data.idxBuff, 1 );
+      let psp_ro = new THREE.Object3D();
+      let pos_ba = new THREE.BufferAttribute( rnr_data.vtxBuff, 3 );
+      let idx_ba = new THREE.BufferAttribute( rnr_data.idxBuff, 1 );
 
-      var ib_len = rnr_data.idxBuff.length;
+      let ib_len = rnr_data.idxBuff.length;
 
-      var fcol = jsrp.getColor(psp.fMainColor);
+      let fcol = jsrp.getColor(psp.fMainColor);
       var line_mat = new THREE.LineBasicMaterial({color:fcol });
+      var mesh_mat = new THREE.MeshBasicMaterial({ side: THREE.DoubleSide, depthWrite: false,
+                                                   color:fcol, transparent: true, opacity: 0.4 });
 
-      for (var ib_pos = 0; ib_pos < ib_len; )
+      for (let ib_pos = 0; ib_pos < ib_len; )
       {
          if (rnr_data.idxBuff[ib_pos] == GL.TRIANGLES)
          {
             // Sergey: make check, for now here many wrong values
-            var is_ok = true, maxindx = rnr_data.vtxBuff.length/3;
-            for (var k=0;is_ok && (k < 3*rnr_data.idxBuff[ib_pos + 1]); ++k)
+            let is_ok = true, maxindx = rnr_data.vtxBuff.length/3;
+            for (let k=0;is_ok && (k < 3*rnr_data.idxBuff[ib_pos + 1]); ++k)
                if (rnr_data.idxBuff[ib_pos+2+k] > maxindx) is_ok = false;
 
             if (is_ok) {
-               var body = new THREE.BufferGeometry();
+               let body = new THREE.BufferGeometry();
                body.setAttribute('position', pos_ba);
                body.setIndex(idx_ba);
                body.setDrawRange(ib_pos + 2, 3 * rnr_data.idxBuff[ib_pos + 1]);
                body.computeVertexNormalsIdxRange(ib_pos + 2, 3 * rnr_data.idxBuff[ib_pos + 1]);
-               var material = new THREE.MeshBasicMaterial({ side: THREE.DoubleSide, depthWrite: false,
-                                               color:fcol, transparent: true, opacity: 0.4 });
 
-               psp_ro.add( new THREE.Mesh(body, material) );
+               psp_ro.add( new THREE.Mesh(body, mesh_mat) );
             } else {
                console.log('Error in makePolygonSetProjected - wrong GL.TRIANGLES indexes');
             }
@@ -1107,7 +1090,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          }
          else if (rnr_data.idxBuff[ib_pos] == GL.LINE_LOOP)
          {
-            var body = new THREE.BufferGeometry();
+            let body = new THREE.BufferGeometry();
             body.setAttribute('position', pos_ba);
             body.setIndex(idx_ba);
             body.setDrawRange(ib_pos + 2, rnr_data.idxBuff[ib_pos + 1]);
@@ -1123,87 +1106,19 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          }
       }
 
-      psp_ro.get_ctrl =  function() { return new EveElemControl(this); }
+      psp_ro.get_ctrl = function() { return new EveElemControl(this); };
+      psp_ro.dispose  = function() {
+         this.children.forEach(c => { c.geometry.dispose(); });
+         line_mat.dispose();
+         mesh_mat.dispose();
+      };
+
 
       return psp_ro;
    }
 
-   EveElements.prototype.makePolygonSetProjected = function(psp, rnr_data)
-   {
-      if (this.useIndexAsIs)
-         return this.makePolygonSetProjectedOld(psp, rnr_data);
-
-      var psp_ro = new THREE.Object3D(),
-          ib_len = rnr_data.idxBuff.length,
-          fcol = jsrp.getColor(psp.fMainColor);
-
-      for (var ib_pos = 0; ib_pos < ib_len; )
-      {
-         if (rnr_data.idxBuff[ib_pos] == GL.TRIANGLES) {
-
-            var nVert = rnr_data.idxBuff[ib_pos + 1] * 3,
-                vBuf = new Float32Array(nVert*3); // plain buffer with all vertices
-
-            for (var k=0;k<nVert;++k) {
-               var pos = rnr_data.idxBuff[ib_pos+2+k];
-               if (pos*3 > rnr_data.vtxBuff.length) { vBuf = null; break; }
-               vBuf[k*3] = rnr_data.vtxBuff[pos*3];
-               vBuf[k*3+1] = rnr_data.vtxBuff[pos*3+1];
-               vBuf[k*3+2] = rnr_data.vtxBuff[pos*3+2];
-            }
-
-            if (vBuf) {
-               var body = new THREE.BufferGeometry();
-               body.setAttribute('position', new THREE.BufferAttribute( vBuf, 3 ));
-               body.computeVertexNormals();
-               var material = new THREE.MeshBasicMaterial({ side: THREE.DoubleSide, depthWrite: false,
-                                  color:fcol, transparent: true, opacity: 0.4 });
-               psp_ro.add( new THREE.Mesh(body, material) );
-            } else {
-               console.log('Error in makePolygonSetProjected - wrong GL.TRIANGLES indexes');
-            }
-
-            ib_pos += 2 + nVert;
-         }
-         else if (rnr_data.idxBuff[ib_pos] == GL.LINE_LOOP)
-         {
-            var nVert = rnr_data.idxBuff[ib_pos + 1],
-                vBuf = new Float32Array(nVert*3); // plain buffer with all vertices
-
-            for (var k=0;k<nVert;++k) {
-               var pos = rnr_data.idxBuff[ib_pos+2+k];
-               if (pos*3 > rnr_data.vtxBuff.length) { vBuf = null; break; }
-               vBuf[k*3] = rnr_data.vtxBuff[pos*3];
-               vBuf[k*3+1] = rnr_data.vtxBuff[pos*3+1];
-               vBuf[k*3+2] = rnr_data.vtxBuff[pos*3+2];
-            }
-
-            if (vBuf) {
-               var body = new THREE.BufferGeometry();
-               body.setAttribute('position', new THREE.BufferAttribute( vBuf, 3 ));
-               var line_mat = new THREE.LineBasicMaterial({color:fcol });
-               psp_ro.add( new THREE.LineLoop(body, line_mat) );
-            } else {
-               console.log('Error in makePolygonSetProjected - wrong GL.LINE_LOOP indexes');
-            }
-
-            ib_pos += 2 + nVert;
-         }
-         else
-         {
-            console.error("Unexpected primitive type " + rnr_data.idxBuff[ib_pos]);
-            break;
-         }
-
-      }
-
-      psp_ro.get_ctrl =  function() { return new EveElemControl(this); }
-
-      return psp_ro;
-   }
 
    ////////////////////////////////////////////////////////////////////////////////////////////
-
 
    function StraightLineSetControl(mesh)
    {
@@ -1238,8 +1153,8 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
    StraightLineSetControl.prototype.getTooltipText = function(intersect)
    {
-      var t = this.obj3d.eve_el.fName || this.obj3d.eve_el.fTitle || "";
-      var idx = this.extractIndex(intersect);
+      let t = this.obj3d.eve_el.fName || this.obj3d.eve_el.fTitle || "";
+      let idx = this.extractIndex(intersect);
       return t + " idx=" + idx;
    }
 
@@ -1261,11 +1176,14 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       return true; // means index is different
    }
 
+   // XXXX - DrawForSelection thing is leaky ... need dispose func for what goes into res.
+   // XXXX - And then somebody needs to call it, too.
+
    StraightLineSetControl.prototype.DrawForSelection = function(sec_idcs, res)
     {
-      var m     = this.obj3d;
-      var index = sec_idcs;
-      var geom = new THREE.BufferGeometry();
+      let m     = this.obj3d;
+      let index = sec_idcs;
+      let geom = new THREE.BufferGeometry();
 
       geom.setAttribute( 'position', m.children[0].geometry.getAttribute("position") );
       if (index.length == 1)
@@ -1273,29 +1191,29 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          geom.setDrawRange(index[0]*2, 2);
       } else if (index.length > 1)
       {
-         var idcs = [];
-         for (var i = 0; i < index.length; ++i)
+         let idcs = [];
+         for (let i = 0; i < index.length; ++i)
             idcs.push(index[i]*2, index[i]*2+1);
          geom.setIndex( idcs );
       }
 
-      var color =  jsrp.getColor(m.eve_el.fMainColor);
-      var lineMaterial = new THREE.LineBasicMaterial({ color: color, linewidth: 4 });
-      var line         = new THREE.LineSegments(geom, lineMaterial);
+      let color =  jsrp.getColor(m.eve_el.fMainColor);
+      let lineMaterial = new THREE.LineBasicMaterial({ color: color, linewidth: 4 });
+      let line         = new THREE.LineSegments(geom, lineMaterial);
       line.matrixAutoUpdate = false;
       line.matrix.fromArray( m.matrix.toArray());
       line.updateMatrixWorld(true);
       res.geom.push(line);
 
-      var el = m.eve_el, mindx = []
+      let el = m.eve_el, mindx = []
 
-      for (var i = 0; i < index.length; ++i)
+      for (let i = 0; i < index.length; ++i)
       {
          if (index[i] < el.fLinePlexSize)
          {
-            var lineid = m.eve_idx_buf[index[i]];
+            let lineid = m.eve_idx_buf[index[i]];
 
-            for (var k = 0; k < el.fMarkerPlexSize; ++k )
+            for (let k = 0; k < el.fMarkerPlexSize; ++k )
             {
                if (m.eve_idx_buf[ k + el.fLinePlexSize] == lineid) mindx.push(k);
             }
@@ -1304,16 +1222,16 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
       if (mindx.length > 0)
       {
-         var pnts = new jsrp.PointsCreator(mindx.length, true, 5);
+         let pnts = new jsrp.PointsCreator(mindx.length, true, 5);
 
-         var arr = m.children[1].geometry.getAttribute("position").array;
+         let arr = m.children[1].geometry.getAttribute("position").array;
 
-         for (var i = 0; i < mindx.length; ++i)
+         for (let i = 0; i < mindx.length; ++i)
          {
-            var p = mindx[i]*3;
+            let p = mindx[i]*3;
             pnts.addPoint(arr[p], arr[p+1], arr[p+2] );
          }
-         var mark = pnts.createPoints(color);
+         let mark = pnts.createPoints(color);
          mark.material.size = m.children[1].material.size;
          mark.matrixAutoUpdate = false;
          mark.matrix.fromArray(m.matrix.toArray());
@@ -1324,18 +1242,18 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
 
    EveElements.prototype.makeStraightLineSet = function(el, rnr_data)
     {
-      var obj3d = new THREE.Object3D();
+      let obj3d = new THREE.Object3D();
 
-      var mainColor = jsrp.getColor(el.fMainColor);
+      let mainColor = jsrp.getColor(el.fMainColor);
 
       let buf = new Float32Array(el.fLinePlexSize * 6);
       for (let i = 0; i < el.fLinePlexSize * 6; ++i)
          buf[i] = rnr_data.vtxBuff[i];
-      var lineMaterial = new THREE.LineBasicMaterial({ color: mainColor, linewidth: el.fLineWidth });
+      let lineMaterial = new THREE.LineBasicMaterial({ color: mainColor, linewidth: el.fLineWidth });
 
-      var geom = new THREE.BufferGeometry();
+      let geom = new THREE.BufferGeometry();
       geom.setAttribute( 'position', new THREE.BufferAttribute( buf, 3 ) );
-      var line = new THREE.LineSegments(geom, lineMaterial);
+      let line = new THREE.LineSegments(geom, lineMaterial);
       obj3d.add(line);
 
       let msize = el.fMarkerPlexSize;
@@ -1346,7 +1264,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       for (let i = startIdx; i < endIdx; i+=3) {
          pnts.addPoint(rnr_data.vtxBuff[i], rnr_data.vtxBuff[i+1], rnr_data.vtxBuff[i+2] );
       }
-      var marker = pnts.createPoints(mainColor);
+      let marker = pnts.createPoints(mainColor);
 
       marker.material.sizeAttenuation = false;
 
@@ -1362,6 +1280,9 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       line.get_ctrl   = function() { return octrl; };
       marker.get_ctrl = function() { return octrl; };
       obj3d.get_ctrl  = function() { return octrl; };
+      obj3d.dispose   = function() {
+         this.children.forEach(c => { c.geometry.dispose(); c.material.dispose(); });
+      };
 
       return obj3d;
    }

--- a/ui5/eve7/lib/EveElements.js
+++ b/ui5/eve7/lib/EveElements.js
@@ -777,7 +777,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
         // get sign for the case of RhoZ projection
         if (calo.render_data.vtxBuff[idx*12 + 1] < 0) bin = -bin ;
 
-        let fcall = "NewBinPicked((Int_t)" +  bin + ", " +  slice + ", " + selectionId + ", " + multi + ")"
+        let fcall = "NewBinPicked(" +  bin + ", " +  slice + ", " + selectionId + ", " + multi + ")"
         scene.mgr.SendMIR(fcall, calo.fElementId, "ROOT::Experimental::REveCalo2D");
         return true;
     }
@@ -975,7 +975,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
         let selectionId = scene.mgr.global_selection_id;
         let multi = event && event.ctrlKey ? true : false;
         let fcall = "NewTowerPicked(" +  idxBuff[idx*2 + 1] + ", " +  idxBuff[idx*2] + ", "
-            + selectionId + ", " + multi + ");"
+            + selectionId + ", " + multi + ")";
         scene.mgr.SendMIR(fcall, calo.fElementId, "ROOT::Experimental::REveCalo3D");
         return true;
     }
@@ -987,7 +987,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
         let idxBuff = calo.render_data.idxBuff;
         let scene = this.obj3d.scene;
         let selectionId = scene.mgr.global_highlight_id;
-        let fcall = "NewTowerPicked(" +  idxBuff[idx*2 + 1] + ", " +  idxBuff[idx*2] + ", " + selectionId + ", false);"
+        let fcall = "NewTowerPicked(" +  idxBuff[idx*2 + 1] + ", " +  idxBuff[idx*2] + ", " + selectionId + ", false)";
         scene.mgr.SendMIR(fcall, calo.fElementId, "ROOT::Experimental::REveCalo3D");
     }
 

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -728,7 +728,8 @@ sap.ui.define([], function() {
          item.endChanges();
       }
 
-      this.handle.send("__REveDoneChanges");
+      if (this.handle.kind != "file")
+         this.handle.send("__REveDoneChanges");
       this.busyProcessingChanges = false;
    }
 

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -195,7 +195,7 @@ sap.ui.define([], function() {
 
       if ((this.handle.kind != "file") || (mir_call == "NextEvent()")) {
 
-         var req = {
+         let req = {
             "mir" : mir_call,
             "fElementId" : element_id,
             "class" : element_class
@@ -210,7 +210,7 @@ sap.ui.define([], function() {
     * onSceneChanged */
    EveManager.prototype.RegisterSceneReceiver = function(id, receiver, func_name) {
 
-      var elem = this.GetElement(id);
+      let elem = this.GetElement(id);
 
       if (!elem) return;
 
@@ -230,8 +230,8 @@ sap.ui.define([], function() {
    /** Invoke function on all receiver of scene events - when such function exists */
    EveManager.prototype.callSceneReceivers = function (scene, fname, arg) {
       if (scene.$receivers) {
-          for (var i=0; i < scene.$receivers.length; i++) {
-              var receiver = scene.$receivers[i];
+          for (let i=0; i < scene.$receivers.length; i++) {
+              let receiver = scene.$receivers[i];
               if (typeof receiver[fname] == "function")
                  receiver[fname](arg);
           }
@@ -249,16 +249,16 @@ sap.ui.define([], function() {
       if (arr[0].fTotalBinarySize)
          this.last_json = arr;
 
-      for (var n = 1; n < arr.length; ++n)
+      for (let n = 1; n < arr.length; ++n)
       {
-         var elem = arr[n];
+         let elem = arr[n];
 
-         var obj = this.map[elem.fElementId];
+         let obj = this.map[elem.fElementId];
 
          if ( ! obj) // YYYY isn't it an error if obj exists?
          {
             // element did not exist up to now
-            var parent = null;
+            let parent = null;
             if (elem.fMotherId !== 0) {
                parent = this.map[elem.fMotherId];
             } else {
@@ -274,8 +274,7 @@ sap.ui.define([], function() {
 
             parent.childs.push(elem);
 
-            // YYYY why?
-            obj = this.map[elem.fElementId] = elem;
+            this.map[elem.fElementId] = elem;
          }
 
          this.ParseUpdateTriggersAndProcessPostStream(elem);
@@ -289,23 +288,24 @@ sap.ui.define([], function() {
 
    //______________________________________________________________________________
 
-   EveManager.prototype.RecursiveRemove = function(elem, delSet) {
-      var elId = elem.fElementId;
-      var motherId = elem.fMotherId;
+   EveManager.prototype.RecursiveRemove = function(elem, delSet)
+   {
+      let elId     = elem.fElementId;
+      let motherId = elem.fMotherId;
 
       // iterate children
       if (elem.childs !== undefined) {
          while (elem.childs.length > 0) {
-            var n = 0;
-            var sub = elem.childs[n];
+            let n = 0;
+            let sub = elem.childs[n];
             this.RecursiveRemove(sub, delSet);
          }
       }
 
-      // delete myself from mater
-      var mother = this.GetElement(motherId);
-      var mc = mother.childs;
-      for (var i = 0; i < mc.length; ++i) {
+      // delete myself from master
+      let mother = this.GetElement(motherId);
+      let mc = mother.childs;
+      for (let i = 0; i < mc.length; ++i) {
 
          if (mc[i].fElementId === elId) {
             mc.splice(i, 1);
@@ -323,39 +323,38 @@ sap.ui.define([], function() {
 
    EveManager.prototype.ImportSceneChangeJson = function(msg)
    {
-      var arr = msg.arr;
       this.last_json = null;
       this.scene_changes = msg;
 
-      var scene = this.GetElement(msg.header.fSceneId);
+      let scene = this.GetElement(msg.header.fSceneId);
       // console.log("ImportSceneChange", scene.fName, msg);
 
       // notify scenes for beginning of changes and
       // notify for element removal
-      var removedIds = msg.header["removedElements"]; // AMT empty set should not be sent at the first place
+      let removedIds = msg.header["removedElements"]; // AMT empty set should not be sent at the first place
       if (removedIds.length)
          this.callSceneReceivers(scene, "elementsRemoved", removedIds);
 
-      var delSet = new Set();
-      for (var r = 0; r < removedIds.length; ++r) {
-         var id  = removedIds[r];
+      let delSet = new Set();
+      for (let r = 0; r < removedIds.length; ++r) {
+         let id  = removedIds[r];
          delSet.add(id);
       }
-     // console.log("start with delSet ", delSet);
+      // console.log("start with delSet ", delSet);
       while (delSet.size != 0) {
-         var it = delSet.values();
-         var id = it.next().value;
+         let it = delSet.values();
+         let id = it.next().value;
          // console.log("going to call RecursiveRemove .... ", this.map[id]);
          this.RecursiveRemove(this.GetElement(id), delSet);
-         // console.log("complete RecursiveREmove ", delSet);
+         // console.log("complete RecursiveRemove ", delSet);
       }
 
       // wait for binary if needed
       if (msg.header.fTotalBinarySize)
       {
           this.last_json = [1];
-          for (var i = 0; i < arr.length; ++i)
-              this.last_json.push(arr[i]);
+          for (let i = 0; i < msg.arr.length; ++i)
+              this.last_json.push(msg.arr[i]);
 
       } else {
          this.CompleteSceneChanges();
@@ -369,28 +368,28 @@ sap.ui.define([], function() {
    {
       if (!this.scene_changes) return;
 
-      var arr = this.scene_changes.arr;
-      var header = this.scene_changes.header;
-      var scene = this.GetElement(header.fSceneId);
-      var nModified = header["numRepresentationChanged"];
+      let arr = this.scene_changes.arr;
+      let header = this.scene_changes.header;
+      let scene = this.GetElement(header.fSceneId);
+      let nModified = header["numRepresentationChanged"];
 
       // first import new elements in element map
-      for (var n=0; n<arr.length; ++n)
+      for (let n=0; n<arr.length; ++n)
       {
-         var em = arr[n];
+         let em = arr[n];
          if (em.changeBit & this.EChangeBits.kCBAdded) {
             this.map[em.fElementId] = em;
          }
       }
 
-      for (var n=0; n<arr.length; ++n)
+      for (let n=0; n<arr.length; ++n)
       {
-         var em = arr[n];
+         let em = arr[n];
 
          em.tag = "changeBit";
          if (em.changeBit & this.EChangeBits.kCBAdded) {
              // create new
-            var parent = this.map[em.fMotherId];
+            let parent = this.map[em.fMotherId];
             if (!parent.childs) // YYYY do we really need to create arrays here? Can it really be undef?
                parent.childs = [];
             parent.childs.push(em);
@@ -401,7 +400,7 @@ sap.ui.define([], function() {
          }
 
          // merge new and old element
-         var obj = this.map[em.fElementId];
+         let obj = this.map[em.fElementId];
          if(!obj) {
             console.log("ERRROR can't find element in map ", em); continue;
          }
@@ -444,10 +443,10 @@ sap.ui.define([], function() {
    EveManager.prototype.FindViewers = function(chlds) {
       if (chlds === undefined) chlds = this.childs;
 
-      for (var k=0;k<chlds.length;++k) {
+      for (let k=0;k<chlds.length;++k) {
          if (!chlds[k].childs) continue;
          if (chlds[k]._typename == "ROOT::Experimental::REveViewerList") return chlds[k].childs;
-         var res = this.FindViewers(chlds[k].childs);
+         let res = this.FindViewers(chlds[k].childs);
          if (res) return res;
       }
    }
@@ -456,17 +455,17 @@ sap.ui.define([], function() {
 
       if (!this.last_json || !rawdata || !rawdata.byteLength) return;
 
-      var arr = this.last_json;
+      let arr = this.last_json;
       this.last_json = null;
 
-      var lastoff = offset;
+      let lastoff = offset;
 
-      for (var n=1; n<arr.length;++n) {
-         var elem = arr[n];
+      for (let n=1; n<arr.length;++n) {
+         let elem = arr[n];
 
          if (!elem.render_data) continue;
 
-         var rd = elem.render_data,
+         let rd = elem.render_data,
              off = offset + rd.rnr_offset,
              obj = this.GetElement(elem.fElementId);
 
@@ -562,7 +561,7 @@ sap.ui.define([], function() {
          return;
       }
 
-      var oldMap = new Map();
+      let oldMap = new Map();
       sel.prev_sel_list.forEach(function(rec) {
          let iset = new Set(rec.sec_idcs);
          let x    = { "valid": true, "implied": rec.implied, "set": iset, "extra": rec.extra };
@@ -574,7 +573,7 @@ sap.ui.define([], function() {
       // I probably can't just throw them out, especially not for the selection primary as it is used
       // as a key.
 
-      var newMap = new Map();
+      let newMap = new Map();
       sel.sel_list.forEach(function(rec) {
          let iset = new Set(rec.sec_idcs);
          let x    = { "valid": true, "implied": rec.implied, "set": iset, "extra": rec.extra };
@@ -607,17 +606,17 @@ sap.ui.define([], function() {
          }
       }
 
-      var changedSet = new Set();
-      for (var [id, value] of oldMap.entries())
+      let changedSet = new Set();
+      for (let [id, value] of oldMap.entries())
       {
          if (JSROOT.EVE.DebugSelection)
             console.log("UnSel prim", id, this.GetElement(id), this.GetElement(id).fSceneId);
 
          this.UnselectElement(sel, id);
-         var iel = this.GetElement(id);
+         let iel = this.GetElement(id);
          changedSet.add(iel.fSceneId);
 
-         for (var imp of value.implied)
+         for (let imp of value.implied)
          {
             if (JSROOT.EVE.DebugSelection)
                console.log("UnSel impl", imp, this.GetElement(imp), this.GetElement(imp).fSceneId);
@@ -627,13 +626,13 @@ sap.ui.define([], function() {
          }
       }
 
-      for (var [id, value] of newMap.entries())
+      for (let [id, value] of newMap.entries())
       {
          if (JSROOT.EVE.DebugSelection)
             console.log("Sel prim", id, this.GetElement(id), this.GetElement(id).fSceneId);
 
-         var secIdcs = Array.from(value.set);
-         var iel = this.GetElement(id);
+         let secIdcs = Array.from(value.set);
+         let iel = this.GetElement(id);
          if ( ! iel) {
             console.log("EveManager.prototype.UT_Selection_Refresh_State this should not happen ", iel);
             continue;
@@ -641,7 +640,7 @@ sap.ui.define([], function() {
          changedSet.add(iel.fSceneId);
          this.SelectElement(sel, id, secIdcs, value.extra);
 
-         for (var imp of value.implied)
+         for (let imp of value.implied)
          {
             if (JSROOT.EVE.DebugSelection)
                console.log("Sel impl", imp, this.GetElement(imp), this.GetElement(imp).fSceneId);
@@ -716,11 +715,11 @@ sap.ui.define([], function() {
    EveManager.prototype.ServerEndRedrawCallback = function()
    {
       // console.log("ServerEndRedrawCallback ", this.listScenesToRedraw);
-      var recs = new Set();
-      for ( var i =0; i < this.listScenesToRedraw.length; i++) {
-         var scene = this.listScenesToRedraw[i];
+      let recs = new Set();
+      for ( let i =0; i < this.listScenesToRedraw.length; i++) {
+         let scene = this.listScenesToRedraw[i];
          if (scene.$receivers) {
-            for (var r=0; r < scene.$receivers.length; r++) {
+            for (let r=0; r < scene.$receivers.length; r++) {
                recs.add( scene.$receivers[r]);
             }
          }
@@ -735,10 +734,10 @@ sap.ui.define([], function() {
 
    /** Method invoked from server message to browse to element elid */
    EveManager.prototype.BrowseElement = function(elid) {
-      var scenes = this.getSceneElements();
+      let scenes = this.getSceneElements();
 
-      for (var i = 0; i < scenes.length; ++i) {
-         var scene = this.GetElement(scenes[i].fElementId);
+      for (let i = 0; i < scenes.length; ++i) {
+         let scene = this.GetElement(scenes[i].fElementId);
          this.callSceneReceivers(scene, "BrowseElement", elid);
          break; // normally default scene is enough
       }
@@ -773,10 +772,10 @@ sap.ui.define([], function() {
 
    /** find elements ids where fMasterId equal to provided */
    EveManager.prototype.FindElemetsForMaster = function(elementId, collect_ids) {
-      var res = [];
+      let res = [];
 
-      for (var elid in this.map) {
-         var el = this.map[elid];
+      for (let elid in this.map) {
+         let el = this.map[elid];
          if ((el.fMasterId === elementId) && (el.fElementId !== elementId))
             res.push(collect_ids ? el.fElementId : el);
       }
@@ -787,9 +786,9 @@ sap.ui.define([], function() {
    /** used to intercept NewElementPicked for hightlight and selection @private */
    EveManager.prototype._intercept_NewElementPicked = function(elementId) {
 
-      var mirElem = this.GetElement(this._intercept_id);
+      let mirElem = this.GetElement(this._intercept_id);
 
-      var msg1 = { content: "BeginChanges" }, msg3 = { content: "EndChanges" },
+      let msg1 = { content: "BeginChanges" }, msg3 = { content: "EndChanges" },
           msg2 = { arr: [ JSROOT.extend({UT_PostStream:"UT_Selection_Refresh_State", changeBit: 4}, mirElem) ],
                    header:{ content:"ElementsRepresentaionChanges", fSceneId: mirElem.fSceneId, fTotalBinarySize:0, numRepresentationChanged:1, removedElements:[] }};
 
@@ -802,7 +801,7 @@ sap.ui.define([], function() {
 
    /** used to intercept BrowseElement call @private */
    EveManager.prototype._intercept_BrowseElement = function(elementId) {
-      var msg1 = { content: "BrowseElement", id: elementId },
+      let msg1 = { content: "BrowseElement", id: elementId },
           msg2 = { content: "BeginChanges" },
           msg3 = { content: "EndChanges" };
 
@@ -812,10 +811,10 @@ sap.ui.define([], function() {
    /** @summary used to intercept SetRnrSelf call
      * @private */
    EveManager.prototype._intercept_SetRnrSelf = function(flag) {
-      var messages = [{ content: "BeginChanges" }];
+      let messages = [{ content: "BeginChanges" }];
 
-      var mirElem = this.GetElement(this._intercept_id);
-      var msg = { arr: [{ changeBit:8, fElementId: mirElem.fElementId, fRnrChildren: mirElem.fRnrChildren, fRnrSelf: flag }],
+      let mirElem = this.GetElement(this._intercept_id);
+      let msg = { arr: [{ changeBit:8, fElementId: mirElem.fElementId, fRnrChildren: mirElem.fRnrChildren, fRnrSelf: flag }],
                   header:{ content: "ElementsRepresentaionChanges", fSceneId: mirElem.fSceneId, fTotalBinarySize:0, numRepresentationChanged:1, removedElements:[]}};
 
       messages.push(msg);
@@ -833,12 +832,12 @@ sap.ui.define([], function() {
    /** @summary used to intercept SetMainColorRGB
      * @private */
    EveManager.prototype._intercept_SetMainColorRGB = function(colr, colg, colb) {
-      var messages = [{ content: "BeginChanges" }];
+      let messages = [{ content: "BeginChanges" }];
 
-      var newColor = JSROOT.Painter.addColor("rgb(" + colr + "," + colg + "," + colb + ")");
+      let newColor = JSROOT.Painter.addColor("rgb(" + colr + "," + colg + "," + colb + ")");
 
-      var mirElem = this.GetElement(this._intercept_id);
-      var msg = { arr: [ JSROOT.extend({changeBit:1}, mirElem) ],
+      let mirElem = this.GetElement(this._intercept_id);
+      let msg = { arr: [ JSROOT.extend({changeBit:1}, mirElem) ],
                   header:{ content: "ElementsRepresentaionChanges", fSceneId: mirElem.fSceneId, fTotalBinarySize:0, numRepresentationChanged:1, removedElements:[]}};
 
       msg.arr[0].fMainColor = newColor;
@@ -847,7 +846,7 @@ sap.ui.define([], function() {
       messages.push(msg);
 
       this.FindElemetsForMaster(this._intercept_id).forEach(function(subElem) {
-         var msg = { arr: [ JSROOT.extend({changeBit:1}, subElem) ],
+         let msg = { arr: [ JSROOT.extend({changeBit:1}, subElem) ],
                header: { content: "ElementsRepresentaionChanges", fSceneId: subElem.fSceneId, fTotalBinarySize:0, numRepresentationChanged:1, removedElements:[]}};
          msg.arr[0].fMainColor = newColor;
          msg.arr[0].sel_list = msg.arr[0].prev_sel_list = msg.arr[0].render_data = undefined;
@@ -866,7 +865,7 @@ sap.ui.define([], function() {
          return false;
 
       // just do not intercept
-      var do_intercept = false;
+      let do_intercept = false;
 
       if (((mir_call.indexOf("NewElementPicked(") == 0) && ((element_id == this.global_highlight_id) || (element_id == this.global_selection_id))) ||
           ((mir_call.indexOf("BrowseElement(") == 0) && (element_id == 0)) ||
@@ -884,7 +883,7 @@ sap.ui.define([], function() {
       if (mir_call.indexOf("SetMainColorRGB(") == 0)
          mir_call = mir_call.replace(/\(UChar_t\)/g, '');
 
-      var func = new Function('JSROOT.$eve7mir._intercept_' + mir_call);
+      let func = new Function('JSROOT.$eve7mir._intercept_' + mir_call);
 
       try {
          func();

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -146,7 +146,7 @@ sap.ui.define([], function() {
          }
 
          if (JSROOT.EVE.gDebug)
-            console.log("OnWebsocketMsg msg len=", msg.length, "txt:", (msg.length < 1000) ? msg : (msg.substr(0, 1000) + "..."));
+            console.log("OnWebsocketMsg msg len=", msg.length, "txt:", (msg.length < 100) ? msg : (msg.substr(0, 500) + "..."));
 
          let resp = JSON.parse(msg);
 
@@ -729,6 +729,7 @@ sap.ui.define([], function() {
          item.endChanges();
       }
 
+      this.handle.send("__REveDoneChanges");
       this.busyProcessingChanges = false;
    }
 

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -784,8 +784,8 @@ sap.ui.define([], function() {
       return res;
    }
 
-   /** used to intercept NewElementPicked for hightlight and selection @private */
-   EveManager.prototype._intercept_NewElementPicked = function(elementId) {
+   /** used to intercept NewElementPickedStr for hightlight and selection @private */
+   EveManager.prototype._intercept_NewElementPickedStr = function(elementId) {
 
       let mirElem = this.GetElement(this._intercept_id);
 
@@ -868,7 +868,7 @@ sap.ui.define([], function() {
       // just do not intercept
       let do_intercept = false;
 
-      if (((mir_call.indexOf("NewElementPicked(") == 0) && ((element_id == this.global_highlight_id) || (element_id == this.global_selection_id))) ||
+      if (((mir_call.indexOf("NewElementPickedStr(") == 0) && ((element_id == this.global_highlight_id) || (element_id == this.global_selection_id))) ||
           ((mir_call.indexOf("BrowseElement(") == 0) && (element_id == 0)) ||
           (mir_call.indexOf("SetRnrSelf(") == 0) || (mir_call.indexOf("SetMainColorRGB(") == 0))
          do_intercept = true;

--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -167,6 +167,8 @@ sap.ui.define([], function() {
          }
          else if (resp.content == "EndChanges") {
             this.ServerEndRedrawCallback();
+            if (resp.log)
+               console.log(resp.log);
          }
          else if (resp.content == "BrowseElement") {
             this.BrowseElement(resp.id);

--- a/ui5/eve7/lib/EveScene.js
+++ b/ui5/eve7/lib/EveScene.js
@@ -16,7 +16,6 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       this.glctrl  = glctrl;
       this.creator = glctrl.viewer.creator;
       this.id2obj_map  = new Map; // base on element id
-      this.mid2obj_map = new Map; // base on master id
 
       this.first_time = true;
 
@@ -64,10 +63,9 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       }
    }
 
-   EveScene.prototype.getObj3D = function(elementId, is_master)
+   EveScene.prototype.getObj3D = function(elementId)
    {
-      let map = is_master ? this.mid2obj_map : this.id2obj_map;
-      return map.get(elementId);
+      return this.id2obj_map.get(elementId);
    }
 
    EveScene.prototype.create3DObjects = function(all_ancestor_children_visible, prnt, res3d)
@@ -101,7 +99,6 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
                   res3d.push(obj3d);
 
                   this.id2obj_map.set(elem.fElementId, obj3d);
-                  if (elem.fMasterId) this.mid2obj_map.set(elem.fMasterId, obj3d);
 
                   obj3d.visible = elem.fRnrSelf && all_ancestor_children_visible;
                   obj3d.all_ancestor_children_visible = all_ancestor_children_visible;
@@ -207,7 +204,6 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
       container.add(obj3d);
 
       this.id2obj_map.set(el.fElementId, obj3d);
-      if (el.fMasterId) this.mid2obj_map.set(el.fMasterId, obj3d);
    }
 
    EveScene.prototype.replaceElement = function (el) {
@@ -227,20 +223,13 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          obj3d.visible = visible;
          container.add(obj3d);
 
-
          this.id2obj_map.set(el.fElementId, obj3d);
-         if (el.fMasterId) this.mid2obj_map.set(el.fMasterId, obj3d);
 
          this.glctrl.viewer.render();
       }
       catch (e) {
          console.error("replace element", e);
       }
-   }
-
-   EveScene.prototype.elementRemoved = function()
-   {
-      // XXXXX how is this empty? not called?
    }
 
    EveScene.prototype.elementsRemoved = function(ids)
@@ -252,7 +241,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          if (!obj3d) {
             let el = this.mgr.GetElement(elId);
             if (el && el.render_data) {
-               console.log("ERROR EveScene.prototype.elementsRemoved can't find obj3d ",this.mgr.GetElement(el));
+               console.log("ERROR EveScene.prototype.elementsRemoved can't find obj3d ", this.mgr.GetElement(el));
             }
             continue;
          }
@@ -261,6 +250,11 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(EveManager) {
          container.remove(obj3d);
 
          this.id2obj_map.delete(elId);
+
+         if (typeof obj3d.dispose !== 'function')
+            console.log("EveScene.elementsRemoved no dispose function for " + this.mgr.GetElement(elId)._typename, ", rnr obj ", obj3d._typename);
+         else
+            obj3d.dispose();
       }
    }
 

--- a/ui5/eve7/lib/GlViewerThree.js
+++ b/ui5/eve7/lib/GlViewerThree.js
@@ -428,9 +428,9 @@ sap.ui.define([
          this.raycaster.setFromCamera(mouse, this.camera);
 
          let intersects = this.raycaster.intersectObjects(this.scene.children, true);
-
          for (let i = 0; i < intersects.length; ++i) {
-            if (intersects[i].object.get_ctrl && intersects[i].object.visible) {
+            if (intersects[i].object.get_ctrl &&
+               intersects[i].object.eve_el.fPickable && intersects[i].object.visible) {
                intersects[i].mouse = mouse;
                intersects[i].w = w;
                intersects[i].h = h;
@@ -443,7 +443,6 @@ sap.ui.define([
          delete this.mousemove_timeout;
 
          var intersect = this.getIntersectAt(x, y);
-
          if (!intersect)
             return this.clearHighlight();
 

--- a/ui5/eve7/lib/GlViewerThree.js
+++ b/ui5/eve7/lib/GlViewerThree.js
@@ -429,7 +429,7 @@ sap.ui.define([
 
          let intersects = this.raycaster.intersectObjects(this.scene.children, true);
          for (let i = 0; i < intersects.length; ++i) {
-            if (intersects[i].object.get_ctrl &&
+            if (intersects[i].object.get_ctrl && intersects[i].object.eve_el &&
                intersects[i].object.eve_el.fPickable && intersects[i].object.visible) {
                intersects[i].mouse = mouse;
                intersects[i].w = w;


### PR DESCRIPTION
With this change, the method invocation request is received directly from civetweb server thread. The changes are executed through REveManager thread execution thread that processes.

The REveManger::DoRedraw() method bacame depreciated.

It is now possible to apply changes without a client interface after the connection is created. This example is implemented in autoplay of events in tutorials/eve7/event_demo.C

Other  changes:
 * Fix memory leaks in the client
 * Reduce calls of TSystem::ProcessLine
 * Add structure to transfer server messages to client log (REveLog).