### PR TITLE
[NFC] Fix display of github PR template when checkboxes are empty

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,8 @@
 
 ## Checklist:
 
-- [] tested changes locally
-- [] updated the docs (if necessary)
+- [ ] tested changes locally
+- [ ] updated the docs (if necessary)
 
 This PR fixes # 
 


### PR DESCRIPTION
Currently it displays like this:

# This Pull request:

## Changes or fixes:


## Checklist:

- [] tested changes locally
- [] updated the docs (if necessary)

This PR fixes # 

