### PR TITLE
[PyROOT][8183] Fix TTreeReader iteration

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -53,6 +53,7 @@ set(py_sources
   ROOT/pythonization/_tseqcollection.py
   ROOT/pythonization/_tstring.py
   ROOT/pythonization/_ttree.py
+  ROOT/pythonization/_ttreereader.py
   ROOT/pythonization/_tvector3.py
   ROOT/pythonization/_tvectort.py
   ${PYROOT_EXTRA_PYSOURCE}

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_ttreereader.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_ttreereader.py
@@ -1,0 +1,31 @@
+# Author: Enric Tejedor CERN  05/2021
+
+################################################################################
+# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from ROOT import pythonization
+
+
+# Iteration
+def _iter(self):
+    # Parameters:
+    # - self: TTreeReader object
+    # Returns:
+    # - A TTreeReader iterator for self
+    while self.Next():
+        yield self.GetCurrentEntry()
+
+
+@pythonization()
+def pythonize_ttreereader(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: name of the class
+
+    if name == 'TTreeReader':
+        klass.__iter__ = _iter

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -46,6 +46,9 @@ if (dataframe)
     ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_asmatrix ttree_asmatrix.py PYTHON_DEPS numpy)
 endif()
 
+# TTreeReader pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_ttreereader_iterable ttreereader_iterable.py)
+
 # TH1 and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_th1_operators th1_operators.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_th2 th2.py)

--- a/bindings/pyroot/pythonizations/test/ttreereader_iterable.py
+++ b/bindings/pyroot/pythonizations/test/ttreereader_iterable.py
@@ -1,0 +1,31 @@
+import unittest
+
+import ROOT
+
+
+class TTreeReaderIterable(unittest.TestCase):
+    """
+    Test for the pythonization that makes instances of TTreeReader
+    iterable in Python.
+    """
+
+    # Tests
+    def test_iterable(self):
+        # Create test tree
+        filename = "ttreereader_iterable.root"
+        rdf = ROOT.RDataFrame(10).Define("x", "int(rdfentry_)").Snapshot("t", filename)
+
+        f = ROOT.TFile(filename)
+        t = f.Get("t")
+        r = ROOT.TTreeReader(t)
+        x = ROOT.TTreeReaderValue['int'](r, "x")
+
+        # Check correspondance between entry number returned by the iterator,
+        # entry number of the reader and value of x
+        for entry in r:
+            self.assertEqual(entry, r.GetCurrentEntry())
+            self.assertEqual(entry, x.__deref__())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The out-of-the-box iterator provided by cppyy is not fully
applicable in the case of TTreeReader: in a given iteration, the
entry number returned by the iterator is correct, but it is
always behind the entry number of the reader itself.

This commit fixes such decoupling by relying on TTreeReader::Next()
and adds a test for it.

Fixes #8183 