### PR TITLE
Fixed title offsetting when using absolute-size fonts and multiple pads

### DIFF
--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -2338,7 +2338,7 @@ L200:
       textaxis->SetTextSize (GetTitleSize());
       charheight = GetTitleSize();
       if ((GetTextFont() % 10) > 2) {
-         charheight = charheight/(gPad->GetWh()*gPad->GetHNDC());
+         charheight /= padh;
       }
       if (x1 == x0) {
          if (autotoff) {

--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -2338,7 +2338,7 @@ L200:
       textaxis->SetTextSize (GetTitleSize());
       charheight = GetTitleSize();
       if ((GetTextFont() % 10) > 2) {
-         charheight = charheight/gPad->GetWh();
+         charheight = charheight/(gPad->GetWh()*gPad->GetHNDC());
       }
       if (x1 == x0) {
          if (autotoff) {


### PR DESCRIPTION
Found there was a small bug in calculation of offset that was affecting the calculation if you have pads that are sub-regions of the main pad