### PR TITLE
Catch captured exceptions by TBB

### DIFF
--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -855,7 +855,8 @@ TEST_P(RDFSimpleTests, NonExistingFileInChain)
    bool exceptionCaught = false;
    try {
       ROOT_EXPECT_ERROR(df.Count().GetValue(), "TFile::TFile", expecteddiag.Data());
-   } catch (const std::runtime_error &e) {
+   // Catch not only std::runtime_error, but also tbb::captured_exception from worker threads.
+   } catch (const std::exception &e) {
       const std::string expected_msg =
          ROOT::IsImplicitMTEnabled()
             ? "TTreeProcessorMT::Process: an error occurred while opening file \"doesnotexist.root\""


### PR DESCRIPTION
If the `std::runtime_error` is thrown by a worker thread, TBB throws a `tbb::captured_exception` on the root thread.