### PR TITLE
Fix bias in RANLUX++

### DIFF
--- a/math/mathcore/inc/Math/RanluxppEngine.h
+++ b/math/mathcore/inc/Math/RanluxppEngine.h
@@ -27,17 +27,17 @@ template <int p>
 class RanluxppEngine final : public TRandomEngine {
 
 private:
-   std::unique_ptr<RanluxppEngineImpl<52, p>> fImpl;
+   std::unique_ptr<RanluxppEngineImpl<48, p>> fImpl;
 
 public:
    RanluxppEngine(uint64_t seed = 314159265);
    virtual ~RanluxppEngine();
 
-   /// Generate a double-precision random number with 52 bits of randomness
+   /// Generate a double-precision random number with 48 bits of randomness
    double Rndm() override;
    /// Generate a double-precision random number (non-virtual method)
    double operator()();
-   /// Generate a random integer value with 52 bits
+   /// Generate a random integer value with 48 bits
    uint64_t IntRndm();
 
    /// Initialize and seed the state of the generator

--- a/math/mathcore/src/RanluxppEngineImpl.cxx
+++ b/math/mathcore/src/RanluxppEngineImpl.cxx
@@ -25,7 +25,7 @@ available at https://github.com/sibidanov/ranluxpp/.
 
 #include "Math/RanluxppEngine.h"
 
-#include "mulmod.h"
+#include "ranluxpp/mulmod.h"
 
 #include <cassert>
 #include <cstdint>

--- a/math/mathcore/src/RanluxppEngineImpl.cxx
+++ b/math/mathcore/src/RanluxppEngineImpl.cxx
@@ -14,13 +14,18 @@ Implementation of the RANLUX++ generator
 
 RANLUX++ is an LCG equivalent of RANLUX using 576 bit numbers.
 
-Described in
+The idea of the generator (such as the initialization method) and the algorithm
+for the modulo operation are described in
 A. Sibidanov, *A revision of the subtract-with-borrow random numbergenerators*,
 *Computer Physics Communications*, 221(2017), 299-303,
 preprint https://arxiv.org/pdf/1705.03123.pdf
 
 The code is loosely based on the Assembly implementation by A. Sibidanov
 available at https://github.com/sibidanov/ranluxpp/.
+
+Compared to the original generator, this implementation contains a fix to ensure
+that the modulo operation of the LCG always returns the smallest value congruent
+to the modulus (based on notes by M. Lüscher).
 */
 
 #include "Math/RanluxppEngine.h"

--- a/math/mathcore/src/ranluxpp/helpers.h
+++ b/math/mathcore/src/ranluxpp/helpers.h
@@ -52,4 +52,105 @@ static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
    return sub;
 }
 
+/// Update r = r - (t1 + t2) + (t3 + t2) * b ** 10
+///
+/// This function also yields cbar = floor(r / m) as its return value (int64_t
+/// because the value can be -1). With an initial value of r = t0, this can
+/// be used for computing the remainder after division by m (see the function
+/// mod_m in mulmod.h). The function to_ranlux passes r = 0 and uses only the
+/// return value to obtain the decimal expansion after divison by m.
+static inline int64_t compute_r(const uint64_t *upper, uint64_t *r)
+{
+   // Subtract t1 (24 * 24 = 576 bits)
+   unsigned carry = 0;
+   for (int i = 0; i < 9; i++) {
+      uint64_t r_i = r[i];
+      r_i = sub_overflow(r_i, carry, carry);
+
+      uint64_t t1_i = upper[i];
+      r_i = sub_carry(r_i, t1_i, carry);
+      r[i] = r_i;
+   }
+   int64_t c = -((int64_t)carry);
+
+   // Subtract t2 (only 240 bits, so need to extend)
+   carry = 0;
+   for (int i = 0; i < 9; i++) {
+      uint64_t r_i = r[i];
+      r_i = sub_overflow(r_i, carry, carry);
+
+      uint64_t t2_bits = 0;
+      if (i < 4) {
+         t2_bits += upper[i + 5] >> 16;
+         if (i < 3) {
+            t2_bits += upper[i + 6] << 48;
+         }
+      }
+      r_i = sub_carry(r_i, t2_bits, carry);
+      r[i] = r_i;
+   }
+   c -= carry;
+
+   // r += (t3 + t2) * 2 ** 240
+   carry = 0;
+   {
+      uint64_t r_3 = r[3];
+      // 16 upper bits
+      uint64_t t2_bits = (upper[5] >> 16) << 48;
+      uint64_t t3_bits = (upper[0] << 48);
+
+      r_3 = add_carry(r_3, t2_bits, carry);
+      r_3 = add_carry(r_3, t3_bits, carry);
+
+      r[3] = r_3;
+   }
+   for (int i = 0; i < 3; i++) {
+      uint64_t r_i = r[i + 4];
+      r_i = add_overflow(r_i, carry, carry);
+
+      uint64_t t2_bits = (upper[5 + i] >> 32) + (upper[6 + i] << 32);
+      uint64_t t3_bits = (upper[i] >> 16) + (upper[1 + i] << 48);
+
+      r_i = add_carry(r_i, t2_bits, carry);
+      r_i = add_carry(r_i, t3_bits, carry);
+
+      r[i + 4] = r_i;
+   }
+   {
+      uint64_t r_7 = r[7];
+      r_7 = add_overflow(r_7, carry, carry);
+
+      uint64_t t2_bits = (upper[8] >> 32);
+      uint64_t t3_bits = (upper[3] >> 16) + (upper[4] << 48);
+
+      r_7 = add_carry(r_7, t2_bits, carry);
+      r_7 = add_carry(r_7, t3_bits, carry);
+
+      r[7] = r_7;
+   }
+   {
+      uint64_t r_8 = r[8];
+      r_8 = add_overflow(r_8, carry, carry);
+
+      uint64_t t3_bits = (upper[4] >> 16) + (upper[5] << 48);
+
+      r_8 = add_carry(r_8, t3_bits, carry);
+
+      r[8] = r_8;
+   }
+   c += carry;
+
+   // c = floor(r / 2 ** 576) has been computed along the way via the carry
+   // flags. Now if c = 0 and the value currently stored in r is greater or
+   // equal to m, we need cbar = 1 and subtract m, otherwise cbar = c. The
+   // value currently in r is greater or equal to m, if and only if one of
+   // the last 240 bits is set and the upper bits are all set.
+   bool greater_m = r[0] | r[1] | r[2] | (r[3] & 0x0000ffffffffffff);
+   greater_m &= (r[3] >> 48) == 0xffff;
+   for (int i = 4; i < 9; i++) {
+      greater_m &= (r[i] == UINT64_MAX);
+   }
+   return c + (c == 0 && greater_m);
+}
+
 #endif

--- a/math/mathcore/src/ranluxpp/helpers.h
+++ b/math/mathcore/src/ranluxpp/helpers.h
@@ -1,0 +1,55 @@
+// @(#)root/mathcore:$Id$
+// Author: Jonas Hahnfeld 11/2020
+
+/*************************************************************************
+ * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef RANLUXPP_HELPERS_H
+#define RANLUXPP_HELPERS_H
+
+#include <cstdint>
+
+/// Compute `a + b` and set `overflow` accordingly.
+static inline uint64_t add_overflow(uint64_t a, uint64_t b, unsigned &overflow)
+{
+   uint64_t add = a + b;
+   overflow = (add < a);
+   return add;
+}
+
+/// Compute `a + b` and increment `carry` if there was an overflow
+static inline uint64_t add_carry(uint64_t a, uint64_t b, unsigned &carry)
+{
+   unsigned overflow;
+   uint64_t add = add_overflow(a, b, overflow);
+   // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
+   // no overflow.
+   carry += overflow;
+   return add;
+}
+
+/// Compute `a - b` and set `overflow` accordingly
+static inline uint64_t sub_overflow(uint64_t a, uint64_t b, unsigned &overflow)
+{
+   uint64_t sub = a - b;
+   overflow = (sub > a);
+   return sub;
+}
+
+/// Compute `a - b` and increment `carry` if there was an overflow
+static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
+{
+   unsigned overflow;
+   uint64_t sub = sub_overflow(a, b, overflow);
+   // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
+   // no overflow.
+   carry += overflow;
+   return sub;
+}
+
+#endif

--- a/math/mathcore/src/ranluxpp/mulmod.h
+++ b/math/mathcore/src/ranluxpp/mulmod.h
@@ -9,52 +9,19 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+#ifndef RANLUXPP_MULMOD_H
+#define RANLUXPP_MULMOD_H
+
+#include "helpers.h"
+
 #include <cstdint>
-
-/// Compute `a + b` and set `overflow` accordingly.
-static inline uint64_t add_overflow(uint64_t a, uint64_t b, unsigned &overflow)
-{
-   uint64_t add = a + b;
-   overflow = (add < a);
-   return add;
-}
-
-/// Compute `a + b` and increment `carry` if there was an overflow
-static inline uint64_t add_carry(uint64_t a, uint64_t b, unsigned &carry)
-{
-   unsigned overflow;
-   uint64_t add = add_overflow(a, b, overflow);
-   // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
-   // no overflow.
-   carry += overflow;
-   return add;
-}
-
-/// Compute `a - b` and set `overflow` accordingly
-static inline uint64_t sub_overflow(uint64_t a, uint64_t b, unsigned &overflow)
-{
-   uint64_t sub = a - b;
-   overflow = (sub > a);
-   return sub;
-}
-
-/// Compute `a - b` and increment `carry` if there was an overflow
-static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
-{
-   unsigned overflow;
-   uint64_t sub = sub_overflow(a, b, overflow);
-   // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
-   // no overflow.
-   carry += overflow;
-   return sub;
-}
 
 /// Multiply two 576 bit numbers, stored as 9 numbers of 64 bits each
 ///
 /// \param[in] in1 first factor as 9 numbers of 64 bits each
 /// \param[in] in2 second factor as 9 numbers of 64 bits each
 /// \param[out] out result with 18 numbers of 64 bits each
-void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
+static void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
 {
    uint64_t next = 0;
    unsigned nextCarry = 0;
@@ -169,7 +136,7 @@ void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
 ///
 /// Note that this function does *not* return the smallest value congruent to
 /// the modulus, it only guarantees a value smaller than \f$ 2^{576} \$!
-void mod_m(const uint64_t *mul, uint64_t *out)
+static void mod_m(const uint64_t *mul, uint64_t *out)
 {
    uint64_t r[9] = {0};
 
@@ -314,7 +281,7 @@ void mod_m(const uint64_t *mul, uint64_t *out)
 ///
 /// \param[in] in1 first factor with 9 numbers of 64 bits each
 /// \param[inout] inout second factor and also the output of the same size
-void mulmod(const uint64_t *in1, uint64_t *inout)
+static void mulmod(const uint64_t *in1, uint64_t *inout)
 {
    uint64_t mul[2 * 9] = {0};
    multiply9x9(in1, inout, mul);
@@ -328,7 +295,7 @@ void mulmod(const uint64_t *in1, uint64_t *inout)
 /// \param[in] n exponent
 ///
 /// The arguments base and res may point to the same location.
-void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
+static void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
 {
    uint64_t fac[9] = {0};
    fac[0] = base[0];
@@ -351,3 +318,5 @@ void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
       mod_m(mul, fac);
    }
 }
+
+#endif

--- a/math/mathcore/src/ranluxpp/ranlux_lcg.h
+++ b/math/mathcore/src/ranluxpp/ranlux_lcg.h
@@ -1,0 +1,92 @@
+// @(#)root/mathcore:$Id$
+// Author: Jonas Hahnfeld 05/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef RANLUXPP_RANLUX_LCG_H
+#define RANLUXPP_RANLUX_LCG_H
+
+#include "helpers.h"
+
+#include <cstdint>
+
+/// Convert RANLUX numbers to an LCG state
+///
+/// \param[in] ranlux the RANLUX numbers as 576 bits
+/// \param[out] lcg the 576 bits of the LCG state, smaller than m
+/// \param[in] c the carry bit of the RANLUX state
+///
+/// \f$ m = 2^{576} - 2^{240} + 1 \f$
+static void to_lcg(const uint64_t *ranlux, unsigned c, uint64_t *lcg)
+{
+   unsigned carry = 0;
+   // Subtract the final 240 bits.
+   for (int i = 0; i < 9; i++) {
+      uint64_t ranlux_i = ranlux[i];
+      uint64_t lcg_i = sub_overflow(ranlux_i, carry, carry);
+
+      uint64_t bits = 0;
+      if (i < 4) {
+         bits += ranlux[i + 5] >> 16;
+         if (i < 3) {
+            bits += ranlux[i + 6] << 48;
+         }
+      }
+      lcg_i = sub_carry(lcg_i, bits, carry);
+      lcg[i] = lcg_i;
+   }
+
+   // Add and propagate the carry bit.
+   for (int i = 0; i < 9; i++) {
+      lcg[i] = add_overflow(lcg[i], c, c);
+   }
+}
+
+/// Convert an LCG state to RANLUX numbers
+///
+/// \param[in] lcg the 576 bits of the LCG state, must be smaller than m
+/// \param[out] ranlux the RANLUX numbers as 576 bits
+/// \param[out] c the carry bit of the RANLUX state
+///
+/// \f$ m = 2^{576} - 2^{240} + 1 \f$
+static void to_ranlux(const uint64_t *lcg, uint64_t *ranlux, unsigned &c_out)
+{
+   uint64_t r[9] = {0};
+   int64_t c = compute_r(lcg, r);
+
+   // ranlux = t1 + t2 + c
+   unsigned carry = 0;
+   for (int i = 0; i < 9; i++) {
+      uint64_t in_i = lcg[i];
+      uint64_t tmp_i = add_overflow(in_i, carry, carry);
+
+      uint64_t bits = 0;
+      if (i < 4) {
+         bits += lcg[i + 5] >> 16;
+         if (i < 3) {
+            bits += lcg[i + 6] << 48;
+         }
+      }
+      tmp_i = add_carry(tmp_i, bits, carry);
+      ranlux[i] = tmp_i;
+   }
+
+   // If c = -1, we need to add it to all components.
+   int64_t c1 = c >> 1;
+   ranlux[0] = add_overflow(ranlux[0], c, carry);
+   for (int i = 1; i < 9; i++) {
+      uint64_t ranlux_i = ranlux[i];
+      ranlux_i = add_overflow(ranlux_i, carry, carry);
+      ranlux_i = add_carry(ranlux_i, c1, carry);
+   }
+
+   c_out = carry;
+}
+
+#endif

--- a/math/mathcore/test/CMakeLists.txt
+++ b/math/mathcore/test/CMakeLists.txt
@@ -81,6 +81,7 @@ ROOT_ADD_GTEST(GradientFittingUnit testGradientFitting.cxx LIBRARIES Core MathCo
 
 ROOT_ADD_GTEST(MulmodUnitOpt mulmod_opt.cxx)
 ROOT_ADD_GTEST(MulmodUnitNoInt128 mulmod_noint128.cxx)
+ROOT_ADD_GTEST(RanluxLCGUnit ranlux_lcg.cxx)
 
 ROOT_ADD_GTEST(RanluxppEngineTests RanluxppEngine.cxx
         LIBRARIES Core MathCore)

--- a/math/mathcore/test/RanluxppEngine.cxx
+++ b/math/mathcore/test/RanluxppEngine.cxx
@@ -9,34 +9,40 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+// This test uses EXPECT_EQ also for floating point numbers - the expected
+// values are entered with enough digits to ensure binary equality.
+
 #include "Math/RanluxppEngine.h"
 
 #include "gtest/gtest.h"
 
 using namespace ROOT::Math;
 
-TEST(RanluxppEngine, DISABLED_random2048)
+TEST(RanluxppEngine, random2048)
 {
    RanluxppEngine2048 rng(314159265);
-   // Match the assembly implementation in skipping the first 11 numbers.
-   rng.Skip(11);
 
-   // Values extracted from the assembly implementation.
-   EXPECT_EQ(rng.IntRndm(), 1357063655714534);
-   EXPECT_DOUBLE_EQ(rng.Rndm(), 0.500504017418743);
+   // The following values were obtained without skipping.
+
+   EXPECT_EQ(rng.IntRndm(), 39378223178113);
+   EXPECT_EQ(rng.Rndm(), 0.57072241146576274673);
 
    // Skip ahead in block.
-   rng.Skip(2);
-   EXPECT_EQ(rng.IntRndm(), 160414309741165);
-   EXPECT_DOUBLE_EQ(rng.Rndm(), 0.9422050833832005);
+   rng.Skip(8);
+   EXPECT_EQ(rng.IntRndm(), 52221857391813);
+   EXPECT_EQ(rng.Rndm(), 0.16812543081078956675);
+
+   // The next call needs to advance the state.
+   EXPECT_EQ(rng.IntRndm(), 185005245121693);
+   EXPECT_EQ(rng.Rndm(), 0.28403302782895423206);
 
    // Skip ahead to start of next block.
-   rng.Skip(5);
-   EXPECT_EQ(rng.IntRndm(), 911953872946889);
-   EXPECT_DOUBLE_EQ(rng.Rndm(), 0.7498142796273863);
+   rng.Skip(10);
+   EXPECT_EQ(rng.IntRndm(), 89237874214503);
+   EXPECT_EQ(rng.Rndm(), 0.79969842495805920635);
 
    // Skip ahead across blocks.
    rng.Skip(42);
-   EXPECT_EQ(rng.IntRndm(), 4265826975858336);
-   EXPECT_DOUBLE_EQ(rng.Rndm(), 0.472544363223621);
+   EXPECT_EQ(rng.IntRndm(), 49145148745150);
+   EXPECT_EQ(rng.Rndm(), 0.74670661284082484599);
 }

--- a/math/mathcore/test/RanluxppEngine.cxx
+++ b/math/mathcore/test/RanluxppEngine.cxx
@@ -15,7 +15,7 @@
 
 using namespace ROOT::Math;
 
-TEST(RanluxppEngine, random2048)
+TEST(RanluxppEngine, DISABLED_random2048)
 {
    RanluxppEngine2048 rng(314159265);
    // Match the assembly implementation in skipping the first 11 numbers.

--- a/math/mathcore/test/mulmod.icc
+++ b/math/mathcore/test/mulmod.icc
@@ -111,10 +111,8 @@ TEST(mod_m, modulus)
 
    mod_m(mul, mod);
 
-   // mod_m does not provide the smallest value, but just a value smaller than
-   // 2 ** 576 that is congruent to mul; in this case, mul itself.
    for (int i = 0; i < 9; i++) {
-      EXPECT_EQ(mod[i], mul[i]);
+      EXPECT_EQ(mod[i], 0);
    }
 }
 
@@ -230,6 +228,8 @@ TEST(mod_m, r_max)
    }
 }
 
+// The modulus m = 2 ** 576 - 2 ** 240 + 1.
+
 TEST(mulmod, simple)
 {
    uint64_t in1[9] = {0};
@@ -247,6 +247,51 @@ TEST(mulmod, simple)
    }
    EXPECT_EQ(inout[3], 0x0000ffffffffffff);
    for (int i = 4; i < 9; i++) {
+      EXPECT_EQ(inout[i], 0);
+   }
+}
+
+TEST(mulmod, modulus)
+{
+   // in1 = m = 2 ** 576 - 2 ** 240 + 1
+   uint64_t in1[9] = {0};
+   in1[0] = 1;
+   in1[3] = 0xffff000000000000;
+   for (int i = 4; i < 9; i++) {
+      in1[i] = 0xffffffffffffffff;
+   }
+   uint64_t inout[9] = {0};
+   inout[0] = 1;
+   // After multiplying the two values, the result will be the modulus m.
+
+   mulmod(in1, inout);
+
+   // mulmod should provide the smallest value congruent to m; in this case 0.
+   for (int i = 0; i < 9; i++) {
+      EXPECT_EQ(inout[i], 0);
+   }
+}
+
+TEST(mulmod, multiple_modulus)
+{
+   // in1 = m = 2 ** 576 - 2 ** 240 + 1
+   uint64_t in1[9] = {0};
+   in1[0] = 1;
+   in1[3] = 0xffff000000000000;
+   for (int i = 4; i < 9; i++) {
+      in1[i] = 0xffffffffffffffff;
+   }
+   uint64_t inout[9];
+   for (int i = 0; i < 9; i++) {
+      inout[i] = 1;
+   }
+   // After multiplying the two values, the result will be a multiple of the
+   // modulus m.
+
+   mulmod(in1, inout);
+
+   // mulmod should provide the smallest value congruent to m; in this case 0.
+   for (int i = 0; i < 9; i++) {
       EXPECT_EQ(inout[i], 0);
    }
 }

--- a/math/mathcore/test/mulmod.icc
+++ b/math/mathcore/test/mulmod.icc
@@ -70,10 +70,7 @@ TEST(multiply9x9, max)
    // and the following Python program:
    //     >>> a = b = (1 << 576) - 1
    //     >>> mul = a * b
-   //     >>> while mul > 0:
-   //     ...     print(hex(mul & 0xffffffffffffffff))
-   //     ...     mul = mul >> 64
-   //     ...
+   //     >>> print(hex(mul))
    EXPECT_EQ(mul[0], 1);
    for (int i = 1; i < 9; i++) {
       EXPECT_EQ(mul[i], 0);
@@ -181,6 +178,11 @@ TEST(mod_m, pattern)
 
 TEST(mod_m, r_min)
 {
+   // To make r = t_0 - (t_1 + t_2) + (t_3 + t_2) * 2 ** 240 minimal (and
+   // negative!), we need t_0 = 0, t_2 = max (because it also aliases the
+   // upper bits of t_1) and t_3 = 0 (it aliases the lower bits of t_1, but
+   // is multiplied with 2 ** 240 for the second, positive term).
+
    uint64_t mul[18] = {0};
    mul[14] = 0xffffffffffff0000;
    for (int i = 15; i < 18; i++) {
@@ -204,6 +206,11 @@ TEST(mod_m, r_min)
 
 TEST(mod_m, r_max)
 {
+   // To make r = t_0 - (t_1 + t_2) + (t_3 + t_2) * 2 ** 240 maximal (and larger
+   // than 2 ** 576!), we need t_0 = max, t_2 = 0 (because it also aliases the
+   // upper bits of t_1) and t_3 = max (it aliases the lower bits of t_1, but is
+   // multiplied with 2 ** 240 for the second, positive term).
+
    uint64_t mul[18] = {0};
    for (int i = 0; i < 14; i++) {
       mul[i] = UINT64_MAX;
@@ -220,6 +227,27 @@ TEST(mod_m, r_max)
    EXPECT_EQ(mod[5], 0xfffffffffffeffff);
    for (int i = 6; i < 9; i++) {
       EXPECT_EQ(mod[i], 0xffffffffffffffff);
+   }
+}
+
+TEST(mulmod, simple)
+{
+   uint64_t in1[9] = {0};
+   uint64_t inout[9] = {0};
+   in1[4] = (uint64_t(1) << 32);
+   inout[4] = (uint64_t(1) << 32);
+   // After multiplying the two values, (2 ** 288) * (2 ** 288) = 2 ** 576.
+
+   mulmod(in1, inout);
+
+   // The same result as mod_m::simple above:
+   // inout = 2 ** 576 - m = 2 ** 240 - 1, all first 240 bits set.
+   for (int i = 0; i < 3; i++) {
+      EXPECT_EQ(inout[i], 0xffffffffffffffff);
+   }
+   EXPECT_EQ(inout[3], 0x0000ffffffffffff);
+   for (int i = 4; i < 9; i++) {
+      EXPECT_EQ(inout[i], 0);
    }
 }
 
@@ -246,7 +274,7 @@ TEST(powermod, mod)
    powermod(base, res, 576);
 
    // The same result as mod_m::simple above:
-   // mod = 2 ** 576 - m = 2 ** 240 - 1, all first 240 bits set.
+   // res = 2 ** 576 - m = 2 ** 240 - 1, all first 240 bits set.
    for (int i = 0; i < 3; i++) {
       EXPECT_EQ(res[i], 0xffffffffffffffff);
    }

--- a/math/mathcore/test/mulmod.icc
+++ b/math/mathcore/test/mulmod.icc
@@ -9,7 +9,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "../src/mulmod.h"
+#include "../src/ranluxpp/mulmod.h"
 
 #include "gtest/gtest.h"
 

--- a/math/mathcore/test/ranlux_lcg.cxx
+++ b/math/mathcore/test/ranlux_lcg.cxx
@@ -1,0 +1,400 @@
+// @(#)root/mathcore:$Id$
+// Author: Jonas Hahnfeld 05/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "../src/ranluxpp/ranlux_lcg.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdint>
+
+TEST(to_lcg, zero)
+{
+   // RANLUX state with zero in all components.
+   uint64_t ranlux[9] = {0};
+   unsigned c = 0;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   for (int i = 0; i < 9; i++) {
+      EXPECT_EQ(lcg[i], 0);
+   }
+}
+
+TEST(to_lcg, one)
+{
+   // RANLUX state with a one in the last component.
+   uint64_t ranlux[9] = {1, 0, 0, 0, 0, 0, 0, 0, 0};
+   unsigned c = 0;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   EXPECT_EQ(lcg[0], 1);
+   for (int i = 1; i < 9; i++) {
+      EXPECT_EQ(lcg[i], 0);
+   }
+}
+
+TEST(to_lcg, carry)
+{
+   // RANLUX state with zero in all components and the carry bit set.
+   uint64_t ranlux[9] = {0};
+   unsigned c = 1;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   // Note that this state is the same as to_lcg::one above. When passed into
+   // the function to_ranlux, it will return the input state of to_lcg::one and
+   // not this one with the carry bit set.
+   EXPECT_EQ(lcg[0], 1);
+   for (int i = 1; i < 9; i++) {
+      EXPECT_EQ(lcg[i], 0);
+   }
+}
+
+TEST(to_lcg, all_ones)
+{
+   // RANLUX state with a one in every component.
+   uint64_t ranlux[9];
+   for (int i = 0; i < 9; i += 3) {
+      ranlux[i+0] = 1 + (1 << 24) + (uint64_t(1) << 48);
+      ranlux[i+1] = (1 << 8) + (uint64_t(1) << 32) + (uint64_t(1) << 56);
+      ranlux[i+2] = (1 << 16) + (uint64_t(1) << 40);
+   }
+   unsigned c = 1;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   EXPECT_EQ(lcg[0], 1);
+   EXPECT_EQ(lcg[1], 0);
+   EXPECT_EQ(lcg[2], 0);
+   EXPECT_EQ(lcg[3], 0x0001000000000000);
+   EXPECT_EQ(lcg[4], 0x0100000100000100);
+   EXPECT_EQ(lcg[5], 0x0000010000010000);
+   EXPECT_EQ(lcg[6], 0x0001000001000001);
+   EXPECT_EQ(lcg[7], 0x0100000100000100);
+   EXPECT_EQ(lcg[8], 0x0000010000010000);
+}
+
+TEST(to_lcg, all_ones_alt)
+{
+   // The RANLUX state that the assembly version returns for the output of
+   // to_lcg::all_ones.
+   uint64_t ranlux[9];
+   for (int i = 0; i < 9; i += 3) {
+      ranlux[i+0] = 1 + (1 << 24) + (uint64_t(1) << 48);
+      ranlux[i+1] = (1 << 8) + (uint64_t(1) << 32) + (uint64_t(1) << 56);
+      ranlux[i+2] = (1 << 16) + (uint64_t(1) << 40);
+   }
+   ranlux[0]++;
+   unsigned c = 0;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   EXPECT_EQ(lcg[0], 1);
+   EXPECT_EQ(lcg[1], 0);
+   EXPECT_EQ(lcg[2], 0);
+   EXPECT_EQ(lcg[3], 0x0001000000000000);
+   EXPECT_EQ(lcg[4], 0x0100000100000100);
+   EXPECT_EQ(lcg[5], 0x0000010000010000);
+   EXPECT_EQ(lcg[6], 0x0001000001000001);
+   EXPECT_EQ(lcg[7], 0x0100000100000100);
+   EXPECT_EQ(lcg[8], 0x0000010000010000);
+}
+
+TEST(to_lcg, all_ones_no_carry)
+{
+   // RANLUX state with a one in every component except the carry.
+   uint64_t ranlux[9];
+   for (int i = 0; i < 9; i += 3) {
+      ranlux[i+0] = 1 + (1 << 24) + (uint64_t(1) << 48);
+      ranlux[i+1] = (1 << 8) + (uint64_t(1) << 32) + (uint64_t(1) << 56);
+      ranlux[i+2] = (1 << 16) + (uint64_t(1) << 40);
+   }
+   unsigned c = 0;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   EXPECT_EQ(lcg[0], 0);
+   EXPECT_EQ(lcg[1], 0);
+   EXPECT_EQ(lcg[2], 0);
+   EXPECT_EQ(lcg[3], 0x0001000000000000);
+   EXPECT_EQ(lcg[4], 0x0100000100000100);
+   EXPECT_EQ(lcg[5], 0x0000010000010000);
+   EXPECT_EQ(lcg[6], 0x0001000001000001);
+   EXPECT_EQ(lcg[7], 0x0100000100000100);
+   EXPECT_EQ(lcg[8], 0x0000010000010000);
+}
+
+TEST(to_lcg, all_ones_no_carry_alt)
+{
+   // The RANLUX state that to_ranlux and the assembly version returns for the
+   // output of to_lcg::all_ones_no_carry.
+   uint64_t ranlux[9];
+   for (int i = 0; i < 9; i += 3) {
+      ranlux[i+0] = 1 + (1 << 24) + (uint64_t(1) << 48);
+      ranlux[i+1] = (1 << 8) + (uint64_t(1) << 32) + (uint64_t(1) << 56);
+      ranlux[i+2] = (1 << 16) + (uint64_t(1) << 40);
+   }
+   ranlux[0]--;
+   unsigned c = 1;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   EXPECT_EQ(lcg[0], 0);
+   EXPECT_EQ(lcg[1], 0);
+   EXPECT_EQ(lcg[2], 0);
+   EXPECT_EQ(lcg[3], 0x0001000000000000);
+   EXPECT_EQ(lcg[4], 0x0100000100000100);
+   EXPECT_EQ(lcg[5], 0x0000010000010000);
+   EXPECT_EQ(lcg[6], 0x0001000001000001);
+   EXPECT_EQ(lcg[7], 0x0100000100000100);
+   EXPECT_EQ(lcg[8], 0x0000010000010000);
+}
+
+TEST(to_lcg, ascending)
+{
+   uint64_t ranlux[9];
+   for (int i = 0; i < 9; i += 3) {
+      uint64_t ii = 8 * (i / 3);
+      ranlux[i+0] = (ii + 1) + ((ii + 2) << 24) + ((ii + 3) << 48);
+      ranlux[i+1] = ((ii + 4) << 8) + ((ii + 5) << 32) + ((ii + 6) << 56);
+      ranlux[i+2] = ((ii + 7) << 16) + ((ii + 8) << 40);
+   }
+   unsigned c = 0;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   EXPECT_EQ(lcg[0], 0xfff1fffff1fffff2);
+   EXPECT_EQ(lcg[1], 0xf1fffff1fffff1ff);
+   EXPECT_EQ(lcg[2], 0xfffff1fffff1ffff);
+   EXPECT_EQ(lcg[3], 0x000afffff1fffff1);
+   EXPECT_EQ(lcg[4], 0x0e00000d00000c00);
+   EXPECT_EQ(lcg[5], 0x00001000000f0000);
+   EXPECT_EQ(lcg[6], 0x0013000012000011);
+   EXPECT_EQ(lcg[7], 0x1600001500001400);
+   EXPECT_EQ(lcg[8], 0x0000180000170000);
+}
+
+TEST(to_lcg, ascending_alt)
+{
+   uint64_t ranlux[9];
+   for (int i = 0; i < 9; i += 3) {
+      uint64_t ii = 8 * (i / 3);
+      ranlux[i+0] = (ii + 1) + ((ii + 2) << 24) + ((ii + 3) << 48);
+      ranlux[i+1] = ((ii + 4) << 8) + ((ii + 5) << 32) + ((ii + 6) << 56);
+      ranlux[i+2] = ((ii + 7) << 16) + ((ii + 8) << 40);
+   }
+   ranlux[0]--;
+   unsigned c = 1;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   EXPECT_EQ(lcg[0], 0xfff1fffff1fffff2);
+   EXPECT_EQ(lcg[1], 0xf1fffff1fffff1ff);
+   EXPECT_EQ(lcg[2], 0xfffff1fffff1ffff);
+   EXPECT_EQ(lcg[3], 0x000afffff1fffff1);
+   EXPECT_EQ(lcg[4], 0x0e00000d00000c00);
+   EXPECT_EQ(lcg[5], 0x00001000000f0000);
+   EXPECT_EQ(lcg[6], 0x0013000012000011);
+   EXPECT_EQ(lcg[7], 0x1600001500001400);
+   EXPECT_EQ(lcg[8], 0x0000180000170000);
+}
+
+TEST(to_lcg, descending)
+{
+   uint64_t ranlux[9];
+   for (int i = 0; i < 9; i += 3) {
+      uint64_t ii = 8 * (2 - i / 3);
+      ranlux[i+0] = (ii + 8) + ((ii + 7) << 24) + ((ii + 6) << 48);
+      ranlux[i+1] = ((ii + 5) << 8) + ((ii + 4) << 32) + ((ii + 3) << 56);
+      ranlux[i+2] = ((ii + 2) << 16) + ((ii + 1) << 40);
+   }
+   unsigned c = 0;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   EXPECT_EQ(lcg[0], 0x000e00000e00000e);
+   EXPECT_EQ(lcg[1], 0x0e00000e00000e00);
+   EXPECT_EQ(lcg[2], 0x00000e00000e0000);
+   EXPECT_EQ(lcg[3], 0x000e00000e00000e);
+   EXPECT_EQ(lcg[4], 0x0b00000c00000d00);
+   EXPECT_EQ(lcg[5], 0x00000900000a0000);
+   EXPECT_EQ(lcg[6], 0x0006000007000008);
+   EXPECT_EQ(lcg[7], 0x0300000400000500);
+   EXPECT_EQ(lcg[8], 0x0000010000020000);
+}
+
+TEST(to_lcg, max)
+{
+   uint64_t max = UINT64_MAX;
+   uint64_t ranlux[9] = {max, max, max, max, max, max, max, max, max};
+   unsigned c = 0;
+   uint64_t lcg[9];
+
+   to_lcg(ranlux, c, lcg);
+
+   EXPECT_EQ(lcg[0], 0);
+   EXPECT_EQ(lcg[1], 0);
+   EXPECT_EQ(lcg[2], 0);
+   EXPECT_EQ(lcg[3], 0xffff000000000000);
+   for (int i = 4; i < 9; i++) {
+      EXPECT_EQ(lcg[i], 0xffffffffffffffff);
+   }
+}
+
+TEST(to_ranlux, zero)
+{
+   uint64_t lcg[9] = {0};
+   uint64_t ranlux[9];
+   unsigned c = 0;
+
+   to_ranlux(lcg, ranlux, c);
+
+   for (int i = 0; i < 9; i++) {
+      EXPECT_EQ(ranlux[i], 0);
+   }
+   EXPECT_EQ(c, 0);
+}
+
+TEST(to_ranlux, one)
+{
+   uint64_t lcg[9] = {1, 0, 0, 0, 0, 0, 0, 0, 0};
+   uint64_t ranlux[9];
+   unsigned c = 0;
+
+   to_ranlux(lcg, ranlux, c);
+
+   EXPECT_EQ(ranlux[0], 1);
+   for (int i = 1; i < 9; i++) {
+      EXPECT_EQ(ranlux[i], 0);
+   }
+   EXPECT_EQ(c, 0);
+}
+
+TEST(to_ranlux, all_ones)
+{
+   // See to_lcg::all_ones
+   uint64_t lcg[9] = {
+      1, 0, 0, 0x0001000000000000, 0x0100000100000100, 0x0000010000010000,
+      0x0001000001000001, 0x0100000100000100, 0x0000010000010000,
+   };
+   uint64_t ranlux[9];
+   unsigned c = 0;
+
+   to_ranlux(lcg, ranlux, c);
+
+   EXPECT_EQ(ranlux[0], 2 + (1 << 24) + (uint64_t(1) << 48));
+   for (int i = 0; i < 9; i += 3) {
+      if (i != 0) {
+         EXPECT_EQ(ranlux[i+0], 1 + (1 << 24) + (uint64_t(1) << 48));
+      }
+      EXPECT_EQ(ranlux[i+1], (1 << 8) + (uint64_t(1) << 32) + (uint64_t(1) << 56));
+      EXPECT_EQ(ranlux[i+2], (1 << 16) + (uint64_t(1) << 40));
+   }
+   EXPECT_EQ(c, 0);
+}
+
+TEST(to_ranlux, all_ones_no_carry)
+{
+   // See to_lcg::all_ones_no_carry and to_lcg::all_ones_no_carry_alt
+   uint64_t lcg[9] = {
+      0, 0, 0, 0x0001000000000000, 0x0100000100000100, 0x0000010000010000,
+      0x0001000001000001, 0x0100000100000100, 0x0000010000010000,
+   };
+   uint64_t ranlux[9];
+   unsigned c = 0;
+
+   to_ranlux(lcg, ranlux, c);
+
+   EXPECT_EQ(ranlux[0], (1 << 24) + (uint64_t(1) << 48));
+   for (int i = 0; i < 9; i += 3) {
+      if (i != 0) {
+         EXPECT_EQ(ranlux[i+0], 1 + (1 << 24) + (uint64_t(1) << 48));
+      }
+      EXPECT_EQ(ranlux[i+1], (1 << 8) + (uint64_t(1) << 32) + (uint64_t(1) << 56));
+      EXPECT_EQ(ranlux[i+2], (1 << 16) + (uint64_t(1) << 40));
+   }
+   EXPECT_EQ(c, 1);
+}
+
+TEST(to_ranlux, ascending)
+{
+   // See to_lcg::ascending and to_lcg::ascending_alt
+   uint64_t lcg[9] = {
+      0xfff1fffff1fffff2, 0xf1fffff1fffff1ff, 0xfffff1fffff1ffff,
+      0x000afffff1fffff1, 0x0e00000d00000c00, 0x00001000000f0000,
+      0x0013000012000011, 0x1600001500001400, 0x0000180000170000,
+   };
+   uint64_t ranlux[9];
+   unsigned c = 0;
+
+   to_ranlux(lcg, ranlux, c);
+
+   EXPECT_EQ(ranlux[0], (2 << 24) + (uint64_t(3) << 48));
+   for (int i = 0; i < 9; i += 3) {
+      int ii = 8 * (i / 3);
+      if (i != 0) {
+         EXPECT_EQ(ranlux[i+0], (ii + 1) + ((ii + 2) << 24) + (uint64_t(ii + 3) << 48));
+      }
+      EXPECT_EQ(ranlux[i+1], ((ii + 4) << 8) + (uint64_t(ii + 5) << 32) + (uint64_t(ii + 6) << 56));
+      EXPECT_EQ(ranlux[i+2], ((ii + 7) << 16) + (uint64_t(ii + 8) << 40));
+   }
+   EXPECT_EQ(c, 1);
+}
+
+TEST(to_ranlux, descending)
+{
+   // See to_lcg::decending
+   uint64_t lcg[9] = {
+      0x000e00000e00000e, 0x0e00000e00000e00, 0x00000e00000e0000,
+      0x000e00000e00000e, 0x0b00000c00000d00, 0x00000900000a0000,
+      0x0006000007000008, 0x0300000400000500, 0x0000010000020000,
+   };
+   uint64_t ranlux[9];
+   unsigned c = 0;
+
+   to_ranlux(lcg, ranlux, c);
+
+   for (int i = 0; i < 9; i += 3) {
+      uint64_t ii = 8 * (2 - i / 3);
+      EXPECT_EQ(ranlux[i+0], (ii + 8) + ((ii + 7) << 24) + ((ii + 6) << 48));
+      EXPECT_EQ(ranlux[i+1], ((ii + 5) << 8) + ((ii + 4) << 32) + ((ii + 3) << 56));
+      EXPECT_EQ(ranlux[i+2], ((ii + 2) << 16) + ((ii + 1) << 40));
+   }
+   EXPECT_EQ(c, 0);
+}
+
+TEST(to_ranlux, max)
+{
+   // See to_lcg::max
+   uint64_t max = UINT64_MAX;
+   uint64_t lcg[9] = {0, 0, 0, 0xffff000000000000, max, max, max, max, max};
+   uint64_t ranlux[9];
+   unsigned c = 0;
+
+   to_ranlux(lcg, ranlux, c);
+
+   EXPECT_EQ(ranlux[0], max - 1);
+   for (int i = 1; i < 9; i++) {
+      EXPECT_EQ(ranlux[i], max);
+   }
+   EXPECT_EQ(c, 1);
+}


### PR DESCRIPTION
From a high-level perspective, this PR does two things:
 * It converts the LCG state back to RANLUX numbers to avoid a bias in the generated numbers as reported by Martin Lüscher. This comes from the fact that the modulus `m = 2 ** 576 - 2 ** 240 + 1` is not a power of 2, so just treating the LCG state as a pool of entropy means that the  upper `576 - 240 = 336` bits have a higher probability of being 0 than 1.
 * Extract only 48 bits instead of 52 bits per random number. This restores the connection to the theoretical properties derived from understanding the original subtract-with-borrow recursion as a dynamical system.