### PR TITLE
make Release() no-op if parameter is not fixed

### DIFF
--- a/math/minuit2/src/MnUserParameterState.cxx
+++ b/math/minuit2/src/MnUserParameterState.cxx
@@ -312,8 +312,8 @@ void MnUserParameterState::Fix(unsigned int e)
 void MnUserParameterState::Release(unsigned int e)
 {
    // release parameter e (external index)
-   // no-op if parameter is const
-   if (Parameter(e).IsConst())
+   // no-op if parameter is const or if it is not fixed
+   if (Parameter(e).IsConst() || !Parameter(e).IsFixed())
       return;
    fParameters.Release(e);
    fCovarianceValid = false;


### PR DESCRIPTION
This fixes a bug when a parameter is "released" when it was not "fixed" before. Without the fix, the internal consistency of MnUserParameterState is destroyed when a user calls Release() on a parameter that is not fixed, since the call appends a wrong index to fIntParameters.

The issue was discovered by an iminuit user and I tracked down the source, see https://github.com/scikit-hep/iminuit/issues/648