### PR TITLE
Fix problem building with gcc11.

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Basic/Attr.td
+++ b/interpreter/llvm/src/tools/clang/include/clang/Basic/Attr.td
@@ -1423,7 +1423,8 @@ def NeonVectorType : TypeAttr {
 }
 
 def NoUniqueAddress : InheritableAttr, TargetSpecificAttr<TargetItaniumCXXABI> {
-  let Spellings = [CXX11<"", "no_unique_address", 201803>];
+  let Spellings = [CXX11<"", "no_unique_address", 201803>,
+                   CXX11<"", "__no_unique_address__", 201803>];
   let Subjects = SubjectList<[NonBitField], ErrorDiag>;
   let Documentation = [NoUniqueAddressDocs];
 }


### PR DESCRIPTION
gcc11 uses the `no_unique_address` attribute in its implementation of `std::tuple`
(which is then used by `std::unique_ptr`).  However, it spells it
`__no_unique_address__`, which cling doesn't recognize.  This can result
in having differing memory layouts for structures in compiled code versus
cling, which will cause mysterious failures.

Patch cling to recognize `__no_unique_address__` as a synonym
for no_unique_address.

See issue #8071.

This should probably also go to 6.24-patches.