### PR TITLE
[RF] Simplify HistFactory models

### DIFF
--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -64,6 +64,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistFactory
     src/Systematics.cxx
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
+  LIBRARIES
+    RooBatchCompute
   DEPENDENCIES
     RooFit
     RooFitCore

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -30,7 +30,8 @@
 
 #include "RooStats/HistFactory/Systematics.h"
 class ParamHistFunc;
-
+class RooProduct;
+class RooHistFunc;
 
 namespace RooStats{
   namespace HistFactory{
@@ -69,7 +70,7 @@ namespace RooStats{
 			      std::vector<std::string>& likelihoodTermNames, 
 			      std::vector<std::string>& totSystTermNames);
 
-      std::string AddNormFactor(RooWorkspace* proto, std::string& channel, 
+      std::unique_ptr<RooProduct> CreateNormFactor(RooWorkspace* proto, std::string& channel,
 				std::string& sigmaEpsilon, Sample& sample, bool doRatio);
 
       void AddMultiVarGaussConstraint(RooWorkspace* proto, std::string prefix, 
@@ -86,16 +87,14 @@ namespace RooStats{
 			   std::map<std::string,double> logNormSyst, 
 			   std::map<std::string,double> noSyst);
 
-      void LinInterpWithConstraint(RooWorkspace* proto, const TH1* nominal, std::vector<HistoSys>,
-				   std::string prefix, std::string productPrefix, 
-				   std::string systTerm, 
-				   std::vector<std::string>& likelihoodTermNames);
+      RooAbsArg* MakeLinInterpWithConstraint(RooHistFunc* nominalHistFunc, RooWorkspace* proto, const std::vector<HistoSys>&,
+				   const std::string& prefix, std::vector<std::string>& likelihoodTermNames, const RooArgList& observables) const;
 
       RooWorkspace* MakeSingleChannelWorkspace(Measurement& measurement, Channel& channel);
 
-      void MakeTotalExpected(RooWorkspace* proto, std::string totName, 
-			     std::vector<std::string>& syst_x_expectedPrefixNames,
-			     std::vector<std::string>& normByNames);
+      void MakeTotalExpected(RooWorkspace* proto, const std::string& totName,
+			     const std::vector<RooProduct*>& sampleScaleFactors,
+			     std::vector<std::vector<RooAbsArg*>>&  sampleHistFuncs) const;
     
       RooDataSet* MergeDataSets(RooWorkspace* combined,
 				std::vector<std::unique_ptr<RooWorkspace>>& wspace_vec,
@@ -104,8 +103,8 @@ namespace RooStats{
 				RooArgList obsList,
 				RooCategory* channelCat);
 
-      void ProcessExpectedHisto(const TH1* hist, RooWorkspace* proto, std::string prefix,
-				std::string productPrefix, std::string systTerm );
+      RooHistFunc* MakeExpectedHistFunc(const TH1* hist, RooWorkspace* proto, std::string prefix,
+          const RooArgList& observables) const;
 
       void SetObsToExpected(RooWorkspace* proto, std::string obsPrefix, std::string expPrefix, 
 			    int lowBin, int highBin);
@@ -137,7 +136,9 @@ namespace RooStats{
       std::vector<std::string> fObsNameVec;
       std::string fObsName;
       std::vector<std::string> fPreprocessFunctions;
-    
+
+      RooArgList createObservables(const TH1 *hist, RooWorkspace *proto) const;
+
       ClassDef(RooStats::HistFactory::HistoToWorkspaceFactoryFast,3)
     };
   

--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -12,20 +12,14 @@
 #ifndef ROO_PARAMHISTFUNC
 #define ROO_PARAMHISTFUNC
 
-#include <list>
-#include <string>
-
 #include "RooAbsReal.h"
-#include "RooRealProxy.h"
 #include "RooListProxy.h"
 #include "RooObjCacheManager.h"
 #include "RooDataHist.h"
 
 // Forward Declarations
 class RooRealVar;
-class RooArgList ;
 class RooWorkspace;
-class RooBinning;
 
 class ParamHistFunc : public RooAbsReal {
 public:
@@ -36,7 +30,7 @@ public:
   virtual ~ParamHistFunc() ;
 
   ParamHistFunc(const ParamHistFunc& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new ParamHistFunc(*this, newname); }
+  virtual TObject* clone(const char* newname) const override { return new ParamHistFunc(*this, newname); }
 
   const RooArgList& paramList() const { return _paramSet ; }
 
@@ -55,18 +49,18 @@ public:
 
   double binVolume() const { return _dataSet.binVolume(); }
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg&) const { return kTRUE ; }
+  virtual Bool_t forceAnalyticalInt(const RooAbsArg&) const override { return kTRUE ; }
 
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const override;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override;
 
   static RooArgList createParamSet(RooWorkspace& w, const std::string&, const RooArgList& Vars);
   static RooArgList createParamSet(RooWorkspace& w, const std::string&, const RooArgList& Vars, Double_t, Double_t);
   static RooArgList createParamSet(const std::string&, Int_t, Double_t, Double_t);
 
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ; 
-  virtual Bool_t isBinnedDistribution(const RooArgSet& /*obs*/) const {return kTRUE;}
+  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override;
+  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override;
+  virtual Bool_t isBinnedDistribution(const RooArgSet& /*obs*/) const override { return true; }
 
 
 protected:
@@ -88,11 +82,8 @@ protected:
   } ;
   mutable RooObjCacheManager _normIntMgr ; // The integration cache manager
 
-  // Turn into a RooListProxy
-  //RooRealProxy _dataVar;       // The RooRealVar
   RooListProxy _dataVars;       // The RooRealVars
   RooListProxy _paramSet ;            // interpolation parameters
-  //RooAbsBinning* _binning;  // Holds the binning of the dataVar (at construction time)
 
   Int_t _numBins;
   struct NumBins {
@@ -108,21 +99,17 @@ protected:
   };
   mutable NumBins _numBinsPerDim; //!
   mutable RooDataHist _dataSet;
-   //Bool_t _normalized;
 
-  // std::vector< Double_t > _nominalVals; // The nominal vals when gamma = 1.0 ( = 1.0 by default)
-  RooArgList   _ownedList ;       // List of owned components
-
-  Int_t getCurrentBin() const ;
+  Int_t getCurrentBin() const;
   Int_t addVarSet( const RooArgList& vars );
   Int_t addParamSet( const RooArgList& params );
   static Int_t GetNumBins( const RooArgSet& vars );
-  Double_t evaluate() const;
+  double evaluate() const override;
 
 private:
   static NumBins getNumBinsPerDim(RooArgSet const& vars);
 
-  ClassDef(ParamHistFunc,6) // Sum of RooAbsReal objects
+  ClassDefOverride(ParamHistFunc, 6)
 };
 
 #endif

--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -105,6 +105,7 @@ protected:
   Int_t addParamSet( const RooArgList& params );
   static Int_t GetNumBins( const RooArgSet& vars );
   double evaluate() const override;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
 
 private:
   static NumBins getNumBinsPerDim(RooArgSet const& vars);

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -96,6 +96,7 @@ protected:
   std::vector<int> _interpCode;
 
   Double_t evaluate() const;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
 
   ClassDef(PiecewiseInterpolation,3) // Sum of RooAbsReal objects
 };

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -37,6 +37,11 @@ public:
   PiecewiseInterpolation(const PiecewiseInterpolation& other, const char* name = 0);
   virtual TObject* clone(const char* newname) const { return new PiecewiseInterpolation(*this, newname); }
 
+  /// Return pointer to the nominal hist function.
+  const RooAbsReal* nominalHist() const {
+    return &_nominal.arg();
+  }
+
   //  virtual Double_t defaultErrorLevel() const ;
 
   //  void printMetaArgs(std::ostream& os) const ;

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -64,6 +64,7 @@
 #include "TStopwatch.h"
 #include "TVectorD.h"
 #include "TMatrixDSym.h"
+#include "ROOT/RMakeUnique.hxx"
 
 // specific to this package
 #include "RooStats/HistFactory/LinInterpVar.h"
@@ -492,7 +493,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     string overallNorm_times_sigmaEpsilon = sample.GetName() + "_" + channel + "_scaleFactors";
     auto sigEps = proto->arg(sigmaEpsilon.c_str());
     assert(sigEps);
-    std::unique_ptr<RooProduct> normFactor( new RooProduct(overallNorm_times_sigmaEpsilon.c_str(), overallNorm_times_sigmaEpsilon.c_str(), RooArgList(*sigEps) ) );
+    auto normFactor = std::make_unique<RooProduct>(overallNorm_times_sigmaEpsilon.c_str(), overallNorm_times_sigmaEpsilon.c_str(), RooArgList(*sigEps));
 
     if(normList.size() > 0){
 

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -755,12 +755,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
           name = name.substr(0, pos) + "shapes";
         }
 
-        RooArgSet terms;
-        for (auto func : thisSampleHistFuncs) {
-          terms.add(*func);
-        }
-
-        RooProduct shapeProduct(name.c_str(), name.c_str(), terms);
+        RooProduct shapeProduct(name.c_str(), name.c_str(), RooArgSet(thisSampleHistFuncs.begin(), thisSampleHistFuncs.end()));
         proto->import(shapeProduct, RecycleConflictNodes());
         shapeList.add(*proto->function(name.c_str()));
       }

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -1979,7 +1979,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       if(!model) cout <<"failed to find model for channel"<<endl;
       //      cout << "int = " << model->createIntegral(*obsN)->getVal() << endl;;
       models.push_back(model);
-      globalObs.add(*ch->set("globalObservables"));
+      globalObs.add(*ch->set("globalObservables"), /*silent=*/true); // silent because observables might exist in other channel.
 
       //      constrainedParams->add( * ch->set("constrainedParams") );
       pdfMap[channel_name]=model;

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -50,6 +50,8 @@
 #include "RooCustomizer.h"
 #include "RooPlot.h"
 #include "RooHelpers.h"
+#include "RooBinning.h"
+#include "RooBinWidthFunction.h"
 #include "RooStats/RooStatsUtils.h"
 #include "RooStats/ModelConfig.h"
 #include "RooStats/HistFactory/PiecewiseInterpolation.h"
@@ -318,22 +320,44 @@ namespace HistFactory{
 
   }
 
-  void HistoToWorkspaceFactoryFast::ProcessExpectedHisto(const TH1* hist,RooWorkspace* proto,
-							 string prefix, string productPrefix, 
-							 string systTerm ) {
+/// Create observables of type RooRealVar. Creates 1 to 3 observables, depending on the type of the histogram.
+RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWorkspace *proto) const {
+  RooArgList observables;
+
+  for (unsigned int idx=0; idx < fObsNameVec.size(); ++idx) {
+    if (!proto->var(fObsNameVec[idx].c_str())) {
+      const TAxis *axis = (idx == 0) ? hist->GetXaxis() : (idx == 1 ? hist->GetYaxis() : hist->GetZaxis());
+      Int_t nbins = axis->GetNbins();
+      Double_t xmin = axis->GetXmin();
+      Double_t xmax = axis->GetXmax();
+      // create observable
+      auto obs = static_cast<RooRealVar*>(proto->factory(
+          Form("%s[%f,%f]", fObsNameVec[idx].c_str(), xmin, xmax)));
+      obs->setBins(nbins);
+      if (axis->IsVariableBinSize()) {
+        RooBinning binning(nbins, axis->GetXbins()->GetArray());
+        obs->setBinning(binning);
+      }
+    }
+
+    observables.add(*proto->var(fObsNameVec[idx].c_str()));
+  }
+
+  return observables;
+}
+
+  /// Create the nominal hist function from `hist`, and register it in the workspace.
+  RooHistFunc* HistoToWorkspaceFactoryFast::MakeExpectedHistFunc(const TH1* hist,RooWorkspace* proto, string prefix,
+      const RooArgList& observables) const {
     if(hist) {
       cxcoutI(HistFactory) << "processing hist " << hist->GetName() << endl;
     } else {
       cxcoutF(HistFactory) << "hist is empty" << endl;
       R__ASSERT(hist != 0); 
-      return;                  
+      return nullptr;
     }
 
-    /// require dimension >=1 or <=3
-    if (fObsNameVec.empty() && !fObsName.empty()) { fObsNameVec.push_back(fObsName); }    
-    R__ASSERT( fObsNameVec.size()>=1 && fObsNameVec.size()<=3 );
-
-    /// determine histogram dimensionality 
+    // determine histogram dimensionality
     unsigned int histndim(1);
     std::string classname = hist->ClassName();
     if      (classname.find("TH1")==0) { histndim=1; }
@@ -341,36 +365,15 @@ namespace HistFactory{
     else if (classname.find("TH3")==0) { histndim=3; }
     R__ASSERT( histndim==fObsNameVec.size() );
 
-    /// create roorealvar observables
-    RooArgList observables;
-    std::vector<std::string>::iterator itr = fObsNameVec.begin();
-    for (int idx=0; itr!=fObsNameVec.end(); ++itr, ++idx ) {
-      if ( !proto->var(itr->c_str()) ) {
-        const TAxis* axis(0);
-        if (idx==0) { axis = hist->GetXaxis(); }
-        if (idx==1) { axis = hist->GetYaxis(); }
-        if (idx==2) { axis = hist->GetZaxis(); }
-        Int_t nbins = axis->GetNbins();
-        Double_t xmin = axis->GetXmin();
-        Double_t xmax = axis->GetXmax();
-        // create observable
-        proto->factory(Form("%s[%f,%f]",itr->c_str(),xmin,xmax));
-        proto->var(itr->c_str())->setBins(nbins);
-      }
-      observables.add( *proto->var(itr->c_str()) );
-    }
+    prefix += "_Hist_alphanominal";
 
-    RooDataHist* histDHist = new RooDataHist((prefix+"nominalDHist").c_str(),"",observables,hist);
-    RooHistFunc* histFunc = new RooHistFunc((prefix+"_nominal").c_str(),"",observables,*histDHist,0) ;
+    RooDataHist histDHist((prefix + "DHist").c_str(),"",observables,hist);
+    RooHistFunc histFunc(prefix.c_str(),"",observables,histDHist,0);
 
-    proto->import(*histFunc);
+    proto->import(histFunc, RecycleConflictNodes());
+    auto histFuncInWS = static_cast<RooHistFunc*>(proto->arg(prefix.c_str()));
 
-    /// now create the product of the overall efficiency times the sigma(params) for this estimate
-    proto->factory(("prod:"+productPrefix+"("+prefix+"_nominal,"+systTerm+")").c_str() );
-
-    delete histDHist;
-    delete histFunc; 
-
+    return histFuncInWS;
   }
 
   void HistoToWorkspaceFactoryFast::AddMultiVarGaussConstraint(RooWorkspace* proto, string prefix,int lowBin, int highBin, vector<string>& constraintTermNames){
@@ -399,59 +402,20 @@ namespace HistFactory{
     RooMultiVarGaussian constraint((prefix+"Constraint").c_str(),"",
              floating, mean, Cov);
              
-    proto->import(constraint);
+    proto->import(constraint, RecycleConflictNodes());
 
     constraintTermNames.push_back(constraint.GetName());
   }
 
-  void HistoToWorkspaceFactoryFast::LinInterpWithConstraint(RooWorkspace* proto, const TH1* nominal,
-      std::vector<HistoSys> histoSysList,
-      string prefix, string productPrefix,
-      string systTerm,
-      vector<string>& constraintTermNames){
+  /// Create a linear interpolation object that holds nominal and systematics, import it into the workspace,
+  /// and return a pointer to it.
+  RooAbsArg* HistoToWorkspaceFactoryFast::MakeLinInterpWithConstraint(RooHistFunc* nominalFunc,
+      RooWorkspace* proto, const std::vector<HistoSys>& histoSysList,
+      const string& prefix, std::vector<string>& constraintTermNames,
+      const RooArgList& observables) const {
 
     // these are the nominal predictions: eg. the mean of some space of variations
     // later fill these in a loop over histogram bins
-
-    // require dimension >=1 or <=3
-    if (fObsNameVec.empty() && !fObsName.empty()) { fObsNameVec.push_back(fObsName); }    
-    R__ASSERT( fObsNameVec.size()>=1 && fObsNameVec.size()<=3 );
-
-    // determine histogram dimensionality 
-    unsigned int histndim(1);
-    std::string classname = nominal->ClassName();
-    if      (classname.find("TH1")==0) { histndim=1; }
-    else if (classname.find("TH2")==0) { histndim=2; }
-    else if (classname.find("TH3")==0) { histndim=3; }
-    R__ASSERT( histndim==fObsNameVec.size() );
-
-    // create roorealvar observables
-    RooArgList observables;
-    std::vector<std::string>::iterator itr = fObsNameVec.begin();
-    for (int idx=0; itr!=fObsNameVec.end(); ++itr, ++idx ) {
-      if ( !proto->var(itr->c_str()) ) {
-        const TAxis* axis(nullptr);
-        if (idx==0) { axis = nominal->GetXaxis(); }
-        else if (idx==1) { axis = nominal->GetYaxis(); }
-        else if (idx==2) { axis = nominal->GetZaxis(); }
-        else {
-          std::cout << "Error: Too many observables.  "
-              << "HistFactory only accepts up to 3 observables (3d) "
-              << std::endl;
-          throw hf_exc();
-        }
-        Int_t nbins = axis->GetNbins();
-        Double_t xmin = axis->GetXmin();
-        Double_t xmax = axis->GetXmax();
-        // create observable
-        proto->factory(Form("%s[%f,%f]",itr->c_str(),xmin,xmax));
-        proto->var(itr->c_str())->setBins(nbins);
-      }
-      observables.add( *proto->var(itr->c_str()) );
-    }
-
-    RooDataHist* nominalDHist = new RooDataHist((prefix+"nominalDHist").c_str(),"",observables,nominal);
-    RooHistFunc* nominalFunc = new RooHistFunc((prefix+"nominal").c_str(),"",observables,*nominalDHist,0) ;
 
     // make list of abstract parameters that interpolate in space of variations
     RooArgList params( ("alpha_Hist") );
@@ -463,7 +427,7 @@ namespace HistFactory{
       std::stringstream str;
       str<<"_"<<j;
 
-      HistoSys& histoSys = histoSysList.at(j);
+      const HistoSys& histoSys = histoSysList.at(j);
       string histoSysName = histoSys.GetName();
 
       RooRealVar* temp = (RooRealVar*) proto->var(("alpha_" + histoSysName).c_str());
@@ -490,7 +454,7 @@ namespace HistFactory{
       std::stringstream str;
       str<<"_"<<j;
 
-      HistoSys& histoSys = histoSysList.at(j);
+      const HistoSys& histoSys = histoSysList.at(j);
       RooDataHist* lowDHist = new RooDataHist((prefix+str.str()+"lowDHist").c_str(),"",observables, histoSys.GetHistoLow());
       RooDataHist* highDHist = new RooDataHist((prefix+str.str()+"highDHist").c_str(),"",observables, histoSys.GetHistoHigh());
       RooHistFunc* lowFunc = new RooHistFunc((prefix+str.str()+"low").c_str(),"",observables,*lowDHist,0) ;
@@ -508,20 +472,27 @@ namespace HistFactory{
     interp.setBinIntegrator(observableSet);
     interp.forceNumInt();
 
-    proto->import(interp); // individual params have already been imported in first loop of this function
+    proto->import(interp, RecycleConflictNodes()); // individual params have already been imported in first loop of this function
 
-    // now create the product of the overall efficiency times the sigma(params) for this estimate
-    proto->factory(("prod:"+productPrefix+"("+prefix+","+systTerm+")").c_str() );    
+    auto interpInWS = proto->arg(prefix.c_str());
+    assert(interpInWS);
 
+    return interpInWS;
   }
 
   // GHL: Consider passing the NormFactor list instead of the entire sample
-  string HistoToWorkspaceFactoryFast::AddNormFactor(RooWorkspace* proto, string& channel, string& sigmaEpsilon, Sample& sample, bool doRatio){
-    string overallNorm_times_sigmaEpsilon ;
-    string prodNames;
+  std::unique_ptr<RooProduct> HistoToWorkspaceFactoryFast::CreateNormFactor(RooWorkspace* proto, string& channel, string& sigmaEpsilon, Sample& sample, bool doRatio){
+
+    std::vector<string> prodNames;
 
     vector<NormFactor> normList = sample.GetNormFactorList();
     vector<string> normFactorNames, rangeNames;
+
+
+    string overallNorm_times_sigmaEpsilon = sample.GetName() + "_" + channel + "_scaleFactors";
+    auto sigEps = proto->arg(sigmaEpsilon.c_str());
+    assert(sigEps);
+    std::unique_ptr<RooProduct> normFactor( new RooProduct(overallNorm_times_sigmaEpsilon.c_str(), overallNorm_times_sigmaEpsilon.c_str(), RooArgList(*sigEps) ) );
 
     if(normList.size() > 0){
 
@@ -530,7 +501,6 @@ namespace HistFactory{
         NormFactor& norm = *itr;
 
         string varname;
-        if(!prodNames.empty()) prodNames += ",";
         if(doRatio) {
           varname = norm.GetName() + "_" + channel;
         }
@@ -557,13 +527,18 @@ namespace HistFactory{
               " Instead, add \n\t<ParamSetting Const=\"True\"> " << varname << " </ParamSetting>\n" <<
               " to your top-level XML's <Measurement> entry" << endl;
         }
-        prodNames+=varname;
+        prodNames.push_back(varname);
         rangeNames.push_back(range.str());
         normFactorNames.push_back(varname);
       }
 
-      overallNorm_times_sigmaEpsilon = sample.GetName() + "_" + channel + "_overallNorm_x_sigma_epsilon";
-      proto->factory(("prod::" + overallNorm_times_sigmaEpsilon + "(" + prodNames + "," + sigmaEpsilon + ")").c_str());
+
+      for (const auto& name : prodNames) {
+        auto arg = proto->arg(name.c_str());
+        assert(arg);
+        normFactor->addTerm(arg);
+      }
+
     }
 
     unsigned int rangeIndex=0;
@@ -571,16 +546,13 @@ namespace HistFactory{
       if( count (normFactorNames.begin(), normFactorNames.end(), *nit) > 1 ){
         cxcoutI(HistFactory) <<"<NormFactor Name =\""<<*nit<<"\"> is duplicated for <Sample Name=\""
             << sample.GetName() << "\">, but only one factor will be included.  \n Instead, define something like"
-            << "\n\t<Function Name=\""<<*nit<<"Squared\" Expresion=\""<<*nit<<"*"<<*nit<<"\" Var=\""<<*nit<<rangeNames.at(rangeIndex)
+            << "\n\t<Function Name=\""<<*nit<<"Squared\" Expression=\""<<*nit<<"*"<<*nit<<"\" Var=\""<<*nit<<rangeNames.at(rangeIndex)
             << "\"> \nin your top-level XML's <Measurment> entry and use <NormFactor Name=\""<<*nit<<"Squared\" in your channel XML file."<< endl;
       }
       ++rangeIndex;
     }
 
-    if(!overallNorm_times_sigmaEpsilon.empty())
-      return overallNorm_times_sigmaEpsilon;
-    else
-      return sigmaEpsilon;
+    return normFactor;
   }        
 
    void HistoToWorkspaceFactoryFast::AddConstraintTerms(RooWorkspace* proto, Measurement & meas, string prefix, 
@@ -736,55 +708,65 @@ namespace HistFactory{
   }
 
 
-  void  HistoToWorkspaceFactoryFast::MakeTotalExpected(RooWorkspace* proto, string totName, 
-						       vector<string>& syst_x_expectedPrefixNames, 
-                                                       vector<string>& normByNames){
+  void  HistoToWorkspaceFactoryFast::MakeTotalExpected(RooWorkspace* proto, const string& totName,
+						       const vector<RooProduct*>& sampleScaleFactors, std::vector<vector<RooAbsArg*>>& sampleHistFuncs) const {
+    assert(sampleScaleFactors.size() == sampleHistFuncs.size());
 
     // for ith bin calculate totN_i =  lumi * sum_j expected_j * syst_j 
-    string command;
-    string coeffList="";
-    string shapeList="";
-    string prepend="";
 
-    if (fObsNameVec.empty() && !fObsName.empty()) { fObsNameVec.push_back(fObsName); } 
+    if (fObsNameVec.empty() && !fObsName.empty())
+      throw std::logic_error("HistFactory didn't process the observables correctly. Please file a bug report.");
 
-    double binWidth(1.0);
-    std::string obsNameVecStr;
-    std::vector<std::string>::iterator itr = fObsNameVec.begin();
-    for (; itr!=fObsNameVec.end(); ++itr) {
-      std::string obsName = *itr;
-      binWidth *= proto->var(obsName.c_str())->numBins()/(proto->var(obsName.c_str())->getMax() - proto->var(obsName.c_str())->getMin()) ; // MB: Note: requires fixed bin sizes
-      if (obsNameVecStr.size()>0) { obsNameVecStr += "_"; }
-      obsNameVecStr += obsName;
+    auto firstHistFunc = dynamic_cast<const RooHistFunc*>(sampleHistFuncs.front().front());
+    if (!firstHistFunc) {
+      auto piecewiseInt = dynamic_cast<const PiecewiseInterpolation*>(sampleHistFuncs.front().front());
+      firstHistFunc = dynamic_cast<const RooHistFunc*>(piecewiseInt->nominalHist());
+    }
+    assert(firstHistFunc);
+
+    // Prepare a function to divide all bin contents by bin width to get a density:
+    const std::string binWidthFunctionName = totName + "_binWidth";
+    RooBinWidthFunction binWidth(binWidthFunctionName.c_str(), "Divide by bin width to obtain probability density", *firstHistFunc, true);
+    proto->import(binWidth);
+    auto binWidthWS = proto->function(binWidthFunctionName.c_str());
+    assert(binWidthWS);
+
+    // Loop through samples and create products of their functions:
+    RooArgSet coefList;
+    RooArgSet shapeList;
+    for (unsigned int i=0; i < sampleHistFuncs.size(); ++i) {
+      assert(!sampleHistFuncs[i].empty());
+      coefList.add(*sampleScaleFactors[i]);
+
+      std::vector<RooAbsArg*>& thisSampleHistFuncs = sampleHistFuncs[i];
+      thisSampleHistFuncs.push_back(binWidthWS);
+
+      if (thisSampleHistFuncs.size() == 1) {
+        // Just one function. Book it.
+        shapeList.add(*thisSampleHistFuncs.front());
+      } else {
+        // Have multiple functions. We need to multiply them.
+        std::string name = thisSampleHistFuncs.front()->GetName();
+        auto pos = name.find("Hist_alpha");
+        if (pos != std::string::npos) {
+          name = name.substr(0, pos) + "shapes";
+        } else if ( (pos = name.find("nominal")) != std::string::npos) {
+          name = name.substr(0, pos) + "shapes";
+        }
+
+        RooArgSet terms;
+        for (auto func : thisSampleHistFuncs) {
+          terms.add(*func);
+        }
+
+        RooProduct shapeProduct(name.c_str(), name.c_str(), terms);
+        proto->import(shapeProduct, RecycleConflictNodes());
+        shapeList.add(*proto->function(name.c_str()));
+      }
     }
 
-    //vector<string>::iterator it=syst_x_expectedPrefixNames.begin();
-    for(unsigned int j=0; j<syst_x_expectedPrefixNames.size();++j){
-      std::stringstream str;
-      str<<"_"<<j;
-      // repatative, but we need one coeff for each term in the sum
-      // maybe can be avoided if we don't use bin width as coefficient
-      command=string(Form("binWidth_%s_%d[%e]",obsNameVecStr.c_str(),j,binWidth));     
-      proto->factory(command.c_str());
-      proto->var(Form("binWidth_%s_%d",obsNameVecStr.c_str(),j))->setConstant();
-      coeffList+=prepend+"binWidth_"+obsNameVecStr+str.str();
-
-      command="prod::L_x_"+syst_x_expectedPrefixNames.at(j)+"("+normByNames.at(j)+","+syst_x_expectedPrefixNames.at(j)+")";
-      /*RooAbsReal* tempFunc =(RooAbsReal*) */
-      proto->factory(command.c_str());
-      shapeList+=prepend+"L_x_"+syst_x_expectedPrefixNames.at(j);
-      prepend=",";
-      
-      // add to num int to product
-      //      tempFunc->specialIntegratorConfig(kTRUE)->method1D().setLabel("RooBinIntegrator")  ;
-      //      tempFunc->forceNumInt();
-
-    }    
-
-    proto->defineSet("coefList",coeffList.c_str());
-    proto->defineSet("shapeList",shapeList.c_str());
-    //    proto->factory(command.c_str());
-    RooRealSumPdf tot(totName.c_str(),totName.c_str(),*proto->set("shapeList"),*proto->set("coefList"),kTRUE);
+    // Sum all samples
+    RooRealSumPdf tot(totName.c_str(), totName.c_str(), shapeList, coefList, true);
     tot.specialIntegratorConfig(kTRUE)->method1D().setLabel("RooBinIntegrator")  ;
     tot.specialIntegratorConfig(kTRUE)->method2D().setLabel("RooBinIntegrator")  ;
     tot.specialIntegratorConfig(kTRUE)->methodND().setLabel("RooBinIntegrator")  ;
@@ -792,27 +774,8 @@ namespace HistFactory{
 
     // for mixed generation in RooSimultaneous
     tot.setAttribute("GenerateBinned"); // for use with RooSimultaneous::generate in mixed mode
-    //    tot.setAttribute("GenerateUnbinned"); // we don't want that
 
-    /*
-    // Use binned numeric integration
-    int nbins = 0;
-    if( fObsNameVec.size() == 1 ) {
-      nbins = proto->var(fObsNameVec.at(0).c_str())->numBins();
-
-      cout <<"num bis for RooRealSumPdf = "<<nbins <<endl;
-      //int nbins = ((RooRealVar*) allVars.first())->numBins();
-      tot.specialIntegratorConfig(kTRUE)->getConfigSection("RooBinIntegrator").setRealValue("numBins",nbins);
-      tot.forceNumInt();
-      
-    } else {
-      cout << "Bin Integrator only supports 1-d.  Will be slow." << std::endl;
-    }
-    */
-    
-
-    proto->import(tot);
-    
+    proto->import(tot, RecycleConflictNodes());
   }
 
   void HistoToWorkspaceFactoryFast::AddPoissonTerms(RooWorkspace* proto, string prefix, string obsPrefix, string expPrefix, int lowBin, int highBin, 
@@ -1253,7 +1216,9 @@ namespace HistFactory{
       fObsNameVec.push_back( fObsName );
     }
 
-    R__ASSERT( fObsNameVec.size()>=1 && fObsNameVec.size()<=3 );
+    if (fObsNameVec.size() == 0 || fObsNameVec.size() >= 3) {
+      throw hf_exc("HistFactory is limited to 1- to 3-dimensional histograms.");
+    }
 
     cxcoutP(HistFactory) << "\n-----------------------------------------\n"
         << "\tStarting to process '"
@@ -1276,14 +1241,14 @@ namespace HistFactory{
     }
 
     RooArgSet likelihoodTerms("likelihoodTerms"), constraintTerms("constraintTerms");
-    vector<string> likelihoodTermNames, constraintTermNames, totSystTermNames, syst_x_expectedPrefixNames, normalizationNames;
+    vector<string> likelihoodTermNames, constraintTermNames, totSystTermNames;
+    // All histogram functions to be multiplied in each sample
+    std::vector<std::vector<RooAbsArg*>> allSampleHistFuncs;
+    std::vector<RooProduct*> sampleScaleFactors;
 
     vector< pair<string,string> >   statNamePairs;
     vector< pair<const TH1*, const TH1*> > statHistPairs; // <nominal, error>
-    std::string                     statFuncName; // the name of the ParamHistFunc
-    std::string                     statNodeName; // the name of the McStat Node
-    // Constraint::Type statConstraintType=Constraint::Gaussian;
-    // Double_t                        statRelErrorThreshold=0.0;
+    const std::string statFuncName = "mc_stat_" + channel_name;
 
     string prefix, range;
 
@@ -1292,8 +1257,8 @@ namespace HistFactory{
     // this is ratio of lumi to nominal lumi.  We will include relative uncertainty in model
     std::stringstream lumiStr;
     // lumi range
-    lumiStr<<"["<<fNomLumi<<",0,"<<10.*fNomLumi<<"]";
-    proto->factory(("Lumi"+lumiStr.str()).c_str());
+    lumiStr << "Lumi[" << fNomLumi << ",0," << 10.*fNomLumi << "]";
+    proto->factory(lumiStr.str().c_str());
     cxcoutI(HistFactory) << "lumi str = " << lumiStr.str() << endl;
 
     std::stringstream lumiErrorStr;
@@ -1310,11 +1275,7 @@ namespace HistFactory{
     // loop through estimates, add expectation, floating bin predictions, 
     // and terms that constrain floating to expectation via uncertainties
     // GHL: Loop over samples instead, which doesn't contain the data
-    vector<Sample>::iterator it = channel.GetSamples().begin();
-    for(; it!=channel.GetSamples().end(); ++it) {
-
-      //ES// string overallSystName = it->name+"_"+it->channel+"_epsilon"; 
-      Sample& sample = (*it);
+    for (Sample& sample : channel.GetSamples()) {
       string overallSystName = sample.GetName() + "_" + channel_name + "_epsilon"; 
 
       string systSourcePrefix = "alpha_";
@@ -1324,13 +1285,17 @@ namespace HistFactory{
       AddConstraintTerms(proto,measurement, systSourcePrefix, overallSystName,
           sample.GetOverallSysList(), constraintTermNames , totSystTermNames);
 
+      allSampleHistFuncs.emplace_back();
+      std::vector<RooAbsArg*>& sampleHistFuncs = allSampleHistFuncs.back();
+
       // GHL: Consider passing the NormFactor list instead of the entire sample
-      overallSystName = AddNormFactor(proto, channel_name, overallSystName, sample, doRatio); 
+      auto normFactors = CreateNormFactor(proto, channel_name, overallSystName, sample, doRatio);
+      assert(normFactors);
 
       // Create the string for the object
       // that is added to the RooRealSumPdf
       // for this channel
-      string syst_x_expectedPrefix = "";
+//      string syst_x_expectedPrefix = "";
 
       // get histogram
       //ES// TH1* nominal = it->nominal;
@@ -1346,28 +1311,24 @@ namespace HistFactory{
       //        - If we have no HistoSys's, do part A
       //        - else, if the histo syst's don't match, return (we ignore this case)
       //        - finally, we take the syst's and apply the linear interpolation w/ constraint
+      string expPrefix = sample.GetName() + "_" + channel_name;
+      // create roorealvar observables
+      RooArgList observables = createObservables(sample.GetHisto(), proto);
+      RooHistFunc* nominalHistFunc = MakeExpectedHistFunc(sample.GetHisto(), proto, expPrefix, observables);
+      assert(nominalHistFunc);
 
       if(sample.GetHistoSysList().size() == 0) {
-
         // If no HistoSys
         cxcoutI(HistFactory) << sample.GetName() + "_" + channel_name + " has no variation histograms " << endl;
-        string expPrefix = sample.GetName() + "_" + channel_name; //+"_expN";
-        syst_x_expectedPrefix = sample.GetName() + "_" + channel_name + "_overallSyst_x_Exp";
 
-        ProcessExpectedHisto(sample.GetHisto(), proto, expPrefix, syst_x_expectedPrefix, 
-            overallSystName);
-      } 
-      else {
+        sampleHistFuncs.push_back(nominalHistFunc);
+      } else {
         // If there ARE HistoSys(s)
         // name of source for variation
         string constraintPrefix = sample.GetName() + "_" + channel_name + "_Hist_alpha"; 
-        syst_x_expectedPrefix = sample.GetName() + "_" + channel_name + "_overallSyst_x_HistSyst";
-        // constraintTermNames are passed by reference and appended to,
-        // overallSystName is a std::string for this sample
 
-        LinInterpWithConstraint(proto, nominal, sample.GetHistoSysList(),
-            constraintPrefix, syst_x_expectedPrefix, overallSystName,
-            constraintTermNames);
+        sampleHistFuncs.push_back( MakeLinInterpWithConstraint(nominalHistFunc, proto,
+            sample.GetHistoSysList(), constraintPrefix, constraintTermNames, observables) );
       }
 
       ////////////////////////////////////
@@ -1390,34 +1351,7 @@ namespace HistFactory{
               << "for channel " << channel_name
               << std::endl;
 
-          /*
-	  Constraint::Type type = channel.GetStatErrorConfig().GetConstraintType();
-	  statConstraintType = Constraint::Gaussian;
-	  if( type == Constraint::Gaussian) {
-	    std::cout << "Using Gaussian StatErrors" << std::endl;
-	    statConstraintType = Constraint::Gaussian;
-	  }
-	  if( type == Constraint::Poisson ) {
-	    std::cout << "Using Poisson StatErrors" << std::endl;
-	    statConstraintType = Constraint::Poisson;
-	  }
-           */
-
-          //statRelErrorThreshold = channel.GetStatErrorConfig().GetRelErrorThreshold();
-
-          // First, get the uncertainty histogram
-          // and push it back to our vectors
-
-          //if( sample.GetStatError().GetErrorHist() ) {
-          //statErrorHist = (TH1*) sample.GetStatError().GetErrorHist()->Clone();
-          //}
-          //if( statErrorHist == NULL ) {
-
-          // We need to get the *ABSOLUTE* uncertainty for use in Stat Uncertainties
-          // This can be done in one of two ways:
-          //   - Use the built-in Errors in the TH1 itself (they are aboslute)
-          //   - Take the supplied *RELATIVE* error and multiply by the nominal
-          string UncertName  = syst_x_expectedPrefix + "_StatAbsolUncert";
+          string UncertName  = sample.GetName() + "_" + channel_name + "_StatAbsolUncert";
           TH1* statErrorHist = NULL;
 
           if( sample.GetStatError().GetErrorHist() == NULL ) {
@@ -1461,19 +1395,18 @@ namespace HistFactory{
           //  and then create the poisson term: Pois(tau | n_exp)Pois(data | n_exp)
 
 
-          // Next, try to get the ParamHistFunc (it may have been
+          // Next, try to get the common ParamHistFunc (it may have been
           // created by another sample in this channel)
           // or create it if it doesn't yet exist:
-          statFuncName = "mc_stat_" + channel_name;
-          ParamHistFunc* paramHist = (ParamHistFunc*) proto->function( statFuncName.c_str() );
-          if( paramHist == NULL ) {
+          ParamHistFunc* paramHist = dynamic_cast<ParamHistFunc*>( proto->function(statFuncName.c_str()) );
+          if( paramHist == nullptr ) {
 
             // Get a RooArgSet of the observables:
             // Names in the list fObsNameVec:
-            RooArgList observables;
+            RooArgList theObservables;
             std::vector<std::string>::iterator itr = fObsNameVec.begin();
             for (int idx=0; itr!=fObsNameVec.end(); ++itr, ++idx ) {
-              observables.add( *proto->var(itr->c_str()) );
+              theObservables.add( *proto->var(itr->c_str()) );
             }
 
             // Create the list of terms to
@@ -1483,34 +1416,19 @@ namespace HistFactory{
             Double_t gammaMax = 10.0;
             RooArgList statFactorParams = ParamHistFunc::createParamSet(*proto,
                 ParamSetPrefix.c_str(),
-                observables,
+                theObservables,
                 gammaMin, gammaMax);
 
             ParamHistFunc statUncertFunc(statFuncName.c_str(), statFuncName.c_str(),
-                observables, statFactorParams );
+                theObservables, statFactorParams );
 
             proto->import( statUncertFunc, RecycleConflictNodes() );
 
             paramHist = (ParamHistFunc*) proto->function( statFuncName.c_str() );
+          }
 
-          } // END: If Statement: Create ParamHistFunc
-
-          // Create the node as a product
-          // of this function and the
-          // expected value from MC
-          statNodeName = sample.GetName() + "_" + channel_name + "_overallSyst_x_StatUncert";
-
-          RooAbsReal* expFunc = (RooAbsReal*) proto->function( syst_x_expectedPrefix.c_str() );
-          RooProduct nodeWithMcStat(statNodeName.c_str(), statNodeName.c_str(),
-              RooArgSet(*paramHist, *expFunc) );
-
-          proto->import( nodeWithMcStat, RecycleConflictNodes() );
-
-          // Push back the final name of the node
-          // to be used in the RooRealSumPdf
-          // (node to be created later)
-          syst_x_expectedPrefix = nodeWithMcStat.GetName();
-
+          // apply stat function to sample
+          sampleHistFuncs.push_back(paramHist);
         }
       } // END: if DoMcStat
 
@@ -1532,7 +1450,6 @@ namespace HistFactory{
               << std::endl;
 
           std::vector<ParamHistFunc*> paramHistFuncList;
-          std::vector<std::string> shapeFactorNameList;
 
           for(unsigned int i=0; i < sample.GetShapeFactorList().size(); ++i) {
 
@@ -1540,12 +1457,12 @@ namespace HistFactory{
 
             std::string funcName = channel_name + "_" + shapeFactor.GetName() + "_shapeFactor";
             ParamHistFunc* paramHist = (ParamHistFunc*) proto->function( funcName.c_str() );
-            if( paramHist == NULL ) {
+            if( paramHist == nullptr ) {
 
-              RooArgList observables;
+              RooArgList theObservables;
               std::vector<std::string>::iterator itr = fObsNameVec.begin();
               for (int idx=0; itr!=fObsNameVec.end(); ++itr, ++idx ) {
-                observables.add( *proto->var(itr->c_str()) );
+                theObservables.add( *proto->var(itr->c_str()) );
               }
 
               // Create the Parameters
@@ -1555,11 +1472,11 @@ namespace HistFactory{
               //      We should change this to range from 0 to /inf
               RooArgList shapeFactorParams = ParamHistFunc::createParamSet(*proto,
                   funcParams.c_str(),
-                  observables, 0, 1000);
+                  theObservables, 0, 1000);
 
               // Create the Function
               ParamHistFunc shapeFactorFunc( funcName.c_str(), funcName.c_str(),
-                  observables, shapeFactorParams );
+                  theObservables, shapeFactorParams );
 
               // Set an initial shape, if requested
               if( shapeFactor.GetInitialShape() != NULL ) {
@@ -1584,38 +1501,20 @@ namespace HistFactory{
             } // End: Create ShapeFactor ParamHistFunc
 
             paramHistFuncList.push_back(paramHist);
-            shapeFactorNameList.push_back(funcName);
-
           } // End loop over ShapeFactor Systematics
 
           // Now that we have the right ShapeFactor,
           // we multiply the expected function
 
-          //std::string shapeFactorNodeName = syst_x_expectedPrefix + "_x_" + funcName;
-          // Dynamically build the name as a long product
-          std::string shapeFactorNodeName = syst_x_expectedPrefix;
-          for( unsigned int i=0; i < shapeFactorNameList.size(); ++i) {
-            shapeFactorNodeName += "_x_" + shapeFactorNameList.at(i);
+          // Append to product of functions
+          for (auto paramHistFunc : paramHistFuncList) {
+            proto->import(*paramHistFunc, RecycleConflictNodes());
+            auto paramHFinWS = proto->arg(paramHistFunc->GetName());
+            assert(paramHFinWS);
+            delete paramHistFunc;
+
+            sampleHistFuncs.push_back(paramHFinWS);
           }
-
-          RooAbsReal* expFunc = (RooAbsReal*) proto->function( syst_x_expectedPrefix.c_str() );
-          RooArgSet nodesForProduct(*expFunc);
-          for( unsigned int i=0; i < paramHistFuncList.size(); ++i) {
-            nodesForProduct.add( *paramHistFuncList.at(i) );
-          }
-          //RooProduct nodeWithShapeFactor(shapeFactorNodeName.c_str(),
-          //                               shapeFactorNodeName.c_str(),
-          //RooArgSet(*paramHist, *expFunc) );
-          RooProduct nodeWithShapeFactor(shapeFactorNodeName.c_str(),
-              shapeFactorNodeName.c_str(),
-              nodesForProduct );
-
-          proto->import( nodeWithShapeFactor, RecycleConflictNodes() );
-
-          // Push back the final name of the node
-          // to be used in the RooRealSumPdf
-          // (node to be created later)
-          syst_x_expectedPrefix = nodeWithShapeFactor.GetName();
 
         }
       } // End: if ShapeFactorName!=""
@@ -1660,21 +1559,21 @@ namespace HistFactory{
               //std::string funcParams = "gamma_" + it->shapeFactorName;
               //paramHist = CreateParamHistFunc( proto, fObsNameVec, funcParams, funcName );
 
-              RooArgList observables;
+              RooArgList theObservables;
               std::vector<std::string>::iterator itr = fObsNameVec.begin();
               for(; itr!=fObsNameVec.end(); ++itr ) {
-                observables.add( *proto->var(itr->c_str()) );
+                theObservables.add( *proto->var(itr->c_str()) );
               }
 
               // Create the Parameters
               std::string funcParams = "gamma_" + shapeSys.GetName();
               RooArgList shapeFactorParams = ParamHistFunc::createParamSet(*proto,
                   funcParams.c_str(),
-                  observables, 0, 10);
+                  theObservables, 0, 10);
 
               // Create the Function
               ParamHistFunc shapeFactorFunc( funcName.c_str(), funcName.c_str(),
-                  observables, shapeFactorParams );
+                  theObservables, shapeFactorParams );
 
               proto->import( shapeFactorFunc, RecycleConflictNodes() );
               paramHist = (ParamHistFunc*) proto->function( funcName.c_str() );
@@ -1709,49 +1608,44 @@ namespace HistFactory{
           // we create the total RooProduct
           // we multiply the expected functio
 
-          std::string NodeName = syst_x_expectedPrefix;
-          RooArgList ShapeSysForNode;
-          RooAbsReal* expFunc = (RooAbsReal*) proto->function( syst_x_expectedPrefix.c_str() );
-          ShapeSysForNode.add( *expFunc );
+
           for( unsigned int i = 0; i < ShapeSysNames.size(); ++i ) {
-            std::string ShapeSysName = ShapeSysNames.at(i);
-            ShapeSysForNode.add( *proto->function(ShapeSysName.c_str()) );
-            NodeName = NodeName + "_x_" + ShapeSysName;
+            auto func = proto->function(ShapeSysNames.at(i).c_str());
+            assert(func);
+            sampleHistFuncs.push_back(func);
           }
-
-          // Create the name for this NEW Node
-          RooProduct nodeWithShapeFactor(NodeName.c_str(), NodeName.c_str(), ShapeSysForNode );
-          proto->import( nodeWithShapeFactor, RecycleConflictNodes() );
-
-          // Push back the final name of the node
-          // to be used in the RooRealSumPdf
-          // (node to be created later)
-          syst_x_expectedPrefix = nodeWithShapeFactor.GetName();
 
         } // End: NumObsVar == 1
 
       } // End: GetShapeSysList.size() != 0
 
-      // Append the name of the "node"
-      // that is to be summed with the
-      // RooRealSumPdf
-      syst_x_expectedPrefixNames.push_back(syst_x_expectedPrefix);
 
       // GHL: This was pretty confusing before,
       //      hopefully using the measurement directly
       //      will improve it
-      if( sample.GetNormalizeByTheory() ) {
-        normalizationNames.push_back( "Lumi" );
+      auto lumi = proto->arg("Lumi");
+      if( !sample.GetNormalizeByTheory() ) {
+        if (!lumi) {
+          TString lumiParamString;
+          lumiParamString += measurement.GetLumi();
+          lumiParamString.ReplaceAll(' ', TString());
+          lumi = proto->factory(("Lumi[" + lumiParamString + "]").Data());
+        } else {
+          static_cast<RooAbsRealLValue*>(lumi)->setVal(measurement.GetLumi());
+        }
       }
-      else {
-        TString lumiParamString;
-        lumiParamString += measurement.GetLumi();
-        lumiParamString.ReplaceAll(' ', TString());
-        normalizationNames.push_back(lumiParamString.Data());
-      }
+      assert(lumi);
+      normFactors->addTerm(lumi);
 
+      // Append the name of the "node"
+      // that is to be summed with the
+      // RooRealSumPdf
+      proto->import(*normFactors, RecycleConflictNodes());
+      auto normFactorsInWS = dynamic_cast<RooProduct*>(proto->arg(normFactors->GetName()));
+      assert(normFactorsInWS);
+
+      sampleScaleFactors.push_back(normFactorsInWS);
     } // END: Loop over EstimateSummaries
-    //    proto->Print();
 
     // If a non-zero number of samples call for
     // Stat Uncertainties, create the statFactor functions
@@ -1759,10 +1653,10 @@ namespace HistFactory{
 
       // Create the histogram of (binwise)
       // stat uncertainties:
-      unique_ptr<TH1> fracStatError( MakeScaledUncertaintyHist( statNodeName + "_RelErr", statHistPairs) );
+      unique_ptr<TH1> fracStatError( MakeScaledUncertaintyHist( channel_name + "_StatUncert" + "_RelErr", statHistPairs) );
       if( fracStatError == NULL ) {
         cxcoutE(HistFactory) << "Error: Failed to make ScaledUncertaintyHist for: "
-            << statNodeName << std::endl;
+            << channel_name + "_StatUncert" + "_RelErr" << std::endl;
         throw hf_exc();
       }
 
@@ -1806,10 +1700,8 @@ namespace HistFactory{
 
     ///////////////////////////////////
     // for ith bin calculate totN_i =  lumi * sum_j expected_j * syst_j 
-    //MakeTotalExpected(proto,channel_name+"_model",channel_name,"Lumi",fLowBin,fHighBin, 
-    //      syst_x_expectedPrefixNames, normalizationNames);
-    MakeTotalExpected(proto, channel_name+"_model", //channel_name,"Lumi",fLowBin,fHighBin, 
-        syst_x_expectedPrefixNames, normalizationNames);
+    MakeTotalExpected(proto, channel_name+"_model",
+        sampleScaleFactors, allSampleHistFuncs);
     likelihoodTermNames.push_back(channel_name+"_model");
 
     //////////////////////////////////////
@@ -1863,7 +1755,6 @@ namespace HistFactory{
     }
     proto->defineSet("constraintTerms",constraintTerms);
     proto->defineSet("likelihoodTerms",likelihoodTerms);
-    //  proto->Print();
 
     // list of observables
     RooArgList observables;
@@ -1937,39 +1828,6 @@ namespace HistFactory{
       ConfigureHistFactoryDataset( obsDataUnbinned.get(), mnominal, 
           proto, fObsNameVec );
 
-      /*
-      //ES// TH1* mnominal = summary.at(0).nominal;
-      TH1* mnominal = data.GetHisto(); 
-      TAxis* ax = mnominal->GetXaxis(); 
-      TAxis* ay = mnominal->GetYaxis(); 
-      TAxis* az = mnominal->GetZaxis(); 	
-
-      for (int i=1; i<=ax->GetNbins(); ++i) { // 1 or more dimension
-	Double_t xval = ax->GetBinCenter(i);
-	proto->var( fObsNameVec[0].c_str() )->setVal( xval );
-	if        (fObsNameVec.size()==1) {
-	  Double_t fval = mnominal->GetBinContent(i);
-	  obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
-	} else { // 2 or more dimensions
-	  for (int j=1; j<=ay->GetNbins(); ++j) {
-	    Double_t yval = ay->GetBinCenter(j);
-	    proto->var( fObsNameVec[1].c_str() )->setVal( yval );
-	    if (fObsNameVec.size()==2) { 
-	      Double_t fval = mnominal->GetBinContent(i,j);
-	      obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
-	    } else { // 3 dimensions 
-	      for (int k=1; k<=az->GetNbins(); ++k) {
-		Double_t zval = az->GetBinCenter(k);
-		proto->var( fObsNameVec[2].c_str() )->setVal( zval );
-		Double_t fval = mnominal->GetBinContent(i,j,k);
-		obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
-	      }
-	    }
-	  }
-	}
-      }
-       */
-
       proto->import(*obsDataUnbinned);
     } // End: Has non-null 'data' entry
 
@@ -1991,39 +1849,6 @@ namespace HistFactory{
 
       ConfigureHistFactoryDataset( obsDataUnbinned.get(), mnominal, 
           proto, fObsNameVec );
-
-      /*
-      //ES// TH1* mnominal = summary.at(0).nominal;
-      TH1* mnominal = data.GetHisto(); 
-      TAxis* ax = mnominal->GetXaxis(); 
-      TAxis* ay = mnominal->GetYaxis(); 
-      TAxis* az = mnominal->GetZaxis(); 	
-
-      for (int i=1; i<=ax->GetNbins(); ++i) { // 1 or more dimension
-	Double_t xval = ax->GetBinCenter(i);
-	proto->var( fObsNameVec[0].c_str() )->setVal( xval );
-	if        (fObsNameVec.size()==1) {
-	  Double_t fval = mnominal->GetBinContent(i);
-	  obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
-	} else { // 2 or more dimensions
-	  for (int j=1; j<=ay->GetNbins(); ++j) {
-	    Double_t yval = ay->GetBinCenter(j);
-	    proto->var( fObsNameVec[1].c_str() )->setVal( yval );
-	    if (fObsNameVec.size()==2) { 
-	      Double_t fval = mnominal->GetBinContent(i,j);
-	      obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
-	    } else { // 3 dimensions 
-	      for (int k=1; k<=az->GetNbins(); ++k) {
-		Double_t zval = az->GetBinCenter(k);
-		proto->var( fObsNameVec[2].c_str() )->setVal( zval );
-		Double_t fval = mnominal->GetBinContent(i,j,k);
-		obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
-	      }
-	    }
-	  }
-	}
-      }
-       */
 
       proto->import(*obsDataUnbinned);
 

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -660,34 +660,17 @@ Double_t ParamHistFunc::analyticalIntegralWN(Int_t /*code*/, const RooArgSet* /*
   // Simply loop over bins, 
   // get the height, and
   // multiply by the bind width
-  
-  RooFIter paramIter = _paramSet.fwdIterator();
-  RooRealVar* param = NULL;
-  Int_t nominalItr = 0;
-  while((param = (RooRealVar*) paramIter.next())) {
+  auto binVolumes = _dataSet.binVolumes(0, _dataSet.numEntries());
+
+  for (unsigned int i=0; i < _paramSet.size(); ++i) {
+    const auto& param = static_cast<const RooRealVar&>(_paramSet[i]);
+    assert(static_cast<Int_t>(i) == _dataSet.getIndex(param)); // We assume that each parameter i belongs to bin i
 
     // Get the gamma's value
-    Double_t paramVal  = (*param).getVal();
-    
-    // Get the bin volume
-    _dataSet.get( nominalItr );
-    Double_t binVolumeDS  = _dataSet.binVolume(); //_binning->binWidth( nominalItr );
+    const double paramVal = param.getVal();
     
     // Finally, get the subtotal
-    value += paramVal*binVolumeDS;
-
-    ++nominalItr;
-
-    /*
-    std::cout << "Integrating : "
-	      << " bin: "  << nomValue
-	      << " binVolume:  "  << binVolumeDS
-	      << " paramValue:  "  << paramVal
-	      << " nomValue:  "  << nomValue
-	      << " subTotal:  "  << value
-	      << std::endl;
-    */
-
+    value += paramVal * binVolumes[i];
   }
 
   return value;

--- a/roofit/histfactory/test/CMakeLists.txt
+++ b/roofit/histfactory/test/CMakeLists.txt
@@ -7,5 +7,5 @@
 # @author Stephan Hageboeck CERN, 2019
 
 ROOT_ADD_GTEST(testHistFactory testHistFactory.cxx
-  LIBRARIES RooFitCore RooFit RooStats HistFactory
+  LIBRARIES RooFitCore RooFit RooStats HistFactory RooBatchCompute
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/ref_6.16_example_UsingC_channel1_meas_model.root ${CMAKE_CURRENT_SOURCE_DIR}/ref_6.16_example_UsingC_combined_meas_model.root)

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -1,14 +1,27 @@
 // Tests for the HistFactory
 // Authors: Stephan Hageboeck, CERN  01/2019
 
+#include "RooStats/HistFactory/Measurement.h"
+#include "RooStats/HistFactory/MakeModelAndMeasurementsFast.h"
 #include "RooStats/HistFactory/Sample.h"
 #include "RooStats/ModelConfig.h"
+
 #include "RooWorkspace.h"
 #include "RooArgSet.h"
+#include "RooSimultaneous.h"
+#include "RooRealSumPdf.h"
+#include "RooRealVar.h"
+#include "RooHelpers.h"
+#include "RooFitResult.h"
+#include "RooPlot.h"
+#include "RunContext.h"
 
 #include "TROOT.h"
 #include "TFile.h"
+#include "TCanvas.h"
 #include "gtest/gtest.h"
+
+#include <set>
 
 using namespace RooStats;
 using namespace RooStats::HistFactory;
@@ -81,3 +94,479 @@ TEST(HistFactory, Read_ROOT6_16_Combined_Model) {
   EXPECT_NEAR(pdf->getVal(), 0.17488817, 1.E-8);
   EXPECT_NEAR(pdf->getVal(*obs), 0.95652174, 1.E-8);
 }
+
+
+
+enum MakeModelMode {kEquidistantBins=0, kCustomBins=1, kEquidistantBins_histoSyst=2, kCustomBins_histoSyst=3};
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Fixture class to set up a toy hist factory model.
+/// In the SetUp() phase
+/// - A file with histograms is created. Depending on the value of MakeModelMode,
+/// equidistant or custom bins are used, and shape systematics are added.
+/// - A Measurement with the histograms in the file is created.
+/// - The corresponding workspace is created.
+class HFFixture : public testing::TestWithParam<MakeModelMode> {
+public:
+  std::string _inputFile{"TestMakeModel.root"};
+  static constexpr bool _verbose = false;
+  double _customBins[3] = {0., 1.8, 2.};
+  const double _targetMu = 2.;
+  const double _targetNominal[2] = {110., 120.};
+  const double _targetSysUp[2]   = {112., 140.};
+  const double _targetSysDo[2]   = {108., 100.};
+  std::unique_ptr<RooWorkspace> ws;
+  std::set<std::string> _systNames; // Systematics defined during set up
+
+  void SetUp() {
+    {
+      TFile example(_inputFile.c_str(), "RECREATE");
+      TH1F *data, *signal, *bkg1, *bkg2, *statUnc, *systUncUp, *systUncDo;
+      if (GetParam() == kEquidistantBins || GetParam() == kEquidistantBins_histoSyst) {
+        data = new TH1F("data","data", 2,1,2);
+        signal = new TH1F("signal","signal histogram (pb)", 2,1,2);
+        bkg1 = new TH1F("background1","background 1 histogram (pb)", 2,1,2);
+        bkg2 = new TH1F("background2","background 2 histogram (pb)", 2,1,2);
+        statUnc = new TH1F("background1_statUncert", "statUncert", 2,1,2);
+        systUncUp = new TH1F("shapeUnc_sigUp", "signal shape uncert.", 2,1,2);
+        systUncDo = new TH1F("shapeUnc_sigDo", "signal shape uncert.", 2,1,2);
+      } else if (GetParam() == kCustomBins || GetParam() == kCustomBins_histoSyst) {
+        data = new TH1F("data","data", 2, _customBins);
+        signal = new TH1F("signal","signal histogram (pb)", 2, _customBins);
+        bkg1 = new TH1F("background1","background 1 histogram (pb)", 2, _customBins);
+        bkg2 = new TH1F("background2","background 2 histogram (pb)", 2, _customBins);
+        statUnc = new TH1F("background1_statUncert", "statUncert", 2, _customBins);
+        systUncUp = new TH1F("shapeUnc_sigUp", "signal shape uncert.", 2, _customBins);
+        systUncDo = new TH1F("shapeUnc_sigDo", "signal shape uncert.", 2, _customBins);
+      } else {
+        // Harden the test and make clang-tidy happy:
+        FAIL() << "This should not be reachable.";
+      }
+
+      bkg1->SetBinContent(1, 100);
+      bkg2->SetBinContent(2, 100);
+
+      for (unsigned int bin=0; bin < 2; ++bin) {
+        signal->   SetBinContent(bin+1, _targetNominal[bin] - 100.);
+        systUncUp->SetBinContent(bin+1, _targetSysUp[bin]   - 100.);
+        systUncDo->SetBinContent(bin+1, _targetSysDo[bin]   - 100.);
+
+        if (GetParam() < kEquidistantBins_histoSyst) {
+          data->SetBinContent(bin+1, _targetMu * signal->GetBinContent(bin+1) + 100.);
+        } else {
+          // Set data such that alpha = -1., fit should pull parameter.
+          data->SetBinContent(bin+1, _targetMu * systUncDo->GetBinContent(bin+1) + 100.);
+        }
+
+        // A small statistical uncertainty
+        statUnc->SetBinContent(bin+1, .05);  // 5% uncertainty
+      }
+
+
+      for (auto hist : {data, signal, bkg1, bkg2, statUnc, systUncUp, systUncDo}) {
+        example.WriteTObject(hist);
+      }
+    }
+
+
+    // Create the measurement
+    Measurement meas("meas", "meas");
+
+    meas.SetOutputFilePrefix( "example_variableBins" );
+    meas.SetPOI( "SigXsecOverSM" );
+    meas.AddConstantParam("alpha_syst1");
+    meas.AddConstantParam("Lumi");
+    if (GetParam() >= kEquidistantBins_histoSyst) {
+      // We are testing the shape systematics. Switch off the normalisation
+      // systematics for the background here:
+      meas.AddConstantParam("alpha_syst2");
+      meas.AddConstantParam("alpha_syst4");
+      meas.AddConstantParam("gamma_stat_channel1_bin_0");
+      meas.AddConstantParam("gamma_stat_channel1_bin_1");
+    }
+
+    meas.SetExportOnly(true);
+
+    meas.SetLumi( 1.0 );
+    meas.SetLumiRelErr( 0.10 );
+
+
+    // Create a channel
+    Channel chan( "channel1" );
+    chan.SetData( "data", _inputFile);
+    chan.SetStatErrorConfig( 0.05, "Poisson" );
+    _systNames.insert("gamma_stat_channel1_bin_0");
+    _systNames.insert("gamma_stat_channel1_bin_1");
+
+
+
+    // Now, create some samples
+
+    // Create the signal sample
+    Sample signal( "signal", "signal", _inputFile);
+    signal.AddOverallSys( "syst1",  0.95, 1.05 );
+    _systNames.insert("alpha_syst1");
+
+    signal.AddNormFactor( "SigXsecOverSM", 1, 0, 3 );
+    if (GetParam() >= kEquidistantBins_histoSyst) {
+      signal.AddHistoSys("SignalShape",
+          "shapeUnc_sigDo", _inputFile, "",
+          "shapeUnc_sigUp", _inputFile, "");
+      _systNames.insert("alpha_SignalShape");
+    }
+    chan.AddSample( signal );
+
+    // Background 1
+    Sample background1( "background1", "background1", _inputFile);
+    background1.ActivateStatError( "background1_statUncert", _inputFile);
+    background1.AddOverallSys( "syst2", 0.95, 1.05  );
+    background1.AddOverallSys( "syst3", 0.99, 1.01  );
+    _systNames.insert("alpha_syst2");
+    _systNames.insert("alpha_syst3");
+    chan.AddSample( background1 );
+
+    // Background 2
+    Sample background2( "background2", "background2", _inputFile);
+    background2.ActivateStatError();
+    background2.AddOverallSys( "syst3", 0.99, 1.01  );
+    background2.AddOverallSys( "syst4", 0.95, 1.05  );
+    _systNames.insert("alpha_syst3");
+    _systNames.insert("alpha_syst4");
+    chan.AddSample( background2 );
+
+
+    // Done with this channel
+    // Add it to the measurement:
+    meas.AddChannel( chan );
+
+    if (!_verbose) {
+      RooMsgService::instance().getStream(1).minLevel = RooFit::PROGRESS;
+      RooMsgService::instance().getStream(2).minLevel = RooFit::WARNING;
+    }
+    RooHelpers::HijackMessageStream hijackW(RooFit::WARNING, RooFit::HistFactory);
+
+    // Collect the histograms from their files,
+    meas.CollectHistograms();
+
+    // Now, create the measurement
+    ws.reset( MakeModelAndMeasurementFast(meas) );
+
+    EXPECT_TRUE(hijackW.str().empty()) << "Warnings logged for HistFactory:\n" << hijackW.str();
+  }
+
+  void TearDown() {
+
+  }
+};
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Test that the model consists of what is expected
+TEST_P(HFFixture, ModelProperties) {
+  auto simPdf = dynamic_cast<RooSimultaneous*>(ws->pdf("simPdf"));
+  ASSERT_NE(simPdf, nullptr);
+
+  auto channelPdf = dynamic_cast<RooRealSumPdf*>(ws->pdf("channel1_model"));
+  ASSERT_NE(channelPdf, nullptr);
+
+  auto obs = dynamic_cast<RooRealVar*>(ws->var("obs_x_channel1"));
+
+  // Nice to inspect the model if needed:
+  channelPdf->graphVizTree("/tmp/graphVizTree.dot");
+
+  // Check bin widths
+  ASSERT_NE(obs, nullptr);
+  if (GetParam() == kEquidistantBins || GetParam() == kEquidistantBins_histoSyst) {
+    EXPECT_DOUBLE_EQ(obs->getBinWidth(0), 0.5);
+    EXPECT_DOUBLE_EQ(obs->getBinWidth(1), 0.5);
+    EXPECT_EQ(obs->numBins(), 2);
+  } else if (GetParam() == kCustomBins || GetParam() == kCustomBins_histoSyst) {
+    EXPECT_DOUBLE_EQ(obs->getBinWidth(0), _customBins[1] - _customBins[0]);
+    EXPECT_DOUBLE_EQ(obs->getBinWidth(1), _customBins[2] - _customBins[1]);
+    EXPECT_EQ(obs->numBins(), 2);
+  } else {
+    throw std::logic_error("Test set up wrongly.");
+  }
+
+  RooStats::ModelConfig* mc = dynamic_cast<RooStats::ModelConfig*>(ws->obj("ModelConfig"));
+  ASSERT_NE(mc, nullptr);
+
+
+  // Check that parameters are in the model
+  for (const auto& systName : _systNames) {
+    auto& var = *ws->var(systName.c_str());
+
+    EXPECT_TRUE(channelPdf->dependsOnValue(var)) << "Expect channel pdf to depend on " << systName;
+    if (!var.isConstant()) {
+      EXPECT_NE(mc->GetNuisanceParameters()->find(systName.c_str()), nullptr) << systName << " should be in list of nuisance parameters.";
+    }
+  }
+
+  // Check that sub models depend on their systematic uncertainties.
+  for (auto& subModelName : std::initializer_list<std::string>{"signal_channel1_shapes", "background1_channel1_shapes", "background2_channel1_shapes"}) {
+    auto subModel = ws->function(subModelName.c_str());
+    ASSERT_NE(subModel, nullptr) << "Unable to retrieve sub model with name " << subModelName;
+    if (subModelName.find("signal") != std::string::npos) {
+      EXPECT_FALSE(subModel->dependsOn(*ws->var("gamma_stat_channel1_bin_0")));
+      EXPECT_FALSE(subModel->dependsOn(*ws->var("gamma_stat_channel1_bin_1")));
+    } else {
+        EXPECT_TRUE(subModel->dependsOn(*ws->var("gamma_stat_channel1_bin_0")));
+        EXPECT_TRUE(subModel->dependsOn(*ws->var("gamma_stat_channel1_bin_1")));
+    }
+  }
+
+  EXPECT_TRUE (ws->function("signal_channel1_scaleFactors")->dependsOn(*ws->var("SigXsecOverSM")));
+  EXPECT_TRUE (ws->function("signal_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst1")));
+  EXPECT_FALSE(ws->function("signal_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst2")));
+  EXPECT_FALSE(ws->function("signal_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst3")));
+  EXPECT_FALSE(ws->function("signal_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst4")));
+
+  EXPECT_FALSE(ws->function("background1_channel1_scaleFactors")->dependsOn(*ws->var("SigXsecOverSM")));
+  EXPECT_FALSE(ws->function("background1_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst1")));
+  EXPECT_TRUE (ws->function("background1_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst2")));
+  EXPECT_TRUE (ws->function("background1_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst3")));
+  EXPECT_FALSE(ws->function("background1_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst4")));
+
+  EXPECT_FALSE(ws->function("background2_channel1_scaleFactors")->dependsOn(*ws->var("SigXsecOverSM")));
+  EXPECT_FALSE(ws->function("background2_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst1")));
+  EXPECT_FALSE(ws->function("background2_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst2")));
+  EXPECT_TRUE (ws->function("background2_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst3")));
+  EXPECT_TRUE (ws->function("background2_channel1_scaleFactors")->dependsOn(*ws->var("alpha_syst4")));
+
+  EXPECT_EQ(*mc->GetParametersOfInterest()->begin(), ws->var("SigXsecOverSM"));
+}
+
+
+/// Test that the values returned are as expected.
+TEST_P(HFFixture, Evaluation) {
+  auto simPdf = dynamic_cast<RooSimultaneous*>(ws->pdf("simPdf"));
+  ASSERT_NE(simPdf, nullptr);
+
+  auto channelPdf = dynamic_cast<RooRealSumPdf*>(ws->pdf("channel1_model"));
+  ASSERT_NE(channelPdf, nullptr);
+
+  auto obs = dynamic_cast<RooRealVar*>(ws->var("obs_x_channel1"));
+
+  RooStats::ModelConfig* mc = dynamic_cast<RooStats::ModelConfig*>(ws->obj("ModelConfig"));
+  ASSERT_NE(mc, nullptr);
+
+  // Test evaluating the model:
+  double normResults[2] = {0., 0.};
+  for (unsigned int i=0; i < 2; ++i) {
+    obs->setBin(i);
+    EXPECT_NEAR(channelPdf->getVal(),
+        _targetNominal[i]/obs->getBinWidth(i), 1.E-9);
+    EXPECT_NEAR(channelPdf->getVal(mc->GetObservables()),
+        _targetNominal[i]/obs->getBinWidth(i)/(_targetNominal[0]+_targetNominal[1]), 1.E-9);
+    normResults[i] = channelPdf->getVal(mc->GetObservables());
+  }
+  EXPECT_NEAR(normResults[0] * obs->getBinWidth(0) + normResults[1] * obs->getBinWidth(1), 1, 1.E-9) << "Integral over PDF range should be 1.";
+
+
+  // Test that shape uncertainties have an effect:
+  if (GetParam() >= kEquidistantBins_histoSyst) {
+    auto var = ws->var("alpha_SignalShape");
+    ASSERT_NE(var, nullptr);
+
+    // Test syst up:
+    var->setVal(1.);
+    for (unsigned int i=0; i < 2; ++i) {
+      obs->setBin(i);
+      EXPECT_NEAR(channelPdf->getVal(),
+          _targetSysUp[i]/obs->getBinWidth(i), 1.E-6);
+      EXPECT_NEAR(channelPdf->getVal(mc->GetObservables()),
+          _targetSysUp[i]/obs->getBinWidth(i)/(_targetSysUp[0]+_targetSysUp[1]), 1.E-6);
+    }
+
+    // Test syst down:
+    var->setVal(-1.);
+    for (unsigned int i=0; i < 2; ++i) {
+      obs->setBin(i);
+      EXPECT_NEAR(channelPdf->getVal(),
+          _targetSysDo[i]/obs->getBinWidth(i), 1.E-6);
+      EXPECT_NEAR(channelPdf->getVal(mc->GetObservables()),
+          _targetSysDo[i]/obs->getBinWidth(i)/(_targetSysDo[0]+_targetSysDo[1]), 1.E-6);
+    }
+  }
+}
+
+
+/// Test that the values returned are as expected.
+TEST_P(HFFixture, BatchEvaluation) {
+  RooHelpers::HijackMessageStream evalMessages(RooFit::INFO, RooFit::FastEvaluations);
+
+  auto simPdf = dynamic_cast<RooSimultaneous*>(ws->pdf("simPdf"));
+  ASSERT_NE(simPdf, nullptr);
+
+  auto channelPdf = dynamic_cast<RooRealSumPdf*>(ws->pdf("channel1_model"));
+  ASSERT_NE(channelPdf, nullptr);
+
+  auto obs = dynamic_cast<RooRealVar*>(ws->var("obs_x_channel1"));
+
+  RooStats::ModelConfig* mc = dynamic_cast<RooStats::ModelConfig*>(ws->obj("ModelConfig"));
+  ASSERT_NE(mc, nullptr);
+
+  // Test evaluating the model:
+  RooBatchCompute::RunContext evalDataOrig;
+  auto batch = evalDataOrig.makeBatch(obs, 2);
+  obs->setBin(0);
+  batch[0] = obs->getVal();
+  obs->setBin(1);
+  batch[1] = obs->getVal();
+
+  RooBatchCompute::RunContext evalData1;
+  evalData1.spans = evalDataOrig.spans;
+  auto results = channelPdf->getValues(evalData1, nullptr);
+  RooBatchCompute::RunContext evalData2;
+  evalData2.spans = evalDataOrig.spans;
+  auto normResults = channelPdf->getValues(evalData2, mc->GetObservables());
+
+  for (unsigned int i=0; i < 2; ++i) {
+    obs->setBin(i);
+    EXPECT_NEAR(results[i],
+        _targetNominal[i]/obs->getBinWidth(i), 1.E-9);
+    EXPECT_NEAR(normResults[i],
+        _targetNominal[i]/obs->getBinWidth(i)/(_targetNominal[0]+_targetNominal[1]), 1.E-9);
+  }
+  EXPECT_NEAR(normResults[0] * obs->getBinWidth(0) + normResults[1] * obs->getBinWidth(1), 1, 1.E-9) << "Integral over PDF range should be 1.";
+
+
+  // Test that shape uncertainties have an effect:
+  if (GetParam() >= kEquidistantBins_histoSyst) {
+    auto var = ws->var("alpha_SignalShape");
+    ASSERT_NE(var, nullptr);
+
+    // Test syst up:
+    var->setVal(1.);
+    RooBatchCompute::RunContext evalData3;
+    evalData3.spans = evalDataOrig.spans;
+    auto resultsSyst = channelPdf->getValues(evalData3, nullptr);
+    RooBatchCompute::RunContext evalData4;
+    evalData4.spans = evalDataOrig.spans;
+    auto normResultsSyst = channelPdf->getValues(evalData4, mc->GetObservables());
+    for (unsigned int i=0; i < 2; ++i) {
+      EXPECT_NEAR(resultsSyst[i],
+          _targetSysUp[i]/obs->getBinWidth(i), 1.E-6);
+      EXPECT_NEAR(normResultsSyst[i],
+          _targetSysUp[i]/obs->getBinWidth(i)/(_targetSysUp[0]+_targetSysUp[1]), 1.E-6);
+    }
+
+    // Test syst down:
+    var->setVal(-1.);
+    RooBatchCompute::RunContext evalData5;
+    evalData5.spans = evalDataOrig.spans;
+    resultsSyst = channelPdf->getValues(evalData5, nullptr);
+    RooBatchCompute::RunContext evalData6;
+    evalData6.spans = evalDataOrig.spans;
+    normResultsSyst = channelPdf->getValues(evalData6, mc->GetObservables());
+    for (unsigned int i=0; i < 2; ++i) {
+      obs->setBin(i);
+      EXPECT_NEAR(resultsSyst[i],
+          _targetSysDo[i]/obs->getBinWidth(i), 1.E-6);
+      EXPECT_NEAR(normResultsSyst[i],
+          _targetSysDo[i]/obs->getBinWidth(i)/(_targetSysDo[0]+_targetSysDo[1]), 1.E-6);
+    }
+  }
+
+  EXPECT_TRUE(evalMessages.str().empty()) << "RooFit issued " << evalMessages.str().substr(0, 1000) << " [...]";
+}
+
+
+/// Fit the model to data, and check parameters.
+TEST_P(HFFixture, Fit) {
+  constexpr bool createPlot = false;
+
+  auto simPdf = dynamic_cast<RooSimultaneous*>(ws->pdf("simPdf"));
+  ASSERT_NE(simPdf, nullptr);
+
+  auto channelPdf = dynamic_cast<RooRealSumPdf*>(ws->pdf("channel1_model"));
+  ASSERT_NE(channelPdf, nullptr);
+
+  // Test fitting the model to data
+  RooAbsData* data = dynamic_cast<RooAbsData*>(ws->data("obsData"));
+  ASSERT_NE(data, nullptr);
+
+  RooStats::ModelConfig* mc = dynamic_cast<RooStats::ModelConfig*>(ws->obj("ModelConfig"));
+  ASSERT_NE(mc, nullptr);
+
+  for (bool batchFit : {true, false}) {
+    for (bool constTermOptimisation : {true, false}) { // This tests both correct pre-caching of constant terms and (if false) that all evaluateSpan() are correct.
+      SCOPED_TRACE(batchFit ? "Batch fit" : "Normal fit");
+      SCOPED_TRACE(constTermOptimisation ? "const term optimisation" : "No const term optimisation");
+
+      std::unique_ptr<RooArgSet> pars( simPdf->getParameters(*data) );
+      // Kick parameters:
+      for (auto par : *pars) {
+        auto real = dynamic_cast<RooAbsRealLValue*>(par);
+        if (real && !real->isConstant())
+          real->setVal(real->getVal() * 0.95);
+      }
+
+      auto fitResult = simPdf->fitTo(*data,
+          RooFit::BatchMode(batchFit),
+          RooFit::Optimize(constTermOptimisation),
+          RooFit::GlobalObservables(*mc->GetGlobalObservables()),
+          RooFit::Save(),
+          RooFit::PrintLevel(-1));
+      ASSERT_NE(fitResult, nullptr);
+      if (verbose)
+        fitResult->Print();
+      EXPECT_EQ(fitResult->status(), 0);
+
+
+      auto checkParam = [fitResult](const std::string& param, double target, double absPrecision) {
+        auto par = dynamic_cast<RooRealVar*>(fitResult->floatParsFinal().find(param.c_str()));
+        if (!par) {
+          // Parameter was constant in this fit
+          par = dynamic_cast<RooRealVar*>(fitResult->constPars().find(param.c_str()));
+          ASSERT_NE(par, nullptr);
+          EXPECT_DOUBLE_EQ(par->getVal(), target) << "Constant parameter " << param << " is off target.";
+        } else {
+          EXPECT_NEAR(par->getVal(), target, par->getError()) << "Parameter " << param << " close to target " << target << " within uncertainty";
+          EXPECT_NEAR(par->getVal(), target, absPrecision) << "Parameter " << param << " close to target " << target;
+        }
+      };
+
+      if (GetParam() < kEquidistantBins_histoSyst) {
+        // Model is set up such that background scale factors should be close to 1, and signal == 2
+        checkParam("SigXsecOverSM", 2., 1.E-2);
+        checkParam("alpha_syst2", 0., 1.E-2);
+        checkParam("alpha_syst3", 0., 1.E-2);
+        checkParam("alpha_syst4", 0., 1.E-2);
+        checkParam("gamma_stat_channel1_bin_0", 1., 1.E-2);
+        checkParam("gamma_stat_channel1_bin_1", 1., 1.E-2);
+      } else if (GetParam() <= kCustomBins_histoSyst) {
+        // Model is set up with a -1 sigma pull on the signal shape parameter.
+        checkParam("SigXsecOverSM", 2., 1.E-1); // Higher tolerance: Expect a pull due to shape syst.
+        checkParam("alpha_syst2", 0., 1.E-2);
+        checkParam("alpha_syst3", 0., 3.E-2); // Micro pull due to shape syst.
+        checkParam("alpha_syst4", 0., 1.E-2);
+        checkParam("gamma_stat_channel1_bin_0", 1., 1.E-2);
+        checkParam("gamma_stat_channel1_bin_1", 1., 1.E-2);
+        checkParam("alpha_SignalShape", -0.9, 5.E-2); // Pull slightly lower than 1 because of constraint term
+      }
+    }
+  }
+
+
+  if (createPlot) {
+    auto obs = dynamic_cast<RooRealVar*>(ws->var("obs_x_channel1"));
+    auto frame = obs->frame();
+    data->plotOn(frame);
+    channelPdf->plotOn(frame);
+    channelPdf->plotOn(frame, RooFit::Components("signal_channel1_shapes"), RooFit::LineColor(kRed));
+    TCanvas canv;
+    frame->Draw();
+    canv.Draw();
+    canv.SaveAs(("/tmp/HFTest" + std::to_string(GetParam()) + ".png").c_str());
+  }
+}
+
+
+INSTANTIATE_TEST_SUITE_P(MakeModelWithNormSysts,
+    HFFixture,
+    testing::Values(kEquidistantBins, kCustomBins));
+
+INSTANTIATE_TEST_SUITE_P(MakeModelWithHistoSysts,
+    HFFixture,
+    testing::Values(kEquidistantBins_histoSyst, kCustomBins_histoSyst));
+

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -225,6 +225,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooWrapperPdf.h
     RooNaNPacker.h
     RooBinSamplingPdf.h
+    RooBinWidthFunction.h
     RooFitLegacy/RooCatTypeLegacy.h
     RooFitLegacy/RooCategorySharedProperties.h
     RooFitLegacy/RooHashTable.h
@@ -438,6 +439,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooHelpers.cxx
     src/RooWrapperPdf.cxx
     src/RooBinSamplingPdf.cxx
+    src/RooBinWidthFunction.cxx
     src/RooFitLegacy/RooCatTypeLegacy.cxx
     src/RooFitLegacy/RooCategorySharedProperties.cxx
     src/RooFitLegacy/RooHashTable.cxx

--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -196,6 +196,8 @@
 #pragma read sourceClass="RooCategoryProxy" targetClass="RooTemplateProxy<RooMultiCategory>";
 #pragma link C++ class RooTemplateProxy<RooAbsCategoryLValue>+;
 #pragma read sourceClass="RooCategoryProxy" targetClass="RooTemplateProxy<RooAbsCategoryLValue>";
+#pragma link C++ class RooTemplateProxy<RooHistFunc>+;
+#pragma link C++ class RooTemplateProxy<const RooHistFunc>+;
 #pragma link C++ class RooRealVar- ;
 #pragma link C++ class RooRealVarSharedProperties+ ;
 #pragma read sourceClass="RooRealVarSharedProperties" targetClass="RooRealVarSharedProperties" version="[1]" \
@@ -356,4 +358,5 @@
 #pragma link C++ options=nomap class std::map<string,TH1*>+ ;
 #pragma link off class RooErrorHandler+ ;
 #endif 
-#pragma link C++ class RooBinSamplingPdf+; 
+#pragma link C++ class RooBinSamplingPdf+;
+#pragma link C++ class RooBinWidthFunction+;

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -615,7 +615,6 @@ private:
   friend class RooObjectFactory ;
   friend class RooHistPdf ;
   friend class RooHistFunc ;
-  friend class RooHistFunc2 ;
   void registerProxy(RooArgProxy& proxy) ;
   void registerProxy(RooSetProxy& proxy) ;
   void registerProxy(RooListProxy& proxy) ;

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -502,6 +502,12 @@ public:
   RooExpensiveObjectCache& expensiveObjectCache() const ;
   virtual void setExpensiveObjectCache(RooExpensiveObjectCache &cache) { _eocache = &cache; }
 
+  /// Overwrite the current value stored in this object, making it look like this object computed that value.
+  /// \param[in] value Value to store.
+  /// \param[in] notifyClients Notify users of this object that they need to
+  /// recompute their values.
+  virtual void setCachedValue(double /*value*/, bool /*notifyClients*/ = true) {};
+
   /// @}
   ////////////////////////////////////////////////////////////////////////////
 

--- a/roofit/roofitcore/inc/RooAbsCategory.h
+++ b/roofit/roofitcore/inc/RooAbsCategory.h
@@ -202,6 +202,7 @@ protected:
   friend class RooVectorDataStore ;
   virtual void syncCache(const RooArgSet* set=0) ;
   virtual void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValueDirty=kTRUE) ;
+  void setCachedValue(double value, bool notifyClients = true) final;
   virtual void attachToTree(TTree& t, Int_t bufSize=32000) ;
   virtual void attachToVStore(RooVectorDataStore& vstore) ;
   virtual void setTreeBranchStatus(TTree& t, Bool_t active) ;

--- a/roofit/roofitcore/inc/RooAbsFunc.h
+++ b/roofit/roofitcore/inc/RooAbsFunc.h
@@ -40,9 +40,6 @@ public:
   }
 
   virtual Double_t operator()(const Double_t xvector[]) const = 0;
-  virtual RooSpan<const double> getValues(std::vector<RooSpan<const double>> /*coordinates*/) const {
-    throw std::logic_error("Not implemented.");
-  }
   virtual Double_t getMinLimit(UInt_t dimension) const = 0;
   virtual Double_t getMaxLimit(UInt_t dimension) const = 0;
 
@@ -68,12 +65,12 @@ public:
     return "(unnamed)" ; 
   }  
 
-  virtual std::list<Double_t>* binBoundaries(Int_t) const { return 0 ; }
+  virtual std::list<Double_t>* binBoundaries(Int_t) const { return nullptr; }
 
+  /// Interface for returning an optional hint for initial sampling points when constructing a curve
+  /// projected on observable.
   virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const {
-    // Interface for returning an optional hint for initial sampling points when constructing a curve 
-    // projected on observable.  
-    return 0 ; 
+    return nullptr;
   }
 
 protected:

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -295,7 +295,7 @@ public:
   virtual void printValue(std::ostream& os) const ;
   virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
 
-  static void setCacheCheck(Bool_t flag) ;
+  inline void setCachedValue(double value, bool notifyClients = true) final;
 
   // Evaluation error logging 
   class EvalError {
@@ -576,6 +576,22 @@ class BatchInterfaceAccessor {
       theReal.checkBatchComputation(evalData, evtNo, normSet, relAccuracy);
     }
 };
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Overwrite the value stored in this object's cache.
+/// This can be used to fake a computation that resulted in `value`.
+/// \param[in] value Value to write.
+/// \param[in] setValDirty If true, notify users of this object that its value changed.
+/// This is the default.
+void RooAbsReal::setCachedValue(double value, bool notifyClients) {
+  _value = value;
+
+  if (notifyClients) {
+    setValueDirty();
+    _valueDirty = false;
+  }
+}
 
 
 #endif

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -42,17 +42,17 @@ public:
   }
 
   /// Construct from iterators.
-  /// \tparam Iterator_t An iterator pointing to RooFit objects or references thereof.
+  /// \tparam Iterator_t An iterator pointing to RooFit objects or pointers/references thereof.
   /// \param beginIt Iterator to first element to add.
-  /// \param end Iterator to end of range to be added.
+  /// \param endIt Iterator to end of range to be added.
   /// \param name Optional name of the collection.
   template<typename Iterator_t,
-      typename value_type = typename std::iterator_traits<Iterator_t>::value_type,
+      typename value_type = typename std::remove_pointer<typename std::iterator_traits<Iterator_t>::value_type>,
       typename = std::enable_if<std::is_convertible<const value_type*, const RooAbsArg*>::value> >
   RooArgList(Iterator_t beginIt, Iterator_t endIt, const char* name="") :
   RooArgList(name) {
     for (auto it = beginIt; it != endIt; ++it) {
-      add(*it);
+      processArg(*it);
     }
   }
 
@@ -92,6 +92,7 @@ protected:
 
 private:
   void processArg(const RooAbsArg& arg) { add(arg); }
+  void processArg(const RooAbsArg* arg) { add(*arg); }
   void processArg(const char* name) { _name = name; }
 
   ClassDef(RooArgList,1) // Ordered list of RooAbsArg objects

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -58,18 +58,18 @@ public:
     (void)dummy;
   }
 
-  /// Construct from iterators.
-  /// \tparam Iterator_t An iterator pointing to RooFit objects or references thereof.
+  /// Construct a (non-owning) RooArgSet from iterators.
+  /// \tparam Iterator_t An iterator pointing to RooFit objects or to pointers/references of those.
   /// \param beginIt Iterator to first element to add.
-  /// \param end Iterator to end of range to be added.
+  /// \param endIt Iterator to end of range to be added.
   /// \param name Optional name of the collection.
   template<typename Iterator_t,
-      typename value_type = typename std::iterator_traits<Iterator_t>::value_type,
+      typename value_type = typename std::remove_pointer<typename std::iterator_traits<Iterator_t>::value_type>::type,
       typename = std::enable_if<std::is_convertible<const value_type*, const RooAbsArg*>::value> >
   RooArgSet(Iterator_t beginIt, Iterator_t endIt, const char* name="") :
   RooArgSet(name) {
     for (auto it = beginIt; it != endIt; ++it) {
-      add(*it);
+      processArg(*it);
     }
   }
 
@@ -129,6 +129,7 @@ protected:
 
 private:
   void processArg(const RooAbsArg& var) { add(var); }
+  void processArg(const RooAbsArg* var) { add(*var); }
   void processArg(const RooArgSet& set) { add(set); if (_name.Length() == 0) _name = set.GetName(); }
   void processArg(const RooArgList& list);
   void processArg(const char* name) { _name = name; }

--- a/roofit/roofitcore/inc/RooBinIntegrator.h
+++ b/roofit/roofitcore/inc/RooBinIntegrator.h
@@ -21,6 +21,10 @@
 #include <vector>
 #include <list>
 
+namespace RooBatchCompute {
+struct RunContext;
+}
+
 class RooBinIntegrator : public RooAbsIntegrator {
 public:
 
@@ -58,6 +62,9 @@ protected:
   mutable Int_t _numBins;                   //! Size of integration range
   
   Bool_t _useIntegrandLimits;  // If true limits of function binding are ued
+
+  std::unique_ptr<RooBatchCompute::RunContext> _evalData;     //! Run context for evaluating a function.
+  std::unique_ptr<RooBatchCompute::RunContext> _evalDataOrig; //! Run context to save bin centres in between invocations.
 
   double* xvec(double xx) { _x[0] = xx ; return _x ; }
   double* xvec(double xx, double yy) { _x[0] = xx ; _x[1] = yy ; return _x ; }

--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -1,0 +1,81 @@
+// Author Stephan Hageboeck, CERN, 6/2020
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * Package: RooFitCore                                                       *
+ *    File: $Id$
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2020, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#ifndef ROOFIT_ROOFITCORE_INC_BINWIDTHFUNCTION_H_
+#define ROOFIT_ROOFITCORE_INC_BINWIDTHFUNCTION_H_
+
+#include "RooAbsReal.h"
+#include "RooTemplateProxy.h"
+#include "RooHistFunc.h"
+
+namespace BatchHelpers { struct RunContext; }
+
+class RooBinWidthFunction : public RooAbsReal {
+public:
+  /// Create an empty instance.
+  RooBinWidthFunction() :
+    _histFunc("HistFuncForBinWidth", "Handle to a RooHistFunc, whose bin volumes should be returned.", this,
+        /*valueServer=*/true, /*shapeServer=*/true) { }
+
+  /// Create an instance.
+  /// \param name Name to identify the object.
+  /// \param title Title for e.g. plotting.
+  /// \param histFunc RooHistFunc object whose bin widths should be returned.
+  /// \param divideByBinWidth If true, return inverse bin width.
+  RooBinWidthFunction(const char* name, const char* title, const RooHistFunc& histFunc, bool divideByBinWidth) :
+    RooAbsReal(name, title),
+    _histFunc("HistFuncForBinWidth", "Handle to a RooHistFunc, whose bin volumes should be returned.", this, histFunc, /*valueServer=*/true, /*shapeServer=*/true),
+    _divideByBinWidth(divideByBinWidth) { }
+
+  /// Copy an existing object.
+  RooBinWidthFunction(const RooBinWidthFunction& other, const char* newname = nullptr) :
+    RooAbsReal(other, newname),
+    _histFunc("HistFuncForBinWidth", this, other._histFunc),
+    _divideByBinWidth(other._divideByBinWidth) { }
+
+  virtual ~RooBinWidthFunction() { }
+
+  /// Copy the object and return as TObject*.
+  virtual TObject* clone(const char* newname = nullptr) const override {
+    return new RooBinWidthFunction(*this, newname);
+  }
+
+  // Plotting and binning hints
+  /// Test if internal RooHistFunc is binned.
+  bool isBinnedDistribution(const RooArgSet& obs) const override {
+    return _histFunc->isBinnedDistribution(obs);
+  }
+  /// Return bin boundaries of internal RooHistFunc.
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override {
+    return _histFunc->binBoundaries(obs, xlo, xhi);
+  }
+  /// Return plotSamplingHint of internal RooHistFunc.
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override {
+    return _histFunc->plotSamplingHint(obs, xlo, xhi);
+  }
+
+  double evaluate() const override;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
+
+private:
+  RooTemplateProxy<const RooHistFunc> _histFunc;
+  bool _divideByBinWidth{false};
+
+  ClassDefOverride(RooBinWidthFunction, 1);
+};
+
+#endif

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -84,6 +84,10 @@ public:
 
   RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const override;
   void getBatches(RooBatchCompute::RunContext& evalData, std::size_t begin, std::size_t len) const override;
+  /// Retrieve all bin volumes. Bins are indexed according to getIndex().
+  RooSpan<const double> binVolumes(std::size_t first, std::size_t len) const {
+    return {_binv + first, len};
+  }
 
   Double_t sum(bool correctForBinSize, bool inverseCorr=false) const ;
   Double_t sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, bool correctForBinSize, bool inverseCorr=false) ;

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -46,6 +46,10 @@ public:
     return *_dataHist ; 
   }
   
+  /// Get total bin volume spanned by this hist function.
+  /// In 1-d, this is e.g. the range spanned on the x-axis.
+  Double_t totVolume() const;
+
   /// Set histogram interpolation order.
   void setInterpolationOrder(Int_t order) { 
 
@@ -81,15 +85,17 @@ public:
   RooArgSet const& getHistObsList() const { return _histObsList; }
 
 
+  Int_t getBin() const;
+  std::vector<Int_t> getBins(RooBatchCompute::RunContext& evalData) const;
+
 protected:
 
   Bool_t importWorkspaceHook(RooWorkspace& ws) ;
   Bool_t areIdentical(const RooDataHist& dh1, const RooDataHist& dh2) ;
 
   Double_t evaluate() const;
-  Double_t totalVolume() const ;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/) const;
   friend class RooAbsCachedReal ;
-  Double_t totVolume() const ;
 
   virtual void ioStreamerPass2() ;
 

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -33,6 +33,9 @@ public:
   RooProduct(const char *name, const char *title, const RooArgList& _prodSet) ;
 
   RooProduct(const RooProduct& other, const char* name = 0);
+
+  void addTerm(RooAbsArg* term);
+
   virtual TObject* clone(const char* newname) const { return new RooProduct(*this, newname); }
   virtual Bool_t forceAnalyticalInt(const RooAbsArg& dep) const ;
   virtual Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars,

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -77,6 +77,8 @@ protected:
 
   Double_t calculate(const RooArgList& partIntList) const;
   Double_t evaluate() const;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
+
   const char* makeFPName(const char *pfx,const RooArgSet& terms) const ;
   ProdMap* groupProductTerms(const RooArgSet&) const;
   Int_t getPartIntList(const RooArgSet* iset, const char *rangeName=0) const;

--- a/roofit/roofitcore/inc/RooRealBinding.h
+++ b/roofit/roofitcore/inc/RooRealBinding.h
@@ -34,6 +34,7 @@ public:
 
   virtual Double_t operator()(const Double_t xvector[]) const;
   virtual RooSpan<const double> getValues(std::vector<RooSpan<const double>> coordinates) const;
+  RooSpan<const double> getValuesOfBoundFunction(RooBatchCompute::RunContext& evalData) const;
   virtual Double_t getMinLimit(UInt_t dimension) const;
   virtual Double_t getMaxLimit(UInt_t dimension) const;
 
@@ -43,6 +44,8 @@ public:
   virtual const char* getName() const ; 
 
   virtual std::list<Double_t>* binBoundaries(Int_t) const ;
+  /// Return a pointer to the observable that defines the `i`-th dimension of the function.
+  RooAbsRealLValue* observable(unsigned int i) const { return i < _vars.size() ? _vars[i] : nullptr; }
   virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
 
 protected:

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -20,7 +20,6 @@
 #include "RooListProxy.h"
 #include "RooAICRegistry.h"
 #include "RooObjCacheManager.h"
-#include <list>
 
 class RooRealSumPdf : public RooAbsPdf {
 public:
@@ -68,6 +67,7 @@ public:
   virtual void setCacheAndTrackHints(RooArgSet&) ;
 
 protected:
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
   
   class CacheElem : public RooAbsCacheElement {
   public:

--- a/roofit/roofitcore/src/RooAbsCategory.cxx
+++ b/roofit/roofitcore/src/RooAbsCategory.cxx
@@ -562,6 +562,24 @@ void RooAbsCategory::copyCache(const RooAbsArg *source, Bool_t /*valueOnly*/, Bo
    }
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Overwrite the value stored in this object's cache.
+/// This can be used to fake a computation that resulted in `value`.
+/// \param[in] value Value to write. The argument is reinterpreted as a category state.
+/// If such a state does not exist, this will create undefined behaviour.
+/// \param[in] notifyClients If true, notify users of this object that its value changed.
+/// This is the default.
+void RooAbsCategory::setCachedValue(double value, bool notifyClients) {
+  _currentIndex = static_cast<value_type>(value);
+
+  if (notifyClients) {
+    setValueDirty();
+    _valueDirty = false;
+  }
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Return name and index of the `n`th defined state. When states are defined using
 /// defineType() or operator[], the order of insertion is tracked, to mimic the behaviour

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -1626,7 +1626,7 @@ RooPlot* RooAbsData::plotOn(RooPlot* frame, const RooLinkedList& argList) const
   // New experimental plotOn() with varargs...
 
   // Define configuration for this method
-  RooCmdConfig pc(Form("RooTreeData::plotOn(%s)",GetName())) ;
+  RooCmdConfig pc(Form("RooAbsData::plotOn(%s)",GetName())) ;
   pc.defineString("drawOption","DrawOption",0,"P") ;
   pc.defineString("cutRange","CutRange",0,"",kTRUE) ;
   pc.defineString("cutString","CutSpec",0,"") ;
@@ -1769,11 +1769,14 @@ RooPlot *RooAbsData::plotOn(RooPlot *frame, PlotOpt o) const
   TString histName(GetName());
   histName.Append("_plot");
   TH1F *hist ;
-    if (o.bins) {
+  if (o.bins) {
     hist= static_cast<TH1F*>(var->createHistogram(histName.Data(), RooFit::AxisLabel("Events"), RooFit::Binning(*o.bins))) ;
+  } else if (!frame->getPlotVar()->getBinning().isUniform()) {
+    hist = static_cast<TH1F*>(var->createHistogram(histName.Data(), RooFit::AxisLabel("Events"),
+        RooFit::Binning(frame->getPlotVar()->getBinning())));
   } else {
     hist= var->createHistogram(histName.Data(), "Events",
-                frame->GetXaxis()->GetXmin(), frame->GetXaxis()->GetXmax(), frame->GetNbinsX());
+        frame->GetXaxis()->GetXmin(), frame->GetXaxis()->GetXmax(), frame->GetNbinsX());
   }
 
   // Keep track of sum-of-weights error

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -26,15 +26,11 @@ points for its contents and provides an iterator over its elements
 **/
 
 #include "RooAbsData.h"
-#include "RooFit.h"
-
-#include <iostream>
 
 #include "TBuffer.h"
 #include "TClass.h"
 #include "TMath.h"
 #include "TTree.h"
-#include "strlcpy.h"
 
 #include "RooFormulaVar.h"
 #include "RooCmdConfig.h"
@@ -56,6 +52,7 @@ points for its contents and provides an iterator over its elements
 #include "RooPlot.h"
 #include "RooCurve.h"
 #include "RooHist.h"
+#include "RooHelpers.h"
 
 #include "TMatrixDSym.h"
 #include "TPaveText.h"
@@ -63,6 +60,9 @@ points for its contents and provides an iterator over its elements
 #include "TH2.h"
 #include "TH3.h"
 #include "Math/Util.h"
+
+#include <iostream>
+#include <memory>
 
 
 using namespace std;
@@ -564,57 +564,53 @@ RooPlot* RooAbsData::plotOn(RooPlot* frame, const RooCmdArg& arg1, const RooCmdA
 TH1 *RooAbsData::createHistogram(const char* varNameList, Int_t xbins, Int_t ybins, Int_t zbins) const
 {
   // Parse list of variable names
-  char buf[1024] ;
-  strlcpy(buf,varNameList,1024) ;
-  char* varName = strtok(buf,",:") ;
+  const auto varNames = RooHelpers::tokenise(varNameList, ",:");
+  RooLinkedList argList;
+  RooRealVar* vars[3] = {nullptr, nullptr, nullptr};
 
-  RooRealVar* xvar = (RooRealVar*) get()->find(varName) ;
-  if (!xvar) {
-    coutE(InputArguments) << "RooAbsData::createHistogram(" << GetName() << ") ERROR: dataset does not contain an observable named " << varName << endl ;
-    return 0 ;
-  }
-  varName = strtok(0,",") ;
-  RooRealVar* yvar = varName ? (RooRealVar*) get()->find(varName) : 0 ;
-  if (varName && !yvar) {
-    coutE(InputArguments) << "RooAbsData::createHistogram(" << GetName() << ") ERROR: dataset does not contain an observable named " << varName << endl ;
-    return 0 ;
-  }
-  varName = strtok(0,",") ;
-  RooRealVar* zvar = varName ? (RooRealVar*) get()->find(varName) : 0 ;
-  if (varName && !zvar) {
-    coutE(InputArguments) << "RooAbsData::createHistogram(" << GetName() << ") ERROR: dataset does not contain an observable named " << varName << endl ;
-    return 0 ;
+  for (unsigned int i = 0; i < varNames.size(); ++i) {
+    if (i >= 3) {
+      coutW(InputArguments) << "RooAbsData::createHistogram(" << GetName() << "): Can only create 3-dimensional histograms. Variable "
+          << i << " " << varNames[i] << " unused." << std::endl;
+      continue;
+    }
+
+    vars[i] = static_cast<RooRealVar*>( get()->find(varNames[i].data()) );
+    if (!vars[i]) {
+      coutE(InputArguments) << "RooAbsData::createHistogram(" << GetName() << ") ERROR: dataset does not contain an observable named " << varNames[i] << std::endl;
+      return nullptr;
+    }
   }
 
-  // Construct list of named arguments to pass to the implementation version of createHistogram()
+  if (!vars[0]) {
+    coutE(InputArguments) << "RooAbsData::createHistogram(" << GetName() << "): No variable to be histogrammed in list '" << varNameList << "'" << std::endl;
+    return nullptr;
+  }
 
-  RooLinkedList argList ;
-  if (xbins<=0  || !xvar->hasMax() || !xvar->hasMin() ) {
-    argList.Add(RooFit::AutoBinning(xbins==0?xvar->numBins():abs(xbins)).Clone()) ;
+  if (xbins<=0  || !vars[0]->hasMax() || !vars[0]->hasMin() ) {
+    argList.Add(RooFit::AutoBinning(xbins==0?vars[0]->numBins():abs(xbins)).Clone()) ;
   } else {
     argList.Add(RooFit::Binning(xbins).Clone()) ;
   }
 
-  if (yvar) {
-    if (ybins<=0 || !yvar->hasMax() || !yvar->hasMin() ) {
-      argList.Add(RooFit::YVar(*yvar,RooFit::AutoBinning(ybins==0?yvar->numBins():abs(ybins))).Clone()) ;
+  if (vars[1]) {
+    if (ybins<=0 || !vars[1]->hasMax() || !vars[1]->hasMin() ) {
+      argList.Add(RooFit::YVar(*vars[1],RooFit::AutoBinning(ybins==0?vars[1]->numBins():abs(ybins))).Clone()) ;
     } else {
-      argList.Add(RooFit::YVar(*yvar,RooFit::Binning(ybins)).Clone()) ;
+      argList.Add(RooFit::YVar(*vars[1],RooFit::Binning(ybins)).Clone()) ;
     }
   }
-
-  if (zvar) {
-    if (zbins<=0 || !zvar->hasMax() || !zvar->hasMin() ) {
-      argList.Add(RooFit::ZVar(*zvar,RooFit::AutoBinning(zbins==0?zvar->numBins():abs(zbins))).Clone()) ;
+  if (vars[2]) {
+    if (zbins<=0 || !vars[2]->hasMax() || !vars[2]->hasMin() ) {
+      argList.Add(RooFit::ZVar(*vars[2],RooFit::AutoBinning(zbins==0?vars[2]->numBins():abs(zbins))).Clone()) ;
     } else {
-      argList.Add(RooFit::ZVar(*zvar,RooFit::Binning(zbins)).Clone()) ;
+      argList.Add(RooFit::ZVar(*vars[2],RooFit::Binning(zbins)).Clone()) ;
     }
   }
-
 
 
   // Call implementation function
-  TH1* result = createHistogram(GetName(),*xvar,argList) ;
+  TH1* result = createHistogram(GetName(), *vars[0], argList);
 
   // Delete temporary list of RooCmdArgs
   argList.Delete() ;
@@ -1768,21 +1764,21 @@ RooPlot *RooAbsData::plotOn(RooPlot *frame, PlotOpt o) const
   // create and fill a temporary histogram of this variable
   TString histName(GetName());
   histName.Append("_plot");
-  TH1F *hist ;
+  std::unique_ptr<TH1> hist;
   if (o.bins) {
-    hist= static_cast<TH1F*>(var->createHistogram(histName.Data(), RooFit::AxisLabel("Events"), RooFit::Binning(*o.bins))) ;
+    hist.reset( var->createHistogram(histName.Data(), RooFit::AxisLabel("Events"), RooFit::Binning(*o.bins)) );
   } else if (!frame->getPlotVar()->getBinning().isUniform()) {
-    hist = static_cast<TH1F*>(var->createHistogram(histName.Data(), RooFit::AxisLabel("Events"),
-        RooFit::Binning(frame->getPlotVar()->getBinning())));
+    hist.reset( var->createHistogram(histName.Data(), RooFit::AxisLabel("Events"),
+        RooFit::Binning(frame->getPlotVar()->getBinning())) );
   } else {
-    hist= var->createHistogram(histName.Data(), "Events",
-        frame->GetXaxis()->GetXmin(), frame->GetXaxis()->GetXmax(), frame->GetNbinsX());
+    hist.reset( var->createHistogram(histName.Data(), "Events",
+        frame->GetXaxis()->GetXmin(), frame->GetXaxis()->GetXmax(), frame->GetNbinsX()) );
   }
 
   // Keep track of sum-of-weights error
   hist->Sumw2() ;
 
-  if(0 == fillHistogram(hist,RooArgList(*var),o.cuts,o.cutRange)) {
+  if(0 == fillHistogram(hist.get(), RooArgList(*var),o.cuts,o.cutRange)) {
     coutE(Plotting) << ClassName() << "::" << GetName()
     << ":plotOn: fillHistogram() failed" << endl;
     return 0;
@@ -1802,7 +1798,6 @@ RooPlot *RooAbsData::plotOn(RooPlot *frame, PlotOpt o) const
   if(0 == graph) {
     coutE(Plotting) << ClassName() << "::" << GetName()
     << ":plotOn: unable to create a RooHist object" << endl;
-    delete hist;
     return 0;
   }
 
@@ -1818,7 +1813,7 @@ RooPlot *RooAbsData::plotOn(RooPlot *frame, PlotOpt o) const
 
   // Store the number of entries before the cut, if any was made
   if ((o.cuts && strlen(o.cuts)) || o.cutRange) {
-    coutI(Plotting) << "RooTreeData::plotOn: plotting " << hist->GetSum() << " events out of " << nEnt << " total events" << endl ;
+    coutI(Plotting) << "RooTreeData::plotOn: plotting " << hist->GetSumOfWeights() << " events out of " << nEnt << " total events" << endl ;
     graph->setRawEntries(nEnt) ;
   }
 
@@ -1858,11 +1853,6 @@ RooPlot *RooAbsData::plotOn(RooPlot *frame, PlotOpt o) const
   // add the RooHist to the specified plot
   frame->addPlotable(graph,o.drawOptions,o.histInvisible,o.refreshFrameNorm);
 
-
-
-  // cleanup
-  delete hist;
-
   return frame;
 }
 
@@ -1896,22 +1886,22 @@ RooPlot* RooAbsData::plotAsymOn(RooPlot* frame, const RooAbsCategoryLValue& asym
   // create and fill temporary histograms of this variable for each state
   TString hist1Name(GetName()),hist2Name(GetName());
   hist1Name.Append("_plot1");
-  TH1F *hist1, *hist2 ;
+  std::unique_ptr<TH1> hist1, hist2;
   hist2Name.Append("_plot2");
 
   if (o.bins) {
-    hist1= var->createHistogram(hist1Name.Data(), "Events", *o.bins) ;
-    hist2= var->createHistogram(hist2Name.Data(), "Events", *o.bins) ;
+    hist1.reset( var->createHistogram(hist1Name.Data(), "Events", *o.bins) );
+    hist2.reset( var->createHistogram(hist2Name.Data(), "Events", *o.bins) );
   } else {
-    hist1= var->createHistogram(hist1Name.Data(), "Events",
+    hist1.reset( var->createHistogram(hist1Name.Data(), "Events",
             frame->GetXaxis()->GetXmin(), frame->GetXaxis()->GetXmax(),
-            frame->GetNbinsX());
-    hist2= var->createHistogram(hist2Name.Data(), "Events",
+            frame->GetNbinsX()) );
+    hist2.reset( var->createHistogram(hist2Name.Data(), "Events",
             frame->GetXaxis()->GetXmin(), frame->GetXaxis()->GetXmax(),
-            frame->GetNbinsX());
+            frame->GetNbinsX()) );
   }
 
-  assert(0 != hist1 && 0 != hist2);
+  assert(hist1 && hist2);
 
   TString cuts1,cuts2 ;
   if (o.cuts && strlen(o.cuts)) {
@@ -1922,8 +1912,8 @@ RooPlot* RooAbsData::plotAsymOn(RooPlot* frame, const RooAbsCategoryLValue& asym
     cuts2 = Form("(%s<0)",asymCat.GetName());
   }
 
-  if(0 == fillHistogram(hist1,RooArgList(*var),cuts1.Data(),o.cutRange) ||
-     0 == fillHistogram(hist2,RooArgList(*var),cuts2.Data(),o.cutRange)) {
+  if(! fillHistogram(hist1.get(), RooArgList(*var),cuts1.Data(),o.cutRange) ||
+     ! fillHistogram(hist2.get(), RooArgList(*var),cuts2.Data(),o.cutRange)) {
     coutE(Plotting) << ClassName() << "::" << GetName()
     << ":plotAsymOn: createHistogram() failed" << endl;
     return 0;
@@ -1952,10 +1942,6 @@ RooPlot* RooAbsData::plotAsymOn(RooPlot* frame, const RooAbsCategoryLValue& asym
 
   // add the RooHist to the specified plot
   frame->addPlotable(graph,o.drawOptions,o.histInvisible,o.refreshFrameNorm);
-
-  // cleanup
-  delete hist1;
-  delete hist2;
 
   return frame;
 }
@@ -1990,22 +1976,22 @@ RooPlot* RooAbsData::plotEffOn(RooPlot* frame, const RooAbsCategoryLValue& effCa
   // create and fill temporary histograms of this variable for each state
   TString hist1Name(GetName()),hist2Name(GetName());
   hist1Name.Append("_plot1");
-  TH1F *hist1, *hist2 ;
+  std::unique_ptr<TH1> hist1, hist2;
   hist2Name.Append("_plot2");
 
   if (o.bins) {
-    hist1= var->createHistogram(hist1Name.Data(), "Events", *o.bins) ;
-    hist2= var->createHistogram(hist2Name.Data(), "Events", *o.bins) ;
+    hist1.reset( var->createHistogram(hist1Name.Data(), "Events", *o.bins) );
+    hist2.reset( var->createHistogram(hist2Name.Data(), "Events", *o.bins) );
   } else {
-    hist1= var->createHistogram(hist1Name.Data(), "Events",
+    hist1.reset( var->createHistogram(hist1Name.Data(), "Events",
             frame->GetXaxis()->GetXmin(), frame->GetXaxis()->GetXmax(),
-            frame->GetNbinsX());
-    hist2= var->createHistogram(hist2Name.Data(), "Events",
+            frame->GetNbinsX()) );
+    hist2.reset( var->createHistogram(hist2Name.Data(), "Events",
             frame->GetXaxis()->GetXmin(), frame->GetXaxis()->GetXmax(),
-            frame->GetNbinsX());
+            frame->GetNbinsX()) );
   }
 
-  assert(0 != hist1 && 0 != hist2);
+  assert(hist1 && hist2);
 
   TString cuts1,cuts2 ;
   if (o.cuts && strlen(o.cuts)) {
@@ -2016,8 +2002,8 @@ RooPlot* RooAbsData::plotEffOn(RooPlot* frame, const RooAbsCategoryLValue& effCa
     cuts2 = Form("(%s==0)",effCat.GetName());
   }
 
-  if(0 == fillHistogram(hist1,RooArgList(*var),cuts1.Data(),o.cutRange) ||
-     0 == fillHistogram(hist2,RooArgList(*var),cuts2.Data(),o.cutRange)) {
+  if(! fillHistogram(hist1.get(), RooArgList(*var),cuts1.Data(),o.cutRange) ||
+     ! fillHistogram(hist2.get(), RooArgList(*var),cuts2.Data(),o.cutRange)) {
     coutE(Plotting) << ClassName() << "::" << GetName()
     << ":plotEffOn: createHistogram() failed" << endl;
     return 0;
@@ -2046,10 +2032,6 @@ RooPlot* RooAbsData::plotEffOn(RooPlot* frame, const RooAbsCategoryLValue& effCa
 
   // add the RooHist to the specified plot
   frame->addPlotable(graph,o.drawOptions,o.histInvisible,o.refreshFrameNorm);
-
-  // cleanup
-  delete hist1;
-  delete hist2;
 
   return frame;
 }

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -3221,7 +3221,6 @@ void RooAbsReal::copyCache(const RooAbsArg* source, Bool_t /*valueOnly*/, Bool_t
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
 
 void RooAbsReal::attachToVStore(RooVectorDataStore& vstore)

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -863,17 +863,15 @@ RooSpan<double> RooAddPdf::evaluateSpan(RooBatchCompute::RunContext& evalData, c
   const RooArgSet* nset = normAndCache.first;
   CacheElem* cache = normAndCache.second;
 
-
   RooSpan<double> output;
 
   for (unsigned int pdfNo = 0; pdfNo < _pdfList.size(); ++pdfNo) {
     const auto& pdf = static_cast<RooAbsPdf&>(_pdfList[pdfNo]);
     auto pdfOutputs = pdf.getValues(evalData, nset);
-    if (output.empty()) {
+    if (output.empty() || (output.size() == 1 && pdfOutputs.size() > 1)) {
+      const double init = output.empty() ? 0. : output[0];
       output = evalData.makeBatch(this, pdfOutputs.size());
-      for (double& val : output) { //CHECK_VECTORISE
-        val = 0.;
-      }
+      std::fill(output.begin(), output.end(), init);
     }
     assert(output.size() == pdfOutputs.size());
 

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -77,7 +77,7 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function) :
   RooAbsIntegrator(function)
 {
   _useIntegrandLimits= kTRUE;
-  assert(0 != integrand() && integrand()->isValid());
+  assert(_function && _function->isValid());
 
   // Allocate coordinate buffer size after number of function dimensions
   _x = new Double_t[_function->getDimension()] ;
@@ -86,18 +86,18 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function) :
   _xmin.resize(_function->getDimension()) ;
   _xmax.resize(_function->getDimension()) ;
 
-  auto realBinding = dynamic_cast<const RooRealBinding*>(integrand());
+  auto realBinding = dynamic_cast<const RooRealBinding*>(_function);
   if (realBinding) {
     _evalData.reset(new RooBatchCompute::RunContext());
     _evalDataOrig.reset(new RooBatchCompute::RunContext());
   }
 
   for (UInt_t i=0 ; i<_function->getDimension() ; i++) {
-    _xmin[i]= integrand()->getMinLimit(i);
-    _xmax[i]= integrand()->getMaxLimit(i);
+    _xmin[i]= _function->getMinLimit(i);
+    _xmax[i]= _function->getMaxLimit(i);
 
     // Retrieve bin configuration from integrand
-    std::unique_ptr<list<Double_t>> tmp{ integrand()->binBoundaries(i) };
+    std::unique_ptr<list<Double_t>> tmp{ _function->binBoundaries(i) };
     if (!tmp) {
       oocoutW((TObject*)0,Integration) << "RooBinIntegrator::RooBinIntegrator WARNING: integrand provide no binning definition observable #" 
           << i << " substituting default binning of " << _numBins << " bins" << endl ;
@@ -130,23 +130,23 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function, const RooNumIntCo
   const RooArgSet& configSet = config.getConfigSection(IsA()->GetName()) ;  
   _useIntegrandLimits= kTRUE;
   _numBins = (Int_t) configSet.getRealValue("numBins") ;
-  assert(0 != integrand() && integrand()->isValid());
+  assert(_function && _function->isValid());
   
   // Allocate coordinate buffer size after number of function dimensions
   _x = new Double_t[_function->getDimension()] ;
 
-  auto realBinding = dynamic_cast<const RooRealBinding*>(integrand());
+  auto realBinding = dynamic_cast<const RooRealBinding*>(_function);
   if (realBinding) {
     _evalData.reset(new RooBatchCompute::RunContext());
     _evalDataOrig.reset(new RooBatchCompute::RunContext());
   }
 
   for (UInt_t i=0 ; i<_function->getDimension() ; i++) {
-    _xmin.push_back(integrand()->getMinLimit(i));
-    _xmax.push_back(integrand()->getMaxLimit(i));
+    _xmin.push_back(_function->getMinLimit(i));
+    _xmax.push_back(_function->getMaxLimit(i));
     
     // Retrieve bin configuration from integrand
-    std::unique_ptr<list<Double_t>> tmp{ integrand()->binBoundaries(i) };
+    std::unique_ptr<list<Double_t>> tmp{ _function->binBoundaries(i) };
     if (!tmp) {
       oocoutW((TObject*)0,Integration) << "RooBinIntegrator::RooBinIntegrator WARNING: integrand provide no binning definition observable #" 
           << i << " substituting default binning of " << _numBins << " bins" << endl ;

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -254,7 +254,7 @@ Double_t RooBinIntegrator::integral(const Double_t *)
 
       // Reset computation results to only contain known bin centres, and keep all memory intact:
       _evalData->spans = _evalDataOrig->spans;
-      auto results = realBinding->getValues(*_evalData);
+      auto results = realBinding->getValuesOfBoundFunction(*_evalData);
       assert(results.size() == binb.size() - 1);
 
       for (unsigned int ibin = 0; ibin < binb.size() - 1; ++ibin) {

--- a/roofit/roofitcore/src/RooBinWidthFunction.cxx
+++ b/roofit/roofitcore/src/RooBinWidthFunction.cxx
@@ -1,0 +1,67 @@
+// Author Stephan Hageboeck, CERN, 10/2020
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * Package: RooFitCore                                                       *
+ *    File: $Id$
+ * Authors:                                                                  *
+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+ *                                                                           *
+ * Copyright (c) 2000-2020, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+
+/**
+ * \class RooBinWidthFunction
+ *
+ * RooBinWidthFunction is a class that returns the bin width (or volume) given a RooHistFunc.
+ * It can be used to normalise by bin width or to compute event densities. Using the extra
+ * argument of the constructor, it can also return the inverse of the bin width (or volume).
+ */
+
+#include "RooBinWidthFunction.h"
+
+#include "RooDataHist.h"
+#include "RunContext.h"
+
+
+/// Compute current bin of observable, and return its volume or inverse volume, depending
+/// on configuration chosen in the constructor.
+/// If the bin is not valid, return a volume of 1.
+double RooBinWidthFunction::evaluate() const {
+  const RooDataHist& dataHist = _histFunc->dataHist();
+  const auto idx = _histFunc->getBin();
+  auto volumes = dataHist.binVolumes(0, dataHist.numEntries());
+  const double volume = idx >= 0 ? volumes[idx] : 1.;
+
+  return _divideByBinWidth ? 1./volume : volume;
+}
+
+
+/// Compute bin index for all values of the observable(s) in `evalData`, and return their volumes or inverse volumes, depending
+/// on the configuration chosen in the constructor.
+/// If a bin is not valid, return a volume of 1.
+RooSpan<double> RooBinWidthFunction::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/) const {
+  const RooDataHist& dataHist = _histFunc->dataHist();
+  std::vector<Int_t> bins = _histFunc->getBins(evalData);
+  auto volumes = dataHist.binVolumes(0, dataHist.numEntries());
+
+  auto results = evalData.makeBatch(this, bins.size());
+
+  if (_divideByBinWidth) {
+    for (std::size_t i=0; i < bins.size(); ++i) {
+      results[i] = bins[i] >= 0 ? 1./volumes[bins[i]] : 1.;
+    }
+  } else {
+    for (std::size_t i=0; i < bins.size(); ++i) {
+      results[i] = bins[i] >= 0 ? volumes[bins[i]] : 1.;
+    }
+  }
+
+  return results;
+}

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -2140,8 +2140,7 @@ void RooDataHist::Streamer(TBuffer &R__b) {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return event weights of all events in range [first, first+len).
-/// If no contiguous structure of weights is stored, an empty batch is be returned.
-/// In this case, the single-value weight() needs to be used to retrieve it.
+/// If cacheValidEntries() has been called, out-of-range events will have a weight of 0.
 RooSpan<const double> RooDataHist::getWeightBatch(std::size_t first, std::size_t len) const {
   return _maskedWeights.empty() ?
       RooSpan<const double>{_wgt + first, len} :

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -977,7 +977,7 @@ Int_t RooDataHist::getIndex(const RooAbsCollection& coord, Bool_t fast) const {
 std::size_t RooDataHist::calcTreeIndex(const RooAbsCollection& coords, bool fast) const
 {
   // With fast, caller promises that layout of "coords" is identical to our internal "vars"
-  assert(!fast || _vars.size() == coords.size());
+  assert(!fast || coords.hasSameLayout(_vars));
 
   if (&_vars == &coords)
     fast = true;

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -24,10 +24,6 @@ multidimensional histogram. The histogram can have an arbitrary number of real o
 discrete dimensions and may have negative values.
 **/
 
-#include "RooFit.h"
-#include "Riostream.h"
-#include "TBuffer.h"
-
 #include "RooHistFunc.h"
 #include "RooDataHist.h"
 #include "RooMsgService.h"
@@ -36,8 +32,12 @@ discrete dimensions and may have negative values.
 #include "RooWorkspace.h"
 #include "RooHistPdf.h"
 #include "RooHelpers.h"
+#include "RunContext.h"
 
 #include "TError.h"
+#include "TBuffer.h"
+
+#include <stdexcept>
 
 using namespace std;
 
@@ -200,6 +200,49 @@ Double_t RooHistFunc::evaluate() const
   Double_t ret =  _dataHist->weightFast(_histObsList,_intOrder,kFALSE,_cdfBoundaries) ;  
   return ret ;
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute value of the HistFunc for every entry in `evalData`.
+/// \param[in/out] evalData Struct with input data. The computation results will be stored here.
+/// \param[in] normSet Set of observables to normalise over (ignored).
+RooSpan<double> RooHistFunc::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/) const {
+  std::vector<RooSpan<const double>> inputValues;
+  std::size_t batchSize = 0;
+  for (const auto& obs : _depList) {
+    auto realObs = dynamic_cast<const RooAbsReal*>(obs);
+    if (realObs) {
+      auto inputs = realObs->getValues(evalData, nullptr);
+      batchSize = std::max(batchSize, inputs.size());
+      inputValues.push_back(std::move(inputs));
+    } else {
+      inputValues.emplace_back();
+    }
+  }
+
+  auto results = evalData.makeBatch(this, batchSize);
+
+  for (std::size_t i = 0; i < batchSize; ++i) {
+    bool skip = false;
+
+    for (auto j = 0u; j < _histObsList.size(); ++j) {
+      const auto histObs = _histObsList[j];
+
+      if (i < inputValues[j].size()) {
+        histObs->setCachedValue(inputValues[j][i], false);
+        if (!histObs->inRange(nullptr)) {
+          skip = true;
+          break;
+        }
+      }
+    }
+
+    results[i] = skip ? 0. : _dataHist->weightFast(_histObsList, _intOrder, false, _cdfBoundaries);
+  }
+
+  return results;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Only handle case of maximum in all variables
@@ -537,3 +580,65 @@ void RooHistFunc::ioStreamerPass2()
   }
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute bin number corresponding to current coordinates.
+/// \return If a bin is not in the current range of the observables, return -1.
+Int_t RooHistFunc::getBin() const {
+  if (!_depList.empty()) {
+    for (auto i = 0u; i < _histObsList.size(); ++i) {
+      const auto harg = _histObsList[i];
+      const auto parg = _depList[i];
+
+      if (harg != parg) {
+        parg->syncCache() ;
+        harg->copyCache(parg,kTRUE) ;
+        if (!harg->inRange(nullptr)) {
+          return -1;
+        }
+      }
+    }
+  }
+
+  return _dataHist->getIndex(_histObsList, true);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute bin numbers corresponding to all coordinates in `evalData`.
+/// \return Vector of bin numbers. If a bin is not in the current range of the observables, return -1.
+std::vector<Int_t> RooHistFunc::getBins(RooBatchCompute::RunContext& evalData) const {
+  std::vector<RooSpan<const double>> depData;
+  for (const auto dep : _depList) {
+    auto real = dynamic_cast<const RooAbsReal*>(dep);
+    if (real) {
+      depData.push_back(real->getValues(evalData, nullptr));
+    } else {
+      depData.emplace_back(nullptr, 0);
+    }
+  }
+
+  const auto batchSize = std::max_element(depData.begin(), depData.end(),
+      [](const RooSpan<const double>& a, const RooSpan<const double>& b){ return a.size() < b.size(); })->size();
+  std::vector<Int_t> results;
+
+  for (std::size_t evt = 0; evt < batchSize; ++evt) {
+    if (!_depList.empty()) {
+      for (auto i = 0u; i < _histObsList.size(); ++i) {
+        const auto harg = _histObsList[i];
+
+        if (evt < depData[i].size())
+          harg->setCachedValue(depData[i][evt], false);
+
+        if (!harg->inRange(nullptr)) {
+          results.push_back(-1);
+          continue;
+        }
+      }
+    }
+
+    results.push_back(_dataHist->getIndex(_histObsList, true));
+  }
+
+  return results;
+}

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -534,8 +534,13 @@ RooSpan<double> RooProdPdf::evaluateSpan(RooBatchCompute::RunContext& evalData, 
 
       if (outputs.empty()) {
         outputs = evalData.makeBatch(this,  partialInt.size());
-        for (double& val : outputs) val = 1.;
+        std::fill(outputs.begin(), outputs.end(), 1.);
+      } else if (outputs.size() == 1 && partialInt.size() > 1) {
+        const double val = outputs[0];
+        outputs = evalData.makeBatch(this, partialInt.size());
+        std::fill(outputs.begin(), outputs.end(), val);
       }
+      assert(outputs.size() == partialInt.size());
 
       for (std::size_t j=0; j < outputs.size(); ++j) {
         outputs[j] *= partialInt[j];

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -81,15 +81,7 @@ RooProduct::RooProduct(const char* name, const char* title, const RooArgList& pr
   _cacheMgr(this,10)
 {
   for (auto comp : prodSet) {
-    if (dynamic_cast<RooAbsReal*>(comp)) {
-      _compRSet.add(*comp) ;
-    } else if (dynamic_cast<RooAbsCategory*>(comp)) {
-      _compCSet.add(*comp) ;
-    } else {
-      coutE(InputArguments) << "RooProduct::ctor(" << GetName() << ") ERROR: component " << comp->GetName() 
-			    << " is not of type RooAbsReal or RooAbsCategory" << endl ;
-      RooErrorHandler::softAbort() ;
-    }
+    addTerm(comp);
   }
   TRACE_CREATE
 }
@@ -109,6 +101,19 @@ RooProduct::RooProduct(const RooProduct& other, const char* name) :
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Add a term to this product.
+void RooProduct::addTerm(RooAbsArg* term) {
+  if (dynamic_cast<RooAbsReal*>(term)) {
+    _compRSet.add(*term) ;
+  } else if (dynamic_cast<RooAbsCategory*>(term)) {
+    _compCSet.add(*term) ;
+  } else {
+    coutE(InputArguments) << "RooProduct::addTerm(" << GetName() << ") ERROR: component " << term->GetName()
+        << " is not of type RooAbsReal or RooAbsCategory" << endl ;
+    throw std::invalid_argument("RooProduct can only handle terms deriving from RooAbsReal or RooAbsCategory.");
+  }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Force internal handling of integration of given observable if any

--- a/roofit/roofitcore/src/RooRealBinding.cxx
+++ b/roofit/roofitcore/src/RooRealBinding.cxx
@@ -197,6 +197,8 @@ Double_t RooRealBinding::operator()(const Double_t xvector[]) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Evaluate the bound object at all locations indicated by the data in `coordinates`.
+/// If `_clipInvalid` is set, the function is set to zero at all points in the arguments
+/// that are not within the range of the observables.
 /// \param coordinates Vector of spans that contain the points where the function should be evaluated.
 /// The ordinal position in the vector corresponds to the ordinal position in the set of
 /// {observables, parameters} that were passed to the constructor.
@@ -233,8 +235,7 @@ RooSpan<const double> RooRealBinding::getValues(std::vector<RooSpan<const double
   if (!parametersValid)
     return {};
 
-  auto results = _func->getValues(*_evalData, _nset);
-  assert(coordinates.front().size() == results.size());
+  auto results = getValuesOfBoundFunction(*_evalData);
 
   if (_clipInvalid) {
     RooSpan<double> resultsWritable(_evalData->getWritableBatch(_func));
@@ -254,6 +255,18 @@ RooSpan<const double> RooRealBinding::getValues(std::vector<RooSpan<const double
   }
 
   return results;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Evaluate the bound object at all locations indicated by the data in `evalData`.
+/// \see RooAbsReal::getValues().
+/// \param[in/out] evalData Struct with spans pointing to the data to be used for evaluation.
+/// The spans can either have a size of `n`, in which case a batch of `n` results is returned, or they can have
+/// a size of 1. In the latter case, the value in the span is broadcast to all `n` events.
+/// \return Batch of function values for each coordinate given in the input spans.
+RooSpan<const double> RooRealBinding::getValuesOfBoundFunction(RooBatchCompute::RunContext& evalData) const {
+  return _func->getValues(evalData, _nset);
 }
 
 


### PR DESCRIPTION
Here, HistFactory is streamlined a bit.

The models are restructured from this:
[HFTest4_old.pdf](https://github.com/root-project/root/files/6466419/HFTest4_old.pdf)

To this:
[HFTest4.pdf](https://github.com/root-project/root/files/6466420/HFTest4.pdf)

The main difference is that first, all binned parts of the calculation are executed (in batches), and then all scale factors are applied to the fully interpolated binned distributions. This reduces the number of function calls and allows for non-uniform binning (ROOT-4958), since the bin width correction is not applied as the last step, but during the binned calculations.

Further, prototypes of batch evaluations functions were added for all objects in HistFactory calculations. There are some possibilities for optimisations:
- [ ] ParamHistFunc::evaluateSpan always recalculates all indices
- [ ] RooBinIntegrator doesn't support multi-dimensional batch evaluations
- [ ] Auto-vectorisation should be checked, especially for performance-critical things like the piecewise interpolation
- [ ] Profiling with an example like in `testHistfactory` but with more bins should be done.