### PR TITLE
[DF] Improve Snapshot branch-address-resetting logic 

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -52,6 +52,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RActionBase.hxx
     ROOT/RDF/RAction.hxx
     ROOT/RDF/RBookedDefines.hxx
+    ROOT/RDF/RDataBlockNotifier.hxx
     ROOT/RDF/RDefineBase.hxx
     ROOT/RDF/RDefine.hxx
     ROOT/RDF/RDefineReader.hxx

--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -56,6 +56,7 @@
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TStatistic>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TProfile>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TProfile2D>+;
+#pragma link C++ class TNotifyLink<ROOT::Internal::RDF::RDataBlockFlag>;
 
 #endif
 

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1193,7 +1193,7 @@ void SetBranchesHelper(BoolArrayMap &, TTree *inputTree, TTree &outputTree, cons
       outputBranch = outputTree.Branch(name.c_str(), address);
    }
    outputBranches.Insert(name, outputBranch);
-   // This is not an array branch, so we don't need to register the address of the input branch.
+   // This is not an array branch, so we don't register the address of the output branch here
    branch = nullptr;
    branchAddress = nullptr;
 }
@@ -1229,12 +1229,11 @@ void SetBranchesHelper(BoolArrayMap &boolArrays, TTree *inputTree, TTree &output
       // Treat:
       // 2. RVec coming from a custom column or a source
       // 3. RVec coming from a column on disk of type vector (the RVec is adopting the data of that vector)
-      // 4. TClonesArray.
-      // In all cases, we write out a std::vector<T> when the column is RVec<T>
+      // 4. TClonesArray written out as RVec<T>
       if (isTClonesArray) {
          Warning("Snapshot",
                  "Branch \"%s\" contains TClonesArrays but the type specified to Snapshot was RVec<T>. The branch will "
-                 "be written out as a std::vector instead of a TClonesArray. Specify that the type of the branch is "
+                 "be written out as a RVec instead of a TClonesArray. Specify that the type of the branch is "
                  "TClonesArray as a Snapshot template parameter to write out a TClonesArray instead.", inName.c_str());
       }
       if (outputBranch) {

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1430,8 +1430,7 @@ public:
 
    std::function<void(unsigned int)> GetDataBlockCallback() final
    {
-      auto callback = [this](unsigned int) mutable { fBranchAddressesNeedReset = true; };
-      return {callback};
+      return [this](unsigned int) mutable { fBranchAddressesNeedReset = true; };
    }
 };
 
@@ -1605,8 +1604,7 @@ public:
 
    std::function<void(unsigned int)> GetDataBlockCallback() final
    {
-      auto callback = [this](unsigned int slot) mutable { fBranchAddressesNeedReset[slot] = 1; };
-      return {callback};
+      return [this](unsigned int slot) mutable { fBranchAddressesNeedReset[slot] = 1; };
    }
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -46,6 +46,7 @@
 #include "ROOT/RDF/RMergeableValue.hxx"
 
 #include <algorithm>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <stdexcept>
@@ -79,6 +80,8 @@ public:
    {
       throw std::logic_error("`GetMergeableValue` is not implemented for this type of action.");
    }
+
+   virtual std::function<void(unsigned int)> GetDataBlockCallback() { return {}; }
 };
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -96,6 +96,41 @@ using namespace ROOT::Detail::RDF;
 
 using Hist_t = ::TH1D;
 
+class RBranchSet {
+   std::vector<TBranch *> fBranches;
+   std::vector<std::string> fNames;
+
+public:
+   TBranch *Get(const std::string &name) const
+   {
+      auto it = std::find(fNames.begin(), fNames.end(), name);
+      if (it == fNames.end())
+         return nullptr;
+      return fBranches[std::distance(fNames.begin(), it)];
+   }
+
+   void Insert(const std::string &name, TBranch *address)
+   {
+      if (address == nullptr) {
+         throw std::logic_error("Trying to insert a null branch address.");
+      }
+      if (std::find(fBranches.begin(), fBranches.end(), address) != fBranches.end()) {
+         throw std::logic_error("Trying to insert a branch address that's already present.");
+      }
+      if (std::find(fNames.begin(), fNames.end(), name) != fNames.end()) {
+         throw std::logic_error("Trying to insert a branch name that's already present.");
+      }
+      fNames.emplace_back(name);
+      fBranches.emplace_back(address);
+   }
+
+   void Clear()
+   {
+      fBranches.clear();
+      fNames.clear();
+   }
+};
+
 /// The container type for each thread's partial result in an action helper
 // We have to avoid to instantiate std::vector<bool> as that makes it impossible to return a reference to one of
 // the thread-local results. In addition, a common definition for the type of the container makes it easy to swap
@@ -1117,9 +1152,28 @@ void *GetData(T & /*v*/)
 
 template <typename T>
 void SetBranchesHelper(BoolArrayMap &, TTree *inputTree, TTree &outputTree, const std::string &inName,
-                       const std::string &name, TBranch *&branch, void *&branchAddress, T *address)
+                       const std::string &name, TBranch *&branch, void *&branchAddress, T *address,
+                       RBranchSet &outputBranches)
 {
-   auto *inputBranch = inputTree ? inputTree->GetBranch(inName.c_str()) : nullptr;
+   static TClassRef TBOClRef("TBranchObject");
+   // FIXME we should be using FindBranch as a fallback if GetBranch fails
+   TBranch *inputBranch = inputTree ? inputTree->GetBranch(inName.c_str()) : nullptr;
+
+   auto *outputBranch = outputBranches.Get(name);
+   if (outputBranch) {
+      // the output branch was already created, we just need to (re)set its address
+      if (inputBranch && inputBranch->IsA() == TBOClRef) {
+         outputBranch->SetAddress(reinterpret_cast<T **>(inputBranch->GetAddress()));
+      } else if (outputBranch->IsA() != TBranch::Class()) {
+         branchAddress = address;
+         outputBranch->SetAddress(&branchAddress);
+      } else {
+         outputBranch->SetAddress(address);
+         branchAddress = address;
+      }
+      return;
+   }
+
    if (inputBranch) {
       // Respect the original bufsize and splitlevel arguments
       // In particular, by keeping splitlevel equal to 0 if this was the case for `inputBranch`, we avoid
@@ -1128,16 +1182,17 @@ void SetBranchesHelper(BoolArrayMap &, TTree *inputTree, TTree &outputTree, cons
       const auto bufSize = inputBranch->GetBasketSize();
       const auto splitLevel = inputBranch->GetSplitLevel();
 
-      static TClassRef tbo_cl("TBranchObject");
-      if (inputBranch->IsA() == tbo_cl) {
+      if (inputBranch->IsA() == TBOClRef) {
          // Need to pass a pointer to pointer
-         outputTree.Branch(name.c_str(), (T **)inputBranch->GetAddress(), bufSize, splitLevel);
+         outputBranch =
+            outputTree.Branch(name.c_str(), reinterpret_cast<T **>(inputBranch->GetAddress()), bufSize, splitLevel);
       } else {
-         outputTree.Branch(name.c_str(), address, bufSize, splitLevel);
+         outputBranch = outputTree.Branch(name.c_str(), address, bufSize, splitLevel);
       }
    } else {
-      outputTree.Branch(name.c_str(), address);
+      outputBranch = outputTree.Branch(name.c_str(), address);
    }
+   outputBranches.Insert(name, outputBranch);
    // This is not an array branch, so we don't need to register the address of the input branch.
    branch = nullptr;
    branchAddress = nullptr;
@@ -1154,7 +1209,8 @@ void SetBranchesHelper(BoolArrayMap &, TTree *inputTree, TTree &outputTree, cons
 /// `branchAddress`) so we can intercept changes in the address of the input branch and tell the output branch.
 template <typename T>
 void SetBranchesHelper(BoolArrayMap &boolArrays, TTree *inputTree, TTree &outputTree, const std::string &inName,
-                       const std::string &outName, TBranch *&branch, void *&branchAddress, RVec<T> *ab)
+                       const std::string &outName, TBranch *&branch, void *&branchAddress, RVec<T> *ab,
+                       RBranchSet &outputBranches)
 {
    TBranch *inputBranch = nullptr;
    if (inputTree) {
@@ -1164,6 +1220,7 @@ void SetBranchesHelper(BoolArrayMap &boolArrays, TTree *inputTree, TTree &output
          inputBranch = inputTree->FindBranch(inName.c_str());
       }
    }
+   auto *outputBranch = outputBranches.Get(outName);
    const bool isTClonesArray = inputBranch != nullptr && std::string(inputBranch->GetClassName()) == "TClonesArray";
    const auto mustWriteRVec = !inputBranch || isTClonesArray ||
                               ROOT::ESTLType::kSTLvector == TClassEdit::IsSTLCont(inputBranch->GetClassName());
@@ -1180,7 +1237,13 @@ void SetBranchesHelper(BoolArrayMap &boolArrays, TTree *inputTree, TTree &output
                  "be written out as a std::vector instead of a TClonesArray. Specify that the type of the branch is "
                  "TClonesArray as a Snapshot template parameter to write out a TClonesArray instead.", inName.c_str());
       }
-      outputTree.Branch(outName.c_str(), ab);
+      if (outputBranch) {
+         branchAddress = GetData(*ab);
+         outputBranch->SetAddress(&branchAddress);
+      } else {
+         auto *b = outputTree.Branch(outName.c_str(), ab);
+         outputBranches.Insert(outName, b);
+      }
       return;
    }
 
@@ -1197,13 +1260,22 @@ void SetBranchesHelper(BoolArrayMap &boolArrays, TTree *inputTree, TTree &output
    /// so we need to explicitly manage storage of the data that the tree needs to Fill branches with.
    auto dataPtr = UpdateBoolArrayIfBool(boolArrays, *ab, outName);
 
-   auto *const outputBranch = outputTree.Branch(outName.c_str(), dataPtr, leaflist.c_str());
-   outputBranch->SetTitle(inputBranch->GetTitle());
-
-   // Record the branch ptr and the address associated to it if this is not a bool array
-   if (!std::is_same<bool, T>::value) {
-      branch = outputBranch;
-      branchAddress = GetData(*ab);
+   if (outputBranch) {
+      if (outputBranch->IsA() != TBranch::Class()) {
+         branchAddress = dataPtr;
+         outputBranch->SetAddress(&branchAddress);
+      } else {
+         outputBranch->SetAddress(dataPtr);
+      }
+   } else {
+      outputBranch = outputTree.Branch(outName.c_str(), dataPtr, leaflist.c_str());
+      outputBranch->SetTitle(inputBranch->GetTitle());
+      outputBranches.Insert(outName, outputBranch);
+      // Record the branch ptr and the address associated to it if this is not a bool array
+      if (!std::is_same<bool, T>::value) {
+         branch = outputBranch;
+         branchAddress = GetData(*ab);
+      }
    }
 }
 
@@ -1238,13 +1310,15 @@ class SnapshotHelper : public RActionImpl<SnapshotHelper<ColTypes...>> {
    const RSnapshotOptions fOptions;
    std::unique_ptr<TFile> fOutputFile;
    std::unique_ptr<TTree> fOutputTree; // must be a ptr because TTrees are not copy/move constructible
-   bool fIsFirstEvent{true};
+   bool fBranchAddressesNeedReset{true};
    const ColumnNames_t fInputBranchNames; // This contains the resolved aliases
    const ColumnNames_t fOutputBranchNames;
    TTree *fInputTree = nullptr; // Current input tree. Set at initialization time (`InitTask`)
    BoolArrayMap fBoolArrays; // Storage for C arrays of bools to be written out
-   std::vector<TBranch *> fBranches;     // Addresses of branches in output, non-null only for the ones holding C arrays
-   std::vector<void *> fBranchAddresses; // Addresses associated to output branches, non-null only for the ones holding C arrays
+   // TODO we might be able to unify fBranches, fBranchAddresses and fOutputBranches
+   std::vector<TBranch *> fBranches; // Addresses of branches in output, non-null only for the ones holding C arrays
+   std::vector<void *> fBranchAddresses; // Addresses of objects associated to output branches
+   RBranchSet fOutputBranches;
 
 public:
    using ColumnTypes_t = TypeList<ColTypes...>;
@@ -1264,20 +1338,17 @@ public:
    {
       if (r)
          fInputTree = r->GetTree();
+      fBranchAddressesNeedReset = true;
    }
 
    void Exec(unsigned int /* slot */, ColTypes &... values)
    {
       using ind_t = std::index_sequence_for<ColTypes...>;
-      if (! fIsFirstEvent) {
+      if (!fBranchAddressesNeedReset) {
          UpdateCArraysPtrs(values..., ind_t{});
       } else {
          SetBranches(values..., ind_t{});
-         // AddClone guarantees that if the input file changes the branches of the output tree are updated with the new
-         // addresses of the branch values
-         if (fInputTree != nullptr)
-            fInputTree->AddClone(fOutputTree.get());
-         fIsFirstEvent = false;
+         fBranchAddressesNeedReset = false;
       }
       UpdateBoolArrays(values..., ind_t{});
       fOutputTree->Fill();
@@ -1303,10 +1374,11 @@ public:
    void SetBranches(ColTypes &... values, std::index_sequence<S...> /*dummy*/)
    {
       // create branches in output tree (and fill fBoolArrays for RVec<bool> columns)
-      int expander[] = {(SetBranchesHelper(fBoolArrays, fInputTree, *fOutputTree, fInputBranchNames[S],
-                                           fOutputBranchNames[S], fBranches[S], fBranchAddresses[S], &values),
-                         0)...,
-                        0};
+      int expander[] = {
+         (SetBranchesHelper(fBoolArrays, fInputTree, *fOutputTree, fInputBranchNames[S], fOutputBranchNames[S],
+                            fBranches[S], fBranchAddresses[S], &values, fOutputBranches),
+          0)...,
+         0};
       (void)expander; // avoid unused variable warnings for older compilers such as gcc 4.9
    }
 
@@ -1355,6 +1427,12 @@ public:
    }
 
    std::string GetActionName() { return "Snapshot"; }
+
+   std::function<void(unsigned int)> GetDataBlockCallback() final
+   {
+      auto callback = [this](unsigned int) mutable { fBranchAddressesNeedReset = true; };
+      return {callback};
+   }
 };
 
 /// Helper object for a multi-thread Snapshot action
@@ -1364,7 +1442,7 @@ class SnapshotHelperMT : public RActionImpl<SnapshotHelperMT<ColTypes...>> {
    std::unique_ptr<ROOT::Experimental::TBufferMerger> fMerger; // must use a ptr because TBufferMerger is not movable
    std::vector<std::shared_ptr<ROOT::Experimental::TBufferMergerFile>> fOutputFiles;
    std::vector<std::unique_ptr<TTree>> fOutputTrees;
-   std::vector<int> fIsFirstEvent;        // vector<bool> does not allow concurrent writing of different elements
+   std::vector<int> fBranchAddressesNeedReset; // vector<bool> does not allow concurrent writing of different elements
    const std::string fFileName;           // name of the output file name
    const std::string fDirName;            // name of TFile subdirectory in which output must be written (possibly empty)
    const std::string fTreeName;           // name of output tree
@@ -1377,17 +1455,18 @@ class SnapshotHelperMT : public RActionImpl<SnapshotHelperMT<ColTypes...>> {
    std::vector<std::vector<TBranch *>> fBranches;
    // Addresses associated to output branches per slot, non-null only for the ones holding C arrays
    std::vector<std::vector<void *>> fBranchAddresses;
+   std::vector<RBranchSet> fOutputBranches;
 
 public:
    using ColumnTypes_t = TypeList<ColTypes...>;
    SnapshotHelperMT(const unsigned int nSlots, std::string_view filename, std::string_view dirname,
                     std::string_view treename, const ColumnNames_t &vbnames, const ColumnNames_t &bnames,
                     const RSnapshotOptions &options)
-      : fNSlots(nSlots), fOutputFiles(fNSlots), fOutputTrees(fNSlots), fIsFirstEvent(fNSlots, 1), fFileName(filename),
-        fDirName(dirname), fTreeName(treename), fOptions(options), fInputBranchNames(vbnames),
+      : fNSlots(nSlots), fOutputFiles(fNSlots), fOutputTrees(fNSlots), fBranchAddressesNeedReset(fNSlots, 1),
+        fFileName(filename), fDirName(dirname), fTreeName(treename), fOptions(options), fInputBranchNames(vbnames),
         fOutputBranchNames(ReplaceDotWithUnderscore(bnames)), fInputTrees(fNSlots), fBoolArrays(fNSlots),
         fBranches(fNSlots, std::vector<TBranch *>(vbnames.size(), nullptr)),
-        fBranchAddresses(fNSlots, std::vector<void *>(vbnames.size(), nullptr))
+        fBranchAddresses(fNSlots, std::vector<void *>(vbnames.size(), nullptr)), fOutputBranches(fNSlots)
    {
       ValidateSnapshotOutput(fOptions, fTreeName, fFileName);
    }
@@ -1418,15 +1497,8 @@ public:
       if (r) {
          // not an empty-source RDF
          fInputTrees[slot] = r->GetTree();
-         // AddClone guarantees that if the input file changes the branches of the output tree are updated with the new
-         // addresses of the branch values. We need this in case of friend trees with different cluster granularity
-         // than the main tree.
-         // FIXME: AddClone might result in many many (safe) warnings printed by TTree::CopyAddresses, see ROOT-9487.
-         const auto friendsListPtr = fInputTrees[slot]->GetListOfFriends();
-         if (friendsListPtr && friendsListPtr->GetEntries() > 0)
-            fInputTrees[slot]->AddClone(fOutputTrees[slot].get());
       }
-      fIsFirstEvent[slot] = 1; // reset first event flag for this slot
+      fBranchAddressesNeedReset[slot] = 1; // reset first event flag for this slot
    }
 
    void FinalizeTask(unsigned int slot)
@@ -1435,16 +1507,17 @@ public:
          fOutputFiles[slot]->Write();
       // clear now to avoid concurrent destruction of output trees and input tree (which has them listed as fClones)
       fOutputTrees[slot].reset(nullptr);
+      fOutputBranches[slot].Clear();
    }
 
    void Exec(unsigned int slot, ColTypes &... values)
    {
       using ind_t = std::index_sequence_for<ColTypes...>;
-      if (!fIsFirstEvent[slot]) {
+      if (fBranchAddressesNeedReset[slot] == 0) {
          UpdateCArraysPtrs(slot, values..., ind_t{});
       } else {
          SetBranches(slot, values..., ind_t{});
-         fIsFirstEvent[slot] = 0;
+         fBranchAddressesNeedReset[slot] = 0;
       }
       UpdateBoolArrays(slot, values..., ind_t{});
       fOutputTrees[slot]->Fill();
@@ -1475,13 +1548,13 @@ public:
    void SetBranches(unsigned int slot, ColTypes &... values, std::index_sequence<S...> /*dummy*/)
    {
          // hack to call TTree::Branch on all variadic template arguments
-         int expander[] = {
-            (SetBranchesHelper(fBoolArrays[slot], fInputTrees[slot], *fOutputTrees[slot], fInputBranchNames[S],
-                               fOutputBranchNames[S], fBranches[slot][S], fBranchAddresses[slot][S], &values),
-             0)...,
-            0};
-      (void)expander; // avoid unused variable warnings for older compilers such as gcc 4.9
-      (void)slot;     // avoid unused variable warnings in gcc6.2
+         int expander[] = {(SetBranchesHelper(fBoolArrays[slot], fInputTrees[slot], *fOutputTrees[slot],
+                                              fInputBranchNames[S], fOutputBranchNames[S], fBranches[slot][S],
+                                              fBranchAddresses[slot][S], &values, fOutputBranches[slot]),
+                            0)...,
+                           0};
+         (void)expander; // avoid unused variable warnings for older compilers such as gcc 4.9
+         (void)slot;     // avoid unused variable warnings in gcc6.2
    }
 
    template <std::size_t... S>
@@ -1529,6 +1602,12 @@ public:
    }
 
    std::string GetActionName() { return "Snapshot"; }
+
+   std::function<void(unsigned int)> GetDataBlockCallback() final
+   {
+      auto callback = [this](unsigned int slot) mutable { fBranchAddressesNeedReset[slot] = 1; };
+      return {callback};
+   }
 };
 
 template <typename Acc, typename Merge, typename R, typename T, typename U,

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -502,6 +502,7 @@ void CallBuildAction(std::shared_ptr<PrevNodeType> *prevNodeOnHeap, const char *
 
    auto actionPtr =
       BuildAction<ColTypes...>(cols, std::move(*helperArgOnHeap), nSlots, std::move(prevNodePtr), ActionTag{}, *defines);
+   loopManager.AddDataBlockCallback(actionPtr->GetDataBlockCallback());
    jittedActionOnHeap->SetAction(std::move(actionPtr));
 
    // defines points to the columns structure in the heap, created before the jitted call so that the jitter can

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -164,6 +164,8 @@ private:
 
    // this one is always available but has lower precedence thanks to `...`
    void *PartialUpdateImpl(...) { throw std::runtime_error("This action does not support callbacks!"); }
+
+   std::function<void(unsigned int)> GetDataBlockCallback() final { return fHelper.GetDataBlockCallback(); }
 };
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
@@ -80,6 +80,8 @@ public:
       with others of the same type.
    */
    virtual std::unique_ptr<RMergeableValueBase> GetMergeableValue() const = 0;
+
+   virtual std::function<void(unsigned int)> GetDataBlockCallback() = 0;
 };
 } // namespace RDF
 } // namespace Internal

--- a/tree/dataframe/inc/ROOT/RDF/RDataBlockNotifier.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDataBlockNotifier.hxx
@@ -1,0 +1,58 @@
+// Author: Enrico Guiraud, 2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RDATABLOCKNOTIFIER
+#define ROOT_RDF_RDATABLOCKNOTIFIER
+
+#include <ROOT/RMakeUnique.hxx>
+#include <TNotifyLink.h>
+
+#include <memory>
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+struct RDataBlockFlag {
+   bool fFlag = false;
+
+public:
+   void SetFlag() { fFlag = true; }
+   void UnsetFlag() { fFlag = false; }
+   bool CheckFlag() const { return fFlag; }
+   bool Notify()
+   {
+      SetFlag();
+      return true;
+   }
+};
+
+class RDataBlockNotifier {
+   // TNotifyLink and RDataBlockFlags per processing slot
+   std::vector<std::unique_ptr<TNotifyLink<RDataBlockFlag>>> fNotifyLink;
+   std::vector<RDataBlockFlag> fFlags;
+
+public:
+   RDataBlockNotifier(unsigned int nSlots) : fNotifyLink(nSlots), fFlags(nSlots) {}
+   bool CheckFlag(unsigned int slot) const { return fFlags[slot].CheckFlag(); }
+   void SetFlag(unsigned int slot) { fFlags[slot].SetFlag(); }
+   void UnsetFlag(unsigned int slot) { fFlags[slot].UnsetFlag(); }
+   TNotifyLink<RDataBlockFlag> &GetChainNotifyLink(unsigned int slot)
+   {
+      if (fNotifyLink[slot] == nullptr)
+         fNotifyLink[slot] = std::make_unique<TNotifyLink<RDataBlockFlag>>(&fFlags[slot]);
+      return *fNotifyLink[slot];
+   }
+};
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT
+
+#endif // ROOT_RDF_RDATABLOCKNOTIFIER

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2586,6 +2586,7 @@ private:
       auto action =
          RDFInternal::BuildAction<ColTypes...>(validColumnNames, helperArg, nSlots, fProxiedPtr, ActionTag{}, fDefines);
       fLoopManager->Book(action.get());
+      fLoopManager->AddDataBlockCallback(action->GetDataBlockCallback());
       return MakeResultPtr(r, *fLoopManager, std::move(action));
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
@@ -60,6 +60,8 @@ public:
 
    // Helper for RMergeableValue
    std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> GetMergeableValue() const final;
+
+   std::function<void(unsigned int)> GetDataBlockCallback() final;
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -12,6 +12,7 @@
 #define ROOT_RLOOPMANAGER
 
 #include "ROOT/RDF/RNodeBase.hxx"
+#include "ROOT/RDF/RDataBlockNotifier.hxx"
 
 #include <functional>
 #include <map>
@@ -115,6 +116,8 @@ class RLoopManager : public RNodeBase {
    std::map<std::string, std::string> fAliasColumnNameMap; ///< ColumnNameAlias-columnName pairs
    std::vector<TCallback> fCallbacks;                      ///< Registered callbacks
    std::vector<TOneTimeCallback> fCallbacksOnce; ///< Registered callbacks to invoke just once before running the loop
+   std::vector<Callback_t> fDataBlockCallbacks; ///< Registered callbacks to call at the beginning of each "data block"
+   RDFInternal::RDataBlockNotifier fDataBlockNotifier;
    unsigned int fNRuns{0}; ///< Number of event loops run
 
    /// Registry of per-slot value pointers for booked data-source columns
@@ -134,8 +137,9 @@ class RLoopManager : public RNodeBase {
    void InitNodeSlots(TTreeReader *r, unsigned int slot);
    void InitNodes();
    void CleanUpNodes();
-   void CleanUpTask(unsigned int slot);
+   void CleanUpTask(TTreeReader *r, unsigned int slot);
    void EvalChildrenCounts();
+   void SetupDataBlockCallbacks(TTreeReader *r, unsigned int slot);
 
 public:
    RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);
@@ -192,6 +196,8 @@ public:
    std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> GetGraph();
 
    const ColumnNames_t &GetBranchNames();
+
+   void AddDataBlockCallback(std::function<void(unsigned int)> &&callback);
 };
 
 } // ns RDF

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -93,3 +93,9 @@ std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> RJittedAction::GetMergea
    R__ASSERT(fConcreteAction != nullptr);
    return fConcreteAction->GetMergeableValue();
 }
+
+std::function<void(unsigned int)> RJittedAction::GetDataBlockCallback()
+{
+   R__ASSERT(fConcreteAction != nullptr);
+   return fConcreteAction->GetDataBlockCallback();
+}

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -302,7 +302,13 @@ namespace RDF {
 struct RCallCleanUpTask {
    RLoopManager &fLoopManager;
    unsigned int fArg;
-   ~RCallCleanUpTask() { fLoopManager.CleanUpTask(fArg); }
+   TTreeReader *fReader;
+
+   RCallCleanUpTask(RLoopManager &lm, unsigned int arg = 0u, TTreeReader *reader = nullptr)
+      : fLoopManager(lm), fArg(arg), fReader(reader)
+   {
+   }
+   ~RCallCleanUpTask() { fLoopManager.CleanUpTask(fReader, fArg); }
 };
 
 } // namespace RDF
@@ -324,20 +330,21 @@ ColumnNames_t ROOT::Internal::RDF::GetBranchNames(TTree &t, bool allowDuplicates
 RLoopManager::RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches)
    : fTree(std::shared_ptr<TTree>(tree, [](TTree *) {})), fDefaultColumns(defaultBranches),
      fNSlots(RDFInternal::GetNSlots()),
-     fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kROOTFilesMT : ELoopType::kROOTFiles)
+     fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kROOTFilesMT : ELoopType::kROOTFiles),
+     fDataBlockNotifier(fNSlots)
 {
 }
 
 RLoopManager::RLoopManager(ULong64_t nEmptyEntries)
    : fNEmptyEntries(nEmptyEntries), fNSlots(RDFInternal::GetNSlots()),
-     fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kNoFilesMT : ELoopType::kNoFiles)
+     fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kNoFilesMT : ELoopType::kNoFiles), fDataBlockNotifier(fNSlots)
 {
 }
 
 RLoopManager::RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches)
    : fDefaultColumns(defaultBranches), fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kDataSourceMT : ELoopType::kDataSource),
-     fDataSource(std::move(ds))
+     fDataSource(std::move(ds)), fDataBlockNotifier(fNSlots)
 {
    fDataSource->SetNSlots(fNSlots);
 }
@@ -374,7 +381,7 @@ void RLoopManager::RunEmptySourceMT()
    auto genFunction = [this, &slotStack](const std::pair<ULong64_t, ULong64_t> &range) {
       RSlotRAII slotRAII(slotStack);
       auto slot = slotRAII.fSlot;
-      RCallCleanUpTask cleanup{*this, slot};
+      RCallCleanUpTask cleanup(*this, slot);
       InitNodeSlots(nullptr, slot);
       R__LOG_INFO(RDFLogChannel()) << LogRangeProcessing({"an empty source", range.first, range.second, slot});
       try {
@@ -399,7 +406,7 @@ void RLoopManager::RunEmptySource()
 {
    InitNodeSlots(nullptr, 0);
    R__LOG_INFO(RDFLogChannel()) << LogRangeProcessing({"an empty source", 0, fNEmptyEntries, 0u});
-   RCallCleanUpTask cleanup{*this, 0u};
+   RCallCleanUpTask cleanup(*this);
    try {
       for (ULong64_t currEntry = 0; currEntry < fNEmptyEntries && fNStopsReceived < fNChildren; ++currEntry) {
          RunAndCheckFilters(0, currEntry);
@@ -423,7 +430,7 @@ void RLoopManager::RunTreeProcessorMT()
    tp->Process([this, &slotStack, &entryCount](TTreeReader &r) -> void {
       RSlotRAII slotRAII(slotStack);
       auto slot = slotRAII.fSlot;
-      RCallCleanUpTask cleanup{*this, slot};
+      RCallCleanUpTask cleanup(*this, slot, &r);
       InitNodeSlots(&r, slot);
       R__LOG_INFO(RDFLogChannel()) << LogRangeProcessing(TreeDatasetLogInfo(r, slot));
       const auto entryRange = r.GetEntriesRange(); // we trust TTreeProcessorMT to call SetEntriesRange
@@ -448,7 +455,7 @@ void RLoopManager::RunTreeReader()
    TTreeReader r(fTree.get(), fTree->GetEntryList());
    if (0 == fTree->GetEntriesFast())
       return;
-   RCallCleanUpTask cleanup{*this, 0u};
+   RCallCleanUpTask cleanup(*this, 0u, &r);
    InitNodeSlots(&r, 0);
    R__LOG_INFO(RDFLogChannel()) << LogRangeProcessing(TreeDatasetLogInfo(r, 0u));
 
@@ -478,7 +485,7 @@ void RLoopManager::RunDataSource()
    while (!ranges.empty() && fNStopsReceived < fNChildren) {
       InitNodeSlots(nullptr, 0u);
       fDataSource->InitSlot(0u, 0ull);
-      RCallCleanUpTask cleanup{*this, 0u};
+      RCallCleanUpTask cleanup(*this);
       try {
          for (const auto &range : ranges) {
             const auto start = range.first;
@@ -513,7 +520,7 @@ void RLoopManager::RunDataSourceMT()
       RSlotRAII slotRAII(slotStack);
       const auto slot = slotRAII.fSlot;
       InitNodeSlots(nullptr, slot);
-      RCallCleanUpTask cleanup{*this, slot};
+      RCallCleanUpTask cleanup(*this, slot);
       fDataSource->InitSlot(slot, range.first);
       const auto start = range.first;
       const auto end = range.second;
@@ -545,6 +552,14 @@ void RLoopManager::RunDataSourceMT()
 /// Named filters must be called even if the analysis logic would not require it, lest they report confusing results.
 void RLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
 {
+   // data-block callbacks run before the rest of the graph
+   if (fDataBlockNotifier.CheckFlag(slot)) {
+      for (auto &callback : fDataBlockCallbacks) {
+         callback(slot);
+      }
+      fDataBlockNotifier.UnsetFlag(slot);
+   }
+
    for (auto &actionPtr : fBookedActions)
       actionPtr->Run(slot, entry);
    for (auto &namedFilterPtr : fBookedNamedFilters)
@@ -558,12 +573,27 @@ void RLoopManager::RunAndCheckFilters(unsigned int slot, Long64_t entry)
 /// calls their `InitSlot` method, to get them ready for running a task.
 void RLoopManager::InitNodeSlots(TTreeReader *r, unsigned int slot)
 {
+   SetupDataBlockCallbacks(r, slot);
    for (auto &ptr : fBookedActions)
       ptr->InitSlot(r, slot);
    for (auto &ptr : fBookedFilters)
       ptr->InitSlot(r, slot);
    for (auto &callback : fCallbacksOnce)
       callback(slot);
+}
+
+void RLoopManager::SetupDataBlockCallbacks(TTreeReader *r, unsigned int slot) {
+   if (r != nullptr) {
+      // we need to set a notifier so that we run the callbacks every time we switch to a new TTree
+      // `PrependLink` inserts this notifier into the TTree/TChain's linked list of notifiers
+      fDataBlockNotifier.GetChainNotifyLink(slot).PrependLink(*r->GetTree());
+   }
+   // Whatever the data source, initially set the "new data block" flag:
+   // - for TChains, this ensures that we don't skip the first data block because
+   //   the correct tree is already loaded
+   // - for RDataSources and empty sources, which currently don't have data blocks, this
+   //   ensures that we run once per task
+   fDataBlockNotifier.SetFlag(slot);
 }
 
 /// Initialize all nodes of the functional graph before running the event loop.
@@ -603,11 +633,14 @@ void RLoopManager::CleanUpNodes()
 
    fCallbacks.clear();
    fCallbacksOnce.clear();
+   fDataBlockCallbacks.clear();
 }
 
 /// Perform clean-up operations. To be called at the end of each task execution.
-void RLoopManager::CleanUpTask(unsigned int slot)
+void RLoopManager::CleanUpTask(TTreeReader *r, unsigned int slot)
 {
+   if (r != nullptr)
+      fDataBlockNotifier.GetChainNotifyLink(slot).RemoveLink(*r->GetTree());
    for (auto &ptr : fBookedActions)
       ptr->FinalizeSlot(slot);
    for (auto &ptr : fBookedFilters)
@@ -820,4 +853,10 @@ bool RLoopManager::HasDSValuePtrs(const std::string &col) const
 void RLoopManager::AddDSValuePtrs(const std::string &col, const std::vector<void *> ptrs)
 {
    fDSValuePtrMap[col] = ptrs;
+}
+
+void RLoopManager::AddDataBlockCallback(std::function<void(unsigned int)> &&callback)
+{
+   if (callback)
+      fDataBlockCallbacks.emplace_back(std::move(callback));
 }

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -38,6 +38,7 @@ ROOT_ADD_GTEST(dataframe_resptr dataframe_resptr.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_take dataframe_take.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_entrylist dataframe_entrylist.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_merge_results dataframe_merge_results.cxx LIBRARIES ROOTDataFrame)
+ROOT_ADD_GTEST(dataframe_datablockcallback dataframe_datablockcallback.cxx CounterHelper.h LIBRARIES ROOTDataFrame)
 
 if (imt)
    ROOT_ADD_GTEST(dataframe_concurrency dataframe_concurrency.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/CounterHelper.h
+++ b/tree/dataframe/test/CounterHelper.h
@@ -18,7 +18,15 @@ public:
    std::shared_ptr<std::atomic_uint> GetResultPtr() const { return fNCalls; }
    void Initialize() {}
    void InitTask(TTreeReader *, unsigned int) {}
+#ifndef COUNTERHELPER_CALLBACKMODE
    void Exec(unsigned int) { ++(*fNCalls); }
+#else
+   void Exec(unsigned int) {}
+   std::function<void(unsigned int)> GetDataBlockCallback() final
+   {
+      return [this](unsigned int) mutable { ++(*this->fNCalls); };
+   }
+#endif
    void Finalize() {}
 
    std::string GetActionName() { return "ThreadSafeCounter"; }

--- a/tree/dataframe/test/MaxSlotHelper.h
+++ b/tree/dataframe/test/MaxSlotHelper.h
@@ -20,5 +20,5 @@ public:
    void Exec(unsigned int slot, unsigned int /*slot2*/) { fMaxSlots[slot] = std::max(fMaxSlots[slot], slot); }
    void Finalize() { *fMaxSlot = *std::max_element(fMaxSlots.begin(), fMaxSlots.end()); }
 
-   std::string GetActionName() { return "MaxSlot"; }   
+   std::string GetActionName() { return "MaxSlot"; }
 };

--- a/tree/dataframe/test/dataframe_datablockcallback.cxx
+++ b/tree/dataframe/test/dataframe_datablockcallback.cxx
@@ -1,0 +1,97 @@
+#define COUNTERHELPER_CALLBACKMODE
+#include "CounterHelper.h"
+#undef COUNTERHELPER_CALLBACKMODE
+
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RTrivialDS.hxx>
+#include <TROOT.h> // ROOT::EnableImplicitMT
+#include <TFile.h>
+#include <TSystem.h>
+#include <TTree.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm> // std::min
+#include <thread> // std::hardware_concurrency
+
+// fixture for all tests in this file
+struct RDFDataBlockCallback : ::testing::TestWithParam<bool> {
+   unsigned int NSLOTS;
+   unsigned int NENTRIES = std::max(10u, std::thread::hardware_concurrency() * 2);
+
+   RDFDataBlockCallback() : NSLOTS(GetParam() ? std::min(4u, std::thread::hardware_concurrency()) : 1u)
+   {
+      if (GetParam())
+         ROOT::EnableImplicitMT();
+   }
+
+   ~RDFDataBlockCallback()
+   {
+      if (GetParam())
+         ROOT::DisableImplicitMT();
+   }
+};
+
+// A RAII object that ensures existence of nFiles root files named prefix0.root, prefix1.root, ...
+// Each file contains a TTree called "t" with one `int` branch called "x" with sequentially increasing values (0,1,2...)
+struct InputFilesRAII {
+   unsigned int fNFiles = 0;
+   std::string fPrefix;
+
+   InputFilesRAII(unsigned int nFiles, std::string prefix) : fNFiles(nFiles), fPrefix(std::move(prefix))
+   {
+      for (auto i = 0u; i < fNFiles; ++i) {
+         TFile f((fPrefix + std::to_string(i) + ".root").c_str(), "recreate");
+         TTree t("t", "t");
+         t.Branch("x", &i);
+         t.Fill();
+         t.Write();
+      }
+   }
+
+   ~InputFilesRAII()
+   {
+      for (auto i = 0u; i < fNFiles; ++i)
+         gSystem->Unlink((fPrefix + std::to_string(i) + ".root").c_str());
+   }
+};
+
+TEST_P(RDFDataBlockCallback, EmptySource) {
+   ROOT::RDataFrame df(NENTRIES);
+   auto result = df.Book<>(CounterHelper(), {});
+   // RDF with empty sources tries to produce 2 tasks per slot when MT is enabled
+   const auto expected = ROOT::IsImplicitMTEnabled() ? std::min(NENTRIES, df.GetNSlots() * 2u) : 1u;
+   EXPECT_EQ(*result, expected);
+}
+
+TEST_P(RDFDataBlockCallback, DataSource) {
+   auto df = ROOT::RDF::MakeTrivialDataFrame(NENTRIES);
+   auto result = df.Book<>(CounterHelper(), {});
+   // RTrivialDS tries to produce NSLOTS tasks
+   const auto expected = ROOT::IsImplicitMTEnabled() ? std::min(NENTRIES, df.GetNSlots()) : 1u;
+   EXPECT_EQ(*result, expected);
+}
+
+TEST_P(RDFDataBlockCallback, TTree) {
+   const std::string prefix = "rdfdatablockcallback_ttree";
+   InputFilesRAII file(1u, prefix);
+   ROOT::RDataFrame df("t", prefix + "*");
+   auto result = df.Book<>(CounterHelper(), {});
+   EXPECT_EQ(*result, 1u);
+}
+
+TEST_P(RDFDataBlockCallback, TChain) {
+   const std::string prefix = "rdfdatablockcallback_ttree";
+   InputFilesRAII file(5u, prefix);
+   ROOT::RDataFrame df("t", prefix + "*");
+   auto result = df.Book<>(CounterHelper(), {});
+   EXPECT_EQ(*result, 5u);
+}
+
+// instantiate single-thread tests
+INSTANTIATE_TEST_SUITE_P(Seq, RDFDataBlockCallback, ::testing::Values(false));
+
+#ifdef R__USE_IMT
+   // instantiate multi-thread tests
+   INSTANTIATE_TEST_SUITE_P(MT, RDFDataBlockCallback, ::testing::Values(true));
+#endif

--- a/tree/dataframe/test/dataframe_datablockcallback.cxx
+++ b/tree/dataframe/test/dataframe_datablockcallback.cxx
@@ -81,7 +81,7 @@ TEST_P(RDFDataBlockCallback, TTree) {
 }
 
 TEST_P(RDFDataBlockCallback, TChain) {
-   const std::string prefix = "rdfdatablockcallback_ttree";
+   const std::string prefix = "rdfdatablockcallback_tchain";
    InputFilesRAII file(5u, prefix);
    ROOT::RDataFrame df("t", prefix + "*");
    auto result = df.Book<>(CounterHelper(), {});


### PR DESCRIPTION
Instead of TTree::AddClone + TTree::CopyAddresses, use the data-block
callback mechanism to reset addresses when needed.
We cannot trust TTree::CopyAddresses to do the right thing because
the output branch might be a different kind of branch than the input
branch (e.g. TBranch vs TBranchElement), which leads to the problem
described at #8295 .

This fixes #8295 for what regards Snapshot.

This PR also adds support for "data-block" callbacks, wired to `TChain`'s `TNotify` mechanism, to be able to react to changes of the underlying TTree (e.g. by resetting the input address of Snapshot's output branches). This is a pre-requisite for the fix, but it also makes it relatively simple to implement `DefinePerSample` as requested in #6745 .

As a side-effect, since we now don't rely on `TTree::CopyAddresses` in `Snapshot` anymore, this PR should also fix #7727 .