### PR TITLE
Fix compilation with gcc 8.2 and c++17

### DIFF
--- a/graf3d/eve7/src/REveCaloData.cxx
+++ b/graf3d/eve7/src/REveCaloData.cxx
@@ -264,7 +264,7 @@ Int_t REveCaloData::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
    for (auto &s : fSliceInfos)
    {
       nlohmann::json slice = {};
-      slice["name"]     = s.fName;
+      slice["name"]     = s.fName.Data();
       slice["threshold"] = s.fThreshold;
       slice["color"]    = s.fColor;
       sarr.push_back(slice);

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -152,7 +152,7 @@ static ParsedExpression ParseRDFExpression(std::string_view expr, const ColumnNa
       TString ss(s);
       TPRegexp dot("\\.");
       dot.Substitute(ss, "\\.", "g");
-      return std::string(std::move(ss));
+      return std::string(ss.Data());
    };
 
    ColumnNames_t varNames;
@@ -176,7 +176,7 @@ static ParsedExpression ParseRDFExpression(std::string_view expr, const ColumnNa
       replacer.Substitute(exprWithVars, varNames[varIdx], "g");
    }
 
-   return ParsedExpression{std::string(std::move(exprWithVars)), std::move(usedCols), std::move(varNames)};
+   return ParsedExpression{std::string(exprWithVars.Data()), std::move(usedCols), std::move(varNames)};
 }
 
 /// Return the static global map of Filter/Define lambda expressions that have been jitted.

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -118,7 +118,7 @@ static void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnName
       if (!branchDirectlyFromTree)
          branchDirectlyFromTree = t.FindBranch(fullName.c_str()); // try harder
       if (branchDirectlyFromTree)
-         UpdateList(bNamesReg, bNames, std::string(branchDirectlyFromTree->GetFullName()), friendName);
+         UpdateList(bNamesReg, bNames, std::string(branchDirectlyFromTree->GetFullName().Data()), friendName);
 
       if (t.GetBranch(subBranchName.c_str()))
          UpdateList(bNamesReg, bNames, subBranchName, friendName);


### PR DESCRIPTION
The changes in this pull request  fix several compilation errors when compiling with gcc 8.2 and c++17.
The errors are all of the type:
```
tree/dataframe/src/RDFInterfaceUtils.cxx:155:39: error: call of overloaded ‘basic_string(std::remove_reference<TString&>::type)’ is ambiguous
       return std::string(std::move(ss));
                                       ^
tree/dataframe/src/RDFInterfaceUtils.cxx:179:63: error: call of overloaded ‘basic_string(std::remove_reference<TString&>::type)’ is ambiguous
    return ParsedExpression{std::string(std::move(exprWithVars)), std::move(usedCols), std::move(varNames)};
                                                               ^
```


