### PR TITLE
Fix Display output when friend trees are present

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -990,19 +990,25 @@ You see how we created one `double` variable for each thread in the pool, and la
 
 \anchor friends
 ### Friend trees
-Friend trees are supported by RDataFrame.
-In order to deal with friend trees with RDataFrame, the user is required to build
-the tree and its friends and instantiate a RDataFrame with it.
+Friend TTrees are supported by RDataFrame.
+Friend TTrees with a TTreeIndex are supported starting from ROOT v6.24.
+
+To use friend trees in RDataFrame, it's necessary to add the friends directly to
+the tree and instantiate a RDataFrame with the main tree:
+
 ~~~{.cpp}
 TTree t([...]);
 TTree ft([...]);
-t.AddFriend(ft, "myFriend");
+t.AddFriend(&ft, "myFriend");
 
 RDataFrame d(t);
 auto f = d.Filter("myFriend.MyCol == 42");
 ~~~
 
-Friend TTrees with a TTreeIndex are supported from ROOT v6.24.
+Columns coming from the friend trees can be referred to by their full name, like in the example above,
+or the friend tree name can be omitted in case the branch name is not ambiguous (e.g. "MyCol" could be used instead of
+      "myFriend.MyCol" in the example above).
+
 
 \anchor other-file-formats
 ### Reading data formats other than ROOT trees

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -69,10 +69,10 @@ static bool ContainsLeaf(const std::set<TLeaf *> &leaves, TLeaf *leaf)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// This overload does not perform any check on the duplicates.
-/// It is used for TBranch objects.
+/// This overload does not check whether the leaf/branch is already in bNamesReg. In case this is a friend leaf/branch,
+/// `allowDuplicates` controls whether we add both `friendname.bname` and `bname` or just the shorter version.
 static void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, const std::string &branchName,
-                             const std::string &friendName)
+                             const std::string &friendName, bool allowDuplicates)
 {
    if (!friendName.empty()) {
       // In case of a friend tree, users might prepend its name/alias to the branch names
@@ -81,8 +81,10 @@ static void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bN
          bNames.push_back(friendBName);
    }
 
-   if (bNamesReg.insert(branchName).second)
-      bNames.push_back(branchName);
+   if (allowDuplicates || friendName.empty()) {
+      if (bNamesReg.insert(branchName).second)
+         bNames.push_back(branchName);
+   }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -96,13 +98,13 @@ static void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bN
       return;
    }
 
-   InsertBranchName(bNamesReg, bNames, branchName, friendName);
+   InsertBranchName(bNamesReg, bNames, branchName, friendName, allowDuplicates);
 
    foundLeaves.insert(leaf);
 }
 
 static void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames, TBranch *b,
-                          std::string prefix, std::string &friendName)
+                          std::string prefix, std::string &friendName, bool allowDuplicates)
 {
    for (auto sb : *b->GetListOfBranches()) {
       TBranch *subBranch = static_cast<TBranch *>(sb);
@@ -113,16 +115,17 @@ static void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnName
       if (!prefix.empty())
          newPrefix = fullName + ".";
 
-      ExploreBranch(t, bNamesReg, bNames, subBranch, newPrefix, friendName);
+      ExploreBranch(t, bNamesReg, bNames, subBranch, newPrefix, friendName, allowDuplicates);
 
       auto branchDirectlyFromTree = t.GetBranch(fullName.c_str());
       if (!branchDirectlyFromTree)
          branchDirectlyFromTree = t.FindBranch(fullName.c_str()); // try harder
       if (branchDirectlyFromTree)
-         InsertBranchName(bNamesReg, bNames, std::string(branchDirectlyFromTree->GetFullName()), friendName);
+         InsertBranchName(bNamesReg, bNames, std::string(branchDirectlyFromTree->GetFullName()), friendName,
+                          allowDuplicates);
 
       if (t.GetBranch(subBranchName.c_str()))
-         InsertBranchName(bNamesReg, bNames, subBranchName, friendName);
+         InsertBranchName(bNamesReg, bNames, subBranchName, friendName, allowDuplicates);
    }
 }
 
@@ -163,8 +166,8 @@ static void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, Colum
             }
          } else if (branch->IsA() == TBranchObject::Class()) {
             // TBranchObject
-            ExploreBranch(t, bNamesReg, bNames, branch, branchName + ".", friendName);
-            InsertBranchName(bNamesReg, bNames, branchName, friendName);
+            ExploreBranch(t, bNamesReg, bNames, branch, branchName + ".", friendName, allowDuplicates);
+            InsertBranchName(bNamesReg, bNames, branchName, friendName, allowDuplicates);
          } else {
             // TBranchElement
             // Check if there is explicit or implicit dot in the name
@@ -178,11 +181,11 @@ static void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, Colum
                dotIsImplied = true;
 
             if (dotIsImplied || branchName.back() == '.')
-               ExploreBranch(t, bNamesReg, bNames, branch, "", friendName);
+               ExploreBranch(t, bNamesReg, bNames, branch, "", friendName, allowDuplicates);
             else
-               ExploreBranch(t, bNamesReg, bNames, branch, branchName + ".", friendName);
+               ExploreBranch(t, bNamesReg, bNames, branch, branchName + ".", friendName, allowDuplicates);
 
-            InsertBranchName(bNamesReg, bNames, branchName, friendName);
+            InsertBranchName(bNamesReg, bNames, branchName, friendName, allowDuplicates);
          }
       }
    }

--- a/tree/dataframe/test/dataframe_display.cxx
+++ b/tree/dataframe/test/dataframe_display.cxx
@@ -229,3 +229,19 @@ TEST(RDFDisplayTests, SubBranch)
    const auto expected = "p.a | p.b | \n42  | 84  | \n    |     | \n";
    EXPECT_EQ(res, expected);
 }
+
+// https://github.com/root-project/root/issues/8450
+TEST(RDFDisplayTests, Friends)
+{
+  TTree main("main", "main");
+  main.Fill();
+  TTree fr("friend", "friend");
+  int x = 0;
+  fr.Branch("x", &x);
+  fr.Fill();
+  main.AddFriend(&fr);
+
+  const auto res = ROOT::RDataFrame(main).Display()->AsString();
+  const auto expected = "friend.x | \n0        | \n         | \n";
+  EXPECT_EQ(res, expected);
+}


### PR DESCRIPTION
Before this patch, friend branches or leaves were listed in the output of `GetColumnNames` twice, as `friendname.bname` and as `bname`. Now we only list the longer version.

This fixes #8450 as a side-effect.

This PR also adds a test and improves the related docs.

Rationale for the change in behavior of `GetColumnNames`: currently, in RDataFrame we have (fairly convoluted) logic to retrieve 3 different lists of branch names given a TTree/TChain:

1. a user-readable of list of available column names returned by `df.GetColumnNames()`
2. a larger list of all valid spellings for all column names, used to validate user inputs (this includes all names returned by `df.GetColumnNames()` plus alternative spellings such as `branchname.leafname` when `branchname == leafname`, shorthands for `friendname.branchname` as just `branchname`, etc.
3. a list of only top-level branches that we use as the list of branches to `Snapshot` by default

Before this patch `df.GetColumnNames()` returned multiple valid spellings for the same friend branch. That can be confusing, so I'd rather (try to) return only one valid spelling for each available branch/leaf. For consistency with `Display` and to not withhold information from users, among the two valid spellings we always show the "fully qualified friendname.branchname". Users can still use the shorthand "branchname" if it's not ambiguous, as the relevant documentation now points out.
I think this solution is the sweet spot between not being surprising (to users and to RDF developers), being easy to implement without further complicating or completely refactoring the branch-retrieval logic and being somewhat backward-compatible.