### PR TITLE
[skip-ci] Fix doxygen \class

### DIFF
--- a/gui/ged/src/TGedMarkerSelect.cxx
+++ b/gui/ged/src/TGedMarkerSelect.cxx
@@ -11,11 +11,8 @@
 
 
 
-/** \class TGedMarkerSelect, TGedMarkerPopup
+/** \class TGedMarkerSelect
     \ingroup ged
-
-The TGedMarkerPopup is a popup containing buttons to
-select marker style.
 
 The TGedMarkerSelect widget is a button showing selected marker
 and a little down arrow. When clicked on the arrow the
@@ -26,6 +23,14 @@ kC_MARKERSEL, kMAR_SELCHANGED, widget id, style.
 
 and the signal:
 MarkerSelected(Style_t marker)
+
+*/
+
+/** \class TGedMarkerPopup
+    \ingroup ged
+
+The TGedMarkerPopup is a popup containing buttons to
+select marker style.
 
 */
 

--- a/gui/gui/inc/TGMimeTypes.h
+++ b/gui/gui/inc/TGMimeTypes.h
@@ -19,6 +19,12 @@
 class TOrdCollection;
 class TRegexp;
 
+/** \class TGMime
+    \ingroup guiwidgets
+
+TGMime is internally used by TGMimeTypes.
+
+*/
 
 class TGMime : public TObject {
 

--- a/gui/gui/src/TGColorDialog.cxx
+++ b/gui/gui/src/TGColorDialog.cxx
@@ -30,7 +30,7 @@ A widget showing an matrix of color cells. The colors can be set and selected.
 */
 
 
-/** \class The TGColorPick
+/** \class TGColorPick
     \ingroup guiwidgets
 
 A widget which allows a color to be picked from HLS color space.

--- a/gui/gui/src/TGDockableFrame.cxx
+++ b/gui/gui/src/TGDockableFrame.cxx
@@ -21,7 +21,7 @@
 **************************************************************************/
 
 
-/** \class  A TGDockableFrame
+/** \class TGDockableFrame
     \ingroup guiwidgets
 
 A frame with handles that allow it to be

--- a/gui/gui/src/TGFSContainer.cxx
+++ b/gui/gui/src/TGFSContainer.cxx
@@ -21,13 +21,26 @@
 **************************************************************************/
 
 
-/** \class TGFileIcon, TGFileEntry, TGFSContainer
+/** \class TGFileIcon
     \ingroup guiwidgets
 
-Utility classes used by the file selection dialog (TGFSDialog).
+Utility class used by the file selection dialog (TGFSDialog).
 
 */
 
+/** \class TGFileEntry
+    \ingroup guiwidgets
+
+Utility class used by the file selection dialog (TGFSDialog).
+
+*/
+
+/** \class TGFSContainer
+    \ingroup guiwidgets
+
+Utility class used by the file selection dialog (TGFSDialog).
+
+*/
 
 #include "TGFSContainer.h"
 #include "TGIcon.h"

--- a/gui/gui/src/TGFont.cxx
+++ b/gui/gui/src/TGFont.cxx
@@ -21,7 +21,7 @@
 **************************************************************************/
 
 
-/** \class TGFont and TGFontPool
+/** \class TGFont
     \ingroup guiwidgets
 
 Encapsulate fonts used in the GUI system.
@@ -30,13 +30,13 @@ Encapsulate fonts used in the GUI system.
 \class TGFontPool
 \ingroup guiwidgets
 
-provides a pool of fonts.
+Provides a pool of fonts.
 
 
 \class TGTextLayout
 \ingroup guiwidgets
 
-is used to keep track of string  measurement
+Is used to keep track of string  measurement
 information when  using the text layout facilities.
 It can be displayed with respect to any origin.
 

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -21,7 +21,7 @@
 **************************************************************************/
 
 
-/** \class The TGFrame
+/** \class TGFrame
     \ingroup guiwidgets
 
 A subclasses of TGWindow, and is used as base

--- a/gui/gui/src/TGImageMap.cxx
+++ b/gui/gui/src/TGImageMap.cxx
@@ -10,8 +10,10 @@
  *************************************************************************/
 
 
-/** \class TGImageMap (with TGRegion and TGRegionWithId help classes)
+/** \class TGImageMap
     \ingroup guiwidgets
+
+(with TGRegion and TGRegionWithId help classes)
 
 A TGImageMap provides the functionality like a clickable image in
 a web browser with sensitive regions (MAP HTML tag).

--- a/gui/gui/src/TGMimeTypes.cxx
+++ b/gui/gui/src/TGMimeTypes.cxx
@@ -20,11 +20,11 @@
 
 **************************************************************************/
 
-/** \class TGMimeTypes and TGMime
+/** \class TGMimeTypes
     \ingroup guiwidgets
 
 This class handles mime types, used by browsers to map file types
-to applications and icons. TGMime is internally used by TGMimeType.
+to applications and icons.
 
 */
 

--- a/gui/recorder/inc/TRecorder.h
+++ b/gui/recorder/inc/TRecorder.h
@@ -341,17 +341,18 @@ public:
    ClassDef(TRecorder,2) // Class provides direct recorder/replayer interface for a user.
 };
 
-/** \class TRecorderState                                                      //
+/** \class TRecorderState
     \ingroup guirecorder
-//  Abstract class that defines interface for a state of recorder.      //
-//  Inherited classes are:                                              //
-//  - TRecorderInactive                                                 //
-//  - TRecorderRecording                                                //
-//  - TRecorderReplaying                                                //
-//  - TRecorderPaused                                                   //
-//                                                                      //
-//  See TRecorder for more information about creating, using,           //
-//  changing and deleting states.                                       //
+
+Abstract class that defines interface for a state of recorder.
+Inherited classes are:
+  - TRecorderInactive
+  - TRecorderRecording
+  - TRecorderReplaying
+  - TRecorderPaused
+
+See TRecorder for more information about creating, using,
+changing and deleting states.
 
 */
 
@@ -417,7 +418,7 @@ private:
    TTree      *fCmdTree;   // TTree with recorded commandline events
    TTree      *fExtraTree; // TTree with recorded extra events (PaveLabels and Texts)
 
-   ULong64_t       fWin;            // Window ID being currenty mapped
+   ULong64_t       fWin;            // Window ID being currently mapped
    TRecGuiEvent   *fGuiEvent;       // GUI event being currently replayed
    TRecCmdEvent   *fCmdEvent;       // Commandline event being currently replayed
    TRecExtraEvent *fExtraEvent;     // Extra event being currently replayed
@@ -440,7 +441,7 @@ private:
 
    Bool_t      fWaitingForWindow;   // Signalizes that we wait for a window to be registered in order
                                     // to replay the next event fNextEvent.
-                                    // Registraion of windows can last different time when recording and replaying.
+                                    // Registration of windows can last different time when recording and replaying.
                                     // If there is an event ready to be replayed but the corresponding windows has not been yet
                                     // registered, we wait (postopone fNextEvent) until it is registered.
 
@@ -517,7 +518,7 @@ private:
                                           // It is increased every time when a new window is registered
 
    Int_t               fFilteredIdsCount; // Only when GUI for recorder is used: Count of windows in GUI recorder
-   Window_t           *fFilteredIds;      // Only when GUI for recorer is used: IDs of windows that creates that GUI.
+   Window_t           *fFilteredIds;      // Only when GUI for recorder is used: IDs of windows that creates that GUI.
                                           // Events for GUI recorder are not recorded.
    Bool_t              fFilterEventPave;  // Special flag to filter events during the pave recording
 

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -189,7 +189,7 @@ ClassImp(TFormula);
        ```root -l -q -e TFormula("", "x%10").Eval(0)```.
 
     The operator `^` is defined to mean exponentiation instead of the C/C++
-    interpretaion xor. `**` is added, also meaning exponentiation.
+    interpretation xor. `**` is added, also meaning exponentiation.
 
     The operators `++` and `@` are added, and are shorthand for the a linear
     function. That means the expression `x@2` will be expanded to
@@ -1852,7 +1852,7 @@ void TFormula::ExtractFunctors(TString &formula)
             i++;
          } while (formula[i] != '\"');
       }
-      // case of e or E for numbers in exponential notaton (e.g. 2.2e-3)
+      // case of e or E for numbers in exponential notation (e.g. 2.2e-3)
       if (IsScientificNotation(formula, i))
          continue;
       // case of x for hexadecimal numbers
@@ -3703,7 +3703,7 @@ void TFormula::Streamer(TBuffer &b)
             }
          }
          else {
-            // we also delay the initializtion of lamda expressions
+            // we also delay the initialization of lamda expressions
             if (!fLazyInitialization) {
                bool ret = InitLambdaExpression(fFormula);
                if (ret) {

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -168,7 +168,7 @@ private:
 };
 
 /**
- * \class TBufferMerger TBufferMerger.hxx
+ * \class TBufferMergerFile TBufferMerger.hxx
  * \ingroup IO
  *
  * A TBufferMergerFile is similar to a TMemFile, but when data

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -38,14 +38,14 @@ public:
      kNoNewLine     = 2,             ///< no indent plus skip newline symbols
      kNoSpaces      = 3,             ///< no new lines plus remove all spaces around "," and ":" symbols
 
-     kMapAsObject   = 5,             ///< store std::map, std::unodered_map as JSON object
+     kMapAsObject   = 5,             ///< store std::map, std::unordered_map as JSON object
 
      // algorithms for array compression - exclusive
      kZeroSuppression = 10,          ///< if array has much zeros in begin and/or end, they will be removed
      kSameSuppression = 20,          ///< zero suppression plus compress many similar values together
      kBase64          = 30,          ///< all binary arrays will be compressed with base64 coding, supported by JSROOT
 
-     kSkipTypeInfo  = 100            // do not store typenames in JSON
+     kSkipTypeInfo  = 100            ///< do not store typenames in JSON
    };
 
    TBufferJSON(TBuffer::EMode mode = TBuffer::kWrite);

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -41,7 +41,7 @@ protected:
    TString        fOutputFilename;            ///< The name of the outputfile for merging
    Bool_t         fFastMethod{kTRUE};         ///< True if using Fast merging algorithm (default)
    Bool_t         fNoTrees{kFALSE};           ///< True if Trees should not be merged (default is kFALSE)
-   Bool_t         fExplicitCompLevel{kFALSE}; ///< True if the user explicitly requested a compressio level change (default kFALSE)
+   Bool_t         fExplicitCompLevel{kFALSE}; ///< True if the user explicitly requested a compression level change (default kFALSE)
    Bool_t         fCompressionChange{kFALSE}; ///< True if the output and input have different compression level (default kFALSE)
    Int_t          fPrintLevel{0};             ///< How much information to print out at run time
    TString        fMergeOptions;              ///< Options (in string format) to be passed down to the Merge functions
@@ -53,7 +53,7 @@ protected:
    Bool_t         fHistoOneGo;                ///< Merger histos in one go (default is kTRUE)
    TString        fObjectNames;               ///< List of object names to be either merged exclusively or skipped
    TList          fMergeList;                 ///< list of TObjString containing the name of the files need to be merged
-   TList          fExcessFiles;               ///<! List of TObjString containing the name of the files not yet added to fFileList due to user or system limitiation on the max number of files opened.
+   TList          fExcessFiles;               ///<! List of TObjString containing the name of the files not yet added to fFileList due to user or system limitation on the max number of files opened.
 
    Bool_t         OpenExcessFiles();
    virtual Bool_t AddFile(TFile *source, Bool_t own, Bool_t cpProgress);
@@ -67,8 +67,8 @@ protected:
 public:
    /// Type of the partial merge
    enum EPartialMergeType {
-      kRegular      = 0,             ///< Normal merge, overwritting the output file.
-      kIncremental  = BIT(1),        ///< Merge the input file with the content of the output file (if already exising).
+      kRegular      = 0,             ///< Normal merge, overwriting the output file.
+      kIncremental  = BIT(1),        ///< Merge the input file with the content of the output file (if already existing).
       kResetable    = BIT(2),        ///< Only the objects with a MergeAfterReset member function.
       kNonResetable = BIT(3),        ///< Only the objects without a MergeAfterReset member function.
       kDelayWrite   = BIT(4),        ///< Delay the TFile write (to reduce the number of write when reusing the file)

--- a/io/io/inc/TFilePrefetch.h
+++ b/io/io/inc/TFilePrefetch.h
@@ -33,19 +33,19 @@ class TFPBlock;
 class TFilePrefetch : public TObject {
 
 private:
-   TFile      *fFile;              // reference to the file
-   TList      *fPendingBlocks;     // list of pending blocks to be read
-   TList      *fReadBlocks;        // list of blocks read
-   TThread    *fConsumer;          // consumer thread
-   std::mutex fMutexPendingList;   // mutex for the pending list
-   std::mutex fMutexReadList;      // mutex for the list of read blocks
-   std::condition_variable fNewBlockAdded;  // signal the addition of a new pending block
-   std::condition_variable fReadBlockAdded; // signal the addition of a new red block
-   TSemaphore *fSemChangeFile;     // semaphore used when changin a file in TChain
-   TString     fPathCache;         // path to the cache directory
-   TStopwatch  fWaitTime;          // time wating to prefetch a buffer (in usec)
-   Bool_t      fThreadJoined;      // mark if async thread was joined
-   std::atomic<Bool_t> fPrefetchFinished;  // true if prefetching is over
+   TFile      *fFile;                       ///< reference to the file
+   TList      *fPendingBlocks;              ///< list of pending blocks to be read
+   TList      *fReadBlocks;                 ///< list of blocks read
+   TThread    *fConsumer;                   ///< consumer thread
+   std::mutex fMutexPendingList;            ///< mutex for the pending list
+   std::mutex fMutexReadList;               ///< mutex for the list of read blocks
+   std::condition_variable fNewBlockAdded;  ///< signal the addition of a new pending block
+   std::condition_variable fReadBlockAdded; ///< signal the addition of a new red block
+   TSemaphore *fSemChangeFile;              ///< semaphore used when changing a file in TChain
+   TString     fPathCache;                  ///< path to the cache directory
+   TStopwatch  fWaitTime;                   ///< time waiting to prefetch a buffer (in usec)
+   Bool_t      fThreadJoined;               ///< mark if async thread was joined
+   std::atomic<Bool_t> fPrefetchFinished;   ///< true if prefetching is over
 
    static TThread::VoidRtnFunc_t ThreadProc(void*);  //create a joinable worker thread
 

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -429,7 +429,7 @@ public:
    virtual TStreamerInfoActions::TActionSequence *GetReadMemberWiseActions(Int_t version);
    virtual TStreamerInfoActions::TActionSequence *GetWriteMemberWiseActions();
 
-   // Set of functions to iterate easily throught the collection
+   // Set of functions to iterate easily through the collection
 
    virtual CreateIterators_t GetFunctionCreateIterators(Bool_t read = kTRUE);
    // typedef void (*CreateIterators_t)(void *collection, void **begin_arena, void **end_arena);

--- a/io/io/inc/TMapFile.h
+++ b/io/io/inc/TMapFile.h
@@ -44,8 +44,8 @@ private:
    Longptr_t   fSemaphore;      ///< Modification semaphore (or getpid() for WIN32)
    ULongptr_t  fhSemaphore;     ///< HANDLE of WIN32 Mutex object to implement semaphore
    TObject    *fGetting;        ///< Don't deadlock in update mode, when from Get() Add() is called
-   Int_t       fWritten;        ///< Number of objects written sofar
-   Double_t    fSumBuffer;      ///< Sum of buffer sizes of objects written sofar
+   Int_t       fWritten;        ///< Number of objects written so far
+   Double_t    fSumBuffer;      ///< Sum of buffer sizes of objects written so far
    Double_t    fSum2Buffer;     ///< Sum of squares of buffer sizes of objects written so far
 
    static Longptr_t fgMapAddress;  ///< Map to this address, set address via SetMapAddress()

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -97,7 +97,7 @@ private:
    Int_t             fSize;              ///<!size of the persistent class
    Int_t             fNdata;             ///<!number of optimized elements
    Int_t             fNfulldata;         ///<!number of elements
-   Int_t             fNslots;            ///<!total numbrer of slots in fComp.
+   Int_t             fNslots;            ///<!total number of slots in fComp.
    TCompInfo        *fComp;              ///<![fNslots with less than fElements->GetEntries()*1.5 used] Compiled info
    TCompInfo       **fCompOpt;           ///<![fNdata]
    TCompInfo       **fCompFull;          ///<![fElements->GetEntries()]

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -9,9 +9,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-/**
-\class TStreamerInfo TStreamerInfo.cxx
-\ingroup IO
+/** \class TStreamerInfo
+    \ingroup IO
 
 Describes a persistent version of a class.
 
@@ -785,7 +784,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
          }
       }
       if (fClass->fIsSyntheticPair) {
-         // The format never change, no need to import the old StreamerInof
+         // The format never change, no need to import the old StreamerInfo
          // (which anyway would have issue when being setup due to the lack
          // of TDataMember in the TClass.
          SetBit(kCanDelete);
@@ -1581,7 +1580,7 @@ namespace {
             // be a pair and thus have a TClass ... so let's just give up ...
             // It actually happens in the case where one of the member is an
             // enum that is part of dictionary payload that is not yet
-            // autoloaded.
+            // auto-loaded.
             return nullptr;
          }
          TVirtualStreamerInfo *info = current->GetValueClass()->GetStreamerInfo();
@@ -1591,7 +1590,7 @@ namespace {
          TStreamerElement *f = (TStreamerElement*) info->GetElements()->At(0);
          TStreamerElement *s = (TStreamerElement*) info->GetElements()->At(1);
 
-         // Since we do not create TClass for pair of unknow types, old->GetValueClass can
+         // Since we do not create TClass for pair of unknown types, old->GetValueClass can
          // be nullptr even-though the type used be known.  An example of such change
          // is `RooExpensiveObjectCache::ExpensiveObject` which used to be recorded
          // as `ExpensiveObject` in the name of the map ... making it unknown
@@ -1808,7 +1807,7 @@ void TStreamerInfo::BuildOld()
       {
          // Prevent BuildOld from modifying existing ArtificialElement (We need to review when and why BuildOld
          // needs to be re-run; it might be needed if the 'current' class change (for example from being an onfile
-         // version to being a version loaded from a shared library) and we thus may have to remove the artifical
+         // version to being a version loaded from a shared library) and we thus may have to remove the artificial
          // element at the beginning of BuildOld)
 
          continue;

--- a/net/davix/inc/ROOT/RRawFileDavix.hxx
+++ b/net/davix/inc/ROOT/RRawFileDavix.hxx
@@ -24,13 +24,14 @@ namespace Internal {
 
 struct RDavixFileDes;
 
-/**
- * \class RRawFileDavix RRawFileDavix.hxx
- *
- * The RRawFileDavix class provides read-only access to remote non-ROOT files.  It uses the Davix library for
- * the transport layer.  It instructs the RRawFile base class to buffer in larger chunks than the default for
- * local files, assuming that remote file access has high(er) latency.
- */
+/** \class RRawFileDavix RRawFileDavix.hxx
+
+The RRawFileDavix class provides read-only access to remote non-ROOT files.  It uses the Davix library for
+the transport layer.  It instructs the RRawFile base class to buffer in larger chunks than the default for
+local files, assuming that remote file access has high(er) latency.
+
+*/
+
 class RRawFileDavix : public RRawFile {
 private:
    std::unique_ptr<Internal::RDavixFileDes> fFileDes;

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -14,11 +14,10 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
  *****************************************************************************/
 
-//////////////////////////////////////////////////////////////////////////////
-/**
-// \class RooChi2Var 
-// RooChi2Var implements a simple \f$ \chi^2 \f$ calculation from a binned dataset
-// and a PDF. It calculates
+/** \class RooChi2Var
+RooChi2Var implements a simple \f$ \chi^2 \f$ calculation from a binned dataset
+and a PDF. It calculates
+
 \f{align*}{
   \chi^2 &= \sum_{\mathrm{bins}}  \left( \frac{N_\mathrm{PDF,bin} - N_\mathrm{Data,bin}}{\Delta_\mathrm{bin}} \right)^2, \\
   \text{where} \\
@@ -34,20 +33,22 @@
         \mathtt{data{\rightarrow}weightError()} &\text{otherwise} \\
     \end{cases}
 \f}
- * If the dataset doesn't have user-defined errors, errors are assumed to be \f$ \sqrt{N} \f$.
- * In extended PDF mode, N_tot (total number of data events) is substituted with N_expected, the
- * expected number of events that the PDF predicts.
+
+If the dataset doesn't have user-defined errors, errors are assumed to be \f$ \sqrt{N} \f$.
+In extended PDF mode, N_tot (total number of data events) is substituted with N_expected, the
+expected number of events that the PDF predicts.
  *
- * \note If the dataset has errors stored, empty bins will prevent the calculation of \f$ \chi^2 \f$, because those have
- * zero error. This leads to messages like:
- * ```
- *   [#0] ERROR:Eval -- RooChi2Var::RooChi2Var(chi2_GenPdf_data_hist) INFINITY ERROR: bin 2 has zero error
- * ```
+\note If the dataset has errors stored, empty bins will prevent the calculation of \f$ \chi^2 \f$, because those have
+zero error. This leads to messages like:
+```
+  [#0] ERROR:Eval -- RooChi2Var::RooChi2Var(chi2_GenPdf_data_hist) INFINITY ERROR: bin 2 has zero error
+```
  *
- * \note In this case, one can use the expected errors of the PDF instead of the data errors:
- * ```{.cpp}
- * RooChi2Var chi2(..., ..., RooFit::DataError(RooAbsData::Expected), ...);
- * ```
+\note In this case, one can use the expected errors of the PDF instead of the data errors:
+```{.cpp}
+RooChi2Var chi2(..., ..., RooFit::DataError(RooAbsData::Expected), ...);
+```
+
  */
 
 #include "RooFit.h"
@@ -97,7 +98,7 @@ RooArgSet RooChi2Var::_emptySet ;
 
 ////////////////////////////////////////////////////////////////////////////////
 ///  RooChi2Var constructor. Optional arguments are:
-///  \param[in] name Name of the PDF 
+///  \param[in] name Name of the PDF
 ///  \param[in] title Title for plotting etc.
 ///  \param[in] func  Function
 ///  \param[in] hdata Data histogram
@@ -114,15 +115,16 @@ RooArgSet RooChi2Var::_emptySet ;
 ///  Verbose()    <td> Verbose output of GOF framework
 ///  <tr><td>
 ///  IntegrateBins()  <td> Integrate PDF within each bin. This sets the desired precision. Only useful for binned fits.
+
 RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataHist& hdata,
-		       const RooCmdArg& arg1,const RooCmdArg& arg2,const RooCmdArg& arg3,
-		       const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,
-		       const RooCmdArg& arg7,const RooCmdArg& arg8,const RooCmdArg& arg9) :
+             const RooCmdArg& arg1,const RooCmdArg& arg2,const RooCmdArg& arg3,
+             const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,
+             const RooCmdArg& arg7,const RooCmdArg& arg8,const RooCmdArg& arg9) :
   RooAbsOptTestStatistic(name,title,func,hdata,_emptySet,
           makeRooAbsTestStatisticCfgForFunc(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9))
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
-  pc.defineInt("etype","DataError",0,(Int_t)RooDataHist::Auto) ;  
+  pc.defineInt("etype","DataError",0,(Int_t)RooDataHist::Auto) ;
   pc.defineInt("extended","Extended",0,kFALSE) ;
   pc.allowUndefined() ;
 
@@ -147,8 +149,8 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsReal& func, Ro
 
 ////////////////////////////////////////////////////////////////////////////////
 ///  RooChi2Var constructor. Optional arguments taken
-///  
-///  \param[in] name Name of the PDF 
+///
+///  \param[in] name Name of the PDF
 ///  \param[in] title Title for plotting etc.
 ///  \param[in] pdf  PDF to fit
 ///  \param[in] hdata Data histogram
@@ -164,19 +166,20 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsReal& func, Ro
 ///  <tr><td>
 ///  Range()      <td> Fit only selected region
 ///  <tr><td>
-///  SumCoefRange() <td> Set the range in which to interpret the coefficients of RooAddPdf components 
+///  SumCoefRange() <td> Set the range in which to interpret the coefficients of RooAddPdf components
 ///  <tr><td>
-///  SplitRange() <td> Fit range is split by index catory of simultaneous PDF
+///  SplitRange() <td> Fit range is split by index category of simultaneous PDF
 ///  <tr><td>
-///  ConditionalObservables() <td> Define projected observables 
+///  ConditionalObservables() <td> Define projected observables
 ///  <tr><td>
 ///  Verbose()    <td> Verbose output of GOF framework
 ///  <tr><td>
 ///  IntegrateBins()  <td> Integrate PDF within each bin. This sets the desired precision.
+
 RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooDataHist& hdata,
-		       const RooCmdArg& arg1,const RooCmdArg& arg2,const RooCmdArg& arg3,
-		       const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,
-		       const RooCmdArg& arg7,const RooCmdArg& arg8,const RooCmdArg& arg9) :
+             const RooCmdArg& arg1,const RooCmdArg& arg2,const RooCmdArg& arg3,
+             const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,
+             const RooCmdArg& arg7,const RooCmdArg& arg8,const RooCmdArg& arg9) :
   RooAbsOptTestStatistic(name,title,pdf,hdata,
                          *static_cast<const RooArgSet*>(RooCmdConfig::decodeObjOnTheFly("RooChi2Var::RooChi2Var","ProjectedObservables",0,&_emptySet,
                                  arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
@@ -184,7 +187,7 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
   pc.defineInt("extended","Extended",0,kFALSE) ;
-  pc.defineInt("etype","DataError",0,(Int_t)RooDataHist::Auto) ;  
+  pc.defineInt("etype","DataError",0,(Int_t)RooDataHist::Auto) ;
   pc.allowUndefined() ;
 
   pc.process(arg1) ;  pc.process(arg2) ;  pc.process(arg3) ;
@@ -207,7 +210,7 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
 /// interpretation of fractions for all component RooAddPdfs that do
 /// not have a frozen range interpretation is set to chosen range
 /// name. If nCPU is greater than one the chi^2 calculation is
-/// paralellized over the specified number of processors. If
+/// parallelized over the specified number of processors. If
 /// interleave is true the partitioning of event over processors
 /// follows a (i % n == i_set) strategy rather than a bulk
 /// partitioning strategy which may result in unequal load balancing
@@ -233,7 +236,7 @@ RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooD
 /// the interpretation of fractions for all component RooAddPdfs that
 /// do not have a frozen range interpretation is set to chosen range
 /// name. If nCPU is greater than one the chi^2 calculation is
-/// paralellized over the specified number of processors. If
+/// parallelized over the specified number of processors. If
 /// interleave is true the partitioning of event over processors
 /// follows a (i % n == i_set) strategy rather than a bulk
 /// partitioning strategy which may result in unequal load balancing
@@ -245,7 +248,7 @@ RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooD
 RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsReal& func, RooDataHist& hdata,
                        const RooArgSet& projDeps, RooChi2Var::FuncMode fmode,
                        RooAbsTestStatistic::Configuration const& cfg,
-                       RooDataHist::ErrorType etype) : 
+                       RooDataHist::ErrorType etype) :
   RooAbsOptTestStatistic(name,title,func,hdata,projDeps,cfg),
   _etype(etype), _funcMode(fmode)
 {
@@ -256,7 +259,7 @@ RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsReal& func, Ro
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
 
-RooChi2Var::RooChi2Var(const RooChi2Var& other, const char* name) : 
+RooChi2Var::RooChi2Var(const RooChi2Var& other, const char* name) :
   RooAbsOptTestStatistic(other,name),
   _etype(other._etype),
   _funcMode(other._funcMode)
@@ -276,13 +279,14 @@ RooChi2Var::~RooChi2Var()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate chi^2 in partition from firstEvent to lastEvent using given stepSize
+/// Throughout the calculation, we use Kahan's algorithm for summing to
+/// prevent loss of precision - this is a factor four more expensive than
+/// straight addition, but since evaluating the PDF is usually much more
+/// expensive than that, we tolerate the additional cost...
 
 Double_t RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const
 {
-  // Throughout the calculation, we use Kahan's algorithm for summing to
-  // prevent loss of precision - this is a factor four more expensive than
-  // straight addition, but since evaluating the PDF is usually much more
-  // expensive than that, we tolerate the additional cost...
+
   Double_t result(0), carry(0);
 
   _dataClone->store()->recalculateCache( _projDeps, firstEvent, lastEvent, stepSize, kFALSE) ;
@@ -299,7 +303,7 @@ Double_t RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastE
   // Loop over bins of dataset
   RooDataHist* hdata = (RooDataHist*) _dataClone ;
   for (auto i=firstEvent ; i<lastEvent ; i+=stepSize) {
-    
+
     // get the data values for this event
     hdata->get(i);
 
@@ -320,29 +324,26 @@ Double_t RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastE
     } else {
       eInt = sqrt(nPdf) ;
     }
-    
+
     // Skip cases where pdf=0 and there is no data
     if (0. == eInt * eInt && 0. == nData * nData && 0. == nPdf * nPdf) continue ;
-    
+
     // Return 0 if eInt=0, special handling in MINUIT will follow
     if (0. == eInt * eInt) {
-      coutE(Eval) << "RooChi2Var::RooChi2Var(" << GetName() << ") INFINITY ERROR: bin " << i 
-		  << " has zero error" << endl ;
+      coutE(Eval) << "RooChi2Var::RooChi2Var(" << GetName() << ") INFINITY ERROR: bin " << i
+        << " has zero error" << endl ;
       return 0.;
     }
-    
+
 //     cout << "Chi2Var[" << i << "] nData = " << nData << " nPdf = " << nPdf << " errorExt = " << eExt << " errorInt = " << eInt << " contrib = " << eExt*eExt/(eInt*eInt) << endl ;
-    
+
     Double_t term = eExt*eExt/(eInt*eInt) ;
     Double_t y = term - carry;
     Double_t t = result + y;
     carry = (t - result) - y;
     result = t;
   }
-    
+
   _evalCarry = carry;
   return result ;
 }
-
-
-


### PR DESCRIPTION

Some \class directives were not correct (extra words like "The" or "A"....)
Fix some typos
Fix some doxygen comments.
Removes TAB
Removes white spaces 