### PR TITLE
[RF] Fix function signature of `operator<<()` in RooAbsArg.cxx

### DIFF
--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1516,7 +1516,7 @@ void RooAbsArg::printTree(ostream& os, TString /*indent*/) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Ostream operator
 
-ostream& operator<<(ostream& os, RooAbsArg &arg)
+ostream& operator<<(ostream& os, RooAbsArg const& arg)
 {
   arg.writeToStream(os,kTRUE) ;
   return os ;


### PR DESCRIPTION
The signature has to match the declaration in RooAbsArg.h:

```C++
std::ostream& operator<<(std::ostream& os, const RooAbsArg &arg);
```

This problem was spotted by users in the forum:
https://root-forum.cern.ch/t/error-while-extracting-getrealvalue-of-roorealvar-defined-with-range/44922/6