### PR TITLE
Use RooMinimizer instead of RooMinuit

### DIFF
--- a/tutorials/roofit/rf601_intminuit.py
+++ b/tutorials/roofit/rf601_intminuit.py
@@ -43,7 +43,7 @@ nll = model.createNLL(data)
 # -------------------------------------------------------------------------------
 
 # Create MINUIT interface object
-m = ROOT.RooMinuit(nll)
+m = ROOT.RooMinimizer(nll)
 
 # Activate verbose logging of MINUIT parameter space stepping
 m.setVerbose(ROOT.kTRUE)
@@ -84,7 +84,7 @@ r = m.save()
 
 # Make contour plot of mx vs sx at 1,2, sigma
 frame = m.contour(frac, sigma_g2, 1, 2, 3)
-frame.SetTitle("RooMinuit contour plot")
+frame.SetTitle("Contour plot")
 
 # Print the fit result snapshot
 r.Print("v")

--- a/tutorials/roofit/rf605_profilell.py
+++ b/tutorials/roofit/rf605_profilell.py
@@ -43,7 +43,7 @@ data = model.generate(ROOT.RooArgSet(x), 1000)
 nll = model.createNLL(data, ROOT.RooFit.NumCPU(2))
 
 # Minimize likelihood w.r.t all parameters before making plots
-ROOT.RooMinuit(nll).migrad()
+ROOT.RooMinimizer(nll).migrad()
 
 # Plot likelihood scan frac
 frame1 = frac.frame(ROOT.RooFit.Bins(10), ROOT.RooFit.Range(0.01, 0.95), ROOT.RooFit.Title("LL and profileLL in frac"))


### PR DESCRIPTION
The tutorials should show the use of the RooMinimizer class instead of RooMinuit, which is the older class supporting only TMinuit and  it will be deprecated in the future.