### PR TITLE
Fix bug in TText::Copy, v6.24

### DIFF
--- a/graf2d/graf/src/TText.cxx
+++ b/graf2d/graf/src/TText.cxx
@@ -112,9 +112,9 @@ void TText::Copy(TObject &obj) const
    TAttText::Copy(((TText&)obj));
    if (((TText&)obj).fWcsTitle != NULL) {
       if (fWcsTitle != NULL) {
-         *reinterpret_cast<std::wstring*>(&((TText&)obj).fWcsTitle) = *reinterpret_cast<const std::wstring*>(&fWcsTitle);
+         *reinterpret_cast<std::wstring*>(((TText&)obj).fWcsTitle) = *reinterpret_cast<const std::wstring*>(fWcsTitle);
       } else {
-        delete reinterpret_cast<std::wstring*>(&((TText&)obj).fWcsTitle);
+        delete reinterpret_cast<std::wstring*>(((TText&)obj).fWcsTitle);
         ((TText&)obj).fWcsTitle = NULL;
       }
    } else {


### PR DESCRIPTION
fWcsTitle was copied wrongly