### PR TITLE
[clad] Initial support of hessian calculation in TFormula using clad

### DIFF
--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -96,14 +96,15 @@ private:
    Bool_t            fAllParametersSetted;         ///<  Flag to control if all parameters are setted
    Bool_t            fLazyInitialization = kFALSE; ///<! Transient flag to control lazy initialization (needed for reading from files)
    std::unique_ptr<TMethodCall> fMethod;           ///<! Pointer to methodcall
-   std::unique_ptr<TMethodCall> fGradMethod;       ///<! Pointer to a methodcall
    TString           fClingName;                   ///<! Unique name passed to Cling to define the function ( double clingName(double*x, double*p) )
    std::string       fSavedInputFormula;           ///<! Unique name used to defined the function and used in the global map (need to be saved in case of lazy initialization)
 
    using CallFuncSignature = TInterpreter::CallFuncIFacePtr_t::Generic_t;
    std::string       fGradGenerationInput;         ///<! Input query to clad to generate a gradient
+   std::string       fHessGenerationInput;         ///<! Input query to clad to generate a hessian
    CallFuncSignature fFuncPtr = nullptr;           ///<! Function pointer, owned by the JIT.
    CallFuncSignature fGradFuncPtr = nullptr;       ///<! Function pointer, owned by the JIT.
+   CallFuncSignature fHessFuncPtr = nullptr;       ///<! Function pointer, owned by the JIT.
    void *   fLambdaPtr = nullptr;                  ///<! Pointer to the lambda function
    static bool       fIsCladRuntimeIncluded;
 
@@ -126,8 +127,15 @@ private:
       assert(fClingName.Length() && "TFormula is not initialized yet!");
       return std::string(fClingName.Data()) + "_grad_1";
    }
+   std::string GetHessianFuncName() const {
+      assert(fClingName.Length() && "TFormula is not initialized yet!");
+      return std::string(fClingName.Data()) + "_hessian_1";
+   }
    bool HasGradientGenerationFailed() const {
-      return !fGradMethod && !fGradGenerationInput.empty();
+      return !fGradFuncPtr && !fGradGenerationInput.empty();
+   }
+   bool HasHessianGenerationFailed() const {
+      return !fHessFuncPtr && !fHessGenerationInput.empty();
    }
 
 protected:
@@ -173,7 +181,7 @@ public:
       kLinear        = BIT(16),    ///< Set to true if the TFormula is for linear fitting
       kLambda        = BIT(17)     ///< Set to true if TFormula has been build with a lambda
    };
-   using GradientStorage = std::vector<Double_t>;
+   using CladStorage = std::vector<Double_t>;
 
                   TFormula();
    virtual        ~TFormula();
@@ -199,18 +207,37 @@ public:
    /// \returns true if a gradient was generated and GradientPar can be called.
    bool GenerateGradientPar();
 
+   /// Generate hessian computation routine with respect to the parameters.
+   /// \returns true if a hessian was generated and HessianPar can be called.
+   bool GenerateHessianPar();
+
    /// Compute the gradient employing automatic differentiation.
    ///
    /// \param[in] x - The given variables, if nullptr the already stored
    ///                variables are used.
    /// \param[out] result - The result of the computation wrt each direction.
-   void GradientPar(const Double_t *x, TFormula::GradientStorage& result);
+   void GradientPar(const Double_t *x, TFormula::CladStorage& result);
 
    void GradientPar(const Double_t *x, Double_t *result);
 
+   /// Compute the gradient employing automatic differentiation.
+   ///
+   /// \param[in] x - The given variables, if nullptr the already stored
+   ///                variables are used.
+   /// \param[out] result - The 2D hessian matrix flattened to form a vector
+   ///                      in row-major order.
+   void HessianPar(const Double_t *x, TFormula::CladStorage& result);
+
+   void HessianPar(const Double_t *x, Double_t *result);
+
    // query if TFormula provides gradient computation using AD (CLAD)
    bool HasGeneratedGradient() const {
-      return fGradMethod != nullptr;
+      return fGradFuncPtr != nullptr;
+   }
+
+   // query if TFormula provides hessian computation using AD (CLAD)
+   bool HasGeneratedHessian() const {
+      return fHessFuncPtr != nullptr;
    }
 
    // template <class T>
@@ -224,6 +251,7 @@ public:
 #endif
    TString        GetExpFormula(Option_t *option="") const;
    TString        GetGradientFormula() const;
+   TString        GetHessianFormula() const;
    const TObject *GetLinearPart(Int_t i) const;
    Int_t          GetNdim() const {return fNdim;}
    Int_t          GetNpar() const {return fNpar;}

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -23,4 +23,5 @@ endif()
 
 if(clad)
   ROOT_ADD_GTEST(TFormulaGradientTests TFormulaGradientTests.cxx LIBRARIES Core MathCore Hist)
+  ROOT_ADD_GTEST(TFormulaHessianTests TFormulaHessianTests.cxx LIBRARIES Core MathCore Hist)
 endif()

--- a/hist/hist/test/TFormulaGradientTests.cxx
+++ b/hist/hist/test/TFormulaGradientTests.cxx
@@ -28,7 +28,7 @@ TEST(TFormulaGradientPar, Sanity)
    double p[] = {30, 60};
    f.SetParameters(p);
    double x[] = {1, 2};
-   TFormula::GradientStorage result(2);
+   TFormula::CladStorage result(2);
    f.GradientPar(x, result);
 
    ASSERT_FLOAT_EQ(x[0] * std::cos(30), result[0]);
@@ -40,7 +40,7 @@ TEST(TFormulaGradientPar, ResultUpsize)
    TFormula f("f", "std::sin([1]) - std::cos([0])");
    double p[] = {60, 30};
    f.SetParameters(p);
-   TFormula::GradientStorage result;
+   TFormula::CladStorage result;
    double x[] = {2, 1};
 
    ASSERT_TRUE(0 == result.size());
@@ -59,7 +59,7 @@ TEST(TFormulaGradientPar, ResultDownsize)
    TFormula f("f", "std::sin([0])");
    double p[] = {60};
    f.SetParameters(p);
-   TFormula::GradientStorage result(2);
+   TFormula::CladStorage result(2);
    double x[] = {1};
 
    ASSERT_TRUE(2 == result.size());
@@ -79,10 +79,10 @@ TEST(TFormulaGradientPar, GausCrossCheck)
    double p[] = {3, 1, 2};
    h->SetParameters(p);
    double x[] = {0};
-   TFormula::GradientStorage result_clad(3);
+   TFormula::CladStorage result_clad(3);
    h->GetFormula()->GradientPar(x, result_clad);
 
-   TFormula::GradientStorage result_num(3);
+   TFormula::CladStorage result_num(3);
    h->GradientPar(x, result_num.data());
 
    ASSERT_FLOAT_EQ(result_num[0], result_clad[0]);
@@ -96,10 +96,10 @@ TEST(TFormulaGradientPar, BreitWignerCrossCheck)
    double p[] = {3, 1, 2.1};
    h->SetParameters(p);
    double x[] = {0};
-   TFormula::GradientStorage result_clad(3);
+   TFormula::CladStorage result_clad(3);
    TFormula* formula = h->GetFormula();
    formula->GradientPar(x, result_clad);
-   TFormula::GradientStorage result_num(3);
+   TFormula::CladStorage result_num(3);
    h->GradientPar(x, result_num.data());
 
    ASSERT_FLOAT_EQ(result_num[0], result_clad[0]);
@@ -113,10 +113,10 @@ TEST(TFormulaGradientPar, BreitWignerCrossCheckAccuracyDemo)
    double p[] = {3, 1, 2};
    h->SetParameters(p);
    double x[] = {0};
-   TFormula::GradientStorage result_clad(3);
+   TFormula::CladStorage result_clad(3);
    TFormula* formula = h->GetFormula();
    formula->GradientPar(x, result_clad);
-   TFormula::GradientStorage result_num(3);
+   TFormula::CladStorage result_num(3);
    h->GradientPar(x, result_num.data());
 
    // This is a classical example why clad is better.
@@ -140,7 +140,7 @@ TEST(TFormulaGradientPar, GetGradFormula)
    std::string s = f.GetGradientFormula().Data();
    // Windows does not support posix regex which are necessary here.
 #ifndef R__WIN32
-   ASSERT_THAT(s, testing::ContainsRegex("void TFormula____id[0-9]*_grad"));
+   ASSERT_THAT(s, testing::ContainsRegex("void TFormula____id[0-9]*_grad_1"));
 #endif // R__WIN32
 }
 

--- a/hist/hist/test/TFormulaHessianTests.cxx
+++ b/hist/hist/test/TFormulaHessianTests.cxx
@@ -1,0 +1,86 @@
+/// \file TFormulaHessianTests.cxx
+///
+/// \brief The file contain unit tests which test the clad-based hessian
+///        computations.
+///
+/// \author Baidyanath Kundu <kundubaidya99@gmail.com>
+///
+/// \date Aug, 2021
+///
+/*************************************************************************
+ * Copyright (C) 1995-2018, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOTUnitTestSupport.h"
+
+#include <Math/MinimizerOptions.h>
+#include <TFormula.h>
+
+TEST(TFormulaHessianPar, Sanity)
+{
+   TFormula f("f", "x*std::sin([0]) - y*std::cos([1])");
+   double p[] = {30, 60};
+   f.SetParameters(p);
+   double x[] = {1, 2};
+   TFormula::CladStorage result(4);
+   f.HessianPar(x, result);
+
+   ASSERT_FLOAT_EQ(-1 * x[0] * std::sin(p[0]), result[0]);
+   ASSERT_FLOAT_EQ(0, result[1]);
+   ASSERT_FLOAT_EQ(0, result[2]);
+   ASSERT_FLOAT_EQ(x[1] * std::cos(p[1]), result[3]);
+}
+
+TEST(TFormulaHessianPar, ResultUpsize)
+{
+   TFormula f("f", "std::sin([1]) - std::cos([0])");
+   double p[] = {60, 30};
+   f.SetParameters(p);
+   TFormula::CladStorage result;
+   double x[] = {2, 1};
+
+   ASSERT_TRUE(0 == result.size());
+   ROOT_EXPECT_WARNING(f.HessianPar(x, result),
+   "TFormula::HessianPar",
+   "The size of hessian result is 0 but 4 is required. Resizing."
+   );
+
+   ASSERT_FLOAT_EQ(std::cos(p[0]), result[0]);
+   ASSERT_FLOAT_EQ(0, result[1]);
+   ASSERT_FLOAT_EQ(0, result[2]);
+   ASSERT_FLOAT_EQ(- std::sin(p[1]), result[3]);
+   ASSERT_TRUE(4 == result.size());
+}
+
+TEST(TFormulaHessianPar, ResultDownsize)
+{
+   TFormula f("f", "std::sin([0])");
+   double p[] = {60};
+   f.SetParameters(p);
+   TFormula::CladStorage result(2);
+   double x[] = {1};
+
+   ASSERT_TRUE(2 == result.size());
+
+   ROOT_EXPECT_NODIAG(f.HessianPar(x, result));
+
+   ASSERT_FLOAT_EQ(- std::sin(p[0]), result[0]);
+   ASSERT_TRUE(2 == result.size());
+}
+
+TEST(TFormulaHessianPar, GetHessFormula)
+{
+   TFormula f("f", "gaus");
+   double p[] = {3, 1, 2};
+   f.SetParameters(p);
+   ASSERT_TRUE(f.GenerateHessianPar());
+   std::string s = f.GetHessianFormula().Data();
+   // Windows does not support posix regex which are necessary here.
+   #ifndef R__WIN32
+   ASSERT_THAT(s, testing::ContainsRegex("void TFormula____id[0-9]*_hessian_1"));
+   #endif // R__WIN32
+}

--- a/math/mathcore/inc/Math/CladDerivator.h
+++ b/math/mathcore/inc/Math/CladDerivator.h
@@ -32,8 +32,18 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  T Abs_darg0_darg0(T d) {
+    return 0;
+  }
+
+  template <typename T>
   Double_t ACos_darg0(T d) {
     return -1./TMath::Sqrt(1 - d * d);
+  }
+
+  template <typename T>
+  Double_t ACos_darg0_darg0(T d) {
+    return - d / (TMath::Sqrt(1 - d * d) * (1 - d * d));
   }
 
   template <typename T>
@@ -42,8 +52,18 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  Double_t ACosH_darg0_darg0(T d) {
+    return - d / (TMath::Sqrt(d * d - 1) * (d * d - 1) * TMath::Sqrt(d * d + 1) * (d * d + 1));
+  }
+
+  template <typename T>
   Double_t ASin_darg0(T d) {
     return 1. / TMath::Sqrt(1 - d * d);
+  }
+
+  template <typename T>
+  Double_t ASin_darg0_darg0(T d) {
+    return d / (TMath::Sqrt(1 - d * d) * (1 - d * d));
   }
 
   template <typename T>
@@ -52,8 +72,18 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  Double_t ASinH_darg0_darg0(T d) {
+    return -d / (TMath::Sqrt(d * d + 1) * (d * d + 1));
+  }
+
+  template <typename T>
   Double_t ATan_darg0(T d) {
     return 1. / (d * d + 1);
+  }
+
+  template <typename T>
+  Double_t ATan_darg0_darg0(T d) {
+    return -2. * d / ((d * d + 1) * (d * d + 1));
   }
 
   template <typename T>
@@ -62,13 +92,29 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  Double_t ATanH_darg0_darg0(T d) {
+    return 2. * d / ((1 - d * d) * (1 - d * d));
+  }
+
+  template <typename T>
   T Cos_darg0(T d) {
     return -TMath::Sin(d);
   }
 
   template <typename T>
+  T Cos_darg0_darg0(T d) {
+    return -TMath::Cos(d);
+  }
+
+  template <typename T>
   T CosH_darg0(T d) {
     return TMath::SinH(d);
+  }
+
+
+  template <typename T>
+  T CosH_darg0_darg0(T d) {
+    return TMath::CosH(d);
   }
 
   template <typename T>
@@ -77,12 +123,27 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  Double_t Erf_darg0_darg0(T d) {
+    return -4 * TMath::Exp(-d * d) * d / TMath::Sqrt(TMath::Pi());
+  }
+
+  template <typename T>
   Double_t Erfc_darg0(T d) { 
-    return -Erf_darg(d);
+    return -Erf_darg0(d);
+  }
+
+  template <typename T>
+  Double_t Erfc_darg0_darg0(T d) {
+    return -Erf_darg0_darg0(d);
   }
 
   template <typename T>
   Double_t Exp_darg0(T d) {
+    return TMath::Exp(d);
+  }
+
+  template <typename T>
+  Double_t Exp_darg0_darg0(T d) {
     return TMath::Exp(d);
   }
 
@@ -92,8 +153,28 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  T Hypot_darg0_darg0(T x, T y) {
+    return y * y / (TMath::Hypot(x, y) * (x * x + y * y));
+  }
+
+  template <typename T>
+  T Hypot_darg0_darg1(T x, T y) {
+    return x * y / (TMath::Hypot(x, y) * (x * x + y * y));
+  }
+
+  template <typename T>
   T Hypot_darg1(T x, T y) {
     return y / TMath::Hypot(x, y);
+  }
+
+  template <typename T>
+  T Hypot_darg1_darg0(T x, T y) {
+    return x * y / (TMath::Hypot(x, y) * (x * x + y * y));
+  }
+
+  template <typename T>
+  T Hypot_darg1_darg1(T x, T y) {
+    return x * x / (TMath::Hypot(x, y) * (x * x + y * y));
   }
     
   template <typename T>
@@ -104,8 +185,27 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  void Hypot_darg0_grad(T x, T y, T* result) {
+    T h = y / (TMath::Hypot(x, y) * (x * x + y * y));
+    result[0] += y * h;
+    result[1] += x * h;
+  }
+
+  template <typename T>
+  void Hypot_darg1_grad(T x, T y, T* result) {
+    T h = x / (TMath::Hypot(x, y) * (x * x + y * y));
+    result[0] += y * h;
+    result[1] += x * h;
+  }
+
+  template <typename T>
   Double_t Log_darg0(T d) {
     return 1. / d;
+  }
+
+  template <typename T>
+  Double_t Log_darg0_darg0(T d) {
+    return -1. / (d * d);
   }
 
   template <typename T>
@@ -114,9 +214,19 @@ namespace custom_derivatives {
   } 
 
   template <typename T>
+  Double_t Log10_darg0_darg0(T d) {
+    return Log_darg0_darg0(d) / TMath::Ln10();
+  }
+
+  template <typename T>
   Double_t Log2_darg0(T d) {
     return Log_darg0(d) / TMath::Log(2);
   } 
+
+  template <typename T>
+  Double_t Log2_darg0_darg0(T d) {
+    return Log_darg0_darg0(d) / TMath::Log(2);
+  }
 
   template <typename T>
   T Max_darg0(T a, T b) {
@@ -124,8 +234,28 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  T Max_darg0_darg0(T a, T b) {
+    return 0;
+  }
+
+  template <typename T>
+  T Max_darg0_darg1(T a, T b) {
+    return 0;
+  }
+
+  template <typename T>
   T Max_darg1(T a, T b) {
     return (a >= b) ? 0 : 1;
+  }
+
+  template <typename T>
+  T Max_darg1_darg0(T a, T b) {
+    return 0;
+  }
+
+  template <typename T>
+  T Max_darg1_darg1(T a, T b) {
+    return 0;
   }
 
   template <typename T>
@@ -137,13 +267,43 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  void Max_darg0_grad(T a, T b, T* result) {
+    return;
+  }
+
+  template <typename T>
+  void Max_darg1_grad(T a, T b, T* result) {
+    return;
+  }
+
+  template <typename T>
   T Min_darg0(T a, T b) {
     return (a <= b) ? 1 : 0;
   }
 
   template <typename T>
+  T Min_darg0_darg0(T a, T b) {
+    return 0;
+  }
+
+  template <typename T>
+  T Min_darg0_darg1(T a, T b) {
+    return 0;
+  }
+
+  template <typename T>
   T Min_darg1(T a, T b) {
     return (a <= b) ? 0 : 1;
+  }
+
+  template <typename T>
+  T Min_darg1_darg0(T a, T b) {
+    return 0;
+  }
+
+  template <typename T>
+  T Min_darg1_darg1(T a, T b) {
+    return 0;
   }
 
   template <typename T>
@@ -155,13 +315,43 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  void Min_darg0_grad(T a, T b, T* result) {
+    return;
+  }
+
+  template <typename T>
+  void Min_darg1_grad(T a, T b, T* result) {
+    return;
+  }
+
+  template <typename T>
   T Power_darg0(T x, T y) {
     return y * TMath::Power(x, y - 1);
   }
 
   template <typename T>
+  T Power_darg0_darg0(T x, T y) {
+    return y * (y - 1) * TMath::Power(x, y - 2);
+  }
+
+  template <typename T>
+  Double_t Power_darg0_darg1(T x, T y) {
+    return TMath::Power(x, y - 1) * (y * TMath::Log(x) + 1);
+  }
+
+  template <typename T>
   Double_t Power_darg1(T x, T y) {
     return TMath::Power(x, y) * TMath::Log(x);
+  }
+
+  template <typename T>
+  Double_t Power_darg1_darg0(T x, T y) {
+    return TMath::Power(x, y - 1) * (y * TMath::Log(x) + 1);
+  }
+
+  template <typename T>
+  Double_t Power_darg1_darg1(T x, T y) {
+    return TMath::Power(x, y) * TMath::Sq(TMath::Log(x));
   }
 
   template <typename T>
@@ -172,8 +362,27 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  Double_t Power_darg0_grad(T x, T y, Double_t* result) {
+    T t = TMath::Power(x, y - 2);
+    result[0] += y * (y - 1) * t;
+    result[1] += x * t * (y * TMath::Log(x) + 1);
+  }
+
+  template <typename T>
+  Double_t Power_darg1_grad(T x, T y, Double_t* result) {
+    T t = TMath::Power(x, y - 1);
+    result[0] += t * (y * TMath::Log(x) + 1);
+    result[1] += x * t * TMath::Sq(TMath::Log(x));
+  }
+
+  template <typename T>
   Double_t Sin_darg0(T d) {
     return TMath::Cos(d);
+  }
+
+  template <typename T>
+  Double_t Sin_darg0_darg0(T d) {
+    return -TMath::Sin(d);
   }
 
   template <typename T>
@@ -182,8 +391,18 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  Double_t SinH_darg0_darg0(T d) {
+    return TMath::SinH(d);
+  }
+
+  template <typename T>
   T Sq_darg0(T d) {
     return 2 * d;
+  }
+
+  template <typename T>
+  T Sq_darg0_darg0(T d) {
+    return 2;
   }
 
   template <typename T>
@@ -192,13 +411,28 @@ namespace custom_derivatives {
   }
 
   template <typename T>
+  Double_t Sqrt_darg0_darg0(T d) {
+    return 0.25 / (TMath::Sqrt(d) * d);
+  }
+
+  template <typename T>
   Double_t Tan_darg0(T d) {
     return 1./ TMath::Sq(TMath::Cos(d));
   }
 
   template <typename T>
+  Double_t Tan_darg0_darg0(T d) {
+    return 2. * TMath::Sin(d) / (TMath::Cos(d) * TMath::Cos(d) * TMath::Cos(d));
+  }
+
+  template <typename T>
   Double_t TanH_darg0(T d) {
     return 1./ TMath::Sq(TMath::CosH(d));
+  }
+
+  template <typename T>
+  Double_t TanH_darg0_darg0(T d) {
+    return -2. * TMath::SinH(d) / (TMath::CosH(d) * TMath::CosH(d) * TMath::CosH(d));
   }
 }
 #endif // CLAD_DERIVATOR


### PR DESCRIPTION
TFormula already supports gradient calculation using clad. This commit extends that support for hessian calculation. Thus the hessian generation is done by clad and TFormula wraps it in a trampoline function.