### PR TITLE
Fix CMake configuration and build with oneTBB

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1240,8 +1240,10 @@ if(imt AND NOT builtin_tbb)
     endif()
   endif()
 
-  # Check that the found TBB does not use captured exceptions.
-  if(TBB_FOUND)
+  # Check that the found TBB does not use captured exceptions. If the header
+  # <tbb/tbb_config.h> does not exist, assume that we have oneTBB newer than
+  # version 2021, which does not have captured exceptions anyway.
+  if(TBB_FOUND AND EXISTS "${TBB_INCLUDE_DIRS}/tbb/tbb_config.h")
     set(CMAKE_REQUIRED_INCLUDES "${TBB_INCLUDE_DIRS}")
     check_cxx_source_compiles("
 #include <tbb/tbb_config.h>

--- a/core/imt/src/RTaskArena.cxx
+++ b/core/imt/src/RTaskArena.cxx
@@ -1,6 +1,5 @@
 // Require TBB without captured exceptions
 #define TBB_USE_CAPTURED_EXCEPTION 0
-#include "tbb/tbb_config.h"
 
 #include "ROOT/RTaskArena.hxx"
 #include "ROpaqueTaskArena.hxx"

--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -1,6 +1,5 @@
 // Require TBB without captured exceptions
 #define TBB_USE_CAPTURED_EXCEPTION 0
-#include "tbb/tbb_config.h"
 
 #include "ROOT/TThreadExecutor.hxx"
 #include "ROpaqueTaskArena.hxx"


### PR DESCRIPTION
Versions newer than 2021 don't have the header tbb/tbb_config.h,
see https://github.com/cms-sw/cmsdist/pull/6936