### PR TITLE
[ntuple] (WIP) RNTuple S3 object store backend

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -13,6 +13,10 @@ if(NOT root7)
   return()
 endif()
 
+if (davix OR builtin_davix)
+  list(APPEND ROOTNTuple_EXTRA_DEPS RDAVIX)
+endif()
+
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTNTuple
 HEADERS
   ROOT/RCluster.hxx
@@ -70,6 +74,7 @@ DEPENDENCIES
   Imt
   RIO
   ROOTVecOps
+  ${ROOTNTuple_EXTRA_DEPS}
 )
 
 # Enable RNTuple support for Intel DAOS
@@ -87,6 +92,16 @@ if(daos OR daos_mock)
     target_include_directories(ROOTNTuple PRIVATE ${DAOS_INCLUDE_DIRS})
     target_link_libraries(ROOTNTuple PRIVATE ${DAOS_LIBRARIES})
   endif()
+endif()
+
+# Enable RNTuple support for S3 backend through Davix
+if(davix OR builtin_davix)
+  set(ROOTNTuple_EXTRA_HEADERS ${ROOTNTuple_EXTRA_HEADERS} ROOT/RPageStorageS3.hxx)
+  target_sources(ROOTNTuple PRIVATE v7/src/RPageStorageS3.cxx)
+  target_compile_definitions(ROOTNTuple PRIVATE R__ENABLE_DAVIX)
+
+  target_include_directories(ROOTNTuple PRIVATE ${DAVIX_INCLUDE_DIR})
+  target_link_libraries(ROOTNTuple PRIVATE ${DAVIX_LIBRARY})
 endif()
 
 if(MSVC)

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageS3.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageS3.hxx
@@ -1,0 +1,173 @@
+/// \file ROOT/RPageStorageS3.hxx
+/// \ingroup NTuple ROOT7
+/// \author Max Orok <maxwellorok@gmail.com>
+/// \date 2021-06-03
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RPageStorageS3
+#define ROOT7_RPageStorageS3
+
+#include <ROOT/RPageStorage.hxx>
+#include <ROOT/RNTupleMetrics.hxx>
+#include <ROOT/RNTupleZip.hxx>
+#include <ROOT/RStringView.hxx>
+
+#include <array>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+namespace ROOT {
+namespace Experimental {
+namespace Detail {
+
+class RCluster;
+class RPageAllocatorHeap;
+class RPagePool;
+class RS3Handle;
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RS3NTupleAnchor
+\ingroup NTuple
+\brief Entry point for an RNTuple in an S3 bucket. It encodes essential
+information to read the ntuple; currently, it contains (un)compressed size of
+the header/footer blobs.
+*/
+// clang-format on
+struct RS3NTupleAnchor {
+   /// Allows for evolving the struct in future versions
+   std::uint32_t fVersion = 0;
+   /// The size of the compressed ntuple header
+   std::uint32_t fNBytesHeader = 0;
+   /// The size of the uncompressed ntuple header
+   std::uint32_t fLenHeader = 0;
+   /// The size of the compressed ntuple footer
+   std::uint32_t fNBytesFooter = 0;
+   /// The size of the uncompressed ntuple footer
+   std::uint32_t fLenFooter = 0;
+
+   bool operator ==(const RS3NTupleAnchor &other) const {
+      return fVersion == other.fVersion &&
+         fNBytesHeader == other.fNBytesHeader &&
+         fLenHeader == other.fLenHeader &&
+         fNBytesFooter == other.fNBytesFooter &&
+         fLenFooter == other.fLenFooter;
+   }
+
+   std::uint32_t Serialize(void *buffer) const;
+   std::uint32_t Deserialize(const void *buffer);
+
+   static std::uint32_t GetSize()
+   { return RS3NTupleAnchor().Serialize(nullptr); }
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RPageSinkS3
+\ingroup NTuple
+\brief Storage provider that writes %RNTuple pages to an S3 bucket at the specified path
+
+Currently, an object is allocated for each page + 3 additional objects (anchor/header/footer).
+*/
+// clang-format on
+class RPageSinkS3 : public RPageSink {
+private:
+   std::unique_ptr<RPageAllocatorHeap> fPageAllocator;
+   /// Handle to the S3 location.
+   std::unique_ptr<RS3Handle> fS3Handle;
+   /// A URI to an S3 location
+   std::string fUri;
+   /// Object ID for the next committed page; it is automatically incremented in CommitSealedPageImpl()`
+   std::atomic<std::uint64_t> fOid{0};
+
+   RS3NTupleAnchor fNTupleAnchor;
+
+protected:
+   void CreateImpl(const RNTupleModel &model) final;
+   RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
+   RClusterDescriptor::RLocator CommitSealedPageImpl(DescriptorId_t columnId,
+                                                     const RPageStorage::RSealedPage &sealedPage) final;
+   RClusterDescriptor::RLocator CommitClusterImpl(NTupleSize_t nEntries) final;
+   void CommitDatasetImpl() final;
+   void WriteNTupleHeader(const void *data, size_t nbytes, size_t lenHeader);
+   void WriteNTupleFooter(const void *data, size_t nbytes, size_t lenFooter);
+   void WriteNTupleAnchor();
+
+public:
+   RPageSinkS3(std::string_view ntupleName, std::string_view uri, const RNTupleWriteOptions &options);
+   virtual ~RPageSinkS3();
+
+   RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) final;
+   void ReleasePage(RPage &page) final;
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RPageAllocatorS3
+\ingroup NTuple
+\brief Manages pages read from S3
+*/
+// clang-format on
+class RPageAllocatorS3 {
+public:
+   static RPage NewPage(ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements);
+   static void DeletePage(const RPage& page);
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RPageSourceS3
+\ingroup NTuple
+\brief Storage provider that reads %RNTuple pages from an S3 bucket
+
+The S3 configuration is specified using the following environment variables:
+- `S3_ACCESS_KEY`
+- `S3_SECRET_KEY`
+- `S3_REGION`
+
+*/
+// clang-format on
+class RPageSourceS3 : public RPageSource {
+private:
+   std::unique_ptr<RPageAllocatorS3> fPageAllocator;
+   std::shared_ptr<RPagePool> fPagePool;
+   std::unique_ptr<RS3Handle> fS3Handle;
+   std::string fUri;
+
+   RPage PopulatePageFromCluster(ColumnHandle_t columnHandle,
+      const RClusterDescriptor &clusterDescriptor, ClusterSize_t::ValueType idxInCluster);
+
+protected:
+   RNTupleDescriptor AttachImpl() final;
+
+public:
+   RPageSourceS3(std::string_view ntupleName, std::string_view uri, const RNTupleReadOptions &options);
+   std::unique_ptr<RPageSource> Clone() const final;
+   virtual ~RPageSourceS3();
+
+   RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;
+   RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
+   void ReleasePage(RPage &page) final;
+
+   void LoadSealedPage(DescriptorId_t columnId, const RClusterIndex &clusterIndex,
+                       RSealedPage &sealedPage) final;
+
+   std::unique_ptr<RCluster> LoadCluster(DescriptorId_t clusterId, const ColumnSet_t &columns) final;
+};
+
+} // namespace Detail
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -27,6 +27,9 @@
 #ifdef R__ENABLE_DAOS
 # include <ROOT/RPageStorageDaos.hxx>
 #endif
+#ifdef R__ENABLE_DAVIX
+#include <ROOT/RPageStorageS3.hxx>
+#endif
 
 #include <Compression.h>
 #include <TError.h>
@@ -64,7 +67,13 @@ std::unique_ptr<ROOT::Experimental::Detail::RPageSource> ROOT::Experimental::Det
 #else
       throw RException(R__FAIL("This RNTuple build does not support DAOS."));
 #endif
-
+   if (location.find("s3://") == 0) {
+#ifdef R__ENABLE_DAVIX
+      return std::make_unique<RPageSourceS3>(ntupleName, location, options);
+#else
+      throw RException(R__FAIL("This RNTuple build does not support S3."));
+#endif
+   }
    return std::make_unique<RPageSourceFile>(ntupleName, location, options);
 }
 
@@ -246,6 +255,12 @@ std::unique_ptr<ROOT::Experimental::Detail::RPageSink> ROOT::Experimental::Detai
       realSink = std::make_unique<RPageSinkDaos>(ntupleName, location, options);
 #else
       throw RException(R__FAIL("This RNTuple build does not support DAOS."));
+#endif
+   } else if (location.find("s3://") == 0) {
+#ifdef R__ENABLE_DAVIX
+      return std::make_unique<RPageSinkS3>(ntupleName, location, options);
+#else
+      throw RException(R__FAIL("This RNTuple build does not support S3."));
 #endif
    } else {
       realSink = std::make_unique<RPageSinkFile>(ntupleName, location, options);

--- a/tree/ntuple/v7/src/RPageStorageS3.cxx
+++ b/tree/ntuple/v7/src/RPageStorageS3.cxx
@@ -1,0 +1,415 @@
+/// \file RPageStorageS3.cxx
+/// \ingroup NTuple ROOT7
+/// \author Max Orok <maxwellorok@gmail.com>
+/// \date 2021-06-03
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RCluster.hxx>
+#include <ROOT/RClusterPool.hxx>
+#include <ROOT/RColumn.hxx>
+#include <ROOT/RPageAllocator.hxx>
+#include <ROOT/RPagePool.hxx>
+#include <ROOT/RPageStorageS3.hxx>
+
+#include <iostream>
+#include <string>
+
+#include "davix.hpp"
+
+namespace {
+   static const std::string kOidAnchor = std::to_string(std::uint64_t(-1));
+   static const std::string kOidHeader = std::to_string(std::uint64_t(-2));
+   static const std::string kOidFooter = std::to_string(std::uint64_t(-3));
+} // anonymous namespace
+
+namespace ROOT {
+namespace Experimental {
+namespace Detail {
+
+class RS3Handle {
+private:
+   std::string fUri;
+   Davix::Context fCtx;
+   Davix::RequestParams fReqParams;
+public:
+   RS3Handle() = default;
+   explicit RS3Handle(std::string_view uri) : fUri(uri) {
+      if (fUri.empty()) {
+         throw ROOT::Experimental::RException(R__FAIL("Empty S3 URI"));
+      }
+      if (fUri.back() != '/') {
+         fUri.push_back('/');
+      }
+      const char *s3_sec = getenv("S3_SECRET_KEY");
+      const char *s3_acc = getenv("S3_ACCESS_KEY");
+      if (s3_sec && s3_acc) {
+         fReqParams.setAwsAuthorizationKeys(s3_sec, s3_acc);
+      }
+      const char *s3_reg = getenv("S3_REGION");
+      if (s3_reg) {
+         fReqParams.setAwsRegion(s3_reg);
+      }
+   }
+   RS3Handle(const RS3Handle&) = delete;
+   RS3Handle& operator=(const RS3Handle&) = delete;
+   RS3Handle(RS3Handle&&) = default;
+   RS3Handle& operator=(RS3Handle&&) = default;
+   ~RS3Handle() = default;
+
+   void ReadObject(std::string_view key, std::vector<char> &buf) {
+      Davix::Uri uri(fUri + std::string(key));
+      Davix::DavFile obj(fCtx, fReqParams, uri);
+      // Danger: there are no size limits on the amount of data read into the buffer
+      // throws Davix::DavixException
+      obj.get(nullptr, buf);
+   }
+   void WriteObject(std::string_view key, const void *buffer, std::size_t nbytes) {
+      Davix::Uri uri(fUri + std::string(key));
+      Davix::DavFile target(fCtx, fReqParams, uri);
+      // throws Davix::DavixException
+      target.put(nullptr, static_cast<const char*>(buffer), nbytes);
+   }
+};
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT
+
+std::uint32_t
+ROOT::Experimental::Detail::RS3NTupleAnchor::Serialize(void *buffer) const
+{
+   using namespace ROOT::Experimental::Internal::RNTupleSerialization;
+   if (buffer != nullptr) {
+      auto bytes = reinterpret_cast<unsigned char *>(buffer);
+      bytes += SerializeUInt32(fVersion, bytes);
+      bytes += SerializeUInt32(fNBytesHeader, bytes);
+      bytes += SerializeUInt32(fLenHeader, bytes);
+      bytes += SerializeUInt32(fNBytesFooter, bytes);
+      bytes += SerializeUInt32(fLenFooter, bytes);
+   }
+   return 20;
+}
+
+std::uint32_t
+ROOT::Experimental::Detail::RS3NTupleAnchor::Deserialize(const void *buffer)
+{
+   using namespace ROOT::Experimental::Internal::RNTupleSerialization;
+   auto bytes = reinterpret_cast<const unsigned char *>(buffer);
+   bytes += DeserializeUInt32(bytes, &fVersion);
+   bytes += DeserializeUInt32(bytes, &fNBytesHeader);
+   bytes += DeserializeUInt32(bytes, &fLenHeader);
+   bytes += DeserializeUInt32(bytes, &fNBytesFooter);
+   bytes += DeserializeUInt32(bytes, &fLenFooter);
+   return 20;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+ROOT::Experimental::Detail::RPageSinkS3::RPageSinkS3(std::string_view ntupleName, std::string_view uri,
+   const RNTupleWriteOptions &options)
+   : RPageSink(ntupleName, options)
+   , fPageAllocator(std::make_unique<RPageAllocatorHeap>())
+   , fUri(uri)
+{
+   R__LOG_WARNING(NTupleLog()) << "The S3 backend is experimental and still under development. " <<
+      "Do not store real data with this version of RNTuple!";
+   fCompressor = std::make_unique<RNTupleCompressor>();
+   EnableDefaultMetrics("RPageSinkS3");
+   std::string ntplUri = fUri + std::string(ntupleName);
+   fS3Handle = std::make_unique<RS3Handle>(ntplUri);
+}
+
+ROOT::Experimental::Detail::RPageSinkS3::~RPageSinkS3() = default;
+
+void ROOT::Experimental::Detail::RPageSinkS3::CreateImpl(const RNTupleModel & /* model */)
+{
+   const auto &descriptor = fDescriptorBuilder.GetDescriptor();
+   auto szHeader = descriptor.GetHeaderSize();
+   auto buffer = std::make_unique<unsigned char[]>(szHeader);
+   descriptor.SerializeHeader(buffer.get());
+
+   auto zipBuffer = std::make_unique<unsigned char[]>(szHeader);
+   auto szZipHeader = fCompressor->Zip(buffer.get(), szHeader, fOptions->GetCompression(),
+      [&zipBuffer](const void *b, size_t n, size_t o){ memcpy(zipBuffer.get() + o, b, n); } );
+   WriteNTupleHeader(zipBuffer.get(), szZipHeader, szHeader);
+}
+
+
+ROOT::Experimental::RClusterDescriptor::RLocator
+ROOT::Experimental::Detail::RPageSinkS3::CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page)
+{
+   auto element = columnHandle.fColumn->GetElement();
+   RPageStorage::RSealedPage sealedPage;
+   {
+      RNTupleAtomicTimer timer(fCounters->fTimeWallZip, fCounters->fTimeCpuZip);
+      sealedPage = SealPage(page, *element, fOptions->GetCompression());
+   }
+
+   fCounters->fSzZip.Add(page.GetSize());
+   return CommitSealedPageImpl(columnHandle.fId, sealedPage);
+}
+
+ROOT::Experimental::RClusterDescriptor::RLocator
+ROOT::Experimental::Detail::RPageSinkS3::CommitSealedPageImpl(
+   DescriptorId_t /*columnId*/, const RPageStorage::RSealedPage &sealedPage)
+{
+   auto offsetData = fOid.fetch_add(1);
+   {
+      RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
+      fS3Handle->WriteObject(std::to_string(offsetData), sealedPage.fBuffer, sealedPage.fSize);
+   }
+
+   RClusterDescriptor::RLocator result;
+   result.fPosition = offsetData;
+   result.fBytesOnStorage = sealedPage.fSize;
+   fCounters->fNPageCommitted.Inc();
+   fCounters->fSzWritePayload.Add(sealedPage.fSize);
+   return result;
+}
+
+// todo(max) figure out we should implement CommitClusterImpl
+ROOT::Experimental::RClusterDescriptor::RLocator
+ROOT::Experimental::Detail::RPageSinkS3::CommitClusterImpl(ROOT::Experimental::NTupleSize_t /* nEntries */)
+{
+   return {};
+}
+
+void ROOT::Experimental::Detail::RPageSinkS3::CommitDatasetImpl()
+{
+   const auto &descriptor = fDescriptorBuilder.GetDescriptor();
+   auto szFooter = descriptor.GetFooterSize();
+   auto buffer = std::make_unique<unsigned char []>(szFooter);
+   descriptor.SerializeFooter(buffer.get());
+
+   auto zipBuffer = std::make_unique<unsigned char []>(szFooter);
+   auto szZipFooter = fCompressor->Zip(buffer.get(), szFooter, fOptions->GetCompression(),
+      [&zipBuffer](const void *b, size_t n, size_t o){ memcpy(zipBuffer.get() + o, b, n); } );
+   WriteNTupleFooter(zipBuffer.get(), szZipFooter, szFooter);
+   WriteNTupleAnchor();
+}
+
+void ROOT::Experimental::Detail::RPageSinkS3::WriteNTupleHeader(
+		const void *data, size_t nbytes, size_t lenHeader)
+{
+   fS3Handle->WriteObject(kOidHeader, data, nbytes);
+   fNTupleAnchor.fLenHeader = lenHeader;
+   fNTupleAnchor.fNBytesHeader = nbytes;
+}
+
+void ROOT::Experimental::Detail::RPageSinkS3::WriteNTupleFooter(
+		const void *data, size_t nbytes, size_t lenFooter)
+{
+   fS3Handle->WriteObject(kOidFooter, data, nbytes);
+   fNTupleAnchor.fLenFooter = lenFooter;
+   fNTupleAnchor.fNBytesFooter = nbytes;
+}
+
+void ROOT::Experimental::Detail::RPageSinkS3::WriteNTupleAnchor() {
+   const auto ntplSize = RS3NTupleAnchor::GetSize();
+   auto buffer = std::make_unique<unsigned char[]>(ntplSize);
+   fNTupleAnchor.Serialize(buffer.get());
+   fS3Handle->WriteObject(kOidAnchor, buffer.get(), ntplSize);
+}
+
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPageSinkS3::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
+{
+   if (nElements == 0)
+      nElements = fOptions->GetNElementsPerPage();
+   auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
+   return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
+}
+
+void ROOT::Experimental::Detail::RPageSinkS3::ReleasePage(RPage &page)
+{
+   fPageAllocator->DeletePage(page);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorS3::NewPage(
+   ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements)
+{
+   RPage newPage(columnId, mem, elementSize * nElements, elementSize);
+   newPage.TryGrow(nElements);
+   return newPage;
+}
+
+void ROOT::Experimental::Detail::RPageAllocatorS3::DeletePage(const RPage& page)
+{
+   if (page.IsNull())
+      return;
+   delete[] reinterpret_cast<unsigned char *>(page.GetBuffer());
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+ROOT::Experimental::Detail::RPageSourceS3::RPageSourceS3(
+   std::string_view ntupleName, std::string_view uri, const RNTupleReadOptions &options)
+   : RPageSource(ntupleName, options)
+   , fPageAllocator(std::make_unique<RPageAllocatorS3>())
+   , fPagePool(std::make_shared<RPagePool>())
+   , fUri(uri)
+{
+   RPageSource::fDecompressor = std::make_unique<RNTupleDecompressor>();
+   EnableDefaultMetrics("RPageSourceS3");
+   std::string ntplUri = fUri + std::string(ntupleName);
+   fS3Handle = std::make_unique<RS3Handle>(ntplUri);
+}
+
+ROOT::Experimental::Detail::RPageSourceS3::~RPageSourceS3() = default;
+
+ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceS3::AttachImpl()
+{
+   R__ASSERT(fS3Handle);
+   RNTupleDescriptorBuilder descBuilder;
+
+   RS3NTupleAnchor ntpl;
+   std::vector<char> buf;
+   buf.reserve(RS3NTupleAnchor::GetSize());
+   fS3Handle->ReadObject(kOidAnchor, buf);
+   if (buf.size() != RS3NTupleAnchor::GetSize()) {
+      throw ROOT::Experimental::RException(R__FAIL("error reading RNTuple anchor"));
+   }
+   ntpl.Deserialize(static_cast<void*>(buf.data()));
+
+   buf.clear();
+   buf.reserve(ntpl.fNBytesHeader);
+   fS3Handle->ReadObject(kOidHeader, buf);
+   if (buf.size() != ntpl.fNBytesHeader) {
+      throw ROOT::Experimental::RException(R__FAIL("error reading RNTuple header"));
+   }
+   auto unzipBuf = std::make_unique<unsigned char[]>(ntpl.fLenHeader);
+   fDecompressor->Unzip(buf.data(), ntpl.fNBytesHeader, ntpl.fLenHeader, unzipBuf.get());
+   descBuilder.SetFromHeader(unzipBuf.get());
+
+   buf.clear();
+   buf.reserve(ntpl.fNBytesFooter);
+   fS3Handle->ReadObject(kOidFooter, buf);
+   if (buf.size() != ntpl.fNBytesFooter) {
+      throw ROOT::Experimental::RException(R__FAIL("error reading RNTuple footer"));
+   }
+   unzipBuf = std::make_unique<unsigned char[]>(ntpl.fLenFooter);
+   fDecompressor->Unzip(buf.data(), ntpl.fNBytesFooter, ntpl.fLenFooter, unzipBuf.get());
+   descBuilder.AddClustersFromFooter(unzipBuf.get());
+
+   return descBuilder.MoveDescriptor();
+}
+
+// todo(max) implement LoadSealedPage
+void ROOT::Experimental::Detail::RPageSourceS3::LoadSealedPage(
+   DescriptorId_t columnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage)
+{
+   (void)columnId;
+   (void)clusterIndex;
+   (void)sealedPage;
+}
+
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceS3::PopulatePageFromCluster(
+   ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor, ClusterSize_t::ValueType idxInCluster)
+{
+   const auto columnId = columnHandle.fId;
+   const auto clusterId = clusterDescriptor.GetId();
+
+   auto pageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
+
+   const auto element = columnHandle.fColumn->GetElement();
+   const auto elementSize = element->GetSize();
+   const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
+
+   const void *sealedPageBuffer = nullptr; // points either to directReadBuffer or to a read-only page in the cluster
+   std::unique_ptr<unsigned char []> directReadBuffer; // only used if cluster pool is turned off
+
+   // todo(max) enable cluster cache
+   std::vector<char> buf;
+   buf.reserve(bytesOnStorage);
+   fS3Handle->ReadObject(std::to_string(pageInfo.fLocator.fPosition), buf);
+   R__ASSERT(buf.size() == bytesOnStorage);
+   directReadBuffer = std::make_unique<unsigned char[]>(bytesOnStorage);
+   memcpy(directReadBuffer.get(), buf.data(), bytesOnStorage);
+   fCounters->fNPageLoaded.Inc();
+   fCounters->fNRead.Inc();
+   fCounters->fSzReadPayload.Add(bytesOnStorage);
+   sealedPageBuffer = directReadBuffer.get();
+
+   std::unique_ptr<unsigned char []> pageBuffer;
+   {
+      RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
+      pageBuffer = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element);
+      fCounters->fSzUnzip.Add(elementSize * pageInfo.fNElements);
+   }
+
+   const auto indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex;
+   auto newPage = fPageAllocator->NewPage(columnId, pageBuffer.release(), elementSize, pageInfo.fNElements);
+   newPage.SetWindow(indexOffset + pageInfo.fFirstInPage, RPage::RClusterInfo(clusterId, indexOffset));
+   fPagePool->RegisterPage(newPage,
+      RPageDeleter([](const RPage &page, void * /*userData*/)
+      {
+         RPageAllocatorS3::DeletePage(page);
+      }, nullptr));
+   fCounters->fNPagePopulated.Inc();
+   return newPage;
+}
+
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceS3::PopulatePage(
+   ColumnHandle_t columnHandle, NTupleSize_t globalIndex)
+{
+   const auto columnId = columnHandle.fId;
+   auto cachedPage = fPagePool->GetPage(columnId, globalIndex);
+   if (!cachedPage.IsNull())
+      return cachedPage;
+
+   const auto clusterId = fDescriptor.FindClusterId(columnId, globalIndex);
+   R__ASSERT(clusterId != kInvalidDescriptorId);
+   const auto &clusterDescriptor = fDescriptor.GetClusterDescriptor(clusterId);
+   const auto selfOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex;
+   R__ASSERT(selfOffset <= globalIndex);
+   return PopulatePageFromCluster(columnHandle, clusterDescriptor, globalIndex - selfOffset);
+}
+
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceS3::PopulatePage(
+   ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex)
+{
+   const auto clusterId = clusterIndex.GetClusterId();
+   const auto idxInCluster = clusterIndex.GetIndex();
+   const auto columnId = columnHandle.fId;
+   auto cachedPage = fPagePool->GetPage(columnId, clusterIndex);
+   if (!cachedPage.IsNull())
+      return cachedPage;
+
+   R__ASSERT(clusterId != kInvalidDescriptorId);
+   const auto &clusterDescriptor = fDescriptor.GetClusterDescriptor(clusterId);
+   return PopulatePageFromCluster(columnHandle, clusterDescriptor, idxInCluster);
+}
+
+void ROOT::Experimental::Detail::RPageSourceS3::ReleasePage(RPage &page)
+{
+   fPagePool->ReturnPage(page);
+}
+
+std::unique_ptr<ROOT::Experimental::Detail::RPageSource>
+ROOT::Experimental::Detail::RPageSourceS3::Clone() const {
+   return std::make_unique<RPageSourceS3>(fNTupleName, fUri, fOptions);
+}
+
+std::unique_ptr<ROOT::Experimental::Detail::RCluster>
+ROOT::Experimental::Detail::RPageSourceS3::LoadCluster(DescriptorId_t clusterId, const ColumnSet_t &columns)
+{
+   (void)columns;
+   return std::make_unique<RCluster>(clusterId);
+}

--- a/tree/ntuple/v7/src/RPageStorageS3.cxx
+++ b/tree/ntuple/v7/src/RPageStorageS3.cxx
@@ -69,14 +69,20 @@ public:
       Davix::Uri uri(fUri + std::string(key));
       Davix::DavFile obj(fCtx, fReqParams, uri);
       // Danger: there are no size limits on the amount of data read into the buffer
-      // throws Davix::DavixException
-      obj.get(nullptr, buf);
+      try {
+         obj.get(nullptr, buf);
+      } catch (const Davix::DavixException &err) {
+         throw ROOT::Experimental::RException(R__FAIL(std::string("S3 read error: ") + err.what()));
+      }
    }
    void WriteObject(std::string_view key, const void *buffer, std::size_t nbytes) {
       Davix::Uri uri(fUri + std::string(key));
       Davix::DavFile target(fCtx, fReqParams, uri);
-      // throws Davix::DavixException
-      target.put(nullptr, static_cast<const char*>(buffer), nbytes);
+      try {
+         target.put(nullptr, static_cast<const char*>(buffer), nbytes);
+      } catch (const Davix::DavixException &err) {
+         throw ROOT::Experimental::RException(R__FAIL(std::string("S3 write error: ") + err.what()));
+      }
    }
 };
 

--- a/tree/ntuple/v7/src/RPageStorageS3.cxx
+++ b/tree/ntuple/v7/src/RPageStorageS3.cxx
@@ -42,12 +42,15 @@ private:
    Davix::RequestParams fReqParams;
 public:
    RS3Handle() = default;
-   explicit RS3Handle(std::string_view uri) : fUri(uri) {
-      if (fUri.empty()) {
-         throw ROOT::Experimental::RException(R__FAIL("Empty S3 URI"));
+   explicit RS3Handle(std::string_view ntupleName, std::string_view uri) {
+      R__ASSERT(!ntupleName.empty() && !uri.empty());
+      fUri += uri;
+      if (uri.back() != '/') {
+         fUri += '/';
       }
-      if (fUri.back() != '/') {
-         fUri.push_back('/');
+      fUri += ntupleName;
+      if (ntupleName.back() != '/') {
+         fUri += '/';
       }
       const char *s3_sec = getenv("S3_SECRET_KEY");
       const char *s3_acc = getenv("S3_ACCESS_KEY");
@@ -132,8 +135,7 @@ ROOT::Experimental::Detail::RPageSinkS3::RPageSinkS3(std::string_view ntupleName
       "Do not store real data with this version of RNTuple!";
    fCompressor = std::make_unique<RNTupleCompressor>();
    EnableDefaultMetrics("RPageSinkS3");
-   std::string ntplUri = fUri + std::string(ntupleName);
-   fS3Handle = std::make_unique<RS3Handle>(ntplUri);
+   fS3Handle = std::make_unique<RS3Handle>(ntupleName, fUri);
 }
 
 ROOT::Experimental::Detail::RPageSinkS3::~RPageSinkS3() = default;
@@ -274,8 +276,7 @@ ROOT::Experimental::Detail::RPageSourceS3::RPageSourceS3(
 {
    RPageSource::fDecompressor = std::make_unique<RNTupleDecompressor>();
    EnableDefaultMetrics("RPageSourceS3");
-   std::string ntplUri = fUri + std::string(ntupleName);
-   fS3Handle = std::make_unique<RS3Handle>(ntplUri);
+   fS3Handle = std::make_unique<RS3Handle>(ntupleName, fUri);
 }
 
 ROOT::Experimental::Detail::RPageSourceS3::~RPageSourceS3() = default;

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -56,3 +56,8 @@ if(daos OR daos_mock)
 
   ROOT_ADD_GTEST(ntuple_storage_daos ntuple_storage_daos.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 endif()
+
+if (davix OR builtin_davix)
+  ROOT_ADD_GTEST(ntuple_storage_s3 ntuple_storage_s3.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+  target_link_libraries(ntuple_storage_s3 PRIVATE ${DAOS_LIBRARIES})
+endif()

--- a/tree/ntuple/v7/test/ntuple_storage_s3.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_s3.cxx
@@ -2,8 +2,7 @@
 
 TEST(RNTuple, S3Basics)
 {
-   std::string s3Uri("s3://ntpl0.s3.us-east-2.amazonaws.com/");
-
+   std::string s3Uri("s3://ntpl0.s3.us-east-2.amazonaws.com");
    {
       auto model = RNTupleModel::Create();
       auto pt = model->MakeField<float>("pt");

--- a/tree/ntuple/v7/test/ntuple_storage_s3.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_s3.cxx
@@ -1,0 +1,30 @@
+#include "ntuple_test.hxx"
+
+TEST(RNTuple, S3Basics)
+{
+   std::string s3Uri("s3://ntpl0.s3.us-east-2.amazonaws.com/");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto pt = model->MakeField<float>("pt");
+      auto vec = model->MakeField<std::vector<int>>("vec");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "my_ntuple", s3Uri);
+      for (int i = 0; i < 100; i++) {
+         *pt = 42.0;
+         *vec = {1, 2, 3};
+         writer->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("my_ntuple", s3Uri);
+   ntuple->PrintInfo();
+   ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kStorageDetails);
+   EXPECT_EQ(100U, ntuple->GetNEntries());
+
+   auto pt = ntuple->GetView<float>("pt");
+   auto vec = ntuple->GetView<std::vector<int>>("vec");
+   for (auto i : ntuple->GetEntryRange()) {
+      EXPECT_EQ(42.0, pt(i));
+      EXPECT_EQ((std::vector<int>{1, 2, 3}), vec(i));
+   }
+}


### PR DESCRIPTION
Add a new page source and sink that use S3 as the backing store. Davix
is used as the S3 interface. The implementation is nearly identical
to the DAOS backend and there is a lot of duplicated code.

```cpp
std::string s3Uri("s3://$(S3_BUCKET).$(S3_HOST)");
{
   auto model = RNTupleModel::Create();
   auto pt = model->MakeField<float>("pt");
   auto vec = model->MakeField<std::vector<int>>("vec");
   // create a new RNTuple named `my_ntuple`
   // -- objects are written to /bucket/my_ntuple/
   auto writer = RNTupleWriter::Recreate(std::move(model), "my_ntuple", s3Uri);
   for (int i = 0; i < 100; i++) {
      *pt = 42.0;
      *vec = {1, 2, 3};
      writer->Fill();
   }
}

// opens the RNTuple at the path /bucket/my_ntuple/
auto ntuple = RNTupleReader::Open("my_ntuple", s3Uri);
```
results in the following objects stored in the bucket:
```shell
my_ntuple/0 # page 0, 1, ... 
my_ntuple/1
my_ntuple/18446744073709551613 # footer
my_ntuple/18446744073709551614 # header
my_ntuple/18446744073709551615 # anchor
my_ntuple/2
```
Like the current DAOS backend, one object is allocated for every page,
plus three for the header, footer, and anchor. Performance will not be
very good yet as only a single request at a time is issued.

Pages are issued keys sequentially from 0, like the DAOS backend. There
are three reserved keys:
* anchor: u64(-1)
* header: u64(-2)
* footer: u64(-3)

S3 access is controlled using the (ROOT & Davix-compatible) envvars:
* S3_REGION
* S3_SECRET_KEY
* S3_ACCESS_KEY

Perhaps these should be changed to the official AWS envvars.

Todo:
- [ ] re-add cluster caching functionality to `PopulatePageFromCluster`
- [ ] implement `LoadCluster`
- [ ] test mocks
- [ ] test with real RNTuples
- [ ] issue concurrent requests to S3