### PR TITLE
clang analysis on GitHub Actions

### DIFF
--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-BASE_COMMIT=$(git rev-parse $TRAVIS_BRANCH)
 echo "Running clang-format against branch $TRAVIS_BRANCH, with hash $BASE_COMMIT"
 COMMIT_FILES=$(git diff --name-only $BASE_COMMIT | grep -i -v LinkDef)
 RESULT_OUTPUT="$(git-clang-format --commit $BASE_COMMIT --diff --binary `which clang-format` $COMMIT_FILES)"

--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-BASE_COMMIT=$(git rev-parse $TRAVIS_BRANCH)
+# BASE_COMMIT=$(git rev-parse $TRAVIS_BRANCH)
 echo "Running clang-format against branch $TRAVIS_BRANCH, with hash $BASE_COMMIT"
 COMMIT_FILES=$(git diff --name-only $BASE_COMMIT | grep -i -v LinkDef)
 RESULT_OUTPUT="$(git-clang-format --commit $BASE_COMMIT --diff --binary `which clang-format` $COMMIT_FILES)"

--- a/.ci/format_script.sh
+++ b/.ci/format_script.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-# BASE_COMMIT=$(git rev-parse $TRAVIS_BRANCH)
+BASE_COMMIT=$(git rev-parse $TRAVIS_BRANCH)
 echo "Running clang-format against branch $TRAVIS_BRANCH, with hash $BASE_COMMIT"
 COMMIT_FILES=$(git diff --name-only $BASE_COMMIT | grep -i -v LinkDef)
 RESULT_OUTPUT="$(git-clang-format --commit $BASE_COMMIT --diff --binary `which clang-format` $COMMIT_FILES)"

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       TRAVIS_BRANCH: ${{ github.base_ref }} 
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
-      BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+      # BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
     steps:
     - uses: actions/checkout@v2
     - name: Fetch base_ref HEAD

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -17,5 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Fetch base_ref HEAD
       run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
+    - name: install clang-tools
+      run: sudo apt-get install -y clang-tools
     - name: run clang-format script
       run: .ci/format_script.sh

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -14,5 +14,7 @@ jobs:
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: run clang-format script
       run: .ci/format_script.sh

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -12,9 +12,8 @@ jobs:
     env:
       TRAVIS_BRANCH: ${{ github.base_ref }} 
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
+      BASE_COMMIT: ${{ github.event.pull_request.head.sha }}
     steps:
     - uses: actions/checkout@v2
-    - name: fetch base branch
-      run: git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin $TRAVIS_BRANCH
     - name: run clang-format script
       run: .ci/format_script.sh

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Fetch base_ref HEAD
       run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
-    - name: install clang-tools
-      run: sudo apt-get install -y clang-tools
+    - name: install clang-format
+      run: sudo apt-get install -y clang-format
     - name: run clang-format script
       run: .ci/format_script.sh

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -1,0 +1,18 @@
+name: clang-tools code analysis
+
+on:
+  # push:
+  #   branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    env:
+      TRAVIS_BRANCH: ${{ github.base_ref }} 
+      TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: run clang-format script
+      run: .ci/format_script.sh

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       TRAVIS_BRANCH: ${{ github.base_ref }} 
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
-      # BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+      BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
     steps:
     - uses: actions/checkout@v2
     - name: Fetch base_ref HEAD

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -14,7 +14,7 @@ jobs:
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
     steps:
     - uses: actions/checkout@v2
-    - name: also pull base branch
-      run: git pull origin $TRAVIS_BRANCH
+    - name: fetch base branch
+      run: git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin $TRAVIS_BRANCH
     - name: run clang-format script
       run: .ci/format_script.sh

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -14,7 +14,7 @@ jobs:
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - name: also pull base branch
+      run: git pull origin $TRAVIS_BRANCH
     - name: run clang-format script
       run: .ci/format_script.sh

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -1,10 +1,10 @@
 name: clang-tools code analysis
 
-on:
+on: pull_request
   # push:
   #   branches: [ $default-branch ]
-  pull_request:
-    branches: [ $default-branch ]
+  # pull_request:
+  #   branches: [ $default-branch ]
 
 jobs:
   clang-format:

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       TRAVIS_BRANCH: ${{ github.base_ref }} 
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
-      BASE_COMMIT: ${{ github.event.pull_request.head.sha }}
+      BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
     steps:
     - uses: actions/checkout@v2
     - name: run clang-format script

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -15,5 +15,7 @@ jobs:
       BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
     steps:
     - uses: actions/checkout@v2
+    - name: Fetch base_ref HEAD
+      run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
     - name: run clang-format script
       run: .ci/format_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,11 @@ matrix:
   include:
     - env: TOOL=clang-format
       script: &format_script
-        - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then .ci/format_script.sh; fi
+        - |
+          if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+            export BASE_COMMIT=$(git rev-parse $TRAVIS_BRANCH)
+            .ci/format_script.sh
+          fi
 
     - env: TOOL=clang-tidy-analyzer
       before_script: &copy_headers


### PR DESCRIPTION
# This Pull request:
Adds a GitHub Actions workflow that runs clang-format and clang-tidy on pull requests.

## Changes or fixes:
- Adds a GH Actions workflow that runs on pull requests
- Modifies one line of the format_script.sh so that both Travis and GH Actions can run it.
- Modifies the .travis.yml to pass in the base ref SHA hash to the format_script.sh.

## Checklist:

- [x] tested changes locally (see https://github.com/roofit-dev/root/pull/23)
- [ ] updated the docs (if necessary)
