### PR TITLE
[DF] Fix gcc 11 warning (v6.24)

### DIFF
--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -1,4 +1,5 @@
 #include "ROOT/RDataFrame.hxx"
+#include "ROOT/RStringView.hxx"
 #include "ROOT/RTrivialDS.hxx"
 #include "TMemFile.h"
 #include "TSystem.h"
@@ -443,7 +444,7 @@ TEST(RDataFrameInterface, ColumnWithSimpleStruct)
    ROOT::RDataFrame df(t);
    const std::vector<std::string> expected({ "c.a", "a", "c.b", "b", "c" });
    EXPECT_EQ(df.GetColumnNames(), expected);
-   for (const std::string &col : {"c.a", "a"}) {
+   for (std::string_view col : {"c.a", "a"}) {
       EXPECT_DOUBLE_EQ(df.Mean<int>(col).GetValue(), 42.); // compiled
       EXPECT_DOUBLE_EQ(df.Mean(col).GetValue(), 42.); // jitted
    }


### PR DESCRIPTION
../tree/dataframe/test/dataframe_interface.cxx:451:28: warning: loop
variable ‘col’ of type ‘const string&’ {aka ‘const
std::__cxx11::basic_string<char>&’} binds to a temporary constructed
from type ‘const char* const’ [-Wrange-loop-construct]

I decided to backport this one because it's fixing a real use-after-delete bug in a test.