### PR TITLE
[v624][RF] Fix missing initializer warnings in MemPoolForRooSets.h

### DIFF
--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -38,7 +38,8 @@ class MemPoolForRooSets {
     Arena()
       : ownedMemory{static_cast<RooSet_t *>(TStorage::ObjectAlloc(2 * POOLSIZE * sizeof(RooSet_t)))},
         memBegin{ownedMemory}, nextItem{ownedMemory},
-        memEnd{memBegin + 2 * POOLSIZE}
+        memEnd{memBegin + 2 * POOLSIZE},
+        cycle{}
     {}
 
     Arena(const Arena &) = delete;
@@ -47,7 +48,8 @@ class MemPoolForRooSets {
         memBegin{other.memBegin}, nextItem{other.nextItem}, memEnd{other.memEnd},
         refCount{other.refCount},
         totCount{other.totCount},
-        assigned{other.assigned}
+        assigned{other.assigned},
+        cycle{}
     {
       // Needed for unique ownership
       other.ownedMemory = nullptr;


### PR DESCRIPTION
This PR fixes build warnings in the v6.24 nightlies.

The same fix was originally done for v6.20 in https://github.com/root-project/root/pull/7995.