### PR TITLE
[RF] Add missing nullptr check to removeCommon helper in RooProdPdf

### DIFF
--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -565,7 +565,7 @@ void removeCommon(std::vector<RooAbsArg*> &v, std::span<RooAbsArg * const> other
 
   for (auto const& arg : other) {
     auto namePtrMatch = [&arg](const RooAbsArg* elm) {
-      return elm->namePtr() == arg->namePtr();
+      return elm != nullptr && elm->namePtr() == arg->namePtr();
     };
 
     auto found = std::find_if(v.begin(), v.end(), namePtrMatch);


### PR DESCRIPTION
This fixes a bug recently introduced by commit bdf7502.

Fixes issue https://github.com/root-project/root/issues/8474.

Thank you so much @VanyaBelyaev for using ROOT master, which was crucial for me to fix this bug before it made it into any release!
