### PR TITLE
[core][6.24] Missing include in string_view header

### DIFF
--- a/core/foundation/inc/ROOT/libcpp_string_view.h
+++ b/core/foundation/inc/ROOT/libcpp_string_view.h
@@ -186,6 +186,7 @@ namespace std {
 #include <ostream>
 #include <iomanip>
 #include <stdexcept>
+#include <limits>
 
 //#include <__debug>
 


### PR DESCRIPTION
FIxes #8281 