### PR TITLE
[DF] Add RDisplay to LinkDef

### DIFF
--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -20,6 +20,7 @@
 #pragma link C++ namespace ROOT::Internal::RDF::GraphDrawing;
 #pragma link C++ namespace ROOT::Detail::RDF;
 #pragma link C++ namespace ROOT::RDF;
+#pragma link C++ class ROOT::RDF::RDisplay-;
 #pragma link C++ class ROOT::Internal::RDF::RActionBase-;
 #pragma link C++ class ROOT::Internal::RDF::RJittedAction-;
 #pragma link C++ class ROOT::Detail::RDF::RFilterBase-;


### PR DESCRIPTION
To help cling autoloading.

Should fix [these failures in Jenkins](https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/2889/LABEL=ROOT-ubuntu18.04,SPEC=nortcxxmod,V=master/testReport/junit/projectroot/runtutorials/tutorial_dataframe_df024_Display/).