### PR TITLE
[RF] Use UniqueId to replace pointer comparisons and disable memory pool

### DIFF
--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -78,6 +78,11 @@ Please use their non-experimental counterparts `ROOT::TBufferMerger` and `ROOT::
 The following lesser-used RooFit functions now return a `std::string` instead of a `const char*`, potentially requiring the update of your code:
 
 - [std::string RooCmdConfig::missingArgs() const](https://root.cern/doc/v628/classRooCmdConfig.html#aec50335293c45a507d347c604bf9651f)
+### Uniquely identifying RooArgSet and RooDataSet objects
+
+Before v6.28, it was ensured that no `RooArgSet` and `RooDataSet` objects on the heap were located at an address that had already been used for an instance of the same class before.
+With v6.28, this is not guaranteed anymore.
+Hence, if your code uses pointer comparisons to uniquely identify RooArgSet or RooDataSet instances, please consider using the new `RooArgSet::uniqueId()` or `RooAbsData::uniqueId()`.
 
 ## Removal of HistoToWorkspaceFactory (non-Fast)
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -22,6 +22,7 @@
 #include "RooArgList.h"
 #include "RooSpan.h"
 #include "RooNameReg.h"
+#include "RooFit/UniqueId.h"
 
 #include "TNamed.h"
 
@@ -301,6 +302,11 @@ public:
   void SetName(const char* name) override ;
   void SetNameTitle(const char *name, const char *title) override ;
 
+  /// Returns a unique ID that is different for every instantiated RooAbsData object.
+  /// This ID can be used whether two RooAbsData are the same object, which is safer
+  /// than memory address comparisons that might result in false positives when
+  /// memory is reused.
+  RooFit::UniqueId<RooAbsData> const& uniqueId() const { return _uniqueId; }
 
 protected:
 
@@ -355,6 +361,8 @@ protected:
 
 private:
   void copyGlobalObservables(const RooAbsData& other);
+
+  const RooFit::UniqueId<RooAbsData> _uniqueId; ///<!
 
    ClassDefOverride(RooAbsData, 6) // Abstract data collection
 };

--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -45,7 +45,7 @@ public:
   const RooAbsData& data() const ;
 
 
-  const char* cacheUniqueSuffix() const override { return Form("_%zx", (size_t)_dataClone) ; }
+  const char* cacheUniqueSuffix() const override;
 
   // Override this to be always true to force calculation of likelihood without parameters
   Bool_t isDerived() const override { return kTRUE ; }

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -23,12 +23,34 @@
 
 class RooArgList ;
 
+// # Original comment on USEMEMPOOLFORARGSET:
+//
 // Use a memory pool for RooArgSet.
 // RooFit assumes (e.g. for caching results) that arg sets that have the same pointer have
 // the same contents. Trying to remove that memory pool lead to wrong results, because the
 // OS *occasionally* returns the same address, and the caching goes wrong.
 // It's hard to track down, so disable this only when e.g. looking for memory leaks!
-#define USEMEMPOOLFORARGSET
+//
+// # Update April 2022:
+//
+// Using pointers comparisons for caching RooFit results caused too many bugs,
+// even wih the memory pool. For example, if the RooArgSet is created on the
+// stack, there is no guarantee that memory is not reused. Also, pointer
+// comparisons still work if the RooArgSets for the cache entry are already out
+// of scope, which can also cause problems. Therefore, when RooArgSets are used
+// for caching, RooFit now uses the `RooArgSet::uniqueId()` as of PR [1].
+//
+// Since pointers are not used as cache keys anymore, the custom memory pool
+// is not necessary anymore. It was decided to deactivate it, because it also
+// caused quite some trouble on its own. It caused unexpected memory increases,
+// possibly because of heap fragmentation [2], and overloading `operator new`
+// and `delete` caused PyROOT issues on some platforms.
+//
+// [1] https://github.com/root-project/root/pull/10333
+// [2] https://github.com/root-project/root/issues/8323
+
+// #define USEMEMPOOLFORARGSET
+
 template <class RooSet_t, size_t>
 class MemPoolForRooSets;
 

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -29,7 +29,26 @@ class RooDataHist;
 #include <list>
 
 
-#define USEMEMPOOLFORDATASET
+//#define USEMEMPOOLFORDATASET
+
+// In the past, a custom memory pool was used for RooDataSet objects on the
+// heap. This memoy pool guaranteed that no memory addresses were reused for
+// different RooDataSets, making it possible to uniquely identify manually
+// allocated RooDataSets by their memory address.
+//
+// However, the memoy pool for RooArgSets caused unexpected memory usage
+// increases, even if no memory leaks were present [1]. It was suspected that
+// the memory allocation pattern with the memory pool might cause some heap
+// fragmentation, which did not happen when the standard allocator was used.
+//
+// To solve that problem, the memory pool was disabled. It is not clear what
+// RooFit code actually relied on the unique memory addresses, but an
+// alternative mechanism to uniquely identify RooDataSet objects was
+// implemented for these usecases (see RooAbsData::uniqueId()) [2].
+//
+// [1] https://github.com/root-project/root/issues/8323
+// [2] https://github.com/root-project/root/pull/8324
+
 template <class RooSet_t, size_t>
 class MemPoolForRooSets;
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -859,3 +859,10 @@ void RooAbsOptTestStatistic::setUpBinSampling() {
   }
 
 }
+
+
+/// Returns a suffix string that is unique for RooAbsOptTestStatistic
+/// instances that don't share the same cloned input data object.
+const char* RooAbsOptTestStatistic::cacheUniqueSuffix() const {
+   return Form("_%lx", _dataClone->uniqueId().value()) ;
+}

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -37,7 +37,15 @@
 /// ownership status. Arguments supplied in the constructor are always added
 /// as unowned elements.
 ///
-///
+/// 
+/// Uniquely identifying RooArgSet objects
+/// ---------------------------------------
+/// 
+/// \warning Before v6.28, it was ensured that no RooArgSet objects on the heap
+/// were located at an address that had already been used for a RooArgSet before.
+/// With v6.28, this is not guaranteed anymore. Hence, if your code uses pointer
+/// comparisons to uniquely identify RooArgSet instances, please consider using
+/// the new `RooArgSet::uniqueId()`.
 
 #include "RooArgSet.h"
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -71,6 +71,15 @@ For the inverse conversion, see `RooAbsData::convertToVectorStore()`.
 ### Creating a dataset using RDataFrame
 \see RooAbsDataHelper, rf408_RDataFrameToRooFit.C
 
+### Uniquely identifying RooDataSet objects
+
+\warning Before v6.28, it was ensured that no RooDataSet objects on the heap
+were located at an address that had already been used for a RooDataSet before.
+With v6.28, this is not guaranteed anymore. Hence, if your code uses pointer
+comparisons to uniquely identify RooDataSet instances, please consider using
+the new `RooAbsData::uniqueId()`.
+
+
 **/
 
 #include "RooDataSet.h"


### PR DESCRIPTION
Disables the memory pool for RooArgSet and RooDataSet to fix https://github.com/root-project/root/issues/8323.

This entails that we can't rely anymore on all RooDataSets allocated on the heap having a unique memory address, so a new `uniqueId` class member is introduced to replace the pointer comparisons.

The RooArgSet already had such a `uniqueId` class member, which is already used as a key for caching as of PR https://github.com/root-project/root/pull/10333, instead of doing pointer comparisons.

More details in the commit descriptions.