### PR TITLE
[ntuple] `RClassField`: add support to load/store class hierarchies

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -290,8 +290,25 @@ public:
 /// The field for a class with dictionary
 class RClassField : public Detail::RFieldBase {
 private:
+   enum ESubFieldRole {
+      kBaseClass,
+      kDataMember,
+   };
+   struct RSubFieldInfo {
+      ESubFieldRole fRole;
+      std::size_t fOffset;
+   };
+   /// Prefix used in the subfield names generated for base classes
+   static constexpr const char *kPrefixInherited{":"};
+
    TClass* fClass;
+   /// Additional information kept for each entry in `fSubFields`
+   std::vector<RSubFieldInfo> fSubFieldsInfo;
    std::size_t fMaxAlignment = 1;
+
+private:
+   RClassField(std::string_view fieldName, std::string_view className, TClass *classp);
+   void Attach(std::unique_ptr<Detail::RFieldBase> child, RSubFieldInfo info);
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -778,8 +778,8 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
 
    for (auto baseClass : ROOT::Detail::TRangeStaticCast<TBaseClass>(*fClass->GetListOfBases())) {
       TClass *c = baseClass->GetClassPointer();
-      auto subField = std::unique_ptr<RClassField>(new RClassField(std::string(kPrefixInherited) + c->GetName(),
-                                                                   c->GetName(), c));
+      auto subField = Detail::RFieldBase::Create(std::string(kPrefixInherited) + c->GetName(),
+                                                 c->GetName()).Unwrap();
       Attach(std::move(subField),
 	     RSubFieldInfo{kBaseClass, static_cast<std::size_t>(baseClass->GetDelta())});
    }

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -16,8 +16,17 @@ struct DerivedA : public CustomStruct {
    std::string a_s;
 };
 
+struct DerivedA2 : public CustomStruct {
+   float a2_f{};
+};
+
 struct DerivedB : public DerivedA {
    float b_f1 = 0.0;
    float b_f2 = 0.0; //!
    std::string b_s;
+};
+
+struct DerivedC : public DerivedA, public DerivedA2 {
+   int c_i{};
+   DerivedA2 c_a2;
 };

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -10,3 +10,14 @@ struct CustomStruct {
    std::vector<std::vector<float>> v2;
    std::string s;
 };
+
+struct DerivedA : public CustomStruct {
+   std::vector<float> a_v;
+   std::string a_s;
+};
+
+struct DerivedB : public DerivedA {
+   float b_f1 = 0.0;
+   float b_f2 = 0.0; //!
+   std::string b_s;
+};

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -30,3 +30,18 @@ struct DerivedC : public DerivedA, public DerivedA2 {
    int c_i{};
    DerivedA2 c_a2;
 };
+
+/// The classes below are based on an excerpt provided by Marcin Nowak (EP-UAT)
+///
+struct IAuxSetOption {};
+
+struct PackedParameters {
+   uint8_t m_nbits, m_nmantissa;
+   float   m_scale;
+   uint8_t m_flags;
+};
+
+template <class T>
+struct PackedContainer : public std::vector<T>, public IAuxSetOption {
+   PackedParameters m_params;
+};

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -5,5 +5,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class CustomStruct+;
+#pragma link C++ class DerivedA+;
+#pragma link C++ class DerivedB+;
 
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -10,4 +10,8 @@
 #pragma link C++ class DerivedB+;
 #pragma link C++ class DerivedC+;
 
+#pragma link C++ class IAuxSetOption+;
+#pragma link C++ class PackedParameters+;
+#pragma link C++ class PackedContainer+;
+
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -6,6 +6,8 @@
 
 #pragma link C++ class CustomStruct+;
 #pragma link C++ class DerivedA+;
+#pragma link C++ class DerivedA2+;
 #pragma link C++ class DerivedB+;
+#pragma link C++ class DerivedC+;
 
 #endif

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -226,6 +226,7 @@ TEST(RNTupleShow, Objects)
       auto customStructfield = model->MakeField<CustomStruct>("CustomStruct");
       auto customStructVec = model->MakeField<std::vector<CustomStruct>>("CustomStructVec");
       auto customStructArray = model->MakeField<std::array<CustomStruct, 2>>("CustomStructArray");
+      auto derivedAfield = model->MakeField<DerivedA>("DerivedA");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
 
       *customStructfield = CustomStruct{4.1f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example1String"};
@@ -238,12 +239,14 @@ TEST(RNTupleShow, Objects)
       CustomStruct{4.5f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "AnotherString1"},
       CustomStruct{4.6f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "AnotherString2"}
       };
+      *derivedAfield = {};
       ntuple->Fill();
    }
    auto model2 = RNTupleModel::Create();
    auto customStructfield = model2->MakeField<CustomStruct>("CustomStruct");
    auto customStructVec = model2->MakeField<std::vector<CustomStruct>>("CustomStructVec");
    auto customStructArray = model2->MakeField<std::array<CustomStruct, 2>>("CustomStructArray");
+   auto derivedAfield = model2->MakeField<DerivedA>("DerivedA");
    auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
 
    std::ostringstream os;
@@ -263,7 +266,17 @@ TEST(RNTupleShow, Objects)
       +      "\"s\": \"Example4String\"}],\n"
       + "  \"CustomStructArray\": [{\"a\": 4.5, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], "
       +      "\"s\": \"AnotherString1\"}, {\"a\": 4.6, \"v1\": [0.1, 0.2, 0.3], "
-      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"AnotherString2\"}]\n"
+      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"AnotherString2\"}],\n"
+      + "  \"DerivedA\": {\n"
+      + "    \":CustomStruct\": {\n"
+      + "      \"a\": 0,\n"
+      + "      \"v1\": [],\n"
+      + "      \"v2\": [],\n"
+      + "      \"s\": \"\"\n"
+      + "    },\n"
+      + "    \"a_v\": [],\n"
+      + "    \"a_s\": \"\"\n"
+      + "  }\n"
       + "}\n" };
    EXPECT_EQ(fString, os.str());
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -6,6 +6,8 @@ TEST(RNTuple, TypeName) {
                 ROOT::Experimental::RField<std::vector<std::string>>::TypeName().c_str());
    EXPECT_STREQ("CustomStruct",
                 ROOT::Experimental::RField<CustomStruct>::TypeName().c_str());
+   EXPECT_STREQ("DerivedB",
+                ROOT::Experimental::RField<DerivedB>::TypeName().c_str());
 }
 
 
@@ -105,4 +107,59 @@ TEST(RNTuple, Casting)
    auto reader = RNTupleReader::Open(std::move(modelC), "ntuple", fileGuard.GetPath());
    reader->LoadEntry(0);
    EXPECT_EQ(42, *fieldCast);
+}
+
+TEST(RNTuple, TClass)
+{
+   FileRaii fileGuard("test_ntuple_tclass.ntuple");
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldKlass = model->MakeField<DerivedB>("klass");
+      RNTupleWriteOptions options;
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath(), options);
+      for (int i = 0; i < 20000; i++) {
+         DerivedB klass;
+         klass.a = static_cast<float>(i);
+         klass.v1.emplace_back(static_cast<float>(i));
+         klass.v2.emplace_back(std::vector<float>(3, static_cast<float>(i)));
+         klass.s = "hi" + std::to_string(i);
+
+         klass.a_v.emplace_back(static_cast<float>(i + 1));
+         klass.a_s = "bye" + std::to_string(i);
+
+         klass.b_f1 = static_cast<float>(i + 2);
+         klass.b_f2 = static_cast<float>(i + 3);
+         *fieldKlass = klass;
+         ntuple->Fill();
+      }
+   }
+
+   {
+      auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
+      EXPECT_EQ(20000U, ntuple->GetNEntries());
+      auto viewKlass = ntuple->GetView<DerivedB>("klass");
+      for (auto i : ntuple->GetEntryRange()) {
+         float fi = static_cast<float>(i);
+         EXPECT_EQ(fi, viewKlass(i).a);
+         EXPECT_EQ(std::vector<float>{fi}, viewKlass(i).v1);
+         EXPECT_EQ((std::vector<float>(3, fi)), viewKlass(i).v2.at(0));
+         EXPECT_EQ("hi" + std::to_string(i), viewKlass(i).s);
+
+         EXPECT_EQ(std::vector<float>{fi + 1}, viewKlass(i).a_v);
+         EXPECT_EQ("bye" + std::to_string(i), viewKlass(i).a_s);
+
+         EXPECT_EQ((fi + 2), viewKlass(i).b_f1);
+         EXPECT_EQ(0.0, viewKlass(i).b_f2);
+      }
+   }
+
+   {
+      auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
+      try {
+         auto viewKlass = ntuple->GetView<DerivedA>("klass");
+         FAIL() << "GetView<a_base_class_of_T> should throw";
+      } catch (const RException& err) {
+         EXPECT_THAT(err.what(), testing::HasSubstr("Column missing: column #0 for field a"));
+      }
+   }
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -8,6 +8,9 @@ TEST(RNTuple, TypeName) {
                 ROOT::Experimental::RField<CustomStruct>::TypeName().c_str());
    EXPECT_STREQ("DerivedB",
                 ROOT::Experimental::RField<DerivedB>::TypeName().c_str());
+
+   auto field = RField<DerivedB>("derived");
+   EXPECT_EQ(sizeof(DerivedB), field.GetValueSize());
 }
 
 


### PR DESCRIPTION
This pull-request extends the support in `RClassField` to load/store arbitrary types by correctly handling inheritance.  See below for the list of changes.

## Changes or fixes:
- An internal subfield named `:XXX` is created for each inherited `XXX` class; additional fields are recursively generated for data members/base classes.
- Reading/writing an object of the derived class includes both, direct and inherited data members.  Non-persistent data members, i.e. `//!`, are not stored.

This PR closes issue #7856.