### PR TITLE
TThread Printf fix memleak

### DIFF
--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -947,7 +947,10 @@ again:
 
    void *arr[2];
    arr[1] = (void*) buf;
-   if (XARequest("PRTF", 2, arr, 0)) return;
+   if (XARequest("PRTF", 2, arr, 0)) {
+      delete [] buf;
+      return;
+   }
 
    printf("%s\n", buf);
    fflush(stdout);


### PR DESCRIPTION
see https://github.com/root-project/root/issues/8297
(This leak seems to be there since https://github.com/root-project/root/commit/656be4df3a8ccbf8cb749bd862d71f1690fbd2c5)