### PR TITLE
The option VLines in plotOn was not implemented properly

### DIFF
--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -377,10 +377,10 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
     // Add two points to make curve jump from 0 to yval at the left end of the plotting range.
     // This ensures that filled polygons are drawn properly. The first point needs to be to the
     // left of the second. Since points are sorted later, its x coordinate is shifted by 1/1000 dx.
-    addPoint(xlo-dx*1.001, 0);
+    addPoint(xlo-dx*0.001, 0);
     addPoint(xlo-dx,yval[0]) ;
   } else if (wmode==Straight) {
-    addPoint(xlo,0) ;
+    addPoint(xlo-dx*0.001,0) ;
   }
 
   addPoint(xlo,yval[0]);
@@ -409,9 +409,9 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
     // Add two points to close polygon. The order matters. Since they are sorted in x later, the second
     // point is shifted by 1/1000 * dx.
     addPoint(xhi+dx,yval[minPoints-1]) ;
-    addPoint(xhi+dx*1.001, 0);
+    addPoint(xhi+dx*0.001, 0);
   } else if (wmode==Straight) {
-    addPoint(xhi,0) ;
+    addPoint(xhi+dx*0.001,0) ;
   }
 }
 


### PR DESCRIPTION
This problem was found [here](https://root-forum.cern.ch/t/unexpected-behavior-of-drawoption-f/44851).
and can be seen also [in this example](https://root.cern/doc/v624/rs701__BayesianCalculator_8C.html)

The fill areas below the curve is not correct. Two points are added at the begging and end of the RooCurve to make the curve jump from 0 to yval at the left end of the plotting range. This ensures that filled polygons are drawn properly. The first point needs to be to the left of the second. The comment said:
"Since points are sorted later, its x coordinate is shifted by 1/1000 dx."
and the code to implement it was `xlo-dx*1.001` ... that's not 1/1000 dx.  the correct implementation is `xlo-dx*0.001`

Similar shift was missing in the case `if (wmode==Straight)`