### PR TITLE
[DF] Add RJittedAction to LinkDef file (v6.24)

### DIFF
--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -21,6 +21,7 @@
 #pragma link C++ namespace ROOT::Detail::RDF;
 #pragma link C++ namespace ROOT::RDF;
 #pragma link C++ class ROOT::Internal::RDF::RActionBase-;
+#pragma link C++ class ROOT::Internal::RDF::RJittedAction-;
 #pragma link C++ class ROOT::Detail::RDF::RFilterBase-;
 #pragma link C++ class ROOT::Detail::RDF::RJittedFilter-;
 #pragma link C++ class ROOT::Detail::RDF::RDefineBase-;


### PR DESCRIPTION
After the latest LLVM upgrade, changes in cling's symbol resolution
logic cause some unresolved symbol failures in RDF jitting.

Adding RJittedAction to the rootmap should help cling autoloading
and work around the problem.