### PR TITLE
Fix bug in TText::Copy method

### DIFF
--- a/graf2d/graf/src/TText.cxx
+++ b/graf2d/graf/src/TText.cxx
@@ -112,9 +112,9 @@ void TText::Copy(TObject &obj) const
    TAttText::Copy(((TText&)obj));
    if (((TText&)obj).fWcsTitle != NULL) {
       if (fWcsTitle != NULL) {
-         *reinterpret_cast<std::wstring*>(&((TText&)obj).fWcsTitle) = *reinterpret_cast<const std::wstring*>(&fWcsTitle);
+         *reinterpret_cast<std::wstring*>(((TText&)obj).fWcsTitle) = *reinterpret_cast<const std::wstring*>(fWcsTitle);
       } else {
-        delete reinterpret_cast<std::wstring*>(&((TText&)obj).fWcsTitle);
+        delete reinterpret_cast<std::wstring*>(((TText&)obj).fWcsTitle);
         ((TText&)obj).fWcsTitle = NULL;
       }
    } else {

--- a/graf2d/graf/src/TText.cxx
+++ b/graf2d/graf/src/TText.cxx
@@ -110,15 +110,15 @@ void TText::Copy(TObject &obj) const
    ((TText&)obj).fY = fY;
    TNamed::Copy(obj);
    TAttText::Copy(((TText&)obj));
-   if (((TText&)obj).fWcsTitle != NULL) {
-      if (fWcsTitle != NULL) {
+   if (((TText&)obj).fWcsTitle) {
+      if (fWcsTitle) {
          *reinterpret_cast<std::wstring*>(((TText&)obj).fWcsTitle) = *reinterpret_cast<const std::wstring*>(fWcsTitle);
       } else {
         delete reinterpret_cast<std::wstring*>(((TText&)obj).fWcsTitle);
-        ((TText&)obj).fWcsTitle = NULL;
+        ((TText&)obj).fWcsTitle = nullptr;
       }
    } else {
-      if (fWcsTitle != NULL) {
+      if (fWcsTitle) {
          ((TText&)(obj)).fWcsTitle = new std::wstring(*reinterpret_cast<const std::wstring*>(fWcsTitle));
       }
    }
@@ -129,10 +129,10 @@ void TText::Copy(TObject &obj) const
 
 const void *TText::GetWcsTitle(void) const
 {
-   if (fWcsTitle != NULL) {
+   if (fWcsTitle) {
       return reinterpret_cast<std::wstring *>(fWcsTitle)->c_str();
    } else {
-      return NULL;
+      return nullptr;
    }
 }
 


### PR DESCRIPTION
`fWcsTitle` accessed wrongly, following macro crashes:

```
void bug()
{
  TText txt1(0,0, L"Any text 1");
  TText txt2(0,0, L"Any text 2");
  
  txt2 = txt1; // this is crashing
}
```

Discovered in gcc11 warnings