### PR TITLE
Fix typo in documentation.

### DIFF
--- a/documentation/users-guide/InputOutput.md
+++ b/documentation/users-guide/InputOutput.md
@@ -2149,7 +2149,7 @@ fXbins.Set( xbins ); \
      - The field is obligatory and defines the name of the in-memory class that
        this rule can be applied to.
   * target
-     - A semicolon-separated list of target class data member names that this rule
+     - A comma-separated list of target class data member names that this rule
        is capable of calculating.
   * embed
      - This property tells the system if the rule should be written in the output


### PR DESCRIPTION
The target list in a read rule is comma-separated, not semicolon separated.