### PR TITLE
[PyROOT][8152] Ignore warnings about register keyword

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/inc/CPyCppyy/API.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/inc/CPyCppyy/API.h
@@ -27,6 +27,11 @@
 #undef _XOPEN_SOURCE
 #endif
 #endif
+#if PY_VERSION_HEX < 0x03000000
+#if __cplusplus >= 201703L
+#pragma GCC diagnostic ignored "-Wregister"
+#endif
+#endif
 #include "Python.h"
 
 // Cppyy types


### PR DESCRIPTION
Python2 headers still use the register keyword, which causes
issues when compiling ROOT with C++ 17, since that is also the
standard that will be used for jitting.

In particular, when cppyy generates a C++ wrapper for a Python
callable parameter, CPyCppyy/API.h is jitted and so are the
Python headers. In Python2 with C++17, such jitting fails and,
as a result, the C++ wrapper can't be generated.

This commit ignores -Wregister when in Python2 and C++ 17.

Fixes #8152 