### PR TITLE
[tree] Print error in case of branch kind mismatch in CopyAddresses

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -3361,6 +3361,13 @@ void TTree::CopyAddresses(TTree* tree, Bool_t undo)
             tree->SetBranchAddress(branch->GetName(), (void*) branch->GetAddress());
             TBranch* br = tree->GetBranch(branch->GetName());
             if (br) {
+               if (br->IsA() != branch->IsA()) {
+                  Error(
+                     "CopyAddresses",
+                     "Branch kind mismatch between input tree '%s' and output tree '%s' for branch '%s': '%s' vs '%s'",
+                     tree->GetName(), br->GetTree()->GetName(), br->GetName(), branch->IsA()->GetName(),
+                     br->IsA()->GetName());
+               }
                // The copy does not own any object allocated by SetAddress().
                // FIXME: We do too much here, br may not be a top-level branch.
                if (br->InheritsFrom(TBranchElement::Class())) {


### PR DESCRIPTION
TTree::CopyAddresses has the built-in pre-condition that the input and
output branches are of the same kind. Clones might be added, however,
for which the pre-condition is violated. This is currently the case,
for example, with certain usages of RDataFrame::Snapshot, which might
create an output branch that is a simple TBranch while the input branch
is e.g. a TBranchElement. This results in wrong data being written out.

With this patch we detect this case and complain.
A proper fix will be proposed soon. The issue is tracked as #8295.