### PR TITLE
[ntuple] Check RNTuple name, location strings are not empty

### DIFF
--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -58,6 +58,12 @@ ROOT::Experimental::Detail::RPageSource::~RPageSource()
 std::unique_ptr<ROOT::Experimental::Detail::RPageSource> ROOT::Experimental::Detail::RPageSource::Create(
    std::string_view ntupleName, std::string_view location, const RNTupleReadOptions &options)
 {
+   if (ntupleName.empty()) {
+      throw RException(R__FAIL("empty RNTuple name"));
+   }
+   if (location.empty()) {
+      throw RException(R__FAIL("empty storage location"));
+   }
    if (location.find("daos://") == 0)
 #ifdef R__ENABLE_DAOS
       return std::make_unique<RPageSourceDaos>(ntupleName, location, options);
@@ -240,6 +246,12 @@ ROOT::Experimental::Detail::RPageSink::~RPageSink()
 std::unique_ptr<ROOT::Experimental::Detail::RPageSink> ROOT::Experimental::Detail::RPageSink::Create(
    std::string_view ntupleName, std::string_view location, const RNTupleWriteOptions &options)
 {
+   if (ntupleName.empty()) {
+      throw RException(R__FAIL("empty RNTuple name"));
+   }
+   if (location.empty()) {
+      throw RException(R__FAIL("empty storage location"));
+   }
    std::unique_ptr<ROOT::Experimental::Detail::RPageSink> realSink;
    if (location.find("daos://") == 0) {
 #ifdef R__ENABLE_DAOS

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -359,6 +359,39 @@ TEST(RNTupleModel, CollectionFieldDescriptions)
    EXPECT_EQ(std::string("muons after basic selection"), muon_desc.GetFieldDescription());
 }
 
+TEST(RNTuple, EmptyString)
+{
+   // empty storage string
+   try {
+      auto model = RNTupleModel::Create();
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", "");
+      FAIL() << "empty writer storage location should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("empty storage location"));
+   }
+   try {
+      auto ntuple = RNTupleReader::Open("myNTuple", "");
+      FAIL() << "empty reader storage location should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("empty storage location"));
+   }
+
+   // empty RNTuple name
+   try {
+      auto model = RNTupleModel::Create();
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "", "file.root");
+      FAIL() << "empty RNTuple name should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("empty RNTuple name"));
+   }
+   try {
+      auto ntuple = RNTupleReader::Open("", "file.root");
+      FAIL() << "empty RNTuple name should throw";
+   } catch (const RException& err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("empty RNTuple name"));
+   }
+}
+
 TEST(RNTuple, NullSafety)
 {
    // RNTupleModel


### PR DESCRIPTION
In the case of the storage location, this change turns an assert
failure into an exception:

Before:
```
Fatal: fileStream violated at line 1145 of `ntuple/v7/src/RMiniFile.cxx'
```

After:
```
C++ exception with description "empty storage location"
```

For the RNTuple name, the empty string only caused issues when added to
a TFile (but that's enough to ban it):

```cpp
std::string path = "some_file.root"
auto file = TFile::Open(path.c_str(), "RECREATE");
{
   auto model = RNTupleModel::Create();
   auto fieldPt = model->MakeField<float>("pt", 42.0);
   auto ntuple = RNTupleWriter::Append(std::move(model), "", *file);
   ntuple->Fill();
}
file->Close();
delete file;

// throws
auto ntuple = RNTupleReader::Open("", path);
```
```
C++ exception with description "no RNTuple named '' in file 'test_ntuple_empty_filename.root' (unchecked RResult access!)
```