### PR TITLE
[ntuple] Improve column casting error message

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -121,8 +121,8 @@ protected:
    }
 
    /// Throws an exception if the column given by fOnDiskId and the columnIndex in the provided descriptor
-   /// is not of one of the allowed types.
-   ROOT::Experimental::EColumnType EnsureColumnType(const std::vector<EColumnType> &allowedTypes,
+   /// is not of one of the requested types.
+   ROOT::Experimental::EColumnType EnsureColumnType(const std::vector<EColumnType> &requestedTypes,
                                                     unsigned int columnIndex, const RNTupleDescriptor &desc);
 
 public:

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -315,7 +315,7 @@ ROOT::Experimental::EColumnType ROOT::Experimental::Detail::RFieldBase::EnsureCo
    throw RException(R__FAIL(
       "On-disk type `" + RColumnElementBase::GetTypeName(columnDesc.GetModel().GetType()) +
          "` of column #" + std::to_string(columnIndex) + " for field `" + fName +
-         "` is not convertible to requested type" + [&]{
+         "` is not convertible to the requested type" + [&]{
             std::string typeStr = requestedTypes.size() > 1 ? "s " : " ";
             for (std::size_t i = 0; i < requestedTypes.size(); i++) {
                typeStr += "`" + RColumnElementBase::GetTypeName(requestedTypes[i]) + "`";

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -97,7 +97,7 @@ TEST(RNTuple, Casting)
       auto reader = RNTupleReader::Open(std::move(modelB), "ntuple", fileGuard.GetPath());
       FAIL() << "should not be able to cast int to float";
    } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("not convertible to requested type"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("not convertible to the requested type"));
    }
 
    auto modelC = RNTupleModel::Create();

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -19,36 +19,36 @@ TEST(RNTuple, CreateField)
 
 TEST(RNTuple, Int64_t)
 {
-   auto field = RField<std::int64_t>("int64");
+   auto field = RField<std::int64_t>("myInt64");
    auto otherField = RFieldBase::Create("test", "std::int64_t").Unwrap();
 }
 
 TEST(RNTuple, Char)
 {
-   auto charField = RField<char>("char");
+   auto charField = RField<char>("myChar");
    auto otherField = RFieldBase::Create("test", "char").Unwrap();
    ASSERT_EQ("char", otherField->GetType());
 
-   auto charTField = RField<Char_t>("char");
+   auto charTField = RField<Char_t>("myChar");
    ASSERT_EQ("char", charTField.GetType());
 }
 
 TEST(RNTuple, Int8_t)
 {
-   auto field = RField<std::int8_t>("int8");
+   auto field = RField<std::int8_t>("myInt8");
    auto otherField = RFieldBase::Create("test", "std::int8_t").Unwrap();
 }
 
 TEST(RNTuple, Int16_t)
 {
-   auto field = RField<std::int16_t>("int16");
+   auto field = RField<std::int16_t>("myInt16");
    auto otherField = RFieldBase::Create("test", "std::int16_t").Unwrap();
    ASSERT_EQ("std::int16_t", RFieldBase::Create("myShort", "Short_t").Unwrap()->GetType());
 }
 
 TEST(RNTuple, UInt16_t)
 {
-   auto field = RField<std::uint16_t>("uint16");
+   auto field = RField<std::uint16_t>("myUint16");
    auto otherField = RFieldBase::Create("test", "std::uint16_t").Unwrap();
    ASSERT_EQ("std::uint16_t", RFieldBase::Create("myUShort", "UShort_t").Unwrap()->GetType());
 }
@@ -68,7 +68,7 @@ TEST(RNTuple, UnsupportedStdTypes)
       EXPECT_THAT(err.what(), testing::HasSubstr("pair<int,float> is not supported"));
    }
    try {
-      auto field = RField<std::weak_ptr<int>>("weak_ptr");
+      auto field = RField<std::weak_ptr<int>>("myWeakPtr");
       FAIL() << "should not be able to make a std::weak_ptr field";
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("weak_ptr<int> is not supported"));
@@ -85,7 +85,7 @@ TEST(RNTuple, Casting)
 {
    FileRaii fileGuard("test_ntuple_casting.root");
    auto modelA = RNTupleModel::Create();
-   modelA->MakeField<std::int32_t>("int", 42);
+   modelA->MakeField<std::int32_t>("myInt", 42);
    {
       auto writer = RNTupleWriter::Recreate(std::move(modelA), "ntuple", fileGuard.GetPath());
       writer->Fill();
@@ -93,7 +93,7 @@ TEST(RNTuple, Casting)
 
    try {
       auto modelB = RNTupleModel::Create();
-      auto fieldCast = modelB->MakeField<float>("int");
+      auto fieldCast = modelB->MakeField<float>("myInt");
       auto reader = RNTupleReader::Open(std::move(modelB), "ntuple", fileGuard.GetPath());
       FAIL() << "should not be able to cast int to float";
    } catch (const RException& err) {
@@ -101,7 +101,7 @@ TEST(RNTuple, Casting)
    }
 
    auto modelC = RNTupleModel::Create();
-   auto fieldCast = modelC->MakeField<std::int64_t>("int");
+   auto fieldCast = modelC->MakeField<std::int64_t>("myInt");
    auto reader = RNTupleReader::Open(std::move(modelC), "ntuple", fileGuard.GetPath());
    reader->LoadEntry(0);
    EXPECT_EQ(42, *fieldCast);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -97,7 +97,7 @@ TEST(RNTuple, Casting)
       auto reader = RNTupleReader::Open(std::move(modelB), "ntuple", fileGuard.GetPath());
       FAIL() << "should not be able to cast int to float";
    } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("Unexpected column type"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("not convertible to requested type"));
    }
 
    auto modelC = RNTupleModel::Create();


### PR DESCRIPTION
Improve error message when the requested type doesn't match the on-disk type:
```cpp
// underlying column is a double
auto view = ntuple->GetView<float>("myDouble");
```

Before:
```
Unexpected column type: Real64 of column #0 for field myDouble
```
After:
```
On-disk type `Real64` of column #0 for field `myDouble` is not convertible to requested type `Real32`
```