### PR TITLE
Fix some warnings seen with gcc11.

### DIFF
--- a/graf2d/graf/inc/TPaveLabel.h
+++ b/graf2d/graf/inc/TPaveLabel.h
@@ -26,6 +26,13 @@ public:
    TPaveLabel();
    TPaveLabel(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2, const char *label, Option_t *option="br");
    TPaveLabel(const TPaveLabel &pavelabel);
+   TPaveLabel& operator=(const TPaveLabel &pavelabel)
+   {
+     if (this != &pavelabel) {
+       ((TPaveLabel&)pavelabel).Copy(*this);
+     }
+     return *this;
+   }
    virtual ~TPaveLabel();
 
    void          Copy(TObject &pavelabel) const;

--- a/math/physics/inc/TVector2.h
+++ b/math/physics/inc/TVector2.h
@@ -31,6 +31,7 @@ public:
    typedef Double_t Scalar;   // to be able to use it with the ROOT::Math::VectorUtil functions
 
    TVector2 ();
+   TVector2 (const TVector2&) = default;
    TVector2 (Double_t *s);
    TVector2 (Double_t x0, Double_t y0);
    virtual ~TVector2();

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -39,7 +39,7 @@ public:
     // Expand parameter pack in C++ 11 way:
     int dummy[] = { 0, (processArg(argsOrName), 0) ... };
     (void)dummy;
-  };
+  }
 
   /// Construct from iterators.
   /// \tparam Iterator_t An iterator pointing to RooFit objects or references thereof.

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -56,7 +56,7 @@ public:
     // Expand parameter pack in C++ 11 way:
     int dummy[] = { 0, (processArg(moreArgsOrName), 0) ... };
     (void)dummy;
-  };
+  }
 
   /// Construct from iterators.
   /// \tparam Iterator_t An iterator pointing to RooFit objects or references thereof.


### PR DESCRIPTION
 - Warnings about deprecated implicit declaration of copy ctor/assignment.
 - Spurious trailing semicolons on function definitions.

This could also go into 6.24-patches.
