### PR TITLE
TFileMerger _actually_ delete directory only if we induced its creation/loading

### DIFF
--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -557,10 +557,11 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
    auto getDirectory = [&dirtodelete](TDirectory *parent, const char *name, const TString &pathname)
    {
       TDirectory *result = dynamic_cast<TDirectory*>(parent->GetList()->FindObject(name));
-      if (!result)
+      if (!result) {
          result = parent->GetDirectory(pathname);
-      else
-         dirtodelete.Add(result);
+         if (result && result != parent)
+            dirtodelete.Add(result);
+      }
 
       return result;
    };


### PR DESCRIPTION
This is the actual heart of 30fd4c79425 which incorrect did the reverse
of its intent.

This fixes #8226