### PR TITLE
Support secondary X/Y axes for RFrame

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -138,8 +138,9 @@ public:
          UpdateDim(0, src);
          UpdateDim(1, src);
          UpdateDim(2, src);
+         UpdateDim(3, src);
+         UpdateDim(4, src);
       }
-
    };
 
 private:

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -149,6 +149,8 @@ private:
    RAttrAxis fAttrX{this, "x"};                   ///<! drawing attributes for X axis
    RAttrAxis fAttrY{this, "y"};                   ///<! drawing attributes for Y axis
    RAttrAxis fAttrZ{this, "z"};                   ///<! drawing attributes for Z axis
+   RAttrAxis fAttrX2{this, "x2"};                 ///<! drawing attributes for X2 axis
+   RAttrAxis fAttrY2{this, "y2"};                 ///<! drawing attributes for Y2 axis
    RAttrValue<bool> fDrawAxes{this, "drawaxes", false}; ///<! draw axes by frame
    RAttrValue<bool> fGridX{this, "gridx", false}; ///<! show grid for X axis
    RAttrValue<bool> fGridY{this, "gridy", false}; ///<! show grid for Y axis
@@ -217,6 +219,14 @@ public:
    const RAttrAxis &GetAttrZ() const { return fAttrZ; }
    RFrame &SetAttrZ(const RAttrAxis &axis) { fAttrZ = axis; return *this; }
    RAttrAxis &AttrZ() { return fAttrZ; }
+
+   const RAttrAxis &GetAttrX2() const { return fAttrX2; }
+   RFrame &SetAttrX2(const RAttrAxis &axis) { fAttrX2 = axis; return *this; }
+   RAttrAxis &AttrX2() { return fAttrX2; }
+
+   const RAttrAxis &GetAttrY2() const { return fAttrY2; }
+   RFrame &SetAttrY2(const RAttrAxis &axis) { fAttrY2 = axis; return *this; }
+   RAttrAxis &AttrY2() { return fAttrY2; }
 
    RFrame &SetGridX(bool on = true) { fGridX = on; return *this; }
    bool GetGridX() const { return fGridX; }

--- a/graf2d/gpadv7/src/RFrame.cxx
+++ b/graf2d/gpadv7/src/RFrame.cxx
@@ -74,6 +74,8 @@ void RFrame::SetClientRanges(unsigned connid, const RUserRanges &ranges, bool is
       AssignZoomRange(0, AttrX(), ranges);
       AssignZoomRange(1, AttrY(), ranges);
       AssignZoomRange(2, AttrZ(), ranges);
+      AssignZoomRange(3, AttrX2(), ranges);
+      AssignZoomRange(4, AttrY2(), ranges);
    }
 
    if (fClientRanges.find(connid) == fClientRanges.end()) {

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -144,6 +144,8 @@ class RHist1Drawable final : public RHistDrawable<1> {
    RAttrValue<double> fBarOffset{this, "bar_offset", 0.}; ///<!  bar offset
    RAttrValue<double> fBarWidth{this, "bar_width", 1.};   ///<!  bar width
    RAttrValue<bool> fText{this, "text", false};           ///<! draw text
+   RAttrValue<bool> fSecondX{this, "secondx", false};     ///<! is draw second x axis for histogram
+   RAttrValue<bool> fSecondY{this, "secondy", false};     ///<! is draw second y axis for histogram
 
 protected:
    std::unique_ptr<RDisplayItem> CreateHistDisplay(const RDisplayContext &) override;
@@ -165,6 +167,18 @@ public:
    RHist1Drawable &Line() { SetDrawKind("l"); return *this; }
    RHist1Drawable &Lego(int kind = 0) { SetDrawKind("lego", kind); return *this; }
    RHist1Drawable &Text(bool on = true) { fText = on; return *this; }
+   RHist1Drawable &SecondX(bool on = true) { fSecondX = on; return *this; }
+   RHist1Drawable &SecondY(bool on = true) { fSecondY = on; return *this; }
+
+   bool IsBar() const { return GetDrawKind() == "bar"; }
+   bool IsError() const { return GetDrawKind() == "err"; }
+   bool IsMarker() const { return GetDrawKind() == "p"; }
+   bool IsHist() const { return GetDrawKind() == "hist"; }
+   bool IsLine() const { return GetDrawKind() == "l"; }
+   bool IsLego() const { return GetDrawKind() == "lego"; }
+   bool IsText() const { return fText; }
+   bool IsSecondX() const { return fSecondX; }
+   bool IsSecondY() const { return fSecondY; }
 
    double GetBarOffset() const { return fBarOffset; }
    double GetBarWidth() const { return fBarWidth; }

--- a/js/changes.md
+++ b/js/changes.md
@@ -1,9 +1,11 @@
 # JSROOT changelog
 
 ## Changes in dev
-1. Fully deprecate old JSRootCore.js script, one have to use  JSRoot.core.js
-2. Upgrade three.js to r127
-3. Upgrade d3.js to 6.7.0
+1. Support fully interactive second X/Y axis for histograms, graphs, functions and spline
+2. Support X+, Y+, RX, RY draw options for TF1
+3. Remove deprecated JSRootCore.js script, one have to use JSRoot.core.js
+4. Upgrade three.js to r127
+5. Upgrade d3.js to 6.7.0
 
 
 ## Changes in 6.1.0

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "10/05/2021";
+   JSROOT.version_date = "14/05/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}
@@ -1446,8 +1446,8 @@
             break;
          case 'TAttAxis':
             extend(obj, { fNdivisions: 510, fAxisColor: 1,
-                                 fLabelColor: 1, fLabelFont: 42, fLabelOffset: 0.005, fLabelSize: 0.035, fTickLength: 0.03,
-                                 fTitleOffset: 1, fTitleSize: 0.035, fTitleColor: 1, fTitleFont : 42 });
+                          fLabelColor: 1, fLabelFont: 42, fLabelOffset: 0.005, fLabelSize: 0.035, fTickLength: 0.03,
+                          fTitleOffset: 1, fTitleSize: 0.035, fTitleColor: 1, fTitleFont : 42 });
             break;
          case 'TAxis':
             create("TNamed", obj);

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "14/05/2021";
+   JSROOT.version_date = "17/05/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -1920,7 +1920,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          menu.add("Unzoom Y", () => this.unzoom("y"));
       if (this.zoom_zmin !== this.zoom_zmax)
          menu.add("Unzoom Z", () => this.unzoom("z"));
-      menu.add("Unzoom all", () => this.unzoom("xyz"));
+      if (this.zoom_x2min !== this.zoom_x2max)
+         menu.add("Unzoom X2", () => this.unzoom("x2"));
+      if (this.zoom_y2min !== this.zoom_y2max)
+         menu.add("Unzoom Y2", () => this.unzoom("y2"));
+      menu.add("Unzoom all", () => this.unzoom("all"));
 
       if (pad) {
          menu.addchk(pad.fLogx, "SetLogx", () => this.toggleAxisLog("x"));
@@ -2143,27 +2147,14 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    /** @summary Unzoom speicified axes
      * @returns {Promise} with boolean flag if zooming changed */
    TFramePainter.prototype.unzoom = function(dox, doy, doz) {
-      if (dox == "x2") {
-         if (!this.x2_handle || (this.zoom_x2min === this.zoom_x2max))
-            return Promise.resolve(false);
+      if (dox == "all")
+         return this.unzoom("x2").then(() => this.unzoom("y2")).then(() => this.unzoom("xyz"));
 
-         this.zoom_x2min = this.zoom_x2max = 0;
-         return this.interactiveRedraw("pad", "zoom").then(() => {
-            this.zoomChangedInteractive("x2", "unzoom");
-            return true;
+      if ((dox == "x2") || (dox == "y2"))
+         return this.zoomSingle(dox, 0, 0).then(changed => {
+            if (changed) this.zoomChangedInteractive(dox, "unzoom");
+            return changed;
          });
-      }
-
-      if (dox == "y2") {
-         if (!this.y2_handle || (this.zoom_y2min === this.zoom_y2max))
-            return Promise.resolve(false);
-
-         this.zoom_y2min = this.zoom_y2max = 0;
-         return this.interactiveRedraw("pad", "zoom").then(() => {
-            this.zoomChangedInteractive("y2", "unzoom");
-            return true;
-         });
-      }
 
       if (typeof dox === 'undefined') { dox = doy = doz = true; } else
       if (typeof dox === 'string') { doz = dox.indexOf("z") >= 0; doy = dox.indexOf("y") >= 0; dox = dox.indexOf("x") >= 0; }

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -1048,7 +1048,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       this.zmax = zmax;
    }
 
-   /** @summary Configure frame axes ranges */
+   /** @summary Configure secondary frame axes ranges */
    TFramePainter.prototype.setAxes2Ranges = function(second_x, xaxis, xmin, xmax, second_y, yaxis, ymin, ymax) {
       if (second_x) {
          this.x2axis = xaxis;
@@ -1532,7 +1532,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    }
 
    /** @summary draw second axes (if any)  */
-   TFramePainter.prototype.drawAxes2 = function() {
+   TFramePainter.prototype.drawAxes2 = function(second_x, second_y) {
 
       let layer = this.getFrameSvg().select(".axis_layer"),
           w = this.getFrameWidth(),
@@ -1540,13 +1540,13 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
           pp = this.getPadPainter(),
           pad = pp.getRootPad(true);
 
-      if (this.x2_handle) {
+      if (second_x) {
          this.x2_handle.invert_side = true;
          this.x2_handle.lbls_both_sides = false;
          this.x2_handle.has_obstacle = false;
       }
 
-      if (this.y2_handle) {
+      if (second_y) {
          this.y2_handle.invert_side = true;
          this.y2_handle.lbls_both_sides = false;
       }
@@ -1559,7 +1559,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          if (pp && pp._fast_drawing) draw_horiz = draw_vertical = null;
       }
 
-      let promise1 = Promise.resolve(true), promise2 = Promise.resolve(true);
+      let promise1 = true, promise2 = true;
 
       if (draw_horiz)
          promise1 = draw_horiz.drawAxis(layer, w, h,

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -2331,7 +2331,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
          fp.createXY2(opts);
 
-         return fp.drawAxes2();
+         return fp.drawAxes2(opts.second_x, opts.second_y);
       } else {
          fp.setAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, 0, 0);
 
@@ -2723,8 +2723,9 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
      * @returns {Promise} for ready
      * @private */
    THistPainter.prototype.addInteractivity = function() {
-      let ismain = this.isMainPainter(), second_axis = (this.options.AxisPos > 0);
-      let fp = ismain || second_axis ? this.getFramePainter() : null;
+      let ismain = this.isMainPainter(),
+          second_axis = (this.options.AxisPos > 0),
+          fp = ismain || second_axis ? this.getFramePainter() : null;
       return fp ? fp.addInteractivity(!ismain && second_axis) : Promise.resolve(false);
    }
 

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -1438,8 +1438,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
       let d = new JSROOT.DrawOptions(opt), check3dbox = "";
 
-      if ((hdim===1) && (histo.fSumw2.length > 0))
-         for (let n=0;n<histo.fSumw2.length;++n)
+      if ((hdim === 1) && (histo.fSumw2.length > 0))
+         for (let n = 0; n < histo.fSumw2.length; ++n)
             if (histo.fSumw2[n] > 0) { this.Error = true; this.Hist = false; this.Zero = false; break; }
 
       this.ndim = hdim || 1; // keep dimensions, used for now in GED
@@ -1455,7 +1455,6 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       // this is actual range of data - used by graph drawing
       if (d.check('YMIN:', true)) this.ymin = parseFloat(d.part);
       if (d.check('YMAX:', true)) this.ymax = parseFloat(d.part);
-
 
       if (d.check('NOOPTIMIZE')) this.Optimize = 0;
       if (d.check('OPTIMIZE')) this.Optimize = 2;
@@ -1486,27 +1485,39 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       if (d.check('TICKX') && pad) pad.fTickx = 1;
       if (d.check('TICKY') && pad) pad.fTicky = 1;
 
-      if (d.check('FILL_', true)) {
-         if (d.partAsInt(1) > 0) {
-            this.histoFillColor = d.partAsInt();
-         } else {
-            for (let col=0;col<8;++col)
-               if (jsrp.getColor(col).toUpperCase() === d.part)
-                  this.histoFillColor = col;
-         }
-      }
-      if (d.check('LINE_', true)) {
-         if (d.partAsInt(1) > 0) {
-            this.histoLineColor = jsrp.root_colors[d.partAsInt()];
-         } else {
-            for (let col=0;col<8;++col)
-               if (jsrp.getColor(col).toUpperCase() === d.part)
-                  this.histoLineColor = d.part;
-         }
+      let getColor = () => {
+         if (d.partAsInt(1) > 0)
+            return d.partAsInt();
+         for (let col = 0; col < 8; ++col)
+            if (jsrp.getColor(col).toUpperCase() === d.part)
+               return col;
+         return -1;
       }
 
-      if (d.check('X+')) this.AxisPos = 10;
-      if (d.check('Y+')) this.AxisPos += 1;
+      if (d.check('FILL_', true)) {
+         let col = getColor();
+         if (col >= 0) this.histoFillColor = col;
+      }
+
+      if (d.check('LINE_', true)) {
+         let col = getColor();
+         if (col >= 0) this.histoLineColor = jsrp.root_colors[col];
+      }
+
+      if (d.check('XAXIS_', true)) {
+         let col = getColor();
+         if (col >= 0) histo.fXaxis.fAxisColor = histo.fXaxis.fLabelColor = histo.fXaxis.fTitleColor = col;
+      }
+
+      if (d.check('YAXIS_', true)) {
+         let col = getColor();
+         if (col >= 0) histo.fYaxis.fAxisColor = histo.fYaxis.fLabelColor = histo.fYaxis.fTitleColor = col;
+      }
+
+      let has_main = painter ? !!painter.getMainPainter() : false;
+
+      if (d.check('X+')) { this.AxisPos = 10; this.second_x = has_main; }
+      if (d.check('Y+')) { this.AxisPos += 1; this.second_y = has_main; }
 
       if (d.check('SAMES')) { this.Same = true; this.ForceStat = true; }
       if (d.check('SAME')) { this.Same = true; this.Func = true; }
@@ -2299,34 +2310,48 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
     /** @summary Draw axes for histogram
       * @desc axes can be drawn only for main histogram */
    THistPainter.prototype.drawAxes = function() {
-      if (!this.isMainPainter())
-         return Promise.resolve(false);
-
       let fp = this.getFramePainter();
       if (!fp) return Promise.resolve(false);
 
       let histo = this.getHisto();
 
-      // artifically add y range to display axes
+      // artificially add y range to display axes
       if (this.ymin === this.ymax) this.ymax += 1;
 
-      fp.setAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, 0, 0);
-      fp.createXY({ ndim: this.getDimension(),
-                    check_pad_range: this.check_pad_range,
-                    zoom_ymin: this.zoom_ymin,
-                    zoom_ymax: this.zoom_ymax,
-                    ymin_nz: this.ymin_nz,
-                    swap_xy: (this.options.BarStyle >= 20),
-                    reverse_x: this.options.RevX,
-                    reverse_y: this.options.RevY,
-                    Proj: this.options.Proj,
-                    extra_y_space: this.options.Text && (this.options.BarStyle > 0) });
-      delete this.check_pad_range;
+      if (!this.isMainPainter()) {
+         let opts = {
+            second_x: (this.options.AxisPos >= 10),
+            second_y: (this.options.AxisPos % 10) == 1
+         };
 
-      if (this.options.Same) return Promise.resolve(false);
+         if ((!opts.second_x && !opts.second_y) || fp.hasDrawnAxes(opts.second_x, opts.second_y))
+            return Promise.resolve(false);
 
-      return fp.drawAxes(false, this.options.Axis < 0, (this.options.Axis < 0),
-                         this.options.AxisPos, this.options.Zscale);
+         fp.setAxes2Ranges(opts.second_x, histo.fXaxis, this.xmin, this.xmax, opts.second_y, histo.fYaxis, this.ymin, this.ymax);
+
+         fp.createXY2(opts);
+
+         return fp.drawAxes2();
+      } else {
+         fp.setAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, 0, 0);
+
+         fp.createXY({ ndim: this.getDimension(),
+                       check_pad_range: this.check_pad_range,
+                       zoom_ymin: this.zoom_ymin,
+                       zoom_ymax: this.zoom_ymax,
+                       ymin_nz: this.ymin_nz,
+                       swap_xy: (this.options.BarStyle >= 20),
+                       reverse_x: this.options.RevX,
+                       reverse_y: this.options.RevY,
+                       Proj: this.options.Proj,
+                       extra_y_space: this.options.Text && (this.options.BarStyle > 0) });
+         delete this.check_pad_range;
+
+         if (this.options.Same) return Promise.resolve(false);
+
+         return fp.drawAxes(false, this.options.Axis < 0, (this.options.Axis < 0),
+                            this.options.AxisPos, this.options.Zscale);
+      }
    }
 
    /** @summary Toggle histogram title drawing
@@ -2624,9 +2649,12 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
      * @private */
    THistPainter.prototype.getSelectIndex = function(axis, side, add) {
       let indx = 0,
-          main = this.getFramePainter(),
           nbin = this['nbins'+axis] || 0,
-          taxis = this.getAxis(axis),
+          taxis = this.getAxis(axis);
+
+      if (this.options.second_x && axis == "x") axis = "x2";
+      if (this.options.second_y && axis == "y") axis = "y2";
+      let main = this.getFramePainter(),
           min = main ? main['zoom_' + axis + 'min'] : 0,
           max = main ? main['zoom_' + axis + 'max'] : 0;
 
@@ -2695,8 +2723,9 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
      * @returns {Promise} for ready
      * @private */
    THistPainter.prototype.addInteractivity = function() {
-      let fp = this.isMainPainter() ? this.getFramePainter() : null;
-      return fp ? fp.addInteractivity() : Promise.resolve(false);
+      let ismain = this.isMainPainter(), second_axis = (this.options.AxisPos > 0);
+      let fp = ismain || second_axis ? this.getFramePainter() : null;
+      return fp ? fp.addInteractivity(!ismain && second_axis) : Promise.resolve(false);
    }
 
    /** @summary Invoke dialog to enter and modify user range
@@ -3228,12 +3257,14 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          return res;
       }
 
+      let funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y);
+
        // calculate graphical coordinates in advance
       for (i = res.i1; i <= res.i2; ++i) {
          x = xaxis.GetBinCoord(i + args.middle);
-         if (pmain.logx && (x <= 0)) { res.i1 = i+1; continue; }
+         if (funcs.logx && (x <= 0)) { res.i1 = i+1; continue; }
          if (res.origx) res.origx[i] = x;
-         res.grx[i] = pmain.grx(x);
+         res.grx[i] = funcs.grx(x);
          if (args.rounding) res.grx[i] = Math.round(res.grx[i]);
 
          if (args.use3d) {
@@ -3243,14 +3274,14 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       }
 
       if (hdim===1) {
-         res.gry[0] = pmain.gry(0);
-         res.gry[1] = pmain.gry(1);
+         res.gry[0] = funcs.gry(0);
+         res.gry[1] = funcs.gry(1);
       } else
       for (j = res.j1; j <= res.j2; ++j) {
          y = yaxis.GetBinCoord(j + args.middle);
-         if (pmain.logy && (y <= 0)) { res.j1 = j+1; continue; }
+         if (funcs.logy && (y <= 0)) { res.j1 = j+1; continue; }
          if (res.origy) res.origy[j] = y;
-         res.gry[j] = pmain.gry(y);
+         res.gry[j] = funcs.gry(y);
          if (args.rounding) res.gry[j] = Math.round(res.gry[j]);
 
          if (args.use3d) {
@@ -3295,18 +3326,19 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
      * @protected */
    THistPainter.prototype.getAxisBinTip = function(name, axis, bin) {
       let pmain = this.getFramePainter(),
-          handle = pmain[name+"_handle"],
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
+          handle = funcs[name+"_handle"],
           x1 = axis.GetBinLowEdge(bin+1);
 
       if (handle.kind === 'labels')
-         return pmain.axisAsText(name, x1);
+         return funcs.axisAsText(name, x1);
 
       let x2 = axis.GetBinLowEdge(bin+2);
 
       if (handle.kind === 'time')
-         return pmain.axisAsText(name, (x1+x2)/2);
+         return funcs.axisAsText(name, (x1+x2)/2);
 
-      return "[" + pmain.axisAsText(name, x1) + ", " + pmain.axisAsText(name, x2) + ")";
+      return "[" + funcs.axisAsText(name, x1) + ", " + funcs.axisAsText(name, x2) + ")";
    }
 
    // ========================================================================
@@ -3596,13 +3628,12 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
    /** @summary Draw histogram as bars
      * @private */
-   TH1Painter.prototype.drawBars = function(height) {
+   TH1Painter.prototype.drawBars = function(height, pmain, funcs) {
 
       this.createG(true);
 
       let left = this.getSelectIndex("x", "left", -1),
           right = this.getSelectIndex("x", "right", 1),
-          pmain = this.getFramePainter(),
           histo = this.getHisto(), xaxis = histo.fXaxis,
           show_text = this.options.Text, text_col, text_angle, text_size,
           i, x1, x2, grx1, grx2, y, gry1, gry2, w,
@@ -3612,8 +3643,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       if (side>4) side = 4;
       gry2 = pmain.swap_xy ? 0 : height;
       if (Number.isFinite(this.options.BaseLine))
-         if (this.options.BaseLine >= pmain.scale_ymin)
-            gry2 = Math.round(pmain.gry(this.options.BaseLine));
+         if (this.options.BaseLine >= funcs.scale_ymin)
+            gry2 = Math.round(funcs.gry(this.options.BaseLine));
 
       if (show_text) {
          text_col = this.getColor(histo.fMarkerColor);
@@ -3632,12 +3663,12 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
          if (pmain.logx && (x2 <= 0)) continue;
 
-         grx1 = Math.round(pmain.grx(x1));
-         grx2 = Math.round(pmain.grx(x2));
+         grx1 = Math.round(funcs.grx(x1));
+         grx2 = Math.round(funcs.grx(x2));
 
          y = histo.getBinContent(i+1);
-         if (pmain.logy && (y < pmain.scale_ymin)) continue;
-         gry1 = Math.round(pmain.gry(y));
+         if (funcs.logy && (y < funcs.scale_ymin)) continue;
+         gry1 = Math.round(funcs.gry(y));
 
          w = grx2 - grx1;
          grx1 += Math.round(histo.fBarOffset/1000*w);
@@ -3695,27 +3726,26 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
    /** @summary Draw histogram as filled errors
      * @private */
-   TH1Painter.prototype.drawFilledErrors = function() {
+   TH1Painter.prototype.drawFilledErrors = function(funcs) {
       this.createG(true);
 
       let left = this.getSelectIndex("x", "left", -1),
           right = this.getSelectIndex("x", "right", 1),
-          pmain = this.getFramePainter(),
           histo = this.getHisto(), xaxis = histo.fXaxis,
           i, x, grx, y, yerr, gry1, gry2,
           bins1 = [], bins2 = [];
 
       for (i = left; i < right; ++i) {
          x = xaxis.GetBinCoord(i+0.5);
-         if (pmain.logx && (x <= 0)) continue;
-         grx = Math.round(pmain.grx(x));
+         if (funcs.logx && (x <= 0)) continue;
+         grx = Math.round(funcs.grx(x));
 
          y = histo.getBinContent(i+1);
          yerr = histo.getBinError(i+1);
-         if (pmain.logy && (y-yerr < pmain.scale_ymin)) continue;
+         if (funcs.logy && (y-yerr < funcs.scale_ymin)) continue;
 
-         gry1 = Math.round(pmain.gry(y + yerr));
-         gry2 = Math.round(pmain.gry(y - yerr));
+         gry1 = Math.round(funcs.gry(y + yerr));
+         gry2 = Math.round(funcs.gry(y - yerr));
 
          bins1.push({ grx:grx, gry: gry1 });
          bins2.unshift({ grx:grx, gry: gry2 });
@@ -3738,16 +3768,17 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       this.createHistDrawAttributes();
 
       let pmain = this.getFramePainter(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           width = pmain.getFrameWidth(), height = pmain.getFrameHeight();
 
       if (!this.draw_content || (width <= 0) || (height <= 0))
           return this.removeG();
 
       if (this.options.Bar)
-         return this.drawBars(height);
+         return this.drawBars(height, pmain, funcs);
 
       if ((this.options.ErrorKind === 3) || (this.options.ErrorKind === 4))
-         return this.drawFilledErrors();
+         return this.drawFilledErrors(pmain, funcs);
 
       let left = this.getSelectIndex("x", "left", -1),
           right = this.getSelectIndex("x", "right", 2),
@@ -3841,15 +3872,15 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       let extract_bin = bin => {
          bincont = histo.getBinContent(bin+1);
          if (exclude_zero && (bincont===0)) return false;
-         mx1 = Math.round(pmain.grx(xaxis.GetBinLowEdge(bin+1)));
-         mx2 = Math.round(pmain.grx(xaxis.GetBinLowEdge(bin+2)));
+         mx1 = Math.round(funcs.grx(xaxis.GetBinLowEdge(bin+1)));
+         mx2 = Math.round(funcs.grx(xaxis.GetBinLowEdge(bin+2)));
          midx = Math.round((mx1+mx2)/2);
-         my = Math.round(pmain.gry(bincont));
+         my = Math.round(funcs.gry(bincont));
          yerr1 = yerr2 = 20;
          if (show_errors) {
             binerr = histo.getBinError(bin+1);
-            yerr1 = Math.round(my - pmain.gry(bincont + binerr)); // up
-            yerr2 = Math.round(pmain.gry(bincont - binerr) - my); // down
+            yerr1 = Math.round(my - funcs.gry(bincont + binerr)); // up
+            yerr2 = Math.round(funcs.gry(bincont - binerr) - my); // down
          }
          return true;
       };
@@ -3926,7 +3957,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
          if (this.logx && (x <= 0)) continue;
 
-         grx = Math.round(pmain.grx(x));
+         grx = Math.round(funcs.grx(x));
 
          lastbin = (i === right);
 
@@ -3934,7 +3965,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
             gry = curry;
          } else {
             y = histo.getBinContent(i+1);
-            gry = Math.round(pmain.gry(y));
+            gry = Math.round(funcs.gry(y));
          }
 
          if (res.length === 0) {
@@ -4002,7 +4033,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       let fill_for_interactive = want_tooltip && this.fillatt.empty() && draw_hist && !draw_markers && !show_line,
           h0 = height + 3;
       if (!fill_for_interactive) {
-         let gry0 = Math.round(pmain.gry(0));
+         let gry0 = Math.round(funcs.gry(0));
          if (gry0 <= 0) h0 = -3; else if (gry0 < height) h0 = gry0;
       }
       let close_path = "L"+currx+","+h0 + "L"+startx+","+h0 + "Z";
@@ -4072,6 +4103,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       let tips = [],
           name = this.getObjectHint(),
           pmain = this.getFramePainter(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           histo = this.getHisto(),
           x1 = histo.fXaxis.GetBinLowEdge(bin+1),
           x2 = histo.fXaxis.GetBinLowEdge(bin+2),
@@ -4082,7 +4114,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
       if (this.options.Error || this.options.Mark) {
          tips.push("x = " + xlbl);
-         tips.push("y = " + pmain.axisAsText("y", cont));
+         tips.push("y = " + funcs.axisAsText("y", cont));
          if (this.options.Error) {
             if (xlbl[0] == "[") tips.push("error x = " + ((x2 - x1) / 2).toPrecision(4));
             tips.push("error y = " + histo.getBinError(bin + 1).toPrecision(4));
@@ -4112,6 +4144,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       let pmain = this.getFramePainter(),
           width = pmain.getFrameWidth(),
           height = pmain.getFrameHeight(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           histo = this.getHisto(),
           findbin = null, show_rect,
           grx1, midx, grx2, gry1, midy, gry2, gapx = 2,
@@ -4121,17 +4154,17 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
       function GetBinGrX(i) {
          let xx = histo.fXaxis.GetBinLowEdge(i+1);
-         return (pmain.logx && (xx<=0)) ? null : pmain.grx(xx);
+         return (funcs.logx && (xx<=0)) ? null : funcs.grx(xx);
       }
 
       function GetBinGrY(i) {
          let yy = histo.getBinContent(i + 1);
-         if (pmain.logy && (yy < pmain.scale_ymin))
-            return pmain.swap_xy ? -1000 : 10*height;
-         return Math.round(pmain.gry(yy));
+         if (funcs.logy && (yy < funcs.scale_ymin))
+            return funcs.swap_xy ? -1000 : 10*height;
+         return Math.round(funcs.gry(yy));
       }
 
-      if (pmain.swap_xy) {
+      if (funcs.swap_xy) {
          let d = pnt.x; pnt_x = pnt_y; pnt_y = d;
          d = height; height = width; width = d;
       }
@@ -4139,9 +4172,9 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       while (l < r-1) {
          let m = Math.round((l+r)*0.5), xx = GetBinGrX(m);
          if ((xx === null) || (xx < pnt_x - 0.5)) {
-            if (pmain.swap_xy) r = m; else l = m;
+            if (funcs.swap_xy) r = m; else l = m;
          } else if (xx > pnt_x + 0.5) {
-            if (pmain.swap_xy) l = m; else r = m;
+            if (funcs.swap_xy) l = m; else r = m;
          } else { l++; r--; }
       }
 
@@ -4192,12 +4225,12 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
          gapx = 0;
 
-         gry1 = Math.round(pmain.gry(((this.options.BaseLine!==false) && (this.options.BaseLine > pmain.scale_ymin)) ? this.options.BaseLine : pmain.scale_ymin));
+         gry1 = Math.round(funcs.gry(((this.options.BaseLine!==false) && (this.options.BaseLine > funcs.scale_ymin)) ? this.options.BaseLine : funcs.scale_ymin));
 
          if (gry1 > gry2) { let d = gry1; gry1 = gry2; gry2 = d; }
 
          if (!pnt.touch && (pnt.nproc === 1))
-            if ((pnt_y<gry1) || (pnt_y>gry2)) findbin = null;
+            if ((pnt_y < gry1) || (pnt_y > gry2)) findbin = null;
 
       } else if (this.options.Error || this.options.Mark || this.options.Line || this.options.Curve)  {
 
@@ -4210,8 +4243,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
             let cont = histo.getBinContent(findbin+1),
                 binerr = histo.getBinError(findbin+1);
 
-            gry1 = Math.round(pmain.gry(cont + binerr)); // up
-            gry2 = Math.round(pmain.gry(cont - binerr)); // down
+            gry1 = Math.round(funcs.gry(cont + binerr)); // up
+            gry2 = Math.round(funcs.gry(cont - binerr)); // down
 
             if ((cont==0) && this.isTProfile()) findbin = null;
 
@@ -4239,7 +4272,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
             gry2 = height;
 
             if (!this.fillatt.empty()) {
-               gry2 = Math.round(pmain.gry(0));
+               gry2 = Math.round(funcs.gry(0));
                if (gry2 < 0) gry2 = 0; else if (gry2 > height) gry2 = height;
                if (gry2 < gry1) { let d = gry1; gry1 = gry2; gry2 = d; }
             }
@@ -4287,14 +4320,14 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          res.changed = ttrect.property("current_bin") !== findbin;
 
          if (res.changed)
-            ttrect.attr("x", pmain.swap_xy ? gry1 : grx1)
-                  .attr("width", pmain.swap_xy ? gry2-gry1 : grx2-grx1)
-                  .attr("y", pmain.swap_xy ? grx1 : gry1)
-                  .attr("height", pmain.swap_xy ? grx2-grx1 : gry2-gry1)
+            ttrect.attr("x", funcs.swap_xy ? gry1 : grx1)
+                  .attr("width", funcs.swap_xy ? gry2-gry1 : grx2-grx1)
+                  .attr("y", funcs.swap_xy ? grx1 : gry1)
+                  .attr("height", funcs.swap_xy ? grx2-grx1 : gry2-gry1)
                   .style("opacity", "0.3")
                   .property("current_bin", findbin);
 
-         res.exact = (Math.abs(midy - pnt_y) <= 5) || ((pnt_y>=gry1) && (pnt_y<=gry2));
+         res.exact = (Math.abs(midy - pnt_y) <= 5) || ((pnt_y >= gry1) && (pnt_y <= gry2));
 
          res.menu = true; // one could show context menu
          // distance to middle point, use to decide which menu to activate
@@ -4849,22 +4882,22 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
           stat_sumx2 = 0, stat_sumy2 = 0,
           xside, yside, xx, yy, zz,
           fp = this.getFramePainter(),
+          funcs = fp.getGrFuncs(this.options.second_x, this.options.second_y),
           res = { name: histo.fName, entries: 0, integral: 0, meanx: 0, meany: 0, rmsx: 0, rmsy: 0, matrix: [0,0,0,0,0,0,0,0,0], xmax: 0, ymax:0, wmax: null };
 
       if (this.isTH2Poly()) {
 
-         let len = histo.fBins.arr.length, i, bin, n, gr, ngr, numgraphs, numpoints,
-             pmain = this.getFramePainter();
+         let len = histo.fBins.arr.length, i, bin, n, gr, ngr, numgraphs, numpoints;
 
          for (i=0;i<len;++i) {
             bin = histo.fBins.arr[i];
 
             xside = 1; yside = 1;
 
-            if (bin.fXmin > pmain.scale_xmax) xside = 2; else
-            if (bin.fXmax < pmain.scale_xmin) xside = 0;
-            if (bin.fYmin > pmain.scale_ymax) yside = 2; else
-            if (bin.fYmax < pmain.scale_ymin) yside = 0;
+            if (bin.fXmin > funcs.scale_xmax) xside = 2; else
+            if (bin.fXmax < funcs.scale_xmin) xside = 0;
+            if (bin.fYmin > funcs.scale_ymax) yside = 2; else
+            if (bin.fYmax < funcs.scale_ymin) yside = 0;
 
             xx = yy = numpoints = 0;
             gr = bin.fPoly; numgraphs = 1;
@@ -5309,6 +5342,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
           main = this.getFramePainter(),
           frame_w = main.getFrameWidth(),
           frame_h = main.getFrameHeight(),
+          funcs = main.getGrFuncs(this.options.second_x, this.options.second_y),
           levels = this.getContourLevels(),
           palette = this.getHistPalette(),
           func = main.getProjectionFunc();
@@ -5318,8 +5352,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          for (let i = iminus; i <= iplus; ++i) {
             if (func) {
                pnt = func(xp[i], yp[i]);
-               pnt.x = Math.round(main.grx(pnt.x));
-               pnt.y = Math.round(main.gry(pnt.y));
+               pnt.x = Math.round(funcs.grx(pnt.x));
+               pnt.y = Math.round(funcs.gry(pnt.y));
             } else {
                pnt = { x: Math.round(xp[i]), y: Math.round(yp[i]) };
             }
@@ -5471,7 +5505,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
    /** @summary Create poly bin
      * @private */
-   TH2Painter.prototype.createPolyBin = function(pmain, bin, text_pos) {
+   TH2Painter.prototype.createPolyBin = function(pmain, funcs, bin, text_pos) {
       let cmd = "", ngr, ngraphs = 1, gr = null;
 
       if (bin.fPoly._typename == 'TMultiGraph')
@@ -5494,8 +5528,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
          let npnts = gr.fNpoints, n,
              x = gr.fX, y = gr.fY,
-             grx = Math.round(pmain.grx(x[0])),
-             gry = Math.round(pmain.gry(y[0])),
+             grx = Math.round(funcs.grx(x[0])),
+             gry = Math.round(funcs.gry(y[0])),
              nextx, nexty;
 
          if ((npnts>2) && (x[0]==x[npnts-1]) && (y[0]==y[npnts-1])) npnts--;
@@ -5503,8 +5537,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          cmd += "M"+grx+","+gry;
 
          for (n=1;n<npnts;++n) {
-            nextx = Math.round(pmain.grx(x[n]));
-            nexty = Math.round(pmain.gry(y[n]));
+            nextx = Math.round(funcs.grx(x[n]));
+            nexty = Math.round(funcs.gry(y[n]));
             if (text_pos) addPoint(grx,gry, nextx, nexty);
             if ((grx!==nextx) || (gry!==nexty)) {
                if (grx === nextx)
@@ -5517,7 +5551,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
             grx = nextx; gry = nexty;
          }
 
-         if (text_pos) addPoint(grx, gry, Math.round(pmain.grx(x[0])), Math.round(pmain.gry(y[0])));
+         if (text_pos) addPoint(grx, gry, Math.round(funcs.grx(x[0])), Math.round(funcs.gry(y[0])));
          cmd += "z";
       }
 
@@ -5526,8 +5560,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
             bin._midx = Math.round(bin._sumx / bin._suml);
             bin._midy = Math.round(bin._sumy / bin._suml);
          } else {
-            bin._midx = Math.round(pmain.grx((bin.fXmin + bin.fXmax)/2));
-            bin._midy = Math.round(pmain.gry((bin.fYmin + bin.fYmax)/2));
+            bin._midx = Math.round(funcs.grx((bin.fXmin + bin.fXmax)/2));
+            bin._midy = Math.round(funcs.gry((bin.fYmin + bin.fYmax)/2));
          }
       }
 
@@ -5539,6 +5573,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
    TH2Painter.prototype.drawPolyBinsColor = function() {
       let histo = this.getObject(),
           pmain = this.getFramePainter(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           h = pmain.getFrameHeight(),
           colPaths = [], textbins = [],
           colindx, cmd, bin, item,
@@ -5562,10 +5597,10 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          }
 
          // check if bin outside visible range
-         if ((bin.fXmin > pmain.scale_xmax) || (bin.fXmax < pmain.scale_xmin) ||
-             (bin.fYmin > pmain.scale_ymax) || (bin.fYmax < pmain.scale_ymin)) continue;
+         if ((bin.fXmin > funcs.scale_xmax) || (bin.fXmax < funcs.scale_xmin) ||
+             (bin.fYmin > funcs.scale_ymax) || (bin.fYmax < funcs.scale_ymin)) continue;
 
-         cmd = this.createPolyBin(pmain, bin, this.options.Text && bin.fContent);
+         cmd = this.createPolyBin(pmain, funcs, bin, this.options.Text && bin.fContent);
 
          if (colPaths[colindx] === undefined)
             colPaths[colindx] = cmd;
@@ -5801,7 +5836,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
             absz = Math.abs(binz);
             if ((absz === 0) || (absz < absmin)) continue;
 
-            zdiff = uselogz ? ((absz>0) ? Math.log(absz) - logmin : 0) : (absz - absmin);
+            zdiff = uselogz ? ((absz > 0) ? Math.log(absz) - logmin : 0) : (absz - absmin);
             // area of the box should be proportional to absolute bin content
             zdiff = 0.5 * ((zdiff < 0) ? 1 : (1 - Math.sqrt(zdiff * xyfactor)));
             // avoid oversized bins
@@ -5821,7 +5856,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
             res += "M"+xx+","+yy + "v"+hh + "h"+ww + "v-"+hh + "z";
 
-            if ((binz<0) && (this.options.BoxStyle === 10))
+            if ((binz < 0) && (this.options.BoxStyle === 10))
                cross += "M"+xx+","+yy + "l"+ww+","+hh + "M"+(xx+ww)+","+yy + "l-"+ww+","+hh;
 
             if ((this.options.BoxStyle === 11) && (ww>5) && (hh>5)) {
@@ -5880,6 +5915,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       let histo = this.getHisto(),
           handle = this.prepareColorDraw(),
           pmain = this.getFramePainter(), // used for axis values conversions
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           w, i, j, y, sum1, cont, center, counter, integral, pnt,
           bars = "", markers = "", posy;
 
@@ -5930,7 +5966,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          }
 
          // exclude points with negative y when log scale is specified
-         if (pmain.logy && (pnt.whiskerm<=0)) continue;
+         if (funcs.logy && (pnt.whiskerm <= 0)) continue;
 
          w = handle.grx[i+1] - handle.grx[i];
          w *= 0.66;
@@ -5941,19 +5977,19 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          pnt.x2 = Math.round(center + w/2);
          center = Math.round(center);
 
-         pnt.y0 = Math.round(pmain.gry(pnt.median));
+         pnt.y0 = Math.round(funcs.gry(pnt.median));
          // mean line
          bars += "M" + pnt.x1 + "," + pnt.y0 + "h" + (pnt.x2-pnt.x1);
 
-         pnt.y1 = Math.round(pmain.gry(pnt.p25y));
-         pnt.y2 = Math.round(pmain.gry(pnt.m25y));
+         pnt.y1 = Math.round(funcs.gry(pnt.p25y));
+         pnt.y2 = Math.round(funcs.gry(pnt.m25y));
 
          // rectangle
          bars += "M" + pnt.x1 + "," + pnt.y1 +
          "v" + (pnt.y2-pnt.y1) + "h" + (pnt.x2-pnt.x1) + "v-" + (pnt.y2-pnt.y1) + "z";
 
-         pnt.yy1 = Math.round(pmain.gry(pnt.whiskerp));
-         pnt.yy2 = Math.round(pmain.gry(pnt.whiskerm));
+         pnt.yy1 = Math.round(funcs.gry(pnt.whiskerp));
+         pnt.yy2 = Math.round(funcs.gry(pnt.whiskerm));
 
          // upper part
          bars += "M" + center + "," + pnt.y1 + "v" + (pnt.yy1-pnt.y1);
@@ -6195,11 +6231,13 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
    /** @summary Provide text information (tooltips) for candle bin
      * @private */
    TH2Painter.prototype.getCandleTooltips = function(p) {
-      let lines = [], main = this.getFramePainter(), histo = this.getHisto();
+      let lines = [], pmain = this.getFramePainter(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
+          histo = this.getHisto();
 
       lines.push(this.getObjectHint());
 
-      lines.push("x = " + main.axisAsText("x", histo.fXaxis.GetBinLowEdge(p.bin+1)));
+      lines.push("x = " + funcs.axisAsText("x", histo.fXaxis.GetBinLowEdge(p.bin+1)));
 
       lines.push('mean y = ' + jsrp.floatToString(p.meany, JSROOT.gStyle.fStatFormat))
       lines.push('m25 = ' + jsrp.floatToString(p.m25y, JSROOT.gStyle.fStatFormat))
@@ -6215,6 +6253,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       let histo = this.getHisto(),
           bin = histo.fBins.arr[binindx],
           pmain = this.getFramePainter(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           binname = bin.fPoly.fName,
           lines = [], numpoints = 0;
 
@@ -6243,8 +6282,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       }
 
       lines.push(this.getObjectHint());
-      lines.push("x = " + pmain.axisAsText("x", realx));
-      lines.push("y = " + pmain.axisAsText("y", realy));
+      lines.push("x = " + funcs.axisAsText("x", realx));
+      lines.push("y = " + funcs.axisAsText("y", realy));
       if (numpoints > 0) lines.push("npnts = " + numpoints);
       lines.push("bin = " + binname);
       if (bin.fContent === Math.round(bin.fContent))
@@ -6270,9 +6309,11 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       if (h.poly) {
          // process tooltips from TH2Poly
 
-         let pmain = this.getFramePainter(), foundindx = -1, bin;
-         const realx = pmain.revertAxis("x", pnt.x),
-               realy = pmain.revertAxis("y", pnt.y);
+         let pmain = this.getFramePainter(),
+             funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
+             foundindx = -1, bin;
+         const realx = funcs.revertAxis("x", pnt.x),
+               realy = funcs.revertAxis("y", pnt.y);
 
          if ((realx!==undefined) && (realy!==undefined)) {
             const len = histo.fBins.arr.length;
@@ -6325,7 +6366,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
             res.changed = ttrect.property("current_bin") !== foundindx;
 
             if (res.changed)
-                  ttrect.attr("d", this.createPolyBin(pmain, bin))
+                  ttrect.attr("d", this.createPolyBin(pmain, funcs, bin))
                         .style("opacity", "0.7")
                         .property("current_bin", foundindx);
          }
@@ -6343,12 +6384,12 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
          let p, i;
 
-         for (i=0;i<h.candle.length;++i) {
+         for (i = 0; i < h.candle.length; ++i) {
             p = h.candle[i];
             if ((p.x1 <= pnt.x) && (pnt.x <= p.x2) && (p.yy1 <= pnt.y) && (pnt.y <= p.yy2)) break;
          }
 
-         if (i>=h.candle.length) {
+         if (i >= h.candle.length) {
             ttrect.remove();
             return null;
          }

--- a/js/scripts/JSRoot.interactive.js
+++ b/js/scripts/JSRoot.interactive.js
@@ -700,6 +700,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             setTimeout(this.processFrameTooltipEvent.bind(this, hintsg.property('last_point'), null), 10);
       },
 
+      /** @summary Add interactive handlers */
       addInteractivity: function(for_second_axes) {
 
          let pp = this.getPadPainter(),
@@ -765,6 +766,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          return Promise.resolve(this);
       },
 
+      /** @summary Add keys handler */
       addKeysHandler: function() {
          if (this.keys_handler || (typeof window == 'undefined')) return;
 
@@ -773,6 +775,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          window.addEventListener('keydown', this.keys_handler, false);
       },
 
+      /** @summary Handle key press */
       processKeyPress: function(evnt) {
          let main = this.selectDom();
          if (!JSROOT.settings.HandleKeys || main.empty() || (this.enabledKeys === false)) return;
@@ -862,6 +865,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          return res;
       },
 
+      /** @summary Start mouse rect zooming */
       startRectSel: function(evnt) {
          // ignore when touch selection is activated
 
@@ -918,6 +922,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             setTimeout(() => this.startLabelsMove(), 500);
       },
 
+      /** @summary Starts labels move */
       startLabelsMove: function() {
          if (this.zoom_rect) return;
 
@@ -930,6 +935,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          }
       },
 
+      /** @summary Process mouse rect zooming */
       moveRectSel: function(evnt) {
 
          if ((this.zoom_kind == 0) || (this.zoom_kind > 100)) return;
@@ -970,6 +976,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          this.zoom_rect.attr("x", x).attr("y", y).attr("width", w).attr("height", h);
       },
 
+      /** @summary Finish mouse rect zooming */
       endRectSel: function(evnt) {
          if ((this.zoom_kind == 0) || (this.zoom_kind > 100)) return;
 
@@ -1027,7 +1034,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             }
          }
 
-         let pnt =  (kind===1) ? { x: this.zoom_origin[0], y: this.zoom_origin[1] } : null;
+         let pnt = (kind===1) ? { x: this.zoom_origin[0], y: this.zoom_origin[1] } : null;
 
          this.clearInteractiveElements();
 
@@ -1050,6 +1057,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       },
 
+      /** @summary Handle mouse double click on frame */
       mouseDoubleClick: function(evnt) {
          evnt.preventDefault();
          let m = d3.pointer(evnt, this.getFrameSvg().node()),
@@ -1077,6 +1085,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          });
       },
 
+      /** @summary Start touch zoom */
       startTouchZoom: function(evnt) {
          // in case when zooming was started, block any other kind of events
          if (this.zoom_kind != 0) {
@@ -1159,12 +1168,13 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                .attr("width", this.zoom_origin[0] - this.zoom_curr[0])
                .attr("height", this.zoom_origin[1] - this.zoom_curr[1]);
 
-         d3.select(window).on("touchmove.zoomRect", this.moveTouchSel.bind(this))
-                          .on("touchcancel.zoomRect", this.endTouchSel.bind(this))
-                          .on("touchend.zoomRect", this.endTouchSel.bind(this));
+         d3.select(window).on("touchmove.zoomRect", this.moveTouchZoom.bind(this))
+                          .on("touchcancel.zoomRect", this.endTouchZoom.bind(this))
+                          .on("touchend.zoomRect", this.endTouchZoom.bind(this));
       },
 
-      moveTouchSel: function(evnt) {
+      /** @summary Move touch zooming */
+      moveTouchZoom: function(evnt) {
          if (this.zoom_kind < 100) return;
 
          evnt.preventDefault();
@@ -1197,7 +1207,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          evnt.stopPropagation();
       },
 
-      endTouchSel: function(evnt) {
+      /** @summary End touch zooming handler */
+      endTouchZoom: function(evnt) {
 
          this.getFrameSvg().on("touchcancel", null)
                          .on("touchend", null);
@@ -1328,6 +1339,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       },
 
+      /** @summary Show frame context menu */
       showContextMenu: function(kind, evnt, obj) {
 
          // ignore context menu when touches zooming is ongoing
@@ -1452,6 +1464,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          delete this[fld];
       },
 
+      /** @summary Clear frame interactive elements */
       clearInteractiveElements: function() {
          if (jsrp.closeMenu) jsrp.closeMenu();
          this.zoom_kind = 0;
@@ -1461,36 +1474,13 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          delete this.zoom_lastpos;
          delete this.zoom_labels;
 
-
          // enable tooltip in frame painter
          setPainterTooltipEnabled(this, true);
       },
 
-      /** Assign frame interactive methods */
+      /** @summary Assign frame interactive methods */
       assign: function(painter) {
          JSROOT.extend(painter, this);
-
-         /*
-         painter.addBasicInteractivity = this.addBasicInteractivity;
-         painter.addInteractivity = this.addInteractivity;
-         painter.addKeysHandler = this.addKeysHandler;
-         painter.processKeyPress = this.processKeyPress;
-         painter.processFrameClick = this.processFrameClick;
-         painter.startRectSel = this.startRectSel;
-         painter.moveRectSel = this.moveRectSel;
-         painter.endRectSel = this.endRectSel;
-         painter.mouseDoubleClick = this.mouseDoubleClick;
-         painter.startTouchZoom = this.startTouchZoom;
-         painter.moveTouchSel = this.moveTouchSel;
-         painter.endTouchSel = this.endTouchSel;
-         painter.analyzeMouseWheelEvent = this.analyzeMouseWheelEvent;
-         painter.isAllowedDefaultYZooming = this.isAllowedDefaultYZooming;
-         painter.mouseWheel = this.mouseWheel;
-         painter.showContextMenu = this.showContextMenu;
-         painter.startTouchMenu = this.startTouchMenu;
-         painter.endTouchMenu = this.endTouchMenu;
-         painter.clearInteractiveElements = this.clearInteractiveElements;
-         */
       }
 
    } // FrameInterative

--- a/js/scripts/JSRoot.io.js
+++ b/js/scripts/JSRoot.io.js
@@ -1356,10 +1356,8 @@ JSROOT.define(['rawinflate'], () => {
             if ((typ === jsrio.kBits) && (kind === jsrio.kUInt)) continue;
             if ((typ === jsrio.kCounter) && (kind === jsrio.kInt)) continue;
 
-            if (typname && typ && (this.fBasicTypes[typname] !== typ)) {
+            if (typname && typ && (this.fBasicTypes[typname] !== typ))
                this.fBasicTypes[typname] = typ;
-               if (!JSROOT.batch_mode) console.log('Extract basic data type', typ, typname);
-            }
          }
       }
    }

--- a/js/scripts/JSRoot.menu.js
+++ b/js/scripts/JSRoot.menu.js
@@ -377,20 +377,25 @@ JSROOT.define(['d3', 'jquery', 'painter', 'jquery-ui'], (d3, $, jsrp) => {
         * @protected */
       addRColorMenu(name, value, set_func) {
          // if (value === undefined) return;
-         let colors = ['black', 'white', 'red', 'green', 'blue', 'yellow', 'magenta', 'cyan'];
+         let colors = ['default', 'black', 'white', 'red', 'green', 'blue', 'yellow', 'magenta', 'cyan'];
 
          this.add("sub:" + name, () => {
             this.input("Enter color name - empty string will reset color", value).then(set_func);
          });
-         let col = null, fillcol = 'black', coltxt = 'default', bkgr = '';
-         for (let n = -1; n < colors.length; ++n) {
-            if (n >= 0) {
-               coltxt = col = colors[n];
-               bkgr = "background-color:" + col;
-               fillcol = (col == 'white') ? 'black' : 'white';
+         let fillcol = 'black';
+         for (let n = 0; n < colors.length; ++n) {
+            let coltxt = colors[n], match = false, bkgr = '';
+            if (n > 0) {
+               bkgr = "background-color:" + coltxt;
+               fillcol = (coltxt == 'white') ? 'black' : 'white';
+
+               if ((typeof value === 'string') && value && (value != 'auto') && (value[0] != '['))
+                  match = (d3.rgb(value).toString() == d3.rgb(coltxt).toString());
+            } else {
+               match = !value;
             }
             let svg = `<svg width='100' height='18' style='margin:0px;${bkgr}'><text x='4' y='12' style='font-size:12px' fill='${fillcol}'>${coltxt}</text></svg>`;
-            this.addchk(value == col, svg, coltxt, res => set_func(res == 'default' ? null : res));
+            this.addchk(match, svg, coltxt, res => set_func(res == 'default' ? null : res));
          }
          this.add("endsub:");
       }
@@ -399,7 +404,7 @@ JSROOT.define(['d3', 'jquery', 'painter', 'jquery-ui'], (d3, $, jsrp) => {
         * @protected */
       addRAttrTextItems(fontHandler, opts, set_func) {
          if (!opts) opts = {};
-         this.addRColorMenu("color", fontHandler.color, sel => set_func({ name: "color_name", value: sel }));
+         this.addRColorMenu("color", fontHandler.color, sel => set_func({ name: "color", value: sel }));
          if (fontHandler.scaled)
             this.addSizeMenu("size", 0.01, 0.10, 0.01, fontHandler.size /fontHandler.scale, sz => set_func({ name: "size", value: sz }));
          else

--- a/js/scripts/JSRoot.more.js
+++ b/js/scripts/JSRoot.more.js
@@ -522,13 +522,9 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
           gxmin = 0, gxmax = 0, tf1 = this.getObject();
 
       if (main && !ignore_zoom)  {
-         if (main.zoom_xmin !== main.zoom_xmax) {
-            gxmin = main.zoom_xmin;
-            gxmax = main.zoom_xmax;
-         } else {
-            gxmin = main.xmin;
-            gxmax = main.xmax;
-         }
+         let gr = main.getGrFuncs(this.second_x, this.second_y);
+         gxmin = gr.scale_xmin;
+         gxmax = gr.scale_xmax;
       }
 
       if ((tf1.fSave.length > 0) && !this.nosave) {
@@ -641,7 +637,7 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
       let min = 100000, best = -1, bin;
 
-      for(let n=0; n<this.bins.length; ++n) {
+      for(let n = 0; n < this.bins.length; ++n) {
          bin = this.bins[n];
          let dist = Math.abs(bin.grx - pnt.x);
          if (dist < min) { min = dist; best = n; }
@@ -681,9 +677,10 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       let name = this.getObjectHint();
       if (name.length > 0) res.lines.push(name);
 
-      let pmain = this.getFramePainter();
-      if (pmain)
-         res.lines.push("x = " + pmain.axisAsText("x",bin.x) + " y = " + pmain.axisAsText("y",bin.y));
+      let pmain = this.getFramePainter(),
+          funcs = pmain ? pmain.getGrFuncs(this.second_x, this.second_y) : null;
+      if (funcs)
+         res.lines.push("x = " + funcs.axisAsText("x",bin.x) + " y = " + funcs.axisAsText("y",bin.y));
 
       return res;
    }
@@ -708,18 +705,20 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       this.createAttFill({ attr: tf1, kind: 1 });
       this.fillatt.used = false;
 
+      let funcs = fp.getGrFuncs(this.second_x, this.second_y);
+
       // first calculate graphical coordinates
-      for(let n=0; n<this.bins.length; ++n) {
+      for(let n = 0; n < this.bins.length; ++n) {
          let bin = this.bins[n];
-         bin.grx = fp.grx(bin.x);
-         bin.gry = fp.gry(bin.y);
+         bin.grx = funcs.grx(bin.x);
+         bin.gry = funcs.gry(bin.y);
       }
 
       if (this.bins.length > 2) {
 
          let h0 = h;  // use maximal frame height for filling
          if ((pmain.hmin!==undefined) && (pmain.hmin>=0)) {
-            h0 = Math.round(fp.gry(0));
+            h0 = Math.round(funcs.gry(0));
             if ((h0 > h) || (h0 < 0)) h0 = h;
          }
 
@@ -763,13 +762,20 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
    }
 
    function drawFunction(divid, tf1, opt) {
-      let painter = new TF1Painter(divid, tf1);
-      let d = new JSROOT.DrawOptions(opt);
+      let painter = new TF1Painter(divid, tf1),
+          d = new JSROOT.DrawOptions(opt),
+          has_main = !!painter.getMainPainter(),
+          aopt = "AXIS";
+      d.check('SAME'); // just ignore same
       painter.nosave = d.check('NOSAVE');
+      if (d.check('X+')) { aopt += "X+"; painter.second_x = has_main; }
+      if (d.check('Y+')) { aopt += "Y+"; painter.second_y = has_main; }
+      if (d.check('RX')) aopt += "RX";
+      if (d.check('RY')) aopt += "RY";
 
       return JSROOT.require("math").then(() => {
-         if (!painter.getMainPainter())
-            return JSROOT.draw(divid, painter.createDummyHisto(), "AXIS");
+         if (!has_main || painter.second_x || painter.second_y)
+            return JSROOT.draw(divid, painter.createDummyHisto(), aopt);
       }).then(() => {
          painter.addToPadPrimitives();
          painter.redraw();
@@ -824,14 +830,16 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
          opt = opt.substr(5);
 
       let graph = this.getObject(),
-          d = new JSROOT.DrawOptions(opt);
+          d = new JSROOT.DrawOptions(opt),
+          has_main = !!this.getMainPainter();
 
       if (!this.options) this.options = {};
 
       JSROOT.extend(this.options, {
          Line: 0, Curve: 0, Rect: 0, Mark: 0, Bar: 0, OutRange: 0,  EF:0, Fill: 0, NoOpt: 0,
-         MainError: 1, Ends: 1, Axis: "", PadStats: false, original: opt
-       });
+         MainError: 1, Ends: 1, Axis: "", PadStats: false, original: opt,
+         second_x: false, second_y: false
+      });
 
       let res = this.options;
 
@@ -839,9 +847,11 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       res.PadStats = d.check("USE_PAD_STATS");
       let hopt = "", checkhopt = ["USE_PAD_TITLE", "LOGXY", "LOGX", "LOGY", "LOGZ", "GRIDXY", "GRIDX", "GRIDY", "TICKXY", "TICKX", "TICKY"];
       checkhopt.forEach(name => { if (d.check(name)) hopt += ";" + name; });
+      if (d.check('XAXIS_', true)) hopt += ";XAXIS_" + d.part;
+      if (d.check('YAXIS_', true)) hopt += ";YAXIS_" + d.part;
 
       if (d.empty()) {
-         res.original = this.getMainPainter() ? "lp" : "alp";
+         res.original = has_main ? "lp" : "alp";
          d = new JSROOT.DrawOptions(res.original);
       }
 
@@ -853,8 +863,8 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       if (d.check('L')) res.Line = 1;
       if (d.check('F')) res.Fill = 1;
       if (d.check('A')) res.Axis = d.check("I") ? "A" : "AXIS"; // I means invisible axis
-      if (d.check('X+')) res.Axis += "X+";
-      if (d.check('Y+')) res.Axis += "Y+";
+      if (d.check('X+')) { res.Axis += "X+"; res.second_x = has_main; }
+      if (d.check('Y+')) { res.Axis += "Y+"; res.second_y = has_main; }
       if (d.check('RX')) res.Axis += "RX";
       if (d.check('RY')) res.Axis += "RY";
       if (d.check('C')) res.Curve = res.Line = 1;
@@ -1069,19 +1079,20 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
    /** @summary Returns tooltip for specified bin
      * @private */
    TGraphPainter.prototype.getTooltips = function(d) {
-      let pmain = this.getFramePainter(), lines = [];
+      let pmain = this.getFramePainter(), lines = [],
+          funcs = pmain ? pmain.getGrFuncs(this.options.second_x, this.options.second_y) : null;
 
       lines.push(this.getObjectHint());
 
-      if (d && pmain) {
-         lines.push("x = " + pmain.axisAsText("x", d.x));
-         lines.push("y = " + pmain.axisAsText("y", d.y));
+      if (d && funcs) {
+         lines.push("x = " + funcs.axisAsText("x", d.x));
+         lines.push("y = " + funcs.axisAsText("y", d.y));
 
-         if (this.options.Errors && (pmain.x_handle.kind=='normal') && ('exlow' in d) && ((d.exlow!=0) || (d.exhigh!=0)))
-            lines.push("error x = -" + pmain.axisAsText("x", d.exlow) + "/+" + pmain.axisAsText("x", d.exhigh));
+         if (this.options.Errors && (funcs.x_handle.kind=='normal') && ('exlow' in d) && ((d.exlow!=0) || (d.exhigh!=0)))
+            lines.push("error x = -" + funcs.axisAsText("x", d.exlow) + "/+" + funcs.axisAsText("x", d.exhigh));
 
-         if ((this.options.Errors || (this.options.EF > 0)) && (pmain.y_handle.kind=='normal') && ('eylow' in d) && ((d.eylow!=0) || (d.eyhigh!=0)))
-            lines.push("error y = -" + pmain.axisAsText("y", d.eylow) + "/+" + pmain.axisAsText("y", d.eyhigh));
+         if ((this.options.Errors || (this.options.EF > 0)) && (funcs.y_handle.kind=='normal') && ('eylow' in d) && ((d.eylow!=0) || (d.eyhigh!=0)))
+            lines.push("error y = -" + funcs.axisAsText("y", d.eylow) + "/+" + funcs.axisAsText("y", d.eyhigh));
       }
       return lines;
    }
@@ -1117,7 +1128,8 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
              else
                 value = (value - this.pad.fY1) / (this.pad.fY2 - this.pad.fY1);
              return (1-value)*this.ph;
-          }
+          },
+          getGrFuncs: function() { return this; }
       }
 
       return pmain.pad ? pmain : null;
@@ -1132,7 +1144,8 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       let w = pmain.getFrameWidth(),
           h = pmain.getFrameHeight(),
           graph = this.getObject(),
-          excl_width = 0;
+          excl_width = 0,
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y);
 
       this.createG(!pmain.pad_layer);
 
@@ -1169,16 +1182,16 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
          // build lower part
          for (let n=0;n<drawbins.length;++n) {
             let bin = drawbins[n];
-            bin.grx = pmain.grx(bin.x);
-            bin.gry = pmain.gry(bin.y - bin.eylow);
+            bin.grx = funcs.grx(bin.x);
+            bin.gry = funcs.gry(bin.y - bin.eylow);
          }
 
          let path1 = jsrp.buildSvgPath((this.options.EF > 1) ? "bezier" : "line", drawbins),
              bins2 = [];
 
-         for (let n=drawbins.length-1;n>=0;--n) {
+         for (let n = drawbins.length-1; n >= 0; --n) {
             let bin = drawbins[n];
-            bin.gry = pmain.gry(bin.y + bin.eyhigh);
+            bin.gry = funcs.gry(bin.y + bin.eyhigh);
             bins2.push(bin);
          }
 
@@ -1204,10 +1217,10 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
          if (!drawbins) drawbins = this.optimizeBins(this.options.Curve ? 5000 : 0);
 
-         for (let n=0;n<drawbins.length;++n) {
+         for (let n = 0; n < drawbins.length; ++n) {
             let bin = drawbins[n];
-            bin.grx = pmain.grx(bin.x);
-            bin.gry = pmain.gry(bin.y);
+            bin.grx = funcs.grx(bin.x);
+            bin.gry = funcs.gry(bin.y);
          }
 
          let kind = "line"; // simple line
@@ -1218,7 +1231,7 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
          if (excl_width!==0) {
             let extrabins = [];
-            for (let n=drawbins.length-1;n>=0;--n) {
+            for (let n = drawbins.length-1; n >= 0; --n) {
                let bin = drawbins[n];
                let dlen = Math.sqrt(bin.dgrx*bin.dgrx + bin.dgry*bin.dgry);
                // shift point, using
@@ -1259,29 +1272,29 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
          drawbins = this.optimizeBins(5000, (pnt,i) => {
 
-            let grx = pmain.grx(pnt.x);
+            let grx = funcs.grx(pnt.x);
 
             // when drawing bars, take all points
             if (!this.options.Bar && ((grx<0) || (grx>w))) return true;
 
-            let gry = pmain.gry(pnt.y);
+            let gry = funcs.gry(pnt.y);
 
-            if (!this.options.Bar && !this.options.OutRange && ((gry<0) || (gry>h))) return true;
+            if (!this.options.Bar && !this.options.OutRange && ((gry < 0) || (gry > h))) return true;
 
             pnt.grx1 = Math.round(grx);
             pnt.gry1 = Math.round(gry);
 
             if (this.has_errors) {
-               pnt.grx0 = Math.round(pmain.grx(pnt.x - pnt.exlow) - grx);
-               pnt.grx2 = Math.round(pmain.grx(pnt.x + pnt.exhigh) - grx);
-               pnt.gry0 = Math.round(pmain.gry(pnt.y - pnt.eylow) - gry);
-               pnt.gry2 = Math.round(pmain.gry(pnt.y + pnt.eyhigh) - gry);
+               pnt.grx0 = Math.round(funcs.grx(pnt.x - pnt.exlow) - grx);
+               pnt.grx2 = Math.round(funcs.grx(pnt.x + pnt.exhigh) - grx);
+               pnt.gry0 = Math.round(funcs.gry(pnt.y - pnt.eylow) - gry);
+               pnt.gry2 = Math.round(funcs.gry(pnt.y + pnt.eyhigh) - gry);
 
                if (this.is_bent) {
-                  pnt.grdx0 = Math.round(pmain.gry(pnt.y + graph.fEXlowd[i]) - gry);
-                  pnt.grdx2 = Math.round(pmain.gry(pnt.y + graph.fEXhighd[i]) - gry);
-                  pnt.grdy0 = Math.round(pmain.grx(pnt.x + graph.fEYlowd[i]) - grx);
-                  pnt.grdy2 = Math.round(pmain.grx(pnt.x + graph.fEYhighd[i]) - grx);
+                  pnt.grdx0 = Math.round(funcs.gry(pnt.y + graph.fEXlowd[i]) - gry);
+                  pnt.grdx2 = Math.round(funcs.gry(pnt.y + graph.fEXhighd[i]) - gry);
+                  pnt.grdy0 = Math.round(funcs.grx(pnt.x + graph.fEYlowd[i]) - grx);
+                  pnt.grdy2 = Math.round(funcs.grx(pnt.x + graph.fEYhighd[i]) - grx);
                } else {
                   pnt.grdx0 = pnt.grdx2 = pnt.grdy0 = pnt.grdy2 = 0;
                }
@@ -1303,7 +1316,7 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
       if (this.options.Bar) {
          // calculate bar width
-         for (let i=1;i<drawbins.length-1;++i)
+         for (let i = 1; i < drawbins.length-1; ++i)
             drawbins[i].width = Math.max(2, (drawbins[i+1].grx1 - drawbins[i-1].grx1) / 2 - 2);
 
          // first and last bins
@@ -1316,7 +1329,7 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
                drawbins[drawbins.length-1].width = drawbins[drawbins.length-2].width;
          }
 
-         let yy0 = Math.round(pmain.gry(0));
+         let yy0 = Math.round(funcs.gry(0));
 
          nodes.append("svg:rect")
             .attr("x", d => Math.round(-d.width/2))
@@ -1417,21 +1430,22 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
          // let produce SVG at maximum 1MB
          let maxnummarker = 1000000 / (this.markeratt.getMarkerLength() + 7), step = 1;
 
-         if (!drawbins) drawbins = this.optimizeBins(maxnummarker); else
-            if (this.canOptimize() && (drawbins.length > 1.5*maxnummarker))
-               step = Math.min(2, Math.round(drawbins.length/maxnummarker));
+         if (!drawbins)
+            drawbins = this.optimizeBins(maxnummarker);
+         else if (this.canOptimize() && (drawbins.length > 1.5*maxnummarker))
+            step = Math.min(2, Math.round(drawbins.length/maxnummarker));
 
-         for (let n=0;n<drawbins.length;n+=step) {
+         for (let n = 0; n < drawbins.length; n+=step) {
             pnt = drawbins[n];
-            grx = pmain.grx(pnt.x);
+            grx = funcs.grx(pnt.x);
             if ((grx > -this.marker_size) && (grx < w + this.marker_size)) {
-               gry = pmain.gry(pnt.y);
+               gry = funcs.gry(pnt.y);
                if ((gry > -this.marker_size) && (gry < h + this.marker_size))
                   path += this.markeratt.create(grx, gry);
             }
          }
 
-         if (path.length>0) {
+         if (path.length > 0) {
             this.draw_g.append("svg:path")
                        .attr("d", path)
                        .call(this.markeratt.func);
@@ -1482,7 +1496,8 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
              rect = { x1: -d.width/2, x2: d.width/2, y1: 0, y2: height - d.gry1 };
 
              if (isbar1) {
-                let yy0 = pmain.gry(0);
+                let funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
+                    yy0 = funcs.gry(0);
                 rect.y1 = (d.gry1 > yy0) ? yy0-d.gry1 : 0;
                 rect.y2 = (d.gry1 > yy0) ? 0 : yy0-d.gry1;
              }
@@ -1570,13 +1585,14 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
           bestbin = null,
           bestdist = 1e10,
           pmain = this.getFramePainter(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           dist, grx, gry, n, bin;
 
-      for (n=0;n<this.bins.length;++n) {
+      for (n = 0; n < this.bins.length; ++n) {
          bin = this.bins[n];
 
-         grx = pmain.grx(bin.x);
-         gry = pmain.gry(bin.y);
+         grx = funcs.grx(bin.x);
+         gry = funcs.gry(bin.y);
 
          dist = (pnt.x-grx)*(pnt.x-grx) + (pnt.y-gry)*(pnt.y-gry);
 
@@ -1595,7 +1611,7 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       if (this.marker_size > 0) radius = Math.max(this.marker_size, radius);
 
       if (bestbin)
-         bestdist = Math.sqrt(Math.pow(pnt.x-pmain.grx(bestbin.x),2) + Math.pow(pnt.y-pmain.gry(bestbin.y),2));
+         bestdist = Math.sqrt(Math.pow(pnt.x-funcs.grx(bestbin.x),2) + Math.pow(pnt.y-funcs.gry(bestbin.y),2));
 
       if (!islines && (bestdist > radius)) bestbin = null;
 
@@ -1611,15 +1627,15 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
             return ((x1>=x) && (x>=x2)) || ((x1<=x) && (x<=x2));
          }
 
-         let bin0 = this.bins[0], grx0 = pmain.grx(bin0.x), gry0, posy = 0;
-         for (n=1;n<this.bins.length;++n) {
+         let bin0 = this.bins[0], grx0 = funcs.grx(bin0.x), gry0, posy = 0;
+         for (n = 1; n < this.bins.length; ++n) {
             bin = this.bins[n];
-            grx = pmain.grx(bin.x);
+            grx = funcs.grx(bin.x);
 
             if (IsInside(pnt.x, grx0, grx)) {
                // if inside interval, check Y distance
-               gry0 = pmain.gry(bin0.y);
-               gry = pmain.gry(bin.y);
+               gry0 = funcs.gry(bin0.y);
+               gry = funcs.gry(bin.y);
 
                if (Math.abs(grx - grx0) < 1) {
                   // very close x - check only y
@@ -1675,10 +1691,11 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       let islines = (this.draw_kind=="lines"),
           ismark = (this.draw_kind=="mark"),
           pmain = this.getFramePainter(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           gr = this.getObject(),
           res = { name: gr.fName, title: gr.fTitle,
-                  x: best.bin ? pmain.grx(best.bin.x) : best.linex,
-                  y: best.bin ? pmain.gry(best.bin.y) : best.liney,
+                  x: best.bin ? funcs.grx(best.bin.x) : best.linex,
+                  y: best.bin ? funcs.gry(best.bin.y) : best.liney,
                   color1: this.lineatt.color,
                   lines: this.getTooltips(best.bin),
                   usepath: true };
@@ -1691,10 +1708,10 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
          res.menu_dist = best.linedist;
       } else if (best.bin) {
          if (this.options.EF && islines) {
-            res.gry1 = pmain.gry(best.bin.y - best.bin.eylow);
-            res.gry2 = pmain.gry(best.bin.y + best.bin.eyhigh);
+            res.gry1 = funcs.gry(best.bin.y - best.bin.eylow);
+            res.gry2 = funcs.gry(best.bin.y + best.bin.eyhigh);
          } else {
-            res.gry1 = res.gry2 = pmain.gry(best.bin.y);
+            res.gry1 = res.gry2 = funcs.gry(best.bin.y);
          }
 
          res.binindx = best.indx;
@@ -1708,7 +1725,8 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
          res.menu_dist = Math.sqrt((pnt.x-res.x)*(pnt.x-res.x) + Math.pow(Math.min(Math.abs(pnt.y-res.gry1),Math.abs(pnt.y-res.gry2)),2));
       }
 
-      if (this.fillatt && this.fillatt.used && !this.fillatt.empty()) res.color2 = this.fillatt.getFillColor();
+      if (this.fillatt && this.fillatt.used && !this.fillatt.empty())
+         res.color2 = this.fillatt.getFillColor();
 
       if (!islines) {
          res.color1 = this.getColor(gr.fMarkerColor);
@@ -1787,9 +1805,10 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       if (hint && hint.exact && (hint.binindx !== undefined)) {
          this.move_binindx = hint.binindx;
          this.move_bin = hint.bin;
-         let main = this.getFramePainter();
-         this.move_x0 = main ? main.grx(this.move_bin.x) : x;
-         this.move_y0 = main ? main.gry(this.move_bin.y) : y;
+         let pmain = this.getFramePainter(),
+             funcs = pmain ? pmain.getGrFuncs(this.options.second_x, this.options.second_y) : null;
+         this.move_x0 = funcs ? funcs.grx(this.move_bin.x) : x;
+         this.move_y0 = funcs ? funcs.gry(this.move_bin.y) : y;
       } else {
          delete this.move_binindx;
       }
@@ -1803,10 +1822,11 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       if (this.move_binindx === undefined) {
          this.draw_g.attr("transform", "translate(" + this.pos_dx + "," + this.pos_dy + ")");
       } else {
-         let main = this.getFramePainter();
-         if (main && this.move_bin) {
-            this.move_bin.x = main.revertAxis("x", this.move_x0 + this.pos_dx);
-            this.move_bin.y = main.revertAxis("y", this.move_y0 + this.pos_dy);
+         let pmain = this.getFramePainter(),
+             funcs = pmain ? pmain.getGrFuncs(this.options.second_x, this.options.second_y) : null;
+         if (funcs && this.move_bin) {
+            this.move_bin.x = funcs.revertAxis("x", this.move_x0 + this.pos_dx);
+            this.move_bin.y = funcs.revertAxis("y", this.move_y0 + this.pos_dy);
             this.drawGraph();
          }
       }
@@ -1820,12 +1840,13 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
          this.draw_g.attr("transform", null);
 
-         let main = this.getFramePainter();
-         if (main && this.bins && !not_changed) {
-            for (let k=0;k<this.bins.length;++k) {
+         let pmain = this.getFramePainter(),
+             funcs = pmain ? pmain.getGrFuncs(this.options.second_x, this.options.second_y) : null;
+         if (funcs && this.bins && !not_changed) {
+            for (let k = 0; k < this.bins.length; ++k) {
                let bin = this.bins[k];
-               bin.x = main.revertAxis("x", main.grx(bin.x) + this.pos_dx);
-               bin.y = main.revertAxis("y", main.gry(bin.y) + this.pos_dy);
+               bin.x = funcs.revertAxis("x", funcs.grx(bin.x) + this.pos_dx);
+               bin.y = funcs.revertAxis("y", funcs.gry(bin.y) + this.pos_dy);
                exec += "SetPoint(" + bin.indx + "," + bin.x + "," + bin.y + ");;";
                if ((bin.indx == 0) && this.matchObjectType('TCutG'))
                   exec += "SetPoint(" + (this.getObject().fNpoints-1) + "," + bin.x + "," + bin.y + ");;";
@@ -1859,19 +1880,19 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
    TGraphPainter.prototype.executeMenuCommand = function(method, args) {
       if (JSROOT.ObjectPainter.prototype.executeMenuCommand.call(this,method,args)) return true;
 
-      let canp = this.getCanvPainter(), fp = this.getFramePainter();
+      let canp = this.getCanvPainter(), pmain = this.getFramePainter();
 
       if ((method.fName == 'RemovePoint') || (method.fName == 'InsertPoint')) {
-         let pnt = fp ? fp.getLastEventPos() : null;
+         let pnt = pmain ? pmain.getLastEventPos() : null;
 
          if (!canp || canp._readonly || !pnt) return true; // ignore function
 
          let hint = this.extractTooltip(pnt);
 
          if (method.fName == 'InsertPoint') {
-            let main = this.getFramePainter(),
-                userx = main ? main.revertAxis("x", pnt.x) : 0,
-                usery = main ? main.revertAxis("y", pnt.y) : 0;
+            let funcs = pmain ? pmain.getGrFuncs(this.options.second_x, this.options.second_y) : null,
+                userx = funcs ? funcs.revertAxis("x", pnt.x) : 0,
+                usery = funcs ? funcs.revertAxis("y", pnt.y) : 0;
             canp.showMessage('InsertPoint(' + userx.toFixed(3) + ',' + usery.toFixed(3) + ') not yet implemented');
          } else if (this.args_menu_id && hint && (hint.binindx !== undefined)) {
             this.submitCanvExec("RemovePoint(" + hint.binindx + ")", this.args_menu_id);
@@ -2054,7 +2075,7 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
       let promise = Promise.resolve();
 
-      if (!painter.getMainPainter() && painter.options.HOptions) {
+      if ((!painter.getMainPainter() || painter.options.second_x || painter.options.second_y) && painter.options.HOptions) {
          let histo = painter.createHistogram();
          promise = JSROOT.draw(divid, histo, painter.options.HOptions).then(hist_painter => {
             if (hist_painter) {
@@ -2068,7 +2089,6 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       return promise.then(() => {
          painter.addToPadPrimitives();
          return painter.drawGraph();
-         // wait until interactive elements assigned
       }).then(() => painter.drawNextFunction(0));
    }
 
@@ -2405,10 +2425,12 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
    TGraphPolarPainter.prototype = Object.create(JSROOT.ObjectPainter.prototype);
 
+   /** @summary Redraw TGraphPolar */
    TGraphPolarPainter.prototype.redraw = function() {
       this.drawGraphPolar();
    }
 
+   /** @summary Decode options for drawing TGraphPolar */
    TGraphPolarPainter.prototype.decodeOptions = function(opt) {
 
       let d = new JSROOT.DrawOptions(opt || "L");
@@ -2426,6 +2448,7 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       this.storeDrawOpt(opt);
    }
 
+   /** @summary Drawing TGraphPolar */
    TGraphPolarPainter.prototype.drawGraphPolar = function() {
       let graph = this.getObject(),
           main = this.getMainPainter();
@@ -2502,7 +2525,6 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
          this.draw_g.append("svg:path")
                .attr("d",mpath)
                .call(this.markeratt.func);
-
    }
 
    /** @summary Create polargram object
@@ -2673,7 +2695,9 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       return knot.fY + dx;
    }
 
-   TSplinePainter.prototype.FindX = function(x) {
+   /** @summary Find idex for x value
+     * @private */
+   TSplinePainter.prototype.findX = function(x) {
       let spline = this.getObject(),
           klow = 0, khig = spline.fNp - 1;
 
@@ -2743,19 +2767,20 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       let cleanup = false,
           spline = this.getObject(),
           main = this.getFramePainter(),
+          funcs = main ? main.getGrFuncs(this.options.second_x, this.options.second_y) : null,
           xx, yy, knot = null, indx = 0;
 
-      if ((pnt === null) || !spline || !main) {
+      if ((pnt === null) || !spline || !funcs) {
          cleanup = true;
       } else {
-         xx = main.revertAxis("x", pnt.x);
-         indx = this.FindX(xx);
+         xx = funcs.revertAxis("x", pnt.x);
+         indx = this.findX(xx);
          knot = spline.fPoly[indx];
          yy = this.eval(knot, xx);
 
          if ((indx < spline.fN-1) && (Math.abs(spline.fPoly[indx+1].fX-xx) < Math.abs(xx-knot.fX))) knot = spline.fPoly[++indx];
 
-         if (Math.abs(main.grx(knot.fX) - pnt.x) < 0.5*this.knot_size) {
+         if (Math.abs(funcs.grx(knot.fX) - pnt.x) < 0.5*this.knot_size) {
             xx = knot.fX; yy = knot.fY;
          } else {
             knot = null;
@@ -2782,11 +2807,11 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
       let res = { name: this.getObject().fName,
                   title: this.getObject().fTitle,
-                  x: main.grx(xx),
-                  y: main.gry(yy),
+                  x: funcs.grx(xx),
+                  y: funcs.gry(yy),
                   color1: this.lineatt.color,
                   lines: [],
-                  exact: (knot !== null) || (Math.abs(main.gry(yy) - pnt.y) < radius) };
+                  exact: (knot !== null) || (Math.abs(funcs.gry(yy) - pnt.y) < radius) };
 
       res.changed = gbin.property("current_xx") !== xx;
       res.menu = res.exact;
@@ -2799,8 +2824,8 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
       let name = this.getObjectHint();
       if (name.length > 0) res.lines.push(name);
-      res.lines.push("x = " + main.axisAsText("x", xx));
-      res.lines.push("y = " + main.axisAsText("y", yy));
+      res.lines.push("x = " + funcs.axisAsText("x", xx));
+      res.lines.push("y = " + funcs.axisAsText("y", yy));
       if (knot !== null) {
          res.lines.push("knot = " + indx);
          res.lines.push("B = " + jsrp.floatToString(knot.fB, JSROOT.gStyle.fStatFormat));
@@ -2815,10 +2840,13 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       return res;
    }
 
+   /** @summary Redraw object
+     * @private */
    TSplinePainter.prototype.redraw = function() {
 
       let spline = this.getObject(),
           pmain = this.getFramePainter(),
+          funcs = pmain ? pmain.getGrFuncs(this.options.second_x, this.options.second_y) : null,
           w = pmain.getFrameWidth(),
           h = pmain.getFrameHeight();
 
@@ -2834,7 +2862,7 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
          let xmin = Math.max(pmain.scale_xmin, spline.fXmin),
              xmax = Math.min(pmain.scale_xmax, spline.fXmax),
-             indx = this.FindX(xmin),
+             indx = this.findX(xmin),
              bins = []; // index of current knot
 
          if (pmain.logx) {
@@ -2850,12 +2878,12 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
             let yy = this.eval(spline.fPoly[indx], xx);
 
-            bins.push({ x: xx, y: yy, grx: pmain.grx(xx), gry: pmain.gry(yy) });
+            bins.push({ x: xx, y: yy, grx: funcs.grx(xx), gry: funcs.gry(yy) });
          }
 
          let h0 = h;  // use maximal frame height for filling
-         if ((pmain.hmin!==undefined) && (pmain.hmin>=0)) {
-            h0 = Math.round(pmain.gry(0));
+         if ((pmain.hmin!==undefined) && (pmain.hmin >= 0)) {
+            h0 = Math.round(funcs.gry(0));
             if ((h0 > h) || (h0 < 0)) h0 = h;
          }
 
@@ -2881,9 +2909,9 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
 
          for (let n=0; n<spline.fPoly.length; n++) {
             let knot = spline.fPoly[n],
-                grx = pmain.grx(knot.fX);
+                grx = funcs.grx(knot.fX);
             if ((grx > -this.knot_size) && (grx < w + this.knot_size)) {
-               let gry = pmain.gry(knot.fY);
+               let gry = funcs.gry(knot.fY);
                if ((gry > -this.knot_size) && (gry < h + this.knot_size)) {
                   path += this.markeratt.create(grx, gry);
                }
@@ -2895,7 +2923,6 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
                        .attr("d", path)
                        .call(this.markeratt.func);
       }
-
    }
 
    /** @summary Checks if it makes sense to zoom inside specified axis range */
@@ -2909,17 +2936,29 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       return true;
    }
 
+   /** @summary Decode options for TSpline drawing */
    TSplinePainter.prototype.decodeOptions = function(opt) {
       let d = new JSROOT.DrawOptions(opt);
 
       if (!this.options) this.options = {};
 
+      let has_main = !!this.getMainPainter();
+
       JSROOT.extend(this.options, {
          Same: d.check('SAME'),
          Line: d.check('L'),
          Curve: d.check('C'),
-         Mark: d.check('P')
+         Mark: d.check('P'),
+         Hopt: "AXIS",
+         second_x: false,
+         second_y: false
       });
+
+      if (!this.options.Line && !this.options.Curve && !this.options.Mark)
+         this.options.Curve = true;
+
+      if (d.check("X+")) { this.options.Hopt += "X+"; this.options.second_x = has_main; }
+      if (d.check("Y+")) { this.options.Hopt += "Y+"; this.options.second_y = has_main; }
 
       this.storeDrawOpt(opt);
    }
@@ -2928,14 +2967,14 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       let painter = new TSplinePainter(divid, spline);
       painter.decodeOptions(opt);
 
-      let promise = Promise.resolve();
-      if (!painter.getMainPainter()) {
-         if (painter.options.Same) {
+      let promise = Promise.resolve(), no_main = !painter.getMainPainter();
+      if (no_main || painter.options.second_x || painter.options.second_y) {
+         if (painter.options.Same && no_main) {
             console.warn('TSpline painter requires histogram to be drawn');
             return null;
          }
          let histo = painter.createDummyHisto();
-         promise = JSROOT.draw(divid, histo, "AXIS");
+         promise = JSROOT.draw(divid, histo, painter.options.Hopt);
       }
 
       return promise.then(() => {

--- a/js/scripts/JSRoot.v7hist.js
+++ b/js/scripts/JSRoot.v7hist.js
@@ -266,8 +266,16 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
       let main = this.getFramePainter();
       if (!main) return Promise.resolve(false);
 
-      if (!this.isMainPainter() || !this.draw_content)
-        return Promise.resolve(true);
+      if (!this.draw_content)
+         return Promise.resolve(true);
+
+      if (!this.isMainPainter()) {
+         if (!this.options.second_x && !this.options.second_y)
+            return Promise.resolve(true);
+
+         main.setAxes2Ranges(this.options.second_x, this.getAxis("x"), this.xmin, this.xmax, this.options.second_y, this.getAxis("y"), this.ymin, this.ymax);
+         return main.drawAxes2(this.options.second_x, this.options.second_y);
+      }
 
       main.cleanupAxes();
       main.xmin = main.xmax = 0;
@@ -344,6 +352,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
             default: axis = obj.fAxes[0]; break;
          }
       } else if (histo && histo.fAxes) {
+         // console.log('histo fAxes', histo.fAxes, histo.fAxes._0)
          switch(name) {
             case "x": axis = histo.fAxes._0; break;
             case "y": axis = histo.fAxes._1; break;
@@ -408,11 +417,10 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
    RHistPainter.prototype.addInteractivity = function() {
       // only first painter in list allowed to add interactive functionality to the frame
 
-      if (JSROOT.batch_mode || !this.isMainPainter())
-         return true;
-
-      let fp = this.getFramePainter();
-      return fp ? fp.addInteractivity() : false;
+      let ismain =  this.isMainPainter(),
+          second_axis = this.options.second_x || this.options.second_y,
+          fp = ismain || second_axis ? this.getFramePainter() : null;
+      return fp ? fp.addInteractivity(!ismain && second_axis) : Promise.resolve(true);
    }
 
    /** @summary Process item reply */
@@ -474,9 +482,13 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
    RHistPainter.prototype.getSelectIndex = function(axis, size, add) {
       // be aware - here indexes starts from 0
       let indx = 0,
-          main = this.getFramePainter(),
           taxis = this.getAxis(axis),
-          nbins = this['nbins'+axis] || 0,
+          nbins = this['nbins'+axis] || 0;
+
+      if (this.options.second_x && axis == "x") axis = "x2";
+      if (this.options.second_y && axis == "y") axis = "y2";
+
+      let main = this.getFramePainter(),
           min = main ? main['zoom_' + axis + 'min'] : 0,
           max = main ? main['zoom_' + axis + 'max'] : 0;
 
@@ -824,12 +836,14 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
       if (args.pixel_density) args.rounding = true;
 
+      let funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y);
+
        // calculate graphical coordinates in advance
       for (i = res.i1; i <= res.i2; ++i) {
          x = xaxis.GetBinCoord(i + args.middle);
-         if (pmain.logx && (x <= 0)) { res.i1 = i+1; continue; }
+         if (funcs.logx && (x <= 0)) { res.i1 = i+1; continue; }
          if (res.origx) res.origx[i] = x;
-         res.grx[i] = pmain.grx(x);
+         res.grx[i] = funcs.grx(x);
          if (args.rounding) res.grx[i] = Math.round(res.grx[i]);
 
          if (args.use3d) {
@@ -847,15 +861,15 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
       while (i < res.i2 + res.stepi + 1)
          res.grx[i++] = res.grx[res.i2];
 
-      if (hdim===1) {
-         res.gry[0] = pmain.gry(0);
-         res.gry[1] = pmain.gry(1);
+      if (hdim === 1) {
+         res.gry[0] = funcs.gry(0);
+         res.gry[1] = funcs.gry(1);
       } else
       for (j = res.j1; j <= res.j2; ++j) {
          y = yaxis.GetBinCoord(j + args.middle);
-         if (pmain.logy && (y <= 0)) { res.j1 = j+1; continue; }
+         if (funcs.logy && (y <= 0)) { res.j1 = j+1; continue; }
          if (res.origy) res.origy[j] = y;
-         res.gry[j] = pmain.gry(y);
+         res.gry[j] = funcs.gry(y);
          if (args.rounding) res.gry[j] = Math.round(res.gry[j]);
 
          if (args.use3d) {
@@ -1127,7 +1141,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
    /** @summary Draw histogram as bars
      * @private */
-   RH1Painter.prototype.drawBars = function(handle, width, height) {
+   RH1Painter.prototype.drawBars = function(handle, funcs, width, height) {
 
       this.createG(true);
 
@@ -1139,21 +1153,21 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
       gry2 = pmain.swap_xy ? 0 : height;
       if (Number.isFinite(this.options.BaseLine))
-         if (this.options.BaseLine >= pmain.scale_ymin)
-            gry2 = Math.round(pmain.gry(this.options.BaseLine));
+         if (this.options.BaseLine >= funcs.scale_ymin)
+            gry2 = Math.round(funcs.gry(this.options.BaseLine));
 
       for (i = left; i < right; i += di) {
          x1 = xaxis.GetBinCoord(i);
          x2 = xaxis.GetBinCoord(i+di);
 
-         if (pmain.logx && (x2 <= 0)) continue;
+         if (funcs.logx && (x2 <= 0)) continue;
 
-         grx1 = Math.round(pmain.grx(x1));
-         grx2 = Math.round(pmain.grx(x2));
+         grx1 = Math.round(funcs.grx(x1));
+         grx2 = Math.round(funcs.grx(x2));
 
          y = histo.getBinContent(i+1);
-         if (pmain.logy && (y < pmain.scale_ymin)) continue;
-         gry1 = Math.round(pmain.gry(y));
+         if (funcs.logy && (y < funcs.scale_ymin)) continue;
+         gry1 = Math.round(funcs.gry(y));
 
          w = grx2 - grx1;
          grx1 += Math.round(this.options.BarOffset*w);
@@ -1199,26 +1213,25 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
    /** @summary Draw histogram as filled errors
      * @private */
-   RH1Painter.prototype.drawFilledErrors = function(handle /*, width, height*/) {
+   RH1Painter.prototype.drawFilledErrors = function(handle, funcs /*, width, height*/) {
       this.createG(true);
 
       let left = handle.i1, right = handle.i2, di = handle.stepi,
-          pmain = this.getFramePainter(),
           histo = this.getHisto(), xaxis = this.getAxis("x"),
           i, x, grx, y, yerr, gry1, gry2,
           bins1 = [], bins2 = [];
 
       for (i = left; i < right; i += di) {
          x = xaxis.GetBinCoord(i+0.5);
-         if (pmain.logx && (x <= 0)) continue;
-         grx = Math.round(pmain.grx(x));
+         if (funcs.logx && (x <= 0)) continue;
+         grx = Math.round(funcs.grx(x));
 
          y = histo.getBinContent(i+1);
          yerr = histo.getBinError(i+1);
-         if (pmain.logy && (y-yerr < pmain.scale_ymin)) continue;
+         if (funcs.logy && (y-yerr < funcs.scale_ymin)) continue;
 
-         gry1 = Math.round(pmain.gry(y + yerr));
-         gry2 = Math.round(pmain.gry(y - yerr));
+         gry1 = Math.round(funcs.gry(y + yerr));
+         gry2 = Math.round(funcs.gry(y - yerr));
 
          bins1.push({grx:grx, gry: gry1});
          bins2.unshift({grx:grx, gry: gry2});
@@ -1239,27 +1252,29 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
    /** @summary Draw 1D histogram as SVG */
    RH1Painter.prototype.draw1DBins = function() {
 
-      let rect = this.getFramePainter().getFrameRect();
+      let pmain = this.getFramePainter(),
+          rect = pmain.getFrameRect();
 
       if (!this.draw_content || (rect.width <= 0) || (rect.height <= 0))
          return this.removeG();
 
       this.createHistDrawAttributes();
 
-      let handle = this.prepareDraw({ extra: 1, only_indexes: true });
+      let handle = this.prepareDraw({ extra: 1, only_indexes: true }),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y);
 
       if (this.options.Bar)
-         return this.drawBars(handle, rect.width, rect.height);
+         return this.drawBars(handle, funcs, rect.width, rect.height);
 
       if ((this.options.ErrorKind === 3) || (this.options.ErrorKind === 4))
-         return this.drawFilledErrors(handle, rect.width, rect.height);
+         return this.drawFilledErrors(handle, funcs, rect.width, rect.height);
 
-      return this.drawHistBins(handle, rect.width, rect.height);
+      return this.drawHistBins(handle, funcs, rect.width, rect.height);
    }
 
    /** @summary Draw histogram bins
      * @private */
-   RH1Painter.prototype.drawHistBins = function(handle, width, height) {
+   RH1Painter.prototype.drawHistBins = function(handle, funcs, width, height) {
       this.createG(true);
 
       let options = this.options,
@@ -1336,15 +1351,15 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
       let draw_bin = besti => {
          bincont = histo.getBinContent(besti+1);
          if (!exclude_zero || (bincont!==0)) {
-            mx1 = Math.round(pmain.grx(xaxis.GetBinCoord(besti)));
-            mx2 = Math.round(pmain.grx(xaxis.GetBinCoord(besti+di)));
+            mx1 = Math.round(funcs.grx(xaxis.GetBinCoord(besti)));
+            mx2 = Math.round(funcs.grx(xaxis.GetBinCoord(besti+di)));
             midx = Math.round((mx1+mx2)/2);
-            my = Math.round(pmain.gry(bincont));
+            my = Math.round(funcs.gry(bincont));
             yerr1 = yerr2 = 20;
             if (show_errors) {
                binerr = histo.getBinError(besti+1);
-               yerr1 = Math.round(my - pmain.gry(bincont + binerr)); // up
-               yerr2 = Math.round(pmain.gry(bincont - binerr) - my); // down
+               yerr1 = Math.round(my - funcs.gry(bincont + binerr)); // up
+               yerr2 = Math.round(funcs.gry(bincont - binerr) - my); // down
             }
 
             if (show_text) {
@@ -1387,9 +1402,9 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
          x = xaxis.GetBinCoord(i);
 
-         if (pmain.logx && (x <= 0)) continue;
+         if (funcs.logx && (x <= 0)) continue;
 
-         grx = Math.round(pmain.grx(x));
+         grx = Math.round(funcs.grx(x));
 
          lastbin = (i > right - di);
 
@@ -1397,7 +1412,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
             gry = curry;
          } else {
             y = histo.getBinContent(i+1);
-            gry = Math.round(pmain.gry(y));
+            gry = Math.round(funcs.gry(y));
          }
 
          if (res.length === 0) {
@@ -1467,7 +1482,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
       if (!this.fillatt.empty() || fill_for_interactive) {
          let h0 = height + 3;
          if (fill_for_interactive) {
-            let gry0 = Math.round(pmain.gry(0));
+            let gry0 = Math.round(funcs.gry(0));
             if (gry0 <= 0) h0 = -3; else if (gry0 < height) h0 = gry0;
          }
          close_path = "L"+currx+","+h0 + "L"+startx+","+h0 + "Z";
@@ -1562,6 +1577,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
       }
 
       let pmain = this.getFramePainter(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           width = pmain.getFrameWidth(),
           height = pmain.getFrameHeight(),
           histo = this.getHisto(), xaxis = this.getAxis("x"),
@@ -1573,33 +1589,33 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
       function GetBinGrX(i) {
          let xx = xaxis.GetBinCoord(i);
-         return (pmain.logx && (xx<=0)) ? null : pmain.grx(xx);
+         return (funcs.logx && (xx<=0)) ? null : funcs.grx(xx);
       }
 
       function GetBinGrY(i) {
          let yy = histo.getBinContent(i + 1);
-         if (pmain.logy && (yy < pmain.scale_ymin))
-            return pmain.swap_xy ? -1000 : 10*height;
-         return Math.round(pmain.gry(yy));
+         if (funcs.logy && (yy < funcs.scale_ymin))
+            return funcs.swap_xy ? -1000 : 10*height;
+         return Math.round(funcs.gry(yy));
       }
 
-      let pnt_x = pmain.swap_xy ? pnt.y : pnt.x,
-          pnt_y = pmain.swap_xy ? pnt.x : pnt.y;
+      let pnt_x = funcs.swap_xy ? pnt.y : pnt.x,
+          pnt_y = funcs.swap_xy ? pnt.x : pnt.y;
 
       while (l < r-1) {
          let m = Math.round((l+r)*0.5),
              xx = GetBinGrX(m);
          if ((xx === null) || (xx < pnt_x - 0.5)) {
-            if (pmain.swap_xy) r = m; else l = m;
+            if (funcs.swap_xy) r = m; else l = m;
          } else if (xx > pnt_x + 0.5) {
-            if (pmain.swap_xy) l = m; else r = m;
+            if (funcs.swap_xy) l = m; else r = m;
          } else { l++; r--; }
       }
 
       findbin = r = l;
       grx1 = GetBinGrX(findbin);
 
-      if (pmain.swap_xy) {
+      if (funcs.swap_xy) {
          while ((l>left) && (GetBinGrX(l-1) < grx1 + 2)) --l;
          while ((r<right) && (GetBinGrX(r+1) > grx1 - 2)) ++r;
       } else {
@@ -1643,7 +1659,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
          gapx = 0;
 
-         gry1 = Math.round(pmain.gry(((this.options.BaseLine!==false) && (this.options.BaseLine > pmain.scale_ymin)) ? this.options.BaseLine : pmain.scale_ymin));
+         gry1 = Math.round(funcs.gry(((this.options.BaseLine!==false) && (this.options.BaseLine > funcs.scale_ymin)) ? this.options.BaseLine : funcs.scale_ymin));
 
          if (gry1 > gry2) { let d = gry1; gry1 = gry2; gry2 = d; }
 
@@ -1661,8 +1677,8 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
             let cont = histo.getBinContent(findbin+1),
                 binerr = histo.getBinError(findbin+1);
 
-            gry1 = Math.round(pmain.gry(cont + binerr)); // up
-            gry2 = Math.round(pmain.gry(cont - binerr)); // down
+            gry1 = Math.round(funcs.gry(cont + binerr)); // up
+            gry2 = Math.round(funcs.gry(cont - binerr)); // down
 
             if ((cont==0) && this.isRProfile()) findbin = null;
 
@@ -1694,7 +1710,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
             gry2 = height;
 
             if (!this.fillatt.empty()) {
-               gry2 = Math.round(pmain.gry(0));
+               gry2 = Math.round(funcs.gry(0));
                if (gry2 < 0) gry2 = 0; else if (gry2 > height) gry2 = height;
                if (gry2 < gry1) { let d = gry1; gry1 = gry2; gry2 = d; }
             }
@@ -1902,11 +1918,14 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
          let kind = painter.v7EvalAttr("kind", "hist"),
              sub = painter.v7EvalAttr("sub", 0),
+             has_main = !!painter.getMainPainter(),
              o = painter.options;
 
          o.Text = painter.v7EvalAttr("text", false);
          o.BarOffset = painter.v7EvalAttr("bar_offset", 0.);
          o.BarWidth = painter.v7EvalAttr("bar_width", 1.);
+         o.second_x = has_main && painter.v7EvalAttr("secondx", false);
+         o.second_y = has_main && painter.v7EvalAttr("secondy", false);
 
          switch(kind) {
             case "bar": o.Bar = true; o.BarStyle = sub; break;
@@ -2569,7 +2588,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
    /** @summary Draw histogram bins as contour
      * @private */
-   RH2Painter.prototype.drawBinsContour = function(frame_w,frame_h) {
+   RH2Painter.prototype.drawBinsContour = function(funcs, frame_w,frame_h) {
       let handle = this.prepareDraw({ rounding: false, extra: 100, original: this.options.Proj != 0 }),
           main = this.getFramePainter(),
           palette = main.getHistPalette(),
@@ -2581,8 +2600,8 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
          for (let i = iminus; i <= iplus; ++i) {
             if (func) {
                pnt = func(xp[i], yp[i]);
-               pnt.x = Math.round(main.grx(pnt.x));
-               pnt.y = Math.round(main.gry(pnt.y));
+               pnt.x = Math.round(funcs.grx(pnt.x));
+               pnt.y = Math.round(funcs.gry(pnt.y));
             } else {
                pnt = { x: Math.round(xp[i]), y: Math.round(yp[i]) };
             }
@@ -2660,7 +2679,8 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
    }
 
    RH2Painter.prototype.createPolyBin = function(pmain, bin, text_pos) {
-      let cmd = "", ngr, ngraphs = 1, gr = null;
+      let cmd = "", ngr, ngraphs = 1, gr = null,
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y);
 
       if (bin.fPoly._typename=='TMultiGraph')
          ngraphs = bin.fPoly.fGraphs.arr.length;
@@ -2682,8 +2702,8 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
          let npnts = gr.fNpoints, n,
              x = gr.fX, y = gr.fY,
-             grx = Math.round(pmain.grx(x[0])),
-             gry = Math.round(pmain.gry(y[0])),
+             grx = Math.round(funcs.grx(x[0])),
+             gry = Math.round(funcs.gry(y[0])),
              nextx, nexty;
 
          if ((npnts>2) && (x[0]==x[npnts-1]) && (y[0]==y[npnts-1])) npnts--;
@@ -2691,8 +2711,8 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
          cmd += "M"+grx+","+gry;
 
          for (n=1;n<npnts;++n) {
-            nextx = Math.round(pmain.grx(x[n]));
-            nexty = Math.round(pmain.gry(y[n]));
+            nextx = Math.round(funcs.grx(x[n]));
+            nexty = Math.round(funcs.gry(y[n]));
             if (text_pos) addPoint(grx,gry, nextx, nexty);
             if ((grx!==nextx) || (gry!==nexty)) {
                if (grx===nextx)
@@ -2705,7 +2725,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
             grx = nextx; gry = nexty;
          }
 
-         if (text_pos) addPoint(grx, gry, Math.round(pmain.grx(x[0])), Math.round(pmain.gry(y[0])));
+         if (text_pos) addPoint(grx, gry, Math.round(funcs.grx(x[0])), Math.round(funcs.gry(y[0])));
          cmd += "z";
       }
 
@@ -2714,8 +2734,8 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
             bin._midx = Math.round(bin._sumx / bin._suml);
             bin._midy = Math.round(bin._sumy / bin._suml);
          } else {
-            bin._midx = Math.round(pmain.grx((bin.fXmin + bin.fXmax)/2));
-            bin._midy = Math.round(pmain.gry((bin.fYmin + bin.fYmax)/2));
+            bin._midx = Math.round(funcs.grx((bin.fXmin + bin.fXmax)/2));
+            bin._midy = Math.round(funcs.gry((bin.fYmin + bin.fYmax)/2));
          }
       }
 
@@ -3043,7 +3063,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
    /** @summary Draw histogram bins as candle plot
      * @private */
-   RH2Painter.prototype.drawBinsCandle = function(w) {
+   RH2Painter.prototype.drawBinsCandle = function(funcs, w) {
       let histo = this.getHisto(), yaxis = this.getAxis("y"),
           handle = this.prepareDraw(),
           pmain = this.getFramePainter(), // used for axis values conversions
@@ -3095,7 +3115,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
          }
 
          // exclude points with negative y when log scale is specified
-         if (pmain.logy && (pnt.whiskerm<=0)) continue;
+         if (funcs.logy && (pnt.whiskerm<=0)) continue;
 
          w = handle.grx[i+1] - handle.grx[i];
          w *= 0.66;
@@ -3106,19 +3126,19 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
          pnt.x2 = Math.round(center + w/2);
          center = Math.round(center);
 
-         pnt.y0 = Math.round(pmain.gry(pnt.median));
+         pnt.y0 = Math.round(funcs.gry(pnt.median));
          // mean line
          bars += "M" + pnt.x1 + "," + pnt.y0 + "h" + (pnt.x2-pnt.x1);
 
-         pnt.y1 = Math.round(pmain.gry(pnt.p25y));
-         pnt.y2 = Math.round(pmain.gry(pnt.m25y));
+         pnt.y1 = Math.round(funcs.gry(pnt.p25y));
+         pnt.y2 = Math.round(funcs.gry(pnt.m25y));
 
          // rectangle
          bars += "M" + pnt.x1 + "," + pnt.y1 +
          "v" + (pnt.y2-pnt.y1) + "h" + (pnt.x2-pnt.x1) + "v-" + (pnt.y2-pnt.y1) + "z";
 
-         pnt.yy1 = Math.round(pmain.gry(pnt.whiskerp));
-         pnt.yy2 = Math.round(pmain.gry(pnt.whiskerm));
+         pnt.yy1 = Math.round(funcs.gry(pnt.whiskerp));
+         pnt.yy2 = Math.round(funcs.gry(pnt.whiskerm));
 
          // upper part
          bars += "M" + center + "," + pnt.y1 + "v" + (pnt.yy1-pnt.y1);
@@ -3303,7 +3323,10 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
 
       this.createG(true);
 
-      let rect = this.getFramePainter().getFrameRect(), handle = null;
+      let pmain = this.getFramePainter(),
+          rect = pmain.getFrameRect(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
+          handle = null;
 
       // if (this.lineatt.color == 'none') this.lineatt.color = 'cyan';
 
@@ -3319,9 +3342,9 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
          else if (this.options.Arrow)
             handle = this.drawBinsArrow();
          else if (this.options.Contour > 0)
-            handle = this.drawBinsContour(rect.width, rect.height);
+            handle = this.drawBinsContour(funcs, rect.width, rect.height);
          else if (this.options.Candle)
-            handle = this.drawBinsCandle(rect.width);
+            handle = this.drawBinsCandle(funcs, rect.width);
 
          if (this.options.Text)
             handle = this.drawBinsText(handle);

--- a/tutorials/v7/draw_rh1_twoaxes.cxx
+++ b/tutorials/v7/draw_rh1_twoaxes.cxx
@@ -1,0 +1,64 @@
+/// \file
+/// \ingroup tutorial_v7
+///
+/// This macro generates two RH1D, fills them and draw in RCanvas.
+/// Second histogram uses enables SecondY() draw option to draw separate Y axis on right side
+///
+/// \macro_image (rcanvas_js)
+/// \macro_code
+///
+/// \date 2021-05-17
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+/// \author Sergey Linev <s.linev@gsi.de>
+
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RHist.hxx"
+#include "ROOT/RHistDrawable.hxx"
+#include "ROOT/RFrameTitle.hxx"
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RPad.hxx"
+#include "TRandom.h"
+
+// macro must be here while cling is not capable to load
+// library automatically for outlined function see ROOT-10336
+R__LOAD_LIBRARY(libROOTHistDraw)
+
+using namespace ROOT::Experimental;
+
+void draw_rh1_twoaxes()
+{
+   // Create the histogram.
+   RAxisConfig xaxis(25, 0., 10.);
+   auto pHist1 = std::make_shared<RH1D>(xaxis);
+   auto pHist2 = std::make_shared<RH1D>(xaxis);
+
+   for (int n=0;n<1000;n++)
+      pHist1->Fill(gRandom->Gaus(3,0.8));
+
+   for (int n=0;n<3000;n++)
+      pHist2->Fill(gRandom->Gaus(7,1.2));
+
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create("RH1 with two Y scales");
+
+   // histograms colors
+   auto col1 = RColor::kRed, col2 = RColor::kBlue;
+
+   // default draw option
+   canvas->Draw<RFrameTitle>("Two independent Y axes for histograms");
+   canvas->Draw(pHist1)->AttrLine().SetColor(col1).SetWidth(2);
+   canvas->Draw(pHist2)->SecondY().AttrLine().SetColor(col2).SetWidth(4);
+
+   canvas->GetFrame()->AttrY().SetTicksColor(col1);
+   canvas->GetFrame()->AttrY2().SetTicksColor(col2);
+
+   canvas->SetSize(800, 600);
+   canvas->Show();
+}


### PR DESCRIPTION
For RH1 objects one can enable `SecondX()` or/and `SecondY()` draw option. 
In this case histogram painter will draw extra axes on the frame - fully interactive with zooming, independent log scale, ...
Provide extra attributes for secondary axes in RFrame
Provide example in tutorials: https://jsroot.gsi.de/dev/examples.htm?more#v7_rh1_twoaxes

Now works only with RH1, can be extend for basic objects like RLine, RText, ...
