### PR TITLE
[cling] Trust that GCC has `__attribute__` `visibility`:

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/Visibility.h
+++ b/interpreter/cling/include/cling/Interpreter/Visibility.h
@@ -24,7 +24,7 @@
 # else
 #  define CLING_LIB_EXPORT __declspec(dllexport)
 # endif
-#elif (__has_attribute(visibility))
+#elif (__has_attribute(visibility)) || defined(__GNUC__)
 # define CLING_LIB_EXPORT __attribute__ ((visibility("default")))
 #else
 # define CLING_LIB_EXPORT


### PR DESCRIPTION
GCC 4.8 (which we support...) does not have __has_attribute. Fixes CentOS7 builds.