### PR TITLE
Simplify Doxyfile

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -846,7 +846,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = . \
+INPUT                  = ./mainpage.md \
                          ../../core/base/ \
                          ../../core/dictgen/ \
                          ../../core/cont/ \
@@ -1025,16 +1025,10 @@ EXCLUDE_PATTERNS       = */G__* \
                          */doc/v5* \
                          */win32gdk/gdk/* \
                          */bindings/pyroot/*.py \
-                         makeimage.C \
-                         makerootfile.C \
-                         libs.C \
-                         filter.cxx \
                          *gl2ps* \
                          *CsgOps* \
-                         converttonotebook.py \
-                         makeimage.py \
-                         parallelNotebooks.py \
                          LinkDef*.h \
+                         launcher.py \
                          */io/io/res/* \
                          */src/lexertk.hpp
 


### PR DESCRIPTION
With this PR the doxygen directory (./) is not included in the INPUT list of files. Only the top file `mainpage.md` is listed . This way we do not need to exclude the macros and scripts needed to build the documentation. Also the temporary file create in the doxygen directory do not pollute the list of files in the reference guide. Finally, the file `launcher.py` in the `tutorials` directory, is excluded from the reference guide.

