### PR TITLE
[DF] Fix Book with helper that takes no columns 

### DIFF
--- a/tree/dataframe/test/CounterHelper.h
+++ b/tree/dataframe/test/CounterHelper.h
@@ -1,0 +1,27 @@
+#ifndef ROOT_RDF_COUNTERHELPER
+#define ROOT_RDF_COUNTERHELPER
+
+#include <ROOT/RDataFrame.hxx>
+
+#include <atomic>
+#include <functional>
+#include <memory>
+
+class CounterHelper : public ROOT::Detail::RDF::RActionImpl<CounterHelper> {
+   std::shared_ptr<std::atomic_uint> fNCalls; // final result
+public:
+   CounterHelper() : fNCalls(std::make_shared<std::atomic_uint>(0u)) {}
+   CounterHelper(CounterHelper &&) = default;
+   CounterHelper(const CounterHelper &) = delete;
+
+   using Result_t = std::atomic_uint;
+   std::shared_ptr<std::atomic_uint> GetResultPtr() const { return fNCalls; }
+   void Initialize() {}
+   void InitTask(TTreeReader *, unsigned int) {}
+   void Exec(unsigned int) { ++(*fNCalls); }
+   void Finalize() {}
+
+   std::string GetActionName() { return "ThreadSafeCounter"; }
+};
+
+#endif

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -1,3 +1,6 @@
+#include "CounterHelper.h"
+#include "MaxSlotHelper.h"
+
 #include "ROOT/RCsvDS.hxx"
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RStringView.hxx"
@@ -755,4 +758,10 @@ TEST(RDataFrameInterface, MutableForeach)
    int i = 0;
    ROOT::RDataFrame(10).Foreach([&](ULong64_t) mutable { ++i; }, {"rdfentry_"});
    EXPECT_EQ(i, 10);
+}
+
+TEST(RDataFrameInterface, BookWithoutColumns)
+{
+   EXPECT_EQ(ROOT::RDataFrame(3).Book<>(CounterHelper()).GetValue(), 3);
+   EXPECT_THROW(ROOT::RDataFrame(3).Book(MaxSlotHelper(1u)), std::logic_error);
 }


### PR DESCRIPTION
Recent changes that added support for jitted Book actions broke the
edge case in which the action helper takes no columns:
`df.Book(Helper{}, {})` now means "jit this action" rather than "this
action does not take any columns".

With this patch, we resolve this ambiguity at runtime by looking at
the list of column names. A helper type is used to make sure that
compilation is fine in all cases.

cc: @bendavid 