### PR TITLE
[RF] Partly revert bab22d74786052ce346302f3dac967a60997283d

### DIFF
--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -376,8 +376,8 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
   if (wmode==Extended) {
     // Add two points to make curve jump from 0 to yval at the left end of the plotting range.
     // This ensures that filled polygons are drawn properly. The first point needs to be to the
-    // left of the second. Since points are sorted later, its x coordinate is shifted by 1/1000 dx.
-    addPoint(xlo-dx*0.001, 0);
+    // left of the second, so it's shifted by 1/1000 more than the second.
+    addPoint(xlo-dx*1.001, 0);
     addPoint(xlo-dx,yval[0]) ;
   } else if (wmode==Straight) {
     addPoint(xlo-dx*0.001,0) ;
@@ -407,9 +407,9 @@ void RooCurve::addPoints(const RooAbsFunc &func, Double_t xlo, Double_t xhi,
 
   if (wmode==Extended) {
     // Add two points to close polygon. The order matters. Since they are sorted in x later, the second
-    // point is shifted by 1/1000 * dx.
+    // point is shifted by 1/1000 more than the second-to-last point.
     addPoint(xhi+dx,yval[minPoints-1]) ;
-    addPoint(xhi+dx*0.001, 0);
+    addPoint(xhi+dx*1.001, 0);
   } else if (wmode==Straight) {
     addPoint(xhi+dx*0.001,0) ;
   }


### PR DESCRIPTION
In bab22d74786052ce346302f3dac967a60997283d, #8198, the extended plotting
option of RooCurve was broken in an attempt to fix polygons created
using the VLines() plotting option.

While the `VLines()` (`wmode==Straight`) indeed needed fixing, `wmode==Extended`
worked as intended, see [ROOT-10931](https://sft.its.cern.ch/jira/browse/ROOT-10931) + its forum link.

The comment for `wmode==Extended` was clarified a bit to prevent future
confusion.