### PR TITLE
[ntuple][doc] Start adding RNTupleReader doc examples

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -271,6 +271,21 @@ public:
    /// field of a collection itself, like GetView<NTupleSize_t>("particle").
    ///
    /// Raises an exception if there is no field with the given name.
+   ///
+   /// **Example: iterate over a field named "pt" of type `float`**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::RNTupleReader;
+   ///
+   /// #include <iostream>
+   ///
+   /// auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
+   /// auto pt = ntuple->GetView<float>("pt");
+   ///
+   /// for (auto i : ntuple->GetEntryRange()) {
+   ///    std::cout << i << ": " << pt(i) << "\n";
+   /// }
+   /// ~~~
    template <typename T>
    RNTupleView<T> GetView(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);
@@ -282,7 +297,9 @@ public:
       return RNTupleView<T>(fieldId, fSource.get());
    }
 
-   /// Raises an exception if there is no field with the given name.
+   /// Raises an exception if:
+   /// * there is no field with the given name or,
+   /// * the field is not a collection
    RNTupleViewCollection GetViewCollection(std::string_view fieldName) {
       auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);
       if (fieldId == kInvalidDescriptorId) {

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -87,6 +87,16 @@ An input ntuple provides data from storage as C++ objects. The ntuple model can 
 or it can be imposed by the user. The latter case allows users to read into a specialized ntuple model that covers
 only a subset of the fields in the ntuple. The ntuple model is used when reading complete entries.
 Individual fields can be read as well by instantiating a tree view.
+
+~~~ {.cpp}
+#include <ROOT/RNTuple.hxx>
+using ROOT::Experimental::RNTupleReader;
+
+#include <iostream>
+
+auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
+std::cout << "myNTuple has " << ntuple->GetNEntries() << " entries\n";
+~~~
 */
 // clang-format on
 class RNTupleReader {
@@ -148,6 +158,20 @@ public:
                                               std::string_view ntupleName,
                                               std::string_view storage,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
+   /// Open an RNTuple for reading.
+   ///
+   /// Throws an RException if there is no RNTuple with the given name.
+   ///
+   /// **Example: open an RNTuple and print the number of entries**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::RNTupleReader;
+   ///
+   /// #include <iostream>
+   ///
+   /// auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
+   /// std::cout << "myNTuple has " << ntuple->GetNEntries() << " entries\n";
+   /// ~~~
    static std::unique_ptr<RNTupleReader> Open(std::string_view ntupleName,
                                               std::string_view storage,
                                               const RNTupleReadOptions &options = RNTupleReadOptions());
@@ -173,6 +197,31 @@ public:
    const RNTupleDescriptor &GetDescriptor() const { return fSource->GetDescriptor(); }
 
    /// Prints a detailed summary of the ntuple, including a list of fields.
+   ///
+   /// **Example: print summary information to stdout**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::ENTupleInfo;
+   /// using ROOT::Experimental::RNTupleReader;
+   ///
+   /// #include <iostream>
+   ///
+   /// auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
+   /// ntuple->PrintInfo();
+   /// // or, equivalently:
+   /// ntuple->PrintInfo(ENTupleInfo::kSummary, std::cout);
+   /// ~~~
+   /// **Example: print detailed column storage data to stderr**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::ENTupleInfo;
+   /// using ROOT::Experimental::RNTupleReader;
+   ///
+   /// #include <iostream>
+   ///
+   /// auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
+   /// ntuple->PrintInfo(ENTupleInfo::kStorageDetails, std::cerr);
+   /// ~~~
    void PrintInfo(const ENTupleInfo what = ENTupleInfo::kSummary, std::ostream &output = std::cout);
 
    /// Shows the values of the i-th entry/row, starting with 0 for the first entry. By default,
@@ -198,6 +247,20 @@ public:
       }
    }
 
+   /// Returns an iterator over the entry indices of the RNTuple.
+   ///
+   /// **Example: iterate over all entries and print each entry in JSON format**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::RNTupleReader;
+   ///
+   /// #include <iostream>
+   ///
+   /// auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
+   /// for (auto i : ntuple->GetEntryRange()) {
+   ///    ntuple->Show(i);
+   /// }
+   /// ~~~
    RNTupleGlobalRange GetEntryRange() { return RNTupleGlobalRange(0, GetNEntries()); }
 
    /// Provides access to an individual field that can contain either a scalar value or a collection, e.g.

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -222,6 +222,8 @@ public:
    /// auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
    /// ntuple->PrintInfo(ENTupleInfo::kStorageDetails, std::cerr);
    /// ~~~
+   ///
+   /// For use of ENTupleInfo::kMetrics, see #EnableMetrics.
    void PrintInfo(const ENTupleInfo what = ENTupleInfo::kSummary, std::ostream &output = std::cout);
 
    /// Shows the values of the i-th entry/row, starting with 0 for the first entry. By default,
@@ -293,6 +295,25 @@ public:
    RIterator begin() { return RIterator(0); }
    RIterator end() { return RIterator(GetNEntries()); }
 
+   /// Enable performance measurements (decompression time, bytes read from storage, etc.)
+   ///
+   /// **Example: inspect the reader metrics after loading every entry**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::ENTupleInfo;
+   /// using ROOT::Experimental::RNTupleReader;
+   ///
+   /// #include <iostream>
+   ///
+   /// auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
+   /// // metrics must be turned on beforehand
+   /// ntuple->EnableMetrics();
+   ///
+   /// for (auto i : ntuple->GetEntryRange()) {
+   ///    ntuple->LoadEntry(i);
+   /// }
+   /// ntuple->PrintInfo(ENTupleInfo::kMetrics);
+   /// ~~~
    void EnableMetrics() { fMetrics.Enable(); }
    const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -254,13 +254,14 @@ public:
    /// **Example: iterate over all entries and print each entry in JSON format**
    /// ~~~ {.cpp}
    /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::ENTupleShowFormat;
    /// using ROOT::Experimental::RNTupleReader;
    ///
    /// #include <iostream>
    ///
    /// auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
    /// for (auto i : ntuple->GetEntryRange()) {
-   ///    ntuple->Show(i);
+   ///    ntuple->Show(i, ENTupleShowFormat::kCompleteJSON);
    /// }
    /// ~~~
    RNTupleGlobalRange GetEntryRange() { return RNTupleGlobalRange(0, GetNEntries()); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -68,6 +68,38 @@ public:
    static std::unique_ptr<RNTupleModel> Create() { return std::make_unique<RNTupleModel>(); }
 
    /// Creates a new field and a corresponding tree value that is managed by a shared pointer.
+   ///
+   /// **Example: create some fields and fill an %RNTuple**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::RNTupleModel;
+   /// using ROOT::Experimental::RNTupleWriter;
+   ///
+   /// #include <vector>
+   ///
+   /// auto model = RNTupleModel::Create();
+   /// auto pt = model->MakeField<float>("pt");
+   /// auto vec = model->MakeField<std::vector<int>>("vec");
+   ///
+   /// // The RNTuple is written to disk when the RNTupleWriter goes out of scope
+   /// {
+   ///    auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", "myFile.root");
+   ///    for (int i = 0; i < 100; i++) {
+   ///       *pt = static_cast<float>(i);
+   ///       *vec = {i, i+1, i+2};
+   ///       ntuple->Fill();
+   ///    }
+   /// }
+   /// ~~~
+   /// **Example: create a field with an initial value**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::RNTupleModel;
+   ///
+   /// auto model = RNTupleModel::Create();
+   /// // pt's initial value is 42.0
+   /// auto pt = model->MakeField<float>("pt", 42.0);
+   /// ~~~
    template <typename T, typename... ArgsT>
    std::shared_ptr<T> MakeField(std::string_view fieldName, ArgsT&&... args) {
       return MakeField<T>({fieldName, ""}, std::forward<ArgsT>(args)...);
@@ -75,6 +107,17 @@ public:
 
    /// Creates a new field given a `{name, description}` pair and a corresponding tree value that
    /// is managed by a shared pointer.
+   ///
+   /// **Example: create a field with a description**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::RNTupleModel;
+   ///
+   /// auto model = RNTupleModel::Create();
+   /// auto hadronFlavour = model->MakeField<float>({
+   ///    "hadronFlavour", "flavour from hadron ghost clustering"
+   /// });
+   /// ~~~
    template <typename T, typename... ArgsT>
    std::shared_ptr<T> MakeField(std::pair<std::string_view, std::string_view> fieldNameDesc,
       ArgsT&&... args)


### PR DESCRIPTION
Adds some `RNTupleReader` usage examples. I think a nice goal is that every method has at least one example. Each example should be self-contained and easily copy-pastable for users to tweak as required.

Doc example structure:
```cpp
~~~ {.cpp}
#include <ROOT/RNTuple.hxx> // all required ROOT headers are included
using ROOT::Experimental::RNTupleReader; // using decls to make the code more readable

#include <iostream> // any other headers

// int main () { implied
auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
std::cout << "myNTuple has " << ntuple->GetNEntries() << " entries\n";
// } implied
~~~
```

To make sure the examples compile and work, I have been writing each in a test repo: https://github.com/mxxo/rntuple-doctests before adding them to the right location.

Rendered examples: 
![image](https://user-images.githubusercontent.com/40000585/121554761-6c31ea80-c9e0-11eb-8540-ab35724d9de3.png)
![image](https://user-images.githubusercontent.com/40000585/121554975-9683a800-c9e0-11eb-8e9a-5320b814bbde.png)
