### PR TITLE
[cling] Also fwd decl underlying type of using decls:

### DIFF
--- a/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.h
+++ b/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.h
@@ -79,6 +79,7 @@ namespace clang {
   class TranslationUnitDecl;
   class TypeAliasDecl;
   class TypedefDecl;
+  class TypedefNameDecl;
   class VarDecl;
   class UsingDirectiveDecl;
 }
@@ -108,6 +109,8 @@ namespace cling {
     std::stack<llvm::raw_ostream*> m_StreamStack;
     std::set<const char*> m_BuiltinNames;
     IgnoreFilesFunc_t m_IgnoreFile; // Call back to ignore some top level files.
+
+    void printTypedefOrAliasDecl(clang::TypedefNameDecl* D);
 
   public:
     ForwardDeclPrinter(llvm::raw_ostream& OutS,


### PR DESCRIPTION
Before, only the using decl itself was forward declared, causing
undeclared identifiers in forward declaration code, as witnessed in
https://github.com/root-project/root/issues/8499

Given the similarity of using and typedef, merge both into a single
function, making sure both have the same featureset, and through that
fixing this issue as a side-effect.

(cherry picked from commit d026b4918a696e6c8a5ef2c15985c8b9d98da2b2)
