### PR TITLE
[RF] No reimplementation of `RooAbsPdf::expectedEvents(const RooArgSet &)`

### DIFF
--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -242,9 +242,14 @@ public:
   inline Bool_t mustBeExtended() const {
     return (extendMode() == MustBeExtended) ; 
   }
+  /// Return expected number of events to be used in calculation of extended
+  /// likelihood.
   virtual Double_t expectedEvents(const RooArgSet* nset) const ; 
-  /// Return expected number of events to be used in calculation of extended likelihood.
-  virtual Double_t expectedEvents(const RooArgSet& nset) const {
+  /// Return expected number of events to be used in calculation of extended
+  /// likelihood. This function should not be overridden, as it just redirects
+  /// to the actual virtual function but takes a RooArgSet reference instead of
+  /// pointer (\see expectedEvents(const RooArgSet*) const).
+  double expectedEvents(const RooArgSet& nset) const {
     return expectedEvents(&nset) ; 
   }
 

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -54,12 +54,9 @@ public:
     // Return extended mode capabilities    
     return (_haveLastCoef || _allExtendable) ? MustBeExtended : CanNotBeExtended; 
   }
+  /// Return expected number of events for extended likelihood calculation, which
+  /// is the sum of all coefficients.
   virtual Double_t expectedEvents(const RooArgSet* nset) const ;
-  virtual Double_t expectedEvents(const RooArgSet& nset) const { 
-    // Return expected number of events for extended likelihood calculation
-    // which is the sum of all coefficients
-    return expectedEvents(&nset) ; 
-  }
 
   const RooArgList& pdfList() const { 
     // Return list of component p.d.fs

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -60,12 +60,9 @@ public:
     // Return extended mode capabilities
     return ((_haveLastCoef&&!_recursive) || _allExtendable) ? MustBeExtended : CanNotBeExtended; 
   }
+  /// Return expected number of events for extended likelihood calculation, which
+  /// is the sum of all coefficients.
   virtual Double_t expectedEvents(const RooArgSet* nset) const ;
-  virtual Double_t expectedEvents(const RooArgSet& nset) const { 
-    // Return expected number of events for extended likelihood calculation
-    // which is the sum of all coefficients
-    return expectedEvents(&nset) ; 
-  }
 
   const RooArgList& pdfList() const { 
     // Return list of component p.d.fs

--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -66,7 +66,6 @@ public:
   bool selfNormalized() const override { return true; }
 
   ExtendMode extendMode() const override { return _pdf->extendMode(); }
-  using RooAbsPdf::expectedEvents;
   virtual Double_t expectedEvents(const RooArgSet* nset) const override { return _pdf->expectedEvents(nset); }
 
   /// Forwards to the PDF's implementation.

--- a/roofit/roofitcore/inc/RooExtendPdf.h
+++ b/roofit/roofitcore/inc/RooExtendPdf.h
@@ -44,8 +44,6 @@ public:
   virtual Bool_t selfNormalized() const { return kTRUE ; }
   virtual ExtendMode extendMode() const { return CanBeExtended ; }
   virtual Double_t expectedEvents(const RooArgSet* nset) const ;
-  ///See expectedEvents(const RooArgSet* nset) const
-  virtual Double_t expectedEvents(const RooArgSet& nset) const { return expectedEvents(&nset) ; }
 
 protected:
 

--- a/roofit/roofitcore/inc/RooExtendedTerm.h
+++ b/roofit/roofitcore/inc/RooExtendedTerm.h
@@ -31,11 +31,8 @@ public:
   Double_t evaluate() const { return 1. ; }
 
   virtual ExtendMode extendMode() const { return CanBeExtended ; }
+  /// Return number of expected events, in other words the value of the associated n parameter.
   virtual Double_t expectedEvents(const RooArgSet* nset) const ;
-  virtual Double_t expectedEvents(const RooArgSet& nset) const { 
-    // Return number of expected events, i.e. the value of the associated n parameter
-    return expectedEvents(&nset) ; 
-  }
 
 protected:
 

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -68,7 +68,6 @@ public:
 
   virtual ExtendMode extendMode() const ;
   virtual Double_t expectedEvents(const RooArgSet* nset) const ; 
-  virtual Double_t expectedEvents(const RooArgSet& nset) const { return expectedEvents(&nset) ; }
 
   const RooArgList& pdfList() const { return _pdfList ; }
 

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -46,12 +46,9 @@ public:
 
   virtual ExtendMode extendMode() const ; 
 
+  /// Return expected number of events for extended likelihood calculation, which
+  /// is the sum of all coefficients.
   virtual Double_t expectedEvents(const RooArgSet* nset) const ;
-  virtual Double_t expectedEvents(const RooArgSet& nset) const { 
-    // Return expected number of events for extended likelihood calculation
-    // which is the sum of all coefficients
-    return expectedEvents(&nset) ; 
-  }
 
   virtual Bool_t selfNormalized() const { return getAttribute("BinnedLikelihoodActive") ; }
 

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -53,7 +53,6 @@ public:
   virtual ExtendMode extendMode() const ;
 
   virtual Double_t expectedEvents(const RooArgSet* nset) const ;
-  virtual Double_t expectedEvents(const RooArgSet& nset) const { return expectedEvents(&nset) ; }
 
   virtual Bool_t forceAnalyticalInt(const RooAbsArg&) const { return kTRUE ; }
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const ;


### PR DESCRIPTION
The function `RooAbsPdf::expectedEvents(const RooArgSet &)` doesn't have
to be reimplemented in the RooAbsPdf child classes, because it should
always redirect to `RooAbsPdf::expectedEvents(const RooArgSet *)`.

In this way, we are also avoiding a virtual function call.

The second PR is this commit does some modernization of `RooAddPdf::expectedEvents`.