### PR TITLE
Fix gcc11 warnings in TASImage

### DIFF
--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -5486,6 +5486,9 @@ void TASImage::DrawFillArea(UInt_t count, TPoint *ptsIn, const char *col,
       del = kTRUE;
    }
 
+   ET.scanlines.next = nullptr; // to avoid compiler warnings
+   ET.ymin = ET.ymax = 0;       // to avoid compiler warnings
+
    ptsOut = firstPoint;
    width = firstWidth;
    CreateETandAET(count, ptsIn, &ET, &AET, pETEs, &SLLBlock);
@@ -5585,6 +5588,9 @@ void TASImage::DrawFillArea(UInt_t count, TPoint *ptsIn, TImage *tile)
    ScanLineListBlock SLLBlock;     // header for ScanLineList
 
    pETEs = new EdgeTableEntry[count];
+
+   ET.scanlines.next = nullptr; // to avoid compiler warnings
+   ET.ymin = ET.ymax = 0;       // to avoid compiler warnings
 
    ptsOut = firstPoint;
    width = firstWidth;


### PR DESCRIPTION
gcc11 complains about non-initialized variable, just make it happy.
Warnings are:
```
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5592:9: warning: ‘ET.EdgeTable::scanlines._ScanLineList::next’ may be used uninitialized [-Wmaybe-uninitialized]
 5592 |    pSLL = ET.scanlines.next;
      |    ~~~~~^~~~~~~~~~~~~~~~~~~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5582:14: note: ‘ET’ declared here
 5582 |    EdgeTable ET;                   // Edge Table header node
      |              ^~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5594:11: warning: ‘ET.EdgeTable::ymin’ may be used uninitialized [-Wmaybe-uninitialized]
 5594 |    for (y = ET.ymin; y < ET.ymax; y++) {
      |         ~~^~~~~~~~~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5582:14: note: ‘ET’ declared here
 5582 |    EdgeTable ET;                   // Edge Table header node
      |              ^~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5594:29: warning: ‘ET.EdgeTable::ymax’ may be used uninitialized [-Wmaybe-uninitialized]
 5594 |    for (y = ET.ymin; y < ET.ymax; y++) {
      |                          ~~~^~~~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5582:14: note: ‘ET’ declared here
 5582 |    EdgeTable ET;                   // Edge Table header node
      |              ^~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx: In member function ‘virtual void TASImage::DrawFillArea(UInt_t, TPoint*, const char*, const char*, UInt_t, UInt_t)’:
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5492:9: warning: ‘ET.EdgeTable::scanlines._ScanLineList::next’ may be used uninitialized [-Wmaybe-uninitialized]
 5492 |    pSLL = ET.scanlines.next;
      |    ~~~~~^~~~~~~~~~~~~~~~~~~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5472:14: note: ‘ET’ declared here
 5472 |    EdgeTable ET;                   // Edge Table header node
      |              ^~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5494:11: warning: ‘ET.EdgeTable::ymin’ may be used uninitialized [-Wmaybe-uninitialized]
 5494 |    for (y = ET.ymin; y < ET.ymax; y++) {
      |         ~~^~~~~~~~~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5472:14: note: ‘ET’ declared here
 5472 |    EdgeTable ET;                   // Edge Table header node
      |              ^~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5494:29: warning: ‘ET.EdgeTable::ymax’ may be used uninitialized [-Wmaybe-uninitialized]
 5494 |    for (y = ET.ymin; y < ET.ymax; y++) {
      |                          ~~~^~~~
/home/linev/git/webgui/graf2d/asimage/src/TASImage.cxx:5472:14: note: ‘ET’ declared here
 5472 |    EdgeTable ET;                   // Edge Table header node
      |              ^~

```