### PR TITLE
Add namespace to LinkDef

### DIFF
--- a/hist/histv7/inc/LinkDef.h
+++ b/hist/histv7/inc/LinkDef.h
@@ -54,4 +54,6 @@
 #pragma link C++ class tuple<ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisEquidistant,ROOT::Experimental::RAxisIrregular>+;
 #pragma link C++ class tuple<ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisEquidistant>+;
 #pragma link C++ class tuple<ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisIrregular,ROOT::Experimental::RAxisIrregular>+;
+
+#pragma link C++ namespace ROOT::Experimental;
 #endif


### PR DESCRIPTION
This addresses test failures like:
```
 998/1157 Test  #997: tutorial-v7-draw_mt.cxx .............................................***Failed    8.47 sec
Processing /builddir/build/BUILD/root-6.25.01/tutorials/v7/draw_mt.cxx...
IncrementalExecutor::executeFunction: symbol '_ZN4ROOT12Experimental7HistLogEv' unresolved while linking [cling interface function]!
You are probably missing the definition of ROOT::Experimental::HistLog()
Maybe you need to load the corresponding shared library?
CMake Error at /builddir/build/BUILD/root-6.25.01/x86_64-redhat-linux-gnu/RootTestDriver.cmake:237 (message):
  error code: 1

1007/1157 Test #1007: tutorial-v7-draw_subpads.cxx ........................................***Failed    6.81 sec
Processing /builddir/build/BUILD/root-6.25.01/tutorials/v7/draw_subpads.cxx...
IncrementalExecutor::executeFunction: symbol '_ZN4ROOT12Experimental7HistLogEv' unresolved while linking [cling interface function]!
You are probably missing the definition of ROOT::Experimental::HistLog()
Maybe you need to load the corresponding shared library?
CMake Error at /builddir/build/BUILD/root-6.25.01/x86_64-redhat-linux-gnu/RootTestDriver.cmake:237 (message):
  error code: 1

1017/1157 Test #1005: tutorial-v7-draw_rh3.cxx ............................................***Failed   28.52 sec
Processing /builddir/build/BUILD/root-6.25.01/tutorials/v7/draw_rh3.cxx...
IncrementalExecutor::executeFunction: symbol '_ZN4ROOT12Experimental7HistLogEv' unresolved while linking [cling interface function]!
You are probably missing the definition of ROOT::Experimental::HistLog()
Maybe you need to load the corresponding shared library?
CMake Error at /builddir/build/BUILD/root-6.25.01/x86_64-redhat-linux-gnu/RootTestDriver.cmake:237 (message):
  error code: 1
```
