### PR TITLE
fix handling of case where idx is negative

### DIFF
--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -68,8 +68,8 @@ public:
 
   /// Return object at given index, or nullptr if index is out of range
   inline RooAbsArg* at(Int_t idx) const { 
-
-    if (idx >= static_cast<Int_t>(_list.size()))
+    if (idx < 0) idx = _list.size()+idx; // allows for python style list access from the back
+    if (idx < 0 || idx >= static_cast<Int_t>(_list.size()))
       return nullptr;
 
     return _list[idx];

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -68,7 +68,7 @@ public:
 
   /// Return object at given index, or nullptr if index is out of range
   inline RooAbsArg* at(Int_t idx) const { 
-    if (idx < 0) idx = _list.size()+idx; // allows for python style list access from the back
+    if (idx < 0) idx += _list.size(); // allows for python style list access from the back
     if (idx < 0 || idx >= static_cast<Int_t>(_list.size()))
       return nullptr;
 


### PR DESCRIPTION
I noticed that RooArgList doesn't handle the case where idx is negative. But also thought it would be nice to add support for use of negative numbers to access the list from the back, so it behaves like a python list in this respect

I noticed that there is nice operator[] behavior in 6.24 (uses at and throws exception) but this isn't in master???