### PR TITLE
Allow standards-based attributes to have leading and trailing underscores.

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Sema/ParsedAttr.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/ParsedAttr.cpp
@@ -125,7 +125,8 @@ static StringRef normalizeAttrName(StringRef AttrName,
       SyntaxUsed == ParsedAttr::AS_GNU ||
       ((SyntaxUsed == ParsedAttr::AS_CXX11 ||
         SyntaxUsed == ParsedAttr::AS_C2x) &&
-       (NormalizedScopeName == "gnu" || NormalizedScopeName == "clang"));
+       (NormalizedScopeName.empty() || NormalizedScopeName == "gnu" ||
+        NormalizedScopeName == "clang"));
   if (ShouldNormalize && AttrName.size() >= 4 && AttrName.startswith("__") &&
       AttrName.endswith("__"))
     AttrName = AttrName.slice(2, AttrName.size() - 2);


### PR DESCRIPTION
This gives library implementers a way to use standards-based attributes that do not conflict with user-defined macros of the same name. Attributes in C2x require this behavior normatively (C2x 6.7.11p4), but there's no reason to not have the same behavior in C++, especially given that such attributes may be used by a C library consumed by a C++ compilation.

llvm-svn: 369033

Backported from llvm-project 2ed4573e8f8619dc67647256ac070bf91f461392

Fixes GCC 11 builds.