### PR TITLE
Enable usage of RCanvas/TObjectDrawable in PyROOT

### DIFF
--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -46,10 +46,11 @@ class RAttrAxis : public RAttrBase {
    RAttrValue<RPadLength> fTicksSize{this, "ticks_size", 0.02_normal};   ///<! ticks size
    RAttrValue<RColor> fTicksColor{this, "ticks_color", RColor::kBlack};  ///<! ticks color
    RAttrValue<int> fTicksWidth{this, "ticks_width", 1};                  ///<! ticks width
-   RAttrText fLabelsAttr{this, "labels"};                                ///<! text attributes for labels
+   RAttrValue<bool> fNoLabels{this, "nolabels", false};                  ///<! disable labels drawing
+   RAttrText fAttrLabels{this, "labels"};                                ///<! text attributes for labels
    RAttrValue<RPadLength> fLabelsOffset{this, "labels_offset", {}};      ///<! axis labels offset - relative
    RAttrValue<bool> fLabelsCenter{this, "labels_center", false};         ///<! center labels
-   RAttrText fTitleAttr{this, "title"};                                  ///<! axis title text attributes
+   RAttrText fAttrTitle{this, "title"};                                  ///<! axis title text attributes
    RAttrValue<std::string> fTitle{this, "title", ""};                    ///<! axis title
    RAttrValue<std::string> fTitlePos{this, "title_position", "right"};   ///<! axis title position - left, right, center
    RAttrValue<RPadLength> fTitleOffset{this, "title_offset", {}};        ///<! axis title offset - relative
@@ -142,16 +143,17 @@ class RAttrAxis : public RAttrBase {
    RAttrAxis &SetLabelsOffset(const RPadLength &len) { fLabelsOffset = len; return *this; }
    RPadLength GetLabelsOffset() const { return fLabelsOffset; }
 
-   const RAttrText &GetLabelsAttr() const { return fLabelsAttr; }
-   RAttrAxis &SetLabelsAttr(const RAttrText &attr) { fLabelsAttr = attr; return *this; }
-   RAttrText &LabelsAttr() { return fLabelsAttr; }
+   RAttrAxis &SetNoLabels(bool on = true) { fNoLabels = on; return *this; }
+   bool GetNoLabels() const { return fNoLabels; }
+
+   const RAttrText &AttrLabels() const { return fAttrLabels; }
+   RAttrText &AttrLabels() { return fAttrLabels; }
 
    RAttrAxis &SetLabelsCenter(bool on = true) { fLabelsCenter = on; return *this; }
    bool GetLabelsCenter() const { return fLabelsCenter; }
 
-   const RAttrText &GetTitleAttr() const { return fTitleAttr; }
-   RAttrAxis &SetTitleAttr(const RAttrText &attr) { fTitleAttr = attr; return *this; }
-   RAttrText &TitleAttr() { return fTitleAttr; }
+   const RAttrText &AttrTitle() const { return fAttrTitle; }
+   RAttrText &AttrTitle() { return fAttrTitle; }
 
    RAttrAxis &SetTitle(const std::string &title) { fTitle = title; return *this; }
    std::string GetTitle() const { return fTitle; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -46,7 +46,7 @@ class RAttrAxis : public RAttrBase {
    RAttrValue<RPadLength> fTicksSize{this, "ticks_size", 0.02_normal};   ///<! ticks size
    RAttrValue<RColor> fTicksColor{this, "ticks_color", RColor::kBlack};  ///<! ticks color
    RAttrValue<int> fTicksWidth{this, "ticks_width", 1};                  ///<! ticks width
-   RAttrValue<bool> fNoLabels{this, "nolabels", false};                  ///<! disable labels drawing
+   RAttrValue<bool> fHideLabels{this, "hidelabels", false};              ///<! disable labels drawing
    RAttrText fAttrLabels{this, "labels"};                                ///<! text attributes for labels
    RAttrValue<RPadLength> fLabelsOffset{this, "labels_offset", {}};      ///<! axis labels offset - relative
    RAttrValue<bool> fLabelsCenter{this, "labels_center", false};         ///<! center labels
@@ -143,8 +143,8 @@ class RAttrAxis : public RAttrBase {
    RAttrAxis &SetLabelsOffset(const RPadLength &len) { fLabelsOffset = len; return *this; }
    RPadLength GetLabelsOffset() const { return fLabelsOffset; }
 
-   RAttrAxis &SetNoLabels(bool on = true) { fNoLabels = on; return *this; }
-   bool GetNoLabels() const { return fNoLabels; }
+   RAttrAxis &SetHideLabels(bool on = true) { fHideLabels = on; return *this; }
+   bool GetHideLabels() const { return fHideLabels; }
 
    const RAttrText &AttrLabels() const { return fAttrLabels; }
    RAttrText &AttrLabels() { return fAttrLabels; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -74,8 +74,8 @@ class RAttrText : public RAttrBase {
       }
 
       SetFontFamily(family);
-      SetFontWeight(style);
-      SetFontStyle(weight);
+      SetFontWeight(weight);
+      SetFontStyle(style);
 
       return *this;
    }

--- a/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
@@ -76,7 +76,7 @@ public:
    static std::shared_ptr<RCanvas> Create(const std::string &title);
 
    /// Create a temporary RCanvas; for long-lived ones please use Create().
-   RCanvas() = default;
+   RCanvas() : RPadBase("canvas") {}
 
    ~RCanvas() = default;
 

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -157,8 +157,8 @@ private:
    RAttrValue<bool> fGridY{this, "gridy", false}; ///<! show grid for Y axis
    RAttrValue<bool> fSwapX{this, "swapx", false}; ///<! swap position of X axis
    RAttrValue<bool> fSwapY{this, "swapy", false}; ///<! swap position of Y axis
-   RAttrValue<int> fTicksX{this, "ticksx", 1};    ///<! X ticks drawing:
-   RAttrValue<int> fTicksY{this, "ticksy", 1};    ///<! Y ticks drawing
+   RAttrValue<int> fTicksX{this, "ticksx", 1};    ///<! X ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
+   RAttrValue<int> fTicksY{this, "ticksy", 1};    ///<! Y ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
    std::map<unsigned, RUserRanges> fClientRanges; ///<! individual client ranges
 
    RFrame(const RFrame &) = delete;

--- a/graf2d/gpadv7/inc/ROOT/RPad.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPad.hxx
@@ -24,6 +24,8 @@ namespace Experimental {
 
 class RPad: public RPadBase {
 
+   friend class RPadBase; ///< required to set parent
+
    /// Pad containing this pad as a sub-pad.
    RPadBase *fParent{nullptr};             ///< The parent pad, if this pad has one.
 
@@ -32,16 +34,22 @@ class RPad: public RPadBase {
 
    RAttrLine fAttrLine{this, "border"};    ///<! border attributes
 
+   void SetParent(RPadBase *parent) { fParent = parent; }
+
 protected:
 
    std::unique_ptr<RDisplayItem> Display(const RDisplayContext &) final;
 
 public:
    /// Create a topmost, non-paintable pad.
-   RPad() = default;
+   RPad() : RPadBase("pad") {}
 
-   /// Create a child pad.
-   RPad(RPadBase *parent, const RPadPos &pos, const RPadExtent &size): fParent(parent) { fPos = pos; fSize = size; }
+   /// Create a pad.
+   RPad(const RPadPos &pos, const RPadExtent &size) : RPad()
+   {
+      fPos = pos;
+      fSize = size;
+   }
 
    /// Destructor to have a vtable.
    virtual ~RPad();

--- a/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
@@ -83,7 +83,7 @@ public:
 
    /// Create drawable of specified class T
    template<class T, class... ARGS>
-   auto Draw(ARGS... args)
+   std::shared_ptr<T> Draw(ARGS... args)
    {
       auto drawable = std::make_shared<T>(args...);
 
@@ -95,7 +95,7 @@ public:
    }
 
    /// Add existing drawable instance to canvas
-   auto Draw(std::shared_ptr<RDrawable> &&drawable)
+   std::shared_ptr<RDrawable> Draw(std::shared_ptr<RDrawable> &&drawable)
    {
       TestIfFrameRequired(drawable.get());
 

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -15,6 +15,7 @@
 #include <ROOT/RAttrFill.hxx>
 #include <ROOT/RAttrValue.hxx>
 #include <ROOT/RPadPos.hxx>
+#include <ROOT/RPadExtent.hxx>
 
 namespace ROOT {
 namespace Experimental {
@@ -38,9 +39,13 @@ class RPave : public RDrawable {
    RAttrValue<RPadLength>  fWidth{this, "width", 0.4};       ///<! pave width
    RAttrValue<RPadLength>  fHeight{this, "height", 0.2};     ///<! pave height
 
+protected:
+
+   RPave(const std::string &csstype) : RDrawable(csstype) {}
+
 public:
 
-   RPave(const std::string &csstype = "pave") : RDrawable(csstype) {}
+   RPave() : RPave("pave") {}
 
    RPave &SetCornerX(const RPadLength &pos) { fCornerX = pos; return *this; }
    RPadLength GetCornerX() const { return fCornerX; }

--- a/graf2d/gpadv7/inc/ROOT/TObjectDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDisplayItem.hxx
@@ -14,6 +14,8 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
+
 #include "TObject.h"
 
 namespace ROOT {
@@ -61,10 +63,16 @@ public:
       if (fOwner) delete fObject;
    }
 
-   void AddTColor(int color_indx, const std::string &color_value)
+   void AddColor(int color_indx, const std::string &color_value)
    {
-      fColIndex.emplace_back(color_indx);
-      fColValue.emplace_back(color_value);
+      auto pos = std::find(fColIndex.begin(), fColIndex.end(), color_indx);
+      if (pos == fColIndex.end()) {
+         fColIndex.emplace_back(color_indx);
+         fColValue.emplace_back(color_value);
+      } else {
+         auto indx = pos - fColIndex.begin();
+         fColValue[indx] = color_value;
+      }
    }
 
 };

--- a/graf2d/gpadv7/inc/ROOT/TObjectDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDisplayItem.hxx
@@ -63,7 +63,7 @@ public:
       if (fOwner) delete fObject;
    }
 
-   void AddColor(int color_indx, const std::string &color_value)
+   void UpdateColor(int color_indx, const std::string &color_value)
    {
       auto pos = std::find(fColIndex.begin(), fColIndex.end(), color_indx);
       if (pos == fColIndex.end()) {

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -68,6 +68,8 @@ protected:
 
    static void ExtractObjectColors(std::unique_ptr<TObjectDisplayItem> &item, TObject *obj);
 
+   static void CheckOwnership(TObject *obj);
+
    static std::string DetectCssType(const TObject *obj);
 
 public:
@@ -78,43 +80,14 @@ public:
       kPalette = 6   ///< list of colors from palette
    };
 
-   TObjectDrawable(const std::shared_ptr<TObject> &obj) : RDrawable(DetectCssType(obj.get()))
-   {
-      fKind = kObject;
-      fObj = obj;
-   }
-
-   TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : RDrawable(DetectCssType(obj.get()))
-   {
-      fKind = kObject;
-      fObj = obj;
-      SetOpt(opt);
-   }
-
-   /// Constructor takes ownership
-   TObjectDrawable(TObject *obj) : RDrawable(DetectCssType(obj))
-   {
-      fKind = kObject;
-      fObj = std::shared_ptr<TObject>(obj);
-   }
-
-   /// Constructor takes ownership
-   TObjectDrawable(TObject *obj, const std::string &opt) : RDrawable(DetectCssType(obj))
-   {
-      fKind = kObject;
-      fObj = std::shared_ptr<TObject>(obj);
-      SetOpt(opt);
-   }
-
-   TObjectDrawable(EKind kind, bool persistent = false) : RDrawable("tobject")
-   {
-      fKind = kind;
-
-      if (persistent)
-         fObj = CreateSpecials(kind);
-   }
-
-   virtual ~TObjectDrawable() = default;
+   TObjectDrawable(TObject &obj);
+   TObjectDrawable(TObject &obj, const std::string &opt);
+   TObjectDrawable(TObject *obj);
+   TObjectDrawable(TObject *obj, const std::string &opt);
+   TObjectDrawable(const std::shared_ptr<TObject> &obj);
+   TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt);
+   TObjectDrawable(EKind kind, bool persistent = false);
+   virtual ~TObjectDrawable();
 
    std::shared_ptr<TObject> GetObject() const { return fObj.get_shared(); }
 

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -64,7 +64,9 @@ protected:
 
    void Execute(const std::string &) final;
 
-   void ExtractTColor(std::unique_ptr<TObjectDisplayItem> &item, const char *class_name, const char *class_member);
+   static void ExtractTColor(std::unique_ptr<TObjectDisplayItem> &item, TObject *obj, const char *class_name, const char *class_member);
+
+   static void ExtractObjectColors(std::unique_ptr<TObjectDisplayItem> &item, TObject *obj);
 
    static std::string DetectCssType(const TObject *obj);
 

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -66,7 +66,7 @@ protected:
 
    void ExtractTColor(std::unique_ptr<TObjectDisplayItem> &item, const char *class_name, const char *class_member);
 
-   static std::string DetectCssType(const std::shared_ptr<TObject> &obj);
+   static std::string DetectCssType(const TObject *obj);
 
 public:
    // special kinds, see TWebSnapshot enums
@@ -76,16 +76,31 @@ public:
       kPalette = 6   ///< list of colors from palette
    };
 
-   TObjectDrawable(const std::shared_ptr<TObject> &obj) : RDrawable(DetectCssType(obj))
+   TObjectDrawable(const std::shared_ptr<TObject> &obj) : RDrawable(DetectCssType(obj.get()))
    {
       fKind = kObject;
       fObj = obj;
    }
 
-   TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : RDrawable(DetectCssType(obj))
+   TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : RDrawable(DetectCssType(obj.get()))
    {
       fKind = kObject;
       fObj = obj;
+      SetOpt(opt);
+   }
+
+   /// Constructor takes ownership
+   TObjectDrawable(TObject *obj) : RDrawable(DetectCssType(obj))
+   {
+      fKind = kObject;
+      fObj = std::shared_ptr<TObject>(obj);
+   }
+
+   /// Constructor takes ownership
+   TObjectDrawable(TObject *obj, const std::string &opt) : RDrawable(DetectCssType(obj))
+   {
+      fKind = kObject;
+      fObj = std::shared_ptr<TObject>(obj);
       SetOpt(opt);
    }
 

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -50,7 +50,7 @@ private:
    RAttrText fAttrText{this, "text"};          ///<! object text attributes
    RAttrMarker fMarkerAttr{this, "marker"};    ///<! object marker attributes
 
-   const char *GetColorCode(TColor *col);
+   static std::string GetColorCode(TColor *col);
 
    std::unique_ptr<TObject> CreateSpecials(int kind);
 
@@ -80,8 +80,8 @@ public:
       kPalette = 6   ///< list of colors from palette
    };
 
-   TObjectDrawable(TObject &obj);
-   TObjectDrawable(TObject &obj, const std::string &opt);
+   TObjectDrawable(const TObject &obj);
+   TObjectDrawable(const TObject &obj, const std::string &opt);
    TObjectDrawable(TObject *obj);
    TObjectDrawable(TObject *obj, const std::string &opt);
    TObjectDrawable(const std::shared_ptr<TObject> &obj);

--- a/graf2d/gpadv7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/src/RPadBase.cxx
@@ -39,10 +39,8 @@ void RPadBase::UseStyle(const std::shared_ptr<RStyle> &style)
 
 void RPadBase::AddPrimitive(std::shared_ptr<RDrawable> drawable)
 {
-   if (drawable->GetCssType() == "pad") {
-      auto pad = dynamic_cast<RPad *>(drawable.get());
-      if (pad) pad->SetParent(this);
-   }
+   if (auto pad = dynamic_cast<RPad *>(drawable.get()))
+      pad->SetParent(this);
 
    fPrimitives.emplace_back(drawable);
 }
@@ -201,10 +199,8 @@ std::shared_ptr<RFrame> RPadBase::GetOrCreateFrame()
 const std::shared_ptr<RFrame> RPadBase::GetFrame() const
 {
    for (auto &drawable : fPrimitives) {
-      if (drawable->GetCssType() == "frame") {
-         const std::shared_ptr<RFrame> frame = std::dynamic_pointer_cast<RFrame>(drawable.get_shared());
-         if (frame) return frame;
-      }
+      if (const std::shared_ptr<RFrame> frame = std::dynamic_pointer_cast<RFrame>(drawable.get_shared()))
+        return frame;
    }
    return nullptr;
 }
@@ -215,10 +211,8 @@ const std::shared_ptr<RFrame> RPadBase::GetFrame() const
 std::shared_ptr<RFrame> RPadBase::GetFrame()
 {
    for (auto &drawable : fPrimitives) {
-      if (drawable->GetCssType() == "frame") {
-         std::shared_ptr<RFrame> frame = std::dynamic_pointer_cast<RFrame>(drawable.get_shared());
-         if (frame) return frame;
-      }
+      if (std::shared_ptr<RFrame> frame = std::dynamic_pointer_cast<RFrame>(drawable.get_shared()))
+         return frame;
    }
    return nullptr;
 }

--- a/graf2d/gpadv7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/TObjectDrawable.cxx
@@ -26,7 +26,7 @@
 
 using namespace ROOT::Experimental;
 
-std::string TObjectDrawable::DetectCssType(const std::shared_ptr<TObject> &obj)
+std::string TObjectDrawable::DetectCssType(const TObject *obj)
 {
    const char *clname = obj ? obj->ClassName() : "TObject";
    if (strncmp(clname, "TH1", 3) == 0) return "th1";

--- a/graf2d/gpadv7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/TObjectDrawable.cxx
@@ -18,6 +18,7 @@
 #include "TObjString.h"
 #include "TROOT.h"
 #include "TStyle.h"
+#include "TMethodCall.h"
 
 #include <exception>
 #include <sstream>
@@ -28,10 +29,17 @@ using namespace ROOT::Experimental;
 
 std::string TObjectDrawable::DetectCssType(const TObject *obj)
 {
+   bool ishist = false;
+   // special handling for TH1 classes without linking to libHist
+   if (obj && obj->InheritsFrom("TH1")) {
+      TMethodCall call(obj->IsA(), "SetDirectory", "nullptr");
+      call.Execute((void *)(obj));
+      ishist = true;
+   }
    const char *clname = obj ? obj->ClassName() : "TObject";
-   if (strncmp(clname, "TH1", 3) == 0) return "th1";
-   if (strncmp(clname, "TH2", 3) == 0) return "th2";
    if (strncmp(clname, "TH3", 3) == 0) return "th3";
+   if (strncmp(clname, "TH2", 3) == 0) return "th2";
+   if ((strncmp(clname, "TH1", 3) == 0) || ishist) return "th1";
    if (strncmp(clname, "TGraph", 6) == 0) return "tgraph";
    if (strcmp(clname, "TLine") == 0) return "tline";
    if (strcmp(clname, "TBox") == 0) return "tbox";

--- a/graf2d/gpadv7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/TObjectDrawable.cxx
@@ -30,12 +30,15 @@
 using namespace ROOT::Experimental;
 
 ////////////////////////////////////////////////////////////////////
-/// Checks object ownership - used for TH1 directory handling
+/// Checks object ownership - used for TH1 directory handling and TF1 globals lists
 
 void TObjectDrawable::CheckOwnership(TObject *obj)
 {
    if (obj && obj->InheritsFrom("TH1")) {
       TMethodCall call(obj->IsA(), "SetDirectory", "nullptr");
+      call.Execute((void *)(obj));
+   } else if (obj && obj->InheritsFrom("TF1")) {
+      TMethodCall call(obj->IsA(), "AddToGlobalList", "kFALSE");
       call.Execute((void *)(obj));
    }
 }

--- a/graf2d/primitivesv7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RBox.hxx
@@ -49,17 +49,8 @@ public:
       fP2 = p2;
    }
 
-   RBox &SetP1(const RPadPos &p1)
-   {
-      fP1 = p1;
-      return *this;
-   }
-
-   RBox &SetP2(const RPadPos &p2)
-   {
-      fP2 = p2;
-      return *this;
-   }
+   RBox &SetP1(const RPadPos &p1) { fP1 = p1; return *this; }
+   RBox &SetP2(const RPadPos &p2) { fP2 = p2; return *this; }
 
    const RPadPos &GetP1() const { return fP1; }
    const RPadPos &GetP2() const { return fP2; }
@@ -70,10 +61,10 @@ public:
    const RAttrFill &AttrFill() const { return fAttrFill; }
    RAttrFill &AttrFill() { return fAttrFill; }
 
-   void SetOnFrame(bool on = true) { fOnFrame = on; }
+   RBox &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
    bool GetOnFrame() const { return fOnFrame; }
 
-   void SetClipping(bool on = true) { fClipping = on; }
+   RBox &SetClipping(bool on = true) { fClipping = on; return *this; }
    bool GetClipping() const { return fClipping; }
 };
 

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -48,7 +48,7 @@ public:
 
       std::string fLabel; ///< label shown for the entry
 
-      bool fLine{true}, fFill{false}, fMarker{false}; ///< enable line, fill, marker showing
+      bool fLine{true}, fFill{false}, fMarker{false}, fError{false}; ///< enable line, fill, marker, error showing
 
       Internal::RIOShared<RDrawable> fDrawable; ///< reference to RDrawable
 
@@ -84,18 +84,10 @@ public:
          fLabel = lbl;
       }
 
-      REntry &SetLabel(const std::string &lbl)
-      {
-         fLabel = lbl;
-         return *this;
-      }
+      REntry &SetLabel(const std::string &lbl) { fLabel = lbl; return *this; }
       const std::string &GetLabel() const { return fLabel; }
 
-      REntry &SetLine(bool on = true)
-      {
-         fLine = on;
-         return *this;
-      }
+      REntry &SetLine(bool on = true) { fLine = on; return *this; }
       bool GetLine() const { return fLine; }
 
       REntry &SetAttrLine(const RAttrLine &attr)
@@ -114,11 +106,7 @@ public:
          return {};
       }
 
-      REntry &SetFill(bool on = true)
-      {
-         fFill = on;
-         return *this;
-      }
+      REntry &SetFill(bool on = true) { fFill = on; return *this; }
       bool GetFill() const { return fFill; }
 
       REntry &SetAttrFill(const RAttrFill &attr)
@@ -137,11 +125,7 @@ public:
          return {};
       }
 
-      REntry &SetMarker(bool on = true)
-      {
-         fMarker = on;
-         return *this;
-      }
+      REntry &SetMarker(bool on = true) { fMarker = on; return *this; }
       bool GetMarker() const { return fMarker; }
 
       REntry &SetAttrMarker(const RAttrMarker &attr)
@@ -159,6 +143,9 @@ public:
             return RAttrMarker(const_cast<RDrawable *>(fDrawable.get()));
          return {};
       }
+
+      REntry &SetError(bool on = true) { fError = on; return *this; }
+      bool GetError() const { return fError; }
    };
 
 private:
@@ -206,11 +193,15 @@ public:
 
    RLegend(const std::string &title) : RLegend() { SetTitle(title); }
 
-   RLegend &SetTitle(const std::string &title)
+   RLegend(const RPadPos &corner, const RPadExtent &size) : RLegend()
    {
-      fTitle = title;
-      return *this;
+      SetCornerX(corner.Horiz());
+      SetCornerY(corner.Vert());
+      SetWidth(size.Horiz());
+      SetHeight(size.Vert());
    }
+
+   RLegend &SetTitle(const std::string &title) { fTitle = title; return *this; }
    const std::string &GetTitle() const { return fTitle; }
 
    REntry &AddEntry(const std::string &lbl)
@@ -219,11 +210,12 @@ public:
       return fEntries.back();
    }
 
-   REntry &AddEntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl)
+   REntry &AddEntry(const std::shared_ptr<RDrawable> &drawable, const std::string &lbl)
    {
       fEntries.emplace_back(drawable, lbl);
       return fEntries.back();
    }
+
 
    auto NumEntries() const { return fEntries.size(); }
 

--- a/graf2d/primitivesv7/inc/ROOT/RLine.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLine.hxx
@@ -40,17 +40,8 @@ public:
       fP2 = p2;
    }
 
-   RLine &SetP1(const RPadPos &p1)
-   {
-      fP1 = p1;
-      return *this;
-   }
-
-   RLine &SetP2(const RPadPos &p2)
-   {
-      fP2 = p2;
-      return *this;
-   }
+   RLine &SetP1(const RPadPos &p1) { fP1 = p1; return *this; }
+   RLine &SetP2(const RPadPos &p2) { fP2 = p2; return *this; }
 
    const RPadPos &GetP1() const { return fP1; }
    const RPadPos &GetP2() const { return fP2; }
@@ -58,10 +49,10 @@ public:
    const RAttrLine &AttrLine() const { return fAttrLine; }
    RAttrLine &AttrLine() { return fAttrLine; }
 
-   void SetOnFrame(bool on = true) { fOnFrame = on; }
+   RLine &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
    bool GetOnFrame() const { return fOnFrame; }
 
-   void SetClipping(bool on = true) { fClipping = on; }
+   RLine &SetClipping(bool on = true) { fClipping = on; return *this; }
    bool GetClipping() const { return fClipping; }
 };
 

--- a/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
@@ -38,20 +38,16 @@ public:
 
    RMarker(const RPadPos &p) : RMarker() { fP = p; }
 
-   RMarker &SetP(const RPadPos &p)
-   {
-      fP = p;
-      return *this;
-   }
+   RMarker &SetP(const RPadPos &p) { fP = p; return *this; }
    const RPadPos &GetP() const { return fP; }
 
    const RAttrMarker &AttrMarker() const { return fAttrMarker; }
    RAttrMarker &AttrMarker() { return fAttrMarker; }
 
-   void SetOnFrame(bool on = true) { fOnFrame = on; }
+   RMarker &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
    bool GetOnFrame() const { return fOnFrame; }
 
-   void SetClipping(bool on = true) { fClipping = on; }
+   RMarker &SetClipping(bool on = true) { fClipping = on; return *this; }
    bool GetClipping() const { return fClipping; }
 
 };

--- a/graf2d/primitivesv7/inc/ROOT/RText.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RText.hxx
@@ -46,27 +46,19 @@ public:
       fPos = p;
    }
 
-   RText &SetText(const std::string &t)
-   {
-      fText = t;
-      return *this;
-   }
+   RText &SetText(const std::string &t) { fText = t; return *this; }
    const std::string &GetText() const { return fText; }
 
-   RText &SetPos(const RPadPos &p)
-   {
-      fPos = p;
-      return *this;
-   }
+   RText &SetPos(const RPadPos &p) { fPos = p; return *this; }
    const RPadPos &GetPos() const { return fPos; }
 
    const RAttrText &AttrText() const { return fAttrText; }
    RAttrText &AttrText() { return fAttrText; }
 
-   void SetOnFrame(bool on = true) { fOnFrame = on; }
+   RText &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
    bool GetOnFrame() const { return fOnFrame; }
 
-   void SetClipping(bool on = true) { fClipping = on; }
+   RText &SetClipping(bool on = true) { fClipping = on; return *this; }
    bool GetClipping() const { return fClipping; }
 };
 

--- a/js/changes.md
+++ b/js/changes.md
@@ -6,6 +6,8 @@
 3. Remove deprecated JSRootCore.js script, one have to use JSRoot.core.js
 4. Upgrade three.js to r127
 5. Upgrade d3.js to 6.7.0
+6. Implement "nozoomx" and "nozoomy" draw options for TPad
+7. Implement "frame" draw option for TGaxis - fix position of axis relative to the frame
 
 
 ## Changes in 6.1.0

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "10/06/2021";
+   JSROOT.version_date = "15/06/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -515,7 +515,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if ((res.length > 0) && real_draw)
          axis_g.append("svg:path").attr("d", res).call(this.lineatt.func);
 
-      if ((secondShift!==0) && (res2.length>0) && real_draw)
+      if ((secondShift !== 0) && (res2.length > 0) && real_draw)
          axis_g.append("svg:path").attr("d", res2).call(this.lineatt.func);
    }
 
@@ -666,7 +666,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       if (is_gaxis) {
          this.createAttLine({ attr: axis });
-         draw_lines = axis.fLineColor != 0;
+         draw_lines = (axis.fLineColor != 0);
          chOpt = axis.fChopt;
          tickSize = axis.fTickSize;
          scaling_size = vertical ? 1.7*h : 0.6*w;
@@ -705,7 +705,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
           // optionY = (chOpt.indexOf("Y")>=0),
           // optionUp = (chOpt.indexOf("0")>=0),
           // optionDown = (chOpt.indexOf("O")>=0),
-          optionUnlab = (chOpt.indexOf("U")>=0),  // no labels
+          optionUnlab = (chOpt.indexOf("U")>=0) || this.optionUnlab,  // no labels
           optionNoopt = (chOpt.indexOf("N")>=0),  // no ticks position optimization
           optionInt = (chOpt.indexOf("I")>=0),    // integer labels
           optionNoexp = axis.TestBit(JSROOT.EAxisBits.kNoExponent);
@@ -726,7 +726,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       let handle = this.createTicks(false, optionNoexp, optionNoopt, optionInt);
 
-      this.drawTicks(axis_g, handle, side, tickSize, ticksPlusMinus, secondShift, draw_lines && !disable_axis_drawing);
+      this.drawTicks(axis_g, handle, side, tickSize, ticksPlusMinus, secondShift, draw_lines && !disable_axis_drawing && !this.disable_ticks);
 
       let labelSize0 = Math.round( (axis.fLabelSize < 1) ? axis.fLabelSize * text_scaling_size : axis.fLabelSize),
           labeloffset = Math.round(Math.abs(axis.fLabelOffset)*text_scaling_size);

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -1133,7 +1133,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       this.ticksColor = this.v7EvalColor("ticks_color", "");
       this.ticksWidth = this.v7EvalAttr("ticks_width", 1);
       this.labelsOffset = this.v7EvalLength("labels_offset", this.scaling_size, 0);
-      this.optionUnlab = this.v7EvalAttr("nolabels", false);
+      this.optionUnlab = this.v7EvalAttr("hidelabels", false);
 
       this.fTitle = this.v7EvalAttr("title", "");
 
@@ -1757,7 +1757,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       this.x_handle = new JSROOT.TAxisPainter(this.getDom(), this.xaxis, true);
       this.x_handle.setPadName(this.getPadName());
-      this.x_handle.optionUnlab = this.v7EvalAttr("x_nolabels", false);
+      this.x_handle.optionUnlab = this.v7EvalAttr("x_hidelabels", false);
 
       this.x_handle.configureAxis("xaxis", this.xmin, this.xmax, this.scale_xmin, this.scale_xmax, this.swap_xy, this.swap_xy ? [0,h] : [0,w],
                                       { reverse: this.reverse_x,
@@ -1770,7 +1770,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       this.y_handle = new JSROOT.TAxisPainter(this.getDom(), this.yaxis, true);
       this.y_handle.setPadName(this.getPadName());
-      this.y_handle.optionUnlab = this.v7EvalAttr("y_nolabels", false);
+      this.y_handle.optionUnlab = this.v7EvalAttr("y_hidelabels", false);
 
       this.y_handle.configureAxis("yaxis", this.ymin, this.ymax, this.scale_ymin, this.scale_ymax, !this.swap_xy, this.swap_xy ? [0,w] : [0,h],
                                       { reverse: this.reverse_y,

--- a/js/scripts/JSRoot.v7more.js
+++ b/js/scripts/JSRoot.v7more.js
@@ -112,7 +112,7 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
 
    function drawLegendContent() {
       let legend     = this.getObject(),
-          textFont   = this.v7EvalFont("legend_text", { size: 12, color: "black", align: 22 }),
+          textFont   = this.v7EvalFont("text", { size: 12, color: "black", align: 22 }),
           width      = this.pave_width,
           height     = this.pave_height,
           nlines     = legend.fEntries.length,
@@ -128,12 +128,11 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
       this.startTextDrawing(textFont, 'font' );
 
       if (legend.fTitle) {
-         this.drawText({ align: 22, latex: 1,
-                         width: width - 2*margin_x, height: stepy, x: margin_x, y: posy, text: legend.fTitle });
+         this.drawText({ latex: 1, width: width - 2*margin_x, height: stepy, x: margin_x, y: posy, text: legend.fTitle });
          posy += stepy;
       }
 
-      for (let i=0; i<legend.fEntries.length; ++i) {
+      for (let i = 0; i<legend.fEntries.length; ++i) {
          let objp = null, entry = legend.fEntries[i];
 
          this.drawText({ latex: 1, width: 0.75*width - 3*margin_x, height: stepy, x: 2*margin_x + width*0.25, y: posy, text: entry.fLabel });
@@ -165,6 +164,15 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
               .attr("y2", Math.round(posy + stepy/2))
               .call(objp.lineatt.func);
 
+         if (objp && entry.fError && objp.lineatt)
+            this.draw_g
+              .append("svg:line")
+              .attr("x1", Math.round(margin_x + width/8))
+              .attr("y1", Math.round(posy + stepy*0.2))
+              .attr("x2", Math.round(margin_x + width/8))
+              .attr("y2", Math.round(posy + stepy*0.8))
+              .call(objp.lineatt.func);
+
          if (objp && entry.fMarker && objp.markeratt)
             this.draw_g.append("svg:path")
                 .attr("d", objp.markeratt.create(margin_x + width/8, posy + stepy/2))
@@ -188,7 +196,7 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
 
    function drawPaveTextContent() {
       let pavetext  = this.getObject(),
-          textFont  = this.v7EvalFont("pavetext_text", { size: 12, color: "black", align: 22 }),
+          textFont  = this.v7EvalFont("text", { size: 12, color: "black", align: 22 }),
           width     = this.pave_width,
           height    = this.pave_height,
           nlines    = pavetext.fText.length;
@@ -201,7 +209,7 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
 
       this.startTextDrawing(textFont, 'font');
 
-      for (let i=0; i < pavetext.fText.length; ++i) {
+      for (let i = 0; i < pavetext.fText.length; ++i) {
          let line = pavetext.fText[i];
 
          this.drawText({ latex: 1, width: width - 2*margin_x, height: stepy, x: margin_x, y: posy, text: line });

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -279,6 +279,7 @@ if(root7)
                  v7/filedialog.cxx
                  v7/fitpanel.cxx
                  v7/fitpanel6.cxx
+                 v7/df104.py
       )
   if(NOT davix)
     list(APPEND root7_veto v7/ntuple/ntpl003_lhcbOpenData.C)
@@ -290,7 +291,7 @@ if(root7)
     list(APPEND root7_veto v7/ntuple/ntpl004_dimuon.C)
   endif()
 else()
-  file(GLOB v7_veto_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/ v7/*.cxx v7/*/*.cxx v7/*.C v7/*/*.C)
+  file(GLOB v7_veto_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/ v7/*.py v7/*.cxx v7/*/*.cxx v7/*.C v7/*/*.C)
   list(APPEND root7_veto ${v7_veto_files})
 endif()
 

--- a/tutorials/launcher.py
+++ b/tutorials/launcher.py
@@ -20,6 +20,7 @@ if os.path.exists(file_path):
     # Ensure batch mode (some tutorials use graphics)
     import ROOT
     ROOT.gROOT.SetBatch(True)
+    ROOT.gROOT.SetWebDisplay("batch")
 
     # Prevent import from generating .pyc files in source directory
     sys.dont_write_bytecode = True

--- a/tutorials/v7/box.cxx
+++ b/tutorials/v7/box.cxx
@@ -26,15 +26,12 @@ void box()
    auto canvas = RCanvas::Create("RBox drawing");
 
    auto box1 = canvas->Draw<RBox>(RPadPos(0.1_normal, 0.3_normal), RPadPos(0.3_normal,0.6_normal));
-   RColor Color1(0, 255, 0, 0.5); // 50% opaque
-   RColor Color2(0, 0, 255, 0.7); // 70% opaque
-
-   box1->AttrBorder().SetColor(Color1).SetWidth(5);
-   box1->AttrFill().SetColor(RColor::kRed);
+   box1->AttrBorder().SetColor(RColor::kBlue).SetWidth(5);
+   box1->AttrFill().SetColor(RColor(0, 255, 0, 127)); // 50% opaque
 
    auto box2 = canvas->Draw<RBox>(RPadPos(0.4_normal, 0.2_normal), RPadPos(0.6_normal,0.7_normal));
-   box2->AttrBorder().SetColor(Color2).SetStyle(2).SetWidth(10);
-   box2->AttrFill().SetColor(RColor::kGreen);
+   box2->AttrBorder().SetColor(RColor::kRed).SetStyle(2).SetWidth(10);
+   box2->AttrFill().SetColor(RColor(0, 0, 255, 179)); // 70% opaque
 
    auto box3 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.4_normal), RPadPos(0.9_normal,0.6_normal));
    box3->AttrBorder().SetWidth(3);

--- a/tutorials/v7/box.py
+++ b/tutorials/v7/box.py
@@ -1,0 +1,41 @@
+## \file
+## \ingroup tutorial_v7
+##
+## This ROOT 7 example demonstrates how to create a ROOT 7 canvas (RCanvas) and
+## draw ROOT 7 boxes in it (RBox). It generates a set of boxes using the
+## "normal" coordinates' system.
+## Run macro with python3 -i box.py command to get interactive canvas
+##
+## \macro_image (rcanvas_js)
+## \macro_code
+##
+## \date 2021-06-15
+## \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+## is welcome!
+## \author Sergey Linev
+
+import ROOT
+from ROOT.Experimental import RCanvas, RBox, RPadPos, RColor
+
+# Create a canvas to be displayed.
+canvas = RCanvas.Create("RBox drawing")
+
+box1 = canvas.Draw[RBox](RPadPos(0.1, 0.1), RPadPos(0.3, 0.6))
+box1.AttrBorder().SetColor(RColor.kBlue).SetWidth(5)
+box1.AttrFill().SetColor(RColor(0, 255, 0, 127)) # 50% opaque
+
+box2 = canvas.Draw[RBox](RPadPos(0.4, 0.2), RPadPos(0.6, 0.7))
+box2.AttrBorder().SetColor(RColor.kRed).SetStyle(2).SetWidth(10)
+box2.AttrFill().SetColor(RColor(0, 0, 255, 179)) # 70% opaque
+
+box3 = canvas.Draw[RBox](RPadPos(0.7, 0.4), RPadPos(0.9, 0.6))
+box3.AttrBorder().SetWidth(3)
+box3.AttrFill().SetColor(RColor.kBlue)
+
+box4 = canvas.Draw[RBox](RPadPos(0.7, 0.7), RPadPos(0.9, 0.9))
+box4.AttrBorder().SetWidth(4)
+
+box5 = canvas.Draw[RBox](RPadPos(0.7, 0.1), RPadPos(0.9, 0.3))
+box5.AttrBorder().SetRx(10).SetRy(10).SetWidth(2)
+
+canvas.Show()

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -1,0 +1,226 @@
+## \file
+## \ingroup tutorial_v7
+## The Higgs to two photons analysis from the ATLAS Open Data 2020 release, with RDataFrame.
+##
+## This tutorial is the Higgs to two photons analysis from the ATLAS Open Data release in 2020
+## (http://opendata.atlas.cern/release/2020/documentation/). The data was taken with the ATLAS detector
+## during 2016 at a center-of-mass energy of 13 TeV. Although the Higgs to two photons decay is very rare,
+## the contribution of the Higgs can be seen as a narrow peak around 125 GeV because of the excellent
+## reconstruction and identification efficiency of photons at the ATLAS experiment.
+##
+## The analysis is translated to a RDataFrame workflow processing 1.7 GB of simulated events and data.
+##
+## This macro is replica of tutorials/dataframe/df104_HiggsToTwoPhotons.py, but with usage of ROOT7 graphics
+## Run macro with python3 -i df104.py command to get interactive canvas
+##
+## \macro_image (rcanvas_js)
+## \macro_code
+##
+## \date 2021-06-15
+## \authors Stefan Wunsch (KIT, CERN) Sergey Linev (GSI)
+
+import ROOT
+import os
+from ROOT.Experimental import RCanvas, RPad, RText, RLegend, RPadPos, RPadExtent, TObjectDrawable
+
+# Enable multi-threading
+ROOT.ROOT.EnableImplicitMT()
+
+# Create a ROOT dataframe for each dataset
+path = "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-01-22"
+df = {}
+df["data"] = ROOT.RDataFrame("mini", (os.path.join(path, "GamGam/Data/data_{}.GamGam.root".format(x)) for x in ("A", "B", "C", "D")))
+df["ggH"] = ROOT.RDataFrame("mini", os.path.join(path, "GamGam/MC/mc_343981.ggH125_gamgam.GamGam.root"))
+df["VBF"] = ROOT.RDataFrame("mini", os.path.join(path, "GamGam/MC/mc_345041.VBFH125_gamgam.GamGam.root"))
+processes = list(df.keys())
+
+# Apply scale factors and MC weight for simulated events and a weight of 1 for the data
+for p in ["ggH", "VBF"]:
+    df[p] = df[p].Define("weight",
+            "scaleFactor_PHOTON * scaleFactor_PhotonTRIGGER * scaleFactor_PILEUP * mcWeight");
+df["data"] = df["data"].Define("weight", "1.0")
+
+# Select the events for the analysis
+for p in processes:
+    # Apply preselection cut on photon trigger
+    df[p] = df[p].Filter("trigP")
+
+    # Find two good muons with tight ID, pt > 25 GeV and not in the transition region between barrel and encap
+    df[p] = df[p].Define("goodphotons", "photon_isTightID && (photon_pt > 25000) && (abs(photon_eta) < 2.37) && ((abs(photon_eta) < 1.37) || (abs(photon_eta) > 1.52))")\
+                 .Filter("Sum(goodphotons) == 2")
+
+    # Take only isolated photons
+    df[p] = df[p].Filter("Sum(photon_ptcone30[goodphotons] / photon_pt[goodphotons] < 0.065) == 2")\
+                 .Filter("Sum(photon_etcone20[goodphotons] / photon_pt[goodphotons] < 0.065) == 2")
+
+# Compile a function to compute the invariant mass of the diphoton system
+ROOT.gInterpreter.Declare(
+"""
+using Vec_t = const ROOT::VecOps::RVec<float>;
+float ComputeInvariantMass(Vec_t& pt, Vec_t& eta, Vec_t& phi, Vec_t& e) {
+    ROOT::Math::PtEtaPhiEVector p1(pt[0], eta[0], phi[0], e[0]);
+    ROOT::Math::PtEtaPhiEVector p2(pt[1], eta[1], phi[1], e[1]);
+    return (p1 + p2).mass() / 1000.0;
+}
+""")
+
+# Define a new column with the invariant mass and perform final event selection
+hists = {}
+for p in processes:
+    # Make four vectors and compute invariant mass
+    df[p] = df[p].Define("m_yy", "ComputeInvariantMass(photon_pt[goodphotons], photon_eta[goodphotons], photon_phi[goodphotons], photon_E[goodphotons])")
+
+    # Make additional kinematic cuts and select mass window
+    df[p] = df[p].Filter("photon_pt[goodphotons][0] / 1000.0 / m_yy > 0.35")\
+                 .Filter("photon_pt[goodphotons][1] / 1000.0 / m_yy > 0.25")\
+                 .Filter("m_yy > 105 && m_yy < 160")
+
+    # Book histogram of the invariant mass with this selection
+    hists[p] = df[p].Histo1D(
+            ROOT.RDF.TH1DModel(p, "Diphoton invariant mass; m_{#gamma#gamma} [GeV];Events", 30, 105, 160),
+            "m_yy", "weight")
+
+# Run the event loop
+
+# RunGraphs allows to run the event loops of the separate RDataFrame graphs
+# concurrently. This results in an improved usage of the available resources
+# if each separate RDataFrame can not utilize all available resources, e.g.,
+# because not enough data is available.
+ROOT.RDF.RunGraphs([hists[s] for s in ["ggH", "VBF", "data"]])
+
+ggh = hists["ggH"].GetValue()
+vbf = hists["VBF"].GetValue()
+data = hists["data"].GetValue()
+
+# Create the plot
+
+# Set styles - not yet available for v7
+# ROOT.gROOT.SetStyle("ATLAS")
+
+# Create canvas with pads for main plot and data/MC ratio
+c = RCanvas.Create("df104_HiggsToTwoPhotons")
+
+lower_pad = c.Draw[RPad](RPadPos(0,0.65), RPadExtent(1, 0.35))
+upper_pad = c.Draw[RPad](RPadPos(0,0), RPadExtent(1, 0.65))
+
+upper_frame = upper_pad.GetOrCreateFrame()
+upper_frame.AttrMargins().SetBottom(0).SetLeft(0.14).SetRight(0.05)
+upper_frame.AttrX().SetNoLabels()
+
+lower_frame = lower_pad.GetOrCreateFrame()
+lower_frame.AttrMargins().SetTop(0).SetLeft(0.14).SetRight(0.05).SetBottom(0.3)
+
+# Fit signal + background model to data
+fit = ROOT.TF1("fit", "([0]+[1]*x+[2]*x^2+[3]*x^3)+[4]*exp(-0.5*((x-[5])/[6])^2)", 105, 160)
+fit.FixParameter(5, 125.0)
+fit.FixParameter(4, 119.1)
+fit.FixParameter(6, 2.39)
+fit.SetLineColor(2)
+fit.SetLineStyle(1)
+fit.SetLineWidth(2)
+# do not draw fit function
+data.Fit("fit", "0", "", 105, 160)
+
+# Draw data
+data.SetMarkerStyle(20)
+data.SetMarkerSize(1.2)
+data.SetLineWidth(2)
+data.SetLineColor(ROOT.kBlack)
+data.SetMinimum(1e-3)
+data.SetMaximum(8e3)
+data.GetYaxis().SetLabelSize(0.045)
+data.GetYaxis().SetTitleSize(0.05)
+data.SetStats(0)
+data.SetTitle("")
+
+data_drawable = upper_pad.Draw[TObjectDrawable](data, "E")
+
+# Draw fit
+fit_drawable = upper_pad.Draw[TObjectDrawable](fit, "SAME")
+
+# Draw background
+bkg = ROOT.TF1("bkg", "([0]+[1]*x+[2]*x^2+[3]*x^3)", 105, 160)
+for i in range(4):
+    bkg.SetParameter(i, fit.GetParameter(i))
+bkg.SetLineColor(4)
+bkg.SetLineStyle(2)
+bkg.SetLineWidth(2)
+bkg_drawable = upper_pad.Draw[TObjectDrawable](bkg, "SAME")
+
+# Scale simulated events with luminosity * cross-section / sum of weights
+# and merge to single Higgs signal
+lumi = 10064.0
+ggh.Scale(lumi * 0.102 / 55922617.6297)
+vbf.Scale(lumi * 0.008518764 / 3441426.13711)
+higgs = ggh.Clone()
+higgs.Add(vbf)
+higgs_drawable = upper_pad.Draw[TObjectDrawable](higgs, "HIST SAME")
+
+
+# Draw ratio
+
+ratiobkg = ROOT.TH1I("zero", "", 10, 105, 160)
+ratiobkg.SetLineColor(4)
+ratiobkg.SetLineStyle(2)
+ratiobkg.SetLineWidth(2)
+ratiobkg.SetMinimum(-125)
+ratiobkg.SetMaximum(250)
+ratiobkg.GetXaxis().SetLabelSize(0.08)
+ratiobkg.GetXaxis().SetTitleSize(0.12)
+ratiobkg.GetXaxis().SetTitleOffset(1.0)
+ratiobkg.GetYaxis().SetLabelSize(0.08)
+ratiobkg.GetYaxis().SetTitleSize(0.09)
+ratiobkg.GetYaxis().SetTitle("Data - Bkg.")
+ratiobkg.GetYaxis().CenterTitle()
+ratiobkg.GetYaxis().SetTitleOffset(0.7)
+ratiobkg.GetYaxis().SetNdivisions(503, False)
+ratiobkg.GetYaxis().ChangeLabel(-1, -1, 0)
+ratiobkg.GetXaxis().SetTitle("m_{#gamma#gamma} [GeV]")
+lower_pad.Draw[TObjectDrawable](ratiobkg, "AXIS")
+
+ratiosig = ROOT.TH1F("ratiosig", "ratiosig", 5500, 105, 160)
+ratiosig.Eval(fit)
+ratiosig.SetLineColor(2)
+ratiosig.SetLineStyle(1)
+ratiosig.SetLineWidth(2)
+ratiosig.Add(bkg, -1)
+lower_pad.Draw[TObjectDrawable](ratiosig, "SAME")
+
+ratiodata = data.Clone()
+ratiodata.Add(bkg, -1)
+for i in range(1, data.GetNbinsX()):
+    ratiodata.SetBinError(i, data.GetBinError(i))
+
+lower_pad.Draw[TObjectDrawable](ratiodata, "E SAME")
+
+# Add legend
+# legend.SetTextFont(42)
+# legend.SetFillStyle(0)
+# legend.SetBorderSize(0)
+# legend.SetTextSize(0.05)
+# legend.SetTextAlign(32)
+
+legend = upper_pad.Draw[RLegend](RPadPos(-0.05, 0.05), RPadExtent(0.3, 0.4))
+legend.AttrText().SetFont(4).SetSize(0.05).SetAlign(32)
+legend.AttrBorder().SetStyle(0).SetWidth(0)
+legend.AttrFill().SetStyle(0)
+
+legend.AddEntry(data_drawable, "Data")
+legend.AddEntry(bkg_drawable, "Background")
+legend.AddEntry(fit_drawable, "Signal + Bkg.")
+legend.AddEntry(higgs_drawable, "Signal")
+
+# Add ATLAS label
+upper_pad.Draw[RText](RPadPos(0.05, 0.88), "ATLAS").SetOnFrame().AttrText().SetFont(7).SetSize(0.05).SetAlign(11)
+
+upper_pad.Draw[RText](RPadPos(0.05 + 0.16, 0.88), "Open Data").SetOnFrame().AttrText().SetFont(4).SetSize(0.05).SetAlign(11)
+
+upper_pad.Draw[RText](RPadPos(0.05, 0.82), "#sqrt{s} = 13 TeV, 10 fb^{-1}").SetOnFrame().AttrText().SetFont(4).SetSize(0.04).SetAlign(11)
+
+# show canvas finally
+c.SetSize(700, 780)
+c.Show()
+
+# Save plot in PNG file
+c.SaveAs("df104.png")
+print("Saved figure to df104.png")

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -105,7 +105,7 @@ upper_pad = c.Draw[RPad](RPadPos(0,0), RPadExtent(1, 0.65))
 
 upper_frame = upper_pad.GetOrCreateFrame()
 upper_frame.AttrMargins().SetBottom(0).SetLeft(0.14).SetRight(0.05)
-upper_frame.AttrX().SetNoLabels()
+upper_frame.AttrX().SetHideLabels()
 
 lower_frame = lower_pad.GetOrCreateFrame()
 lower_frame.AttrMargins().SetTop(0).SetLeft(0.14).SetRight(0.05).SetBottom(0.3)

--- a/tutorials/v7/draw_axes.cxx
+++ b/tutorials/v7/draw_axes.cxx
@@ -46,7 +46,7 @@ void draw_axes()
 
    auto draw4 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.3_normal), false, w1);
    draw4->SetMinMax(TDatime(2020,11,12,9,0,0).Convert(), TDatime(2020,11,12,12,0,0).Convert())
-          .AttrAxis().SetTimeDisplay("%d/%m/%y %H:%M").SetTitle("time display").LabelsAttr().SetSize(0.01).SetColor(RColor::kRed);
+          .AttrAxis().SetTimeDisplay("%d/%m/%y %H:%M").SetTitle("time display").AttrLabels().SetSize(0.01).SetColor(RColor::kRed);
 
    std::vector<std::string> labels = {"first", "second", "third", "forth", "fifth"};
    auto draw5 = canvas->Draw<RAxisLabelsDrawable>(RPadPos(x1, 0.1_normal), false, w1);
@@ -56,7 +56,7 @@ void draw_axes()
    draw6->SetMinMax(0, 10).AttrAxis().SetTitle("vertical negative length").SetEndingArrow();
 
    auto draw7 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.9_normal), false, w2);
-   draw7->SetMinMax(1, 100).AttrAxis().SetLog(10).SetTitle("log10 scale").SetTitleCenter().TitleAttr().SetFont(12).SetColor(RColor::kGreen);
+   draw7->SetMinMax(1, 100).AttrAxis().SetLog(10).SetTitle("log10 scale").SetTitleCenter().AttrTitle().SetFont(12).SetColor(RColor::kGreen);
 
    auto draw8 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.7_normal), false, w2);
    draw8->SetMinMax(0.125, 128).AttrAxis().SetLog(2).SetTitle("log2 scale").SetTitleCenter();

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -37,20 +37,25 @@ auto v6_style = RStyle::Parse("tgraph { line_width: 3; line_color: red; }");
 void draw_v6()
 {
    static constexpr int npoints = 10;
+   static constexpr int nth1points = 100;
+   static constexpr int nth2points = 40;
+
    double x[npoints] = { 1., 2., 3., 4., 5., 6., 7., 8., 9., 10. };
    double y[npoints] = { .1, .2, .3, .4, .3, .2, .1, .2, .3, .4 };
-   auto gr = std::make_shared<TGraph>(npoints, x, y);
+   auto gr = new TGraph(npoints, x, y);
 
-   static constexpr int nth1points = 100;
-   auto th1 = std::make_shared<TH1I>("gaus", "Example of TH1", nth1points, -5, 5);
-   th1->SetDirectory(nullptr);
+   // create normal object to be able draw it once
+   auto th1 = new TH1I("gaus", "Example of TH1", nth1points, -5, 5);
+   // it is recommended to set directory to nullptr, but it is also automatically done in TObjectDrawable
+   // th1->SetDirectory(nullptr);
    for (int n=0;n<nth1points;++n) {
       double x = 10.*n/nth1points-5.;
       th1->SetBinContent(n+1, (int) (1000*TMath::Gaus(x)));
    }
 
-   static constexpr int nth2points = 40;
+   // use std::shared_ptr<TH2I> to let draw same histogram twice with different draw options
    auto th2 = std::make_shared<TH2I>("gaus2", "Example of TH2", nth2points, -5, 5, nth2points, -5, 5);
+   // is is highly recommended to set directory to nullptr to avoid ownership conflicts
    th2->SetDirectory(nullptr);
    for (int n=0;n<nth2points;++n) {
       for (int k=0;k<nth2points;++k) {
@@ -78,6 +83,7 @@ void draw_v6()
    // Divide canvas on 2x2 sub-pads to show different draw options
    auto subpads = canvas->Divide(2,2);
 
+   // draw graph with "AL" option, drawable take over object ownership
    subpads[0][0]->Draw<TObjectDrawable>(gr, "AL");
 
    // one can change basic attributes via v7 classes, value will be replaced on client side
@@ -88,7 +94,7 @@ void draw_v6()
    // show same object again, but with other draw options
    subpads[1][1]->Draw<TObjectDrawable>(th2, "lego2");
 
-   // add style, here used to configure TGraph attrbutes, evaluated only on client side
+   // add style, here used to configure TGraph attributes, evaluated only on client side
    canvas->UseStyle(v6_style);
 
    // new window in web browser should popup and async update will be triggered

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -48,10 +48,7 @@ void draw_v6()
    auto th1 = new TH1I("gaus", "Example of TH1", nth1points, -5, 5);
    // it is recommended to set directory to nullptr, but it is also automatically done in TObjectDrawable
    // th1->SetDirectory(nullptr);
-   for (int n=0;n<nth1points;++n) {
-      double x = 10.*n/nth1points-5.;
-      th1->SetBinContent(n+1, (int) (1000*TMath::Gaus(x)));
-   }
+   th1->FillRandom("gaus", 5000);
 
    // use std::shared_ptr<TH2I> to let draw same histogram twice with different draw options
    auto th2 = std::make_shared<TH2I>("gaus2", "Example of TH2", nth2points, -5, 5, nth2points, -5, 5);


### PR DESCRIPTION
1. Provide return types in `RPadBase::Draw` methods instead of `auto` - PyROOT is not able to deduce type. Modify several other signatures to let use PyROOT without extra casting 
2. Improve `TObjectDrawable` - it can extract `Color_t` values and sends actual value to client, no need to always send full colors lists
3. Let handle `TH1`, `TF1` and `THStack` in TObjectDrawable
4. Improve `RLegend` to draw errors marker
5. Provide modified version of `df104.py` macro which works with ROOT7 graphics. 
