### PR TITLE
[skip-ci] a slash was missing

### DIFF
--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -1,8 +1,8 @@
 /// \file
 /// \ingroup tutorial_v7
-//
+///
 /// This ROOT 7 example demonstrates how to create a ROOT 7 canvas (RCanvas),
-/// divide on subpads and draw histograms there
+/// divide on sub-pads and draw histograms there
 ///
 /// \macro_image (rcanvas_js)
 /// \macro_code


### PR DESCRIPTION
This tutorial was not properly displayed in the ref guide.