### PR TITLE
Use latest JSROOT as fallback in JupyROOT

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -83,7 +83,7 @@ if (typeof require !== 'undefined') {{
     // Try loading a local version of requirejs and fallback to cdn if not possible.
     script_load(base_url + 'static/scripts/JSRoot.core.js', script_success, function(){{
         console.error('Fail to load JSROOT locally, please check your jupyter_notebook_config.py file')
-        script_load('https://root.cern/js/5.9.0/scripts/JSRootCore.min.js', script_success, function(){{
+        script_load('https://root.cern/js/6.1.0/scripts/JSRoot.core.min.js', script_success, function(){{
             document.getElementById("{jsDivId}").innerHTML = "Failed to load JSROOT";
         }});
     }});


### PR DESCRIPTION
ROOT is now contains v6.x of JSROOT and its API used also
in JupyROOT notebooks. Therefore fallback version should
be also from v6.x - latest is 6.1.0