### PR TITLE
protect fIsRunning from TThread, and fix typo

### DIFF
--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -58,7 +58,7 @@ private:
    Int_t              fArgc;            //Number of com   mand line arguments
    char             **fArgv;            //Command line arguments
    TApplicationImp   *fAppImp;          //!Window system specific application implementation
-   Bool_t             fIsRunning;       //True when in event loop (Run() has been called)
+   std::atomic<bool>  fIsRunning;       //True when in event loop (Run() has been called)
    Bool_t             fReturnFromRun;   //When true return from Run()
    Bool_t             fNoLog;           //Do not process logon and logoff macros
    Bool_t             fNoLogo;          //Do not show splash screen and welcome message
@@ -145,7 +145,7 @@ public:
 
    TApplication   *GetAppRemote() const { return fAppRemote; }
 
-   Bool_t          IsRunning() const;
+   Bool_t          IsRunning() const { return fIsRunning; }
    Bool_t          ReturnFromRun() const { return fReturnFromRun; }
    void            SetReturnFromRun(Bool_t ret) { fReturnFromRun = ret; }
 

--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -145,7 +145,7 @@ public:
 
    TApplication   *GetAppRemote() const { return fAppRemote; }
 
-   Bool_t          IsRunning() const { return fIsRunning; }
+   Bool_t          IsRunning() const;
    Bool_t          ReturnFromRun() const { return fReturnFromRun; }
    void            SetReturnFromRun(Bool_t ret) { fReturnFromRun = ret; }
 

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -245,12 +245,6 @@ TApplication::~TApplication()
    SafeDelete(fAppImp);
 }
 
-Bool_t TApplication::IsRunning() const
-{
-   R__LOCKGUARD(gROOTMutex);
-   return fIsRunning;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Static method. This method should be called from static library
 /// initializers if the library needs the low level graphics system.
@@ -1625,14 +1619,10 @@ void TApplication::Run(Bool_t retrn)
 {
    SetReturnFromRun(retrn);
 
-   gROOTMutex->Lock();
    fIsRunning = kTRUE;
-   gROOTMutex->UnLock();
 
    gSystem->Run();
-   gROOTMutex->Lock();
    fIsRunning = kFALSE;
-   gROOTMutex->UnLock();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -245,6 +245,12 @@ TApplication::~TApplication()
    SafeDelete(fAppImp);
 }
 
+Bool_t TApplication::IsRunning() const
+{
+   R__LOCKGUARD(gROOTMutex);
+   return fIsRunning;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Static method. This method should be called from static library
 /// initializers if the library needs the low level graphics system.
@@ -1619,7 +1625,9 @@ void TApplication::Run(Bool_t retrn)
 {
    SetReturnFromRun(retrn);
 
+   gROOTMutex->Lock();
    fIsRunning = kTRUE;
+   gROOTMutex->UnLock();
 
    gSystem->Run();
    fIsRunning = kFALSE;

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -1630,7 +1630,9 @@ void TApplication::Run(Bool_t retrn)
    gROOTMutex->UnLock();
 
    gSystem->Run();
+   gROOTMutex->Lock();
    fIsRunning = kFALSE;
+   gROOTMutex->UnLock();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -1204,7 +1204,7 @@ TThreadTimer::TThreadTimer(Long_t ms) : TTimer(ms, kTRUE)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Periodically execute the TThread::XAxtion() method in the main thread.
+/// Periodically execute the TThread::XAction() method in the main thread.
 
 Bool_t TThreadTimer::Notify()
 {

--- a/etc/helgrind-root.supp
+++ b/etc/helgrind-root.supp
@@ -41,6 +41,13 @@
    Helgrind:Race
    fun:_ZN11TBufferFile12WriteVersionEPK6TClassb
 }
+{
+   Due to TApplication::fIsRunning which is a std::atomic<bool> ... may hide other problems.
+   Helgrind:Race
+   fun:load
+   fun:_ZNKSt6atomicIbEcvbEv
+   fun:_ZNK12TApplication9IsRunningEv
+}
 
 {
    Due to TClass::fLastReadInfo which is an std::atomic ... may hide other problems.


### PR DESCRIPTION
Addresses one of the issues on https://github.com/root-project/root/issues/8365

Namely, TThread::Printf() causing a data race with TApplication::Run()

```
TApplication::IsRunning() const (TApplication.h:148)
TThread::XARequest(char const*, int, void**, int*) (TThread.cxx:1029)
This conflicts with a previous write of size 1 by thread #1
TApplication::Run(bool) (TApplication.cxx:1622)
```

After this fix, the error disappears from helgrind.