### PR TITLE
[cling] Silence GCC 4.8 / CentOS7 warnings.

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/LookupHelper.h
+++ b/interpreter/cling/include/cling/Interpreter/LookupHelper.h
@@ -58,7 +58,7 @@ namespace cling {
   private:
     std::unique_ptr<clang::Parser> m_Parser;
     Interpreter* m_Interpreter; // we do not own.
-    std::array<const clang::Type*, kNumCachedStrings> m_StringTy = {};
+    std::array<const clang::Type*, kNumCachedStrings> m_StringTy = {{}};
     /// A map containing the hash of the lookup buffer. This allows us to avoid
     /// allocating memory for parsing when we know nothing has changed. Used by
     /// StartParsingRAII.

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -2094,7 +2094,7 @@ namespace cling {
       // getStringType can be called multiple times with Cache being null, and
       // the local cache should be discarded when that occurs.
       if (!Cache)
-        m_StringTy = {};
+        m_StringTy = {{}};
       QualType Qt = findType("std::string", WithDiagnostics);
       m_StringTy[kStdString] = Qt.isNull() ? nullptr : Qt.getTypePtr();
       if (!m_StringTy[kStdString]) return kNotAString;

--- a/interpreter/cling/lib/Utils/PlatformPosix.cpp
+++ b/interpreter/cling/lib/Utils/PlatformPosix.cpp
@@ -89,7 +89,7 @@ namespace {
        return n == 1;
     }
   };
-  thread_local std::array<const void*, 8> PointerCheck::lines = {};
+  thread_local std::array<const void*, 8> PointerCheck::lines = {{}};
   thread_local unsigned PointerCheck::mostRecent = 0;
 }
 


### PR DESCRIPTION
```
cling/include/cling/Interpreter/LookupHelper.h:61:69: warning: missing initializer for member ‘std::array<const clang::Type*, 4ul>::_M_elems’ [-Wmissing-field-initializers]
     std::array<const clang::Type*, kNumCachedStrings> m_StringTy = {};
                                                                     ^
```