### PR TITLE
[ntuple] perf: Use map::find instead of map::count

### DIFF
--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -480,7 +480,7 @@ std::unordered_set<ROOT::Experimental::DescriptorId_t> ROOT::Experimental::RClus
 
 bool ROOT::Experimental::RClusterDescriptor::ContainsColumn(DescriptorId_t columnId) const
 {
-   return fColumnRanges.count(columnId) > 0;
+   return fColumnRanges.find(columnId) != fColumnRanges.end();
 }
 
 


### PR DESCRIPTION
`RClusterDescriptor::ContainsColumn` is called as part of the main read
path and so is a candidate for optimization efforts:

```
RColumn::MapPage
   RPageSourceFile::PopulatePage
      RNTupleDescriptor::FindClusterId
         RClusterDescriptor::ContainsColumn
```

A comparison of the test case `ntuple_extended` using perf and g++ 9.3
found that `unordered_map::find` appeared to be faster than
`unordered_map::count`. The generated assembly was also shorter for `find`.

perf output for `ROOT::Experimental::RClusterDescriptor::ContainsColumn`:

```
count: 4.67%     4.67%  ntuple_extended  libROOTNTuple.so
find:  3.85%     3.85%  ntuple_extended  libROOTNTuple.so
```
I'm not sure if I entirely trust the results, because I am running inside a VM. But for every test iteration `find` has been faster than `count`. I do think having better assembly generation for `find` is more persuasive than just the percentage difference.

<details>
  <summary> Assembly comparison </summary>

```
4.67%     4.67%  ntuple_extended  libROOTNTuple.so     [.] ROOT::Experimental::RClusterDescriptor::ContainsColumn
unordered_map.count
Percent│    Disassembly of section .text:
       │
       │    0000000000074d80 <ROOT::Experimental::RClusterDescriptor::ContainsColumn(unsigned long) const>:
       │    _ZNK4ROOT12Experimental18RClusterDescriptor14ContainsColumnEm():
  1.20 │      mov    0x60(%rdi),%r8
 36.14 │      mov    %rsi,%rax
  2.41 │      xor    %edx,%edx
       │      div    %r8
  3.61 │      mov    0x58(%rdi),%rax
  2.41 │      mov    (%rax,%rdx,8),%rax
 30.12 │      mov    %rdx,%r10
  1.20 │      test   %rax,%rax
       │    ↓ je     70
       │      mov    (%rax),%rcx
       │      test   %rcx,%rcx
       │    ↓ je     70
       │      mov    0x8(%rcx),%rdi
 21.69 │      xor    %r9d,%r9d
       │    ↓ jmp    4e
       │      nop
       │30:   test   %r9,%r9
       │    ↓ jne    78
       │      mov    (%rcx),%rcx
       │      test   %rcx,%rcx
       │    ↓ je     5f
       │3d:   mov    0x8(%rcx),%rdi
       │      xor    %edx,%edx
       │      mov    %rdi,%rax
       │      div    %r8
       │      cmp    %rdx,%r10
       │    ↓ jne    5f
       │4e:   cmp    %rsi,%rdi
       │    ↑ jne    30
  1.20 │      mov    (%rcx),%rcx
       │      add    $0x1,%r9
       │      test   %rcx,%rcx
       │    ↑ jne    3d
       │5f:   test   %r9,%r9
       │      setne  %al
       │    ← retq
       │      nop
       │70:   xor    %eax,%eax
       │    ← retq
       │      nop
       │78:   mov    $0x1,%eax

unordered_map.find
3.85%     3.85%  ntuple_extended  libROOTNTuple.so     [.] ROOT::Experimental::RClusterDescriptor::ContainsColumn
Percent│
       │
       │
       │    Disassembly of section .text:
       │
       │    0000000000074d80 <ROOT::Experimental::RClusterDescriptor::ContainsColumn(unsigned long) const>:
       │    _ZNK4ROOT12Experimental18RClusterDescriptor14ContainsColumnEm():
       │      mov    0x60(%rdi),%r8
 17.31 │      mov    %rsi,%rax
       │      xor    %edx,%edx
       │      div    %r8
 11.54 │      mov    0x58(%rdi),%rax
       │      mov    (%rax,%rdx,8),%rax
 28.85 │      mov    %rdx,%r9
       │      test   %rax,%rax
       │    ↓ je     50
       │      mov    (%rax),%rcx
  1.92 │      mov    0x8(%rcx),%rdi
 40.38 │   ┌──jmp    41
       │   │  nop
       │28:│  mov    (%rcx),%rcx
       │   │  test   %rcx,%rcx
       │   │↓ je     50
       │   │  mov    0x8(%rcx),%rdi
       │   │  xor    %edx,%edx
       │   │  mov    %rdi,%rax
       │   │  div    %r8
       │   │  cmp    %rdx,%r9
       │   │↓ jne    50
       │41:└─→cmp    %rdi,%rsi
       │    ↑ jne    28
       │      mov    $0x1,%eax
       │    ← retq
       │      nop
       │50:   xor    %eax,%eax
       │    ← retq
```
</details>