### PR TITLE
[JupyROOT][6974] Import get_ipython explicitly in JsMVA

### DIFF
--- a/bindings/jsmva/python/JsMVA/__init__.py
+++ b/bindings/jsmva/python/JsMVA/__init__.py
@@ -3,6 +3,7 @@
 # @package JsMVA
 # @author  Attila Bagoly <battila93@gmail.com>
 
+from IPython import get_ipython
 from IPython.core.extensions import ExtensionManager
 
 ## This function will register JsMVAMagic class to ipython


### PR DESCRIPTION
Addresses this comment:

https://github.com/root-project/root/issues/6974#issuecomment-866391935

applying the same fix as in

https://github.com/etejedor/root/commit/87940dfcffadd5a6b2b427c0b024077cb61b5b96