### PR TITLE
[ntuple, browser] Use RField visitor to draw histograms

### DIFF
--- a/gui/browsable/src/RFieldHolder.hxx
+++ b/gui/browsable/src/RFieldHolder.hxx
@@ -16,21 +16,32 @@
 
 #include "TClass.h"
 
+namespace ROOT {
+namespace Experimental {
+namespace Detail {
+class RPageSource;
+}
+}
+}
+
 class RFieldHolder : public ROOT::Experimental::Browsable::RHolder {
-   std::shared_ptr<ROOT::Experimental::RNTupleReader> fNTuple;
+   std::shared_ptr<ROOT::Experimental::Detail::RPageSource> fNtplSource;
    std::string fParentName;
 
    ROOT::Experimental::DescriptorId_t fFieldId;
 
 public:
-   RFieldHolder(std::shared_ptr<ROOT::Experimental::RNTupleReader> tuple, const std::string &parent_name, ROOT::Experimental::DescriptorId_t id) : fNTuple(tuple), fParentName(parent_name), fFieldId(id) {}
+   RFieldHolder(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> ntplSource,
+                const std::string &parent_name,
+                ROOT::Experimental::DescriptorId_t id)
+                : fNtplSource(ntplSource), fParentName(parent_name), fFieldId(id) {}
 
    const TClass *GetClass() const override { return TClass::GetClass<ROOT::Experimental::RNTuple>(); }
 
    /** Returns direct (temporary) object pointer */
    const void *GetObject() const override { return nullptr; }
 
-   auto GetNTuple() const { return fNTuple; }
+   auto GetNtplSource() const { return fNtplSource; }
    auto GetParentName() const { return fParentName; }
    auto GetId() const { return fFieldId; }
 };

--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -71,10 +71,11 @@ class RFieldProvider : public RProvider {
             max += 2;
             if (min > 1) min -= 2;
             int npoints = TMath::Nint(max - min);
-            fHist = std::make_unique<TH1F>(fHist->GetName(), fHist->GetTitle(), npoints, min, max);
-            fHist->SetDirectory(nullptr);
+            std::unique_ptr<TH1> h1 = std::make_unique<TH1F>(fHist->GetName(), fHist->GetTitle(), npoints, min, max);
+            h1->SetDirectory(nullptr);
             for (Int_t n = 0; n < len; ++n)
-               fHist->Fill(buf[2 + 2*n], buf[1 + 2*n]);
+               h1->Fill(buf[2 + 2*n], buf[1 + 2*n]);
+            std::swap(fHist, h1);
          }
       }
 

--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -31,131 +31,6 @@ using namespace std::string_literals;
 template<typename T>
 using RField = ROOT::Experimental::RField<T>;
 
-namespace {
-
-class RDrawVisitor : public ROOT::Experimental::Detail::RFieldVisitor {
-private:
-   std::shared_ptr<ROOT::Experimental::Detail::RPageSource> fNtplSource;
-   std::unique_ptr<TH1> fHist;
-
-   /** Test collected entries if it looks like integer values and one can use better binning */
-   void TestHistBuffer()
-   {
-      auto len = fHist->GetBufferLength();
-      auto buf = fHist->GetBuffer();
-
-      if (!buf || (len < 5))
-         return;
-
-      Double_t min = buf[1], max = buf[1];
-      Bool_t is_integer = kTRUE;
-
-      for (Int_t n = 0; n < len; ++n) {
-         Double_t v = buf[2 + 2*n];
-         if (v > max) max = v;
-         if (v < min) min = v;
-         if (TMath::Abs(v - TMath::Nint(v)) > 1e-5) { is_integer = kFALSE; break; }
-      }
-
-      // special case when only integer values in short range - better binning
-      if (is_integer && (max-min < 100)) {
-         max += 2;
-         if (min > 1) min -= 2;
-         int npoints = TMath::Nint(max - min);
-         fHist = std::make_unique<TH1F>(fHist->GetName(), fHist->GetTitle(), npoints, min, max);
-         fHist->SetDirectory(nullptr);
-         for (Int_t n = 0; n < len; ++n)
-            fHist->Fill(buf[2 + 2*n], buf[1 + 2*n]);
-      }
-   }
-
-   template<typename T>
-   void FillHistogram(const RField<T> &field)
-   {
-      std::string title = "Drawing of RField "s + field.GetName();
-
-      fHist = std::make_unique<TH1F>("hdraw", title.c_str(), 100, 0, 0);
-      fHist->SetDirectory(nullptr);
-
-      auto bufsize = (fHist->GetBufferSize() - 1) / 2;
-      int cnt = 0;
-      if (bufsize > 10) bufsize-=3; else bufsize = -1;
-
-      auto view = ROOT::Experimental::RNTupleView<T>(field.GetOnDiskId(), fNtplSource.get());
-      for (auto i : view.GetFieldRange()) {
-         fHist->Fill(view(i));
-         if (++cnt == bufsize) {
-            TestHistBuffer();
-            ++cnt;
-         }
-      }
-      if (cnt < bufsize)
-         TestHistBuffer();
-
-      fHist->BufferEmpty();
-   }
-
-   void FillStringHistogram(const RField<std::string> &field)
-   {
-      std::map<std::string, int> values;
-
-      int nentries = 0;
-
-      auto view = ROOT::Experimental::RNTupleView<std::string>(field.GetOnDiskId(), fNtplSource.get());
-      for (auto i : view.GetFieldRange()) {
-          std::string v = view(i);
-          nentries++;
-          auto iter = values.find(v);
-          if (iter != values.end())
-             iter->second++;
-          else if (values.size() >= 50)
-             return;
-          else
-             values[v] = 0;
-      }
-
-      // now create histogram with labels
-
-      std::string title = "Drawing of RField "s + field.GetName();
-      fHist = std::make_unique<TH1F>("h",title.c_str(),3,0,3);
-      fHist->SetDirectory(nullptr);
-      fHist->SetStats(0);
-      fHist->SetEntries(nentries);
-      fHist->SetCanExtend(TH1::kAllAxes);
-      for (auto &entry : values)
-         fHist->Fill(entry.first.c_str(), entry.second);
-      fHist->LabelsDeflate();
-      fHist->Sumw2(kFALSE);
-   }
-
-public:
-   explicit RDrawVisitor(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> ntplSource) : fNtplSource(ntplSource)
-   {
-   }
-
-   TH1 *MoveHist() {
-      return fHist.release();
-   }
-
-   void VisitField(const ROOT::Experimental::Detail::RFieldBase & /* field */) final {}
-   void VisitBoolField(const RField<bool> &field) final { FillHistogram(field); }
-   void VisitFloatField(const RField<float> &field) final { FillHistogram(field); }
-   void VisitDoubleField(const RField<double> &field) final { FillHistogram(field); }
-   void VisitCharField(const RField<char> &field) final { FillHistogram(field); }
-   void VisitInt8Field(const RField<std::int8_t> &field) final { FillHistogram(field); }
-   void VisitInt16Field(const RField<std::int16_t> &field) final { FillHistogram(field); }
-   void VisitIntField(const RField<int> &field) final { FillHistogram(field); }
-   void VisitInt64Field(const RField<std::int64_t> &field) final { FillHistogram(field); }
-   void VisitStringField(const RField<std::string> &field) final { FillStringHistogram(field); }
-   void VisitUInt16Field(const RField<std::uint16_t> &field) final { FillHistogram(field); }
-   void VisitUInt32Field(const RField<std::uint32_t> &field) final { FillHistogram(field); }
-   void VisitUInt64Field(const RField<std::uint64_t> &field) final { FillHistogram(field); }
-   void VisitUInt8Field(const RField<std::uint8_t> &field) final { FillHistogram(field); }
-};
-
-} // anonymous namespace
-
-
 // ==============================================================================================
 
 /** \class RFieldProvider
@@ -167,8 +42,128 @@ public:
 */
 
 class RFieldProvider : public RProvider {
-public:
+   class RDrawVisitor : public ROOT::Experimental::Detail::RFieldVisitor {
+   private:
+      std::shared_ptr<ROOT::Experimental::Detail::RPageSource> fNtplSource;
+      std::unique_ptr<TH1> fHist;
 
+      /** Test collected entries if it looks like integer values and one can use better binning */
+      void TestHistBuffer()
+      {
+         auto len = fHist->GetBufferLength();
+         auto buf = fHist->GetBuffer();
+
+         if (!buf || (len < 5))
+            return;
+
+         Double_t min = buf[1], max = buf[1];
+         Bool_t is_integer = kTRUE;
+
+         for (Int_t n = 0; n < len; ++n) {
+            Double_t v = buf[2 + 2*n];
+            if (v > max) max = v;
+            if (v < min) min = v;
+            if (TMath::Abs(v - TMath::Nint(v)) > 1e-5) { is_integer = kFALSE; break; }
+         }
+
+         // special case when only integer values in short range - better binning
+         if (is_integer && (max-min < 100)) {
+            max += 2;
+            if (min > 1) min -= 2;
+            int npoints = TMath::Nint(max - min);
+            fHist = std::make_unique<TH1F>(fHist->GetName(), fHist->GetTitle(), npoints, min, max);
+            fHist->SetDirectory(nullptr);
+            for (Int_t n = 0; n < len; ++n)
+               fHist->Fill(buf[2 + 2*n], buf[1 + 2*n]);
+         }
+      }
+
+      template<typename T>
+      void FillHistogram(const RField<T> &field)
+      {
+         std::string title = "Drawing of RField "s + field.GetName();
+
+         fHist = std::make_unique<TH1F>("hdraw", title.c_str(), 100, 0, 0);
+         fHist->SetDirectory(nullptr);
+
+         auto bufsize = (fHist->GetBufferSize() - 1) / 2;
+         int cnt = 0;
+         if (bufsize > 10) bufsize-=3; else bufsize = -1;
+
+         auto view = ROOT::Experimental::RNTupleView<T>(field.GetOnDiskId(), fNtplSource.get());
+         for (auto i : view.GetFieldRange()) {
+            fHist->Fill(view(i));
+            if (++cnt == bufsize) {
+               TestHistBuffer();
+               ++cnt;
+            }
+         }
+         if (cnt < bufsize)
+            TestHistBuffer();
+
+         fHist->BufferEmpty();
+      }
+
+      void FillStringHistogram(const RField<std::string> &field)
+      {
+         std::map<std::string, int> values;
+
+         int nentries = 0;
+
+         auto view = ROOT::Experimental::RNTupleView<std::string>(field.GetOnDiskId(), fNtplSource.get());
+         for (auto i : view.GetFieldRange()) {
+             std::string v = view(i);
+             nentries++;
+             auto iter = values.find(v);
+             if (iter != values.end())
+                iter->second++;
+             else if (values.size() >= 50)
+                return;
+             else
+                values[v] = 0;
+         }
+
+         // now create histogram with labels
+
+         std::string title = "Drawing of RField "s + field.GetName();
+         fHist = std::make_unique<TH1F>("h",title.c_str(),3,0,3);
+         fHist->SetDirectory(nullptr);
+         fHist->SetStats(0);
+         fHist->SetEntries(nentries);
+         fHist->SetCanExtend(TH1::kAllAxes);
+         for (auto &entry : values)
+            fHist->Fill(entry.first.c_str(), entry.second);
+         fHist->LabelsDeflate();
+         fHist->Sumw2(kFALSE);
+      }
+
+   public:
+      explicit RDrawVisitor(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> ntplSource)
+         : fNtplSource(ntplSource)
+      {
+      }
+
+      TH1 *MoveHist() {
+         return fHist.release();
+      }
+
+      void VisitField(const ROOT::Experimental::Detail::RFieldBase & /* field */) final {}
+      void VisitBoolField(const RField<bool> &field) final { FillHistogram(field); }
+      void VisitFloatField(const RField<float> &field) final { FillHistogram(field); }
+      void VisitDoubleField(const RField<double> &field) final { FillHistogram(field); }
+      void VisitCharField(const RField<char> &field) final { FillHistogram(field); }
+      void VisitInt8Field(const RField<std::int8_t> &field) final { FillHistogram(field); }
+      void VisitInt16Field(const RField<std::int16_t> &field) final { FillHistogram(field); }
+      void VisitIntField(const RField<int> &field) final { FillHistogram(field); }
+      void VisitInt64Field(const RField<std::int64_t> &field) final { FillHistogram(field); }
+      void VisitStringField(const RField<std::string> &field) final { FillStringHistogram(field); }
+      void VisitUInt16Field(const RField<std::uint16_t> &field) final { FillHistogram(field); }
+      void VisitUInt32Field(const RField<std::uint32_t> &field) final { FillHistogram(field); }
+      void VisitUInt64Field(const RField<std::uint64_t> &field) final { FillHistogram(field); }
+      void VisitUInt8Field(const RField<std::uint8_t> &field) final { FillHistogram(field); }
+   }; // class RDrawVisitor
+
+public:
    // virtual ~RFieldProvider() = default;
 
    TH1 *DrawField(RFieldHolder *holder)

--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -90,7 +90,7 @@ public:
       if (bufsize > 10) bufsize-=3; else bufsize = -1;
 
       auto view = tuple->GetView<T>(field_name);
-      for (auto i : tuple->GetEntryRange()) {
+      for (auto i : view.GetFieldRange()) {
          h1->Fill(view(i));
          if (++cnt == bufsize) {
             h1 = TestHistBuffer(h1);
@@ -111,7 +111,7 @@ public:
       int nentries = 0;
 
       auto view = tuple->GetView<std::string>(field_name);
-      for (auto i : tuple->GetEntryRange()) {
+      for (auto i : view.GetFieldRange()) {
           std::string v = view(i);
           nentries++;
           auto iter = values.find(v);

--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -12,19 +12,148 @@
 #include "TH1.h"
 #include "TMath.h"
 #include <map>
+#include <memory>
 #include <string>
+#include <utility>
 
 #include <ROOT/Browsable/RProvider.hxx>
 
-#include <ROOT/RNTuple.hxx>
-// #include <ROOT/RNTupleDescriptor.hxx>
-// #include <ROOT/RMiniFile.hxx>
+#include <ROOT/RFieldVisitor.hxx>
+#include <ROOT/RPageStorage.hxx>
+#include <ROOT/RNTupleView.hxx>
 
 #include "RFieldHolder.hxx"
 
 using namespace ROOT::Experimental::Browsable;
 
 using namespace std::string_literals;
+
+template<typename T>
+using RField = ROOT::Experimental::RField<T>;
+
+namespace {
+
+class RDrawVisitor : public ROOT::Experimental::Detail::RFieldVisitor {
+private:
+   std::shared_ptr<ROOT::Experimental::Detail::RPageSource> fNtplSource;
+   std::unique_ptr<TH1> fHist;
+
+   /** Test collected entries if it looks like integer values and one can use better binning */
+   void TestHistBuffer()
+   {
+      auto len = fHist->GetBufferLength();
+      auto buf = fHist->GetBuffer();
+
+      if (!buf || (len < 5))
+         return;
+
+      Double_t min = buf[1], max = buf[1];
+      Bool_t is_integer = kTRUE;
+
+      for (Int_t n = 0; n < len; ++n) {
+         Double_t v = buf[2 + 2*n];
+         if (v > max) max = v;
+         if (v < min) min = v;
+         if (TMath::Abs(v - TMath::Nint(v)) > 1e-5) { is_integer = kFALSE; break; }
+      }
+
+      // special case when only integer values in short range - better binning
+      if (is_integer && (max-min < 100)) {
+         max += 2;
+         if (min > 1) min -= 2;
+         int npoints = TMath::Nint(max - min);
+         fHist = std::make_unique<TH1F>(fHist->GetName(), fHist->GetTitle(), npoints, min, max);
+         fHist->SetDirectory(nullptr);
+         for (Int_t n = 0; n < len; ++n)
+            fHist->Fill(buf[2 + 2*n], buf[1 + 2*n]);
+      }
+   }
+
+   template<typename T>
+   void FillHistogram(const RField<T> &field)
+   {
+      std::string title = "Drawing of RField "s + field.GetName();
+
+      fHist = std::make_unique<TH1F>("hdraw", title.c_str(), 100, 0, 0);
+      fHist->SetDirectory(nullptr);
+
+      auto bufsize = (fHist->GetBufferSize() - 1) / 2;
+      int cnt = 0;
+      if (bufsize > 10) bufsize-=3; else bufsize = -1;
+
+      auto view = ROOT::Experimental::RNTupleView<T>(field.GetOnDiskId(), fNtplSource.get());
+      for (auto i : view.GetFieldRange()) {
+         fHist->Fill(view(i));
+         if (++cnt == bufsize) {
+            TestHistBuffer();
+            ++cnt;
+         }
+      }
+      if (cnt < bufsize)
+         TestHistBuffer();
+
+      fHist->BufferEmpty();
+   }
+
+   void FillStringHistogram(const RField<std::string> &field)
+   {
+      std::map<std::string, int> values;
+
+      int nentries = 0;
+
+      auto view = ROOT::Experimental::RNTupleView<std::string>(field.GetOnDiskId(), fNtplSource.get());
+      for (auto i : view.GetFieldRange()) {
+          std::string v = view(i);
+          nentries++;
+          auto iter = values.find(v);
+          if (iter != values.end())
+             iter->second++;
+          else if (values.size() >= 50)
+             return;
+          else
+             values[v] = 0;
+      }
+
+      // now create histogram with labels
+
+      std::string title = "Drawing of RField "s + field.GetName();
+      fHist = std::make_unique<TH1F>("h",title.c_str(),3,0,3);
+      fHist->SetDirectory(nullptr);
+      fHist->SetStats(0);
+      fHist->SetEntries(nentries);
+      fHist->SetCanExtend(TH1::kAllAxes);
+      for (auto &entry : values)
+         fHist->Fill(entry.first.c_str(), entry.second);
+      fHist->LabelsDeflate();
+      fHist->Sumw2(kFALSE);
+   }
+
+public:
+   explicit RDrawVisitor(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> ntplSource) : fNtplSource(ntplSource)
+   {
+   }
+
+   TH1 *MoveHist() {
+      return fHist.release();
+   }
+
+   void VisitField(const ROOT::Experimental::Detail::RFieldBase & /* field */) final {}
+   void VisitBoolField(const RField<bool> &field) final { FillHistogram(field); }
+   void VisitFloatField(const RField<float> &field) final { FillHistogram(field); }
+   void VisitDoubleField(const RField<double> &field) final { FillHistogram(field); }
+   void VisitCharField(const RField<char> &field) final { FillHistogram(field); }
+   void VisitInt8Field(const RField<std::int8_t> &field) final { FillHistogram(field); }
+   void VisitInt16Field(const RField<std::int16_t> &field) final { FillHistogram(field); }
+   void VisitIntField(const RField<int> &field) final { FillHistogram(field); }
+   void VisitInt64Field(const RField<std::int64_t> &field) final { FillHistogram(field); }
+   void VisitStringField(const RField<std::string> &field) final { FillStringHistogram(field); }
+   void VisitUInt16Field(const RField<std::uint16_t> &field) final { FillHistogram(field); }
+   void VisitUInt32Field(const RField<std::uint32_t> &field) final { FillHistogram(field); }
+   void VisitUInt64Field(const RField<std::uint64_t> &field) final { FillHistogram(field); }
+   void VisitUInt8Field(const RField<std::uint8_t> &field) final { FillHistogram(field); }
+};
+
+} // anonymous namespace
 
 
 // ==============================================================================================
@@ -42,128 +171,21 @@ public:
 
    // virtual ~RFieldProvider() = default;
 
-   /** Test collected entries if it looks like integer values and one can use better binning */
-   TH1F *TestHistBuffer(TH1F *hist)
-   {
-      auto len = hist->GetBufferLength();
-      auto buf = hist->GetBuffer();
-
-      if (!buf || (len < 5)) return hist;
-
-      Double_t min = buf[1], max = buf[1];
-      Bool_t is_integer = kTRUE;
-
-      for (Int_t n = 0; n < len; ++n) {
-         Double_t v = buf[2 + 2*n];
-         if (v > max) max = v;
-         if (v < min) min = v;
-         if (TMath::Abs(v - TMath::Nint(v)) > 1e-5) { is_integer = kFALSE; break; }
-      }
-
-      // special case when only integer values in short range - better binning
-      if (is_integer && (max-min < 100)) {
-         max += 2;
-         if (min > 1) min -= 2;
-         int npoints = TMath::Nint(max - min);
-         TH1F *h1 = new TH1F(hist->GetName(), hist->GetTitle(), npoints, min, max);
-         h1->SetDirectory(nullptr);
-         for (Int_t n = 0; n < len; ++n)
-            h1->Fill(buf[2 + 2*n], buf[1 + 2*n]);
-         delete hist;
-         return h1;
-      }
-
-      return hist;
-   }
-
-
-   template<typename T>
-   TH1 *FillHistogram(std::shared_ptr<ROOT::Experimental::RNTupleReader> &tuple, const std::string &field_name)
-   {
-      std::string title = "Drawing of RField "s + field_name.c_str();
-
-      auto h1 = new TH1F("hdraw", title.c_str(), 100, 0, 0);
-      h1->SetDirectory(nullptr);
-
-      auto bufsize = (h1->GetBufferSize() - 1) / 2;
-      int cnt = 0;
-      if (bufsize > 10) bufsize-=3; else bufsize = -1;
-
-      auto view = tuple->GetView<T>(field_name);
-      for (auto i : view.GetFieldRange()) {
-         h1->Fill(view(i));
-         if (++cnt == bufsize) {
-            h1 = TestHistBuffer(h1);
-            ++cnt;
-         }
-      }
-      if (cnt < bufsize)
-         h1 = TestHistBuffer(h1);
-
-      h1->BufferEmpty();
-      return h1;
-   }
-
-   TH1 *FillStringHistogram(std::shared_ptr<ROOT::Experimental::RNTupleReader> &tuple, const std::string &field_name)
-   {
-      std::map<std::string, int> values;
-
-      int nentries = 0;
-
-      auto view = tuple->GetView<std::string>(field_name);
-      for (auto i : view.GetFieldRange()) {
-          std::string v = view(i);
-          nentries++;
-          auto iter = values.find(v);
-          if (iter != values.end())
-             iter->second++;
-          else if (values.size() >= 50)
-             return nullptr;
-          else
-             values[v] = 0;
-      }
-
-      // now create histogram with labels
-
-      std::string title = "Drawing of RField "s + field_name.c_str();
-      TH1F *h = new TH1F("h",title.c_str(),3,0,3);
-      h->SetDirectory(nullptr);
-      h->SetStats(0);
-      h->SetEntries(nentries);
-      h->SetCanExtend(TH1::kAllAxes);
-      for (auto &entry : values)
-         h->Fill(entry.first.c_str(), entry.second);
-      h->LabelsDeflate();
-      h->Sumw2(kFALSE);
-      return h;
-   }
-
    TH1 *DrawField(RFieldHolder *holder)
    {
       if (!holder) return nullptr;
 
-      auto tuple = holder->GetNTuple();
+      auto ntplSource = holder->GetNtplSource();
       std::string name = holder->GetParentName();
 
-      auto &field = tuple->GetDescriptor().GetFieldDescriptor(holder->GetId());
-      name.append(field.GetFieldName());
+      const auto &desc = ntplSource->GetDescriptor();
+      auto field = desc.GetFieldDescriptor(holder->GetId()).CreateField(desc);
+      name.append(field->GetName());
 
-      if (field.GetTypeName() == "double"s)
-         return FillHistogram<double>(tuple, name);
-      else if (field.GetTypeName() == "float"s)
-         return FillHistogram<float>(tuple, name);
-      else if (field.GetTypeName() == "int"s)
-         return FillHistogram<int>(tuple, name);
-      else if (field.GetTypeName() == "std::int32_t"s)
-         return FillHistogram<int32_t>(tuple, name);
-      else if (field.GetTypeName() == "std::uint32_t"s)
-         return FillHistogram<uint32_t>(tuple, name);
-      else if (field.GetTypeName() == "std::string"s)
-         return FillStringHistogram(tuple, name);
-
-      return nullptr;
+      RDrawVisitor drawVisitor(ntplSource);
+      field->AcceptVisitor(drawVisitor);
+      return drawVisitor.MoveHist();
    }
-
 };
 
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -150,7 +150,6 @@ Fields of simple types with a Map() method will use that and thus expose zero-co
 // clang-format on
 template <typename T>
 class RNTupleView {
-   friend class RNTupleReader;
    friend class RNTupleViewCollection;
 
    using FieldT = RField<T>;
@@ -160,6 +159,8 @@ private:
    FieldT fField;
    /// Used as a Read() destination for fields that are not mappable
    Detail::RFieldValue fValue;
+
+public:
 
    RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
      : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName()), fValue(fField.GenerateValue())
@@ -173,7 +174,6 @@ private:
       }
    }
 
-public:
    RNTupleView(const RNTupleView& other) = delete;
    RNTupleView(RNTupleView&& other) = default;
    RNTupleView& operator=(const RNTupleView& other) = delete;


### PR DESCRIPTION
# This Pull request:
Uses the RFieldVisitor infrastructure to draw histograms in the ROOT7 browser.

## Changes or fixes:
- Adds browsing support for all numerical RNTuple types
- Fixes browsing of RNTuple collections