### PR TITLE
[RF] Move creation of constraint sum out of RooAbsPdf::createNLL

### DIFF
--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -280,10 +280,6 @@ public:
 
   virtual RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=0, const RooArgSet* auxProto=0, 
 					   Bool_t verbose=kFALSE, Bool_t autoBinned=kTRUE, const char* binnedTag="") const ;
-  
-  std::string getConstraintSetCacheName(RooArgSet const& observables) const;
-  RooArgSet const* tryToGetConstraintSetFromWorkspace(RooArgSet const& observables) const;
-  void tryToCacheConstraintSetInWorkspace(RooArgSet const& observables, RooArgSet const& constraints) const;
 
 private:
 

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -280,6 +280,10 @@ public:
 
   virtual RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=0, const RooArgSet* auxProto=0, 
 					   Bool_t verbose=kFALSE, Bool_t autoBinned=kTRUE, const char* binnedTag="") const ;
+  
+  std::string getConstraintSetCacheName(RooArgSet const& observables) const;
+  RooArgSet const* tryToGetConstraintSetFromWorkspace(RooArgSet const& observables) const;
+  void tryToCacheConstraintSetInWorkspace(RooArgSet const& observables, RooArgSet const& constraints) const;
 
 private:
 

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -22,6 +22,7 @@
 
 class RooRealVar;
 class RooArgList ;
+class RooWorkspace ;
 
 class RooConstraintSum : public RooAbsReal {
 public:
@@ -41,7 +42,8 @@ public:
         RooArgSet const* constrainedParameters,
         RooArgSet const* externalConstraints,
         RooArgSet const* globalObservables,
-        const char* globalObservablesTag);
+        const char* globalObservablesTag,
+        RooWorkspace * workspace = nullptr);
 
 protected:
 

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -19,7 +19,6 @@
 #include "RooAbsReal.h"
 #include "RooListProxy.h"
 #include "RooSetProxy.h"
-#include "TStopwatch.h"
 
 class RooRealVar;
 class RooArgList ;
@@ -27,9 +26,8 @@ class RooArgList ;
 class RooConstraintSum : public RooAbsReal {
 public:
 
-  RooConstraintSum() ;
+  RooConstraintSum() {}
   RooConstraintSum(const char *name, const char *title, const RooArgSet& constraintSet, const RooArgSet& paramSet) ;
-  virtual ~RooConstraintSum() ;
 
   RooConstraintSum(const RooConstraintSum& other, const char* name = 0);
   virtual TObject* clone(const char* newname) const { return new RooConstraintSum(*this, newname); }

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -36,6 +36,15 @@ public:
 
   const RooArgList& list() { return _set1 ; }
 
+  static std::unique_ptr<RooAbsReal> createConstraintTerm(
+        std::string const& name,
+        RooAbsPdf const& pdf,
+        RooArgSet const& observables,
+        RooArgSet const* constrainedParameters,
+        RooArgSet const* externalConstraints,
+        RooArgSet const* globalObservables,
+        const char* globalObservablesTag);
+
 protected:
 
   RooListProxy _set1 ;    // Set of constraint terms

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -248,6 +248,7 @@ public:
  private:
     friend class RooAbsArg;
     friend class RooAbsPdf;
+    friend class RooConstraintSum;
     Bool_t defineSetInternal(const char *name, const RooArgSet &aset);
 
     Bool_t isValidCPPID(const char *name);

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1126,7 +1126,8 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
           pc.getSet("cPars"), // Constrain RooCmdArg
           pc.getSet("extCons"), // ExternalConstraints RooCmdArg
           pc.getSet("glObs"), // GlobalObservables RooCmdArg
-          pc.getString("globstag",0,true) // GlobalObservablesTag RooCmdArg
+          pc.getString("globstag",0,true), // GlobalObservablesTag RooCmdArg
+          _myws // passing workspace to cache the set of constraints
   );
 
   // Include constraints, if any, in likelihood
@@ -3645,38 +3646,5 @@ void RooAbsPdf::setNormRangeOverride(const char* rangeName)
   if (_norm) {
     _normMgr.sterilize() ;
     _norm = 0 ;
-  }
-}
-
-
-std::string RooAbsPdf::getConstraintSetCacheName(RooArgSet const& observables) const {
-  auto observableNames = RooHelpers::getColonSeparatedNameString(observables);
-  return std::string("CACHE_CONSTR_OF_PDF_") + GetName() + "_FOR_OBS_" +  observableNames;
-}
-
-
-RooArgSet const* RooAbsPdf::tryToGetConstraintSetFromWorkspace(RooArgSet const& observables) const {
-  if(!_myws) return nullptr;
-
-  const std::string constraintSetCacheName = getConstraintSetCacheName(observables);
-
-  if(_myws->set(constraintSetCacheName.c_str())) {
-    // retrieve from cache
-    const RooArgSet *constr = _myws->set(getConstraintSetCacheName(observables).c_str());
-    coutI(Minimization) << "createNLL picked up cached constraints from workspace with " << constr->size()
-                        << " entries" << endl;
-    return constr;
-  }
-  return nullptr;
-}
-
-
-void RooAbsPdf::tryToCacheConstraintSetInWorkspace(RooArgSet const& observables, RooArgSet const& constraints) const {
-  // write to cache
-  if (_myws) {
-     const std::string constraintSetCacheName = getConstraintSetCacheName(observables);
-     coutI(Minimization) << "createNLL: caching constraint set under name "
-                         << constraintSetCacheName << " with " << constraints.size() << " entries" << endl;
-     _myws->defineSetInternal(constraintSetCacheName.c_str(), constraints);
   }
 }

--- a/roofit/roofitcore/src/RooConstraintSum.cxx
+++ b/roofit/roofitcore/src/RooConstraintSum.cxx
@@ -27,41 +27,20 @@ arguments.
 **/
 
 
-#include "RooFit.h"
-
-#include "Riostream.h"
-#include <math.h>
-
 #include "RooConstraintSum.h"
 #include "RooAbsReal.h"
 #include "RooAbsPdf.h"
 #include "RooErrorHandler.h"
 #include "RooArgSet.h"
-#include "RooNLLVar.h"
-#include "RooChi2Var.h"
 #include "RooMsgService.h"
 
 #include <ROOT/RMakeUnique.hxx>
 
-using namespace std;
-
 ClassImp(RooConstraintSum);
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Default constructor
-
-RooConstraintSum::RooConstraintSum()
-{
-
-}
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor with set of constraint p.d.f.s. All elements in constraintSet must inherit from RooAbsPdf
+/// Constructor with set of constraint p.d.f.s. All elements in constraintSet must inherit from RooAbsPdf.
 
 RooConstraintSum::RooConstraintSum(const char* name, const char* title, const RooArgSet& constraintSet, const RooArgSet& normSet) :
   RooAbsReal(name, title),
@@ -71,7 +50,7 @@ RooConstraintSum::RooConstraintSum(const char* name, const char* title, const Ro
   for (const auto comp : constraintSet) {
     if (!dynamic_cast<RooAbsPdf*>(comp)) {
       coutE(InputArguments) << "RooConstraintSum::ctor(" << GetName() << ") ERROR: component " << comp->GetName() 
-			    << " is not of type RooAbsPdf" << endl ;
+                            << " is not of type RooAbsPdf" << std::endl ;
       RooErrorHandler::softAbort() ;
     }
     _set1.add(*comp) ;
@@ -81,34 +60,19 @@ RooConstraintSum::RooConstraintSum(const char* name, const char* title, const Ro
 }
 
 
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor
+/// Copy constructor.
 
 RooConstraintSum::RooConstraintSum(const RooConstraintSum& other, const char* name) :
   RooAbsReal(other, name), 
   _set1("set1",this,other._set1),
   _paramSet("paramSet",this,other._paramSet)
 {
-
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooConstraintSum::~RooConstraintSum() 
-{
-
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return sum of -log of constraint p.d.f.s
+/// Return sum of -log of constraint p.d.f.s.
 
 Double_t RooConstraintSum::evaluate() const 
 {
@@ -141,14 +105,14 @@ std::unique_ptr<RooArgSet> getGlobalObservables(
 
   if(globalObservablesTag) {
     oocoutI(&pdf, Minimization) << "User-defined specification of global observables definition with tag named '"
-                                <<  globalObservablesTag << "'" << endl;
+                                <<  globalObservablesTag << "'" << std::endl;
   } else {
     // Neither GlobalObservables nor GlobalObservablesTag has been processed -
     // try if a default tag is defined in the head node Check if head not
     // specifies default global observable tag
     if(auto defaultGlobalObservablesTag = pdf.getStringAttribute("DefaultGlobalObservablesTag")) {
       oocoutI(&pdf, Minimization) << "p.d.f. provides built-in specification of global observables definition "
-                                  << "with tag named '" <<  defaultGlobalObservablesTag << "'" << endl;
+                                  << "with tag named '" <<  defaultGlobalObservablesTag << "'" << std::endl;
       globalObservablesTag = defaultGlobalObservablesTag;
     }
   }
@@ -230,9 +194,9 @@ std::unique_ptr<RooAbsReal> RooConstraintSum::createConstraintTerm(
 
   if (!allConstraints.empty()) {
 
-    oocoutI(&pdf, Minimization) << " Including the following constraint terms in minimization: " << allConstraints << endl ;
+    oocoutI(&pdf, Minimization) << " Including the following constraint terms in minimization: " << allConstraints << std::endl ;
     if (glObs) {
-      oocoutI(&pdf, Minimization) << "The following global observables have been defined: " << *glObs << endl ;
+      oocoutI(&pdf, Minimization) << "The following global observables have been defined: " << *glObs << std::endl ;
     }
     auto constraintTerm = std::make_unique<RooConstraintSum>(name.c_str(),"nllCons",allConstraints,glObs ? *glObs : cPars) ;
     constraintTerm->setOperMode(RooAbsArg::ADirty) ;


### PR DESCRIPTION
The logic to create the constraint sum for a given pdf is moved to the
`RooConstraintSum` class as a static member function.

This makes the remaining code in RooAbsPdf easier to understand and also
allows for easy creation of the constraint sum outside of
`RooAbsPdf::createNL`, which is useful for debugging and manually creating likelihoods. And for reusing the
constraint term in other placed (intended for the new RooFit batch mode).

This change also makes it easier to see which command args go into the constraint term.