### PR TITLE
Try to hide fwd include in doxygen

### DIFF
--- a/math/genvector/inc/Math/Vector2D.h
+++ b/math/genvector/inc/Math/Vector2D.h
@@ -4,14 +4,43 @@
 #ifndef ROOT_ROOT_Math_Vector2D
 #define ROOT_ROOT_Math_Vector2D
 
-// defines typedefs to specific vectors and forward declarations
-#include "Math/Vector2Dfwd.h"
+// Defines typedefs to specific vectors and forward declarations.
+//
+namespace ROOT {
 
-// coordinate system types
+   namespace Math {
+
+      template<class CoordSystem, class Tag> class DisplacementVector2D;
+
+      template<typename T> class Cartesian2D;
+      template<typename T> class Polar2D;
+
+      class DefaultCoordinateSystemTag;
+
+      /// 2D Vector based on the cartesian coordinates x,y in double precision
+      typedef DisplacementVector2D< Cartesian2D<double>, DefaultCoordinateSystemTag > XYVector;
+      typedef XYVector XYVectorD;
+
+      /// 2D Vector based on the cartesian coordinates x,y,z in single precision
+      typedef DisplacementVector2D< Cartesian2D<float>, DefaultCoordinateSystemTag > XYVectorF;
+
+      /// 2D Vector based on the polar coordinates rho, phi in double precision.
+      typedef DisplacementVector2D< Polar2D<double>, DefaultCoordinateSystemTag > Polar2DVector;
+      typedef Polar2DVector Polar2DVectorD;
+
+      /// 2D Vector based on the polar coordinates rho, phi in single precision.
+      typedef DisplacementVector2D< Polar2D<float>, DefaultCoordinateSystemTag > Polar2DVectorF;
+
+   } // end namespace Math
+
+} // end namespace ROOT
+
+
+// Coordinate system types.
 #include "Math/GenVector/Cartesian2D.h"
 #include "Math/GenVector/Polar2D.h"
 
-// generic Vector2D class definition
+// Generic Vector2D class definition.
 #include "Math/GenVector/DisplacementVector2D.h"
 
 #endif

--- a/math/genvector/inc/Math/Vector2Dfwd.h
+++ b/math/genvector/inc/Math/Vector2Dfwd.h
@@ -12,7 +12,6 @@
 //
 // Created by: Lorenzo Moneta  at Mon Apr 16 2007
 //
-//
 #ifndef ROOT_Math_Vector2Dfwd
 #define ROOT_Math_Vector2Dfwd  1
 
@@ -22,7 +21,6 @@ namespace ROOT {
 
    namespace Math {
 
-
       template<class CoordSystem, class Tag> class DisplacementVector2D;
 
       template<typename T> class Cartesian2D;
@@ -30,48 +28,12 @@ namespace ROOT {
 
       class DefaultCoordinateSystemTag;
 
-
-      /**
-         2D Vector based on the cartesian coordinates x,y in double precision
-
-       To use it add the line `#include <Vector2D.h>`
-
-       See the documentation on the DisplacementVector2D page.
-      */
       typedef DisplacementVector2D< Cartesian2D<double>, DefaultCoordinateSystemTag > XYVector;
       typedef XYVector XYVectorD;
-
-      /**
-         2D Vector based on the cartesian coordinates x,y,z in single precision
-
-       To use it add the line `#include <Vector2D.h>`
-
-       See the documentation on the DisplacementVector2D page.
-      */
       typedef DisplacementVector2D< Cartesian2D<float>, DefaultCoordinateSystemTag > XYVectorF;
-
-
-      /**
-         2D Vector based on the polar coordinates rho, phi in double precision.
-
-       To use it add the line `#include <Vector2D.h>`
-
-       See the documentation on the DisplacementVector2D page.
-      */
       typedef DisplacementVector2D< Polar2D<double>, DefaultCoordinateSystemTag > Polar2DVector;
       typedef Polar2DVector Polar2DVectorD;
-
-      /**
-         2D Vector based on the polar coordinates rho, phi in single precision.
-
-       To use it add the line `#include <Vector2D.h>`
-
-       See the documentation on the DisplacementVector2D page.
-      */
       typedef DisplacementVector2D< Polar2D<float>, DefaultCoordinateSystemTag > Polar2DVectorF;
-
-
-
 
    } // end namespace Math
 

--- a/math/genvector/inc/Math/Vector3D.h
+++ b/math/genvector/inc/Math/Vector3D.h
@@ -4,16 +4,60 @@
 #ifndef ROOT_ROOT_Math_Vector3D
 #define ROOT_ROOT_Math_Vector3D
 
-// defines typedefs to specific vectors and forward declarations
-#include "Math/Vector3Dfwd.h"
+// Defines typedefs to specific vectors and forward declarations.
 
-// coordinate system types
+namespace ROOT {
+
+   namespace Math {
+
+      template<class CoordSystem, class Tag> class DisplacementVector3D;
+
+      template<typename T> class Cartesian3D;
+      template<typename T> class CylindricalEta3D;
+      template<typename T> class Polar3D;
+      template<typename T> class Cylindrical3D;
+
+      class DefaultCoordinateSystemTag;
+
+      /// 3D Vector based on the cartesian coordinates x,y,z in double precision
+      typedef DisplacementVector3D< Cartesian3D<double>, DefaultCoordinateSystemTag > XYZVector;
+
+      /// 3D Vector based on the cartesian coordinates x,y,z in single precision
+      typedef DisplacementVector3D< Cartesian3D<float>, DefaultCoordinateSystemTag > XYZVectorF;
+      typedef XYZVector XYZVectorD;
+
+      /// 3D Vector based on the eta based cylindrical coordinates rho, eta, phi in double precision.
+      typedef DisplacementVector3D< CylindricalEta3D<double>, DefaultCoordinateSystemTag > RhoEtaPhiVector;
+
+      /// 3D Vector based on the eta based cylindrical coordinates rho, eta, phi in single precision.
+      typedef DisplacementVector3D< CylindricalEta3D<float>, DefaultCoordinateSystemTag > RhoEtaPhiVectorF;
+      typedef RhoEtaPhiVector RhoEtaPhiVectorD;
+
+      /// 3D Vector based on the polar coordinates rho, theta, phi in double precision.
+      typedef DisplacementVector3D< Polar3D<double>, DefaultCoordinateSystemTag > Polar3DVector;
+
+      /// 3D Vector based on the polar coordinates rho, theta, phi in single precision.
+      typedef DisplacementVector3D< Polar3D<float>, DefaultCoordinateSystemTag > Polar3DVectorF;
+      typedef Polar3DVector Polar3DVectorD;
+
+      /// 3D Vector based on the cylindrical coordinates rho, z, phi in double precision.
+      typedef DisplacementVector3D< Cylindrical3D<double>, DefaultCoordinateSystemTag > RhoZPhiVector;
+
+      /// 3D Vector based on the cylindrical coordinates rho, z, phi in single precision.
+      typedef DisplacementVector3D< Cylindrical3D<float>, DefaultCoordinateSystemTag > RhoZPhiVectorF;
+      typedef RhoZPhiVector RhoZPhiVectorD;
+
+   } // end namespace Math
+
+} // end namespace ROOT
+
+// Coordinate system types.
 #include "Math/GenVector/Cartesian3D.h"
 #include "Math/GenVector/CylindricalEta3D.h"
 #include "Math/GenVector/Polar3D.h"
 #include "Math/GenVector/Cylindrical3D.h"
 
-// generic Vector3D class definition
+// Generic Vector3D class definition.
 #include "Math/GenVector/DisplacementVector3D.h"
 
 #endif

--- a/math/genvector/inc/Math/Vector3Dfwd.h
+++ b/math/genvector/inc/Math/Vector3Dfwd.h
@@ -21,93 +21,31 @@
 
 namespace ROOT {
 
-  namespace Math {
+   namespace Math {
 
+      template<class CoordSystem, class Tag> class DisplacementVector3D;
 
-    template<class CoordSystem, class Tag> class DisplacementVector3D;
+      template<typename T> class Cartesian3D;
+      template<typename T> class CylindricalEta3D;
+      template<typename T> class Polar3D;
+      template<typename T> class Cylindrical3D;
 
-    template<typename T> class Cartesian3D;
-    template<typename T> class CylindricalEta3D;
-    template<typename T> class Polar3D;
-    template<typename T> class Cylindrical3D;
+      class DefaultCoordinateSystemTag;
 
-    class DefaultCoordinateSystemTag;
+      typedef DisplacementVector3D< Cartesian3D<double>, DefaultCoordinateSystemTag > XYZVector;
+      typedef DisplacementVector3D< Cartesian3D<float>, DefaultCoordinateSystemTag > XYZVectorF;
+      typedef XYZVector XYZVectorD;
+      typedef DisplacementVector3D< CylindricalEta3D<double>, DefaultCoordinateSystemTag > RhoEtaPhiVector;
+      typedef DisplacementVector3D< CylindricalEta3D<float>, DefaultCoordinateSystemTag > RhoEtaPhiVectorF;
+      typedef RhoEtaPhiVector RhoEtaPhiVectorD;
+      typedef DisplacementVector3D< Polar3D<double>, DefaultCoordinateSystemTag > Polar3DVector;
+      typedef DisplacementVector3D< Polar3D<float>, DefaultCoordinateSystemTag > Polar3DVectorF;
+      typedef Polar3DVector Polar3DVectorD;
+      typedef DisplacementVector3D< Cylindrical3D<double>, DefaultCoordinateSystemTag > RhoZPhiVector;
+      typedef DisplacementVector3D< Cylindrical3D<float>, DefaultCoordinateSystemTag > RhoZPhiVectorF;
+      typedef RhoZPhiVector RhoZPhiVectorD;
 
-
-    /**
-       3D Vector based on the cartesian coordinates x,y,z in double precision
-
-       To use it add the line `#include <Vector3D.h>`
-
-       See the documentation on the DisplacementVector3D page.
-    */
-    typedef DisplacementVector3D< Cartesian3D<double>, DefaultCoordinateSystemTag > XYZVector;
-    /**
-       3D Vector based on the cartesian coordinates x,y,z in single precision
-
-       To use it add the line `#include <Vector3D.h>`
-
-       See the documentation on the DisplacementVector3D page.
-    */
-    typedef DisplacementVector3D< Cartesian3D<float>, DefaultCoordinateSystemTag > XYZVectorF;
-    typedef XYZVector XYZVectorD;
-
-    /**
-       3D Vector based on the eta based cylindrical coordinates rho, eta, phi in double precision.
-
-       To use it add the line `#include <Vector3D.h>`
-
-       See the documentation on the DisplacementVector3D page.
-    */
-    typedef DisplacementVector3D< CylindricalEta3D<double>, DefaultCoordinateSystemTag > RhoEtaPhiVector;
-    /**
-       3D Vector based on the eta based cylindrical coordinates rho, eta, phi in single precision.
-
-       To use it add the line `#include <Vector3D.h>`
-
-       See the documentation on the DisplacementVector3D page.
-    */
-    typedef DisplacementVector3D< CylindricalEta3D<float>, DefaultCoordinateSystemTag > RhoEtaPhiVectorF;
-    typedef RhoEtaPhiVector RhoEtaPhiVectorD;
-
-    /**
-       3D Vector based on the polar coordinates rho, theta, phi in double precision.
-
-       To use it add the line `#include <Vector3D.h>`
-
-       See the documentation on the DisplacementVector3D page.
-    */
-    typedef DisplacementVector3D< Polar3D<double>, DefaultCoordinateSystemTag > Polar3DVector;
-    /**
-       3D Vector based on the polar coordinates rho, theta, phi in single precision.
-
-       To use it add the line `#include <Vector3D.h>`
-
-       See the documentation on the DisplacementVector3D page.
-    */
-    typedef DisplacementVector3D< Polar3D<float>, DefaultCoordinateSystemTag > Polar3DVectorF;
-    typedef Polar3DVector Polar3DVectorD;
-
-    /**
-       3D Vector based on the cylindrical coordinates rho, z, phi in double precision.
-
-       To use it add the line `#include <Vector3D.h>`
-
-       See the documentation on the DisplacementVector3D page.
-    */
-    typedef DisplacementVector3D< Cylindrical3D<double>, DefaultCoordinateSystemTag > RhoZPhiVector;
-    /**
-       3D Vector based on the cylindrical coordinates rho, z, phi in single precision.
-
-       To use it add the line `#include <Vector3D.h>`
-
-       See the documentation on the DisplacementVector3D page.
-    */
-    typedef DisplacementVector3D< Cylindrical3D<float>, DefaultCoordinateSystemTag > RhoZPhiVectorF;
-    typedef RhoZPhiVector RhoZPhiVectorD;
-
-
-  } // end namespace Math
+   } // end namespace Math
 
 } // end namespace ROOT
 

--- a/math/genvector/inc/Math/Vector4D.h
+++ b/math/genvector/inc/Math/Vector4D.h
@@ -4,30 +4,52 @@
 #ifndef ROOT_Math_Vector4D
 #define ROOT_Math_Vector4D
 
-// defines typedefs to specific vectors and forward declarations
-// define additional (to Cartesian) coordinate system types
-#include "Math/Vector4Dfwd.h"
-// generic LorentzVector class definition
+// Defines typedefs to specific vectors and forward declarations.
+// Define additional (to Cartesian) coordinate system types.
+
+namespace ROOT {
+
+   namespace Math {
+
+      // forward declarations of Lorentz Vectors and type defs definitions
+
+      template<class CoordSystem> class LorentzVector;
+
+      template<typename T> class PxPyPzE4D;
+      template<typename T> class PtEtaPhiE4D;
+      template<typename T> class PxPyPzM4D;
+      template<typename T> class PtEtaPhiM4D;
+
+      // For LorentzVector have only double classes (define the vector in the global ref frame)
+
+      /// LorentzVector based on x,y,x,t (or px,py,pz,E) coordinates in double precision with metric (-,-,-,+)
+      typedef LorentzVector<PxPyPzE4D<double> > XYZTVector;
+      // For consistency
+      typedef LorentzVector<PxPyPzE4D<double> > PxPyPzEVector;
+
+      /// LorentzVector based on x,y,x,t (or px,py,pz,E) coordinates in float precision with metric (-,-,-,+)
+      typedef LorentzVector< PxPyPzE4D <float> > XYZTVectorF;
+
+      /// LorentzVector based on the x, y, z,  and Mass in double precision
+      typedef LorentzVector<PxPyPzM4D<double> > PxPyPzMVector;
+
+      /// LorentzVector based on the cylindrical coordinates Pt, eta, phi and E (rho, eta, phi, t) in double precision
+      typedef LorentzVector<PtEtaPhiE4D<double> > PtEtaPhiEVector;
+
+      /// LorentzVector based on the cylindrical coordinates pt, eta, phi and Mass in double precision
+      typedef LorentzVector<PtEtaPhiM4D<double> > PtEtaPhiMVector;
+
+   } // end namespace Math
+
+} // end namespace ROOT
+
+// Generic LorentzVector class definition.
 
 #include "Math/GenVector/PxPyPzE4D.h"
 #include "Math/GenVector/PtEtaPhiE4D.h"
 #include "Math/GenVector/PxPyPzM4D.h"
 #include "Math/GenVector/PtEtaPhiM4D.h"
 
-
 #include "Math/GenVector/LorentzVector.h"
 
-//#include "Math/GenVector/PtEtaPhiMSystem.h"
-//#include "Math/GenVector/EEtaPhiMSystem.h"
-
-
-
 #endif
-
-
-
-
-
-
-
-

--- a/math/genvector/inc/Math/Vector4Dfwd.h
+++ b/math/genvector/inc/Math/Vector4Dfwd.h
@@ -22,8 +22,7 @@ namespace ROOT {
 
   namespace Math {
 
-
-    // forward declarations of Lorentz Vectors and type defs definitions
+    // Forward declarations of Lorentz Vectors and type defs definitions
 
     template<class CoordSystem> class LorentzVector;
 
@@ -31,66 +30,13 @@ namespace ROOT {
     template<typename T> class PtEtaPhiE4D;
     template<typename T> class PxPyPzM4D;
     template<typename T> class PtEtaPhiM4D;
-//     template<typename T> class EEtaPhiMSystem;
 
-
-    // for LorentzVector have only double classes (define the vector in the global ref frame)
-
-    /**
-       LorentzVector based on x,y,x,t (or px,py,pz,E) coordinates in double precision with metric (-,-,-,+)
-
-       To use it add the line `#include <Vector4D.h>`
-
-       See the documentation on the LorentzVector page.
-    */
     typedef LorentzVector<PxPyPzE4D<double> > XYZTVector;
-    // for consistency
     typedef LorentzVector<PxPyPzE4D<double> > PxPyPzEVector;
-
-
-    /**
-       LorentzVector based on x,y,x,t (or px,py,pz,E) coordinates in float precision with metric (-,-,-,+)
-
-       To use it add the line `#include <Vector4D.h>`
-
-       See the documentation on the LorentzVector page.
-    */
     typedef LorentzVector< PxPyPzE4D <float> > XYZTVectorF;
-
-
-    /**
-       LorentzVector based on the x, y, z,  and Mass in double precision
-
-       To use it add the line `#include <Vector4D.h>`
-
-       See the documentation on the LorentzVector page.
-    */
     typedef LorentzVector<PxPyPzM4D<double> > PxPyPzMVector;
-
-    /**
-       LorentzVector based on the cylindrical coordinates Pt, eta, phi and E (rho, eta, phi, t) in double precision
-
-       To use it add the line `#include <Vector4D.h>`
-
-       See the documentation on the LorentzVector page.
-    */
     typedef LorentzVector<PtEtaPhiE4D<double> > PtEtaPhiEVector;
-
-    /**
-       LorentzVector based on the cylindrical coordinates pt, eta, phi and Mass in double precision
-
-       To use it add the line `#include <Vector4D.h>`
-
-       See the documentation on the LorentzVector page.
-    */
     typedef LorentzVector<PtEtaPhiM4D<double> > PtEtaPhiMVector;
-
-//     /**
-//        LorentzVector based on the coordinates E, Eta, Phi and Mass in double precision. These coordinates are normally used to represents a cluster objects in a calorimeter at a collider experiment.
-//     */
-//     typedef BasicLorentzVector<EEtaPhiMSystem<double> > LorentzVectorEEtaPhiM;
-
-
 
   } // end namespace Math
 


### PR DESCRIPTION
Try to better fix https://github.com/root-project/root/issues/8051
In  the files `Vector2-4-3D.h` the definitions in the fwd files are now duplicated, 
in order typedef like `PtEtaPhiMVector` appears defined in `Vector4D.h` in the ref guide
as it is the file users should include.