### PR TITLE
[RF] Warning message on repeated named RooCmdArgs in RooCmdConfig

### DIFF
--- a/roofit/roofitcore/inc/RooCmdConfig.h
+++ b/roofit/roofitcore/inc/RooCmdConfig.h
@@ -25,6 +25,7 @@
 #include <TString.h>
 
 #include <string>
+#include <unordered_map>
 
 class RooArgSet;
 
@@ -58,7 +59,7 @@ public:
   bool defineObject(const char* name, const char* argName, Int_t setNum, const TObject* obj=nullptr, bool isArray=false) ;
   bool defineSet(const char* name, const char* argName, Int_t setNum, const RooArgSet* set=nullptr) ;
 
-  bool process(const RooCmdArg& arg) ;
+  bool process(const RooCmdArg& arg, bool warnAboutDuplicates=true) ;
   template<class... Args_t>
   bool process(const RooCmdArg& arg, Args_t && ...args);
   bool process(const RooLinkedList& argList) ;
@@ -102,7 +103,7 @@ public:
   static double decodeDoubleOnTheFly(const char* callerID, const char* cmdArgName, int idx, double defVal,
       std::initializer_list<std::reference_wrapper<const RooCmdArg>> args);
 
-protected:
+private:
 
   template<class T>
   struct Var {
@@ -130,6 +131,8 @@ protected:
   TList _mList ; ///< Mutex cmd list
   TList _yList ; ///< Dependency cmd list
   TList _pList ; ///< Processed cmd list
+
+  std::unordered_map<std::string, int> _processedCmdArgNames; ///<!
 
   ClassDefOverride(RooCmdConfig,0) // Configurable parse of RooCmdArg objects
 };

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2968,9 +2968,11 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
   }
   frame->updateNormVars(*frame->getPlotVar()) ;
 
-  // Append overriding scale factor command at end of original command list
   RooCmdArg tmp = RooFit::Normalization(scaleFactor,Raw) ;
-  tmp.setInt(1,1) ; // Flag this normalization command as created for internal use (so that VisualizeError can strip it)
+  // flag this normalization command as created for internal information
+  // transfer between RooAbsPdf::plotOn and RooAbsReal::plotOn
+  // (must be ignored by RooAbsReal::VisualizeError)
+  tmp.SetName("_Normalization");
   cmdList.Add(&tmp) ;
 
   // Was a component selected requested

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1709,6 +1709,11 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   pc.defineString("sliceCatState","SliceCat",0,"",true) ;
   pc.defineDouble("scaleFactor","Normalization",0,1.0) ;
   pc.defineInt("scaleType","Normalization",0,Relative) ;
+
+  // for internal use only
+  pc.defineDouble("_scaleFactor","_Normalization",0,1.0) ;
+  pc.defineInt("_scaleType","_Normalization",0,Relative) ;
+
   pc.defineSet("sliceSet","SliceVars",0) ;
   pc.defineObject("sliceCatList","SliceCat",0,0,true) ;
   // This dummy is needed for plotOn to recognize the "SliceCatMany" command.
@@ -1781,8 +1786,9 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   o.numee       = pc.getInt("numee") ;
   o.drawOptions = drawOpt.Data();
   o.curveNameSuffix = pc.getString("curveNameSuffix") ;
-  o.scaleFactor = pc.getDouble("scaleFactor") ;
-  o.stype = (ScaleType) pc.getInt("scaleType")  ;
+  bool hasInternalNormalization = argList.FindObject("_Normalization");
+  o.scaleFactor = pc.getDouble(hasInternalNormalization ? "_scaleFactor" : "scaleFactor");
+  o.stype = (ScaleType)(pc.getInt(hasInternalNormalization ? "_scaleType" : "scaleType"));
   o.projData = (const RooAbsData*) pc.getObject("projData") ;
   o.binProjData = pc.getInt("binProjData") ;
   o.projDataSet = pc.getSet("projDataSet");
@@ -2741,12 +2747,7 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
   // Strip any 'internal normalization' arguments from std::list
   RooLinkedList plotArgList ;
   for (auto * cmd : static_range_cast<RooCmdArg*>(plotArgListTmp)) {
-    if (std::string("Normalization")==cmd->GetName()) {
-      if (((RooCmdArg*)cmd)->getInt(1)!=0) {
-      } else {
-   plotArgList.Add(cmd) ;
-      }
-    } else {
+    if (std::string("_Normalization") != cmd->GetName()) {
       plotArgList.Add(cmd) ;
     }
   }

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -592,6 +592,15 @@ void RooMCStudy::resetFitParams()
 }
 
 
+namespace {
+
+void overwriteCmdArg(RooLinkedList& cmdList, RooCmdArg& cmd) {
+  if(auto found = cmdList.FindObject(cmd.GetName())) cmdList.Remove(found);
+  cmdList.Add(&cmd);
+}
+
+} // namespace
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Internal function. Performs actual fit according to specifications
@@ -615,11 +624,11 @@ RooFitResult* RooMCStudy::doFit(RooAbsData* genSample)
   RooCmdArg plevel = RooFit::PrintLevel(_silence ? -1 : 1) ;
 
   RooLinkedList fitOptList(_fitOptList) ;
-  fitOptList.Add(&save) ;
+  overwriteCmdArg(fitOptList, save) ;
   if (!_projDeps.empty()) {
-    fitOptList.Add(&condo) ;
+    overwriteCmdArg(fitOptList, condo) ;
   }
-  fitOptList.Add(&plevel) ;
+  overwriteCmdArg(fitOptList, plevel) ;
   RooFitResult* fr = _fitModel->fitTo(*data,fitOptList) ;
 
   return fr ;

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -554,6 +554,14 @@ double RooSimultaneous::analyticalIntegralWN(Int_t code, const RooArgSet* normSe
 
 
 
+namespace {
+
+void overwriteCmdArg(RooLinkedList& cmdList, RooCmdArg& cmd) {
+  if(auto found = cmdList.FindObject(cmd.GetName())) cmdList.Remove(found);
+  cmdList.Add(&cmd);
+}
+
+} // namespace
 
 
 
@@ -763,9 +771,9 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
     // WVE -- do not adjust normalization for asymmetry plots
     RooLinkedList cmdList2(cmdList) ;
     if (!cmdList.find("Asymmetry")) {
-      cmdList2.Add(&tmp1) ;
+      overwriteCmdArg(cmdList2, tmp1);
     }
-    cmdList2.Add(&tmp2) ;
+    overwriteCmdArg(cmdList2, tmp2);
 
     // Plot single component
     RooPlot* retFrame = getPdf(idxCatClone->getCurrentLabel())->plotOn(frame,cmdList2);
@@ -880,15 +888,15 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
   RooCmdArg tmp2 = RooFit::ProjWData(*projDataSet,*projDataTmp) ;
   // WVE -- do not adjust normalization for asymmetry plots
   if (!cmdList.find("Asymmetry")) {
-    cmdList2.Add(&tmp1) ;
+    overwriteCmdArg(cmdList2, tmp1);
   }
-  cmdList2.Add(&tmp2) ;
+  overwriteCmdArg(cmdList2, tmp2);
 
   RooPlot* frame2 ;
   if (!projSetTmp.empty()) {
     // Plot temporary function
     RooCmdArg tmp3 = RooFit::Project(projSetTmp) ;
-    cmdList2.Add(&tmp3) ;
+    overwriteCmdArg(cmdList2, tmp3);
     frame2 = plotVar.plotOn(frame,cmdList2) ;
   } else {
     // Plot temporary function

--- a/tutorials/roofit/rf401_importttreethx.C
+++ b/tutorials/roofit/rf401_importttreethx.C
@@ -46,17 +46,9 @@ void rf401_importttreethx()
    RooCategory c("c", "c", {{"SampleA",0}, {"SampleB",1}, {"SampleC",2}});
 
    // Create a binned dataset that imports contents of all TH1 mapped by index category c
-   RooDataHist *dh = new RooDataHist("dh", "dh", x, Index(c), Import("SampleA", *hh_1), Import("SampleB", *hh_2),
-                                     Import("SampleC", *hh_3));
+   RooDataHist *dh = new RooDataHist("dh", "dh", x, Index(c),
+                                     Import({{"SampleA", hh_1}, {"SampleB", hh_2}, {"SampleC", hh_3}}));
    dh->Print();
-
-   // Alternative constructor form for importing multiple histograms
-   std::map<std::string, TH1 *> hmap;
-   hmap["SampleA"] = hh_1;
-   hmap["SampleB"] = hh_2;
-   hmap["SampleC"] = hh_3;
-   RooDataHist *dh2 = new RooDataHist("dh", "dh", x, c, hmap);
-   dh2->Print();
 
    // I m p o r t i n g   a   T T r e e   i n t o   a   R o o D a t a S e t   w i t h   c u t s
    // -----------------------------------------------------------------------------------------
@@ -102,8 +94,8 @@ void rf401_importttreethx()
    RooDataSet *dsC = (RooDataSet *)ds2.reduce(RooArgSet(x, y), "z>5");
 
    // Create a dataset that imports contents of all the above datasets mapped by index category c
-   RooDataSet *dsABC = new RooDataSet("dsABC", "dsABC", RooArgSet(x, y), Index(c), Import("SampleA", *dsA),
-                                      Import("SampleB", *dsB), Import("SampleC", *dsC));
+   RooDataSet *dsABC = new RooDataSet("dsABC", "dsABC", RooArgSet(x, y), Index(c),
+                                      Import({{"SampleA", dsA}, {"SampleB", dsB}, {"SampleC", dsC}}));
 
    dsABC->Print();
 }


### PR DESCRIPTION
### More detailed description of main commit (1st commit)

This commit addresses Jira issue [ROOT-2784](https://sft.its.cern.ch/jira/browse/ROOT-2784) (from 2010, oldest open RooFit "bug"!).

Emit warning message in RooCmdConfig when multiple named arguments of
the same type are encountered, for which no chaining behavior is
defined.

To make the warning message more clear, a map is implemeted to look up
the name of the function in the `RooFit` namespace that is used to
create the repeated RooCmdArg. Usually, the names of the argument and
the name of the function that created it are identical, but there are
exceptions that are hardcoded in this map.

Furthermore, a warning message is also emitted for the commands that
have a defined chaining behavior (`Import`, `Link`, and `Slice`), where
the alternatives that take a `std::map` with the multiple commands is
suggested. This is done to encourage RooFit code that can be easily
ported to Python if desired, because chainig command arguments with the
same name is not possible in Python RooFit (commands are passed as
keyword arguments, which can't be repeated).

Having such a warning message also helps users that try to chain more
commands than `RooAbsReal::plotOn` can digest. They will get the
solution in the warning message instead of having to ask in the forum,
which happend for example in [this forum post](https://root-forum.cern.ch/t/simultaneous-fit-with-8-pdfs-using-roosimultaneous-and-roodataset/45331).

### Quick description of other commits

* commit 1:
  * main commit explianed above
* commit 2 - 4:
  * update RooFit code to not trigger the warnings
* commit 5:
  * update RooFit C tutorial files to not trigger the warnings
  * Python tutorials can only be updated after pythonizations for `Import`, `Link`, and `Slice`