### PR TITLE
Test if json_fwd.hpp exists

### DIFF
--- a/graf3d/eve7/CMakeLists.txt
+++ b/graf3d/eve7/CMakeLists.txt
@@ -135,8 +135,23 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTEve
 
 if(builtin_nlohmannjson)
    target_include_directories(ROOTEve PRIVATE ${CMAKE_SOURCE_DIR}/builtins)
+   target_compile_definitions(ROOTEve INTERFACE NLOHMANN_JSON_PROVIDES_FWD_HPP)
 else()
    target_link_libraries(ROOTEve PUBLIC nlohmann_json::nlohmann_json)
+
+   get_target_property(inc_dirs nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
+   foreach(dir ${inc_dirs})
+      if(EXISTS "${dir}/nlohmann/json_fwd.hpp")
+         set(found_fwd true)
+      endif()
+   endforeach()
+
+   if(found_fwd)
+      target_compile_definitions(ROOTEve INTERFACE NLOHMANN_JSON_PROVIDES_FWD_HPP)
+   else()
+      message("-- missing nlohmann/json_fwd.hpp required by eve7")
+   endif()
+
 endif()
 
 # this is required for glew

--- a/graf3d/eve7/inc/ROOT/REveElement.hxx
+++ b/graf3d/eve7/inc/ROOT/REveElement.hxx
@@ -18,7 +18,11 @@
 
 #include <memory>
 
+#ifdef NLOHMANN_JSON_PROVIDES_FWD_HPP
 #include <nlohmann/json_fwd.hpp>
+#else
+#include <nlohmann/json.hpp>
+#endif
 
 class TGeoMatrix;
 


### PR DESCRIPTION
On some platforms external nlohmann/json.hpp installed without
such special include. In this case full version has to be used.

Provide special define when compile EVE7 which indicates if
json_fwd.hpp can be used. In the macros such define is not
exported and therefore full version of nlohmann/json.hpp
will be used.

Better solution then https://github.com/root-project/root/pull/8343