### PR TITLE
[skip-ci] The anchor to doxyref was wrong

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -276,8 +276,10 @@ auto hpt = d.Define("pt", "sqrt(pxs * pxs + pys * pys)[E>200]")
             .Histo1D("pt");
 hpt->Draw();
 ~~~
-<a name="RVecdoxyref"></a>
+\anchor RVecdoxyref
+
 **/
+
 // clang-format on
 template <typename T>
 class RVec {


### PR DESCRIPTION
The [TOC last item](https://root.cern.ch/doc/master/classROOT_1_1VecOps_1_1RVec.html) was not active.

