### PR TITLE
[DF] Use a RAII object to make sure to always run CleanUpTask (v6.24)

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -95,6 +95,8 @@ class RLoopManager : public RNodeBase {
       }
    };
 
+   friend struct RCallCleanUpTask;
+
    std::vector<RDFInternal::RActionBase *> fBookedActions; ///< Non-owning pointers to actions to be run
    std::vector<RDFInternal::RActionBase *> fRunActions;    ///< Non-owning pointers to actions already run
    std::vector<RFilterBase *> fBookedFilters;


### PR DESCRIPTION
Before this patch we skipped running CleanUpTask if the status
of the TTreeReader after a single-thread event loop over ROOT data
encountered an error.