### PR TITLE
Fix Math tutorials when libMathmore is not available

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -180,6 +180,7 @@ if(NOT ROOT_mathmore_FOUND)
       math/LegendreAssoc.C
       math/Legendre.C
       math/mathmoreIntegration.C
+      math/multivarGaus.C
       math/tStudent.C
       math/normalDist.C
       roostats/TestNonCentral.C

--- a/tutorials/math/exampleFunction.py
+++ b/tutorials/math/exampleFunction.py
@@ -68,7 +68,11 @@ def g(x): return 2 * x
 gradFunc = ROOT.Math.GradFunctor1D(f, g)
 
 #check if ROOT has mathmore
-if (ROOT.gSystem.Load("libMathMore") < 0) :
+prevLevel = ROOT.gErrorIgnoreLevel
+ROOT.gErrorIgnoreLevel=ROOT.kFatal
+ret = ROOT.gSystem.Load("libMathMore") 
+ROOT.gErrorIgnoreLevel=prevLevel
+if (ret < 0) :
    print("ROOT has not Mathmore")
    print("derivative value at x = 1", gradFunc.Derivative(1) )
 


### PR DESCRIPTION
- Veto tutorial multiVarGaus.C when mathmore is not available
- Disable printing error message in exampleFunction.py when mathmore is not available

This fixes ROOT-8145