### PR TITLE
[NFC][skip-ci] Mention why we check cgroup quotas in LogicalCPUBandwidthControl

### DIFF
--- a/core/imt/src/RTaskArena.cxx
+++ b/core/imt/src/RTaskArena.cxx
@@ -43,6 +43,7 @@
 namespace ROOT {
 namespace Internal {
 
+// To honor cgroup quotas if set: see https://github.com/oneapi-src/oneTBB/issues/190
 int LogicalCPUBandwithControl()
 {
 #ifdef R__LINUX


### PR DESCRIPTION
So we don't forget in case someone [asks again](https://mattermost.web.cern.ch/root/pl/s81mayu83infbcs79z5qi3peic)