### PR TITLE
[PyROOT] Add Python include paths with -isystem

### DIFF
--- a/bindings/jupyroot/CMakeLists.txt
+++ b/bindings/jupyroot/CMakeLists.txt
@@ -52,16 +52,7 @@ foreach(val RANGE ${how_many_pythons})
     target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all Core)
   endif()
 
-  target_include_directories(${libname} PRIVATE ${python_include_dir})
-
-  # Disables warnings originating from deprecated register keyword in Python
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
-    target_compile_options(${libname} PRIVATE -Wno-register)
-  endif()
-  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
-    target_compile_options(${libname} PRIVATE -Wno-register)
-    target_compile_options(${libname} PRIVATE -Wno-deprecated-register)
-  endif()
+  target_include_directories(${libname} SYSTEM PRIVATE ${python_include_dir})
 
   # Compile .py files
   foreach(py_source ${py_sources})

--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -82,26 +82,19 @@ foreach(val RANGE ${how_many_pythons})
     target_compile_options(${libname} PRIVATE -Wno-cast-function-type)
   endif()
 
-  # Disables warnings originating from deprecated register keyword in Python
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
-    target_compile_options(${libname} PRIVATE -Wno-register)
-  endif()
-  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
-    target_compile_options(${libname} PRIVATE -Wno-register)
-    target_compile_options(${libname} PRIVATE -Wno-deprecated-register)
-  endif()
-
   # Disables warnings due to new field tp_vectorcall in Python 3.8
   if(NOT MSVC AND ${python_version_string} VERSION_GREATER_EQUAL "3.8")
     target_compile_options(${libname} PRIVATE -Wno-missing-field-initializers)
   endif()
 
   target_include_directories(${libname}
+     SYSTEM PUBLIC ${python_include_dir})
+
+  target_include_directories(${libname}
      PRIVATE
         ${CMAKE_SOURCE_DIR}/core/foundation/inc   # needed for string_view backport
         ${CMAKE_BINARY_DIR}/ginclude
      PUBLIC
-        ${python_include_dir}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   )

--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -111,21 +111,14 @@ foreach(val RANGE ${how_many_pythons})
   endif()
 
   target_include_directories(${libname}
-     PRIVATE ${python_include_dir}
-     PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
+     SYSTEM PRIVATE ${python_include_dir})
+
+  target_include_directories(${libname}
+     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
 
   # Disables warnings caused by Py_RETURN_TRUE/Py_RETURN_FALSE
   if(NOT MSVC)
     target_compile_options(${libname} PRIVATE -Wno-strict-aliasing)
-  endif()
-
-  # Disables warnings originating from deprecated register keyword in Python
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
-    target_compile_options(${libname} PRIVATE -Wno-register)
-  endif()
-  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_STANDARD GREATER_EQUAL 11)
-    target_compile_options(${libname} PRIVATE -Wno-register)
-    target_compile_options(${libname} PRIVATE -Wno-deprecated-register)
   endif()
 
   # Compile .py files


### PR DESCRIPTION
Prevent warnings about the 'register' keyword in Python2 headers.

The explicit silencing of such warnings can also be removed.