### PR TITLE
[PyROOT] Remove setting of -mavx in EXTRA_CLING_ARGS

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
+++ b/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
@@ -85,21 +85,7 @@ def set_cling_compile_options(add_defaults = False):
         CURRENT_ARGS = os.environ['EXTRA_CLING_ARGS']
 
     if add_defaults:
-        has_avx = False
-        try:
-            with open('/proc/cpuinfo', 'r') as ci:
-                for line in ci:
-                    if 'avx' in line:
-                        has_avx = True
-                        break
-        except Exception:
-            try:
-                cli_arg = subprocess.check_output(['sysctl', 'machdep.cpu.features'])
-                has_avx = 'avx' in cli_arg.decode("utf-8").strip().lower()
-            except Exception:
-                pass
         CURRENT_ARGS += ' -O2'
-        if has_avx: CURRENT_ARGS += ' -mavx'
         os.putenv('EXTRA_CLING_ARGS', CURRENT_ARGS)
         os.environ['EXTRA_CLING_ARGS'] = CURRENT_ARGS
 


### PR DESCRIPTION
To prevent adding the flag when ROOT is not built with AVX support.

Discussion:
https://root-forum.cern.ch/t/avx-illegal-instruction-in-job-submitted-from-pyroot