### PR TITLE
[webgui] use less chrome processes when running headless

### DIFF
--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -380,8 +380,8 @@ RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserCreator(true)
    fHeadlessExec = gEnv->GetValue("WebGui.ChromeHeadless", "$prog --headless --disable-gpu $geometry $url &");
    fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --app=$url &"); // & in windows mean usage of spawn
 #else
-   fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "$prog --headless --incognito $geometry $url");
-   fHeadlessExec = gEnv->GetValue("WebGui.ChromeHeadless", "fork: --headless --incognito $geometry $url");
+   fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "$prog --headless --incognito --no-sandbox --no-zygote --disable-extensions $geometry $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.ChromeHeadless", "fork: --headless --incognito --no-sandbox --no-zygote --disable-extensions $geometry $url");
    fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --incognito --app=\'$url\' &");
 #endif
 }

--- a/gui/webdisplay/test/CMakeLists.txt
+++ b/gui/webdisplay/test/CMakeLists.txt
@@ -12,6 +12,7 @@
 # test only can be run if Firefox or Chrome are detected on the system
 if (CHROME_EXECUTABLE OR FIREFOX_EXECUTABLE)
   ROOT_ADD_TEST(test-webgui-ping
+                RUN_SERIAL
                 COPY_TO_BUILDDIR ${CMAKE_SOURCE_DIR}/tutorials/webgui/ping/ping.cxx ${CMAKE_SOURCE_DIR}/tutorials/webgui/ping/ping.html
                 COMMAND root.exe -b -q -l ping.cxx
                 PASSREGEX "PING-PONG TEST COMPLETED")

--- a/tutorials/webgui/ping/ping.cxx
+++ b/tutorials/webgui/ping/ping.cxx
@@ -11,6 +11,7 @@
 
 #include <ROOT/RWebWindow.hxx>
 #include <iostream>
+#include <chrono>
 
 std::shared_ptr<ROOT::Experimental::RWebWindow> window;
 
@@ -143,10 +144,16 @@ void ping(int nclients = 1, int test_mode = 0)
    if (batch_mode) {
       const int run_limit = 200;
       const double run_time = 50.;
+      auto t1 = std::chrono::high_resolution_clock::now();
       window->WaitFor([=](double tm) { return (current_counter >= run_limit) || (tm > run_time) ? 1 : 0; });
+      auto t2 = std::chrono::high_resolution_clock::now();
+      auto ms_int = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
+
       if (current_counter >= run_limit)
-         std::cout << "PING-PONG TEST COMPLETED" << std::endl;
+         std::cout << "PING-PONG TEST COMPLETED";
       else
-         std::cout << "PING-PONG TEST FAIL" << std::endl;
+         std::cout << "PING-PONG TEST FAIL cnt:" << current_counter;
+
+      std::cout << " runs:" << ms_int.count() << "ms" << std::endl;
    }
 }


### PR DESCRIPTION
Do not allow to start sandbox or zygote processes, disable extensions.
Reduce from 9 to 4 number of required processes with chromium 90

May help to solve sporadic errors with `webgui_ping` test on ` pcepsft11`