### PR TITLE
[core][6.18][skip-ci] Missing include in string_view header

### DIFF
--- a/core/foundation/inc/ROOT/libcpp_string_view.h
+++ b/core/foundation/inc/ROOT/libcpp_string_view.h
@@ -186,6 +186,7 @@ namespace std {
 #include <ostream>
 #include <iomanip>
 #include <stdexcept>
+#include <limits>
 
 //#include <__debug>
 


### PR DESCRIPTION
6.18 Backport of #8107 according to discussion in #8281