### PR TITLE
[ntuple] Add explicit EnableMT methods to RNTupleReader, Writer

### DIFF
--- a/core/imt/src/TTaskGroup.cxx
+++ b/core/imt/src/TTaskGroup.cxx
@@ -55,9 +55,6 @@ using namespace ROOT::Internal;
 TTaskGroup::TTaskGroup()
 {
 #ifdef R__USE_IMT
-   if (!ROOT::IsImplicitMTEnabled()) {
-      throw std::runtime_error("Implicit parallelism not enabled. Cannot instantiate a TTaskGroup.");
-   }
    fTaskContainer = ((void *)new tbb::task_group());
 #endif
 }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -231,6 +231,10 @@ public:
    RIterator end() { return RIterator(GetNEntries()); }
 
    void EnableMetrics() { fMetrics.Enable(); }
+   /// Enable multi-threaded decompression, if IMT is enabled for this build (otherwise, no-op).
+   ///
+   /// This method has no effect if ROOT::EnableImplicitMT was called before.
+   void EnableMT();
    const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
 };
 
@@ -291,6 +295,10 @@ public:
    void CommitCluster();
 
    void EnableMetrics() { fMetrics.Enable(); }
+   /// Enable multi-threaded compression, if IMT is enabled for this build (otherwise, no-op).
+   ///
+   /// This method has no effect if ROOT::EnableImplicitMT was called before.
+   void EnableMT();
    const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
 };
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -267,6 +267,17 @@ void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, const ENTupleSh
    }
 }
 
+void ROOT::Experimental::RNTupleReader::EnableMT()
+{
+#ifdef R__USE_IMT
+   if (fUnzipTasks) {
+      return;
+   }
+   fUnzipTasks = std::make_unique<RNTupleImtTaskScheduler>();
+   fSource->SetTaskScheduler(fUnzipTasks.get());
+#endif
+}
+
 
 //------------------------------------------------------------------------------
 
@@ -335,6 +346,17 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster()
    }
    fSink->CommitCluster(fNEntries);
    fLastCommitted = fNEntries;
+}
+
+void ROOT::Experimental::RNTupleWriter::EnableMT()
+{
+#ifdef R__USE_IMT
+   if (fZipTasks) {
+      return;
+   }
+   fZipTasks = std::make_unique<RNTupleImtTaskScheduler>();
+   fSink->SetTaskScheduler(fZipTasks.get());
+#endif
 }
 
 

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -215,4 +215,52 @@ TEST(RPageSinkBuf, ParallelZip) {
       EXPECT_EQ((std::vector<float>(3, fi)), viewKlassVec(i).at(0).v2.at(0));
       EXPECT_EQ("hi" + std::to_string(i), viewKlassVec(i).at(0).s);
    }
+   ROOT::DisableImplicitMT();
+}
+
+TEST(RPageSinkBuf, SelectiveMT) {
+   FileRaii fileGuard("test_ntuple_selective_mt.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto floatField = model->MakeField<float>("pt");
+      auto fieldKlassVec = model->MakeField<std::vector<CustomStruct>>("klassVec");
+      auto ntuple = std::make_unique<RNTupleWriter>(std::move(model),
+         std::make_unique<RPageSinkBuf>(std::make_unique<RPageSinkFile>(
+            "buf_pzip", fileGuard.GetPath(), RNTupleWriteOptions()
+      )));
+      ASSERT_FALSE(ROOT::IsImplicitMTEnabled());
+      ntuple->EnableMT(); // only enable MT for the RNTupleWriter
+      ASSERT_FALSE(ROOT::IsImplicitMTEnabled());
+      ntuple->EnableMetrics();
+      for (int i = 0; i < 20000; i++) {
+         *floatField = static_cast<float>(i);
+         CustomStruct klass;
+         klass.a = 42.0;
+         klass.v1.emplace_back(static_cast<float>(i));
+         klass.v2.emplace_back(std::vector<float>(3, static_cast<float>(i)));
+         klass.s = "hi" + std::to_string(i);
+         *fieldKlassVec = std::vector<CustomStruct>{klass};
+         ntuple->Fill();
+         if (i && i % 15000 == 0) {
+            ntuple->CommitCluster();
+            auto *parallel_zip = ntuple->GetMetrics().GetCounter(
+               "RNTupleWriter.RPageSinkBuf.ParallelZip");
+            ASSERT_FALSE(parallel_zip == nullptr);
+            EXPECT_EQ(1, parallel_zip->GetValueAsInt());
+         }
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("buf_pzip", fileGuard.GetPath());
+   EXPECT_EQ(20000, ntuple->GetNEntries());
+
+   auto viewPt = ntuple->GetView<float>("pt");
+   auto viewKlassVec = ntuple->GetView<std::vector<CustomStruct>>("klassVec");
+   for (auto i : ntuple->GetEntryRange()) {
+      float fi = static_cast<float>(i);
+      EXPECT_EQ(fi, viewPt(i));
+      EXPECT_EQ(std::vector<float>{fi}, viewKlassVec(i).at(0).v1);
+      EXPECT_EQ((std::vector<float>(3, fi)), viewKlassVec(i).at(0).v2.at(0));
+      EXPECT_EQ("hi" + std::to_string(i), viewKlassVec(i).at(0).s);
+   }
 }


### PR DESCRIPTION
Allow users to request multithreaded (de)compression even if IMT is not enabled globally with `ROOT::EnableImplicitMT()`. This required a change to `TTaskGroup` to avoid checking if IMT was enabled -- as I understand it, we can use TBB even if IMT isn't turned on because we don't use `RTaskArena`. 