### PR TITLE
[cmake] Prevent inclusion of stdatomic.h in cxxmodules:

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -178,10 +178,14 @@ endif()
 # Darwin's complex.h does not implement C11's __STDC_NO_COMPLEX__, use the
 # header guard instead. This prevents inclusion of complex.h in Darwin.pcm.
 # GCC <=5 has _COMPLEX_H but none of the others.
+# __CLANG_STDATOMIC_H prevents inclusion of stdatomic in our Darwin.pcm: its
+# macros cause conflics with boost.
 target_compile_definitions(Core PRIVATE
   __STDC_NO_COMPLEX__
   __COMPLEX_H__
   _COMPLEX_H
+
+  __CLANG_STDATOMIC_H
  )
 
 #while basic libs do not depend on Core, we have to add includes directly


### PR DESCRIPTION
It causes a clash of a macro defined in stdatomic with an identifier in boost.
Fixes https://github.com/root-project/root/issues/6454.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

