### PR TITLE
parse correctly the compiler version

### DIFF
--- a/build/unix/compiledata.sh
+++ b/build/unix/compiledata.sh
@@ -65,7 +65,7 @@ BXX="`basename $CXX`"
 COMPILERVERS="$BXX"
 case $BXX in
 g++* | c++*)
-   cxxTemp=`$CXX -dumpversion`
+   cxxTemp=`$CXX -dumpfullversion -dumpversion`
    COMPILERVERSSTR="`$CXX --version 2>&1 | grep -i $BXX | sed -n '1p'`"
    COMPILERVERS="gcc"
    if [ `uname` == "Darwin" ]; then
@@ -76,12 +76,12 @@ g++* | c++*)
    fi
    ;;
 icc)
-   cxxTemp=`$CXX -dumpversion`
+   cxxTemp=`$CXX -dumpfullversion -dumpversion`
    COMPILERVERSSTR="Intel icc $cxxTemp"
    COMPILERVERS="icc"
    ;;
 clang++*)
-   cxxTemp=`$CXX -dumpversion`
+   cxxTemp=`$CXX -dumpfullversion -dumpversion`
    COMPILERVERSSTR="`$CXX --version 2>&1 | grep -i clang | sed -n '1p'`"
    COMPILERVERS="clang"
    ;;

--- a/build/unix/compiledata.sh
+++ b/build/unix/compiledata.sh
@@ -66,7 +66,7 @@ COMPILERVERS="$BXX"
 case $BXX in
 g++* | c++*)
    cxxTemp=`$CXX -dumpversion`
-   COMPILERVERSSTR="`$CXX --version 2>&1 | grep -i gcc | sed -n '1p'`"
+   COMPILERVERSSTR="`$CXX --version 2>&1 | grep -i $BXX | sed -n '1p'`"
    COMPILERVERS="gcc"
    if [ `uname` == "Darwin" ]; then
       if [ "x$COMPILERVERSSTR" == "x" ]; then


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Fixes the incorrect parsing of the gcc version on Ubuntu 18 or 20.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/8551

