### PR TITLE
Disable tutorials/legacy/thread/threadsh1.C

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -292,7 +292,9 @@ set(extra_veto
   tree/h1chain.C
   http/*.C
   eve7/*.C
-  r/rootlogon.C)
+  r/rootlogon.C
+  legacy/thread/threadsh1.C # disabled on 6.22 due to randomic failures on some platforms
+)
 
 set(all_veto hsimple.C
              geom/geometry.C


### PR DESCRIPTION
It causes randomic failures in our nightlies, and being in legacy
code we are happy with disabling the tutorial altogether.

As per the discussion at https://mattermost.web.cern.ch/root/pl/g8m58haqp7fejmn3wjumbur78y