### PR TITLE
Extend io customization support: whole obj rule in split obj.

### DIFF
--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4197,6 +4197,7 @@ void TStreamerInfoActions::TActionSequence::AddToOffset(Int_t delta)
        iter != end;
        ++iter)
    {
+      // (fElemId == -1) indications that the action is a Push or Pop DataCache.
       if (iter->fConfiguration->fElemId != (UInt_t)-1 &&
           !iter->fConfiguration->fInfo->GetElements()->At(iter->fConfiguration->fElemId)->TestBit(TStreamerElement::kCache))
          iter->fConfiguration->AddToOffset(delta);

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -103,9 +103,9 @@ namespace TStreamerInfoActions
       aElement->GetSequenceType(sequenceType);
 
       printf("StreamerInfoAction, class:%s, name=%s, fType[%d]=%d,"
-             " %s, offset=%d (%s)\n",
+             " %s, offset=%d (%s), elemnId=%d \n",
              info->GetClass()->GetName(), aElement->GetName(), fElemId, fCompInfo->fType,
-             aElement->ClassName(), fOffset, sequenceType.Data());
+             aElement->ClassName(), fOffset, sequenceType.Data(), fElemId);
    }
 
    void TConfiguration::PrintDebug(TBuffer &buf, void *addr) const
@@ -4197,7 +4197,8 @@ void TStreamerInfoActions::TActionSequence::AddToOffset(Int_t delta)
        iter != end;
        ++iter)
    {
-      if (!iter->fConfiguration->fInfo->GetElements()->At(iter->fConfiguration->fElemId)->TestBit(TStreamerElement::kCache))
+      if (iter->fConfiguration->fElemId != (UInt_t)-1 &&
+          !iter->fConfiguration->fInfo->GetElements()->At(iter->fConfiguration->fElemId)->TestBit(TStreamerElement::kCache))
          iter->fConfiguration->AddToOffset(delta);
    }
 }

--- a/tree/tree/inc/TLeafElement.h
+++ b/tree/tree/inc/TLeafElement.h
@@ -50,6 +50,7 @@ public:
    virtual Int_t   *GenerateOffsetArrayBase(Int_t /*base*/, Int_t /*events*/) { return nullptr; }
    virtual DeserializeType GetDeserializeType() const;
 
+           Int_t    GetID() const { return fID; }
    virtual TString  GetFullName() const;
    virtual Int_t    GetLen() const {return ((TBranchElement*)fBranch)->GetNdata()*fLen;}
    TMethodCall     *GetMethodCall(const char *name);

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -3608,7 +3608,8 @@ void TBranchElement::InitializeOffsets()
             // to remove it's name to get the correct real data offsets
             ////////////////////////////////////////////////////////////////////
 
-            if( dynamic_cast<TBranchSTL*>(fParent) && stlParentName.Length() )
+            const bool isToplevelCollection = (this == GetMother() && (fType == 3 || fType == 4));
+            if( stlParentName.Length() && (dynamic_cast<TBranchSTL*>(fParent) || isToplevelCollection))
             {
                if( !strncmp( stlParentName.Data(), dataName.Data(), stlParentName.Length()-1 )
                   && dataName[ stlParentName.Length() ] == '.' )

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2241,7 +2241,7 @@ void TBranchElement::InitInfo()
                if (parent && parent->fOnfileObject == nullptr)
                   parent->fOnfileObject = fOnfileObject;
             }
-            // Propage this to all the other branch of this type.
+            // Propagate this to all the other branch belonging to the same object.
             TObjArray *branches = toplevel ? GetListOfBranches() : GetMother()->GetSubBranch(this)->GetListOfBranches();
             Int_t nbranches = branches->GetEntriesFast();
             TBranchElement *lastbranch = this;
@@ -2289,8 +2289,23 @@ void TBranchElement::InitInfo()
                      }
                   }
                }
+            } else {
+               // Case of a top level branch or 'empty node' (object marker for split sub-object)
+               TString fullname( GetFullName() );
+               Ssiz_t lastdot = fullname.Last('.');
+               if (lastdot != TString::kNPOS) {
+                  TString &thisprefix = fullname.Remove(lastdot + 1);  // Mod fullname and 'rename' the variable.
+                  for(Int_t i = 0; i < nbranches; ++i) {
+                     TBranchElement* subbranch = (TBranchElement*)branches->At(i);
+                     TString subbranch_name(subbranch->GetFullName());
+                     if ( ! subbranch_name.BeginsWith(thisprefix)) {
+                        lastindex = i - 1;
+                        break;
+                     }
+                  }
+               }
             }
-            for (Int_t i = firstindex; i < nbranches; ++i) {
+            for (Int_t i = firstindex; i <= lastindex; ++i) {
                TBranchElement* subbranch = (TBranchElement*)branches->At(i);
                Bool_t match = kFALSE;
                if (this != subbranch) {
@@ -2314,11 +2329,6 @@ void TBranchElement::InitInfo()
                   }
                }
                if (match) {
-                  TLeafElement *subleaf = dynamic_cast<TLeafElement*>(subbranch->GetListOfLeaves()->At(0));
-                  auto branchid = subleaf ? subleaf->GetID() : subbranch->GetID();
-                  if (i != firstindex && branchid <= firstid) {
-                     break;
-                  }
                   if (subbranch->fOnfileObject && subbranch->fOnfileObject != fOnfileObject) {
                      if (seenExisting) {
                         Error("SetOnfileObject (lambda)", "2 distincts fOnfileObject are in the hierarchy of %s for type %s",

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2059,7 +2059,6 @@ static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoAct
          auto search = be ? be->GetListOfBranches() : &branches;
          TVirtualArray *onfileObject = nullptr;
 
-         // Note: This is duplicated, please move.
          TString subprefix;
          if (prefix.Length() && nextel->IsA() == TStreamerBase::Class()) {
             // We skip the name of the base class if there is already a prefix.
@@ -2072,10 +2071,8 @@ static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoAct
          for (Int_t bi = 0; bi < nbranches; ++bi) {
             TBranchElement* subbe = (TBranchElement*)search->At(bi);
             if (elementClass == subbe->GetInfo()->GetClass() // Use GetInfo to provoke its creation.
-               && subbe->GetOnfileObject())
-            if (elementClass == subbe->GetInfo()->GetClass() // Use GetInfo to provoke its creation.
                && subbe->GetOnfileObject()
-               && strncmp(subbe->GetName(), subprefix.Data(), subprefix.Length()) == 0)
+               && strncmp(subbe->GetFullName(), subprefix.Data(), subprefix.Length()) == 0)
             {
                nextinfo = subbe->GetInfo();
                onfileObject = subbe->GetOnfileObject();
@@ -2260,25 +2257,37 @@ void TBranchElement::InitInfo()
             // First find the first branch of corresponding to the same class as 'this'
             // branch
             Int_t index = branches->IndexOf(this);
-            Int_t firstindex = -1;
-            TLeafElement *leaf = dynamic_cast<TLeafElement*>(this->GetListOfLeaves()->At(0));
-            auto currentid = leaf ? leaf->GetID() : GetID();
-            Int_t firstid = currentid;
+            Int_t firstindex = 0;
+            Int_t lastindex = nbranches - 1;
             if (index >= 0) {
-               firstindex = index;
-               for(Int_t i = index - 1; i >= 0; --i) {
-                  TBranchElement* subbranch = (TBranchElement*)branches->At(i);
+               TString fullname( GetFullName() );
+               Ssiz_t lastdot = fullname.Last('.');
+               if (lastdot == TString::kNPOS) {
+                  // No prefix or index, thus this is a first level branch
+                  TBranchElement* subbranch = (TBranchElement*)branches->At(0);
                   if (!subbranch->fInfo)
                      subbranch->SetupInfo();
-                  TLeafElement *subleaf = dynamic_cast<TLeafElement*>(subbranch->GetListOfLeaves()->At(0));
-                  auto branchid = subleaf ? subleaf->GetID() : subbranch->GetID();
-                  if (subbranch->fInfo == info && branchid >= currentid) {
-                     // We moved to another data member (of the enclosing class) of the same
-                     // type
-                     break;
+               } else {
+                  TString &thisprefix = fullname.Remove(lastdot + 1);  // Mod fullname and 'rename' the variable.
+                  for(Int_t i = index - 1; i >= 0; --i) {
+                     TBranchElement* subbranch = (TBranchElement*)branches->At(i);
+                     TString subbranch_name(subbranch->GetFullName());
+                     if ( ! subbranch_name.BeginsWith(thisprefix)) {
+                        // We moved to another data member (of the enclosing class)
+                        firstindex = i + 1;
+                        break;
+                     }
+                     if (!subbranch->fInfo)
+                        subbranch->SetupInfo();
                   }
-                  firstindex = i;
-                  firstid = branchid;
+                  for(Int_t i = index; i < nbranches; ++i) {
+                     TBranchElement* subbranch = (TBranchElement*)branches->At(i);
+                     TString subbranch_name(subbranch->GetFullName());
+                     if ( ! subbranch_name.BeginsWith(thisprefix)) {
+                        lastindex = i - 1;
+                        break;
+                     }
+                  }
                }
             }
             for (Int_t i = firstindex; i < nbranches; ++i) {
@@ -2454,7 +2463,7 @@ void TBranchElement::InitInfo()
                localInfo = FindOnfileInfo(fClonesClass, fBranches);
             }
 
-            TString prefix(GetName());
+            TString prefix(GetFullName());
             if (fType == 2 && fID >= 0) {
                auto start = prefix.Length();
                if (prefix[start - 1] == '.')

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -3839,8 +3839,8 @@ void TBranchElement::Print(Option_t* option) const
    Int_t nbranches = fBranches.GetEntriesFast();
    if (strncmp(option,"debugAddress",strlen("debugAddress"))==0) {
       if (strlen(option)==strlen("debugAddress")) {
-         Printf("%-24s %-16s %2s %4s %-16s %-16s %8s %8s %s\n",
-                "Branch Name", "Streamer Class", "ID", "Type", "Class", "Parent", "pOffset", "fOffset", "fObject");
+         Printf("%-24s %-16s %2s %4s %-16s %-16s %8s %8s %s %s\n",
+                "Branch Name", "Streamer Class", "ID", "Type", "Class", "Parent", "pOffset", "fOffset", "fObject", "fOnfileObject");
       }
       if (strlen(GetName())>24) Printf("%-24s\n%-24s ", GetName(),"");
       else Printf("%-24s ", GetName());
@@ -3849,11 +3849,11 @@ void TBranchElement::Print(Option_t* option) const
       Int_t ind = parent ? parent->GetListOfBranches()->IndexOf(this) : -1;
       TVirtualStreamerInfo *info = ((TBranchElement*)this)->GetInfoImp();
 
-      Printf("%-16s %2d %4d %-16s %-16s %8x %8x %p\n",
+      Printf("%-16s %2d %4d %-16s %-16s %8x %8x %p %p%s\n",
              info ? info->GetName() : "StreamerInfo unavailable", GetID(), GetType(),
              GetClassName(), GetParentName(),
              (fBranchOffset&&parent && ind>=0) ? parent->fBranchOffset[ind] : 0,
-             GetOffset(), GetObject());
+             GetOffset(), GetObject(), fOnfileObject, TestBit(kOwnOnfileObj) ? " (owned)" : "");
       for (Int_t i = 0; i < nbranches; ++i) {
          TBranchElement* subbranch = (TBranchElement*)fBranches.At(i);
          subbranch->Print("debugAddressSub");

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2406,7 +2406,7 @@ void TBranchElement::InitInfo()
                SetOnfileObject(fInfo);
             }
          }
-         if (fType == 3 || fType == 4 || (fType == 0 && fID == -2)) {
+         if (fType == 3 || fType == 4 || (fType == 0 && fID == -2) || fType == 2) {
             // Need to add the rule targeting transient members.
             TStreamerInfo *localInfo = fInfo;
             if (fType == 3 || fType == 4) {

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2254,7 +2254,7 @@ void TBranchElement::InitInfo()
                currentVersion = info->GetClassVersion();
             }
 
-            // First find the first branch of corresponding to the same class as 'this'
+            // First find the first branch corresponding to the same class as 'this'
             // branch
             Int_t index = branches->IndexOf(this);
             Int_t firstindex = 0;


### PR DESCRIPTION
Extend the support for a rule that applies to several data members (and thus currently is applied as the 'object level') to
the case of a split object embedded within a split subobject of an object (previous it worked only for the collection case).

This fixes issue #8428 , see also https://cdcvs.fnal.gov/redmine/issues/25893.


This PR fixes #8428

