### PR TITLE
Fix compilation on RHEL/CentOS 7 with gcc 4.8.5

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2746,7 +2746,9 @@ private:
 
    template <typename Helper, typename ActionResultType, typename... Others>
    RResultPtr<ActionResultType>
-   CallCreateActionWithoutColsIfPossible(const std::shared_ptr<ActionResultType> &, Others...)
+   CallCreateActionWithoutColsIfPossible(const std::shared_ptr<ActionResultType> &,
+                                         const std::shared_ptr<Helper>& /*hPtr*/,
+                                         Others...)
    {
       throw std::logic_error(std::string("An action was booked with no input columns, but the action requires "
                                          "columns! The action helper type was ") +


### PR DESCRIPTION
gcc 4.8.5 says the template overload is ambiguous:
```
.../tree/dataframe/inc/ROOT/RDF/RInterface.hxx: In instantiation of 'ROOT::RDF::RResultPtr<typename Helper::Result_t> ROOT::RDF::RInterface<T, V>::Book(Helper&&, const ColumnNames_t&) [with FirstColumn = ROOT::Detail::RDF::RInferredType; OtherColumns = {}; Helper = CounterHelper; Proxied = ROOT::Detail::RDF::RLoopManager; DataSource = void; typename Helper::Result_t = std::__atomic_base<unsigned int>; ROOT::RDF::RInterface<T, V>::ColumnNames_t = std::vector<std::basic_string<char> >]':
.../tree/dataframe/test/dataframe_interface.cxx:765:4:   required from here
.../tree/dataframe/inc/ROOT/RDF/RInterface.hxx:2430:54: error: call of overloaded 'CallCreateActionWithoutColsIfPossible(std::shared_ptr<std::__atomic_base<unsigned int> >&, std::shared_ptr<CounterHelper>&, ROOT::TypeTraits::TypeList<ROOT::Detail::RDF::RInferredType>)' is ambiguous
          return CallCreateActionWithoutColsIfPossible<Helper>(resPtr, hPtr, TTraits::TypeList<FirstColumn>{});
                                                      ^
.../tree/dataframe/inc/ROOT/RDF/RInterface.hxx:2430:54: note: candidates are:
.../tree/dataframe/inc/ROOT/RDF/RInterface.hxx:2738:9: note: decltype ((hPtr->.Exec(0u), ROOT::RDF::RResultPtr<T2>{})) ROOT::RDF::RInterface<T, V>::CallCreateActionWithoutColsIfPossible(const std::shared_ptr<ActionResultType>&, const std::shared_ptr<_Tp1>&, ROOT::TypeTraits::TypeList<ROOT::Detail::RDF::RInferredType>) [with Helper = CounterHelper; ActionResultType = std::__atomic_base<unsigned int>; Proxied = ROOT::Detail::RDF::RLoopManager; DataSource = void; decltype ((hPtr->.Exec(0u), ROOT::RDF::RResultPtr<T2>{})) = ROOT::RDF::RResultPtr<std::__atomic_base<unsigned int> >]
    auto CallCreateActionWithoutColsIfPossible(const std::shared_ptr<ActionResultType> &resPtr,
         ^
.../tree/dataframe/inc/ROOT/RDF/RInterface.hxx:2748:4: note: ROOT::RDF::RResultPtr<T2> ROOT::RDF::RInterface<T, V>::CallCreateActionWithoutColsIfPossible(const std::shared_ptr<ActionResultType>&, Others ...) [with Helper = CounterHelper; ActionResultType = std::__atomic_base<unsigned int>; Others = {std::shared_ptr<CounterHelper>, ROOT::TypeTraits::TypeList<ROOT::Detail::RDF::RInferredType>}; Proxied = ROOT::Detail::RDF::RLoopManager; DataSource = void]
    CallCreateActionWithoutColsIfPossible(const std::shared_ptr<ActionResultType> &, Others...)
    ^
```