### PR TITLE
Should fix unprotected memcpy call.

### DIFF
--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -132,7 +132,7 @@ TString::TString(const char *cs, Ssiz_t n)
       return;
    }
    char *data = Init(n, n);
-   memcpy(data, cs, n);
+   memmove(data, cs, n);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Should fix [this](https://github.com/root-project/root/issues/8136) issue

`memmove` and `memcpy` are basically equivalent, just that memmove supports overlapping memory. This should fix the given issue.