### PR TITLE
Fix setting the Minimizer options in GSLSimAnMinimizer

### DIFF
--- a/math/mathcore/inc/Math/Minimizer.h
+++ b/math/mathcore/inc/Math/Minimizer.h
@@ -470,6 +470,9 @@ public:
       fOptions = opt;
    }
 
+   /// set only the extra options
+   void SetExtraOptions(const IOptions & extraOptions) { fOptions.SetExtraOptions(extraOptions); }
+
    /// reset the defaut options (defined in MinimizerOptions)
    void SetDefaultOptions() {
       fOptions.ResetToDefaultOptions();

--- a/math/mathcore/src/FitConfig.cxx
+++ b/math/mathcore/src/FitConfig.cxx
@@ -229,7 +229,9 @@ ROOT::Math::Minimizer * FitConfig::CreateMinimizer() {
    min->SetValidError( fParabErrors );
    min->SetStrategy( fMinimizerOpts.Strategy() );
    min->SetErrorDef( fMinimizerOpts.ErrorDef() );
-
+   // set extra options if existing
+   if (fMinimizerOpts.ExtraOptions())
+      min->SetExtraOptions(*fMinimizerOpts.ExtraOptions());
 
    return min;
 }

--- a/math/mathcore/src/MinimizerOptions.cxx
+++ b/math/mathcore/src/MinimizerOptions.cxx
@@ -44,6 +44,9 @@ void MinimizerOptions::SetDefaultMinimizer(const char * type, const char * algo)
    // set the default minimizer type and algorithm
    if (type) Minim::gDefaultMinimizer = std::string(type);
    if (algo) Minim::gDefaultMinimAlgo = std::string(algo);
+   if (Minim::gDefaultMinimAlgo == "" && ( Minim::gDefaultMinimizer == "Minuit" ||
+       Minim::gDefaultMinimizer == "Minuit2") )
+      Minim::gDefaultMinimAlgo = "Migrad";
 }
 void MinimizerOptions::SetDefaultErrorDef(double up) {
    // set the default error definition
@@ -79,7 +82,12 @@ void MinimizerOptions::SetDefaultExtraOptions(const IOptions * extraoptions) {
    Minim::gDefaultExtraOptions = (extraoptions) ? extraoptions->Clone() : 0;
 }
 
-const std::string & MinimizerOptions::DefaultMinimizerAlgo() { return Minim::gDefaultMinimAlgo; }
+const std::string & MinimizerOptions::DefaultMinimizerAlgo() { 
+   if (Minim::gDefaultMinimAlgo == "Migrad" && Minim::gDefaultMinimizer != "Minuit" && 
+      Minim::gDefaultMinimizer != "Minuit2" )
+      Minim::gDefaultMinimAlgo = "";
+   return Minim::gDefaultMinimAlgo;
+}
 double MinimizerOptions::DefaultErrorDef()         { return Minim::gDefaultErrorDef; }
 double MinimizerOptions::DefaultTolerance()        { return Minim::gDefaultTolerance; }
 double MinimizerOptions::DefaultPrecision()        { return Minim::gDefaultPrecision; }
@@ -173,13 +181,16 @@ void MinimizerOptions::ResetToDefaultOptions() {
    fAlgoType =  Minim::gDefaultMinimAlgo;
 
    // case of Fumili2 and TMinuit
-   if (fMinimType == "TMinuit") fMinimType = "Minuit";
+   if (fMinimType == "TMinuit") 
+      fMinimType = "Minuit";
    else if (fMinimType == "Fumili2") {
       fMinimType = "Minuit2";
       fAlgoType = "Fumili";
    }
    else if (fMinimType == "GSLMultiMin" && fAlgoType == "Migrad")
       fAlgoType = "BFGS2";
+   else if (fMinimType != "Minuit" && fMinimType != "Minuit2" && fAlgoType == "Migrad")
+      fAlgoType = "";
 
    delete fExtraOptions;
    fExtraOptions = 0;
@@ -243,4 +254,3 @@ void MinimizerOptions::PrintDefault(const char * name, std::ostream & os) {
 } // end namespace Math
 
 } // end namespace ROOT
-

--- a/math/mathmore/inc/Math/GSLSimAnMinimizer.h
+++ b/math/mathmore/inc/Math/GSLSimAnMinimizer.h
@@ -50,74 +50,85 @@ namespace ROOT {
 
 
 //_____________________________________________________________________________________
-/**
-   GSLSimAnMinimizer class for minimization using simulated annealing
-   using the algorithm from
-   <A HREF="http://www.gnu.org/software/gsl/manual/html_node/Simulated-Annealing.html">
-   GSL</A>.
-   It implements the ROOT::Minimizer interface and
-   a plug-in (name "GSLSimAn") exists to instantiate this class via the plug-in manager
-
-   @ingroup MultiMin
-*/
-class GSLSimAnMinimizer : public  ROOT::Math::BasicMinimizer {
-
-public:
-
    /**
-      Default constructor
+      GSLSimAnMinimizer class for minimization using simulated annealing
+      using the algorithm from
+      <A HREF="http://www.gnu.org/software/gsl/manual/html_node/Simulated-Annealing.html">
+      GSL</A>.
+      It implements the ROOT::Minimizer interface and
+      a plug-in (name "GSLSimAn") exists to instantiate this class via the plug-in manager
+      Configuration (Setting/getting) the options is done through the methods defined in the
+      ROOT::Math::Minimizer class.
+      The user needs to call the base class method ROOT::Math::Minimizer::SetOptions to set the
+      corresponding options.
+      Here is some code example for increasing n_tries from 200 (default) to 1000
+       ```
+         ROOT::Math::GenAlgoOptions simanOpt;
+         simanOpt.SetValue("n_tries", 1000);
+         ROOT::Math::MinimizerOptions opt;
+         opt.SetExtraOptions(simanOpt);
+         minimizer->SetOptions(opt);
+       ```
+
+      @ingroup MultiMin
    */
-   GSLSimAnMinimizer (int type = 0);
+   class GSLSimAnMinimizer : public ROOT::Math::BasicMinimizer {
 
-   /**
-      Destructor (no operations)
-   */
-   virtual ~GSLSimAnMinimizer ();
+   public:
+      /**
+         Default constructor
+      */
+      GSLSimAnMinimizer(int type = 0);
 
-private:
-   // usually copying is non trivial, so we make this unaccessible
+      /**
+         Destructor (no operations)
+      */
+      virtual ~GSLSimAnMinimizer();
 
-   /**
-      Copy constructor
-   */
-   GSLSimAnMinimizer(const GSLSimAnMinimizer &) : ROOT::Math::BasicMinimizer() {}
+   private:
+      // usually copying is non trivial, so we make this unaccessible
 
-   /**
-      Assignment operator
-   */
-   GSLSimAnMinimizer & operator = (const GSLSimAnMinimizer & rhs)  {
-      if (this == &rhs) return *this;  // time saving self-test
-      return *this;
-   }
+      /**
+         Copy constructor
+      */
+      GSLSimAnMinimizer(const GSLSimAnMinimizer &) : ROOT::Math::BasicMinimizer() {}
 
-public:
+      /**
+         Assignment operator
+      */
+      GSLSimAnMinimizer &operator=(const GSLSimAnMinimizer &rhs)
+      {
+         if (this == &rhs)
+            return *this; // time saving self-test
+         return *this;
+      }
 
+   public:
+      /// method to perform the minimization
+      virtual bool Minimize();
 
-   /// method to perform the minimization
-   virtual  bool Minimize();
+      /// number of calls
+      unsigned int NCalls() const;
 
-   /// number of calls
-   unsigned int NCalls() const;
+      /// Get current minimizer option parameteres
+      const GSLSimAnParams &MinimizerParameters() const { return fSolver.Params(); }
 
-   /// Get current minimizer options
-   virtual ROOT::Math::MinimizerOptions Options() const;
+      /// set new minimizer option parameters using directly the GSLSimAnParams structure
+      void SetParameters(const GSLSimAnParams &params)
+      {
+         fSolver.SetParams(params);
+         DoSetMinimOptions(params); // store new parameters also in MinimizerOptions
+      }
 
-   /// Get current minimizer option parameteres 
-   const GSLSimAnParams & MinimizerParameters() const { return fSolver.Params(); }
-   
+   protected:
+      /// set minimizer option parameters from stored ROOT::Math::MinimizerOptions (fOpt)
+      void DoSetSimAnParameters(const MinimizerOptions &opt);
 
-   /// set new minimizer options
-   virtual void SetOptions(const ROOT::Math::MinimizerOptions & opt);
+      /// Set the Minimizer options from the simulated annealing parameters
+      void DoSetMinimOptions(const GSLSimAnParams &params);
 
-   /// set new minimizer option parameters using directly the GSLSimAnParams structure 
-   void SetParameters(const  GSLSimAnParams & params ) {  fSolver.SetParams(params); }
-
-protected:
-
-private:
-
-
-   ROOT::Math::GSLSimAnnealing  fSolver;
+   private:
+      ROOT::Math::GSLSimAnnealing fSolver;
 
 
 };


### PR DESCRIPTION
As reported in https://root-forum.cern.ch/t/how-can-i-set-the-tuning-parameters-for-gslsimanminimizer-when-using-root-fitter/45497  the setting of the specific options for the GSLSimAnMinimizer does not work from the Fitter class or the base Minimizer class.  This is happening also for other minimizers

This is now fixed in this PR by removing SetOptions() and Options() derived methods (one can use the base class ones) 
and correctly set the options in the solver class before minimizing.
The setting of the options through the Fitter class is fixed by adding a Minimizer::SetExtraOptions method and calling it from FItConfig::CreateMinimizer
 
In addition when not using Minuit or Minuit2 do not have Migrad as default algorithm in MinimizerOptions.

An example on how to set the options has been updated in the doc. 
This code example also shows that now setting of the options works:
```
{
TH1D h1("h1","h1",100,-3,4) ;                                                                                                                 
h1.FillRandom("gaus");                                                                                                                        
ROOT::Math::MinimizerOptions::SetDefaultMinimizer("GSLSimAn") ;  
ROOT::Math::GenAlgoOptions simanOpt; ;                                                                                                        
simanOpt.SetValue("n_tries", 1000);                                                                                                 
ROOT::Math::MinimizerOptions::SetDefaultExtraOptions(&simanOpt) ; 
ROOT::Math::MinimizerOptions::SetDefaultPrintLevel(1)  ;  // options ar enow printed when level is >=1                                                                                     
h1.Fit("gaus") ;
}
```  

 