### PR TITLE
Cosmetic change in a comment inside TH1::LabelsInflate() in the TH1.cxx

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -5243,7 +5243,7 @@ void TH1::LabelsDeflate(Option_t *ax)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Double the number of bins for axis.
-/// Refill histogram
+/// Refill histogram.
 /// This function is called by TAxis::FindBin(const char *label)
 
 void TH1::LabelsInflate(Option_t *ax)


### PR DESCRIPTION
This Pull request adds a missing period in a member-function description for better readability.

Changes or fixes: cosmetic change in the description of the `TH1::LabelsInflate()`. Without this change there is no newline between "Refill histogram" and "This function is called by..." as shown in this screenshot:
![image](https://user-images.githubusercontent.com/7541582/123423509-4dc71400-d5c8-11eb-8ea5-ca6ebad9dfe7.png)



Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)


