### PR TITLE
[WIP][NTuple][skip-ci] Add support for caching of RNTuple

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
@@ -92,6 +92,8 @@ private:
    /// Every cluster pool is responsible for exactly one page source that triggers loading of the clusters
    /// (GetCluster()) and is used for implementing the I/O and cluster memory allocation (PageSource::LoadCluster()).
    RPageSource &fPageSource;
+   /// Each cluster pool might also need to create a PageSink if caching of the RNTuple is enabled
+   std::unique_ptr<RPageSink> fPageSink{nullptr};
    /// The number of clusters before the currently active cluster that should stay in the pool if present
    unsigned int fWindowPre;
    /// The number of desired clusters in the pool, including the currently active cluster


### PR DESCRIPTION
This is a very early draft for caching `RNTuple`s. The goal is to save only the portions (clusters) of the original RNTuple that are actually read during an analysis to a new RNTuple .

In this draft it is shown an attempt at exercising the part where the compressed clusters are saved during the IO pipeline already implemented in RClusterPool. To this end, an `RPageSink` is created at the beginning of the pipeline with the same header as the RNTuple being read. After the compressed cluster is retrieved in memory, its columns and pages are traversed and saved to the cached RNTuple.

For now this feature can be reproduced with a very limited example, divided in three pieces
### 1. Write an RNTuple
```cpp
void write_ntuple()
{
   auto model = RNTupleModel::Create();
   auto myintfield = model->MakeField<int>("myintfield");
   auto myintfieldsquared = model->MakeField<int>("myintfieldsquared");

   std::string_view ntuplename{"myntuple"};
   std::string_view filename{"myntuple.root"};
   auto ntuple = RNTupleWriter::Recreate(std::move(model), ntuplename, filename);

   constexpr int nentries = 10;
   for (int i = 0; i < nentries; i++) {
      *myintfield = i;
      *myintfieldsquared = i*i;
      ntuple->Fill();
      // Create a cluster every 5 entries
      if (i == 4 || i == 9) ntuple->CommitCluster();
   }
}
```
### 2. Read the RNTuple (this will create a `cachedntuple.root` file)
```cpp
void read_ntuple()
{
   std::string_view ntuplename{"myntuple"};
   std::string_view filename{"myntuple.root"};
   auto ntuple = RNTupleReader::Open(ntuplename, filename);

   for (auto entryid: *ntuple){
      ntuple->LoadEntry(entryid);
   }
}
```
### 3. Print info of the cached RNTuple
```cpp
void read_cache()
{
   std::string_view ntuplename{"myntuple"};
   std::string_view filename{"cachedntuple.root"};

   auto model = RNTupleModel::Create();
   auto myintfield = model->MakeField<int>("myintfield");
   auto myintfieldsquared = model->MakeField<int>("myintfieldsquared");
   auto ntuple = RNTupleReader::Open(std::move(model), ntuplename, filename);
   ntuple->PrintInfo();

   for (auto entryid: *ntuple){
      ntuple->LoadEntry(entryid);
      std::cout << "Read entry " << entryid << " with value " << *myintfield << "\n";
      std::cout << "Read entry " << entryid << " with value " << *myintfieldsquared << "\n";
   }
}
```


## TODOS

1. Still missing all the logic for automatically switching to read the cached RNTuple rather than the original one
2. That `entriessofar` variable needed to pass to the `CommitCluster` function hopefully can be avoided
3. Tests with more complex data schemes
4. Some logic to enable the caching optionally from the user side