### PR TITLE
Fix 'this' pointer is null warnings

### DIFF
--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -591,7 +591,7 @@ void RooDataHist::importDHistSet(const RooArgList& /*vars*/, RooCategory& indexC
 void RooDataHist::_adjustBinning(RooRealVar &theirVar, const TAxis &axis,
     RooRealVar *ourVar, Int_t *offset)
 {
-  if (!dynamic_cast<RooRealVar*>(ourVar)) {
+  if (!dynamic_cast<RooRealVar*>(static_cast<RooAbsArg*>(ourVar))) {
     coutE(InputArguments) << "RooDataHist::adjustBinning(" << GetName() << ") ERROR: dimension " << ourVar->GetName() << " must be real" << endl ;
     assert(0) ;
   }

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -149,10 +149,10 @@ RooRealSumFunc::RooRealSumFunc(const char *name, const char *title, const RooArg
       _coefList.add(*coef);
    }
 
-   func = (RooAbsReal *)funcIter->Next();
+   func = (RooAbsArg *)funcIter->Next();
    if (func) {
       if (!dynamic_cast<RooAbsReal *>(func)) {
-         coutE(InputArguments) << "RooRealSumFunc::RooRealSumFunc(" << GetName() << ") last func " << coef->GetName()
+         coutE(InputArguments) << "RooRealSumFunc::RooRealSumFunc(" << GetName() << ") last func " << func->GetName()
                                << " is not of type RooAbsReal, fatal error" << endl;
          assert(0);
       }

--- a/tmva/tmva/src/DNN/Architectures/Reference/DataLoader.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Reference/DataLoader.cxx
@@ -128,7 +128,7 @@ void TDataLoader<TMVAInput_t, TReference<Real_t>>::CopyInput(TMatrixT<Real_t> &m
    Event *event = nullptr;
 
    Int_t m = matrix.GetNrows();
-   Int_t n = event->GetNVariables();
+   Int_t n = matrix.GetNcols();
 
    // Copy input variables.
 


### PR DESCRIPTION
```
.../roofit/roofitcore/src/RooDataHist.cxx: In member function 'void RooDataHist::_adjustBinning(RooRealVar&, const TAxis&, RooRealVar*, Int_t*)':
.../roofit/roofitcore/src/RooDataHist.cxx:595:122: warning: 'this' pointer is null [-Wnonnull]
  595 |     coutE(InputArguments) << "RooDataHist::adjustBinning(" << GetName() << ") ERROR: dimension " << ourVar->GetName() << " must be real" << endl ;
      |                                                                                                                          ^~~~~~~~~~~~~~~

.../roofit/roofitcore/src/RooRealSumFunc.cxx: In constructor 'RooRealSumFunc::RooRealSumFunc(const char*, const char*, const RooArgList&, const RooArgList&)':
.../roofit/roofitcore/src/RooRealSumFunc.cxx:156:35: warning: 'this' pointer is null [-Wnonnull]
  156 |                                << " is not of type RooAbsReal, fatal error" << endl;
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

.../tmva/tmva/src/DNN/Architectures/Reference/DataLoader.cxx: In member function 'void TMVA::DNN::TDataLoader<AData, TMVA::DNN::TReference<AReal> >::CopyInput(TMatrixT<AReal>&, TMVA::DNN::IndexIterator_t) [with AData = std::tuple<const std::vector<TMVA::Event*, std::allocator<TMVA::Event*> >&, const TMVA::DataSetInfo&>; AReal = float]':
.../tmva/tmva/src/DNN/Architectures/Reference/DataLoader.cxx:131:34: warning: 'this' pointer is null [-Wnonnull]
  131 |    Int_t n = event->GetNVariables();
      |              ~~~~~~~~~~~~~~~~~~~~^~
In file included from .../tmva/tmva/inc/TMVA/VariableTransformBase.h:48,
                 from .../tmva/tmva/inc/TMVA/Tools.h:58,
                 from .../tmva/tmva/inc/TMVA/DNN/GeneralLayer.h:36,
                 from .../tmva/tmva/inc/TMVA/DNN/CNN/ConvLayer.h:32,
                 from .../tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h:24,
                 from .../tmva/tmva/src/DNN/Architectures/Reference/DataLoader.cxx:17:
.../tmva/tmva/inc/TMVA/Event.h:88:16: note: in a call to non-static member function 'UInt_t TMVA::Event::GetNVariables() const'
   88 |       UInt_t   GetNVariables()        const;
      |                ^~~~~~~~~~~~~
```
