### PR TITLE
[llvm] Suppress -Wmisleading-indentation note:

### DIFF
--- a/interpreter/llvm/src/lib/Target/X86/CMakeLists.txt
+++ b/interpreter/llvm/src/lib/Target/X86/CMakeLists.txt
@@ -70,6 +70,14 @@ set(sources
   X86WinEHState.cpp
   )
 
+if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
+  # note: ‘-Wmisleading-indentation’ is disabled from this point onwards, since
+  # column-tracking was disabled due to the size of the code/headers.
+  set_source_files_properties(X86ISelDAGToDAG.cpp PROPERTIES
+    COMPILE_FLAGS -Wno-misleading-indentation
+    )
+endif()
+
 add_llvm_target(X86CodeGen ${sources})
 
 add_subdirectory(AsmParser)


### PR DESCRIPTION
interpreter/llvm/src/lib/Target/X86/X86GenDAGISel.inc:266881: note: ‘-Wmisleading-indentation’ is disabled from this point onwards, since column-tracking was disabled due to the size of the code/headers
We cannot disable the note, we can only disable the warning itself.

See https://github.com/root-project/root/issues/8129