### PR TITLE
[jupyter] configure ServerApp to let use "lab" properly

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -124,6 +124,12 @@ From now on, the likelihoods are normalized by the sum of integrals in each rang
 ## JavaScript ROOT
 
 
+## Jupyter lab
+
+- Let use created notebooks with viewers like https://nbviewer.jupyter.org/
+- Fix problem with using of local JSROOT version
+
+
 ## Tutorials
 
 

--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -67,7 +67,7 @@ function script_load_{jsDivId}(src, on_error) {{
     let script = document.createElement('script');
     script.src = src;
     script.onload = function() {{ display_{jsDivId}(JSROOT); }};
-    script.onerror = on_error;
+    script.onerror = function() {{ script.remove(); on_error(); }};
     document.head.appendChild(script);
 }}
 

--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -75,7 +75,7 @@ if (typeof requirejs !== 'undefined') {{
 
     // We are in jupyter notebooks, use require.js which should be configured already
     requirejs.config({{
-       paths: {{ 'JSRootCore' : [ 'scripts/JSRoot.core', 'https://root.cern/js/6.1.0/scripts/JSRoot.core.min', 'https://jsroot.gsi.de/6.1.0/scripts/JSRoot.core.min' ] }}
+       paths: {{ 'JSRootCore' : [ 'scripts/JSRoot.core', 'https://root.cern/js/6.1.1/scripts/JSRoot.core.min', 'https://jsroot.gsi.de/6.1.1/scripts/JSRoot.core.min' ] }}
     }})(['JSRootCore'],  function(Core) {{
        display_{jsDivId}(Core);
     }});
@@ -98,7 +98,7 @@ if (typeof requirejs !== 'undefined') {{
     // Try loading a local version of requirejs and fallback to cdn if not possible.
     script_load_{jsDivId}(base_url + 'static/scripts/JSRoot.core.js', function(){{
         console.error('Fail to load JSROOT locally, please check your jupyter_notebook_config.py file');
-        script_load_{jsDivId}('https://root.cern/js/6.1.0/scripts/JSRoot.core.min.js', function(){{
+        script_load_{jsDivId}('https://root.cern/js/6.1.1/scripts/JSRoot.core.min.js', function(){{
             document.getElementById("{jsDivId}").innerHTML = "Failed to load JSROOT";
         }});
     }});

--- a/etc/notebook/jupyter_notebook_config.py.in
+++ b/etc/notebook/jupyter_notebook_config.py.in
@@ -1,7 +1,13 @@
 import os
-if 'ROOTSYS' in os.environ:
-    # Prefer using JSROOT from ROOTSYS if defined
+if 'JSROOTSYS' in os.environ:
+    # Let use localy installed JSROOT as THttpServer does
+    c.NotebookApp.extra_static_paths.append(os.environ['JSROOTSYS'])
+    c.ServerApp.extra_static_paths.append(os.environ['JSROOTSYS'])
+elif 'ROOTSYS' in os.environ:
+    # By default use JSROOT from ROOTSYS if defined
     c.NotebookApp.extra_static_paths.append(os.path.join(os.environ['ROOTSYS'], 'js/'))
+    c.ServerApp.extra_static_paths.append(os.path.join(os.environ['ROOTSYS'], 'js/'))
 else:
     # Fall back to CMAKE_INSTALL_PREFIX/CMAKE_INSTALL_JSROOTDIR, e.g., for a system installation
     c.NotebookApp.extra_static_paths.append(os.path.join("@CMAKE_INSTALL_PREFIX@", "@CMAKE_INSTALL_JSROOTDIR@"))
+    c.ServerApp.extra_static_paths.append(os.path.join("@CMAKE_INSTALL_PREFIX@", "@CMAKE_INSTALL_JSROOTDIR@"))


### PR DESCRIPTION
Only then configuration of "static" paths is really used.
Small fix in utility.py, which only important with older JSROOT