### PR TITLE
[RF] Remove redundant sanity check

### DIFF
--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -121,10 +121,6 @@ RooAddModel::RooAddModel(const char *name, const char *title, const RooArgList& 
       coutE(InputArguments) << "RooAddModel::RooAddModel(" << GetName() << ") coefficient " << coef->GetName() << " is not of type RooAbsReal, ignored" << endl ;
       continue ;
     }
-    if (!dynamic_cast<RooAbsReal*>(pdf)) {
-      coutE(InputArguments) << "RooAddModel::RooAddModel(" << GetName() << ") pdf " << pdf->GetName() << " is not of type RooAbsPdf, ignored" << endl ;
-      continue ;
-    }
     _pdfList.add(*pdf) ;
     _coefList.add(*coef) ;    
   }


### PR DESCRIPTION
`pdf` is `RooAbsPdf*`, and `RooAbsPdf` inherits from `RooAbsReal`,
so the check can only fail if `pdf` is a nullptr, in which case
`pdf->GetName()` would be a nullptr dereference.

This fixes the following warning in gcc11:

```
../roofit/roofitcore/src/RooAddModel.cxx: In constructor ‘RooAddModel::RooAddModel(const char*, const char*, const RooArgList&, const RooArgList&, Bool_t)’:
../roofit/roofitcore/src/RooAddModel.cxx:125:106: warning: ‘this’ pointer is null [-Wnonnull]
  125 |       coutE(InputArguments) << "RooAddModel::RooAddModel(" << GetName() << ") pdf " << pdf->GetName() << " is not of type RooAbsPdf, ignored" << endl ;
```

# This Pull request:

## Changes or fixes:


## Checklist:

- [] tested changes locally
- [] updated the docs (if necessary)

This PR fixes # 

