### PR TITLE
[RF] Set plot norm variables in RooAbsPdf::plotOn before using them

### DIFF
--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2970,6 +2970,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
 		      << "): ERROR the 'Expected' scale option can only be used on extendable PDFs" << endl ;
       return frame ;
     }
+    frame->updateNormVars(*frame->getPlotVar()) ;
     nExpected = expectedEvents(frame->getNormVars()) ;
   }
 
@@ -3185,6 +3186,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot *frame, PlotOpt o) const
 		      << "): ERROR the 'Expected' scale option can only be used on extendable PDFs" << endl ;
       return frame ;
     }
+    frame->updateNormVars(*frame->getPlotVar()) ;
     nExpected = expectedEvents(frame->getNormVars()) ;
   }
 


### PR DESCRIPTION
The first call to `frame->updateNormVars(*frame->getPlotVar())` should
be made before the first call to `frame->getNormVars()` in the
`RooAbsPdf::plotOn` function.

This fixes the Jira issue [ROOT-5529](https://sft.its.cern.ch/jira/browse/ROOT-5529).