### PR TITLE
[cling] Prevent memory leak of TClingDataMemberInfo::fClassInfo. (#7915)

### DIFF
--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -95,10 +95,16 @@ bool TClingDataMemberIter::ShouldSkip(const clang::UsingShadowDecl *USD) const
 TClingDataMemberInfo::TClingDataMemberInfo(cling::Interpreter *interp,
                                            TClingClassInfo *ci,
                                            TDictionary::EMemberSelection selection)
-: TClingDeclInfo(nullptr), fInterp(interp), fClassInfo(ci ? new TClingClassInfo(*ci) : new TClingClassInfo(interp))
+: TClingDeclInfo(nullptr), fInterp(interp)
 {
 
    R__LOCKGUARD(gInterpreterMutex);
+
+   if (ci) {
+      fClassInfo = *ci;
+   } else {
+      fClassInfo = TClingClassInfo(interp);
+   }
 
    if (!ci || !ci->IsValid()) {
       return;
@@ -113,8 +119,14 @@ TClingDataMemberInfo::TClingDataMemberInfo(cling::Interpreter *interp,
 TClingDataMemberInfo::TClingDataMemberInfo(cling::Interpreter *interp,
                                            const clang::ValueDecl *ValD,
                                            TClingClassInfo *ci)
-: TClingDeclInfo(ValD), fInterp(interp), fClassInfo(ci ? new TClingClassInfo(*ci) : new TClingClassInfo(interp))
+: TClingDeclInfo(ValD), fInterp(interp)
 {
+
+   if (ci) {
+      fClassInfo = *ci;
+   } else {
+      fClassInfo = TClingClassInfo(interp);
+   }
 
    using namespace llvm;
    const auto DC = ValD->getDeclContext();
@@ -176,7 +188,7 @@ const clang::ValueDecl *TClingDataMemberInfo::GetTargetValueDecl() const
 }
 
 const clang::Type *TClingDataMemberInfo::GetClassAsType() const {
-   return fClassInfo ? fClassInfo->GetType() : nullptr;
+   return fClassInfo.GetType();
 }
 
 int TClingDataMemberInfo::ArrayDim() const

--- a/core/metacling/src/TClingDataMemberInfo.h
+++ b/core/metacling/src/TClingDataMemberInfo.h
@@ -26,6 +26,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#include "TClingClassInfo.h"
 #include "TClingDeclInfo.h"
 #include "TClingMemberIter.h"
 #include "TDictionary.h"
@@ -44,8 +45,6 @@ namespace ROOT {
       class TNormalizedCtxt;
    }
 }
-
-class TClingClassInfo;
 
 /// Iterate over VarDecl, FieldDecl, EnumConstantDecl, IndirectFieldDecl, and 
 /// UsingShadowDecls thereof, within a scope, recursing through "transparent"
@@ -74,7 +73,7 @@ class TClingDataMemberInfo final : public TClingDeclInfo {
 private:
 
    cling::Interpreter    *fInterp;    // Cling interpreter, we do *not* own.
-   TClingClassInfo       *fClassInfo = nullptr; // ClassInfo for the decl context, for X<Float16_t> vs X<float>.
+   TClingClassInfo        fClassInfo; // ClassInfo for the decl context, for X<Float16_t> vs X<float>.
    TClingDataMemberIter   fIter; // Current decl.
    std::string            fTitle; // The meta info for the member.
    bool                   fFirstTime = true; // We need to skip the first increment to support the cint Next() semantics.

--- a/core/metacling/src/TClingDeclInfo.h
+++ b/core/metacling/src/TClingDeclInfo.h
@@ -31,6 +31,7 @@ protected:
    mutable std::string fNameCache;
    long Property(long property, clang::QualType &qt) const;
 public:
+   TClingDeclInfo() = default;
    TClingDeclInfo(const clang::Decl* D) : fDecl(D) {}
    virtual ~TClingDeclInfo();
 


### PR DESCRIPTION
(cherry picked from commit e6d16d66632a3f77b73b03c4547336f49a0cf2f0)
Backport of https://github.com/root-project/root/pull/7915
Per request https://github.com/root-project/root/issues/7207#issuecomment-862188934

