### PR TITLE
[rntuple] Factor out common code in the sealed pages path and add support for sealed pages to DAOS

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -216,6 +216,15 @@ public:
             return fNElements == other.fNElements && fLocator == other.fLocator;
          }
       };
+      struct RPageInfoExtended : RPageInfo {
+         /// Index (in cluster) of the first element in page.
+         RClusterSize::ValueType fFirstInPage;
+         /// Page number in the corresponding RPageRange.
+         NTupleSize_t fPageNo;
+
+         RPageInfoExtended(const RPageInfo &pi, RClusterSize::ValueType i, NTupleSize_t n)
+            : RPageInfo(pi), fFirstInPage(i), fPageNo(n) {}
+      };
 
       RPageRange() = default;
       RPageRange(const RPageRange &other) = delete;
@@ -229,6 +238,9 @@ public:
          clone.fPageInfos = fPageInfos;
          return clone;
       }
+
+      /// Find the page in the RPageRange that contains the given element. The element must exist.
+      RPageInfoExtended Find(RClusterSize::ValueType idxInCluster) const;
 
       DescriptorId_t fColumnId = kInvalidDescriptorId;
       std::vector<RPageInfo> fPageInfos;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -70,6 +70,9 @@ private:
    std::uint64_t fClusterMaxOffset = 0;
    RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
 
+   RClusterDescriptor::RLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage,
+                                                std::size_t bytesPacked);
+
 protected:
    void CreateImpl(const RNTupleModel &model) final;
    RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -457,6 +457,27 @@ bool ROOT::Experimental::RColumnDescriptor::operator==(const RColumnDescriptor &
 ////////////////////////////////////////////////////////////////////////////////
 
 
+ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfoExtended
+ROOT::Experimental::RClusterDescriptor::RPageRange::Find(ROOT::Experimental::RClusterSize::ValueType idxInCluster) const
+{
+   // TODO(jblomer): binary search
+   RPageInfo pageInfo;
+   decltype(idxInCluster) firstInPage = 0;
+   NTupleSize_t pageNo = 0;
+   for (const auto &pi : fPageInfos) {
+      if (firstInPage + pi.fNElements > idxInCluster) {
+         pageInfo = pi;
+         break;
+      }
+      firstInPage += pi.fNElements;
+      ++pageNo;
+   }
+   R__ASSERT(firstInPage <= idxInCluster);
+   R__ASSERT((firstInPage + pageInfo.fNElements) > idxInCluster);
+   return RPageInfoExtended{pageInfo, firstInPage, pageNo};
+}
+
+
 bool ROOT::Experimental::RClusterDescriptor::operator==(const RClusterDescriptor &other) const
 {
    return fClusterId == other.fClusterId &&


### PR DESCRIPTION
First, this PR factors out common parts of the code in commit/load of (sealed) pages.  Specifically, this affects:
- `CommitPageImpl` and `CommitSealedPageImpl`.
- `PopulatePageFromCluster()` and `LoadSealedPage()`. Locating the RPageInfo from the cluster index is now a member function of RPageRange.

Second, it provides support for sealed pages in the DAOS backend.

Closes issue #8079.