### PR TITLE
[RF] Add overload of the Slice argument that takes map of categories

### DIFF
--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -78,6 +78,7 @@ RooCmdArg Normalization(Double_t scaleFactor) ;
 RooCmdArg Slice(const RooArgSet& sliceSet) ;
 RooCmdArg Slice(RooArgSet && sliceSet) ;
 RooCmdArg Slice(RooCategory& cat, const char* label) ;
+RooCmdArg Slice(std::map<RooCategory*, std::string> const&) ;
 RooCmdArg Project(const RooArgSet& projSet) ;
 RooCmdArg Project(RooArgSet && projSet) ;
 RooCmdArg ProjWData(const RooAbsData& projData, Bool_t binData=kFALSE) ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1595,10 +1595,13 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 ///
 /// <tr><td> `Slice(RooCategory& cat, const char* label)`        <td> Override default projection behaviour by omitting the specified category
 ///                                    observable from the projection, i.e., by not integrating over all states of this category.
-///                                    The slice is positioned at the given label value. Multiple Slice() commands can be given to specify slices
-///                                    in multiple observables, e.g.
+///                                    The slice is positioned at the given label value. To pass multiple Slice() commands, please use the
+///                                    Slice(std::map<RooCategory*, std::string> const&) argument explained below.
+///
+/// <tr><td> `Slice(std::map<RooCategory*, std::string> const&)`        <td> Omits multiple categories from the projection, as explianed above.
+///                                    Can be used with initializer lists for convenience, e.g.
 /// ```{.cpp}
-///   pdf.plotOn(frame, Slice(tagCategory, "2tag"), Slice(jetCategory, "3jet"));
+///   pdf.plotOn(frame, Slice({{&tagCategory, "2tag"}, {&jetCategory, "3jet"}});
 /// ```
 ///
 /// <tr><td> `Project(const RooArgSet& set)`   <td> Override default projection behaviour by projecting over observables
@@ -1743,6 +1746,10 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   pc.defineInt("scaleType","Normalization",0,Relative) ; 
   pc.defineObject("sliceSet","SliceVars",0) ;
   pc.defineObject("sliceCatList","SliceCat",0,0,kTRUE) ;
+  // This dummy is needed for plotOn to recognize the "SliceCatMany" command.
+  // It is not used directly, but the "SliceCat" commands are nested in it.
+  // Removing this dummy definition results in "ERROR: unrecognized command: SliceCatMany".
+  pc.defineObject("dummy1","SliceCatMany",0) ;
   pc.defineObject("projSet","Project",0) ;
   pc.defineObject("asymCat","Asymmetry",0) ;
   pc.defineDouble("precision","Precision",0,1e-3) ;

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -35,6 +35,32 @@ using namespace std;
 
 namespace RooFit {
 
+  // anonymous namespace for helper functions for the implementation of the global functions
+  namespace {
+
+  template<class T>
+  RooCmdArg processImportItem(std::pair<std::string const, T*> const& item) {
+    return Import(item.first.c_str(), *item.second) ;
+  }
+
+  template<class T>
+  RooCmdArg processLinkItem(std::pair<std::string const, T*> const& item) {
+    return Link(item.first.c_str(), *item.second) ;
+  }
+
+  template<class Map_t, class Func_t>
+  RooCmdArg processMap(const char* name, Func_t func, Map_t const& map) {
+    RooCmdArg container(name,0,0,0,0,0,0,0,0) ;
+    for (auto const& item : map) {
+      container.addArg(func(item)) ;
+    }
+    container.setProcessRecArgs(true,false) ;
+    return container ;
+  }
+
+  } // namespace
+
+
   // RooAbsReal::plotOn arguments
   RooCmdArg DrawOption(const char* opt)            { return RooCmdArg("DrawOption",0,0,0,0,opt,0,0,0) ; }
   RooCmdArg Slice(const RooArgSet& sliceSet)       { return RooCmdArg("SliceVars",0,0,0,0,0,0,&sliceSet,0) ; }
@@ -110,22 +136,10 @@ namespace RooFit {
   RooCmdArg Import(TH1& histo, Bool_t importDensity)      { return RooCmdArg("ImportHisto",importDensity,0,0,0,0,0,&histo,0) ; }
 
   RooCmdArg Import(const std::map<std::string,RooDataHist*>& arg) {
-    RooCmdArg container("ImportDataHistSliceMany",0,0,0,0,0,0,0,0) ; 
-    std::map<std::string,RooDataHist*>::const_iterator iter ;
-    for (iter = arg.begin() ; iter!=arg.end() ; ++iter) {
-      container.addArg(Import(iter->first.c_str(),*(iter->second))) ;
-    }
-    container.setProcessRecArgs(kTRUE,kFALSE) ;
-    return container ;
+    return processMap("ImportDataHistSliceMany", processImportItem<RooDataHist>, arg);
   }
   RooCmdArg Import(const std::map<std::string,TH1*>& arg) {
-    RooCmdArg container("ImportHistoSliceMany",0,0,0,0,0,0,0,0) ; 
-    std::map<std::string,TH1*>::const_iterator iter ;
-    for (iter = arg.begin() ; iter!=arg.end() ; ++iter) {
-      container.addArg(Import(iter->first.c_str(),*(iter->second))) ;
-    }
-    container.setProcessRecArgs(kTRUE,kFALSE) ;
-    return container ;
+    return processMap("ImportHistoSliceMany", processImportItem<TH1>, arg);
   }
 
   
@@ -144,22 +158,10 @@ namespace RooFit {
   RooCmdArg OwnLinked()                                 { return RooCmdArg("OwnLinked",1,0,0,0,0,0,0,0,0,0,0) ; }
 
   RooCmdArg Import(const std::map<std::string,RooDataSet*>& arg) {
-    RooCmdArg container("ImportDataSliceMany",0,0,0,0,0,0,0,0) ; 
-    std::map<std::string,RooDataSet*>::const_iterator iter ;
-    for (iter = arg.begin() ; iter!=arg.end() ; ++iter) {
-      container.addArg(Import(iter->first.c_str(),*(iter->second))) ;
-    }
-    container.setProcessRecArgs(kTRUE,kFALSE) ;
-    return container ;
+    return processMap("ImportDataSliceMany", processImportItem<RooDataSet>, arg);
   }
   RooCmdArg Link(const std::map<std::string,RooAbsData*>& arg) {
-    RooCmdArg container("LinkDataSliceMany",0,0,0,0,0,0,0,0) ; 
-    std::map<std::string,RooAbsData*>::const_iterator iter ;
-    for (iter = arg.begin() ; iter!=arg.end() ; ++iter) {
-      container.addArg(Link(iter->first.c_str(),*(iter->second))) ;
-    }
-    container.setProcessRecArgs(kTRUE,kFALSE) ;
-    return container ;
+    return processMap("LinkDataSliceMany", processLinkItem<RooAbsData>, arg);
   }
  
 

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -48,6 +48,10 @@ namespace RooFit {
     return Link(item.first.c_str(), *item.second) ;
   }
 
+  RooCmdArg processSliceItem(std::pair<RooCategory * const, std::string> const& item) {
+    return Slice(*item.first, item.second.c_str());
+  }
+
   template<class Map_t, class Func_t>
   RooCmdArg processMap(const char* name, Func_t func, Map_t const& map) {
     RooCmdArg container(name,0,0,0,0,0,0,0,0) ;
@@ -66,6 +70,9 @@ namespace RooFit {
   RooCmdArg Slice(const RooArgSet& sliceSet)       { return RooCmdArg("SliceVars",0,0,0,0,0,0,&sliceSet,0) ; }
   RooCmdArg Slice(RooArgSet && sliceSet)           { return Slice(RooCmdArg::take(std::move(sliceSet))); }
   RooCmdArg Slice(RooCategory& cat, const char* label) { return RooCmdArg("SliceCat",0,0,0,0,label,0,&cat,0) ; }
+  RooCmdArg Slice(std::map<RooCategory*, std::string> const& arg) {
+    return processMap("SliceCatMany", processSliceItem, arg);
+  }
 
   RooCmdArg Project(const RooArgSet& projSet)      { return RooCmdArg("Project",0,0,0,0,0,0,&projSet,0) ; }
   RooCmdArg Project(RooArgSet && projSet)          { return Project(RooCmdArg::take(std::move(projSet))); }

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -598,6 +598,10 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
   pc.defineDouble("scaleFactor","Normalization",0,1.0) ;
   pc.defineInt("scaleType","Normalization",0,RooAbsPdf::Relative) ;
   pc.defineObject("sliceCatList","SliceCat",0,0,kTRUE) ;
+  // This dummy is needed for plotOn to recognize the "SliceCatMany" command.
+  // It is not used directly, but the "SliceCat" commands are nested in it.
+  // Removing this dummy definition results in "ERROR: unrecognized command: SliceCatMany".
+  pc.defineObject("dummy1","SliceCatMany",0) ;
   pc.defineObject("projSet","Project",0) ;
   pc.defineObject("sliceSet","SliceVars",0) ;
   pc.defineObject("projDataSet","ProjData",0) ;

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -3968,7 +3968,7 @@ public:
   sample.defineType("control") ;
 
   // Construct combined dataset in (x,sample)
-  RooDataSet combData("combData","combined data",x,Index(sample),Import("physics",*data),Import("control",*data_ctl)) ;
+  RooDataSet combData("combData","combined data",x,Index(sample),Import({{"physics",data}, {"control",data_ctl}})) ;
 
 
 
@@ -5851,20 +5851,20 @@ public:
   RooPlot* frame2 = dt.frame(Title("B decay distribution of mixed events (B0/B0bar)")) ;
 
   data->plotOn(frame2,Cut("mixState==mixState::mixed&&tagFlav==tagFlav::B0")) ;
-  bmix.plotOn(frame2,Slice(tagFlav,"B0"),Slice(mixState,"mixed")) ;
+  bmix.plotOn(frame2,Slice({{&tagFlav,"B0"}, {&mixState,"mixed"}})) ;
 
   data->plotOn(frame2,Cut("mixState==mixState::mixed&&tagFlav==tagFlav::B0bar"),MarkerColor(kCyan)) ;
-  bmix.plotOn(frame2,Slice(tagFlav,"B0bar"),Slice(mixState,"mixed"),LineColor(kCyan),Name("alt")) ;
+  bmix.plotOn(frame2,Slice({{&tagFlav,"B0bar"}, {&mixState,"mixed"}}),LineColor(kCyan),Name("alt")) ;
 
 
   // Plot unmixed slice for B0 and B0bar tagged data separately
   RooPlot* frame3 = dt.frame(Title("B decay distribution of unmixed events (B0/B0bar)")) ;
 
   data->plotOn(frame3,Cut("mixState==mixState::unmixed&&tagFlav==tagFlav::B0")) ;
-  bmix.plotOn(frame3,Slice(tagFlav,"B0"),Slice(mixState,"unmixed")) ;
+  bmix.plotOn(frame3,Slice({{&tagFlav,"B0"}, {&mixState,"unmixed"}})) ;
 
   data->plotOn(frame3,Cut("mixState==mixState::unmixed&&tagFlav==tagFlav::B0bar"),MarkerColor(kCyan)) ;
-  bmix.plotOn(frame3,Slice(tagFlav,"B0bar"),Slice(mixState,"unmixed"),LineColor(kCyan),Name("alt")) ;
+  bmix.plotOn(frame3,Slice({{&tagFlav,"B0bar"}, {&mixState,"unmixed"}}),LineColor(kCyan),Name("alt")) ;
 
 
 

--- a/tutorials/roofit/rf501_simultaneouspdf.C
+++ b/tutorials/roofit/rf501_simultaneouspdf.C
@@ -79,8 +79,8 @@ void rf501_simultaneouspdf()
    sample.defineType("control");
 
    // Construct combined dataset in (x,sample)
-   RooDataSet combData("combData", "combined data", x, Index(sample), Import("physics", *data),
-                       Import("control", *data_ctl));
+   RooDataSet combData("combData", "combined data", x, Index(sample),
+                       Import({{"physics", data}, {"control", data_ctl}}));
 
    // C o n s t r u c t   a   s i m u l t a n e o u s   p d f   i n   ( x , s a m p l e )
    // -----------------------------------------------------------------------------------

--- a/tutorials/roofit/rf708_bphysics.C
+++ b/tutorials/roofit/rf708_bphysics.C
@@ -79,19 +79,19 @@ void rf708_bphysics()
    RooPlot *frame2 = dt.frame(Title("B decay distribution of mixed events (B0/B0bar)"));
 
    data->plotOn(frame2, Cut("mixState==mixState::mixed&&tagFlav==tagFlav::B0"));
-   bmix.plotOn(frame2, Slice(tagFlav, "B0"), Slice(mixState, "mixed"));
+   bmix.plotOn(frame2, Slice({{&tagFlav, "B0"}, {&mixState, "mixed"}}));
 
    data->plotOn(frame2, Cut("mixState==mixState::mixed&&tagFlav==tagFlav::B0bar"), MarkerColor(kCyan));
-   bmix.plotOn(frame2, Slice(tagFlav, "B0bar"), Slice(mixState, "mixed"), LineColor(kCyan));
+   bmix.plotOn(frame2, Slice({{&tagFlav, "B0bar"}, {&mixState, "mixed"}}), LineColor(kCyan));
 
    // Plot unmixed slice for B0 and B0bar tagged data separately
    RooPlot *frame3 = dt.frame(Title("B decay distribution of unmixed events (B0/B0bar)"));
 
    data->plotOn(frame3, Cut("mixState==mixState::unmixed&&tagFlav==tagFlav::B0"));
-   bmix.plotOn(frame3, Slice(tagFlav, "B0"), Slice(mixState, "unmixed"));
+   bmix.plotOn(frame3, Slice({{&tagFlav, "B0"}, {&mixState, "unmixed"}}));
 
    data->plotOn(frame3, Cut("mixState==mixState::unmixed&&tagFlav==tagFlav::B0bar"), MarkerColor(kCyan));
-   bmix.plotOn(frame3, Slice(tagFlav, "B0bar"), Slice(mixState, "unmixed"), LineColor(kCyan));
+   bmix.plotOn(frame3, Slice({{&tagFlav, "B0bar"}, {&mixState, "unmixed"}}), LineColor(kCyan));
 
    // -------------------------------------------------
    // B - D e c a y   w i t h   C P   v i o l a t i o n


### PR DESCRIPTION
Before, if one wanted to slice over mulitple categories in
`RooAbsReal::plotOn`, one had to repeatedly use the Slice command
argument. This is problematic for the keyword pythonizations in pyROOT,
because keyword arguments in python can't be repeated.

With this change, it is also not necessary anymore to repeat any command
arguements in RooFit. This will help to solve Jira issue [ROOT-2784](https://sft.its.cern.ch/jira/browse/ROOT-2784), as
we can just always throw an error (or issue a warning) if a RooCmdArg is repeated.