### PR TITLE
[RF] Fix copy-paste error in RooAddModel constructor and modernization

### DIFF
--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -86,7 +86,7 @@ RooAddModel::RooAddModel() :
 /// All PDFs must inherit from RooAbsPdf. All coefficients must inherit from RooAbsReal.
 
 RooAddModel::RooAddModel(const char *name, const char *title, const RooArgList& inPdfList, const RooArgList& inCoefList, Bool_t ownPdfList) :
-  RooResolutionModel(name,title,((RooResolutionModel*)inPdfList.at(0))->convVar()),
+  RooResolutionModel(name,title,(static_cast<RooResolutionModel*>(inPdfList.at(0)))->convVar()),
   _refCoefNorm("!refCoefNorm","Reference coefficient normalization set",this,kFALSE,kFALSE),
   _refCoefRangeName(0),
   _projectCoefs(kFALSE),
@@ -99,29 +99,32 @@ RooAddModel::RooAddModel(const char *name, const char *title, const RooArgList& 
   _allExtendable(kFALSE)
 { 
   if (inPdfList.getSize()>inCoefList.getSize()+1) {
-    coutE(InputArguments) << "RooAddModel::RooAddModel(" << GetName() 
-			  << ") number of pdfs and coefficients inconsistent, must have Npdf=Ncoef or Npdf=Ncoef+1" << endl ;
-    assert(0) ;
+    std::stringstream msgSs;
+    msgSs << "RooAddModel::RooAddModel(" << GetName()
+          << ") number of pdfs and coefficients inconsistent, must have Npdf=Ncoef or Npdf=Ncoef+1";
+    const std::string msgStr = msgSs.str();
+    coutE(InputArguments) << msgStr << endl;
+    throw std::runtime_error(msgStr);
   }
  
   // Constructor with N PDFs and N or N-1 coefs
-  TIterator* pdfIter = inPdfList.createIterator() ;
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsPdf* pdf ;
-  RooAbsReal* coef ;
+  auto pdfIter = inPdfList.fwdIterator() ;
 
-  while((coef = (RooAbsPdf*)coefIter->Next())) {
-    pdf = (RooAbsPdf*) pdfIter->Next() ;
+  for(auto const& coef : inCoefList) {
+    auto pdf = pdfIter.next() ;
     if (!pdf) {
-      coutE(InputArguments) << "RooAddModel::RooAddModel(" << GetName() 
-			    << ") number of pdfs and coefficients inconsistent, must have Npdf=Ncoef or Npdf=Ncoef+1" << endl ;
-      assert(0) ;
+      std::stringstream msgSs;
+      msgSs << "RooAddModel::RooAddModel(" << GetName() 
+            << ") number of pdfs and coefficients inconsistent, must have Npdf=Ncoef or Npdf=Ncoef+1";
+      const std::string msgStr = msgSs.str();
+      coutE(InputArguments) << msgStr << endl;
+      throw std::runtime_error(msgStr);
     }
     if (!dynamic_cast<RooAbsReal*>(coef)) {
       coutE(InputArguments) << "RooAddModel::RooAddModel(" << GetName() << ") coefficient " << coef->GetName() << " is not of type RooAbsReal, ignored" << endl ;
       continue ;
     }
-    if (!dynamic_cast<RooAbsReal*>(pdf)) {
+    if (!dynamic_cast<RooAbsPdf*>(pdf)) {
       coutE(InputArguments) << "RooAddModel::RooAddModel(" << GetName() << ") pdf " << pdf->GetName() << " is not of type RooAbsPdf, ignored" << endl ;
       continue ;
     }
@@ -129,19 +132,18 @@ RooAddModel::RooAddModel(const char *name, const char *title, const RooArgList& 
     _coefList.add(*coef) ;    
   }
 
-  pdf = (RooAbsPdf*) pdfIter->Next() ;
-  if (pdf) {
-    if (!dynamic_cast<RooAbsReal*>(pdf)) {
-      coutE(InputArguments) << "RooAddModel::RooAddModel(" << GetName() << ") last pdf " << coef->GetName() << " is not of type RooAbsPdf, fatal error" << endl ;
-      assert(0) ;
+  if (auto pdf = pdfIter.next()) {
+    if (!dynamic_cast<RooAbsPdf*>(pdf)) {
+      std::stringstream msgSs;
+      msgSs << "RooAddModel::RooAddModel(" << GetName() << ") last pdf " << pdf->GetName() << " is not of type RooAbsPdf, fatal error";
+      const std::string msgStr = msgSs.str();
+      coutE(InputArguments) << msgStr << endl;
+      throw std::runtime_error(msgStr);
     }
     _pdfList.add(*pdf) ;  
   } else {
     _haveLastCoef=kTRUE ;
   }
-
-  delete pdfIter ;
-  delete coefIter  ;
 
   _coefCache = new Double_t[_pdfList.getSize()] ;
   _coefErrCount = _errorCount ;


### PR DESCRIPTION
* replace wrong `dynamic_cast<RooAbsReal*>` with
  `dynamic_cast<RooAbsPdf*>` (presumably a copy-paste error)

* use `TIter` and range-based loop instead of `TIterator*`

* avoid C-style casts

* replace `assert(0)` with `std::runtime_error`, as asserts only work in
  debug buils

* replace one orrurence of `coef->GetName()` with `pdf->GetName()`,
  which was probably also a copy-paste error

This fixes the following warning in gcc11:

```
../roofit/roofitcore/src/RooAddModel.cxx: In constructor ‘RooAddModel::RooAddModel(const char*, const char*, const RooArgList&, const RooArgList&, Bool_t)’:
../roofit/roofitcore/src/RooAddModel.cxx:125:106: warning: ‘this’ pointer is null [-Wnonnull]
  125 |       coutE(InputArguments) << "RooAddModel::RooAddModel(" << GetName() << ") pdf " << pdf->GetName() << " is not of type RooAbsPdf, ignored" << endl ;
```

This PR superseeds PR https://github.com/root-project/root/pull/8432 and addresses issue https://github.com/root-project/root/issues/8129.