### PR TITLE
[rbrowsable] fix potential ownership problem

### DIFF
--- a/gui/browsable/inc/ROOT/Browsable/TObjectHolder.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectHolder.hxx
@@ -30,8 +30,15 @@ protected:
    void *AccessObject() final { return fOwner ? nullptr : fObj; }
    void *TakeObject() final;
    RHolder *DoCopy() const final { return new TObjectHolder(fObj); }
+   void ClearROOTOwnership(TObject *obj);
 public:
-   TObjectHolder(TObject *obj, bool owner = false) { fObj = obj; fOwner = owner; }
+   TObjectHolder(TObject *obj, bool owner = false)
+   {
+      fObj = obj;
+      fOwner = owner;
+      if (fOwner) ClearROOTOwnership(fObj);
+   }
+
    virtual ~TObjectHolder()
    {
       if (fOwner) delete fObj;


### PR DESCRIPTION
If objects like TH1 or TF1 should be owned by TObjectHolder,
unregister them from global lists which can destroy them
