### PR TITLE
[DF] Do not store references to callables in PassAsVec (6.24)

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -49,7 +49,7 @@ template <std::size_t... N, typename T, typename F>
 class PassAsVecHelper<std::index_sequence<N...>, T, F> {
    template <std::size_t Idx>
    using AlwaysT = T;
-   F fFunc;
+   typename std::decay<F>::type fFunc;
 
 public:
    PassAsVecHelper(F &&f) : fFunc(std::forward<F>(f)) {}


### PR DESCRIPTION
Make sure to always store the callables by value.
This fixes #8276.