### PR TITLE
[skip-ci] Fix stressGUI and Makefile.win32

### DIFF
--- a/test/Makefile.win32
+++ b/test/Makefile.win32
@@ -47,6 +47,18 @@ ExeSuf        = .exe
 DllSuf        = dll
 OutPutOpt     = -out:
 
+!IF "$(PLATFORM)" == "x86"
+CPU=i386
+DLLENTRY = @12
+MACHINE=IX86
+!endif
+
+!IF "$(PLATFORM)" == "x64"
+CPU=x86_64
+MACHINE=AMD64
+DLLENTRY =
+!ENDIF
+
 # Win32 system with Microsoft Visual C/C++
 
 APPVER        = 5.01
@@ -54,7 +66,6 @@ cc            = cl
 link          = link
 implib        = lib
 lflags        = $(lflags) /INCREMENTAL:NO /NOLOGO
-DLLENTRY      = @12
 conlflags     = $(lflags) -subsystem:console
 guilflags     = $(lflags) -subsystem:windows
 dlllflags     = $(lflags) -entry:_DllMainCRTStartup$(DLLENTRY) -dll
@@ -334,13 +345,13 @@ all:            $(PROGRAMS)
 
 $(EVENTSO):     $(EVENTO)
                 BINDEXPLIB  $* $(EVENTO) > $*.def
-                lib -nologo -MACHINE:IX86 $(EVENTO) -def:$*.def $(OutPutOpt)$(EVENTLIB)
+                lib -nologo -MACHINE:$(MACHINE) $(EVENTO) -def:$*.def $(OutPutOpt)$(EVENTLIB)
                 $(LD) $(SOFLAGS) $(LDFLAGS) $(EVENTO) $*.exp $(LIBS) $(OutPutOpt)$(EVENTSO)
                 @echo "$(EVENTSO) done"
 
 $(EVENTMTSO):   $(EVENTMTO)
                 BINDEXPLIB  $* $(EVENTMTO) > $*.def
-                lib -nologo -MACHINE:IX86 $(EVENTMTO) -def:$*.def $(OutPutOpt)$(EVENTMTLIB)
+                lib -nologo -MACHINE:$(MACHINE) $(EVENTMTO) -def:$*.def $(OutPutOpt)$(EVENTMTLIB)
                 $(LD) $(SOFLAGS) $(LDFLAGS) $(EVENTMTO) $*.exp $(LIBS) $(OutPutOpt)$(EVENTMTSO)
                 @echo "$(EVENTMTSO) done"
 
@@ -511,15 +522,21 @@ $(BENCH):       $(BENCHO) $(TBENCHSO)
 
 Hello:          $(HELLOSO)
 $(HELLOSO):     $(HELLOO)
-                $(LD) $(SOFLAGS) $(LDFLAGS) $(HELLOO) $(GLIBS) $(OutPutOpt)$@
+                BINDEXPLIB  $* $(HELLOO) > $*.def
+                lib -nologo -MACHINE:$(MACHINE) $(HELLOO) -def:$*.def $(OutPutOpt)Hello.lib
+                $(LD) $(SOFLAGS) $(LDFLAGS) $(HELLOO) $*.exp $(GLIBS) $(OutPutOpt)$@
 
 Aclock:         $(ACLOCKSO)
 $(ACLOCKSO):    $(ACLOCKO)
-                $(LD) $(SOFLAGS) $(LDFLAGS) $(ACLOCKO) $(GLIBS) $(OutPutOpt)$@
+                BINDEXPLIB  $* $(ACLOCKO) > $*.def
+                lib -nologo -MACHINE:$(MACHINE) $(ACLOCKO) -def:$*.def $(OutPutOpt)Aclock.lib
+                $(LD) $(SOFLAGS) $(LDFLAGS) $(ACLOCKO) $*.exp $(GLIBS) $(OutPutOpt)$@
 
 Tetris:         $(TETRISSO)
 $(TETRISSO):    $(TETRISO)
-                $(LD) $(SOFLAGS) $(LDFLAGS) $(TETRISO) $(GLIBS) $(OutPutOpt)$@
+                BINDEXPLIB  $* $(TETRISO) > $*.def
+                lib -nologo -MACHINE:$(MACHINE) $(TETRISO) -def:$*.def $(OutPutOpt)Tetris.lib
+                $(LD) $(SOFLAGS) $(LDFLAGS) $(TETRISO) $*.exp $(GLIBS) $(OutPutOpt)$@
 
 $(TBENCHSO):    $(TBENCHO)
                 $(LD) $(SOFLAGS) $(LDFLAGS) $(TBENCHO) $(LIBS) $(OutPutOpt)$@

--- a/test/stressGUI.cxx
+++ b/test/stressGUI.cxx
@@ -2185,7 +2185,7 @@ void testSplitFrame()
    first->GetFirst()->VSplit();
    first->GetSecond()->VSplit();
    first->GetSecond()->GetSecond()->SetEditable();
-   new TGTextEditor("stressGUI.cxx", gClient->GetRoot());
+   new TGTextEditor(Form("%s/test/stressGUI.cxx", gRootSys.Data()), gClient->GetRoot());
    first->GetSecond()->GetSecond()->SetEditable(kFALSE);
    mf->MapSubwindows();
    mf->Resize(600, 400);
@@ -2282,9 +2282,9 @@ void testPaletteEditor()
 
 void testHtmlBrowser()
 {
-   TGHtmlBrowser *b = new TGHtmlBrowser("http://bellenot.web.cern.ch/bellenot/Public/html_test/html_test.html");
+   TGHtmlBrowser *b = new TGHtmlBrowser("https://bellenot.web.cern.ch/public/html_test/html_test.html");
    ProcessFrame((TGMainFrame*)b, "HTML Browser 1");
-   b->Selected("http://bellenot.web.cern.ch/bellenot/Public/html_test/gallery/");
+   b->Selected("https://bellenot.web.cern.ch/public/html_test/gallery/");
    ProcessFrame((TGMainFrame*)b, "HTML Browser 2");
    b->CloseWindow();
 }

--- a/tutorials/gui/Slider3Demo.C
+++ b/tutorials/gui/Slider3Demo.C
@@ -195,15 +195,15 @@ void TTripleSliderDemo::DoText(const char * /*text*/)
 
    switch (id) {
       case HId1:
-         fHslider1->SetPosition(atof(fTbh1->GetString()),
-                                fHslider1->GetMaxPosition());
+         fHslider1->SetPosition((Float_t)atof(fTbh1->GetString()),
+                                (Float_t)fHslider1->GetMaxPosition());
          break;
       case HId2:
-         fHslider1->SetPointerPosition(atof(fTbh2->GetString()));
+         fHslider1->SetPointerPosition((Float_t)atof(fTbh2->GetString()));
          break;
       case HId3:
-         fHslider1->SetPosition(fHslider1->GetMinPosition(),
-                                atof(fTbh1->GetString()));
+         fHslider1->SetPosition((Float_t)fHslider1->GetMinPosition(),
+                                (Float_t)atof(fTbh1->GetString()));
          break;
       default:
          break;


### PR DESCRIPTION
Discovered when running `stressGUI`:
- Fix a couple of PATHs in `stressGUI.cxx`
- Fix the compilation of `Aclock`, `Hello`, and `Tetris` and add support for `Win64` in `test/Makefile.win32`
- Fix the following error with `tutorials/gui/Slider3Demo.C`:
  ```
  tutorials\gui\Slider3Demo.C:198:21: error: call to member function 'SetPosition' is ambiguous
  ```