### PR TITLE
Backport fixes in 6.24: fix of printing a warning in RooAddPdf plus another fix when sorting RooAbsArg's 

### DIFF
--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -810,18 +810,11 @@ Double_t RooAddPdf::getValV(const RooArgSet *nset) const
 {
    // special handling in case when an empty set is passed
    // use saved normalization set when it is available
+   //when nset is a nullptr the subsequent call to RooAddPdf::evaluate called from
+   // RooAbsPdf::getValV will result in a warning message since in this case interpretation of coefficient is arbitrary
    if (nset == nullptr) {
       nset = _normSet;
-      // check that nset is not a null pointer
-      // in this case interpretation of coefficient is arbitrary
-      if (!nset) {
-         oocoutW(this, Eval) << "Evaluating RooAddPdf without a defined normalization set. This can lead to ambiguos "
-                                "coefficients definition and incorrect results."
-                             << " Use RooAddPdf::fixCoefNormalization(nset) to provide a normalization set for "
-                                "defining uniquely RooAddPdf coefficients!"
-                             << std::endl;
-      }
-   }
+    }
    return RooAbsPdf::getValV(nset);
 }
 
@@ -833,6 +826,15 @@ Double_t RooAddPdf::evaluate() const
   auto normAndCache = getNormAndCache();
   const RooArgSet* nset = normAndCache.first;
   CacheElem* cache = normAndCache.second;
+
+  // nset is obtained from _normSet or if it is a null pointer from _refCoefNorm
+  if (!nset) {
+     oocoutW(this, Eval) << "Evaluating RooAddPdf without a defined normalization set. This can lead to ambiguos "
+        "coefficients definition and incorrect results."
+                         << " Use RooAddPdf::fixCoefNormalization(nset) to provide a normalization set for "
+        "defining uniquely RooAddPdf coefficients!"
+                         << std::endl;
+  }
 
   // Do running sum of coef/pdf pairs, calculate lastCoef.
   Double_t value(0);

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -967,6 +967,8 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
 
   // Step 2 - reorder tracked nodes
   std::sort(trackArgs.begin(), trackArgs.end(), [](RooAbsArg* left, RooAbsArg* right){
+    //LM: exclude same comparison. This avoids an issue when using sort in MacOS  versions
+    if (left == right) return false;
     return right->dependsOn(*left);
   });
 


### PR DESCRIPTION
This Pull request is a backport in 6.24 of #8030 and #8111