### PR TITLE
[DF] Do not store references to callables in PassAsVec 

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -49,7 +49,7 @@ template <std::size_t... N, typename T, typename F>
 class PassAsVecHelper<std::index_sequence<N...>, T, F> {
    template <std::size_t Idx>
    using AlwaysT = T;
-   F fFunc;
+   typename std::decay<F>::type fFunc;
 
 public:
    PassAsVecHelper(F &&f) : fFunc(std::forward<F>(f)) {}

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -56,6 +56,19 @@ TEST(RDFHelpers, PassAsVec)
    EXPECT_EQ(1u, *df.Filter(PassAsVec<2, int>(TwoOnesDeque), {"one", "_1"}).Count());
 }
 
+
+// this tests https://github.com/root-project/root/issues/8276
+TEST(RDFHelpers, ReturnPassAsVec)
+{
+   auto returnPassAsVecLambda = [] {
+      double f = 42;
+      auto fn = [f](std::vector<int>) { return f; };
+      return PassAsVec<1, int>(fn);
+   };
+   auto fn = returnPassAsVecLambda();
+   EXPECT_EQ(fn(0), 42.);
+}
+
 class SaveGraphTestHelper {
 private:
    RDataFrame rd1;


### PR DESCRIPTION
Make sure to always store the callables by value.
This fixes #8276.