### PR TITLE
[RF] Avoid using RooCmdArg::_nextSharedData directly in header file

### DIFF
--- a/roofit/roofitcore/inc/RooCmdArg.h
+++ b/roofit/roofitcore/inc/RooCmdArg.h
@@ -100,8 +100,8 @@ public:
 
   template<class T>
   static T const& take(T && obj) {
-    _nextSharedData.emplace_back(new T{std::move(obj)});
-    return static_cast<T const&>(*_nextSharedData.back());
+    getNextSharedData().emplace_back(new T{std::move(obj)});
+    return static_cast<T const&>(*getNextSharedData().back());
   }
 
 protected:
@@ -128,6 +128,7 @@ private:
 
   // the next RooCmdArg created will take ownership of this data
   static DataCollection _nextSharedData;
+  static DataCollection &getNextSharedData();
   
   ClassDef(RooCmdArg,2) // Generic named argument container
 };

--- a/roofit/roofitcore/src/RooCmdArg.cxx
+++ b/roofit/roofitcore/src/RooCmdArg.cxx
@@ -232,3 +232,5 @@ void RooCmdArg::Print(const char*) const {
 }
 
 RooCmdArg::DataCollection RooCmdArg::_nextSharedData = RooCmdArg::DataCollection{};
+
+RooCmdArg::DataCollection &RooCmdArg::getNextSharedData() { return _nextSharedData; }


### PR DESCRIPTION
Calling `RooCmdArg::take` in `RooGlobalFunc.h` header can cause linker
errors, because it accesses a static data member. That's unsupported
across DLL boundaries on Windows.

This should fix the Windows 10 test errors that appeard after #8416.