### PR TITLE
Fix invalid use of incomplete class in RWebBrowserImp

### DIFF
--- a/gui/browserv7/src/RWebBrowserImp.cxx
+++ b/gui/browserv7/src/RWebBrowserImp.cxx
@@ -13,7 +13,7 @@
 #include <ROOT/RWebBrowserImp.hxx>
 
 #include "TROOT.h"
-
+#include "TSeqCollection.h" // needed in gROOT->GetListOfFiles()->FindObject
 
 using namespace ROOT::Experimental;
 


### PR DESCRIPTION
I got these errors while building from master on Fedora 32 with the following command `cmake -GNinja -Ddev=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Release` 

```
/home/vpadulan/Programs/rootproject/root/gui/browserv7/src/RWebBrowserImp.cxx: In member function ‘virtual void ROOT::Experimental::RWebBrowserImp::BrowseObj(TObject*)’:
/home/vpadulan/Programs/rootproject/root/gui/browserv7/src/RWebBrowserImp.cxx:89:31: error: invalid use of incomplete type ‘class TSeqCollection’
   89 |    if (gROOT->GetListOfFiles()->FindObject(obj))
      |                               ^~
In file included from /home/vpadulan/Programs/rootproject/root/gui/browserv7/src/RWebBrowserImp.cxx:15:
/home/vpadulan/Programs/rootproject/root/core/base/inc/TROOT.h:59:7: note: forward declaration of ‘class TSeqCollection’
   59 | class TSeqCollection;
      |       ^~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```

Not sure if it's the right fix, but I thought it was worth mentioning.