### PR TITLE
Remove not needed fatal message (fixing #8280)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,11 +649,10 @@ if(testing)
   endif()
 endif()
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0")
-  if (${CMAKE_MINIMUM_REQUIRED_VERSION} VERSION_GREATER_EQUAL "3.10.0")
-    message(FATAL_ERROR "Remove this condition")
-  endif()
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0")
   cmake_host_system_information(RESULT PROCESSOR QUERY PROCESSOR_DESCRIPTION)
+else()
+  set(PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
 endif()
 
 message(STATUS "ROOT Configuration \n


### PR DESCRIPTION
Fixes: #8280
@vgvassilev soon this workaround introduced by you will not be needed (see https://github.com/root-project/root/pull/8336)