### PR TITLE
[ged] Document `TGedPatternSelect`, not `The` (NFC). [skip-ci]

### DIFF
--- a/gui/ged/src/TGedPatternSelect.cxx
+++ b/gui/ged/src/TGedPatternSelect.cxx
@@ -36,7 +36,7 @@ The TGedPatternPopup is a popup containing a TGedPatternSelector.
 */
 
 
-/** \class  The TGedPatternSelect
+/** \class  TGedPatternSelect
     \ingroup ged
 
 is a button with pattern area with


### PR DESCRIPTION
https://root.cern.ch/doc/master/classThe.html ...