### PR TITLE
[ntuple] DAOS object class customization (2/2):  provide `RNTupleWriteOptionsDaos`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RDaos.hxx
@@ -155,7 +155,7 @@ private:
    daos_handle_t fContainerHandle{};
    uuid_t fContainerUuid{};
    std::shared_ptr<RDaosPool> fPool;
-   ObjClassId_t fDefaultObjectClass{OC_RP_XSF};
+   ObjClassId_t fDefaultObjectClass{OC_SX};
 
    /**
      \brief Perform a vector read/write operation on different objects.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -83,7 +83,7 @@ public:
 */
 // clang-format on
 class RNTupleWriteOptionsDaos : public RNTupleWriteOptions {
-  std::string fObjectClass{"RP_XSF"};
+  std::string fObjectClass{"SX"};
 
 public:
    virtual ~RNTupleWriteOptionsDaos() = default;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -52,6 +52,10 @@ class RNTupleWriteOptions {
    bool fUseBufferedWrite = true;
 
 public:
+   virtual ~RNTupleWriteOptions() = default;
+   virtual std::unique_ptr<RNTupleWriteOptions> Clone() const
+   { return std::make_unique<RNTupleWriteOptions>(*this); }
+
    int GetCompression() const { return fCompression; }
    void SetCompression(int val) { fCompression = val; }
    void SetCompression(RCompressionSetting::EAlgorithm algorithm, int compressionLevel) {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -75,6 +75,27 @@ public:
    void SetUseBufferedWrite(bool val) { fUseBufferedWrite = val; }
 };
 
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleWriteOptionsDaos
+\ingroup NTuple
+\brief DAOS-specific user-tunable settings for storing ntuples
+*/
+// clang-format on
+class RNTupleWriteOptionsDaos : public RNTupleWriteOptions {
+  std::string fObjectClass{"RP_XSF"};
+
+public:
+   virtual ~RNTupleWriteOptionsDaos() = default;
+   std::unique_ptr<RNTupleWriteOptions> Clone() const override
+   { return std::make_unique<RNTupleWriteOptionsDaos>(*this); }
+
+   const std::string &GetObjectClass() const { return fObjectClass; }
+   /// Set the object class used to generate OIDs that relate to user data. Any
+   /// `OC_xxx` constant defined in `daos_obj_class.h` may be used here without
+   /// the OC_ prefix.
+   void SetObjectClass(const std::string &val) { fObjectClass = val; }
+};
 
 // clang-format off
 /**

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -50,6 +50,9 @@ std::uint32_t SerializeUInt16(std::uint16_t val, void *buffer);
 std::uint32_t DeserializeInt16(const void *buffer, std::int16_t *val);
 std::uint32_t DeserializeUInt16(const void *buffer, std::uint16_t *val);
 
+std::uint32_t SerializeString(const std::string &val, void *buffer);
+std::uint32_t DeserializeString(const void *buffer, std::string *val);
+
 } // namespace RNTupleSerialization
 
 void PrintRNTuple(const RNTuple& ntuple, std::ostream& output);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -164,7 +164,7 @@ protected:
    std::unique_ptr<RCounters> fCounters;
    RNTupleMetrics fMetrics;
 
-   RNTupleWriteOptions fOptions;
+   std::unique_ptr<RNTupleWriteOptions> fOptions;
 
    /// Helper to zip pages and header/footer; includes a 16MB (kMAXZIPBUF) zip buffer.
    /// There could be concrete page sinks that don't need a compressor.  Therefore, and in order to stay consistent
@@ -226,7 +226,7 @@ public:
                                             const RNTupleWriteOptions &options = RNTupleWriteOptions());
    EPageStorageType GetType() final { return EPageStorageType::kSink; }
    /// Returns the sink's write options.
-   const RNTupleWriteOptions &GetWriteOptions() const { return fOptions; }
+   const RNTupleWriteOptions &GetWriteOptions() const { return *fOptions; }
 
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) final;
    void DropColumn(ColumnHandle_t /*columnHandle*/) final {}

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -45,7 +45,8 @@ class RDaosContainer;
 \ingroup NTuple
 \brief Entry point for an RNTuple in a DAOS container. It encodes essential
 information to read the ntuple; currently, it contains (un)compressed size of
-the header/footer blobs.
+the header/footer blobs and the object class for user data OIDs.
+The length of a serialized anchor cannot be greater than the value returned by the `GetSize` function.
 */
 // clang-format on
 struct RDaosNTupleAnchor {
@@ -59,20 +60,22 @@ struct RDaosNTupleAnchor {
    std::uint32_t fNBytesFooter = 0;
    /// The size of the uncompressed ntuple footer
    std::uint32_t fLenFooter = 0;
+   /// The object class for user data OIDs, e.g. `SX`
+   std::string fObjClass{};
 
    bool operator ==(const RDaosNTupleAnchor &other) const {
       return fVersion == other.fVersion &&
          fNBytesHeader == other.fNBytesHeader &&
          fLenHeader == other.fLenHeader &&
          fNBytesFooter == other.fNBytesFooter &&
-         fLenFooter == other.fLenFooter;
+         fLenFooter == other.fLenFooter &&
+         fObjClass == other.fObjClass;
    }
 
    std::uint32_t Serialize(void *buffer) const;
    std::uint32_t Deserialize(const void *buffer);
 
-   static std::uint32_t GetSize()
-   { return RDaosNTupleAnchor().Serialize(nullptr); }
+   static std::uint32_t GetSize();
 };
 
 // clang-format off
@@ -179,6 +182,9 @@ public:
                        RSealedPage &sealedPage) final;
 
    std::unique_ptr<RCluster> LoadCluster(DescriptorId_t clusterId, const ColumnSet_t &columns) final;
+
+   /// Return the object class used for user data OIDs in this ntuple.
+   std::string GetObjectClass() const;
 };
 
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -25,7 +25,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <cstring>
 #include <iostream>
 #include <utility>
 
@@ -63,27 +62,6 @@ std::uint32_t DeserializeClusterSize(const void *buffer, ROOT::Experimental::Clu
    auto nbytes = DeserializeUInt32(buffer, &size);
    *val = size;
    return nbytes;
-}
-
-std::uint32_t SerializeString(const std::string &val, void *buffer)
-{
-   if (buffer != nullptr) {
-      auto pos = reinterpret_cast<unsigned char *>(buffer);
-      pos += SerializeUInt32(val.length(), pos);
-      memcpy(pos, val.data(), val.length());
-   }
-   return SerializeUInt32(val.length(), nullptr) + val.length();
-}
-
-std::uint32_t DeserializeString(const void *buffer, std::string *val)
-{
-   auto base = reinterpret_cast<const unsigned char *>(buffer);
-   auto bytes = base;
-   std::uint32_t length;
-   bytes += DeserializeUInt32(buffer, &length);
-   val->resize(length);
-   memcpy(&(*val)[0], bytes, length);
-   return bytes + length - base;
 }
 
 std::uint32_t SerializeLocator(const ROOT::Experimental::RClusterDescriptor::RLocator &val, void *buffer)

--- a/tree/ntuple/v7/src/RNTupleUtil.cxx
+++ b/tree/ntuple/v7/src/RNTupleUtil.cxx
@@ -18,6 +18,7 @@
 #include "ROOT/RLogger.hxx"
 #include "ROOT/RMiniFile.hxx"
 
+#include <cstring>
 #include <iostream>
 
 ROOT::Experimental::RLogChannel &ROOT::Experimental::NTupleLog() {
@@ -124,6 +125,27 @@ std::uint32_t DeserializeInt16(const void *buffer, std::int16_t *val)
 std::uint32_t DeserializeUInt16(const void *buffer, std::uint16_t *val)
 {
    return DeserializeInt16(buffer, reinterpret_cast<std::int16_t *>(val));
+}
+
+std::uint32_t SerializeString(const std::string &val, void *buffer)
+{
+   if (buffer != nullptr) {
+      auto pos = reinterpret_cast<unsigned char *>(buffer);
+      pos += SerializeUInt32(val.length(), pos);
+      memcpy(pos, val.data(), val.length());
+   }
+   return SerializeUInt32(val.length(), nullptr) + val.length();
+}
+
+std::uint32_t DeserializeString(const void *buffer, std::string *val)
+{
+   auto base = reinterpret_cast<const unsigned char *>(buffer);
+   auto bytes = base;
+   std::uint32_t length;
+   bytes += DeserializeUInt32(buffer, &length);
+   val->resize(length);
+   memcpy(&(*val)[0], bytes, length);
+   return bytes + length - base;
 }
 
 } // namespace RNTupleSerialization

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -63,7 +63,7 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitPageImpl(ColumnHandle_t columnHa
    fTaskScheduler->AddTask([this, zipItem, colId = columnHandle.fId] {
       zipItem->fSealedPage = SealPage(zipItem->fPage,
          *fBufferedColumns.at(colId).GetHandle().fColumn->GetElement(),
-         fOptions.GetCompression(), zipItem->fBuf.get()
+         GetWriteOptions().GetCompression(), zipItem->fBuf.get()
       );
    });
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -229,7 +229,7 @@ void ROOT::Experimental::Detail::RPageSource::EnableDefaultMetrics(const std::st
 
 
 ROOT::Experimental::Detail::RPageSink::RPageSink(std::string_view name, const RNTupleWriteOptions &options)
-   : RPageStorage(name), fMetrics(""), fOptions(options)
+   : RPageStorage(name), fMetrics(""), fOptions(options.Clone())
 {
 }
 
@@ -297,7 +297,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
       columnRange.fColumnId = i;
       columnRange.fFirstElementIndex = 0;
       columnRange.fNElements = 0;
-      columnRange.fCompressionSettings = fOptions.GetCompression();
+      columnRange.fCompressionSettings = GetWriteOptions().GetCompression();
       fOpenColumnRanges.emplace_back(columnRange);
       RClusterDescriptor::RPageRange pageRange;
       pageRange.fColumnId = i;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -133,7 +133,7 @@ void ROOT::Experimental::Detail::RPageSinkDaos::CreateImpl(const RNTupleModel & 
    descriptor.SerializeHeader(buffer.get());
 
    auto zipBuffer = std::make_unique<unsigned char[]>(szHeader);
-   auto szZipHeader = fCompressor->Zip(buffer.get(), szHeader, fOptions.GetCompression(),
+   auto szZipHeader = fCompressor->Zip(buffer.get(), szHeader, GetWriteOptions().GetCompression(),
       [&zipBuffer](const void *b, size_t n, size_t o){ memcpy(zipBuffer.get() + o, b, n); } );
    WriteNTupleHeader(zipBuffer.get(), szZipHeader, szHeader);
 }
@@ -146,7 +146,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitPageImpl(ColumnHandle_t columnH
    RPageStorage::RSealedPage sealedPage;
    {
       RNTupleAtomicTimer timer(fCounters->fTimeWallZip, fCounters->fTimeCpuZip);
-      sealedPage = SealPage(page, *element, fOptions.GetCompression());
+      sealedPage = SealPage(page, *element, GetWriteOptions().GetCompression());
    }
 
    fCounters->fSzZip.Add(page.GetSize());
@@ -192,7 +192,7 @@ void ROOT::Experimental::Detail::RPageSinkDaos::CommitDatasetImpl()
    descriptor.SerializeFooter(buffer.get());
 
    auto zipBuffer = std::make_unique<unsigned char []>(szFooter);
-   auto szZipFooter = fCompressor->Zip(buffer.get(), szFooter, fOptions.GetCompression(),
+   auto szZipFooter = fCompressor->Zip(buffer.get(), szFooter, GetWriteOptions().GetCompression(),
       [&zipBuffer](const void *b, size_t n, size_t o){ memcpy(zipBuffer.get() + o, b, n); } );
    WriteNTupleFooter(zipBuffer.get(), szZipFooter, szFooter);
    WriteNTupleAnchor();
@@ -226,7 +226,7 @@ ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSinkDaos::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
 {
    if (nElements == 0)
-      nElements = fOptions.GetNElementsPerPage();
+      nElements = GetWriteOptions().GetNElementsPerPage();
    auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
    return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -93,7 +93,7 @@ void ROOT::Experimental::Detail::RPageSinkFile::CreateImpl(const RNTupleModel & 
    descriptor.SerializeHeader(buffer.get());
 
    auto zipBuffer = std::make_unique<unsigned char[]>(szHeader);
-   auto szZipHeader = fCompressor->Zip(buffer.get(), szHeader, fOptions.GetCompression(),
+   auto szZipHeader = fCompressor->Zip(buffer.get(), szHeader, GetWriteOptions().GetCompression(),
       [&zipBuffer](const void *b, size_t n, size_t o){ memcpy(zipBuffer.get() + o, b, n); } );
    fWriter->WriteNTupleHeader(zipBuffer.get(), szZipHeader, szHeader);
 }
@@ -127,7 +127,7 @@ ROOT::Experimental::Detail::RPageSinkFile::CommitPageImpl(ColumnHandle_t columnH
    RPageStorage::RSealedPage sealedPage;
    {
       RNTupleAtomicTimer timer(fCounters->fTimeWallZip, fCounters->fTimeCpuZip);
-      sealedPage = SealPage(page, *element, fOptions.GetCompression());
+      sealedPage = SealPage(page, *element, GetWriteOptions().GetCompression());
    }
 
    fCounters->fSzZip.Add(page.GetSize());
@@ -167,7 +167,7 @@ void ROOT::Experimental::Detail::RPageSinkFile::CommitDatasetImpl()
    descriptor.SerializeFooter(buffer.get());
 
    auto zipBuffer = std::make_unique<unsigned char []>(szFooter);
-   auto szZipFooter = fCompressor->Zip(buffer.get(), szFooter, fOptions.GetCompression(),
+   auto szZipFooter = fCompressor->Zip(buffer.get(), szFooter, GetWriteOptions().GetCompression(),
       [&zipBuffer](const void *b, size_t n, size_t o){ memcpy(zipBuffer.get() + o, b, n); } );
    fWriter->WriteNTupleFooter(zipBuffer.get(), szZipFooter, szFooter);
    fWriter->Commit();
@@ -178,7 +178,7 @@ ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSinkFile::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
 {
    if (nElements == 0)
-      nElements = fOptions.GetNElementsPerPage();
+      nElements = GetWriteOptions().GetNElementsPerPage();
    auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
    return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
 }

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -80,6 +80,7 @@ using RNTupleReader = ROOT::Experimental::RNTupleReader;
 using RNTupleReadOptions = ROOT::Experimental::RNTupleReadOptions;
 using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
 using RNTupleWriteOptions = ROOT::Experimental::RNTupleWriteOptions;
+using RNTupleWriteOptionsDaos = ROOT::Experimental::RNTupleWriteOptionsDaos;
 using RNTupleMetrics = ROOT::Experimental::Detail::RNTupleMetrics;
 using RNTupleModel = ROOT::Experimental::RNTupleModel;
 using RNTuplePlainCounter = ROOT::Experimental::Detail::RNTuplePlainCounter;


### PR DESCRIPTION
This pull-request is a follow-up of #8402.  `RNTupleWriteOptionsDaos`, i.e. a subclass of `RNTupleWriteOptions`, may now be used to provide DAOS-specific options.  Currently, we only support setting the object class used for user data OIDs.

## Changes or fixes:
- Contains the required changes to support backend-dependent options: classes derived from `RNTupleWriteOptions` may carry additional options.
- String serialization/deserialization routines moved to the `ROOT::Experimental::Internal::RNTupleSerialization` namespace, where they can be reused.
- RPageStorageDaos: the provided object class, if given, is used for generating the OIDs that relate to user data.  `OC_SX` is always used to store metadata (i.e. header/footer and anchor).  The object class must be known to read the ntuple; thus, the object class name is stored in the anchor.
- Changed the default object class for user data to the more conservative `OC_SX` (before was `OC_RP_XSF`).  `OC_SX` distributes data over all the targets and is probably a more sane default.

This PR closes issue #8205.