### PR TITLE
[ntuple] Provide a common set of performance counters in `RPage{Sink,Source}`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleMetrics.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleMetrics.hxx
@@ -313,7 +313,10 @@ public:
       return ptrCounter;
    }
 
-   /// Searches this object and all the observed sub metrics. Returns nullptr if name is not found.
+   /// Searches counters registered in this object only. Returns nullptr if `name` is not found.
+   const RNTuplePerfCounter *GetLocalCounter(std::string_view name) const;
+   /// Searches this object and all the observed sub metrics. `name` must start with the prefix used
+   /// by this RNTupleMetrics instance. Returns nullptr if `name` is not found.
    const RNTuplePerfCounter *GetCounter(std::string_view name) const;
 
    void ObserveMetrics(RNTupleMetrics &observee);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RPageStorage
 
 #include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RPage.hxx>
@@ -44,7 +45,6 @@ class RNTupleCompressor;
 class RNTupleDecompressor;
 class RPagePool;
 class RFieldBase;
-class RNTupleMetrics;
 
 enum class EPageStorageType {
    kSink,
@@ -128,8 +128,9 @@ public:
    /// of allocating pages.
    virtual void ReleasePage(RPage &page) = 0;
 
-   /// Returns an empty metrics.  Page storage implementations usually have their own metrics.
-   virtual RNTupleMetrics &GetMetrics();
+   /// Page storage implementations have their own metrics. The RPageSink and RPageSource classes provide
+   /// a default set of metrics.
+   virtual RNTupleMetrics &GetMetrics() = 0;
    /// Returns the NTuple name.
    const std::string &GetNTupleName() const { return fNTupleName; }
 
@@ -149,6 +150,19 @@ up to the given entry number are committed.
 // clang-format on
 class RPageSink : public RPageStorage {
 protected:
+   /// Default I/O performance counters that get registered in fMetrics
+   struct RCounters {
+      RNTupleAtomicCounter &fNPageCommitted;
+      RNTupleAtomicCounter &fSzWritePayload;
+      RNTupleAtomicCounter &fSzZip;
+      RNTupleAtomicCounter &fTimeWallWrite;
+      RNTupleAtomicCounter &fTimeWallZip;
+      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuWrite;
+      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuZip;
+   };
+   std::unique_ptr<RCounters> fCounters;
+   RNTupleMetrics fMetrics;
+
    RNTupleWriteOptions fOptions;
 
    /// Helper to zip pages and header/footer; includes a 16MB (kMAXZIPBUF) zip buffer.
@@ -186,6 +200,17 @@ protected:
    static RSealedPage SealPage(const RPage &page, const RColumnElementBase &element,
       int compressionSetting, void *buf);
 
+   /// Enables the default set of metrics provided by RPageSink. `prefix` will be used as the prefix for
+   /// the counters registered in the internal RNTupleMetrics object.
+   /// This set of counters can be extended by a subclass by calling `fMetrics.MakeCounter<...>()`.
+   ///
+   /// A subclass using the default set of metrics is always responsible for updating the counters
+   /// appropriately, e.g. `fCounters->fNPageCommited.Inc()`
+   ///
+   /// Alternatively, a subclass might provide its own RNTupleMetrics object by overriding the
+   /// GetMetrics() member function.
+   void EnableDefaultMetrics(const std::string &prefix);
+
 public:
    RPageSink(std::string_view ntupleName, const RNTupleWriteOptions &options);
 
@@ -222,6 +247,9 @@ public:
    /// Get a new, empty page for the given column that can be filled with up to nElements.  If nElements is zero,
    /// the page sink picks an appropriate size.
    virtual RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) = 0;
+
+   /// Returns the default metrics object.  Subclasses might alternatively provide their own metrics object by overriding this.
+   virtual RNTupleMetrics &GetMetrics() override { return fMetrics; };
 };
 
 // clang-format off
@@ -240,6 +268,30 @@ public:
    using ColumnSet_t = std::unordered_set<DescriptorId_t>;
 
 protected:
+   /// Default I/O performance counters that get registered in fMetrics
+   struct RCounters {
+      RNTupleAtomicCounter &fNReadV;
+      RNTupleAtomicCounter &fNRead;
+      RNTupleAtomicCounter &fSzReadPayload;
+      RNTupleAtomicCounter &fSzReadOverhead;
+      RNTupleAtomicCounter &fSzUnzip;
+      RNTupleAtomicCounter &fNClusterLoaded;
+      RNTupleAtomicCounter &fNPageLoaded;
+      RNTupleAtomicCounter &fNPagePopulated;
+      RNTupleAtomicCounter &fTimeWallRead;
+      RNTupleAtomicCounter &fTimeWallUnzip;
+      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuRead;
+      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuUnzip;
+      RNTupleCalcPerf &fBandwidthReadUncompressed;
+      RNTupleCalcPerf &fBandwidthReadCompressed;
+      RNTupleCalcPerf &fBandwidthUnzip;
+      RNTupleCalcPerf &fFractionReadOverhead;
+      RNTupleCalcPerf &fCompressionRatio;
+   };
+   std::unique_ptr<RCounters> fCounters;
+   /// Wraps the I/O counters and is observed by the RNTupleReader metrics
+   RNTupleMetrics fMetrics;
+
    RNTupleReadOptions fOptions;
    RNTupleDescriptor fDescriptor;
    /// The active columns are implicitly defined by the model fields or views
@@ -260,6 +312,14 @@ protected:
    /// The optimization of directly mapping pages is left to the concrete page source implementations.
    /// Usage of this method requires construction of fDecompressor.
    std::unique_ptr<unsigned char []> UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element);
+
+   /// Enables the default set of metrics provided by RPageSource. `prefix` will be used as the prefix for
+   /// the counters registered in the internal RNTupleMetrics object.
+   /// A subclass using the default set of metrics is responsible for updating the counters
+   /// appropriately, e.g. `fCounters->fNRead.Inc()`
+   /// Alternatively, a subclass might provide its own RNTupleMetrics object by overriding the
+   /// GetMetrics() member function.
+   void EnableDefaultMetrics(const std::string &prefix);
 
 public:
    RPageSource(std::string_view ntupleName, const RNTupleReadOptions &fOptions);
@@ -313,6 +373,9 @@ public:
    /// actual implementation will only run if a task scheduler is set. In practice, a task scheduler is set
    /// if implicit multi-threading is turned on.
    void UnzipCluster(RCluster *cluster);
+
+   /// Returns the default metrics object.  Subclasses might alternatively override the method and provide their own metrics object.
+   virtual RNTupleMetrics &GetMetrics() override { return fMetrics; };
 };
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -17,7 +17,6 @@
 #define ROOT7_RPageStorageDaos
 
 #include <ROOT/RPageStorage.hxx>
-#include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RStringView.hxx>
 
@@ -86,18 +85,6 @@ Currently, an object is allocated for each page + 3 additional objects (anchor/h
 // clang-format on
 class RPageSinkDaos : public RPageSink {
 private:
-   /// I/O performance counters that get registered in fMetrics
-   struct RCounters {
-      RNTupleAtomicCounter &fNPageCommitted;
-      RNTupleAtomicCounter &fSzWritePayload;
-      RNTupleAtomicCounter &fSzZip;
-      RNTupleAtomicCounter &fTimeWallWrite;
-      RNTupleAtomicCounter &fTimeWallZip;
-      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuWrite;
-      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuZip;
-   };
-   std::unique_ptr<RCounters> fCounters;
-   RNTupleMetrics fMetrics;
    std::unique_ptr<RPageAllocatorHeap> fPageAllocator;
 
    /// \brief Underlying DAOS container. An internal `std::shared_ptr` keep the pool connection alive.
@@ -127,8 +114,6 @@ public:
 
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) final;
    void ReleasePage(RPage &page) final;
-
-   RNTupleMetrics &GetMetrics() final { return fMetrics; }
 };
 
 
@@ -155,24 +140,6 @@ public:
 // clang-format on
 class RPageSourceDaos : public RPageSource {
 private:
-   /// I/O performance counters that get registered in fMetrics
-   struct RCounters {
-      RNTupleAtomicCounter &fNReadV;
-      RNTupleAtomicCounter &fNRead;
-      RNTupleAtomicCounter &fSzReadPayload;
-      RNTupleAtomicCounter &fSzUnzip;
-      RNTupleAtomicCounter &fNClusterLoaded;
-      RNTupleAtomicCounter &fNPageLoaded;
-      RNTupleAtomicCounter &fNPagePopulated;
-      RNTupleAtomicCounter &fTimeWallRead;
-      RNTupleAtomicCounter &fTimeWallUnzip;
-      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuRead;
-      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuUnzip;
-   };
-   std::unique_ptr<RCounters> fCounters;
-   /// Wraps the I/O counters and is observed by the RNTupleReader metrics
-   RNTupleMetrics fMetrics;
-
    /// Populated pages might be shared; the memory buffer is managed by the RPageAllocatorDaos
    std::unique_ptr<RPageAllocatorDaos> fPageAllocator;
    // TODO: the page pool should probably be handled by the base class.
@@ -209,8 +176,6 @@ public:
                        RSealedPage &sealedPage) final;
 
    std::unique_ptr<RCluster> LoadCluster(DescriptorId_t clusterId, const ColumnSet_t &columns) final;
-
-   RNTupleMetrics &GetMetrics() final { return fMetrics; }
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -17,7 +17,6 @@
 #define ROOT7_RPageStorageFile
 
 #include <ROOT/RMiniFile.hxx>
-#include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RPageStorage.hxx>
 #include <ROOT/RStringView.hxx>
@@ -55,18 +54,6 @@ The written file can be either in ROOT format or in RNTuple bare format.
 // clang-format on
 class RPageSinkFile : public RPageSink {
 private:
-   /// I/O performance counters that get registered in fMetrics
-   struct RCounters {
-      RNTupleAtomicCounter &fNPageCommitted;
-      RNTupleAtomicCounter &fSzWritePayload;
-      RNTupleAtomicCounter &fSzZip;
-      RNTupleAtomicCounter &fTimeWallWrite;
-      RNTupleAtomicCounter &fTimeWallZip;
-      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuWrite;
-      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuZip;
-   };
-   std::unique_ptr<RCounters> fCounters;
-   RNTupleMetrics fMetrics;
    std::unique_ptr<RPageAllocatorHeap> fPageAllocator;
 
    std::unique_ptr<Internal::RNTupleFileWriter> fWriter;
@@ -100,8 +87,6 @@ public:
 
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) final;
    void ReleasePage(RPage &page) final;
-
-   RNTupleMetrics &GetMetrics() final { return fMetrics; }
 };
 
 
@@ -132,30 +117,6 @@ public:
    static constexpr std::size_t kMaxPageSize = 1024 * 1024;
 
 private:
-   /// I/O performance counters that get registered in fMetrics
-   struct RCounters {
-      RNTupleAtomicCounter &fNReadV;
-      RNTupleAtomicCounter &fNRead;
-      RNTupleAtomicCounter &fSzReadPayload ;
-      RNTupleAtomicCounter &fSzReadOverhead;
-      RNTupleAtomicCounter &fSzUnzip;
-      RNTupleAtomicCounter &fNClusterLoaded;
-      RNTupleAtomicCounter &fNPageLoaded;
-      RNTupleAtomicCounter &fNPagePopulated;
-      RNTupleAtomicCounter &fTimeWallRead;
-      RNTupleAtomicCounter &fTimeWallUnzip;
-      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuRead;
-      RNTupleTickCounter<RNTupleAtomicCounter> &fTimeCpuUnzip;
-      RNTupleCalcPerf &fBandwidthReadUncompressed;
-      RNTupleCalcPerf &fBandwidthReadCompressed;
-      RNTupleCalcPerf &fBandwidthUnzip;
-      RNTupleCalcPerf &fFractionReadOverhead;
-      RNTupleCalcPerf &fCompressionRatio;
-   };
-   std::unique_ptr<RCounters> fCounters;
-   /// Wraps the I/O counters and is observed by the RNTupleReader metrics
-   RNTupleMetrics fMetrics;
-
    /// Populated pages might be shared; there memory buffer is managed by the RPageAllocatorFile
    std::unique_ptr<RPageAllocatorFile> fPageAllocator;
    /// The page pool might, at some point, be used by multiple page sources
@@ -197,8 +158,6 @@ public:
                        RSealedPage &sealedPage) final;
 
    std::unique_ptr<RCluster> LoadCluster(DescriptorId_t clusterId, const ColumnSet_t &columns) final;
-
-   RNTupleMetrics &GetMetrics() final { return fMetrics; }
 };
 
 

--- a/tree/ntuple/v7/src/RNTupleMetrics.cxx
+++ b/tree/ntuple/v7/src/RNTupleMetrics.cxx
@@ -30,11 +30,17 @@ std::string ROOT::Experimental::Detail::RNTuplePerfCounter::ToString() const
 
 bool ROOT::Experimental::Detail::RNTupleMetrics::Contains(const std::string &name) const
 {
+  return GetLocalCounter(name) != nullptr;
+}
+
+const ROOT::Experimental::Detail::RNTuplePerfCounter*
+ROOT::Experimental::Detail::RNTupleMetrics::GetLocalCounter(std::string_view name) const
+{
    for (const auto &c : fCounters) {
       if (c->GetName() == name)
-         return true;
+         return c.get();
    }
-   return false;
+   return nullptr;
 }
 
 const ROOT::Experimental::Detail::RNTuplePerfCounter*
@@ -45,10 +51,8 @@ ROOT::Experimental::Detail::RNTupleMetrics::GetCounter(std::string_view name) co
       return nullptr;
 
    auto innerName = name.substr(prefix.length());
-   for (const auto &c : fCounters) {
-      if (c->GetName() == innerName)
-         return c.get();
-   }
+   if (auto counter = GetLocalCounter(innerName))
+      return counter;
 
    for (auto m : fObservedMetrics) {
       auto counter = m->GetCounter(innerName);

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -108,23 +108,13 @@ ROOT::Experimental::Detail::RDaosNTupleAnchor::Deserialize(const void *buffer)
 ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos(std::string_view ntupleName, std::string_view uri,
    const RNTupleWriteOptions &options)
    : RPageSink(ntupleName, options)
-   , fMetrics("RPageSinkDaos")
    , fPageAllocator(std::make_unique<RPageAllocatorHeap>())
    , fURI(uri)
 {
    R__LOG_WARNING(NTupleLog()) << "The DAOS backend is experimental and still under development. " <<
       "Do not store real data with this version of RNTuple!";
-   fCounters = std::unique_ptr<RCounters>(new RCounters{
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("nPageCommitted", "", "number of pages committed to storage"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("szWritePayload", "B", "volume written for committed pages"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("szZip", "B", "volume before zipping"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("timeWallWrite", "ns", "wall clock time spent writing"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("timeWallZip", "ns", "wall clock time spent compressing"),
-      *fMetrics.MakeCounter<RNTupleTickCounter<RNTupleAtomicCounter>*>("timeCpuWrite", "ns", "CPU time spent writing"),
-      *fMetrics.MakeCounter<RNTupleTickCounter<RNTupleAtomicCounter>*> ("timeCpuZip", "ns",
-                                                                        "CPU time spent compressing")
-   });
    fCompressor = std::make_unique<RNTupleCompressor>();
+   EnableDefaultMetrics("RPageSinkDaos");
 }
 
 
@@ -274,28 +264,13 @@ void ROOT::Experimental::Detail::RPageAllocatorDaos::DeletePage(const RPage& pag
 ROOT::Experimental::Detail::RPageSourceDaos::RPageSourceDaos(std::string_view ntupleName, std::string_view uri,
    const RNTupleReadOptions &options)
    : RPageSource(ntupleName, options)
-   , fMetrics("RPageSourceDaos")
    , fPageAllocator(std::make_unique<RPageAllocatorDaos>())
    , fPagePool(std::make_shared<RPagePool>())
    , fURI(uri)
    , fClusterPool(std::make_unique<RClusterPool>(*this))
 {
    fDecompressor = std::make_unique<RNTupleDecompressor>();
-   fCounters = std::unique_ptr<RCounters>(new RCounters{
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("nReadV", "", "number of vector read requests"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("nRead", "", "number of byte ranges read"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("szReadPayload", "B", "volume read from container"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*> ("szUnzip", "B", "volume after unzipping"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("nClusterLoaded", "",
-                                                   "number of partial clusters preloaded from storage"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*> ("nPageLoaded", "", "number of pages loaded from storage"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*> ("nPagePopulated", "", "number of populated pages"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*>("timeWallRead", "ns", "wall clock time spent reading"),
-      *fMetrics.MakeCounter<RNTupleAtomicCounter*> ("timeWallUnzip", "ns", "wall clock time spent decompressing"),
-      *fMetrics.MakeCounter<RNTupleTickCounter<RNTupleAtomicCounter>*>("timeCpuRead", "ns", "CPU time spent reading"),
-      *fMetrics.MakeCounter<RNTupleTickCounter<RNTupleAtomicCounter>*> ("timeCpuUnzip", "ns",
-                                                                       "CPU time spent decompressing")
-   });
+   EnableDefaultMetrics("RPageSourceDaos");
 
    auto args = ParseDaosURI(uri);
    auto pool = std::make_shared<RDaosPool>(args.fPoolUuid, args.fSvcReplicas);


### PR DESCRIPTION
This pull-request extends `RPageSink` and `RPageSource` to provide a common set of performance counters that can be enabled in a subclass via `EnableDefaultMetrics()`.  Afterward, the set might be extended in a subclass via a call to `fMetrics.MakeCounter<...>()`.

This not only removes boilerplate code from subclasses, but also provides a useful set of regular/computed counters.  A subclass, however, is still responsible for updating the base counters.

Alternatively, subclasses may still ignore the default set of metrics and provide their own `RNTupleMetrics` object by overriding the `GetMetrics()` member function.

Closes issue #8360.