### PR TITLE
[tree] First fix for #8295

### DIFF
--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -39,6 +39,7 @@ class TVirtualArray;
 class TBranchElement : public TBranch {
 
 // Friends
+   friend TTree;
    friend class TTreeCloner;
    friend class TLeafElement;
 


### PR DESCRIPTION
Drawbacks:
- needs TBranchElement to list TTree as a friend
- only covers the case of TBranchElement/TBranch mismatches (the one
  reported in #8295), there might be others
- does not fix other issues with RDF and warnings from CopyAddresses, e.g. #7727

This is an alternative to #8375 that is much more ad-hoc but it fixes the reported problem and should not break other tests, differently from #8375 which introduces an issue in case of clashing branch names.