### PR TITLE
[DF] Fix gcc 11 warning

### DIFF
--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -1,6 +1,7 @@
-#include "ROOT/RDataFrame.hxx"
-#include "ROOT/RTrivialDS.hxx"
 #include "ROOT/RCsvDS.hxx"
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RStringView.hxx"
+#include "ROOT/RTrivialDS.hxx"
 #include "TMemFile.h"
 #include "TSystem.h"
 #include "TTree.h"
@@ -448,7 +449,7 @@ TEST(RDataFrameInterface, ColumnWithSimpleStruct)
    ROOT::RDataFrame df(t);
    const std::vector<std::string> expected({ "c.a", "a", "c.b", "b", "c" });
    EXPECT_EQ(df.GetColumnNames(), expected);
-   for (const std::string &col : {"c.a", "a"}) {
+   for (std::string_view col : {"c.a", "a"}) {
       EXPECT_DOUBLE_EQ(df.Mean<int>(col).GetValue(), 42.); // compiled
       EXPECT_DOUBLE_EQ(df.Mean(col).GetValue(), 42.); // jitted
    }


### PR DESCRIPTION
../tree/dataframe/test/dataframe_interface.cxx:451:28: warning: loop
variable ‘col’ of type ‘const string&’ {aka ‘const
std::__cxx11::basic_string<char>&’} binds to a temporary constructed
from type ‘const char* const’ [-Wrange-loop-construct]

@Axel-Naumann I don't really understand why the const ref does not increase the lifetime of the temporary as usual in this case, but this is the warning: https://godbolt.org/z/ss4zz8v3M