### PR TITLE
[reve] rename some members to avoid duplication 

### DIFF
--- a/graf3d/eve/inc/TEveTreeTools.h
+++ b/graf3d/eve/inc/TEveTreeTools.h
@@ -21,19 +21,19 @@
 
 class TEveSelectorToEventList : public TSelectorDraw
 {
-   TEveSelectorToEventList(const TEveSelectorToEventList&);            // Not implemented
-   TEveSelectorToEventList& operator=(const TEveSelectorToEventList&); // Not implemented
+   TEveSelectorToEventList(const TEveSelectorToEventList&) = delete;
+   TEveSelectorToEventList& operator=(const TEveSelectorToEventList&) = delete;
 
 protected:
    TEventList* fEvList;
-   TList       fInput;
+   TList       fInputList;
 public:
    TEveSelectorToEventList(TEventList* evl, const char* sel);
 
    virtual Int_t  Version() const { return 1; }
    virtual Bool_t Process(Long64_t entry);
 
-   ClassDef(TEveSelectorToEventList, 1); // TSelector that stores entry numbers of matching TTree entries into an event-list.
+   ClassDef(TEveSelectorToEventList, 2); // TSelector that stores entry numbers of matching TTree entries into an event-list.
 };
 
 /******************************************************************************/
@@ -65,11 +65,11 @@ public:
 
 class TEvePointSelector : public TSelectorDraw
 {
-   TEvePointSelector(const TEvePointSelector&);            // Not implemented
-   TEvePointSelector& operator=(const TEvePointSelector&); // Not implemented
+   TEvePointSelector(const TEvePointSelector&) = delete;
+   TEvePointSelector& operator=(const TEvePointSelector&) = delete;
 
 protected:
-   TTree                  *fTree;
+   TTree                  *fSelectTree;
    TEvePointSelectorConsumer *fConsumer;
 
    TString                 fVarexp;
@@ -78,7 +78,7 @@ protected:
    TString                 fSubIdExp;
    Int_t                   fSubIdNum;
 
-   TList                   fInput;
+   TList                   fInputList;
 
 public:
    TEvePointSelector(TTree* t=0, TEvePointSelectorConsumer* c=0,
@@ -90,8 +90,8 @@ public:
    virtual void  TakeAction();
 
 
-   TTree* GetTree() const   { return fTree; }
-   void   SetTree(TTree* t) { fTree = t; }
+   TTree* GetTree() const   { return fSelectTree; }
+   void   SetTree(TTree* t) { fSelectTree = t; }
 
    TEvePointSelectorConsumer* GetConsumer() const { return fConsumer; }
    void SetConsumer(TEvePointSelectorConsumer* c) { fConsumer = c; }
@@ -107,7 +107,7 @@ public:
 
    Int_t GetSubIdNum() const { return fSubIdNum; }
 
-   ClassDef(TEvePointSelector, 1); // TSelector for direct extraction of point-like data from a Tree.
+   ClassDef(TEvePointSelector, 2); // TSelector for direct extraction of point-like data from a Tree.
 };
 
 #endif

--- a/graf3d/eve/src/TEveTreeTools.cxx
+++ b/graf3d/eve/src/TEveTreeTools.cxx
@@ -32,9 +32,10 @@ ClassImp(TEveSelectorToEventList);
 TEveSelectorToEventList::TEveSelectorToEventList(TEventList* evl, const char* sel) :
    TSelectorDraw(), fEvList(evl)
 {
-   fInput.Add(new TNamed("varexp", ""));
-   fInput.Add(new TNamed("selection", sel));
-   SetInputList(&fInput);
+   fInputList.SetOwner(kTRUE);
+   fInputList.Add(new TNamed("varexp", ""));
+   fInputList.Add(new TNamed("selection", sel));
+   SetInputList(&fInputList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -70,14 +71,15 @@ TEvePointSelector::TEvePointSelector(TTree* t,
                                      const char* vexp, const char* sel) :
    TSelectorDraw(),
 
-   fTree      (t),
+   fSelectTree(t),
    fConsumer  (c),
    fVarexp    (vexp),
    fSelection (sel),
    fSubIdExp  (),
    fSubIdNum  (0)
 {
-   SetInputList(&fInput);
+   fInputList.SetOwner(kTRUE);
+   SetInputList(&fInputList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -99,15 +101,15 @@ Long64_t TEvePointSelector::Select(const char* selection)
    else
       sel = fSelection;
 
-   fInput.Delete();
-   fInput.Add(new TNamed("varexp",    var.Data()));
-   fInput.Add(new TNamed("selection", sel.Data()));
+   fInputList.Delete();
+   fInputList.Add(new TNamed("varexp",    var.Data()));
+   fInputList.Add(new TNamed("selection", sel.Data()));
 
    if (fConsumer)
       fConsumer->InitFill(fSubIdNum);
 
-   if (fTree)
-      fTree->Process(this, "goff");
+   if (fSelectTree)
+      fSelectTree->Process(this, "goff");
 
    return fSelectedRows;
 }
@@ -117,7 +119,7 @@ Long64_t TEvePointSelector::Select(const char* selection)
 
 Long64_t TEvePointSelector::Select(TTree* t, const char* selection)
 {
-   fTree = t;
+   fSelectTree = t;
    return Select(selection);
 }
 

--- a/graf3d/eve7/inc/ROOT/REveTreeTools.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTreeTools.hxx
@@ -30,7 +30,7 @@ class REveSelectorToEventList : public TSelectorDraw
 
 protected:
    TEventList *fEvList{nullptr};
-   TList fInput;
+   TList fInputList;
 
 public:
    REveSelectorToEventList(TEventList *evl, const char *sel);
@@ -39,7 +39,7 @@ public:
    virtual Int_t Version() const { return 1; }
    virtual Bool_t Process(Long64_t entry);
 
-   ClassDef(REveSelectorToEventList, 1); // TSelector that stores entry numbers of matching TTree entries into an event-list.
+   ClassDef(REveSelectorToEventList, 2); // TSelector that stores entry numbers of matching TTree entries into an event-list.
 };
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -79,7 +79,7 @@ class REvePointSelector : public TSelectorDraw
    REvePointSelector &operator=(const REvePointSelector &) = delete;
 
 protected:
-   TTree *fTree{nullptr};
+   TTree *fSelectTree{nullptr};
    REvePointSelectorConsumer *fConsumer{nullptr};
 
    TString fVarexp;
@@ -88,7 +88,7 @@ protected:
    TString fSubIdExp;
    Int_t fSubIdNum;
 
-   TList fInput;
+   TList fInputList;
 
 public:
    REvePointSelector(TTree *t = nullptr, REvePointSelectorConsumer *c = nullptr, const char *vexp = "", const char *sel = "");
@@ -98,8 +98,8 @@ public:
    virtual Long64_t Select(TTree *t, const char *selection = nullptr);
    virtual void TakeAction();
 
-   TTree *GetTree() const { return fTree; }
-   void SetTree(TTree *t) { fTree = t; }
+   TTree *GetTree() const { return fSelectTree; }
+   void SetTree(TTree *t) { fSelectTree = t; }
 
    REvePointSelectorConsumer *GetConsumer() const { return fConsumer; }
    void SetConsumer(REvePointSelectorConsumer *c) { fConsumer = c; }
@@ -115,7 +115,7 @@ public:
 
    Int_t GetSubIdNum() const { return fSubIdNum; }
 
-   ClassDef(REvePointSelector, 1); // TSelector for direct extraction of point-like data from a Tree.
+   ClassDef(REvePointSelector, 2); // TSelector for direct extraction of point-like data from a Tree.
 };
 
 } // namespace Experimental

--- a/graf3d/eve7/src/REveTreeTools.cxx
+++ b/graf3d/eve7/src/REveTreeTools.cxx
@@ -33,6 +33,7 @@ an event-list.
 REveSelectorToEventList::REveSelectorToEventList(TEventList* evl, const char* sel) :
    TSelectorDraw(), fEvList(evl)
 {
+   fInputList.SetOwner(kTRUE);
    fInputList.Add(new TNamed("varexp", ""));
    fInputList.Add(new TNamed("selection", sel));
    SetInputList(&fInputList);
@@ -75,6 +76,7 @@ REvePointSelector::REvePointSelector(TTree* t,
    fSubIdExp  (),
    fSubIdNum  (0)
 {
+   fInputList.SetOwner(kTRUE);
    SetInputList(&fInputList);
 }
 

--- a/graf3d/eve7/src/REveTreeTools.cxx
+++ b/graf3d/eve7/src/REveTreeTools.cxx
@@ -33,9 +33,9 @@ an event-list.
 REveSelectorToEventList::REveSelectorToEventList(TEventList* evl, const char* sel) :
    TSelectorDraw(), fEvList(evl)
 {
-   fInput.Add(new TNamed("varexp", ""));
-   fInput.Add(new TNamed("selection", sel));
-   SetInputList(&fInput);
+   fInputList.Add(new TNamed("varexp", ""));
+   fInputList.Add(new TNamed("selection", sel));
+   SetInputList(&fInputList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -68,14 +68,14 @@ REvePointSelector::REvePointSelector(TTree* t,
                                      const char* vexp, const char* sel) :
    TSelectorDraw(),
 
-   fTree      (t),
+   fSelectTree  (t),
    fConsumer  (c),
    fVarexp    (vexp),
    fSelection (sel),
    fSubIdExp  (),
    fSubIdNum  (0)
 {
-   SetInputList(&fInput);
+   SetInputList(&fInputList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -97,15 +97,15 @@ Long64_t REvePointSelector::Select(const char* selection)
    else
       sel = fSelection;
 
-   fInput.Delete();
-   fInput.Add(new TNamed("varexp",    var.Data()));
-   fInput.Add(new TNamed("selection", sel.Data()));
+   fInputList.Delete();
+   fInputList.Add(new TNamed("varexp",    var.Data()));
+   fInputList.Add(new TNamed("selection", sel.Data()));
 
    if (fConsumer)
       fConsumer->InitFill(fSubIdNum);
 
-   if (fTree)
-      fTree->Process(this, "goff");
+   if (fSelectTree)
+      fSelectTree->Process(this, "goff");
 
    return fSelectedRows;
 }
@@ -115,7 +115,7 @@ Long64_t REvePointSelector::Select(const char* selection)
 
 Long64_t REvePointSelector::Select(TTree *t, const char *selection)
 {
-   fTree = t;
+   fSelectTree = t;
    return Select(selection);
 }
 


### PR DESCRIPTION
TSelectorDraw class already has internally fTree and fInput members,
therefore better not to use them in derived classes,
especially when generating streamer infos for them

Fix small memory leak in these classes