### PR TITLE
[ntuple,c++20] Add explicit constructor in `RSealedPage`; fixes -std=c++20 compilation error

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -85,6 +85,7 @@ public:
       std::uint32_t fNElements = 0;
 
       RSealedPage() = default;
+      RSealedPage(const void *b, std::uint32_t s, std::uint32_t n) : fBuffer(b), fSize(s), fNElements(n) {}
       RSealedPage(const RSealedPage &other) = delete;
       RSealedPage& operator =(const RSealedPage &other) = delete;
       RSealedPage(RSealedPage &&other) = default;


### PR DESCRIPTION
C++20 does not allow aggregate initialization, i.e. `{ ... }`, if a struct/class
has explicitly defaulted or deleted constructors.  This fixes the following
compilation error:

```
cannot convert ‘<brace-enclosed initializer list>’ to ‘const ROOT::Experimental::Detail::RPageStorage::RSealedPage&’
  411 |       pageBuffer = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element);
      |                    ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```