### PR TITLE
MathMore: Add Lambert W functions

### DIFF
--- a/math/mathmore/inc/Math/SpecFuncMathMore.h
+++ b/math/mathmore/inc/Math/SpecFuncMathMore.h
@@ -493,6 +493,51 @@ namespace Math {
 
   /**
 
+  Calculates the Lambert W function on branch 0
+
+  The Lambert W functions are defined to be the solution of the equation
+
+  \f[ W(x) \exp(W(x)) = x \f]
+
+  For detailed description see
+  <A HREF="https://mathworld.wolfram.com/LambertW-Function.html">Mathworld</A>
+  or <A HREF="https://en.wikipedia.org/wiki/Lambert_W_function">Wikipedia</A>.
+
+  This function implements the Lambert W function on branch 0, which is real
+  valued and defined for \f$ x \geq -1/e \f$ with \f$ W_0(x) \geq -1 \f$.
+
+  @ingroup SpecFunc
+
+  */
+
+  double lambert_W0(double x);
+
+
+  /**
+
+  Calculates the Lambert W function on branch -1
+
+  The Lambert W functions are defined to be the solution of the equation
+
+  \f[ W(x) \exp(W(x)) = x \f]
+
+  For detailed description see
+  <A HREF="https://mathworld.wolfram.com/LambertW-Function.html">Mathworld</A>
+  or <A HREF="https://en.wikipedia.org/wiki/Lambert_W_function">Wikipedia</A>.
+
+  This function implements the Lambert W function on branch -1, which is real
+  valued and defined for \f$ -1/e \seq x < 0 \f$ with
+  \f$ W_{-1}(x) \seq -1 \f$.
+
+  @ingroup SpecFunc
+
+  */
+
+  double lambert_Wm1(double x);
+
+
+  /**
+
   Calculates the Legendre polynomials.
 
   \f[ P_{l}(x) = \frac{1}{2^l l!} \frac{d^l}{dx^l}  (x^2 - 1)^l \f]

--- a/math/mathmore/src/SpecFuncMathMore.cxx
+++ b/math/mathmore/src/SpecFuncMathMore.cxx
@@ -19,6 +19,7 @@
 
 #include "gsl/gsl_sf_bessel.h"
 #include "gsl/gsl_sf_legendre.h"
+#include "gsl/gsl_sf_lambert.h"
 #include "gsl/gsl_sf_laguerre.h"
 #include "gsl/gsl_sf_hyperg.h"
 #include "gsl/gsl_sf_ellint.h"
@@ -327,6 +328,18 @@ double laguerre(unsigned n, double x) {
 }
 
 
+// Lambert W function on branch 0
+
+double lambert_W0(double x) {
+   return gsl_sf_lambert_W0(x);
+}
+
+
+// Lambert W function on branch -1
+
+double lambert_Wm1(double x) {
+   return gsl_sf_lambert_Wm1(x);
+}
 
 
 // [5.2.1.19] Legendre polynomials

--- a/math/mathmore/test/testSpecFunc.cxx
+++ b/math/mathmore/test/testSpecFunc.cxx
@@ -190,6 +190,10 @@ int testSpecFunc() {
 
    iret |= compare("laguerre(4, 1.) ", laguerre(4, 1.), -0.6250, 4); // need to find more precise value
 
+   iret |= compare("lambert_W0(-0.1) ", lambert_W0(-0.1), -0.1118325591589629648);
+
+   iret |= compare("lambert_Wm1(-0.1) ", lambert_Wm1(-0.1), -3.5771520639572972184);
+
    iret |= compare("legendre(10, -0.5) ", legendre(10, -0.5), -0.1882286071777345);
 
    iret |= compare("riemann_zeta(-0.5) ", riemann_zeta(-0.5), -0.207886224977354566017307, 16);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Adds the Lambert W function to MathMore using GSL.

One question: I'm not sure what some of the docstrings in the source file mean.
I copied these from other functions:
```cxx
// [5.2.1.18] Laguerre polynomials
// (26.x.11)
```

Does the first one specify the version the function is introduced? What does the second number specify?


I tested it and it works, the only thing missing are the docstrings.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #8471.

/cc @lmoneta
