### PR TITLE
[skip-ci] better names for doxygen macros.

### DIFF
--- a/documentation/doxygen/MakeRCanvasJS.C
+++ b/documentation/doxygen/MakeRCanvasJS.C
@@ -2,7 +2,7 @@
 
 #include "ROOT/RCanvas.hxx"
 
-void makejsonfile(const char *MacroName, const char *IN, const char *OutDir, bool cp, bool py)
+void MakeRCanvasJS(const char *MacroName, const char *IN, const char *OutDir, bool cp, bool py)
 {
    using namespace ROOT::Experimental;
 

--- a/documentation/doxygen/MakeTCanvasJS.C
+++ b/documentation/doxygen/MakeTCanvasJS.C
@@ -1,6 +1,6 @@
 /// Generates the root file output of the macro MacroName
 
-void makerootfile(const char *MacroName, const char *IN, const char *OutDir, bool cp, bool py)
+void MakeTCanvasJS(const char *MacroName, const char *IN, const char *OutDir, bool cp, bool py)
 {
 
    // Execute the macro as a C++ one or a Python one.

--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -54,8 +54,8 @@
 ///  is passed, the macro is executed without the batch option.
 ///  Some tutorials generate pictures (png or pdf) with `Print` or `SaveAs`.
 ///  Such pictures can be displayed with `\macro_image (picture_name.png[.pdf])`
-///  When the option (js) is used the image is displayed as JavaScript.
-///  For ROOT 7 tutorials, when the option (json) is used the image is displayed as json file.
+///  When the option (tcanvas_js) is used the image is displayed as JavaScript.
+///  For ROOT 7 tutorials, when the option (rcanvas_js) is used the image is displayed as json file.
 ///
 ///  2. `\macro_code`
 ///  The macro code is shown.  A caption can be added: `\macro_code This is code`
@@ -323,10 +323,10 @@ void FilterTutorial()
       if (gLineString.find("\\macro_image") != string::npos) {
          bool nobatch = (gLineString.find("(nobatch)") != string::npos);
          ReplaceAll(gLineString,"(nobatch)","");
-         bool js = (gLineString.find("(js)") != string::npos);
-         ReplaceAll(gLineString,"(js)","");
-         bool json = (gLineString.find("(json)") != string::npos);
-         ReplaceAll(gLineString,"(json)","");
+         bool tcanvas_js = (gLineString.find("(tcanvas_js)") != string::npos);
+         ReplaceAll(gLineString,"(tcanvas_js)","");
+         bool rcanvas_js = (gLineString.find("(rcanvas_js)") != string::npos);
+         ReplaceAll(gLineString,"(rcanvas_js)","");
 
          bool image_created_by_macro = (gLineString.find(".png)") != string::npos) ||
                                        (gLineString.find(".svg)") != string::npos) ||
@@ -340,20 +340,20 @@ void FilterTutorial()
             ExecuteCommand(StringFormat("mv %s %s/html", image_name.c_str(), gOutDir.c_str()));
             ReplaceAll(gLineString, "macro_image (", "image html ");
             ReplaceAll(gLineString, ")", "");
-         } else if (js) {
+         } else if (tcanvas_js) {
             string IN;
             IN = gImageName;
             int i = IN.find(".");
             IN.erase(i,IN.length());
-            ExecuteCommand(StringFormat("root -l -b -q \"makerootfile.C(\\\"%s\\\",\\\"%s\\\",\\\"%s\\\",false,false)\"",
+            ExecuteCommand(StringFormat("root -l -b -q \"MakeTCanvasJS.C(\\\"%s\\\",\\\"%s\\\",\\\"%s\\\",false,false)\"",
                                          gFileName.c_str(), IN.c_str(), gOutDir.c_str()));
             ReplaceAll(gLineString, "macro_image", StringFormat("htmlinclude %s.html",IN.c_str()));
-         } else if (json) {
+         } else if (rcanvas_js) {
             string IN;
             IN = gImageName;
             int i = IN.find(".");
             IN.erase(i,IN.length());
-            ExecuteCommand(StringFormat("root -l -b -q --web=batch \"makejsonfile.C(\\\"%s\\\",\\\"%s\\\",\\\"%s\\\",false,false)\"",
+            ExecuteCommand(StringFormat("root -l -b -q --web=batch \"MakeRCanvasJS.C(\\\"%s\\\",\\\"%s\\\",\\\"%s\\\",false,false)\"",
                                           gFileName.c_str(), IN.c_str(), gOutDir.c_str()));
             ReplaceAll(gLineString, "macro_image", StringFormat("htmlinclude %s.html",IN.c_str()));
          } else {

--- a/tutorials/graphics/arrows.C
+++ b/tutorials/graphics/arrows.C
@@ -3,7 +3,7 @@
 /// \notebook -js
 /// Draw arrows.
 ///
-/// \macro_image (js)
+/// \macro_image (tcanvas_js)
 /// \macro_code
 ///
 /// \author Rene Brun

--- a/tutorials/graphics/mandelbrot.C
+++ b/tutorials/graphics/mandelbrot.C
@@ -8,7 +8,7 @@
 ///
 /// Try it (in compiled mode!) with:   `root mandelbrot.C+`
 ///
-/// \macro_image (js)
+/// \macro_image (tcanvas_js)
 ///
 /// ### Details
 ///

--- a/tutorials/v7/box.cxx
+++ b/tutorials/v7/box.cxx
@@ -5,7 +5,7 @@
 /// draw ROOT 7 boxes in it (RBox). It generates a set of boxes using the
 /// "normal" coordinates' system.
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2018-10-10

--- a/tutorials/v7/draw.cxx
+++ b/tutorials/v7/draw.cxx
@@ -1,7 +1,9 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// \macro_image (json)
+/// This ROOT 7 example shows how to create a histogram, fill it  and draw it.
+///
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2015-03-22

--- a/tutorials/v7/draw_axes.cxx
+++ b/tutorials/v7/draw_axes.cxx
@@ -4,7 +4,7 @@
 /// This ROOT7 example demonstrates how to create a RCanvas and
 /// draw several RAxis objects with different options.
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2020-11-03

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -1,7 +1,9 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// \macro_image (json)
+/// This ROOT 7 example shows how to create a frame.
+///
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2020-02-20

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -4,7 +4,7 @@
 /// This macro generates two TH1D objects and build RLegend
 /// In addition use of auto colors are shown
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2019-10-09

--- a/tutorials/v7/draw_pave.cxx
+++ b/tutorials/v7/draw_pave.cxx
@@ -4,7 +4,7 @@
 /// This macro generates a small V7 TH1D, fills it and draw it in a V7 canvas.
 /// The canvas is display in the web browser
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2015-03-22

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -4,7 +4,7 @@
 /// This macro generates two RH1D, fills them and draw with different options in RCanvas.
 /// The canvas is display in the web browser
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2015-03-22

--- a/tutorials/v7/draw_rh2.cxx
+++ b/tutorials/v7/draw_rh2.cxx
@@ -3,7 +3,7 @@
 ///
 /// This macro generates RH2D and draw it with different options in RCanvas
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2020-06-25

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -4,7 +4,7 @@
 /// This macro generates a small V7 TH2D, fills it with random values and
 /// draw it in a V7 canvas, using configured web browser
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2020-03-04

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -4,7 +4,7 @@
 /// This macro generates really large RH2D histogram, fills it with predefined pattern and
 /// draw it in a RCanvas, using Optmize() drawing mode
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2020-06-26

--- a/tutorials/v7/draw_rh3.cxx
+++ b/tutorials/v7/draw_rh3.cxx
@@ -4,7 +4,7 @@
 /// This macro generates a small RH3D, fills it with random values and
 /// draw it in RCanvas, using configured web browser
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2020-06-18

--- a/tutorials/v7/draw_rh3_large.cxx
+++ b/tutorials/v7/draw_rh3_large.cxx
@@ -4,7 +4,7 @@
 /// This macro generates really large RH2D histogram, fills it with predefined pattern and
 /// draw it in a RCanvas, using Optmize() drawing mode
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2020-06-26

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -4,7 +4,7 @@
 /// This ROOT 7 example demonstrates how to create a ROOT 7 canvas (RCanvas),
 /// divide on subpads and draw histograms there
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2018-03-13

--- a/tutorials/v7/draw_text.cxx
+++ b/tutorials/v7/draw_text.cxx
@@ -4,7 +4,7 @@
 /// This macro demonstrate the text attributes for RText. Angle, size and color are
 /// changed in a loop. The text alignment and the text font are fixed.
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2017-10-17

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -3,7 +3,7 @@
 ///
 /// This macro shows how ROOT objects like TH1, TH2, TGraph can be drawn in RCanvas.
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2017-06-02

--- a/tutorials/v7/global_temperatures.cxx
+++ b/tutorials/v7/global_temperatures.cxx
@@ -6,7 +6,7 @@
 /// average temperature per city by season. Then it does the same for average temperature per city for the years between 1993-2002, and 2003-2013.
 /// Finally, the tutorial visualizes this processed data through histograms.
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 ///

--- a/tutorials/v7/lineRStyle.cxx
+++ b/tutorials/v7/lineRStyle.cxx
@@ -4,7 +4,7 @@
 /// This ROOT 7 example demonstrates how to customize RLine object using RStyle
 /// "normal" coordinates' system.
 ///
-/// \macro_image (json)
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2019-10-04

--- a/tutorials/v7/lineStyle.cxx
+++ b/tutorials/v7/lineStyle.cxx
@@ -1,7 +1,9 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// \macro_image (json)
+/// This ROOT 7 example shows the various line styles.
+///
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2018-03-18

--- a/tutorials/v7/lineWidth.cxx
+++ b/tutorials/v7/lineWidth.cxx
@@ -1,7 +1,9 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// \macro_image (json)
+/// This ROOT 7 example shows the various line widths.
+///
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2018-03-18

--- a/tutorials/v7/markerStyle.cxx
+++ b/tutorials/v7/markerStyle.cxx
@@ -1,7 +1,9 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// \macro_image (json)
+/// This ROOT 7 example shows the various marker style.
+///
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2018-03-18

--- a/tutorials/v7/pad.cxx
+++ b/tutorials/v7/pad.cxx
@@ -1,7 +1,10 @@
 /// \file
 /// \ingroup tutorial_v7
 ///
-/// \macro_image (json)
+/// This ROOT 7 example demonstrates how to create a ROOT 7 canvas (RCanvas) and
+/// and divide it in 9 sub-pads.
+///
+/// \macro_image (rcanvas_js)
 /// \macro_code
 ///
 /// \date 2015-03-22


### PR DESCRIPTION
better names for doxygen macros making json files and name of the \macro_image options.