### PR TITLE
Add TTreeProcessorMP to LinkDef

### DIFF
--- a/tree/treeplayer/inc/LinkDef.h
+++ b/tree/treeplayer/inc/LinkDef.h
@@ -30,6 +30,7 @@
 #pragma link C++ class TSimpleAnalysis+;
 #ifndef _MSC_VER
 #pragma link C++ class TMPWorkerTree+;
+#pragma link C++ class ROOT::TTreeProcessorMP-;
 #endif
 #ifdef R__USE_IMT
 #pragma link C++ class ROOT::TTreeProcessorMT-;


### PR DESCRIPTION
This fixes test failure:
```
 745/1157 Test  #729: tutorial-multicore-mp102_readNtuplesFillHistosAndFit ................***Failed    1.55 sec
Processing /builddir/build/BUILD/root-6.25.01/tutorials/multicore/mp102_readNtuplesFillHistosAndFit.C...
IncrementalExecutor::executeFunction: symbol '_ZN4ROOT16TTreeProcessorMPC1Ej' unresolved while linking [cling interface function]!
You are probably missing the definition of ROOT::TTreeProcessorMP::TTreeProcessorMP(unsigned int)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol '_ZN4ROOT16TTreeProcessorMP11ReplyToIdleEP7TSocket' unresolved while linking [cling interface function]!
You are probably missing the definition of ROOT::TTreeProcessorMP::ReplyToIdle(TSocket*)
Maybe you need to load the corresponding shared library?
CMake Error at /builddir/build/BUILD/root-6.25.01/x86_64-redhat-linux-gnu/RootTestDriver.cmake:237 (message):
  error code: 1
```
