### PR TITLE
[v624][RF] Fix memory leak in RooSecondMoment

### DIFF
--- a/roofit/roofitcore/inc/RooTemplateProxy.h
+++ b/roofit/roofitcore/inc/RooTemplateProxy.h
@@ -236,6 +236,37 @@ public:
   }
 
 
+  ////////////////////////////////////////////////////////////////////////////////
+  /// Create a new object held and owned by proxy.
+  /// Can only be done if the proxy was non-owning before.
+  template<class U, class... ConstructorArgs>
+  U& emplaceOwnedArg(ConstructorArgs&&... constructorArgs) {
+    if(_ownArg) {
+      // let's maybe not support overwriting owned args unless it becomes necessary
+      throw std::runtime_error("Error in RooTemplateProxy: emplaceOwnedArg<>() called on a proxy already owning an arg.");
+    }
+    auto arg = new U{std::forward<ConstructorArgs>(constructorArgs)...};
+    setArg(*arg);
+    _ownArg = true;
+    return *arg;
+  }
+
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// Move a new object held and owned by proxy.
+  /// Can only be done if the proxy was non-owning before.
+  template<class U>
+  U& putOwnedArg(std::unique_ptr<U> arg) {
+    if(_ownArg) {
+      // let's maybe not support overwriting owned args unless it becomes necessary
+      throw std::runtime_error("Error in RooTemplateProxy: putOwnedArg<>() called on a proxy already owning an arg.");
+    }
+    auto argPtr = arg.get();
+    setArg(*arg.release());
+    _ownArg = true;
+    return *argPtr;
+  }
+
   /// \name Legacy interface
   /// In ROOT versions before 6.22, RooFit didn't have this typed proxy. Therefore, a number of functions
   /// for forwarding calls to the proxied objects were necessary. The functions in this group can all be

--- a/roofit/roofitcore/src/RooSecondMoment.cxx
+++ b/roofit/roofitcore/src/RooSecondMoment.cxx
@@ -77,11 +77,10 @@ RooSecondMoment::RooSecondMoment(const char* name, const char* title, RooAbsReal
   if (centr) {
 
     string m1name=Form("%s_moment1",GetName()) ;
-    RooAbsReal* mom1 = func.mean(x) ;
-    _mean.setArg(*mom1) ;
+    _mean.putOwnedArg(std::unique_ptr<RooAbsMoment>{func.mean(x)}) ;
     
     string pname=Form("%s_product",name) ;
-    _xfOffset = mom1->getVal() ;
+    _xfOffset = _mean->getVal() ;
     XF = new RooFormulaVar(pname.c_str(),Form("pow((@0-%f),2)*@1",_xfOffset),RooArgList(x,func)) ;  
         
   } else {
@@ -125,11 +124,10 @@ RooSecondMoment::RooSecondMoment(const char* name, const char* title, RooAbsReal
   if (centr) {
 
     string m1name=Form("%s_moment1",GetName()) ;
-    RooAbsReal* mom1 = func.mean(x,nset) ;
-    _mean.setArg(*mom1) ;
+    _mean.putOwnedArg(std::unique_ptr<RooAbsMoment>{func.mean(x,nset)}) ;
     
     string pname=Form("%s_product",name) ;
-    _xfOffset = mom1->getVal() ;
+    _xfOffset = _mean->getVal() ;
     XF = new RooFormulaVar(pname.c_str(),Form("pow((@0-%f),2)*@1",_xfOffset),RooArgList(x,func)) ;  
 
 


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/8238.

The backport is motivated by the fact that the memory leak was already reported in the forum twice:
* https://root-forum.cern.ch/t/roomomentmorph-slow-memory-leak/45062
* https://root-forum.cern.ch/t/roomomentmorph-memory-leak/26756

...and one time on the old roottalk:
https://groups.cern.ch/group/roottalk/Lists/Archive/Flat.aspx?RootFolder=%2fgroup%2froottalk%2fLists%2fArchive%2fRooMomentMorph%20getVal%28%29%20call%20increases%20memory%20a%20lot&FolderCTID=0x01200200A201AF59FD011C4E9284C43BF0CDA2A4