### PR TITLE
[ntuple] Check TKey class name is RNTuple

### DIFF
--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -961,6 +961,11 @@ ROOT::Experimental::Internal::RMiniFileReader::GetNTupleProper(std::string_view 
 
       offset += key.GetHeaderSize();
       ReadBuffer(&name, 1, offset);
+      ReadBuffer(&name, name.GetSize(), offset);
+      if (std::string_view(name.fData, name.fLName) != kNTupleClassName) {
+         offset = offsetNextKey;
+         continue;
+      }
       offset += name.GetSize();
       ReadBuffer(&name, 1, offset);
       ReadBuffer(&name, name.GetSize(), offset);


### PR DESCRIPTION
Fixes issue #8284 where TKeys with the same name as the requested RNTuple
would be attempted to be parsed as an RNTuple, leading to internal
parser assert failures later on.

e.g.
```cpp
// actually holds a TTree named "Events"
auto reader = RNTupleReader::Open("Events", "test80X_NANO.root");
```

Internal error before: 
```
Fatal: nread == nbytes violated at line 1011 of `~/root/tree/ntuple/v7/src/RMiniFile.cxx'
aborting
```

Exception thrown after: 
```
C++ exception with description "no RNTuple named 'Events' in file 'test80X_NANO.root' (unchecked RResult access!)
```