### PR TITLE
[RF] Add RooAbsArg::getParameters RooAbsArg::getObservables overloads that takes output parameter 

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
@@ -68,7 +68,7 @@ public:
 
   void initializeBarlowCache();
 
-  RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected=kTRUE) const;
+  bool getParameters(const RooArgSet* depList, RooArgSet& outputSet, bool stripDisconnected=true) const;
 
   // void setAlwaysStartFromMin(Bool_t flag) { _startFromMin = flag ; }
   // Bool_t alwaysStartFromMin() const { return _startFromMin ; }

--- a/roofit/histfactory/src/RooBarlowBeestonLL.cxx
+++ b/roofit/histfactory/src/RooBarlowBeestonLL.cxx
@@ -356,24 +356,23 @@ void RooStats::HistFactory::RooBarlowBeestonLL::initializeBarlowCache() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooArgSet* RooStats::HistFactory::RooBarlowBeestonLL::getParameters(const RooArgSet* depList, Bool_t stripDisconnected) const {
-  RooArgSet* allArgs = RooAbsArg::getParameters( depList, stripDisconnected );
+bool RooStats::HistFactory::RooBarlowBeestonLL::getParameters(const RooArgSet* depList,
+                                                              RooArgSet& outputSet,
+                                                              bool stripDisconnected) const {
+  bool errorInBaseCall = RooAbsArg::getParameters( depList, outputSet, stripDisconnected );
 
-  TIter iter_args = allArgs->createIterator();
-  RooRealVar* arg;
-  while((arg=(RooRealVar*)iter_args.Next())) {
-    std::string arg_name = arg->GetName();
+  for (auto const& arg : outputSet) {
 
     // If there is a gamma in the name,
     // strip it from the list of dependencies
 
-    if( _statUncertParams.find(arg_name.c_str()) != _statUncertParams.end() ) {
-      allArgs->remove( *arg, kTRUE );
+    if( _statUncertParams.find(arg->GetName()) != _statUncertParams.end() ) {
+      outputSet.remove( *arg, true );
     }
 
   }
 
-  return allArgs;
+  return errorInBaseCall || false;
 
 }
 

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -300,7 +300,8 @@ public:
   RooArgSet* getObservables(const RooAbsData& data) const {
     return getObservables(&data) ;
   }
-  RooArgSet* getObservables(const RooArgSet* depList, Bool_t valueOnly=kTRUE) const ;
+  RooArgSet* getObservables(const RooArgSet* depList, bool valueOnly=true) const ;
+  bool getObservables(const RooArgSet* depList, RooArgSet& outputSet, bool valueOnly=true) const;
   Bool_t observableOverlaps(const RooAbsData* dset, const RooAbsArg& testArg) const ;
   Bool_t observableOverlaps(const RooArgSet* depList, const RooAbsArg& testArg) const ;
   virtual Bool_t checkObservables(const RooArgSet* nset) const ;

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -280,16 +280,17 @@ public:
   friend class RooAddPdf ;
   friend class RooAddPdfOrig ;
   RooArgSet* getVariables(Bool_t stripDisconnected=kTRUE) const ;
-  RooArgSet* getParameters(const RooAbsData* data, Bool_t stripDisconnected=kTRUE) const ;
+  RooArgSet* getParameters(const RooAbsData* data, bool stripDisconnected=true) const ;
   /// Return the parameters of this p.d.f when used in conjuction with dataset 'data'
-  RooArgSet* getParameters(const RooAbsData& data, Bool_t stripDisconnected=kTRUE) const {
+  RooArgSet* getParameters(const RooAbsData& data, bool stripDisconnected=true) const {
     return getParameters(&data,stripDisconnected) ;
   }
   /// Return the parameters of the p.d.f given the provided set of observables
-  RooArgSet* getParameters(const RooArgSet& observables, Bool_t stripDisconnected=kTRUE) const {
+  RooArgSet* getParameters(const RooArgSet& observables, bool stripDisconnected=true) const {
     return getParameters(&observables,stripDisconnected);
   }
-  virtual RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected=kTRUE) const ;
+  RooArgSet* getParameters(const RooArgSet* observables, bool stripDisconnected=true) const;
+  virtual bool getParameters(const RooArgSet* observables, RooArgSet& outputSet, bool stripDisconnected=true) const;
   /// Given a set of possible observables, return the observables that this PDF depends on.
   RooArgSet* getObservables(const RooArgSet& set, Bool_t valueOnly=kTRUE) const {
     return getObservables(&set,valueOnly) ;

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -692,12 +692,31 @@ RooArgSet* RooAbsArg::getObservables(const RooAbsData* set) const
 /// for deleting the returned argset. The complement of this function
 /// is getParameters().
 
-RooArgSet* RooAbsArg::getObservables(const RooArgSet* dataList, Bool_t valueOnly) const
+RooArgSet* RooAbsArg::getObservables(const RooArgSet* dataList, bool valueOnly) const
 {
-  //cout << "RooAbsArg::getObservables(" << GetName() << ")" << endl ;
+  auto depList = new RooArgSet;
+  getObservables(dataList, *depList, valueOnly);
+  return depList;
+}
 
-  RooArgSet* depList = new RooArgSet("dependents") ;
-  if (!dataList) return depList ;
+
+////////////////////////////////////////////////////////////////////////////////
+/// Create a list of leaf nodes in the arg tree starting with
+/// ourself as top node that match any of the names the args in the
+/// supplied argset.
+/// Returns `true` only if something went wrong.
+/// The complement of this function is getParameters().
+/// \param[in] dataList Set of leaf nodes to match.
+/// \param[out] outputSet Output set.
+/// \param[in] valueOnly If this parameter is true, we only match leafs that
+///                      depend on the value of any arg in `dataList`.
+
+bool RooAbsArg::getObservables(const RooArgSet* dataList, RooArgSet& outputSet, bool valueOnly) const
+{
+  outputSet.clear();
+  outputSet.setName("dependents");
+
+  if (!dataList) return false;
 
   // Make iterator over tree leaf node list
   RooArgSet leafList("leafNodeServerList") ;
@@ -706,18 +725,18 @@ RooArgSet* RooAbsArg::getObservables(const RooArgSet* dataList, Bool_t valueOnly
   if (valueOnly) {
     for (const auto arg : leafList) {
       if (arg->dependsOnValue(*dataList) && arg->isLValue()) {
-        depList->add(*arg) ;
+        outputSet.add(*arg) ;
       }
     }
   } else {
     for (const auto arg : leafList) {
       if (arg->dependsOn(*dataList) && arg->isLValue()) {
-        depList->add(*arg) ;
+        outputSet.add(*arg) ;
       }
     }
   }
 
-  return depList ;
+  return false;
 }
 
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4905,12 +4905,12 @@ RooSpan<double> RooAbsReal::evaluateSpan(RooBatchCompute::RunContext& evalData, 
   // the leaf values itself to integrate over them. That's why we only add the
   // parameters and observables here.
   RooArgSet allLeafs;
-  for(auto const& param : *getParameters(RooArgSet{})) {
-    allLeafs.add(*param);
-  }
-  for(auto const& obs : *getObservables(RooArgSet{})) {
-    allLeafs.add(*obs);
-  }
+  RooArgSet parameters;
+  RooArgSet observables;
+  getParameters(normSet, parameters);
+  getObservables(normSet, observables);
+  allLeafs.add(parameters);
+  allLeafs.add(observables);
 
   std::vector<RooAbsRealLValue*> settableLeaves;
   std::vector<RooSpan<const double>> leafValues;


### PR DESCRIPTION
Creating RooArgSets on the heap should be avoided. The existing
`RooAbsArg::getParameters/Observables` created a RooArgSet calling `operator new`.
This commit adds an overload of `RooAbsArg::getParameters/Observables` that takes an
output parameter such that the output RooArgSet can also be created on
the stack.

Using these new methods, a memory leak in `RooAbsReal::evaluateSpan` is fixed. This leak was recently introduced in PR https://github.com/root-project/root/pull/7742 and backported to 6.24.

Therefore, this fix should also be backported to 6.24.