### PR TITLE
[RF] Fix missing initializer warnings in MemPoolForRooSets.h (2nd try)

### DIFF
--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -37,7 +37,7 @@ class MemPoolForRooSets {
       : ownedMemory{static_cast<RooSet_t *>(::operator new(2 * POOLSIZE * sizeof(RooSet_t)))},
         memBegin{ownedMemory}, nextItem{ownedMemory},
         memEnd{memBegin + 2 * POOLSIZE},
-        cycle{}
+        cycle{{}}
     {}
 
     Arena(const Arena &) = delete;
@@ -47,7 +47,7 @@ class MemPoolForRooSets {
         refCount{other.refCount},
         totCount{other.totCount},
         assigned{other.assigned},
-        cycle{}
+        cycle{{}}
     {
       // Needed for unique ownership
       other.ownedMemory = nullptr;
@@ -170,7 +170,7 @@ class MemPoolForRooSets {
     std::size_t totCount = 0;
 
     std::bitset<POOLSIZE> assigned = {};
-    std::array<int, POOLSIZE> cycle = {};
+    std::array<int, POOLSIZE> cycle = {{}};
   };
 
 


### PR DESCRIPTION
This PR should finally fix the build warnings in the master nightlies,
after the unsuccessful fix attempt in commit
4ed5ea3976743d1206a8f8c7579adeb1818a9695.

I have checked that the missing field initializer warnings go away with
this change by compiling the following example snippet under gcc48:

```C++
// compile with g++ -Wmissing-field-initializers -std=c++11 -o test test.cc

struct A{

   A()
     : arr_{{}}
   {}

   std::array<int, 10> arr_ = {{}};
};

int main() {
    A a{};
    std::cout << a.arr_[0] << std::endl;
    return 0;
}
```

The warnings are reproduced, and can successfully be suppressed by
replacing `{}` with `{{}}`.

This is a backport of 855fd44340e13161f88ca09a86e50abf5c1cd5a1.

