### PR TITLE
[Windows] Fix fatal error C1001: Internal compiler error

### DIFF
--- a/math/mathcore/inc/Math/Functor.h
+++ b/math/mathcore/inc/Math/Functor.h
@@ -178,7 +178,7 @@ public:
    ImplFunc * Copy() const { return new FunctorGradHandler(*this); }
 
    // clone of the function handler (use copy-ctor)
-#if defined(_MSC_VER) && !defined(__CLING__)
+#if defined(_MSC_VER) && (_MSC_VER > 1923) && (_MSC_VER < 1929) && !defined(__CLING__)
    // FIXME: this is a work-around for a compiler error with VS 2019 (16.4.3)
    // try to remove this #ifdef when updating Visual Studio
    auto Clone() const { return Copy(); }

--- a/math/mathcore/inc/Math/Functor.h
+++ b/math/mathcore/inc/Math/Functor.h
@@ -178,7 +178,7 @@ public:
    ImplFunc * Copy() const { return new FunctorGradHandler(*this); }
 
    // clone of the function handler (use copy-ctor)
-#if defined(_MSC_VER) && (_MSC_VER > 1923) && (_MSC_VER < 1929) && !defined(__CLING__)
+#if defined(_MSC_VER) && (_MSC_VER < 1929) && !defined(__CLING__)
    // FIXME: this is a work-around for a compiler error with VS 2019 (16.4.3)
    // try to remove this #ifdef when updating Visual Studio
    auto Clone() const { return Copy(); }


### PR DESCRIPTION
After updating Visual Studio 2019 to the version `16.10.0`, there is a `fatal error C1001: Internal compiler error` when compiling `G__MathCore.cxx`
See the bug report at Microsoft: [[v16.10.0] Fatal error C1001: Internal compiler error](https://developercommunity.visualstudio.com/t/v16100-fatal-error-c1001-internal-compiler-error/1437980?from=email&viewtype=all)
And the proposed workaround:

 1. Remove the `auto` return type from `FunctorGradHandler::Clone()`. This function is the cause of the ICE and replacing `auto` with `ImplFunc*` will resolve the issue.
 2. Only if fixing the source is not an option, add `/d1deducedReturnEncoding-` to your build. This will disable the recent compiler work around deduced return types. Keep in mind that this option should only be used as a last resort because it is not a permanent switch.

Interestingly enough, the `auto` return type was introduced as a workaround for another compiler error with `VS 2019 (16.4.3)`