### PR TITLE
[DF] Split `HeadNode` class in different head nodes according to data source

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -64,6 +64,11 @@ class BaseBackend(ABC):
     headers = set()
     shared_libraries = set()
 
+    # Define a minimum amount of partitions for any distributed RDataFrame.
+    # This is a safe lower limit, to account for backends that may not support
+    # the case where the distributed RDataFrame processes only one partition.
+    MIN_NPARTITIONS = 2
+
     @classmethod
     def register_initialization(cls, fun, *args, **kwargs):
         """

--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -305,12 +305,12 @@ class BaseBackend(ABC):
         """
         pass
 
-    def optimize_npartitions(self, npartitions):
+    def optimize_npartitions(self):
         """
         Distributed backends may optimize the number of partitions of the
         current dataset or leave it as it is.
         """
-        return npartitions
+        return self.MIN_NPARTITIONS
 
     def distribute_files(self, files_paths):
         """

--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
@@ -149,6 +149,15 @@ class SparkBackend(Base.BaseBackend):
             self.sc.addFile(filepath)
 
     def make_dataframe(self, *args, **kwargs):
-        """Creates an instance of SparkDataFrame"""
-        headnode = HeadNode.get_headnode(*args)
-        return DataFrame.RDataFrame(headnode, self, **kwargs)
+        """
+        Creates an instance of distributed RDataFrame that can send computations
+        to a Spark cluster.
+        """
+        # Set the number of partitions for this dataframe, one of the following:
+        # 1. User-supplied `npartitions` optional argument
+        # 2. An educated guess according to the backend, using the backend's
+        #    `optimize_npartitions` function
+        # 3. Set `npartitions` to 2
+        npartitions = kwargs.pop("npartitions", self.optimize_npartitions(Base.BaseBackend.MIN_NPARTITIONS))
+        headnode = HeadNode.get_headnode(npartitions, *args)
+        return DataFrame.RDataFrame(headnode, self)

--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
@@ -13,7 +13,7 @@
 import ntpath  # Filename from path (should be platform-independent)
 
 from DistRDF import DataFrame
-from DistRDF import Node
+from DistRDF import HeadNode
 from DistRDF.Backends import Base
 from DistRDF.Backends import Utils
 
@@ -150,5 +150,5 @@ class SparkBackend(Base.BaseBackend):
 
     def make_dataframe(self, *args, **kwargs):
         """Creates an instance of SparkDataFrame"""
-        headnode = Node.HeadNode(*args)
+        headnode = HeadNode.get_headnode(*args)
         return DataFrame.RDataFrame(headnode, self, **kwargs)

--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
@@ -64,16 +64,16 @@ class SparkBackend(Base.BaseBackend):
         else:
             self.sc = pyspark.SparkContext.getOrCreate()
 
-    def optimize_npartitions(self, npartitions):
+    def optimize_npartitions(self):
         numex = self.sc.getConf().get("spark.executor.instances")
         numcoresperex = self.sc.getConf().get("spark.executor.cores")
 
-        if numex:
-            if numcoresperex:
+        if numex is not None:
+            if numcoresperex is not None:
                 return int(numex) * int(numcoresperex)
             return int(numex)
         else:
-            return npartitions
+            return self.MIN_NPARTITIONS
 
     def ProcessAndMerge(self, ranges, mapper, reducer):
         """
@@ -158,6 +158,6 @@ class SparkBackend(Base.BaseBackend):
         # 2. An educated guess according to the backend, using the backend's
         #    `optimize_npartitions` function
         # 3. Set `npartitions` to 2
-        npartitions = kwargs.pop("npartitions", self.optimize_npartitions(Base.BaseBackend.MIN_NPARTITIONS))
+        npartitions = kwargs.pop("npartitions", self.optimize_npartitions())
         headnode = HeadNode.get_headnode(npartitions, *args)
         return DataFrame.RDataFrame(headnode, self)

--- a/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
+++ b/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
@@ -24,21 +24,12 @@ class RDataFrame(object):
     Interface to an RDataFrame that can run its computation graph distributedly.
     """
 
-    MIN_NPARTITIONS = 2
-
-    def __init__(self, headnode, backend, **kwargs):
+    def __init__(self, headnode, backend):
         """Initialization of """
 
         self._headnode = headnode
 
         self._headnode.backend = backend
-
-        # Set the number of partitions for this dataset, one of the following:
-        # 1. User-supplied `npartitions` optional argument
-        # 2. An educated guess according to the backend, using the backend's
-        #    `optimize_npartitions` function
-        # 3. Set `npartitions` to 2
-        self._headnode.npartitions = kwargs.get("npartitions", backend.optimize_npartitions(RDataFrame.MIN_NPARTITIONS))
 
         self._headproxy = Proxy.TransformationProxy(self._headnode)
 

--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -1,0 +1,378 @@
+import glob
+import logging
+import warnings
+
+import ROOT
+
+from DistRDF import Node
+
+logger = logging.getLogger(__name__)
+
+def get_headnode(*args):
+    """
+    A factory for different kinds of head nodes of the RDataFrame computation
+    graph, depending on the arguments to the RDataFrame constructor. Currently
+    can return a TreeHeadNode or an EmptySourceHeadNode. Parses the arguments and
+    compares them against the possible RDataFrame constructors.
+    """
+
+    # Early check that arguments are accepted by RDataFrame
+    try:
+        ROOT.RDataFrame(*args)
+    except TypeError:
+        raise TypeError(("The arguments provided are not accepted by any RDataFrame constructor. "
+                         "See the RDataFrame documentation for the accepted constructor argument types."))
+
+    firstarg = args[0]
+    if isinstance(firstarg, int):
+        # RDataFrame(ULong64_t numEntries)
+        return EmptySourceHeadNode(firstarg)
+    elif isinstance(firstarg, (ROOT.TTree, str)):
+        # RDataFrame(std::string_view treeName, filenameglob, defaultBranches = {})
+        # RDataFrame(std::string_view treename, filenames, defaultBranches = {})
+        # RDataFrame(std::string_view treeName, dirPtr, defaultBranches = {})
+        # RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches = {})
+        return TreeHeadNode(*args)
+    else:
+        raise RuntimeError(
+            ("First argument {} of type {} is not recognised as a supported "
+                "argument for distributed RDataFrame. Currently only TTree/Tchain "
+                "based datasets or datasets created from a number of entries "
+                "can be processed distributedly.").format(firstarg, type(firstarg)))
+
+
+class FriendInfo(object):
+    """
+    A simple class to hold information about friend trees.
+
+    Attributes:
+        friend_names (list): A list with the names of the `ROOT.TTree` objects
+            which are friends of the main `ROOT.TTree`.
+
+        friend_file_names (list): A list with the paths to the files
+            corresponding to the trees in the `friend_names` attribute. Each
+            element of `friend_names` can correspond to multiple file names.
+    """
+
+    def __init__(self, friend_names=[], friend_file_names=[]):
+        """
+        Create an instance of FriendInfo
+
+        Args:
+            friend_names (list): A list containing the treenames of the friend
+                trees.
+
+            friend_file_names (list): A list containing the file names
+                corresponding to a given treename in friend_names. Each
+                treename can correspond to multiple file names.
+        """
+        self.friend_names = friend_names
+        self.friend_file_names = friend_file_names
+
+    def __bool__(self):
+        """
+        Define the behaviour of FriendInfo instance when boolean evaluated.
+        Both lists have to be non-empty in order to return True.
+
+        Returns:
+            bool: True if both lists are non-empty, False otherwise.
+        """
+        return bool(self.friend_names) and bool(self.friend_file_names)
+
+    def __nonzero__(self):
+        """
+        Python 2 dunder method for __bool__. Kept for compatibility.
+        """
+        return self.__bool__()
+
+
+class EmptySourceHeadNode(Node.Node):
+    """
+    The head node of a computation graph where the RDataFrame data source is
+    empty and a number of sequential entries will be created at runtime. This
+    head node is responsible for the following RDataFrame constructor::
+
+        RDataFrame(ULong64_t numEntries)
+
+    Attributes:
+        nentries (int): The number of sequential entries the RDataFrame will create.
+
+        npartitions (int): The number of partitions the dataset will be split in
+            for distributed execution.
+    """
+
+    def __init__(self, nentries):
+        """
+        Creates a new RDataFrame instance for the given arguments.
+
+        Args:
+            nentries (int): The number of entries this RDataFrame will process.
+        """
+        super(EmptySourceHeadNode, self).__init__(None, None)
+
+        self.nentries = nentries
+        # Set at creation of the dataframe, might be optimized by the backend
+        # in optimize_partitions
+        self.npartitions = 2
+
+    def build_ranges(self):
+        """Build the ranges for this dataset."""
+        # Empty datasets cannot be processed distributedly
+        if not self.nentries:
+            raise RuntimeError(
+                ("Cannot build a distributed RDataFrame with zero entries. "
+                 "Distributed computation will fail. "))
+        if self.npartitions > self.nentries:
+            # Restrict 'npartitions' if it's greater than 'nentries'
+            msg = ("Number of partitions {0} is greater than number of entries {1} "
+                   "in the dataframe. Using {1} partition(s)".format(self.npartitions, self.nentries))
+            warnings.warn(msg, UserWarning, stacklevel=2)
+            self.npartitions = self.nentries
+        return Node.RangesBuilder(self)._get_balanced_ranges(self.nentries)
+
+
+class TreeHeadNode(Node.Node):
+    """
+    The head node of a computation graph where the RDataFrame data source is
+    a TTree. This head node is responsible for the following RDataFrame constructor::
+
+        RDataFrame(std::string_view treeName, std::string_view filenameglob, const ColumnNames_t &defaultBranches = {})
+        RDataFrame(std::string_view treename, const std::vector<std::string> &fileglobs, const ColumnNames_t &defaultBranches = {})
+        RDataFrame(std::string_view treeName, TDirectory *dirPtr, const ColumnNames_t &defaultBranches = {})
+        RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches = {})
+
+    Attributes:
+        args (iterable): An iterable of arguments that were provided to construct
+            the RDataFrame object.
+
+        npartitions (int): The number of partitions the dataset will be split in
+            for distributed execution.
+    """
+
+    def __init__(self, *args):
+        """
+        Creates a new RDataFrame instance for the given arguments.
+
+        Args:
+            *args (iterable): Iterable with the arguments to the RDataFrame constructor.
+        """
+        super(TreeHeadNode, self).__init__(None, None)
+
+        # Keep the arguments to parse them when needed
+        self.args = args
+        # Set at creation of the dataframe, might be optimized by the backend
+        # in optimize_partitions
+        self.npartitions = 2
+
+    @property
+    def tree(self):
+        """Tree instance if present."""
+        return self.get_tree()
+
+    @property
+    def treename(self):
+        """Name of the tree."""
+        return self.get_treename()
+
+    @property
+    def nentries(self):
+        """Entries of this dataset."""
+        return self.get_num_entries()
+
+    @property
+    def defaultbranches(self):
+        """Default branches selected by the user in the constructor."""
+        return self.get_branches()
+
+    @property
+    def inputfiles(self):
+        """List of input files of the dataset."""
+        return self.get_inputfiles()
+
+    @property
+    def friendinfo(self):
+        """Information about friend trees of the dataset."""
+        return self._get_friend_info()
+
+    def get_branches(self):
+        """Gets list of default branches if passed by the user."""
+        # ROOT Constructor:
+        # RDataFrame(TTree& tree, defaultBranches = {})
+        if len(self.args) == 2 and isinstance(self.args[0], ROOT.TTree):
+            return self.args[1]
+        # ROOT Constructors:
+        # RDataFrame(treeName, filenameglob, defaultBranches = {})
+        # RDataFrame(treename, filenames, defaultBranches = {})
+        # RDataFrame(treeName, dirPtr, defaultBranches = {})
+        if len(self.args) == 3:
+            return self.args[2]
+
+        return None
+
+    def get_num_entries(self):
+        """
+        Gets the number of entries in the given dataset.
+
+        Returns:
+            int: This is the computed number of entries in the input dataset.
+
+        """
+        # First argument can be a string or a TTree/TChain
+        firstarg = self.args[0]
+        if isinstance(firstarg, ROOT.TTree):
+            # If the argument is a TTree or TChain,
+            # get the number of entries from it.
+            return firstarg.GetEntries()
+        elif isinstance(firstarg, str):
+            # Construct a ROOT.TChain object with the name of the tree
+            chain = ROOT.TChain(firstarg)
+
+            # Add the list of input files to the chain
+            for fname in self.inputfiles:
+                chain.Add(fname)
+
+            return chain.GetEntries()
+
+    def get_treename(self):
+        """
+        Get name of the TTree.
+
+        Returns:
+            (str, None): Name of the TTree, or :obj:`None` if there is no tree.
+
+        """
+        first_arg = self.args[0]
+        if isinstance(first_arg, ROOT.TTree):
+            # Get name from a given TTree/TChain
+            return first_arg.GetName()
+        elif isinstance(first_arg, str):
+            # First argument was the name of the tree
+            return first_arg
+
+    def get_tree(self):
+        """
+        Get ROOT.TTree instance given as constructor argument.
+
+        Returns:
+            (ROOT.TTree, None): instance of the tree used to instantiate the
+            RDataFrame, or `None` if another object was used. ROOT.Tchain
+            inherits from ROOT.TTree so that can be the return value as well.
+        """
+        first_arg = self.args[0]
+        if isinstance(first_arg, ROOT.TTree):
+            return first_arg
+
+        return None
+
+    def get_inputfiles(self):
+        """
+        Get list of input files.
+
+        Returns:
+            (list): List of input files of the dataset.
+
+        """
+        firstarg = self.args[0]
+        if isinstance(firstarg, ROOT.TChain):
+            # Extract file names from a given TChain
+            chain = firstarg
+            return [chainElem.GetTitle()
+                    for chainElem in chain.GetListOfFiles()]
+        elif isinstance(firstarg, ROOT.TTree):
+            # Retrieve the associated file
+            treefile = firstarg.GetCurrentFile()
+            if not treefile:
+                # The tree has no associated input file
+                raise RuntimeError(("Trees with no associated files are not supported. "
+                                    "Please save your tree to a file and retry."))
+            else:
+                return [treefile.GetName()]
+
+        if len(self.args) > 1:
+            # Second argument can be:
+            # 1. A simple string representing a file or a glob of files
+            # 2. A vector of filename strings
+            # 3. A pointer to a TDirectory (i.e. the file of the dataset)
+            secondarg = self.args[1]
+            if isinstance(secondarg, str):
+                # Expand globbing excluding remote files
+                remote_prefixes = ("root:", "http:", "https:")
+                if not secondarg.startswith(remote_prefixes):
+                    return glob.glob(secondarg)
+                else:
+                    return [secondarg]
+            elif isinstance(secondarg, (list, ROOT.std.vector("string"))):
+                # Make sure this returns a list of Python strings
+                return [str(filename) for filename in secondarg]
+            elif isinstance(secondarg, ROOT.TDirectory):
+                # Return the name of the file
+                return [str(secondarg.GetName())]
+
+    def _get_friend_info(self):
+        """
+        Retrieve friend tree names and filenames of a given `ROOT.TTree`
+        object.
+
+        Args:
+            tree (ROOT.TTree): the ROOT.TTree instance used as an argument to
+                DistRDF.RDataFrame(). ROOT.TChain inherits from ROOT.TTree so it
+                is a valid argument too.
+
+        Returns:
+            (FriendInfo): A FriendInfo instance with two lists as variables.
+                The first list holds the names of the friend tree(s), the
+                second list holds the file names of each of the trees in the
+                first list, each tree name can correspond to multiple file
+                names.
+        """
+        friend_names = []
+        friend_file_names = []
+
+        # Retrieve the TTree instance
+        tree = self.get_tree()
+
+        # Early return if the dataframe wasn't constructed from a TTree.
+        if tree is None:
+            return FriendInfo()
+
+        # Get a list of ROOT.TFriendElement objects
+        friends = tree.GetListOfFriends()
+        if not friends:
+            # RDataFrame may have been created with a TTree without
+            # friend trees.
+            return FriendInfo()
+
+        for friend in friends:
+            friend_tree = friend.GetTree()  # ROOT.TTree
+            real_name = friend_tree.GetName()  # Treename as string
+
+            # TChain inherits from TTree
+            if isinstance(friend_tree, ROOT.TChain):
+                cur_friend_files = [
+                    # The title of a TFile is the file name
+                    chain_file.GetTitle()
+                    for chain_file
+                    # Get a list of ROOT.TFile objects
+                    in friend_tree.GetListOfFiles()
+                ]
+
+            else:
+                cur_friend_files = [
+                    friend_tree.
+                    GetCurrentFile().  # ROOT.TFile
+                    GetName()  # Filename as string
+                ]
+            friend_file_names.append(cur_friend_files)
+            friend_names.append(real_name)
+
+        return FriendInfo(friend_names, friend_file_names)
+
+    def build_ranges(self):
+        """Build the ranges for this dataset."""
+        # Empty datasets cannot be processed distributedly
+        if not self.nentries:
+            raise RuntimeError(
+                ("Cannot build a distributed RDataFrame with zero entries. "
+                 "Distributed computation will fail. "))
+
+        return Node.RangesBuilder(self)._get_clustered_ranges(self.treename, self.inputfiles, self._get_friend_info())

--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -159,36 +159,45 @@ class TreeHeadNode(Node.Node):
         super(TreeHeadNode, self).__init__(None, None)
 
         # Keep the arguments to parse them when needed
+        # TODO: Instead of storing the args here and parsing them various times
+        # in different class methods, parse them only once in this function and
+        # directly store the appropriate data members
         self.args = args
         # Set at creation of the dataframe, might be optimized by the backend
         # in optimize_partitions
         self.npartitions = 2
 
+    # TODO: Decide whether to remove/change the property or the getter
     @property
     def tree(self):
         """Tree instance if present."""
         return self.get_tree()
 
+    # TODO: Decide whether to remove/change the property or the getter
     @property
     def treename(self):
         """Name of the tree."""
         return self.get_treename()
 
+    # TODO: Decide whether to remove/change the property or the getter
     @property
     def nentries(self):
         """Entries of this dataset."""
         return self.get_num_entries()
 
+    # TODO: Decide whether to remove/change the property or the getter
     @property
     def defaultbranches(self):
         """Default branches selected by the user in the constructor."""
         return self.get_branches()
 
+    # TODO: Decide whether to remove/change the property or the getter
     @property
     def inputfiles(self):
         """List of input files of the dataset."""
         return self.get_inputfiles()
 
+    # TODO: Decide whether to remove/change the property or the getter
     @property
     def friendinfo(self):
         """Information about friend trees of the dataset."""
@@ -209,6 +218,8 @@ class TreeHeadNode(Node.Node):
 
         return None
 
+    # TODO: This function is very costly! Make sure to use only once at most, 
+    # or think if it can be avoided altogether.
     def get_num_entries(self):
         """
         Gets the number of entries in the given dataset.

--- a/bindings/experimental/distrdf/python/DistRDF/Node.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Node.py
@@ -9,9 +9,6 @@
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
-
-from __future__ import print_function
-
 import collections
 import glob
 import logging

--- a/bindings/experimental/distrdf/python/DistRDF/Node.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Node.py
@@ -232,7 +232,8 @@ class Node(object):
         self.children = children
         return self.is_prunable()
 
-
+# TODO: RangesBuilder class should be removed and its methods should become
+# free functions.
 class RangesBuilder(object):
 
     def __init__(self, headnode):

--- a/bindings/experimental/distrdf/test/backend/test_dist.py
+++ b/bindings/experimental/distrdf/test/backend/test_dist.py
@@ -1,6 +1,6 @@
 import unittest
 
-from DistRDF import Node
+from DistRDF import HeadNode
 from DistRDF import Proxy
 from DistRDF.Backends import Base
 
@@ -81,7 +81,7 @@ class DistRDataFrameInterface(unittest.TestCase):
         def __init__(self, *args):
             """initialize"""
 
-            self.headnode = Node.HeadNode(*args)
+            self.headnode = HeadNode.get_headnode(*args)
 
             self.headnode.backend = DistRDataFrameInterface.TestBackend()
 

--- a/bindings/experimental/distrdf/test/backend/test_dist.py
+++ b/bindings/experimental/distrdf/test/backend/test_dist.py
@@ -81,7 +81,8 @@ class DistRDataFrameInterface(unittest.TestCase):
         def __init__(self, *args):
             """initialize"""
 
-            self.headnode = HeadNode.get_headnode(*args, npartitions=None)
+            # Passing None as `npartitions`, the tests will change it as needed.
+            self.headnode = HeadNode.get_headnode(None, *args)
 
             self.headnode.backend = DistRDataFrameInterface.TestBackend()
 

--- a/bindings/experimental/distrdf/test/backend/test_dist.py
+++ b/bindings/experimental/distrdf/test/backend/test_dist.py
@@ -81,7 +81,7 @@ class DistRDataFrameInterface(unittest.TestCase):
         def __init__(self, *args):
             """initialize"""
 
-            self.headnode = HeadNode.get_headnode(*args)
+            self.headnode = HeadNode.get_headnode(*args, npartitions=None)
 
             self.headnode.backend = DistRDataFrameInterface.TestBackend()
 
@@ -97,6 +97,7 @@ class DistRDataFrameInterface(unittest.TestCase):
         on its parameters.
         """
         headnode = rdf.headnode
+        headnode.npartitions = 2
 
         hist = rdf.Define("b1", "tdfentry_")\
                   .Histo1D("b1")
@@ -106,7 +107,6 @@ class DistRDataFrameInterface(unittest.TestCase):
         # the RDataFrame head node
         hist.GetValue()
 
-        headnode.npartitions = 2
         ranges = rangesToTuples(headnode.build_ranges())
         return ranges
 

--- a/bindings/experimental/distrdf/test/backend/test_spark.py
+++ b/bindings/experimental/distrdf/test/backend/test_spark.py
@@ -70,7 +70,7 @@ class SparkBackendInitTest(unittest.TestCase):
         sc = pyspark.SparkContext(conf=sconf)
         backend = Backend.SparkBackend(sparkcontext=sc)
 
-        self.assertEqual(backend.optimize_npartitions(1), 10)
+        self.assertEqual(backend.optimize_npartitions(), 10)
 
 
 class OperationSupportTest(unittest.TestCase):

--- a/bindings/experimental/distrdf/test/test_buildranges.py
+++ b/bindings/experimental/distrdf/test/test_buildranges.py
@@ -9,6 +9,13 @@ def rangesToTuples(ranges):
     return list(map(lambda r: (r.start, r.end), ranges))
 
 
+def create_dummy_headnode(*args):
+    """Create dummy head node instance needed in the test"""
+    # Pass None as `npartitions`. The tests will modify this member
+    # according to needs
+    return get_headnode(None, *args)
+
+
 class BuildRangesTest(unittest.TestCase):
     """
     Test the building of ranges with information from the head node of the graph
@@ -21,7 +28,7 @@ class BuildRangesTest(unittest.TestCase):
         number of partitions.
 
         """
-        headnode = get_headnode(1, npartitions=None)
+        headnode = create_dummy_headnode(1)
         builder = RangesBuilder(headnode)
 
         nentries_small = 10
@@ -60,7 +67,7 @@ class BuildRangesTest(unittest.TestCase):
         the number of partitions.
 
         """
-        headnode = get_headnode(1, npartitions=None)
+        headnode = create_dummy_headnode(1)
         builder = RangesBuilder(headnode)
 
         nentries_1 = 10
@@ -90,7 +97,7 @@ class BuildRangesTest(unittest.TestCase):
         number of partitions.
 
         """
-        headnode = get_headnode(1, npartitions=None)
+        headnode = create_dummy_headnode(1)
         builder = RangesBuilder(headnode)
 
         nentries = 5
@@ -109,7 +116,7 @@ class BuildRangesTest(unittest.TestCase):
         contains a single cluster and the number of partitions is 1
 
         """
-        headnode = get_headnode(1, npartitions=None)
+        headnode = create_dummy_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "TotemNtuple"
@@ -130,7 +137,7 @@ class BuildRangesTest(unittest.TestCase):
 
         """
 
-        headnode = get_headnode(1, npartitions=None)
+        headnode = create_dummy_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "TotemNtuple"
@@ -157,7 +164,7 @@ class BuildRangesTest(unittest.TestCase):
         different numbers of entries.
 
         """
-        headnode = get_headnode(1, npartitions=None)
+        headnode = create_dummy_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -180,7 +187,7 @@ class BuildRangesTest(unittest.TestCase):
         possible for four partitions
 
         """
-        headnode = get_headnode(1, npartitions=None)
+        headnode = create_dummy_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -205,7 +212,7 @@ class BuildRangesTest(unittest.TestCase):
         possible for four partitions
 
         """
-        headnode = get_headnode(1, npartitions=None)
+        headnode = create_dummy_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -231,7 +238,7 @@ class BuildRangesTest(unittest.TestCase):
         clusters)
 
         """
-        headnode = get_headnode(1, npartitions=None)
+        headnode = create_dummy_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -256,7 +263,7 @@ class BuildRangesTest(unittest.TestCase):
         contains clusters.
 
         """
-        headnode = get_headnode("myTree", "backend/1000clusters.root", npartitions=None)
+        headnode = create_dummy_headnode("myTree", "backend/1000clusters.root")
         builder = RangesBuilder(headnode)
 
         headnode.npartitions = 1000
@@ -279,7 +286,7 @@ class BuildRangesTest(unittest.TestCase):
         clusters involved.
 
         """
-        headnode = get_headnode(50, npartitions=None)
+        headnode = create_dummy_headnode(50)
         builder = RangesBuilder(headnode)
 
         headnode.npartitions = 16

--- a/bindings/experimental/distrdf/test/test_buildranges.py
+++ b/bindings/experimental/distrdf/test/test_buildranges.py
@@ -21,7 +21,7 @@ class BuildRangesTest(unittest.TestCase):
         number of partitions.
 
         """
-        headnode = get_headnode(1)
+        headnode = get_headnode(1, npartitions=None)
         builder = RangesBuilder(headnode)
 
         nentries_small = 10
@@ -60,7 +60,7 @@ class BuildRangesTest(unittest.TestCase):
         the number of partitions.
 
         """
-        headnode = get_headnode(1)
+        headnode = get_headnode(1, npartitions=None)
         builder = RangesBuilder(headnode)
 
         nentries_1 = 10
@@ -90,7 +90,7 @@ class BuildRangesTest(unittest.TestCase):
         number of partitions.
 
         """
-        headnode = get_headnode(1)
+        headnode = get_headnode(1, npartitions=None)
         builder = RangesBuilder(headnode)
 
         nentries = 5
@@ -109,7 +109,7 @@ class BuildRangesTest(unittest.TestCase):
         contains a single cluster and the number of partitions is 1
 
         """
-        headnode = get_headnode(1)
+        headnode = get_headnode(1, npartitions=None)
         builder = RangesBuilder(headnode)
 
         treename = "TotemNtuple"
@@ -130,7 +130,7 @@ class BuildRangesTest(unittest.TestCase):
 
         """
 
-        headnode = get_headnode(1)
+        headnode = get_headnode(1, npartitions=None)
         builder = RangesBuilder(headnode)
 
         treename = "TotemNtuple"
@@ -157,7 +157,7 @@ class BuildRangesTest(unittest.TestCase):
         different numbers of entries.
 
         """
-        headnode = get_headnode(1)
+        headnode = get_headnode(1, npartitions=None)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -180,7 +180,7 @@ class BuildRangesTest(unittest.TestCase):
         possible for four partitions
 
         """
-        headnode = get_headnode(1)
+        headnode = get_headnode(1, npartitions=None)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -205,7 +205,7 @@ class BuildRangesTest(unittest.TestCase):
         possible for four partitions
 
         """
-        headnode = get_headnode(1)
+        headnode = get_headnode(1, npartitions=None)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -231,7 +231,7 @@ class BuildRangesTest(unittest.TestCase):
         clusters)
 
         """
-        headnode = get_headnode(1)
+        headnode = get_headnode(1, npartitions=None)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -256,7 +256,7 @@ class BuildRangesTest(unittest.TestCase):
         contains clusters.
 
         """
-        headnode = get_headnode("myTree", "backend/1000clusters.root")
+        headnode = get_headnode("myTree", "backend/1000clusters.root", npartitions=None)
         builder = RangesBuilder(headnode)
 
         headnode.npartitions = 1000
@@ -279,7 +279,7 @@ class BuildRangesTest(unittest.TestCase):
         clusters involved.
 
         """
-        headnode = get_headnode(50)
+        headnode = get_headnode(50, npartitions=None)
         builder = RangesBuilder(headnode)
 
         headnode.npartitions = 16

--- a/bindings/experimental/distrdf/test/test_buildranges.py
+++ b/bindings/experimental/distrdf/test/test_buildranges.py
@@ -1,4 +1,4 @@
-from DistRDF.Node import HeadNode
+from DistRDF.HeadNode import get_headnode
 from DistRDF.Node import RangesBuilder
 import warnings
 import unittest
@@ -21,7 +21,7 @@ class BuildRangesTest(unittest.TestCase):
         number of partitions.
 
         """
-        headnode = HeadNode(1)
+        headnode = get_headnode(1)
         builder = RangesBuilder(headnode)
 
         nentries_small = 10
@@ -60,7 +60,7 @@ class BuildRangesTest(unittest.TestCase):
         the number of partitions.
 
         """
-        headnode = HeadNode(1)
+        headnode = get_headnode(1)
         builder = RangesBuilder(headnode)
 
         nentries_1 = 10
@@ -90,7 +90,7 @@ class BuildRangesTest(unittest.TestCase):
         number of partitions.
 
         """
-        headnode = HeadNode(1)
+        headnode = get_headnode(1)
         builder = RangesBuilder(headnode)
 
         nentries = 5
@@ -109,7 +109,7 @@ class BuildRangesTest(unittest.TestCase):
         contains a single cluster and the number of partitions is 1
 
         """
-        headnode = HeadNode(1)
+        headnode = get_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "TotemNtuple"
@@ -130,7 +130,7 @@ class BuildRangesTest(unittest.TestCase):
 
         """
 
-        headnode = HeadNode(1)
+        headnode = get_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "TotemNtuple"
@@ -157,7 +157,7 @@ class BuildRangesTest(unittest.TestCase):
         different numbers of entries.
 
         """
-        headnode = HeadNode(1)
+        headnode = get_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -180,7 +180,7 @@ class BuildRangesTest(unittest.TestCase):
         possible for four partitions
 
         """
-        headnode = HeadNode(1)
+        headnode = get_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -205,7 +205,7 @@ class BuildRangesTest(unittest.TestCase):
         possible for four partitions
 
         """
-        headnode = HeadNode(1)
+        headnode = get_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -231,7 +231,7 @@ class BuildRangesTest(unittest.TestCase):
         clusters)
 
         """
-        headnode = HeadNode(1)
+        headnode = get_headnode(1)
         builder = RangesBuilder(headnode)
 
         treename = "myTree"
@@ -256,7 +256,7 @@ class BuildRangesTest(unittest.TestCase):
         contains clusters.
 
         """
-        headnode = HeadNode("myTree", "backend/1000clusters.root")
+        headnode = get_headnode("myTree", "backend/1000clusters.root")
         builder = RangesBuilder(headnode)
 
         headnode.npartitions = 1000
@@ -279,7 +279,7 @@ class BuildRangesTest(unittest.TestCase):
         clusters involved.
 
         """
-        headnode = HeadNode(50)
+        headnode = get_headnode(50)
         builder = RangesBuilder(headnode)
 
         headnode.npartitions = 16

--- a/bindings/experimental/distrdf/test/test_callable_generator.py
+++ b/bindings/experimental/distrdf/test/test_callable_generator.py
@@ -58,7 +58,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         t = ComputationGraphGeneratorTest.Temp()
 
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
         node = Proxy.TransformationProxy(hn)
         # Set of operations to build the graph
@@ -91,7 +91,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         t = ComputationGraphGeneratorTest.Temp()
 
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
         node = Proxy.TransformationProxy(hn)
 

--- a/bindings/experimental/distrdf/test/test_callable_generator.py
+++ b/bindings/experimental/distrdf/test/test_callable_generator.py
@@ -4,6 +4,13 @@ from DistRDF import ComputationGraphGenerator, HeadNode, Proxy
 from DistRDF.Backends import Base
 
 
+def create_dummy_headnode(*args):
+    """Create dummy head node instance needed in the test"""
+    # Pass None as `npartitions`. The tests will modify this member
+    # according to needs
+    return HeadNode.get_headnode(None, *args)
+
+
 class ComputationGraphGeneratorTest(unittest.TestCase):
     """
     Check mechanism to create a callable function that returns a PyROOT object
@@ -58,7 +65,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         t = ComputationGraphGeneratorTest.Temp()
 
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
         node = Proxy.TransformationProxy(hn)
         # Set of operations to build the graph
@@ -91,7 +98,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         t = ComputationGraphGeneratorTest.Temp()
 
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
         node = Proxy.TransformationProxy(hn)
 

--- a/bindings/experimental/distrdf/test/test_callable_generator.py
+++ b/bindings/experimental/distrdf/test/test_callable_generator.py
@@ -1,6 +1,6 @@
 import unittest
 
-from DistRDF import ComputationGraphGenerator, Node, Proxy
+from DistRDF import ComputationGraphGenerator, HeadNode, Proxy
 from DistRDF.Backends import Base
 
 
@@ -58,7 +58,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         t = ComputationGraphGeneratorTest.Temp()
 
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
         node = Proxy.TransformationProxy(hn)
         # Set of operations to build the graph
@@ -91,7 +91,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         t = ComputationGraphGeneratorTest.Temp()
 
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
         node = Proxy.TransformationProxy(hn)
 

--- a/bindings/experimental/distrdf/test/test_friendinfo.py
+++ b/bindings/experimental/distrdf/test/test_friendinfo.py
@@ -3,8 +3,7 @@ import unittest
 from array import array
 
 import ROOT
-from DistRDF.Node import FriendInfo
-from DistRDF.Node import HeadNode
+from DistRDF.HeadNode import FriendInfo, get_headnode
 
 
 class FriendInfoTest(unittest.TestCase):
@@ -85,7 +84,7 @@ class FriendInfoTest(unittest.TestCase):
         basetree.AddFriend(friendtree)
 
         # Instantiate head node of the graph with the base TTree
-        headnode = HeadNode(basetree)
+        headnode = get_headnode(basetree)
 
         # Retrieve FriendInfo instance
         friend_info = headnode._get_friend_info()

--- a/bindings/experimental/distrdf/test/test_friendinfo.py
+++ b/bindings/experimental/distrdf/test/test_friendinfo.py
@@ -84,7 +84,8 @@ class FriendInfoTest(unittest.TestCase):
         basetree.AddFriend(friendtree)
 
         # Instantiate head node of the graph with the base TTree
-        headnode = get_headnode(basetree, npartitions=None)
+        # Passing None as `npartitions` since it is not required for the test
+        headnode = get_headnode(None, basetree)
 
         # Retrieve FriendInfo instance
         friend_info = headnode._get_friend_info()

--- a/bindings/experimental/distrdf/test/test_friendinfo.py
+++ b/bindings/experimental/distrdf/test/test_friendinfo.py
@@ -84,7 +84,7 @@ class FriendInfoTest(unittest.TestCase):
         basetree.AddFriend(friendtree)
 
         # Instantiate head node of the graph with the base TTree
-        headnode = get_headnode(basetree)
+        headnode = get_headnode(basetree, npartitions=None)
 
         # Retrieve FriendInfo instance
         friend_info = headnode._get_friend_info()

--- a/bindings/experimental/distrdf/test/test_headnode.py
+++ b/bindings/experimental/distrdf/test/test_headnode.py
@@ -31,7 +31,7 @@ class DataFrameConstructorTests(unittest.TestCase):
             x[0] = i
             tree.Fill()
 
-        headnode = HeadNode.get_headnode(tree)
+        headnode = HeadNode.get_headnode(tree, npartitions=None)
         with self.assertRaises(RuntimeError):
             # Trees with no associated files are not supported
             headnode.get_inputfiles()
@@ -55,7 +55,7 @@ class DataFrameConstructorTests(unittest.TestCase):
 
     def test_integer_arg(self):
         """Constructor with number of entries"""
-        hn = HeadNode.get_headnode(10)
+        hn = HeadNode.get_headnode(10, npartitions=None)
 
         self.assertEqual(hn.nentries, 10)
         self.assertIsInstance(hn, HeadNode.EmptySourceHeadNode)
@@ -70,13 +70,13 @@ class DataFrameConstructorTests(unittest.TestCase):
             reqd_vec.push_back(elem)
 
         # RDataFrame constructor with 2nd argument as string
-        hn_1 = HeadNode.get_headnode("treename", "file.root")
+        hn_1 = HeadNode.get_headnode("treename", "file.root", npartitions=None)
 
         # RDataFrame constructor with 2nd argument as Python list
-        hn_2 = HeadNode.get_headnode("treename", rdf_2_files)
+        hn_2 = HeadNode.get_headnode("treename", rdf_2_files, npartitions=None)
 
         # RDataFrame constructor with 2nd argument as ROOT CPP Vector
-        hn_3 = HeadNode.get_headnode("treename", reqd_vec)
+        hn_3 = HeadNode.get_headnode("treename", reqd_vec, npartitions=None)
 
         self.assertArgs(hn_1.args, ["treename", "file.root"])
         self.assertArgs(hn_2.args, ["treename", rdf_2_files])
@@ -92,10 +92,10 @@ class DataFrameConstructorTests(unittest.TestCase):
             reqd_vec.push_back(elem)
 
         # RDataFrame constructor with 3rd argument as Python list
-        hn_1 = HeadNode.get_headnode("treename", "file.root", rdf_branches)
+        hn_1 = HeadNode.get_headnode("treename", "file.root", rdf_branches, npartitions=None)
 
         # RDataFrame constructor with 3rd argument as ROOT CPP Vector
-        hn_2 = HeadNode.get_headnode("treename", "file.root", reqd_vec)
+        hn_2 = HeadNode.get_headnode("treename", "file.root", reqd_vec, npartitions=None)
 
         self.assertArgs(hn_1.args, ["treename", "file.root", rdf_branches])
         self.assertArgs(hn_2.args, ["treename", "file.root", reqd_vec])
@@ -117,19 +117,19 @@ class DataFrameConstructorTests(unittest.TestCase):
 
         # RDataFrame constructor with 2nd argument as Python List
         # and 3rd argument as Python List
-        hn_1 = HeadNode.get_headnode("treename", rdf_files, rdf_branches)
+        hn_1 = HeadNode.get_headnode("treename", rdf_files, rdf_branches, npartitions=None)
 
         # RDataFrame constructor with 2nd argument as Python List
         # and 3rd argument as ROOT CPP Vector
-        hn_2 = HeadNode.get_headnode("treename", rdf_files, reqd_branches_vec)
+        hn_2 = HeadNode.get_headnode("treename", rdf_files, reqd_branches_vec, npartitions=None)
 
         # RDataFrame constructor with 2nd argument as ROOT CPP Vector
         # and 3rd argument as Python List
-        hn_3 = HeadNode.get_headnode("treename", reqd_files_vec, rdf_branches)
+        hn_3 = HeadNode.get_headnode("treename", reqd_files_vec, rdf_branches, npartitions=None)
 
         # RDataFrame constructor with 2nd and 3rd arguments as ROOT
         # CPP Vectors
-        hn_4 = HeadNode.get_headnode("treename", reqd_files_vec, reqd_branches_vec)
+        hn_4 = HeadNode.get_headnode("treename", reqd_files_vec, reqd_branches_vec, npartitions=None)
 
         self.assertArgs(hn_1.args, ["treename", rdf_files, rdf_branches])
         self.assertArgs(hn_2.args, ["treename", rdf_files, reqd_branches_vec])
@@ -157,9 +157,9 @@ class NumEntriesTest(unittest.TestCase):
         files_vec.push_back("data.root")
 
         # Create RDataFrame instances
-        hn = HeadNode.get_headnode("tree", "data.root")
-        hn_1 = HeadNode.get_headnode("tree", ["data.root"])
-        hn_2 = HeadNode.get_headnode("tree", files_vec)
+        hn = HeadNode.get_headnode("tree", "data.root", npartitions=None)
+        hn_1 = HeadNode.get_headnode("tree", ["data.root"], npartitions=None)
+        hn_2 = HeadNode.get_headnode("tree", files_vec, npartitions=None)
 
         self.assertEqual(hn.get_num_entries(), 1111)
         self.assertEqual(hn_1.get_num_entries(), 1111)
@@ -178,10 +178,10 @@ class NumEntriesTest(unittest.TestCase):
         branches_vec_2.push_back("b2")
 
         # Create RDataFrame instances
-        hn = HeadNode.get_headnode("tree", "data.root", ["b1"])
-        hn_1 = HeadNode.get_headnode("tree", "data.root", ["b2"])
-        hn_2 = HeadNode.get_headnode("tree", "data.root", branches_vec_1)
-        hn_3 = HeadNode.get_headnode("tree", "data.root", branches_vec_2)
+        hn = HeadNode.get_headnode("tree", "data.root", ["b1"], npartitions=None)
+        hn_1 = HeadNode.get_headnode("tree", "data.root", ["b2"], npartitions=None)
+        hn_2 = HeadNode.get_headnode("tree", "data.root", branches_vec_1, npartitions=None)
+        hn_3 = HeadNode.get_headnode("tree", "data.root", branches_vec_2, npartitions=None)
 
         self.assertEqual(hn.get_num_entries(), 1234)
         self.assertEqual(hn_1.get_num_entries(), 1234)
@@ -202,6 +202,6 @@ class NumEntriesTest(unittest.TestCase):
             v[i] = 1  # Change the vector element to 1
             tree.Fill()  # Fill the tree with that element
 
-        hn = HeadNode.get_headnode(tree)
+        hn = HeadNode.get_headnode(tree, npartitions=None)
 
         self.assertEqual(hn.get_num_entries(), 4)

--- a/bindings/experimental/distrdf/test/test_headnode.py
+++ b/bindings/experimental/distrdf/test/test_headnode.py
@@ -2,7 +2,7 @@ import unittest
 from array import array
 
 import ROOT
-from DistRDF import Node
+from DistRDF import HeadNode
 
 
 class DataFrameConstructorTests(unittest.TestCase):
@@ -12,15 +12,15 @@ class DataFrameConstructorTests(unittest.TestCase):
         """Constructor with incorrect arguments"""
         with self.assertRaises(TypeError):
             # Incorrect first argument in 2-argument case
-            Node.HeadNode(10, "file.root")
+            HeadNode.get_headnode(10, "file.root")
 
         with self.assertRaises(TypeError):
             # Incorrect third argument in 3-argument case
-            Node.HeadNode("treename", "file.root", "column1")
+            HeadNode.get_headnode("treename", "file.root", "column1")
 
         with self.assertRaises(TypeError):
             # No argument case
-            Node.HeadNode()
+            HeadNode.get_headnode()
 
     def test_inmemory_tree(self):
         """Constructor with an in-memory-only tree is not supported"""
@@ -31,7 +31,7 @@ class DataFrameConstructorTests(unittest.TestCase):
             x[0] = i
             tree.Fill()
 
-        headnode = Node.HeadNode(tree)
+        headnode = HeadNode.get_headnode(tree)
         with self.assertRaises(RuntimeError):
             # Trees with no associated files are not supported
             headnode.get_inputfiles()
@@ -55,9 +55,10 @@ class DataFrameConstructorTests(unittest.TestCase):
 
     def test_integer_arg(self):
         """Constructor with number of entries"""
-        hn = Node.HeadNode(10)
+        hn = HeadNode.get_headnode(10)
 
-        self.assertListEqual(hn.args, [10])
+        self.assertEqual(hn.nentries, 10)
+        self.assertIsInstance(hn, HeadNode.EmptySourceHeadNode)
 
     def test_two_args(self):
         """Constructor with list of input files"""
@@ -69,13 +70,13 @@ class DataFrameConstructorTests(unittest.TestCase):
             reqd_vec.push_back(elem)
 
         # RDataFrame constructor with 2nd argument as string
-        hn_1 = Node.HeadNode("treename", "file.root")
+        hn_1 = HeadNode.get_headnode("treename", "file.root")
 
         # RDataFrame constructor with 2nd argument as Python list
-        hn_2 = Node.HeadNode("treename", rdf_2_files)
+        hn_2 = HeadNode.get_headnode("treename", rdf_2_files)
 
         # RDataFrame constructor with 2nd argument as ROOT CPP Vector
-        hn_3 = Node.HeadNode("treename", reqd_vec)
+        hn_3 = HeadNode.get_headnode("treename", reqd_vec)
 
         self.assertArgs(hn_1.args, ["treename", "file.root"])
         self.assertArgs(hn_2.args, ["treename", rdf_2_files])
@@ -91,10 +92,10 @@ class DataFrameConstructorTests(unittest.TestCase):
             reqd_vec.push_back(elem)
 
         # RDataFrame constructor with 3rd argument as Python list
-        hn_1 = Node.HeadNode("treename", "file.root", rdf_branches)
+        hn_1 = HeadNode.get_headnode("treename", "file.root", rdf_branches)
 
         # RDataFrame constructor with 3rd argument as ROOT CPP Vector
-        hn_2 = Node.HeadNode("treename", "file.root", reqd_vec)
+        hn_2 = HeadNode.get_headnode("treename", "file.root", reqd_vec)
 
         self.assertArgs(hn_1.args, ["treename", "file.root", rdf_branches])
         self.assertArgs(hn_2.args, ["treename", "file.root", reqd_vec])
@@ -116,19 +117,19 @@ class DataFrameConstructorTests(unittest.TestCase):
 
         # RDataFrame constructor with 2nd argument as Python List
         # and 3rd argument as Python List
-        hn_1 = Node.HeadNode("treename", rdf_files, rdf_branches)
+        hn_1 = HeadNode.get_headnode("treename", rdf_files, rdf_branches)
 
         # RDataFrame constructor with 2nd argument as Python List
         # and 3rd argument as ROOT CPP Vector
-        hn_2 = Node.HeadNode("treename", rdf_files, reqd_branches_vec)
+        hn_2 = HeadNode.get_headnode("treename", rdf_files, reqd_branches_vec)
 
         # RDataFrame constructor with 2nd argument as ROOT CPP Vector
         # and 3rd argument as Python List
-        hn_3 = Node.HeadNode("treename", reqd_files_vec, rdf_branches)
+        hn_3 = HeadNode.get_headnode("treename", reqd_files_vec, rdf_branches)
 
         # RDataFrame constructor with 2nd and 3rd arguments as ROOT
         # CPP Vectors
-        hn_4 = Node.HeadNode("treename", reqd_files_vec, reqd_branches_vec)
+        hn_4 = HeadNode.get_headnode("treename", reqd_files_vec, reqd_branches_vec)
 
         self.assertArgs(hn_1.args, ["treename", rdf_files, rdf_branches])
         self.assertArgs(hn_2.args, ["treename", rdf_files, reqd_branches_vec])
@@ -145,16 +146,6 @@ class NumEntriesTest(unittest.TestCase):
         tdf = ROOT.ROOT.RDataFrame(size)
         tdf.Define("b1", "(double) tdfentry_").Snapshot("tree", "data.root")
 
-    def test_num_entries_single_arg_case(self):
-        """
-        Ensure that the number of entries recorded are correct in the case
-        of a single integer argument to RDataFrame.
-
-        """
-        hn = Node.HeadNode(123)  # Create HeadNoded instance
-
-        self.assertEqual(hn.get_num_entries(), 123)
-
     def test_num_entries_two_args_case(self):
         """
         Ensure that the number of entries recorded are correct in the case
@@ -166,9 +157,9 @@ class NumEntriesTest(unittest.TestCase):
         files_vec.push_back("data.root")
 
         # Create RDataFrame instances
-        hn = Node.HeadNode("tree", "data.root")
-        hn_1 = Node.HeadNode("tree", ["data.root"])
-        hn_2 = Node.HeadNode("tree", files_vec)
+        hn = HeadNode.get_headnode("tree", "data.root")
+        hn_1 = HeadNode.get_headnode("tree", ["data.root"])
+        hn_2 = HeadNode.get_headnode("tree", files_vec)
 
         self.assertEqual(hn.get_num_entries(), 1111)
         self.assertEqual(hn_1.get_num_entries(), 1111)
@@ -187,10 +178,10 @@ class NumEntriesTest(unittest.TestCase):
         branches_vec_2.push_back("b2")
 
         # Create RDataFrame instances
-        hn = Node.HeadNode("tree", "data.root", ["b1"])
-        hn_1 = Node.HeadNode("tree", "data.root", ["b2"])
-        hn_2 = Node.HeadNode("tree", "data.root", branches_vec_1)
-        hn_3 = Node.HeadNode("tree", "data.root", branches_vec_2)
+        hn = HeadNode.get_headnode("tree", "data.root", ["b1"])
+        hn_1 = HeadNode.get_headnode("tree", "data.root", ["b2"])
+        hn_2 = HeadNode.get_headnode("tree", "data.root", branches_vec_1)
+        hn_3 = HeadNode.get_headnode("tree", "data.root", branches_vec_2)
 
         self.assertEqual(hn.get_num_entries(), 1234)
         self.assertEqual(hn_1.get_num_entries(), 1234)
@@ -211,6 +202,6 @@ class NumEntriesTest(unittest.TestCase):
             v[i] = 1  # Change the vector element to 1
             tree.Fill()  # Fill the tree with that element
 
-        hn = Node.HeadNode(tree)
+        hn = HeadNode.get_headnode(tree)
 
         self.assertEqual(hn.get_num_entries(), 4)

--- a/bindings/experimental/distrdf/test/test_headnode.py
+++ b/bindings/experimental/distrdf/test/test_headnode.py
@@ -2,7 +2,14 @@ import unittest
 from array import array
 
 import ROOT
-from DistRDF import HeadNode
+from DistRDF.HeadNode import get_headnode, EmptySourceHeadNode
+
+
+def create_dummy_headnode(*args):
+    """Create dummy head node instance needed in the test"""
+    # Pass None as `npartitions`. The tests will modify this member
+    # according to needs
+    return get_headnode(None, *args)
 
 
 class DataFrameConstructorTests(unittest.TestCase):
@@ -12,15 +19,15 @@ class DataFrameConstructorTests(unittest.TestCase):
         """Constructor with incorrect arguments"""
         with self.assertRaises(TypeError):
             # Incorrect first argument in 2-argument case
-            HeadNode.get_headnode(10, "file.root")
+            create_dummy_headnode(10, "file.root")
 
         with self.assertRaises(TypeError):
             # Incorrect third argument in 3-argument case
-            HeadNode.get_headnode("treename", "file.root", "column1")
+            create_dummy_headnode("treename", "file.root", "column1")
 
         with self.assertRaises(TypeError):
             # No argument case
-            HeadNode.get_headnode()
+            create_dummy_headnode()
 
     def test_inmemory_tree(self):
         """Constructor with an in-memory-only tree is not supported"""
@@ -31,7 +38,7 @@ class DataFrameConstructorTests(unittest.TestCase):
             x[0] = i
             tree.Fill()
 
-        headnode = HeadNode.get_headnode(tree, npartitions=None)
+        headnode = create_dummy_headnode(tree)
         with self.assertRaises(RuntimeError):
             # Trees with no associated files are not supported
             headnode.get_inputfiles()
@@ -55,10 +62,10 @@ class DataFrameConstructorTests(unittest.TestCase):
 
     def test_integer_arg(self):
         """Constructor with number of entries"""
-        hn = HeadNode.get_headnode(10, npartitions=None)
+        hn = create_dummy_headnode(10)
 
         self.assertEqual(hn.nentries, 10)
-        self.assertIsInstance(hn, HeadNode.EmptySourceHeadNode)
+        self.assertIsInstance(hn, EmptySourceHeadNode)
 
     def test_two_args(self):
         """Constructor with list of input files"""
@@ -70,13 +77,13 @@ class DataFrameConstructorTests(unittest.TestCase):
             reqd_vec.push_back(elem)
 
         # RDataFrame constructor with 2nd argument as string
-        hn_1 = HeadNode.get_headnode("treename", "file.root", npartitions=None)
+        hn_1 = create_dummy_headnode("treename", "file.root")
 
         # RDataFrame constructor with 2nd argument as Python list
-        hn_2 = HeadNode.get_headnode("treename", rdf_2_files, npartitions=None)
+        hn_2 = create_dummy_headnode("treename", rdf_2_files)
 
         # RDataFrame constructor with 2nd argument as ROOT CPP Vector
-        hn_3 = HeadNode.get_headnode("treename", reqd_vec, npartitions=None)
+        hn_3 = create_dummy_headnode("treename", reqd_vec)
 
         self.assertArgs(hn_1.args, ["treename", "file.root"])
         self.assertArgs(hn_2.args, ["treename", rdf_2_files])
@@ -92,10 +99,10 @@ class DataFrameConstructorTests(unittest.TestCase):
             reqd_vec.push_back(elem)
 
         # RDataFrame constructor with 3rd argument as Python list
-        hn_1 = HeadNode.get_headnode("treename", "file.root", rdf_branches, npartitions=None)
+        hn_1 = create_dummy_headnode("treename", "file.root", rdf_branches)
 
         # RDataFrame constructor with 3rd argument as ROOT CPP Vector
-        hn_2 = HeadNode.get_headnode("treename", "file.root", reqd_vec, npartitions=None)
+        hn_2 = create_dummy_headnode("treename", "file.root", reqd_vec)
 
         self.assertArgs(hn_1.args, ["treename", "file.root", rdf_branches])
         self.assertArgs(hn_2.args, ["treename", "file.root", reqd_vec])
@@ -117,19 +124,19 @@ class DataFrameConstructorTests(unittest.TestCase):
 
         # RDataFrame constructor with 2nd argument as Python List
         # and 3rd argument as Python List
-        hn_1 = HeadNode.get_headnode("treename", rdf_files, rdf_branches, npartitions=None)
+        hn_1 = create_dummy_headnode("treename", rdf_files, rdf_branches)
 
         # RDataFrame constructor with 2nd argument as Python List
         # and 3rd argument as ROOT CPP Vector
-        hn_2 = HeadNode.get_headnode("treename", rdf_files, reqd_branches_vec, npartitions=None)
+        hn_2 = create_dummy_headnode("treename", rdf_files, reqd_branches_vec)
 
         # RDataFrame constructor with 2nd argument as ROOT CPP Vector
         # and 3rd argument as Python List
-        hn_3 = HeadNode.get_headnode("treename", reqd_files_vec, rdf_branches, npartitions=None)
+        hn_3 = create_dummy_headnode("treename", reqd_files_vec, rdf_branches)
 
         # RDataFrame constructor with 2nd and 3rd arguments as ROOT
         # CPP Vectors
-        hn_4 = HeadNode.get_headnode("treename", reqd_files_vec, reqd_branches_vec, npartitions=None)
+        hn_4 = create_dummy_headnode("treename", reqd_files_vec, reqd_branches_vec)
 
         self.assertArgs(hn_1.args, ["treename", rdf_files, rdf_branches])
         self.assertArgs(hn_2.args, ["treename", rdf_files, reqd_branches_vec])
@@ -157,9 +164,9 @@ class NumEntriesTest(unittest.TestCase):
         files_vec.push_back("data.root")
 
         # Create RDataFrame instances
-        hn = HeadNode.get_headnode("tree", "data.root", npartitions=None)
-        hn_1 = HeadNode.get_headnode("tree", ["data.root"], npartitions=None)
-        hn_2 = HeadNode.get_headnode("tree", files_vec, npartitions=None)
+        hn = create_dummy_headnode("tree", "data.root")
+        hn_1 = create_dummy_headnode("tree", ["data.root"])
+        hn_2 = create_dummy_headnode("tree", files_vec)
 
         self.assertEqual(hn.get_num_entries(), 1111)
         self.assertEqual(hn_1.get_num_entries(), 1111)
@@ -178,10 +185,10 @@ class NumEntriesTest(unittest.TestCase):
         branches_vec_2.push_back("b2")
 
         # Create RDataFrame instances
-        hn = HeadNode.get_headnode("tree", "data.root", ["b1"], npartitions=None)
-        hn_1 = HeadNode.get_headnode("tree", "data.root", ["b2"], npartitions=None)
-        hn_2 = HeadNode.get_headnode("tree", "data.root", branches_vec_1, npartitions=None)
-        hn_3 = HeadNode.get_headnode("tree", "data.root", branches_vec_2, npartitions=None)
+        hn = create_dummy_headnode("tree", "data.root", ["b1"])
+        hn_1 = create_dummy_headnode("tree", "data.root", ["b2"])
+        hn_2 = create_dummy_headnode("tree", "data.root", branches_vec_1)
+        hn_3 = create_dummy_headnode("tree", "data.root", branches_vec_2)
 
         self.assertEqual(hn.get_num_entries(), 1234)
         self.assertEqual(hn_1.get_num_entries(), 1234)
@@ -202,6 +209,6 @@ class NumEntriesTest(unittest.TestCase):
             v[i] = 1  # Change the vector element to 1
             tree.Fill()  # Fill the tree with that element
 
-        hn = HeadNode.get_headnode(tree, npartitions=None)
+        hn = create_dummy_headnode(tree)
 
         self.assertEqual(hn.get_num_entries(), 4)

--- a/bindings/experimental/distrdf/test/test_node.py
+++ b/bindings/experimental/distrdf/test/test_node.py
@@ -30,7 +30,7 @@ class OperationReadTest(unittest.TestCase):
 
     def test_attr_read(self):
         """Function names are read accurately."""
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         func = node.Define  # noqa: avoid PEP8 F841
@@ -38,7 +38,7 @@ class OperationReadTest(unittest.TestCase):
 
     def test_args_read(self):
         """Arguments (unnamed) are read accurately."""
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Define(1, "b", a="1", b=2)
@@ -46,7 +46,7 @@ class OperationReadTest(unittest.TestCase):
 
     def test_kwargs_read(self):
         """Named arguments are read accurately."""
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Define(1, "b", a="1", b=2)
@@ -61,7 +61,7 @@ class NodeReturnTest(unittest.TestCase):
 
     def test_action_proxy_return(self):
         """Proxy objects are returned for action nodes."""
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Count()
@@ -70,7 +70,7 @@ class NodeReturnTest(unittest.TestCase):
 
     def test_transformation_proxy_return(self):
         """Node objects are returned for transformation nodes."""
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Define(1)
@@ -135,7 +135,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -163,7 +163,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -190,7 +190,7 @@ class DfsTest(unittest.TestCase):
         and no children get pruned recursively.
         """
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -218,7 +218,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -248,7 +248,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -284,7 +284,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -316,7 +316,7 @@ class DunderMethodsTest(unittest.TestCase):
         Node class.
 
         """
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         n1 = node.Define("a", b="c")  # First child node
@@ -341,7 +341,7 @@ class DunderMethodsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -433,7 +433,7 @@ class PickleTest(unittest.TestCase):
 
         # Node definitions
         # Head node
-        hn = HeadNode.get_headnode(1)
+        hn = HeadNode.get_headnode(1, npartitions=None)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         n1 = node.Define("a", b="c")  # First child node

--- a/bindings/experimental/distrdf/test/test_node.py
+++ b/bindings/experimental/distrdf/test/test_node.py
@@ -1,7 +1,15 @@
 import unittest
 
-from DistRDF import Node, HeadNode, Proxy
+from DistRDF import Node, Proxy
 from DistRDF.Backends import Base
+from DistRDF.HeadNode import get_headnode
+
+
+def create_dummy_headnode(*args):
+    """Create dummy head node instance needed in the test"""
+    # Pass None as `npartitions`. The tests will modify this member
+    # according to needs
+    return get_headnode(None, *args)
 
 
 class TestBackend(Base.BaseBackend):
@@ -30,7 +38,7 @@ class OperationReadTest(unittest.TestCase):
 
     def test_attr_read(self):
         """Function names are read accurately."""
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         func = node.Define  # noqa: avoid PEP8 F841
@@ -38,7 +46,7 @@ class OperationReadTest(unittest.TestCase):
 
     def test_args_read(self):
         """Arguments (unnamed) are read accurately."""
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Define(1, "b", a="1", b=2)
@@ -46,7 +54,7 @@ class OperationReadTest(unittest.TestCase):
 
     def test_kwargs_read(self):
         """Named arguments are read accurately."""
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Define(1, "b", a="1", b=2)
@@ -61,7 +69,7 @@ class NodeReturnTest(unittest.TestCase):
 
     def test_action_proxy_return(self):
         """Proxy objects are returned for action nodes."""
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Count()
@@ -70,7 +78,7 @@ class NodeReturnTest(unittest.TestCase):
 
     def test_transformation_proxy_return(self):
         """Node objects are returned for transformation nodes."""
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Define(1)
@@ -135,7 +143,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -163,7 +171,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -190,7 +198,7 @@ class DfsTest(unittest.TestCase):
         and no children get pruned recursively.
         """
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -218,7 +226,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -248,7 +256,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -284,7 +292,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -316,7 +324,7 @@ class DunderMethodsTest(unittest.TestCase):
         Node class.
 
         """
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         n1 = node.Define("a", b="c")  # First child node
@@ -341,7 +349,7 @@ class DunderMethodsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -433,7 +441,7 @@ class PickleTest(unittest.TestCase):
 
         # Node definitions
         # Head node
-        hn = HeadNode.get_headnode(1, npartitions=None)
+        hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         n1 = node.Define("a", b="c")  # First child node

--- a/bindings/experimental/distrdf/test/test_node.py
+++ b/bindings/experimental/distrdf/test/test_node.py
@@ -1,6 +1,6 @@
 import unittest
 
-from DistRDF import Node, Proxy
+from DistRDF import Node, HeadNode, Proxy
 from DistRDF.Backends import Base
 
 
@@ -30,7 +30,7 @@ class OperationReadTest(unittest.TestCase):
 
     def test_attr_read(self):
         """Function names are read accurately."""
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         func = node.Define  # noqa: avoid PEP8 F841
@@ -38,7 +38,7 @@ class OperationReadTest(unittest.TestCase):
 
     def test_args_read(self):
         """Arguments (unnamed) are read accurately."""
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Define(1, "b", a="1", b=2)
@@ -46,7 +46,7 @@ class OperationReadTest(unittest.TestCase):
 
     def test_kwargs_read(self):
         """Named arguments are read accurately."""
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Define(1, "b", a="1", b=2)
@@ -61,7 +61,7 @@ class NodeReturnTest(unittest.TestCase):
 
     def test_action_proxy_return(self):
         """Proxy objects are returned for action nodes."""
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Count()
@@ -70,7 +70,7 @@ class NodeReturnTest(unittest.TestCase):
 
     def test_transformation_proxy_return(self):
         """Node objects are returned for transformation nodes."""
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         newNode = node.Define(1)
@@ -135,7 +135,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -163,7 +163,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -190,7 +190,7 @@ class DfsTest(unittest.TestCase):
         and no children get pruned recursively.
         """
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -218,7 +218,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -248,7 +248,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -284,7 +284,7 @@ class DfsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -316,7 +316,7 @@ class DunderMethodsTest(unittest.TestCase):
         Node class.
 
         """
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         n1 = node.Define("a", b="c")  # First child node
@@ -341,7 +341,7 @@ class DunderMethodsTest(unittest.TestCase):
 
         """
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
 
@@ -433,7 +433,7 @@ class PickleTest(unittest.TestCase):
 
         # Node definitions
         # Head node
-        hn = Node.HeadNode(1)
+        hn = HeadNode.get_headnode(1)
         hn.backend = TestBackend()
         node = Proxy.TransformationProxy(hn)
         n1 = node.Define("a", b="c")  # First child node


### PR DESCRIPTION
This PR addresses step 1 of #8391

> Split the big HeadNode class in differente head node types according to the original data source (e.g. EntriesHeadNode, TreeHeadNode, in the future also RNTupleHeadNode). Use a factory to get the correct head node type according to user provided arguments to the RDataFrame constructor

It also addresses the comments from the original PR regarding the files touched in this PR, except for the following:
* The comments about changing the names of the getters in `TreeHeadNode` and doing the parsing of constructor arguments only once in `__init__.` will be addressed both in another PR. Probably the properties can be removed or changed in favor of having the attributes already set during `__init__` thanks to the mentioned single-pass parsing.
* Checking that `glob.glob` behaves similarly to TChain's globbing is left for another time

