### PR TITLE
Better fix for Windows

### DIFF
--- a/math/mathcore/inc/Math/Functor.h
+++ b/math/mathcore/inc/Math/Functor.h
@@ -178,10 +178,12 @@ public:
    ImplFunc * Copy() const { return new FunctorGradHandler(*this); }
 
    // clone of the function handler (use copy-ctor)
-#if defined(_MSC_VER) && (_MSC_VER < 1929) && !defined(__CLING__)
-   // FIXME: this is a work-around for a compiler error with VS 2019 (16.4.3)
-   // try to remove this #ifdef when updating Visual Studio
-   auto Clone() const { return Copy(); }
+#ifdef _MSC_VER
+   // FIXME: this is a work-around for a a problem with how the compiler
+   // generates the covariant virtual function "Clone". To address the
+   // issue just use the original return type of the virtual base class.
+   // Try to remove this #ifdef when updating Visual Studio
+   typename ParentFunctor::ImplBase* Clone() const { return Copy(); }
 #else
    BaseFunc * Clone() const { return Copy(); }
 #endif


### PR DESCRIPTION
See the bug report at Microsoft: [Problem with how the compiler generates covariant virtual functions](https://developercommunity.visualstudio.com/t/Problem-with-how-the-compiler-generates/1441440)
And the proposed workaround:
>It turns out to be a problem with how the compiler generates the covariant virtual function `Clone` in `FunctorGradHandler`. To address the issue just use the original return type of the virtual base:
>```
>template
>class FunctorGradHandler : public ParentFunctor::Impl {
>...
>   typename ParentFunctor::ImplBase* Clone() const { return Copy(); }
>...
>};
>```
> This should avoid the need for the compiler to generate the problematic covariant function.