### PR TITLE
Fix bug in [R/T]EveRefCnt::OnZeroRefCount() method

### DIFF
--- a/graf3d/eve/inc/TEveFrameBox.h
+++ b/graf3d/eve/inc/TEveFrameBox.h
@@ -85,6 +85,8 @@ public:
    Bool_t GetDrawBack() const   { return fDrawBack; }
    void   SetDrawBack(Bool_t f) { fDrawBack = f;    }
 
+   virtual void OnZeroRefCount() { delete this; }
+
    ClassDef(TEveFrameBox, 0); // Description of a 2D or 3D frame that can be used to visually group a set of objects.
 };
 

--- a/graf3d/eve/inc/TEveRGBAPalette.h
+++ b/graf3d/eve/inc/TEveRGBAPalette.h
@@ -151,6 +151,8 @@ public:
    void   SetOverColorPixel(Pixel_t pix);
    void   SetOverColorRGBA(UChar_t r, UChar_t g, UChar_t b, UChar_t a=255);
 
+   virtual void OnZeroRefCount() { delete this; }
+
    // ================================================================
 
    void MinMaxValChanged(); // *SIGNAL*

--- a/graf3d/eve7/inc/ROOT/REveFrameBox.hxx
+++ b/graf3d/eve7/inc/ROOT/REveFrameBox.hxx
@@ -23,8 +23,8 @@ public:
    enum EFrameType_e  { kFT_None, kFT_Quad, kFT_Box };
 
 private:
-   REveFrameBox(const REveFrameBox&);            // Not implemented
-   REveFrameBox& operator=(const REveFrameBox&); // Not implemented
+   REveFrameBox(const REveFrameBox&) = delete;
+   REveFrameBox& operator=(const REveFrameBox&) = delete;
 
 protected:
    EFrameType_e fFrameType;
@@ -84,6 +84,8 @@ public:
 
    Bool_t GetDrawBack() const   { return fDrawBack; }
    void   SetDrawBack(Bool_t f) { fDrawBack = f;    }
+
+   void OnZeroRefCount() override { delete this; }
 
 };
 

--- a/graf3d/eve7/inc/ROOT/REveRGBAPalette.hxx
+++ b/graf3d/eve7/inc/ROOT/REveRGBAPalette.hxx
@@ -14,15 +14,12 @@
 
 #include "ROOT/REveUtil.hxx"
 
-#include "TObject.h"
-
 #include "TMath.h"
 
 namespace ROOT {
 namespace Experimental {
 
-class REveRGBAPalette : public TObject,
-                        public REveRefCnt
+class REveRGBAPalette : public REveRefCnt
 {
    friend class REveRGBAPaletteEditor;
    friend class REveRGBAPaletteSubEditor;
@@ -33,8 +30,8 @@ public:
    enum ELimitAction_e { kLA_Cut, kLA_Mark, kLA_Clip, kLA_Wrap };
 
 private:
-   REveRGBAPalette(const REveRGBAPalette&);            // Not implemented
-   REveRGBAPalette& operator=(const REveRGBAPalette&); // Not implemented
+   REveRGBAPalette(const REveRGBAPalette&) = delete;
+   REveRGBAPalette& operator=(const REveRGBAPalette&) = delete;
 
 protected:
    Double_t  fUIf;       // UI representation calculated as: d = fUIf*i + fUIc
@@ -152,13 +149,9 @@ public:
    void   SetOverColorPixel(Pixel_t pix);
    void   SetOverColorRGBA(UChar_t r, UChar_t g, UChar_t b, UChar_t a=255);
 
-   virtual void OnZeroRefCount() { delete this; }
+   void OnZeroRefCount() override { delete this; }
 
-   // ================================================================
-
-   ClassDef(REveRGBAPalette, 0); // A generic, speed-optimised mapping from value to RGBA color supporting different wrapping and range truncation modes.
 };
-
 
 /******************************************************************************/
 // Inlines for REveRGBAPalette

--- a/graf3d/eve7/inc/ROOT/REveRGBAPalette.hxx
+++ b/graf3d/eve7/inc/ROOT/REveRGBAPalette.hxx
@@ -152,6 +152,8 @@ public:
    void   SetOverColorPixel(Pixel_t pix);
    void   SetOverColorRGBA(UChar_t r, UChar_t g, UChar_t b, UChar_t a=255);
 
+   virtual void OnZeroRefCount() { delete this; }
+
    // ================================================================
 
    ClassDef(REveRGBAPalette, 0); // A generic, speed-optimised mapping from value to RGBA color supporting different wrapping and range truncation modes.

--- a/graf3d/eve7/inc/ROOT/REveUtil.hxx
+++ b/graf3d/eve7/inc/ROOT/REveUtil.hxx
@@ -101,15 +101,15 @@ public:
 
 class REveRefCnt
 {
+   REveRefCnt(const REveRefCnt &) = delete;
+   REveRefCnt &operator=(const REveRefCnt &) = delete;
+
 protected:
    Int_t fRefCount{0};
 
 public:
    REveRefCnt() = default;
    virtual ~REveRefCnt() {}
-
-   REveRefCnt(const REveRefCnt &) : fRefCount(0) {}
-   REveRefCnt &operator=(const REveRefCnt &) { return *this; }
 
    void IncRefCount() { ++fRefCount; }
    void DecRefCount()
@@ -118,7 +118,7 @@ public:
          OnZeroRefCount();
    }
 
-   virtual void OnZeroRefCount() { delete this; }
+   virtual void OnZeroRefCount() = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -128,17 +128,17 @@ public:
 
 class REveRefBackPtr : public REveRefCnt
 {
+   REveRefBackPtr(const REveRefBackPtr &) = delete;
+   REveRefBackPtr &operator=(const REveRefBackPtr &) = delete;
+
 protected:
    typedef std::map<REveElement *, Int_t> RefMap_t;
 
    RefMap_t fBackRefs;
 
 public:
-   REveRefBackPtr();
+   REveRefBackPtr() = default;
    virtual ~REveRefBackPtr();
-
-   REveRefBackPtr(const REveRefBackPtr &);
-   REveRefBackPtr &operator=(const REveRefBackPtr &);
 
    using REveRefCnt::DecRefCount;
    using REveRefCnt::IncRefCount;

--- a/graf3d/eve7/src/REveRGBAPalette.cxx
+++ b/graf3d/eve7/src/REveRGBAPalette.cxx
@@ -34,7 +34,6 @@ ClassImp(REveRGBAPalette);
 /// Constructor.
 
 REveRGBAPalette::REveRGBAPalette() :
-   TObject(),
    REveRefCnt(),
 
    fUIf(1), fUIc(0),
@@ -67,7 +66,6 @@ REveRGBAPalette::REveRGBAPalette() :
 
 REveRGBAPalette::REveRGBAPalette(Int_t min, Int_t max, Bool_t interp,
                                  Bool_t showdef, Bool_t fixcolrng) :
-   TObject(),
    REveRefCnt(),
 
    fUIf(1), fUIc(0),

--- a/graf3d/eve7/src/REveUtil.cxx
+++ b/graf3d/eve7/src/REveUtil.cxx
@@ -384,40 +384,11 @@ REveElement objects.
 */
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Default constructor.
-
-REveRefBackPtr::REveRefBackPtr() :
-   REveRefCnt(),
-   fBackRefs()
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Destructor. Noop, should complain if back-ref list is not empty.
 
 REveRefBackPtr::~REveRefBackPtr()
 {
    // !!! Complain if list not empty.
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor. New copy starts with zero reference count and
-/// empty back-reference list.
-
-REveRefBackPtr::REveRefBackPtr(const REveRefBackPtr&) :
-   REveRefCnt(),
-   fBackRefs()
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Assignment operator. Reference count and back-reference
-/// information is not assigned as these object hold pointers to a
-/// specific object.
-
-REveRefBackPtr& REveRefBackPtr::operator=(const REveRefBackPtr&)
-{
-   return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
One cannot simply call `delete this` in base class - 
especially when derived class uses multiple inheritance.
Therefore provide OnZeroRefCount implementation in all derived classes
In REve also mark this method as abstract to ensure that such problem
not appear in the future