### PR TITLE
Comment out unused `args` parameter in daos_obj_generate_id

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
+++ b/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
@@ -410,7 +410,7 @@ enum {
 };
 
 static inline int daos_obj_generate_id(daos_obj_id_t *oid, daos_ofeat_t ofeats,
-		     daos_oclass_id_t cid, uint32_t args)
+		     daos_oclass_id_t cid, uint32_t /*args*/)
 {
 	(void)args;
 	uint64_t hdr;


### PR DESCRIPTION
This is done to avoid a compiler warning (or an error for me, as I treated compiler warnings as errors).