### PR TITLE
Change the documentation of TQObject [skip-ci]

### DIFF
--- a/core/base/inc/TQObject.h
+++ b/core/base/inc/TQObject.h
@@ -146,7 +146,7 @@ public:
    /// ~~~
    ///
    /// If we call Emit with an array of the parameters, they should be converted
-   /// to long type.
+   /// to Longptr_t type.
    /// Example:
    /// ~~~ {.cpp}
    ///    TQObject *processor; // data processor
@@ -155,9 +155,9 @@ public:
    ///    processor->Connect("Evaluated(Float_t,Float_t)",
    ///                       "TH1F",hist,"Fill12(Axis_t,Axis_t)");
    ///
-   ///    Long_t args[2];
-   ///    args[0] = (Long_t)processor->GetValue(1);
-   ///    args[1] = (Long_t)processor->GetValue(2);
+   ///    Longptr_t args[2];
+   ///    args[0] = (Longptr_t)processor->GetValue(1);
+   ///    args[1] = (Longptr_t)processor->GetValue(2);
    ///
    ///    processor->Emit("Evaluated(Float_t,Float_t)",args);
    /// ~~~


### PR DESCRIPTION
Following the changes for Win64, adapt the example in the documentation to use the proper `Longptr_t` type. Thanks @Sergey Linev