### PR TITLE
Backport Jupyter fixes to v6.24

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -56,6 +56,21 @@ _jsCode = """
      style="width: {jsCanvasWidth}px; height: {jsCanvasHeight}px">
 </div>
 <script>
+
+function display_{jsDivId}(Core) {{
+   let obj = Core.parse({jsonContent});
+   Core.settings.HandleKeys = false;
+   Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
+}}
+
+function script_load_{jsDivId}(src, on_error) {{
+    let script = document.createElement('script');
+    script.src = src;
+    script.onload = function() {{ display_{jsDivId}(JSROOT); }};
+    script.onerror = on_error;
+    document.head.appendChild(script);
+}}
+
 if (typeof requirejs !== 'undefined') {{
 
     // We are in jupyter notebooks, use require.js which should be configured already
@@ -81,31 +96,14 @@ if (typeof requirejs !== 'undefined') {{
     }}
 
     // Try loading a local version of requirejs and fallback to cdn if not possible.
-    script_load(base_url + 'static/scripts/JSRoot.core.js', script_success, function(){{
-        console.error('Fail to load JSROOT locally, please check your jupyter_notebook_config.py file')
-        script_load('https://root.cern/js/6.1.0/scripts/JSRoot.core.min.js', script_success, function(){{
+    script_load_{jsDivId}(base_url + 'static/scripts/JSRoot.core.js', function(){{
+        console.error('Fail to load JSROOT locally, please check your jupyter_notebook_config.py file');
+        script_load_{jsDivId}('https://root.cern/js/6.1.0/scripts/JSRoot.core.min.js', function(){{
             document.getElementById("{jsDivId}").innerHTML = "Failed to load JSROOT";
         }});
     }});
 }}
 
-function script_load(src, on_load, on_error) {{
-    var script = document.createElement('script');
-    script.src = src;
-    script.onload = on_load;
-    script.onerror = on_error;
-    document.head.appendChild(script);
-}}
-
-function script_success() {{
-   display_{jsDivId}(JSROOT);
-}}
-
-function display_{jsDivId}(Core) {{
-   var obj = Core.parse({jsonContent});
-   Core.settings.HandleKeys = false;
-   Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
-}}
 </script>
 """
 

--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -67,7 +67,7 @@ function script_load_{jsDivId}(src, on_error) {{
     let script = document.createElement('script');
     script.src = src;
     script.onload = function() {{ display_{jsDivId}(JSROOT); }};
-    script.onerror = on_error;
+    script.onerror = function() {{ script.remove(); on_error(); }};
     document.head.appendChild(script);
 }}
 

--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -75,7 +75,7 @@ if (typeof requirejs !== 'undefined') {{
 
     // We are in jupyter notebooks, use require.js which should be configured already
     requirejs.config({{
-       paths: {{ 'JSRootCore' : [ 'scripts/JSRoot.core', 'https://root.cern/js/6.1.0/scripts/JSRoot.core.min', 'https://jsroot.gsi.de/6.1.0/scripts/JSRoot.core.min' ] }}
+       paths: {{ 'JSRootCore' : [ 'scripts/JSRoot.core', 'https://root.cern/js/6.1.1/scripts/JSRoot.core.min', 'https://jsroot.gsi.de/6.1.1/scripts/JSRoot.core.min' ] }}
     }})(['JSRootCore'],  function(Core) {{
        display_{jsDivId}(Core);
     }});
@@ -98,7 +98,7 @@ if (typeof requirejs !== 'undefined') {{
     // Try loading a local version of requirejs and fallback to cdn if not possible.
     script_load_{jsDivId}(base_url + 'static/scripts/JSRoot.core.js', function(){{
         console.error('Fail to load JSROOT locally, please check your jupyter_notebook_config.py file');
-        script_load_{jsDivId}('https://root.cern/js/6.1.0/scripts/JSRoot.core.min.js', function(){{
+        script_load_{jsDivId}('https://root.cern/js/6.1.1/scripts/JSRoot.core.min.js', function(){{
             document.getElementById("{jsDivId}").innerHTML = "Failed to load JSROOT";
         }});
     }});

--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -56,14 +56,14 @@ _jsCode = """
      style="width: {jsCanvasWidth}px; height: {jsCanvasHeight}px">
 </div>
 <script>
-if (typeof require !== 'undefined') {{
+if (typeof requirejs !== 'undefined') {{
 
     // We are in jupyter notebooks, use require.js which should be configured already
-    require(['scripts/JSRoot.core'],
-        function(Core) {{
-           display_{jsDivId}(Core);
-        }}
-    );
+    requirejs.config({{
+       paths: {{ 'JSRootCore' : [ 'scripts/JSRoot.core', 'https://root.cern/js/6.1.0/scripts/JSRoot.core.min', 'https://jsroot.gsi.de/6.1.0/scripts/JSRoot.core.min' ] }}
+    }})(['JSRootCore'],  function(Core) {{
+       display_{jsDivId}(Core);
+    }});
 
 }} else if (typeof JSROOT !== 'undefined') {{
 

--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -83,7 +83,7 @@ if (typeof require !== 'undefined') {{
     // Try loading a local version of requirejs and fallback to cdn if not possible.
     script_load(base_url + 'static/scripts/JSRoot.core.js', script_success, function(){{
         console.error('Fail to load JSROOT locally, please check your jupyter_notebook_config.py file')
-        script_load('https://root.cern/js/5.9.0/scripts/JSRootCore.min.js', script_success, function(){{
+        script_load('https://root.cern/js/6.1.0/scripts/JSRoot.core.min.js', script_success, function(){{
             document.getElementById("{jsDivId}").innerHTML = "Failed to load JSROOT";
         }});
     }});

--- a/etc/notebook/jupyter_notebook_config.py.in
+++ b/etc/notebook/jupyter_notebook_config.py.in
@@ -1,7 +1,13 @@
 import os
-if 'ROOTSYS' in os.environ:
-    # Prefer using JSROOT from ROOTSYS if defined
+if 'JSROOTSYS' in os.environ:
+    # Let use localy installed JSROOT as THttpServer does
+    c.NotebookApp.extra_static_paths.append(os.environ['JSROOTSYS'])
+    c.ServerApp.extra_static_paths.append(os.environ['JSROOTSYS'])
+elif 'ROOTSYS' in os.environ:
+    # By default use JSROOT from ROOTSYS if defined
     c.NotebookApp.extra_static_paths.append(os.path.join(os.environ['ROOTSYS'], 'js/'))
+    c.ServerApp.extra_static_paths.append(os.path.join(os.environ['ROOTSYS'], 'js/'))
 else:
     # Fall back to CMAKE_INSTALL_PREFIX/CMAKE_INSTALL_JSROOTDIR, e.g., for a system installation
     c.NotebookApp.extra_static_paths.append(os.path.join("@CMAKE_INSTALL_PREFIX@", "@CMAKE_INSTALL_JSROOTDIR@"))
+    c.ServerApp.extra_static_paths.append(os.path.join("@CMAKE_INSTALL_PREFIX@", "@CMAKE_INSTALL_JSROOTDIR@"))

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -101,11 +101,11 @@
    /** @summary JSROOT version id
      * @desc For the JSROOT release the string in format "major.minor.patch" like "6.0.0"
      * For the ROOT release string is "ROOT major.minor.patch" like "ROOT 6.24.00" */
-   JSROOT.version_id = "ROOT 6.24.00";
+   JSROOT.version_id = "ROOT 6.24.02";
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "23/03/2021";
+   JSROOT.version_date = "25/06/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -4352,13 +4352,13 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       painter.addPadButtons();
 
-      if (nocanvas && opt.indexOf("noframe") < 0)
-         drawFrame(divid, null);
+      let promise = (nocanvas && opt.indexOf("noframe") < 0) ? drawFrame(divid, null) : Promise.resolve(true);
+      return promise.then(() => {
+         // select global reference - required for keys handling
+         jsrp.selectActivePad({ pp: painter, active: true });
 
-      // select global reference - required for keys handling
-      jsrp.selectActivePad({ pp: painter, active: true });
-
-      return painter.drawPrimitives().then(() => {
+         return painter.drawPrimitives();
+      }).then(() => {
          painter.showPadButtons();
          return painter;
       });


### PR DESCRIPTION
1. Let use "static" folder correctly in `jupyter lab`
2. If local JSROOT not found, correctly load remote version
3. Let use produced notebooks in nbviewer
4. Includes JSROOT bugfix