### PR TITLE
[ntuple] Fix DAOS test compilation for old CMake

### DIFF
--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -52,7 +52,7 @@ if(daos OR daos_mock)
     set(daos_test_pool 1b245c52-765e-449d-80b1-8dce93bafc4b)
   endif()
   set_property(SOURCE ntuple_storage_daos.cxx
-               APPEND PROPERTY COMPILE_OPTIONS -DR__DAOS_TEST_POOL="${daos_test_pool}")
+               APPEND PROPERTY COMPILE_DEFINITIONS R__DAOS_TEST_POOL="${daos_test_pool}")
 
   ROOT_ADD_GTEST(ntuple_storage_daos ntuple_storage_daos.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 endif()


### PR DESCRIPTION
When trying to build the tests using CMake 3.10, `R__DAOS_TEST_POOL` was not
getting defined correctly which caused build errors like:

```
expected ‘)’ before ‘R__DAOS_TEST_POOL’
    5 |    std::string daosUri("daos://" R__DAOS_TEST_POOL ":1/a947484e-e3bc-48cb-8f71-3292c19b59a4");
      |                       ~         ^~~~~~~~~~~~~~~~~~
      |                                 )
```

Moving from `COMPILE_OPTIONS` to `COMPILE_DEFINITIONS` seemed to fix it.