### PR TITLE
[cling] Warn on redundant parentheses in declarators whose parsing might not match the user intent

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -235,7 +235,7 @@ enum ESendRecvOptions {
 #ifdef __CINT__
 typedef void *Func_t;
 #else
-typedef void ((*Func_t)());
+typedef void (*Func_t)();
 #endif
 
 R__EXTERN const char  *gRootDir;

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1310,6 +1310,9 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
         default: llvm_unreachable("Unrecognized C++ version");
       }
     }
+    // Warn on redundant parentheses surrounding declarator, e.g. `bool(i)`,
+    // whose parsing might not match the user intent.
+    argvCompile.push_back("-Wredundant-parens");
 
     // This argument starts the cling instance with the x86 target. Otherwise,
     // the first job in the joblist starts the cling instance with the nvptx


### PR DESCRIPTION
Enable `-Wredundant-parens`, to warn about redundant parentheses in declarators whose parsing might not match the user intent, e.g.
```
root [0] int i = 1;
root [1] (bool)i
(bool) true
root [2] bool(i)
ROOT_prompt_1:1:5: redundant parentheses surrounding declarator [-Wredundant-parens]
bool(i)
    ^~~
(bool) false
```

For more information see the discussion [here](http://github.com/root-project/issues/8304).
This PR fixes issue #8304.