### PR TITLE
[clad] Bump clad version to v0.8.

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 ExternalProject_Add(
   clad
   GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-  GIT_TAG v0.7
+  GIT_TAG v0.8
   UPDATE_COMMAND ""
   CMAKE_ARGS -G ${CMAKE_GENERATOR}
              -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
The new release includes some improvements:
* Implement #pragma clad ON/OFF/DEFAULT to control regions where clad is active
* Add getCode() interface for interactive use

See more at: https://github.com/vgvassilev/clad/blob/v0.8/docs/ReleaseNotes.md