### PR TITLE
Fix hesse call limit

### DIFF
--- a/math/minuit2/inc/Minuit2/FunctionMinimum.h
+++ b/math/minuit2/inc/Minuit2/FunctionMinimum.h
@@ -66,6 +66,7 @@ public:
       fPtr->fUserState = MnUserParameterState(State(), Up(), Seed().Trafo());
       fPtr->fAboveMaxEdm = status == MnAboveMaxEdm;
       fPtr->fReachedCallLimit = status == MnReachedCallLimit;
+      assert(fPtr->fUserState.IsValid() == IsValid());
    }
 
    const MinimumSeed &Seed() const { return fPtr->fSeed; }

--- a/math/minuit2/inc/Minuit2/FunctionMinimum.h
+++ b/math/minuit2/inc/Minuit2/FunctionMinimum.h
@@ -64,8 +64,8 @@ public:
       fPtr->fStates.push_back(state);
       // LM : update also the user state
       fPtr->fUserState = MnUserParameterState(State(), Up(), Seed().Trafo());
-      // reset maxedm flag. If new state has edm over max other method must be used
       fPtr->fAboveMaxEdm = status == MnAboveMaxEdm;
+      fPtr->fReachedCallLimit = status == MnReachedCallLimit;
    }
 
    const MinimumSeed &Seed() const { return fPtr->fSeed; }

--- a/math/minuit2/inc/Minuit2/FunctionMinimum.h
+++ b/math/minuit2/inc/Minuit2/FunctionMinimum.h
@@ -64,6 +64,7 @@ public:
       fPtr->fStates.push_back(state);
       // LM : update also the user state
       fPtr->fUserState = MnUserParameterState(State(), Up(), Seed().Trafo());
+      // reset maxedm flag. If new state has edm over max other method must be used
       fPtr->fAboveMaxEdm = status == MnAboveMaxEdm;
       fPtr->fReachedCallLimit = status == MnReachedCallLimit;
    }

--- a/math/minuit2/inc/Minuit2/FunctionMinimum.h
+++ b/math/minuit2/inc/Minuit2/FunctionMinimum.h
@@ -66,7 +66,6 @@ public:
       fPtr->fUserState = MnUserParameterState(State(), Up(), Seed().Trafo());
       fPtr->fAboveMaxEdm = status == MnAboveMaxEdm;
       fPtr->fReachedCallLimit = status == MnReachedCallLimit;
-      assert(fPtr->fUserState.IsValid() == IsValid());
    }
 
    const MinimumSeed &Seed() const { return fPtr->fSeed; }

--- a/math/minuit2/inc/Minuit2/MinimumError.h
+++ b/math/minuit2/inc/Minuit2/MinimumError.h
@@ -30,9 +30,9 @@ class MinimumError {
 public:
    enum Status {
       MnUnset,
-      MnGood,
-      MnNotPosDef,
+      MnPosDef,
       MnMadePosDef,
+      MnNotPosDef,
       MnHesseFailed,
       MnInvertFailed,
       MnReachedCallLimit,
@@ -41,7 +41,7 @@ public:
 public:
    MinimumError(unsigned int n) : fPtr{new Data{{n}, 1.0, MnUnset}} {}
 
-   MinimumError(const MnAlgebraicSymMatrix &mat, double dcov) : fPtr{new Data{mat, dcov, MnGood}} {}
+   MinimumError(const MnAlgebraicSymMatrix &mat, double dcov) : fPtr{new Data{mat, dcov, MnPosDef}} {}
 
    MinimumError(const MnAlgebraicSymMatrix &mat, Status status) : fPtr{new Data{mat, 1.0, status}} {}
 
@@ -66,10 +66,10 @@ public:
    double Dcovar() const { return fPtr->fDCovar; }
    Status GetStatus() const { return fPtr->fStatus; }
 
-   bool IsValid() const { return GetStatus() == MnGood || GetStatus() == MnMadePosDef; }
+   bool IsValid() const { return IsAvailable() && (IsPosDef() || IsMadePosDef()); }
    bool IsAccurate() const { return IsValid() && Dcovar() < 0.1; }
 
-   bool IsPosDef() const { return GetStatus() == MnGood; }
+   bool IsPosDef() const { return GetStatus() == MnPosDef; }
    bool IsMadePosDef() const { return GetStatus() == MnMadePosDef; }
    bool HesseFailed() const { return GetStatus() == MnHesseFailed; }
    bool InvertFailed() const { return GetStatus() == MnInvertFailed; }

--- a/math/minuit2/inc/Minuit2/MinimumError.h
+++ b/math/minuit2/inc/Minuit2/MinimumError.h
@@ -64,14 +64,17 @@ public:
    }
 
    double Dcovar() const { return fPtr->fDCovar; }
+   Status GetStatus() const { return fPtr->fStatus; }
+
+   bool IsValid() const { return GetStatus() == MnValid; }
    bool IsAccurate() const { return IsValid() && Dcovar() < 0.1; }
-   bool IsValid() const { return fPtr->fStatus == MnValid; }
-   bool IsPosDef() const { return fPtr->fStatus != MnNotPosDef; }
-   bool IsMadePosDef() const { return fPtr->fStatus == MnMadePosDef; }
-   bool HesseFailed() const { return fPtr->fStatus == MnHesseFailed; }
-   bool InvertFailed() const { return fPtr->fStatus == MnInvertFailed; }
-   bool HasReachedCallLimit() const { return fPtr->Status == MnReachedCallLimit; }
-   bool IsAvailable() const { return fPtr->fStatus != MnUnset; }
+
+   bool IsPosDef() const { return GetStatus() != MnNotPosDef; }
+   bool IsMadePosDef() const { return GetStatus() == MnMadePosDef; }
+   bool HesseFailed() const { return GetStatus() == MnHesseFailed; }
+   bool InvertFailed() const { return GetStatus() == MnInvertFailed; }
+   bool HasReachedCallLimit() const { return GetStatus() == MnReachedCallLimit; }
+   bool IsAvailable() const { return GetStatus() != MnUnset; }
 
 private:
    struct Data {

--- a/math/minuit2/inc/Minuit2/MinimumError.h
+++ b/math/minuit2/inc/Minuit2/MinimumError.h
@@ -30,7 +30,7 @@ class MinimumError {
 public:
    enum Status {
       MnUnset,
-      MnValid,
+      MnGood,
       MnNotPosDef,
       MnMadePosDef,
       MnHesseFailed,
@@ -41,7 +41,7 @@ public:
 public:
    MinimumError(unsigned int n) : fPtr{new Data{{n}, 1.0, MnUnset}} {}
 
-   MinimumError(const MnAlgebraicSymMatrix &mat, double dcov) : fPtr{new Data{mat, dcov, MnValid}} {}
+   MinimumError(const MnAlgebraicSymMatrix &mat, double dcov) : fPtr{new Data{mat, dcov, MnGood}} {}
 
    MinimumError(const MnAlgebraicSymMatrix &mat, Status status) : fPtr{new Data{mat, 1.0, status}} {}
 
@@ -66,10 +66,10 @@ public:
    double Dcovar() const { return fPtr->fDCovar; }
    Status GetStatus() const { return fPtr->fStatus; }
 
-   bool IsValid() const { return GetStatus() == MnValid; }
+   bool IsValid() const { return GetStatus() == MnGood || GetStatus() == MnMadePosDef; }
    bool IsAccurate() const { return IsValid() && Dcovar() < 0.1; }
 
-   bool IsPosDef() const { return GetStatus() != MnNotPosDef; }
+   bool IsPosDef() const { return GetStatus() == MnGood; }
    bool IsMadePosDef() const { return GetStatus() == MnMadePosDef; }
    bool HesseFailed() const { return GetStatus() == MnHesseFailed; }
    bool InvertFailed() const { return GetStatus() == MnInvertFailed; }

--- a/math/minuit2/inc/Minuit2/MinimumError.h
+++ b/math/minuit2/inc/Minuit2/MinimumError.h
@@ -67,7 +67,7 @@ public:
    Status GetStatus() const { return fPtr->fStatus; }
 
    bool IsValid() const { return IsAvailable() && (IsPosDef() || IsMadePosDef()); }
-   bool IsAccurate() const { return IsValid() && Dcovar() < 0.1; }
+   bool IsAccurate() const { return IsPosDef() && Dcovar() < 0.1; }
 
    bool IsPosDef() const { return GetStatus() == MnPosDef; }
    bool IsMadePosDef() const { return GetStatus() == MnMadePosDef; }

--- a/math/minuit2/inc/Minuit2/MnUserParameterState.h
+++ b/math/minuit2/inc/Minuit2/MnUserParameterState.h
@@ -56,35 +56,6 @@ public:
    /// construct from internal parameters (after minimization)
    MnUserParameterState(const MinimumState &, double, const MnUserTransformation &);
 
-   ~MnUserParameterState() {}
-
-   MnUserParameterState(const MnUserParameterState &state)
-      : fValid(state.fValid), fCovarianceValid(state.fCovarianceValid), fGCCValid(state.fGCCValid),
-        fCovStatus(state.fCovStatus), fFVal(state.fFVal), fEDM(state.fEDM), fNFcn(state.fNFcn),
-        fParameters(state.fParameters), fCovariance(state.fCovariance), fGlobalCC(state.fGlobalCC),
-        fIntParameters(state.fIntParameters), fIntCovariance(state.fIntCovariance)
-   {
-   }
-
-   MnUserParameterState &operator=(const MnUserParameterState &state)
-   {
-      if (this != &state) {
-         fValid = state.fValid;
-         fCovarianceValid = state.fCovarianceValid;
-         fGCCValid = state.fGCCValid;
-         fCovStatus = state.fCovStatus;
-         fFVal = state.fFVal;
-         fEDM = state.fEDM;
-         fNFcn = state.fNFcn;
-         fParameters = state.fParameters;
-         fCovariance = state.fCovariance;
-         fGlobalCC = state.fGlobalCC;
-         fIntParameters = state.fIntParameters;
-         fIntCovariance = state.fIntCovariance;
-      }
-      return *this;
-   }
-
    // user external representation
    const MnUserParameters &Parameters() const { return fParameters; }
    const MnUserCovariance &Covariance() const { return fCovariance; }

--- a/math/minuit2/src/MnHesse.cxx
+++ b/math/minuit2/src/MnHesse.cxx
@@ -218,8 +218,8 @@ MinimumState MnHesse::operator()(const MnFcn &mfcn, const MinimumState &st, cons
             vhmat(j, j) = tmp < prec.Eps2() ? 1. : tmp;
          }
 
-         return MinimumState(st.Parameters(), MinimumError(vhmat, MinimumError::MnHesseFailed), st.Gradient(), st.Edm(),
-                             mfcn.NumOfCalls());
+         return MinimumState(st.Parameters(), MinimumError(vhmat, MinimumError::MnReachedCallLimit), st.Gradient(),
+                             st.Edm(), mfcn.NumOfCalls());
       }
    }
 

--- a/math/minuit2/src/MnUserParameterState.cxx
+++ b/math/minuit2/src/MnUserParameterState.cxx
@@ -112,7 +112,7 @@ MnUserParameterState::MnUserParameterState(const MnUserParameters &par, const Mn
 //
 //
 MnUserParameterState::MnUserParameterState(const MinimumState &st, double up, const MnUserTransformation &trafo)
-   : fValid(false), fCovarianceValid(false), fGCCValid(false), fCovStatus(-1), fFVal(st.Fval()), fEDM(st.Edm()),
+   : fValid(st.IsValid()), fCovarianceValid(false), fGCCValid(false), fCovStatus(-1), fFVal(st.Fval()), fEDM(st.Edm()),
      fNFcn(st.NFcn()), fParameters(MnUserParameters()), fCovariance(MnUserCovariance()),
      fGlobalCC(MnGlobalCorrelationCoeff()), fIntParameters(std::vector<double>()), fIntCovariance(MnUserCovariance())
 {

--- a/math/minuit2/src/MnUserParameterState.cxx
+++ b/math/minuit2/src/MnUserParameterState.cxx
@@ -155,6 +155,9 @@ MnUserParameterState::MnUserParameterState(const MinimumState &st, double up, co
       }
    }
 
+   // Add(...) sets fValid to true even if it was false, need to restore its state
+   fValid = st.IsValid();
+
    // need to be set afterwards because becore the ::Add method set fCovarianceValid to false
    fCovarianceValid = st.Error().IsValid();
 

--- a/math/minuit2/src/MnUserParameterState.cxx
+++ b/math/minuit2/src/MnUserParameterState.cxx
@@ -112,7 +112,7 @@ MnUserParameterState::MnUserParameterState(const MnUserParameters &par, const Mn
 //
 //
 MnUserParameterState::MnUserParameterState(const MinimumState &st, double up, const MnUserTransformation &trafo)
-   : fValid(st.IsValid()), fCovarianceValid(false), fGCCValid(false), fCovStatus(-1), fFVal(st.Fval()), fEDM(st.Edm()),
+   : fValid(false), fCovarianceValid(false), fGCCValid(false), fCovStatus(-1), fFVal(st.Fval()), fEDM(st.Edm()),
      fNFcn(st.NFcn()), fParameters(MnUserParameters()), fCovariance(MnUserCovariance()),
      fGlobalCC(MnGlobalCorrelationCoeff()), fIntParameters(std::vector<double>()), fIntCovariance(MnUserCovariance())
 {
@@ -154,9 +154,6 @@ MnUserParameterState::MnUserParameterState(const MinimumState &st, double up, co
          Add((*ipar).GetName(), st.Vec()(i), err);
       }
    }
-
-   // Add(...) sets fValid to true even if it was false, need to restore its state
-   fValid = st.IsValid();
 
    // need to be set afterwards because becore the ::Add method set fCovarianceValid to false
    fCovarianceValid = st.Error().IsValid();

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -182,22 +182,19 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
 
    // Add latest state (Hessian calculation)
    const MinimumState &latest = result.back();
-   if (latest.Error().IsAvailable()) {
-      if (latest.Error().HasReachedCallLimit()) {
-         // communicate to user that call limit was reached in MnHesse
-         min.Add(latest, FunctionMinimum::MnReachedCallLimit);
-      } else {
-         // check edm (add a factor of 10 in tolerance )
-         if (edm > 10 * edmval) {
-            min.Add(latest, FunctionMinimum::MnAboveMaxEdm);
-            print.Warn("No convergence; Edm", edm, "is above tolerance", 10 * edmval);
-         } else {
-            // check if minimum had edm above max before
-            if (min.IsAboveMaxEdm())
-               print.Info("Edm has been re-computed after Hesse; Edm", edm, "is now within tolerance");
-            min.Add(latest);
-         }
-      }
+
+   // check edm (add a factor of 10 in tolerance )
+   if (edm > 10 * edmval) {
+      min.Add(latest, FunctionMinimum::MnAboveMaxEdm);
+      print.Warn("No convergence; Edm", edm, "is above tolerance", 10 * edmval);
+   } else if (latest.Error().HasReachedCallLimit()) {
+      // communicate to user that call limit was reached in MnHesse
+      min.Add(latest, FunctionMinimum::MnReachedCallLimit);
+   } else if (latest.Error().IsAvailable()) {
+      // check if minimum had edm above max before
+      if (min.IsAboveMaxEdm())
+         print.Info("Edm has been re-computed after Hesse; Edm", edm, "is now within tolerance");
+      min.Add(latest);
    }
 
    print.Debug("Minimum found", min);

--- a/math/minuit2/src/VariableMetricBuilder.cxx
+++ b/math/minuit2/src/VariableMetricBuilder.cxx
@@ -106,12 +106,10 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
    int maxfcn_eff = maxfcn;
    int ipass = 0;
    bool iterate = false;
-   bool hessianComputed = false;
 
    do {
 
       iterate = false;
-      hessianComputed = false;
 
       print.Debug(ipass > 0 ? "Continue" : "Start", "iterating...");
 
@@ -140,8 +138,6 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
          print.Debug("MnMigrad will verify convergence and Error matrix; dcov =", min.Error().Dcovar());
 
          MinimumState st = MnHesse(strategy)(fcn, min.State(), min.Seed().Trafo(), maxfcn);
-
-         hessianComputed = true;
 
          print.Info("After Hessian");
 
@@ -185,17 +181,23 @@ FunctionMinimum VariableMetricBuilder::Minimum(const MnFcn &fcn, const GradientC
    } while (iterate);
 
    // Add latest state (Hessian calculation)
-   // and check edm (add a factor of 10 in tolerance )
-   if (edm > 10 * edmval) {
-      min.Add(result.back(), FunctionMinimum::MnAboveMaxEdm);
-      print.Warn("No convergence; Edm", edm, "is above tolerance", 10 * edmval);
-   } else {
-      // check if minimum has edm above max before
-      if (min.IsAboveMaxEdm()) {
-         print.Info("Edm has been re-computed after Hesse; Edm", edm, "is now within tolerance");
+   const MinimumState &latest = result.back();
+   if (latest.Error().IsAvailable()) {
+      if (latest.Error().HasReachedCallLimit()) {
+         // communicate to user that call limit was reached in MnHesse
+         min.Add(latest, FunctionMinimum::MnReachedCallLimit);
+      } else {
+         // check edm (add a factor of 10 in tolerance )
+         if (edm > 10 * edmval) {
+            min.Add(latest, FunctionMinimum::MnAboveMaxEdm);
+            print.Warn("No convergence; Edm", edm, "is above tolerance", 10 * edmval);
+         } else {
+            // check if minimum had edm above max before
+            if (min.IsAboveMaxEdm())
+               print.Info("Edm has been re-computed after Hesse; Edm", edm, "is now within tolerance");
+            min.Add(latest);
+         }
       }
-      if (hessianComputed)
-         min.Add(result.back());
    }
 
    print.Debug("Minimum found", min);


### PR DESCRIPTION
This finally fixes https://github.com/scikit-hep/iminuit/issues/637

The following changes are implemented:

1) Store information that MnHesse reached call limit in MinimumError
- Add new states MnUnset, MnPosDef, and MnReachedCallLimit to MinimumError::Status
- Switch MinimumError status storage from bools to enum, since there is actually only one unique state at a time and toggling the bools correctly is error-prone; it also simplifies the implementation

2) Propagate information from MinimumError to FunctionMinimum via Add

I slightly simplified the implementation of VariableMetricBuilder, the variable `hessianComputed` was not needed, the information whether Hesse was run can be obtained from the MinimumState object.

Other changes (which could be broken into a separate PR):
- Removed trivial implementations of copy ctor and copy assignment in MnUserParameterState, the defaults should be used instead (rule of 0)

