### PR TITLE
Implement json output for v7 tutorials in the reference guide.

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -124,6 +124,9 @@ From now on, the likelihoods are normalized by the sum of integrals in each rang
 
 ## Class Reference Guide
 
+- Images for ROOT7 tutorials can be generated, in json format, using the directive using
+  `\macro_image (json)` in the macro header.
+
 
 ## Build, Configuration and Testing Infrastructure
 

--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -55,6 +55,7 @@
 ///  Some tutorials generate pictures (png or pdf) with `Print` or `SaveAs`.
 ///  Such pictures can be displayed with `\macro_image (picture_name.png[.pdf])`
 ///  When the option (js) is used the image is displayed as JavaScript.
+///  For ROOT 7 tutorials, when the option (json) is used the image is displayed as json file.
 ///
 ///  2. `\macro_code`
 ///  The macro code is shown.  A caption can be added: `\macro_code This is code`
@@ -324,6 +325,9 @@ void FilterTutorial()
          ReplaceAll(gLineString,"(nobatch)","");
          bool js = (gLineString.find("(js)") != string::npos);
          ReplaceAll(gLineString,"(js)","");
+         bool json = (gLineString.find("(json)") != string::npos);
+         ReplaceAll(gLineString,"(json)","");
+
          bool image_created_by_macro = (gLineString.find(".png)") != string::npos) ||
                                        (gLineString.find(".svg)") != string::npos) ||
                                        (gLineString.find(".pdf)") != string::npos);
@@ -339,10 +343,18 @@ void FilterTutorial()
          } else if (js) {
             string IN;
             IN = gImageName;
-            int i = IN.find(".C");
+            int i = IN.find(".");
             IN.erase(i,IN.length());
             ExecuteCommand(StringFormat("root -l -b -q \"makerootfile.C(\\\"%s\\\",\\\"%s\\\",\\\"%s\\\",false,false)\"",
                                          gFileName.c_str(), IN.c_str(), gOutDir.c_str()));
+            ReplaceAll(gLineString, "macro_image", StringFormat("htmlinclude %s.html",IN.c_str()));
+         } else if (json) {
+            string IN;
+            IN = gImageName;
+            int i = IN.find(".");
+            IN.erase(i,IN.length());
+            ExecuteCommand(StringFormat("root -l -b -q --web=batch \"makejsonfile.C(\\\"%s\\\",\\\"%s\\\",\\\"%s\\\",false,false)\"",
+                                          gFileName.c_str(), IN.c_str(), gOutDir.c_str()));
             ReplaceAll(gLineString, "macro_image", StringFormat("htmlinclude %s.html",IN.c_str()));
          } else {
             if (gPython) {

--- a/documentation/doxygen/makejsonfile.C
+++ b/documentation/doxygen/makejsonfile.C
@@ -1,0 +1,38 @@
+/// Generates the json file output of the macro MacroName
+
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RColor.hxx"
+#include "ROOT/RText.hxx"
+#include "ROOT/RPadPos.hxx"
+
+void makejsonfile(const char *MacroName, const char *IN, const char *OutDir, bool cp, bool py)
+{
+   using namespace ROOT::Experimental;
+
+   // Execute the macro as a C++ one or a Python one.
+   if (!py) gROOT->ProcessLine(Form(".x %s",MacroName));
+   else     gROOT->ProcessLine(Form("TPython::ExecScript(\"%s\");",MacroName));
+
+   // If needed, copy the macro in the documentation directory.
+   if (cp) {
+      TString MN = MacroName;
+      Int_t i = MN.Index("(");
+      Int_t l = MN.Length();
+      if (i>0) MN.Remove(i, l);
+      gSystem->Exec(TString::Format("cp %s %s/macros", MN.Data(), OutDir));
+   }
+
+   // Retrieve the RCanvas produced by the macro execution and produce the json file.
+   auto canv = RCanvas::GetCanvases()[0];
+   TString json_file = TString::Format("%s/html/%s.json",OutDir,IN);
+   canv->SaveAs(json_file.Data());
+
+   // Build the html file inlining the json picture
+   FILE *fh = fopen(TString::Format("%s/macros/%s.html",OutDir,IN), "w");
+   fprintf(fh,"<script src=\"https://root.cern/js/dev/scripts/JSRoot.core.min.js\" type=\"text/javascript\"></script>\n");
+   fprintf(fh,"<div id=\"draw_json_%s\" style=\"width:700px; height:500px\"></div>\n", IN);
+   fprintf(fh,"<script type='text/javascript'>JSROOT.httpRequest(\"./%s.json\",\"object\")",IN);
+   fprintf(fh,".then(obj => JSROOT.draw(\"draw_json_%s\", obj))", IN);
+   fprintf(fh,";</script>\n");
+   fclose(fh);
+}

--- a/documentation/doxygen/makerootfile.C
+++ b/documentation/doxygen/makerootfile.C
@@ -1,7 +1,5 @@
 /// Generates the root file output of the macro MacroName
 
-
-
 void makerootfile(const char *MacroName, const char *IN, const char *OutDir, bool cp, bool py)
 {
 

--- a/tutorials/v7/box.cxx
+++ b/tutorials/v7/box.cxx
@@ -5,6 +5,7 @@
 /// draw ROOT 7 boxes in it (RBox). It generates a set of boxes using the
 /// "normal" coordinates' system.
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2018-10-10
@@ -40,15 +41,9 @@ void box()
    Box3->AttrBox().AttrFill().SetColor(RColor::kBlue);
 
    auto Box4 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.7_normal), RPadPos(0.9_normal,0.9_normal));
-   //OptsBox4->SetFillStyle(0);
-   //OptsBox4->SetRoundWidth(50);
-   //OptsBox4->SetRoundHeight(25);
    Box4->AttrBox().AttrBorder().SetWidth(3);
 
    auto Box5 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.1_normal), RPadPos(0.9_normal,0.3_normal));
-   //OptsBox5->SetFillStyle(0);
-   //OptsBox5->SetRoundWidth(25);
-   //OptsBox5->SetRoundHeight(50);
    Box5->AttrBox().AttrBorder().SetWidth(3);
 
    canvas->Show();

--- a/tutorials/v7/draw.cxx
+++ b/tutorials/v7/draw.cxx
@@ -1,6 +1,7 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2015-03-22

--- a/tutorials/v7/draw_axes.cxx
+++ b/tutorials/v7/draw_axes.cxx
@@ -4,6 +4,7 @@
 /// This ROOT7 example demonstrates how to create a RCanvas and
 /// draw several RAxis objects with different options.
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2020-11-03

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -1,6 +1,7 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2020-02-20

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -4,6 +4,7 @@
 /// This macro generates two TH1D objects and build RLegend
 /// In addition use of auto colors are shown
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2019-10-09

--- a/tutorials/v7/draw_pave.cxx
+++ b/tutorials/v7/draw_pave.cxx
@@ -4,6 +4,7 @@
 /// This macro generates a small V7 TH1D, fills it and draw it in a V7 canvas.
 /// The canvas is display in the web browser
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2015-03-22

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -4,6 +4,7 @@
 /// This macro generates two RH1D, fills them and draw with different options in RCanvas.
 /// The canvas is display in the web browser
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2015-03-22

--- a/tutorials/v7/draw_rh2.cxx
+++ b/tutorials/v7/draw_rh2.cxx
@@ -3,6 +3,7 @@
 ///
 /// This macro generates RH2D and draw it with different options in RCanvas
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2020-06-25

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -4,6 +4,7 @@
 /// This macro generates a small V7 TH2D, fills it with random values and
 /// draw it in a V7 canvas, using configured web browser
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2020-03-04

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -4,6 +4,7 @@
 /// This macro generates really large RH2D histogram, fills it with predefined pattern and
 /// draw it in a RCanvas, using Optmize() drawing mode
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2020-06-26

--- a/tutorials/v7/draw_rh3.cxx
+++ b/tutorials/v7/draw_rh3.cxx
@@ -4,6 +4,7 @@
 /// This macro generates a small RH3D, fills it with random values and
 /// draw it in RCanvas, using configured web browser
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2020-06-18

--- a/tutorials/v7/draw_rh3_large.cxx
+++ b/tutorials/v7/draw_rh3_large.cxx
@@ -4,6 +4,7 @@
 /// This macro generates really large RH2D histogram, fills it with predefined pattern and
 /// draw it in a RCanvas, using Optmize() drawing mode
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2020-06-26

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -4,6 +4,7 @@
 /// This ROOT 7 example demonstrates how to create a ROOT 7 canvas (RCanvas),
 /// divide on subpads and draw histograms there
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2018-03-13

--- a/tutorials/v7/draw_text.cxx
+++ b/tutorials/v7/draw_text.cxx
@@ -1,6 +1,10 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
+/// This macro demonstrate the text attributes for RText. Angle, size and color are
+/// changed in a loop. The text alignment and the text font are fixed.
+///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2017-10-17

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -3,6 +3,7 @@
 ///
 /// This macro shows how ROOT objects like TH1, TH2, TGraph can be drawn in RCanvas.
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2017-06-02

--- a/tutorials/v7/global_temperatures.cxx
+++ b/tutorials/v7/global_temperatures.cxx
@@ -6,6 +6,7 @@
 /// average temperature per city by season. Then it does the same for average temperature per city for the years between 1993-2002, and 2003-2013.
 /// Finally, the tutorial visualizes this processed data through histograms.
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 ///

--- a/tutorials/v7/line.cxx
+++ b/tutorials/v7/line.cxx
@@ -42,5 +42,7 @@ void line()
 
    canvas->SetSize(900, 700);
 
+   canvas->SaveAs("line.png");
+
    canvas->Show();
 }

--- a/tutorials/v7/line.cxx
+++ b/tutorials/v7/line.cxx
@@ -42,8 +42,5 @@ void line()
 
    canvas->SetSize(900, 700);
 
-   // requires Chrome browser, runs in headless mode
-   canvas->SaveAs("line.png");
-
-   // canvas->Show();
+   canvas->Show();
 }

--- a/tutorials/v7/lineRStyle.cxx
+++ b/tutorials/v7/lineRStyle.cxx
@@ -4,6 +4,7 @@
 /// This ROOT 7 example demonstrates how to customize RLine object using RStyle
 /// "normal" coordinates' system.
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2019-10-04

--- a/tutorials/v7/lineStyle.cxx
+++ b/tutorials/v7/lineStyle.cxx
@@ -1,6 +1,7 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2018-03-18

--- a/tutorials/v7/lineWidth.cxx
+++ b/tutorials/v7/lineWidth.cxx
@@ -1,6 +1,7 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2018-03-18

--- a/tutorials/v7/markerStyle.cxx
+++ b/tutorials/v7/markerStyle.cxx
@@ -1,6 +1,7 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2018-03-18

--- a/tutorials/v7/pad.cxx
+++ b/tutorials/v7/pad.cxx
@@ -1,6 +1,7 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
+/// \macro_image (json)
 /// \macro_code
 ///
 /// \date 2015-03-22


### PR DESCRIPTION
- Images for ROOT7 tutorials can be generated, in json format, using the directive using
  `\macro_image (json)` in the macro header.
